### PR TITLE
feat: add generic card action callback dispatch

### DIFF
--- a/.octospec/tasks/card-action-callback-dispatch/brief.md
+++ b/.octospec/tasks/card-action-callback-dispatch/brief.md
@@ -1,0 +1,386 @@
+---
+type: Task
+title: "Task: card-action-callback-dispatch"
+description: Build a sender-bound card-action callback dispatch layer in octo-server, so first-party services react to card actions by implementing one signed HTTP decide endpoint (no bot polling). Docs access-request approve/deny is the pilot consumer.
+tags: ["message", "card", "internal", "bot-api", "trust-boundary", "wire-contract", "auth", "space", "isolation", "acl", "rate-limit", "i18n", "error-response", "observability", "testing"]
+timestamp: 2026-07-15T00:00:00+08:00
+# --- octospec extension fields ---
+slug: card-action-callback-dispatch
+upstream: "TBD — file issue; direct prior art octo-server#584 (docs-notify card producer + reserved metadata namespace), octo-server#548 (card_action loop)"
+source: self
+---
+
+# Task: card-action-callback-dispatch
+
+> One task = one `.octospec/tasks/<slug>/` directory. This brief is the spec for
+> the work. AI may draft it from existing code; a human confirms it.
+
+## Goal
+
+Add the **card-action callback dispatch layer**: octo-server consumes
+`card_action` events **in-process** and delivers them to the owning first-party
+service via a **signed, config-registered HTTP callback** carrying a typed
+decision request. The consumer service implements **one authenticated HTTP
+endpoint** that returns a decision result; octo-server owns everything else —
+queue consumption, retry/backoff/DLQ, callback signing, and rendering the final
+card state + applicant notification.
+
+This replaces the rejected **pull model** (where each new consumer would have to
+implement bot-event polling + ack + cursor + a bot token + card-edit + notify
+calls, re-paid per service and re-implemented per language). The maintainer
+confirmed docs is the **first of several** consumers (加群审批 / 权限授权 /
+任务确认 …), so the recurring per-consumer cost must be paid **once, in
+octo-server**, not by every downstream service.
+
+Design intent, per new consumer:
+
+```
+新增消费方 = 实现一个带验签的 decide 端点 + 在配置里加一行路由
+         (不轮询、不要 bot token、不碰 bot/IM API、语言无关)
+```
+
+This promise applies to consumers that accept the shared **standard approval
+UI**. A route may bind an independent `notify_token_env`; that owner then sends
+the initial card through the generic `approval_card` notify ingress without a
+new producer registration or template. octo-server supplies the approve/deny
+actions, owner metadata, generic fallback finalizer, and requester outcome.
+Docs remains a specialized template binding. A consumer that needs a genuinely
+different visual still adds one reviewed octo-server binding, but an
+unrecognized owner must never run a callback and only then fail finalization.
+
+**Pilot consumer — docs access-request approve/deny.** The docs
+`access_requested` notification is upgraded from an `octo/v1` display card to an
+`octo/v2` approve/deny card; the click is dispatched to docs-backend's decide
+endpoint; octo-server renders the finalized card + notifies the applicant.
+
+End-to-end (pilot):
+
+```
+A 申请文档 (docs-backend 创建 pending)
+→ docs-backend 调 POST /v1/internal/notify (DocsCard kind=access_requested)
+→ octo-server 用 notification bot 发 octo/v2 审批卡给审批人 B (approve/deny)
+→ B 点击 → POST /v1/message/card/action (校验/claim 已现成)
+→ card_action 按权威 (sender_uid=notification, owner=docs,
+   action_type=access_request.decision) 命中路由注册表
+   → 入内部分发队列 (registered internal owner) 而非外部 bot 事件队列
+→ 进程内 dispatcher 弹出, 带 HMAC 签名 POST 到 docs 的 decide 端点
+   请求: {event_id, action_id, decision, operator_uid(仅作身份断言), doc_id,
+          request_id, inputs, data, channel/message ids, space_id, acted_at}
+→ docs-backend 验签 → 幂等(event_id) → 重校验 B 仍为 admin → CAS pending→approved/denied
+   返回: {disposition, state, requester_uid, display fields}
+→ octo-server 按返回结果: 编辑 B 的卡为最终态 (走卡片信任边界 + card_seq CAS)
+   + 给 A 发 v1 展示卡通知 (已获权 / 已拒绝)
+→ 全部完成后 ack (从分发队列移除)
+```
+
+This brief scopes **octo-server's** deliverables. The docs-backend decide
+endpoint is a hard cross-repo dependency required for E2E but out of this repo's
+acceptance (§ Cross-repo dependency).
+
+## Background
+
+### Why callback (not pull), and the one honest cost
+
+Three consume topologies were evaluated: standalone polling worker, pull
+(consumer polls its own bot queue), and callback (octo consumes in-process +
+pushes to registered endpoints). With docs confirmed as the first of several
+first-party consumers, callback wins decisively on **recurring per-consumer
+cost**:
+
+| Per new consumer | pull | **callback (this brief)** |
+|---|---|---|
+| poll loop + event_id cursor + ack | each re-implements | octo does once |
+| bot token provisioning | each needs one | none |
+| card edit / notify | each calls bot/IM APIs | octo owns rendering |
+| language | bot client per language | plain signed HTTP (polyglot) |
+| integration shape | service bent into a bot | one inbound endpoint |
+
+Callback also aligns better with the **existing trust boundary**: PR #577
+(`internal/carddispatch`) made octo-server the *sole* in-process card
+origination boundary.
+In pull, docs would mutate the card via `/v1/bot/message/edit` directly; in
+callback, the final-state card edit stays *inside* octo-server's card
+origination/mutation boundary. Card trust, `plain`, i18n, and the 512 KiB
+recheck all stay in one place. The existing dispatcher only exposes `Send`; this
+task therefore extracts a small, shared internal card-mutation primitive from
+the Bot API edit path rather than bypassing that path's ownership, lifecycle,
+normalization, revision, CAS, and CMD-sync rules.
+
+**The one honest cost:** octo-server has **no outbound delivery-reliability
+layer today** (verified 2026-07-15: `modules/webhook/` is inbound-verify +
+mobile push; `modules/webhook/hmac.go` verifies *incoming* signatures; the bot
+event queue is pull-side only). So this task builds, net-new: internal dispatch
+queue + retry/backoff/timeout + DLQ + outbound HMAC signing +
+idempotent delivery. This is built **once** and amortized across all consumers —
+the correct platform investment given the stated future.
+
+### SSRF / trust posture
+
+The rejected callback risks (SSRF, dynamic registration) applied to a
+**data-driven** callback where the card carries a URL. This design is
+**config-driven**: routes are `(sender_uid, owner, action_type) → {url,
+secret_env, timeout, retry}` from server config, URLs validated against an exact
+HTTPS allowlist. Cards never carry a callback URL; redirects are disabled. The
+`owner` / `action_type` fields live in `Action.Submit.data` and are picked by the
+reviewed octo-server template. They are still only "trusted as authored" at the
+generic card protocol layer, so callback routing additionally requires the
+stored message sender to equal the route's configured internal `sender_uid`.
+An external Bot copying the same `data` therefore remains on the existing pull
+path and cannot invoke a first-party callback.
+
+The structured notify ingress is also producer-bound for interactive cards:
+the docs pilot uses `OCTO_DOCS_NOTIFY_TOKEN`; generic routes use their own
+`notify_token_env`. Each token resolves to a server-side `(sender_uid, owner)`
+and only explicitly token-enabled action types. It cannot mint another owner's
+card, select an owner in request JSON, or reuse the callback HMAC secret.
+
+### Current state (verified 2026-07-15 against main @ acb12089)
+
+- `card_action` pipeline is merged (PR #548): `POST /v1/message/card/action`
+  does validate → idempotent claim → `EnqueueBotTypedEvent(msgM.FromUID, …)` →
+  confirm, with `card_seq` CAS on edits (`modules/message/api_card_action.go`).
+  Today it enqueues **every** action to the sender bot's event queue
+  (`robotEvent:{botUID}`, Redis ZSET, `Robot.MessageExpire` TTL —
+  `modules/robot/api.go:229`) for the sender bot to poll via `/v1/bot/events`.
+- `docs-notify` producer (`main.go:375-388`) is bound to the `notification` User
+  Bot, DM-only, **`ProfileV1` display-only**. `access_requested`
+  (`modules/notify/model.go:64`, `card.go:274` `deliverDocsCardNotification`)
+  builds a v1 `/d/{doc_id}` resource card — no interactive element today.
+- `octo/v1` rejects interactive elements; `octo/v2` permits `Action.Submit` /
+  `Input`. `carddispatch` gates `ProfileV2` producers on a non-empty
+  `ActionEventOwner` (`internal/carddispatch/registry.go:154`).
+- octo-docs-backend has **no outbound IM** and integration is identity-only
+  (`accessRequests.ts:13-17`, per the `card-message-internal-dispatch` brief);
+  it does have approve/deny domain logic. In this design docs-backend adds
+  **only** the decide endpoint — no polling, no IM, no bot token.
+
+### Web / mobile rendering
+
+Out of scope per maintainer direction; this brief does not gate on the client
+rendering of `octo/v2` interactive elements.
+
+## Load-bearing list
+
+Existing behaviors/contracts this change touches — review depth + rule
+injection anchor here:
+
+- **`card_action` ingest routing** (`modules/message/api_card_action.go`) — after
+  the existing validate/claim, branch on `(stored sender_uid, owner,
+  action_type)`: **registered internal route → internal dispatch queue**;
+  external/non-internal sender → existing `EnqueueBotTypedEvent`. An action from
+  a registered internal sender whose owner/action is absent or malformed fails
+  closed and releases the pending claim; it never falls into an unconsumed Bot
+  queue. All current validation, anti-IDOR, visibility, claim, and
+  `event_data` shaping is preserved.
+- **Route registry** (new, static config) — `(sender_uid, owner, action_type) →
+  {url, secret_env, timeout, retry policy}`, with exact HTTPS URLs and no
+  redirects. Config/env driven, never data driven. Bootstrap validates each
+  internal `ProfileV2` producer's `ActionEventOwner` against a route bound to the
+  same sender, so a v2 producer cannot start in a black-hole configuration.
+- **Internal dispatch queue** (new, durable Redis) — one ZSET-based due queue +
+  leased queue + payload hash, with Lua claim/ack/nack/reclaim/defer transitions.
+  Lease ownership is token-bound; finalization heartbeats extend the matching
+  lease, and expired leases are requeued. When a route is already at its
+  per-route concurrency limit, the worker atomically returns the lease to ready
+  with a short delay and rolls back the claim attempt; capacity deferral cannot
+  burn retries, block shutdown, or starve an unrelated route. The live queue
+  TTL is the same `Robot.MessageExpire` source used by D4, preserving the
+  existing action-window/idempotency-window invariant.
+- **In-process dispatcher** (new) — single logical consumer, multi-replica-safe
+  via a Redis claim/lease (any replica pops; processing idempotent → no leader
+  election). Per event: route lookup → signed callback POST (timeout) → on
+  decision render card + notify → ack. Retry/backoff on transport failure;
+  exhaustion → DLQ + alert.
+- **Outbound delivery reliability** (new) — HMAC-SHA256 signing over a versioned
+  canonical string containing method, path, timestamp, event_id, and SHA-256 of
+  the exact body; retry with bounded exponential backoff, per-call timeout, and
+  DLQ. HTTPS is mandatory and redirects are disabled. `event_id` is the replay
+  key, so consumers need no second nonce store. Per-route concurrency is
+  bounded; a general circuit-breaker platform is deliberately deferred.
+- **typed-decision contract** (new wire contract) — request/response schema
+  above; additive-only evolution. `event_id` is a decimal JSON string so
+  JavaScript and other consumers preserve the full `int64` identity without
+  precision loss. `operator_uid` is authenticated by octo but is not
+  authorization: the consumer re-checks its own current ACL. Responses are
+  schema/size-bounded and carry separate `disposition` and authoritative
+  business `state`; the consumer must replay the same stored response for one
+  `event_id`.
+- **Card finalization inside the trust boundary** — extract a producer/sender-
+  bound internal card-mutation primitive from the existing Bot edit path. It
+  retains message ownership, revoke/delete, card-only replacement,
+  `NormalizeContentEdit`, content-hash idempotency, `card_seq` CAS, revision
+  append, and CMD sync. The callback path uses `event_id` as its deterministic
+  `card_seq`. The consumer never calls `/v1/bot/message/edit`.
+- **Standard approval finalizer** — finalization is routed by authoritative
+  `(owner, action_type)`: docs uses its reviewed resource template; every other
+  registered route falls back to a server-owned standard approval template.
+  The fallback mutates the operator's card with `card_seq=event_id` and sends a
+  v1 requester outcome from the shared notification identity. Therefore adding
+  a standard approval consumer does not require an octo-server code change.
+- **Standard approval ingress** — a route with `notify_token_env` dynamically
+  installs one DM-only `octo/v2` producer for its owner. The owner-bound token
+  may submit `ApprovalCard{action_type,title,description,data}` only for action
+  types that explicitly repeat that token binding. octo injects owner,
+  approve/deny decisions, labels, layout, and escaping; callers cannot submit a
+  URL or arbitrary card JSON. Callback and notify secrets must be distinct.
+- **Docs pilot producer** (`main.go` `cardDispatchProducerSpecs`, notify DocsCard
+  path) — `access_requested` upgraded to an `octo/v2` approve/deny producer
+  (`notification` sender, `ProfileV2`, `ActionEventOwner`="docs", DM); two new
+  outcome kinds (`access_granted`/`access_denied`) as v1 display cards for the
+  applicant. Fallback to v1 display when the flag is off.
+- **Producer-bound notify ingress** — docs structured cards require
+  `OCTO_DOCS_NOTIFY_TOKEN`; generic approval cards require the token named by
+  their route. The legacy global token continues to authorize legacy/summary
+  requests but cannot mint any interactive approval card.
+- **Feature flag** — per-owner enable (e.g. `OCTO_DOCS_APPROVAL_CARD_ENABLED`)
+  gating the pilot; interacts with global `OCTO_CARD_MESSAGE_ENABLED` (v2
+  requires it on).
+- **i18n** — approve/deny labels + outcome-card text localized per recipient
+  (`i18n.OutboundLanguage`); any new error codes registered + zh-CN translated;
+  denied card leaks no approver identity/reason.
+- **Space isolation** — approval + outcome cards keep
+  `SpacePolicySystemNotification`, DM-only, recipient membership verified.
+- **Rate limiting** — `card_action` already carries `SharedUIDRateLimiter`; no
+  new hand-rolled counter.
+
+## Out of scope
+
+- **pull / bot-polling for first-party consumers** — superseded by this layer.
+  Genuinely external/third-party bots keep the existing `/v1/bot/events` pull
+  path (this brief does not change it).
+- **octo-docs-backend decide endpoint** — separate repo (§ below); required for
+  E2E, not part of this repo's acceptance.
+- **Web / mobile `octo/v2` rendering** — per maintainer direction.
+- **Multi-approver card fan-out + sync** — phase 1 acts on a single approver's
+  card (edited in place via the `card_action` event's own `message_id`); the
+  `request_id → message_id[]` mapping is deferred.
+- **Group / thread approval cards** — DM-only first.
+- **Rich inputs** (permission-level select, reason text) — approve/deny only;
+  `Input.*` deferred to `card-message-p3-rich-inputs`.
+- **Dynamic / data-driven callback registration** — routes are static config
+  only.
+- **Approver selection policy** (who is B, offline/left fallback) — docs product
+  decision, not octo rails.
+- **Custom outcome templates for future owners** — this task ships docs plus a
+  generic standard-approval template. New custom visual families remain a code
+  review, but standard approval consumers do not.
+- **Exactly-once applicant notification** — business decisions and terminal
+  edits are idempotent, but the applicant notification remains at-least-once.
+  A crash after transport success and before queue ack may produce a rare
+  duplicate, consistent with the existing notify contract; no outbox is added.
+- **General circuit-breaker framework** — bounded concurrency and scheduled
+  retry already protect dependencies in v1.
+
+## Acceptance
+
+Machine-checkable on the octo-server side:
+
+- **Routing**: only `(stored sender_uid, owner, action_type)` matching a
+  registered route is enqueued to the internal queue. An external Bot copying a
+  registered owner/action remains on its Bot queue. An unknown action from a
+  registered internal sender fails closed and is not confirmed. Integration
+  tests assert all three branches.
+- **Dispatch happy path** (stubbed consumer returning `applied`): dispatcher
+  POSTs a signed HTTPS request (valid versioned HMAC over method/path/timestamp/
+  event_id/body hash, redirects disabled) to the
+  registered URL with the typed-decision fields, then renders the final card
+  (via the carddispatch boundary, `card_seq` incremented) and sends the
+  applicant notification. Test asserts signature validity, request shape, card
+  finalized, notify sent, event ack'd. Oversized or malformed callback
+  responses are rejected before rendering.
+- **Retry + DLQ**: consumer 5xx/timeout → dispatcher retries with backoff and
+  does NOT ack; after configured attempts → event lands in DLQ + an alert
+  metric fires; the card is NOT finalized. Test with a failing stub.
+- **Route saturation**: if one route has no available concurrency slot, its
+  claimed lease is token-bound deferred without consuming an attempt; another
+  route remains dispatchable and dispatcher shutdown does not wait for the
+  saturated slot. Tests assert all three properties.
+- **Idempotency / replay**: re-delivering the same `event_id` (dispatcher crash
+  before ack) re-calls decide (consumer returns the same stored typed result)
+  and re-renders the byte-identical terminal frame (`card_seq=event_id`, CAS
+  no-op). The applicant notification is at-least-once; tests assert no duplicate
+  domain transition or card revision and explicitly allow transport duplication
+  at the crash boundary.
+- **SSRF guard**: non-HTTPS, credential-bearing, fragment-bearing, or
+  non-allowlisted exact URLs are rejected at config load; redirects are never
+  followed and proxy environment variables are ignored. Cards never carry a
+  URL. Tests assert each rejection.
+- **Docs pilot flag on**: `POST /v1/internal/notify` with
+  `DocsCard{kind:"access_requested"}` sends an `octo/v2` card (sender
+  `notification`, DM) with approve + deny actions. **Flag off**: unchanged
+  `octo/v1` display card. Both tested.
+- **Notify capability**: legacy `NOTIFY_INTERNAL_TOKEN` cannot submit a
+  `DocsCard`; the docs token can submit only `DocsCard` requests. Missing docs
+  token fails closed.
+- **Generic approval capability**: `notify_token_env` is owner/action-bound;
+  its token sends a server-authored v2 approval card but cannot send payload,
+  summary/docs cards, another owner's action, or callback-only actions. Token
+  reuse across owners or with callback/legacy/docs secrets fails startup.
+- **Outcome cards**: `access_granted`/`access_denied` build v1 display cards;
+  denied card body contains no approver uid/name/reason. Test asserts.
+- **Second-owner onboarding**: a non-docs route (for example
+  `tasks/task.decision`) obtains its initial v2 card through the generic
+  `approval_card` ingress, reaches its callback, uses the standard approval
+  finalizer, edits the operator card, sends the requester outcome, and ACKs.
+  No owner-specific octo-server code or Bot API call is required. Integration
+  coverage asserts the ingress capability and callback/fallback path.
+- **Guard + tooling**: `TestMessageNoLegacyResponseError` and notify/docs guards
+  pass with new files listed; `make i18n-extract-check` + `make i18n-lint` pass;
+  new codes have zh-CN; `golangci-lint run ./...` clean; `go test -race` on
+  touched packages green (dispatcher concurrency test with `-race`).
+- **Observability**: dispatch latency, consumer error rate, retry count, leased
+  count, DLQ depth, and applicant-notify failure use bounded per-owner labels.
+  The repo ships metric definitions and a DLQ replay command/runbook; deployment
+  alert thresholds are an operational follow-up, not claimed as code output.
+- **Protocol consistency**: amend `card-message-interaction`,
+  `card-message-p2-action-loop`, `card-message-internal-dispatch`, and
+  `docs/card-protocol.md` to describe the sender-bound first-party callback
+  branch while preserving the third-party Bot pull contract.
+
+## Cross-repo dependency (octo-docs-backend — out of this repo's acceptance)
+
+The **entire** docs-side work is one endpoint:
+
+- Follow [`docs/card-action-callback-consumer.md`](../../../docs/card-action-callback-consumer.md)
+  for the wire schema, canonical HMAC, TypeScript verification example,
+  idempotency transaction, typed results, and retry contract.
+
+- Implement `POST <decide-url>`: require HTTPS at deployment; verify the
+  versioned HMAC signature + timestamp freshness + `event_id` replay key;
+  idempotent by `event_id`; re-check `operator_uid` is still a document admin
+  (octo authenticated it, but authorization stays local); `pending →
+  approved/denied` CAS (concurrent clicks: first valid decision wins). Persist
+  and replay the same typed response for one `event_id`:
+  - `disposition`: `applied|replayed|forbidden|conflict|not_found`.
+  - `state`: `pending|approved|denied|cancelled`.
+  - bounded `requester_uid` is required for `approved` / `denied` (octo must
+    notify the applicant); it may be omitted for other states. Display fields
+    remain optional and are consumed only by reviewed octo templates.
+- No polling, no bot token, no card/IM/notify code. Grant is source-of-truth;
+  the applicant notification is octo's best-effort render (retry independent of
+  the grant).
+
+## Locked implementation decisions (maintainer-confirmed 2026-07-15)
+
+1. **Sender** — shared `notification` User Bot; callback consumers need no Bot
+   token. Sender binding is part of every internal callback route.
+2. **Transport auth** — HMAC-SHA256 over a versioned canonical string, over
+   HTTPS. `event_id` is the replay key; no second nonce store and no mTLS in v1.
+   Secrets are referenced by env name and never stored in shared config/logs.
+3. **Queue** — Redis ZSET ready/leased/DLQ state machine with token-bound Lua
+   claim/ack/nack/reclaim/defer. Capacity defer is attempt-neutral and scheduled
+   after a short delay. No leader election and no Redis Stream abstraction.
+4. **Standard card lifecycle** — octo owns the generic initial approval
+   template, final template, requester outcome, and shared mutation primitive.
+   A route-bound notify token provides the only generic ingress. Docs binds a
+   specialized template; all other routes use the standard fallback. A new
+   standard consumer needs only secrets + route + decide endpoint; a genuinely
+   new visual template still requires an octo-server code review.
+5. **DLQ** — bounded retries, then DLQ retained 30 days; alert + manual replay
+   command/runbook. No automatic DLQ replay in v1.
+6. **Protection** — per-route concurrency + timeout + exponential backoff;
+   general circuit breaker deferred.
+7. **Retention** — live queue TTL equals `Robot.MessageExpire` (default 7 days),
+   keeping D4 idempotency and actionable event windows aligned.
+8. **Delivery semantics** — callback decision and terminal card mutation are
+   idempotent; applicant notification is explicitly at-least-once.

--- a/.octospec/tasks/card-action-callback-dispatch/context.yaml
+++ b/.octospec/tasks/card-action-callback-dispatch/context.yaml
@@ -1,0 +1,14 @@
+injected:
+  - id: space-isolation
+    source: repo
+  - id: trust-boundary
+    source: repo
+  - id: error-handling
+    source: repo
+  - id: rate-limit
+    source: repo
+  - id: testing
+    source: repo
+  - id: commit-style
+    source: repo
+brief: .octospec/tasks/card-action-callback-dispatch/brief.md

--- a/.octospec/tasks/card-message-interaction/brief.md
+++ b/.octospec/tasks/card-message-interaction/brief.md
@@ -21,6 +21,10 @@ briefs are confirmed, and P1/P2 may land in adjacent releases.
 
 ## Goal
 
+> This brief is authoritative for the external/third-party Bot pull and edit
+> contract. First-party callback routing and finalization are defined only by
+> [`../card-action-callback-dispatch/brief.md`](../card-action-callback-dispatch/brief.md).
+
 Make cards interactive: a user taps a button (or fills inputs and submits) on
 a bot-sent card, the owning bot receives a `card_action` event, processes it,
 and rewrites the card so all three clients converge on the new state ("button

--- a/.octospec/tasks/card-message-internal-dispatch/brief.md
+++ b/.octospec/tasks/card-message-internal-dispatch/brief.md
@@ -17,6 +17,12 @@ source: self
 
 ## Goal
 
+> This brief owns internal card origination only. Current first-party action
+> routing and finalization are defined by
+> [`../card-action-callback-dispatch/brief.md`](../card-action-callback-dispatch/brief.md);
+> the external Bot pull contract remains in
+> [`../card-message-interaction/brief.md`](../card-message-interaction/brief.md).
+
 Add `internal/carddispatch` as the only supported path for an in-process
 business module to originate an `InteractiveCard` (`type=17`) message, so that
 server-side scenarios — smart-summary results delivered/forwarded into chats as
@@ -268,53 +274,25 @@ with different readiness):
   finalization, provenance, quotas, idempotency, audit, and transport. The
   generic contract is `../user-resource-share-card/brief.md`; smart-summary is
   the initial use case, while a future docs user-share card onboards as another
-  provider and does not require a docs Bot. Automated docs notifications/
-  actions, if desired, remain a separate Bot producer problem. The generic
+  provider and does not require a docs Bot. Automated docs notifications are
+  defined by [`docs-notify-contract.md`](./docs-notify-contract.md); access
+  approval actions are defined by
+  [`../card-action-callback-dispatch/brief.md`](../card-action-callback-dispatch/brief.md).
+  The generic
   path is **not Bot API OBO**: no S2S caller
   supplies `actor_uid`, no request contains `from_uid`, and arbitrary card
   payloads remain forbidden.
 
-### Interactive cards (octo/v2): how future action scenarios fit
+### Interactive cards (`octo/v2`)
 
-Foreseeable scenarios where the recipient acts on the card — merge a PR,
-close an issue, approve an access/authorization request — are deliberately
-accommodated by this contract and require **no new dispatch machinery**. The
-pilot's cards are display-only (`octo/v1`) with a deep link, but nothing in
-the pilot blocks a later interactive producer. What changes for an
-interactive producer is what it must bring, not how it dispatches:
+This task defines only the trusted origination boundary for an `octo/v2` card.
+Do not derive action delivery, consumer responsibilities, retries, or terminal
+mutation from this older dispatch brief:
 
-- **The Decision 5 gate is the whole difference.** A producer registered for
-  `octo/v2` must name the existing bot event consumer that owns `card_action`
-  for its sender bot; the registry refuses the interactive profile otherwise
-  (already in Acceptance › Capability and configuration). Sending an
-  interactive card goes through the exact same pipeline.
-- **The action loop is the existing one**, hardened by
-  card-message-appbot-trust: recipient taps → `POST /v1/message/card/action`
-  → live sender-trust check → `card_action` event on the **sender bot's**
-  event queue → the bot's owning service polls `/v1/bot/events` and ACKs via
-  Bot API. The dispatcher never adds a second callback route (Out of scope
-  holds).
-- **Sender identity choice is therefore scenario-driven.** An interactive
-  producer's bot must be backed by a service that actually runs the event
-  poll loop: e.g. a GitHub-integration bot whose sidecar executes merge/close
-  against GitHub, or a docs bot whose backend executes the approval, then
-  reflects the outcome by **editing the card** through the existing card-edit
-  path (`card_seq` / `pkg/cardrevision`) instead of sending a new card.
-  Display-only producers (the pilot) may use consumer-less bots; upgrading a
-  producer to `octo/v2` later means giving its bot an event consumer first —
-  or registering a separate producer bound to a bot that has one.
-- **Executor responsibilities stay outside the dispatcher**: authorize the
-  acting user in the target system at execution time (a visible button is
-  NOT authorization — the event's actor identity must be checked against the
-  external system's ACL), and handle the poll/ACK at-least-once delivery
-  idempotently (dedup on event/card identity before executing side effects
-  like a merge).
-
-These scenarios (`devops` PR/issue cards, `docs` approval cards) are far
-candidates: each onboards with its own producer table row, a named event
-consumer, and its own brief for the executor side. They are listed here so
-the registry/config schema is designed with the action-owner field from day
-one rather than retrofitted.
+- first-party callback routing and finalization:
+  [`../card-action-callback-dispatch/brief.md`](../card-action-callback-dispatch/brief.md);
+- external/third-party Bot pull and edit contract:
+  [`../card-message-interaction/brief.md`](../card-message-interaction/brief.md).
 
 ### Card template and deep-link (designed, confirmed 2026-07-13)
 
@@ -381,7 +359,7 @@ not implement a mutable generic "send as any UID" service.
 | Owning module / constructor | `modules/notify`; it obtains its producer-bound `Sender` from the single registry composed at server bootstrap (exact wiring resolved in implementation per Decision 11 — must fit the `register.AddModule` module system without mutable package-global registration) |
 | Sender bot UID configuration source | **Amended 2026-07-14: reuse the static `notification` User Bot** provisioned by `ensureNotifyBot` (`user` + `app` + `robot.status=1`). Summary cards, generic text notifications, and summary-card text fallback share one DM identity. This supersedes the dedicated `summary` Bot decision from 2026-07-13; the producer-bound capability still prevents generic notify callers from originating cards |
 | Allowed channel types | DM (person) only at pilot; group/thread widening is a separate reviewed change tied to smart-summary origin回发, and that review must include a per-channel rate rule and the cluster-cap decision. Group/thread sends use the member-exempt posting mode (Decision 4): the bot joins no group, member list and 群人数 unchanged |
-| Allowed card profiles / action-event owner | `octo/v1` (display-only) only; `octo/v2` forbidden — the notification Bot has no compatible summary action-event consumer polling `/v1/bot/events`, so no one could own `card_action` (see Method › Interactive cards for the upgrade path) |
+| Allowed card profiles / action-event owner | `octo/v1` (display-only) only; an interactive summary workflow would require its own reviewed owner/action route under [`../card-action-callback-dispatch/brief.md`](../card-action-callback-dispatch/brief.md) |
 | Required Space source | `NotifyReq.space_id` supplied by the internal caller and member-verified by notify's `memberCache`; the dispatcher independently re-verifies live Space/membership (Decision 3). DM policy = system-notification mode (space-member DM, Decision 4) |
 | Expected peak concurrency / QPS | max-in-flight **20** per process (mirrors notify's existing bounded send pool) — **confirmed 2026-07-13** |
 | Business retry/idempotency requirement | smart-summary already retries per recipient with `summary_notification` dedup state ⇒ at-least-once from the caller side; a transport-ambiguous failure may duplicate a card; dispatcher stays single-attempt (Decision 8). **Confirmed 2026-07-13: duplicates are acceptable for notification cards; no outbox** |
@@ -457,10 +435,9 @@ not implement a mutable generic "send as any UID" service.
    transport metadata are impossible through the API. Initial scope rejects
    mentions; a later mention feature must extend the dispatcher and retain the
    post-expansion recheck rather than bypass it.
-   An `octo/v2` producer must name the existing bot event consumer that owns
-   `card_action`; a producer with no such consumer is restricted to the
-   non-interactive profile. The dispatcher does not create a second callback
-   route for internal modules.
+   An `octo/v2` producer must declare its action owner. Action routing and
+   consumer ownership are validated by the contracts linked in
+   “Interactive cards”; this origination dispatcher does not define them.
 6. **Dispatcher owns an immutable input snapshot.** The API accepts a standard
    Adaptive Card document as bytes (or defensively deep-copies an equivalent
    typed value) before validation. It never mutates or retains caller-owned maps
@@ -649,8 +626,9 @@ caller must map them through that endpoint's registered `errcode` facade.
   unchanged.
 - Incoming Webhook card actions/callbacks; webhook identities still have no bot
   event consumer.
-- A new internal `card_action` callback/event bus. Interactive profiles retain
-  the existing sender-bot event ownership and poll/ACK contract.
+- Card-action delivery, callback reliability, and terminal finalization; these
+  belong to [`../card-action-callback-dispatch/brief.md`](../card-action-callback-dispatch/brief.md)
+  and the public Bot interaction contract linked above.
 - OBO, fan-out inside the dispatcher, streams, subscribers, transient/no-persist
   cards, mention expansion, broadcast cards, typing/read receipts, or card
   edits/revisions.

--- a/.octospec/tasks/card-message-internal-dispatch/docs-notify-contract.md
+++ b/.octospec/tasks/card-message-internal-dispatch/docs-notify-contract.md
@@ -1,17 +1,23 @@
 # docs-notify 卡片通知 — 跨仓 ingress 契约
 
+> 本文是 docs-backend 调用 `/v1/internal/notify` 的唯一入站契约。访问审批的
+> action 路由、可靠投递、终态与部署引用
+> [`docs/card-action-callback-dispatch.md`](../../../docs/card-action-callback-dispatch.md)；
+> 消费方验签、幂等和 typed result 引用
+> [`docs/card-action-callback-consumer.md`](../../../docs/card-action-callback-consumer.md)，
+> 本文不重复维护该流程。
+
 > 仓内契约，供 octo-server `docs-notify` 生产者与 `octo-docs-backend` 对齐,PR
 > 打开后整理成英文 issue/comment 同步给 `Mininglamp-OSS/octo-docs-backend`。
 > 关联:brief.md(本目录)、summary-notify-contract.md(姊妹契约)、
 > handoff.md、`docs/docs-notify-card.md`。
-> 状态:契约草案,由本 PR 落地 `pkg/cardtmpl` / `modules/notify` 侧。
-> 最后更新 2026-07-14。
+> 状态:已实现。最后更新 2026-07-15。
 
 ## 背景一句话
 
 `docs-notify` 是 `internal/carddispatch` 的**第二个**生产者（首个见
 `summary-notify-contract.md`）,把 docs-backend 想推给用户的**自动化系统通知**
-（分享、评论、访问申请）升级为 `octo/v1` 展示卡片,复用 `notification` User Bot
+（分享、评论、访问申请）升级为服务端模板卡片,复用 `notification` User Bot
 身份 → 用户会话列表**不新增**系统 Bot 会话。docs-backend 不构造 type-17 map、
 不发文本兜底、不做卡片模板 —— 只发**结构化字段** `DocsCardFields`,一切文案 /
 布局 / deep-link / i18n 由 octo-server owning。
@@ -21,17 +27,20 @@
 
 ## 契约要点（锁定项）
 
-1. **同端点、同 token、同粒度**:仍是 `POST /v1/internal/notify`,头
-   `X-Internal-Token`（复用 `NOTIFY_INTERNAL_TOKEN`;fail-closed）,**一请求
+1. **同端点、独立 token、同粒度**:仍是 `POST /v1/internal/notify`,头
+   `X-Internal-Token: <OCTO_DOCS_NOTIFY_TOKEN>`（fail-closed；不得与 legacy、
+   callback 或其它 owner token 复用），**一请求
    一收件人**（`targets` 单元素）。`space_id` / `service` / `actor_uid` 语义
    与 summary 完全相同,octo-server 已有的 dedup / actor 排除 / memberCache
    / ensureNotifyBotReady / carddispatch 派发全部复用。
-2. **三选一互斥**:`Payload` / `Card`（summary） / `DocsCard`（docs）**只能
-   出现一个**。多于一个 → 400 `err.server.notify.card_invalid`;全都缺失
+2. **结构化入口互斥**:`Payload` / `Card`（summary） / `DocsCard`（docs） /
+   `ApprovalCard`（通用审批）**只能出现一个**。多于一个 → 400
+   `err.server.notify.card_invalid`;全都缺失
    → 400 legacy「payload不能为空」。字段级检测:
    - `req.Payload != nil` 计入(包括空 `{}` —— 呼应「显式意图」)。
    - `req.Card != nil` 计入。
    - `req.DocsCard != nil` 计入。
+   - `req.ApprovalCard != nil` 计入。
 3. **禁止客户端手搓 type-17 map**:Decision 14 仍生效 —— `payload` 若被
    `cardmsg.IsCardPayload` 判为卡片(`type=17`)一律 400
    `err.server.notify.card_not_allowed`,无论走 `Card` 还是 `DocsCard`。
@@ -53,7 +62,7 @@
 
 ```jsonc
 POST /v1/internal/notify
-X-Internal-Token: <NOTIFY_INTERNAL_TOKEN>
+X-Internal-Token: <OCTO_DOCS_NOTIFY_TOKEN>
 {
   "space_id":  "spc_xxx",              // 现状:必填,server 用 memberCache 校验收件人
   "service":   "docs-service",         // 现状不变
@@ -61,6 +70,7 @@ X-Internal-Token: <NOTIFY_INTERNAL_TOKEN>
   "actor_uid": "",                     // 现状:通知场景一般留空
   "docs_card": {                       // 新增:非空即走 docs-notify 卡片 producer
     "doc_id":     "d_20260713_abcd",   // ★ 见下「标识」
+    "request_id": "",                  // access_requested + 审批开关开启时必填
     "kind":       "shared",            // "shared" | "commented" | "access_requested"
     "title":      "产品设计方案",         // 原始标题(server 负责转义/截断)
     "actor_name": "Alice",             // 预格式化的操作人显示名;空则用「有人」/「Someone」兜底
@@ -94,6 +104,7 @@ X-Internal-Token: <NOTIFY_INTERNAL_TOKEN>
 | card 字段 | docs-backend 来源(建议) |
 | --- | --- |
 | `doc_id` | 文档实体的 `id` 字段(与 `/d/:docId` 路由 taskId 同义) |
+| `request_id` | 访问申请的稳定业务 ID；`access_requested` 审批卡用于幂等/CAS |
 | `kind` | 触发场景:分享 = `shared`;评论 = `commented`;访问申请 = `access_requested` |
 | `title` | 文档 `title` 字段(空则用「无标题」兜底 —— docs-backend 侧决策) |
 | `actor_name` | 触发者的显示名(docs-backend 已 resolve;匿名场景可留空) |
@@ -105,8 +116,9 @@ X-Internal-Token: <NOTIFY_INTERNAL_TOKEN>
 - `docs-notify` producer 绑定已有 `notification` Bot(`user`+`app`+
   `robot.status=1`),卡片和纯文本降级复用其 provisioning/readiness;
   不新增专用 `docs` Bot。
-- 注册 `docs-notify` producer(DM/`octo/v1`/system-notification/MaxInFlight
-  20),经 `SenderFromContext` 注入 `modules/notify`。与 `summary-notify` 同
+- 注册 `docs-notify` producer(DM/system-notification/MaxInFlight 20)：默认
+  `octo/v1`，启用访问审批时增加 `octo/v2`;经 `SenderFromContext` 注入
+  `modules/notify`。与 `summary-notify` 同
   `ProducerSpec` shape,仅 ID 不同(见 `main.cardDispatchProducerSpecs`)。
 - `docs_card` 分支:`memberCache.verify` → `cardtmpl.BuildDocsResourceCard` →
   每个成员 `sender.Send` → 汇总 `delivered/filtered`。**建卡/配置(如
@@ -129,8 +141,7 @@ X-Internal-Token: <NOTIFY_INTERNAL_TOKEN>
    建议实现要点:
    - 每场景一个函数(`NotifyDocShared` / `NotifyDocCommented` /
      `NotifyDocAccessRequested`),内部塞 `Kind` 常量;
-   - 复用 `X-Internal-Token`(`NOTIFY_INTERNAL_TOKEN` = 同一 token,
-     docs-backend 与 smart-summary 共用);
+   - 使用独立 `X-Internal-Token: <OCTO_DOCS_NOTIFY_TOKEN>`;
    - per-recipient dedup(避免同一评论触发多次通知);
    - 消费 `NotifyResp{delivered,filtered}` —— 只认 `delivered[]` 判真送达,
      `filtered` 内标记为 `not_space_member` / `busy` / `dispatch_failed` 的
@@ -146,9 +157,10 @@ X-Internal-Token: <NOTIFY_INTERNAL_TOKEN>
 
 - 用户主动分享文档到 DM/群/子区 —— 见 `../user-resource-share-card/brief.md`,
   发送方为分享用户本人,非 Bot proxy。
-- 访问申请的交互(「同意 / 拒绝」按钮) —— 需要 producer 升级到 `octo/v2` +
-  绑定一个跑 `/v1/bot/events` 的 action-owner;docs-backend 目前是
-  TS/Hocuspocus,不跑 Go bot 事件轮询,升级为独立议题。
+- 访问申请的点击、decide 回调和终态 —— 由独立的
+  [callback dispatch](../../../docs/card-action-callback-dispatch.md) /
+  [callback consumer](../../../docs/card-action-callback-consumer.md) 文档定义，不在本
+  ingress 契约重复。
 - 群/子区自动通知(如「这份文档被评论了」推到关联群) —— 需要 producer
   widening 到 group/thread channel type,同步需要 per-channel rate rule +
   cluster-wide cap 决策(brief › Industry practice alignment)。

--- a/.octospec/tasks/card-message-internal-dispatch/handoff.md
+++ b/.octospec/tasks/card-message-internal-dispatch/handoff.md
@@ -2,7 +2,8 @@
 
 > Forward-looking guide for the next stage. The spec is `brief.md` in this
 > directory; this file says **where we are** and **what to do next**.
-> Last updated 2026-07-14.
+> Last updated 2026-07-15. This handoff covers the original dispatch foundation
+> and summary pilot; later docs approval work is referenced rather than restated.
 
 ## TL;DR
 
@@ -148,9 +149,13 @@ Each of these is its own follow-up PR after the pilot is live.
   server-minted card flow for **DM, group, and thread** targets. The sharing
   user is the sender; `notification` does not proxy the share. Generic contract:
   `../user-resource-share-card/brief.md`.
-- **Docs user share:** later onboards as another resource provider and does not
-  need a docs Bot. Automated docs notifications/actions would be a different
-  Bot-producer task.
+- **Docs paths:** user share remains a separate resource provider. Automated
+  docs notifications are defined by [`docs-notify-contract.md`](./docs-notify-contract.md);
+  access approval actions are defined by
+  [`../card-action-callback-dispatch/brief.md`](../card-action-callback-dispatch/brief.md),
+  with separate
+  [operations](../../../docs/card-action-callback-dispatch.md) and
+  [consumer integration](../../../docs/card-action-callback-consumer.md) guides.
 
 ## Locked decisions (2026-07-13; sender amended 2026-07-14)
 

--- a/.octospec/tasks/card-message-internal-dispatch/summary-notify-contract.md
+++ b/.octospec/tasks/card-message-internal-dispatch/summary-notify-contract.md
@@ -3,7 +3,7 @@
 > 仓内草稿,供 octo-server P2(`summary-notify` pilot）实现时对齐,PR 打开后整理成英文
 > issue/comment 同步给 `Mininglamp-OSS/octo-smart-summary`。
 > 关联:brief.md(本目录)、handoff.md、docs-notify-contract.md(姊妹契约,
-> 同一 ingress 端点、同 token、同响应 shape)、octo-server PR #577(P1 地基)、
+> 同一 ingress 端点、独立 capability token、同响应 shape)、octo-server PR #577(P1 地基)、
 > #579(pilot)、#580(共用 notification Bot)。
 > 状态:已实现;`docs-notify` 姊妹 producer 于同 PR 落地(见 handoff)。
 > 最后更新 2026-07-14。

--- a/.octospec/tasks/card-message-p2-action-loop/brief.md
+++ b/.octospec/tasks/card-message-p2-action-loop/brief.md
@@ -17,6 +17,11 @@ source: self
 
 ## Goal
 
+> This PR-B brief is authoritative for the external/third-party Bot pull
+> implementation. First-party callback routing and terminal rendering are
+> defined only by
+> [`../card-action-callback-dispatch/brief.md`](../card-action-callback-dispatch/brief.md).
+
 Ship the **first PR of card message P2** (parent contract:
 `.octospec/tasks/card-message-interaction/brief.md`, decisions D1–D12): the
 **interaction closed loop** so a user can tap a button (or fill inputs and

--- a/docs/card-action-callback-consumer.md
+++ b/docs/card-action-callback-consumer.md
@@ -1,0 +1,402 @@
+# Card action callback consumer integration
+
+This guide is for first-party services that consume interactive card actions
+from octo-server. A consumer implements one HTTPS decision endpoint; it does not
+poll a Bot queue, hold a Bot token, or call message/card APIs.
+
+For octo-server route configuration, monitoring, DLQ replay, and rollout, see
+[`card-action-callback-dispatch.md`](./card-action-callback-dispatch.md).
+
+## Onboarding contract
+
+Before enabling a producer:
+
+1. Deploy an exact HTTPS endpoint with no redirect.
+2. Provision a callback HMAC secret of at least 32 random bytes in both
+   services. For generic approval ingress, provision a second, distinct notify
+   bearer token of the same minimum length.
+3. Give octo-server operators the exact URL, sender UID, owner, action type,
+   timeout, retry policy, and secret environment-variable name.
+4. Verify HMAC over the raw request body before JSON decoding.
+5. Enforce timestamp freshness and durable idempotency by `event_id`.
+6. Re-check the operator's current authorization in the consumer domain.
+7. Apply the domain decision with a compare-and-swap and persist the exact typed
+   response in the same transaction.
+
+The callback is at-least-once. A timeout, process crash, or lost response can
+cause the same `event_id` to be delivered again.
+
+## Standard approval onboarding
+
+For a consumer using the standard terminal visual, no owner-specific
+octo-server code is required:
+
+1. Add the exact sender-bound callback route to `OCTO_CARD_ACTION_ROUTES`, set
+   `notify_token_env`, and add its URL to `OCTO_CARD_ACTION_ALLOWED_URLS`.
+2. Implement this signed decide contract and return a typed result.
+3. Call `/v1/internal/notify` with the route-bound token and an
+   `approval_card` containing `action_type`, display text, and bounded domain
+   identifiers.
+
+Example initial-card request:
+
+```json
+{
+  "space_id": "space-1",
+  "service": "smart-summary",
+  "targets": ["user-b"],
+  "actor_uid": "user-a",
+  "approval_card": {
+    "action_type": "summary.publish.decision",
+    "title": "Publish summary",
+    "description": "Review before publishing",
+    "data": {"task_no": "task-1"}
+  }
+}
+```
+
+Send `X-Internal-Token: <the value named by notify_token_env>`. The token fixes
+`sender_uid` and `owner`; callers cannot select either. It can mint cards only
+for action types whose route repeats that `notify_token_env`. The server owns
+the Allow/Deny labels, action IDs, reserved metadata, layout, escaping, and
+profile. The request accepts neither callback URLs nor arbitrary card JSON.
+
+The generic request exposes consumer-specific identifiers in `data`. The
+docs-only `doc_id` and `request_id` top-level conveniences may be absent. For a
+standard approval result, `display.title` is optional but recommended; octo
+uses only that reviewed display field, removes all actions, renders the status,
+and sends a v1 requester outcome. It ignores callback-authored URLs, card JSON,
+reasons, and arbitrary display fields.
+
+Docs uses the same callback transport contract but keeps its existing
+`DocsCard`/`OCTO_DOCS_NOTIFY_TOKEN` ingress and specialized deep-link/template
+binding. A genuinely new visual family still requires octo-server review.
+
+## HTTP request
+
+octo-server sends `POST` to the configured exact path with:
+
+| Header             | Value                                                           |
+| ------------------ | --------------------------------------------------------------- |
+| `Content-Type`     | `application/json`                                              |
+| `X-Octo-Timestamp` | Unix timestamp in seconds                                       |
+| `X-Octo-Event-ID`  | Decimal event ID; must exactly match the body `event_id` string |
+| `X-Octo-Signature` | `v1=<lowercase hex HMAC-SHA256>`                                |
+
+Example request body:
+
+```json
+{
+  "event_id": "9007199254740993",
+  "action_id": "approve",
+  "decision": "approve",
+  "operator_uid": "user-b",
+  "doc_id": "doc-1",
+  "request_id": "request-1",
+  "inputs": {},
+  "data": {
+    "owner": "docs",
+    "action_type": "access_request.decision",
+    "decision": "approve",
+    "doc_id": "doc-1",
+    "request_id": "request-1"
+  },
+  "message_id": "190001234567890",
+  "channel_id": "notification",
+  "channel_type": 1,
+  "space_id": "space-1",
+  "acted_at": 1784073600
+}
+```
+
+`operator_uid` is an authenticated identity assertion from octo-server, not an
+authorization grant. The consumer must still verify that this user can decide
+the referenced request. `data`, `channel_id`, and display fields must not be
+used as substitutes for consumer-owned ACL or request state.
+
+`event_id` is deliberately encoded as a decimal string because its full `int64`
+range exceeds JavaScript's safe integer range. Store and compare it as a string;
+do not coerce it to a JavaScript `number`.
+
+`inputs` is always a JSON object; actions without form inputs receive `{}`.
+
+## Signature verification
+
+The canonical UTF-8 bytes are:
+
+```text
+v1\nPOST\n<escaped-path>\n<timestamp>\n<event-id>\n<sha256-of-exact-body>
+```
+
+The signature is `v1=` followed by the lowercase hex HMAC-SHA256 of that
+canonical value. Hash the exact bytes received on the wire. Re-serializing JSON
+before verification changes the signature.
+
+The following Express example uses a fixed callback path and a five-minute
+freshness window. Mount `express.raw` for this route before any global
+`express.json` middleware.
+
+```ts
+import { createHash, createHmac, timingSafeEqual } from "node:crypto";
+import express, { type Request, type Response } from "express";
+
+const app = express();
+const callbackPath = "/v1/card-actions/decide";
+const maxSkewSeconds = 300;
+const configuredSecret = process.env.OCTO_DOCS_CARD_ACTION_SECRET;
+
+type DecisionRequest = {
+  event_id: string;
+  action_id: string;
+  decision: string;
+  operator_uid: string;
+  doc_id?: string;
+  request_id?: string;
+  inputs: Record<string, unknown>;
+  data?: Record<string, unknown>;
+  message_id: string;
+  channel_id: string;
+  channel_type: number;
+  space_id?: string;
+  acted_at: number;
+};
+
+type DecisionResult = {
+  disposition: "applied" | "replayed" | "forbidden" | "conflict" | "not_found";
+  state: "pending" | "approved" | "denied" | "cancelled";
+  requester_uid?: string;
+  display?: Record<string, string>;
+};
+
+declare function decideIdempotently(
+  request: DecisionRequest,
+): Promise<DecisionResult>;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseDecisionRequest(value: unknown): DecisionRequest {
+  if (!isRecord(value)) throw new Error("request must be an object");
+  const requiredStrings = [
+    "action_id",
+    "decision",
+    "operator_uid",
+    "message_id",
+  ];
+  if (
+    requiredStrings.some(
+      (key) => typeof value[key] !== "string" || value[key] === "",
+    )
+  ) {
+    throw new Error("missing required string");
+  }
+  if (
+    typeof value.event_id !== "string" ||
+    !/^[1-9][0-9]*$/.test(value.event_id)
+  ) {
+    throw new Error("invalid event_id");
+  }
+  if (
+    typeof value.channel_type !== "number" ||
+    !Number.isInteger(value.channel_type) ||
+    typeof value.acted_at !== "number" ||
+    !Number.isSafeInteger(value.acted_at)
+  ) {
+    throw new Error("invalid numeric field");
+  }
+  if (
+    !isRecord(value.inputs) ||
+    (value.data !== undefined && !isRecord(value.data))
+  ) {
+    throw new Error("invalid action data");
+  }
+  for (const key of ["doc_id", "request_id", "space_id"]) {
+    if (value[key] !== undefined && typeof value[key] !== "string") {
+      throw new Error(`invalid ${key}`);
+    }
+  }
+  return value as unknown as DecisionRequest;
+}
+
+if (!configuredSecret || Buffer.byteLength(configuredSecret) < 32) {
+  throw new Error(
+    "OCTO_DOCS_CARD_ACTION_SECRET must contain at least 32 bytes",
+  );
+}
+const secret = configuredSecret;
+
+function verifyOctoSignature(
+  rawBody: Buffer,
+  timestamp: string,
+  eventID: string,
+  signature: string,
+  nowSeconds = Math.floor(Date.now() / 1000),
+): boolean {
+  if (!/^[1-9][0-9]*$/.test(eventID) || !/^[0-9]+$/.test(timestamp))
+    return false;
+  if (!/^v1=[0-9a-f]{64}$/.test(signature)) return false;
+
+  const sentAt = Number(timestamp);
+  if (
+    !Number.isSafeInteger(sentAt) ||
+    Math.abs(nowSeconds - sentAt) > maxSkewSeconds
+  ) {
+    return false;
+  }
+
+  const bodyHash = createHash("sha256").update(rawBody).digest("hex");
+  const canonical = [
+    "v1",
+    "POST",
+    callbackPath,
+    timestamp,
+    eventID,
+    bodyHash,
+  ].join("\n");
+  const expected = createHmac("sha256", secret).update(canonical).digest();
+  const provided = Buffer.from(signature.slice(3), "hex");
+  return (
+    provided.length === expected.length && timingSafeEqual(provided, expected)
+  );
+}
+
+app.post(
+  callbackPath,
+  express.raw({ type: "application/json", limit: "64kb" }),
+  async (req: Request, res: Response) => {
+    const rawBody = Buffer.isBuffer(req.body) ? req.body : Buffer.alloc(0);
+    const timestamp = req.header("X-Octo-Timestamp") ?? "";
+    const eventID = req.header("X-Octo-Event-ID") ?? "";
+    const signature = req.header("X-Octo-Signature") ?? "";
+
+    if (!verifyOctoSignature(rawBody, timestamp, eventID, signature)) {
+      res.status(401).json({ error: "unauthorized" });
+      return;
+    }
+
+    let request: DecisionRequest;
+    try {
+      request = parseDecisionRequest(JSON.parse(rawBody.toString("utf8")));
+    } catch {
+      res.status(400).json({ error: "invalid_request" });
+      return;
+    }
+    if (request.event_id !== eventID) {
+      res.status(401).json({ error: "unauthorized" });
+      return;
+    }
+
+    try {
+      const result = await decideIdempotently(request);
+      res.status(200).json(result);
+    } catch {
+      // Log the internal cause with event_id; never expose it to octo-server.
+      res.status(503).json({ error: "temporarily_unavailable" });
+    }
+  },
+);
+```
+
+`DecisionRequest`, runtime validation, and `decideIdempotently` are
+consumer-owned. The example validates required transport fields and permits
+additive request fields; add consumer-domain bounds before accessing storage.
+The transaction must follow this order:
+
+```text
+BEGIN
+  SELECT stored_response FROM card_action_receipt WHERE event_id = ?
+  if found: COMMIT and replay stored_response
+
+  lock the domain request identified by request_id/doc_id
+  verify the request belongs to the expected Space/resource
+  re-check operator_uid is currently authorized
+  CAS pending -> approved/denied (first valid decision wins)
+  INSERT card_action_receipt(event_id, stored_response) with UNIQUE(event_id)
+COMMIT
+return stored_response
+```
+
+If concurrent requests race on the same `event_id`, the unique-key loser must
+reload and return the already stored response. Never perform the domain update
+outside the transaction that records the idempotency result.
+
+## Typed response
+
+Return HTTP 200 with exactly these top-level fields:
+
+```ts
+type DecisionResult = {
+  disposition: "applied" | "replayed" | "forbidden" | "conflict" | "not_found";
+  state: "pending" | "approved" | "denied" | "cancelled";
+  requester_uid?: string;
+  display?: Record<string, string>;
+};
+```
+
+Applied approval example:
+
+```json
+{
+  "disposition": "applied",
+  "state": "approved",
+  "requester_uid": "user-a",
+  "display": { "title": "Roadmap" }
+}
+```
+
+An idempotent replay must return the exact stored result for the same
+`event_id`. If the original result was the applied approval above, repeat that
+same result; do not rewrite its disposition merely because this HTTP delivery
+is a replay. `replayed` is valid when it was the authoritative result initially
+stored for that event, for example when the business transition had already
+been committed by another decision path:
+
+```json
+{
+  "disposition": "replayed",
+  "state": "approved",
+  "requester_uid": "user-a",
+  "display": { "title": "Roadmap" }
+}
+```
+
+Business rejection is also a typed HTTP 200 response, not an HTTP 403:
+
+```json
+{ "disposition": "forbidden", "state": "pending" }
+```
+
+`requester_uid` is required whenever `state` is `approved` or `denied`, because
+octo-server must notify the applicant. Responses are limited to 64 KiB and the
+current decoder rejects unknown top-level fields. Coordinate schema additions
+with an octo-server release.
+
+For standard approval routes, the originating card must carry an authoritative
+`space_id`; terminal requester notification fails closed without it.
+
+## HTTP and retry behavior
+
+| Consumer response                             | octo-server behavior                               |
+| --------------------------------------------- | -------------------------------------------------- |
+| `2xx` + valid typed body                      | Finalize card and applicant notification, then ACK |
+| `408`, `429`, or `5xx`                        | Retry with bounded exponential backoff             |
+| Other `4xx`                                   | Permanent rejection; move to DLQ                   |
+| `3xx`                                         | Redirect rejected; move to DLQ                     |
+| Timeout / transport failure                   | Retry                                              |
+| Invalid, oversized, or unknown-field response | Retry, then DLQ after exhaustion                   |
+
+Do not return HTTP 403/404 for normal domain outcomes; use the typed
+`disposition` values so octo-server can render the authoritative state.
+
+## Consumer test checklist
+
+- valid signature over exact raw body;
+- one-byte body mutation fails verification;
+- stale timestamp fails verification;
+- header/body `event_id` mismatch fails verification;
+- duplicate `event_id` replays one stored response without a second transition;
+- concurrent approve/deny produces one domain winner;
+- operator removed from ACL before click returns `forbidden`;
+- terminal `approved`/`denied` always includes `requester_uid`;
+- transient `5xx` can be retried safely.

--- a/docs/card-action-callback-dispatch.md
+++ b/docs/card-action-callback-dispatch.md
@@ -1,0 +1,159 @@
+# Card action callback dispatch operations
+
+This runbook covers the first-party callback branch of `card_action`. External
+and third-party Bots continue to consume `/v1/bot/events`; do not migrate those
+queues to this worker.
+
+Consumer implementers should start with
+[`card-action-callback-consumer.md`](./card-action-callback-consumer.md) for the
+wire contract, TypeScript verification example, idempotency, and retry rules.
+
+Standard approve/deny consumers need a signed decide endpoint and one route
+entry with `notify_token_env`. That entry authorizes both the callback and an
+owner-bound generic `approval_card` ingress. Docs is bound to its specialized
+resource-card finalizer; every other registered `(owner, action_type)` uses
+octo-server's standard approval terminal card and requester notification. A
+custom terminal visual remains a reviewed octo-server extension, not
+callback-authored card JSON.
+
+## Required configuration
+
+Routes are static startup configuration. Card data can select only a registered
+`(stored sender_uid, owner, action_type)` tuple and never carries a URL.
+
+```bash
+export OCTO_CARD_ACTION_ALLOWED_URLS='https://docs.internal/v1/card-actions/decide'
+export OCTO_CARD_ACTION_ROUTES='[{"sender_uid":"notification","owner":"docs","action_type":"access_request.decision","url":"https://docs.internal/v1/card-actions/decide","secret_env":"OCTO_DOCS_CARD_ACTION_SECRET","timeout_ms":3000,"max_attempts":5,"base_backoff_ms":1000,"max_backoff_ms":60000,"max_in_flight":8}]'
+export OCTO_DOCS_CARD_ACTION_SECRET='<at least 32 random bytes>'
+export OCTO_DOCS_NOTIFY_TOKEN='<dedicated docs ingress token>'
+export OCTO_DOCS_APPROVAL_CARD_ENABLED=true
+export OCTO_CARD_MESSAGE_ENABLED=true
+```
+
+Startup fails if a route is malformed, not in the exact HTTPS allowlist, has a
+missing/short secret, or if the docs pilot is enabled without its exact route.
+Callback redirects and environment HTTP proxies are disabled.
+
+For example, a second service can add a route without adding a finalizer or Bot
+worker:
+
+```json
+{
+  "sender_uid": "notification",
+  "owner": "tasks",
+  "action_type": "task.decision",
+  "url": "https://tasks.internal/v1/card-actions/decide",
+  "secret_env": "OCTO_TASKS_CARD_ACTION_SECRET",
+  "notify_token_env": "OCTO_TASKS_NOTIFY_TOKEN",
+  "timeout_ms": 3000,
+  "max_attempts": 5,
+  "base_backoff_ms": 1000,
+  "max_backoff_ms": 60000,
+  "max_in_flight": 8
+}
+```
+
+Set both referenced values to distinct random secrets of at least 32 bytes and
+add the exact callback URL to `OCTO_CARD_ACTION_ALLOWED_URLS`:
+
+```bash
+export OCTO_TASKS_CARD_ACTION_SECRET='<at least 32 random bytes>'
+export OCTO_TASKS_NOTIFY_TOKEN='<different, at least 32 random bytes>'
+```
+
+`notify_token_env` is optional for callback-only routes whose initial card is
+produced elsewhere. When present, it dynamically installs an `octo/v2`,
+DM-only producer bound to the route owner and the shared `notification` sender.
+The token must differ from the callback secret, `NOTIFY_INTERNAL_TOKEN`, every
+other owner token, and `OCTO_DOCS_NOTIFY_TOKEN`. `OCTO_CARD_MESSAGE_ENABLED`
+must be `true`.
+
+The service creates the standard initial card through the existing notify API:
+
+```http
+POST /v1/internal/notify
+X-Internal-Token: <OCTO_TASKS_NOTIFY_TOKEN>
+Content-Type: application/json
+
+{
+  "space_id": "space-1",
+  "service": "tasks",
+  "targets": ["approver-b"],
+  "actor_uid": "requester-a",
+  "approval_card": {
+    "action_type": "task.decision",
+    "title": "Deploy release",
+    "description": "Approve production deployment",
+    "data": {"task_id": "task-1"}
+  }
+}
+```
+
+The token supplies the authoritative owner; the request cannot choose it. The
+server adds approve/deny actions and reserved metadata. `data` accepts at most
+32 lower-case keys with string values up to 500 runes; `owner`, `action_type`,
+and `decision` are reserved. No callback URL or card JSON is accepted.
+
+The callback receives `X-Octo-Timestamp`, `X-Octo-Event-ID`, and
+`X-Octo-Signature: v1=<hex HMAC-SHA256>`. The canonical signed bytes are:
+
+```text
+v1\nMETHOD\nPATH\nTIMESTAMP\nEVENT_ID\nSHA256(EXACT_BODY)
+```
+
+The consumer must reject stale timestamps, verify HMAC before decoding business
+fields, persist idempotency by `event_id`, re-check its current ACL, CAS the
+domain request, and replay the same typed response for a repeated event.
+
+## Queue and alerts
+
+The worker uses Redis ready/leased/DLQ ZSETs with token-bound Lua transitions.
+Finalization heartbeats extend only the matching lease token. Expired leases
+are reclaimed; a stale worker cannot renew or ACK another worker's lease.
+If a route has reached `max_in_flight`, its lease is atomically deferred for one
+poll interval without consuming an attempt, so other routes and shutdown remain
+unblocked.
+Live retention equals `Robot.MessageExpire`; DLQ retention is 30 days.
+
+Alert from these bounded-label metrics:
+
+- `dmwork_card_action_dispatch_error_total{owner,category}`
+- `dmwork_card_action_dispatch_retry_total{owner}`
+- `dmwork_card_action_dispatch_duration_seconds{owner,result}`
+- `dmwork_card_action_dispatch_leased{owner}`
+- `dmwork_card_action_dispatch_ready_depth`
+- `dmwork_card_action_dispatch_dlq_depth`
+- `dmwork_card_action_dispatch_applicant_notify_failure_total{owner}`
+
+Deployment-specific thresholds belong in the monitoring repository. At
+minimum, alert on sustained DLQ depth above zero and sustained `consumer_5xx`,
+`invalid_response`, or applicant notification failures.
+
+## Manual DLQ replay
+
+First inspect logs/metrics and fix the consumer or configuration. Record the
+exact `event_id`; there is deliberately no bulk or automatic replay.
+
+```bash
+go run ./tools/card-action-dlq -config configs/tsdd.yaml -action depth
+go run ./tools/card-action-dlq -config configs/tsdd.yaml -action replay -event-id 12345
+```
+
+Replay resets attempts and returns that one event to ready state. The consumer
+must remain idempotent: its domain decision may already have committed. Terminal
+card mutation is also idempotent (`card_seq=event_id`). Applicant notification
+is at-least-once, so replay may duplicate it at the documented crash boundary.
+
+## Rollout and rollback
+
+Deploy the signed docs decide endpoint first. Configure its secret/route while
+keeping `OCTO_DOCS_APPROVAL_CARD_ENABLED=false`; verify metrics, then enable the
+pilot. Roll back by disabling the pilot, which restores the existing `octo/v1`
+display card. Keep routes until ready/leased queues drain; removing a live route
+sends affected events to DLQ rather than to the Bot pull queue.
+
+For a generic owner, deploy the decide endpoint first, then add the allowlist,
+route, callback secret, and notify token in one restart. Verify a test
+`approval_card` before switching business traffic. Roll back by stopping new
+approval-card calls, draining ready/leased events, and only then removing the
+route and secrets.

--- a/docs/card-protocol.md
+++ b/docs/card-protocol.md
@@ -190,11 +190,28 @@ robot API（legacy）`/robot/sendMessage` 同样接受 type-17（校验与 bot i
 
 ```
 客户端点按钮 → POST /v1/message/card/action     （鉴权/防伪造/幂等,即时 ack）
-            → bot 事件队列 event_type="card_action"（/v1/bot/events 轮询,至少一次）
-            → bot 处理 → /v1/bot/message/edit 整卡替换帧
+            → 服务端按 stored sender + data.owner/action_type 分支：
+              - 注册的一方 sender/route：内部可靠队列 → HMAC callback
+                → octo-server 写终态卡并通知申请人
+              - 其它 Bot：bot 事件队列 event_type="card_action"
+                （/v1/bot/events 轮询,至少一次）→ Bot 调 /v1/bot/message/edit
             → message_extra + CMD /v1/message/extra/sync
             → 三端重渲染新帧（消息列表/sync 响应即卡片状态权威,无独立状态 API）
 ```
+
+一方 callback 路由是静态启动配置，卡片不携带 URL。路由键必须同时匹配消息表中的
+`sender_uid`、服务端模板写入的 `data.owner` 和 `data.action_type`。外部 Bot 即使复制相同
+`data` 仍走原有 pull 队列；已注册的一方 sender 若提交未知/缺失 owner/action，则
+fail-closed，不会落入无人消费的 Bot 队列。传输、队列与运维合同见
+[`card-action-callback-dispatch.md`](./card-action-callback-dispatch.md)。
+
+终态渲染按权威 owner/action 选择：docs 使用专用资源卡模板，其余已注册 route 使用
+服务端标准审批终态模板与申请人通知。因此标准审批消费方只新增 decide endpoint + route；
+只有定制视觉需要增加受审的 octo-server finalizer binding。
+
+标准审批初始卡同样不需要新增代码：route 可配置独立 `notify_token_env`，消费方用该 token
+向 `/v1/internal/notify` 提交结构化 `approval_card`。token 在服务端绑定 sender/owner/action；
+消费方不能自选 owner、callback URL 或提交任意卡片 JSON。
 
 - **状态在卡片内容里**：防重复操作 = 服务端幂等（业务身份键
   `message_id+action_id+operator_uid`，`client_token` 只是关联 ID）+ bot 重写

--- a/docs/docs-notify-card.md
+++ b/docs/docs-notify-card.md
@@ -1,8 +1,16 @@
 # Docs-Notify 通知卡片（`internal/carddispatch` 第二个生产者）
 
+> 本文只描述 `docs-notify` 的卡片形态与组装。入站鉴权、请求和响应以
+> [docs-notify 跨仓 ingress 契约](../.octospec/tasks/card-message-internal-dispatch/docs-notify-contract.md)
+> 为准；访问审批的路由、可靠投递、终态与部署以
+> [card-action callback 运维文档](./card-action-callback-dispatch.md)为准；消费方验签、
+> 幂等与 typed result 以
+> [callback consumer 对接文档](./card-action-callback-consumer.md)为准。
+
 > **权威声明**：本文档描述 `docs-notify` 生产者当前的卡片形态与组装规则。
 > 权威源码：`pkg/cardtmpl/resource.go`（`BuildDocsResourceCard` + `docsDeepLink`）、
 > `modules/notify/card.go`（`deliverDocsCardNotification` / `buildDocsCard` /
+> `buildDocsAccessRequestCard` /
 > `docsLabelsFor` / `docsAttributionAndVariant`）、`modules/notify/model.go`
 > （`DocsCardFields`）、`internal/carddispatch/`（派发流水线）、
 > `pkg/cardmsg`（wire 协议与校验）。规范源头：
@@ -25,10 +33,10 @@
   （`ensureNotifyBot` provision）；用户会话列表里不产生第二个系统 Bot 会话。**能力
   隔离在 producer 粒度**：不同 producer 各自的 `MaxInFlight` / 允许 profile / 允许
   channel type 独立配置，`docs-backend` 不因共用 Bot 身份而获得跨 producer 越权。
-- **接口层**：仍是 `POST /v1/internal/notify` + `X-Internal-Token`。body 里
-  `Payload` / `Card`（summary） / `DocsCard`（docs） **三选一**，见 §3。
+- **接口层**：以跨仓 ingress 契约为准，本文不重复鉴权和请求结构。
 - **生产者信息**：`ProducerID="docs-notify"`，`SenderUID=NotifyBotUIDValue`，
-  `AllowedChannelTypes=[Person]`，`AllowedProfiles=[octo/v1]`，
+  `AllowedChannelTypes=[Person]`；默认仅允许 `octo/v1`，启用访问审批时同时允许
+  `octo/v2`；
   `SpacePolicy=SystemNotification`，`MaxInFlight=20/process`。
 
 **用户主动分享** 不是 docs-notify 的范围（brief Out-of-scope）：那是一条独立的
@@ -148,28 +156,18 @@ WuKongIM wire 信封（`plain` 由服务端权威派生）：
 - `kind: "access_requested"` + `actor_name: "Bob"` → attribution =
   `"Bob 请求访问文档"`，`metadata.octo.variant = "docs.access_requested"`
 
+`access_requested` 的交互卡、终态和申请人结果通知不在本文重复，统一引用
+[`card-action-callback-dispatch.md`](./card-action-callback-dispatch.md)。
+
 **约定** `docs-backend` 端预格式化 `actor_name`（可含姓+称谓、显示名等，逐字符
 `escapeMarkdown` 后落入 attribution）。octo-server 不做二次身份解析（避免 card 路径
 额外 DB 依赖）；跨仓契约见 `docs-notify-contract.md` §3。
 
 ## 3. Ingress 契约（`POST /v1/internal/notify`）
 
-完整跨仓契约见 `.octospec/tasks/card-message-internal-dispatch/docs-notify-contract.md`。
-摘要：
-
-- 头 `X-Internal-Token`（同 `NOTIFY_INTERNAL_TOKEN`，与 summary 复用；fail-closed）。
-- 一请求一收件人（`targets` 单元素）；`space_id` / `service` / `actor_uid` 语义
-  与 summary 完全对齐。
-- **三选一**：`Payload` / `Card`（summary） / `DocsCard`（docs） 只能出现一个。
-  多于一个 → 400 `err.server.notify.card_invalid`；全都缺失 → 400
-  `payload不能为空`（legacy）。
-- `Payload` 里禁止手搓 type-17（Decision 14；`cardmsg.IsCardPayload` 匹配即 400
-  `err.server.notify.card_not_allowed`）。
-- 响应仍为 `NotifyResp{delivered:[], filtered:{uid:reason}}`，reason 词表与
-  summary 一致（`target_denied` / `dispatch_failed` / `busy` / `not_space_member`
-  / `send_failed`），docs-backend 侧的重试/dedup 逻辑可**照抄** smart-summary。
-- **批量端点 `/notify/batch` 拒绝任何 `Card` / `DocsCard` 条目** — 卡片只能走单请求
-  路径（Preflight 400），因为 batch 走 legacy 文本 fan-out，不经 carddispatch。
+完整跨仓契约见
+[`.octospec/tasks/card-message-internal-dispatch/docs-notify-contract.md`](../.octospec/tasks/card-message-internal-dispatch/docs-notify-contract.md)。
+鉴权 Token、字段约束、请求示例、互斥规则、响应和重试语义只在该契约维护。
 
 ## 4. 服务端组装管线
 
@@ -181,8 +179,9 @@ WuKongIM wire 信封（`plain` 由服务端权威派生）：
    - dedup → actor 排除；
    - `memberCache.verify(space_id, targets)`；非成员进 `Filtered`；
    - `ensureNotifyBotReady()`（与 summary 共享）；
-   - `buildDocsCard` → `docsAttributionAndVariant` → `cardtmpl.BuildDocsResourceCard`；
-   - `carddispatch.Sender.Send(ctx, Target{DM}, Card{octo/v1, document})` 并发（内嵌
+   - 普通展示卡走 `buildDocsCard`；启用访问审批后的 `access_requested` 走
+     `buildDocsAccessRequestCard`；
+   - `carddispatch.Sender.Send(ctx, Target{DM}, Card{profile, document})` 并发（内嵌
      `sem` 20 与 producer `MaxInFlight` 20 一致）。
 3. **派发管线**（`internal/carddispatch`，Decisions 7/8/11）与 summary **完全相同**。
 4. **文本降级**：`canCard` 请求级决策；`cardmsg.Enabled()==false` /
@@ -227,13 +226,7 @@ summary 侧仍在等 octo-web `/s/:taskId` 上线。
 ## 8. 已知调优候选
 
 同 `docs/summary-notify-card.md` §8（`color:"Attention"` / `color:"Good"` / 让
-Excerpt 与 FactSet 位置可调）。多一个 docs 专属候选：
-
-- **访问申请交互按钮**：`access_requested` 变体天生适合「同意 / 拒绝」的交互卡（`octo/v2`），
-  但需要 producer 从 `octo/v1` 升级到 `octo/v2` 并绑定一个跑 `/v1/bot/events` 的
-  action-owner（brief › 「Interactive cards」小节）。docs-backend 目前是 TS/Hocuspocus，
-  不跑 Go bot 事件轮询——如果要走 `octo/v2` 交互，需要单独设计 executor 服务。**这是后续
-  独立议题**，不在本 producer 范围。
+Excerpt 与 FactSet 位置可调）。
 
 ## 9. 参考
 
@@ -250,7 +243,9 @@ Excerpt 与 FactSet 位置可调）。多一个 docs 专属候选：
   - `.octospec/tasks/card-message-internal-dispatch/brief.md`
   - `.octospec/tasks/card-message-internal-dispatch/docs-notify-contract.md`（跨仓）
   - `.octospec/tasks/card-message-internal-dispatch/summary-notify-contract.md`（姊妹）
+  - `docs/card-action-callback-dispatch.md` — 一方 action 路由、队列、部署与运维
+  - `docs/card-action-callback-consumer.md` — 消费方验签、幂等与 typed result
   - `docs/card-protocol.md` — wire 协议权威
   - `docs/summary-notify-card.md` — 姊妹 producer 文档，共享管线细节
 - 相关 PR：#577（dispatch 基座）、#579（`summary-notify` pilot）、#580（复用
-  `notification` bot 身份）、本 PR（`docs-notify` producer + `metadata.octo.{variant,source}`）
+  `notification` bot 身份）、#584（`docs-notify` producer + `metadata.octo.{variant,source}`）

--- a/internal/cardactiondispatch/config.go
+++ b/internal/cardactiondispatch/config.go
@@ -1,0 +1,78 @@
+package cardactiondispatch
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+)
+
+type routeJSON struct {
+	SenderUID      string `json:"sender_uid"`
+	Owner          string `json:"owner"`
+	ActionType     string `json:"action_type"`
+	URL            string `json:"url"`
+	SecretEnv      string `json:"secret_env"`
+	NotifyTokenEnv string `json:"notify_token_env"`
+	TimeoutMS      int64  `json:"timeout_ms"`
+	MaxAttempts    int    `json:"max_attempts"`
+	BaseBackoffMS  int64  `json:"base_backoff_ms"`
+	MaxBackoffMS   int64  `json:"max_backoff_ms"`
+	MaxInFlight    int    `json:"max_in_flight"`
+}
+
+func LoadRouteSpecs(raw string) ([]RouteSpec, error) {
+	if strings.TrimSpace(raw) == "" {
+		return nil, nil
+	}
+	decoder := json.NewDecoder(strings.NewReader(raw))
+	decoder.DisallowUnknownFields()
+	var encoded []routeJSON
+	if err := decoder.Decode(&encoded); err != nil {
+		return nil, fmt.Errorf("cardactiondispatch: decode routes: %w", err)
+	}
+	var trailing interface{}
+	if err := decoder.Decode(&trailing); err != io.EOF {
+		return nil, errors.New("cardactiondispatch: trailing route configuration")
+	}
+	specs := make([]RouteSpec, 0, len(encoded))
+	for _, item := range encoded {
+		if item.TimeoutMS < 0 || item.BaseBackoffMS < 0 || item.MaxBackoffMS < 0 {
+			return nil, errors.New("cardactiondispatch: route durations must not be negative")
+		}
+		spec := RouteSpec{
+			SenderUID:      item.SenderUID,
+			Owner:          item.Owner,
+			ActionType:     item.ActionType,
+			URL:            item.URL,
+			SecretEnv:      item.SecretEnv,
+			NotifyTokenEnv: item.NotifyTokenEnv,
+			MaxAttempts:    item.MaxAttempts,
+			MaxInFlight:    item.MaxInFlight,
+		}
+		if item.TimeoutMS > 0 {
+			spec.Timeout = time.Duration(item.TimeoutMS) * time.Millisecond
+		}
+		if item.BaseBackoffMS > 0 {
+			spec.BaseBackoff = time.Duration(item.BaseBackoffMS) * time.Millisecond
+		}
+		if item.MaxBackoffMS > 0 {
+			spec.MaxBackoff = time.Duration(item.MaxBackoffMS) * time.Millisecond
+		}
+		specs = append(specs, withRouteDefaults(spec))
+	}
+	return specs, nil
+}
+
+func LoadAllowedURLs(raw string) []string {
+	parts := strings.Split(raw, ",")
+	urls := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if value := strings.TrimSpace(part); value != "" {
+			urls = append(urls, value)
+		}
+	}
+	return urls
+}

--- a/internal/cardactiondispatch/contract.go
+++ b/internal/cardactiondispatch/contract.go
@@ -1,0 +1,169 @@
+package cardactiondispatch
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"unicode/utf8"
+)
+
+const MaxDecisionResponseBytes = 64 << 10
+
+type Disposition string
+
+const (
+	DispositionApplied   Disposition = "applied"
+	DispositionReplayed  Disposition = "replayed"
+	DispositionForbidden Disposition = "forbidden"
+	DispositionConflict  Disposition = "conflict"
+	DispositionNotFound  Disposition = "not_found"
+)
+
+type State string
+
+const (
+	StatePending   State = "pending"
+	StateApproved  State = "approved"
+	StateDenied    State = "denied"
+	StateCancelled State = "cancelled"
+)
+
+type Event struct {
+	EventID     int64                  `json:"event_id"`
+	SenderUID   string                 `json:"sender_uid"`
+	Owner       string                 `json:"owner"`
+	ActionType  string                 `json:"action_type"`
+	MessageID   string                 `json:"message_id"`
+	ChannelID   string                 `json:"channel_id"`
+	ChannelType uint8                  `json:"channel_type"`
+	SpaceID     string                 `json:"space_id,omitempty"`
+	ActionID    string                 `json:"action_id"`
+	OperatorUID string                 `json:"operator_uid"`
+	ClientToken string                 `json:"client_token,omitempty"`
+	ActedAt     int64                  `json:"acted_at"`
+	Inputs      map[string]interface{} `json:"inputs"`
+	Data        map[string]interface{} `json:"data,omitempty"`
+}
+
+type DecisionRequest struct {
+	EventID     int64                  `json:"event_id,string"`
+	ActionID    string                 `json:"action_id"`
+	Decision    string                 `json:"decision"`
+	OperatorUID string                 `json:"operator_uid"`
+	DocID       string                 `json:"doc_id,omitempty"`
+	RequestID   string                 `json:"request_id,omitempty"`
+	Inputs      map[string]interface{} `json:"inputs"`
+	Data        map[string]interface{} `json:"data,omitempty"`
+	MessageID   string                 `json:"message_id"`
+	ChannelID   string                 `json:"channel_id"`
+	ChannelType uint8                  `json:"channel_type"`
+	SpaceID     string                 `json:"space_id,omitempty"`
+	ActedAt     int64                  `json:"acted_at"`
+}
+
+type DecisionResult struct {
+	Disposition  Disposition       `json:"disposition"`
+	State        State             `json:"state"`
+	RequesterUID string            `json:"requester_uid,omitempty"`
+	Display      map[string]string `json:"display,omitempty"`
+}
+
+func DecisionRequestFromEvent(event Event) DecisionRequest {
+	inputs := event.Inputs
+	if inputs == nil {
+		inputs = map[string]interface{}{}
+	}
+	return DecisionRequest{
+		EventID:     event.EventID,
+		ActionID:    event.ActionID,
+		Decision:    stringField(event.Data, "decision"),
+		OperatorUID: event.OperatorUID,
+		DocID:       stringField(event.Data, "doc_id"),
+		RequestID:   stringField(event.Data, "request_id"),
+		Inputs:      inputs,
+		Data:        event.Data,
+		MessageID:   event.MessageID,
+		ChannelID:   event.ChannelID,
+		ChannelType: event.ChannelType,
+		SpaceID:     event.SpaceID,
+		ActedAt:     event.ActedAt,
+	}
+}
+
+func DecodeDecisionResult(reader io.Reader) (DecisionResult, error) {
+	if reader == nil {
+		return DecisionResult{}, errors.New("cardactiondispatch: empty decision response")
+	}
+	limited := io.LimitReader(reader, MaxDecisionResponseBytes+1)
+	body, err := io.ReadAll(limited)
+	if err != nil {
+		return DecisionResult{}, fmt.Errorf("cardactiondispatch: read decision response: %w", err)
+	}
+	if len(body) > MaxDecisionResponseBytes {
+		return DecisionResult{}, errors.New("cardactiondispatch: decision response too large")
+	}
+	decoder := json.NewDecoder(bytes.NewReader(body))
+	decoder.DisallowUnknownFields()
+	var result DecisionResult
+	if err := decoder.Decode(&result); err != nil {
+		return DecisionResult{}, fmt.Errorf("cardactiondispatch: decode decision response: %w", err)
+	}
+	if err := ensureJSONEOF(decoder); err != nil {
+		return DecisionResult{}, err
+	}
+	if !validDisposition(result.Disposition) || !validState(result.State) {
+		return DecisionResult{}, errors.New("cardactiondispatch: invalid decision result enum")
+	}
+	if len(result.RequesterUID) > 128 || strings.TrimSpace(result.RequesterUID) != result.RequesterUID {
+		return DecisionResult{}, errors.New("cardactiondispatch: invalid requester_uid")
+	}
+	if (result.State == StateApproved || result.State == StateDenied) && result.RequesterUID == "" {
+		return DecisionResult{}, errors.New("cardactiondispatch: terminal decision requires requester_uid")
+	}
+	if len(result.Display) > 32 {
+		return DecisionResult{}, errors.New("cardactiondispatch: too many display fields")
+	}
+	for key, value := range result.Display {
+		if key == "" || len(key) > 64 || utf8.RuneCountInString(value) > 500 {
+			return DecisionResult{}, errors.New("cardactiondispatch: invalid display field")
+		}
+	}
+	return result, nil
+}
+
+func ensureJSONEOF(decoder *json.Decoder) error {
+	var trailing interface{}
+	if err := decoder.Decode(&trailing); err != io.EOF {
+		if err == nil {
+			return errors.New("cardactiondispatch: trailing decision response")
+		}
+		return fmt.Errorf("cardactiondispatch: decode trailing decision response: %w", err)
+	}
+	return nil
+}
+
+func validDisposition(value Disposition) bool {
+	switch value {
+	case DispositionApplied, DispositionReplayed, DispositionForbidden, DispositionConflict, DispositionNotFound:
+		return true
+	default:
+		return false
+	}
+}
+
+func validState(value State) bool {
+	switch value {
+	case StatePending, StateApproved, StateDenied, StateCancelled:
+		return true
+	default:
+		return false
+	}
+}
+
+func stringField(values map[string]interface{}, key string) string {
+	value, _ := values[key].(string)
+	return value
+}

--- a/internal/cardactiondispatch/contract_test.go
+++ b/internal/cardactiondispatch/contract_test.go
@@ -1,0 +1,587 @@
+package cardactiondispatch
+
+import (
+	"bytes"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	rd "github.com/go-redis/redis"
+)
+
+const testCallbackSecret = "0123456789abcdef0123456789abcdef"
+
+func validRouteSpec() RouteSpec {
+	return RouteSpec{
+		SenderUID:   "notification",
+		Owner:       "docs",
+		ActionType:  "access_request.decision",
+		URL:         "https://docs.internal/v1/card-actions/decide",
+		SecretEnv:   "OCTO_DOCS_CARD_ACTION_SECRET",
+		Timeout:     3 * time.Second,
+		MaxAttempts: 3,
+		BaseBackoff: time.Second,
+		MaxBackoff:  30 * time.Second,
+		MaxInFlight: 4,
+	}
+}
+
+func testGetenv(key string) string {
+	if key == "OCTO_DOCS_CARD_ACTION_SECRET" {
+		return testCallbackSecret
+	}
+	return ""
+}
+
+func TestRegistryResolveIsBoundToStoredSender(t *testing.T) {
+	registry, err := NewRegistry(
+		[]RouteSpec{validRouteSpec()},
+		[]string{"https://docs.internal/v1/card-actions/decide"},
+		testGetenv,
+	)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+
+	tests := []struct {
+		name       string
+		senderUID  string
+		owner      string
+		actionType string
+		want       ResolutionKind
+	}{
+		{
+			name:       "registered sender and action use callback",
+			senderUID:  "notification",
+			owner:      "docs",
+			actionType: "access_request.decision",
+			want:       ResolutionCallback,
+		},
+		{
+			name:       "external bot copying metadata stays on pull queue",
+			senderUID:  "third-party-bot",
+			owner:      "docs",
+			actionType: "access_request.decision",
+			want:       ResolutionBotPull,
+		},
+		{
+			name:       "registered internal sender with unknown action fails closed",
+			senderUID:  "notification",
+			owner:      "docs",
+			actionType: "unknown",
+			want:       ResolutionReject,
+		},
+		{
+			name:       "registered internal sender with malformed metadata fails closed",
+			senderUID:  "notification",
+			owner:      "",
+			actionType: "",
+			want:       ResolutionReject,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := registry.Resolve(tt.senderUID, tt.owner, tt.actionType)
+			if got.Kind != tt.want {
+				t.Fatalf("Resolve() kind = %q, want %q", got.Kind, tt.want)
+			}
+			if tt.want == ResolutionCallback && got.Route == nil {
+				t.Fatal("callback resolution must include the immutable route")
+			}
+		})
+	}
+}
+
+func TestNewRegistryRejectsUnsafeOrAmbiguousRoutes(t *testing.T) {
+	tests := []struct {
+		name       string
+		mutate     func(*RouteSpec)
+		allowed    []string
+		getenv     func(string) string
+		additional []RouteSpec
+	}{
+		{
+			name: "non https URL",
+			mutate: func(spec *RouteSpec) {
+				spec.URL = "http://docs.internal/v1/card-actions/decide"
+			},
+			allowed: []string{"http://docs.internal/v1/card-actions/decide"},
+		},
+		{
+			name: "credential bearing URL",
+			mutate: func(spec *RouteSpec) {
+				spec.URL = "https://user:pass@docs.internal/v1/card-actions/decide"
+			},
+			allowed: []string{"https://user:pass@docs.internal/v1/card-actions/decide"},
+		},
+		{
+			name: "fragment bearing URL",
+			mutate: func(spec *RouteSpec) {
+				spec.URL = "https://docs.internal/v1/card-actions/decide#fragment"
+			},
+			allowed: []string{"https://docs.internal/v1/card-actions/decide#fragment"},
+		},
+		{
+			name:    "URL not in exact allowlist",
+			mutate:  func(*RouteSpec) {},
+			allowed: []string{"https://other.internal/v1/card-actions/decide"},
+		},
+		{
+			name:    "missing secret",
+			mutate:  func(*RouteSpec) {},
+			allowed: []string{"https://docs.internal/v1/card-actions/decide"},
+			getenv:  func(string) string { return "" },
+		},
+		{
+			name:    "duplicate route key",
+			mutate:  func(*RouteSpec) {},
+			allowed: []string{"https://docs.internal/v1/card-actions/decide"},
+			additional: []RouteSpec{
+				validRouteSpec(),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			spec := validRouteSpec()
+			tt.mutate(&spec)
+			getenv := tt.getenv
+			if getenv == nil {
+				getenv = testGetenv
+			}
+			_, err := NewRegistry(append([]RouteSpec{spec}, tt.additional...), tt.allowed, getenv)
+			if err == nil {
+				t.Fatal("NewRegistry() error = nil, want configuration rejection")
+			}
+		})
+	}
+}
+
+func TestLoadRouteSpecsUsesBoundedProductionDefaults(t *testing.T) {
+	raw := `[{
+		"sender_uid":"notification",
+		"owner":"docs",
+		"action_type":"access_request.decision",
+		"url":"https://docs.internal/v1/card-actions/decide",
+		"secret_env":"OCTO_DOCS_CARD_ACTION_SECRET",
+		"notify_token_env":"OCTO_DOCS_NOTIFY_TOKEN"
+	}]`
+	specs, err := LoadRouteSpecs(raw)
+	if err != nil {
+		t.Fatalf("LoadRouteSpecs() error = %v", err)
+	}
+	if len(specs) != 1 {
+		t.Fatalf("LoadRouteSpecs() count = %d, want 1", len(specs))
+	}
+	got := specs[0]
+	if got.Timeout <= 0 || got.Timeout > 10*time.Second {
+		t.Errorf("default timeout = %s, want bounded positive timeout", got.Timeout)
+	}
+	if got.MaxAttempts < 1 || got.MaxAttempts > 10 {
+		t.Errorf("default max attempts = %d, want [1,10]", got.MaxAttempts)
+	}
+	if got.MaxInFlight < 1 || got.MaxInFlight > 100 {
+		t.Errorf("default max in flight = %d, want [1,100]", got.MaxInFlight)
+	}
+	if got.NotifyTokenEnv != "OCTO_DOCS_NOTIFY_TOKEN" {
+		t.Errorf("notify token env = %q", got.NotifyTokenEnv)
+	}
+}
+
+func TestRegistryBindsNotifyTokenToOnlyConfiguredOwnerActions(t *testing.T) {
+	const notifyToken = "abcdef0123456789abcdef0123456789"
+	primary := validRouteSpec()
+	primary.Owner = "smart-summary"
+	primary.ActionType = "summary.publish.decision"
+	primary.NotifyTokenEnv = "OCTO_SMART_SUMMARY_NOTIFY_TOKEN"
+	secondary := primary
+	secondary.ActionType = "summary.delete.decision"
+	secondary.NotifyTokenEnv = ""
+
+	getenv := func(key string) string {
+		switch key {
+		case primary.SecretEnv:
+			return testCallbackSecret
+		case primary.NotifyTokenEnv:
+			return notifyToken
+		default:
+			return ""
+		}
+	}
+	registry, err := NewRegistry([]RouteSpec{primary, secondary}, []string{primary.URL}, getenv)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	capability, ok := registry.ResolveNotifyToken(notifyToken)
+	if !ok {
+		t.Fatal("ResolveNotifyToken() rejected configured token")
+	}
+	if capability.SenderUID != primary.SenderUID || capability.Owner != primary.Owner {
+		t.Fatalf("notify capability = %+v", capability)
+	}
+	if !registry.CanNotify(capability, primary.ActionType) {
+		t.Fatal("configured notify action was rejected")
+	}
+	if registry.CanNotify(capability, secondary.ActionType) {
+		t.Fatal("callback-only action was accepted by notify capability")
+	}
+	if _, ok := registry.ResolveNotifyToken("wrong-token"); ok {
+		t.Fatal("ResolveNotifyToken() accepted wrong token")
+	}
+	if got := registry.NotifyProducers(); len(got) != 1 || got[0] != capability {
+		t.Fatalf("NotifyProducers() = %+v, want [%+v]", got, capability)
+	}
+}
+
+func TestRegistryRejectsUnsafeNotifyTokenBindings(t *testing.T) {
+	const notifyToken = "abcdef0123456789abcdef0123456789"
+	tests := []struct {
+		name   string
+		specs  func() []RouteSpec
+		getenv func(string) string
+	}{
+		{
+			name: "short notify token",
+			specs: func() []RouteSpec {
+				spec := validRouteSpec()
+				spec.NotifyTokenEnv = "OCTO_DOCS_NOTIFY_TOKEN"
+				return []RouteSpec{spec}
+			},
+			getenv: func(key string) string {
+				if key == "OCTO_DOCS_NOTIFY_TOKEN" {
+					return "short"
+				}
+				return testGetenv(key)
+			},
+		},
+		{
+			name: "callback and notify secret reuse",
+			specs: func() []RouteSpec {
+				spec := validRouteSpec()
+				spec.NotifyTokenEnv = "OCTO_DOCS_NOTIFY_TOKEN"
+				return []RouteSpec{spec}
+			},
+			getenv: func(string) string { return testCallbackSecret },
+		},
+		{
+			name: "one notify token bound to two owners",
+			specs: func() []RouteSpec {
+				docs := validRouteSpec()
+				docs.NotifyTokenEnv = "OCTO_SHARED_NOTIFY_TOKEN"
+				tasks := docs
+				tasks.Owner = "tasks"
+				tasks.ActionType = "task.decision"
+				return []RouteSpec{docs, tasks}
+			},
+			getenv: func(key string) string {
+				if key == "OCTO_SHARED_NOTIFY_TOKEN" {
+					return notifyToken
+				}
+				return testGetenv(key)
+			},
+		},
+		{
+			name: "notify token reuses another route callback secret",
+			specs: func() []RouteSpec {
+				docs := validRouteSpec()
+				tasks := docs
+				tasks.Owner = "tasks"
+				tasks.ActionType = "task.decision"
+				tasks.SecretEnv = "OCTO_TASKS_CARD_ACTION_SECRET"
+				tasks.NotifyTokenEnv = "OCTO_TASKS_NOTIFY_TOKEN"
+				return []RouteSpec{docs, tasks}
+			},
+			getenv: func(key string) string {
+				switch key {
+				case "OCTO_DOCS_CARD_ACTION_SECRET", "OCTO_TASKS_NOTIFY_TOKEN":
+					return testCallbackSecret
+				case "OCTO_TASKS_CARD_ACTION_SECRET":
+					return "fedcba9876543210fedcba9876543210"
+				default:
+					return ""
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := NewRegistry(tt.specs(), []string{validRouteSpec().URL}, tt.getenv); err == nil {
+				t.Fatal("NewRegistry() error = nil")
+			}
+		})
+	}
+}
+
+func TestRegistryRejectsNotifyTokenThatConflictsWithBroaderIngress(t *testing.T) {
+	spec := validRouteSpec()
+	spec.NotifyTokenEnv = "OCTO_TASKS_NOTIFY_TOKEN"
+	getenv := func(key string) string {
+		if key == spec.NotifyTokenEnv {
+			return "abcdef0123456789abcdef0123456789"
+		}
+		return testGetenv(key)
+	}
+	registry, err := NewRegistry([]RouteSpec{spec}, []string{spec.URL}, getenv)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	tests := []struct {
+		name  string
+		token string
+	}{
+		{name: "route notify token", token: "abcdef0123456789abcdef0123456789"},
+		{name: "callback secret", token: testCallbackSecret},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := registry.ValidateNotifyTokenExclusions(tt.token); err == nil {
+				t.Fatal("ValidateNotifyTokenExclusions() error = nil")
+			}
+		})
+	}
+}
+
+func TestHMACSignatureUsesVersionedCanonicalRequest(t *testing.T) {
+	body := []byte(`{"event_id":"42","decision":"approve"}`)
+	timestamp := "1784073600"
+	eventID := "42"
+	wantCanonical := "v1\nPOST\n/v1/card-actions/decide\n1784073600\n42\n" + sha256Hex(body)
+	if got := CanonicalRequest(http.MethodPost, "/v1/card-actions/decide", timestamp, eventID, body); got != wantCanonical {
+		t.Fatalf("CanonicalRequest() = %q, want %q", got, wantCanonical)
+	}
+
+	mac := hmac.New(sha256.New, []byte(testCallbackSecret))
+	_, _ = mac.Write([]byte(wantCanonical))
+	wantSignature := "v1=" + hex.EncodeToString(mac.Sum(nil))
+	gotSignature := Sign(testCallbackSecret, http.MethodPost, "/v1/card-actions/decide", timestamp, eventID, body)
+	if gotSignature != wantSignature {
+		t.Fatalf("Sign() = %q, want %q", gotSignature, wantSignature)
+	}
+	if !Verify(testCallbackSecret, gotSignature, http.MethodPost, "/v1/card-actions/decide", timestamp, eventID, body) {
+		t.Fatal("Verify() rejected a valid signature")
+	}
+	if Verify(testCallbackSecret, gotSignature, http.MethodPost, "/v1/card-actions/decide", timestamp, eventID, append(body, ' ')) {
+		t.Fatal("Verify() accepted a signature for mutated exact body bytes")
+	}
+}
+
+func TestDecisionRequestMarshalsEventIDWithoutJavaScriptPrecisionLoss(t *testing.T) {
+	const eventID int64 = 9_007_199_254_740_993
+	body, err := json.Marshal(DecisionRequest{EventID: eventID})
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(body, &fields); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+	if got, want := string(fields["event_id"]), `"9007199254740993"`; got != want {
+		t.Fatalf("event_id JSON = %s, want %s", got, want)
+	}
+}
+
+func TestDecisionRequestNormalizesMissingInputsToEmptyObject(t *testing.T) {
+	body, err := json.Marshal(DecisionRequestFromEvent(Event{EventID: 1}))
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(body, &fields); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+	if got, want := string(fields["inputs"]), `{}`; got != want {
+		t.Fatalf("inputs JSON = %s, want %s", got, want)
+	}
+}
+
+func TestDecodeDecisionResultIsTypedAndSizeBounded(t *testing.T) {
+	valid := `{"disposition":"applied","state":"approved","requester_uid":"user-a","display":{"title":"Roadmap"}}`
+	result, err := DecodeDecisionResult(strings.NewReader(valid))
+	if err != nil {
+		t.Fatalf("DecodeDecisionResult(valid) error = %v", err)
+	}
+	if result.Disposition != DispositionApplied || result.State != StateApproved || result.RequesterUID != "user-a" {
+		t.Fatalf("DecodeDecisionResult(valid) = %+v", result)
+	}
+
+	invalid := []string{
+		`{"disposition":"unknown","state":"approved"}`,
+		`{"disposition":"applied","state":"unknown"}`,
+		`{"disposition":"applied","state":"approved"}`,
+		`{"disposition":"applied","state":"approved","requester_uid":"user-a","extra":true}`,
+		`{"disposition":"applied","state":"approved","display":{"title":1}}`,
+	}
+	for _, body := range invalid {
+		if _, err := DecodeDecisionResult(strings.NewReader(body)); err == nil {
+			t.Errorf("DecodeDecisionResult(%s) error = nil, want rejection", body)
+		}
+	}
+
+	oversized := bytes.NewReader(bytes.Repeat([]byte("x"), MaxDecisionResponseBytes+1))
+	if _, err := DecodeDecisionResult(oversized); err == nil {
+		t.Fatal("DecodeDecisionResult() accepted oversized response")
+	}
+}
+
+func TestRedisQueueLeaseTokenRetryDLQAndReplay(t *testing.T) {
+	client := rd.NewClient(&rd.Options{Addr: "127.0.0.1:6379"})
+	if err := client.Ping().Err(); err != nil {
+		t.Skipf("Redis unavailable: %v", err)
+	}
+	t.Cleanup(func() { _ = client.Close() })
+
+	prefix := fmt.Sprintf("test:card_action_dispatch:%d", time.Now().UnixNano())
+	queue, err := NewRedisQueue(client, QueueConfig{
+		Prefix:       prefix,
+		LiveTTL:      10 * time.Minute,
+		DLQRetention: 30 * 24 * time.Hour,
+	})
+	if err != nil {
+		t.Fatalf("NewRedisQueue() error = %v", err)
+	}
+	t.Cleanup(func() {
+		keys, _ := client.Keys(prefix + "*").Result()
+		if len(keys) > 0 {
+			_ = client.Del(keys...).Err()
+		}
+	})
+
+	now := time.Now().Truncate(time.Millisecond)
+	event := Event{
+		EventID:     42,
+		SenderUID:   "notification",
+		Owner:       "docs",
+		ActionType:  "access_request.decision",
+		MessageID:   "1001",
+		ChannelID:   "user-b",
+		ChannelType: 1,
+		SpaceID:     "space-1",
+		ActionID:    "approve",
+		OperatorUID: "user-b",
+		ClientToken: "tap-1",
+		ActedAt:     now.Unix(),
+		Inputs:      map[string]interface{}{},
+		Data: map[string]interface{}{
+			"owner":       "docs",
+			"action_type": "access_request.decision",
+			"decision":    "approve",
+			"doc_id":      "doc-1",
+			"request_id":  "request-1",
+		},
+	}
+	if err := queue.Enqueue(event, now); err != nil {
+		t.Fatalf("Enqueue() error = %v", err)
+	}
+	// Enqueue is idempotent on event_id and must not reset attempts/state.
+	if err := queue.Enqueue(event, now.Add(time.Second)); err != nil {
+		t.Fatalf("duplicate Enqueue() error = %v", err)
+	}
+
+	lease, err := queue.Claim(now, 5*time.Second)
+	if err != nil {
+		t.Fatalf("Claim() error = %v", err)
+	}
+	if lease == nil || lease.Event.EventID != event.EventID || lease.Attempt != 1 || lease.Token == "" {
+		t.Fatalf("Claim() = %+v, want event 42 attempt 1 with token", lease)
+	}
+	if acked, err := queue.Ack(event.EventID, "wrong-token"); err != nil || acked {
+		t.Fatalf("Ack(wrong token) = (%v, %v), want (false, nil)", acked, err)
+	}
+	if reclaimed, err := queue.ReclaimExpired(now.Add(4*time.Second), 10); err != nil || reclaimed != 0 {
+		t.Fatalf("ReclaimExpired(before lease) = (%d, %v), want (0, nil)", reclaimed, err)
+	}
+	if reclaimed, err := queue.ReclaimExpired(now.Add(6*time.Second), 10); err != nil || reclaimed != 1 {
+		t.Fatalf("ReclaimExpired(after lease) = (%d, %v), want (1, nil)", reclaimed, err)
+	}
+
+	lease, err = queue.Claim(now.Add(6*time.Second), 5*time.Second)
+	if err != nil || lease == nil || lease.Attempt != 2 {
+		t.Fatalf("second Claim() = (%+v, %v), want attempt 2", lease, err)
+	}
+	if lease.Token == "" {
+		t.Fatal("reclaimed lease has empty token")
+	}
+	outcome, err := queue.Nack(*lease, now.Add(6*time.Second), 2*time.Second, 3, "upstream_5xx")
+	if err != nil || outcome != NackRequeued {
+		t.Fatalf("Nack(retry) = (%q, %v), want (%q, nil)", outcome, err, NackRequeued)
+	}
+	if premature, err := queue.Claim(now.Add(7*time.Second), 5*time.Second); err != nil || premature != nil {
+		t.Fatalf("Claim(before backoff) = (%+v, %v), want (nil, nil)", premature, err)
+	}
+
+	lease, err = queue.Claim(now.Add(9*time.Second), 5*time.Second)
+	if err != nil || lease == nil || lease.Attempt != 3 {
+		t.Fatalf("third Claim() = (%+v, %v), want attempt 3", lease, err)
+	}
+	outcome, err = queue.Nack(*lease, now.Add(9*time.Second), 0, 3, "timeout")
+	if err != nil || outcome != NackDeadLettered {
+		t.Fatalf("Nack(exhausted) = (%q, %v), want (%q, nil)", outcome, err, NackDeadLettered)
+	}
+	depths, err := queue.Depths()
+	if err != nil {
+		t.Fatalf("Depths() error = %v", err)
+	}
+	if depths.Ready != 0 || depths.Leased != 0 || depths.DLQ != 1 {
+		t.Fatalf("Depths() = %+v, want ready=0 leased=0 dlq=1", depths)
+	}
+
+	replayed, err := queue.ReplayDLQ(event.EventID, now.Add(10*time.Second))
+	if err != nil || !replayed {
+		t.Fatalf("ReplayDLQ() = (%v, %v), want (true, nil)", replayed, err)
+	}
+	lease, err = queue.Claim(now.Add(10*time.Second), 5*time.Second)
+	if err != nil || lease == nil || lease.Event.EventID != event.EventID || lease.Attempt != 1 {
+		t.Fatalf("Claim(after DLQ replay) = (%+v, %v), want event 42 reset to attempt 1", lease, err)
+	}
+	if acked, err := queue.Ack(event.EventID, lease.Token); err != nil || !acked {
+		t.Fatalf("Ack(valid token) = (%v, %v), want (true, nil)", acked, err)
+	}
+}
+
+func TestRedisQueueDLQRetentionIsPerEvent(t *testing.T) {
+	client := rd.NewClient(&rd.Options{Addr: "127.0.0.1:6379"})
+	if err := client.Ping().Err(); err != nil {
+		t.Skipf("Redis unavailable: %v", err)
+	}
+	t.Cleanup(func() { _ = client.Close() })
+	prefix := fmt.Sprintf("test:card_action_dlq_retention:%d", time.Now().UnixNano())
+	queue, err := NewRedisQueue(client, QueueConfig{Prefix: prefix, LiveTTL: time.Hour, DLQRetention: 30 * 24 * time.Hour})
+	if err != nil {
+		t.Fatalf("NewRedisQueue() error = %v", err)
+	}
+	t.Cleanup(func() {
+		keys, _ := client.Keys(prefix + "*").Result()
+		if len(keys) > 0 {
+			_ = client.Del(keys...).Err()
+		}
+	})
+	now := time.Now().Truncate(time.Millisecond)
+	event := testDispatchEvent()
+	if err := queue.Enqueue(event, now); err != nil {
+		t.Fatalf("Enqueue() error = %v", err)
+	}
+	lease, err := queue.Claim(now, time.Minute)
+	if err != nil || lease == nil {
+		t.Fatalf("Claim() = (%+v, %v)", lease, err)
+	}
+	if outcome, err := queue.Nack(*lease, now, time.Hour, 1, "forced"); err != nil || outcome != NackDeadLettered {
+		t.Fatalf("Nack() = (%q, %v)", outcome, err)
+	}
+	if replayed, err := queue.ReplayDLQ(event.EventID, now.Add(30*24*time.Hour+time.Millisecond)); err != nil || replayed {
+		t.Fatalf("ReplayDLQ(expired) = (%v, %v), want (false, nil)", replayed, err)
+	}
+}
+
+func sha256Hex(body []byte) string {
+	sum := sha256.Sum256(body)
+	return hex.EncodeToString(sum[:])
+}

--- a/internal/cardactiondispatch/coverage_test.go
+++ b/internal/cardactiondispatch/coverage_test.go
@@ -1,0 +1,189 @@
+package cardactiondispatch
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+	"unicode/utf8"
+
+	rd "github.com/go-redis/redis"
+)
+
+type idleDispatchQueue struct {
+	claims   atomic.Int32
+	reclaims atomic.Int32
+}
+
+func (q *idleDispatchQueue) Claim(time.Time, time.Duration) (*Lease, error) {
+	q.claims.Add(1)
+	return nil, nil
+}
+func (*idleDispatchQueue) Renew(int64, string, time.Time, time.Duration) (bool, error) {
+	return true, nil
+}
+func (*idleDispatchQueue) Defer(int64, string, time.Time) (bool, error) { return true, nil }
+func (*idleDispatchQueue) Ack(int64, string) (bool, error)              { return true, nil }
+func (*idleDispatchQueue) Nack(Lease, time.Time, time.Duration, int, string) (NackOutcome, error) {
+	return NackRequeued, nil
+}
+func (q *idleDispatchQueue) ReclaimExpired(time.Time, int) (int, error) {
+	q.reclaims.Add(1)
+	return 0, nil
+}
+
+func TestDispatcherLifecycleStartsStopsAndRejectsDoubleStart(t *testing.T) {
+	registry, err := NewRegistry([]RouteSpec{validRouteSpec()}, []string{validRouteSpec().URL}, testGetenv)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	queue := &idleDispatchQueue{}
+	dispatcher, err := NewDispatcher(queue, registry, &stubDeliverer{}, FinalizerFunc(func(context.Context, Event, DecisionResult) error { return nil }), DispatcherConfig{
+		LeaseDuration: time.Second, PollInterval: time.Millisecond, ReclaimInterval: time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("NewDispatcher() error = %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := dispatcher.Start(ctx); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	if err := dispatcher.Start(ctx); err == nil {
+		t.Fatal("second Start() error = nil")
+	}
+	deadline := time.After(time.Second)
+	for queue.claims.Load() == 0 || queue.reclaims.Load() == 0 {
+		select {
+		case <-deadline:
+			t.Fatal("dispatcher did not poll and reclaim before deadline")
+		default:
+		}
+	}
+	dispatcher.Stop()
+	dispatcher.Stop() // idempotent
+	if !strings.Contains(dispatcher.String(), "lease=1s") {
+		t.Fatalf("String() = %q", dispatcher.String())
+	}
+}
+
+type stubDeliverer struct{}
+
+func (*stubDeliverer) Deliver(context.Context, *Route, DecisionRequest) (DecisionResult, error) {
+	return DecisionResult{}, nil
+}
+
+func TestConfigAndValidationErrorPathsFailClosed(t *testing.T) {
+	if got := LoadAllowedURLs(" https://a.internal/x, ,https://b.internal/y "); len(got) != 2 {
+		t.Fatalf("LoadAllowedURLs() = %v", got)
+	}
+	for _, raw := range []string{
+		`not-json`,
+		`[{"sender_uid":"notification","unknown":true}]`,
+		`[] {}`,
+		`[{"sender_uid":"notification","owner":"docs","action_type":"access_request.decision","url":"https://docs.internal/x","secret_env":"OCTO_DOCS_CARD_ACTION_SECRET","timeout_ms":-1}]`,
+	} {
+		if _, err := LoadRouteSpecs(raw); err == nil {
+			t.Fatalf("LoadRouteSpecs(%q) error = nil", raw)
+		}
+	}
+
+	tests := []struct {
+		name   string
+		mutate func(*RouteSpec)
+	}{
+		{"invalid sender", func(s *RouteSpec) { s.SenderUID = "iwh_bad" }},
+		{"invalid owner", func(s *RouteSpec) { s.Owner = "Bad Owner" }},
+		{"invalid action", func(s *RouteSpec) { s.ActionType = "Bad Action" }},
+		{"invalid secret env", func(s *RouteSpec) { s.SecretEnv = "bad-env" }},
+		{"timeout too small", func(s *RouteSpec) { s.Timeout = time.Millisecond }},
+		{"attempts too many", func(s *RouteSpec) { s.MaxAttempts = 11 }},
+		{"base backoff too small", func(s *RouteSpec) { s.BaseBackoff = time.Millisecond }},
+		{"max backoff below base", func(s *RouteSpec) { s.MaxBackoff = 500 * time.Millisecond }},
+		{"concurrency too high", func(s *RouteSpec) { s.MaxInFlight = 101 }},
+		{"query URL", func(s *RouteSpec) { s.URL += "?dynamic=1" }},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			spec := validRouteSpec()
+			tt.mutate(&spec)
+			_, err := NewRegistry([]RouteSpec{spec}, []string{spec.URL}, testGetenv)
+			if err == nil {
+				t.Fatal("NewRegistry() error = nil")
+			}
+		})
+	}
+}
+
+func TestDecisionAndQueueInputBounds(t *testing.T) {
+	invalidResults := []string{
+		`{"disposition":"applied","state":"approved"} {}`,
+		`{"disposition":"applied","state":"approved","requester_uid":" padded "}`,
+		`{"disposition":"applied","state":"approved","display":{"":"x"}}`,
+	}
+	for _, raw := range invalidResults {
+		if _, err := DecodeDecisionResult(strings.NewReader(raw)); err == nil {
+			t.Fatalf("DecodeDecisionResult(%q) error = nil", raw)
+		}
+	}
+
+	client := rd.NewClient(&rd.Options{Addr: "127.0.0.1:1"})
+	defer client.Close()
+	if _, err := NewRedisQueue(nil, QueueConfig{Prefix: "x", LiveTTL: time.Second, DLQRetention: time.Second}); err == nil {
+		t.Fatal("NewRedisQueue(nil) error = nil")
+	}
+	if _, err := NewRedisQueue(client, QueueConfig{Prefix: "bad prefix", LiveTTL: time.Second, DLQRetention: time.Second}); err == nil {
+		t.Fatal("NewRedisQueue(bad prefix) error = nil")
+	}
+	queue, err := NewRedisQueue(client, QueueConfig{Prefix: "bounds", LiveTTL: time.Second, DLQRetention: time.Second})
+	if err != nil {
+		t.Fatalf("NewRedisQueue() error = %v", err)
+	}
+	if err := queue.Enqueue(Event{}, time.Now()); err == nil {
+		t.Fatal("Enqueue(invalid event) error = nil")
+	}
+	if _, err := queue.Claim(time.Now(), 0); err == nil {
+		t.Fatal("Claim(zero lease) error = nil")
+	}
+	if _, err := queue.Nack(Lease{}, time.Now(), -time.Second, 1, "x"); err == nil {
+		t.Fatal("Nack(negative delay) error = nil")
+	}
+	if _, err := queue.ReclaimExpired(time.Now(), 0); err == nil {
+		t.Fatal("ReclaimExpired(zero limit) error = nil")
+	}
+}
+
+func TestTruncatePreservesUTF8WithinByteLimit(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		limit int
+		want  string
+	}{
+		{name: "multibyte boundary", value: "你好", limit: 4, want: "你"},
+		{name: "ASCII boundary", value: "abcdef", limit: 4, want: "abcd"},
+		{name: "below limit", value: "你好", limit: 6, want: "你好"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := truncate(tt.value, tt.limit)
+			if got != tt.want || len(got) > tt.limit || !utf8.ValidString(got) {
+				t.Fatalf("truncate(%q, %d) = %q, want %q valid UTF-8 within byte limit", tt.value, tt.limit, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDeliveryErrorCarriesRetryMetadataWithoutResponseBody(t *testing.T) {
+	cause := errors.New("dial timeout")
+	err := &DeliveryError{Category: "transport_failed", retryable: true, cause: cause}
+	if !Retryable(err) || !errors.Is(err, cause) || !strings.Contains(err.Error(), "transport_failed") {
+		t.Fatalf("delivery error metadata lost: %v", err)
+	}
+	statusErr := &DeliveryError{Category: "consumer_5xx", Status: 503}
+	if !strings.Contains(statusErr.Error(), "503") {
+		t.Fatalf("status error = %q", statusErr.Error())
+	}
+}

--- a/internal/cardactiondispatch/dispatcher.go
+++ b/internal/cardactiondispatch/dispatcher.go
@@ -1,0 +1,420 @@
+package cardactiondispatch
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+type dispatchQueue interface {
+	Claim(now time.Time, leaseDuration time.Duration) (*Lease, error)
+	Renew(eventID int64, token string, now time.Time, leaseDuration time.Duration) (bool, error)
+	Defer(eventID int64, token string, due time.Time) (bool, error)
+	Ack(eventID int64, token string) (bool, error)
+	Nack(lease Lease, now time.Time, delay time.Duration, maxAttempts int, reason string) (NackOutcome, error)
+	ReclaimExpired(now time.Time, limit int) (int, error)
+}
+
+type callbackDeliverer interface {
+	Deliver(ctx context.Context, route *Route, request DecisionRequest) (DecisionResult, error)
+}
+
+type Finalizer interface {
+	Finalize(ctx context.Context, event Event, result DecisionResult) error
+}
+
+type FinalizerFunc func(context.Context, Event, DecisionResult) error
+
+func (f FinalizerFunc) Finalize(ctx context.Context, event Event, result DecisionResult) error {
+	return f(ctx, event, result)
+}
+
+type DispatcherConfig struct {
+	LeaseDuration   time.Duration
+	PollInterval    time.Duration
+	ReclaimInterval time.Duration
+	Metrics         *Metrics
+	Logger          interface {
+		Warn(string, ...zap.Field)
+		Error(string, ...zap.Field)
+	}
+}
+
+type Dispatcher struct {
+	queue     dispatchQueue
+	registry  *Registry
+	deliverer callbackDeliverer
+	finalizer Finalizer
+	config    DispatcherConfig
+	metrics   *Metrics
+	logger    interface {
+		Warn(string, ...zap.Field)
+		Error(string, ...zap.Field)
+	}
+	routeSlots  map[routeKey]chan struct{}
+	workerCount int
+	clock       func() time.Time
+
+	mu     sync.Mutex
+	cancel context.CancelFunc
+	wait   sync.WaitGroup
+}
+
+func NewDispatcher(queue dispatchQueue, registry *Registry, deliverer callbackDeliverer, finalizer Finalizer, cfg DispatcherConfig) (*Dispatcher, error) {
+	if queue == nil || registry == nil || deliverer == nil || finalizer == nil {
+		return nil, errors.New("cardactiondispatch: dispatcher dependencies are required")
+	}
+	if cfg.LeaseDuration == 0 {
+		cfg.LeaseDuration = 30 * time.Second
+	}
+	if cfg.PollInterval == 0 {
+		cfg.PollInterval = 250 * time.Millisecond
+	}
+	if cfg.ReclaimInterval == 0 {
+		cfg.ReclaimInterval = 5 * time.Second
+	}
+	if cfg.LeaseDuration <= 0 || cfg.PollInterval <= 0 || cfg.ReclaimInterval <= 0 {
+		return nil, errors.New("cardactiondispatch: dispatcher durations must be positive")
+	}
+	routeSlots := make(map[routeKey]chan struct{}, len(registry.routes))
+	workerCount := 0
+	for key, route := range registry.routes {
+		routeSlots[key] = make(chan struct{}, route.MaxInFlight)
+		workerCount += route.MaxInFlight
+	}
+	if workerCount < 1 {
+		workerCount = 1
+	}
+	if workerCount > 100 {
+		workerCount = 100
+	}
+	return &Dispatcher{
+		queue: queue, registry: registry, deliverer: deliverer, finalizer: finalizer,
+		config: cfg, metrics: cfg.Metrics, logger: cfg.Logger,
+		routeSlots: routeSlots, workerCount: workerCount, clock: time.Now,
+	}, nil
+}
+
+// ProcessOne claims and completely handles at most one due event. Callback and
+// finalization failures are converted into a durable retry/DLQ transition; an
+// error is returned only when the queue state itself could not be made safe.
+func (d *Dispatcher) ProcessOne(ctx context.Context, now time.Time) (bool, error) {
+	if err := ctx.Err(); err != nil {
+		return false, err
+	}
+	lease, err := d.queue.Claim(now, d.config.LeaseDuration)
+	if err != nil {
+		d.metrics.observeError("", "queue_error")
+		return false, err
+	}
+	if lease == nil {
+		return false, nil
+	}
+	owner := lease.Event.Owner
+	started := time.Now()
+	resultLabel := "error"
+	d.metrics.beginLease(owner)
+	defer func() {
+		d.metrics.endLease(owner)
+		d.metrics.finish(owner, resultLabel, started)
+	}()
+	route, ok := d.registry.Route(lease.Event.SenderUID, lease.Event.Owner, lease.Event.ActionType)
+	if !ok {
+		d.metrics.observeError(owner, "route_missing")
+		outcome, nackErr := d.nack(*lease, now, false, lease.Attempt, "route_missing")
+		resultLabel = resultForNack(outcome, nackErr)
+		d.logTransition(lease, "route_missing", outcome, nackErr)
+		d.refreshDepthMetrics()
+		return true, nackErr
+	}
+	if lease.Attempt > route.MaxAttempts {
+		const category = "attempts_exhausted"
+		d.metrics.observeError(owner, category)
+		outcome, nackErr := d.queue.Nack(*lease, d.clock(), 0, route.MaxAttempts, category)
+		resultLabel = resultForNack(outcome, nackErr)
+		d.logTransition(lease, category, outcome, nackErr)
+		d.refreshDepthMetrics()
+		return true, nackErr
+	}
+	slot := d.routeSlots[routeKey{senderUID: route.SenderUID, owner: route.Owner, actionType: route.ActionType}]
+	if slot != nil {
+		select {
+		case slot <- struct{}{}:
+			defer func() { <-slot }()
+		default:
+			deferred, deferErr := d.queue.Defer(lease.Event.EventID, lease.Token, d.clock().Add(d.config.PollInterval))
+			if deferErr != nil {
+				d.metrics.observeError(owner, "queue_error")
+				d.refreshDepthMetrics()
+				return true, deferErr
+			}
+			if !deferred {
+				d.metrics.observeError(owner, "ack_lost")
+				d.refreshDepthMetrics()
+				return true, errors.New("cardactiondispatch: lease ownership lost before capacity defer")
+			}
+			resultLabel = "deferred"
+			d.refreshDepthMetrics()
+			return true, nil
+		}
+	}
+	// Once an event is leased, process it to a durable queue transition even if
+	// shutdown begins. HTTP still has the per-route timeout, so Stop is bounded.
+	workCtx := context.WithoutCancel(ctx)
+	result, err := d.deliverer.Deliver(workCtx, route, DecisionRequestFromEvent(lease.Event))
+	if err != nil {
+		category := errorCategory(err)
+		d.metrics.observeError(owner, category)
+		retry := Retryable(err)
+		outcome, nackErr := d.nack(*lease, d.clock(), retry, route.MaxAttempts, category)
+		if outcome == NackRequeued {
+			d.metrics.observeRetry(owner)
+		}
+		resultLabel = resultForNack(outcome, nackErr)
+		d.logTransition(lease, category, outcome, nackErr)
+		d.refreshDepthMetrics()
+		return true, nackErr
+	}
+	stopHeartbeat := d.startLeaseHeartbeat(*lease)
+	finalizeErr := d.finalizer.Finalize(workCtx, lease.Event, result)
+	if renewErr := stopHeartbeat(); renewErr != nil {
+		d.metrics.observeError(owner, "queue_error")
+		d.refreshDepthMetrics()
+		return true, renewErr
+	}
+	if finalizeErr != nil {
+		category := finalizeErrorCategory(finalizeErr)
+		d.metrics.observeError(owner, category)
+		if category == "applicant_notify_failed" {
+			d.metrics.observeApplicantNotifyFailure(owner)
+		}
+		outcome, nackErr := d.nack(*lease, d.clock(), true, route.MaxAttempts, category)
+		if outcome == NackRequeued {
+			d.metrics.observeRetry(owner)
+		}
+		resultLabel = resultForNack(outcome, nackErr)
+		d.logTransition(lease, category, outcome, nackErr)
+		d.refreshDepthMetrics()
+		return true, nackErr
+	}
+	acked, err := d.queue.Ack(lease.Event.EventID, lease.Token)
+	if err != nil {
+		d.metrics.observeError(owner, "queue_error")
+		return true, err
+	}
+	if !acked {
+		d.metrics.observeError(owner, "ack_lost")
+		return true, errors.New("cardactiondispatch: lease ownership lost before ack")
+	}
+	resultLabel = "ok"
+	d.refreshDepthMetrics()
+	return true, nil
+}
+
+func (d *Dispatcher) startLeaseHeartbeat(lease Lease) func() error {
+	stop := make(chan struct{})
+	done := make(chan error, 1)
+	interval := d.config.LeaseDuration / 3
+	if interval <= 0 {
+		interval = time.Nanosecond
+	}
+	go func() {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-stop:
+				done <- nil
+				return
+			case now := <-ticker.C:
+				renewed, err := d.queue.Renew(lease.Event.EventID, lease.Token, now, d.config.LeaseDuration)
+				if err != nil {
+					done <- err
+					return
+				}
+				if !renewed {
+					done <- errors.New("cardactiondispatch: lease ownership lost during finalization")
+					return
+				}
+			}
+		}
+	}()
+	return func() error {
+		close(stop)
+		return <-done
+	}
+}
+
+func (d *Dispatcher) logTransition(lease *Lease, category string, outcome NackOutcome, err error) {
+	if d.logger == nil || lease == nil {
+		return
+	}
+	fields := []zap.Field{
+		zap.Int64("event_id", lease.Event.EventID),
+		zap.String("owner", metricOwner(lease.Event.Owner)),
+		zap.Int("attempt", lease.Attempt),
+		zap.String("category", metricErrorCategory(category)),
+		zap.String("queue_outcome", string(outcome)),
+	}
+	if err != nil {
+		fields = append(fields, zap.Error(err))
+	}
+	if outcome == NackDeadLettered || err != nil {
+		d.logger.Error("card action dispatch failed", fields...)
+		return
+	}
+	d.logger.Warn("card action dispatch scheduled retry", fields...)
+}
+
+func (d *Dispatcher) nack(lease Lease, now time.Time, retry bool, maxAttempts int, reason string) (NackOutcome, error) {
+	delay := time.Duration(0)
+	if retry {
+		delay = retryBackoff(lease.Attempt, d.routeFor(lease.Event))
+	} else {
+		// A permanent protocol/configuration error moves to DLQ immediately.
+		maxAttempts = lease.Attempt
+	}
+	return d.queue.Nack(lease, now, delay, maxAttempts, reason)
+}
+
+func (d *Dispatcher) routeFor(event Event) *Route {
+	route, _ := d.registry.Route(event.SenderUID, event.Owner, event.ActionType)
+	return route
+}
+
+func retryBackoff(attempt int, route *Route) time.Duration {
+	if route == nil {
+		return 0
+	}
+	delay := route.BaseBackoff
+	for i := 1; i < attempt && delay < route.MaxBackoff; i++ {
+		if delay > route.MaxBackoff/2 {
+			return route.MaxBackoff
+		}
+		delay *= 2
+	}
+	if delay > route.MaxBackoff {
+		return route.MaxBackoff
+	}
+	return delay
+}
+
+func errorCategory(err error) string {
+	var deliveryErr *DeliveryError
+	if errors.As(err, &deliveryErr) {
+		return deliveryErr.Category
+	}
+	return "unknown"
+}
+
+type categorizedFinalizerError interface {
+	Category() string
+}
+
+func finalizeErrorCategory(err error) string {
+	var categorized categorizedFinalizerError
+	if errors.As(err, &categorized) {
+		return metricErrorCategory(categorized.Category())
+	}
+	return "finalize_failed"
+}
+
+func resultForNack(outcome NackOutcome, err error) string {
+	if err != nil {
+		return "error"
+	}
+	if outcome == NackDeadLettered {
+		return "dlq"
+	}
+	return "retry"
+}
+
+type queueDepthReader interface {
+	Depths() (QueueDepths, error)
+}
+
+func (d *Dispatcher) refreshDepthMetrics() {
+	reader, ok := d.queue.(queueDepthReader)
+	if !ok {
+		return
+	}
+	depths, err := reader.Depths()
+	if err != nil {
+		d.metrics.observeError("", "queue_error")
+		return
+	}
+	d.metrics.setDepths(depths.Ready, depths.DLQ)
+}
+
+func (d *Dispatcher) Start(parent context.Context) error {
+	if parent == nil {
+		return errors.New("cardactiondispatch: parent context is required")
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.cancel != nil {
+		return errors.New("cardactiondispatch: dispatcher already started")
+	}
+	ctx, cancel := context.WithCancel(parent)
+	d.cancel = cancel
+	d.wait.Add(1)
+	go d.run(ctx)
+	return nil
+}
+
+func (d *Dispatcher) Stop() {
+	d.mu.Lock()
+	cancel := d.cancel
+	d.cancel = nil
+	d.mu.Unlock()
+	if cancel != nil {
+		cancel()
+		d.wait.Wait()
+	}
+}
+
+func (d *Dispatcher) run(ctx context.Context) {
+	defer d.wait.Done()
+	poll := time.NewTicker(d.config.PollInterval)
+	reclaim := time.NewTicker(d.config.ReclaimInterval)
+	defer poll.Stop()
+	defer reclaim.Stop()
+	var workers sync.WaitGroup
+	for i := 0; i < d.workerCount; i++ {
+		workers.Add(1)
+		go func() {
+			defer workers.Done()
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				case now := <-poll.C:
+					for {
+						processed, err := d.ProcessOne(ctx, now)
+						if err != nil || !processed {
+							break
+						}
+						now = time.Now()
+					}
+				}
+			}
+		}()
+	}
+	defer workers.Wait()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case now := <-reclaim.C:
+			_, _ = d.queue.ReclaimExpired(now, 100)
+		}
+	}
+}
+
+func (d *Dispatcher) String() string {
+	return fmt.Sprintf("cardactiondispatch.Dispatcher{lease=%s,poll=%s}", d.config.LeaseDuration, d.config.PollInterval)
+}

--- a/internal/cardactiondispatch/dispatcher_test.go
+++ b/internal/cardactiondispatch/dispatcher_test.go
@@ -1,0 +1,888 @@
+package cardactiondispatch
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	rd "github.com/go-redis/redis"
+)
+
+type concurrentLeaseQueue struct {
+	mu       sync.Mutex
+	leases   []Lease
+	acked    chan int64
+	nacked   chan nackCall
+	renewed  chan renewCall
+	deferred chan deferCall
+}
+
+type nackCall struct {
+	now          time.Time
+	delay        time.Duration
+	leaseAttempt int
+	maxAttempts  int
+	reason       string
+}
+
+type renewCall struct {
+	eventID       int64
+	token         string
+	leaseDuration time.Duration
+}
+
+type deferCall struct {
+	eventID int64
+	token   string
+	due     time.Time
+}
+
+func (q *concurrentLeaseQueue) Claim(time.Time, time.Duration) (*Lease, error) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	if len(q.leases) == 0 {
+		return nil, nil
+	}
+	lease := q.leases[0]
+	q.leases = q.leases[1:]
+	return &lease, nil
+}
+func (q *concurrentLeaseQueue) Ack(eventID int64, _ string) (bool, error) {
+	if q.acked != nil {
+		q.acked <- eventID
+	}
+	return true, nil
+}
+func (q *concurrentLeaseQueue) Nack(lease Lease, now time.Time, delay time.Duration, maxAttempts int, reason string) (NackOutcome, error) {
+	if q.nacked != nil {
+		q.nacked <- nackCall{
+			now: now, delay: delay, leaseAttempt: lease.Attempt,
+			maxAttempts: maxAttempts, reason: reason,
+		}
+	}
+	if lease.Attempt >= maxAttempts {
+		return NackDeadLettered, nil
+	}
+	return NackRequeued, nil
+}
+func (q *concurrentLeaseQueue) Renew(eventID int64, token string, _ time.Time, leaseDuration time.Duration) (bool, error) {
+	if q.renewed != nil {
+		q.renewed <- renewCall{eventID: eventID, token: token, leaseDuration: leaseDuration}
+	}
+	return true, nil
+}
+func (q *concurrentLeaseQueue) Defer(eventID int64, token string, due time.Time) (bool, error) {
+	if q.deferred != nil {
+		q.deferred <- deferCall{eventID: eventID, token: token, due: due}
+	}
+	return true, nil
+}
+func (*concurrentLeaseQueue) ReclaimExpired(time.Time, int) (int, error) { return 0, nil }
+
+type capturingDeliverer struct {
+	owners chan string
+}
+
+type callbackDelivererFunc func(context.Context, *Route, DecisionRequest) (DecisionResult, error)
+
+func (f callbackDelivererFunc) Deliver(ctx context.Context, route *Route, request DecisionRequest) (DecisionResult, error) {
+	return f(ctx, route, request)
+}
+
+func (d *capturingDeliverer) Deliver(_ context.Context, route *Route, _ DecisionRequest) (DecisionResult, error) {
+	d.owners <- route.Owner
+	return DecisionResult{Disposition: DispositionApplied, State: StateApproved}, nil
+}
+
+type blockingDeliverer struct {
+	entered chan struct{}
+	release chan struct{}
+}
+
+func (d *blockingDeliverer) Deliver(context.Context, *Route, DecisionRequest) (DecisionResult, error) {
+	d.entered <- struct{}{}
+	<-d.release
+	return DecisionResult{Disposition: DispositionApplied, State: StateApproved}, nil
+}
+
+type contextAwareBlockingDeliverer struct {
+	entered chan struct{}
+	release chan struct{}
+}
+
+type retryableDeliverer struct{}
+
+func (*retryableDeliverer) Deliver(context.Context, *Route, DecisionRequest) (DecisionResult, error) {
+	return DecisionResult{}, &DeliveryError{Category: "consumer_5xx", retryable: true}
+}
+
+func (d *contextAwareBlockingDeliverer) Deliver(ctx context.Context, _ *Route, _ DecisionRequest) (DecisionResult, error) {
+	d.entered <- struct{}{}
+	select {
+	case <-d.release:
+		return DecisionResult{Disposition: DispositionApplied, State: StateApproved}, nil
+	case <-ctx.Done():
+		return DecisionResult{}, ctx.Err()
+	}
+}
+
+func TestDispatcherHonorsPerRouteConcurrency(t *testing.T) {
+	spec := validRouteSpec()
+	spec.MaxInFlight = 2
+	registry, err := NewRegistry([]RouteSpec{spec}, []string{spec.URL}, testGetenv)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	queue := &concurrentLeaseQueue{}
+	for i := int64(1); i <= 5; i++ {
+		event := testDispatchEvent()
+		event.EventID = i
+		queue.leases = append(queue.leases, Lease{Event: event, Token: strconv.FormatInt(i, 10), Attempt: 1})
+	}
+	deliverer := &blockingDeliverer{entered: make(chan struct{}, 5), release: make(chan struct{})}
+	var releaseOnce sync.Once
+	release := func() { releaseOnce.Do(func() { close(deliverer.release) }) }
+	defer release()
+	dispatcher, err := NewDispatcher(queue, registry, deliverer, FinalizerFunc(func(context.Context, Event, DecisionResult) error { return nil }), DispatcherConfig{LeaseDuration: time.Second})
+	if err != nil {
+		t.Fatalf("NewDispatcher() error = %v", err)
+	}
+	var wait sync.WaitGroup
+	for i := 0; i < 5; i++ {
+		wait.Add(1)
+		go func() {
+			defer wait.Done()
+			_, _ = dispatcher.ProcessOne(context.Background(), time.Now())
+		}()
+	}
+	for i := 0; i < 2; i++ {
+		select {
+		case <-deliverer.entered:
+		case <-time.After(time.Second):
+			t.Fatal("expected two callbacks to enter")
+		}
+	}
+	select {
+	case <-deliverer.entered:
+		t.Fatal("third callback exceeded route MaxInFlight=2")
+	case <-time.After(20 * time.Millisecond):
+	}
+	release()
+	wait.Wait()
+}
+
+func TestDispatcherDefersSaturatedRouteAndProcessesOtherRoute(t *testing.T) {
+	docs := validRouteSpec()
+	docs.MaxInFlight = 1
+	tasks := docs
+	tasks.Owner = "tasks"
+	tasks.ActionType = "task.decision"
+	tasks.URL = "https://tasks.internal/v1/card-actions/decide"
+	registry, err := NewRegistry([]RouteSpec{docs, tasks}, []string{docs.URL, tasks.URL}, testGetenv)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	docsEvent := testDispatchEvent()
+	tasksEvent := testDispatchEvent()
+	tasksEvent.EventID = 43
+	tasksEvent.Owner = tasks.Owner
+	tasksEvent.ActionType = tasks.ActionType
+	queue := &concurrentLeaseQueue{
+		leases: []Lease{
+			{Event: docsEvent, Token: "docs-lease", Attempt: 1},
+			{Event: tasksEvent, Token: "tasks-lease", Attempt: 1},
+		},
+		acked:    make(chan int64, 1),
+		deferred: make(chan deferCall, 1),
+	}
+	deliverer := &capturingDeliverer{owners: make(chan string, 1)}
+	dispatcher, err := NewDispatcher(queue, registry, deliverer, FinalizerFunc(func(context.Context, Event, DecisionResult) error { return nil }), DispatcherConfig{
+		LeaseDuration: time.Second,
+		PollInterval:  25 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("NewDispatcher() error = %v", err)
+	}
+	docsSlot := dispatcher.routeSlots[routeKey{senderUID: docs.SenderUID, owner: docs.Owner, actionType: docs.ActionType}]
+	docsSlot <- struct{}{}
+	defer func() { <-docsSlot }()
+	now := time.Now().Truncate(time.Millisecond)
+	dispatcher.clock = func() time.Time { return now }
+
+	firstDone := make(chan error, 1)
+	go func() {
+		_, processErr := dispatcher.ProcessOne(context.Background(), now)
+		firstDone <- processErr
+	}()
+	select {
+	case processErr := <-firstDone:
+		if processErr != nil {
+			t.Fatalf("ProcessOne(saturated route) error = %v", processErr)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("saturated route blocked while holding a lease")
+	}
+	select {
+	case call := <-queue.deferred:
+		if call.eventID != docsEvent.EventID || call.token != "docs-lease" || !call.due.Equal(now.Add(25*time.Millisecond)) {
+			t.Fatalf("Defer() call = %+v", call)
+		}
+	default:
+		t.Fatal("saturated route lease was not deferred")
+	}
+
+	if processed, processErr := dispatcher.ProcessOne(context.Background(), now); processErr != nil || !processed {
+		t.Fatalf("ProcessOne(other route) = (%v, %v), want (true, nil)", processed, processErr)
+	}
+	select {
+	case owner := <-deliverer.owners:
+		if owner != tasks.Owner {
+			t.Fatalf("delivered owner = %q, want %q", owner, tasks.Owner)
+		}
+	default:
+		t.Fatal("available route was not delivered")
+	}
+}
+
+func TestDispatcherStopDoesNotWaitOnSaturatedRouteSlot(t *testing.T) {
+	spec := validRouteSpec()
+	spec.MaxInFlight = 1
+	registry, err := NewRegistry([]RouteSpec{spec}, []string{spec.URL}, testGetenv)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	event := testDispatchEvent()
+	queue := &concurrentLeaseQueue{
+		leases:   []Lease{{Event: event, Token: "lease-42", Attempt: 1}},
+		deferred: make(chan deferCall, 1),
+	}
+	dispatcher, err := NewDispatcher(queue, registry, &stubDeliverer{}, FinalizerFunc(func(context.Context, Event, DecisionResult) error { return nil }), DispatcherConfig{
+		LeaseDuration: time.Second,
+		PollInterval:  time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("NewDispatcher() error = %v", err)
+	}
+	slot := dispatcher.routeSlots[routeKey{senderUID: spec.SenderUID, owner: spec.Owner, actionType: spec.ActionType}]
+	slot <- struct{}{}
+	defer func() { <-slot }()
+	if err := dispatcher.Start(context.Background()); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	select {
+	case <-queue.deferred:
+	case <-time.After(time.Second):
+		dispatcher.Stop()
+		t.Fatal("saturated route event was not deferred")
+	}
+	stopped := make(chan struct{})
+	go func() {
+		dispatcher.Stop()
+		close(stopped)
+	}()
+	select {
+	case <-stopped:
+	case <-time.After(time.Second):
+		t.Fatal("Stop() waited on a saturated route slot")
+	}
+}
+
+func TestDispatcherStartProcessesUpToPerRouteConcurrency(t *testing.T) {
+	spec := validRouteSpec()
+	spec.MaxInFlight = 2
+	registry, err := NewRegistry([]RouteSpec{spec}, []string{spec.URL}, testGetenv)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	queue := &concurrentLeaseQueue{}
+	for i := int64(1); i <= 3; i++ {
+		event := testDispatchEvent()
+		event.EventID = i
+		queue.leases = append(queue.leases, Lease{Event: event, Token: strconv.FormatInt(i, 10), Attempt: 1})
+	}
+	deliverer := &blockingDeliverer{entered: make(chan struct{}, 3), release: make(chan struct{})}
+	var releaseOnce sync.Once
+	release := func() { releaseOnce.Do(func() { close(deliverer.release) }) }
+	dispatcher, err := NewDispatcher(queue, registry, deliverer, FinalizerFunc(func(context.Context, Event, DecisionResult) error { return nil }), DispatcherConfig{
+		LeaseDuration: time.Second,
+		PollInterval:  time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("NewDispatcher() error = %v", err)
+	}
+	if err := dispatcher.Start(context.Background()); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	defer dispatcher.Stop()
+	defer release()
+
+	for i := 0; i < 2; i++ {
+		select {
+		case <-deliverer.entered:
+		case <-time.After(time.Second):
+			t.Fatal("dispatcher did not fill the configured route concurrency")
+		}
+	}
+	select {
+	case <-deliverer.entered:
+		t.Fatal("dispatcher exceeded route MaxInFlight=2")
+	case <-time.After(20 * time.Millisecond):
+	}
+	release()
+}
+
+func TestDispatcherStopCompletesClaimedEvent(t *testing.T) {
+	spec := validRouteSpec()
+	registry, err := NewRegistry([]RouteSpec{spec}, []string{spec.URL}, testGetenv)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	event := testDispatchEvent()
+	queue := &concurrentLeaseQueue{
+		leases: []Lease{{Event: event, Token: "lease-42", Attempt: 1}},
+		acked:  make(chan int64, 1),
+	}
+	deliverer := &contextAwareBlockingDeliverer{entered: make(chan struct{}, 1), release: make(chan struct{})}
+	var releaseOnce sync.Once
+	release := func() { releaseOnce.Do(func() { close(deliverer.release) }) }
+	defer release()
+	dispatcher, err := NewDispatcher(queue, registry, deliverer, FinalizerFunc(func(context.Context, Event, DecisionResult) error { return nil }), DispatcherConfig{
+		LeaseDuration: time.Second,
+		PollInterval:  time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("NewDispatcher() error = %v", err)
+	}
+	if err := dispatcher.Start(context.Background()); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	select {
+	case <-deliverer.entered:
+	case <-time.After(time.Second):
+		dispatcher.Stop()
+		t.Fatal("dispatcher did not claim the event")
+	}
+
+	stopped := make(chan struct{})
+	go func() {
+		dispatcher.Stop()
+		close(stopped)
+	}()
+	select {
+	case <-stopped:
+		t.Fatal("Stop() returned before the claimed event reached a durable transition")
+	case <-time.After(20 * time.Millisecond):
+	}
+	release()
+	select {
+	case eventID := <-queue.acked:
+		if eventID != event.EventID {
+			t.Fatalf("Ack() event_id = %d, want %d", eventID, event.EventID)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("claimed event was not acknowledged during shutdown")
+	}
+	select {
+	case <-stopped:
+	case <-time.After(time.Second):
+		t.Fatal("Stop() did not return after the claimed event completed")
+	}
+}
+
+func TestDispatcherRenewsLeaseDuringSlowFinalization(t *testing.T) {
+	spec := validRouteSpec()
+	registry, err := NewRegistry([]RouteSpec{spec}, []string{spec.URL}, testGetenv)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	event := testDispatchEvent()
+	queue := &concurrentLeaseQueue{
+		leases:  []Lease{{Event: event, Token: "lease-42", Attempt: 1}},
+		acked:   make(chan int64, 1),
+		renewed: make(chan renewCall, 1),
+	}
+	finalizeEntered := make(chan struct{}, 1)
+	releaseFinalize := make(chan struct{})
+	var releaseOnce sync.Once
+	release := func() { releaseOnce.Do(func() { close(releaseFinalize) }) }
+	defer release()
+	finalizer := FinalizerFunc(func(context.Context, Event, DecisionResult) error {
+		finalizeEntered <- struct{}{}
+		<-releaseFinalize
+		return nil
+	})
+	leaseDuration := 60 * time.Millisecond
+	dispatcher, err := NewDispatcher(queue, registry, &stubDeliverer{}, finalizer, DispatcherConfig{
+		LeaseDuration: leaseDuration,
+	})
+	if err != nil {
+		t.Fatalf("NewDispatcher() error = %v", err)
+	}
+	done := make(chan error, 1)
+	go func() {
+		_, processErr := dispatcher.ProcessOne(context.Background(), time.Now())
+		done <- processErr
+	}()
+	select {
+	case <-finalizeEntered:
+	case <-time.After(time.Second):
+		t.Fatal("finalizer did not start")
+	}
+	select {
+	case call := <-queue.renewed:
+		if call.eventID != event.EventID || call.token != "lease-42" || call.leaseDuration != leaseDuration {
+			t.Fatalf("Renew() call = %+v", call)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("slow finalization did not renew its lease")
+	}
+	release()
+	select {
+	case processErr := <-done:
+		if processErr != nil {
+			t.Fatalf("ProcessOne() error = %v", processErr)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("ProcessOne() did not finish after finalizer release")
+	}
+	select {
+	case eventID := <-queue.acked:
+		if eventID != event.EventID {
+			t.Fatalf("Ack() event_id = %d, want %d", eventID, event.EventID)
+		}
+	default:
+		t.Fatal("finalized event was not acknowledged")
+	}
+}
+
+func TestRedisQueueRenewExtendsOnlyMatchingLease(t *testing.T) {
+	queue := newDispatchTestQueue(t)
+	now := time.Now().Truncate(time.Millisecond)
+	event := testDispatchEvent()
+	if err := queue.Enqueue(event, now); err != nil {
+		t.Fatalf("Enqueue() error = %v", err)
+	}
+	lease, err := queue.Claim(now, 50*time.Millisecond)
+	if err != nil || lease == nil {
+		t.Fatalf("Claim() = (%+v, %v)", lease, err)
+	}
+	if renewed, renewErr := queue.Renew(event.EventID, "wrong-token", now.Add(40*time.Millisecond), 100*time.Millisecond); renewErr != nil || renewed {
+		t.Fatalf("Renew(wrong token) = (%v, %v), want (false, nil)", renewed, renewErr)
+	}
+	if renewed, renewErr := queue.Renew(event.EventID, lease.Token, now.Add(40*time.Millisecond), 100*time.Millisecond); renewErr != nil || !renewed {
+		t.Fatalf("Renew(valid token) = (%v, %v), want (true, nil)", renewed, renewErr)
+	}
+	if reclaimed, reclaimErr := queue.ReclaimExpired(now.Add(60*time.Millisecond), 10); reclaimErr != nil || reclaimed != 0 {
+		t.Fatalf("ReclaimExpired(before renewed lease) = (%d, %v), want (0, nil)", reclaimed, reclaimErr)
+	}
+	if reclaimed, reclaimErr := queue.ReclaimExpired(now.Add(150*time.Millisecond), 10); reclaimErr != nil || reclaimed != 1 {
+		t.Fatalf("ReclaimExpired(after renewed lease) = (%d, %v), want (1, nil)", reclaimed, reclaimErr)
+	}
+}
+
+func TestRedisQueueDeferPreservesAttemptAndOwnership(t *testing.T) {
+	queue := newDispatchTestQueue(t)
+	now := time.Now().Truncate(time.Millisecond)
+	event := testDispatchEvent()
+	if err := queue.Enqueue(event, now); err != nil {
+		t.Fatalf("Enqueue() error = %v", err)
+	}
+	lease, err := queue.Claim(now, time.Second)
+	if err != nil || lease == nil || lease.Attempt != 1 {
+		t.Fatalf("Claim() = (%+v, %v), want attempt 1", lease, err)
+	}
+	due := now.Add(100 * time.Millisecond)
+	if deferred, deferErr := queue.Defer(event.EventID, "wrong-token", due); deferErr != nil || deferred {
+		t.Fatalf("Defer(wrong token) = (%v, %v), want (false, nil)", deferred, deferErr)
+	}
+	if deferred, deferErr := queue.Defer(event.EventID, lease.Token, due); deferErr != nil || !deferred {
+		t.Fatalf("Defer(valid token) = (%v, %v), want (true, nil)", deferred, deferErr)
+	}
+	if premature, claimErr := queue.Claim(now.Add(50*time.Millisecond), time.Second); claimErr != nil || premature != nil {
+		t.Fatalf("Claim(before deferred due) = (%+v, %v), want (nil, nil)", premature, claimErr)
+	}
+	reclaimed, claimErr := queue.Claim(due, time.Second)
+	if claimErr != nil || reclaimed == nil || reclaimed.Attempt != 1 {
+		t.Fatalf("Claim(after defer) = (%+v, %v), want preserved attempt 1", reclaimed, claimErr)
+	}
+	if acked, ackErr := queue.Ack(event.EventID, reclaimed.Token); ackErr != nil || !acked {
+		t.Fatalf("Ack() = (%v, %v), want (true, nil)", acked, ackErr)
+	}
+}
+
+func TestDispatcherSchedulesRetryFromFailureTime(t *testing.T) {
+	spec := validRouteSpec()
+	registry, err := NewRegistry([]RouteSpec{spec}, []string{spec.URL}, testGetenv)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	claimedAt := time.Unix(1_784_073_600, 0)
+	failedAt := claimedAt.Add(spec.Timeout)
+	queue := &concurrentLeaseQueue{
+		leases: []Lease{{Event: testDispatchEvent(), Token: "lease-42", Attempt: 1}},
+		nacked: make(chan nackCall, 1),
+	}
+	dispatcher, err := NewDispatcher(queue, registry, &retryableDeliverer{}, FinalizerFunc(func(context.Context, Event, DecisionResult) error { return nil }), DispatcherConfig{
+		LeaseDuration: time.Second,
+	})
+	if err != nil {
+		t.Fatalf("NewDispatcher() error = %v", err)
+	}
+	dispatcher.clock = func() time.Time { return failedAt }
+	if processed, err := dispatcher.ProcessOne(context.Background(), claimedAt); err != nil || !processed {
+		t.Fatalf("ProcessOne() = (%v, %v), want (true, nil)", processed, err)
+	}
+	select {
+	case call := <-queue.nacked:
+		if !call.now.Equal(failedAt) {
+			t.Fatalf("Nack() time = %s, want failure time %s", call.now, failedAt)
+		}
+		if call.delay != spec.BaseBackoff {
+			t.Fatalf("Nack() delay = %s, want %s", call.delay, spec.BaseBackoff)
+		}
+	default:
+		t.Fatal("Nack() was not called")
+	}
+}
+
+func TestDispatcherDeadLettersLeaseBeyondRouteAttemptLimitWithoutDelivery(t *testing.T) {
+	spec := validRouteSpec()
+	spec.MaxAttempts = 2
+	registry, err := NewRegistry([]RouteSpec{spec}, []string{spec.URL}, testGetenv)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	queue := &concurrentLeaseQueue{
+		leases: []Lease{{Event: testDispatchEvent(), Token: "lease-42", Attempt: spec.MaxAttempts + 1}},
+		acked:  make(chan int64, 1),
+		nacked: make(chan nackCall, 1),
+	}
+	var deliveryCount atomic.Int32
+	deliverer := callbackDelivererFunc(func(context.Context, *Route, DecisionRequest) (DecisionResult, error) {
+		deliveryCount.Add(1)
+		return DecisionResult{}, nil
+	})
+	var finalizeCount atomic.Int32
+	dispatcher, err := NewDispatcher(queue, registry, deliverer, FinalizerFunc(func(context.Context, Event, DecisionResult) error {
+		finalizeCount.Add(1)
+		return nil
+	}), DispatcherConfig{LeaseDuration: time.Second})
+	if err != nil {
+		t.Fatalf("NewDispatcher() error = %v", err)
+	}
+	if processed, processErr := dispatcher.ProcessOne(context.Background(), time.Now()); processErr != nil || !processed {
+		t.Fatalf("ProcessOne() = (%v, %v), want (true, nil)", processed, processErr)
+	}
+	if deliveryCount.Load() != 0 || finalizeCount.Load() != 0 {
+		t.Fatalf("delivery/finalize counts = %d/%d, want 0/0", deliveryCount.Load(), finalizeCount.Load())
+	}
+	select {
+	case call := <-queue.nacked:
+		if call.leaseAttempt != spec.MaxAttempts+1 || call.maxAttempts != spec.MaxAttempts || call.reason != "attempts_exhausted" {
+			t.Fatalf("Nack() call = %+v", call)
+		}
+	default:
+		t.Fatal("exhausted lease was not dead-lettered")
+	}
+	select {
+	case eventID := <-queue.acked:
+		t.Fatalf("exhausted event %d was acknowledged", eventID)
+	default:
+	}
+}
+
+func TestHTTPDelivererSignsExactBodyAndDecodesTypedResult(t *testing.T) {
+	var received DecisionRequest
+	var signatureOK atomic.Bool
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer r.Body.Close()
+		var raw json.RawMessage
+		if err := json.NewDecoder(r.Body).Decode(&raw); err != nil {
+			t.Errorf("decode raw request: %v", err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		if err := json.Unmarshal(raw, &received); err != nil {
+			t.Errorf("decode typed request: %v", err)
+		}
+		timestamp := r.Header.Get(HeaderTimestamp)
+		eventID := r.Header.Get(HeaderEventID)
+		if Verify(testCallbackSecret, r.Header.Get(HeaderSignature), r.Method, r.URL.EscapedPath(), timestamp, eventID, raw) {
+			signatureOK.Store(true)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"disposition":"applied","state":"approved","requester_uid":"user-a","display":{"title":"Roadmap"}}`))
+	}))
+	defer server.Close()
+
+	registry := registryForTestServer(t, server.URL, 3)
+	resolution := registry.Resolve("notification", "docs", "access_request.decision")
+	deliverer := NewHTTPDeliverer(server.Client().Transport, func() time.Time {
+		return time.Unix(1_784_073_600, 0)
+	})
+	request := DecisionRequestFromEvent(testDispatchEvent())
+	result, err := deliverer.Deliver(context.Background(), resolution.Route, request)
+	if err != nil {
+		t.Fatalf("Deliver() error = %v", err)
+	}
+	if !signatureOK.Load() {
+		t.Fatal("callback signature did not verify against the exact body")
+	}
+	if received.EventID != 42 || received.Decision != "approve" || received.DocID != "doc-1" ||
+		received.RequestID != "request-1" || received.OperatorUID != "user-b" {
+		t.Fatalf("callback request = %+v", received)
+	}
+	if result.State != StateApproved || result.RequesterUID != "user-a" {
+		t.Fatalf("Deliver() result = %+v", result)
+	}
+}
+
+func TestHTTPDelivererNeverFollowsRedirects(t *testing.T) {
+	var redirected atomic.Bool
+	mux := http.NewServeMux()
+	mux.HandleFunc("/start", func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "/target", http.StatusFound)
+	})
+	mux.HandleFunc("/target", func(w http.ResponseWriter, _ *http.Request) {
+		redirected.Store(true)
+		w.WriteHeader(http.StatusOK)
+	})
+	server := httptest.NewTLSServer(mux)
+	defer server.Close()
+
+	callbackURL := server.URL + "/start"
+	registry := registryForTestServer(t, callbackURL, 1)
+	deliverer := NewHTTPDeliverer(server.Client().Transport, time.Now)
+	_, err := deliverer.Deliver(context.Background(), registry.Resolve("notification", "docs", "access_request.decision").Route, DecisionRequestFromEvent(testDispatchEvent()))
+	if err == nil {
+		t.Fatal("Deliver() error = nil for redirect response")
+	}
+	if redirected.Load() {
+		t.Fatal("HTTP deliverer followed a callback redirect")
+	}
+}
+
+func TestHTTPDelivererDefaultTransportIgnoresProxyEnvironment(t *testing.T) {
+	deliverer := NewHTTPDeliverer(nil, time.Now)
+	transport, ok := deliverer.client.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("default transport type = %T, want *http.Transport", deliverer.client.Transport)
+	}
+	if transport.Proxy != nil {
+		t.Fatal("default callback transport must ignore HTTP_PROXY/HTTPS_PROXY")
+	}
+}
+
+func TestHTTPDelivererClassifiesRetryableFailures(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer server.Close()
+	registry := registryForTestServer(t, server.URL, 2)
+	deliverer := NewHTTPDeliverer(server.Client().Transport, time.Now)
+	_, err := deliverer.Deliver(context.Background(), registry.Resolve("notification", "docs", "access_request.decision").Route, DecisionRequestFromEvent(testDispatchEvent()))
+	if err == nil || !Retryable(err) {
+		t.Fatalf("Deliver(503) error = %v, want retryable", err)
+	}
+}
+
+func TestDispatcherHappyPathFinalizesThenAcknowledges(t *testing.T) {
+	queue := newDispatchTestQueue(t)
+	event := testDispatchEvent()
+	now := time.Now().Truncate(time.Millisecond)
+	if err := queue.Enqueue(event, now); err != nil {
+		t.Fatalf("Enqueue() error = %v", err)
+	}
+
+	var callbackCount atomic.Int32
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		callbackCount.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"disposition":"applied","state":"approved","requester_uid":"user-a","display":{"title":"Roadmap"}}`))
+	}))
+	defer server.Close()
+	registry := registryForTestServer(t, server.URL, 3)
+
+	var mu sync.Mutex
+	var finalized []DecisionResult
+	finalizer := FinalizerFunc(func(_ context.Context, gotEvent Event, result DecisionResult) error {
+		mu.Lock()
+		defer mu.Unlock()
+		if gotEvent.EventID != event.EventID {
+			t.Errorf("Finalize event_id = %d, want %d", gotEvent.EventID, event.EventID)
+		}
+		finalized = append(finalized, result)
+		return nil
+	})
+	dispatcher, err := NewDispatcher(queue, registry, NewHTTPDeliverer(server.Client().Transport, func() time.Time { return now }), finalizer, DispatcherConfig{
+		LeaseDuration: 5 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("NewDispatcher() error = %v", err)
+	}
+	processed, err := dispatcher.ProcessOne(context.Background(), now)
+	if err != nil || !processed {
+		t.Fatalf("ProcessOne() = (%v, %v), want (true, nil)", processed, err)
+	}
+	if callbackCount.Load() != 1 {
+		t.Fatalf("callback count = %d, want 1", callbackCount.Load())
+	}
+	mu.Lock()
+	if len(finalized) != 1 || finalized[0].State != StateApproved {
+		t.Fatalf("finalized = %+v, want one approved result", finalized)
+	}
+	mu.Unlock()
+	assertQueueDepths(t, queue, QueueDepths{})
+}
+
+func TestDispatcherRetries5xxThenMovesToDLQ(t *testing.T) {
+	queue := newDispatchTestQueue(t)
+	event := testDispatchEvent()
+	now := time.Now().Truncate(time.Millisecond)
+	if err := queue.Enqueue(event, now); err != nil {
+		t.Fatalf("Enqueue() error = %v", err)
+	}
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+	registry := registryForTestServer(t, server.URL, 2)
+	dispatcher, err := NewDispatcher(queue, registry, NewHTTPDeliverer(server.Client().Transport, func() time.Time { return now }), FinalizerFunc(func(context.Context, Event, DecisionResult) error {
+		t.Fatal("finalizer called for failed callback")
+		return nil
+	}), DispatcherConfig{LeaseDuration: 5 * time.Second})
+	if err != nil {
+		t.Fatalf("NewDispatcher() error = %v", err)
+	}
+	transitionNow := now
+	dispatcher.clock = func() time.Time { return transitionNow }
+
+	processed, err := dispatcher.ProcessOne(context.Background(), now)
+	if err != nil || !processed {
+		t.Fatalf("first ProcessOne() = (%v, %v), want handled retry", processed, err)
+	}
+	assertQueueDepths(t, queue, QueueDepths{Ready: 1})
+
+	transitionNow = now.Add(defaultBaseBackoff)
+	processed, err = dispatcher.ProcessOne(context.Background(), transitionNow)
+	if err != nil || !processed {
+		t.Fatalf("second ProcessOne() = (%v, %v), want handled DLQ", processed, err)
+	}
+	assertQueueDepths(t, queue, QueueDepths{DLQ: 1})
+}
+
+func TestDispatcherRetriesFinalizationWithoutDuplicatingQueueState(t *testing.T) {
+	queue := newDispatchTestQueue(t)
+	event := testDispatchEvent()
+	now := time.Now().Truncate(time.Millisecond)
+	if err := queue.Enqueue(event, now); err != nil {
+		t.Fatalf("Enqueue() error = %v", err)
+	}
+	var callbackCount atomic.Int32
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		callbackCount.Add(1)
+		_, _ = w.Write([]byte(`{"disposition":"replayed","state":"approved","requester_uid":"user-a","display":{"title":"Roadmap"}}`))
+	}))
+	defer server.Close()
+
+	var finalizeCount atomic.Int32
+	finalizer := FinalizerFunc(func(context.Context, Event, DecisionResult) error {
+		if finalizeCount.Add(1) == 1 {
+			return errors.New("transient card mutation failure")
+		}
+		return nil
+	})
+	dispatcher, err := NewDispatcher(queue, registryForTestServer(t, server.URL, 3), NewHTTPDeliverer(server.Client().Transport, func() time.Time { return now }), finalizer, DispatcherConfig{LeaseDuration: 5 * time.Second})
+	if err != nil {
+		t.Fatalf("NewDispatcher() error = %v", err)
+	}
+	transitionNow := now
+	dispatcher.clock = func() time.Time { return transitionNow }
+	if processed, err := dispatcher.ProcessOne(context.Background(), now); err != nil || !processed {
+		t.Fatalf("first ProcessOne() = (%v, %v)", processed, err)
+	}
+	transitionNow = now.Add(defaultBaseBackoff)
+	if processed, err := dispatcher.ProcessOne(context.Background(), transitionNow); err != nil || !processed {
+		t.Fatalf("second ProcessOne() = (%v, %v)", processed, err)
+	}
+	if callbackCount.Load() != 2 || finalizeCount.Load() != 2 {
+		t.Fatalf("callback/finalize counts = %d/%d, want 2/2", callbackCount.Load(), finalizeCount.Load())
+	}
+	assertQueueDepths(t, queue, QueueDepths{})
+}
+
+func registryForTestServer(t *testing.T, callbackURL string, maxAttempts int) *Registry {
+	t.Helper()
+	spec := validRouteSpec()
+	spec.URL = callbackURL
+	spec.MaxAttempts = maxAttempts
+	registry, err := NewRegistry([]RouteSpec{spec}, []string{callbackURL}, testGetenv)
+	if err != nil {
+		t.Fatalf("NewRegistry(test server) error = %v", err)
+	}
+	return registry
+}
+
+func testDispatchEvent() Event {
+	return Event{
+		EventID:     42,
+		SenderUID:   "notification",
+		Owner:       "docs",
+		ActionType:  "access_request.decision",
+		MessageID:   "1001",
+		ChannelID:   "user-b",
+		ChannelType: 1,
+		SpaceID:     "space-1",
+		ActionID:    "approve",
+		OperatorUID: "user-b",
+		ClientToken: "tap-1",
+		ActedAt:     1_784_073_600,
+		Inputs:      map[string]interface{}{},
+		Data: map[string]interface{}{
+			"owner":       "docs",
+			"action_type": "access_request.decision",
+			"decision":    "approve",
+			"doc_id":      "doc-1",
+			"request_id":  "request-1",
+		},
+	}
+}
+
+func newDispatchTestQueue(t *testing.T) *RedisQueue {
+	t.Helper()
+	client := rd.NewClient(&rd.Options{Addr: "127.0.0.1:6379"})
+	if err := client.Ping().Err(); err != nil {
+		t.Skipf("Redis unavailable: %v", err)
+	}
+	prefix := "test:card_action_dispatcher:" + strconv.FormatInt(time.Now().UnixNano(), 10)
+	queue, err := NewRedisQueue(client, QueueConfig{Prefix: prefix, LiveTTL: time.Hour, DLQRetention: 30 * 24 * time.Hour})
+	if err != nil {
+		t.Fatalf("NewRedisQueue() error = %v", err)
+	}
+	t.Cleanup(func() {
+		keys, _ := client.Keys(prefix + "*").Result()
+		if len(keys) > 0 {
+			_ = client.Del(keys...).Err()
+		}
+		_ = client.Close()
+	})
+	return queue
+}
+
+func assertQueueDepths(t *testing.T, queue *RedisQueue, want QueueDepths) {
+	t.Helper()
+	got, err := queue.Depths()
+	if err != nil {
+		t.Fatalf("Depths() error = %v", err)
+	}
+	if got != want {
+		t.Fatalf("Depths() = %+v, want %+v", got, want)
+	}
+}

--- a/internal/cardactiondispatch/finalizer.go
+++ b/internal/cardactiondispatch/finalizer.go
@@ -1,0 +1,48 @@
+package cardactiondispatch
+
+import (
+	"context"
+	"errors"
+)
+
+// FinalizerKey binds a route to an optional specialized terminal renderer.
+// Routes without a binding use the standard approval fallback.
+type FinalizerKey struct {
+	Owner      string
+	ActionType string
+}
+
+// FinalizerRegistry keeps custom terminal visuals explicit while preserving
+// config-only onboarding for standard approval consumers.
+type FinalizerRegistry struct {
+	fallback Finalizer
+	routes   map[FinalizerKey]Finalizer
+}
+
+func NewFinalizerRegistry(fallback Finalizer, bindings map[FinalizerKey]Finalizer) (*FinalizerRegistry, error) {
+	if fallback == nil {
+		return nil, errors.New("cardactiondispatch: standard finalizer is required")
+	}
+	routes := make(map[FinalizerKey]Finalizer, len(bindings))
+	for key, finalizer := range bindings {
+		if !ownerPattern.MatchString(key.Owner) || !actionTypePattern.MatchString(key.ActionType) {
+			return nil, errors.New("cardactiondispatch: invalid finalizer binding")
+		}
+		if finalizer == nil {
+			return nil, errors.New("cardactiondispatch: finalizer binding is required")
+		}
+		routes[key] = finalizer
+	}
+	return &FinalizerRegistry{fallback: fallback, routes: routes}, nil
+}
+
+func (r *FinalizerRegistry) Finalize(ctx context.Context, event Event, result DecisionResult) error {
+	if r == nil || r.fallback == nil {
+		return errors.New("cardactiondispatch: finalizer registry unavailable")
+	}
+	finalizer := r.fallback
+	if specialized, ok := r.routes[FinalizerKey{Owner: event.Owner, ActionType: event.ActionType}]; ok {
+		finalizer = specialized
+	}
+	return finalizer.Finalize(ctx, event, result)
+}

--- a/internal/cardactiondispatch/finalizer_test.go
+++ b/internal/cardactiondispatch/finalizer_test.go
@@ -1,0 +1,61 @@
+package cardactiondispatch
+
+import (
+	"context"
+	"testing"
+)
+
+type recordingFinalizer struct {
+	events []Event
+}
+
+func (f *recordingFinalizer) Finalize(_ context.Context, event Event, _ DecisionResult) error {
+	f.events = append(f.events, event)
+	return nil
+}
+
+func TestFinalizerRegistryUsesSpecializedBindingAndStandardFallback(t *testing.T) {
+	standard := &recordingFinalizer{}
+	docs := &recordingFinalizer{}
+	registry, err := NewFinalizerRegistry(standard, map[FinalizerKey]Finalizer{
+		{Owner: "docs", ActionType: "access_request.decision"}: docs,
+	})
+	if err != nil {
+		t.Fatalf("NewFinalizerRegistry() error = %v", err)
+	}
+
+	result := DecisionResult{Disposition: DispositionApplied, State: StateApproved, RequesterUID: "user-a"}
+	if err := registry.Finalize(context.Background(), Event{Owner: "docs", ActionType: "access_request.decision"}, result); err != nil {
+		t.Fatalf("Finalize(docs) error = %v", err)
+	}
+	if err := registry.Finalize(context.Background(), Event{Owner: "tasks", ActionType: "task.decision"}, result); err != nil {
+		t.Fatalf("Finalize(tasks) error = %v", err)
+	}
+	if len(docs.events) != 1 || docs.events[0].Owner != "docs" {
+		t.Fatalf("docs events = %+v", docs.events)
+	}
+	if len(standard.events) != 1 || standard.events[0].Owner != "tasks" {
+		t.Fatalf("standard events = %+v", standard.events)
+	}
+}
+
+func TestFinalizerRegistryRejectsInvalidBindings(t *testing.T) {
+	standard := &recordingFinalizer{}
+	tests := []struct {
+		name     string
+		fallback Finalizer
+		bindings map[FinalizerKey]Finalizer
+	}{
+		{name: "missing fallback", bindings: map[FinalizerKey]Finalizer{}},
+		{name: "invalid owner", fallback: standard, bindings: map[FinalizerKey]Finalizer{{Owner: "Bad Owner", ActionType: "x"}: standard}},
+		{name: "invalid action", fallback: standard, bindings: map[FinalizerKey]Finalizer{{Owner: "docs", ActionType: ""}: standard}},
+		{name: "nil specialized finalizer", fallback: standard, bindings: map[FinalizerKey]Finalizer{{Owner: "docs", ActionType: "x"}: nil}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := NewFinalizerRegistry(tt.fallback, tt.bindings); err == nil {
+				t.Fatal("NewFinalizerRegistry() error = nil")
+			}
+		})
+	}
+}

--- a/internal/cardactiondispatch/http.go
+++ b/internal/cardactiondispatch/http.go
@@ -1,0 +1,123 @@
+package cardactiondispatch
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"time"
+)
+
+const (
+	HeaderSignature = "X-Octo-Signature"
+	HeaderTimestamp = "X-Octo-Timestamp"
+	HeaderEventID   = "X-Octo-Event-ID"
+)
+
+type HTTPDeliverer struct {
+	client *http.Client
+	clock  func() time.Time
+}
+
+type DeliveryError struct {
+	Category  string
+	Status    int
+	retryable bool
+	cause     error
+}
+
+func (e *DeliveryError) Error() string {
+	if e.Status > 0 {
+		return fmt.Sprintf("cardactiondispatch: callback %s (status %d)", e.Category, e.Status)
+	}
+	return "cardactiondispatch: callback " + e.Category
+}
+
+func (e *DeliveryError) Unwrap() error { return e.cause }
+
+func Retryable(err error) bool {
+	var deliveryErr *DeliveryError
+	return errors.As(err, &deliveryErr) && deliveryErr.retryable
+}
+
+func NewHTTPDeliverer(transport http.RoundTripper, clock func() time.Time) *HTTPDeliverer {
+	if transport == nil {
+		base := http.DefaultTransport.(*http.Transport).Clone()
+		// Routes are already exact, static HTTPS URLs. Ignoring proxy environment
+		// variables prevents deployment-level proxy settings from reopening SSRF.
+		base.Proxy = nil
+		transport = base
+	}
+	if clock == nil {
+		clock = time.Now
+	}
+	return &HTTPDeliverer{
+		client: &http.Client{
+			Transport: transport,
+			CheckRedirect: func(*http.Request, []*http.Request) error {
+				return http.ErrUseLastResponse
+			},
+		},
+		clock: clock,
+	}
+}
+
+func (d *HTTPDeliverer) Deliver(ctx context.Context, route *Route, request DecisionRequest) (DecisionResult, error) {
+	if ctx == nil || route == nil {
+		return DecisionResult{}, &DeliveryError{Category: "invalid_request"}
+	}
+	body, err := json.Marshal(request)
+	if err != nil {
+		return DecisionResult{}, &DeliveryError{Category: "encode_failed", cause: err}
+	}
+	parsed, err := url.Parse(route.URL)
+	if err != nil {
+		return DecisionResult{}, &DeliveryError{Category: "invalid_route", cause: err}
+	}
+	path := parsed.EscapedPath()
+	if path == "" {
+		path = "/"
+	}
+	timestamp := strconv.FormatInt(d.clock().Unix(), 10)
+	eventID := strconv.FormatInt(request.EventID, 10)
+
+	requestCtx, cancel := context.WithTimeout(ctx, route.Timeout)
+	defer cancel()
+	httpRequest, err := http.NewRequestWithContext(requestCtx, http.MethodPost, route.URL, bytes.NewReader(body))
+	if err != nil {
+		return DecisionResult{}, &DeliveryError{Category: "request_failed", cause: err}
+	}
+	httpRequest.Header.Set("Content-Type", "application/json")
+	httpRequest.Header.Set("User-Agent", "octo-server/card-action-dispatch-v1")
+	httpRequest.Header.Set(HeaderTimestamp, timestamp)
+	httpRequest.Header.Set(HeaderEventID, eventID)
+	httpRequest.Header.Set(HeaderSignature, Sign(route.secret, http.MethodPost, path, timestamp, eventID, body))
+
+	response, err := d.client.Do(httpRequest)
+	if err != nil {
+		retry := ctx.Err() == nil
+		return DecisionResult{}, &DeliveryError{Category: "transport_failed", retryable: retry, cause: err}
+	}
+	defer response.Body.Close()
+	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
+		_, _ = io.Copy(io.Discard, io.LimitReader(response.Body, 4<<10))
+		retry := response.StatusCode == http.StatusRequestTimeout || response.StatusCode == http.StatusTooManyRequests || response.StatusCode >= 500
+		category := "rejected"
+		if response.StatusCode >= 300 && response.StatusCode < 400 {
+			category = "redirect_rejected"
+		} else if response.StatusCode >= 500 {
+			category = "consumer_5xx"
+		}
+		return DecisionResult{}, &DeliveryError{Category: category, Status: response.StatusCode, retryable: retry}
+	}
+	result, err := DecodeDecisionResult(response.Body)
+	if err != nil {
+		return DecisionResult{}, &DeliveryError{Category: "invalid_response", retryable: true, cause: err}
+	}
+	return result, nil
+}

--- a/internal/cardactiondispatch/metrics.go
+++ b/internal/cardactiondispatch/metrics.go
@@ -1,0 +1,136 @@
+package cardactiondispatch
+
+import (
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type Metrics struct {
+	duration                *prometheus.HistogramVec
+	results                 *prometheus.CounterVec
+	errors                  *prometheus.CounterVec
+	retries                 *prometheus.CounterVec
+	leased                  *prometheus.GaugeVec
+	readyDepth              prometheus.Gauge
+	dlqDepth                prometheus.Gauge
+	applicantNotifyFailures *prometheus.CounterVec
+}
+
+func NewMetrics(reg prometheus.Registerer) *Metrics {
+	if reg == nil {
+		return nil
+	}
+	metrics := &Metrics{
+		duration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Name:    "dmwork_card_action_dispatch_duration_seconds",
+			Help:    "End-to-end first-party card action dispatch duration.",
+			Buckets: prometheus.DefBuckets,
+		}, []string{"owner", "result"}),
+		results: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "dmwork_card_action_dispatch_result_total",
+			Help: "First-party card action dispatch results.",
+		}, []string{"owner", "result"}),
+		errors: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "dmwork_card_action_dispatch_error_total",
+			Help: "First-party card action callback and finalization errors.",
+		}, []string{"owner", "category"}),
+		retries: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "dmwork_card_action_dispatch_retry_total",
+			Help: "Scheduled first-party card action retries.",
+		}, []string{"owner"}),
+		leased: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "dmwork_card_action_dispatch_leased",
+			Help: "Currently leased card action events in this process.",
+		}, []string{"owner"}),
+		readyDepth: prometheus.NewGauge(prometheus.GaugeOpts{
+			Name: "dmwork_card_action_dispatch_ready_depth",
+			Help: "Current shared ready card action queue depth.",
+		}),
+		dlqDepth: prometheus.NewGauge(prometheus.GaugeOpts{
+			Name: "dmwork_card_action_dispatch_dlq_depth",
+			Help: "Current shared card action dead-letter queue depth.",
+		}),
+		applicantNotifyFailures: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "dmwork_card_action_dispatch_applicant_notify_failure_total",
+			Help: "Applicant outcome notification failures after a card action decision.",
+		}, []string{"owner"}),
+	}
+	reg.MustRegister(metrics.duration, metrics.results, metrics.errors, metrics.retries,
+		metrics.leased, metrics.readyDepth, metrics.dlqDepth, metrics.applicantNotifyFailures)
+	return metrics
+}
+
+func (m *Metrics) beginLease(owner string) {
+	if m != nil {
+		m.leased.WithLabelValues(metricOwner(owner)).Inc()
+	}
+}
+
+func (m *Metrics) endLease(owner string) {
+	if m != nil {
+		m.leased.WithLabelValues(metricOwner(owner)).Dec()
+	}
+}
+
+func (m *Metrics) finish(owner, result string, started time.Time) {
+	if m == nil {
+		return
+	}
+	owner = metricOwner(owner)
+	result = metricResult(result)
+	m.results.WithLabelValues(owner, result).Inc()
+	m.duration.WithLabelValues(owner, result).Observe(time.Since(started).Seconds())
+}
+
+func (m *Metrics) observeError(owner, category string) {
+	if m != nil {
+		m.errors.WithLabelValues(metricOwner(owner), metricErrorCategory(category)).Inc()
+	}
+}
+
+func (m *Metrics) observeRetry(owner string) {
+	if m != nil {
+		m.retries.WithLabelValues(metricOwner(owner)).Inc()
+	}
+}
+
+func (m *Metrics) observeApplicantNotifyFailure(owner string) {
+	if m != nil {
+		m.applicantNotifyFailures.WithLabelValues(metricOwner(owner)).Inc()
+	}
+}
+
+func (m *Metrics) setDepths(ready, dlq int64) {
+	if m != nil {
+		m.readyDepth.Set(float64(ready))
+		m.dlqDepth.Set(float64(dlq))
+	}
+}
+
+func metricOwner(owner string) string {
+	if ownerPattern.MatchString(owner) {
+		return owner
+	}
+	return "invalid"
+}
+
+func metricResult(result string) string {
+	switch result {
+	case "ok", "deferred", "retry", "dlq", "error":
+		return result
+	default:
+		return "error"
+	}
+}
+
+func metricErrorCategory(category string) string {
+	switch category {
+	case "transport_failed", "rejected", "redirect_rejected", "invalid_response",
+		"consumer_5xx", "finalize_failed", "applicant_notify_failed", "route_missing",
+		"attempts_exhausted", "queue_error", "ack_lost":
+		return category
+	default:
+		return "unknown"
+	}
+}

--- a/internal/cardactiondispatch/metrics_test.go
+++ b/internal/cardactiondispatch/metrics_test.go
@@ -1,0 +1,45 @@
+package cardactiondispatch
+
+import (
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+func TestMetricsExposeBoundedDispatchAndQueueSignals(t *testing.T) {
+	registry := prometheus.NewRegistry()
+	metrics := NewMetrics(registry)
+	started := time.Now().Add(-time.Second)
+
+	metrics.beginLease("docs")
+	metrics.observeRetry("docs")
+	metrics.observeError("docs", "consumer_5xx")
+	metrics.observeApplicantNotifyFailure("docs")
+	metrics.finish("docs", "retry", started)
+	metrics.setDepths(2, 1)
+
+	if got := testutil.ToFloat64(metrics.leased.WithLabelValues("docs")); got != 1 {
+		t.Fatalf("leased gauge = %v, want 1", got)
+	}
+	if got := testutil.ToFloat64(metrics.retries.WithLabelValues("docs")); got != 1 {
+		t.Fatalf("retry counter = %v, want 1", got)
+	}
+	if got := testutil.ToFloat64(metrics.errors.WithLabelValues("docs", "consumer_5xx")); got != 1 {
+		t.Fatalf("error counter = %v, want 1", got)
+	}
+	if got := testutil.ToFloat64(metrics.applicantNotifyFailures.WithLabelValues("docs")); got != 1 {
+		t.Fatalf("notify failure counter = %v, want 1", got)
+	}
+	if got := testutil.ToFloat64(metrics.dlqDepth); got != 1 {
+		t.Fatalf("DLQ depth = %v, want 1", got)
+	}
+	metrics.endLease("docs")
+
+	// Untrusted labels never create attacker-controlled cardinality.
+	metrics.observeError("../../arbitrary", "arbitrary-error-body")
+	if got := testutil.ToFloat64(metrics.errors.WithLabelValues("invalid", "unknown")); got != 1 {
+		t.Fatalf("normalized error counter = %v, want 1", got)
+	}
+}

--- a/internal/cardactiondispatch/orchestration_integration_test.go
+++ b/internal/cardactiondispatch/orchestration_integration_test.go
@@ -1,0 +1,369 @@
+//go:build integration
+
+package cardactiondispatch_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"hash/crc32"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	"github.com/Mininglamp-OSS/octo-server/internal/cardactiondispatch"
+	"github.com/Mininglamp-OSS/octo-server/internal/carddispatch"
+	_ "github.com/Mininglamp-OSS/octo-server/modules/app_bot"
+	_ "github.com/Mininglamp-OSS/octo-server/modules/base"
+	_ "github.com/Mininglamp-OSS/octo-server/modules/group"
+	_ "github.com/Mininglamp-OSS/octo-server/modules/message"
+	"github.com/Mininglamp-OSS/octo-server/modules/notify"
+	_ "github.com/Mininglamp-OSS/octo-server/modules/robot"
+	_ "github.com/Mininglamp-OSS/octo-server/modules/thread"
+	_ "github.com/Mininglamp-OSS/octo-server/modules/webhook"
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardmsg"
+	"github.com/go-redis/redis"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type callbackE2ESender struct {
+	targets []carddispatch.Target
+	cards   []carddispatch.Card
+}
+
+func (s *callbackE2ESender) Send(_ context.Context, target carddispatch.Target, card carddispatch.Card) (*carddispatch.Result, error) {
+	s.targets = append(s.targets, target)
+	s.cards = append(s.cards, card)
+	return &carddispatch.Result{MessageID: 9802, MessageSeq: 1}, nil
+}
+
+type callbackE2EFinalizer struct {
+	delegate cardactiondispatch.Finalizer
+	events   []cardactiondispatch.Event
+}
+
+type callbackE2EMutator struct {
+	requests []carddispatch.CardMutationRequest
+}
+
+func (m *callbackE2EMutator) Mutate(_ context.Context, request carddispatch.CardMutationRequest) (carddispatch.CardMutationResult, error) {
+	m.requests = append(m.requests, request)
+	return carddispatch.CardMutationResult{Applied: true}, nil
+}
+
+func (f *callbackE2EFinalizer) Finalize(ctx context.Context, event cardactiondispatch.Event, result cardactiondispatch.DecisionResult) error {
+	f.events = append(f.events, event)
+	return f.delegate.Finalize(ctx, event, result)
+}
+
+type docsCallbackCapture struct {
+	method         string
+	path           string
+	request        cardactiondispatch.DecisionRequest
+	signatureValid bool
+	err            error
+}
+
+// TestCardActionCallbackOrchestrationWithMockDocs exercises the octo-server
+// orchestration boundary end to end. The docs domain endpoint and applicant IM
+// send are test doubles; HTTP routing, MySQL authority lookup, Redis queueing,
+// signed callback delivery, typed-result decoding, WuKongIM lookup, card
+// mutation persistence, and finalization are real.
+func TestCardActionCallbackOrchestrationWithMockDocs(t *testing.T) {
+	t.Setenv(cardmsg.EnvEnabled, "true")
+	t.Setenv("OCTO_MASTER_KEY", "0123456789abcdef0123456789abcdef")
+	t.Setenv("NOTIFY_INTERNAL_TOKEN", "legacy-notify-token")
+	t.Setenv("OCTO_DOCS_NOTIFY_TOKEN", "docs-notify-token")
+	const secret = "0123456789abcdef0123456789abcdef"
+
+	callbackCalls := make(chan docsCallbackCapture, 1)
+	docsServer := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capture := docsCallbackCapture{method: r.Method, path: r.URL.EscapedPath()}
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			capture.err = err
+		} else if err := json.Unmarshal(body, &capture.request); err != nil {
+			capture.err = err
+		}
+		capture.signatureValid = cardactiondispatch.Verify(
+			secret,
+			r.Header.Get(cardactiondispatch.HeaderSignature),
+			r.Method,
+			r.URL.EscapedPath(),
+			r.Header.Get(cardactiondispatch.HeaderTimestamp),
+			r.Header.Get(cardactiondispatch.HeaderEventID),
+			body,
+		)
+		callbackCalls <- capture
+		if capture.err != nil || !capture.signatureValid {
+			http.Error(w, "invalid callback", http.StatusUnauthorized)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"disposition":"applied","state":"approved","requester_uid":"user-a","display":{"title":"Roadmap"}}`))
+	}))
+	defer docsServer.Close()
+	callbackURL := docsServer.URL + "/v1/card-actions/decide"
+
+	s, ctx := testutil.NewTestServer()
+	defer func() { _ = testutil.CleanAllTables(ctx) }()
+	ctx.GetConfig().External.WebLoginURL = "https://im.example.com/login"
+
+	rds := redis.NewClient(&redis.Options{Addr: ctx.GetConfig().DB.RedisAddr, Password: ctx.GetConfig().DB.RedisPass})
+	prefix := fmt.Sprintf("test:card_action_callback_e2e:%d", time.Now().UnixNano())
+	cleanupRedisPatterns(t, rds, "ratelimit:uid:*", "cardaction:*", "robotEvent:*", prefix+"*")
+	t.Cleanup(func() {
+		cleanupRedisPatterns(t, rds, "ratelimit:uid:*", "cardaction:*", "robotEvent:*", prefix+"*")
+		_ = rds.Close()
+	})
+
+	registry, err := cardactiondispatch.NewRegistry([]cardactiondispatch.RouteSpec{{
+		SenderUID: "notification", Owner: "docs", ActionType: "access_request.decision",
+		URL: callbackURL, SecretEnv: "OCTO_DOCS_CARD_ACTION_SECRET",
+	}}, []string{callbackURL}, func(string) string { return secret })
+	require.NoError(t, err)
+	queue, err := cardactiondispatch.NewRedisQueue(rds, cardactiondispatch.QueueConfig{
+		Prefix: prefix, LiveTTL: ctx.GetConfig().Robot.MessageExpire, DLQRetention: 30 * 24 * time.Hour,
+	})
+	require.NoError(t, err)
+	service, err := cardactiondispatch.NewService(registry, queue, ctx)
+	require.NoError(t, err)
+	require.NoError(t, cardactiondispatch.Install(ctx, service))
+
+	sender := &callbackE2ESender{}
+	docsFinalizer, err := notify.NewDocsActionFinalizer(ctx, carddispatch.NewCardMutator(ctx), sender)
+	require.NoError(t, err)
+	finalizer := &callbackE2EFinalizer{delegate: docsFinalizer}
+	dispatcher, err := cardactiondispatch.NewDispatcher(
+		queue,
+		registry,
+		cardactiondispatch.NewHTTPDeliverer(docsServer.Client().Transport, time.Now),
+		finalizer,
+		cardactiondispatch.DispatcherConfig{},
+	)
+	require.NoError(t, err)
+
+	messageID := seedCallbackE2EBotAndMessage(t, ctx, cardV2InternalEnvelope(t))
+
+	w := httptest.NewRecorder()
+	req, err := http.NewRequest(http.MethodPost, "/v1/message/card/action", bytes.NewReader([]byte(util.ToJson(map[string]interface{}{
+		"message_id": messageID, "channel_id": "notification", "channel_type": common.ChannelTypePerson.Uint8(),
+		"action_id": "approve", "client_token": "token-" + messageID,
+	}))))
+	require.NoError(t, err)
+	req.Header.Set("token", testutil.Token)
+	s.GetRoute().ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	processed, err := dispatcher.ProcessOne(context.Background(), time.Now().Add(time.Second))
+	require.NoError(t, err)
+	require.True(t, processed)
+
+	callback := <-callbackCalls
+	require.NoError(t, callback.err)
+	assert.Equal(t, http.MethodPost, callback.method)
+	assert.Equal(t, "/v1/card-actions/decide", callback.path)
+	assert.True(t, callback.signatureValid)
+	assert.True(t, callback.request.EventID > 0)
+	assert.Equal(t, "approve", callback.request.ActionID)
+	assert.Equal(t, "approve", callback.request.Decision)
+	assert.Equal(t, testutil.UID, callback.request.OperatorUID)
+	assert.Equal(t, "doc-1", callback.request.DocID)
+	assert.Equal(t, "request-1", callback.request.RequestID)
+	assert.Equal(t, messageID, callback.request.MessageID)
+	assert.Equal(t, "notification", callback.request.ChannelID)
+	assert.Equal(t, common.ChannelTypePerson.Uint8(), callback.request.ChannelType)
+	assert.Equal(t, "space-1", callback.request.SpaceID)
+	assert.NotZero(t, callback.request.ActedAt)
+
+	require.Len(t, finalizer.events, 1)
+	assert.Equal(t, "notification", finalizer.events[0].SenderUID)
+	assert.Equal(t, "docs", finalizer.events[0].Owner)
+	assert.Equal(t, "access_request.decision", finalizer.events[0].ActionType)
+
+	var mutation struct {
+		ChannelID   string `db:"channel_id"`
+		ContentEdit string `db:"content_edit"`
+	}
+	require.NoError(t, ctx.DB().Select("channel_id", "content_edit").From("message_extra").
+		Where("message_id=?", messageID).LoadOne(&mutation))
+	assert.Equal(t, common.GetFakeChannelIDWith("notification", testutil.UID), mutation.ChannelID)
+	var terminal map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(mutation.ContentEdit), &terminal))
+	assert.Equal(t, float64(callback.request.EventID), terminal["card_seq"])
+	card, ok := terminal["card"].(map[string]interface{})
+	require.True(t, ok)
+	_, hasActions := card["actions"]
+	assert.False(t, hasActions)
+
+	require.Len(t, sender.targets, 1)
+	require.Len(t, sender.cards, 1)
+	assert.Equal(t, "user-a", sender.targets[0].ChannelID)
+	assert.Equal(t, "space-1", sender.targets[0].SpaceID)
+	assert.Equal(t, cardmsg.ProfileV1, sender.cards[0].Profile)
+
+	depths, err := queue.Depths()
+	require.NoError(t, err)
+	assert.Equal(t, cardactiondispatch.QueueDepths{}, depths)
+}
+
+func TestCardActionCallbackOrchestrationUsesStandardFinalizerForNewOwner(t *testing.T) {
+	t.Setenv("OCTO_MASTER_KEY", "0123456789abcdef0123456789abcdef")
+	const secret = "0123456789abcdef0123456789abcdef"
+	callbackCalls := make(chan docsCallbackCapture, 1)
+	consumer := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		capture := docsCallbackCapture{method: r.Method, path: r.URL.EscapedPath(), err: err}
+		if err == nil {
+			capture.err = json.Unmarshal(body, &capture.request)
+		}
+		capture.signatureValid = cardactiondispatch.Verify(
+			secret, r.Header.Get(cardactiondispatch.HeaderSignature), r.Method, r.URL.EscapedPath(),
+			r.Header.Get(cardactiondispatch.HeaderTimestamp), r.Header.Get(cardactiondispatch.HeaderEventID), body,
+		)
+		callbackCalls <- capture
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"disposition":"applied","state":"approved","requester_uid":"user-a","display":{"title":"Deploy release"}}`))
+	}))
+	defer consumer.Close()
+
+	_, ctx := testutil.NewTestServer()
+	defer func() { _ = testutil.CleanAllTables(ctx) }()
+	rds := redis.NewClient(&redis.Options{Addr: ctx.GetConfig().DB.RedisAddr, Password: ctx.GetConfig().DB.RedisPass})
+	prefix := fmt.Sprintf("test:card_action_generic_e2e:%d", time.Now().UnixNano())
+	cleanupRedisPatterns(t, rds, prefix+"*")
+	t.Cleanup(func() {
+		cleanupRedisPatterns(t, rds, prefix+"*")
+		_ = rds.Close()
+	})
+
+	callbackURL := consumer.URL + "/v1/card-actions/decide"
+	registry, err := cardactiondispatch.NewRegistry([]cardactiondispatch.RouteSpec{{
+		SenderUID: "notification", Owner: "tasks", ActionType: "task.decision",
+		URL: callbackURL, SecretEnv: "OCTO_TASKS_CARD_ACTION_SECRET",
+	}}, []string{callbackURL}, func(string) string { return secret })
+	require.NoError(t, err)
+	queue, err := cardactiondispatch.NewRedisQueue(rds, cardactiondispatch.QueueConfig{
+		Prefix: prefix, LiveTTL: time.Hour, DLQRetention: 30 * 24 * time.Hour,
+	})
+	require.NoError(t, err)
+	service, err := cardactiondispatch.NewService(registry, queue, ctx)
+	require.NoError(t, err)
+	eventID, err := service.Enqueue(cardactiondispatch.Event{
+		SenderUID: "notification", Owner: "tasks", ActionType: "task.decision",
+		MessageID: "task-message-1", ChannelID: "notification", ChannelType: common.ChannelTypePerson.Uint8(),
+		SpaceID: "space-1", ActionID: "approve", OperatorUID: "user-b", ActedAt: time.Now().Unix(),
+		Data: map[string]interface{}{"owner": "tasks", "action_type": "task.decision", "decision": "approve", "task_id": "task-1"},
+	})
+	require.NoError(t, err)
+
+	mutator := &callbackE2EMutator{}
+	sender := &callbackE2ESender{}
+	standard, err := notify.NewStandardActionFinalizer(mutator, sender)
+	require.NoError(t, err)
+	finalizers, err := cardactiondispatch.NewFinalizerRegistry(standard, nil)
+	require.NoError(t, err)
+	dispatcher, err := cardactiondispatch.NewDispatcher(
+		queue, registry, cardactiondispatch.NewHTTPDeliverer(consumer.Client().Transport, time.Now), finalizers,
+		cardactiondispatch.DispatcherConfig{},
+	)
+	require.NoError(t, err)
+	processed, err := dispatcher.ProcessOne(context.Background(), time.Now().Add(time.Second))
+	require.NoError(t, err)
+	require.True(t, processed)
+
+	callback := <-callbackCalls
+	require.NoError(t, callback.err)
+	assert.True(t, callback.signatureValid)
+	assert.Equal(t, eventID, callback.request.EventID)
+	assert.Equal(t, "approve", callback.request.Decision)
+	assert.Equal(t, "task-1", callback.request.Data["task_id"])
+	require.Len(t, mutator.requests, 1)
+	assert.Equal(t, "user-b", mutator.requests[0].ChannelID)
+	assert.Contains(t, mutator.requests[0].ContentEdit, "approval.approved")
+	require.Len(t, sender.targets, 1)
+	assert.Equal(t, "user-a", sender.targets[0].ChannelID)
+	assert.Equal(t, cardmsg.ProfileV1, sender.cards[0].Profile)
+	depths, err := queue.Depths()
+	require.NoError(t, err)
+	assert.Equal(t, cardactiondispatch.QueueDepths{}, depths)
+}
+
+func seedCallbackE2EBotAndMessage(t *testing.T, ctx *config.Context, payload []byte) string {
+	t.Helper()
+	_, err := ctx.DB().InsertBySql("INSERT IGNORE INTO robot(robot_id,status) VALUES(?,1)", "notification").Exec()
+	require.NoError(t, err)
+	var envelope map[string]interface{}
+	require.NoError(t, json.Unmarshal(payload, &envelope))
+	sent, err := ctx.SendMessageWithResult(config.NewPersonalMsgSendReq(
+		testutil.UID, "notification", envelope, "space-1", config.PersonalMsgOptions{},
+	))
+	require.NoError(t, err)
+	require.NotZero(t, sent.MessageID)
+	var messageSeq uint32
+	require.Eventually(t, func() bool {
+		response, searchErr := ctx.IMSearchMessages(&config.MsgSearchReq{
+			LoginUID: "notification", ChannelID: testutil.UID,
+			ChannelType: common.ChannelTypePerson.Uint8(), MessageIds: []int64{sent.MessageID},
+		})
+		if searchErr != nil || response == nil || len(response.Messages) == 0 {
+			return false
+		}
+		messageSeq = response.Messages[0].MessageSeq
+		return messageSeq > 0
+	}, 6*time.Second, 100*time.Millisecond, "card message was not persisted by WuKongIM")
+	messageID := fmt.Sprintf("%d", sent.MessageID)
+	channelID := common.GetFakeChannelIDWith(testutil.UID, "notification")
+	table := "message"
+	if count := ctx.GetConfig().TablePartitionConfig.MessageTableCount; count > 0 {
+		if index := crc32.ChecksumIEEE([]byte(channelID)) % uint32(count); index > 0 {
+			table = fmt.Sprintf("message%d", index)
+		}
+	}
+	_, err = ctx.DB().InsertBySql(
+		fmt.Sprintf("INSERT INTO `%s` (message_id,message_seq,client_msg_no,from_uid,channel_id,channel_type,timestamp,payload,is_deleted) VALUES (?,?,?,?,?,?,?,?,0)", table),
+		sent.MessageID, messageSeq, "callback-e2e-"+messageID, "notification", channelID, common.ChannelTypePerson.Uint8(), time.Now().Unix(), payload,
+	).Exec()
+	require.NoError(t, err)
+	return messageID
+}
+
+func cardV2InternalEnvelope(t *testing.T) []byte {
+	t.Helper()
+	raw, err := json.Marshal(map[string]interface{}{
+		"type": cardmsg.InteractiveCard.Int(), "card_version": cardmsg.CardVersion,
+		"profile": cardmsg.ProfileV2, "plain": "Document access request", "space_id": "space-1",
+		"card": map[string]interface{}{
+			"type": "AdaptiveCard", "version": cardmsg.CardVersion,
+			"body": []interface{}{map[string]interface{}{"type": "TextBlock", "text": "Document access request"}},
+			"actions": []interface{}{map[string]interface{}{
+				"type": "Action.Submit", "id": "approve", "title": "Allow",
+				"data": map[string]interface{}{
+					"owner": "docs", "action_type": "access_request.decision", "decision": "approve",
+					"doc_id": "doc-1", "request_id": "request-1",
+				},
+			}},
+		},
+	})
+	require.NoError(t, err)
+	return raw
+}
+
+func cleanupRedisPatterns(t *testing.T, client *redis.Client, patterns ...string) {
+	t.Helper()
+	for _, pattern := range patterns {
+		keys, err := client.Keys(pattern).Result()
+		require.NoError(t, err)
+		if len(keys) > 0 {
+			require.NoError(t, client.Del(keys...).Err())
+		}
+	}
+}

--- a/internal/cardactiondispatch/queue.go
+++ b/internal/cardactiondispatch/queue.go
@@ -1,0 +1,414 @@
+package cardactiondispatch
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	rd "github.com/go-redis/redis"
+)
+
+type QueueConfig struct {
+	Prefix       string
+	LiveTTL      time.Duration
+	DLQRetention time.Duration
+}
+
+type Lease struct {
+	Event   Event
+	Token   string
+	Attempt int
+}
+
+type NackOutcome string
+
+const (
+	NackRequeued      NackOutcome = "requeued"
+	NackDeadLettered  NackOutcome = "dead_lettered"
+	NackTokenMismatch NackOutcome = "token_mismatch"
+)
+
+type QueueDepths struct {
+	Ready  int64
+	Leased int64
+	DLQ    int64
+}
+
+type RedisQueue struct {
+	client       *rd.Client
+	keys         queueKeys
+	liveTTL      time.Duration
+	dlqRetention time.Duration
+}
+
+type queueKeys struct {
+	ready      string
+	leased     string
+	payload    string
+	attempts   string
+	tokens     string
+	dlq        string
+	dlqPayload string
+	dlqMeta    string
+}
+
+var enqueueScript = rd.NewScript(`
+if redis.call('HEXISTS', KEYS[7], ARGV[1]) == 1 or redis.call('HEXISTS', KEYS[3], ARGV[1]) == 1 then
+  return 0
+end
+redis.call('HSET', KEYS[3], ARGV[1], ARGV[2])
+redis.call('HSET', KEYS[4], ARGV[1], 0)
+redis.call('ZADD', KEYS[1], ARGV[3], ARGV[1])
+for i = 1, 5 do redis.call('PEXPIRE', KEYS[i], ARGV[4]) end
+return 1
+`)
+
+var claimScript = rd.NewScript(`
+local ids = redis.call('ZRANGEBYSCORE', KEYS[1], '-inf', ARGV[1], 'LIMIT', 0, 1)
+if #ids == 0 then return {} end
+local id = ids[1]
+local payload = redis.call('HGET', KEYS[3], id)
+if not payload then
+  redis.call('ZREM', KEYS[1], id)
+  redis.call('HDEL', KEYS[4], id)
+  return {}
+end
+if redis.call('ZREM', KEYS[1], id) ~= 1 then return {} end
+local attempt = redis.call('HINCRBY', KEYS[4], id, 1)
+redis.call('ZADD', KEYS[2], ARGV[2], id)
+redis.call('HSET', KEYS[5], id, ARGV[3])
+for i = 1, 5 do redis.call('PEXPIRE', KEYS[i], ARGV[4]) end
+return {id, payload, tostring(attempt), ARGV[3]}
+`)
+
+var ackScript = rd.NewScript(`
+if redis.call('HGET', KEYS[5], ARGV[1]) ~= ARGV[2] then return 0 end
+redis.call('ZREM', KEYS[2], ARGV[1])
+redis.call('HDEL', KEYS[3], ARGV[1])
+redis.call('HDEL', KEYS[4], ARGV[1])
+redis.call('HDEL', KEYS[5], ARGV[1])
+return 1
+`)
+
+var renewScript = rd.NewScript(`
+if redis.call('HGET', KEYS[5], ARGV[1]) ~= ARGV[2] then return 0 end
+if not redis.call('ZSCORE', KEYS[2], ARGV[1]) then return 0 end
+redis.call('ZADD', KEYS[2], ARGV[3], ARGV[1])
+for i = 1, 5 do redis.call('PEXPIRE', KEYS[i], ARGV[4]) end
+return 1
+`)
+
+var deferScript = rd.NewScript(`
+if redis.call('HGET', KEYS[5], ARGV[1]) ~= ARGV[2] then return 0 end
+if redis.call('ZREM', KEYS[2], ARGV[1]) ~= 1 then return 0 end
+redis.call('HDEL', KEYS[5], ARGV[1])
+local attempt = tonumber(redis.call('HGET', KEYS[4], ARGV[1]) or '0')
+if attempt > 0 then redis.call('HINCRBY', KEYS[4], ARGV[1], -1) end
+redis.call('ZADD', KEYS[1], ARGV[3], ARGV[1])
+for i = 1, 5 do redis.call('PEXPIRE', KEYS[i], ARGV[4]) end
+return 1
+`)
+
+var nackScript = rd.NewScript(`
+if redis.call('HGET', KEYS[5], ARGV[1]) ~= ARGV[2] then return 0 end
+local payload = redis.call('HGET', KEYS[3], ARGV[1])
+local attempt = tonumber(redis.call('HGET', KEYS[4], ARGV[1]) or '0')
+redis.call('ZREM', KEYS[2], ARGV[1])
+redis.call('HDEL', KEYS[5], ARGV[1])
+if attempt >= tonumber(ARGV[4]) then
+	local expired = redis.call('ZRANGEBYSCORE', KEYS[6], '-inf', ARGV[8])
+	for _, expired_id in ipairs(expired) do
+		redis.call('HDEL', KEYS[7], expired_id)
+		redis.call('HDEL', KEYS[8], expired_id)
+	end
+	redis.call('ZREMRANGEBYSCORE', KEYS[6], '-inf', ARGV[8])
+  redis.call('HDEL', KEYS[3], ARGV[1])
+  redis.call('HDEL', KEYS[4], ARGV[1])
+  redis.call('ZADD', KEYS[6], ARGV[9], ARGV[1])
+  redis.call('HSET', KEYS[7], ARGV[1], payload)
+  redis.call('HSET', KEYS[8], ARGV[1], ARGV[5])
+  for i = 6, 8 do redis.call('PEXPIRE', KEYS[i], ARGV[7]) end
+  return 2
+end
+redis.call('ZADD', KEYS[1], ARGV[3], ARGV[1])
+for i = 1, 5 do redis.call('PEXPIRE', KEYS[i], ARGV[6]) end
+return 1
+`)
+
+var reclaimScript = rd.NewScript(`
+local ids = redis.call('ZRANGEBYSCORE', KEYS[2], '-inf', ARGV[1], 'LIMIT', 0, ARGV[2])
+for _, id in ipairs(ids) do
+  if redis.call('ZREM', KEYS[2], id) == 1 then
+    redis.call('HDEL', KEYS[5], id)
+    if redis.call('HEXISTS', KEYS[3], id) == 1 then
+      redis.call('ZADD', KEYS[1], ARGV[1], id)
+    end
+  end
+end
+for i = 1, 5 do redis.call('PEXPIRE', KEYS[i], ARGV[3]) end
+return #ids
+`)
+
+var replayDLQScript = rd.NewScript(`
+local payload = redis.call('HGET', KEYS[7], ARGV[1])
+if not payload then return 0 end
+local score = redis.call('ZSCORE', KEYS[6], ARGV[1])
+if not score or tonumber(score) <= tonumber(ARGV[4]) then
+	redis.call('ZREM', KEYS[6], ARGV[1])
+	redis.call('HDEL', KEYS[7], ARGV[1])
+	redis.call('HDEL', KEYS[8], ARGV[1])
+	return 0
+end
+redis.call('ZREM', KEYS[6], ARGV[1])
+redis.call('HDEL', KEYS[7], ARGV[1])
+redis.call('HDEL', KEYS[8], ARGV[1])
+redis.call('HSET', KEYS[3], ARGV[1], payload)
+redis.call('HSET', KEYS[4], ARGV[1], 0)
+redis.call('ZADD', KEYS[1], ARGV[2], ARGV[1])
+for i = 1, 5 do redis.call('PEXPIRE', KEYS[i], ARGV[3]) end
+return 1
+`)
+
+var pruneDLQScript = rd.NewScript(`
+local expired = redis.call('ZRANGEBYSCORE', KEYS[6], '-inf', ARGV[1])
+for _, id in ipairs(expired) do
+	redis.call('HDEL', KEYS[7], id)
+	redis.call('HDEL', KEYS[8], id)
+end
+redis.call('ZREMRANGEBYSCORE', KEYS[6], '-inf', ARGV[1])
+return #expired
+`)
+
+func NewRedisQueue(client *rd.Client, cfg QueueConfig) (*RedisQueue, error) {
+	if client == nil {
+		return nil, errors.New("cardactiondispatch: Redis client is required")
+	}
+	if strings.TrimSpace(cfg.Prefix) == "" || strings.ContainsAny(cfg.Prefix, " \t\r\n") {
+		return nil, errors.New("cardactiondispatch: invalid queue prefix")
+	}
+	if cfg.LiveTTL <= 0 || cfg.DLQRetention <= 0 {
+		return nil, errors.New("cardactiondispatch: queue retention must be positive")
+	}
+	base := cfg.Prefix + ":{queue}:"
+	return &RedisQueue{
+		client: client,
+		keys: queueKeys{
+			ready:      base + "ready",
+			leased:     base + "leased",
+			payload:    base + "payload",
+			attempts:   base + "attempts",
+			tokens:     base + "tokens",
+			dlq:        base + "dlq",
+			dlqPayload: base + "dlq_payload",
+			dlqMeta:    base + "dlq_meta",
+		},
+		liveTTL:      cfg.LiveTTL,
+		dlqRetention: cfg.DLQRetention,
+	}, nil
+}
+
+func (q *RedisQueue) Enqueue(event Event, due time.Time) error {
+	if event.EventID <= 0 || event.SenderUID == "" || event.Owner == "" || event.ActionType == "" {
+		return errors.New("cardactiondispatch: invalid queue event")
+	}
+	payload, err := json.Marshal(event)
+	if err != nil {
+		return fmt.Errorf("cardactiondispatch: marshal event: %w", err)
+	}
+	_, err = enqueueScript.Run(q.client, q.scriptKeys(),
+		strconv.FormatInt(event.EventID, 10), payload, unixMillis(due), durationMillis(q.liveTTL)).Result()
+	if err != nil {
+		return fmt.Errorf("cardactiondispatch: enqueue event: %w", err)
+	}
+	return nil
+}
+
+func (q *RedisQueue) Claim(now time.Time, leaseDuration time.Duration) (*Lease, error) {
+	if leaseDuration <= 0 {
+		return nil, errors.New("cardactiondispatch: lease duration must be positive")
+	}
+	token, err := newLeaseToken()
+	if err != nil {
+		return nil, err
+	}
+	value, err := claimScript.Run(q.client, q.scriptKeys(),
+		unixMillis(now), unixMillis(now.Add(leaseDuration)), token, durationMillis(q.liveTTL)).Result()
+	if err != nil {
+		return nil, fmt.Errorf("cardactiondispatch: claim event: %w", err)
+	}
+	items, ok := value.([]interface{})
+	if !ok || len(items) == 0 {
+		return nil, nil
+	}
+	if len(items) != 4 {
+		return nil, errors.New("cardactiondispatch: malformed Redis claim response")
+	}
+	payload, ok := redisString(items[1])
+	if !ok {
+		return nil, errors.New("cardactiondispatch: malformed claimed payload")
+	}
+	var event Event
+	if err := json.Unmarshal([]byte(payload), &event); err != nil {
+		return nil, fmt.Errorf("cardactiondispatch: decode claimed event: %w", err)
+	}
+	attemptRaw, ok := redisString(items[2])
+	if !ok {
+		return nil, errors.New("cardactiondispatch: malformed claimed attempt")
+	}
+	attempt, err := strconv.Atoi(attemptRaw)
+	if err != nil {
+		return nil, fmt.Errorf("cardactiondispatch: decode claimed attempt: %w", err)
+	}
+	claimedToken, ok := redisString(items[3])
+	if !ok || claimedToken == "" {
+		return nil, errors.New("cardactiondispatch: malformed claimed token")
+	}
+	return &Lease{Event: event, Token: claimedToken, Attempt: attempt}, nil
+}
+
+func (q *RedisQueue) Ack(eventID int64, token string) (bool, error) {
+	value, err := ackScript.Run(q.client, q.scriptKeys(), strconv.FormatInt(eventID, 10), token).Int()
+	if err != nil {
+		return false, fmt.Errorf("cardactiondispatch: ack event: %w", err)
+	}
+	return value == 1, nil
+}
+
+func (q *RedisQueue) Renew(eventID int64, token string, now time.Time, leaseDuration time.Duration) (bool, error) {
+	if eventID <= 0 || token == "" || leaseDuration <= 0 {
+		return false, errors.New("cardactiondispatch: invalid lease renewal")
+	}
+	value, err := renewScript.Run(q.client, q.scriptKeys(),
+		strconv.FormatInt(eventID, 10), token, unixMillis(now.Add(leaseDuration)), durationMillis(q.liveTTL)).Int()
+	if err != nil {
+		return false, fmt.Errorf("cardactiondispatch: renew lease: %w", err)
+	}
+	return value == 1, nil
+}
+
+// Defer returns a capacity-blocked lease to ready without consuming a delivery
+// attempt. The lease token and leased-set membership are checked atomically, so
+// a stale worker cannot move a lease owned by another replica.
+func (q *RedisQueue) Defer(eventID int64, token string, due time.Time) (bool, error) {
+	if eventID <= 0 || token == "" || due.IsZero() {
+		return false, errors.New("cardactiondispatch: invalid lease defer")
+	}
+	value, err := deferScript.Run(q.client, q.scriptKeys(),
+		strconv.FormatInt(eventID, 10), token, unixMillis(due), durationMillis(q.liveTTL)).Int()
+	if err != nil {
+		return false, fmt.Errorf("cardactiondispatch: defer lease: %w", err)
+	}
+	return value == 1, nil
+}
+
+func (q *RedisQueue) Nack(lease Lease, now time.Time, delay time.Duration, maxAttempts int, reason string) (NackOutcome, error) {
+	if maxAttempts < 1 || delay < 0 {
+		return "", errors.New("cardactiondispatch: invalid nack policy")
+	}
+	meta, _ := json.Marshal(map[string]interface{}{
+		"attempt":   lease.Attempt,
+		"reason":    truncate(reason, 256),
+		"failed_at": now.Unix(),
+	})
+	value, err := nackScript.Run(q.client, q.scriptKeys(),
+		strconv.FormatInt(lease.Event.EventID, 10), lease.Token, unixMillis(now.Add(delay)), maxAttempts,
+		meta, durationMillis(q.liveTTL), durationMillis(q.dlqRetention), unixMillis(now.Add(-q.dlqRetention)), unixMillis(now)).Int()
+	if err != nil {
+		return "", fmt.Errorf("cardactiondispatch: nack event: %w", err)
+	}
+	switch value {
+	case 0:
+		return NackTokenMismatch, nil
+	case 1:
+		return NackRequeued, nil
+	case 2:
+		return NackDeadLettered, nil
+	default:
+		return "", errors.New("cardactiondispatch: malformed Redis nack response")
+	}
+}
+
+func (q *RedisQueue) ReclaimExpired(now time.Time, limit int) (int, error) {
+	if limit < 1 || limit > 1000 {
+		return 0, errors.New("cardactiondispatch: reclaim limit must be between 1 and 1000")
+	}
+	value, err := reclaimScript.Run(q.client, q.scriptKeys(), unixMillis(now), limit, durationMillis(q.liveTTL)).Int()
+	if err != nil {
+		return 0, fmt.Errorf("cardactiondispatch: reclaim events: %w", err)
+	}
+	return value, nil
+}
+
+func (q *RedisQueue) ReplayDLQ(eventID int64, due time.Time) (bool, error) {
+	value, err := replayDLQScript.Run(q.client, q.scriptKeys(),
+		strconv.FormatInt(eventID, 10), unixMillis(due), durationMillis(q.liveTTL), unixMillis(due.Add(-q.dlqRetention))).Int()
+	if err != nil {
+		return false, fmt.Errorf("cardactiondispatch: replay DLQ event: %w", err)
+	}
+	return value == 1, nil
+}
+
+func (q *RedisQueue) Depths() (QueueDepths, error) {
+	if _, err := pruneDLQScript.Run(q.client, q.scriptKeys(), unixMillis(time.Now().Add(-q.dlqRetention))).Result(); err != nil {
+		return QueueDepths{}, fmt.Errorf("cardactiondispatch: prune expired DLQ events: %w", err)
+	}
+	pipe := q.client.Pipeline()
+	ready := pipe.ZCard(q.keys.ready)
+	leased := pipe.ZCard(q.keys.leased)
+	dlq := pipe.ZCard(q.keys.dlq)
+	if _, err := pipe.Exec(); err != nil {
+		return QueueDepths{}, fmt.Errorf("cardactiondispatch: read queue depths: %w", err)
+	}
+	return QueueDepths{Ready: ready.Val(), Leased: leased.Val(), DLQ: dlq.Val()}, nil
+}
+
+func (q *RedisQueue) scriptKeys() []string {
+	return []string{
+		q.keys.ready, q.keys.leased, q.keys.payload, q.keys.attempts,
+		q.keys.tokens, q.keys.dlq, q.keys.dlqPayload, q.keys.dlqMeta,
+	}
+}
+
+func newLeaseToken() (string, error) {
+	var raw [16]byte
+	if _, err := rand.Read(raw[:]); err != nil {
+		return "", fmt.Errorf("cardactiondispatch: generate lease token: %w", err)
+	}
+	return hex.EncodeToString(raw[:]), nil
+}
+
+func redisString(value interface{}) (string, bool) {
+	switch typed := value.(type) {
+	case string:
+		return typed, true
+	case []byte:
+		return string(typed), true
+	default:
+		return "", false
+	}
+}
+
+func unixMillis(value time.Time) int64 {
+	return value.UnixNano() / int64(time.Millisecond)
+}
+
+func durationMillis(value time.Duration) int64 {
+	return int64(value / time.Millisecond)
+}
+
+func truncate(value string, limit int) string {
+	if len(value) <= limit {
+		return value
+	}
+	cut := limit
+	for cut > 0 && !utf8.ValidString(value[:cut]) {
+		cut--
+	}
+	return value[:cut]
+}

--- a/internal/cardactiondispatch/registry.go
+++ b/internal/cardactiondispatch/registry.go
@@ -1,0 +1,363 @@
+package cardactiondispatch
+
+import (
+	"crypto/subtle"
+	"errors"
+	"fmt"
+	"net/url"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+)
+
+type ResolutionKind string
+
+const (
+	ResolutionCallback ResolutionKind = "callback"
+	ResolutionBotPull  ResolutionKind = "bot_pull"
+	ResolutionReject   ResolutionKind = "reject"
+)
+
+const (
+	defaultTimeout     = 3 * time.Second
+	defaultMaxAttempts = 5
+	defaultBaseBackoff = time.Second
+	defaultMaxBackoff  = time.Minute
+	defaultMaxInFlight = 8
+)
+
+var (
+	ownerPattern      = regexp.MustCompile(`^[a-z][a-z0-9-]{0,63}$`)
+	actionTypePattern = regexp.MustCompile(`^[a-z][a-z0-9_.-]{0,127}$`)
+	senderPattern     = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9_.-]{0,127}$`)
+	secretEnvPattern  = regexp.MustCompile(`^[A-Z][A-Z0-9_]{0,127}$`)
+)
+
+type RouteSpec struct {
+	SenderUID      string
+	Owner          string
+	ActionType     string
+	URL            string
+	SecretEnv      string
+	NotifyTokenEnv string
+	Timeout        time.Duration
+	MaxAttempts    int
+	BaseBackoff    time.Duration
+	MaxBackoff     time.Duration
+	MaxInFlight    int
+}
+
+type Route struct {
+	SenderUID   string
+	Owner       string
+	ActionType  string
+	URL         string
+	Timeout     time.Duration
+	MaxAttempts int
+	BaseBackoff time.Duration
+	MaxBackoff  time.Duration
+	MaxInFlight int
+
+	secret string
+}
+
+type Resolution struct {
+	Kind  ResolutionKind
+	Route *Route
+}
+
+type routeKey struct {
+	senderUID  string
+	owner      string
+	actionType string
+}
+
+// NotifyCapability is the server-authoritative identity granted to one
+// first-party notification caller. The bearer token never supplies owner or
+// sender metadata; it resolves to this value at the ingress boundary.
+type NotifyCapability struct {
+	SenderUID string
+	Owner     string
+}
+
+type notifyCredential struct {
+	capability NotifyCapability
+	tokenEnv   string
+	token      string
+}
+
+type Registry struct {
+	routes            map[routeKey]*Route
+	internalSenders   map[string]struct{}
+	notifyActions     map[routeKey]struct{}
+	notifyCredentials []notifyCredential
+	callbackSecrets   map[string]struct{}
+}
+
+func NewRegistry(specs []RouteSpec, allowedURLs []string, getenv func(string) string) (*Registry, error) {
+	if getenv == nil {
+		return nil, errors.New("cardactiondispatch: getenv is required")
+	}
+	allowed, err := validateAllowedURLs(allowedURLs)
+	if err != nil {
+		return nil, err
+	}
+	registry := &Registry{
+		routes:          make(map[routeKey]*Route, len(specs)),
+		internalSenders: make(map[string]struct{}),
+		notifyActions:   make(map[routeKey]struct{}),
+		callbackSecrets: make(map[string]struct{}, len(specs)),
+	}
+	credentialsByCapability := make(map[NotifyCapability]notifyCredential)
+	tokenOwners := make(map[string]NotifyCapability)
+	for i, input := range specs {
+		spec := withRouteDefaults(input)
+		if err := validateRouteSpec(spec, allowed, getenv); err != nil {
+			return nil, fmt.Errorf("cardactiondispatch: route %d: %w", i, err)
+		}
+		key := routeKey{senderUID: spec.SenderUID, owner: spec.Owner, actionType: spec.ActionType}
+		if _, exists := registry.routes[key]; exists {
+			return nil, fmt.Errorf("cardactiondispatch: duplicate route for sender=%q owner=%q action_type=%q", spec.SenderUID, spec.Owner, spec.ActionType)
+		}
+		callbackSecret := getenv(spec.SecretEnv)
+		registry.routes[key] = &Route{
+			SenderUID:   spec.SenderUID,
+			Owner:       spec.Owner,
+			ActionType:  spec.ActionType,
+			URL:         spec.URL,
+			Timeout:     spec.Timeout,
+			MaxAttempts: spec.MaxAttempts,
+			BaseBackoff: spec.BaseBackoff,
+			MaxBackoff:  spec.MaxBackoff,
+			MaxInFlight: spec.MaxInFlight,
+			secret:      callbackSecret,
+		}
+		registry.callbackSecrets[callbackSecret] = struct{}{}
+		registry.internalSenders[spec.SenderUID] = struct{}{}
+		if spec.NotifyTokenEnv != "" {
+			capability := NotifyCapability{SenderUID: spec.SenderUID, Owner: spec.Owner}
+			credential := notifyCredential{
+				capability: capability,
+				tokenEnv:   spec.NotifyTokenEnv,
+				token:      getenv(spec.NotifyTokenEnv),
+			}
+			if existing, ok := credentialsByCapability[capability]; ok && existing.tokenEnv != credential.tokenEnv {
+				return nil, fmt.Errorf("cardactiondispatch: route %d: inconsistent notify_token_env for sender/owner", i)
+			}
+			if owner, ok := tokenOwners[credential.token]; ok && owner != capability {
+				return nil, fmt.Errorf("cardactiondispatch: route %d: notify token is bound to multiple owners", i)
+			}
+			credentialsByCapability[capability] = credential
+			tokenOwners[credential.token] = capability
+			registry.notifyActions[key] = struct{}{}
+		}
+	}
+	for _, credential := range credentialsByCapability {
+		if _, conflicts := registry.callbackSecrets[credential.token]; conflicts {
+			return nil, errors.New("cardactiondispatch: notify token conflicts with a callback secret")
+		}
+	}
+	registry.notifyCredentials = make([]notifyCredential, 0, len(credentialsByCapability))
+	for _, credential := range credentialsByCapability {
+		registry.notifyCredentials = append(registry.notifyCredentials, credential)
+	}
+	sort.Slice(registry.notifyCredentials, func(i, j int) bool {
+		left, right := registry.notifyCredentials[i].capability, registry.notifyCredentials[j].capability
+		if left.SenderUID == right.SenderUID {
+			return left.Owner < right.Owner
+		}
+		return left.SenderUID < right.SenderUID
+	})
+	return registry, nil
+}
+
+func (r *Registry) Resolve(senderUID, owner, actionType string) Resolution {
+	if r == nil {
+		return Resolution{Kind: ResolutionBotPull}
+	}
+	if route, ok := r.routes[routeKey{senderUID: senderUID, owner: owner, actionType: actionType}]; ok {
+		return Resolution{Kind: ResolutionCallback, Route: route}
+	}
+	if _, internal := r.internalSenders[senderUID]; internal {
+		return Resolution{Kind: ResolutionReject}
+	}
+	return Resolution{Kind: ResolutionBotPull}
+}
+
+func (r *Registry) Route(senderUID, owner, actionType string) (*Route, bool) {
+	if r == nil {
+		return nil, false
+	}
+	route, ok := r.routes[routeKey{senderUID: senderUID, owner: owner, actionType: actionType}]
+	return route, ok
+}
+
+// ResolveNotifyToken performs a constant-time comparison against every
+// configured first-party notification capability. Tokens are unique across
+// capabilities, so at most one result can match.
+func (r *Registry) ResolveNotifyToken(token string) (NotifyCapability, bool) {
+	if r == nil || token == "" {
+		return NotifyCapability{}, false
+	}
+	matched := -1
+	for i := range r.notifyCredentials {
+		if subtle.ConstantTimeCompare([]byte(token), []byte(r.notifyCredentials[i].token)) == 1 {
+			matched = i
+		}
+	}
+	if matched < 0 {
+		return NotifyCapability{}, false
+	}
+	return r.notifyCredentials[matched].capability, true
+}
+
+// CanNotify keeps a capability scoped to only the action types that explicitly
+// declare its notify_token_env. A token for one owner cannot mint another
+// owner's card or access a callback-only route.
+func (r *Registry) CanNotify(capability NotifyCapability, actionType string) bool {
+	if r == nil {
+		return false
+	}
+	_, ok := r.notifyActions[routeKey{
+		senderUID:  capability.SenderUID,
+		owner:      capability.Owner,
+		actionType: actionType,
+	}]
+	return ok
+}
+
+func (r *Registry) NotifyProducers() []NotifyCapability {
+	if r == nil {
+		return nil
+	}
+	producers := make([]NotifyCapability, len(r.notifyCredentials))
+	for i := range r.notifyCredentials {
+		producers[i] = r.notifyCredentials[i].capability
+	}
+	return producers
+}
+
+// ValidateNotifyTokenExclusions prevents a route-scoped approval token from
+// accidentally inheriting a broader legacy/docs notify capability.
+func (r *Registry) ValidateNotifyTokenExclusions(tokens ...string) error {
+	if r == nil {
+		return errors.New("cardactiondispatch: registry unavailable")
+	}
+	for _, token := range tokens {
+		if token == "" {
+			continue
+		}
+		if _, ok := r.ResolveNotifyToken(token); ok {
+			return errors.New("cardactiondispatch: action notify token conflicts with an existing notify token")
+		}
+		if _, ok := r.callbackSecrets[token]; ok {
+			return errors.New("cardactiondispatch: callback secret conflicts with an existing notify token")
+		}
+	}
+	return nil
+}
+
+func withRouteDefaults(spec RouteSpec) RouteSpec {
+	if spec.Timeout == 0 {
+		spec.Timeout = defaultTimeout
+	}
+	if spec.MaxAttempts == 0 {
+		spec.MaxAttempts = defaultMaxAttempts
+	}
+	if spec.BaseBackoff == 0 {
+		spec.BaseBackoff = defaultBaseBackoff
+	}
+	if spec.MaxBackoff == 0 {
+		spec.MaxBackoff = defaultMaxBackoff
+	}
+	if spec.MaxInFlight == 0 {
+		spec.MaxInFlight = defaultMaxInFlight
+	}
+	return spec
+}
+
+func validateRouteSpec(spec RouteSpec, allowed map[string]struct{}, getenv func(string) string) error {
+	if !senderPattern.MatchString(spec.SenderUID) || strings.HasPrefix(spec.SenderUID, "iwh_") {
+		return errors.New("invalid sender_uid")
+	}
+	if !ownerPattern.MatchString(spec.Owner) {
+		return errors.New("invalid owner")
+	}
+	if !actionTypePattern.MatchString(spec.ActionType) {
+		return errors.New("invalid action_type")
+	}
+	canonical, err := validateCallbackURL(spec.URL)
+	if err != nil {
+		return err
+	}
+	if _, ok := allowed[canonical]; !ok {
+		return errors.New("callback URL is not in the exact allowlist")
+	}
+	if !secretEnvPattern.MatchString(spec.SecretEnv) {
+		return errors.New("invalid secret_env")
+	}
+	if len(getenv(spec.SecretEnv)) < 32 {
+		return errors.New("callback secret must contain at least 32 bytes")
+	}
+	if spec.NotifyTokenEnv != "" {
+		if !secretEnvPattern.MatchString(spec.NotifyTokenEnv) {
+			return errors.New("invalid notify_token_env")
+		}
+		notifyToken := getenv(spec.NotifyTokenEnv)
+		if len(notifyToken) < 32 {
+			return errors.New("notify token must contain at least 32 bytes")
+		}
+		if spec.NotifyTokenEnv == spec.SecretEnv || notifyToken == getenv(spec.SecretEnv) {
+			return errors.New("notify token must differ from callback secret")
+		}
+	}
+	if spec.Timeout < 100*time.Millisecond || spec.Timeout > 10*time.Second {
+		return errors.New("timeout must be between 100ms and 10s")
+	}
+	if spec.MaxAttempts < 1 || spec.MaxAttempts > 10 {
+		return errors.New("max_attempts must be between 1 and 10")
+	}
+	if spec.BaseBackoff < 100*time.Millisecond || spec.BaseBackoff > time.Minute {
+		return errors.New("base_backoff must be between 100ms and 1m")
+	}
+	if spec.MaxBackoff < spec.BaseBackoff || spec.MaxBackoff > 10*time.Minute {
+		return errors.New("max_backoff must be between base_backoff and 10m")
+	}
+	if spec.MaxInFlight < 1 || spec.MaxInFlight > 100 {
+		return errors.New("max_in_flight must be between 1 and 100")
+	}
+	return nil
+}
+
+func validateAllowedURLs(values []string) (map[string]struct{}, error) {
+	allowed := make(map[string]struct{}, len(values))
+	for i, value := range values {
+		canonical, err := validateCallbackURL(value)
+		if err != nil {
+			return nil, fmt.Errorf("cardactiondispatch: allowed URL %d: %w", i, err)
+		}
+		allowed[canonical] = struct{}{}
+	}
+	return allowed, nil
+}
+
+func validateCallbackURL(raw string) (string, error) {
+	if strings.TrimSpace(raw) != raw || raw == "" {
+		return "", errors.New("invalid callback URL")
+	}
+	u, err := url.Parse(raw)
+	if err != nil || u.Scheme != "https" || u.Host == "" || u.Opaque != "" {
+		return "", errors.New("callback URL must be an absolute HTTPS URL")
+	}
+	if u.User != nil {
+		return "", errors.New("callback URL must not contain credentials")
+	}
+	if u.Fragment != "" {
+		return "", errors.New("callback URL must not contain a fragment")
+	}
+	if u.RawQuery != "" {
+		return "", errors.New("callback URL must not contain a query")
+	}
+	return u.String(), nil
+}

--- a/internal/cardactiondispatch/service.go
+++ b/internal/cardactiondispatch/service.go
@@ -1,0 +1,106 @@
+package cardactiondispatch
+
+import (
+	"errors"
+	"fmt"
+	"time"
+)
+
+const (
+	serviceContextKey = "octo-server.internal.cardactiondispatch.service.v1"
+	eventSequenceKey  = "cardActionDispatchEvent"
+)
+
+var ErrServiceAlreadyInstalled = errors.New("cardactiondispatch: service already installed")
+
+type eventQueue interface {
+	Enqueue(event Event, due time.Time) error
+}
+
+type sequenceGenerator interface {
+	GenSeq(key string) (int64, error)
+}
+
+type ValueStore interface {
+	SetValue(value interface{}, key string)
+	Value(key string) interface{}
+}
+
+type Service struct {
+	registry *Registry
+	queue    eventQueue
+	sequence sequenceGenerator
+	clock    func() time.Time
+}
+
+func NewService(registry *Registry, queue eventQueue, sequence sequenceGenerator) (*Service, error) {
+	if registry == nil || queue == nil || sequence == nil {
+		return nil, errors.New("cardactiondispatch: service dependencies are required")
+	}
+	return &Service{registry: registry, queue: queue, sequence: sequence, clock: time.Now}, nil
+}
+
+func (s *Service) Resolve(senderUID, owner, actionType string) Resolution {
+	if s == nil {
+		return Resolution{Kind: ResolutionBotPull}
+	}
+	return s.registry.Resolve(senderUID, owner, actionType)
+}
+
+func (s *Service) ResolveNotifyToken(token string) (NotifyCapability, bool) {
+	if s == nil {
+		return NotifyCapability{}, false
+	}
+	return s.registry.ResolveNotifyToken(token)
+}
+
+func (s *Service) CanNotify(capability NotifyCapability, actionType string) bool {
+	return s != nil && s.registry.CanNotify(capability, actionType)
+}
+
+func (s *Service) NotifyProducers() []NotifyCapability {
+	if s == nil {
+		return nil
+	}
+	return s.registry.NotifyProducers()
+}
+
+func (s *Service) Enqueue(event Event) (int64, error) {
+	if s == nil {
+		return 0, errors.New("cardactiondispatch: service unavailable")
+	}
+	if event.EventID != 0 {
+		return 0, errors.New("cardactiondispatch: caller must not assign event_id")
+	}
+	if resolution := s.registry.Resolve(event.SenderUID, event.Owner, event.ActionType); resolution.Kind != ResolutionCallback {
+		return 0, errors.New("cardactiondispatch: event has no registered callback route")
+	}
+	eventID, err := s.sequence.GenSeq(eventSequenceKey)
+	if err != nil {
+		return 0, fmt.Errorf("cardactiondispatch: allocate event_id: %w", err)
+	}
+	event.EventID = eventID
+	if err := s.queue.Enqueue(event, s.clock()); err != nil {
+		return 0, err
+	}
+	return eventID, nil
+}
+
+func Install(ctx ValueStore, service *Service) error {
+	if ctx == nil || service == nil {
+		return errors.New("cardactiondispatch: install requires context and service")
+	}
+	if ctx.Value(serviceContextKey) != nil {
+		return ErrServiceAlreadyInstalled
+	}
+	ctx.SetValue(service, serviceContextKey)
+	return nil
+}
+
+func FromContext(ctx ValueStore) (*Service, bool) {
+	if ctx == nil {
+		return nil, false
+	}
+	service, ok := ctx.Value(serviceContextKey).(*Service)
+	return service, ok && service != nil
+}

--- a/internal/cardactiondispatch/service_test.go
+++ b/internal/cardactiondispatch/service_test.go
@@ -1,0 +1,90 @@
+package cardactiondispatch
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+type captureEventQueue struct {
+	event Event
+	due   time.Time
+	err   error
+}
+
+func (q *captureEventQueue) Enqueue(event Event, due time.Time) error {
+	q.event = event
+	q.due = due
+	return q.err
+}
+
+type fixedSequence struct {
+	value int64
+	err   error
+}
+
+func (s fixedSequence) GenSeq(string) (int64, error) { return s.value, s.err }
+
+type valueStore map[string]interface{}
+
+func (s valueStore) SetValue(value interface{}, key string) { s[key] = value }
+func (s valueStore) Value(key string) interface{}           { return s[key] }
+
+func TestServiceAllocatesEventIDAndInstallsPerContext(t *testing.T) {
+	registry, err := NewRegistry([]RouteSpec{validRouteSpec()}, []string{validRouteSpec().URL}, testGetenv)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	queue := &captureEventQueue{}
+	service, err := NewService(registry, queue, fixedSequence{value: 991})
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+	event := testDispatchEvent()
+	event.EventID = 0
+	eventID, err := service.Enqueue(event)
+	if err != nil {
+		t.Fatalf("Enqueue() error = %v", err)
+	}
+	if eventID != 991 || queue.event.EventID != 991 || queue.due.IsZero() {
+		t.Fatalf("Enqueue() = id %d event %+v due %v", eventID, queue.event, queue.due)
+	}
+
+	ctx := valueStore{}
+	if err := Install(ctx, service); err != nil {
+		t.Fatalf("Install() error = %v", err)
+	}
+	if got, ok := FromContext(ctx); !ok || got != service {
+		t.Fatalf("FromContext() = (%p, %v), want (%p, true)", got, ok, service)
+	}
+	if err := Install(ctx, service); !errors.Is(err, ErrServiceAlreadyInstalled) {
+		t.Fatalf("second Install() error = %v, want ErrServiceAlreadyInstalled", err)
+	}
+}
+
+func TestServiceRejectsUnregisteredOrCallerAssignedEvents(t *testing.T) {
+	registry, err := NewRegistry([]RouteSpec{validRouteSpec()}, []string{validRouteSpec().URL}, testGetenv)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	service, err := NewService(registry, &captureEventQueue{}, fixedSequence{value: 1})
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+	event := testDispatchEvent()
+	if _, err := service.Enqueue(event); err == nil {
+		t.Fatal("Enqueue(caller event_id) error = nil")
+	}
+	event.EventID = 0
+	event.ActionType = "unknown"
+	if _, err := service.Enqueue(event); err == nil {
+		t.Fatal("Enqueue(unregistered route) error = nil")
+	}
+
+	queue := &captureEventQueue{err: errors.New("redis down")}
+	service, _ = NewService(registry, queue, fixedSequence{value: 2})
+	event.ActionType = "access_request.decision"
+	if _, err := service.Enqueue(event); err == nil {
+		t.Fatal("Enqueue(queue failure) error = nil")
+	}
+}

--- a/internal/cardactiondispatch/signature.go
+++ b/internal/cardactiondispatch/signature.go
@@ -1,0 +1,33 @@
+package cardactiondispatch
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+)
+
+const signatureVersion = "v1"
+
+func CanonicalRequest(method, path, timestamp, eventID string, body []byte) string {
+	sum := sha256.Sum256(body)
+	return strings.Join([]string{
+		signatureVersion,
+		strings.ToUpper(method),
+		path,
+		timestamp,
+		eventID,
+		hex.EncodeToString(sum[:]),
+	}, "\n")
+}
+
+func Sign(secret, method, path, timestamp, eventID string, body []byte) string {
+	mac := hmac.New(sha256.New, []byte(secret))
+	_, _ = mac.Write([]byte(CanonicalRequest(method, path, timestamp, eventID, body)))
+	return signatureVersion + "=" + hex.EncodeToString(mac.Sum(nil))
+}
+
+func Verify(secret, signature, method, path, timestamp, eventID string, body []byte) bool {
+	want := Sign(secret, method, path, timestamp, eventID, body)
+	return hmac.Equal([]byte(signature), []byte(want))
+}

--- a/internal/carddispatch/mutation.go
+++ b/internal/carddispatch/mutation.go
@@ -1,0 +1,322 @@
+package carddispatch
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	liblog "github.com/Mininglamp-OSS/octo-lib/pkg/log"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardmsg"
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardrevision"
+	"github.com/go-sql-driver/mysql"
+	"github.com/gocraft/dbr/v2"
+	"go.uber.org/zap"
+)
+
+var (
+	ErrCardMutationInvalid   = errors.New("carddispatch: invalid card mutation")
+	ErrCardMutationNotFound  = errors.New("carddispatch: card mutation target not found")
+	ErrCardMutationForbidden = errors.New("carddispatch: card mutation sender mismatch")
+	ErrCardMutationConflict  = errors.New("carddispatch: stale card mutation")
+)
+
+const cardMutationCASMaxAttempts = 5
+
+type CardMutationRequest struct {
+	SenderUID   string
+	MessageID   string
+	MessageSeq  uint32
+	ChannelID   string
+	ChannelType uint8
+	ContentEdit string
+}
+
+type CardMutationResult struct {
+	Applied bool
+	Replay  bool
+}
+
+type CardMutationCASRequest struct {
+	MessageID   string
+	MessageSeq  uint32
+	ChannelID   string
+	ChannelType uint8
+	ContentEdit string
+	ContentHash string
+	EditedAt    int
+	CardSeq     int64
+	// StorageChannel is true when ChannelID is already the persisted fake DM
+	// channel. The existing Bot API resolves that before entering CAS.
+	StorageChannel bool
+}
+
+type storedCardMessage struct {
+	MessageID  string
+	MessageSeq uint32
+	FromUID    string
+	Payload    []byte
+}
+
+type cardMutationWrite struct {
+	SenderUID      string
+	MessageID      string
+	MessageSeq     uint32
+	ChannelID      string
+	ChannelType    uint8
+	ContentEdit    string
+	ContentHash    string
+	EditedAt       int
+	CardSeq        int64
+	StorageChannel bool
+}
+
+type cardMutationBackend interface {
+	Lookup(context.Context, CardMutationRequest) (storedCardMessage, error)
+	Lifecycle(messageID string) (revoked bool, deleted bool, err error)
+	ContentHashExists(messageID, hash string) (bool, error)
+	CASWrite(cardMutationWrite) (conflict bool, replay bool, err error)
+	AppendRevision(cardMutationWrite) error
+	Sync(cardMutationWrite) error
+}
+
+type CardMutator struct {
+	backend cardMutationBackend
+	logger  interface{ Error(string, ...zap.Field) }
+}
+
+func NewCardMutator(ctx *config.Context) *CardMutator {
+	mutator := newCardMutator(newProductionMutationBackend(ctx))
+	mutator.logger = liblog.NewTLog("CardMutation")
+	return mutator
+}
+
+func newCardMutator(backend cardMutationBackend) *CardMutator {
+	return &CardMutator{backend: backend}
+}
+
+func (m *CardMutator) Mutate(ctx context.Context, request CardMutationRequest) (CardMutationResult, error) {
+	if m == nil || m.backend == nil || ctx == nil || request.SenderUID == "" || request.MessageID == "" ||
+		request.ChannelID == "" || request.ContentEdit == "" {
+		return CardMutationResult{}, ErrCardMutationInvalid
+	}
+	message, err := m.backend.Lookup(ctx, request)
+	if err != nil {
+		return CardMutationResult{}, err
+	}
+	if message.MessageID != request.MessageID || message.FromUID != request.SenderUID {
+		return CardMutationResult{}, ErrCardMutationForbidden
+	}
+	if !cardmsg.IsCardRawPayload(message.Payload) || !cardmsg.IsCardContentEdit(request.ContentEdit) {
+		return CardMutationResult{}, ErrCardMutationInvalid
+	}
+	revoked, deleted, err := m.backend.Lifecycle(request.MessageID)
+	if err != nil {
+		return CardMutationResult{}, fmt.Errorf("carddispatch: query card lifecycle: %w", err)
+	}
+	if revoked || deleted {
+		return CardMutationResult{}, ErrCardMutationNotFound
+	}
+	normalized, err := cardmsg.NormalizeContentEdit(request.ContentEdit)
+	if err != nil {
+		return CardMutationResult{}, fmt.Errorf("%w: %v", ErrCardMutationInvalid, err)
+	}
+	cardSeq, hasCardSeq := cardmsg.CardSeqFromContentEdit(normalized)
+	if !hasCardSeq || cardSeq <= 0 {
+		return CardMutationResult{}, ErrCardMutationInvalid
+	}
+	hash := util.MD5(normalized)
+	exists, err := m.backend.ContentHashExists(request.MessageID, hash)
+	if err != nil {
+		return CardMutationResult{}, fmt.Errorf("carddispatch: query mutation hash: %w", err)
+	}
+	if exists {
+		return CardMutationResult{Replay: true}, nil
+	}
+	write := cardMutationWrite{
+		SenderUID: request.SenderUID, MessageID: request.MessageID, MessageSeq: message.MessageSeq,
+		ChannelID: request.ChannelID, ChannelType: request.ChannelType, ContentEdit: normalized,
+		ContentHash: hash, EditedAt: int(time.Now().Unix()), CardSeq: cardSeq,
+	}
+	conflict, replay, err := m.backend.CASWrite(write)
+	if err != nil {
+		return CardMutationResult{}, fmt.Errorf("carddispatch: persist mutation: %w", err)
+	}
+	if conflict {
+		return CardMutationResult{}, ErrCardMutationConflict
+	}
+	if replay {
+		return CardMutationResult{Replay: true}, nil
+	}
+	// Revision history and CMD fanout are secondary to the authoritative
+	// content_edit, matching the existing Bot API semantics.
+	if err := m.backend.AppendRevision(write); err != nil && m.logger != nil {
+		m.logger.Error("card mutation revision append failed", zap.Error(err), zap.String("message_id", request.MessageID))
+	}
+	if err := m.backend.Sync(write); err != nil && m.logger != nil {
+		m.logger.Error("card mutation CMD sync failed", zap.Error(err), zap.String("message_id", request.MessageID))
+	}
+	return CardMutationResult{Applied: true}, nil
+}
+
+func (m *CardMutator) WriteCAS(request CardMutationCASRequest) (bool, error) {
+	if m == nil || m.backend == nil {
+		return false, ErrCardMutationInvalid
+	}
+	conflict, _, err := m.backend.CASWrite(cardMutationWrite{
+		MessageID: request.MessageID, MessageSeq: request.MessageSeq, ChannelID: request.ChannelID,
+		ChannelType: request.ChannelType, ContentEdit: request.ContentEdit, ContentHash: request.ContentHash,
+		EditedAt: request.EditedAt, CardSeq: request.CardSeq, StorageChannel: request.StorageChannel,
+	})
+	return conflict, err
+}
+
+type productionMutationBackend struct {
+	ctx       *config.Context
+	revisions *cardrevision.Store
+}
+
+func newProductionMutationBackend(ctx *config.Context) *productionMutationBackend {
+	if ctx == nil {
+		return nil
+	}
+	return &productionMutationBackend{ctx: ctx, revisions: cardrevision.NewStore(ctx.DB())}
+}
+
+func (b *productionMutationBackend) Lookup(_ context.Context, request CardMutationRequest) (storedCardMessage, error) {
+	if b == nil || b.ctx == nil {
+		return storedCardMessage{}, ErrCardMutationInvalid
+	}
+	if request.MessageSeq > 0 {
+		response, err := b.ctx.IMGetWithChannelAndSeqs(request.ChannelID, request.ChannelType, request.SenderUID, []uint32{request.MessageSeq})
+		if err != nil {
+			return storedCardMessage{}, err
+		}
+		if response == nil || len(response.Messages) == 0 {
+			return storedCardMessage{}, ErrCardMutationNotFound
+		}
+		message := response.Messages[0]
+		return storedCardMessage{
+			MessageID: strconv.FormatInt(message.MessageID, 10), MessageSeq: message.MessageSeq,
+			FromUID: message.FromUID, Payload: message.Payload,
+		}, nil
+	}
+	messageID, err := strconv.ParseInt(request.MessageID, 10, 64)
+	if err != nil {
+		return storedCardMessage{}, ErrCardMutationInvalid
+	}
+	response, err := b.ctx.IMSearchMessages(&config.MsgSearchReq{
+		ChannelID: request.ChannelID, ChannelType: request.ChannelType,
+		MessageIds: []int64{messageID}, LoginUID: request.SenderUID,
+	})
+	if err != nil {
+		return storedCardMessage{}, err
+	}
+	if response == nil || len(response.Messages) == 0 {
+		return storedCardMessage{}, ErrCardMutationNotFound
+	}
+	message := response.Messages[0]
+	if message.MessageSeq == 0 {
+		return storedCardMessage{}, ErrCardMutationNotFound
+	}
+	return storedCardMessage{
+		MessageID: strconv.FormatInt(message.MessageID, 10), MessageSeq: message.MessageSeq,
+		FromUID: message.FromUID, Payload: message.Payload,
+	}, nil
+}
+
+func (b *productionMutationBackend) Lifecycle(messageID string) (bool, bool, error) {
+	var lifecycle struct {
+		Revoke    int `db:"revoke"`
+		IsDeleted int `db:"is_deleted"`
+	}
+	err := b.ctx.DB().SelectBySql("SELECT `revoke`, is_deleted FROM message_extra WHERE message_id=?", messageID).LoadOne(&lifecycle)
+	if err == dbr.ErrNotFound {
+		return false, false, nil
+	}
+	return lifecycle.Revoke == 1, lifecycle.IsDeleted == 1, err
+}
+
+func (b *productionMutationBackend) ContentHashExists(messageID, hash string) (bool, error) {
+	var count int
+	err := b.ctx.DB().Select("count(*)").From("message_extra").Where("message_id=? and content_edit_hash=?", messageID, hash).LoadOne(&count)
+	return count > 0, err
+}
+
+func (b *productionMutationBackend) CASWrite(write cardMutationWrite) (bool, bool, error) {
+	var conflict, replay bool
+	var err error
+	for attempt := 0; attempt < cardMutationCASMaxAttempts; attempt++ {
+		conflict, replay, err = b.casWriteOnce(write)
+		if err == nil || !isMutationRetriableLockError(err) {
+			break
+		}
+		time.Sleep(time.Duration(attempt+1) * 3 * time.Millisecond)
+	}
+	return conflict, replay, err
+}
+
+func (b *productionMutationBackend) casWriteOnce(write cardMutationWrite) (bool, bool, error) {
+	tx, err := b.ctx.DB().Begin()
+	if err != nil {
+		return false, false, err
+	}
+	defer tx.RollbackUnlessCommitted()
+
+	var stored struct {
+		CardSeq dbr.NullInt64 `db:"card_seq"`
+		Hash    string        `db:"content_edit_hash"`
+	}
+	if err := tx.SelectBySql("SELECT card_seq, content_edit_hash FROM message_extra WHERE message_id=? FOR UPDATE", write.MessageID).LoadOne(&stored); err != nil && err != dbr.ErrNotFound {
+		return false, false, err
+	}
+	if stored.CardSeq.Valid && stored.CardSeq.Int64 >= write.CardSeq {
+		if stored.CardSeq.Int64 == write.CardSeq && stored.Hash == write.ContentHash {
+			return false, true, nil
+		}
+		return true, false, nil
+	}
+	fakeChannelID := write.ChannelID
+	if write.ChannelType == common.ChannelTypePerson.Uint8() && !write.StorageChannel {
+		fakeChannelID = common.GetFakeChannelIDWith(write.SenderUID, write.ChannelID)
+	}
+	version, err := b.ctx.GenSeq(fmt.Sprintf("%s:%s", common.MessageExtraSeqKey, fakeChannelID))
+	if err != nil {
+		return false, false, err
+	}
+	if _, err := tx.InsertBySql(
+		"INSERT INTO message_extra (message_id,message_seq,channel_id,channel_type,content_edit,content_edit_hash,edited_at,version,card_seq) VALUES (?,?,?,?,?,?,?,?,?) ON DUPLICATE KEY UPDATE content_edit=VALUES(content_edit),content_edit_hash=VALUES(content_edit_hash),edited_at=VALUES(edited_at),version=VALUES(version),card_seq=VALUES(card_seq)",
+		write.MessageID, write.MessageSeq, fakeChannelID, write.ChannelType, write.ContentEdit, write.ContentHash, write.EditedAt, version, write.CardSeq,
+	).Exec(); err != nil {
+		return false, false, err
+	}
+	return false, false, tx.Commit()
+}
+
+func (b *productionMutationBackend) AppendRevision(write cardMutationWrite) error {
+	fakeChannelID := write.ChannelID
+	if write.ChannelType == common.ChannelTypePerson.Uint8() && !write.StorageChannel {
+		fakeChannelID = common.GetFakeChannelIDWith(write.SenderUID, write.ChannelID)
+	}
+	return b.revisions.AppendFrame(cardrevision.Revision{
+		MessageID: write.MessageID, ChannelID: fakeChannelID, ChannelType: write.ChannelType,
+		Content: dbr.NewNullString(write.ContentEdit), Plain: cardmsg.PlainFromContentEdit(write.ContentEdit),
+		CardSeq: dbr.NewNullInt64(write.CardSeq), EditorUID: write.SenderUID, EditedAt: int64(write.EditedAt),
+	})
+}
+
+func (b *productionMutationBackend) Sync(write cardMutationWrite) error {
+	return b.ctx.SendCMD(config.MsgCMDReq{
+		NoPersist: true, ChannelID: write.ChannelID, ChannelType: write.ChannelType,
+		FromUID: write.SenderUID, CMD: common.CMDSyncMessageExtra,
+	})
+}
+
+func isMutationRetriableLockError(err error) bool {
+	var mysqlErr *mysql.MySQLError
+	return errors.As(err, &mysqlErr) && (mysqlErr.Number == 1213 || mysqlErr.Number == 1205)
+}

--- a/internal/carddispatch/mutation_test.go
+++ b/internal/carddispatch/mutation_test.go
@@ -1,0 +1,183 @@
+package carddispatch
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardmsg"
+)
+
+type fakeMutationBackend struct {
+	message       storedCardMessage
+	lookupErr     error
+	revoked       bool
+	deleted       bool
+	lifecycleErr  error
+	hashExists    bool
+	hashErr       error
+	writeConflict bool
+	writeReplay   bool
+	writeErr      error
+	writes        []cardMutationWrite
+	revisions     []cardMutationWrite
+	syncs         []cardMutationWrite
+}
+
+func (b *fakeMutationBackend) Lookup(_ context.Context, _ CardMutationRequest) (storedCardMessage, error) {
+	return b.message, b.lookupErr
+}
+
+func (b *fakeMutationBackend) Lifecycle(string) (bool, bool, error) {
+	return b.revoked, b.deleted, b.lifecycleErr
+}
+
+func (b *fakeMutationBackend) ContentHashExists(string, string) (bool, error) {
+	return b.hashExists, b.hashErr
+}
+
+func (b *fakeMutationBackend) CASWrite(write cardMutationWrite) (bool, bool, error) {
+	b.writes = append(b.writes, write)
+	return b.writeConflict, b.writeReplay, b.writeErr
+}
+
+func (b *fakeMutationBackend) AppendRevision(write cardMutationWrite) error {
+	b.revisions = append(b.revisions, write)
+	return nil
+}
+
+func (b *fakeMutationBackend) Sync(write cardMutationWrite) error {
+	b.syncs = append(b.syncs, write)
+	return nil
+}
+
+func TestCardMutatorPreservesOwnershipLifecycleCASAndReplay(t *testing.T) {
+	original := testCardEnvelope(t, 0, true)
+	terminal := testCardEnvelope(t, 42, false)
+
+	t.Run("applies canonical terminal frame", func(t *testing.T) {
+		backend := &fakeMutationBackend{message: storedCardMessage{
+			MessageID: "1001", MessageSeq: 7, FromUID: "notification", Payload: original,
+		}}
+		mutator := newCardMutator(backend)
+		result, err := mutator.Mutate(context.Background(), CardMutationRequest{
+			SenderUID: "notification", MessageID: "1001", ChannelID: "user-b", ChannelType: 1,
+			ContentEdit: string(terminal),
+		})
+		if err != nil {
+			t.Fatalf("Mutate() error = %v", err)
+		}
+		if !result.Applied || result.Replay {
+			t.Fatalf("Mutate() result = %+v", result)
+		}
+		if len(backend.writes) != 1 || backend.writes[0].CardSeq != 42 {
+			t.Fatalf("CAS writes = %+v", backend.writes)
+		}
+		if len(backend.revisions) != 1 || len(backend.syncs) != 1 {
+			t.Fatalf("revision/sync counts = %d/%d, want 1/1", len(backend.revisions), len(backend.syncs))
+		}
+		if backend.writes[0].ContentEdit == string(terminal) {
+			t.Fatal("Mutate() must persist cardmsg-normalized canonical bytes, not trust caller bytes verbatim")
+		}
+	})
+
+	t.Run("byte identical frame is idempotent replay", func(t *testing.T) {
+		backend := &fakeMutationBackend{
+			message:    storedCardMessage{MessageID: "1001", MessageSeq: 7, FromUID: "notification", Payload: original},
+			hashExists: true,
+		}
+		result, err := newCardMutator(backend).Mutate(context.Background(), CardMutationRequest{
+			SenderUID: "notification", MessageID: "1001", ChannelID: "user-b", ChannelType: 1,
+			ContentEdit: string(terminal),
+		})
+		if err != nil || !result.Replay || result.Applied {
+			t.Fatalf("Mutate(replay) = (%+v, %v)", result, err)
+		}
+		if len(backend.writes)+len(backend.revisions)+len(backend.syncs) != 0 {
+			t.Fatal("idempotent replay must not write CAS, revision, or CMD")
+		}
+	})
+
+	t.Run("concurrent identical CAS winner is idempotent replay", func(t *testing.T) {
+		backend := &fakeMutationBackend{
+			message:     storedCardMessage{MessageID: "1001", MessageSeq: 7, FromUID: "notification", Payload: original},
+			writeReplay: true,
+		}
+		result, err := newCardMutator(backend).Mutate(context.Background(), CardMutationRequest{
+			SenderUID: "notification", MessageID: "1001", ChannelID: "user-b", ChannelType: 1,
+			ContentEdit: string(terminal),
+		})
+		if err != nil || !result.Replay || result.Applied {
+			t.Fatalf("Mutate(concurrent replay) = (%+v, %v)", result, err)
+		}
+		if len(backend.revisions)+len(backend.syncs) != 0 {
+			t.Fatal("concurrent replay must not append a duplicate revision or CMD")
+		}
+	})
+
+	tests := []struct {
+		name    string
+		backend fakeMutationBackend
+		req     CardMutationRequest
+		wantErr error
+	}{
+		{
+			name: "wrong sender",
+			backend: fakeMutationBackend{message: storedCardMessage{
+				MessageID: "1001", MessageSeq: 7, FromUID: "other", Payload: original,
+			}},
+			req:     CardMutationRequest{SenderUID: "notification", MessageID: "1001", ChannelID: "user-b", ChannelType: 1, ContentEdit: string(terminal)},
+			wantErr: ErrCardMutationForbidden,
+		},
+		{
+			name: "revoked",
+			backend: fakeMutationBackend{message: storedCardMessage{
+				MessageID: "1001", MessageSeq: 7, FromUID: "notification", Payload: original,
+			}, revoked: true},
+			req:     CardMutationRequest{SenderUID: "notification", MessageID: "1001", ChannelID: "user-b", ChannelType: 1, ContentEdit: string(terminal)},
+			wantErr: ErrCardMutationNotFound,
+		},
+		{
+			name: "stale card seq",
+			backend: fakeMutationBackend{message: storedCardMessage{
+				MessageID: "1001", MessageSeq: 7, FromUID: "notification", Payload: original,
+			}, writeConflict: true},
+			req:     CardMutationRequest{SenderUID: "notification", MessageID: "1001", ChannelID: "user-b", ChannelType: 1, ContentEdit: string(terminal)},
+			wantErr: ErrCardMutationConflict,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := newCardMutator(&tt.backend).Mutate(context.Background(), tt.req)
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("Mutate() error = %v, want %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func testCardEnvelope(t *testing.T, cardSeq int64, withAction bool) []byte {
+	t.Helper()
+	card := map[string]interface{}{
+		"type": "AdaptiveCard", "version": cardmsg.CardVersion,
+		"body": []interface{}{map[string]interface{}{"type": "TextBlock", "text": "Document access"}},
+	}
+	if withAction {
+		card["actions"] = []interface{}{map[string]interface{}{
+			"type": "Action.Submit", "id": "approve", "title": "Allow",
+		}}
+	}
+	envelope := map[string]interface{}{
+		"type": cardmsg.InteractiveCard.Int(), "card_version": cardmsg.CardVersion,
+		"profile": cardmsg.ProfileV2, "card": card, "space_id": "space-1",
+	}
+	if cardSeq > 0 {
+		envelope["card_seq"] = cardSeq
+	}
+	raw, err := json.MarshalIndent(envelope, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal test card: %v", err)
+	}
+	return raw
+}

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"net/http"
@@ -20,6 +21,7 @@ import (
 	libwkhttp "github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
 	"github.com/Mininglamp-OSS/octo-lib/server"
 	_ "github.com/Mininglamp-OSS/octo-server/internal"
+	"github.com/Mininglamp-OSS/octo-server/internal/cardactiondispatch"
 	"github.com/Mininglamp-OSS/octo-server/internal/carddispatch"
 	commonapi "github.com/Mininglamp-OSS/octo-server/modules/base/common"
 	"github.com/Mininglamp-OSS/octo-server/modules/base/event"
@@ -232,6 +234,10 @@ func runAPI(ctx *config.Context) {
 	if err := installCardDispatch(ctx); err != nil {
 		panic(fmt.Errorf("install internal card dispatch registry: %w", err))
 	}
+	cardActionRuntime, err := installCardActionDispatch(ctx)
+	if err != nil {
+		panic(fmt.Errorf("install card action callback dispatch: %w", err))
+	}
 	// 构造进程级共享头像渲染缓存,并把观测 hooks 接到上面注册的头像指标。所有头像端点
 	// (user 的 UserAvatar;群组头像渲染合并后亦然——#478)经 avatarrender.GetOrRender
 	// 共用这一个实例:共享 LRU + 同一个渲染信号量(后者唯一,才是真正的进程级渲染并发
@@ -266,7 +272,8 @@ func runAPI(ctx *config.Context) {
 	libdb.SetDBObserver(metrics.ObserveDB)
 	libredis.SetRedisObserver(metrics.ObserveRedisCmd)
 	metrics.RegisterPoolCollectors(prometheus.DefaultRegisterer, ctx.DB().DB, map[string]*rd.Client{
-		"ratelimit": rlRedis,
+		"ratelimit":            rlRedis,
+		"card_action_dispatch": cardActionRuntime.redisClient,
 	})
 	// 在所有指标族注册完成后再起 scrape 端点,避免启动窗口内的 scrape 漏掉
 	// 依赖/连接池指标族(Jerry-Xin #442 review)。
@@ -307,7 +314,12 @@ func runAPI(ctx *config.Context) {
 	// 模块安装
 	err = module.Setup(ctx)
 	if err != nil {
+		cardActionRuntime.Stop()
 		panic(err)
+	}
+	if err := cardActionRuntime.Start(context.Background()); err != nil {
+		cardActionRuntime.Stop()
+		panic(fmt.Errorf("start card action callback dispatcher: %w", err))
 	}
 	//开始定时处理事件
 	cn := cron.New()
@@ -329,6 +341,7 @@ func runAPI(ctx *config.Context) {
 
 	// 运行: 阻塞直到 go-svc 收到 SIGINT/SIGTERM 并完成业务 Stop。
 	err = svc.Run(s)
+	cardActionRuntime.Stop()
 
 	// 业务停下后再 graceful shutdown metrics scrape 端点 — 时序上避开和 go-svc
 	// 的信号处理竞态(go-svc 自己调 signal.Notify, 我们不再额外抢信号)。
@@ -347,6 +360,14 @@ func runAPI(ctx *config.Context) {
 }
 
 func installCardDispatch(ctx *config.Context) error {
+	actionRoutes, err := cardactiondispatch.LoadRouteSpecs(os.Getenv("OCTO_CARD_ACTION_ROUTES"))
+	if err != nil {
+		return err
+	}
+	actionProducers, err := cardActionApprovalProducerSpecs(actionRoutes)
+	if err != nil {
+		return err
+	}
 	deps := carddispatch.Dependencies{
 		IdentityResolver: botidentity.New(ctx),
 		Authorizer:       carddispatch.NewDBAuthorizer(ctx.DB()),
@@ -354,8 +375,38 @@ func installCardDispatch(ctx *config.Context) error {
 		Metrics:          carddispatch.NewMetrics(prometheus.DefaultRegisterer),
 		Logger:           log.NewTLog("CardDispatch"),
 	}
-	registry := carddispatch.NewRegistry(deps, cardDispatchProducerSpecs())
+	producerSpecs := append(cardDispatchProducerSpecs(), actionProducers...)
+	registry := carddispatch.NewRegistry(deps, producerSpecs)
 	return carddispatch.Install(ctx, registry)
+}
+
+func cardActionApprovalProducerSpecs(routes []cardactiondispatch.RouteSpec) ([]carddispatch.ProducerSpec, error) {
+	seen := make(map[cardactiondispatch.NotifyCapability]struct{})
+	result := make([]carddispatch.ProducerSpec, 0)
+	for _, route := range routes {
+		if route.NotifyTokenEnv == "" {
+			continue
+		}
+		capability := cardactiondispatch.NotifyCapability{SenderUID: route.SenderUID, Owner: route.Owner}
+		if capability.SenderUID != notify.NotifyBotUIDValue {
+			return nil, errors.New("action notify routes must use the shared notification sender")
+		}
+		if _, ok := seen[capability]; ok {
+			continue
+		}
+		seen[capability] = struct{}{}
+		result = append(result, carddispatch.ProducerSpec{
+			ID: notify.ActionNotifyProducerID(capability.Owner), Enabled: true,
+			SenderUID:           capability.SenderUID,
+			AllowedChannelTypes: []uint8{common.ChannelTypePerson.Uint8()},
+			AllowedProfiles:     []string{cardmsg.ProfileV2},
+			ActionEventOwner:    capability.Owner,
+			SpacePolicy:         carddispatch.SpacePolicySystemNotification,
+			GroupPolicy:         carddispatch.GroupPolicyMemberRequired,
+			MaxInFlight:         20,
+		})
+	}
+	return result, nil
 }
 
 func cardDispatchProducerSpecs() []carddispatch.ProducerSpec {
@@ -385,7 +436,109 @@ func cardDispatchProducerSpecs() []carddispatch.ProducerSpec {
 	summarySpec.ID = summaryNotifyProducerID
 	docsSpec := base
 	docsSpec.ID = docsNotifyProducerID
-	return []carddispatch.ProducerSpec{summarySpec, docsSpec}
+	actionOutcomeSpec := base
+	actionOutcomeSpec.ID = actionOutcomeProducerID
+	if notify.DocsApprovalCardsEnabled() {
+		docsSpec.AllowedProfiles = []string{cardmsg.ProfileV1, cardmsg.ProfileV2}
+		docsSpec.ActionEventOwner = "docs"
+	}
+	return []carddispatch.ProducerSpec{summarySpec, docsSpec, actionOutcomeSpec}
+}
+
+type cardActionDispatchRuntime struct {
+	dispatcher  *cardactiondispatch.Dispatcher
+	redisClient *rd.Client
+}
+
+func (r *cardActionDispatchRuntime) Start(ctx context.Context) error {
+	if r == nil || r.dispatcher == nil {
+		return errors.New("card action dispatch runtime unavailable")
+	}
+	return r.dispatcher.Start(ctx)
+}
+
+func (r *cardActionDispatchRuntime) Stop() {
+	if r == nil {
+		return
+	}
+	if r.dispatcher != nil {
+		r.dispatcher.Stop()
+	}
+	if r.redisClient != nil {
+		_ = r.redisClient.Close()
+	}
+}
+
+func installCardActionDispatch(ctx *config.Context) (*cardActionDispatchRuntime, error) {
+	specs, err := cardactiondispatch.LoadRouteSpecs(os.Getenv("OCTO_CARD_ACTION_ROUTES"))
+	if err != nil {
+		return nil, err
+	}
+	registry, err := cardactiondispatch.NewRegistry(
+		specs,
+		cardactiondispatch.LoadAllowedURLs(os.Getenv("OCTO_CARD_ACTION_ALLOWED_URLS")),
+		os.Getenv,
+	)
+	if err != nil {
+		return nil, err
+	}
+	if err := registry.ValidateNotifyTokenExclusions(os.Getenv("NOTIFY_INTERNAL_TOKEN"), os.Getenv("OCTO_DOCS_NOTIFY_TOKEN")); err != nil {
+		return nil, err
+	}
+	if len(registry.NotifyProducers()) > 0 && !cardmsg.Enabled() {
+		return nil, errors.New("action notify routes require OCTO_CARD_MESSAGE_ENABLED")
+	}
+	if notify.DocsApprovalCardsEnabled() {
+		if !cardmsg.Enabled() {
+			return nil, errors.New("OCTO_DOCS_APPROVAL_CARD_ENABLED requires OCTO_CARD_MESSAGE_ENABLED")
+		}
+		resolution := registry.Resolve(notify.NotifyBotUIDValue, "docs", "access_request.decision")
+		if resolution.Kind != cardactiondispatch.ResolutionCallback {
+			return nil, errors.New("docs approval cards require a notification/docs/access_request.decision callback route")
+		}
+	}
+	redisClient := octoredis.NewInstrumentedClient(ctx.GetConfig(), func(options *rd.Options) {
+		options.MaxRetries = 1
+		options.PoolSize = 10
+	})
+	queue, err := cardactiondispatch.NewRedisQueue(redisClient, cardactiondispatch.QueueConfig{
+		Prefix:       "card_action_dispatch",
+		LiveTTL:      ctx.GetConfig().Robot.MessageExpire,
+		DLQRetention: 30 * 24 * time.Hour,
+	})
+	if err != nil {
+		_ = redisClient.Close()
+		return nil, err
+	}
+	service, err := cardactiondispatch.NewService(registry, queue, ctx)
+	if err != nil {
+		_ = redisClient.Close()
+		return nil, err
+	}
+	if err := cardactiondispatch.Install(ctx, service); err != nil {
+		_ = redisClient.Close()
+		return nil, err
+	}
+	finalizer, err := notify.NewActionFinalizerFromContext(ctx)
+	if err != nil {
+		_ = redisClient.Close()
+		return nil, err
+	}
+	dispatcher, err := cardactiondispatch.NewDispatcher(
+		queue,
+		registry,
+		cardactiondispatch.NewHTTPDeliverer(nil, time.Now),
+		finalizer,
+		cardactiondispatch.DispatcherConfig{
+			Metrics: cardactiondispatch.NewMetrics(prometheus.DefaultRegisterer),
+			Logger:  log.NewTLog("CardActionDispatch"),
+		},
+	)
+	if err != nil {
+		_ = redisClient.Close()
+		return nil, err
+	}
+	return &cardActionDispatchRuntime{dispatcher: dispatcher, redisClient: redisClient}, nil
 }
 
 // {summaryNotify,docsNotify}ProducerID mirror modules/notify's producer IDs.
@@ -394,6 +547,7 @@ func cardDispatchProducerSpecs() []carddispatch.ProducerSpec {
 const (
 	summaryNotifyProducerID = carddispatch.ProducerID("summary-notify")
 	docsNotifyProducerID    = carddispatch.ProducerID("docs-notify")
+	actionOutcomeProducerID = carddispatch.ProducerID("action-outcome")
 )
 
 func printServerInfo(ctx *config.Context) {

--- a/main_carddispatch_test.go
+++ b/main_carddispatch_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-server/internal/cardactiondispatch"
 	"github.com/Mininglamp-OSS/octo-server/internal/carddispatch"
 	"github.com/Mininglamp-OSS/octo-server/modules/notify"
 	"github.com/Mininglamp-OSS/octo-server/pkg/cardmsg"
@@ -25,21 +26,43 @@ func TestCardDispatchRegistryInstalledBeforeModuleConstruction(t *testing.T) {
 	if setup < 0 || install > setup {
 		t.Fatal("card dispatch registry must be installed before module.Setup constructs producers")
 	}
+	actionInstall := strings.Index(text, "installCardActionDispatch(ctx)")
+	if actionInstall < 0 || actionInstall > setup {
+		t.Fatal("card action dispatch service must be installed before module.Setup constructs message handlers")
+	}
+	start := strings.Index(text, "cardActionRuntime.Start(")
+	stop := strings.LastIndex(text, "cardActionRuntime.Stop()")
+	serve := strings.Index(text, "svc.Run(s)")
+	if start < setup || start > serve {
+		t.Fatal("card action dispatcher must start after module setup and before serving")
+	}
+	if stop < serve {
+		t.Fatal("card action dispatcher must stop after the server exits")
+	}
+	if !strings.Contains(text, "notify.NewActionFinalizerFromContext(ctx)") {
+		t.Fatal("card action dispatcher must compose specialized finalizers with the standard fallback")
+	}
+	if strings.Contains(text, "notify.NewDocsActionFinalizerFromContext(ctx)") {
+		t.Fatal("composition root must not wire the docs-only finalizer directly")
+	}
 }
 
 // TestNotificationCardProducerRegistrations pins the production card-dispatch
 // producers to the reviewed shape (Sender identity, DM-only, octo/v1,
-// system-notification Space policy, MaxInFlight=20). Both `summary-notify` and
-// `docs-notify` share this shape by design (see modules/notify — capability
-// isolation lives on the producer ID, not the sender identity). Any *new*
+// system-notification Space policy, MaxInFlight=20). `summary-notify`,
+// `docs-notify`, and the internal-only `action-outcome` sender share this shape
+// by design (see modules/notify — capability isolation lives on the producer
+// ID, not the sender identity). Any *new*
 // production producer needs its own reviewed entry here, so this test
 // deliberately fails on unknown IDs — the sender-of-cards allowlist is not
 // silently extensible.
 func TestNotificationCardProducerRegistrations(t *testing.T) {
+	t.Setenv("OCTO_DOCS_APPROVAL_CARD_ENABLED", "false")
 	specs := cardDispatchProducerSpecs()
 	want := map[carddispatch.ProducerID]bool{
 		"summary-notify": false,
 		"docs-notify":    false,
+		"action-outcome": false,
 	}
 	for _, spec := range specs {
 		seen, known := want[spec.ID]
@@ -77,5 +100,64 @@ func TestNotificationCardProducerRegistrations(t *testing.T) {
 		if !seen {
 			t.Fatalf("expected producer %q was not registered", id)
 		}
+	}
+}
+
+func TestDocsApprovalProducerEnablesOnlyReviewedV2Owner(t *testing.T) {
+	t.Setenv("OCTO_DOCS_APPROVAL_CARD_ENABLED", "true")
+	specs := cardDispatchProducerSpecs()
+	for _, spec := range specs {
+		if spec.ID != "docs-notify" {
+			if spec.ActionEventOwner != "" {
+				t.Fatalf("non-docs producer %q unexpectedly owns actions", spec.ID)
+			}
+			continue
+		}
+		if spec.ActionEventOwner != "docs" {
+			t.Fatalf("docs action owner = %q, want docs", spec.ActionEventOwner)
+		}
+		if len(spec.AllowedProfiles) != 2 || spec.AllowedProfiles[0] != cardmsg.ProfileV1 || spec.AllowedProfiles[1] != cardmsg.ProfileV2 {
+			t.Fatalf("docs profiles = %v, want [octo/v1 octo/v2]", spec.AllowedProfiles)
+		}
+		return
+	}
+	t.Fatal("docs-notify producer missing")
+}
+
+func TestConfiguredApprovalRouteAddsOwnerBoundV2Producer(t *testing.T) {
+	specs, err := cardActionApprovalProducerSpecs([]cardactiondispatch.RouteSpec{
+		{
+			SenderUID: "notification", Owner: "smart-summary", ActionType: "summary.publish.decision",
+			NotifyTokenEnv: "OCTO_SMART_SUMMARY_NOTIFY_TOKEN",
+		},
+		{
+			SenderUID: "notification", Owner: "smart-summary", ActionType: "summary.delete.decision",
+			NotifyTokenEnv: "OCTO_SMART_SUMMARY_NOTIFY_TOKEN",
+		},
+	})
+	if err != nil {
+		t.Fatalf("cardActionApprovalProducerSpecs() error = %v", err)
+	}
+	if len(specs) != 1 {
+		t.Fatalf("producer count = %d, want 1 per sender/owner", len(specs))
+	}
+	spec := specs[0]
+	if spec.SenderUID != notify.NotifyBotUIDValue || spec.ActionEventOwner != "smart-summary" {
+		t.Fatalf("producer = %+v", spec)
+	}
+	if len(spec.AllowedProfiles) != 1 || spec.AllowedProfiles[0] != cardmsg.ProfileV2 {
+		t.Fatalf("profiles = %v, want [octo/v2]", spec.AllowedProfiles)
+	}
+}
+
+func TestConfiguredApprovalRouteRejectsNonNotificationSender(t *testing.T) {
+	_, err := cardActionApprovalProducerSpecs([]cardactiondispatch.RouteSpec{
+		{
+			SenderUID: "service-bot", Owner: "tasks", ActionType: "task.decision",
+			NotifyTokenEnv: "OCTO_TASKS_NOTIFY_TOKEN",
+		},
+	})
+	if err == nil {
+		t.Fatal("cardActionApprovalProducerSpecs() error = nil")
 	}
 }

--- a/modules/bot_api/bot_api.go
+++ b/modules/bot_api/bot_api.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/internal/carddispatch"
 	"github.com/Mininglamp-OSS/octo-server/modules/file"
 	"github.com/Mininglamp-OSS/octo-server/modules/group"
 	"github.com/Mininglamp-OSS/octo-server/modules/robot"
@@ -30,13 +31,13 @@ const (
 // BotAPI is the public Bot API gateway module.
 // It handles all bot-facing endpoints (/v1/bot/*) with unified auth.
 type BotAPI struct {
-	ctx                   *config.Context
-	db                    *botAPIDB
-	userService           user.IService
-	fileService           file.IService
-	groupService          group.IService
-	userDB                *user.DB
-	threadService         thread.IService
+	ctx           *config.Context
+	db            *botAPIDB
+	userService   user.IService
+	fileService   file.IService
+	groupService  group.IService
+	userDB        *user.DB
+	threadService thread.IService
 	// robotService gives the OBO fan-out path a way to enqueue synthetic
 	// events directly into a grantee bot's /v1/bot/events queue. The
 	// webhook layer drops NoPersist=1 messages before NotifyMessagesListeners
@@ -47,10 +48,14 @@ type BotAPI struct {
 	// Jerry-Xin review blocker. fanoutForMessage calls robotService
 	// AFTER dispatchFanout succeeds so we only enqueue events that
 	// WuKongIM actually accepted.
-	robotService          robot.IService
+	robotService robot.IService
 	// cardRevisions is the D10 card revision history store (shared table
 	// octo_message_card_revision; written here on bot card edits + clear).
-	cardRevisions         *cardrevision.Store
+	cardRevisions *cardrevision.Store
+	// cardMutator owns the card_seq CAS primitive shared with first-party
+	// callback finalization. Existing tests that construct BotAPI literals keep
+	// the legacy local fallback in cardSeqCASWrite when this field is nil.
+	cardMutator           *carddispatch.CardMutator
 	speechClient          *voice_adapter.SpeechClient
 	maxVoiceContextLength int
 	maxBodySize           int64
@@ -187,6 +192,7 @@ func NewBotAPI(ctx *config.Context) *BotAPI {
 		threadService:         thread.NewService(ctx),
 		robotService:          robot.NewService(ctx),
 		cardRevisions:         cardrevision.NewStore(ctx.DB()),
+		cardMutator:           carddispatch.NewCardMutator(ctx),
 		speechClient:          voice_adapter.NewSpeechClient(speechURL, speechKey, time.Duration(timeoutSec)*time.Second),
 		maxVoiceContextLength: maxCtxLen,
 		maxBodySize:           maxBodySize,

--- a/modules/bot_api/card_cas_retry_test.go
+++ b/modules/bot_api/card_cas_retry_test.go
@@ -1,0 +1,30 @@
+package bot_api
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestCardSeqEditDelegatesRetryPolicyToSharedMutator(t *testing.T) {
+	raw, err := os.ReadFile("send.go")
+	if err != nil {
+		t.Fatalf("read send.go: %v", err)
+	}
+	source := string(raw)
+	start := strings.Index(source, "if hasCardSeq {")
+	if start < 0 {
+		t.Fatal("send.go is missing the card_seq edit branch")
+	}
+	end := strings.Index(source[start:], "\n\t} else {")
+	if end < 0 {
+		t.Fatal("send.go card_seq edit branch has no boundary")
+	}
+	branch := source[start : start+end]
+	if strings.Contains(branch, "for attempt :=") {
+		t.Fatal("card_seq edit branch must not wrap the shared CAS mutator in another retry loop")
+	}
+	if strings.Count(branch, "ba.cardSeqCASWrite(") != 1 {
+		t.Fatalf("card_seq edit branch must call cardSeqCASWrite exactly once:\n%s", branch)
+	}
+}

--- a/modules/bot_api/send.go
+++ b/modules/bot_api/send.go
@@ -14,6 +14,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/internal/carddispatch"
 	"github.com/Mininglamp-OSS/octo-server/modules/group"
 	"github.com/Mininglamp-OSS/octo-server/pkg/cardmsg"
 	"github.com/Mininglamp-OSS/octo-server/pkg/cardrevision"
@@ -930,22 +931,10 @@ func (ba *BotAPI) botMessageEdit(c *wkhttp.Context) {
 
 	editedAt := int(time.Now().Unix())
 	if hasCardSeq {
-		// P2 D9：带 card_seq 的卡片编辑走条件 CAS。并发首帧在 InnoDB 下可能因
-		// insert-intention gap-lock 互相死锁（1213）—— 死锁是瞬时的，有界重试即可
-		// 化解：一旦某帧提交、行已存在，后续事务的 SELECT ... FOR UPDATE 只取记录锁，
-		// 不再产生 gap-lock 死锁；重试中重读到已提交的更高 seq 后要么应用要么按 CAS
-		// 拒绝，"最高 seq 必胜"不变量成立。
-		var (
-			conflict bool
-			casErr   error
-		)
-		for attempt := 0; attempt < cardSeqCASMaxAttempts; attempt++ {
-			conflict, casErr = ba.cardSeqCASWrite(req.MessageID, req.MessageSeq, fakeChannelID, req.ChannelType, contentEdit, contentMD5, editedAt, cardSeq)
-			if casErr == nil || !isRetriableMySQLLockErr(casErr) {
-				break
-			}
-			time.Sleep(time.Duration(attempt+1) * 3 * time.Millisecond)
-		}
+		// P2 D9：带 card_seq 的卡片编辑走共享条件 CAS。生产 CardMutator 的 backend
+		// 已统一承担 InnoDB 死锁/锁等待的有界重试；这里单次委托，避免嵌套重试把
+		// 最坏事务次数从 5 放大到 25。
+		conflict, casErr := ba.cardSeqCASWrite(req.MessageID, req.MessageSeq, fakeChannelID, req.ChannelType, contentEdit, contentMD5, editedAt, cardSeq)
 		if casErr != nil {
 			ba.Error("card_seq CAS 写入编辑内容失败！", zap.Error(casErr), zap.String("messageID", req.MessageID))
 			httperr.ResponseErrorL(c, errcode.ErrBotAPIStoreFailed, nil, nil)
@@ -1018,8 +1007,8 @@ const cardSeqCASMaxAttempts = 5
 // cardSeqCASWrite 执行 P2 D9 的 card_seq 条件 CAS 写：事务内 SELECT ... FOR UPDATE
 // 锁住该消息的 message_extra 行（不存在则取 next-key 锁串行化并发首帧），比对已存
 // card_seq —— 新值 ≤ 已存（非 NULL）→ 返回 conflict=true（乱序/迟到帧，什么都不写）；
-// 否则连 card_seq 一并 upsert 并提交。返回的 err 若是可重试锁错误（1213/1205），
-// 由调用方有界重试化解（死锁瞬时；重试后重读已提交的更高 seq，仍按 CAS 判定）。
+// 否则连 card_seq 一并 upsert 并提交。生产路径的可重试锁错误（1213/1205）由共享
+// CardMutator backend 统一有界重试；此处不再叠加第二层重试。
 //
 // P1-2（PR#548 review）：message_extra.version 在**拿到行锁之后**才分配。GenSeq
 // 是每-channel 单调递增,而 delta-sync 按 version 升序取增量帧
@@ -1029,6 +1018,13 @@ const cardSeqCASMaxAttempts = 5
 // 不可见,违反 D6"各端收敛"/D9"no lost-update"）。锁内分配把竞争写的 GenSeq 调用按
 // 提交顺序串行化：赢家写（最大 seq、最后一次 advancing 写）必得最大 version。
 func (ba *BotAPI) cardSeqCASWrite(messageID string, messageSeq uint32, fakeChannelID string, channelType uint8, contentEdit, contentMD5 string, editedAt int, cardSeq int64) (conflict bool, err error) {
+	if ba.cardMutator != nil {
+		return ba.cardMutator.WriteCAS(carddispatch.CardMutationCASRequest{
+			MessageID: messageID, MessageSeq: messageSeq, ChannelID: fakeChannelID,
+			ChannelType: channelType, ContentEdit: contentEdit, ContentHash: contentMD5,
+			EditedAt: editedAt, CardSeq: cardSeq, StorageChannel: true,
+		})
+	}
 	tx, err := ba.ctx.DB().Begin()
 	if err != nil {
 		return false, err

--- a/modules/message/api_card_action.go
+++ b/modules/message/api_card_action.go
@@ -24,12 +24,14 @@ package message
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"strings"
 	"time"
 
 	"github.com/Mininglamp-OSS/octo-lib/common"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/internal/cardactiondispatch"
 	"github.com/Mininglamp-OSS/octo-server/modules/group"
 	"github.com/Mininglamp-OSS/octo-server/modules/thread"
 	"github.com/Mininglamp-OSS/octo-server/pkg/cardmsg"
@@ -245,9 +247,30 @@ func (m *Message) cardAction(c *wkhttp.Context) {
 	if actionData != nil {
 		eventData["data"] = actionData
 	}
-	eventID, err := m.robotService.EnqueueBotTypedEvent(msgM.FromUID, cardmsg.EventTypeCardAction, eventData)
+	owner, actionType := cardActionRouteMetadata(actionData)
+	eventID, err := m.enqueueCardAction(msgM.FromUID, owner, actionType, eventData, cardactiondispatch.Event{
+		SenderUID:   msgM.FromUID,
+		Owner:       owner,
+		ActionType:  actionType,
+		MessageID:   req.MessageID,
+		ChannelID:   req.ChannelID,
+		ChannelType: req.ChannelType,
+		SpaceID:     stringEventField(eventData, "space_id"),
+		ActionID:    req.ActionID,
+		OperatorUID: loginUID,
+		ClientToken: req.ClientToken,
+		ActedAt:     eventData["acted_at"].(int64),
+		Inputs:      req.Inputs,
+		Data:        actionData,
+	})
 	if err != nil {
 		m.releaseCardClaim(idemKey)
+		if errors.Is(err, errInternalCardActionRouteRejected) {
+			m.Warn("内部 card_action 路由未注册,拒绝", zap.String("sender_uid", msgM.FromUID),
+				zap.String("owner", owner), zap.String("action_type", actionType))
+			httperr.ResponseErrorL(c, errcode.ErrMessageCardActionInvalid, nil, nil)
+			return
+		}
 		m.Error("card_action 事件入队失败,已释放幂等 claim", zap.Error(err), zap.String("botUID", msgM.FromUID))
 		httperr.ResponseErrorL(c, errcode.ErrMessageStoreFailed, nil, nil)
 		return
@@ -258,6 +281,38 @@ func (m *Message) cardAction(c *wkhttp.Context) {
 		m.Warn("卡片动作幂等 confirm 未生效", zap.Bool("ok", ok), zap.Error(err), zap.String("key", idemKey))
 	}
 	c.Response(map[string]interface{}{"accepted": true, "replay": false})
+}
+
+var errInternalCardActionRouteRejected = errors.New("internal card action route rejected")
+
+func (m *Message) enqueueCardAction(senderUID, owner, actionType string, botEventData map[string]interface{}, internalEvent cardactiondispatch.Event) (int64, error) {
+	service, installed := cardactiondispatch.FromContext(m.ctx)
+	if !installed {
+		return m.robotService.EnqueueBotTypedEvent(senderUID, cardmsg.EventTypeCardAction, botEventData)
+	}
+	resolution := service.Resolve(senderUID, owner, actionType)
+	switch resolution.Kind {
+	case cardactiondispatch.ResolutionCallback:
+		return service.Enqueue(internalEvent)
+	case cardactiondispatch.ResolutionReject:
+		return 0, errInternalCardActionRouteRejected
+	default:
+		return m.robotService.EnqueueBotTypedEvent(senderUID, cardmsg.EventTypeCardAction, botEventData)
+	}
+}
+
+func cardActionRouteMetadata(data map[string]interface{}) (string, string) {
+	if data == nil {
+		return "", ""
+	}
+	owner, _ := data["owner"].(string)
+	actionType, _ := data["action_type"].(string)
+	return strings.TrimSpace(owner), strings.TrimSpace(actionType)
+}
+
+func stringEventField(data map[string]interface{}, key string) string {
+	value, _ := data[key].(string)
+	return value
 }
 
 // releaseCardClaim 补偿释放首次校验失败 / 入队失败的幂等 claim（P1-4：首次 claim

--- a/modules/message/api_card_action_test.go
+++ b/modules/message/api_card_action_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
 	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	"github.com/Mininglamp-OSS/octo-server/internal/cardactiondispatch"
 	_ "github.com/Mininglamp-OSS/octo-server/modules/app_bot"
 	"github.com/Mininglamp-OSS/octo-server/modules/group"
 	"github.com/Mininglamp-OSS/octo-server/modules/robot"
@@ -46,6 +47,116 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func cardV2InternalEnvelopeJSON(t *testing.T, actionID, actionType string) []byte {
+	t.Helper()
+	envelope := map[string]interface{}{
+		"type":         cardmsg.InteractiveCard.Int(),
+		"card_version": cardmsg.CardVersion,
+		"profile":      cardmsg.ProfileV2,
+		"plain":        "文档访问申请",
+		"space_id":     "space-1",
+		"card": map[string]interface{}{
+			"type": "AdaptiveCard", "version": cardmsg.CardVersion,
+			"body": []interface{}{map[string]interface{}{"type": "TextBlock", "text": "文档访问申请"}},
+			"actions": []interface{}{map[string]interface{}{
+				"type": "Action.Submit", "id": actionID, "title": actionID,
+				"data": map[string]interface{}{
+					"owner": "docs", "action_type": actionType, "decision": "approve",
+					"doc_id": "doc-1", "request_id": "request-1",
+				},
+			}},
+		},
+	}
+	raw, err := json.Marshal(envelope)
+	require.NoError(t, err)
+	return raw
+}
+
+func TestCardActionSenderBoundCallbackRouting(t *testing.T) {
+	t.Setenv(cardmsg.EnvEnabled, "true")
+	t.Setenv("OCTO_DOCS_CARD_ACTION_SECRET", "0123456789abcdef0123456789abcdef")
+	t.Setenv("OCTO_MASTER_KEY", "0123456789abcdef0123456789abcdef")
+	s, ctx := testutil.NewTestServer()
+	defer func() { _ = testutil.CleanAllTables(ctx) }()
+	resetCardActionState(t, ctx)
+
+	callbackURL := "https://docs.internal/v1/card-actions/decide"
+	registry, err := cardactiondispatch.NewRegistry([]cardactiondispatch.RouteSpec{{
+		SenderUID: "notification", Owner: "docs", ActionType: "access_request.decision",
+		URL: callbackURL, SecretEnv: "OCTO_DOCS_CARD_ACTION_SECRET",
+	}}, []string{callbackURL}, func(key string) string { return "0123456789abcdef0123456789abcdef" })
+	require.NoError(t, err)
+	rds := redis.NewClient(&redis.Options{Addr: ctx.GetConfig().DB.RedisAddr, Password: ctx.GetConfig().DB.RedisPass})
+	defer rds.Close()
+	queue, err := cardactiondispatch.NewRedisQueue(rds, cardactiondispatch.QueueConfig{
+		Prefix: "test:message:card_action_dispatch", LiveTTL: ctx.GetConfig().Robot.MessageExpire, DLQRetention: 30 * 24 * time.Hour,
+	})
+	require.NoError(t, err)
+	service, err := cardactiondispatch.NewService(registry, queue, ctx)
+	require.NoError(t, err)
+	require.NoError(t, cardactiondispatch.Install(ctx, service))
+
+	seedCardBot(t, ctx, "notification")
+	seedCardBot(t, ctx, "external-copy-bot")
+	notifyChannel := common.GetFakeChannelIDWith(uid, "notification")
+	externalChannel := common.GetFakeChannelIDWith(uid, "external-copy-bot")
+	seedCardMessage(t, ctx, 9701, "notification", notifyChannel, common.ChannelTypePerson.Uint8(), cardV2InternalEnvelopeJSON(t, "approve", "access_request.decision"))
+	seedCardMessage(t, ctx, 9702, "external-copy-bot", externalChannel, common.ChannelTypePerson.Uint8(), cardV2InternalEnvelopeJSON(t, "approve", "access_request.decision"))
+	seedCardMessage(t, ctx, 9703, "notification", notifyChannel, common.ChannelTypePerson.Uint8(), cardV2InternalEnvelopeJSON(t, "approve-unknown", "unknown"))
+
+	post := func(messageID, peer, actionID string) *httptest.ResponseRecorder {
+		t.Helper()
+		w := httptest.NewRecorder()
+		req, reqErr := http.NewRequest(http.MethodPost, "/v1/message/card/action", bytes.NewReader([]byte(util.ToJson(map[string]interface{}{
+			"message_id": messageID, "channel_id": peer, "channel_type": common.ChannelTypePerson.Uint8(),
+			"action_id": actionID, "client_token": "token-" + messageID,
+		}))))
+		require.NoError(t, reqErr)
+		req.Header.Set("token", token)
+		s.GetRoute().ServeHTTP(w, req)
+		return w
+	}
+
+	// Exact (stored sender, owner, action_type) match goes only to the internal queue.
+	w := post("9701", "notification", "approve")
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	depths, err := queue.Depths()
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), depths.Ready)
+	botDepth, err := rds.ZCard("robotEvent:notification").Result()
+	require.NoError(t, err)
+	assert.Zero(t, botDepth)
+	lease, err := queue.Claim(time.Now().Add(time.Second), time.Minute)
+	require.NoError(t, err)
+	require.NotNil(t, lease)
+	assert.Equal(t, "notification", lease.Event.SenderUID)
+	assert.Equal(t, "docs", lease.Event.Owner)
+	assert.Equal(t, "access_request.decision", lease.Event.ActionType)
+	assert.Equal(t, uid, lease.Event.OperatorUID)
+	require.True(t, lease.Event.EventID > 0)
+	acked, err := queue.Ack(lease.Event.EventID, lease.Token)
+	require.NoError(t, err)
+	require.True(t, acked)
+
+	// A third-party bot copying identical action data remains on the existing pull path.
+	w = post("9702", "external-copy-bot", "approve")
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	botDepth, err = rds.ZCard("robotEvent:external-copy-bot").Result()
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), botDepth)
+	depths, _ = queue.Depths()
+	assert.Zero(t, depths.Ready)
+
+	// An internal sender with an unknown action fails closed and releases its D4 claim.
+	w = post("9703", "notification", "approve-unknown")
+	assert.Equal(t, http.StatusBadRequest, w.Code, w.Body.String())
+	botDepth, _ = rds.ZCard("robotEvent:notification").Result()
+	assert.Zero(t, botDepth)
+	claimExists, err := rds.Exists(cardActionClaimKey("9703", "approve-unknown", uid)).Result()
+	require.NoError(t, err)
+	assert.Zero(t, claimExists)
+}
 
 const cardActionBotUID = "bot_card_1"
 

--- a/modules/notify/action_finalizer.go
+++ b/modules/notify/action_finalizer.go
@@ -1,0 +1,152 @@
+package notify
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-server/internal/cardactiondispatch"
+	"github.com/Mininglamp-OSS/octo-server/internal/carddispatch"
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardmsg"
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl"
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
+)
+
+type cardActionMutator interface {
+	Mutate(context.Context, carddispatch.CardMutationRequest) (carddispatch.CardMutationResult, error)
+}
+
+type DocsActionFinalizer struct {
+	ctx     *config.Context
+	mutator cardActionMutator
+	sender  carddispatch.Sender
+}
+
+type actionFinalizeError struct {
+	category string
+	err      error
+}
+
+func (e *actionFinalizeError) Error() string    { return "notify: " + e.category }
+func (e *actionFinalizeError) Unwrap() error    { return e.err }
+func (e *actionFinalizeError) Category() string { return e.category }
+
+func NewDocsActionFinalizer(ctx *config.Context, mutator cardActionMutator, sender carddispatch.Sender) (*DocsActionFinalizer, error) {
+	if ctx == nil || mutator == nil || sender == nil {
+		return nil, errors.New("notify: docs action finalizer dependencies are required")
+	}
+	return &DocsActionFinalizer{ctx: ctx, mutator: mutator, sender: sender}, nil
+}
+
+func NewDocsActionFinalizerFromContext(ctx *config.Context) (*DocsActionFinalizer, error) {
+	sender, err := carddispatch.SenderFromContext(ctx, docsNotifyProducerID)
+	if err != nil {
+		return nil, err
+	}
+	return NewDocsActionFinalizer(ctx, carddispatch.NewCardMutator(ctx), sender)
+}
+
+func (f *DocsActionFinalizer) Finalize(ctx context.Context, event cardactiondispatch.Event, result cardactiondispatch.DecisionResult) error {
+	if event.Owner != "docs" || event.ActionType != "access_request.decision" || event.EventID <= 0 {
+		return errors.New("notify: unsupported card action result")
+	}
+	docID, _ := event.Data["doc_id"].(string)
+	if strings.TrimSpace(docID) == "" || strings.TrimSpace(event.SpaceID) == "" {
+		return errors.New("notify: docs action result is missing authoritative context")
+	}
+	if (result.State == cardactiondispatch.StateApproved || result.State == cardactiondispatch.StateDenied) &&
+		strings.TrimSpace(result.RequesterUID) == "" {
+		return errors.New("notify: terminal docs decision is missing requester_uid")
+	}
+	channelID := event.ChannelID
+	if event.ChannelType == common.ChannelTypePerson.Uint8() {
+		if strings.TrimSpace(event.OperatorUID) == "" {
+			return errors.New("notify: docs DM action is missing operator_uid")
+		}
+		channelID = event.OperatorUID
+	}
+	lang := i18n.OutboundLanguage(ctx)
+	title := strings.TrimSpace(result.Display["title"])
+	if title == "" {
+		title = docID
+	}
+	terminalDocument, err := f.buildTerminalDocument(ctx, lang, docID, event.SpaceID, title, result)
+	if err != nil {
+		return err
+	}
+	contentEdit, err := buildTerminalEnvelope(terminalDocument, event.SpaceID, event.EventID)
+	if err != nil {
+		return err
+	}
+	if _, err := f.mutator.Mutate(ctx, carddispatch.CardMutationRequest{
+		SenderUID: event.SenderUID, MessageID: event.MessageID, ChannelID: channelID,
+		ChannelType: event.ChannelType, ContentEdit: contentEdit,
+	}); err != nil {
+		return err
+	}
+	if result.State != cardactiondispatch.StateApproved && result.State != cardactiondispatch.StateDenied {
+		return nil
+	}
+	outcomeDocument, err := f.buildOutcomeDocument(ctx, lang, docID, event.SpaceID, title, result.State)
+	if err != nil {
+		return err
+	}
+	_, err = f.sender.Send(ctx, carddispatch.Target{
+		SpaceID: event.SpaceID, ChannelID: result.RequesterUID, ChannelType: common.ChannelTypePerson.Uint8(),
+	}, carddispatch.Card{Profile: cardmsg.ProfileV1, Document: outcomeDocument})
+	if err != nil {
+		return &actionFinalizeError{category: "applicant_notify_failed", err: err}
+	}
+	return nil
+}
+
+func (f *DocsActionFinalizer) buildTerminalDocument(ctx context.Context, lang, docID, spaceID, title string, result cardactiondispatch.DecisionResult) (json.RawMessage, error) {
+	labels := docsLabelsFor(lang)
+	attribution := labels.accessDeniedBanner
+	variant := "docs.access_denied"
+	switch result.State {
+	case cardactiondispatch.StateApproved:
+		attribution, variant = labels.accessGrantedBanner, "docs.access_approved"
+	case cardactiondispatch.StateDenied:
+		attribution, variant = labels.accessDeniedBanner, "docs.access_denied"
+	case cardactiondispatch.StateCancelled:
+		attribution, variant = labels.accessCancelledBanner, "docs.access_cancelled"
+	default:
+		attribution, variant = labels.accessUnavailableBanner, "docs.access_unavailable"
+	}
+	return cardtmpl.BuildDocsResourceCard(ctx, f.ctx.GetConfig().External.WebLoginURL, docID, spaceID, cardtmpl.ResourceCard{
+		Title: title, Attribution: attribution, Variant: variant, Source: cardtmpl.Source{Label: labels.sourceLabel},
+	})
+}
+
+func (f *DocsActionFinalizer) buildOutcomeDocument(ctx context.Context, lang, docID, spaceID, title string, state cardactiondispatch.State) (json.RawMessage, error) {
+	labels := docsLabelsFor(lang)
+	attribution := labels.accessGrantedBanner
+	variant := "docs.access_granted"
+	if state == cardactiondispatch.StateDenied {
+		attribution, variant = labels.accessDeniedBanner, "docs.access_denied"
+	}
+	return cardtmpl.BuildDocsResourceCard(ctx, f.ctx.GetConfig().External.WebLoginURL, docID, spaceID, cardtmpl.ResourceCard{
+		Title: title, Attribution: attribution, Variant: variant, Source: cardtmpl.Source{Label: labels.sourceLabel},
+	})
+}
+
+func buildTerminalEnvelope(document json.RawMessage, spaceID string, cardSeq int64) (string, error) {
+	var card map[string]interface{}
+	if err := json.Unmarshal(document, &card); err != nil {
+		return "", fmt.Errorf("notify: decode terminal card: %w", err)
+	}
+	envelope := map[string]interface{}{
+		"type": cardmsg.InteractiveCard.Int(), "card_version": cardmsg.CardVersion,
+		"profile": cardmsg.ProfileV2, "space_id": spaceID, "card_seq": cardSeq, "card": card,
+	}
+	raw, err := json.Marshal(envelope)
+	if err != nil {
+		return "", fmt.Errorf("notify: marshal terminal card: %w", err)
+	}
+	return string(raw), nil
+}

--- a/modules/notify/action_finalizer_registry.go
+++ b/modules/notify/action_finalizer_registry.go
@@ -1,0 +1,27 @@
+package notify
+
+import (
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-server/internal/cardactiondispatch"
+	"github.com/Mininglamp-OSS/octo-server/internal/carddispatch"
+)
+
+// NewActionFinalizerFromContext composes the standard approval fallback with
+// the docs-specific visual. New standard consumers require no code binding.
+func NewActionFinalizerFromContext(ctx *config.Context) (*cardactiondispatch.FinalizerRegistry, error) {
+	docs, err := NewDocsActionFinalizerFromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+	outcomeSender, err := carddispatch.SenderFromContext(ctx, actionOutcomeProducerID)
+	if err != nil {
+		return nil, err
+	}
+	standard, err := NewStandardActionFinalizer(carddispatch.NewCardMutator(ctx), outcomeSender)
+	if err != nil {
+		return nil, err
+	}
+	return cardactiondispatch.NewFinalizerRegistry(standard, map[cardactiondispatch.FinalizerKey]cardactiondispatch.Finalizer{
+		{Owner: "docs", ActionType: "access_request.decision"}: docs,
+	})
+}

--- a/modules/notify/action_finalizer_test.go
+++ b/modules/notify/action_finalizer_test.go
@@ -1,0 +1,279 @@
+package notify
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-server/internal/cardactiondispatch"
+	"github.com/Mininglamp-OSS/octo-server/internal/carddispatch"
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardmsg"
+)
+
+type captureCardMutator struct {
+	requests []carddispatch.CardMutationRequest
+}
+
+func (m *captureCardMutator) Mutate(_ context.Context, request carddispatch.CardMutationRequest) (carddispatch.CardMutationResult, error) {
+	m.requests = append(m.requests, request)
+	return carddispatch.CardMutationResult{Applied: true}, nil
+}
+
+func TestDocsActionFinalizerUsesEventIDAsCardSeqAndNotifiesRequester(t *testing.T) {
+	wk := newWuKongServer()
+	defer wk.close()
+	ctx := newTestContext(t, wk)
+	ctx.GetConfig().External.WebLoginURL = "https://im.example.com/login"
+	mutator := &captureCardMutator{}
+	sender := &capturingCardSender{}
+	finalizer, err := NewDocsActionFinalizer(ctx, mutator, sender)
+	if err != nil {
+		t.Fatalf("NewDocsActionFinalizer() error = %v", err)
+	}
+	event := cardactiondispatch.Event{
+		EventID: 42, SenderUID: NotifyBotUIDValue, Owner: "docs", ActionType: "access_request.decision",
+		MessageID: "1001", ChannelID: NotifyBotUIDValue, ChannelType: 1, SpaceID: "space-1",
+		OperatorUID: "user-b",
+		Data:        map[string]interface{}{"doc_id": "doc-1", "request_id": "request-1"},
+	}
+	result := cardactiondispatch.DecisionResult{
+		Disposition:  cardactiondispatch.DispositionApplied,
+		State:        cardactiondispatch.StateApproved,
+		RequesterUID: "user-a",
+		Display:      map[string]string{"title": "Roadmap", "approver": "must-not-render", "reason": "must-not-render"},
+	}
+	if err := finalizer.Finalize(context.Background(), event, result); err != nil {
+		t.Fatalf("Finalize() error = %v", err)
+	}
+	if len(mutator.requests) != 1 {
+		t.Fatalf("mutation count = %d, want 1", len(mutator.requests))
+	}
+	mutation := mutator.requests[0]
+	if mutation.SenderUID != NotifyBotUIDValue || mutation.MessageID != "1001" || mutation.ChannelID != "user-b" {
+		t.Fatalf("mutation target = %+v", mutation)
+	}
+	var terminal map[string]interface{}
+	if err := json.Unmarshal([]byte(mutation.ContentEdit), &terminal); err != nil {
+		t.Fatalf("decode terminal content_edit: %v", err)
+	}
+	if terminal["card_seq"] != float64(42) || terminal["profile"] != cardmsg.ProfileV2 {
+		t.Fatalf("terminal envelope = %+v", terminal)
+	}
+	card, _ := terminal["card"].(map[string]interface{})
+	if _, hasActions := card["actions"]; hasActions {
+		t.Fatal("terminal card must remove approval actions")
+	}
+	if strings.Contains(mutation.ContentEdit, "must-not-render") {
+		t.Fatal("terminal card leaked unreviewed callback display fields")
+	}
+
+	outcome := sender.last()
+	if target := sender.lastTarget(); target.ChannelID != result.RequesterUID || target.SpaceID != event.SpaceID {
+		t.Fatalf("applicant outcome target = %+v, want requester %q in space %q", target, result.RequesterUID, event.SpaceID)
+	}
+	if outcome.Profile != cardmsg.ProfileV1 {
+		t.Fatalf("applicant outcome profile = %q, want octo/v1", outcome.Profile)
+	}
+	if strings.Contains(string(outcome.Document), "must-not-render") {
+		t.Fatal("applicant outcome leaked approver/reason")
+	}
+
+	// Replayed callbacks render byte-identical content. The second applicant
+	// notification is explicitly allowed by the at-least-once boundary.
+	if err := finalizer.Finalize(context.Background(), event, result); err != nil {
+		t.Fatalf("Finalize(replay) error = %v", err)
+	}
+	if len(mutator.requests) != 2 || mutator.requests[0].ContentEdit != mutator.requests[1].ContentEdit {
+		t.Fatal("replay did not produce a byte-identical deterministic terminal frame")
+	}
+}
+
+func TestDocsActionFinalizerRejectsTerminalResultWithoutRequesterBeforeMutation(t *testing.T) {
+	wk := newWuKongServer()
+	defer wk.close()
+	ctx := newTestContext(t, wk)
+	ctx.GetConfig().External.WebLoginURL = "https://im.example.com/login"
+	mutator := &captureCardMutator{}
+	finalizer, err := NewDocsActionFinalizer(ctx, mutator, &capturingCardSender{})
+	if err != nil {
+		t.Fatalf("NewDocsActionFinalizer() error = %v", err)
+	}
+	event := cardactiondispatch.Event{
+		EventID: 42, SenderUID: NotifyBotUIDValue, Owner: "docs", ActionType: "access_request.decision",
+		MessageID: "1001", ChannelID: "user-b", ChannelType: 1, SpaceID: "space-1",
+		Data: map[string]interface{}{"doc_id": "doc-1", "request_id": "request-1"},
+	}
+	result := cardactiondispatch.DecisionResult{
+		Disposition: cardactiondispatch.DispositionApplied,
+		State:       cardactiondispatch.StateApproved,
+		Display:     map[string]string{"title": "Roadmap"},
+	}
+	if err := finalizer.Finalize(context.Background(), event, result); err == nil {
+		t.Fatal("Finalize() error = nil for terminal result without requester_uid")
+	}
+	if len(mutator.requests) != 0 {
+		t.Fatalf("mutation count = %d, want 0 before requester validation", len(mutator.requests))
+	}
+}
+
+func TestDocsActionFinalizerUsesAuthoritativeMutationChannel(t *testing.T) {
+	wk := newWuKongServer()
+	defer wk.close()
+	ctx := newTestContext(t, wk)
+	ctx.GetConfig().External.WebLoginURL = "https://im.example.com/login"
+	tests := []struct {
+		name        string
+		channelID   string
+		channelType uint8
+		operatorUID string
+		wantChannel string
+		wantErr     bool
+	}{
+		{
+			name: "DM requires operator", channelID: NotifyBotUIDValue,
+			channelType: common.ChannelTypePerson.Uint8(), wantErr: true,
+		},
+		{
+			name: "group keeps event channel", channelID: "group-1",
+			channelType: common.ChannelTypeGroup.Uint8(), operatorUID: "user-b", wantChannel: "group-1",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mutator := &captureCardMutator{}
+			finalizer, err := NewDocsActionFinalizer(ctx, mutator, &capturingCardSender{})
+			if err != nil {
+				t.Fatalf("NewDocsActionFinalizer() error = %v", err)
+			}
+			event := cardactiondispatch.Event{
+				EventID: 42, SenderUID: NotifyBotUIDValue, Owner: "docs", ActionType: "access_request.decision",
+				MessageID: "1001", ChannelID: tt.channelID, ChannelType: tt.channelType, SpaceID: "space-1",
+				OperatorUID: tt.operatorUID, Data: map[string]interface{}{"doc_id": "doc-1", "request_id": "request-1"},
+			}
+			result := cardactiondispatch.DecisionResult{
+				Disposition: cardactiondispatch.DispositionApplied, State: cardactiondispatch.StateCancelled,
+				Display: map[string]string{"title": "Roadmap"},
+			}
+			err = finalizer.Finalize(context.Background(), event, result)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("Finalize() error = nil")
+				}
+				if len(mutator.requests) != 0 {
+					t.Fatalf("mutation count = %d, want 0", len(mutator.requests))
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Finalize() error = %v", err)
+			}
+			if len(mutator.requests) != 1 || mutator.requests[0].ChannelID != tt.wantChannel {
+				t.Fatalf("mutation requests = %+v, want channel %q", mutator.requests, tt.wantChannel)
+			}
+		})
+	}
+}
+
+func TestStandardActionFinalizerSupportsNewOwnerWithoutOwnerSpecificCode(t *testing.T) {
+	mutator := &captureCardMutator{}
+	sender := &capturingCardSender{}
+	finalizer, err := NewStandardActionFinalizer(mutator, sender)
+	if err != nil {
+		t.Fatalf("NewStandardActionFinalizer() error = %v", err)
+	}
+	event := cardactiondispatch.Event{
+		EventID: 84, SenderUID: NotifyBotUIDValue, Owner: "tasks", ActionType: "task.decision",
+		MessageID: "2001", ChannelID: NotifyBotUIDValue, ChannelType: 1, SpaceID: "space-1",
+		OperatorUID: "user-b",
+	}
+	result := cardactiondispatch.DecisionResult{
+		Disposition: cardactiondispatch.DispositionApplied,
+		State:       cardactiondispatch.StateApproved, RequesterUID: "user-a",
+		Display: map[string]string{"title": "Deploy release"},
+	}
+	if err := finalizer.Finalize(context.Background(), event, result); err != nil {
+		t.Fatalf("Finalize() error = %v", err)
+	}
+	if len(mutator.requests) != 1 {
+		t.Fatalf("mutation count = %d, want 1", len(mutator.requests))
+	}
+	mutation := mutator.requests[0]
+	if mutation.ChannelID != event.OperatorUID || mutation.SenderUID != event.SenderUID {
+		t.Fatalf("mutation target = %+v", mutation)
+	}
+	if _, err := cardmsg.NormalizeContentEdit(mutation.ContentEdit); err != nil {
+		t.Fatalf("standard terminal content_edit is invalid: %v", err)
+	}
+	var terminal map[string]interface{}
+	if err := json.Unmarshal([]byte(mutation.ContentEdit), &terminal); err != nil {
+		t.Fatalf("decode terminal content_edit: %v", err)
+	}
+	if terminal["card_seq"] != float64(event.EventID) || terminal["profile"] != cardmsg.ProfileV2 {
+		t.Fatalf("terminal envelope = %+v", terminal)
+	}
+	if !strings.Contains(mutation.ContentEdit, "Deploy release") || !strings.Contains(mutation.ContentEdit, "approval.approved") {
+		t.Fatalf("standard terminal card = %s", mutation.ContentEdit)
+	}
+	card, _ := terminal["card"].(map[string]interface{})
+	if _, hasActions := card["actions"]; hasActions {
+		t.Fatal("standard terminal card must not retain actions")
+	}
+
+	if target := sender.lastTarget(); target.ChannelID != result.RequesterUID || target.SpaceID != event.SpaceID {
+		t.Fatalf("requester outcome target = %+v", target)
+	}
+	if outcome := sender.last(); outcome.Profile != cardmsg.ProfileV1 || !strings.Contains(string(outcome.Document), "Deploy release") {
+		t.Fatalf("requester outcome = %+v", outcome)
+	}
+}
+
+func TestStandardActionFinalizerRejectsMissingTerminalContextBeforeMutation(t *testing.T) {
+	mutator := &captureCardMutator{}
+	finalizer, err := NewStandardActionFinalizer(mutator, &capturingCardSender{})
+	if err != nil {
+		t.Fatalf("NewStandardActionFinalizer() error = %v", err)
+	}
+	base := cardactiondispatch.Event{
+		EventID: 1, SenderUID: NotifyBotUIDValue, Owner: "tasks", ActionType: "task.decision",
+		MessageID: "1", ChannelID: NotifyBotUIDValue, ChannelType: common.ChannelTypePerson.Uint8(),
+		SpaceID: "space-1", OperatorUID: "user-b",
+	}
+	result := cardactiondispatch.DecisionResult{Disposition: cardactiondispatch.DispositionApplied, State: cardactiondispatch.StateApproved}
+	if err := finalizer.Finalize(context.Background(), base, result); err == nil {
+		t.Fatal("Finalize(missing requester_uid) error = nil")
+	}
+	result.RequesterUID = "user-a"
+	base.SpaceID = ""
+	if err := finalizer.Finalize(context.Background(), base, result); err == nil {
+		t.Fatal("Finalize(missing space_id) error = nil")
+	}
+	if len(mutator.requests) != 0 {
+		t.Fatalf("mutation count = %d, want 0", len(mutator.requests))
+	}
+}
+
+func TestStandardActionFinalizerUsesAuthoritativeGroupChannel(t *testing.T) {
+	mutator := &captureCardMutator{}
+	sender := &capturingCardSender{}
+	finalizer, err := NewStandardActionFinalizer(mutator, sender)
+	if err != nil {
+		t.Fatalf("NewStandardActionFinalizer() error = %v", err)
+	}
+	event := cardactiondispatch.Event{
+		EventID: 2, SenderUID: "tasks-bot", Owner: "tasks", ActionType: "task.decision",
+		MessageID: "2", ChannelID: "group-1", ChannelType: common.ChannelTypeGroup.Uint8(),
+		SpaceID: "space-1",
+	}
+	result := cardactiondispatch.DecisionResult{Disposition: cardactiondispatch.DispositionApplied, State: cardactiondispatch.StateCancelled}
+	if err := finalizer.Finalize(context.Background(), event, result); err != nil {
+		t.Fatalf("Finalize() error = %v", err)
+	}
+	if len(mutator.requests) != 1 || mutator.requests[0].ChannelID != event.ChannelID {
+		t.Fatalf("mutation requests = %+v", mutator.requests)
+	}
+	if len(sender.cards) != 0 {
+		t.Fatalf("non-terminal requester notification count = %d, want 0", len(sender.cards))
+	}
+}

--- a/modules/notify/api.go
+++ b/modules/notify/api.go
@@ -1,7 +1,9 @@
 package notify
 
 import (
+	"crypto/sha256"
 	"crypto/subtle"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"net/http"
@@ -13,6 +15,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/internal/cardactiondispatch"
 	"github.com/Mininglamp-OSS/octo-server/internal/carddispatch"
 	"github.com/Mininglamp-OSS/octo-server/modules/base/app"
 	"github.com/Mininglamp-OSS/octo-server/modules/base/event"
@@ -27,13 +30,29 @@ import (
 // InternalTokenHeader is the header key for internal service authentication.
 const InternalTokenHeader = "X-Internal-Token"
 
-// summaryNotifyProducerID / docsNotifyProducerID are the carddispatch producers
-// this module owns. Both are bound to the shared `notification` User Bot so
-// summary cards, docs cards, and legacy text notifications appear in one system
-// DM conversation; capability isolation lives at the producer level.
+const notifyCapabilityContextKey = "octo.notify.capability"
+
+type notifyCapabilityKind string
+
+const (
+	notifyCapabilityLegacy notifyCapabilityKind = "legacy"
+	notifyCapabilityDocs   notifyCapabilityKind = "docs"
+	notifyCapabilityAction notifyCapabilityKind = "action"
+)
+
+type notifyCapability struct {
+	Kind   notifyCapabilityKind
+	Action cardactiondispatch.NotifyCapability
+}
+
+// These carddispatch producers are bound to the shared `notification` User Bot
+// so summary cards, docs cards, generic action outcomes, and legacy text
+// notifications appear in one system DM conversation. Capability isolation
+// lives at the producer level.
 const (
 	summaryNotifyProducerID = "summary-notify"
 	docsNotifyProducerID    = "docs-notify"
+	actionOutcomeProducerID = "action-outcome"
 )
 
 var (
@@ -52,15 +71,26 @@ type Notify struct {
 	botOK         atomic.Bool
 	cardSender    carddispatch.Sender
 	docsSender    carddispatch.Sender
+	actionService *cardactiondispatch.Service
+	actionSenders map[cardactiondispatch.NotifyCapability]carddispatch.Sender
 	internalToken string
+	docsToken     string
 	log.Log
 }
 
 // New 创建 Notify 实例
 func New(ctx *config.Context) *Notify {
 	token := os.Getenv("NOTIFY_INTERNAL_TOKEN")
+	docsToken := os.Getenv("OCTO_DOCS_NOTIFY_TOKEN")
 	if token == "" {
 		log.NewTLog("Notify").Warn("NOTIFY_INTERNAL_TOKEN not set — internal API will reject all requests")
+	}
+	if docsToken == "" {
+		log.NewTLog("Notify").Warn("OCTO_DOCS_NOTIFY_TOKEN not set — docs notification requests will be rejected")
+	}
+	if token != "" && docsToken == token {
+		log.NewTLog("Notify").Error("OCTO_DOCS_NOTIFY_TOKEN must differ from NOTIFY_INTERNAL_TOKEN; docs capability disabled")
+		docsToken = ""
 	}
 
 	n := &Notify{
@@ -70,7 +100,9 @@ func New(ctx *config.Context) *Notify {
 		db:            ctx.DB(),
 		memberCache:   newMemberCache(),
 		internalToken: token,
+		docsToken:     docsToken,
 		Log:           log.NewTLog("Notify"),
+		actionSenders: make(map[cardactiondispatch.NotifyCapability]carddispatch.Sender),
 	}
 
 	// Obtain the producer-bound card Senders from the single registry composed at
@@ -85,6 +117,17 @@ func New(ctx *config.Context) *Notify {
 		n.Warn("docs-notify card sender unavailable; docs card notifications will degrade to text", zap.Error(senderErr))
 	} else {
 		n.docsSender = sender
+	}
+	if actionService, ok := cardactiondispatch.FromContext(ctx); ok {
+		n.actionService = actionService
+		for _, capability := range actionService.NotifyProducers() {
+			sender, senderErr := carddispatch.SenderFromContext(ctx, ActionNotifyProducerID(capability.Owner))
+			if senderErr != nil {
+				n.Error("action-notify card sender unavailable", zap.String("owner", capability.Owner), zap.Error(senderErr))
+				continue
+			}
+			n.actionSenders[capability] = sender
+		}
 	}
 
 	// 注册缓存失效回调（通过 event 包避免循环依赖）
@@ -144,12 +187,22 @@ func (n *Notify) Route(r *wkhttp.WKHttp) {
 // token 未配置时 fail-closed（拒绝所有请求）。
 func (n *Notify) internalAuthMiddleware() wkhttp.HandlerFunc {
 	return func(c *wkhttp.Context) {
-		if n.internalToken == "" {
+		if n.internalToken == "" && n.docsToken == "" && n.actionService == nil {
 			c.AbortWithStatusJSON(http.StatusUnauthorized, map[string]string{"error": "internal API auth not configured"})
 			return
 		}
 		token := c.GetHeader(InternalTokenHeader)
-		if subtle.ConstantTimeCompare([]byte(token), []byte(n.internalToken)) != 1 {
+		switch {
+		case n.internalToken != "" && subtle.ConstantTimeCompare([]byte(token), []byte(n.internalToken)) == 1:
+			c.Set(notifyCapabilityContextKey, notifyCapability{Kind: notifyCapabilityLegacy})
+		case n.docsToken != "" && subtle.ConstantTimeCompare([]byte(token), []byte(n.docsToken)) == 1:
+			c.Set(notifyCapabilityContextKey, notifyCapability{Kind: notifyCapabilityDocs})
+		default:
+			if action, ok := n.actionService.ResolveNotifyToken(token); ok {
+				c.Set(notifyCapabilityContextKey, notifyCapability{Kind: notifyCapabilityAction, Action: action})
+				c.Next()
+				return
+			}
 			c.AbortWithStatusJSON(http.StatusUnauthorized, map[string]string{"error": "unauthorized"})
 			return
 		}
@@ -194,16 +247,25 @@ func (n *Notify) sendNotify(c *wkhttp.Context) {
 	if req.DocsCard != nil {
 		present++
 	}
+	if req.ApprovalCard != nil {
+		present++
+	}
 	switch {
 	case present > 1:
 		httperr.ResponseErrorL(c, errcode.ErrNotifyCardInvalid, nil, nil)
 		return
-	case req.Card == nil && req.DocsCard == nil && len(req.Payload) == 0:
+	case req.Card == nil && req.DocsCard == nil && req.ApprovalCard == nil && len(req.Payload) == 0:
 		c.ResponseErrorWithStatus(errors.New("payload不能为空"), http.StatusBadRequest)
 		return
 	}
+	capability, _ := c.Get(notifyCapabilityContextKey)
+	typedCapability, _ := capability.(notifyCapability)
+	if !n.notifyCapabilityAllows(typedCapability, &req) {
+		httperr.ResponseErrorL(c, errcode.ErrNotifyCardNotAllowed, nil, nil)
+		return
+	}
 
-	resp, err := n.dispatchNotify(&req)
+	resp, err := n.dispatchNotify(&req, typedCapability)
 	if err != nil {
 		if errors.Is(err, errNotifyCardNotAllowed) {
 			httperr.ResponseErrorL(c, errcode.ErrNotifyCardNotAllowed, nil, nil)
@@ -222,12 +284,15 @@ func (n *Notify) sendNotify(c *wkhttp.Context) {
 
 // dispatchNotify routes a single request to the correct producer path (when a
 // structured Card / DocsCard is present) or the legacy text path.
-func (n *Notify) dispatchNotify(req *NotifyReq) (*NotifyResp, error) {
+func (n *Notify) dispatchNotify(req *NotifyReq, capability notifyCapability) (*NotifyResp, error) {
 	if req != nil && req.Card != nil {
 		return n.deliverCardNotification(req)
 	}
 	if req != nil && req.DocsCard != nil {
 		return n.deliverDocsCardNotification(req)
+	}
+	if req != nil && req.ApprovalCard != nil {
+		return n.deliverApprovalCardNotification(req, capability.Action)
 	}
 	return n.deliverNotification(req)
 }
@@ -247,12 +312,18 @@ func (n *Notify) sendNotifyBatch(c *wkhttp.Context) {
 		c.ResponseErrorWithStatus(errors.New("批量上限50条"), http.StatusBadRequest)
 		return
 	}
+	capabilityValue, _ := c.Get(notifyCapabilityContextKey)
+	capability, _ := capabilityValue.(notifyCapability)
+	if capability.Kind == notifyCapabilityDocs || capability.Kind == notifyCapabilityAction {
+		httperr.ResponseErrorL(c, errcode.ErrNotifyCardNotAllowed, nil, nil)
+		return
+	}
 	// Preflight the whole batch before delivering any earlier text item. This
 	// preserves the zero-transport guarantee when a later entry is a card.
 	// Card / DocsCard notifications are single-endpoint only (they fan out through
 	// the carddispatch producer), so any card entry in a batch is rejected outright.
 	for i := range req.Notifications {
-		if req.Notifications[i].Card != nil || req.Notifications[i].DocsCard != nil {
+		if req.Notifications[i].Card != nil || req.Notifications[i].DocsCard != nil || req.Notifications[i].ApprovalCard != nil {
 			httperr.ResponseErrorL(c, errcode.ErrNotifyCardInvalid, nil, nil)
 			return
 		}
@@ -284,6 +355,30 @@ func (n *Notify) sendNotifyBatch(c *wkhttp.Context) {
 	} else {
 		c.Response(resp)
 	}
+}
+
+func (n *Notify) notifyCapabilityAllows(capability notifyCapability, req *NotifyReq) bool {
+	if n == nil || req == nil {
+		return false
+	}
+	switch capability.Kind {
+	case notifyCapabilityLegacy:
+		return req.DocsCard == nil && req.ApprovalCard == nil
+	case notifyCapabilityDocs:
+		return req.DocsCard != nil && req.Card == nil && req.ApprovalCard == nil && req.Payload == nil
+	case notifyCapabilityAction:
+		return req.ApprovalCard != nil && req.Card == nil && req.DocsCard == nil && req.Payload == nil &&
+			n.actionService != nil && n.actionService.CanNotify(capability.Action, req.ApprovalCard.ActionType)
+	default:
+		return false
+	}
+}
+
+// ActionNotifyProducerID maps one route-bound owner to a stable internal
+// producer without putting unbounded owner text into registry identifiers.
+func ActionNotifyProducerID(owner string) carddispatch.ProducerID {
+	digest := sha256.Sum256([]byte(owner))
+	return carddispatch.ProducerID("action-notify-" + hex.EncodeToString(digest[:8]))
 }
 
 // deliverNotification 校验、过滤、投递

--- a/modules/notify/approval_card.go
+++ b/modules/notify/approval_card.go
@@ -1,0 +1,113 @@
+package notify
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-server/internal/cardactiondispatch"
+	"github.com/Mininglamp-OSS/octo-server/internal/carddispatch"
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardmsg"
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl"
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
+	"go.uber.org/zap"
+)
+
+func (n *Notify) deliverApprovalCardNotification(req *NotifyReq, capability cardactiondispatch.NotifyCapability) (*NotifyResp, error) {
+	if req == nil || req.ApprovalCard == nil || n.actionService == nil ||
+		!n.actionService.CanNotify(capability, req.ApprovalCard.ActionType) {
+		return nil, errNotifyCardNotAllowed
+	}
+	card := req.ApprovalCard
+	if strings.TrimSpace(req.SpaceID) == "" || len(req.Targets) == 0 || len(req.Targets) > 200 ||
+		strings.TrimSpace(card.Title) == "" {
+		return nil, errNotifyCardInvalid
+	}
+	sender := n.actionSenders[capability]
+	if sender == nil || !cardmsg.Enabled() {
+		return nil, errors.New("notify: action card producer unavailable")
+	}
+	targets := dedupTargets(req.Targets)
+	if req.ActorUID != "" {
+		filtered := make([]string, 0, len(targets))
+		for _, uid := range targets {
+			if uid != req.ActorUID {
+				filtered = append(filtered, uid)
+			}
+		}
+		targets = filtered
+	}
+	members, filteredMap, err := n.memberCache.verify(n.db, req.SpaceID, targets)
+	if err != nil {
+		return nil, fmt.Errorf("member verification failed: %w", err)
+	}
+	if len(members) == 0 {
+		return &NotifyResp{Delivered: []string{}, Filtered: filteredMap}, nil
+	}
+	n.ensureNotifyBotReady()
+	if !n.botOK.Load() {
+		return nil, errors.New("notification bot unavailable")
+	}
+	document, err := n.buildApprovalRequestCard(card, capability, i18n.OutboundLanguage(context.Background()))
+	if err != nil {
+		return nil, errNotifyCardInvalid
+	}
+
+	type sendResult struct {
+		uid    string
+		reason string
+	}
+	resultCh := make(chan sendResult, len(members))
+	sem := make(chan struct{}, 20)
+	for _, targetUID := range members {
+		sem <- struct{}{}
+		go func(uid string) {
+			defer func() { <-sem }()
+			reason := ""
+			if _, sendErr := sender.Send(context.Background(), carddispatch.Target{
+				SpaceID: req.SpaceID, ChannelID: uid, ChannelType: common.ChannelTypePerson.Uint8(),
+			}, carddispatch.Card{Profile: cardmsg.ProfileV2, Document: document}); sendErr != nil {
+				reason = string(carddispatch.CategoryOf(sendErr))
+				n.Warn("deliver action approval card failed", zap.String("owner", capability.Owner),
+					zap.String("action_type", card.ActionType), zap.String("target", uid), zap.Error(sendErr))
+			}
+			resultCh <- sendResult{uid: uid, reason: reason}
+		}(targetUID)
+	}
+	delivered := make([]string, 0, len(members))
+	for range members {
+		result := <-resultCh
+		if result.reason == "" {
+			delivered = append(delivered, result.uid)
+		} else {
+			filteredMap[result.uid] = result.reason
+		}
+	}
+	return &NotifyResp{Delivered: delivered, Filtered: filteredMap}, nil
+}
+
+func (n *Notify) buildApprovalRequestCard(card *ApprovalCardFields, capability cardactiondispatch.NotifyCapability, lang string) ([]byte, error) {
+	if card == nil {
+		return nil, errNotifyCardInvalid
+	}
+	labels := approvalActionLabelsFor(lang)
+	return cardtmpl.BuildApprovalRequestCard(cardtmpl.ApprovalRequestCard{
+		Title: card.Title, Description: card.Description, Owner: capability.Owner,
+		ActionType: card.ActionType, Data: card.Data,
+		ApproveTitle: labels.approve, DenyTitle: labels.deny,
+	})
+}
+
+type approvalActionLabels struct {
+	approve string
+	deny    string
+}
+
+func approvalActionLabelsFor(lang string) approvalActionLabels {
+	if strings.EqualFold(lang, "zh-CN") || strings.HasPrefix(strings.ToLower(lang), "zh") {
+		return approvalActionLabels{approve: "允许", deny: "拒绝"}
+	}
+	return approvalActionLabels{approve: "Allow", deny: "Deny"}
+}

--- a/modules/notify/card.go
+++ b/modules/notify/card.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
+	"strconv"
 	"strings"
 	"unicode"
 
@@ -289,7 +291,11 @@ func (n *Notify) deliverDocsCardNotification(req *NotifyReq) (*NotifyResp, error
 		return nil, errNotifyCardInvalid
 	}
 	if card.Kind != DocsCardKindShared && card.Kind != DocsCardKindCommented &&
-		card.Kind != DocsCardKindAccessRequested {
+		card.Kind != DocsCardKindAccessRequested && card.Kind != DocsCardKindAccessGranted &&
+		card.Kind != DocsCardKindAccessDenied {
+		return nil, errNotifyCardInvalid
+	}
+	if card.Kind == DocsCardKindAccessRequested && docsApprovalCardsEnabled() && strings.TrimSpace(card.RequestID) == "" {
 		return nil, errNotifyCardInvalid
 	}
 
@@ -320,9 +326,19 @@ func (n *Notify) deliverDocsCardNotification(req *NotifyReq) (*NotifyResp, error
 	lang := i18n.OutboundLanguage(context.Background())
 
 	canCard := n.docsSender != nil && cardmsg.Enabled()
+	profile := cardmsg.ProfileV1
 	var document json.RawMessage
 	if canCard {
-		doc, buildErr := n.buildDocsCard(context.Background(), req.SpaceID, card, lang)
+		var (
+			doc      json.RawMessage
+			buildErr error
+		)
+		if card.Kind == DocsCardKindAccessRequested && docsApprovalCardsEnabled() {
+			profile = cardmsg.ProfileV2
+			doc, buildErr = n.buildDocsAccessRequestCard(context.Background(), req.SpaceID, card, lang)
+		} else {
+			doc, buildErr = n.buildDocsCard(context.Background(), req.SpaceID, card, lang)
+		}
 		if buildErr != nil {
 			n.Warn("build docs card failed, degrading to text",
 				zap.Error(buildErr), zap.String("space_id", req.SpaceID), zap.String("doc_id", card.DocID))
@@ -356,7 +372,7 @@ func (n *Notify) deliverDocsCardNotification(req *NotifyReq) (*NotifyResp, error
 						ChannelID:   uid,
 						ChannelType: common.ChannelTypePerson.Uint8(),
 					},
-					carddispatch.Card{Profile: cardmsg.ProfileV1, Document: document},
+					carddispatch.Card{Profile: profile, Document: document},
 				)
 				if sendErr != nil {
 					reason = string(carddispatch.CategoryOf(sendErr))
@@ -404,7 +420,8 @@ func (n *Notify) deliverDocsCardNotification(req *NotifyReq) (*NotifyResp, error
 func (n *Notify) buildDocsCard(ctx context.Context, spaceID string, card *DocsCardFields, lang string) (json.RawMessage, error) {
 	labels := docsLabelsFor(lang)
 	facts := make([]cardtmpl.Fact, 0, 2)
-	if actor := strings.TrimSpace(card.ActorName); actor != "" {
+	isOutcome := card.Kind == DocsCardKindAccessGranted || card.Kind == DocsCardKindAccessDenied
+	if actor := strings.TrimSpace(card.ActorName); actor != "" && !isOutcome {
 		facts = append(facts, cardtmpl.Fact{Title: labels.actor, Value: actor})
 	}
 	if ts := strings.TrimSpace(card.UpdatedAt); ts != "" {
@@ -417,11 +434,55 @@ func (n *Notify) buildDocsCard(ctx context.Context, spaceID string, card *DocsCa
 	return cardtmpl.BuildDocsResourceCard(ctx, webLoginURL, card.DocID, spaceID, cardtmpl.ResourceCard{
 		Title:       card.Title,
 		Attribution: attribution,
-		Excerpt:     strings.TrimSpace(card.Excerpt),
+		Excerpt:     docsSafeExcerpt(card),
 		Facts:       facts,
 		Variant:     variant,
 		Source:      cardtmpl.Source{Label: labels.sourceLabel},
 	})
+}
+
+func (n *Notify) buildDocsAccessRequestCard(ctx context.Context, spaceID string, card *DocsCardFields, lang string) (json.RawMessage, error) {
+	labels := docsLabelsFor(lang)
+	facts := make([]cardtmpl.Fact, 0, 2)
+	if actor := strings.TrimSpace(card.ActorName); actor != "" {
+		facts = append(facts, cardtmpl.Fact{Title: labels.actor, Value: actor})
+	}
+	if ts := strings.TrimSpace(card.UpdatedAt); ts != "" {
+		facts = append(facts, cardtmpl.Fact{Title: labels.updatedAt, Value: ts})
+	}
+	attribution, variant := docsAttributionAndVariant(card.Kind, card.ActorName, labels)
+	return cardtmpl.BuildDocsAccessRequestCard(
+		ctx,
+		n.ctx.GetConfig().External.WebLoginURL,
+		card.DocID,
+		card.RequestID,
+		spaceID,
+		cardtmpl.ResourceCard{
+			Title:       card.Title,
+			Attribution: attribution,
+			Excerpt:     strings.TrimSpace(card.Excerpt),
+			Facts:       facts,
+			Variant:     variant,
+			Source:      cardtmpl.Source{Label: labels.sourceLabel},
+		},
+		cardtmpl.ApprovalActions{ApproveTitle: labels.approve, DenyTitle: labels.deny},
+	)
+}
+
+func docsApprovalCardsEnabled() bool {
+	enabled, err := strconv.ParseBool(os.Getenv("OCTO_DOCS_APPROVAL_CARD_ENABLED"))
+	return err == nil && enabled
+}
+
+// DocsApprovalCardsEnabled exposes the rollout decision to the composition
+// root so producer capability and callback routing fail closed together.
+func DocsApprovalCardsEnabled() bool { return docsApprovalCardsEnabled() }
+
+func docsSafeExcerpt(card *DocsCardFields) string {
+	if card == nil || card.Kind == DocsCardKindAccessGranted || card.Kind == DocsCardKindAccessDenied {
+		return ""
+	}
+	return strings.TrimSpace(card.Excerpt)
 }
 
 // docsAttributionAndVariant maps DocsCard.Kind to a (localized attribution
@@ -430,6 +491,10 @@ func (n *Notify) buildDocsCard(ctx context.Context, spaceID string, card *DocsCa
 func docsAttributionAndVariant(kind, actorName string, labels docsLabels) (string, string) {
 	actor := strings.TrimSpace(actorName)
 	switch kind {
+	case DocsCardKindAccessGranted:
+		return labels.accessGrantedBanner, "docs.access_granted"
+	case DocsCardKindAccessDenied:
+		return labels.accessDeniedBanner, "docs.access_denied"
 	case DocsCardKindCommented:
 		if actor != "" {
 			return fmt.Sprintf(labels.commentedBanner, actor), "docs.commented"
@@ -456,13 +521,17 @@ func buildDocsFallbackText(card *DocsCardFields, lang string) string {
 	labels := docsLabelsFor(lang)
 	// sanitizeLine the actor before it flows into the attribution line, and each
 	// other caller field, so an embedded newline can't inject a spoofed line.
-	attribution, _ := docsAttributionAndVariant(card.Kind, sanitizeLine(card.ActorName), labels)
+	actorName := card.ActorName
+	if card.Kind == DocsCardKindAccessGranted || card.Kind == DocsCardKindAccessDenied {
+		actorName = ""
+	}
+	attribution, _ := docsAttributionAndVariant(card.Kind, sanitizeLine(actorName), labels)
 	var b strings.Builder
 	b.WriteString(attribution)
 	if title := sanitizeLine(card.Title); title != "" {
 		fmt.Fprintf(&b, "\n%s%s", labels.title+labels.kvSep, title)
 	}
-	if excerpt := sanitizeLine(card.Excerpt); excerpt != "" {
+	if excerpt := sanitizeLine(docsSafeExcerpt(card)); excerpt != "" {
 		fmt.Fprintf(&b, "\n%s", excerpt)
 	}
 	if ts := sanitizeLine(card.UpdatedAt); ts != "" {
@@ -478,6 +547,12 @@ type docsLabels struct {
 	commentedBannerAnon       string
 	accessRequestedBanner     string
 	accessRequestedBannerAnon string
+	accessGrantedBanner       string
+	accessDeniedBanner        string
+	accessCancelledBanner     string
+	accessUnavailableBanner   string
+	approve                   string
+	deny                      string
 	title                     string
 	actor                     string
 	updatedAt                 string
@@ -494,6 +569,12 @@ func docsLabelsFor(lang string) docsLabels {
 			commentedBannerAnon:       "有新评论",
 			accessRequestedBanner:     "%s 请求访问文档",
 			accessRequestedBannerAnon: "有人请求访问文档",
+			accessGrantedBanner:       "文档访问已获批准",
+			accessDeniedBanner:        "访问申请已拒绝",
+			accessCancelledBanner:     "访问申请已取消",
+			accessUnavailableBanner:   "当前无法处理此访问申请",
+			approve:                   "允许",
+			deny:                      "拒绝",
 			title:                     "文档",
 			actor:                     "操作人",
 			updatedAt:                 "时间",
@@ -508,6 +589,12 @@ func docsLabelsFor(lang string) docsLabels {
 		commentedBannerAnon:       "A new comment on a document",
 		accessRequestedBanner:     "%s requested access to a document",
 		accessRequestedBannerAnon: "Someone requested access to a document",
+		accessGrantedBanner:       "Document access granted",
+		accessDeniedBanner:        "Document access request denied",
+		accessCancelledBanner:     "Document access request cancelled",
+		accessUnavailableBanner:   "This access request is no longer actionable",
+		approve:                   "Allow",
+		deny:                      "Deny",
 		title:                     "Document",
 		actor:                     "By",
 		updatedAt:                 "At",

--- a/modules/notify/card_action_test.go
+++ b/modules/notify/card_action_test.go
@@ -1,0 +1,257 @@
+package notify
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-server/internal/cardactiondispatch"
+	"github.com/Mininglamp-OSS/octo-server/internal/carddispatch"
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardmsg"
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type capturingCardSender struct {
+	mu      sync.Mutex
+	targets []carddispatch.Target
+	cards   []carddispatch.Card
+}
+
+type unusedActionQueue struct{}
+
+func (unusedActionQueue) Enqueue(cardactiondispatch.Event, time.Time) error { return nil }
+
+func (s *capturingCardSender) Send(_ context.Context, target carddispatch.Target, card carddispatch.Card) (*carddispatch.Result, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.targets = append(s.targets, target)
+	s.cards = append(s.cards, card)
+	return &carddispatch.Result{MessageID: 1001, MessageSeq: 1}, nil
+}
+
+func (s *capturingCardSender) last() carddispatch.Card {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.cards[len(s.cards)-1]
+}
+
+func (s *capturingCardSender) lastTarget() carddispatch.Target {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.targets[len(s.targets)-1]
+}
+
+func validAccessRequestDocsCard() *DocsCardFields {
+	card := validDocsCard()
+	card.Kind = DocsCardKindAccessRequested
+	card.RequestID = "request-1"
+	return card
+}
+
+func TestBuildDocsAccessRequestCardProducesValidOctoV2(t *testing.T) {
+	wk := newWuKongServer()
+	defer wk.close()
+	ctx := newTestContext(t, wk)
+	ctx.GetConfig().External.WebLoginURL = "https://im.example.com/login"
+	n := newTestNotify(ctx, nil, nil, nil, "legacy-token")
+
+	document, err := n.buildDocsAccessRequestCard(context.Background(), "space-1", validAccessRequestDocsCard(), "zh-CN")
+	require.NoError(t, err)
+	var card map[string]interface{}
+	require.NoError(t, json.Unmarshal(document, &card))
+	require.NoError(t, cardmsg.Validate(map[string]interface{}{
+		"type":         cardmsg.InteractiveCard.Int(),
+		"card_version": cardmsg.CardVersion,
+		"profile":      cardmsg.ProfileV2,
+		"card":         card,
+	}))
+	assert.Contains(t, string(document), `"title":"允许"`)
+	assert.Contains(t, string(document), `"title":"拒绝"`)
+}
+
+func TestDeliverDocsAccessRequestHonorsApprovalFlag(t *testing.T) {
+	tests := []struct {
+		name        string
+		flag        string
+		wantProfile string
+	}{
+		{name: "enabled sends v2", flag: "true", wantProfile: cardmsg.ProfileV2},
+		{name: "disabled preserves v1", flag: "false", wantProfile: cardmsg.ProfileV1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("OCTO_DOCS_APPROVAL_CARD_ENABLED", tt.flag)
+			t.Setenv("OCTO_CARD_MESSAGE_ENABLED", "true")
+			wk := newWuKongServer()
+			defer wk.close()
+			ctx := newTestContext(t, wk)
+			ctx.GetConfig().External.WebLoginURL = "https://im.example.com/login"
+			n := newTestNotify(ctx, nil, nil, nil, "legacy-token")
+			n.botOK.Store(true)
+			primeMemberCache(n, "space-1", "user-b")
+			capture := &capturingCardSender{}
+			n.docsSender = capture
+
+			response, err := n.deliverDocsCardNotification(&NotifyReq{
+				SpaceID: "space-1", Service: "docs", Targets: []string{"user-b"}, ActorUID: "user-a",
+				DocsCard: validAccessRequestDocsCard(),
+			})
+			require.NoError(t, err)
+			assert.Equal(t, []string{"user-b"}, response.Delivered)
+			assert.Equal(t, tt.wantProfile, capture.last().Profile)
+		})
+	}
+}
+
+func TestDocsOutcomeCardsAreV1AndDeniedDoesNotLeakApproverOrReason(t *testing.T) {
+	wk := newWuKongServer()
+	defer wk.close()
+	ctx := newTestContext(t, wk)
+	ctx.GetConfig().External.WebLoginURL = "https://im.example.com/login"
+	n := newTestNotify(ctx, nil, nil, nil, "legacy-token")
+
+	for _, kind := range []string{DocsCardKindAccessGranted, DocsCardKindAccessDenied} {
+		card := validDocsCard()
+		card.Kind = kind
+		card.ActorName = "approver-secret"
+		card.Excerpt = "denial-reason-secret"
+		document, err := n.buildDocsCard(context.Background(), "space-1", card, "zh-CN")
+		require.NoError(t, err)
+		assert.NotContains(t, string(document), "approver-secret")
+		if kind == DocsCardKindAccessDenied {
+			assert.NotContains(t, string(document), "denial-reason-secret")
+			assert.Contains(t, string(document), "访问申请已拒绝")
+			fallback := buildDocsFallbackText(card, "zh-CN")
+			assert.NotContains(t, fallback, "approver-secret")
+			assert.NotContains(t, fallback, "denial-reason-secret")
+		} else {
+			assert.Contains(t, string(document), "文档访问已获批准")
+		}
+	}
+}
+
+func TestIntegration_NotifyTokensAreCapabilityScoped(t *testing.T) {
+	t.Setenv("OCTO_DOCS_APPROVAL_CARD_ENABLED", "false")
+	wk := newWuKongServer()
+	defer wk.close()
+	ctx := newTestContext(t, wk)
+	ctx.GetConfig().External.WebLoginURL = "https://im.example.com/login"
+	n := newTestNotify(ctx, nil, nil, nil, "legacy-token")
+	n.docsToken = "docs-token"
+	n.botOK.Store(true)
+	primeMemberCache(n, "space-1", "user-b")
+	n.docsSender = &capturingCardSender{}
+	router := buildRouter(n)
+	router.SetErrorRenderer(i18n.NewErrorRenderer(i18n.NewLocalizer(i18n.DefaultLanguage)))
+
+	docsRequest := NotifyReq{
+		SpaceID: "space-1", Service: "docs", Targets: []string{"user-b"}, DocsCard: validAccessRequestDocsCard(),
+	}
+	legacyHeader := http.Header{InternalTokenHeader: []string{"legacy-token"}}
+	legacyResponse := doJSONRequest(t, router, http.MethodPost, "/v1/internal/notify", legacyHeader, docsRequest)
+	assert.Equal(t, http.StatusBadRequest, legacyResponse.Code)
+	assert.Contains(t, legacyResponse.Body.String(), "err.server.notify.card_not_allowed")
+
+	docsHeader := http.Header{InternalTokenHeader: []string{"docs-token"}}
+	docsResponse := doJSONRequest(t, router, http.MethodPost, "/v1/internal/notify", docsHeader, docsRequest)
+	assert.Equal(t, http.StatusOK, docsResponse.Code)
+
+	legacyRequest := NotifyReq{
+		SpaceID: "space-1", Service: "other", Targets: []string{"user-b"}, Payload: map[string]interface{}{"type": 1, "content": "x"},
+	}
+	docsToLegacy := doJSONRequest(t, router, http.MethodPost, "/v1/internal/notify", docsHeader, legacyRequest)
+	assert.Equal(t, http.StatusBadRequest, docsToLegacy.Code)
+	assert.Contains(t, docsToLegacy.Body.String(), "err.server.notify.card_not_allowed")
+}
+
+func TestIntegration_GenericApprovalTokenIsOwnerBoundAndSendsV2(t *testing.T) {
+	t.Setenv("OCTO_CARD_MESSAGE_ENABLED", "true")
+	const (
+		callbackSecret = "0123456789abcdef0123456789abcdef"
+		notifyToken    = "abcdef0123456789abcdef0123456789"
+	)
+	wk := newWuKongServer()
+	defer wk.close()
+	ctx := newTestContext(t, wk)
+	registry, err := cardactiondispatch.NewRegistry([]cardactiondispatch.RouteSpec{
+		{
+			SenderUID: "notification", Owner: "smart-summary", ActionType: "summary.publish.decision",
+			URL:       "https://summary.internal/v1/card-actions/decide",
+			SecretEnv: "OCTO_SMART_SUMMARY_CARD_ACTION_SECRET", NotifyTokenEnv: "OCTO_SMART_SUMMARY_NOTIFY_TOKEN",
+		},
+	}, []string{"https://summary.internal/v1/card-actions/decide"}, func(key string) string {
+		switch key {
+		case "OCTO_SMART_SUMMARY_CARD_ACTION_SECRET":
+			return callbackSecret
+		case "OCTO_SMART_SUMMARY_NOTIFY_TOKEN":
+			return notifyToken
+		default:
+			return ""
+		}
+	})
+	require.NoError(t, err)
+	service, err := cardactiondispatch.NewService(registry, unusedActionQueue{}, ctx)
+	require.NoError(t, err)
+	capability := cardactiondispatch.NotifyCapability{SenderUID: "notification", Owner: "smart-summary"}
+	capture := &capturingCardSender{}
+	n := newTestNotify(ctx, nil, nil, nil, "legacy-token")
+	n.actionService = service
+	n.actionSenders = map[cardactiondispatch.NotifyCapability]carddispatch.Sender{capability: capture}
+	n.botOK.Store(true)
+	primeMemberCache(n, "space-1", "user-b")
+	router := buildRouter(n)
+	router.SetErrorRenderer(i18n.NewErrorRenderer(i18n.NewLocalizer(i18n.DefaultLanguage)))
+
+	request := NotifyReq{
+		SpaceID: "space-1", Service: "smart-summary", Targets: []string{"user-b"}, ActorUID: "user-a",
+		ApprovalCard: &ApprovalCardFields{
+			ActionType: "summary.publish.decision", Title: "Publish summary", Description: "Review it first",
+			Data: map[string]string{"task_no": "task-1"},
+		},
+	}
+	actionHeader := http.Header{InternalTokenHeader: []string{notifyToken}}
+	response := doJSONRequest(t, router, http.MethodPost, "/v1/internal/notify", actionHeader, request)
+	require.Equal(t, http.StatusOK, response.Code, response.Body.String())
+	require.Len(t, capture.cards, 1)
+	assert.Equal(t, cardmsg.ProfileV2, capture.last().Profile)
+	assert.Contains(t, string(capture.last().Document), `"owner":"smart-summary"`)
+	assert.Contains(t, string(capture.last().Document), `"action_type":"summary.publish.decision"`)
+	assert.Contains(t, string(capture.last().Document), `"task_no":"task-1"`)
+
+	legacyHeader := http.Header{InternalTokenHeader: []string{"legacy-token"}}
+	legacyResponse := doJSONRequest(t, router, http.MethodPost, "/v1/internal/notify", legacyHeader, request)
+	assert.Equal(t, http.StatusBadRequest, legacyResponse.Code)
+
+	request.ApprovalCard.ActionType = "summary.delete.decision"
+	unknownAction := doJSONRequest(t, router, http.MethodPost, "/v1/internal/notify", actionHeader, request)
+	assert.Equal(t, http.StatusBadRequest, unknownAction.Code)
+	assert.Len(t, capture.cards, 1, "rejected capabilities must not reach transport")
+
+	docsAttempt := NotifyReq{
+		SpaceID: "space-1", Service: "docs", Targets: []string{"user-b"}, DocsCard: validAccessRequestDocsCard(),
+	}
+	docsResponse := doJSONRequest(t, router, http.MethodPost, "/v1/internal/notify", actionHeader, docsAttempt)
+	assert.Equal(t, http.StatusBadRequest, docsResponse.Code)
+}
+
+func TestIntegration_MissingDocsTokenFailsClosed(t *testing.T) {
+	wk := newWuKongServer()
+	defer wk.close()
+	ctx := newTestContext(t, wk)
+	n := newTestNotify(ctx, nil, nil, nil, "legacy-token")
+	n.docsToken = ""
+	router := buildRouter(n)
+	router.SetErrorRenderer(i18n.NewErrorRenderer(i18n.NewLocalizer(i18n.DefaultLanguage)))
+
+	header := http.Header{InternalTokenHeader: []string{"legacy-token"}}
+	response := doJSONRequest(t, router, http.MethodPost, "/v1/internal/notify", header, NotifyReq{
+		SpaceID: "space-1", Service: "docs", Targets: []string{"user-b"}, DocsCard: validAccessRequestDocsCard(),
+	})
+	assert.Equal(t, http.StatusBadRequest, response.Code)
+	assert.Contains(t, response.Body.String(), "err.server.notify.card_not_allowed")
+}

--- a/modules/notify/model.go
+++ b/modules/notify/model.go
@@ -2,22 +2,32 @@ package notify
 
 // NotifyReq 通知请求
 //
-// Payload / Card / DocsCard 三选一:
+// Payload / Card / DocsCard / ApprovalCard 四选一:
 //   - 文本通知(现状):填 Payload{type:1,content:...},另两者省略。
 //   - 智能总结卡片(summary-notify pilot):填结构化 Card,另两者省略。服务端用
 //     pkg/cardtmpl 生成 octo/v1 卡片,经 internal/carddispatch 派发。
 //   - 文档通知卡片(docs-notify):填结构化 DocsCard,另两者省略。
+//   - 通用审批卡片:填结构化 ApprovalCard；owner 由路由绑定的独立 token
+//     决定，调用方只提供 action_type 和有界业务标识。
 //
 // 调用方永不构造 type-17 map(Decision 14 仍拒绝 payload 里的 card 形状)。
 type NotifyReq struct {
-	SpaceID  string                 `json:"space_id" binding:"required"`
-	Service  string                 `json:"service" binding:"required"`
-	Event    string                 `json:"event"`
-	Targets  []string               `json:"targets" binding:"required"`
-	ActorUID string                 `json:"actor_uid"`
-	Payload  map[string]interface{} `json:"payload"`
-	Card     *SummaryCardFields     `json:"card"`
-	DocsCard *DocsCardFields        `json:"docs_card"`
+	SpaceID      string                 `json:"space_id" binding:"required"`
+	Service      string                 `json:"service" binding:"required"`
+	Event        string                 `json:"event"`
+	Targets      []string               `json:"targets" binding:"required"`
+	ActorUID     string                 `json:"actor_uid"`
+	Payload      map[string]interface{} `json:"payload"`
+	Card         *SummaryCardFields     `json:"card"`
+	DocsCard     *DocsCardFields        `json:"docs_card"`
+	ApprovalCard *ApprovalCardFields    `json:"approval_card"`
+}
+
+type ApprovalCardFields struct {
+	ActionType  string            `json:"action_type"`
+	Title       string            `json:"title"`
+	Description string            `json:"description"`
+	Data        map[string]string `json:"data"`
 }
 
 // SummaryCardFields 是 summary-notify 卡片通知的结构化入参(跨仓契约,见
@@ -50,6 +60,7 @@ const (
 // so octo-server does not resolve secondary identities on the card path.
 type DocsCardFields struct {
 	DocID     string `json:"doc_id"`     // maps to /d/{doc_id}?sp={space_id}
+	RequestID string `json:"request_id"` // required by access_requested v2; docs domain idempotency/CAS key
 	Kind      string `json:"kind"`       // "shared" | "commented" | "access_requested"
 	Title     string `json:"title"`      // document title
 	ActorName string `json:"actor_name"` // pre-resolved actor display name; empty allowed
@@ -62,6 +73,8 @@ const (
 	DocsCardKindShared          = "shared"
 	DocsCardKindCommented       = "commented"
 	DocsCardKindAccessRequested = "access_requested"
+	DocsCardKindAccessGranted   = "access_granted"
+	DocsCardKindAccessDenied    = "access_denied"
 )
 
 // BatchNotifyReq 批量通知请求

--- a/modules/notify/standard_action_finalizer.go
+++ b/modules/notify/standard_action_finalizer.go
@@ -1,0 +1,110 @@
+package notify
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-server/internal/cardactiondispatch"
+	"github.com/Mininglamp-OSS/octo-server/internal/carddispatch"
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardmsg"
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl"
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
+)
+
+type StandardActionFinalizer struct {
+	mutator cardActionMutator
+	sender  carddispatch.Sender
+}
+
+func NewStandardActionFinalizer(mutator cardActionMutator, sender carddispatch.Sender) (*StandardActionFinalizer, error) {
+	if mutator == nil || sender == nil {
+		return nil, errors.New("notify: standard action finalizer dependencies are required")
+	}
+	return &StandardActionFinalizer{mutator: mutator, sender: sender}, nil
+}
+
+func (f *StandardActionFinalizer) Finalize(ctx context.Context, event cardactiondispatch.Event, result cardactiondispatch.DecisionResult) error {
+	if ctx == nil || event.EventID <= 0 || strings.TrimSpace(event.SenderUID) == "" ||
+		strings.TrimSpace(event.MessageID) == "" || event.ChannelType == 0 || strings.TrimSpace(event.ChannelID) == "" ||
+		strings.TrimSpace(event.SpaceID) == "" {
+		return errors.New("notify: standard action result is missing authoritative context")
+	}
+	terminal := result.State == cardactiondispatch.StateApproved || result.State == cardactiondispatch.StateDenied
+	if terminal && strings.TrimSpace(result.RequesterUID) == "" {
+		return errors.New("notify: terminal standard action requires requester_uid")
+	}
+	labels := standardApprovalLabelsFor(i18n.OutboundLanguage(ctx))
+	title := strings.TrimSpace(result.Display["title"])
+	if title == "" {
+		title, _ = event.Data["title"].(string)
+	}
+	if strings.TrimSpace(title) == "" {
+		title = labels.title
+	}
+	status, variant := labels.unavailable, "approval.unavailable"
+	switch result.State {
+	case cardactiondispatch.StateApproved:
+		status, variant = labels.approved, "approval.approved"
+	case cardactiondispatch.StateDenied:
+		status, variant = labels.denied, "approval.denied"
+	case cardactiondispatch.StateCancelled:
+		status, variant = labels.cancelled, "approval.cancelled"
+	}
+	document, err := cardtmpl.BuildApprovalResultCard(cardtmpl.ApprovalResultCard{
+		Title: title, Status: status, Variant: variant, Source: labels.source,
+	})
+	if err != nil {
+		return err
+	}
+	contentEdit, err := buildTerminalEnvelope(document, event.SpaceID, event.EventID)
+	if err != nil {
+		return err
+	}
+	channelID := event.ChannelID
+	if event.ChannelType == common.ChannelTypePerson.Uint8() {
+		if strings.TrimSpace(event.OperatorUID) == "" {
+			return errors.New("notify: standard DM action is missing operator_uid")
+		}
+		channelID = event.OperatorUID
+	}
+	if _, err := f.mutator.Mutate(ctx, carddispatch.CardMutationRequest{
+		SenderUID: event.SenderUID, MessageID: event.MessageID, ChannelID: channelID,
+		ChannelType: event.ChannelType, ContentEdit: contentEdit,
+	}); err != nil {
+		return err
+	}
+	if !terminal {
+		return nil
+	}
+	_, err = f.sender.Send(ctx, carddispatch.Target{
+		SpaceID: event.SpaceID, ChannelID: result.RequesterUID, ChannelType: common.ChannelTypePerson.Uint8(),
+	}, carddispatch.Card{Profile: cardmsg.ProfileV1, Document: document})
+	if err != nil {
+		return &actionFinalizeError{category: "applicant_notify_failed", err: err}
+	}
+	return nil
+}
+
+type standardApprovalLabels struct {
+	title       string
+	approved    string
+	denied      string
+	cancelled   string
+	unavailable string
+	source      string
+}
+
+func standardApprovalLabelsFor(lang string) standardApprovalLabels {
+	if strings.EqualFold(lang, "zh-CN") || strings.HasPrefix(strings.ToLower(lang), "zh") {
+		return standardApprovalLabels{
+			title: "审批请求", approved: "申请已允许", denied: "申请已拒绝",
+			cancelled: "申请已取消", unavailable: "申请暂不可用", source: "审批",
+		}
+	}
+	return standardApprovalLabels{
+		title: "Approval request", approved: "Request approved", denied: "Request denied",
+		cancelled: "Request cancelled", unavailable: "Request unavailable", source: "Approval",
+	}
+}

--- a/pilote2e/docs_card_wukongim_test.go
+++ b/pilote2e/docs_card_wukongim_test.go
@@ -93,7 +93,8 @@ func TestDocsNotify_HTTPEndpointDeliversCardToWuKongIM(t *testing.T) {
 	t.Setenv(cardmsg.EnvEnabled, "true")
 	t.Setenv("OCTO_MASTER_KEY", "0123456789abcdef0123456789abcdef")
 	t.Setenv("OCTO_USER_API_KEY_SECRET", "0123456789abcdef0123456789abcdef")
-	t.Setenv("NOTIFY_INTERNAL_TOKEN", "pilote2e-docs-token")
+	t.Setenv("NOTIFY_INTERNAL_TOKEN", "pilote2e-default-token")
+	t.Setenv("OCTO_DOCS_NOTIFY_TOKEN", "pilote2e-docs-token")
 
 	recipient := fmt.Sprintf("uid_pilote2e_docs_%d", time.Now().UnixNano())
 
@@ -180,6 +181,7 @@ func TestSummaryAndDocsNotify_NoRegression(t *testing.T) {
 	t.Setenv("OCTO_MASTER_KEY", "0123456789abcdef0123456789abcdef")
 	t.Setenv("OCTO_USER_API_KEY_SECRET", "0123456789abcdef0123456789abcdef")
 	t.Setenv("NOTIFY_INTERNAL_TOKEN", "pilote2e-both-token")
+	t.Setenv("OCTO_DOCS_NOTIFY_TOKEN", "pilote2e-both-docs-token")
 
 	recipient := fmt.Sprintf("uid_pilote2e_both_%d", time.Now().UnixNano())
 
@@ -217,9 +219,9 @@ func TestSummaryAndDocsNotify_NoRegression(t *testing.T) {
 	n.Route(r)
 	r.SetErrorRenderer(octoi18n.NewErrorRenderer(octoi18n.NewLocalizer(octoi18n.DefaultLanguage)))
 
-	postJSON := func(t *testing.T, body []byte, expected string) {
+	postJSON := func(t *testing.T, token string, body []byte, expected string) {
 		t.Helper()
-		delivered, lastCode, lastBody := postUntilDelivered(t, r, "/v1/internal/notify", "pilote2e-both-token", body, expected)
+		delivered, lastCode, lastBody := postUntilDelivered(t, r, "/v1/internal/notify", token, body, expected)
 		require.Equal(t, http.StatusOK, lastCode, "notify POST must succeed (last body: %s)", truncate(lastBody))
 		require.Contains(t, delivered, expected, "recipient must be delivered")
 	}
@@ -238,8 +240,8 @@ func TestSummaryAndDocsNotify_NoRegression(t *testing.T) {
 			ActorName: "Bob", Excerpt: "review please",
 		},
 	})
-	postJSON(t, summaryBody, recipient)
-	postJSON(t, docsBody, recipient)
+	postJSON(t, "pilote2e-both-token", summaryBody, recipient)
+	postJSON(t, "pilote2e-both-docs-token", docsBody, recipient)
 
 	// Both cards must be readable back from WuKongIM under the recipient's
 	// notification-bot DM channel. Read all persisted type-17s and assert both

--- a/pkg/cardtmpl/approval_request.go
+++ b/pkg/cardtmpl/approval_request.go
@@ -1,0 +1,94 @@
+package cardtmpl
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardmsg"
+)
+
+const (
+	ApprovalApproveActionID = "approval-approve"
+	ApprovalDenyActionID    = "approval-deny"
+	maxApprovalDataFields   = 32
+)
+
+var (
+	approvalOwnerPattern      = regexp.MustCompile(`^[a-z][a-z0-9-]{0,63}$`)
+	approvalActionTypePattern = regexp.MustCompile(`^[a-z][a-z0-9_.-]{0,127}$`)
+	approvalDataKeyPattern    = regexp.MustCompile(`^[a-z][a-z0-9_.-]{0,63}$`)
+)
+
+type ApprovalRequestCard struct {
+	Title        string
+	Description  string
+	Owner        string
+	ActionType   string
+	Data         map[string]string
+	ApproveTitle string
+	DenyTitle    string
+}
+
+// BuildApprovalRequestCard is the shared server-owned approve/deny template.
+// Callers provide bounded business identifiers, never an action owner, URL, or
+// arbitrary Adaptive Card JSON.
+func BuildApprovalRequestCard(input ApprovalRequestCard) (json.RawMessage, error) {
+	title := truncateRunes(strings.TrimSpace(input.Title), maxTitleRunes)
+	description := truncateRunes(strings.TrimSpace(input.Description), MaxExcerptRunes)
+	approveTitle := strings.TrimSpace(input.ApproveTitle)
+	denyTitle := strings.TrimSpace(input.DenyTitle)
+	if title == "" || !approvalOwnerPattern.MatchString(input.Owner) || !approvalActionTypePattern.MatchString(input.ActionType) {
+		return nil, errors.New("cardtmpl: approval request identity is invalid")
+	}
+	if approveTitle == "" || denyTitle == "" || utf8.RuneCountInString(approveTitle) > 80 || utf8.RuneCountInString(denyTitle) > 80 {
+		return nil, errors.New("cardtmpl: approval action labels are invalid")
+	}
+	if len(input.Data) > maxApprovalDataFields {
+		return nil, errors.New("cardtmpl: too many approval data fields")
+	}
+	baseData := make(map[string]interface{}, len(input.Data)+2)
+	for key, value := range input.Data {
+		if key == "owner" || key == "action_type" || key == "decision" ||
+			!approvalDataKeyPattern.MatchString(key) || utf8.RuneCountInString(value) > maxFactRunes {
+			return nil, errors.New("cardtmpl: approval data field is invalid")
+		}
+		baseData[key] = value
+	}
+	baseData["owner"] = input.Owner
+	baseData["action_type"] = input.ActionType
+	approveData := copyActionData(baseData)
+	approveData["decision"] = "approve"
+	denyData := copyActionData(baseData)
+	denyData["decision"] = "deny"
+
+	body := []interface{}{
+		map[string]interface{}{
+			"type": "TextBlock", "text": escapeMarkdown(title), "weight": "Bolder", "wrap": true,
+		},
+	}
+	if description != "" {
+		body = append(body, map[string]interface{}{
+			"type": "TextBlock", "text": escapeMarkdown(description), "wrap": true,
+		})
+	}
+	document := map[string]interface{}{
+		"type": "AdaptiveCard", "version": cardmsg.CardVersion, "body": body,
+		"actions": []interface{}{
+			map[string]interface{}{
+				"type": "Action.Submit", "id": ApprovalApproveActionID, "title": approveTitle, "data": approveData,
+			},
+			map[string]interface{}{
+				"type": "Action.Submit", "id": ApprovalDenyActionID, "title": denyTitle, "data": denyData,
+			},
+		},
+	}
+	raw, err := json.Marshal(document)
+	if err != nil {
+		return nil, fmt.Errorf("cardtmpl: marshal approval request card: %w", err)
+	}
+	return raw, nil
+}

--- a/pkg/cardtmpl/approval_request_test.go
+++ b/pkg/cardtmpl/approval_request_test.go
@@ -1,0 +1,76 @@
+package cardtmpl
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardmsg"
+)
+
+func TestBuildApprovalRequestCardOwnsActionsAndReservedMetadata(t *testing.T) {
+	raw, err := BuildApprovalRequestCard(ApprovalRequestCard{
+		Title:        "**Publish** summary",
+		Description:  "Review before publishing",
+		Owner:        "smart-summary",
+		ActionType:   "summary.publish.decision",
+		Data:         map[string]string{"task_no": "task-1"},
+		ApproveTitle: "Allow",
+		DenyTitle:    "Deny",
+	})
+	if err != nil {
+		t.Fatalf("BuildApprovalRequestCard() error = %v", err)
+	}
+	var card map[string]interface{}
+	if err := json.Unmarshal(raw, &card); err != nil {
+		t.Fatalf("decode card: %v", err)
+	}
+	if err := cardmsg.Validate(map[string]interface{}{
+		"type": cardmsg.InteractiveCard.Int(), "card_version": cardmsg.CardVersion,
+		"profile": cardmsg.ProfileV2, "card": card,
+	}); err != nil {
+		t.Fatalf("approval request card is invalid: %v", err)
+	}
+	actions, _ := card["actions"].([]interface{})
+	if len(actions) != 2 {
+		t.Fatalf("actions = %+v", actions)
+	}
+	decisions := map[string]bool{}
+	for _, value := range actions {
+		action, _ := value.(map[string]interface{})
+		data, _ := action["data"].(map[string]interface{})
+		if data["owner"] != "smart-summary" || data["action_type"] != "summary.publish.decision" || data["task_no"] != "task-1" {
+			t.Fatalf("action data = %+v", data)
+		}
+		decision, _ := data["decision"].(string)
+		decisions[decision] = true
+	}
+	if !decisions["approve"] || !decisions["deny"] {
+		t.Fatalf("decisions = %+v", decisions)
+	}
+	if strings.Contains(string(raw), "http") {
+		t.Fatalf("approval request leaked a callback URL: %s", raw)
+	}
+	if !strings.Contains(string(raw), `\\*\\*Publish\\*\\* summary`) {
+		t.Fatalf("title was not markdown escaped: %s", raw)
+	}
+}
+
+func TestBuildApprovalRequestCardRejectsReservedAndUnboundedData(t *testing.T) {
+	base := ApprovalRequestCard{
+		Title: "Approve", Owner: "tasks", ActionType: "task.decision",
+		ApproveTitle: "Allow", DenyTitle: "Deny",
+	}
+	for _, data := range []map[string]string{
+		{"owner": "spoofed"},
+		{"decision": "approve"},
+		{"bad key": "value"},
+		{"task_id": strings.Repeat("x", 501)},
+	} {
+		input := base
+		input.Data = data
+		if _, err := BuildApprovalRequestCard(input); err == nil {
+			t.Fatalf("BuildApprovalRequestCard(data=%v) error = nil", data)
+		}
+	}
+}

--- a/pkg/cardtmpl/approval_result.go
+++ b/pkg/cardtmpl/approval_result.go
@@ -1,0 +1,56 @@
+package cardtmpl
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardmsg"
+)
+
+type ApprovalResultCard struct {
+	Title   string
+	Status  string
+	Variant string
+	Source  string
+}
+
+// BuildApprovalResultCard renders the shared terminal/outcome visual for
+// config-only approval consumers. It deliberately has no URL or arbitrary
+// callback-authored layout: the consumer supplies display text only and octo
+// owns the complete Adaptive Card shape.
+func BuildApprovalResultCard(result ApprovalResultCard) (json.RawMessage, error) {
+	title := truncateRunes(strings.TrimSpace(result.Title), maxTitleRunes)
+	status := truncateRunes(strings.TrimSpace(result.Status), maxFactRunes)
+	if title == "" || status == "" {
+		return nil, errors.New("cardtmpl: approval result title and status are required")
+	}
+	if utf8.RuneCountInString(result.Source) > maxTitleRunes {
+		return nil, errors.New("cardtmpl: approval result source too long")
+	}
+	octo := map[string]interface{}{}
+	if variant := strings.TrimSpace(result.Variant); variant != "" {
+		octo["variant"] = variant
+	}
+	if source := strings.TrimSpace(result.Source); source != "" {
+		octo["source"] = map[string]interface{}{"label": source}
+	}
+	card := map[string]interface{}{
+		"type":    "AdaptiveCard",
+		"version": cardmsg.CardVersion,
+		"body": []interface{}{
+			map[string]interface{}{"type": "TextBlock", "text": escapeMarkdown(title), "weight": "Bolder", "wrap": true},
+			map[string]interface{}{"type": "TextBlock", "text": escapeMarkdown(status), "isSubtle": true, "spacing": "None", "wrap": true},
+		},
+	}
+	if len(octo) > 0 {
+		card["metadata"] = map[string]interface{}{"octo": octo}
+	}
+	raw, err := json.Marshal(card)
+	if err != nil {
+		return nil, fmt.Errorf("cardtmpl: marshal approval result card: %w", err)
+	}
+	return raw, nil
+}

--- a/pkg/cardtmpl/approval_result_test.go
+++ b/pkg/cardtmpl/approval_result_test.go
@@ -1,0 +1,52 @@
+package cardtmpl
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+func TestBuildApprovalResultCardOwnsShapeAndEscapesDisplayText(t *testing.T) {
+	raw, err := BuildApprovalResultCard(ApprovalResultCard{
+		Title: "**Deploy**", Status: "Request approved", Variant: "approval.approved", Source: "Approval",
+	})
+	if err != nil {
+		t.Fatalf("BuildApprovalResultCard() error = %v", err)
+	}
+	var card map[string]interface{}
+	if err := json.Unmarshal(raw, &card); err != nil {
+		t.Fatalf("decode card: %v", err)
+	}
+	if _, ok := card["actions"]; ok {
+		t.Fatal("approval result card must not contain actions")
+	}
+	metadata, _ := card["metadata"].(map[string]interface{})
+	if _, ok := metadata["webUrl"]; ok {
+		t.Fatal("generic approval result must not trust a consumer URL")
+	}
+	if !strings.Contains(string(raw), `\\*\\*Deploy\\*\\*`) {
+		t.Fatalf("display title was not markdown escaped: %s", raw)
+	}
+}
+
+func TestBuildApprovalResultCardTruncatesTitleAndRejectsMissingStatus(t *testing.T) {
+	raw, err := BuildApprovalResultCard(ApprovalResultCard{Title: strings.Repeat("界", maxTitleRunes+10), Status: "ok"})
+	if err != nil {
+		t.Fatalf("BuildApprovalResultCard(long title) error = %v", err)
+	}
+	var card struct {
+		Body []struct {
+			Text string `json:"text"`
+		} `json:"body"`
+	}
+	if err := json.Unmarshal(raw, &card); err != nil {
+		t.Fatalf("decode card: %v", err)
+	}
+	if len(card.Body) == 0 || utf8.RuneCountInString(card.Body[0].Text) != maxTitleRunes {
+		t.Fatalf("title rune count = %d, want %d", utf8.RuneCountInString(card.Body[0].Text), maxTitleRunes)
+	}
+	if _, err := BuildApprovalResultCard(ApprovalResultCard{Title: "x"}); err == nil {
+		t.Fatal("BuildApprovalResultCard(missing status) error = nil")
+	}
+}

--- a/pkg/cardtmpl/docs_action.go
+++ b/pkg/cardtmpl/docs_action.go
@@ -1,0 +1,87 @@
+package cardtmpl
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"unicode/utf8"
+)
+
+const (
+	DocsApproveActionID = "docs-access-approve"
+	DocsDenyActionID    = "docs-access-deny"
+)
+
+type ApprovalActions struct {
+	ApproveTitle string
+	DenyTitle    string
+}
+
+// BuildDocsAccessRequestCard extends the reviewed docs resource template with
+// the two server-authored Submit actions used by the docs approval pilot. The
+// callback route itself never appears in card bytes; only bounded domain data
+// needed by the registered docs route is embedded.
+func BuildDocsAccessRequestCard(
+	ctx context.Context,
+	webLoginURL string,
+	docID string,
+	requestID string,
+	spaceID string,
+	resource ResourceCard,
+	actions ApprovalActions,
+) (json.RawMessage, error) {
+	if strings.TrimSpace(requestID) == "" || utf8.RuneCountInString(requestID) > 200 {
+		return nil, errors.New("cardtmpl: request ID is invalid")
+	}
+	if strings.TrimSpace(actions.ApproveTitle) == "" || strings.TrimSpace(actions.DenyTitle) == "" ||
+		utf8.RuneCountInString(actions.ApproveTitle) > 80 || utf8.RuneCountInString(actions.DenyTitle) > 80 {
+		return nil, errors.New("cardtmpl: approval action labels are invalid")
+	}
+	document, err := BuildDocsResourceCard(ctx, webLoginURL, docID, spaceID, resource)
+	if err != nil {
+		return nil, err
+	}
+	var card map[string]interface{}
+	if err := json.Unmarshal(document, &card); err != nil {
+		return nil, fmt.Errorf("cardtmpl: decode docs resource card: %w", err)
+	}
+	baseData := map[string]interface{}{
+		"owner":       "docs",
+		"action_type": "access_request.decision",
+		"doc_id":      docID,
+		"request_id":  requestID,
+	}
+	approveData := copyActionData(baseData)
+	approveData["decision"] = "approve"
+	denyData := copyActionData(baseData)
+	denyData["decision"] = "deny"
+	card["actions"] = []interface{}{
+		map[string]interface{}{
+			"type":  "Action.Submit",
+			"id":    DocsApproveActionID,
+			"title": actions.ApproveTitle,
+			"data":  approveData,
+		},
+		map[string]interface{}{
+			"type":  "Action.Submit",
+			"id":    DocsDenyActionID,
+			"title": actions.DenyTitle,
+			"data":  denyData,
+		},
+	}
+	raw, err := json.Marshal(card)
+	if err != nil {
+		return nil, fmt.Errorf("cardtmpl: marshal docs access request card: %w", err)
+	}
+	return raw, nil
+}
+
+func copyActionData(source map[string]interface{}) map[string]interface{} {
+	copy := make(map[string]interface{}, len(source)+1)
+	for key, value := range source {
+		copy[key] = value
+	}
+	return copy
+}

--- a/pkg/cardtmpl/docs_action_test.go
+++ b/pkg/cardtmpl/docs_action_test.go
@@ -1,0 +1,73 @@
+package cardtmpl
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardmsg"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildDocsAccessRequestCardProducesReviewedV2Actions(t *testing.T) {
+	document, err := BuildDocsAccessRequestCard(
+		localizedContext("zh-CN"),
+		"https://im.example.com/login",
+		"doc-1",
+		"request-1",
+		"space-1",
+		exampleDocsResourceCard(),
+		ApprovalActions{ApproveTitle: "允许", DenyTitle: "拒绝"},
+	)
+	require.NoError(t, err)
+
+	var card map[string]interface{}
+	require.NoError(t, json.Unmarshal(document, &card))
+	actions, ok := card["actions"].([]interface{})
+	require.True(t, ok)
+	require.Len(t, actions, 2)
+
+	want := []struct {
+		id       string
+		title    string
+		decision string
+	}{
+		{id: DocsApproveActionID, title: "允许", decision: "approve"},
+		{id: DocsDenyActionID, title: "拒绝", decision: "deny"},
+	}
+	for i, expected := range want {
+		action, ok := actions[i].(map[string]interface{})
+		require.True(t, ok)
+		assert.Equal(t, "Action.Submit", action["type"])
+		assert.Equal(t, expected.id, action["id"])
+		assert.Equal(t, expected.title, action["title"])
+		data, ok := action["data"].(map[string]interface{})
+		require.True(t, ok)
+		assert.Equal(t, "docs", data["owner"])
+		assert.Equal(t, "access_request.decision", data["action_type"])
+		assert.Equal(t, expected.decision, data["decision"])
+		assert.Equal(t, "doc-1", data["doc_id"])
+		assert.Equal(t, "request-1", data["request_id"])
+	}
+
+	envelope := map[string]interface{}{
+		"type":         cardmsg.InteractiveCard.Int(),
+		"card_version": cardmsg.CardVersion,
+		"profile":      cardmsg.ProfileV2,
+		"card":         card,
+	}
+	require.NoError(t, cardmsg.Validate(envelope), "reviewed docs template must pass octo/v2 validation")
+}
+
+func TestBuildDocsAccessRequestCardRejectsMissingRequestID(t *testing.T) {
+	_, err := BuildDocsAccessRequestCard(
+		localizedContext("en-US"),
+		"https://im.example.com/login",
+		"doc-1",
+		"",
+		"space-1",
+		exampleDocsResourceCard(),
+		ApprovalActions{ApproveTitle: "Allow", DenyTitle: "Deny"},
+	)
+	require.Error(t, err)
+}

--- a/tools/card-action-dlq/main.go
+++ b/tools/card-action-dlq/main.go
@@ -1,0 +1,80 @@
+// Command card-action-dlq inspects or manually replays one card-action DLQ
+// event. It intentionally has no bulk/automatic replay mode.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-server/internal/cardactiondispatch"
+	octoredis "github.com/Mininglamp-OSS/octo-server/pkg/redis"
+	"github.com/spf13/viper"
+)
+
+func main() {
+	var configFile, action string
+	var eventID int64
+	flag.StringVar(&configFile, "config", "configs/tsdd.yaml", "octo-server config file")
+	flag.StringVar(&action, "action", "depth", "depth or replay")
+	flag.Int64Var(&eventID, "event-id", 0, "exact event_id to replay")
+	flag.Parse()
+
+	cfg, err := loadConfig(configFile)
+	if err != nil {
+		fatal(err)
+	}
+	client := octoredis.NewInstrumentedClient(cfg)
+	defer client.Close()
+	queue, err := cardactiondispatch.NewRedisQueue(client, cardactiondispatch.QueueConfig{
+		Prefix: "card_action_dispatch", LiveTTL: cfg.Robot.MessageExpire, DLQRetention: 30 * 24 * time.Hour,
+	})
+	if err != nil {
+		fatal(err)
+	}
+
+	switch action {
+	case "depth":
+		depths, err := queue.Depths()
+		if err != nil {
+			fatal(err)
+		}
+		fmt.Printf("ready=%d leased=%d dlq=%d\n", depths.Ready, depths.Leased, depths.DLQ)
+	case "replay":
+		if eventID <= 0 {
+			fatal(fmt.Errorf("-event-id must be a positive exact event id"))
+		}
+		replayed, err := queue.ReplayDLQ(eventID, time.Now())
+		if err != nil {
+			fatal(err)
+		}
+		if !replayed {
+			fatal(fmt.Errorf("event_id %d was not present in the DLQ", eventID))
+		}
+		fmt.Printf("replayed event_id=%d\n", eventID)
+	default:
+		fatal(fmt.Errorf("unsupported -action %q", action))
+	}
+}
+
+func loadConfig(path string) (*config.Config, error) {
+	vp := viper.New()
+	vp.SetConfigFile(path)
+	if err := vp.ReadInConfig(); err != nil {
+		return nil, fmt.Errorf("read config %s: %w", path, err)
+	}
+	vp.SetEnvPrefix("TS")
+	vp.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
+	vp.AutomaticEnv()
+	cfg := config.New()
+	cfg.ConfigureWithViper(vp)
+	return cfg, nil
+}
+
+func fatal(err error) {
+	fmt.Fprintln(os.Stderr, "card-action-dlq:", err)
+	os.Exit(1)
+}


### PR DESCRIPTION
## Summary

Add a generic, server-owned approval-card lifecycle for first-party services. A standard consumer configures an owner/action route with `notify_token_env`, sends a structured `approval_card`, and implements one signed decide endpoint; octo-server owns the interactive card, reliable callback delivery, terminal mutation, and requester notification. Docs access approval is the first specialized-template pilot. External and third-party bots keep the existing pull-based Bot event flow.

## Related Issue

Follow-up to #584. No issue is closed by this PR.

## Linked Spec

`.octospec/tasks/card-action-callback-dispatch/brief.md`

## Changes

- Route registered first-party card actions by authoritative `(sender_uid, owner, action_type)` while preserving the existing external Bot queue path.
- Add a static HTTPS callback registry, HMAC-signed typed delivery, Redis ready/leased/DLQ state machine, token-bound finalization heartbeats, attempt-neutral capacity deferral, bounded retries, timeouts, metrics, and a manual DLQ replay command.
- Finalize cards inside the trusted mutation boundary and notify the requester after an authoritative consumer decision.
- Add a standard approval lifecycle for new owners: a route may bind `notify_token_env`, which dynamically installs an owner-bound `octo/v2` producer and authorizes structured `approval_card` requests. Callers cannot choose owner/sender, submit callback URLs/card JSON, or invoke another owner's/callback-only action.
- Route typed results through a finalizer registry: docs keeps its specialized resource-card rendering while every other registered owner gets the server-owned standard terminal card and requester outcome.
- Add the docs approve/deny card pilot, capability-scoped notify token, outcome cards, feature flag, and localized templates.
- Cover DM finalization with the real WuKongIM lookup and production card mutator so terminal state is written to the approving user's stored DM channel.
- Add a consumer integration guide with the complete request/response contract, canonical HMAC, idempotency/CAS requirements, retry semantics, and a TypeScript/Express verification example. Callback `event_id` is a decimal JSON string so JavaScript consumers preserve the full `int64` identity.

## Testing

- [x] Unit tests added/updated
- [x] Manually verified
- `go test -race -cover ./internal/cardactiondispatch -count=1` (81.8% statement coverage)
- `go test -race ./internal/carddispatch ./modules/bot_api ./modules/notify ./pkg/cardtmpl . -count=1`
- `GIN_MODE=release go test -race -tags integration ./internal/cardactiondispatch -run '^(TestCardActionCallbackOrchestrationWithMockDocs|TestCardActionCallbackOrchestrationUsesStandardFinalizerForNewOwner)$' -count=1`
- `GIN_MODE=release go test -race -tags integration ./modules/message -run '^TestCardActionSenderBoundCallbackRouting$' -count=1`
- `OCTO_MASTER_KEY=<test-key> GIN_MODE=release go test -tags pilote2e ./pilote2e -run '^(TestDocsNotify_HTTPEndpointDeliversCardToWuKongIM|TestSummaryAndDocsNotify_NoRegression)$' -count=1`
- `go vet -tags integration ./internal/cardactiondispatch/... ./modules/notify/... ./pkg/cardtmpl/...`
- `make i18n-extract-check && make i18n-lint`
- Every package returned by `go list ./...` passed with `go test <package> -count=1` after recreating the local MySQL test database and flushing Redis before each package; test configuration included `OCTO_MASTER_KEY`.
- GitHub CI was re-triggered for the current three-commit head `859b8dfe`; local verification above is complete.

## COMPREHENSION

1. **What does this change actually do to the load-bearing path?**

   A generic owner first calls the existing internal notify API with its route-bound token and structured approval fields. octo-server authors the v2 card and reserved action metadata. After existing card-action validation and idempotent claim, octo-server resolves the stored sender plus reviewed action metadata. Registered first-party actions enter the internal callback queue; unregistered third-party senders continue to the existing Bot pull queue. Successful typed decisions are rendered and persisted by octo-server, then the requester is notified.

2. **What could break because of it (dependents + failure mode)?**

   A bad route, token/secret, timeout, or unavailable consumer can reject startup, block new approval-card ingress, delay first-party action completion, or eventually move an event to DLQ. Incorrect DM peer selection can persist terminal state against the wrong channel. Callback delivery is at-least-once and consumers must deduplicate by `event_id`; terminal card mutation is CAS-idempotent, while applicant notification may be repeated at the documented crash boundary. Configuration is fail-closed and exact-allowlisted, notify tokens are owner/action scoped and distinct from callback secrets, slow finalization renews only its matching lease token, and saturated routes are token-bound deferred without consuming attempts or blocking other routes. `MaxInFlight` is per process, so aggregate callback concurrency scales with replica count. External Bot delivery remains unchanged.

3. **How do you know it works (specific test/repro/trace)?**

   Unit tests cover registry safety, route-bound notify capabilities, generic approval ingress/template ownership, canonical signatures, cross-language event IDs, typed response bounds, queue lease/renew/defer/retry/DLQ/replay, route-saturation fairness, shutdown, mutation CAS, specialized/fallback finalizers, and requester notification targets. Integration tests cover all routing branches; execute `card/action -> MySQL authority lookup -> Redis queue -> TLS/HMAC mock docs endpoint -> production mutator -> applicant notification -> ACK`; and run a second owner through signed callback, standard finalization, notification, and ACK.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] PR description is in English
- [x] Added tests for my changes
- [x] Updated documentation
- [x] Followed commit message conventions (Conventional Commits)
