### PR TITLE
feat(cardtmpl): enrich docs access-request approval card + deny-reason channel

### DIFF
--- a/.octospec/journal/shared/docs-approval-card-enrich.md
+++ b/.octospec/journal/shared/docs-approval-card-enrich.md
@@ -1,0 +1,88 @@
+---
+type: Journal
+title: "docs-approval-card-enrich: richer docs access-request card + reviewer deny-reason flow"
+description: Enrich the docs access-request approval card (header/status, big title, requester row, reason box) across pending + terminal states, and add a reviewer deny-reason dialog whose value rides the existing declared-input channel to the docs backend.
+tags: [cardtmpl, notify, docs-approval, card-message, i18n, trust-boundary, wire-contract, testing]
+timestamp: 2026-07-17T00:00:00Z
+slug: docs-approval-card-enrich
+---
+
+# docs-approval-card-enrich
+
+Branch `claude/docs-permission-card-template-bccd8h` (octo-server + octo-web).
+Brings the 通知助手 「文档申请权限」 card closer to the approved prototype and adds a
+reviewer deny-reason capture flow.
+
+## What was done
+
+### octo-server
+1. **Enriched pending card** — rewrote `pkg/cardtmpl/docs_action.go`
+   `BuildDocsAccessRequestCard` to emit a structured AC 1.5 body via
+   `DocsApprovalContent`: header row (source label + colored status), big title
+   (`separator`), a bold-actor banner (`RichTextBlock`), a requester
+   `ColumnSet` (optional Person avatar + name/role + timestamp), an
+   `emphasis` reason box, and a **hidden `Input.Text id="deny_reason"`**. All
+   caller strings run through `escapeMarkdown`; the avatar goes through
+   `requireHTTPS`. Primary sentences sized `Medium` (14px), labels/meta `Small`
+   (12px), title `ExtraLarge` → a 20/14/12 hierarchy.
+2. **Terminal card** — new `BuildDocsApprovalOutcomeCard` (header + title +
+   good/attention result box; denied box surfaces the reviewer reason).
+   `modules/notify/action_finalizer.go` `buildTerminalDocument` uses it for
+   approved/denied and threads `event.Inputs["deny_reason"]`; cancelled/
+   unavailable keep the plain rebuild. view-details is a **body ActionSet**, not
+   a root action, so the terminal card carries no decision buttons (preserves the
+   existing "terminal removes approval actions" invariant).
+3. **Contract + labels** — additive optional `DocsCardFields.ActorAvatarURL`
+   (https, docs-backend owned); new zh-CN/en-US `docsLabels`
+   (header/status/banner/role/reason/result copy). deny action `data` carries
+   `doc_title`/`actor` as local display context for the web dialog.
+4. `scripts/cardpreview` emits the three new states for offline SDK preview.
+
+### octo-web
+5. **Deny dialog** — `denyReasonDialog.tsx`: `InteractiveCardCell.handleSubmit`
+   intercepts the docs deny action (matched by `data.owner/action_type/decision`),
+   opens a `wkConfirm` danger modal with a required reason (≤200), then
+   `performSubmit` merges `inputs[deny_reason]`. Approve/other paths unchanged.
+   i18n keys + dialog CSS added.
+
+## Why it works end-to-end
+
+The deny reason must ride under a **declared** input id — the card/action
+endpoint fail-closes on undeclared inputs (`pkg/cardmsg.ValidateInputs`). The
+hidden `deny_reason` input declares it; the web dialog fills `inputs.deny_reason`;
+it flows `Event.Inputs → DecisionRequest.Inputs` (signed POST) to the docs
+backend **for free**, and the finalizer reads the same value onto the denied
+terminal card.
+
+Both the server (`pkg/cardmsg/validate.go`) and client
+(`validateCardForOcto.ts`) card whitelists are type/structure gates that are
+lenient on presentation props, so all enrichment (`Container.style`, `color`,
+`size`, nested `ColumnSet`, `Image.style=Person`) passes; **images must be
+absolute https** on both sides (data:/http: stripped), which is why the avatar is
+a validated https field, not a data URI.
+
+## Verification
+- `go test ./pkg/cardtmpl/... ./modules/notify/{card,finalizer}` (new tests:
+  enriched layout + declared deny_reason input + https-only avatar + markdown
+  escaping + terminal approved/denied + reason threading); golangci-lint 0
+  issues; gofmt/vet clean; `make i18n-extract-check` + `make i18n-lint` pass;
+  full `go build ./...` + card-dispatch lint pass.
+- octo-web: 221 InteractiveCard vitest pass incl. new `denyReasonDialog` suite.
+- Faithful render preview via real `adaptivecards@3.0.6` SDK + octo HostConfig
+  (cardpreview JSON → headless Chromium).
+
+## Out of scope / follow-ups
+- docs-backend owns `actor_avatar_url` population and `DecisionRequest`
+  reason consumption.
+- Terminal card shows header + title + result box only (finalizer lacks
+  actor/timestamp); a fuller terminal requires docs-backend echoing them.
+- Pill-shaped status badge + right-aligned footer/meta line would need a
+  per-variant client renderer / HostConfig change (status is colored text this
+  round).
+
+## Learning
+When a card needs a free-text value on submit, the value MUST be declared as an
+`Input.*` id in the server-authored frame even if the UI collects it in a custom
+modal — `ValidateInputs` drops undeclared keys fail-closed. A hidden
+`Input.Text` is the minimal declaration; the frontend can then own the capture UX
+and just populate `inputs[<id>]`.

--- a/.octospec/log.md
+++ b/.octospec/log.md
@@ -4,6 +4,16 @@ Change history for this repo's `.octospec/`, following the
 [OKF](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md)
 change-log convention (§7). Newest first.
 
+## 2026-07-17 (docs-approval-card-enrich)
+
+- **Feature** — Enriched the docs access-request approval card (header + colored
+  status, big title, requester row with optional avatar, boxed reason) across
+  pending + terminal states, and added a reviewer deny-reason dialog whose value
+  rides a declared hidden `deny_reason` input through
+  `DecisionRequest.Inputs` to the docs backend. Additive optional
+  `DocsCardFields.actor_avatar_url` (https-validated). Cross-repo (octo-web deny
+  dialog). See [journal](journal/shared/docs-approval-card-enrich.md).
+
 ## 2026-07-16 (space-new-user-welcome-message)
 
 - **Feature** — At-most-once Space welcome DM from the `notification` bot on a

--- a/.octospec/tasks/docs-approval-card-enrich/brief.md
+++ b/.octospec/tasks/docs-approval-card-enrich/brief.md
@@ -1,0 +1,96 @@
+---
+type: Task
+title: "Task: docs-approval-card-enrich"
+description: Enrich the docs access-request approval card layout + add a deny-reason capture flow
+tags: [cardtmpl, notify, docs-approval, card-message]
+timestamp: 2026-07-17T00:00:00Z
+# --- octospec extension fields ---
+slug: docs-approval-card-enrich
+upstream: self
+source: self
+---
+
+# Task: docs-approval-card-enrich
+
+## Goal
+Bring the docs "access request" approval card (通知助手 → 文档申请权限卡) closer to the
+approved prototype, and add a reviewer **deny-reason** capture flow:
+
+1. **Pending card (待处理)** — richer AC layout: a header line (`文档申请 · <space/doc
+   scope>` + a status label), a large document title, a requester row (optional
+   avatar + name + role + timestamp), a boxed "申请原因" section, and the
+   existing `查看详情 / 拒绝 / 允许` actions.
+2. **Deny reason** — clicking 拒绝 opens a dialog (frontend) to collect a required
+   reason; the reason rides to the docs backend via the existing
+   `DecisionRequest.Inputs` channel under a **declared** `Input.Text` id.
+3. **Terminal card (已允许 / 已拒绝)** — the finalizer rebuild gets the same header
+   style + a result box; the denied state surfaces the reviewer's reason.
+
+## Background
+- Card is built server-side as an AdaptiveCard 1.5 doc, rendered client-side by
+  the official `adaptivecards` SDK under a custom octo HostConfig.
+- Pending card: `pkg/cardtmpl/docs_action.go` `BuildDocsAccessRequestCard` (today
+  reuses the plain `BuildDocsResourceCard` body). Producer:
+  `modules/notify/card.go` `buildDocsAccessRequestCard` (ProfileV2, feature flag
+  `OCTO_DOCS_APPROVAL_CARD_ENABLED`).
+- Terminal card: `modules/notify/action_finalizer.go`
+  `DocsActionFinalizer.buildTerminalDocument` (only has `title + state`; ignores
+  `event.Inputs`).
+- Deny reason channel: submit `inputs` are validated against **declared** card
+  `Input.*` ids (`pkg/cardmsg/inputs.go` `ValidateInputs`), flow into
+  `cardactiondispatch.Event.Inputs` → `DecisionRequest.Inputs` (HMAC-signed POST
+  to docs backend). No reason field otherwise exists.
+- Both server (`pkg/cardmsg/validate.go`) and client
+  (`validateCardForOcto.ts`) whitelists are **type/structure gates, lenient on
+  style props**; all enrichment props pass. **Images must be absolute https**
+  (data:/http: stripped).
+- `DocsCardFields` carries only pre-formatted strings; no actor uid/avatar today.
+
+## Load-bearing list
+- **wire-contract** — additive optional field `actor_avatar_url` on
+  `DocsCardFields` (cross-repo docs-notify contract); a hidden `Input.Text`
+  `deny_reason` declared in the card frame (contract for the submit `inputs`
+  channel). Additive-only; existing payloads keep working.
+- **escape / markdown** — card renders caller-supplied strings (actor name,
+  title, reason). Must keep `escapeMarkdown` on every rendered field so a
+  crafted value can't inject markdown/links (`pkg/cardtmpl/resource.go`).
+- **url-destination / trust-boundary** — `actor_avatar_url` is a rendered image
+  URL; must pass the positive https allowlist (`requireHTTPS`) before it lands
+  in card bytes, same discipline as `IconURL`.
+- **i18n** — new localized labels (header label, status badges, role,
+  result-box copy) added to `docsLabels` (zh-CN + en-US), resolved via
+  `i18n.OutboundLanguage`. No hardcoded user-facing strings.
+- **space** — the docs card delivery path (member verification, space_id in the
+  envelope) must be unchanged; enrichment is body-only.
+- **card-budget** — enriched card stays within `MaxNodes=200` / `MaxDepth=16`
+  and passes `cardmsg.Validate` on the server and `validateCardForOcto` on the
+  client.
+
+## Out of scope
+- Docs-backend changes (it owns `actor_avatar_url` population and the
+  `DecisionRequest.reason` consumption). We only make the channels available.
+- Right-aligning the action row / footer meta line and the pill-shaped badge
+  background (would need octo HostConfig / a per-variant client CSS change);
+  status shown as colored text this round.
+- Any change to the generic card/action dispatch, rate-limit, or auth layers.
+- Reproducing the full requester row + reason box in the **terminal** card
+  (finalizer lacks actor/timestamp; it shows header + title + result box only).
+- Server-side "reason required" enforcement as a new errcode (kept client-side +
+  docs-backend business rule; `isRequired` is not a server card gate).
+
+## Acceptance
+- `go test ./pkg/cardtmpl/... ./modules/notify/...` passes, including new tests:
+  - enriched pending card passes `cardmsg.Validate` (ProfileV2), declares
+    `Input.Text` id `deny_reason`, and carries the two submit actions.
+  - `actor_avatar_url` renders an Image only when https; empty → no image;
+    non-https → build error (mirrors `IconURL`).
+  - actor name / reason are markdown-escaped in the card bytes.
+  - terminal denied card includes the reason from `event.Inputs["deny_reason"]`;
+    approved card shows the granted result box.
+- `make i18n-extract-check` + `make i18n-lint` pass; zh-CN entries added for any
+  new registered codes (none expected — labels are template-local, not errcodes).
+- `golangci-lint run ./pkg/cardtmpl/... ./modules/notify/...` clean.
+- octo-web: `cd apps/web && pnpm test` (card interaction + new deny-dialog tests)
+  and `pnpm lint` pass.
+- A re-rendered preview (real `adaptivecards` SDK) of the enriched pending +
+  terminal cards matches the approved demo direction.

--- a/.octospec/tasks/docs-approval-card-enrich/context.yaml
+++ b/.octospec/tasks/docs-approval-card-enrich/context.yaml
@@ -1,0 +1,31 @@
+slug: docs-approval-card-enrich
+rules_injected:
+  - id: trust-boundary
+    load_bearing: true
+    why: card renders caller-supplied strings (actor name, title, reason, deny_reason) and an avatar URL; escape leaf text + https-validate URL destinations.
+  - id: error-handling
+    load_bearing: true
+    why: modules/notify + new i18n labels; no new errcode (labels are template-local); run i18n gates.
+  - id: space-isolation
+    load_bearing: true
+    why: docs card delivery path enforces member verification + space_id envelope; enrichment must stay body-only, no isolation change.
+  - id: testing
+    load_bearing: false
+    why: add pkg/cardtmpl (pure) + modules/notify tests.
+  - id: commit-style
+    load_bearing: false
+    why: conventional commits, English.
+key_files:
+  server:
+    - pkg/cardtmpl/docs_action.go        # pending card builder (rewrite → enriched)
+    - pkg/cardtmpl/resource.go           # escapeMarkdown / requireHTTPS helpers (reuse)
+    - modules/notify/card.go             # buildDocsAccessRequestCard producer + docsLabels
+    - modules/notify/model.go            # DocsCardFields (+ ActorAvatarURL)
+    - modules/notify/action_finalizer.go # terminal card rebuild (+ deny_reason)
+  web:
+    - packages/dmworkbase/src/Messages/InteractiveCard/InteractiveCardCell.tsx  # deny interception
+    - packages/dmworkbase/src/Messages/InteractiveCard/cardAction.ts            # submit inputs
+decisions:
+  - deny reason rides in a declared hidden Input.Text id=deny_reason (server ValidateInputs requires declared).
+  - avatar via additive optional actor_avatar_url (https-only), rendered only when present.
+  - terminal card constrained to header+title+result box (finalizer lacks actor/timestamp).

--- a/modules/notify/action_finalizer.go
+++ b/modules/notify/action_finalizer.go
@@ -74,7 +74,13 @@ func (f *DocsActionFinalizer) Finalize(ctx context.Context, event cardactiondisp
 	if title == "" {
 		title = docID
 	}
-	terminalDocument, err := f.buildTerminalDocument(ctx, lang, docID, event.SpaceID, title, result)
+	// The reviewer deny reason (if any) rode in as a declared input; surface it on
+	// the denied terminal card. Missing/blank is fine (approve, or no reason typed).
+	denyReason := ""
+	if v, ok := event.Inputs[cardtmpl.DocsDenyReasonInputID].(string); ok {
+		denyReason = strings.TrimSpace(v)
+	}
+	terminalDocument, err := f.buildTerminalDocument(ctx, lang, docID, event.SpaceID, title, denyReason, result)
 	if err != nil {
 		return err
 	}
@@ -104,21 +110,32 @@ func (f *DocsActionFinalizer) Finalize(ctx context.Context, event cardactiondisp
 	return nil
 }
 
-func (f *DocsActionFinalizer) buildTerminalDocument(ctx context.Context, lang, docID, spaceID, title string, result cardactiondispatch.DecisionResult) (json.RawMessage, error) {
+func (f *DocsActionFinalizer) buildTerminalDocument(ctx context.Context, lang, docID, spaceID, title, denyReason string, result cardactiondispatch.DecisionResult) (json.RawMessage, error) {
 	labels := docsLabelsFor(lang)
-	attribution := labels.accessDeniedBanner
-	variant := "docs.access_denied"
+	webLoginURL := f.ctx.GetConfig().External.WebLoginURL
+	// Approved / denied get the enriched outcome card (header + title + result
+	// box); the denied box surfaces the reviewer reason.
 	switch result.State {
 	case cardactiondispatch.StateApproved:
-		attribution, variant = labels.accessGrantedBanner, "docs.access_approved"
+		return cardtmpl.BuildDocsApprovalOutcomeCard(ctx, webLoginURL, docID, spaceID, cardtmpl.DocsOutcomeContent{
+			Title: title, Variant: "docs.access_approved", Source: cardtmpl.Source{Label: labels.sourceLabel},
+			Denied: false, HeaderLabel: labels.approvalHeader, StatusLabel: labels.approvedStatus,
+			ResultText: labels.approvedResult,
+		})
 	case cardactiondispatch.StateDenied:
-		attribution, variant = labels.accessDeniedBanner, "docs.access_denied"
-	case cardactiondispatch.StateCancelled:
-		attribution, variant = labels.accessCancelledBanner, "docs.access_cancelled"
-	default:
-		attribution, variant = labels.accessUnavailableBanner, "docs.access_unavailable"
+		return cardtmpl.BuildDocsApprovalOutcomeCard(ctx, webLoginURL, docID, spaceID, cardtmpl.DocsOutcomeContent{
+			Title: title, Variant: "docs.access_denied", Source: cardtmpl.Source{Label: labels.sourceLabel},
+			Denied: true, HeaderLabel: labels.approvalHeader, StatusLabel: labels.deniedStatus,
+			ResultText: labels.deniedResult, ReasonLabel: labels.denyReasonLabel, Reason: denyReason,
+		})
 	}
-	return cardtmpl.BuildDocsResourceCard(ctx, f.ctx.GetConfig().External.WebLoginURL, docID, spaceID, cardtmpl.ResourceCard{
+	// Cancelled / unavailable are transient states without an enriched design —
+	// keep the prior plain resource-card rebuild.
+	attribution, variant := labels.accessUnavailableBanner, "docs.access_unavailable"
+	if result.State == cardactiondispatch.StateCancelled {
+		attribution, variant = labels.accessCancelledBanner, "docs.access_cancelled"
+	}
+	return cardtmpl.BuildDocsResourceCard(ctx, webLoginURL, docID, spaceID, cardtmpl.ResourceCard{
 		Title: title, Attribution: attribution, Variant: variant, Source: cardtmpl.Source{Label: labels.sourceLabel},
 	})
 }

--- a/modules/notify/action_finalizer_test.go
+++ b/modules/notify/action_finalizer_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-server/internal/cardactiondispatch"
 	"github.com/Mininglamp-OSS/octo-server/internal/carddispatch"
 	"github.com/Mininglamp-OSS/octo-server/pkg/cardmsg"
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl"
 )
 
 type captureCardMutator struct {
@@ -87,6 +88,53 @@ func TestDocsActionFinalizerUsesEventIDAsCardSeqAndNotifiesRequester(t *testing.
 	}
 	if len(mutator.requests) != 2 || mutator.requests[0].ContentEdit != mutator.requests[1].ContentEdit {
 		t.Fatal("replay did not produce a byte-identical deterministic terminal frame")
+	}
+}
+
+func TestDocsActionFinalizerEnrichedTerminalAndDenyReason(t *testing.T) {
+	wk := newWuKongServer()
+	defer wk.close()
+	ctx := newTestContext(t, wk)
+	ctx.GetConfig().External.WebLoginURL = "https://im.example.com/login"
+
+	build := func(state cardactiondispatch.State, inputs map[string]interface{}) string {
+		mutator := &captureCardMutator{}
+		finalizer, err := NewDocsActionFinalizer(ctx, mutator, &capturingCardSender{})
+		if err != nil {
+			t.Fatalf("NewDocsActionFinalizer() error = %v", err)
+		}
+		event := cardactiondispatch.Event{
+			EventID: 7, SenderUID: NotifyBotUIDValue, Owner: "docs", ActionType: "access_request.decision",
+			MessageID: "1001", ChannelID: NotifyBotUIDValue, ChannelType: 1, SpaceID: "space-1",
+			OperatorUID: "user-b",
+			Data:        map[string]interface{}{"doc_id": "doc-1", "request_id": "request-1"},
+			Inputs:      inputs,
+		}
+		result := cardactiondispatch.DecisionResult{
+			Disposition: cardactiondispatch.DispositionApplied, State: state,
+			RequesterUID: "user-a", Display: map[string]string{"title": "Roadmap"},
+		}
+		if err := finalizer.Finalize(context.Background(), event, result); err != nil {
+			t.Fatalf("Finalize() error = %v", err)
+		}
+		if len(mutator.requests) != 1 {
+			t.Fatalf("mutation count = %d, want 1", len(mutator.requests))
+		}
+		return mutator.requests[0].ContentEdit
+	}
+
+	approved := build(cardactiondispatch.StateApproved, nil)
+	if !strings.Contains(approved, "已允许") || !strings.Contains(approved, "申请人已获得所申请的文档权限。") {
+		t.Fatalf("approved terminal card missing enriched result box: %s", approved)
+	}
+
+	// The reviewer deny reason rides in via event.Inputs and is surfaced on the
+	// denied terminal card.
+	denied := build(cardactiondispatch.StateDenied, map[string]interface{}{
+		cardtmpl.DocsDenyReasonInputID: "范围不符，请缩小到 Q3",
+	})
+	if !strings.Contains(denied, "已拒绝") || !strings.Contains(denied, "范围不符，请缩小到 Q3") {
+		t.Fatalf("denied terminal card missing status or reason: %s", denied)
 	}
 }
 

--- a/modules/notify/card.go
+++ b/modules/notify/card.go
@@ -443,27 +443,30 @@ func (n *Notify) buildDocsCard(ctx context.Context, spaceID string, card *DocsCa
 
 func (n *Notify) buildDocsAccessRequestCard(ctx context.Context, spaceID string, card *DocsCardFields, lang string) (json.RawMessage, error) {
 	labels := docsLabelsFor(lang)
-	facts := make([]cardtmpl.Fact, 0, 2)
-	if actor := strings.TrimSpace(card.ActorName); actor != "" {
-		facts = append(facts, cardtmpl.Fact{Title: labels.actor, Value: actor})
+	actor := strings.TrimSpace(card.ActorName)
+	bannerSuffix := labels.requestBannerSuffix
+	if actor == "" {
+		bannerSuffix = labels.requestBannerAnon
 	}
-	if ts := strings.TrimSpace(card.UpdatedAt); ts != "" {
-		facts = append(facts, cardtmpl.Fact{Title: labels.updatedAt, Value: ts})
-	}
-	attribution, variant := docsAttributionAndVariant(card.Kind, card.ActorName, labels)
 	return cardtmpl.BuildDocsAccessRequestCard(
 		ctx,
 		n.ctx.GetConfig().External.WebLoginURL,
 		card.DocID,
 		card.RequestID,
 		spaceID,
-		cardtmpl.ResourceCard{
-			Title:       card.Title,
-			Attribution: attribution,
-			Excerpt:     strings.TrimSpace(card.Excerpt),
-			Facts:       facts,
-			Variant:     variant,
-			Source:      cardtmpl.Source{Label: labels.sourceLabel},
+		cardtmpl.DocsApprovalContent{
+			Title:        card.Title,
+			Actor:        actor,
+			ActorAvatar:  strings.TrimSpace(card.ActorAvatarURL),
+			Timestamp:    strings.TrimSpace(card.UpdatedAt),
+			Reason:       strings.TrimSpace(card.Excerpt),
+			Variant:      "docs.access_requested",
+			Source:       cardtmpl.Source{Label: labels.sourceLabel},
+			HeaderLabel:  labels.approvalHeader,
+			StatusLabel:  labels.pendingStatus,
+			BannerSuffix: bannerSuffix,
+			RoleLabel:    labels.roleRequester,
+			ReasonLabel:  labels.reasonLabel,
 		},
 		cardtmpl.ApprovalActions{ApproveTitle: labels.approve, DenyTitle: labels.deny},
 	)
@@ -558,6 +561,18 @@ type docsLabels struct {
 	updatedAt                 string
 	kvSep                     string
 	sourceLabel               string // ResourceCard.Source.Label — "文档" / "Docs"
+	// Enriched access-request / outcome card copy (docs-approval-card-enrich).
+	approvalHeader      string // header label — "文档申请" / "Document access"
+	pendingStatus       string // "待你处理" / "Pending"
+	approvedStatus      string // "已允许" / "Approved"
+	deniedStatus        string // "已拒绝" / "Denied"
+	requestBannerSuffix string // subtle sentence after the bold actor
+	requestBannerAnon   string // subject-less banner when actor is unknown
+	roleRequester       string // "申请人" / "Requester"
+	reasonLabel         string // "申请原因" / "Reason"
+	denyReasonLabel     string // "拒绝原因" / "Reason for denial"
+	approvedResult      string // result-box copy on approval
+	deniedResult        string // result-box copy on denial
 }
 
 func docsLabelsFor(lang string) docsLabels {
@@ -580,6 +595,17 @@ func docsLabelsFor(lang string) docsLabels {
 			updatedAt:                 "时间",
 			kvSep:                     "：",
 			sourceLabel:               "文档",
+			approvalHeader:            "文档申请",
+			pendingStatus:             "待你处理",
+			approvedStatus:            "已允许",
+			deniedStatus:              "已拒绝",
+			requestBannerSuffix:       "申请成为此文档的查看者。",
+			requestBannerAnon:         "有人申请成为此文档的查看者。",
+			roleRequester:             "申请人",
+			reasonLabel:               "申请原因",
+			denyReasonLabel:           "拒绝原因",
+			approvedResult:            "申请人已获得所申请的文档权限。",
+			deniedResult:              "申请已被拒绝。",
 		}
 	}
 	return docsLabels{
@@ -600,6 +626,17 @@ func docsLabelsFor(lang string) docsLabels {
 		updatedAt:                 "At",
 		kvSep:                     ": ",
 		sourceLabel:               "Docs",
+		approvalHeader:            "Document access",
+		pendingStatus:             "Pending",
+		approvedStatus:            "Approved",
+		deniedStatus:              "Denied",
+		requestBannerSuffix:       "is requesting viewer access to this document.",
+		requestBannerAnon:         "Someone is requesting viewer access to this document.",
+		roleRequester:             "Requester",
+		reasonLabel:               "Reason",
+		denyReasonLabel:           "Reason for denial",
+		approvedResult:            "The requester now has the requested document access.",
+		deniedResult:              "The access request was denied.",
 	}
 }
 

--- a/modules/notify/model.go
+++ b/modules/notify/model.go
@@ -76,8 +76,14 @@ type DocsCardFields struct {
 	Kind      string `json:"kind"`       // "shared" | "commented" | "access_requested"
 	Title     string `json:"title"`      // document title
 	ActorName string `json:"actor_name"` // pre-resolved actor display name; empty allowed
-	Excerpt   string `json:"excerpt"`    // optional preview / comment / access reason
-	UpdatedAt string `json:"updated_at"` // pre-formatted timestamp; empty allowed
+	// ActorAvatarURL is an optional absolute https avatar for the requester,
+	// surfaced on the access-request approval card. Additive & backward
+	// compatible: empty (or omitted) renders no avatar; a non-https value fails
+	// the card build (same positive allowlist as any rendered image URL). The
+	// docs backend owns population; octo-server does not resolve it.
+	ActorAvatarURL string `json:"actor_avatar_url"`
+	Excerpt        string `json:"excerpt"`    // optional preview / comment / access reason
+	UpdatedAt      string `json:"updated_at"` // pre-formatted timestamp; empty allowed
 }
 
 // Docs card notification kinds.

--- a/pkg/cardtmpl/docs_action.go
+++ b/pkg/cardtmpl/docs_action.go
@@ -25,7 +25,13 @@ const (
 
 	maxActorRunes     = 120
 	maxTimestampRunes = 80
-	maxReasonRunes    = MaxExcerptRunes
+	// maxReasonRunes bounds the reason text rendered on the card and the hidden
+	// input's maxLength hint. Note this is independent of the server-side submit
+	// enforcement boundary: cardmsg.ValidateInputs caps a submitted deny_reason by
+	// cardmsg.MaxInputTextBytes (4 KiB, byte-based), not by this rune count — a
+	// client that ignores maxLength can still submit up to that byte cap, and the
+	// display path re-truncates to this bound. Keep the two limits in mind separately.
+	maxReasonRunes = MaxExcerptRunes
 )
 
 type ApprovalActions struct {
@@ -140,8 +146,11 @@ func BuildDocsAccessRequestCard(
 		// render "<actor> will not get access to <title>". They are not the reason
 		// channel (that is the declared deny_reason input) and the server still
 		// re-extracts data from the stored frame — a client copy is never trusted.
+		// Bound both to the same caps the render paths use so the persisted frame /
+		// wire payload can't grow unbounded (Title is already validated <= maxTitleRunes
+		// at entry; Actor is only display-truncated in the helpers, so bound it here).
 		"doc_title": content.Title,
-		"actor":     content.Actor,
+		"actor":     truncateRunes(strings.TrimSpace(content.Actor), maxActorRunes),
 	}
 	approveData := copyActionData(baseData)
 	approveData["decision"] = "approve"
@@ -277,11 +286,18 @@ func docsBanner(actor, suffix string) map[string]interface{} {
 			"size": "Medium", "isSubtle": true, "wrap": true, "spacing": "Default",
 		}
 	}
+	// TextRun renders its text as literal plain text (no markdown surface — see
+	// pkg/cardmsg/validate.go "TextRun 不渲染 markdown" and plain.go), so it must NOT
+	// be escapeMarkdown'd: escaping here would show literal backslashes for actors
+	// with markdown metachars (e.g. "Wang (FE)" → "Wang \(FE\)"). Values are still
+	// truncateRunes-bounded above, and TextRun carries no link/URL surface, so raw
+	// text cannot inject markup. (The anonymous branch above uses a TextBlock, which
+	// DOES render markdown, so its escapeMarkdown is correct and stays.)
 	return map[string]interface{}{
 		"type": "RichTextBlock", "spacing": "Default",
 		"inlines": []interface{}{
-			map[string]interface{}{"type": "TextRun", "text": escapeMarkdown(actor + " "), "size": "Medium", "weight": "Bolder"},
-			map[string]interface{}{"type": "TextRun", "text": escapeMarkdown(suffix), "size": "Medium", "isSubtle": true},
+			map[string]interface{}{"type": "TextRun", "text": actor + " ", "size": "Medium", "weight": "Bolder"},
+			map[string]interface{}{"type": "TextRun", "text": suffix, "size": "Medium", "isSubtle": true},
 		},
 	}
 }

--- a/pkg/cardtmpl/docs_action.go
+++ b/pkg/cardtmpl/docs_action.go
@@ -286,16 +286,17 @@ func docsBanner(actor, suffix string) map[string]interface{} {
 	}
 }
 
-// docsRequesterRow builds [avatar?] [name / role] [timestamp]. Returns nil when
-// there is nothing to show (no actor, no timestamp).
+// docsRequesterRow builds [avatar?] [name / role] [timestamp]. Returns nil for an
+// anonymous request (no actor): the banner already conveys it, and a lone
+// role/timestamp with no name reads as broken.
 func docsRequesterRow(actor, avatar, roleLabel, timestamp string) map[string]interface{} {
 	actor = truncateRunes(strings.TrimSpace(actor), maxActorRunes)
 	timestamp = truncateRunes(strings.TrimSpace(timestamp), maxTimestampRunes)
-	if actor == "" && timestamp == "" {
+	if actor == "" {
 		return nil
 	}
 	var columns []interface{}
-	if actor != "" && avatar != "" {
+	if avatar != "" {
 		columns = append(columns, map[string]interface{}{
 			"type": "Column", "width": "auto", "verticalContentAlignment": "Center",
 			"items": []interface{}{
@@ -306,12 +307,11 @@ func docsRequesterRow(actor, avatar, roleLabel, timestamp string) map[string]int
 			},
 		})
 	}
-	nameItems := []interface{}{}
-	if actor != "" {
-		nameItems = append(nameItems, map[string]interface{}{
+	nameItems := []interface{}{
+		map[string]interface{}{
 			"type": "TextBlock", "text": escapeMarkdown(actor),
 			"weight": "Bolder", "wrap": false, "spacing": "None",
-		})
+		},
 	}
 	if strings.TrimSpace(roleLabel) != "" {
 		nameItems = append(nameItems, map[string]interface{}{

--- a/pkg/cardtmpl/docs_action.go
+++ b/pkg/cardtmpl/docs_action.go
@@ -7,11 +7,25 @@ import (
 	"fmt"
 	"strings"
 	"unicode/utf8"
+
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardmsg"
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
 )
 
 const (
 	DocsApproveActionID = "docs-access-approve"
 	DocsDenyActionID    = "docs-access-deny"
+	// DocsDenyReasonInputID is the id of the (hidden) Input.Text that declares the
+	// reviewer deny-reason channel. The reason must ride under a *declared* input
+	// id — the card/action endpoint fail-closes on undeclared inputs
+	// (pkg/cardmsg.ValidateInputs) — so this id is the cross-repo contract the web
+	// deny dialog submits (inputs[DocsDenyReasonInputID]) and the value reaches the
+	// docs backend verbatim via DecisionRequest.Inputs.
+	DocsDenyReasonInputID = "deny_reason"
+
+	maxActorRunes     = 120
+	maxTimestampRunes = 80
+	maxReasonRunes    = MaxExcerptRunes
 )
 
 type ApprovalActions struct {
@@ -19,17 +33,56 @@ type ApprovalActions struct {
 	DenyTitle    string
 }
 
-// BuildDocsAccessRequestCard extends the reviewed docs resource template with
-// the two server-authored Submit actions used by the docs approval pilot. The
-// callback route itself never appears in card bytes; only bounded domain data
-// needed by the registered docs route is embedded.
+// DocsApprovalContent carries the enriched docs access-request card fields. All
+// string fields except the *Label ones are caller-supplied display strings that
+// this template escapes (escapeMarkdown) and bounds; the labels are server-owned
+// localized copy (producer picks them by language). ActorAvatar is optional and
+// must be an absolute https URL when present (empty => no avatar column).
+type DocsApprovalContent struct {
+	Title       string
+	Actor       string
+	ActorAvatar string
+	Timestamp   string
+	Reason      string
+	Variant     string
+	Source      Source
+
+	HeaderLabel  string // e.g. "文档申请" / "Document access"
+	StatusLabel  string // e.g. "待你处理" / "Pending"
+	BannerSuffix string // e.g. "申请成为此文档的查看者。" (rendered subtle after the bold actor)
+	RoleLabel    string // e.g. "申请人" / "Requester"
+	ReasonLabel  string // e.g. "申请原因" / "Reason"
+}
+
+// DocsOutcomeContent carries the enriched terminal (已允许 / 已拒绝) card fields.
+// The finalizer only has title + decision (+ the reviewer reason for denials), so
+// this state renders header + title + a result box — not the full requester row.
+type DocsOutcomeContent struct {
+	Title   string
+	Variant string
+	Source  Source
+	Denied  bool // true => denied (attention), false => approved (good)
+
+	HeaderLabel string // "文档申请"
+	StatusLabel string // "已允许" / "已拒绝"
+	ResultText  string // "申请人已获得所申请的文档权限。" / "申请已被拒绝。"
+	ReasonLabel string // "拒绝原因"
+	Reason      string // reviewer deny reason (denied only); "" => omit
+}
+
+// BuildDocsAccessRequestCard renders the enriched docs access-request approval
+// card: a header line (label + status), a large document title, a requester row
+// (optional avatar + name + role + timestamp), a boxed reason section, a hidden
+// deny-reason input, and the two server-authored Submit actions (+ view-details).
+// The callback route never appears in card bytes; only bounded domain data the
+// registered docs route needs is embedded.
 func BuildDocsAccessRequestCard(
 	ctx context.Context,
 	webLoginURL string,
 	docID string,
 	requestID string,
 	spaceID string,
-	resource ResourceCard,
+	content DocsApprovalContent,
 	actions ApprovalActions,
 ) (json.RawMessage, error) {
 	if strings.TrimSpace(requestID) == "" || utf8.RuneCountInString(requestID) > 200 {
@@ -39,51 +92,298 @@ func BuildDocsAccessRequestCard(
 		utf8.RuneCountInString(actions.ApproveTitle) > 80 || utf8.RuneCountInString(actions.DenyTitle) > 80 {
 		return nil, errors.New("cardtmpl: approval action labels are invalid")
 	}
-	document, err := BuildDocsResourceCard(ctx, webLoginURL, docID, spaceID, resource)
+	if strings.TrimSpace(content.Title) == "" || utf8.RuneCountInString(content.Title) > maxTitleRunes {
+		return nil, errors.New("cardtmpl: resource title is invalid")
+	}
+	if content.ActorAvatar != "" {
+		if err := requireHTTPS(content.ActorAvatar); err != nil {
+			return nil, fmt.Errorf("cardtmpl: actor avatar URL: %w", err)
+		}
+	}
+	if content.Source.IconURL != "" {
+		if err := requireHTTPS(content.Source.IconURL); err != nil {
+			return nil, fmt.Errorf("cardtmpl: source icon URL: %w", err)
+		}
+	}
+	deepLink, err := docsDeepLink(webLoginURL, docID, spaceID)
 	if err != nil {
 		return nil, err
 	}
-	var card map[string]interface{}
-	if err := json.Unmarshal(document, &card); err != nil {
-		return nil, fmt.Errorf("cardtmpl: decode docs resource card: %w", err)
+	lang := i18n.OutboundLanguage(ctx)
+	labels := labelsForLanguage(lang)
+
+	body := []interface{}{
+		docsApprovalHeader(content.HeaderLabel, content.StatusLabel, "Warning"),
+		docsApprovalTitle(content.Title),
+		docsBanner(content.Actor, content.BannerSuffix),
 	}
+	if row := docsRequesterRow(content.Actor, content.ActorAvatar, content.RoleLabel, content.Timestamp); row != nil {
+		body = append(body, row)
+	}
+	if box := docsReasonBox(content.ReasonLabel, content.Reason); box != nil {
+		body = append(body, box)
+	}
+	// Hidden Input.Text declares the deny-reason id so a submitted
+	// inputs[deny_reason] survives ValidateInputs. It is not shown in the card;
+	// the web deny dialog owns reason capture and populates the submit inputs.
+	body = append(body, map[string]interface{}{
+		"type": "Input.Text", "id": DocsDenyReasonInputID, "isVisible": false,
+		"isMultiline": true, "maxLength": maxReasonRunes,
+	})
+
 	baseData := map[string]interface{}{
 		"owner":       "docs",
 		"action_type": "access_request.decision",
 		"doc_id":      docID,
 		"request_id":  requestID,
+		// doc_title / actor are display context the web deny dialog reads locally to
+		// render "<actor> will not get access to <title>". They are not the reason
+		// channel (that is the declared deny_reason input) and the server still
+		// re-extracts data from the stored frame — a client copy is never trusted.
+		"doc_title": content.Title,
+		"actor":     content.Actor,
 	}
 	approveData := copyActionData(baseData)
 	approveData["decision"] = "approve"
 	denyData := copyActionData(baseData)
 	denyData["decision"] = "deny"
-	card["actions"] = []interface{}{
-		map[string]interface{}{
-			"type":  "Action.Submit",
-			"id":    DocsApproveActionID,
-			"title": actions.ApproveTitle,
-			"style": "positive",
-			"data":  approveData,
-		},
-		map[string]interface{}{
-			"type":  "Action.Submit",
-			"id":    DocsDenyActionID,
-			"title": actions.DenyTitle,
-			"style": "destructive",
-			"data":  denyData,
+
+	document := map[string]interface{}{
+		"type":     "AdaptiveCard",
+		"version":  cardmsg.CardVersion,
+		"metadata": buildMetadata(deepLink, content.Variant, content.Source),
+		"body":     body,
+		"actions": []interface{}{
+			map[string]interface{}{"type": "Action.OpenUrl", "title": labels.viewDetails, "url": deepLink},
+			map[string]interface{}{
+				"type": "Action.Submit", "id": DocsDenyActionID, "title": actions.DenyTitle,
+				"style": "destructive", "data": denyData,
+			},
+			map[string]interface{}{
+				"type": "Action.Submit", "id": DocsApproveActionID, "title": actions.ApproveTitle,
+				"style": "positive", "data": approveData,
+			},
 		},
 	}
-	raw, err := json.Marshal(card)
+	raw, err := json.Marshal(document)
 	if err != nil {
 		return nil, fmt.Errorf("cardtmpl: marshal docs access request card: %w", err)
 	}
 	return raw, nil
 }
 
-func copyActionData(source map[string]interface{}) map[string]interface{} {
-	copy := make(map[string]interface{}, len(source)+1)
-	for key, value := range source {
-		copy[key] = value
+// BuildDocsApprovalOutcomeCard renders the terminal (已允许 / 已拒绝) docs card:
+// header (label + colored status) + title + a result box. The denied box surfaces
+// the reviewer's reason. No decision actions remain; view-details stays.
+func BuildDocsApprovalOutcomeCard(
+	ctx context.Context,
+	webLoginURL string,
+	docID string,
+	spaceID string,
+	content DocsOutcomeContent,
+) (json.RawMessage, error) {
+	if strings.TrimSpace(content.Title) == "" || utf8.RuneCountInString(content.Title) > maxTitleRunes {
+		return nil, errors.New("cardtmpl: resource title is invalid")
 	}
-	return copy
+	if content.Source.IconURL != "" {
+		if err := requireHTTPS(content.Source.IconURL); err != nil {
+			return nil, fmt.Errorf("cardtmpl: source icon URL: %w", err)
+		}
+	}
+	deepLink, err := docsDeepLink(webLoginURL, docID, spaceID)
+	if err != nil {
+		return nil, err
+	}
+	lang := i18n.OutboundLanguage(ctx)
+	labels := labelsForLanguage(lang)
+
+	statusColor := "Good"
+	boxStyle := "good"
+	if content.Denied {
+		statusColor, boxStyle = "Attention", "attention"
+	}
+	body := []interface{}{
+		docsApprovalHeader(content.HeaderLabel, content.StatusLabel, statusColor),
+		docsApprovalTitle(content.Title),
+		docsResultBox(boxStyle, statusColor, content.ResultText, content.ReasonLabel, content.Reason),
+		// view-details rides as a body ActionSet (not a root action) so the
+		// terminal card carries no decision/submit actions — the approve/deny
+		// buttons are gone once the request is resolved.
+		map[string]interface{}{
+			"type": "ActionSet",
+			"actions": []interface{}{
+				map[string]interface{}{"type": "Action.OpenUrl", "title": labels.viewDetails, "url": deepLink},
+			},
+		},
+	}
+	document := map[string]interface{}{
+		"type":     "AdaptiveCard",
+		"version":  cardmsg.CardVersion,
+		"metadata": buildMetadata(deepLink, content.Variant, content.Source),
+		"body":     body,
+	}
+	raw, err := json.Marshal(document)
+	if err != nil {
+		return nil, fmt.Errorf("cardtmpl: marshal docs outcome card: %w", err)
+	}
+	return raw, nil
+}
+
+// docsApprovalHeader is the shared top row: a bold source label on the left and a
+// small colored status label on the right (color drives pending/approved/denied).
+func docsApprovalHeader(headerLabel, statusLabel, statusColor string) map[string]interface{} {
+	columns := []interface{}{
+		map[string]interface{}{
+			"type": "Column", "width": "stretch", "verticalContentAlignment": "Center",
+			"items": []interface{}{
+				map[string]interface{}{
+					"type": "TextBlock", "text": escapeMarkdown(headerLabel),
+					"weight": "Bolder", "size": "Small", "wrap": false, "spacing": "None",
+				},
+			},
+		},
+	}
+	if strings.TrimSpace(statusLabel) != "" {
+		columns = append(columns, map[string]interface{}{
+			"type": "Column", "width": "auto", "verticalContentAlignment": "Center",
+			"items": []interface{}{
+				map[string]interface{}{
+					"type": "TextBlock", "text": escapeMarkdown(statusLabel),
+					"weight": "Bolder", "size": "Small", "color": statusColor,
+					"horizontalAlignment": "Right", "wrap": false, "spacing": "None",
+				},
+			},
+		})
+	}
+	return map[string]interface{}{"type": "ColumnSet", "spacing": "None", "columns": columns}
+}
+
+func docsApprovalTitle(title string) map[string]interface{} {
+	return map[string]interface{}{
+		"type": "TextBlock", "text": escapeMarkdown(title),
+		"size": "ExtraLarge", "weight": "Bolder", "wrap": true,
+		"separator": true, "spacing": "Medium",
+	}
+}
+
+// docsBanner renders "<bold actor> <subtle suffix>". With no actor it degrades to
+// the subtle suffix alone (producer passes the subject-less sentence).
+func docsBanner(actor, suffix string) map[string]interface{} {
+	actor = truncateRunes(strings.TrimSpace(actor), maxActorRunes)
+	suffix = truncateRunes(strings.TrimSpace(suffix), maxTitleRunes)
+	if actor == "" {
+		return map[string]interface{}{
+			"type": "TextBlock", "text": escapeMarkdown(suffix),
+			"size": "Medium", "isSubtle": true, "wrap": true, "spacing": "Default",
+		}
+	}
+	return map[string]interface{}{
+		"type": "RichTextBlock", "spacing": "Default",
+		"inlines": []interface{}{
+			map[string]interface{}{"type": "TextRun", "text": escapeMarkdown(actor + " "), "size": "Medium", "weight": "Bolder"},
+			map[string]interface{}{"type": "TextRun", "text": escapeMarkdown(suffix), "size": "Medium", "isSubtle": true},
+		},
+	}
+}
+
+// docsRequesterRow builds [avatar?] [name / role] [timestamp]. Returns nil when
+// there is nothing to show (no actor, no timestamp).
+func docsRequesterRow(actor, avatar, roleLabel, timestamp string) map[string]interface{} {
+	actor = truncateRunes(strings.TrimSpace(actor), maxActorRunes)
+	timestamp = truncateRunes(strings.TrimSpace(timestamp), maxTimestampRunes)
+	if actor == "" && timestamp == "" {
+		return nil
+	}
+	var columns []interface{}
+	if actor != "" && avatar != "" {
+		columns = append(columns, map[string]interface{}{
+			"type": "Column", "width": "auto", "verticalContentAlignment": "Center",
+			"items": []interface{}{
+				map[string]interface{}{
+					"type": "Image", "url": avatar, "style": "Person",
+					"width": "36px", "height": "36px",
+				},
+			},
+		})
+	}
+	nameItems := []interface{}{}
+	if actor != "" {
+		nameItems = append(nameItems, map[string]interface{}{
+			"type": "TextBlock", "text": escapeMarkdown(actor),
+			"weight": "Bolder", "wrap": false, "spacing": "None",
+		})
+	}
+	if strings.TrimSpace(roleLabel) != "" {
+		nameItems = append(nameItems, map[string]interface{}{
+			"type": "TextBlock", "text": escapeMarkdown(roleLabel),
+			"isSubtle": true, "size": "Small", "wrap": false, "spacing": "None",
+		})
+	}
+	columns = append(columns, map[string]interface{}{
+		"type": "Column", "width": "stretch", "verticalContentAlignment": "Center",
+		"items": nameItems,
+	})
+	if timestamp != "" {
+		columns = append(columns, map[string]interface{}{
+			"type": "Column", "width": "auto", "verticalContentAlignment": "Center",
+			"items": []interface{}{
+				map[string]interface{}{
+					"type": "TextBlock", "text": escapeMarkdown(timestamp),
+					"isSubtle": true, "size": "Small", "horizontalAlignment": "Right", "wrap": false,
+				},
+			},
+		})
+	}
+	return map[string]interface{}{"type": "ColumnSet", "spacing": "Medium", "columns": columns}
+}
+
+// docsReasonBox is the emphasis-styled reason section. Returns nil when empty.
+func docsReasonBox(label, reason string) map[string]interface{} {
+	reason = truncateRunes(strings.TrimSpace(reason), maxReasonRunes)
+	if reason == "" {
+		return nil
+	}
+	items := []interface{}{}
+	if strings.TrimSpace(label) != "" {
+		items = append(items, map[string]interface{}{
+			"type": "TextBlock", "text": escapeMarkdown(label),
+			"size": "Small", "weight": "Bolder", "isSubtle": true, "spacing": "None",
+		})
+	}
+	items = append(items, map[string]interface{}{
+		"type": "TextBlock", "text": escapeMarkdown(reason), "size": "Medium", "wrap": true, "spacing": "Small",
+	})
+	return map[string]interface{}{"type": "Container", "style": "emphasis", "spacing": "Medium", "items": items}
+}
+
+// docsResultBox is the terminal good/attention result section. For denials it
+// appends the reviewer reason as a labeled sub-line.
+func docsResultBox(boxStyle, textColor, resultText, reasonLabel, reason string) map[string]interface{} {
+	items := []interface{}{
+		map[string]interface{}{
+			"type": "TextBlock", "text": escapeMarkdown(strings.TrimSpace(resultText)),
+			"size": "Medium", "weight": "Bolder", "color": textColor, "wrap": true, "spacing": "None",
+		},
+	}
+	if r := truncateRunes(strings.TrimSpace(reason), maxReasonRunes); r != "" {
+		label := strings.TrimSpace(reasonLabel)
+		if label != "" {
+			items = append(items, map[string]interface{}{
+				"type": "TextBlock", "text": escapeMarkdown(label),
+				"size": "Small", "weight": "Bolder", "isSubtle": true, "spacing": "Small",
+			})
+		}
+		items = append(items, map[string]interface{}{
+			"type": "TextBlock", "text": escapeMarkdown(r), "size": "Medium", "wrap": true, "spacing": "None",
+		})
+	}
+	return map[string]interface{}{"type": "Container", "style": boxStyle, "spacing": "Medium", "items": items}
+}
+
+func copyActionData(source map[string]interface{}) map[string]interface{} {
+	dst := make(map[string]interface{}, len(source)+1)
+	for key, value := range source {
+		dst[key] = value
+	}
+	return dst
 }

--- a/pkg/cardtmpl/docs_action_test.go
+++ b/pkg/cardtmpl/docs_action_test.go
@@ -243,6 +243,79 @@ func anyTextContains(nodes []map[string]interface{}, want string) bool {
 	return false
 }
 
+func TestBuildDocsAccessRequestCardBannerTextRunNotEscaped(t *testing.T) {
+	// TextRun renders literal text (no markdown surface), so the bold-actor banner
+	// must NOT be backslash-escaped — otherwise "Wang (FE)" shows as "Wang \(FE\)".
+	c := exampleDocsApprovalContent()
+	c.Actor = "Wang (FE)_lead"
+	c.BannerSuffix = "requested access."
+	doc, err := BuildDocsAccessRequestCard(
+		localizedContext("en-US"), "https://im.example.com/login", "d", "r", "s", c,
+		ApprovalActions{ApproveTitle: "Allow", DenyTitle: "Deny"},
+	)
+	require.NoError(t, err)
+	nodes := flattenCardNodes(mustCardMap(t, doc)["body"])
+	runs := nodesOfType(nodes, "TextRun")
+	require.NotEmpty(t, runs, "enriched banner should use RichTextBlock TextRun inlines")
+	rawActor := false
+	for _, r := range runs {
+		s, _ := r["text"].(string)
+		if strings.Contains(s, `\(`) || strings.Contains(s, `\_`) {
+			t.Fatalf("banner TextRun must not be markdown-escaped: %q", s)
+		}
+		if strings.Contains(s, "Wang (FE)_lead") {
+			rawActor = true
+		}
+	}
+	assert.True(t, rawActor, "banner TextRun should carry the raw (unescaped) actor")
+	// The requester-row name is a TextBlock (markdown-rendered) and MUST stay escaped.
+	assert.True(t, anyTextContains(nodes, `Wang \(FE\)\_lead`), "requester-row TextBlock actor stays escaped")
+}
+
+func TestBuildDocsAccessRequestCardAnonymous(t *testing.T) {
+	c := exampleDocsApprovalContent()
+	c.Actor = ""
+	c.ActorAvatar = ""
+	c.BannerSuffix = "Someone requested access to this document."
+	doc, err := BuildDocsAccessRequestCard(
+		localizedContext("en-US"), "https://im.example.com/login", "d", "r", "s", c,
+		ApprovalActions{ApproveTitle: "Allow", DenyTitle: "Deny"},
+	)
+	require.NoError(t, err)
+	card := mustCardMap(t, doc)
+	nodes := flattenCardNodes(card["body"])
+	// Anonymous: subject-less banner is a plain TextBlock (no TextRun inlines) and
+	// there is no requester row (no avatar Image).
+	assert.Empty(t, nodesOfType(nodes, "TextRun"), "anonymous banner must not use TextRun inlines")
+	assert.Empty(t, nodesOfType(nodes, "Image"), "anonymous request has no avatar row")
+	assert.True(t, cardHasText(nodes, "Someone requested access to this document."))
+	require.NoError(t, cardmsg.Validate(map[string]interface{}{
+		"type": cardmsg.InteractiveCard.Int(), "card_version": cardmsg.CardVersion,
+		"profile": cardmsg.ProfileV2, "card": card,
+	}))
+}
+
+func TestBuildDocsAccessRequestCardBoundsActorInData(t *testing.T) {
+	c := exampleDocsApprovalContent()
+	c.Actor = strings.Repeat("名", maxActorRunes+50)
+	doc, err := BuildDocsAccessRequestCard(
+		localizedContext("zh-CN"), "https://im.example.com/login", "d", "r", "s", c,
+		ApprovalActions{ApproveTitle: "允许", DenyTitle: "拒绝"},
+	)
+	require.NoError(t, err)
+	actions := mustCardMap(t, doc)["actions"].([]interface{})
+	for _, a := range actions {
+		m := a.(map[string]interface{})
+		data, ok := m["data"].(map[string]interface{})
+		if !ok {
+			continue // Action.OpenUrl has no data
+		}
+		actorInData, _ := data["actor"].(string)
+		assert.LessOrEqual(t, len([]rune(actorInData)), maxActorRunes,
+			"data.actor must be bounded to maxActorRunes")
+	}
+}
+
 func TestBuildDocsApprovalOutcomeCard(t *testing.T) {
 	base := "https://im.example.com/login"
 

--- a/pkg/cardtmpl/docs_action_test.go
+++ b/pkg/cardtmpl/docs_action_test.go
@@ -2,6 +2,7 @@ package cardtmpl
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/Mininglamp-OSS/octo-server/pkg/cardmsg"
@@ -9,51 +10,109 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestBuildDocsAccessRequestCardProducesReviewedV2Actions(t *testing.T) {
+func exampleDocsApprovalContent() DocsApprovalContent {
+	return DocsApprovalContent{
+		Title:        "2026 Q3 产品路线图",
+		Actor:        "李四",
+		Timestamp:    "2026-07-16 11:15",
+		Reason:       "申请查看权限，用于对齐 Q3 交付节奏。",
+		Variant:      "docs.access_requested",
+		Source:       Source{Label: "文档"},
+		HeaderLabel:  "文档申请",
+		StatusLabel:  "待你处理",
+		BannerSuffix: "申请成为此文档的查看者。",
+		RoleLabel:    "申请人",
+		ReasonLabel:  "申请原因",
+	}
+}
+
+// flattenCardNodes recursively collects every element/action object (any map
+// carrying a "type") reachable through the known AC child collections.
+func flattenCardNodes(v interface{}) []map[string]interface{} {
+	var out []map[string]interface{}
+	switch node := v.(type) {
+	case map[string]interface{}:
+		if _, ok := node["type"]; ok {
+			out = append(out, node)
+		}
+		for _, key := range []string{"body", "items", "columns", "inlines", "actions", "facts"} {
+			if child, ok := node[key]; ok {
+				out = append(out, flattenCardNodes(child)...)
+			}
+		}
+	case []interface{}:
+		for _, item := range node {
+			out = append(out, flattenCardNodes(item)...)
+		}
+	}
+	return out
+}
+
+func nodesOfType(nodes []map[string]interface{}, t string) []map[string]interface{} {
+	var out []map[string]interface{}
+	for _, n := range nodes {
+		if s, _ := n["type"].(string); s == t {
+			out = append(out, n)
+		}
+	}
+	return out
+}
+
+func TestBuildDocsAccessRequestCardEnrichedLayoutAndActions(t *testing.T) {
 	document, err := BuildDocsAccessRequestCard(
 		localizedContext("zh-CN"),
 		"https://im.example.com/login",
 		"doc-1",
 		"request-1",
 		"space-1",
-		exampleDocsResourceCard(),
+		exampleDocsApprovalContent(),
 		ApprovalActions{ApproveTitle: "允许", DenyTitle: "拒绝"},
 	)
 	require.NoError(t, err)
 
 	var card map[string]interface{}
 	require.NoError(t, json.Unmarshal(document, &card))
+
+	// Actions: view-details (OpenUrl) then deny (destructive) then approve
+	// (positive) — approve is the primary/rightmost decision.
 	actions, ok := card["actions"].([]interface{})
 	require.True(t, ok)
-	require.Len(t, actions, 2)
-
-	want := []struct {
-		id       string
-		title    string
-		style    string
-		decision string
-	}{
-		{id: DocsApproveActionID, title: "允许", style: "positive", decision: "approve"},
-		{id: DocsDenyActionID, title: "拒绝", style: "destructive", decision: "deny"},
-	}
-	for i, expected := range want {
-		action, ok := actions[i].(map[string]interface{})
-		require.True(t, ok)
-		assert.Equal(t, "Action.Submit", action["type"])
-		assert.Equal(t, expected.id, action["id"])
-		assert.Equal(t, expected.title, action["title"])
-		// Parity with the generic approval card (approval_request.go): approve =
-		// primary (positive), deny = secondary (destructive) so the docs access
-		// request card and the generic approval card render consistently.
-		assert.Equal(t, expected.style, action["style"])
-		data, ok := action["data"].(map[string]interface{})
-		require.True(t, ok)
+	require.Len(t, actions, 3)
+	view := actions[0].(map[string]interface{})
+	assert.Equal(t, "Action.OpenUrl", view["type"])
+	assert.Equal(t, "查看详情", view["title"])
+	deny := actions[1].(map[string]interface{})
+	assert.Equal(t, "Action.Submit", deny["type"])
+	assert.Equal(t, DocsDenyActionID, deny["id"])
+	assert.Equal(t, "destructive", deny["style"])
+	approve := actions[2].(map[string]interface{})
+	assert.Equal(t, "Action.Submit", approve["type"])
+	assert.Equal(t, DocsApproveActionID, approve["id"])
+	assert.Equal(t, "positive", approve["style"])
+	for _, a := range []map[string]interface{}{deny, approve} {
+		data := a["data"].(map[string]interface{})
 		assert.Equal(t, "docs", data["owner"])
 		assert.Equal(t, "access_request.decision", data["action_type"])
-		assert.Equal(t, expected.decision, data["decision"])
 		assert.Equal(t, "doc-1", data["doc_id"])
 		assert.Equal(t, "request-1", data["request_id"])
 	}
+	assert.Equal(t, "deny", deny["data"].(map[string]interface{})["decision"])
+	assert.Equal(t, "approve", approve["data"].(map[string]interface{})["decision"])
+
+	nodes := flattenCardNodes(card["body"])
+	// The hidden deny-reason input must be declared (id channel for the reason).
+	inputs := nodesOfType(nodes, "Input.Text")
+	require.Len(t, inputs, 1)
+	assert.Equal(t, DocsDenyReasonInputID, inputs[0]["id"])
+	assert.Equal(t, false, inputs[0]["isVisible"])
+
+	// Enriched sections are present: header label, status, big title, reason box.
+	require.NotEmpty(t, nodesOfType(nodes, "ColumnSet"))
+	require.NotEmpty(t, nodesOfType(nodes, "Container"))
+	assert.True(t, cardHasText(nodes, "文档申请"))
+	assert.True(t, cardHasText(nodes, "待你处理"))
+	assert.True(t, cardHasText(nodes, "2026 Q3 产品路线图"))
+	assert.True(t, cardHasText(nodes, "申请原因"))
 
 	envelope := map[string]interface{}{
 		"type":         cardmsg.InteractiveCard.Int(),
@@ -61,7 +120,17 @@ func TestBuildDocsAccessRequestCardProducesReviewedV2Actions(t *testing.T) {
 		"profile":      cardmsg.ProfileV2,
 		"card":         card,
 	}
-	require.NoError(t, cardmsg.Validate(envelope), "reviewed docs template must pass octo/v2 validation")
+	require.NoError(t, cardmsg.Validate(envelope), "enriched docs template must pass octo/v2 validation")
+}
+
+// cardHasText reports whether any TextBlock/TextRun's text equals want.
+func cardHasText(nodes []map[string]interface{}, want string) bool {
+	for _, n := range nodes {
+		if s, _ := n["text"].(string); s == want {
+			return true
+		}
+	}
+	return false
 }
 
 func TestBuildDocsAccessRequestCardRejectsMissingRequestID(t *testing.T) {
@@ -71,8 +140,117 @@ func TestBuildDocsAccessRequestCardRejectsMissingRequestID(t *testing.T) {
 		"doc-1",
 		"",
 		"space-1",
-		exampleDocsResourceCard(),
+		exampleDocsApprovalContent(),
 		ApprovalActions{ApproveTitle: "Allow", DenyTitle: "Deny"},
 	)
 	require.Error(t, err)
+}
+
+func TestBuildDocsAccessRequestCardAvatarHTTPSOnly(t *testing.T) {
+	base := "https://im.example.com/login"
+	actions := ApprovalActions{ApproveTitle: "允许", DenyTitle: "拒绝"}
+
+	// Empty avatar => no Image element.
+	noAvatar := exampleDocsApprovalContent()
+	doc, err := BuildDocsAccessRequestCard(localizedContext("zh-CN"), base, "d", "r", "s", noAvatar, actions)
+	require.NoError(t, err)
+	var card map[string]interface{}
+	require.NoError(t, json.Unmarshal(doc, &card))
+	assert.Empty(t, nodesOfType(flattenCardNodes(card["body"]), "Image"))
+
+	// https avatar => one Person Image.
+	withAvatar := exampleDocsApprovalContent()
+	withAvatar.ActorAvatar = "https://cdn.example.com/a/lisi.png"
+	doc, err = BuildDocsAccessRequestCard(localizedContext("zh-CN"), base, "d", "r", "s", withAvatar, actions)
+	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(doc, &card))
+	images := nodesOfType(flattenCardNodes(card["body"]), "Image")
+	require.Len(t, images, 1)
+	assert.Equal(t, "Person", images[0]["style"])
+	assert.Equal(t, "https://cdn.example.com/a/lisi.png", images[0]["url"])
+
+	// non-https avatar => build error (positive https allowlist).
+	for _, bad := range []string{"http://cdn.example.com/a.png", "data:image/png;base64,AAAA", "//cdn/a.png"} {
+		c := exampleDocsApprovalContent()
+		c.ActorAvatar = bad
+		_, err := BuildDocsAccessRequestCard(localizedContext("zh-CN"), base, "d", "r", "s", c, actions)
+		require.Error(t, err, "avatar %q must be rejected", bad)
+	}
+}
+
+func TestBuildDocsAccessRequestCardEscapesCallerText(t *testing.T) {
+	c := exampleDocsApprovalContent()
+	c.Actor = "李四*x*"
+	c.Reason = "see [here](http://evil)"
+	c.Title = "Road_map_"
+	doc, err := BuildDocsAccessRequestCard(
+		localizedContext("zh-CN"),
+		"https://im.example.com/login", "d", "r", "s", c,
+		ApprovalActions{ApproveTitle: "允许", DenyTitle: "拒绝"},
+	)
+	require.NoError(t, err)
+	// Raw markdown control chars must be backslash-escaped in the card bytes so a
+	// crafted actor/title/reason cannot forge formatting or links.
+	nodes := flattenCardNodes(mustCardMap(t, doc)["body"])
+	assert.True(t, anyTextContains(nodes, `李四\*x\*`), "actor markdown must be escaped")
+	assert.True(t, anyTextContains(nodes, `\[here\]`), "reason link markdown must be escaped")
+	assert.True(t, anyTextContains(nodes, `Road\_map\_`), "title markdown must be escaped")
+}
+
+func mustCardMap(t *testing.T, doc json.RawMessage) map[string]interface{} {
+	t.Helper()
+	var card map[string]interface{}
+	require.NoError(t, json.Unmarshal(doc, &card))
+	return card
+}
+
+func anyTextContains(nodes []map[string]interface{}, want string) bool {
+	for _, n := range nodes {
+		if s, _ := n["text"].(string); strings.Contains(s, want) {
+			return true
+		}
+	}
+	return false
+}
+
+func TestBuildDocsApprovalOutcomeCard(t *testing.T) {
+	base := "https://im.example.com/login"
+
+	// Approved: good box, no reason, validates.
+	approved, err := BuildDocsApprovalOutcomeCard(localizedContext("zh-CN"), base, "d", "s", DocsOutcomeContent{
+		Title: "2026 Q3 产品路线图", Variant: "docs.access_approved", Source: Source{Label: "文档"},
+		Denied: false, HeaderLabel: "文档申请", StatusLabel: "已允许",
+		ResultText: "申请人已获得所申请的文档权限。",
+	})
+	require.NoError(t, err)
+	card := mustCardMap(t, approved)
+	nodes := flattenCardNodes(card["body"])
+	assert.True(t, cardHasText(nodes, "已允许"))
+	assert.True(t, cardHasText(nodes, "申请人已获得所申请的文档权限。"))
+	requireOutcomeValidates(t, card)
+
+	// Denied: attention box surfaces the reviewer reason (escaped), validates.
+	denied, err := BuildDocsApprovalOutcomeCard(localizedContext("zh-CN"), base, "d", "s", DocsOutcomeContent{
+		Title: "2026 Q3 产品路线图", Variant: "docs.access_denied", Source: Source{Label: "文档"},
+		Denied: true, HeaderLabel: "文档申请", StatusLabel: "已拒绝",
+		ResultText: "申请已被拒绝。", ReasonLabel: "拒绝原因", Reason: "权限范围*不符*",
+	})
+	require.NoError(t, err)
+	card = mustCardMap(t, denied)
+	nodes = flattenCardNodes(card["body"])
+	assert.True(t, cardHasText(nodes, "已拒绝"))
+	assert.True(t, cardHasText(nodes, "拒绝原因"))
+	assert.True(t, anyTextContains(nodes, `权限范围\*不符\*`), "deny reason must be escaped")
+	requireOutcomeValidates(t, card)
+}
+
+func requireOutcomeValidates(t *testing.T, card map[string]interface{}) {
+	t.Helper()
+	envelope := map[string]interface{}{
+		"type":         cardmsg.InteractiveCard.Int(),
+		"card_version": cardmsg.CardVersion,
+		"profile":      cardmsg.ProfileV2,
+		"card":         card,
+	}
+	require.NoError(t, cardmsg.Validate(envelope), "outcome card must pass octo/v2 validation")
 }

--- a/pkg/cardtmpl/docs_action_test.go
+++ b/pkg/cardtmpl/docs_action_test.go
@@ -133,6 +133,36 @@ func cardHasText(nodes []map[string]interface{}, want string) bool {
 	return false
 }
 
+// TestDocsAccessRequestCardDenyReasonSubmitContract closes the load-bearing seam
+// of the reason channel without infra: the enriched card declares the deny_reason
+// input, so the real card/action inputs validator (cardmsg.ValidateInputs)
+// accepts a submitted inputs[deny_reason] and fail-closes on undeclared keys.
+func TestDocsAccessRequestCardDenyReasonSubmitContract(t *testing.T) {
+	document, err := BuildDocsAccessRequestCard(
+		localizedContext("zh-CN"), "https://im.example.com/login", "doc-1", "request-1", "space-1",
+		exampleDocsApprovalContent(), ApprovalActions{ApproveTitle: "允许", DenyTitle: "拒绝"},
+	)
+	require.NoError(t, err)
+	var card map[string]interface{}
+	require.NoError(t, json.Unmarshal(document, &card))
+	envelope, err := json.Marshal(map[string]interface{}{"card": card})
+	require.NoError(t, err)
+
+	// The reviewer reason submits under the declared deny_reason input → accepted.
+	require.NoError(t, cardmsg.ValidateInputs(envelope, map[string]interface{}{
+		DocsDenyReasonInputID: "范围不符，请对齐后再申请",
+	}))
+	// Empty reason is a valid shape (the server does not enforce isRequired; the
+	// dialog does). Approve submits deny_reason:"" harmlessly.
+	require.NoError(t, cardmsg.ValidateInputs(envelope, map[string]interface{}{
+		DocsDenyReasonInputID: "",
+	}))
+	// An undeclared input is rejected fail-closed — a forged key can't ride along.
+	require.Error(t, cardmsg.ValidateInputs(envelope, map[string]interface{}{
+		"totally_undeclared": "x",
+	}))
+}
+
 func TestBuildDocsAccessRequestCardRejectsMissingRequestID(t *testing.T) {
 	_, err := BuildDocsAccessRequestCard(
 		localizedContext("en-US"),

--- a/scripts/cardpreview/main.go
+++ b/scripts/cardpreview/main.go
@@ -60,10 +60,50 @@ func main() {
 		},
 	))
 
+	docsAccessRequested := mustCard(cardtmpl.BuildDocsAccessRequestCard(
+		ctx, base, "d_20260716_q3", "DOC-REQ-025", "spc_xxx",
+		cardtmpl.DocsApprovalContent{
+			Title:        "2026 Q3 产品路线图",
+			Actor:        "李四",
+			ActorAvatar:  "https://cdn.example.com/avatar/lisi.png",
+			Timestamp:    "2026-07-16 11:15",
+			Reason:       "申请查看权限，用于对齐 Q3 交付节奏。",
+			Variant:      "docs.access_requested",
+			Source:       cardtmpl.Source{Label: "文档"},
+			HeaderLabel:  "文档申请",
+			StatusLabel:  "待你处理",
+			BannerSuffix: "申请成为此文档的查看者。",
+			RoleLabel:    "申请人",
+			ReasonLabel:  "申请原因",
+		},
+		cardtmpl.ApprovalActions{ApproveTitle: "允许", DenyTitle: "拒绝"},
+	))
+
+	docsAccessApproved := mustCard(cardtmpl.BuildDocsApprovalOutcomeCard(
+		ctx, base, "d_20260716_q3", "spc_xxx",
+		cardtmpl.DocsOutcomeContent{
+			Title: "2026 Q3 产品路线图", Variant: "docs.access_approved", Source: cardtmpl.Source{Label: "文档"},
+			Denied: false, HeaderLabel: "文档申请", StatusLabel: "已允许",
+			ResultText: "申请人已获得所申请的文档权限。",
+		},
+	))
+
+	docsAccessDenied := mustCard(cardtmpl.BuildDocsApprovalOutcomeCard(
+		ctx, base, "d_20260716_q3", "spc_xxx",
+		cardtmpl.DocsOutcomeContent{
+			Title: "2026 Q3 产品路线图", Variant: "docs.access_denied", Source: cardtmpl.Source{Label: "文档"},
+			Denied: true, HeaderLabel: "文档申请", StatusLabel: "已拒绝",
+			ResultText: "申请已被拒绝。", ReasonLabel: "拒绝原因", Reason: "当前版本范围未覆盖该文档，请对齐范围后再申请。",
+		},
+	))
+
 	out := map[string]json.RawMessage{
-		"summary_completed": summaryCompleted,
-		"summary_failed":    summaryFailed,
-		"docs_shared":       docsShared,
+		"summary_completed":     summaryCompleted,
+		"summary_failed":        summaryFailed,
+		"docs_shared":           docsShared,
+		"docs_access_requested": docsAccessRequested,
+		"docs_access_approved":  docsAccessApproved,
+		"docs_access_denied":    docsAccessDenied,
 	}
 	b, err := json.MarshalIndent(out, "", "  ")
 	if err != nil {


### PR DESCRIPTION
## Summary

Reworks the docs "access request" approval card (通知助手 → 文档申请权限卡) into a structured layout across its **pending** and **terminal** states, and adds a reviewer **deny-reason** channel. Clicking 拒绝 in the web client now opens a required-reason dialog; the reason rides to the docs backend through the existing card/action inputs path. Companion frontend PR in `octo-web` (same branch `claude/docs-permission-card-template-bccd8h`).

## Related Issue

_None — self-initiated._

## Linked Spec

`.octospec/tasks/docs-approval-card-enrich/brief.md` (journal: `.octospec/journal/shared/docs-approval-card-enrich.md`).

## Changes

- **`pkg/cardtmpl/docs_action.go`** — `BuildDocsAccessRequestCard` now builds the enriched AC 1.5 body from `DocsApprovalContent`: header row (source label + colored status), large title, bold-actor banner, requester `ColumnSet` (optional Person avatar + name/role + timestamp), an `emphasis` reason box, and a **hidden `Input.Text id="deny_reason"`** that declares the reason channel. New `BuildDocsApprovalOutcomeCard` builds the approved/denied terminal card (header + title + good/attention result box; denied surfaces the reviewer reason). All caller strings stay `escapeMarkdown`'d; images stay https-only.
- **`modules/notify/model.go`** — additive optional `DocsCardFields.actor_avatar_url` (https-validated; docs-backend owned).
- **`modules/notify/card.go`** — `buildDocsAccessRequestCard` maps the fields + new zh-CN/en-US labels (header/status/banner/role/reason/result).
- **`modules/notify/action_finalizer.go`** — `buildTerminalDocument` uses the enriched outcome card for approved/denied and threads `event.Inputs["deny_reason"]` onto the denied card; cancelled/unavailable keep the plain rebuild. view-details is a body `ActionSet`, not a root action, so the terminal card keeps carrying **no** decision buttons.
- **`scripts/cardpreview/main.go`** — emits the three new states for offline SDK preview.
- Review fix: requester row is skipped for anonymous requests (no actor).

**Cross-service note (please confirm on the docs-backend side):** the deny/approve action `data` now also carries `doc_title` and `actor` (display context the web dialog reads locally). Because the server re-extracts `data` from the stored frame, these two keys now appear in the `DecisionRequest.Data` payload POSTed to the docs backend. They are safe to ignore, but a strict/closed-schema consumer must allowlist them.

## Testing

Commands run (all green):

```
go test ./pkg/cardtmpl/...
go test ./modules/notify/ -run 'TestDocsActionFinalizer|TestBuildDocsAccessRequestCard|TestDeliverDocsAccessRequest|TestDocsOutcomeCards'
golangci-lint run ./pkg/cardtmpl/... ./modules/notify/...
make i18n-extract-check && make i18n-lint
go build ./...
```

New tests: enriched layout + declared `deny_reason` input, `ValidateInputs` accepts `inputs[deny_reason]` and fail-closes on undeclared keys, https-only avatar, markdown escaping of caller text, terminal approved/denied + reason threading. The enriched + terminal cards were also rendered with the real `adaptivecards@3.0.6` SDK + octo HostConfig to verify visuals.

> Note: the full `./modules/notify/...` suite additionally contains DB-backed integration tests (`space_welcome_integration_test.go` → `testutil.NewTestServer`) that require MySQL/Redis/WuKongIM and were not run in the authoring sandbox; CI runs them with infra.

- [x] Unit tests added/updated
- [x] Manually verified (real-SDK render preview)

## COMPREHENSION

1. **What does this change actually do to the load-bearing path?** It changes the AC document produced for `DocsCardKindAccessRequested` (behind `OCTO_DOCS_APPROVAL_CARD_ENABLED`) and the finalizer's terminal rebuild. The new load-bearing seam is the deny-reason channel: the card declares a hidden `deny_reason` `Input.Text`, so `cardmsg.ValidateInputs` accepts a submitted `inputs[deny_reason]` (and still fail-closes on undeclared keys); the value flows `Event.Inputs → DecisionRequest.Inputs` to the docs backend and is read back by the finalizer onto the denied terminal card.

2. **What could break (dependents + failure mode)?** (a) Old approval cards already delivered (before this deploy) have no `deny_reason` input — the companion web PR guards the dialog behind `card.getAllInputs()` containing the id, so old cards fall back to direct submit. (b) The docs backend receives two new keys in `DecisionRequest.Data` (see cross-service note) — a closed-schema consumer could reject. (c) Enriched elements must pass both the server (`pkg/cardmsg`) and client (`validateCardForOcto`) whitelists — verified they do; images must be https on both sides, hence the https-validated avatar field. Deploy server before web so new cards carry the input first.

3. **How do you know it works?** `TestDocsAccessRequestCardDenyReasonSubmitContract` asserts `ValidateInputs` accepts the declared `deny_reason` and rejects undeclared keys; `TestDocsActionFinalizerEnrichedTerminalAndDenyReason` asserts the reason threads onto the denied terminal card; `cardmsg.Validate` (octo/v2) passes on every generated card in the tests; and the cards were rendered with the production `adaptivecards` SDK to confirm the layout.

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] PR description is in English
- [x] Added tests for my changes
- [x] Updated documentation (octospec brief/journal/log)
- [x] Followed commit message conventions (Conventional Commits)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ATmYMWdTCLZMHKfHC2xt6j

---
_Generated by [Claude Code](https://claude.ai/code/session_01ATmYMWdTCLZMHKfHC2xt6j)_