### PR TITLE
feat(user): expose mcp.read / mcp.write capabilities on manager_me

### DIFF
--- a/modules/user/api_manager.go
+++ b/modules/user/api_manager.go
@@ -129,7 +129,7 @@ func (m *Manager) me(c *wkhttp.Context) {
 //   - space.read        = 空间/成员/邀请/入群申请 列表查询（requireAdmin）
 //   - space.write       = 建空间/改资料/加成员/邀请增改禁用/通过拒绝入群申请（requireAdmin，故恒 true）
 //   - space.destructive = 强制解散/封禁/强制移除/改成员角色（requireSuperAdmin）
-//   - mcp.read          = 系统 MCP 列表/详情查看（admin ∪ superAdmin，恒 true）
+//   - mcp.read          = 系统 MCP 列表/详情查看（requireSuperAdmin）
 //   - mcp.write         = 系统 MCP 创建/编辑/删除（requireSuperAdmin）
 //
 // TODO(#366 Part 2): 目前这张表按各端点当前档位手工维护；集中式 authz 策略表落地
@@ -145,7 +145,8 @@ func managerCapabilities(isSuper bool) map[string]bool {
 		"users.write":        isSuper, // 重置密码 / 新增用户 / 解封 / 改密
 		"users.manage_admin": isSuper, // 管理员账号 增/查/删
 		"groups.write":       isSuper, // 解散封禁群 / 强制移除成员
-		"mcp.write":          isSuper, // 系统 MCP 创建/编辑/删除（marketplace admin surface）
+		"mcp.read":           isSuper, // 系统 MCP 列表/详情（marketplace admin surface 只认共享 X-Admin-Token 不分 role，此处收窄到超管以缩小页面暴露面）
+		"mcp.write":          isSuper, // 系统 MCP 创建/编辑/删除（同上）
 		// admin ∪ superAdmin（此处恒 true，列出供前端统一读取）
 		"appversion.read": true, // 版本列表
 		"dashboard.read":  true, // 运营看板查看
@@ -153,7 +154,6 @@ func managerCapabilities(isSuper bool) map[string]bool {
 		"groups.read":     true, // 群组列表 / 禁用群 / 群成员 / 群黑名单
 		"space.read":      true, // 空间查看 / 列表
 		"space.write":     true, // 建空间 / 改资料 / 加成员 / 邀请增改禁用 / 通过拒绝入群申请（requireAdmin）
-		"mcp.read":        true, // 系统 MCP 列表 / 详情（octo-admin SystemMcp 页面入口）
 	}
 }
 

--- a/modules/user/api_manager.go
+++ b/modules/user/api_manager.go
@@ -129,6 +129,8 @@ func (m *Manager) me(c *wkhttp.Context) {
 //   - space.read        = 空间/成员/邀请/入群申请 列表查询（requireAdmin）
 //   - space.write       = 建空间/改资料/加成员/邀请增改禁用/通过拒绝入群申请（requireAdmin，故恒 true）
 //   - space.destructive = 强制解散/封禁/强制移除/改成员角色（requireSuperAdmin）
+//   - mcp.read          = 系统 MCP 列表/详情查看（admin ∪ superAdmin，恒 true）
+//   - mcp.write         = 系统 MCP 创建/编辑/删除（requireSuperAdmin）
 //
 // TODO(#366 Part 2): 目前这张表按各端点当前档位手工维护；集中式 authz 策略表落地
 // 后，应改为由同一份 route→role 真源派生，彻底消除前后端漂移。
@@ -143,6 +145,7 @@ func managerCapabilities(isSuper bool) map[string]bool {
 		"users.write":        isSuper, // 重置密码 / 新增用户 / 解封 / 改密
 		"users.manage_admin": isSuper, // 管理员账号 增/查/删
 		"groups.write":       isSuper, // 解散封禁群 / 强制移除成员
+		"mcp.write":          isSuper, // 系统 MCP 创建/编辑/删除（marketplace admin surface）
 		// admin ∪ superAdmin（此处恒 true，列出供前端统一读取）
 		"appversion.read": true, // 版本列表
 		"dashboard.read":  true, // 运营看板查看
@@ -150,6 +153,7 @@ func managerCapabilities(isSuper bool) map[string]bool {
 		"groups.read":     true, // 群组列表 / 禁用群 / 群成员 / 群黑名单
 		"space.read":      true, // 空间查看 / 列表
 		"space.write":     true, // 建空间 / 改资料 / 加成员 / 邀请增改禁用 / 通过拒绝入群申请（requireAdmin）
+		"mcp.read":        true, // 系统 MCP 列表 / 详情（octo-admin SystemMcp 页面入口）
 	}
 }
 

--- a/modules/user/api_manager_me_test.go
+++ b/modules/user/api_manager_me_test.go
@@ -22,10 +22,10 @@ func TestManagerCapabilities(t *testing.T) {
 
 	superOnly := []string{
 		"system_setting", "backup", "appversion.write", "dashboard.trigger", "space.destructive",
-		"users.write", "users.manage_admin", "groups.write", "mcp.write",
+		"users.write", "users.manage_admin", "groups.write", "mcp.write", "mcp.read",
 	}
 	adminTier := []string{
-		"appversion.read", "dashboard.read", "users.read", "groups.read", "space.read", "space.write", "mcp.read",
+		"appversion.read", "dashboard.read", "users.read", "groups.read", "space.read", "space.write",
 	}
 
 	for _, k := range superOnly {
@@ -115,11 +115,11 @@ func TestManagerMe_AdminGetsReadCapsNotWrite(t *testing.T) {
 	assert.True(t, resp.Capabilities["users.read"], "admin should have users.read")
 	assert.True(t, resp.Capabilities["groups.read"], "admin should have groups.read")
 	assert.True(t, resp.Capabilities["space.write"], "admin should have space.write (admin-allowed space writes)")
-	assert.True(t, resp.Capabilities["mcp.read"], "admin should have mcp.read (view system MCP catalog)")
 	assert.False(t, resp.Capabilities["users.write"], "admin must NOT have users.write")
 	assert.False(t, resp.Capabilities["users.manage_admin"], "admin must NOT have users.manage_admin")
 	assert.False(t, resp.Capabilities["groups.write"], "admin must NOT have groups.write")
 	assert.False(t, resp.Capabilities["space.destructive"], "admin must NOT have space.destructive")
+	assert.False(t, resp.Capabilities["mcp.read"], "admin must NOT have mcp.read (system MCP list/detail is superAdmin-only)")
 	assert.False(t, resp.Capabilities["mcp.write"], "admin must NOT have mcp.write (system MCP create/edit/delete)")
 	assert.False(t, resp.Capabilities["system_setting"], "admin must NOT have system_setting")
 }

--- a/modules/user/api_manager_me_test.go
+++ b/modules/user/api_manager_me_test.go
@@ -22,10 +22,10 @@ func TestManagerCapabilities(t *testing.T) {
 
 	superOnly := []string{
 		"system_setting", "backup", "appversion.write", "dashboard.trigger", "space.destructive",
-		"users.write", "users.manage_admin", "groups.write",
+		"users.write", "users.manage_admin", "groups.write", "mcp.write",
 	}
 	adminTier := []string{
-		"appversion.read", "dashboard.read", "users.read", "groups.read", "space.read", "space.write",
+		"appversion.read", "dashboard.read", "users.read", "groups.read", "space.read", "space.write", "mcp.read",
 	}
 
 	for _, k := range superOnly {
@@ -115,10 +115,12 @@ func TestManagerMe_AdminGetsReadCapsNotWrite(t *testing.T) {
 	assert.True(t, resp.Capabilities["users.read"], "admin should have users.read")
 	assert.True(t, resp.Capabilities["groups.read"], "admin should have groups.read")
 	assert.True(t, resp.Capabilities["space.write"], "admin should have space.write (admin-allowed space writes)")
+	assert.True(t, resp.Capabilities["mcp.read"], "admin should have mcp.read (view system MCP catalog)")
 	assert.False(t, resp.Capabilities["users.write"], "admin must NOT have users.write")
 	assert.False(t, resp.Capabilities["users.manage_admin"], "admin must NOT have users.manage_admin")
 	assert.False(t, resp.Capabilities["groups.write"], "admin must NOT have groups.write")
 	assert.False(t, resp.Capabilities["space.destructive"], "admin must NOT have space.destructive")
+	assert.False(t, resp.Capabilities["mcp.write"], "admin must NOT have mcp.write (system MCP create/edit/delete)")
 	assert.False(t, resp.Capabilities["system_setting"], "admin must NOT have system_setting")
 }
 
@@ -140,4 +142,6 @@ func TestManagerMe_SuperAdminGetsWriteCaps(t *testing.T) {
 	assert.True(t, resp.Capabilities["groups.write"], "superAdmin should have groups.write")
 	assert.True(t, resp.Capabilities["system_setting"], "superAdmin should have system_setting")
 	assert.True(t, resp.Capabilities["users.read"], "superAdmin should have users.read")
+	assert.True(t, resp.Capabilities["mcp.write"], "superAdmin should have mcp.write")
+	assert.True(t, resp.Capabilities["mcp.read"], "superAdmin should have mcp.read")
 }


### PR DESCRIPTION
The octo-admin console's "系统 MCP" page (SystemMcp/index.tsx) is gated by the `mcp.read` capability on the sidebar item and the `CapabilityRoute` guard on the route. Without the backend surfacing these two keys, the menu is unreachable through the normal manager path — the frontend had to ship a temporary `hasManagerCapability` bypass to be usable locally. Backfill the pair so that bypass can come out.

The gates map to what the marketplace admin surface actually enforces (`/market/api/v1/admin/mcps`, superAdmin-only via `X-Admin-Token`):

- mcp.read  = list / detail — superAdmin only (narrowed to match the marketplace `X-Admin-Token` gate; keeps `manager_me`'s self-report from handing plain admins a menu entry that 403s on click)
- mcp.write = create / edit / delete — superAdmin only

Testing:
- Update TestManagerCapabilities to pin both keys in `superOnly` (both are superAdmin-only after the narrowing), and rely on the derived length-sanity total.
- Add positive/negative assertions to the admin and superAdmin HTTP tests so a future contract slip surfaces as a test failure, not as a silently invisible page.

## Summary

<!-- What does this PR do? -->

## Related Issue

Closes #599

## Linked Spec

<!-- Link to .octospec/tasks/<slug>/brief.md or the issue this implements.
     Required when the change touches load-bearing behavior. -->

## Changes

<!-- Bullet list of concrete changes -->

-
-

## Testing

<!-- How was this tested? Include commands, screenshots, or test output. -->

- [ ] Unit tests added/updated
- [ ] Manually verified

## COMPREHENSION

<!-- Required for load-bearing / architectural / P0 changes. Answer to substance,
     not boilerplate. Delete this section for trivial changes (typo/docs/lint/config). -->

1. **What does this change actually do** to the load-bearing path?

2. **What could break** because of it (dependents + failure mode)?

3. **How do you know it works** (specific test/repro/trace)?

## Checklist

- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] PR description is in English
- [ ] Added tests for my changes
- [ ] Updated documentation
- [ ] Followed commit message conventions (Conventional Commits)


