### PR TITLE
feat(cardaction): allow HTTP callbacks and bounded custom approval_card actions

### DIFF
--- a/.octospec/journal/shared/card-action-internal-http-actions.md
+++ b/.octospec/journal/shared/card-action-internal-http-actions.md
@@ -1,0 +1,160 @@
+---
+type: Journal
+title: "Journal: card-action-internal-http-actions"
+description: Follow-up to #588 — allow plain HTTP callbacks and 1-5 bounded custom actions on approval_card without weakening the server-owned card boundary.
+tags: ["card", "internal", "trust-boundary", "wire-contract", "testing"]
+timestamp: 2026-07-16T02:00:00+08:00
+# --- octospec extension fields ---
+task: card-action-internal-http-actions
+source: self
+---
+
+# Journal: card-action-internal-http-actions
+
+## What was done
+
+Two small follow-ups to #588 plus one bundled configuration collapse:
+
+- `internal/cardactiondispatch` — `validateCallbackURL` now accepts both
+  `http://` and `https://`; the static `OCTO_CARD_ACTION_ROUTES[].url` list is
+  itself the exact allowlist. Reject-cases were tightened at the same time:
+  `u.Hostname() != ""` (blocks `http://:8080/x`), `u.ForceQuery` (blocks
+  trailing `?`), raw-`#` prefilter (blocks trailing `#` and embedded `#` that
+  `url.Parse` would swallow), unsupported schemes, credentials, opaque forms.
+  `NewRegistry` is now two-argument; `LoadAllowedURLs` was deleted.
+- `main.go` — reads `OCTO_CARD_ACTION_ALLOWED_URLS` only to emit one structured
+  deprecation WARN (`deprecated_env=OCTO_CARD_ACTION_ALLOWED_URLS`), then
+  ignores it. Rolling upgrades that still carry the variable do not fail
+  startup.
+- `pkg/cardtmpl` — added `ApprovalRequestAction` and an optional
+  `ApprovalRequestCard.Actions` slice. When `Actions == nil` the byte-for-byte
+  legacy `approve/deny` output stays intact (golden-bytes test). When non-nil,
+  1..5 buttons are rendered with server-derived action IDs
+  (`approval-<decision>`), owner/action_type/decision injected into every
+  submit payload, and `data` reserved-key checks unchanged. A non-nil empty
+  slice is treated as a caller bug, not a silent fallback. Titles are checked
+  for control characters on the raw string before `TrimSpace` runs.
+- `modules/notify` — added `ApprovalCardFields.Actions` (`json:"actions,omitempty"`)
+  and `ApprovalCardAction`. Delivery routes nil to the localized approve/deny
+  path; any non-nil slice enters the strict validator.
+- Contract-critical tests are consumer-neutral: 7 HTTP-scheme acceptance
+  shapes, 13 URL rejection shapes, plain-HTTP HMAC-and-transport E2E, plain-HTTP
+  redirect rejection with typed `redirect_rejected` category, and a
+  custom-decision orchestration E2E (`approval-execute` → HMAC callback →
+  consumer maps to `approved` → standard finalizer renders standard terminal
+  wording → requester notification).
+
+Locked wire-contract decisions (drawn from the discussion draft, not from any
+one owner):
+
+- Actions optional; when present 1-5 items, `decision` matches
+  `^[a-z][a-z0-9_.-]{0,47}$`, `title` is 1-80 runes, no control characters,
+  unique decisions per card, no mixing with approve/deny defaults.
+- Terminal states unchanged: `approved`/`denied`/`cancelled`/`pending`.
+  Consumers map their custom `decision` to a state — the server does not
+  translate.
+- Only `approved`/`denied` notify the requester, matching #588. Custom
+  `decision` values never trigger direct notification.
+- Caller-provided button i18n is single-copy per request; per-recipient
+  language rendering is explicitly out of scope for this change.
+
+## Load-bearing intent
+
+- **URL is operator-authorized, not shape-recognized.** The presence of
+  `http://` in a static route is the authorization. octo-server does not
+  inspect hostnames (K8s DNS, docker service names, `host.docker.internal`,
+  IP literals). Reachability is a NetworkPolicy/service-mesh concern; scheme
+  choice is a confidentiality decision the operator makes explicitly.
+- **Config is single-source.** `OCTO_CARD_ACTION_ROUTES` is the exact URL
+  registry. `OCTO_CARD_ACTION_ALLOWED_URLS` shared the same ConfigMap boundary,
+  produced dual-write drift, and gave no independent review — hence removed.
+- **Card content is server-built.** Callers pass `decision` + display `title`;
+  the server owns action IDs, injects reserved metadata, and remains the only
+  code path that can add a URL/style/input. `data` reserved-key checks
+  (`owner`/`action_type`/`decision`) still apply.
+- **Nil ≠ empty.** `Actions == nil` means "omitted, use defaults." An explicit
+  `"actions": []` is a caller bug and is rejected at 400, not silently
+  downgraded. This closes a subtle bypass where a caller intending zero
+  buttons would get the localized approve/deny anyway.
+- **Terminal contract unchanged.** No new callback result states, no
+  per-action data/URL/input/style, no arbitrary card JSON, and no
+  custom-decision path into requester notification. The wire contract from
+  #588 is deliberately not widened.
+- **HMAC does not encrypt.** Both docs (`callback-dispatch.md`,
+  `callback-consumer.md`) now carry an explicit residual-risk callout for
+  plain-HTTP transport and for the absence of independently-signed callback
+  responses.
+
+## Deferred (out of scope, tracked)
+
+- Independently-signed callback responses. HTTP transport is still
+  fail-closed on the request signature; response tampering remains a residual
+  risk.
+- Custom `outcome_label` / business terminal wording. Standard approval
+  wording (`approval.approved` / `denied` / `cancelled`) is what renders
+  regardless of the custom decision.
+- Non-terminal "still clickable" actions. Every finalizer still removes the
+  buttons on any typed response; `pending` shows the standard "unavailable"
+  terminal wording.
+- Per-recipient language rendering of caller-supplied button titles.
+- `OCTO_DOCS_APPROVAL_CARD_ENABLED` behavior. Kept as-is; separate rollout.
+
+## Injected rule compliance
+
+- **error-handling**: no new response paths; `/v1/internal/notify` already
+  goes through the localized envelope. Card-build failures still surface as
+  the existing `errNotifyCardInvalid`. Custom-decision validation errors
+  reject at 400 through the same route.
+- **rate-limit**: no route, middleware, or Redis frequency-counter change.
+- **wire-contract**: an unset optional field on the JSON boundary preserves
+  legacy output byte-for-byte (`TestBuildApprovalRequestCardOmittedActionsIsByteCompatible`
+  pins golden bytes).
+- **testing**: focused unit + race + integration + a new orchestration E2E
+  exercise every failure category the reviewer named — nil vs non-nil-empty
+  actions, raw `#`/`?`/empty-host URLs, leading-whitespace control chars,
+  plain-HTTP HMAC over cleartext, plain-HTTP redirect rejection, and
+  proxy-env-variable ignoring.
+
+## Verification
+
+- `go build ./... && go vet ./... && gofmt -l ...` — PASS.
+- `go test -race ./internal/cardactiondispatch/... ./pkg/cardtmpl/... ./modules/notify/... .` — PASS.
+- Coverage — cardactiondispatch 81.5%, cardtmpl 89.9%, notify 71.2%.
+- `go test -tags=integration -race ./internal/cardactiondispatch/...` on a
+  freshly-recreated local `test` schema — PASS (all 3 orchestration E2Es
+  including new custom-decision path).
+- `go test -tags=integration -race -run TestCardActionSenderBoundCallbackRouting ./modules/message/...`
+  on a freshly-recreated schema — PASS. This is the compile-blocker the
+  reviewer flagged; its `NewRegistry` call site was migrated to the
+  two-argument signature.
+- `make i18n-lint` (direct-error-response + unregistered-code) — PASS.
+
+## Gotchas worth remembering
+
+- Go's `url.Parse` silently drops trailing empty `#` and produces
+  `Fragment == ""`. Checking the parsed field alone lets `https://host/path#`
+  through. Prefilter the raw string for `#` before parsing. The same applies
+  in principle to `?`, though `u.ForceQuery` covers that case.
+- `strings.TrimSpace` also strips control-class whitespace (`\t \n \r \v`).
+  Any "reject control characters" rule must run on the raw string, not the
+  trimmed one, or leading/trailing tabs and newlines slip through.
+- `omitempty` only affects encode. For decode, `nil` (field absent) and
+  `[]` (explicit empty array) are distinct on the wire; treat them as
+  different states rather than collapsing with `len() == 0`.
+- Local integration tests need the shared `test` schema dropped/recreated
+  between packages, matching CI. `Unable to create migration plan / unknown
+  migration` is the canonical symptom — do not try to reconcile migrations
+  in-place.
+
+## Rollout
+
+- No DB migration. `kubectl rollout` is sufficient.
+- Deploy → verify no `OCTO_CARD_ACTION_ALLOWED_URLS deprecated` WARN (or
+  clean it up when convenient).
+- Add each new consumer as one JSON route entry plus its
+  `<OWNER>_CARD_ACTION_SECRET` + `<OWNER>_NOTIFY_TOKEN` secrets. `http://`
+  in the route URL is a conscious operator authorization.
+- Rollback: delete the route from `OCTO_CARD_ACTION_ROUTES` and restart, or
+  change its `url` back to HTTPS. In-flight events retry until the new URL
+  is reachable or the attempt cap is exhausted (then DLQ, replayable via
+  `tools/card-action-dlq`).

--- a/.octospec/learnings/pending/json-nil-vs-empty-slice.md
+++ b/.octospec/learnings/pending/json-nil-vs-empty-slice.md
@@ -1,0 +1,47 @@
+---
+type: Learning
+title: "Optional JSON slice/map: nil is not empty"
+description: For optional collection fields on a request boundary, treat nil (field omitted) and non-nil-empty (explicit []) as different states. Collapsing with len()==0 silently downgrades a caller bug into a fallback.
+tags: ["api", "validation", "wire-contract", "review"]
+timestamp: 2026-07-16T02:00:00Z
+# --- octospec extension fields ---
+source: self
+origin_task: card-action-internal-http-actions
+origin_pr: dmwork-org/octo-server (approval_card actions follow-up)
+status: pending
+candidate_rule: error-handling
+---
+# Optional JSON slice/map: nil is not empty
+
+When adding an optional collection field to an existing request struct
+(`Actions []Foo` / `Filters map[string]string` / `Ids []int`), a natural
+"caller didn't set it → use default" branch reaches for `len(field) == 0`.
+That collapses two wire-level states that JSON keeps distinct:
+
+- `field` omitted → decoded `nil` → the caller wants the default
+- `"field": []` → decoded non-nil empty → the caller sent zero elements,
+  usually a bug in their generation code
+
+`len() == 0` treats both as "use default." A caller who accidentally builds
+an empty array (map lookup miss, filter that removed everything, framework
+serializing `Optional.empty()` as `[]`) gets a silent, incorrect fallback
+instead of a 400.
+
+**Rule candidate:** for any optional collection on a request struct, split
+the branch by nilness:
+
+```go
+switch {
+case field == nil:
+    // caller omitted → apply default
+case len(field) == 0:
+    // caller sent explicit empty → 400 (caller bug, don't silently downgrade)
+default:
+    // validate and use
+}
+```
+
+`omitempty` only affects encode; decode still preserves the distinction. Caught
+in review on the approval_card actions follow-up
+(`err.server.notify.card_invalid` at the ingress; `cardtmpl` layer treats
+non-nil-empty as an explicit rejection error).

--- a/.octospec/learnings/pending/url-parse-raw-prefilter.md
+++ b/.octospec/learnings/pending/url-parse-raw-prefilter.md
@@ -1,0 +1,46 @@
+---
+type: Learning
+title: "URL boundary checks must prefilter the raw string, not the parsed struct"
+description: Go's net/url silently drops empty fragments and folds ports into Host. Validating only url.URL fields lets malformed raw URLs through. Reject on the raw string before parsing.
+tags: ["ssrf", "url", "validation", "trust-boundary", "review"]
+timestamp: 2026-07-16T02:00:00Z
+# --- octospec extension fields ---
+source: self
+origin_task: card-action-internal-http-actions
+origin_pr: dmwork-org/octo-server (approval_card actions follow-up)
+status: pending
+candidate_rule: security
+---
+# URL boundary checks must prefilter the raw string, not the parsed struct
+
+Validating callback / webhook URLs by inspecting `url.URL` fields alone is
+insufficient. `net/url` is deliberately lenient in three places that matter
+for a trust-boundary check:
+
+1. **Empty fragment is discarded.** `url.Parse("https://host/path#")`
+   produces `Fragment == ""` — indistinguishable from a URL that had no `#`
+   at all. Checking `u.Fragment != ""` accepts both. `u.ForceQuery` provides
+   the equivalent for a trailing `?`, but there is no `ForceFragment` — you
+   must reject `#` on the raw string.
+
+2. **Host contains the port.** `url.Parse("http://:8080/x").Host == ":8080"`
+   is non-empty and looks valid. `u.Hostname()` strips the port and returns
+   `""`, which is what a hostname predicate actually wants.
+
+3. **Scheme-only oddities.** `url.Parse("https:opaque")` leaves `u.Opaque`
+   set and `u.Host == ""`. Some strict scheme checks miss this because the
+   scheme is right; the shape isn't.
+
+**Rule candidate:** at any external-URL trust boundary (callback allowlist,
+webhook target, image proxy, redirect destination), the validator should:
+
+- trim-then-reject-if-mutated (`strings.TrimSpace(raw) != raw`),
+- prefilter the raw string for `#` (and for `?` if you don't rely on
+  `ForceQuery`),
+- parse, then check `u.Scheme` against a small allowlist, `u.Hostname() != ""`
+  (not `u.Host`), `u.Opaque == ""`, `u.User == nil`,
+- reject `u.Fragment != ""`, `u.RawQuery != ""`, `u.ForceQuery`.
+
+Caught in review on the approval_card HTTP-scheme follow-up
+(`internal/cardactiondispatch.validateCallbackURL`). Both misses had test
+vectors: `https://host/path#` and `http://:8080/path`.

--- a/.octospec/log.md
+++ b/.octospec/log.md
@@ -4,6 +4,25 @@ Change history for this repo's `.octospec/`, following the
 [OKF](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md)
 change-log convention (§7). Newest first.
 
+## 2026-07-16 (card-action-internal-http-actions)
+
+- **Follow-up** — Two small extensions to #588 plus one bundled config
+  collapse. `OCTO_CARD_ACTION_ROUTES[].url` now accepts `http://` in addition
+  to `https://`; hostname form is intentionally not inspected (route
+  registration = operator authorization). URL validator tightened at the same
+  time: `Hostname() != ""` (blocks `http://:8080/x`), `ForceQuery` (blocks
+  trailing `?`), raw-`#` prefilter (blocks trailing/embedded `#`).
+  `OCTO_CARD_ACTION_ALLOWED_URLS` is deleted from code paths and emits a
+  structured deprecation WARN if still set, so rolling upgrades do not fail.
+  `approval_card.actions` grew an optional 1..5 bounded slice: server-derived
+  action IDs, reserved metadata enforced, control-character-in-title checked
+  on the raw string, `nil` preserves byte-for-byte legacy approve/deny while a
+  non-nil empty slice is rejected as a caller bug. Callback wire contract
+  (states, requester notification, HMAC canonical) is deliberately unchanged.
+  Coverage — cardactiondispatch 81.5%, cardtmpl 89.9%, notify 71.2%. Brief/context
+  under `.octospec/tasks/card-action-internal-http-actions/`; shared journal
+  `.octospec/journal/shared/card-action-internal-http-actions.md`.
+
 ## 2026-07-13 (card-message-appbot-trust)
 
 - **Fix** — Closed the P0 App Bot card trust split without changing the send

--- a/.octospec/tasks/card-action-internal-http-actions/brief.md
+++ b/.octospec/tasks/card-action-internal-http-actions/brief.md
@@ -1,0 +1,162 @@
+---
+type: Task
+title: "Task: card-action-internal-http-actions"
+description: Allow plain HTTP callbacks declared in the static route registry and bounded custom actions on the generic approval_card ingress, without weakening the server-owned card boundary or the config-driven URL allowlist.
+tags: ["card", "internal", "trust-boundary", "wire-contract", "testing"]
+timestamp: 2026-07-16T10:00:00+08:00
+slug: card-action-internal-http-actions
+upstream: "TBD — follow-up to octo-server#588"
+source: self
+---
+
+# Task: card-action-internal-http-actions
+
+## Goal
+
+Two small follow-ups to the callback dispatch layer merged in #588:
+
+1. Allow `OCTO_CARD_ACTION_ROUTES[].url` to use plain `http://` in addition to
+   `https://`. The static route registry is itself the allowlist; hostname shape
+   (Kubernetes DNS, docker service name, `host.docker.internal`, IP literal) is
+   not inspected. The presence of `http://` in a route is the operator's
+   explicit authorization.
+2. Let the generic `approval_card` ingress render a bounded list of server-built
+   `Action.Submit` buttons instead of always forcing localized `approve` /
+   `deny`.
+
+The callback remains config-driven and the card remains template-driven. Neither
+change permits request-supplied callback URLs or arbitrary Adaptive Card JSON.
+The contract is consumer-neutral: no owner is privileged, and examples must not
+become requirements that future services have to copy.
+
+Bundled configuration collapse (out of the discussion draft):
+
+3. Delete `OCTO_CARD_ACTION_ALLOWED_URLS`. `OCTO_CARD_ACTION_ROUTES[].url` is
+   already the exact URL and shares the same ConfigMap/operator boundary; the
+   two lists cannot form an independent security review and only produce
+   dual-write drift. If the deprecated env is set at startup, log a single
+   structured WARN and ignore it (do not fail startup — rolling upgrades may
+   still carry the old variable).
+
+## Implementation gate
+
+Update and review the standalone operations and consumer integration documents
+first. Do not change production code or tests for HTTP/actions/config collapse
+until the consumer-neutral contract, examples, security boundaries, and rollout
+steps are confirmed.
+
+## Locked decisions (from the discussion draft)
+
+| # | Question | Decision |
+|---|---|---|
+| 1 | actions count | Optional; when provided, 1-5 items. Absent = current localized approve/deny, byte-compatible with #588. |
+| 2 | terminal result states | Reuse `approved` / `denied` / `cancelled` / `pending`. Consumer maps its custom `decision` to a state. |
+| 3 | non-terminal "still clickable" actions | Not in this change. Current finalizers always remove actions and update the card. |
+| 4 | button i18n | Caller-provided single copy per request. Per-recipient language rendering is a future v2. |
+| 5 | requester notification for custom decisions | Only `approved` / `denied` notify the requester (unchanged from #588). Custom `decision` never triggers direct requester notification; the mapped `state` does. |
+
+## Contract
+
+`approval_card.actions` is optional. When omitted, the existing localized
+approve/deny actions are emitted unchanged. When present it contains 1-5 items:
+
+```json
+{
+  "decision": "publish",
+  "title": "发布"
+}
+```
+
+- `decision` is the stable callback value and must be unique within the card,
+  lowercase, and match `[a-z][a-z0-9_.-]{0,47}`.
+- `title` is display text, trimmed, non-empty, and at most 80 Unicode code
+  points. Control characters are rejected.
+- octo-server derives the action ID as `approval-<decision>`, injects the
+  authoritative `owner` and `action_type`, and copies only the existing bounded
+  shared `data` map. Per-action data, styles, URLs, inputs, and caller-authored
+  card JSON remain unsupported.
+- The callback receives the selected `decision` through the existing signed
+  `DecisionRequest`. The existing typed result states (`pending`, `approved`,
+  `denied`, `cancelled`) do not change.
+
+Example:
+
+```json
+{
+  "service": "tasks",
+  "approval_card": {
+    "action_type": "task.execute.decision",
+    "title": "执行任务",
+    "description": "请选择本次任务的处理方式",
+    "data": {"task_id": "task-1"},
+    "actions": [
+      {"decision": "execute", "title": "执行"},
+      {"decision": "reject", "title": "拒绝"},
+      {"decision": "cancel", "title": "取消"}
+    ]
+  }
+}
+```
+
+## Security boundaries
+
+- The static `OCTO_CARD_ACTION_ROUTES` is the exact URL registry. Card content,
+  action requests, and consumer responses cannot supply or override the callback
+  URL. HMAC signing, timeout, retry/DLQ, disabled redirects, and disabled
+  environment proxies are unchanged.
+- Both `http://` and `https://` are accepted; other schemes and non-absolute
+  URLs, URLs with credentials, query strings, fragments, or opaque forms remain
+  rejected at startup.
+- Hostname form is not inspected. Operators are responsible for making the
+  chosen HTTP destination reachable only from the octo-server pods that need
+  it (NetworkPolicy, service mesh, container network, or localhost binding).
+- HMAC only authenticates the request; it does not encrypt payload or response.
+  Callback bodies may contain operator UID, Space ID, and business identifiers.
+  When a route uses `http://`, the deployment must treat the transport as a
+  trusted network boundary. Cross-cluster, cross-network, or public callbacks
+  must use HTTPS.
+- Callback secrets and notify tokens remain per-capability. A notify token
+  cannot equal any callback secret (existing per-route + cross-route check);
+  legacy `NOTIFY_INTERNAL_TOKEN` and `OCTO_DOCS_NOTIFY_TOKEN` also cannot
+  collide with action notify tokens (existing exclusion check).
+- Custom actions are structural fields only. Callers cannot choose owner,
+  callback URL, action JSON, or callback headers.
+
+## Out of scope
+
+- A global "allow insecure HTTP" switch or Kubernetes/Docker environment
+  detection.
+- Per-recipient language rendering of caller-supplied button titles.
+- New callback result states, custom terminal-card layouts, or non-terminal
+  "still clickable" actions.
+- Per-action arbitrary data, styles, URLs, inputs, or card JSON.
+- TLS issuance, service-mesh setup, or NetworkPolicy management.
+- Independent signing of callback responses (known residual risk; tracked
+  separately).
+
+## Acceptance
+
+- Existing HTTPS routes and approve/deny cards are byte-compatible with #588.
+- `OCTO_CARD_ACTION_ROUTES[].url` accepts `http://` and delivers with the same
+  HMAC, retry, DLQ, and redirect/proxy discipline as `https://`.
+- `OCTO_CARD_ACTION_ALLOWED_URLS`, when set at startup, produces a single
+  structured deprecation WARN and does not affect routing decisions.
+- Absolute URL requirements (scheme in {http,https}, host present, no
+  credentials/query/fragment/opaque) continue to reject malformed values at
+  startup.
+- Custom `approval_card.actions` renders the requested labels and signed
+  callback decisions; empty, duplicate, malformed, or oversized actions are
+  rejected before card production.
+- Unit tests cover URL and template boundaries; notify integration tests cover
+  backward compatibility (omitted `actions` byte-equal to #588) and 1-5 custom
+  action rendering.
+- The `card-action-callback-consumer.md` and `card-action-callback-dispatch.md`
+  documents are updated by reference rather than duplicating #588 design, and
+  they carry the residual-risk callout for plain HTTP.
+- A new first-party consumer, regardless of implementation language or owner,
+  can complete route registration, card production, signature verification,
+  idempotent decision handling, typed response, rollout, and DLQ operations
+  from the two standalone integration documents. Consumer-specific examples
+  are illustrative only and must not introduce owner-specific requirements;
+  the signing section retains the deterministic language-neutral test vector
+  in addition to the TypeScript reference implementation.

--- a/docs/card-action-callback-consumer.md
+++ b/docs/card-action-callback-consumer.md
@@ -73,12 +73,16 @@ for action types whose route repeats that `notify_token_env`. The server owns
 action IDs, reserved metadata, layout, escaping, and profile. The request
 accepts neither callback URLs nor arbitrary card JSON.
 
-`actions` is optional. Omit it to preserve the localized Allow/Deny actions and
-their `approve`/`deny` decisions. Sending `"actions": []` (an explicit empty
-array) is treated as a caller bug and rejected — the fallback path is nil, not
-an empty slice. When present, it contains 1-5 entries:
+`actions` is optional. Omit it (or send explicit JSON `null` — equivalent on
+the wire) to preserve the localized Allow/Deny actions and their
+`approve`/`deny` decisions. Sending `"actions": []` (an explicit empty array)
+is treated as a caller bug and rejected — the fallback path is nil, not an
+empty slice. When present, it contains 1-5 entries:
 
-- `decision`: a unique stable value matching `[a-z][a-z0-9_.-]{0,47}`;
+- `decision`: a unique stable value matching `[a-z][a-z0-9_.-]{0,47}`. The
+  tokens `approve` and `deny` are reserved for the legacy 2-button template
+  and rejected as custom decisions so their derived action IDs stay
+  collision-free with `approval-approve` / `approval-deny`;
 - `title`: trimmed display text containing 1-80 Unicode code points; control
   characters (including tabs, newlines, and the BEL byte) are rejected so the
   server never emits an unrenderable button label.

--- a/docs/card-action-callback-consumer.md
+++ b/docs/card-action-callback-consumer.md
@@ -1,8 +1,9 @@
 # Card action callback consumer integration
 
-This guide is for first-party services that consume interactive card actions
-from octo-server. A consumer implements one HTTPS decision endpoint; it does not
-poll a Bot queue, hold a Bot token, or call message/card APIs.
+This guide is for any first-party service that consumes interactive card
+actions from octo-server. A consumer implements one signed decision endpoint;
+it does not poll a Bot queue, hold a Bot token, or call message/card APIs. The
+contract is language- and owner-independent.
 
 For octo-server route configuration, monitoring, DLQ replay, and rollout, see
 [`card-action-callback-dispatch.md`](./card-action-callback-dispatch.md).
@@ -11,7 +12,10 @@ For octo-server route configuration, monitoring, DLQ replay, and rollout, see
 
 Before enabling a producer:
 
-1. Deploy an exact HTTPS endpoint with no redirect.
+1. Deploy an exact HTTPS endpoint with no redirect. An in-cluster or local
+   `http://` endpoint is also allowed when it is declared explicitly in the
+   octo-server `OCTO_CARD_ACTION_ROUTES` registry; the operations guide covers
+   its confidentiality and network-isolation requirements.
 2. Provision a callback HMAC secret of at least 32 random bytes in both
    services. For generic approval ingress, provision a second, distinct notify
    bearer token of the same minimum length.
@@ -24,33 +28,41 @@ Before enabling a producer:
    response in the same transaction.
 
 The callback is at-least-once. A timeout, process crash, or lost response can
-cause the same `event_id` to be delivered again.
+cause the same `event_id` to be delivered again. Keep clocks synchronized and
+reject timestamps outside a bounded freshness window; the reference
+implementation uses five minutes.
 
-## Standard approval onboarding
+## Standard action-card onboarding
 
 For a consumer using the standard terminal visual, no owner-specific
 octo-server code is required:
 
-1. Add the exact sender-bound callback route to `OCTO_CARD_ACTION_ROUTES`, set
-   `notify_token_env`, and add its URL to `OCTO_CARD_ACTION_ALLOWED_URLS`.
+1. Add the exact sender-bound callback route to `OCTO_CARD_ACTION_ROUTES` and
+   set `notify_token_env`. The route's `url` is itself the exact allowlist
+   entry — no separate URL list to maintain.
 2. Implement this signed decide contract and return a typed result.
 3. Call `/v1/internal/notify` with the route-bound token and an
-   `approval_card` containing `action_type`, display text, and bounded domain
-   identifiers.
+   `approval_card` containing `action_type`, display text, bounded domain
+   identifiers, and optional bounded actions.
 
 Example initial-card request:
 
 ```json
 {
   "space_id": "space-1",
-  "service": "smart-summary",
+  "service": "tasks",
   "targets": ["user-b"],
   "actor_uid": "user-a",
   "approval_card": {
-    "action_type": "summary.publish.decision",
-    "title": "Publish summary",
-    "description": "Review before publishing",
-    "data": {"task_no": "task-1"}
+    "action_type": "task.execute.decision",
+    "title": "Execute task",
+    "description": "Choose how to handle this task",
+    "data": {"task_id": "task-1"},
+    "actions": [
+      {"decision": "execute", "title": "Execute"},
+      {"decision": "reject", "title": "Reject"},
+      {"decision": "cancel", "title": "Cancel"}
+    ]
   }
 }
 ```
@@ -58,8 +70,27 @@ Example initial-card request:
 Send `X-Internal-Token: <the value named by notify_token_env>`. The token fixes
 `sender_uid` and `owner`; callers cannot select either. It can mint cards only
 for action types whose route repeats that `notify_token_env`. The server owns
-the Allow/Deny labels, action IDs, reserved metadata, layout, escaping, and
-profile. The request accepts neither callback URLs nor arbitrary card JSON.
+action IDs, reserved metadata, layout, escaping, and profile. The request
+accepts neither callback URLs nor arbitrary card JSON.
+
+`actions` is optional. Omit it to preserve the localized Allow/Deny actions and
+their `approve`/`deny` decisions. Sending `"actions": []` (an explicit empty
+array) is treated as a caller bug and rejected — the fallback path is nil, not
+an empty slice. When present, it contains 1-5 entries:
+
+- `decision`: a unique stable value matching `[a-z][a-z0-9_.-]{0,47}`;
+- `title`: trimmed display text containing 1-80 Unicode code points; control
+  characters (including tabs, newlines, and the BEL byte) are rejected so the
+  server never emits an unrenderable button label.
+
+octo-server derives each action ID as `approval-<decision>` and injects the
+route-bound owner/action type into every submit payload. Per-action data,
+styles, URLs, inputs, and caller-authored card JSON are not supported. Put
+bounded shared domain identifiers in the card's `data` map.
+
+Custom action titles are caller-provided display text. Supply the language
+appropriate for the target audience; octo-server validates and renders the
+text but does not translate consumer-specific wording.
 
 The generic request exposes consumer-specific identifiers in `data`. The
 docs-only `doc_id` and `request_id` top-level conveniences may be absent. For a
@@ -88,18 +119,15 @@ Example request body:
 ```json
 {
   "event_id": "9007199254740993",
-  "action_id": "approve",
-  "decision": "approve",
+  "action_id": "approval-execute",
+  "decision": "execute",
   "operator_uid": "user-b",
-  "doc_id": "doc-1",
-  "request_id": "request-1",
   "inputs": {},
   "data": {
-    "owner": "docs",
-    "action_type": "access_request.decision",
-    "decision": "approve",
-    "doc_id": "doc-1",
-    "request_id": "request-1"
+    "owner": "tasks",
+    "action_type": "task.execute.decision",
+    "decision": "execute",
+    "task_id": "task-1"
   },
   "message_id": "190001234567890",
   "channel_id": "notification",
@@ -113,6 +141,10 @@ Example request body:
 authorization grant. The consumer must still verify that this user can decide
 the referenced request. `data`, `channel_id`, and display fields must not be
 used as substitutes for consumer-owned ACL or request state.
+
+Treat `decision` as an enum owned by the consumer endpoint. Reject values that
+were not configured for this business action; never dispatch it as a method
+name, SQL fragment, URL, or other executable input.
 
 `event_id` is deliberately encoded as a decimal string because its full `int64`
 range exceeds JavaScript's safe integer range. Store and compare it as a string;
@@ -132,6 +164,25 @@ The signature is `v1=` followed by the lowercase hex HMAC-SHA256 of that
 canonical value. Hash the exact bytes received on the wire. Re-serializing JSON
 before verification changes the signature.
 
+### Language-neutral test vector
+
+Use this fixed non-production vector to verify any implementation. The body is
+the single UTF-8 line shown below with no trailing newline.
+
+```text
+secret:    0123456789abcdef0123456789abcdef
+method:    POST
+path:      /v1/card-actions/decide
+timestamp: 1784073600
+event_id:  9007199254740993
+body:      {"event_id":"9007199254740993","action_id":"approval-execute","decision":"execute","operator_uid":"user-b","inputs":{},"data":{"owner":"tasks","action_type":"task.execute.decision","decision":"execute","task_id":"task-1"},"message_id":"190001234567890","channel_id":"notification","channel_type":1,"space_id":"space-1","acted_at":1784073600}
+body_sha256: e5f9edc7558b6dbac6f754308b161d79a84e9d4635377a8afd6f95b6baa4c6cc
+X-Octo-Signature: v1=77d6abe3e80bd90d70545ce90d8c87daafd65a22b62919cee71b450613d6e50f
+```
+
+Changing any body byte, the escaped path, timestamp, or event ID must produce a
+different signature.
+
 The following Express example uses a fixed callback path and a five-minute
 freshness window. Mount `express.raw` for this route before any global
 `express.json` middleware.
@@ -143,7 +194,8 @@ import express, { type Request, type Response } from "express";
 const app = express();
 const callbackPath = "/v1/card-actions/decide";
 const maxSkewSeconds = 300;
-const configuredSecret = process.env.OCTO_DOCS_CARD_ACTION_SECRET;
+// Bind this name to the secret_env configured for this route.
+const configuredSecret = process.env.OCTO_CARD_ACTION_SECRET;
 
 type DecisionRequest = {
   event_id: string;
@@ -183,6 +235,7 @@ function parseDecisionRequest(value: unknown): DecisionRequest {
     "decision",
     "operator_uid",
     "message_id",
+    "channel_id",
   ];
   if (
     requiredStrings.some(
@@ -221,7 +274,7 @@ function parseDecisionRequest(value: unknown): DecisionRequest {
 
 if (!configuredSecret || Buffer.byteLength(configuredSecret) < 32) {
   throw new Error(
-    "OCTO_DOCS_CARD_ACTION_SECRET must contain at least 32 bytes",
+    "OCTO_CARD_ACTION_SECRET must contain at least 32 bytes",
   );
 }
 const secret = configuredSecret;
@@ -308,10 +361,11 @@ BEGIN
   SELECT stored_response FROM card_action_receipt WHERE event_id = ?
   if found: COMMIT and replay stored_response
 
-  lock the domain request identified by request_id/doc_id
+  validate the expected action_type and decision enum
+  lock the domain request identified by consumer-owned data (for example task_id)
   verify the request belongs to the expected Space/resource
   re-check operator_uid is currently authorized
-  CAS pending -> approved/denied (first valid decision wins)
+  apply the selected business operation with a CAS (first valid decision wins)
   INSERT card_action_receipt(event_id, stored_response) with UNIQUE(event_id)
 COMMIT
 return stored_response
@@ -334,19 +388,19 @@ type DecisionResult = {
 };
 ```
 
-Applied approval example:
+Applied action example:
 
 ```json
 {
   "disposition": "applied",
   "state": "approved",
   "requester_uid": "user-a",
-  "display": { "title": "Roadmap" }
+  "display": { "title": "Execute task" }
 }
 ```
 
 An idempotent replay must return the exact stored result for the same
-`event_id`. If the original result was the applied approval above, repeat that
+`event_id`. If the original result was the applied action above, repeat that
 same result; do not rewrite its disposition merely because this HTTP delivery
 is a replay. `replayed` is valid when it was the authoritative result initially
 stored for that event, for example when the business transition had already
@@ -357,7 +411,7 @@ been committed by another decision path:
   "disposition": "replayed",
   "state": "approved",
   "requester_uid": "user-a",
-  "display": { "title": "Roadmap" }
+  "display": { "title": "Execute task" }
 }
 ```
 
@@ -367,10 +421,29 @@ Business rejection is also a typed HTTP 200 response, not an HTTP 403:
 { "disposition": "forbidden", "state": "pending" }
 ```
 
+The selected `decision` and returned `state` are separate contracts. A custom
+decision such as `execute`, `reject`, or `cancel` does not create a new state:
+
+- return `approved` when the requested operation was accepted/completed;
+- return `denied` when it was authoritatively rejected;
+- return `cancelled` when the underlying request was cancelled;
+- use `pending` only to report the current authoritative non-terminal domain
+  state. octo-server still removes the actions and renders the standard
+  unavailable terminal visual; it does not leave the card interactive.
+
+Every valid typed response finalizes and ACKs this card action. If these four
+states or the standard terminal wording cannot represent the result, the
+consumer needs a separately reviewed finalizer/template rather than inventing
+callback response fields.
+
 `requester_uid` is required whenever `state` is `approved` or `denied`, because
-octo-server must notify the applicant. Responses are limited to 64 KiB and the
-current decoder rejects unknown top-level fields. Coordinate schema additions
-with an octo-server release.
+octo-server must notify the applicant. It must be the consumer-authoritative
+request initiator, not the operator or an unverified callback field. Responses
+are limited to 64 KiB and the current decoder rejects unknown top-level fields.
+`display` accepts at most 32 string fields; keys are non-empty and at most 64
+bytes, and values are at most 500 Unicode code points. The standard finalizer
+currently consumes only `display.title`. Coordinate schema additions with an
+octo-server release.
 
 For standard approval routes, the originating card must carry an authoritative
 `space_id`; terminal requester notification fails closed without it.
@@ -379,7 +452,7 @@ For standard approval routes, the originating card must carry an authoritative
 
 | Consumer response                             | octo-server behavior                               |
 | --------------------------------------------- | -------------------------------------------------- |
-| `2xx` + valid typed body                      | Finalize card and applicant notification, then ACK |
+| `2xx` + valid typed body                      | Finalize card; approved/denied also notify requester; then ACK |
 | `408`, `429`, or `5xx`                        | Retry with bounded exponential backoff             |
 | Other `4xx`                                   | Permanent rejection; move to DLQ                   |
 | `3xx`                                         | Redirect rejected; move to DLQ                     |
@@ -396,7 +469,8 @@ Do not return HTTP 403/404 for normal domain outcomes; use the typed
 - stale timestamp fails verification;
 - header/body `event_id` mismatch fails verification;
 - duplicate `event_id` replays one stored response without a second transition;
-- concurrent approve/deny produces one domain winner;
+- an unknown `decision` is rejected without a domain transition;
+- concurrent decisions produce one domain winner;
 - operator removed from ACL before click returns `forbidden`;
 - terminal `approved`/`denied` always includes `requester_uid`;
 - transient `5xx` can be retried safely.

--- a/docs/card-action-callback-dispatch.md
+++ b/docs/card-action-callback-dispatch.md
@@ -156,16 +156,18 @@ callers must inspect both `delivered` and `filtered`.
 
 The token supplies the authoritative owner; the request cannot choose it. The
 server adds reserved metadata and builds every action. `actions` is optional:
-omitting the field preserves the existing localized approve/deny buttons.
-Sending `"actions": []` (explicit empty array) is a caller bug and rejected —
-the fallback path is nil, not an empty slice. When present, it must contain
-1-5 items. Each `decision` is unique and matches `[a-z][a-z0-9_.-]{0,47}`;
-each trimmed `title` is 1-80 Unicode code points and cannot contain control
-characters (tabs, newlines, BEL, etc.). octo-server derives the action ID as
-`approval-<decision>` and the callback receives that decision unchanged. `data`
-accepts at most 32 lower-case keys with string values up to 500 runes; `owner`,
-`action_type`, and `decision` are reserved. No per-action data, URL, input,
-style, or arbitrary card JSON is accepted.
+omitting the field (or sending explicit JSON `null` — equivalent on the wire)
+preserves the existing localized approve/deny buttons. Sending `"actions": []`
+(explicit empty array) is a caller bug and rejected — the fallback path is
+nil, not an empty slice. When present, it must contain 1-5 items. Each
+`decision` is unique and matches `[a-z][a-z0-9_.-]{0,47}`; the tokens
+`approve` and `deny` are reserved for the legacy template and rejected as
+custom decisions. Each trimmed `title` is 1-80 Unicode code points and cannot
+contain control characters (tabs, newlines, BEL, etc.). octo-server derives
+the action ID as `approval-<decision>` and the callback receives that decision
+unchanged. `data` accepts at most 32 lower-case keys with string values up to
+500 runes; `owner`, `action_type`, and `decision` are reserved. No per-action
+data, URL, input, style, or arbitrary card JSON is accepted.
 
 Custom decisions do not add callback result states. The consumer still returns
 one authoritative `state`: `approved`, `denied`, `cancelled`, or `pending`.

--- a/docs/card-action-callback-dispatch.md
+++ b/docs/card-action-callback-dispatch.md
@@ -8,40 +8,28 @@ Consumer implementers should start with
 [`card-action-callback-consumer.md`](./card-action-callback-consumer.md) for the
 wire contract, TypeScript verification example, idempotency, and retry rules.
 
-Standard approve/deny consumers need a signed decide endpoint and one route
-entry with `notify_token_env`. That entry authorizes both the callback and an
-owner-bound generic `approval_card` ingress. Docs is bound to its specialized
-resource-card finalizer; every other registered `(owner, action_type)` uses
-octo-server's standard approval terminal card and requester notification. A
-custom terminal visual remains a reviewed octo-server extension, not
-callback-authored card JSON.
+Standard action consumers need a signed decide endpoint and one route entry
+with `notify_token_env`. That entry authorizes both the callback and an
+owner-bound generic `approval_card` ingress. The card may use the compatible
+localized approve/deny defaults or 1-5 bounded custom actions. Docs is bound to
+its specialized resource-card finalizer; every other registered `(owner,
+action_type)` uses octo-server's standard terminal card and requester
+notification. A custom terminal visual remains a reviewed octo-server
+extension, not callback-authored card JSON.
 
 ## Required configuration
 
 Routes are static startup configuration. Card data can select only a registered
 `(stored sender_uid, owner, action_type)` tuple and never carries a URL.
 
-```bash
-export OCTO_CARD_ACTION_ALLOWED_URLS='https://docs.internal/v1/card-actions/decide'
-export OCTO_CARD_ACTION_ROUTES='[{"sender_uid":"notification","owner":"docs","action_type":"access_request.decision","url":"https://docs.internal/v1/card-actions/decide","secret_env":"OCTO_DOCS_CARD_ACTION_SECRET","timeout_ms":3000,"max_attempts":5,"base_backoff_ms":1000,"max_backoff_ms":60000,"max_in_flight":8}]'
-export OCTO_DOCS_CARD_ACTION_SECRET='<at least 32 random bytes>'
-export OCTO_DOCS_NOTIFY_TOKEN='<dedicated docs ingress token>'
-export OCTO_DOCS_APPROVAL_CARD_ENABLED=true
-export OCTO_CARD_MESSAGE_ENABLED=true
-```
-
-Startup fails if a route is malformed, not in the exact HTTPS allowlist, has a
-missing/short secret, or if the docs pilot is enabled without its exact route.
-Callback redirects and environment HTTP proxies are disabled.
-
-For example, a second service can add a route without adding a finalizer or Bot
+For example, a new service can add a route without adding a finalizer or Bot
 worker:
 
 ```json
 {
   "sender_uid": "notification",
   "owner": "tasks",
-  "action_type": "task.decision",
+  "action_type": "task.execute.decision",
   "url": "https://tasks.internal/v1/card-actions/decide",
   "secret_env": "OCTO_TASKS_CARD_ACTION_SECRET",
   "notify_token_env": "OCTO_TASKS_NOTIFY_TOKEN",
@@ -53,13 +41,69 @@ worker:
 }
 ```
 
-Set both referenced values to distinct random secrets of at least 32 bytes and
-add the exact callback URL to `OCTO_CARD_ACTION_ALLOWED_URLS`:
+Route fields:
+
+| Field | Requirement |
+| --- | --- |
+| `sender_uid` | Use `notification` when `notify_token_env` enables the generic ingress |
+| `owner` | Stable lowercase service owner, `[a-z][a-z0-9-]{0,63}` |
+| `action_type` | Stable action contract, `[a-z][a-z0-9_.-]{0,127}` |
+| `url` | Exact absolute callback URL under the transport policy below; this list is itself the allowlist |
+| `secret_env` | Environment variable containing at least 32 bytes |
+| `notify_token_env` | Optional; enables `approval_card`, also at least 32 bytes; it may be shared by action types of the same owner but must differ from callback secrets and other owners' or legacy/docs notify tokens |
+| `timeout_ms` | Default 3000; allowed 100-10000 |
+| `max_attempts` | Default 5; allowed 1-10 |
+| `base_backoff_ms` | Default 1000; allowed 100-60000 |
+| `max_backoff_ms` | Default 60000; between base backoff and 600000 |
+| `max_in_flight` | Default 8; allowed 1-100, enforced per route per octo-server process |
+
+Total callback concurrency scales with the number of octo-server replicas;
+size the consumer and its downstream pool accordingly.
+
+Set both referenced values to distinct random secrets of at least 32 bytes:
 
 ```bash
+export OCTO_CARD_ACTION_ROUTES='[{"sender_uid":"notification","owner":"tasks","action_type":"task.execute.decision","url":"https://tasks.internal/v1/card-actions/decide","secret_env":"OCTO_TASKS_CARD_ACTION_SECRET","notify_token_env":"OCTO_TASKS_NOTIFY_TOKEN","timeout_ms":3000,"max_attempts":5,"base_backoff_ms":1000,"max_backoff_ms":60000,"max_in_flight":8}]'
 export OCTO_TASKS_CARD_ACTION_SECRET='<at least 32 random bytes>'
 export OCTO_TASKS_NOTIFY_TOKEN='<different, at least 32 random bytes>'
+export OCTO_CARD_MESSAGE_ENABLED=true
 ```
+
+`OCTO_CARD_ACTION_ROUTES` is a single JSON array containing every route and is
+itself the exact URL allowlist. Startup fails if a route is malformed or has a
+missing/short secret or an invalid cross-capability token reuse.
+
+`OCTO_CARD_ACTION_ALLOWED_URLS` is deprecated and no longer consulted. If it is
+still present in a rolling upgrade, octo-server logs a single structured
+deprecation WARN at startup and continues; remove it from the ConfigMap when
+convenient.
+
+### Callback URL transport policy
+
+- Both `https://` and `http://` are accepted. The scheme chosen in each route
+  is the operator's explicit authorization for that destination.
+- URLs must be absolute, contain a host, and carry no user credentials, query,
+  fragment, or opaque form. Redirects and environment HTTP proxies remain
+  disabled for both schemes.
+- Hostname shape (Kubernetes Service DNS, docker service name,
+  `host.docker.internal`, IP literal, or `localhost`) is not inspected;
+  reachability is a network-layer concern, not a URL-parser concern.
+
+Representative destinations for HTTP:
+
+```text
+http://smart-summary.dmwork-test.svc:8080/v1/card-actions/decide
+http://smart-summary:8080/v1/card-actions/decide
+http://host.docker.internal:8080/v1/card-actions/decide
+http://127.0.0.1:8080/v1/card-actions/decide
+```
+
+HMAC authenticates the request but does not encrypt it, and callback responses
+are not separately signed. Callback bodies may contain the operator UID, Space
+ID, and business identifiers. When plain HTTP is used, restrict consumer
+ingress and octo-server egress with cluster NetworkPolicy or a service mesh
+that encrypts pod traffic; prefer HTTPS for anything that crosses a cluster,
+a network zone, or a public boundary.
 
 `notify_token_env` is optional for callback-only routes whose initial card is
 produced elsewhere. When present, it dynamically installs an `octo/v2`,
@@ -81,18 +125,53 @@ Content-Type: application/json
   "targets": ["approver-b"],
   "actor_uid": "requester-a",
   "approval_card": {
-    "action_type": "task.decision",
-    "title": "Deploy release",
-    "description": "Approve production deployment",
-    "data": {"task_id": "task-1"}
+    "action_type": "task.execute.decision",
+    "title": "Execute task",
+    "description": "Choose how to handle this task",
+    "data": {"task_id": "task-1"},
+    "actions": [
+      {"decision": "execute", "title": "Execute"},
+      {"decision": "reject", "title": "Reject"},
+      {"decision": "cancel", "title": "Cancel"}
+    ]
   }
 }
 ```
 
+`space_id`, `service`, and `targets` are required. `targets` contains 1-200 user
+IDs and is de-duplicated; `actor_uid`, when present, is excluded from delivery.
+The token-bound owner is authoritative, not the caller-supplied `service`
+label. Generic action cards are DM-only and every target must be a current
+member of the Space. The batch notify endpoint does not accept
+`approval_card`.
+
+A successful request returns the actual delivery result:
+
+```json
+{"delivered":["approver-b"],"filtered":{}}
+```
+
+An HTTP 200 therefore does not imply every requested target received the card;
+callers must inspect both `delivered` and `filtered`.
+
 The token supplies the authoritative owner; the request cannot choose it. The
-server adds approve/deny actions and reserved metadata. `data` accepts at most
-32 lower-case keys with string values up to 500 runes; `owner`, `action_type`,
-and `decision` are reserved. No callback URL or card JSON is accepted.
+server adds reserved metadata and builds every action. `actions` is optional:
+omitting the field preserves the existing localized approve/deny buttons.
+Sending `"actions": []` (explicit empty array) is a caller bug and rejected —
+the fallback path is nil, not an empty slice. When present, it must contain
+1-5 items. Each `decision` is unique and matches `[a-z][a-z0-9_.-]{0,47}`;
+each trimmed `title` is 1-80 Unicode code points and cannot contain control
+characters (tabs, newlines, BEL, etc.). octo-server derives the action ID as
+`approval-<decision>` and the callback receives that decision unchanged. `data`
+accepts at most 32 lower-case keys with string values up to 500 runes; `owner`,
+`action_type`, and `decision` are reserved. No per-action data, URL, input,
+style, or arbitrary card JSON is accepted.
+
+Custom decisions do not add callback result states. The consumer still returns
+one authoritative `state`: `approved`, `denied`, `cancelled`, or `pending`.
+Every valid typed response finalizes the current card; `pending` does not keep
+the buttons interactive. Use a custom finalizer only when the standard terminal
+status cannot represent the business outcome.
 
 The callback receives `X-Octo-Timestamp`, `X-Octo-Event-ID`, and
 `X-Octo-Signature: v1=<hex HMAC-SHA256>`. The canonical signed bytes are:
@@ -152,8 +231,8 @@ pilot. Roll back by disabling the pilot, which restores the existing `octo/v1`
 display card. Keep routes until ready/leased queues drain; removing a live route
 sends affected events to DLQ rather than to the Bot pull queue.
 
-For a generic owner, deploy the decide endpoint first, then add the allowlist,
-route, callback secret, and notify token in one restart. Verify a test
-`approval_card` before switching business traffic. Roll back by stopping new
-approval-card calls, draining ready/leased events, and only then removing the
-route and secrets.
+For a generic owner, deploy the decide endpoint first, then add the route,
+callback secret, and notify token in one restart. Verify every configured
+action on a test `approval_card` before switching business traffic. Roll back
+by stopping new approval-card calls, draining ready/leased events, and only then
+removing the route and secrets.

--- a/docs/card-protocol.md
+++ b/docs/card-protocol.md
@@ -205,13 +205,10 @@ robot API（legacy）`/robot/sendMessage` 同样接受 type-17（校验与 bot i
 fail-closed，不会落入无人消费的 Bot 队列。传输、队列与运维合同见
 [`card-action-callback-dispatch.md`](./card-action-callback-dispatch.md)。
 
-终态渲染按权威 owner/action 选择：docs 使用专用资源卡模板，其余已注册 route 使用
-服务端标准审批终态模板与申请人通知。因此标准审批消费方只新增 decide endpoint + route；
-只有定制视觉需要增加受审的 octo-server finalizer binding。
-
-标准审批初始卡同样不需要新增代码：route 可配置独立 `notify_token_env`，消费方用该 token
-向 `/v1/internal/notify` 提交结构化 `approval_card`。token 在服务端绑定 sender/owner/action；
-消费方不能自选 owner、callback URL 或提交任意卡片 JSON。
+一方消费方的 route/notify 配置、标准 action 卡、终态约束、回调验签、幂等、重试与 DLQ
+统一以 [`card-action-callback-dispatch.md`](./card-action-callback-dispatch.md) 和
+[`card-action-callback-consumer.md`](./card-action-callback-consumer.md) 为准；本文不重复维护
+消费方接入合同。
 
 - **状态在卡片内容里**：防重复操作 = 服务端幂等（业务身份键
   `message_id+action_id+operator_uid`，`client_token` 只是关联 ID）+ bot 重写

--- a/internal/cardactiondispatch/config.go
+++ b/internal/cardactiondispatch/config.go
@@ -65,14 +65,3 @@ func LoadRouteSpecs(raw string) ([]RouteSpec, error) {
 	}
 	return specs, nil
 }
-
-func LoadAllowedURLs(raw string) []string {
-	parts := strings.Split(raw, ",")
-	urls := make([]string, 0, len(parts))
-	for _, part := range parts {
-		if value := strings.TrimSpace(part); value != "" {
-			urls = append(urls, value)
-		}
-	}
-	return urls
-}

--- a/internal/cardactiondispatch/contract_test.go
+++ b/internal/cardactiondispatch/contract_test.go
@@ -42,7 +42,6 @@ func testGetenv(key string) string {
 func TestRegistryResolveIsBoundToStoredSender(t *testing.T) {
 	registry, err := NewRegistry(
 		[]RouteSpec{validRouteSpec()},
-		[]string{"https://docs.internal/v1/card-actions/decide"},
 		testGetenv,
 	)
 	if err != nil {
@@ -103,46 +102,47 @@ func TestNewRegistryRejectsUnsafeOrAmbiguousRoutes(t *testing.T) {
 	tests := []struct {
 		name       string
 		mutate     func(*RouteSpec)
-		allowed    []string
 		getenv     func(string) string
 		additional []RouteSpec
 	}{
 		{
-			name: "non https URL",
+			name: "unsupported scheme",
 			mutate: func(spec *RouteSpec) {
-				spec.URL = "http://docs.internal/v1/card-actions/decide"
+				spec.URL = "ftp://docs.internal/v1/card-actions/decide"
 			},
-			allowed: []string{"http://docs.internal/v1/card-actions/decide"},
 		},
 		{
 			name: "credential bearing URL",
 			mutate: func(spec *RouteSpec) {
 				spec.URL = "https://user:pass@docs.internal/v1/card-actions/decide"
 			},
-			allowed: []string{"https://user:pass@docs.internal/v1/card-actions/decide"},
 		},
 		{
 			name: "fragment bearing URL",
 			mutate: func(spec *RouteSpec) {
 				spec.URL = "https://docs.internal/v1/card-actions/decide#fragment"
 			},
-			allowed: []string{"https://docs.internal/v1/card-actions/decide#fragment"},
 		},
 		{
-			name:    "URL not in exact allowlist",
-			mutate:  func(*RouteSpec) {},
-			allowed: []string{"https://other.internal/v1/card-actions/decide"},
+			name: "query bearing URL",
+			mutate: func(spec *RouteSpec) {
+				spec.URL = "https://docs.internal/v1/card-actions/decide?trace=1"
+			},
 		},
 		{
-			name:    "missing secret",
-			mutate:  func(*RouteSpec) {},
-			allowed: []string{"https://docs.internal/v1/card-actions/decide"},
-			getenv:  func(string) string { return "" },
+			name: "URL missing host",
+			mutate: func(spec *RouteSpec) {
+				spec.URL = "https:///v1/card-actions/decide"
+			},
 		},
 		{
-			name:    "duplicate route key",
-			mutate:  func(*RouteSpec) {},
-			allowed: []string{"https://docs.internal/v1/card-actions/decide"},
+			name:   "missing secret",
+			mutate: func(*RouteSpec) {},
+			getenv: func(string) string { return "" },
+		},
+		{
+			name:   "duplicate route key",
+			mutate: func(*RouteSpec) {},
 			additional: []RouteSpec{
 				validRouteSpec(),
 			},
@@ -157,7 +157,7 @@ func TestNewRegistryRejectsUnsafeOrAmbiguousRoutes(t *testing.T) {
 			if getenv == nil {
 				getenv = testGetenv
 			}
-			_, err := NewRegistry(append([]RouteSpec{spec}, tt.additional...), tt.allowed, getenv)
+			_, err := NewRegistry(append([]RouteSpec{spec}, tt.additional...), getenv)
 			if err == nil {
 				t.Fatal("NewRegistry() error = nil, want configuration rejection")
 			}
@@ -216,7 +216,7 @@ func TestRegistryBindsNotifyTokenToOnlyConfiguredOwnerActions(t *testing.T) {
 			return ""
 		}
 	}
-	registry, err := NewRegistry([]RouteSpec{primary, secondary}, []string{primary.URL}, getenv)
+	registry, err := NewRegistry([]RouteSpec{primary, secondary}, getenv)
 	if err != nil {
 		t.Fatalf("NewRegistry() error = %v", err)
 	}
@@ -314,7 +314,7 @@ func TestRegistryRejectsUnsafeNotifyTokenBindings(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if _, err := NewRegistry(tt.specs(), []string{validRouteSpec().URL}, tt.getenv); err == nil {
+			if _, err := NewRegistry(tt.specs(), tt.getenv); err == nil {
 				t.Fatal("NewRegistry() error = nil")
 			}
 		})
@@ -330,7 +330,7 @@ func TestRegistryRejectsNotifyTokenThatConflictsWithBroaderIngress(t *testing.T)
 		}
 		return testGetenv(key)
 	}
-	registry, err := NewRegistry([]RouteSpec{spec}, []string{spec.URL}, getenv)
+	registry, err := NewRegistry([]RouteSpec{spec}, getenv)
 	if err != nil {
 		t.Fatalf("NewRegistry() error = %v", err)
 	}

--- a/internal/cardactiondispatch/coverage_test.go
+++ b/internal/cardactiondispatch/coverage_test.go
@@ -35,7 +35,7 @@ func (q *idleDispatchQueue) ReclaimExpired(time.Time, int) (int, error) {
 }
 
 func TestDispatcherLifecycleStartsStopsAndRejectsDoubleStart(t *testing.T) {
-	registry, err := NewRegistry([]RouteSpec{validRouteSpec()}, []string{validRouteSpec().URL}, testGetenv)
+	registry, err := NewRegistry([]RouteSpec{validRouteSpec()}, testGetenv)
 	if err != nil {
 		t.Fatalf("NewRegistry() error = %v", err)
 	}
@@ -76,9 +76,6 @@ func (*stubDeliverer) Deliver(context.Context, *Route, DecisionRequest) (Decisio
 }
 
 func TestConfigAndValidationErrorPathsFailClosed(t *testing.T) {
-	if got := LoadAllowedURLs(" https://a.internal/x, ,https://b.internal/y "); len(got) != 2 {
-		t.Fatalf("LoadAllowedURLs() = %v", got)
-	}
 	for _, raw := range []string{
 		`not-json`,
 		`[{"sender_uid":"notification","unknown":true}]`,
@@ -109,7 +106,7 @@ func TestConfigAndValidationErrorPathsFailClosed(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			spec := validRouteSpec()
 			tt.mutate(&spec)
-			_, err := NewRegistry([]RouteSpec{spec}, []string{spec.URL}, testGetenv)
+			_, err := NewRegistry([]RouteSpec{spec}, testGetenv)
 			if err == nil {
 				t.Fatal("NewRegistry() error = nil")
 			}

--- a/internal/cardactiondispatch/dispatcher_test.go
+++ b/internal/cardactiondispatch/dispatcher_test.go
@@ -136,7 +136,7 @@ func (d *contextAwareBlockingDeliverer) Deliver(ctx context.Context, _ *Route, _
 func TestDispatcherHonorsPerRouteConcurrency(t *testing.T) {
 	spec := validRouteSpec()
 	spec.MaxInFlight = 2
-	registry, err := NewRegistry([]RouteSpec{spec}, []string{spec.URL}, testGetenv)
+	registry, err := NewRegistry([]RouteSpec{spec}, testGetenv)
 	if err != nil {
 		t.Fatalf("NewRegistry() error = %v", err)
 	}
@@ -185,7 +185,7 @@ func TestDispatcherDefersSaturatedRouteAndProcessesOtherRoute(t *testing.T) {
 	tasks.Owner = "tasks"
 	tasks.ActionType = "task.decision"
 	tasks.URL = "https://tasks.internal/v1/card-actions/decide"
-	registry, err := NewRegistry([]RouteSpec{docs, tasks}, []string{docs.URL, tasks.URL}, testGetenv)
+	registry, err := NewRegistry([]RouteSpec{docs, tasks}, testGetenv)
 	if err != nil {
 		t.Fatalf("NewRegistry() error = %v", err)
 	}
@@ -254,7 +254,7 @@ func TestDispatcherDefersSaturatedRouteAndProcessesOtherRoute(t *testing.T) {
 func TestDispatcherStopDoesNotWaitOnSaturatedRouteSlot(t *testing.T) {
 	spec := validRouteSpec()
 	spec.MaxInFlight = 1
-	registry, err := NewRegistry([]RouteSpec{spec}, []string{spec.URL}, testGetenv)
+	registry, err := NewRegistry([]RouteSpec{spec}, testGetenv)
 	if err != nil {
 		t.Fatalf("NewRegistry() error = %v", err)
 	}
@@ -297,7 +297,7 @@ func TestDispatcherStopDoesNotWaitOnSaturatedRouteSlot(t *testing.T) {
 func TestDispatcherStartProcessesUpToPerRouteConcurrency(t *testing.T) {
 	spec := validRouteSpec()
 	spec.MaxInFlight = 2
-	registry, err := NewRegistry([]RouteSpec{spec}, []string{spec.URL}, testGetenv)
+	registry, err := NewRegistry([]RouteSpec{spec}, testGetenv)
 	if err != nil {
 		t.Fatalf("NewRegistry() error = %v", err)
 	}
@@ -340,7 +340,7 @@ func TestDispatcherStartProcessesUpToPerRouteConcurrency(t *testing.T) {
 
 func TestDispatcherStopCompletesClaimedEvent(t *testing.T) {
 	spec := validRouteSpec()
-	registry, err := NewRegistry([]RouteSpec{spec}, []string{spec.URL}, testGetenv)
+	registry, err := NewRegistry([]RouteSpec{spec}, testGetenv)
 	if err != nil {
 		t.Fatalf("NewRegistry() error = %v", err)
 	}
@@ -398,7 +398,7 @@ func TestDispatcherStopCompletesClaimedEvent(t *testing.T) {
 
 func TestDispatcherRenewsLeaseDuringSlowFinalization(t *testing.T) {
 	spec := validRouteSpec()
-	registry, err := NewRegistry([]RouteSpec{spec}, []string{spec.URL}, testGetenv)
+	registry, err := NewRegistry([]RouteSpec{spec}, testGetenv)
 	if err != nil {
 		t.Fatalf("NewRegistry() error = %v", err)
 	}
@@ -519,7 +519,7 @@ func TestRedisQueueDeferPreservesAttemptAndOwnership(t *testing.T) {
 
 func TestDispatcherSchedulesRetryFromFailureTime(t *testing.T) {
 	spec := validRouteSpec()
-	registry, err := NewRegistry([]RouteSpec{spec}, []string{spec.URL}, testGetenv)
+	registry, err := NewRegistry([]RouteSpec{spec}, testGetenv)
 	if err != nil {
 		t.Fatalf("NewRegistry() error = %v", err)
 	}
@@ -555,7 +555,7 @@ func TestDispatcherSchedulesRetryFromFailureTime(t *testing.T) {
 func TestDispatcherDeadLettersLeaseBeyondRouteAttemptLimitWithoutDelivery(t *testing.T) {
 	spec := validRouteSpec()
 	spec.MaxAttempts = 2
-	registry, err := NewRegistry([]RouteSpec{spec}, []string{spec.URL}, testGetenv)
+	registry, err := NewRegistry([]RouteSpec{spec}, testGetenv)
 	if err != nil {
 		t.Fatalf("NewRegistry() error = %v", err)
 	}
@@ -823,7 +823,7 @@ func registryForTestServer(t *testing.T, callbackURL string, maxAttempts int) *R
 	spec := validRouteSpec()
 	spec.URL = callbackURL
 	spec.MaxAttempts = maxAttempts
-	registry, err := NewRegistry([]RouteSpec{spec}, []string{callbackURL}, testGetenv)
+	registry, err := NewRegistry([]RouteSpec{spec}, testGetenv)
 	if err != nil {
 		t.Fatalf("NewRegistry(test server) error = %v", err)
 	}

--- a/internal/cardactiondispatch/http.go
+++ b/internal/cardactiondispatch/http.go
@@ -48,8 +48,9 @@ func Retryable(err error) bool {
 func NewHTTPDeliverer(transport http.RoundTripper, clock func() time.Time) *HTTPDeliverer {
 	if transport == nil {
 		base := http.DefaultTransport.(*http.Transport).Clone()
-		// Routes are already exact, static HTTPS URLs. Ignoring proxy environment
-		// variables prevents deployment-level proxy settings from reopening SSRF.
+		// Routes are already exact, static URLs registered by operators.
+		// Ignoring proxy environment variables prevents deployment-level proxy
+		// settings from reopening SSRF for both http and https destinations.
 		base.Proxy = nil
 		transport = base
 	}

--- a/internal/cardactiondispatch/orchestration_integration_test.go
+++ b/internal/cardactiondispatch/orchestration_integration_test.go
@@ -128,7 +128,7 @@ func TestCardActionCallbackOrchestrationWithMockDocs(t *testing.T) {
 	registry, err := cardactiondispatch.NewRegistry([]cardactiondispatch.RouteSpec{{
 		SenderUID: "notification", Owner: "docs", ActionType: "access_request.decision",
 		URL: callbackURL, SecretEnv: "OCTO_DOCS_CARD_ACTION_SECRET",
-	}}, []string{callbackURL}, func(string) string { return secret })
+	}}, func(string) string { return secret })
 	require.NoError(t, err)
 	queue, err := cardactiondispatch.NewRedisQueue(rds, cardactiondispatch.QueueConfig{
 		Prefix: prefix, LiveTTL: ctx.GetConfig().Robot.MessageExpire, DLQRetention: 30 * 24 * time.Hour,
@@ -249,7 +249,7 @@ func TestCardActionCallbackOrchestrationUsesStandardFinalizerForNewOwner(t *test
 	registry, err := cardactiondispatch.NewRegistry([]cardactiondispatch.RouteSpec{{
 		SenderUID: "notification", Owner: "tasks", ActionType: "task.decision",
 		URL: callbackURL, SecretEnv: "OCTO_TASKS_CARD_ACTION_SECRET",
-	}}, []string{callbackURL}, func(string) string { return secret })
+	}}, func(string) string { return secret })
 	require.NoError(t, err)
 	queue, err := cardactiondispatch.NewRedisQueue(rds, cardactiondispatch.QueueConfig{
 		Prefix: prefix, LiveTTL: time.Hour, DLQRetention: 30 * 24 * time.Hour,
@@ -366,4 +366,112 @@ func cleanupRedisPatterns(t *testing.T, client *redis.Client, patterns ...string
 			require.NoError(t, client.Del(keys...).Err())
 		}
 	}
+}
+
+// TestCardActionCallbackOrchestrationForwardsCustomDecisionEndToEnd is the
+// end-to-end guard for the http-actions follow-up: a caller-supplied custom
+// decision (`execute`) must round-trip from the enqueued click through the
+// signed callback body to the consumer's typed response, and the standard
+// finalizer must render the state the consumer picked (`approved`) instead of
+// hardcoding a decision-derived state.
+func TestCardActionCallbackOrchestrationForwardsCustomDecisionEndToEnd(t *testing.T) {
+	t.Setenv(cardmsg.EnvEnabled, "true")
+	t.Setenv("OCTO_MASTER_KEY", "0123456789abcdef0123456789abcdef")
+	const secret = "0123456789abcdef0123456789abcdef"
+	callbackCalls := make(chan docsCallbackCapture, 1)
+	consumer := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		capture := docsCallbackCapture{method: r.Method, path: r.URL.EscapedPath(), err: err}
+		if err == nil {
+			capture.err = json.Unmarshal(body, &capture.request)
+		}
+		capture.signatureValid = cardactiondispatch.Verify(
+			secret, r.Header.Get(cardactiondispatch.HeaderSignature), r.Method, r.URL.EscapedPath(),
+			r.Header.Get(cardactiondispatch.HeaderTimestamp), r.Header.Get(cardactiondispatch.HeaderEventID), body,
+		)
+		callbackCalls <- capture
+		w.Header().Set("Content-Type", "application/json")
+		// The consumer maps the caller's custom `execute` decision to the
+		// standard `approved` state; octo-server must respect that mapping.
+		_, _ = w.Write([]byte(`{"disposition":"applied","state":"approved","requester_uid":"user-a","display":{"title":"Execute task"}}`))
+	}))
+	defer consumer.Close()
+
+	_, ctx := testutil.NewTestServer()
+	defer func() { _ = testutil.CleanAllTables(ctx) }()
+	rds := redis.NewClient(&redis.Options{Addr: ctx.GetConfig().DB.RedisAddr, Password: ctx.GetConfig().DB.RedisPass})
+	prefix := fmt.Sprintf("test:card_action_custom_decision_e2e:%d", time.Now().UnixNano())
+	cleanupRedisPatterns(t, rds, prefix+"*")
+	t.Cleanup(func() {
+		cleanupRedisPatterns(t, rds, prefix+"*")
+		_ = rds.Close()
+	})
+
+	callbackURL := consumer.URL + "/v1/card-actions/decide"
+	registry, err := cardactiondispatch.NewRegistry([]cardactiondispatch.RouteSpec{{
+		SenderUID: "notification", Owner: "tasks", ActionType: "task.execute.decision",
+		URL: callbackURL, SecretEnv: "OCTO_TASKS_CARD_ACTION_SECRET",
+	}}, func(string) string { return secret })
+	require.NoError(t, err)
+	queue, err := cardactiondispatch.NewRedisQueue(rds, cardactiondispatch.QueueConfig{
+		Prefix: prefix, LiveTTL: time.Hour, DLQRetention: 30 * 24 * time.Hour,
+	})
+	require.NoError(t, err)
+	service, err := cardactiondispatch.NewService(registry, queue, ctx)
+	require.NoError(t, err)
+
+	// Simulate the click on the custom `execute` Action.Submit button. The
+	// action ID mirrors what pkg/cardtmpl derives for a custom decision.
+	eventID, err := service.Enqueue(cardactiondispatch.Event{
+		SenderUID: "notification", Owner: "tasks", ActionType: "task.execute.decision",
+		MessageID: "task-message-custom-1", ChannelID: "notification", ChannelType: common.ChannelTypePerson.Uint8(),
+		SpaceID: "space-1", ActionID: "approval-execute", OperatorUID: "user-b", ActedAt: time.Now().Unix(),
+		Data: map[string]interface{}{
+			"owner": "tasks", "action_type": "task.execute.decision",
+			"decision": "execute", "task_id": "task-1",
+		},
+	})
+	require.NoError(t, err)
+
+	mutator := &callbackE2EMutator{}
+	sender := &callbackE2ESender{}
+	standard, err := notify.NewStandardActionFinalizer(mutator, sender)
+	require.NoError(t, err)
+	finalizers, err := cardactiondispatch.NewFinalizerRegistry(standard, nil)
+	require.NoError(t, err)
+	dispatcher, err := cardactiondispatch.NewDispatcher(
+		queue, registry, cardactiondispatch.NewHTTPDeliverer(consumer.Client().Transport, time.Now), finalizers,
+		cardactiondispatch.DispatcherConfig{},
+	)
+	require.NoError(t, err)
+	processed, err := dispatcher.ProcessOne(context.Background(), time.Now().Add(time.Second))
+	require.NoError(t, err)
+	require.True(t, processed)
+
+	callback := <-callbackCalls
+	require.NoError(t, callback.err)
+	assert.True(t, callback.signatureValid, "custom-decision callback must still sign the exact body")
+	assert.Equal(t, eventID, callback.request.EventID)
+	assert.Equal(t, "execute", callback.request.Decision,
+		"custom decision must reach the consumer unmodified — no server-side rewrite to approve/deny")
+	assert.Equal(t, "approval-execute", callback.request.ActionID,
+		"action ID must follow the derived approval-<decision> convention")
+	assert.Equal(t, "task-1", callback.request.Data["task_id"])
+	assert.Equal(t, "execute", callback.request.Data["decision"],
+		"reserved decision field in Data must mirror the top-level decision")
+
+	// Standard finalizer must use the consumer-returned state (approved), not
+	// something derived from the custom decision name.
+	require.Len(t, mutator.requests, 1)
+	assert.Equal(t, "user-b", mutator.requests[0].ChannelID)
+	assert.Contains(t, mutator.requests[0].ContentEdit, "approval.approved",
+		"terminal card must render the consumer-picked state, not the decision string")
+	require.Len(t, sender.targets, 1)
+	assert.Equal(t, "user-a", sender.targets[0].ChannelID,
+		"requester notification must fire on approved regardless of the custom decision label")
+	assert.Equal(t, cardmsg.ProfileV1, sender.cards[0].Profile)
+
+	depths, err := queue.Depths()
+	require.NoError(t, err)
+	assert.Equal(t, cardactiondispatch.QueueDepths{}, depths, "queue must drain cleanly on successful custom-decision callback")
 }

--- a/internal/cardactiondispatch/registry.go
+++ b/internal/cardactiondispatch/registry.go
@@ -95,13 +95,9 @@ type Registry struct {
 	callbackSecrets   map[string]struct{}
 }
 
-func NewRegistry(specs []RouteSpec, allowedURLs []string, getenv func(string) string) (*Registry, error) {
+func NewRegistry(specs []RouteSpec, getenv func(string) string) (*Registry, error) {
 	if getenv == nil {
 		return nil, errors.New("cardactiondispatch: getenv is required")
-	}
-	allowed, err := validateAllowedURLs(allowedURLs)
-	if err != nil {
-		return nil, err
 	}
 	registry := &Registry{
 		routes:          make(map[routeKey]*Route, len(specs)),
@@ -113,7 +109,7 @@ func NewRegistry(specs []RouteSpec, allowedURLs []string, getenv func(string) st
 	tokenOwners := make(map[string]NotifyCapability)
 	for i, input := range specs {
 		spec := withRouteDefaults(input)
-		if err := validateRouteSpec(spec, allowed, getenv); err != nil {
+		if err := validateRouteSpec(spec, getenv); err != nil {
 			return nil, fmt.Errorf("cardactiondispatch: route %d: %w", i, err)
 		}
 		key := routeKey{senderUID: spec.SenderUID, owner: spec.Owner, actionType: spec.ActionType}
@@ -277,7 +273,7 @@ func withRouteDefaults(spec RouteSpec) RouteSpec {
 	return spec
 }
 
-func validateRouteSpec(spec RouteSpec, allowed map[string]struct{}, getenv func(string) string) error {
+func validateRouteSpec(spec RouteSpec, getenv func(string) string) error {
 	if !senderPattern.MatchString(spec.SenderUID) || strings.HasPrefix(spec.SenderUID, "iwh_") {
 		return errors.New("invalid sender_uid")
 	}
@@ -287,12 +283,8 @@ func validateRouteSpec(spec RouteSpec, allowed map[string]struct{}, getenv func(
 	if !actionTypePattern.MatchString(spec.ActionType) {
 		return errors.New("invalid action_type")
 	}
-	canonical, err := validateCallbackURL(spec.URL)
-	if err != nil {
+	if _, err := validateCallbackURL(spec.URL); err != nil {
 		return err
-	}
-	if _, ok := allowed[canonical]; !ok {
-		return errors.New("callback URL is not in the exact allowlist")
 	}
 	if !secretEnvPattern.MatchString(spec.SecretEnv) {
 		return errors.New("invalid secret_env")
@@ -330,25 +322,21 @@ func validateRouteSpec(spec RouteSpec, allowed map[string]struct{}, getenv func(
 	return nil
 }
 
-func validateAllowedURLs(values []string) (map[string]struct{}, error) {
-	allowed := make(map[string]struct{}, len(values))
-	for i, value := range values {
-		canonical, err := validateCallbackURL(value)
-		if err != nil {
-			return nil, fmt.Errorf("cardactiondispatch: allowed URL %d: %w", i, err)
-		}
-		allowed[canonical] = struct{}{}
-	}
-	return allowed, nil
-}
-
 func validateCallbackURL(raw string) (string, error) {
 	if strings.TrimSpace(raw) != raw || raw == "" {
 		return "", errors.New("invalid callback URL")
 	}
+	// Fragments are stripped by url.Parse *before* setting the Fragment field
+	// when they are empty (e.g. "https://host/path#"), so checking u.Fragment
+	// alone lets a trailing '#' through. Reject on the raw string first.
+	if strings.ContainsRune(raw, '#') {
+		return "", errors.New("callback URL must not contain a fragment")
+	}
 	u, err := url.Parse(raw)
-	if err != nil || u.Scheme != "https" || u.Host == "" || u.Opaque != "" {
-		return "", errors.New("callback URL must be an absolute HTTPS URL")
+	// Hostname() strips the ":port" so that URLs like "http://:8080/path" are
+	// rejected as host-less. Host alone contains the port and would pass.
+	if err != nil || (u.Scheme != "https" && u.Scheme != "http") || u.Hostname() == "" || u.Opaque != "" {
+		return "", errors.New("callback URL must be an absolute http(s) URL")
 	}
 	if u.User != nil {
 		return "", errors.New("callback URL must not contain credentials")
@@ -356,7 +344,9 @@ func validateCallbackURL(raw string) (string, error) {
 	if u.Fragment != "" {
 		return "", errors.New("callback URL must not contain a fragment")
 	}
-	if u.RawQuery != "" {
+	// ForceQuery covers the "trailing ?" form where RawQuery is empty but the
+	// separator was present, which url.String would preserve on the wire.
+	if u.RawQuery != "" || u.ForceQuery {
 		return "", errors.New("callback URL must not contain a query")
 	}
 	return u.String(), nil

--- a/internal/cardactiondispatch/registry_http_scheme_test.go
+++ b/internal/cardactiondispatch/registry_http_scheme_test.go
@@ -1,0 +1,184 @@
+package cardactiondispatch
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestNewRegistryAcceptsHTTPCallbackDestinations locks the http-actions
+// follow-up: OCTO_CARD_ACTION_ROUTES[].url is itself the exact allowlist and
+// http:// is a valid transport for every destination shape that only makes
+// sense inside an operator-controlled network. Hostname form (K8s Service DNS,
+// docker service name, host.docker.internal, IP literal) is intentionally not
+// inspected.
+func TestNewRegistryAcceptsHTTPCallbackDestinations(t *testing.T) {
+	tests := []struct {
+		name string
+		url  string
+	}{
+		{"kubernetes service short form", "http://smart-summary.dmwork-test.svc:8080/v1/card-actions/decide"},
+		{"kubernetes service full FQDN", "http://smart-summary.dmwork-test.svc.cluster.local:8080/v1/card-actions/decide"},
+		{"docker compose service short name", "http://smart-summary:8080/v1/card-actions/decide"},
+		{"host docker internal", "http://host.docker.internal:8080/v1/card-actions/decide"},
+		{"IPv4 literal with port", "http://127.0.0.1:8080/v1/card-actions/decide"},
+		{"IPv6 literal with port", "http://[::1]:8080/v1/card-actions/decide"},
+		{"HTTPS still accepted", "https://tasks.internal/v1/card-actions/decide"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			spec := validRouteSpec()
+			spec.URL = tt.url
+			if _, err := NewRegistry([]RouteSpec{spec}, testGetenv); err != nil {
+				t.Fatalf("NewRegistry() error = %v; want acceptance of %s", err, tt.url)
+			}
+		})
+	}
+}
+
+// TestValidateCallbackURLRejectsUnsafeShapes ensures the scheme relaxation did
+// not weaken the other URL-shape defenses. These previously lived only in the
+// combined allowlist path.
+func TestValidateCallbackURLRejectsUnsafeShapes(t *testing.T) {
+	tests := []struct {
+		name string
+		url  string
+	}{
+		{"empty", ""},
+		{"whitespace padding", " https://docs.internal/v1/card-actions/decide "},
+		{"unsupported scheme file", "file:///etc/passwd"},
+		{"unsupported scheme gopher", "gopher://docs.internal/v1/card-actions/decide"},
+		{"non absolute relative", "/v1/card-actions/decide"},
+		{"opaque form", "https:opaque"},
+		{"credentials", "https://user:pass@docs.internal/v1/card-actions/decide"},
+		{"query string", "https://docs.internal/v1/card-actions/decide?trace=1"},
+		{"trailing question mark", "https://docs.internal/v1/card-actions/decide?"},
+		{"fragment", "https://docs.internal/v1/card-actions/decide#anchor"},
+		{"trailing hash empty fragment", "https://docs.internal/v1/card-actions/decide#"},
+		{"embedded hash in path segment", "https://docs.internal/v1/card-actions/de#cide"},
+		{"http missing host", "http:///v1/card-actions/decide"},
+		{"http port only no host", "http://:8080/v1/card-actions/decide"},
+		{"https port only no host", "https://:443/v1/card-actions/decide"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := validateCallbackURL(tt.url); err == nil {
+				t.Fatalf("validateCallbackURL(%q) error = nil; want rejection", tt.url)
+			}
+		})
+	}
+}
+
+// TestHTTPDelivererDeliversPlainHTTPWithHMACAndDisciplinedTransport is the
+// end-to-end guard for the http-actions follow-up. It spins up a plain
+// httptest.NewServer (no TLS) and checks that:
+//   - the plain HTTP scheme is accepted by NewRegistry via the shared route
+//     validator;
+//   - HMAC signing still authenticates the request over cleartext;
+//   - the deliverer refuses to follow redirects on HTTP just like on HTTPS;
+//   - HTTP_PROXY environment variables cannot re-open SSRF for plain HTTP.
+func TestHTTPDelivererDeliversPlainHTTPWithHMACAndDisciplinedTransport(t *testing.T) {
+	// Guard against the deliverer accidentally honoring proxy env vars.
+	t.Setenv("HTTP_PROXY", "http://127.0.0.1:1")
+	t.Setenv("http_proxy", "http://127.0.0.1:1")
+
+	var signatureOK atomic.Bool
+	var callCount atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount.Add(1)
+		defer r.Body.Close()
+		raw, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("read body: %v", err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		if Verify(testCallbackSecret, r.Header.Get(HeaderSignature), r.Method, r.URL.EscapedPath(),
+			r.Header.Get(HeaderTimestamp), r.Header.Get(HeaderEventID), raw) {
+			signatureOK.Store(true)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"disposition":"applied","state":"approved","requester_uid":"user-a"}`))
+	}))
+	defer server.Close()
+
+	if scheme := server.URL[:len("http://")]; scheme != "http://" {
+		t.Fatalf("httptest.NewServer scheme = %q; want plain http", scheme)
+	}
+
+	registry := registryForTestServer(t, server.URL+"/v1/card-actions/decide", 1)
+	route := registry.Resolve("notification", "docs", "access_request.decision").Route
+	if route == nil {
+		t.Fatal("plain http route did not register")
+	}
+
+	// Pass nil transport so the deliverer builds its production default
+	// (Proxy=nil). This exercises the disciplined transport itself, not the
+	// test server's transport.
+	deliverer := NewHTTPDeliverer(nil, func() time.Time { return time.Unix(1_784_073_600, 0) })
+	result, err := deliverer.Deliver(context.Background(), route, DecisionRequestFromEvent(testDispatchEvent()))
+	if err != nil {
+		t.Fatalf("Deliver() error = %v (HTTP_PROXY leaked into transport?)", err)
+	}
+	if !signatureOK.Load() {
+		t.Fatal("callback HMAC signature did not verify over cleartext")
+	}
+	if result.State != StateApproved {
+		t.Fatalf("Deliver() result state = %q, want approved", result.State)
+	}
+	if got := callCount.Load(); got != 1 {
+		t.Fatalf("callback hit count = %d, want 1", got)
+	}
+	// Sanity: the deliverer's transport really is proxy-less.
+	if os.Getenv("HTTP_PROXY") == "" {
+		t.Fatal("test setup lost HTTP_PROXY before assertion")
+	}
+}
+
+func TestHTTPDelivererRefusesRedirectsOnPlainHTTP(t *testing.T) {
+	var redirected atomic.Bool
+	mux := http.NewServeMux()
+	mux.HandleFunc("/start", func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "/target", http.StatusFound)
+	})
+	mux.HandleFunc("/target", func(w http.ResponseWriter, _ *http.Request) {
+		redirected.Store(true)
+		w.WriteHeader(http.StatusOK)
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	registry := registryForTestServer(t, server.URL+"/start", 1)
+	deliverer := NewHTTPDeliverer(nil, time.Now)
+	_, err := deliverer.Deliver(context.Background(),
+		registry.Resolve("notification", "docs", "access_request.decision").Route,
+		DecisionRequestFromEvent(testDispatchEvent()))
+	if err == nil {
+		t.Fatal("Deliver() error = nil for plain-HTTP redirect")
+	}
+	if redirected.Load() {
+		t.Fatal("HTTP deliverer followed a plain-HTTP callback redirect")
+	}
+	// Categorize the error the same way HTTPS redirect rejection does so
+	// operator alerts stay consistent across schemes.
+	var deliveryErr *DeliveryError
+	if !errorsAsDelivery(err, &deliveryErr) || deliveryErr.Category != "redirect_rejected" {
+		t.Fatalf("Deliver() error = %v; want DeliveryError{Category: redirect_rejected}", err)
+	}
+}
+
+// errorsAsDelivery is a tiny helper so this file does not import "errors"
+// just for the type assertion.
+func errorsAsDelivery(err error, target **DeliveryError) bool {
+	de, ok := err.(*DeliveryError)
+	if !ok {
+		return false
+	}
+	*target = de
+	return true
+}

--- a/internal/cardactiondispatch/service_test.go
+++ b/internal/cardactiondispatch/service_test.go
@@ -31,7 +31,7 @@ func (s valueStore) SetValue(value interface{}, key string) { s[key] = value }
 func (s valueStore) Value(key string) interface{}           { return s[key] }
 
 func TestServiceAllocatesEventIDAndInstallsPerContext(t *testing.T) {
-	registry, err := NewRegistry([]RouteSpec{validRouteSpec()}, []string{validRouteSpec().URL}, testGetenv)
+	registry, err := NewRegistry([]RouteSpec{validRouteSpec()}, testGetenv)
 	if err != nil {
 		t.Fatalf("NewRegistry() error = %v", err)
 	}
@@ -63,7 +63,7 @@ func TestServiceAllocatesEventIDAndInstallsPerContext(t *testing.T) {
 }
 
 func TestServiceRejectsUnregisteredOrCallerAssignedEvents(t *testing.T) {
-	registry, err := NewRegistry([]RouteSpec{validRouteSpec()}, []string{validRouteSpec().URL}, testGetenv)
+	registry, err := NewRegistry([]RouteSpec{validRouteSpec()}, testGetenv)
 	if err != nil {
 		t.Fatalf("NewRegistry() error = %v", err)
 	}

--- a/main.go
+++ b/main.go
@@ -474,11 +474,14 @@ func installCardActionDispatch(ctx *config.Context) (*cardActionDispatchRuntime,
 	if err != nil {
 		return nil, err
 	}
-	registry, err := cardactiondispatch.NewRegistry(
-		specs,
-		cardactiondispatch.LoadAllowedURLs(os.Getenv("OCTO_CARD_ACTION_ALLOWED_URLS")),
-		os.Getenv,
-	)
+	if legacy := strings.TrimSpace(os.Getenv("OCTO_CARD_ACTION_ALLOWED_URLS")); legacy != "" {
+		// OCTO_CARD_ACTION_ROUTES[].url is itself the exact allowlist since the
+		// http-actions follow-up. The dual-write env is intentionally ignored to
+		// avoid drift; keep the WARN so rolling upgrades surface the leftover.
+		log.Warn("OCTO_CARD_ACTION_ALLOWED_URLS is deprecated and ignored; remove it from the deployment configuration",
+			zap.String("deprecated_env", "OCTO_CARD_ACTION_ALLOWED_URLS"))
+	}
+	registry, err := cardactiondispatch.NewRegistry(specs, os.Getenv)
 	if err != nil {
 		return nil, err
 	}

--- a/main_carddispatch_test.go
+++ b/main_carddispatch_test.go
@@ -161,3 +161,37 @@ func TestConfiguredApprovalRouteRejectsNonNotificationSender(t *testing.T) {
 		t.Fatal("cardActionApprovalProducerSpecs() error = nil")
 	}
 }
+
+// TestDeprecatedAllowedURLsEnvIsIgnoredWithStructuredWarn locks the
+// http-actions follow-up decision (b): OCTO_CARD_ACTION_ALLOWED_URLS must be
+// treated as deprecated. Startup must not fail on it (rolling upgrades still
+// carry the variable) and must emit a single structured WARN so operators can
+// see it in the ConfigMap review.
+func TestDeprecatedAllowedURLsEnvIsIgnoredWithStructuredWarn(t *testing.T) {
+	source, err := os.ReadFile("main.go")
+	if err != nil {
+		t.Fatalf("read main.go: %v", err)
+	}
+	text := string(source)
+	if !strings.Contains(text, `os.Getenv("OCTO_CARD_ACTION_ALLOWED_URLS")`) {
+		t.Fatal("main.go no longer reads OCTO_CARD_ACTION_ALLOWED_URLS; expected a deprecation branch")
+	}
+	// The WARN must be emitted through the shared log helper (log.Warn) so it
+	// lands in the standard structured logger pipeline rather than stderr.
+	if !strings.Contains(text, "log.Warn(\"OCTO_CARD_ACTION_ALLOWED_URLS is deprecated") {
+		t.Fatal("expected log.Warn call announcing the deprecation on startup")
+	}
+	// Include a machine-readable deprecated_env field so log ingestion can
+	// route/alert on it without regex-parsing the message string.
+	if !strings.Contains(text, `zap.String("deprecated_env", "OCTO_CARD_ACTION_ALLOWED_URLS")`) {
+		t.Fatal("deprecation WARN must include a deprecated_env structured field")
+	}
+	// The variable must no longer feed into NewRegistry — the whole point of
+	// the follow-up is to keep it out of the routing decision.
+	if strings.Contains(text, "LoadAllowedURLs(") {
+		t.Fatal("LoadAllowedURLs is deleted; main.go must not reference it")
+	}
+	if !strings.Contains(text, "cardactiondispatch.NewRegistry(specs, os.Getenv)") {
+		t.Fatal("NewRegistry must be called with the two-argument (specs, getenv) signature")
+	}
+}

--- a/modules/message/api_card_action_test.go
+++ b/modules/message/api_card_action_test.go
@@ -85,7 +85,7 @@ func TestCardActionSenderBoundCallbackRouting(t *testing.T) {
 	registry, err := cardactiondispatch.NewRegistry([]cardactiondispatch.RouteSpec{{
 		SenderUID: "notification", Owner: "docs", ActionType: "access_request.decision",
 		URL: callbackURL, SecretEnv: "OCTO_DOCS_CARD_ACTION_SECRET",
-	}}, []string{callbackURL}, func(key string) string { return "0123456789abcdef0123456789abcdef" })
+	}}, func(key string) string { return "0123456789abcdef0123456789abcdef" })
 	require.NoError(t, err)
 	rds := redis.NewClient(&redis.Options{Addr: ctx.GetConfig().DB.RedisAddr, Password: ctx.GetConfig().DB.RedisPass})
 	defer rds.Close()

--- a/modules/notify/approval_card.go
+++ b/modules/notify/approval_card.go
@@ -92,12 +92,27 @@ func (n *Notify) buildApprovalRequestCard(card *ApprovalCardFields, capability c
 	if card == nil {
 		return nil, errNotifyCardInvalid
 	}
-	labels := approvalActionLabelsFor(lang)
-	return cardtmpl.BuildApprovalRequestCard(cardtmpl.ApprovalRequestCard{
+	tmpl := cardtmpl.ApprovalRequestCard{
 		Title: card.Title, Description: card.Description, Owner: capability.Owner,
 		ActionType: card.ActionType, Data: card.Data,
-		ApproveTitle: labels.approve, DenyTitle: labels.deny,
-	})
+	}
+	// nil = caller omitted the field → server-owned localized approve/deny.
+	// Non-nil (including explicit []) enters the custom path so cardtmpl can
+	// reject the empty slice as a caller bug instead of silently falling back.
+	if card.Actions == nil {
+		labels := approvalActionLabelsFor(lang)
+		tmpl.ApproveTitle = labels.approve
+		tmpl.DenyTitle = labels.deny
+	} else {
+		actions := make([]cardtmpl.ApprovalRequestAction, 0, len(card.Actions))
+		for _, a := range card.Actions {
+			actions = append(actions, cardtmpl.ApprovalRequestAction{
+				Decision: a.Decision, Title: a.Title,
+			})
+		}
+		tmpl.Actions = actions
+	}
+	return cardtmpl.BuildApprovalRequestCard(tmpl)
 }
 
 type approvalActionLabels struct {

--- a/modules/notify/card_action_test.go
+++ b/modules/notify/card_action_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"net/http/httptest"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -184,7 +186,7 @@ func TestIntegration_GenericApprovalTokenIsOwnerBoundAndSendsV2(t *testing.T) {
 			URL:       "https://summary.internal/v1/card-actions/decide",
 			SecretEnv: "OCTO_SMART_SUMMARY_CARD_ACTION_SECRET", NotifyTokenEnv: "OCTO_SMART_SUMMARY_NOTIFY_TOKEN",
 		},
-	}, []string{"https://summary.internal/v1/card-actions/decide"}, func(key string) string {
+	}, func(key string) string {
 		switch key {
 		case "OCTO_SMART_SUMMARY_CARD_ACTION_SECRET":
 			return callbackSecret
@@ -237,6 +239,127 @@ func TestIntegration_GenericApprovalTokenIsOwnerBoundAndSendsV2(t *testing.T) {
 	}
 	docsResponse := doJSONRequest(t, router, http.MethodPost, "/v1/internal/notify", actionHeader, docsAttempt)
 	assert.Equal(t, http.StatusBadRequest, docsResponse.Code)
+}
+
+// TestIntegration_ApprovalCardCustomActionsRenderInOrder verifies the
+// http-actions follow-up wire path: a caller-supplied 1-5 actions slice ends
+// up as server-built Action.Submit buttons with the reserved owner/action_type
+// metadata injected and the router-owned action IDs, without leaking a URL.
+func TestIntegration_ApprovalCardCustomActionsRenderInOrder(t *testing.T) {
+	t.Setenv("OCTO_CARD_MESSAGE_ENABLED", "true")
+	const (
+		callbackSecret = "0123456789abcdef0123456789abcdef"
+		notifyToken    = "abcdef0123456789abcdef0123456789"
+	)
+	wk := newWuKongServer()
+	defer wk.close()
+	ctx := newTestContext(t, wk)
+	registry, err := cardactiondispatch.NewRegistry([]cardactiondispatch.RouteSpec{
+		{
+			SenderUID: "notification", Owner: "tasks", ActionType: "task.execute.decision",
+			URL:       "https://tasks.internal/v1/card-actions/decide",
+			SecretEnv: "OCTO_TASKS_CARD_ACTION_SECRET", NotifyTokenEnv: "OCTO_TASKS_NOTIFY_TOKEN",
+		},
+	}, func(key string) string {
+		switch key {
+		case "OCTO_TASKS_CARD_ACTION_SECRET":
+			return callbackSecret
+		case "OCTO_TASKS_NOTIFY_TOKEN":
+			return notifyToken
+		default:
+			return ""
+		}
+	})
+	require.NoError(t, err)
+	service, err := cardactiondispatch.NewService(registry, unusedActionQueue{}, ctx)
+	require.NoError(t, err)
+	capability := cardactiondispatch.NotifyCapability{SenderUID: "notification", Owner: "tasks"}
+	capture := &capturingCardSender{}
+	n := newTestNotify(ctx, nil, nil, nil, "legacy-token")
+	n.actionService = service
+	n.actionSenders = map[cardactiondispatch.NotifyCapability]carddispatch.Sender{capability: capture}
+	n.botOK.Store(true)
+	primeMemberCache(n, "space-1", "user-b")
+	router := buildRouter(n)
+	router.SetErrorRenderer(i18n.NewErrorRenderer(i18n.NewLocalizer(i18n.DefaultLanguage)))
+
+	request := NotifyReq{
+		SpaceID: "space-1", Service: "tasks", Targets: []string{"user-b"}, ActorUID: "user-a",
+		ApprovalCard: &ApprovalCardFields{
+			ActionType: "task.execute.decision", Title: "Execute task", Description: "Pick one",
+			Data: map[string]string{"task_id": "task-1"},
+			Actions: []ApprovalCardAction{
+				{Decision: "execute", Title: "Execute"},
+				{Decision: "reject", Title: "Reject"},
+				{Decision: "cancel", Title: "Cancel"},
+			},
+		},
+	}
+	header := http.Header{InternalTokenHeader: []string{notifyToken}}
+	response := doJSONRequest(t, router, http.MethodPost, "/v1/internal/notify", header, request)
+	require.Equal(t, http.StatusOK, response.Code, response.Body.String())
+	require.Len(t, capture.cards, 1)
+
+	document := capture.last().Document
+	assert.NotContains(t, string(document), "http")
+	assert.Contains(t, string(document), `"id":"approval-execute"`)
+	assert.Contains(t, string(document), `"id":"approval-reject"`)
+	assert.Contains(t, string(document), `"id":"approval-cancel"`)
+	assert.Contains(t, string(document), `"title":"Execute"`)
+	assert.Contains(t, string(document), `"title":"Cancel"`)
+	assert.NotContains(t, string(document), `"id":"approval-approve"`)
+
+	var card map[string]interface{}
+	require.NoError(t, json.Unmarshal(document, &card))
+	actions, _ := card["actions"].([]interface{})
+	require.Len(t, actions, 3)
+	for _, value := range actions {
+		action, _ := value.(map[string]interface{})
+		data, _ := action["data"].(map[string]interface{})
+		assert.Equal(t, "tasks", data["owner"])
+		assert.Equal(t, "task.execute.decision", data["action_type"])
+		assert.Equal(t, "task-1", data["task_id"])
+	}
+
+	invalid := request
+	invalid.ApprovalCard = &ApprovalCardFields{
+		ActionType: "task.execute.decision", Title: "Execute task",
+		Actions: []ApprovalCardAction{
+			{Decision: "Execute", Title: "bad"},
+		},
+	}
+	rejected := doJSONRequest(t, router, http.MethodPost, "/v1/internal/notify", header, invalid)
+	assert.Equal(t, http.StatusBadRequest, rejected.Code)
+	assert.Len(t, capture.cards, 1, "invalid decisions must not reach transport")
+
+	// Verify the on-the-wire JSON boundary: an explicit "actions": [] is a
+	// caller bug, not a fallback to approve/deny. Send raw JSON to make sure
+	// nil vs non-nil-empty is preserved through gin's binder.
+	rawEmpty := `{"space_id":"space-1","service":"tasks","targets":["user-b"],"actor_uid":"user-a",` +
+		`"approval_card":{"action_type":"task.execute.decision","title":"Execute task",` +
+		`"description":"Pick one","data":{"task_id":"task-1"},"actions":[]}}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/internal/notify", strings.NewReader(rawEmpty))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set(InternalTokenHeader, notifyToken)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusBadRequest, rec.Code, rec.Body.String())
+	assert.Len(t, capture.cards, 1, "explicit empty actions must not fall back to approve/deny")
+
+	// Sanity: omitting the field ("actions" not present) is equivalent to
+	// nil and still succeeds via the localized approve/deny template.
+	rawOmitted := `{"space_id":"space-1","service":"tasks","targets":["user-b"],"actor_uid":"user-a",` +
+		`"approval_card":{"action_type":"task.execute.decision","title":"Execute task",` +
+		`"description":"Pick one","data":{"task_id":"task-1"}}}`
+	reqOmit := httptest.NewRequest(http.MethodPost, "/v1/internal/notify", strings.NewReader(rawOmitted))
+	reqOmit.Header.Set("Content-Type", "application/json")
+	reqOmit.Header.Set(InternalTokenHeader, notifyToken)
+	recOmit := httptest.NewRecorder()
+	router.ServeHTTP(recOmit, reqOmit)
+	assert.Equal(t, http.StatusOK, recOmit.Code, recOmit.Body.String())
+	require.Len(t, capture.cards, 2)
+	assert.Contains(t, string(capture.last().Document), `"id":"approval-approve"`,
+		"omitted actions must reach the localized approve/deny template")
 }
 
 func TestIntegration_MissingDocsTokenFailsClosed(t *testing.T) {

--- a/modules/notify/card_action_test.go
+++ b/modules/notify/card_action_test.go
@@ -360,6 +360,23 @@ func TestIntegration_ApprovalCardCustomActionsRenderInOrder(t *testing.T) {
 	require.Len(t, capture.cards, 2)
 	assert.Contains(t, string(capture.last().Document), `"id":"approval-approve"`,
 		"omitted actions must reach the localized approve/deny template")
+
+	// Wire equivalence: explicit "actions": null MUST decode to a nil slice
+	// (Go's encoding/json contract) and therefore reach the same legacy
+	// approve/deny template as an omitted field. This pins the doc claim that
+	// null and omit are interchangeable on the wire.
+	rawNull := `{"space_id":"space-1","service":"tasks","targets":["user-b"],"actor_uid":"user-a",` +
+		`"approval_card":{"action_type":"task.execute.decision","title":"Execute task",` +
+		`"description":"Pick one","data":{"task_id":"task-1"},"actions":null}}`
+	reqNull := httptest.NewRequest(http.MethodPost, "/v1/internal/notify", strings.NewReader(rawNull))
+	reqNull.Header.Set("Content-Type", "application/json")
+	reqNull.Header.Set(InternalTokenHeader, notifyToken)
+	recNull := httptest.NewRecorder()
+	router.ServeHTTP(recNull, reqNull)
+	assert.Equal(t, http.StatusOK, recNull.Code, recNull.Body.String())
+	require.Len(t, capture.cards, 3)
+	assert.Contains(t, string(capture.last().Document), `"id":"approval-approve"`,
+		`explicit "actions": null must decode to nil and take the legacy approve/deny template`)
 }
 
 func TestIntegration_MissingDocsTokenFailsClosed(t *testing.T) {

--- a/modules/notify/model.go
+++ b/modules/notify/model.go
@@ -28,6 +28,18 @@ type ApprovalCardFields struct {
 	Title       string            `json:"title"`
 	Description string            `json:"description"`
 	Data        map[string]string `json:"data"`
+	// Actions is optional. When omitted, octo-server renders the localized
+	// approve/deny buttons (byte-compatible with the pre-http-actions release).
+	// When present, it must contain 1..MaxApprovalCustomActions items; each
+	// decision is a stable callback token and each title is display text.
+	Actions []ApprovalCardAction `json:"actions,omitempty"`
+}
+
+// ApprovalCardAction lets the caller name a bounded, custom button on the
+// generic approval card. Server owns the action ID and reserved metadata.
+type ApprovalCardAction struct {
+	Decision string `json:"decision"`
+	Title    string `json:"title"`
 }
 
 // SummaryCardFields 是 summary-notify 卡片通知的结构化入参(跨仓契约,见

--- a/pkg/cardtmpl/approval_request.go
+++ b/pkg/cardtmpl/approval_request.go
@@ -33,12 +33,27 @@ var (
 	// to the consumer through DecisionRequest.decision. Lowercase, starts with
 	// a letter, digits/underscore/dot/dash allowed, 1-48 chars.
 	approvalDecisionPattern = regexp.MustCompile(`^[a-z][a-z0-9_.-]{0,47}$`)
+
+	// reservedApprovalDecisions matches the tokens the legacy approve/deny
+	// template emits (`approval-approve` / `approval-deny`). A custom-actions
+	// caller that picked either of these would render buttons whose IDs
+	// collide with the legacy template on any client-side analytics or replay
+	// log keyed only on action_id. Reject to keep the ID namespace clean.
+	reservedApprovalDecisions = map[string]struct{}{
+		"approve": {},
+		"deny":    {},
+	}
 )
 
 // ApprovalRequestAction lets the caller name a bounded, custom Action.Submit
 // button on the generic approval card. Server owns the action ID, the injected
 // owner/action_type metadata, and the card layout; callers only supply the
 // stable callback token (decision) and a display label (title).
+//
+// The tokens "approve" and "deny" are reserved for the legacy 2-button
+// template; passing either as Decision returns a validation error to keep the
+// server-derived "approval-<decision>" action IDs collision-free with the
+// legacy ApprovalApproveActionID / ApprovalDenyActionID.
 type ApprovalRequestAction struct {
 	Decision string
 	Title    string
@@ -153,6 +168,9 @@ func buildApprovalActions(input ApprovalRequestCard, baseData map[string]interfa
 		decision := action.Decision
 		if !approvalDecisionPattern.MatchString(decision) {
 			return nil, errors.New("cardtmpl: approval action decision is invalid")
+		}
+		if _, reserved := reservedApprovalDecisions[decision]; reserved {
+			return nil, errors.New("cardtmpl: approval action decision collides with reserved approve/deny namespace")
 		}
 		if _, dup := seen[decision]; dup {
 			return nil, errors.New("cardtmpl: approval action decisions must be unique")

--- a/pkg/cardtmpl/approval_request.go
+++ b/pkg/cardtmpl/approval_request.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+	"unicode"
 	"unicode/utf8"
 
 	"github.com/Mininglamp-OSS/octo-server/pkg/cardmsg"
@@ -15,37 +16,62 @@ const (
 	ApprovalApproveActionID = "approval-approve"
 	ApprovalDenyActionID    = "approval-deny"
 	maxApprovalDataFields   = 32
+	// MaxApprovalCustomActions caps the actions[] on approval_card. Five keeps
+	// the terminal card readable on narrow layouts; enlarging it requires a
+	// wire-contract review because clients render every button inline.
+	MaxApprovalCustomActions = 5
+	// MaxApprovalActionTitleRunes matches the shared 80-rune ceiling for
+	// button labels; longer copy belongs in title/description.
+	MaxApprovalActionTitleRunes = 80
 )
 
 var (
 	approvalOwnerPattern      = regexp.MustCompile(`^[a-z][a-z0-9-]{0,63}$`)
 	approvalActionTypePattern = regexp.MustCompile(`^[a-z][a-z0-9_.-]{0,127}$`)
 	approvalDataKeyPattern    = regexp.MustCompile(`^[a-z][a-z0-9_.-]{0,63}$`)
+	// approvalDecisionPattern matches the stable callback token surfaced back
+	// to the consumer through DecisionRequest.decision. Lowercase, starts with
+	// a letter, digits/underscore/dot/dash allowed, 1-48 chars.
+	approvalDecisionPattern = regexp.MustCompile(`^[a-z][a-z0-9_.-]{0,47}$`)
 )
 
-type ApprovalRequestCard struct {
-	Title        string
-	Description  string
-	Owner        string
-	ActionType   string
-	Data         map[string]string
-	ApproveTitle string
-	DenyTitle    string
+// ApprovalRequestAction lets the caller name a bounded, custom Action.Submit
+// button on the generic approval card. Server owns the action ID, the injected
+// owner/action_type metadata, and the card layout; callers only supply the
+// stable callback token (decision) and a display label (title).
+type ApprovalRequestAction struct {
+	Decision string
+	Title    string
 }
 
-// BuildApprovalRequestCard is the shared server-owned approve/deny template.
+type ApprovalRequestCard struct {
+	Title       string
+	Description string
+	Owner       string
+	ActionType  string
+	Data        map[string]string
+	// ApproveTitle and DenyTitle drive the localized 2-button template when
+	// Actions is nil/empty. Callers using Actions leave both empty.
+	ApproveTitle string
+	DenyTitle    string
+	// Actions, when non-nil, replaces the approve/deny template with 1..N
+	// server-built Action.Submit buttons where N = MaxApprovalCustomActions.
+	// A nil slice preserves the legacy approve/deny wire form byte-compatibly;
+	// an explicit empty slice is a caller bug and rejected by validation.
+	Actions []ApprovalRequestAction
+}
+
+// BuildApprovalRequestCard is the shared server-owned approval template.
 // Callers provide bounded business identifiers, never an action owner, URL, or
-// arbitrary Adaptive Card JSON.
+// arbitrary Adaptive Card JSON. When input.Actions is nil the output is
+// identical to the pre-http-actions release (localized approve/deny buttons);
+// a non-nil Actions slice is required to be 1..MaxApprovalCustomActions long
+// and drives the button set instead.
 func BuildApprovalRequestCard(input ApprovalRequestCard) (json.RawMessage, error) {
 	title := truncateRunes(strings.TrimSpace(input.Title), maxTitleRunes)
 	description := truncateRunes(strings.TrimSpace(input.Description), MaxExcerptRunes)
-	approveTitle := strings.TrimSpace(input.ApproveTitle)
-	denyTitle := strings.TrimSpace(input.DenyTitle)
 	if title == "" || !approvalOwnerPattern.MatchString(input.Owner) || !approvalActionTypePattern.MatchString(input.ActionType) {
 		return nil, errors.New("cardtmpl: approval request identity is invalid")
-	}
-	if approveTitle == "" || denyTitle == "" || utf8.RuneCountInString(approveTitle) > 80 || utf8.RuneCountInString(denyTitle) > 80 {
-		return nil, errors.New("cardtmpl: approval action labels are invalid")
 	}
 	if len(input.Data) > maxApprovalDataFields {
 		return nil, errors.New("cardtmpl: too many approval data fields")
@@ -60,10 +86,11 @@ func BuildApprovalRequestCard(input ApprovalRequestCard) (json.RawMessage, error
 	}
 	baseData["owner"] = input.Owner
 	baseData["action_type"] = input.ActionType
-	approveData := copyActionData(baseData)
-	approveData["decision"] = "approve"
-	denyData := copyActionData(baseData)
-	denyData["decision"] = "deny"
+
+	actions, err := buildApprovalActions(input, baseData)
+	if err != nil {
+		return nil, err
+	}
 
 	body := []interface{}{
 		map[string]interface{}{
@@ -77,18 +104,88 @@ func BuildApprovalRequestCard(input ApprovalRequestCard) (json.RawMessage, error
 	}
 	document := map[string]interface{}{
 		"type": "AdaptiveCard", "version": cardmsg.CardVersion, "body": body,
-		"actions": []interface{}{
-			map[string]interface{}{
-				"type": "Action.Submit", "id": ApprovalApproveActionID, "title": approveTitle, "data": approveData,
-			},
-			map[string]interface{}{
-				"type": "Action.Submit", "id": ApprovalDenyActionID, "title": denyTitle, "data": denyData,
-			},
-		},
+		"actions": actions,
 	}
 	raw, err := json.Marshal(document)
 	if err != nil {
 		return nil, fmt.Errorf("cardtmpl: marshal approval request card: %w", err)
 	}
 	return raw, nil
+}
+
+func buildApprovalActions(input ApprovalRequestCard, baseData map[string]interface{}) ([]interface{}, error) {
+	// nil (unset) preserves the legacy approve/deny template.
+	// A non-nil but empty slice signals the caller *tried* to send a custom
+	// action set and picked zero; that is a caller bug, not a fallback.
+	if input.Actions == nil {
+		approveTitle := strings.TrimSpace(input.ApproveTitle)
+		denyTitle := strings.TrimSpace(input.DenyTitle)
+		if approveTitle == "" || denyTitle == "" ||
+			utf8.RuneCountInString(approveTitle) > MaxApprovalActionTitleRunes ||
+			utf8.RuneCountInString(denyTitle) > MaxApprovalActionTitleRunes {
+			return nil, errors.New("cardtmpl: approval action labels are invalid")
+		}
+		approveData := copyActionData(baseData)
+		approveData["decision"] = "approve"
+		denyData := copyActionData(baseData)
+		denyData["decision"] = "deny"
+		return []interface{}{
+			map[string]interface{}{
+				"type": "Action.Submit", "id": ApprovalApproveActionID, "title": approveTitle, "data": approveData,
+			},
+			map[string]interface{}{
+				"type": "Action.Submit", "id": ApprovalDenyActionID, "title": denyTitle, "data": denyData,
+			},
+		}, nil
+	}
+	if input.ApproveTitle != "" || input.DenyTitle != "" {
+		return nil, errors.New("cardtmpl: approval actions cannot mix approve/deny defaults with custom actions")
+	}
+	if len(input.Actions) == 0 {
+		return nil, errors.New("cardtmpl: approval actions must contain at least one entry")
+	}
+	if len(input.Actions) > MaxApprovalCustomActions {
+		return nil, errors.New("cardtmpl: too many approval actions")
+	}
+	seen := make(map[string]struct{}, len(input.Actions))
+	built := make([]interface{}, 0, len(input.Actions))
+	for _, action := range input.Actions {
+		decision := action.Decision
+		if !approvalDecisionPattern.MatchString(decision) {
+			return nil, errors.New("cardtmpl: approval action decision is invalid")
+		}
+		if _, dup := seen[decision]; dup {
+			return nil, errors.New("cardtmpl: approval action decisions must be unique")
+		}
+		seen[decision] = struct{}{}
+
+		// Reject control characters on the *raw* title, before TrimSpace
+		// strips whitespace-class runes like \t \n \r. Otherwise leading or
+		// trailing tabs/newlines would sneak through as "trimmed clean".
+		if containsControl(action.Title) {
+			return nil, errors.New("cardtmpl: approval action title is invalid")
+		}
+		title := strings.TrimSpace(action.Title)
+		if title == "" || utf8.RuneCountInString(title) > MaxApprovalActionTitleRunes {
+			return nil, errors.New("cardtmpl: approval action title is invalid")
+		}
+		data := copyActionData(baseData)
+		data["decision"] = decision
+		built = append(built, map[string]interface{}{
+			"type":  "Action.Submit",
+			"id":    "approval-" + decision,
+			"title": title,
+			"data":  data,
+		})
+	}
+	return built, nil
+}
+
+func containsControl(s string) bool {
+	for _, r := range s {
+		if unicode.IsControl(r) {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/cardtmpl/approval_request_actions_test.go
+++ b/pkg/cardtmpl/approval_request_actions_test.go
@@ -1,0 +1,191 @@
+package cardtmpl
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestBuildApprovalRequestCardCustomActionsRenderServerBuiltButtons locks the
+// http-actions follow-up: when Actions is non-empty the card renders exactly
+// those Action.Submit buttons with server-owned IDs and reserved metadata; the
+// old approve/deny path stays untouched when Actions is nil.
+func TestBuildApprovalRequestCardCustomActionsRenderServerBuiltButtons(t *testing.T) {
+	raw, err := BuildApprovalRequestCard(ApprovalRequestCard{
+		Title:      "Execute task",
+		Owner:      "tasks",
+		ActionType: "task.execute.decision",
+		Data:       map[string]string{"task_id": "task-1"},
+		Actions: []ApprovalRequestAction{
+			{Decision: "execute", Title: "执行"},
+			{Decision: "reject", Title: "拒绝"},
+			{Decision: "cancel", Title: "取消"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("BuildApprovalRequestCard() error = %v", err)
+	}
+	var card map[string]interface{}
+	if err := json.Unmarshal(raw, &card); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	actions, _ := card["actions"].([]interface{})
+	if len(actions) != 3 {
+		t.Fatalf("len(actions) = %d, want 3", len(actions))
+	}
+	want := map[string]string{
+		"approval-execute": "执行",
+		"approval-reject":  "拒绝",
+		"approval-cancel":  "取消",
+	}
+	for _, value := range actions {
+		action, _ := value.(map[string]interface{})
+		id, _ := action["id"].(string)
+		title, _ := action["title"].(string)
+		if expected, ok := want[id]; !ok || expected != title {
+			t.Fatalf("action id=%q title=%q not in wanted set %+v", id, title, want)
+		}
+		delete(want, id)
+		data, _ := action["data"].(map[string]interface{})
+		if data["owner"] != "tasks" || data["action_type"] != "task.execute.decision" || data["task_id"] != "task-1" {
+			t.Fatalf("reserved metadata not injected on %s: %+v", id, data)
+		}
+		decision, _ := data["decision"].(string)
+		if want, _ := strings.CutPrefix(id, "approval-"); decision != want {
+			t.Fatalf("decision on %s = %q, want %q", id, decision, want)
+		}
+	}
+	if len(want) != 0 {
+		t.Fatalf("missing actions in output: %+v", want)
+	}
+	if strings.Contains(string(raw), "http") {
+		t.Fatalf("card leaked a URL: %s", raw)
+	}
+}
+
+// TestBuildApprovalRequestCardOmittedActionsIsByteCompatible verifies the
+// http-actions change does not perturb the legacy approve/deny output. The
+// exact bytes below are captured from the pre-http-actions release; any drift
+// in ordering, keys, escaping, or reserved metadata will fail this test and
+// force a wire-contract review before shipping.
+func TestBuildApprovalRequestCardOmittedActionsIsByteCompatible(t *testing.T) {
+	raw, err := BuildApprovalRequestCard(ApprovalRequestCard{
+		Title:        "Publish summary",
+		Description:  "Review before publishing",
+		Owner:        "smart-summary",
+		ActionType:   "summary.publish.decision",
+		Data:         map[string]string{"task_no": "task-1"},
+		ApproveTitle: "Allow",
+		DenyTitle:    "Deny",
+	})
+	if err != nil {
+		t.Fatalf("BuildApprovalRequestCard() error = %v", err)
+	}
+	const golden = `{"actions":[{"data":{"action_type":"summary.publish.decision","decision":"approve","owner":"smart-summary","task_no":"task-1"},"id":"approval-approve","title":"Allow","type":"Action.Submit"},{"data":{"action_type":"summary.publish.decision","decision":"deny","owner":"smart-summary","task_no":"task-1"},"id":"approval-deny","title":"Deny","type":"Action.Submit"}],"body":[{"text":"Publish summary","type":"TextBlock","weight":"Bolder","wrap":true},{"text":"Review before publishing","type":"TextBlock","wrap":true}],"type":"AdaptiveCard","version":"1.5"}`
+	if string(raw) != golden {
+		t.Fatalf("legacy approve/deny bytes drifted from #588\n  got: %s\n want: %s", raw, golden)
+	}
+}
+
+// TestBuildApprovalRequestCardNonNilEmptyActionsFailsClosed ensures a caller
+// that ships `"actions": []` is treated as a caller bug rather than silently
+// downgraded to the default approve/deny template. nil (omitted) still routes
+// to the legacy path.
+func TestBuildApprovalRequestCardNonNilEmptyActionsFailsClosed(t *testing.T) {
+	base := ApprovalRequestCard{
+		Title: "Execute task", Owner: "tasks", ActionType: "task.execute.decision",
+	}
+	if _, err := BuildApprovalRequestCard(func() ApprovalRequestCard {
+		c := base
+		c.Actions = []ApprovalRequestAction{}
+		return c
+	}()); err == nil {
+		t.Fatal("BuildApprovalRequestCard(actions=[]) error = nil, want caller-bug rejection")
+	}
+	// nil (unset) plus approve/deny labels still succeeds — the legacy path.
+	if _, err := BuildApprovalRequestCard(func() ApprovalRequestCard {
+		c := base
+		c.ApproveTitle = "Allow"
+		c.DenyTitle = "Deny"
+		return c
+	}()); err != nil {
+		t.Fatalf("BuildApprovalRequestCard(actions=nil) error = %v, want legacy success", err)
+	}
+}
+
+func TestBuildApprovalRequestCardRejectsInvalidCustomActions(t *testing.T) {
+	base := ApprovalRequestCard{
+		Title: "Execute task", Owner: "tasks", ActionType: "task.execute.decision",
+	}
+	tests := []struct {
+		name    string
+		actions []ApprovalRequestAction
+	}{
+		{"single item empty decision and title", []ApprovalRequestAction{{Decision: "", Title: ""}}},
+		{"missing decision", []ApprovalRequestAction{{Title: "Execute"}}},
+		{"uppercase decision", []ApprovalRequestAction{{Decision: "Execute", Title: "Execute"}}},
+		{"decision with space", []ApprovalRequestAction{{Decision: "do it", Title: "Execute"}}},
+		{"decision too long", []ApprovalRequestAction{{Decision: strings.Repeat("a", 49), Title: "Execute"}}},
+		{"decision starting with digit", []ApprovalRequestAction{{Decision: "1exec", Title: "Execute"}}},
+		{"reserved-looking still valid pattern still rejected via duplicate", []ApprovalRequestAction{
+			{Decision: "execute", Title: "Execute"},
+			{Decision: "execute", Title: "Redo"},
+		}},
+		{"empty title", []ApprovalRequestAction{{Decision: "execute", Title: ""}}},
+		{"whitespace title", []ApprovalRequestAction{{Decision: "execute", Title: "   "}}},
+		{"title too long", []ApprovalRequestAction{{Decision: "execute", Title: strings.Repeat("字", 81)}}},
+		{"title with control char", []ApprovalRequestAction{{Decision: "execute", Title: "Execute\x07"}}},
+		{"title with leading tab (trim would hide it)", []ApprovalRequestAction{{Decision: "execute", Title: "\tExecute"}}},
+		{"title with trailing newline (trim would hide it)", []ApprovalRequestAction{{Decision: "execute", Title: "Execute\n"}}},
+		{"title with carriage return (trim would hide it)", []ApprovalRequestAction{{Decision: "execute", Title: "Execute\r"}}},
+		{"title with vertical tab", []ApprovalRequestAction{{Decision: "execute", Title: "Exec\vute"}}},
+		{"exceeds max count", func() []ApprovalRequestAction {
+			out := make([]ApprovalRequestAction, MaxApprovalCustomActions+1)
+			for i := range out {
+				out[i] = ApprovalRequestAction{
+					Decision: string(rune('a'+i)) + "cmd",
+					Title:    "T",
+				}
+			}
+			return out
+		}()},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			input := base
+			input.Actions = tt.actions
+			if _, err := BuildApprovalRequestCard(input); err == nil {
+				t.Fatalf("BuildApprovalRequestCard(actions=%+v) error = nil, want rejection", tt.actions)
+			}
+		})
+	}
+}
+
+func TestBuildApprovalRequestCardRejectsMixingCustomActionsWithApproveDenyDefaults(t *testing.T) {
+	input := ApprovalRequestCard{
+		Title: "Execute task", Owner: "tasks", ActionType: "task.execute.decision",
+		ApproveTitle: "Allow",
+		Actions: []ApprovalRequestAction{
+			{Decision: "execute", Title: "Execute"},
+		},
+	}
+	if _, err := BuildApprovalRequestCard(input); err == nil {
+		t.Fatal("BuildApprovalRequestCard() error = nil; want mixing to be rejected")
+	}
+}
+
+func TestBuildApprovalRequestCardMaxCustomActionsIsAccepted(t *testing.T) {
+	actions := make([]ApprovalRequestAction, MaxApprovalCustomActions)
+	for i := range actions {
+		actions[i] = ApprovalRequestAction{
+			Decision: string(rune('a'+i)) + "opt",
+			Title:    "T",
+		}
+	}
+	if _, err := BuildApprovalRequestCard(ApprovalRequestCard{
+		Title: "Choose", Owner: "tasks", ActionType: "task.pick.decision",
+		Actions: actions,
+	}); err != nil {
+		t.Fatalf("BuildApprovalRequestCard(max) error = %v", err)
+	}
+}

--- a/pkg/cardtmpl/approval_request_actions_test.go
+++ b/pkg/cardtmpl/approval_request_actions_test.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardmsg"
 )
 
 // TestBuildApprovalRequestCardCustomActionsRenderServerBuiltButtons locks the
@@ -131,6 +133,16 @@ func TestBuildApprovalRequestCardRejectsInvalidCustomActions(t *testing.T) {
 			{Decision: "execute", Title: "Execute"},
 			{Decision: "execute", Title: "Redo"},
 		}},
+		{"reserved decision approve collides with legacy template", []ApprovalRequestAction{
+			{Decision: "approve", Title: "Allow"},
+		}},
+		{"reserved decision deny collides with legacy template", []ApprovalRequestAction{
+			{Decision: "deny", Title: "Reject"},
+		}},
+		{"reserved decision approve mixed with other valid decisions", []ApprovalRequestAction{
+			{Decision: "execute", Title: "Execute"},
+			{Decision: "approve", Title: "Allow"},
+		}},
 		{"empty title", []ApprovalRequestAction{{Decision: "execute", Title: ""}}},
 		{"whitespace title", []ApprovalRequestAction{{Decision: "execute", Title: "   "}}},
 		{"title too long", []ApprovalRequestAction{{Decision: "execute", Title: strings.Repeat("字", 81)}}},
@@ -188,4 +200,99 @@ func TestBuildApprovalRequestCardMaxCustomActionsIsAccepted(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("BuildApprovalRequestCard(max) error = %v", err)
 	}
+}
+
+// TestBuildApprovalRequestCardRoundTripsThroughSubmitAction stitches the
+// builder to the runtime extractor. The two sides are exercised separately
+// elsewhere, but the click path relies on their shapes agreeing: builder emits
+// `id = "approval-<decision>"` with a top-level `actions[]`, and
+// cardmsg.SubmitAction traverses `card["actions"]` matching by type/id and
+// returns the authored `data`. A silent drift in either side (id derivation
+// change, key rename, moving actions off the top-level) would fail this test
+// while every isolated test in this PR still passed.
+//
+// Covers both branches — custom actions and the legacy approve/deny — plus a
+// synthetic action ID lookup that must miss.
+func TestBuildApprovalRequestCardRoundTripsThroughSubmitAction(t *testing.T) {
+	newEnvelope := func(t *testing.T, raw json.RawMessage) []byte {
+		t.Helper()
+		var card map[string]interface{}
+		if err := json.Unmarshal(raw, &card); err != nil {
+			t.Fatalf("decode card: %v", err)
+		}
+		envelope, err := json.Marshal(map[string]interface{}{
+			"type":         cardmsg.InteractiveCard.Int(),
+			"card_version": cardmsg.CardVersion,
+			"profile":      cardmsg.ProfileV2,
+			"card":         card,
+		})
+		if err != nil {
+			t.Fatalf("marshal envelope: %v", err)
+		}
+		return envelope
+	}
+
+	t.Run("custom actions", func(t *testing.T) {
+		raw, err := BuildApprovalRequestCard(ApprovalRequestCard{
+			Title:      "Execute task",
+			Owner:      "tasks",
+			ActionType: "task.execute.decision",
+			Data:       map[string]string{"task_id": "task-1"},
+			Actions: []ApprovalRequestAction{
+				{Decision: "execute", Title: "Execute"},
+				{Decision: "reject", Title: "Reject"},
+				{Decision: "cancel", Title: "Cancel"},
+			},
+		})
+		if err != nil {
+			t.Fatalf("BuildApprovalRequestCard() error = %v", err)
+		}
+		envelope := newEnvelope(t, raw)
+
+		for decision, wantTaskID := range map[string]string{"execute": "task-1", "reject": "task-1", "cancel": "task-1"} {
+			id := "approval-" + decision
+			data, found := cardmsg.SubmitAction(envelope, id)
+			if !found {
+				t.Fatalf("SubmitAction(%q) found = false; builder emitted a button the extractor cannot find", id)
+			}
+			if data["decision"] != decision {
+				t.Fatalf("SubmitAction(%q).decision = %v, want %q", id, data["decision"], decision)
+			}
+			if data["owner"] != "tasks" || data["action_type"] != "task.execute.decision" {
+				t.Fatalf("reserved metadata lost on %q: %+v", id, data)
+			}
+			if data["task_id"] != wantTaskID {
+				t.Fatalf("shared data lost on %q: task_id = %v, want %q", id, data["task_id"], wantTaskID)
+			}
+		}
+
+		if _, found := cardmsg.SubmitAction(envelope, "approval-nope"); found {
+			t.Fatal("SubmitAction(bogus) found = true; extractor accepted an ID the builder never emitted")
+		}
+	})
+
+	t.Run("legacy approve deny", func(t *testing.T) {
+		raw, err := BuildApprovalRequestCard(ApprovalRequestCard{
+			Title:        "Publish summary",
+			Owner:        "smart-summary",
+			ActionType:   "summary.publish.decision",
+			Data:         map[string]string{"task_no": "task-7"},
+			ApproveTitle: "Allow",
+			DenyTitle:    "Deny",
+		})
+		if err != nil {
+			t.Fatalf("BuildApprovalRequestCard() error = %v", err)
+		}
+		envelope := newEnvelope(t, raw)
+
+		approveData, found := cardmsg.SubmitAction(envelope, ApprovalApproveActionID)
+		if !found || approveData["decision"] != "approve" ||
+			approveData["owner"] != "smart-summary" || approveData["task_no"] != "task-7" {
+			t.Fatalf("legacy approve action lost round-trip: found=%v data=%+v", found, approveData)
+		}
+		denyData, found := cardmsg.SubmitAction(envelope, ApprovalDenyActionID)
+		if !found || denyData["decision"] != "deny" {
+			t.Fatalf("legacy deny action lost round-trip: found=%v data=%+v", found, denyData)
+		}
+	})
 }


### PR DESCRIPTION
## Summary

Follow-up to #588. Two small extensions to the callback dispatch layer plus one bundled config collapse:

1. `OCTO_CARD_ACTION_ROUTES[].url` now accepts `http://` alongside `https://`. Hostname form is not inspected; the presence of `http://` in a static route is the operator's explicit authorization.
2. `approval_card` grew an optional 1–5 bounded `actions` list, so a consumer can render buttons like `execute` / `reject` / `cancel` instead of only `approve` / `deny`. Server owns action IDs, reserved metadata, and card JSON. Nil preserves the byte-for-byte legacy approve/deny output; a non-nil empty slice is a caller bug and returns 400.
3. `OCTO_CARD_ACTION_ALLOWED_URLS` is deleted from routing decisions. If still present at startup it produces one structured deprecation WARN and is ignored — rolling upgrades do not fail.

HMAC signing, redirect ban, proxy-env ignoring, retry/DLQ, terminal states, and requester-notification behavior are deliberately unchanged.

## Linked Spec

`.octospec/tasks/card-action-internal-http-actions/brief.md`

## Changes

- `internal/cardactiondispatch/registry.go` — two-arg `NewRegistry`; `validateCallbackURL` accepts `http`/`https` and rejects credentials/query/fragment/opaque/empty-host, plus raw `#` and `ForceQuery` prefilters.
- `internal/cardactiondispatch/config.go` — `LoadAllowedURLs` deleted.
- `internal/cardactiondispatch/http.go` — comment update; `Proxy=nil` now covers both schemes.
- `main.go` — reads deprecated env only to emit a structured WARN; installs registry with the new signature.
- `pkg/cardtmpl/approval_request.go` — new `ApprovalRequestAction` / `MaxApprovalCustomActions=5`; validator checks control characters on the raw title before `TrimSpace`.
- `modules/notify/model.go`, `modules/notify/approval_card.go` — `ApprovalCardFields.Actions` optional field with strict nil-vs-empty semantics.
- Docs — `docs/card-action-callback-dispatch.md`, `docs/card-action-callback-consumer.md`, `docs/card-protocol.md` updated by reference.
- Tests — new `internal/cardactiondispatch/registry_http_scheme_test.go` (7 accept + 13 reject + plain-HTTP HMAC and redirect E2Es); new `pkg/cardtmpl/approval_request_actions_test.go` (actions boundaries + golden-bytes for legacy path); new orchestration integration test `TestCardActionCallbackOrchestrationForwardsCustomDecisionEndToEnd`; existing tests migrated to the two-arg registry signature (this also fixed the compile block in `modules/message/api_card_action_test.go`).
- `.octospec/journal/shared/card-action-internal-http-actions.md`, `.octospec/learnings/pending/{json-nil-vs-empty-slice,url-parse-raw-prefilter}.md`.

## Testing

- [x] Unit + race — `cardactiondispatch`, `cardtmpl`, `notify`, main package: PASS.
- [x] Coverage — cardactiondispatch 81.5%, cardtmpl 89.9%, notify 71.2%.
- [x] Integration (fresh local `test` schema) — full `internal/cardactiondispatch` orchestration suite including the new custom-decision E2E: PASS.
- [x] Integration (fresh schema) — `modules/message` sender-bound routing E2E (compile-blocker fixup): PASS.
- [x] `go build ./...`, `go vet ./...`, `gofmt -l`, `make i18n-lint`: clean.
- [x] Manual byte-compat check — omitting `actions` produces the exact same JSON as before this PR.

Unrelated pre-existing test flake: `TestCardActionEndToEndAndIdempotency` panics without `OCTO_MASTER_KEY` on both this branch and clean `main`; not in scope for this PR.

## COMPREHENSION

1. **What does this change actually do to the load-bearing path?**

   For the callback URL: `validateCallbackURL` no longer forces `https`. It accepts `http` and `https`, verifies the URL has a real host (`Hostname() != ""`), no credentials, no query (including bare `?`), no fragment (including bare `#` and embedded `#`), and no opaque form. The rest of the callback path — HMAC signing, canonical body, redirect refusal, proxy-env ignoring, retry/DLQ — is byte-identical.

   For approval_card actions: a nil `Actions` slice takes the untouched legacy code path (localized approve/deny buttons, byte-identical output). A non-nil slice enters a strict validator that produces server-built `Action.Submit` buttons whose IDs are `approval-<decision>` and whose payloads carry the server-injected `owner`, `action_type`, and per-button `decision`. Callers cannot supply per-action data, style, URL, input, or arbitrary card JSON, and cannot mix custom actions with approve/deny defaults.

   For config: `OCTO_CARD_ACTION_ALLOWED_URLS` no longer feeds routing. It is read once at startup only to log a structured deprecation WARN.

2. **What could break because of it (dependents + failure mode)?**

   - Deployments that route to a plain HTTP endpoint over an untrusted network — HMAC does not encrypt. Both docs carry an explicit residual-risk callout.
   - A caller who currently ships `"actions": []` (explicit empty array) will start getting 400 instead of the old approve/deny fallback. There are no known callers doing this; this is intentional to catch caller bugs.
   - A caller who registered a route that only worked because of shape validation (e.g. lookalike `service.namespace.svc.example.com`) is no longer relied on — the route registry is the single source of truth. If a bad URL was accidentally in the registry it will still be accepted; that risk is unchanged from the pre-PR world where the registry was co-authoritative with the allowlist.
   - Deployments still carrying `OCTO_CARD_ACTION_ALLOWED_URLS` in their ConfigMap will keep booting; a WARN will show in logs until the variable is removed.

3. **How do you know it works (specific test/repro/trace)?**

   - Byte-compat: `TestBuildApprovalRequestCardOmittedActionsIsByteCompatible` pins the exact JSON produced when `Actions == nil`.
   - URL boundary: `TestValidateCallbackURLRejectsUnsafeShapes` covers empty, unsupported schemes, credentials, query, trailing `?`, fragment, trailing `#`, embedded `#`, `http://` and `https://` with port-only host, and whitespace-padded strings.
   - HTTP acceptance: `TestNewRegistryAcceptsHTTPCallbackDestinations` covers K8s Service short/full DNS, docker service name, `host.docker.internal`, IPv4/IPv6 literals, and HTTPS.
   - Cleartext transport: `TestHTTPDelivererDeliversPlainHTTPWithHMACAndDisciplinedTransport` runs a real `httptest.NewServer` with `HTTP_PROXY` set in the environment, asserting the deliverer's default transport ignores it and HMAC verifies over the exact body.
   - Redirect ban on HTTP: `TestHTTPDelivererRefusesRedirectsOnPlainHTTP` asserts the returned error is a `DeliveryError{Category: "redirect_rejected"}`.
   - Custom decision end-to-end: `TestCardActionCallbackOrchestrationForwardsCustomDecisionEndToEnd` enqueues a click, verifies the callback body carries `decision=execute` and `action_id=approval-execute`, that the standard finalizer renders `approval.approved` (not the decision string), that the requester notification fires, and that the queue drains.
   - Wire-level nil-vs-empty: `TestIntegration_ApprovalCardCustomActionsRenderInOrder` sends raw JSON with `"actions": []` and asserts 400, then sends raw JSON with the field omitted and asserts a successful approve/deny render.
   - Deprecation contract: `TestDeprecatedAllowedURLsEnvIsIgnoredWithStructuredWarn` pins that `main.go` still reads the deprecated env, emits `log.Warn` with a `deprecated_env` structured field, no longer calls `LoadAllowedURLs`, and uses the two-arg `NewRegistry`.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] PR description is in English
- [x] Added tests for my changes
- [x] Updated documentation
- [x] Followed commit message conventions (Conventional Commits)