### PR TITLE
fix(thread): auto-follow reactivated thread for parent-channel followers (#586)

### DIFF
--- a/modules/conversation_ext/service.go
+++ b/modules/conversation_ext/service.go
@@ -651,6 +651,27 @@ func (s *Service) UnfollowChannel(uid, spaceID, groupNo string) error {
 // 调用方应在 thread.Service.CreateThread 的 commit 之后立即调用，错误以 wrap 形式上传，
 // 由调用方决定是否记日志 / 触发告警（thread 创建不应因 fanout 失败回滚）。
 func (s *Service) OnThreadCreated(groupNo, shortID string) error {
+	return s.fanoutThreadFollow(groupNo, shortID)
+}
+
+// OnThreadReactivated 在归档子区被新消息复活（archived -> active）之后调用，
+// 给所有已对 parent channel 开启 auto_follow_threads=1 的用户物化 thread ext 行。
+//
+// issue #586：FollowChannel 物化（EnumerateActiveShortIDs）只枚举 active 子区，
+// 因此关注时处于 archived 的子区从未生成 ext 行；OnThreadCreated 只在创建时 fanout。
+// 结果是被复活的子区右侧 active 列表可见、左侧「关注」列表却永久缺失。此处与
+// OnThreadCreated 对称补齐：复用同一 fanout 逻辑（INSERT IGNORE，幂等，与既有
+// ext 行重叠是 no-op），只在 RecordMessageAndReactivate 确实翻转了 status 时调用。
+//
+// best-effort：与 OnThreadCreated 一样错误以 wrap 形式上传，由调用方记日志不阻断消息摄入。
+func (s *Service) OnThreadReactivated(groupNo, shortID string) error {
+	return s.fanoutThreadFollow(groupNo, shortID)
+}
+
+// fanoutThreadFollow 是 OnThreadCreated / OnThreadReactivated 共用的 fanout 主体：
+// 给所有对 parent channel 开启 auto_follow_threads=1 且未 group_unfollowed 的活跃
+// 成员物化 thread ext 行并 bump 各自的 follow_version。INSERT IGNORE 保证幂等。
+func (s *Service) fanoutThreadFollow(groupNo, shortID string) error {
 	if groupNo == "" {
 		return errors.New("group_no must not be empty")
 	}

--- a/modules/conversation_ext/service_test.go
+++ b/modules/conversation_ext/service_test.go
@@ -680,6 +680,65 @@ func TestService_OnThreadCreated_InvalidInput(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// OnThreadReactivated fanout — issue #586: 归档子区被消息复活后与 OnThreadCreated
+// 对称地给关注父群的用户补 thread ext 行，否则左侧「关注」列表永久缺失该子区。
+// 复用同一 fanout 主体（fanoutThreadFollow），行为与 OnThreadCreated 一致。
+// ---------------------------------------------------------------------------
+
+func TestService_OnThreadReactivated_MaterializesForAutoFollowUsers(t *testing.T) {
+	svc := newServiceForTest(t)
+	const space, grp, shortID = "s1", "grp-ofr-1", "thr-react"
+	channelID := grp + threadSeparator + shortID
+
+	// A：开启 auto_follow_threads（关注了 channel）
+	require.NoError(t, svc.FollowChannel("uA", space, grp))
+	// B：关注过群但显式取关 —— auto_follow_threads 已清零
+	require.NoError(t, svc.UnfollowChannel("uB", space, grp))
+	// C：从未操作过该 channel
+
+	require.NoError(t, svc.OnThreadReactivated(grp, shortID))
+
+	rowA, err := svc.db.Get("uA", space, targetTypeThread, channelID)
+	require.NoError(t, err)
+	assert.NotNil(t, rowA, "auto_follow_threads=1 的用户应在复活 fanout 中拿到 thread 行")
+
+	rowB, err := svc.db.Get("uB", space, targetTypeThread, channelID)
+	require.NoError(t, err)
+	assert.Nil(t, rowB, "已取消关注 channel 的用户不应被复活 fanout 触及")
+
+	rowC, err := svc.db.Get("uC", space, targetTypeThread, channelID)
+	require.NoError(t, err)
+	assert.Nil(t, rowC, "从未关注 channel 的用户不应被复活 fanout 触及")
+}
+
+func TestService_OnThreadReactivated_Idempotent_PreservesExistingRow(t *testing.T) {
+	svc := newServiceForTest(t)
+	const space, grp, shortID = "s1", "grp-ofr-2", "thr-react-dup"
+	channelID := grp + threadSeparator + shortID
+
+	require.NoError(t, svc.FollowChannel("uA", space, grp))
+	// uA 已手动给该 thread 拖到 sort=88（例如关注时子区曾 active 被物化后又归档）
+	require.NoError(t, svc.db.Upsert("uA", space, targetTypeThread, channelID, ConvExtFields{
+		FollowSort: intPtr(88),
+	}))
+
+	// 复活 fanout 与既有 ext 行重叠时必须是 no-op（INSERT IGNORE）。
+	require.NoError(t, svc.OnThreadReactivated(grp, shortID))
+
+	row, err := svc.db.Get("uA", space, targetTypeThread, channelID)
+	require.NoError(t, err)
+	require.NotNil(t, row)
+	assert.Equal(t, 88, row.FollowSort, "已存在的 thread 行（含手动排序）必须保留，复活 fanout 不应覆盖")
+}
+
+func TestService_OnThreadReactivated_InvalidInput(t *testing.T) {
+	svc := newServiceForTest(t)
+
+	require.Error(t, svc.OnThreadReactivated("", "thr"))
+	require.Error(t, svc.OnThreadReactivated("grp", ""))
+}
+
+// ---------------------------------------------------------------------------
 // UnfollowChannel happy path + cascade
 // ---------------------------------------------------------------------------
 

--- a/modules/thread/api.go
+++ b/modules/thread/api.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/modules/conversation_ext"
 	"github.com/Mininglamp-OSS/octo-server/modules/group"
 	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
 	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
@@ -70,10 +71,25 @@ func (t *Thread) onMessages(messages []*config.MessageResp) {
 		if runeLen := len([]rune(content)); runeLen > 500 {
 			content = string([]rune(content)[:500])
 		}
-		if err := t.db.RecordMessageAndReactivate(shortID, content, msg.FromUID, func() (int64, error) {
+		reactivated, err := t.db.RecordMessageAndReactivate(shortID, content, msg.FromUID, func() (int64, error) {
 			return t.ctx.GenSeq(ThreadSeqKey)
-		}); err != nil {
+		})
+		if err != nil {
 			t.Error("更新消息统计/解档失败", zap.Error(err), zap.String("shortID", shortID))
+		} else if reactivated {
+			// issue #586：子区被消息复活（archived->active）时，与 OnThreadCreated 对称地
+			// 给所有关注父群（auto_follow_threads=1 AND group_unfollowed=0）的用户补 thread
+			// ext 行，否则左侧「关注」列表会永久缺失这个已复活的子区（FollowChannel 物化
+			// 只枚举 active 子区，关注时处于 archived 的子区从未生成 ext 行）。
+			// 与 OnThreadCreated 一样是 commit 后 best-effort：失败只警告，不阻断消息摄入。
+			if convSvc := conversation_ext.GetGlobalConvExtService(); convSvc != nil {
+				if ferr := convSvc.OnThreadReactivated(groupNo, shortID); ferr != nil {
+					t.Warn("OnThreadReactivated fanout 失败（子区已复活，sidebar 会延迟到下次 FollowChannel/refollow 补齐）",
+						zap.String("groupNo", groupNo),
+						zap.String("shortID", shortID),
+						zap.Error(ferr))
+				}
+			}
 		}
 
 		// 发送者不是子区成员，自动加入

--- a/modules/thread/archive_db_test.go
+++ b/modules/thread/archive_db_test.go
@@ -177,7 +177,9 @@ func TestRecordMessageAndReactivate_ResurrectsArchived(t *testing.T) {
 	require.Equal(t, ThreadStatusArchived, m.Status)
 
 	// 此后 listener 落库消息统计：必须把 status 抬回 active 并写新版本
-	require.NoError(t, db.RecordMessageAndReactivate("raced", "hello", "sender-1", constVersion(200)))
+	reactivated, err := db.RecordMessageAndReactivate("raced", "hello", "sender-1", constVersion(200))
+	require.NoError(t, err)
+	assert.True(t, reactivated, "archived->active transition must report reactivated=true")
 
 	m, err = db.QueryByShortID("raced")
 	require.NoError(t, err)
@@ -203,10 +205,12 @@ func TestRecordMessageAndReactivate_NoVersionBumpForAlreadyActive(t *testing.T) 
 	insertThreadWithVersion(t, db, "active_thread", ThreadStatusActive, &now, 42)
 
 	called := false
-	require.NoError(t, db.RecordMessageAndReactivate("active_thread", "hi", "u1", func() (int64, error) {
+	reactivated, err := db.RecordMessageAndReactivate("active_thread", "hi", "u1", func() (int64, error) {
 		called = true
 		return 999, nil
-	}))
+	})
+	require.NoError(t, err)
+	assert.False(t, reactivated, "already-active thread must report reactivated=false")
 
 	m, err := db.QueryByShortID("active_thread")
 	require.NoError(t, err)
@@ -226,7 +230,9 @@ func TestRecordMessageAndReactivate_DeletedStaysDeleted(t *testing.T) {
 	now := time.Now()
 	insertThreadWithVersion(t, db, "deleted_thread", ThreadStatusDeleted, &now, 7)
 
-	require.NoError(t, db.RecordMessageAndReactivate("deleted_thread", "x", "u1", constVersion(999)))
+	reactivated, err := db.RecordMessageAndReactivate("deleted_thread", "x", "u1", constVersion(999))
+	require.NoError(t, err)
+	assert.False(t, reactivated, "deleted thread must report reactivated=false")
 
 	m, err := db.QueryByShortID("deleted_thread")
 	require.NoError(t, err)
@@ -269,7 +275,9 @@ func TestRecordMessageAndReactivate_VersionMonotonicVsCronArchive(t *testing.T) 
 		return newV, nil
 	}
 
-	require.NoError(t, db.RecordMessageAndReactivate("monotonic", "msg", "u1", gen))
+	reactivated, err := db.RecordMessageAndReactivate("monotonic", "msg", "u1", gen)
+	require.NoError(t, err)
+	assert.True(t, reactivated, "archived->active transition must report reactivated=true")
 
 	m, err := db.QueryByShortID("monotonic")
 	require.NoError(t, err)
@@ -479,7 +487,7 @@ func TestArchiveStaleBatch_ConcurrentWithMessages(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			for r := 0; r < rounds; r++ {
-				_ = db.RecordMessageAndReactivate(sid, "msg", "sender", gen)
+				_, _ = db.RecordMessageAndReactivate(sid, "msg", "sender", gen)
 				time.Sleep(1 * time.Millisecond)
 			}
 		}()
@@ -490,7 +498,8 @@ func TestArchiveStaleBatch_ConcurrentWithMessages(t *testing.T) {
 	// 收尾：最后再跑一遍消息路（确保每个子区最后一次写入是消息，模拟"消息到了之后不再有
 	// cron 在它身上跑"的真实条件，因为生产里 cron 是周期触发不是连续触发）。
 	for _, sid := range shortIDs {
-		require.NoError(t, db.RecordMessageAndReactivate(sid, "final", "sender", gen))
+		_, err := db.RecordMessageAndReactivate(sid, "final", "sender", gen)
+		require.NoError(t, err)
 	}
 
 	// 断言：所有刚发过消息的子区都必须是 active

--- a/modules/thread/db.go
+++ b/modules/thread/db.go
@@ -764,6 +764,9 @@ func (d *DB) CountMembersBatch(threadIDs []int64) (map[int64]int, error) {
 }
 
 // RecordMessageAndReactivate 收到消息时的事务路径：在行锁内决定是否解档。
+// 返回 reactivated 表示本次调用是否真的把 status 从 archived 翻转为 active
+// （archived->active 分支返回 true；纯统计/已 active、以及已删除/不存在分支返回 false）。
+// 调用方据此决定是否补 fanout ext 行（issue #586）。
 //
 // 流程：BEGIN → SELECT ... FOR UPDATE → 看当前 status 决定是否解档 → UPDATE → COMMIT。
 // 关键点：
@@ -778,10 +781,10 @@ func (d *DB) CountMembersBatch(threadIDs []int64) (map[int64]int, error) {
 //     active（新版本号严格 > cron 的版本号，因为 GenSeq 是全局单调）。
 //   - 我们先拿锁 → last_message_at=NOW → cron 的 WHERE last_message_at<cutoff 不匹配
 //     → cron 跳过本行。
-func (d *DB) RecordMessageAndReactivate(shortID, content, senderUID string, newVersion func() (int64, error)) error {
+func (d *DB) RecordMessageAndReactivate(shortID, content, senderUID string, newVersion func() (int64, error)) (reactivated bool, err error) {
 	tx, err := d.session.Begin()
 	if err != nil {
-		return fmt.Errorf("record message: begin tx: %w", err)
+		return false, fmt.Errorf("record message: begin tx: %w", err)
 	}
 	defer tx.RollbackUnlessCommitted()
 
@@ -791,18 +794,18 @@ func (d *DB) RecordMessageAndReactivate(shortID, content, senderUID string, newV
 		shortID, ThreadStatusDeleted,
 	).Load(&status)
 	if err != nil {
-		return fmt.Errorf("record message: lock thread: %w", err)
+		return false, fmt.Errorf("record message: lock thread: %w", err)
 	}
 	if loaded == 0 {
 		// 行不存在或已删除：消息到达不该复活已删的子区，直接放弃，但事务正常 commit。
-		return tx.Commit()
+		return false, tx.Commit()
 	}
 
 	now := time.Now()
 	if status == ThreadStatusArchived {
 		version, gerr := newVersion()
 		if gerr != nil {
-			return fmt.Errorf("record message: gen version: %w", gerr)
+			return false, fmt.Errorf("record message: gen version: %w", gerr)
 		}
 		if _, err := tx.UpdateBySql(
 			"UPDATE thread SET status=?, version=?, last_message_at=?, "+
@@ -811,9 +814,10 @@ func (d *DB) RecordMessageAndReactivate(shortID, content, senderUID string, newV
 				"WHERE short_id=?",
 			ThreadStatusActive, version, now, content, senderUID, now, shortID,
 		).Exec(); err != nil {
-			return fmt.Errorf("record message: reactivate update: %w", err)
+			return false, fmt.Errorf("record message: reactivate update: %w", err)
 		}
-		return tx.Commit()
+		// 本次调用确实把 status 从 archived 翻转为 active，通知调用方补 fanout ext 行。
+		return true, tx.Commit()
 	}
 
 	// status == active：仅更新统计，不动 version。
@@ -823,9 +827,9 @@ func (d *DB) RecordMessageAndReactivate(shortID, content, senderUID string, newV
 			"WHERE short_id=?",
 		now, content, senderUID, now, shortID,
 	).Exec(); err != nil {
-		return fmt.Errorf("record message: stats update: %w", err)
+		return false, fmt.Errorf("record message: stats update: %w", err)
 	}
-	return tx.Commit()
+	return false, tx.Commit()
 }
 
 // UpdateMessageStats 原子更新消息统计（收到消息时调用）


### PR DESCRIPTION
## 背景

Fixes #586

一个已被**关注**的 channel 下，某子区（thread）被归档后，用户在归档子区里发新消息使其自动复活为 `active`：

- ✅ 右侧「活跃区 thread 列表」立刻显示（它读 `thread` 表，只看 `status`）。
- ❌ 左侧「关注」folder 下该 channel 里**永久缺失**该子区，且**整页刷新照样缺失**。

## 根因

两侧数据源不同：左侧「关注」列表读 `user_conversation_ext`（`ListThreadExts`, `target_type=5`），一个子区必须存在 ext 行才会出现在左侧。而 ext 行只有两条创建路径：

1. `FollowChannel` 物化 —— `EnumerateActiveShortIDs` 只枚举 **active** 子区，关注时处于 archived 的子区从未生成 ext 行；
2. `OnThreadCreated` fanout —— 仅在子区**创建**时触发。

子区从 archived 被消息复活时（`modules/thread/api.go` `onMessages` → `RecordMessageAndReactivate`）只 `UPDATE thread SET status=Active`，**从不给关注了父群的用户补 ext 行**。因此左侧永久缺失。

## 修复（与 OnThreadCreated 对称）

当子区因新消息从 archived 复活为 active 时，若父 channel 处于被关注状态，则对所有 `auto_follow_threads=1 AND group_unfollowed=0` 的活跃父群成员补 thread ext 行——与 `OnThreadCreated` 完全对称。

- **`modules/thread/db.go`**：`RecordMessageAndReactivate` 现返回 `(reactivated bool, err error)`；仅在 `archived -> active` 分支返回 `true`，纯统计/已 active、已删除/不存在分支返回 `false`。加锁与 version 语义不变。
- **`modules/conversation_ext/service.go`**：抽出共用 fanout 主体 `fanoutThreadFollow`，新增 `OnThreadReactivated`；它与 `OnThreadCreated` 都委托给该 helper，行为完全一致且幂等（`INSERT IGNORE`，与既有 ext 行重叠为 no-op），并 bump `follow_version` 让在线客户端自动重刷 `sidebar/sync`。
- **`modules/thread/api.go`**：`onMessages` 仅在 `reactivated==true` 时调用 `OnThreadReactivated`，复用与 `CreateThread` 相同的 `GetGlobalConvExtService()` 引用；失败只记 warning，绝不阻断消息摄入。

## 测试

- `modules/thread/archive_db_test.go`：更新调用方为二值签名，断言 `reactivated` 在 `archived->active` 为 `true`、在 active/deleted 路径为 `false`。
- `modules/conversation_ext/service_test.go`：新增 `OnThreadReactivated` 测试（对 auto-follow 用户物化 ext 行 / 幂等 / 非法入参），镜像 `OnThreadCreated` 测试。

### 验证结果

```
go build ./...                                   ✅ pass
go vet ./modules/thread/... ./modules/conversation_ext/...   ✅ pass
go test ./modules/thread/...                     ✅ ok (11.6s)
go test -tags integration ./modules/conversation_ext/        ✅ ok (1.4s)
```

（DB-backed 集成测试跑在真实 MySQL/Redis 上，非 skip。）

## 影响范围

- 仅触及 `modules/thread/api.go`、`modules/thread/db.go`、`modules/conversation_ext/service.go` 及对应测试。
- `OnThreadCreated` 可观测行为不变（仅提取共用 helper）。
- 幂等 `INSERT IGNORE` + `reactivated` 门控保证不会每条消息都 fanout，热路径无写放大。
