### PR TITLE
fix(message): log person self-loop channel_id on card action ingress

### DIFF
--- a/modules/message/api_card_action.go
+++ b/modules/message/api_card_action.go
@@ -341,6 +341,15 @@ func (m *Message) authorizeCardChannelMember(c *wkhttp.Context, loginUID, messag
 	lookupChannelID := channelID
 	switch channelType {
 	case common.ChannelTypePerson.Uint8():
+		// 观测点（不改语义）：person 频道的 channel_id 是**对端 uid**，客户端不该把它
+		// 提成操作者自身。self-loop 会算出 fakeChannel(self,self) 必然 miss → 归并到
+		// invalid（防枚举，行为不变）。打一条 WARN 让「客户端提交 self-loop channel」类
+		// 问题可被立即定位 —— 典型来源是与系统 bot（notification 等）的 DM，其 recv 包
+		// channelID 塌缩为接收人自身而非对端 bot（见 octo-web#831，客户端已回退到 fromUID）。
+		if channelID == loginUID {
+			m.Warn("卡片动作 channel_id 为操作者自身(person self-loop),按 invalid 处理",
+				zap.String("uid", loginUID), zap.String("messageID", messageID))
+		}
 		lookupChannelID = common.GetFakeChannelIDWith(loginUID, channelID)
 	case common.ChannelTypeGroup.Uint8(), common.ChannelTypeCommunityTopic.Uint8():
 		// group / topic：消息就存于声明频道本身。


### PR DESCRIPTION
## Summary

Observability-only follow-up to Mininglamp-OSS/octo-web#831. When a card action submit declares `channel_id` equal to the operator's own uid (a person "self-loop"), `authorizeCardChannelMember` computes `fakeChannel(self, self)`, misses the stored row, and folds into the generic `invalid` response (anti-enumeration). **Behavior is unchanged**; this adds a WARN so the self-loop — typically a client submitting a system-bot DM whose recv `channelID` collapsed to the receiver rather than the peer bot — is immediately diagnosable in logs instead of an opaque 400.

## Related Issue

Refs Mininglamp-OSS/octo-web#831 (client-side fix: Mininglamp-OSS/octo-web#834).

## Linked Spec

Not load-bearing — no change to the authorization decision, the storage lookup, or the response; a diagnostic log line only. Context: Mininglamp-OSS/octo-web#831.

## Changes

- In `authorizeCardChannelMember` (person branch), emit a WARN with `uid` + `messageID` when `channel_id == loginUID`. The `fakeChannel(loginUID, channelID)` lookup and the miss→`invalid` (400, anti-enumeration) grouping are left byte-for-byte identical.

## Testing

- `go build ./modules/message/` and `go vet ./modules/message/` pass.
- Source guard `TestMessageNoLegacyResponseError` passes (no new/raw error response introduced).
- `make i18n-lint` passes (no new error codes; no inline codes passed to `ResponseErrorL`).
- `gofmt` clean.

- [ ] Unit tests added/updated <!-- log-only, behavior unchanged; guarded by the existing source guard + i18n lint -->
- [ ] Manually verified

## COMPREHENSION

1. **What does this change actually do** to the load-bearing path? Nothing to the decision path — it adds a single `m.Warn` inside the person branch of `authorizeCardChannelMember`. The anti-IDOR channel binding, the `fakeChannel(loginUID, channelID)` computation, the membership check, and the miss→`invalid` grouping all remain identical.

2. **What could break** because of it (dependents + failure mode)? Effectively nothing: `m.Warn` cannot alter control flow or the response. The only observable effect is log volume from pre-fix clients that still submit a self-loop `channel_id`; that subsides once octo-web#834 ships. No new error code, no i18n surface, no new response shape.

3. **How do you know it works** (specific test/repro/trace)? `go build`/`go vet` compile the module + tests; `TestMessageNoLegacyResponseError` confirms no raw/legacy response was added; `make i18n-lint` confirms no unregistered codes. The WARN fires exactly on the `channelID == loginUID` person path that already resolves to `invalid`, so it strictly annotates the existing failure without changing it.

## Checklist

- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] PR description is in English
- [ ] Added tests for my changes <!-- log-only; behavior unchanged, covered by existing guard + lint -->
- [ ] Updated documentation
- [x] Followed commit message conventions (Conventional Commits)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X6NQFjcxFaNQRHXPs6PV6i

---
_Generated by [Claude Code](https://claude.ai/code/session_01X6NQFjcxFaNQRHXPs6PV6i)_