### PR TITLE
feat(messages_search): support octo-cli message search as bot / as-user (OBO)

### DIFF
--- a/modules/bot_api/bot_api.go
+++ b/modules/bot_api/bot_api.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-server/internal/carddispatch"
 	"github.com/Mininglamp-OSS/octo-server/modules/file"
 	"github.com/Mininglamp-OSS/octo-server/modules/group"
+	"github.com/Mininglamp-OSS/octo-server/modules/messages_search"
 	"github.com/Mininglamp-OSS/octo-server/modules/robot"
 	"github.com/Mininglamp-OSS/octo-server/modules/thread"
 	"github.com/Mininglamp-OSS/octo-server/modules/user"
@@ -137,6 +138,11 @@ type BotAPI struct {
 	// full user-service stack.
 	// nil in production → the real userService.IsFriend runs.
 	friendCheckOverride func(uid, toUID string) (bool, error)
+	// searchHandler 是共享的消息搜索 Handler（messages_search.Shared），bot 搜索路由
+	// /v1/bot/messages/_search* 复用它（YUJ-49 / #B）。与 web、uk 入口共用同一实例，
+	// 从而共享限流桶与 sender 缓存。principal 由本模块的 resolveSearchPrincipal 按
+	// on_behalf_of 区分 as-bot / as-user(OBO)。
+	searchHandler *messages_search.Handler
 	log.Log
 }
 
@@ -197,6 +203,7 @@ func NewBotAPI(ctx *config.Context) *BotAPI {
 		maxVoiceContextLength: maxCtxLen,
 		maxBodySize:           maxBodySize,
 		maxFileSize:           maxFileSize,
+		searchHandler:         messages_search.Shared(ctx),
 		Log:                   log.NewTLog("BotAPI"),
 	}
 	// YUJ-1166 / Mininglamp-OSS/octo-server#81 — Persona Clone fan-out.
@@ -287,6 +294,10 @@ func (ba *BotAPI) Route(r *wkhttp.WKHttp) {
 	// 群入站 Webhook 管理（bot token 面），与用户路由共用 incomingwebhook 实例与
 	// 权限矩阵（管理员 bot 同权人类管理员）。实现在 incoming_webhook.go。
 	ba.registerIncomingWebhookRoutes(r)
+
+	// 消息搜索（YUJ-49 / #B）：/v1/bot/messages/_search*，authBot 鉴权，principal 由
+	// on_behalf_of 区分 as-bot / as-user(OBO)。实现在 search_route.go。
+	ba.mountSearchRoutes(r)
 }
 
 // ==================== Helper Functions ====================

--- a/modules/bot_api/obo_check.go
+++ b/modules/bot_api/obo_check.go
@@ -211,6 +211,34 @@ func (ba *BotAPI) checkOBO(botUID, grantor, channelID string, channelType uint8)
 	return nil
 }
 
+// SearchOBOAllowed adapts checkOBO for the messages_search as-user(OBO) search
+// gate (YUJ-53 / search-as-user). It answers the same per-channel question as
+// the send path — "may grantee bot botUID read (channelID, channelType) as
+// grantor?" — reusing the identical grant + scope + grantorCanReadChannel
+// (TOCTOU) logic, so search authorization can never diverge from send.
+//
+// It exists so messages_search can consume the OBO decision through a narrow
+// (bool, error) seam WITHOUT importing bot_api's internals or the
+// ErrOBONotAuthorized sentinel: the "existence-hidden" outcome collapses to
+// (false, nil) while genuine infra failures propagate for fail-closed
+// handling.
+//
+// Return contract for the search layer:
+//   - (true,  nil) — authorized; search may proceed as grantor.
+//   - (false, nil) — ErrOBONotAuthorized: no active grant / scope disabled /
+//     grantor lost live channel access. The caller hides existence (NOT_FOUND).
+//   - (false, err) — infra error; the caller fails closed (INTERNAL_ERROR).
+func (ba *BotAPI) SearchOBOAllowed(botUID, grantorUID, channelID string, channelType uint8) (bool, error) {
+	err := ba.checkOBO(botUID, grantorUID, channelID, channelType)
+	if err == nil {
+		return true, nil
+	}
+	if errors.Is(err, ErrOBONotAuthorized) {
+		return false, nil
+	}
+	return false, err
+}
+
 // oboStoreOrDefault returns the test-injected oboStore if set, else the
 // production DB-backed one. Mirrors spaceQuerierOrDefault so the test seam
 // is consistent across the module.

--- a/modules/bot_api/obo_search_adapter_test.go
+++ b/modules/bot_api/obo_search_adapter_test.go
@@ -1,0 +1,76 @@
+// Package bot_api · YUJ-53 — Unit tests for the SearchOBOAllowed adapter that
+// exposes checkOBO to the messages_search as-user(OBO) gate. The adapter only
+// remaps checkOBO's error contract into (bool, error); the underlying grant /
+// scope / TOCTOU matrix is exercised by obo_check_test.go.
+package bot_api
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+)
+
+// TestSearchOBOAllowed_Authorized — an active grant + enabled scope + live
+// grantor access maps to (true, nil).
+func TestSearchOBOAllowed_Authorized(t *testing.T) {
+	s := newFakeOBOStore()
+	gid, err := s.insertGrant(tGrantor, tBot, "auto", "")
+	if err != nil {
+		t.Fatalf("insertGrant: %v", err)
+	}
+	enable := 1
+	if err := s.updateGrant(gid, "", &enable, nil); err != nil {
+		t.Fatalf("updateGrant: %v", err)
+	}
+	if _, err := s.insertScope(gid, tChan, common.ChannelTypeGroup.Uint8(), 1); err != nil {
+		t.Fatalf("insertScope: %v", err)
+	}
+
+	ba := newBotAPIWithFakeStore(s)
+	ok, err := ba.SearchOBOAllowed(tBot, tGrantor, tChan, common.ChannelTypeGroup.Uint8())
+	if err != nil {
+		t.Fatalf("authorized: unexpected err %v", err)
+	}
+	if !ok {
+		t.Fatalf("authorized: want ok=true")
+	}
+}
+
+// TestSearchOBOAllowed_NotAuthorizedHidesExistence — ErrOBONotAuthorized
+// (no grant here) collapses to (false, nil) so the search layer hides the
+// channel rather than surfacing a distinguishable error.
+func TestSearchOBOAllowed_NotAuthorizedHidesExistence(t *testing.T) {
+	ba := newBotAPIWithFakeStore(newFakeOBOStore())
+	ok, err := ba.SearchOBOAllowed(tBot, tGrantor, tChan, common.ChannelTypeGroup.Uint8())
+	if err != nil {
+		t.Fatalf("not-authorized must not surface an error, got %v", err)
+	}
+	if ok {
+		t.Fatalf("not-authorized: want ok=false")
+	}
+}
+
+// TestSearchOBOAllowed_InfraErrorPropagates — a genuine infra error (grantor
+// live-access re-check fails) propagates as (false, err) so the caller can
+// fail closed with INTERNAL rather than mistaking it for "not authorized".
+func TestSearchOBOAllowed_InfraErrorPropagates(t *testing.T) {
+	s := newFakeOBOStore()
+	gid, _ := s.insertGrant(tGrantor, tBot, "auto", "")
+	enable := 1
+	_ = s.updateGrant(gid, "", &enable, nil)
+	_, _ = s.insertScope(gid, tChan, common.ChannelTypeGroup.Uint8(), 1)
+
+	ba := newBotAPIWithFakeStore(s)
+	sentinel := errors.New("db down")
+	ba.oboChannelAccessOverride = func(uid, channelID string, channelType uint8) (bool, error) {
+		return false, sentinel
+	}
+	ok, err := ba.SearchOBOAllowed(tBot, tGrantor, tChan, common.ChannelTypeGroup.Uint8())
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("infra error must propagate, got %v", err)
+	}
+	if ok {
+		t.Fatalf("infra error: want ok=false")
+	}
+}

--- a/modules/bot_api/search_route.go
+++ b/modules/bot_api/search_route.go
@@ -40,6 +40,11 @@ type searchOBOFieldProbe struct {
 
 // mountSearchRoutes 挂载 bot 搜索子树。由 Route() 调用。
 func (ba *BotAPI) mountSearchRoutes(r *wkhttp.WKHttp) {
+	// YUJ-53 / #F：把 as-user(OBO) 的 scope 门注入共享搜索 Handler。messages_search 的
+	// obo gate（oboCanReadChannel / oboEnumerateReadableChannels）逐频道经此 checker 复用
+	// 发消息侧的 grant + scope + grantorCanReadChannel 实时权限（TOCTOU 一致）。缺此注入则
+	// obo gate 走 errOBONoChecker fail-closed，OBO 搜索会被整体拒绝。
+	ba.searchHandler.SetOBOChecker(ba)
 	ba.searchHandler.MountSubtree(r, "/v1/bot/messages",
 		ba.authBot(),
 		ba.botActorUID(),
@@ -50,7 +55,10 @@ func (ba *BotAPI) mountSearchRoutes(r *wkhttp.WKHttp) {
 
 // resolveSearchPrincipal 是 bot 搜索的 principal 解析中间件（authBot 之后、
 // searchRateLimiter 之前运行）。它按 on_behalf_of 落 as-bot 或 as-user(OBO) 主体，
-// 供后续限流/审计/handler 统一经 principal 读取。
+// 供后续限流/审计/handler 统一经 principal 读取。App Bot 在两条分支都在主体构造阶段
+// fail-closed 拒绝（一期不做）。as-user(OBO) 分支在入口做 channel 无关的 grant 存在性
+// fail-fast（validateSearchOBO），逐频道的 scope + TOCTOU 收敛下沉到 messages_search 的
+// obo gate（复用注入的 ba.SearchOBOAllowed，见 mountSearchRoutes）。
 func (ba *BotAPI) resolveSearchPrincipal(c *wkhttp.Context) {
 	obo := parseSearchOnBehalfOf(c)
 	if obo == "" {
@@ -73,14 +81,28 @@ func (ba *BotAPI) resolveSearchPrincipal(c *wkhttp.Context) {
 		return
 	}
 
-	// as-user(OBO)：on_behalf_of 存在 → 以 grantor 身份搜索。grant + scope +
-	// grantorCanReadChannel 的实时权限校验（TOCTOU 与发消息侧一致）由 validateSearchOBO
-	// 承载——YUJ-53 / #F 复用 obo_check.go 接线；在其落地前本层 fail-closed，绝不放行
-	// 未校验的 as-user 搜索。
+	// as-user(OBO)：on_behalf_of 存在 → 以 grantor 身份搜索。
 	botUID := getRobotIDFromContext(c)
+
+	// App Bot 一期整体不做，且拿不到 OBO grant（grant 只查 robot 表，App Bot 在 app_bot
+	// 表）。在主体构造阶段显式 fail-closed 拒绝——与 as-bot 分支一致，而非放行后靠 obo gate
+	// 静默返回空，避免 App Bot 搜索被误当作「无结果」。
+	if getBotKindFromContext(c) == BotKindApp {
+		ba.Warn("search OBO denied: app bot is not supported (YUJ-49)",
+			zap.String("bot", botUID))
+		httperr.ResponseErrorLWithStatus(c, errcode.ErrBotAPIBotUnavailable, nil, nil)
+		c.Abort()
+		return
+	}
+
+	// 入口 grant 存在性 fail-fast（channel 无关）：bot 当前是否被 grantor 授权（active=1 且
+	// global_enabled=1，与发消息侧 checkOBO 的 grant 门同一谓词）。无 grant → 整体拒绝，
+	// 避免把完全未授权的 OBO 搜索降级为「逐频道过滤后 200 空结果」。逐频道的 scope +
+	// grantorCanReadChannel 实时权限（TOCTOU 与发消息侧一致）由 messages_search 的 obo gate
+	// 经注入的 ba.SearchOBOAllowed 收敛（见 mountSearchRoutes / obo.go）。
 	if err := ba.validateSearchOBO(c, botUID, obo); err != nil {
 		if errors.Is(err, ErrOBONotAuthorized) {
-			ba.Warn("search OBO denied: no active grant/scope",
+			ba.Warn("search OBO denied: no active grant",
 				zap.String("bot", botUID), zap.String("on_behalf_of", obo))
 			httperr.ResponseErrorLWithStatus(c, errcode.ErrBotAPIOBONotAuthorized, nil, nil)
 			c.Abort()
@@ -92,9 +114,8 @@ func (ba *BotAPI) resolveSearchPrincipal(c *wkhttp.Context) {
 		c.Abort()
 		return
 	}
-	// spaceID 目前不从 bot 请求携带（bot 无 space_member）；OBO 场景的 Space 归属由 #F
-	// 随 grantor 解析并注入。#B 先以空 spaceID 组装载体（在 validateSearchOBO 放行前不
-	// 可达此处），待 #F 接线后补全。
+	// spaceID 不从 bot 请求携带（bot 无 space_member）。P2P 分支回退到 grantor 好友判定
+	// （安全，grantor=创建者）；群/子区经 obo gate 逐频道 ∩ scope 收敛，不依赖 spaceID。
 	p, err := messages_search.NewOBOPrincipal(botUID, obo, "")
 	if err != nil {
 		ba.Warn("search OBO principal build failed",
@@ -107,16 +128,31 @@ func (ba *BotAPI) resolveSearchPrincipal(c *wkhttp.Context) {
 	c.Next()
 }
 
-// validateSearchOBO 是 as-user(OBO) 搜索的实时权限校验挂载点（YUJ-53 / #F）。
-// #F 将在此复用 obo_check.go 的 grant + scope + grantorCanReadChannel（TOCTOU 与发消息
-// 侧一致）做实时收敛。#B（本层仅入口接线）fail-closed：on_behalf_of 搜索在 #F 落地前
-// 一律按未授权拒绝，杜绝放行任何未经校验的 as-user 搜索。返回 ErrOBONotAuthorized 时
-// 调用方隐藏 grant 是否存在（与发消息侧一致的存在性隐藏）。
+// validateSearchOBO 是 as-user(OBO) 搜索的入口 fail-fast：channel 无关地校验 bot 当前是否
+// 被 grantor 授权（active=1 且 global_enabled=1 的 grant 行，与发消息侧 checkOBO 的 grant
+// 门同一谓词）。逐频道的 scope + grantorCanReadChannel 实时权限（TOCTOU）不在此层——它需要
+// channel 维度，由 messages_search 的 obo gate 经注入的 ba.SearchOBOAllowed 承载（决策九：
+// 单频道门与 global allowlist 共用同一谓词）。
+//
+// 返回约定：
+//   - nil                    → grant 存在，principal 可组装；越权收敛交给逐频道 gate。
+//   - ErrOBONotAuthorized     → 无 active+enabled grant / 主体缺失 / 自授 → 整体拒绝
+//     （存在性隐藏，与发消息侧一致，不泄露 grant 是否存在）。
+//   - 其他 err                → 基础设施错误 → 调用方 fail-closed（INTERNAL）。
 func (ba *BotAPI) validateSearchOBO(c *wkhttp.Context, botUID, grantorUID string) error {
 	_ = c
-	_ = botUID
-	_ = grantorUID
-	return ErrOBONotAuthorized
+	if botUID == "" || grantorUID == "" || botUID == grantorUID {
+		// 与 checkOBO 一致的 fail-closed：主体缺失 / 自授一律未授权。
+		return ErrOBONotAuthorized
+	}
+	grant, err := ba.oboStoreOrDefault().findActiveGrantByGrantorBot(grantorUID, botUID)
+	if err != nil {
+		return err
+	}
+	if grant == nil {
+		return ErrOBONotAuthorized
+	}
+	return nil
 }
 
 // parseSearchOnBehalfOf 读取并还原请求 body，解析出 on_behalf_of（缺失 / body 为空 /

--- a/modules/bot_api/search_route.go
+++ b/modules/bot_api/search_route.go
@@ -1,0 +1,137 @@
+package bot_api
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"strings"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/modules/messages_search"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
+	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
+	appwkhttp "github.com/Mininglamp-OSS/octo-server/pkg/wkhttp"
+	"go.uber.org/zap"
+)
+
+// 消息搜索的 bot 入口（YUJ-49 / #B，决策六/七/十）。
+//
+// 把 messages_search 的全部 _search* 端点挂到 /v1/bot/messages，以 authBot() 鉴权，
+// principal 由请求 body 的 on_behalf_of 字段区分：
+//   - 无 on_behalf_of → as-bot（principal=user_bot，subjectUID=botUID）。
+//   - 有 on_behalf_of → as-user(OBO)（principal=obo，subjectUID=grantorUID）。
+//
+// 中间件链对齐 messages_search/api.go（SpaceMiddleware 除外——/v1/bot 不挂 Space 门，
+// bot 无 space_member、spaceID 走 principal 参数）：
+//
+//	authBot → botActorUID → SharedUIDRateLimiter → resolveSearchPrincipal → searchRateLimiter → audit → backendGate
+//
+// botActorUID 把 robot_id 落到 "uid"（与 incoming_webhook 一致），使随后的
+// SharedUIDRateLimiter 按 botUID 而非 IP 计量——与「限流按 botUID，防单 bot 打爆」的
+// 决策一致；细粒度 searchRateLimiter 同样经 principal.RateLimitKey() 归到 botUID。
+// 审计 login_uid 记搜索主体、并在 as-user 时同记 bot_uid + grantor_uid。
+
+// searchOBOFieldProbe 只解析 on_behalf_of，用于在 handler BindJSON 之前区分主体。
+// 其余搜索参数留给各 _search* handler 自行绑定。
+type searchOBOFieldProbe struct {
+	OnBehalfOf string `json:"on_behalf_of"`
+}
+
+// mountSearchRoutes 挂载 bot 搜索子树。由 Route() 调用。
+func (ba *BotAPI) mountSearchRoutes(r *wkhttp.WKHttp) {
+	ba.searchHandler.MountSubtree(r, "/v1/bot/messages",
+		ba.authBot(),
+		ba.botActorUID(),
+		appwkhttp.SharedUIDRateLimiter(r, ba.ctx),
+		ba.resolveSearchPrincipal,
+	)
+}
+
+// resolveSearchPrincipal 是 bot 搜索的 principal 解析中间件（authBot 之后、
+// searchRateLimiter 之前运行）。它按 on_behalf_of 落 as-bot 或 as-user(OBO) 主体，
+// 供后续限流/审计/handler 统一经 principal 读取。
+func (ba *BotAPI) resolveSearchPrincipal(c *wkhttp.Context) {
+	obo := parseSearchOnBehalfOf(c)
+	if obo == "" {
+		// as-bot：以 User Bot 自身身份搜索。App Bot 一期显式拒绝（决策五）。
+		p, err := messages_search.AuthenticateUserBot(c)
+		if err != nil {
+			if errors.Is(err, messages_search.ErrAppBotSearchDenied) {
+				ba.Warn("search denied: app bot is not supported (YUJ-49)",
+					zap.String("bot", getRobotIDFromContext(c)))
+				httperr.ResponseErrorLWithStatus(c, errcode.ErrBotAPIBotUnavailable, nil, nil)
+				c.Abort()
+				return
+			}
+			// robot_id 缺失——authBot 之后不应发生，fail-closed。
+			respondBotAPIAuthFailed(c)
+			return
+		}
+		messages_search.SetPrincipal(c, p)
+		c.Next()
+		return
+	}
+
+	// as-user(OBO)：on_behalf_of 存在 → 以 grantor 身份搜索。grant + scope +
+	// grantorCanReadChannel 的实时权限校验（TOCTOU 与发消息侧一致）由 validateSearchOBO
+	// 承载——YUJ-53 / #F 复用 obo_check.go 接线；在其落地前本层 fail-closed，绝不放行
+	// 未校验的 as-user 搜索。
+	botUID := getRobotIDFromContext(c)
+	if err := ba.validateSearchOBO(c, botUID, obo); err != nil {
+		if errors.Is(err, ErrOBONotAuthorized) {
+			ba.Warn("search OBO denied: no active grant/scope",
+				zap.String("bot", botUID), zap.String("on_behalf_of", obo))
+			httperr.ResponseErrorLWithStatus(c, errcode.ErrBotAPIOBONotAuthorized, nil, nil)
+			c.Abort()
+			return
+		}
+		ba.Error("search OBO check failed", zap.Error(err),
+			zap.String("bot", botUID), zap.String("on_behalf_of", obo))
+		httperr.ResponseErrorLWithStatus(c, errcode.ErrBotAPIOBOInternal, nil, nil)
+		c.Abort()
+		return
+	}
+	// spaceID 目前不从 bot 请求携带（bot 无 space_member）；OBO 场景的 Space 归属由 #F
+	// 随 grantor 解析并注入。#B 先以空 spaceID 组装载体（在 validateSearchOBO 放行前不
+	// 可达此处），待 #F 接线后补全。
+	p, err := messages_search.NewOBOPrincipal(botUID, obo, "")
+	if err != nil {
+		ba.Warn("search OBO principal build failed",
+			zap.String("bot", botUID), zap.String("on_behalf_of", obo), zap.Error(err))
+		httperr.ResponseErrorLWithStatus(c, errcode.ErrBotAPIOBONotAuthorized, nil, nil)
+		c.Abort()
+		return
+	}
+	messages_search.SetPrincipal(c, p)
+	c.Next()
+}
+
+// validateSearchOBO 是 as-user(OBO) 搜索的实时权限校验挂载点（YUJ-53 / #F）。
+// #F 将在此复用 obo_check.go 的 grant + scope + grantorCanReadChannel（TOCTOU 与发消息
+// 侧一致）做实时收敛。#B（本层仅入口接线）fail-closed：on_behalf_of 搜索在 #F 落地前
+// 一律按未授权拒绝，杜绝放行任何未经校验的 as-user 搜索。返回 ErrOBONotAuthorized 时
+// 调用方隐藏 grant 是否存在（与发消息侧一致的存在性隐藏）。
+func (ba *BotAPI) validateSearchOBO(c *wkhttp.Context, botUID, grantorUID string) error {
+	_ = c
+	_ = botUID
+	_ = grantorUID
+	return ErrOBONotAuthorized
+}
+
+// parseSearchOnBehalfOf 读取并还原请求 body，解析出 on_behalf_of（缺失 / body 为空 /
+// 非法 JSON → 返回 ""，交由后续 handler 的 BindJSON 统一报错）。还原 body 使各 _search*
+// handler 能再次 BindJSON 读取完整请求体。
+func parseSearchOnBehalfOf(c *wkhttp.Context) string {
+	body, err := c.GetRawData()
+	if err != nil || len(body) == 0 {
+		return ""
+	}
+	// 还原 body 供 handler 复读（GetRawData 会消费 Request.Body）。
+	c.Request.Body = io.NopCloser(bytes.NewReader(body))
+	var probe searchOBOFieldProbe
+	if json.Unmarshal(body, &probe) != nil {
+		return ""
+	}
+	return strings.TrimSpace(probe.OnBehalfOf)
+}

--- a/modules/bot_api/search_route_test.go
+++ b/modules/bot_api/search_route_test.go
@@ -1,0 +1,120 @@
+package bot_api
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/modules/messages_search"
+	"github.com/gin-gonic/gin"
+)
+
+// YUJ-49 (#B) — bot search entry: resolveSearchPrincipal distinguishes as-bot
+// (no on_behalf_of) from as-user(OBO) (on_behalf_of present), and App Bot is
+// explicitly denied. The OBO real-permission check (grant/scope/TOCTOU) is #F;
+// until it wires validateSearchOBO, on_behalf_of搜索 fails closed.
+
+func newBotSearchCtx(t *testing.T, body string) (*wkhttp.Context, *httptest.ResponseRecorder) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	gc, _ := gin.CreateTestContext(rec)
+	gc.Request = httptest.NewRequest("POST", "/v1/bot/messages/_search", strings.NewReader(body))
+	return &wkhttp.Context{Context: gc}, rec
+}
+
+func newSearchTestBotAPI() *BotAPI { return &BotAPI{Log: log.NewTLog("bot-search-test")} }
+
+func TestResolveSearchPrincipal_AsBot(t *testing.T) {
+	ba := newSearchTestBotAPI()
+	c, rec := newBotSearchCtx(t, `{"keyword":"hi"}`)
+	c.Set(CtxKeyRobotID, "bot_1")
+	c.Set(CtxKeyBotKind, BotKindUser)
+
+	ba.resolveSearchPrincipal(c)
+
+	if c.IsAborted() {
+		t.Fatalf("as-bot must not abort, body=%q", rec.Body.String())
+	}
+	if got := messages_search.PrincipalKind(c); got != "user_bot" {
+		t.Fatalf("principal kind = %q, want user_bot", got)
+	}
+	// Body must still be readable by the downstream _search* handler (the probe
+	// consumed it via GetRawData and must have restored it).
+	b, _ := io.ReadAll(c.Request.Body)
+	if !strings.Contains(string(b), "keyword") {
+		t.Fatalf("request body not restored for handler BindJSON, got %q", string(b))
+	}
+}
+
+func TestResolveSearchPrincipal_AppBotDenied(t *testing.T) {
+	ba := newSearchTestBotAPI()
+	c, rec := newBotSearchCtx(t, `{}`)
+	c.Set(CtxKeyRobotID, "app_1")
+	c.Set(CtxKeyBotKind, BotKindApp)
+
+	ba.resolveSearchPrincipal(c)
+
+	if !c.IsAborted() {
+		t.Fatalf("App Bot must be denied (决策五), chain must abort")
+	}
+	if got := messages_search.PrincipalKind(c); got != "" {
+		t.Fatalf("App Bot must not set a search principal, got %q", got)
+	}
+	if rec.Code == http.StatusOK {
+		t.Fatalf("App Bot denial must not return 200")
+	}
+}
+
+func TestResolveSearchPrincipal_OBOFailClosedUntilF(t *testing.T) {
+	ba := newSearchTestBotAPI()
+	c, rec := newBotSearchCtx(t, `{"on_behalf_of":"grantor_2","keyword":"x"}`)
+	c.Set(CtxKeyRobotID, "bot_1")
+	c.Set(CtxKeyBotKind, BotKindUser)
+
+	ba.resolveSearchPrincipal(c)
+
+	if !c.IsAborted() {
+		t.Fatalf("on_behalf_of search must fail closed until #F wires validateSearchOBO")
+	}
+	if got := messages_search.PrincipalKind(c); got != "" {
+		t.Fatalf("fail-closed OBO must not set a principal, got %q", got)
+	}
+	if rec.Code == http.StatusOK {
+		t.Fatalf("fail-closed OBO must not return 200")
+	}
+}
+
+func TestParseSearchOnBehalfOf(t *testing.T) {
+	// present (trimmed) + body restored for the handler.
+	c, _ := newBotSearchCtx(t, `{"on_behalf_of":"  g1  ","keyword":"k"}`)
+	if got := parseSearchOnBehalfOf(c); got != "g1" {
+		t.Fatalf("trimmed on_behalf_of = %q, want g1", got)
+	}
+	b, _ := io.ReadAll(c.Request.Body)
+	if !strings.Contains(string(b), "keyword") {
+		t.Fatalf("body must be restored after probe, got %q", string(b))
+	}
+
+	// absent → "".
+	c2, _ := newBotSearchCtx(t, `{"keyword":"k"}`)
+	if got := parseSearchOnBehalfOf(c2); got != "" {
+		t.Fatalf("no on_behalf_of field = %q, want empty", got)
+	}
+
+	// invalid JSON → treated as no obo (handler re-binds and reports the error).
+	c3, _ := newBotSearchCtx(t, `not json`)
+	if got := parseSearchOnBehalfOf(c3); got != "" {
+		t.Fatalf("invalid json on_behalf_of = %q, want empty", got)
+	}
+
+	// empty body → "".
+	c4, _ := newBotSearchCtx(t, ``)
+	if got := parseSearchOnBehalfOf(c4); got != "" {
+		t.Fatalf("empty body on_behalf_of = %q, want empty", got)
+	}
+}

--- a/modules/bot_api/search_route_test.go
+++ b/modules/bot_api/search_route_test.go
@@ -1,6 +1,7 @@
 package bot_api
 
 import (
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -13,10 +14,12 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-// YUJ-49 (#B) — bot search entry: resolveSearchPrincipal distinguishes as-bot
-// (no on_behalf_of) from as-user(OBO) (on_behalf_of present), and App Bot is
-// explicitly denied. The OBO real-permission check (grant/scope/TOCTOU) is #F;
-// until it wires validateSearchOBO, on_behalf_of搜索 fails closed.
+// YUJ-49 (#B) / YUJ-53 (#F) — bot search entry: resolveSearchPrincipal
+// distinguishes as-bot (no on_behalf_of) from as-user(OBO) (on_behalf_of
+// present). App Bot is explicitly denied on both branches. The OBO entry does
+// a channel-agnostic grant-existence fail-fast (validateSearchOBO); the
+// per-channel scope + grantorCanReadChannel (TOCTOU) check is reused by the
+// messages_search obo gate via the injected ba.SearchOBOAllowed.
 
 func newBotSearchCtx(t *testing.T, body string) (*wkhttp.Context, *httptest.ResponseRecorder) {
 	t.Helper()
@@ -70,8 +73,45 @@ func TestResolveSearchPrincipal_AppBotDenied(t *testing.T) {
 	}
 }
 
-func TestResolveSearchPrincipal_OBOFailClosedUntilF(t *testing.T) {
-	ba := newSearchTestBotAPI()
+func TestResolveSearchPrincipal_OBOAuthorizedSetsPrincipal(t *testing.T) {
+	// A live grant (active=1, global_enabled=1) exists for (grantor, bot):
+	// the entry fail-fast passes and an obo principal is set. Per-channel
+	// scope/TOCTOU is left to the messages_search obo gate.
+	s := newFakeOBOStore()
+	gid, err := s.insertGrant("grantor_2", "bot_1", "auto", "")
+	if err != nil {
+		t.Fatalf("insertGrant: %v", err)
+	}
+	enable := 1
+	if err := s.updateGrant(gid, "", &enable, nil); err != nil {
+		t.Fatalf("updateGrant: %v", err)
+	}
+	ba := newBotAPIWithFakeStore(s)
+
+	c, rec := newBotSearchCtx(t, `{"on_behalf_of":"grantor_2","keyword":"x"}`)
+	c.Set(CtxKeyRobotID, "bot_1")
+	c.Set(CtxKeyBotKind, BotKindUser)
+
+	ba.resolveSearchPrincipal(c)
+
+	if c.IsAborted() {
+		t.Fatalf("authorized OBO must not abort, body=%q", rec.Body.String())
+	}
+	if got := messages_search.PrincipalKind(c); got != "obo" {
+		t.Fatalf("principal kind = %q, want obo", got)
+	}
+	// Body must still be readable by the downstream _search* handler.
+	b, _ := io.ReadAll(c.Request.Body)
+	if !strings.Contains(string(b), "keyword") {
+		t.Fatalf("request body not restored for handler BindJSON, got %q", string(b))
+	}
+}
+
+func TestResolveSearchPrincipal_OBONoGrantDenied(t *testing.T) {
+	// No grant row at all → entry fail-fast rejects the whole request
+	// (existence-hidden), never degrades to a 200 empty result.
+	ba := newBotAPIWithFakeStore(newFakeOBOStore())
+
 	c, rec := newBotSearchCtx(t, `{"on_behalf_of":"grantor_2","keyword":"x"}`)
 	c.Set(CtxKeyRobotID, "bot_1")
 	c.Set(CtxKeyBotKind, BotKindUser)
@@ -79,13 +119,63 @@ func TestResolveSearchPrincipal_OBOFailClosedUntilF(t *testing.T) {
 	ba.resolveSearchPrincipal(c)
 
 	if !c.IsAborted() {
-		t.Fatalf("on_behalf_of search must fail closed until #F wires validateSearchOBO")
+		t.Fatalf("OBO with no grant must abort")
 	}
 	if got := messages_search.PrincipalKind(c); got != "" {
-		t.Fatalf("fail-closed OBO must not set a principal, got %q", got)
+		t.Fatalf("unauthorized OBO must not set a principal, got %q", got)
 	}
 	if rec.Code == http.StatusOK {
-		t.Fatalf("fail-closed OBO must not return 200")
+		t.Fatalf("unauthorized OBO must not return 200")
+	}
+}
+
+func TestResolveSearchPrincipal_OBOAppBotDenied(t *testing.T) {
+	// App Bot cannot hold an OBO grant; it must be denied at principal
+	// construction, not silently returned as "no results".
+	s := newFakeOBOStore()
+	gid, _ := s.insertGrant("grantor_2", "app_1", "auto", "")
+	enable := 1
+	_ = s.updateGrant(gid, "", &enable, nil)
+	ba := newBotAPIWithFakeStore(s)
+
+	c, rec := newBotSearchCtx(t, `{"on_behalf_of":"grantor_2","keyword":"x"}`)
+	c.Set(CtxKeyRobotID, "app_1")
+	c.Set(CtxKeyBotKind, BotKindApp)
+
+	ba.resolveSearchPrincipal(c)
+
+	if !c.IsAborted() {
+		t.Fatalf("App Bot OBO search must be denied (决策五), chain must abort")
+	}
+	if got := messages_search.PrincipalKind(c); got != "" {
+		t.Fatalf("App Bot must not set a search principal, got %q", got)
+	}
+	if rec.Code == http.StatusOK {
+		t.Fatalf("App Bot denial must not return 200")
+	}
+}
+
+func TestResolveSearchPrincipal_OBOInfraErrorFailsClosed(t *testing.T) {
+	// A DB error on the grant lookup must fail closed (abort, non-200), never
+	// fall through to an unauthenticated / unscoped search.
+	s := newFakeOBOStore()
+	s.failFindActiveGrant = errors.New("db down")
+	ba := newBotAPIWithFakeStore(s)
+
+	c, rec := newBotSearchCtx(t, `{"on_behalf_of":"grantor_2","keyword":"x"}`)
+	c.Set(CtxKeyRobotID, "bot_1")
+	c.Set(CtxKeyBotKind, BotKindUser)
+
+	ba.resolveSearchPrincipal(c)
+
+	if !c.IsAborted() {
+		t.Fatalf("OBO infra error must fail closed (abort)")
+	}
+	if got := messages_search.PrincipalKind(c); got != "" {
+		t.Fatalf("infra-error OBO must not set a principal, got %q", got)
+	}
+	if rec.Code == http.StatusOK {
+		t.Fatalf("infra-error OBO must not return 200")
 	}
 }
 

--- a/modules/botfather/api.go
+++ b/modules/botfather/api.go
@@ -15,6 +15,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-server/modules/botfather/cmdmenu"
 	"github.com/Mininglamp-OSS/octo-server/modules/file"
 	"github.com/Mininglamp-OSS/octo-server/modules/group"
+	"github.com/Mininglamp-OSS/octo-server/modules/messages_search"
 	"github.com/Mininglamp-OSS/octo-server/modules/thread"
 	"github.com/Mininglamp-OSS/octo-server/modules/user"
 	"github.com/Mininglamp-OSS/octo-server/pkg/botutil"
@@ -39,6 +40,11 @@ type BotFather struct {
 	robotEventPrefix string
 	initOnce         sync.Once
 	msgSem           chan struct{} // 限制并发消息处理的信号量
+	// searchHandler 是共享的消息搜索 Handler（messages_search.Shared）。uk 搜索路由
+	// /v1/user/messages/_search* 复用它（YUJ-49 / #B，决策十正式接线）：authUserAPIKey
+	// 鉴权、principal=uk（subjectUID=keyModel.UID，spaceID=api_key_space_id）。与 web、
+	// bot 入口共用同一实例，共享限流桶与 sender 缓存。
+	searchHandler *messages_search.Handler
 	log.Log
 }
 
@@ -57,6 +63,7 @@ func New(ctx *config.Context) *BotFather {
 		threadService:    thread.NewService(ctx),
 		robotEventPrefix: "robotEvent:",
 		msgSem:           make(chan struct{}, 100),
+		searchHandler:    messages_search.Shared(ctx),
 		Log:              log.NewTLog("BotFather"),
 	}
 
@@ -94,6 +101,10 @@ func (bf *BotFather) Route(r *wkhttp.WKHttp) {
 
 	// User Bot API 端点（使用User API Key认证）
 	bf.setupUserAPIRoutes(r)
+
+	// 消息搜索（YUJ-49 / #B，决策十正式接线）：/v1/user/messages/_search*，
+	// authUserAPIKey 鉴权，principal=uk（直接真人身份）。实现在 search_route.go。
+	bf.mountSearchRoutes(r)
 
 	// Robot Apply API 端点（使用用户认证）
 	bf.setupApplyRoutes(r)

--- a/modules/botfather/search_route.go
+++ b/modules/botfather/search_route.go
@@ -1,0 +1,42 @@
+package botfather
+
+import (
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/modules/messages_search"
+	appwkhttp "github.com/Mininglamp-OSS/octo-server/pkg/wkhttp"
+)
+
+// 消息搜索的 uk 入口（YUJ-49 / #B，决策十正式接线）。
+//
+// 把 messages_search 的全部 _search* 端点挂到 /v1/user/messages，以 authUserAPIKey()
+// 鉴权，principal=uk：subjectUID = keyModel.UID（直接真人身份）、spaceID =
+// api_key_space_id、限流/审计主体 = key UID。uk 无 bot、无 OBO scope 收窄，可读谓词走
+// 真人可达集（复用 messages_search 现有真人分支 checkChannelAccess / buildAllowlist）。
+//
+// 中间件链对齐 setupUserAPIRoutes（authUserAPIKey + SharedUIDRateLimiter）再接搜索专属
+// 链，无 SpaceMiddleware（spaceID 走 principal 的 api_key_space_id）：
+//
+//	authUserAPIKey → SharedUIDRateLimiter → resolveUKPrincipal → searchRateLimiter → audit → backendGate
+
+// mountSearchRoutes 挂载 uk 搜索子树。由 Route() 调用。
+func (bf *BotFather) mountSearchRoutes(r *wkhttp.WKHttp) {
+	bf.searchHandler.MountSubtree(r, "/v1/user/messages",
+		bf.authUserAPIKey(),
+		appwkhttp.SharedUIDRateLimiter(r, bf.ctx),
+		bf.resolveUKPrincipal,
+	)
+}
+
+// resolveUKPrincipal 是 uk 搜索的 principal 解析中间件（authUserAPIKey 之后、
+// searchRateLimiter 之前运行）。authUserAPIKey 已把 api_key_uid / api_key_space_id 落
+// context，这里据此组装 uk 主体并写入，供后续限流/审计/handler 统一读取。
+func (bf *BotFather) resolveUKPrincipal(c *wkhttp.Context) {
+	p, err := messages_search.AuthenticateUK(c)
+	if err != nil {
+		// api_key_uid 缺失——authUserAPIKey 之后不应发生，fail-closed。
+		respondBotfatherAuthFailed(c)
+		return
+	}
+	messages_search.SetPrincipal(c, p)
+	c.Next()
+}

--- a/modules/botfather/search_route.go
+++ b/modules/botfather/search_route.go
@@ -3,7 +3,11 @@ package botfather
 import (
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
 	"github.com/Mininglamp-OSS/octo-server/modules/messages_search"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
+	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
+	spacepkg "github.com/Mininglamp-OSS/octo-server/pkg/space"
 	appwkhttp "github.com/Mininglamp-OSS/octo-server/pkg/wkhttp"
+	"go.uber.org/zap"
 )
 
 // 消息搜索的 uk 入口（YUJ-49 / #B，决策十正式接线）。
@@ -17,6 +21,13 @@ import (
 // 链，无 SpaceMiddleware（spaceID 走 principal 的 api_key_space_id）：
 //
 //	authUserAPIKey → SharedUIDRateLimiter → resolveUKPrincipal → searchRateLimiter → audit → backendGate
+//
+// resolveUKPrincipal 内联补齐人类路由 SpaceMiddleware 的等价成员资格门（YUJ-58）：
+// authUserAPIKey 只校验 key status / integration-client enablement / user active，不重查
+// key 主人是否仍是 api_key_space_id 冻结的 Space 成员。缺此门时，一个在成员期签发、之后
+// 主人被移出该 Space 的存量 key 仍被无限期信任，可经 global DM 枚举检索该 Space 当前成员的
+// DM 历史（buildAllowlist→enumerateDMPeers 只信任 allowlist、不重校验调用者本人的 space
+// 成员资格）。人类 web 路由此时会被 SpaceMiddleware 的成员资格检查拒绝。
 
 // mountSearchRoutes 挂载 uk 搜索子树。由 Route() 调用。
 func (bf *BotFather) mountSearchRoutes(r *wkhttp.WKHttp) {
@@ -30,13 +41,47 @@ func (bf *BotFather) mountSearchRoutes(r *wkhttp.WKHttp) {
 // resolveUKPrincipal 是 uk 搜索的 principal 解析中间件（authUserAPIKey 之后、
 // searchRateLimiter 之前运行）。authUserAPIKey 已把 api_key_uid / api_key_space_id 落
 // context，这里据此组装 uk 主体并写入，供后续限流/审计/handler 统一读取。
+//
+// 成员资格校验委托给 spacepkg.CheckMembership（与人类路由 SpaceMiddleware 同款语义：
+// join space.status=1 + space_member.status=1），checker 经 resolveUKPrincipalWithChecker
+// 注入以便单测无需 DB。
 func (bf *BotFather) resolveUKPrincipal(c *wkhttp.Context) {
+	bf.resolveUKPrincipalWithChecker(c, func(spaceID, uid string) (bool, error) {
+		return spacepkg.CheckMembership(bf.ctx.DB(), spaceID, uid)
+	})
+}
+
+// resolveUKPrincipalWithChecker 是 resolveUKPrincipal 的可注入实现：checkMembership 抽出
+// 便于单测替身。校验落在 uk 主体鉴权路径（YUJ-58 要求三：归一化，勿在 enumerateDMPeers
+// 内联特判绕过谓词一致性）。
+func (bf *BotFather) resolveUKPrincipalWithChecker(c *wkhttp.Context, checkMembership spacepkg.MembershipChecker) {
 	p, err := messages_search.AuthenticateUK(c)
 	if err != nil {
 		// api_key_uid 缺失——authUserAPIKey 之后不应发生，fail-closed。
 		respondBotfatherAuthFailed(c)
 		return
 	}
+
+	// 仅当 key 绑定了 Space（spaceID 非空）时校验成员资格：无 Space 的 uk 无成员资格可查，
+	// 与人类 SpaceMiddleware「无 space_id 则跳过」对齐；其空 Space 由下游 RequiresSpaceScope
+	// 的必填门 fail-close，不在此拦截。
+	if spaceID := p.SpaceID(); spaceID != "" {
+		member, mErr := checkMembership(spaceID, p.SubjectUID())
+		if mErr != nil {
+			bf.Error("uk 搜索校验 Space 成员身份失败", zap.String("space_id", spaceID), zap.Error(mErr))
+			httperr.ResponseErrorLWithStatus(c, errcode.ErrSharedInternal, nil, nil)
+			c.Abort()
+			return
+		}
+		if !member {
+			// 与人类 SpaceMiddleware 同款 fail-closed（403）：key 主人已被移出 / 禁用该 Space，
+			// 或该 Space 已停用。存量 active key 不再被无限期信任。
+			httperr.ResponseErrorLWithStatus(c, errcode.ErrSharedForbidden, nil, nil)
+			c.Abort()
+			return
+		}
+	}
+
 	messages_search.SetPrincipal(c, p)
 	c.Next()
 }

--- a/modules/botfather/search_route_test.go
+++ b/modules/botfather/search_route_test.go
@@ -1,0 +1,57 @@
+package botfather
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/modules/messages_search"
+	"github.com/gin-gonic/gin"
+)
+
+// YUJ-49 (#B) — uk search entry: resolveUKPrincipal turns the authUserAPIKey()
+// context (api_key_uid / api_key_space_id) into a uk principal (直接真人身份).
+
+func newUKSearchCtx(t *testing.T) (*wkhttp.Context, *httptest.ResponseRecorder) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	gc, _ := gin.CreateTestContext(rec)
+	gc.Request = httptest.NewRequest("POST", "/v1/user/messages/_search", nil)
+	return &wkhttp.Context{Context: gc}, rec
+}
+
+func TestResolveUKPrincipal_DirectRealUser(t *testing.T) {
+	bf := &BotFather{Log: log.NewTLog("uk-search-test")}
+	c, rec := newUKSearchCtx(t)
+	c.Set("api_key_uid", "u_9")
+	c.Set("api_key_space_id", "sp_1")
+
+	bf.resolveUKPrincipal(c)
+
+	if c.IsAborted() {
+		t.Fatalf("uk with valid key must not abort, body=%q", rec.Body.String())
+	}
+	if got := messages_search.PrincipalKind(c); got != "uk" {
+		t.Fatalf("principal kind = %q, want uk", got)
+	}
+}
+
+func TestResolveUKPrincipal_MissingKeyFailsClosed(t *testing.T) {
+	bf := &BotFather{Log: log.NewTLog("uk-search-test")}
+	c, rec := newUKSearchCtx(t)
+
+	bf.resolveUKPrincipal(c)
+
+	if !c.IsAborted() {
+		t.Fatalf("missing api_key_uid must fail closed / abort")
+	}
+	if got := messages_search.PrincipalKind(c); got != "" {
+		t.Fatalf("missing key must not set a principal, got %q", got)
+	}
+	if rec.Code == http.StatusOK {
+		t.Fatalf("missing key must not return 200")
+	}
+}

--- a/modules/botfather/search_route_test.go
+++ b/modules/botfather/search_route_test.go
@@ -1,6 +1,7 @@
 package botfather
 
 import (
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -13,6 +14,14 @@ import (
 
 // YUJ-49 (#B) — uk search entry: resolveUKPrincipal turns the authUserAPIKey()
 // context (api_key_uid / api_key_space_id) into a uk principal (直接真人身份).
+//
+// YUJ-58 (RC #608) — resolveUKPrincipal additionally enforces live Space
+// membership of the key owner against api_key_space_id, mirroring the human
+// route's SpaceMiddleware. An expired key whose owner has been removed from /
+// disabled in the frozen Space must fail closed (403), otherwise global DM
+// search would enumerate that Space's current members' DM history. Membership
+// is checked via an injectable spacepkg.MembershipChecker so these unit tests
+// need no DB; a DB-backed regression lives alongside the SpaceMiddleware tests.
 
 func newUKSearchCtx(t *testing.T) (*wkhttp.Context, *httptest.ResponseRecorder) {
 	t.Helper()
@@ -23,16 +32,32 @@ func newUKSearchCtx(t *testing.T) (*wkhttp.Context, *httptest.ResponseRecorder) 
 	return &wkhttp.Context{Context: gc}, rec
 }
 
+// memberChecker returns a stub MembershipChecker that always reports isMember,
+// recording whether it was invoked so tests can assert the space-scoped gate
+// only runs when api_key_space_id is present.
+func memberChecker(isMember bool, called *bool) func(spaceID, uid string) (bool, error) {
+	return func(spaceID, uid string) (bool, error) {
+		if called != nil {
+			*called = true
+		}
+		return isMember, nil
+	}
+}
+
 func TestResolveUKPrincipal_DirectRealUser(t *testing.T) {
 	bf := &BotFather{Log: log.NewTLog("uk-search-test")}
 	c, rec := newUKSearchCtx(t)
 	c.Set("api_key_uid", "u_9")
 	c.Set("api_key_space_id", "sp_1")
 
-	bf.resolveUKPrincipal(c)
+	called := false
+	bf.resolveUKPrincipalWithChecker(c, memberChecker(true, &called))
 
 	if c.IsAborted() {
-		t.Fatalf("uk with valid key must not abort, body=%q", rec.Body.String())
+		t.Fatalf("uk with valid key + active membership must not abort, body=%q", rec.Body.String())
+	}
+	if !called {
+		t.Fatalf("membership must be checked when api_key_space_id is present")
 	}
 	if got := messages_search.PrincipalKind(c); got != "uk" {
 		t.Fatalf("principal kind = %q, want uk", got)
@@ -53,5 +78,75 @@ func TestResolveUKPrincipal_MissingKeyFailsClosed(t *testing.T) {
 	}
 	if rec.Code == http.StatusOK {
 		t.Fatalf("missing key must not return 200")
+	}
+}
+
+// TestResolveUKPrincipal_NonMemberFailsClosed is the core YUJ-58 regression: an
+// active key whose owner is no longer an active member of the frozen
+// api_key_space_id must be denied (403) and never get a uk principal — matching
+// the human route's SpaceMiddleware, closing the global-DM-enumeration bypass.
+func TestResolveUKPrincipal_NonMemberFailsClosed(t *testing.T) {
+	bf := &BotFather{Log: log.NewTLog("uk-search-test")}
+	c, rec := newUKSearchCtx(t)
+	c.Set("api_key_uid", "u_9")
+	c.Set("api_key_space_id", "sp_1")
+
+	bf.resolveUKPrincipalWithChecker(c, memberChecker(false, nil))
+
+	if !c.IsAborted() {
+		t.Fatalf("non-member key must fail closed / abort")
+	}
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("non-member must return 403 (align SpaceMiddleware), got %d body=%q", rec.Code, rec.Body.String())
+	}
+	if got := messages_search.PrincipalKind(c); got != "" {
+		t.Fatalf("non-member must not set a principal, got %q", got)
+	}
+}
+
+// TestResolveUKPrincipal_MembershipErrorFailsClosed: a checker error must
+// fail closed (500), not fall through to a resolved principal.
+func TestResolveUKPrincipal_MembershipErrorFailsClosed(t *testing.T) {
+	bf := &BotFather{Log: log.NewTLog("uk-search-test")}
+	c, rec := newUKSearchCtx(t)
+	c.Set("api_key_uid", "u_9")
+	c.Set("api_key_space_id", "sp_1")
+
+	bf.resolveUKPrincipalWithChecker(c, func(spaceID, uid string) (bool, error) {
+		return false, errors.New("db down")
+	})
+
+	if !c.IsAborted() {
+		t.Fatalf("membership check error must fail closed / abort")
+	}
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("membership error must return 500, got %d body=%q", rec.Code, rec.Body.String())
+	}
+	if got := messages_search.PrincipalKind(c); got != "" {
+		t.Fatalf("membership error must not set a principal, got %q", got)
+	}
+}
+
+// TestResolveUKPrincipal_NoSpaceSkipsMembership: a spaceless uk key
+// (api_key_space_id empty) has no membership to check — the gate is skipped and
+// the uk principal is resolved; the empty-Space fail-close is enforced
+// downstream by RequiresSpaceScope, not here.
+func TestResolveUKPrincipal_NoSpaceSkipsMembership(t *testing.T) {
+	bf := &BotFather{Log: log.NewTLog("uk-search-test")}
+	c, rec := newUKSearchCtx(t)
+	c.Set("api_key_uid", "u_9")
+	// no api_key_space_id
+
+	called := false
+	bf.resolveUKPrincipalWithChecker(c, memberChecker(true, &called))
+
+	if c.IsAborted() {
+		t.Fatalf("spaceless uk must not abort here, body=%q", rec.Body.String())
+	}
+	if called {
+		t.Fatalf("membership must NOT be checked when api_key_space_id is empty")
+	}
+	if got := messages_search.PrincipalKind(c); got != "uk" {
+		t.Fatalf("principal kind = %q, want uk", got)
 	}
 }

--- a/modules/messages_search/1module.go
+++ b/modules/messages_search/1module.go
@@ -15,7 +15,9 @@ func init() {
 		return register.Module{
 			Name: "messages_search",
 			SetupAPI: func() register.APIRouter {
-				return New(ctx.(*config.Context))
+				// Shared 单例：web / bot / uk 三条路由树共用同一 Handler（YUJ-49），
+				// 共享限流桶与 sender 缓存。bot_api / botfather 也经 Shared 取同一实例。
+				return Shared(ctx.(*config.Context))
 			},
 			Swagger: swaggerContent,
 		}

--- a/modules/messages_search/api.go
+++ b/modules/messages_search/api.go
@@ -69,6 +69,13 @@ type Handler struct {
 
 	limiter *uidLimiter
 	cache   *senderCache
+	// oboCheck is the as-user(OBO) scope gate seam (YUJ-53 / #F). Nil until
+	// the bot search route (#B) injects a bot_api-backed adapter via
+	// SetOBOChecker; *bot_api.BotAPI.SearchOBOAllowed satisfies oboChecker
+	// structurally so messages_search stays decoupled from bot_api. When an
+	// obo principal reaches the gate with this nil, the gate fails closed
+	// (never degrades to un-scoped grantor search). See obo.go.
+	oboCheck oboChecker
 	// mode is the resolved OCTO_SEARCH_BACKEND posture. When mode.ESServe is
 	// false the backendGate middleware refuses every _search* request with
 	// SEARCH_DISABLED — the OS path never serves under zinc/disabled.

--- a/modules/messages_search/api_i18n_test.go
+++ b/modules/messages_search/api_i18n_test.go
@@ -25,6 +25,8 @@ func TestMessagesSearchNoLegacyResponseError(t *testing.T) {
 		"audit.go",
 		"space_scope.go",
 		"visibility.go",
+		"principal.go",
+		"predicate.go",
 	}
 	// Banned literals — exact substring match.
 	banned := []string{

--- a/modules/messages_search/audit.go
+++ b/modules/messages_search/audit.go
@@ -27,11 +27,22 @@ func (h *Handler) auditMiddleware() wkhttp.HandlerFunc {
 		c.Next()
 		took := time.Since(start)
 
+		// 审计主体走 principal（决策十）：login_uid 记搜索主体（真人=登录 uid，as-bot=botUID，
+		// obo=grantorUID，uk=key UID）；as-user 场景再同时记 bot_uid + grantor_uid 以追溯
+		//（哪个 bot 代哪个 grantor 发起）。真人路径 bot_uid/grantor_uid 为空、字段自动省略，
+		// 日志形态与现状一致。
+		principal := h.principal(c)
 		fields := []zap.Field{
 			zap.String("path", c.FullPath()),
-			zap.String("login_uid", c.GetLoginUID()),
+			zap.String("login_uid", principal.SubjectUID()),
 			zap.Int64("took_ms", took.Milliseconds()),
 			zap.Int("status", c.Writer.Status()),
+		}
+		if botUID := principal.AuditBotUID(); botUID != "" {
+			fields = append(fields, zap.String("bot_uid", botUID))
+		}
+		if grantorUID := principal.AuditGrantorUID(); grantorUID != "" {
+			fields = append(fields, zap.String("grantor_uid", grantorUID))
 		}
 		if v, ok := c.Get(auditFieldKindKey); ok {
 			if s, _ := v.(string); s != "" {

--- a/modules/messages_search/authz.go
+++ b/modules/messages_search/authz.go
@@ -207,6 +207,50 @@ func (h *Handler) checkP2PAccess(c *wkhttp.Context, peerUID, loginUID string) bo
 	return true
 }
 
+// botCheckP2PAccess gates DM search for an as-bot principal (#C / YUJ-50). The
+// bot subject's rule is deliberately narrower than the real-user
+// checkP2PAccess: allow iff the bot and the peer are friends, and NOTHING else.
+//
+//   - No Space segment: a bot has no `space_member` row, so the same-Space
+//     branch of the real-user gate can never fire for it. Consulting Space
+//     here would only add a lookup that is structurally always false.
+//   - No P2P blacklist, either direction (决策已确认):
+//     · bot→peer  — a bot can't blacklist anyone (addBlacklist is a real-user
+//     session feature, user/api.go), so this side is always empty;
+//     · peer→bot  — deliberately NOT consulted: a bot must stay able to search
+//     a conversation it is party to even if the peer has blocked it.
+//     So blacklistPolicy for userBotPrincipal is `none` (principal.go) and this
+//     gate never calls ExistBlacklist.
+//   - No bot-classification of the peer (QueryPeerRobotInfo): friendship alone
+//     decides. The peer may be a real user or another bot; the single IsFriend
+//     edge is the whole predicate.
+//
+// Direction: IsFriend(botUID, peer) — the same single-direction query the
+// real-user gate uses (authz.go, real-user path) and the exact enumeration dual
+// of #E's GetFriends(botUID) in buildBotAllowlist. Keeping this one edge (not a
+// two-call bidirectional check) is what makes 决策九 hold: 单频道门放行 ⇔ 出现在
+// global allowlist. Friend rows are stored as mutual pairs, so this still means
+// "互为好友".
+//
+// Denials render NOT_FOUND/resource=channel (anti-enumeration, identical to the
+// real-user path); an IsFriend lookup error fail-closes with INTERNAL_ERROR.
+func (h *Handler) botCheckP2PAccess(c *wkhttp.Context, botUID, peerUID string) bool {
+	isFriend, err := h.userService.IsFriend(botUID, peerUID)
+	if err != nil {
+		h.Error("as-bot p2p access check failed: IsFriend",
+			zap.Error(err),
+			zap.String("bot_uid", botUID),
+			zap.String("peer", peerUID))
+		respondInternal(c)
+		return false
+	}
+	if !isFriend {
+		respondNotFound(c, "channel")
+		return false
+	}
+	return true
+}
+
 // checkGroupAccess fail-closes if the group is missing, then gates on active
 // membership. Disbanded groups are NOT rejected here: per the 企业微信式 disband
 // semantics (产品决策 2026-06), history & search stay readable after disband —

--- a/modules/messages_search/authz.go
+++ b/modules/messages_search/authz.go
@@ -1,11 +1,8 @@
 package messages_search
 
 import (
-	"strings"
-
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
 	"github.com/Mininglamp-OSS/octo-server/modules/thread"
-	spacepkg "github.com/Mininglamp-OSS/octo-server/pkg/space"
 	"go.uber.org/zap"
 )
 
@@ -142,7 +139,9 @@ func (h *Handler) checkP2PAccess(c *wkhttp.Context, peerUID, loginUID string) bo
 		// covers enterprise contact-book deployments where friend is empty;
 		// friend fallback preserves legacy non-Space deployments.
 		allowed := false
-		spaceID := strings.TrimSpace(spacepkg.GetSpaceID(c))
+		// spaceID 走 principal（决策十）：真人等价于 GetSpaceID(c)；bot 无 space_member
+		// 行、Space 为空（as-bot 的 P2P 分支由 #C 用 bot 谓词接管，不落此真人分支）。
+		spaceID := h.principal(c).SpaceID()
 		if spaceID != "" {
 			sameSpace, serr := h.userService.AreSpaceMembers(spaceID, loginUID, peerUID)
 			if serr != nil {

--- a/modules/messages_search/authz_bot_test.go
+++ b/modules/messages_search/authz_bot_test.go
@@ -1,0 +1,164 @@
+package messages_search
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-server/modules/group"
+)
+
+// as-bot 群/子区单频道门（#D / YUJ-51）。验收口径：
+//   - as-bot：所在群 / 子区历史可搜；非成员 / 被移出 / 被拉黑 → 搜不到（NOT_FOUND，反枚举）。
+//   - 主体是 botUID：ExistMemberActive 必须以 botUID 求值（bot 有自己的 group_member 行）。
+//   - 归一化（决策九）：群/子区门复用真人 checkGroupAccess / checkThreadAccess，仅主体 uid
+//     换成 botUID——与 #E buildBotAllowlist 的 ExistMembersActive 枚举同源，不另写一套规则。
+//   - as-bot 群/子区门不触碰 P2P 机器（friend / blacklist / space），那是 DM 门（#C）的事。
+
+// TestBotCanReadChannel_GroupMemberAllowed — a bot that is an active member of
+// a normal-status group passes, and membership is checked against the botUID
+// (bot has its own group_member row), not any human identity.
+func TestBotCanReadChannel_GroupMemberAllowed(t *testing.T) {
+	gSvc := &stubAuthzGroupSvc{
+		activeMembers: map[string]bool{"G1": true},
+		groupModels:   map[string]*group.InfoResp{"G1": {GroupNo: "G1", Status: 1}},
+	}
+	uSvc := &stubAuthzUserSvc{}
+	h := newAuthzHandlerFull(gSvc, uSvc, &stubAuthzThreadSvc{})
+	c, rec := newAuthzCtx(t)
+
+	if !h.canReadChannel(c, userBotPrincipal{botUID: "bot9"}, channelTypeGroup, "G1") {
+		t.Fatalf("as-bot active group member must pass the gate")
+	}
+	if gSvc.gotUID != "bot9" || gSvc.gotGroupNo != "G1" {
+		t.Fatalf("group membership must be checked with the botUID; got group=%q uid=%q", gSvc.gotGroupNo, gSvc.gotUID)
+	}
+	// The group gate must not drift onto the P2P machinery (friend/blacklist/space).
+	if uSvc.friendCalls != 0 || uSvc.blCalls != 0 || uSvc.spaceCalls != 0 || uSvc.robotCalls != 0 {
+		t.Fatalf("as-bot group gate must not consult P2P services; friend=%d bl=%d space=%d robot=%d",
+			uSvc.friendCalls, uSvc.blCalls, uSvc.spaceCalls, uSvc.robotCalls)
+	}
+	if rec.Body.Len() != 0 {
+		t.Fatalf("no response should be written on allow, got %q", rec.Body.String())
+	}
+}
+
+// TestBotCanReadChannel_GroupNonMemberDenied — a bot that is NOT an active
+// member (kicked / group-blacklisted → ExistMemberActive false, including the
+// #354 cascade that flips an owner-blacklisted user's in-group bot to
+// status!=Normal) must be denied with NOT_FOUND (anti-enumeration).
+func TestBotCanReadChannel_GroupNonMemberDenied(t *testing.T) {
+	gSvc := &stubAuthzGroupSvc{
+		activeMembers: map[string]bool{}, // bot not active (removed / group-blacklisted)
+		groupModels:   map[string]*group.InfoResp{"G1": {GroupNo: "G1", Status: 1}},
+	}
+	h := newAuthzHandlerFull(gSvc, &stubAuthzUserSvc{}, &stubAuthzThreadSvc{})
+	c, rec := newAuthzCtx(t)
+
+	if h.canReadChannel(c, userBotPrincipal{botUID: "bot9"}, channelTypeGroup, "G1") {
+		t.Fatalf("as-bot non-member (or group-blacklisted) must be denied")
+	}
+	if gSvc.memberCalls != 1 || gSvc.gotUID != "bot9" {
+		t.Fatalf("ExistMemberActive must be consulted once with botUID; calls=%d uid=%q", gSvc.memberCalls, gSvc.gotUID)
+	}
+	if !strings.Contains(rec.Body.String(), "not found") {
+		t.Fatalf("denial should render the not_found envelope, got %q", rec.Body.String())
+	}
+}
+
+// TestBotCanReadChannel_GroupMissingDenied — a missing group model is treated
+// as "does not exist" → NOT_FOUND, before any membership lookup.
+func TestBotCanReadChannel_GroupMissingDenied(t *testing.T) {
+	gSvc := &stubAuthzGroupSvc{
+		activeMembers: map[string]bool{"G1": true}, // would pass membership, but group is gone
+		groupModels:   map[string]*group.InfoResp{},
+	}
+	h := newAuthzHandlerFull(gSvc, &stubAuthzUserSvc{}, &stubAuthzThreadSvc{})
+	c, rec := newAuthzCtx(t)
+
+	if h.canReadChannel(c, userBotPrincipal{botUID: "bot9"}, channelTypeGroup, "G1") {
+		t.Fatalf("as-bot search of a missing group must be denied")
+	}
+	if gSvc.memberCalls != 0 {
+		t.Fatalf("missing group must short-circuit before ExistMemberActive; got %d", gSvc.memberCalls)
+	}
+	if !strings.Contains(rec.Body.String(), "not found") {
+		t.Fatalf("denial should render the not_found envelope, got %q", rec.Body.String())
+	}
+}
+
+// TestBotCanReadChannel_GroupMemberErrorFailsClosed — an ExistMemberActive DB
+// error must fail closed (deny), never silently allow.
+func TestBotCanReadChannel_GroupMemberErrorFailsClosed(t *testing.T) {
+	gSvc := &stubAuthzGroupSvc{
+		groupModels: map[string]*group.InfoResp{"G1": {GroupNo: "G1", Status: 1}},
+		memberErr:   errors.New("db down"),
+	}
+	h := newAuthzHandlerFull(gSvc, &stubAuthzUserSvc{}, &stubAuthzThreadSvc{})
+	c, rec := newAuthzCtx(t)
+
+	if h.canReadChannel(c, userBotPrincipal{botUID: "bot9"}, channelTypeGroup, "G1") {
+		t.Fatalf("as-bot ExistMemberActive error must fail closed")
+	}
+	if rec.Body.Len() == 0 {
+		t.Fatalf("fail-closed denial must write a response")
+	}
+}
+
+// TestBotCanReadChannel_ThreadMemberAllowed — a bot that is an active member of
+// the parent group can search an existing thread (子区继承父群成员身份). The
+// parent-group membership is checked against the botUID.
+func TestBotCanReadChannel_ThreadMemberAllowed(t *testing.T) {
+	gSvc := &stubAuthzGroupSvc{activeMembers: map[string]bool{"G9": true}}
+	tSvc := &stubAuthzThreadSvc{threadOK: map[string]bool{"G9|123456789012345": true}}
+	h := newAuthzHandlerFull(gSvc, &stubAuthzUserSvc{}, tSvc)
+	c, rec := newAuthzCtx(t)
+
+	if !h.canReadChannel(c, userBotPrincipal{botUID: "bot9"}, channelTypeThread, "G9____123456789012345") {
+		t.Fatalf("as-bot parent-group member must pass the thread gate")
+	}
+	if gSvc.gotGroupNo != "G9" || gSvc.gotUID != "bot9" {
+		t.Fatalf("thread gate must check the parent group with botUID; got group=%q uid=%q", gSvc.gotGroupNo, gSvc.gotUID)
+	}
+	if tSvc.threadCalls != 1 {
+		t.Fatalf("thread gate must consult GetThread exactly once, got %d", tSvc.threadCalls)
+	}
+	if rec.Body.Len() != 0 {
+		t.Fatalf("no response should be written on allow, got %q", rec.Body.String())
+	}
+}
+
+// TestBotCanReadChannel_ThreadNonMemberDenied — a bot that is not an active
+// member of the parent group is denied (NOT_FOUND), same as a real non-member.
+func TestBotCanReadChannel_ThreadNonMemberDenied(t *testing.T) {
+	gSvc := &stubAuthzGroupSvc{activeMembers: map[string]bool{}}
+	tSvc := &stubAuthzThreadSvc{threadOK: map[string]bool{"G9|123456789012345": true}}
+	h := newAuthzHandlerFull(gSvc, &stubAuthzUserSvc{}, tSvc)
+	c, rec := newAuthzCtx(t)
+
+	if h.canReadChannel(c, userBotPrincipal{botUID: "bot9"}, channelTypeThread, "G9____123456789012345") {
+		t.Fatalf("as-bot non-member of parent group must be denied thread search")
+	}
+	if !strings.Contains(rec.Body.String(), "not found") {
+		t.Fatalf("denial should render the not_found envelope, got %q", rec.Body.String())
+	}
+}
+
+// TestBotCanReadChannel_ThreadMissingDenied — a missing/deleted thread is
+// denied (NOT_FOUND) before the parent-group membership lookup runs.
+func TestBotCanReadChannel_ThreadMissingDenied(t *testing.T) {
+	gSvc := &stubAuthzGroupSvc{activeMembers: map[string]bool{"G9": true}}
+	tSvc := &stubAuthzThreadSvc{threadOK: map[string]bool{}} // GetThread always errors → not found
+	h := newAuthzHandlerFull(gSvc, &stubAuthzUserSvc{}, tSvc)
+	c, rec := newAuthzCtx(t)
+
+	if h.canReadChannel(c, userBotPrincipal{botUID: "bot9"}, channelTypeThread, "G9____123456789012345") {
+		t.Fatalf("as-bot search of a missing/deleted thread must be denied")
+	}
+	if gSvc.memberCalls != 0 {
+		t.Fatalf("ExistMemberActive must not be reached after GetThread err; got %d", gSvc.memberCalls)
+	}
+	if !strings.Contains(rec.Body.String(), "not found") {
+		t.Fatalf("denial should render the not_found envelope, got %q", rec.Body.String())
+	}
+}

--- a/modules/messages_search/obo.go
+++ b/modules/messages_search/obo.go
@@ -1,0 +1,142 @@
+package messages_search
+
+import (
+	"errors"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"go.uber.org/zap"
+)
+
+// as-user(OBO) 搜索鉴权接线（YUJ-53 / #F）。
+//
+// 「search as user」= 请求带 on_behalf_of，经 OBO 以 grantor（当前=创建者）身份搜索。
+// 鉴权语义（决策十）= 真人分支（grantor 真人可达 + 双向 blacklist，主体=grantorUID）∩
+// OBO 已授 scope。scope 校验复用发消息侧 bot_api/obo_check.go 的
+// grant + scope + grantorCanReadChannel 实时权限——因此 TOCTOU 与发消息侧一致：grantor 被
+// 踢出群 / 解除好友 / scope 被关后立刻搜不到（防拿旧 grant 越权）。
+//
+// messages_search 刻意不导入 bot_api（保持解耦，见 principal.go 顶部说明），OBO 校验以注入
+// 式 seam 承载：#B 装配 bot 搜索路由时用 SetOBOChecker 注入 bot_api 支持的适配器
+// （*bot_api.BotAPI.SearchOBOAllowed 结构性满足 oboChecker）。
+//
+// 归一化（决策九）：单频道门（oboCanReadChannel）与 global allowlist
+// （oboEnumerateReadableChannels）共用同一 oboChecker，保证「单频道放行 ⇔ 频道出现在
+// allowlist」双向一致，杜绝两路漂移。
+
+// oboChecker 是 as-user(OBO) 搜索 scope 门的注入 seam。语义与发消息侧 checkOBO 完全一致。
+// 返回约定（存在性隐藏 + fail-closed）：
+//   - (true,  nil) → (channelID, channelType) 对 grantor 已授权 → 放行；
+//   - (false, nil) → ErrOBONotAuthorized 语义（无 grant / scope disabled / grantor 已失去
+//     实时访问）→ 调用方渲染 NOT_FOUND，不泄露 grant/scope 是否存在；
+//   - (false, err) → 基础设施错误 → 调用方 fail-closed（INTERNAL_ERROR）。
+type oboChecker interface {
+	SearchOBOAllowed(botUID, grantorUID, channelID string, channelType uint8) (bool, error)
+}
+
+// errOBONoChecker as-user(OBO) 主体命中搜索但路由未注入 oboChecker（#B 装配遗漏）。
+// fail-closed：绝不在缺 checker 时把 obo 搜索降级为无 scope 约束的 grantor 全量。
+var errOBONoChecker = errors.New("messages_search: obo checker not wired (YUJ-49 route assembly)")
+
+// SetOBOChecker 注入 as-user(OBO) scope 门实现（#B 在装配 bot 搜索路由时调用）。
+func (h *Handler) SetOBOChecker(c oboChecker) { h.oboCheck = c }
+
+// oboAllowed 带 nil-guard 地调用注入的 oboChecker；缺 checker → fail-closed error。
+func (h *Handler) oboAllowed(botUID, grantorUID, channelID string, channelType uint8) (bool, error) {
+	if h.oboCheck == nil {
+		return false, errOBONoChecker
+	}
+	return h.oboCheck.SearchOBOAllowed(botUID, grantorUID, channelID, channelType)
+}
+
+// oboCanReadChannel 是 as-user(OBO) 的单频道门（canReadChannel 的 obo 分支）。
+// 语义 = grantor 真人分支（checkChannelAccess，含双向 blacklist）∩ OBO 已授 scope。
+// 任一不过 → NOT_FOUND（存在性隐藏，与真人拒绝同面）；基础设施错 → INTERNAL（fail-closed）。
+//
+// 真人分支在先：以 grantorUID 为主体复用现有 checkChannelAccess（#C/#D 的 user 分支），
+// 覆盖群/子区成员、P2P 好友/同 Space、双向 blacklist；随后 ∩ OBO scope 二次收窄。两段的
+// grantorCanReadChannel/成员校验都取实时权限，故 TOCTOU 双重兜底。
+func (h *Handler) oboCanReadChannel(c *wkhttp.Context, p Principal, channelType uint8, channelID string) bool {
+	op, ok := p.(oboPrincipal)
+	if !ok {
+		// 不应发生：dispatch 已按 Kind 分派。防御性 fail-closed。
+		h.Error("messages_search: obo gate received non-obo principal",
+			zap.String("kind", p.Kind().String()))
+		respondInternal(c)
+		return false
+	}
+	// 1) 真人分支（主体=grantorUID）。拒绝时 checkChannelAccess 已渲染 NOT_FOUND/INTERNAL。
+	if !h.checkChannelAccess(c, channelType, channelID, op.grantorUID) {
+		return false
+	}
+	// 2) ∩ OBO 已授 scope：grant + scope + grantorCanReadChannel 实时权限（TOCTOU）。
+	allowed, err := h.oboAllowed(op.botUID, op.grantorUID, channelID, channelType)
+	if err != nil {
+		h.Error("messages_search: obo scope check failed",
+			zap.String("bot_uid", op.botUID),
+			zap.String("grantor_uid", op.grantorUID),
+			zap.Uint8("channel_type", channelType),
+			zap.String("channel_id", channelID),
+			zap.Error(err))
+		respondInternal(c)
+		return false
+	}
+	if !allowed {
+		// 存在性隐藏：与真人拒绝一致，不泄露 grant/scope 是否存在。
+		respondNotFound(c, "channel")
+		return false
+	}
+	return true
+}
+
+// oboEnumerateReadableChannels 是 as-user(OBO) 的 global allowlist
+// （enumerateReadableChannels 的 obo 分支），与 oboCanReadChannel 同一谓词（决策九）：
+// 先取 grantor 真人可达集（buildAllowlist），再 ∩ OBO 已授 scope 逐频道收窄。保证
+// 「单频道门放行 ⇔ 频道出现在 global allowlist」双向一致。
+//
+// 基础设施错 → 整体 fail-closed（返回 err；上游按现有真人 allowlist 失败策略处理，不静默截断）。
+func (h *Handler) oboEnumerateReadableChannels(c *wkhttp.Context, p Principal) ([]channelRef, []channelRef, []channelRef, allowlistTimings, error) {
+	op, ok := p.(oboPrincipal)
+	if !ok {
+		h.Error("messages_search: obo allowlist received non-obo principal",
+			zap.String("kind", p.Kind().String()))
+		return nil, nil, nil, allowlistTimings{}, errOBONoChecker
+	}
+	allowGroup, allowDM, allowThread, timings, err := h.buildAllowlist(c, op.grantorUID, op.spaceID)
+	if err != nil {
+		return nil, nil, nil, timings, err
+	}
+	fg, err := h.filterChannelsByOBO(op.botUID, op.grantorUID, allowGroup)
+	if err != nil {
+		return nil, nil, nil, timings, err
+	}
+	fdm, err := h.filterChannelsByOBO(op.botUID, op.grantorUID, allowDM)
+	if err != nil {
+		return nil, nil, nil, timings, err
+	}
+	fth, err := h.filterChannelsByOBO(op.botUID, op.grantorUID, allowThread)
+	if err != nil {
+		return nil, nil, nil, timings, err
+	}
+	return fg, fdm, fth, timings, nil
+}
+
+// filterChannelsByOBO 逐频道 ∩ OBO 已授 scope，仅保留放行的频道。每个 channelRef 用自身
+// WireID（DM=peer uid、群=group_no、子区=组合 id `<group>____<short>`）+ ChannelType 求值，
+// 与发消息侧 checkOBO 的 per-type 语义完全一致。基础设施错 → 立即返回 err（fail-closed，
+// 不部分放行）。ErrOBONotAuthorized 语义的频道被静默剔除（存在性隐藏）。
+func (h *Handler) filterChannelsByOBO(botUID, grantorUID string, refs []channelRef) ([]channelRef, error) {
+	if len(refs) == 0 {
+		return refs, nil
+	}
+	out := make([]channelRef, 0, len(refs))
+	for _, ref := range refs {
+		allowed, err := h.oboAllowed(botUID, grantorUID, ref.WireID, ref.ChannelType)
+		if err != nil {
+			return nil, err
+		}
+		if allowed {
+			out = append(out, ref)
+		}
+	}
+	return out, nil
+}

--- a/modules/messages_search/obo_test.go
+++ b/modules/messages_search/obo_test.go
@@ -1,0 +1,337 @@
+package messages_search
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-server/modules/group"
+	"github.com/Mininglamp-OSS/octo-server/modules/thread"
+)
+
+// as-user(OBO) 鉴权接线单测（YUJ-53 / #F）。覆盖：
+//   - 单频道门 = grantor 真人分支 ∩ OBO 已授 scope；
+//   - 真人分支在先且短路（grantor 无权 → 不消费 OBO checker）；
+//   - OBO scope 拒绝 → NOT_FOUND（存在性隐藏）；
+//   - 双向 blacklist 对 grantor 生效；
+//   - TOCTOU：grantor 失去实时成员资格 → 拒绝；
+//   - checker 缺失 / infra 错 → fail-closed（INTERNAL），绝不降级为无 scope grantor 全量；
+//   - global allowlist 与单频道门共用同一 OBO 谓词（决策九一致性）；
+//   - App Bot 主体构造显式拒绝。
+
+// fakeOBOChecker 是 oboChecker 的测试替身。allow[key] 命中 → 放行；err 非空 → infra 错。
+type fakeOBOChecker struct {
+	allow map[string]bool
+	err   error
+	calls int
+	seen  []string // 记录被求值的 "channelID|type"，用于断言短路 / 频道维度
+}
+
+func oboKey(channelID string, channelType uint8) string {
+	return channelID + "|" + string(rune('0'+channelType))
+}
+
+func (f *fakeOBOChecker) SearchOBOAllowed(botUID, grantorUID, channelID string, channelType uint8) (bool, error) {
+	f.calls++
+	f.seen = append(f.seen, oboKey(channelID, channelType))
+	if f.err != nil {
+		return false, f.err
+	}
+	return f.allow[oboKey(channelID, channelType)], nil
+}
+
+// newOBOHandler 组装带 authz 桩 + 注入 oboChecker 的 Handler。
+func newOBOHandler(gSvc *stubAuthzGroupSvc, uSvc *stubAuthzUserSvc, chk oboChecker) *Handler {
+	h := newAuthzHandlerFull(gSvc, uSvc, &stubAuthzThreadSvc{})
+	h.oboCheck = chk
+	return h
+}
+
+func oboGroupPrincipal() oboPrincipal {
+	return oboPrincipal{botUID: "bot9", grantorUID: "grace", spaceID: ""}
+}
+
+// TestOBOCanReadChannel_GroupAllowed — grantor 是活跃成员且 OBO scope 已授 → 放行，
+// 不写响应。经 canReadChannel dispatch 进入 obo 分支。
+func TestOBOCanReadChannel_GroupAllowed(t *testing.T) {
+	gSvc := &stubAuthzGroupSvc{
+		groupModels:   map[string]*group.InfoResp{"G1": {GroupNo: "G1", Status: 1}, "G2": {GroupNo: "G2", Status: 1}},
+		activeMembers: map[string]bool{"G1": true},
+	}
+	chk := &fakeOBOChecker{allow: map[string]bool{oboKey("G1", channelTypeGroup): true}}
+	h := newOBOHandler(gSvc, &stubAuthzUserSvc{}, chk)
+	c, rec := newAuthzCtx(t)
+	p := oboGroupPrincipal()
+	setPrincipal(c, p)
+
+	if !h.canReadChannel(c, p, channelTypeGroup, "G1") {
+		t.Fatalf("grantor member + obo scope granted must pass, body=%q", rec.Body.String())
+	}
+	if rec.Body.Len() != 0 {
+		t.Fatalf("allow must not write a response, got %q", rec.Body.String())
+	}
+	if chk.calls != 1 {
+		t.Fatalf("obo checker must be consulted exactly once, got %d", chk.calls)
+	}
+}
+
+// TestOBOCanReadChannel_ScopeDeniedHidesChannel — grantor 可达但 OBO 未授权该频道 →
+// NOT_FOUND（存在性隐藏）。
+func TestOBOCanReadChannel_ScopeDeniedHidesChannel(t *testing.T) {
+	gSvc := &stubAuthzGroupSvc{
+		groupModels:   map[string]*group.InfoResp{"G1": {GroupNo: "G1", Status: 1}, "G2": {GroupNo: "G2", Status: 1}},
+		activeMembers: map[string]bool{"G1": true},
+	}
+	chk := &fakeOBOChecker{allow: map[string]bool{}} // scope 未授
+	h := newOBOHandler(gSvc, &stubAuthzUserSvc{}, chk)
+	c, rec := newAuthzCtx(t)
+	p := oboGroupPrincipal()
+	setPrincipal(c, p)
+
+	if h.canReadChannel(c, p, channelTypeGroup, "G1") {
+		t.Fatalf("obo scope not granted must be denied")
+	}
+	if !strings.Contains(rec.Body.String(), "not found") {
+		t.Fatalf("scope denial must render the not_found envelope, got %q", rec.Body.String())
+	}
+	if chk.calls != 1 {
+		t.Fatalf("obo checker must be consulted once (real-person passed), got %d", chk.calls)
+	}
+}
+
+// TestOBOCanReadChannel_RealPersonDeniedShortCircuits — grantor 非成员 → 真人分支先拒，
+// OBO checker 根本不被消费（证明真人分支在先）。
+func TestOBOCanReadChannel_RealPersonDeniedShortCircuits(t *testing.T) {
+	gSvc := &stubAuthzGroupSvc{
+		groupModels:   map[string]*group.InfoResp{"G1": {GroupNo: "G1", Status: 1}, "G2": {GroupNo: "G2", Status: 1}},
+		activeMembers: map[string]bool{}, // 非成员
+	}
+	chk := &fakeOBOChecker{allow: map[string]bool{oboKey("G1", channelTypeGroup): true}}
+	h := newOBOHandler(gSvc, &stubAuthzUserSvc{}, chk)
+	c, rec := newAuthzCtx(t)
+	p := oboGroupPrincipal()
+	setPrincipal(c, p)
+
+	if h.canReadChannel(c, p, channelTypeGroup, "G1") {
+		t.Fatalf("non-member grantor must be denied")
+	}
+	if !strings.Contains(rec.Body.String(), "not found") {
+		t.Fatalf("real-person denial must render the not_found envelope, got %q", rec.Body.String())
+	}
+	if chk.calls != 0 {
+		t.Fatalf("obo checker must NOT be consulted when real-person gate fails, got %d", chk.calls)
+	}
+}
+
+// TestOBOCanReadChannel_TOCTOU_GrantorLostMembership — grantor 已被踢出群
+// （ExistMemberActive=false）→ 立即拒绝，不放行陈旧 grant。TOCTOU 与发消息侧一致。
+func TestOBOCanReadChannel_TOCTOU_GrantorLostMembership(t *testing.T) {
+	gSvc := &stubAuthzGroupSvc{
+		groupModels:   map[string]*group.InfoResp{"G1": {GroupNo: "G1", Status: 1}, "G2": {GroupNo: "G2", Status: 1}},
+		activeMembers: map[string]bool{"G1": false}, // 已失去实时成员资格
+	}
+	chk := &fakeOBOChecker{allow: map[string]bool{oboKey("G1", channelTypeGroup): true}}
+	h := newOBOHandler(gSvc, &stubAuthzUserSvc{}, chk)
+	c, rec := newAuthzCtx(t)
+	p := oboGroupPrincipal()
+	setPrincipal(c, p)
+
+	if h.canReadChannel(c, p, channelTypeGroup, "G1") {
+		t.Fatalf("grantor who lost live membership must be denied (TOCTOU)")
+	}
+	if !strings.Contains(rec.Body.String(), "not found") {
+		t.Fatalf("TOCTOU denial must render the not_found envelope, got %q", rec.Body.String())
+	}
+}
+
+// TestOBOCanReadChannel_DMBidirectionalBlacklist — grantor 与对端互为好友，但对端拉黑
+// grantor → 双向 blacklist 生效，NOT_FOUND。obo 完全复用真人双向黑名单。
+func TestOBOCanReadChannel_DMBidirectionalBlacklist(t *testing.T) {
+	uSvc := &stubAuthzUserSvc{
+		friends:    map[string]bool{friendKey("grace", "peer"): true},
+		blacklists: map[string]bool{blacklistKey("peer", "grace"): true}, // peer→grantor 拉黑
+		robots:     map[string]robotStub{"peer": {isRobot: false}},
+	}
+	chk := &fakeOBOChecker{allow: map[string]bool{oboKey("peer", channelTypePerson): true}}
+	h := newOBOHandler(&stubAuthzGroupSvc{}, uSvc, chk)
+	c, rec := newAuthzCtx(t)
+	p := oboGroupPrincipal()
+	setPrincipal(c, p)
+
+	if h.canReadChannel(c, p, channelTypePerson, "peer") {
+		t.Fatalf("bidirectional blacklist must hide the DM for obo grantor")
+	}
+	if !strings.Contains(rec.Body.String(), "not found") {
+		t.Fatalf("blacklist denial must render the not_found envelope, got %q", rec.Body.String())
+	}
+	if chk.calls != 0 {
+		t.Fatalf("blacklist (real-person gate) must short-circuit before obo scope, got %d", chk.calls)
+	}
+}
+
+// TestOBOCanReadChannel_NoCheckerFailsClosed — 路由未注入 oboChecker → INTERNAL，
+// 绝不降级为无 scope 约束的 grantor 全量搜索。
+func TestOBOCanReadChannel_NoCheckerFailsClosed(t *testing.T) {
+	gSvc := &stubAuthzGroupSvc{
+		groupModels:   map[string]*group.InfoResp{"G1": {GroupNo: "G1", Status: 1}, "G2": {GroupNo: "G2", Status: 1}},
+		activeMembers: map[string]bool{"G1": true},
+	}
+	h := newOBOHandler(gSvc, &stubAuthzUserSvc{}, nil) // 无 checker
+	c, rec := newAuthzCtx(t)
+	p := oboGroupPrincipal()
+	setPrincipal(c, p)
+
+	if h.canReadChannel(c, p, channelTypeGroup, "G1") {
+		t.Fatalf("missing obo checker must fail closed")
+	}
+	if !strings.Contains(rec.Body.String(), "Internal search error") {
+		t.Fatalf("missing checker must render the internal-error envelope, got %q", rec.Body.String())
+	}
+}
+
+// TestOBOCanReadChannel_CheckerErrorFailsClosed — OBO checker 返回 infra 错 → INTERNAL。
+func TestOBOCanReadChannel_CheckerErrorFailsClosed(t *testing.T) {
+	gSvc := &stubAuthzGroupSvc{
+		groupModels:   map[string]*group.InfoResp{"G1": {GroupNo: "G1", Status: 1}, "G2": {GroupNo: "G2", Status: 1}},
+		activeMembers: map[string]bool{"G1": true},
+	}
+	chk := &fakeOBOChecker{err: errors.New("obo store down")}
+	h := newOBOHandler(gSvc, &stubAuthzUserSvc{}, chk)
+	c, rec := newAuthzCtx(t)
+	p := oboGroupPrincipal()
+	setPrincipal(c, p)
+
+	if h.canReadChannel(c, p, channelTypeGroup, "G1") {
+		t.Fatalf("obo checker infra error must fail closed")
+	}
+	if !strings.Contains(rec.Body.String(), "Internal search error") {
+		t.Fatalf("checker error must render the internal-error envelope, got %q", rec.Body.String())
+	}
+}
+
+// TestFilterChannelsByOBO_NarrowsByScope — global allowlist 逐频道 ∩ OBO scope：仅保留
+// 被授权的频道，且用每个频道自身 WireID + ChannelType 求值（子区用组合 id）。
+func TestFilterChannelsByOBO_NarrowsByScope(t *testing.T) {
+	threadID := thread.BuildChannelID("G2", "t123")
+	refs := []channelRef{
+		{OSChannelID: "G1", WireID: "G1", ChannelType: channelTypeGroup},
+		{OSChannelID: "G2", WireID: "G2", ChannelType: channelTypeGroup},
+		{OSChannelID: threadID, WireID: threadID, ChannelType: channelTypeThread},
+	}
+	chk := &fakeOBOChecker{allow: map[string]bool{
+		oboKey("G1", channelTypeGroup):      true,
+		oboKey(threadID, channelTypeThread): true,
+		// G2 未授权 → 被剔除
+	}}
+	h := newOBOHandler(&stubAuthzGroupSvc{}, &stubAuthzUserSvc{}, chk)
+
+	out, err := h.filterChannelsByOBO("bot9", "grace", refs)
+	if err != nil {
+		t.Fatalf("unexpected err %v", err)
+	}
+	if len(out) != 2 {
+		t.Fatalf("want 2 channels after scope narrowing, got %d (%+v)", len(out), out)
+	}
+	if out[0].WireID != "G1" || out[1].WireID != threadID {
+		t.Fatalf("scope narrowing kept wrong channels: %+v", out)
+	}
+}
+
+// TestFilterChannelsByOBO_FailClosedOnError — checker infra 错 → 整体返回 err（不部分放行）。
+func TestFilterChannelsByOBO_FailClosedOnError(t *testing.T) {
+	refs := []channelRef{{WireID: "G1", ChannelType: channelTypeGroup}}
+	chk := &fakeOBOChecker{err: errors.New("boom")}
+	h := newOBOHandler(&stubAuthzGroupSvc{}, &stubAuthzUserSvc{}, chk)
+
+	if _, err := h.filterChannelsByOBO("bot9", "grace", refs); err == nil {
+		t.Fatalf("infra error must fail closed (return err)")
+	}
+}
+
+// TestOBOCrossPathConsistency — 决策九：任取频道，单频道门放行 ⇔ 该频道存活于 global
+// allowlist 的 scope 收窄。两路共用同一 OBO 谓词（oboAllowed），故对同一 (wireID,type) 一致。
+func TestOBOCrossPathConsistency(t *testing.T) {
+	gSvc := &stubAuthzGroupSvc{
+		groupModels:   map[string]*group.InfoResp{"G1": {GroupNo: "G1", Status: 1}, "G2": {GroupNo: "G2", Status: 1}},
+		activeMembers: map[string]bool{"G1": true, "G2": true},
+	}
+	// G1 授权、G2 未授权。
+	allow := map[string]bool{oboKey("G1", channelTypeGroup): true}
+	refs := []channelRef{
+		{WireID: "G1", ChannelType: channelTypeGroup},
+		{WireID: "G2", ChannelType: channelTypeGroup},
+	}
+	p := oboGroupPrincipal()
+
+	for _, ref := range refs {
+		// 单频道门
+		singleChk := &fakeOBOChecker{allow: allow}
+		h1 := newOBOHandler(gSvc, &stubAuthzUserSvc{}, singleChk)
+		c, _ := newAuthzCtx(t)
+		setPrincipal(c, p)
+		single := h1.canReadChannel(c, p, ref.ChannelType, ref.WireID)
+
+		// allowlist 收窄
+		listChk := &fakeOBOChecker{allow: allow}
+		h2 := newOBOHandler(gSvc, &stubAuthzUserSvc{}, listChk)
+		out, err := h2.filterChannelsByOBO(p.botUID, p.grantorUID, []channelRef{ref})
+		if err != nil {
+			t.Fatalf("filter err: %v", err)
+		}
+		inList := len(out) == 1
+
+		if single != inList {
+			t.Fatalf("cross-path drift for %s: single=%v inList=%v", ref.WireID, single, inList)
+		}
+	}
+}
+
+// TestAuthenticateOBOFromContext_AppBotDenied — App Bot 主体构造显式拒绝（不静默放行）。
+func TestAuthenticateOBOFromContext_AppBotDenied(t *testing.T) {
+	c, _ := newPrincipalCtx(t)
+	c.Set(ctxKeyRobotID, "appbot1")
+	c.Set(ctxKeyBotKind, botKindApp)
+
+	_, err := authenticateOBOFromContext(c, "grace")
+	if !errors.Is(err, errPrincipalAppBotDenied) {
+		t.Fatalf("App Bot OBO must be explicitly denied, got %v", err)
+	}
+}
+
+// TestAuthenticateOBOFromContext_UserBotAssembled — User Bot + grantor → oboPrincipal
+// 载体（主体=grantor、审计记 botUID+grantor、限流按 botUID）。
+func TestAuthenticateOBOFromContext_UserBotAssembled(t *testing.T) {
+	c, _ := newPrincipalCtx(t)
+	c.Set(ctxKeyRobotID, "bot9")
+	c.Set(ctxKeyBotKind, botKindUser)
+
+	p, err := authenticateOBOFromContext(c, "grace")
+	if err != nil {
+		t.Fatalf("unexpected err %v", err)
+	}
+	if p.Kind() != principalKindOBO {
+		t.Fatalf("want obo kind, got %s", p.Kind())
+	}
+	if p.SubjectUID() != "grace" {
+		t.Fatalf("subject must be grantor, got %q", p.SubjectUID())
+	}
+	if p.RateLimitKey() != "bot9" || p.AuditBotUID() != "bot9" || p.AuditGrantorUID() != "grace" {
+		t.Fatalf("rate/audit mismatch: rl=%q auditBot=%q auditGrantor=%q",
+			p.RateLimitKey(), p.AuditBotUID(), p.AuditGrantorUID())
+	}
+}
+
+// TestAuthenticateOBOFromContext_MissingInputs — 缺 botUID / grantor → 未鉴权（fail-closed）。
+func TestAuthenticateOBOFromContext_MissingInputs(t *testing.T) {
+	// 缺 robot_id
+	c1, _ := newPrincipalCtx(t)
+	if _, err := authenticateOBOFromContext(c1, "grace"); !errors.Is(err, errPrincipalUnauthenticated) {
+		t.Fatalf("missing bot uid must be unauthenticated, got %v", err)
+	}
+	// 缺 grantor
+	c2, _ := newPrincipalCtx(t)
+	c2.Set(ctxKeyRobotID, "bot9")
+	if _, err := authenticateOBOFromContext(c2, ""); !errors.Is(err, errPrincipalUnauthenticated) {
+		t.Fatalf("missing grantor must be unauthenticated, got %v", err)
+	}
+}

--- a/modules/messages_search/predicate.go
+++ b/modules/messages_search/predicate.go
@@ -1,8 +1,6 @@
 package messages_search
 
 import (
-	"errors"
-
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
 	"go.uber.org/zap"
 )
@@ -17,10 +15,7 @@ import (
 //   - user / obo / uk 三类真人语义主体 → 复用现有 checkChannelAccess / buildAllowlist，
 //     仅主体 uid 由 principal.SubjectUID() 提供（obo=grantor、uk=key UID）。
 //   - as-bot 分支是 #C/#D（canReadChannel）与 #E（enumerateReadableChannels）的接线点，
-//     本层 fail-closed 占位（#B 之前无 bot 路由，不影响现网）。
-
-// errBotPredicateNotImplemented as-bot 可读谓词尚未接线（#C/#D/#E）。
-var errBotPredicateNotImplemented = errors.New("messages_search: as-bot readable predicate not implemented (YUJ-50/51/52)")
+//     #E（YUJ-52）已接线枚举；#C/#D 单频道门待接线（botCanReadChannel 仍 fail-closed 占位）。
 
 // canReadChannel 是单频道门——#C/#D 按 principal 分支细化、#E 的 allowlist 枚举同一谓词。
 // 真人语义主体（user / obo / uk）走现有 checkChannelAccess（主体 uid 来自 principal）；
@@ -52,7 +47,7 @@ func (h *Handler) enumerateReadableChannels(c *wkhttp.Context, p Principal) ([]c
 
 // principalForSubject 为一个「已解析的真人语义主体」返回其 principal 载体，供内部枚举
 // 路径（resolveGlobalScope）经归一化谓词求值时使用。优先返回路由显式写入的 principal
-//（bot / uk / obo，#B），否则用传入的 uid/spaceID 组装真人载体——这保证现网真人路径与
+// （bot / uk / obo，#B），否则用传入的 uid/spaceID 组装真人载体——这保证现网真人路径与
 // 直接以 (loginUID, spaceID) 驱动枚举的既有单测行为完全不变。
 func principalForSubject(c *wkhttp.Context, uid, spaceID string) Principal {
 	if v, ok := c.Get(principalCtxKey); ok {
@@ -66,7 +61,7 @@ func principalForSubject(c *wkhttp.Context, uid, spaceID string) Principal {
 // botCanReadChannel 是 as-bot 单频道门的接线点（#C/#D）。bot 谓词 =
 // IsFriend(botUID, peer) 的 DM ∪ ExistMemberActive(group, botUID) 的群/子区，
 // 且跳过 Space 段与全部 P2P blacklist。本层 fail-closed 占位：渲染 NOT_FOUND
-//（反枚举，与真人拒绝一致）。#B 接线 bot 路由前不会触达此分支。
+// （反枚举，与真人拒绝一致）。#B 接线 bot 路由前不会触达此分支。
 func (h *Handler) botCanReadChannel(c *wkhttp.Context, p Principal, channelType uint8, channelID string) bool {
 	h.Warn("messages_search: as-bot channel gate not yet implemented (YUJ-50/51); denying fail-closed",
 		zap.String("bot_uid", p.SubjectUID()),
@@ -76,11 +71,18 @@ func (h *Handler) botCanReadChannel(c *wkhttp.Context, p Principal, channelType 
 	return false
 }
 
-// botEnumerateReadableChannels 是 as-bot global allowlist 枚举的接线点（#E）。
-// allowlist = bot 所在群/子区 ∪ IsFriend(botUID) 的 DM 对端，与 botCanReadChannel
-// 同一谓词。本层 fail-closed 占位返回错误（#B 接线 bot 路由前不会触达此分支）。
+// botEnumerateReadableChannels 是 as-bot global allowlist 枚举（#E / YUJ-52），与
+// botCanReadChannel（#C/#D）严格同一谓词（决策九）：
+//   - 群/子区：ExistMemberActive(group, botUID) 为真的群及其活跃子区（子区继承父群成员身份）；
+//   - DM：IsFriend(botUID, peer) 的每个好友对端（无黑名单、无 Space、无 bot-in-Space 抑制）。
+//
+// 实现委托给 buildBotAllowlist（与真人 buildAllowlist 同处 search_global.go），复用
+// 既有 enumerateThreadsForGroups 与 per-group/聚合 thread 上限——不为 bot 另设上限，也
+// 不在此内联重写任何鉴权规则（有界性与归一化理由见 buildBotAllowlist 文档）。
+//
+// App Bot：一期禁用 global。authenticateUserBot 已在 principal 构造阶段 fail-closed 拒绝
+// App Bot（errPrincipalAppBotDenied），只有 User Bot 能构造出 userBotPrincipal 抵达此处，
+// 故无需在此重复运行时判定（本主体类型即 App-Bot-已排除 的保证）。
 func (h *Handler) botEnumerateReadableChannels(_ *wkhttp.Context, p Principal) ([]channelRef, []channelRef, []channelRef, allowlistTimings, error) {
-	h.Warn("messages_search: as-bot global allowlist not yet implemented (YUJ-52); failing closed",
-		zap.String("bot_uid", p.SubjectUID()))
-	return nil, nil, nil, allowlistTimings{}, errBotPredicateNotImplemented
+	return h.buildBotAllowlist(p.SubjectUID())
 }

--- a/modules/messages_search/predicate.go
+++ b/modules/messages_search/predicate.go
@@ -60,15 +60,36 @@ func principalForSubject(c *wkhttp.Context, uid, spaceID string) Principal {
 
 // botCanReadChannel 是 as-bot 单频道门的接线点（#C/#D）。bot 谓词 =
 // IsFriend(botUID, peer) 的 DM ∪ ExistMemberActive(group, botUID) 的群/子区，
-// 且跳过 Space 段与全部 P2P blacklist。本层 fail-closed 占位：渲染 NOT_FOUND
-// （反枚举，与真人拒绝一致）。#B 接线 bot 路由前不会触达此分支。
+// 且跳过 Space 段与全部 P2P blacklist。按 channelType 分派：
+//
+//   - person（1）：#C（YUJ-50）已接线 —— botCheckP2PAccess（见 authz.go），
+//     谓词 = IsFriend(botUID, peer)，是 #E buildBotAllowlist 的 GetFriends(botUID)
+//     枚举对偶（决策九）；跳过 Space 与双向 blacklist。
+//   - group（2）/ thread（5）：#D（YUJ-51）的接线点，尚未落地 —— 保持 fail-closed
+//     占位（渲染 NOT_FOUND，反枚举，与真人拒绝一致）。
+//   - 其他：validate.go 已在此前拒绝未知 channelType；仍 fail-closed 兜底。
+//
+// #B 接线 bot 路由前不会触达此分支。
 func (h *Handler) botCanReadChannel(c *wkhttp.Context, p Principal, channelType uint8, channelID string) bool {
-	h.Warn("messages_search: as-bot channel gate not yet implemented (YUJ-50/51); denying fail-closed",
-		zap.String("bot_uid", p.SubjectUID()),
-		zap.Uint8("channel_type", channelType),
-		zap.String("channel_id", channelID))
-	respondNotFound(c, "channel")
-	return false
+	switch channelType {
+	case channelTypePerson:
+		return h.botCheckP2PAccess(c, p.SubjectUID(), channelID)
+	case channelTypeGroup, channelTypeThread:
+		// #D（YUJ-51）尚未接线：群/子区门主体换 botUID（ExistMemberActive）在此落。
+		h.Warn("messages_search: as-bot group/thread gate not yet implemented (YUJ-51); denying fail-closed",
+			zap.String("bot_uid", p.SubjectUID()),
+			zap.Uint8("channel_type", channelType),
+			zap.String("channel_id", channelID))
+		respondNotFound(c, "channel")
+		return false
+	default:
+		h.Warn("messages_search: as-bot channel gate unexpected channel_type; denying fail-closed",
+			zap.String("bot_uid", p.SubjectUID()),
+			zap.Uint8("channel_type", channelType),
+			zap.String("channel_id", channelID))
+		respondNotFound(c, "channel")
+		return false
+	}
 }
 
 // botEnumerateReadableChannels 是 as-bot global allowlist 枚举（#E / YUJ-52），与

--- a/modules/messages_search/predicate.go
+++ b/modules/messages_search/predicate.go
@@ -11,10 +11,12 @@ import (
 //	canReadChannel(principal, channel)         // 单频道门对一个频道求值
 //	enumerateReadableChannels(principal)       // 全局 allowlist 枚举同一谓词
 //
-// 本层（YUJ-48）只定义接口 + dispatch，不改鉴权语义：
-//   - user / obo / uk 三类真人语义主体 → 复用现有 checkChannelAccess / buildAllowlist，
-//     仅主体 uid 由 principal.SubjectUID() 提供（obo=grantor、uk=key UID）。
-//   - as-bot 分支是 #C/#D（canReadChannel）与 #E（enumerateReadableChannels）的接线点：
+// 本层（YUJ-48）定义接口 + dispatch；各主体分支语义分文件落地：
+//   - user / uk：真人语义主体 → 复用现有 checkChannelAccess / buildAllowlist，仅主体 uid
+//     由 principal.SubjectUID() 提供（uk=key UID）。
+//   - obo：grantor 真人分支 ∩ OBO 已授 scope（YUJ-53 / #F，见 obo.go）——单频道门与
+//     allowlist 共用同一 oboChecker 谓词。
+//   - as-bot：#C/#D（canReadChannel）与 #E（enumerateReadableChannels）的接线点：
 //     #C（YUJ-50）已接线 DM 门（IsFriend，跳过 blacklist）、#D（YUJ-51）已接线群/子区门
 //     （复用 ExistMemberActive，主体=botUID）、#E（YUJ-52）已接线 global allowlist 枚举。
 
@@ -25,8 +27,11 @@ func (h *Handler) canReadChannel(c *wkhttp.Context, p Principal, channelType uin
 	switch p.Kind() {
 	case principalKindUserBot:
 		return h.botCanReadChannel(c, p, channelType, channelID)
+	case principalKindOBO:
+		// as-user(OBO)：grantor 真人分支 ∩ OBO 已授 scope（YUJ-53 / #F，见 obo.go）。
+		return h.oboCanReadChannel(c, p, channelType, channelID)
 	default:
-		// user / obo / uk：真人语义，主体 uid 各异。checkChannelAccess 内部的
+		// user / uk：真人语义，主体 uid 各异。checkChannelAccess 内部的
 		// 双向黑名单由 blacklistPolicy 决定（真人语义主体均为 bidirectional）。
 		return h.checkChannelAccess(c, channelType, channelID, p.SubjectUID())
 	}
@@ -41,6 +46,10 @@ func (h *Handler) enumerateReadableChannels(c *wkhttp.Context, p Principal) ([]c
 	switch p.Kind() {
 	case principalKindUserBot:
 		return h.botEnumerateReadableChannels(c, p)
+	case principalKindOBO:
+		// as-user(OBO)：grantor 真人可达集 ∩ OBO 已授 scope，与 oboCanReadChannel 同一
+		// 谓词（决策九，见 obo.go）。
+		return h.oboEnumerateReadableChannels(c, p)
 	default:
 		return h.buildAllowlist(c, p.SubjectUID(), p.SpaceID())
 	}

--- a/modules/messages_search/predicate.go
+++ b/modules/messages_search/predicate.go
@@ -1,0 +1,86 @@
+package messages_search
+
+import (
+	"errors"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"go.uber.org/zap"
+)
+
+// 归一化可读谓词（决策九）。bot 主体的「单一可读谓词」，供 #C/#D（单频道门单点求值）与
+// #E（global allowlist 枚举）共用，杜绝两路各写一套鉴权规则而漂移。
+//
+//	canReadChannel(principal, channel)         // 单频道门对一个频道求值
+//	enumerateReadableChannels(principal)       // 全局 allowlist 枚举同一谓词
+//
+// 本层（YUJ-48）只定义接口 + dispatch，不改鉴权语义：
+//   - user / obo / uk 三类真人语义主体 → 复用现有 checkChannelAccess / buildAllowlist，
+//     仅主体 uid 由 principal.SubjectUID() 提供（obo=grantor、uk=key UID）。
+//   - as-bot 分支是 #C/#D（canReadChannel）与 #E（enumerateReadableChannels）的接线点，
+//     本层 fail-closed 占位（#B 之前无 bot 路由，不影响现网）。
+
+// errBotPredicateNotImplemented as-bot 可读谓词尚未接线（#C/#D/#E）。
+var errBotPredicateNotImplemented = errors.New("messages_search: as-bot readable predicate not implemented (YUJ-50/51/52)")
+
+// canReadChannel 是单频道门——#C/#D 按 principal 分支细化、#E 的 allowlist 枚举同一谓词。
+// 真人语义主体（user / obo / uk）走现有 checkChannelAccess（主体 uid 来自 principal）；
+// as-bot 分支由 #C/#D 用 bot 谓词替换本层占位。
+func (h *Handler) canReadChannel(c *wkhttp.Context, p Principal, channelType uint8, channelID string) bool {
+	switch p.Kind() {
+	case principalKindUserBot:
+		return h.botCanReadChannel(c, p, channelType, channelID)
+	default:
+		// user / obo / uk：真人语义，主体 uid 各异。checkChannelAccess 内部的
+		// 双向黑名单由 blacklistPolicy 决定（真人语义主体均为 bidirectional）。
+		return h.checkChannelAccess(c, channelType, channelID, p.SubjectUID())
+	}
+}
+
+// enumerateReadableChannels 是 canReadChannel 的 global-allowlist 对偶：必须枚举出与
+// canReadChannel 对同一 principal 放行完全一致的频道集（决策九）。真人语义主体委托给
+// buildAllowlist；as-bot 分支是 #E 的接线点。
+//
+// 返回 (allowGroup, allowDM, allowThread, timings, err)，与 buildAllowlist 同形。
+func (h *Handler) enumerateReadableChannels(c *wkhttp.Context, p Principal) ([]channelRef, []channelRef, []channelRef, allowlistTimings, error) {
+	switch p.Kind() {
+	case principalKindUserBot:
+		return h.botEnumerateReadableChannels(c, p)
+	default:
+		return h.buildAllowlist(c, p.SubjectUID(), p.SpaceID())
+	}
+}
+
+// principalForSubject 为一个「已解析的真人语义主体」返回其 principal 载体，供内部枚举
+// 路径（resolveGlobalScope）经归一化谓词求值时使用。优先返回路由显式写入的 principal
+//（bot / uk / obo，#B），否则用传入的 uid/spaceID 组装真人载体——这保证现网真人路径与
+// 直接以 (loginUID, spaceID) 驱动枚举的既有单测行为完全不变。
+func principalForSubject(c *wkhttp.Context, uid, spaceID string) Principal {
+	if v, ok := c.Get(principalCtxKey); ok {
+		if p, ok := v.(Principal); ok && p != nil {
+			return p
+		}
+	}
+	return userPrincipal{uid: uid, spaceID: spaceID}
+}
+
+// botCanReadChannel 是 as-bot 单频道门的接线点（#C/#D）。bot 谓词 =
+// IsFriend(botUID, peer) 的 DM ∪ ExistMemberActive(group, botUID) 的群/子区，
+// 且跳过 Space 段与全部 P2P blacklist。本层 fail-closed 占位：渲染 NOT_FOUND
+//（反枚举，与真人拒绝一致）。#B 接线 bot 路由前不会触达此分支。
+func (h *Handler) botCanReadChannel(c *wkhttp.Context, p Principal, channelType uint8, channelID string) bool {
+	h.Warn("messages_search: as-bot channel gate not yet implemented (YUJ-50/51); denying fail-closed",
+		zap.String("bot_uid", p.SubjectUID()),
+		zap.Uint8("channel_type", channelType),
+		zap.String("channel_id", channelID))
+	respondNotFound(c, "channel")
+	return false
+}
+
+// botEnumerateReadableChannels 是 as-bot global allowlist 枚举的接线点（#E）。
+// allowlist = bot 所在群/子区 ∪ IsFriend(botUID) 的 DM 对端，与 botCanReadChannel
+// 同一谓词。本层 fail-closed 占位返回错误（#B 接线 bot 路由前不会触达此分支）。
+func (h *Handler) botEnumerateReadableChannels(_ *wkhttp.Context, p Principal) ([]channelRef, []channelRef, []channelRef, allowlistTimings, error) {
+	h.Warn("messages_search: as-bot global allowlist not yet implemented (YUJ-52); failing closed",
+		zap.String("bot_uid", p.SubjectUID()))
+	return nil, nil, nil, allowlistTimings{}, errBotPredicateNotImplemented
+}

--- a/modules/messages_search/predicate.go
+++ b/modules/messages_search/predicate.go
@@ -14,8 +14,9 @@ import (
 // 本层（YUJ-48）只定义接口 + dispatch，不改鉴权语义：
 //   - user / obo / uk 三类真人语义主体 → 复用现有 checkChannelAccess / buildAllowlist，
 //     仅主体 uid 由 principal.SubjectUID() 提供（obo=grantor、uk=key UID）。
-//   - as-bot 分支是 #C/#D（canReadChannel）与 #E（enumerateReadableChannels）的接线点，
-//     #E（YUJ-52）已接线枚举；#C/#D 单频道门待接线（botCanReadChannel 仍 fail-closed 占位）。
+//   - as-bot 分支是 #C/#D（canReadChannel）与 #E（enumerateReadableChannels）的接线点：
+//     #C（YUJ-50）已接线 DM 门（IsFriend，跳过 blacklist）、#D（YUJ-51）已接线群/子区门
+//     （复用 ExistMemberActive，主体=botUID）、#E（YUJ-52）已接线 global allowlist 枚举。
 
 // canReadChannel 是单频道门——#C/#D 按 principal 分支细化、#E 的 allowlist 枚举同一谓词。
 // 真人语义主体（user / obo / uk）走现有 checkChannelAccess（主体 uid 来自 principal）；
@@ -58,33 +59,41 @@ func principalForSubject(c *wkhttp.Context, uid, spaceID string) Principal {
 	return userPrincipal{uid: uid, spaceID: spaceID}
 }
 
-// botCanReadChannel 是 as-bot 单频道门的接线点（#C/#D）。bot 谓词 =
-// IsFriend(botUID, peer) 的 DM ∪ ExistMemberActive(group, botUID) 的群/子区，
-// 且跳过 Space 段与全部 P2P blacklist。按 channelType 分派：
+// botCanReadChannel 是 as-bot 单频道门（决策九），按 channelType 分支——bot 谓词 =
+// IsFriend(botUID, peer) 的 DM ∪ ExistMemberActive(group, botUID) 的群/子区，跳过 Space 段
+// 与全部 P2P blacklist：
 //
-//   - person（1）：#C（YUJ-50）已接线 —— botCheckP2PAccess（见 authz.go），
-//     谓词 = IsFriend(botUID, peer)，是 #E buildBotAllowlist 的 GetFriends(botUID)
-//     枚举对偶（决策九）；跳过 Space 与双向 blacklist。
-//   - group（2）/ thread（5）：#D（YUJ-51）的接线点，尚未落地 —— 保持 fail-closed
-//     占位（渲染 NOT_FOUND，反枚举，与真人拒绝一致）。
-//   - 其他：validate.go 已在此前拒绝未知 channelType；仍 fail-closed 兜底。
+//   - DM（#C / YUJ-50）：botCheckP2PAccess(c, botUID, peer)（见 authz.go），谓词 =
+//     IsFriend(botUID, peer)，是 #E buildBotAllowlist 的 GetFriends(botUID) 枚举对偶；
+//     跳过 Space 与双向 blacklist。
+//   - 群（#D / YUJ-51）：checkGroupAccess(c, groupNo, botUID)。as-bot 群门与真人群门完全同源
+//     ——都落在 ExistMemberActive(groupNo, botUID)：bot 有自己的 group_member 行（发消息路径
+//     bot_api/send.go:394-404 已在用），status=Normal 天然排除被移出 / 被群拉黑的 bot；#354 的
+//     group/bot_cascade.go expandBlacklistTargetsWithOwnedBots 让「拉黑用户连带拉黑其在群 bot」
+//     → 被拉黑者的 bot status!=Normal → 天然搜不到该群，群级黑名单白拿，无需在此另写一套规则。
+//   - 子区（#D / YUJ-51）：checkThreadAccess(c, channelID, botUID)。子区继承父群成员身份
+//     ——门即 ExistMemberActive(parentGroupNo, botUID)，与群门同一谓词；bot 无子区免打扰
+//     设置，GetThread 的 mute 查询仅返回空，不参与放行判定。
+//   - 其他：validate.go 已在入口拒绝未知 channelType；此处 defense-in-depth fail-closed 兜底。
 //
+// 归一化（决策九硬约束）：群/子区门是 ExistMemberActive 的单点求值，与 #E buildBotAllowlist
+// 的 ExistMembersActive 枚举严格同源——保证「单频道门放行 ⇔ 出现在 global allowlist」
+//（#G 跨路一致性）。所有拒绝渲染 NOT_FOUND/resource=channel（反枚举，与真人拒绝一致），
+// DB 错由 botCheckP2PAccess / checkGroupAccess / checkThreadAccess 内部 fail-closed。
 // #B 接线 bot 路由前不会触达此分支。
 func (h *Handler) botCanReadChannel(c *wkhttp.Context, p Principal, channelType uint8, channelID string) bool {
+	botUID := p.SubjectUID()
 	switch channelType {
 	case channelTypePerson:
-		return h.botCheckP2PAccess(c, p.SubjectUID(), channelID)
-	case channelTypeGroup, channelTypeThread:
-		// #D（YUJ-51）尚未接线：群/子区门主体换 botUID（ExistMemberActive）在此落。
-		h.Warn("messages_search: as-bot group/thread gate not yet implemented (YUJ-51); denying fail-closed",
-			zap.String("bot_uid", p.SubjectUID()),
-			zap.Uint8("channel_type", channelType),
-			zap.String("channel_id", channelID))
-		respondNotFound(c, "channel")
-		return false
+		return h.botCheckP2PAccess(c, botUID, channelID)
+	case channelTypeGroup:
+		return h.checkGroupAccess(c, channelID, botUID)
+	case channelTypeThread:
+		return h.checkThreadAccess(c, channelID, botUID)
 	default:
-		h.Warn("messages_search: as-bot channel gate unexpected channel_type; denying fail-closed",
-			zap.String("bot_uid", p.SubjectUID()),
+		// validate.go 已在入口拒绝未知 channel_type；此处 defense-in-depth 兜底。
+		h.Warn("messages_search: as-bot gate unexpected channel_type; denying fail-closed",
+			zap.String("bot_uid", botUID),
 			zap.Uint8("channel_type", channelType),
 			zap.String("channel_id", channelID))
 		respondNotFound(c, "channel")

--- a/modules/messages_search/principal.go
+++ b/modules/messages_search/principal.go
@@ -1,0 +1,260 @@
+package messages_search
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	spacepkg "github.com/Mininglamp-OSS/octo-server/pkg/space"
+)
+
+// Principal 抽象化「当前搜索主体」（决策十）。在引入 bot 主体之前，messages_search
+// 全程直接取 c.GetLoginUID()（真人）；本抽象让 handler 只依赖接口，真人 / as-bot /
+// as-user(OBO) / as-user(uk) 四态各自提供身份、Space、限流键、黑名单策略与审计字段。
+//
+// 本层（YUJ-48 / Stage 1）只落「载体 + 可读谓词接口 + 单测」，不改任何鉴权语义：
+//   - 真人（user）实现行为与现状完全一致（SubjectUID==GetLoginUID、SpaceID==GetSpaceID）。
+//   - user_bot / obo / uk 三套实现提供 Authenticate + BlacklistPolicy（uk 为完整实现，
+//     非桩；obo 的 grant/scope/TOCTOU 校验在 #F 落，本层只组装载体）。
+//   - bot 主体的可读谓词逻辑（IsFriend / ExistMemberActive）在 #C/#D/#E 落，本层
+//     只定义 canReadChannel / enumerateReadableChannels 的接口与 dispatch（见 predicate.go）。
+
+// principalKind 标识请求背后的凭证类型。
+type principalKind uint8
+
+const (
+	// principalKindUser 真人 web/登录态（context key "uid"，现存路径）。
+	principalKindUser principalKind = iota
+	// principalKindUserBot as-bot：以 User Bot 自身身份搜索（context key "robot_id"）。
+	principalKindUserBot
+	// principalKindOBO as-user：经 OBO 以 grantor 身份搜索（主体 = grantorUID）。
+	principalKindOBO
+	// principalKindUK as-user：经 uk_ User API Key 的直接真人身份（主体 = key UID）。
+	principalKindUK
+)
+
+func (k principalKind) String() string {
+	switch k {
+	case principalKindUser:
+		return "user"
+	case principalKindUserBot:
+		return "user_bot"
+	case principalKindOBO:
+		return "obo"
+	case principalKindUK:
+		return "uk"
+	default:
+		return "unknown"
+	}
+}
+
+// blacklistPolicy 决定是否对主体套用真人双向黑名单门。
+type blacklistPolicy uint8
+
+const (
+	// blacklistNone user_bot 显式短路：bot 无法有意义地拉黑他人 / 被拉黑
+	//（addBlacklist 是真人会话专属；对方→bot 方向已决策不取，见 #C）。
+	blacklistNone blacklistPolicy = iota
+	// blacklistRealUserBidirectional user / obo / uk 复用同一份真人双向逻辑，
+	// 仅主体 uid 来源不同（obo=grantor、uk=key UID）。
+	blacklistRealUserBidirectional
+)
+
+func (p blacklistPolicy) String() string {
+	switch p {
+	case blacklistNone:
+		return "none"
+	case blacklistRealUserBidirectional:
+		return "real-user-bidirectional"
+	default:
+		return "unknown"
+	}
+}
+
+// context key 常量，镜像 bot_api/auth.go（CtxKeyRobotID/CtxKeyBotKind）与
+// botfather/api_user.go（api_key_uid / api_key_space_id）。本层刻意本地定义、不
+// 导入 bot_api/botfather，让搜索模块在 #B 接线路由之前保持解耦；值必须与来源一致。
+const (
+	ctxKeyLoginUID      = "uid"
+	ctxKeyRobotID       = "robot_id"
+	ctxKeyBotKind       = "bot_kind"
+	ctxKeyAPIKeyUID     = "api_key_uid"
+	ctxKeyAPIKeySpaceID = "api_key_space_id"
+
+	botKindUser = "user"
+	botKindApp  = "app"
+)
+
+// principalCtxKey 存放被路由显式解析出的主体（bot / uk / obo 在 #B 写入）。真人路由
+// 不写入，靠 Handler.principal 的惰性默认构造。
+const principalCtxKey = "messages_search.principal"
+
+var (
+	// errPrincipalUnauthenticated 上游鉴权中间件未在 context 落主体身份。
+	errPrincipalUnauthenticated = errors.New("messages_search: principal not authenticated")
+	// errPrincipalAppBotDenied App Bot 不支持搜索（一期整体不做 App Bot，#F 兜底显式拒绝）。
+	errPrincipalAppBotDenied = errors.New("messages_search: app bot is not supported for search")
+)
+
+// Principal 是搜索主体的策略接口。handler 只依赖此接口取身份 / Space / 策略；
+// 归一化可读谓词（canReadChannel / enumerateReadableChannels）以 Handler 方法承载，
+// 按 Kind 分派（见 predicate.go）。
+type Principal interface {
+	// Kind 凭证类型。
+	Kind() principalKind
+	// SubjectUID 是「可达频道集」所依据的身份：真人登录 uid、bot 自身（as-bot）、
+	// grantor（obo）或 key 拥有者（uk）。
+	SubjectUID() string
+	// SpaceID 请求所属 Space；bot 路由不挂 SpaceMiddleware 故为空，uk 取 api_key_space_id。
+	SpaceID() string
+	// BlacklistPolicy 报告是否对该主体套用真人双向黑名单门。
+	BlacklistPolicy() blacklistPolicy
+	// RateLimitKey 限流令牌桶键：as-bot / obo 都按 botUID 计（防单 bot 打爆），
+	// uk 按 key UID，user 按自身 uid。
+	RateLimitKey() string
+	// AuditBotUID / AuditGrantorUID 供审计追溯（as-user 同时记 botUID + grantorUID）；
+	// 不适用时返回 ""。
+	AuditBotUID() string
+	AuditGrantorUID() string
+}
+
+// userPrincipal 真人登录态。行为与现状完全一致。
+type userPrincipal struct {
+	uid     string
+	spaceID string
+}
+
+func (p userPrincipal) Kind() principalKind             { return principalKindUser }
+func (p userPrincipal) SubjectUID() string              { return p.uid }
+func (p userPrincipal) SpaceID() string                 { return p.spaceID }
+func (p userPrincipal) BlacklistPolicy() blacklistPolicy { return blacklistRealUserBidirectional }
+func (p userPrincipal) RateLimitKey() string            { return p.uid }
+func (p userPrincipal) AuditBotUID() string             { return "" }
+func (p userPrincipal) AuditGrantorUID() string         { return "" }
+
+// userBotPrincipal as-bot：主体 = botUID，Space 空，黑名单不查，限流/审计按 botUID。
+type userBotPrincipal struct {
+	botUID string
+}
+
+func (p userBotPrincipal) Kind() principalKind             { return principalKindUserBot }
+func (p userBotPrincipal) SubjectUID() string              { return p.botUID }
+func (p userBotPrincipal) SpaceID() string                 { return "" }
+func (p userBotPrincipal) BlacklistPolicy() blacklistPolicy { return blacklistNone }
+func (p userBotPrincipal) RateLimitKey() string            { return p.botUID }
+func (p userBotPrincipal) AuditBotUID() string             { return p.botUID }
+func (p userBotPrincipal) AuditGrantorUID() string         { return "" }
+
+// oboPrincipal as-user(OBO)：主体 = grantorUID（走真人分支），黑名单复用真人双向，
+// 限流/审计按 botUID，审计并记 grantorUID 以追溯。
+type oboPrincipal struct {
+	botUID     string
+	grantorUID string
+	spaceID    string
+}
+
+func (p oboPrincipal) Kind() principalKind             { return principalKindOBO }
+func (p oboPrincipal) SubjectUID() string              { return p.grantorUID }
+func (p oboPrincipal) SpaceID() string                 { return p.spaceID }
+func (p oboPrincipal) BlacklistPolicy() blacklistPolicy { return blacklistRealUserBidirectional }
+func (p oboPrincipal) RateLimitKey() string            { return p.botUID }
+func (p oboPrincipal) AuditBotUID() string             { return p.botUID }
+func (p oboPrincipal) AuditGrantorUID() string         { return p.grantorUID }
+
+// ukPrincipal as-user(uk)：主体 = keyModel.UID（直接真人身份，不做 OBO scope 收窄），
+// 黑名单复用真人双向，Space 取 api_key_space_id，限流/审计按 key UID。
+type ukPrincipal struct {
+	keyUID  string
+	spaceID string
+}
+
+func (p ukPrincipal) Kind() principalKind             { return principalKindUK }
+func (p ukPrincipal) SubjectUID() string              { return p.keyUID }
+func (p ukPrincipal) SpaceID() string                 { return p.spaceID }
+func (p ukPrincipal) BlacklistPolicy() blacklistPolicy { return blacklistRealUserBidirectional }
+func (p ukPrincipal) RateLimitKey() string            { return p.keyUID }
+func (p ukPrincipal) AuditBotUID() string             { return "" }
+func (p ukPrincipal) AuditGrantorUID() string         { return "" }
+
+// setPrincipal 把显式解析出的主体写入 context（bot / uk / obo 路由在 #B 使用）。
+// 真人路由不调用，依赖 Handler.principal 的惰性默认。
+func setPrincipal(c *wkhttp.Context, p Principal) {
+	c.Set(principalCtxKey, p)
+}
+
+// principal 返回本请求的搜索主体。若路由显式写入（bot / uk / obo，#B），返回该值；
+// 否则从鉴权 context（"uid" + SpaceMiddleware）构造真人默认。
+//
+// 这是搜索路径读取 GetLoginUID() / GetSpaceID() 的【唯一】站点——handler 不再直接
+// 调用它们（决策十验收）。
+func (h *Handler) principal(c *wkhttp.Context) Principal {
+	if v, ok := c.Get(principalCtxKey); ok {
+		if p, ok := v.(Principal); ok && p != nil {
+			return p
+		}
+	}
+	return authenticateUser(c)
+}
+
+// authenticateUser 从鉴权 context 构造真人主体（现存路径的 Authenticate）。
+func authenticateUser(c *wkhttp.Context) Principal {
+	return userPrincipal{
+		uid:     c.GetLoginUID(),
+		spaceID: strings.TrimSpace(spacepkg.GetSpaceID(c)),
+	}
+}
+
+// authenticateUserBot 解析 as-bot 主体：subjectUID = botUID（authBot() 落的 "robot_id"），
+// Space 空（/v1/bot 不挂 SpaceMiddleware）。App Bot 显式拒绝（一期不做，#F 兜底）。
+func authenticateUserBot(c *wkhttp.Context) (Principal, error) {
+	botUID := ctxString(c, ctxKeyRobotID)
+	if botUID == "" {
+		return nil, errPrincipalUnauthenticated
+	}
+	if ctxString(c, ctxKeyBotKind) == botKindApp {
+		return nil, errPrincipalAppBotDenied
+	}
+	return userBotPrincipal{botUID: botUID}, nil
+}
+
+// authenticateOBO 组装 as-user(OBO) 主体：subjectUID = grantorUID（以 grantor 身份搜、
+// 走真人分支），限流/审计仍按 botUID。grant + scope + TOCTOU 的实时权限校验是 #F 的职责
+//（复用 bot_api/obo_check.go），本构造器只从两个已校验入参组装载体。
+func authenticateOBO(botUID, grantorUID, spaceID string) (Principal, error) {
+	if botUID == "" || grantorUID == "" {
+		return nil, errPrincipalUnauthenticated
+	}
+	if botUID == grantorUID {
+		// 与 checkOBO 一致的 fail-closed：主体不能自授。
+		return nil, errPrincipalUnauthenticated
+	}
+	return oboPrincipal{
+		botUID:     botUID,
+		grantorUID: grantorUID,
+		spaceID:    strings.TrimSpace(spaceID),
+	}, nil
+}
+
+// authenticateUK 解析 uk_ 主体（一期正式接线，完整实现，非桩）：subjectUID = keyModel.UID，
+// Space = api_key_space_id。botfather 的 authUserAPIKey() 中间件已校验 key
+//（status/ClientID/active-user）并在此之前落 context。
+func authenticateUK(c *wkhttp.Context) (Principal, error) {
+	keyUID := ctxString(c, ctxKeyAPIKeyUID)
+	if keyUID == "" {
+		return nil, errPrincipalUnauthenticated
+	}
+	return ukPrincipal{
+		keyUID:  keyUID,
+		spaceID: strings.TrimSpace(ctxString(c, ctxKeyAPIKeySpaceID)),
+	}, nil
+}
+
+// ctxString 读取一个 string context 值，缺失或类型不符返回 ""。
+func ctxString(c *wkhttp.Context, key string) string {
+	v, ok := c.Get(key)
+	if !ok || v == nil {
+		return ""
+	}
+	s, _ := v.(string)
+	return s
+}

--- a/modules/messages_search/principal.go
+++ b/modules/messages_search/principal.go
@@ -107,6 +107,13 @@ type Principal interface {
 	SubjectUID() string
 	// SpaceID 请求所属 Space；bot 路由不挂 SpaceMiddleware 故为空，uk 取 api_key_space_id。
 	SpaceID() string
+	// RequiresSpaceScope 报告「空 Space 是否必须 fail-close」（决策十 / YUJ-57）。
+	// 真人语义且实际驻留在某个 Space 的主体（user / uk）依赖 spaceId 段收窄跨 Space
+	// DM 泄露，空 Space 触发必填门 fail-close；而**天然无 Space** 的主体（user_bot /
+	// obo）根本不属于任何 Space，其可读频道集由 per-principal 谓词
+	//（IsFriend / grantor allowlist）枚举，DM 可见性无需 spaceId 段兜底，故空 Space
+	// 合法、**不**被必填门提前挡下（否则无 space 的 bot 永远搜不到任何结果）。
+	RequiresSpaceScope() bool
 	// BlacklistPolicy 报告是否对该主体套用真人双向黑名单门。
 	BlacklistPolicy() blacklistPolicy
 	// RateLimitKey 限流令牌桶键：as-bot / obo 都按 botUID 计（防单 bot 打爆），
@@ -124,26 +131,28 @@ type userPrincipal struct {
 	spaceID string
 }
 
-func (p userPrincipal) Kind() principalKind             { return principalKindUser }
-func (p userPrincipal) SubjectUID() string              { return p.uid }
-func (p userPrincipal) SpaceID() string                 { return p.spaceID }
+func (p userPrincipal) Kind() principalKind              { return principalKindUser }
+func (p userPrincipal) SubjectUID() string               { return p.uid }
+func (p userPrincipal) SpaceID() string                  { return p.spaceID }
+func (p userPrincipal) RequiresSpaceScope() bool         { return true }
 func (p userPrincipal) BlacklistPolicy() blacklistPolicy { return blacklistRealUserBidirectional }
-func (p userPrincipal) RateLimitKey() string            { return p.uid }
-func (p userPrincipal) AuditBotUID() string             { return "" }
-func (p userPrincipal) AuditGrantorUID() string         { return "" }
+func (p userPrincipal) RateLimitKey() string             { return p.uid }
+func (p userPrincipal) AuditBotUID() string              { return "" }
+func (p userPrincipal) AuditGrantorUID() string          { return "" }
 
 // userBotPrincipal as-bot：主体 = botUID，Space 空，黑名单不查，限流/审计按 botUID。
 type userBotPrincipal struct {
 	botUID string
 }
 
-func (p userBotPrincipal) Kind() principalKind             { return principalKindUserBot }
-func (p userBotPrincipal) SubjectUID() string              { return p.botUID }
-func (p userBotPrincipal) SpaceID() string                 { return "" }
+func (p userBotPrincipal) Kind() principalKind              { return principalKindUserBot }
+func (p userBotPrincipal) SubjectUID() string               { return p.botUID }
+func (p userBotPrincipal) SpaceID() string                  { return "" }
+func (p userBotPrincipal) RequiresSpaceScope() bool         { return false }
 func (p userBotPrincipal) BlacklistPolicy() blacklistPolicy { return blacklistNone }
-func (p userBotPrincipal) RateLimitKey() string            { return p.botUID }
-func (p userBotPrincipal) AuditBotUID() string             { return p.botUID }
-func (p userBotPrincipal) AuditGrantorUID() string         { return "" }
+func (p userBotPrincipal) RateLimitKey() string             { return p.botUID }
+func (p userBotPrincipal) AuditBotUID() string              { return p.botUID }
+func (p userBotPrincipal) AuditGrantorUID() string          { return "" }
 
 // oboPrincipal as-user(OBO)：主体 = grantorUID（走真人分支），黑名单复用真人双向，
 // 限流/审计按 botUID，审计并记 grantorUID 以追溯。
@@ -153,13 +162,14 @@ type oboPrincipal struct {
 	spaceID    string
 }
 
-func (p oboPrincipal) Kind() principalKind             { return principalKindOBO }
-func (p oboPrincipal) SubjectUID() string              { return p.grantorUID }
-func (p oboPrincipal) SpaceID() string                 { return p.spaceID }
+func (p oboPrincipal) Kind() principalKind              { return principalKindOBO }
+func (p oboPrincipal) SubjectUID() string               { return p.grantorUID }
+func (p oboPrincipal) SpaceID() string                  { return p.spaceID }
+func (p oboPrincipal) RequiresSpaceScope() bool         { return false }
 func (p oboPrincipal) BlacklistPolicy() blacklistPolicy { return blacklistRealUserBidirectional }
-func (p oboPrincipal) RateLimitKey() string            { return p.botUID }
-func (p oboPrincipal) AuditBotUID() string             { return p.botUID }
-func (p oboPrincipal) AuditGrantorUID() string         { return p.grantorUID }
+func (p oboPrincipal) RateLimitKey() string             { return p.botUID }
+func (p oboPrincipal) AuditBotUID() string              { return p.botUID }
+func (p oboPrincipal) AuditGrantorUID() string          { return p.grantorUID }
 
 // ukPrincipal as-user(uk)：主体 = keyModel.UID（直接真人身份，不做 OBO scope 收窄），
 // 黑名单复用真人双向，Space 取 api_key_space_id，限流/审计按 key UID。
@@ -168,13 +178,14 @@ type ukPrincipal struct {
 	spaceID string
 }
 
-func (p ukPrincipal) Kind() principalKind             { return principalKindUK }
-func (p ukPrincipal) SubjectUID() string              { return p.keyUID }
-func (p ukPrincipal) SpaceID() string                 { return p.spaceID }
+func (p ukPrincipal) Kind() principalKind              { return principalKindUK }
+func (p ukPrincipal) SubjectUID() string               { return p.keyUID }
+func (p ukPrincipal) SpaceID() string                  { return p.spaceID }
+func (p ukPrincipal) RequiresSpaceScope() bool         { return true }
 func (p ukPrincipal) BlacklistPolicy() blacklistPolicy { return blacklistRealUserBidirectional }
-func (p ukPrincipal) RateLimitKey() string            { return p.keyUID }
-func (p ukPrincipal) AuditBotUID() string             { return "" }
-func (p ukPrincipal) AuditGrantorUID() string         { return "" }
+func (p ukPrincipal) RateLimitKey() string             { return p.keyUID }
+func (p ukPrincipal) AuditBotUID() string              { return "" }
+func (p ukPrincipal) AuditGrantorUID() string          { return "" }
 
 // setPrincipal 把显式解析出的主体写入 context（bot / uk / obo 路由在 #B 使用）。
 // 真人路由不调用，依赖 Handler.principal 的惰性默认。

--- a/modules/messages_search/principal.go
+++ b/modules/messages_search/principal.go
@@ -218,8 +218,9 @@ func authenticateUserBot(c *wkhttp.Context) (Principal, error) {
 }
 
 // authenticateOBO 组装 as-user(OBO) 主体：subjectUID = grantorUID（以 grantor 身份搜、
-// 走真人分支），限流/审计仍按 botUID。grant + scope + TOCTOU 的实时权限校验是 #F 的职责
-//（复用 bot_api/obo_check.go），本构造器只从两个已校验入参组装载体。
+// 走真人分支），限流/审计仍按 botUID。grant + scope + TOCTOU 的实时权限校验在搜索热路径
+// per-channel 进行（YUJ-53 / #F，见 obo.go 的 oboCanReadChannel），因为 checkOBO 需 channel
+// 维度；本构造器只从已解析入参组装载体。
 func authenticateOBO(botUID, grantorUID, spaceID string) (Principal, error) {
 	if botUID == "" || grantorUID == "" {
 		return nil, errPrincipalUnauthenticated
@@ -233,6 +234,27 @@ func authenticateOBO(botUID, grantorUID, spaceID string) (Principal, error) {
 		grantorUID: grantorUID,
 		spaceID:    strings.TrimSpace(spaceID),
 	}, nil
+}
+
+// authenticateOBOFromContext 从 authBot() 落的 context 组装 as-user(OBO) 主体（#B 在解析
+// 请求体 on_behalf_of 后调用，grantorUID 由其传入）。相较 authenticateOBO 多两道 context
+// 侧的 fail-closed 门：
+//   - botUID 取自 "robot_id"（authBot 落）；缺失 → errPrincipalUnauthenticated。
+//   - App Bot 显式拒绝（YUJ-53 / #F 验收）：一期整体不做 App Bot，且 App Bot 拿不到 OBO
+//     grant（grant 只查 robot 表，App Bot 在 app_bot 表）。此处在主体构造阶段就 fail-closed
+//     显式拒绝，而非放行后靠 checkOBO 静默返回空——避免 App Bot 搜索被误当作"无结果"。
+//
+// spaceID 走 grantor 的 Space（spacepkg.GetSpaceID 读 space_id / X-Space-Id）；bot 路由不挂
+// SpaceMiddleware 时通常为空，P2P 分支即回退到 grantor 好友判定（安全，grantor=创建者）。
+func authenticateOBOFromContext(c *wkhttp.Context, grantorUID string) (Principal, error) {
+	botUID := ctxString(c, ctxKeyRobotID)
+	if botUID == "" {
+		return nil, errPrincipalUnauthenticated
+	}
+	if ctxString(c, ctxKeyBotKind) == botKindApp {
+		return nil, errPrincipalAppBotDenied
+	}
+	return authenticateOBO(botUID, grantorUID, spacepkg.GetSpaceID(c))
 }
 
 // authenticateUK 解析 uk_ 主体（一期正式接线，完整实现，非桩）：subjectUID = keyModel.UID，

--- a/modules/messages_search/principal_test.go
+++ b/modules/messages_search/principal_test.go
@@ -145,6 +145,30 @@ func TestPrincipalBlacklistPolicy(t *testing.T) {
 	}
 }
 
+// TestPrincipalRequiresSpaceScope — YUJ-57: the fail-close Space gate applies
+// ONLY to space-scoped principals (user / uk). Space-less principals (as-bot /
+// OBO) legitimately carry no Space, so RequiresSpaceScope must be false — they
+// must NOT be blocked by RequireSpaceID before reaching the allowlist predicate.
+func TestPrincipalRequiresSpaceScope(t *testing.T) {
+	cases := []struct {
+		name string
+		p    Principal
+		want bool
+	}{
+		{"user", userPrincipal{uid: "alice", spaceID: "S1"}, true},
+		{"uk", ukPrincipal{keyUID: "kate", spaceID: "S2"}, true},
+		{"user_bot", userBotPrincipal{botUID: "bot9"}, false},
+		{"obo", oboPrincipal{botUID: "bot9", grantorUID: "grace"}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.p.RequiresSpaceScope(); got != tc.want {
+				t.Fatalf("RequiresSpaceScope = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
 // ---------- Authenticate: user ----------
 
 func TestAuthenticateUser(t *testing.T) {

--- a/modules/messages_search/principal_test.go
+++ b/modules/messages_search/principal_test.go
@@ -1,0 +1,378 @@
+package messages_search
+
+import (
+	"errors"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/gin-gonic/gin"
+)
+
+// newPrincipalCtx builds a bare wkhttp.Context whose gin context keys can be
+// set to mimic what each auth middleware would populate (real-user
+// AuthMiddleware → "uid"/"space_id"; authBot → "robot_id"/"bot_kind";
+// authUserAPIKey → "api_key_uid"/"api_key_space_id").
+func newPrincipalCtx(t *testing.T) (*wkhttp.Context, *httptest.ResponseRecorder) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	gc, _ := gin.CreateTestContext(rec)
+	gc.Request = httptest.NewRequest("POST", "/v1/messages/_search", nil)
+	return &wkhttp.Context{Context: gc}, rec
+}
+
+// ---------- carrier: three-state (+user) value coverage ----------
+
+// TestPrincipalCarrier_SubjectUID covers 决策十 acceptance "principal 载体单测覆盖
+// 三态取值": SubjectUID resolves to loginUID / botUID / grantorUID / keyUID per kind.
+func TestPrincipalCarrier_SubjectUID(t *testing.T) {
+	cases := []struct {
+		name string
+		p    Principal
+		want string
+	}{
+		{"user", userPrincipal{uid: "alice", spaceID: "S1"}, "alice"},
+		{"user_bot", userBotPrincipal{botUID: "bot9"}, "bot9"},
+		{"obo", oboPrincipal{botUID: "bot9", grantorUID: "grace", spaceID: "S1"}, "grace"},
+		{"uk", ukPrincipal{keyUID: "kate", spaceID: "S2"}, "kate"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.p.SubjectUID(); got != tc.want {
+				t.Fatalf("SubjectUID = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestPrincipalCarrier_SpaceID — user/obo/uk carry a Space; user_bot never does
+// (/v1/bot has no SpaceMiddleware).
+func TestPrincipalCarrier_SpaceID(t *testing.T) {
+	if got := (userPrincipal{spaceID: "S1"}).SpaceID(); got != "S1" {
+		t.Fatalf("user SpaceID = %q, want S1", got)
+	}
+	if got := (userBotPrincipal{botUID: "b"}).SpaceID(); got != "" {
+		t.Fatalf("user_bot SpaceID = %q, want empty", got)
+	}
+	if got := (oboPrincipal{grantorUID: "g", spaceID: "S1"}).SpaceID(); got != "S1" {
+		t.Fatalf("obo SpaceID = %q, want S1", got)
+	}
+	if got := (ukPrincipal{keyUID: "k", spaceID: "S2"}).SpaceID(); got != "S2" {
+		t.Fatalf("uk SpaceID = %q, want S2", got)
+	}
+}
+
+// TestPrincipalCarrier_RateLimitKey — as-bot AND obo meter by botUID (防单 bot
+// 打爆); uk by key UID; user by its own uid.
+func TestPrincipalCarrier_RateLimitKey(t *testing.T) {
+	if got := (userPrincipal{uid: "alice"}).RateLimitKey(); got != "alice" {
+		t.Fatalf("user RateLimitKey = %q, want alice", got)
+	}
+	if got := (userBotPrincipal{botUID: "bot9"}).RateLimitKey(); got != "bot9" {
+		t.Fatalf("user_bot RateLimitKey = %q, want bot9", got)
+	}
+	if got := (oboPrincipal{botUID: "bot9", grantorUID: "grace"}).RateLimitKey(); got != "bot9" {
+		t.Fatalf("obo RateLimitKey = %q, want bot9 (meter by bot, not grantor)", got)
+	}
+	if got := (ukPrincipal{keyUID: "kate"}).RateLimitKey(); got != "kate" {
+		t.Fatalf("uk RateLimitKey = %q, want kate", got)
+	}
+}
+
+// TestPrincipalCarrier_AuditUIDs — as-user(OBO) records BOTH botUID and
+// grantorUID for traceability; user_bot records only botUID; user/uk record
+// neither (login_uid alone suffices).
+func TestPrincipalCarrier_AuditUIDs(t *testing.T) {
+	cases := []struct {
+		name          string
+		p             Principal
+		wantBot       string
+		wantGrantor   string
+	}{
+		{"user", userPrincipal{uid: "alice"}, "", ""},
+		{"user_bot", userBotPrincipal{botUID: "bot9"}, "bot9", ""},
+		{"obo", oboPrincipal{botUID: "bot9", grantorUID: "grace"}, "bot9", "grace"},
+		{"uk", ukPrincipal{keyUID: "kate"}, "", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.p.AuditBotUID(); got != tc.wantBot {
+				t.Fatalf("AuditBotUID = %q, want %q", got, tc.wantBot)
+			}
+			if got := tc.p.AuditGrantorUID(); got != tc.wantGrantor {
+				t.Fatalf("AuditGrantorUID = %q, want %q", got, tc.wantGrantor)
+			}
+		})
+	}
+}
+
+// ---------- blacklist policy ----------
+
+// TestPrincipalBlacklistPolicy — 决策十 acceptance "blacklist 策略单测:
+// user_bot=不查、obo/uk=真人双向（主体 uid 各异）". obo & uk share the real-user
+// bidirectional gate; user_bot short-circuits.
+func TestPrincipalBlacklistPolicy(t *testing.T) {
+	cases := []struct {
+		name string
+		p    Principal
+		want blacklistPolicy
+	}{
+		{"user", userPrincipal{uid: "alice"}, blacklistRealUserBidirectional},
+		{"user_bot", userBotPrincipal{botUID: "bot9"}, blacklistNone},
+		{"obo", oboPrincipal{botUID: "bot9", grantorUID: "grace"}, blacklistRealUserBidirectional},
+		{"uk", ukPrincipal{keyUID: "kate"}, blacklistRealUserBidirectional},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.p.BlacklistPolicy(); got != tc.want {
+				t.Fatalf("BlacklistPolicy = %v, want %v", got, tc.want)
+			}
+		})
+	}
+	// obo & uk resolve the SAME policy but from different subject uids.
+	obo := oboPrincipal{botUID: "bot9", grantorUID: "grace"}
+	uk := ukPrincipal{keyUID: "kate"}
+	if obo.BlacklistPolicy() != uk.BlacklistPolicy() {
+		t.Fatalf("obo and uk must share the real-user bidirectional policy")
+	}
+	if obo.SubjectUID() == uk.SubjectUID() {
+		t.Fatalf("obo and uk must carry distinct subject uids (grantor vs key UID)")
+	}
+}
+
+// ---------- Authenticate: user ----------
+
+func TestAuthenticateUser(t *testing.T) {
+	c, _ := newPrincipalCtx(t)
+	c.Set("uid", "alice")
+	c.Set("space_id", "  S1  ") // must be trimmed
+	p := authenticateUser(c)
+	if p.Kind() != principalKindUser {
+		t.Fatalf("kind = %v, want user", p.Kind())
+	}
+	if p.SubjectUID() != "alice" {
+		t.Fatalf("SubjectUID = %q, want alice", p.SubjectUID())
+	}
+	if p.SpaceID() != "S1" {
+		t.Fatalf("SpaceID = %q, want trimmed S1", p.SpaceID())
+	}
+}
+
+// ---------- Authenticate: user_bot ----------
+
+func TestAuthenticateUserBot_OK(t *testing.T) {
+	c, _ := newPrincipalCtx(t)
+	c.Set(ctxKeyRobotID, "bot9")
+	c.Set(ctxKeyBotKind, botKindUser)
+	p, err := authenticateUserBot(c)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if p.Kind() != principalKindUserBot {
+		t.Fatalf("kind = %v, want user_bot", p.Kind())
+	}
+	if p.SubjectUID() != "bot9" {
+		t.Fatalf("SubjectUID = %q, want bot9", p.SubjectUID())
+	}
+	if p.SpaceID() != "" {
+		t.Fatalf("SpaceID = %q, want empty (no SpaceMiddleware on /v1/bot)", p.SpaceID())
+	}
+	if p.BlacklistPolicy() != blacklistNone {
+		t.Fatalf("user_bot must skip blacklist")
+	}
+}
+
+func TestAuthenticateUserBot_AppBotDenied(t *testing.T) {
+	c, _ := newPrincipalCtx(t)
+	c.Set(ctxKeyRobotID, "appbot1")
+	c.Set(ctxKeyBotKind, botKindApp)
+	_, err := authenticateUserBot(c)
+	if !errors.Is(err, errPrincipalAppBotDenied) {
+		t.Fatalf("app bot must be denied, got err=%v", err)
+	}
+}
+
+func TestAuthenticateUserBot_MissingRobotID(t *testing.T) {
+	c, _ := newPrincipalCtx(t)
+	_, err := authenticateUserBot(c)
+	if !errors.Is(err, errPrincipalUnauthenticated) {
+		t.Fatalf("missing robot_id must be unauthenticated, got err=%v", err)
+	}
+}
+
+// ---------- Authenticate: obo ----------
+
+func TestAuthenticateOBO_OK(t *testing.T) {
+	p, err := authenticateOBO("bot9", "grace", "  S1 ")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if p.Kind() != principalKindOBO {
+		t.Fatalf("kind = %v, want obo", p.Kind())
+	}
+	if p.SubjectUID() != "grace" {
+		t.Fatalf("SubjectUID = %q, want grantor grace", p.SubjectUID())
+	}
+	if p.SpaceID() != "S1" {
+		t.Fatalf("SpaceID = %q, want trimmed S1", p.SpaceID())
+	}
+	if p.RateLimitKey() != "bot9" || p.AuditBotUID() != "bot9" || p.AuditGrantorUID() != "grace" {
+		t.Fatalf("obo audit/ratelimit fields wrong: rl=%q bot=%q grantor=%q",
+			p.RateLimitKey(), p.AuditBotUID(), p.AuditGrantorUID())
+	}
+}
+
+func TestAuthenticateOBO_MissingInputs(t *testing.T) {
+	if _, err := authenticateOBO("", "grace", ""); !errors.Is(err, errPrincipalUnauthenticated) {
+		t.Fatalf("empty botUID must be unauthenticated, got %v", err)
+	}
+	if _, err := authenticateOBO("bot9", "", ""); !errors.Is(err, errPrincipalUnauthenticated) {
+		t.Fatalf("empty grantor must be unauthenticated, got %v", err)
+	}
+	if _, err := authenticateOBO("same", "same", ""); !errors.Is(err, errPrincipalUnauthenticated) {
+		t.Fatalf("bot==grantor must fail closed, got %v", err)
+	}
+}
+
+// ---------- Authenticate: uk (complete implementation, not a stub) ----------
+
+func TestAuthenticateUK_OK(t *testing.T) {
+	c, _ := newPrincipalCtx(t)
+	c.Set(ctxKeyAPIKeyUID, "kate")
+	c.Set(ctxKeyAPIKeySpaceID, " S2 ")
+	p, err := authenticateUK(c)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if p.Kind() != principalKindUK {
+		t.Fatalf("kind = %v, want uk", p.Kind())
+	}
+	if p.SubjectUID() != "kate" {
+		t.Fatalf("SubjectUID = %q, want key UID kate", p.SubjectUID())
+	}
+	if p.SpaceID() != "S2" {
+		t.Fatalf("SpaceID = %q, want trimmed api_key_space_id S2", p.SpaceID())
+	}
+	if p.RateLimitKey() != "kate" {
+		t.Fatalf("uk must meter by key UID, got %q", p.RateLimitKey())
+	}
+	if p.BlacklistPolicy() != blacklistRealUserBidirectional {
+		t.Fatalf("uk must apply real-user bidirectional blacklist")
+	}
+	if p.AuditBotUID() != "" {
+		t.Fatalf("uk has no bot in the path, AuditBotUID must be empty, got %q", p.AuditBotUID())
+	}
+}
+
+func TestAuthenticateUK_MissingKeyUID(t *testing.T) {
+	c, _ := newPrincipalCtx(t)
+	_, err := authenticateUK(c)
+	if !errors.Is(err, errPrincipalUnauthenticated) {
+		t.Fatalf("missing api_key_uid must be unauthenticated, got %v", err)
+	}
+}
+
+// ---------- Handler.principal: lazy default vs explicit set ----------
+
+// TestHandlerPrincipal_LazyUserDefault — with no explicit principal, the
+// real-user carrier is constructed live from the auth context, so behaviour is
+// identical to the pre-refactor c.GetLoginUID()/GetSpaceID() reads.
+func TestHandlerPrincipal_LazyUserDefault(t *testing.T) {
+	h := &Handler{Log: log.NewTLog("principal-test")}
+	c, _ := newPrincipalCtx(t)
+	c.Set("uid", "alice")
+	c.Set("space_id", "S1")
+	p := h.principal(c)
+	if p.Kind() != principalKindUser || p.SubjectUID() != "alice" || p.SpaceID() != "S1" {
+		t.Fatalf("lazy default must be user{alice,S1}, got kind=%v uid=%q space=%q",
+			p.Kind(), p.SubjectUID(), p.SpaceID())
+	}
+}
+
+// TestHandlerPrincipal_ExplicitSetWins — a route that setPrincipal()'d a bot
+// carrier (#B) must be returned verbatim, overriding the lazy default.
+func TestHandlerPrincipal_ExplicitSetWins(t *testing.T) {
+	h := &Handler{Log: log.NewTLog("principal-test")}
+	c, _ := newPrincipalCtx(t)
+	c.Set("uid", "alice") // would-be lazy default
+	setPrincipal(c, userBotPrincipal{botUID: "bot9"})
+	p := h.principal(c)
+	if p.Kind() != principalKindUserBot || p.SubjectUID() != "bot9" {
+		t.Fatalf("explicit principal must win, got kind=%v uid=%q", p.Kind(), p.SubjectUID())
+	}
+}
+
+// TestPrincipalForSubject_PrefersContext — the global enumeration seam reuses
+// an explicitly-set principal, else falls back to a user carrier over the
+// passed subject (preserving the direct-call semantics existing tests rely on).
+func TestPrincipalForSubject_PrefersContext(t *testing.T) {
+	c, _ := newPrincipalCtx(t)
+	// No context principal → fall back to user{loginUID, spaceID}.
+	p := principalForSubject(c, "alice", "S1")
+	if p.Kind() != principalKindUser || p.SubjectUID() != "alice" || p.SpaceID() != "S1" {
+		t.Fatalf("fallback must be user{alice,S1}, got kind=%v uid=%q space=%q",
+			p.Kind(), p.SubjectUID(), p.SpaceID())
+	}
+	// Explicit principal set → returned regardless of the passed subject.
+	setPrincipal(c, userBotPrincipal{botUID: "bot9"})
+	p = principalForSubject(c, "alice", "S1")
+	if p.Kind() != principalKindUserBot || p.SubjectUID() != "bot9" {
+		t.Fatalf("context principal must win, got kind=%v uid=%q", p.Kind(), p.SubjectUID())
+	}
+}
+
+// ---------- predicate dispatch (决策九 seam) ----------
+
+// TestCanReadChannel_RealUserDelegates — for a real-user principal the
+// single-channel gate must delegate to checkChannelAccess with the subject uid
+// (self-DM passes without touching friend/blacklist).
+func TestCanReadChannel_RealUserDelegates(t *testing.T) {
+	uSvc := &stubAuthzUserSvc{}
+	h := newAuthzHandlerFull(&stubAuthzGroupSvc{}, uSvc, &stubAuthzThreadSvc{})
+	c, _ := newAuthzCtx(t)
+	// self-DM: peer == subject, must pass without friend/blacklist lookups.
+	if !h.canReadChannel(c, userPrincipal{uid: "me"}, channelTypePerson, "me") {
+		t.Fatalf("real-user self-DM must pass canReadChannel")
+	}
+	if uSvc.friendCalls != 0 || uSvc.blCalls != 0 {
+		t.Fatalf("self-DM must not consult friend/blacklist; got friend=%d bl=%d",
+			uSvc.friendCalls, uSvc.blCalls)
+	}
+}
+
+// TestCanReadChannel_UserBotFailsClosed — the as-bot branch is a #C/#D seam;
+// until wired it must deny fail-closed with NOT_FOUND (never silently allow).
+func TestCanReadChannel_UserBotFailsClosed(t *testing.T) {
+	h := newAuthzHandlerFull(&stubAuthzGroupSvc{}, &stubAuthzUserSvc{}, &stubAuthzThreadSvc{})
+	c, rec := newAuthzCtx(t)
+	if h.canReadChannel(c, userBotPrincipal{botUID: "bot9"}, channelTypeGroup, "g1") {
+		t.Fatalf("as-bot gate must fail closed until #C/#D wire it")
+	}
+	if rec.Body.Len() == 0 {
+		t.Fatalf("as-bot denial must render a response (NOT_FOUND)")
+	}
+}
+
+// TestEnumerateReadableChannels_UserBotNotImplemented — the as-bot allowlist
+// enumeration is #E's seam; until then it fails closed with an error.
+func TestEnumerateReadableChannels_UserBotNotImplemented(t *testing.T) {
+	h := newAuthzHandlerFull(&stubAuthzGroupSvc{}, &stubAuthzUserSvc{}, &stubAuthzThreadSvc{})
+	c, _ := newAuthzCtx(t)
+	_, _, _, _, err := h.enumerateReadableChannels(c, userBotPrincipal{botUID: "bot9"})
+	if !errors.Is(err, errBotPredicateNotImplemented) {
+		t.Fatalf("as-bot enumeration must fail closed until #E, got err=%v", err)
+	}
+}
+
+// TestPrincipalKindString / blacklistPolicyString — stable labels for logs.
+func TestPrincipalKindString(t *testing.T) {
+	if principalKindUser.String() != "user" || principalKindUserBot.String() != "user_bot" ||
+		principalKindOBO.String() != "obo" || principalKindUK.String() != "uk" {
+		t.Fatalf("principalKind labels drifted")
+	}
+	if blacklistNone.String() != "none" || blacklistRealUserBidirectional.String() != "real-user-bidirectional" {
+		t.Fatalf("blacklistPolicy labels drifted")
+	}
+}

--- a/modules/messages_search/principal_test.go
+++ b/modules/messages_search/principal_test.go
@@ -345,13 +345,15 @@ func TestCanReadChannel_RealUserDelegates(t *testing.T) {
 	}
 }
 
-// TestCanReadChannel_UserBotFailsClosed — the as-bot branch is a #C/#D seam;
-// until wired it must deny fail-closed with NOT_FOUND (never silently allow).
-func TestCanReadChannel_UserBotFailsClosed(t *testing.T) {
+// TestCanReadChannel_UserBotP2PFailsClosed — the as-bot DM (person) branch is
+// #C's seam (YUJ-50); until wired it must deny fail-closed with NOT_FOUND
+// (never silently allow). The group/thread branches are wired by #D and are
+// covered in authz_bot_test.go.
+func TestCanReadChannel_UserBotP2PFailsClosed(t *testing.T) {
 	h := newAuthzHandlerFull(&stubAuthzGroupSvc{}, &stubAuthzUserSvc{}, &stubAuthzThreadSvc{})
 	c, rec := newAuthzCtx(t)
-	if h.canReadChannel(c, userBotPrincipal{botUID: "bot9"}, channelTypeGroup, "g1") {
-		t.Fatalf("as-bot gate must fail closed until #C/#D wire it")
+	if h.canReadChannel(c, userBotPrincipal{botUID: "bot9"}, channelTypePerson, "peer") {
+		t.Fatalf("as-bot P2P gate must fail closed until #C wires it")
 	}
 	if rec.Body.Len() == 0 {
 		t.Fatalf("as-bot denial must render a response (NOT_FOUND)")

--- a/modules/messages_search/principal_test.go
+++ b/modules/messages_search/principal_test.go
@@ -3,6 +3,7 @@ package messages_search
 import (
 	"errors"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
@@ -354,6 +355,119 @@ func TestCanReadChannel_UserBotFailsClosed(t *testing.T) {
 	}
 	if rec.Body.Len() == 0 {
 		t.Fatalf("as-bot denial must render a response (NOT_FOUND)")
+	}
+}
+
+// TestCanReadChannel_UserBotP2PFriendAllowed — as-bot DM gate (#C): a bot that
+// is friends with the peer may search that DM. Space and blacklist must NOT be
+// consulted (bot has no Space row; blacklistPolicy=none).
+func TestCanReadChannel_UserBotP2PFriendAllowed(t *testing.T) {
+	uSvc := &stubAuthzUserSvc{
+		friends: map[string]bool{friendKey("bot9", "peer"): true},
+		// A peer→bot blacklist row is present to prove the gate never reads it.
+		blacklists: map[string]bool{blacklistKey("peer", "bot9"): true},
+	}
+	h := newAuthzHandlerFull(&stubAuthzGroupSvc{}, uSvc, &stubAuthzThreadSvc{})
+	c, rec := newAuthzCtx(t)
+
+	if !h.canReadChannel(c, userBotPrincipal{botUID: "bot9"}, channelTypePerson, "peer") {
+		t.Fatalf("as-bot friend DM must pass the p2p gate")
+	}
+	if rec.Body.Len() != 0 {
+		t.Fatalf("no response should be written on allow, got %q", rec.Body.String())
+	}
+	if uSvc.friendCalls != 1 {
+		t.Fatalf("expected exactly one IsFriend lookup, got %d", uSvc.friendCalls)
+	}
+	if uSvc.blCalls != 0 || uSvc.spaceCalls != 0 || uSvc.robotCalls != 0 {
+		t.Fatalf("as-bot p2p must skip blacklist/Space/bot-classification; got bl=%d space=%d robot=%d",
+			uSvc.blCalls, uSvc.spaceCalls, uSvc.robotCalls)
+	}
+}
+
+// TestCanReadChannel_UserBotP2PBlacklistedButFriendAllowed — 决策不取: friend but
+// blocked BY the peer still searchable (a bot must stay able to search a DM it
+// is party to). Directly asserts the acceptance criterion.
+func TestCanReadChannel_UserBotP2PBlacklistedButFriendAllowed(t *testing.T) {
+	uSvc := &stubAuthzUserSvc{
+		friends: map[string]bool{friendKey("bot9", "peer"): true},
+		blacklists: map[string]bool{
+			blacklistKey("peer", "bot9"): true, // peer blocked the bot
+			blacklistKey("bot9", "peer"): true, // and (hypothetically) vice-versa
+		},
+	}
+	h := newAuthzHandlerFull(&stubAuthzGroupSvc{}, uSvc, &stubAuthzThreadSvc{})
+	c, rec := newAuthzCtx(t)
+
+	if !h.canReadChannel(c, userBotPrincipal{botUID: "bot9"}, channelTypePerson, "peer") {
+		t.Fatalf("as-bot friend DM must remain searchable regardless of blacklist (决策不取)")
+	}
+	if uSvc.blCalls != 0 {
+		t.Fatalf("as-bot p2p must never query blacklist; got %d calls", uSvc.blCalls)
+	}
+	if rec.Body.Len() != 0 {
+		t.Fatalf("no response on allow, got %q", rec.Body.String())
+	}
+}
+
+// TestCanReadChannel_UserBotP2PNotFriendDenied — a bot that is not friends with
+// the peer is denied as NOT_FOUND (anti-enumeration), no blacklist follow-up.
+func TestCanReadChannel_UserBotP2PNotFriendDenied(t *testing.T) {
+	uSvc := &stubAuthzUserSvc{friends: map[string]bool{}}
+	h := newAuthzHandlerFull(&stubAuthzGroupSvc{}, uSvc, &stubAuthzThreadSvc{})
+	c, rec := newAuthzCtx(t)
+
+	if h.canReadChannel(c, userBotPrincipal{botUID: "bot9"}, channelTypePerson, "peer") {
+		t.Fatalf("as-bot non-friend DM must be denied")
+	}
+	if uSvc.blCalls != 0 {
+		t.Fatalf("blacklist must not be queried after non-friend rejection; got %d", uSvc.blCalls)
+	}
+	if !strings.Contains(rec.Body.String(), "not found") {
+		t.Fatalf("denial should render the not_found envelope, got %q", rec.Body.String())
+	}
+}
+
+// TestCanReadChannel_UserBotP2PIsFriendErrorFailsClosed — an IsFriend DB error
+// must fail closed (deny) rather than leak access.
+func TestCanReadChannel_UserBotP2PIsFriendErrorFailsClosed(t *testing.T) {
+	uSvc := &stubAuthzUserSvc{friendErr: errors.New("db down")}
+	h := newAuthzHandlerFull(&stubAuthzGroupSvc{}, uSvc, &stubAuthzThreadSvc{})
+	c, _ := newAuthzCtx(t)
+
+	if h.canReadChannel(c, userBotPrincipal{botUID: "bot9"}, channelTypePerson, "peer") {
+		t.Fatalf("as-bot IsFriend error must fail closed")
+	}
+}
+
+// TestCanReadChannel_UserBotP2PUsesBotUID — the gate keys IsFriend on the bot's
+// own SubjectUID (botUID), not the login uid. Proves the subject substitution.
+func TestCanReadChannel_UserBotP2PUsesBotUID(t *testing.T) {
+	uSvc := &stubAuthzUserSvc{friends: map[string]bool{friendKey("bot9", "peer"): true}}
+	h := newAuthzHandlerFull(&stubAuthzGroupSvc{}, uSvc, &stubAuthzThreadSvc{})
+	c, _ := newAuthzCtx(t)
+
+	// Friend edge exists for bot9→peer only; a different bot must be denied.
+	if h.canReadChannel(c, userBotPrincipal{botUID: "other"}, channelTypePerson, "peer") {
+		t.Fatalf("gate must key IsFriend on the bot SubjectUID; a non-friend bot must be denied")
+	}
+	if !h.canReadChannel(c, userBotPrincipal{botUID: "bot9"}, channelTypePerson, "peer") {
+		t.Fatalf("the friend bot (bot9) must be allowed")
+	}
+}
+
+// TestCanReadChannel_UserBotGroupThreadFailClosed — group/thread remain #D's
+// unwired seam after #C: still deny fail-closed with NOT_FOUND.
+func TestCanReadChannel_UserBotGroupThreadFailClosed(t *testing.T) {
+	for _, ct := range []uint8{channelTypeGroup, channelTypeThread} {
+		h := newAuthzHandlerFull(&stubAuthzGroupSvc{}, &stubAuthzUserSvc{}, &stubAuthzThreadSvc{})
+		c, rec := newAuthzCtx(t)
+		if h.canReadChannel(c, userBotPrincipal{botUID: "bot9"}, ct, "chan") {
+			t.Fatalf("as-bot group/thread gate must fail closed until #D wires it (ct=%d)", ct)
+		}
+		if rec.Body.Len() == 0 {
+			t.Fatalf("as-bot group/thread denial must render a response (ct=%d)", ct)
+		}
 	}
 }
 

--- a/modules/messages_search/principal_test.go
+++ b/modules/messages_search/principal_test.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/modules/group"
+	"github.com/Mininglamp-OSS/octo-server/modules/user"
 	"github.com/gin-gonic/gin"
 )
 
@@ -86,10 +88,10 @@ func TestPrincipalCarrier_RateLimitKey(t *testing.T) {
 // neither (login_uid alone suffices).
 func TestPrincipalCarrier_AuditUIDs(t *testing.T) {
 	cases := []struct {
-		name          string
-		p             Principal
-		wantBot       string
-		wantGrantor   string
+		name        string
+		p           Principal
+		wantBot     string
+		wantGrantor string
 	}{
 		{"user", userPrincipal{uid: "alice"}, "", ""},
 		{"user_bot", userBotPrincipal{botUID: "bot9"}, "bot9", ""},
@@ -355,14 +357,28 @@ func TestCanReadChannel_UserBotFailsClosed(t *testing.T) {
 	}
 }
 
-// TestEnumerateReadableChannels_UserBotNotImplemented — the as-bot allowlist
-// enumeration is #E's seam; until then it fails closed with an error.
-func TestEnumerateReadableChannels_UserBotNotImplemented(t *testing.T) {
-	h := newAuthzHandlerFull(&stubAuthzGroupSvc{}, &stubAuthzUserSvc{}, &stubAuthzThreadSvc{})
+// TestEnumerateReadableChannels_UserBotEnumerates — the as-bot allowlist
+// enumeration is #E (YUJ-52). enumerateReadableChannels must dispatch a
+// userBotPrincipal to buildBotAllowlist (friends ∪ groups ∪ threads), NOT the
+// old fail-closed placeholder. Full behaviour is covered in
+// search_global_test.go; here we only assert the dispatch is wired.
+func TestEnumerateReadableChannels_UserBotEnumerates(t *testing.T) {
+	gSvc := &stubGroupSvc{groupsByUID: map[string][]*group.InfoResp{"bot9": {{GroupNo: "g1"}}}}
+	uSvc := &stubUserSvc{friends: []*user.FriendResp{{UID: "alice"}}}
+	h := newHandlerForGlobalTests()
+	h.groupService = gSvc
+	h.userService = uSvc
+	h.threadEnumFn = func([]string) (map[string][]string, error) { return nil, nil }
 	c, _ := newAuthzCtx(t)
-	_, _, _, _, err := h.enumerateReadableChannels(c, userBotPrincipal{botUID: "bot9"})
-	if !errors.Is(err, errBotPredicateNotImplemented) {
-		t.Fatalf("as-bot enumeration must fail closed until #E, got err=%v", err)
+	allowGroup, allowDM, _, _, err := h.enumerateReadableChannels(c, userBotPrincipal{botUID: "bot9"})
+	if err != nil {
+		t.Fatalf("as-bot enumeration must succeed once #E is wired, got err=%v", err)
+	}
+	if len(allowGroup) != 1 || allowGroup[0].OSChannelID != "g1" {
+		t.Fatalf("expected bot group g1 in allowlist, got %+v", allowGroup)
+	}
+	if len(allowDM) != 1 || allowDM[0].WireID != "alice" {
+		t.Fatalf("expected bot friend alice in DM allowlist, got %+v", allowDM)
 	}
 }
 

--- a/modules/messages_search/ratelimit.go
+++ b/modules/messages_search/ratelimit.go
@@ -121,7 +121,9 @@ func (l *uidLimiter) sweepLocked(now time.Time) {
 // request through unmetered.
 func (h *Handler) searchRateLimiter() wkhttp.HandlerFunc {
 	return func(c *wkhttp.Context) {
-		key := c.GetLoginUID()
+		// 限流键走 principal（决策十）：真人=自身 uid（现状不变）；as-bot / obo 都按
+		// botUID 计（防单 bot 打爆）；uk 按 key UID。
+		key := h.principal(c).RateLimitKey()
 		if key == "" {
 			key = "ip:" + c.ClientIP()
 		}

--- a/modules/messages_search/route_subtree.go
+++ b/modules/messages_search/route_subtree.go
@@ -1,0 +1,102 @@
+package messages_search
+
+import (
+	"sync"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+)
+
+// 本文件是 YUJ-49（#B）的入口接线层：把同一套 _search* handler 暴露给 bot / uk 两条
+// 新路由树，并把 principal 解析（决策十）下沉到路由入口。设计要点（决策六/七/十）：
+//
+//   - 一套 handler、一个 Handler 实例（Shared 单例）承载 web / bot / uk 三条路由树，
+//     共享同一份限流桶与 sender 缓存；三者仅入口鉴权 + principal 解析不同。
+//   - bot_api / botfather 各自提供「鉴权 + principal 解析」中间件，MountSubtree 追加
+//     搜索专属链（searchRateLimiter → auditMiddleware → backendGate）并挂载全部端点，
+//     与 /v1/messages（web）的端点集合完全一致（同一 routeMounters）。
+//   - SpaceMiddleware 刻意不进 bot/uk 链：bot 无 space_member（spaceID 恒空），uk 的
+//     spaceID 走 api_key_space_id（principal 读取），故两条链都不挂 Space 门
+//     （对齐 space_inject.go:148「/v1/bot 不挂 SpaceMiddleware」）。
+//
+// principal 的三态区分下沉在此：命中哪条路由 + on_behalf_of 是否存在 →
+//   - bot 路由 + 无 on_behalf_of = as-bot（user_bot）；
+//   - bot 路由 + on_behalf_of   = as-user(OBO)（grantor）；
+//   - uk 路由                    = as-user 直接身份（uk）。
+// 具体解析由本文件导出的构造器完成，接线由 bot_api / botfather 的入口中间件驱动。
+
+var (
+	sharedOnce sync.Once
+	sharedH    *Handler
+)
+
+// Shared 返回进程内唯一的搜索 Handler。web（本模块 SetupAPI）、bot（bot_api）、
+// uk（botfather）三条路由树共用它，从而共享限流桶 / sender 缓存 / 后端模式解析——
+// 单个 bot 的搜索配额是一致的一份，而非按入口分裂。首个调用方（模块装载顺序决定）
+// 用其 *config.Context 构造；后续调用返回同一实例（各模块拿到的 ctx 是同一个）。
+func Shared(ctx *config.Context) *Handler {
+	sharedOnce.Do(func() {
+		sharedH = New(ctx)
+	})
+	return sharedH
+}
+
+// MountSubtree 在 r 上以 prefix 为前缀挂载全部 _search* 端点，前置 front（调用方的
+// 鉴权 + principal 解析中间件），再接搜索专属链 searchRateLimiter → auditMiddleware →
+// backendGate，最后经 routeMounters 注册与 /v1/messages 完全一致的端点集合。
+//
+// front 约定：必须在放行前对成功请求调用 SetPrincipal（bot=user_bot/obo、uk=uk），
+// 因为 searchRateLimiter（取限流键）与 auditMiddleware（取审计主体）都依赖 principal。
+// front 内部若鉴权/授权失败，应自行响应并 Abort，链在此中止。
+//
+// backendGate 位于链尾（鉴权 + 限流 + 审计之后），与 web 侧一致：即便后端为
+// disabled/zinc，拒绝也照样计量与审计，杜绝无度量的「搜索关闭」枚举旁路（V9）。
+func (h *Handler) MountSubtree(r *wkhttp.WKHttp, prefix string, front ...wkhttp.HandlerFunc) {
+	chain := make([]wkhttp.HandlerFunc, 0, len(front)+3)
+	chain = append(chain, front...)
+	chain = append(chain, h.searchRateLimiter(), h.auditMiddleware(), h.backendGate())
+	g := r.Group(prefix, chain...)
+	for _, mount := range routeMounters {
+		mount(h, g)
+	}
+}
+
+// ---- principal 解析：供 bot_api / botfather 的入口中间件调用（决策十）----
+
+// SetPrincipal 把已解析的搜索主体写入 context，handler 经 h.principal(c) 读取。
+// bot / uk / obo 路由显式调用；web 真人路由不调用，靠 Handler.principal 惰性默认。
+func SetPrincipal(c *wkhttp.Context, p Principal) { setPrincipal(c, p) }
+
+// AuthenticateUserBot 解析 as-bot 主体：subjectUID = botUID（要求上游 authBot() 已在
+// context 落 robot_id）。App Bot 返回 ErrAppBotSearchDenied（一期不支持，决策五，
+// 调用方须显式拒绝、不得静默放行）。
+func AuthenticateUserBot(c *wkhttp.Context) (Principal, error) { return authenticateUserBot(c) }
+
+// AuthenticateUK 解析 uk 主体：subjectUID = keyModel.UID、spaceID = api_key_space_id
+//（要求上游 authUserAPIKey() 已落 api_key_uid / api_key_space_id）。
+func AuthenticateUK(c *wkhttp.Context) (Principal, error) { return authenticateUK(c) }
+
+// NewOBOPrincipal 组装 as-user(OBO) 主体：subjectUID = grantorUID（走真人分支）、
+// 限流/审计按 botUID、审计并记 grantorUID。grant + scope + grantorCanReadChannel 的
+// 实时权限校验（TOCTOU 与发消息侧一致）由调用方在此之前完成（#F 复用
+// bot_api/obo_check.go）；本构造器只从两个已校验入参组装载体。
+func NewOBOPrincipal(botUID, grantorUID, spaceID string) (Principal, error) {
+	return authenticateOBO(botUID, grantorUID, spaceID)
+}
+
+// 导出鉴权错误哨兵，供入口中间件按类型映射响应（App Bot 拒绝 vs 一般未鉴权）。
+var (
+	ErrPrincipalUnauthenticated = errPrincipalUnauthenticated
+	ErrAppBotSearchDenied       = errPrincipalAppBotDenied
+)
+
+// PrincipalKind 返回本请求已解析主体的类型名（user / user_bot / obo / uk），未解析
+// 返回空串。供入口接线的单测断言「命中哪条路由 + on_behalf_of → 对应 principal」。
+func PrincipalKind(c *wkhttp.Context) string {
+	if v, ok := c.Get(principalCtxKey); ok {
+		if p, ok := v.(Principal); ok && p != nil {
+			return p.Kind().String()
+		}
+	}
+	return ""
+}

--- a/modules/messages_search/route_subtree_test.go
+++ b/modules/messages_search/route_subtree_test.go
@@ -1,0 +1,237 @@
+package messages_search
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/pkg/searchbackend"
+	"github.com/gin-gonic/gin"
+)
+
+// YUJ-49 (#B) — the entry-wiring layer that exposes the shared _search* handler
+// to the bot / uk route trees, resolving the correct principal at the route
+// edge. These tests cover the exported principal resolvers (三态区分) and
+// MountSubtree (endpoint coverage + the searchRateLimiter → audit → backendGate
+// chain fronted by a caller-supplied resolver).
+
+func newResolveCtx(t *testing.T) *wkhttp.Context {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	gc, _ := gin.CreateTestContext(rec)
+	gc.Request = httptest.NewRequest("POST", "/x", nil)
+	return &wkhttp.Context{Context: gc}
+}
+
+func TestAuthenticateUserBot_UserBotAppBotAndMissing(t *testing.T) {
+	// User Bot: subject = botUID, no space, blacklist not consulted, all
+	// metering/audit keyed on botUID.
+	c := newResolveCtx(t)
+	c.Set(ctxKeyRobotID, "bot_1")
+	p, err := AuthenticateUserBot(c)
+	if err != nil {
+		t.Fatalf("user bot: unexpected err %v", err)
+	}
+	if p.Kind() != principalKindUserBot {
+		t.Fatalf("kind = %v, want user_bot", p.Kind())
+	}
+	if p.SubjectUID() != "bot_1" || p.RateLimitKey() != "bot_1" || p.AuditBotUID() != "bot_1" {
+		t.Fatalf("subject/ratelimit/audit must all be botUID, got %+v", p)
+	}
+	if p.SpaceID() != "" {
+		t.Fatalf("bot spaceID must be empty, got %q", p.SpaceID())
+	}
+	if p.BlacklistPolicy() != blacklistNone {
+		t.Fatalf("bot blacklist policy must be none, got %v", p.BlacklistPolicy())
+	}
+	if p.AuditGrantorUID() != "" {
+		t.Fatalf("bot audit grantor must be empty, got %q", p.AuditGrantorUID())
+	}
+
+	// App Bot: explicitly denied (一期不做 App Bot，决策五).
+	appc := newResolveCtx(t)
+	appc.Set(ctxKeyRobotID, "app_1")
+	appc.Set(ctxKeyBotKind, botKindApp)
+	if _, err := AuthenticateUserBot(appc); !errors.Is(err, ErrAppBotSearchDenied) {
+		t.Fatalf("app bot must be denied, got %v", err)
+	}
+
+	// No robot_id in context → unauthenticated (fail-closed).
+	if _, err := AuthenticateUserBot(newResolveCtx(t)); !errors.Is(err, ErrPrincipalUnauthenticated) {
+		t.Fatalf("missing robot_id must be unauthenticated, got %v", err)
+	}
+}
+
+func TestAuthenticateUK_DirectRealUser(t *testing.T) {
+	c := newResolveCtx(t)
+	c.Set(ctxKeyAPIKeyUID, "u_9")
+	c.Set(ctxKeyAPIKeySpaceID, "sp_1")
+	p, err := AuthenticateUK(c)
+	if err != nil {
+		t.Fatalf("uk: unexpected err %v", err)
+	}
+	if p.Kind() != principalKindUK {
+		t.Fatalf("kind = %v, want uk", p.Kind())
+	}
+	if p.SubjectUID() != "u_9" || p.RateLimitKey() != "u_9" {
+		t.Fatalf("uk subject/ratelimit must be key UID, got %+v", p)
+	}
+	if p.SpaceID() != "sp_1" {
+		t.Fatalf("uk spaceID must be api_key_space_id, got %q", p.SpaceID())
+	}
+	if p.BlacklistPolicy() != blacklistRealUserBidirectional {
+		t.Fatalf("uk blacklist must be real-user bidirectional, got %v", p.BlacklistPolicy())
+	}
+	if p.AuditBotUID() != "" || p.AuditGrantorUID() != "" {
+		t.Fatalf("uk has no bot/grantor audit fields, got %+v", p)
+	}
+
+	if _, err := AuthenticateUK(newResolveCtx(t)); !errors.Is(err, ErrPrincipalUnauthenticated) {
+		t.Fatalf("missing api_key_uid must be unauthenticated, got %v", err)
+	}
+}
+
+func TestNewOBOPrincipal_GrantorSubjectBotMetering(t *testing.T) {
+	p, err := NewOBOPrincipal("bot_1", "grantor_2", "sp_3")
+	if err != nil {
+		t.Fatalf("obo: unexpected err %v", err)
+	}
+	if p.Kind() != principalKindOBO {
+		t.Fatalf("kind = %v, want obo", p.Kind())
+	}
+	if p.SubjectUID() != "grantor_2" {
+		t.Fatalf("obo subject must be grantor, got %q", p.SubjectUID())
+	}
+	if p.RateLimitKey() != "bot_1" {
+		t.Fatalf("obo rate-limit key must be botUID (防单 bot 打爆), got %q", p.RateLimitKey())
+	}
+	if p.AuditBotUID() != "bot_1" || p.AuditGrantorUID() != "grantor_2" {
+		t.Fatalf("obo audit must record bot+grantor, got %+v", p)
+	}
+	if p.SpaceID() != "sp_3" {
+		t.Fatalf("obo spaceID must follow grantor, got %q", p.SpaceID())
+	}
+	if p.BlacklistPolicy() != blacklistRealUserBidirectional {
+		t.Fatalf("obo blacklist must be real-user bidirectional, got %v", p.BlacklistPolicy())
+	}
+
+	// Self-grant and empty inputs fail closed (与 checkOBO 一致).
+	if _, err := NewOBOPrincipal("x", "x", ""); !errors.Is(err, ErrPrincipalUnauthenticated) {
+		t.Fatalf("self-grant must fail closed, got %v", err)
+	}
+	if _, err := NewOBOPrincipal("bot", "", ""); !errors.Is(err, ErrPrincipalUnauthenticated) {
+		t.Fatalf("empty grantor must fail closed, got %v", err)
+	}
+}
+
+func TestSetPrincipalAndPrincipalKind(t *testing.T) {
+	c := newResolveCtx(t)
+	if got := PrincipalKind(c); got != "" {
+		t.Fatalf("no principal yet, PrincipalKind = %q, want empty", got)
+	}
+	SetPrincipal(c, userBotPrincipal{botUID: "b"})
+	if got := PrincipalKind(c); got != "user_bot" {
+		t.Fatalf("PrincipalKind = %q, want user_bot", got)
+	}
+}
+
+// newSubtreeTestHandler builds a Handler wired just enough to exercise the
+// MountSubtree chain (searchRateLimiter needs a limiter; backendGate needs a
+// mode; audit needs a Log). ESServe is left false so backendGate aborts every
+// request with SEARCH_DISABLED before any real search handler (which would need
+// ES/MySQL) runs — that is exactly what proves the route is mounted and the
+// chain is reached.
+func newSubtreeTestHandler() *Handler {
+	return &Handler{
+		Log:     log.NewTLog("route-subtree-test"),
+		limiter: newUIDLimiter(5, 20),
+		mode:    searchbackend.Mode{ESServe: false, Declared: searchbackend.DeclaredDisabled},
+	}
+}
+
+func TestMountSubtree_EndpointsAndChain(t *testing.T) {
+	h := newSubtreeTestHandler()
+	r := wkhttp.New()
+
+	var resolved int
+	front := func(c *wkhttp.Context) {
+		resolved++
+		SetPrincipal(c, userBotPrincipal{botUID: "bot_meter"})
+		c.Next()
+	}
+	h.MountSubtree(r, "/v1/bot/messages", front)
+
+	// Every registered _search* endpoint must be reachable under the new prefix
+	// (chain reaches backendGate → SEARCH_DISABLED, i.e. NOT a 404).
+	endpoints := []string{
+		"/v1/bot/messages/_search",
+		"/v1/bot/messages/_search_media",
+		"/v1/bot/messages/_search_files",
+		"/v1/bot/messages/_search_all",
+		"/v1/bot/messages/_search_around",
+		"/v1/bot/messages/_search_global_messages",
+		"/v1/bot/messages/_search_global_files",
+		"/v1/bot/messages/_search_global_groups",
+	}
+	if len(endpoints) != len(routeMounters) {
+		t.Fatalf("test endpoint list (%d) drifted from routeMounters (%d); update the list",
+			len(endpoints), len(routeMounters))
+	}
+	for _, path := range endpoints {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest("POST", path, strings.NewReader(`{}`))
+		r.ServeHTTP(rec, req)
+		if rec.Code == http.StatusNotFound {
+			t.Fatalf("%s: not mounted (404) — MountSubtree must register it under the prefix", path)
+		}
+		body := strings.ToLower(rec.Body.String())
+		if !strings.Contains(body, "disabled") && !strings.Contains(rec.Body.String(), "未启用") &&
+			!strings.Contains(body, "not enabled") {
+			t.Fatalf("%s: expected SEARCH_DISABLED (chain reached backendGate), got %q", path, rec.Body.String())
+		}
+	}
+	if resolved != len(endpoints) {
+		t.Fatalf("front resolver ran %d times, want %d (must run before the chain on every endpoint)",
+			resolved, len(endpoints))
+	}
+
+	// A sibling path NOT registered must 404 — the subtree only mounts the
+	// _search* set, nothing broader.
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, httptest.NewRequest("POST", "/v1/bot/messages/not_a_search", nil))
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("unregistered path must 404, got %d", rec.Code)
+	}
+}
+
+func TestMountSubtree_FrontAbortShortCircuits(t *testing.T) {
+	h := newSubtreeTestHandler()
+	r := wkhttp.New()
+
+	reached := false
+	front := func(c *wkhttp.Context) {
+		// Simulate an auth/authorization failure at the route edge.
+		c.JSON(http.StatusUnauthorized, gin.H{"msg": "denied"})
+		c.Abort()
+	}
+	// Wrap a probe as the last "front" middleware to detect leak-through.
+	probe := func(c *wkhttp.Context) {
+		reached = true
+		c.Next()
+	}
+	h.MountSubtree(r, "/v1/bot/messages", front, probe)
+
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, httptest.NewRequest("POST", "/v1/bot/messages/_search", strings.NewReader(`{}`)))
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("front abort must short-circuit with its own status, got %d", rec.Code)
+	}
+	if reached {
+		t.Fatalf("downstream middleware must not run after front Abort")
+	}
+}

--- a/modules/messages_search/search_all.go
+++ b/modules/messages_search/search_all.go
@@ -34,7 +34,8 @@ func (h *Handler) searchAll(c *wkhttp.Context) {
 		return
 	}
 	req.Keyword = strings.TrimSpace(req.Keyword)
-	loginUID := c.GetLoginUID()
+	p := h.principal(c)
+	loginUID := p.SubjectUID()
 
 	if !validateKeywordOptional(c, req.Keyword) {
 		return
@@ -46,7 +47,7 @@ func (h *Handler) searchAll(c *wkhttp.Context) {
 	if !ok {
 		return
 	}
-	if !h.checkChannelAccess(c, req.ChannelType, req.ChannelID, loginUID) {
+	if !h.canReadChannel(c, p, req.ChannelType, req.ChannelID) {
 		return
 	}
 	spaceID, ok := h.resolveP2PSpaceScope(c, req.ChannelType, loginUID)

--- a/modules/messages_search/search_around.go
+++ b/modules/messages_search/search_around.go
@@ -51,7 +51,8 @@ func (h *Handler) searchAround(c *wkhttp.Context) {
 		respondValidation(c, "body", "invalid JSON")
 		return
 	}
-	loginUID := c.GetLoginUID()
+	p := h.principal(c)
+	loginUID := p.SubjectUID()
 
 	// Reuse the shared field validation (channel form, page_size, filters).
 	// No sort/cursor on this endpoint; relevance is not applicable.
@@ -64,7 +65,7 @@ func (h *Handler) searchAround(c *wkhttp.Context) {
 		respondValidation(c, "anchor_message_id", "must be a positive integer id")
 		return
 	}
-	if !h.checkChannelAccess(c, req.ChannelType, req.ChannelID, loginUID) {
+	if !h.canReadChannel(c, p, req.ChannelType, req.ChannelID) {
 		return
 	}
 	spaceID, ok := h.resolveP2PSpaceScope(c, req.ChannelType, loginUID)

--- a/modules/messages_search/search_files.go
+++ b/modules/messages_search/search_files.go
@@ -54,7 +54,8 @@ func (h *Handler) searchFiles(c *wkhttp.Context) {
 		return
 	}
 	req.Keyword = strings.TrimSpace(req.Keyword)
-	loginUID := c.GetLoginUID()
+	p := h.principal(c)
+	loginUID := p.SubjectUID()
 
 	if !validateKeywordOptional(c, req.Keyword) {
 		return
@@ -63,7 +64,7 @@ func (h *Handler) searchFiles(c *wkhttp.Context) {
 	if !ok {
 		return
 	}
-	if !h.checkChannelAccess(c, req.ChannelType, req.ChannelID, loginUID) {
+	if !h.canReadChannel(c, p, req.ChannelType, req.ChannelID) {
 		return
 	}
 	spaceID, ok := h.resolveP2PSpaceScope(c, req.ChannelType, loginUID)

--- a/modules/messages_search/search_global.go
+++ b/modules/messages_search/search_global.go
@@ -438,14 +438,23 @@ func normalizeMemberUIDs(loginUID string, uids []string, single string) []string
 func (h *Handler) resolveGlobalScope(c *wkhttp.Context, loginUID string, channelIDs []GlobalChannelRef, rawMemberUIDs []string, legacyMemberUID string) (osChannelIDs []string, spaceID string, singleFast *channelRef, timings allowlistTimings, ok bool) {
 	// spaceID 走 principal（决策十）：真人等价于 GetSpaceID(c)；bot 路由无 SpaceMiddleware
 	// 故为空；uk 取 api_key_space_id.
-	spaceID = h.principal(c).SpaceID()
-	if spaceID == "" {
+	p := h.principal(c)
+	spaceID = p.SpaceID()
+	if spaceID == "" && p.RequiresSpaceScope() {
 		// DM double-guard is space-dependent; without a Space the guard cannot
 		// fire (§6.5). We fail-closed on the DM side identically to
 		// resolveP2PSpaceScope so a missing Space cannot silently escape the
 		// filter. RequireSpaceID=false is the operator escape hatch — we
 		// mirror it here so the two paths behave the same during the v1.9
 		// indexer rollout.
+		//
+		// YUJ-57: only real-user-scoped principals (user / uk) are subject to
+		// this gate. Space-less principals (as-bot / OBO) legitimately carry no
+		// Space and their allowlist is enumerated by the per-principal readable
+		// predicate (IsFriend / grantor allowlist), which already bounds DM
+		// visibility without a spaceId term — so they proceed with spaceID=""
+		// (applyGlobalDMSpaceScope then emits no DM clause) instead of being
+		// blocked here before ever reaching enumerateReadableChannels.
 		if h.cfg.RequireSpaceID {
 			respondNotFound(c, "channel")
 			return nil, "", nil, timings, false

--- a/modules/messages_search/search_global.go
+++ b/modules/messages_search/search_global.go
@@ -436,7 +436,9 @@ func normalizeMemberUIDs(loginUID string, uids []string, single string) []string
 // this Space OR the channel_ids/member_uid intersection is empty — the
 // handler should return an empty envelope without touching OS.
 func (h *Handler) resolveGlobalScope(c *wkhttp.Context, loginUID string, channelIDs []GlobalChannelRef, rawMemberUIDs []string, legacyMemberUID string) (osChannelIDs []string, spaceID string, singleFast *channelRef, timings allowlistTimings, ok bool) {
-	spaceID = strings.TrimSpace(spacepkg.GetSpaceID(c))
+	// spaceID 走 principal（决策十）：真人等价于 GetSpaceID(c)；bot 路由无 SpaceMiddleware
+	// 故为空；uk 取 api_key_space_id.
+	spaceID = h.principal(c).SpaceID()
 	if spaceID == "" {
 		// DM double-guard is space-dependent; without a Space the guard cannot
 		// fire (§6.5). We fail-closed on the DM side identically to
@@ -452,7 +454,11 @@ func (h *Handler) resolveGlobalScope(c *wkhttp.Context, loginUID string, channel
 			zap.String("uid", loginUID))
 	}
 
-	allowGroup, allowDM, allowThread, allowTimings, err := h.buildAllowlist(c, loginUID, spaceID)
+	// 全局 allowlist 枚举经归一化谓词 enumerateReadableChannels（决策九）：真人语义主体
+	// 委托 buildAllowlist（现状不变），as-bot 分支在 #E 落——保证单频道门与 allowlist
+	// 共用同一谓词，不各写一套。principalForSubject 优先取路由显式写入的 principal
+	//（bot/uk，#B），否则用已解析的 (loginUID, spaceID) 组装真人载体（现网/既有单测行为不变）。
+	allowGroup, allowDM, allowThread, allowTimings, err := h.enumerateReadableChannels(c, principalForSubject(c, loginUID, spaceID))
 	timings = allowTimings
 	if err != nil {
 		h.Error("messages_search: allowlist build failed", zap.Error(err))

--- a/modules/messages_search/search_global.go
+++ b/modules/messages_search/search_global.go
@@ -724,6 +724,128 @@ func (h *Handler) buildAllowlist(_ *wkhttp.Context, loginUID, spaceID string) ([
 	return allowGroup, allowDM, allowThread, timings, nil
 }
 
+// buildBotAllowlist enumerates the as-bot global allowlist (#E / YUJ-52): the
+// exact channel set botCanReadChannel (#C/#D) would admit for this bot, so the
+// single-channel gate and the global feed stay one predicate (决策九). It is the
+// bot-subject counterpart of buildAllowlist — same enumeration skeleton, but the
+// subject is botUID and the bot主体语义 strips two real-user-only edges:
+//
+//   - Groups: GetGroupsWithMemberUID(botUID) gated by ExistMembersActive — the
+//     enumeration dual of the ExistMemberActive relation the single-channel group
+//     gate (#D) point-evaluates. status!=Normal rows (kicked / group-blacklisted,
+//     including the #354 cascade that flips an owner-blacklisted user's in-group
+//     bot to non-Normal) drop out for free, so 群级黑名单 is inherited, not re-coded.
+//   - DM peers: GetFriends(botUID) — the enumeration dual of IsFriend(botUID, peer)
+//     (#C). No bidirectional-blacklist gate (bot 主体 blacklistPolicy=none: bot 无法
+//     有意义地拉黑/被拉黑，见 #C), no Space-member union and no bot-in-Space
+//     suppression (bot 无 Space；且此处主体本身即 bot，对端由 IsFriend 收口).
+//   - Threads: active threads under the active groups, reusing
+//     enumerateThreadsForGroups (子区继承父群成员身份，与 #D 一致).
+//
+// 有界性 (issue 已确认): checkBotOwnership 只允许创建者把自己的 bot 拉进群，
+// cascadeRemoveBotsInvitedByUIDTx 在创建者退群时级联移除其 bot，故 bot 群集合 ⊆ 创建者
+// 群集合，量级与真人 global 同阶——沿用现有 per-group / 聚合 thread 上限
+// (maxThreadsPerGroup / maxTotalThreadChannelIDs)，不为 bot 另设上限；超限降级行为与真人
+// 路径完全一致 (enumerateThreadsForGroups 同一实现)。
+//
+// 归一化 (决策九硬约束): 与 buildAllowlist 的差异纯粹是主体语义 (bot 无 Space、无黑名单)，
+// 不在此内联重写任何鉴权规则——所用的 friendship / active-membership 关系与 #C/#D 单频道门
+// 同源，故「单频道门放行 ⇔ 出现在 global allowlist」(#G 跨路一致性) 成立。
+func (h *Handler) buildBotAllowlist(botUID string) ([]channelRef, []channelRef, []channelRef, allowlistTimings, error) {
+	var timings allowlistTimings
+	if botUID == "" {
+		// Defensive: an empty subject owns no channel. Fail-closed to an empty
+		// allowlist rather than risk enumerating an unbounded set.
+		return nil, nil, nil, timings, nil
+	}
+
+	// Groups: joined groups gated by active membership. No Space filter (bot has
+	// no Space) and thus no external-group lookup — both are real-user Space
+	// machinery that does not apply to the bot subject.
+	groups, err := h.groupService.GetGroupsWithMemberUID(botUID)
+	if err != nil {
+		return nil, nil, nil, timings, err
+	}
+	candidateGroupNos := make([]string, 0, len(groups))
+	candidateGroupSet := make(map[string]struct{}, len(groups))
+	for _, g := range groups {
+		if g == nil || g.GroupNo == "" {
+			continue
+		}
+		if _, dup := candidateGroupSet[g.GroupNo]; dup {
+			continue
+		}
+		candidateGroupSet[g.GroupNo] = struct{}{}
+		candidateGroupNos = append(candidateGroupNos, g.GroupNo)
+	}
+	// Active-status gate — mirrors buildAllowlist: drop groups whose group_member
+	// row is non-Normal so a kicked / group-blacklisted bot cannot search that
+	// group via the global feed. Fail-closed on error (return, don't degrade to
+	// an un-gated allowlist).
+	activeGroupSet := candidateGroupSet
+	if len(candidateGroupNos) > 0 {
+		start := time.Now()
+		activeNos, gerr := h.groupService.ExistMembersActive(candidateGroupNos, botUID)
+		timings.memberActive += time.Since(start)
+		if gerr != nil {
+			h.Error("messages_search: ExistMembersActive lookup failed; fail-closed on bot group allowlist",
+				zap.String("bot_uid", botUID),
+				zap.Error(gerr))
+			return nil, nil, nil, timings, gerr
+		}
+		activeGroupSet = make(map[string]struct{}, len(activeNos))
+		for _, no := range activeNos {
+			activeGroupSet[no] = struct{}{}
+		}
+	}
+	allowGroup := make([]channelRef, 0, len(candidateGroupNos))
+	groupNos := make([]string, 0, len(candidateGroupNos))
+	for _, no := range candidateGroupNos {
+		if _, ok := activeGroupSet[no]; !ok {
+			continue
+		}
+		allowGroup = append(allowGroup, channelRef{
+			OSChannelID: no,
+			WireID:      no,
+			ChannelType: channelTypeGroup,
+		})
+		groupNos = append(groupNos, no)
+	}
+
+	// DM peers: friend edges only. No blacklist gate (blacklistNone), no
+	// Space-member union, no bot-in-Space filter — see the doc comment.
+	dmStart := time.Now()
+	friends, ferr := h.userService.GetFriends(botUID)
+	if ferr != nil {
+		return nil, nil, nil, timings, ferr
+	}
+	allowDM := make([]channelRef, 0, len(friends))
+	seenPeer := make(map[string]struct{}, len(friends))
+	for _, f := range friends {
+		if f == nil || f.UID == "" || f.UID == botUID {
+			continue
+		}
+		if _, dup := seenPeer[f.UID]; dup {
+			continue
+		}
+		seenPeer[f.UID] = struct{}{}
+		allowDM = append(allowDM, channelRef{
+			OSChannelID: fakeChannelIDFor(botUID, f.UID),
+			WireID:      f.UID,
+			ChannelType: channelTypePerson,
+		})
+	}
+	timings.dmPeers += time.Since(dmStart)
+
+	// Threads under the active groups — same batch helper + hard caps as the
+	// real-user path; threads inherit their parent group's membership gate.
+	threadStart := time.Now()
+	allowThread := h.enumerateThreadsForGroups(groupNos)
+	timings.threadEnum += time.Since(threadStart)
+
+	return allowGroup, allowDM, allowThread, timings, nil
+}
+
 // enumerateThreadsForGroups fans a single batch query against the thread
 // table and turns every (groupNo, shortID) row into a composite
 // `{groupNo}____{shortID}` channelRef with channelType=5. Bounded by two

--- a/modules/messages_search/search_global_bot_test.go
+++ b/modules/messages_search/search_global_bot_test.go
@@ -1,0 +1,254 @@
+package messages_search
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-server/modules/group"
+	"github.com/Mininglamp-OSS/octo-server/modules/thread"
+	"github.com/Mininglamp-OSS/octo-server/modules/user"
+)
+
+// buildBotAllowlist (#E / YUJ-52) is the as-bot counterpart of buildAllowlist:
+// friends ∪ active groups ∪ threads under those groups, with the real-user-only
+// Space + blacklist edges stripped. These tests pin the acceptance criteria:
+//   - 命中集 = 好友 DM ∪ 群 ∪ 子区;
+//   - 越界频道 (非好友 / 非活跃群成员) 不返回;
+//   - bot 主体不查黑名单、不并 Space 成员;
+//   - ExistMembersActive 失败 fail-closed (返回错误, 不降级为无门 allowlist).
+
+// newBotAllowlistHandler wires the enumeration-capable stubs + a thread seam so
+// buildBotAllowlist can be exercised without a real MySQL/OS dependency.
+func newBotAllowlistHandler(gSvc group.IService, uSvc user.IService, threadsByGroup map[string][]string) *Handler {
+	h := newHandlerForGlobalTests()
+	h.groupService = gSvc
+	h.userService = uSvc
+	h.threadEnumFn = func(groupNos []string) (map[string][]string, error) {
+		out := map[string][]string{}
+		for _, gn := range groupNos {
+			if sids, ok := threadsByGroup[gn]; ok {
+				out[gn] = sids
+			}
+		}
+		return out, nil
+	}
+	return h
+}
+
+// TestBuildBotAllowlist_FriendsGroupsThreads — the happy path: a bot that is an
+// active member of one group (with a sub-thread) and friends with one peer sees
+// exactly that group, that thread, and that DM. Nothing else.
+func TestBuildBotAllowlist_FriendsGroupsThreads(t *testing.T) {
+	const botUID = "bot9"
+	gSvc := &stubGroupSvc{
+		groupsByUID: map[string][]*group.InfoResp{botUID: {{GroupNo: "g1"}}},
+		// nil activeGroupsForMember => every candidate group is active.
+	}
+	uSvc := &stubUserSvc{friends: []*user.FriendResp{{UID: "alice"}}}
+	h := newBotAllowlistHandler(gSvc, uSvc, map[string][]string{"g1": {"t1"}})
+
+	allowGroup, allowDM, allowThread, _, err := h.buildBotAllowlist(botUID)
+	if err != nil {
+		t.Fatalf("buildBotAllowlist: %v", err)
+	}
+	if len(allowGroup) != 1 || allowGroup[0].OSChannelID != "g1" || allowGroup[0].ChannelType != channelTypeGroup {
+		t.Fatalf("expected group g1, got %+v", allowGroup)
+	}
+	if len(allowThread) != 1 || allowThread[0].OSChannelID != thread.BuildChannelID("g1", "t1") ||
+		allowThread[0].ChannelType != channelTypeThread {
+		t.Fatalf("expected thread g1/t1, got %+v", allowThread)
+	}
+	if len(allowDM) != 1 {
+		t.Fatalf("expected exactly one DM peer, got %+v", allowDM)
+	}
+	if allowDM[0].WireID != "alice" || allowDM[0].ChannelType != channelTypePerson {
+		t.Fatalf("expected DM peer alice, got %+v", allowDM[0])
+	}
+	// DM OS channelId must be the fake-channel id built from (botUID, peer), the
+	// same shape resolveGlobalScope reverses back to the peer uid on the wire.
+	if allowDM[0].OSChannelID != fakeChannelIDFor(botUID, "alice") {
+		t.Fatalf("DM OS channelId mismatch: got %q", allowDM[0].OSChannelID)
+	}
+}
+
+// TestBuildBotAllowlist_InactiveGroupDropped — a group the bot is NOT an active
+// member of (kicked / group-blacklisted → status!=Normal, so ExistMembersActive
+// excludes it) must not appear, and neither must its threads. 越界群不返回.
+func TestBuildBotAllowlist_InactiveGroupDropped(t *testing.T) {
+	const botUID = "bot9"
+	gSvc := &stubGroupSvc{
+		groupsByUID: map[string][]*group.InfoResp{botUID: {{GroupNo: "g1"}, {GroupNo: "g2"}}},
+		// Only g1 is active for the bot; g2 was left/removed.
+		activeGroupsForMember: map[string]map[string]bool{botUID: {"g1": true}},
+	}
+	uSvc := &stubUserSvc{}
+	h := newBotAllowlistHandler(gSvc, uSvc, map[string][]string{"g1": {"t1"}, "g2": {"t2"}})
+
+	allowGroup, _, allowThread, _, err := h.buildBotAllowlist(botUID)
+	if err != nil {
+		t.Fatalf("buildBotAllowlist: %v", err)
+	}
+	if len(allowGroup) != 1 || allowGroup[0].OSChannelID != "g1" {
+		t.Fatalf("inactive group g2 must be dropped; got %+v", allowGroup)
+	}
+	// g2's thread must not leak through the thread enumeration either.
+	for _, tr := range allowThread {
+		if tr.OSChannelID == thread.BuildChannelID("g2", "t2") {
+			t.Fatalf("thread under inactive group g2 leaked: %+v", allowThread)
+		}
+	}
+	if len(allowThread) != 1 || allowThread[0].OSChannelID != thread.BuildChannelID("g1", "t1") {
+		t.Fatalf("expected only g1's thread, got %+v", allowThread)
+	}
+}
+
+// TestBuildBotAllowlist_NoBlacklistNoSpaceMembers — the bot subject skips the
+// bidirectional blacklist gate AND the Space-member union entirely:
+//   - a friend the bot has "blacklisted" (fixture) still appears (blacklistNone);
+//   - the Space-member seam (spaceMembersFn) is never consulted;
+//   - only friends surface as DM peers — no non-friend Space colleague.
+func TestBuildBotAllowlist_NoBlacklistNoSpaceMembers(t *testing.T) {
+	const botUID = "bot9"
+	gSvc := &stubGroupSvc{}
+	uSvc := &stubUserSvc{
+		friends: []*user.FriendResp{{UID: "alice"}},
+		// A blacklist edge in BOTH directions between bot and alice. The real-user
+		// path would drop alice; the bot path must NOT consult this at all.
+		blacklist: map[string]bool{
+			botUID + "->alice": true,
+			"alice->" + botUID: true,
+		},
+	}
+	h := newBotAllowlistHandler(gSvc, uSvc, nil)
+	// Guard: these real-user-only seams must never fire on the bot path.
+	h.spaceMembersFn = func(string, string) ([]string, error) {
+		t.Fatalf("bot allowlist must NOT union Space members")
+		return nil, nil
+	}
+	h.dmBotFilterFn = func(string, []string) ([]string, error) {
+		t.Fatalf("bot allowlist must NOT run the bot-in-Space filter")
+		return nil, nil
+	}
+
+	_, allowDM, _, _, err := h.buildBotAllowlist(botUID)
+	if err != nil {
+		t.Fatalf("buildBotAllowlist: %v", err)
+	}
+	if len(allowDM) != 1 || allowDM[0].WireID != "alice" {
+		t.Fatalf("blacklisted friend must still surface for a bot (blacklistNone); got %+v", allowDM)
+	}
+}
+
+// TestBuildBotAllowlist_MemberActiveError_FailClosed — an ExistMembersActive
+// failure must propagate as an error (fail-closed), NOT degrade to an un-gated
+// group allowlist. Mirrors the real-user buildAllowlist policy.
+func TestBuildBotAllowlist_MemberActiveError_FailClosed(t *testing.T) {
+	const botUID = "bot9"
+	gSvc := &stubGroupSvc{
+		groupsByUID:              map[string][]*group.InfoResp{botUID: {{GroupNo: "g1"}}},
+		activeGroupsForMemberErr: errors.New("db down"),
+	}
+	uSvc := &stubUserSvc{}
+	h := newBotAllowlistHandler(gSvc, uSvc, nil)
+
+	allowGroup, _, _, _, err := h.buildBotAllowlist(botUID)
+	if err == nil {
+		t.Fatalf("ExistMembersActive failure must fail closed with an error")
+	}
+	if allowGroup != nil {
+		t.Fatalf("fail-closed must not return a degraded allowlist; got %+v", allowGroup)
+	}
+}
+
+// TestBuildBotAllowlist_GroupsErrorFailClosed — GetGroupsWithMemberUID failure
+// propagates (no silent empty allowlist that would look like "no rooms").
+func TestBuildBotAllowlist_GroupsErrorFailClosed(t *testing.T) {
+	gSvc := &stubGroupSvc{groupsByUIDErr: errors.New("db down")}
+	h := newBotAllowlistHandler(gSvc, &stubUserSvc{}, nil)
+	if _, _, _, _, err := h.buildBotAllowlist("bot9"); err == nil {
+		t.Fatalf("GetGroupsWithMemberUID failure must propagate")
+	}
+}
+
+// TestBuildBotAllowlist_FriendsErrorFailClosed — GetFriends failure propagates.
+func TestBuildBotAllowlist_FriendsErrorFailClosed(t *testing.T) {
+	uSvc := &stubUserSvc{friendsErr: errors.New("db down")}
+	h := newBotAllowlistHandler(&stubGroupSvc{}, uSvc, nil)
+	if _, _, _, _, err := h.buildBotAllowlist("bot9"); err == nil {
+		t.Fatalf("GetFriends failure must propagate")
+	}
+}
+
+// TestBuildBotAllowlist_EmptySubject — a blank botUID owns no channel; return an
+// empty allowlist without touching any service (defensive fail-closed).
+func TestBuildBotAllowlist_EmptySubject(t *testing.T) {
+	gSvc := &stubGroupSvc{groupsByUIDErr: errors.New("must not be called")}
+	uSvc := &stubUserSvc{friendsErr: errors.New("must not be called")}
+	h := newBotAllowlistHandler(gSvc, uSvc, nil)
+	allowGroup, allowDM, allowThread, _, err := h.buildBotAllowlist("")
+	if err != nil {
+		t.Fatalf("empty subject must not error: %v", err)
+	}
+	if len(allowGroup)+len(allowDM)+len(allowThread) != 0 {
+		t.Fatalf("empty subject must yield an empty allowlist")
+	}
+}
+
+// TestBuildBotAllowlist_SelfAndBlankPeersDropped — the bot never DMs itself, and
+// blank / duplicate friend rows are collapsed.
+func TestBuildBotAllowlist_SelfAndBlankPeersDropped(t *testing.T) {
+	const botUID = "bot9"
+	uSvc := &stubUserSvc{friends: []*user.FriendResp{
+		{UID: botUID}, // self — drop
+		{UID: ""},     // blank — drop
+		{UID: "alice"},
+		{UID: "alice"}, // dup — collapse
+	}}
+	h := newBotAllowlistHandler(&stubGroupSvc{}, uSvc, nil)
+	_, allowDM, _, _, err := h.buildBotAllowlist(botUID)
+	if err != nil {
+		t.Fatalf("buildBotAllowlist: %v", err)
+	}
+	if len(allowDM) != 1 || allowDM[0].WireID != "alice" {
+		t.Fatalf("self/blank/dup peers must be dropped; got %+v", allowDM)
+	}
+}
+
+// TestBuildBotAllowlist_ThreadCapDowngrade — a group whose thread count exceeds
+// maxThreadsPerGroup downgrades to "group only" (its own message hits survive,
+// its thread hits are dropped) — identical to the real-user path since both go
+// through enumerateThreadsForGroups. Confirms 超上限降级行为与真人一致.
+func TestBuildBotAllowlist_ThreadCapDowngrade(t *testing.T) {
+	const botUID = "bot9"
+	overCap := make([]string, maxThreadsPerGroup+1)
+	for i := range overCap {
+		overCap[i] = "t" + itoaTest(i)
+	}
+	gSvc := &stubGroupSvc{groupsByUID: map[string][]*group.InfoResp{botUID: {{GroupNo: "g1"}}}}
+	h := newBotAllowlistHandler(gSvc, &stubUserSvc{}, map[string][]string{"g1": overCap})
+
+	allowGroup, _, allowThread, _, err := h.buildBotAllowlist(botUID)
+	if err != nil {
+		t.Fatalf("buildBotAllowlist: %v", err)
+	}
+	if len(allowGroup) != 1 || allowGroup[0].OSChannelID != "g1" {
+		t.Fatalf("group must still surface after thread cap downgrade; got %+v", allowGroup)
+	}
+	if len(allowThread) != 0 {
+		t.Fatalf("over-cap group must downgrade to group-only (no threads); got %d threads", len(allowThread))
+	}
+}
+
+// itoaTest is a tiny local int→string helper so the cap test doesn't pull in
+// strconv just for fixture ids.
+func itoaTest(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var b []byte
+	for n > 0 {
+		b = append([]byte{byte('0' + n%10)}, b...)
+		n /= 10
+	}
+	return string(b)
+}

--- a/modules/messages_search/search_global_files.go
+++ b/modules/messages_search/search_global_files.go
@@ -45,7 +45,7 @@ func (h *Handler) searchGlobalFiles(c *wkhttp.Context) {
 		return
 	}
 	req.Keyword = strings.TrimSpace(req.Keyword)
-	loginUID := c.GetLoginUID()
+	loginUID := h.principal(c).SubjectUID()
 
 	if !validateKeywordOptional(c, req.Keyword) {
 		return
@@ -250,8 +250,9 @@ func (h *Handler) buildGlobalFileHits(ctx context.Context, hits []*elastic.Searc
 // need to apply. So instead of forwarding to h.searchFiles (which would drop
 // those), we re-scope this handler's own query to the single channel.
 func (h *Handler) dispatchSingleFiles(c *wkhttp.Context, req SearchGlobalFilesReq, target channelRef, loginUID string, pageSize int) {
-	// Access gate mirrors the single-channel path.
-	if !h.checkChannelAccess(c, target.ChannelType, target.WireID, loginUID) {
+	// Access gate mirrors the single-channel path. Routed through canReadChannel
+	// so the global fast path shares #C/#D's per-principal gate (决策九).
+	if !h.canReadChannel(c, principalForSubject(c, loginUID, ""), target.ChannelType, target.WireID) {
 		return
 	}
 	// Fast path: run the same global DSL with a scope of one channel. This

--- a/modules/messages_search/search_global_groups.go
+++ b/modules/messages_search/search_global_groups.go
@@ -101,7 +101,11 @@ func (h *Handler) searchGlobalGroups(c *wkhttp.Context) {
 		return
 	}
 	req.Keyword = strings.TrimSpace(req.Keyword)
-	loginUID := c.GetLoginUID()
+	// 主体统一走 principal.SubjectUID()（决策十）—— 与 _search_global_messages /
+	// _search_global_files 对齐。OBO 路由下 context login uid 是 botUID，但搜索主体
+	// 必须是 grantorUID，否则 DM fake channel / applyVisiblesWhitelist / 审计会用错
+	// 主体，与另两条 global 路径漂移（YUJ-57）。
+	loginUID := h.principal(c).SubjectUID()
 
 	if !validateKeywordOptional(c, req.Keyword) {
 		return

--- a/modules/messages_search/search_global_messages.go
+++ b/modules/messages_search/search_global_messages.go
@@ -46,7 +46,7 @@ func (h *Handler) searchGlobalMessages(c *wkhttp.Context) {
 		return
 	}
 	req.Keyword = strings.TrimSpace(req.Keyword)
-	loginUID := c.GetLoginUID()
+	loginUID := h.principal(c).SubjectUID()
 
 	if !validateKeywordOptional(c, req.Keyword) {
 		return
@@ -351,10 +351,12 @@ func (h *Handler) dispatchSingleAll(c *wkhttp.Context, req SearchGlobalMessagesR
 			SentAtTo:   req.Filters.SentAtTo,
 		},
 	}
-	// Preserve authorisation shape by explicitly running checkChannelAccess
-	// here — the caller already resolved the room via the allowlist gate but
-	// the single-channel path assumes this check has already happened.
-	if !h.checkChannelAccess(c, inner.ChannelType, inner.ChannelID, loginUID) {
+	// Preserve authorisation shape by explicitly running the readable-channel
+	// gate here — the caller already resolved the room via the allowlist gate
+	// but the single-channel path assumes this check has already happened.
+	// Routed through canReadChannel so #C/#D's per-principal single-channel gate
+	// covers the global fast path too (决策九: 同一谓词).
+	if !h.canReadChannel(c, principalForSubject(c, loginUID, ""), inner.ChannelType, inner.ChannelID) {
 		return
 	}
 	// Rebuild the wire request context by rewriting BindJSON's already-

--- a/modules/messages_search/search_global_space_gate_test.go
+++ b/modules/messages_search/search_global_space_gate_test.go
@@ -1,0 +1,150 @@
+package messages_search
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/modules/group"
+	"github.com/gin-gonic/gin"
+)
+
+// YUJ-57 — the default RequireSpaceID=true Space gate must apply ONLY to
+// space-scoped principals (user / uk). Space-less principals (as-bot / OBO)
+// carry no Space and must NOT be blocked before ever reaching the allowlist
+// predicate. These tests deliberately set RequireSpaceID=true (the production
+// default) — a bare SearchConfig{} zero-values it to false and would silently
+// stop exercising the gate at all.
+
+// recordingGroupSvc wraps stubGroupSvc to capture which subject uid the
+// allowlist enumeration queried, so a test can prove searchGlobalGroups builds
+// its scope for the principal SUBJECT (grantorUID under OBO) rather than the
+// context login uid (botUID).
+type recordingGroupSvc struct {
+	*stubGroupSvc
+	queried []string
+}
+
+func (s *recordingGroupSvc) GetGroupsWithMemberUID(uid string) ([]*group.InfoResp, error) {
+	s.queried = append(s.queried, uid)
+	return s.stubGroupSvc.GetGroupsWithMemberUID(uid)
+}
+
+// TestResolveGlobalScope_OBOEmptySpaceBypassesGate_RequireTrue — an OBO
+// principal (subject = grantorUID) with no Space must pass the RequireSpaceID
+// gate and go on to enumerate the grantor's allowlist, rather than 404 at the
+// gate. The allowlist collapsing to the grantor's group also proves the
+// enumeration subject is the grantor, not the botUID.
+func TestResolveGlobalScope_OBOEmptySpaceBypassesGate_RequireTrue(t *testing.T) {
+	grantor := "grantor"
+	gSvc := &stubGroupSvc{
+		groupsByUID: map[string][]*group.InfoResp{grantor: {{GroupNo: "grpG"}}},
+	}
+	h := newAllowlistHandler(t, gSvc, &stubUserSvc{})
+	h.cfg.RequireSpaceID = true
+	h.threadEnumFn = func([]string) (map[string][]string, error) { return nil, nil }
+	// OBO enumeration ∩'s the grantor allowlist with the OBO scope gate; wire a
+	// checker that grants the grantor's group so the request resolves rather than
+	// fail-closing on a missing checker (that path is covered by obo_test.go).
+	h.oboCheck = &fakeOBOChecker{allow: map[string]bool{oboKey("grpG", channelTypeGroup): true}}
+
+	c, rec := newValidatorCtx(t)
+	c.Set("uid", "bot9") // OBO route's context login uid is the botUID — must be ignored
+	setPrincipal(c, oboPrincipal{botUID: "bot9", grantorUID: grantor, spaceID: ""})
+
+	osIDs, _, _, _, ok := h.resolveGlobalScope(c, grantor, nil, nil, "")
+	if !ok {
+		t.Fatalf("OBO with empty Space must bypass the fail-close gate under RequireSpaceID=true")
+	}
+	if rec.Body.Len() != 0 {
+		t.Fatalf("bypass must not write a 404 response: %q", rec.Body.String())
+	}
+	if len(osIDs) != 1 || osIDs[0] != "grpG" {
+		t.Fatalf("allowlist must be enumerated for the grantor subject; got %v", osIDs)
+	}
+}
+
+// TestResolveGlobalScope_UserEmptySpaceFailsClosed_RequireTrue — the exemption
+// is scoped to space-less principals. A real web user with no resolved Space
+// must STILL fail-close under RequireSpaceID (regression guard so the YUJ-57
+// bypass never leaks to the real-user path).
+func TestResolveGlobalScope_UserEmptySpaceFailsClosed_RequireTrue(t *testing.T) {
+	h := newAllowlistHandler(t, &stubGroupSvc{}, &stubUserSvc{})
+	h.cfg.RequireSpaceID = true
+
+	c, rec := newValidatorCtx(t)
+	c.Set("uid", "alice") // lazy user principal, no space_id ⇒ empty Space
+
+	osIDs, _, _, _, ok := h.resolveGlobalScope(c, "alice", nil, nil, "")
+	if ok {
+		t.Fatalf("real user with empty Space must fail-close under RequireSpaceID=true")
+	}
+	if len(osIDs) != 0 {
+		t.Fatalf("fail-close must return no channels, got %v", osIDs)
+	}
+	if !strings.Contains(rec.Body.String(), "not found") {
+		t.Fatalf("user fail-close must render NOT_FOUND, got %q", rec.Body.String())
+	}
+}
+
+// TestSearchGlobalGroups_SubjectFromPrincipal_OBO — the groups endpoint must
+// resolve its search subject via principal.SubjectUID() (grantorUID under OBO),
+// matching _search_global_messages / _search_global_files. Before the fix it
+// read c.GetLoginUID() (the botUID under an OBO route), which would enumerate
+// the wrong allowlist and drift from the other two global paths on the DM fake
+// channel, applyVisiblesWhitelist and audit subject.
+//
+// The grantor has no readable channels here, so the handler returns the empty
+// groups envelope before ever touching OpenSearch; the load-bearing assertion
+// is that the allowlist enumeration was queried for the grantor, never the
+// botUID.
+func TestSearchGlobalGroups_SubjectFromPrincipal_OBO(t *testing.T) {
+	grantor := "grantor"
+	rec0 := &recordingGroupSvc{stubGroupSvc: &stubGroupSvc{
+		// Neither subject has groups, so the allowlist is empty regardless — the
+		// point is WHICH uid gets queried, not the result.
+		groupsByUID: map[string][]*group.InfoResp{},
+	}}
+	h := newAllowlistHandler(t, rec0, &stubUserSvc{})
+	h.cfg.RequireSpaceID = true
+	h.threadEnumFn = func([]string) (map[string][]string, error) { return nil, nil }
+
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	gc, _ := gin.CreateTestContext(rec)
+	gc.Request = httptest.NewRequest("POST", "/v1/messages/_search_global_groups",
+		strings.NewReader(`{"keyword":"hello"}`))
+	gc.Set("uid", "bot9") // OBO context login uid = botUID — must NOT be the subject
+	c := &wkhttp.Context{Context: gc}
+	setPrincipal(c, oboPrincipal{botUID: "bot9", grantorUID: grantor, spaceID: ""})
+
+	h.searchGlobalGroups(c)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("empty-scope groups request must return 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var env CursorList
+	if err := json.Unmarshal(rec.Body.Bytes(), &env); err != nil {
+		t.Fatalf("response must be a success envelope, got %q (err %v)", rec.Body.String(), err)
+	}
+	if len(rec0.queried) == 0 {
+		t.Fatalf("allowlist enumeration was never invoked")
+	}
+	for _, uid := range rec0.queried {
+		if uid == "bot9" {
+			t.Fatalf("groups subject must be the grantor, never the botUID; queried %v", rec0.queried)
+		}
+	}
+	sawGrantor := false
+	for _, uid := range rec0.queried {
+		if uid == grantor {
+			sawGrantor = true
+		}
+	}
+	if !sawGrantor {
+		t.Fatalf("allowlist must be enumerated for the grantor subject; queried %v", rec0.queried)
+	}
+}

--- a/modules/messages_search/search_media.go
+++ b/modules/messages_search/search_media.go
@@ -47,7 +47,8 @@ func (h *Handler) searchMedia(c *wkhttp.Context) {
 		return
 	}
 	req.Keyword = strings.TrimSpace(req.Keyword)
-	loginUID := c.GetLoginUID()
+	p := h.principal(c)
+	loginUID := p.SubjectUID()
 
 	if !validateKeywordMustBeEmpty(c, req.Keyword) {
 		return
@@ -56,7 +57,7 @@ func (h *Handler) searchMedia(c *wkhttp.Context) {
 	if !ok {
 		return
 	}
-	if !h.checkChannelAccess(c, req.ChannelType, req.ChannelID, loginUID) {
+	if !h.canReadChannel(c, p, req.ChannelType, req.ChannelID) {
 		return
 	}
 	spaceID, ok := h.resolveP2PSpaceScope(c, req.ChannelType, loginUID)

--- a/modules/messages_search/search_messages.go
+++ b/modules/messages_search/search_messages.go
@@ -65,7 +65,8 @@ func (h *Handler) searchMessages(c *wkhttp.Context) {
 		return
 	}
 	req.Keyword = strings.TrimSpace(req.Keyword)
-	loginUID := c.GetLoginUID()
+	p := h.principal(c)
+	loginUID := p.SubjectUID()
 
 	if !validateKeywordOptional(c, req.Keyword) {
 		return
@@ -77,7 +78,7 @@ func (h *Handler) searchMessages(c *wkhttp.Context) {
 	if !ok {
 		return
 	}
-	if !h.checkChannelAccess(c, req.ChannelType, req.ChannelID, loginUID) {
+	if !h.canReadChannel(c, p, req.ChannelType, req.ChannelID) {
 		return
 	}
 	spaceID, ok := h.resolveP2PSpaceScope(c, req.ChannelType, loginUID)

--- a/modules/messages_search/space_filter_test.go
+++ b/modules/messages_search/space_filter_test.go
@@ -267,3 +267,46 @@ func TestResolveP2PSpaceScope_P2PWhitespaceSpaceIDTreatedAsMissing_RequireFalse(
 		t.Fatalf("escape hatch must not write an error response: %q", rec.Body.String())
 	}
 }
+
+// TestResolveP2PSpaceScope_BotBypassesGate_RequireTrue — YUJ-57: an as-bot
+// principal carries no Space (bot routes have no SpaceMiddleware). Even with
+// RequireSpaceID=true the p2p gate must NOT fail-close — the bot's DM
+// reachability is bounded by the per-principal readable predicate, not a
+// spaceId term. This is the single-DM fast path a global bot search collapses
+// to; without the bypass it would 404 despite resolveGlobalScope letting it in.
+func TestResolveP2PSpaceScope_BotBypassesGate_RequireTrue(t *testing.T) {
+	h := newSpaceHandler(true)
+	c, rec := newSpaceCtx(t, "")
+	setPrincipal(c, userBotPrincipal{botUID: "bot9"})
+	got, ok := h.resolveP2PSpaceScope(c, channelTypePerson, "bot9")
+	if !ok {
+		t.Fatalf("as-bot p2p must bypass the space fail-close, got ok=false")
+	}
+	if got != "" {
+		t.Fatalf("as-bot has no Space; expected empty spaceID, got %q", got)
+	}
+	if rec.Body.Len() != 0 {
+		t.Fatalf("bot bypass must not write a response: %q", rec.Body.String())
+	}
+}
+
+// TestResolveP2PSpaceScope_UKStillGated_RequireTrue — the exemption is scoped
+// to space-less principals. A uk principal is real-user-semantic and space
+// scoped; if its Space is empty it must STILL fail-close under RequireSpaceID,
+// exactly like a plain web user (regression guard against over-broadening the
+// YUJ-57 bypass).
+func TestResolveP2PSpaceScope_UKStillGated_RequireTrue(t *testing.T) {
+	h := newSpaceHandler(true)
+	c, rec := newSpaceCtx(t, "")
+	setPrincipal(c, ukPrincipal{keyUID: "kate"}) // empty api_key_space_id
+	got, ok := h.resolveP2PSpaceScope(c, channelTypePerson, "kate")
+	if ok {
+		t.Fatalf("uk with empty Space must still fail-close, got ok=true")
+	}
+	if got != "" {
+		t.Fatalf("fail-close must return empty spaceID, got %q", got)
+	}
+	if !strings.Contains(rec.Body.String(), "not found") {
+		t.Fatalf("uk fail-close must render NOT_FOUND, got %q", rec.Body.String())
+	}
+}

--- a/modules/messages_search/space_scope.go
+++ b/modules/messages_search/space_scope.go
@@ -1,10 +1,7 @@
 package messages_search
 
 import (
-	"strings"
-
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
-	spacepkg "github.com/Mininglamp-OSS/octo-server/pkg/space"
 	"go.uber.org/zap"
 )
 
@@ -33,7 +30,10 @@ func (h *Handler) resolveP2PSpaceScope(c *wkhttp.Context, channelType uint8, log
 	if channelType != channelTypePerson {
 		return "", true
 	}
-	spaceID := strings.TrimSpace(spacepkg.GetSpaceID(c))
+	// spaceID 走 principal（决策十）：真人主体等价于 GetSpaceID(c)；bot 路由不挂
+	// SpaceMiddleware 故为空；uk 取 api_key_space_id。The principal is the single
+	// source so the p2p Space scope stays consistent across all four subjects.
+	spaceID := h.principal(c).SpaceID()
 	if spaceID != "" {
 		return spaceID, true
 	}

--- a/modules/messages_search/space_scope.go
+++ b/modules/messages_search/space_scope.go
@@ -19,7 +19,12 @@ import (
 //     attach the term filter so the search is scoped to that Space.
 //   - p2p && spaceID empty && RequireSpaceID=true → fail-closed.
 //     respondNotFound (resource=channel) so we don't leak whether the peer
-//     exists in any Space, and return false to abort the handler.
+//     exists in any Space, and return false to abort the handler. This gate
+//     applies ONLY to space-scoped principals (user / uk); a space-less
+//     principal (as-bot / OBO, see Principal.RequiresSpaceScope) proceeds with
+//     ("", true) regardless of RequireSpaceID — it has no Space to resolve and
+//     its DM reachability is bounded by the per-principal readable predicate,
+//     not a spaceId term (YUJ-57).
 //   - p2p && spaceID empty && RequireSpaceID=false → ("", true) with a
 //     WARN log. Operational escape hatch only; intended for the rollout
 //     window before the v1.9 indexer is writing `payload.space_id` and the
@@ -33,15 +38,24 @@ func (h *Handler) resolveP2PSpaceScope(c *wkhttp.Context, channelType uint8, log
 	// spaceID 走 principal（决策十）：真人主体等价于 GetSpaceID(c)；bot 路由不挂
 	// SpaceMiddleware 故为空；uk 取 api_key_space_id。The principal is the single
 	// source so the p2p Space scope stays consistent across all four subjects.
-	spaceID := h.principal(c).SpaceID()
+	p := h.principal(c)
+	spaceID := p.SpaceID()
 	if spaceID != "" {
 		return spaceID, true
 	}
-	if h.cfg.RequireSpaceID {
-		respondNotFound(c, "channel")
-		return "", false
+	// YUJ-57: space-less principals (as-bot / OBO) legitimately carry no Space,
+	// so the fail-close gate must not apply to them — otherwise a global search
+	// whose scope collapses to a single DM (routed through this p2p gate via the
+	// fast path) would 404 for a bot even after resolveGlobalScope let it in.
+	// Their DM reachability is bounded by the per-principal readable predicate,
+	// not a spaceId term, so we proceed with spaceID="".
+	if p.RequiresSpaceScope() {
+		if h.cfg.RequireSpaceID {
+			respondNotFound(c, "channel")
+			return "", false
+		}
+		h.Warn("messages_search: p2p search without spaceID; OCTO_SEARCH_REQUIRE_SPACE_ID=false escape hatch active",
+			zap.String("uid", loginUID))
 	}
-	h.Warn("messages_search: p2p search without spaceID; OCTO_SEARCH_REQUIRE_SPACE_ID=false escape hatch active",
-		zap.String("uid", loginUID))
 	return "", true
 }


### PR DESCRIPTION
## Summary

Make octo-server message search **principal-aware** so octo-cli can search under two identities:

- **search as bot** — the User Bot's own identity (friend DMs + joined groups/threads, including global).
- **search as user (OBO)** — on-behalf-of the grantor, fully reusing the existing human authorization path.

**User Bot only in this phase; App Bot is explicitly denied.**

## Changes

- **Principal abstraction** (`user` / `bot` / `obo-grantor` / `uk`) collapsed into a single normalized read predicate — `canReadChannel` / `enumerateReadableChannels` — so single-channel gates and the global allowlist share **one** predicate (no inlined rule copies that can drift).
- **as-bot P2P gate**: friends-only; skips the Space segment and P2P blacklist (a bot has no `space_member` row and cannot blacklist anyone).
- **as-bot group/thread gate**: subject = `botUID` via `ExistMemberActive` (group-level blacklist inherited for free; kicked/blacklisted bot drops out).
- **as-bot global allowlist**: `friends ∪ joined groups ∪ threads`, bounded (a bot's group set ⊆ its creator's group set, so magnitude matches a human's global).
- **as-user (OBO)**: entry grant-existence fail-fast + per-channel scope / TOCTOU convergence reusing the send-side checker; App Bot denied at principal construction.
- **Spaceless bot/OBO global search**: the default `RequireSpaceID` fail-close now only constrains human (`user` / `uk`) subjects; bot/OBO with empty `spaceID` proceed into the same per-principal allowlist predicate. `_search_global_groups` now uses `principal.SubjectUID()`, aligned with messages/files.
- **Route mounting**: bot + uk search routes with principal resolution.

## Testing

- `go build ./...` ✅
- `go vet ./modules/messages_search/` ✅
- `go test ./modules/messages_search/` ✅ (full suite green)
- `go test ./modules/bot_api/` OBO route matrix ✅ (`TestResolveSearchPrincipal_OBO*`, `TestCheckOBO_*`, `TestSearchOBOAllowed_*`, App-Bot-denial cases)

> Note: `bot_api` integration tests that depend on MySQL/Redis/WuKongIM should be run in an infra-provisioned environment; they were not exercised locally.


Fixes #607
