### PR TITLE
feat(incomingwebhook): render GitHub/GitLab webhook events as InteractiveCard

### DIFF
--- a/.octospec/journal/shared/webhook-cardmsg-adapter.md
+++ b/.octospec/journal/shared/webhook-cardmsg-adapter.md
@@ -1,0 +1,84 @@
+---
+type: Journal
+title: "Journal: webhook-cardmsg-adapter"
+description: GitHub/GitLab incoming-webhook adapters render their event subset as InteractiveCard(17) octo/v1 cards when OCTO_CARD_MESSAGE_ENABLED is on, degrading to the untouched markdown text path when off. GitLab pipeline cards carry a Branch/Status/Duration/Jobs FactSet. Server-only; octo-web renderer already ships octo/v1 + iwh_ trust.
+tags: ["incomingwebhook", "adapter", "webhook", "card", "wire-contract", "trust-boundary", "external-content", "markdown", "url-destination", "i18n"]
+timestamp: 2026-07-16T00:00:00Z
+# --- octospec extension fields ---
+task: webhook-cardmsg-adapter
+upstream: self
+source: self
+---
+# Journal: webhook-cardmsg-adapter
+
+## What was done
+
+The GitHub and GitLab incoming-webhook adapters now render their existing event
+subset as an **InteractiveCard (=17) octo/v1 card** (structured header + body +
+a "View on {GitHub|GitLab}" `Action.OpenUrl`) when `OCTO_CARD_MESSAGE_ENABLED`
+is on. When the flag is off — or when a built card fails self-validation — they
+**degrade to the existing markdown text path**, whose renderers are left byte-for-byte
+unchanged (so the flag-off wire is identical to before, locked by the pre-existing
+`adapter_github_test.go` / `adapter_gitlab_test.go` string assertions).
+
+- `adapter_card.go` (new): the shared card model + assembler (`vcsCardData.card`),
+  one escaper (`escapeCardText`, mirrors `cardtmpl.escapeMarkdown`) + `cardCodeSpan`
+  used by **both** adapters (parity), `httpURLForCard` (positive http(s) allowlist,
+  omits the button rather than failing on a bad URL), `validateVCSCard` (self-check
+  via `cardmsg.Validate` → degrade), `vcsPushReq` (card-or-text selector),
+  `vcsViewLabel` (localized button title), and the pipeline FactSet helpers.
+- `adapter_github.go` / `adapter_gitlab.go`: per-event card builders next to their
+  text siblings; the `parse` tail builds a card only when `cardmsg.Enabled()` and
+  routes through `vcsPushReq`. The card object becomes `req.Card` and flows through
+  the existing `msgTypeCard` branch (`buildCardPayload` → `Validate`/`Finalize` →
+  server-derived `plain`, `from.kind=webhook`, server `space_id`). No handlePush change.
+
+## Load-bearing decisions
+
+- **Escape at the leaf, parity across siblings** (trust-boundary): every external
+  VCS field (actor / repo / title / commit message / comment) is escaped at the card
+  TextBlock/Fact leaf by one shared escaper; bold is `weight:Bolder` (not markdown
+  `**`) and refs/SHAs are code spans, so escaped text can never re-open emphasis or a
+  link. Primary navigation is a structured `Action.OpenUrl` (allowlisted), never a
+  markdown destination — no destination-breakout surface. A parity table test drives a
+  `] ) * [ javascript:` payload through **both** github and gitlab and asserts the
+  authoritative `cardmsg.Validate` still passes (proof no live bad-URL/element leaked).
+- **Degrade, never a new 400**: card-vs-text is chosen per push via `cardmsg.Enabled()`;
+  the built card self-validates through the same `cardmsg.Validate` the ingress uses, so
+  anything malformed falls back to text. No new errcode / response was added
+  (`i18n-lint` + the `NoLegacyResponseError` guard both green; `adapter_card.go` added to
+  the guard list).
+- **Outbound language** = `i18n.OutboundLanguage(context.Background())` (deployment
+  default, no request ctx) — same discipline as `modules/notify` / `pkg/cardtmpl`. The
+  "View on {..}" and pipeline FactSet labels are localized in-Go (content labels, not
+  errcodes).
+
+## Deviation from brief (accepted mid-review)
+
+The brief scoped this as a rendering-format change with "no new event fields". During
+visual review the pipeline card was **enriched** (still the same `Pipeline Hook` event,
+no subset change): it now renders a **FactSet — Branch / Status / Duration / Jobs (N)** —
+parsing `object_attributes.duration` and the `builds[]` array (both previously unparsed).
+This is **card-only**: the text path is untouched, so flag-off bytes stay identical. The
+headline (`Pipeline #<id>`) carries the status color (Good/Attention/Warning).
+
+## Verification
+
+- `go test ./modules/incomingwebhook/ -run '<card + adapter + guard>'` green;
+  `golangci-lint run ./modules/incomingwebhook/...` = 0 issues; `gofmt` clean;
+  `make i18n-lint` green.
+- Truthful render: a throwaway test dumped the **actual** card JSON from the shipped
+  builders; it was rendered headless with the real `adaptivecards@3.0.6` + octo-web's
+  own `--wk-*` theme tokens + a host config mirroring `octoHostConfig` — output matches
+  the intended design in light and dark, and the hostile push card shows the injection
+  rendered literally with no "View" button (its `javascript:` repo URL was dropped).
+
+## Follow-ups / notes
+
+- octo-web: **no change** — `InteractiveCard` renderer already ships octo/v1 and trusts
+  `iwh_` senders (`senderTrust.classifyCardSender` → webhook → display-only render).
+- WeCom / Feishu / Multica adapters and the native `msg_type` paths are untouched.
+- HMAC signature verification (`X-Hub-Signature-256` etc.) remains a separate optional
+  follow-up, out of this change.
+- Enabling cards in any deployment stays an ops decision gated on the client
+  render-gate (`OCTO_CARD_MESSAGE_ENABLED` default off).

--- a/.octospec/log.md
+++ b/.octospec/log.md
@@ -23,6 +23,20 @@ change-log convention (§7). Newest first.
   under `.octospec/tasks/card-action-internal-http-actions/`; shared journal
   `.octospec/journal/shared/card-action-internal-http-actions.md`.
 
+## 2026-07-16 (webhook-cardmsg-adapter)
+
+- **Feature** — The GitHub/GitLab incoming-webhook adapters render their event
+  subset as `InteractiveCard` (=17) octo/v1 cards (structured header + body + a
+  "View on {GitHub|GitLab}" `Action.OpenUrl`) when `OCTO_CARD_MESSAGE_ENABLED`
+  is on, and degrade to the untouched markdown text path when off (flag-off wire
+  byte-identical). New `adapter_card.go` holds the shared card anatomy + one leaf
+  escaper + http(s) allowlist + self-validate/degrade selector, used by both
+  adapters (trust-boundary parity). GitLab pipeline cards render a
+  Branch/Status/Duration/Jobs FactSet (parses `duration` + `builds[]`, card-only).
+  Server-only: octo-web already ships the octo/v1 renderer + `iwh_` sender trust.
+  Brief/context under `.octospec/tasks/webhook-cardmsg-adapter/`; shared journal
+  `.octospec/journal/shared/webhook-cardmsg-adapter.md`.
+
 ## 2026-07-13 (card-message-appbot-trust)
 
 - **Fix** — Closed the P0 App Bot card trust split without changing the send

--- a/.octospec/tasks/webhook-cardmsg-adapter/brief.md
+++ b/.octospec/tasks/webhook-cardmsg-adapter/brief.md
@@ -1,0 +1,147 @@
+---
+type: Task
+title: "Task: webhook-cardmsg-adapter"
+description: GitHub/GitLab incoming-webhook adapters render their event subset as InteractiveCard(17) octo/v1 cards, degrading to the existing markdown text when OCTO_CARD_MESSAGE_ENABLED is off. Server-only; structured card layout; no new events, no changed ping/skip/no_event semantics.
+tags: ["incomingwebhook", "adapter", "webhook", "card", "wire-contract", "trust-boundary", "external-content", "markdown", "url-destination", "i18n", "testing"]
+timestamp: 2026-07-15T00:00:00Z
+# --- octospec extension fields ---
+slug: webhook-cardmsg-adapter
+upstream: self
+source: self
+---
+
+# Task: webhook-cardmsg-adapter
+
+> Related specs (context, not restated here): the InteractiveCard wire contract
+> lives in `.octospec/tasks/card-message-protocol/brief.md` and `pkg/cardmsg`
+> (the single octo/v1 whitelist authority); `docs/card-protocol.md` mirrors it.
+> This brief captures only the incomingwebhook GitHub/GitLab adapter change.
+
+## Goal
+
+Upgrade the **GitHub** and **GitLab** incoming-webhook adapters so their
+rendered event subset is delivered as an **InteractiveCard (=17) octo/v1 card**
+(structured header + body + a "View" `Action.OpenUrl`) instead of a single
+markdown text line — while keeping the whole event pipeline (subset, ping,
+skip, no_event, audit) byte-for-byte unchanged.
+
+Because cards sit behind the deployment gate `OCTO_CARD_MESSAGE_ENABLED`
+(default off, protocol Decision 2) and depend on the client render-gate, the
+adapters **degrade to the existing markdown text path when the flag is off**.
+Merge never breaks GitHub/GitLab delivery; enabling cards is an ops decision
+gated on the client renderer (already shipped in octo-web — see Background).
+
+## Background
+
+- The push pipeline (`modules/incomingwebhook/api.go handlePush`) dispatches by
+  `req.MsgType`: `""`/`text` → `buildPayload`, `richtext` → `buildRichTextPayload`,
+  `card` → `buildCardPayload` (already exists, `card.go`). Adapters only translate
+  the platform body into a `pushPayloadReq`; today github/gitlab return
+  `{Content: <markdown>}` and ride the text path.
+- `pkg/cardmsg` owns the octo/v1 whitelist authority: `Validate` (write-strict:
+  element/action whitelist, 512 KiB, positive http(s) URL allowlist incl.
+  TextBlock markdown links, node/depth caps) + `Finalize` (re-derives the
+  server-authoritative `plain`, re-checks size). `buildCardPayload` already runs
+  both on a caller-supplied `req.Card map[string]interface{}`.
+- We are the **producer** here (we author the card server-side, unlike the
+  native `msg_type:"card"` path which accepts caller AC JSON). `pkg/cardtmpl` is
+  the reviewed server-side template precedent (`modules/notify` summary/docs
+  cards): header + optional excerpt + FactSet + `Action.OpenUrl`, with
+  `escapeMarkdown` on every leaf and `metadata.octo.{variant,source}`.
+- **octo-web renderer is ready**: `packages/dmworkbase/src/Messages/InteractiveCard/`
+  is a full octo/v1 pipeline; `senderTrust.classifyCardSender` trusts `iwh_*`
+  senders (`renderDecision` renders their structured card, display-only —
+  `interactive:false`). GitHub/GitLab cards (FromUID `iwh_*`, only whitelisted
+  elements + `Action.OpenUrl`) render with **no web change**.
+- Governing rule: `.octospec/rules/trust-boundary.md` (load-bearing) — escape at
+  the boundary the caller can't cross, keep parity across sibling adapters,
+  no URL-destination breakout, bound the payload.
+
+## Load-bearing list
+<!-- touches tags: adapter, webhook, external-content, trust-boundary, markdown,
+     url-destination, wire-contract, i18n, card, testing -->
+
+- **GitHub adapter render subset** (`adapter_github.go`): push / pull_request
+  (opened/closed·merged/reopened/ready_for_review) / issues / issue_comment /
+  release; ping → 200 no-msg; subset-outside → 200 skip `event`; missing
+  `X-GitHub-Event` → 400 `no_event`. Subset and these outcomes MUST NOT change.
+- **GitLab adapter render subset** (`adapter_gitlab.go`): Push / Tag Push /
+  Merge Request / Issue / Note / Pipeline (terminal states only); `X-Gitlab-Token`
+  second gate; skip / `no_event` semantics. MUST NOT change. `verifyGitLabToken`
+  and the URL-token auth chain are untouched.
+- **Trust boundary / external content**: VCS-controlled text (actor login/name,
+  repo path, PR/issue/release titles, commit messages, comment snippets) is
+  attacker-influenced. It must be escaped **at the card leaf** (TextBlock text,
+  FactSet title/value) before delivery; all URLs (`Action.OpenUrl.url`, any
+  Image url, any TextBlock markdown link) go through the positive http(s)
+  allowlist. Prefer structured `Action.OpenUrl` over markdown link
+  destinations inside TextBlock to avoid the destination-breakout surface.
+- **Adapter parity**: whatever escaping/URL discipline the card path applies to
+  GitHub must hold identically for GitLab; the two card producers share one
+  escaper + one card-anatomy helper (no divergent leaf handling).
+- **Card wire contract** (`pkg/cardmsg`): the produced `req.Card` envelope is
+  validated by `cardmsg.Validate`/`Finalize` exactly like every other type-17
+  producer — no bypass, server pins `card_version`/`profile`, `from.kind=webhook`,
+  server-derived `space_id`; `RecheckPayloadSize` after mention expansion still
+  applies (handlePush already calls it).
+- **Server-authoritative `plain`**: `Finalize` derives `plain` from the card
+  body (TextBlock/FactSet); it must be non-empty and readable (drives search /
+  quote / offline push / conversation summary). The old markdown line's
+  information is preserved on the card so derived plain stays informative.
+- **Degrade path** (`OCTO_CARD_MESSAGE_ENABLED`): flag off → existing markdown
+  text path, unchanged bytes. Flag on → card. Decision is per-push via
+  `cardmsg.Enabled()`; no request context, so outbound language is the
+  deployment default (`i18n.OutboundLanguage(context.Background())`, same
+  discipline as notify/botfather).
+- **Deliveries / audit**: adapter names stay `github`/`gitlab`; `status`/`reason`
+  columns and body caps (1 MiB github/gitlab input; card output < 512 KiB via
+  cardmsg) unchanged; card build failure must not silently drop — it degrades to
+  text (never a new 400 on the happy path).
+- **i18n**: card action label ("View on GitHub"/"在 GitHub 查看",
+  "View on GitLab"/"在 GitLab 查看") localized via outbound-language negotiation;
+  no hardcoded user-facing strings.
+
+## Out of scope
+
+- WeCom / Feishu / Multica adapters and the native `msg_type` paths
+  (text/richtext/card) — untouched.
+- Any new event type or action, or any change to the ping/skip/no_event/subset
+  decisions — this is a rendering-format change only.
+- octo-web / any client repo — renderer already ships octo/v1 + `iwh_` trust.
+- `pkg/cardmsg` whitelist / validation semantics, `OCTO_CARD_MESSAGE_ENABLED`
+  default, and the P2 interactive contract (Input.*/Action.Submit) — not touched.
+- Enabling cards in any environment (ops decision, client-gate precondition).
+- HMAC signature verification (`X-Hub-Signature-256` etc.) — remains a separate
+  optional follow-up, out of this change.
+
+## Acceptance
+
+- **Flag off** (`OCTO_CARD_MESSAGE_ENABLED` unset/false): a GitHub `push` and a
+  GitLab `Merge Request` event each deliver the **same markdown text payload as
+  today** (type 1, `content` byte-identical to the pre-change renderer). Existing
+  `adapter_github_test.go` / `adapter_gitlab_test.go` text assertions pass
+  unchanged (flag-off is the default test env).
+- **Flag on**: the same events deliver a type-17 card whose envelope passes
+  `cardmsg.Validate` + `Finalize`; `payload["plain"]` is non-empty and contains
+  the actor + action + repo (and, for push, the commit summary). A "View" action
+  (`Action.OpenUrl`) points at the PR/issue/commit/pipeline/repo URL and passes
+  the http(s) allowlist.
+- **Trust boundary**: a table test proves a PR title / branch / actor name
+  containing `]`, `)`, `*`, `[`, `<`, `javascript:`/`data:` URL does not (a)
+  break out of a TextBlock/FactSet leaf into forged markup, nor (b) inject a
+  non-http(s) actionable URL — parity-asserted for **both** github and gitlab.
+- **Subset unchanged**: `ping` → 200 no message; subset-outside event → 200
+  `skipped:"event"`; missing event header → 400 `no_event`; a
+  `pull_request:synchronize` / GitLab MR `update` still skips — with the flag in
+  either state.
+- **Degrade on card-build failure**: if the card builder returns an error while
+  the flag is on, the push still delivers the text payload (200), not a 400 —
+  covered by a test forcing a build error.
+- Gates green: `golangci-lint run ./...`; `go test ./modules/incomingwebhook/...`
+  (MySQL+Redis); if any errcode/response touched, `make i18n-extract-check` +
+  `make i18n-lint` and zh-CN entries; guard test
+  `TestIncomingWebhookNoLegacyResponseError` file list updated if a new
+  handler-bearing `.go` file lands.
+- Scope hygiene: `git diff --stat` touches only `modules/incomingwebhook/**`
+  (+ `docs/`/`.octospec/` + a shared card escaper if promoted to `pkg/cardmsg`);
+  no octo-web change; no WeCom/Feishu/Multica/native-path diff.

--- a/.octospec/tasks/webhook-cardmsg-adapter/context.yaml
+++ b/.octospec/tasks/webhook-cardmsg-adapter/context.yaml
@@ -1,0 +1,42 @@
+slug: webhook-cardmsg-adapter
+rules_injected:
+  - id: trust-boundary
+    tier: repo
+    load_bearing: true
+    why: github/gitlab are attacker-influenced ingress; the card path escapes every external
+         leaf (actor/repo/title/commit msg/comment) at the card TextBlock/FactSet via a shared
+         escaper, and routes all URLs (Action.OpenUrl) through cardmsg's positive http(s)
+         allowlist. Parity held — one shared card escaper + one anatomy helper for BOTH adapters;
+         primary navigation is a structured Action.OpenUrl (no markdown-destination breakout).
+  - id: error-handling
+    tier: repo
+    load_bearing: true
+    why: no new error codes / responses. Cards degrade to the existing text path when the flag is
+         off OR the built card fails self-validation, so the happy path never becomes a new 400;
+         the msgTypeCard branch's existing error mapping is reused unchanged.
+  - id: space-isolation
+    tier: repo
+    load_bearing: true
+    why: card envelope still routes through buildCardPayload — space_id server-derived from the
+         group (never caller-set), from.kind=webhook pinned; targetChannel/delivery unchanged.
+         The adapter only produces the card body; no new data-access surface.
+  - id: testing
+    tier: repo
+    load_bearing: false
+    why: new adapter_card_test.go (card shape + validate + trust-boundary parity + degrade) plus
+         extend adapter_github_test.go / adapter_gitlab_test.go (flag-off bytes identical, flag-on card).
+  - id: commit-style
+    tier: repo
+    load_bearing: false
+    why: Conventional Commits, English.
+files_touched:
+  - modules/incomingwebhook/adapter_card.go     # NEW shared card model+assembler+escaper+url allowlist+view label+self-validate+selector
+  - modules/incomingwebhook/adapter_github.go   # add per-event card builders; parse tail picks card (flag on) else text
+  - modules/incomingwebhook/adapter_gitlab.go   # add per-event card builders; parse tail picks card (flag on) else text
+  - modules/incomingwebhook/api_i18n_test.go    # add adapter_card.go to the NoLegacyResponseError guard list
+parity_decisions:
+  - "Card leaf escaping uses one shared escapeCardText (mirrors pkg/cardtmpl.escapeMarkdown) + cardCodeSpan; both github and gitlab card builders use only these — no divergent per-adapter escaping."
+  - "Bold is TextBlock weight:Bolder (not markdown **), refs/SHAs are code spans (backticks stripped from content) — so escaped external text can never re-open emphasis or a link."
+  - "Primary link is a structured Action.OpenUrl validated by httpURLForCard (parse+scheme http(s)+host); non-http(s) → button omitted (card still valid), never a markdown destination interpolation."
+  - "Card-vs-text chosen per push via cardmsg.Enabled(); on Enabled()+build the card self-validates through cardmsg.Validate — any failure degrades to the untouched text path (flag-off bytes identical, guaranteed by unchanged text renderers)."
+  - "Outbound language = i18n.OutboundLanguage(context.Background()) (deployment default, no request ctx) — same discipline as modules/notify + cardtmpl; 'View on {GitHub|GitLab}' / '在 {..} 查看' localized in-Go (content label, not an errcode)."

--- a/modules/incomingwebhook/adapter_card.go
+++ b/modules/incomingwebhook/adapter_card.go
@@ -61,10 +61,44 @@ var cardMarkdownEscaper = strings.NewReplacer(
 	`|`, `\|`,
 )
 
-// escapeCardText clamps external text to max runes (single line) then escapes it for
-// safe placement in a card TextBlock leaf.
+// escapeCardText clamps external text to max runes (single line), escapes inline
+// markdown, then neutralizes a leading block marker — safe for placement at a card
+// TextBlock / Fact line start.
 func escapeCardText(s string, max int) string {
-	return cardMarkdownEscaper.Replace(clipRunes(oneLine(s), max))
+	return neutralizeLeadingBlockMarker(cardMarkdownEscaper.Replace(clipRunes(oneLine(s), max)))
+}
+
+// neutralizeLeadingBlockMarker backslash-escapes a leading markdown BLOCK marker so
+// external text placed at a TextBlock/Fact line start cannot open a bullet/ordered
+// list or a thematic break. octo-web's CardMarkdown renders ul/ol/li (and <hr>), and
+// these markers are NOT covered by cardMarkdownEscaper — it only neutralizes INLINE
+// markers (`* _ [ ] ( ) < > \` # ~ |`); the ordered `)` marker and `*`/`_` are
+// already escaped there, leaving `-`, `+`, and ordered `N.` as the injection surface
+// (e.g. a hostile issue-comment body `1. Deploy approved` forging a numbered list in
+// a trusted-webhook card). Operates on the already-inline-escaped string; a leading
+// backslash/other char is a no-op. stripMarkdown unescapes for the authoritative
+// plain, so the literal marker still shows in search/quote text.
+func neutralizeLeadingBlockMarker(s string) string {
+	if s == "" {
+		return s
+	}
+	// Bullet list markers (`- x`, `+ x`) and dash thematic breaks (`---`): a leading
+	// backslash makes the char literal and the line neither a list nor an <hr>.
+	if s[0] == '-' || s[0] == '+' {
+		return `\` + s
+	}
+	// Ordered list marker `N.` followed by whitespace/end — escape the dot. (`N)` is
+	// already neutralized because `)` is inline-escaped above.)
+	i := 0
+	for i < len(s) && s[i] >= '0' && s[i] <= '9' {
+		i++
+	}
+	if i > 0 && i < len(s) && s[i] == '.' {
+		if rest := s[i+1:]; rest == "" || rest[0] == ' ' || rest[0] == '\t' {
+			return s[:i] + `\.` + rest
+		}
+	}
+	return s
 }
 
 // cardCodeSpan renders an external short token (branch / tag / short SHA) as a

--- a/modules/incomingwebhook/adapter_card.go
+++ b/modules/incomingwebhook/adapter_card.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 
 	"github.com/Mininglamp-OSS/octo-server/pkg/cardmsg"
+	"go.uber.org/zap"
 )
 
 const (
@@ -59,6 +60,10 @@ var cardMarkdownEscaper = strings.NewReplacer(
 	`#`, `\#`,
 	`~`, `\~`,
 	`|`, `\|`,
+	// `!` guards image syntax `![alt](url)`: cardmsg.Validate already allowlists any
+	// image destination (defence in depth), but escaping `!` stops the image node
+	// from ever forming (PR #596 review, mochashanyao nit).
+	`!`, `\!`,
 )
 
 // escapeCardText clamps external text to max runes (single line), escapes inline
@@ -198,15 +203,18 @@ func (d vcsCardData) card(lang string) map[string]interface{} {
 	if d.variant != "" {
 		metaOcto["variant"] = d.variant
 	}
-	metadata := map[string]interface{}{"octo": metaOcto}
 	card := map[string]interface{}{
 		"type":     "AdaptiveCard",
 		"version":  cardmsg.CardVersion,
-		"metadata": metadata,
+		"metadata": map[string]interface{}{"octo": metaOcto},
 		"body":     body,
 	}
+	// Navigation is the single structured Action.OpenUrl (allowlisted by both
+	// httpURLForCard and cardmsg.Validate). We deliberately do NOT also mirror the URL
+	// into metadata.webUrl: cardmsg's validator does not walk the metadata subtree, so
+	// carrying a URL there would rely on incidental coupling for the "every rendered URL
+	// was allowlisted" invariant (PR #596 review, yujiawei P2).
 	if d.url != "" {
-		metadata["webUrl"] = d.url
 		card["actions"] = []interface{}{
 			map[string]interface{}{
 				"type": "Action.OpenUrl", "title": vcsViewLabel(d.source, lang), "url": d.url,
@@ -248,8 +256,18 @@ func validateVCSCard(card map[string]interface{}) error {
 // path — flag off OR card build/validate failure). Card plain is derived by Finalize
 // from the card body, so no text seed is needed.
 func vcsPushReq(text string, card map[string]interface{}) *pushPayloadReq {
-	if card != nil && validateVCSCard(card) == nil {
-		return &pushPayloadReq{MsgType: msgTypeCard, Card: card}
+	if card != nil {
+		if err := validateVCSCard(card); err != nil {
+			// A server-built card failing self-validation is a card-builder bug (an
+			// attacker-controlled field can't reach here un-escaped). We still degrade to
+			// text so delivery is preserved, but log it so the regression is visible in
+			// production instead of silent (PR #596 review, Jerry-Xin). Response contract
+			// unchanged. zap.L() is the package-scope logger (cf. modules/cardtrust).
+			zap.L().Warn("incomingwebhook: built VCS card failed self-validation; degrading to text",
+				zap.Error(err))
+		} else {
+			return &pushPayloadReq{MsgType: msgTypeCard, Card: card}
+		}
 	}
 	return &pushPayloadReq{Content: clipRunes(text, maxContentRunes())}
 }
@@ -270,11 +288,22 @@ func pipelineLabelsFor(lang string) pipelineLabels {
 	return pipelineLabels{branch: "Branch", status: "Status", duration: "Duration", jobs: "Jobs"}
 }
 
+// maxPipelineDurationSec sanity-caps the rendered duration. GitLab's
+// object_attributes.duration is an unbounded external float64; without a cap a
+// hostile/buggy self-hosted instance sending e.g. 1e12 would render an absurd
+// "277777777h 46m" string (PR #596 review, yujiawei P2). 100h is far above any real
+// pipeline; anything larger renders as the cap.
+const maxPipelineDurationSec = 100 * 3600
+
 // formatPipelineDuration renders a pipeline elapsed time (seconds) as a compact,
-// language-neutral "1h 2m" / "3m 42s" / "42s". <= 0 (missing / null) → "".
+// language-neutral "1h 2m" / "3m 42s" / "42s". <= 0 (missing / null) → ""; values
+// above the sanity cap are clamped.
 func formatPipelineDuration(sec int) string {
 	if sec <= 0 {
 		return ""
+	}
+	if sec > maxPipelineDurationSec {
+		sec = maxPipelineDurationSec
 	}
 	h := sec / 3600
 	m := (sec % 3600) / 60

--- a/modules/incomingwebhook/adapter_card.go
+++ b/modules/incomingwebhook/adapter_card.go
@@ -1,0 +1,288 @@
+package incomingwebhook
+
+// InteractiveCard(=17) rendering for the VCS event adapters (github / gitlab) —
+// spec: .octospec/tasks/webhook-cardmsg-adapter/brief.md.
+//
+// When OCTO_CARD_MESSAGE_ENABLED is on, github/gitlab events render as an octo/v1
+// card (structured header + body + one Action.OpenUrl); when it is off — or when a
+// built card fails self-validation — they degrade to the existing markdown text
+// path (bytes unchanged). We are the PRODUCER here (unlike the native
+// msg_type:"card" path which takes caller AC JSON), so every external leaf is
+// escaped at the card TextBlock and every URL goes through cardmsg's positive
+// http(s) allowlist. The two adapters share ONE escaper + ONE card anatomy so a
+// defense added for github holds identically for gitlab (trust-boundary: escape at
+// the leaf + adapter parity).
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardmsg"
+)
+
+const (
+	// cardSourceGitHub / cardSourceGitLab feed metadata.octo.source.label and the
+	// localized "View on {source}" button title.
+	cardSourceGitHub = "GitHub"
+	cardSourceGitLab = "GitLab"
+
+	// cardActorMax bounds an actor display name before it enters the headline —
+	// same rune clamp intent as the text path's actor handling.
+	cardActorMax = 64
+	// cardRefMax / cardTitleMax / cardCommitMsgMax bound the external ref / title /
+	// commit-message leaves (mirror the text path's clamps).
+	cardRefMax       = 200
+	cardTitleMax     = 200
+	cardCommitMsgMax = 120
+	cardShaMax       = 16
+	cardQuoteMax     = 300
+)
+
+// cardMarkdownEscaper mirrors pkg/cardtmpl.escapeMarkdown: it neutralizes every AC
+// markdown metacharacter so external VCS text (actor, repo, PR/issue titles, commit
+// messages, comment snippets) renders LITERALLY in a TextBlock leaf — it can never
+// re-open emphasis, forge a link, or activate an autolink/HTML span. This is the
+// card-side twin of the text path's mdInertText; both adapters use only this one
+// escaper for card leaves (trust-boundary: escape at the leaf + parity).
+var cardMarkdownEscaper = strings.NewReplacer(
+	`\`, `\\`,
+	`*`, `\*`,
+	`_`, `\_`,
+	`[`, `\[`,
+	`]`, `\]`,
+	`(`, `\(`,
+	`)`, `\)`,
+	`<`, `\<`,
+	`>`, `\>`,
+	"`", "\\`",
+	`#`, `\#`,
+	`~`, `\~`,
+	`|`, `\|`,
+)
+
+// escapeCardText clamps external text to max runes (single line) then escapes it for
+// safe placement in a card TextBlock leaf.
+func escapeCardText(s string, max int) string {
+	return cardMarkdownEscaper.Replace(clipRunes(oneLine(s), max))
+}
+
+// cardCodeSpan renders an external short token (branch / tag / short SHA) as a
+// markdown code span. Backticks are stripped from the content (a single-backtick
+// span cannot safely escape a backtick), and inside a code span AC does not
+// interpret markdown, so the token shows verbatim. Empty content yields "" (no
+// empty span).
+func cardCodeSpan(s string, max int) string {
+	inner := mdCodeSpanText(s, max)
+	if inner == "" {
+		return ""
+	}
+	return "`" + inner + "`"
+}
+
+// httpURLForCard returns raw when it is an absolute http(s) URL with a host, else
+// "". Mirrors cardmsg.checkURL's positive allowlist so the adapter can DEGRADE a
+// bad/missing link by omitting the button (the card stays valid) rather than failing
+// validation — the primary navigation is always a structured Action.OpenUrl, never a
+// markdown destination the caller could break out of.
+func httpURLForCard(raw string) string {
+	raw = strings.TrimSpace(raw)
+	u, err := url.Parse(raw)
+	if err != nil {
+		return ""
+	}
+	if s := strings.ToLower(u.Scheme); (s == "http" || s == "https") && u.Host != "" {
+		return raw
+	}
+	return ""
+}
+
+// vcsCardData is the neutral card model BOTH adapters fill — one anatomy keeps the
+// github and gitlab cards structurally identical (parity). All string fields are
+// already-safe markdown (composed with escapeCardText / cardCodeSpan); the assembler
+// does not re-escape.
+type vcsCardData struct {
+	source   string    // "GitHub" / "GitLab": metadata.octo.source.label + button label
+	variant  string    // metadata.octo.variant, e.g. "vcs.github.push"
+	headline string    // bold title line (whole TextBlock is Bolder)
+	status   string    // "", "Attention", "Good", "Warning" — headline color (pipeline status)
+	subtitle string    // subtle repo/context line; "" omits it
+	lines    []string  // body lines (commit list / "#N · title"); each its own TextBlock
+	facts    []vcsFact // labeled metadata rows (pipeline Branch/Status/Duration/Jobs); "" omits the FactSet
+	quote    string    // comment snippet; "" omits it; rendered in an emphasis Container
+	url      string    // Action.OpenUrl target (already http(s)-validated); "" omits the button
+}
+
+// vcsFact is one FactSet row (title/value already-safe markdown; the assembler does
+// not re-escape).
+type vcsFact struct {
+	title string
+	value string
+}
+
+// card assembles the octo/v1 AdaptiveCard object (the value that becomes req.Card;
+// handlePush's msgTypeCard branch wraps it in the type-17 envelope and runs
+// cardmsg.Validate/Finalize). Uses only whitelisted elements: TextBlock, Container,
+// ActionSet(Action.OpenUrl).
+func (d vcsCardData) card(lang string) map[string]interface{} {
+	headline := map[string]interface{}{
+		"type": "TextBlock", "text": d.headline, "weight": "Bolder", "wrap": true,
+	}
+	if d.status != "" {
+		headline["color"] = d.status
+	}
+	body := []interface{}{headline}
+	if d.subtitle != "" {
+		body = append(body, map[string]interface{}{
+			"type": "TextBlock", "text": d.subtitle, "isSubtle": true, "spacing": "None", "wrap": true,
+		})
+	}
+	for _, ln := range d.lines {
+		if ln == "" {
+			continue
+		}
+		body = append(body, map[string]interface{}{
+			"type": "TextBlock", "text": ln, "wrap": true, "spacing": "Small",
+		})
+	}
+	if len(d.facts) > 0 {
+		facts := make([]interface{}, 0, len(d.facts))
+		for _, f := range d.facts {
+			facts = append(facts, map[string]interface{}{"title": f.title, "value": f.value})
+		}
+		body = append(body, map[string]interface{}{"type": "FactSet", "facts": facts})
+	}
+	if d.quote != "" {
+		body = append(body, map[string]interface{}{
+			"type": "Container", "style": "emphasis",
+			"items": []interface{}{
+				map[string]interface{}{"type": "TextBlock", "text": d.quote, "wrap": true, "isSubtle": true},
+			},
+		})
+	}
+	metaOcto := map[string]interface{}{"source": map[string]interface{}{"label": d.source}}
+	if d.variant != "" {
+		metaOcto["variant"] = d.variant
+	}
+	metadata := map[string]interface{}{"octo": metaOcto}
+	card := map[string]interface{}{
+		"type":     "AdaptiveCard",
+		"version":  cardmsg.CardVersion,
+		"metadata": metadata,
+		"body":     body,
+	}
+	if d.url != "" {
+		metadata["webUrl"] = d.url
+		card["actions"] = []interface{}{
+			map[string]interface{}{
+				"type": "Action.OpenUrl", "title": vcsViewLabel(d.source, lang), "url": d.url,
+			},
+		}
+	}
+	return card
+}
+
+// vcsViewLabel localizes the "View on {GitHub|GitLab}" action title via the
+// deployment outbound language (a content label, not an errcode — same discipline as
+// modules/notify / pkg/cardtmpl label sets).
+func vcsViewLabel(source, lang string) string {
+	if isZhLang(lang) {
+		return "在 " + source + " 查看"
+	}
+	return "View on " + source
+}
+
+func isZhLang(lang string) bool {
+	return strings.EqualFold(lang, "zh-CN") || strings.HasPrefix(strings.ToLower(lang), "zh")
+}
+
+// validateVCSCard runs the authoritative cardmsg.Validate over a minimal type-17
+// envelope wrapping card, so a server-built card that is (via a bug) malformed is
+// caught HERE and degraded to text — never surfaced as a 400. Envelope-only fields
+// (from / space_id) are not needed by Validate (it checks structure / URL / size).
+func validateVCSCard(card map[string]interface{}) error {
+	return cardmsg.Validate(map[string]interface{}{
+		"type":         cardmsg.InteractiveCard.Int(),
+		"card":         card,
+		"card_version": cardmsg.CardVersion,
+		"profile":      cardmsg.ProfileV1,
+	})
+}
+
+// vcsPushReq picks the pushPayloadReq for a rendered VCS event: a card request when a
+// card was built (flag on) AND it self-validates, else the text request (the degrade
+// path — flag off OR card build/validate failure). Card plain is derived by Finalize
+// from the card body, so no text seed is needed.
+func vcsPushReq(text string, card map[string]interface{}) *pushPayloadReq {
+	if card != nil && validateVCSCard(card) == nil {
+		return &pushPayloadReq{MsgType: msgTypeCard, Card: card}
+	}
+	return &pushPayloadReq{Content: clipRunes(text, maxContentRunes())}
+}
+
+// maxRenderedJobs bounds how many pipeline job names the "Jobs (N)" fact lists
+// before eliding — the (N) count still reflects the true total.
+const maxRenderedJobs = 8
+
+// pipelineLabels are the localized FactSet titles for the pipeline card.
+type pipelineLabels struct {
+	branch, status, duration, jobs string
+}
+
+func pipelineLabelsFor(lang string) pipelineLabels {
+	if isZhLang(lang) {
+		return pipelineLabels{branch: "分支", status: "状态", duration: "耗时", jobs: "任务"}
+	}
+	return pipelineLabels{branch: "Branch", status: "Status", duration: "Duration", jobs: "Jobs"}
+}
+
+// formatPipelineDuration renders a pipeline elapsed time (seconds) as a compact,
+// language-neutral "1h 2m" / "3m 42s" / "42s". <= 0 (missing / null) → "".
+func formatPipelineDuration(sec int) string {
+	if sec <= 0 {
+		return ""
+	}
+	h := sec / 3600
+	m := (sec % 3600) / 60
+	s := sec % 60
+	switch {
+	case h > 0:
+		return fmt.Sprintf("%dh %dm", h, m)
+	case m > 0:
+		return fmt.Sprintf("%dm %ds", m, s)
+	default:
+		return fmt.Sprintf("%ds", s)
+	}
+}
+
+// pipelineStatusColor maps a GitLab terminal pipeline status to an AC TextBlock
+// color so the headline reads at a glance (success green / failed red / canceled
+// amber). Unknown → "" (default color).
+func pipelineStatusColor(status string) string {
+	switch status {
+	case "success":
+		return "Good"
+	case "failed":
+		return "Attention"
+	case "canceled":
+		return "Warning"
+	}
+	return ""
+}
+
+// joinShaMsg composes a "`sha` message" body line, trimming to avoid a leading space
+// when the sha code span is empty.
+func joinShaMsg(sha, msg string) string {
+	return strings.TrimSpace(sha + " " + msg)
+}
+
+// numberedTitle composes a "<mark>N · <title>" body line (e.g. "#1234 · Add cards"),
+// with the external title escaped. mark is a safe literal ("#" for issues/PRs,
+// "!" for GitLab MRs).
+func numberedTitle(mark string, number int, title string) string {
+	t := escapeCardText(title, cardTitleMax)
+	if t == "" {
+		return fmt.Sprintf("%s%d", mark, number)
+	}
+	return fmt.Sprintf("%s%d · %s", mark, number, t)
+}

--- a/modules/incomingwebhook/adapter_card_test.go
+++ b/modules/incomingwebhook/adapter_card_test.go
@@ -1,6 +1,7 @@
 package incomingwebhook
 
 import (
+	"encoding/json"
 	"net/http"
 	"strings"
 	"testing"
@@ -9,6 +10,36 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// The card builders take the already-parsed *ev (parse unmarshals once); these
+// helpers unmarshal a JSON fixture and build, keeping the tests fixture-driven.
+func ghPushCardFrom(t *testing.T, body string) map[string]interface{} {
+	t.Helper()
+	var ev ghPushEvent
+	require.NoError(t, json.Unmarshal([]byte(body), &ev))
+	return buildGitHubPushCard(&ev, "en-US")
+}
+
+func ghIssueCommentCardFrom(t *testing.T, body string) map[string]interface{} {
+	t.Helper()
+	var ev ghIssueCommentEvent
+	require.NoError(t, json.Unmarshal([]byte(body), &ev))
+	return buildGitHubIssueCommentCard(&ev, "en-US")
+}
+
+func glPushCardFrom(t *testing.T, body string) map[string]interface{} {
+	t.Helper()
+	var ev glPushEvent
+	require.NoError(t, json.Unmarshal([]byte(body), &ev))
+	return buildGitLabPushCard(&ev, "en-US")
+}
+
+func glPipelineCardFrom(t *testing.T, body string) map[string]interface{} {
+	t.Helper()
+	var ev glPipelineEvent
+	require.NoError(t, json.Unmarshal([]byte(body), &ev))
+	return buildGitLabPipelineCard(&ev, "en-US")
+}
 
 // Card-path unit tests for the github/gitlab adapters (card-message
 // webhook-cardmsg-adapter). No DB/Redis/IM: the builders are pure translation and
@@ -61,7 +92,7 @@ func cardOpenURL(card map[string]interface{}) (url, title string) {
 func cardActionURL(card map[string]interface{}) string { u, _ := cardOpenURL(card); return u }
 
 func TestBuildGitHubPushCard(t *testing.T) {
-	body := []byte(`{
+	card := ghPushCardFrom(t, `{
 		"ref": "refs/heads/main",
 		"compare": "https://github.com/octo/repo/compare/aaaa...bbbb",
 		"commits": [
@@ -71,7 +102,6 @@ func TestBuildGitHubPushCard(t *testing.T) {
 		"repository": {"full_name": "octo/repo", "html_url": "https://github.com/octo/repo"},
 		"sender": {"login": "alice"}
 	}`)
-	card := buildGitHubPushCard(body, "en-US")
 	require.NotNil(t, card)
 	// Authoritative gate: the produced card is a valid octo/v1 card.
 	require.NoError(t, validateVCSCard(card), "server-built card must pass cardmsg.Validate")
@@ -93,7 +123,7 @@ func TestBuildGitHubPushCard(t *testing.T) {
 }
 
 func TestBuildGitLabPipelineCard_StatusColor(t *testing.T) {
-	body := []byte(`{
+	card := glPipelineCardFrom(t, `{
 		"object_attributes": {"id": 4567, "ref": "test", "status": "success", "duration": 446},
 		"user": {"username": "bob"},
 		"project": {"path_with_namespace": "grp/app", "web_url": "https://gitlab.com/grp/app"},
@@ -105,7 +135,6 @@ func TestBuildGitLabPipelineCard_StatusColor(t *testing.T) {
 			{"name": "deploy", "status": "success"}
 		]
 	}`)
-	card := buildGitLabPipelineCard(body, "en-US")
 	require.NotNil(t, card)
 	require.NoError(t, validateVCSCard(card))
 
@@ -121,7 +150,7 @@ func TestBuildGitLabPipelineCard_StatusColor(t *testing.T) {
 	assert.Equal(t, "https://gitlab.com/grp/app/-/pipelines/4567", cardActionURL(card))
 
 	// Non-terminal status → no card (degrades to text/skip upstream).
-	assert.Nil(t, buildGitLabPipelineCard([]byte(`{"object_attributes":{"status":"running"}}`), "en-US"))
+	assert.Nil(t, glPipelineCardFrom(t, `{"object_attributes":{"status":"running"}}`))
 }
 
 func TestFormatPipelineDuration(t *testing.T) {
@@ -137,13 +166,13 @@ func TestFormatPipelineDuration(t *testing.T) {
 // for BOTH github and gitlab with the same assertions.
 func TestVCSCard_TrustBoundary(t *testing.T) {
 	// A commit message that tries to inject a link + bold, and a hostile repo URL.
-	ghBody := []byte(`{
+	ghCard := ghPushCardFrom(t, `{
 		"ref": "refs/heads/main",
 		"commits": [{"id":"0badc0de","message":"[click](javascript:alert(1)) **not bold** ]break[","url":"u"}],
 		"repository": {"full_name": "a]b*c/repo", "html_url": "javascript:alert(1)"},
 		"sender": {"login": "mallory"}
 	}`)
-	glBody := []byte(`{
+	glCard := glPushCardFrom(t, `{
 		"ref": "refs/heads/main",
 		"commits": [{"id":"0badc0de","message":"[click](javascript:alert(1)) **not bold** ]break["}],
 		"user": {"name": "m]a*l"},
@@ -154,8 +183,8 @@ func TestVCSCard_TrustBoundary(t *testing.T) {
 		name string
 		card map[string]interface{}
 	}{
-		{"github", buildGitHubPushCard(ghBody, "en-US")},
-		{"gitlab", buildGitLabPushCard(glBody, "en-US")},
+		{"github", ghCard},
+		{"gitlab", glCard},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			require.NotNil(t, tc.card)
@@ -183,6 +212,54 @@ func TestVCSCard_TrustBoundary(t *testing.T) {
 	}
 }
 
+func TestNeutralizeLeadingBlockMarker(t *testing.T) {
+	// Leading bullet / ordered / thematic-break markers are neutralized.
+	assert.Equal(t, `\- rm -rf`, neutralizeLeadingBlockMarker("- rm -rf"))
+	assert.Equal(t, `\+ item`, neutralizeLeadingBlockMarker("+ item"))
+	assert.Equal(t, `\---`, neutralizeLeadingBlockMarker("---"))
+	assert.Equal(t, `1\. Deploy`, neutralizeLeadingBlockMarker("1. Deploy"))
+	assert.Equal(t, `12\. x`, neutralizeLeadingBlockMarker("12. x"))
+	// Non-markers and already-escaped leads are untouched.
+	assert.Equal(t, "alice pushed", neutralizeLeadingBlockMarker("alice pushed"))
+	assert.Equal(t, `\[x`, neutralizeLeadingBlockMarker(`\[x`))
+	assert.Equal(t, "1.5 rating", neutralizeLeadingBlockMarker("1.5 rating"), "ordered marker needs whitespace/end after the dot")
+	assert.Equal(t, "", neutralizeLeadingBlockMarker(""))
+}
+
+// TestVCSCard_ListMarkerNeutralized proves the trust-boundary defense for BLOCK
+// markdown: attacker-controlled text at a TextBlock line start (issue-comment body →
+// quote; GitLab display-name fallback → headline) cannot open a bullet/ordered list.
+func TestVCSCard_ListMarkerNeutralized(t *testing.T) {
+	t.Run("github issue_comment quote", func(t *testing.T) {
+		card := ghIssueCommentCardFrom(t, `{
+			"action":"created",
+			"issue":{"number":7,"title":"t","html_url":"h"},
+			"comment":{"html_url":"https://github.com/o/r/issues/7#c1","body":"1. Deploy approved now"},
+			"repository":{"full_name":"o/r"},"sender":{"login":"mallory"}}`)
+		require.NotNil(t, card)
+		require.NoError(t, validateVCSCard(card))
+		leaves := cardBodyText(card)
+		assert.Contains(t, leaves, `1\. Deploy approved now`, "leading ordered marker must be escaped so the quote can't become a numbered list")
+		assert.NotContains(t, leaves, "\n1. ", "no live ordered-list marker at a leaf line start")
+		// The comment content is preserved in the authoritative plain (search/quote).
+		assert.Contains(t, cardmsg.BuildPlain(card), "Deploy approved now")
+	})
+
+	t.Run("gitlab display-name headline", func(t *testing.T) {
+		// username absent → free-text user_name fallback lands at the headline line start.
+		card := glPushCardFrom(t, `{
+			"ref":"refs/heads/main",
+			"commits":[{"id":"abc1234","message":"m","url":"u"}],
+			"user_name":"- Security Team",
+			"project":{"path_with_namespace":"o/r","web_url":"https://gitlab.com/o/r"}}`)
+		require.NotNil(t, card)
+		require.NoError(t, validateVCSCard(card))
+		headline := card["body"].([]interface{})[0].(map[string]interface{})["text"].(string)
+		assert.True(t, strings.HasPrefix(headline, `\- Security Team`),
+			"a display name starting with '- ' must not open a bullet list in the headline; got %q", headline)
+	})
+}
+
 // TestVCSPushReq_Degrade covers the degrade contract: nil card or a card that fails
 // self-validation falls back to the text payload (never a card request / 400).
 func TestVCSPushReq_Degrade(t *testing.T) {
@@ -206,7 +283,7 @@ func TestVCSPushReq_Degrade(t *testing.T) {
 	})
 
 	t.Run("valid card → card path", func(t *testing.T) {
-		good := buildGitHubPushCard([]byte(`{"ref":"refs/heads/main","commits":[{"id":"abc1234","message":"m","url":"u"}],"repository":{"full_name":"o/r","html_url":"https://github.com/o/r"},"sender":{"login":"a"}}`), "en-US")
+		good := ghPushCardFrom(t, `{"ref":"refs/heads/main","commits":[{"id":"abc1234","message":"m","url":"u"}],"repository":{"full_name":"o/r","html_url":"https://github.com/o/r"},"sender":{"login":"a"}}`)
 		require.NotNil(t, good)
 		req := vcsPushReq("fallback text", good)
 		assert.Equal(t, msgTypeCard, req.MsgType)

--- a/modules/incomingwebhook/adapter_card_test.go
+++ b/modules/incomingwebhook/adapter_card_test.go
@@ -380,6 +380,41 @@ func TestVCSParse_FlagGate(t *testing.T) {
 	})
 }
 
+// TestBuildCardPayload_AdapterEnvelope locks the full production envelope path: an
+// adapter-produced req.Card fed through buildCardPayload must yield a type-17 payload
+// with server-pinned card_version/profile, a from.kind=webhook identity carrying the
+// webhook_id + configured name, the server-derived space_id, and a non-placeholder
+// authoritative plain derived by Finalize (PR #596 review, Jerry-Xin).
+func TestBuildCardPayload_AdapterEnvelope(t *testing.T) {
+	t.Setenv(cardmsg.EnvEnabled, "1")
+	card := ghPushCardFrom(t, `{
+		"ref":"refs/heads/main",
+		"commits":[{"id":"abc1234","message":"fix: guard nil","url":"https://github.com/o/r/commit/abc1234"}],
+		"repository":{"full_name":"o/r","html_url":"https://github.com/o/r"},
+		"sender":{"login":"alice"}}`)
+	require.NotNil(t, card)
+
+	m := &incomingWebhookModel{WebhookID: "iwh_abc", SpaceID: "sp_1", Name: "CI Bot"}
+	payload, err := buildCardPayload(m, &pushPayloadReq{MsgType: msgTypeCard, Card: card}, false)
+	require.NoError(t, err)
+
+	assert.Equal(t, cardmsg.InteractiveCard.Int(), payload["type"])
+	assert.Equal(t, cardmsg.CardVersion, payload["card_version"])
+	assert.Equal(t, cardmsg.ProfileV1, payload["profile"])
+	assert.Equal(t, "sp_1", payload["space_id"], "space_id is server-derived from the webhook row")
+
+	from, _ := payload["from"].(map[string]interface{})
+	require.NotNil(t, from)
+	assert.Equal(t, extraKindValue, from["kind"])
+	assert.Equal(t, "iwh_abc", from["webhook_id"])
+	assert.Equal(t, "CI Bot", from["name"])
+
+	plain, _ := payload["plain"].(string)
+	assert.NotEmpty(t, plain, "Finalize derives an authoritative plain")
+	assert.NotEqual(t, cardmsg.PlaceholderCard, plain, "plain comes from the card body, not the [卡片] fallback")
+	assert.Contains(t, plain, "pushed")
+}
+
 func TestVCSViewLabel(t *testing.T) {
 	assert.Equal(t, "View on GitHub", vcsViewLabel(cardSourceGitHub, "en-US"))
 	assert.Equal(t, "在 GitHub 查看", vcsViewLabel(cardSourceGitHub, "zh-CN"))

--- a/modules/incomingwebhook/adapter_card_test.go
+++ b/modules/incomingwebhook/adapter_card_test.go
@@ -1,0 +1,261 @@
+package incomingwebhook
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardmsg"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Card-path unit tests for the github/gitlab adapters (card-message
+// webhook-cardmsg-adapter). No DB/Redis/IM: the builders are pure translation and
+// cardmsg.Validate/BuildPlain are the authoritative gates exercised directly.
+
+// cardBodyText concatenates every rendered TextBlock leaf (recursing into
+// Container.items) so a test can assert what a leaf carries. It is the render-facing
+// counterpart to cardmsg.BuildPlain (which strips markdown); here we keep the raw
+// leaf text to prove escaping happened.
+func cardBodyText(card map[string]interface{}) string {
+	var b strings.Builder
+	var walk func(items []interface{})
+	walk = func(items []interface{}) {
+		for _, it := range items {
+			el, _ := it.(map[string]interface{})
+			if el == nil {
+				continue
+			}
+			if el["type"] == "TextBlock" {
+				if s, _ := el["text"].(string); s != "" {
+					b.WriteString(s)
+					b.WriteByte('\n')
+				}
+			}
+			if sub, ok := el["items"].([]interface{}); ok {
+				walk(sub)
+			}
+		}
+	}
+	if body, ok := card["body"].([]interface{}); ok {
+		walk(body)
+	}
+	return b.String()
+}
+
+// cardOpenURL returns the first Action.OpenUrl (url, title) on the card, or "","".
+func cardOpenURL(card map[string]interface{}) (url, title string) {
+	acts, _ := card["actions"].([]interface{})
+	for _, a := range acts {
+		act, _ := a.(map[string]interface{})
+		if act != nil && act["type"] == "Action.OpenUrl" {
+			u, _ := act["url"].(string)
+			t, _ := act["title"].(string)
+			return u, t
+		}
+	}
+	return "", ""
+}
+
+func cardActionURL(card map[string]interface{}) string { u, _ := cardOpenURL(card); return u }
+
+func TestBuildGitHubPushCard(t *testing.T) {
+	body := []byte(`{
+		"ref": "refs/heads/main",
+		"compare": "https://github.com/octo/repo/compare/aaaa...bbbb",
+		"commits": [
+			{"id": "aaaabbbbccccdddd", "message": "feat: first\n\nbody", "url": "https://github.com/o/r/commit/aaaabbbb"},
+			{"id": "1111222233334444", "message": "fix: second", "url": "https://github.com/o/r/commit/11112222"}
+		],
+		"repository": {"full_name": "octo/repo", "html_url": "https://github.com/octo/repo"},
+		"sender": {"login": "alice"}
+	}`)
+	card := buildGitHubPushCard(body, "en-US")
+	require.NotNil(t, card)
+	// Authoritative gate: the produced card is a valid octo/v1 card.
+	require.NoError(t, validateVCSCard(card), "server-built card must pass cardmsg.Validate")
+
+	assert.Equal(t, "AdaptiveCard", card["type"])
+	assert.Equal(t, cardmsg.CardVersion, card["version"])
+
+	plain := cardmsg.BuildPlain(card)
+	assert.Contains(t, plain, "alice pushed 2 commit(s) to main")
+	assert.Contains(t, plain, "octo/repo")
+	assert.Contains(t, plain, "aaaabbb feat: first", "first commit: short sha + first message line")
+	assert.Contains(t, plain, "1111222 fix: second")
+	assert.NotContains(t, plain, "body", "only the first line of a commit message is rendered")
+
+	// Prefer the compare URL for the View action, with the localized title.
+	url, title := cardOpenURL(card)
+	assert.Equal(t, "https://github.com/octo/repo/compare/aaaa...bbbb", url)
+	assert.Equal(t, "View on GitHub", title)
+}
+
+func TestBuildGitLabPipelineCard_StatusColor(t *testing.T) {
+	body := []byte(`{
+		"object_attributes": {"id": 4567, "ref": "test", "status": "success", "duration": 446},
+		"user": {"username": "bob"},
+		"project": {"path_with_namespace": "grp/app", "web_url": "https://gitlab.com/grp/app"},
+		"builds": [
+			{"name": "build", "status": "success"},
+			{"name": "unit", "status": "success"},
+			{"name": "lint", "status": "success"},
+			{"name": "e2e", "status": "success"},
+			{"name": "deploy", "status": "success"}
+		]
+	}`)
+	card := buildGitLabPipelineCard(body, "en-US")
+	require.NotNil(t, card)
+	require.NoError(t, validateVCSCard(card))
+
+	// success → headline TextBlock carries color=Good; status word lives in the FactSet.
+	body0 := card["body"].([]interface{})[0].(map[string]interface{})
+	assert.Equal(t, "Good", body0["color"])
+	plain := cardmsg.BuildPlain(card)
+	assert.Contains(t, plain, "Pipeline #4567")
+	assert.Contains(t, plain, "Branch: test")
+	assert.Contains(t, plain, "Status: success")
+	assert.Contains(t, plain, "Duration: 7m 26s", "446s → 7m 26s")
+	assert.Contains(t, plain, "Jobs (5): build / unit / lint / e2e / deploy")
+	assert.Equal(t, "https://gitlab.com/grp/app/-/pipelines/4567", cardActionURL(card))
+
+	// Non-terminal status → no card (degrades to text/skip upstream).
+	assert.Nil(t, buildGitLabPipelineCard([]byte(`{"object_attributes":{"status":"running"}}`), "en-US"))
+}
+
+func TestFormatPipelineDuration(t *testing.T) {
+	assert.Equal(t, "", formatPipelineDuration(0))
+	assert.Equal(t, "42s", formatPipelineDuration(42))
+	assert.Equal(t, "7m 26s", formatPipelineDuration(446))
+	assert.Equal(t, "1h 2m", formatPipelineDuration(3720))
+}
+
+// TestVCSCard_TrustBoundary is the parity gate: a hostile actor / title / commit
+// message / URL from either platform must (a) render literally in the card leaf (no
+// emphasis/link breakout) and (b) never produce a non-http(s) actionable URL. Proven
+// for BOTH github and gitlab with the same assertions.
+func TestVCSCard_TrustBoundary(t *testing.T) {
+	// A commit message that tries to inject a link + bold, and a hostile repo URL.
+	ghBody := []byte(`{
+		"ref": "refs/heads/main",
+		"commits": [{"id":"0badc0de","message":"[click](javascript:alert(1)) **not bold** ]break[","url":"u"}],
+		"repository": {"full_name": "a]b*c/repo", "html_url": "javascript:alert(1)"},
+		"sender": {"login": "mallory"}
+	}`)
+	glBody := []byte(`{
+		"ref": "refs/heads/main",
+		"commits": [{"id":"0badc0de","message":"[click](javascript:alert(1)) **not bold** ]break["}],
+		"user": {"name": "m]a*l"},
+		"project": {"path_with_namespace": "a]b*c/repo", "web_url": "javascript:alert(1)"}
+	}`)
+
+	for _, tc := range []struct {
+		name string
+		card map[string]interface{}
+	}{
+		{"github", buildGitHubPushCard(ghBody, "en-US")},
+		{"gitlab", buildGitLabPushCard(glBody, "en-US")},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.NotNil(t, tc.card)
+			// The authoritative gate passing IS the proof no unescaped javascript: link
+			// or forbidden element leaked — Validate walks every markdown link target
+			// through the positive http(s) allowlist.
+			require.NoError(t, validateVCSCard(tc.card))
+
+			leaves := cardBodyText(tc.card)
+			// The hostile markup is escaped: brackets/parens/asterisks are backslash-escaped,
+			// so no live link or emphasis is formed.
+			assert.Contains(t, leaves, `\[click\]\(javascript:alert\(1\)\)`,
+				"link syntax must be escaped to render literally")
+			assert.Contains(t, leaves, `\*\*not bold\*\*`, "bold syntax must be escaped")
+			assert.NotContains(t, leaves, "](javascript:", "no live markdown link may survive")
+
+			// The hostile repo URL is not http(s) → button omitted, never an actionable
+			// javascript: URL.
+			assert.NotContains(t, cardActionURL(tc.card), "javascript:")
+			assert.Empty(t, cardActionURL(tc.card), "non-http(s) repo url → no View button")
+
+			// Derived plain shows the literal text (defense visible to search/quote too).
+			assert.Contains(t, cardmsg.BuildPlain(tc.card), "not bold")
+		})
+	}
+}
+
+// TestVCSPushReq_Degrade covers the degrade contract: nil card or a card that fails
+// self-validation falls back to the text payload (never a card request / 400).
+func TestVCSPushReq_Degrade(t *testing.T) {
+	text := "**alice** pushed 1 commit(s) to `main`"
+
+	t.Run("nil card → text", func(t *testing.T) {
+		req := vcsPushReq(text, nil)
+		assert.Empty(t, req.MsgType)
+		assert.Equal(t, text, req.Content)
+	})
+
+	t.Run("invalid card → text (degrade, not 400)", func(t *testing.T) {
+		bad := map[string]interface{}{
+			"type": "AdaptiveCard", "version": cardmsg.CardVersion,
+			"body": []interface{}{map[string]interface{}{"type": "Bogus"}}, // not whitelisted
+		}
+		require.Error(t, validateVCSCard(bad), "precondition: card is invalid")
+		req := vcsPushReq(text, bad)
+		assert.Empty(t, req.MsgType, "an invalid card must not reach the card path")
+		assert.Equal(t, text, req.Content)
+	})
+
+	t.Run("valid card → card path", func(t *testing.T) {
+		good := buildGitHubPushCard([]byte(`{"ref":"refs/heads/main","commits":[{"id":"abc1234","message":"m","url":"u"}],"repository":{"full_name":"o/r","html_url":"https://github.com/o/r"},"sender":{"login":"a"}}`), "en-US")
+		require.NotNil(t, good)
+		req := vcsPushReq("fallback text", good)
+		assert.Equal(t, msgTypeCard, req.MsgType)
+		assert.NotNil(t, req.Card)
+		assert.Empty(t, req.Content, "card path does not set text content")
+	})
+}
+
+// TestVCSParse_FlagGate covers the top-level dispatch: with the flag off the adapter
+// emits the historical text path (MsgType empty); with the flag on it emits a card.
+func TestVCSParse_FlagGate(t *testing.T) {
+	ghPush := []byte(`{"ref":"refs/heads/main","commits":[{"id":"abc1234","message":"m","url":"u"}],"repository":{"full_name":"o/r","html_url":"https://github.com/o/r"},"sender":{"login":"a"}}`)
+	glMR := []byte(`{"object_attributes":{"iid":42,"title":"Refactor","url":"https://gitlab.com/o/r/-/merge_requests/42","action":"open"},"user":{"username":"a"},"project":{"path_with_namespace":"o/r","web_url":"https://gitlab.com/o/r"}}`)
+
+	t.Run("flag off → text", func(t *testing.T) {
+		t.Setenv(cardmsg.EnvEnabled, "")
+		req, _, _ := parseGitHubPush(ghHeader("push"), ghPush)
+		require.NotNil(t, req)
+		assert.Empty(t, req.MsgType)
+		assert.NotEmpty(t, req.Content)
+	})
+
+	t.Run("flag on → card (github + gitlab)", func(t *testing.T) {
+		t.Setenv(cardmsg.EnvEnabled, "1")
+
+		req, skip, invalid := parseGitHubPush(ghHeader("push"), ghPush)
+		require.NotNil(t, req, "skip=%q invalid=%q", skip, invalid)
+		assert.Equal(t, msgTypeCard, req.MsgType)
+		require.NoError(t, validateVCSCard(req.Card))
+
+		req2, skip2, invalid2 := parseGitLabPush(glHeader("Merge Request Hook"), glMR)
+		require.NotNil(t, req2, "skip=%q invalid=%q", skip2, invalid2)
+		assert.Equal(t, msgTypeCard, req2.MsgType)
+		require.NoError(t, validateVCSCard(req2.Card))
+	})
+
+	t.Run("flag on but skip/no_event unchanged", func(t *testing.T) {
+		t.Setenv(cardmsg.EnvEnabled, "1")
+		// missing event header → still no_event
+		_, _, invalid := parseGitHubPush(http.Header{}, []byte(`{}`))
+		assert.Equal(t, "no_event", invalid)
+		// subset-outside action → still skip
+		_, skip, _ := parseGitHubPush(ghHeader("pull_request"), []byte(`{"action":"synchronize"}`))
+		assert.Equal(t, "event", skip)
+	})
+}
+
+func TestVCSViewLabel(t *testing.T) {
+	assert.Equal(t, "View on GitHub", vcsViewLabel(cardSourceGitHub, "en-US"))
+	assert.Equal(t, "在 GitHub 查看", vcsViewLabel(cardSourceGitHub, "zh-CN"))
+	assert.Equal(t, "在 GitLab 查看", vcsViewLabel(cardSourceGitLab, "zh-Hans"))
+}

--- a/modules/incomingwebhook/adapter_card_test.go
+++ b/modules/incomingwebhook/adapter_card_test.go
@@ -158,6 +158,55 @@ func TestFormatPipelineDuration(t *testing.T) {
 	assert.Equal(t, "42s", formatPipelineDuration(42))
 	assert.Equal(t, "7m 26s", formatPipelineDuration(446))
 	assert.Equal(t, "1h 2m", formatPipelineDuration(3720))
+	// A hostile/absurd external duration is clamped, not rendered as "277777777h …".
+	assert.Equal(t, "100h 0m", formatPipelineDuration(1_000_000_000))
+}
+
+// TestAllVCSCardBuilders_Smoke exercises every event-specific builder (the ones only
+// indirectly covered elsewhere: GitHub PR/issues/release, GitLab tag/note) so a
+// regression in any one is caught: card is non-nil, passes the authoritative
+// validator, derives non-empty plain, and carries the expected headline.
+func TestAllVCSCardBuilders_Smoke(t *testing.T) {
+	cases := []struct {
+		name     string
+		build    func(t *testing.T) map[string]interface{}
+		headline string
+	}{
+		{"gh pull_request opened", func(t *testing.T) map[string]interface{} {
+			var ev ghPullRequestEvent
+			require.NoError(t, json.Unmarshal([]byte(`{"action":"opened","pull_request":{"number":9,"title":"Add cards","html_url":"https://github.com/o/r/pull/9"},"repository":{"full_name":"o/r"},"sender":{"login":"alice"}}`), &ev))
+			return buildGitHubPullRequestCard(&ev, "en-US")
+		}, "alice opened a pull request"},
+		{"gh issues closed", func(t *testing.T) map[string]interface{} {
+			var ev ghIssuesEvent
+			require.NoError(t, json.Unmarshal([]byte(`{"action":"closed","issue":{"number":3,"title":"Bug","html_url":"https://github.com/o/r/issues/3"},"repository":{"full_name":"o/r"},"sender":{"login":"bob"}}`), &ev))
+			return buildGitHubIssuesCard(&ev, "en-US")
+		}, "bob closed an issue"},
+		{"gh release published", func(t *testing.T) map[string]interface{} {
+			var ev ghReleaseEvent
+			require.NoError(t, json.Unmarshal([]byte(`{"action":"published","release":{"tag_name":"v1.2.0","name":"v1.2.0","html_url":"https://github.com/o/r/releases/v1.2.0"},"repository":{"full_name":"o/r"},"sender":{"login":"carol"}}`), &ev))
+			return buildGitHubReleaseCard(&ev, "en-US")
+		}, "carol published a release"},
+		{"gl tag push", func(t *testing.T) map[string]interface{} {
+			var ev glPushEvent
+			require.NoError(t, json.Unmarshal([]byte(`{"ref":"refs/tags/v2.0.0","after":"abc123","user_username":"dave","project":{"path_with_namespace":"o/r","web_url":"https://gitlab.com/o/r"}}`), &ev))
+			return buildGitLabTagPushCard(&ev, "en-US")
+		}, "dave pushed tag"},
+		{"gl note on MR", func(t *testing.T) map[string]interface{} {
+			var ev glNoteEvent
+			require.NoError(t, json.Unmarshal([]byte(`{"user":{"username":"erin"},"object_attributes":{"note":"lgtm","noteable_type":"MergeRequest","url":"https://gitlab.com/o/r/-/merge_requests/5#note_1"},"merge_request":{"iid":5,"title":"Refactor"},"project":{"path_with_namespace":"o/r","web_url":"https://gitlab.com/o/r"}}`), &ev))
+			return buildGitLabNoteCard(&ev, "en-US")
+		}, "erin commented"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			card := c.build(t)
+			require.NotNil(t, card)
+			require.NoError(t, validateVCSCard(card), "server-built card must pass cardmsg.Validate")
+			assert.NotEmpty(t, cardmsg.BuildPlain(card))
+			assert.Contains(t, cardBodyText(card), c.headline)
+		})
+	}
 }
 
 // TestVCSCard_TrustBoundary is the parity gate: a hostile actor / title / commit

--- a/modules/incomingwebhook/adapter_github.go
+++ b/modules/incomingwebhook/adapter_github.go
@@ -18,12 +18,16 @@ package incomingwebhook
 // 所有 gh* 结构体只声明渲染需要的字段（白名单解析），其余 payload 字段一律忽略。
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
 	"os"
 	"strconv"
 	"strings"
+
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardmsg"
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
 )
 
 // 渲染的提交列表上限：push 事件单次最多带 20 个 commit（GitHub 截断），全列会刷屏。
@@ -73,13 +77,16 @@ type ghCommit struct {
 }
 
 type ghPushEvent struct {
-	Ref        string     `json:"ref"`
-	Created    bool       `json:"created"`
-	Deleted    bool       `json:"deleted"`
-	Forced     bool       `json:"forced"`
-	Commits    []ghCommit `json:"commits"`
-	Repository ghRepo     `json:"repository"`
-	Sender     ghUser     `json:"sender"`
+	Ref     string     `json:"ref"`
+	Created bool       `json:"created"`
+	Deleted bool       `json:"deleted"`
+	Forced  bool       `json:"forced"`
+	Commits []ghCommit `json:"commits"`
+	// Compare is GitHub's canonical diff URL for the push (card "View" target;
+	// unused by the text renderer). Falls back to the repo URL when absent.
+	Compare    string `json:"compare"`
+	Repository ghRepo `json:"repository"`
+	Sender     ghUser `json:"sender"`
 }
 
 type ghPullRequestEvent struct {
@@ -171,8 +178,15 @@ func parseGitHubPush(header http.Header, body []byte) (*pushPayloadReq, string, 
 		// 事件类型支持、但动作不在渲染子集内（synchronize / labeled / ...）：同上 skip。
 		return nil, "event", ""
 	}
-	// 事件体里的标题 / 提交信息长度不受我们控制：钳到语义上限内，绝不让平台流量 413。
-	return &pushPayloadReq{Content: clipRunes(content, maxContentRunes())}, "", ""
+	// card-message webhook-cardmsg-adapter：开关开时把同一事件渲成 InteractiveCard(=17)，
+	// 关闭（或卡片自校验失败）时 vcsPushReq 降级回上面的 markdown 文本路径——文本渲染器
+	// 保持原样，故 flag-off 的 content 字节与历史完全一致。事件体里的标题 / 提交信息长度
+	// 不受我们控制：文本路径钳到语义上限内（vcsPushReq 内），绝不让平台流量 413。
+	var card map[string]interface{}
+	if cardmsg.Enabled() {
+		card = buildGitHubEventCard(event, body, i18n.OutboundLanguage(context.Background()))
+	}
+	return vcsPushReq(content, card), "", ""
 }
 
 func renderGitHubPush(body []byte) (string, error) {
@@ -326,4 +340,196 @@ func ghShortSHA(sha string) string {
 		return sha[:7]
 	}
 	return sha
+}
+
+// ============================================================
+// Card rendering (card-message webhook-cardmsg-adapter)
+// ============================================================
+//
+// buildGitHubEventCard mirrors the text renderers' event/action decisions but emits
+// an octo/v1 card object (see adapter_card.go). It returns nil for any event/action
+// outside the rendered subset (the caller already handled skip via the text
+// renderer's empty content) or on a parse error — nil degrades to text via
+// vcsPushReq. It re-unmarshals the same gh* structs the text path uses; only one
+// path runs per request (flag on OR off), so there is no double-unmarshal at runtime.
+
+func buildGitHubEventCard(event string, body []byte, lang string) map[string]interface{} {
+	switch event {
+	case "push":
+		return buildGitHubPushCard(body, lang)
+	case "pull_request":
+		return buildGitHubPullRequestCard(body, lang)
+	case "issues":
+		return buildGitHubIssuesCard(body, lang)
+	case "issue_comment":
+		return buildGitHubIssueCommentCard(body, lang)
+	case "release":
+		return buildGitHubReleaseCard(body, lang)
+	}
+	return nil
+}
+
+// ghActorCard is ghLogin for the card path: escaped for a TextBlock leaf (a GitHub
+// login has a restricted charset, but escaping is harmless and keeps parity with the
+// free-text GitLab display name).
+func ghActorCard(u ghUser) string {
+	if u.Login == "" {
+		return "someone"
+	}
+	return escapeCardText(u.Login, cardActorMax)
+}
+
+// ghRepoURLCard prefers the push compare URL, else the repo HTML URL, each through
+// the http(s) allowlist ("" when neither is a valid absolute http(s) URL → button
+// omitted).
+func ghRepoURLCard(compare string, r ghRepo) string {
+	if u := httpURLForCard(compare); u != "" {
+		return u
+	}
+	return httpURLForCard(r.HTMLURL)
+}
+
+func buildGitHubPushCard(body []byte, lang string) map[string]interface{} {
+	var ev ghPushEvent
+	if err := json.Unmarshal(body, &ev); err != nil {
+		return nil
+	}
+	who := ghActorCard(ev.Sender)
+	ref := cardCodeSpan(ghShortRef(ev.Ref), cardRefMax)
+	d := vcsCardData{
+		source:   cardSourceGitHub,
+		variant:  "vcs.github.push",
+		subtitle: escapeCardText(ev.Repository.FullName, cardTitleMax),
+		url:      ghRepoURLCard(ev.Compare, ev.Repository),
+	}
+	switch {
+	case strings.HasPrefix(ev.Ref, "refs/tags/"):
+		if ev.Deleted {
+			d.headline = fmt.Sprintf("%s deleted tag %s", who, ref)
+		} else {
+			d.headline = fmt.Sprintf("%s pushed tag %s", who, ref)
+		}
+	case ev.Deleted:
+		d.headline = fmt.Sprintf("%s deleted branch %s", who, ref)
+	case ev.Created && len(ev.Commits) == 0:
+		d.headline = fmt.Sprintf("%s created branch %s", who, ref)
+	case len(ev.Commits) == 0:
+		// 退化 ref 更新（无提交、非建/删）：文本路径 skip，卡片同样不产出。
+		return nil
+	default:
+		verb := "pushed"
+		if ev.Forced {
+			verb = "force-pushed"
+		}
+		d.headline = fmt.Sprintf("%s %s %d commit(s) to %s", who, verb, len(ev.Commits), ref)
+		for i, cm := range ev.Commits {
+			if i == maxRenderedCommits {
+				d.lines = append(d.lines, fmt.Sprintf("…and %d more", len(ev.Commits)-maxRenderedCommits))
+				break
+			}
+			d.lines = append(d.lines, joinShaMsg(
+				cardCodeSpan(ghShortSHA(cm.ID), cardShaMax),
+				escapeCardText(firstLine(cm.Message), cardCommitMsgMax)))
+		}
+	}
+	return d.card(lang)
+}
+
+// ghPRVerbPhrase maps a pull_request action to a card headline verb phrase; ""
+// signals a subset-outside action (card not produced).
+func ghPRVerbPhrase(action string, merged bool) string {
+	switch action {
+	case "opened":
+		return "opened a pull request"
+	case "reopened":
+		return "reopened a pull request"
+	case "ready_for_review":
+		return "marked a pull request ready for review"
+	case "closed":
+		if merged {
+			return "merged a pull request"
+		}
+		return "closed a pull request"
+	}
+	return ""
+}
+
+func buildGitHubPullRequestCard(body []byte, lang string) map[string]interface{} {
+	var ev ghPullRequestEvent
+	if err := json.Unmarshal(body, &ev); err != nil {
+		return nil
+	}
+	phrase := ghPRVerbPhrase(ev.Action, ev.PullRequest.Merged)
+	if phrase == "" {
+		return nil
+	}
+	return vcsCardData{
+		source:   cardSourceGitHub,
+		variant:  "vcs.github.pull_request",
+		headline: fmt.Sprintf("%s %s", ghActorCard(ev.Sender), phrase),
+		subtitle: escapeCardText(ev.Repository.FullName, cardTitleMax),
+		lines:    []string{numberedTitle("#", ev.PullRequest.Number, ev.PullRequest.Title)},
+		url:      httpURLForCard(ev.PullRequest.HTMLURL),
+	}.card(lang)
+}
+
+func buildGitHubIssuesCard(body []byte, lang string) map[string]interface{} {
+	var ev ghIssuesEvent
+	if err := json.Unmarshal(body, &ev); err != nil {
+		return nil
+	}
+	switch ev.Action {
+	case "opened", "closed", "reopened":
+	default:
+		return nil
+	}
+	return vcsCardData{
+		source:   cardSourceGitHub,
+		variant:  "vcs.github.issues",
+		headline: fmt.Sprintf("%s %s an issue", ghActorCard(ev.Sender), ev.Action),
+		subtitle: escapeCardText(ev.Repository.FullName, cardTitleMax),
+		lines:    []string{numberedTitle("#", ev.Issue.Number, ev.Issue.Title)},
+		url:      httpURLForCard(ev.Issue.HTMLURL),
+	}.card(lang)
+}
+
+func buildGitHubIssueCommentCard(body []byte, lang string) map[string]interface{} {
+	var ev ghIssueCommentEvent
+	if err := json.Unmarshal(body, &ev); err != nil {
+		return nil
+	}
+	if ev.Action != "created" {
+		return nil
+	}
+	return vcsCardData{
+		source:   cardSourceGitHub,
+		variant:  "vcs.github.issue_comment",
+		headline: fmt.Sprintf("%s commented on an issue", ghActorCard(ev.Sender)),
+		subtitle: escapeCardText(ev.Repository.FullName, cardTitleMax),
+		lines:    []string{numberedTitle("#", ev.Issue.Number, ev.Issue.Title)},
+		quote:    escapeCardText(ev.Comment.Body, cardQuoteMax),
+		url:      httpURLForCard(ev.Comment.HTMLURL),
+	}.card(lang)
+}
+
+func buildGitHubReleaseCard(body []byte, lang string) map[string]interface{} {
+	var ev ghReleaseEvent
+	if err := json.Unmarshal(body, &ev); err != nil {
+		return nil
+	}
+	if ev.Action != "published" {
+		return nil
+	}
+	title := ev.Release.Name
+	if strings.TrimSpace(title) == "" {
+		title = ev.Release.TagName
+	}
+	return vcsCardData{
+		source:   cardSourceGitHub,
+		variant:  "vcs.github.release",
+		headline: fmt.Sprintf("%s published a release", ghActorCard(ev.Sender)),
+		subtitle: escapeCardText(ev.Repository.FullName, cardTitleMax),
+		lines:    []string{escapeCardText(title, cardTitleMax)},
+		url:      httpURLForCard(ev.Release.HTMLURL),
+	}.card(lang)
 }

--- a/modules/incomingwebhook/adapter_github.go
+++ b/modules/incomingwebhook/adapter_github.go
@@ -150,67 +150,100 @@ func parseGitHubPush(header http.Header, body []byte) (*pushPayloadReq, string, 
 		return nil, "", "no_event"
 	}
 
-	var content string
-	var err error
-	switch event {
-	case "ping":
+	if event == "ping" {
 		// GitHub 创建 webhook 时的连通性测试：200 即可，不发消息。
 		return nil, "ping", ""
+	}
+	// card-message webhook-cardmsg-adapter：开关开时把同一事件渲成 InteractiveCard(=17)，
+	// 关闭（或卡片自校验失败）时 vcsPushReq 降级回 markdown 文本路径（文本渲染器输出不变，
+	// flag-off 字节与历史一致）。body 每事件【只反序列化一次】，文本与卡片共用同一 *ev。
+	// 事件体里的标题 / 提交信息长度不受我们控制：文本路径钳到语义上限内（vcsPushReq 内）。
+	wantCard := cardmsg.Enabled()
+	lang := ""
+	if wantCard {
+		lang = i18n.OutboundLanguage(context.Background())
+	}
+	var content string
+	var card map[string]interface{}
+	switch event {
 	case "push":
-		content, err = renderGitHubPush(body)
+		var ev ghPushEvent
+		if err := json.Unmarshal(body, &ev); err != nil {
+			return nil, "", "json"
+		}
+		content = renderGitHubPush(&ev)
+		if content != "" && wantCard {
+			card = buildGitHubPushCard(&ev, lang)
+		}
 	case "pull_request":
-		content, err = renderGitHubPullRequest(body)
+		var ev ghPullRequestEvent
+		if err := json.Unmarshal(body, &ev); err != nil {
+			return nil, "", "json"
+		}
+		content = renderGitHubPullRequest(&ev)
+		if content != "" && wantCard {
+			card = buildGitHubPullRequestCard(&ev, lang)
+		}
 	case "issues":
-		content, err = renderGitHubIssues(body)
+		var ev ghIssuesEvent
+		if err := json.Unmarshal(body, &ev); err != nil {
+			return nil, "", "json"
+		}
+		content = renderGitHubIssues(&ev)
+		if content != "" && wantCard {
+			card = buildGitHubIssuesCard(&ev, lang)
+		}
 	case "issue_comment":
-		content, err = renderGitHubIssueComment(body)
+		var ev ghIssueCommentEvent
+		if err := json.Unmarshal(body, &ev); err != nil {
+			return nil, "", "json"
+		}
+		content = renderGitHubIssueComment(&ev)
+		if content != "" && wantCard {
+			card = buildGitHubIssueCommentCard(&ev, lang)
+		}
 	case "release":
-		content, err = renderGitHubRelease(body)
+		var ev ghReleaseEvent
+		if err := json.Unmarshal(body, &ev); err != nil {
+			return nil, "", "json"
+		}
+		content = renderGitHubRelease(&ev)
+		if content != "" && wantCard {
+			card = buildGitHubReleaseCard(&ev, lang)
+		}
 	default:
 		// 渲染子集之外的事件类型：通常只是 GitHub 侧订阅范围大于我们渲染的子集，
 		// 调用方无需修复 → 200 + skipped（见文件头注释）。
 		return nil, "event", ""
 	}
-	if err != nil {
-		return nil, "", "json"
-	}
 	if content == "" {
 		// 事件类型支持、但动作不在渲染子集内（synchronize / labeled / ...）：同上 skip。
 		return nil, "event", ""
 	}
-	// card-message webhook-cardmsg-adapter：开关开时把同一事件渲成 InteractiveCard(=17)，
-	// 关闭（或卡片自校验失败）时 vcsPushReq 降级回上面的 markdown 文本路径——文本渲染器
-	// 保持原样，故 flag-off 的 content 字节与历史完全一致。事件体里的标题 / 提交信息长度
-	// 不受我们控制：文本路径钳到语义上限内（vcsPushReq 内），绝不让平台流量 413。
-	var card map[string]interface{}
-	if cardmsg.Enabled() {
-		card = buildGitHubEventCard(event, body, i18n.OutboundLanguage(context.Background()))
-	}
 	return vcsPushReq(content, card), "", ""
 }
 
-func renderGitHubPush(body []byte) (string, error) {
-	var ev ghPushEvent
-	if err := json.Unmarshal(body, &ev); err != nil {
-		return "", err
-	}
+// renderGitHubPush renders the text-path markdown for a push event. Returns "" for a
+// degenerate ref update outside the rendered subset (caller treats "" as skip). The
+// body is unmarshalled once by the caller; this operates on the shared *ev.
+func renderGitHubPush(ev *ghPushEvent) string {
 	who := ghLogin(ev.Sender)
 	ref := ghShortRef(ev.Ref)
 	switch {
 	case strings.HasPrefix(ev.Ref, "refs/tags/"):
 		if ev.Deleted {
-			return ghWithRepo(fmt.Sprintf("**%s** deleted tag `%s`", who, ref), ev.Repository), nil
+			return ghWithRepo(fmt.Sprintf("**%s** deleted tag `%s`", who, ref), ev.Repository)
 		}
-		return ghWithRepo(fmt.Sprintf("**%s** pushed tag `%s`", who, ref), ev.Repository), nil
+		return ghWithRepo(fmt.Sprintf("**%s** pushed tag `%s`", who, ref), ev.Repository)
 	case ev.Deleted:
-		return ghWithRepo(fmt.Sprintf("**%s** deleted branch `%s`", who, ref), ev.Repository), nil
+		return ghWithRepo(fmt.Sprintf("**%s** deleted branch `%s`", who, ref), ev.Repository)
 	case ev.Created && len(ev.Commits) == 0:
-		return ghWithRepo(fmt.Sprintf("**%s** created branch `%s`", who, ref), ev.Repository), nil
+		return ghWithRepo(fmt.Sprintf("**%s** created branch `%s`", who, ref), ev.Repository)
 	case len(ev.Commits) == 0:
 		// 非 create/delete 且无提交的退化 ref 更新（如 force-push 回相同内容）：渲染
 		// "pushed 0 commit(s)" 只会制造噪音——返回空走 skip 路径（review 跟进，两位
 		// reviewer 同时指出）。
-		return "", nil
+		return ""
 	}
 
 	verb := "pushed"
@@ -228,14 +261,10 @@ func renderGitHubPush(body []byte) (string, error) {
 		}
 		fmt.Fprintf(&b, "\n- [`%s`](%s) %s", ghShortSHA(cm.ID), cm.URL, clipRunes(firstLine(cm.Message), 120))
 	}
-	return b.String(), nil
+	return b.String()
 }
 
-func renderGitHubPullRequest(body []byte) (string, error) {
-	var ev ghPullRequestEvent
-	if err := json.Unmarshal(body, &ev); err != nil {
-		return "", err
-	}
+func renderGitHubPullRequest(ev *ghPullRequestEvent) string {
 	var verb string
 	switch ev.Action {
 	case "opened", "reopened":
@@ -249,37 +278,29 @@ func renderGitHubPullRequest(body []byte) (string, error) {
 		}
 	default:
 		// synchronize / labeled / review_requested / ... 刷屏动作不渲染 → skip。
-		return "", nil
+		return ""
 	}
 	return ghWithRepo(fmt.Sprintf("**%s** %s pull request [#%d %s](%s)",
 		ghLogin(ev.Sender), verb, ev.PullRequest.Number,
 		mdLinkText(ev.PullRequest.Title, 200), ev.PullRequest.HTMLURL),
-		ev.Repository), nil
+		ev.Repository)
 }
 
-func renderGitHubIssues(body []byte) (string, error) {
-	var ev ghIssuesEvent
-	if err := json.Unmarshal(body, &ev); err != nil {
-		return "", err
-	}
+func renderGitHubIssues(ev *ghIssuesEvent) string {
 	switch ev.Action {
 	case "opened", "closed", "reopened":
 	default:
-		return "", nil
+		return ""
 	}
 	return ghWithRepo(fmt.Sprintf("**%s** %s issue [#%d %s](%s)",
 		ghLogin(ev.Sender), ev.Action, ev.Issue.Number,
 		mdLinkText(ev.Issue.Title, 200), ev.Issue.HTMLURL),
-		ev.Repository), nil
+		ev.Repository)
 }
 
-func renderGitHubIssueComment(body []byte) (string, error) {
-	var ev ghIssueCommentEvent
-	if err := json.Unmarshal(body, &ev); err != nil {
-		return "", err
-	}
+func renderGitHubIssueComment(ev *ghIssueCommentEvent) string {
 	if ev.Action != "created" {
-		return "", nil
+		return ""
 	}
 	line := ghWithRepo(fmt.Sprintf("**%s** commented on [#%d %s](%s)",
 		ghLogin(ev.Sender), ev.Issue.Number,
@@ -288,16 +309,12 @@ func renderGitHubIssueComment(body []byte) (string, error) {
 	if snippet := clipRunes(oneLine(ev.Comment.Body), 300); snippet != "" {
 		line += "\n> " + snippet
 	}
-	return line, nil
+	return line
 }
 
-func renderGitHubRelease(body []byte) (string, error) {
-	var ev ghReleaseEvent
-	if err := json.Unmarshal(body, &ev); err != nil {
-		return "", err
-	}
+func renderGitHubRelease(ev *ghReleaseEvent) string {
 	if ev.Action != "published" {
-		return "", nil
+		return ""
 	}
 	title := ev.Release.Name
 	if strings.TrimSpace(title) == "" {
@@ -305,7 +322,7 @@ func renderGitHubRelease(body []byte) (string, error) {
 	}
 	return ghWithRepo(fmt.Sprintf("**%s** published release [%s](%s)",
 		ghLogin(ev.Sender), mdLinkText(title, 200), ev.Release.HTMLURL),
-		ev.Repository), nil
+		ev.Repository)
 }
 
 // ghLogin 兜底空 sender（GitHub 偶发不带 sender，如某些 App 触发的事件）。
@@ -346,28 +363,10 @@ func ghShortSHA(sha string) string {
 // Card rendering (card-message webhook-cardmsg-adapter)
 // ============================================================
 //
-// buildGitHubEventCard mirrors the text renderers' event/action decisions but emits
-// an octo/v1 card object (see adapter_card.go). It returns nil for any event/action
-// outside the rendered subset (the caller already handled skip via the text
-// renderer's empty content) or on a parse error — nil degrades to text via
-// vcsPushReq. It re-unmarshals the same gh* structs the text path uses; only one
-// path runs per request (flag on OR off), so there is no double-unmarshal at runtime.
-
-func buildGitHubEventCard(event string, body []byte, lang string) map[string]interface{} {
-	switch event {
-	case "push":
-		return buildGitHubPushCard(body, lang)
-	case "pull_request":
-		return buildGitHubPullRequestCard(body, lang)
-	case "issues":
-		return buildGitHubIssuesCard(body, lang)
-	case "issue_comment":
-		return buildGitHubIssueCommentCard(body, lang)
-	case "release":
-		return buildGitHubReleaseCard(body, lang)
-	}
-	return nil
-}
+// The card builders below mirror the text renderers' event/action decisions but emit
+// an octo/v1 card object (see adapter_card.go). They operate on the SAME *ev the text
+// renderer used (parseGitHubPush unmarshals once), and return nil for any
+// event/action outside the rendered subset — nil degrades to text via vcsPushReq.
 
 // ghActorCard is ghLogin for the card path: escaped for a TextBlock leaf (a GitHub
 // login has a restricted charset, but escaping is harmless and keeps parity with the
@@ -389,11 +388,7 @@ func ghRepoURLCard(compare string, r ghRepo) string {
 	return httpURLForCard(r.HTMLURL)
 }
 
-func buildGitHubPushCard(body []byte, lang string) map[string]interface{} {
-	var ev ghPushEvent
-	if err := json.Unmarshal(body, &ev); err != nil {
-		return nil
-	}
+func buildGitHubPushCard(ev *ghPushEvent, lang string) map[string]interface{} {
 	who := ghActorCard(ev.Sender)
 	ref := cardCodeSpan(ghShortRef(ev.Ref), cardRefMax)
 	d := vcsCardData{
@@ -454,11 +449,7 @@ func ghPRVerbPhrase(action string, merged bool) string {
 	return ""
 }
 
-func buildGitHubPullRequestCard(body []byte, lang string) map[string]interface{} {
-	var ev ghPullRequestEvent
-	if err := json.Unmarshal(body, &ev); err != nil {
-		return nil
-	}
+func buildGitHubPullRequestCard(ev *ghPullRequestEvent, lang string) map[string]interface{} {
 	phrase := ghPRVerbPhrase(ev.Action, ev.PullRequest.Merged)
 	if phrase == "" {
 		return nil
@@ -473,11 +464,7 @@ func buildGitHubPullRequestCard(body []byte, lang string) map[string]interface{}
 	}.card(lang)
 }
 
-func buildGitHubIssuesCard(body []byte, lang string) map[string]interface{} {
-	var ev ghIssuesEvent
-	if err := json.Unmarshal(body, &ev); err != nil {
-		return nil
-	}
+func buildGitHubIssuesCard(ev *ghIssuesEvent, lang string) map[string]interface{} {
 	switch ev.Action {
 	case "opened", "closed", "reopened":
 	default:
@@ -493,11 +480,7 @@ func buildGitHubIssuesCard(body []byte, lang string) map[string]interface{} {
 	}.card(lang)
 }
 
-func buildGitHubIssueCommentCard(body []byte, lang string) map[string]interface{} {
-	var ev ghIssueCommentEvent
-	if err := json.Unmarshal(body, &ev); err != nil {
-		return nil
-	}
+func buildGitHubIssueCommentCard(ev *ghIssueCommentEvent, lang string) map[string]interface{} {
 	if ev.Action != "created" {
 		return nil
 	}
@@ -512,11 +495,7 @@ func buildGitHubIssueCommentCard(body []byte, lang string) map[string]interface{
 	}.card(lang)
 }
 
-func buildGitHubReleaseCard(body []byte, lang string) map[string]interface{} {
-	var ev ghReleaseEvent
-	if err := json.Unmarshal(body, &ev); err != nil {
-		return nil
-	}
+func buildGitHubReleaseCard(ev *ghReleaseEvent, lang string) map[string]interface{} {
 	if ev.Action != "published" {
 		return nil
 	}

--- a/modules/incomingwebhook/adapter_gitlab.go
+++ b/modules/incomingwebhook/adapter_gitlab.go
@@ -191,58 +191,98 @@ func parseGitLabPush(header http.Header, body []byte) (*pushPayloadReq, string, 
 		return nil, "", "no_event"
 	}
 
+	// card-message webhook-cardmsg-adapter：开关开时渲成 InteractiveCard(=17)，关闭
+	//（或卡片自校验失败）时 vcsPushReq 降级回 markdown 文本路径（文本渲染器输出不变，
+	// flag-off 字节与历史一致）。body 每事件【只反序列化一次】，文本与卡片共用同一 *ev。
+	// 与 github 适配器同一套卡片骨架 / 转义器（parity）。
+	wantCard := cardmsg.Enabled()
+	lang := ""
+	if wantCard {
+		lang = i18n.OutboundLanguage(context.Background())
+	}
 	var content string
-	var err error
+	var card map[string]interface{}
 	switch event {
 	case "Push Hook":
-		content, err = renderGitLabPush(body)
+		var ev glPushEvent
+		if err := json.Unmarshal(body, &ev); err != nil {
+			return nil, "", "json"
+		}
+		content = renderGitLabPush(&ev)
+		if content != "" && wantCard {
+			card = buildGitLabPushCard(&ev, lang)
+		}
 	case "Tag Push Hook":
-		content, err = renderGitLabTagPush(body)
+		var ev glPushEvent
+		if err := json.Unmarshal(body, &ev); err != nil {
+			return nil, "", "json"
+		}
+		content = renderGitLabTagPush(&ev)
+		if content != "" && wantCard {
+			card = buildGitLabTagPushCard(&ev, lang)
+		}
 	case "Merge Request Hook":
-		content, err = renderGitLabMergeRequest(body)
+		var ev glMergeRequestEvent
+		if err := json.Unmarshal(body, &ev); err != nil {
+			return nil, "", "json"
+		}
+		content = renderGitLabMergeRequest(&ev)
+		if content != "" && wantCard {
+			card = buildGitLabMergeRequestCard(&ev, lang)
+		}
 	case "Issue Hook":
-		content, err = renderGitLabIssue(body)
+		var ev glIssueEvent
+		if err := json.Unmarshal(body, &ev); err != nil {
+			return nil, "", "json"
+		}
+		content = renderGitLabIssue(&ev)
+		if content != "" && wantCard {
+			card = buildGitLabIssueCard(&ev, lang)
+		}
 	case "Note Hook":
-		content, err = renderGitLabNote(body)
+		var ev glNoteEvent
+		if err := json.Unmarshal(body, &ev); err != nil {
+			return nil, "", "json"
+		}
+		content = renderGitLabNote(&ev)
+		if content != "" && wantCard {
+			card = buildGitLabNoteCard(&ev, lang)
+		}
 	case "Pipeline Hook":
-		content, err = renderGitLabPipeline(body)
+		var ev glPipelineEvent
+		if err := json.Unmarshal(body, &ev); err != nil {
+			return nil, "", "json"
+		}
+		content = renderGitLabPipeline(&ev)
+		if content != "" && wantCard {
+			card = buildGitLabPipelineCard(&ev, lang)
+		}
 	default:
 		// 渲染子集之外的事件类型（Job Hook / Wiki Page Hook / ...）：通常只是订阅范围
 		// 大于我们渲染的子集，调用方无需修复 → 200 + skipped。
 		return nil, "event", ""
 	}
-	if err != nil {
-		return nil, "", "json"
-	}
 	if content == "" {
 		// 事件类型支持、但动作不在渲染子集内（MR update / pipeline running / ...）：skip。
 		return nil, "event", ""
 	}
-	// card-message webhook-cardmsg-adapter：开关开时渲成 InteractiveCard(=17)，关闭
-	//（或卡片自校验失败）时 vcsPushReq 降级回上面的 markdown 文本路径（文本渲染器原样
-	// 保留，flag-off 字节与历史一致）。与 github 适配器同一套卡片骨架 / 转义器（parity）。
-	var card map[string]interface{}
-	if cardmsg.Enabled() {
-		card = buildGitLabEventCard(event, body, i18n.OutboundLanguage(context.Background()))
-	}
 	return vcsPushReq(content, card), "", ""
 }
 
-func renderGitLabPush(body []byte) (string, error) {
-	var ev glPushEvent
-	if err := json.Unmarshal(body, &ev); err != nil {
-		return "", err
-	}
+// renderGitLabPush and its siblings render the text-path markdown from the shared
+// *ev (parseGitLabPush unmarshals once). "" means the event/action is outside the
+// rendered subset (caller treats "" as skip).
+func renderGitLabPush(ev *glPushEvent) string {
 	who := glActor(ev.UserUsername, ev.UserName)
 	ref := glShortRef(ev.Ref)
 	switch {
 	case glIsZeroSHA(ev.After):
-		return glWithRepo(fmt.Sprintf("**%s** deleted branch `%s`", who, ref), ev.Project), nil
+		return glWithRepo(fmt.Sprintf("**%s** deleted branch `%s`", who, ref), ev.Project)
 	case glIsZeroSHA(ev.Before) && len(ev.Commits) == 0:
-		return glWithRepo(fmt.Sprintf("**%s** created branch `%s`", who, ref), ev.Project), nil
+		return glWithRepo(fmt.Sprintf("**%s** created branch `%s`", who, ref), ev.Project)
 	case len(ev.Commits) == 0:
 		// 退化 ref 更新（无提交、非建/删）：渲染 "pushed 0 commit(s)" 只是噪音 → skip。
-		return "", nil
+		return ""
 	}
 
 	// n = total_commits_count，但绝不小于实际渲染的 commits 数：total 缺省(0)时回退
@@ -263,61 +303,45 @@ func renderGitLabPush(body []byte) (string, error) {
 		}
 		fmt.Fprintf(&b, "\n- [`%s`](%s) %s", glShortSHA(cm.ID), cm.URL, clipRunes(firstLine(cm.Message), 120))
 	}
-	return b.String(), nil
+	return b.String()
 }
 
-func renderGitLabTagPush(body []byte) (string, error) {
-	var ev glPushEvent
-	if err := json.Unmarshal(body, &ev); err != nil {
-		return "", err
-	}
+func renderGitLabTagPush(ev *glPushEvent) string {
 	who := glActor(ev.UserUsername, ev.UserName)
 	tag := glShortRef(ev.Ref)
 	if glIsZeroSHA(ev.After) {
-		return glWithRepo(fmt.Sprintf("**%s** deleted tag `%s`", who, tag), ev.Project), nil
+		return glWithRepo(fmt.Sprintf("**%s** deleted tag `%s`", who, tag), ev.Project)
 	}
-	return glWithRepo(fmt.Sprintf("**%s** pushed tag `%s`", who, tag), ev.Project), nil
+	return glWithRepo(fmt.Sprintf("**%s** pushed tag `%s`", who, tag), ev.Project)
 }
 
-func renderGitLabMergeRequest(body []byte) (string, error) {
-	var ev glMergeRequestEvent
-	if err := json.Unmarshal(body, &ev); err != nil {
-		return "", err
-	}
+func renderGitLabMergeRequest(ev *glMergeRequestEvent) string {
 	verb := glActionVerb(ev.ObjectAttributes.Action)
 	if verb == "" {
 		// update / approved / unapproved / ... 刷屏动作不渲染 → skip。
-		return "", nil
+		return ""
 	}
 	return glWithRepo(fmt.Sprintf("**%s** %s merge request [!%d %s](%s)",
 		glActor(ev.User.Username, ev.User.Name), verb, ev.ObjectAttributes.IID,
 		mdLinkText(ev.ObjectAttributes.Title, 200), ev.ObjectAttributes.URL),
-		ev.Project), nil
+		ev.Project)
 }
 
-func renderGitLabIssue(body []byte) (string, error) {
-	var ev glIssueEvent
-	if err := json.Unmarshal(body, &ev); err != nil {
-		return "", err
-	}
+func renderGitLabIssue(ev *glIssueEvent) string {
 	verb := glActionVerb(ev.ObjectAttributes.Action)
 	if verb == "" {
-		return "", nil
+		return ""
 	}
 	return glWithRepo(fmt.Sprintf("**%s** %s issue [#%d %s](%s)",
 		glActor(ev.User.Username, ev.User.Name), verb, ev.ObjectAttributes.IID,
 		mdLinkText(ev.ObjectAttributes.Title, 200), ev.ObjectAttributes.URL),
-		ev.Project), nil
+		ev.Project)
 }
 
-func renderGitLabNote(body []byte) (string, error) {
-	var ev glNoteEvent
-	if err := json.Unmarshal(body, &ev); err != nil {
-		return "", err
-	}
+func renderGitLabNote(ev *glNoteEvent) string {
 	if ev.ObjectAttributes.System {
 		// 系统备注（改标签/指派/状态等自动生成）：与 GitHub 只渲染人写评论一致，skip。
-		return "", nil
+		return ""
 	}
 	who := glActor(ev.User.Username, ev.User.Name)
 	url := ev.ObjectAttributes.URL
@@ -339,19 +363,15 @@ func renderGitLabNote(body []byte) (string, error) {
 	if snippet := clipRunes(oneLine(ev.ObjectAttributes.Note), 300); snippet != "" {
 		line += "\n> " + snippet
 	}
-	return line, nil
+	return line
 }
 
-func renderGitLabPipeline(body []byte) (string, error) {
-	var ev glPipelineEvent
-	if err := json.Unmarshal(body, &ev); err != nil {
-		return "", err
-	}
+func renderGitLabPipeline(ev *glPipelineEvent) string {
 	// 只渲染终态：running / pending / created / manual / skipped 都会刷屏 → skip。
 	switch ev.ObjectAttributes.Status {
 	case "success", "failed", "canceled":
 	default:
-		return "", nil
+		return ""
 	}
 	// Pipeline 是唯一自拼 URL 的事件（MR/Issue/Note 直接用 object_attributes.url 绝对
 	// 地址）。project.web_url 缺失时（白名单解析不保证字段必到）退化为不带链接的纯文本，
@@ -365,7 +385,7 @@ func renderGitLabPipeline(body []byte) (string, error) {
 		line = fmt.Sprintf("Pipeline #%d %s on `%s`",
 			ev.ObjectAttributes.ID, ev.ObjectAttributes.Status, glShortRef(ev.ObjectAttributes.Ref))
 	}
-	return glWithRepo(line, ev.Project), nil
+	return glWithRepo(line, ev.Project)
 }
 
 // glActor 优先用 username（GitLab 用户名字符集受限：[a-zA-Z0-9_.-]，进 `**X**` 粗体
@@ -434,28 +454,11 @@ func glShortSHA(sha string) string {
 // Card rendering (card-message webhook-cardmsg-adapter)
 // ============================================================
 //
-// buildGitLabEventCard mirrors the text renderers' event/action decisions but emits
+// The card builders below mirror the text renderers' event/action decisions but emit
 // an octo/v1 card object using the SAME anatomy + escaper as the github adapter
-// (adapter_card.go) — parity. Returns nil for subset-outside actions / parse errors
+// (adapter_card.go) — parity. They operate on the SAME *ev the text renderer used
+// (parseGitLabPush unmarshals once), returning nil for subset-outside actions
 // (→ degrade to text via vcsPushReq).
-
-func buildGitLabEventCard(event string, body []byte, lang string) map[string]interface{} {
-	switch event {
-	case "Push Hook":
-		return buildGitLabPushCard(body, lang)
-	case "Tag Push Hook":
-		return buildGitLabTagPushCard(body, lang)
-	case "Merge Request Hook":
-		return buildGitLabMergeRequestCard(body, lang)
-	case "Issue Hook":
-		return buildGitLabIssueCard(body, lang)
-	case "Note Hook":
-		return buildGitLabNoteCard(body, lang)
-	case "Pipeline Hook":
-		return buildGitLabPipelineCard(body, lang)
-	}
-	return nil
-}
 
 // glActorCard is glActor for the card path: username (restricted charset) or the
 // free-text display name, both escaped for a TextBlock leaf.
@@ -469,11 +472,7 @@ func glActorCard(username, name string) string {
 	return "someone"
 }
 
-func buildGitLabPushCard(body []byte, lang string) map[string]interface{} {
-	var ev glPushEvent
-	if err := json.Unmarshal(body, &ev); err != nil {
-		return nil
-	}
+func buildGitLabPushCard(ev *glPushEvent, lang string) map[string]interface{} {
 	who := glActorCard(ev.UserUsername, ev.UserName)
 	ref := cardCodeSpan(glShortRef(ev.Ref), cardRefMax)
 	d := vcsCardData{
@@ -505,11 +504,7 @@ func buildGitLabPushCard(body []byte, lang string) map[string]interface{} {
 	return d.card(lang)
 }
 
-func buildGitLabTagPushCard(body []byte, lang string) map[string]interface{} {
-	var ev glPushEvent
-	if err := json.Unmarshal(body, &ev); err != nil {
-		return nil
-	}
+func buildGitLabTagPushCard(ev *glPushEvent, lang string) map[string]interface{} {
 	who := glActorCard(ev.UserUsername, ev.UserName)
 	tag := cardCodeSpan(glShortRef(ev.Ref), cardRefMax)
 	headline := fmt.Sprintf("%s pushed tag %s", who, tag)
@@ -525,11 +520,7 @@ func buildGitLabTagPushCard(body []byte, lang string) map[string]interface{} {
 	}.card(lang)
 }
 
-func buildGitLabMergeRequestCard(body []byte, lang string) map[string]interface{} {
-	var ev glMergeRequestEvent
-	if err := json.Unmarshal(body, &ev); err != nil {
-		return nil
-	}
+func buildGitLabMergeRequestCard(ev *glMergeRequestEvent, lang string) map[string]interface{} {
 	verb := glActionVerb(ev.ObjectAttributes.Action)
 	if verb == "" {
 		return nil
@@ -544,11 +535,7 @@ func buildGitLabMergeRequestCard(body []byte, lang string) map[string]interface{
 	}.card(lang)
 }
 
-func buildGitLabIssueCard(body []byte, lang string) map[string]interface{} {
-	var ev glIssueEvent
-	if err := json.Unmarshal(body, &ev); err != nil {
-		return nil
-	}
+func buildGitLabIssueCard(ev *glIssueEvent, lang string) map[string]interface{} {
 	verb := glActionVerb(ev.ObjectAttributes.Action)
 	if verb == "" {
 		return nil
@@ -563,11 +550,7 @@ func buildGitLabIssueCard(body []byte, lang string) map[string]interface{} {
 	}.card(lang)
 }
 
-func buildGitLabNoteCard(body []byte, lang string) map[string]interface{} {
-	var ev glNoteEvent
-	if err := json.Unmarshal(body, &ev); err != nil {
-		return nil
-	}
+func buildGitLabNoteCard(ev *glNoteEvent, lang string) map[string]interface{} {
 	if ev.ObjectAttributes.System {
 		return nil
 	}
@@ -593,11 +576,7 @@ func buildGitLabNoteCard(body []byte, lang string) map[string]interface{} {
 	}.card(lang)
 }
 
-func buildGitLabPipelineCard(body []byte, lang string) map[string]interface{} {
-	var ev glPipelineEvent
-	if err := json.Unmarshal(body, &ev); err != nil {
-		return nil
-	}
+func buildGitLabPipelineCard(ev *glPipelineEvent, lang string) map[string]interface{} {
 	switch ev.ObjectAttributes.Status {
 	case "success", "failed", "canceled":
 	default:

--- a/modules/incomingwebhook/adapter_gitlab.go
+++ b/modules/incomingwebhook/adapter_gitlab.go
@@ -17,6 +17,7 @@ package incomingwebhook
 // 字段（白名单解析），其余 payload 字段一律忽略。
 
 import (
+	"context"
 	"crypto/subtle"
 	"encoding/json"
 	"fmt"
@@ -24,6 +25,9 @@ import (
 	"os"
 	"strconv"
 	"strings"
+
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardmsg"
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
 )
 
 // 渲染的提交列表上限（与 GitHub 适配器一致：全列会刷屏）。
@@ -158,9 +162,21 @@ type glPipelineEvent struct {
 		ID     int    `json:"id"`
 		Ref    string `json:"ref"`
 		Status string `json:"status"`
+		// Duration 是流水线耗时（秒，GitLab 在终态事件里给出）。仅卡片路径渲染
+		// （文本路径保持历史输出不变）。可能缺省(0)/为 null → 不展示。
+		Duration float64 `json:"duration"`
 	} `json:"object_attributes"`
 	User    glUser    `json:"user"`
 	Project glProject `json:"project"`
+	// Builds 是本次流水线的作业列表（GitLab 在 Pipeline Hook 里给出）。仅卡片路径用于
+	// "Jobs (N)" 事实行；缺省即不展示该行。
+	Builds []glBuild `json:"builds"`
+}
+
+// glBuild 是流水线里的单个作业（白名单解析：只取渲染需要的字段）。
+type glBuild struct {
+	Name   string `json:"name"`
+	Status string `json:"status"`
 }
 
 // parseGitLabPush 把 GitLab webhook 事件翻译成 native 推送请求（pushAdapter.parse）。
@@ -202,7 +218,14 @@ func parseGitLabPush(header http.Header, body []byte) (*pushPayloadReq, string, 
 		// 事件类型支持、但动作不在渲染子集内（MR update / pipeline running / ...）：skip。
 		return nil, "event", ""
 	}
-	return &pushPayloadReq{Content: clipRunes(content, maxContentRunes())}, "", ""
+	// card-message webhook-cardmsg-adapter：开关开时渲成 InteractiveCard(=17)，关闭
+	//（或卡片自校验失败）时 vcsPushReq 降级回上面的 markdown 文本路径（文本渲染器原样
+	// 保留，flag-off 字节与历史一致）。与 github 适配器同一套卡片骨架 / 转义器（parity）。
+	var card map[string]interface{}
+	if cardmsg.Enabled() {
+		card = buildGitLabEventCard(event, body, i18n.OutboundLanguage(context.Background()))
+	}
+	return vcsPushReq(content, card), "", ""
 }
 
 func renderGitLabPush(body []byte) (string, error) {
@@ -405,4 +428,219 @@ func glShortSHA(sha string) string {
 		return sha[:8]
 	}
 	return sha
+}
+
+// ============================================================
+// Card rendering (card-message webhook-cardmsg-adapter)
+// ============================================================
+//
+// buildGitLabEventCard mirrors the text renderers' event/action decisions but emits
+// an octo/v1 card object using the SAME anatomy + escaper as the github adapter
+// (adapter_card.go) — parity. Returns nil for subset-outside actions / parse errors
+// (→ degrade to text via vcsPushReq).
+
+func buildGitLabEventCard(event string, body []byte, lang string) map[string]interface{} {
+	switch event {
+	case "Push Hook":
+		return buildGitLabPushCard(body, lang)
+	case "Tag Push Hook":
+		return buildGitLabTagPushCard(body, lang)
+	case "Merge Request Hook":
+		return buildGitLabMergeRequestCard(body, lang)
+	case "Issue Hook":
+		return buildGitLabIssueCard(body, lang)
+	case "Note Hook":
+		return buildGitLabNoteCard(body, lang)
+	case "Pipeline Hook":
+		return buildGitLabPipelineCard(body, lang)
+	}
+	return nil
+}
+
+// glActorCard is glActor for the card path: username (restricted charset) or the
+// free-text display name, both escaped for a TextBlock leaf.
+func glActorCard(username, name string) string {
+	if username != "" {
+		return escapeCardText(username, cardActorMax)
+	}
+	if name != "" {
+		return escapeCardText(name, cardActorMax)
+	}
+	return "someone"
+}
+
+func buildGitLabPushCard(body []byte, lang string) map[string]interface{} {
+	var ev glPushEvent
+	if err := json.Unmarshal(body, &ev); err != nil {
+		return nil
+	}
+	who := glActorCard(ev.UserUsername, ev.UserName)
+	ref := cardCodeSpan(glShortRef(ev.Ref), cardRefMax)
+	d := vcsCardData{
+		source:   cardSourceGitLab,
+		variant:  "vcs.gitlab.push",
+		subtitle: escapeCardText(ev.Project.PathWithNamespace, cardTitleMax),
+		url:      httpURLForCard(ev.Project.WebURL),
+	}
+	switch {
+	case glIsZeroSHA(ev.After):
+		d.headline = fmt.Sprintf("%s deleted branch %s", who, ref)
+	case glIsZeroSHA(ev.Before) && len(ev.Commits) == 0:
+		d.headline = fmt.Sprintf("%s created branch %s", who, ref)
+	case len(ev.Commits) == 0:
+		return nil
+	default:
+		n := max(ev.TotalCommits, len(ev.Commits))
+		d.headline = fmt.Sprintf("%s pushed %d commit(s) to %s", who, n, ref)
+		for i, cm := range ev.Commits {
+			if i == maxRenderedGitLabCommits {
+				d.lines = append(d.lines, fmt.Sprintf("…and %d more", n-maxRenderedGitLabCommits))
+				break
+			}
+			d.lines = append(d.lines, joinShaMsg(
+				cardCodeSpan(glShortSHA(cm.ID), cardShaMax),
+				escapeCardText(firstLine(cm.Message), cardCommitMsgMax)))
+		}
+	}
+	return d.card(lang)
+}
+
+func buildGitLabTagPushCard(body []byte, lang string) map[string]interface{} {
+	var ev glPushEvent
+	if err := json.Unmarshal(body, &ev); err != nil {
+		return nil
+	}
+	who := glActorCard(ev.UserUsername, ev.UserName)
+	tag := cardCodeSpan(glShortRef(ev.Ref), cardRefMax)
+	headline := fmt.Sprintf("%s pushed tag %s", who, tag)
+	if glIsZeroSHA(ev.After) {
+		headline = fmt.Sprintf("%s deleted tag %s", who, tag)
+	}
+	return vcsCardData{
+		source:   cardSourceGitLab,
+		variant:  "vcs.gitlab.tag_push",
+		headline: headline,
+		subtitle: escapeCardText(ev.Project.PathWithNamespace, cardTitleMax),
+		url:      httpURLForCard(ev.Project.WebURL),
+	}.card(lang)
+}
+
+func buildGitLabMergeRequestCard(body []byte, lang string) map[string]interface{} {
+	var ev glMergeRequestEvent
+	if err := json.Unmarshal(body, &ev); err != nil {
+		return nil
+	}
+	verb := glActionVerb(ev.ObjectAttributes.Action)
+	if verb == "" {
+		return nil
+	}
+	return vcsCardData{
+		source:   cardSourceGitLab,
+		variant:  "vcs.gitlab.merge_request",
+		headline: fmt.Sprintf("%s %s a merge request", glActorCard(ev.User.Username, ev.User.Name), verb),
+		subtitle: escapeCardText(ev.Project.PathWithNamespace, cardTitleMax),
+		lines:    []string{numberedTitle("!", ev.ObjectAttributes.IID, ev.ObjectAttributes.Title)},
+		url:      httpURLForCard(ev.ObjectAttributes.URL),
+	}.card(lang)
+}
+
+func buildGitLabIssueCard(body []byte, lang string) map[string]interface{} {
+	var ev glIssueEvent
+	if err := json.Unmarshal(body, &ev); err != nil {
+		return nil
+	}
+	verb := glActionVerb(ev.ObjectAttributes.Action)
+	if verb == "" {
+		return nil
+	}
+	return vcsCardData{
+		source:   cardSourceGitLab,
+		variant:  "vcs.gitlab.issue",
+		headline: fmt.Sprintf("%s %s an issue", glActorCard(ev.User.Username, ev.User.Name), verb),
+		subtitle: escapeCardText(ev.Project.PathWithNamespace, cardTitleMax),
+		lines:    []string{numberedTitle("#", ev.ObjectAttributes.IID, ev.ObjectAttributes.Title)},
+		url:      httpURLForCard(ev.ObjectAttributes.URL),
+	}.card(lang)
+}
+
+func buildGitLabNoteCard(body []byte, lang string) map[string]interface{} {
+	var ev glNoteEvent
+	if err := json.Unmarshal(body, &ev); err != nil {
+		return nil
+	}
+	if ev.ObjectAttributes.System {
+		return nil
+	}
+	var target string
+	switch ev.ObjectAttributes.NoteableType {
+	case "MergeRequest":
+		target = numberedTitle("!", ev.MergeRequest.IID, ev.MergeRequest.Title)
+	case "Issue":
+		target = numberedTitle("#", ev.Issue.IID, ev.Issue.Title)
+	case "Commit":
+		target = "commit " + cardCodeSpan(glShortSHA(ev.Commit.ID), cardShaMax)
+	default:
+		target = "a comment"
+	}
+	return vcsCardData{
+		source:   cardSourceGitLab,
+		variant:  "vcs.gitlab.note",
+		headline: fmt.Sprintf("%s commented", glActorCard(ev.User.Username, ev.User.Name)),
+		subtitle: escapeCardText(ev.Project.PathWithNamespace, cardTitleMax),
+		lines:    []string{target},
+		quote:    escapeCardText(ev.ObjectAttributes.Note, cardQuoteMax),
+		url:      httpURLForCard(ev.ObjectAttributes.URL),
+	}.card(lang)
+}
+
+func buildGitLabPipelineCard(body []byte, lang string) map[string]interface{} {
+	var ev glPipelineEvent
+	if err := json.Unmarshal(body, &ev); err != nil {
+		return nil
+	}
+	switch ev.ObjectAttributes.Status {
+	case "success", "failed", "canceled":
+	default:
+		return nil
+	}
+	// 卡片专属的结构化 FactSet（分支 / 状态 / 耗时 / 作业）——文本路径不含这些字段，
+	// 故 flag-off 字节不变。标签本地化（内容标签，非 errcode），值在叶子处转义。
+	labels := pipelineLabelsFor(lang)
+	facts := []vcsFact{
+		{title: labels.branch, value: escapeCardText(glShortRef(ev.ObjectAttributes.Ref), cardRefMax)},
+		{title: labels.status, value: escapeCardText(ev.ObjectAttributes.Status, cardActorMax)},
+	}
+	if dur := formatPipelineDuration(int(ev.ObjectAttributes.Duration)); dur != "" {
+		facts = append(facts, vcsFact{title: labels.duration, value: dur})
+	}
+	if len(ev.Builds) > 0 {
+		names := make([]string, 0, maxRenderedJobs)
+		for i, b := range ev.Builds {
+			if i == maxRenderedJobs {
+				break
+			}
+			names = append(names, escapeCardText(b.Name, cardActorMax))
+		}
+		value := strings.Join(names, " / ")
+		if len(ev.Builds) > maxRenderedJobs {
+			value += " …"
+		}
+		facts = append(facts, vcsFact{
+			title: fmt.Sprintf("%s (%d)", labels.jobs, len(ev.Builds)),
+			value: value,
+		})
+	}
+	url := ""
+	if p := httpURLForCard(ev.Project.WebURL); p != "" {
+		url = fmt.Sprintf("%s/-/pipelines/%d", strings.TrimRight(p, "/"), ev.ObjectAttributes.ID)
+	}
+	return vcsCardData{
+		source:   cardSourceGitLab,
+		variant:  "vcs.gitlab.pipeline",
+		headline: fmt.Sprintf("Pipeline #%d", ev.ObjectAttributes.ID),
+		status:   pipelineStatusColor(ev.ObjectAttributes.Status),
+		subtitle: escapeCardText(ev.Project.PathWithNamespace, cardTitleMax),
+		facts:    facts,
+		url:      url,
+	}.card(lang)
 }

--- a/modules/incomingwebhook/api_i18n_test.go
+++ b/modules/incomingwebhook/api_i18n_test.go
@@ -21,7 +21,7 @@ import (
 func TestIncomingWebhookNoLegacyResponseError(t *testing.T) {
 	files := []string{"api.go", "api_i18n.go", "ratelimit.go", "localfloor.go", "cache.go",
 		"adapter.go", "adapter_github.go", "adapter_wecom.go", "adapter_multica.go",
-		"adapter_gitlab.go", "adapter_feishu.go", "mention.go", "mention_expand.go"}
+		"adapter_gitlab.go", "adapter_feishu.go", "adapter_card.go", "mention.go", "mention_expand.go"}
 	banned := []string{
 		".ResponseError(",
 		".ResponseErrorf(",

--- a/modules/incomingwebhook/api_test.go
+++ b/modules/incomingwebhook/api_test.go
@@ -21,6 +21,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardmsg"
+
 	// 该模块自身需注册以触发其 SQL 迁移
 	_ "github.com/Mininglamp-OSS/octo-server/modules/incomingwebhook"
 	// 迁移依赖链：以下模块的 SQL 迁移会修改本模块依赖的 group/group_member/user 表，
@@ -40,6 +42,12 @@ func TestMain(m *testing.M) {
 	if os.Getenv("OCTO_MASTER_KEY") == "" {
 		os.Setenv("OCTO_MASTER_KEY", "12345678901234567890123456789012")
 	}
+	// The github/gitlab adapters branch on cardmsg.Enabled() (OCTO_CARD_MESSAGE_ENABLED),
+	// so force it OFF as the deterministic test baseline — otherwise the text-path
+	// adapter tests (which assert the flag-off markdown output) become sensitive to an
+	// ambient/CI value of the var (PR #596 review, Jerry-Xin). Card tests opt in
+	// per-case via t.Setenv(cardmsg.EnvEnabled, "1").
+	os.Setenv(cardmsg.EnvEnabled, "")
 	os.Exit(m.Run())
 }
 


### PR DESCRIPTION
## Summary

The **GitHub** and **GitLab** incoming-webhook adapters now render their existing
event subset as an **InteractiveCard (=17) octo/v1 card** (structured header + body
+ a "View on {GitHub|GitLab}" `Action.OpenUrl`) when `OCTO_CARD_MESSAGE_ENABLED`
is on, and **degrade to the existing markdown text path** when it is off (or when a
built card fails self-validation) — so the flag-off wire stays byte-identical and
merge never breaks delivery. Enabling cards remains an ops decision gated on the
client render-gate. Server-only: octo-web already ships the octo/v1 renderer and
trusts `iwh_` senders.

## Related Issue

N/A — tracked under `.octospec/tasks/webhook-cardmsg-adapter/`.

## Linked Spec

`.octospec/tasks/webhook-cardmsg-adapter/brief.md` (context: `.octospec/tasks/card-message-protocol/brief.md` + `pkg/cardmsg`; journal `.octospec/journal/shared/webhook-cardmsg-adapter.md`).

## Changes

- **`adapter_card.go` (new)** — shared card model + assembler (`vcsCardData.card`), one leaf escaper (`escapeCardText` + `neutralizeLeadingBlockMarker`, mirrors `pkg/cardtmpl.escapeMarkdown`) + `cardCodeSpan`, http(s) allowlist (`httpURLForCard`), self-validate/degrade selector (`validateVCSCard` / `vcsPushReq`), localized "View on {…}" label, and the pipeline FactSet helpers. Used by **both** adapters (trust-boundary parity).
- **`adapter_github.go` / `adapter_gitlab.go`** — per-event card builders next to their text siblings. `parse` unmarshals each event body **once** and shares the `*ev` between the text renderer and the card builder; the card object flows through the existing `msgTypeCard` branch (`buildCardPayload` → `cardmsg.Validate`/`Finalize` → server-derived `plain`, `from.kind=webhook`, server `space_id`) — no `handlePush` change, no new error code/response.
- **GitLab pipeline card** — renders a **Branch / Status / Duration / Jobs (N)** FactSet (parses `object_attributes.duration` + `builds[]`; card-only, text path unchanged); headline colored by status (Good/Attention/Warning).
- **Trust boundary** — external VCS text (actor / repo / titles / commit messages / comment bodies) is escaped at the card leaf, including a **leading block-marker** neutralizer so a hostile comment like `1. Deploy approved` can't open a markdown list; every URL is a structured `Action.OpenUrl` through the positive http(s) allowlist (non-http(s) → button omitted).
- **Tests + guard list** — new `adapter_card_test.go` (shape / validate / plain / trust-boundary parity / list-marker / degrade / flag-gate / duration); `adapter_card.go` added to `TestIncomingWebhookNoLegacyResponseError`.

## Testing

- `go test ./modules/incomingwebhook/...` — new card tests green; the pre-existing `adapter_github_test.go` / `adapter_gitlab_test.go` string assertions pass **verbatim** (flag-off byte-identity).
- `golangci-lint run ./modules/incomingwebhook/...` → 0 issues; `gofmt` clean; `make i18n-lint` clean.
- **Truthful visual verification**: dumped the actual card JSON emitted by the shipped builders and rendered it headless with the real `adaptivecards@3.0.6` + octo-web's `--wk-*` theme tokens + a host config mirroring `octoHostConfig` (light + dark) — layout matches intent, and a hostile push renders its markup literally with no "View" button (its `javascript:` repo URL was dropped by the allowlist).

- [x] Unit tests added/updated
- [x] Manually verified

## COMPREHENSION

1. **What does this change actually do to the load-bearing path?**
   It adds a card-rendering branch to the github/gitlab adapter `parse` path. When `cardmsg.Enabled()`, the parsed event is rendered to an octo/v1 card object that rides the existing type-17 pipeline (`buildCardPayload` → `Validate`/`Finalize`); otherwise it falls back to the unchanged markdown text payload. The event body is now unmarshalled **once** per event and shared between the text and card renderers. External content is escaped at the card leaf and all URLs go through `cardmsg`'s http(s) allowlist.

2. **What could break (dependents + failure mode)?**
   (a) Flag-off must stay byte-identical for existing text consumers — guarded by leaving the text renderers' output untouched and by the existing string-assertion tests. (b) A malformed server-built card could return 400 instead of delivering — prevented by the adapter self-validating the card and degrading to text on any failure. (c) Attacker-controlled VCS text could forge links/emphasis/lists in a trusted-webhook card — escaped at the leaf (inline + leading block markers) with a parity table test across both adapters; URLs restricted to structured `Action.OpenUrl` on the http(s) allowlist. (d) The client could silently render plain if it rejected our card properties — verified octo-web's `validateCardForOcto` is type-strict but property-lenient (accepts `color`/`style`/`weight`/`isSubtle`) and `senderTrust` renders `iwh_` cards.

3. **How do you know it works (specific test/repro/trace)?**
   `pkg`-local card tests cover shape, `cardmsg.Validate`, derived `plain`, trust-boundary parity, the leading-list-marker defense, the degrade-to-text contract, and the flag gate; the pre-existing text-path tests pass verbatim (byte-identity). End-to-end: the shipped builders' real JSON was rendered through the actual `adaptivecards@3.0.6` engine + octo-web theme tokens/host config and screenshotted in light and dark, confirming the layout and the injection defense.

## Checklist

- [x] PR description is in English
- [x] Added tests for my changes
- [x] Updated documentation (task brief + journal + `.octospec/log.md`)
- [x] Followed commit message conventions (Conventional Commits)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017z8oSoSGaziy1XM7fmHLWx

---
_Generated by [Claude Code](https://claude.ai/code/session_017z8oSoSGaziy1XM7fmHLWx)_