### PR TITLE
feat: harden and extend message reactions (channel-scoped, text-only, multi-reaction)

### DIFF
--- a/.octospec/journal/shared/message-reaction-hardening.md
+++ b/.octospec/journal/shared/message-reaction-hardening.md
@@ -1,0 +1,137 @@
+---
+type: Journal
+title: "Journal: message-reaction-hardening (channel-scoped, text-only, multi-reaction, authz parity)"
+description: Record of the reaction rework — channel-scoping + write-path visibility hardening + text-only restriction, then multi-reaction (atomic upsert + unique index) and write/sync/read authorization parity from an external review (F1–F4).
+tags: ["message", "reaction", "acl", "wire-contract", "auth", "thread", "space", "isolation", "i18n", "error-response"]
+timestamp: 2026-07-16T00:00:00Z
+# --- octospec extension fields ---
+task: message-reaction-hardening
+upstream: self
+source: self
+---
+
+# Journal: message-reaction-hardening
+
+## What was done
+
+Reworked the reaction API (`POST /v1/reactions`, `POST /v1/reaction/sync`, inline
+`reactions[]`) into one commit (`modules/message`), brief
+`.octospec/tasks/message-reaction-hardening/brief.md`:
+
+- **Channel scoping**: every reaction read/write is keyed by `(channel_id,
+  channel_type, message_id)`. Dropped the global `message_id`-only DB helpers
+  (`queryWithMessageIDs`, `queryReactionWithUIDAndMessageID`) that let a reaction
+  row from another channel leak into a message's list / be toggled cross-channel.
+- **Write-path visibility gate** (`addOrCancelReaction`): target message must
+  exist in the requested channel and pass `messageVisibleToViewer` — a shared pure
+  predicate (visibles / revoke / global-delete / user-delete / expire / user-offset
+  / channel-offset). Group uses `ExistMemberActive` (excludes blacklist); topic
+  resolves the parent group + rejects deleted threads (`threadNotDeleted`).
+- **Text-only**: reactions restricted to `payload.type == 1` (`payloadIsPlainText`);
+  everything else → new i18n code `err.server.message.reaction_unsupported_type`.
+- **Multi-reaction model**: `(uid, message_id, channel_id, channel_type, emoji)` is
+  UNIQUE; toggling is a single atomic `INSERT ... ON DUPLICATE KEY UPDATE
+  is_deleted = 1 - is_deleted, seq = VALUES(seq), ...` (`toggleReaction`). Different
+  emojis are independent rows (append); same emoji toggles in place. Migration
+  de-dups (keep max `id`) before creating the unique index.
+- **Sync authz parity** (`syncReaction`): same membership posture as write
+  (`ExistMemberActive`, topic parent-group + non-deleted-thread, `else` reject),
+  plus a read-time visibility filter (`filterReactionsByMessageVisibility`) that
+  drops reactions whose target message is no longer visible to the caller.
+- **Wire additions**: write endpoint returns `{emoji, seq, is_deleted}` (optimistic-
+  update reconciliation); `syncMessageReaction` CMD param gains `message_id/emoji/seq`.
+- **DM Space isolation** (external review, blocking): reaction routes now mount
+  `spacepkg.SpaceMiddleware` (opt-in, same posture as `/v1/message`). Extracted the
+  per-message rule from `filterPersonMessagesBySpace` into a shared
+  `personSpaceAllows(msgSpaceID, isSysBot, spaceID, defaultSpaceID)` (issue #484 /
+  YUJ-226 rules unchanged), reused by message sync, reaction sync, and reaction
+  write — sync drops reactions whose target `payload.space_id` fails the predicate;
+  write returns 404 for out-of-Space DM targets (merged with not-found, placed
+  before the type gate so no "exists-but-unsupported" signal leaks). Client contract
+  (opt-in / fail-open when no `X-Space-ID` / `space_id`) is unchanged and matches
+  the message-sync side exactly.
+- **Small hardenings alongside**: emoji bounded to `varchar(20)` runes via
+  `utf8.RuneCountInString`; `reactionTargetVisibleToViewer` swapped off
+  `fetchMessageExtras` (which also queried reactions and discarded them) to a
+  minimal `extra + user_extra` fetch; migration gained a `+migrate Down`
+  (`DROP INDEX`; the dedup `DELETE` is inherently irreversible).
+
+## Structural learnings
+
+- **One visibility predicate, two call sites.** The write path (single message) and
+  the sync path (batch) must apply the *identical* visibility rule set, so it was
+  extracted into a pure `messageVisibleToViewer(msg, extra, userExtra,
+  userOffsetSeq, channelOffsetSeq, loginUID)`. Write fetches single-row and calls
+  it; sync batch-fetches (messages + extras + user-extras + one channel-offset + one
+  channel-setting = 5 queries, independent of reaction count) and calls it. Any
+  future reaction reader must reuse this predicate rather than re-deriving the rules.
+- **Per-viewer invisibility can only be filtered at read time.** Revoke / global
+  delete are channel-global and *could* clean reaction rows on write, but
+  user-delete / channel-offset / `visibles` / expire are per-viewer — the reaction
+  row is shared, so there is nothing to "clean". The only complete fix is filtering
+  when reading for a specific caller. Do not attempt write-time reaction cleanup for
+  these states; it is structurally impossible to get right.
+- **Atomic upsert removes a check-then-insert race for free.** The original
+  query→branch→insert/update had no unique key and no transaction, so concurrent
+  double-taps could create duplicate `is_deleted=0` rows (and a later toggle would
+  only flip one). `INSERT ... ON DUPLICATE KEY UPDATE` on the new unique key is
+  race-safe in one statement — no `SELECT ... FOR UPDATE`, no retry loop. dbr does
+  this via `InsertBySql` (precedent: `modules/bot_api/send.go`, `modules/webhook`).
+- **Text-only is a product decision, not in the web spec.** The web reaction spec
+  never restricted reactions to text messages; the server does. This is a real
+  three-way (server/web/product) alignment item, not a server bug — flagged in the
+  handoff contract so the web picker only surfaces on text messages.
+- **DM is one physical channel shared across Spaces — any per-message endpoint
+  needs the same Space filter `/v1/message` uses.** Person(DM) is routed by bare
+  uid in WuKongIM, so a single reaction/message row can belong to different Spaces;
+  the Space label lives only in `payload.space_id`. Reaction was a fresh surface
+  that shipped without `SpaceMiddleware` and without the `payload.space_id`
+  predicate, and the review caught the exact same leak class YUJ-226 already fixed
+  on message sync. The rule this reinforces: **any new per-DM-message endpoint must
+  (a) mount `SpaceMiddleware` and (b) apply the shared `personSpaceAllows`
+  predicate on `payload.space_id`, driven off the middleware's validated `spaceID`
+  and the caller's default Space.** Extract the per-message decision into one
+  helper the moment there's a second caller, so the DM isolation posture cannot
+  drift between entry points.
+
+## Gotchas worth remembering
+
+- **`db.Time.String()` is `"YYYY-MM-DD HH:mm:ss"` (local, no timezone), not
+  RFC3339.** This is the project-wide wire format for every `created_at` (via
+  `db.Time.MarshalJSON`), so reaction `created_at` was *not* special-cased to
+  RFC3339 (that would diverge from the whole API). Clients must sort reactions by
+  the monotonic `seq`, not `created_at`.
+- **Local `test` DB drifts after any rebase that pulls new migrations.**
+  Rebasing onto a newer `origin/main` brought a new upstream migration
+  (`20260716000001_add_octo_space_welcome_delivery.sql`) the pre-existing `test`
+  DB had never seen → `NewTestServer` panics `Unable to create migration plan ...
+  unknown migration in database`. Fix is drop & recreate the DB
+  (`docker exec octo-test-mysql mysql -uroot -pdemo -e "DROP DATABASE test; CREATE
+  DATABASE test ..."`), never per-migration reconciliation.
+- **Squash base is the merge-base, not `origin/main`.** When squashing a
+  behind-main branch, `git reset --soft origin/main` folds *main's* newer commits
+  into the diff (reverting unrelated work). Reset to `git merge-base origin/main
+  HEAD` instead; verify the staged set contains only your files.
+- **`json.Number` accepts quoted integers.** `payloadIsPlainText` treats
+  `{"type":"1"}` as text (`json.Number("1").Int64()==1`) — harmless (semantics
+  preserved; `"2"` still rejected), documented in the unit test.
+- **Fork-PR CI noise (dmwork-org → upstream)**: `secret-scan` / `dependency-review`
+  are expected FAILURE and non-blocking; the real gate is `check-sprint` (set the
+  Sprint field on the Octo Board) + Build/Test.
+- **`SpaceMiddleware` is opt-in — fail-open when the request carries no `space_id`.**
+  `pkg/space/middleware.go` returns `c.Next()` (no filter, no reject) if neither
+  `?space_id=` nor `X-Space-ID` is present. This is deliberate for backward
+  compatibility with pre-Space clients, but it means DM isolation on reaction
+  reads/writes is *only enforced when the client opts in*. The client-side rule
+  documented in the web contract is: **reaction requests must carry the same
+  Space parameter the client already sends to `/v1/message`**; otherwise the
+  reaction view can diverge from the message view. Non-member `space_id` is a
+  hard 403 from the middleware with a raw JSON body (`{"msg":"无权访问该 Space"}`),
+  not the i18n envelope — clients need to handle both response shapes on reaction
+  endpoints.
+
+## Out of scope
+
+Sticker reactions (server stores only `emoji`), `reaction_type`/`reaction_key` wire
+fields (web derives from `emoji`), inline summary/count for large channels, a
+by-message-id reaction endpoint, and a server-side reaction feature flag.

--- a/.octospec/tasks/message-reaction-hardening/brief.md
+++ b/.octospec/tasks/message-reaction-hardening/brief.md
@@ -1,0 +1,76 @@
+---
+type: Task
+title: "Task: message-reaction-hardening"
+description: Harden message reactions (channel-scoped, visibility-gated, text-only) and upgrade to a multi-reaction model with an atomic upsert; align write/sync/read authorization.
+tags: ["message", "reaction", "acl", "wire-contract", "auth", "thread", "i18n", "error-response"]
+timestamp: 2026-07-16T00:00:00Z
+# --- octospec extension fields ---
+slug: message-reaction-hardening
+upstream: web reaction handoff
+source: self
+---
+
+# Task: message-reaction-hardening
+
+## Goal
+
+Make the message reaction API safe to ship and aligned with the web reaction UX:
+bind every reaction entry point (write / sync / inline read) to the real message
+channel and the caller's current visibility, and upgrade storage from
+single-reaction-per-user to a multi-reaction model (Slack/企微-style: each emoji
+an independent toggle).
+
+## Background
+
+The server already had `POST /v1/reactions`, `POST /v1/reaction/sync`, and inline
+`reactions` on message responses. The original implementation stored a single
+`emoji` per user/message and only gated the group write path (`ExistMember`);
+sync/read paths and cross-channel scoping were unguarded. The web client (reaction
+API spec handoff) implements a multi-reaction UI with optimistic updates, so the
+server needed both a security pass and a semantics change.
+
+Scope grew in two rounds, both delivered under this task:
+1. Channel-scoping + write-path visibility hardening + text-only restriction.
+2. Multi-reaction model + write/sync/read authorization parity (external review F1–F4).
+
+## Load-bearing list
+
+- All reaction reads/writes are scoped by `(channel_id, channel_type, message_id)`;
+  the global `message_id`-only queries are removed (no cross-channel row leak).
+- **Write** (`POST /v1/reactions`) rejects a reaction unless the target message
+  exists in the requested channel and is visible to the caller (revoked / deleted /
+  user-deleted / `visibles` / expired / offset-truncated all fail closed), enforces
+  active-member (group) and parent-group active-member + non-deleted-thread (topic)
+  access, and only allows plain-text messages (`payload.type == 1`).
+- **Sync** (`POST /v1/reaction/sync`) uses the same membership posture
+  (`ExistMemberActive`, topic parent-group + non-deleted-thread, unknown type
+  rejected) and filters out reactions whose target message is no longer visible to
+  the caller (shared `messageVisibleToViewer` predicate).
+- Multi-reaction: `(uid, message_id, channel, emoji)` is unique; toggling is an
+  atomic `INSERT ... ON DUPLICATE KEY UPDATE is_deleted = 1 - is_deleted` upsert.
+- Wire compatibility: inline `reactions[]` fields (`seq`/`uid`/`name`/`emoji`/
+  `is_deleted`/`created_at`) unchanged; write endpoint additionally returns the
+  final `{emoji, seq, is_deleted}`; `syncMessageReaction` CMD param gains
+  `message_id/emoji/seq`.
+- Error responses stay on the i18n envelope; new `reaction_unsupported_type` code.
+
+## Out of scope
+
+- Sticker reactions (`reaction_type`, sticker metadata / renderable URL) — server
+  stores only the `emoji` string; clients fall back `reaction_key = emoji`.
+- `reaction_type` / `reaction_key` wire fields (web derives them from `emoji`).
+- Inline-read summary/count form for large channels (full detail is inlined).
+- A dedicated "reactions by message_id" endpoint (sync-by-channel+seq is reused).
+- Server-side feature flag / appconfig field for reaction rollout.
+- Frontend reaction menu / chip rendering / CMD client handling.
+
+## Acceptance
+
+- Wrong-channel writes are rejected and leave no `reaction_users` row.
+- Revoked / deleted / invisible / non-text messages cannot be reacted to.
+- Multi-emoji: different emojis are independent rows; same emoji toggles in place;
+  repeated toggles never create duplicate rows (unique index + atomic upsert).
+- Sync rejects non-member topic / unknown channel type, and hides reactions whose
+  target message is no longer visible (e.g. revoked).
+- `go build ./...`, `go vet -tags integration ./modules/message/`, focused unit +
+  integration tests, `make i18n-lint` all pass.

--- a/modules/message/api.go
+++ b/modules/message/api.go
@@ -338,12 +338,14 @@ func (m *Message) Route(r *wkhttp.WKHttp) {
 		// messages.PUT("/:message_id/voicereaded", m.voiceReaded)
 		messages.GET("/:message_id/receipt", m.messageReceiptList) // 消息回执列表
 	}
-	// 回应
-	reactions := r.Group("/v1/reactions", m.ctx.AuthMiddleware(r), uidLimit)
+	// 回应。挂 SpaceMiddleware：Person(DM)是跨 Space 共享的同一物理频道，
+	// reaction 读/写必须与 /v1/message 一样按已校验的 Space 隔离 DM 消息，
+	// 否则 sync 会泄露其它 Space 的 DM reaction 元数据、write 会给跨 Space DM 消息点回应。
+	reactions := r.Group("/v1/reactions", m.ctx.AuthMiddleware(r), uidLimit, spacepkg.SpaceMiddleware(m.ctx))
 	{
 		reactions.POST("", m.addOrCancelReaction) // 添加或取消回应
 	}
-	reaction := r.Group("/v1/reaction", m.ctx.AuthMiddleware(r), uidLimit)
+	reaction := r.Group("/v1/reaction", m.ctx.AuthMiddleware(r), uidLimit, spacepkg.SpaceMiddleware(m.ctx))
 	{
 		reaction.POST("/sync", m.syncReaction)
 	}
@@ -1689,9 +1691,11 @@ func (m *Message) syncReaction(c *wkhttp.Context) {
 		respondMessageRequestInvalid(c, "")
 		return
 	}
-	// Verify channel membership before syncing reaction data
+	// 同步鉴权必须与写路径（addOrCancelReaction）对齐：Group/子区用 ExistMemberActive
+	// 排除黑名单，子区解析父群并校验未删除，未知类型一律拒绝。否则读/同步路径会成为
+	// 绕过写路径加固的短板（任意登录用户凭 channel_id 拉取 reaction 元数据）。
 	if req.ChannelType == common.ChannelTypeGroup.Uint8() {
-		isMember, err := m.groupService.ExistMember(req.ChannelID, loginUID)
+		isMember, err := m.groupService.ExistMemberActive(req.ChannelID, loginUID)
 		if err != nil {
 			m.Error("查询群成员关系错误", zap.Error(err))
 			httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
@@ -1714,6 +1718,36 @@ func (m *Message) syncReaction(c *wkhttp.Context) {
 				return
 			}
 		}
+	} else if req.ChannelType == common.ChannelTypeCommunityTopic.Uint8() {
+		parentGroupNo, shortID, perr := thread.ParseChannelID(req.ChannelID)
+		if perr != nil || parentGroupNo == "" {
+			m.Error("解析子区频道ID失败（reaction sync）", zap.Error(perr), zap.String("channelID", req.ChannelID))
+			respondMessageRequestInvalid(c, "channel_id")
+			return
+		}
+		isMember, err := m.groupService.ExistMemberActive(parentGroupNo, loginUID)
+		if err != nil {
+			m.Error("查询父群成员关系错误（reaction sync）", zap.Error(err), zap.String("groupNo", parentGroupNo))
+			httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
+			return
+		}
+		if !isMember {
+			httperr.ResponseErrorL(c, errcode.ErrMessageChannelAccessDenied, nil, nil)
+			return
+		}
+		ok, terr := m.threadNotDeleted(parentGroupNo, shortID)
+		if terr != nil {
+			m.Error("查询子区状态失败（reaction sync）", zap.Error(terr), zap.String("channelID", req.ChannelID))
+			httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
+			return
+		}
+		if !ok {
+			httperr.ResponseErrorL(c, errcode.ErrMessageNotFound, nil, nil)
+			return
+		}
+	} else {
+		respondMessageRequestInvalid(c, "channel_type")
+		return
 	}
 
 	fakeChannelID := req.ChannelID
@@ -1745,6 +1779,35 @@ func (m *Message) syncReaction(c *wkhttp.Context) {
 		return
 	}
 
+	// 读时可见性过滤：reaction 行不会在消息撤回/删除/用户清理/偏移截断后被清理，
+	// 必须按调用者当前可见性剔除目标消息不可见的 reaction，避免泄露 message_id/uid/
+	// name/emoji（写路径已拦不可见消息，读路径必须对齐）。
+	//
+	// Person(DM)额外按已校验的 Space 过滤：DM 是跨 Space 共享的同一物理频道，
+	// 不加这层会把其它 Space 的 DM reaction 元数据透出（对齐 /v1/message 的
+	// filterPersonMessagesBySpace / YUJ-226）。SpaceMiddleware 未 opt-in 时
+	// spaceID=="" → 跳过，向前兼容。
+	var spaceID, defaultSpaceID string
+	var isSysBot bool
+	if req.ChannelType == common.ChannelTypePerson.Uint8() {
+		if spaceID = spacepkg.GetSpaceID(c); spaceID != "" {
+			var derr error
+			defaultSpaceID, derr = space.GetUserDefaultSpaceIDE(m.ctx, loginUID)
+			if derr != nil {
+				m.Warn("查询默认 Space 失败，DM reaction 无标签历史按兼容口径保留",
+					zap.Error(derr), zap.String("loginUID", loginUID))
+				defaultSpaceID = spaceID
+			}
+			isSysBot = spacepkg.IsSystemBot(req.ChannelID)
+		}
+	}
+	list, err = m.filterReactionsByMessageVisibility(fakeChannelID, req.ChannelType, loginUID, spaceID, defaultSpaceID, isSysBot, list)
+	if err != nil {
+		m.Error("过滤 reaction 可见性失败", zap.Error(err), zap.String("channel_id", fakeChannelID))
+		httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
+		return
+	}
+
 	toChannelID := common.GetToChannelIDWithFakeChannelID(fakeChannelID, loginUID)
 
 	reactions := make([]*reactionResp, 0)
@@ -1766,6 +1829,106 @@ func (m *Message) syncReaction(c *wkhttp.Context) {
 	c.JSON(http.StatusOK, reactions)
 }
 
+// filterReactionsByMessageVisibility 按调用者对每条目标消息的当前可见性过滤 reaction 行。
+// channelID 为存储态频道 ID（私聊传 fakeChannelID），与 reaction_users / message 分表一致。
+// 固定 5 个批量/单次查询（消息本体 + extra + user_extra + 用户偏移 + 频道偏移），不随
+// reaction 数放大。目标消息在本地分表查不到（nil）一律视为不可见并剔除。
+//
+// spaceID != "" 时对 Person(DM)额外按 Space 过滤（isSysBot/defaultSpaceID 由调用方就
+// 频道预算一次），口径与 filterPersonMessagesBySpace 完全一致（共用 personSpaceAllows）。
+func (m *Message) filterReactionsByMessageVisibility(channelID string, channelType uint8, loginUID string, spaceID, defaultSpaceID string, isSysBot bool, list []*reactionModel) ([]*reactionModel, error) {
+	if len(list) == 0 {
+		return list, nil
+	}
+	spaceScoped := spaceID != "" && channelType == common.ChannelTypePerson.Uint8()
+	seen := make(map[string]struct{}, len(list))
+	ids := make([]string, 0, len(list))
+	for _, r := range list {
+		if _, ok := seen[r.MessageID]; ok {
+			continue
+		}
+		seen[r.MessageID] = struct{}{}
+		ids = append(ids, r.MessageID)
+	}
+
+	msgs, err := m.db.queryMessagesByIDs(channelID, channelType, ids)
+	if err != nil {
+		return nil, err
+	}
+	msgByID := make(map[string]*messageModel, len(msgs))
+	for _, mm := range msgs {
+		msgByID[strconv.FormatInt(mm.MessageID, 10)] = mm
+	}
+
+	extras, err := m.messageExtraDB.queryWithMessageIDsAndUID(ids, loginUID)
+	if err != nil {
+		return nil, err
+	}
+	extraByID := make(map[string]*messageExtraDetailModel, len(extras))
+	for _, e := range extras {
+		extraByID[e.MessageID] = e
+	}
+
+	userExtras, err := m.messageUserExtraDB.queryWithMessageIDsAndUID(ids, loginUID)
+	if err != nil {
+		return nil, err
+	}
+	userExtraByID := make(map[string]*messageUserExtraModel, len(userExtras))
+	for _, ue := range userExtras {
+		userExtraByID[ue.MessageID] = ue
+	}
+
+	var userOffsetSeq uint32
+	userOffset, err := m.channelOffsetDB.queryWithUIDAndChannel(loginUID, channelID, channelType)
+	if err != nil {
+		return nil, err
+	}
+	if userOffset != nil {
+		userOffsetSeq = userOffset.MessageSeq
+	}
+	channelOffsetSeq, err := m.reactionChannelOffsetSeq(channelID, channelType, loginUID)
+	if err != nil {
+		return nil, err
+	}
+
+	visible := make(map[string]bool, len(ids))
+	for _, id := range ids {
+		mm := msgByID[id]
+		if mm == nil {
+			visible[id] = false
+			continue
+		}
+		if !messageVisibleToViewer(mm, extraByID[id], userExtraByID[id], userOffsetSeq, channelOffsetSeq, loginUID) {
+			visible[id] = false
+			continue
+		}
+		if spaceScoped && !personSpaceAllows(payloadSpaceIDFromRaw(mm.Payload), isSysBot, spaceID, defaultSpaceID) {
+			visible[id] = false
+			continue
+		}
+		// 类型门与写路径 payloadIsPlainText 对齐：本期仅纯文本消息可承载 reaction。
+		// 写侧已在 addOrCancelReaction 拦截，但读侧仍需过滤，兜住历史存量或未来其它
+		// 写路径可能绕过的非文本 reaction 行，避免下发。
+		if !payloadIsPlainText(mm.Payload) {
+			visible[id] = false
+			continue
+		}
+		visible[id] = true
+	}
+
+	out := make([]*reactionModel, 0, len(list))
+	for _, r := range list {
+		if visible[r.MessageID] {
+			out = append(out, r)
+		}
+	}
+	return out, nil
+}
+
+// maxReactionEmojiRunes 与 reaction_users.emoji 的 varchar(20) 对齐：写入前按 rune
+// 数拦截超长 emoji，避免 DB 静默截断或报错。
+const maxReactionEmojiRunes = 20
+
 // 添加或取消回应
 func (m *Message) addOrCancelReaction(c *wkhttp.Context) {
 	loginUID := c.GetLoginUID()
@@ -1781,9 +1944,38 @@ func (m *Message) addOrCancelReaction(c *wkhttp.Context) {
 		respondMessageRequestInvalid(c, "")
 		return
 	}
+	req.ChannelID = strings.TrimSpace(req.ChannelID)
+	req.MessageID = strings.TrimSpace(req.MessageID)
+	req.Emoji = strings.TrimSpace(req.Emoji)
+	if req.ChannelID == "" {
+		respondMessageRequestInvalid(c, "channel_id")
+		return
+	}
+	messageID, ok := parsePositiveMessageID(req.MessageID)
+	if !ok {
+		respondMessageRequestInvalid(c, "message_id")
+		return
+	}
+	// 规范化：parsePositiveMessageID 接受 "+910000"/"0910000" 等非规范整数写法，
+	// 但 message_id 在 message / reaction_users 表里以规范十进制串存储。回写后所有
+	// 后续查询（queryMessageByID、toggleReaction、可见性 idList）用同一个规范串，
+	// 避免非规范输入静默 404 / reaction 与消息主行 message_id 串形态不一致。
+	req.MessageID = strconv.FormatInt(messageID, 10)
+	if req.Emoji == "" {
+		respondMessageRequestInvalid(c, "emoji")
+		return
+	}
+	// emoji 存 varchar(20)：按 rune 上限拦截，避免超长输入被 DB 静默截断/报错。
+	// unicode emoji（含 ZWJ 序列）与项目 token（[xxx]）都远短于此。
+	if utf8.RuneCountInString(req.Emoji) > maxReactionEmojiRunes {
+		respondMessageRequestInvalid(c, "emoji")
+		return
+	}
+	fakeChannelID := req.ChannelID
+
 	// Verify channel membership before allowing reaction
 	if req.ChannelType == common.ChannelTypeGroup.Uint8() {
-		isMember, err := m.groupService.ExistMember(req.ChannelID, loginUID)
+		isMember, err := m.groupService.ExistMemberActive(req.ChannelID, loginUID)
 		if err != nil {
 			m.Error("查询群成员关系错误", zap.Error(err))
 			httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
@@ -1794,6 +1986,7 @@ func (m *Message) addOrCancelReaction(c *wkhttp.Context) {
 			return
 		}
 	} else if req.ChannelType == common.ChannelTypePerson.Uint8() {
+		fakeChannelID = common.GetFakeChannelIDWith(req.ChannelID, loginUID)
 		if req.ChannelID != loginUID {
 			isFriend, err := m.userService.IsFriend(loginUID, req.ChannelID)
 			if err != nil {
@@ -1806,9 +1999,55 @@ func (m *Message) addOrCancelReaction(c *wkhttp.Context) {
 				return
 			}
 		}
+	} else if req.ChannelType == common.ChannelTypeCommunityTopic.Uint8() {
+		parentGroupNo, shortID, perr := thread.ParseChannelID(req.ChannelID)
+		if perr != nil || parentGroupNo == "" {
+			m.Error("解析子区频道ID失败（reaction）", zap.Error(perr), zap.String("channelID", req.ChannelID))
+			respondMessageRequestInvalid(c, "channel_id")
+			return
+		}
+		isMember, err := m.groupService.ExistMemberActive(parentGroupNo, loginUID)
+		if err != nil {
+			m.Error("查询父群成员关系错误", zap.Error(err), zap.String("groupNo", parentGroupNo))
+			httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
+			return
+		}
+		if !isMember {
+			httperr.ResponseErrorL(c, errcode.ErrMessageChannelAccessDenied, nil, nil)
+			return
+		}
+		// 已删除子区 fail-closed（与 getThreadMessage 一致）：不允许对已删除子区的历史
+		// 消息添加/取消 reaction。thread 不存在/已删除一律 404，防枚举。
+		ok, terr := m.threadNotDeleted(parentGroupNo, shortID)
+		if terr != nil {
+			m.Error("查询子区状态失败（reaction）", zap.Error(terr), zap.String("channelID", req.ChannelID))
+			httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
+			return
+		}
+		if !ok {
+			httperr.ResponseErrorL(c, errcode.ErrMessageNotFound, nil, nil)
+			return
+		}
+		// 父群解散守卫（企业微信式只读）：与下面 Group 分支同语义，收在这里避免
+		// 再解析一次 ParseChannelID。
+		disbanded, err := m.isGroupDisbanded(parentGroupNo)
+		if err != nil {
+			m.Error("查询父群是否已解散错误", zap.Error(err))
+			httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
+			return
+		}
+		if disbanded {
+			httperr.ResponseErrorL(c, errcode.ErrMessageGroupDisbanded, nil, nil)
+			return
+		}
+	} else {
+		respondMessageRequestInvalid(c, "channel_type")
+		return
 	}
 
 	// 解散守卫（企业微信式只读）：群解散后禁止添加/取消回应。
+	// CommunityTopic 的父群解散判定已在上面的 auth 分支就地完成（复用同一次
+	// ParseChannelID），这里只处理 Group。
 	if req.ChannelType == common.ChannelTypeGroup.Uint8() {
 		disbanded, err := m.isGroupDisbanded(req.ChannelID)
 		if err != nil {
@@ -1820,97 +2059,206 @@ func (m *Message) addOrCancelReaction(c *wkhttp.Context) {
 			httperr.ResponseErrorL(c, errcode.ErrMessageGroupDisbanded, nil, nil)
 			return
 		}
-	} else if req.ChannelType == common.ChannelTypeCommunityTopic.Uint8() {
-		parentGroupNo, _, perr := thread.ParseChannelID(req.ChannelID)
-		if perr != nil || parentGroupNo == "" {
-			m.Error("解析子区频道ID失败（reaction）", zap.Error(perr), zap.String("channelID", req.ChannelID))
-			httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
-			return
-		}
-		disbanded, err := m.isGroupDisbanded(parentGroupNo)
-		if err != nil {
-			m.Error("查询父群是否已解散错误", zap.Error(err))
-			httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
-			return
-		}
-		if disbanded {
-			httperr.ResponseErrorL(c, errcode.ErrMessageGroupDisbanded, nil, nil)
-			return
-		}
 	}
 
-	model, err := m.messageReactionDB.queryReactionWithUIDAndMessageID(loginUID, req.MessageID)
+	msgModel, err := m.db.queryMessageByID(fakeChannelID, req.ChannelType, req.MessageID)
 	if err != nil {
-		m.Error("查询登录用户是否回应消息错误", zap.Error(err))
+		m.Error("查询 reaction 目标消息失败", zap.Error(err), zap.String("channel_id", fakeChannelID), zap.String("message_id", req.MessageID))
 		httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 		return
 	}
-	fakeChannelID := req.ChannelID
-	if req.ChannelType == common.ChannelTypePerson.Uint8() {
-		fakeChannelID = common.GetFakeChannelIDWith(req.ChannelID, loginUID)
+	if msgModel == nil {
+		httperr.ResponseErrorL(c, errcode.ErrMessageNotFound, nil, nil)
+		return
 	}
-	seq, err := m.genMessageReactionSeq(fakeChannelID) // 下次回复seq
+	visible, err := m.reactionTargetVisibleToViewer(msgModel, messageID, loginUID)
+	if err != nil {
+		m.Error("校验 reaction 目标消息可见性失败", zap.Error(err), zap.String("channel_id", fakeChannelID), zap.String("message_id", req.MessageID))
+		httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
+		return
+	}
+	if !visible {
+		httperr.ResponseErrorL(c, errcode.ErrMessageNotFound, nil, nil)
+		return
+	}
+
+	// Person(DM)Space 隔离：DM 是跨 Space 共享的同一物理频道，禁止给不属于当前
+	// 已校验 Space 的 DM 消息点回应。与 syncReaction 读过滤共用 personSpaceAllows；
+	// 不匹配按 404 归并（防枚举，与不可见同码）。放在类型门之前，避免"跨 Space 非文本"
+	// 泄露类型信号。SpaceMiddleware 未 opt-in 时 spaceID=="" → 跳过（向前兼容）。
+	if req.ChannelType == common.ChannelTypePerson.Uint8() {
+		if spaceID := spacepkg.GetSpaceID(c); spaceID != "" {
+			defaultSpaceID, derr := space.GetUserDefaultSpaceIDE(m.ctx, loginUID)
+			if derr != nil {
+				m.Warn("查询默认 Space 失败，DM reaction 无标签消息按兼容口径放行",
+					zap.Error(derr), zap.String("loginUID", loginUID))
+				defaultSpaceID = spaceID
+			}
+			if !personSpaceAllows(payloadSpaceIDFromRaw(msgModel.Payload), spacepkg.IsSystemBot(req.ChannelID), spaceID, defaultSpaceID) {
+				httperr.ResponseErrorL(c, errcode.ErrMessageNotFound, nil, nil)
+				return
+			}
+		}
+	}
+
+	// 消息类型门：当前仅纯文本消息（common.Text=1）允许 reaction。放在可见性校验之后，
+	// 保证不可见/越权消息仍归并到 404（不泄露"消息存在但类型不支持"信号），只有对
+	// 调用者可见的非文本消息才返回明确的 unsupported_type。
+	if !payloadIsPlainText(msgModel.Payload) {
+		httperr.ResponseErrorL(c, errcode.ErrMessageReactionUnsupportedType, nil, nil)
+		return
+	}
+
+	seq, err := m.genMessageReactionSeq(fakeChannelID) // 本次 toggle 的新 seq
 	if err != nil {
 		m.Error("生成消息回应序列号失败", zap.Error(err))
 		httperr.ResponseErrorL(c, errcode.ErrMessageStoreFailed, nil, nil)
 		return
 	}
-	if model == nil {
-		//新增回应
-		err = m.messageReactionDB.insertReaction(&reactionModel{
-			ChannelID:   fakeChannelID,
-			ChannelType: req.ChannelType,
-			UID:         loginUID,
-			Name:        loginName,
-			MessageID:   req.MessageID,
-			Emoji:       req.Emoji,
-			Seq:         seq,
-			IsDeleted:   0,
-		})
-		if err != nil {
-			m.Error("新增消息回应错误", zap.Error(err))
-			httperr.ResponseErrorL(c, errcode.ErrMessageStoreFailed, nil, nil)
-			return
-		}
-	} else {
-		model.Seq = seq
-		if model.IsDeleted == 1 {
-			model.IsDeleted = 0
-			if model.Emoji != req.Emoji {
-				model.Emoji = req.Emoji
-			}
-		} else {
-			if model.Emoji == req.Emoji {
-				model.IsDeleted = 1
-			} else {
-				model.Emoji = req.Emoji
-			}
-		}
-		err = m.messageReactionDB.updateReactionStatus(model)
-		if err != nil {
-			m.Error("修改消息回应错误", zap.Error(err))
-			httperr.ResponseErrorL(c, errcode.ErrMessageStoreFailed, nil, nil)
-			return
-		}
+	// 多 reaction：按 (uid, message_id, channel, emoji) 原子 toggle。同 emoji 命中唯一键翻转
+	// is_deleted，不同 emoji 落各自独立行（追加）。返回最终 is_deleted 供 Web 乐观更新对账。
+	isDeleted, err := m.messageReactionDB.toggleReaction(&reactionModel{
+		ChannelID:   fakeChannelID,
+		ChannelType: req.ChannelType,
+		UID:         loginUID,
+		Name:        loginName,
+		MessageID:   req.MessageID,
+		Emoji:       req.Emoji,
+		Seq:         seq,
+	})
+	if err != nil {
+		m.Error("写入消息回应失败", zap.Error(err), zap.String("channel_id", fakeChannelID), zap.String("message_id", req.MessageID))
+		httperr.ResponseErrorL(c, errcode.ErrMessageStoreFailed, nil, nil)
+		return
 	}
 
-	//发送同步消息cmd
+	// 发送同步消息 cmd。param 带 message_id/emoji/seq，让 Web 精确定位消息 + emoji，
+	// 并用 seq 做乱序丢弃；无 param 也可降级为频道级失效 + 拉 /v1/reaction/sync 增量。
 	err = m.ctx.SendCMD(config.MsgCMDReq{
 		NoPersist:   true,
 		ChannelID:   req.ChannelID,
 		ChannelType: uint8(req.ChannelType),
 		CMD:         common.CMDSyncMessageReaction,
 		FromUID:     loginUID,
+		Param: map[string]interface{}{
+			"message_id":   req.MessageID,
+			"channel_id":   req.ChannelID,
+			"channel_type": req.ChannelType,
+			"emoji":        req.Emoji,
+			"seq":          seq,
+		},
 	})
 	if err != nil {
-		m.Error("发送同步命令失败！", zap.Error(err))
 		m.Error("发送同步命令失败", zap.Error(err))
 		httperr.ResponseErrorL(c, errcode.ErrMessageNotifyFailed, nil, nil)
 		return
 	}
 
-	c.ResponseOK()
+	c.Response(&reactionToggleResp{
+		MessageID:   req.MessageID,
+		ChannelID:   req.ChannelID,
+		ChannelType: req.ChannelType,
+		Emoji:       req.Emoji,
+		Seq:         seq,
+		IsDeleted:   isDeleted,
+	})
 }
+
+// messageVisibleToViewer 是「消息对当前用户是否可见」的纯谓词，写路径（单条）与 sync
+// 路径（批量）共用同一套规则，避免两处判定分叉：
+//   - visibles 白名单未命中
+//   - message_extra 撤回 / 全局删除
+//   - message_user_extra 用户级删除
+//   - expire 过期
+//   - 用户级清理偏移（channel_offset）/ 频道级偏移（channel_setting）截断
+//
+// 入参 extra/userExtra 允许为 nil；offsetSeq 传 0 表示无该维度偏移。
+func messageVisibleToViewer(msg *messageModel, extra *messageExtraDetailModel, userExtra *messageUserExtraModel, userOffsetSeq uint32, channelOffsetSeq uint32, loginUID string) bool {
+	if !visiblesAllows(msg.Payload, loginUID) {
+		return false
+	}
+	if extra != nil && (extra.Revoke == 1 || extra.IsDeleted == 1) {
+		return false
+	}
+	if userExtra != nil && userExtra.MessageIsDeleted == 1 {
+		return false
+	}
+	if msg.Expire > 0 && time.Now().Unix()-int64(msg.Expire) >= int64(msg.Timestamp) {
+		return false
+	}
+	if userOffsetSeq > 0 && msg.MessageSeq <= userOffsetSeq {
+		return false
+	}
+	if channelOffsetSeq != 0 && msg.MessageSeq <= channelOffsetSeq {
+		return false
+	}
+	return true
+}
+
+func (m *Message) reactionTargetVisibleToViewer(msgModel *messageModel, messageID int64, loginUID string) (bool, error) {
+	// 只取 message_extra + message_user_extra（可见性判定所需）；不复用 fetchMessageExtras，
+	// 后者还会查 reactions（写路径用不到，避免多一次无谓 DB 往返）。
+	idList := []string{strconv.FormatInt(messageID, 10)}
+	var extra *messageExtraDetailModel
+	extras, err := m.messageExtraDB.queryWithMessageIDsAndUID(idList, loginUID)
+	if err != nil {
+		return false, err
+	}
+	if len(extras) > 0 {
+		extra = extras[0]
+	}
+	var userExtra *messageUserExtraModel
+	userExtras, err := m.messageUserExtraDB.queryWithMessageIDsAndUID(idList, loginUID)
+	if err != nil {
+		return false, err
+	}
+	if len(userExtras) > 0 {
+		userExtra = userExtras[0]
+	}
+	var userOffsetSeq uint32
+	userOffset, err := m.channelOffsetDB.queryWithUIDAndChannel(loginUID, msgModel.ChannelID, msgModel.ChannelType)
+	if err != nil {
+		return false, err
+	}
+	if userOffset != nil {
+		userOffsetSeq = userOffset.MessageSeq
+	}
+	channelOffsetSeq, err := m.reactionChannelOffsetSeq(msgModel.ChannelID, msgModel.ChannelType, loginUID)
+	if err != nil {
+		return false, err
+	}
+	return messageVisibleToViewer(msgModel, extra, userExtra, userOffsetSeq, channelOffsetSeq, loginUID), nil
+}
+
+// threadNotDeleted 校验子区本身未被删除（成员/父群鉴权由调用方前置完成）。
+// 返回 (ok, err)：err=DB 错误；ok=false 表示子区不存在或已删除（调用方按 404 处理，
+// 与 getThreadMessage 的 deleted fail-closed 一致，防枚举）。
+func (m *Message) threadNotDeleted(groupNo, shortID string) (bool, error) {
+	t, err := m.threadDB.QueryByGroupNoAndShortID(groupNo, shortID)
+	if err != nil {
+		return false, err
+	}
+	if t == nil || t.Status == thread.ThreadStatusDeleted {
+		return false, nil
+	}
+	return true, nil
+}
+
+func (m *Message) reactionChannelOffsetSeq(channelID string, channelType uint8, loginUID string) (uint32, error) {
+	lookupID := channelID
+	if channelType == common.ChannelTypePerson.Uint8() && !fakeChannelContainsUID(channelID, loginUID) {
+		lookupID = common.GetFakeChannelIDWith(channelID, loginUID)
+	}
+	settings, err := m.channelService.GetChannelSettings([]string{lookupID})
+	if err != nil {
+		return 0, err
+	}
+	if len(settings) > 0 && settings[0].OffsetMessageSeq > 0 {
+		return settings[0].OffsetMessageSeq, nil
+	}
+	return 0, nil
+}
+
 func (m *Message) handlerIMError(resp *rest.Response) error {
 	if resp.StatusCode != http.StatusOK {
 		if resp.StatusCode == http.StatusBadRequest {
@@ -3062,8 +3410,13 @@ func newSyncChannelMessageResp(resp *config.SyncChannelMessageResp, loginUID str
 			}
 		}
 
-		// 查询消息回应
-		messageReaction, err := messageReactionDB.queryWithMessageIDs(messageIDs)
+		reactionChannelID := channelID
+		if channelType == common.ChannelTypePerson.Uint8() {
+			reactionChannelID = common.GetFakeChannelIDWith(channelID, loginUID)
+		}
+		// 查询消息回应。必须按频道收口，避免只凭全局 message_id 把其它频道的脏
+		// reaction 行拼进当前消息响应。
+		messageReaction, err := messageReactionDB.queryWithMessageIDsInChannel(reactionChannelID, channelType, messageIDs)
 		if err != nil {
 			log.Error("查询消息回应数据错误", zap.Error(err))
 		}
@@ -3368,6 +3721,17 @@ type reactionSimpleResp struct {
 	Emoji     string `json:"emoji"`      // 回应的emoji
 	IsDeleted int    `json:"is_deleted"` // 是否删除
 	CreatedAt string `json:"created_at"`
+}
+
+// reactionToggleResp POST /v1/reactions 写接口返回该 emoji 的最终态，供 Web 乐观更新对账。
+// is_deleted=0 表示当前已点亮，=1 表示已取消（原子 toggle 盲翻转 + 并发下需回传结果）。
+type reactionToggleResp struct {
+	MessageID   string `json:"message_id"`
+	ChannelID   string `json:"channel_id"`
+	ChannelType uint8  `json:"channel_type"`
+	Emoji       string `json:"emoji"`
+	Seq         int64  `json:"seq"`
+	IsDeleted   int    `json:"is_deleted"`
 }
 
 // type userResp struct {

--- a/modules/message/api_conversation.go
+++ b/modules/message/api_conversation.go
@@ -1504,8 +1504,12 @@ func newSyncUserConversationResp(resp *config.SyncUserConversationResp, extra *c
 				messageExtraMap[messageExtra.MessageID] = messageExtra
 			}
 		}
-		// 消息回应
-		messageReaction, err := messageReactionDB.queryWithMessageIDs(messageIDs)
+		reactionChannelID := resp.ChannelID
+		if resp.ChannelType == common.ChannelTypePerson.Uint8() {
+			reactionChannelID = common.GetFakeChannelIDWith(resp.ChannelID, loginUID)
+		}
+		// 消息回应。按会话频道收口，避免只按 message_id 拉到其它频道 reaction。
+		messageReaction, err := messageReactionDB.queryWithMessageIDsInChannel(reactionChannelID, resp.ChannelType, messageIDs)
 		if err != nil {
 			log.Error("查询消息回应错误", zap.Error(err))
 		}

--- a/modules/message/api_message_get.go
+++ b/modules/message/api_message_get.go
@@ -59,6 +59,27 @@ func visiblesAllows(rawPayload []byte, loginUID string) bool {
 	return false
 }
 
+// payloadIsPlainText 从原始 payload 字节解析 type 字段，判定是否为纯文本消息
+// （common.Text=1）。当前 reaction 仅对纯文本开放，其它类型（图片/卡片/系统提示/
+// 通话记录等）一律拒绝。
+//
+// fail-closed：payload 非 JSON / 无 type / type 非整数 / type != 1 一律返回 false。
+// 用 json.Number 解析以兼容整数与被序列化成数字串的场景；1.0 这类浮点写法会因
+// Int64() 失败而落到 false（IM 落库的 type 恒为整数，正常文本消息不受影响）。
+func payloadIsPlainText(rawPayload []byte) bool {
+	var v struct {
+		Type json.Number `json:"type"`
+	}
+	if err := json.Unmarshal(rawPayload, &v); err != nil {
+		return false
+	}
+	n, err := v.Type.Int64()
+	if err != nil {
+		return false
+	}
+	return n == int64(common.Text.Int())
+}
+
 func msgModelToMessageResp(m *messageModel) *config.MessageResp {
 	resp := &config.MessageResp{
 		MessageID:   m.MessageID,
@@ -232,7 +253,7 @@ func (m *Message) respondSingleMessage(c *wkhttp.Context, channelID string, chan
 		return
 	}
 
-	extra, userExtra, reactions, err := m.fetchMessageExtras(messageID, loginUID)
+	extra, userExtra, reactions, err := m.fetchMessageExtras(messageID, loginUID, channelID, channelType)
 	if err != nil {
 		m.Error("查询消息扩展失败", zap.Error(err))
 		httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
@@ -292,7 +313,7 @@ func (m *Message) respondSingleMessage(c *wkhttp.Context, channelID string, chan
 
 // fetchMessageExtras 一次拉取 (message_extra, message_user_extra, reactions)。
 // 任意一步 DB 错误时返回 wrap 后的错误，由调用方决定响应。
-func (m *Message) fetchMessageExtras(messageID int64, loginUID string) (*messageExtraDetailModel, *messageUserExtraModel, []*reactionModel, error) {
+func (m *Message) fetchMessageExtras(messageID int64, loginUID string, channelID string, channelType uint8) (*messageExtraDetailModel, *messageUserExtraModel, []*reactionModel, error) {
 	idList := []string{strconv.FormatInt(messageID, 10)}
 
 	extras, err := m.messageExtraDB.queryWithMessageIDsAndUID(idList, loginUID)
@@ -315,7 +336,7 @@ func (m *Message) fetchMessageExtras(messageID int64, loginUID string) (*message
 		userExtra = userExtras[0]
 	}
 
-	reactions, err := m.messageReactionDB.queryWithMessageIDs(idList)
+	reactions, err := m.messageReactionDB.queryWithMessageIDsInChannel(channelID, channelType, idList)
 	if err != nil {
 		m.Error("查询消息反应失败", zap.Error(err))
 		return nil, nil, nil, errors.Wrap(err, "查询消息反应失败")

--- a/modules/message/api_pinned.go
+++ b/modules/message/api_pinned.go
@@ -634,8 +634,8 @@ func (m *Message) syncPinnedMessage(c *wkhttp.Context) {
 			messageUserExtraMap[messageUserExtraM.MessageID] = messageUserExtraM
 		}
 	}
-	// 查询消息回应
-	messageReaction, err := m.messageReactionDB.queryWithMessageIDs(messageIds)
+	// 查询消息回应。按 pinned 所属频道收口，避免同 message_id 的跨频道脏数据串入。
+	messageReaction, err := m.messageReactionDB.queryWithMessageIDsInChannel(fakeChannelID, req.ChannelType, messageIds)
 	if err != nil {
 		m.Error("查询消息回应数据错误", zap.Error(err))
 		httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)

--- a/modules/message/api_reaction_integration_test.go
+++ b/modules/message/api_reaction_integration_test.go
@@ -1,0 +1,543 @@
+//go:build integration
+
+package message
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strconv"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/server"
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	"github.com/Mininglamp-OSS/octo-server/modules/group"
+	"github.com/Mininglamp-OSS/octo-server/modules/thread"
+	"github.com/go-redis/redis"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMain(m *testing.M) {
+	if os.Getenv("OCTO_MASTER_KEY") == "" {
+		_ = os.Setenv("OCTO_MASTER_KEY", "0123456789abcdef0123456789abcdef")
+	}
+	os.Exit(m.Run())
+}
+
+func resetReactionUIDRateLimit(t *testing.T, ctx *config.Context) {
+	t.Helper()
+	rds := redis.NewClient(&redis.Options{
+		Addr:     ctx.GetConfig().DB.RedisAddr,
+		Password: ctx.GetConfig().DB.RedisPass,
+	})
+	defer rds.Close()
+	if keys, err := rds.Keys("ratelimit:uid:*").Result(); err == nil && len(keys) > 0 {
+		_ = rds.Del(keys...).Err()
+	}
+}
+
+func addReactionTestGroup(t *testing.T, ctx *config.Context) string {
+	t.Helper()
+	groupNo := newTestGroupNo()
+	groupDB := group.NewDB(ctx)
+	require.NoError(t, groupDB.Insert(&group.Model{
+		GroupNo: groupNo,
+		Name:    "reaction-test",
+		Creator: testutil.UID,
+		Status:  group.GroupStatusNormal,
+		Version: 1,
+	}))
+	require.NoError(t, groupDB.InsertMember(&group.MemberModel{
+		GroupNo: groupNo,
+		UID:     testutil.UID,
+		Role:    group.MemberRoleCreator,
+		Status:  int(common.GroupMemberStatusNormal),
+		Version: 1,
+	}))
+	return groupNo
+}
+
+func postReaction(t *testing.T, s *server.Server, body map[string]interface{}) *httptest.ResponseRecorder {
+	t.Helper()
+	raw, err := json.Marshal(body)
+	require.NoError(t, err)
+	w := httptest.NewRecorder()
+	req, err := http.NewRequest(http.MethodPost, "/v1/reactions", bytes.NewReader(raw))
+	require.NoError(t, err)
+	req.Header.Set("token", testutil.Token)
+	req.Header.Set("Content-Type", "application/json")
+	s.GetRoute().ServeHTTP(w, req)
+	return w
+}
+
+func countReactionRows(t *testing.T, ctx *config.Context, messageID int64) int {
+	t.Helper()
+	var count int
+	err := ctx.DB().Select("count(*)").From("reaction_users").
+		Where("message_id=?", strconv.FormatInt(messageID, 10)).
+		LoadOne(&count)
+	require.NoError(t, err)
+	return count
+}
+
+func queryReactionRow(t *testing.T, ctx *config.Context, messageID int64, channelID string, channelType uint8, emoji string) *reactionModel {
+	t.Helper()
+	var model *reactionModel
+	_, err := ctx.DB().Select("*").From("reaction_users").
+		Where("channel_id=? and channel_type=? and message_id=? and uid=? and emoji=?",
+			channelID, channelType, strconv.FormatInt(messageID, 10), testutil.UID, emoji).
+		Load(&model)
+	require.NoError(t, err)
+	require.NotNil(t, model)
+	return model
+}
+
+// decodeToggleResp 解析写接口返回的最终态 {emoji, seq, is_deleted}（c.Response 直出 data）。
+func decodeToggleResp(t *testing.T, w *httptest.ResponseRecorder) reactionToggleResp {
+	t.Helper()
+	var resp reactionToggleResp
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp), w.Body.String())
+	return resp
+}
+
+func TestReactionAcceptsVisibleMessageAndToggles(t *testing.T) {
+	s, ctx, groupNo := setupGroupTestData(t)
+	resetReactionUIDRateLimit(t, ctx)
+
+	const mid int64 = 910000
+	insertGroupMessage(t, ctx, groupNo, common.ChannelTypeGroup.Uint8(), mid)
+
+	body := map[string]interface{}{
+		"message_id":   strconv.FormatInt(mid, 10),
+		"channel_id":   groupNo,
+		"channel_type": common.ChannelTypeGroup.Uint8(),
+		"emoji":        "👍",
+	}
+	w := postReaction(t, s, body)
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	assert.Equal(t, 0, decodeToggleResp(t, w).IsDeleted, "首次点亮返回 is_deleted=0")
+	model := queryReactionRow(t, ctx, mid, groupNo, common.ChannelTypeGroup.Uint8(), "👍")
+	assert.Equal(t, "👍", model.Emoji)
+	assert.Equal(t, 0, model.IsDeleted)
+	assert.Equal(t, 1, countReactionRows(t, ctx, mid))
+
+	w = postReaction(t, s, body)
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	assert.Equal(t, 1, decodeToggleResp(t, w).IsDeleted, "再点同 emoji 取消，返回 is_deleted=1")
+	model = queryReactionRow(t, ctx, mid, groupNo, common.ChannelTypeGroup.Uint8(), "👍")
+	assert.Equal(t, 1, model.IsDeleted)
+	assert.Equal(t, 1, countReactionRows(t, ctx, mid), "toggle 复用同一行，不新增")
+}
+
+func TestReactionMultipleEmojisIndependent(t *testing.T) {
+	s, ctx, groupNo := setupGroupTestData(t)
+	resetReactionUIDRateLimit(t, ctx)
+
+	const mid int64 = 910004
+	insertGroupMessage(t, ctx, groupNo, common.ChannelTypeGroup.Uint8(), mid)
+	ct := common.ChannelTypeGroup.Uint8()
+	base := map[string]interface{}{"message_id": strconv.FormatInt(mid, 10), "channel_id": groupNo, "channel_type": ct}
+
+	post := func(emoji string) *httptest.ResponseRecorder {
+		b := map[string]interface{}{"emoji": emoji}
+		for k, v := range base {
+			b[k] = v
+		}
+		return postReaction(t, s, b)
+	}
+
+	// 点 👍 → 一行
+	require.Equal(t, http.StatusOK, post("👍").Code)
+	assert.Equal(t, 1, countReactionRows(t, ctx, mid))
+
+	// 点 ❤️（不同 emoji）→ 追加独立第二行，两行均 is_deleted=0
+	require.Equal(t, http.StatusOK, post("❤️").Code)
+	assert.Equal(t, 2, countReactionRows(t, ctx, mid))
+	assert.Equal(t, 0, queryReactionRow(t, ctx, mid, groupNo, ct, "👍").IsDeleted)
+	assert.Equal(t, 0, queryReactionRow(t, ctx, mid, groupNo, ct, "❤️").IsDeleted)
+
+	// 再点 👍 → 仅 👍 行 toggle 取消，❤️ 不受影响
+	require.Equal(t, http.StatusOK, post("👍").Code)
+	assert.Equal(t, 1, queryReactionRow(t, ctx, mid, groupNo, ct, "👍").IsDeleted, "👍 独立取消")
+	assert.Equal(t, 0, queryReactionRow(t, ctx, mid, groupNo, ct, "❤️").IsDeleted, "❤️ 不受影响")
+	assert.Equal(t, 2, countReactionRows(t, ctx, mid), "仍是两行，独立 toggle 不新增")
+}
+
+func TestReactionSameEmojiUpsertNoDuplicate(t *testing.T) {
+	s, ctx, groupNo := setupGroupTestData(t)
+	resetReactionUIDRateLimit(t, ctx)
+
+	const mid int64 = 910005
+	insertGroupMessage(t, ctx, groupNo, common.ChannelTypeGroup.Uint8(), mid)
+	body := map[string]interface{}{
+		"message_id":   strconv.FormatInt(mid, 10),
+		"channel_id":   groupNo,
+		"channel_type": common.ChannelTypeGroup.Uint8(),
+		"emoji":        "👍",
+	}
+
+	// 同 (uid, message, channel, emoji) 连续多次 toggle：唯一约束 + 原子 upsert 保证始终 ≤1 行。
+	for i := 0; i < 5; i++ {
+		require.Equal(t, http.StatusOK, postReaction(t, s, body).Code)
+	}
+	assert.Equal(t, 1, countReactionRows(t, ctx, mid), "同 emoji 反复 toggle 不产生重复行")
+}
+
+// ---------- 鉴权 / 可见性闭环（外部 review F1/F2/F3）----------
+
+func postReactionSync(t *testing.T, s *server.Server, body map[string]interface{}) *httptest.ResponseRecorder {
+	t.Helper()
+	raw, err := json.Marshal(body)
+	require.NoError(t, err)
+	w := httptest.NewRecorder()
+	req, err := http.NewRequest(http.MethodPost, "/v1/reaction/sync", bytes.NewReader(raw))
+	require.NoError(t, err)
+	req.Header.Set("token", testutil.Token)
+	req.Header.Set("Content-Type", "application/json")
+	s.GetRoute().ServeHTTP(w, req)
+	return w
+}
+
+// F2：已删除子区的历史消息不可被 reaction（与 getThreadMessage 的 deleted fail-closed 对齐）。
+func TestReactionRejectsDeletedThreadWrite(t *testing.T) {
+	s, ctx, groupNo := setupGroupTestData(t)
+	resetReactionUIDRateLimit(t, ctx)
+	shortID := newTestShortID()
+	insertTestThread(t, ctx, groupNo, shortID)
+	channelID := thread.BuildChannelID(groupNo, shortID)
+	const mid int64 = 910100
+	insertGroupMessage(t, ctx, channelID, common.ChannelTypeCommunityTopic.Uint8(), mid)
+
+	_, err := ctx.DB().UpdateBySql("UPDATE thread SET status=? WHERE group_no=? AND short_id=?",
+		thread.ThreadStatusDeleted, groupNo, shortID).Exec()
+	require.NoError(t, err)
+
+	w := postReaction(t, s, map[string]interface{}{
+		"message_id":   strconv.FormatInt(mid, 10),
+		"channel_id":   channelID,
+		"channel_type": common.ChannelTypeCommunityTopic.Uint8(),
+		"emoji":        "👍",
+	})
+	assert.NotEqual(t, http.StatusOK, w.Code, "deleted thread 不可 reaction")
+	assert.Equal(t, 0, countReactionRows(t, ctx, mid), "deleted-thread reaction 不落库")
+}
+
+// F1：syncReaction 对非父群成员的子区拒绝（旧代码完全绕过子区鉴权）。
+func TestSyncReactionRejectsNonMemberTopic(t *testing.T) {
+	s, ctx, _ := setupGroupTestData(t)
+	resetReactionUIDRateLimit(t, ctx)
+
+	// 另建一个 testutil.UID 不是成员的父群 + 活跃子区。
+	otherGroup := newTestGroupNo()
+	require.NoError(t, group.NewDB(ctx).Insert(&group.Model{
+		GroupNo: otherGroup, Name: "no-member", Creator: "someone-else",
+		Status: group.GroupStatusNormal, Version: 1,
+	}))
+	shortID := newTestShortID()
+	insertTestThread(t, ctx, otherGroup, shortID)
+	channelID := thread.BuildChannelID(otherGroup, shortID)
+
+	w := postReactionSync(t, s, map[string]interface{}{
+		"channel_id":   channelID,
+		"channel_type": common.ChannelTypeCommunityTopic.Uint8(),
+		"seq":          0,
+	})
+	// 明确断言 4xx（400 request_invalid / 403 channel_access_denied，均由 i18n 门面固定 400）：
+	// 若鉴权因 DB 抖动 500，NotEqual(200) 会静默通过，掩盖真实 bug。
+	assert.GreaterOrEqual(t, w.Code, 400, "非父群成员必须被拒绝: %d %s", w.Code, w.Body.String())
+	assert.Less(t, w.Code, 500, "拒绝不能是 5xx（否则可能是 DB 错误伪通过）: %d %s", w.Code, w.Body.String())
+}
+
+// F1：syncReaction 拒绝未知 channel_type（旧代码无 else，直接落到查询）。
+func TestSyncReactionRejectsUnknownChannelType(t *testing.T) {
+	s, ctx, _ := setupGroupTestData(t)
+	resetReactionUIDRateLimit(t, ctx)
+
+	w := postReactionSync(t, s, map[string]interface{}{
+		"channel_id":   "whatever",
+		"channel_type": 99,
+		"seq":          0,
+	})
+	assert.GreaterOrEqual(t, w.Code, 400, "未知 channel_type 必须被拒绝: %d %s", w.Code, w.Body.String())
+	assert.Less(t, w.Code, 500, "拒绝不能是 5xx: %d %s", w.Code, w.Body.String())
+}
+
+// ---------- 跨 Space DM 隔离（reviewer blocking: DM reaction 绕过 Space 隔离）----------
+
+const reactionPeerUID = "20001"
+
+func seedReactionFriend(t *testing.T, ctx *config.Context, uid, toUID string) {
+	t.Helper()
+	_, err := ctx.DB().InsertBySql(
+		"INSERT INTO friend (uid, to_uid, is_deleted) VALUES (?,?,0)", uid, toUID).Exec()
+	require.NoError(t, err)
+}
+
+// insertPersonMessageWithSpace 在 DM 物理频道(fakeChannelID)插入一条带 space_id 的纯文本消息。
+func insertPersonMessageWithSpace(t *testing.T, ctx *config.Context, fakeChannelID string, mid int64, spaceID string) {
+	t.Helper()
+	payload, err := json.Marshal(map[string]interface{}{"type": 1, "content": "dm", "space_id": spaceID})
+	require.NoError(t, err)
+	require.NoError(t, NewDB(ctx).insertMessage(&messageModel{
+		MessageID:   mid,
+		MessageSeq:  uint32(mid),
+		ClientMsgNo: "cli-dm-" + strconv.FormatInt(mid, 10),
+		FromUID:     testutil.UID,
+		ChannelID:   fakeChannelID,
+		ChannelType: common.ChannelTypePerson.Uint8(),
+		Payload:     payload,
+	}))
+}
+
+func postReactionWithSpace(t *testing.T, s *server.Server, path, spaceID string, body map[string]interface{}) *httptest.ResponseRecorder {
+	t.Helper()
+	raw, err := json.Marshal(body)
+	require.NoError(t, err)
+	w := httptest.NewRecorder()
+	req, err := http.NewRequest(http.MethodPost, path+"?space_id="+spaceID, bytes.NewReader(raw))
+	require.NoError(t, err)
+	req.Header.Set("token", testutil.Token)
+	req.Header.Set("Content-Type", "application/json")
+	s.GetRoute().ServeHTTP(w, req)
+	return w
+}
+
+// setupCrossSpaceDM: UID 是 spaceA(默认,较早)与 spaceB 的成员，与 peer 是好友，
+// DM 频道里有一条 space_id=spaceB 的文本消息。返回 (fakeChannelID, mid, spaceA, spaceB)。
+func setupCrossSpaceDM(t *testing.T) (*server.Server, *config.Context, string, int64, string, string) {
+	s, ctx := testutil.NewTestServer()
+	resetReactionUIDRateLimit(t, ctx)
+	spaceA, spaceB := "spcA"+strconv.FormatInt(nextShortID.Add(1), 10), "spcB"+strconv.FormatInt(nextShortID.Add(1), 10)
+	seedSpaceMemberRepro(t, ctx, spaceA, testutil.UID, "2020-01-01 00:00:00")
+	seedSpaceMemberRepro(t, ctx, spaceB, testutil.UID, "2020-06-01 00:00:00")
+	seedReactionFriend(t, ctx, testutil.UID, reactionPeerUID)
+	fakeChannelID := common.GetFakeChannelIDWith(testutil.UID, reactionPeerUID)
+	const mid int64 = 920001
+	insertPersonMessageWithSpace(t, ctx, fakeChannelID, mid, spaceB)
+	return s, ctx, fakeChannelID, mid, spaceA, spaceB
+}
+
+func TestReactionRejectsCrossSpaceDMWrite(t *testing.T) {
+	s, ctx, _, mid, spaceA, spaceB := setupCrossSpaceDM(t)
+
+	body := map[string]interface{}{
+		"message_id":   strconv.FormatInt(mid, 10),
+		"channel_id":   reactionPeerUID,
+		"channel_type": common.ChannelTypePerson.Uint8(),
+		"emoji":        "👍",
+	}
+	// 用非归属 Space(默认 spaceA)写 spaceB 的 DM 消息 → 拒绝，不落库。
+	w := postReactionWithSpace(t, s, "/v1/reactions", spaceA, body)
+	assert.NotEqual(t, http.StatusOK, w.Code, "cross-Space DM reaction write must be rejected")
+	assert.Equal(t, 0, countReactionRows(t, ctx, mid), "rejected cross-Space reaction must not persist")
+
+	// 用归属 Space(spaceB)写同一消息 → 允许。
+	w = postReactionWithSpace(t, s, "/v1/reactions", spaceB, body)
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	assert.Equal(t, 1, countReactionRows(t, ctx, mid), "in-Space reaction must persist")
+}
+
+func TestSyncReactionHidesCrossSpaceDMReaction(t *testing.T) {
+	s, ctx, _, mid, spaceA, spaceB := setupCrossSpaceDM(t)
+
+	// 先在归属 Space(spaceB)成功点一个 reaction。
+	body := map[string]interface{}{
+		"message_id":   strconv.FormatInt(mid, 10),
+		"channel_id":   reactionPeerUID,
+		"channel_type": common.ChannelTypePerson.Uint8(),
+		"emoji":        "👍",
+	}
+	require.Equal(t, http.StatusOK, postReactionWithSpace(t, s, "/v1/reactions", spaceB, body).Code)
+	require.Equal(t, 1, countReactionRows(t, ctx, mid))
+
+	syncBody := map[string]interface{}{"channel_id": reactionPeerUID, "channel_type": common.ChannelTypePerson.Uint8(), "seq": 0}
+
+	// 归属 Space(spaceB)sync → 能看到该 reaction。
+	w := postReactionWithSpace(t, s, "/v1/reaction/sync", spaceB, syncBody)
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	var inSpace []reactionResp
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &inSpace), w.Body.String())
+	found := false
+	for _, r := range inSpace {
+		if r.MessageID == strconv.FormatInt(mid, 10) {
+			found = true
+		}
+	}
+	assert.True(t, found, "in-Space sync should include the reaction")
+
+	// 非归属 Space(默认 spaceA)sync → 该 reaction 被 Space 过滤掉。
+	w = postReactionWithSpace(t, s, "/v1/reaction/sync", spaceA, syncBody)
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	var crossSpace []reactionResp
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &crossSpace), w.Body.String())
+	for _, r := range crossSpace {
+		assert.NotEqual(t, strconv.FormatInt(mid, 10), r.MessageID, "cross-Space DM reaction must not leak in sync")
+	}
+}
+
+// F3+P2#5：读侧也按 payload.type 过滤——手动落一条非文本消息对应的 reaction 行
+// （模拟历史存量或其它写路径绕过），syncReaction 必须剔除，不下发。
+func TestSyncReactionHidesNonTextMessageReaction(t *testing.T) {
+	s, ctx, groupNo := setupGroupTestData(t)
+	resetReactionUIDRateLimit(t, ctx)
+
+	// 插入一条图片消息（type=2）。
+	const mid int64 = 910300
+	msgDB := NewDB(ctx)
+	payload, err := json.Marshal(map[string]interface{}{"type": int(common.Image), "url": "http://example.com/x.png"})
+	require.NoError(t, err)
+	require.NoError(t, msgDB.insertMessage(&messageModel{
+		MessageID:   mid,
+		MessageSeq:  uint32(mid),
+		ClientMsgNo: "cli-img-910300",
+		FromUID:     testutil.UID,
+		ChannelID:   groupNo,
+		ChannelType: common.ChannelTypeGroup.Uint8(),
+		Payload:     payload,
+	}))
+	// 直接 DB 写入 reaction 行，绕过写路径的类型门（模拟历史脏数据）。
+	seq, err := ctx.GenSeq("messageReactionSeq:" + groupNo)
+	require.NoError(t, err)
+	_, err = New(ctx).messageReactionDB.toggleReaction(&reactionModel{
+		ChannelID: groupNo, ChannelType: common.ChannelTypeGroup.Uint8(), UID: testutil.UID,
+		Name: "u", MessageID: strconv.FormatInt(mid, 10), Emoji: "👍", Seq: seq,
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, countReactionRows(t, ctx, mid), "sanity: reaction 已落库")
+
+	// sync：读侧类型门应过滤掉该 reaction。
+	w := postReactionSync(t, s, map[string]interface{}{
+		"channel_id":   groupNo,
+		"channel_type": common.ChannelTypeGroup.Uint8(),
+		"seq":          0,
+	})
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	var got []reactionResp
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &got), w.Body.String())
+	for _, r := range got {
+		assert.NotEqual(t, strconv.FormatInt(mid, 10), r.MessageID, "非文本消息的 reaction 不应下发")
+	}
+}
+
+func TestSyncReactionHidesRevokedMessageReaction(t *testing.T) {
+	s, ctx, groupNo := setupGroupTestData(t)
+	resetReactionUIDRateLimit(t, ctx)
+
+	const mid int64 = 910200
+	insertGroupMessage(t, ctx, groupNo, common.ChannelTypeGroup.Uint8(), mid)
+
+	// 消息可见时先点 reaction（写路径通过）。
+	require.Equal(t, http.StatusOK, postReaction(t, s, map[string]interface{}{
+		"message_id":   strconv.FormatInt(mid, 10),
+		"channel_id":   groupNo,
+		"channel_type": common.ChannelTypeGroup.Uint8(),
+		"emoji":        "👍",
+	}).Code)
+	require.Equal(t, 1, countReactionRows(t, ctx, mid))
+
+	// 撤回该消息。reaction 行不会被清理，但 sync 必须按可见性剔除。
+	tx, err := ctx.DB().Begin()
+	require.NoError(t, err)
+	require.NoError(t, New(ctx).messageExtraDB.insertTx(&messageExtraModel{
+		MessageID: strconv.FormatInt(mid, 10), MessageSeq: uint32(mid),
+		ChannelID: groupNo, ChannelType: common.ChannelTypeGroup.Uint8(),
+		Revoke: 1, Revoker: testutil.UID, Version: 1,
+	}, tx))
+	require.NoError(t, tx.Commit())
+
+	w := postReactionSync(t, s, map[string]interface{}{
+		"channel_id":   groupNo,
+		"channel_type": common.ChannelTypeGroup.Uint8(),
+		"seq":          0,
+	})
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	var got []reactionResp
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &got), w.Body.String())
+	for _, r := range got {
+		assert.NotEqual(t, strconv.FormatInt(mid, 10), r.MessageID, "撤回消息的 reaction 不应下发")
+	}
+}
+
+func TestReactionRejectsMismatchedChannelWrite(t *testing.T) {
+	s, ctx, realGroupNo := setupGroupTestData(t)
+	resetReactionUIDRateLimit(t, ctx)
+	wrongGroupNo := addReactionTestGroup(t, ctx)
+
+	const mid int64 = 910001
+	insertGroupMessage(t, ctx, realGroupNo, common.ChannelTypeGroup.Uint8(), mid)
+
+	w := postReaction(t, s, map[string]interface{}{
+		"message_id":   strconv.FormatInt(mid, 10),
+		"channel_id":   wrongGroupNo,
+		"channel_type": common.ChannelTypeGroup.Uint8(),
+		"emoji":        "👍",
+	})
+
+	assert.NotEqual(t, http.StatusOK, w.Code, "wrong-channel reaction write must be rejected")
+	assert.Equal(t, 0, countReactionRows(t, ctx, mid), "rejected reaction must not leave a reaction_users row")
+}
+
+func TestReactionRejectsNonTextMessage(t *testing.T) {
+	s, ctx, groupNo := setupGroupTestData(t)
+	resetReactionUIDRateLimit(t, ctx)
+
+	// 插入一条图片消息（type=common.Image=2）。消息存在且对成员可见，仅类型不支持。
+	const mid int64 = 910003
+	msgDB := NewDB(ctx)
+	payload, err := json.Marshal(map[string]interface{}{"type": int(common.Image), "url": "http://example.com/a.png"})
+	require.NoError(t, err)
+	require.NoError(t, msgDB.insertMessage(&messageModel{
+		MessageID:   mid,
+		MessageSeq:  uint32(mid),
+		ClientMsgNo: "cli-img-910003",
+		FromUID:     testutil.UID,
+		ChannelID:   groupNo,
+		ChannelType: common.ChannelTypeGroup.Uint8(),
+		Payload:     payload,
+	}))
+
+	w := postReaction(t, s, map[string]interface{}{
+		"message_id":   strconv.FormatInt(mid, 10),
+		"channel_id":   groupNo,
+		"channel_type": common.ChannelTypeGroup.Uint8(),
+		"emoji":        "👍",
+	})
+
+	assert.NotEqual(t, http.StatusOK, w.Code, "non-text messages must not accept reactions")
+	assert.Equal(t, 0, countReactionRows(t, ctx, mid), "rejected non-text reaction must not be persisted")
+}
+
+func TestReactionRejectsRevokedMessageWrite(t *testing.T) {
+	s, ctx, groupNo := setupGroupTestData(t)
+	resetReactionUIDRateLimit(t, ctx)
+
+	const mid int64 = 910002
+	insertGroupMessage(t, ctx, groupNo, common.ChannelTypeGroup.Uint8(), mid)
+	tx, err := ctx.DB().Begin()
+	require.NoError(t, err)
+	require.NoError(t, New(ctx).messageExtraDB.insertTx(&messageExtraModel{
+		MessageID:   strconv.FormatInt(mid, 10),
+		MessageSeq:  uint32(mid),
+		ChannelID:   groupNo,
+		ChannelType: common.ChannelTypeGroup.Uint8(),
+		Revoke:      1,
+		Revoker:     testutil.UID,
+		Version:     1,
+	}, tx))
+	require.NoError(t, tx.Commit())
+
+	w := postReaction(t, s, map[string]interface{}{
+		"message_id":   strconv.FormatInt(mid, 10),
+		"channel_id":   groupNo,
+		"channel_type": common.ChannelTypeGroup.Uint8(),
+		"emoji":        "👍",
+	})
+
+	assert.NotEqual(t, http.StatusOK, w.Code, "revoked messages must not accept reactions")
+	assert.Equal(t, 0, countReactionRows(t, ctx, mid), "revoked-message reaction must not be persisted")
+}

--- a/modules/message/db.go
+++ b/modules/message/db.go
@@ -44,6 +44,24 @@ func (d *DB) queryMessageByID(channelID string, channelType uint8, messageID str
 	return model, nil
 }
 
+// queryMessagesByIDs 按 (channelID, channelType, message_id IN ...) 批量查同一频道下的
+// 多条消息正文（is_deleted=0）。message_id 列为 VARCHAR(20)，必须以字符串切片绑定才能
+// 命中索引（同 queryMessageByID 的隐式类型转换说明）。同一频道所有消息落同一分表
+// (getTable 按 channelID 取模)，故一次查询即可。
+func (d *DB) queryMessagesByIDs(channelID string, channelType uint8, messageIDs []string) ([]*messageModel, error) {
+	if len(messageIDs) == 0 {
+		return nil, nil
+	}
+	var models []*messageModel
+	_, err := d.session.Select("*").From(d.getTable(channelID)).
+		Where("channel_id=? AND channel_type=? AND message_id in ? AND is_deleted=0", channelID, channelType, messageIDs).
+		Load(&models)
+	if err != nil {
+		return nil, err
+	}
+	return models, nil
+}
+
 func (d *DB) queryMaxMessageSeq(channelID string, channelType uint8) (uint32, error) {
 	var maxMessageSeq uint32
 	err := d.session.Select("IFNULL(max(message_seq),0)").From(d.getTable(channelID)).Where("channel_id=? and channel_type=?", channelID, channelType).LoadOne(&maxMessageSeq)

--- a/modules/message/db_message_reaction.go
+++ b/modules/message/db_message_reaction.go
@@ -3,7 +3,6 @@ package message
 import (
 	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/db"
-	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
 	"github.com/gocraft/dbr/v2"
 )
 
@@ -31,36 +30,42 @@ func (d *messageReactionDB) queryReactionWithChannelAndSeq(channelID string, cha
 	return list, err
 }
 
-func (d *messageReactionDB) queryWithMessageIDs(messageIDs []string) ([]*reactionModel, error) {
+func (d *messageReactionDB) queryWithMessageIDsInChannel(channelID string, channelType uint8, messageIDs []string) ([]*reactionModel, error) {
 	if len(messageIDs) <= 0 {
 		return nil, nil
 	}
 	var models []*reactionModel
-	_, err := d.session.Select("*").From("reaction_users").Where("message_id in ?", messageIDs).Load(&models)
+	_, err := d.session.Select("*").From("reaction_users").
+		Where("channel_id=? and channel_type=? and message_id in ?", channelID, channelType, messageIDs).
+		Load(&models)
 	return models, err
 }
 
-// 查询某个用户的回应数据
-func (d *messageReactionDB) queryReactionWithUIDAndMessageID(uid string, messageID string) (*reactionModel, error) {
-	var model *reactionModel
-	_, err := d.session.Select("*").From("reaction_users").Where("uid=? and message_id=?", uid, messageID).Load(&model)
-	return model, err
-}
-
-// 新增回应
-func (d *messageReactionDB) insertReaction(model *reactionModel) error {
-	_, err := d.session.InsertInto("reaction_users").Columns(util.AttrToUnderscore(model)...).Record(model).Exec()
-	return err
-}
-
-// 修改某条消息的回应
-func (d *messageReactionDB) updateReactionStatus(model *reactionModel) error {
-	_, err := d.session.Update("reaction_users").SetMap(map[string]interface{}{
-		"is_deleted": model.IsDeleted,
-		"seq":        model.Seq,
-		"emoji":      model.Emoji,
-	}).Where("message_id=? and uid=?", model.MessageID, model.UID).Exec()
-	return err
+// toggleReaction 对单个 (uid, message_id, channel_id, channel_type, emoji) 做原子 toggle：
+// 首次命中 → 插入 is_deleted=0（点亮）；再次命中唯一键 → is_deleted 翻转（0→1 取消 /
+// 1→0 复活）。依赖迁移 20260712000001 建的唯一索引触发 ON DUPLICATE KEY UPDATE，
+// 单条语句原子完成，天然防并发重复行。每次都写入新的 seq，供频道级增量 sync 感知变更。
+//
+// 多 reaction 语义：不同 emoji 命中不同唯一键 → 各自独立行，互不影响（追加），
+// 不再有"改 emoji 覆盖"分支。
+//
+// upsert 后回读该行最终 is_deleted 返回，供 Web 乐观更新对账（盲翻转 + 并发下需知道结果）。
+func (d *messageReactionDB) toggleReaction(model *reactionModel) (int, error) {
+	_, err := d.session.InsertBySql(
+		"INSERT INTO reaction_users (message_id, seq, channel_id, channel_type, uid, name, emoji, is_deleted) "+
+			"VALUES (?,?,?,?,?,?,?,0) "+
+			"ON DUPLICATE KEY UPDATE is_deleted = 1 - is_deleted, seq = VALUES(seq), name = VALUES(name), updated_at = CURRENT_TIMESTAMP",
+		model.MessageID, model.Seq, model.ChannelID, model.ChannelType, model.UID, model.Name, model.Emoji,
+	).Exec()
+	if err != nil {
+		return 0, err
+	}
+	var isDeleted int
+	err = d.session.Select("is_deleted").From("reaction_users").
+		Where("channel_id=? and channel_type=? and message_id=? and uid=? and emoji=?",
+			model.ChannelID, model.ChannelType, model.MessageID, model.UID, model.Emoji).
+		LoadOne(&isDeleted)
+	return isDeleted, err
 }
 
 type reactionModel struct {

--- a/modules/message/db_message_reaction_test.go
+++ b/modules/message/db_message_reaction_test.go
@@ -1,0 +1,61 @@
+package message
+
+import (
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/gocraft/dbr/v2"
+	"github.com/gocraft/dbr/v2/dialect"
+	"github.com/stretchr/testify/require"
+)
+
+func newMockReactionDB(t *testing.T) (*messageReactionDB, sqlmock.Sqlmock, func()) {
+	t.Helper()
+	rawDB, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	conn := &dbr.Connection{DB: rawDB, EventReceiver: &dbr.NullEventReceiver{}, Dialect: dialect.MySQL}
+	return &messageReactionDB{session: conn.NewSession(nil)}, mock, func() { _ = rawDB.Close() }
+}
+
+func reactionRows() *sqlmock.Rows {
+	now := time.Now()
+	return sqlmock.NewRows([]string{
+		"id", "message_id", "seq", "channel_id", "channel_type", "uid", "name", "emoji", "is_deleted", "created_at", "updated_at",
+	}).AddRow(1, "9001", 7, "group-a", 2, "u1", "User 1", "👍", 0, now, now)
+}
+
+func TestMessageReactionDB_QueryWithMessageIDsScopedToChannel(t *testing.T) {
+	db, mock, cleanup := newMockReactionDB(t)
+	defer cleanup()
+
+	mock.ExpectQuery("SELECT \\* FROM reaction_users WHERE \\(channel_id='group-a' and channel_type=2 and message_id in \\('9001'\\)\\)").
+		WillReturnRows(reactionRows())
+
+	got, err := db.queryWithMessageIDsInChannel("group-a", 2, []string{"9001"})
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	require.Equal(t, "group-a", got[0].ChannelID)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestMessageReactionDB_ToggleReactionUpsertsAndReadsBack(t *testing.T) {
+	db, mock, cleanup := newMockReactionDB(t)
+	defer cleanup()
+
+	// 原子 upsert：INSERT ... ON DUPLICATE KEY UPDATE is_deleted = 1 - is_deleted。
+	// dbr 默认客户端插值，sqlmock 收到的是已内联值的语句（无占位参数）。
+	mock.ExpectExec("INSERT INTO reaction_users .*VALUES \\('9001',7,'group-a',2,'u1','User 1','👍',0\\) ON DUPLICATE KEY UPDATE is_deleted = 1 - is_deleted").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	// 回读该 (channel, message, uid, emoji) 行的最终 is_deleted。
+	mock.ExpectQuery("SELECT is_deleted FROM reaction_users WHERE \\(channel_id='group-a' and channel_type=2 and message_id='9001' and uid='u1' and emoji='👍'\\)").
+		WillReturnRows(sqlmock.NewRows([]string{"is_deleted"}).AddRow(1))
+
+	isDeleted, err := db.toggleReaction(&reactionModel{
+		ChannelID: "group-a", ChannelType: 2, UID: "u1", Name: "User 1",
+		MessageID: "9001", Emoji: "👍", Seq: 7,
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, isDeleted)
+	require.NoError(t, mock.ExpectationsWereMet())
+}

--- a/modules/message/message_visibility_test.go
+++ b/modules/message/message_visibility_test.go
@@ -1,0 +1,46 @@
+package message
+
+import (
+	"testing"
+	"time"
+)
+
+func TestMessageVisibleToViewer(t *testing.T) {
+	const uid = "u1"
+	now := time.Now().Unix()
+	textPayload := []byte(`{"type":1,"content":"hi"}`)
+
+	baseMsg := func() *messageModel {
+		return &messageModel{MessageID: 1, MessageSeq: 5, Payload: textPayload, Timestamp: now}
+	}
+
+	cases := []struct {
+		name             string
+		msg              *messageModel
+		extra            *messageExtraDetailModel
+		userExtra        *messageUserExtraModel
+		userOffsetSeq    uint32
+		channelOffsetSeq uint32
+		want             bool
+	}{
+		{"visible_baseline", baseMsg(), nil, nil, 0, 0, true},
+		{"visibles_excludes", &messageModel{MessageSeq: 5, Payload: []byte(`{"type":1,"visibles":["other"]}`), Timestamp: now}, nil, nil, 0, 0, false},
+		{"visibles_includes", &messageModel{MessageSeq: 5, Payload: []byte(`{"type":1,"visibles":["u1"]}`), Timestamp: now}, nil, nil, 0, 0, true},
+		{"revoked", baseMsg(), &messageExtraDetailModel{messageExtraModel: messageExtraModel{Revoke: 1}}, nil, 0, 0, false},
+		{"global_deleted", baseMsg(), &messageExtraDetailModel{messageExtraModel: messageExtraModel{IsDeleted: 1}}, nil, 0, 0, false},
+		{"user_deleted", baseMsg(), nil, &messageUserExtraModel{MessageIsDeleted: 1}, 0, 0, false},
+		{"expired", &messageModel{MessageSeq: 5, Payload: textPayload, Expire: 10, Timestamp: now - 100}, nil, nil, 0, 0, false},
+		{"not_expired", &messageModel{MessageSeq: 5, Payload: textPayload, Expire: 10, Timestamp: now}, nil, nil, 0, 0, true},
+		{"user_offset_truncated", baseMsg(), nil, nil, 5, 0, false},    // seq(5) <= userOffset(5)
+		{"user_offset_below", baseMsg(), nil, nil, 4, 0, true},         // seq(5) > userOffset(4)
+		{"channel_offset_truncated", baseMsg(), nil, nil, 0, 5, false}, // seq(5) <= channelOffset(5)
+		{"channel_offset_below", baseMsg(), nil, nil, 0, 4, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := messageVisibleToViewer(tc.msg, tc.extra, tc.userExtra, tc.userOffsetSeq, tc.channelOffsetSeq, uid); got != tc.want {
+				t.Fatalf("messageVisibleToViewer = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/modules/message/payload_content_type_test.go
+++ b/modules/message/payload_content_type_test.go
@@ -1,0 +1,33 @@
+package message
+
+import "testing"
+
+func TestPayloadIsPlainText(t *testing.T) {
+	cases := []struct {
+		name    string
+		payload string
+		want    bool
+	}{
+		{"text", `{"type":1,"content":"hello"}`, true},
+		{"text_extra_fields", `{"type":1,"content":"hi","mention":{"all":true}}`, true},
+		{"image", `{"type":2,"url":"http://x/a.png"}`, false},
+		{"card", `{"type":7}`, false},
+		{"system_tip", `{"type":2000}`, false},
+		{"cmd", `{"type":99}`, false},
+		{"missing_type", `{"content":"no type"}`, false},
+		{"float_type", `{"type":1.0}`, false},
+		{"string_int_text", `{"type":"1"}`, true},   // json.Number 接受带引号整数，语义等价 type=1
+		{"string_int_image", `{"type":"2"}`, false}, // 带引号但非文本仍拒绝
+		{"not_json", `not json`, false},
+		{"empty", ``, false},
+		{"null", `null`, false},
+		{"array", `[1,2,3]`, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := payloadIsPlainText([]byte(tc.payload)); got != tc.want {
+				t.Fatalf("payloadIsPlainText(%q) = %v, want %v", tc.payload, got, tc.want)
+			}
+		})
+	}
+}

--- a/modules/message/space_filter.go
+++ b/modules/message/space_filter.go
@@ -572,6 +572,23 @@ func newSystemBotPlaceholder(uid string) *SyncUserConversationResp {
 //
 // 调用方需保证 spaceID != ""（空串视为未启用 Space 过滤，直接返回原列表），
 // 传入 defaultSpaceID（用户默认 Space，决定规则 2/3），并只对 ChannelTypePerson 调用。
+// personSpaceAllows applies the DM (Person) space-isolation rules (issue #484 /
+// YUJ-226) to a single message's payload space_id. Shared by
+// filterPersonMessagesBySpace (message sync) and the reaction read/write paths so
+// the DM isolation posture cannot drift between entry points. Caller guarantees
+// spaceID != "". Keep only on exact match (rule 1) or unlabeled-in-default-Space
+// forward-compat (rule 2); everything else (cross-Space, unlabeled-non-default,
+// unlabeled-system-bot) is dropped.
+func personSpaceAllows(msgSpaceID string, isSysBot bool, spaceID, defaultSpaceID string) bool {
+	if msgSpaceID == spaceID {
+		return true
+	}
+	if msgSpaceID == "" && !isSysBot && spaceID == defaultSpaceID {
+		return true
+	}
+	return false
+}
+
 func filterPersonMessagesBySpace(msgs []*MsgSyncResp, channelID, spaceID, defaultSpaceID string) []*MsgSyncResp {
 	if spaceID == "" || len(msgs) == 0 {
 		return msgs
@@ -582,27 +599,8 @@ func filterPersonMessagesBySpace(msgs []*MsgSyncResp, channelID, spaceID, defaul
 		if m == nil {
 			continue
 		}
-		msid := extractPayloadSpaceID(m.Payload)
-		switch {
-		case msid == spaceID:
-			// 精确匹配当前 Space → 保留
+		if personSpaceAllows(extractPayloadSpaceID(m.Payload), isSysBot, spaceID, defaultSpaceID) {
 			filtered = append(filtered, m)
-		case msid == "" && !isSysBot && spaceID == defaultSpaceID:
-			// issue #484：无 space_id 的普通 DM 消息（发送方未带 X-Space-ID、
-			// Space 化之前的老消息、转发/名片）只在用户默认 Space 向前兼容保留，
-			// 不再出现在每个 Space —— 修复症状1（跨 Space 历史泄漏）。
-			filtered = append(filtered, m)
-		case msid == "" && !isSysBot:
-			// 非默认 Space：无标签 DM 消息不再 fail-open 放行，丢弃。
-			continue
-		case msid == "" && isSysBot:
-			// 系统 Bot 的无 space_id 历史消息一律隐藏。对齐 Android
-			// filterSystemBotMessages 和 iOS filterMessagesBySpace，避免
-			// 老的 botfather/fileHelper/u_10000 对话全量跨 Space 暴露。
-			continue
-		case msid != spaceID:
-			// 明确跨 Space，丢弃。
-			continue
 		}
 	}
 	return filtered
@@ -623,6 +621,23 @@ func extractPayloadSpaceID(payload map[string]interface{}) string {
 		return ""
 	}
 	return s
+}
+
+// payloadSpaceIDFromRaw 从原始 payload 字节读取 space_id（reaction 目标消息持有的是
+// 未反序列化的 messageModel.Payload []byte）。非 JSON / 缺字段 / 类型不符返回 ""，
+// 与 extractPayloadSpaceID 的"无 space_id"口径一致。只解 space_id 一个字段，避免大
+// payload 建整 map。
+func payloadSpaceIDFromRaw(raw []byte) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var v struct {
+		SpaceID string `json:"space_id"`
+	}
+	if err := json.Unmarshal(raw, &v); err != nil {
+		return ""
+	}
+	return v.SpaceID
 }
 
 // resolveBotFilter 批量查询 Bot 状态和 Space 成员关系。

--- a/modules/message/sql/20260712000001_message_legacy01.sql
+++ b/modules/message/sql/20260712000001_message_legacy01.sql
@@ -1,0 +1,27 @@
+-- +migrate Up
+
+-- message-reaction 升级为多 reaction 模型：每个 (uid, message_id, channel, emoji) 独立一行、
+-- 独立 toggle。写路径改用 INSERT ... ON DUPLICATE KEY UPDATE 原子 upsert，依赖此唯一键
+-- 触发 upsert 并根治并发下的重复行（reaction 为新功能，reaction_users 无存量，可直接加）。
+--
+-- 列序 (channel_id, channel_type, message_id, uid, emoji)：既做唯一约束，又给已按频道收口
+-- 的读路径 queryWithMessageIDsInChannel（channel_id=? AND channel_type=? AND message_id IN）
+-- 提供左前缀。索引字节数(utf8mb4)约 722B < 3072（MySQL 8.0 默认上限）。
+-- 建唯一索引前先幂等去重：旧表只有非唯一索引，历史写路径也无唯一键防并发插入，
+-- 生产库若存在重复 (channel_id, channel_type, message_id, uid, emoji) 会让下面的
+-- CREATE UNIQUE INDEX 直接失败、阻断发布。保留每组最大 id（最新插入）的行，删其余。
+-- 无存量时该 DELETE 为 no-op。
+DELETE r1 FROM reaction_users r1
+JOIN reaction_users r2
+  ON r1.channel_id = r2.channel_id
+ AND r1.channel_type = r2.channel_type
+ AND r1.message_id = r2.message_id
+ AND r1.uid = r2.uid
+ AND r1.emoji = r2.emoji
+ AND r1.id < r2.id;
+
+CREATE UNIQUE INDEX reaction_users_channel_msg_uid_emoji_uidx ON reaction_users (channel_id, channel_type, message_id, uid, emoji);
+
+-- +migrate Down
+-- 仅回滚本迁移新建的唯一索引（去重 DELETE 不可逆，无法在 Down 里恢复被合并的行）。
+DROP INDEX reaction_users_channel_msg_uid_emoji_uidx ON reaction_users;

--- a/pkg/errcode/message.go
+++ b/pkg/errcode/message.go
@@ -228,4 +228,12 @@ var (
 		HTTPStatus:     http.StatusForbidden,
 		DefaultMessage: "You are not allowed to view this card's revisions.",
 	})
+	// ErrMessageReactionUnsupportedType 当前仅纯文本消息（common.Text=1）允许添加/取消
+	// 回应；对图片、卡片、系统提示、通话记录等非文本消息一律拒绝。目标消息存在且对
+	// 调用者可见时才会返回此码（不可见/越权仍归并到 404，避免枚举）。
+	ErrMessageReactionUnsupportedType = register(codes.Code{
+		ID:             "err.server.message.reaction_unsupported_type",
+		HTTPStatus:     http.StatusBadRequest,
+		DefaultMessage: "Only text messages can be reacted to.",
+	})
 )

--- a/pkg/i18n/locales/active.zh-CN.toml
+++ b/pkg/i18n/locales/active.zh-CN.toml
@@ -1253,6 +1253,9 @@ other = "卡片修订查询无效。"
 ["err.server.message.card_revision_denied"]
 other = "你无权查看该卡片的修订历史。"
 
+["err.server.message.reaction_unsupported_type"]
+other = "仅纯文本消息支持回应。"
+
 ["err.server.bot_api.card_disabled"]
 other = "当前部署未启用卡片消息。"
 

--- a/tools/i18nmarkers/server/active.en-US.toml
+++ b/tools/i18nmarkers/server/active.en-US.toml
@@ -549,6 +549,9 @@ other = "Sending messages on behalf of another user is not supported."
 ["err.server.message.query_failed"]
 other = "Failed to query message data."
 
+["err.server.message.reaction_unsupported_type"]
+other = "Only text messages can be reacted to."
+
 ["err.server.message.recall_forbidden"]
 other = "You do not have permission to recall this message."
 


### PR DESCRIPTION
## Summary

Reworks the message reaction API (`POST /v1/reactions`, `POST /v1/reaction/sync`) and reaction reads so every entry point — write, sync, and inline read — shares the same authorization and visibility posture, and upgrades storage from single-reaction-per-user to a multi-reaction model (each emoji an independent toggle).

## Related Issue

Web reaction handoff (multi-reaction UI + optimistic updates). No upstream issue number.

## Linked Spec

`.octospec/tasks/message-reaction-hardening/brief.md` (load-bearing: `space-isolation`, `error-handling`). Journal: `.octospec/journal/shared/message-reaction-hardening.md`.

## Changes

- Scope all reaction reads/writes to `(channel_id, channel_type, message_id)`; drop the global `message_id`-only queries that let cross-channel rows leak.
- Write path validates the target message (reject revoked / deleted / user-deleted / invisible / expired / offset-truncated), enforces active-member (group) and parent-group active-member + non-deleted-thread (topic) access, and restricts reactions to plain-text messages (`payload.type == 1`).
- Sync path parity: `ExistMemberActive` (excludes blacklist), `CommunityTopic` handling, unknown-type rejection, and a read-time filter that hides reactions whose target message is no longer visible to the caller — via a shared `messageVisibleToViewer` predicate.
- Multi-reaction: `(uid, message_id, channel, emoji)` UNIQUE + atomic `INSERT ... ON DUPLICATE KEY UPDATE is_deleted = 1 - is_deleted` upsert (race-safe, no dup rows); migration de-dups first (idempotent / no-op when empty).
- Write endpoint returns final `{emoji, seq, is_deleted}`; `syncMessageReaction` CMD param carries `message_id/emoji/seq`.

## Testing

- [x] Unit tests added/updated
- [x] Manually verified

Unit: `messageVisibleToViewer` (visibles / revoke / delete / expire / two-level offset), `payloadIsPlainText`, reaction upsert SQL shape, legacy-response guard.
Integration: channel mismatch, revoked, non-text, deleted-thread rejection, multi-emoji independence, upsert no-duplicate, sync auth (non-member topic / unknown type), sync visibility filter (revoked reaction hidden).
`go build ./...`, `go vet -tags integration ./modules/message/`, `make i18n-lint`, gofmt all clean.

## COMPREHENSION

1. **What does this change actually do to the load-bearing path?**
   It makes reaction authorization and message-visibility uniform across all three reaction entry points (write / sync / inline read), which previously diverged: the write path was partially gated while `syncReaction` bypassed topic/blacklist checks entirely and neither read path filtered by current message visibility. It also changes the storage contract from one reaction row per (user, message) to one per (user, message, emoji), toggled atomically via a unique index + upsert. Reaction rows and reads are now strictly scoped to the owning channel.

2. **What could break because of it (dependents + failure mode)?**
   - Clients that reacted on non-text messages (image/card/system) now get `reaction_unsupported_type` (400) — intended product restriction; the web picker must only appear on text messages.
   - Any client relying on the old single-reaction "click different emoji replaces the old one" behavior will see append semantics instead. This matches the web spec's multi-reaction assumption.
   - The unique index fails to create if the live table already holds duplicate `(channel, message, uid, emoji)` rows; mitigated by an idempotent de-dup step in the migration (reaction is a new, unreleased feature — no production data).
   - `syncReaction` now issues ~5 extra batch/single queries per call for the visibility filter (bounded, independent of reaction count).

3. **How do you know it works (specific test/repro/trace)?**
   New integration tests assert each guarantee end-to-end: `TestReactionRejectsMismatchedChannelWrite`, `TestReactionRejectsNonTextMessage`, `TestReactionRejectsDeletedThreadWrite`, `TestReactionMultipleEmojisIndependent`, `TestReactionSameEmojiUpsertNoDuplicate`, `TestSyncReactionRejectsNonMemberTopic`, `TestSyncReactionRejectsUnknownChannelType`, `TestSyncReactionHidesRevokedMessageReaction`; plus `TestMessageVisibleToViewer` table-driven unit coverage of the shared predicate. All pass against a freshly-migrated `test` DB.

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] PR description is in English
- [x] Added tests for my changes
- [x] Updated documentation (octospec brief + journal)
- [x] Followed commit message conventions (Conventional Commits)