### PR TITLE
feat(notify): docs-notify card producer + reserved metadata namespace

### DIFF
--- a/.octospec/tasks/card-message-internal-dispatch/docs-notify-contract.md
+++ b/.octospec/tasks/card-message-internal-dispatch/docs-notify-contract.md
@@ -1,0 +1,157 @@
+# docs-notify 卡片通知 — 跨仓 ingress 契约
+
+> 仓内契约，供 octo-server `docs-notify` 生产者与 `octo-docs-backend` 对齐,PR
+> 打开后整理成英文 issue/comment 同步给 `Mininglamp-OSS/octo-docs-backend`。
+> 关联:brief.md(本目录)、summary-notify-contract.md(姊妹契约)、
+> handoff.md、`docs/docs-notify-card.md`。
+> 状态:契约草案,由本 PR 落地 `pkg/cardtmpl` / `modules/notify` 侧。
+> 最后更新 2026-07-14。
+
+## 背景一句话
+
+`docs-notify` 是 `internal/carddispatch` 的**第二个**生产者（首个见
+`summary-notify-contract.md`）,把 docs-backend 想推给用户的**自动化系统通知**
+（分享、评论、访问申请）升级为 `octo/v1` 展示卡片,复用 `notification` User Bot
+身份 → 用户会话列表**不新增**系统 Bot 会话。docs-backend 不构造 type-17 map、
+不发文本兜底、不做卡片模板 —— 只发**结构化字段** `DocsCardFields`,一切文案 /
+布局 / deep-link / i18n 由 octo-server owning。
+
+**用户主动分享** 不在本契约内 —— 那是独立的用户认证 + 服务端 mint 通路
+（见 `.octospec/tasks/user-resource-share-card/brief.md`）,发送方为分享用户本人。
+
+## 契约要点（锁定项）
+
+1. **同端点、同 token、同粒度**:仍是 `POST /v1/internal/notify`,头
+   `X-Internal-Token`（复用 `NOTIFY_INTERNAL_TOKEN`;fail-closed）,**一请求
+   一收件人**（`targets` 单元素）。`space_id` / `service` / `actor_uid` 语义
+   与 summary 完全相同,octo-server 已有的 dedup / actor 排除 / memberCache
+   / ensureNotifyBotReady / carddispatch 派发全部复用。
+2. **三选一互斥**:`Payload` / `Card`（summary） / `DocsCard`（docs）**只能
+   出现一个**。多于一个 → 400 `err.server.notify.card_invalid`;全都缺失
+   → 400 legacy「payload不能为空」。字段级检测:
+   - `req.Payload != nil` 计入(包括空 `{}` —— 呼应「显式意图」)。
+   - `req.Card != nil` 计入。
+   - `req.DocsCard != nil` 计入。
+3. **禁止客户端手搓 type-17 map**:Decision 14 仍生效 —— `payload` 若被
+   `cardmsg.IsCardPayload` 判为卡片(`type=17`)一律 400
+   `err.server.notify.card_not_allowed`,无论走 `Card` 还是 `DocsCard`。
+4. **响应契约不变**:仍返回 `NotifyResp{delivered:[], filtered:{uid:reason}}`。
+   reason 词表与 summary 一致(`not_space_member` / `target_denied`
+   / `dispatch_failed` / `busy` / `send_failed`) —— docs-backend 可**照抄**
+   smart-summary 的 dedup / retry / sweep 状态机。
+5. **模板/文案/链接归属 octo-server**:docs-backend **只发原始字段**;卡片布局、
+   按钮文案(查看详情)、FactSet 标签(操作人 / 时间)、attribution
+   (「Alice 分享了文档」)、`/d/{doc_id}?sp={space_id}` deep-link、
+   `metadata.octo.variant` / `metadata.octo.source` 全部由 octo-server
+   `pkg/cardtmpl` + `modules/notify.buildDocsCard` + `i18n.OutboundLanguage`
+   生成。docs-backend 不再拼「XX 分享了 <link>」这类降级文本(旧字段作废;
+   octo-server 侧的 `buildDocsFallbackText` 负责纯文本降级)。
+6. **批量端点 `/notify/batch` 拒绝 `DocsCard`**:与 `Card` 同,卡片必须走单条端点
+   `/notify`;batch 一条含 `DocsCard` 即 400,不做任何投递。
+
+## 请求体（卡片模式）
+
+```jsonc
+POST /v1/internal/notify
+X-Internal-Token: <NOTIFY_INTERNAL_TOKEN>
+{
+  "space_id":  "spc_xxx",              // 现状:必填,server 用 memberCache 校验收件人
+  "service":   "docs-service",         // 现状不变
+  "targets":   ["uid_recipient"],      // 现状:单收件人
+  "actor_uid": "",                     // 现状:通知场景一般留空
+  "docs_card": {                       // 新增:非空即走 docs-notify 卡片 producer
+    "doc_id":     "d_20260713_abcd",   // ★ 见下「标识」
+    "kind":       "shared",            // "shared" | "commented" | "access_requested"
+    "title":      "产品设计方案",         // 原始标题(server 负责转义/截断)
+    "actor_name": "Alice",             // 预格式化的操作人显示名;空则用「有人」/「Someone」兜底
+    "excerpt":    "Q3 上线计划已确认",    // 可选预览/评论/申请说明;≤ 300 runes 截断
+    "updated_at": "2026-07-13 15:04"   // 已格式化的时间字符串;空则省略「时间」行
+  }
+}
+```
+
+`payload` / `card` / `docs_card` 三者同时缺失 → 400 legacy;多于一个 → 400
+`err.server.notify.card_invalid`。
+
+## 三个约定（对齐 summary-notify）
+
+- **标识 `doc_id`(不是自增 `id`)**:deep-link `/d/{doc_id}?sp={space_id}` 用
+  docs-backend 侧不可枚举的文档标识 —— 与 octo-web `/d/:docId` 独立路由
+  (已在线;冷加载 + 登录跳转 + XIN-398 多会话 sid 恢复)对齐。**这是 docs-notify
+  与 summary-notify 的关键差异:docs 侧「查看详情」按钮开箱可用**,
+  summary 侧仍在等 `/s/:taskId` 上线。
+- **时间字段传「已格式化字符串」**:`updated_at` 由 docs-backend 用其自身时区
+  格式化后传字符串,octo-server 原样填进 FactSet 值。理由:octo-server 无 docs
+  业务时区配置,避免时区漂移。**标签(「时间」/「At」)仍由 octo-server 按收件
+  人语言本地化。**
+- **`actor_name` 传预格式化的显示名**:显示名由 docs-backend 侧解析(可含姓+
+  称谓 / 组织信息 / 匿名替换等业务规则);octo-server 侧 `escapeMarkdown` 后
+  嵌入 attribution。理由:避免 card 路径依赖额外 DB 查询,一致性与 summary
+  的 `Title` 同一纪律。
+
+## 字段来源（docs-backend 侧现成 / 需要新增）
+
+| card 字段 | docs-backend 来源(建议) |
+| --- | --- |
+| `doc_id` | 文档实体的 `id` 字段(与 `/d/:docId` 路由 taskId 同义) |
+| `kind` | 触发场景:分享 = `shared`;评论 = `commented`;访问申请 = `access_requested` |
+| `title` | 文档 `title` 字段(空则用「无标题」兜底 —— docs-backend 侧决策) |
+| `actor_name` | 触发者的显示名(docs-backend 已 resolve;匿名场景可留空) |
+| `excerpt` | 分享:留空 / 简短介绍;评论:评论内容摘要;访问申请:申请理由 |
+| `updated_at` | 触发事件的时间戳格式化字符串(docs-backend 时区) |
+
+## octo-server 侧（本 PR 落地）
+
+- `docs-notify` producer 绑定已有 `notification` Bot(`user`+`app`+
+  `robot.status=1`),卡片和纯文本降级复用其 provisioning/readiness;
+  不新增专用 `docs` Bot。
+- 注册 `docs-notify` producer(DM/`octo/v1`/system-notification/MaxInFlight
+  20),经 `SenderFromContext` 注入 `modules/notify`。与 `summary-notify` 同
+  `ProducerSpec` shape,仅 ID 不同(见 `main.cardDispatchProducerSpecs`)。
+- `docs_card` 分支:`memberCache.verify` → `cardtmpl.BuildDocsResourceCard` →
+  每个成员 `sender.Send` → 汇总 `delivered/filtered`。**建卡/配置(如
+  deep-link 非 https)失败降级为原纯文本 DM**,保证通知必达(此为 octo-server
+  侧策略,brief 未强制,PR 说明)。
+- **metadata 预留**:每张卡在 AdaptiveCard 根塞 `metadata.webUrl` +
+  `metadata.octo = {variant, source}`;`variant` 保留词表见
+  `docs/summary-notify-card.md` §2.3;`source.label` 供渲染端做「来自文档」
+  角标 —— docs-backend 无需管这些字段,server 侧根据 `kind` 决定 variant,
+  根据 producer 决定 source.label。
+
+## enablement 门（端到端上线前必须齐）
+
+1. **octo-web** 上线 `/d/:docId` 路由 —— **已在线**(既有 standalone
+   doc 通路);相较 summary,docs 端「查看详情」链接开箱可用;
+2. octo-server 落 `cardtmpl` snapshot/Validate 测试 + `docsDeepLink` 形状测试
+   + pilote2e E2E(**本 PR 落地**);
+3. **octo-docs-backend** 侧新增 outbound IM notify 客户端(仿造
+   `octo-smart-summary/internal/notify/`),按上述 body 结构 POST。
+   建议实现要点:
+   - 每场景一个函数(`NotifyDocShared` / `NotifyDocCommented` /
+     `NotifyDocAccessRequested`),内部塞 `Kind` 常量;
+   - 复用 `X-Internal-Token`(`NOTIFY_INTERNAL_TOKEN` = 同一 token,
+     docs-backend 与 smart-summary 共用);
+   - per-recipient dedup(避免同一评论触发多次通知);
+   - 消费 `NotifyResp{delivered,filtered}` —— 只认 `delivered[]` 判真送达,
+     `filtered` 内标记为 `not_space_member` / `busy` / `dispatch_failed` 的
+     可延时重试;
+   - **不实现自身文本降级路径** —— server 侧已负责;发失败即上报错误让
+     调用方按业务重试(与 smart-summary 侧的 `Sweep` 一致)。
+
+在 (1)(3) 到位前,octo-server 侧行为惰性:无 `docs_card` 请求即无 docs 卡片
+流量;全局 `OCTO_CARD_MESSAGE_ENABLED` 为总开关,回滚可移除 producer spec
+或关该 env。
+
+## 明确不在本契约内
+
+- 用户主动分享文档到 DM/群/子区 —— 见 `../user-resource-share-card/brief.md`,
+  发送方为分享用户本人,非 Bot proxy。
+- 访问申请的交互(「同意 / 拒绝」按钮) —— 需要 producer 升级到 `octo/v2` +
+  绑定一个跑 `/v1/bot/events` 的 action-owner;docs-backend 目前是
+  TS/Hocuspocus,不跑 Go bot 事件轮询,升级为独立议题。
+- 群/子区自动通知(如「这份文档被评论了」推到关联群) —— 需要 producer
+  widening 到 group/thread channel type,同步需要 per-channel rate rule +
+  cluster-wide cap 决策(brief › Industry practice alignment)。
+- 文档缩略图 / 富预览(Image / RichTextBlock) —— 目前只用 TextBlock + FactSet
+  +  Optional Excerpt。未来若加缩略图,需要 docs-backend 自建 SSRF-safe
+  fetcher 并提供绝对 https URL。

--- a/.octospec/tasks/card-message-internal-dispatch/summary-notify-contract.md
+++ b/.octospec/tasks/card-message-internal-dispatch/summary-notify-contract.md
@@ -2,8 +2,11 @@
 
 > 仓内草稿,供 octo-server P2(`summary-notify` pilot）实现时对齐,PR 打开后整理成英文
 > issue/comment 同步给 `Mininglamp-OSS/octo-smart-summary`。
-> 关联:brief.md(本目录)、handoff.md、octo-server PR #577(P1 地基)。
-> 状态:待 smart-summary owner 确认字段清单。最后更新 2026-07-14。
+> 关联:brief.md(本目录)、handoff.md、docs-notify-contract.md(姊妹契约,
+> 同一 ingress 端点、同 token、同响应 shape)、octo-server PR #577(P1 地基)、
+> #579(pilot)、#580(共用 notification Bot)。
+> 状态:已实现;`docs-notify` 姊妹 producer 于同 PR 落地(见 handoff)。
+> 最后更新 2026-07-14。
 
 ## 背景一句话
 

--- a/configs/tsdd.yaml
+++ b/configs/tsdd.yaml
@@ -35,9 +35,13 @@ mode: "debug" #   运行模式 debug or release
 
 ##################### 外网配置 ####################
 #external:
-#  ip: "" # 外网ip
-#  baseURL: "" # 外网访问地址 例如 http://192.0.2.1:8090
-#  webLoginURL: "" # web im的登录地址 例如 https://web.tangsengdaodao.com
+#  ip: "" # 外网ip；仅当 baseURL 空时作为兜底 host（见 pkg/botutil/connect.go）
+#  baseURL: "" # 外网 API 访问地址 例如 http://192.0.2.1:8090（baseURL 已给出时 ip 冗余，两者保留是历史兜底）
+#  webLoginURL: "" # web im 的登录/门户地址 例如 https://web.tangsengdaodao.com
+#  # webLoginURL 是**卡片通知 deep-link** 的 origin 来源（/s/:taskId、/d/:docId）；
+#  # 未配置或非 https 时，summary-notify / docs-notify 建卡失败，会静默降级为纯文本 DM
+#  # （见 pkg/cardtmpl/resource.go summaryDeepLink / docsDeepLink 与
+#  # modules/notify/card.go 的 build-then-degrade 分支）。
 
 ##################### 日志配置 ####################
 #logger:

--- a/docs/docs-notify-card.md
+++ b/docs/docs-notify-card.md
@@ -1,0 +1,253 @@
+# Docs-Notify 通知卡片（`internal/carddispatch` 第二个生产者）
+
+> **权威声明**：本文档描述 `docs-notify` 生产者当前的卡片形态与组装规则。
+> 权威源码：`pkg/cardtmpl/resource.go`（`BuildDocsResourceCard` + `docsDeepLink`）、
+> `modules/notify/card.go`（`deliverDocsCardNotification` / `buildDocsCard` /
+> `docsLabelsFor` / `docsAttributionAndVariant`）、`modules/notify/model.go`
+> （`DocsCardFields`）、`internal/carddispatch/`（派发流水线）、
+> `pkg/cardmsg`（wire 协议与校验）。规范源头：
+> `.octospec/tasks/card-message-internal-dispatch/brief.md`（Decisions 1/3/4/11/14）与
+> 同目录 `docs-notify-contract.md`（跨仓 ingress 契约）。两者如有出入，以代码为准。
+>
+> 兄弟文档：`docs/summary-notify-card.md`（`summary-notify` 生产者）— 组装管线、
+> 降级链、Deep-link 前置、`metadata.octo.variant` 保留词表、错误分类**完全一致**，
+> 本文档只呈现 docs 特有的字段/文案/deep-link 差异。
+
+## 1. 概览
+
+`docs-notify` 是 `internal/carddispatch` 落地的第二个内部卡片生产者，服务于
+**docs-backend 的自动化通知**（分享、评论、访问申请）。业务侧（`octo-docs-backend`）
+经既有 `POST /v1/internal/notify` 内网接口投递**结构化字段**
+（`NotifyReq.DocsCard` = `DocsCardFields`），octo-server 侧完成
+**卡片组装 → 派发 → 降级**闭环。
+
+- **发送方身份**：与 `summary-notify` 共用同一 `notification` User Bot
+  （`ensureNotifyBot` provision）；用户会话列表里不产生第二个系统 Bot 会话。**能力
+  隔离在 producer 粒度**：不同 producer 各自的 `MaxInFlight` / 允许 profile / 允许
+  channel type 独立配置，`docs-backend` 不因共用 Bot 身份而获得跨 producer 越权。
+- **接口层**：仍是 `POST /v1/internal/notify` + `X-Internal-Token`。body 里
+  `Payload` / `Card`（summary） / `DocsCard`（docs） **三选一**，见 §3。
+- **生产者信息**：`ProducerID="docs-notify"`，`SenderUID=NotifyBotUIDValue`，
+  `AllowedChannelTypes=[Person]`，`AllowedProfiles=[octo/v1]`，
+  `SpacePolicy=SystemNotification`，`MaxInFlight=20/process`。
+
+**用户主动分享** 不是 docs-notify 的范围（brief Out-of-scope）：那是一条独立的
+「用户认证 + 服务端 mint」资源分享通路（`.octospec/tasks/user-resource-share-card/`
+brief），发送方为分享用户本人，与本 producer 无关。docs-notify 覆盖的是
+**自动化系统通知**：文档被分享给你、评论了你、有人请求访问你的文档等。
+
+## 2. 卡片形态（Adaptive Card 1.5）
+
+`DocsCardFields.Kind` 决定 attribution / variant；`ActorName` 决定 attribution
+的主语（缺省用「有人」/「Someone」兜底）。
+
+| `Kind` | 场景 | attribution（含 `ActorName`） | attribution（无 `ActorName`） | `metadata.octo.variant` |
+|---|---|---|---|---|
+| `"shared"` | 文档被分享 | `{Actor} 分享了文档` | `有人分享了文档` | `docs.shared` |
+| `"commented"` | 有新评论 | `{Actor} 评论了文档` | `有新评论` | `docs.commented` |
+| `"access_requested"` | 访问申请 | `{Actor} 请求访问文档` | `有人请求访问文档` | `docs.access_requested` |
+
+**公共结构**（与 summary 卡完全对齐）：
+- Header：无 `IconURL` 时是 `Container` + 加粗 `TextBlock(Title)` + 可选
+  `isSubtle` attribution TextBlock。
+- Excerpt：可选 `TextBlock(wrap=true)`，超过 `MaxExcerptRunes=300` 截断。
+- FactSet：`ActorName`（若非空）→ 「操作人 / By」；`UpdatedAt`（若非空）→ 「时间 /
+  At」。两者都空则整块省略。
+- ActionSet：`Action.OpenUrl("查看详情", deepLink)`。
+- **入卡文本一律经 `escapeMarkdown` 转义**（同 summary，`* _ [ ] ( ) < > \` \# ~ |`
+  逐字符加反斜杠），阻断外部字段被 CommonMark 解析成活链接／图片。
+
+### 2.1 shared 完整 AC JSON
+
+示例入参（跨仓契约见 `docs-notify-contract.md`）：
+
+```jsonc
+{
+  "space_id":  "spc_xxx",
+  "service":   "docs-service",
+  "targets":   ["uid_recipient"],
+  "actor_uid": "",
+  "docs_card": {
+    "doc_id":     "d_20260713_abcd",
+    "kind":       "shared",
+    "title":      "产品设计方案",
+    "actor_name": "Alice",
+    "excerpt":    "Q3 上线计划已确认",
+    "updated_at": "2026-07-13 15:04"
+  }
+}
+```
+
+服务端组装（AC 1.5，`profile=octo/v1`，`card_version="1.5"`）：
+
+```json
+{
+  "type": "AdaptiveCard",
+  "version": "1.5",
+  "metadata": {
+    "webUrl": "https://im.example.com/d/d_20260713_abcd?sp=spc_xxx",
+    "octo": { "variant": "docs.shared" }
+  },
+  "body": [
+    { "type": "Container", "items": [
+      { "type": "TextBlock", "text": "产品设计方案", "weight": "Bolder", "wrap": true },
+      { "type": "TextBlock", "text": "Alice 分享了文档", "isSubtle": true, "spacing": "None", "wrap": true }
+    ]},
+    { "type": "TextBlock", "text": "Q3 上线计划已确认", "wrap": true },
+    { "type": "FactSet", "facts": [
+      { "title": "操作人", "value": "Alice" },
+      { "title": "时间",   "value": "2026-07-13 15:04" }
+    ]},
+    { "type": "ActionSet", "actions": [
+      { "type": "Action.OpenUrl", "title": "查看详情",
+        "url": "https://im.example.com/d/d_20260713_abcd?sp=spc_xxx" }
+    ]}
+  ]
+}
+```
+
+WuKongIM wire 信封（`plain` 由服务端权威派生）：
+
+```jsonc
+{
+  "type": 17,
+  "card_version": "1.5",
+  "profile": "octo/v1",
+  "space_id": "spc_xxx",              // 由 carddispatch 权威注入
+  "plain":    "产品设计方案\nAlice 分享了文档\nQ3 上线计划已确认\n操作人: Alice\n时间: 2026-07-13 15:04",
+  "card":     { ... /* 上方 body */ }
+}
+```
+
+渲染效果（示意）：
+
+```
+┌───────────────────────────────────────────────┐
+│ 产品设计方案                                    │
+│ Alice 分享了文档                                │
+│                                                │
+│ Q3 上线计划已确认                                │
+│                                                │
+│ 操作人   Alice                                  │
+│ 时间     2026-07-13 15:04                       │
+│                                                │
+│ [ 查看详情 ]                                    │
+└───────────────────────────────────────────────┘
+```
+
+### 2.2 commented / access_requested 变体
+
+字段与 `shared` 相同、只是 `kind` + attribution / variant 不同。省略 `ActorName`
+时 attribution 走匿名兜底：
+
+- `kind: "commented"` + 无 `actor_name` → attribution = `"有新评论"`，
+  `metadata.octo.variant = "docs.commented"`
+- `kind: "access_requested"` + `actor_name: "Bob"` → attribution =
+  `"Bob 请求访问文档"`，`metadata.octo.variant = "docs.access_requested"`
+
+**约定** `docs-backend` 端预格式化 `actor_name`（可含姓+称谓、显示名等，逐字符
+`escapeMarkdown` 后落入 attribution）。octo-server 不做二次身份解析（避免 card 路径
+额外 DB 依赖）；跨仓契约见 `docs-notify-contract.md` §3。
+
+## 3. Ingress 契约（`POST /v1/internal/notify`）
+
+完整跨仓契约见 `.octospec/tasks/card-message-internal-dispatch/docs-notify-contract.md`。
+摘要：
+
+- 头 `X-Internal-Token`（同 `NOTIFY_INTERNAL_TOKEN`，与 summary 复用；fail-closed）。
+- 一请求一收件人（`targets` 单元素）；`space_id` / `service` / `actor_uid` 语义
+  与 summary 完全对齐。
+- **三选一**：`Payload` / `Card`（summary） / `DocsCard`（docs） 只能出现一个。
+  多于一个 → 400 `err.server.notify.card_invalid`；全都缺失 → 400
+  `payload不能为空`（legacy）。
+- `Payload` 里禁止手搓 type-17（Decision 14；`cardmsg.IsCardPayload` 匹配即 400
+  `err.server.notify.card_not_allowed`）。
+- 响应仍为 `NotifyResp{delivered:[], filtered:{uid:reason}}`，reason 词表与
+  summary 一致（`target_denied` / `dispatch_failed` / `busy` / `not_space_member`
+  / `send_failed`），docs-backend 侧的重试/dedup 逻辑可**照抄** smart-summary。
+- **批量端点 `/notify/batch` 拒绝任何 `Card` / `DocsCard` 条目** — 卡片只能走单请求
+  路径（Preflight 400），因为 batch 走 legacy 文本 fan-out，不经 carddispatch。
+
+## 4. 服务端组装管线
+
+1. **Ingress 校验**：`modules/notify/api.go` bind → 三选一互斥（`present > 1` →
+   `err.server.notify.card_invalid` 400；`payload==nil && card==nil && docs_card==nil &&
+   len(payload)==0` → legacy 400）→ Decision 14 gate。
+2. **业务组装**：`modules/notify/card.go` `deliverDocsCardNotification`：
+   - `Kind` 合法性 → 400 unmapped；
+   - dedup → actor 排除；
+   - `memberCache.verify(space_id, targets)`；非成员进 `Filtered`；
+   - `ensureNotifyBotReady()`（与 summary 共享）；
+   - `buildDocsCard` → `docsAttributionAndVariant` → `cardtmpl.BuildDocsResourceCard`；
+   - `carddispatch.Sender.Send(ctx, Target{DM}, Card{octo/v1, document})` 并发（内嵌
+     `sem` 20 与 producer `MaxInFlight` 20 一致）。
+3. **派发管线**（`internal/carddispatch`，Decisions 7/8/11）与 summary **完全相同**。
+4. **文本降级**：`canCard` 请求级决策；`cardmsg.Enabled()==false` /
+   `docsSender==nil` / `buildDocsCard` 失败（含非 https deep-link 前置） → 整请求走
+   `sendSummaryText`（服务端复用同一 API，`from_uid=NotifyBotUIDValue`，
+   `payload={type:1,content:buildDocsFallbackText(...)}`）。文本兜底格式：
+   `{attribution}\n文档：{Title}\n{Excerpt}\n时间：{UpdatedAt}`（按存在与否行）。
+
+## 5. 文案与 i18n（`docsLabelsFor`）
+
+`i18n.OutboundLanguage(ctx)` 决定。当前 `deliverDocsCardNotification` 用
+`context.Background()`（deployment 默认外语），与 summary / 邮件 / botfather 同纪律。
+
+| Key | zh-CN（默认） | en-US |
+|---|---|---|
+| `sharedBanner` / `sharedBannerAnon` | `%s 分享了文档` / 有人分享了文档 | `%s shared a document` / A document was shared with you |
+| `commentedBanner` / `commentedBannerAnon` | `%s 评论了文档` / 有新评论 | `%s commented on a document` / A new comment on a document |
+| `accessRequestedBanner` / `accessRequestedBannerAnon` | `%s 请求访问文档` / 有人请求访问文档 | `%s requested access to a document` / Someone requested access to a document |
+| `title` | 文档 | Document |
+| `actor` | 操作人 | By |
+| `updatedAt` | 时间 | At |
+
+按钮文案由 `pkg/cardtmpl.labelsForLanguage` 提供（同 summary）：
+`viewDetails=查看详情/View details`、`copy=复制/Copy`（docs-notify 未使用后者）。
+
+## 6. Deep-link（`/d/{doc_id}?sp={space_id}`）
+
+`cardtmpl.docsDeepLink`：从 `External.WebLoginURL` 取 origin（`scheme://host`），拼
+`/d/` + `PathEscape(doc_id)` + `?sp=` + `QueryEscape(space_id)`。origin 必须是
+**绝对 https**；否则 `BuildDocsResourceCard` 返回错误 → 请求级降级为纯文本 DM。
+
+**前置**：octo-web `/d/:docId` 路由**已在线**（`packages/dmworkbase` 走的是既有
+standalone doc 通路，含冷加载 → 登录跳转 → 多会话 sid 恢复的 XIN-398 测试套件）。
+这是 docs-notify 与 summary-notify 的关键差异——docs 侧「查看详情」按钮开箱可用；
+summary 侧仍在等 octo-web `/s/:taskId` 上线。
+
+## 7. 降级与错误分类
+
+与 summary 完全一致，见 `docs/summary-notify-card.md` §7。reason 词表：
+`not_space_member` / `target_denied` / `dispatch_failed` / `busy` / `send_failed`。
+
+## 8. 已知调优候选
+
+同 `docs/summary-notify-card.md` §8（`color:"Attention"` / `color:"Good"` / 让
+Excerpt 与 FactSet 位置可调）。多一个 docs 专属候选：
+
+- **访问申请交互按钮**：`access_requested` 变体天生适合「同意 / 拒绝」的交互卡（`octo/v2`），
+  但需要 producer 从 `octo/v1` 升级到 `octo/v2` 并绑定一个跑 `/v1/bot/events` 的
+  action-owner（brief › 「Interactive cards」小节）。docs-backend 目前是 TS/Hocuspocus，
+  不跑 Go bot 事件轮询——如果要走 `octo/v2` 交互，需要单独设计 executor 服务。**这是后续
+  独立议题**，不在本 producer 范围。
+
+## 9. 参考
+
+- 代码
+  - `pkg/cardtmpl/resource.go` — 模板家族（`BuildSummaryResourceCard` /
+    `BuildDocsResourceCard` 共用 `buildResourceCard`）、`metadata` 组装
+  - `modules/notify/card.go` — `deliverDocsCardNotification` / `buildDocsCard` /
+    `docsAttributionAndVariant` / `docsLabelsFor`
+  - `modules/notify/model.go` — `DocsCardFields` + `DocsCardKind*` 常量（跨仓契约字段）
+  - `modules/notify/api.go` — 三选一 mutex、docs-notify sender 装配
+  - `main.go` — `cardDispatchProducerSpecs`（summary-notify + docs-notify 同 shape）
+  - `pilote2e/docs_card_wukongim_test.go` — E2E：POST → 真 WuKongIM → 读回验 type-17
+- 契约与规范
+  - `.octospec/tasks/card-message-internal-dispatch/brief.md`
+  - `.octospec/tasks/card-message-internal-dispatch/docs-notify-contract.md`（跨仓）
+  - `.octospec/tasks/card-message-internal-dispatch/summary-notify-contract.md`（姊妹）
+  - `docs/card-protocol.md` — wire 协议权威
+  - `docs/summary-notify-card.md` — 姊妹 producer 文档，共享管线细节
+- 相关 PR：#577（dispatch 基座）、#579（`summary-notify` pilot）、#580（复用
+  `notification` bot 身份）、本 PR（`docs-notify` producer + `metadata.octo.variant`）

--- a/docs/docs-notify-card.md
+++ b/docs/docs-notify-card.md
@@ -10,7 +10,7 @@
 > 同目录 `docs-notify-contract.md`（跨仓 ingress 契约）。两者如有出入，以代码为准。
 >
 > 兄弟文档：`docs/summary-notify-card.md`（`summary-notify` 生产者）— 组装管线、
-> 降级链、Deep-link 前置、`metadata.octo.variant` 保留词表、错误分类**完全一致**，
+> 降级链、Deep-link 前置、`metadata.octo.{variant,source}` 保留词表、错误分类**完全一致**，
 > 本文档只呈现 docs 特有的字段/文案/deep-link 差异。
 
 ## 1. 概览
@@ -86,7 +86,10 @@ brief），发送方为分享用户本人，与本 producer 无关。docs-notify
   "version": "1.5",
   "metadata": {
     "webUrl": "https://im.example.com/d/d_20260713_abcd?sp=spc_xxx",
-    "octo": { "variant": "docs.shared" }
+    "octo": {
+      "variant": "docs.shared",
+      "source": { "label": "文档" }
+    }
   },
   "body": [
     { "type": "Container", "items": [
@@ -250,4 +253,4 @@ Excerpt 与 FactSet 位置可调）。多一个 docs 专属候选：
   - `docs/card-protocol.md` — wire 协议权威
   - `docs/summary-notify-card.md` — 姊妹 producer 文档，共享管线细节
 - 相关 PR：#577（dispatch 基座）、#579（`summary-notify` pilot）、#580（复用
-  `notification` bot 身份）、本 PR（`docs-notify` producer + `metadata.octo.variant`）
+  `notification` bot 身份）、本 PR（`docs-notify` producer + `metadata.octo.{variant,source}`）

--- a/docs/summary-notify-card.md
+++ b/docs/summary-notify-card.md
@@ -1,0 +1,325 @@
+# Summary-Notify 通知卡片（`internal/carddispatch` 首个生产者）
+
+> **权威声明**：本文档描述 `summary-notify` 生产者当前的卡片形态与组装规则。
+> 权威源码：`pkg/cardtmpl/resource.go`（AC JSON 组装）、`modules/notify/card.go`
+> （文案 / attribution / excerpt / 文本降级）、`internal/carddispatch/`（派发流水线）、
+> `pkg/cardmsg`（wire 协议与校验）。规范源头：
+> `.octospec/tasks/card-message-internal-dispatch/brief.md`（Decisions 1/3/4/11/14）与
+> 同目录 `summary-notify-contract.md`（跨仓 ingress 契约）。两者如有出入，以代码为准。
+>
+> 相关 PR：#577（dispatch 基座）、#579（`summary-notify` pilot）、#580（复用
+> `notification` bot 身份）。
+
+## 1. 概览
+
+`summary-notify` 是 `internal/carddispatch` 落地的**第一个**内部卡片生产者。业务侧
+（`octo-smart-summary` worker）任务终态后经**既有** `POST /v1/internal/notify` 内网
+接口投递**结构化字段**（`NotifyReq.Card` = `SummaryCardFields`），octo-server 侧完成
+**卡片组装 → 派发 → 降级**闭环：
+
+```
+smart-summary worker
+   │  POST /v1/internal/notify  (X-Internal-Token, 一请求一收件人)
+   ▼
+modules/notify.deliverCardNotification
+   │  dedup → actor 排除 → live member 校验 → readiness 检查
+   ▼
+cardtmpl.BuildSummaryResourceCard        （组装 AC JSON，deep-link 由 External 决定）
+   │
+   ▼
+carddispatch.Sender.Send                 （producer-bound；DM/octo/v1/system-notification）
+   │
+   ▼  单次 SendMessageWithResult 送 WuKongIM，from_uid = notification User Bot
+   (卡片建卡/校验/派发失败 → 整请求降级为纯文本 DM，仍走同一 notification 身份)
+```
+
+- **发送方身份**：复用已有 `notification` User Bot（`ensureNotifyBot` provision 的
+  `user`+`app`+`robot.status=1`）；卡片与文本降级同一 DM 会话，无独立 summary Bot（#580）。
+- **接口层不变**：仍是 `POST /v1/internal/notify` + `X-Internal-Token`，body 里
+  `Payload` 与 `Card` **二选一**。Decision 14：`Payload` 若被 `cardmsg.IsCardPayload`
+  判为卡片则 400 拒绝——「凡卡片必须走结构化 `Card`」是硬性契约。
+- **生产者信息**：`ProducerID="summary-notify"`，`SenderUID=NotifyBotUIDValue`，
+  `AllowedChannelTypes=[Person]`，`AllowedProfiles=[octo/v1]`，
+  `SpacePolicy=SystemNotification`，`MaxInFlight=20/process`。
+
+## 2. 卡片形态（Adaptive Card 1.5）
+
+`summary-notify` 使用 `pkg/cardtmpl` 的 `ResourceCard` 家族（`octo/v1` 展示白名单
+子集），两种 `Kind`：
+
+| `Kind` | 场景 | attribution | excerpt | FactSet |
+|---|---|---|---|---|
+| `"completed"` | 总结生成成功 | `labels.completedBanner` | 空 | 有效字段 |
+| `"failed"` | 生成失败 | `labels.failedBanner` | `labels.failedPrefix + Reason` | 有效字段（通常为空） |
+
+**公共结构**：
+- Header：无 `IconURL` 时是 `Container`，含 `TextBlock(Title, weight=Bolder)` 与
+  可选的 `TextBlock(Attribution, isSubtle, spacing=None)`；有 icon 时用
+  `ColumnSet(auto Image + stretch title stack)`。`summary-notify` 目前不设置 icon。
+- Excerpt：可选 `TextBlock(wrap=true)`，超过 `MaxExcerptRunes=300` 时截断加省略号。
+- FactSet：仅当 `TimeRange`/`Members>0`/`MsgCount>0`/`GeneratedAt` 至少一个非空时出现。
+- ActionSet：至少 `Action.OpenUrl("查看详情", deepLink)`；可选 `Action.CopyToClipboard`
+  （`summary-notify` 未使用）。
+- **入卡文本一律经 `escapeMarkdown` 转义**（`* _ [ ] ( ) < > \` \# ~ |` 逐字符加
+  反斜杠），阻断外部字段中的 markdown 链接/图片/自动链接被 CommonMark 解析器解为
+  可点击链接（否则会额外过 URL allowlist 或走渲染面）。
+
+### 2.1 completed 完整 AC JSON
+
+字段来源：见跨仓契约 `summary-notify-contract.md`。示例入参：
+
+```jsonc
+{
+  "space_id":  "spc_xxx",
+  "service":   "summary-service",
+  "targets":   ["uid_recipient"],
+  "actor_uid": "",
+  "card": {
+    "task_no":     "TN_20260713_abcd",
+    "kind":        "completed",
+    "title":       "产品周会纪要",
+    "time_range":  "2026-07-06 10:00 ~ 2026-07-13 10:00",
+    "members":     5,
+    "msg_count":   128,
+    "generated_at":"2026-07-13 15:04",
+    "reason":      ""
+  }
+}
+```
+
+服务端组装的 `card` 文档（AC 1.5，`profile=octo/v1`，`card_version="1.5"`）：
+
+```json
+{
+  "type": "AdaptiveCard",
+  "version": "1.5",
+  "body": [
+    { "type": "Container", "items": [
+      { "type": "TextBlock", "text": "产品周会纪要", "weight": "Bolder", "wrap": true },
+      { "type": "TextBlock", "text": "总结已生成完成", "isSubtle": true, "spacing": "None", "wrap": true }
+    ]},
+    { "type": "FactSet", "facts": [
+      { "title": "时间范围", "value": "2026-07-06 10:00 ~ 2026-07-13 10:00" },
+      { "title": "参与成员", "value": "5 人" },
+      { "title": "消息数量", "value": "128 条" },
+      { "title": "生成时间", "value": "2026-07-13 15:04" }
+    ]},
+    { "type": "ActionSet", "actions": [
+      { "type": "Action.OpenUrl", "title": "查看详情",
+        "url": "https://im.example.com/s/TN_20260713_abcd?sp=spc_xxx" }
+    ]}
+  ]
+}
+```
+
+发送到 WuKongIM 时的完整 wire 信封（`plain` 由服务端权威派生，见 `card-protocol.md` §5）：
+
+```jsonc
+{
+  "type": 17,
+  "card_version": "1.5",
+  "profile": "octo/v1",
+  "space_id": "spc_xxx",       // 由 carddispatch 权威注入
+  "plain":    "产品周会纪要\n总结已生成完成\n时间范围: 2026-07-06 10:00 ~ ...\n参与成员: 5 人\n...",
+  "card":     { ... /* 上方 body */ }
+}
+```
+
+渲染效果（示意）：
+
+```
+┌───────────────────────────────────────────────┐
+│ 产品周会纪要                                    │
+│ 总结已生成完成                                  │
+│                                                │
+│ 时间范围   2026-07-06 10:00 ~ 2026-07-13 10:00 │
+│ 参与成员   5 人                                 │
+│ 消息数量   128 条                               │
+│ 生成时间   2026-07-13 15:04                     │
+│                                                │
+│ [ 查看详情 ]                                    │
+└───────────────────────────────────────────────┘
+```
+
+### 2.2 failed 完整 AC JSON
+
+入参（失败一般只有 title + reason，其它字段空/零 → 服务端省略）：
+
+```jsonc
+{
+  "space_id":  "spc_xxx",
+  "service":   "summary-service",
+  "targets":   ["uid_recipient"],
+  "card": {
+    "task_no": "TN_20260713_abcd",
+    "kind":    "failed",
+    "title":   "产品周会纪要",
+    "reason":  "upstream LLM 5xx"
+  }
+}
+```
+
+服务端组装：
+
+```json
+{
+  "type": "AdaptiveCard",
+  "version": "1.5",
+  "body": [
+    { "type": "Container", "items": [
+      { "type": "TextBlock", "text": "产品周会纪要", "weight": "Bolder", "wrap": true },
+      { "type": "TextBlock", "text": "总结生成失败", "isSubtle": true, "spacing": "None", "wrap": true }
+    ]},
+    { "type": "TextBlock", "text": "失败原因：upstream LLM 5xx", "wrap": true },
+    { "type": "ActionSet", "actions": [
+      { "type": "Action.OpenUrl", "title": "查看详情",
+        "url": "https://im.example.com/s/TN_20260713_abcd?sp=spc_xxx" }
+    ]}
+  ]
+}
+```
+
+渲染效果（示意）：
+
+```
+┌───────────────────────────────────────────────┐
+│ 产品周会纪要                                    │
+│ 总结生成失败                                    │
+│                                                │
+│ 失败原因：upstream LLM 5xx                      │
+│                                                │
+│ [ 查看详情 ]                                    │
+└───────────────────────────────────────────────┘
+```
+
+## 3. Ingress 契约（`POST /v1/internal/notify`）
+
+完整跨仓契约见 `.octospec/tasks/card-message-internal-dispatch/summary-notify-contract.md`
+（本仓草稿，PR 打开后同步到 `Mininglamp-OSS/octo-smart-summary` 的
+issue/comment）。摘要：
+
+- 头 `X-Internal-Token`（`SUMMARY_NOTIFY_TOKEN` / `NOTIFY_INTERNAL_TOKEN`；fail-closed）。
+- 一请求一收件人（`targets` 单元素），smart-summary 侧
+  claim / markSent / markFailed / Sweep 状态机与 `space_id` / `service` / `actor_uid`
+  语义不变。
+- **`Payload` 与 `Card` 二选一**：文本仍走 `Payload{type:1,content:...}`；卡片填
+  `Card`。两者同时缺失 → 400；同时存在 → 400（`err.server.notify.card_invalid`）。
+- **`Payload` 里禁止手搓 type-17**：`cardmsg.IsCardPayload` 匹配即 400（Decision 14）。
+- 响应仍为 `NotifyResp{delivered:[], filtered:{uid:reason}}`：卡片派发 uid 进
+  `delivered`，`target_denied` / `dispatch_failed` / `busy` / 建卡失败 → uid 进
+  `filtered`。smart-summary 现有「只认 `delivered[]` 判真送达 + 非成员进 `filtered`
+  重试」的逻辑一行不用改。
+
+## 4. 服务端组装管线（关键代码路径）
+
+1. **Ingress 校验**：`modules/notify/api.go` bind → `Payload` / `Card` 互斥 → 若 `Payload`
+   带 type-17 shape → 400（Decision 14）。
+2. **业务组装**：`modules/notify/card.go` `deliverCardNotification`：
+   - dedup → actor 排除；
+   - `memberCache.verify(space_id, targets)`：非成员 → `Filtered`；
+   - `ensureNotifyBotReady()`：readiness 未就绪 → 请求级失败（调用方重试）；
+   - `buildSummaryCard`：按 `Kind` 组装 attribution / excerpt / facts，交给
+     `cardtmpl.BuildSummaryResourceCard`；
+   - `carddispatch.Sender.Send(ctx, Target{DM}, Card{octo/v1, document})` 逐收件人
+     并发（内嵌 `sem` 20 与 producer `MaxInFlight` 20 一致）。
+3. **派发管线**（`internal/carddispatch`，Decisions 7/8/11）：live bot identity →
+   live Space/target ACL → envelope 组装（`type=17`, `card_version="1.5"`,
+   `profile=octo/v1`, 服务端 `space_id`, 服务端 `plain`）→ `cardmsg.Validate` →
+   `cardmsg.Finalize` → `cardmsg.RecheckPayloadSize` → **一次** `SendMessageWithResult`。
+4. **文本降级**：`canCard` 在**请求级**决策；`cardmsg.Enabled()==false` /
+   sender 未注入 / `buildSummaryCard` 失败（含非 https deep-link 前置） → 整请求走
+   `sendSummaryText`（`config.NewPersonalMsgSendReq`，`from_uid=NotifyBotUIDValue`，
+   `payload={type:1,content:buildSummaryFallbackText(...)}`）。文本兜底文案见
+   `buildSummaryFallbackText`：completed / failed 分别按 headline + 键值行拼装。
+
+## 5. 文案与 i18n（`summaryLabelsFor`）
+
+`i18n.OutboundLanguage(ctx)` 决定；目前 `deliverCardNotification` 用
+`context.Background()`（deployment 默认外语），与邮件模板 / botfather 出站文案同纪律。
+后续如按收件人语言分发，改为按 uid resolve 即可，模板层无需改动。
+
+| Key | zh-CN（默认） | en-US |
+|---|---|---|
+| `completedBanner` | 总结已生成完成 | Summary ready |
+| `failedBanner` | 总结生成失败 | Summary failed |
+| `timeRange` | 时间范围 | Time range |
+| `members` / `membersValue` | 参与成员 / `%d 人` | Participants / `%d` |
+| `msgCount` / `msgCountValue` | 消息数量 / `%d 条` | Messages / `%d` |
+| `generatedAt` | 生成时间 | Generated at |
+| `failedPrefix` | 失败原因： | Reason:  |
+| `completedHeadline`（fallback text） | 你的总结「%s」已生成完成。 | Your summary "%s" is ready. |
+| `failedHeadline`（fallback text） | 你的总结「%s」生成失败。 | Your summary "%s" failed to generate. |
+
+按钮文案由 `pkg/cardtmpl` 的 `labelsForLanguage` 独立提供：`viewDetails=查看详情/View
+details`、`copy=复制/Copy`（`summary-notify` 不使用后者）。
+
+## 6. Deep-link（`/s/{task_no}?sp={space_id}`）
+
+`cardtmpl.summaryDeepLink`：从 `External.WebLoginURL` 取 origin（`scheme://host`），
+拼 `/s/` + `PathEscape(task_no)` + `?sp=` + `QueryEscape(space_id)`。origin 必须是
+**绝对 https**，否则 `BuildSummaryResourceCard` 返回错误 → 请求级降级为纯文本 DM。
+
+**前置**（enablement 门 (1)，见 brief）：**octo-web 需注册 `/s/:taskId` 独立浏览器
+路由**，行为镜像 `/d/:docId`（冷加载 → 登录跳转 → 多会话 sid 恢复，XIN-398 测试套）；
+登录态命中现有 `WKApp.openSummaryDetail(taskId)`。**目前 octo-web `main` 尚未上线该路由**
+（本仓 handoff `P2 gating tests` 未收敛），因此生产环境「查看详情」按钮仍会 404。
+smart-summary 切换 `Card` 前需要 octo-web 该路由与本仓 pilot 一起启用。
+
+## 7. 降级与错误分类
+
+| 触发 | 结果 | 收件人级别处理 |
+|---|---|---|
+| `cardmsg.Enabled() == false` | 请求级 → 走文本 | delivered 记文本送达 |
+| `n.cardSender == nil`（producer 未注入） | 请求级 → 走文本 | 同上 |
+| `buildSummaryCard` 失败（如非 https base URL） | 请求级 → 走文本；`Warn` 日志 | 同上 |
+| `ensureNotifyBotReady()` 未就绪 | **请求级失败**（500 类）| 调用方重试 |
+| 收件人非 Space 成员 | `Filtered[uid]=<memberCache 原因>` | smart-summary 现有重试逻辑 |
+| `carddispatch` 返回 `target_denied` | `Filtered[uid]="target_denied"` | 同上 |
+| `carddispatch` 返回 `busy` | `Filtered[uid]="busy"` | 同上 |
+| `carddispatch` 返回 `dispatch_failed` | `Filtered[uid]="dispatch_failed"` | 同上 |
+| 文本降级路径 `SendMessage` 失败 | `Filtered[uid]="send_failed"` | 同上 |
+
+Decision 8：dispatcher 单次 `SendMessageWithResult`，不隐式重试；transport-ambiguous
+的重复由调用方接受（brief pilot table，2026-07-13 确认）。
+
+## 8. 已知调优候选（open，可讨论后再改）
+
+以下点是渲染 / 文案层面的**可选**改进；不改也满足契约。改动落在 `modules/notify/card.go`
+的 `buildSummaryCard` / `summaryLabelsFor`，不涉及 `pkg/cardtmpl` 或 wire 契约。
+
+1. **失败状态视觉区分**：目前 `failedBanner` 与 `completedBanner` 同用
+   `isSubtle:true` 灰色文本，仅靠文案区分。可给 failed 的 attribution `TextBlock`
+   增加 `color:"Attention"`（AC 1.5 内置枚举；`pkg/cardmsg/validate.go` TextBlock
+   分支未对 `color` 做 allowlist，能过校验；三端自研 renderer 需实现）。示例：
+
+   ```json
+   { "type":"TextBlock","text":"总结生成失败",
+     "isSubtle":true,"color":"Attention","spacing":"None","wrap":true }
+   ```
+
+2. **失败原因改用 FactSet 行**：把「失败原因：<reason>」从独立 `TextBlock` excerpt
+   改为 `FactSet` 一行（`title="失败原因"`，`value=Reason`），视觉与 completed 卡的
+   FactSet 一致。`escapeMarkdown` 已作用于 Fact.value，安全性不变。取舍：excerpt 换行
+   自然、易读；FactSet 更规整、但长 reason 挤压 value 列。
+
+3. **完成状态强调**：给 `completedBanner` 加 `color:"Good"` 也可行（AC 1.5 语义色），
+   与失败态 `Attention` 对称。同样只需 renderer 支持。
+
+三条都是**渲染层小改**，不涉及 `pkg/cardmsg` allowlist、wire 契约、ingress 协议。
+在 octo-web `/s/:taskId` 落地前可以并行讨论、单独提 PR。
+
+## 9. 参考
+
+- 代码
+  - `pkg/cardtmpl/resource.go` — 模板与 deep-link 组装、markdown 转义、rune 截断
+  - `modules/notify/card.go` — Kind → attribution/excerpt/facts 映射、文本降级
+  - `modules/notify/model.go` — `SummaryCardFields` 结构（跨仓契约字段）
+  - `internal/carddispatch/` — dispatch pipeline（Decisions 3/4/7/8）
+  - `pkg/cardmsg/` — wire 协议、`Validate` / `Finalize` / `RecheckPayloadSize`
+- 契约与规范
+  - `.octospec/tasks/card-message-internal-dispatch/brief.md`
+  - `.octospec/tasks/card-message-internal-dispatch/summary-notify-contract.md`
+  - `.octospec/tasks/card-message-internal-dispatch/handoff.md`
+  - `docs/card-protocol.md` — wire 协议权威（§1 信封、§2 白名单、§5 plain 派生）
+- 相关 PR：#577（dispatch 基座）、#579（`summary-notify` pilot）、#580（复用
+  `notification` bot 身份）

--- a/docs/summary-notify-card.md
+++ b/docs/summary-notify-card.md
@@ -93,6 +93,10 @@ carddispatch.Sender.Send                 （producer-bound；DM/octo/v1/system-n
 {
   "type": "AdaptiveCard",
   "version": "1.5",
+  "metadata": {
+    "webUrl": "https://im.example.com/s/TN_20260713_abcd?sp=spc_xxx",
+    "octo": { "variant": "summary.completed" }
+  },
   "body": [
     { "type": "Container", "items": [
       { "type": "TextBlock", "text": "产品周会纪要", "weight": "Bolder", "wrap": true },
@@ -165,6 +169,10 @@ carddispatch.Sender.Send                 （producer-bound；DM/octo/v1/system-n
 {
   "type": "AdaptiveCard",
   "version": "1.5",
+  "metadata": {
+    "webUrl": "https://im.example.com/s/TN_20260713_abcd?sp=spc_xxx",
+    "octo": { "variant": "summary.failed" }
+  },
   "body": [
     { "type": "Container", "items": [
       { "type": "TextBlock", "text": "产品周会纪要", "weight": "Bolder", "wrap": true },
@@ -191,6 +199,31 @@ carddispatch.Sender.Send                 （producer-bound；DM/octo/v1/system-n
 │ [ 查看详情 ]                                    │
 └───────────────────────────────────────────────┘
 ```
+
+### 2.3 AC `metadata`（跨 producer 共享的约定）
+
+每张卡都在 AdaptiveCard 根上带上标准 AC 1.5 `metadata` 对象，内嵌 **保留命名空间**
+`octo` 供未来渲染层区分卡片家族／样式。字段稳定、低基数，值由服务端生成：
+
+```json
+"metadata": {
+  "webUrl": "<deep-link>",              // AC 1.5 标准字段；与主 Action.OpenUrl.url 同源
+  "octo":   { "variant": "<family>.<kind>" }
+}
+```
+
+`variant` 保留词表（`{producer_family}.{kind}`，只增不改）：
+
+| producer | Kind | variant |
+|---|---|---|
+| `summary-notify` | `completed` | `summary.completed` |
+| `summary-notify` | `failed` | `summary.failed` |
+| `docs-notify` | `shared` / `commented` / `access_requested` | `docs.shared` / `docs.commented` / `docs.access_requested` |
+| 后续新增 producer | 自定 kind | `<family>.<kind>` |
+
+渲染端**可以但不必**读 `variant` —— 未识别的值等同「泛用卡片」。产者永远不塞用户
+输入到 `metadata`（只塞服务端选定的 `variant` + 服务端拼的 `webUrl`），避免绕开
+主体 URL/markdown 白名单（`pkg/cardmsg.Validate` 不解析 `metadata` 子字段）。
 
 ## 3. Ingress 契约（`POST /v1/internal/notify`）
 

--- a/docs/summary-notify-card.md
+++ b/docs/summary-notify-card.md
@@ -95,7 +95,10 @@ carddispatch.Sender.Send                 （producer-bound；DM/octo/v1/system-n
   "version": "1.5",
   "metadata": {
     "webUrl": "https://im.example.com/s/TN_20260713_abcd?sp=spc_xxx",
-    "octo": { "variant": "summary.completed" }
+    "octo": {
+      "variant": "summary.completed",
+      "source": { "label": "智能总结" }
+    }
   },
   "body": [
     { "type": "Container", "items": [
@@ -171,7 +174,10 @@ carddispatch.Sender.Send                 （producer-bound；DM/octo/v1/system-n
   "version": "1.5",
   "metadata": {
     "webUrl": "https://im.example.com/s/TN_20260713_abcd?sp=spc_xxx",
-    "octo": { "variant": "summary.failed" }
+    "octo": {
+      "variant": "summary.failed",
+      "source": { "label": "智能总结" }
+    }
   },
   "body": [
     { "type": "Container", "items": [
@@ -203,27 +209,38 @@ carddispatch.Sender.Send                 （producer-bound；DM/octo/v1/system-n
 ### 2.3 AC `metadata`（跨 producer 共享的约定）
 
 每张卡都在 AdaptiveCard 根上带上标准 AC 1.5 `metadata` 对象，内嵌 **保留命名空间**
-`octo` 供未来渲染层区分卡片家族／样式。字段稳定、低基数，值由服务端生成：
+`octo` 供渲染层区分卡片家族／样式、显示来源角标。字段稳定、低基数，值由服务端生成：
 
 ```json
 "metadata": {
   "webUrl": "<deep-link>",              // AC 1.5 标准字段；与主 Action.OpenUrl.url 同源
-  "octo":   { "variant": "<family>.<kind>" }
+  "octo": {
+    "variant": "<family>.<kind>",       // 卡片家族+种类标识，见下表
+    "source":  { "label": "<来源名>", "iconUrl": "<可选 https 角标图标>" }
+  }
 }
 ```
 
-`variant` 保留词表（`{producer_family}.{kind}`，只增不改）：
+- **`variant`** —— 稳定标识，渲染端**可以但不必**读；未识别值等同「泛用卡片」。
+- **`source`** —— 来源能力，供渲染端显示「来自 XX」chip / 角标。`label` 由 producer
+  **按出站语言**传入（`i18n.OutboundLanguage` → `summaryLabelsFor`/`docsLabelsFor` 的
+  `sourceLabel`），与卡片其它文案同一套 i18n；`iconUrl` 可选（当前 pilot 只填 `label`）。
+  模板**不自动**把 `source` 渲进卡体——是否显示、以何形态显示（chip / 前缀 / 静默）由
+  渲染端决定，机器消费方则已拿到来源信号。
 
-| producer | Kind | variant |
-|---|---|---|
-| `summary-notify` | `completed` | `summary.completed` |
-| `summary-notify` | `failed` | `summary.failed` |
-| `docs-notify` | `shared` / `commented` / `access_requested` | `docs.shared` / `docs.commented` / `docs.access_requested` |
-| 后续新增 producer | 自定 kind | `<family>.<kind>` |
+`variant` / `source.label` 保留词表（`{producer_family}.{kind}`，只增不改）：
 
-渲染端**可以但不必**读 `variant` —— 未识别的值等同「泛用卡片」。产者永远不塞用户
-输入到 `metadata`（只塞服务端选定的 `variant` + 服务端拼的 `webUrl`），避免绕开
-主体 URL/markdown 白名单（`pkg/cardmsg.Validate` 不解析 `metadata` 子字段）。
+| producer | Kind | variant | `source.label`（zh-CN / en-US） |
+|---|---|---|---|
+| `summary-notify` | `completed` | `summary.completed` | 智能总结 / Smart Summary |
+| `summary-notify` | `failed` | `summary.failed` | 智能总结 / Smart Summary |
+| `docs-notify` | `shared` / `commented` / `access_requested` | `docs.shared` / `docs.commented` / `docs.access_requested` | 文档 / Docs |
+| 后续新增 producer | 自定 kind | `<family>.<kind>` | 该 producer 的 i18n `sourceLabel` |
+
+产者永远不塞用户输入到 `metadata`（只塞服务端选定的 `variant`/`source` + 服务端拼的
+`webUrl`），避免绕开主体 URL/markdown 白名单（`pkg/cardmsg.Validate` 不解析
+`metadata` 子字段——正因如此，`metadata` 里没有任何调用方可控的输入面）。
+`source.iconUrl` 若设置，`cardtmpl` 会走 `requireHTTPS` 正向校验。
 
 ## 3. Ingress 契约（`POST /v1/internal/notify`）
 

--- a/main.go
+++ b/main.go
@@ -354,37 +354,47 @@ func installCardDispatch(ctx *config.Context) error {
 		Metrics:          carddispatch.NewMetrics(prometheus.DefaultRegisterer),
 		Logger:           log.NewTLog("CardDispatch"),
 	}
-	registry := carddispatch.NewRegistry(deps, summaryNotifyProducerSpecs())
+	registry := carddispatch.NewRegistry(deps, cardDispatchProducerSpecs())
 	return carddispatch.Install(ctx, registry)
 }
 
-func summaryNotifyProducerSpecs() []carddispatch.ProducerSpec {
-	// summary-notify pilot (brief › pilot table, all rows confirmed 2026-07-13):
-	// existing `notification` User Bot, DM-only, display-only octo/v1,
-	// system-notification Space policy, in-flight 20/process. modules/notify
-	// obtains this producer's bound Sender via carddispatch.SenderFromContext.
+func cardDispatchProducerSpecs() []carddispatch.ProducerSpec {
+	// Every producer here shares the same shape (existing `notification` User
+	// Bot, DM-only, display-only octo/v1, system-notification Space policy,
+	// in-flight 20/process; brief › pilot table, all rows confirmed
+	// 2026-07-13). modules/notify obtains each producer's bound Sender via
+	// carddispatch.SenderFromContext.
 	//
-	// Registration is inert until modules/notify receives a structured card
-	// request (NotifyReq.Card) AND OCTO_CARD_MESSAGE_ENABLED is on; end-to-end
-	// enablement additionally depends on octo-web shipping the /s/:taskId route
-	// and octo-smart-summary switching its send from text to the card fields.
-	return []carddispatch.ProducerSpec{
-		{
-			ID:                  summaryNotifyProducerID,
-			Enabled:             true,
-			SenderUID:           notify.NotifyBotUIDValue,
-			AllowedChannelTypes: []uint8{common.ChannelTypePerson.Uint8()},
-			AllowedProfiles:     []string{cardmsg.ProfileV1},
-			SpacePolicy:         carddispatch.SpacePolicySystemNotification,
-			GroupPolicy:         carddispatch.GroupPolicyMemberRequired, // unused at DM pilot; must be a valid value
-			MaxInFlight:         20,
-		},
+	// Registrations are inert until modules/notify receives a matching
+	// structured card request (NotifyReq.Card or NotifyReq.DocsCard) AND
+	// OCTO_CARD_MESSAGE_ENABLED is on. End-to-end enablement of a producer
+	// additionally depends on octo-web shipping the matching deep-link route
+	// (/s/:taskId for summary — not yet on main; /d/:docId for docs — already
+	// live) and the caller-side switching from text payloads to structured
+	// fields.
+	base := carddispatch.ProducerSpec{
+		Enabled:             true,
+		SenderUID:           notify.NotifyBotUIDValue,
+		AllowedChannelTypes: []uint8{common.ChannelTypePerson.Uint8()},
+		AllowedProfiles:     []string{cardmsg.ProfileV1},
+		SpacePolicy:         carddispatch.SpacePolicySystemNotification,
+		GroupPolicy:         carddispatch.GroupPolicyMemberRequired, // unused at DM pilot; must be a valid value
+		MaxInFlight:         20,
 	}
+	summarySpec := base
+	summarySpec.ID = summaryNotifyProducerID
+	docsSpec := base
+	docsSpec.ID = docsNotifyProducerID
+	return []carddispatch.ProducerSpec{summarySpec, docsSpec}
 }
 
-// summaryNotifyProducerID mirrors modules/notify's producer ID. Kept here so the
-// composition root can register the spec without importing an unexported const.
-const summaryNotifyProducerID = carddispatch.ProducerID("summary-notify")
+// {summaryNotify,docsNotify}ProducerID mirror modules/notify's producer IDs.
+// Kept here so the composition root can register the spec without importing an
+// unexported const.
+const (
+	summaryNotifyProducerID = carddispatch.ProducerID("summary-notify")
+	docsNotifyProducerID    = carddispatch.ProducerID("docs-notify")
+)
 
 func printServerInfo(ctx *config.Context) {
 	infoStr := `

--- a/main_carddispatch_test.go
+++ b/main_carddispatch_test.go
@@ -27,35 +27,55 @@ func TestCardDispatchRegistryInstalledBeforeModuleConstruction(t *testing.T) {
 	}
 }
 
-func TestSummaryNotifyIsOnlyProductionCardProducer(t *testing.T) {
-	specs := summaryNotifyProducerSpecs()
-	if len(specs) != 1 {
-		t.Fatalf("production registry has %d producers; want summary-notify only", len(specs))
+// TestNotificationCardProducerRegistrations pins the production card-dispatch
+// producers to the reviewed shape (Sender identity, DM-only, octo/v1,
+// system-notification Space policy, MaxInFlight=20). Both `summary-notify` and
+// `docs-notify` share this shape by design (see modules/notify — capability
+// isolation lives on the producer ID, not the sender identity). Any *new*
+// production producer needs its own reviewed entry here, so this test
+// deliberately fails on unknown IDs — the sender-of-cards allowlist is not
+// silently extensible.
+func TestNotificationCardProducerRegistrations(t *testing.T) {
+	specs := cardDispatchProducerSpecs()
+	want := map[carddispatch.ProducerID]bool{
+		"summary-notify": false,
+		"docs-notify":    false,
 	}
+	for _, spec := range specs {
+		seen, known := want[spec.ID]
+		if !known {
+			t.Fatalf("unexpected production producer %q — new senders require a reviewed entry", spec.ID)
+		}
+		if seen {
+			t.Fatalf("producer %q registered twice", spec.ID)
+		}
+		want[spec.ID] = true
 
-	spec := specs[0]
-	if spec.ID != carddispatch.ProducerID("summary-notify") {
-		t.Fatalf("producer ID = %q; want summary-notify", spec.ID)
+		if !spec.Enabled {
+			t.Fatalf("%s producer must be enabled", spec.ID)
+		}
+		if spec.SenderUID != notify.NotifyBotUIDValue {
+			t.Fatalf("%s sender UID = %q; want existing notification bot %q", spec.ID, spec.SenderUID, notify.NotifyBotUIDValue)
+		}
+		if len(spec.AllowedChannelTypes) != 1 || spec.AllowedChannelTypes[0] != common.ChannelTypePerson.Uint8() {
+			t.Fatalf("%s allowed channel types = %v; want DM only", spec.ID, spec.AllowedChannelTypes)
+		}
+		if len(spec.AllowedProfiles) != 1 || spec.AllowedProfiles[0] != cardmsg.ProfileV1 {
+			t.Fatalf("%s allowed profiles = %v; want octo/v1 only", spec.ID, spec.AllowedProfiles)
+		}
+		if spec.SpacePolicy != carddispatch.SpacePolicySystemNotification {
+			t.Fatalf("%s space policy = %q; want system_notification", spec.ID, spec.SpacePolicy)
+		}
+		if spec.GroupPolicy != carddispatch.GroupPolicyMemberRequired {
+			t.Fatalf("%s group policy = %q; want member_required", spec.ID, spec.GroupPolicy)
+		}
+		if spec.MaxInFlight != 20 {
+			t.Fatalf("%s max in flight = %d; want 20", spec.ID, spec.MaxInFlight)
+		}
 	}
-	if !spec.Enabled {
-		t.Fatal("summary-notify producer must be enabled")
-	}
-	if spec.SenderUID != notify.NotifyBotUIDValue {
-		t.Fatalf("sender UID = %q; want existing notification bot %q", spec.SenderUID, notify.NotifyBotUIDValue)
-	}
-	if len(spec.AllowedChannelTypes) != 1 || spec.AllowedChannelTypes[0] != common.ChannelTypePerson.Uint8() {
-		t.Fatalf("allowed channel types = %v; want DM only", spec.AllowedChannelTypes)
-	}
-	if len(spec.AllowedProfiles) != 1 || spec.AllowedProfiles[0] != cardmsg.ProfileV1 {
-		t.Fatalf("allowed profiles = %v; want octo/v1 only", spec.AllowedProfiles)
-	}
-	if spec.SpacePolicy != carddispatch.SpacePolicySystemNotification {
-		t.Fatalf("space policy = %q; want system_notification", spec.SpacePolicy)
-	}
-	if spec.GroupPolicy != carddispatch.GroupPolicyMemberRequired {
-		t.Fatalf("group policy = %q; want member_required", spec.GroupPolicy)
-	}
-	if spec.MaxInFlight != 20 {
-		t.Fatalf("max in flight = %d; want 20", spec.MaxInFlight)
+	for id, seen := range want {
+		if !seen {
+			t.Fatalf("expected producer %q was not registered", id)
+		}
 	}
 }

--- a/modules/notify/api.go
+++ b/modules/notify/api.go
@@ -27,8 +27,14 @@ import (
 // InternalTokenHeader is the header key for internal service authentication.
 const InternalTokenHeader = "X-Internal-Token"
 
-// summaryNotifyProducerID is the carddispatch producer this module owns.
-const summaryNotifyProducerID = "summary-notify"
+// summaryNotifyProducerID / docsNotifyProducerID are the carddispatch producers
+// this module owns. Both are bound to the shared `notification` User Bot so
+// summary cards, docs cards, and legacy text notifications appear in one system
+// DM conversation; capability isolation lives at the producer level.
+const (
+	summaryNotifyProducerID = "summary-notify"
+	docsNotifyProducerID    = "docs-notify"
+)
 
 var (
 	errNotifyCardNotAllowed = errors.New("card payload not allowed on internal notify ingress")
@@ -45,6 +51,7 @@ type Notify struct {
 	botMu         sync.Mutex
 	botOK         atomic.Bool
 	cardSender    carddispatch.Sender
+	docsSender    carddispatch.Sender
 	internalToken string
 	log.Log
 }
@@ -66,13 +73,18 @@ func New(ctx *config.Context) *Notify {
 		Log:           log.NewTLog("Notify"),
 	}
 
-	// Obtain the producer-bound card Sender from the single registry composed at
+	// Obtain the producer-bound card Senders from the single registry composed at
 	// bootstrap (main.installCardDispatch, before module construction). A missing
 	// registration is non-fatal: card notifications degrade to the text DM path.
 	if sender, senderErr := carddispatch.SenderFromContext(ctx, summaryNotifyProducerID); senderErr != nil {
 		n.Warn("summary-notify card sender unavailable; card notifications will degrade to text", zap.Error(senderErr))
 	} else {
 		n.cardSender = sender
+	}
+	if sender, senderErr := carddispatch.SenderFromContext(ctx, docsNotifyProducerID); senderErr != nil {
+		n.Warn("docs-notify card sender unavailable; docs card notifications will degrade to text", zap.Error(senderErr))
+	} else {
+		n.docsSender = sender
 	}
 
 	// 注册缓存失效回调（通过 event 包避免循环依赖）
@@ -167,13 +179,26 @@ func (n *Notify) sendNotify(c *wkhttp.Context) {
 		return
 	}
 	// Payload dropped its binding:"required" so card requests (Payload absent,
-	// Card present) bind cleanly. payload and card are mutually exclusive
-	// (contract); a text request that carries neither keeps the legacy 400.
+	// Card / DocsCard present) bind cleanly. Payload / Card / DocsCard are
+	// mutually exclusive (contract). Presence uses != nil for Payload (an
+	// explicit `{}` counts as "caller intended to send a payload" and must not
+	// silently combine with Card / DocsCard); the legacy "payload不能为空" 400
+	// still fires when nothing meaningful is provided.
+	present := 0
+	if req.Payload != nil {
+		present++
+	}
+	if req.Card != nil {
+		present++
+	}
+	if req.DocsCard != nil {
+		present++
+	}
 	switch {
-	case req.Card != nil && req.Payload != nil:
+	case present > 1:
 		httperr.ResponseErrorL(c, errcode.ErrNotifyCardInvalid, nil, nil)
 		return
-	case req.Card == nil && len(req.Payload) == 0:
+	case req.Card == nil && req.DocsCard == nil && len(req.Payload) == 0:
 		c.ResponseErrorWithStatus(errors.New("payload不能为空"), http.StatusBadRequest)
 		return
 	}
@@ -195,11 +220,14 @@ func (n *Notify) sendNotify(c *wkhttp.Context) {
 	c.Response(resp)
 }
 
-// dispatchNotify routes a single request to the card producer path (when a
-// structured Card is present) or the legacy text path.
+// dispatchNotify routes a single request to the correct producer path (when a
+// structured Card / DocsCard is present) or the legacy text path.
 func (n *Notify) dispatchNotify(req *NotifyReq) (*NotifyResp, error) {
 	if req != nil && req.Card != nil {
 		return n.deliverCardNotification(req)
+	}
+	if req != nil && req.DocsCard != nil {
+		return n.deliverDocsCardNotification(req)
 	}
 	return n.deliverNotification(req)
 }
@@ -221,10 +249,10 @@ func (n *Notify) sendNotifyBatch(c *wkhttp.Context) {
 	}
 	// Preflight the whole batch before delivering any earlier text item. This
 	// preserves the zero-transport guarantee when a later entry is a card.
-	// Card notifications are single-endpoint only (they fan out through the
-	// carddispatch producer), so a Card in a batch entry is rejected outright.
+	// Card / DocsCard notifications are single-endpoint only (they fan out through
+	// the carddispatch producer), so any card entry in a batch is rejected outright.
 	for i := range req.Notifications {
-		if req.Notifications[i].Card != nil {
+		if req.Notifications[i].Card != nil || req.Notifications[i].DocsCard != nil {
 			httperr.ResponseErrorL(c, errcode.ErrNotifyCardInvalid, nil, nil)
 			return
 		}

--- a/modules/notify/card.go
+++ b/modules/notify/card.go
@@ -176,8 +176,10 @@ func (n *Notify) buildSummaryCard(ctx context.Context, spaceID string, card *Sum
 
 	attribution := labels.completedBanner
 	excerpt := ""
+	variant := "summary.completed"
 	if card.Kind == SummaryCardKindFailed {
 		attribution = labels.failedBanner
+		variant = "summary.failed"
 		if reason := strings.TrimSpace(card.Reason); reason != "" {
 			excerpt = labels.failedPrefix + reason
 		}
@@ -189,6 +191,8 @@ func (n *Notify) buildSummaryCard(ctx context.Context, spaceID string, card *Sum
 		Attribution: attribution,
 		Excerpt:     excerpt,
 		Facts:       facts,
+		Variant:     variant,
+		Source:      cardtmpl.Source{Label: labels.sourceLabel},
 	})
 }
 
@@ -247,6 +251,250 @@ type summaryLabels struct {
 	kvSep             string
 	completedHeadline string // fmt verb for the title, used by the text fallback
 	failedHeadline    string
+	sourceLabel       string // ResourceCard.Source.Label — "智能总结" / "Smart Summary"
+}
+
+// deliverDocsCardNotification is the docs-notify card path. Structurally it
+// mirrors deliverCardNotification (dedup -> actor exclusion -> live member
+// verification -> bounded fan-out) but binds to the docs-notify producer and
+// uses BuildDocsResourceCard for the /d/{doc_id}?sp={space_id} deep link. A
+// build failure degrades the whole request to a plain-text DM so a docs
+// notification is never silently lost.
+func (n *Notify) deliverDocsCardNotification(req *NotifyReq) (*NotifyResp, error) {
+	if req == nil || req.DocsCard == nil {
+		return nil, errNotifyCardInvalid
+	}
+	card := req.DocsCard
+	if strings.TrimSpace(req.SpaceID) == "" || len(req.Targets) == 0 || len(req.Targets) > 200 {
+		return nil, errNotifyCardInvalid
+	}
+	if strings.TrimSpace(card.DocID) == "" || strings.TrimSpace(card.Title) == "" {
+		return nil, errNotifyCardInvalid
+	}
+	if card.Kind != DocsCardKindShared && card.Kind != DocsCardKindCommented &&
+		card.Kind != DocsCardKindAccessRequested {
+		return nil, errNotifyCardInvalid
+	}
+
+	targets := dedupTargets(req.Targets)
+	if req.ActorUID != "" {
+		tmp := make([]string, 0, len(targets))
+		for _, uid := range targets {
+			if uid != req.ActorUID {
+				tmp = append(tmp, uid)
+			}
+		}
+		targets = tmp
+	}
+
+	members, filteredMap, err := n.memberCache.verify(n.db, req.SpaceID, targets)
+	if err != nil {
+		return nil, fmt.Errorf("member verification failed: %w", err)
+	}
+	if len(members) == 0 {
+		return &NotifyResp{Delivered: []string{}, Filtered: filteredMap}, nil
+	}
+
+	n.ensureNotifyBotReady()
+	if !n.botOK.Load() {
+		return nil, errors.New("notification bot unavailable")
+	}
+
+	lang := i18n.OutboundLanguage(context.Background())
+
+	canCard := n.docsSender != nil && cardmsg.Enabled()
+	var document json.RawMessage
+	if canCard {
+		doc, buildErr := n.buildDocsCard(context.Background(), req.SpaceID, card, lang)
+		if buildErr != nil {
+			n.Warn("build docs card failed, degrading to text",
+				zap.Error(buildErr), zap.String("space_id", req.SpaceID), zap.String("doc_id", card.DocID))
+			canCard = false
+		} else {
+			document = doc
+		}
+	}
+	fallbackText := ""
+	if !canCard {
+		fallbackText = buildDocsFallbackText(card, lang)
+	}
+
+	type sendResult struct {
+		uid    string
+		reason string
+	}
+	resultCh := make(chan sendResult, len(members))
+	sem := make(chan struct{}, 20)
+
+	for _, targetUID := range members {
+		sem <- struct{}{}
+		go func(uid string) {
+			defer func() { <-sem }()
+			reason := ""
+			if canCard {
+				_, sendErr := n.docsSender.Send(
+					context.Background(),
+					carddispatch.Target{
+						SpaceID:     req.SpaceID,
+						ChannelID:   uid,
+						ChannelType: common.ChannelTypePerson.Uint8(),
+					},
+					carddispatch.Card{Profile: cardmsg.ProfileV1, Document: document},
+				)
+				if sendErr != nil {
+					reason = string(carddispatch.CategoryOf(sendErr))
+					n.Warn("投递文档卡片失败",
+						zap.String("target", uid), zap.String("space_id", req.SpaceID),
+						zap.String("category", reason), zap.Error(sendErr))
+				}
+			} else if txtErr := n.sendSummaryText(uid, req.SpaceID, fallbackText); txtErr != nil {
+				reason = "send_failed"
+				n.Warn("投递文档文本失败",
+					zap.String("target", uid), zap.String("space_id", req.SpaceID), zap.Error(txtErr))
+			}
+			resultCh <- sendResult{uid: uid, reason: reason}
+		}(targetUID)
+	}
+
+	delivered := make([]string, 0, len(members))
+	for range members {
+		r := <-resultCh
+		if r.reason == "" {
+			delivered = append(delivered, r.uid)
+		} else {
+			filteredMap[r.uid] = r.reason
+		}
+	}
+
+	n.Info("notify_docs_card_delivered",
+		zap.String("service", req.Service),
+		zap.String("space_id", req.SpaceID),
+		zap.String("doc_id", card.DocID),
+		zap.String("kind", card.Kind),
+		zap.Bool("as_card", canCard),
+		zap.Int("targets", len(req.Targets)),
+		zap.Int("delivered", len(delivered)),
+		zap.Int("filtered", len(filteredMap)),
+	)
+
+	return &NotifyResp{Delivered: delivered, Filtered: filteredMap}, nil
+}
+
+// buildDocsCard renders the octo/v1 ResourceCard for a docs-notify
+// notification. Kind maps to Variant / Attribution deterministically; ActorName
+// and UpdatedAt render as optional FactSet rows. Excerpt is the free-form
+// preview / comment / access reason bounded by cardtmpl.MaxExcerptRunes.
+func (n *Notify) buildDocsCard(ctx context.Context, spaceID string, card *DocsCardFields, lang string) (json.RawMessage, error) {
+	labels := docsLabelsFor(lang)
+	facts := make([]cardtmpl.Fact, 0, 2)
+	if actor := strings.TrimSpace(card.ActorName); actor != "" {
+		facts = append(facts, cardtmpl.Fact{Title: labels.actor, Value: actor})
+	}
+	if ts := strings.TrimSpace(card.UpdatedAt); ts != "" {
+		facts = append(facts, cardtmpl.Fact{Title: labels.updatedAt, Value: ts})
+	}
+
+	attribution, variant := docsAttributionAndVariant(card.Kind, card.ActorName, labels)
+
+	webLoginURL := n.ctx.GetConfig().External.WebLoginURL
+	return cardtmpl.BuildDocsResourceCard(ctx, webLoginURL, card.DocID, spaceID, cardtmpl.ResourceCard{
+		Title:       card.Title,
+		Attribution: attribution,
+		Excerpt:     strings.TrimSpace(card.Excerpt),
+		Facts:       facts,
+		Variant:     variant,
+		Source:      cardtmpl.Source{Label: labels.sourceLabel},
+	})
+}
+
+// docsAttributionAndVariant maps DocsCard.Kind to a (localized attribution
+// line, Variant string). When ActorName is present the attribution embeds it;
+// otherwise a subject-less form is used ("Shared a document" / "文档已分享").
+func docsAttributionAndVariant(kind, actorName string, labels docsLabels) (string, string) {
+	actor := strings.TrimSpace(actorName)
+	switch kind {
+	case DocsCardKindCommented:
+		if actor != "" {
+			return fmt.Sprintf(labels.commentedBanner, actor), "docs.commented"
+		}
+		return labels.commentedBannerAnon, "docs.commented"
+	case DocsCardKindAccessRequested:
+		if actor != "" {
+			return fmt.Sprintf(labels.accessRequestedBanner, actor), "docs.access_requested"
+		}
+		return labels.accessRequestedBannerAnon, "docs.access_requested"
+	default: // DocsCardKindShared
+		if actor != "" {
+			return fmt.Sprintf(labels.sharedBanner, actor), "docs.shared"
+		}
+		return labels.sharedBannerAnon, "docs.shared"
+	}
+}
+
+// buildDocsFallbackText mirrors buildSummaryFallbackText: composes the plain
+// DM used when a card cannot be built (feature disabled, sender missing, or
+// template/config error). No information is lost — every field that would
+// appear on the card is emitted as a text line.
+func buildDocsFallbackText(card *DocsCardFields, lang string) string {
+	labels := docsLabelsFor(lang)
+	attribution, _ := docsAttributionAndVariant(card.Kind, card.ActorName, labels)
+	var b strings.Builder
+	b.WriteString(attribution)
+	if title := strings.TrimSpace(card.Title); title != "" {
+		fmt.Fprintf(&b, "\n%s%s", labels.title+labels.kvSep, title)
+	}
+	if excerpt := strings.TrimSpace(card.Excerpt); excerpt != "" {
+		fmt.Fprintf(&b, "\n%s", excerpt)
+	}
+	if ts := strings.TrimSpace(card.UpdatedAt); ts != "" {
+		fmt.Fprintf(&b, "\n%s%s", labels.updatedAt+labels.kvSep, ts)
+	}
+	return b.String()
+}
+
+type docsLabels struct {
+	sharedBanner              string // "%s 分享了文档"
+	sharedBannerAnon          string
+	commentedBanner           string
+	commentedBannerAnon       string
+	accessRequestedBanner     string
+	accessRequestedBannerAnon string
+	title                     string
+	actor                     string
+	updatedAt                 string
+	kvSep                     string
+	sourceLabel               string // ResourceCard.Source.Label — "文档" / "Docs"
+}
+
+func docsLabelsFor(lang string) docsLabels {
+	if strings.EqualFold(lang, "zh-CN") || strings.HasPrefix(strings.ToLower(lang), "zh") {
+		return docsLabels{
+			sharedBanner:              "%s 分享了文档",
+			sharedBannerAnon:          "有人分享了文档",
+			commentedBanner:           "%s 评论了文档",
+			commentedBannerAnon:       "有新评论",
+			accessRequestedBanner:     "%s 请求访问文档",
+			accessRequestedBannerAnon: "有人请求访问文档",
+			title:                     "文档",
+			actor:                     "操作人",
+			updatedAt:                 "时间",
+			kvSep:                     "：",
+			sourceLabel:               "文档",
+		}
+	}
+	return docsLabels{
+		sharedBanner:              "%s shared a document",
+		sharedBannerAnon:          "A document was shared with you",
+		commentedBanner:           "%s commented on a document",
+		commentedBannerAnon:       "A new comment on a document",
+		accessRequestedBanner:     "%s requested access to a document",
+		accessRequestedBannerAnon: "Someone requested access to a document",
+		title:                     "Document",
+		actor:                     "By",
+		updatedAt:                 "At",
+		kvSep:                     ": ",
+		sourceLabel:               "Docs",
+	}
 }
 
 func summaryLabelsFor(lang string) summaryLabels {
@@ -264,6 +512,7 @@ func summaryLabelsFor(lang string) summaryLabels {
 			kvSep:             "：",
 			completedHeadline: "你的总结「%s」已生成完成。",
 			failedHeadline:    "你的总结「%s」生成失败。",
+			sourceLabel:       "智能总结",
 		}
 	}
 	return summaryLabels{
@@ -279,5 +528,6 @@ func summaryLabelsFor(lang string) summaryLabels {
 		kvSep:             ": ",
 		completedHeadline: "Your summary \"%s\" is ready.",
 		failedHeadline:    "Your summary \"%s\" failed to generate.",
+		sourceLabel:       "Smart Summary",
 	}
 }

--- a/modules/notify/card.go
+++ b/modules/notify/card.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"unicode"
 
 	"github.com/Mininglamp-OSS/octo-lib/common"
 	"github.com/Mininglamp-OSS/octo-lib/config"
@@ -209,21 +210,37 @@ func (n *Notify) sendSummaryText(uid, spaceID, text string) error {
 	))
 }
 
+// sanitizeLine collapses any control character (newline, CR, tab, …) in a
+// caller-supplied string to a single space and trims the result. The plain-text
+// fallback DM is line-structured, so an embedded "\n" in a caller field (title,
+// excerpt, actor name) could otherwise inject a spoofed attribution/label line.
+// Card rendering has its own defence (escapeMarkdown); this is the text-path
+// equivalent. It is a strict superset of strings.TrimSpace for our inputs.
+func sanitizeLine(s string) string {
+	return strings.TrimSpace(strings.Map(func(r rune) rune {
+		if unicode.IsControl(r) {
+			return ' '
+		}
+		return r
+	}, s))
+}
+
 // buildSummaryFallbackText composes the plain-text DM used when a card cannot be
 // built. It mirrors the fields the card would carry so no information is lost.
+// Caller fields are sanitizeLine'd so a newline can't inject a spoofed line.
 func buildSummaryFallbackText(card *SummaryCardFields, lang string) string {
 	labels := summaryLabelsFor(lang)
 	var b strings.Builder
-	title := strings.TrimSpace(card.Title)
+	title := sanitizeLine(card.Title)
 	if card.Kind == SummaryCardKindFailed {
 		fmt.Fprintf(&b, labels.failedHeadline, title)
-		if reason := strings.TrimSpace(card.Reason); reason != "" {
+		if reason := sanitizeLine(card.Reason); reason != "" {
 			fmt.Fprintf(&b, "\n%s%s", labels.failedPrefix, reason)
 		}
 		return b.String()
 	}
 	fmt.Fprintf(&b, labels.completedHeadline, title)
-	if tr := strings.TrimSpace(card.TimeRange); tr != "" {
+	if tr := sanitizeLine(card.TimeRange); tr != "" {
 		fmt.Fprintf(&b, "\n%s%s", labels.timeRange+labels.kvSep, tr)
 	}
 	if card.Members > 0 {
@@ -232,7 +249,7 @@ func buildSummaryFallbackText(card *SummaryCardFields, lang string) string {
 	if card.MsgCount > 0 {
 		fmt.Fprintf(&b, "\n%s"+labels.msgCountValue, labels.msgCount+labels.kvSep, card.MsgCount)
 	}
-	if gen := strings.TrimSpace(card.GeneratedAt); gen != "" {
+	if gen := sanitizeLine(card.GeneratedAt); gen != "" {
 		fmt.Fprintf(&b, "\n%s%s", labels.generatedAt+labels.kvSep, gen)
 	}
 	return b.String()
@@ -437,16 +454,18 @@ func docsAttributionAndVariant(kind, actorName string, labels docsLabels) (strin
 // appear on the card is emitted as a text line.
 func buildDocsFallbackText(card *DocsCardFields, lang string) string {
 	labels := docsLabelsFor(lang)
-	attribution, _ := docsAttributionAndVariant(card.Kind, card.ActorName, labels)
+	// sanitizeLine the actor before it flows into the attribution line, and each
+	// other caller field, so an embedded newline can't inject a spoofed line.
+	attribution, _ := docsAttributionAndVariant(card.Kind, sanitizeLine(card.ActorName), labels)
 	var b strings.Builder
 	b.WriteString(attribution)
-	if title := strings.TrimSpace(card.Title); title != "" {
+	if title := sanitizeLine(card.Title); title != "" {
 		fmt.Fprintf(&b, "\n%s%s", labels.title+labels.kvSep, title)
 	}
-	if excerpt := strings.TrimSpace(card.Excerpt); excerpt != "" {
+	if excerpt := sanitizeLine(card.Excerpt); excerpt != "" {
 		fmt.Fprintf(&b, "\n%s", excerpt)
 	}
-	if ts := strings.TrimSpace(card.UpdatedAt); ts != "" {
+	if ts := sanitizeLine(card.UpdatedAt); ts != "" {
 		fmt.Fprintf(&b, "\n%s%s", labels.updatedAt+labels.kvSep, ts)
 	}
 	return b.String()

--- a/modules/notify/card_test.go
+++ b/modules/notify/card_test.go
@@ -192,6 +192,158 @@ func TestIntegration_NotifyRejectsPayloadAndCardTogether(t *testing.T) {
 	}
 }
 
+// validDocsCard returns a minimal well-formed docs card request field set.
+func validDocsCard() *DocsCardFields {
+	return &DocsCardFields{
+		DocID:     "doc_abcd",
+		Kind:      DocsCardKindShared,
+		Title:     "产品设计方案",
+		ActorName: "Alice",
+		Excerpt:   "Q3 上线计划已确认",
+		UpdatedAt: "2026-07-13 15:04",
+	}
+}
+
+func TestDeliverDocsCardNotification_ValidationRejectsBadFields(t *testing.T) {
+	n := &Notify{} // validation short-circuits before any DB/cache access
+
+	cases := map[string]NotifyReq{
+		"missing docs card": {SpaceID: "s", Targets: []string{"u"}},
+		"missing space":     {Targets: []string{"u"}, DocsCard: validDocsCard()},
+		"empty targets":     {SpaceID: "s", Targets: nil, DocsCard: validDocsCard()},
+		"missing doc_id":    {SpaceID: "s", Targets: []string{"u"}, DocsCard: &DocsCardFields{Kind: DocsCardKindShared, Title: "t"}},
+		"missing title":     {SpaceID: "s", Targets: []string{"u"}, DocsCard: &DocsCardFields{DocID: "d", Kind: DocsCardKindShared}},
+		"unknown kind":      {SpaceID: "s", Targets: []string{"u"}, DocsCard: &DocsCardFields{DocID: "d", Kind: "weird", Title: "t"}},
+	}
+	for name, req := range cases {
+		t.Run(name, func(t *testing.T) {
+			r := req
+			_, err := n.deliverDocsCardNotification(&r)
+			require.ErrorIs(t, err, errNotifyCardInvalid)
+		})
+	}
+}
+
+func TestBuildDocsCard_ProducesValidOctoV1(t *testing.T) {
+	wk := newWuKongServer()
+	defer wk.close()
+	ctx := newTestContext(t, wk)
+	ctx.GetConfig().External.WebLoginURL = "https://im.example.com/login"
+	n := newTestNotify(ctx, nil, nil, nil, "tk")
+
+	for _, kind := range []string{DocsCardKindShared, DocsCardKindCommented, DocsCardKindAccessRequested} {
+		t.Run(kind, func(t *testing.T) {
+			card := validDocsCard()
+			card.Kind = kind
+			doc, err := n.buildDocsCard(context.Background(), "spc_1", card, "zh-CN")
+			require.NoError(t, err)
+
+			var cardObj map[string]interface{}
+			require.NoError(t, json.Unmarshal(doc, &cardObj))
+			envelope := map[string]interface{}{
+				"type":         cardmsg.InteractiveCard.Int(),
+				"card_version": cardmsg.CardVersion,
+				"profile":      cardmsg.ProfileV1,
+				"card":         cardObj,
+			}
+			require.NoError(t, cardmsg.Validate(envelope), "docs template output must pass octo/v1 Validate")
+			// Deep link built from WebLoginURL origin only, /d/{doc_id}?sp={space}.
+			assert.Contains(t, string(doc), "https://im.example.com/d/doc_abcd?sp=spc_1")
+			assert.NotContains(t, string(doc), "/login")
+			// Variant identifier is embedded in metadata.octo.variant.
+			metadata, _ := cardObj["metadata"].(map[string]interface{})
+			octo, _ := metadata["octo"].(map[string]interface{})
+			assert.Equal(t, "docs."+kind, octo["variant"], "variant identifier reserved namespace")
+			assert.Contains(t, metadata["webUrl"], "/d/doc_abcd")
+		})
+	}
+}
+
+func TestBuildDocsCard_AttributionFallsBackWithoutActor(t *testing.T) {
+	wk := newWuKongServer()
+	defer wk.close()
+	ctx := newTestContext(t, wk)
+	ctx.GetConfig().External.WebLoginURL = "https://im.example.com/login"
+	n := newTestNotify(ctx, nil, nil, nil, "tk")
+
+	card := validDocsCard()
+	card.ActorName = ""
+	doc, err := n.buildDocsCard(context.Background(), "spc_1", card, "zh-CN")
+	require.NoError(t, err)
+	assert.Contains(t, string(doc), "有人分享了文档", "anonymous attribution must be used when actor is unknown")
+	assert.NotContains(t, string(doc), " 分享了文档", "no leading-space placeholder for missing actor")
+}
+
+func TestBuildDocsCard_RejectsNonHTTPSDeepLinkOrigin(t *testing.T) {
+	wk := newWuKongServer()
+	defer wk.close()
+	ctx := newTestContext(t, wk)
+	ctx.GetConfig().External.WebLoginURL = "http://im.example.com" // not https
+	n := newTestNotify(ctx, nil, nil, nil, "tk")
+
+	_, err := n.buildDocsCard(context.Background(), "spc_1", validDocsCard(), "zh-CN")
+	require.Error(t, err, "a non-https origin must fail docs card build so the caller degrades to text")
+}
+
+func TestBuildDocsFallbackText(t *testing.T) {
+	text := buildDocsFallbackText(validDocsCard(), "zh-CN")
+	assert.Contains(t, text, "Alice 分享了文档")
+	assert.Contains(t, text, "文档：产品设计方案")
+	assert.Contains(t, text, "Q3 上线计划已确认")
+	assert.Contains(t, text, "时间：2026-07-13 15:04")
+}
+
+// Text fallback path when the docs card sender is unavailable: still delivers,
+// never silently dropped. Mirrors the summary DegradesToText test.
+func TestDeliverDocsCardNotification_DegradesToTextWhenSenderUnavailable(t *testing.T) {
+	wk := newWuKongServer()
+	defer wk.close()
+	ctx := newTestContext(t, wk)
+	n := newTestNotify(ctx, nil, nil, nil, "tk")
+	n.docsSender = nil // no producer bound → cannot build a card
+	n.botOK.Store(true)
+	primeMemberCache(n, "spc_1", "uid_a")
+
+	resp, err := n.deliverDocsCardNotification(&NotifyReq{
+		SpaceID: "spc_1", Service: "docs-service", Targets: []string{"uid_a"}, DocsCard: validDocsCard(),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"uid_a"}, resp.Delivered)
+	assert.Empty(t, resp.Filtered)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&wk.messageCount), "exactly one text DM should be sent")
+}
+
+// The single-endpoint mutex also covers DocsCard combined with either Payload
+// or the summary Card field.
+func TestIntegration_NotifyMutexRejectsDocsCardCombinations(t *testing.T) {
+	wk := newWuKongServer()
+	defer wk.close()
+	ctx := newTestContext(t, wk)
+	db, _, closeDB := newMockedDBSession(t)
+	defer closeDB()
+
+	n := newTestNotify(ctx, db, newStubUserService(), &stubAppService{}, "tk")
+	r := buildRouter(n)
+	r.SetErrorRenderer(i18n.NewErrorRenderer(i18n.NewLocalizer(i18n.DefaultLanguage)))
+	h := http.Header{}
+	h.Set(InternalTokenHeader, "tk")
+
+	cases := map[string]NotifyReq{
+		"payload + docs card": {SpaceID: "spc_1", Service: "svc", Targets: []string{"uid_a"},
+			Payload: map[string]interface{}{"type": 1, "content": "ok"}, DocsCard: validDocsCard()},
+		"summary card + docs card": {SpaceID: "spc_1", Service: "svc", Targets: []string{"uid_a"},
+			Card: validCard(), DocsCard: validDocsCard()},
+	}
+	for name, req := range cases {
+		t.Run(name, func(t *testing.T) {
+			w := doJSONRequest(t, r, http.MethodPost, "/v1/internal/notify", h, req)
+			assert.Equal(t, http.StatusBadRequest, w.Code)
+			assert.Contains(t, w.Body.String(), "err.server.notify.card_invalid")
+			assert.Zero(t, atomic.LoadInt32(&wk.messageCount))
+		})
+	}
+}
+
 func TestIntegration_NotifyBatchRejectsCardField(t *testing.T) {
 	wk := newWuKongServer()
 	defer wk.close()
@@ -205,11 +357,24 @@ func TestIntegration_NotifyBatchRejectsCardField(t *testing.T) {
 	h := http.Header{}
 	h.Set(InternalTokenHeader, "tk")
 
-	w := doJSONRequest(t, r, http.MethodPost, "/v1/internal/notify/batch", h, BatchNotifyReq{Notifications: []NotifyReq{
-		{SpaceID: "spc_1", Service: "summary-service", Targets: []string{"uid_a"}, Payload: map[string]interface{}{"type": 1, "content": "ok"}},
-		{SpaceID: "spc_1", Service: "summary-service", Targets: []string{"uid_b"}, Card: validCard()},
-	}})
-	assert.Equal(t, http.StatusBadRequest, w.Code)
-	assert.Contains(t, w.Body.String(), "err.server.notify.card_invalid")
-	assert.Zero(t, atomic.LoadInt32(&wk.messageCount))
+	// Both the summary Card and the docs DocsCard fields are single-endpoint
+	// only; either one in a batch entry short-circuits the whole batch.
+	cases := map[string][]NotifyReq{
+		"summary card in batch": {
+			{SpaceID: "spc_1", Service: "summary-service", Targets: []string{"uid_a"}, Payload: map[string]interface{}{"type": 1, "content": "ok"}},
+			{SpaceID: "spc_1", Service: "summary-service", Targets: []string{"uid_b"}, Card: validCard()},
+		},
+		"docs card in batch": {
+			{SpaceID: "spc_1", Service: "docs-service", Targets: []string{"uid_a"}, Payload: map[string]interface{}{"type": 1, "content": "ok"}},
+			{SpaceID: "spc_1", Service: "docs-service", Targets: []string{"uid_b"}, DocsCard: validDocsCard()},
+		},
+	}
+	for name, entries := range cases {
+		t.Run(name, func(t *testing.T) {
+			w := doJSONRequest(t, r, http.MethodPost, "/v1/internal/notify/batch", h, BatchNotifyReq{Notifications: entries})
+			assert.Equal(t, http.StatusBadRequest, w.Code)
+			assert.Contains(t, w.Body.String(), "err.server.notify.card_invalid")
+			assert.Zero(t, atomic.LoadInt32(&wk.messageCount))
+		})
+	}
 }

--- a/modules/notify/card_test.go
+++ b/modules/notify/card_test.go
@@ -162,6 +162,33 @@ func TestDeliverCardNotification_DegradesToTextWhenSenderUnavailable(t *testing.
 	assert.Equal(t, int32(1), atomic.LoadInt32(&wk.messageCount), "exactly one text DM should be sent")
 }
 
+// A non-member target must be excluded from delivery and reported in Filtered,
+// never delivered — this locks the member-verify pre-filter. A regression that
+// dropped it would otherwise pass every other card-path unit test (they only
+// seed the delivered member). carddispatch re-verifies membership independently
+// (Decision 3), but the pre-filter is the first gate and worth pinning. Uses
+// the text-fallback path (nil sender) so no carddispatch mock is needed; the
+// assertion is that the stranger reaches neither Delivered nor transport.
+func TestDeliverCardNotification_NonMemberExcluded(t *testing.T) {
+	wk := newWuKongServer()
+	defer wk.close()
+	ctx := newTestContext(t, wk)
+	n := newTestNotify(ctx, nil, nil, nil, "tk")
+	n.cardSender = nil
+	n.botOK.Store(true)
+	primeMemberCache(n, "spc_1", "uid_member") // uid_stranger is NOT a member
+
+	resp, err := n.deliverCardNotification(&NotifyReq{
+		SpaceID: "spc_1", Service: "summary-service",
+		Targets: []string{"uid_member", "uid_stranger"}, Card: validCard(),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"uid_member"}, resp.Delivered)
+	assert.Equal(t, "not_space_member", resp.Filtered["uid_stranger"])
+	assert.NotContains(t, resp.Delivered, "uid_stranger")
+	assert.Equal(t, int32(1), atomic.LoadInt32(&wk.messageCount), "only the member gets a DM")
+}
+
 // payload and card are mutually exclusive on the single endpoint (contract).
 func TestIntegration_NotifyRejectsPayloadAndCardTogether(t *testing.T) {
 	wk := newWuKongServer()
@@ -311,6 +338,38 @@ func TestDeliverDocsCardNotification_DegradesToTextWhenSenderUnavailable(t *test
 	assert.Equal(t, []string{"uid_a"}, resp.Delivered)
 	assert.Empty(t, resp.Filtered)
 	assert.Equal(t, int32(1), atomic.LoadInt32(&wk.messageCount), "exactly one text DM should be sent")
+}
+
+// Docs path: same non-member pre-filter guarantee as the summary path above.
+func TestDeliverDocsCardNotification_NonMemberExcluded(t *testing.T) {
+	wk := newWuKongServer()
+	defer wk.close()
+	ctx := newTestContext(t, wk)
+	n := newTestNotify(ctx, nil, nil, nil, "tk")
+	n.docsSender = nil
+	n.botOK.Store(true)
+	primeMemberCache(n, "spc_1", "uid_member") // uid_stranger is NOT a member
+
+	resp, err := n.deliverDocsCardNotification(&NotifyReq{
+		SpaceID: "spc_1", Service: "docs-service",
+		Targets: []string{"uid_member", "uid_stranger"}, DocsCard: validDocsCard(),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"uid_member"}, resp.Delivered)
+	assert.Equal(t, "not_space_member", resp.Filtered["uid_stranger"])
+	assert.NotContains(t, resp.Delivered, "uid_stranger")
+	assert.Equal(t, int32(1), atomic.LoadInt32(&wk.messageCount), "only the member gets a DM")
+}
+
+// A newline embedded in a caller field must not inject a spoofed line into the
+// plain-text fallback DM: sanitizeLine collapses control chars to spaces.
+func TestBuildDocsFallbackText_StripsNewlineInjection(t *testing.T) {
+	card := validDocsCard()
+	card.ActorName = "Alice\n系统管理员"
+	card.Title = "标题\n伪造：越权提示"
+	text := buildDocsFallbackText(card, "zh-CN")
+	assert.NotContains(t, text, "\n伪造", "an embedded title newline must not start a new line")
+	assert.Contains(t, text, "Alice 系统管理员 分享了文档", "actor newline collapses to a space in the attribution")
 }
 
 // The single-endpoint mutex also covers DocsCard combined with either Payload

--- a/modules/notify/model.go
+++ b/modules/notify/model.go
@@ -2,11 +2,13 @@ package notify
 
 // NotifyReq 通知请求
 //
-// Payload 与 Card 二选一:
-//   - 文本通知(现状):填 Payload{type:1,content:...},Card 省略。
-//   - 卡片通知(summary-notify pilot):填结构化 Card,Payload 省略。服务端用
-//     pkg/cardtmpl 生成 octo/v1 卡片,经 internal/carddispatch 派发。调用方永不
-//     构造 type-17 map(Decision 14 仍拒绝 payload 里的 card 形状)。
+// Payload / Card / DocsCard 三选一:
+//   - 文本通知(现状):填 Payload{type:1,content:...},另两者省略。
+//   - 智能总结卡片(summary-notify pilot):填结构化 Card,另两者省略。服务端用
+//     pkg/cardtmpl 生成 octo/v1 卡片,经 internal/carddispatch 派发。
+//   - 文档通知卡片(docs-notify):填结构化 DocsCard,另两者省略。
+//
+// 调用方永不构造 type-17 map(Decision 14 仍拒绝 payload 里的 card 形状)。
 type NotifyReq struct {
 	SpaceID  string                 `json:"space_id" binding:"required"`
 	Service  string                 `json:"service" binding:"required"`
@@ -15,6 +17,7 @@ type NotifyReq struct {
 	ActorUID string                 `json:"actor_uid"`
 	Payload  map[string]interface{} `json:"payload"`
 	Card     *SummaryCardFields     `json:"card"`
+	DocsCard *DocsCardFields        `json:"docs_card"`
 }
 
 // SummaryCardFields 是 summary-notify 卡片通知的结构化入参(跨仓契约,见
@@ -36,6 +39,29 @@ type SummaryCardFields struct {
 const (
 	SummaryCardKindCompleted = "completed"
 	SummaryCardKindFailed    = "failed"
+)
+
+// DocsCardFields is the docs-notify structured card input (cross-repo contract,
+// see .octospec/tasks/card-message-internal-dispatch/docs-notify-contract.md).
+// Fields carry raw values only; attribution/label copy, layout, and the
+// /d/{doc_id}?sp={space_id} deep-link are owned by the server (pkg/cardtmpl +
+// modules/notify.buildDocsCard + i18n.OutboundLanguage). The docs backend
+// pre-formats display strings it wants surfaced verbatim (ActorName, UpdatedAt)
+// so octo-server does not resolve secondary identities on the card path.
+type DocsCardFields struct {
+	DocID     string `json:"doc_id"`     // maps to /d/{doc_id}?sp={space_id}
+	Kind      string `json:"kind"`       // "shared" | "commented" | "access_requested"
+	Title     string `json:"title"`      // document title
+	ActorName string `json:"actor_name"` // pre-resolved actor display name; empty allowed
+	Excerpt   string `json:"excerpt"`    // optional preview / comment / access reason
+	UpdatedAt string `json:"updated_at"` // pre-formatted timestamp; empty allowed
+}
+
+// Docs card notification kinds.
+const (
+	DocsCardKindShared           = "shared"
+	DocsCardKindCommented        = "commented"
+	DocsCardKindAccessRequested  = "access_requested"
 )
 
 // BatchNotifyReq 批量通知请求

--- a/modules/notify/model.go
+++ b/modules/notify/model.go
@@ -59,9 +59,9 @@ type DocsCardFields struct {
 
 // Docs card notification kinds.
 const (
-	DocsCardKindShared           = "shared"
-	DocsCardKindCommented        = "commented"
-	DocsCardKindAccessRequested  = "access_requested"
+	DocsCardKindShared          = "shared"
+	DocsCardKindCommented       = "commented"
+	DocsCardKindAccessRequested = "access_requested"
 )
 
 // BatchNotifyReq 批量通知请求

--- a/pilote2e/docs_card_wukongim_test.go
+++ b/pilote2e/docs_card_wukongim_test.go
@@ -1,0 +1,270 @@
+//go:build pilote2e
+
+// Docs-notify E2E: end-to-end proof that a POST to the real
+// /v1/internal/notify handler with a structured DocsCard field results in a
+// type-17 card persisted in WuKongIM under the /d/{doc_id}?sp={space_id}
+// deep link, delivered by the shared notification bot. Mirrors
+// summary_card_wukongim_test.go — same integration stack requirements
+// (MySQL 127.0.0.1:3306 root/demo/test, Redis 127.0.0.1:6379,
+// WuKongIM 127.0.0.1:5001) and the same build tag:
+//
+//	go test -tags pilote2e ./pilote2e/ -run TestDocsNotify -v
+package pilote2e
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	liblog "github.com/Mininglamp-OSS/octo-lib/pkg/log"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	"github.com/Mininglamp-OSS/octo-server/internal/carddispatch"
+	"github.com/Mininglamp-OSS/octo-server/modules/botidentity"
+	"github.com/Mininglamp-OSS/octo-server/modules/notify"
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardmsg"
+	octoi18n "github.com/Mininglamp-OSS/octo-server/pkg/i18n"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const e2eDocsProducer = carddispatch.ProducerID("docs-notify")
+
+// postUntilDelivered posts JSON to the notify endpoint until BOTH conditions
+// hold: (1) HTTP 200 (past the async notification-bot readiness window), and
+// (2) `expectedUID` is in the `delivered` list. This tolerates a transient
+// window where the second `notify` instance's memberCache hasn't yet caught up
+// with a freshly-seeded space_member row — a real class of test setup race
+// the smart-summary / docs-backend callers already handle by retrying filtered
+// recipients, so the E2E test mirrors that behaviour.
+func postUntilDelivered(
+	t *testing.T,
+	r wkhttpRouter,
+	path, token string,
+	body []byte,
+	expectedUID string,
+) (delivered []string, lastCode int, lastBody string) {
+	t.Helper()
+	for attempt := 0; attempt < 40; attempt++ {
+		req, _ := http.NewRequest(http.MethodPost, path, bytes.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set(notify.InternalTokenHeader, token)
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+		lastCode, lastBody = w.Code, w.Body.String()
+		if w.Code == http.StatusOK {
+			var resp struct {
+				Delivered []string          `json:"delivered"`
+				Filtered  map[string]string `json:"filtered"`
+			}
+			if json.Unmarshal(w.Body.Bytes(), &resp) == nil {
+				delivered = resp.Delivered
+				for _, uid := range delivered {
+					if uid == expectedUID {
+						return
+					}
+				}
+			}
+		}
+		time.Sleep(250 * time.Millisecond)
+	}
+	return
+}
+
+// wkhttpRouter is the minimal ServeHTTP surface both wkhttp.WKHttp and
+// http.Handler satisfy; keeping it here so postUntilDelivered doesn't leak
+// wkhttp into every test's import.
+type wkhttpRouter interface {
+	ServeHTTP(http.ResponseWriter, *http.Request)
+}
+
+// TestDocsNotify_HTTPEndpointDeliversCardToWuKongIM POSTs the cross-repo docs
+// contract body to the real POST /v1/internal/notify handler, has
+// modules/notify build the docs card server-side, and confirms the type-17
+// card persisted in WuKongIM carries the docs-flavoured deep link
+// (/d/{doc_id}?sp={space}) and the reserved metadata.octo.variant identifier.
+func TestDocsNotify_HTTPEndpointDeliversCardToWuKongIM(t *testing.T) {
+	t.Setenv(cardmsg.EnvEnabled, "true")
+	t.Setenv("OCTO_MASTER_KEY", "0123456789abcdef0123456789abcdef")
+	t.Setenv("OCTO_USER_API_KEY_SECRET", "0123456789abcdef0123456789abcdef")
+	t.Setenv("NOTIFY_INTERNAL_TOKEN", "pilote2e-docs-token")
+
+	recipient := fmt.Sprintf("uid_pilote2e_docs_%d", time.Now().UnixNano())
+
+	_, ctx := testutil.NewTestServer()
+	defer testutil.CleanAllTables(ctx)
+	ctx.GetConfig().External.WebLoginURL = "https://im.example.com/login"
+
+	seedSpace(t, ctx)
+	seedSpaceMember(t, ctx, recipient)
+
+	// Install BOTH production producers (mirrors main.cardDispatchProducerSpecs)
+	// so notify.New picks up the docs-notify Sender via SenderFromContext.
+	deps := carddispatch.Dependencies{
+		IdentityResolver: botidentity.New(ctx),
+		Authorizer:       carddispatch.NewDBAuthorizer(ctx.DB()),
+		Transport:        ctx,
+		Metrics:          carddispatch.NewMetrics(prometheus.NewRegistry()),
+		Logger:           liblog.NewTLog("pilote2e-docs"),
+	}
+	baseSpec := carddispatch.ProducerSpec{
+		Enabled:             true,
+		SenderUID:           e2eNotifyBotID,
+		AllowedChannelTypes: []uint8{common.ChannelTypePerson.Uint8()},
+		AllowedProfiles:     []string{cardmsg.ProfileV1},
+		SpacePolicy:         carddispatch.SpacePolicySystemNotification,
+		GroupPolicy:         carddispatch.GroupPolicyMemberRequired,
+		MaxInFlight:         20,
+	}
+	summarySpec := baseSpec
+	summarySpec.ID = e2eProducer
+	docsSpec := baseSpec
+	docsSpec.ID = e2eDocsProducer
+	registry := carddispatch.NewRegistry(deps, []carddispatch.ProducerSpec{summarySpec, docsSpec})
+	require.NoError(t, carddispatch.Install(ctx, registry))
+
+	n := notify.New(ctx)
+	r := wkhttp.New()
+	n.Route(r)
+	r.SetErrorRenderer(octoi18n.NewErrorRenderer(octoi18n.NewLocalizer(octoi18n.DefaultLanguage)))
+
+	reqBody := notify.NotifyReq{
+		SpaceID: e2eSpaceID,
+		Service: "docs-service",
+		Targets: []string{recipient},
+		DocsCard: &notify.DocsCardFields{
+			DocID:     "d_pilote2e_http",
+			Kind:      notify.DocsCardKindShared,
+			Title:     "产品设计方案",
+			ActorName: "Alice",
+			Excerpt:   "Q3 上线计划已确认",
+			UpdatedAt: "2026-07-13 15:04",
+		},
+	}
+	body, _ := json.Marshal(reqBody)
+
+	delivered, lastCode, lastBody := postUntilDelivered(t, r, "/v1/internal/notify", "pilote2e-docs-token", body, recipient)
+	require.Equal(t, http.StatusOK, lastCode, "docs card POST must succeed (last body: %s)", truncate(lastBody))
+	require.Equal(t, []string{recipient}, delivered, "the recipient must receive the docs card")
+
+	msg := readBackType17(t, ctx.GetConfig().WuKongIM.APIURL, recipient, 0)
+	require.NotNil(t, msg, "a type-17 docs card must be readable from WuKongIM channel log")
+	assert.EqualValues(t, cardmsg.InteractiveCard.Int(), intOf(msg["type"]))
+	assert.Equal(t, cardmsg.ProfileV1, msg["profile"])
+	assert.Equal(t, e2eSpaceID, msg["space_id"], "server-authored space_id on the wire")
+	assert.Equal(t, e2eNotifyBotID, msg["__from_uid"], "delivered by the bound notification bot (shared identity, capability isolated by producer)")
+
+	payloadJSON := compactJSON(msg)
+	// Deep-link points at octo-web /d/:docId (already live) — not /s/:taskId.
+	assert.Contains(t, payloadJSON, "https://im.example.com/d/d_pilote2e_http?sp="+e2eSpaceID,
+		"docs deep-link must be /d/{doc_id}?sp={space} — that's the whole reason for a separate producer")
+	// Reserved namespace variant identifier so renderers can style docs cards
+	// distinctly from summary cards later without re-parsing content.
+	assert.Contains(t, payloadJSON, `"variant":"docs.shared"`,
+		"metadata.octo.variant must carry the reserved docs.shared identifier")
+	t.Logf("docs-notify HTTP-path persisted card: message_id=%d message_seq=%d from_uid=%v",
+		intOf(msg["__message_id"]), intOf(msg["__message_seq"]), msg["__from_uid"])
+}
+
+// TestSummaryAndDocsNotify_NoRegression re-runs both producers back-to-back in
+// one server lifecycle, proving the two shared-notification-bot paths don't
+// interfere and that adding docs-notify hasn't changed summary behaviour.
+func TestSummaryAndDocsNotify_NoRegression(t *testing.T) {
+	t.Setenv(cardmsg.EnvEnabled, "true")
+	t.Setenv("OCTO_MASTER_KEY", "0123456789abcdef0123456789abcdef")
+	t.Setenv("OCTO_USER_API_KEY_SECRET", "0123456789abcdef0123456789abcdef")
+	t.Setenv("NOTIFY_INTERNAL_TOKEN", "pilote2e-both-token")
+
+	recipient := fmt.Sprintf("uid_pilote2e_both_%d", time.Now().UnixNano())
+
+	_, ctx := testutil.NewTestServer()
+	defer testutil.CleanAllTables(ctx)
+	ctx.GetConfig().External.WebLoginURL = "https://im.example.com/login"
+
+	seedSpace(t, ctx)
+	seedSpaceMember(t, ctx, recipient)
+
+	deps := carddispatch.Dependencies{
+		IdentityResolver: botidentity.New(ctx),
+		Authorizer:       carddispatch.NewDBAuthorizer(ctx.DB()),
+		Transport:        ctx,
+		Metrics:          carddispatch.NewMetrics(prometheus.NewRegistry()),
+		Logger:           liblog.NewTLog("pilote2e-both"),
+	}
+	baseSpec := carddispatch.ProducerSpec{
+		Enabled:             true,
+		SenderUID:           e2eNotifyBotID,
+		AllowedChannelTypes: []uint8{common.ChannelTypePerson.Uint8()},
+		AllowedProfiles:     []string{cardmsg.ProfileV1},
+		SpacePolicy:         carddispatch.SpacePolicySystemNotification,
+		GroupPolicy:         carddispatch.GroupPolicyMemberRequired,
+		MaxInFlight:         20,
+	}
+	summarySpec := baseSpec
+	summarySpec.ID = e2eProducer
+	docsSpec := baseSpec
+	docsSpec.ID = e2eDocsProducer
+	require.NoError(t, carddispatch.Install(ctx, carddispatch.NewRegistry(deps, []carddispatch.ProducerSpec{summarySpec, docsSpec})))
+
+	n := notify.New(ctx)
+	r := wkhttp.New()
+	n.Route(r)
+	r.SetErrorRenderer(octoi18n.NewErrorRenderer(octoi18n.NewLocalizer(octoi18n.DefaultLanguage)))
+
+	postJSON := func(t *testing.T, body []byte, expected string) {
+		t.Helper()
+		delivered, lastCode, lastBody := postUntilDelivered(t, r, "/v1/internal/notify", "pilote2e-both-token", body, expected)
+		require.Equal(t, http.StatusOK, lastCode, "notify POST must succeed (last body: %s)", truncate(lastBody))
+		require.Contains(t, delivered, expected, "recipient must be delivered")
+	}
+
+	summaryBody, _ := json.Marshal(notify.NotifyReq{
+		SpaceID: e2eSpaceID, Service: "summary-service", Targets: []string{recipient},
+		Card: &notify.SummaryCardFields{
+			TaskNo: "TN_regression_1", Kind: notify.SummaryCardKindCompleted, Title: "周会纪要",
+			TimeRange: "2026-07-06 10:00 ~ 2026-07-13 10:00", Members: 3, MsgCount: 42,
+		},
+	})
+	docsBody, _ := json.Marshal(notify.NotifyReq{
+		SpaceID: e2eSpaceID, Service: "docs-service", Targets: []string{recipient},
+		DocsCard: &notify.DocsCardFields{
+			DocID: "d_regression_1", Kind: notify.DocsCardKindShared, Title: "设计稿",
+			ActorName: "Bob", Excerpt: "review please",
+		},
+	})
+	postJSON(t, summaryBody, recipient)
+	postJSON(t, docsBody, recipient)
+
+	// Both cards must be readable back from WuKongIM under the recipient's
+	// notification-bot DM channel. Read all persisted type-17s and assert both
+	// deep-link shapes appear.
+	var sawSummary, sawDocs bool
+	for attempt := 0; attempt < 20 && !(sawSummary && sawDocs); attempt++ {
+		msgs := channelMessageSync(t, ctx.GetConfig().WuKongIM.APIURL, recipient, e2eNotifyBotID)
+		for _, m := range msgs {
+			payload := decodePayload(m)
+			if payload == nil || intOf(payload["type"]) != int64(cardmsg.InteractiveCard.Int()) {
+				continue
+			}
+			pj := compactJSON(payload)
+			if bytes.Contains([]byte(pj), []byte("/s/TN_regression_1?sp="+e2eSpaceID)) {
+				sawSummary = true
+			}
+			if bytes.Contains([]byte(pj), []byte("/d/d_regression_1?sp="+e2eSpaceID)) {
+				sawDocs = true
+			}
+		}
+		if sawSummary && sawDocs {
+			break
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	assert.True(t, sawSummary, "summary card must persist under /s/ deep link (no regression)")
+	assert.True(t, sawDocs, "docs card must persist under /d/ deep link")
+}

--- a/pkg/cardtmpl/docs_test.go
+++ b/pkg/cardtmpl/docs_test.go
@@ -1,0 +1,124 @@
+package cardtmpl
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardmsg"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func exampleDocsResourceCard() ResourceCard {
+	return ResourceCard{
+		Title:       "Product roadmap 2026",
+		Attribution: "Alice shared a document",
+		Excerpt:     "Q3 launch plan is finalized.",
+		Variant:     "docs.shared",
+		Source:      Source{Label: "Docs"},
+	}
+}
+
+func TestBuildDocsResourceCardSnapshotAndValidation(t *testing.T) {
+	document, err := BuildDocsResourceCard(
+		localizedContext("en-US"),
+		"https://im.example.com/login?redirect=1",
+		"doc/42",
+		"space a",
+		exampleDocsResourceCard(),
+	)
+	require.NoError(t, err)
+
+	want := `{
+	  "type":"AdaptiveCard",
+	  "version":"1.5",
+	  "metadata":{
+	    "webUrl":"https://im.example.com/d/doc%2F42?sp=space+a",
+	    "octo":{
+	      "variant":"docs.shared",
+	      "source":{"label":"Docs"}
+	    }
+	  },
+	  "body":[
+	    {"type":"Container","items":[
+	      {"type":"TextBlock","text":"Product roadmap 2026","weight":"Bolder","wrap":true},
+	      {"type":"TextBlock","text":"Alice shared a document","isSubtle":true,"spacing":"None","wrap":true}
+	    ]},
+	    {"type":"TextBlock","text":"Q3 launch plan is finalized.","wrap":true},
+	    {"type":"ActionSet","actions":[
+	      {"type":"Action.OpenUrl","title":"View details","url":"https://im.example.com/d/doc%2F42?sp=space+a"}
+	    ]}
+	  ]
+	}`
+	assert.JSONEq(t, want, string(document))
+
+	envelope := map[string]interface{}{
+		"type":         cardmsg.InteractiveCard.Int(),
+		"card_version": cardmsg.CardVersion,
+		"profile":      cardmsg.ProfileV1,
+		"card":         mustDecodeCard(t, document),
+	}
+	require.NoError(t, cardmsg.Validate(envelope))
+}
+
+func TestBuildDocsResourceCardUsesOutboundLanguage(t *testing.T) {
+	document, err := BuildDocsResourceCard(
+		localizedContext("zh-CN"),
+		"https://im.example.com/login",
+		"doc-1",
+		"space-1",
+		exampleDocsResourceCard(),
+	)
+	require.NoError(t, err)
+	assert.Contains(t, string(document), `"title":"查看详情"`)
+}
+
+func TestBuildDocsResourceCardDeepLinkShape(t *testing.T) {
+	document, err := BuildDocsResourceCard(
+		localizedContext("en-US"),
+		"https://im.example.com/login?redirect=1",
+		"doc-abc",
+		"space-1",
+		exampleDocsResourceCard(),
+	)
+	require.NoError(t, err)
+
+	var card struct {
+		Body []map[string]interface{} `json:"body"`
+	}
+	require.NoError(t, json.Unmarshal(document, &card))
+	// ActionSet is the last body element; first action's url pins the /d/ shape.
+	require.NotEmpty(t, card.Body)
+	last := card.Body[len(card.Body)-1]
+	require.Equal(t, "ActionSet", last["type"])
+	actions, _ := last["actions"].([]interface{})
+	require.NotEmpty(t, actions)
+	first, _ := actions[0].(map[string]interface{})
+	require.NotNil(t, first)
+	assert.Equal(t, "Action.OpenUrl", first["type"])
+	assert.Equal(t, "https://im.example.com/d/doc-abc?sp=space-1", first["url"])
+}
+
+func TestBuildDocsResourceCardRejectsUnsafeInputs(t *testing.T) {
+	cases := []struct {
+		name       string
+		webBaseURL string
+		docID      string
+		spaceID    string
+		resource   ResourceCard
+	}{
+		{name: "non https web base", webBaseURL: "http://im.example.com/login", docID: "doc-1", spaceID: "space-1", resource: exampleDocsResourceCard()},
+		{name: "unsafe icon", webBaseURL: "https://im.example.com/login", docID: "doc-1", spaceID: "space-1", resource: func() ResourceCard { r := exampleDocsResourceCard(); r.IconURL = "javascript:alert(1)"; return r }()},
+		{name: "missing title", webBaseURL: "https://im.example.com/login", docID: "doc-1", spaceID: "space-1", resource: func() ResourceCard { r := exampleDocsResourceCard(); r.Title = ""; return r }()},
+		{name: "empty doc id", webBaseURL: "https://im.example.com/login", docID: "", spaceID: "space-1", resource: exampleDocsResourceCard()},
+		{name: "empty space id", webBaseURL: "https://im.example.com/login", docID: "doc-1", spaceID: "", resource: exampleDocsResourceCard()},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			document, err := BuildDocsResourceCard(localizedContext("en-US"), tc.webBaseURL, tc.docID, tc.spaceID, tc.resource)
+			assert.Nil(t, document)
+			assert.Error(t, err)
+		})
+	}
+}

--- a/pkg/cardtmpl/resource.go
+++ b/pkg/cardtmpl/resource.go
@@ -34,6 +34,28 @@ type ResourceCard struct {
 	Excerpt     string
 	Facts       []Fact
 	CopyText    string
+	// Variant is the stable, low-cardinality identifier the renderer / client
+	// can key off to style card families independently (e.g. "summary.completed",
+	// "summary.failed", "docs.shared", "docs.commented"). Emitted into
+	// `metadata.octo.variant` on the AdaptiveCard root; unknown values pass
+	// straight through — the renderer decides whether to specialise.
+	// See docs/summary-notify-card.md §2 for the reserved namespace.
+	Variant string
+	// Source names the originating capability so renderers can surface a
+	// "来自 XX" / "From XX" chip / badge (角标) next to the card. Both fields
+	// are optional and land in `metadata.octo.source`; the current template
+	// does NOT auto-render them into the card body — surfacing is a renderer
+	// decision (chip / prefix / silent), which lets the visual pilot stay
+	// unchanged while machine consumers already have the source signal.
+	Source Source
+}
+
+// Source describes the producer family that authored the card, for both
+// display badging and machine identification. Values are server-picked (never
+// user-supplied) and land in `metadata.octo.source`.
+type Source struct {
+	Label   string // human-readable source name, e.g. "智能总结" / "Smart Summary" / "文档" / "Docs"
+	IconURL string // absolute https icon URL, optional; renderers may use it for the chip
 }
 
 func BuildSummaryResourceCard(
@@ -46,6 +68,45 @@ func BuildSummaryResourceCard(
 	if strings.TrimSpace(taskID) == "" || strings.TrimSpace(spaceID) == "" {
 		return nil, errors.New("cardtmpl: task ID and space ID are required")
 	}
+	deepLink, err := summaryDeepLink(webLoginURL, taskID, spaceID)
+	if err != nil {
+		return nil, err
+	}
+	return buildResourceCard(ctx, deepLink, resource)
+}
+
+// BuildDocsResourceCard renders an octo/v1 ResourceCard for a docs-notify
+// notification (docs-backend automated flows: share/comment/access request).
+// The deep-link points at octo-web's /d/:docId standalone route (mirrors
+// summaryDeepLink); labels/attribution mapping stay in the producer module.
+func BuildDocsResourceCard(
+	ctx context.Context,
+	webLoginURL string,
+	docID string,
+	spaceID string,
+	resource ResourceCard,
+) (json.RawMessage, error) {
+	if strings.TrimSpace(docID) == "" || strings.TrimSpace(spaceID) == "" {
+		return nil, errors.New("cardtmpl: doc ID and space ID are required")
+	}
+	deepLink, err := docsDeepLink(webLoginURL, docID, spaceID)
+	if err != nil {
+		return nil, err
+	}
+	return buildResourceCard(ctx, deepLink, resource)
+}
+
+// buildResourceCard assembles the octo/v1 body (header + optional excerpt +
+// optional FactSet + ActionSet) from a validated ResourceCard and an already
+// built https deep-link URL. Callers own scenario-specific input validation
+// (identifier presence, deep-link shape); this helper enforces the
+// scenario-independent bounds (title length, fact count, copy text size,
+// icon-must-be-https) and returns the marshalled AC 1.5 document.
+func buildResourceCard(
+	ctx context.Context,
+	deepLink string,
+	resource ResourceCard,
+) (json.RawMessage, error) {
 	if strings.TrimSpace(resource.Title) == "" || utf8.RuneCountInString(resource.Title) > maxTitleRunes {
 		return nil, errors.New("cardtmpl: resource title is invalid")
 	}
@@ -69,9 +130,13 @@ func BuildSummaryResourceCard(
 			return nil, fmt.Errorf("cardtmpl: icon URL: %w", err)
 		}
 	}
-	deepLink, err := summaryDeepLink(webLoginURL, taskID, spaceID)
-	if err != nil {
-		return nil, err
+	if resource.Source.IconURL != "" {
+		if err := requireHTTPS(resource.Source.IconURL); err != nil {
+			return nil, fmt.Errorf("cardtmpl: source icon URL: %w", err)
+		}
+	}
+	if utf8.RuneCountInString(resource.Source.Label) > maxTitleRunes {
+		return nil, errors.New("cardtmpl: source label too long")
 	}
 
 	lang := i18n.OutboundLanguage(ctx)
@@ -145,9 +210,10 @@ func BuildSummaryResourceCard(
 	body = append(body, map[string]interface{}{"type": "ActionSet", "actions": actions})
 
 	document := map[string]interface{}{
-		"type":    "AdaptiveCard",
-		"version": cardmsg.CardVersion,
-		"body":    body,
+		"type":     "AdaptiveCard",
+		"version":  cardmsg.CardVersion,
+		"metadata": buildMetadata(deepLink, resource.Variant, resource.Source),
+		"body":     body,
 	}
 	raw, err := json.Marshal(document)
 	if err != nil {
@@ -157,12 +223,62 @@ func BuildSummaryResourceCard(
 }
 
 func summaryDeepLink(webLoginURL, taskID, spaceID string) (string, error) {
+	origin, err := webOrigin(webLoginURL)
+	if err != nil {
+		return "", err
+	}
+	return origin + "/s/" + url.PathEscape(taskID) + "?sp=" + url.QueryEscape(spaceID), nil
+}
+
+// docsDeepLink mirrors summaryDeepLink but targets octo-web's already-live
+// standalone doc route /d/:docId (cold-load → login bounce → multi-session
+// sid recovery, XIN-398 suite). The origin comes from External.WebLoginURL
+// (positive-allowlisted absolute https).
+func docsDeepLink(webLoginURL, docID, spaceID string) (string, error) {
+	origin, err := webOrigin(webLoginURL)
+	if err != nil {
+		return "", err
+	}
+	return origin + "/d/" + url.PathEscape(docID) + "?sp=" + url.QueryEscape(spaceID), nil
+}
+
+// buildMetadata assembles the AdaptiveCard 1.5 `metadata` object. The standard
+// `webUrl` sub-field (canonical browser URL for this card) is always set from
+// the same deep-link that drives the primary "View details" action, so
+// client-side features that key off the URL don't need to walk actions. The
+// `octo` sub-object namespaces our extensions:
+//   - `variant`: stable low-cardinality identifier (`summary.completed` etc.)
+//   - `source`:  originating capability {label, iconUrl} for renderer badges
+//
+// Both octo sub-fields are omitted when empty to keep the wire minimal.
+func buildMetadata(deepLink, variant string, source Source) map[string]interface{} {
+	metadata := map[string]interface{}{"webUrl": deepLink}
+	octo := map[string]interface{}{}
+	if strings.TrimSpace(variant) != "" {
+		octo["variant"] = variant
+	}
+	if strings.TrimSpace(source.Label) != "" || strings.TrimSpace(source.IconURL) != "" {
+		s := map[string]interface{}{}
+		if strings.TrimSpace(source.Label) != "" {
+			s["label"] = source.Label
+		}
+		if strings.TrimSpace(source.IconURL) != "" {
+			s["iconUrl"] = source.IconURL
+		}
+		octo["source"] = s
+	}
+	if len(octo) > 0 {
+		metadata["octo"] = octo
+	}
+	return metadata
+}
+
+func webOrigin(webLoginURL string) (string, error) {
 	base, err := url.Parse(strings.TrimSpace(webLoginURL))
 	if err != nil || base.Scheme != "https" || base.Host == "" {
 		return "", errors.New("cardtmpl: web base URL must be absolute https")
 	}
-	origin := (&url.URL{Scheme: base.Scheme, Host: base.Host}).String()
-	return origin + "/s/" + url.PathEscape(taskID) + "?sp=" + url.QueryEscape(spaceID), nil
+	return (&url.URL{Scheme: base.Scheme, Host: base.Host}).String(), nil
 }
 
 func requireHTTPS(raw string) error {

--- a/pkg/cardtmpl/resource.go
+++ b/pkg/cardtmpl/resource.go
@@ -54,8 +54,16 @@ type ResourceCard struct {
 // display badging and machine identification. Values are server-picked (never
 // user-supplied) and land in `metadata.octo.source`.
 type Source struct {
-	Label   string // human-readable source name, e.g. "智能总结" / "Smart Summary" / "文档" / "Docs"
-	IconURL string // absolute https icon URL, optional; renderers may use it for the chip
+	// Label is a human-readable source name. It is already localized by the
+	// caller: producers pass it from their per-language label set
+	// (modules/notify summaryLabelsFor/docsLabelsFor, keyed by
+	// i18n.OutboundLanguage) — e.g. "智能总结"/"Smart Summary",
+	// "文档"/"Docs" — so this template stores whatever localized string it
+	// receives and does not itself pick a language.
+	Label string
+	// IconURL is an optional absolute https icon URL; renderers may use it for
+	// the chip. Empty by default (the pilot sets Label only).
+	IconURL string
 }
 
 func BuildSummaryResourceCard(

--- a/pkg/cardtmpl/resource_test.go
+++ b/pkg/cardtmpl/resource_test.go
@@ -31,6 +31,8 @@ func exampleResourceCard() ResourceCard {
 			{Title: "Messages", Value: "128"},
 		},
 		CopyText: "summary-42",
+		Variant:  "summary.completed",
+		Source:   Source{Label: "Smart Summary"},
 	}
 }
 
@@ -47,6 +49,13 @@ func TestBuildSummaryResourceCardSnapshotAndValidation(t *testing.T) {
 	want := `{
 	  "type":"AdaptiveCard",
 	  "version":"1.5",
+	  "metadata":{
+	    "webUrl":"https://im.example.com/s/task%2F42?sp=space+a",
+	    "octo":{
+	      "variant":"summary.completed",
+	      "source":{"label":"Smart Summary"}
+	    }
+	  },
 	  "body":[
 	    {"type":"ColumnSet","columns":[
 	      {"type":"Column","width":"auto","items":[{"type":"Image","url":"https://static.example.com/summary.png","size":"Small"}]},

--- a/scripts/cardpreview/README.md
+++ b/scripts/cardpreview/README.md
@@ -1,0 +1,33 @@
+# cardpreview — deterministic sample AC JSON generator
+
+`go run ./scripts/cardpreview` prints the three canonical notification card
+documents to stdout as `{"summary_completed": {...}, "summary_failed": {...},
+"docs_shared": {...}}`. Same code paths as production
+(`pkg/cardtmpl.BuildSummaryResourceCard` / `BuildDocsResourceCard`) so the
+output tracks whatever the templates emit today — no hand-authored samples to
+drift.
+
+Use it to:
+- Feed the actual octo-web / mobile AC renderer for a truthful preview
+  screenshot (drop the JSON into a fixture, mount the same `renderOctoCard` /
+  host config the chat cell uses).
+- Regenerate the JSON snippets in `docs/summary-notify-card.md` §2 /
+  `docs/docs-notify-card.md` §2 whenever the template shape changes.
+- Spot-check the reserved `metadata.octo.variant` / `metadata.octo.source`
+  namespace after adding a new Kind or Source label.
+
+```bash
+go run ./scripts/cardpreview > /tmp/cards.json
+jq . /tmp/cards.json
+```
+
+The tool has no runtime dependencies beyond `pkg/cardtmpl` (which itself only
+depends on `pkg/cardmsg` for the version/copy-text constants and `pkg/i18n` for
+outbound language). To exercise it against octo-web's real renderer, mount
+`AdaptiveCards.AdaptiveCard` with the host config from
+`packages/dmworkbase/src/Messages/InteractiveCard/sdk/octoHostConfig.ts`, wrap
+the mount node in `.wk-interactive-card > .wk-interactive-card-sdk` so
+`packages/dmworkbase/src/Messages/InteractiveCard/index.css` styles apply, and
+install a markdown processor on `AdaptiveCard.onProcessMarkdown` (the app uses
+`cardMarkdownToSafeHtml`; a stock CommonMark parser produces byte-equivalent
+output for the whitelist subset we ship).

--- a/scripts/cardpreview/main.go
+++ b/scripts/cardpreview/main.go
@@ -1,0 +1,85 @@
+package main
+
+// Standalone tool that writes the three sample cards' AC JSON to stdout as
+// `{"summary_completed": {...}, "summary_failed": {...}, "docs_shared": {...}}`.
+// Uses the same pkg/cardtmpl + modules/notify code paths the production
+// producers run.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl"
+)
+
+func main() {
+	ctx := context.Background()
+	base := "https://im.example.com/login"
+
+	summaryCompleted := mustCard(cardtmpl.BuildSummaryResourceCard(
+		ctx, base, "TN_20260713_abcd", "spc_xxx",
+		cardtmpl.ResourceCard{
+			Title:       "产品周会纪要",
+			Attribution: "总结已生成完成",
+			Facts: []cardtmpl.Fact{
+				{Title: "时间范围", Value: "2026-07-06 10:00 ~ 2026-07-13 10:00"},
+				{Title: "参与成员", Value: "5 人"},
+				{Title: "消息数量", Value: "128 条"},
+				{Title: "生成时间", Value: "2026-07-13 15:04"},
+			},
+			Variant: "summary.completed",
+			Source:  cardtmpl.Source{Label: "智能总结"},
+		},
+	))
+
+	summaryFailed := mustCard(cardtmpl.BuildSummaryResourceCard(
+		ctx, base, "TN_20260713_abcd", "spc_xxx",
+		cardtmpl.ResourceCard{
+			Title:       "产品周会纪要",
+			Attribution: "总结生成失败",
+			Excerpt:     "失败原因：upstream LLM 5xx",
+			Variant:     "summary.failed",
+			Source:      cardtmpl.Source{Label: "智能总结"},
+		},
+	))
+
+	docsShared := mustCard(cardtmpl.BuildDocsResourceCard(
+		ctx, base, "d_20260713_abcd", "spc_xxx",
+		cardtmpl.ResourceCard{
+			Title:       "产品设计方案",
+			Attribution: "Alice 分享了文档",
+			Excerpt:     "Q3 上线计划已确认",
+			Facts: []cardtmpl.Fact{
+				{Title: "操作人", Value: "Alice"},
+				{Title: "时间", Value: "2026-07-13 15:04"},
+			},
+			Variant: "docs.shared",
+			Source:  cardtmpl.Source{Label: "文档"},
+		},
+	))
+
+	out := map[string]json.RawMessage{
+		"summary_completed": summaryCompleted,
+		"summary_failed":    summaryFailed,
+		"docs_shared":       docsShared,
+	}
+	b, err := json.MarshalIndent(out, "", "  ")
+	if err != nil {
+		fatal("marshal: %v", err)
+	}
+	_, _ = os.Stdout.Write(b)
+}
+
+func mustCard(raw json.RawMessage, err error) json.RawMessage {
+	if err != nil {
+		fatal("build card: %v", err)
+	}
+	return raw
+}
+
+func fatal(f string, args ...interface{}) {
+	fmt.Fprintf(os.Stderr, f+"\n", args...)
+	os.Exit(1)
+}


### PR DESCRIPTION
## Summary

Adds `docs-notify` as the **second `internal/carddispatch` producer**, giving
docs-backend the same trusted, server-templated card path that `summary-notify`
gave smart-summary (PRs #579/#580). Also introduces a stable
`metadata.octo.{variant,source}` namespace on every notification card so
renderers can style card families independently without re-parsing content, and
reserves a visible **source badge (角标)** slot for future "来自智能总结 / 来自文档"
styling. octo-server scope only; **DM (person) targets only**.

## Related Issue

Refs #571. Foundation: #577. Pilot: #579, #580 (merged).

## Linked Spec

- `.octospec/tasks/card-message-internal-dispatch/brief.md` (Decisions 1/3/4/11/14)
- `.octospec/tasks/card-message-internal-dispatch/docs-notify-contract.md` (new cross-repo wire contract for octo-docs-backend)
- `.octospec/tasks/card-message-internal-dispatch/summary-notify-contract.md` (sibling, points at the new contract)

## Changes

- **Template (`pkg/cardtmpl`)** — factor the shared octo/v1 body assembly into
  `buildResourceCard`; expose `BuildSummaryResourceCard` +
  `BuildDocsResourceCard` (docs deep-link `/d/{doc_id}?sp={space_id}`, mirroring
  `summaryDeepLink`). `ResourceCard` grows `Variant` and
  `Source{Label, IconURL}`. Every card now emits an AC 1.5 `metadata` object:
  `webUrl` (canonical URL) + `octo.{variant, source}`.
- **Ingress (`modules/notify`)** — new structured `NotifyReq.DocsCard`
  (`DocsCardFields`, **not** a type-17 map). `Payload` / `Card` / `DocsCard` are
  **mutually exclusive** (both/all-present → 400 `err.server.notify.card_invalid`;
  none → legacy 400). `deliverDocsCardNotification` reuses the exact
  dedup → actor-exclude → live member verify → bounded fan-out pipeline through
  the producer-bound `carddispatch.Sender`, preserving
  `NotifyResp{delivered,filtered}`.
- **Kinds & i18n** — `shared` / `commented` / `access_requested`, each mapping to
  a localized attribution (with/without actor) and a reserved
  `metadata.octo.variant`; zh-CN + en-US label tables; `Source.Label` =
  "智能总结" / "Smart Summary" and "文档" / "Docs".
- **Text fallback** — `buildDocsFallbackText` mirrors `buildSummaryFallbackText`
  so a card-build failure (feature off, sender missing, non-https deep-link
  origin) degrades to a plain DM instead of dropping the notification.
- **Wiring (`main.go`)** — `cardDispatchProducerSpecs` registers both
  `summary-notify` and `docs-notify` against the shared `notification` User Bot
  (same DM-only / `octo/v1` / system-notification / `MaxInFlight=20` shape). No
  `register.AddModule` change, no package-global registration (Decision 1/11).
  Capability isolation stays on the producer ID.
- **Config (`configs/tsdd.yaml`)** — the `external.webLoginURL` comment now
  states its role as the card deep-link origin; a missing/non-https value
  silently degrades card notifications to text.
- **Tooling** — `scripts/cardpreview` dumps the three canonical cards as AC JSON
  via the production code paths (used to drive octo-web's real renderer for
  truthful screenshots; see below).
- **Docs** — `docs/docs-notify-card.md` (sibling of `docs/summary-notify-card.md`);
  `metadata.octo.variant/source` section added to the summary doc.

## Testing

```
go vet ./...                                                   # clean
go test ./pkg/cardtmpl/... ./modules/notify/... ./pkg/cardmsg/... ./internal/carddispatch/... .   # ok
go run ./tools/lint-card-dispatch ./modules ./internal         # guard green
make i18n-extract-check && make i18n-lint                      # green
golangci-lint run ./...                                        # 0 issues
# E2E against real MySQL + Redis + WuKongIM:
go test -tags pilote2e ./pilote2e -run 'TestDocsNotify|TestSummaryAndDocsNotify_NoRegression'   # pass
```

Real-renderer screenshots (octo-web's actual `theme/*.css` +
`InteractiveCard/index.css` + ported `octoHostConfig`, `marked` for markdown)
were produced from `scripts/cardpreview` output for `summary.completed`,
`summary.failed`, and `docs.shared` and verified against the design reference.

- [x] Unit/integration tests added/updated
- [x] Manually verified (unit + pilote2e E2E + real-renderer screenshot)

## COMPREHENSION

1. **What does this change actually do to the load-bearing path?**
   It adds a second trusted card *producer* (`docs-notify`) to the
   `internal/carddispatch` boundary and a `NotifyReq.DocsCard` ingress on the
   existing `POST /v1/internal/notify`. A structured `DocsCard` request is
   authored into an `octo/v1` card by `cardtmpl` and dispatched through the
   producer-bound `Sender`, which runs the full fail-closed pipeline (live bot
   identity → live Space/member ACL → `Validate` → authoritative `plain`/
   `space_id` → final size recheck → one transport call). The new
   `metadata.octo` object is server-authored only — `pkg/cardmsg.Validate` does
   not walk metadata sub-fields, so no user input reaches it there, and the
   `variant`/`source` values are picked by the server from `Kind`/producer, never
   from the caller.

2. **What could break because of it (dependents + failure mode)?**
   The only live caller of `/v1/internal/notify` today is smart-summary, which
   sends `Card` (or text) and is untouched — the 3-way mutex keeps its existing
   400s intact (a present-but-empty `{}` payload still counts as intent-to-send,
   so it cannot silently combine with a card). `docs-notify` is inert until
   octo-docs-backend opts in with `DocsCard` **and** `OCTO_CARD_MESSAGE_ENABLED`
   is on. A non-https `External.WebLoginURL` fails the card build fail-closed and
   degrades to a text DM rather than sending a dead link. Rollback: remove the
   one `docs-notify` spec or flip the global env.

3. **How do you know it works (specific test/repro/trace)?**
   `pkg/cardtmpl` docs snapshot + `cardmsg.Validate` + deep-link shape +
   unsafe-input rejection tests; `modules/notify` docs validation matrix,
   kind→variant mapping, actor fallback, degrade-to-text, batch preflight, and
   3-way-mutex integration tests; `main_carddispatch_test.go` pins both producers
   to the reviewed shape and rejects unknown IDs; and
   `pilote2e/docs_card_wukongim_test.go` drives a real
   `POST /v1/internal/notify` → real WuKongIM and reads back the persisted
   type-17 card, asserting the `/d/{doc_id}?sp=` deep-link and
   `metadata.octo.variant="docs.shared"`. `TestSummaryAndDocsNotify_NoRegression`
   runs both producers back-to-back in one server lifecycle.

## Cross-repo dependency (must sync)

End-to-end needs octo-docs-backend to add an outbound notify client (symmetric
to `octo-smart-summary/internal/notify/`) that POSTs the `DocsCard` body per
`docs-notify-contract.md`. Unlike summary, the docs deep-link route (`/d/:docId`)
is **already live** in octo-web, so the "查看详情" button works on day one.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] PR description is in English
- [x] Added tests for my changes
- [x] Updated documentation
- [x] Followed commit message conventions (Conventional Commits)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rni147Au4tj4jj7AJPFCCK)_