### PR TITLE
feat(notify): at-most-once Space new-user welcome DM

### DIFF
--- a/.octospec/journal/shared/space-new-user-welcome-message.md
+++ b/.octospec/journal/shared/space-new-user-welcome-message.md
@@ -1,0 +1,93 @@
+---
+type: Journal
+title: "space-new-user-welcome-message: at-most-once Space welcome DM via notify ledger"
+description: Deliver one configurable welcome DM from the notification bot on a human user's first join to a designated Space, backed by a persistent delivery ledger + reconciler + send worker.
+tags: [notify, onboarding, space, isolation, i18n, system-setting, migration, idempotency, testing]
+timestamp: 2026-07-16T00:00:00Z
+---
+
+# space-new-user-welcome-message
+
+Branch `space-new-user-welcome-message`. Minimal implementation of the main
+chain "first-join human → exactly one ledger row → member re-check before send".
+Send semantics are at-most-once; transport-ambiguous outcomes become `unknown`
+and are never auto-retried.
+
+## What was done
+
+1. **Delivery ledger** — new `octo_space_welcome_delivery` table (migration in
+   `modules/notify/sql/`), the permanent dedupe source of truth. Status machine
+   pending/claimed/dispatching/sent/failed/skipped/unknown. `notify/1module.go`
+   gains `//go:embed sql` + `SQLDir` (it had none before — without it the
+   migration would never run).
+2. **Config** — five `system_setting` keys under category `onboarding`.
+   `modules/common` gains `SpaceWelcomeConfig()` (reads all five keys from ONE
+   snapshot in a single atomic access so a caller cannot straddle a background
+   `Reload()`), `ValidateSpaceWelcomeCombination`, and prospective composite
+   validation on the manager write path (validate `merge(current snapshot,
+   incoming items)`, not the pre-write snapshot). New i18n error code
+   `err.server.common.space_welcome_config_invalid`.
+3. **notify service** — `space_welcome*.go`: event enqueue (extends the
+   `SpaceMemberJoin` listener; never blocks/rolls back the join), a 60s
+   reconciler (catches dropped events / restarts / the manager `addMembers`
+   path), and a send worker (idle 5s poll / active drain / per-wake cap 20).
+   Claim via `SELECT ... FOR UPDATE SKIP LOCKED`; every post-claim UPDATE is a
+   CAS guarded by `status + claim_owner`. `attempts` grows ONLY on a definitive
+   pre-IM failure; backoff {5s,30s,120s}, 4th failure → terminal failed. Any
+   failure after the dispatching transition → `unknown` (no retry).
+4. **notify-local sender** — a context-aware HTTP sender (`http.Client{Timeout:
+   15s}` + `NewRequestWithContext`, explicit `Content-Type: application/json` +
+   manager token) instead of octo-lib's `SendMessageWithResult` (which sets no
+   timeout and takes no context). octo-lib is unmodified. 15s < 30s lease.
+5. **Observability** — kept minimal per product steer: in-process atomic
+   counters (also used by tests to assert enqueue-vs-dedup and send outcomes) +
+   structured logs. No Prometheus wiring yet; promoting the counters later is a
+   drop-in.
+
+## Structural learnings / gotchas
+
+- **DB writes NOW() in the deployment-local wall clock** (this deployment runs a
+  uniform `+08:00`; overseas mounts a TZ env var to run UTC). Comparing a UTC
+  `active_from` against `space_member.created_at` (written by `NOW()`) directly
+  is off by the session offset. Fix mirrors the existing repo convention in
+  `modules/opanalytics/etl_db.go`: `UNIX_TIMESTAMP(sm.created_at) >=
+  activeFrom.Unix()` — epoch-to-epoch, TZ-agnostic, no CONVERT_TZ / no DSN
+  `loc` dependency, valid because writer and reader connections share one global
+  session zone. The ledger's own timestamps stay app-supplied UTC and only ever
+  compare against each other, so they are self-consistent regardless.
+- **`pkg/space.SystemBots` contains `notification`** (the sender identity). The
+  human-filter `IsSystemBot` check is scoped strictly to the RECIPIENT uid; the
+  send path / sender identity never runs through it, or the feature would
+  self-exclude.
+- **Prospective validation direction matters**: validating the current snapshot
+  alone gets both directions wrong (accepts a patch that breaks the composite,
+  rejects a patch that repairs it). Always validate the merged five-tuple.
+- **A `package common` internal test cannot blank-import `modules/space`**
+  (`modules/space` imports `modules/common` → cycle), so the write-path HTTP
+  prospective test could not seed a real `space` row; that seam is covered by
+  the validation function tests (both directions) plus the notify integration
+  tests, which exercise the space-active check against a real `space` table.
+
+## Verification
+
+- `go build ./...`, `go vet`, `make i18n-extract-check`, `make i18n-lint`,
+  `git diff --check` all clean.
+- `go test -race` green for `modules/notify`, `modules/common`, `modules/space`
+  (each on a fresh test DB — the shared `test` DB churns migrations across
+  package binaries with different module sets; drop & recreate between them).
+- Integration coverage: enqueue idempotency + concurrent single-insert; claim
+  SKIP LOCKED single-winner; sweep claimed→pending / dispatching→unknown;
+  cross-owner CAS blocked; pre-IM backoff→failed; precheck (member_left / robot
+  / orphan / recipient system-bot); reconcile catch-up; active_from boundary;
+  dispatch success/unknown/skip; event enqueue/dedup/exclusions/disabled.
+
+## Not done (deliberate / out of scope)
+
+- No octo-lib change, no client-supplied idempotency key (end-to-end
+  exactly-once is a separate task); no auto-retry of `unknown`.
+- No management API / CLI (operators use SQL + the ledger).
+- Prometheus/Grafana wiring deferred.
+- Three product/ops sign-off items gate flipping `enabled=true` in production
+  (at-most-once acceptable; `skipped` is terminal; peak join-rate vs the
+  single-replica ~240/min drain envelope). Code implements the recommended
+  stance; enabling = accepting them.

--- a/.octospec/learnings/pending/app-time-vs-now-column-epoch-compare.md
+++ b/.octospec/learnings/pending/app-time-vs-now-column-epoch-compare.md
@@ -1,0 +1,53 @@
+---
+type: Learning
+title: "Compare app time against NOW()-written DATETIME columns via UNIX_TIMESTAMP, not a UTC time.Time param"
+description: The DB session runs a deployment-local zone and the DSN sets no driver loc, so a Go time.Time param and a NOW()-written column are off by the session offset unless compared as epochs.
+tags: [time, timezone, mysql, dbr, correctness]
+timestamp: 2026-07-16T00:00:00Z
+status: pending
+---
+
+# Compare app time vs NOW()-written DATETIME columns as epochs
+
+## Context
+
+octo-server's MySQL runs a deployment-local session timezone (this deployment
+is `+08:00`; overseas mounts a `TZ` env var to run UTC). Legacy columns such as
+`space_member.created_at` are written by `NOW()` in that local wall clock. The
+MySQL DSN sets `charset=utf8mb4&parseTime=true` with **no `loc`**, so
+go-sql-driver serializes a Go `time.Time` bound parameter as its **UTC** wall
+clock.
+
+## The trap
+
+`WHERE created_at >= ?` with a `time.Time` (e.g. a UTC `active_from`) compares a
+UTC-serialized string against a local-wall-clock column → off by the session
+offset (8h here). This is silent: it "works" only when the DB session happens to
+be UTC.
+
+## The rule
+
+When comparing an application-supplied absolute instant against a DATETIME
+column that was written by `NOW()`/`CURRENT_TIMESTAMP` (deployment-local),
+compare epoch-to-epoch:
+
+```sql
+WHERE UNIX_TIMESTAMP(col) >= ?     -- bind param = t.Unix()
+```
+
+`UNIX_TIMESTAMP(col)` interprets the column in the session zone and yields a UTC
+epoch; `t.Unix()` is an unambiguous UTC epoch. This is TZ-agnostic and needs no
+`CONVERT_TZ` (no tz tables) and no DSN `loc`. Valid because writer and reader
+connections share one global session zone.
+
+Precedent already in the repo: `modules/opanalytics/etl_db.go`
+(`UNIX_TIMESTAMP(created_at)`, `SELECT UNIX_TIMESTAMP()` for "now").
+
+A table you fully own can instead store all timestamps as app-supplied values in
+one canonical zone and only ever compare them against each other (self-consistent
+regardless of DB zone) — but the moment you compare against a `NOW()`-written
+column you do not own, use the epoch form.
+
+## Promotion note
+
+Candidate for a `time`/`persistence` rule. Not auto-promoted — review separately.

--- a/.octospec/log.md
+++ b/.octospec/log.md
@@ -4,6 +4,26 @@ Change history for this repo's `.octospec/`, following the
 [OKF](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md)
 change-log convention (§7). Newest first.
 
+## 2026-07-16 (space-new-user-welcome-message)
+
+- **Feature** — At-most-once Space welcome DM from the `notification` bot on a
+  human user's first join to a designated Space. New `octo_space_welcome_delivery`
+  ledger (migration in `modules/notify/sql/`; `notify/1module.go` gains
+  `//go:embed sql` + `SQLDir`), a 60s reconciler and a single-row send worker
+  (claim via `FOR UPDATE SKIP LOCKED`, CAS guarded by `status + claim_owner`,
+  `attempts` grows only on pre-IM failure with backoff {5s,30s,120s}→failed,
+  any post-dispatch failure → `unknown` never retried). Config is five
+  `system_setting` keys under `onboarding`; `modules/common` gains an atomic
+  `SpaceWelcomeConfig()` snapshot accessor + prospective composite validation on
+  the manager write path + i18n code `err.server.common.space_welcome_config_invalid`.
+  A notify-local 15s context-aware HTTP sender replaces octo-lib's timeout-less
+  helper (octo-lib unmodified). `active_from` vs `space_member.created_at`
+  compared via `UNIX_TIMESTAMP` (mirrors `modules/opanalytics`). Observability
+  kept minimal (in-process counters + logs). Ships `enabled=false`; three
+  product/ops sign-off items gate turning it on. Brief under
+  `.octospec/tasks/space-new-user-welcome-message/`; shared journal
+  `.octospec/journal/shared/space-new-user-welcome-message.md`.
+
 ## 2026-07-16 (card-action-internal-http-actions)
 
 - **Follow-up** — Two small extensions to #588 plus one bundled config

--- a/.octospec/tasks/space-new-user-welcome-message/brief.md
+++ b/.octospec/tasks/space-new-user-welcome-message/brief.md
@@ -1,0 +1,576 @@
+---
+type: Task
+title: "Task: space-new-user-welcome-message"
+description: Reliably deliver one configurable welcome DM from the system notification bot to a human user on their first join to a designated Space (minimal implementation).
+tags: ["notify", "onboarding", "space", "isolation", "i18n", "system-setting", "migration", "idempotency", "observability", "wire-contract", "error-response", "testing"]
+timestamp: 2026-07-16T18:20:00+08:00
+# --- octospec extension fields ---
+slug: space-new-user-welcome-message
+upstream: self
+source: self
+---
+
+# Task: space-new-user-welcome-message
+
+> One task = one `.octospec/tasks/<slug>/` directory. This brief is the spec for
+> the work. AI may draft it from existing code; a human confirms it.
+
+## Goal
+
+Provide an automated welcome for a single admin-designated Space: once the
+feature is active, when a human user first joins that Space, deliver one DM
+from the built-in system identity `notification` (display name "通知助手")
+carrying the current `space_id` and a red-dot indicator.
+
+Scope is the **minimal implementation**: guarantee only the main chain
+"first-join human → exactly one delivery ledger row → member re-check before
+send" as a reliable replacement for the manual workflow. Send semantics is
+**at-most-once**; outcomes that cross the WuKongIM call boundary and become
+unclear are recorded as `unknown`, never auto-retried, and surfaced via
+metrics + logs for operator handling.
+
+## Background
+
+- `SpaceMemberJoin` is written by a goroutine in a separate transaction after
+  the member row commits (`modules/space/api.go:1977`); a process crash between
+  the two loses the event. `api_manager.addMembers` explicitly bypasses the
+  event (`modules/space/api_manager.go:609`). Therefore the event cannot be
+  the sole source of truth — a persistent ledger plus periodic reconciliation
+  are both required.
+- `modules/notify` already provides the `notification` system bot,
+  authoritative `payload.space_id` injection via `NewPersonalMsgSendReq`,
+  server-returned `message_id/client_msg_no` (via octo-lib's send helper),
+  and red-dot personal DM delivery (`modules/notify/api.go:437-468`). This
+  task reuses the payload-construction primitive `NewPersonalMsgSendReq`
+  but replaces the HTTP delivery step (see below).
+- `MsgSendReq` has no `client_msg_no` input field (octo-lib
+  `config/msg.go:797`); an end-to-end idempotency key does not exist, so
+  **only** at-most-once is achievable. This task does not attempt to add one.
+- `SystemSettings` uses an in-memory snapshot with a 60s background reload
+  (`modules/common/system_settings.go:72`). The minimal implementation accepts
+  this convergence window; an admin write triggers `Reload()` **on the replica
+  handling that write**, and peer replicas converge within at most 60s.
+- octo-lib's `SendMessageWithResult` neither accepts a `context.Context`
+  nor sets an HTTP client timeout — the underlying sendgrid `rest.API`
+  (`pkg/network/network.go`) uses default timeouts (i.e. none). Wrapping
+  the call in `context.WithTimeout` at the caller cannot actually interrupt
+  the request; the caller can only return early while the goroutine (and
+  socket) linger, and at-most-once accounting cannot rely on the timeout.
+- **The task must not modify octo-lib.** The following are already exported
+  and sufficient for a self-contained context-aware sender inside
+  `modules/notify`:
+  - `config.Context.GetConfig() *config.Config` (`config/context.go:77`)
+  - `config.Config.WuKongIM.APIURL` (`config/config.go:156`)
+  - `config.Config.WuKongIMManagerTokenHeaderMap()` (`config/msg.go`,
+    explicitly labeled "公共方法供外部模块使用")
+  - `config.NewPersonalMsgSendReq(...)` (payload construction, unchanged)
+  Response body shape (`data.message_id`, `data.client_msg_no`,
+  `data.message_seq`) is stable — this task mirrors the parse in
+  `config/msg.go:152-163`.
+- `modules/notify/1module.go` today does **not** register a `SQLDir`. This
+  task must add `//go:embed sql` and `SQLDir: register.NewSQLFS(sqlFS)`
+  following the pattern used in every other module (e.g. `app_bot`,
+  `backup`, `botfather`); without it, the new migration will not execute.
+- BotFather's Space welcome and `u_10000`'s register/login welcome serve
+  different purposes; they are left untouched and may coexist with this feature.
+
+## Load-bearing list
+
+- **Product trigger semantics** — Deliver only when a `space_member` row
+  satisfies `space_id = target`, `status = 1`, and `created_at >= active_from`,
+  and only for the **first** such membership. Pre-existing members and
+  rejoiners whose original join predated `active_from` are excluded.
+- **Sender identity and wire protocol** — Fixed
+  `from_uid = notification` / `channel_type = PERSON` / `red_dot = 1` /
+  `payload.type = Text`; `payload.space_id` is authoritatively overwritten by
+  `NewPersonalMsgSendReq`. Neither admin nor caller may choose or forge the
+  sender or submit arbitrary payload. The message body is plain text — no
+  placeholder rendering, no HTML, no card variants.
+- **Space isolation** — Config must match exactly one existing, non-dissolved
+  Space; both enqueue and pre-send re-check membership by
+  `(space_id, uid, status=1)`. Any cache or lookup anomaly fails closed; the
+  code never delivers cross-Space or to non-members. Pre-send membership
+  check must not read a stale cache; if `modules/space` does not expose a
+  cache-bypassing accessor, the implementation performs a direct DB read
+  (documented on the caller in `modules/notify`).
+- **Human filter** — Both enqueue and pre-send exclude `user.robot = 1`,
+  `pkg/space.SystemBots`, and orphan `space_member` rows whose `user` row is
+  missing.
+  - **`SystemBots` contains `notification`** (`pkg/space/query.go:20-25`).
+    Any call to `pkg/space.IsSystemBot` / `SystemBots[uid]` in this feature
+    must be scoped strictly to *"is this recipient uid ineligible"*.
+    Send-path code, sender-identity resolution, and any generic
+    early-return `if IsSystemBot(uid) { return }` template **must not** touch
+    the sender uid, or the feature will self-exclude.
+- **First-join semantics** — `space_member.created_at` is the permanent
+  anchor for a user's first-ever membership in this Space and is not reset
+  on re-join. Verified in code:
+  - `executeJoinSpace` → `atomicReactivateMemberIfNotFull` updates only
+    `status/role/updated_at` (`modules/space/db.go:562-565`), leaving
+    `created_at` untouched.
+  - Manager force-add uses `INSERT ... ON DUPLICATE KEY UPDATE status=1,
+    updated_at=NOW()` (`modules/space/db_manager.go:381`); the update clause
+    excludes `created_at`.
+  Therefore `space_member.created_at >= active_from` correctly excludes
+  members who first joined before the feature went live even if they left
+  and rejoined afterwards. The reconciler and event handler both key off
+  this column; no auxiliary "current-active-period-start" is required.
+- **Runtime configuration** (registered under `system_setting`, typed getters)
+  - `onboarding.space_welcome_enabled` (bool, default false)
+  - `onboarding.space_welcome_space_id` (string)
+  - `onboarding.space_welcome_active_from` (UTC RFC3339 string)
+  - `onboarding.space_welcome_message_zh_cn` (string, trimmed non-empty,
+    ≤ 2000 Unicode code points)
+  - `onboarding.space_welcome_message_en_us` (same rule)
+  - **Snapshot accessor** — `modules/common` must expose a single
+    `SpaceWelcomeConfig()` returning a struct with all five fields read from
+    the **same** `SystemSettings` snapshot in one atomic access. Callers
+    (event handler, worker, reconciler, manager write path) must not read
+    the five keys individually; splitting the reads risks straddling a
+    background `Reload()` and using an inconsistent combination.
+- **Configuration validation** — When enabling, all five keys must form a
+  **valid combination**: Space exists and is active, time parses, both message
+  bodies non-empty within the length limit.
+  - **Manager write path uses prospective validation** — the write endpoint
+    must NOT validate the current `SpaceWelcomeConfig()` snapshot; it must
+    construct `prospective = merge(current snapshot, incoming items)` and
+    validate that composite. Rationale: partial updates (e.g. changing only
+    `space_id` while leaving message bodies unchanged) must pass if the
+    resulting five-tuple is valid, and must fail if any incoming field
+    breaks the composite — using the pre-write snapshot alone gets both
+    directions wrong. Validate first, then commit the items in one
+    transaction, then trigger `SystemSettings.Reload()` on the handling
+    replica.
+  - **Runtime re-validation** — Worker/reconciler re-validate
+    `SpaceWelcomeConfig()` **before each cycle**; any failure fails closed
+    for that cycle and increments `config_invalid_total`. Fail-closed
+    applies from the next cycle after `SystemSettings` reloads the invalid
+    combination — cycles still running on a valid earlier snapshot are not
+    aborted mid-flight.
+- **Delivery ledger table** — New migration
+  `modules/notify/sql/<yyyyMMdd>-01_add_octo_space_welcome_delivery.sql`
+  creating `octo_space_welcome_delivery`:
+  ```
+  id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+  space_id VARCHAR(<match space.space_id>) NOT NULL,   -- length+COLLATE must match `space`
+  uid      VARCHAR(<match user.uid>)      NOT NULL,   -- length+COLLATE must match `user`
+  status TINYINT NOT NULL DEFAULT 0,
+  -- 0=pending    : claimable by worker
+  -- 1=claimed    : worker locked the row; IM call not yet started; sweep => back to pending
+  -- 2=dispatching: worker has begun the IM call; sweep => unknown (transport-ambiguous)
+  -- 3=sent       : terminal success
+  -- 4=failed     : terminal (pre-IM retry budget exhausted)
+  -- 5=skipped    : terminal (recipient ineligible at pre-send check: left / bot / orphan)
+  -- 6=unknown    : terminal (transport-ambiguous; operator handles)
+  attempts INT NOT NULL DEFAULT 0,
+  next_retry_at DATETIME NULL COMMENT 'UTC; application-level UTC values, never NOW()',
+  lang VARCHAR(16) NULL,                  -- written at send time
+  message_id BIGINT NULL,
+  client_msg_no VARCHAR(100) NULL,        -- match existing message table width
+  claim_owner VARCHAR(128) NULL,          -- <hostname>:<pid>, K8s pod names can approach 63 chars
+  claim_expire_at DATETIME NULL COMMENT 'UTC; application-level UTC values',
+  error_class VARCHAR(64) NULL,
+  created_at DATETIME NOT NULL COMMENT 'UTC; application-level UTC values',
+  updated_at DATETIME NOT NULL COMMENT 'UTC; application-level UTC values',
+  UNIQUE KEY uk_space_uid (space_id, uid),
+  KEY idx_claim (space_id, status, next_retry_at)
+  ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=<match reconciler-join partners>
+    COMMENT='onboarding space welcome delivery ledger';
+  ```
+  - `space_id` / `uid` column type, length, and `COLLATE` must be identical to
+    the columns joined by the reconciler (`space`, `space_member`, `user`);
+    mismatched collations trigger MySQL error 1267 on JOIN (see prior incident
+    `issue_344_display_name_fallback`).
+  - `idx_claim (space_id, status, next_retry_at)` is shaped to match the
+    worker's claim `WHERE` predicate exactly; leaving `space_id` out forces a
+    range scan.
+  - **Time discipline** — all timestamps are UTC. The application computes
+    `time.Now().UTC()` and passes it as a bound parameter for every write;
+    SQL must **not** use `NOW()` for this table (repository convention writes
+    naked `NOW()`, but the DB session TZ is not pinned in the DSN, so `NOW()`
+    would silently mix wall-clock with the UTC RFC3339 `active_from`).
+    `active_from` from `system_setting` is parsed as RFC3339 UTC.
+  - Retention: **no auto-archival**. The ledger is the permanent dedupe
+    source-of-truth and grows monotonically; operators do not truncate it.
+- **Module wiring** — `modules/notify/1module.go` must add
+  `//go:embed sql` (with `import "embed"`) and register `SQLDir:
+  register.NewSQLFS(sqlFS)` on the module. Follow `modules/app_bot/1module.go`
+  as a reference.
+- **Enqueue idempotency** — Both the event path and the reconciler use
+  `INSERT ... ON DUPLICATE KEY UPDATE id = id` (never `INSERT IGNORE`, which
+  silently swallows non-uniqueness errors such as charset truncation).
+  `enqueue_total{source}` is incremented **only when affected rows > 0**;
+  duplicate hits increment `enqueue_dedup_total{source}` instead.
+- **Low-latency event path** — Extend `notify.handleSpaceMemberEvent`
+  (`modules/notify/api.go:213`); when the event matches
+  `SpaceWelcomeConfig()`, upsert a pending row. The listener does not send
+  messages; enqueue failure must never roll back or block the completed join.
+- **Reconciliation path** — Per-process background goroutine (interval 60s,
+  compile-time constant), started from `modules/notify/1module.go`'s
+  `Start()` hook and stopped on `context.Cancel()` for clean test shutdown.
+  Each cycle: read `SpaceWelcomeConfig()` (skip if disabled/invalid) → scan
+  the current target Space for `status=1 AND created_at >= active_from`
+  members that lack a ledger row → cap at 500 rows per cycle → upsert
+  pending rows. This path covers dropped events, restarts, and `addMembers`.
+- **Send worker (in-process)** — Per-process background goroutine, same
+  lifecycle hooks. **Drive loop**:
+  - **Idle → sleep, active → drain.** When a cycle produces a claimed row,
+    immediately try the next claim without waiting; when a cycle produces no
+    claimable row, sleep 5s before the next attempt. This lets a small
+    backlog drain quickly while keeping steady-state polling at 5s.
+  - **Per-cycle safety cap: 20 rows.** After 20 successfully claimed rows in
+    one wake, break out to the sleep branch so a single goroutine cannot
+    monopolize the shared DB session or starve other work. The cap is a
+    safety valve, not a rate limit — the next wake resumes immediately.
+  - **Steady-state upper bound (single replica): 20 rows / (20 × per-row
+    latency + 5s idle), i.e. under nominal per-row latency ≲1s roughly
+    240 rows/min in burst; empty queue steady state is one poll per 5s.
+    Multiple replicas scale linearly via row-lock contention.** This bound
+    is descriptive, not a product SLA — see Open questions.
+  1. Read `SpaceWelcomeConfig()`; skip (fall through to sleep) if
+     disabled/invalid.
+  2. **Sweep** (once per wake, not per row):
+     - `claimed` rows past `claim_expire_at` → back to `pending`
+       (`next_retry_at = NOW_UTC()`; safe because IM was not yet called;
+       `attempts` **is not decremented and was not incremented at claim** —
+       see below).
+     - `dispatching` rows past `claim_expire_at` → `unknown` with
+       `error_class='claim_expired'` (we cannot prove whether IM was called).
+  3. **Claim** — one row per iteration, two-phase inside one transaction:
+     ```sql
+     SELECT id FROM octo_space_welcome_delivery
+       WHERE space_id=? AND status=0
+         AND (next_retry_at IS NULL OR next_retry_at<=?)   -- ? = NOW_UTC
+       ORDER BY id LIMIT 1
+       FOR UPDATE SKIP LOCKED;
+     UPDATE octo_space_welcome_delivery
+       SET status=1,
+           claim_owner=?, claim_expire_at=?,               -- lease = NOW_UTC + 30s
+           updated_at=?
+       WHERE id=?;
+     ```
+     `claim_owner=<hostname>:<pid>` re-selects the row and is CAS predicate
+     on every subsequent update. **Note**: `attempts` is deliberately NOT
+     incremented at claim. `attempts` counts only **consecutive pre-IM
+     failures** (see Dispatch below); claim, precheck-skip, sweep-recycle,
+     `sent`, and `unknown` never consume the retry budget. Otherwise a
+     process crash between claim and IM call would burn attempts without any
+     failure signal, which contradicts the semantic.
+     - No row returned → break out to the sleep branch (idle).
+     - Row returned → run Dispatch, then continue the loop (drain).
+  4. **Dispatch** — the claimed row goes through:
+     - **Pre-send re-check** (bypassing stale caches, executed under a bounded
+       DB context — see DB timeouts below): recipient still member of target
+       Space, not a robot / system bot (`SystemBots` **for recipient only** —
+       see Human filter), `user` row exists.
+       - Not eligible → CAS `WHERE id=? AND status=1 AND claim_owner=?` to
+         `status=5 skipped` with `error_class=member_left | human_filter |
+         orphan_member`. Increments `skip_non_member_total`. No further
+         cycles will touch this row — this replaces the earlier
+         "keep pending forever" loop and avoids the hot-loop on users who
+         never rejoin. **`attempts` is not consumed.**
+     - Resolve language via `user.LanguageService` (`zh-*` → zh-CN, otherwise
+       en-US); on **any** lookup failure fall back to `OCTO_DEFAULT_LANGUAGE`
+       and continue — language lookup is never treated as a retryable error.
+     - CAS transition to `status=2 dispatching`, extend
+       `claim_expire_at = NOW_UTC + 30s` and persist `lang`.
+     - Build the payload via `config.NewPersonalMsgSendReq(...)` (retained
+       from octo-lib for authoritative `payload.space_id` and content
+       shaping).
+     - Deliver via a **notify-local context-aware HTTP sender** — do **not**
+       call `SendMessageWithResult`. The sender:
+       - reads `APIURL = ctx.GetConfig().WuKongIM.APIURL` and
+         `authHeader = ctx.GetConfig().WuKongIMManagerTokenHeaderMap()`
+         (this helper returns only `{"token": ...}`);
+       - builds `http.NewRequestWithContext(ctx, POST, APIURL+"/message/send",
+         body)`; **sets `Content-Type: application/json` explicitly** in
+         addition to `authHeader`; posts through a shared `http.Client` with
+         `Timeout: 15s` (this timeout is authoritative because the socket is
+         actually closed on expiry — unlike the octo-lib helper);
+       - on 200 OK parses `data.message_id` / `data.client_msg_no` /
+         `data.message_seq` (mirrors octo-lib `config/msg.go:152-163`);
+       - on non-200 or transport error returns a typed result the worker can
+         classify below.
+       This sender lives in `modules/notify` only. octo-lib is **not**
+       modified.
+     - **Success** → CAS to `status=3 sent`, persist
+       `message_id/client_msg_no`. `attempts` unchanged.
+     - **Definitively pre-IM failure** observed before the `dispatching`
+       transition (bot not ready, config unreadable, precheck DB error, lang
+       service DB error not caught by the local fallback) → CAS back to
+       `status=0 pending` with `attempts=attempts+1` and
+       `next_retry_at = NOW_UTC + backoff(new_attempts)`,
+       `backoff = {5s, 30s, 120s}` for attempts 1/2/3. **`attempts` is
+       incremented here — this is the only place it grows.** After the 4th
+       consecutive pre-IM failure, CAS to `status=4 failed` with
+       `error_class`.
+     - **Any failure after the `dispatching` transition** — IM timeout,
+       connection reset, empty response, non-200, or the post-success ledger
+       update failing — CAS to `status=6 unknown`; never auto-retry.
+       `attempts` unchanged.
+  - **DB call context deadlines.** Every DB call issued by the worker
+    (sweep, claim, precheck, CAS transitions, ledger persist) runs under a
+    bounded context — recommended 3s per call — so the "precheck + CAS
+    overhead ≲ 5s < 30s lease" budget is enforced rather than assumed. A DB
+    timeout on precheck is a definitive pre-IM failure (attempts+1 + backoff);
+    a DB timeout on the post-success persist is transport-ambiguous → mark
+    `unknown`.
+  - Every UPDATE past claim includes `AND status=<expected> AND
+    claim_owner=<self>` to prevent a lease-expired sweep on another replica
+    from being overwritten by this replica.
+  - Multiple replicas race safely via `SELECT ... FOR UPDATE SKIP LOCKED`;
+    no leader election, no distributed lock.
+- **Disable / re-enable** — When disabled: new events are not enqueued, the
+  reconciler skips, and the worker skips claiming and dispatch (sweep still
+  runs to promote any stale rows to their terminal state). The replica
+  handling the admin flip takes effect immediately via
+  `SystemSettings.Reload()`; peer replicas converge within at most one
+  `SystemSettings` reload cycle (currently 60s). In-flight rows in
+  `dispatching` cannot be physically recalled (the HTTP request is already
+  on the wire) and are allowed to complete. Re-enabling with the same
+  `active_from` lets the reconciler catch up members who joined during the
+  pause; advance `active_from` if that catch-up is undesired.
+- **Space switch** — Worker and reconciler always operate against the
+  current configured `space_id`. Leftover pending rows for the previous
+  Space are filtered out by the SQL `space_id = current` clause and are not
+  garbage collected; operators clean them up manually via SQL as needed.
+- **Observability** (minimal metric set)
+  - **counters**: `enqueue_total{source=event|reconciler}`,
+    `enqueue_dedup_total{source=event|reconciler}`, `send_success_total`,
+    `send_failed_total`, `send_unknown_total`, `skip_non_member_total`,
+    `config_invalid_total`, `sweep_reclaimed_total{from=claimed|dispatching}`
+  - **gauges**: `pending_backlog`, `unknown_backlog`,
+    `oldest_pending_age_seconds` (implementation may sample; large-scale
+    accuracy is not required for the minimal version)
+  - **stage** (structured log field) enumeration: `enqueue`, `sweep`,
+    `claim`, `precheck`, `dispatch`, `persist`
+  - **error_class** enumeration: `bot_not_ready`, `member_left`,
+    `human_filter`, `orphan_member`, `config_read`, `im_timeout`,
+    `im_bad_response`, `sent_persist`, `claim_expired`
+  - Structured log fields per event: `delivery_id`, `space_id`, `uid`,
+    `stage`, `error_class`. **Never** log the full welcome body, sensitive
+    user data, or raw upstream error strings.
+- **Operator handling channel (minimal)** — `unknown` and `failed` rows are
+  handled via Grafana alerts on the above metrics plus direct SQL access.
+  This task **does not** introduce a management API or CLI.
+- **Test-infra caveats** — Integration tests must reset any residual
+  `ratelimit:uid:*` buckets in setup. i18n error branches must inject an
+  `ErrorRenderer` in the test server. If the test DB reports an unknown
+  migration, drop and recreate the DB rather than diff migrations.
+- **Error responses and permissions** — No new public write endpoints. Any
+  new config-validation error codes go through the `pkg/httperr` i18n
+  envelope; raw `ResponseError` / `c.JSON` / `AbortWithStatusJSON` non-OK
+  responses are forbidden.
+- **Compatibility with existing behavior** — `/v1/internal/notify`, card
+  notifications, BotFather Space welcome, and the `u_10000` register/login
+  welcome remain unchanged. Target users may see these DMs alongside the new
+  Space welcome — this is a pre-existing behavior of those pipelines, not a
+  change introduced by this task.
+
+## Out of scope
+
+- Multi-Space configuration with per-Space copy; per-Space admin self-service
+  UI/API.
+- Retroactive bulk send to members who joined before `active_from`.
+- Rich text, cards, attachments, placeholder rendering (e.g. `{nickname}`),
+  scheduled send, audience targeting, workflow orchestration.
+- Modifying or replacing the `u_10000` register/login welcome or BotFather
+  Space welcome pipelines and templates.
+- Changes to client message protocol, conversation list, or red-dot rules;
+  separate triggering logic per Web/iOS/Android client.
+- Modifying WuKongIM or octo-lib to add a client-supplied idempotency key or
+  a default HTTP timeout; end-to-end exactly-once is a separate task.
+- Auto-retrying `unknown` rows; auto-recalling possible duplicate messages;
+  guessing the outcome of an ambiguous IM call.
+- Bounded concurrent dispatch within one claim batch, multi-row batches, or
+  a worker pool inside a single replica (single-row-per-cycle is deliberate).
+- Modifying octo-lib (add `SendMessageWithContext`, add HTTP client timeout,
+  etc.). A tracking follow-up may be filed against octo-lib separately, but
+  this task is self-contained on the octo-server side.
+- Re-attempting delivery after a `skipped` terminal state (users who leave
+  before send do not get a later welcome even if they rejoin).
+- General outbox / task queue / workflow platform.
+- Cross-replica leader election, distributed lock, or introducing
+  Kafka/Redis-backed queues.
+- Management endpoints for pending listing, manual resend, or cleanup —
+  handled via SQL.
+- Ledger archival / TTL / purge; the table grows monotonically by design.
+- Production repo assignment, image SHA, K8s manifests, and final production
+  configuration values (owned by the release pipeline).
+
+## Acceptance
+
+- **Config validation**: with `enabled=true`, writes with a non-existent
+  Space, unparseable time, empty (after trim) or > 2000 code point message
+  bodies are rejected at the manager write path. Dirty configs written
+  directly to the DB fail closed at the worker/reconciler and increment
+  `config_invalid_total`.
+- **Prospective validation**: a partial update touching only a subset of
+  the five keys is accepted iff `merge(current snapshot, incoming items)`
+  is a valid combination. A test where the current snapshot is valid, the
+  incoming patch alone would look valid, but the merge is invalid, is
+  rejected; and vice versa (invalid snapshot + valid patch that repairs
+  the composite is accepted).
+- **Snapshot atomicity**: worker/reconciler/event handler read
+  `SpaceWelcomeConfig()` once per cycle; a mid-cycle `SystemSettings.Reload()`
+  that produces an invalid combination fails closed only from the next cycle,
+  never mid-cycle.
+- **Disable / re-enable**: flipping to `enabled=false` immediately stops the
+  admin-request replica from claiming; peer replicas stop within 60s;
+  in-flight `dispatching` rows are allowed to complete; no new pending is
+  created and no reconciler catch-up happens. Flipping back to `enabled=true`
+  with the same `active_from` results in the next reconciler cycle enqueueing
+  members who joined during the pause.
+- **Unique delivery**: a human user's first join to the target Space produces
+  exactly one `(space_id, uid)` row; duplicate/concurrent/replayed
+  `SpaceMemberJoin` events neither insert new rows nor re-send.
+  `enqueue_total` counts only actual insertions; duplicates raise
+  `enqueue_dedup_total` instead.
+- **Exclusion set**: non-target Spaces, pre-`active_from` members, robots,
+  system bots (recipient only), orphan `space_member` rows, and users who
+  left and did not rejoin as active members receive no message.
+- **Entry-point coverage**: normal invite, approval, and Space-admin add flow
+  through the low-latency event path; `addMembers` and any "row committed but
+  event missing" scenarios are covered by the next reconciler cycle.
+- **Restart recovery**: simulating a crash between member commit and event
+  write and then restarting produces a delivery via the reconciler within at
+  most one reconciler cycle (60s). Recovery is not sub-second; this is the
+  chosen reconciler interval, not a product trade-off.
+- **Migration executes**: after adding `//go:embed sql` + `SQLDir` to
+  `modules/notify/1module.go`, a fresh test DB brings `octo_space_welcome_
+  delivery` online without operator intervention.
+- **Concurrent claim**: two replicas racing on the same pending row —
+  `SELECT ... FOR UPDATE SKIP LOCKED` + `UPDATE` ensures the row is claimed
+  by exactly one replica.
+- **Drive loop**: idle poll interval is 5s; on any successful claim the
+  worker immediately loops back to claim the next row without waiting; a
+  per-wake safety cap of 20 rows forces a fall-through to the sleep branch.
+  No throughput SLA is asserted; see **Open questions** for the required
+  peak-rate confirmation.
+- **`attempts` semantics**: `attempts` is incremented **only** on a
+  definitive pre-IM failure that transitions the row back to `pending`; it
+  is not touched by claim, sweep, precheck-skip, `sent`, or `unknown`. A
+  crash-and-recover path never burns the retry budget.
+- **State-machine transitions**:
+  - Crash after `claimed`, before `dispatching` → sweep returns the row to
+    `pending`; subsequent claim proceeds normally without duplicating a
+    real send.
+  - Crash after `dispatching`, before terminal → sweep transitions the row
+    to `unknown`; no auto re-send.
+  - Every UPDATE past claim uses `WHERE id=? AND status=<expected> AND
+    claim_owner=<self>`; a stale replica cannot overwrite the current owner.
+- **User leaves before send**: while a row is pending, if the user leaves
+  the target Space, the pre-send check transitions the row to
+  `status=5 skipped` with `error_class=member_left`; no message is sent and
+  the row is not revisited even if the user rejoins later.
+- **Language selection**: `zh-*` users receive the zh copy, other supported
+  users the en copy; on any lookup failure/unset the code falls back to
+  `OCTO_DEFAULT_LANGUAGE` and proceeds (no retry). The chosen language is
+  persisted to `lang`.
+- **Send protocol**: `from_uid=notification`, `channel_type=PERSON`,
+  `red_dot=1`, `payload.type=Text`, `payload.space_id = current configured
+  space_id`.
+- **IM timeout enforcement**: the notify-local sender uses
+  `http.NewRequestWithContext` + `http.Client{Timeout: 15s}`; timeouts
+  actually close the socket and unblock the caller (unlike a
+  `context.WithTimeout` wrapper around octo-lib's `SendMessageWithResult`,
+  which cannot interrupt the underlying request). 15s < 30s dispatch lease
+  guarantees a hung request cannot outlive the lease.
+- **HTTP request headers**: the notify-local sender explicitly sets
+  `Content-Type: application/json` in addition to the `token` header
+  returned by `WuKongIMManagerTokenHeaderMap()`; a test asserts both are
+  present on outbound requests.
+- **DB call context deadlines**: every DB call inside the worker (sweep,
+  claim, precheck, CAS transitions, ledger persist) is issued under a
+  bounded context (≤ 3s per call); a slow-query fault-injection test
+  confirms the worker fails the row through the pre-IM / unknown paths
+  rather than dangling.
+- **No octo-lib change**: the diff contains no modification under
+  `vendor/github.com/Mininglamp-OSS/octo-lib` (or the module path
+  equivalent); `go.mod` version of octo-lib is unchanged.
+- **Success persistence**: on a 200-OK response from the notify-local
+  sender the row records `message_id` / `client_msg_no` (parsed from the IM
+  response body, same shape as octo-lib parses) and moves to `status=3`;
+  no subsequent event/reconciler/restart triggers another send.
+- **Bounded retry**: pre-IM definitive failures back off `{5s, 30s, 120s}`
+  and after the **4th consecutive pre-IM failure** move to `failed`.
+- **Transport-ambiguous**: IM timeout / connection reset / empty response /
+  post-success ledger update failure all record `status=6 unknown`; neither
+  the worker nor the reconciler retries.
+- **Space switch**: after the config changes to a different `space_id`, the
+  worker and reconciler operate only on the new Space; the previous Space's
+  pending rows remain in the table (operator-cleaned via SQL) but are never
+  claimed again.
+- **Schema alignment**: `space_id` and `uid` columns match the length,
+  character set, and collation of the columns they join against; a JOIN
+  smoke test confirms no MySQL 1267 error.
+- **Time discipline**: no SQL statement in this feature uses naked `NOW()`;
+  all timestamps are application-supplied UTC values.
+- **Backward compatibility**: existing tests in `modules/notify`,
+  `modules/space`, `modules/common`, and bot provisioning continue to pass;
+  no wire response changes.
+- **This task's tests cover at minimum**: config combination validation and
+  `SpaceWelcomeConfig()` snapshot atomicity; ledger unique constraint under
+  concurrent upsert; event enqueue; reconciler catch-up (including the
+  `addMembers` path); `active_from` time boundary; human filter (with
+  `notification` as sender not filtered); user leaves before send → row
+  becomes `skipped` and is not revisited even after rejoin; language
+  fallback (including lookup failure fallback without retry); disable
+  (admin replica immediate / peer convergence via reload); success
+  persistence; `unknown` non-retry; sweep of `claimed` back to `pending`;
+  sweep of `dispatching` to `unknown`; CAS predicate blocking cross-owner
+  overwrite; concurrent `SELECT ... FOR UPDATE SKIP LOCKED` claim.
+- **Command-line verification**:
+  - `go test -race ./modules/notify/...`
+  - `go test -race ./modules/common/...`
+  - `go test -race ./modules/space/...`
+  - When touching error codes / i18n: `make i18n-extract-check && make i18n-lint`
+  - `go test -race ./...`
+  - `git diff --check`
+- **Rollout**: land migration + deploy with `enabled=false` → write target
+  `space_id`, UTC `active_from`, and zh/en message bodies → verify with two
+  fresh test accounts that the DM, red dot, copy, ledger row (`status=3`),
+  and metrics are correct → flip the switch. On incident, flip the switch
+  off first; retain the ledger and migration for audit and recovery.
+
+## Open questions (product / operations sign-off required before enabling)
+
+These are product/business decisions, not physical constraints or existing
+system facts. Enabling the feature in production requires explicit sign-off
+on each. Code can land and be deployed with `enabled=false` without
+sign-off; flipping `enabled=true` in production is blocked until each is
+recorded (e.g. in the octospec journal for this task).
+
+1. **At-most-once behavior.** In transport-ambiguous cases (IM 15s timeout,
+   connection reset, non-200, post-success ledger update failure), the row
+   is marked `unknown` and never auto-retried; the user may or may not have
+   received the message, with no side channel to reconstruct which. →
+   Confirm a small ongoing `unknown_backlog` handled by SQL + Grafana is
+   acceptable, and that occasional silent missed welcomes are preferred
+   over occasional duplicates.
+2. **`skipped` is terminal.** A user who leaves the target Space before the
+   worker sends is marked `skipped` and will not receive the welcome even
+   if they rejoin later. → Confirm this matches product intent, or change
+   the design to keep such rows revisitable (out of the current minimal
+   scope).
+3. **Throughput ceiling vs peak join rate.** A single replica drains a
+   fresh backlog at roughly `20 rows / (20 × per-row latency + 5s)` —
+   under nominal ≲ 1s per-row latency, ~240 rows/min in burst; steady
+   state polls every 5s when idle. Multiple replicas scale linearly. →
+   Confirm the expected peak-join rate for the target Space fits within
+   this envelope, backed by a real estimate rather than assumed.
+
+Existing system facts, documented here for completeness but **not**
+open questions:
+
+- Target users may receive DMs from BotFather's Space welcome and/or
+  `u_10000`'s register/login welcome in addition to this feature's DM.
+  Those pipelines predate this task and are unchanged; this task does not
+  need product sign-off to leave them alone. If the product later wants to
+  sequence or suppress them, file a separate task.
+- Disable takes effect immediately on the admin-request replica and within
+  ≤ 60s on peers, bounded by the shared `SystemSettings` reload TTL. Lost
+  events are picked up within ≤ 60s by the reconciler. These are
+  properties of `system_setting` and the chosen 60s reconciler interval,
+  not one-off product trade-offs. Every other `system_setting`-backed
+  feature on this server operates under the same reload window.

--- a/modules/common/api_manager_system_setting.go
+++ b/modules/common/api_manager_system_setting.go
@@ -10,6 +10,10 @@ import (
 	commonbase "github.com/Mininglamp-OSS/octo-server/modules/base/common"
 
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
+	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
+	spacepkg "github.com/Mininglamp-OSS/octo-server/pkg/space"
 	"go.uber.org/zap"
 )
 
@@ -283,6 +287,60 @@ func (m *Manager) updateSystemSettings(c *wkhttp.Context) {
 			// Anything goes.
 		}
 		plans = append(plans, p)
+	}
+
+	// Prospective composite validation for the onboarding space-welcome
+	// five-tuple (task space-new-user-welcome-message). A partial update
+	// (e.g. changing only space_id) must be validated against
+	// merge(current snapshot, incoming items), NOT the pre-write snapshot
+	// alone: validating the current snapshot would wrongly accept a patch that
+	// breaks the composite and wrongly reject a patch that repairs it. We
+	// therefore start from SpaceWelcomeConfig() and overlay the just-validated
+	// plan values before validating. Only runs when this batch touches an
+	// onboarding.* key, so unrelated writes pay nothing.
+	welcomeIncoming := map[string]string{}
+	for _, p := range plans {
+		if p.def.Category == "onboarding" {
+			welcomeIncoming[p.def.Key] = p.value
+		}
+	}
+	if len(welcomeIncoming) > 0 {
+		prospective := m.systemSettings.SpaceWelcomeConfig()
+		if v, ok := welcomeIncoming["space_welcome_enabled"]; ok {
+			prospective.Enabled = v == "1"
+		}
+		if v, ok := welcomeIncoming["space_welcome_space_id"]; ok {
+			prospective.SpaceID = v
+		}
+		if v, ok := welcomeIncoming["space_welcome_active_from"]; ok {
+			prospective.ActiveFromRaw = v
+		}
+		if v, ok := welcomeIncoming["space_welcome_message_zh_cn"]; ok {
+			prospective.MessageZhCN = v
+		}
+		if v, ok := welcomeIncoming["space_welcome_message_en_us"]; ok {
+			prospective.MessageEnUS = v
+		}
+		field, verr := ValidateSpaceWelcomeCombination(prospective, func(spaceID string) (bool, error) {
+			// GetSpaceName returns "" (no error) when the space is missing or
+			// dissolved (status!=1), non-empty when it exists and is active.
+			name, e := spacepkg.GetSpaceName(m.ctx.DB(), spaceID)
+			if e != nil {
+				return false, e
+			}
+			return name != "", nil
+		})
+		if verr != nil {
+			// Infrastructure error (space lookup DB read failed). Do not leak
+			// the DB detail — log it, respond with the generic internal code.
+			m.Error("校验 space welcome 目标空间失败", zap.Error(verr))
+			httperr.ResponseErrorL(c, errcode.ErrSharedInternal, nil, nil)
+			return
+		}
+		if field != "" {
+			httperr.ResponseErrorL(c, errcode.ErrSpaceWelcomeConfigInvalid, nil, i18n.Details{"field": field})
+			return
+		}
 	}
 
 	// Atomic batch: open one transaction, queue every upsert, commit only

--- a/modules/common/space_welcome_config_test.go
+++ b/modules/common/space_welcome_config_test.go
@@ -1,0 +1,200 @@
+package common
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// snapshotFor builds a NoInfra SystemSettings whose snapshot holds exactly the
+// given onboarding.* keys.
+func welcomeSnapshot(t *testing.T, kv map[string]string) *SystemSettings {
+	t.Helper()
+	s := &SystemSettings{}
+	snap := map[string]string{}
+	for k, v := range kv {
+		snap["onboarding."+k] = v
+	}
+	s.snapshot.Store(&snap)
+	return s
+}
+
+func validWelcomeKV() map[string]string {
+	return map[string]string{
+		"space_welcome_enabled":       "1",
+		"space_welcome_space_id":      "spc_x",
+		"space_welcome_active_from":   "2026-07-16T00:00:00Z",
+		"space_welcome_message_zh_cn": "欢迎加入",
+		"space_welcome_message_en_us": "Welcome aboard",
+	}
+}
+
+func TestSpaceWelcomeConfig_ReadsAllFiveKeys(t *testing.T) {
+	s := welcomeSnapshot(t, validWelcomeKV())
+	cfg := s.SpaceWelcomeConfig()
+	assert.True(t, cfg.Enabled)
+	assert.Equal(t, "spc_x", cfg.SpaceID)
+	assert.Equal(t, "2026-07-16T00:00:00Z", cfg.ActiveFromRaw)
+	assert.Equal(t, "欢迎加入", cfg.MessageZhCN)
+	assert.Equal(t, "Welcome aboard", cfg.MessageEnUS)
+
+	at, ok := cfg.ParsedActiveFrom()
+	assert.True(t, ok)
+	assert.Equal(t, time.Date(2026, 7, 16, 0, 0, 0, 0, time.UTC), at)
+}
+
+func TestSpaceWelcomeConfig_Defaults(t *testing.T) {
+	s := welcomeSnapshot(t, map[string]string{})
+	cfg := s.SpaceWelcomeConfig()
+	assert.False(t, cfg.Enabled)
+	assert.Empty(t, cfg.SpaceID)
+	_, ok := cfg.ParsedActiveFrom()
+	assert.False(t, ok)
+}
+
+// TestSpaceWelcomeConfig_SnapshotAtomicity swaps between two complete but
+// distinct tuples while a reader loops. Every read must return one whole tuple,
+// never a mix of the two — this is the property the single-snapshot accessor
+// guarantees. Run under -race.
+func TestSpaceWelcomeConfig_SnapshotAtomicity(t *testing.T) {
+	s := &SystemSettings{}
+	tupleA := map[string]string{
+		"onboarding.space_welcome_enabled":       "1",
+		"onboarding.space_welcome_space_id":      "spc_a",
+		"onboarding.space_welcome_active_from":   "2026-01-01T00:00:00Z",
+		"onboarding.space_welcome_message_zh_cn": "A-zh",
+		"onboarding.space_welcome_message_en_us": "A-en",
+	}
+	tupleB := map[string]string{
+		"onboarding.space_welcome_enabled":       "1",
+		"onboarding.space_welcome_space_id":      "spc_b",
+		"onboarding.space_welcome_active_from":   "2026-02-02T00:00:00Z",
+		"onboarding.space_welcome_message_zh_cn": "B-zh",
+		"onboarding.space_welcome_message_en_us": "B-en",
+	}
+	s.snapshot.Store(&tupleA)
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		toggle := false
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				if toggle {
+					s.snapshot.Store(&tupleA)
+				} else {
+					s.snapshot.Store(&tupleB)
+				}
+				toggle = !toggle
+			}
+		}
+	}()
+
+	for i := 0; i < 5000; i++ {
+		cfg := s.SpaceWelcomeConfig()
+		switch cfg.SpaceID {
+		case "spc_a":
+			assert.Equal(t, "A-zh", cfg.MessageZhCN)
+			assert.Equal(t, "A-en", cfg.MessageEnUS)
+			assert.Equal(t, "2026-01-01T00:00:00Z", cfg.ActiveFromRaw)
+		case "spc_b":
+			assert.Equal(t, "B-zh", cfg.MessageZhCN)
+			assert.Equal(t, "B-en", cfg.MessageEnUS)
+			assert.Equal(t, "2026-02-02T00:00:00Z", cfg.ActiveFromRaw)
+		default:
+			t.Fatalf("torn read: space_id=%q", cfg.SpaceID)
+		}
+	}
+	close(stop)
+	wg.Wait()
+}
+
+func TestValidateSpaceWelcomeCombination(t *testing.T) {
+	activeSpace := func(string) (bool, error) { return true, nil }
+	longMsg := make([]rune, spaceWelcomeMessageMaxRunes+1)
+	for i := range longMsg {
+		longMsg[i] = 'x'
+	}
+
+	cases := []struct {
+		name      string
+		mutate    func(*SpaceWelcomeConfig)
+		checker   func(string) (bool, error)
+		wantField string
+	}{
+		{"disabled always ok", func(c *SpaceWelcomeConfig) { c.Enabled = false; c.SpaceID = "" }, nil, ""},
+		{"valid", nil, activeSpace, ""},
+		{"missing space_id", func(c *SpaceWelcomeConfig) { c.SpaceID = "  " }, activeSpace, "space_welcome_space_id"},
+		{"bad time", func(c *SpaceWelcomeConfig) { c.ActiveFromRaw = "not-a-time" }, activeSpace, "space_welcome_active_from"},
+		{"empty zh", func(c *SpaceWelcomeConfig) { c.MessageZhCN = "   " }, activeSpace, "space_welcome_message_zh_cn"},
+		{"empty en", func(c *SpaceWelcomeConfig) { c.MessageEnUS = "" }, activeSpace, "space_welcome_message_en_us"},
+		{"oversize zh", func(c *SpaceWelcomeConfig) { c.MessageZhCN = string(longMsg) }, activeSpace, "space_welcome_message_zh_cn"},
+		{"space not active", nil, func(string) (bool, error) { return false, nil }, "space_welcome_space_id"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := SpaceWelcomeConfig{
+				Enabled:       true,
+				SpaceID:       "spc_x",
+				ActiveFromRaw: "2026-07-16T00:00:00Z",
+				MessageZhCN:   "欢迎",
+				MessageEnUS:   "Welcome",
+			}
+			if tc.mutate != nil {
+				tc.mutate(&cfg)
+			}
+			field, err := ValidateSpaceWelcomeCombination(cfg, tc.checker)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.wantField, field)
+		})
+	}
+}
+
+func TestValidateSpaceWelcomeCombination_SpaceCheckError(t *testing.T) {
+	cfg := SpaceWelcomeConfig{
+		Enabled: true, SpaceID: "spc_x", ActiveFromRaw: "2026-07-16T00:00:00Z",
+		MessageZhCN: "欢迎", MessageEnUS: "Welcome",
+	}
+	_, err := ValidateSpaceWelcomeCombination(cfg, func(string) (bool, error) {
+		return false, assert.AnError
+	})
+	assert.Error(t, err, "infra error must surface, not be masked as a validation field")
+}
+
+// TestValidateSpaceWelcomeCombination_Prospective covers the two directions the
+// prospective-merge write path must get right, by validating the merged tuple
+// directly (the handler builds the same merge inline).
+func TestValidateSpaceWelcomeCombination_Prospective(t *testing.T) {
+	activeSpace := func(string) (bool, error) { return true, nil }
+
+	// (1) Valid current snapshot; a patch that alone looks fine but whose merge
+	// is invalid (blanks the zh message) must be rejected.
+	current := SpaceWelcomeConfig{
+		Enabled: true, SpaceID: "spc_x", ActiveFromRaw: "2026-07-16T00:00:00Z",
+		MessageZhCN: "欢迎", MessageEnUS: "Welcome",
+	}
+	merged := current
+	merged.MessageZhCN = "" // incoming patch clears zh
+	field, err := ValidateSpaceWelcomeCombination(merged, activeSpace)
+	assert.NoError(t, err)
+	assert.Equal(t, "space_welcome_message_zh_cn", field, "merge that breaks the composite must be rejected")
+
+	// (2) Invalid current snapshot (enabled but no space_id); a patch that adds a
+	// valid space_id repairs the composite and must be accepted.
+	broken := SpaceWelcomeConfig{
+		Enabled: true, SpaceID: "", ActiveFromRaw: "2026-07-16T00:00:00Z",
+		MessageZhCN: "欢迎", MessageEnUS: "Welcome",
+	}
+	repaired := broken
+	repaired.SpaceID = "spc_x" // incoming patch supplies the space
+	field, err = ValidateSpaceWelcomeCombination(repaired, activeSpace)
+	assert.NoError(t, err)
+	assert.Empty(t, field, "patch that repairs the composite must be accepted")
+}

--- a/modules/common/system_setting_schema.go
+++ b/modules/common/system_setting_schema.go
@@ -201,6 +201,24 @@ var systemSettingSchema = []settingDef{
 	{Category: "sticker", Key: "compress_max_dimension", Type: settingTypeInt, Description: "贴纸压缩缩放目标边长(px，仅静态 jpg/png)；压缩开启后大于此值等比缩小再存；硬上限 1024，默认 512。建议 ≤ upload_max_dimension，否则压后仍超 upload_max_dimension 的图会被 fail-closed 拒绝", Positive: true,
 		Effective: func(s *SystemSettings) string { return strconv.Itoa(s.StickerCompressMaxDimension()) }},
 
+	// Space 新成员欢迎语（onboarding.space_welcome_*）— task
+	// space-new-user-welcome-message。这五个键必须构成一致的「启用组合」：
+	// enabled=true 时，space_id 必须指向存在且未解散的 Space，active_from 可按
+	// RFC3339(UTC) 解析，中英文文案 trim 后非空且 ≤2000 code points。写侧做
+	// prospective 组合校验（merge 快照+入参），worker/reconciler 每周期再校验一次
+	// fail-closed。调用方读取一律走 SpaceWelcomeConfig()（单快照原子读五键），
+	// 不要逐键读，避免跨 Reload() 拼出不一致组合。默认关闭，随快照 60s 内多实例收敛。
+	{Category: "onboarding", Key: "space_welcome_enabled", Type: settingTypeBool, Description: "是否开启「新成员加入指定 Space 时由通知助手发送一条欢迎语 DM」（默认关闭；启用需 space_id/active_from/中英文文案构成有效组合）",
+		Effective: func(s *SystemSettings) string { return boolToCanonical(s.SpaceWelcomeConfig().Enabled) }},
+	{Category: "onboarding", Key: "space_welcome_space_id", Type: settingTypeString, Description: "欢迎语目标 Space 的 space_id（必须存在且未解散）",
+		Effective: func(s *SystemSettings) string { return s.SpaceWelcomeConfig().SpaceID }},
+	{Category: "onboarding", Key: "space_welcome_active_from", Type: settingTypeString, Description: "欢迎语生效起点（RFC3339 UTC，如 2026-07-16T00:00:00Z）；仅 created_at>=此刻首次加入的成员会收到",
+		Effective: func(s *SystemSettings) string { return s.SpaceWelcomeConfig().ActiveFromRaw }},
+	{Category: "onboarding", Key: "space_welcome_message_zh_cn", Type: settingTypeString, Description: "欢迎语中文文案（纯文本，trim 后非空，≤2000 字符）",
+		Effective: func(s *SystemSettings) string { return s.SpaceWelcomeConfig().MessageZhCN }},
+	{Category: "onboarding", Key: "space_welcome_message_en_us", Type: settingTypeString, Description: "欢迎语英文文案（纯文本，trim 后非空，≤2000 字符）",
+		Effective: func(s *SystemSettings) string { return s.SpaceWelcomeConfig().MessageEnUS }},
+
 	// Email server config — formerly yaml-only (Support.* in config.go).
 	{Category: "support", Key: "email", Type: settingTypeString, Description: "技术支持邮箱（发件人）",
 		Effective: func(s *SystemSettings) string { return s.SupportEmail() }},

--- a/modules/common/system_settings.go
+++ b/modules/common/system_settings.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+	"unicode/utf8"
 
 	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
@@ -200,6 +201,14 @@ func (s *SystemSettings) getBool(category, key string, fallback bool) bool {
 	if !ok {
 		return fallback
 	}
+	return parseSettingBool(v, fallback)
+}
+
+// parseSettingBool applies the canonical system_setting bool literal rules
+// (1/true/TRUE → true, 0/false/FALSE → false, anything else → fallback).
+// Shared by getBool and the atomic SpaceWelcomeConfig reader so both spell the
+// parse the same way.
+func parseSettingBool(v string, fallback bool) bool {
 	switch v {
 	case "1", "true", "TRUE":
 		return true
@@ -351,13 +360,14 @@ var oidcProviderIDRe = regexp.MustCompile(`^[a-z0-9][a-z0-9_-]{0,63}$`)
 // the safety override and lock everyone out.
 //
 // Why duplicated instead of importing modules/oidc:
-//   modules/common ← system_settings.go would need to import modules/oidc,
-//   but modules/oidc transitively imports modules/user → modules/common,
-//   creating a cycle. Extracting oidc.LoadConfig into its own leaf package
-//   was considered and rejected as out-of-scope churn for this PR. The
-//   trade-off is mirroring the required-env list here; modules/oidc/
-//   config.go carries a reciprocal comment so adding a new required env
-//   prompts updating both places.
+//
+//	modules/common ← system_settings.go would need to import modules/oidc,
+//	but modules/oidc transitively imports modules/user → modules/common,
+//	creating a cycle. Extracting oidc.LoadConfig into its own leaf package
+//	was considered and rejected as out-of-scope churn for this PR. The
+//	trade-off is mirroring the required-env list here; modules/oidc/
+//	config.go carries a reciprocal comment so adding a new required env
+//	prompts updating both places.
 //
 // Mirrored requirements (keep in sync with modules/oidc/config.go):
 //   - DM_OIDC_ENABLED  parsed by strconv.ParseBool — accepts 1/0/t/T/true/
@@ -428,13 +438,14 @@ func isOIDCFullyConfigured() bool {
 // works after flipping the switch.
 //
 // Why localOff is a parameter, not read from snapshot here:
-//   Callers know the intended value with stronger guarantees than the
-//   shared snapshot. The manager-write path can pass the just-validated
-//   request value (independent of whether Reload succeeded — PR #104 P2
-//   from yujiawei). Startup passes the freshly-loaded snapshot value.
-//   Reading the snapshot directly inside this method would silently miss
-//   the warning when Reload fails right after a write, exactly when ops
-//   most needs the signal.
+//
+//	Callers know the intended value with stronger guarantees than the
+//	shared snapshot. The manager-write path can pass the just-validated
+//	request value (independent of whether Reload succeeded — PR #104 P2
+//	from yujiawei). Startup passes the freshly-loaded snapshot value.
+//	Reading the snapshot directly inside this method would silently miss
+//	the warning when Reload fails right after a write, exactly when ops
+//	most needs the signal.
 //
 // Callers: invoke once at server startup (Common.Route) after Load
 // completes, and from the manager update handler after a write that
@@ -469,11 +480,11 @@ const envSpaceDisableUserCreate = "DM_SPACE_DISABLE_USER_CREATE"
 // SpaceDisableUserCreate reports whether the user-facing「创建空间」入口应被
 // 关闭。完整 fallback 链(按优先级):
 //
-//	1. DB 行存在且 value 非空 → 走 getBool 解析(1/true/TRUE → true;
-//	   0/false/FALSE → false; 未知字面量 → false)。**不再回退到 env** —— 与
-//	   其他 bool 设置一致,未知字面量等同 "admin 不希望关闭"。
-//	2. DB 行不存在,或 value="" → env DM_SPACE_DISABLE_USER_CREATE
-//	3. 都缺失 → false (保持开放)
+//  1. DB 行存在且 value 非空 → 走 getBool 解析(1/true/TRUE → true;
+//     0/false/FALSE → false; 未知字面量 → false)。**不再回退到 env** —— 与
+//     其他 bool 设置一致,未知字面量等同 "admin 不希望关闭"。
+//  2. DB 行不存在,或 value="" → env DM_SPACE_DISABLE_USER_CREATE
+//  3. 都缺失 → false (保持开放)
 //
 // 注：manager 写接口对 bool 值已做规范化(只接受 0/1/true/false 及大小写
 // 变体),正常路径不会出现未知字面量;此规则覆盖的是有人绕过 API 直接改 DB
@@ -1021,4 +1032,117 @@ func (s *SystemSettings) StickerCompressMaxDimension() int {
 		defaultStickerCompressMaxDimension,
 		stickerUploadMaxDimensionHardCap,
 	)
+}
+
+// ---------------------------------------------------------------------------
+// Space new-user welcome (onboarding.space_welcome_*) — task
+// space-new-user-welcome-message
+// ---------------------------------------------------------------------------
+
+const (
+	// spaceWelcomeCategory is the system_setting category for the five
+	// onboarding welcome keys.
+	spaceWelcomeCategory = "onboarding"
+	// spaceWelcomeMessageMaxRunes bounds each localized welcome body in Unicode
+	// code points (validated on the manager write path and re-validated at
+	// runtime).
+	spaceWelcomeMessageMaxRunes = 2000
+)
+
+// SpaceWelcomeConfig is an atomic, point-in-time view of the five
+// onboarding.space_welcome_* settings. All five fields are read from the SAME
+// SystemSettings snapshot in one access, so a caller can never straddle a
+// background Reload() and combine values from two different snapshots. The
+// event handler, send worker, reconciler and the manager write path all rely
+// on this atomicity — reading the keys individually would risk an inconsistent
+// five-tuple.
+type SpaceWelcomeConfig struct {
+	Enabled       bool
+	SpaceID       string
+	ActiveFromRaw string
+	MessageZhCN   string
+	MessageEnUS   string
+}
+
+// SpaceWelcomeConfig returns the current five-tuple, all read from one snapshot.
+func (s *SystemSettings) SpaceWelcomeConfig() SpaceWelcomeConfig {
+	snapPtr := s.snapshot.Load()
+	get := func(key string) string {
+		if snapPtr == nil {
+			return ""
+		}
+		return (*snapPtr)[schemaKey(spaceWelcomeCategory, key)]
+	}
+	return SpaceWelcomeConfig{
+		Enabled:       parseSettingBool(get("space_welcome_enabled"), false),
+		SpaceID:       get("space_welcome_space_id"),
+		ActiveFromRaw: get("space_welcome_active_from"),
+		MessageZhCN:   get("space_welcome_message_zh_cn"),
+		MessageEnUS:   get("space_welcome_message_en_us"),
+	}
+}
+
+// ParsedActiveFrom parses ActiveFromRaw as RFC3339 and returns it in UTC.
+// ok is false when the value is empty or unparseable — callers treat that as an
+// invalid combination (fail closed) when the feature is enabled.
+func (c SpaceWelcomeConfig) ParsedActiveFrom() (time.Time, bool) {
+	if c.ActiveFromRaw == "" {
+		return time.Time{}, false
+	}
+	t, err := time.Parse(time.RFC3339, c.ActiveFromRaw)
+	if err != nil {
+		return time.Time{}, false
+	}
+	return t.UTC(), true
+}
+
+// validWelcomeMessage reports whether a localized body is non-empty after trim
+// and within the code-point limit.
+func validWelcomeMessage(msg string) bool {
+	if strings.TrimSpace(msg) == "" {
+		return false
+	}
+	return utf8.RuneCountInString(msg) <= spaceWelcomeMessageMaxRunes
+}
+
+// ValidateSpaceWelcomeCombination validates the five-tuple as a coherent
+// combination.
+//
+//   - When disabled it always passes: a partial or empty config is fine while
+//     the feature is off.
+//   - When enabled it requires a non-empty space_id that isActiveSpace confirms
+//     exists and is not dissolved, a parseable RFC3339 active_from, and both
+//     message bodies non-empty (after trim) within spaceWelcomeMessageMaxRunes.
+//
+// The (field, err) contract lets the caller distinguish a validation failure
+// (err == nil, field != "" naming the first offending key) from an
+// infrastructure error (err != nil, e.g. the space lookup DB read failed). A
+// nil isActiveSpace skips only the space existence check — used by callers that
+// cannot reach the DB or want the pure static checks.
+func ValidateSpaceWelcomeCombination(cfg SpaceWelcomeConfig, isActiveSpace func(spaceID string) (bool, error)) (field string, err error) {
+	if !cfg.Enabled {
+		return "", nil
+	}
+	if strings.TrimSpace(cfg.SpaceID) == "" {
+		return "space_welcome_space_id", nil
+	}
+	if _, ok := cfg.ParsedActiveFrom(); !ok {
+		return "space_welcome_active_from", nil
+	}
+	if !validWelcomeMessage(cfg.MessageZhCN) {
+		return "space_welcome_message_zh_cn", nil
+	}
+	if !validWelcomeMessage(cfg.MessageEnUS) {
+		return "space_welcome_message_en_us", nil
+	}
+	if isActiveSpace != nil {
+		active, checkErr := isActiveSpace(cfg.SpaceID)
+		if checkErr != nil {
+			return "space_welcome_space_id", checkErr
+		}
+		if !active {
+			return "space_welcome_space_id", nil
+		}
+	}
+	return "", nil
 }

--- a/modules/notify/1module.go
+++ b/modules/notify/1module.go
@@ -1,16 +1,31 @@
 package notify
 
 import (
+	"embed"
+
 	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/register"
 )
 
+//go:embed sql
+var sqlFS embed.FS
+
 func init() {
 	register.AddModule(func(ctx interface{}) register.Module {
+		// Construct the single Notify instance here so SetupAPI and the
+		// Start/Stop lifecycle hooks share it (mirrors modules/webhook).
+		n := New(ctx.(*config.Context))
 		return register.Module{
 			Name: "notify",
 			SetupAPI: func() register.APIRouter {
-				return New(ctx.(*config.Context))
+				return n
+			},
+			SQLDir: register.NewSQLFS(sqlFS),
+			Start: func() error {
+				return n.Start()
+			},
+			Stop: func() error {
+				return n.Stop()
 			},
 		}
 	})

--- a/modules/notify/api.go
+++ b/modules/notify/api.go
@@ -19,6 +19,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-server/internal/carddispatch"
 	"github.com/Mininglamp-OSS/octo-server/modules/base/app"
 	"github.com/Mininglamp-OSS/octo-server/modules/base/event"
+	"github.com/Mininglamp-OSS/octo-server/modules/common"
 	"github.com/Mininglamp-OSS/octo-server/modules/user"
 	"github.com/Mininglamp-OSS/octo-server/pkg/cardmsg"
 	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
@@ -75,6 +76,7 @@ type Notify struct {
 	actionSenders map[cardactiondispatch.NotifyCapability]carddispatch.Sender
 	internalToken string
 	docsToken     string
+	spaceWelcome  *spaceWelcomeService
 	log.Log
 }
 
@@ -143,6 +145,24 @@ func New(ctx *config.Context) *Notify {
 	// 监听成员加入事件
 	ctx.AddEventListener(event.SpaceMemberJoin, n.handleSpaceMemberEvent)
 
+	// Space 新成员欢迎语（task space-new-user-welcome-message）。langSvc 在无缓存
+	// 的测试环境下为 nil，resolveLanguage 会回退到 OCTO_DEFAULT_LANGUAGE。服务对象
+	// 在此构造，reconciler/worker goroutine 由模块 Start() 启动、Stop() 停止。
+	var langSvc *user.LanguageService
+	if ctx.Cache() != nil {
+		langSvc = user.NewLanguageService(user.NewDB(ctx), ctx.Cache())
+	}
+	n.spaceWelcome = newSpaceWelcomeService(
+		ctx,
+		common.EnsureSystemSettings(ctx),
+		langSvc,
+		NotifyBotUID(),
+		func() bool {
+			n.ensureNotifyBotReady()
+			return n.botOK.Load()
+		},
+	)
+
 	// 启动时创建全局通知 Bot（单例，带 panic recovery）。summary-notify
 	// 卡片复用同一身份，避免在用户会话列表中产生第二个系统 Bot 会话。
 	go func() {
@@ -210,7 +230,7 @@ func (n *Notify) internalAuthMiddleware() wkhttp.HandlerFunc {
 	}
 }
 
-// handleSpaceMemberEvent 成员变动时失效缓存
+// handleSpaceMemberEvent 成员变动时失效缓存，并在命中欢迎语配置时入队一条待投递。
 func (n *Notify) handleSpaceMemberEvent(data []byte, commit config.EventCommit) {
 	var req map[string]interface{}
 	if err := util.ReadJsonByByte(data, &req); err != nil {
@@ -218,10 +238,33 @@ func (n *Notify) handleSpaceMemberEvent(data []byte, commit config.EventCommit) 
 		commit(nil)
 		return
 	}
-	if spaceID, _ := req["space_id"].(string); spaceID != "" {
+	spaceID, _ := req["space_id"].(string)
+	uid, _ := req["uid"].(string)
+	if spaceID != "" {
 		n.memberCache.invalidate(spaceID)
 	}
+	// 低延迟入队：命中欢迎语配置的首次加入 human 成员写一条 pending 行。入队失败
+	// 只记日志、绝不阻塞或回滚已完成的加入（对账 goroutine 会兜底补齐）。
+	if n.spaceWelcome != nil && spaceID != "" && uid != "" {
+		n.spaceWelcome.handleMemberJoin(spaceID, uid)
+	}
 	commit(nil)
+}
+
+// Start 启动欢迎语的对账 + 发送 worker goroutine（模块生命周期钩子）。
+func (n *Notify) Start() error {
+	if n.spaceWelcome != nil {
+		n.spaceWelcome.Start()
+	}
+	return nil
+}
+
+// Stop 停止欢迎语后台 goroutine（context.Cancel + 等待清理退出）。
+func (n *Notify) Stop() error {
+	if n.spaceWelcome != nil {
+		n.spaceWelcome.Stop()
+	}
+	return nil
 }
 
 // sendNotify handles POST /v1/internal/notify

--- a/modules/notify/api.go
+++ b/modules/notify/api.go
@@ -163,20 +163,6 @@ func New(ctx *config.Context) *Notify {
 		},
 	)
 
-	// 启动时创建全局通知 Bot（单例，带 panic recovery）。summary-notify
-	// 卡片复用同一身份，避免在用户会话列表中产生第二个系统 Bot 会话。
-	go func() {
-		defer func() {
-			if r := recover(); r != nil {
-				n.Error("ensureNotifyBot panic", zap.Any("recover", r))
-			}
-		}()
-		n.ensureNotifyBotReady()
-		if n.botOK.Load() {
-			n.Info("Notify bot ready")
-		}
-	}()
-
 	return n
 }
 
@@ -253,6 +239,21 @@ func (n *Notify) handleSpaceMemberEvent(data []byte, commit config.EventCommit) 
 
 // Start 启动欢迎语的对账 + 发送 worker goroutine（模块生命周期钩子）。
 func (n *Notify) Start() error {
+	// 通知 Bot 的 provisioning 放在 Start()（而非 New()）：New() 现在于
+	// register.GetModules 阶段被调用，早于 module.Setup 跑迁移；若在 New() 里就
+	// 写库，可能对尚未建好的 schema 做写入。Start() 在迁移完成后才执行，安全。
+	// 带 panic recovery；失败可由 deliverNotification / worker 的 lazy 重试自愈。
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				n.Error("ensureNotifyBot panic", zap.Any("recover", r))
+			}
+		}()
+		n.ensureNotifyBotReady()
+		if n.botOK.Load() {
+			n.Info("Notify bot ready")
+		}
+	}()
 	if n.spaceWelcome != nil {
 		n.spaceWelcome.Start()
 	}

--- a/modules/notify/space_welcome.go
+++ b/modules/notify/space_welcome.go
@@ -1,0 +1,498 @@
+package notify
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
+	"github.com/Mininglamp-OSS/octo-server/modules/common"
+	"github.com/Mininglamp-OSS/octo-server/modules/user"
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
+	spacepkg "github.com/Mininglamp-OSS/octo-server/pkg/space"
+	"go.uber.org/zap"
+)
+
+// space_welcome.go — orchestration for the Space new-user welcome feature.
+//
+// Reliability contract (minimal implementation): first-join human → exactly one
+// ledger row → member re-check before send. Send semantics are at-most-once;
+// transport-ambiguous outcomes become `unknown` and are never auto-retried.
+//
+// The three moving parts share one ledger (octo_space_welcome_delivery):
+//   - the low-latency event path (handleMemberJoin) upserts a pending row;
+//   - the reconciler catches dropped events / restarts / the addMembers path;
+//   - the send worker claims pending rows, re-checks eligibility, and delivers.
+
+const langResolveTimeout = 2 * time.Second
+
+// spaceWelcomeService owns the reconciler + worker goroutines and the enqueue
+// path. It is constructed once per process by Notify.New and started/stopped via
+// the module Start/Stop hooks.
+type spaceWelcomeService struct {
+	ctx      *config.Context
+	store    *spaceWelcomeStore
+	settings *common.SystemSettings
+	langSvc  *user.LanguageService
+	metrics  *spaceWelcomeMetrics
+	fromUID  string
+	// sendFn delivers one personal DM. Defaults to the notify-local
+	// context-aware HTTP sender; overridable in tests.
+	sendFn func(ctx context.Context, req *config.MsgSendReq) (*swSendResult, error)
+	// botReady provisions (idempotent, retriable) and reports the notification
+	// bot readiness. A not-ready bot is a definitive pre-IM failure.
+	botReady func() bool
+	// now returns the current time; injectable for tests. Always UTC.
+	now func() time.Time
+
+	mu     sync.Mutex
+	cancel context.CancelFunc
+	wait   sync.WaitGroup
+
+	log.Log
+}
+
+func newSpaceWelcomeService(ctx *config.Context, settings *common.SystemSettings, langSvc *user.LanguageService, fromUID string, botReady func() bool) *spaceWelcomeService {
+	owner := claimOwnerID()
+	sender := newSpaceWelcomeSender(ctx)
+	return &spaceWelcomeService{
+		ctx:      ctx,
+		store:    newSpaceWelcomeStore(ctx.DB(), owner),
+		settings: settings,
+		langSvc:  langSvc,
+		metrics:  newSpaceWelcomeMetrics(),
+		fromUID:  fromUID,
+		sendFn:   sender.send,
+		botReady: botReady,
+		now:      func() time.Time { return time.Now().UTC() },
+		Log:      log.NewTLog("SpaceWelcome"),
+	}
+}
+
+// claimOwnerID builds a <hostname>:<pid> owner tag (K8s pod names can approach
+// 63 chars; the column is VARCHAR(128)).
+func claimOwnerID() string {
+	host, err := os.Hostname()
+	if err != nil || host == "" {
+		host = "unknown"
+	}
+	return fmt.Sprintf("%s:%d", host, os.Getpid())
+}
+
+// Start launches the reconciler and worker goroutines. Idempotent.
+func (s *spaceWelcomeService) Start() {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.cancel != nil {
+		return
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	s.cancel = cancel
+	s.wait.Add(2)
+	go s.reconcileLoop(ctx)
+	go s.workerLoop(ctx)
+	s.Info("space welcome service started", zap.String("claim_owner", s.store.claimOwner))
+}
+
+// Stop cancels the goroutines and waits for a clean shutdown.
+func (s *spaceWelcomeService) Stop() {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	cancel := s.cancel
+	s.cancel = nil
+	s.mu.Unlock()
+	if cancel != nil {
+		cancel()
+		s.wait.Wait()
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Event path (low latency)
+// ---------------------------------------------------------------------------
+
+// handleMemberJoin is invoked from the SpaceMemberJoin listener. When the event
+// matches the enabled config and the recipient is a first-join human member of
+// the target Space, it upserts a pending ledger row. Enqueue failure never
+// blocks or rolls back the completed join — it is logged and dropped (the
+// reconciler will catch it up).
+func (s *spaceWelcomeService) handleMemberJoin(spaceID, uid string) {
+	if s == nil || spaceID == "" || uid == "" {
+		return
+	}
+	cfg := s.settings.SpaceWelcomeConfig()
+	if !cfg.Enabled || spaceID != cfg.SpaceID {
+		return
+	}
+	// Static combination re-validation (no space-existence DB check on the hot
+	// path — the reconciler enforces that). Fail closed on an invalid config.
+	if field, _ := common.ValidateSpaceWelcomeCombination(cfg, nil); field != "" {
+		s.metrics.incConfigInvalid()
+		return
+	}
+	activeFrom, ok := cfg.ParsedActiveFrom()
+	if !ok {
+		s.metrics.incConfigInvalid()
+		return
+	}
+
+	// System-bot exclusion is scoped strictly to the recipient uid.
+	if spacepkg.IsSystemBot(uid) {
+		return
+	}
+
+	callCtx, cancel := context.WithTimeout(context.Background(), swDBCallTimeout)
+	defer cancel()
+	eligible, err := s.store.firstJoinHumanMember(callCtx, cfg.SpaceID, uid, activeFrom)
+	if err != nil {
+		s.Warn("welcome enqueue eligibility check failed",
+			zap.String("stage", swStageEnqueue), zap.String("space_id", cfg.SpaceID), zap.String("uid", uid), zap.Error(err))
+		return
+	}
+	if !eligible {
+		return
+	}
+	s.enqueue(callCtx, cfg.SpaceID, uid, swSourceEvent)
+}
+
+// enqueue upserts a pending row and splits enqueue_total vs enqueue_dedup_total.
+func (s *spaceWelcomeService) enqueue(ctx context.Context, spaceID, uid, source string) {
+	inserted, err := s.store.upsertPending(ctx, spaceID, uid, s.now())
+	if err != nil {
+		s.Warn("welcome enqueue upsert failed",
+			zap.String("stage", swStageEnqueue), zap.String("source", source),
+			zap.String("space_id", spaceID), zap.String("uid", uid), zap.Error(err))
+		return
+	}
+	if inserted {
+		s.metrics.incEnqueue(source)
+	} else {
+		s.metrics.incEnqueueDedup(source)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Reconciler
+// ---------------------------------------------------------------------------
+
+func (s *spaceWelcomeService) reconcileLoop(ctx context.Context) {
+	defer s.wait.Done()
+	ticker := time.NewTicker(swReconcileInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			s.safeRun("reconcile", func() { s.runReconcileOnce(ctx) })
+		}
+	}
+}
+
+// runReconcileOnce reads the config, re-validates (fail closed), scans the
+// target Space for active human members lacking a ledger row, and enqueues up
+// to swReconcileCap of them.
+func (s *spaceWelcomeService) runReconcileOnce(ctx context.Context) {
+	cfg := s.settings.SpaceWelcomeConfig()
+	if !cfg.Enabled {
+		return
+	}
+	if !s.validateRuntime(ctx, cfg) {
+		return
+	}
+	activeFrom, _ := cfg.ParsedActiveFrom()
+
+	scanCtx, cancel := context.WithTimeout(ctx, swDBCallTimeout)
+	uids, err := s.store.reconcileScan(scanCtx, cfg.SpaceID, activeFrom, spacepkg.SystemBotList(), swReconcileCap)
+	cancel()
+	if err != nil {
+		s.Warn("welcome reconcile scan failed",
+			zap.String("stage", swStageEnqueue), zap.String("space_id", cfg.SpaceID), zap.Error(err))
+		return
+	}
+	for _, uid := range uids {
+		if ctx.Err() != nil {
+			return
+		}
+		callCtx, c := context.WithTimeout(ctx, swDBCallTimeout)
+		s.enqueue(callCtx, cfg.SpaceID, uid, swSourceReconciler)
+		c()
+	}
+	if len(uids) > 0 {
+		s.Info("welcome reconcile enqueued",
+			zap.String("space_id", cfg.SpaceID), zap.Int("candidates", len(uids)))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Send worker
+// ---------------------------------------------------------------------------
+
+func (s *spaceWelcomeService) workerLoop(ctx context.Context) {
+	defer s.wait.Done()
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+		s.safeRun("worker", func() { s.runWorkerWake(ctx) })
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(swIdleSleep):
+		}
+	}
+}
+
+// runWorkerWake sweeps stale rows (always, even when disabled, so lease-expired
+// rows still reach a terminal state), then — when enabled and valid — drains up
+// to swWorkerWakeCap claimed rows. The per-wake cap is a safety valve; the next
+// wake resumes after the idle sleep.
+func (s *spaceWelcomeService) runWorkerWake(ctx context.Context) {
+	cfg := s.settings.SpaceWelcomeConfig()
+
+	// Sweep runs against the configured Space regardless of enabled, so that a
+	// disabled feature still promotes stale claimed/dispatching rows.
+	if cfg.SpaceID != "" {
+		s.sweep(ctx, cfg.SpaceID)
+	}
+
+	if !cfg.Enabled || !s.validateRuntime(ctx, cfg) {
+		return
+	}
+
+	for claimed := 0; claimed < swWorkerWakeCap; claimed++ {
+		if ctx.Err() != nil {
+			return
+		}
+		claimCtx, cancel := context.WithTimeout(ctx, swDBCallTimeout)
+		row, err := s.store.claimOne(claimCtx, cfg.SpaceID, s.now())
+		cancel()
+		if err != nil {
+			s.Warn("welcome claim failed", zap.String("stage", swStageClaim), zap.String("space_id", cfg.SpaceID), zap.Error(err))
+			return
+		}
+		if row == nil {
+			return // idle — fall through to sleep
+		}
+		s.dispatch(ctx, cfg, row)
+	}
+}
+
+// sweep reclaims lease-expired claimed rows (-> pending) and promotes
+// lease-expired dispatching rows (-> unknown). Runs once per wake.
+func (s *spaceWelcomeService) sweep(ctx context.Context, spaceID string) {
+	now := s.now()
+	c1, cancel1 := context.WithTimeout(ctx, swDBCallTimeout)
+	reclaimed, err := s.store.sweepClaimed(c1, spaceID, now)
+	cancel1()
+	if err != nil {
+		s.Warn("welcome sweep claimed failed", zap.String("stage", swStageSweep), zap.String("space_id", spaceID), zap.Error(err))
+	} else {
+		s.metrics.addSweepClaimed(reclaimed)
+	}
+
+	c2, cancel2 := context.WithTimeout(ctx, swDBCallTimeout)
+	promoted, err := s.store.sweepDispatching(c2, spaceID, now)
+	cancel2()
+	if err != nil {
+		s.Warn("welcome sweep dispatching failed", zap.String("stage", swStageSweep), zap.String("space_id", spaceID), zap.Error(err))
+	} else if promoted > 0 {
+		s.metrics.addSweepDispatching(promoted)
+		s.Warn("welcome dispatching rows swept to unknown", zap.String("space_id", spaceID), zap.Int64("count", promoted))
+	}
+}
+
+// dispatch takes one claimed row through pre-send re-check, dispatching
+// transition, IM delivery, and the terminal ledger transition.
+func (s *spaceWelcomeService) dispatch(ctx context.Context, cfg common.SpaceWelcomeConfig, row *spaceWelcomeRow) {
+	// Pre-send eligibility re-check (bypasses stale cache; recipient-only
+	// system-bot scope). A DB error here is a definitive pre-IM failure.
+	pcCtx, cancel := context.WithTimeout(ctx, swDBCallTimeout)
+	pc, err := s.store.precheckRecipient(pcCtx, cfg.SpaceID, row.UID, spacepkg.IsSystemBot)
+	cancel()
+	if err != nil {
+		s.Warn("welcome precheck failed", zap.String("stage", swStagePrecheck), zap.Int64("delivery_id", row.ID),
+			zap.String("space_id", cfg.SpaceID), zap.String("uid", row.UID), zap.Error(err))
+		s.preIMFailure(ctx, row, swErrConfigRead)
+		return
+	}
+	if !pc.eligible {
+		skCtx, c := context.WithTimeout(ctx, swDBCallTimeout)
+		ok, casErr := s.store.casToSkipped(skCtx, row.ID, pc.errClass, s.now())
+		c()
+		if casErr != nil {
+			s.Warn("welcome cas to skipped failed", zap.String("stage", swStagePrecheck), zap.Int64("delivery_id", row.ID), zap.Error(casErr))
+			return
+		}
+		if ok {
+			s.metrics.incSkipNonMember()
+			s.Info("welcome recipient skipped", zap.String("stage", swStagePrecheck), zap.Int64("delivery_id", row.ID),
+				zap.String("space_id", cfg.SpaceID), zap.String("uid", row.UID), zap.String("error_class", pc.errClass))
+		}
+		return
+	}
+
+	// Bot must be ready before we cross into dispatching. Not ready → pre-IM.
+	if s.botReady != nil && !s.botReady() {
+		s.preIMFailure(ctx, row, swErrBotNotReady)
+		return
+	}
+
+	lang := s.resolveLanguage(row.UID)
+
+	dsCtx, cancel := context.WithTimeout(ctx, swDBCallTimeout)
+	ok, err := s.store.casToDispatching(dsCtx, row.ID, lang, s.now())
+	cancel()
+	if err != nil {
+		s.Warn("welcome cas to dispatching failed", zap.String("stage", swStageDispatch), zap.Int64("delivery_id", row.ID), zap.Error(err))
+		s.preIMFailure(ctx, row, swErrConfigRead)
+		return
+	}
+	if !ok {
+		// Ownership lost (a peer sweep reclaimed the row after lease expiry).
+		// Do not send — avoids a double delivery.
+		s.Warn("welcome dispatch ownership lost before send", zap.String("stage", swStageDispatch), zap.Int64("delivery_id", row.ID))
+		return
+	}
+
+	// Build the personal DM. NewPersonalMsgSendReq is authoritative for
+	// payload.space_id; red_dot=1; payload.type=Text plain body.
+	payload := map[string]interface{}{"type": 1, "content": s.messageForLang(cfg, lang)}
+	req := config.NewPersonalMsgSendReq(row.UID, s.fromUID, payload, cfg.SpaceID,
+		config.PersonalMsgOptions{Header: config.MsgHeader{RedDot: 1}})
+
+	// The IM call must not be aborted by a shutdown mid-flight (the request is
+	// on the wire); the 15s client timeout bounds it. Stop is therefore bounded
+	// by the HTTP timeout, not left dangling.
+	sendCtx := context.WithoutCancel(ctx)
+	result, sendErr := s.sendFn(sendCtx, req)
+	if sendErr != nil {
+		// Any failure AFTER the dispatching transition is transport-ambiguous.
+		class := swErrIMTimeout
+		var se *swSendError
+		if errors.As(sendErr, &se) {
+			class = se.class
+		}
+		s.toUnknown(ctx, row, class)
+		return
+	}
+
+	// Success → persist identifiers. A failure of THIS ledger write is itself
+	// transport-ambiguous (message was sent, but we could not record it).
+	persistCtx, cancel := context.WithTimeout(ctx, swDBCallTimeout)
+	sentOK, persistErr := s.store.casToSent(persistCtx, row.ID, result.messageID, result.clientMsgNo, s.now())
+	cancel()
+	if persistErr != nil {
+		s.Error("welcome sent persist failed", zap.String("stage", swStagePersist), zap.Int64("delivery_id", row.ID), zap.Error(persistErr))
+		s.toUnknown(ctx, row, swErrSentPersist)
+		return
+	}
+	if !sentOK {
+		// Ownership lost between dispatch and persist (a sweep already moved the
+		// row to unknown). Leave it; do not resurrect.
+		s.Warn("welcome sent persist ownership lost", zap.String("stage", swStagePersist), zap.Int64("delivery_id", row.ID))
+		return
+	}
+	s.metrics.incSendSuccess()
+	s.Info("welcome delivered", zap.String("stage", swStagePersist), zap.Int64("delivery_id", row.ID),
+		zap.String("space_id", cfg.SpaceID), zap.String("uid", row.UID), zap.String("lang", lang))
+}
+
+// preIMFailure records a definitive pre-IM failure (the only place attempts
+// grows): backs off to pending, or fails terminally after the retry budget.
+func (s *spaceWelcomeService) preIMFailure(ctx context.Context, row *spaceWelcomeRow, class string) {
+	c, cancel := context.WithTimeout(ctx, swDBCallTimeout)
+	_, err := s.store.casPreIMFailure(c, row.ID, row.Attempts, class, s.now())
+	cancel()
+	if err != nil {
+		s.Warn("welcome cas pre-IM failure failed", zap.Int64("delivery_id", row.ID), zap.String("error_class", class), zap.Error(err))
+		return
+	}
+	if row.Attempts+1 > swMaxPreIMAttempts {
+		s.metrics.incSendFailed()
+		s.Warn("welcome delivery failed (retry budget exhausted)", zap.Int64("delivery_id", row.ID), zap.String("error_class", class))
+	}
+}
+
+// toUnknown records a transport-ambiguous outcome (never auto-retried).
+func (s *spaceWelcomeService) toUnknown(ctx context.Context, row *spaceWelcomeRow, class string) {
+	c, cancel := context.WithTimeout(ctx, swDBCallTimeout)
+	_, err := s.store.casToUnknown(c, row.ID, class, s.now())
+	cancel()
+	if err != nil {
+		s.Error("welcome cas to unknown failed", zap.Int64("delivery_id", row.ID), zap.String("error_class", class), zap.Error(err))
+		return
+	}
+	s.metrics.incSendUnknown()
+	s.Warn("welcome delivery outcome unknown", zap.String("stage", swStageDispatch), zap.Int64("delivery_id", row.ID), zap.String("error_class", class))
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// validateRuntime re-validates the enabled config including that the target
+// Space exists and is active. Any config failure increments config_invalid_total
+// and fails the cycle closed; an infra error (space lookup) also fails closed
+// for the cycle without counting as a config error. The space check is bounded
+// by swDBCallTimeout.
+func (s *spaceWelcomeService) validateRuntime(ctx context.Context, cfg common.SpaceWelcomeConfig) bool {
+	field, err := common.ValidateSpaceWelcomeCombination(cfg, func(spaceID string) (bool, error) {
+		c, cancel := context.WithTimeout(ctx, swDBCallTimeout)
+		defer cancel()
+		return s.store.spaceActive(c, spaceID)
+	})
+	if err != nil {
+		s.Warn("welcome runtime space check failed", zap.String("space_id", cfg.SpaceID), zap.Error(err))
+		return false
+	}
+	if field != "" {
+		s.metrics.incConfigInvalid()
+		s.Warn("welcome config invalid; failing closed", zap.String("field", field))
+		return false
+	}
+	return true
+}
+
+// resolveLanguage resolves the recipient's outbound language (zh-CN/en-US). On
+// any lookup failure or unset preference it falls back to OCTO_DEFAULT_LANGUAGE
+// — language lookup is never a retryable error.
+func (s *spaceWelcomeService) resolveLanguage(uid string) string {
+	if s.langSvc != nil {
+		rctx, cancel := context.WithTimeout(context.Background(), langResolveTimeout)
+		lang, err := s.langSvc.Resolve(rctx, uid)
+		cancel()
+		if err == nil && lang != "" {
+			return lang
+		}
+	}
+	return i18n.OutboundLanguage(context.Background())
+}
+
+// messageForLang picks the localized body. zh-* → zh copy, otherwise en copy.
+func (s *spaceWelcomeService) messageForLang(cfg common.SpaceWelcomeConfig, lang string) string {
+	if strings.HasPrefix(strings.ToLower(lang), "zh") {
+		return cfg.MessageZhCN
+	}
+	return cfg.MessageEnUS
+}
+
+// safeRun runs fn with panic recovery so one bad cycle cannot kill the loop.
+func (s *spaceWelcomeService) safeRun(what string, fn func()) {
+	defer func() {
+		if r := recover(); r != nil {
+			s.Error("space welcome cycle panic", zap.String("cycle", what), zap.Any("recover", r))
+		}
+	}()
+	fn()
+}

--- a/modules/notify/space_welcome.go
+++ b/modules/notify/space_welcome.go
@@ -460,13 +460,17 @@ func (s *spaceWelcomeService) dispatch(ctx context.Context, cfg common.SpaceWelc
 // grows): backs off to pending, or fails terminally after the retry budget.
 func (s *spaceWelcomeService) preIMFailure(ctx context.Context, row *spaceWelcomeRow, class string) {
 	c, cancel := context.WithTimeout(ctx, swDBCallTimeout)
-	_, err := s.store.casPreIMFailure(c, row.ID, row.Attempts, class, s.now())
+	ok, err := s.store.casPreIMFailure(c, row.ID, row.Attempts, class, s.now())
 	cancel()
 	if err != nil {
 		s.Warn("welcome cas pre-IM failure failed", zap.Int64("delivery_id", row.ID), zap.String("error_class", class), zap.Error(err))
 		return
 	}
-	if row.Attempts+1 > swMaxPreIMAttempts {
+	// Only count a terminal failure when THIS replica actually made the
+	// transition. ok=false means a peer's sweep reclaimed the row (it may still
+	// be retried by its new owner), so counting send_failed here would
+	// over-report terminal failures in a multi-replica deployment.
+	if ok && row.Attempts+1 > swMaxPreIMAttempts {
 		s.metrics.incSendFailed()
 		s.Warn("welcome delivery failed (retry budget exhausted)", zap.Int64("delivery_id", row.ID), zap.String("error_class", class))
 	}

--- a/modules/notify/space_welcome.go
+++ b/modules/notify/space_welcome.go
@@ -31,6 +31,27 @@ import (
 
 const langResolveTimeout = 2 * time.Second
 
+// swBotReadyTimeout caps the (context-less) bot-readiness probe so a hung
+// WuKongIM / DB dependency cannot wedge the single worker goroutine or Stop().
+const swBotReadyTimeout = 5 * time.Second
+
+// callWithTimeout runs fn in a goroutine and returns (result, true) if it
+// completes within d, or (zero, false) on timeout. On timeout the goroutine is
+// left to finish in the background (a bounded leak on a degenerate hung
+// dependency) — the point is that the caller (the worker) is never blocked
+// beyond d, so pre-IM retry / clean Stop always make progress.
+func callWithTimeout[T any](d time.Duration, fn func() T) (T, bool) {
+	ch := make(chan T, 1)
+	go func() { ch <- fn() }()
+	select {
+	case v := <-ch:
+		return v, true
+	case <-time.After(d):
+		var zero T
+		return zero, false
+	}
+}
+
 // spaceWelcomeService owns the reconciler + worker goroutines and the enqueue
 // path. It is constructed once per process by Notify.New and started/stopped via
 // the module Start/Stop hooks.
@@ -274,6 +295,13 @@ func (s *spaceWelcomeService) runWorkerWake(ctx context.Context) {
 		if ctx.Err() != nil {
 			return
 		}
+		// Re-read the config each iteration (a cheap atomic snapshot read) so an
+		// admin disable or Space switch stops NEW claims immediately on this
+		// replica, rather than after the current wake's 20-row budget drains.
+		cur := s.settings.SpaceWelcomeConfig()
+		if !cur.Enabled || cur.SpaceID != cfg.SpaceID {
+			return
+		}
 		claimCtx, cancel := context.WithTimeout(ctx, swDBCallTimeout)
 		row, err := s.store.claimOne(claimCtx, cfg.SpaceID, s.now())
 		cancel()
@@ -343,12 +371,32 @@ func (s *spaceWelcomeService) dispatch(ctx context.Context, cfg common.SpaceWelc
 	}
 
 	// Bot must be ready before we cross into dispatching. Not ready → pre-IM.
-	if s.botReady != nil && !s.botReady() {
-		s.preIMFailure(ctx, row, swErrBotNotReady)
+	// Bounded: ensureNotifyBotReady issues DB + network calls with no context of
+	// its own, so we cap it here — a hung dependency must not wedge the single
+	// worker (nor Stop()). A timeout is treated as bot-not-ready (pre-IM retry).
+	if s.botReady != nil {
+		ready, ok := callWithTimeout(swBotReadyTimeout, s.botReady)
+		if !ok || !ready {
+			s.preIMFailure(ctx, row, swErrBotNotReady)
+			return
+		}
+	}
+
+	// Preflight the IM endpoint BEFORE crossing into dispatching. An unconfigured
+	// APIURL means no HTTP will be sent — that is a definitive pre-IM failure
+	// (retryable once config is fixed), NOT a transport-ambiguous unknown.
+	if s.ctx.GetConfig().WuKongIM.APIURL == "" {
+		s.preIMFailure(ctx, row, swErrConfigRead)
 		return
 	}
 
-	lang := s.resolveLanguage(row.UID)
+	// Language resolution is bounded the same way: the 2s context inside
+	// resolveLanguage may not interrupt a hung cache/DB, so cap the whole call
+	// and fall back to the default language on timeout (never a retryable error).
+	lang, langOK := callWithTimeout(langResolveTimeout+time.Second, func() string { return s.resolveLanguage(row.UID) })
+	if !langOK {
+		lang = i18n.OutboundLanguage(context.Background())
+	}
 
 	dsCtx, cancel := context.WithTimeout(ctx, swDBCallTimeout)
 	ok, err := s.store.casToDispatching(dsCtx, row.ID, lang, s.now())

--- a/modules/notify/space_welcome.go
+++ b/modules/notify/space_welcome.go
@@ -479,14 +479,19 @@ func (s *spaceWelcomeService) preIMFailure(ctx context.Context, row *spaceWelcom
 // toUnknown records a transport-ambiguous outcome (never auto-retried).
 func (s *spaceWelcomeService) toUnknown(ctx context.Context, row *spaceWelcomeRow, class string) {
 	c, cancel := context.WithTimeout(ctx, swDBCallTimeout)
-	_, err := s.store.casToUnknown(c, row.ID, class, s.now())
+	ok, err := s.store.casToUnknown(c, row.ID, class, s.now())
 	cancel()
 	if err != nil {
 		s.Error("welcome cas to unknown failed", zap.Int64("delivery_id", row.ID), zap.String("error_class", class), zap.Error(err))
 		return
 	}
-	s.metrics.incSendUnknown()
-	s.Warn("welcome delivery outcome unknown", zap.String("stage", swStageDispatch), zap.Int64("delivery_id", row.ID), zap.String("error_class", class))
+	// Only count when THIS replica made the transition; ok=false means a peer
+	// sweep already moved the row, so counting here would over-report (mirrors
+	// the CAS-gating in preIMFailure).
+	if ok {
+		s.metrics.incSendUnknown()
+		s.Warn("welcome delivery outcome unknown", zap.String("stage", swStageDispatch), zap.Int64("delivery_id", row.ID), zap.String("error_class", class))
+	}
 }
 
 // ---------------------------------------------------------------------------

--- a/modules/notify/space_welcome_db.go
+++ b/modules/notify/space_welcome_db.go
@@ -1,0 +1,327 @@
+package notify
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/gocraft/dbr/v2"
+)
+
+// spaceWelcomeStore is the DB access layer for the delivery ledger. Every call
+// runs under a caller-supplied context; the service wraps each in swDBCallTimeout.
+//
+// Time discipline: ALL timestamp writes take an application-computed UTC value
+// as a bound parameter (never NOW()), because the DB session TZ is not pinned
+// and the SQL would otherwise mix wall-clock with the UTC active_from.
+type spaceWelcomeStore struct {
+	db         *dbr.Session
+	claimOwner string
+}
+
+func newSpaceWelcomeStore(db *dbr.Session, claimOwner string) *spaceWelcomeStore {
+	return &spaceWelcomeStore{db: db, claimOwner: claimOwner}
+}
+
+// upsertPending inserts a pending row for (spaceID, uid) if absent. Returns
+// inserted=true only when a new row was actually created; a duplicate hit
+// (ON DUPLICATE KEY UPDATE id=id) reports inserted=false so the caller can
+// split enqueue_total vs enqueue_dedup_total. INSERT ... ON DUPLICATE KEY
+// UPDATE (never INSERT IGNORE, which would swallow charset-truncation errors).
+func (s *spaceWelcomeStore) upsertPending(ctx context.Context, spaceID, uid string, now time.Time) (inserted bool, err error) {
+	res, err := s.db.InsertBySql(
+		"INSERT INTO "+spaceWelcomeTable+" (space_id, uid, status, attempts, created_at, updated_at) "+
+			"VALUES (?, ?, ?, 0, ?, ?) ON DUPLICATE KEY UPDATE id = id",
+		spaceID, uid, swStatusPending, now, now,
+	).ExecContext(ctx)
+	if err != nil {
+		return false, fmt.Errorf("upsert pending welcome row: %w", err)
+	}
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return false, fmt.Errorf("read affected rows: %w", err)
+	}
+	// MySQL (default, no CLIENT_FOUND_ROWS): 1 = inserted, 0 = duplicate no-op.
+	return affected > 0, nil
+}
+
+// claimOne atomically claims one due pending row for spaceID via
+// SELECT ... FOR UPDATE SKIP LOCKED + UPDATE inside one transaction. Returns
+// (nil, nil) when no claimable row exists. attempts is deliberately NOT
+// incremented at claim.
+func (s *spaceWelcomeStore) claimOne(ctx context.Context, spaceID string, now time.Time) (*spaceWelcomeRow, error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("begin claim tx: %w", err)
+	}
+	defer tx.RollbackUnlessCommitted()
+
+	var row spaceWelcomeRow
+	err = tx.SelectBySql(
+		"SELECT id, space_id, uid, attempts FROM "+spaceWelcomeTable+" "+
+			"WHERE space_id=? AND status=? AND (next_retry_at IS NULL OR next_retry_at<=?) "+
+			"ORDER BY id LIMIT 1 FOR UPDATE SKIP LOCKED",
+		spaceID, swStatusPending, now,
+	).LoadOneContext(ctx, &row)
+	if err != nil {
+		if errors.Is(err, dbr.ErrNotFound) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("select claimable welcome row: %w", err)
+	}
+
+	if _, err = tx.UpdateBySql(
+		"UPDATE "+spaceWelcomeTable+" SET status=?, claim_owner=?, claim_expire_at=?, updated_at=? WHERE id=?",
+		swStatusClaimed, s.claimOwner, now.Add(swClaimLease), now, row.ID,
+	).ExecContext(ctx); err != nil {
+		return nil, fmt.Errorf("mark welcome row claimed: %w", err)
+	}
+	if err = tx.Commit(); err != nil {
+		return nil, fmt.Errorf("commit claim tx: %w", err)
+	}
+	return &row, nil
+}
+
+// sweepClaimed recycles claimed rows whose lease expired back to pending. Safe
+// because the IM call was not yet started; attempts is not decremented (and was
+// not incremented at claim). next_retry_at is set to now so the row is
+// immediately re-claimable.
+func (s *spaceWelcomeStore) sweepClaimed(ctx context.Context, spaceID string, now time.Time) (int64, error) {
+	res, err := s.db.UpdateBySql(
+		"UPDATE "+spaceWelcomeTable+" SET status=?, next_retry_at=?, claim_owner=NULL, claim_expire_at=NULL, updated_at=? "+
+			"WHERE space_id=? AND status=? AND claim_expire_at IS NOT NULL AND claim_expire_at<=?",
+		swStatusPending, now, now, spaceID, swStatusClaimed, now,
+	).ExecContext(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("sweep claimed welcome rows: %w", err)
+	}
+	return res.RowsAffected()
+}
+
+// sweepDispatching promotes dispatching rows whose lease expired to unknown
+// (we cannot prove whether the IM call happened). Never auto-retried.
+func (s *spaceWelcomeStore) sweepDispatching(ctx context.Context, spaceID string, now time.Time) (int64, error) {
+	res, err := s.db.UpdateBySql(
+		"UPDATE "+spaceWelcomeTable+" SET status=?, error_class=?, updated_at=? "+
+			"WHERE space_id=? AND status=? AND claim_expire_at IS NOT NULL AND claim_expire_at<=?",
+		swStatusUnknown, swErrClaimExpired, now, spaceID, swStatusDispatching, now,
+	).ExecContext(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("sweep dispatching welcome rows: %w", err)
+	}
+	return res.RowsAffected()
+}
+
+// cas runs a CAS UPDATE guarded by id + expected status + claim_owner=self, so a
+// lease-expired sweep on another replica cannot be overwritten by this replica.
+// Returns ok=false when no row matched (ownership lost / status moved on).
+func (s *spaceWelcomeStore) cas(ctx context.Context, query string, args ...interface{}) (bool, error) {
+	res, err := s.db.UpdateBySql(query, args...).ExecContext(ctx)
+	if err != nil {
+		return false, err
+	}
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+	return affected > 0, nil
+}
+
+// casToDispatching transitions claimed -> dispatching, persisting lang and
+// extending the lease.
+func (s *spaceWelcomeStore) casToDispatching(ctx context.Context, id int64, lang string, now time.Time) (bool, error) {
+	ok, err := s.cas(ctx,
+		"UPDATE "+spaceWelcomeTable+" SET status=?, lang=?, claim_expire_at=?, updated_at=? "+
+			"WHERE id=? AND status=? AND claim_owner=?",
+		swStatusDispatching, lang, now.Add(swClaimLease), now, id, swStatusClaimed, s.claimOwner,
+	)
+	if err != nil {
+		return false, fmt.Errorf("cas to dispatching: %w", err)
+	}
+	return ok, nil
+}
+
+// casToSent transitions dispatching -> sent, persisting the IM identifiers.
+func (s *spaceWelcomeStore) casToSent(ctx context.Context, id int64, messageID int64, clientMsgNo string, now time.Time) (bool, error) {
+	ok, err := s.cas(ctx,
+		"UPDATE "+spaceWelcomeTable+" SET status=?, message_id=?, client_msg_no=?, error_class=NULL, updated_at=? "+
+			"WHERE id=? AND status=? AND claim_owner=?",
+		swStatusSent, messageID, clientMsgNo, now, id, swStatusDispatching, s.claimOwner,
+	)
+	if err != nil {
+		return false, fmt.Errorf("cas to sent: %w", err)
+	}
+	return ok, nil
+}
+
+// casToSkipped transitions claimed -> skipped (recipient ineligible at pre-send
+// check). attempts is not consumed. Terminal — never revisited.
+func (s *spaceWelcomeStore) casToSkipped(ctx context.Context, id int64, errClass string, now time.Time) (bool, error) {
+	ok, err := s.cas(ctx,
+		"UPDATE "+spaceWelcomeTable+" SET status=?, error_class=?, claim_owner=NULL, claim_expire_at=NULL, updated_at=? "+
+			"WHERE id=? AND status=? AND claim_owner=?",
+		swStatusSkipped, errClass, now, id, swStatusClaimed, s.claimOwner,
+	)
+	if err != nil {
+		return false, fmt.Errorf("cas to skipped: %w", err)
+	}
+	return ok, nil
+}
+
+// casToUnknown transitions dispatching -> unknown (transport-ambiguous). Never
+// auto-retried.
+func (s *spaceWelcomeStore) casToUnknown(ctx context.Context, id int64, errClass string, now time.Time) (bool, error) {
+	ok, err := s.cas(ctx,
+		"UPDATE "+spaceWelcomeTable+" SET status=?, error_class=?, claim_owner=NULL, claim_expire_at=NULL, updated_at=? "+
+			"WHERE id=? AND status=? AND claim_owner=?",
+		swStatusUnknown, errClass, now, id, swStatusDispatching, s.claimOwner,
+	)
+	if err != nil {
+		return false, fmt.Errorf("cas to unknown: %w", err)
+	}
+	return ok, nil
+}
+
+// casPreIMFailure is the ONLY place attempts grows. A definitive pre-IM failure
+// (observed while status=claimed) either backs the row off to pending
+// (attempts+1, next_retry_at = now + backoff(new_attempts)) or, after the 4th
+// consecutive failure, moves it to terminal failed. CAS guarded by claim_owner.
+func (s *spaceWelcomeStore) casPreIMFailure(ctx context.Context, id int64, attempts int, errClass string, now time.Time) (bool, error) {
+	newAttempts := attempts + 1
+	if newAttempts > swMaxPreIMAttempts {
+		ok, err := s.cas(ctx,
+			"UPDATE "+spaceWelcomeTable+" SET status=?, attempts=?, error_class=?, claim_owner=NULL, claim_expire_at=NULL, updated_at=? "+
+				"WHERE id=? AND status=? AND claim_owner=?",
+			swStatusFailed, newAttempts, errClass, now, id, swStatusClaimed, s.claimOwner,
+		)
+		if err != nil {
+			return false, fmt.Errorf("cas to failed: %w", err)
+		}
+		return ok, nil
+	}
+	nextRetry := now.Add(swBackoff[newAttempts-1])
+	ok, err := s.cas(ctx,
+		"UPDATE "+spaceWelcomeTable+" SET status=?, attempts=?, error_class=?, next_retry_at=?, claim_owner=NULL, claim_expire_at=NULL, updated_at=? "+
+			"WHERE id=? AND status=? AND claim_owner=?",
+		swStatusPending, newAttempts, errClass, nextRetry, now, id, swStatusClaimed, s.claimOwner,
+	)
+	if err != nil {
+		return false, fmt.Errorf("cas pre-IM retry: %w", err)
+	}
+	return ok, nil
+}
+
+// precheckResult is the outcome of the pre-send recipient re-check.
+type precheckResult struct {
+	eligible bool
+	errClass string // set when !eligible: member_left | human_filter | orphan_member
+}
+
+// precheckRecipient re-checks recipient eligibility with a direct DB read
+// (bypassing the module's stale member cache): the user row must exist (not
+// orphan), must not be a robot, must not be a system bot (recipient only), and
+// must still be an active member of the target Space. A DB error is returned to
+// the caller (treated as a definitive pre-IM failure). systemBot membership is
+// scoped strictly to the recipient uid — the sender identity is never touched
+// here.
+func (s *spaceWelcomeStore) precheckRecipient(ctx context.Context, spaceID, uid string, isSystemBot func(string) bool) (precheckResult, error) {
+	if isSystemBot != nil && isSystemBot(uid) {
+		return precheckResult{eligible: false, errClass: swErrHumanFilter}, nil
+	}
+
+	var robot int
+	err := s.db.SelectBySql("SELECT robot FROM `user` WHERE uid=?", uid).LoadOneContext(ctx, &robot)
+	if err != nil {
+		if errors.Is(err, dbr.ErrNotFound) {
+			return precheckResult{eligible: false, errClass: swErrOrphanMember}, nil
+		}
+		return precheckResult{}, fmt.Errorf("precheck user robot: %w", err)
+	}
+	if robot == 1 {
+		return precheckResult{eligible: false, errClass: swErrHumanFilter}, nil
+	}
+
+	var member int
+	err = s.db.SelectBySql(
+		"SELECT COUNT(*) FROM space_member WHERE space_id=? AND uid=? AND status=1",
+		spaceID, uid,
+	).LoadOneContext(ctx, &member)
+	if err != nil {
+		return precheckResult{}, fmt.Errorf("precheck membership: %w", err)
+	}
+	if member == 0 {
+		return precheckResult{eligible: false, errClass: swErrMemberLeft}, nil
+	}
+	return precheckResult{eligible: true}, nil
+}
+
+// firstJoinHumanMember reports whether uid is an active human member of spaceID
+// whose first-ever join (space_member.created_at, never reset on rejoin) is
+// at/after activeFrom. It excludes robots and orphan members (JOIN user). The
+// system-bot exclusion is applied by the caller (recipient-only scope). Used by
+// the low-latency event path to decide whether to enqueue.
+//
+// Time-zone correctness: space_member.created_at is written by NOW() in the DB
+// session wall clock (e.g. +08:00 in this deployment), while activeFrom is a UTC
+// instant. Comparing them directly would be off by the session offset, so we
+// compare epoch-to-epoch: UNIX_TIMESTAMP(created_at) interprets the column in the
+// session TZ and yields a UTC epoch, matched against activeFrom.Unix(). Correct
+// regardless of the DB session TZ or the driver loc setting.
+func (s *spaceWelcomeStore) firstJoinHumanMember(ctx context.Context, spaceID, uid string, activeFrom time.Time) (bool, error) {
+	var n int
+	err := s.db.SelectBySql(
+		"SELECT COUNT(*) FROM space_member sm "+
+			"JOIN `user` u ON u.uid = sm.uid AND u.robot = 0 "+
+			"WHERE sm.space_id = ? AND sm.uid = ? AND sm.status = 1 AND UNIX_TIMESTAMP(sm.created_at) >= ?",
+		spaceID, uid, activeFrom.Unix(),
+	).LoadOneContext(ctx, &n)
+	if err != nil && !errors.Is(err, dbr.ErrNotFound) {
+		return false, fmt.Errorf("enqueue eligibility check: %w", err)
+	}
+	return n > 0, nil
+}
+
+// reconcileScan returns up to `limit` uids that are active human members of
+// spaceID whose first join is at/after activeFrom and that still lack a ledger
+// row. This is the periodic catch-up for dropped events, restarts and the
+// manager addMembers path (which bypasses the SpaceMemberJoin event).
+//
+// The scan JOINs the ledger against space / space_member / user; the ledger's
+// space_id/uid COLLATE matches those columns (utf8mb4_general_ci) so the JOIN
+// cannot hit MySQL 1267.
+//
+// activeFrom (a UTC instant) is compared epoch-to-epoch against
+// space_member.created_at via UNIX_TIMESTAMP — see firstJoinHumanMember for why
+// this is TZ-correct regardless of the DB session zone.
+func (s *spaceWelcomeStore) reconcileScan(ctx context.Context, spaceID string, activeFrom time.Time, systemBots []string, limit int) ([]string, error) {
+	builder := s.db.SelectBySql(
+		"SELECT sm.uid FROM space_member sm "+
+			"JOIN `user` u ON u.uid = sm.uid AND u.robot = 0 "+
+			"LEFT JOIN "+spaceWelcomeTable+" d ON d.space_id = sm.space_id AND d.uid = sm.uid "+
+			"WHERE sm.space_id = ? AND sm.status = 1 AND UNIX_TIMESTAMP(sm.created_at) >= ? AND d.id IS NULL "+
+			"AND sm.uid NOT IN ? "+
+			"ORDER BY sm.created_at, sm.uid LIMIT ?",
+		spaceID, activeFrom.Unix(), systemBots, limit,
+	)
+	var uids []string
+	if _, err := builder.LoadContext(ctx, &uids); err != nil {
+		return nil, fmt.Errorf("reconcile scan: %w", err)
+	}
+	return uids, nil
+}
+
+// spaceActive reports whether spaceID refers to an existing, non-dissolved
+// Space (status=1). Used by the runtime re-validation, bounded by the caller's
+// context.
+func (s *spaceWelcomeStore) spaceActive(ctx context.Context, spaceID string) (bool, error) {
+	if spaceID == "" {
+		return false, nil
+	}
+	var n int
+	err := s.db.SelectBySql("SELECT COUNT(*) FROM space WHERE space_id=? AND status=1", spaceID).LoadOneContext(ctx, &n)
+	if err != nil && !errors.Is(err, dbr.ErrNotFound) {
+		return false, fmt.Errorf("space active check: %w", err)
+	}
+	return n > 0, nil
+}

--- a/modules/notify/space_welcome_db.go
+++ b/modules/notify/space_welcome_db.go
@@ -103,7 +103,7 @@ func (s *spaceWelcomeStore) sweepClaimed(ctx context.Context, spaceID string, no
 // (we cannot prove whether the IM call happened). Never auto-retried.
 func (s *spaceWelcomeStore) sweepDispatching(ctx context.Context, spaceID string, now time.Time) (int64, error) {
 	res, err := s.db.UpdateBySql(
-		"UPDATE "+spaceWelcomeTable+" SET status=?, error_class=?, updated_at=? "+
+		"UPDATE "+spaceWelcomeTable+" SET status=?, error_class=?, claim_owner=NULL, claim_expire_at=NULL, updated_at=? "+
 			"WHERE space_id=? AND status=? AND claim_expire_at IS NOT NULL AND claim_expire_at<=?",
 		swStatusUnknown, swErrClaimExpired, now, spaceID, swStatusDispatching, now,
 	).ExecContext(ctx)
@@ -226,6 +226,11 @@ type precheckResult struct {
 // scoped strictly to the recipient uid — the sender identity is never touched
 // here.
 func (s *spaceWelcomeStore) precheckRecipient(ctx context.Context, spaceID, uid string, isSystemBot func(string) bool) (precheckResult, error) {
+	// System-bot exclusion is the PRIMARY self-DM guard: the sender uid
+	// `notification` lives in pkg/space.SystemBots, so this drops it (and any
+	// other system bot) as a recipient. The robot=1 check below is the backstop
+	// — keep both; weakening the SystemBots map must not silently open a
+	// notification→notification self-DM.
 	if isSystemBot != nil && isSystemBot(uid) {
 		return precheckResult{eligible: false, errClass: swErrHumanFilter}, nil
 	}

--- a/modules/notify/space_welcome_db.go
+++ b/modules/notify/space_welcome_db.go
@@ -325,3 +325,18 @@ func (s *spaceWelcomeStore) spaceActive(ctx context.Context, spaceID string) (bo
 	}
 	return n > 0, nil
 }
+
+// countByStatus returns the number of ledger rows for spaceID in the given
+// status. Used by the drive-loop / disable tests to assert claimed vs pending
+// counts (and available for a future pending_backlog gauge).
+func (s *spaceWelcomeStore) countByStatus(ctx context.Context, spaceID string, status int) (int64, error) {
+	var n int64
+	err := s.db.SelectBySql(
+		"SELECT COUNT(*) FROM "+spaceWelcomeTable+" WHERE space_id=? AND status=?",
+		spaceID, status,
+	).LoadOneContext(ctx, &n)
+	if err != nil && !errors.Is(err, dbr.ErrNotFound) {
+		return 0, err
+	}
+	return n, nil
+}

--- a/modules/notify/space_welcome_integration_test.go
+++ b/modules/notify/space_welcome_integration_test.go
@@ -247,9 +247,10 @@ func TestStore_SweepDispatching_ToUnknown(t *testing.T) {
 	require.NoError(t, err)
 	assert.EqualValues(t, 1, n)
 
-	status, _, errClass, _, _ := swRowStatus(t, ctx, id)
+	status, _, errClass, owner, _ := swRowStatus(t, ctx, id)
 	assert.Equal(t, swStatusUnknown, status)
 	assert.Equal(t, swErrClaimExpired, errClass)
+	assert.Empty(t, owner, "terminal sweep must clear claim_owner (no phantom-leased terminal rows)")
 }
 
 // A not-yet-expired lease must survive the sweep.

--- a/modules/notify/space_welcome_integration_test.go
+++ b/modules/notify/space_welcome_integration_test.go
@@ -2,6 +2,7 @@ package notify
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -604,3 +605,106 @@ func TestService_ReconcileOnce_CatchUp(t *testing.T) {
 }
 
 func ptrTime(t time.Time) *time.Time { return &t }
+
+// ---------------------------------------------------------------------------
+// Review follow-ups: worker drive-loop cap, immediate disable, config-error
+// preflight (P1-2 / P2-4).
+// ---------------------------------------------------------------------------
+
+// TestService_Worker_WakeCap seeds more than the per-wake cap of pending rows
+// and verifies one runWorkerWake claims at most swWorkerWakeCap of them.
+func TestService_Worker_WakeCap(t *testing.T) {
+	ctx := swTestServer(t)
+	settings := common.EnsureSystemSettings(ctx)
+	activeFrom := time.Now().UTC().Add(-time.Hour)
+	swInsertSpace(t, ctx, "spc_1", 1)
+	swSetConfig(t, ctx, settings, swEnabledConfig("spc_1", activeFrom))
+
+	total := swWorkerWakeCap + 5
+	for i := 0; i < total; i++ {
+		uid := fmt.Sprintf("u_%02d", i)
+		swInsertUser(t, ctx, uid, 0)
+		swInsertMember(t, ctx, "spc_1", uid, 1, time.Now().UTC())
+		swInsertLedger(t, ctx, "spc_1", uid, swStatusPending, "", nil, 0)
+	}
+
+	svc := swNewService(ctx, settings)
+	svc.sendFn = func(_ context.Context, _ *config.MsgSendReq) (*swSendResult, error) {
+		return &swSendResult{messageID: 1, clientMsgNo: "x"}, nil
+	}
+	svc.runWorkerWake(bg())
+
+	var sent, pending int64
+	sent, _ = svc.store.countByStatus(bg(), "spc_1", swStatusSent)
+	pending, _ = svc.store.countByStatus(bg(), "spc_1", swStatusPending)
+	assert.EqualValues(t, swWorkerWakeCap, sent, "one wake sends at most the per-wake cap")
+	assert.EqualValues(t, 5, pending, "the remainder stays pending for the next wake")
+}
+
+// TestService_Worker_ImmediateDisableMidDrain flips the config to disabled after
+// the first successful send; the worker must stop claiming the rest of this wake
+// (not drain the full cap). Guards the P1-2 fix.
+func TestService_Worker_ImmediateDisableMidDrain(t *testing.T) {
+	ctx := swTestServer(t)
+	settings := common.EnsureSystemSettings(ctx)
+	activeFrom := time.Now().UTC().Add(-time.Hour)
+	swInsertSpace(t, ctx, "spc_1", 1)
+	swSetConfig(t, ctx, settings, swEnabledConfig("spc_1", activeFrom))
+
+	for i := 0; i < 3; i++ {
+		uid := fmt.Sprintf("u_%02d", i)
+		swInsertUser(t, ctx, uid, 0)
+		swInsertMember(t, ctx, "spc_1", uid, 1, time.Now().UTC())
+		swInsertLedger(t, ctx, "spc_1", uid, swStatusPending, "", nil, 0)
+	}
+
+	svc := swNewService(ctx, settings)
+	svc.sendFn = func(_ context.Context, _ *config.MsgSendReq) (*swSendResult, error) {
+		// Disable the feature right after the first delivery, mimicking an admin
+		// flip mid-wake, and reload the shared snapshot.
+		_, _ = ctx.DB().InsertBySql(
+			"INSERT INTO system_setting (category, key_name, value, value_type, description) VALUES ('onboarding','space_welcome_enabled','0','bool','') " +
+				"ON DUPLICATE KEY UPDATE value='0'").Exec()
+		_ = settings.Reload()
+		return &swSendResult{messageID: 1, clientMsgNo: "x"}, nil
+	}
+	svc.runWorkerWake(bg())
+
+	sent, _ := svc.store.countByStatus(bg(), "spc_1", swStatusSent)
+	pending, _ := svc.store.countByStatus(bg(), "spc_1", swStatusPending)
+	assert.EqualValues(t, 1, sent, "disable mid-wake stops further claims immediately")
+	assert.EqualValues(t, 2, pending, "rows not yet claimed stay pending")
+}
+
+// TestService_Dispatch_EmptyAPIURL_PreIMNotUnknown verifies an unconfigured IM
+// endpoint is a retryable pre-IM failure (attempts+1, back to pending), NOT a
+// terminal unknown. Guards the P2-4 fix.
+func TestService_Dispatch_EmptyAPIURL_PreIMNotUnknown(t *testing.T) {
+	ctx := swTestServer(t)
+	settings := common.EnsureSystemSettings(ctx)
+	activeFrom := time.Now().UTC().Add(-time.Hour)
+	swInsertSpace(t, ctx, "spc_1", 1)
+	swInsertUser(t, ctx, "u_1", 0)
+	swInsertMember(t, ctx, "spc_1", "u_1", 1, time.Now().UTC())
+	swSetConfig(t, ctx, settings, swEnabledConfig("spc_1", activeFrom))
+
+	svc := swNewService(ctx, settings)
+	sendCalled := false
+	svc.sendFn = func(_ context.Context, _ *config.MsgSendReq) (*swSendResult, error) {
+		sendCalled = true
+		return &swSendResult{messageID: 1}, nil
+	}
+	// Blank the IM endpoint and restore afterwards.
+	cfg := ctx.GetConfig()
+	orig := cfg.WuKongIM.APIURL
+	cfg.WuKongIM.APIURL = ""
+	defer func() { cfg.WuKongIM.APIURL = orig }()
+
+	id := swInsertLedger(t, ctx, "spc_1", "u_1", swStatusClaimed, svc.store.claimOwner, ptrTime(time.Now().UTC().Add(time.Minute)), 0)
+	svc.dispatch(bg(), settings.SpaceWelcomeConfig(), &spaceWelcomeRow{ID: id, SpaceID: "spc_1", UID: "u_1"})
+
+	status, attempts, _, _, _ := swRowStatus(t, ctx, id)
+	assert.Equal(t, swStatusPending, status, "config error must be pre-IM retryable, not unknown")
+	assert.Equal(t, 1, attempts, "pre-IM failure increments attempts")
+	assert.False(t, sendCalled, "no HTTP send should be attempted with an empty APIURL")
+}

--- a/modules/notify/space_welcome_integration_test.go
+++ b/modules/notify/space_welcome_integration_test.go
@@ -1,0 +1,606 @@
+package notify
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	"github.com/Mininglamp-OSS/octo-server/modules/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	// Blank imports so NewTestServer runs the migrations for the tables the
+	// welcome ledger JOINs against. notify already pulls space/user/group
+	// transitively; robot owns the `robot` table the space migration JOINs.
+	_ "github.com/Mininglamp-OSS/octo-server/modules/robot"
+)
+
+// ---------------------------------------------------------------------------
+// Test harness
+// ---------------------------------------------------------------------------
+
+func swTestServer(t *testing.T) *config.Context {
+	t.Helper()
+	// modules/common.Route generates + stores an encrypted key at setup; without
+	// a master key it panics. This is imported transitively via our config path.
+	t.Setenv("OCTO_MASTER_KEY", "0123456789abcdef0123456789abcdef")
+	_, ctx := testutil.NewTestServer()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+	t.Cleanup(func() { _ = testutil.CleanAllTables(ctx) })
+	return ctx
+}
+
+func swInsertUser(t *testing.T, ctx *config.Context, uid string, robot int) {
+	t.Helper()
+	// short_no has a UNIQUE index; give each user a distinct value (empty '' would
+	// collide across inserts).
+	_, err := ctx.DB().InsertBySql("INSERT INTO `user` (uid, name, short_no, robot) VALUES (?, ?, ?, ?)", uid, uid, uid, robot).Exec()
+	require.NoError(t, err)
+}
+
+func swInsertSpace(t *testing.T, ctx *config.Context, spaceID string, status int) {
+	t.Helper()
+	_, err := ctx.DB().InsertBySql("INSERT INTO `space` (space_id, name, status) VALUES (?, ?, ?)", spaceID, spaceID, status).Exec()
+	require.NoError(t, err)
+}
+
+func swInsertMember(t *testing.T, ctx *config.Context, spaceID, uid string, status int, createdAt time.Time) {
+	t.Helper()
+	// Store created_at via FROM_UNIXTIME so it lands in the DB session's wall
+	// clock exactly as NOW() would in production, and UNIX_TIMESTAMP round-trips
+	// back to createdAt.Unix() regardless of the test DB's session TZ.
+	_, err := ctx.DB().InsertBySql(
+		"INSERT INTO `space_member` (space_id, uid, role, status, created_at, updated_at) VALUES (?, ?, 0, ?, FROM_UNIXTIME(?), FROM_UNIXTIME(?))",
+		spaceID, uid, status, createdAt.Unix(), createdAt.Unix(),
+	).Exec()
+	require.NoError(t, err)
+}
+
+// swInsertLedger inserts a ledger row directly in a chosen state (for sweep/CAS
+// tests that bypass the claim path).
+func swInsertLedger(t *testing.T, ctx *config.Context, spaceID, uid string, status int, owner string, claimExpire *time.Time, attempts int) int64 {
+	t.Helper()
+	now := time.Now().UTC()
+	res, err := ctx.DB().InsertBySql(
+		"INSERT INTO "+spaceWelcomeTable+" (space_id, uid, status, attempts, claim_owner, claim_expire_at, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+		spaceID, uid, status, attempts, owner, claimExpire, now, now,
+	).Exec()
+	require.NoError(t, err)
+	id, err := res.LastInsertId()
+	require.NoError(t, err)
+	return id
+}
+
+func swRowStatus(t *testing.T, ctx *config.Context, id int64) (status, attempts int, errClass, owner string, messageID int64) {
+	t.Helper()
+	var row struct {
+		Status    int    `db:"status"`
+		Attempts  int    `db:"attempts"`
+		ErrorCl   string `db:"error_class"`
+		Owner     string `db:"claim_owner"`
+		MessageID int64  `db:"message_id"`
+	}
+	err := ctx.DB().SelectBySql(
+		"SELECT status, attempts, COALESCE(error_class,'') AS error_class, COALESCE(claim_owner,'') AS claim_owner, COALESCE(message_id,0) AS message_id FROM "+spaceWelcomeTable+" WHERE id=?",
+		id,
+	).LoadOne(&row)
+	require.NoError(t, err)
+	return row.Status, row.Attempts, row.ErrorCl, row.Owner, row.MessageID
+}
+
+func swCountRows(t *testing.T, ctx *config.Context, spaceID string) int {
+	t.Helper()
+	var n int
+	err := ctx.DB().SelectBySql("SELECT COUNT(*) FROM "+spaceWelcomeTable+" WHERE space_id=?", spaceID).LoadOne(&n)
+	require.NoError(t, err)
+	return n
+}
+
+func bg() context.Context { return context.Background() }
+
+// ---------------------------------------------------------------------------
+// Ledger store: enqueue idempotency & unique constraint
+// ---------------------------------------------------------------------------
+
+func TestStore_UpsertPending_Idempotent(t *testing.T) {
+	ctx := swTestServer(t)
+	store := newSpaceWelcomeStore(ctx.DB(), "owner-1")
+	now := time.Now().UTC()
+
+	inserted, err := store.upsertPending(bg(), "spc_1", "u_1", now)
+	require.NoError(t, err)
+	assert.True(t, inserted, "first upsert must insert")
+
+	inserted, err = store.upsertPending(bg(), "spc_1", "u_1", now)
+	require.NoError(t, err)
+	assert.False(t, inserted, "duplicate upsert must report not-inserted (dedup)")
+
+	assert.Equal(t, 1, swCountRows(t, ctx, "spc_1"), "unique (space_id,uid) must keep exactly one row")
+}
+
+func TestStore_UpsertPending_ConcurrentSingleInsert(t *testing.T) {
+	ctx := swTestServer(t)
+	store := newSpaceWelcomeStore(ctx.DB(), "owner-1")
+	now := time.Now().UTC()
+
+	var wg sync.WaitGroup
+	var insertedCount int32
+	var mu sync.Mutex
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if ins, err := store.upsertPending(bg(), "spc_c", "u_c", now); err == nil && ins {
+				mu.Lock()
+				insertedCount++
+				mu.Unlock()
+			}
+		}()
+	}
+	wg.Wait()
+	assert.EqualValues(t, 1, insertedCount, "exactly one concurrent upsert reports inserted")
+	assert.Equal(t, 1, swCountRows(t, ctx, "spc_c"))
+}
+
+// ---------------------------------------------------------------------------
+// Claim: SELECT ... FOR UPDATE SKIP LOCKED
+// ---------------------------------------------------------------------------
+
+func TestStore_ClaimOne(t *testing.T) {
+	ctx := swTestServer(t)
+	store := newSpaceWelcomeStore(ctx.DB(), "owner-A")
+	now := time.Now().UTC()
+	_, err := store.upsertPending(bg(), "spc_1", "u_1", now)
+	require.NoError(t, err)
+
+	row, err := store.claimOne(bg(), "spc_1", now)
+	require.NoError(t, err)
+	require.NotNil(t, row)
+	assert.Equal(t, "u_1", row.UID)
+
+	status, _, _, owner, _ := swRowStatus(t, ctx, row.ID)
+	assert.Equal(t, swStatusClaimed, status)
+	assert.Equal(t, "owner-A", owner)
+
+	// Nothing left to claim.
+	row2, err := store.claimOne(bg(), "spc_1", now)
+	require.NoError(t, err)
+	assert.Nil(t, row2)
+}
+
+func TestStore_ClaimOne_ConcurrentSingleWinner(t *testing.T) {
+	ctx := swTestServer(t)
+	now := time.Now().UTC()
+	sA := newSpaceWelcomeStore(ctx.DB(), "owner-A")
+	sB := newSpaceWelcomeStore(ctx.DB(), "owner-B")
+	_, err := sA.upsertPending(bg(), "spc_1", "u_1", now)
+	require.NoError(t, err)
+
+	var wins int32
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+	for _, st := range []*spaceWelcomeStore{sA, sB} {
+		wg.Add(1)
+		go func(store *spaceWelcomeStore) {
+			defer wg.Done()
+			if row, err := store.claimOne(bg(), "spc_1", now); err == nil && row != nil {
+				mu.Lock()
+				wins++
+				mu.Unlock()
+			}
+		}(st)
+	}
+	wg.Wait()
+	assert.EqualValues(t, 1, wins, "SKIP LOCKED must let exactly one replica claim the row")
+}
+
+// next_retry_at in the future must not be claimable yet.
+func TestStore_ClaimOne_RespectsNextRetry(t *testing.T) {
+	ctx := swTestServer(t)
+	store := newSpaceWelcomeStore(ctx.DB(), "owner-A")
+	now := time.Now().UTC()
+	id := swInsertLedger(t, ctx, "spc_1", "u_1", swStatusPending, "", nil, 1)
+	_, err := ctx.DB().UpdateBySql("UPDATE "+spaceWelcomeTable+" SET next_retry_at=? WHERE id=?", now.Add(time.Hour), id).Exec()
+	require.NoError(t, err)
+
+	row, err := store.claimOne(bg(), "spc_1", now)
+	require.NoError(t, err)
+	assert.Nil(t, row, "row with next_retry_at in the future is not yet claimable")
+
+	row, err = store.claimOne(bg(), "spc_1", now.Add(2*time.Hour))
+	require.NoError(t, err)
+	assert.NotNil(t, row, "row becomes claimable once next_retry_at has passed")
+}
+
+// ---------------------------------------------------------------------------
+// Sweep
+// ---------------------------------------------------------------------------
+
+func TestStore_SweepClaimed_BackToPending(t *testing.T) {
+	ctx := swTestServer(t)
+	store := newSpaceWelcomeStore(ctx.DB(), "owner-A")
+	now := time.Now().UTC()
+	past := now.Add(-time.Minute)
+	id := swInsertLedger(t, ctx, "spc_1", "u_1", swStatusClaimed, "owner-dead", &past, 2)
+
+	n, err := store.sweepClaimed(bg(), "spc_1", now)
+	require.NoError(t, err)
+	assert.EqualValues(t, 1, n)
+
+	status, attempts, _, _, _ := swRowStatus(t, ctx, id)
+	assert.Equal(t, swStatusPending, status)
+	assert.Equal(t, 2, attempts, "sweep must not consume the retry budget")
+}
+
+func TestStore_SweepDispatching_ToUnknown(t *testing.T) {
+	ctx := swTestServer(t)
+	store := newSpaceWelcomeStore(ctx.DB(), "owner-A")
+	now := time.Now().UTC()
+	past := now.Add(-time.Minute)
+	id := swInsertLedger(t, ctx, "spc_1", "u_1", swStatusDispatching, "owner-dead", &past, 0)
+
+	n, err := store.sweepDispatching(bg(), "spc_1", now)
+	require.NoError(t, err)
+	assert.EqualValues(t, 1, n)
+
+	status, _, errClass, _, _ := swRowStatus(t, ctx, id)
+	assert.Equal(t, swStatusUnknown, status)
+	assert.Equal(t, swErrClaimExpired, errClass)
+}
+
+// A not-yet-expired lease must survive the sweep.
+func TestStore_Sweep_RespectsLease(t *testing.T) {
+	ctx := swTestServer(t)
+	store := newSpaceWelcomeStore(ctx.DB(), "owner-A")
+	now := time.Now().UTC()
+	future := now.Add(time.Minute)
+	id := swInsertLedger(t, ctx, "spc_1", "u_1", swStatusClaimed, "owner-live", &future, 0)
+
+	n, err := store.sweepClaimed(bg(), "spc_1", now)
+	require.NoError(t, err)
+	assert.EqualValues(t, 0, n)
+	status, _, _, _, _ := swRowStatus(t, ctx, id)
+	assert.Equal(t, swStatusClaimed, status)
+}
+
+// ---------------------------------------------------------------------------
+// CAS transitions & cross-owner protection
+// ---------------------------------------------------------------------------
+
+func TestStore_CAS_CrossOwnerBlocked(t *testing.T) {
+	ctx := swTestServer(t)
+	now := time.Now().UTC()
+	future := now.Add(time.Minute)
+	id := swInsertLedger(t, ctx, "spc_1", "u_1", swStatusClaimed, "owner-A", &future, 0)
+
+	// A different replica must not be able to move a row it does not own.
+	sB := newSpaceWelcomeStore(ctx.DB(), "owner-B")
+	ok, err := sB.casToDispatching(bg(), id, "zh-CN", now)
+	require.NoError(t, err)
+	assert.False(t, ok, "cross-owner CAS must not match")
+
+	status, _, _, _, _ := swRowStatus(t, ctx, id)
+	assert.Equal(t, swStatusClaimed, status, "row untouched by non-owner")
+
+	// The true owner succeeds.
+	sA := newSpaceWelcomeStore(ctx.DB(), "owner-A")
+	ok, err = sA.casToDispatching(bg(), id, "zh-CN", now)
+	require.NoError(t, err)
+	assert.True(t, ok)
+}
+
+func TestStore_CasPreIMFailure_BackoffThenFailed(t *testing.T) {
+	ctx := swTestServer(t)
+	store := newSpaceWelcomeStore(ctx.DB(), "owner-A")
+	now := time.Now().UTC()
+
+	// attempts 0->1, 1->2, 2->3 back off to pending; 3->4 fails terminally.
+	for attempt := 0; attempt <= swMaxPreIMAttempts; attempt++ {
+		id := swInsertLedger(t, ctx, "spc_p", "u_p"+string(rune('a'+attempt)), swStatusClaimed, "owner-A", nil, attempt)
+		ok, err := store.casPreIMFailure(bg(), id, attempt, swErrBotNotReady, now)
+		require.NoError(t, err)
+		require.True(t, ok)
+		status, attempts, _, _, _ := swRowStatus(t, ctx, id)
+		assert.Equal(t, attempt+1, attempts, "attempts increments by one")
+		if attempt+1 > swMaxPreIMAttempts {
+			assert.Equal(t, swStatusFailed, status, "4th consecutive pre-IM failure is terminal-failed")
+		} else {
+			assert.Equal(t, swStatusPending, status, "pre-IM failure within budget backs off to pending")
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Pre-send recipient re-check
+// ---------------------------------------------------------------------------
+
+func TestStore_Precheck(t *testing.T) {
+	ctx := swTestServer(t)
+	store := newSpaceWelcomeStore(ctx.DB(), "owner-A")
+	now := time.Now().UTC()
+
+	// eligible human member
+	swInsertUser(t, ctx, "human", 0)
+	swInsertMember(t, ctx, "spc_1", "human", 1, now)
+	// robot member
+	swInsertUser(t, ctx, "bot", 1)
+	swInsertMember(t, ctx, "spc_1", "bot", 1, now)
+	// left member (user exists, no active membership)
+	swInsertUser(t, ctx, "left", 0)
+	// orphan: no user row, but ineligible on user lookup
+
+	cases := []struct {
+		uid      string
+		eligible bool
+		errClass string
+	}{
+		{"human", true, ""},
+		{"bot", false, swErrHumanFilter},
+		{"left", false, swErrMemberLeft},
+		{"orphan", false, swErrOrphanMember},
+		{"notification", false, swErrHumanFilter}, // system bot as recipient
+	}
+	for _, tc := range cases {
+		t.Run(tc.uid, func(t *testing.T) {
+			res, err := store.precheckRecipient(bg(), "spc_1", tc.uid, isSystemBotForTest)
+			require.NoError(t, err)
+			assert.Equal(t, tc.eligible, res.eligible)
+			if !tc.eligible {
+				assert.Equal(t, tc.errClass, res.errClass)
+			}
+		})
+	}
+}
+
+// isSystemBotForTest mirrors pkg/space.IsSystemBot for the recipient-only scope.
+func isSystemBotForTest(uid string) bool { return uid == "notification" }
+
+// ---------------------------------------------------------------------------
+// Reconcile scan & first-join eligibility
+// ---------------------------------------------------------------------------
+
+func TestStore_ReconcileScan(t *testing.T) {
+	ctx := swTestServer(t)
+	store := newSpaceWelcomeStore(ctx.DB(), "owner-A")
+	activeFrom := time.Date(2026, 7, 16, 0, 0, 0, 0, time.UTC)
+	before := activeFrom.Add(-time.Hour)
+	after := activeFrom.Add(time.Hour)
+
+	swInsertSpace(t, ctx, "spc_1", 1)
+	// eligible: human, active, joined after active_from, no ledger row
+	swInsertUser(t, ctx, "new_human", 0)
+	swInsertMember(t, ctx, "spc_1", "new_human", 1, after)
+	// excluded: joined before active_from
+	swInsertUser(t, ctx, "old_human", 0)
+	swInsertMember(t, ctx, "spc_1", "old_human", 1, before)
+	// excluded: robot
+	swInsertUser(t, ctx, "robot1", 1)
+	swInsertMember(t, ctx, "spc_1", "robot1", 1, after)
+	// excluded: already has a ledger row
+	swInsertUser(t, ctx, "done_human", 0)
+	swInsertMember(t, ctx, "spc_1", "done_human", 1, after)
+	_, err := store.upsertPending(bg(), "spc_1", "done_human", time.Now().UTC())
+	require.NoError(t, err)
+	// excluded: left (status=0)
+	swInsertUser(t, ctx, "left_human", 0)
+	swInsertMember(t, ctx, "spc_1", "left_human", 0, after)
+	// excluded: different space
+	swInsertUser(t, ctx, "other_space_human", 0)
+	swInsertMember(t, ctx, "spc_2", "other_space_human", 1, after)
+
+	uids, err := store.reconcileScan(bg(), "spc_1", activeFrom, []string{"notification", "botfather"}, 500)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"new_human"}, uids)
+}
+
+func TestStore_FirstJoinHumanMember_Boundary(t *testing.T) {
+	ctx := swTestServer(t)
+	store := newSpaceWelcomeStore(ctx.DB(), "owner-A")
+	activeFrom := time.Date(2026, 7, 16, 0, 0, 0, 0, time.UTC)
+
+	swInsertUser(t, ctx, "at_boundary", 0)
+	swInsertMember(t, ctx, "spc_1", "at_boundary", 1, activeFrom) // created_at == active_from → included
+	swInsertUser(t, ctx, "before", 0)
+	swInsertMember(t, ctx, "spc_1", "before", 1, activeFrom.Add(-time.Second))
+
+	ok, err := store.firstJoinHumanMember(bg(), "spc_1", "at_boundary", activeFrom)
+	require.NoError(t, err)
+	assert.True(t, ok, "created_at == active_from must be included (>=)")
+
+	ok, err = store.firstJoinHumanMember(bg(), "spc_1", "before", activeFrom)
+	require.NoError(t, err)
+	assert.False(t, ok, "created_at before active_from must be excluded")
+}
+
+// ---------------------------------------------------------------------------
+// Service: dispatch state machine (stubbed sender)
+// ---------------------------------------------------------------------------
+
+func swSetConfig(t *testing.T, ctx *config.Context, settings *common.SystemSettings, kv map[string]string) {
+	t.Helper()
+	for k, v := range kv {
+		vt := "string"
+		if k == "space_welcome_enabled" {
+			vt = "bool"
+		}
+		_, err := ctx.DB().InsertBySql(
+			"INSERT INTO system_setting (category, key_name, value, value_type, description) VALUES ('onboarding', ?, ?, ?, '') "+
+				"ON DUPLICATE KEY UPDATE value=VALUES(value), value_type=VALUES(value_type)",
+			k, v, vt,
+		).Exec()
+		require.NoError(t, err)
+	}
+	require.NoError(t, settings.Load())
+}
+
+func swEnabledConfig(spaceID string, activeFrom time.Time) map[string]string {
+	return map[string]string{
+		"space_welcome_enabled":       "1",
+		"space_welcome_space_id":      spaceID,
+		"space_welcome_active_from":   activeFrom.UTC().Format(time.RFC3339),
+		"space_welcome_message_zh_cn": "欢迎加入本空间",
+		"space_welcome_message_en_us": "Welcome to the space",
+	}
+}
+
+func swNewService(ctx *config.Context, settings *common.SystemSettings) *spaceWelcomeService {
+	svc := newSpaceWelcomeService(ctx, settings, nil, NotifyBotUID(), func() bool { return true })
+	return svc
+}
+
+func TestService_Dispatch_Success(t *testing.T) {
+	ctx := swTestServer(t)
+	settings := common.EnsureSystemSettings(ctx)
+	activeFrom := time.Now().UTC().Add(-time.Hour)
+	swInsertSpace(t, ctx, "spc_1", 1)
+	swInsertUser(t, ctx, "u_1", 0)
+	swInsertMember(t, ctx, "spc_1", "u_1", 1, time.Now().UTC())
+	swSetConfig(t, ctx, settings, swEnabledConfig("spc_1", activeFrom))
+
+	svc := swNewService(ctx, settings)
+	var gotReq *config.MsgSendReq
+	svc.sendFn = func(_ context.Context, req *config.MsgSendReq) (*swSendResult, error) {
+		gotReq = req
+		return &swSendResult{messageID: 999, clientMsgNo: "cmn-1"}, nil
+	}
+
+	id := swInsertLedger(t, ctx, "spc_1", "u_1", swStatusClaimed, svc.store.claimOwner, ptrTime(time.Now().UTC().Add(time.Minute)), 0)
+	svc.dispatch(bg(), settings.SpaceWelcomeConfig(), &spaceWelcomeRow{ID: id, SpaceID: "spc_1", UID: "u_1"})
+
+	status, _, _, _, messageID := swRowStatus(t, ctx, id)
+	assert.Equal(t, swStatusSent, status)
+	assert.EqualValues(t, 999, messageID)
+	assert.EqualValues(t, 1, svc.metrics.sendSuccess.Load())
+	// Wire protocol: from notification, red_dot=1, personal channel.
+	require.NotNil(t, gotReq)
+	assert.Equal(t, "notification", gotReq.FromUID)
+	assert.EqualValues(t, 1, gotReq.Header.RedDot)
+}
+
+func TestService_Dispatch_Unknown(t *testing.T) {
+	ctx := swTestServer(t)
+	settings := common.EnsureSystemSettings(ctx)
+	activeFrom := time.Now().UTC().Add(-time.Hour)
+	swInsertSpace(t, ctx, "spc_1", 1)
+	swInsertUser(t, ctx, "u_1", 0)
+	swInsertMember(t, ctx, "spc_1", "u_1", 1, time.Now().UTC())
+	swSetConfig(t, ctx, settings, swEnabledConfig("spc_1", activeFrom))
+
+	svc := swNewService(ctx, settings)
+	svc.sendFn = func(_ context.Context, _ *config.MsgSendReq) (*swSendResult, error) {
+		return nil, &swSendError{class: swErrIMTimeout}
+	}
+	id := swInsertLedger(t, ctx, "spc_1", "u_1", swStatusClaimed, svc.store.claimOwner, ptrTime(time.Now().UTC().Add(time.Minute)), 0)
+	svc.dispatch(bg(), settings.SpaceWelcomeConfig(), &spaceWelcomeRow{ID: id, SpaceID: "spc_1", UID: "u_1"})
+
+	status, _, errClass, _, _ := swRowStatus(t, ctx, id)
+	assert.Equal(t, swStatusUnknown, status)
+	assert.Equal(t, swErrIMTimeout, errClass)
+	assert.EqualValues(t, 1, svc.metrics.sendUnknown.Load())
+}
+
+func TestService_Dispatch_SkipMemberLeft(t *testing.T) {
+	ctx := swTestServer(t)
+	settings := common.EnsureSystemSettings(ctx)
+	activeFrom := time.Now().UTC().Add(-time.Hour)
+	swInsertSpace(t, ctx, "spc_1", 1)
+	swInsertUser(t, ctx, "u_gone", 0) // user exists but NOT a member
+	swSetConfig(t, ctx, settings, swEnabledConfig("spc_1", activeFrom))
+
+	svc := swNewService(ctx, settings)
+	sendCalled := false
+	svc.sendFn = func(_ context.Context, _ *config.MsgSendReq) (*swSendResult, error) {
+		sendCalled = true
+		return &swSendResult{messageID: 1}, nil
+	}
+	id := swInsertLedger(t, ctx, "spc_1", "u_gone", swStatusClaimed, svc.store.claimOwner, ptrTime(time.Now().UTC().Add(time.Minute)), 0)
+	svc.dispatch(bg(), settings.SpaceWelcomeConfig(), &spaceWelcomeRow{ID: id, SpaceID: "spc_1", UID: "u_gone"})
+
+	status, _, errClass, _, _ := swRowStatus(t, ctx, id)
+	assert.Equal(t, swStatusSkipped, status)
+	assert.Equal(t, swErrMemberLeft, errClass)
+	assert.False(t, sendCalled, "must not deliver to an ineligible recipient")
+	assert.EqualValues(t, 1, svc.metrics.skipNonMember.Load())
+}
+
+// ---------------------------------------------------------------------------
+// Service: event enqueue & disable
+// ---------------------------------------------------------------------------
+
+func TestService_HandleMemberJoin_EnqueueAndDedup(t *testing.T) {
+	ctx := swTestServer(t)
+	settings := common.EnsureSystemSettings(ctx)
+	activeFrom := time.Now().UTC().Add(-time.Hour)
+	swInsertSpace(t, ctx, "spc_1", 1)
+	swInsertUser(t, ctx, "u_1", 0)
+	swInsertMember(t, ctx, "spc_1", "u_1", 1, time.Now().UTC())
+	swSetConfig(t, ctx, settings, swEnabledConfig("spc_1", activeFrom))
+
+	svc := swNewService(ctx, settings)
+	svc.handleMemberJoin("spc_1", "u_1")
+	assert.Equal(t, 1, swCountRows(t, ctx, "spc_1"))
+	assert.EqualValues(t, 1, svc.metrics.enqueueEvent.Load())
+
+	// Replayed event → dedup, no new row.
+	svc.handleMemberJoin("spc_1", "u_1")
+	assert.Equal(t, 1, swCountRows(t, ctx, "spc_1"))
+	assert.EqualValues(t, 1, svc.metrics.enqueueEvent.Load())
+	assert.EqualValues(t, 1, svc.metrics.dedupEvent.Load())
+}
+
+func TestService_HandleMemberJoin_Excludes(t *testing.T) {
+	ctx := swTestServer(t)
+	settings := common.EnsureSystemSettings(ctx)
+	activeFrom := time.Now().UTC()
+	swInsertSpace(t, ctx, "spc_1", 1)
+	swSetConfig(t, ctx, settings, swEnabledConfig("spc_1", activeFrom))
+	svc := swNewService(ctx, settings)
+
+	// robot
+	swInsertUser(t, ctx, "bot", 1)
+	swInsertMember(t, ctx, "spc_1", "bot", 1, activeFrom.Add(time.Minute))
+	// pre-active_from human
+	swInsertUser(t, ctx, "old", 0)
+	swInsertMember(t, ctx, "spc_1", "old", 1, activeFrom.Add(-time.Hour))
+
+	svc.handleMemberJoin("spc_1", "bot")
+	svc.handleMemberJoin("spc_1", "old")
+	svc.handleMemberJoin("spc_2", "someone") // wrong space
+	svc.handleMemberJoin("spc_1", "notification")
+	assert.Equal(t, 0, swCountRows(t, ctx, "spc_1"))
+}
+
+func TestService_HandleMemberJoin_DisabledNoEnqueue(t *testing.T) {
+	ctx := swTestServer(t)
+	settings := common.EnsureSystemSettings(ctx)
+	swInsertSpace(t, ctx, "spc_1", 1)
+	swInsertUser(t, ctx, "u_1", 0)
+	swInsertMember(t, ctx, "spc_1", "u_1", 1, time.Now().UTC())
+	cfg := swEnabledConfig("spc_1", time.Now().UTC().Add(-time.Hour))
+	cfg["space_welcome_enabled"] = "0" // disabled
+	swSetConfig(t, ctx, settings, cfg)
+
+	svc := swNewService(ctx, settings)
+	svc.handleMemberJoin("spc_1", "u_1")
+	assert.Equal(t, 0, swCountRows(t, ctx, "spc_1"), "disabled feature must not enqueue")
+}
+
+func TestService_ReconcileOnce_CatchUp(t *testing.T) {
+	ctx := swTestServer(t)
+	settings := common.EnsureSystemSettings(ctx)
+	activeFrom := time.Now().UTC().Add(-time.Hour)
+	swInsertSpace(t, ctx, "spc_1", 1)
+	swInsertUser(t, ctx, "u_1", 0)
+	swInsertMember(t, ctx, "spc_1", "u_1", 1, time.Now().UTC()) // joined, but event was "lost"
+	swSetConfig(t, ctx, settings, swEnabledConfig("spc_1", activeFrom))
+
+	svc := swNewService(ctx, settings)
+	svc.runReconcileOnce(bg())
+	assert.Equal(t, 1, swCountRows(t, ctx, "spc_1"), "reconciler must catch up a member with no ledger row")
+	assert.EqualValues(t, 1, svc.metrics.enqueueReconciler.Load())
+}
+
+func ptrTime(t time.Time) *time.Time { return &t }

--- a/modules/notify/space_welcome_metrics.go
+++ b/modules/notify/space_welcome_metrics.go
@@ -1,0 +1,97 @@
+package notify
+
+import "sync/atomic"
+
+// space_welcome_metrics.go — lightweight, in-process counters for the space
+// welcome pipeline.
+//
+// Observability is intentionally minimal for this iteration (structured logs
+// are the primary operator signal; Grafana wiring is deferred). These atomic
+// counters are process-local and nil-safe, and are read directly by tests to
+// assert enqueue-vs-dedup and send-outcome behaviour. Promoting them to
+// Prometheus later is a drop-in: add a collector that samples these values.
+type spaceWelcomeMetrics struct {
+	enqueueEvent      atomic.Int64
+	enqueueReconciler atomic.Int64
+	dedupEvent        atomic.Int64
+	dedupReconciler   atomic.Int64
+	sendSuccess       atomic.Int64
+	sendFailed        atomic.Int64
+	sendUnknown       atomic.Int64
+	skipNonMember     atomic.Int64
+	configInvalid     atomic.Int64
+	sweepClaimed      atomic.Int64
+	sweepDispatching  atomic.Int64
+}
+
+func newSpaceWelcomeMetrics() *spaceWelcomeMetrics { return &spaceWelcomeMetrics{} }
+
+// enqueue source labels.
+const (
+	swSourceEvent      = "event"
+	swSourceReconciler = "reconciler"
+)
+
+func (m *spaceWelcomeMetrics) incEnqueue(source string) {
+	if m == nil {
+		return
+	}
+	if source == swSourceReconciler {
+		m.enqueueReconciler.Add(1)
+	} else {
+		m.enqueueEvent.Add(1)
+	}
+}
+
+func (m *spaceWelcomeMetrics) incEnqueueDedup(source string) {
+	if m == nil {
+		return
+	}
+	if source == swSourceReconciler {
+		m.dedupReconciler.Add(1)
+	} else {
+		m.dedupEvent.Add(1)
+	}
+}
+
+func (m *spaceWelcomeMetrics) incSendSuccess() {
+	if m != nil {
+		m.sendSuccess.Add(1)
+	}
+}
+
+func (m *spaceWelcomeMetrics) incSendFailed() {
+	if m != nil {
+		m.sendFailed.Add(1)
+	}
+}
+
+func (m *spaceWelcomeMetrics) incSendUnknown() {
+	if m != nil {
+		m.sendUnknown.Add(1)
+	}
+}
+
+func (m *spaceWelcomeMetrics) incSkipNonMember() {
+	if m != nil {
+		m.skipNonMember.Add(1)
+	}
+}
+
+func (m *spaceWelcomeMetrics) incConfigInvalid() {
+	if m != nil {
+		m.configInvalid.Add(1)
+	}
+}
+
+func (m *spaceWelcomeMetrics) addSweepClaimed(n int64) {
+	if m != nil && n > 0 {
+		m.sweepClaimed.Add(n)
+	}
+}
+
+func (m *spaceWelcomeMetrics) addSweepDispatching(n int64) {
+	if m != nil && n > 0 {
+		m.sweepDispatching.Add(n)
+	}
+}

--- a/modules/notify/space_welcome_model.go
+++ b/modules/notify/space_welcome_model.go
@@ -1,0 +1,87 @@
+package notify
+
+import "time"
+
+// Space new-user welcome delivery ledger — task space-new-user-welcome-message.
+//
+// This file holds the shared constants (status machine, error_class, stage,
+// tunables) for the onboarding welcome feature. The ledger table
+// octo_space_welcome_delivery is the permanent, monotonically-growing dedupe
+// source of truth; send semantics are at-most-once.
+
+const spaceWelcomeTable = "octo_space_welcome_delivery"
+
+// Ledger row status machine. Terminal states: sent / failed / skipped / unknown.
+const (
+	swStatusPending     = 0 // claimable by worker
+	swStatusClaimed     = 1 // worker locked the row; IM call not yet started; sweep => pending
+	swStatusDispatching = 2 // worker began the IM call; sweep => unknown (transport-ambiguous)
+	swStatusSent        = 3 // terminal success
+	swStatusFailed      = 4 // terminal (pre-IM retry budget exhausted)
+	swStatusSkipped     = 5 // terminal (recipient ineligible at pre-send check)
+	swStatusUnknown     = 6 // terminal (transport-ambiguous; operator handles)
+)
+
+// error_class enumeration (structured log field + ledger column).
+const (
+	swErrBotNotReady   = "bot_not_ready"
+	swErrMemberLeft    = "member_left"
+	swErrHumanFilter   = "human_filter"
+	swErrOrphanMember  = "orphan_member"
+	swErrConfigRead    = "config_read"
+	swErrIMTimeout     = "im_timeout"
+	swErrIMBadResponse = "im_bad_response"
+	swErrSentPersist   = "sent_persist"
+	swErrClaimExpired  = "claim_expired"
+)
+
+// stage enumeration (structured log field).
+const (
+	swStageEnqueue  = "enqueue"
+	swStageSweep    = "sweep"
+	swStageClaim    = "claim"
+	swStagePrecheck = "precheck"
+	swStageDispatch = "dispatch"
+	swStagePersist  = "persist"
+)
+
+const (
+	// swDBCallTimeout bounds every DB call the worker issues so precheck + CAS
+	// overhead stays well under the 30s claim lease rather than dangling.
+	swDBCallTimeout = 3 * time.Second
+	// swClaimLease is how long a claimed/dispatching row is leased to one owner
+	// before a peer's sweep may reclaim it. 15s IM timeout < 30s lease, so a hung
+	// request can never outlive the lease.
+	swClaimLease = 30 * time.Second
+	// swReconcileInterval is the reconciler cadence (compile-time constant).
+	swReconcileInterval = 60 * time.Second
+	// swReconcileCap bounds rows enqueued per reconcile cycle.
+	swReconcileCap = 500
+	// swWorkerWakeCap is the per-wake safety valve: after this many successful
+	// claims in one wake the worker falls through to the idle sleep so a single
+	// goroutine cannot monopolise the shared DB session.
+	swWorkerWakeCap = 20
+	// swIdleSleep is the steady-state poll interval when the queue is empty.
+	swIdleSleep = 5 * time.Second
+	// swHTTPTimeout is the notify-local sender's authoritative timeout — the
+	// socket is actually closed on expiry (unlike octo-lib's helper).
+	swHTTPTimeout = 15 * time.Second
+)
+
+// swBackoff is the pre-IM retry backoff for attempts 1/2/3. After the 4th
+// consecutive pre-IM failure the row moves to failed. attempts counts ONLY
+// consecutive pre-IM failures.
+var swBackoff = []time.Duration{5 * time.Second, 30 * time.Second, 120 * time.Second}
+
+// swMaxPreIMAttempts is the number of pre-IM failures tolerated before the row
+// becomes terminal-failed (the 4th failure fails it). Kept in sync with the
+// length of swBackoff.
+const swMaxPreIMAttempts = 3
+
+// spaceWelcomeRow is the minimal claimed-row projection the worker needs.
+type spaceWelcomeRow struct {
+	ID       int64  `db:"id"`
+	SpaceID  string `db:"space_id"`
+	UID      string `db:"uid"`
+	Attempts int    `db:"attempts"`
+}

--- a/modules/notify/space_welcome_sender.go
+++ b/modules/notify/space_welcome_sender.go
@@ -1,0 +1,129 @@
+package notify
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+)
+
+// space_welcome_sender.go — a notify-local, context-aware HTTP sender for the
+// WuKongIM /message/send endpoint.
+//
+// Why not octo-lib's SendMessageWithResult: that helper neither accepts a
+// context nor sets an HTTP client timeout (the underlying sendgrid rest.API
+// uses no timeout), so wrapping it in context.WithTimeout cannot actually
+// interrupt a hung request — the socket lingers. This sender uses
+// http.NewRequestWithContext + a shared http.Client{Timeout: 15s}, so a timeout
+// genuinely closes the socket and unblocks the worker, and 15s < 30s lease
+// guarantees a hung request cannot outlive its claim.
+//
+// octo-lib is NOT modified: we only read exported config accessors and mirror
+// the stable response body parse from config/msg.go.
+
+// swSendResult is the classified outcome of one /message/send call.
+type swSendResult struct {
+	messageID   int64
+	clientMsgNo string
+	messageSeq  uint32
+}
+
+// swSendError is a transport/protocol error classified into an error_class the
+// worker maps to a ledger transition (im_timeout / im_bad_response).
+type swSendError struct {
+	class string
+	err   error
+}
+
+func (e *swSendError) Error() string {
+	if e.err == nil {
+		return e.class
+	}
+	return e.class + ": " + e.err.Error()
+}
+
+func (e *swSendError) Unwrap() error { return e.err }
+
+// spaceWelcomeSender posts personal DM messages to WuKongIM with a hard timeout.
+type spaceWelcomeSender struct {
+	ctx    *config.Context
+	client *http.Client
+}
+
+func newSpaceWelcomeSender(ctx *config.Context) *spaceWelcomeSender {
+	return &spaceWelcomeSender{
+		ctx:    ctx,
+		client: &http.Client{Timeout: swHTTPTimeout},
+	}
+}
+
+// send posts req to <APIURL>/message/send. On 200 OK it parses
+// data.message_id / data.client_msg_no / data.message_seq (mirroring
+// config/msg.go). Any non-200, transport error, or unparseable body is returned
+// as a *swSendError classified for the worker's unknown-vs-retry decision.
+func (s *spaceWelcomeSender) send(ctx context.Context, req *config.MsgSendReq) (*swSendResult, error) {
+	cfg := s.ctx.GetConfig()
+	apiURL := cfg.WuKongIM.APIURL
+	if apiURL == "" {
+		return nil, &swSendError{class: swErrIMBadResponse, err: errors.New("WuKongIM APIURL not configured")}
+	}
+
+	body, err := json.Marshal(req)
+	if err != nil {
+		return nil, &swSendError{class: swErrIMBadResponse, err: fmt.Errorf("marshal send req: %w", err)}
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, apiURL+"/message/send", bytes.NewReader(body))
+	if err != nil {
+		return nil, &swSendError{class: swErrIMBadResponse, err: fmt.Errorf("build send request: %w", err)}
+	}
+	// Content-Type must be set explicitly in addition to the manager token —
+	// the token header map only carries {"token": ...}.
+	httpReq.Header.Set("Content-Type", "application/json")
+	for k, v := range cfg.WuKongIMManagerTokenHeaderMap() {
+		httpReq.Header.Set(k, v)
+	}
+
+	resp, err := s.client.Do(httpReq)
+	if err != nil {
+		// Timeout / connection reset / DNS — transport-ambiguous.
+		return nil, &swSendError{class: swErrIMTimeout, err: err}
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
+	if err != nil {
+		return nil, &swSendError{class: swErrIMTimeout, err: fmt.Errorf("read send response: %w", err)}
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, &swSendError{class: swErrIMBadResponse, err: fmt.Errorf("IM /message/send status %d", resp.StatusCode)}
+	}
+
+	// Parse the stable response shape { "data": { message_id, client_msg_no,
+	// message_seq } } — same fields octo-lib's config/msg.go reads.
+	var parsed struct {
+		Data struct {
+			MessageID   int64  `json:"message_id"`
+			ClientMsgNo string `json:"client_msg_no"`
+			MessageSeq  uint32 `json:"message_seq"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(respBody, &parsed); err != nil {
+		return nil, &swSendError{class: swErrIMBadResponse, err: fmt.Errorf("decode send response: %w", err)}
+	}
+	if parsed.Data.MessageID == 0 && parsed.Data.ClientMsgNo == "" {
+		// Empty/degenerate body on a 200 — treat as transport-ambiguous rather
+		// than a confirmed success (we cannot prove the message persisted).
+		return nil, &swSendError{class: swErrIMBadResponse, err: errors.New("empty message_id/client_msg_no in 200 response")}
+	}
+	return &swSendResult{
+		messageID:   parsed.Data.MessageID,
+		clientMsgNo: parsed.Data.ClientMsgNo,
+		messageSeq:  parsed.Data.MessageSeq,
+	}, nil
+}

--- a/modules/notify/space_welcome_unit_test.go
+++ b/modules/notify/space_welcome_unit_test.go
@@ -1,0 +1,124 @@
+package notify
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-server/modules/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newSenderTestContext(apiURL string) *config.Context {
+	cfg := config.New()
+	cfg.Test = true
+	cfg.WuKongIM.APIURL = apiURL
+	cfg.WuKongIM.ManagerToken = "mgr-token-xyz"
+	cfg.EventPoolSize = 1
+	cfg.Push.PushPoolSize = 1
+	cfg.Robot.EventPoolSize = 1
+	return config.NewContext(cfg)
+}
+
+func TestSpaceWelcomeSender_SetsHeadersAndParsesResult(t *testing.T) {
+	var gotContentType, gotToken, gotPath string
+	var gotBody map[string]interface{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotContentType = r.Header.Get("Content-Type")
+		gotToken = r.Header.Get("token")
+		gotPath = r.URL.Path
+		raw, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(raw, &gotBody)
+		_, _ = w.Write([]byte(`{"data":{"message_id":123456,"client_msg_no":"cmn-9","message_seq":7}}`))
+	}))
+	defer srv.Close()
+
+	sender := newSpaceWelcomeSender(newSenderTestContext(srv.URL))
+	payload := map[string]interface{}{"type": 1, "content": "hi"}
+	req := config.NewPersonalMsgSendReq("u_1", "notification", payload, "spc_1",
+		config.PersonalMsgOptions{Header: config.MsgHeader{RedDot: 1}})
+
+	res, err := sender.send(context.Background(), req)
+	require.NoError(t, err)
+	assert.Equal(t, int64(123456), res.messageID)
+	assert.Equal(t, "cmn-9", res.clientMsgNo)
+	assert.Equal(t, uint32(7), res.messageSeq)
+
+	// Content-Type must be set explicitly in addition to the token header.
+	assert.Equal(t, "application/json", gotContentType)
+	assert.Equal(t, "mgr-token-xyz", gotToken)
+	assert.Equal(t, "/message/send", gotPath)
+	// Authoritative wire protocol on the outbound request.
+	assert.Equal(t, "notification", gotBody["from_uid"])
+	assert.EqualValues(t, 1, gotBody["channel_type"]) // ChannelTypePerson
+}
+
+func TestSpaceWelcomeSender_Non200IsBadResponse(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`boom`))
+	}))
+	defer srv.Close()
+	sender := newSpaceWelcomeSender(newSenderTestContext(srv.URL))
+	req := config.NewPersonalMsgSendReq("u_1", "notification", map[string]interface{}{"type": 1, "content": "x"}, "spc_1", config.PersonalMsgOptions{})
+	_, err := sender.send(context.Background(), req)
+	require.Error(t, err)
+	var se *swSendError
+	require.ErrorAs(t, err, &se)
+	assert.Equal(t, swErrIMBadResponse, se.class)
+}
+
+func TestSpaceWelcomeSender_Empty200IsBadResponse(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{}}`))
+	}))
+	defer srv.Close()
+	sender := newSpaceWelcomeSender(newSenderTestContext(srv.URL))
+	req := config.NewPersonalMsgSendReq("u_1", "notification", map[string]interface{}{"type": 1, "content": "x"}, "spc_1", config.PersonalMsgOptions{})
+	_, err := sender.send(context.Background(), req)
+	require.Error(t, err)
+	var se *swSendError
+	require.ErrorAs(t, err, &se)
+	assert.Equal(t, swErrIMBadResponse, se.class)
+}
+
+func TestSpaceWelcomeSender_ContextTimeoutIsTransportAmbiguous(t *testing.T) {
+	block := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-block // hang until the test releases
+	}))
+	defer srv.Close()
+	defer close(block)
+
+	sender := newSpaceWelcomeSender(newSenderTestContext(srv.URL))
+	req := config.NewPersonalMsgSendReq("u_1", "notification", map[string]interface{}{"type": 1, "content": "x"}, "spc_1", config.PersonalMsgOptions{})
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	_, err := sender.send(ctx, req)
+	require.Error(t, err)
+	var se *swSendError
+	require.ErrorAs(t, err, &se)
+	assert.Equal(t, swErrIMTimeout, se.class, "a timeout must classify as transport-ambiguous")
+}
+
+func TestMessageForLang(t *testing.T) {
+	svc := &spaceWelcomeService{}
+	cfg := common.SpaceWelcomeConfig{MessageZhCN: "中文", MessageEnUS: "english"}
+	assert.Equal(t, "中文", svc.messageForLang(cfg, "zh-CN"))
+	assert.Equal(t, "中文", svc.messageForLang(cfg, "zh-Hans"))
+	assert.Equal(t, "english", svc.messageForLang(cfg, "en-US"))
+	assert.Equal(t, "english", svc.messageForLang(cfg, ""))
+	assert.Equal(t, "english", svc.messageForLang(cfg, "fr-FR"))
+}
+
+func TestClaimOwnerID(t *testing.T) {
+	owner := claimOwnerID()
+	assert.Contains(t, owner, ":", "owner must be <hostname>:<pid>")
+	assert.NotEqual(t, ":", owner)
+}

--- a/modules/notify/space_welcome_unit_test.go
+++ b/modules/notify/space_welcome_unit_test.go
@@ -122,3 +122,27 @@ func TestClaimOwnerID(t *testing.T) {
 	assert.Contains(t, owner, ":", "owner must be <hostname>:<pid>")
 	assert.NotEqual(t, ":", owner)
 }
+
+func TestResolveLanguage_FallbackWhenNoService(t *testing.T) {
+	// langSvc == nil (no cache in this env) must fall back to the default
+	// outbound language, never empty, never an error/retry.
+	svc := &spaceWelcomeService{}
+	lang := svc.resolveLanguage("u_1")
+	assert.NotEmpty(t, lang, "must fall back to OCTO_DEFAULT_LANGUAGE, never empty")
+}
+
+func TestCallWithTimeout(t *testing.T) {
+	// Completes within the deadline → (value, true).
+	v, ok := callWithTimeout(time.Second, func() int { return 42 })
+	assert.True(t, ok)
+	assert.Equal(t, 42, v)
+
+	// Exceeds the deadline → (zero, false); the caller is unblocked promptly.
+	start := time.Now()
+	_, ok = callWithTimeout(50*time.Millisecond, func() string {
+		time.Sleep(500 * time.Millisecond)
+		return "late"
+	})
+	assert.False(t, ok, "a hung call must time out")
+	assert.Less(t, time.Since(start), 300*time.Millisecond, "caller must not block for the full call")
+}

--- a/modules/notify/sql/20260716000001_add_octo_space_welcome_delivery.sql
+++ b/modules/notify/sql/20260716000001_add_octo_space_welcome_delivery.sql
@@ -1,0 +1,30 @@
+-- +migrate Up
+
+-- Space 新成员欢迎语的投递账本（at-most-once）。
+-- 唯一去重真源：一个 (space_id, uid) 至多一行、至多投递一次。
+-- 时间纪律：本表所有时间列均为应用侧写入的 UTC 值（time.Now().UTC() 作为 bound
+-- 参数），禁止使用 NOW()——DB 会话时区未在 DSN 固定，NOW() 会把服务器墙钟与
+-- active_from(RFC3339 UTC) 混用。因此不给任何时间列设 DEFAULT CURRENT_TIMESTAMP。
+-- COLLATE 显式对齐 space / space_member / user 的 JOIN 键（utf8mb4_general_ci），
+-- 避免对账 JOIN 触发 MySQL 1267（见 issue_344 collation 混排事故）。
+CREATE TABLE `octo_space_welcome_delivery` (
+  `id`              BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+  `space_id`        VARCHAR(40)  NOT NULL DEFAULT ''         COMMENT '目标 Space（长度/字符集/COLLATE 对齐 space.space_id）',
+  `uid`             VARCHAR(40)  NOT NULL DEFAULT ''         COMMENT '收件人 UID（对齐 user.uid / space_member.uid）',
+  `status`          TINYINT      NOT NULL DEFAULT 0          COMMENT '0=pending 1=claimed 2=dispatching 3=sent 4=failed 5=skipped 6=unknown',
+  `attempts`        INT          NOT NULL DEFAULT 0          COMMENT '仅统计连续 pre-IM 失败次数；claim/sweep/precheck-skip/sent/unknown 均不消耗',
+  `next_retry_at`   DATETIME     NULL                        COMMENT 'UTC；应用侧写入，禁 NOW()；下一次可被 claim 的时间',
+  `lang`            VARCHAR(16)  NULL                        COMMENT '发送时解析出的收件人语言（zh-CN/en-US）',
+  `message_id`      BIGINT       NULL                        COMMENT 'IM 返回的 message_id（成功时）',
+  `client_msg_no`   VARCHAR(100) NULL                        COMMENT 'IM 返回的 client_msg_no（对齐 message 表宽度）',
+  `claim_owner`     VARCHAR(128) NULL                        COMMENT '<hostname>:<pid>；每次 claim 后 update 的 CAS 断言',
+  `claim_expire_at` DATETIME     NULL                        COMMENT 'UTC；应用侧写入；claim 租约到期时间',
+  `error_class`     VARCHAR(64)  NULL                        COMMENT '错误分类：bot_not_ready/member_left/human_filter/orphan_member/config_read/im_timeout/im_bad_response/sent_persist/claim_expired',
+  `created_at`      DATETIME     NOT NULL                    COMMENT 'UTC；应用侧写入，禁 NOW()',
+  `updated_at`      DATETIME     NOT NULL                    COMMENT 'UTC；应用侧写入，禁 NOW()',
+  UNIQUE KEY `uk_space_uid` (`space_id`, `uid`),
+  KEY `idx_claim` (`space_id`, `status`, `next_retry_at`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci COMMENT='onboarding space welcome delivery ledger';
+
+-- +migrate Down
+DROP TABLE IF EXISTS `octo_space_welcome_delivery`;

--- a/pkg/errcode/common.go
+++ b/pkg/errcode/common.go
@@ -1,0 +1,23 @@
+package errcode
+
+import (
+	"net/http"
+
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n/codes"
+)
+
+var (
+	// ErrSpaceWelcomeConfigInvalid is returned by the manager system_setting
+	// write path when the onboarding space-welcome five-tuple does not form a
+	// valid *enabled* combination — a missing/dissolved target Space, an
+	// unparseable RFC3339 active_from, or a message body that is empty (after
+	// trim) or exceeds the code-point limit. The `field` detail names the first
+	// offending key so the admin UI can point at it; the specific reason stays
+	// generic on the wire (log carries the rest).
+	ErrSpaceWelcomeConfigInvalid = register(codes.Code{
+		ID:             "err.server.common.space_welcome_config_invalid",
+		HTTPStatus:     http.StatusBadRequest,
+		DefaultMessage: "Invalid space welcome configuration.",
+		SafeDetailKeys: []string{"field"},
+	})
+)

--- a/pkg/i18n/locales/active.zh-CN.toml
+++ b/pkg/i18n/locales/active.zh-CN.toml
@@ -42,6 +42,9 @@ other = "服务器内部错误。"
 ["err.server.notify.card_not_allowed"]
 other = "内部通知接口不允许发送卡片消息。"
 
+["err.server.common.space_welcome_config_invalid"]
+other = "空间欢迎语配置无效，请检查目标空间是否存在且未解散、生效时间格式，以及中英文文案是否非空且未超长。"
+
 ["err.server.notify.card_invalid"]
 other = "卡片通知请求无效。"
 

--- a/tools/i18nmarkers/server/active.en-US.toml
+++ b/tools/i18nmarkers/server/active.en-US.toml
@@ -294,6 +294,9 @@ other = "The group and the category are not in the same space."
 ["err.server.category.store_failed"]
 other = "Failed to update category data."
 
+["err.server.common.space_welcome_config_invalid"]
+other = "Invalid space welcome configuration."
+
 ["err.server.group.already_member"]
 other = "You are already a member of this group."
 


### PR DESCRIPTION
## Summary

Deliver **one** configurable welcome DM from the built-in `notification` bot
("通知助手") when a **human** user first joins an admin-designated Space. Minimal
implementation of the main chain "first-join human → exactly one ledger row →
member re-check before send". Send semantics are **at-most-once**;
transport-ambiguous outcomes are recorded as `unknown` and never auto-retried.

Ships with the feature `enabled=false` (no behaviour change on deploy).

## Related Issue

N/A (self-originated task).

## Linked Spec

`.octospec/tasks/space-new-user-welcome-message/brief.md`

## Changes

- **Ledger**: new `octo_space_welcome_delivery` table (migration in
  `modules/notify/sql/`); wired `//go:embed sql` + `SQLDir` into
  `notify/1module.go` (it had none before, so the migration now runs).
- **Config**: five `system_setting` keys under `onboarding`; `modules/common`
  gains an atomic `SpaceWelcomeConfig()` snapshot accessor + prospective
  composite validation on the manager write path; i18n code
  `err.server.common.space_welcome_config_invalid` via `httperr`.
- **notify service**: event enqueue (extends the `SpaceMemberJoin` listener,
  never blocks/rolls back the join), a 60s reconciler (dropped events /
  restarts / manager `addMembers`), and a send worker (idle 5s / drain /
  per-wake cap 20). Claim via `SELECT ... FOR UPDATE SKIP LOCKED`; every
  post-claim UPDATE is a CAS guarded by `status + claim_owner`. `attempts`
  grows only on a definitive pre-IM failure (backoff 5s/30s/120s, 4th → failed);
  any failure after the dispatching transition → `unknown`.
- **Sender**: notify-local context-aware HTTP sender (`http.Client{Timeout:15s}`
  + `NewRequestWithContext`, explicit `Content-Type` + manager token). octo-lib
  is unmodified; 15s < 30s lease.
- **Time**: `active_from` vs `space_member.created_at` compared via
  `UNIX_TIMESTAMP` epoch (mirrors `modules/opanalytics`), correct for the
  deployment-local DB session zone.
- Observability kept minimal (in-process counters + structured logs).

## Testing

- `go build ./...`, `go vet`, `make i18n-extract-check`, `make i18n-lint`,
  `git diff --check` — all clean.
- `go test -race` green for `modules/notify`, `modules/common`, `modules/space`
  (each on a fresh test DB).
- Integration coverage: enqueue idempotency + concurrent single-insert; claim
  SKIP LOCKED single-winner; sweep claimed→pending / dispatching→unknown;
  cross-owner CAS blocked; pre-IM backoff→failed; precheck (member_left / robot
  / orphan / recipient system-bot); reconcile catch-up; active_from boundary;
  dispatch success/unknown/skip; event enqueue/dedup/exclusions/disabled.

- [x] Unit tests added/updated
- [x] Manually verified (via integration tests against real MySQL)

## COMPREHENSION

1. **What does this change actually do to the load-bearing path?**
   It adds a new outbound side-effect gated on Space membership. The trigger
   reads `space_member` (`space_id`, `status=1`, first-join `created_at ≥
   active_from`) and re-checks membership with a direct DB read (bypassing the
   stale member cache) immediately before send. Every ledger query is scoped by
   `space_id = current` and the recipient is filtered for robot / system-bot /
   orphan, so it can never deliver cross-Space or to a non-member. It touches
   the error-response wire contract only by adding one new i18n code through
   `httperr` (no raw responses; lint enforced).

2. **What could break because of it (dependents + failure mode)?**
   The `SpaceMemberJoin` listener now also enqueues; enqueue failure is logged
   and dropped, never rolling back or blocking the completed join. Two new
   per-process goroutines (reconciler + worker) start via the module
   `Start()`/`Stop()` hooks. Worst cases: a config the admin wrote directly to
   the DB fails closed at runtime (`config_invalid` + no send); a
   transport-ambiguous IM call yields a `skipped`/`unknown` row an operator
   inspects via SQL. Multiple replicas race safely via `FOR UPDATE SKIP LOCKED`
   + CAS on `claim_owner`; no leader election. Feature ships `enabled=false`.

3. **How do you know it works (specific test/repro/trace)?**
   `go test -race ./modules/notify/...` exercises the full state machine against
   real MySQL: unique-constraint dedup, concurrent single-winner claim, sweep
   transitions, cross-owner CAS block, bounded pre-IM retry, the four precheck
   exclusions (including `notification` as sender NOT filtered), reconcile
   catch-up, the `active_from` boundary, and dispatch success/unknown/skip with
   a stubbed sender. `modules/common` tests cover snapshot atomicity under
   concurrent reload and prospective validation in both directions.

## Checklist

- [x] PR description is in English
- [x] Added tests for my changes
- [x] Followed commit message conventions (Conventional Commits)
