### PR TITLE
feat(incomingwebhook): GitHub webhook parity — stop filtering + card facts

### DIFF
--- a/.octospec/journal/shared/github-webhook-parity.md
+++ b/.octospec/journal/shared/github-webhook-parity.md
@@ -1,0 +1,128 @@
+---
+type: Journal
+title: "Journal: github-webhook-parity"
+description: GitHub pull_request/issues cards gained Source/Target branch + Labels FactSet rows, mirroring GitLab; the adapter stopped filtering pull_request/issues/issue_comment/release actions. Applied the whitelist-gate-as-implicit-sanitizer lesson from the GitLab task up front — every widened field was escaped in the same commit, plus a pre-existing actor/repo-name escaping gap was closed for parity with GitLab's already-fixed glActor.
+tags: ["incomingwebhook", "adapter", "github", "card", "trust-boundary", "external-content", "markdown"]
+timestamp: 2026-07-20T00:00:00Z
+# --- octospec extension fields ---
+task: github-webhook-parity
+upstream: self
+source: self
+---
+# Journal: github-webhook-parity
+
+## What was done
+
+One commit on `feat/github-webhook-parity` (following the GitLab task's
+retrospective, applied proactively this time rather than across several
+review-driven follow-ups):
+
+1. **Stop filtering GitHub events.** Replaced the closed-whitelist switches
+   in `renderGitHubPullRequest`/`renderGitHubIssues`/`renderGitHubIssueComment`/
+   `renderGitHubRelease` (and their card-path twins) with four new mapper
+   functions — `ghPRVerb`, `ghIssueVerb`, `ghCommentVerb`, `ghReleaseVerb` —
+   each documented with the same "raw-passthrough fallback, caller must
+   escape" contract `glActionVerb` carries. Known actions map to readable
+   English verbs (e.g. `synchronize` → "pushed new commits to",
+   `ready_for_review` → "marked ready for review"); genuinely unknown/future
+   GitHub action values pass through raw. The only remaining skip is a
+   missing `action` field.
+
+2. **Add Source/Target branch + Labels FactSet to the PR card, Labels to the
+   Issue card.** `ghPullRequestEvent`/`ghIssuesEvent` now parse
+   `pull_request.base.ref`/`head.ref`/`labels[]` and `issue.labels[]` (all
+   previously unparsed — nested under `pull_request`/`issue` rather than
+   top-level like GitLab's `labels[]`, hence the separate `ghLabel` type and
+   `ghLabelsFact` helper, which is otherwise a straight port of GitLab's
+   `glLabelsFact`). Card-only; text degrade path unaffected.
+
+3. **Escape every field the filter removal exposed, in this same commit.**
+   All 8 verb-mapper call sites (2 events × {text, card} × ... — actually 4
+   render functions × {text via `mdInertText`, card via `escapeCardText`} =
+   8 sites) escape the verb before interpolation. Verified by grep + manual
+   read of every call site before committing (see Verification) rather than
+   relying on a later review pass to find the gap, which is what happened
+   three times on the GitLab task.
+
+4. **Fold in the pre-existing `ghLogin`/`ghWithRepo` escaping gap.** These
+   are GitHub's structural twins of GitLab's `glActor`/`glWithRepo`, which
+   were already fixed in `gitlab-mr-issue-cards` (`glActor`'s `username`
+   branch was unescaped on the same "restricted charset" assumption that
+   doesn't hold once you account for this endpoint only checking a shared
+   token, not verifying genuine GitHub origin). `ghLogin`/`ghWithRepo` had
+   the identical gap, entirely unfixed until now. Folded into this task
+   rather than deferred, because (a) it's the exact same fix pattern already
+   established and reviewed for GitLab, (b) it's a genuine asymmetry-closer
+   (GitLab already has this fix; GitHub didn't), not a new asymmetry, and
+   (c) `renderGitHubPush`/`buildGitHubPushCard` — untouched by the action-
+   filter work — get the fix for free since `ghLogin`/`ghWithRepo` are
+   shared helpers.
+
+5. **Renamed `glCappedFactValue` → `cappedFactValue`.** It's shared
+   `adapter_card.go` infra used by both adapters' Jobs/Labels facts; leaving
+   the GitLab-specific prefix on a function GitHub's `ghLabelsFact` now also
+   calls would be actively misleading to a future reader. Mechanical rename
+   only, no behavior change (`sed` across the 3 files that referenced it).
+
+## Load-bearing decisions
+
+- **Apply a filed learning proactively, not just reactively.** The GitLab
+  task's pending learning
+  (`gitlab-mr-issue-cards-whitelist-gate-sanitizer.md`) exists specifically
+  so this exact situation — widening another action-based gate — doesn't
+  repeat the same discovery-by-review cycle. Concretely: before writing any
+  code, enumerated every field the four whitelist gates were about to stop
+  protecting (the 4 actions themselves) and escaped all 8 interpolation
+  sites in the same commit, then separately grepped afterward to confirm no
+  site was missed (see Verification). This is the "enumerate every field the
+  same commit un-gates, not just the one already flagged" step the learning
+  calls for, done at write-time instead of via a third review round.
+- **Fold in a known-elsewhere-fixed pre-existing gap; defer known-nowhere-
+  fixed ones.** `ghLogin`/`ghWithRepo` (GitLab already has the fix) got
+  folded in. The ref/branch code-span backtick issue and the URL-destination
+  breakout (neither adapter has ever had the fix) stayed deferred — fixing
+  those properly needs `renderGitHubPush`/`renderGitLabPush`/tag/note, none
+  of which this task touches, plus doing both adapters in the same pass per
+  the repo's adapter-parity rule. Same boundary the GitLab task drew; see
+  its journal for the reasoning this mirrors.
+- **`ghCommentVerb`'s known values are full phrases (`"commented on"`,
+  `"edited a comment on"`), not bare verbs**, unlike the other three
+  mappers. This keeps the single `"**actor** %s [#N title]"` / `"%s %s an
+  issue"` template working uniformly across all four event types without a
+  special-cased sentence structure for comments — the phrase already
+  includes the preposition the template needs.
+
+## Verification
+
+- Grepped every `ghPRVerb(`/`ghIssueVerb(`/`ghCommentVerb(`/`ghReleaseVerb(`
+  call site (8 total) and manually confirmed each one's `verb` value is
+  wrapped in `mdInertText`/`escapeCardText` before reaching a `fmt.Sprintf`
+  destined for rendered output — done *before* running the hostile-payload
+  tests below, as a design check, not just a test-driven discovery.
+- `go test ./modules/incomingwebhook/... -run '<adapter/card subset>'` green
+  on the first run after implementation (no red-green-red cycle this time,
+  unlike the GitLab task's multi-round review churn) — includes hostile-
+  action regression tests (text + card, PR/Issues/Release) and hostile-
+  login/repo-name tests (text path, mirroring GitLab's equivalent).
+- `golangci-lint run ./modules/incomingwebhook/...` = 0 issues; `gofmt`
+  clean; `make i18n-lint` OK (no error-code changes).
+- Manual render check (throwaway test, not committed) confirmed realistic
+  PR/issue payloads render sensibly on both paths (see PR description for
+  the actual output).
+
+## Follow-ups / notes
+
+- The already-tracked deferred hardening item (ref/branch code-span
+  backtick breakout + URL-destination breakout — see
+  `gitlab-mr-issue-cards.md`'s Follow-ups section) now has its GitHub-side
+  exposure widened the same way GitLab's pipeline widening did: previously
+  only 4 PR actions + 3 issue actions + `created` comments + `published`
+  releases reached the affected `html_url`/`comment.html_url` sinks; now
+  every action does. Still not fixed here, for the same reasons (needs
+  `renderGitHubPush` + both adapters in one consistent pass).
+- Comment-body blockquote escaping (`issue_comment`'s `comment.body`) is
+  still unescaped on the text path, matching GitLab's Note `note` field —
+  deliberately left symmetric. Worth folding into the same deferred
+  follow-up rather than fixing one adapter first.
+- GitHub's `push` event text/card rendering is otherwise untouched — no
+  action whitelist existed there to remove.

--- a/.octospec/journal/shared/github-webhook-parity.md
+++ b/.octospec/journal/shared/github-webhook-parity.md
@@ -110,6 +110,30 @@ review-driven follow-ups):
   PR/issue payloads render sensibly on both paths (see PR description for
   the actual output).
 
+## Review round (PR #611)
+
+Three independent reviewers (lml2468, Jerry-Xin, yujiawei) approved with no
+P0/P1 findings — the proactive escaping (see "Load-bearing decisions" above)
+meant none of them found a repeat of the GitLab task's "widened gate, missed
+an escape site" bug. One P2 non-blocking finding, folded in directly rather
+than deferred (all three reviews were in hand, so this was a single batched
+decision, not a one-at-a-time back-and-forth):
+
+- **yujiawei**: `ready_for_review`/`converted_to_draft` are complete
+  predicate phrases ("marked ready for review", "converted to draft"), not
+  transitive verbs — running them through the generic `"%s %s pull request
+  [#N]"` / `"%s %s a pull request"` templates put the object in the wrong
+  place ("actor marked ready for review a pull request"). Fixed by special-
+  casing these two known-literal actions in both
+  `renderGitHubPullRequest`/`buildGitHubPullRequestCard` to place the PR
+  reference mid-phrase ("actor marked pull request [#N] ready for review" /
+  "actor converted a pull request to draft"); every other action keeps the
+  uniform template unchanged. No escaping impact — both branches match on
+  the literal `ev.Action` string, not on interpolated content.
+- Jerry-Xin's and lml2468's findings were both "no action needed, already
+  tracked" — restating the same deferred URL-destination / comment-body
+  items this journal already lists below.
+
 ## Follow-ups / notes
 
 - The already-tracked deferred hardening item (ref/branch code-span

--- a/.octospec/log.md
+++ b/.octospec/log.md
@@ -4,6 +4,26 @@ Change history for this repo's `.octospec/`, following the
 [OKF](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md)
 change-log convention (§7). Newest first.
 
+## 2026-07-20 (github-webhook-parity)
+
+- **Feature** — GitHub `pull_request`/`issues` InteractiveCards gained
+  Source/Target branch (PR) + Labels(N) FactSet rows, mirroring the GitLab
+  MR/Issue cards from `gitlab-mr-issue-cards` earlier the same day.
+- **Behavior change** — GitHub adapter no longer filters
+  `pull_request`/`issues`/`issue_comment`/`release` events by action
+  (explicit product decision, mirroring the GitLab one); every action now
+  renders on both text and card paths.
+- **Fix** — Applied the `gitlab-mr-issue-cards` task's pending learning
+  (whitelist-gate-as-implicit-sanitizer) proactively: every field the filter
+  removal exposed was escaped in the same commit (verified by enumerating
+  and grepping every call site before committing, not discovered via a
+  later review round). Also folded in a pre-existing, previously-unfixed
+  escaping gap in `ghLogin`/`ghWithRepo` (GitHub's twin of GitLab's already-
+  fixed `glActor`/`glWithRepo`), for adapter parity. Renamed the shared
+  `glCappedFactValue` helper to `cappedFactValue` since GitHub's new Labels
+  fact now calls it too. See
+  [journal](journal/shared/github-webhook-parity.md).
+
 ## 2026-07-20 (gitlab-mr-issue-cards)
 
 - **Feature** — GitLab merge_request/issue InteractiveCards gained a

--- a/.octospec/tasks/github-webhook-parity/brief.md
+++ b/.octospec/tasks/github-webhook-parity/brief.md
@@ -1,0 +1,117 @@
+---
+type: Task
+title: "Task: github-webhook-parity"
+description: Bring the GitHub incoming-webhook adapter to parity with the GitLab adapter's gitlab-mr-issue-cards work — stop filtering pull_request/issues/issue_comment/release actions, add Source/Target branch + Labels FactSet rows to the PR/Issue cards, and close the corresponding trust-boundary escaping gaps up front.
+tags: ["incomingwebhook", "adapter", "github", "card", "trust-boundary", "external-content", "markdown", "testing"]
+timestamp: 2026-07-20T00:00:00Z
+# --- octospec extension fields ---
+slug: github-webhook-parity
+upstream: self
+source: self
+---
+
+# Task: github-webhook-parity
+
+> Mirrors `.octospec/tasks/gitlab-mr-issue-cards/brief.md` — same two changes
+> (stop filtering, add FactSet enrichment), same underlying trust-boundary
+> reasoning, applied to the sibling GitHub adapter. Read that brief's journal
+> for the full incident history (three review rounds each found an instance
+> of the same "widen a gate, forget to escape" bug class); this task applies
+> those lessons up front instead of discovering them one review round at a
+> time.
+
+## Goal
+
+1. GitHub `pull_request`/`issues` cards carry the same kind of structured
+   metadata the GitLab MR/Issue cards already have: Source/Target branch (PR
+   only, from `pull_request.head.ref`/`base.ref`) and a Labels(N) FactSet row
+   (both PR and issue, from `pull_request.labels[]`/`issue.labels[]`).
+2. Stop filtering GitHub `pull_request`/`issues`/`issue_comment`/`release`
+   events by which action they carry. Previously: PR rendered only
+   `opened`/`closed`/`reopened`/`ready_for_review`; issues only
+   `opened`/`closed`/`reopened`; issue_comment only `created`; release only
+   `published`. Every action now renders (mapped to a readable verb where
+   possible, raw-passthrough — escaped — otherwise); the only remaining skip
+   is a malformed payload missing the `action` field itself.
+
+## Background
+
+- Card anatomy (`vcsCardData`, `vcsFact`, `escapeCardText`, `cardCodeSpan`,
+  `cappedFactValue`) lives in `modules/incomingwebhook/adapter_card.go`,
+  shared by both adapters — this task's Labels-fact code reuses the exact
+  same `cappedFactValue` helper the GitLab task built (renamed from
+  `glCappedFactValue` to drop the misleading GitLab-only prefix, since it's
+  now a genuine two-adapter shared helper).
+- The GitLab task (`gitlab-mr-issue-cards`) shipped the identical feature
+  pair for GitLab and, across three independent review rounds, surfaced the
+  same bug class three times: a whitelist gate that only ever returned safe
+  literals was widened to pass through raw external input, and the escaping
+  fix initially only covered the field the first review flagged (`action`),
+  missing a sibling field the same commit also un-gated (`status`), and
+  later a third, pre-existing instance in a shared actor-rendering helper
+  (`glActor`'s `username` branch) that had never been escaped at all. See
+  that task's journal and the resulting pending learning
+  (`.octospec/learnings/pending/gitlab-mr-issue-cards-whitelist-gate-sanitizer.md`)
+  for the full incident writeup.
+- This task applies that learning proactively: every action-verb function
+  (`ghPRVerb`/`ghIssueVerb`/`ghCommentVerb`/`ghReleaseVerb`) is designed from
+  the start with the same "return value may be raw external input, caller
+  MUST escape" contract documented in its own doc comment, and every one of
+  its 8 call sites (4 text via `mdInertText`, 4 card via `escapeCardText`)
+  was escaped in the same commit — not discovered later via review. The
+  pre-existing `ghLogin`/`ghWithRepo` actor/repo-name escaping gap (the
+  GitHub-side twin of `glActor`/`glWithRepo`, already fixed for GitLab) was
+  also folded in here for the same "brings a known-fixed-elsewhere gap to
+  parity" reason `glActor`'s fix was folded into the GitLab PR.
+
+## Load-bearing list
+
+- `modules/incomingwebhook/adapter_github.go` — `ghPRVerb`/`ghIssueVerb`/
+  `ghCommentVerb`/`ghReleaseVerb` (new action → verb mappers, full
+  passthrough instead of whitelist gates), `renderGitHubPullRequest`/
+  `renderGitHubIssues`/`renderGitHubIssueComment`/`renderGitHubRelease`
+  (text path), `buildGitHubPullRequestCard`/`buildGitHubIssuesCard`/
+  `buildGitHubIssueCommentCard`/`buildGitHubReleaseCard` (card path),
+  `ghLogin`/`ghWithRepo` (now escape internally).
+- `modules/incomingwebhook/adapter_card.go` — `cappedFactValue` (renamed from
+  `glCappedFactValue`; no behavior change) gains a second caller
+  (`ghLabelsFact`) alongside GitLab's `glLabelsFact`.
+- Trust boundary: this endpoint (like GitLab's) authenticates only a shared
+  URL token — it does not verify the payload genuinely originates from
+  GitHub (`X-Hub-Signature-256` HMAC verification is optional/unenforced,
+  per the file's own header comment). Every field a removed gate exposes, or
+  that was already reachable but unescaped, must be escaped at every
+  interpolation site on both paths.
+
+## Out of scope
+
+- GitLab adapter — untouched by this task (only a mechanical rename of the
+  now-shared `cappedFactValue` helper touches `adapter_gitlab.go`).
+- `push` event — has no action-based whitelist to remove (its branching is
+  create/delete/degenerate-ref logic, not an action string), so it's
+  structurally unchanged; it benefits automatically from the `ghLogin`/
+  `ghWithRepo` escaping fix since those are shared helpers.
+- The already-tracked deferred follow-up (ref/branch code-span backtick
+  breakout, raw URL-destination breakout in markdown link syntax) — this
+  task does not fix either for GitHub. Fixing them requires touching
+  `renderGitHubPush` (untouched here) and mirrors the same GitLab gaps
+  already deferred in `gitlab-mr-issue-cards`; see that journal's follow-up
+  section, now updated to note the action-filter removal here widens which
+  GitHub actions reach the URL-destination sink (previously only 4 PR
+  actions + 3 issue actions + `created` comments + `published` releases
+  reached `object_attributes`-equivalent URLs; now all actions do).
+- Comment-body blockquote escaping (`issue_comment`'s `comment.body`,
+  GitLab's Note `note` field) — pre-existing on both adapters, deliberately
+  left symmetric/unfixed to avoid creating a new cross-adapter asymmetry;
+  noted as a candidate to fold into the same deferred follow-up.
+
+## Acceptance
+
+- `go test ./modules/incomingwebhook/...` (adapter/card subset) green.
+- `golangci-lint run ./modules/incomingwebhook/...` = 0 issues; `gofmt` clean.
+- A hostile `action` value (`"**pwn** [x](http://evil.example)"`) renders as
+  literal escaped text — never a live link/emphasis — on both the text and
+  card paths, for `pull_request`, `issues`, and `release` (regression
+  tests, not just manual verification).
+- A hostile `sender.login`/`repository.full_name` renders as literal escaped
+  text on the text path (regression test — the `ghLogin`/`ghWithRepo` fix).

--- a/modules/incomingwebhook/README.md
+++ b/modules/incomingwebhook/README.md
@@ -197,17 +197,17 @@ POST /v1/incoming-webhooks/:webhook_id/:token/github
 |------|-----------|------|
 | `ping` | — | 返回 200 不发消息（GitHub 创建 webhook 时的连通性测试） |
 | `push` | — | 分支/标签 push、删除、force-push；最多列 5 条提交 |
-| `pull_request` | `opened` / `closed`(含 merged) / `reopened` / `ready_for_review` | `synchronize` 等刷屏动作跳过 |
-| `issues` | `opened` / `closed` / `reopened` | |
-| `issue_comment` | `created` | 评论摘要压成单行、截断 300 rune |
-| `release` | `published` | |
+| `pull_request` | 所有 action（`opened`/`closed`(含 merged)/`reopened`/`synchronize`/`labeled`/...） | 卡片带 Source/Target 分支 + Labels FactSet；只有缺 `action` 字段的畸形 payload 才跳过 |
+| `issues` | 所有 action | 卡片带 Labels FactSet；只有缺 `action` 字段的畸形 payload 才跳过 |
+| `issue_comment` | 所有 action（`created`/`edited`/`deleted`） | 评论摘要压成单行、截断 300 rune；`deleted` 无正文可引用 |
+| `release` | 所有 action（`published`/`created`/`edited`/...） | |
 
-**子集之外的事件/动作返回 200 + `{"skipped":"event"}`**（GitHub 侧显示投递成功、
-不标红；deliveries 里以 `status=3` 可见），缺 `X-GitHub-Event` 头则按 400
-`reason=no_event` 拒绝——配置错误与「正常但不渲染」用不同 reason 区分，deliveries 里
-只看 reason 即可分辨。事件里的超长字段（标题/提交信息/评论）服务端截断；GitHub 可控的
-链接文本（PR/issue/release 标题）里的 `]`/`[` 会被转义，防止破坏渲染出的链接。GitHub
-流量不会触发 413。
+**子集之外的事件类型返回 200 + `{"skipped":"event"}`**（未实现的事件类型，如 `watch`/
+`star`；GitHub 侧显示投递成功、不标红；deliveries 里以 `status=3` 可见），缺
+`X-GitHub-Event` 头则按 400 `reason=no_event` 拒绝——配置错误与「正常但不渲染」用不同
+reason 区分，deliveries 里只看 reason 即可分辨。事件里的超长字段（标题/提交信息/评论）
+服务端截断；GitHub 可控的字段（actor login、仓库全名、PR/issue/release 标题、未知
+action 值等）均经转义，防止破坏渲染出的链接或伪造粗体/链接。GitHub 流量不会触发 413。
 
 **body 上限独立于 native**：GitHub 事件 JSON 由平台生成（真实 push/PR 事件普遍
 >8KiB，发送方无法修短），github 路由的请求体上限默认 **1MiB**

--- a/modules/incomingwebhook/adapter_card.go
+++ b/modules/incomingwebhook/adapter_card.go
@@ -287,7 +287,7 @@ const maxRenderedLabels = 10
 // name, even though both happened to want 64 today (PR #610 review, yujiawei P2).
 const cardFactItemMax = 64
 
-// glCappedFactValue builds a capped, "/"-joined FactSet value from raw external name
+// cappedFactValue builds a capped, "/"-joined FactSet value from raw external name
 // strings — shared by the pipeline card's Jobs fact and the GitLab MR/Issue Labels
 // fact (previously duplicated inline at each call site, which could let their
 // escaping/capping decisions silently drift apart). Each name is escaped via
@@ -295,7 +295,7 @@ const cardFactItemMax = 64
 // and counting, so the fact never shows an empty slot or an inflated (N). Returns
 // ("", 0) when there is nothing left to show — the caller omits the FactSet row
 // entirely in that case.
-func glCappedFactValue(rawNames []string, max int) (value string, count int) {
+func cappedFactValue(rawNames []string, max int) (value string, count int) {
 	names := make([]string, 0, len(rawNames))
 	for _, n := range rawNames {
 		if v := escapeCardText(n, cardFactItemMax); v != "" {

--- a/modules/incomingwebhook/adapter_card_test.go
+++ b/modules/incomingwebhook/adapter_card_test.go
@@ -211,6 +211,20 @@ func TestBuildGitHubPullRequestCard_Facts(t *testing.T) {
 		assert.Contains(t, cardmsg.BuildPlain(card), "carol pushed new commits to a pull request")
 	})
 
+	t.Run("ready_for_review headline places the object mid-phrase", func(t *testing.T) {
+		card := ghPullRequestCardFrom(t, `{"action":"ready_for_review","pull_request":{"number":1,"title":"x"},"sender":{"login":"carol"}}`)
+		require.NotNil(t, card)
+		require.NoError(t, validateVCSCard(card))
+		assert.Contains(t, cardmsg.BuildPlain(card), "carol marked a pull request ready for review")
+	})
+
+	t.Run("converted_to_draft headline places the object mid-phrase", func(t *testing.T) {
+		card := ghPullRequestCardFrom(t, `{"action":"converted_to_draft","pull_request":{"number":1,"title":"x"},"sender":{"login":"carol"}}`)
+		require.NotNil(t, card)
+		require.NoError(t, validateVCSCard(card))
+		assert.Contains(t, cardmsg.BuildPlain(card), "carol converted a pull request to draft")
+	})
+
 	t.Run("missing action has no card (nothing to render)", func(t *testing.T) {
 		assert.Nil(t, ghPullRequestCardFrom(t, `{"pull_request":{"number":1}}`))
 	})

--- a/modules/incomingwebhook/adapter_card_test.go
+++ b/modules/incomingwebhook/adapter_card_test.go
@@ -28,6 +28,20 @@ func ghIssueCommentCardFrom(t *testing.T, body string) map[string]interface{} {
 	return buildGitHubIssueCommentCard(&ev, "en-US")
 }
 
+func ghPullRequestCardFrom(t *testing.T, body string) map[string]interface{} {
+	t.Helper()
+	var ev ghPullRequestEvent
+	require.NoError(t, json.Unmarshal([]byte(body), &ev))
+	return buildGitHubPullRequestCard(&ev, "en-US")
+}
+
+func ghIssuesCardFrom(t *testing.T, body string) map[string]interface{} {
+	t.Helper()
+	var ev ghIssuesEvent
+	require.NoError(t, json.Unmarshal([]byte(body), &ev))
+	return buildGitHubIssuesCard(&ev, "en-US")
+}
+
 func glPushCardFrom(t *testing.T, body string) map[string]interface{} {
 	t.Helper()
 	var ev glPushEvent
@@ -153,6 +167,107 @@ func TestBuildGitHubPushCard(t *testing.T) {
 	url, title := cardOpenURL(card)
 	assert.Equal(t, "https://github.com/octo/repo/compare/aaaa...bbbb", url)
 	assert.Equal(t, "View on GitHub", title)
+}
+
+func TestBuildGitHubPullRequestCard_Facts(t *testing.T) {
+	card := ghPullRequestCardFrom(t, `{
+		"action": "opened",
+		"pull_request": {"number": 42, "title": "Add cards", "html_url": "https://github.com/o/r/pull/42",
+			"base": {"ref": "main"}, "head": {"ref": "feature/cards"},
+			"labels": [{"name": "backend"}, {"name": "needs-review"}]},
+		"repository": {"full_name": "o/r"},
+		"sender": {"login": "carol"}
+	}`)
+	require.NotNil(t, card)
+	require.NoError(t, validateVCSCard(card))
+
+	plain := cardmsg.BuildPlain(card)
+	assert.Contains(t, plain, "carol opened a pull request")
+	assert.Contains(t, plain, "#42 · Add cards")
+	assert.Contains(t, plain, "Source: feature/cards")
+	assert.Contains(t, plain, "Target: main")
+	assert.Contains(t, plain, "Labels (2): backend / needs-review")
+
+	t.Run("no base/head/labels omits the facts entirely", func(t *testing.T) {
+		card := ghPullRequestCardFrom(t, `{
+			"action": "opened",
+			"pull_request": {"number": 42, "title": "Add cards", "html_url": "https://github.com/o/r/pull/42"},
+			"repository": {"full_name": "o/r"},
+			"sender": {"login": "carol"}
+		}`)
+		require.NotNil(t, card)
+		require.NoError(t, validateVCSCard(card))
+		body, _ := card["body"].([]interface{})
+		for _, it := range body {
+			el, _ := it.(map[string]interface{})
+			assert.NotEqual(t, "FactSet", el["type"], "no FactSet block when there is nothing to show")
+		}
+	})
+
+	t.Run("synchronize action is rendered too (no longer filtered)", func(t *testing.T) {
+		card := ghPullRequestCardFrom(t, `{"action":"synchronize","pull_request":{"number":1,"title":"x"},"sender":{"login":"carol"}}`)
+		require.NotNil(t, card)
+		require.NoError(t, validateVCSCard(card))
+		assert.Contains(t, cardmsg.BuildPlain(card), "carol pushed new commits to a pull request")
+	})
+
+	t.Run("missing action has no card (nothing to render)", func(t *testing.T) {
+		assert.Nil(t, ghPullRequestCardFrom(t, `{"pull_request":{"number":1}}`))
+	})
+
+	t.Run("hostile unknown action is escaped in the card headline (trust-boundary)", func(t *testing.T) {
+		card := ghPullRequestCardFrom(t, `{"action":"**pwn** [x](http://evil.example)",
+			"pull_request":{"number":1,"title":"x"},"sender":{"login":"carol"}}`)
+		require.NotNil(t, card)
+		require.NoError(t, validateVCSCard(card), "server-built card must pass cardmsg.Validate")
+		leaves := cardBodyText(card)
+		assert.Contains(t, leaves, `\*\*pwn\*\* \[x\]\(http://evil.example\)`,
+			"markdown metacharacters in an unmapped action must be escaped, never form a live link/emphasis")
+	})
+}
+
+func TestBuildGitHubIssuesCard_Facts(t *testing.T) {
+	card := ghIssuesCardFrom(t, `{
+		"action": "opened",
+		"issue": {"number": 7, "title": "Login broken", "html_url": "https://github.com/o/r/issues/7",
+			"labels": [{"name": "bug"}, {"name": "P1"}]},
+		"repository": {"full_name": "o/r"},
+		"sender": {"login": "dave"}
+	}`)
+	require.NotNil(t, card)
+	require.NoError(t, validateVCSCard(card))
+	plain := cardmsg.BuildPlain(card)
+	assert.Contains(t, plain, "Labels (2): bug / P1")
+
+	t.Run("no labels omits the fact", func(t *testing.T) {
+		card := ghIssuesCardFrom(t, `{
+			"action": "opened",
+			"issue": {"number": 7, "title": "Login broken"},
+			"repository": {"full_name": "o/r"},
+			"sender": {"login": "dave"}
+		}`)
+		require.NotNil(t, card)
+		body, _ := card["body"].([]interface{})
+		for _, it := range body {
+			el, _ := it.(map[string]interface{})
+			assert.NotEqual(t, "FactSet", el["type"])
+		}
+	})
+
+	t.Run("labeled action is rendered too (no longer filtered)", func(t *testing.T) {
+		card := ghIssuesCardFrom(t, `{"action":"labeled","issue":{"number":1,"title":"x"},"sender":{"login":"dave"}}`)
+		require.NotNil(t, card)
+		require.NoError(t, validateVCSCard(card))
+		assert.Contains(t, cardmsg.BuildPlain(card), "dave labeled an issue")
+	})
+
+	t.Run("hostile unknown action is escaped in the card headline (trust-boundary)", func(t *testing.T) {
+		card := ghIssuesCardFrom(t, `{"action":"**pwn** [x](http://evil.example)",
+			"issue":{"number":1,"title":"x"},"sender":{"login":"dave"}}`)
+		require.NotNil(t, card)
+		require.NoError(t, validateVCSCard(card), "server-built card must pass cardmsg.Validate")
+		assert.Contains(t, cardBodyText(card), `\*\*pwn\*\* \[x\]\(http://evil.example\)`)
+	})
 }
 
 func TestBuildGitLabPipelineCard_StatusColor(t *testing.T) {
@@ -355,7 +470,7 @@ func TestGlLabelsFact_OverflowAndEscaping(t *testing.T) {
 	t.Run("whitespace-only label title is dropped, not counted as a blank slot", func(t *testing.T) {
 		// escapeCardText's oneLine() trims a whitespace-only title to "" (unlike a
 		// lone backtick, which cardMarkdownEscaper *escapes* to `\`` rather than
-		// stripping — it does not go blank). glCappedFactValue must drop titles that
+		// stripping — it does not go blank). cappedFactValue must drop titles that
 		// come out blank, from both the joined value and the (N) count (PR #610
 		// review, mochashanyao P2: verifies this documented behavior explicitly).
 		card := glMergeRequestCardFrom(t, `{
@@ -583,8 +698,9 @@ func TestVCSParse_FlagGate(t *testing.T) {
 		// missing event header → still no_event
 		_, _, invalid := parseGitHubPush(http.Header{}, []byte(`{}`))
 		assert.Equal(t, "no_event", invalid)
-		// subset-outside action → still skip
-		_, skip, _ := parseGitHubPush(ghHeader("pull_request"), []byte(`{"action":"synchronize"}`))
+		// missing action field → still skip (the one remaining filter, now that
+		// action-based filtering is removed)
+		_, skip, _ := parseGitHubPush(ghHeader("pull_request"), []byte(`{}`))
 		assert.Equal(t, "event", skip)
 	})
 }

--- a/modules/incomingwebhook/adapter_github.go
+++ b/modules/incomingwebhook/adapter_github.go
@@ -291,9 +291,19 @@ func renderGitHubPullRequest(ev *ghPullRequestEvent) string {
 		// 缺 action 字段的畸形 payload：没有可渲染的动作 → skip（唯一保留的过滤）。
 		return ""
 	}
-	return ghWithRepo(fmt.Sprintf("**%s** %s pull request [#%d %s](%s)",
-		ghLogin(ev.Sender), mdInertText(verb, glActorMax), ev.PullRequest.Number,
-		mdLinkText(ev.PullRequest.Title, 200), ev.PullRequest.HTMLURL),
+	pr := fmt.Sprintf("pull request [#%d %s](%s)", ev.PullRequest.Number,
+		mdLinkText(ev.PullRequest.Title, 200), ev.PullRequest.HTMLURL)
+	// ready_for_review/converted_to_draft 是完整谓语短语，不是能直接接宾语的及物动词，
+	// 套用通用的 "VERB pull request [#N]" 模板会语序错乱（"marked ready for review
+	// pull request #N"）。这两个 action 是已知字面量分支，宾语单独摆在短语中间。
+	switch ev.Action {
+	case "ready_for_review":
+		return ghWithRepo(fmt.Sprintf("**%s** marked %s ready for review", ghLogin(ev.Sender), pr), ev.Repository)
+	case "converted_to_draft":
+		return ghWithRepo(fmt.Sprintf("**%s** converted %s to draft", ghLogin(ev.Sender), pr), ev.Repository)
+	}
+	return ghWithRepo(fmt.Sprintf("**%s** %s %s",
+		ghLogin(ev.Sender), mdInertText(verb, glActorMax), pr),
 		ev.Repository)
 }
 
@@ -596,10 +606,19 @@ func buildGitHubPullRequestCard(ev *ghPullRequestEvent, lang string) map[string]
 	if f := ghLabelsFact(labels.labels, ev.PullRequest.Labels); f != nil {
 		facts = append(facts, *f)
 	}
+	var headline string
+	switch ev.Action {
+	case "ready_for_review":
+		headline = fmt.Sprintf("%s marked a pull request ready for review", ghActorCard(ev.Sender))
+	case "converted_to_draft":
+		headline = fmt.Sprintf("%s converted a pull request to draft", ghActorCard(ev.Sender))
+	default:
+		headline = fmt.Sprintf("%s %s a pull request", ghActorCard(ev.Sender), escapeCardText(verb, cardActorMax))
+	}
 	return vcsCardData{
 		source:   cardSourceGitHub,
 		variant:  "vcs.github.pull_request",
-		headline: fmt.Sprintf("%s %s a pull request", ghActorCard(ev.Sender), escapeCardText(verb, cardActorMax)),
+		headline: headline,
 		subtitle: escapeCardText(ev.Repository.FullName, cardTitleMax),
 		lines:    []string{numberedTitle("#", ev.PullRequest.Number, ev.PullRequest.Title)},
 		facts:    facts,

--- a/modules/incomingwebhook/adapter_github.go
+++ b/modules/incomingwebhook/adapter_github.go
@@ -10,10 +10,12 @@ package incomingwebhook
 // X-Hub-Signature-256 校验留作后续可选项，参考 modules/webhook/hmac.go）。
 //
 // 渲染策略：按 X-GitHub-Event 把常用事件翻译成 markdown 文本（走 native 纯文本路径，
-// 客户端按 markdown 渲染）。刻意只渲染「人关心的」动作子集——例如 pull_request 的
-// synchronize（PR 分支每次 push 都触发）若也进群会刷屏。子集之外的事件 / 动作返回
-// 200 并以 auditSkipped 落审计：GitHub 侧显示绿色投递成功（不会把 webhook 标红），
-// 管理端 deliveries 里 reason=event 可见，两边都不糊弄。
+// 客户端按 markdown 渲染）。pull_request/issues/issue_comment/release 的所有 action
+// 均会渲染（产品决定：不按「是否刷屏」过滤，与 GitLab 适配器同一决定——旧版本只渲染
+// open/close/reopen/merge 等子集，现已放开）；仍在渲染子集之外的只有事件【类型】本身
+// （watch / star 等未实现的事件类型）与畸形 payload（缺 action 字段）。子集之外的
+// 事件返回 200 并以 auditSkipped 落审计：GitHub 侧显示绿色投递成功（不会把 webhook
+// 标红），管理端 deliveries 里 reason=event 可见，两边都不糊弄。
 //
 // 所有 gh* 结构体只声明渲染需要的字段（白名单解析），其余 payload 字段一律忽略。
 
@@ -89,6 +91,13 @@ type ghPushEvent struct {
 	Sender     ghUser `json:"sender"`
 }
 
+// ghLabel is a GitHub label object (the `labels[]` array GitHub attaches to
+// pull_request/issues event payloads, nested under pull_request/issue rather than
+// top-level like GitLab's). Only Name is rendered.
+type ghLabel struct {
+	Name string `json:"name"`
+}
+
 type ghPullRequestEvent struct {
 	Action      string `json:"action"`
 	PullRequest struct {
@@ -96,6 +105,16 @@ type ghPullRequestEvent struct {
 		Title   string `json:"title"`
 		HTMLURL string `json:"html_url"`
 		Merged  bool   `json:"merged"`
+		// Base/Head feed the card-only Target/Source FactSet rows (text path
+		// unchanged, same "card-only" convention as the GitLab MR card).
+		Base struct {
+			Ref string `json:"ref"`
+		} `json:"base"`
+		Head struct {
+			Ref string `json:"ref"`
+		} `json:"head"`
+		// Labels feeds the card-only Labels FactSet row;缺省即不展示该行。
+		Labels []ghLabel `json:"labels"`
 	} `json:"pull_request"`
 	Repository ghRepo `json:"repository"`
 	Sender     ghUser `json:"sender"`
@@ -107,6 +126,8 @@ type ghIssuesEvent struct {
 		Number  int    `json:"number"`
 		Title   string `json:"title"`
 		HTMLURL string `json:"html_url"`
+		// Labels feeds the card-only Labels FactSet row;缺省即不展示该行。
+		Labels []ghLabel `json:"labels"`
 	} `json:"issue"`
 	Repository ghRepo `json:"repository"`
 	Sender     ghUser `json:"sender"`
@@ -265,47 +286,41 @@ func renderGitHubPush(ev *ghPushEvent) string {
 }
 
 func renderGitHubPullRequest(ev *ghPullRequestEvent) string {
-	var verb string
-	switch ev.Action {
-	case "opened", "reopened":
-		verb = ev.Action
-	case "ready_for_review":
-		verb = "marked ready for review:"
-	case "closed":
-		verb = "closed"
-		if ev.PullRequest.Merged {
-			verb = "merged"
-		}
-	default:
-		// synchronize / labeled / review_requested / ... 刷屏动作不渲染 → skip。
+	verb := ghPRVerb(ev.Action, ev.PullRequest.Merged)
+	if verb == "" {
+		// 缺 action 字段的畸形 payload：没有可渲染的动作 → skip（唯一保留的过滤）。
 		return ""
 	}
 	return ghWithRepo(fmt.Sprintf("**%s** %s pull request [#%d %s](%s)",
-		ghLogin(ev.Sender), verb, ev.PullRequest.Number,
+		ghLogin(ev.Sender), mdInertText(verb, glActorMax), ev.PullRequest.Number,
 		mdLinkText(ev.PullRequest.Title, 200), ev.PullRequest.HTMLURL),
 		ev.Repository)
 }
 
 func renderGitHubIssues(ev *ghIssuesEvent) string {
-	switch ev.Action {
-	case "opened", "closed", "reopened":
-	default:
+	verb := ghIssueVerb(ev.Action)
+	if verb == "" {
 		return ""
 	}
 	return ghWithRepo(fmt.Sprintf("**%s** %s issue [#%d %s](%s)",
-		ghLogin(ev.Sender), ev.Action, ev.Issue.Number,
+		ghLogin(ev.Sender), mdInertText(verb, glActorMax), ev.Issue.Number,
 		mdLinkText(ev.Issue.Title, 200), ev.Issue.HTMLURL),
 		ev.Repository)
 }
 
 func renderGitHubIssueComment(ev *ghIssueCommentEvent) string {
-	if ev.Action != "created" {
+	verb := ghCommentVerb(ev.Action)
+	if verb == "" {
 		return ""
 	}
-	line := ghWithRepo(fmt.Sprintf("**%s** commented on [#%d %s](%s)",
-		ghLogin(ev.Sender), ev.Issue.Number,
+	line := ghWithRepo(fmt.Sprintf("**%s** %s [#%d %s](%s)",
+		ghLogin(ev.Sender), mdInertText(verb, glActorMax), ev.Issue.Number,
 		mdLinkText(ev.Issue.Title, 200), ev.Comment.HTMLURL),
 		ev.Repository)
+	if ev.Action == "deleted" {
+		// 已删除的评论没有正文可引用。
+		return line
+	}
 	if snippet := clipRunes(oneLine(ev.Comment.Body), 300); snippet != "" {
 		line += "\n> " + snippet
 	}
@@ -313,35 +328,168 @@ func renderGitHubIssueComment(ev *ghIssueCommentEvent) string {
 }
 
 func renderGitHubRelease(ev *ghReleaseEvent) string {
-	if ev.Action != "published" {
+	verb := ghReleaseVerb(ev.Action)
+	if verb == "" {
 		return ""
 	}
 	title := ev.Release.Name
 	if strings.TrimSpace(title) == "" {
 		title = ev.Release.TagName
 	}
-	return ghWithRepo(fmt.Sprintf("**%s** published release [%s](%s)",
-		ghLogin(ev.Sender), mdLinkText(title, 200), ev.Release.HTMLURL),
+	return ghWithRepo(fmt.Sprintf("**%s** %s release [%s](%s)",
+		ghLogin(ev.Sender), mdInertText(verb, glActorMax), mdLinkText(title, 200), ev.Release.HTMLURL),
 		ev.Repository)
 }
 
-// ghLogin 兜底空 sender（GitHub 偶发不带 sender，如某些 App 触发的事件）。
+// ghPRVerb 把 GitHub pull_request 的 action 映射为渲染动词。所有 action 都会渲染
+// （产品决定，与 GitLab glActionVerb 同一决定）——返回空仅表示 action 字段本身缺省，
+// 这是唯一保留的过滤。已知值给出通顺的英文；未知/GitHub 未来新增的值原样透传。
+//
+// ⚠️ 未知值分支直接回传外部输入本身——调用方必须在拼进 markdown/card 前用
+// mdInertText / escapeCardText 转义这个返回值，不能假设它总是字面量安全（与
+// glActionVerb 同一契约，见 GitLab #610 review 的教训）。
+func ghPRVerb(action string, merged bool) string {
+	switch action {
+	case "":
+		return ""
+	case "opened":
+		return "opened"
+	case "reopened":
+		return "reopened"
+	case "closed":
+		if merged {
+			return "merged"
+		}
+		return "closed"
+	case "ready_for_review":
+		return "marked ready for review"
+	case "converted_to_draft":
+		return "converted to draft"
+	case "synchronize":
+		return "pushed new commits to"
+	case "edited":
+		return "edited"
+	case "labeled":
+		return "labeled"
+	case "unlabeled":
+		return "unlabeled"
+	case "assigned":
+		return "assigned"
+	case "unassigned":
+		return "unassigned"
+	case "review_requested":
+		return "requested review on"
+	case "review_request_removed":
+		return "removed review request on"
+	case "locked":
+		return "locked"
+	case "unlocked":
+		return "unlocked"
+	default:
+		return action
+	}
+}
+
+// ghIssueVerb 同 ghPRVerb，覆盖 issues 事件的 action。同一转义契约。
+func ghIssueVerb(action string) string {
+	switch action {
+	case "":
+		return ""
+	case "opened":
+		return "opened"
+	case "closed":
+		return "closed"
+	case "reopened":
+		return "reopened"
+	case "edited":
+		return "edited"
+	case "labeled":
+		return "labeled"
+	case "unlabeled":
+		return "unlabeled"
+	case "assigned":
+		return "assigned"
+	case "unassigned":
+		return "unassigned"
+	case "pinned":
+		return "pinned"
+	case "unpinned":
+		return "unpinned"
+	case "locked":
+		return "locked"
+	case "unlocked":
+		return "unlocked"
+	default:
+		return action
+	}
+}
+
+// ghCommentVerb 同 ghPRVerb，覆盖 issue_comment 事件的 action。已知值直接拼出完整
+// 动词短语（含 "on"/"a comment on"），使调用方 "**actor** VERB [#N title]" 的拼接
+// 模板保持一致。同一转义契约。
+func ghCommentVerb(action string) string {
+	switch action {
+	case "":
+		return ""
+	case "created":
+		return "commented on"
+	case "edited":
+		return "edited a comment on"
+	case "deleted":
+		return "deleted a comment on"
+	default:
+		return action
+	}
+}
+
+// ghReleaseVerb 同 ghPRVerb，覆盖 release 事件的 action。同一转义契约。
+func ghReleaseVerb(action string) string {
+	switch action {
+	case "":
+		return ""
+	case "published":
+		return "published"
+	case "unpublished":
+		return "unpublished"
+	case "created":
+		return "created"
+	case "edited":
+		return "edited"
+	case "deleted":
+		return "deleted"
+	case "prereleased":
+		return "pre-released"
+	case "released":
+		return "released"
+	default:
+		return action
+	}
+}
+
+// ghLogin 兜底空 sender（GitHub 偶发不带 sender，如某些 App 触发的事件），非空时
+// 经 mdInertText 转义。login 字符集虽受 GitHub 官方限制，但本端点不校验请求真的来自
+// GitHub（只查共享 URL token，无强制 HMAC——见文件头注释），持有 token 的调用方能把
+// login 设成任意字符串；不转义会重现 GitLab glActor 的 username 注入（GitLab #610
+// review，yujiawei 发现）。card 路径的 ghActorCard 一直就转义，这里补齐文本路径。
 func ghLogin(u ghUser) string {
 	if u.Login == "" {
 		return "someone"
 	}
-	return u.Login
+	return mdInertText(u.Login, glActorMax)
 }
 
 // ghWithRepo 给消息行追加 " · [repo](url)" 尾注；repo 信息缺失时原样返回。
+// FullName 经 mdInertText 转义——同 ghLogin 的理由，不能假设仓库全名字面量安全
+// （与 GitLab glWithRepo 对 PathWithNamespace 的处理同口径）。
 func ghWithRepo(line string, r ghRepo) string {
 	if r.FullName == "" {
 		return line
 	}
+	name := mdInertText(r.FullName, 200)
 	if r.HTMLURL == "" {
-		return line + " · " + r.FullName
+		return line + " · " + name
 	}
-	return fmt.Sprintf("%s · [%s](%s)", line, r.FullName, r.HTMLURL)
+	return fmt.Sprintf("%s · [%s](%s)", line, name, r.HTMLURL)
 }
 
 // ghShortRef 把 refs/heads/main → main、refs/tags/v1.0 → v1.0。
@@ -430,73 +578,92 @@ func buildGitHubPushCard(ev *ghPushEvent, lang string) map[string]interface{} {
 	return d.card(lang)
 }
 
-// ghPRVerbPhrase maps a pull_request action to a card headline verb phrase; ""
-// signals a subset-outside action (card not produced).
-func ghPRVerbPhrase(action string, merged bool) string {
-	switch action {
-	case "opened":
-		return "opened a pull request"
-	case "reopened":
-		return "reopened a pull request"
-	case "ready_for_review":
-		return "marked a pull request ready for review"
-	case "closed":
-		if merged {
-			return "merged a pull request"
-		}
-		return "closed a pull request"
-	}
-	return ""
-}
-
 func buildGitHubPullRequestCard(ev *ghPullRequestEvent, lang string) map[string]interface{} {
-	phrase := ghPRVerbPhrase(ev.Action, ev.PullRequest.Merged)
-	if phrase == "" {
+	verb := ghPRVerb(ev.Action, ev.PullRequest.Merged)
+	if verb == "" {
 		return nil
+	}
+	// 卡片专属的结构化 FactSet（源分支 / 目标分支 / 标签）——文本路径不含这些字段，
+	// 故 flag-off 字节不变，与 GitLab MR 卡片同一约定（见 buildGitLabMergeRequestCard）。
+	labels := vcsCardLabelsFor(lang)
+	var facts []vcsFact
+	if src := cardCodeSpan(ev.PullRequest.Head.Ref, cardRefMax); src != "" {
+		facts = append(facts, vcsFact{title: labels.source, value: src})
+	}
+	if tgt := cardCodeSpan(ev.PullRequest.Base.Ref, cardRefMax); tgt != "" {
+		facts = append(facts, vcsFact{title: labels.target, value: tgt})
+	}
+	if f := ghLabelsFact(labels.labels, ev.PullRequest.Labels); f != nil {
+		facts = append(facts, *f)
 	}
 	return vcsCardData{
 		source:   cardSourceGitHub,
 		variant:  "vcs.github.pull_request",
-		headline: fmt.Sprintf("%s %s", ghActorCard(ev.Sender), phrase),
+		headline: fmt.Sprintf("%s %s a pull request", ghActorCard(ev.Sender), escapeCardText(verb, cardActorMax)),
 		subtitle: escapeCardText(ev.Repository.FullName, cardTitleMax),
 		lines:    []string{numberedTitle("#", ev.PullRequest.Number, ev.PullRequest.Title)},
+		facts:    facts,
 		url:      httpURLForCard(ev.PullRequest.HTMLURL),
 	}.card(lang)
 }
 
 func buildGitHubIssuesCard(ev *ghIssuesEvent, lang string) map[string]interface{} {
-	switch ev.Action {
-	case "opened", "closed", "reopened":
-	default:
+	verb := ghIssueVerb(ev.Action)
+	if verb == "" {
 		return nil
+	}
+	var facts []vcsFact
+	if f := ghLabelsFact(vcsCardLabelsFor(lang).labels, ev.Issue.Labels); f != nil {
+		facts = append(facts, *f)
 	}
 	return vcsCardData{
 		source:   cardSourceGitHub,
 		variant:  "vcs.github.issues",
-		headline: fmt.Sprintf("%s %s an issue", ghActorCard(ev.Sender), ev.Action),
+		headline: fmt.Sprintf("%s %s an issue", ghActorCard(ev.Sender), escapeCardText(verb, cardActorMax)),
 		subtitle: escapeCardText(ev.Repository.FullName, cardTitleMax),
 		lines:    []string{numberedTitle("#", ev.Issue.Number, ev.Issue.Title)},
+		facts:    facts,
 		url:      httpURLForCard(ev.Issue.HTMLURL),
 	}.card(lang)
 }
 
-func buildGitHubIssueCommentCard(ev *ghIssueCommentEvent, lang string) map[string]interface{} {
-	if ev.Action != "created" {
+// ghLabelsFact builds the shared "Labels (N)" FactSet row for the PR/Issue cards
+// (nil when there is nothing to show), mirroring GitLab's glLabelsFact — same
+// escaping/capping contract via the shared cappedFactValue helper.
+func ghLabelsFact(title string, labels []ghLabel) *vcsFact {
+	names := make([]string, len(labels))
+	for i, l := range labels {
+		names[i] = l.Name
+	}
+	value, n := cappedFactValue(names, maxRenderedLabels)
+	if n == 0 {
 		return nil
 	}
-	return vcsCardData{
+	return &vcsFact{title: fmt.Sprintf("%s (%d)", title, n), value: value}
+}
+
+func buildGitHubIssueCommentCard(ev *ghIssueCommentEvent, lang string) map[string]interface{} {
+	verb := ghCommentVerb(ev.Action)
+	if verb == "" {
+		return nil
+	}
+	d := vcsCardData{
 		source:   cardSourceGitHub,
 		variant:  "vcs.github.issue_comment",
-		headline: fmt.Sprintf("%s commented on an issue", ghActorCard(ev.Sender)),
+		headline: fmt.Sprintf("%s %s an issue", ghActorCard(ev.Sender), escapeCardText(verb, cardActorMax)),
 		subtitle: escapeCardText(ev.Repository.FullName, cardTitleMax),
 		lines:    []string{numberedTitle("#", ev.Issue.Number, ev.Issue.Title)},
-		quote:    escapeCardText(ev.Comment.Body, cardQuoteMax),
 		url:      httpURLForCard(ev.Comment.HTMLURL),
-	}.card(lang)
+	}
+	if ev.Action != "deleted" {
+		d.quote = escapeCardText(ev.Comment.Body, cardQuoteMax)
+	}
+	return d.card(lang)
 }
 
 func buildGitHubReleaseCard(ev *ghReleaseEvent, lang string) map[string]interface{} {
-	if ev.Action != "published" {
+	verb := ghReleaseVerb(ev.Action)
+	if verb == "" {
 		return nil
 	}
 	title := ev.Release.Name
@@ -506,7 +673,7 @@ func buildGitHubReleaseCard(ev *ghReleaseEvent, lang string) map[string]interfac
 	return vcsCardData{
 		source:   cardSourceGitHub,
 		variant:  "vcs.github.release",
-		headline: fmt.Sprintf("%s published a release", ghActorCard(ev.Sender)),
+		headline: fmt.Sprintf("%s %s a release", ghActorCard(ev.Sender), escapeCardText(verb, cardActorMax)),
 		subtitle: escapeCardText(ev.Repository.FullName, cardTitleMax),
 		lines:    []string{escapeCardText(title, cardTitleMax)},
 		url:      httpURLForCard(ev.Release.HTMLURL),

--- a/modules/incomingwebhook/adapter_github_test.go
+++ b/modules/incomingwebhook/adapter_github_test.go
@@ -171,8 +171,26 @@ func TestParseGitHubPush_PullRequest(t *testing.T) {
 		require.NotNil(t, req)
 		assert.Contains(t, req.Content, "closed pull request")
 	})
-	t.Run("synchronize is skipped", func(t *testing.T) {
-		req, skip, invalid := parseGitHubPush(ghHeader("pull_request"), []byte(fmt.Sprintf(tpl, "synchronize", false)))
+	t.Run("synchronize is rendered (no longer filtered)", func(t *testing.T) {
+		req, _, _ := parseGitHubPush(ghHeader("pull_request"), []byte(fmt.Sprintf(tpl, "synchronize", false)))
+		require.NotNil(t, req)
+		assert.Contains(t, req.Content, "**carol** pushed new commits to pull request [#12 Add feature](https://github.com/o/r/pull/12)")
+	})
+	t.Run("truly unknown action falls back to the raw value", func(t *testing.T) {
+		// `_` is escaped by mdInertText like any other external field (expected).
+		req, _, _ := parseGitHubPush(ghHeader("pull_request"), []byte(fmt.Sprintf(tpl, "auto_merge_enabled", false)))
+		require.NotNil(t, req)
+		assert.Contains(t, req.Content, `**carol** auto\_merge\_enabled pull request`)
+	})
+	t.Run("hostile unknown action is escaped, not rendered live (trust-boundary)", func(t *testing.T) {
+		req, _, _ := parseGitHubPush(ghHeader("pull_request"), []byte(fmt.Sprintf(tpl, "**pwn** [x](http://evil.example)", false)))
+		require.NotNil(t, req)
+		assert.Contains(t, req.Content, `\*\*pwn\*\* \[x\](http://evil.example)`,
+			"markdown metacharacters in an unmapped action must be escaped")
+	})
+	t.Run("missing action is still skipped (malformed payload)", func(t *testing.T) {
+		body := `{"pull_request":{"number":12,"title":"Add feature","html_url":"https://github.com/o/r/pull/12"},"sender":{"login":"carol"}}`
+		req, skip, invalid := parseGitHubPush(ghHeader("pull_request"), []byte(body))
 		assert.Nil(t, req)
 		assert.Equal(t, "event", skip)
 		assert.Empty(t, invalid)
@@ -186,8 +204,20 @@ func TestParseGitHubPush_IssuesAndComments(t *testing.T) {
 		require.NotNil(t, req)
 		assert.Contains(t, req.Content, "**dan** opened issue [#3 Bug](https://github.com/o/r/issues/3)")
 	})
-	t.Run("issue labeled is skipped", func(t *testing.T) {
-		body := `{"action":"labeled","issue":{"number":3,"title":"Bug"},"sender":{"login":"dan"}}`
+	t.Run("issue labeled is rendered (no longer filtered)", func(t *testing.T) {
+		body := `{"action":"labeled","issue":{"number":3,"title":"Bug","html_url":"https://github.com/o/r/issues/3"},"sender":{"login":"dan"}}`
+		req, _, _ := parseGitHubPush(ghHeader("issues"), []byte(body))
+		require.NotNil(t, req)
+		assert.Contains(t, req.Content, "**dan** labeled issue [#3 Bug](https://github.com/o/r/issues/3)")
+	})
+	t.Run("hostile unknown issue action is escaped (trust-boundary)", func(t *testing.T) {
+		body := `{"action":"**pwn** [x](http://evil.example)","issue":{"number":3,"title":"Bug","html_url":"https://github.com/o/r/issues/3"},"sender":{"login":"dan"}}`
+		req, _, _ := parseGitHubPush(ghHeader("issues"), []byte(body))
+		require.NotNil(t, req)
+		assert.Contains(t, req.Content, `\*\*pwn\*\* \[x\](http://evil.example)`)
+	})
+	t.Run("missing issue action is still skipped (malformed payload)", func(t *testing.T) {
+		body := `{"issue":{"number":3,"title":"Bug"},"sender":{"login":"dan"}}`
 		req, skip, _ := parseGitHubPush(ghHeader("issues"), []byte(body))
 		assert.Nil(t, req)
 		assert.Equal(t, "event", skip)
@@ -202,8 +232,22 @@ func TestParseGitHubPush_IssuesAndComments(t *testing.T) {
 		assert.Contains(t, req.Content, "**eve** commented on [#3 Bug](https://github.com/o/r/issues/3#c1)")
 		assert.Contains(t, req.Content, "> line one line two", "comment body is flattened to one line")
 	})
-	t.Run("comment edited is skipped", func(t *testing.T) {
-		body := `{"action":"edited","issue":{"number":3},"comment":{"body":"x"},"sender":{"login":"eve"}}`
+	t.Run("comment edited is rendered (no longer filtered)", func(t *testing.T) {
+		body := `{"action":"edited","issue":{"number":3,"title":"Bug"},"comment":{"html_url":"https://github.com/o/r/issues/3#c1","body":"x"},"sender":{"login":"eve"}}`
+		req, _, _ := parseGitHubPush(ghHeader("issue_comment"), []byte(body))
+		require.NotNil(t, req)
+		assert.Contains(t, req.Content, "**eve** edited a comment on [#3 Bug](https://github.com/o/r/issues/3#c1)")
+		assert.Contains(t, req.Content, "> x")
+	})
+	t.Run("comment deleted has no body to quote", func(t *testing.T) {
+		body := `{"action":"deleted","issue":{"number":3,"title":"Bug"},"comment":{"html_url":"https://github.com/o/r/issues/3#c1","body":"gone"},"sender":{"login":"eve"}}`
+		req, _, _ := parseGitHubPush(ghHeader("issue_comment"), []byte(body))
+		require.NotNil(t, req)
+		assert.Contains(t, req.Content, "**eve** deleted a comment on [#3 Bug](https://github.com/o/r/issues/3#c1)")
+		assert.NotContains(t, req.Content, "gone", "a deleted comment's body is not meaningful to quote")
+	})
+	t.Run("missing comment action is still skipped (malformed payload)", func(t *testing.T) {
+		body := `{"issue":{"number":3},"comment":{"body":"x"},"sender":{"login":"eve"}}`
 		req, skip, _ := parseGitHubPush(ghHeader("issue_comment"), []byte(body))
 		assert.Nil(t, req)
 		assert.Equal(t, "event", skip)
@@ -223,11 +267,46 @@ func TestParseGitHubPush_Release(t *testing.T) {
 		require.NotNil(t, req)
 		assert.Contains(t, req.Content, "[v2.0.0](u)")
 	})
-	t.Run("created is skipped", func(t *testing.T) {
-		body := `{"action":"created","release":{"tag_name":"v2.0.0"},"sender":{"login":"fred"}}`
+	t.Run("created is rendered (no longer filtered)", func(t *testing.T) {
+		body := `{"action":"created","release":{"tag_name":"v2.0.0","html_url":"u"},"sender":{"login":"fred"}}`
+		req, _, _ := parseGitHubPush(ghHeader("release"), []byte(body))
+		require.NotNil(t, req)
+		assert.Contains(t, req.Content, "**fred** created release [v2.0.0](u)")
+	})
+	t.Run("hostile unknown release action is escaped (trust-boundary)", func(t *testing.T) {
+		body := `{"action":"**pwn** [x](http://evil.example)","release":{"tag_name":"v2.0.0","html_url":"u"},"sender":{"login":"fred"}}`
+		req, _, _ := parseGitHubPush(ghHeader("release"), []byte(body))
+		require.NotNil(t, req)
+		assert.Contains(t, req.Content, `\*\*pwn\*\* \[x\](http://evil.example)`)
+	})
+	t.Run("missing release action is still skipped (malformed payload)", func(t *testing.T) {
+		body := `{"release":{"tag_name":"v2.0.0"},"sender":{"login":"fred"}}`
 		req, skip, _ := parseGitHubPush(ghHeader("release"), []byte(body))
 		assert.Nil(t, req)
 		assert.Equal(t, "event", skip)
+	})
+}
+
+// GitHub sender.login / repository.full_name were historically un-escaped on the
+// assumption GitHub's restricted charset makes them injection-free — but this
+// endpoint only verifies a shared URL token, not that the payload is genuinely from
+// GitHub, so a token holder can set either field to anything. Same trust-boundary
+// class as GitLab's glActor/glWithRepo fix (GitLab #610 review, yujiawei); closed
+// here for GitHub parity.
+func TestParseGitHubPush_ActorAndRepoNameEscaped(t *testing.T) {
+	t.Run("hostile sender login", func(t *testing.T) {
+		body := `{"ref":"refs/heads/main","commits":[{"id":"abc","message":"m","url":"u"}],
+			"repository":{"full_name":"o/r"},"sender":{"login":"**evil** [x](http://attacker)"}}`
+		req, _, _ := parseGitHubPush(ghHeader("push"), []byte(body))
+		require.NotNil(t, req)
+		assert.Contains(t, req.Content, `\*\*evil\*\* \[x\](http://attacker)`)
+	})
+	t.Run("hostile repository full_name", func(t *testing.T) {
+		body := `{"ref":"refs/heads/main","commits":[{"id":"abc","message":"m","url":"u"}],
+			"repository":{"full_name":"**evil** [x](http://attacker)","html_url":"https://github.com/o/r"},"sender":{"login":"a"}}`
+		req, _, _ := parseGitHubPush(ghHeader("push"), []byte(body))
+		require.NotNil(t, req)
+		assert.Contains(t, req.Content, `\*\*evil\*\* \[x\](http://attacker)`)
 	})
 }
 

--- a/modules/incomingwebhook/adapter_github_test.go
+++ b/modules/incomingwebhook/adapter_github_test.go
@@ -176,6 +176,16 @@ func TestParseGitHubPush_PullRequest(t *testing.T) {
 		require.NotNil(t, req)
 		assert.Contains(t, req.Content, "**carol** pushed new commits to pull request [#12 Add feature](https://github.com/o/r/pull/12)")
 	})
+	t.Run("ready_for_review reads naturally (object mid-phrase, not appended)", func(t *testing.T) {
+		req, _, _ := parseGitHubPush(ghHeader("pull_request"), []byte(fmt.Sprintf(tpl, "ready_for_review", false)))
+		require.NotNil(t, req)
+		assert.Contains(t, req.Content, "**carol** marked pull request [#12 Add feature](https://github.com/o/r/pull/12) ready for review")
+	})
+	t.Run("converted_to_draft reads naturally (object mid-phrase, not appended)", func(t *testing.T) {
+		req, _, _ := parseGitHubPush(ghHeader("pull_request"), []byte(fmt.Sprintf(tpl, "converted_to_draft", false)))
+		require.NotNil(t, req)
+		assert.Contains(t, req.Content, "**carol** converted pull request [#12 Add feature](https://github.com/o/r/pull/12) to draft")
+	})
 	t.Run("truly unknown action falls back to the raw value", func(t *testing.T) {
 		// `_` is escaped by mdInertText like any other external field (expected).
 		req, _, _ := parseGitHubPush(ghHeader("pull_request"), []byte(fmt.Sprintf(tpl, "auto_merge_enabled", false)))

--- a/modules/incomingwebhook/adapter_gitlab.go
+++ b/modules/incomingwebhook/adapter_gitlab.go
@@ -619,7 +619,7 @@ func buildGitLabIssueCard(ev *glIssueEvent, lang string) map[string]interface{} 
 // glLabelsFact builds the shared "Labels (N)" FactSet row for the MR/Issue cards
 // (nil when there is nothing to show — no labels, or every label title is blank —
 // so the caller omits the row entirely). Label titles are project-defined free text,
-// escaped/capped by the shared glCappedFactValue (same convention as the pipeline
+// escaped/capped by the shared cappedFactValue (same convention as the pipeline
 // card's Jobs fact); the count in the title reflects the real (non-blank) total, not
 // the truncated list.
 func glLabelsFact(title string, labels []glLabel) *vcsFact {
@@ -627,7 +627,7 @@ func glLabelsFact(title string, labels []glLabel) *vcsFact {
 	for i, l := range labels {
 		names[i] = l.Title
 	}
-	value, n := glCappedFactValue(names, maxRenderedLabels)
+	value, n := cappedFactValue(names, maxRenderedLabels)
 	if n == 0 {
 		return nil
 	}
@@ -679,7 +679,7 @@ func buildGitLabPipelineCard(ev *glPipelineEvent, lang string) map[string]interf
 		for i, b := range ev.Builds {
 			names[i] = b.Name
 		}
-		if value, n := glCappedFactValue(names, maxRenderedJobs); n > 0 {
+		if value, n := cappedFactValue(names, maxRenderedJobs); n > 0 {
 			facts = append(facts, vcsFact{title: fmt.Sprintf("%s (%d)", labels.jobs, n), value: value})
 		}
 	}


### PR DESCRIPTION
## Summary

Mirrors #610 (`gitlab-mr-issue-cards`) for the GitHub adapter:

- `pull_request`/`issues` InteractiveCards gain a Source/Target branch (PR) + Labels(N) FactSet, parsing `pull_request.base/head.ref` and `pull_request`/`issue.labels[]` (previously unparsed). Card-only; the plain-text degrade path is unchanged, so flag-off bytes stay identical to history.
- GitHub no longer filters `pull_request`/`issues`/`issue_comment`/`release` events by which action they carry (explicit product decision, mirroring the GitLab one — this branch was requested right after #610 merged, specifically to bring GitHub to parity). Every action now renders on both text and card paths, mapped to a readable verb where possible; unmapped/future action values pass through raw. The only remaining skip is a malformed payload missing the `action` field.
- Applied the lesson from #610's review process **proactively** rather than discovering it via review again: every one of the 8 new verb-interpolation sites (4 text via `mdInertText`, 4 card via `escapeCardText`) was escaped in this same commit, verified by enumerating and grepping every call site before running tests.
- Folded in a pre-existing, previously-unfixed escaping gap: `ghLogin`/`ghWithRepo` (GitHub's structural twin of GitLab's `glActor`/`glWithRepo`, which #610 already fixed) now escape `sender.login`/`repository.full_name`. `push`/tag rendering gets this fix for free since these are shared helpers.
- Mechanical rename: `glCappedFactValue` → `cappedFactValue` (shared `adapter_card.go` infra), since GitHub's new Labels fact now calls it too and the GitLab-specific prefix would be misleading.

## Related Issue

N/A — direct follow-up to #610, user-requested immediately after that PR merged.

## Linked Spec

`.octospec/tasks/github-webhook-parity/brief.md`. Journal: `.octospec/journal/shared/github-webhook-parity.md`. Mirrors `.octospec/tasks/gitlab-mr-issue-cards/brief.md` and applies its pending learning (`.octospec/learnings/pending/gitlab-mr-issue-cards-whitelist-gate-sanitizer.md`).

## Changes

- `modules/incomingwebhook/adapter_github.go`:
  - `ghPullRequestEvent`/`ghIssuesEvent` parse `base.ref`/`head.ref`/`labels[]`; new `ghLabel` type.
  - `buildGitHubPullRequestCard`/`buildGitHubIssuesCard` add the Source/Target/Labels FactSet rows via the new `ghLabelsFact` helper.
  - New `ghPRVerb`/`ghIssueVerb`/`ghCommentVerb`/`ghReleaseVerb` action→verb mappers replace the closed-whitelist switches; each documents the same "raw-passthrough, caller must escape" contract as GitLab's `glActionVerb`.
  - `ghLogin`/`ghWithRepo` now escape via `mdInertText` (were previously raw).
- `modules/incomingwebhook/adapter_card.go`: `glCappedFactValue` → `cappedFactValue` rename (no behavior change).
- `modules/incomingwebhook/README.md`: updated the GitHub event table to match.
- Tests: hostile-action regression tests (text + card, PR/Issues/Release) using the same hostile payload shape as #610; hostile-login/repo-name regression tests (text path); Source/Target/Labels FactSet coverage; updated tests that previously asserted old "action X is skipped" behavior.

## Testing

- [x] Unit tests added/updated
- [x] Manually verified (throwaway test dumping actual rendered output for realistic PR/issue payloads, both text and card paths)

```
go test ./modules/incomingwebhook/... -run 'TestParseGitHubPush|TestParseGitLabPush|TestBuildGitHub|TestBuildGitLab|TestAllVCSCardBuilders|TestVCSCard|TestVCSPushReq|TestVCSParse|TestVCSViewLabel|TestFormatPipelineDuration|TestGlLabelsFact|TestNeutralizeLeadingBlockMarker'
# ok

gofmt -l modules/incomingwebhook/*.go   # clean
go vet ./modules/incomingwebhook/...     # clean
golangci-lint run ./modules/incomingwebhook/...  # 0 issues
make i18n-lint                           # OK (no error-code changes)
```

## COMPREHENSION

1. **What does this change actually do to the load-bearing path?** Widens which GitHub webhook events reach chat delivery (previously ~4 PR actions, 3 issue actions, 1 comment action, 1 release action rendered; now all of them do), and adds structured fields to two of the five InteractiveCard variants. Changes 4 action-string fields from closed whitelists (each only ever returning a handful of safe literals) to open passthroughs — the escaping fix is necessary because the mapper functions' return values are no longer trustworthy by construction, only by the explicit `mdInertText`/`escapeCardText` calls at each of the 8 call sites. Also closes a separate, pre-existing gap (`ghLogin`/`ghWithRepo`) unrelated to the filter removal but touched in the same pass.

2. **What could break because of it (dependents + failure mode)?** Same message-volume tradeoff as #610: a repo with active PRs now emits a message per `synchronize`/`labeled`/etc., not just open/close/merge. This is the explicitly accepted tradeoff from the GitLab decision, applied consistently. Security-wise: the escaping fixes prevent forged markdown/links via `action` fields and `sender.login`/`repository.full_name` — all attacker-influencable, since this endpoint (like GitLab's) only checks a shared URL token and does not enforce `X-Hub-Signature-256`. No wire-contract/response-shape change; `handlePush`/`vcsPushReq`/the flag-gate dispatch are untouched.

3. **How do you know it works (specific test/repro/trace)?** `TestParseGitHubPush_PullRequest/hostile_unknown_action_is_escaped...`, the `_IssuesAndComments`/`_Release` equivalents, and `TestBuildGitHubPullRequestCard_Facts`/`TestBuildGitHubIssuesCard_Facts`'s hostile-action-in-headline subtests assert the exact escaped string appears (never a live link/emphasis), on both text and card paths. `TestParseGitHubPush_ActorAndRepoNameEscaped` locks the `ghLogin`/`ghWithRepo` fix the same way GitLab's `TestParseGitLabPush_ActorUsernameEscaped` did. All pre-existing GitHub adapter/card tests still pass (updated where they asserted now-obsolete "action X is skipped" behavior).

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] PR description is in English
- [x] Added tests for my changes
- [x] Updated documentation
- [x] Followed commit message conventions (Conventional Commits)

---
_Generated by [Claude Code](https://claude.ai/code/session_0145iGd54wRsXdZVbTcmG8nr)_