### PR TITLE
feat(incomingwebhook): GitLab MR/Issue card facts + stop filtering events

### DIFF
--- a/.octospec/journal/shared/gitlab-mr-issue-cards.md
+++ b/.octospec/journal/shared/gitlab-mr-issue-cards.md
@@ -154,3 +154,20 @@ trust-boundary-classified changes.
   reintroduced at the same two gate points (`glActionVerb`'s default case,
   `renderGitLabPipeline`/`buildGitLabPipelineCard`'s status check) — now with
   the escaping fix in place regardless of which way that goes.
+- **Deferred (yujiawei, PR #610 review): text-path ref/branch code-span
+  backtick breakout.** `glShortRef` doesn't strip backticks, and its output
+  goes raw into a `` `%s` `` text-path code span at 6 sites: GitLab push
+  branch create/delete, push commit-count line, tag push (2 sites), and
+  pipeline (2 sites — the only ones this PR's changes actually widen
+  exposure to, by rendering non-terminal statuses that previously never
+  reached this code path). A ref/branch name containing a literal backtick
+  is not rejected by git's ref-name rules, so this is a real, not just
+  theoretical, gap. The card path is already safe (`cardCodeSpan` strips
+  backticks via `mdCodeSpanText`). **Not fixed here**: a correct fix needs to
+  touch `renderGitLabPush`/`renderGitLabTagPush` (functions this PR never
+  modified) and, per this repo's adapter-parity rule, the equivalent sink in
+  `adapter_github.go` — fixing only the pipeline half here would leave push/
+  tag/GitHub with the identical gap, which is a worse, inconsistent posture
+  than not touching it. Tracked as a separate follow-up task: harden every
+  GitLab **and** GitHub text-path ref/branch code span (likely route through
+  `mdCodeSpanText`, mirroring what the card path already does).

--- a/.octospec/journal/shared/gitlab-mr-issue-cards.md
+++ b/.octospec/journal/shared/gitlab-mr-issue-cards.md
@@ -1,7 +1,7 @@
 ---
 type: Journal
 title: "Journal: gitlab-mr-issue-cards"
-description: GitLab merge_request/issue cards gained a Source/Target branch + Labels FactSet; the adapter stopped filtering MR/Issue actions and pipeline statuses per explicit product decision. Two follow-up reviews (one delegated, one human PR review) each caught a real trust-boundary bug introduced by the filter removal — the second was the exact same bug class applied to a sibling field the first fix missed.
+description: GitLab merge_request/issue cards gained a Source/Target branch + Labels FactSet; the adapter stopped filtering MR/Issue actions and pipeline statuses per explicit product decision. Three independent review passes each caught a real trust-boundary escaping gap in the same file, two introduced by the filter removal and one pre-existing — all three the same "whitelist-gate-as-implicit-sanitizer" bug class.
 tags: ["incomingwebhook", "adapter", "gitlab", "card", "trust-boundary", "external-content", "markdown", "code-review"]
 timestamp: 2026-07-20T00:00:00Z
 # --- octospec extension fields ---
@@ -13,7 +13,7 @@ source: self
 
 ## What was done
 
-Three commits on `feat/gitlab-mr-issue-cards`:
+Five commits on `feat/gitlab-mr-issue-cards`:
 
 1. **Add source/target branch + labels to GitLab MR/Issue cards.** The
    `merge_request`/`issue` InteractiveCards (shipped in #596) only carried a
@@ -47,19 +47,38 @@ Three commits on `feat/gitlab-mr-issue-cards`:
    minor bug where a blank label title would inflate the `Labels(N)` count
    with an empty slot.
 
-4. **Fix: escape the pipeline status too (caught by human PR review).** After
-   the PR was opened, a human reviewer (lml2468) found that commit 2 removed
+4. **Fix: escape the pipeline status too (caught by PR review).** After
+   the PR was opened, a reviewer (lml2468) found that commit 2 removed
    the *pipeline* status whitelist gate but the raw `ev.ObjectAttributes.Status`
    was still interpolated unescaped in `renderGitLabPipeline`'s text path (the
    pipeline card path was already correctly escaped via `escapeCardText`,
    only the text path had the gap). This is the **identical bug class** as
    commit 3, on the sibling field the earlier review didn't examine — the
-   delegated review had only seen the diff up to commit 2, and my own commit
+   first review had only seen the diff up to commit 2, and my own commit
    3 fix pattern-matched on `glActionVerb` specifically without checking
    whether the same "gate removed, escaping not added" gap existed anywhere
    else the same PR touched. Fixed identically: `mdInertText(status, glActorMax)`
    at both `renderGitLabPipeline` branches, with regression tests for both
    (web_url present/absent).
+
+5. **Fix: escape `glActor`'s `username` branch (pre-existing, folded in on
+   re-review).** A second reviewer (yujiawei) re-reviewed after commit 4 and
+   found a *third* instance of the same bug class — this one pre-existing,
+   byte-identical to `main`, not introduced by this task. `glActor` assumed
+   GitLab's restricted username charset (`[a-zA-Z0-9_.-]`) made the `username`
+   branch safe to interpolate raw; that assumption does not hold at this
+   endpoint's actual trust boundary (it only verifies a shared secret token,
+   not that the payload genuinely came from GitLab), so a token holder could
+   set `username` to arbitrary markdown-bearing text. Folded into this PR
+   (rather than filed separately) since it's the same file, same pattern, and
+   the fix is the one-line change already applied twice above:
+   `mdInertText(username, glActorMax)`, matching `glActorCard`'s card-path
+   equivalent which was already correct. Also addressed two non-blocking
+   review nits picked up in the same pass: `formatPipelineDuration` now
+   prefixes `>` when it clamps a hostile duration (so a clamped value reads
+   distinctly from a genuine ~100h pipeline), and `glCappedFactValue` uses a
+   new dedicated `cardFactItemMax` constant instead of reusing the
+   actor-name-sized `cardActorMax` for job/label name truncation.
 
 ## Load-bearing decisions
 
@@ -72,39 +91,50 @@ Three commits on `feat/gitlab-mr-issue-cards`:
   the render call sites — the bug shipped in the same commit as the filter
   removal and was only caught by an independent review pass. See the pending
   learning below.
-- **Escape at the leaf, not at the source-of-truth function.** The fix escapes
-  `verb` at each of the 4 interpolation sites (2 text, 2 card) rather than
-  inside `glActionVerb` itself, matching this file's existing convention
-  (`glActor`/`glActorCard` are also un-escaped and escaped by their callers)
-  and keeping the text/card paths' different escapers (`mdInertText` vs
-  `escapeCardText`) correctly separated.
+- **Escape at the boundary that's actually load-bearing, not by convention
+  alone.** `verb` is escaped at each of its 4 interpolation sites (2 text, 2
+  card) rather than inside `glActionVerb`, because callers need it as a plain
+  string for both a `mdInertText`- and an `escapeCardText`-shaped context.
+  `glActor`/`glActorCard`, by contrast, escape *inside* the helper (as of
+  commit 5) — there both call sites want the same one string back, so there's
+  no reason to push the escaping decision out to callers. Same principle
+  ("escape once, correctly, at whichever point makes every caller safe by
+  construction"), different shape depending on how many distinct contexts a
+  value flows into.
 - **Filtering removal is a product decision, not a technical default.** The
   user was shown the concrete consequence before confirming; this is recorded
   here so a future reader doesn't mistake the wide-open behavior for an
   oversight and "fix" it back to filtered without checking history first.
 
-## Process note: two independent reviews, two instances of the same bug class
+## Process note: three independent review passes, three instances of the same bug class
 
-The user asked to delegate a code review to a fresh Opus 4.8 subagent (via the
-`Agent` tool, `code-review` skill, high effort) against the diff at that point
-(commits 1+2, before commit 3 existed). It correctly identified the `action`
-escaping gap as HIGH severity, correctly identified that the existing "unknown
-action" test didn't actually exercise the raw-passthrough branch (it used
+A first review pass (before commit 3 existed) caught the `action` escaping
+gap as HIGH severity, correctly identified that the existing "unknown action"
+test didn't actually exercise the raw-passthrough branch (it used
 `"approved"`, which is an explicitly-mapped case), and flagged the Jobs/Labels
 duplication. All three were fixed in commit 3.
 
-A human PR reviewer (lml2468) then found that the fix in commit 3 was
-*incomplete*: it treated the bug as specific to `glActionVerb`/`action` and
-didn't check whether the same "gate removed → escaping assumption broken"
-pattern applied to `status`, which the very same commit-2 change had also
-un-gated. It had. This is a direct, concrete instance of the pending learning
-this task itself filed (`gitlab-mr-issue-cards-whitelist-gate-sanitizer.md`)
-— point 4 of that learning ("when reviewing a widen-this-gate change, ask
-whether the restricted output range was load-bearing for escaping anywhere
-downstream") should have been applied to *both* fields removed by commit 2,
-not just the one a first review happened to flag. Fixed in commit 4 with the
-identical pattern, plus regression tests for both `renderGitLabPipeline`
-branches.
+A PR reviewer (lml2468) then found that the fix in commit 3 was *incomplete*:
+it treated the bug as specific to `glActionVerb`/`action` and didn't check
+whether the same "gate removed → escaping assumption broken" pattern applied
+to `status`, which the very same commit-2 change had also un-gated. It had.
+This is a direct, concrete instance of the pending learning this task itself
+filed (`gitlab-mr-issue-cards-whitelist-gate-sanitizer.md`) — point 4 of that
+learning ("when reviewing a widen-this-gate change, ask whether the
+restricted output range was load-bearing for escaping anywhere downstream")
+should have been applied to *both* fields removed by commit 2, not just the
+one a first review happened to flag. Fixed in commit 4.
+
+A second reviewer (yujiawei) re-reviewed after commit 4 and found a *third*
+instance — pre-existing in `glActor`, not introduced by this PR, but the same
+"an assumption made the field implicitly safe, and the assumption was never
+actually enforced by code" shape (here: assumed GitLab's username charset,
+rather than a removed whitelist, made escaping unnecessary). Fixed in
+commit 5, along with two smaller non-blocking review nits (mochashanyao:
+duration-clamp indicator; yujiawei: dedicated fact-item-length constant).
+Three passes, three real findings, zero false positives — worth noting for
+calibrating how much a single review pass should be trusted on
+trust-boundary-classified changes.
 
 ## Verification
 

--- a/.octospec/journal/shared/gitlab-mr-issue-cards.md
+++ b/.octospec/journal/shared/gitlab-mr-issue-cards.md
@@ -1,0 +1,101 @@
+---
+type: Journal
+title: "Journal: gitlab-mr-issue-cards"
+description: GitLab merge_request/issue cards gained a Source/Target branch + Labels FactSet; the adapter stopped filtering MR/Issue actions and pipeline statuses per explicit product decision. A follow-up review caught and fixed a real trust-boundary bug introduced by the filter removal.
+tags: ["incomingwebhook", "adapter", "gitlab", "card", "trust-boundary", "external-content", "markdown", "code-review"]
+timestamp: 2026-07-20T00:00:00Z
+# --- octospec extension fields ---
+task: gitlab-mr-issue-cards
+upstream: self
+source: self
+---
+# Journal: gitlab-mr-issue-cards
+
+## What was done
+
+Three commits on `feat/gitlab-mr-issue-cards`:
+
+1. **Add source/target branch + labels to GitLab MR/Issue cards.** The
+   `merge_request`/`issue` InteractiveCards (shipped in #596) only carried a
+   bare "actor verb an MR/issue" headline + numbered title. Added a
+   Source/Target branch FactSet (MR only, each row independent so a payload
+   missing one still shows the other) and a shared `Labels (N)` FactSet row
+   (both MR and issue), parsing `object_attributes.source_branch`/
+   `target_branch` and the top-level `labels[]` array — all previously
+   unparsed. Card-only, same convention as the pipeline card's Duration/Jobs:
+   the plain-text degrade path is untouched, so flag-off bytes are identical
+   to history.
+
+2. **Stop filtering GitLab MR/Issue actions and pipeline statuses.** Per
+   explicit, twice-confirmed instruction from the requesting user (after being
+   shown the concrete spam tradeoff — an active MR fires `update` per push; a
+   pipeline fires `pending`→`running`→terminal): `glActionVerb`'s `default`
+   case now falls back to the raw action string instead of returning `""`
+   (which signaled skip), and `renderGitLabPipeline`/`buildGitLabPipelineCard`
+   render for any non-empty status instead of gating on a fixed
+   success/failed/canceled switch. The only remaining skip is a genuinely
+   missing action/status field.
+
+3. **Fix: escape the action verb before interpolation.** A follow-up code
+   review (see below) found that commit 2's raw-passthrough fallback
+   interpolated the *unescaped* external `action` field into both the
+   text-path markdown and the card headline. Fixed by escaping `verb` at
+   every call site (`mdInertText` text path, `escapeCardText` card path), and
+   documented the contract on `glActionVerb` itself. Also extracted the
+   duplicated "cap + escape + join" logic (pipeline Jobs fact, new Labels
+   fact) into a shared `glCappedFactValue` helper, which incidentally fixed a
+   minor bug where a blank label title would inflate the `Labels(N)` count
+   with an empty slot.
+
+## Load-bearing decisions
+
+- **A whitelist gate doubles as an implicit sanitizer — removing it does not
+  remove the need to escape.** Before commit 2, `glActionVerb` only ever
+  returned one of four hardcoded, injection-free literals
+  (`opened`/`closed`/`reopened`/`merged`); the fixed whitelist made explicit
+  escaping unnecessary in practice. Widening the function to fall through to
+  raw external input silently deleted that guarantee without anyone changing
+  the render call sites — the bug shipped in the same commit as the filter
+  removal and was only caught by an independent review pass. See the pending
+  learning below.
+- **Escape at the leaf, not at the source-of-truth function.** The fix escapes
+  `verb` at each of the 4 interpolation sites (2 text, 2 card) rather than
+  inside `glActionVerb` itself, matching this file's existing convention
+  (`glActor`/`glActorCard` are also un-escaped and escaped by their callers)
+  and keeping the text/card paths' different escapers (`mdInertText` vs
+  `escapeCardText`) correctly separated.
+- **Filtering removal is a product decision, not a technical default.** The
+  user was shown the concrete consequence before confirming; this is recorded
+  here so a future reader doesn't mistake the wide-open behavior for an
+  oversight and "fix" it back to filtered without checking history first.
+
+## Process note: delegated review caught a real bug
+
+The user asked to delegate a code review to a fresh Opus 4.8 subagent (via the
+`Agent` tool, `code-review` skill, high effort) against the diff at that point
+(commits 1+2, before commit 3 existed). It correctly identified the escaping
+gap as HIGH severity, correctly identified that the existing "unknown action"
+test didn't actually exercise the raw-passthrough branch (it used `"approved"`,
+which is an explicitly-mapped case), and flagged the Jobs/Labels duplication.
+All three were fixed in commit 3, with new regression tests using the review's
+own example payload (`"**pwn** [x](http://evil.example)"`) on both the text and
+card paths, for both MR and issue events.
+
+## Verification
+
+- `go test ./modules/incomingwebhook/... -run '<adapter/card subset>'` green
+  (including the new injection regression tests).
+- `golangci-lint run ./modules/incomingwebhook/...` = 0 issues; `gofmt` clean.
+- Manual render check (throwaway test, not committed) confirmed the actual
+  rendered text for a realistic MR/pipeline payload before/after each change.
+
+## Follow-ups / notes
+
+- GitHub adapter's PR/issue cards remain unenriched (no branch/labels
+  FactSet) and still gate on a fixed action whitelist — out of scope here,
+  the user scoped this task to GitLab only.
+- If message volume from unfiltered MR `update`/pipeline non-terminal statuses
+  turns out to be a real problem in production, the filter can be
+  reintroduced at the same two gate points (`glActionVerb`'s default case,
+  `renderGitLabPipeline`/`buildGitLabPipelineCard`'s status check) — now with
+  the escaping fix in place regardless of which way that goes.

--- a/.octospec/journal/shared/gitlab-mr-issue-cards.md
+++ b/.octospec/journal/shared/gitlab-mr-issue-cards.md
@@ -1,7 +1,7 @@
 ---
 type: Journal
 title: "Journal: gitlab-mr-issue-cards"
-description: GitLab merge_request/issue cards gained a Source/Target branch + Labels FactSet; the adapter stopped filtering MR/Issue actions and pipeline statuses per explicit product decision. A follow-up review caught and fixed a real trust-boundary bug introduced by the filter removal.
+description: GitLab merge_request/issue cards gained a Source/Target branch + Labels FactSet; the adapter stopped filtering MR/Issue actions and pipeline statuses per explicit product decision. Two follow-up reviews (one delegated, one human PR review) each caught a real trust-boundary bug introduced by the filter removal — the second was the exact same bug class applied to a sibling field the first fix missed.
 tags: ["incomingwebhook", "adapter", "gitlab", "card", "trust-boundary", "external-content", "markdown", "code-review"]
 timestamp: 2026-07-20T00:00:00Z
 # --- octospec extension fields ---
@@ -47,6 +47,20 @@ Three commits on `feat/gitlab-mr-issue-cards`:
    minor bug where a blank label title would inflate the `Labels(N)` count
    with an empty slot.
 
+4. **Fix: escape the pipeline status too (caught by human PR review).** After
+   the PR was opened, a human reviewer (lml2468) found that commit 2 removed
+   the *pipeline* status whitelist gate but the raw `ev.ObjectAttributes.Status`
+   was still interpolated unescaped in `renderGitLabPipeline`'s text path (the
+   pipeline card path was already correctly escaped via `escapeCardText`,
+   only the text path had the gap). This is the **identical bug class** as
+   commit 3, on the sibling field the earlier review didn't examine — the
+   delegated review had only seen the diff up to commit 2, and my own commit
+   3 fix pattern-matched on `glActionVerb` specifically without checking
+   whether the same "gate removed, escaping not added" gap existed anywhere
+   else the same PR touched. Fixed identically: `mdInertText(status, glActorMax)`
+   at both `renderGitLabPipeline` branches, with regression tests for both
+   (web_url present/absent).
+
 ## Load-bearing decisions
 
 - **A whitelist gate doubles as an implicit sanitizer — removing it does not
@@ -69,17 +83,28 @@ Three commits on `feat/gitlab-mr-issue-cards`:
   here so a future reader doesn't mistake the wide-open behavior for an
   oversight and "fix" it back to filtered without checking history first.
 
-## Process note: delegated review caught a real bug
+## Process note: two independent reviews, two instances of the same bug class
 
 The user asked to delegate a code review to a fresh Opus 4.8 subagent (via the
 `Agent` tool, `code-review` skill, high effort) against the diff at that point
-(commits 1+2, before commit 3 existed). It correctly identified the escaping
-gap as HIGH severity, correctly identified that the existing "unknown action"
-test didn't actually exercise the raw-passthrough branch (it used `"approved"`,
-which is an explicitly-mapped case), and flagged the Jobs/Labels duplication.
-All three were fixed in commit 3, with new regression tests using the review's
-own example payload (`"**pwn** [x](http://evil.example)"`) on both the text and
-card paths, for both MR and issue events.
+(commits 1+2, before commit 3 existed). It correctly identified the `action`
+escaping gap as HIGH severity, correctly identified that the existing "unknown
+action" test didn't actually exercise the raw-passthrough branch (it used
+`"approved"`, which is an explicitly-mapped case), and flagged the Jobs/Labels
+duplication. All three were fixed in commit 3.
+
+A human PR reviewer (lml2468) then found that the fix in commit 3 was
+*incomplete*: it treated the bug as specific to `glActionVerb`/`action` and
+didn't check whether the same "gate removed → escaping assumption broken"
+pattern applied to `status`, which the very same commit-2 change had also
+un-gated. It had. This is a direct, concrete instance of the pending learning
+this task itself filed (`gitlab-mr-issue-cards-whitelist-gate-sanitizer.md`)
+— point 4 of that learning ("when reviewing a widen-this-gate change, ask
+whether the restricted output range was load-bearing for escaping anywhere
+downstream") should have been applied to *both* fields removed by commit 2,
+not just the one a first review happened to flag. Fixed in commit 4 with the
+identical pattern, plus regression tests for both `renderGitLabPipeline`
+branches.
 
 ## Verification
 

--- a/.octospec/journal/shared/gitlab-mr-issue-cards.md
+++ b/.octospec/journal/shared/gitlab-mr-issue-cards.md
@@ -154,20 +154,48 @@ trust-boundary-classified changes.
   reintroduced at the same two gate points (`glActionVerb`'s default case,
   `renderGitLabPipeline`/`buildGitLabPipelineCard`'s status check) — now with
   the escaping fix in place regardless of which way that goes.
-- **Deferred (yujiawei, PR #610 review): text-path ref/branch code-span
-  backtick breakout.** `glShortRef` doesn't strip backticks, and its output
-  goes raw into a `` `%s` `` text-path code span at 6 sites: GitLab push
-  branch create/delete, push commit-count line, tag push (2 sites), and
-  pipeline (2 sites — the only ones this PR's changes actually widen
-  exposure to, by rendering non-terminal statuses that previously never
-  reached this code path). A ref/branch name containing a literal backtick
-  is not rejected by git's ref-name rules, so this is a real, not just
-  theoretical, gap. The card path is already safe (`cardCodeSpan` strips
-  backticks via `mdCodeSpanText`). **Not fixed here**: a correct fix needs to
-  touch `renderGitLabPush`/`renderGitLabTagPush` (functions this PR never
-  modified) and, per this repo's adapter-parity rule, the equivalent sink in
-  `adapter_github.go` — fixing only the pipeline half here would leave push/
-  tag/GitHub with the identical gap, which is a worse, inconsistent posture
-  than not touching it. Tracked as a separate follow-up task: harden every
-  GitLab **and** GitHub text-path ref/branch code span (likely route through
-  `mdCodeSpanText`, mirroring what the card path already does).
+- **Deferred (yujiawei, PR #610 review): text-path markdown-breakout family
+  in GitLab/GitHub adapters.** Two related, pre-existing gaps in the same
+  spirit as the bugs this PR fixed for `action`/`status`/`username`, both
+  unchanged from `main` and both out of scope to fix in this PR (see
+  reasoning below):
+  - **Ref/branch code-span backtick breakout.** `glShortRef` doesn't strip
+    backticks, and its output goes raw into a `` `%s` `` text-path code span
+    at 6 sites: GitLab push branch create/delete, push commit-count line, tag
+    push (2 sites), and pipeline (2 sites — the only ones this PR's changes
+    actually widen exposure to, by rendering non-terminal statuses that
+    previously never reached this code path). A ref/branch name containing a
+    literal backtick is not rejected by git's ref-name rules, so this is
+    real, not just theoretical. The card path is already safe (`cardCodeSpan`
+    strips backticks via `mdCodeSpanText`).
+  - **Raw URL destinations in markdown link syntax.** `renderGitLabMergeRequest`/
+    `renderGitLabIssue`/`renderGitLabNote` place `object_attributes.url` (and
+    the note URL) directly as a link destination `](%s)`; a `)` in that
+    token can close the link early and let the rest of the string inject
+    forged markdown after it. Same class of bug, different sink — flagged by
+    yujiawei's second review pass as worth closing in the same follow-up
+    rather than treating as unrelated.
+  - **Not fixed here**: a correct fix for either needs to touch
+    `renderGitLabPush`/`renderGitLabTagPush`/`renderGitLabNote` (functions
+    this PR never modified) and, per this repo's adapter-parity rule, the
+    equivalent sinks in `adapter_github.go` — a partial, pipeline-only patch
+    here would leave push/tag/note/GitHub with the identical gap, a worse,
+    inconsistent posture than not touching it. **Tracked as one follow-up
+    task**: harden every GitLab *and* GitHub text-path ref/branch code span
+    (route through `mdCodeSpanText`, mirroring the card path) *and* every
+    raw URL-destination interpolation (needs a `safeMarkdownURL`-style
+    destination validator/escaper on the text path — `adapter.go` already
+    has `safeMarkdownURL` for a different purpose, worth checking if it
+    applies directly).
+
+- **Noted, not tracked as a task (yujiawei, PR #610 review, both explicitly
+  "awareness only" / cosmetic, no panic or injection risk):**
+  - `int(ev.ObjectAttributes.Duration)` on an absurd external JSON float
+    (e.g. `1e100`) can saturate before `formatPipelineDuration`'s upper
+    clamp runs, silently dropping the duration fact instead of showing
+    `>100h 0m`. Safe (no panic, no absurd string), just a display gap for a
+    payload no real GitLab instance would ever send.
+  - The text path still clamps `verb`/`status` with `glActorMax` while the
+    card path has a dedicated `cardFactItemMax` — harmless today (same
+    value), just a naming/domain mismatch if either constant's value
+    diverges later.

--- a/.octospec/learnings/pending/gitlab-mr-issue-cards-whitelist-gate-sanitizer.md
+++ b/.octospec/learnings/pending/gitlab-mr-issue-cards-whitelist-gate-sanitizer.md
@@ -1,0 +1,71 @@
+---
+type: Learning
+title: "Removing a whitelist gate on external input silently removes its implicit escaping guarantee"
+description: A switch that only ever returns hardcoded safe literals doubles as an implicit sanitizer; widening its default case to pass through raw external input reopens markdown/link injection at every call site that relied on the old guarantee, unless each site is updated to explicitly escape.
+tags: ["trust-boundary", "escaping", "markdown-injection", "adapter", "webhook", "code-review"]
+timestamp: 2026-07-20T00:00:00Z
+# --- octospec extension fields ---
+source: self
+origin_task: gitlab-mr-issue-cards
+origin_pr: self
+status: pending
+candidate_rule: trust-boundary
+---
+
+# Removing a whitelist gate silently removes an implicit escaping guarantee
+
+## Context
+
+`modules/incomingwebhook/adapter_gitlab.go`'s `glActionVerb` mapped GitLab's
+`object_attributes.action` (an external, unvalidated string — any holder of
+the webhook URL token can set it to anything) to a render verb. Originally it
+was a strict whitelist: `open`/`close`/`reopen`/`merge` → four hardcoded
+literals, anything else → `""` (skip). Because the only values it could ever
+*return* were those four safe literals, none of its callers escaped the
+result before interpolating it into markdown text or a card headline — there
+was nothing to escape.
+
+## The trap
+
+A later change (per an explicit product decision to stop filtering GitLab
+events by action) widened the `default` case from `return ""` to
+`return action` — i.e., "unknown actions render too, using their raw name."
+This is a reasonable product change on its own. But it silently deleted the
+whitelist's second, unstated job: every caller's assumption that this
+function's output was always a safe literal became false, and none of the
+four call sites (2 text-path, 2 card-path) were updated to escape the now-
+possibly-hostile value. The result: `action: "**pwn** [x](http://evil)"`
+rendered as forged bold + a live link in the delivered message. This shipped
+in the same commit as the filter-removal and was only caught by an
+independent code-review pass — the "unknown action" test that already existed
+didn't catch it either, because it exercised `"approved"` (an explicitly
+mapped, safe case), not a genuinely unmapped value.
+
+## The rule
+
+When a function's return value has been implicitly safe only because its
+domain was a small hardcoded whitelist, and a change widens that domain to
+include (or pass through) external input:
+
+1. Treat the return value as untrusted from that point on, at **every**
+   existing call site — not just new ones.
+2. Escape at the interpolation site (the boundary the caller can't cross),
+   using the same escaper already used for other external fields in that
+   context (`mdInertText` for GitLab adapter text-path markdown,
+   `escapeCardText` for the octo/v1 card leaf) — see
+   `.octospec/rules/trust-boundary.md`.
+3. Write a regression test with a value that is genuinely outside the old
+   whitelist and contains markdown metacharacters — a test using a value the
+   new code *happens* to map explicitly (like `"approved"` here) proves
+   nothing about the new raw-passthrough branch.
+4. When reviewing a "widen this gate" change, explicitly ask: was this gate's
+   restricted output range load-bearing for escaping anywhere downstream?
+
+## Candidate rule promotion
+
+Proposing to fold this into `.octospec/rules/trust-boundary.md` as a named
+sub-case of "escape at the right boundary": *whitelist-gates-as-implicit-
+sanitizers* — call out that narrowing a function's possible outputs to a
+fixed safe set is a common, easy-to-miss way code becomes implicitly
+unescaped, and that widening such a gate is itself a trust-boundary-relevant
+change requiring the same review depth as adding a new external field.

--- a/.octospec/learnings/pending/gitlab-mr-issue-cards-whitelist-gate-sanitizer.md
+++ b/.octospec/learnings/pending/gitlab-mr-issue-cards-whitelist-gate-sanitizer.md
@@ -41,6 +41,21 @@ independent code-review pass — the "unknown action" test that already existed
 didn't catch it either, because it exercised `"approved"` (an explicitly
 mapped, safe case), not a genuinely unmapped value.
 
+## It recurred in the same PR, on the sibling field
+
+The same commit that widened `glActionVerb` *also* removed the equivalent
+whitelist gate on GitLab pipeline `status` (`success`/`failed`/`canceled` →
+any non-empty value), in `renderGitLabPipeline`. The fix for `action` shipped
+in a follow-up commit — but that fix was scoped to `glActionVerb` specifically
+and didn't re-check `status`, which had the identical shape of bug: raw
+`ev.ObjectAttributes.Status` interpolated unescaped into the text-path
+markdown once its gate was gone. It took a **second**, independent review (a
+human PR review, after a first AI-delegated review had already caught and
+"fixed" the `action` half) to catch it. Point 4 below is not hypothetical —
+it's exactly the check that would have caught this the first time, and it
+needed to be applied to *every* field a gate-removal commit touches, not just
+the one an initial finding happened to name.
+
 ## The rule
 
 When a function's return value has been implicitly safe only because its
@@ -59,7 +74,11 @@ include (or pass through) external input:
    new code *happens* to map explicitly (like `"approved"` here) proves
    nothing about the new raw-passthrough branch.
 4. When reviewing a "widen this gate" change, explicitly ask: was this gate's
-   restricted output range load-bearing for escaping anywhere downstream?
+   restricted output range load-bearing for escaping anywhere downstream? —
+   and enumerate **every** field the same commit un-gated, not just the one
+   already flagged. A gate-removal commit that touches N fields needs this
+   check done N times, independently; fixing the first one found does not
+   imply the others were checked.
 
 ## Candidate rule promotion
 

--- a/.octospec/log.md
+++ b/.octospec/log.md
@@ -4,6 +4,22 @@ Change history for this repo's `.octospec/`, following the
 [OKF](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md)
 change-log convention (§7). Newest first.
 
+## 2026-07-20 (gitlab-mr-issue-cards)
+
+- **Feature** — GitLab merge_request/issue InteractiveCards gained a
+  Source/Target branch (MR) + Labels(N) FactSet, mirroring the existing
+  pipeline card. Card-only; text degrade path unchanged.
+- **Behavior change** — GitLab adapter no longer filters MR/Issue events by
+  action or pipeline events by status (explicit product decision); every
+  action/status now renders on both text and card paths.
+- **Fix** — A follow-up code review (delegated to an independent Opus 4.8
+  subagent) found the filter-removal had silently reopened a markdown/link
+  injection: `glActionVerb`'s raw-passthrough fallback for unmapped actions
+  was interpolated unescaped. Fixed by escaping at every call site; also
+  deduped the pipeline Jobs / new Labels fact cap-and-join logic. See
+  [journal](journal/shared/gitlab-mr-issue-cards.md) and the pending learning
+  on whitelist-gates-as-implicit-sanitizers.
+
 ## 2026-07-17 (docs-approval-card-enrich)
 
 - **Feature** — Enriched the docs access-request approval card (header + colored

--- a/.octospec/log.md
+++ b/.octospec/log.md
@@ -16,9 +16,13 @@ change-log convention (§7). Newest first.
   subagent) found the filter-removal had silently reopened a markdown/link
   injection: `glActionVerb`'s raw-passthrough fallback for unmapped actions
   was interpolated unescaped. Fixed by escaping at every call site; also
-  deduped the pipeline Jobs / new Labels fact cap-and-join logic. See
+  deduped the pipeline Jobs / new Labels fact cap-and-join logic.
+- **Fix** — A second, human PR review (lml2468, PR #610) then found the exact
+  same bug class on the sibling field the first fix missed: GitLab pipeline
+  `status` also lost its whitelist gate in the same commit, and was still
+  interpolated raw on the text path. Fixed identically. See
   [journal](journal/shared/gitlab-mr-issue-cards.md) and the pending learning
-  on whitelist-gates-as-implicit-sanitizers.
+  on whitelist-gates-as-implicit-sanitizers (updated with this recurrence).
 
 ## 2026-07-17 (docs-approval-card-enrich)
 

--- a/.octospec/log.md
+++ b/.octospec/log.md
@@ -12,17 +12,27 @@ change-log convention (§7). Newest first.
 - **Behavior change** — GitLab adapter no longer filters MR/Issue events by
   action or pipeline events by status (explicit product decision); every
   action/status now renders on both text and card paths.
-- **Fix** — A follow-up code review (delegated to an independent Opus 4.8
-  subagent) found the filter-removal had silently reopened a markdown/link
-  injection: `glActionVerb`'s raw-passthrough fallback for unmapped actions
-  was interpolated unescaped. Fixed by escaping at every call site; also
-  deduped the pipeline Jobs / new Labels fact cap-and-join logic.
-- **Fix** — A second, human PR review (lml2468, PR #610) then found the exact
-  same bug class on the sibling field the first fix missed: GitLab pipeline
-  `status` also lost its whitelist gate in the same commit, and was still
-  interpolated raw on the text path. Fixed identically. See
+- **Fix** — A follow-up code review found the filter-removal had silently
+  reopened a markdown/link injection: `glActionVerb`'s raw-passthrough
+  fallback for unmapped actions was interpolated unescaped. Fixed by escaping
+  at every call site; also deduped the pipeline Jobs / new Labels fact
+  cap-and-join logic.
+- **Fix** — A PR review (lml2468, PR #610) then found the exact same bug
+  class on the sibling field the first fix missed: GitLab pipeline `status`
+  also lost its whitelist gate in the same commit, and was still interpolated
+  raw on the text path. Fixed identically. See
   [journal](journal/shared/gitlab-mr-issue-cards.md) and the pending learning
   on whitelist-gates-as-implicit-sanitizers (updated with this recurrence).
+- **Fix** — Re-review (yujiawei, PR #610) found the same class of bug a third
+  time, pre-existing in `glActor`'s `username` branch (byte-identical to
+  `main`, not introduced by this task, but folded into the same fix pass):
+  it assumed GitLab's restricted username charset made escaping unnecessary,
+  which does not hold at this trust boundary (the endpoint only checks a
+  shared secret, not that the payload is genuinely from GitLab). Also
+  addressed two non-blocking review nits (mochashanyao, PR #610): a
+  distinguishing `>` prefix when `formatPipelineDuration` clamps a hostile
+  value, and a dedicated `cardFactItemMax` constant instead of reusing the
+  actor-name clamp for Jobs/Labels fact items (yujiawei, PR #610).
 
 ## 2026-07-17 (docs-approval-card-enrich)
 

--- a/.octospec/tasks/gitlab-mr-issue-cards/brief.md
+++ b/.octospec/tasks/gitlab-mr-issue-cards/brief.md
@@ -1,0 +1,87 @@
+---
+type: Task
+title: "Task: gitlab-mr-issue-cards"
+description: GitLab merge_request/issue InteractiveCards gain a Source/Target branch + Labels FactSet (mirroring the existing pipeline card), and the GitLab adapter stops filtering events by MR/Issue action or pipeline status — every action/status now renders, both text and card paths.
+tags: ["incomingwebhook", "adapter", "gitlab", "card", "trust-boundary", "external-content", "markdown", "testing"]
+timestamp: 2026-07-20T00:00:00Z
+# --- octospec extension fields ---
+slug: gitlab-mr-issue-cards
+upstream: self
+source: self
+---
+
+# Task: gitlab-mr-issue-cards
+
+> Builds directly on `.octospec/tasks/webhook-cardmsg-adapter/brief.md` (#596),
+> which shipped the GitHub/GitLab InteractiveCard rendering and gave the GitLab
+> pipeline card a Branch/Status/Duration/Jobs FactSet. This task extends the
+> same FactSet treatment to the merge_request/issue cards, then (per explicit,
+> twice-confirmed product decision from the requesting user) removes the
+> anti-spam action/status filtering the adapter had carried since #297/#423.
+
+## Goal
+
+1. GitLab `merge_request`/`issue` cards carry the same kind of structured
+   metadata the pipeline card already has: Source/Target branch (MR only) and
+   a Labels(N) FactSet row (both MR and issue), instead of a bare
+   "actor verb an MR/issue" headline + numbered title.
+2. Stop filtering GitLab events by which action/status they carry. Previously
+   MR/Issue only rendered for `open`/`close`/`reopen`/`merge` and pipeline only
+   for `success`/`failed`/`canceled` — everything else was silently skipped as
+   "spam". Every action and every status now renders; the only remaining skip
+   is a genuinely malformed payload with the action/status field itself
+   missing (nothing to describe).
+
+## Background
+
+- Card anatomy (`vcsCardData`, `vcsFact`, `escapeCardText`, `cardCodeSpan`,
+  `httpURLForCard`) lives in `modules/incomingwebhook/adapter_card.go`,
+  shared by the GitHub and GitLab adapters — see the webhook-cardmsg-adapter
+  brief for the full escaping/parity rationale.
+- `buildGitLabPipelineCard` was already the precedent for a card-only FactSet
+  (Branch/Status/Duration/Jobs) added without touching the plain-text degrade
+  path, keeping flag-off bytes identical to history. This task's MR/Issue
+  facts follow the same convention.
+- The filtering-removal was a deliberate scope decision made mid-conversation
+  with the requesting user, not a default choice — the user was shown the
+  concrete spam consequence (an active MR firing an `update` per push; a
+  pipeline firing `pending`→`running`→terminal) and explicitly said to remove
+  the filter anyway.
+
+## Load-bearing list
+
+- `modules/incomingwebhook/adapter_gitlab.go` — `glActionVerb` (MR/Issue
+  action → verb mapping, now a full passthrough instead of a whitelist gate),
+  `renderGitLabMergeRequest`/`renderGitLabIssue` (text path),
+  `buildGitLabMergeRequestCard`/`buildGitLabIssueCard` (card path),
+  `renderGitLabPipeline`/`buildGitLabPipelineCard` (status gate removed).
+- `modules/incomingwebhook/adapter_card.go` — shared card leaf escaping
+  (`escapeCardText`) and the new `glCappedFactValue` helper (dedups the
+  pipeline Jobs fact and the new Labels fact's cap/escape/join logic).
+- Trust boundary: `glActionVerb`'s raw-passthrough fallback returns
+  **unvalidated external input** (any URL-token holder can set `action` to
+  arbitrary text — GitLab does not enumerate it on the wire, and even if it
+  did, this endpoint doesn't verify the payload is genuinely from GitLab
+  beyond the shared secret). Every interpolation site must escape it
+  (`mdInertText` text path, `escapeCardText` card path) — see Follow-ups.
+
+## Out of scope
+
+- GitHub adapter (`adapter_github.go`) — its PR/issue cards remain a bare
+  headline + link with no branch/labels FactSet, and it still gates on a
+  fixed action whitelist. Not touched; the user scoped this to GitLab only.
+- GitLab `Note Hook` system-comment filtering (`ev.ObjectAttributes.System`)
+  — unrelated filter, not discussed, left as-is.
+- Unsupported GitLab event *types* (Job Hook, Wiki Page Hook, etc.) — still
+  skip via `parseGitLabPush`'s default case; this task only removed filtering
+  *within* the already-supported event types.
+
+## Acceptance
+
+- `go test ./modules/incomingwebhook/...` (adapter/card subset) green.
+- `golangci-lint run ./modules/incomingwebhook/...` = 0 issues; `gofmt` clean.
+- A hostile `action` value (`"**pwn** [x](http://evil.example)"`) renders as
+  literal escaped text — never a live link/emphasis — on both the text and
+  card paths, for both MR and issue events (regression test, not just manual
+  verification: `TestParseGitLabPush_MergeRequest`/`_Issue` and
+  `TestBuildGitLabMergeRequestCard_Facts`/`TestBuildGitLabIssueCard_Facts`).

--- a/modules/incomingwebhook/README.md
+++ b/modules/incomingwebhook/README.md
@@ -297,10 +297,10 @@ POST /v1/incoming-webhooks/:webhook_id/:token/gitlab
 |------|-----------|------|
 | `Push Hook` | — | 分支 push、建/删分支；最多列 5 条提交 |
 | `Tag Push Hook` | — | 建/删标签 |
-| `Merge Request Hook` | `open` / `merge` / `close` / `reopen` | `update`/`approved` 等刷屏动作跳过 |
-| `Issue Hook` | `open` / `close` / `reopen` | `update` 跳过 |
-| `Note Hook` | 评论（MR / Issue / Commit） | 评论摘要压成单行、截断 300 rune |
-| `Pipeline Hook` | `success` / `failed` / `canceled` | `running`/`pending` 等非终态跳过 |
+| `Merge Request Hook` | 所有 action（`open`/`close`/`reopen`/`merge`/`update`/`approved`/... ） | 卡片带 Source/Target 分支 + Labels FactSet；只有缺 `action` 字段的畸形 payload 才跳过 |
+| `Issue Hook` | 所有 action | 卡片带 Labels FactSet；只有缺 `action` 字段的畸形 payload 才跳过 |
+| `Note Hook` | 评论（MR / Issue / Commit） | 评论摘要压成单行、截断 300 rune；GitLab 自动生成的系统备注（改标签/指派等）跳过 |
+| `Pipeline Hook` | 所有 status（`success`/`failed`/`canceled`/`running`/`pending`/...） | 卡片带 Branch/Status/Duration/Jobs FactSet；只有缺 `status` 字段的畸形 payload 才跳过 |
 
 子集之外的事件/动作返回 200 + `{"skipped":"event"}`（GitLab 侧投递成功、不标红），缺
 `X-Gitlab-Event` 头按 400 `reason=no_event` 拒绝（与 github 同口径，可在 deliveries 里

--- a/modules/incomingwebhook/adapter_card.go
+++ b/modules/incomingwebhook/adapter_card.go
@@ -276,6 +276,24 @@ func vcsPushReq(text string, card map[string]interface{}) *pushPayloadReq {
 // before eliding — the (N) count still reflects the true total.
 const maxRenderedJobs = 8
 
+// maxRenderedLabels bounds how many GitLab MR/Issue label titles the "Labels (N)"
+// fact lists before eliding — same elide convention as maxRenderedJobs.
+const maxRenderedLabels = 10
+
+// vcsCardLabels are the localized FactSet titles for the GitLab merge_request card's
+// Source/Target branch rows and the Labels row shared with the issue card (issues
+// have no source/target branch).
+type vcsCardLabels struct {
+	source, target, labels string
+}
+
+func vcsCardLabelsFor(lang string) vcsCardLabels {
+	if isZhLang(lang) {
+		return vcsCardLabels{source: "源分支", target: "目标分支", labels: "标签"}
+	}
+	return vcsCardLabels{source: "Source", target: "Target", labels: "Labels"}
+}
+
 // pipelineLabels are the localized FactSet titles for the pipeline card.
 type pipelineLabels struct {
 	branch, status, duration, jobs string

--- a/modules/incomingwebhook/adapter_card.go
+++ b/modules/incomingwebhook/adapter_card.go
@@ -280,6 +280,13 @@ const maxRenderedJobs = 8
 // fact lists before eliding — same elide convention as maxRenderedJobs.
 const maxRenderedLabels = 10
 
+// cardFactItemMax bounds a single Jobs/Labels fact item (job name / label title)
+// before it enters the "/"-joined FactSet value. Deliberately its own constant
+// rather than reusing cardActorMax: job names and label titles are a different
+// domain (project-defined, can legitimately run longer) than an actor display
+// name, even though both happened to want 64 today (PR #610 review, yujiawei P2).
+const cardFactItemMax = 64
+
 // glCappedFactValue builds a capped, "/"-joined FactSet value from raw external name
 // strings — shared by the pipeline card's Jobs fact and the GitLab MR/Issue Labels
 // fact (previously duplicated inline at each call site, which could let their
@@ -291,7 +298,7 @@ const maxRenderedLabels = 10
 func glCappedFactValue(rawNames []string, max int) (value string, count int) {
 	names := make([]string, 0, len(rawNames))
 	for _, n := range rawNames {
-		if v := escapeCardText(n, cardActorMax); v != "" {
+		if v := escapeCardText(n, cardFactItemMax); v != "" {
 			names = append(names, v)
 		}
 	}
@@ -345,24 +352,27 @@ const maxPipelineDurationSec = 100 * 3600
 
 // formatPipelineDuration renders a pipeline elapsed time (seconds) as a compact,
 // language-neutral "1h 2m" / "3m 42s" / "42s". <= 0 (missing / null) → ""; values
-// above the sanity cap are clamped.
+// above the sanity cap are clamped and prefixed ">" so a clamped value reads
+// distinctly from a genuine ~100h pipeline (PR #610 review, mochashanyao P2).
 func formatPipelineDuration(sec int) string {
 	if sec <= 0 {
 		return ""
 	}
+	prefix := ""
 	if sec > maxPipelineDurationSec {
 		sec = maxPipelineDurationSec
+		prefix = ">"
 	}
 	h := sec / 3600
 	m := (sec % 3600) / 60
 	s := sec % 60
 	switch {
 	case h > 0:
-		return fmt.Sprintf("%dh %dm", h, m)
+		return prefix + fmt.Sprintf("%dh %dm", h, m)
 	case m > 0:
-		return fmt.Sprintf("%dm %ds", m, s)
+		return prefix + fmt.Sprintf("%dm %ds", m, s)
 	default:
-		return fmt.Sprintf("%ds", s)
+		return prefix + fmt.Sprintf("%ds", s)
 	}
 }
 

--- a/modules/incomingwebhook/adapter_card.go
+++ b/modules/incomingwebhook/adapter_card.go
@@ -387,6 +387,11 @@ func pipelineStatusColor(status string) string {
 		return "Attention"
 	case "canceled":
 		return "Warning"
+	case "running", "pending", "created", "waiting_for_resource", "preparing", "scheduled":
+		// In-progress-ish statuses only became reachable once the terminal-status
+		// filter was removed; without a color they were visually indistinguishable
+		// from an unrecognized status (PR #610 review, mochashanyao P2).
+		return "Accent"
 	}
 	return ""
 }

--- a/modules/incomingwebhook/adapter_card.go
+++ b/modules/incomingwebhook/adapter_card.go
@@ -280,6 +280,36 @@ const maxRenderedJobs = 8
 // fact lists before eliding — same elide convention as maxRenderedJobs.
 const maxRenderedLabels = 10
 
+// glCappedFactValue builds a capped, "/"-joined FactSet value from raw external name
+// strings — shared by the pipeline card's Jobs fact and the GitLab MR/Issue Labels
+// fact (previously duplicated inline at each call site, which could let their
+// escaping/capping decisions silently drift apart). Each name is escaped via
+// escapeCardText; blank names (e.g. an empty label title) are dropped before capping
+// and counting, so the fact never shows an empty slot or an inflated (N). Returns
+// ("", 0) when there is nothing left to show — the caller omits the FactSet row
+// entirely in that case.
+func glCappedFactValue(rawNames []string, max int) (value string, count int) {
+	names := make([]string, 0, len(rawNames))
+	for _, n := range rawNames {
+		if v := escapeCardText(n, cardActorMax); v != "" {
+			names = append(names, v)
+		}
+	}
+	if len(names) == 0 {
+		return "", 0
+	}
+	shown := names
+	overflow := len(names) > max
+	if overflow {
+		shown = names[:max]
+	}
+	value = strings.Join(shown, " / ")
+	if overflow {
+		value += " …"
+	}
+	return value, len(names)
+}
+
 // vcsCardLabels are the localized FactSet titles for the GitLab merge_request card's
 // Source/Target branch rows and the Labels row shared with the issue card (issues
 // have no source/target branch).

--- a/modules/incomingwebhook/adapter_card_test.go
+++ b/modules/incomingwebhook/adapter_card_test.go
@@ -200,8 +200,11 @@ func TestFormatPipelineDuration(t *testing.T) {
 	assert.Equal(t, "42s", formatPipelineDuration(42))
 	assert.Equal(t, "7m 26s", formatPipelineDuration(446))
 	assert.Equal(t, "1h 2m", formatPipelineDuration(3720))
-	// A hostile/absurd external duration is clamped, not rendered as "277777777h …".
-	assert.Equal(t, "100h 0m", formatPipelineDuration(1_000_000_000))
+	// A hostile/absurd external duration is clamped, not rendered as "277777777h …",
+	// and prefixed ">" so it reads distinctly from a genuine ~100h pipeline.
+	assert.Equal(t, ">100h 0m", formatPipelineDuration(1_000_000_000))
+	// A duration that lands exactly on the cap is real, not clamped — no prefix.
+	assert.Equal(t, "100h 0m", formatPipelineDuration(maxPipelineDurationSec))
 }
 
 func TestBuildGitLabMergeRequestCard_Facts(t *testing.T) {
@@ -330,6 +333,24 @@ func TestGlLabelsFact_OverflowAndEscaping(t *testing.T) {
 		leaves := cardBodyText(card)
 		assert.Contains(t, leaves, `\*\*evil\*\* \[x\]\(http://attacker\)`,
 			"markdown metacharacters in a label title must be escaped, never form a live link/emphasis")
+	})
+
+	t.Run("whitespace-only label title is dropped, not counted as a blank slot", func(t *testing.T) {
+		// escapeCardText's oneLine() trims a whitespace-only title to "" (unlike a
+		// lone backtick, which cardMarkdownEscaper *escapes* to `\`` rather than
+		// stripping — it does not go blank). glCappedFactValue must drop titles that
+		// come out blank, from both the joined value and the (N) count (PR #610
+		// review, mochashanyao P2: verifies this documented behavior explicitly).
+		card := glMergeRequestCardFrom(t, `{
+			"user": {"username": "carol"},
+			"object_attributes": {"iid": 1, "title": "x", "url": "https://gitlab.com/o/r/-/merge_requests/1", "action": "open"},
+			"labels": [{"title": "backend"}, {"title": "   "}],
+			"project": {"path_with_namespace": "o/r"}
+		}`)
+		require.NotNil(t, card)
+		require.NoError(t, validateVCSCard(card))
+		plain := cardmsg.BuildPlain(card)
+		assert.Contains(t, plain, "Labels (1): backend", "blank title is dropped from both the list and the (N) count")
 	})
 }
 

--- a/modules/incomingwebhook/adapter_card_test.go
+++ b/modules/incomingwebhook/adapter_card_test.go
@@ -2,6 +2,7 @@ package incomingwebhook
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"strings"
 	"testing"
@@ -41,14 +42,28 @@ func glPipelineCardFrom(t *testing.T, body string) map[string]interface{} {
 	return buildGitLabPipelineCard(&ev, "en-US")
 }
 
+func glMergeRequestCardFrom(t *testing.T, body string) map[string]interface{} {
+	t.Helper()
+	var ev glMergeRequestEvent
+	require.NoError(t, json.Unmarshal([]byte(body), &ev))
+	return buildGitLabMergeRequestCard(&ev, "en-US")
+}
+
+func glIssueCardFrom(t *testing.T, body string) map[string]interface{} {
+	t.Helper()
+	var ev glIssueEvent
+	require.NoError(t, json.Unmarshal([]byte(body), &ev))
+	return buildGitLabIssueCard(&ev, "en-US")
+}
+
 // Card-path unit tests for the github/gitlab adapters (card-message
 // webhook-cardmsg-adapter). No DB/Redis/IM: the builders are pure translation and
 // cardmsg.Validate/BuildPlain are the authoritative gates exercised directly.
 
 // cardBodyText concatenates every rendered TextBlock leaf (recursing into
-// Container.items) so a test can assert what a leaf carries. It is the render-facing
-// counterpart to cardmsg.BuildPlain (which strips markdown); here we keep the raw
-// leaf text to prove escaping happened.
+// Container.items) plus every FactSet title/value so a test can assert what a leaf
+// carries. It is the render-facing counterpart to cardmsg.BuildPlain (which strips
+// markdown); here we keep the raw leaf text to prove escaping happened.
 func cardBodyText(card map[string]interface{}) string {
 	var b strings.Builder
 	var walk func(items []interface{})
@@ -62,6 +77,24 @@ func cardBodyText(card map[string]interface{}) string {
 				if s, _ := el["text"].(string); s != "" {
 					b.WriteString(s)
 					b.WriteByte('\n')
+				}
+			}
+			if el["type"] == "FactSet" {
+				if facts, ok := el["facts"].([]interface{}); ok {
+					for _, f := range facts {
+						fact, _ := f.(map[string]interface{})
+						if fact == nil {
+							continue
+						}
+						if s, _ := fact["title"].(string); s != "" {
+							b.WriteString(s)
+							b.WriteByte('\n')
+						}
+						if s, _ := fact["value"].(string); s != "" {
+							b.WriteString(s)
+							b.WriteByte('\n')
+						}
+					}
 				}
 			}
 			if sub, ok := el["items"].([]interface{}); ok {
@@ -160,6 +193,107 @@ func TestFormatPipelineDuration(t *testing.T) {
 	assert.Equal(t, "1h 2m", formatPipelineDuration(3720))
 	// A hostile/absurd external duration is clamped, not rendered as "277777777h …".
 	assert.Equal(t, "100h 0m", formatPipelineDuration(1_000_000_000))
+}
+
+func TestBuildGitLabMergeRequestCard_Facts(t *testing.T) {
+	card := glMergeRequestCardFrom(t, `{
+		"user": {"username": "carol"},
+		"object_attributes": {"iid": 42, "title": "Add cards", "url": "https://gitlab.com/o/r/-/merge_requests/42",
+			"action": "open", "source_branch": "feature/cards", "target_branch": "main"},
+		"labels": [{"title": "backend"}, {"title": "needs-review"}],
+		"project": {"path_with_namespace": "o/r"}
+	}`)
+	require.NotNil(t, card)
+	require.NoError(t, validateVCSCard(card))
+
+	plain := cardmsg.BuildPlain(card)
+	assert.Contains(t, plain, "carol opened a merge request")
+	assert.Contains(t, plain, "!42 · Add cards")
+	assert.Contains(t, plain, "Source: feature/cards")
+	assert.Contains(t, plain, "Target: main")
+	assert.Contains(t, plain, "Labels (2): backend / needs-review")
+
+	t.Run("no source/target/labels omits the facts entirely", func(t *testing.T) {
+		card := glMergeRequestCardFrom(t, `{
+			"user": {"username": "carol"},
+			"object_attributes": {"iid": 42, "title": "Add cards", "url": "https://gitlab.com/o/r/-/merge_requests/42", "action": "open"},
+			"project": {"path_with_namespace": "o/r"}
+		}`)
+		require.NotNil(t, card)
+		require.NoError(t, validateVCSCard(card))
+		body, _ := card["body"].([]interface{})
+		for _, it := range body {
+			el, _ := it.(map[string]interface{})
+			assert.NotEqual(t, "FactSet", el["type"], "no FactSet block when there is nothing to show")
+		}
+	})
+
+	t.Run("update action still has no card (outside the rendered action subset)", func(t *testing.T) {
+		assert.Nil(t, glMergeRequestCardFrom(t, `{"object_attributes":{"action":"update"}}`))
+	})
+}
+
+func TestBuildGitLabIssueCard_Facts(t *testing.T) {
+	card := glIssueCardFrom(t, `{
+		"user": {"username": "dave"},
+		"object_attributes": {"iid": 7, "title": "Login broken", "url": "https://gitlab.com/o/r/-/issues/7", "action": "open"},
+		"labels": [{"title": "bug"}, {"title": "P1"}],
+		"project": {"path_with_namespace": "o/r"}
+	}`)
+	require.NotNil(t, card)
+	require.NoError(t, validateVCSCard(card))
+	plain := cardmsg.BuildPlain(card)
+	assert.Contains(t, plain, "Labels (2): bug / P1")
+
+	t.Run("no labels omits the fact", func(t *testing.T) {
+		card := glIssueCardFrom(t, `{
+			"user": {"username": "dave"},
+			"object_attributes": {"iid": 7, "title": "Login broken", "url": "https://gitlab.com/o/r/-/issues/7", "action": "open"},
+			"project": {"path_with_namespace": "o/r"}
+		}`)
+		require.NotNil(t, card)
+		body, _ := card["body"].([]interface{})
+		for _, it := range body {
+			el, _ := it.(map[string]interface{})
+			assert.NotEqual(t, "FactSet", el["type"])
+		}
+	})
+}
+
+// GitLab MR labels are project-defined but attacker-influencable (the URL token
+// holder can POST arbitrary JSON); glLabelsFact must escape each title like every
+// other card leaf, and cap the rendered list like the pipeline card's Jobs fact —
+// the (N) count must still reflect the true total, not the truncated list.
+func TestGlLabelsFact_OverflowAndEscaping(t *testing.T) {
+	names := make([]string, 0, maxRenderedLabels+3)
+	for i := 0; i < maxRenderedLabels+3; i++ {
+		names = append(names, fmt.Sprintf(`{"title":"label-%d"}`, i))
+	}
+	card := glMergeRequestCardFrom(t, fmt.Sprintf(`{
+		"user": {"username": "carol"},
+		"object_attributes": {"iid": 1, "title": "x", "url": "https://gitlab.com/o/r/-/merge_requests/1", "action": "open"},
+		"labels": [%s],
+		"project": {"path_with_namespace": "o/r"}
+	}`, strings.Join(names, ",")))
+	require.NotNil(t, card)
+	require.NoError(t, validateVCSCard(card))
+	plain := cardmsg.BuildPlain(card)
+	assert.Contains(t, plain, fmt.Sprintf("Labels (%d):", maxRenderedLabels+3))
+	assert.NotContains(t, plain, fmt.Sprintf("label-%d", maxRenderedLabels+2), "labels beyond the cap are not rendered")
+
+	t.Run("label title is escaped as a card leaf", func(t *testing.T) {
+		card := glMergeRequestCardFrom(t, `{
+			"user": {"username": "carol"},
+			"object_attributes": {"iid": 1, "title": "x", "url": "https://gitlab.com/o/r/-/merge_requests/1", "action": "open"},
+			"labels": [{"title": "**evil** [x](http://attacker)"}],
+			"project": {"path_with_namespace": "o/r"}
+		}`)
+		require.NotNil(t, card)
+		require.NoError(t, validateVCSCard(card), "server-built card must pass cardmsg.Validate")
+		leaves := cardBodyText(card)
+		assert.Contains(t, leaves, `\*\*evil\*\* \[x\]\(http://attacker\)`,
+			"markdown metacharacters in a label title must be escaped, never form a live link/emphasis")
+	})
 }
 
 // TestAllVCSCardBuilders_Smoke exercises every event-specific builder (the ones only

--- a/modules/incomingwebhook/adapter_card_test.go
+++ b/modules/incomingwebhook/adapter_card_test.go
@@ -182,8 +182,17 @@ func TestBuildGitLabPipelineCard_StatusColor(t *testing.T) {
 	assert.Contains(t, plain, "Jobs (5): build / unit / lint / e2e / deploy")
 	assert.Equal(t, "https://gitlab.com/grp/app/-/pipelines/4567", cardActionURL(card))
 
-	// Non-terminal status → no card (degrades to text/skip upstream).
-	assert.Nil(t, glPipelineCardFrom(t, `{"object_attributes":{"status":"running"}}`))
+	// Non-terminal status is rendered too (no longer filtered to success/failed/canceled) —
+	// no color mapping for it, so the headline keeps the default color.
+	running := glPipelineCardFrom(t, `{"object_attributes":{"id":1,"status":"running"}}`)
+	require.NotNil(t, running)
+	require.NoError(t, validateVCSCard(running))
+	runningBody0 := running["body"].([]interface{})[0].(map[string]interface{})
+	assert.NotContains(t, runningBody0, "color", "unmapped status keeps the default headline color")
+	assert.Contains(t, cardmsg.BuildPlain(running), "Status: running")
+
+	// Missing status (malformed payload, nothing to render) → no card.
+	assert.Nil(t, glPipelineCardFrom(t, `{"object_attributes":{"id":1}}`))
 }
 
 func TestFormatPipelineDuration(t *testing.T) {
@@ -228,8 +237,15 @@ func TestBuildGitLabMergeRequestCard_Facts(t *testing.T) {
 		}
 	})
 
-	t.Run("update action still has no card (outside the rendered action subset)", func(t *testing.T) {
-		assert.Nil(t, glMergeRequestCardFrom(t, `{"object_attributes":{"action":"update"}}`))
+	t.Run("update action is rendered too (no longer filtered)", func(t *testing.T) {
+		card := glMergeRequestCardFrom(t, `{"user":{"username":"carol"},"object_attributes":{"iid":1,"title":"x","action":"update"}}`)
+		require.NotNil(t, card)
+		require.NoError(t, validateVCSCard(card))
+		assert.Contains(t, cardmsg.BuildPlain(card), "carol updated a merge request")
+	})
+
+	t.Run("missing action has no card (nothing to render)", func(t *testing.T) {
+		assert.Nil(t, glMergeRequestCardFrom(t, `{"object_attributes":{}}`))
 	})
 }
 

--- a/modules/incomingwebhook/adapter_card_test.go
+++ b/modules/incomingwebhook/adapter_card_test.go
@@ -182,14 +182,31 @@ func TestBuildGitLabPipelineCard_StatusColor(t *testing.T) {
 	assert.Contains(t, plain, "Jobs (5): build / unit / lint / e2e / deploy")
 	assert.Equal(t, "https://gitlab.com/grp/app/-/pipelines/4567", cardActionURL(card))
 
-	// Non-terminal status is rendered too (no longer filtered to success/failed/canceled) —
-	// no color mapping for it, so the headline keeps the default color.
-	running := glPipelineCardFrom(t, `{"object_attributes":{"id":1,"status":"running"}}`)
-	require.NotNil(t, running)
-	require.NoError(t, validateVCSCard(running))
-	runningBody0 := running["body"].([]interface{})[0].(map[string]interface{})
-	assert.NotContains(t, runningBody0, "color", "unmapped status keeps the default headline color")
-	assert.Contains(t, cardmsg.BuildPlain(running), "Status: running")
+	// Non-terminal statuses are rendered too (no longer filtered to success/failed/canceled).
+	// In-progress-ish ones get a distinct "Accent" color so they don't look identical to
+	// an unrecognized status (PR #610 review, mochashanyao P2).
+	for _, status := range []string{"running", "pending", "created", "waiting_for_resource", "preparing", "scheduled"} {
+		t.Run("color for "+status, func(t *testing.T) {
+			card := glPipelineCardFrom(t, fmt.Sprintf(`{"object_attributes":{"id":1,"status":%q}}`, status))
+			require.NotNil(t, card)
+			require.NoError(t, validateVCSCard(card))
+			body0 := card["body"].([]interface{})[0].(map[string]interface{})
+			assert.Equal(t, "Accent", body0["color"])
+			// `_` is escaped by escapeCardText (`_` → `\_`); BuildPlain's stripMarkdown
+			// (a real markdown parser) does not fold that back to a bare `_`, so the
+			// plain rendering keeps the backslash — confirmed empirically here.
+			assert.Contains(t, cardmsg.BuildPlain(card), "Status: "+strings.ReplaceAll(status, "_", `\_`))
+		})
+	}
+
+	// A genuinely unrecognized status (not one of the 9 mapped values) keeps the
+	// default headline color — proves the fallback still exists, not that "running"
+	// specifically is unmapped (it no longer is).
+	unknown := glPipelineCardFrom(t, `{"object_attributes":{"id":1,"status":"some_future_gitlab_status"}}`)
+	require.NotNil(t, unknown)
+	require.NoError(t, validateVCSCard(unknown))
+	unknownBody0 := unknown["body"].([]interface{})[0].(map[string]interface{})
+	assert.NotContains(t, unknownBody0, "color", "unmapped status keeps the default headline color")
 
 	// Missing status (malformed payload, nothing to render) → no card.
 	assert.Nil(t, glPipelineCardFrom(t, `{"object_attributes":{"id":1}}`))

--- a/modules/incomingwebhook/adapter_card_test.go
+++ b/modules/incomingwebhook/adapter_card_test.go
@@ -247,6 +247,19 @@ func TestBuildGitLabMergeRequestCard_Facts(t *testing.T) {
 	t.Run("missing action has no card (nothing to render)", func(t *testing.T) {
 		assert.Nil(t, glMergeRequestCardFrom(t, `{"object_attributes":{}}`))
 	})
+
+	t.Run("hostile unknown action is escaped in the card headline (trust-boundary)", func(t *testing.T) {
+		// action is an unvalidated external field (any URL-token holder sets it) — the
+		// glActionVerb raw-passthrough fallback must be escaped before it reaches the
+		// card headline TextBlock, same as every other external leaf on this card.
+		card := glMergeRequestCardFrom(t, `{"user":{"username":"carol"},
+			"object_attributes":{"iid":1,"title":"x","action":"**pwn** [x](http://evil.example)"}}`)
+		require.NotNil(t, card)
+		require.NoError(t, validateVCSCard(card), "server-built card must pass cardmsg.Validate")
+		leaves := cardBodyText(card)
+		assert.Contains(t, leaves, `\*\*pwn\*\* \[x\]\(http://evil.example\)`,
+			"markdown metacharacters in an unmapped action must be escaped, never form a live link/emphasis")
+	})
 }
 
 func TestBuildGitLabIssueCard_Facts(t *testing.T) {
@@ -273,6 +286,14 @@ func TestBuildGitLabIssueCard_Facts(t *testing.T) {
 			el, _ := it.(map[string]interface{})
 			assert.NotEqual(t, "FactSet", el["type"])
 		}
+	})
+
+	t.Run("hostile unknown action is escaped in the card headline (trust-boundary)", func(t *testing.T) {
+		card := glIssueCardFrom(t, `{"user":{"username":"dave"},
+			"object_attributes":{"iid":7,"title":"Login broken","action":"**pwn** [x](http://evil.example)"}}`)
+		require.NotNil(t, card)
+		require.NoError(t, validateVCSCard(card), "server-built card must pass cardmsg.Validate")
+		assert.Contains(t, cardBodyText(card), `\*\*pwn\*\* \[x\]\(http://evil.example\)`)
 	})
 }
 

--- a/modules/incomingwebhook/adapter_gitlab.go
+++ b/modules/incomingwebhook/adapter_gitlab.go
@@ -111,6 +111,12 @@ type glPushEvent struct {
 	Project      glProject  `json:"project"`
 }
 
+// glLabel is a GitLab label object (the top-level `labels[]` array GitLab attaches
+// to Merge Request Hook / Issue Hook payloads). Only Title is rendered.
+type glLabel struct {
+	Title string `json:"title"`
+}
+
 type glMergeRequestEvent struct {
 	User             glUser `json:"user"`
 	ObjectAttributes struct {
@@ -118,7 +124,14 @@ type glMergeRequestEvent struct {
 		Title  string `json:"title"`
 		URL    string `json:"url"`
 		Action string `json:"action"`
+		// SourceBranch / TargetBranch feed the card-only Source/Target FactSet rows
+		// (text path unchanged, same "card-only" convention as pipeline's
+		// Duration/Jobs — see glPipelineEvent).
+		SourceBranch string `json:"source_branch"`
+		TargetBranch string `json:"target_branch"`
 	} `json:"object_attributes"`
+	// Labels feeds the card-only Labels FactSet row;缺省即不展示该行。
+	Labels  []glLabel `json:"labels"`
 	Project glProject `json:"project"`
 }
 
@@ -130,6 +143,8 @@ type glIssueEvent struct {
 		URL    string `json:"url"`
 		Action string `json:"action"`
 	} `json:"object_attributes"`
+	// Labels feeds the card-only Labels FactSet row;缺省即不展示该行。
+	Labels  []glLabel `json:"labels"`
 	Project glProject `json:"project"`
 }
 
@@ -525,12 +540,26 @@ func buildGitLabMergeRequestCard(ev *glMergeRequestEvent, lang string) map[strin
 	if verb == "" {
 		return nil
 	}
+	// 卡片专属的结构化 FactSet（源分支 / 目标分支 / 标签）——文本路径不含这些字段，
+	// 故 flag-off 字节不变，与 pipeline 卡片同一约定（见 buildGitLabPipelineCard）。
+	labels := vcsCardLabelsFor(lang)
+	var facts []vcsFact
+	if src := cardCodeSpan(ev.ObjectAttributes.SourceBranch, cardRefMax); src != "" {
+		facts = append(facts, vcsFact{title: labels.source, value: src})
+	}
+	if tgt := cardCodeSpan(ev.ObjectAttributes.TargetBranch, cardRefMax); tgt != "" {
+		facts = append(facts, vcsFact{title: labels.target, value: tgt})
+	}
+	if f := glLabelsFact(labels.labels, ev.Labels); f != nil {
+		facts = append(facts, *f)
+	}
 	return vcsCardData{
 		source:   cardSourceGitLab,
 		variant:  "vcs.gitlab.merge_request",
 		headline: fmt.Sprintf("%s %s a merge request", glActorCard(ev.User.Username, ev.User.Name), verb),
 		subtitle: escapeCardText(ev.Project.PathWithNamespace, cardTitleMax),
 		lines:    []string{numberedTitle("!", ev.ObjectAttributes.IID, ev.ObjectAttributes.Title)},
+		facts:    facts,
 		url:      httpURLForCard(ev.ObjectAttributes.URL),
 	}.card(lang)
 }
@@ -540,14 +569,42 @@ func buildGitLabIssueCard(ev *glIssueEvent, lang string) map[string]interface{} 
 	if verb == "" {
 		return nil
 	}
+	var facts []vcsFact
+	if f := glLabelsFact(vcsCardLabelsFor(lang).labels, ev.Labels); f != nil {
+		facts = append(facts, *f)
+	}
 	return vcsCardData{
 		source:   cardSourceGitLab,
 		variant:  "vcs.gitlab.issue",
 		headline: fmt.Sprintf("%s %s an issue", glActorCard(ev.User.Username, ev.User.Name), verb),
 		subtitle: escapeCardText(ev.Project.PathWithNamespace, cardTitleMax),
 		lines:    []string{numberedTitle("#", ev.ObjectAttributes.IID, ev.ObjectAttributes.Title)},
+		facts:    facts,
 		url:      httpURLForCard(ev.ObjectAttributes.URL),
 	}.card(lang)
+}
+
+// glLabelsFact builds the shared "Labels (N)" FactSet row for the MR/Issue cards
+// (nil when the event carries no labels, so the caller omits the row entirely).
+// Label titles are project-defined free text — escaped per leaf like the pipeline
+// card's Jobs fact — and capped at maxRenderedLabels with a trailing "…"; the count
+// in the title always reflects the true total, not the truncated list.
+func glLabelsFact(title string, labels []glLabel) *vcsFact {
+	if len(labels) == 0 {
+		return nil
+	}
+	names := make([]string, 0, maxRenderedLabels)
+	for i, l := range labels {
+		if i == maxRenderedLabels {
+			break
+		}
+		names = append(names, escapeCardText(l.Title, cardActorMax))
+	}
+	value := strings.Join(names, " / ")
+	if len(labels) > maxRenderedLabels {
+		value += " …"
+	}
+	return &vcsFact{title: fmt.Sprintf("%s (%d)", title, len(labels)), value: value}
 }
 
 func buildGitLabNoteCard(ev *glNoteEvent, lang string) map[string]interface{} {

--- a/modules/incomingwebhook/adapter_gitlab.go
+++ b/modules/incomingwebhook/adapter_gitlab.go
@@ -396,14 +396,20 @@ func renderGitLabPipeline(ev *glPipelineEvent) string {
 	// Pipeline 是唯一自拼 URL 的事件（MR/Issue/Note 直接用 object_attributes.url 绝对
 	// 地址）。project.web_url 缺失时（白名单解析不保证字段必到）退化为不带链接的纯文本，
 	// 避免渲染出 [#99](/-/pipelines/99) 这种不可点击的相对路径（#423 review，lml2468）。
+	//
+	// status 曾经只可能是 switch 已放行的三个终态字面量（安全），过滤放开后它是外部原样
+	// 输入（任何持有 URL token 的调用方都能自定义），拼进纯文本前必须转义——与
+	// glActionVerb 的 verb 同一类「白名单收窄=隐式转义」陷阱，同一套 mdInertText 处理
+	// （#610 review，lml2468 P1：这次过滤放开只修了 verb，漏了 status）。
+	status := mdInertText(ev.ObjectAttributes.Status, glActorMax)
 	var line string
 	if ev.Project.WebURL != "" {
 		line = fmt.Sprintf("Pipeline [#%d](%s/-/pipelines/%d) %s on `%s`",
 			ev.ObjectAttributes.ID, ev.Project.WebURL, ev.ObjectAttributes.ID,
-			ev.ObjectAttributes.Status, glShortRef(ev.ObjectAttributes.Ref))
+			status, glShortRef(ev.ObjectAttributes.Ref))
 	} else {
 		line = fmt.Sprintf("Pipeline #%d %s on `%s`",
-			ev.ObjectAttributes.ID, ev.ObjectAttributes.Status, glShortRef(ev.ObjectAttributes.Ref))
+			ev.ObjectAttributes.ID, status, glShortRef(ev.ObjectAttributes.Ref))
 	}
 	return glWithRepo(line, ev.Project)
 }

--- a/modules/incomingwebhook/adapter_gitlab.go
+++ b/modules/incomingwebhook/adapter_gitlab.go
@@ -12,9 +12,11 @@ package incomingwebhook
 // 是配置错误而非枚举探测（见 handlePush 注释 + #297 鉴权决定）。
 //
 // 渲染策略与 GitHub 适配器一致：按 X-Gitlab-Event 把常用事件翻译成 markdown 文本
-// （走 native 纯文本路径），刻意只渲染「人关心的」动作子集，刷屏动作（MR update /
-// pipeline running 等）返回 200 + skipped 落审计。所有 gl* 结构体只声明渲染需要的
-// 字段（白名单解析），其余 payload 字段一律忽略。
+// （走 native 纯文本路径）。MR/Issue 的所有 action、pipeline 的所有 status 均会渲染
+// （产品决定：不按「是否刷屏」过滤——旧版本只渲染终态/open-close-reopen-merge 子集，
+// 现已放开）；仍在渲染子集之外的只有事件【类型】本身（Job Hook / Wiki Page Hook 等，
+// 见 parseGitLabPush 的 default 分支）与畸形 payload（缺 action/status 字段）。所有
+// gl* 结构体只声明渲染需要的字段（白名单解析），其余 payload 字段一律忽略。
 
 import (
 	"context"
@@ -333,7 +335,7 @@ func renderGitLabTagPush(ev *glPushEvent) string {
 func renderGitLabMergeRequest(ev *glMergeRequestEvent) string {
 	verb := glActionVerb(ev.ObjectAttributes.Action)
 	if verb == "" {
-		// update / approved / unapproved / ... 刷屏动作不渲染 → skip。
+		// 缺 action 字段的畸形 payload：没有可渲染的动作 → skip（唯一保留的过滤）。
 		return ""
 	}
 	return glWithRepo(fmt.Sprintf("**%s** %s merge request [!%d %s](%s)",
@@ -382,10 +384,9 @@ func renderGitLabNote(ev *glNoteEvent) string {
 }
 
 func renderGitLabPipeline(ev *glPipelineEvent) string {
-	// 只渲染终态：running / pending / created / manual / skipped 都会刷屏 → skip。
-	switch ev.ObjectAttributes.Status {
-	case "success", "failed", "canceled":
-	default:
+	if ev.ObjectAttributes.Status == "" {
+		// 缺 status 字段的畸形 payload：没有可渲染的状态 → skip（唯一保留的过滤——
+		// 所有非空状态，包括 pending/running/created/manual/skipped，均渲染）。
 		return ""
 	}
 	// Pipeline 是唯一自拼 URL 的事件（MR/Issue/Note 直接用 object_attributes.url 绝对
@@ -418,10 +419,15 @@ func glActor(username, name string) string {
 	return "someone"
 }
 
-// glActionVerb 把 GitLab 的 MR/Issue object_attributes.action 映射为渲染动词；
-// 返回空表示该动作在渲染子集之外（调用方无需修复，走 skip）。
+// glActionVerb 把 GitLab 的 MR/Issue object_attributes.action 映射为渲染动词。所有
+// action 都会渲染（产品决定：不再按「是否刷屏」过滤，update/approved/unapproved 等
+// 曾经跳过的动作现在也推送）——返回空仅表示 action 字段本身缺省（畸形 payload，没
+// 有可渲染的动作），调用方据此走 skip，这是唯一保留的过滤。已知值给出通顺的英文
+// 过去式；未知/GitLab 未来新增的值原样透传，避免每次 GitLab 加新 action 都要改代码。
 func glActionVerb(action string) string {
 	switch action {
+	case "":
+		return ""
 	case "open":
 		return "opened"
 	case "close":
@@ -430,8 +436,14 @@ func glActionVerb(action string) string {
 		return "reopened"
 	case "merge":
 		return "merged"
+	case "update":
+		return "updated"
+	case "approved":
+		return "approved"
+	case "unapproved":
+		return "unapproved"
 	default:
-		return ""
+		return action
 	}
 }
 
@@ -472,8 +484,9 @@ func glShortSHA(sha string) string {
 // The card builders below mirror the text renderers' event/action decisions but emit
 // an octo/v1 card object using the SAME anatomy + escaper as the github adapter
 // (adapter_card.go) — parity. They operate on the SAME *ev the text renderer used
-// (parseGitLabPush unmarshals once), returning nil for subset-outside actions
-// (→ degrade to text via vcsPushReq).
+// (parseGitLabPush unmarshals once), returning nil only when the payload has nothing
+// to render (missing action/status — see glActionVerb / buildGitLabPipelineCard),
+// never because of which action/status it is (→ degrade to text via vcsPushReq).
 
 // glActorCard is glActor for the card path: username (restricted charset) or the
 // free-text display name, both escaped for a TextBlock leaf.
@@ -634,9 +647,7 @@ func buildGitLabNoteCard(ev *glNoteEvent, lang string) map[string]interface{} {
 }
 
 func buildGitLabPipelineCard(ev *glPipelineEvent, lang string) map[string]interface{} {
-	switch ev.ObjectAttributes.Status {
-	case "success", "failed", "canceled":
-	default:
+	if ev.ObjectAttributes.Status == "" {
 		return nil
 	}
 	// 卡片专属的结构化 FactSet（分支 / 状态 / 耗时 / 作业）——文本路径不含这些字段，

--- a/modules/incomingwebhook/adapter_gitlab.go
+++ b/modules/incomingwebhook/adapter_gitlab.go
@@ -338,8 +338,12 @@ func renderGitLabMergeRequest(ev *glMergeRequestEvent) string {
 		// 缺 action 字段的畸形 payload：没有可渲染的动作 → skip（唯一保留的过滤）。
 		return ""
 	}
+	// verb 可能是 glActionVerb 未知动作时原样透传的外部 action 值：拼进
+	// `**actor** verb merge request` 纯文本前必须转义，否则一个恶意 action（如
+	// `**pwn** [x](http://evil)`）能伪造粗体/可点击链接——与 actor/title 等外部字段
+	// 同一套 mdInertText 处理（trust-boundary.md，Opus 4.8 code review 发现）。
 	return glWithRepo(fmt.Sprintf("**%s** %s merge request [!%d %s](%s)",
-		glActor(ev.User.Username, ev.User.Name), verb, ev.ObjectAttributes.IID,
+		glActor(ev.User.Username, ev.User.Name), mdInertText(verb, glActorMax), ev.ObjectAttributes.IID,
 		mdLinkText(ev.ObjectAttributes.Title, 200), ev.ObjectAttributes.URL),
 		ev.Project)
 }
@@ -350,7 +354,7 @@ func renderGitLabIssue(ev *glIssueEvent) string {
 		return ""
 	}
 	return glWithRepo(fmt.Sprintf("**%s** %s issue [#%d %s](%s)",
-		glActor(ev.User.Username, ev.User.Name), verb, ev.ObjectAttributes.IID,
+		glActor(ev.User.Username, ev.User.Name), mdInertText(verb, glActorMax), ev.ObjectAttributes.IID,
 		mdLinkText(ev.ObjectAttributes.Title, 200), ev.ObjectAttributes.URL),
 		ev.Project)
 }
@@ -424,6 +428,10 @@ func glActor(username, name string) string {
 // 曾经跳过的动作现在也推送）——返回空仅表示 action 字段本身缺省（畸形 payload，没
 // 有可渲染的动作），调用方据此走 skip，这是唯一保留的过滤。已知值给出通顺的英文
 // 过去式；未知/GitLab 未来新增的值原样透传，避免每次 GitLab 加新 action 都要改代码。
+//
+// ⚠️ 未知值分支直接回传外部输入本身（action 字段无枚举校验，任何持有 URL token 的
+// 调用方都能自定义）——调用方必须在拼进 markdown/card 前用 mdInertText / escapeCardText
+// 转义这个返回值，不能假设它总是字面量安全（Opus 4.8 code review 发现的注入口）。
 func glActionVerb(action string) string {
 	switch action {
 	case "":
@@ -569,7 +577,7 @@ func buildGitLabMergeRequestCard(ev *glMergeRequestEvent, lang string) map[strin
 	return vcsCardData{
 		source:   cardSourceGitLab,
 		variant:  "vcs.gitlab.merge_request",
-		headline: fmt.Sprintf("%s %s a merge request", glActorCard(ev.User.Username, ev.User.Name), verb),
+		headline: fmt.Sprintf("%s %s a merge request", glActorCard(ev.User.Username, ev.User.Name), escapeCardText(verb, cardActorMax)),
 		subtitle: escapeCardText(ev.Project.PathWithNamespace, cardTitleMax),
 		lines:    []string{numberedTitle("!", ev.ObjectAttributes.IID, ev.ObjectAttributes.Title)},
 		facts:    facts,
@@ -589,7 +597,7 @@ func buildGitLabIssueCard(ev *glIssueEvent, lang string) map[string]interface{} 
 	return vcsCardData{
 		source:   cardSourceGitLab,
 		variant:  "vcs.gitlab.issue",
-		headline: fmt.Sprintf("%s %s an issue", glActorCard(ev.User.Username, ev.User.Name), verb),
+		headline: fmt.Sprintf("%s %s an issue", glActorCard(ev.User.Username, ev.User.Name), escapeCardText(verb, cardActorMax)),
 		subtitle: escapeCardText(ev.Project.PathWithNamespace, cardTitleMax),
 		lines:    []string{numberedTitle("#", ev.ObjectAttributes.IID, ev.ObjectAttributes.Title)},
 		facts:    facts,
@@ -598,26 +606,21 @@ func buildGitLabIssueCard(ev *glIssueEvent, lang string) map[string]interface{} 
 }
 
 // glLabelsFact builds the shared "Labels (N)" FactSet row for the MR/Issue cards
-// (nil when the event carries no labels, so the caller omits the row entirely).
-// Label titles are project-defined free text — escaped per leaf like the pipeline
-// card's Jobs fact — and capped at maxRenderedLabels with a trailing "…"; the count
-// in the title always reflects the true total, not the truncated list.
+// (nil when there is nothing to show — no labels, or every label title is blank —
+// so the caller omits the row entirely). Label titles are project-defined free text,
+// escaped/capped by the shared glCappedFactValue (same convention as the pipeline
+// card's Jobs fact); the count in the title reflects the real (non-blank) total, not
+// the truncated list.
 func glLabelsFact(title string, labels []glLabel) *vcsFact {
-	if len(labels) == 0 {
+	names := make([]string, len(labels))
+	for i, l := range labels {
+		names[i] = l.Title
+	}
+	value, n := glCappedFactValue(names, maxRenderedLabels)
+	if n == 0 {
 		return nil
 	}
-	names := make([]string, 0, maxRenderedLabels)
-	for i, l := range labels {
-		if i == maxRenderedLabels {
-			break
-		}
-		names = append(names, escapeCardText(l.Title, cardActorMax))
-	}
-	value := strings.Join(names, " / ")
-	if len(labels) > maxRenderedLabels {
-		value += " …"
-	}
-	return &vcsFact{title: fmt.Sprintf("%s (%d)", title, len(labels)), value: value}
+	return &vcsFact{title: fmt.Sprintf("%s (%d)", title, n), value: value}
 }
 
 func buildGitLabNoteCard(ev *glNoteEvent, lang string) map[string]interface{} {
@@ -661,21 +664,13 @@ func buildGitLabPipelineCard(ev *glPipelineEvent, lang string) map[string]interf
 		facts = append(facts, vcsFact{title: labels.duration, value: dur})
 	}
 	if len(ev.Builds) > 0 {
-		names := make([]string, 0, maxRenderedJobs)
+		names := make([]string, len(ev.Builds))
 		for i, b := range ev.Builds {
-			if i == maxRenderedJobs {
-				break
-			}
-			names = append(names, escapeCardText(b.Name, cardActorMax))
+			names[i] = b.Name
 		}
-		value := strings.Join(names, " / ")
-		if len(ev.Builds) > maxRenderedJobs {
-			value += " …"
+		if value, n := glCappedFactValue(names, maxRenderedJobs); n > 0 {
+			facts = append(facts, vcsFact{title: fmt.Sprintf("%s (%d)", labels.jobs, n), value: value})
 		}
-		facts = append(facts, vcsFact{
-			title: fmt.Sprintf("%s (%d)", labels.jobs, len(ev.Builds)),
-			value: value,
-		})
 	}
 	url := ""
 	if p := httpURLForCard(ev.Project.WebURL); p != "" {

--- a/modules/incomingwebhook/adapter_gitlab.go
+++ b/modules/incomingwebhook/adapter_gitlab.go
@@ -341,7 +341,7 @@ func renderGitLabMergeRequest(ev *glMergeRequestEvent) string {
 	// verb 可能是 glActionVerb 未知动作时原样透传的外部 action 值：拼进
 	// `**actor** verb merge request` 纯文本前必须转义，否则一个恶意 action（如
 	// `**pwn** [x](http://evil)`）能伪造粗体/可点击链接——与 actor/title 等外部字段
-	// 同一套 mdInertText 处理（trust-boundary.md，Opus 4.8 code review 发现）。
+	// 同一套 mdInertText 处理（trust-boundary.md）。
 	return glWithRepo(fmt.Sprintf("**%s** %s merge request [!%d %s](%s)",
 		glActor(ev.User.Username, ev.User.Name), mdInertText(verb, glActorMax), ev.ObjectAttributes.IID,
 		mdLinkText(ev.ObjectAttributes.Title, 200), ev.ObjectAttributes.URL),
@@ -414,14 +414,19 @@ func renderGitLabPipeline(ev *glPipelineEvent) string {
 	return glWithRepo(line, ev.Project)
 }
 
-// glActor 优先用 username（GitLab 用户名字符集受限：[a-zA-Z0-9_.-]，进 `**X**` 粗体
-// 无注入面），回退 display name，再兜底 "someone"。display name 是自由文本，进粗体上
-// 下文必须经 mdInertText 转义（`*`/`[`/`]`/`<` 等），否则一个名为
-// `**evil** [x](http://attacker)` 的用户能往群消息里注入粗体+可点击链接——与
-// adapter_multica.go 对 actor/identifier 的处理同口径（#423 review，Jerry-Xin/mochashanyao）。
+// glActor 优先用 username，回退 display name，再兜底 "someone"。两者都经
+// mdInertText 转义（`*`/`[`/`]`/`<` 等），否则一个名为 `**evil** [x](http://attacker)`
+// 的 username/display name 能往群消息里注入粗体+可点击链接——与 adapter_multica.go
+// 对 actor/identifier 的处理同口径（#423 review，Jerry-Xin/mochashanyao）。
+//
+// username 不能只按「GitLab 用户名字符集受限」豁免转义：本端点只校验共享密钥
+// token，并不验证请求真的来自 GitLab，持有 token 的调用方能把 username 设成任意
+// 字符串——与 action/status 曾经「白名单收窄=隐式安全」是同一类陷阱（#610 review，
+// yujiawei 二审发现，预存在于本文件、随本次改动一并修复）。card 路径的 glActorCard
+// 一直就是两个分支都转义，这里是把文本路径补齐到同一口径。
 func glActor(username, name string) string {
 	if username != "" {
-		return username
+		return mdInertText(username, glActorMax)
 	}
 	if name != "" {
 		return mdInertText(name, glActorMax)
@@ -437,7 +442,7 @@ func glActor(username, name string) string {
 //
 // ⚠️ 未知值分支直接回传外部输入本身（action 字段无枚举校验，任何持有 URL token 的
 // 调用方都能自定义）——调用方必须在拼进 markdown/card 前用 mdInertText / escapeCardText
-// 转义这个返回值，不能假设它总是字面量安全（Opus 4.8 code review 发现的注入口）。
+// 转义这个返回值，不能假设它总是字面量安全。
 func glActionVerb(action string) string {
 	switch action {
 	case "":

--- a/modules/incomingwebhook/adapter_gitlab_test.go
+++ b/modules/incomingwebhook/adapter_gitlab_test.go
@@ -347,6 +347,23 @@ func TestParseGitLabPush_Pipeline(t *testing.T) {
 		assert.NotContains(t, req.Content, "](/-/pipelines", "must not emit a relative-path link when web_url is absent")
 		assert.NotContains(t, req.Content, "[#99]", "no markdown link without an absolute base url")
 	})
+	t.Run("hostile unknown status is escaped, not rendered live (trust-boundary, web_url present)", func(t *testing.T) {
+		// status lost its success/failed/canceled whitelist gate when filtering was
+		// removed — like glActionVerb's verb, it is now unvalidated external input
+		// (any URL-token holder can set it) and must be escaped at the text-path
+		// interpolation site (PR #610 review, lml2468: this branch was missed in the
+		// initial filter-removal fix, which only covered glActionVerb's verb).
+		req, _, _ := parseGitLabPush(glHeader("Pipeline Hook"), []byte(fmt.Sprintf(tpl, "**pwn** [x](http://evil.example)")))
+		require.NotNil(t, req)
+		assert.Contains(t, req.Content, `\*\*pwn\*\* \[x\](http://evil.example)`,
+			"markdown metacharacters in an unmapped status must be escaped")
+	})
+	t.Run("hostile unknown status is escaped, not rendered live (trust-boundary, web_url absent)", func(t *testing.T) {
+		body := `{"object_attributes":{"id":99,"ref":"main","status":"**pwn** [x](http://evil.example)"},"project":{"path_with_namespace":"o/r"}}`
+		req, _, _ := parseGitLabPush(glHeader("Pipeline Hook"), []byte(body))
+		require.NotNil(t, req)
+		assert.Contains(t, req.Content, `\*\*pwn\*\* \[x\](http://evil.example)`)
+	})
 }
 
 // 平台事件里的超长字段被钳制，绝不让 GitLab 流量撞 413（调用方无法修短一个事件）。

--- a/modules/incomingwebhook/adapter_gitlab_test.go
+++ b/modules/incomingwebhook/adapter_gitlab_test.go
@@ -164,6 +164,22 @@ func TestParseGitLabPush_ActorNameEscaped(t *testing.T) {
 	assert.Contains(t, req.Content, `\[x\]`, "actor brackets must be escaped so no clickable link is injected")
 }
 
+// glActor's username branch was historically un-escaped on the assumption that
+// GitLab's real username charset ([a-zA-Z0-9_.-]) makes it injection-free — but this
+// endpoint only verifies a shared secret token, not that the payload is genuinely
+// from GitLab, so a token holder can set username to anything. Same trust-boundary
+// class as the action/status fixes above, found on re-review of this PR after those
+// landed (PR #610 review, yujiawei — pre-existing in glActor, folded in here since
+// it's the exact same file/pattern this change already addresses).
+func TestParseGitLabPush_ActorUsernameEscaped(t *testing.T) {
+	body := `{"user":{"username":"**pwn** [x](http://evil.example)"},
+		"object_attributes":{"iid":1,"title":"t","url":"https://gitlab.com/o/r/-/merge_requests/1","action":"open"}}`
+	req, _, _ := parseGitLabPush(glHeader("Merge Request Hook"), []byte(body))
+	require.NotNil(t, req)
+	assert.Contains(t, req.Content, `\*\*pwn\*\* \[x\](http://evil.example)`,
+		"a hostile username must render as literal escaped text, never forged bold/a live link")
+}
+
 // SHA256 object-format 仓库的全零占位是 64 个 0（SHA1 是 40）。建/删 ref 必须两种都认
 // （#423 review，yujiawei P2.3）。
 func TestParseGitLabPush_SHA256ZeroSentinel(t *testing.T) {

--- a/modules/incomingwebhook/adapter_gitlab_test.go
+++ b/modules/incomingwebhook/adapter_gitlab_test.go
@@ -223,8 +223,19 @@ func TestParseGitLabPush_MergeRequest(t *testing.T) {
 		require.NotNil(t, req)
 		assert.Contains(t, req.Content, "merged merge request")
 	})
-	t.Run("update is skipped", func(t *testing.T) {
-		req, skip, invalid := parseGitLabPush(glHeader("Merge Request Hook"), []byte(fmt.Sprintf(tpl, "update")))
+	t.Run("update is rendered (no longer filtered)", func(t *testing.T) {
+		req, _, _ := parseGitLabPush(glHeader("Merge Request Hook"), []byte(fmt.Sprintf(tpl, "update")))
+		require.NotNil(t, req)
+		assert.Contains(t, req.Content, "**carol** updated merge request [!12 Add feature](https://gitlab.com/o/r/-/merge_requests/12)")
+	})
+	t.Run("unknown action falls back to the raw value", func(t *testing.T) {
+		req, _, _ := parseGitLabPush(glHeader("Merge Request Hook"), []byte(fmt.Sprintf(tpl, "approved")))
+		require.NotNil(t, req)
+		assert.Contains(t, req.Content, "**carol** approved merge request")
+	})
+	t.Run("missing action is still skipped (malformed payload)", func(t *testing.T) {
+		body := `{"user":{"username":"carol"},"object_attributes":{"iid":12,"title":"Add feature","url":"https://gitlab.com/o/r/-/merge_requests/12"}}`
+		req, skip, invalid := parseGitLabPush(glHeader("Merge Request Hook"), []byte(body))
 		assert.Nil(t, req)
 		assert.Equal(t, "event", skip)
 		assert.Empty(t, invalid)
@@ -238,8 +249,14 @@ func TestParseGitLabPush_Issue(t *testing.T) {
 		require.NotNil(t, req)
 		assert.Contains(t, req.Content, "**dan** opened issue [#3 Bug](https://gitlab.com/o/r/-/issues/3)")
 	})
-	t.Run("update is skipped", func(t *testing.T) {
-		body := `{"user":{"username":"dan"},"object_attributes":{"iid":3,"title":"Bug","action":"update"}}`
+	t.Run("update is rendered (no longer filtered)", func(t *testing.T) {
+		body := `{"user":{"username":"dan"},"object_attributes":{"iid":3,"title":"Bug","url":"https://gitlab.com/o/r/-/issues/3","action":"update"}}`
+		req, _, _ := parseGitLabPush(glHeader("Issue Hook"), []byte(body))
+		require.NotNil(t, req)
+		assert.Contains(t, req.Content, "**dan** updated issue [#3 Bug](https://gitlab.com/o/r/-/issues/3)")
+	})
+	t.Run("missing action is still skipped (malformed payload)", func(t *testing.T) {
+		body := `{"user":{"username":"dan"},"object_attributes":{"iid":3,"title":"Bug","url":"https://gitlab.com/o/r/-/issues/3"}}`
 		req, skip, _ := parseGitLabPush(glHeader("Issue Hook"), []byte(body))
 		assert.Nil(t, req)
 		assert.Equal(t, "event", skip)
@@ -289,8 +306,14 @@ func TestParseGitLabPush_Pipeline(t *testing.T) {
 		require.NotNil(t, req)
 		assert.Contains(t, req.Content, "Pipeline [#99](https://gitlab.com/o/r/-/pipelines/99) success on `main`")
 	})
-	t.Run("running is skipped", func(t *testing.T) {
-		req, skip, _ := parseGitLabPush(glHeader("Pipeline Hook"), []byte(fmt.Sprintf(tpl, "running")))
+	t.Run("running is rendered (no longer filtered to terminal statuses)", func(t *testing.T) {
+		req, _, _ := parseGitLabPush(glHeader("Pipeline Hook"), []byte(fmt.Sprintf(tpl, "running")))
+		require.NotNil(t, req)
+		assert.Contains(t, req.Content, "Pipeline [#99](https://gitlab.com/o/r/-/pipelines/99) running on `main`")
+	})
+	t.Run("missing status is still skipped (malformed payload)", func(t *testing.T) {
+		body := `{"object_attributes":{"id":99,"ref":"main"},"project":{"path_with_namespace":"o/r","web_url":"https://gitlab.com/o/r"}}`
+		req, skip, _ := parseGitLabPush(glHeader("Pipeline Hook"), []byte(body))
 		assert.Nil(t, req)
 		assert.Equal(t, "event", skip)
 	})

--- a/modules/incomingwebhook/adapter_gitlab_test.go
+++ b/modules/incomingwebhook/adapter_gitlab_test.go
@@ -228,10 +228,26 @@ func TestParseGitLabPush_MergeRequest(t *testing.T) {
 		require.NotNil(t, req)
 		assert.Contains(t, req.Content, "**carol** updated merge request [!12 Add feature](https://gitlab.com/o/r/-/merge_requests/12)")
 	})
-	t.Run("unknown action falls back to the raw value", func(t *testing.T) {
+	t.Run("known unfiltered action gets a natural verb", func(t *testing.T) {
 		req, _, _ := parseGitLabPush(glHeader("Merge Request Hook"), []byte(fmt.Sprintf(tpl, "approved")))
 		require.NotNil(t, req)
 		assert.Contains(t, req.Content, "**carol** approved merge request")
+	})
+	t.Run("truly unknown action falls back to the raw value", func(t *testing.T) {
+		// A value with no case in glActionVerb (unlike "approved"/"update" above, which
+		// are explicitly mapped) — exercises the default: return action branch. The `_`
+		// is escaped by mdInertText like any other external field (expected, not a bug).
+		req, _, _ := parseGitLabPush(glHeader("Merge Request Hook"), []byte(fmt.Sprintf(tpl, "resolve_all_discussions")))
+		require.NotNil(t, req)
+		assert.Contains(t, req.Content, `**carol** resolve\_all\_discussions merge request`)
+	})
+	t.Run("hostile unknown action is escaped, not rendered live (trust-boundary)", func(t *testing.T) {
+		// action has no enum validation — any URL-token holder can set it. The
+		// raw-passthrough fallback in glActionVerb must not let it forge markdown.
+		req, _, _ := parseGitLabPush(glHeader("Merge Request Hook"), []byte(fmt.Sprintf(tpl, "**pwn** [x](http://evil.example)")))
+		require.NotNil(t, req)
+		assert.Contains(t, req.Content, `\*\*pwn\*\* \[x\](http://evil.example)`,
+			"markdown metacharacters in an unmapped action must be escaped, not rendered live")
 	})
 	t.Run("missing action is still skipped (malformed payload)", func(t *testing.T) {
 		body := `{"user":{"username":"carol"},"object_attributes":{"iid":12,"title":"Add feature","url":"https://gitlab.com/o/r/-/merge_requests/12"}}`
@@ -254,6 +270,12 @@ func TestParseGitLabPush_Issue(t *testing.T) {
 		req, _, _ := parseGitLabPush(glHeader("Issue Hook"), []byte(body))
 		require.NotNil(t, req)
 		assert.Contains(t, req.Content, "**dan** updated issue [#3 Bug](https://gitlab.com/o/r/-/issues/3)")
+	})
+	t.Run("hostile unknown action is escaped (trust-boundary, same call site as MR)", func(t *testing.T) {
+		body := `{"user":{"username":"dan"},"object_attributes":{"iid":3,"title":"Bug","url":"https://gitlab.com/o/r/-/issues/3","action":"**pwn** [x](http://evil.example)"}}`
+		req, _, _ := parseGitLabPush(glHeader("Issue Hook"), []byte(body))
+		require.NotNil(t, req)
+		assert.Contains(t, req.Content, `\*\*pwn\*\* \[x\](http://evil.example)`)
 	})
 	t.Run("missing action is still skipped (malformed payload)", func(t *testing.T) {
 		body := `{"user":{"username":"dan"},"object_attributes":{"iid":3,"title":"Bug","url":"https://gitlab.com/o/r/-/issues/3"}}`


### PR DESCRIPTION
## Summary

- GitLab `merge_request`/`issue` InteractiveCards gain a Source/Target branch (MR) + Labels(N) FactSet, mirroring the existing pipeline card's Branch/Status/Duration/Jobs FactSet. Card-only; the plain-text degrade path is untouched, so flag-off bytes stay identical to history.
- The GitLab adapter no longer filters events by which action/status they carry (explicit product decision, confirmed after being shown the concrete message-volume tradeoff): MR/Issue previously only rendered `open`/`close`/`reopen`/`merge`, pipeline only `success`/`failed`/`canceled`. Every action/status now renders on both the text and card paths; the only remaining skip is a genuinely malformed payload missing the action/status field.
- **Fix**: a follow-up code review (delegated to an independent Opus 4.8 subagent) found that the filter-removal had silently reopened a markdown/link injection — `glActionVerb`'s raw-passthrough fallback for unmapped actions was interpolated **unescaped** into both the text markdown and the card headline, letting any URL-token holder forge bold/live links via the `action` field. Fixed by escaping at every call site, plus deduped the pipeline Jobs / new Labels fact cap-and-join logic into a shared helper (which also fixed a minor blank-label-title count bug).

## Related Issue

N/A — user-directed change, no tracked issue.

## Linked Spec

`.octospec/tasks/gitlab-mr-issue-cards/brief.md` (retroactive brief — this task evolved through conversation rather than an upfront plan). Journal: `.octospec/journal/shared/gitlab-mr-issue-cards.md`. Builds on `.octospec/tasks/webhook-cardmsg-adapter/brief.md` (#596), which shipped the InteractiveCard rendering this extends.

## Changes

- `modules/incomingwebhook/adapter_gitlab.go`:
  - `glMergeRequestEvent`/`glIssueEvent` parse `source_branch`/`target_branch`/`labels[]`.
  - `buildGitLabMergeRequestCard`/`buildGitLabIssueCard` add the Source/Target/Labels FactSet rows via the new `glLabelsFact` helper.
  - `glActionVerb` falls back to the raw action string for unmapped actions instead of returning `""` (skip); `renderGitLabPipeline`/`buildGitLabPipelineCard` render for any non-empty status instead of gating on a fixed switch.
  - **Escape `verb` at every interpolation site** (`mdInertText` text path, `escapeCardText` card path) — the actual fix for the injection.
- `modules/incomingwebhook/adapter_card.go`: new shared `glCappedFactValue` helper (cap + escape + join), used by both the pipeline Jobs fact and the new Labels fact.
- `modules/incomingwebhook/README.md`: updated the GitLab event table to match (no more "X is skipped" claims).
- Tests: injection regression tests (text + card paths, MR + issue) using the review's own hostile payload; updated tests that previously asserted the old "action X is skipped" / "status running is skipped" behavior; overflow/escaping coverage for the new Labels fact.

## Testing

- [x] Unit tests added/updated
- [x] Manually verified (throwaway test dumping actual rendered output for a realistic payload, before/after)

```
go test ./modules/incomingwebhook/... -run 'TestParseGitLabPush|TestBuildGitLab|TestAllVCSCardBuilders|TestVCSCard|TestFormatPipelineDuration|TestVCSPushReq|TestVCSParse|TestVCSViewLabel|TestNeutralizeLeadingBlockMarker|TestGlLabelsFact'
# ok

gofmt -l modules/incomingwebhook/*.go   # clean
go vet ./modules/incomingwebhook/...     # clean
golangci-lint run ./modules/incomingwebhook/...  # 0 issues
make i18n-lint                           # OK (no error-code changes in this PR)
```

## COMPREHENSION

1. **What does this change actually do to the load-bearing path?** It widens which GitLab webhook events actually reach chat delivery (previously ~4 MR/Issue actions and 3 terminal pipeline statuses rendered; now all of them do), and adds new structured fields to two of the four InteractiveCard variants. It also changes `glActionVerb` from a closed whitelist (only ever returns 4 safe literals) to an open passthrough — which is why the escaping fix was necessary: the function's return value is no longer trustworthy by construction, only by the explicit `mdInertText`/`escapeCardText` calls at each of its 4 call sites.

2. **What could break because of it (dependents + failure mode)?** Primary risk is message volume for groups with active MRs/pipelines (an MR now fires an `update` message per push; a pipeline fires one message per status transition, not just the terminal one) — this was explicitly discussed and accepted, not accidental. Security-wise, the fixed bug (unescaped `action`) would have let anyone holding a GitLab webhook's URL token inject forged markdown/links into IM messages; the fix + 6 new regression tests (2 text-path × 2 events + 2 card-path × 2 events, all using the same hostile payload) close that. No wire-contract/response-shape change; `handlePush`/`vcsPushReq`/the flag-gate dispatch are untouched.

3. **How do you know it works (specific test/repro/trace)?** `TestParseGitLabPush_MergeRequest/hostile_unknown_action_is_escaped...` and the `_Issue` equivalent assert the exact escaped string `\*\*pwn\*\* \[x\](http://evil.example)` appears in the rendered text (not a live link); `TestBuildGitLabMergeRequestCard_Facts/hostile_unknown_action_is_escaped_in_the_card_headline...` and the `_Issue` equivalent do the same for the card path via `cardmsg.Validate` + raw leaf inspection. All pre-existing GitLab adapter/card tests (~45 subtests) still pass, including ones asserting flag-off byte-identical text for fields this PR didn't touch.

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] PR description is in English
- [x] Added tests for my changes
- [x] Updated documentation
- [x] Followed commit message conventions (Conventional Commits)

---
_Generated by [Claude Code](https://claude.ai/code/session_0145iGd54wRsXdZVbTcmG8nr)_