### PR TITLE
feat(webhook): add /octo incoming-webhook suffix as multica alias

### DIFF
--- a/modules/incomingwebhook/adapter.go
+++ b/modules/incomingwebhook/adapter.go
@@ -74,7 +74,10 @@ var (
 	// 的固定 JSON envelope）。multica envelope 比 GitHub 事件紧凑（不嵌入
 	// repository 对象），8 KiB 足够，沿用 native 的 bodyLimit。
 	multicaAdapter = pushAdapter{name: adapterMultica, parse: parseMulticaPush, bodyLimit: maxBytes}
-	gitlabAdapter  = pushAdapter{
+	// octoAdapter 是 multica 的对外别名：解析/渲染完全复用 parseMulticaPush，仅 name 不同，
+	// 使经 /octo 推送的投递审计（deliveries.adapter）记为 "octo"，不在审计层暴露 multica 名。
+	octoAdapter   = pushAdapter{name: adapterOcto, parse: parseMulticaPush, bodyLimit: maxBytes}
+	gitlabAdapter = pushAdapter{
 		name:      adapterGitLab,
 		parse:     parseGitLabPush,
 		bodyLimit: gitlabMaxBytes,

--- a/modules/incomingwebhook/adapter_catalog.go
+++ b/modules/incomingwebhook/adapter_catalog.go
@@ -45,7 +45,8 @@ var publicAdapterCatalog = []publicAdapterDef{
 	{Key: adapterGitHub, Suffix: adapterGitHub, ContentType: "application/json", Auth: adapterAuthResp{Type: "url_token"}, ShowExample: true},
 	{Key: adapterGitLab, Suffix: adapterGitLab, ContentType: "application/json", Auth: adapterAuthResp{Type: "url_token_and_header", Header: "X-Gitlab-Token", ValueSource: "token"}, ShowExample: true},
 	{Key: adapterFeishu, Suffix: adapterFeishu, ContentType: "application/json", Auth: adapterAuthResp{Type: "url_token"}, ShowExample: true},
-	{Key: adapterMultica, Suffix: adapterMultica, ContentType: "application/json", Auth: adapterAuthResp{Type: "url_token"}, ShowExample: true},
+	{Key: adapterMultica, Suffix: adapterMultica, ContentType: "application/json", Auth: adapterAuthResp{Type: "url_token"}, ShowExample: false},
+	{Key: adapterOcto, Suffix: adapterOcto, ContentType: "application/json", Auth: adapterAuthResp{Type: "url_token"}, ShowExample: true},
 	{Key: adapterWeCom, Suffix: adapterWeCom, ContentType: "application/json", Auth: adapterAuthResp{Type: "url_token"}, ShowExample: true},
 }
 

--- a/modules/incomingwebhook/adapter_catalog_test.go
+++ b/modules/incomingwebhook/adapter_catalog_test.go
@@ -20,11 +20,14 @@ func TestAdapterExamplesRenderSupportedLanguages(t *testing.T) {
 				keys = append(keys, ex.Key)
 				assert.NotEmpty(t, ex.Title, "title for %s/%s", lang, ex.Key)
 				assert.NotEmpty(t, ex.Description, "description for %s/%s", lang, ex.Key)
-				assert.NotEmpty(t, ex.Steps, "steps for %s/%s", lang, ex.Key)
+				// octo 适配器刻意不提供接入步骤（说明已在 description 里），steps 为空是预期。
+				if ex.Key != "octo" {
+					assert.NotEmpty(t, ex.Steps, "steps for %s/%s", lang, ex.Key)
+				}
 				assert.Equal(t, "application/json", ex.ContentType)
 				assert.Equal(t, urls[ex.Key], ex.URL, "example URL must stay in sync with urls[%s]", ex.Key)
 			}
-			assert.Equal(t, []string{"github", "gitlab", "feishu", "multica", "wecom"}, keys)
+			assert.Equal(t, []string{"github", "gitlab", "feishu", "octo", "wecom"}, keys)
 		})
 	}
 }

--- a/modules/incomingwebhook/adapter_push_test.go
+++ b/modules/incomingwebhook/adapter_push_test.go
@@ -69,9 +69,12 @@ func TestCreate_ReturnsLocalizedAdapterExamples(t *testing.T) {
 		assert.NotEmpty(t, ex["description"])
 		steps, ok := ex["steps"].([]interface{})
 		require.True(t, ok, "steps must be array for %s", key)
-		assert.NotEmpty(t, steps)
+		// octo 适配器刻意不提供接入步骤（说明已在 description 里），steps 为空是预期。
+		if key != "octo" {
+			assert.NotEmpty(t, steps)
+		}
 	}
-	assert.Equal(t, []string{"github", "gitlab", "feishu", "multica", "wecom"}, keys)
+	assert.Equal(t, []string{"github", "gitlab", "feishu", "octo", "wecom"}, keys)
 	firstDescription, _ := rawExamples[0].(map[string]interface{})["description"].(string)
 	assert.Contains(t, firstDescription, "repository")
 }

--- a/modules/incomingwebhook/alias_push_test.go
+++ b/modules/incomingwebhook/alias_push_test.go
@@ -47,7 +47,7 @@ func TestAliasPush_WrongToken_Unauthorized(t *testing.T) {
 	assert.Equalf(t, http.StatusUnauthorized, w.Code, "wrong token must 401 via alias; body=%s", w.Body.String())
 }
 
-// 别名适配器路由（GitHub ping）：与 canonical 一致 200 + skipped，证明 6 条推送形态都
+// 别名适配器路由（GitHub ping）：与 canonical 一致 200 + skipped，证明 7 条推送形态都
 // 在别名前缀下注册并走同一条链。
 func TestAliasPush_GitHubPing_SkippedLikeCanonical(t *testing.T) {
 	handler, _, groupNo := setupTestEnv(t)
@@ -62,13 +62,13 @@ func TestAliasPush_GitHubPing_SkippedLikeCanonical(t *testing.T) {
 	assert.Contains(t, w.Body.String(), `"skipped"`, "alias ping must mark delivery skipped, same as canonical")
 }
 
-// 别名前缀下全部 6 条推送形态（native + 5 个适配器）都已注册并走同一条鉴权链：错误 token
-// 一律 401，证明每条别名路由都存在且经过 token 校验。#456 review (Octo-Q P2) 指出 wecom/
-// multica/gitlab/feishu 4 个适配器后缀未在别名上单测——mountPush 闭包让 6 条统一注册、
-// 结构上不可能漏挂，这条遍历测试把该不变量显式钉死（belt & suspenders）。
+// 别名前缀下全部 7 条推送形态（native + 6 个适配器，含 octo 这个 multica 的对外别名）
+// 都已注册并走同一条鉴权链：错误 token 一律 401，证明每条别名路由都存在且经过 token 校验。
+// mountPush 闭包让所有形态统一注册、结构上不可能漏挂，这条遍历测试把该不变量显式钉死
+// （belt & suspenders）。
 func TestAliasPush_AllPushRoutesRegistered(t *testing.T) {
-	// 固定宽松的限流 env，让本测试自包含、不受 CI 全局调低 burst 影响（#456 review
-	// Jerry-Xin 🟡）：6 次错误 token 在默认 burst(60) 下本就安全，但若某环境全局压低
+	// 固定宽松的限流 env，让本测试自包含、不受 CI 全局调低 burst 影响：7 次错误 token 在
+	// 默认 burst(60) 下本就安全，但若某环境全局压低
 	// IP_FAIL_BURST / IP_BURST / local-floor 桶，401 可能翻成 429。strict 限流器与
 	// local floor 在 Route()/New() 构造时读 env，故必须在 setupTestEnv 之前 Setenv。
 	t.Setenv("DM_INCOMINGWEBHOOK_IP_FAIL_RPS", "10000")
@@ -83,13 +83,13 @@ func TestAliasPush_AllPushRoutesRegistered(t *testing.T) {
 	handler, ctx, groupNo := setupTestEnv(t)
 	whID, _ := createWebhookWithToken(t, handler, groupNo)
 
-	// 固定 IP + 重置失败/限流桶：6 次错误 token 走同一 IP，重置桶让本测试与并发的其它
+	// 固定 IP + 重置失败/限流桶：7 次错误 token 走同一 IP，重置桶让本测试与并发的其它
 	// 匿名推送测试互不串桶（env 已宽松，桶容量也足够）。
 	const ip = "203.0.113.201"
 	resetIPFailBucket(t, ctx, ip)
 	resetStrictIPBucket(t, ctx, ip)
 
-	for _, suffix := range []string{"", "github", "wecom", "multica", "gitlab", "feishu"} {
+	for _, suffix := range []string{"", "github", "wecom", "multica", "octo", "gitlab", "feishu"} {
 		path := fmt.Sprintf("/v1/webhooks/%s/%s", whID, "wrong-token")
 		if suffix != "" {
 			path += "/" + suffix

--- a/modules/incomingwebhook/api.go
+++ b/modules/incomingwebhook/api.go
@@ -260,6 +260,10 @@ func (w *IncomingWebhook) Route(r *wkhttp.WKHttp) {
 			push.POST(base+"/github", chain(w.pushGitHub)...)
 			push.POST(base+"/wecom", chain(w.pushWeCom)...)
 			push.POST(base+"/multica", chain(w.pushMultica)...)
+			// /octo 是 /multica 的对外别名（隐藏 multica 产品名）：解析与渲染复用同一套
+			// parseMulticaPush，但用独立的 octoAdapter，使投递审计 adapter 记为 "octo"。
+			// /multica 保留以兼容存量订阅。
+			push.POST(base+"/octo", chain(w.pushOcto)...)
 			push.POST(base+"/gitlab", chain(w.pushGitLab)...)
 			push.POST(base+"/feishu", chain(w.pushFeishu)...)
 		}
@@ -1274,6 +1278,7 @@ func (w *IncomingWebhook) push(c *wkhttp.Context)        { w.handlePush(c, nativ
 func (w *IncomingWebhook) pushGitHub(c *wkhttp.Context)  { w.handlePush(c, githubAdapter) }
 func (w *IncomingWebhook) pushWeCom(c *wkhttp.Context)   { w.handlePush(c, wecomAdapter) }
 func (w *IncomingWebhook) pushMultica(c *wkhttp.Context) { w.handlePush(c, multicaAdapter) }
+func (w *IncomingWebhook) pushOcto(c *wkhttp.Context)    { w.handlePush(c, octoAdapter) }
 func (w *IncomingWebhook) pushGitLab(c *wkhttp.Context)  { w.handlePush(c, gitlabAdapter) }
 func (w *IncomingWebhook) pushFeishu(c *wkhttp.Context)  { w.handlePush(c, feishuAdapter) }
 

--- a/modules/incomingwebhook/model.go
+++ b/modules/incomingwebhook/model.go
@@ -80,6 +80,7 @@ const (
 	adapterGitHub  = "github"  // GitHub 事件适配器（#297 Phase 3）
 	adapterWeCom   = "wecom"   // 企业微信群机器人格式适配器（#297 Phase 3）
 	adapterMultica = "multica" // Multica 出站 webhook 适配器（#426）
+	adapterOcto    = "octo"    // Multica 出站 webhook 的对外别名后缀，与 multica 共用同一解析/渲染
 	adapterGitLab  = "gitlab"  // GitLab 事件适配器（#297 Phase 4）
 	adapterFeishu  = "feishu"  // 飞书自定义机器人格式适配器（#297 Phase 4）
 )

--- a/modules/incomingwebhook/templates/en-US/adapter.tmpl
+++ b/modules/incomingwebhook/templates/en-US/adapter.tmpl
@@ -30,6 +30,10 @@ Paste the following URL and save
 Select the issue events to receive
 {{end}}
 
+{{define "adapter.octo.title"}}Octo{{end}}
+{{define "adapter.octo.description"}}Add the following URL to the Webhook settings of the corresponding Loop "Project"; status changes will be pushed to this group.{{end}}
+{{define "adapter.octo.steps"}}{{end}}
+
 {{define "adapter.wecom.title"}}WeCom Bot Compatible{{end}}
 {{define "adapter.wecom.description"}}Compatible with WeCom custom bot payloads; replace the existing WeCom bot URL with the following URL to migrate.{{end}}
 {{define "adapter.wecom.steps"}}

--- a/modules/incomingwebhook/templates/zh-CN/adapter.tmpl
+++ b/modules/incomingwebhook/templates/zh-CN/adapter.tmpl
@@ -30,6 +30,10 @@
 选择需要接收的议题事件
 {{end}}
 
+{{define "adapter.octo.title"}}Octo{{end}}
+{{define "adapter.octo.description"}}把下面地址填入对应回路「项目」的 Webhook 配置，状态变更时会推送到此群。{{end}}
+{{define "adapter.octo.steps"}}{{end}}
+
 {{define "adapter.wecom.title"}}企业微信机器人兼容{{end}}
 {{define "adapter.wecom.description"}}兼容企业微信自定义机器人格式，把现有企业微信机器人 URL 换成下面地址即可迁移。{{end}}
 {{define "adapter.wecom.steps"}}


### PR DESCRIPTION
## What

新增 `/octo` incoming-webhook 后缀,作为 `/multica` 的对外别名:对外场景不再暴露 multica 产品名。

## Why

incoming webhook 面向对外场景(把回路 issue 状态变更推送到群)。原 `/multica` 后缀把 "multica" 产品名暴露在对外 URL、示例展示与投递审计里,不适合对外呈现。

## How

- **路由**:`/octo` 与 `/multica` 并存;`/octo` 用独立 `octoAdapter`(仅 `name` 不同,复用 `parseMulticaPush`),使投递审计的 `adapter` 记为 `octo` 而非 `multica`
- **展示**:catalog 中 octo 展示、multica 隐藏(`/multica` 路由保留,兼容存量订阅)
- **文案**:octo 的 title/description 面向回路项目 Webhook 配置,去掉接入步骤
- **测试**:同步 example key 列表与 steps 断言,别名路由遍历纳入 octo

纯加法,`/multica` 路由与 `multicaAdapter` 原样保留,存量订阅不受影响。

## 验证

- `go build` / `go vet` / `gofmt` 通过
- incomingwebhook 包单测通过(catalog / i18n / multica 解析)
- 本地 e2e:经 `/octo` 推送 → HTTP 200 且投递审计 `adapter=octo`

Closes #590
