### PR TITLE
fix(sidebar): gate self-created thread exemption on active status

### DIFF
--- a/modules/message/api_sidebar.go
+++ b/modules/message/api_sidebar.go
@@ -505,7 +505,7 @@ func (sb *Sidebar) Sync(c *wkhttp.Context) {
 				selfCreatedThreads[key] = struct{}{}
 			}
 		}
-		items = mergeThreadEntries(items, threadExtRows, lastMsgAtMap, categorySetting, unfollowedGroups, groupSpaceMap, externalGroupMap, defaultSpaceID, selfCreatedThreads)
+		items = mergeThreadEntries(items, threadExtRows, lastMsgAtMap, categorySetting, unfollowedGroups, groupSpaceMap, externalGroupMap, defaultSpaceID, selfCreatedThreads, threadStatusMap)
 
 		// GH octo-server#310：把 thread 生命周期状态回填到 thread 条目。statusMap
 		// 来自 loadThreadLastMsgAt（复用 QueryActiveByGroupShortIDs 已 SELECT 的
@@ -1218,10 +1218,11 @@ func buildRecentItems(
 // unfollowed (or whose category was removed) would still surface in the follow
 // tab, exposing stale state.
 //
-// issue #557 — 例外：创建者自建的子区（selfCreatedThreads 命中）必须始终渲染，
-// 即使父群从未关注/未分类/被显式取关。识别口径是 thread.creator_uid==loginUID
-// （硬事实，来自 thread 表，不可能命中别人的子区），因此只对创建者本人放宽，
-// 对 fanout / 关注者行零影响，Blocking #4 的保护原样保留。为何安全：
+// issue #557 — 例外：创建者自建的**active**子区（selfCreatedThreads 命中且
+// status==ThreadStatusActive）必须始终渲染，即使父群从未关注/未分类/被显式取关。
+// 识别口径是 thread.creator_uid==loginUID（硬事实，来自 thread 表，不可能命中别人
+// 的子区），因此只对创建者本人放宽，对 fanout / 关注者行零影响，Blocking #4 的保护
+// 原样保留。为何安全：
 //  1. 豁免键严格等于 creator_uid==loginUID，别人的子区永不匹配；
 //  2. 豁免只跳过「分类/取关」前置，space 过滤（2a.5）与父群成员过滤（2a.6）
 //     在本函数之前执行且不受影响——被移出父群/跨 Space 的创建者行早已被剔除；
@@ -1229,6 +1230,11 @@ func buildRecentItems(
 //     auto_follow=1 AND group_unfollowed=0 的成员——「thread 行存在但父群未关注/
 //     未分类」几乎只能是创建者补行，豁免不会复活任何本应被删的 fanout 行；
 //  4. alive（lastMsgAtMap）检查不变，已删除子区仍被丢弃。
+//
+// XIN-1135（块B）— 豁免加 active 守卫：已归档(status=2)的自建子区不再享受 #557 豁免，
+// 回落到常规 parent-follow 谓词，避免归档子区在每次 /sidebar/sync 被无条件重新 emit
+// 进关注 Tab。对齐 /conversation/sync 的 server 端 active 语义。status 复用
+// threadStatusMap，零额外查询。见 selfCreated 分支内注释。
 //
 // PR review follow-up：ext 行存在但目标 thread 已被删除（cleanup 延迟 / 失败）的
 // 情况，loadThreadLastMsgAt 不会把它放进 lastMsgAtMap。本函数据此 skip，
@@ -1253,6 +1259,10 @@ func mergeThreadEntries(
 	// （issue #557）。命中时跳过父群未关注/未分类前置丢弃，但分类字段仍安全取值
 	// （父群无分类时 catID=nil，落"未分类"桶）。
 	selfCreatedThreads map[string]struct{},
+	// threadStatusMap 的键同为 ext.TargetID（"{groupNo}____{shortID}"），值为 thread
+	// 生命周期 status（来自 loadThreadLastMsgAt 复用的 QueryActiveByGroupShortIDs，
+	// 零额外查询）。用于给 #557 自建豁免加 active 守卫：仅 active 自建子区放宽 emit。
+	threadStatusMap map[string]int,
 ) []*SidebarItem {
 	if len(threadExtRows) == 0 {
 		return existing
@@ -1282,8 +1292,18 @@ func mergeThreadEntries(
 			continue
 		}
 		_, selfCreated := selfCreatedThreads[ext.TargetID]
+		// XIN-1135 (块B) — 自建豁免加 server 端 active 守卫：只有 active 的自建子区
+		// 才放宽父群前置丢弃。已归档(status=2)的自建子区必须回落到常规 parent-follow
+		// 谓词，否则它会在每次 /sidebar/sync 被无条件重新 emit 进关注 Tab（线上「归档
+		// 子区刷新后重现」的直接成因，根因 #565 selfCreated 豁免缺 status 守卫）。对齐
+		// /conversation/sync 的 QueryActiveShortIDs status=active 语义。status 复用
+		// threadStatusMap（loadThreadLastMsgAt 已带回），零额外查询；alive 检查已保证
+		// 存活行必在 statusMap 中，故 != ThreadStatusActive 精确命中 archived。
+		if selfCreated && threadStatusMap[ext.TargetID] != thread.ThreadStatusActive {
+			selfCreated = false
+		}
 		// Apply parent-follow predicate (mirrors buildFollowItems thread branch),
-		// except for the creator's own thread (issue #557).
+		// except for the creator's own ACTIVE thread (issue #557 + XIN-1135 guard).
 		cs, hasCategory := categorySetting[groupNo]
 		if !selfCreated {
 			if !hasCategory || cs.CategoryID == nil {

--- a/modules/message/api_sidebar_integration_test.go
+++ b/modules/message/api_sidebar_integration_test.go
@@ -148,7 +148,7 @@ func TestIntegration_Sidebar_FollowTab_BasicSmoke(t *testing.T) {
 	// 5. Run the same pure-function pipeline as Sidebar.Sync follow branch.
 	items := buildFollowItems(stubConvs, categorySetting, unfollowedGroups, followedDMs, threadExtMap, nil, nil, nil, nil, "")
 	// mergeThreadEntries: thread is already in IM result, so no new item added.
-	items = mergeThreadEntries(items, threadExtRows, map[string]*time.Time{}, categorySetting, unfollowedGroups, nil, nil, "", nil)
+	items = mergeThreadEntries(items, threadExtRows, map[string]*time.Time{}, categorySetting, unfollowedGroups, nil, nil, "", nil, nil)
 	sortFollowItems(items)
 
 	// 6. Assert exactly 3 items with correct target_type.
@@ -319,7 +319,7 @@ func TestIntegration_Sidebar_MergeThreadEntries_AddsDBOnlyThreads(t *testing.T) 
 		threadInIM:   &alive,
 		threadDBOnly: &alive,
 	}
-	items = mergeThreadEntries(items, threadExtRows, lastMsgAtMap, categorySetting, map[string]struct{}{}, nil, nil, "", nil)
+	items = mergeThreadEntries(items, threadExtRows, lastMsgAtMap, categorySetting, map[string]struct{}{}, nil, nil, "", nil, nil)
 	require.Len(t, items, 2, "mergeThreadEntries must add the DB-only thread")
 
 	// Both thread IDs must be present.

--- a/modules/message/api_sidebar_status_test.go
+++ b/modules/message/api_sidebar_status_test.go
@@ -183,7 +183,7 @@ func TestSidebar_FollowTab_BackfillsStatus(t *testing.T) {
 
 	lastMsgAt, statusMap, _, err := sb.loadThreadLastMsgAt(threadExtRows)
 	require.NoError(t, err)
-	items = mergeThreadEntries(items, threadExtRows, lastMsgAt, categorySetting, nil, nil, nil, "", nil)
+	items = mergeThreadEntries(items, threadExtRows, lastMsgAt, categorySetting, nil, nil, nil, "", nil, statusMap)
 	backfillThreadStatus(items, statusMap)
 
 	byID := map[string]*SidebarItem{}

--- a/modules/message/api_sidebar_test.go
+++ b/modules/message/api_sidebar_test.go
@@ -427,6 +427,28 @@ func aliveThread(channelID string, lastMsgAt *time.Time) map[string]*time.Time {
 	return map[string]*time.Time{channelID: lastMsgAt}
 }
 
+// activeStatus builds a threadStatusMap marking each channel ID as an ACTIVE
+// thread (thread.ThreadStatusActive). The issue #557 self-created exemption only
+// applies to active threads (XIN-1135 guard); archived self-created threads fall
+// back to the parent-follow predicate.
+func activeStatus(channelIDs ...string) map[string]int {
+	m := make(map[string]int, len(channelIDs))
+	for _, id := range channelIDs {
+		m[id] = thread.ThreadStatusActive
+	}
+	return m
+}
+
+// archivedStatus builds a threadStatusMap marking each channel ID as an ARCHIVED
+// thread (thread.ThreadStatusArchived).
+func archivedStatus(channelIDs ...string) map[string]int {
+	m := make(map[string]int, len(channelIDs))
+	for _, id := range channelIDs {
+		m[id] = thread.ThreadStatusArchived
+	}
+	return m
+}
+
 func TestMergeThreadEntries_AddsNewEntry(t *testing.T) {
 	existing := []*SidebarItem{
 		{TargetID: "g1____th1", TargetType: int(common.ChannelTypeCommunityTopic)},
@@ -444,7 +466,7 @@ func TestMergeThreadEntries_AddsNewEntry(t *testing.T) {
 	}
 
 	cat, unfollowed := followedG1()
-	result := mergeThreadEntries(existing, threadExtRows, lastMsgAtMap, cat, unfollowed, nil, nil, "", nil)
+	result := mergeThreadEntries(existing, threadExtRows, lastMsgAtMap, cat, unfollowed, nil, nil, "", nil, nil)
 	require.Len(t, result, 2)
 	ids := []string{result[0].TargetID, result[1].TargetID}
 	assert.Contains(t, ids, th2ChannelID)
@@ -459,14 +481,14 @@ func TestMergeThreadEntries_NoDuplicateIfAlreadyPresent(t *testing.T) {
 	}
 	cat, unfollowed := followedG1()
 	// nil map is fine here: presentIDs short-circuits before the alive check.
-	result := mergeThreadEntries(existing, threadExtRows, nil, cat, unfollowed, nil, nil, "", nil)
+	result := mergeThreadEntries(existing, threadExtRows, nil, cat, unfollowed, nil, nil, "", nil, nil)
 	assert.Len(t, result, 1) // no duplicate
 }
 
 func TestMergeThreadEntries_EmptyExt(t *testing.T) {
 	existing := []*SidebarItem{}
 	cat, unfollowed := followedG1()
-	result := mergeThreadEntries(existing, nil, nil, cat, unfollowed, nil, nil, "", nil)
+	result := mergeThreadEntries(existing, nil, nil, cat, unfollowed, nil, nil, "", nil, nil)
 	assert.Len(t, result, 0)
 }
 
@@ -479,7 +501,7 @@ func TestMergeThreadEntries_SkipWhenThreadDeleted(t *testing.T) {
 	}
 	cat, unfollowed := followedG1()
 	// lastMsgAtMap 为空（thread 已被删除，cleanup 还没清理 ext 行）
-	result := mergeThreadEntries(existing, threadExtRows, map[string]*time.Time{}, cat, unfollowed, nil, nil, "", nil)
+	result := mergeThreadEntries(existing, threadExtRows, map[string]*time.Time{}, cat, unfollowed, nil, nil, "", nil, nil)
 	assert.Len(t, result, 0,
 		"thread 已删除时 ext 行必须被 skip，避免 ghost 条目出现在 follow tab")
 }
@@ -493,7 +515,7 @@ func TestMergeThreadEntries_AliveThreadEmitsTimestamp(t *testing.T) {
 		{TargetID: "g1____alive", FollowSort: 3},
 	}
 	cat, unfollowed := followedG1()
-	result := mergeThreadEntries(existing, threadExtRows, aliveThread("g1____alive", &now), cat, unfollowed, nil, nil, "", nil)
+	result := mergeThreadEntries(existing, threadExtRows, aliveThread("g1____alive", &now), cat, unfollowed, nil, nil, "", nil, nil)
 	require.Len(t, result, 1)
 	assert.Equal(t, now.Unix(), result[0].Timestamp,
 		"alive thread 的 timestamp 必须从 lastMsgAtMap 正确读取")
@@ -509,7 +531,7 @@ func TestMergeThreadEntries_AliveThreadNilLastMsgAt(t *testing.T) {
 	}
 	cat, unfollowed := followedG1()
 	// 键存在但值为 nil = thread 活跃但还没消息
-	result := mergeThreadEntries(existing, threadExtRows, aliveThread("g1____fresh", nil), cat, unfollowed, nil, nil, "", nil)
+	result := mergeThreadEntries(existing, threadExtRows, aliveThread("g1____fresh", nil), cat, unfollowed, nil, nil, "", nil, nil)
 	require.Len(t, result, 1, "活跃 thread 即便 last_message_at=NULL 也必须 emit")
 	assert.Equal(t, int64(0), result[0].Timestamp)
 }
@@ -525,7 +547,7 @@ func TestMergeThreadEntries_SkipWhenParentUnfollowed(t *testing.T) {
 	cat, _ := followedG1()
 	unfollowed := map[string]struct{}{"g1": {}}
 
-	result := mergeThreadEntries(existing, threadExtRows, aliveThread("g1____th-orphan", nil), cat, unfollowed, nil, nil, "", nil)
+	result := mergeThreadEntries(existing, threadExtRows, aliveThread("g1____th-orphan", nil), cat, unfollowed, nil, nil, "", nil, nil)
 	assert.Len(t, result, 0,
 		"thread whose parent group is unfollowed must NOT be merged into follow tab")
 }
@@ -539,7 +561,7 @@ func TestMergeThreadEntries_SkipWhenParentHasNoCategory(t *testing.T) {
 	}
 	cat, unfollowed := followedG1() // only g1 is in the follow set, g-noCat is not
 
-	result := mergeThreadEntries(existing, threadExtRows, aliveThread("g-noCat____th-orphan", nil), cat, unfollowed, nil, nil, "", nil)
+	result := mergeThreadEntries(existing, threadExtRows, aliveThread("g-noCat____th-orphan", nil), cat, unfollowed, nil, nil, "", nil, nil)
 	assert.Len(t, result, 0,
 		"thread whose parent group lacks a category (not in follow set) must NOT be merged")
 }
@@ -556,7 +578,7 @@ func TestMergeThreadEntries_SelfCreated_UncategorizedParent_Rendered(t *testing.
 	cat, unfollowed := followedG1() // g-noCat 不在 follow set
 	selfCreated := map[string]struct{}{cid: {}}
 
-	result := mergeThreadEntries(existing, threadExtRows, aliveThread(cid, nil), cat, unfollowed, nil, nil, "", selfCreated)
+	result := mergeThreadEntries(existing, threadExtRows, aliveThread(cid, nil), cat, unfollowed, nil, nil, "", selfCreated, activeStatus(cid))
 	require.Len(t, result, 1, "创建者自建子区即使父群未分类也必须渲染（issue #557）")
 	assert.Equal(t, cid, result[0].TargetID)
 	assert.True(t, result[0].IsFollowed)
@@ -575,7 +597,7 @@ func TestMergeThreadEntries_SelfCreated_UnfollowedParent_Rendered(t *testing.T) 
 	unfollowed := map[string]struct{}{"g1": {}} // 父群显式取关
 	selfCreated := map[string]struct{}{cid: {}}
 
-	result := mergeThreadEntries(existing, threadExtRows, aliveThread(cid, nil), cat, unfollowed, nil, nil, "", selfCreated)
+	result := mergeThreadEntries(existing, threadExtRows, aliveThread(cid, nil), cat, unfollowed, nil, nil, "", selfCreated, activeStatus(cid))
 	require.Len(t, result, 1, "父群被取关也不应隐藏创建者自建子区（issue #557）")
 	assert.Equal(t, cid, result[0].TargetID)
 	// 父群 g1 有分类：自建子区仍继承父群分类（豁免只跳过丢弃前置，不改分类归属）。
@@ -594,7 +616,7 @@ func TestMergeThreadEntries_NonSelfCreated_UncategorizedParent_Dropped(t *testin
 	// selfCreated 不含 cid（该子区非本人创建）
 	selfCreated := map[string]struct{}{"g-noCat____someone-elses": {}}
 
-	result := mergeThreadEntries(existing, threadExtRows, aliveThread(cid, nil), cat, unfollowed, nil, nil, "", selfCreated)
+	result := mergeThreadEntries(existing, threadExtRows, aliveThread(cid, nil), cat, unfollowed, nil, nil, "", selfCreated, nil)
 	assert.Len(t, result, 0,
 		"非创建者子区不被豁免：父群未分类必须丢弃（防误放）")
 }
@@ -608,9 +630,75 @@ func TestMergeThreadEntries_SelfCreated_DeletedThread_StillDropped(t *testing.T)
 	selfCreated := map[string]struct{}{cid: {}}
 
 	// lastMsgAtMap 为空 → thread 已删除 / 不存在
-	result := mergeThreadEntries(existing, threadExtRows, map[string]*time.Time{}, cat, unfollowed, nil, nil, "", selfCreated)
+	result := mergeThreadEntries(existing, threadExtRows, map[string]*time.Time{}, cat, unfollowed, nil, nil, "", selfCreated, nil)
 	assert.Len(t, result, 0,
 		"创建者豁免不改活跃性判定：已删除子区仍必须丢弃")
+}
+
+// XIN-1135 (块B) — 自建豁免加 server 端 active 守卫。
+// 归档(status=2)的自建子区不再无条件 emit：豁免回落到常规 parent-follow 谓词。
+// 父群未分类/未关注时归档自建子区被丢弃（修复「归档子区刷新后重现」）。
+// 本断言在修复前为红（archived selfCreated 仍 emit），加守卫后转绿。
+func TestMergeThreadEntries_SelfCreated_Archived_UncategorizedParent_Dropped(t *testing.T) {
+	existing := []*SidebarItem{}
+	cid := "g-noCat____th-self-archived"
+	threadExtRows := []*convext.Model{{TargetID: cid, FollowSort: 7}}
+	cat, unfollowed := followedG1() // g-noCat 不在 follow set
+	selfCreated := map[string]struct{}{cid: {}}
+
+	// thread 仍 alive（archived != deleted），但 status=archived。
+	result := mergeThreadEntries(existing, threadExtRows, aliveThread(cid, nil), cat, unfollowed, nil, nil, "", selfCreated, archivedStatus(cid))
+	assert.Len(t, result, 0,
+		"归档自建子区不再享受 #557 豁免：父群未分类必须丢弃（XIN-1135 块B）")
+}
+
+// XIN-1135 (块B) 配套 — 父群被显式取关时，归档自建子区同样被丢弃（回落到
+// parent-follow 谓词，取关父群 → drop）。
+func TestMergeThreadEntries_SelfCreated_Archived_UnfollowedParent_Dropped(t *testing.T) {
+	existing := []*SidebarItem{}
+	cid := "g1____th-self-archived"
+	threadExtRows := []*convext.Model{{TargetID: cid, FollowSort: 1}}
+	cat, _ := followedG1()
+	unfollowed := map[string]struct{}{"g1": {}} // 父群显式取关
+	selfCreated := map[string]struct{}{cid: {}}
+
+	result := mergeThreadEntries(existing, threadExtRows, aliveThread(cid, nil), cat, unfollowed, nil, nil, "", selfCreated, archivedStatus(cid))
+	assert.Len(t, result, 0,
+		"归档自建子区在父群被取关时也被丢弃（XIN-1135 块B）")
+}
+
+// XIN-1135 固化 #557 — 新建(active 且 last_message_at=NULL)自建子区仍必须 emit，
+// 即使父群未分类。守卫只拦 archived，active 路径原样保留。
+func TestMergeThreadEntries_SelfCreated_ActiveFresh_UncategorizedParent_Rendered(t *testing.T) {
+	existing := []*SidebarItem{}
+	cid := "g-noCat____th-self-fresh"
+	threadExtRows := []*convext.Model{{TargetID: cid, FollowSort: 9}}
+	cat, unfollowed := followedG1() // g-noCat 不在 follow set
+	selfCreated := map[string]struct{}{cid: {}}
+
+	// active 且刚创建（last_message_at=NULL → ts=0）：#557 场景「创建者看得到自建 active 子区」。
+	result := mergeThreadEntries(existing, threadExtRows, aliveThread(cid, nil), cat, unfollowed, nil, nil, "", selfCreated, activeStatus(cid))
+	require.Len(t, result, 1, "新建 active 自建子区必须 emit（固化 #557，XIN-1135 守卫只拦 archived）")
+	assert.Equal(t, cid, result[0].TargetID)
+	assert.True(t, result[0].IsFollowed)
+	assert.Nil(t, result[0].CategoryID, "父群未分类 → 落未分类桶")
+	assert.Equal(t, int64(0), result[0].Timestamp, "新建未发消息 → ts=0")
+}
+
+// XIN-1135 — status 缺失（statusMap 无此键，罕见的 fail-open 兜底）时，自建豁免
+// 不生效（视同非 active），回落到 parent-follow 谓词。生产路径下 alive 保证 status
+// 必在 map 中，此断言仅锁定防御性语义。
+func TestMergeThreadEntries_SelfCreated_StatusMissing_NotExempted(t *testing.T) {
+	existing := []*SidebarItem{}
+	cid := "g-noCat____th-self-nostatus"
+	threadExtRows := []*convext.Model{{TargetID: cid, FollowSort: 1}}
+	cat, unfollowed := followedG1() // g-noCat 不在 follow set
+	selfCreated := map[string]struct{}{cid: {}}
+
+	// alive 但 statusMap 为空 → threadStatusMap[cid]==0 != active → 不豁免 → drop。
+	result := mergeThreadEntries(existing, threadExtRows, aliveThread(cid, nil), cat, unfollowed, nil, nil, "", selfCreated, map[string]int{})
+	assert.Len(t, result, 0,
+		"status 缺失时自建豁免不生效（默认非 active），回落 parent-follow 谓词丢弃")
 }
 
 // PR review (Round 3) Blocking #4 — malformed thread channel ID (no separator)
@@ -622,7 +710,7 @@ func TestMergeThreadEntries_SkipMalformedChannelID(t *testing.T) {
 	}
 	cat, unfollowed := followedG1()
 
-	result := mergeThreadEntries(existing, threadExtRows, nil, cat, unfollowed, nil, nil, "", nil)
+	result := mergeThreadEntries(existing, threadExtRows, nil, cat, unfollowed, nil, nil, "", nil, nil)
 	assert.Len(t, result, 0,
 		"malformed thread channel id (no separator) must be skipped")
 }

--- a/modules/message/issue557_creator_thread_e2e_test.go
+++ b/modules/message/issue557_creator_thread_e2e_test.go
@@ -262,7 +262,7 @@ func issue557FollowTabThreadItems(t *testing.T, sb *Sidebar, loginUID string, un
 	rows, err = sb.filterThreadExtsByParentMembership(rows, loginUID)
 	require.NoError(t, err, "filterThreadExtsByParentMembership")
 
-	lastMsgAt, _, creatorMap, err := sb.loadThreadLastMsgAt(rows)
+	lastMsgAt, statusMap, creatorMap, err := sb.loadThreadLastMsgAt(rows)
 	require.NoError(t, err, "loadThreadLastMsgAt")
 
 	selfCreated := make(map[string]struct{})
@@ -278,6 +278,7 @@ func issue557FollowTabThreadItems(t *testing.T, sb *Sidebar, loginUID string, un
 		unfollowedGroups,
 		map[string]string{}, map[string]string{}, "",
 		selfCreated,
+		statusMap,
 	)
 }
 

--- a/modules/message/round2_findings_test.go
+++ b/modules/message/round2_findings_test.go
@@ -85,7 +85,7 @@ func TestSpaceID_Round2_Finding2_DBOnlyThreadInheritsParentSpace(t *testing.T) {
 	}
 
 	items := mergeThreadEntries(nil, extRows, aliveThread("g_db_parent____th9", nil),
-		categorySetting, nil, groupSpaceMap, nil, "", nil)
+		categorySetting, nil, groupSpaceMap, nil, "", nil, nil)
 
 	require.Len(t, items, 1)
 	assert.Equal(t, "spaceX", items[0].SpaceID,
@@ -182,7 +182,7 @@ func TestSpaceID_Round2_Finding3_MergeThreadEntries_ExternalGroupMySource(t *tes
 
 	result := mergeThreadEntries(nil, threadExtRows,
 		aliveThread("g_external____alive", nil),
-		categorySetting, nil, groupSpaceMap, externalGroupMap, "", nil)
+		categorySetting, nil, groupSpaceMap, externalGroupMap, "", nil, nil)
 
 	require.Len(t, result, 1)
 	assert.Equal(t, "spaceB", result[0].SpaceID)

--- a/modules/message/round3_findings_test.go
+++ b/modules/message/round3_findings_test.go
@@ -211,7 +211,7 @@ func TestSpaceID_Round3_Finding2_Sidebar_EmptySourceFallback(t *testing.T) {
 		}
 		result := mergeThreadEntries(nil, extRows,
 			aliveThread("g_legacy_ext____alive", nil),
-			categorySetting, nil, groupSpaceMap, externalGroupMap, defaultSpaceID, nil)
+			categorySetting, nil, groupSpaceMap, externalGroupMap, defaultSpaceID, nil, nil)
 		require.Len(t, result, 1)
 		assert.Equal(t, "spaceDefault", result[0].MySourceSpaceID,
 			"DB-only thread: 父群 source='' 兜底到 defaultSpaceID")

--- a/modules/message/sidebar_space_id_test.go
+++ b/modules/message/sidebar_space_id_test.go
@@ -102,7 +102,7 @@ func TestSpaceID_MergeThreadEntries_FillsParentSpaceID(t *testing.T) {
 	}
 	groupSpaceMap := map[string]string{"g1": "spaceC"}
 
-	result := mergeThreadEntries(nil, threadExtRows, aliveThread("g1____alive", nil), categorySetting, nil, groupSpaceMap, nil, "", nil)
+	result := mergeThreadEntries(nil, threadExtRows, aliveThread("g1____alive", nil), categorySetting, nil, groupSpaceMap, nil, "", nil, nil)
 
 	if assert.Len(t, result, 1) {
 		assert.Equal(t, "g1____alive", result[0].TargetID)


### PR DESCRIPTION
## Summary

`/sidebar/sync` (follow tab) unconditionally re-emitted a creator's own **archived** thread on every sync. `mergeThreadEntries` exempts self-created threads from the parent-follow predicate (#557), but that exemption did not check the thread's lifecycle status, so an archived (`status=2`) self-created thread whose parent group is unfollowed/uncategorized kept reappearing in the follow tab after refresh.

Combined with `QueryActiveByGroupShortIDs` returning `status != deleted` (i.e. archived rows are still fetched), the creator saw a thread that should have been archived on every follow-tab refresh.

## Fix

Gate the #557 self-created exemption on `thread.ThreadStatusActive`:

- Only **active** self-created threads bypass the parent-follow predicate.
- Archived self-created threads fall back to the normal parent-follow predicate and are dropped when the parent group is not in the follow set.

This aligns `/sidebar/sync` with the server-side active guard `/conversation/sync` already applies (`QueryActiveShortIDs`, `status = active`).

Status is reused from the map `loadThreadLastMsgAt` already returns (`QueryActiveByGroupShortIDs` already `SELECT`s `status`), so **no extra query** is issued.

**Root cause:** the #565 self-created ext-row exemption lacked a `status` guard.

## Scope

- Touches only `modules/message/api_sidebar.go` (`mergeThreadEntries` selfCreated branch) + the corresponding tests.
- Does **not** change the auto-archive threshold or any backfill.

## #557 preserved

A freshly created (active, `last_message_at` NULL) self-created thread still renders in the follow tab even when the parent group is uncategorized. Locked with a dedicated test.

## Tests

New pure unit tests in `api_sidebar_test.go`:

- `TestMergeThreadEntries_SelfCreated_Archived_UncategorizedParent_Dropped` — archived self-created + uncategorized parent → not emitted (red before the guard, green after).
- `TestMergeThreadEntries_SelfCreated_Archived_UnfollowedParent_Dropped` — archived self-created + unfollowed parent → not emitted.
- `TestMergeThreadEntries_SelfCreated_ActiveFresh_UncategorizedParent_Rendered` — active/newly-created self-created still emitted (locks #557).
- `TestMergeThreadEntries_SelfCreated_StatusMissing_NotExempted` — defensive: missing status defaults to non-active.

The two archived assertions were verified to fail on the pre-fix code (the archived thread still emitted) and pass after the guard. Existing #557 and DB-backed status tests updated for the new signature and pass. `go build ./...` and `go test ./modules/message/` are green.

Related: #557 (creator's own thread ext row), #565 (self-created exemption without a status guard).
