### PR TITLE
feat: add skill manager capabilities

### DIFF
--- a/modules/user/api_manager.go
+++ b/modules/user/api_manager.go
@@ -129,6 +129,8 @@ func (m *Manager) me(c *wkhttp.Context) {
 //   - space.read        = 空间/成员/邀请/入群申请 列表查询（requireAdmin）
 //   - space.write       = 建空间/改资料/加成员/邀请增改禁用/通过拒绝入群申请（requireAdmin，故恒 true）
 //   - space.destructive = 强制解散/封禁/强制移除/改成员角色（requireSuperAdmin）
+//   - skill.read        = 系统 Skill 列表/详情查看（requireSuperAdmin）
+//   - skill.write       = 系统 Skill 创建/编辑/删除/分类管理（requireSuperAdmin）
 //   - mcp.read          = 系统 MCP 列表/详情查看（requireSuperAdmin）
 //   - mcp.write         = 系统 MCP 创建/编辑/删除（requireSuperAdmin）
 //
@@ -145,6 +147,8 @@ func managerCapabilities(isSuper bool) map[string]bool {
 		"users.write":        isSuper, // 重置密码 / 新增用户 / 解封 / 改密
 		"users.manage_admin": isSuper, // 管理员账号 增/查/删
 		"groups.write":       isSuper, // 解散封禁群 / 强制移除成员
+		"skill.read":         isSuper, // 系统 Skill 列表/详情（marketplace admin surface）
+		"skill.write":        isSuper, // 系统 Skill 创建/编辑/删除/分类管理（marketplace admin surface）
 		"mcp.read":           isSuper, // 系统 MCP 列表/详情（marketplace admin surface 只认共享 X-Admin-Token 不分 role，此处收窄到超管以缩小页面暴露面）
 		"mcp.write":          isSuper, // 系统 MCP 创建/编辑/删除（同上）
 		// admin ∪ superAdmin（此处恒 true，列出供前端统一读取）

--- a/modules/user/api_manager_me_test.go
+++ b/modules/user/api_manager_me_test.go
@@ -22,7 +22,7 @@ func TestManagerCapabilities(t *testing.T) {
 
 	superOnly := []string{
 		"system_setting", "backup", "appversion.write", "dashboard.trigger", "space.destructive",
-		"users.write", "users.manage_admin", "groups.write", "mcp.write", "mcp.read",
+		"users.write", "users.manage_admin", "groups.write", "skill.write", "skill.read", "mcp.write", "mcp.read",
 	}
 	adminTier := []string{
 		"appversion.read", "dashboard.read", "users.read", "groups.read", "space.read", "space.write",
@@ -119,6 +119,8 @@ func TestManagerMe_AdminGetsReadCapsNotWrite(t *testing.T) {
 	assert.False(t, resp.Capabilities["users.manage_admin"], "admin must NOT have users.manage_admin")
 	assert.False(t, resp.Capabilities["groups.write"], "admin must NOT have groups.write")
 	assert.False(t, resp.Capabilities["space.destructive"], "admin must NOT have space.destructive")
+	assert.False(t, resp.Capabilities["skill.read"], "admin must NOT have skill.read (system Skill list/detail is superAdmin-only)")
+	assert.False(t, resp.Capabilities["skill.write"], "admin must NOT have skill.write (system Skill create/edit/delete/category management)")
 	assert.False(t, resp.Capabilities["mcp.read"], "admin must NOT have mcp.read (system MCP list/detail is superAdmin-only)")
 	assert.False(t, resp.Capabilities["mcp.write"], "admin must NOT have mcp.write (system MCP create/edit/delete)")
 	assert.False(t, resp.Capabilities["system_setting"], "admin must NOT have system_setting")
@@ -142,6 +144,8 @@ func TestManagerMe_SuperAdminGetsWriteCaps(t *testing.T) {
 	assert.True(t, resp.Capabilities["groups.write"], "superAdmin should have groups.write")
 	assert.True(t, resp.Capabilities["system_setting"], "superAdmin should have system_setting")
 	assert.True(t, resp.Capabilities["users.read"], "superAdmin should have users.read")
+	assert.True(t, resp.Capabilities["skill.write"], "superAdmin should have skill.write")
+	assert.True(t, resp.Capabilities["skill.read"], "superAdmin should have skill.read")
 	assert.True(t, resp.Capabilities["mcp.write"], "superAdmin should have mcp.write")
 	assert.True(t, resp.Capabilities["mcp.read"], "superAdmin should have mcp.read")
 }


### PR DESCRIPTION
## Summary

- Expose `skill.read` and `skill.write` in `/v1/manager/me` capabilities.
- Keep Skill marketplace capabilities aligned with MCP marketplace capabilities as superAdmin-only.
- Extend manager capability tests to cover ordinary admin and superAdmin Skill permissions.

## Linked Spec

- Closes #620
- Related frontend work: Mininglamp-OSS/octo-web#926

## How verified

- `go env -w GOPROXY=https://goproxy.cn,direct` was applied locally so Go modules can download through the China-accessible proxy.
- Passed: `go test ./modules/user -run 'TestManagerCapabilities|TestManagerMe'`.
- Local test setup note: the Docker MySQL `octo-marketplace-mysql-1` root password was temporarily changed from `root` to the testutil-required `demo`, a temporary `test` schema was created with `utf8mb4_general_ci`, then the root password was restored to `root` and the temporary schema was dropped after the test run.

## COMPREHENSION

1. **What does this change actually do** to the load-bearing path?

   `/v1/manager/me` now returns two additional capability keys, `skill.read` and `skill.write`. Before this PR, the backend capability contract exposed MCP marketplace permissions but had no Skill marketplace permissions. After this PR, Skill list/detail and Skill create/edit/delete/category management can be feature-detected by octo-admin from the same manager capability map. Both keys are true only for superAdmin and false for ordinary admin.

2. **What could break** because of it (dependents + failure mode)?

   The direct dependent is octo-admin capability-based rendering for the Skill marketplace. Wrong key names would leave the UI hidden or disabled even for superAdmin. Wrong role gating would either expose Skill marketplace controls to ordinary admin or hide them from superAdmin. Existing manager capability consumers should tolerate the additive keys, but frontend code that assumes an exact capability set would need to ignore unknown entries.

3. **How do you know it works** (specific test/repro/trace)?

   `go test ./modules/user -run 'TestManagerCapabilities|TestManagerMe'` passed locally. The covered tests include `TestManagerCapabilities`, `TestManagerMe_AdminGetsReadCapsNotWrite`, and `TestManagerMe_SuperAdminGetsWriteCaps`, which assert the new Skill capability keys are false for ordinary admin and true for superAdmin.