### PR TITLE
feat(messages_search): aggregation-first global search — L1 groups endpoint + presence calibration

### DIFF
--- a/modules/messages_search/audit.go
+++ b/modules/messages_search/audit.go
@@ -106,6 +106,16 @@ func (h *Handler) auditMiddleware() wkhttp.HandlerFunc {
 				fields = append(fields, zap.Int("oversample_pages", n))
 			}
 		}
+		if v, ok := c.Get(auditFieldPresenceProbeBucketsKey); ok {
+			if n, _ := v.(int); n >= 0 {
+				fields = append(fields, zap.Int("presence_probe_buckets", n))
+			}
+		}
+		if v, ok := c.Get(auditFieldPresenceProbeDocsKey); ok {
+			if n, _ := v.(int); n >= 0 {
+				fields = append(fields, zap.Int("presence_probe_docs", n))
+			}
+		}
 		h.Info("messages_search.audit", fields...)
 	}
 }

--- a/modules/messages_search/config.go
+++ b/modules/messages_search/config.go
@@ -65,6 +65,34 @@ type SearchConfig struct {
 	//     misclassifying queries in production and a one-line config flip
 	//     is preferable to a redeploy.
 	StopwordStripEnabled bool
+	// Groups holds the L1 group-aggregation (_search_global_groups) knobs.
+	// See aggregation-first design doc §9; every value is config-driven, never
+	// hardcoded, and never controlled by the request.
+	Groups GroupAggConfig
+}
+
+// GroupAggConfig carries the L1 aggregation (_search_global_groups) tunables.
+//
+//   - MaxGroups: terms(channelId) bucket cap. Beyond it the response sets
+//     pagination.has_more=true and returns the most-active MaxGroups buckets.
+//   - PerGroupMax: single-group preview cap (clamp N to this).
+//   - PresenceProbe: over-fetch margin. top_hits size T = PerGroupMax +
+//     PresenceProbe so backend B's presence calibration has sample headroom.
+//   - PreviewBudget / K2: reserved for backend B (per-frequency preview
+//     allocation / presence deep-probe cap); read here so the config surface
+//     is complete and the two PRs don't re-open config.go.
+type GroupAggConfig struct {
+	MaxGroups     int
+	PerGroupMax   int
+	PresenceProbe int
+	PreviewBudget int
+	K2            int
+}
+
+// TopHitsSize is the over-fetch size T for the per-bucket top_hits preview
+// aggregation: PerGroupMax preview slots + PresenceProbe calibration headroom.
+func (g GroupAggConfig) TopHitsSize() int {
+	return g.PerGroupMax + g.PresenceProbe
 }
 
 // RateLimitCfg drives the per-loginUID 5 QPS / 20 burst limiter.
@@ -94,6 +122,13 @@ func loadConfig() SearchConfig {
 		// the ops kill switch documented in
 		// docs/messages-search/2026-06-23-multimatch-or-trap-fix.md §8.
 		StopwordStripEnabled: parseBool(os.Getenv("OCTO_SEARCH_STOPWORD_STRIP_ENABLED"), true),
+		Groups: GroupAggConfig{
+			MaxGroups:     parseInt(os.Getenv("OCTO_SEARCH_GROUPS_MAX_GROUPS"), 200),
+			PerGroupMax:   parseInt(os.Getenv("OCTO_SEARCH_GROUPS_PER_GROUP_MAX"), 20),
+			PresenceProbe: parseInt(os.Getenv("OCTO_SEARCH_GROUPS_PRESENCE_PROBE"), 20),
+			PreviewBudget: parseInt(os.Getenv("OCTO_SEARCH_GROUPS_PREVIEW_BUDGET"), 500),
+			K2:            parseInt(os.Getenv("OCTO_SEARCH_GROUPS_K2"), 500),
+		},
 	}
 }
 

--- a/modules/messages_search/presence.go
+++ b/modules/messages_search/presence.go
@@ -2,6 +2,7 @@ package messages_search
 
 import (
 	"context"
+	"encoding/json"
 	"sort"
 	"time"
 
@@ -19,9 +20,17 @@ const deepProbePageSize = 50
 // (INCLUDE): it carries the visible hits (most-recent-first) drawn either from
 // the top-T sample or discovered by the deep probe. EXCLUDE buckets are dropped
 // before this stage so they never reach the wire.
+//
+// latestVisibleTS is the timestamp (ms) of the most-recent VISIBLE hit
+// (visible[0]) — the RC fix. The wire `latest_at` and the returned bucket order
+// must both derive from this, NOT from the OS pre-filter max(timestamp) held in
+// pb.latestTS: if the newest match in a bucket is hidden (admin/self-deleted,
+// cleared history, visibles), the OS max would leak that hidden message's
+// recency into latest_at and pull the bucket up the latest-first order.
 type calibratedBucket struct {
-	pb      parsedBucket
-	visible []*elastic.SearchHit
+	pb              parsedBucket
+	visible         []*elastic.SearchHit
+	latestVisibleTS int64
 }
 
 // presenceStats is the §7 埋点 for the presence pass: how many buckets went
@@ -99,7 +108,7 @@ func (h *Handler) calibratePresence(
 		switch classifyPresence(len(pb.hits), pb.docCount, len(vis)) {
 		case presenceInclude:
 			// ≥1 visible hit in the sample.
-			out = append(out, calibratedBucket{pb: pb, visible: vis})
+			out = append(out, calibratedBucket{pb: pb, visible: vis, latestVisibleTS: latestVisibleTS(vis)})
 		case presenceExclude:
 			// 0 visible and the top-T already covered the whole bucket → the
 			// group has no visible hit at all → drop it.
@@ -113,7 +122,7 @@ func (h *Handler) calibratePresence(
 				return nil, stats, err
 			}
 			if found {
-				out = append(out, calibratedBucket{pb: pb, visible: dvis})
+				out = append(out, calibratedBucket{pb: pb, visible: dvis, latestVisibleTS: latestVisibleTS(dvis)})
 			}
 		}
 	}
@@ -145,6 +154,32 @@ func classifyPresence(sampleSize int, docCount int64, visibleCount int) presence
 		return presenceExclude
 	}
 	return presenceUnresolved
+}
+
+// latestVisibleTS returns the timestamp (ms) of the most-recent VISIBLE hit in
+// a calibrated bucket. visible is most-recent-first (top_hits / deep-probe both
+// sort time_desc and the filter preserves that order), so visible[0] is the
+// newest hit the caller may actually see. Empty → 0 (defensive; INCLUDE buckets
+// always carry ≥1 visible hit).
+func latestVisibleTS(visible []*elastic.SearchHit) int64 {
+	if len(visible) == 0 {
+		return 0
+	}
+	return hitTimestampMS(visible[0])
+}
+
+// hitTimestampMS reads the OS doc `timestamp` (ms) off a hit's _source. Used to
+// recompute latest_at from the calibrated visible hit rather than the OS
+// pre-filter max(timestamp), which would leak a hidden message's recency.
+func hitTimestampMS(hit *elastic.SearchHit) int64 {
+	if hit == nil {
+		return 0
+	}
+	var d Doc
+	if err := json.Unmarshal(rawSource(hit.Source), &d); err != nil {
+		return 0
+	}
+	return d.Timestamp
 }
 
 // deepProbeBucket is the UNRESOLVED old-ward probe (§2.2). It resumes strictly

--- a/modules/messages_search/presence.go
+++ b/modules/messages_search/presence.go
@@ -1,0 +1,372 @@
+package messages_search
+
+import (
+	"context"
+	"sort"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/olivere/elastic"
+)
+
+// deepProbePageSize is the old-ward search_after page size for the UNRESOLVED
+// deep probe (§2.2). Fixed (not config) — it only trades round-trips against
+// per-page filterVisible width and never affects the visible result, which is
+// bounded by K2.
+const deepProbePageSize = 50
+
+// calibratedBucket is a terms bucket that survived presence calibration
+// (INCLUDE): it carries the visible hits (most-recent-first) drawn either from
+// the top-T sample or discovered by the deep probe. EXCLUDE buckets are dropped
+// before this stage so they never reach the wire.
+type calibratedBucket struct {
+	pb      parsedBucket
+	visible []*elastic.SearchHit
+}
+
+// presenceStats is the §7 埋点 for the presence pass: how many buckets went
+// UNRESOLVED into the deep probe and how many docs the probe scanned in total.
+type presenceStats struct {
+	deepProbeBuckets int
+	deepProbeDocs    int
+}
+
+// calibratePresence implements §2.2: for every candidate bucket it decides
+// INCLUDE / EXCLUDE / UNRESOLVED from the over-fetched top-T sample, then deep-
+// probes the UNRESOLVED ones to first-visible / K2. It closes the A-review
+// Blocker — the raw top_hits are filtered through the five-gate filterVisible
+// (revoked + visibles already dropped at the OS layer; admin/mutual is_deleted,
+// self-delete, channel-offset watermark applied here) so no invisible message's
+// snippet/sender/time can leak into preview.
+//
+// A single batched filterVisible covers the top-T of ALL buckets in one MySQL
+// round-trip (the whole point of visibility.go's batch surface). Fail-closed:
+// any DB error propagates so the handler responds INTERNAL_ERROR rather than
+// releasing uncalibrated hits.
+func (h *Handler) calibratePresence(
+	ctx context.Context,
+	client *elastic.Client,
+	base elastic.Query,
+	buckets []parsedBucket,
+	loginUID string,
+	timings *searchPhaseTimings,
+) ([]calibratedBucket, presenceStats, error) {
+	var stats presenceStats
+	if len(buckets) == 0 {
+		return nil, stats, nil
+	}
+
+	// Project every top-T hit once, collecting the refs for the single batched
+	// filterVisible while remembering each hit's ref so the per-bucket verdict
+	// can test membership without re-projecting.
+	project := projectDocRef("", loginUID)
+	bucketRefs := make([][]msgRef, len(buckets))
+	var allRefs []msgRef
+	for bi, pb := range buckets {
+		refs := make([]msgRef, len(pb.hits))
+		for i, hit := range pb.hits {
+			if r, ok := project(hit); ok {
+				refs[i] = r
+				allRefs = append(allRefs, r)
+			}
+		}
+		bucketRefs[bi] = refs
+	}
+
+	keep := map[string]struct{}{}
+	if len(allRefs) > 0 {
+		start := time.Now()
+		var err error
+		keep, err = h.filterVisible(ctx, loginUID, "", allRefs)
+		timings.filterVisible += time.Since(start)
+		if err != nil {
+			return nil, stats, err
+		}
+	}
+
+	out := make([]calibratedBucket, 0, len(buckets))
+	for bi, pb := range buckets {
+		var vis []*elastic.SearchHit
+		for i, hit := range pb.hits {
+			r := bucketRefs[bi][i]
+			if r.MessageID == "" {
+				continue
+			}
+			if _, okv := keep[r.MessageID]; okv {
+				vis = append(vis, hit)
+			}
+		}
+		switch classifyPresence(len(pb.hits), pb.docCount, len(vis)) {
+		case presenceInclude:
+			// ≥1 visible hit in the sample.
+			out = append(out, calibratedBucket{pb: pb, visible: vis})
+		case presenceExclude:
+			// 0 visible and the top-T already covered the whole bucket → the
+			// group has no visible hit at all → drop it.
+			continue
+		case presenceUnresolved:
+			// The most recent T are all hidden but older docs remain.
+			found, dvis, scanned, err := h.deepProbeBucket(ctx, client, base, pb, loginUID, timings)
+			stats.deepProbeBuckets++
+			stats.deepProbeDocs += scanned
+			if err != nil {
+				return nil, stats, err
+			}
+			if found {
+				out = append(out, calibratedBucket{pb: pb, visible: dvis})
+			}
+		}
+	}
+	return out, stats, nil
+}
+
+// presenceVerdict is the three-state §2.2 outcome of the top-T sample check.
+type presenceVerdict int
+
+const (
+	presenceInclude presenceVerdict = iota
+	presenceExclude
+	presenceUnresolved
+)
+
+// classifyPresence maps (top-T sample size, doc_count, visible-in-sample count)
+// to the §2.2 verdict. ≥1 visible → INCLUDE. 0 visible with the sample already
+// covering the whole bucket (sampleSize >= doc_count ⟺ T >= doc_count, exact on
+// the single-shard index) → EXCLUDE. 0 visible with older docs beyond the
+// sample → UNRESOLVED (deep probe). Boundary: sampleSize == doc_count with 0
+// visible is EXCLUDE, never a spurious UNRESOLVED (test ⑤). See §14.11 for the
+// post-reshard caveat where doc_count turns approximate and EXCLUDE must yield
+// to unconditional deep probing.
+func classifyPresence(sampleSize int, docCount int64, visibleCount int) presenceVerdict {
+	if visibleCount > 0 {
+		return presenceInclude
+	}
+	if int64(sampleSize) >= docCount {
+		return presenceExclude
+	}
+	return presenceUnresolved
+}
+
+// deepProbeBucket is the UNRESOLVED old-ward probe (§2.2). It resumes strictly
+// after the oldest top-T hit (search_after — no overlap, no skip) and pages
+// backwards through the single channel running filterVisible per page:
+//
+//   - first visible hit found → INCLUDE (returns that page's visible hits)
+//   - channel exhausted (page shorter than requested) → EXCLUDE
+//   - cumulative scan (top-T + probe) reaches K2 → EXCLUDE (bounded latency)
+//
+// The K2 budget counts the top-T we already examined, so the group is presence-
+// exact for M_group ≤ K2 and a group whose only visible hit sits past K2 is a
+// known, metered residual (test ⑥). The probe reuses the L1 `base` query
+// (analysis already done once) narrowed to this channel; DM buckets pass their
+// OS fake channelId as-is (that is what the index stores). This wires the OS
+// round-trip closure and delegates the loop to deepProbeVisible so the paging /
+// budget / three-outcome logic is unit-testable without a live cluster.
+func (h *Handler) deepProbeBucket(
+	ctx context.Context,
+	client *elastic.Client,
+	base elastic.Query,
+	pb parsedBucket,
+	loginUID string,
+	timings *searchPhaseTimings,
+) (found bool, visible []*elastic.SearchHit, scanned int, err error) {
+	budget := h.cfg.Groups.K2 - len(pb.hits)
+	if budget <= 0 || len(pb.hits) == 0 {
+		return false, nil, 0, nil
+	}
+	initialSA, ok := buildSearchAfterFromHit(pb.hits[len(pb.hits)-1], false)
+	if !ok {
+		// Can't build a safe resume boundary → conservative EXCLUDE (never a
+		// leak; at worst hides a group whose visible hit is older than T).
+		return false, nil, 0, nil
+	}
+
+	sorters := searchSorters("time_desc")
+	osSearch := func(searchAfter []any, size int) ([]*elastic.SearchHit, error) {
+		query := elastic.NewBoolQuery().Filter(base, elastic.NewTermQuery("channelId", pb.key))
+		applyVisiblesWhitelist(query, loginUID)
+		svc := client.Search().
+			Index(h.cfg.OSReadAlias).
+			Query(query).
+			Size(size).
+			TrackTotalHits(false).
+			FetchSourceContext(fileContentSourceExcludes()).
+			SortBy(sorters...).
+			SearchAfter(searchAfter...)
+		res, qerr := svc.Do(ctx)
+		if qerr != nil {
+			return nil, qerr
+		}
+		if res == nil || res.Hits == nil {
+			return nil, nil
+		}
+		return res.Hits.Hits, nil
+	}
+	return h.deepProbeVisible(ctx, loginUID, initialSA, budget, osSearch, timings)
+}
+
+// deepProbeVisible is the pure paging loop of the UNRESOLVED deep probe: it
+// pulls old-ward pages via osSearch (deepProbePageSize, trimmed to the residual
+// budget) and applies filterVisible to each. The three outcomes mirror §2.2:
+// first visible hit → (true, that page's visible hits); a short page → channel
+// exhausted → (false, nil); the K2-anchored budget consumed → (false, nil).
+// Each page is filtered exactly once against recall-time state, so a permission
+// change mid-probe (test ⑦) is self-consistent within the request — earlier
+// pages are never re-scanned.
+func (h *Handler) deepProbeVisible(
+	ctx context.Context,
+	loginUID string,
+	initialSA []any,
+	budget int,
+	osSearch osQueryFn,
+	timings *searchPhaseTimings,
+) (found bool, visible []*elastic.SearchHit, scanned int, err error) {
+	searchAfter := initialSA
+	project := projectDocRef("", loginUID)
+	for scanned < budget {
+		size := deepProbePageSize
+		if rem := budget - scanned; rem < size {
+			size = rem
+		}
+		start := time.Now()
+		hits, qerr := osSearch(searchAfter, size)
+		if timings != nil {
+			timings.osSearch += time.Since(start)
+		}
+		if qerr != nil {
+			return false, nil, scanned, qerr
+		}
+		if len(hits) == 0 {
+			return false, nil, scanned, nil // channel exhausted
+		}
+		scanned += len(hits)
+
+		refs := make([]msgRef, len(hits))
+		filterInput := make([]msgRef, 0, len(hits))
+		for i, hit := range hits {
+			if r, pok := project(hit); pok {
+				refs[i] = r
+				filterInput = append(filterInput, r)
+			}
+		}
+		if len(filterInput) > 0 {
+			fstart := time.Now()
+			keep, ferr := h.filterVisible(ctx, loginUID, "", filterInput)
+			if timings != nil {
+				timings.filterVisible += time.Since(fstart)
+			}
+			if ferr != nil {
+				return false, nil, scanned, ferr
+			}
+			var vis []*elastic.SearchHit
+			for i, hit := range hits {
+				if refs[i].MessageID == "" {
+					continue
+				}
+				if _, okv := keep[refs[i].MessageID]; okv {
+					vis = append(vis, hit)
+				}
+			}
+			if len(vis) > 0 {
+				return true, vis, scanned, nil // first visible → INCLUDE
+			}
+		}
+		if len(hits) < size {
+			return false, nil, scanned, nil // channel exhausted
+		}
+		nextSA, sok := buildSearchAfterFromHit(hits[len(hits)-1], false)
+		if !sok {
+			return false, nil, scanned, nil
+		}
+		searchAfter = nextSA
+	}
+	return false, nil, scanned, nil // K2 budget exhausted → EXCLUDE
+}
+
+// allocatePreviewN spreads the global previewBudget across the calibrated
+// buckets weighted by match frequency (doc_count), so active groups get more
+// preview rows and low-frequency groups fall to the floor of 1 (§4:
+// 老/低频群 N=1、活跃多). Each N is clamped to [1, perGroupMax]. latest_at
+// already governs bucket order (terms order + top_hits desc) and therefore
+// WHICH rows preview shows; doc_count governs HOW MANY. Budget is a soft
+// ceiling — the perGroupMax clamp may leave the sum below budget, never above
+// (every bucket ≤ perGroupMax and the weighted extra sums to ≤ budget-n).
+func allocatePreviewN(buckets []calibratedBucket, budget, perGroupMax int) []int {
+	n := len(buckets)
+	ns := make([]int, n)
+	if n == 0 {
+		return ns
+	}
+	if perGroupMax < 1 {
+		perGroupMax = 1
+	}
+	// Floor: every included bucket shows at least one visible row.
+	for i := range ns {
+		ns[i] = 1
+	}
+	extra := budget - n
+	if extra < 0 {
+		extra = 0
+	}
+
+	weights := make([]float64, n)
+	var totalW float64
+	for i, b := range buckets {
+		w := float64(b.pb.docCount)
+		if w < 1 {
+			w = 1
+		}
+		weights[i] = w
+		totalW += w
+	}
+
+	if extra > 0 && totalW > 0 {
+		// Largest-remainder apportionment of `extra` across the weights.
+		type rem struct {
+			idx  int
+			frac float64
+		}
+		rems := make([]rem, n)
+		assigned := 0
+		for i := range ns {
+			exact := float64(extra) * weights[i] / totalW
+			add := int(exact)
+			ns[i] += add
+			assigned += add
+			rems[i] = rem{idx: i, frac: exact - float64(add)}
+		}
+		leftover := extra - assigned
+		sort.SliceStable(rems, func(a, b int) bool { return rems[a].frac > rems[b].frac })
+		for k := 0; k < leftover && k < len(rems); k++ {
+			ns[rems[k].idx]++
+		}
+	}
+
+	for i := range ns {
+		if ns[i] > perGroupMax {
+			ns[i] = perGroupMax
+		}
+		if ns[i] < 1 {
+			ns[i] = 1
+		}
+	}
+	return ns
+}
+
+// gin context keys carrying the presence deep-probe 埋点 (§7) out to the audit
+// middleware, alongside the YUJ-27 per-phase timings.
+const (
+	auditFieldPresenceProbeBucketsKey = "messages_search.audit.presence_probe_buckets"
+	auditFieldPresenceProbeDocsKey    = "messages_search.audit.presence_probe_docs"
+)
+
+// recordPresenceStats ferries the presence deep-probe counters into the audit
+// pipeline. Zero values are still recorded so "no probe this request" stays
+// distinguishable from "field absent on a non-L1 request".
+func recordPresenceStats(c *wkhttp.Context, s presenceStats) {
+	if c == nil {
+		return
+	}
+	c.Set(auditFieldPresenceProbeBucketsKey, s.deepProbeBuckets)
+	c.Set(auditFieldPresenceProbeDocsKey, s.deepProbeDocs)
+}

--- a/modules/messages_search/presence_test.go
+++ b/modules/messages_search/presence_test.go
@@ -147,6 +147,73 @@ func TestCalibratePresence_FailClosed(t *testing.T) {
 	}
 }
 
+// TestCalibratePresence_LatestVisibleTS is the RC regression: when a bucket's
+// most-recent match is admin-deleted and an older message is visible, the
+// calibrated latest_at must be the OLDER visible message's timestamp — never
+// the hidden newest one's. This is the value assembleGroupBucket puts on the
+// wire and buildGroupsResult sorts by, so a hidden newest match can no longer
+// leak its recency or bias the bucket order.
+func TestCalibratePresence_LatestVisibleTS(t *testing.T) {
+	// hit 10 is the NEWEST match (ts 1_700_000_200) but admin-deleted; hit 11
+	// (ts 1_700_000_100) is the newest VISIBLE one.
+	pb := parsedBucket{
+		key:      "gA",
+		docCount: 2,
+		latestTS: 1_700_000_200, // OS pre-filter max — must NOT reach the wire
+		hits: []*elastic.SearchHit{
+			presenceHit(10, 2, "gA", 2, 1_700_000_200),
+			presenceHit(11, 1, "gA", 2, 1_700_000_100),
+		},
+	}
+	h := presenceHandler(&stubProbe{deleted: deletedIDs(10)}, 500)
+	var tm searchPhaseTimings
+	out, _, err := h.calibratePresence(context.Background(), nil, nil, []parsedBucket{pb}, "me", &tm)
+	if err != nil {
+		t.Fatalf("calibrate: %v", err)
+	}
+	if len(out) != 1 {
+		t.Fatalf("bucket with an older visible hit must INCLUDE; got %d", len(out))
+	}
+	if out[0].latestVisibleTS != 1_700_000_100 {
+		t.Errorf("latest_at must be the visible hit's ts 1_700_000_100 (not the deleted newest 1_700_000_200); got %d", out[0].latestVisibleTS)
+	}
+	// The deleted newest hit must not have leaked into the visible set either.
+	for _, hit := range out[0].visible {
+		if id, _ := lastHitMessageIDAndSubSeq(hit); id == 10 {
+			t.Errorf("admin-deleted newest hit 10 leaked into the visible set")
+		}
+	}
+}
+
+// TestCalibratePresence_DeepProbeLatestVisibleTS is the UNRESOLVED-path variant
+// of the RC regression: every top-T hit is hidden, so the bucket only INCLUDEs
+// via the deep probe — and its latest_at must be the deep-probe-found visible
+// hit's timestamp, still never the OS pre-filter max.
+func TestCalibratePresence_DeepProbeLatestVisibleTS(t *testing.T) {
+	// docCount 3 with a top-T of 1 all-hidden hit → sample doesn't cover the
+	// bucket → UNRESOLVED. deepProbeBucket reuses base as an OS query, so route
+	// the probe through a Handler whose visibility hides only the newest.
+	// Here we exercise deepProbeVisible directly for a deterministic stream.
+	stream := []*elastic.SearchHit{
+		presenceHit(20, 3, "gA", 2, 1_700_000_050), // hidden (older than top-T boundary)
+		presenceHit(21, 2, "gA", 2, 1_700_000_040), // visible → newest visible
+		presenceHit(22, 1, "gA", 2, 1_700_000_030), // visible
+	}
+	f := &fakeOS{stream: stream}
+	h := presenceHandler(&stubProbe{deleted: deletedIDs(20)}, 500)
+	var tm searchPhaseTimings
+	found, vis, _, err := h.deepProbeVisible(context.Background(), "me", []any{float64(1_700_000_060), float64(19), float64(0)}, 500, f.fn(), &tm)
+	if err != nil {
+		t.Fatalf("probe: %v", err)
+	}
+	if !found || len(vis) == 0 {
+		t.Fatal("expected the probe to find a visible hit")
+	}
+	if got := latestVisibleTS(vis); got != 1_700_000_040 {
+		t.Errorf("deep-probe latest_at must be the newest visible hit ts 1_700_000_040; got %d", got)
+	}
+}
+
 // --- deepProbeVisible: first-visible / exhausted / K2 budget (②③⑥⑦) --------
 
 // fakeOS models an OpenSearch search_after stream: it returns up to `size` hits

--- a/modules/messages_search/presence_test.go
+++ b/modules/messages_search/presence_test.go
@@ -1,0 +1,295 @@
+package messages_search
+
+import (
+	"context"
+	"encoding/json"
+	"strconv"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
+	"github.com/olivere/elastic"
+)
+
+// presenceHit builds a synthetic OS SearchHit with a typed _source and the
+// time_desc sort tuple [timestamp, messageId, subSeq] so projectDocRef and
+// buildSearchAfterFromHit both read it the way the production top_hits /
+// deep-probe hits are shaped.
+func presenceHit(id int64, seq uint64, channelID string, channelType uint32, ts int64) *elastic.SearchHit {
+	doc := Doc{
+		MessageID:   id,
+		MessageSeq:  seq,
+		From:        "sender",
+		ChannelID:   channelID,
+		ChannelType: channelType,
+		Timestamp:   ts,
+	}
+	body, _ := json.Marshal(doc)
+	src := json.RawMessage(body)
+	return &elastic.SearchHit{
+		Source: &src,
+		Sort:   []any{float64(ts), float64(id), float64(0)},
+	}
+}
+
+func presenceHandler(p visibilityProbe, k2 int) *Handler {
+	return &Handler{
+		Log:        log.NewTLog("messages_search-presence-test"),
+		cfg:        SearchConfig{Groups: GroupAggConfig{K2: k2, PerGroupMax: 20, PresenceProbe: 20, PreviewBudget: 500}},
+		visibility: p,
+	}
+}
+
+// deletedIDs turns a list of message ids into the stubProbe globally-deleted
+// map (message_extra.is_deleted=1 — one of the MySQL-only gates OS can't see).
+func deletedIDs(ids ...int64) map[string]bool {
+	m := map[string]bool{}
+	for _, id := range ids {
+		m[strconv.FormatInt(id, 10)] = true
+	}
+	return m
+}
+
+// --- classifyPresence: the three-state boundary (§2.2, tests ①⑤) -----------
+
+func TestClassifyPresence(t *testing.T) {
+	cases := []struct {
+		name       string
+		sampleSize int
+		docCount   int64
+		visible    int
+		want       presenceVerdict
+	}{
+		{"has visible", 40, 128, 3, presenceInclude},
+		{"unique hit filtered (①)", 1, 1, 0, presenceExclude},
+		{"T==doc_count 0 visible (⑤)", 40, 40, 0, presenceExclude},
+		{"sample covers all, none visible", 5, 5, 0, presenceExclude},
+		{"recent T hidden, more behind", 40, 200, 0, presenceUnresolved},
+		{"one short of full, none visible", 39, 40, 0, presenceUnresolved},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := classifyPresence(tc.sampleSize, tc.docCount, tc.visible); got != tc.want {
+				t.Errorf("classifyPresence(%d,%d,%d)=%v want %v", tc.sampleSize, tc.docCount, tc.visible, got, tc.want)
+			}
+		})
+	}
+}
+
+// --- calibratePresence: INCLUDE keeps only visible, EXCLUDE drops the bucket -
+
+// TestCalibratePresence_IncludeFiltersPreview is the A-review Blocker guard: a
+// bucket whose top-T mixes visible + admin-deleted hits must INCLUDE only the
+// visible ones — the deleted message's hit never survives into preview.
+func TestCalibratePresence_IncludeFiltersPreview(t *testing.T) {
+	// hit 10 visible, hit 11 globally-deleted, hit 12 visible.
+	pb := parsedBucket{
+		key:      "gA",
+		docCount: 3,
+		latestTS: 1_700_000_200,
+		hits: []*elastic.SearchHit{
+			presenceHit(10, 3, "gA", 2, 1_700_000_200),
+			presenceHit(11, 2, "gA", 2, 1_700_000_100),
+			presenceHit(12, 1, "gA", 2, 1_700_000_000),
+		},
+	}
+	h := presenceHandler(&stubProbe{deleted: deletedIDs(11)}, 500)
+	var tm searchPhaseTimings
+	out, stats, err := h.calibratePresence(context.Background(), nil, nil, []parsedBucket{pb}, "me", &tm)
+	if err != nil {
+		t.Fatalf("calibrate: %v", err)
+	}
+	if len(out) != 1 {
+		t.Fatalf("bucket with visible hits must INCLUDE; got %d buckets", len(out))
+	}
+	if len(out[0].visible) != 2 {
+		t.Fatalf("preview must carry only the 2 visible hits; got %d", len(out[0].visible))
+	}
+	for _, hit := range out[0].visible {
+		if id, _ := lastHitMessageIDAndSubSeq(hit); id == 11 {
+			t.Errorf("globally-deleted hit 11 leaked into preview")
+		}
+	}
+	if stats.deepProbeBuckets != 0 {
+		t.Errorf("no deep probe expected when the sample has a visible hit; got %d", stats.deepProbeBuckets)
+	}
+}
+
+// TestCalibratePresence_ExcludeUniqueFiltered — case ①: a group whose only hit
+// is filtered is dropped entirely (0 visible, sample covers all).
+func TestCalibratePresence_ExcludeUniqueFiltered(t *testing.T) {
+	pb := parsedBucket{
+		key:      "gLonely",
+		docCount: 1,
+		hits:     []*elastic.SearchHit{presenceHit(50, 1, "gLonely", 2, 1_700_000_000)},
+	}
+	h := presenceHandler(&stubProbe{deleted: deletedIDs(50)}, 500)
+	var tm searchPhaseTimings
+	out, stats, err := h.calibratePresence(context.Background(), nil, nil, []parsedBucket{pb}, "me", &tm)
+	if err != nil {
+		t.Fatalf("calibrate: %v", err)
+	}
+	if len(out) != 0 {
+		t.Fatalf("group with its only hit filtered must EXCLUDE; got %d buckets", len(out))
+	}
+	if stats.deepProbeBuckets != 0 {
+		t.Errorf("EXCLUDE (sample covers all) must not deep probe; got %d", stats.deepProbeBuckets)
+	}
+}
+
+// TestCalibratePresence_FailClosed — a DB gate error propagates so the handler
+// can surface INTERNAL_ERROR instead of leaking uncalibrated hits.
+func TestCalibratePresence_FailClosed(t *testing.T) {
+	pb := parsedBucket{key: "gA", docCount: 1, hits: []*elastic.SearchHit{presenceHit(10, 1, "gA", 2, 1_700_000_000)}}
+	h := presenceHandler(&stubProbe{deletedErr: context.DeadlineExceeded}, 500)
+	var tm searchPhaseTimings
+	if _, _, err := h.calibratePresence(context.Background(), nil, nil, []parsedBucket{pb}, "me", &tm); err == nil {
+		t.Fatal("expected calibrate to propagate the fail-closed DB error")
+	}
+}
+
+// --- deepProbeVisible: first-visible / exhausted / K2 budget (②③⑥⑦) --------
+
+// fakeOS models an OpenSearch search_after stream: it returns up to `size` hits
+// per call from a flat, time-desc-ordered slice, advancing an internal cursor.
+// A page shorter than the requested size means the stream is exhausted — the
+// same signal the real deep probe reads. gotSizes records the requested sizes
+// so the budget-driven page trimming can be asserted.
+type fakeOS struct {
+	stream   []*elastic.SearchHit
+	idx      int
+	gotSizes []int
+}
+
+func (f *fakeOS) fn() osQueryFn {
+	return func(_ []any, size int) ([]*elastic.SearchHit, error) {
+		f.gotSizes = append(f.gotSizes, size)
+		if f.idx >= len(f.stream) {
+			return nil, nil
+		}
+		end := f.idx + size
+		if end > len(f.stream) {
+			end = len(f.stream)
+		}
+		page := f.stream[f.idx:end]
+		f.idx = end
+		return page, nil
+	}
+}
+
+func hidden(base int64, n int) []*elastic.SearchHit {
+	out := make([]*elastic.SearchHit, n)
+	for i := 0; i < n; i++ {
+		id := base + int64(i)
+		out[i] = presenceHit(id, uint64(10000-int(id)), "gA", 2, 900-int64(i))
+	}
+	return out
+}
+
+// TestDeepProbeVisible_FirstVisibleInclude — case ②: the recent T are all
+// hidden but an older doc is visible → INCLUDE at that hit.
+func TestDeepProbeVisible_FirstVisibleInclude(t *testing.T) {
+	// 20,21,23 deleted; 22 visible (time-desc order 20,21,22,23).
+	stream := []*elastic.SearchHit{
+		presenceHit(20, 20, "gA", 2, 900), presenceHit(21, 19, "gA", 2, 890),
+		presenceHit(22, 18, "gA", 2, 880), presenceHit(23, 17, "gA", 2, 870),
+	}
+	f := &fakeOS{stream: stream}
+	h := presenceHandler(&stubProbe{deleted: deletedIDs(20, 21, 23)}, 500)
+	var tm searchPhaseTimings
+	found, vis, scanned, err := h.deepProbeVisible(context.Background(), "me", []any{float64(900), float64(20), float64(0)}, 500, f.fn(), &tm)
+	if err != nil {
+		t.Fatalf("probe: %v", err)
+	}
+	if !found {
+		t.Fatal("expected INCLUDE once an older visible hit is found (②)")
+	}
+	if len(vis) != 1 {
+		t.Fatalf("expected 1 visible hit on the found page; got %d", len(vis))
+	}
+	if id, _ := lastHitMessageIDAndSubSeq(vis[0]); id != 22 {
+		t.Errorf("expected visible hit 22; got %d", id)
+	}
+	if scanned != 4 {
+		t.Errorf("scanned should count the page (4); got %d", scanned)
+	}
+}
+
+// TestDeepProbeVisible_PagesAdvance — case ⑦ (self-consistency): the probe
+// pages old-ward via search_after, filtering each page exactly once against
+// recall-time state and never re-scanning an earlier page, until it hits a
+// visible doc on a later page.
+func TestDeepProbeVisible_PagesAdvance(t *testing.T) {
+	stream := append(hidden(100, deepProbePageSize), presenceHit(9999, 1, "gA", 2, 100)) // 50 hidden + 1 visible
+	del := make([]int64, deepProbePageSize)
+	for i := range del {
+		del[i] = 100 + int64(i)
+	}
+	probe := &stubProbe{deleted: deletedIDs(del...)}
+	f := &fakeOS{stream: stream}
+	h := presenceHandler(probe, 500)
+	var tm searchPhaseTimings
+	found, vis, scanned, err := h.deepProbeVisible(context.Background(), "me", nil, 500, f.fn(), &tm)
+	if err != nil {
+		t.Fatalf("probe: %v", err)
+	}
+	if !found || len(vis) != 1 {
+		t.Fatalf("expected INCLUDE on the second page; found=%v vis=%d", found, len(vis))
+	}
+	if id, _ := lastHitMessageIDAndSubSeq(vis[0]); id != 9999 {
+		t.Errorf("expected the visible hit 9999 from page 2; got %d", id)
+	}
+	if scanned != deepProbePageSize+1 {
+		t.Errorf("scanned must span both pages (%d); got %d", deepProbePageSize+1, scanned)
+	}
+	// filterVisible runs once per page (2 pages) — no earlier page re-scanned.
+	if probe.deletedCalls != 2 {
+		t.Errorf("expected one filterVisible pass per page (2); got %d", probe.deletedCalls)
+	}
+}
+
+// TestDeepProbeVisible_ChannelExhausted — case ③: M_group ≤ K2 fully scanned,
+// all hidden → EXCLUDE. A short first page signals exhaustion.
+func TestDeepProbeVisible_ChannelExhausted(t *testing.T) {
+	stream := []*elastic.SearchHit{presenceHit(30, 5, "gA", 2, 800), presenceHit(31, 4, "gA", 2, 790)}
+	f := &fakeOS{stream: stream}
+	h := presenceHandler(&stubProbe{deleted: deletedIDs(30, 31)}, 500)
+	var tm searchPhaseTimings
+	found, _, scanned, err := h.deepProbeVisible(context.Background(), "me", nil, 500, f.fn(), &tm)
+	if err != nil {
+		t.Fatalf("probe: %v", err)
+	}
+	if found {
+		t.Fatal("fully-scanned all-hidden channel must EXCLUDE (③)")
+	}
+	if scanned != 2 {
+		t.Errorf("scanned=2 expected; got %d", scanned)
+	}
+}
+
+// TestDeepProbeVisible_K2BudgetExhausted — case ⑥: the probe never scans past
+// the K2-anchored budget; a visible hit sitting beyond it is a metered residual
+// and the bucket is EXCLUDEd. Budget 4 → first (and only) page trimmed to 4.
+func TestDeepProbeVisible_K2BudgetExhausted(t *testing.T) {
+	// A long all-hidden stream with a visible hit far past the budget.
+	stream := append(hidden(100, 20), presenceHit(9999, 1, "gA", 2, 100))
+	del := make([]int64, 20)
+	for i := range del {
+		del[i] = 100 + int64(i)
+	}
+	f := &fakeOS{stream: stream}
+	h := presenceHandler(&stubProbe{deleted: deletedIDs(del...)}, 500)
+	var tm searchPhaseTimings
+	found, _, scanned, err := h.deepProbeVisible(context.Background(), "me", nil, 4, f.fn(), &tm)
+	if err != nil {
+		t.Fatalf("probe: %v", err)
+	}
+	if found {
+		t.Fatal("budget-bounded probe must EXCLUDE when the visible hit is past K2 (⑥)")
+	}
+	if scanned > 4 {
+		t.Errorf("scanned must not exceed the budget of 4; got %d", scanned)
+	}
+	if len(f.gotSizes) == 0 || f.gotSizes[0] != 4 {
+		t.Errorf("first page size must be trimmed to the residual budget 4; got %v", f.gotSizes)
+	}
+}

--- a/modules/messages_search/preview_budget_test.go
+++ b/modules/messages_search/preview_budget_test.go
@@ -1,0 +1,64 @@
+package messages_search
+
+import "testing"
+
+func cb(docCount, latestTS int64) calibratedBucket {
+	return calibratedBucket{pb: parsedBucket{docCount: docCount, latestTS: latestTS}}
+}
+
+// TestAllocatePreviewN_FloorAndClamp — every bucket gets at least 1 and never
+// more than perGroupMax (§4: 老/低频群 N=1).
+func TestAllocatePreviewN_FloorAndClamp(t *testing.T) {
+	buckets := []calibratedBucket{cb(1, 1), cb(1, 1), cb(10_000, 1)}
+	ns := allocatePreviewN(buckets, 500, 20)
+	if len(ns) != 3 {
+		t.Fatalf("want 3 allocations; got %d", len(ns))
+	}
+	for i, n := range ns {
+		if n < 1 {
+			t.Errorf("bucket %d must get at least 1; got %d", i, n)
+		}
+		if n > 20 {
+			t.Errorf("bucket %d must be clamped to perGroupMax=20; got %d", i, n)
+		}
+	}
+	// The dominant-frequency bucket saturates to the perGroupMax clamp.
+	if ns[2] != 20 {
+		t.Errorf("high-frequency bucket should clamp to 20; got %d", ns[2])
+	}
+	// Low-frequency buckets fall to the floor.
+	if ns[0] != 1 || ns[1] != 1 {
+		t.Errorf("low-frequency buckets should sit at the floor of 1; got %d,%d", ns[0], ns[1])
+	}
+}
+
+// TestAllocatePreviewN_FrequencyWeighted — a more active bucket gets no fewer
+// preview rows than a less active one.
+func TestAllocatePreviewN_FrequencyWeighted(t *testing.T) {
+	buckets := []calibratedBucket{cb(5, 1), cb(50, 1), cb(500, 1)}
+	ns := allocatePreviewN(buckets, 60, 20)
+	if !(ns[0] <= ns[1] && ns[1] <= ns[2]) {
+		t.Errorf("N must be non-decreasing with frequency; got %v", ns)
+	}
+}
+
+// TestAllocatePreviewN_BudgetCeiling — the total never exceeds previewBudget.
+func TestAllocatePreviewN_BudgetCeiling(t *testing.T) {
+	buckets := []calibratedBucket{cb(100, 1), cb(200, 1), cb(300, 1), cb(400, 1)}
+	budget := 30
+	ns := allocatePreviewN(buckets, budget, 20)
+	sum := 0
+	for _, n := range ns {
+		sum += n
+	}
+	if sum > budget {
+		t.Errorf("total preview rows %d must not exceed budget %d (%v)", sum, budget, ns)
+	}
+}
+
+// TestAllocatePreviewN_Empty — no buckets → no allocations.
+func TestAllocatePreviewN_Empty(t *testing.T) {
+	if got := allocatePreviewN(nil, 500, 20); len(got) != 0 {
+		t.Errorf("empty buckets → empty allocation; got %v", got)
+	}
+}

--- a/modules/messages_search/route_chain_test.go
+++ b/modules/messages_search/route_chain_test.go
@@ -16,11 +16,11 @@ import (
 // test would flag the drift.
 func TestRouteMountersCoverAllEndpoints(t *testing.T) {
 	// _search, _search_media, _search_files, _search_all, _search_around,
-	// _search_global_messages, _search_global_files. The _search_file_types
-	// enum endpoint is intentionally NOT mounted via registerRoute — it lives
-	// on a separate group without backendGate/Space (§7.5), so it must be
-	// excluded from this counter.
-	const wantEndpoints = 7
+	// _search_global_messages, _search_global_files, _search_global_groups.
+	// The _search_file_types enum endpoint is intentionally NOT mounted via
+	// registerRoute — it lives on a separate group without backendGate/Space
+	// (§7.5), so it must be excluded from this counter.
+	const wantEndpoints = 8
 	if len(routeMounters) != wantEndpoints {
 		t.Fatalf("expected %d endpoints registered via registerRoute (so all go "+
 			"through the shared rate-limit/audit/backendGate chain), got %d. "+

--- a/modules/messages_search/search_global_groups.go
+++ b/modules/messages_search/search_global_groups.go
@@ -1,0 +1,482 @@
+package messages_search
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/modules/thread"
+	"github.com/google/uuid"
+	"github.com/olivere/elastic"
+	"go.uber.org/zap"
+)
+
+// SearchGlobalGroupsReq is the request body for
+// POST /v1/messages/_search_global_groups — the L1 group-aggregation
+// (聚合优先) overview (aggregation-first design §2). Unlike
+// _search_global_messages it has NO sort / page_size / cursor: L1 returns one
+// aggregated overview per request and the bucket order is fixed to latest_at
+// desc. `sequence` is echoed back verbatim for the frontend's stale-response
+// guard (§4) — the backend does not validate its monotonicity.
+type SearchGlobalGroupsReq struct {
+	Keyword  string              `json:"keyword,omitempty"`
+	Sequence int64               `json:"sequence,omitempty"`
+	Filters  GlobalSearchFilters `json:"filters,omitempty"`
+}
+
+// GroupsResult is the `data` object of the L1 response. The outer envelope is
+// the shared {data, pagination} shell (pagination.has_more = 命中群数 >
+// maxGroups; next_cursor is always ""). total_groups is a cardinality HLL
+// estimate so total_groups_approx is always true.
+type GroupsResult struct {
+	Sequence          int64         `json:"sequence"`
+	QueryID           string        `json:"query_id"`
+	TotalGroups       int64         `json:"total_groups"`
+	TotalGroupsApprox bool          `json:"total_groups_approx"`
+	Groups            []GroupBucket `json:"groups"`
+}
+
+// GroupBucket is one aggregated channel/thread/DM bucket. DM buckets carry the
+// reversed peer uid in ChannelID (channel_type=1) with no parent_group_no /
+// thread fields; group buckets set parent_group_no to their own channel_id;
+// thread buckets (channel_type=5) carry parent_group_no + thread_id +
+// thread_name. match_count is the OS doc_count (pre-visibility) so
+// match_count_approx is always true.
+type GroupBucket struct {
+	ChannelID        string       `json:"channel_id"`
+	ChannelType      uint8        `json:"channel_type"`
+	ParentGroupNo    string       `json:"parent_group_no,omitempty"`
+	GroupName        string       `json:"group_name"`
+	ThreadID         string       `json:"thread_id,omitempty"`
+	ThreadName       string       `json:"thread_name,omitempty"`
+	MatchCount       int64        `json:"match_count"`
+	MatchCountApprox bool         `json:"match_count_approx"`
+	LatestAt         string       `json:"latest_at"`
+	Preview          []MessageHit `json:"preview"`
+}
+
+func init() {
+	registerRoute(func(h *Handler, g *wkhttp.RouterGroup) {
+		g.POST("/_search_global_groups", h.searchGlobalGroups)
+	})
+}
+
+// searchGlobalGroups is POST /v1/messages/_search_global_groups. It runs a
+// single OS terms(channelId) aggregation over the caller's allowlist scope
+// (reusing the _search_global_messages DSL) plus an OS-layer visibles
+// whitelist, then projects each bucket into the L1 overview shape. presence
+// calibration + per-frequency preview allocation are backend B — this handler
+// returns the raw top_hits preview.
+func (h *Handler) searchGlobalGroups(c *wkhttp.Context) {
+	var req SearchGlobalGroupsReq
+	if err := c.BindJSON(&req); err != nil {
+		respondValidation(c, "body", "invalid JSON")
+		return
+	}
+	req.Keyword = strings.TrimSpace(req.Keyword)
+	loginUID := c.GetLoginUID()
+
+	if !validateKeywordOptional(c, req.Keyword) {
+		return
+	}
+	// §2.3 trigger gate — STRICTER than _search_global_messages'
+	// validateSearchNotEmpty: sent_at_* / content_types / channel_types alone
+	// do NOT trigger. Only keyword ∨ sender_ids ∨ member_uids/member_uid ∨
+	// channel_ids may open an aggregation, keeping the terms scope bounded.
+	if !groupsTriggerSatisfied(req.Keyword, req.Filters) {
+		respondValidation(c, "keyword", "at least one of keyword, sender_ids, member_uids, or channel_ids is required")
+		return
+	}
+	if _, ok := validateGlobalBase(c, h.cfg, "", "", req.Filters, 0, false); !ok {
+		return
+	}
+
+	osChannelIDs, spaceID, _, allowTimings, ok := h.resolveGlobalScope(c, loginUID, req.Filters.ChannelIDs, req.Filters.MemberUIDs, req.Filters.MemberUID)
+	if !ok {
+		return
+	}
+	recordAllowlistTimings(c, allowTimings)
+	if len(osChannelIDs) == 0 {
+		recordAudit(c, "search_global_groups", 0, "", req.Keyword, 0)
+		c.Response(groupsEnvelope(emptyGroupsResult(req.Sequence), false))
+		return
+	}
+
+	client, err := ESClient(h.cfg)
+	if err != nil {
+		h.Error("ESClient init failed", zap.Error(err))
+		respondUpstream(c)
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(c.Request.Context(), h.cfg.Timeout)
+	defer cancel()
+
+	msgReq := SearchGlobalMessagesReq{Keyword: req.Keyword, Filters: req.Filters}
+	base, analyzeErr := buildGlobalMessagesDSL(ctx, newOSIKSmartAnalyzer(client), h.cfg.StopwordStripEnabled, msgReq, osChannelIDs, spaceID)
+	if analyzeErr != nil {
+		h.Warn("messages_search: _analyze fallback (degraded keyword clause)", zap.Error(analyzeErr))
+	}
+	query := elastic.NewBoolQuery().Filter(base)
+	applyVisiblesWhitelist(query, loginUID)
+
+	res, qerr := h.runGroupsAggregation(ctx, client, query, req.Keyword != "")
+	if qerr != nil {
+		if responder := classifyOSError(qerr); responder != nil {
+			h.Warn("OS search_global_groups failed", zap.Error(qerr))
+			responder(c)
+			return
+		}
+		h.Error("messages_search: groups aggregation failed", zap.Error(qerr))
+		respondInternal(c)
+		return
+	}
+
+	result, hasMore := h.buildGroupsResult(ctx, res, req.Sequence, loginUID)
+	recordAudit(c, "search_global_groups", 0, "", req.Keyword, len(result.Groups))
+	c.Response(groupsEnvelope(result, hasMore))
+}
+
+// groupsTriggerSatisfied implements the §2.3 trigger gate. It deliberately
+// does NOT count sent_at_* / content_types / channel_types — those alone must
+// return VALIDATION_ERROR, which is why hasEffectiveFilters (which treats
+// sent_at as effective) is not reused here.
+func groupsTriggerSatisfied(keyword string, f GlobalSearchFilters) bool {
+	if strings.TrimSpace(keyword) != "" {
+		return true
+	}
+	for _, s := range f.SenderIDs {
+		if strings.TrimSpace(s) != "" {
+			return true
+		}
+	}
+	for _, u := range f.MemberUIDs {
+		if strings.TrimSpace(u) != "" {
+			return true
+		}
+	}
+	if strings.TrimSpace(f.MemberUID) != "" {
+		return true
+	}
+	for _, ref := range f.ChannelIDs {
+		if strings.TrimSpace(ref.ChannelID) != "" {
+			return true
+		}
+	}
+	return false
+}
+
+// applyVisiblesWhitelist adds the OS-layer visibles gate: a doc is visible when
+// its `visibles` array is empty/absent (no per-message allowlist) OR it lists
+// the caller. An empty array indexes no values, so exists(visibles) is false
+// for both absent and empty docs — mustNot(exists) covers the "no gate" case.
+// Together with the revoked mustNot already emitted by buildGlobalMessagesDSL
+// this pushes the two OS-resident visibility signals into the query layer so
+// backend B's presence calibration only has to chase the MySQL-only signals.
+func applyVisiblesWhitelist(b *elastic.BoolQuery, loginUID string) {
+	noGate := elastic.NewBoolQuery().MustNot(elastic.NewExistsQuery("visibles"))
+	listed := elastic.NewTermQuery("visibles", loginUID)
+	b.Filter(elastic.NewBoolQuery().Should(noGate, listed).MinimumShouldMatch("1"))
+}
+
+// runGroupsAggregation issues the single size:0 terms(channelId) aggregation.
+// Each bucket carries max(timestamp) (latest_at), a top_hits over-fetch of
+// T=perGroupMax+presenceProbe (preview + backend-B calibration headroom); a
+// sibling cardinality(channelId) yields the approximate total_groups.
+func (h *Handler) runGroupsAggregation(ctx context.Context, client *elastic.Client, query elastic.Query, withHighlight bool) (*elastic.SearchResult, error) {
+	gc := h.cfg.Groups
+	preview := elastic.NewTopHitsAggregation().
+		Size(gc.TopHitsSize()).
+		SortBy(searchSorters("time_desc")...).
+		FetchSourceContext(fileContentSourceExcludes())
+	if withHighlight {
+		preview = preview.Highlight(buildSearchAllHighlight())
+	}
+	byChannel := elastic.NewTermsAggregation().
+		Field("channelId").
+		Size(gc.MaxGroups).
+		OrderByAggregation("latest", false).
+		SubAggregation("latest", elastic.NewMaxAggregation().Field("timestamp")).
+		SubAggregation("preview", preview)
+	return client.Search().
+		Index(h.cfg.OSReadAlias).
+		Query(query).
+		Size(0).
+		TrackTotalHits(false).
+		Aggregation("by_channel", byChannel).
+		Aggregation("group_count", elastic.NewCardinalityAggregation().Field("channelId")).
+		Do(ctx)
+}
+
+// parsedBucket is the pre-projection view of one terms bucket.
+type parsedBucket struct {
+	key      string
+	docCount int64
+	latestTS int64
+	hits     []*elastic.SearchHit // already capped to perGroupMax
+}
+
+// buildGroupsResult projects the aggregation response into the L1 data object
+// and reports has_more (命中群数 > maxGroups, signalled by the terms
+// sum_other_doc_count on the single-shard index).
+func (h *Handler) buildGroupsResult(ctx context.Context, res *elastic.SearchResult, seq int64, loginUID string) (GroupsResult, bool) {
+	result := emptyGroupsResult(seq)
+	parsed, totalGroups, hasMore, ok := parseGroupsAggregation(res, h.cfg.Groups.PerGroupMax)
+	result.TotalGroups = totalGroups
+	if !ok {
+		return result, false
+	}
+
+	var groupNos, shortIDs, peerUIDs []string
+	for _, pb := range parsed {
+		ct, wireID, parentGroupNo, shortID := classifyGroupBucket(pb.key, loginUID)
+		switch ct {
+		case channelTypePerson:
+			peerUIDs = append(peerUIDs, wireID)
+		case channelTypeGroup:
+			groupNos = append(groupNos, pb.key)
+		case channelTypeThread:
+			groupNos = append(groupNos, parentGroupNo)
+			shortIDs = append(shortIDs, shortID)
+		}
+	}
+
+	groupNames := h.resolveGroupNames(groupNos)
+	threadNames := h.resolveThreadNames(shortIDs)
+	peerNames := h.resolvePeerNames(peerUIDs)
+	previews := h.projectPreview(ctx, parsed, loginUID)
+
+	for i, pb := range parsed {
+		result.Groups = append(result.Groups, assembleGroupBucket(pb, previews[i], loginUID, groupNames, threadNames, peerNames))
+	}
+	return result, hasMore
+}
+
+// parseGroupsAggregation is the pure (I/O-free) reader of the OS aggregation
+// response: it extracts total_groups (cardinality), has_more (terms
+// sum_other_doc_count > 0 on the single-shard index) and each bucket's key /
+// doc_count / latest_at / preview hits (capped to perGroupMax). Kept separate
+// from name resolution so the has_more + bucket parsing can be unit-tested
+// without standing up group/user/thread services. ok=false means the response
+// carried no by_channel terms aggregation.
+func parseGroupsAggregation(res *elastic.SearchResult, perGroupMax int) (buckets []parsedBucket, totalGroups int64, hasMore, ok bool) {
+	if res == nil || res.Aggregations == nil {
+		return nil, 0, false, false
+	}
+	if card, cok := res.Aggregations.Cardinality("group_count"); cok && card.Value != nil {
+		totalGroups = int64(*card.Value)
+	}
+	terms, tok := res.Aggregations.Terms("by_channel")
+	if !tok || terms == nil {
+		return nil, totalGroups, false, false
+	}
+	hasMore = terms.SumOfOtherDocCount > 0
+	for _, b := range terms.Buckets {
+		key := bucketKeyString(b)
+		if key == "" {
+			continue
+		}
+		latestTS := int64(0)
+		if m, mok := b.Max("latest"); mok && m.Value != nil {
+			latestTS = int64(*m.Value)
+		}
+		var hits []*elastic.SearchHit
+		if th, hok := b.TopHits("preview"); hok && th != nil && th.Hits != nil {
+			hits = th.Hits.Hits
+			if perGroupMax > 0 && len(hits) > perGroupMax {
+				hits = hits[:perGroupMax]
+			}
+		}
+		buckets = append(buckets, parsedBucket{key: key, docCount: b.DocCount, latestTS: latestTS, hits: hits})
+	}
+	return buckets, totalGroups, hasMore, true
+}
+
+// projectPreview turns each bucket's raw top_hits into []MessageHit and fills
+// sender names/avatars in a single batched senderJoin across all buckets (the
+// global endpoints deliberately skip per-group remark scoping — channelType=0
+// degrades senderJoin to a plain user lookup).
+func (h *Handler) projectPreview(ctx context.Context, buckets []parsedBucket, loginUID string) [][]MessageHit {
+	previews := make([][]MessageHit, len(buckets))
+	var senderIDs []string
+	for bi, pb := range buckets {
+		hits := make([]MessageHit, 0, len(pb.hits))
+		for _, hit := range pb.hits {
+			var doc Doc
+			if err := json.Unmarshal(rawSource(hit.Source), &doc); err != nil {
+				h.Warn("messages_search: bad groups preview _source skipped", zap.Error(err))
+				continue
+			}
+			wireID, wireType := wireChannelFromDoc(doc, loginUID)
+			mh := h.singleMessageHit(doc, wireID, wireType, map[string][]string(hit.Highlight))
+			hits = append(hits, mh)
+			senderIDs = append(senderIDs, doc.From)
+			for _, im := range mh.InnerMessages {
+				if im.SenderID != "" {
+					senderIDs = append(senderIDs, im.SenderID)
+				}
+			}
+		}
+		previews[bi] = hits
+	}
+	join := h.senderJoin(ctx, uniqUIDs(senderIDs), 0, "")
+	for bi := range previews {
+		for i := range previews[bi] {
+			mh := &previews[bi][i]
+			mh.SenderName = join.Names[mh.SenderID]
+			mh.SenderAvatarURL = join.Avatars[mh.SenderID]
+			for j := range mh.InnerMessages {
+				if uid := mh.InnerMessages[j].SenderID; uid != "" {
+					mh.InnerMessages[j].SenderName = join.Names[uid]
+				}
+			}
+		}
+	}
+	return previews
+}
+
+// classifyGroupBucket maps a terms(channelId) key to its wire shape. DM buckets
+// carry a p2p fake channelId (`uidA@uidB`) reversed to the peer uid; thread
+// buckets carry the composite `{group_no}____{short_id}`; everything else is a
+// group whose parent_group_no is itself.
+func classifyGroupBucket(key, loginUID string) (channelType uint8, wireID, parentGroupNo, threadShortID string) {
+	if common.IsFakeChannel(key) {
+		return channelTypePerson, common.GetToChannelIDWithFakeChannelID(key, loginUID), "", ""
+	}
+	if groupNo, shortID, err := thread.ParseChannelID(key); err == nil {
+		return channelTypeThread, key, groupNo, shortID
+	}
+	return channelTypeGroup, key, key, ""
+}
+
+// assembleGroupBucket builds the wire bucket from the parsed bucket + resolved
+// name maps. Pure (no I/O) so the DM reversal / thread parent_group_no / group
+// shapes are unit-testable without OS or MySQL.
+func assembleGroupBucket(pb parsedBucket, preview []MessageHit, loginUID string, groupNames, threadNames, peerNames map[string]string) GroupBucket {
+	if preview == nil {
+		preview = []MessageHit{}
+	}
+	ct, wireID, parentGroupNo, threadShortID := classifyGroupBucket(pb.key, loginUID)
+	gb := GroupBucket{
+		ChannelID:        wireID,
+		ChannelType:      ct,
+		MatchCount:       pb.docCount,
+		MatchCountApprox: true,
+		LatestAt:         msToRFC3339(pb.latestTS),
+		Preview:          preview,
+	}
+	switch ct {
+	case channelTypePerson:
+		gb.GroupName = peerNames[wireID]
+	case channelTypeGroup:
+		gb.ParentGroupNo = pb.key
+		gb.GroupName = groupNames[pb.key]
+	case channelTypeThread:
+		gb.ParentGroupNo = parentGroupNo
+		gb.ThreadID = pb.key
+		gb.ThreadName = threadNames[threadShortID]
+		gb.GroupName = groupNames[parentGroupNo]
+	}
+	return gb
+}
+
+// resolveGroupNames batch-resolves group_no → group name. Soft-fail: on error
+// the names are dropped (empty group_name) but the request still serves.
+func (h *Handler) resolveGroupNames(groupNos []string) map[string]string {
+	out := map[string]string{}
+	groupNos = uniqUIDs(groupNos)
+	if len(groupNos) == 0 {
+		return out
+	}
+	infos, err := h.groupService.GetGroups(groupNos)
+	if err != nil {
+		h.Warn("messages_search: groups name lookup failed", zap.Error(err))
+		return out
+	}
+	for _, g := range infos {
+		if g != nil {
+			out[g.GroupNo] = g.Name
+		}
+	}
+	return out
+}
+
+// resolvePeerNames batch-resolves DM peer uid → display name via the user
+// profile (§5b: DM header名字走对端用户档案 fallback). Soft-fail to placeholder.
+func (h *Handler) resolvePeerNames(peerUIDs []string) map[string]string {
+	out := map[string]string{}
+	peerUIDs = uniqUIDs(peerUIDs)
+	if len(peerUIDs) == 0 {
+		return out
+	}
+	users, err := h.userService.GetUsers(peerUIDs)
+	if err != nil {
+		h.Warn("messages_search: DM peer name lookup failed", zap.Error(err))
+		return out
+	}
+	for _, u := range users {
+		if u != nil {
+			out[u.UID] = u.Name
+		}
+	}
+	return out
+}
+
+// resolveThreadNames batch-resolves thread short_id → thread name. Soft-fail:
+// on error thread_name is left empty and the bucket still renders under its
+// parent group.
+func (h *Handler) resolveThreadNames(shortIDs []string) map[string]string {
+	out := map[string]string{}
+	shortIDs = uniqUIDs(shortIDs)
+	if len(shortIDs) == 0 {
+		return out
+	}
+	models, err := thread.NewDB(h.ctx).QueryByShortIDs(shortIDs)
+	if err != nil {
+		h.Warn("messages_search: thread name lookup failed", zap.Error(err))
+		return out
+	}
+	for sid, m := range models {
+		if m != nil {
+			out[sid] = m.Name
+		}
+	}
+	return out
+}
+
+// bucketKeyString reads the terms bucket key as a string (channelId is a
+// keyword field). Falls back to key_as_string for defensiveness.
+func bucketKeyString(b *elastic.AggregationBucketKeyItem) string {
+	if b == nil {
+		return ""
+	}
+	if s, ok := b.Key.(string); ok {
+		return s
+	}
+	if b.KeyAsString != nil {
+		return *b.KeyAsString
+	}
+	return ""
+}
+
+// emptyGroupsResult is the zero-hit / empty-scope data object (§5.5).
+func emptyGroupsResult(seq int64) GroupsResult {
+	return GroupsResult{
+		Sequence:          seq,
+		QueryID:           uuid.NewString(),
+		TotalGroups:       0,
+		TotalGroupsApprox: true,
+		Groups:            []GroupBucket{},
+	}
+}
+
+// groupsEnvelope wraps the L1 data object into the shared {data, pagination}
+// shell. next_cursor is always "" (L1 has no per-row pagination).
+func groupsEnvelope(result GroupsResult, hasMore bool) CursorList {
+	return CursorList{
+		Data:       result,
+		Pagination: Pagination{HasMore: hasMore, NextCursor: ""},
+	}
+}

--- a/modules/messages_search/search_global_groups.go
+++ b/modules/messages_search/search_global_groups.go
@@ -134,7 +134,21 @@ func (h *Handler) searchGlobalGroups(c *wkhttp.Context) {
 		return
 	}
 
-	result, hasMore := h.buildGroupsResult(ctx, res, req.Sequence, loginUID)
+	result, hasMore, berr := h.buildGroupsResult(ctx, c, res, req.Sequence, loginUID, client, base)
+	if berr != nil {
+		// Deep-probe OS round-trips can fail like any other search; a
+		// classifiable OS error maps to UPSTREAM_UNAVAILABLE, everything else
+		// (notably the fail-closed filterVisible DB gate) is INTERNAL_ERROR so
+		// we never fall through to leaking uncalibrated preview.
+		if responder := classifyOSError(berr); responder != nil {
+			h.Warn("OS presence deep-probe failed", zap.Error(berr))
+			responder(c)
+			return
+		}
+		h.Error("messages_search: presence calibration failed", zap.Error(berr))
+		respondInternal(c)
+		return
+	}
 	recordAudit(c, "search_global_groups", 0, "", req.Keyword, len(result.Groups))
 	c.Response(groupsEnvelope(result, hasMore))
 }
@@ -218,25 +232,56 @@ type parsedBucket struct {
 	hits     []*elastic.SearchHit // already capped to perGroupMax
 }
 
-// buildGroupsResult projects the aggregation response into the L1 data object
-// and reports has_more (命中群数 > maxGroups, signalled by the terms
-// sum_other_doc_count on the single-shard index).
-func (h *Handler) buildGroupsResult(ctx context.Context, res *elastic.SearchResult, seq int64, loginUID string) (GroupsResult, bool) {
+// buildGroupsResult projects the aggregation response into the L1 data object.
+// Backend B: between parse and assemble it runs presence calibration (§2.2) so
+// every returned bucket "确有可见命中" and every preview row is a filterVisible
+// -passed visible hit — the raw top_hits are NEVER projected to the wire (that
+// was the A-review Blocker: uncalibrated preview leaked snippet/sender/time of
+// admin-deleted / self-deleted / cleared-history messages). has_more still
+// reflects 命中群数 > maxGroups (terms sum_other_doc_count on the single-shard
+// index). Returns an error when calibration hits a fail-closed DB gate or a
+// deep-probe OS round-trip fails, so the caller can respond upstream/internal
+// instead of leaking.
+func (h *Handler) buildGroupsResult(ctx context.Context, c *wkhttp.Context, res *elastic.SearchResult, seq int64, loginUID string, client *elastic.Client, base elastic.Query) (GroupsResult, bool, error) {
 	result := emptyGroupsResult(seq)
-	parsed, totalGroups, hasMore, ok := parseGroupsAggregation(res, h.cfg.Groups.PerGroupMax)
+	// Keep the FULL over-fetched top-T sample (T=perGroupMax+presenceProbe) for
+	// calibration — do not truncate to perGroupMax here; preview trimming to the
+	// per-frequency N happens after INCLUDE/EXCLUDE is decided.
+	parsed, totalGroups, hasMore, ok := parseGroupsAggregation(res, h.cfg.Groups.TopHitsSize())
 	result.TotalGroups = totalGroups
 	if !ok {
-		return result, false
+		return result, false, nil
+	}
+
+	var timings searchPhaseTimings
+	calibrated, stats, err := h.calibratePresence(ctx, client, base, parsed, loginUID, &timings)
+	recordSearchTimings(c, timings)
+	recordPresenceStats(c, stats)
+	if err != nil {
+		return result, false, err
+	}
+
+	// Per-frequency N allocation (§4): spread previewBudget across the surviving
+	// buckets weighted by match frequency, then take the most-recent N visible
+	// rows per bucket.
+	ns := allocatePreviewN(calibrated, h.cfg.Groups.PreviewBudget, h.cfg.Groups.PerGroupMax)
+	visibleHits := make([][]*elastic.SearchHit, len(calibrated))
+	for i, cb := range calibrated {
+		k := ns[i]
+		if k > len(cb.visible) {
+			k = len(cb.visible)
+		}
+		visibleHits[i] = cb.visible[:k]
 	}
 
 	var groupNos, shortIDs, peerUIDs []string
-	for _, pb := range parsed {
-		ct, wireID, parentGroupNo, shortID := classifyGroupBucket(pb.key, loginUID)
+	for _, cb := range calibrated {
+		ct, wireID, parentGroupNo, shortID := classifyGroupBucket(cb.pb.key, loginUID)
 		switch ct {
 		case channelTypePerson:
 			peerUIDs = append(peerUIDs, wireID)
 		case channelTypeGroup:
-			groupNos = append(groupNos, pb.key)
+			groupNos = append(groupNos, cb.pb.key)
 		case channelTypeThread:
 			groupNos = append(groupNos, parentGroupNo)
 			shortIDs = append(shortIDs, shortID)
@@ -246,22 +291,24 @@ func (h *Handler) buildGroupsResult(ctx context.Context, res *elastic.SearchResu
 	groupNames := h.resolveGroupNames(groupNos)
 	threadNames := h.resolveThreadNames(shortIDs)
 	peerNames := h.resolvePeerNames(peerUIDs)
-	previews := h.projectPreview(ctx, parsed, loginUID)
+	previews := h.projectPreview(ctx, visibleHits, loginUID)
 
-	for i, pb := range parsed {
-		result.Groups = append(result.Groups, assembleGroupBucket(pb, previews[i], loginUID, groupNames, threadNames, peerNames))
+	for i, cb := range calibrated {
+		result.Groups = append(result.Groups, assembleGroupBucket(cb.pb, previews[i], loginUID, groupNames, threadNames, peerNames))
 	}
-	return result, hasMore
+	return result, hasMore, nil
 }
 
 // parseGroupsAggregation is the pure (I/O-free) reader of the OS aggregation
 // response: it extracts total_groups (cardinality), has_more (terms
 // sum_other_doc_count > 0 on the single-shard index) and each bucket's key /
-// doc_count / latest_at / preview hits (capped to perGroupMax). Kept separate
-// from name resolution so the has_more + bucket parsing can be unit-tested
-// without standing up group/user/thread services. ok=false means the response
-// carried no by_channel terms aggregation.
-func parseGroupsAggregation(res *elastic.SearchResult, perGroupMax int) (buckets []parsedBucket, totalGroups int64, hasMore, ok bool) {
+// doc_count / latest_at / preview hits (capped to capHits). Backend B passes
+// TopHitsSize() as capHits so the full over-fetched top-T sample survives for
+// presence calibration; preview trimming to the per-frequency N happens later.
+// Kept separate from name resolution so the has_more + bucket parsing can be
+// unit-tested without standing up group/user/thread services. ok=false means
+// the response carried no by_channel terms aggregation.
+func parseGroupsAggregation(res *elastic.SearchResult, capHits int) (buckets []parsedBucket, totalGroups int64, hasMore, ok bool) {
 	if res == nil || res.Aggregations == nil {
 		return nil, 0, false, false
 	}
@@ -285,8 +332,8 @@ func parseGroupsAggregation(res *elastic.SearchResult, perGroupMax int) (buckets
 		var hits []*elastic.SearchHit
 		if th, hok := b.TopHits("preview"); hok && th != nil && th.Hits != nil {
 			hits = th.Hits.Hits
-			if perGroupMax > 0 && len(hits) > perGroupMax {
-				hits = hits[:perGroupMax]
+			if capHits > 0 && len(hits) > capHits {
+				hits = hits[:capHits]
 			}
 		}
 		buckets = append(buckets, parsedBucket{key: key, docCount: b.DocCount, latestTS: latestTS, hits: hits})
@@ -294,16 +341,18 @@ func parseGroupsAggregation(res *elastic.SearchResult, perGroupMax int) (buckets
 	return buckets, totalGroups, hasMore, true
 }
 
-// projectPreview turns each bucket's raw top_hits into []MessageHit and fills
-// sender names/avatars in a single batched senderJoin across all buckets (the
-// global endpoints deliberately skip per-group remark scoping — channelType=0
-// degrades senderJoin to a plain user lookup).
-func (h *Handler) projectPreview(ctx context.Context, buckets []parsedBucket, loginUID string) [][]MessageHit {
-	previews := make([][]MessageHit, len(buckets))
+// projectPreview turns each bucket's already-calibrated visible hits into
+// []MessageHit and fills sender names/avatars in a single batched senderJoin
+// across all buckets (the global endpoints deliberately skip per-group remark
+// scoping — channelType=0 degrades senderJoin to a plain user lookup). Input is
+// the presence-calibrated + N-trimmed visible hits per bucket, so nothing here
+// reaches the wire without having passed filterVisible.
+func (h *Handler) projectPreview(ctx context.Context, bucketHits [][]*elastic.SearchHit, loginUID string) [][]MessageHit {
+	previews := make([][]MessageHit, len(bucketHits))
 	var senderIDs []string
-	for bi, pb := range buckets {
-		hits := make([]MessageHit, 0, len(pb.hits))
-		for _, hit := range pb.hits {
+	for bi, hitList := range bucketHits {
+		hits := make([]MessageHit, 0, len(hitList))
+		for _, hit := range hitList {
 			var doc Doc
 			if err := json.Unmarshal(rawSource(hit.Source), &doc); err != nil {
 				h.Warn("messages_search: bad groups preview _source skipped", zap.Error(err))

--- a/modules/messages_search/search_global_groups.go
+++ b/modules/messages_search/search_global_groups.go
@@ -29,8 +29,17 @@ type SearchGlobalGroupsReq struct {
 
 // GroupsResult is the `data` object of the L1 response. The outer envelope is
 // the shared {data, pagination} shell (pagination.has_more = 命中群数 >
-// maxGroups; next_cursor is always ""). total_groups is a cardinality HLL
-// estimate so total_groups_approx is always true.
+// maxGroups; next_cursor is always "").
+//
+// total_groups is a cardinality HLL estimate over the PRE-visibility candidate
+// set, so total_groups_approx is always true. Per the aggregation-first design
+// §6 ("count 近似，精确计数成本无界不做") this is an accepted, non-sensitive
+// pre-filter approximation — deliberately NOT post-calibrated against
+// filterVisible (owner decision, option A): recomputing it could only count the
+// visible docs inside the bounded sampling window, which is itself an
+// approximation at unbounded cost. Contrast latest_at / bucket order, which WERE
+// real leaks of hidden messages' recency and are now recomputed from the visible
+// hit (see GroupBucket.LatestAt).
 type GroupsResult struct {
 	Sequence          int64         `json:"sequence"`
 	QueryID           string        `json:"query_id"`
@@ -43,10 +52,20 @@ type GroupsResult struct {
 // reversed peer uid in ChannelID (channel_type=1) with no parent_group_no /
 // thread fields; group buckets set parent_group_no to their own channel_id;
 // thread buckets (channel_type=5) carry parent_group_no + thread_id +
-// thread_name. match_count is the OS doc_count (pre-visibility) so
-// match_count_approx is always true. latest_at, by contrast, is recomputed from
-// the calibrated visible hit (see calibratedBucket.latestVisibleTS) — never the
-// OS pre-filter max(timestamp) — so a hidden newest match cannot leak its time.
+// thread_name.
+//
+// match_count is the OS doc_count — a PRE-visibility approximate metric, so
+// match_count_approx is always true. Per design §6 + owner decision (option A)
+// it is deliberately left as the pre-filter count and NOT post-calibrated: it
+// therefore INCLUDES hits hidden from the caller by the five visibility gates
+// (admin/mutual delete, self-delete, cleared history, visibles) and so may read
+// HIGHER than the number of messages the caller can actually open. This is an
+// accepted, non-sensitive approximation (it exposes only a possibly-inflated
+// count, never a hidden message's content/sender/time); match_count_approx=true
+// is the wire signal of exactly this. latest_at, by contrast, IS recomputed
+// from the calibrated visible hit (see calibratedBucket.latestVisibleTS) — never
+// the OS pre-filter max(timestamp) — because a hidden newest match there would
+// leak its time and bias bucket order (a real leak, now fixed).
 type GroupBucket struct {
 	ChannelID        string       `json:"channel_id"`
 	ChannelType      uint8        `json:"channel_type"`
@@ -54,6 +73,9 @@ type GroupBucket struct {
 	GroupName        string       `json:"group_name"`
 	ThreadID         string       `json:"thread_id,omitempty"`
 	ThreadName       string       `json:"thread_name,omitempty"`
+	// MatchCount is the pre-visibility OS doc_count (may exceed the caller's
+	// visible count — see the type doc). Left as-is by design §6 / owner
+	// option A; MatchCountApprox flags it.
 	MatchCount       int64        `json:"match_count"`
 	MatchCountApprox bool         `json:"match_count_approx"`
 	LatestAt         string       `json:"latest_at"`
@@ -445,8 +467,11 @@ func assembleGroupBucket(pb parsedBucket, latestAtMS int64, preview []MessageHit
 	}
 	ct, wireID, parentGroupNo, threadShortID := classifyGroupBucket(pb.key, loginUID)
 	gb := GroupBucket{
-		ChannelID:        wireID,
-		ChannelType:      ct,
+		ChannelID:   wireID,
+		ChannelType: ct,
+		// match_count = pre-visibility OS doc_count (design §6 / owner option A):
+		// kept as the pre-filter approximation, may include hidden hits, flagged
+		// by MatchCountApprox. Only latest_at is recalibrated to visible hits.
 		MatchCount:       pb.docCount,
 		MatchCountApprox: true,
 		LatestAt:         msToRFC3339(latestAtMS),

--- a/modules/messages_search/search_global_groups.go
+++ b/modules/messages_search/search_global_groups.go
@@ -3,6 +3,7 @@ package messages_search
 import (
 	"context"
 	"encoding/json"
+	"sort"
 	"strings"
 
 	"github.com/Mininglamp-OSS/octo-lib/common"
@@ -43,7 +44,9 @@ type GroupsResult struct {
 // thread fields; group buckets set parent_group_no to their own channel_id;
 // thread buckets (channel_type=5) carry parent_group_no + thread_id +
 // thread_name. match_count is the OS doc_count (pre-visibility) so
-// match_count_approx is always true.
+// match_count_approx is always true. latest_at, by contrast, is recomputed from
+// the calibrated visible hit (see calibratedBucket.latestVisibleTS) — never the
+// OS pre-filter max(timestamp) — so a hidden newest match cannot leak its time.
 type GroupBucket struct {
 	ChannelID        string       `json:"channel_id"`
 	ChannelType      uint8        `json:"channel_type"`
@@ -196,9 +199,13 @@ func applyVisiblesWhitelist(b *elastic.BoolQuery, loginUID string) {
 }
 
 // runGroupsAggregation issues the single size:0 terms(channelId) aggregation.
-// Each bucket carries max(timestamp) (latest_at), a top_hits over-fetch of
+// Each bucket carries max(timestamp), a top_hits over-fetch of
 // T=perGroupMax+presenceProbe (preview + backend-B calibration headroom); a
-// sibling cardinality(channelId) yields the approximate total_groups.
+// sibling cardinality(channelId) yields the approximate total_groups. The
+// max(timestamp) sub-agg orders the terms buckets so we pick the latest-active
+// maxGroups CANDIDATES — it is NOT the wire latest_at: that is recomputed from
+// the calibrated visible hit in buildGroupsResult (RC fix), which also re-sorts
+// the survivors by that visible time.
 func (h *Handler) runGroupsAggregation(ctx context.Context, client *elastic.Client, query elastic.Query, withHighlight bool) (*elastic.SearchResult, error) {
 	gc := h.cfg.Groups
 	preview := elastic.NewTopHitsAggregation().
@@ -224,7 +231,10 @@ func (h *Handler) runGroupsAggregation(ctx context.Context, client *elastic.Clie
 		Do(ctx)
 }
 
-// parsedBucket is the pre-projection view of one terms bucket.
+// parsedBucket is the pre-projection view of one terms bucket. latestTS is the
+// OS pre-filter max(timestamp) — retained for the terms candidate ordering and
+// diagnostics only; it is NOT the wire latest_at (which is recomputed from the
+// calibrated visible hit — see calibratedBucket.latestVisibleTS).
 type parsedBucket struct {
 	key      string
 	docCount int64
@@ -261,6 +271,18 @@ func (h *Handler) buildGroupsResult(ctx context.Context, c *wkhttp.Context, res 
 		return result, false, err
 	}
 
+	// RC fix: latest_at and the returned bucket order must reflect the
+	// CALIBRATED visible hit, never the OS pre-filter max(timestamp). The OS
+	// terms agg still orders CANDIDATES by pre-filter max — that only decides
+	// which maxGroups buckets we look at, and since visible ⊆ all a bucket whose
+	// visible latest is recent also has an at-least-as-recent pre-filter max, so
+	// no bucket that should surface is dropped from the candidate set. But the
+	// FINAL order returned to the client is re-sorted here by the visible
+	// latest_at, so a bucket whose newest match is hidden (admin/self-deleted,
+	// cleared history, visibles) no longer jumps the order or leaks its hidden
+	// recency.
+	sortByVisibleLatest(calibrated)
+
 	// Per-frequency N allocation (§4): spread previewBudget across the surviving
 	// buckets weighted by match frequency, then take the most-recent N visible
 	// rows per bucket.
@@ -294,9 +316,20 @@ func (h *Handler) buildGroupsResult(ctx context.Context, c *wkhttp.Context, res 
 	previews := h.projectPreview(ctx, visibleHits, loginUID)
 
 	for i, cb := range calibrated {
-		result.Groups = append(result.Groups, assembleGroupBucket(cb.pb, previews[i], loginUID, groupNames, threadNames, peerNames))
+		result.Groups = append(result.Groups, assembleGroupBucket(cb.pb, cb.latestVisibleTS, previews[i], loginUID, groupNames, threadNames, peerNames))
 	}
 	return result, hasMore, nil
+}
+
+// sortByVisibleLatest reorders the calibrated buckets most-recent-first by the
+// CALIBRATED visible latest_at (RC fix, §2.2). Stable, so equal-timestamp
+// buckets keep the OS candidate order (pre-filter max desc) as a deterministic
+// tiebreak. This is the guarantee that a bucket whose newest match is hidden
+// cannot bias the returned order by its hidden recency.
+func sortByVisibleLatest(calibrated []calibratedBucket) {
+	sort.SliceStable(calibrated, func(i, j int) bool {
+		return calibrated[i].latestVisibleTS > calibrated[j].latestVisibleTS
+	})
 }
 
 // parseGroupsAggregation is the pure (I/O-free) reader of the OS aggregation
@@ -401,9 +434,12 @@ func classifyGroupBucket(key, loginUID string) (channelType uint8, wireID, paren
 }
 
 // assembleGroupBucket builds the wire bucket from the parsed bucket + resolved
-// name maps. Pure (no I/O) so the DM reversal / thread parent_group_no / group
+// name maps. latestAtMS is the CALIBRATED visible latest_at (calibratedBucket
+// .latestVisibleTS) — deliberately passed in rather than read from pb.latestTS
+// (the OS pre-filter max) so a hidden newest match never leaks its timestamp
+// (RC fix). Pure (no I/O) so the DM reversal / thread parent_group_no / group
 // shapes are unit-testable without OS or MySQL.
-func assembleGroupBucket(pb parsedBucket, preview []MessageHit, loginUID string, groupNames, threadNames, peerNames map[string]string) GroupBucket {
+func assembleGroupBucket(pb parsedBucket, latestAtMS int64, preview []MessageHit, loginUID string, groupNames, threadNames, peerNames map[string]string) GroupBucket {
 	if preview == nil {
 		preview = []MessageHit{}
 	}
@@ -413,7 +449,7 @@ func assembleGroupBucket(pb parsedBucket, preview []MessageHit, loginUID string,
 		ChannelType:      ct,
 		MatchCount:       pb.docCount,
 		MatchCountApprox: true,
-		LatestAt:         msToRFC3339(pb.latestTS),
+		LatestAt:         msToRFC3339(latestAtMS),
 		Preview:          preview,
 	}
 	switch ct {

--- a/modules/messages_search/search_global_groups_test.go
+++ b/modules/messages_search/search_global_groups_test.go
@@ -1,0 +1,268 @@
+package messages_search
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-server/modules/thread"
+	"github.com/olivere/elastic"
+)
+
+// --- §2.3 trigger gate: three states ---------------------------------------
+
+func TestGroupsTriggerSatisfied(t *testing.T) {
+	cases := []struct {
+		name    string
+		keyword string
+		filters GlobalSearchFilters
+		want    bool
+	}{
+		{"keyword", "hello", GlobalSearchFilters{}, true},
+		{"sender", "", GlobalSearchFilters{SenderIDs: []string{"u1"}}, true},
+		{"member_uids", "", GlobalSearchFilters{MemberUIDs: []string{"u2"}}, true},
+		{"member_uid legacy", "", GlobalSearchFilters{MemberUID: "u3"}, true},
+		{"channel_ids", "", GlobalSearchFilters{ChannelIDs: []GlobalChannelRef{{ChannelID: "gA", ChannelType: 2}}}, true},
+		// The three that must NOT trigger on their own (stricter than
+		// validateSearchNotEmpty, which treats sent_at as effective).
+		{"sent_at only", "", GlobalSearchFilters{SentAtFrom: "2026-01-01T00:00:00Z"}, false},
+		{"content_types only", "", GlobalSearchFilters{ContentTypes: []int{1}}, false},
+		{"channel_types only", "", GlobalSearchFilters{ChannelTypes: []uint8{2}}, false},
+		{"empty", "", GlobalSearchFilters{}, false},
+		// Blank-only entries do not trigger.
+		{"blank sender", "", GlobalSearchFilters{SenderIDs: []string{"  "}}, false},
+		{"blank channel_id", "", GlobalSearchFilters{ChannelIDs: []GlobalChannelRef{{ChannelID: "  "}}}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := groupsTriggerSatisfied(tc.keyword, tc.filters); got != tc.want {
+				t.Errorf("groupsTriggerSatisfied(%q,%+v)=%v want %v", tc.keyword, tc.filters, got, tc.want)
+			}
+		})
+	}
+}
+
+// --- visibles + revoked blocked at the OS query layer ----------------------
+
+// TestGroupsDSL_VisiblesAndRevokedAtOSLayer builds the exact filter the handler
+// hands to OS (base _search_global_messages DSL + visibles whitelist) and
+// asserts both OS-resident visibility signals are pushed into the query.
+func TestGroupsDSL_VisiblesAndRevokedAtOSLayer(t *testing.T) {
+	msgReq := SearchGlobalMessagesReq{Keyword: "report", Filters: GlobalSearchFilters{}}
+	base, _ := buildGlobalMessagesDSL(context.Background(), fallbackTestAnalyzer(), true, msgReq, []string{"gA", "gB"}, "space1")
+	query := elastic.NewBoolQuery().Filter(base)
+	applyVisiblesWhitelist(query, "me")
+	body := marshalDSL(t, query)
+
+	if !strings.Contains(body, `"visibles"`) {
+		t.Errorf("visibles whitelist must be in the OS query:\n%s", body)
+	}
+	if !strings.Contains(body, `"revoked"`) {
+		t.Errorf("revoked must_not must be in the OS query:\n%s", body)
+	}
+	// The visibles gate must be a should(mustNot exists, term=me) so empty/absent
+	// visibles stays visible while a listed caller matches.
+	if !strings.Contains(body, `"exists"`) {
+		t.Errorf("visibles gate must use exists() for the no-gate branch:\n%s", body)
+	}
+	if !strings.Contains(body, `"channelId"`) {
+		t.Errorf("terms(channelId) allowlist scope must be in the OS query:\n%s", body)
+	}
+}
+
+// TestApplyVisiblesWhitelist_ShouldShape pins the should/minimum_should_match
+// structure independently of the base DSL.
+func TestApplyVisiblesWhitelist_ShouldShape(t *testing.T) {
+	b := elastic.NewBoolQuery()
+	applyVisiblesWhitelist(b, "u42")
+	body := marshalDSL(t, b)
+	if !strings.Contains(body, `"minimum_should_match":"1"`) {
+		t.Errorf("visibles gate must require minimum_should_match=1:\n%s", body)
+	}
+	if !strings.Contains(body, `"u42"`) {
+		t.Errorf("visibles gate must term-match the caller uid:\n%s", body)
+	}
+}
+
+// --- bucket projection: DM reversal / thread / group ------------------------
+
+func TestAssembleGroupBucket_DMReversal(t *testing.T) {
+	loginUID, peerUID := "me", "peer99"
+	key := fakeChannelIDFor(loginUID, peerUID)
+	pb := parsedBucket{key: key, docCount: 8, latestTS: 1_700_000_000}
+	gb := assembleGroupBucket(pb, nil, loginUID, nil, nil, map[string]string{peerUID: "张三"})
+
+	if gb.ChannelType != channelTypePerson {
+		t.Errorf("DM bucket channel_type=1; got %d", gb.ChannelType)
+	}
+	if gb.ChannelID != peerUID {
+		t.Errorf("DM channel_id must reverse to peer uid %q; got %q", peerUID, gb.ChannelID)
+	}
+	if gb.ParentGroupNo != "" || gb.ThreadID != "" || gb.ThreadName != "" {
+		t.Errorf("DM bucket must not carry parent_group_no/thread fields: %+v", gb)
+	}
+	if gb.GroupName != "张三" {
+		t.Errorf("DM group_name must come from peer profile; got %q", gb.GroupName)
+	}
+	if !gb.MatchCountApprox || gb.MatchCount != 8 {
+		t.Errorf("match_count=8 approx=true expected; got %d/%v", gb.MatchCount, gb.MatchCountApprox)
+	}
+	// preview must serialise as [] not null.
+	if b, _ := json.Marshal(gb); !strings.Contains(string(b), `"preview":[]`) {
+		t.Errorf("preview must serialise as []: %s", b)
+	}
+}
+
+func TestAssembleGroupBucket_Thread(t *testing.T) {
+	loginUID := "me"
+	groupNo, shortID := "gA", "thr1"
+	key := thread.BuildChannelID(groupNo, shortID)
+	pb := parsedBucket{key: key, docCount: 12, latestTS: 1_700_000_100}
+	gb := assembleGroupBucket(pb, []MessageHit{}, loginUID,
+		map[string]string{groupNo: "项目群"}, map[string]string{shortID: "需求评审"}, nil)
+
+	if gb.ChannelType != channelTypeThread {
+		t.Errorf("thread bucket channel_type=5; got %d", gb.ChannelType)
+	}
+	if gb.ParentGroupNo != groupNo {
+		t.Errorf("thread parent_group_no must be %q; got %q", groupNo, gb.ParentGroupNo)
+	}
+	if gb.ThreadID != key {
+		t.Errorf("thread_id must be the composite channel_id %q; got %q", key, gb.ThreadID)
+	}
+	if gb.ThreadName != "需求评审" {
+		t.Errorf("thread_name mismatch; got %q", gb.ThreadName)
+	}
+	if gb.GroupName != "项目群" {
+		t.Errorf("thread group_name must be the parent group name; got %q", gb.GroupName)
+	}
+	if gb.ChannelID != key {
+		t.Errorf("thread channel_id echoes the composite id; got %q", gb.ChannelID)
+	}
+}
+
+func TestAssembleGroupBucket_Group(t *testing.T) {
+	pb := parsedBucket{key: "gZ", docCount: 128, latestTS: 1_700_000_200}
+	gb := assembleGroupBucket(pb, nil, "me", map[string]string{"gZ": "大群"}, nil, nil)
+
+	if gb.ChannelType != channelTypeGroup {
+		t.Errorf("group bucket channel_type=2; got %d", gb.ChannelType)
+	}
+	if gb.ParentGroupNo != "gZ" {
+		t.Errorf("group parent_group_no must equal its own channel_id; got %q", gb.ParentGroupNo)
+	}
+	if gb.ThreadID != "" || gb.ThreadName != "" {
+		t.Errorf("group bucket must not carry thread fields: %+v", gb)
+	}
+	if gb.GroupName != "大群" {
+		t.Errorf("group_name mismatch; got %q", gb.GroupName)
+	}
+}
+
+// --- response shell + has_more (parse from a synthetic OS aggregation) ------
+
+func aggResult(t *testing.T, raw string) *elastic.SearchResult {
+	t.Helper()
+	var aggs elastic.Aggregations
+	if err := json.Unmarshal([]byte(raw), &aggs); err != nil {
+		t.Fatalf("bad test aggregation json: %v", err)
+	}
+	return &elastic.SearchResult{Aggregations: aggs}
+}
+
+func TestParseGroupsAggregation_HasMoreAndTotals(t *testing.T) {
+	// sum_other_doc_count > 0 → more groups than the bucket cap → has_more.
+	raw := `{
+	  "group_count": {"value": 37},
+	  "by_channel": {
+	    "doc_count_error_upper_bound": 0,
+	    "sum_other_doc_count": 5,
+	    "buckets": [
+	      {"key":"gA","doc_count":12,"latest":{"value":1700000000.0},"preview":{"hits":{"total":1,"hits":[]}}},
+	      {"key":"gB","doc_count":3,"latest":{"value":1699999000.0},"preview":{"hits":{"total":1,"hits":[]}}}
+	    ]
+	  }
+	}`
+	buckets, total, hasMore, ok := parseGroupsAggregation(aggResult(t, raw), 20)
+	if !ok {
+		t.Fatal("expected ok=true for a well-formed aggregation")
+	}
+	if total != 37 {
+		t.Errorf("total_groups=37 expected; got %d", total)
+	}
+	if !hasMore {
+		t.Errorf("has_more must be true when sum_other_doc_count>0")
+	}
+	if len(buckets) != 2 {
+		t.Fatalf("expected 2 buckets; got %d", len(buckets))
+	}
+	if buckets[0].key != "gA" || buckets[0].docCount != 12 || buckets[0].latestTS != 1700000000 {
+		t.Errorf("bucket[0] parse mismatch: %+v", buckets[0])
+	}
+}
+
+func TestParseGroupsAggregation_NoMore(t *testing.T) {
+	raw := `{
+	  "group_count": {"value": 2},
+	  "by_channel": {"sum_other_doc_count": 0, "buckets": [
+	    {"key":"gA","doc_count":1,"latest":{"value":1700000000.0},"preview":{"hits":{"total":1,"hits":[]}}}
+	  ]}
+	}`
+	_, total, hasMore, ok := parseGroupsAggregation(aggResult(t, raw), 20)
+	if !ok || total != 2 || hasMore {
+		t.Errorf("expected ok/total=2/has_more=false; got ok=%v total=%d hasMore=%v", ok, total, hasMore)
+	}
+}
+
+// TestGroupsEnvelope_Shape pins the {data, pagination} wire shell so the
+// frontend's literal next_cursor==="" check and the approx flags hold.
+func TestGroupsEnvelope_Shape(t *testing.T) {
+	result := GroupsResult{
+		Sequence:          1042,
+		QueryID:           "q1",
+		TotalGroups:       37,
+		TotalGroupsApprox: true,
+		Groups:            []GroupBucket{},
+	}
+	b, err := json.Marshal(groupsEnvelope(result, true))
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(b)
+	for _, want := range []string{
+		`"data"`, `"pagination"`, `"has_more":true`, `"next_cursor":""`,
+		`"sequence":1042`, `"query_id":"q1"`, `"total_groups":37`,
+		`"total_groups_approx":true`, `"groups":[]`,
+	} {
+		if !strings.Contains(s, want) {
+			t.Errorf("envelope missing %s:\n%s", want, s)
+		}
+	}
+}
+
+func TestEmptyGroupsResult_Shape(t *testing.T) {
+	r := emptyGroupsResult(7)
+	if r.Sequence != 7 || !r.TotalGroupsApprox || r.TotalGroups != 0 || r.Groups == nil {
+		t.Errorf("empty result shape wrong: %+v", r)
+	}
+	if b, _ := json.Marshal(r); !strings.Contains(string(b), `"groups":[]`) {
+		t.Errorf("empty groups must serialise as []: %s", b)
+	}
+}
+
+// TestClassifyGroupBucket covers the three bucket-key shapes directly.
+func TestClassifyGroupBucket(t *testing.T) {
+	loginUID := "me"
+	dmKey := fakeChannelIDFor(loginUID, "peer")
+	if ct, wire, _, _ := classifyGroupBucket(dmKey, loginUID); ct != channelTypePerson || wire != "peer" {
+		t.Errorf("DM classify wrong: ct=%d wire=%s", ct, wire)
+	}
+	thrKey := thread.BuildChannelID("gA", "s1")
+	if ct, _, pg, sid := classifyGroupBucket(thrKey, loginUID); ct != channelTypeThread || pg != "gA" || sid != "s1" {
+		t.Errorf("thread classify wrong: ct=%d pg=%s sid=%s", ct, pg, sid)
+	}
+	if ct, wire, pg, _ := classifyGroupBucket("gPlain", loginUID); ct != channelTypeGroup || wire != "gPlain" || pg != "gPlain" {
+		t.Errorf("group classify wrong: ct=%d wire=%s pg=%s", ct, wire, pg)
+	}
+}

--- a/modules/messages_search/search_global_groups_test.go
+++ b/modules/messages_search/search_global_groups_test.go
@@ -91,7 +91,7 @@ func TestAssembleGroupBucket_DMReversal(t *testing.T) {
 	loginUID, peerUID := "me", "peer99"
 	key := fakeChannelIDFor(loginUID, peerUID)
 	pb := parsedBucket{key: key, docCount: 8, latestTS: 1_700_000_000}
-	gb := assembleGroupBucket(pb, nil, loginUID, nil, nil, map[string]string{peerUID: "张三"})
+	gb := assembleGroupBucket(pb, pb.latestTS, nil, loginUID, nil, nil, map[string]string{peerUID: "张三"})
 
 	if gb.ChannelType != channelTypePerson {
 		t.Errorf("DM bucket channel_type=1; got %d", gb.ChannelType)
@@ -119,7 +119,7 @@ func TestAssembleGroupBucket_Thread(t *testing.T) {
 	groupNo, shortID := "gA", "thr1"
 	key := thread.BuildChannelID(groupNo, shortID)
 	pb := parsedBucket{key: key, docCount: 12, latestTS: 1_700_000_100}
-	gb := assembleGroupBucket(pb, []MessageHit{}, loginUID,
+	gb := assembleGroupBucket(pb, pb.latestTS, []MessageHit{}, loginUID,
 		map[string]string{groupNo: "项目群"}, map[string]string{shortID: "需求评审"}, nil)
 
 	if gb.ChannelType != channelTypeThread {
@@ -144,7 +144,7 @@ func TestAssembleGroupBucket_Thread(t *testing.T) {
 
 func TestAssembleGroupBucket_Group(t *testing.T) {
 	pb := parsedBucket{key: "gZ", docCount: 128, latestTS: 1_700_000_200}
-	gb := assembleGroupBucket(pb, nil, "me", map[string]string{"gZ": "大群"}, nil, nil)
+	gb := assembleGroupBucket(pb, pb.latestTS, nil, "me", map[string]string{"gZ": "大群"}, nil, nil)
 
 	if gb.ChannelType != channelTypeGroup {
 		t.Errorf("group bucket channel_type=2; got %d", gb.ChannelType)
@@ -157,6 +157,44 @@ func TestAssembleGroupBucket_Group(t *testing.T) {
 	}
 	if gb.GroupName != "大群" {
 		t.Errorf("group_name mismatch; got %q", gb.GroupName)
+	}
+}
+
+// TestSortByVisibleLatest_NotBiasedByHiddenHits is the RC ordering regression:
+// bucket order must follow the CALIBRATED visible latest_at, not the OS
+// pre-filter max. gHidden has the newest pre-filter max (its newest match is
+// hidden) but the OLDEST visible hit — it must sort LAST, not first.
+func TestSortByVisibleLatest_NotBiasedByHiddenHits(t *testing.T) {
+	calibrated := []calibratedBucket{
+		// OS candidate order (pre-filter max desc): gHidden, gA, gB.
+		{pb: parsedBucket{key: "gHidden", latestTS: 1_700_009_999}, latestVisibleTS: 1_700_000_000},
+		{pb: parsedBucket{key: "gA", latestTS: 1_700_000_500}, latestVisibleTS: 1_700_000_500},
+		{pb: parsedBucket{key: "gB", latestTS: 1_700_000_300}, latestVisibleTS: 1_700_000_300},
+	}
+	sortByVisibleLatest(calibrated)
+
+	gotOrder := []string{calibrated[0].pb.key, calibrated[1].pb.key, calibrated[2].pb.key}
+	wantOrder := []string{"gA", "gB", "gHidden"}
+	for i := range wantOrder {
+		if gotOrder[i] != wantOrder[i] {
+			t.Fatalf("visible-latest order = %v; want %v (gHidden must not jump the order via its hidden newest match)", gotOrder, wantOrder)
+		}
+	}
+}
+
+// TestSortByVisibleLatest_StableTiebreak — equal visible latest_at keeps the OS
+// candidate order (input order) as a deterministic tiebreak.
+func TestSortByVisibleLatest_StableTiebreak(t *testing.T) {
+	calibrated := []calibratedBucket{
+		{pb: parsedBucket{key: "first"}, latestVisibleTS: 1_700_000_000},
+		{pb: parsedBucket{key: "second"}, latestVisibleTS: 1_700_000_000},
+		{pb: parsedBucket{key: "third"}, latestVisibleTS: 1_700_000_000},
+	}
+	sortByVisibleLatest(calibrated)
+	for i, want := range []string{"first", "second", "third"} {
+		if calibrated[i].pb.key != want {
+			t.Errorf("stable tiebreak broken at %d: got %q want %q", i, calibrated[i].pb.key, want)
+		}
 	}
 }
 

--- a/modules/messages_search/visibility.go
+++ b/modules/messages_search/visibility.go
@@ -165,6 +165,33 @@ type msgRef struct {
 	Visibles   []string // sender-set allowlist; non-empty => caller must be in it
 }
 
+// filterVisibleChunkSize bounds the id / channel count in any single probe
+// round-trip so the underlying `... IN (?)` clauses never balloon. The presence
+// batch can present up to maxGroups × T ids at once; the message.IService
+// queries do not chunk internally, so this is where the width is capped.
+const filterVisibleChunkSize = 1000
+
+// chunkStrings splits s into consecutive slices of at most size elements
+// (size <= 0 falls back to a single chunk). Empty input yields no chunks so a
+// zero-id call makes zero round-trips.
+func chunkStrings(s []string, size int) [][]string {
+	if len(s) == 0 {
+		return nil
+	}
+	if size <= 0 {
+		return [][]string{s}
+	}
+	out := make([][]string, 0, (len(s)+size-1)/size)
+	for i := 0; i < len(s); i += size {
+		end := i + size
+		if end > len(s) {
+			end = len(s)
+		}
+		out = append(out, s[i:end])
+	}
+	return out
+}
+
 // filterVisible is the search-side analogue of message.filterMessages. It
 // rejects hits the caller must NOT see based on the same five signals the
 // /messages and /channel_files read paths consult:
@@ -214,17 +241,40 @@ func (h *Handler) filterVisible(ctx context.Context, loginUID, channelID string,
 		uniqueIDs = append(uniqueIDs, r.MessageID)
 	}
 
-	revokedSet, err := h.visibility.RevokedSet(uniqueIDs)
-	if err != nil {
-		return nil, fmt.Errorf("filterVisible: RevokedSet: %w", err)
-	}
-	deletedSet, err := h.visibility.GloballyDeletedSet(uniqueIDs)
-	if err != nil {
-		return nil, fmt.Errorf("filterVisible: GloballyDeletedSet: %w", err)
-	}
-	userDeletedSet, err := h.visibility.UserDeletedSet(loginUID, uniqueIDs)
-	if err != nil {
-		return nil, fmt.Errorf("filterVisible: UserDeletedSet: %w", err)
+	// Chunk the id set before hitting the probe. The presence batch
+	// (calibratePresence) can hand us up to maxGroups × T (200 × 40 = 8000)
+	// unique ids in one shot, and the underlying message.IService queries build
+	// a single `message_id IN (?)` clause with NO chunking — an 8000-element IN
+	// risks blowing the driver's placeholder budget / max_allowed_packet and
+	// planning a pathological scan. Chunking here keeps every IN bounded
+	// regardless of the probe implementation. Single-channel callers stay a
+	// single chunk (their pages are pageSize-bounded), so their round-trip shape
+	// is byte-identical to before.
+	revokedSet := make(map[string]struct{}, len(uniqueIDs))
+	deletedSet := make(map[string]struct{}, len(uniqueIDs))
+	userDeletedSet := make(map[string]struct{}, len(uniqueIDs))
+	for _, chunk := range chunkStrings(uniqueIDs, filterVisibleChunkSize) {
+		rs, err := h.visibility.RevokedSet(chunk)
+		if err != nil {
+			return nil, fmt.Errorf("filterVisible: RevokedSet: %w", err)
+		}
+		for id := range rs {
+			revokedSet[id] = struct{}{}
+		}
+		ds, err := h.visibility.GloballyDeletedSet(chunk)
+		if err != nil {
+			return nil, fmt.Errorf("filterVisible: GloballyDeletedSet: %w", err)
+		}
+		for id := range ds {
+			deletedSet[id] = struct{}{}
+		}
+		uds, err := h.visibility.UserDeletedSet(loginUID, chunk)
+		if err != nil {
+			return nil, fmt.Errorf("filterVisible: UserDeletedSet: %w", err)
+		}
+		for id := range uds {
+			userDeletedSet[id] = struct{}{}
+		}
 	}
 	// Multi-channel channel-offset lookup (§8.2 generalisation). Each hit is
 	// gated by its own room's clear-history watermark instead of a single
@@ -253,9 +303,15 @@ func (h *Handler) filterVisible(ctx context.Context, loginUID, channelID string,
 	for id := range channelSet {
 		channelList = append(channelList, id)
 	}
-	offsets, err := h.visibility.ChannelOffsets(loginUID, channelList)
-	if err != nil {
-		return nil, fmt.Errorf("filterVisible: ChannelOffsets: %w", err)
+	offsets := make(map[string]uint32, len(channelList))
+	for _, chunk := range chunkStrings(channelList, filterVisibleChunkSize) {
+		part, err := h.visibility.ChannelOffsets(loginUID, chunk)
+		if err != nil {
+			return nil, fmt.Errorf("filterVisible: ChannelOffsets: %w", err)
+		}
+		for id, seq := range part {
+			offsets[id] = seq
+		}
 	}
 
 	keep := make(map[string]struct{}, len(refs))

--- a/modules/messages_search/visibility_test.go
+++ b/modules/messages_search/visibility_test.go
@@ -807,3 +807,57 @@ func TestProjectDocRef_VirtualWithZeroParentFallsBackToOwn(t *testing.T) {
 		t.Fatalf("zero parent must fall back to own id; got %q", ref.MessageID)
 	}
 }
+
+// TestFilterVisible_ChunksLargeIDSet is the RC non-blocking item: the presence
+// batch can hand filterVisible up to maxGroups × T ids, and the underlying
+// probe builds an unchunked `IN (?)`. filterVisible must split the id set into
+// filterVisibleChunkSize batches (one probe call per chunk) while still
+// filtering correctly across chunk boundaries.
+func TestFilterVisible_ChunksLargeIDSet(t *testing.T) {
+	const n = 2*filterVisibleChunkSize + 500 // 3 chunks
+	refs := make([]msgRef, n)
+	for i := 0; i < n; i++ {
+		refs[i] = msgRef{MessageID: strconv.Itoa(1_000_000 + i), MessageSeq: uint32(i + 1), ChannelID: "gA"}
+	}
+	// Hide one id that lands in the 3rd chunk so the union-across-chunks path is
+	// exercised, not just the first batch.
+	hiddenID := strconv.Itoa(1_000_000 + 2*filterVisibleChunkSize + 100)
+	probe := &stubProbe{deleted: map[string]bool{hiddenID: true}}
+	h := newVisibilityHandler(probe)
+
+	keep, err := h.filterVisible(context.Background(), "me", "", refs)
+	if err != nil {
+		t.Fatalf("filterVisible: %v", err)
+	}
+	wantChunks := (n + filterVisibleChunkSize - 1) / filterVisibleChunkSize
+	if probe.revokedCalls != wantChunks {
+		t.Errorf("RevokedSet must run once per chunk (%d); got %d", wantChunks, probe.revokedCalls)
+	}
+	if probe.deletedCalls != wantChunks {
+		t.Errorf("GloballyDeletedSet must run once per chunk (%d); got %d", wantChunks, probe.deletedCalls)
+	}
+	if probe.userDeletedCalls != wantChunks {
+		t.Errorf("UserDeletedSet must run once per chunk (%d); got %d", wantChunks, probe.userDeletedCalls)
+	}
+	if _, ok := keep[hiddenID]; ok {
+		t.Errorf("hidden id %s (3rd chunk) must be filtered out across the chunk boundary", hiddenID)
+	}
+	if len(keep) != n-1 {
+		t.Errorf("all but the 1 hidden id must be kept; got %d want %d", len(keep), n-1)
+	}
+}
+
+// TestChunkStrings covers the split helper's boundaries.
+func TestChunkStrings(t *testing.T) {
+	if got := chunkStrings(nil, 1000); got != nil {
+		t.Errorf("empty input must yield no chunks; got %v", got)
+	}
+	ids := []string{"a", "b", "c", "d", "e"}
+	got := chunkStrings(ids, 2)
+	if len(got) != 3 || len(got[0]) != 2 || len(got[2]) != 1 {
+		t.Errorf("expected [2,2,1] chunking; got %v", got)
+	}
+	if one := chunkStrings(ids, 0); len(one) != 1 || len(one[0]) != len(ids) {
+		t.Errorf("size<=0 must collapse to a single chunk; got %v", one)
+	}
+}


### PR DESCRIPTION
## What

Adds the **aggregation-first (L1) global search** endpoint `POST /v1/messages/_search_global_groups` on top of the existing `messages_search` module, plus the presence-calibration layer that makes the per-conversation overview visibility-exact.

Two logically separable commits (kept together for an atomic deploy — see below):
- **`608ca11` — L1 aggregation endpoint**: one OS `terms(channelId)` aggregation → candidate buckets with `max(timestamp)` (latest), `top_hits` (preview over-fetch), `doc_count` (approx count), `cardinality` (total groups). DM buckets reverse-resolved from the p2p fake channel id to the peer uid (`channel_type=1`, no thread); thread buckets carry `parent_group_no`. `revoked` + `visibles` gated at the OS query layer. Response shell `{data, pagination}` consistent with the existing search endpoints. Config-driven `maxGroups` / over-fetch `T`.
- **`277d798` — presence calibration + deep-probe + per-frequency preview**: batch `filterVisible` over each bucket's over-fetched top-T in a single MySQL round-trip → three-state classify (INCLUDE / EXCLUDE / UNRESOLVED). UNRESOLVED buckets deep-probe via `search_after` back-paging until the first visible hit (INCLUDE), channel exhausted (EXCLUDE), or the `K2` budget is hit (EXCLUDE, bounded latency). Per-conversation preview count `N` allocated from `previewBudget` weighted by `doc_count`, clamped to `perGroupMax`. Instrumentation for probe bucket/doc counts.

## Why combined into one PR

A and B are strongly coupled: the L1 endpoint's preview is only **visibility-safe once B's `filterVisible` calibration is in place**. Shipping A alone would expose previews that bypass the MySQL-only visibility gates (admin/mutual delete, self-delete, channel-offset watermark) — an information leak. They are therefore submitted as one PR for a single atomic deploy.

## Visibility guarantee

Preview hits are emitted **only** after passing the full five-gate `filterVisible`; the raw `top_hits` path is never sent to the wire. `filterVisible` DB errors are fail-closed (`INTERNAL_ERROR`, no uncalibrated hit released). A regression test asserts an admin-deleted hit mixed into the top-T never reaches the preview.

## Review response (CHANGES_REQUESTED)

Two follow-up commits address the review:

- **`50e7c9e` — `latest_at` + bucket order recomputed from the calibrated visible hit.** This was the Major/Blocking finding: `latest_at` and the latest-first bucket order used the OS **pre-filter** `max(timestamp)`, so a bucket whose newest match was hidden (admin/self-deleted, cleared history, visibles) leaked that hidden message's recency and biased the order — contradicting the per-conversation "time doesn't leak" claim. Now every bucket's `latest_at` is the timestamp of its newest **visible** hit (INCLUDE → `visible[0]`; UNRESOLVED → the visible hit the deep probe actually found; never the OS max), and the returned `groups[]` are re-sorted by that visible `latest_at`. The OS terms agg still orders *candidates* by pre-filter max (visible ⊆ all, so nothing that should surface is dropped), but the wire order follows the visible time. Regression tests cover the top-T and deep-probe paths and assert a hidden-newest bucket does not jump the order.
- **`5d31a9a` — presence batch `filterVisible` now chunks its id / channel sets** (`filterVisibleChunkSize = 1000`). The underlying `message.IService` queries build a single unchunked `... IN (?)`; the presence batch can present up to `maxGroups × T` (~8000) ids at once, so the width is now bounded here. Single-channel callers stay one chunk (page-size-bounded), unchanged.

## Notes (accepted approximations — by design, not bugs)

These are the two remaining pre-filter approximations. Both are **accepted, non-sensitive metadata** per the aggregation-first design §6 ("count 近似，精确计数成本无界不做") and the owner's decision (option A) — distinct from `latest_at` / bucket order above, which were real recency leaks and have been fixed to recompute from the visible hit.

- **`match_count` is the pre-visibility OS `doc_count`** (`match_count_approx = true`). It counts matching docs **before** the five visibility gates, so it *includes* hits hidden from the caller and may read **higher** than the number of messages the caller can actually open. It is deliberately **not** post-calibrated: recomputing could only count the visible docs inside the bounded sampling window (itself an approximation) at unbounded cost, and it exposes at most a possibly-inflated integer — never a hidden message's content, sender, or timestamp. `match_count_approx = true` is the wire signal of exactly this.
- **`total_groups` is a `cardinality` HLL estimate over the pre-visibility candidate set** (`total_groups_approx = true`); it can exceed the returned `groups` length when candidate buckets are EXCLUDE'd. Clients should treat `groups` as authoritative for the empty state.

## Testing

- `go build ./...`, `go vet ./modules/messages_search/`, `go test ./modules/messages_search/` all green.
- New tests cover: trigger gate three states, OS-layer `visibles`/`revoked` gating, DM reverse-resolution, thread `parent_group_no`, response shell shape, `maxGroups` over-limit `has_more`, presence three-state classify, calibrate INCLUDE/EXCLUDE/fail-closed + preview filtering, deep-probe first-visible/exhausted/pages-advance/K2, per-frequency N allocation, and the review-response additions: `latest_at` recompute (top-T + deep-probe), visible-latest bucket ordering + stable tiebreak, and `filterVisible` id-set chunking.
- End-to-end L1 latency instrumentation is in place; live numbers require an OS+MySQL test environment.

Fixes #592