### PR TITLE
feat(cardtmpl): give approval buttons primary/secondary ActionStyle

### DIFF
--- a/docs/card-action-callback-consumer.md
+++ b/docs/card-action-callback-consumer.md
@@ -89,8 +89,10 @@ empty slice. When present, it contains 1-5 entries:
 
 octo-server derives each action ID as `approval-<decision>` and injects the
 route-bound owner/action type into every submit payload. Per-action data,
-styles, URLs, inputs, and caller-authored card JSON are not supported. Put
-bounded shared domain identifiers in the card's `data` map.
+styles, URLs, inputs, and caller-authored card JSON are not supported from
+callers. (The server sets an `ActionStyle` on its own legacy approve/deny
+buttons — approve `positive`, deny `destructive`; custom actions carry none.)
+Put bounded shared domain identifiers in the card's `data` map.
 
 Custom action titles are caller-provided display text. Supply the language
 appropriate for the target audience; octo-server validates and renders the

--- a/docs/card-action-callback-dispatch.md
+++ b/docs/card-action-callback-dispatch.md
@@ -157,7 +157,9 @@ callers must inspect both `delivered` and `filtered`.
 The token supplies the authoritative owner; the request cannot choose it. The
 server adds reserved metadata and builds every action. `actions` is optional:
 omitting the field (or sending explicit JSON `null` — equivalent on the wire)
-preserves the existing localized approve/deny buttons. Sending `"actions": []`
+preserves the existing localized approve/deny buttons — which the server emits
+with an `ActionStyle` (approve `positive`, deny `destructive`) so clients render
+a primary vs secondary affordance. Sending `"actions": []`
 (explicit empty array) is a caller bug and rejected — the fallback path is
 nil, not an empty slice. When present, it must contain 1-5 items. Each
 `decision` is unique and matches `[a-z][a-z0-9_.-]{0,47}`; the tokens
@@ -167,7 +169,9 @@ contain control characters (tabs, newlines, BEL, etc.). octo-server derives
 the action ID as `approval-<decision>` and the callback receives that decision
 unchanged. `data` accepts at most 32 lower-case keys with string values up to
 500 runes; `owner`, `action_type`, and `decision` are reserved. No per-action
-data, URL, input, style, or arbitrary card JSON is accepted.
+data, URL, input, style, or arbitrary card JSON is accepted from callers (the
+server sets `style` on its own legacy approve/deny buttons; custom actions
+carry none).
 
 Custom decisions do not add callback result states. The consumer still returns
 one authoritative `state`: `approved`, `denied`, `cancelled`, or `pending`.

--- a/pkg/cardtmpl/approval_request.go
+++ b/pkg/cardtmpl/approval_request.go
@@ -146,10 +146,12 @@ func buildApprovalActions(input ApprovalRequestCard, baseData map[string]interfa
 		denyData["decision"] = "deny"
 		return []interface{}{
 			map[string]interface{}{
-				"type": "Action.Submit", "id": ApprovalApproveActionID, "title": approveTitle, "data": approveData,
+				"type": "Action.Submit", "id": ApprovalApproveActionID, "title": approveTitle,
+				"style": "positive", "data": approveData,
 			},
 			map[string]interface{}{
-				"type": "Action.Submit", "id": ApprovalDenyActionID, "title": denyTitle, "data": denyData,
+				"type": "Action.Submit", "id": ApprovalDenyActionID, "title": denyTitle,
+				"style": "destructive", "data": denyData,
 			},
 		}, nil
 	}

--- a/pkg/cardtmpl/approval_request_actions_test.go
+++ b/pkg/cardtmpl/approval_request_actions_test.go
@@ -56,6 +56,13 @@ func TestBuildApprovalRequestCardCustomActionsRenderServerBuiltButtons(t *testin
 		if want, _ := strings.CutPrefix(id, "approval-"); decision != want {
 			t.Fatalf("decision on %s = %q, want %q", id, decision, want)
 		}
+		// Custom actions carry no ActionStyle: the server only assigns
+		// positive/destructive to the built-in approve/deny pair, which have
+		// inherent semantics. Pin the invariant so a future permissive binding
+		// (e.g. map[string]interface{}) can't silently let a caller inject style.
+		if _, hasStyle := action["style"]; hasStyle {
+			t.Fatalf("custom action %s must not carry a style key: %+v", id, action)
+		}
 	}
 	if len(want) != 0 {
 		t.Fatalf("missing actions in output: %+v", want)

--- a/pkg/cardtmpl/approval_request_actions_test.go
+++ b/pkg/cardtmpl/approval_request_actions_test.go
@@ -65,11 +65,17 @@ func TestBuildApprovalRequestCardCustomActionsRenderServerBuiltButtons(t *testin
 	}
 }
 
-// TestBuildApprovalRequestCardOmittedActionsIsByteCompatible verifies the
-// http-actions change does not perturb the legacy approve/deny output. The
-// exact bytes below are captured from the pre-http-actions release; any drift
-// in ordering, keys, escaping, or reserved metadata will fail this test and
-// force a wire-contract review before shipping.
+// TestBuildApprovalRequestCardOmittedActionsIsByteCompatible pins the legacy
+// approve/deny wire form. The golden below is the frozen reference; any drift
+// in ordering, keys, escaping, or reserved metadata fails this test and forces
+// a deliberate wire-contract review before shipping.
+//
+// Reviewed change: the approve/deny buttons now carry ActionStyle
+// (approve="positive", deny="destructive") so clients render a primary vs
+// secondary affordance instead of two identical buttons. cardmsg.Validate
+// accepts it (type-based action validation, no whitelist change), and it is a
+// purely additive key — no existing key/order/escaping moved. Golden updated
+// to match; everything else stays byte-identical to #588.
 func TestBuildApprovalRequestCardOmittedActionsIsByteCompatible(t *testing.T) {
 	raw, err := BuildApprovalRequestCard(ApprovalRequestCard{
 		Title:        "Publish summary",
@@ -83,9 +89,9 @@ func TestBuildApprovalRequestCardOmittedActionsIsByteCompatible(t *testing.T) {
 	if err != nil {
 		t.Fatalf("BuildApprovalRequestCard() error = %v", err)
 	}
-	const golden = `{"actions":[{"data":{"action_type":"summary.publish.decision","decision":"approve","owner":"smart-summary","task_no":"task-1"},"id":"approval-approve","title":"Allow","type":"Action.Submit"},{"data":{"action_type":"summary.publish.decision","decision":"deny","owner":"smart-summary","task_no":"task-1"},"id":"approval-deny","title":"Deny","type":"Action.Submit"}],"body":[{"text":"Publish summary","type":"TextBlock","weight":"Bolder","wrap":true},{"text":"Review before publishing","type":"TextBlock","wrap":true}],"type":"AdaptiveCard","version":"1.5"}`
+	const golden = `{"actions":[{"data":{"action_type":"summary.publish.decision","decision":"approve","owner":"smart-summary","task_no":"task-1"},"id":"approval-approve","style":"positive","title":"Allow","type":"Action.Submit"},{"data":{"action_type":"summary.publish.decision","decision":"deny","owner":"smart-summary","task_no":"task-1"},"id":"approval-deny","style":"destructive","title":"Deny","type":"Action.Submit"}],"body":[{"text":"Publish summary","type":"TextBlock","weight":"Bolder","wrap":true},{"text":"Review before publishing","type":"TextBlock","wrap":true}],"type":"AdaptiveCard","version":"1.5"}`
 	if string(raw) != golden {
-		t.Fatalf("legacy approve/deny bytes drifted from #588\n  got: %s\n want: %s", raw, golden)
+		t.Fatalf("legacy approve/deny bytes drifted from reviewed baseline\n  got: %s\n want: %s", raw, golden)
 	}
 }
 

--- a/pkg/cardtmpl/approval_request_test.go
+++ b/pkg/cardtmpl/approval_request_test.go
@@ -36,6 +36,7 @@ func TestBuildApprovalRequestCardOwnsActionsAndReservedMetadata(t *testing.T) {
 		t.Fatalf("actions = %+v", actions)
 	}
 	decisions := map[string]bool{}
+	styles := map[string]string{}
 	for _, value := range actions {
 		action, _ := value.(map[string]interface{})
 		data, _ := action["data"].(map[string]interface{})
@@ -44,9 +45,16 @@ func TestBuildApprovalRequestCardOwnsActionsAndReservedMetadata(t *testing.T) {
 		}
 		decision, _ := data["decision"].(string)
 		decisions[decision] = true
+		styles[decision], _ = action["style"].(string)
 	}
 	if !decisions["approve"] || !decisions["deny"] {
 		t.Fatalf("decisions = %+v", decisions)
+	}
+	// approve/deny carry ActionStyle so clients render a primary vs secondary
+	// affordance instead of two identical buttons. cardmsg.Validate (above)
+	// already accepted style, so this is a pure additive on the wire.
+	if styles["approve"] != "positive" || styles["deny"] != "destructive" {
+		t.Fatalf("action styles = %+v (want approve=positive, deny=destructive)", styles)
 	}
 	if strings.Contains(string(raw), "http") {
 		t.Fatalf("approval request leaked a callback URL: %s", raw)

--- a/pkg/cardtmpl/docs_action.go
+++ b/pkg/cardtmpl/docs_action.go
@@ -62,12 +62,14 @@ func BuildDocsAccessRequestCard(
 			"type":  "Action.Submit",
 			"id":    DocsApproveActionID,
 			"title": actions.ApproveTitle,
+			"style": "positive",
 			"data":  approveData,
 		},
 		map[string]interface{}{
 			"type":  "Action.Submit",
 			"id":    DocsDenyActionID,
 			"title": actions.DenyTitle,
+			"style": "destructive",
 			"data":  denyData,
 		},
 	}

--- a/pkg/cardtmpl/docs_action_test.go
+++ b/pkg/cardtmpl/docs_action_test.go
@@ -30,10 +30,11 @@ func TestBuildDocsAccessRequestCardProducesReviewedV2Actions(t *testing.T) {
 	want := []struct {
 		id       string
 		title    string
+		style    string
 		decision string
 	}{
-		{id: DocsApproveActionID, title: "允许", decision: "approve"},
-		{id: DocsDenyActionID, title: "拒绝", decision: "deny"},
+		{id: DocsApproveActionID, title: "允许", style: "positive", decision: "approve"},
+		{id: DocsDenyActionID, title: "拒绝", style: "destructive", decision: "deny"},
 	}
 	for i, expected := range want {
 		action, ok := actions[i].(map[string]interface{})
@@ -41,6 +42,10 @@ func TestBuildDocsAccessRequestCardProducesReviewedV2Actions(t *testing.T) {
 		assert.Equal(t, "Action.Submit", action["type"])
 		assert.Equal(t, expected.id, action["id"])
 		assert.Equal(t, expected.title, action["title"])
+		// Parity with the generic approval card (approval_request.go): approve =
+		// primary (positive), deny = secondary (destructive) so the docs access
+		// request card and the generic approval card render consistently.
+		assert.Equal(t, expected.style, action["style"])
 		data, ok := action["data"].(map[string]interface{})
 		require.True(t, ok)
 		assert.Equal(t, "docs", data["owner"])


### PR DESCRIPTION
## Summary

The approval-request card's approve/deny buttons carried no `ActionStyle`, so clients rendered two identical buttons with no primary-vs-secondary cue. This adds `style: "positive"` to the approve action and `style: "destructive"` to the deny action so renderers can differentiate the affordance (primary vs secondary). Purely additive on the wire — no existing key, ordering, or escaping changed. The sibling **docs access-request card** (`docs_action.go`) gets the same treatment so the two approval surfaces render consistently.

Pairs with the octo-web renderer change (`Mininglamp-OSS/octo-web` #816, merged) that styles the two variants.

## Related Issue

N/A

## Linked Spec

Wire contract: `docs/card-protocol.md` (Adaptive Cards 1.5, octo profile). This is an additive `style` key on existing `Action.Submit` buttons; `cardmsg.Validate` already accepts it via type-based action validation (no whitelist change).

## Changes

- `pkg/cardtmpl/approval_request.go`: the legacy approve/deny template now emits `style: "positive"` (approve) and `style: "destructive"` (deny).
- `pkg/cardtmpl/docs_action.go`: the docs access-request card's approve/deny buttons get the same `style` values, for cross-template parity (they build their own buttons rather than reusing the generic template).
- `pkg/cardtmpl/approval_request_test.go` and `pkg/cardtmpl/docs_action_test.go`: assert the styles on both templates and keep `cardmsg.Validate` passing.
- `pkg/cardtmpl/approval_request_actions_test.go`: byte-compat golden updated to include the additive `style` key, plus a negative assertion that custom (caller-supplied) actions carry **no** `style`.
- `docs/card-action-callback-dispatch.md` and `docs/card-action-callback-consumer.md`: note that the server sets `ActionStyle` on its own legacy approve/deny buttons, while caller-supplied per-action style stays rejected.

## Testing

- `go test ./pkg/cardtmpl/ ./pkg/cardmsg/` — all pass (byte-compat golden + style assertions on both templates + custom-actions-carry-no-style).
- Verified the emitted JSON passes the real `cardmsg.Validate` (octo/v2 profile).
- Fed the emitted JSON through the real AdaptiveCards 3.0.6 SDK + octo-web's shipped card CSS to confirm approve = primary (solid) / deny = secondary (ghost).

- [x] Unit tests added/updated
- [x] Manually verified

## COMPREHENSION

1. **What does this change actually do** to the load-bearing path?
   Adds a `style` field to the two `Action.Submit` buttons in both server-owned approval templates (generic approval + docs access-request). Action IDs, `data` (owner/action_type/decision), ordering, and escaping are unchanged, so card-action callback routing and idempotency keys are unaffected. Custom (caller-supplied) actions are deliberately left unstyled.

2. **What could break** because of it (dependents + failure mode)?
   Anything pinning the exact approval-card bytes — i.e. the byte-compat golden test, which is updated here. Clients that don't understand `ActionStyle` ignore it (standard Adaptive Cards behavior), so older clients render as before. No validation/whitelist path changes (type-based action validation tolerates the extra key).

3. **How do you know it works** (specific test/repro/trace)?
   `go test ./pkg/cardtmpl/` passes, including the updated golden, the style assertions on both templates, and the new custom-actions-carry-no-style assertion; the emitted JSON was rendered through the real AdaptiveCards SDK with octo-web's CSS and produced a solid (primary) approve + ghost (secondary) deny.

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] PR description is in English
- [x] Added tests for my changes
- [x] Updated documentation
- [x] Followed commit message conventions (Conventional Commits)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E2FHToMTWZnMq6cbQyTjqg