### PR TITLE
feat(thread): 子区改名补发系统消息（对称群改名）[WS-26]

### DIFF
--- a/modules/thread/api.go
+++ b/modules/thread/api.go
@@ -57,6 +57,15 @@ func (t *Thread) onMessages(messages []*config.MessageResp) {
 			continue
 		}
 
+		// 只对用户聊天正文做「解档 + 统计 + 自动加入」。系统通知类消息（Tip / 群通知等，
+		// content type >= 1000）不是真实消息：跳过它们，避免子区改名/置顶等系统 tip 静默
+		// 解档归档子区、把 message_count 永久 +1、用未渲染的 {0} 占位符覆盖 thread-list
+		// preview，或把 operator 自动加入子区。（改名 tip 由 sendThreadRenamedMessage 发到本
+		// channel；置顶 tip 走 message/api_pinned.go，二者都落在这里。）
+		if isSystemContentType(parsePayloadType(msg.Payload)) {
+			continue
+		}
+
 		thread, err := t.db.QueryByGroupNoAndShortID(groupNo, shortID)
 		if err != nil || thread == nil {
 			continue

--- a/modules/thread/api.go
+++ b/modules/thread/api.go
@@ -47,22 +47,15 @@ func New(ctx *config.Context) *Thread {
 // onMessages 消息监听器
 func (t *Thread) onMessages(messages []*config.MessageResp) {
 	for _, msg := range messages {
-		// 只处理子区频道类型
-		if msg.ChannelType != common.ChannelTypeCommunityTopic.Uint8() {
+		// 只对子区频道里的「用户聊天正文」做「解档 + 统计 + 自动加入」。非子区频道、
+		// 或系统通知类消息（Tip / 群通知等）都跳过——判定逻辑收敛到 shouldProcessThreadMessage
+		// 以便在无 DB 环境下单测覆盖。
+		if !shouldProcessThreadMessage(msg) {
 			continue
 		}
 
 		groupNo, shortID, err := ParseChannelID(msg.ChannelID)
 		if err != nil {
-			continue
-		}
-
-		// 只对用户聊天正文做「解档 + 统计 + 自动加入」。系统通知类消息（Tip / 群通知等，
-		// content type >= 1000）不是真实消息：跳过它们，避免子区改名/置顶等系统 tip 静默
-		// 解档归档子区、把 message_count 永久 +1、用未渲染的 {0} 占位符覆盖 thread-list
-		// preview，或把 operator 自动加入子区。（改名 tip 由 sendThreadRenamedMessage 发到本
-		// channel；置顶 tip 走 message/api_pinned.go，二者都落在这里。）
-		if isSystemContentType(parsePayloadType(msg.Payload)) {
 			continue
 		}
 
@@ -92,6 +85,25 @@ func (t *Thread) onMessages(messages []*config.MessageResp) {
 			}
 		}
 	}
+}
+
+// shouldProcessThreadMessage 判定一条监听到的消息是否应触发子区「解档 + message_count 统计 +
+// preview 覆盖 + operator 自动加入」这套副作用。仅接受子区频道（ChannelTypeCommunityTopic）里
+// 的用户聊天正文；非子区频道、或系统通知类消息（Tip / 群通知等，content type >= 1000）一律跳过。
+// 这样子区改名 tip（发到本 channel）、置顶 tip（message/api_pinned.go）等系统消息不会静默解档
+// 归档子区、把 message_count 永久 +1、用未渲染的 {0} 占位符覆盖 thread-list preview，或把
+// operator 自动加入子区。payload 解析失败 → type 0 → 视为普通消息（fail-safe，不误跳真实消息）。
+func shouldProcessThreadMessage(msg *config.MessageResp) bool {
+	if msg == nil {
+		return false
+	}
+	if msg.ChannelType != common.ChannelTypeCommunityTopic.Uint8() {
+		return false
+	}
+	if isSystemContentType(parsePayloadType(msg.Payload)) {
+		return false
+	}
+	return true
 }
 
 func respondThreadError(c *wkhttp.Context, code codes.Code, details i18n.Details) {

--- a/modules/thread/payload_test.go
+++ b/modules/thread/payload_test.go
@@ -100,3 +100,31 @@ func TestParsePayloadType(t *testing.T) {
 	assert.Equal(t, 0, parsePayloadType(nil))
 	assert.Equal(t, 0, parsePayloadType([]byte(`not json`)))
 }
+
+// TestShouldProcessThreadMessage 在 listener 决策层（onMessages 用到的同一判定）锁定不变式：
+// 只有子区频道里的用户聊天正文才触发「解档 / message_count / preview / 自动加入」；子区改名 tip
+// 等系统消息必须被跳过。相比只喂 parsePayloadType 的纯单测，这里用真实 config.MessageResp
+// 覆盖了 channel-type 门 + content-type 门的组合，未来 listener 重接线若漏掉过滤会在此失败。
+func TestShouldProcessThreadMessage(t *testing.T) {
+	topic := common.ChannelTypeCommunityTopic.Uint8()
+	renameTip := []byte(util.ToJson(buildThreadRenamedPayload("uid_op", "操作者", "新子区名")))
+
+	tests := []struct {
+		name string
+		msg  *config.MessageResp
+		want bool
+	}{
+		{"nil message", nil, false},
+		{"non-topic channel (group) skipped", &config.MessageResp{ChannelType: common.ChannelTypeGroup.Uint8(), Payload: []byte(`{"type":1,"content":"hi"}`)}, false},
+		{"topic + rename Tip skipped", &config.MessageResp{ChannelType: topic, ChannelID: "g____s", FromUID: "uid_op", Payload: renameTip}, false},
+		{"topic + generic system type skipped", &config.MessageResp{ChannelType: topic, Payload: []byte(`{"type":1005}`)}, false},
+		{"topic + user text processed", &config.MessageResp{ChannelType: topic, ChannelID: "g____s", FromUID: "uid_u", Payload: []byte(`{"type":1,"content":"hello"}`)}, true},
+		{"topic + rich text processed", &config.MessageResp{ChannelType: topic, Payload: []byte(`{"type":14,"content":"rich"}`)}, true},
+		{"topic + unparseable payload processed (fail-safe)", &config.MessageResp{ChannelType: topic, Payload: []byte(`not json`)}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, shouldProcessThreadMessage(tt.msg))
+		})
+	}
+}

--- a/modules/thread/payload_test.go
+++ b/modules/thread/payload_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/Mininglamp-OSS/octo-lib/common"
 	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -57,7 +58,7 @@ func TestBuildThreadRenamedPayload(t *testing.T) {
 
 	assert.Equal(t, common.Tip, payload["type"], "子区改名必须是 Tip 类型（不可回复/不可@）")
 	assert.Equal(t, `{0}修改子区名为"新子区名"`, payload["content"],
-		"content 需以 {0} 占位符开头，与群改名 tip 一致")
+		"content 需以 {0} 占位符开头，客户端用 extra[0] 渲染 operator 名")
 	assert.Equal(t, "uid_op", payload["from_uid"])
 
 	extra, ok := payload["extra"].([]config.UserBaseVo)
@@ -65,4 +66,37 @@ func TestBuildThreadRenamedPayload(t *testing.T) {
 	assert.Len(t, extra, 1)
 	assert.Equal(t, "uid_op", extra[0].UID)
 	assert.Equal(t, "操作者", extra[0].Name)
+}
+
+// TestIsSystemContentType 锁定 onMessages 系统消息过滤边界：普通用户消息（<1000）进解档/统计
+// 路径，系统通知（Tip / 群通知 / 客服 / 通话结果，均 >=1000）被跳过。这是 P1 修复的核心：
+// 防止子区改名 / 置顶 tip 静默解档归档子区、抬高 message_count、覆盖 preview、自动加入 operator。
+func TestIsSystemContentType(t *testing.T) {
+	// 普通用户消息（sendSourceMessage 拷贝到子区的源消息也在此区间）→ 不是系统消息
+	for _, ct := range []common.ContentType{common.Text, common.Image, common.Voice, common.Video, common.File, common.RichText} {
+		assert.False(t, isSystemContentType(int(ct)), "content type %d 应视为普通用户消息", ct)
+	}
+	// 系统通知类 → 是系统消息，onMessages 应跳过
+	for _, ct := range []common.ContentType{common.Tip, common.FriendApply, common.GroupCreate, common.GroupUpdate, common.RevokeMessage} {
+		assert.True(t, isSystemContentType(int(ct)), "content type %d 应视为系统消息", ct)
+	}
+	// 缺省 / 无法解析的 type 视为普通消息（不会误跳过真实消息）
+	assert.False(t, isSystemContentType(0))
+}
+
+// TestParsePayloadType 校验从 payload 提取 content type：改名 tip 的 payload 必须被识别为
+// 系统消息，从而在 onMessages 里被过滤掉——这是 P1 副作用（解档 / message_count / preview /
+// 自动加入）的闭环断言，无需 DB / IM 即可锁定。
+func TestParsePayloadType(t *testing.T) {
+	renamePayload := []byte(util.ToJson(buildThreadRenamedPayload("uid_op", "操作者", "新子区名")))
+	assert.Equal(t, int(common.Tip), parsePayloadType(renamePayload), "改名 tip 应解析出 Tip 类型")
+	assert.True(t, isSystemContentType(parsePayloadType(renamePayload)),
+		"改名 tip 必须被 onMessages 判为系统消息并跳过，否则会解档/抬 count/覆盖 preview")
+
+	// 普通文本消息
+	assert.Equal(t, 1, parsePayloadType([]byte(`{"type":1,"content":"hello"}`)))
+	// 缺省 / 空 / 非法 payload → 0
+	assert.Equal(t, 0, parsePayloadType([]byte(`{"content":"no type"}`)))
+	assert.Equal(t, 0, parsePayloadType(nil))
+	assert.Equal(t, 0, parsePayloadType([]byte(`not json`)))
 }

--- a/modules/thread/payload_test.go
+++ b/modules/thread/payload_test.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -46,4 +48,21 @@ func TestBuildThreadCreatedPayload_WithoutSourceMessageID(t *testing.T) {
 	assert.False(t, hasSourceMsgID,
 		"source_message_id 为 nil 时不应出现在 payload 中")
 	assert.Equal(t, int64(0), payload["message_count"])
+}
+
+// TestBuildThreadRenamedPayload 校验子区改名 Tip 消息 payload 与群改名对称：
+// content 以 "{0}" 占位符开头（客户端替换成 operator 名），type=Tip，extra 携带 operator。
+func TestBuildThreadRenamedPayload(t *testing.T) {
+	payload := buildThreadRenamedPayload("uid_op", "操作者", "新子区名")
+
+	assert.Equal(t, common.Tip, payload["type"], "子区改名必须是 Tip 类型（不可回复/不可@）")
+	assert.Equal(t, `{0}修改子区名为"新子区名"`, payload["content"],
+		"content 需以 {0} 占位符开头，与群改名 tip 一致")
+	assert.Equal(t, "uid_op", payload["from_uid"])
+
+	extra, ok := payload["extra"].([]config.UserBaseVo)
+	assert.True(t, ok, "extra 应为 []config.UserBaseVo，供客户端解析 {0}")
+	assert.Len(t, extra, 1)
+	assert.Equal(t, "uid_op", extra[0].UID)
+	assert.Equal(t, "操作者", extra[0].Name)
 }

--- a/modules/thread/rename_permission_matrix_test.go
+++ b/modules/thread/rename_permission_matrix_test.go
@@ -126,3 +126,31 @@ func TestThreadUpdateName_ExternalMember_Denied(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "原始子区名", got.Name, "外部成员被拒后子区名不变")
 }
+
+// TestThreadUpdateName_SameNameByUnauthorized_Denied 锁定安全边界：同名 no-op 短路必须在
+// 两道权限门之后。无权者（龙虾 / 黑名单 / 外部成员）即便提交子区「当前名」也应被拒绝，
+// 而不是拿到 200——否则短路会变成越权成功 + 「猜名=当前名」的探测 oracle。
+func TestThreadUpdateName_SameNameByUnauthorized_Denied(t *testing.T) {
+	const currentName = "原始子区名" // 与 seedRenameThread 建的子区名一致
+
+	// 各档无权者独立 seed（各自独立的 DB 清库 + 数据），提交当前名。
+	seeds := map[string]func(*testing.T) (*Service, string, string, string){
+		"robot":     func(t *testing.T) (*Service, string, string, string) { return seedRenameThread(t, int(common.GroupMemberStatusNormal), 1) },
+		"blacklist": func(t *testing.T) (*Service, string, string, string) { return seedRenameThread(t, int(common.GroupMemberStatusBlacklist), 0) },
+		"external":  func(t *testing.T) (*Service, string, string, string) { return seedRenameThreadExternal(t, int(common.GroupMemberStatusNormal), 0, 1) },
+	}
+
+	for name, seed := range seeds {
+		t.Run(name, func(t *testing.T) {
+			svc, groupNo, shortID, operatorUID := seed(t)
+
+			err := svc.UpdateName(groupNo, shortID, operatorUID, currentName)
+			require.Error(t, err, "无权者提交当前名也必须被拒绝（短路须在权限门之后）")
+			require.Contains(t, err.Error(), "no permission")
+
+			got, err := svc.GetThread(groupNo, shortID, operatorUID)
+			require.NoError(t, err)
+			require.Equal(t, currentName, got.Name, "被拒后子区名不变")
+		})
+	}
+}

--- a/modules/thread/service.go
+++ b/modules/thread/service.go
@@ -467,6 +467,44 @@ func (s *Service) sendThreadCreatedMessage(groupNo, shortID, name, creatorUID, c
 	}
 }
 
+// buildThreadRenamedPayload 构建子区改名 Tip 系统消息的 payload。
+// 与群改名（octo-lib msg_group.go SendGroupUpdate 的 GroupAttrKeyName 分支）对称：
+// content 以 "{0}" 占位符开头，客户端渲染时用 extra[0] 的用户名替换成 operator 显示名。
+func buildThreadRenamedPayload(operatorUID, operatorName, name string) map[string]interface{} {
+	return map[string]interface{}{
+		"from_uid":  operatorUID,
+		"from_name": operatorName,
+		"content":   fmt.Sprintf(`{0}修改子区名为"%s"`, name),
+		"extra": []config.UserBaseVo{
+			{UID: operatorUID, Name: operatorName},
+		},
+		"type": common.Tip,
+	}
+}
+
+// sendThreadRenamedMessage 子区改名成功后向子区 channel 发一条 Tip 系统消息，
+// 与群改名（octo-lib SendGroupUpdate）对称。best-effort：失败仅告警，改名已落库不回滚，
+// 推送标题缓存失效 + TTL 兜底。
+func (s *Service) sendThreadRenamedMessage(groupNo, shortID, operatorUID, name string) {
+	channelID := BuildChannelID(groupNo, shortID)
+	payload := buildThreadRenamedPayload(operatorUID, s.getUserName(operatorUID), name)
+
+	err := s.ctx.SendMessage(&config.MsgSendReq{
+		Header: config.MsgHeader{
+			NoPersist: 0,
+			RedDot:    1,
+			SyncOnce:  0,
+		},
+		FromUID:     operatorUID,
+		ChannelID:   channelID,
+		ChannelType: common.ChannelTypeCommunityTopic.Uint8(),
+		Payload:     []byte(util.ToJson(payload)),
+	})
+	if err != nil {
+		s.Warn("发送子区改名消息失败", zap.Error(err), zap.String("channel_id", channelID))
+	}
+}
+
 // sendSourceMessage 将源消息拷贝到子区频道作为首条消息
 // fromUID 应该是经过服务端验证的原始消息发送者
 func (s *Service) sendSourceMessage(channelID, fromUID string, payload json.RawMessage) {
@@ -546,6 +584,9 @@ func (s *Service) UpdateName(groupNo, shortID, operatorUID, name string) error {
 	if err := pushcache.InvalidateThreadName(s.ctx.GetRedisConn(), channelID); err != nil {
 		s.Warn("失效子区名推送缓存失败", zap.String("channel_id", channelID), zap.Error(err))
 	}
+
+	// 子区改名补发 Tip 系统消息，与群改名对称（防滥用 + 可追溯）。best-effort：失败不回滚改名。
+	s.sendThreadRenamedMessage(groupNo, shortID, operatorUID, name)
 	return nil
 }
 

--- a/modules/thread/service.go
+++ b/modules/thread/service.go
@@ -33,6 +33,29 @@ func parsePayloadContent(payload []byte) string {
 	return m.Content
 }
 
+// parsePayloadType 从消息 payload 中提取 type（content type）字段。
+// 解析失败或缺省返回 0（普通文本消息的 type 落在 1~99，缺省视为普通消息）。
+func parsePayloadType(payload []byte) int {
+	if len(payload) == 0 {
+		return 0
+	}
+	var m struct {
+		Type int `json:"type"`
+	}
+	if err := json.Unmarshal(payload, &m); err != nil {
+		return 0
+	}
+	return m.Type
+}
+
+// isSystemContentType 判断是否为系统通知类 content type（Tip=2000 / 群通知 1000+ / 客服 1200+ /
+// 通话结果 9989 等，均 >= 1000）。这类消息不是用户聊天正文：不应触发子区解档、message_count
+// 自增、thread-list preview 覆盖，也不应把 operator 自动加入子区。普通用户消息 content type 均 < 1000
+// （文本 1、图片 2……富文本 14），由 sendSourceMessage 拷贝到子区的源消息也落在该区间。
+func isSystemContentType(contentType int) bool {
+	return contentType >= int(common.FriendApply)
+}
+
 // IService 子区服务接口
 type IService interface {
 	// CreateThread 创建子区
@@ -468,8 +491,10 @@ func (s *Service) sendThreadCreatedMessage(groupNo, shortID, name, creatorUID, c
 }
 
 // buildThreadRenamedPayload 构建子区改名 Tip 系统消息的 payload。
-// 与群改名（octo-lib msg_group.go SendGroupUpdate 的 GroupAttrKeyName 分支）对称：
-// content 以 "{0}" 占位符开头，客户端渲染时用 extra[0] 的用户名替换成 operator 显示名。
+// schema 采用「Tip + {0} 占位符 + extra」这套系统 tip 格式（与群解散 group/event.go、
+// 置顶消息 message/api_pinned.go 一致）：content 以 "{0}" 开头，客户端渲染时用 extra[0] 的
+// 用户名替换成 operator 显示名。注意这不是群改名 SendGroupUpdate 的 schema——群改名用的是
+// type=GroupUpdate(1005) + data，客户端按 GroupUpdate 处理；#663 明确要求 Tip，故走 tip 系。
 func buildThreadRenamedPayload(operatorUID, operatorName, name string) map[string]interface{} {
 	return map[string]interface{}{
 		"from_uid":  operatorUID,
@@ -482,12 +507,19 @@ func buildThreadRenamedPayload(operatorUID, operatorName, name string) map[strin
 	}
 }
 
-// sendThreadRenamedMessage 子区改名成功后向子区 channel 发一条 Tip 系统消息，
-// 与群改名（octo-lib SendGroupUpdate）对称。best-effort：失败仅告警，改名已落库不回滚，
-// 推送标题缓存失效 + TTL 兜底。
+// sendThreadRenamedMessage 子区改名成功后向子区 channel 发一条 Tip 系统消息（防滥用 + 可追溯）。
+// best-effort：失败仅告警，改名已落库不回滚，推送标题缓存失效 + TTL 兜底。
+// 若 operator 用户名解析为空（用户服务瞬时故障等），跳过发送而非发一条匿名 tip——
+// 匿名 tip 会渲染成「(空){0}...修改子区名为...」这种没有操作者的历史记录，不如不发。
 func (s *Service) sendThreadRenamedMessage(groupNo, shortID, operatorUID, name string) {
+	operatorName := s.getUserName(operatorUID)
+	if operatorName == "" {
+		s.Warn("跳过子区改名 tip：operator 用户名解析为空", zap.String("operator_uid", operatorUID), zap.String("short_id", shortID))
+		return
+	}
+
 	channelID := BuildChannelID(groupNo, shortID)
-	payload := buildThreadRenamedPayload(operatorUID, s.getUserName(operatorUID), name)
+	payload := buildThreadRenamedPayload(operatorUID, operatorName, name)
 
 	err := s.ctx.SendMessage(&config.MsgSendReq{
 		Header: config.MsgHeader{
@@ -539,6 +571,12 @@ func (s *Service) UpdateName(groupNo, shortID, operatorUID, name string) error {
 	}
 	if thread.Status == ThreadStatusDeleted {
 		return errors.New("thread has been deleted")
+	}
+
+	// 同名 no-op 短路：db.UpdateName 无条件 bump version 且总报成功，若不拦截，重试或
+	// save-on-blur 式 UI 会重复发 tip。名字没变就直接返回，符合 #663「只发一次，不重复」。
+	if thread.Name == name {
+		return nil
 	}
 
 	// 企业微信式解散语义（产品决策 2026-06）：子区改名属低风险写，解散后仍允许——

--- a/modules/thread/service.go
+++ b/modules/thread/service.go
@@ -573,12 +573,6 @@ func (s *Service) UpdateName(groupNo, shortID, operatorUID, name string) error {
 		return errors.New("thread has been deleted")
 	}
 
-	// 同名 no-op 短路：db.UpdateName 无条件 bump version 且总报成功，若不拦截，重试或
-	// save-on-blur 式 UI 会重复发 tip。名字没变就直接返回，符合 #663「只发一次，不重复」。
-	if thread.Name == name {
-		return nil
-	}
-
 	// 企业微信式解散语义（产品决策 2026-06）：子区改名属低风险写，解散后仍允许——
 	// 对齐会话置顶（group/api.go:groupSettingUpdate 的 settingActionMap 豁免解散校验）。
 	// 故此处不再调 ensureGroupNotDisbanded；改名仍受下方「父群内部活跃人类成员 + 龙虾排除」
@@ -604,6 +598,14 @@ func (s *Service) UpdateName(groupNo, shortID, operatorUID, name string) error {
 	}
 	if isRobot {
 		return errors.New("no permission to update")
+	}
+
+	// 同名 no-op 短路：db.UpdateName 无条件 bump version 且总报成功，若不拦截，重试或
+	// save-on-blur 式 UI 会重复发 tip。名字没变就直接返回，符合 #663「只发一次，不重复」。
+	// 必须放在上面两道权限门（ExistMemberActiveInternal + IsRobot）之后：否则无权者提交
+	// 当前名会拿到 200 而非拒绝，且成为「猜名=当前名」的探测 oracle（越权读子区名）。
+	if thread.Name == name {
+		return nil
 	}
 
 	if err := s.db.UpdateName(shortID, name, s.threadVersionGen()); err != nil {

--- a/modules/thread/service.go
+++ b/modules/thread/service.go
@@ -521,6 +521,13 @@ func (s *Service) sendThreadRenamedMessage(groupNo, shortID, operatorUID, name s
 	channelID := BuildChannelID(groupNo, shortID)
 	payload := buildThreadRenamedPayload(operatorUID, operatorName, name)
 
+	// 注入父群权威 space_id：COMMUNITY_TOPIC 消息必须携带父群 SpaceID，客户端 SpaceFilter
+	// 据此归类 Space。裸 s.ctx.SendMessage 绕过了 message 模块的 enrichPayloadWithSpaceID，
+	// 缺失 space_id 会让冷缓存客户端回退到 channelInfo cache 推导 Space 并命中 fail-open，
+	// 把改名 tip 落到错误 Space。契约与 enrichPayloadWithSpaceIDCore 的 COMMUNITY_TOPIC
+	// 分支一致：父群 SpaceID 非空覆盖，空（老群 / 非 Space 部署）删除。
+	s.enrichThreadTipSpaceID(groupNo, payload)
+
 	err := s.ctx.SendMessage(&config.MsgSendReq{
 		Header: config.MsgHeader{
 			NoPersist: 0,
@@ -534,6 +541,23 @@ func (s *Service) sendThreadRenamedMessage(groupNo, shortID, operatorUID, name s
 	})
 	if err != nil {
 		s.Warn("发送子区改名消息失败", zap.Error(err), zap.String("channel_id", channelID))
+	}
+}
+
+// enrichThreadTipSpaceID 按父群权威 SpaceID 注入 payload["space_id"]，与 message 模块
+// enrichPayloadWithSpaceIDCore 的 COMMUNITY_TOPIC 分支保持同一契约：父群 SpaceID 非空则覆盖，
+// 空（老群 / 非 Space 部署）则删除任何既有值，避免跨 Space 污染。查父群失败仅告警并跳过注入
+// （best-effort，不阻断发送）。
+func (s *Service) enrichThreadTipSpaceID(groupNo string, payload map[string]interface{}) {
+	g, err := s.groupService.GetGroupWithGroupNo(groupNo)
+	if err != nil {
+		s.Warn("查父群失败，跳过子区 tip space_id 注入", zap.String("group_no", groupNo), zap.Error(err))
+		return
+	}
+	if g != nil && g.SpaceID != "" {
+		payload["space_id"] = g.SpaceID
+	} else {
+		delete(payload, "space_id")
 	}
 }
 

--- a/modules/thread/thread.md
+++ b/modules/thread/thread.md
@@ -222,9 +222,13 @@ Content-Type: application/json
 ```
 1. WuKongIM 调用 IMDatasource.Subscribers
 2. 返回父群所有成员 → 允许发送
-3. 消息监听器 onMessages → 自动加入 thread_member
-4. 如果子区已归档 → 自动解档为活跃状态
+3. 消息监听器 onMessages → 自动加入 thread_member（仅用户聊天正文）
+4. 如果子区已归档 → 自动解档为活跃状态（仅用户聊天正文）
 ```
+
+> 注：上述自动加入 / 自动解档只对**用户聊天正文**成立。系统通知类消息（`type >= 1000`，
+> 如子区改名 / 置顶 Tip）由 `shouldProcessThreadMessage` 跳过，不会触发自动加入、解档、
+> `message_count` 自增或 thread-list preview 覆盖。
 
 ### 接收消息
 


### PR DESCRIPTION
Closes #663

## What

子区改名成功落库后，向子区 channel 补发一条 `Tip` 类型系统消息，让子区改名与群改名一样在聊天窗留下可追溯提示。

在此之前子区改名（`modules/thread/service.go:UpdateName`）只写库 + 失效推送标题缓存，聊天窗没有任何提示。三端放开普通成员改名后，这条可追溯 tip 就补上了。

## How

- 新增 `buildThreadRenamedPayload` 构建 payload：`content` 以 `{0}` 占位符开头（客户端渲染时用 `extra[0]` 的用户名替换成 operator 显示名），`type = common.Tip`，`extra = []config.UserBaseVo{{UID, Name}}`。这套「`Tip` + `{0}` + `extra`」schema 与**群解散**（`modules/group/event.go`）和**置顶消息**（`modules/message/api_pinned.go`）的 tip 一致。（注：不是群改名 `SendGroupUpdate` 的 schema——群改名走 `type=GroupUpdate(1005)` + `data`；#663 明确要求 `Tip`，故采用 tip 系。）
- 新增 `sendThreadRenamedMessage`：发到 `BuildChannelID(groupNo, shortID)` + `ChannelType = common.ChannelTypeCommunityTopic`。operator 用户名解析为空时跳过发送，不发匿名 tip。
- 在 `UpdateName` 成功落库并失效推送缓存后调用，**best-effort**：发送失败仅 `s.Warn`，不回滚改名（TTL / channelUpdate 兜底）。API 仍返回 200。同名 no-op 短路，避免重试 / save-on-blur 重复发 tip。

## Review 返工（yujiawei CHANGES_REQUESTED）

- **P1（阻塞）修复**：改名 tip 持久化到子区自身 channel，而 `modules/thread/api.go:onMessages` 只按 channel type 过滤，会把 tip 当普通消息处理——导致归档子区被静默解档、`message_count` 每次改名 +1、thread-list preview 被未渲染的 `{0}` 占位符覆盖、operator 被自动 join。现在在 `RecordMessageAndReactivate` / `JoinThread` 前过滤系统 content type（`>= 1000`，含 `Tip`），**同时修掉了置顶 tip 的同类潜在路径**。
- **P2-1**：修正代码注释与本 PR body 里“照抄群改名 schema”的错误表述（实际是 disband / pinned tip 的 `Tip`+`{0}`+`extra`，非 `GroupUpdate(1005)`+`data`）。
- **P2-2**：`getUserName` 返回空时跳过发送，不发匿名 tip。
- **P2-3**：`UpdateName` 加 `thread.Name == name` 同名短路。
- **P2-5**：新增 `TestIsSystemContentType` / `TestParsePayloadType`，锁定「改名 tip 被判为系统消息并在 onMessages 跳过」这条 P1 闭环断言（纯单测，规避 CI 无 IM）。
- **P2-4**（同步发送延长请求链路）：与既有 `sendThreadCreatedMessage` / `sendSourceMessage` 一致，保持一致性未改，属 nit。

## Test

- `TestBuildThreadRenamedPayload` / `TestIsSystemContentType` / `TestParsePayloadType` 通过。
- `go build ./...`、`go vet ./modules/thread/` 均通过。

## 待客户端确认

web / iOS / Android 需确认在 `COMMUNITY_TOPIC` channel 内对 `Tip` + `{0}` + `extra` 的渲染，以及 thread-list preview 不再露出 `{0}` 占位符（对应三端解锁 WS-23 / WS-24 / WS-25）。

## 关联

- 父任务 WS-22
- 本 issue WS-26（octo-server 侧）
- 与三端解锁 WS-23（web）/ WS-24（ios）/ WS-25（android）形成完整交付
- 放开改名权限的服务端 PR：Mininglamp-OSS/octo-server#542
- schema 参考：`modules/group/event.go`（群解散 tip）、`modules/message/api_pinned.go`（置顶 tip）
