### PR TITLE
refactor(notify): single plain-text Space welcome message (drop bilingual split)

### DIFF
--- a/.octospec/tasks/space-new-user-welcome-message/brief.md
+++ b/.octospec/tasks/space-new-user-welcome-message/brief.md
@@ -119,24 +119,26 @@ metrics + logs for operator handling.
   - `onboarding.space_welcome_enabled` (bool, default false)
   - `onboarding.space_welcome_space_id` (string)
   - `onboarding.space_welcome_active_from` (UTC RFC3339 string)
-  - `onboarding.space_welcome_message_zh_cn` (string, trimmed non-empty,
-    ≤ 2000 Unicode code points)
-  - `onboarding.space_welcome_message_en_us` (same rule)
+  - `onboarding.space_welcome_message` (string, trimmed non-empty,
+    ≤ 2000 Unicode code points; single plain-text body sent to every
+    recipient — no per-language split; newlines preserved verbatim, no
+    markdown rendering. Superseded the earlier `_message_zh_cn` /
+    `_message_en_us` bilingual pair in PR #606.)
   - **Snapshot accessor** — `modules/common` must expose a single
-    `SpaceWelcomeConfig()` returning a struct with all five fields read from
+    `SpaceWelcomeConfig()` returning a struct with all four fields read from
     the **same** `SystemSettings` snapshot in one atomic access. Callers
     (event handler, worker, reconciler, manager write path) must not read
-    the five keys individually; splitting the reads risks straddling a
+    the four keys individually; splitting the reads risks straddling a
     background `Reload()` and using an inconsistent combination.
-- **Configuration validation** — When enabling, all five keys must form a
-  **valid combination**: Space exists and is active, time parses, both message
-  bodies non-empty within the length limit.
+- **Configuration validation** — When enabling, all four keys must form a
+  **valid combination**: Space exists and is active, time parses, and the
+  message body is non-empty within the length limit.
   - **Manager write path uses prospective validation** — the write endpoint
     must NOT validate the current `SpaceWelcomeConfig()` snapshot; it must
     construct `prospective = merge(current snapshot, incoming items)` and
     validate that composite. Rationale: partial updates (e.g. changing only
-    `space_id` while leaving message bodies unchanged) must pass if the
-    resulting five-tuple is valid, and must fail if any incoming field
+    `space_id` while leaving the message unchanged) must pass if the
+    resulting composite is valid, and must fail if any incoming field
     breaks the composite — using the pre-write snapshot alone gets both
     directions wrong. Validate first, then commit the items in one
     transaction, then trigger `SystemSettings.Reload()` on the handling
@@ -406,7 +408,7 @@ metrics + logs for operator handling.
   directly to the DB fail closed at the worker/reconciler and increment
   `config_invalid_total`.
 - **Prospective validation**: a partial update touching only a subset of
-  the five keys is accepted iff `merge(current snapshot, incoming items)`
+  the four keys is accepted iff `merge(current snapshot, incoming items)`
   is a valid combination. A test where the current snapshot is valid, the
   incoming patch alone would look valid, but the merge is invalid, is
   rejected; and vice versa (invalid snapshot + valid patch that repairs
@@ -528,7 +530,7 @@ metrics + logs for operator handling.
   - `go test -race ./...`
   - `git diff --check`
 - **Rollout**: land migration + deploy with `enabled=false` → write target
-  `space_id`, UTC `active_from`, and zh/en message bodies → verify with two
+  `space_id`, UTC `active_from`, and the welcome message body → verify with two
   fresh test accounts that the DM, red dot, copy, ledger row (`status=3`),
   and metrics are correct → flip the switch. On incident, flip the switch
   off first; retain the ledger and migration for audit and recovery.

--- a/modules/common/api_manager_system_setting.go
+++ b/modules/common/api_manager_system_setting.go
@@ -315,11 +315,8 @@ func (m *Manager) updateSystemSettings(c *wkhttp.Context) {
 		if v, ok := welcomeIncoming["space_welcome_active_from"]; ok {
 			prospective.ActiveFromRaw = v
 		}
-		if v, ok := welcomeIncoming["space_welcome_message_zh_cn"]; ok {
-			prospective.MessageZhCN = v
-		}
-		if v, ok := welcomeIncoming["space_welcome_message_en_us"]; ok {
-			prospective.MessageEnUS = v
+		if v, ok := welcomeIncoming["space_welcome_message"]; ok {
+			prospective.Message = v
 		}
 		field, verr := ValidateSpaceWelcomeCombination(prospective, func(spaceID string) (bool, error) {
 			// GetSpaceName returns "" (no error) when the space is missing or

--- a/modules/common/api_manager_system_setting.go
+++ b/modules/common/api_manager_system_setting.go
@@ -290,7 +290,7 @@ func (m *Manager) updateSystemSettings(c *wkhttp.Context) {
 	}
 
 	// Prospective composite validation for the onboarding space-welcome
-	// five-tuple (task space-new-user-welcome-message). A partial update
+	// config (task space-new-user-welcome-message). A partial update
 	// (e.g. changing only space_id) must be validated against
 	// merge(current snapshot, incoming items), NOT the pre-write snapshot
 	// alone: validating the current snapshot would wrongly accept a patch that

--- a/modules/common/space_welcome_config_test.go
+++ b/modules/common/space_welcome_config_test.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -8,8 +9,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// snapshotFor builds a NoInfra SystemSettings whose snapshot holds exactly the
-// given onboarding.* keys.
+// welcomeSnapshot builds a NoInfra SystemSettings whose snapshot holds exactly
+// the given onboarding.* keys.
 func welcomeSnapshot(t *testing.T, kv map[string]string) *SystemSettings {
 	t.Helper()
 	s := &SystemSettings{}
@@ -23,22 +24,20 @@ func welcomeSnapshot(t *testing.T, kv map[string]string) *SystemSettings {
 
 func validWelcomeKV() map[string]string {
 	return map[string]string{
-		"space_welcome_enabled":       "1",
-		"space_welcome_space_id":      "spc_x",
-		"space_welcome_active_from":   "2026-07-16T00:00:00Z",
-		"space_welcome_message_zh_cn": "欢迎加入",
-		"space_welcome_message_en_us": "Welcome aboard",
+		"space_welcome_enabled":     "1",
+		"space_welcome_space_id":    "spc_x",
+		"space_welcome_active_from": "2026-07-16T00:00:00Z",
+		"space_welcome_message":     "欢迎加入",
 	}
 }
 
-func TestSpaceWelcomeConfig_ReadsAllFiveKeys(t *testing.T) {
+func TestSpaceWelcomeConfig_ReadsAllKeys(t *testing.T) {
 	s := welcomeSnapshot(t, validWelcomeKV())
 	cfg := s.SpaceWelcomeConfig()
 	assert.True(t, cfg.Enabled)
 	assert.Equal(t, "spc_x", cfg.SpaceID)
 	assert.Equal(t, "2026-07-16T00:00:00Z", cfg.ActiveFromRaw)
-	assert.Equal(t, "欢迎加入", cfg.MessageZhCN)
-	assert.Equal(t, "Welcome aboard", cfg.MessageEnUS)
+	assert.Equal(t, "欢迎加入", cfg.Message)
 
 	at, ok := cfg.ParsedActiveFrom()
 	assert.True(t, ok)
@@ -50,29 +49,48 @@ func TestSpaceWelcomeConfig_Defaults(t *testing.T) {
 	cfg := s.SpaceWelcomeConfig()
 	assert.False(t, cfg.Enabled)
 	assert.Empty(t, cfg.SpaceID)
+	assert.Empty(t, cfg.Message)
 	_, ok := cfg.ParsedActiveFrom()
 	assert.False(t, ok)
 }
 
+// TestSpaceWelcomeConfig_MultilineMessagePreserved locks in that a plain-text
+// body with newlines is read back verbatim (no stripping/collapsing) and passes
+// validation — line breaks are the intended way to format the welcome.
+func TestSpaceWelcomeConfig_MultilineMessagePreserved(t *testing.T) {
+	body := "第一行\n第二行\n\nWelcome\nline 2"
+	s := welcomeSnapshot(t, map[string]string{
+		"space_welcome_enabled":     "1",
+		"space_welcome_space_id":    "spc_x",
+		"space_welcome_active_from": "2026-07-16T00:00:00Z",
+		"space_welcome_message":     body,
+	})
+	cfg := s.SpaceWelcomeConfig()
+	assert.Equal(t, body, cfg.Message, "internal newlines must be preserved verbatim")
+
+	field, err := ValidateSpaceWelcomeCombination(cfg, func(string) (bool, error) { return true, nil })
+	assert.NoError(t, err)
+	assert.Empty(t, field, "a multi-line body is valid (TrimSpace only strips leading/trailing)")
+	assert.Equal(t, 4, strings.Count(cfg.Message, "\n"), "all newlines retained")
+}
+
 // TestSpaceWelcomeConfig_SnapshotAtomicity swaps between two complete but
 // distinct tuples while a reader loops. Every read must return one whole tuple,
-// never a mix of the two — this is the property the single-snapshot accessor
-// guarantees. Run under -race.
+// never a mix of the two — the property the single-snapshot accessor guarantees.
+// Run under -race.
 func TestSpaceWelcomeConfig_SnapshotAtomicity(t *testing.T) {
 	s := &SystemSettings{}
 	tupleA := map[string]string{
-		"onboarding.space_welcome_enabled":       "1",
-		"onboarding.space_welcome_space_id":      "spc_a",
-		"onboarding.space_welcome_active_from":   "2026-01-01T00:00:00Z",
-		"onboarding.space_welcome_message_zh_cn": "A-zh",
-		"onboarding.space_welcome_message_en_us": "A-en",
+		"onboarding.space_welcome_enabled":     "1",
+		"onboarding.space_welcome_space_id":    "spc_a",
+		"onboarding.space_welcome_active_from": "2026-01-01T00:00:00Z",
+		"onboarding.space_welcome_message":     "A-msg",
 	}
 	tupleB := map[string]string{
-		"onboarding.space_welcome_enabled":       "1",
-		"onboarding.space_welcome_space_id":      "spc_b",
-		"onboarding.space_welcome_active_from":   "2026-02-02T00:00:00Z",
-		"onboarding.space_welcome_message_zh_cn": "B-zh",
-		"onboarding.space_welcome_message_en_us": "B-en",
+		"onboarding.space_welcome_enabled":     "1",
+		"onboarding.space_welcome_space_id":    "spc_b",
+		"onboarding.space_welcome_active_from": "2026-02-02T00:00:00Z",
+		"onboarding.space_welcome_message":     "B-msg",
 	}
 	s.snapshot.Store(&tupleA)
 
@@ -101,12 +119,10 @@ func TestSpaceWelcomeConfig_SnapshotAtomicity(t *testing.T) {
 		cfg := s.SpaceWelcomeConfig()
 		switch cfg.SpaceID {
 		case "spc_a":
-			assert.Equal(t, "A-zh", cfg.MessageZhCN)
-			assert.Equal(t, "A-en", cfg.MessageEnUS)
+			assert.Equal(t, "A-msg", cfg.Message)
 			assert.Equal(t, "2026-01-01T00:00:00Z", cfg.ActiveFromRaw)
 		case "spc_b":
-			assert.Equal(t, "B-zh", cfg.MessageZhCN)
-			assert.Equal(t, "B-en", cfg.MessageEnUS)
+			assert.Equal(t, "B-msg", cfg.Message)
 			assert.Equal(t, "2026-02-02T00:00:00Z", cfg.ActiveFromRaw)
 		default:
 			t.Fatalf("torn read: space_id=%q", cfg.SpaceID)
@@ -133,9 +149,8 @@ func TestValidateSpaceWelcomeCombination(t *testing.T) {
 		{"valid", nil, activeSpace, ""},
 		{"missing space_id", func(c *SpaceWelcomeConfig) { c.SpaceID = "  " }, activeSpace, "space_welcome_space_id"},
 		{"bad time", func(c *SpaceWelcomeConfig) { c.ActiveFromRaw = "not-a-time" }, activeSpace, "space_welcome_active_from"},
-		{"empty zh", func(c *SpaceWelcomeConfig) { c.MessageZhCN = "   " }, activeSpace, "space_welcome_message_zh_cn"},
-		{"empty en", func(c *SpaceWelcomeConfig) { c.MessageEnUS = "" }, activeSpace, "space_welcome_message_en_us"},
-		{"oversize zh", func(c *SpaceWelcomeConfig) { c.MessageZhCN = string(longMsg) }, activeSpace, "space_welcome_message_zh_cn"},
+		{"empty message", func(c *SpaceWelcomeConfig) { c.Message = "   " }, activeSpace, "space_welcome_message"},
+		{"oversize message", func(c *SpaceWelcomeConfig) { c.Message = string(longMsg) }, activeSpace, "space_welcome_message"},
 		{"space not active", nil, func(string) (bool, error) { return false, nil }, "space_welcome_space_id"},
 	}
 	for _, tc := range cases {
@@ -144,8 +159,7 @@ func TestValidateSpaceWelcomeCombination(t *testing.T) {
 				Enabled:       true,
 				SpaceID:       "spc_x",
 				ActiveFromRaw: "2026-07-16T00:00:00Z",
-				MessageZhCN:   "欢迎",
-				MessageEnUS:   "Welcome",
+				Message:       "欢迎",
 			}
 			if tc.mutate != nil {
 				tc.mutate(&cfg)
@@ -159,8 +173,7 @@ func TestValidateSpaceWelcomeCombination(t *testing.T) {
 
 func TestValidateSpaceWelcomeCombination_SpaceCheckError(t *testing.T) {
 	cfg := SpaceWelcomeConfig{
-		Enabled: true, SpaceID: "spc_x", ActiveFromRaw: "2026-07-16T00:00:00Z",
-		MessageZhCN: "欢迎", MessageEnUS: "Welcome",
+		Enabled: true, SpaceID: "spc_x", ActiveFromRaw: "2026-07-16T00:00:00Z", Message: "欢迎",
 	}
 	_, err := ValidateSpaceWelcomeCombination(cfg, func(string) (bool, error) {
 		return false, assert.AnError
@@ -175,22 +188,20 @@ func TestValidateSpaceWelcomeCombination_Prospective(t *testing.T) {
 	activeSpace := func(string) (bool, error) { return true, nil }
 
 	// (1) Valid current snapshot; a patch that alone looks fine but whose merge
-	// is invalid (blanks the zh message) must be rejected.
+	// is invalid (blanks the message) must be rejected.
 	current := SpaceWelcomeConfig{
-		Enabled: true, SpaceID: "spc_x", ActiveFromRaw: "2026-07-16T00:00:00Z",
-		MessageZhCN: "欢迎", MessageEnUS: "Welcome",
+		Enabled: true, SpaceID: "spc_x", ActiveFromRaw: "2026-07-16T00:00:00Z", Message: "欢迎",
 	}
 	merged := current
-	merged.MessageZhCN = "" // incoming patch clears zh
+	merged.Message = "" // incoming patch clears the message
 	field, err := ValidateSpaceWelcomeCombination(merged, activeSpace)
 	assert.NoError(t, err)
-	assert.Equal(t, "space_welcome_message_zh_cn", field, "merge that breaks the composite must be rejected")
+	assert.Equal(t, "space_welcome_message", field, "merge that breaks the composite must be rejected")
 
 	// (2) Invalid current snapshot (enabled but no space_id); a patch that adds a
 	// valid space_id repairs the composite and must be accepted.
 	broken := SpaceWelcomeConfig{
-		Enabled: true, SpaceID: "", ActiveFromRaw: "2026-07-16T00:00:00Z",
-		MessageZhCN: "欢迎", MessageEnUS: "Welcome",
+		Enabled: true, SpaceID: "", ActiveFromRaw: "2026-07-16T00:00:00Z", Message: "欢迎",
 	}
 	repaired := broken
 	repaired.SpaceID = "spc_x" // incoming patch supplies the space

--- a/modules/common/system_setting_schema.go
+++ b/modules/common/system_setting_schema.go
@@ -202,22 +202,22 @@ var systemSettingSchema = []settingDef{
 		Effective: func(s *SystemSettings) string { return strconv.Itoa(s.StickerCompressMaxDimension()) }},
 
 	// Space 新成员欢迎语（onboarding.space_welcome_*）— task
-	// space-new-user-welcome-message。这五个键必须构成一致的「启用组合」：
+	// space-new-user-welcome-message。这四个键必须构成一致的「启用组合」：
 	// enabled=true 时，space_id 必须指向存在且未解散的 Space，active_from 可按
-	// RFC3339(UTC) 解析，中英文文案 trim 后非空且 ≤2000 code points。写侧做
+	// RFC3339(UTC) 解析，message trim 后非空且 ≤2000 code points。写侧做
 	// prospective 组合校验（merge 快照+入参），worker/reconciler 每周期再校验一次
-	// fail-closed。调用方读取一律走 SpaceWelcomeConfig()（单快照原子读五键），
+	// fail-closed。调用方读取一律走 SpaceWelcomeConfig()（单快照原子读四键），
 	// 不要逐键读，避免跨 Reload() 拼出不一致组合。默认关闭，随快照 60s 内多实例收敛。
-	{Category: "onboarding", Key: "space_welcome_enabled", Type: settingTypeBool, Description: "是否开启「新成员加入指定 Space 时由通知助手发送一条欢迎语 DM」（默认关闭；启用需 space_id/active_from/中英文文案构成有效组合）",
+	// 文案是「所有人同一份纯文本」，不区分语言；支持换行（\n 原样保留、客户端 type:1
+	// 文本渲染换行），不渲染 markdown。
+	{Category: "onboarding", Key: "space_welcome_enabled", Type: settingTypeBool, Description: "是否开启「新成员加入指定 Space 时由通知助手发送一条欢迎语 DM」（默认关闭；启用需 space_id/active_from/message 构成有效组合）",
 		Effective: func(s *SystemSettings) string { return boolToCanonical(s.SpaceWelcomeConfig().Enabled) }},
 	{Category: "onboarding", Key: "space_welcome_space_id", Type: settingTypeString, Description: "欢迎语目标 Space 的 space_id（必须存在且未解散）",
 		Effective: func(s *SystemSettings) string { return s.SpaceWelcomeConfig().SpaceID }},
 	{Category: "onboarding", Key: "space_welcome_active_from", Type: settingTypeString, Description: "欢迎语生效起点（RFC3339 UTC，如 2026-07-16T00:00:00Z）；仅 created_at>=此刻首次加入的成员会收到",
 		Effective: func(s *SystemSettings) string { return s.SpaceWelcomeConfig().ActiveFromRaw }},
-	{Category: "onboarding", Key: "space_welcome_message_zh_cn", Type: settingTypeString, Description: "欢迎语中文文案（纯文本，trim 后非空，≤2000 字符）",
-		Effective: func(s *SystemSettings) string { return s.SpaceWelcomeConfig().MessageZhCN }},
-	{Category: "onboarding", Key: "space_welcome_message_en_us", Type: settingTypeString, Description: "欢迎语英文文案（纯文本，trim 后非空，≤2000 字符）",
-		Effective: func(s *SystemSettings) string { return s.SpaceWelcomeConfig().MessageEnUS }},
+	{Category: "onboarding", Key: "space_welcome_message", Type: settingTypeString, Description: "欢迎语文案（纯文本，所有人同一份，trim 后非空，≤2000 字符；支持换行 \\n，不渲染 markdown）",
+		Effective: func(s *SystemSettings) string { return s.SpaceWelcomeConfig().Message }},
 
 	// Email server config — formerly yaml-only (Support.* in config.go).
 	{Category: "support", Key: "email", Type: settingTypeString, Description: "技术支持邮箱（发件人）",

--- a/modules/common/system_settings.go
+++ b/modules/common/system_settings.go
@@ -1040,31 +1040,33 @@ func (s *SystemSettings) StickerCompressMaxDimension() int {
 // ---------------------------------------------------------------------------
 
 const (
-	// spaceWelcomeCategory is the system_setting category for the five
-	// onboarding welcome keys.
+	// spaceWelcomeCategory is the system_setting category for the onboarding
+	// welcome keys.
 	spaceWelcomeCategory = "onboarding"
-	// spaceWelcomeMessageMaxRunes bounds each localized welcome body in Unicode
-	// code points (validated on the manager write path and re-validated at
-	// runtime).
+	// spaceWelcomeMessageMaxRunes bounds the welcome body in Unicode code points
+	// (validated on the manager write path and re-validated at runtime).
 	spaceWelcomeMessageMaxRunes = 2000
 )
 
-// SpaceWelcomeConfig is an atomic, point-in-time view of the five
-// onboarding.space_welcome_* settings. All five fields are read from the SAME
+// SpaceWelcomeConfig is an atomic, point-in-time view of the four
+// onboarding.space_welcome_* settings. All fields are read from the SAME
 // SystemSettings snapshot in one access, so a caller can never straddle a
 // background Reload() and combine values from two different snapshots. The
 // event handler, send worker, reconciler and the manager write path all rely
 // on this atomicity — reading the keys individually would risk an inconsistent
-// five-tuple.
+// combination.
+//
+// Message is a single plain-text body sent to every recipient (no per-language
+// split); it may contain line breaks (\n preserved verbatim; clients render
+// type:1 text with newlines) but no markdown.
 type SpaceWelcomeConfig struct {
 	Enabled       bool
 	SpaceID       string
 	ActiveFromRaw string
-	MessageZhCN   string
-	MessageEnUS   string
+	Message       string
 }
 
-// SpaceWelcomeConfig returns the current five-tuple, all read from one snapshot.
+// SpaceWelcomeConfig returns the current tuple, all read from one snapshot.
 func (s *SystemSettings) SpaceWelcomeConfig() SpaceWelcomeConfig {
 	snapPtr := s.snapshot.Load()
 	get := func(key string) string {
@@ -1077,8 +1079,7 @@ func (s *SystemSettings) SpaceWelcomeConfig() SpaceWelcomeConfig {
 		Enabled:       parseSettingBool(get("space_welcome_enabled"), false),
 		SpaceID:       get("space_welcome_space_id"),
 		ActiveFromRaw: get("space_welcome_active_from"),
-		MessageZhCN:   get("space_welcome_message_zh_cn"),
-		MessageEnUS:   get("space_welcome_message_en_us"),
+		Message:       get("space_welcome_message"),
 	}
 }
 
@@ -1096,8 +1097,9 @@ func (c SpaceWelcomeConfig) ParsedActiveFrom() (time.Time, bool) {
 	return t.UTC(), true
 }
 
-// validWelcomeMessage reports whether a localized body is non-empty after trim
-// and within the code-point limit.
+// validWelcomeMessage reports whether the body is non-empty after trim and
+// within the code-point limit. Internal newlines are preserved (TrimSpace only
+// strips leading/trailing whitespace), so multi-line plain-text bodies pass.
 func validWelcomeMessage(msg string) bool {
 	if strings.TrimSpace(msg) == "" {
 		return false
@@ -1105,14 +1107,13 @@ func validWelcomeMessage(msg string) bool {
 	return utf8.RuneCountInString(msg) <= spaceWelcomeMessageMaxRunes
 }
 
-// ValidateSpaceWelcomeCombination validates the five-tuple as a coherent
-// combination.
+// ValidateSpaceWelcomeCombination validates the tuple as a coherent combination.
 //
 //   - When disabled it always passes: a partial or empty config is fine while
 //     the feature is off.
 //   - When enabled it requires a non-empty space_id that isActiveSpace confirms
-//     exists and is not dissolved, a parseable RFC3339 active_from, and both
-//     message bodies non-empty (after trim) within spaceWelcomeMessageMaxRunes.
+//     exists and is not dissolved, a parseable RFC3339 active_from, and a
+//     message non-empty (after trim) within spaceWelcomeMessageMaxRunes.
 //
 // The (field, err) contract lets the caller distinguish a validation failure
 // (err == nil, field != "" naming the first offending key) from an
@@ -1129,11 +1130,8 @@ func ValidateSpaceWelcomeCombination(cfg SpaceWelcomeConfig, isActiveSpace func(
 	if _, ok := cfg.ParsedActiveFrom(); !ok {
 		return "space_welcome_active_from", nil
 	}
-	if !validWelcomeMessage(cfg.MessageZhCN) {
-		return "space_welcome_message_zh_cn", nil
-	}
-	if !validWelcomeMessage(cfg.MessageEnUS) {
-		return "space_welcome_message_en_us", nil
+	if !validWelcomeMessage(cfg.Message) {
+		return "space_welcome_message", nil
 	}
 	if isActiveSpace != nil {
 		active, checkErr := isActiveSpace(cfg.SpaceID)

--- a/modules/notify/api.go
+++ b/modules/notify/api.go
@@ -145,17 +145,12 @@ func New(ctx *config.Context) *Notify {
 	// 监听成员加入事件
 	ctx.AddEventListener(event.SpaceMemberJoin, n.handleSpaceMemberEvent)
 
-	// Space 新成员欢迎语（task space-new-user-welcome-message）。langSvc 在无缓存
-	// 的测试环境下为 nil，resolveLanguage 会回退到 OCTO_DEFAULT_LANGUAGE。服务对象
-	// 在此构造，reconciler/worker goroutine 由模块 Start() 启动、Stop() 停止。
-	var langSvc *user.LanguageService
-	if ctx.Cache() != nil {
-		langSvc = user.NewLanguageService(user.NewDB(ctx), ctx.Cache())
-	}
+	// Space 新成员欢迎语（task space-new-user-welcome-message）。欢迎语是所有人
+	// 同一份纯文本（不区分语言）。服务对象在此构造，reconciler/worker goroutine
+	// 由模块 Start() 启动、Stop() 停止。
 	n.spaceWelcome = newSpaceWelcomeService(
 		ctx,
 		common.EnsureSystemSettings(ctx),
-		langSvc,
 		NotifyBotUID(),
 		func() bool {
 			n.ensureNotifyBotReady()

--- a/modules/notify/space_welcome.go
+++ b/modules/notify/space_welcome.go
@@ -5,15 +5,12 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"strings"
 	"sync"
 	"time"
 
 	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
 	"github.com/Mininglamp-OSS/octo-server/modules/common"
-	"github.com/Mininglamp-OSS/octo-server/modules/user"
-	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
 	spacepkg "github.com/Mininglamp-OSS/octo-server/pkg/space"
 	"go.uber.org/zap"
 )
@@ -28,8 +25,9 @@ import (
 //   - the low-latency event path (handleMemberJoin) upserts a pending row;
 //   - the reconciler catches dropped events / restarts / the addMembers path;
 //   - the send worker claims pending rows, re-checks eligibility, and delivers.
-
-const langResolveTimeout = 2 * time.Second
+//
+// The welcome body is a single plain-text message for all recipients (no
+// per-language routing).
 
 // swBotReadyTimeout caps the (context-less) bot-readiness probe so a hung
 // WuKongIM / DB dependency cannot wedge the single worker goroutine or Stop().
@@ -59,7 +57,6 @@ type spaceWelcomeService struct {
 	ctx      *config.Context
 	store    *spaceWelcomeStore
 	settings *common.SystemSettings
-	langSvc  *user.LanguageService
 	metrics  *spaceWelcomeMetrics
 	fromUID  string
 	// sendFn delivers one personal DM. Defaults to the notify-local
@@ -78,14 +75,13 @@ type spaceWelcomeService struct {
 	log.Log
 }
 
-func newSpaceWelcomeService(ctx *config.Context, settings *common.SystemSettings, langSvc *user.LanguageService, fromUID string, botReady func() bool) *spaceWelcomeService {
+func newSpaceWelcomeService(ctx *config.Context, settings *common.SystemSettings, fromUID string, botReady func() bool) *spaceWelcomeService {
 	owner := claimOwnerID()
 	sender := newSpaceWelcomeSender(ctx)
 	return &spaceWelcomeService{
 		ctx:      ctx,
 		store:    newSpaceWelcomeStore(ctx.DB(), owner),
 		settings: settings,
-		langSvc:  langSvc,
 		metrics:  newSpaceWelcomeMetrics(),
 		fromUID:  fromUID,
 		sendFn:   sender.send,
@@ -390,16 +386,10 @@ func (s *spaceWelcomeService) dispatch(ctx context.Context, cfg common.SpaceWelc
 		return
 	}
 
-	// Language resolution is bounded the same way: the 2s context inside
-	// resolveLanguage may not interrupt a hung cache/DB, so cap the whole call
-	// and fall back to the default language on timeout (never a retryable error).
-	lang, langOK := callWithTimeout(langResolveTimeout+time.Second, func() string { return s.resolveLanguage(row.UID) })
-	if !langOK {
-		lang = i18n.OutboundLanguage(context.Background())
-	}
-
 	dsCtx, cancel := context.WithTimeout(ctx, swDBCallTimeout)
-	ok, err := s.store.casToDispatching(dsCtx, row.ID, lang, s.now())
+	// lang is recorded empty: the welcome body is a single language-agnostic
+	// plain-text message, so there is no per-recipient language to resolve.
+	ok, err := s.store.casToDispatching(dsCtx, row.ID, "", s.now())
 	cancel()
 	if err != nil {
 		s.Warn("welcome cas to dispatching failed", zap.String("stage", swStageDispatch), zap.Int64("delivery_id", row.ID), zap.Error(err))
@@ -414,8 +404,9 @@ func (s *spaceWelcomeService) dispatch(ctx context.Context, cfg common.SpaceWelc
 	}
 
 	// Build the personal DM. NewPersonalMsgSendReq is authoritative for
-	// payload.space_id; red_dot=1; payload.type=Text plain body.
-	payload := map[string]interface{}{"type": 1, "content": s.messageForLang(cfg, lang)}
+	// payload.space_id; red_dot=1; payload.type=Text plain body (single message
+	// for all recipients; newlines preserved verbatim, no markdown rendering).
+	payload := map[string]interface{}{"type": 1, "content": cfg.Message}
 	req := config.NewPersonalMsgSendReq(row.UID, s.fromUID, payload, cfg.SpaceID,
 		config.PersonalMsgOptions{Header: config.MsgHeader{RedDot: 1}})
 
@@ -453,7 +444,7 @@ func (s *spaceWelcomeService) dispatch(ctx context.Context, cfg common.SpaceWelc
 	}
 	s.metrics.incSendSuccess()
 	s.Info("welcome delivered", zap.String("stage", swStagePersist), zap.Int64("delivery_id", row.ID),
-		zap.String("space_id", cfg.SpaceID), zap.String("uid", row.UID), zap.String("lang", lang))
+		zap.String("space_id", cfg.SpaceID), zap.String("uid", row.UID))
 }
 
 // preIMFailure records a definitive pre-IM failure (the only place attempts
@@ -519,29 +510,6 @@ func (s *spaceWelcomeService) validateRuntime(ctx context.Context, cfg common.Sp
 		return false
 	}
 	return true
-}
-
-// resolveLanguage resolves the recipient's outbound language (zh-CN/en-US). On
-// any lookup failure or unset preference it falls back to OCTO_DEFAULT_LANGUAGE
-// — language lookup is never a retryable error.
-func (s *spaceWelcomeService) resolveLanguage(uid string) string {
-	if s.langSvc != nil {
-		rctx, cancel := context.WithTimeout(context.Background(), langResolveTimeout)
-		lang, err := s.langSvc.Resolve(rctx, uid)
-		cancel()
-		if err == nil && lang != "" {
-			return lang
-		}
-	}
-	return i18n.OutboundLanguage(context.Background())
-}
-
-// messageForLang picks the localized body. zh-* → zh copy, otherwise en copy.
-func (s *spaceWelcomeService) messageForLang(cfg common.SpaceWelcomeConfig, lang string) string {
-	if strings.HasPrefix(strings.ToLower(lang), "zh") {
-		return cfg.MessageZhCN
-	}
-	return cfg.MessageEnUS
 }
 
 // safeRun runs fn with panic recovery so one bad cycle cannot kill the loop.

--- a/modules/notify/space_welcome_integration_test.go
+++ b/modules/notify/space_welcome_integration_test.go
@@ -440,16 +440,15 @@ func swSetConfig(t *testing.T, ctx *config.Context, settings *common.SystemSetti
 
 func swEnabledConfig(spaceID string, activeFrom time.Time) map[string]string {
 	return map[string]string{
-		"space_welcome_enabled":       "1",
-		"space_welcome_space_id":      spaceID,
-		"space_welcome_active_from":   activeFrom.UTC().Format(time.RFC3339),
-		"space_welcome_message_zh_cn": "欢迎加入本空间",
-		"space_welcome_message_en_us": "Welcome to the space",
+		"space_welcome_enabled":     "1",
+		"space_welcome_space_id":    spaceID,
+		"space_welcome_active_from": activeFrom.UTC().Format(time.RFC3339),
+		"space_welcome_message":     "欢迎加入本空间\n有问题随时找我",
 	}
 }
 
 func swNewService(ctx *config.Context, settings *common.SystemSettings) *spaceWelcomeService {
-	svc := newSpaceWelcomeService(ctx, settings, nil, NotifyBotUID(), func() bool { return true })
+	svc := newSpaceWelcomeService(ctx, settings, NotifyBotUID(), func() bool { return true })
 	return svc
 }
 
@@ -480,6 +479,9 @@ func TestService_Dispatch_Success(t *testing.T) {
 	require.NotNil(t, gotReq)
 	assert.Equal(t, "notification", gotReq.FromUID)
 	assert.EqualValues(t, 1, gotReq.Header.RedDot)
+	// Single plain-text body sent verbatim, newlines preserved (type:1 content).
+	assert.Contains(t, string(gotReq.Payload), "欢迎加入本空间\\n有问题随时找我",
+		"the configured single message (with newline) must be sent verbatim")
 }
 
 func TestService_Dispatch_Unknown(t *testing.T) {

--- a/modules/notify/space_welcome_unit_test.go
+++ b/modules/notify/space_welcome_unit_test.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/Mininglamp-OSS/octo-lib/config"
-	"github.com/Mininglamp-OSS/octo-server/modules/common"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -107,28 +106,10 @@ func TestSpaceWelcomeSender_ContextTimeoutIsTransportAmbiguous(t *testing.T) {
 	assert.Equal(t, swErrIMTimeout, se.class, "a timeout must classify as transport-ambiguous")
 }
 
-func TestMessageForLang(t *testing.T) {
-	svc := &spaceWelcomeService{}
-	cfg := common.SpaceWelcomeConfig{MessageZhCN: "中文", MessageEnUS: "english"}
-	assert.Equal(t, "中文", svc.messageForLang(cfg, "zh-CN"))
-	assert.Equal(t, "中文", svc.messageForLang(cfg, "zh-Hans"))
-	assert.Equal(t, "english", svc.messageForLang(cfg, "en-US"))
-	assert.Equal(t, "english", svc.messageForLang(cfg, ""))
-	assert.Equal(t, "english", svc.messageForLang(cfg, "fr-FR"))
-}
-
 func TestClaimOwnerID(t *testing.T) {
 	owner := claimOwnerID()
 	assert.Contains(t, owner, ":", "owner must be <hostname>:<pid>")
 	assert.NotEqual(t, ":", owner)
-}
-
-func TestResolveLanguage_FallbackWhenNoService(t *testing.T) {
-	// langSvc == nil (no cache in this env) must fall back to the default
-	// outbound language, never empty, never an error/retry.
-	svc := &spaceWelcomeService{}
-	lang := svc.resolveLanguage("u_1")
-	assert.NotEmpty(t, lang, "must fall back to OCTO_DEFAULT_LANGUAGE, never empty")
 }
 
 func TestCallWithTimeout(t *testing.T) {

--- a/pkg/i18n/locales/active.zh-CN.toml
+++ b/pkg/i18n/locales/active.zh-CN.toml
@@ -43,7 +43,7 @@ other = "服务器内部错误。"
 other = "内部通知接口不允许发送卡片消息。"
 
 ["err.server.common.space_welcome_config_invalid"]
-other = "空间欢迎语配置无效，请检查目标空间是否存在且未解散、生效时间格式，以及中英文文案是否非空且未超长。"
+other = "空间欢迎语配置无效，请检查目标空间是否存在且未解散、生效时间格式，以及欢迎语文案是否非空且未超长。"
 
 ["err.server.notify.card_invalid"]
 other = "卡片通知请求无效。"


### PR DESCRIPTION
## Summary

Product follow-up to #604 (Space new-user welcome DM, shipped `enabled=false`).
The welcome message no longer distinguishes zh/en — **one plain-text body is
sent to every recipient**, and **line breaks are supported** (newlines preserved
verbatim; clients render `type:1` text with breaks; markdown is NOT rendered).

## Changes

- **Config**: replace the two keys `onboarding.space_welcome_message_zh_cn` /
  `space_welcome_message_en_us` with a single `onboarding.space_welcome_message`.
  `SpaceWelcomeConfig` now has one `Message` field; composite validation and the
  manager prospective-merge write path use the single key.
- **notify**: drop language resolution (`resolveLanguage` / `messageForLang` /
  the `langSvc` dependency and its bounded lookup); `dispatch` sends
  `cfg.Message` directly. The ledger `lang` column is written empty
  (language-agnostic) — no schema change.
- **i18n**: update the zh-CN copy for `err.server.common.space_welcome_config_invalid`
  (drop the 中英文 wording).
- No SQL migration: `system_setting` is a generic KV store, and the ledger
  `lang` column is unchanged.

## Line breaks
Already supported end-to-end: validation only `TrimSpace`s (internal `\n`
preserved), and the body is passed to `payload.content` verbatim. Admins format
with real newlines (plain text); `###` / `**` markdown does not render.

## Testing

- `go build ./...`, `go vet`, `make i18n-extract-check`, `make i18n-lint`,
  `git diff --check` — all clean.
- `go test -race` green for `modules/notify` and `modules/common` (fresh DB).
- New/updated tests: single-message config read / defaults / snapshot atomicity;
  single-message validation + prospective-merge both directions; **multi-line
  body preserved-and-valid**; dispatch sends the configured body (with newline)
  verbatim over the wire.

- [x] Unit tests added/updated
- [x] Manually verified via integration tests against real MySQL

## Note
Depends conceptually on #604 (already merged to `main`). Feature remains
`enabled=false`; production-enable gates (metrics/alerting + product sign-offs)
are unchanged and tracked separately.
