### PR TITLE
feat(user): expose mcp.read / mcp.write capabilities on manager_me

### DIFF
--- a/modules/user/api_manager.go
+++ b/modules/user/api_manager.go
@@ -129,7 +129,7 @@ func (m *Manager) me(c *wkhttp.Context) {
 //   - space.read        = 空间/成员/邀请/入群申请 列表查询（requireAdmin）
 //   - space.write       = 建空间/改资料/加成员/邀请增改禁用/通过拒绝入群申请（requireAdmin，故恒 true）
 //   - space.destructive = 强制解散/封禁/强制移除/改成员角色（requireSuperAdmin）
-//   - mcp.read          = 系统 MCP 列表/详情查看（admin ∪ superAdmin，恒 true）
+//   - mcp.read          = 系统 MCP 列表/详情查看（requireSuperAdmin）
 //   - mcp.write         = 系统 MCP 创建/编辑/删除（requireSuperAdmin）
 //
 // TODO(#366 Part 2): 目前这张表按各端点当前档位手工维护；集中式 authz 策略表落地
@@ -145,7 +145,8 @@ func managerCapabilities(isSuper bool) map[string]bool {
 		"users.write":        isSuper, // 重置密码 / 新增用户 / 解封 / 改密
 		"users.manage_admin": isSuper, // 管理员账号 增/查/删
 		"groups.write":       isSuper, // 解散封禁群 / 强制移除成员
-		"mcp.write":          isSuper, // 系统 MCP 创建/编辑/删除（marketplace admin surface）
+		"mcp.read":           isSuper, // 系统 MCP 列表/详情（marketplace admin surface 只认共享 X-Admin-Token 不分 role，此处收窄到超管以缩小页面暴露面）
+		"mcp.write":          isSuper, // 系统 MCP 创建/编辑/删除（同上）
 		// admin ∪ superAdmin（此处恒 true，列出供前端统一读取）
 		"appversion.read": true, // 版本列表
 		"dashboard.read":  true, // 运营看板查看
@@ -153,7 +154,6 @@ func managerCapabilities(isSuper bool) map[string]bool {
 		"groups.read":     true, // 群组列表 / 禁用群 / 群成员 / 群黑名单
 		"space.read":      true, // 空间查看 / 列表
 		"space.write":     true, // 建空间 / 改资料 / 加成员 / 邀请增改禁用 / 通过拒绝入群申请（requireAdmin）
-		"mcp.read":        true, // 系统 MCP 列表 / 详情（octo-admin SystemMcp 页面入口）
 	}
 }
 

--- a/modules/user/api_manager.go
+++ b/modules/user/api_manager.go
@@ -129,6 +129,8 @@ func (m *Manager) me(c *wkhttp.Context) {
 //   - space.read        = 空间/成员/邀请/入群申请 列表查询（requireAdmin）
 //   - space.write       = 建空间/改资料/加成员/邀请增改禁用/通过拒绝入群申请（requireAdmin，故恒 true）
 //   - space.destructive = 强制解散/封禁/强制移除/改成员角色（requireSuperAdmin）
+//   - mcp.read          = 系统 MCP 列表/详情查看（admin ∪ superAdmin，恒 true）
+//   - mcp.write         = 系统 MCP 创建/编辑/删除（requireSuperAdmin）
 //
 // TODO(#366 Part 2): 目前这张表按各端点当前档位手工维护；集中式 authz 策略表落地
 // 后，应改为由同一份 route→role 真源派生，彻底消除前后端漂移。
@@ -143,6 +145,7 @@ func managerCapabilities(isSuper bool) map[string]bool {
 		"users.write":        isSuper, // 重置密码 / 新增用户 / 解封 / 改密
 		"users.manage_admin": isSuper, // 管理员账号 增/查/删
 		"groups.write":       isSuper, // 解散封禁群 / 强制移除成员
+		"mcp.write":          isSuper, // 系统 MCP 创建/编辑/删除（marketplace admin surface）
 		// admin ∪ superAdmin（此处恒 true，列出供前端统一读取）
 		"appversion.read": true, // 版本列表
 		"dashboard.read":  true, // 运营看板查看
@@ -150,6 +153,7 @@ func managerCapabilities(isSuper bool) map[string]bool {
 		"groups.read":     true, // 群组列表 / 禁用群 / 群成员 / 群黑名单
 		"space.read":      true, // 空间查看 / 列表
 		"space.write":     true, // 建空间 / 改资料 / 加成员 / 邀请增改禁用 / 通过拒绝入群申请（requireAdmin）
+		"mcp.read":        true, // 系统 MCP 列表 / 详情（octo-admin SystemMcp 页面入口）
 	}
 }
 

--- a/modules/user/api_manager_me_test.go
+++ b/modules/user/api_manager_me_test.go
@@ -22,10 +22,10 @@ func TestManagerCapabilities(t *testing.T) {
 
 	superOnly := []string{
 		"system_setting", "backup", "appversion.write", "dashboard.trigger", "space.destructive",
-		"users.write", "users.manage_admin", "groups.write", "mcp.write",
+		"users.write", "users.manage_admin", "groups.write", "mcp.write", "mcp.read",
 	}
 	adminTier := []string{
-		"appversion.read", "dashboard.read", "users.read", "groups.read", "space.read", "space.write", "mcp.read",
+		"appversion.read", "dashboard.read", "users.read", "groups.read", "space.read", "space.write",
 	}
 
 	for _, k := range superOnly {
@@ -115,11 +115,11 @@ func TestManagerMe_AdminGetsReadCapsNotWrite(t *testing.T) {
 	assert.True(t, resp.Capabilities["users.read"], "admin should have users.read")
 	assert.True(t, resp.Capabilities["groups.read"], "admin should have groups.read")
 	assert.True(t, resp.Capabilities["space.write"], "admin should have space.write (admin-allowed space writes)")
-	assert.True(t, resp.Capabilities["mcp.read"], "admin should have mcp.read (view system MCP catalog)")
 	assert.False(t, resp.Capabilities["users.write"], "admin must NOT have users.write")
 	assert.False(t, resp.Capabilities["users.manage_admin"], "admin must NOT have users.manage_admin")
 	assert.False(t, resp.Capabilities["groups.write"], "admin must NOT have groups.write")
 	assert.False(t, resp.Capabilities["space.destructive"], "admin must NOT have space.destructive")
+	assert.False(t, resp.Capabilities["mcp.read"], "admin must NOT have mcp.read (system MCP list/detail is superAdmin-only)")
 	assert.False(t, resp.Capabilities["mcp.write"], "admin must NOT have mcp.write (system MCP create/edit/delete)")
 	assert.False(t, resp.Capabilities["system_setting"], "admin must NOT have system_setting")
 }

--- a/modules/user/api_manager_me_test.go
+++ b/modules/user/api_manager_me_test.go
@@ -22,10 +22,10 @@ func TestManagerCapabilities(t *testing.T) {
 
 	superOnly := []string{
 		"system_setting", "backup", "appversion.write", "dashboard.trigger", "space.destructive",
-		"users.write", "users.manage_admin", "groups.write",
+		"users.write", "users.manage_admin", "groups.write", "mcp.write",
 	}
 	adminTier := []string{
-		"appversion.read", "dashboard.read", "users.read", "groups.read", "space.read", "space.write",
+		"appversion.read", "dashboard.read", "users.read", "groups.read", "space.read", "space.write", "mcp.read",
 	}
 
 	for _, k := range superOnly {
@@ -115,10 +115,12 @@ func TestManagerMe_AdminGetsReadCapsNotWrite(t *testing.T) {
 	assert.True(t, resp.Capabilities["users.read"], "admin should have users.read")
 	assert.True(t, resp.Capabilities["groups.read"], "admin should have groups.read")
 	assert.True(t, resp.Capabilities["space.write"], "admin should have space.write (admin-allowed space writes)")
+	assert.True(t, resp.Capabilities["mcp.read"], "admin should have mcp.read (view system MCP catalog)")
 	assert.False(t, resp.Capabilities["users.write"], "admin must NOT have users.write")
 	assert.False(t, resp.Capabilities["users.manage_admin"], "admin must NOT have users.manage_admin")
 	assert.False(t, resp.Capabilities["groups.write"], "admin must NOT have groups.write")
 	assert.False(t, resp.Capabilities["space.destructive"], "admin must NOT have space.destructive")
+	assert.False(t, resp.Capabilities["mcp.write"], "admin must NOT have mcp.write (system MCP create/edit/delete)")
 	assert.False(t, resp.Capabilities["system_setting"], "admin must NOT have system_setting")
 }
 
@@ -140,4 +142,6 @@ func TestManagerMe_SuperAdminGetsWriteCaps(t *testing.T) {
 	assert.True(t, resp.Capabilities["groups.write"], "superAdmin should have groups.write")
 	assert.True(t, resp.Capabilities["system_setting"], "superAdmin should have system_setting")
 	assert.True(t, resp.Capabilities["users.read"], "superAdmin should have users.read")
+	assert.True(t, resp.Capabilities["mcp.write"], "superAdmin should have mcp.write")
+	assert.True(t, resp.Capabilities["mcp.read"], "superAdmin should have mcp.read")
 }


### PR DESCRIPTION
## Summary

Backfill two capability keys — `mcp.read` and `mcp.write` — on `GET /v1/manager/me`'s `managerCapabilities()` self-report map, so `octo-admin`'s "系统 MCP" page (`SystemMcp/index.tsx`) can drive its sidebar item and `CapabilityRoute` gate from the backend contract instead of shipping a temporary `hasManagerCapability` role-sniffing bypass. Both keys are `isSuper` (superAdmin-only), mirroring the marketplace admin surface (`/market/api/v1/admin/mcps`), which authenticates with a shared `X-Admin-Token` that does not differentiate by admin tier.

## Linked Spec

Closes #599.

The capability contract lives inline in `modules/user/api_manager.go` (doc block above `managerCapabilities`); the underlying gap this PR fills is that the octo-admin console cannot presently reach the "系统 MCP" page through the normal manager path.

## How verified

- `go test ./modules/user -run TestManagerCapabilities` — pure-map contract test; pins `mcp.read` and `mcp.write` in `superOnly` and enforces the derived length-sanity invariant (`len(superOnly)+len(adminTier) == len(map)`), so any future dropped/renamed key trips it automatically. Passes.
- `go test ./modules/user -run 'TestManagerMe_AdminGetsReadCapsNotWrite|TestManagerMe_SuperAdminGetsWriteCaps'` — HTTP-level assertions on `/v1/manager/me` for both tiers: admin gets `mcp.read=false, mcp.write=false`; superAdmin gets both `true`. Passes.
- Code search confirms `managerCapabilities` is referenced only by `me()` and its test — no path uses it as an access decision, so a wrong tier here is a UI-drift bug, not privilege escalation.

## COMPREHENSION

1. **What does this change actually do** to the load-bearing path?

   Adds `mcp.read: isSuper` and `mcp.write: isSuper` to the capability map returned by `GET /v1/manager/me`. This map is a **self-report** consumed by the frontend to decide whether to render sidebar items and mount `CapabilityRoute`-guarded routes; it is not itself an authorization gate. Real enforcement stays where it always was — `CheckLoginRole` / `CheckLoginRoleIsSuperAdmin` on octo-server endpoints and the shared `X-Admin-Token` at the marketplace admin surface.

   Before: no `mcp.*` keys, so octo-admin had to ship a temporary `hasManagerCapability` role-sniffing bypass to make the "系统 MCP" page reachable. After: both keys are surfaced, gated to superAdmin, matching the marketplace `X-Admin-Token` (which does not distinguish admin from superAdmin — the whole admin surface is superAdmin-only in practice).

2. **What could break** because of it (dependents + failure mode)?

   - **octo-admin `SystemMcp` route/sidebar** — the only real consumer. If `mcp.read` were mis-tiered as `true` (admin ∪ superAdmin), a plain admin would see the menu entry and click into a page that 403s on entry — the inverted confused-deputy this map exists to prevent. Locked down by `mcp.read: isSuper` and the negative assertion `admin must NOT have mcp.read` in `TestManagerMe_AdminGetsReadCapsNotWrite`.
   - **Future capability-map consumers that iterate keys** — a dropped/renamed key without a matching tier-table update would silently drift. Mitigated by the derived length-sanity total in `TestManagerCapabilities`.
   - **Not** a dependent: server-side authorization. Verified by tree grep — `managerCapabilities` is called only from `me()` and its test. No new source of truth is introduced.

3. **How do you know it works** (specific test/repro/trace)?

   - Pure-map contract: `TestManagerCapabilities` pins both keys in `superOnly` and asserts the derived-length invariant, so any tier slip surfaces as a test failure.
   - HTTP-level, admin tier: `TestManagerMe_AdminGetsReadCapsNotWrite` asserts `resp.Capabilities["mcp.read"] == false` and `resp.Capabilities["mcp.write"] == false` on the actual `/v1/manager/me` response.
   - HTTP-level, superAdmin tier: `TestManagerMe_SuperAdminGetsWriteCaps` asserts both keys are `true`.
   - Both HTTP tests are self-scoped to the authenticated caller (no caller-supplied id) — no IDOR surface added.
   - The `TODO(#366 Part 2)` comment above `managerCapabilities` remains valid — this manual capability table is the interim source of truth pending central authz consolidation.
