### PR TITLE
fix(cardaction): defer route_missing dispatch, make DLQ retention configurable

### DIFF
--- a/.octospec/journal/shared/route-missing-retry.md
+++ b/.octospec/journal/shared/route-missing-retry.md
@@ -161,3 +161,26 @@ folded into a second follow-up commit.
 was a misread — `observeError` sits *above* the expiry gate, so it does fire per re-check and the
 doc is correct. yujiawei's `acted_at` type-assertion note is verified safe (same in-memory map, no
 JSON round-trip). The "summary says 7d" note was already fixed by the PR-body update.
+
+## Review round 3 (re-review of the first-miss marker)
+
+6. **`route_missing_since` marker leaked** (Jerry-Xin, Critical). The round-2 marker is one shared
+   Redis hash with a whole-hash `PEXPIRE`. Redis has no per-field TTL, and every miss refreshes the
+   hash TTL, so under sustained route-missing traffic (a route absent across a rolling deploy touches
+   many events) the key never expires and a field per COMPLETED event accumulates forever — the
+   marker was only cleared on `ReplayDLQ`, not on `Ack` or terminal `Nack`. My round-2 comment's
+   "self-reaps via TTL" claim was wrong. **Fix:** `HDEL` the marker on every exit transition —
+   `ackScript` (delivery) and `nackScript` (one `HDEL` after the token check, covering both the
+   requeue and dead-letter branches); `replayDLQScript` already cleared it. Both `Ack` and `Nack`
+   invoke the script with `q.scriptKeys()`, so `KEYS[9]` (the marker hash) is in scope. New
+   Redis-backed lifecycle test `TestRouteMissingMarkerClearedOnTerminalTransitions` proves the field
+   is gone after Ack and after terminal dead-letter. Validated against a real local Redis — all
+   Redis-backed tests plus the existing lease/ack/nack/replay contract tests pass, so the added
+   `HDEL`s don't regress the transition contract. Octo-Q flagged the same field but as a non-blocking
+   nit ("self-reaps via TTL; event IDs never recur"); it under-weighted the whole-hash-TTL-refresh
+   interaction, so Jerry-Xin's blocking call was the correct one.
+
+**Round-3 non-blocking, fixed in the same commit** (both doc drift from earlier deltas): the
+`card-action-dlq` CLI comment still said replay "refuses (and prunes)" — corrected to non-destructive;
+the pending learning still prescribed an `ActedAt`-based deadline — rewritten to the first-observed-miss
+design plus a new point on per-item marker lifecycle vs whole-key TTL.

--- a/.octospec/journal/shared/route-missing-retry.md
+++ b/.octospec/journal/shared/route-missing-retry.md
@@ -1,0 +1,95 @@
+---
+type: Journal
+title: "Journal: route-missing-retry"
+description: Card-action dispatch now retries a route_missing (bounded) instead of dead-lettering it on the first attempt, so a config-divergence window across a restart self-heals.
+tags: ["card", "dispatch", "reliability", "dlq", "testing"]
+timestamp: 2026-07-20T16:30:00+08:00
+# --- octospec extension fields ---
+task: route-missing-retry
+source: self
+---
+
+# Journal: route-missing-retry
+
+## What was done
+
+`internal/cardactiondispatch/dispatcher.go` — in `ProcessOne`, the `route_missing`
+branch (route not found in the registry for `{sender_uid, owner, action_type}`) no
+longer dead-letters on the first attempt. It now **defers** the event:
+
+- Old: `d.nack(*lease, now, false, lease.Attempt, "route_missing")` — `retry=false`
+  forces `maxAttempts = lease.Attempt`, so `queue.Nack` dead-letters immediately.
+- New: within `routeMissingMaxWindow` (15m of `Event.ActedAt`), `d.queue.Defer(eventID,
+  token, now+routeMissingDeferInterval)` — re-checks every `routeMissingDeferInterval`
+  (5s) **without consuming an attempt**, mirroring the `max_in_flight` capacity-defer path.
+  Past the window it dead-letters via `d.nack(..., false, ...)` (`reason=route_missing`).
+- Added `routeMissingMaxWindow`, `routeMissingDeferInterval`, and `routeMissingExpired`.
+
+**Why defer, not a bounded nack (the first cut):** the first implementation nacked with
+a capped-exponential backoff up to a `routeMissingMaxAttempts=10` budget. An `xhigh`
+code review caught that this shares the SAME `lease.Attempt` counter as delivery: after
+more than `route.MaxAttempts` (default 5; configs use 3) route-missing retries, the event
+would hit the `attempts_exhausted` gate the moment its route returned — dead-lettered
+exactly when it became deliverable, and as `attempts_exhausted` not `route_missing`. So
+the self-heal window was really `route.MaxAttempts` (~seconds), not the advertised
+minutes. Deferring consumes no attempt, so the event delivers on its original budget
+whenever the route returns — the fix the change was meant to be.
+
+`internal/cardactiondispatch/route_missing_test.go` (new) — pins: early attempt requeues
+with a non-zero backoff against the bounded budget (not `lease.Attempt`); the final attempt
+still dead-letters with the reason preserved; `Deliver`/`Finalize` never run while the route
+is missing; `routeMissingBackoff` is positive, capped, monotonic.
+
+## Why (root cause)
+
+Single-replica prod symptom: docs approve/deny cards never updated. DLQ held events with
+reason `route_missing`, `attempt=1`, callback never invoked (no octo-docs-backend receipt,
+no downstream log). An event only enters this queue when its route existed at *enqueue* time
+(`Registry.Resolve` → `ResolutionCallback`); enqueue and dispatch share one in-process
+registry — so `route_missing` at dispatch means the registry changed between the two, i.e.
+a restart/redeploy came up before `OCTO_CARD_ACTION_ROUTES` had the route, while the durable
+Redis queue carried the event across that window. Immediate, non-retryable DLQ turned that
+transient window into permanent loss (and no self-heal), which read at the UI as "approve
+has no response."
+
+## Verification
+
+- Reproduced the pre-fix behavior against the real package (two registries — with/without
+  the route; enqueue under one, dispatch under the other) → `route_missing`, immediate DLQ,
+  `Deliver`/`Finalize` never called.
+- Tests (`route_missing_test.go`): `TestRouteMissingDefersWithoutConsumingAttempt` (fresh
+  event defers, is NOT nacked — the guard for the attempt-budget bug), 
+  `TestRouteMissingDeadLettersAfterWindow` (past the window → immediate DLQ, reason preserved),
+  `TestRouteMissingExpired` (window boundary + unset-timestamp guard). The defer test fails
+  against the nack-based first cut, so it pins the fix.
+- `go test ./internal/cardactiondispatch/` green; `go build ./...` clean; `go vet` +
+  `golangci-lint` clean.
+
+## Scope / residual
+
+- Forward-looking only: already-dead-lettered events are NOT resurrected by this change —
+  they need a manual DLQ replay.
+- Operational root cause (a run without `OCTO_CARD_ACTION_ROUTES` loaded) is config/deploy
+  hygiene, out of scope for this code change.
+- A genuinely unconfigured route still DLQs, just after `routeMissingMaxAttempts` (~a few
+  minutes) rather than on attempt 1 — deliberate trade of slightly-later DLQ visibility for
+  self-healing a transient window.
+
+## Learning
+
+Staged in `.octospec/learnings/pending/durable-queue-registry-divergence.md`: a durable,
+process-shared work queue combined with a per-process in-memory config table (built once at
+startup from env) can dead-letter valid work across a restart/rollout that changes the config;
+"transient config absence" should be a bounded retry, not a first-attempt DLQ.
+
+## Follow-up: DLQ retention is now configurable (default 7d)
+
+Same branch, separate concern. The DLQ retention was a hardcoded `30 * 24 * time.Hour`
+duplicated in `main.go` and `tools/card-action-dlq/main.go`. Replaced with a shared resolver
+`cardactiondispatch.DLQRetention(os.Getenv)` (in `config.go`) reading
+`OCTO_CARD_ACTION_DLQ_RETENTION_DAYS` (whole days, 1–365; empty/invalid → `DefaultDLQRetention`),
+and **changed the default 30 → 7 days**. Both binaries now share one resolver so they cannot
+drift (the CLI must match the running server, or it prunes/replays against a different window).
+Trade-off: dead-lettered events are recoverable for 7 days by default instead of 30 — set the
+env higher where a longer recovery window is wanted. Test: `dlq_retention_test.go`
+(`TestDLQRetentionFromEnv`). Doc updated: `docs/card-action-callback-dispatch.md`.

--- a/.octospec/journal/shared/route-missing-retry.md
+++ b/.octospec/journal/shared/route-missing-retry.md
@@ -35,10 +35,11 @@ the self-heal window was really `route.MaxAttempts` (~seconds), not the advertis
 minutes. Deferring consumes no attempt, so the event delivers on its original budget
 whenever the route returns — the fix the change was meant to be.
 
-`internal/cardactiondispatch/route_missing_test.go` (new) — pins: early attempt requeues
-with a non-zero backoff against the bounded budget (not `lease.Attempt`); the final attempt
-still dead-letters with the reason preserved; `Deliver`/`Finalize` never run while the route
-is missing; `routeMissingBackoff` is positive, capped, monotonic.
+`internal/cardactiondispatch/route_missing_test.go` (new) — pins: a fresh route-missing event
+**defers** and is NOT nacked (the guard against the attempt-budget bug); an event past
+`routeMissingMaxWindow` dead-letters immediately with the reason preserved; `Deliver`/`Finalize`
+never run while the route is missing; and `routeMissingExpired` covers the window boundary plus
+the unset/negative `ActedAt` guard.
 
 ## Why (root cause)
 
@@ -71,9 +72,9 @@ has no response."
   they need a manual DLQ replay.
 - Operational root cause (a run without `OCTO_CARD_ACTION_ROUTES` loaded) is config/deploy
   hygiene, out of scope for this code change.
-- A genuinely unconfigured route still DLQs, just after `routeMissingMaxAttempts` (~a few
-  minutes) rather than on attempt 1 — deliberate trade of slightly-later DLQ visibility for
-  self-healing a transient window.
+- A genuinely unconfigured route still DLQs, just after `routeMissingMaxWindow` (15m) rather
+  than on attempt 1 — deliberate trade of slightly-later DLQ visibility for self-healing a
+  transient window.
 
 ## Learning
 
@@ -82,14 +83,47 @@ process-shared work queue combined with a per-process in-memory config table (bu
 startup from env) can dead-letter valid work across a restart/rollout that changes the config;
 "transient config absence" should be a bounded retry, not a first-attempt DLQ.
 
-## Follow-up: DLQ retention is now configurable (default 7d)
+## Follow-up: DLQ retention is now configurable (default 30d, opt into shorter)
 
 Same branch, separate concern. The DLQ retention was a hardcoded `30 * 24 * time.Hour`
 duplicated in `main.go` and `tools/card-action-dlq/main.go`. Replaced with a shared resolver
-`cardactiondispatch.DLQRetention(os.Getenv)` (in `config.go`) reading
-`OCTO_CARD_ACTION_DLQ_RETENTION_DAYS` (whole days, 1–365; empty/invalid → `DefaultDLQRetention`),
-and **changed the default 30 → 7 days**. Both binaries now share one resolver so they cannot
-drift (the CLI must match the running server, or it prunes/replays against a different window).
-Trade-off: dead-lettered events are recoverable for 7 days by default instead of 30 — set the
-env higher where a longer recovery window is wanted. Test: `dlq_retention_test.go`
-(`TestDLQRetentionFromEnv`). Doc updated: `docs/card-action-callback-dispatch.md`.
+`cardactiondispatch.DLQRetentionFromEnv(os.Getenv)` (in `config.go`) reading
+`OCTO_CARD_ACTION_DLQ_RETENTION_DAYS` (whole days, 1–365; empty/invalid → `DefaultDLQRetention`).
+Both binaries share the one resolver so the CODE value cannot drift. `DefaultDLQRetention` stays
+**30 days** — the value the code already shipped with — so an upgrade that does not set the
+override keeps the existing recovery window and never silently prunes older DLQ entries on first
+deploy. Opt into a shorter window (e.g. `7`) per deployment via the env var. Test:
+`dlq_retention_test.go` (`TestDLQRetentionFromEnv`). Doc updated: `docs/card-action-callback-dispatch.md`.
+
+## Review round (PR #621, 4 reviewers)
+
+The PR drew four independent reviews (lml2468 APPROVE, then Jerry-Xin, mochashanyao/Octo-Q, and
+yujiawei CHANGES_REQUESTED). Three blocking corrections, all folded into this branch as a
+follow-up commit; the metric-noise nit was intentionally left as-is.
+
+1. **route_missing with `ActedAt<=0` deferred forever** (Jerry-Xin Critical, yujiawei P2).
+   `routeMissingExpired` returned "not-expired" for a non-positive `ActedAt`, so a legacy/malformed
+   event with a missing route would re-defer every 5s indefinitely — never delivered, never
+   dead-lettered — silently breaking the bounded-window guarantee. The wait is bounded by
+   elapsed-since-`ActedAt`, and there is nothing to measure against when it is unset. **Fix:**
+   non-positive `ActedAt` is now EXPIRED → immediate dead-letter (`reason=route_missing`, visible
+   and replayable). Chose the runtime guard over an `Enqueue`-time guard because it also protects
+   events already sitting in the durable queue and avoids churning many test event builders.
+   New test: `TestRouteMissingZeroActedAtDeadLetters`; `TestRouteMissingExpired` flipped.
+
+2. **DLQ default 30→7d silently prunes on deploy** (Octo-Q P1, yujiawei P1 follow-up). The
+   configurability change had lowered the default to 7d; yujiawei traced that the *server itself*
+   (`refreshDepthMetrics → Depths → pruneDLQScript`, ~every 250ms) would irreversibly prune
+   8–30-day-old DLQ entries on the first event after deploy, no operator action needed. **Fix:**
+   restored `DefaultDLQRetention = 30d`; 7d (or any 1–365) remains available via the env var. The
+   user chose this over shipping 7d-with-a-warning.
+
+3. **CLI `depth` deletes on a read** (yujiawei P1). The read-only `depth` command called
+   `Depths()`, which prunes using retention resolved from the *CLI's* env — so inspecting the DLQ
+   from a shell without the server's env var could delete recoverable entries. **Fix:** new
+   `RedisQueue.DepthsNoPrune()` (ZCard only); `depth` uses it. The running server is now the sole
+   pruning authority. `main.go` also logs the raw override value so an invalid-→-fallback is visible.
+
+**Left as-is (documented, not a defect):** `observeError(route_missing)` fires once per 5s
+re-check while an event waits. That is intentional and documented in the runbook's alerting
+section; folding it to fire only on dead-letter would drop the "route currently missing" signal.

--- a/.octospec/journal/shared/route-missing-retry.md
+++ b/.octospec/journal/shared/route-missing-retry.md
@@ -110,6 +110,8 @@ follow-up commit; the metric-noise nit was intentionally left as-is.
    and replayable). Chose the runtime guard over an `Enqueue`-time guard because it also protects
    events already sitting in the durable queue and avoids churning many test event builders.
    New test: `TestRouteMissingZeroActedAtDeadLetters`; `TestRouteMissingExpired` flipped.
+   *(Superseded in review round 2 — the window was re-anchored on the first observed miss, which
+   removes the `ActedAt<=0` edge by construction; this test was replaced accordingly. See below.)*
 
 2. **DLQ default 30→7d silently prunes on deploy** (Octo-Q P1, yujiawei P1 follow-up). The
    configurability change had lowered the default to 7d; yujiawei traced that the *server itself*
@@ -127,3 +129,35 @@ follow-up commit; the metric-noise nit was intentionally left as-is.
 **Left as-is (documented, not a defect):** `observeError(route_missing)` fires once per 5s
 re-check while an event waits. That is intentional and documented in the runbook's alerting
 section; folding it to fire only on dead-letter would drop the "route currently missing" signal.
+
+## Review round 2 (re-reviews on the fixed head)
+
+The re-reviews confirmed round 1's three fixes and surfaced two more blocking corrections, both
+folded into a second follow-up commit.
+
+4. **Window anchored on `ActedAt`, not first-miss** (Jerry-Xin, Critical). The 15-minute window
+   was measured from `Event.ActedAt` (when the user acted), so an event that dwelt in the durable
+   queue past the window before its FIRST dispatch attempt — a long restart / outage / backlog,
+   exactly the window this feature guards — got **zero** self-heal window and dead-lettered on its
+   first miss. **Fix:** anchor the window on the FIRST observed miss. A durable per-event marker
+   (Redis hash `route_missing_since`, `HSETNX`-then-read, TTL = live TTL) is written/read by
+   `RedisQueue.RouteMissingSeenAt`; the dispatcher measures `now - firstSeen` and `routeMissingExpired`
+   now takes that `firstSeen` time. This **supersedes** round 1's `ActedAt<=0` special-case: `ActedAt`
+   is no longer consulted for the window, the marker is always a real stamp, so the unset-timestamp
+   edge and the permanent-defer wedge are gone by construction. `ReplayDLQ` clears the marker so a
+   replayed event starts a fresh window. Tests: `TestRouteMissingOldActedAtDefersOnFirstMiss`
+   (old `ActedAt`, first miss → defer — the exact case Jerry-Xin asked for),
+   `TestRouteMissingSeenAtAnchorsOnFirstMiss` (Redis: marker stable across calls, cleared on replay).
+
+5. **`replay` silently deletes a server-retained entry** (yujiawei, P1). `replayDLQScript`'s expiry
+   branch deleted an entry older than the CLI's *own* resolved retention before returning 0 ("not
+   present"), so a CLI whose window was shorter than the server's could destroy a recoverable entry —
+   the same destructive-tool class `DepthsNoPrune` fixed for `depth`. **Fix:** the expiry branch now
+   just `return 0` — no delete; the running server's `Depths()` prune is the single pruning authority.
+   Test: `TestReplayDLQPastRetentionIsNonDestructive` (Redis: refused replay leaves the entry, a
+   within-window replay then succeeds).
+
+**Round-2 non-blocking, no code change:** Octo-Q's "metric fires once per event, not per re-check"
+was a misread — `observeError` sits *above* the expiry gate, so it does fire per re-check and the
+doc is correct. yujiawei's `acted_at` type-assertion note is verified safe (same in-memory map, no
+JSON round-trip). The "summary says 7d" note was already fixed by the PR-body update.

--- a/.octospec/learnings/pending/durable-queue-registry-divergence.md
+++ b/.octospec/learnings/pending/durable-queue-registry-divergence.md
@@ -50,12 +50,21 @@ startup** (env, in-memory registry, feature flags):
 5. **A per-process config table + a cross-process durable queue is a divergence source by
    construction** — enqueue and dispatch can run under different config even on one replica
    (across a restart) and trivially across replicas/rollouts. Design the consumer to tolerate it.
-6. **A bounded "wait it out" needs a trustworthy clock; if the item lacks the field the window
-   is measured against, dead-letter immediately — don't defer.** The bound here is elapsed time
-   since the event's `ActedAt`; an item with `ActedAt<=0` (legacy/malformed, and enqueue didn't
-   validate it) has nothing to measure against, so "not expired yet" is true on every re-check and
-   the item defers forever — never delivered, never dead-lettered — the exact permanent-loss the
-   defer was meant to prevent, now silent. Treat "can't evaluate the deadline" as *past* the
-   deadline (fail toward the visible DLQ), and prefer a runtime guard over an enqueue guard when
-   items may already be sitting in the durable queue. (PR #621 review caught this; the first defer
-   cut returned not-expired for a missing timestamp.)
+6. **Anchor a bounded "wait it out" on when the WAIT started, recorded per item — not on a
+   business timestamp like acted-at.** The window here bounds "how long we wait on a missing
+   route." Measuring it from `Event.ActedAt` (when the user acted) is wrong: an item can be far
+   older than the window for reasons unrelated to the wait — queue backlog, an outage, redelivery
+   — so on its FIRST miss `now - ActedAt` already exceeds the window and it dead-letters with zero
+   self-heal, exactly in the long-outage/rollout case the wait was meant to cover. And a missing or
+   zero acted-at has nothing to measure against at all (a permanent-defer wedge). The robust design
+   is a durable per-item marker written when the wait first begins (first observed miss) and read on
+   every re-check; the window is `now - firstSeen`. That needs no business timestamp and no
+   special-case for legacy/zero values.
+7. **A per-item marker in a shared structure needs explicit lifecycle cleanup — a whole-key TTL is
+   not per-field GC.** The first-miss marker lived as a field in one Redis hash with a hash-level
+   `PEXPIRE`. Redis cannot expire individual fields, and every new miss refreshed the whole-hash
+   TTL, so under sustained traffic the key never expired and a field-per-item leaked for every
+   completed event. Delete the marker on EVERY exit transition (success, terminal dead-letter,
+   replay); keep the TTL only as a backstop that reaps the key once activity stops. (PR #621 walked
+   this exact path across review rounds: acted-at anchor → zero-acted-at special-case → first-miss
+   marker → marker-lifecycle cleanup, each step caught by a reviewer.)

--- a/.octospec/learnings/pending/durable-queue-registry-divergence.md
+++ b/.octospec/learnings/pending/durable-queue-registry-divergence.md
@@ -50,3 +50,12 @@ startup** (env, in-memory registry, feature flags):
 5. **A per-process config table + a cross-process durable queue is a divergence source by
    construction** — enqueue and dispatch can run under different config even on one replica
    (across a restart) and trivially across replicas/rollouts. Design the consumer to tolerate it.
+6. **A bounded "wait it out" needs a trustworthy clock; if the item lacks the field the window
+   is measured against, dead-letter immediately — don't defer.** The bound here is elapsed time
+   since the event's `ActedAt`; an item with `ActedAt<=0` (legacy/malformed, and enqueue didn't
+   validate it) has nothing to measure against, so "not expired yet" is true on every re-check and
+   the item defers forever — never delivered, never dead-lettered — the exact permanent-loss the
+   defer was meant to prevent, now silent. Treat "can't evaluate the deadline" as *past* the
+   deadline (fail toward the visible DLQ), and prefer a runtime guard over an enqueue guard when
+   items may already be sitting in the durable queue. (PR #621 review caught this; the first defer
+   cut returned not-expired for a missing timestamp.)

--- a/.octospec/learnings/pending/durable-queue-registry-divergence.md
+++ b/.octospec/learnings/pending/durable-queue-registry-divergence.md
@@ -1,0 +1,52 @@
+---
+type: Learning
+title: "A durable queue + a per-process in-memory config table can dead-letter valid work across a restart"
+description: When work outlives the process but routing/config is built once from env at startup, a config-divergent restart makes the consumer reject valid queued work; treat 'config absent' as a bounded retry, not a first-attempt DLQ.
+tags: ["reliability", "dispatch", "queue", "dlq", "config", "review"]
+timestamp: 2026-07-20T16:30:00+08:00
+# --- octospec extension fields ---
+source: self
+origin_task: route-missing-retry
+origin_pr: Mininglamp-OSS/octo-server (branch claude/docs-access-request-allow-no-response-69whvw)
+status: pending
+candidate_rule: dispatch-reliability
+---
+
+# A durable queue + a per-process in-memory config table can dead-letter valid work across a restart
+
+## Context
+`internal/cardactiondispatch` persists card-action events in a durable Redis queue but
+resolves the destination route from a per-process in-memory registry built once at startup
+from `OCTO_CARD_ACTION_ROUTES`. An event is only ever enqueued when the route is present
+(enqueue-time `Resolve` gate), yet the dispatcher rejected it with `route_missing` — because
+between enqueue and dispatch the process restarted into a run whose env had not (yet) loaded
+the route. The queue outlived the process; the config did not. The miss was then treated as a
+**permanent** error (`retry=false` → immediate DLQ), so a decision whose route existed moments
+later was lost with no self-heal — surfacing as "the button does nothing."
+
+This looked, in turn, like a grant failure, then a 401 secret mismatch, then a cross-pod
+divergence — all wrong. The DLQ reason field (`route_missing`) plus the "single replica" fact
+were what finally pinned it: same process, so enqueue-with-route and dispatch-without-route can
+only happen across a restart, carried by the durable queue.
+
+## Rule of thumb
+When a durable/shared work queue is consumed against config that is loaded **per process at
+startup** (env, in-memory registry, feature flags):
+
+1. **A "config/route not found" at consume time is usually TRANSIENT, not permanent** — the
+   item was accepted when the config *was* present, and a rollout / restart / not-yet-loaded
+   window is the common cause. Let it ride out the window (defer / re-check) so it processes
+   once the config returns; do not dead-letter on the first miss.
+2. **Wait WITHOUT spending the delivery-attempt budget.** Model "config not ready yet" as a
+   *defer* (no attempt consumed), not a *failed attempt* (a nack/retry). If waiting shares the
+   same attempt counter as real delivery, then once the config returns the item can be at (or
+   past) its max-attempts and get dead-lettered as `attempts_exhausted` the moment it became
+   processable — the opposite of self-healing. (This repo's first cut nacked with a bounded
+   backoff and an xhigh code review caught exactly this; the fix was to defer instead.)
+3. **Keep the DLQ as a real signal**: still dead-letter after a bounded window so a genuinely
+   removed/misconfigured route stays visible and alertable — just later, not on the first miss.
+4. **Delivery outcomes are diagnosable only if the failure reason is recorded** on the item
+   (here: the DLQ `reason` field). Preserve it verbatim.
+5. **A per-process config table + a cross-process durable queue is a divergence source by
+   construction** — enqueue and dispatch can run under different config even on one replica
+   (across a restart) and trivially across replicas/rollouts. Design the consumer to tolerate it.

--- a/.octospec/log.md
+++ b/.octospec/log.md
@@ -4,6 +4,31 @@ Change history for this repo's `.octospec/`, following the
 [OKF](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md)
 change-log convention (§7). Newest first.
 
+## 2026-07-20 (route-missing-retry)
+
+- **Fix** — Card-action dispatch (`internal/cardactiondispatch`) now **defers** a
+  `route_missing` at dispatch time (no attempt consumed) instead of dead-lettering on
+  the first attempt. An event only enters the queue when its route existed at enqueue
+  time, so a miss at dispatch means the process restarted into a run whose
+  `OCTO_CARD_ACTION_ROUTES` lacked the route while the durable queue carried the event
+  across — previously a permanent, non-self-healing DLQ that read at the UI as docs
+  approve/deny cards never updating. Deferring (rather than nacking) matters: a nack
+  spends `route.MaxAttempts`, so the event would trip `attempts_exhausted` the moment
+  its route returned. Within `routeMissingMaxWindow` (15m) the event waits and then
+  dispatches on its original attempt budget; past the window it dead-letters
+  (`reason=route_missing`) so a genuine misconfiguration stays visible. The attempt-budget
+  interaction was caught by an `xhigh` code review of the first (nack-based) cut. See
+  [brief](tasks/route-missing-retry/brief.md) · [journal](journal/shared/route-missing-retry.md).
+- **Learning (pending)** — `durable-queue-registry-divergence`: a durable/shared work
+  queue consumed against per-process, startup-loaded config can dead-letter valid work
+  across a config-divergent restart; treat "config absent at consume time" as a bounded
+  retry, not a first-attempt DLQ.
+- **Change (config)** — Card-action DLQ retention is now configurable via
+  `OCTO_CARD_ACTION_DLQ_RETENTION_DAYS` (whole days, 1–365) through a shared
+  `cardactiondispatch.DLQRetentionFromEnv` resolver used by both `main.go` and
+  `tools/card-action-dlq` (so they can't drift). **Default lowered 30 → 7 days**;
+  set the env higher for a longer recovery window. Doc updated.
+
 ## 2026-07-20 (github-webhook-parity)
 
 - **Feature** — GitHub `pull_request`/`issues` InteractiveCards gained

--- a/.octospec/log.md
+++ b/.octospec/log.md
@@ -26,8 +26,19 @@ change-log convention (§7). Newest first.
 - **Change (config)** — Card-action DLQ retention is now configurable via
   `OCTO_CARD_ACTION_DLQ_RETENTION_DAYS` (whole days, 1–365) through a shared
   `cardactiondispatch.DLQRetentionFromEnv` resolver used by both `main.go` and
-  `tools/card-action-dlq` (so they can't drift). **Default lowered 30 → 7 days**;
-  set the env higher for a longer recovery window. Doc updated.
+  `tools/card-action-dlq` (so they can't drift). **Default stays 30 days** (the pre-change
+  value), so an upgrade that doesn't set the override keeps the existing recovery window and
+  never prunes older DLQ entries on first deploy; set the env to a smaller value (e.g. `7`) to
+  opt into a shorter window. Doc updated.
+- **Fix (review round, PR #621, 4 reviewers)** — three blocking corrections folded in:
+  (1) a `route_missing` event with a non-positive `ActedAt` now **dead-letters immediately**
+  instead of deferring forever (the wait is bounded by elapsed-since-`ActedAt`, so an unset
+  timestamp had nothing to measure against and re-deferred every 5s indefinitely);
+  (2) the DLQ-retention default was kept at **30 days** rather than lowered to 7 (the running
+  server's lazy prune would otherwise silently delete 8–30-day-old DLQ entries on first deploy);
+  (3) the `card-action-dlq` CLI's read-only `depth` no longer prunes (new `DepthsNoPrune`), so
+  inspecting the DLQ can't delete recoverable entries. The metric-noise nit (per-re-check
+  `observeError`) was left as documented-intentional.
 
 ## 2026-07-20 (github-webhook-parity)
 

--- a/.octospec/log.md
+++ b/.octospec/log.md
@@ -39,6 +39,17 @@ change-log convention (§7). Newest first.
   (3) the `card-action-dlq` CLI's read-only `depth` no longer prunes (new `DepthsNoPrune`), so
   inspecting the DLQ can't delete recoverable entries. The metric-noise nit (per-re-check
   `observeError`) was left as documented-intentional.
+- **Fix (review round 2, PR #621 re-reviews)** — two further blocking corrections folded in:
+  (4) the bounded route-missing window is now anchored on the **first observed miss** (a durable
+  per-event `route_missing_since` marker via `RouteMissingSeenAt`), not on `Event.ActedAt` — an
+  event that dwelt in the durable queue past the window before its first dispatch (long
+  restart/outage/backlog) now still defers on its first transient miss instead of dead-lettering
+  immediately; this supersedes round 1's `ActedAt<=0` special-case (the marker is always a real
+  stamp, so that edge is gone by construction), and `ReplayDLQ` clears the marker so a replayed
+  event starts fresh; (5) the `card-action-dlq replay` path is now **non-destructive** — an entry
+  past the CLI's resolved retention is refused without being deleted, so the running server stays
+  the single pruning authority (a shorter CLI window can no longer silently destroy a
+  server-retained entry).
 
 ## 2026-07-20 (github-webhook-parity)
 

--- a/.octospec/log.md
+++ b/.octospec/log.md
@@ -50,6 +50,15 @@ change-log convention (§7). Newest first.
   past the CLI's resolved retention is refused without being deleted, so the running server stays
   the single pruning authority (a shorter CLI window can no longer silently destroy a
   server-retained entry).
+- **Fix (review round 3, PR #621 re-review)** — the round-2 first-miss marker
+  (`route_missing_since`) leaked: it is one shared Redis hash with a whole-hash TTL (no per-field
+  expiry), refreshed on every miss, so under sustained route-missing traffic a field per COMPLETED
+  event accumulated unbounded (it was cleared only on replay, not on delivery or dead-letter).
+  Fixed by `HDEL`-ing the marker on every exit transition (`ackScript`, `nackScript`
+  requeue+dead-letter, and the existing `replayDLQScript`); a new Redis-backed lifecycle test proves
+  the field is gone after Ack and after terminal dead-letter. Also folded in two doc-drift fixes (a
+  stale CLI "refuses (and prunes)" comment; the pending learning's `ActedAt`-based deadline →
+  first-observed-miss, plus a new marker-lifecycle-vs-whole-key-TTL point).
 
 ## 2026-07-20 (github-webhook-parity)
 

--- a/.octospec/tasks/route-missing-retry/brief.md
+++ b/.octospec/tasks/route-missing-retry/brief.md
@@ -67,14 +67,23 @@ DLQ, `Deliver`/`Finalize` never called.
 - `route_missing` within `routeMissingMaxWindow` **defers** (no attempt consumed) — it is
   NOT nacked, so the delivery attempt budget is untouched and a returning route delivers on
   the original attempt (never trips `attempts_exhausted`).
-- `route_missing` past `routeMissingMaxWindow` **dead-letters** immediately (reason preserved).
+- The bounded window is anchored on the **first observed route-miss** (a durable per-event
+  marker, `RouteMissingSeenAt`), NOT on `Event.ActedAt`. An event that dwelt in the queue past
+  the window before its first dispatch (long restart/outage/backlog) still **defers** on its
+  first transient miss; only after waiting past `routeMissingMaxWindow` *since that first miss*
+  does it dead-letter (reason preserved). This also removes the `ActedAt<=0` edge entirely — the
+  marker is always a real stamp, so there is no unset-timestamp case and no permanent-defer wedge.
+  (Review-driven: anchoring on `ActedAt` gave a backlogged event zero self-heal window; earlier
+  cuts anchored on `ActedAt` and special-cased `ActedAt<=0`.)
 - `Deliver` and `Finalize` are never invoked while the route is missing.
-- `routeMissingExpired` treats a non-positive `ActedAt` as **expired** — a route-missing event
-  with an unset/invalid `ActedAt` dead-letters immediately (reason preserved) instead of
-  deferring. (Review-driven correction: the first cut returned "not-expired" here, which wedged
-  such an event in a permanent 5s defer loop — never delivered, never dead-lettered — because
-  the wait is bounded by elapsed-since-`ActedAt` and there was nothing to measure against.)
+- The DLQ `replay` path is **non-destructive**: an entry past the CLI's resolved retention is
+  refused (returns false) but NOT deleted — the running server stays the single pruning authority.
+  (Review-driven: the CLI resolves retention from its own env; a shorter window could otherwise
+  silently delete a server-retained entry.) A successful replay clears the first-miss marker so
+  the re-queued event starts a fresh window.
 - Green: `go test ./internal/cardactiondispatch/`; clean: `go build ./...`, `go vet`, `golangci-lint`.
 - Tests: `internal/cardactiondispatch/route_missing_test.go`
   (`TestRouteMissingDefersWithoutConsumingAttempt`, `TestRouteMissingDeadLettersAfterWindow`,
-  `TestRouteMissingZeroActedAtDeadLetters`, `TestRouteMissingExpired`).
+  `TestRouteMissingOldActedAtDefersOnFirstMiss`, `TestRouteMissingExpired`) and
+  `route_missing_queue_test.go` (`TestReplayDLQPastRetentionIsNonDestructive`,
+  `TestRouteMissingSeenAtAnchorsOnFirstMiss`, Redis-backed).

--- a/.octospec/tasks/route-missing-retry/brief.md
+++ b/.octospec/tasks/route-missing-retry/brief.md
@@ -81,9 +81,16 @@ DLQ, `Deliver`/`Finalize` never called.
   (Review-driven: the CLI resolves retention from its own env; a shorter window could otherwise
   silently delete a server-retained entry.) A successful replay clears the first-miss marker so
   the re-queued event starts a fresh window.
+- The first-miss marker has a **bounded lifecycle**: it is HDEL'd on every exit transition —
+  `ackScript` (delivery), `nackScript` (both requeue and terminal dead-letter), and `replayDLQScript`
+  — so the shared `route_missing_since` hash holds markers only for events currently waiting in the
+  defer loop and cannot grow unbounded. (Review-driven: a whole-hash `PEXPIRE` cannot expire
+  individual fields, and every miss refreshes it, so relying on TTL alone leaked a field per
+  completed event under sustained route-missing traffic.)
 - Green: `go test ./internal/cardactiondispatch/`; clean: `go build ./...`, `go vet`, `golangci-lint`.
 - Tests: `internal/cardactiondispatch/route_missing_test.go`
   (`TestRouteMissingDefersWithoutConsumingAttempt`, `TestRouteMissingDeadLettersAfterWindow`,
   `TestRouteMissingOldActedAtDefersOnFirstMiss`, `TestRouteMissingExpired`) and
   `route_missing_queue_test.go` (`TestReplayDLQPastRetentionIsNonDestructive`,
-  `TestRouteMissingSeenAtAnchorsOnFirstMiss`, Redis-backed).
+  `TestRouteMissingSeenAtAnchorsOnFirstMiss`, `TestRouteMissingMarkerClearedOnTerminalTransitions`,
+  Redis-backed).

--- a/.octospec/tasks/route-missing-retry/brief.md
+++ b/.octospec/tasks/route-missing-retry/brief.md
@@ -1,0 +1,76 @@
+---
+type: Task
+title: "Task: route-missing-retry"
+description: Treat a route_missing at card-action dispatch as a bounded retry instead of an immediate dead-letter, so a transient config-divergence window self-heals.
+tags: ["card", "dispatch", "reliability", "dlq", "testing"]
+timestamp: 2026-07-20T16:30:00+08:00
+# --- octospec extension fields ---
+slug: route-missing-retry
+upstream: none (diagnosed from a prod DLQ investigation — docs approve/deny cards never updating)
+source: self
+---
+
+# Task: route-missing-retry
+
+## Goal
+When the card-action dispatcher (`internal/cardactiondispatch`) claims a queued
+event whose route is absent from the current process's registry (`route_missing`),
+retry it with a bounded, capped-exponential backoff instead of dead-lettering it on
+the first attempt. A route miss at dispatch is transient far more often than it is a
+permanent misconfiguration, and the durable Redis queue outlives that window — so the
+event should ride it out and dispatch once the route returns, instead of being lost.
+
+## Background
+Production single-replica symptom: docs access-request approve/deny cards never
+updated after clicking. DLQ inspection showed events (approve `1003002`, deny
+`1001002/1001003`) dead-lettered with reason `route_missing`, `attempt=1`, and the
+callback never invoked (no octo-docs-backend receipt, no downstream log).
+
+Mechanism (pinned by an invariant): an event only enters the dispatch queue when its
+route existed at *enqueue* time — `Registry.Resolve` must return `ResolutionCallback`,
+else the event goes to bot-pull or is rejected and never reaches this queue. Within one
+process, enqueue and dispatch share the same in-memory registry, so a `route_missing`
+at dispatch means the registry differed between enqueue and dispatch: a restart/redeploy
+changed `OCTO_CARD_ACTION_ROUTES` (e.g. came up before the route loaded) while the
+durable queue carried the event across the window. The old code
+(`d.nack(*lease, now, false, lease.Attempt, "route_missing")` → `retry=false` forces
+`maxAttempts=lease.Attempt`) dead-lettered on the first such attempt, permanently losing
+a decision whose route existed moments later — and, being non-retryable, never self-healed.
+
+Reproduced against the real package (two registries, one with / one without the route;
+event enqueued under the first, dispatched under the second) → `route_missing`, immediate
+DLQ, `Deliver`/`Finalize` never called.
+
+## Load-bearing list
+- **Card-action dispatch retry/DLQ semantics** (`internal/cardactiondispatch/dispatcher.go`,
+  `ProcessOne`): which nack retries vs dead-letters, and the attempt/backoff accounting.
+  (No existing `.octospec/rules` tag covers dispatch-queue reliability — captured as a
+  pending learning.)
+- **At-least-once + idempotency contract**: retrying `route_missing` re-delivers later;
+  the consumer (octo-docs-backend) is idempotent by `event_id` (receipt CAS) and the whole
+  path is already at-least-once, so a delayed re-delivery is safe.
+- **DLQ as an operational signal**: a *genuinely* unconfigured route must still land in the
+  DLQ (visible/alertable) — now after a bounded budget rather than on attempt 1.
+- `touches: testing` — new package unit tests.
+- `touches: commit` — Conventional Commit.
+
+## Out of scope
+- The operational root cause (a run coming up without `OCTO_CARD_ACTION_ROUTES` loaded) —
+  config/deploy hygiene, not code.
+- Replaying already-dead-lettered events (manual DLQ replay; this change is forward-looking).
+- Enqueue-time resolution, route-config schema, signature/secret handling, and the existing
+  delivery-error retry path — all untouched.
+- octo-web; and the two other diagnosed docs-card issues (applicant deny-reason omitted;
+  applicant name empty) — separate work.
+
+## Acceptance
+- `route_missing` within `routeMissingMaxWindow` **defers** (no attempt consumed) — it is
+  NOT nacked, so the delivery attempt budget is untouched and a returning route delivers on
+  the original attempt (never trips `attempts_exhausted`).
+- `route_missing` past `routeMissingMaxWindow` **dead-letters** immediately (reason preserved).
+- `Deliver` and `Finalize` are never invoked while the route is missing.
+- `routeMissingExpired` treats a non-positive `ActedAt` as not-expired (no premature DLQ).
+- Green: `go test ./internal/cardactiondispatch/`; clean: `go build ./...`, `go vet`, `golangci-lint`.
+- Tests: `internal/cardactiondispatch/route_missing_test.go`
+  (`TestRouteMissingDefersWithoutConsumingAttempt`, `TestRouteMissingDeadLettersAfterWindow`,
+  `TestRouteMissingExpired`).

--- a/.octospec/tasks/route-missing-retry/brief.md
+++ b/.octospec/tasks/route-missing-retry/brief.md
@@ -69,8 +69,12 @@ DLQ, `Deliver`/`Finalize` never called.
   the original attempt (never trips `attempts_exhausted`).
 - `route_missing` past `routeMissingMaxWindow` **dead-letters** immediately (reason preserved).
 - `Deliver` and `Finalize` are never invoked while the route is missing.
-- `routeMissingExpired` treats a non-positive `ActedAt` as not-expired (no premature DLQ).
+- `routeMissingExpired` treats a non-positive `ActedAt` as **expired** — a route-missing event
+  with an unset/invalid `ActedAt` dead-letters immediately (reason preserved) instead of
+  deferring. (Review-driven correction: the first cut returned "not-expired" here, which wedged
+  such an event in a permanent 5s defer loop — never delivered, never dead-lettered — because
+  the wait is bounded by elapsed-since-`ActedAt` and there was nothing to measure against.)
 - Green: `go test ./internal/cardactiondispatch/`; clean: `go build ./...`, `go vet`, `golangci-lint`.
 - Tests: `internal/cardactiondispatch/route_missing_test.go`
   (`TestRouteMissingDefersWithoutConsumingAttempt`, `TestRouteMissingDeadLettersAfterWindow`,
-  `TestRouteMissingExpired`).
+  `TestRouteMissingZeroActedAtDeadLetters`, `TestRouteMissingExpired`).

--- a/.octospec/tasks/route-missing-retry/context.yaml
+++ b/.octospec/tasks/route-missing-retry/context.yaml
@@ -77,3 +77,25 @@ notes:
   - The metric-noise nit (observeError fires once per 5s re-check while waiting) is left as-is:
     it is intentional and documented (docs/card-action-callback-dispatch.md "Queue and alerts"),
     and moving it would drop the "route currently missing" operational signal. Not a defect.
+  - PR review round 2 (re-reviews on the fixed head) produced two more blocking corrections:
+    (4) BLOCKING (Jerry-Xin, Critical) — the bounded window was anchored on Event.ActedAt, so an
+    event that dwelt in the durable queue past the window before its FIRST dispatch (long
+    restart/outage/backlog — exactly this feature's target scenario) got zero self-heal window and
+    dead-lettered on its first miss. Fixed by anchoring the window on the FIRST observed miss: a
+    durable per-event marker (Redis hash route_missing_since, HSETNX-then-read, TTL=liveTTL) written
+    by RedisQueue.RouteMissingSeenAt and read in the dispatcher; routeMissingExpired now takes that
+    firstSeen time. This SUPERSEDES round-1's ActedAt<=0 special-case (correction 1): ActedAt is no
+    longer consulted for the window, the marker is always a real stamp, so the unset-timestamp edge
+    and the permanent-defer wedge are both gone by construction. ReplayDLQ clears the marker so a
+    replayed event starts a fresh window. New tests: TestRouteMissingOldActedAtDefersOnFirstMiss,
+    TestRouteMissingSeenAtAnchorsOnFirstMiss (Redis).
+    (5) BLOCKING (yujiawei, P1) — the DLQ `replay` path deleted an entry older than the CLI's
+    resolved retention before returning 0, so a CLI whose window was shorter than the server's could
+    silently destroy a server-retained entry — the same destructive-tool class DepthsNoPrune fixed
+    for `depth`. Fixed by making replayDLQScript's expiry branch non-destructive (return 0 without
+    deleting); the running server's Depths() prune is the single pruning authority. New test:
+    TestReplayDLQPastRetentionIsNonDestructive (Redis).
+  - Non-blocking notes from round 2 that needed NO code change: Octo-Q's "metric fires once per event
+    not per re-check" was a misread (observeError sits above the expiry gate, so it does fire per
+    re-check — doc is correct); yujiawei's acted_at type-assertion note verified safe (same in-memory
+    map, no JSON round-trip); the "PR summary says 7d" note was already resolved by the body update.

--- a/.octospec/tasks/route-missing-retry/context.yaml
+++ b/.octospec/tasks/route-missing-retry/context.yaml
@@ -58,3 +58,22 @@ notes:
     delivery attempt (Nack). The first cut used a bounded nack and an xhigh code review
     caught that it shared the delivery attempt budget → attempts_exhausted on route return.
     Learning staged: learnings/pending/durable-queue-registry-divergence.md.
+  - PR review round (4 reviewers on #621) produced three corrections, all folded into this task:
+    (1) BLOCKING — routeMissingExpired returned "not-expired" for a non-positive ActedAt, so a
+    legacy/malformed event with ActedAt<=0 and a missing route would re-defer every 5s forever
+    (never delivered, never dead-lettered). Fixed: non-positive ActedAt is now EXPIRED → immediate
+    dead-letter (reason preserved, visible/replayable). Runtime guard chosen over an Enqueue-time
+    guard because it also covers already-queued legacy events and avoids churning many test event
+    builders. Test: TestRouteMissingZeroActedAtDeadLetters.
+    (2) BLOCKING — the separate DLQ-retention change had lowered the default 30→7d; on deploy the
+    server (refreshDepthMetrics → Depths → pruneDLQScript) would irreversibly prune 8–30-day-old
+    DLQ entries with no operator action. Fixed: DefaultDLQRetention restored to 30d (the pre-change
+    value); 7d (or any 1–365) stays available via OCTO_CARD_ACTION_DLQ_RETENTION_DAYS. User chose
+    this (keep the existing contract as default, opt into shorter per deploy).
+    (3) BLOCKING — the card-action-dlq CLI's read-only `depth` pruned via Depths() using retention
+    resolved from the CLI's own env, so inspecting the DLQ from a shell without the server's env
+    could delete recoverable entries. Fixed: new RedisQueue.DepthsNoPrune() (ZCard only); `depth`
+    uses it. The server remains the sole pruning authority.
+  - The metric-noise nit (observeError fires once per 5s re-check while waiting) is left as-is:
+    it is intentional and documented (docs/card-action-callback-dispatch.md "Queue and alerts"),
+    and moving it would drop the "route currently missing" operational signal. Not a defect.

--- a/.octospec/tasks/route-missing-retry/context.yaml
+++ b/.octospec/tasks/route-missing-retry/context.yaml
@@ -99,3 +99,20 @@ notes:
     not per re-check" was a misread (observeError sits above the expiry gate, so it does fire per
     re-check — doc is correct); yujiawei's acted_at type-assertion note verified safe (same in-memory
     map, no JSON round-trip); the "PR summary says 7d" note was already resolved by the body update.
+  - PR review round 3 (re-review of the first-miss marker) produced one more blocking correction:
+    (6) BLOCKING (Jerry-Xin, Critical) — the round-2 route_missing_since marker leaked. It is one
+    shared Redis hash with a whole-hash PEXPIRE; Redis cannot expire individual fields, and every
+    miss refreshed the hash TTL, so under sustained route-missing traffic the key never expired and
+    a field per COMPLETED event accumulated forever (the marker was only cleared on ReplayDLQ, not on
+    Ack/terminal Nack). The round-2 comment's "self-reaps via TTL" claim was wrong. Fixed by HDEL'ing
+    the marker on every exit transition: ackScript (delivery), nackScript (both requeue and
+    dead-letter branches — one HDEL after the token check covers both), plus the existing
+    replayDLQScript. New Redis-backed lifecycle test TestRouteMissingMarkerClearedOnTerminalTransitions
+    asserts the field is gone after Ack and after terminal dead-letter. Validated against a real local
+    Redis (all Redis-backed tests + existing lease/ack/nack/replay contract tests pass), not just the
+    fakes. Octo-Q flagged the same thing but as a non-blocking nit ("self-reaps via TTL, event IDs
+    never recur") — it under-weighted the whole-hash-TTL-refresh interaction; Jerry-Xin's blocking
+    call was correct.
+  - Round-3 non-blocking, fixed in the same commit (both doc drift from earlier deltas): the
+    card-action-dlq CLI comment said replay "refuses (and prunes)" (replay is now non-destructive);
+    the pending learning still prescribed an ActedAt-based deadline (superseded by first-observed-miss).

--- a/.octospec/tasks/route-missing-retry/context.yaml
+++ b/.octospec/tasks/route-missing-retry/context.yaml
@@ -1,0 +1,60 @@
+# Rules resolved for this task (octospec Implement phase).
+slug: route-missing-retry
+resolved_at: 2026-07-20T16:30:00+08:00
+
+# Files touched: internal/cardactiondispatch/dispatcher.go,
+#                internal/cardactiondispatch/route_missing_test.go
+# Path-glob matches: rate-limit (internal/**/*.go), space-isolation (internal/**/*.go),
+#                    testing (**/*_test.go), commit-style (**).
+
+rules_injected:
+  - id: space-isolation
+    tier: repo
+    load_bearing: true
+    why: >
+      Path glob internal/**/*.go matches. Checked for cross-space leakage.
+    applied:
+      - N/A — no data access and no Space boundary is crossed. The dispatcher acts on
+        events already space-validated at enqueue time (modules/message card/action
+        endpoint). This change only decides retry-vs-DLQ on a route-lookup miss keyed by
+        (sender_uid, owner, action_type); it reads no user data and grants nothing.
+      - Retrying does not widen access: re-delivery targets the exact same event; the
+        consumer re-checks operator authorization per its own contract.
+  - id: rate-limit
+    tier: repo
+    load_bearing: true
+    why: >
+      Path glob internal/**/*.go matches; the change adds a defer/re-check schedule.
+    applied:
+      - N/A — not request-frequency limiting. route_missing reuses the queue's EXISTING
+        Defer mechanism (the same one the max_in_flight capacity path uses) on a fixed
+        routeMissingDeferInterval. No hand-rolled Redis counter is introduced; no HTTP
+        throttling.
+  - id: testing
+    tier: repo
+    load_bearing: false
+    applied:
+      - Risk-proportional package unit tests added (route_missing retry, eventual DLQ,
+        backoff bounds, and that Deliver/Finalize never run while the route is missing).
+      - Tests use the package's in-memory fake queue (concurrentLeaseQueue); they need no
+        MySQL/Redis/WuKongIM, so the testutil NewTestServer/CleanAllTables setup does not apply.
+  - id: commit-style
+    tier: repo
+    load_bearing: false
+    applied:
+      - Conventional Commit `fix(cardaction): ...`, English body.
+      - No linked GitHub issue (diagnosed from a live prod investigation, not an issue).
+
+notes:
+  - error-handling rule does NOT match (paths are modules/**, pkg/errcode/**, pkg/**/httperr/**;
+    internal/** is excluded) and the change emits no user-facing error response — it only
+    changes an internal dispatch nack policy. No new error codes; make i18n-* not required.
+  - trust-boundary rule does NOT match (adapter/webhook/richtext paths only).
+  - Design residual (documented): a genuinely unconfigured route now dead-letters after
+    routeMissingMaxWindow (15m from Event.ActedAt) instead of on attempt 1 — a deliberate
+    trade of later DLQ visibility for fully self-healing a transient rolling-deploy /
+    restart window. The DLQ signal (reason=route_missing) is preserved, just delayed.
+  - route_missing is modeled as "not ready yet" (Defer, no attempt consumed), NOT a failed
+    delivery attempt (Nack). The first cut used a bounded nack and an xhigh code review
+    caught that it shared the delivery attempt budget → attempts_exhausted on route return.
+    Learning staged: learnings/pending/durable-queue-registry-divergence.md.

--- a/docs/card-action-callback-dispatch.md
+++ b/docs/card-action-callback-dispatch.md
@@ -208,7 +208,11 @@ are reclaimed; a stale worker cannot renew or ACK another worker's lease.
 If a route has reached `max_in_flight`, its lease is atomically deferred for one
 poll interval without consuming an attempt, so other routes and shutdown remain
 unblocked.
-Live retention equals `Robot.MessageExpire`; DLQ retention is 30 days.
+Live retention equals `Robot.MessageExpire`. DLQ retention defaults to 7 days and
+is overridable via `OCTO_CARD_ACTION_DLQ_RETENTION_DAYS` (whole days, 1–365; empty
+or invalid values fall back to the default). The retention clock starts when the
+event is dead-lettered, and pruning is lazy (on `Depths()` / `ReplayDLQ`), so replay
+a dead-lettered event within the window.
 
 Alert from these bounded-label metrics:
 
@@ -223,6 +227,15 @@ Alert from these bounded-label metrics:
 Deployment-specific thresholds belong in the monitoring repository. At
 minimum, alert on sustained DLQ depth above zero and sustained `consumer_5xx`,
 `invalid_response`, or applicant notification failures.
+
+A `route_missing` at dispatch is treated as transient (a rolling deploy / restart
+that came up before `OCTO_CARD_ACTION_ROUTES` loaded the route): the event is
+**deferred** (no attempt consumed) and re-checked until the route returns or it has
+waited ~15 minutes, after which it dead-letters (`reason=route_missing`). So
+`error_total{category="route_missing"}` increments **once per re-check** while an
+event waits, not once per event — treat sustained non-zero `route_missing` (or DLQ
+entries with that reason) as a route-config divergence to fix, and size any rate
+alert accordingly.
 
 ## Manual DLQ replay
 

--- a/docs/card-action-callback-dispatch.md
+++ b/docs/card-action-callback-dispatch.md
@@ -208,11 +208,17 @@ are reclaimed; a stale worker cannot renew or ACK another worker's lease.
 If a route has reached `max_in_flight`, its lease is atomically deferred for one
 poll interval without consuming an attempt, so other routes and shutdown remain
 unblocked.
-Live retention equals `Robot.MessageExpire`. DLQ retention defaults to 7 days and
+Live retention equals `Robot.MessageExpire`. DLQ retention defaults to 30 days and
 is overridable via `OCTO_CARD_ACTION_DLQ_RETENTION_DAYS` (whole days, 1–365; empty
-or invalid values fall back to the default). The retention clock starts when the
-event is dead-lettered, and pruning is lazy (on `Depths()` / `ReplayDLQ`), so replay
-a dead-lettered event within the window.
+or invalid values fall back to the default). The default preserves the recovery window
+the code shipped with before retention was configurable, so an upgrade that does not set
+the override never silently prunes older DLQ entries on first deploy; set the env to a
+smaller value (e.g. `7`) to opt into a shorter window. The retention clock starts when the
+event is dead-lettered, and pruning is lazy — the running server is the pruning authority,
+pruning on its own `Depths()` calls with its resolved window. Replay a dead-lettered event
+within the window. The `card-action-dlq` CLI's `depth` command is read-only and never
+prunes; only its `replay` applies retention, so export the same
+`OCTO_CARD_ACTION_DLQ_RETENTION_DAYS` the server uses before replaying.
 
 Alert from these bounded-label metrics:
 
@@ -235,7 +241,11 @@ waited ~15 minutes, after which it dead-letters (`reason=route_missing`). So
 `error_total{category="route_missing"}` increments **once per re-check** while an
 event waits, not once per event — treat sustained non-zero `route_missing` (or DLQ
 entries with that reason) as a route-config divergence to fix, and size any rate
-alert accordingly.
+alert accordingly. The wait is bounded by elapsed time since the event's acted-at
+timestamp; an event whose acted-at is missing or non-positive (a legacy/malformed
+event — production always stamps it at enqueue) cannot be time-bounded, so on a route
+miss it dead-letters immediately (`reason=route_missing`) rather than deferring, which
+keeps it visible and replayable instead of wedged in a permanent defer loop.
 
 ## Manual DLQ replay
 

--- a/docs/card-action-callback-dispatch.md
+++ b/docs/card-action-callback-dispatch.md
@@ -214,11 +214,14 @@ or invalid values fall back to the default). The default preserves the recovery 
 the code shipped with before retention was configurable, so an upgrade that does not set
 the override never silently prunes older DLQ entries on first deploy; set the env to a
 smaller value (e.g. `7`) to opt into a shorter window. The retention clock starts when the
-event is dead-lettered, and pruning is lazy — the running server is the pruning authority,
-pruning on its own `Depths()` calls with its resolved window. Replay a dead-lettered event
-within the window. The `card-action-dlq` CLI's `depth` command is read-only and never
-prunes; only its `replay` applies retention, so export the same
-`OCTO_CARD_ACTION_DLQ_RETENTION_DAYS` the server uses before replaying.
+event is dead-lettered, and pruning is lazy — the running server is the **sole** pruning
+authority, pruning on its own `Depths()` calls with its resolved window. Replay a dead-lettered
+event within the window. The `card-action-dlq` CLI never prunes: `depth` is read-only, and
+`replay` is non-destructive — if the entry is older than the CLI's resolved window it refuses
+(prints "not present") but does **not** delete it, so inspecting or replaying from a shell whose
+`OCTO_CARD_ACTION_DLQ_RETENTION_DAYS` is shorter than the server's can never destroy a
+server-retained entry. Still, export the same value the server uses so `replay` doesn't refuse an
+entry the server still retains.
 
 Alert from these bounded-label metrics:
 
@@ -241,11 +244,13 @@ waited ~15 minutes, after which it dead-letters (`reason=route_missing`). So
 `error_total{category="route_missing"}` increments **once per re-check** while an
 event waits, not once per event — treat sustained non-zero `route_missing` (or DLQ
 entries with that reason) as a route-config divergence to fix, and size any rate
-alert accordingly. The wait is bounded by elapsed time since the event's acted-at
-timestamp; an event whose acted-at is missing or non-positive (a legacy/malformed
-event — production always stamps it at enqueue) cannot be time-bounded, so on a route
-miss it dead-letters immediately (`reason=route_missing`) rather than deferring, which
-keeps it visible and replayable instead of wedged in a permanent defer loop.
+alert accordingly. The wait is bounded by elapsed time since the route-miss was **first
+observed** (persisted per event), not since the user acted — so an event that sat in the
+durable queue for a long time before its first dispatch attempt (a long restart / outage /
+backlog carried by the durable queue) still gets the full ~15-minute self-heal window on its
+first transient miss, rather than being dead-lettered immediately because its acted-at is
+already old. The first-miss marker is cleared when the event is replayed from the DLQ, so a
+replayed event starts a fresh window.
 
 ## Manual DLQ replay
 
@@ -261,6 +266,11 @@ Replay resets attempts and returns that one event to ready state. The consumer
 must remain idempotent: its domain decision may already have committed. Terminal
 card mutation is also idempotent (`card_seq=event_id`). Applicant notification
 is at-least-once, so replay may duplicate it at the documented crash boundary.
+Replay is non-destructive: an entry older than the CLI's resolved retention is
+refused (`event_id N was not present in the DLQ`) but left intact for the server to
+prune — it never deletes a server-retained entry. If a replay reports "not present"
+for an entry you expect to exist, re-run with `OCTO_CARD_ACTION_DLQ_RETENTION_DAYS`
+set to the server's value.
 
 ## Rollout and rollback
 

--- a/internal/cardactiondispatch/config.go
+++ b/internal/cardactiondispatch/config.go
@@ -5,9 +5,42 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"strconv"
 	"strings"
 	"time"
 )
+
+const (
+	// DefaultDLQRetention is the fallback dead-letter retention: how long a
+	// dead-lettered card-action event stays replayable (via tools/card-action-dlq)
+	// before pruning, when the env override is unset or invalid.
+	DefaultDLQRetention = 7 * 24 * time.Hour
+	// DLQRetentionEnv names the retention override, expressed in whole days.
+	DLQRetentionEnv = "OCTO_CARD_ACTION_DLQ_RETENTION_DAYS"
+	// maxDLQRetentionDays bounds the override so a typo cannot pin the DLQ open for
+	// an unreasonable span.
+	maxDLQRetentionDays = 365
+)
+
+// DLQRetentionFromEnv resolves the dead-letter retention from OCTO_CARD_ACTION_DLQ_RETENTION_DAYS
+// (whole days). Empty / non-integer / non-positive / over-max values fall back to
+// DefaultDLQRetention so a misconfigured override degrades to a safe window rather than
+// truncating the recovery span (NewRedisQueue rejects a non-positive retention outright).
+// Shared by main.go and tools/card-action-dlq so the two binaries never drift on the CODE
+// value — but note both read the process env, so an operator must export the SAME
+// OCTO_CARD_ACTION_DLQ_RETENTION_DAYS when running the CLI as the server uses, or the CLI's
+// prune-on-read (Depths/ReplayDLQ) will delete events at a different window than the server.
+func DLQRetentionFromEnv(getenv func(string) string) time.Duration {
+	raw := strings.TrimSpace(getenv(DLQRetentionEnv))
+	if raw == "" {
+		return DefaultDLQRetention
+	}
+	days, err := strconv.Atoi(raw)
+	if err != nil || days <= 0 || days > maxDLQRetentionDays {
+		return DefaultDLQRetention
+	}
+	return time.Duration(days) * 24 * time.Hour
+}
 
 type routeJSON struct {
 	SenderUID      string `json:"sender_uid"`

--- a/internal/cardactiondispatch/config.go
+++ b/internal/cardactiondispatch/config.go
@@ -13,8 +13,12 @@ import (
 const (
 	// DefaultDLQRetention is the fallback dead-letter retention: how long a
 	// dead-lettered card-action event stays replayable (via tools/card-action-dlq)
-	// before pruning, when the env override is unset or invalid.
-	DefaultDLQRetention = 7 * 24 * time.Hour
+	// before pruning, when the env override is unset or invalid. It matches the
+	// value the code shipped with before the retention became configurable, so an
+	// upgrade that does not set the override keeps the existing recovery window and
+	// never silently prunes older DLQ entries on first deploy. Opt into a shorter
+	// window via DLQRetentionEnv.
+	DefaultDLQRetention = 30 * 24 * time.Hour
 	// DLQRetentionEnv names the retention override, expressed in whole days.
 	DLQRetentionEnv = "OCTO_CARD_ACTION_DLQ_RETENTION_DAYS"
 	// maxDLQRetentionDays bounds the override so a typo cannot pin the DLQ open for
@@ -27,9 +31,10 @@ const (
 // DefaultDLQRetention so a misconfigured override degrades to a safe window rather than
 // truncating the recovery span (NewRedisQueue rejects a non-positive retention outright).
 // Shared by main.go and tools/card-action-dlq so the two binaries never drift on the CODE
-// value — but note both read the process env, so an operator must export the SAME
-// OCTO_CARD_ACTION_DLQ_RETENTION_DAYS when running the CLI as the server uses, or the CLI's
-// prune-on-read (Depths/ReplayDLQ) will delete events at a different window than the server.
+// value. The server is the pruning authority: it prunes lazily on its own Depths() calls with
+// this resolved window. The CLI only ever applies retention on an explicit `replay`; its
+// read-only `depth` never prunes (see DepthsNoPrune), so merely inspecting the DLQ from a shell
+// that lacks the env var can no longer delete server-retained events.
 func DLQRetentionFromEnv(getenv func(string) string) time.Duration {
 	raw := strings.TrimSpace(getenv(DLQRetentionEnv))
 	if raw == "" {

--- a/internal/cardactiondispatch/coverage_test.go
+++ b/internal/cardactiondispatch/coverage_test.go
@@ -33,6 +33,9 @@ func (q *idleDispatchQueue) ReclaimExpired(time.Time, int) (int, error) {
 	q.reclaims.Add(1)
 	return 0, nil
 }
+func (*idleDispatchQueue) RouteMissingSeenAt(_ int64, now time.Time) (time.Time, error) {
+	return now, nil
+}
 
 func TestDispatcherLifecycleStartsStopsAndRejectsDoubleStart(t *testing.T) {
 	registry, err := NewRegistry([]RouteSpec{validRouteSpec()}, testGetenv)

--- a/internal/cardactiondispatch/dispatcher.go
+++ b/internal/cardactiondispatch/dispatcher.go
@@ -125,11 +125,39 @@ func (d *Dispatcher) ProcessOne(ctx context.Context, now time.Time) (bool, error
 	route, ok := d.registry.Route(lease.Event.SenderUID, lease.Event.Owner, lease.Event.ActionType)
 	if !ok {
 		d.metrics.observeError(owner, "route_missing")
-		outcome, nackErr := d.nack(*lease, now, false, lease.Attempt, "route_missing")
-		resultLabel = resultForNack(outcome, nackErr)
-		d.logTransition(lease, "route_missing", outcome, nackErr)
+		// A missing route is TRANSIENT, not permanent: an event only reaches this
+		// queue when its route existed at enqueue time (Registry.Resolve returned a
+		// callback), so a miss here means the route was absent from THIS process's
+		// registry at dispatch time — a rolling deploy, or a restart/redeploy that
+		// came up before OCTO_CARD_ACTION_ROUTES carried the route — while the durable
+		// queue outlived that window. DEFER (no attempt consumed) so the event rides
+		// out the window and dispatches on its ORIGINAL attempt budget once the route
+		// returns. Consuming an attempt here (a nack) would let route-absence waiting
+		// exhaust route.MaxAttempts, so the event would trip the attempts_exhausted
+		// gate the moment its route came back — the opposite of self-healing. Only once
+		// the event has waited past routeMissingMaxWindow do we dead-letter it as a
+		// genuine misconfiguration, preserving the DLQ breadcrumb (reason=route_missing).
+		if routeMissingExpired(lease.Event.ActedAt, d.clock()) {
+			outcome, nackErr := d.nack(*lease, d.clock(), false, lease.Attempt, "route_missing")
+			resultLabel = resultForNack(outcome, nackErr)
+			d.logTransition(lease, "route_missing", outcome, nackErr)
+			d.refreshDepthMetrics()
+			return true, nackErr
+		}
+		deferred, deferErr := d.queue.Defer(lease.Event.EventID, lease.Token, d.clock().Add(routeMissingDeferInterval))
+		if deferErr != nil {
+			d.metrics.observeError(owner, "queue_error")
+			d.refreshDepthMetrics()
+			return true, deferErr
+		}
+		if !deferred {
+			d.metrics.observeError(owner, "ack_lost")
+			d.refreshDepthMetrics()
+			return true, errors.New("cardactiondispatch: lease ownership lost before route-missing defer")
+		}
+		resultLabel = "deferred"
 		d.refreshDepthMetrics()
-		return true, nackErr
+		return true, nil
 	}
 	if lease.Attempt > route.MaxAttempts {
 		const category = "attempts_exhausted"
@@ -301,6 +329,28 @@ func retryBackoff(attempt int, route *Route) time.Duration {
 		return route.MaxBackoff
 	}
 	return delay
+}
+
+// routeMissingMaxWindow bounds how long an event may wait on a missing route before
+// it is dead-lettered as a genuine misconfiguration. It is generous enough to ride
+// out a rolling deploy / restart window; within it the event is DEFERRED (no attempt
+// consumed), so a route that returns still delivers on its original attempt budget
+// rather than tripping the attempts_exhausted gate.
+const routeMissingMaxWindow = 15 * time.Minute
+
+// routeMissingDeferInterval is how often a route-missing event is re-checked while it
+// waits inside routeMissingMaxWindow. It is deliberately coarser than PollInterval so a
+// long-missing route does not busy re-claim the same event every poll tick.
+const routeMissingDeferInterval = 5 * time.Second
+
+// routeMissingExpired reports whether an event acted at actedAtUnix (unix seconds) has
+// waited on a missing route past routeMissingMaxWindow. A non-positive actedAt (unset)
+// is treated as not-expired, so a missing timestamp never forces a premature dead-letter.
+func routeMissingExpired(actedAtUnix int64, now time.Time) bool {
+	if actedAtUnix <= 0 {
+		return false
+	}
+	return now.Unix()-actedAtUnix >= int64(routeMissingMaxWindow/time.Second)
 }
 
 func errorCategory(err error) string {

--- a/internal/cardactiondispatch/dispatcher.go
+++ b/internal/cardactiondispatch/dispatcher.go
@@ -17,6 +17,10 @@ type dispatchQueue interface {
 	Ack(eventID int64, token string) (bool, error)
 	Nack(lease Lease, now time.Time, delay time.Duration, maxAttempts int, reason string) (NackOutcome, error)
 	ReclaimExpired(now time.Time, limit int) (int, error)
+	// RouteMissingSeenAt records (once) and returns when this event's route was first
+	// observed missing at dispatch, so the bounded route-missing window is measured from
+	// that point rather than from Event.ActedAt.
+	RouteMissingSeenAt(eventID int64, now time.Time) (time.Time, error)
 }
 
 type callbackDeliverer interface {
@@ -134,10 +138,23 @@ func (d *Dispatcher) ProcessOne(ctx context.Context, now time.Time) (bool, error
 		// out the window and dispatches on its ORIGINAL attempt budget once the route
 		// returns. Consuming an attempt here (a nack) would let route-absence waiting
 		// exhaust route.MaxAttempts, so the event would trip the attempts_exhausted
-		// gate the moment its route came back — the opposite of self-healing. Only once
-		// the event has waited past routeMissingMaxWindow do we dead-letter it as a
-		// genuine misconfiguration, preserving the DLQ breadcrumb (reason=route_missing).
-		if routeMissingExpired(lease.Event.ActedAt, d.clock()) {
+		// gate the moment its route came back — the opposite of self-healing.
+		//
+		// The window is measured from the FIRST observed miss (persisted per event via
+		// RouteMissingSeenAt), NOT from Event.ActedAt. An event can sit in the durable
+		// queue arbitrarily long before its first dispatch attempt — a long restart /
+		// outage / backlog, exactly the window this guards — and must still get the full
+		// self-heal window on its first transient miss, instead of being dead-lettered
+		// immediately because its acted-at is already older than the window. Only after it
+		// has waited past routeMissingMaxWindow SINCE that first miss do we dead-letter it
+		// as a genuine misconfiguration, preserving the DLQ breadcrumb (reason=route_missing).
+		firstSeen, seenErr := d.queue.RouteMissingSeenAt(lease.Event.EventID, d.clock())
+		if seenErr != nil {
+			d.metrics.observeError(owner, "queue_error")
+			d.refreshDepthMetrics()
+			return true, seenErr
+		}
+		if routeMissingExpired(firstSeen, d.clock()) {
 			outcome, nackErr := d.nack(*lease, d.clock(), false, lease.Attempt, "route_missing")
 			resultLabel = resultForNack(outcome, nackErr)
 			d.logTransition(lease, "route_missing", outcome, nackErr)
@@ -343,22 +360,15 @@ const routeMissingMaxWindow = 15 * time.Minute
 // long-missing route does not busy re-claim the same event every poll tick.
 const routeMissingDeferInterval = 5 * time.Second
 
-// routeMissingExpired reports whether an event acted at actedAtUnix (unix seconds) has
-// waited on a missing route past routeMissingMaxWindow and must now be dead-lettered.
-//
-// A non-positive actedAt (unset / legacy / malformed) is treated as EXPIRED. The defer
-// loop bounds the wait by elapsed time since actedAt; with no trustworthy timestamp there
-// is nothing to measure against, so returning "not expired" here would re-defer the event
-// on every re-check forever — never delivered, never dead-lettered — silently breaking the
-// bounded-window guarantee (flagged in review). Dead-lettering immediately instead keeps the
-// event visible and replayable (reason=route_missing) rather than wedged in permanent defer.
-// Production always stamps ActedAt at enqueue (modules/message/api_card_action.go), so this
-// only ever catches a legacy/malformed event that predates or violates that invariant.
-func routeMissingExpired(actedAtUnix int64, now time.Time) bool {
-	if actedAtUnix <= 0 {
-		return true
-	}
-	return now.Unix()-actedAtUnix >= int64(routeMissingMaxWindow/time.Second)
+// routeMissingExpired reports whether an event whose route was first observed missing at
+// firstSeen has now waited past routeMissingMaxWindow and must be dead-lettered. The window
+// is anchored on the FIRST observed miss (a durable per-event marker set by RouteMissingSeenAt),
+// not on Event.ActedAt, so a long queue dwell before the first dispatch attempt never robs the
+// event of its self-heal window. firstSeen is always a real stamp (the marker is written on the
+// first miss), so there is no "unset timestamp" edge — an event with any ActedAt, including an
+// unset/legacy one, gets a full window from its first miss and can never wedge in permanent defer.
+func routeMissingExpired(firstSeen time.Time, now time.Time) bool {
+	return now.Sub(firstSeen) >= routeMissingMaxWindow
 }
 
 func errorCategory(err error) string {

--- a/internal/cardactiondispatch/dispatcher.go
+++ b/internal/cardactiondispatch/dispatcher.go
@@ -344,11 +344,19 @@ const routeMissingMaxWindow = 15 * time.Minute
 const routeMissingDeferInterval = 5 * time.Second
 
 // routeMissingExpired reports whether an event acted at actedAtUnix (unix seconds) has
-// waited on a missing route past routeMissingMaxWindow. A non-positive actedAt (unset)
-// is treated as not-expired, so a missing timestamp never forces a premature dead-letter.
+// waited on a missing route past routeMissingMaxWindow and must now be dead-lettered.
+//
+// A non-positive actedAt (unset / legacy / malformed) is treated as EXPIRED. The defer
+// loop bounds the wait by elapsed time since actedAt; with no trustworthy timestamp there
+// is nothing to measure against, so returning "not expired" here would re-defer the event
+// on every re-check forever — never delivered, never dead-lettered — silently breaking the
+// bounded-window guarantee (flagged in review). Dead-lettering immediately instead keeps the
+// event visible and replayable (reason=route_missing) rather than wedged in permanent defer.
+// Production always stamps ActedAt at enqueue (modules/message/api_card_action.go), so this
+// only ever catches a legacy/malformed event that predates or violates that invariant.
 func routeMissingExpired(actedAtUnix int64, now time.Time) bool {
 	if actedAtUnix <= 0 {
-		return false
+		return true
 	}
 	return now.Unix()-actedAtUnix >= int64(routeMissingMaxWindow/time.Second)
 }

--- a/internal/cardactiondispatch/dispatcher_test.go
+++ b/internal/cardactiondispatch/dispatcher_test.go
@@ -22,6 +22,10 @@ type concurrentLeaseQueue struct {
 	nacked   chan nackCall
 	renewed  chan renewCall
 	deferred chan deferCall
+	// routeMissingSince fakes the durable first-observed-miss marker. A test may pre-seed an
+	// entry to simulate an event that has already waited (→ past the window); otherwise the
+	// first RouteMissingSeenAt call stamps `now`, mirroring the real HSETNX-then-read.
+	routeMissingSince map[int64]time.Time
 }
 
 type nackCall struct {
@@ -85,6 +89,18 @@ func (q *concurrentLeaseQueue) Defer(eventID int64, token string, due time.Time)
 	return true, nil
 }
 func (*concurrentLeaseQueue) ReclaimExpired(time.Time, int) (int, error) { return 0, nil }
+func (q *concurrentLeaseQueue) RouteMissingSeenAt(eventID int64, now time.Time) (time.Time, error) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	if q.routeMissingSince == nil {
+		q.routeMissingSince = make(map[int64]time.Time)
+	}
+	if seen, ok := q.routeMissingSince[eventID]; ok {
+		return seen, nil
+	}
+	q.routeMissingSince[eventID] = now
+	return now, nil
+}
 
 type capturingDeliverer struct {
 	owners chan string

--- a/internal/cardactiondispatch/dlq_retention_test.go
+++ b/internal/cardactiondispatch/dlq_retention_test.go
@@ -6,8 +6,10 @@ import (
 )
 
 func TestDLQRetentionFromEnv(t *testing.T) {
-	if DefaultDLQRetention != 7*24*time.Hour {
-		t.Fatalf("DefaultDLQRetention = %v, want 7 days", DefaultDLQRetention)
+	// The default matches the value shipped before retention was configurable, so an
+	// upgrade that does not set the override keeps the existing 30-day recovery window.
+	if DefaultDLQRetention != 30*24*time.Hour {
+		t.Fatalf("DefaultDLQRetention = %v, want 30 days", DefaultDLQRetention)
 	}
 	tests := []struct {
 		name string
@@ -16,7 +18,7 @@ func TestDLQRetentionFromEnv(t *testing.T) {
 	}{
 		{"unset falls back to default", "", DefaultDLQRetention},
 		{"whitespace falls back to default", "   ", DefaultDLQRetention},
-		{"explicit default", "7", 7 * 24 * time.Hour},
+		{"seven-day override", "7", 7 * 24 * time.Hour},
 		{"one day", "1", 24 * time.Hour},
 		{"valid whole days", "14", 14 * 24 * time.Hour},
 		{"at max is accepted", "365", 365 * 24 * time.Hour},

--- a/internal/cardactiondispatch/dlq_retention_test.go
+++ b/internal/cardactiondispatch/dlq_retention_test.go
@@ -1,0 +1,41 @@
+package cardactiondispatch
+
+import (
+	"testing"
+	"time"
+)
+
+func TestDLQRetentionFromEnv(t *testing.T) {
+	if DefaultDLQRetention != 7*24*time.Hour {
+		t.Fatalf("DefaultDLQRetention = %v, want 7 days", DefaultDLQRetention)
+	}
+	tests := []struct {
+		name string
+		val  string
+		want time.Duration
+	}{
+		{"unset falls back to default", "", DefaultDLQRetention},
+		{"whitespace falls back to default", "   ", DefaultDLQRetention},
+		{"explicit default", "7", 7 * 24 * time.Hour},
+		{"one day", "1", 24 * time.Hour},
+		{"valid whole days", "14", 14 * 24 * time.Hour},
+		{"at max is accepted", "365", 365 * 24 * time.Hour},
+		{"zero falls back", "0", DefaultDLQRetention},
+		{"negative falls back", "-3", DefaultDLQRetention},
+		{"non-integer falls back", "7d", DefaultDLQRetention},
+		{"over-max falls back", "9999", DefaultDLQRetention},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			getenv := func(k string) string {
+				if k == DLQRetentionEnv {
+					return tt.val
+				}
+				return ""
+			}
+			if got := DLQRetentionFromEnv(getenv); got != tt.want {
+				t.Fatalf("DLQRetentionFromEnv(%q) = %v, want %v", tt.val, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/cardactiondispatch/queue.go
+++ b/internal/cardactiondispatch/queue.go
@@ -354,10 +354,24 @@ func (q *RedisQueue) ReplayDLQ(eventID int64, due time.Time) (bool, error) {
 	return value == 1, nil
 }
 
+// Depths prunes DLQ entries older than the retention window, then reports queue depths.
+// The running server calls this (via refreshDepthMetrics), so it is the single pruning
+// authority and prunes lazily with its own resolved retention. Read-only inspectors must
+// use DepthsNoPrune instead so observing the queue cannot delete recoverable entries.
 func (q *RedisQueue) Depths() (QueueDepths, error) {
 	if _, err := pruneDLQScript.Run(q.client, q.scriptKeys(), unixMillis(time.Now().Add(-q.dlqRetention))).Result(); err != nil {
 		return QueueDepths{}, fmt.Errorf("cardactiondispatch: prune expired DLQ events: %w", err)
 	}
+	return q.DepthsNoPrune()
+}
+
+// DepthsNoPrune reports queue depths WITHOUT pruning the DLQ. Use it for read-only
+// inspection (the card-action-dlq `depth` command) so merely observing the DLQ can never
+// delete recoverable entries — even from a shell whose OCTO_CARD_ACTION_DLQ_RETENTION_DAYS
+// differs from the server's. Pruning stays the running server's job (see Depths). The
+// reported DLQ count therefore includes any not-yet-pruned expired entries, which is the
+// honest current contents for a manual inspection.
+func (q *RedisQueue) DepthsNoPrune() (QueueDepths, error) {
 	pipe := q.client.Pipeline()
 	ready := pipe.ZCard(q.keys.ready)
 	leased := pipe.ZCard(q.keys.leased)

--- a/internal/cardactiondispatch/queue.go
+++ b/internal/cardactiondispatch/queue.go
@@ -94,6 +94,7 @@ redis.call('ZREM', KEYS[2], ARGV[1])
 redis.call('HDEL', KEYS[3], ARGV[1])
 redis.call('HDEL', KEYS[4], ARGV[1])
 redis.call('HDEL', KEYS[5], ARGV[1])
+redis.call('HDEL', KEYS[9], ARGV[1])
 return 1
 `)
 
@@ -122,6 +123,7 @@ local payload = redis.call('HGET', KEYS[3], ARGV[1])
 local attempt = tonumber(redis.call('HGET', KEYS[4], ARGV[1]) or '0')
 redis.call('ZREM', KEYS[2], ARGV[1])
 redis.call('HDEL', KEYS[5], ARGV[1])
+redis.call('HDEL', KEYS[9], ARGV[1])
 if attempt >= tonumber(ARGV[4]) then
 	local expired = redis.call('ZRANGEBYSCORE', KEYS[6], '-inf', ARGV[8])
 	for _, expired_id in ipairs(expired) do
@@ -195,10 +197,13 @@ return #expired
 // at dispatch, and returns that timestamp (unix ms). KEYS[1] = route_missing_since hash;
 // ARGV[1] = event_id, ARGV[2] = now_ms, ARGV[3] = ttl_ms. HSETNX-then-read semantics: the
 // first miss stamps now, later misses read the stored stamp, so the bounded route-missing
-// window is measured from the FIRST miss (not from Event.ActedAt). The hash carries the live
-// TTL so a marker for an event that is delivered/dead-lettered and never replayed self-reaps;
-// event IDs never recur, so a leaked marker is harmless. ReplayDLQ clears the marker so a
-// replayed event starts a fresh window.
+// window is measured from the FIRST miss (not from Event.ActedAt). The marker is explicitly
+// removed on every exit transition — ackScript, nackScript (both requeue and dead-letter),
+// and replayDLQScript all HDEL the field — so the hash only ever holds markers for events
+// currently waiting in the route-missing defer loop and CANNOT grow unbounded under sustained
+// route-missing traffic (a whole-hash PEXPIRE cannot expire individual fields, so relying on
+// TTL alone would leak). The hash-level TTL refreshed here to liveTTL is only a backstop that
+// reaps the whole key once misses stop.
 var routeMissingSinceScript = rd.NewScript(`
 local v = redis.call('HGET', KEYS[1], ARGV[1])
 if not v then

--- a/internal/cardactiondispatch/queue.go
+++ b/internal/cardactiondispatch/queue.go
@@ -48,14 +48,15 @@ type RedisQueue struct {
 }
 
 type queueKeys struct {
-	ready      string
-	leased     string
-	payload    string
-	attempts   string
-	tokens     string
-	dlq        string
-	dlqPayload string
-	dlqMeta    string
+	ready             string
+	leased            string
+	payload           string
+	attempts          string
+	tokens            string
+	dlq               string
+	dlqPayload        string
+	dlqMeta           string
+	routeMissingSince string
 }
 
 var enqueueScript = rd.NewScript(`
@@ -155,19 +156,24 @@ for i = 1, 5 do redis.call('PEXPIRE', KEYS[i], ARGV[3]) end
 return #ids
 `)
 
+// replayDLQScript returns a dead-lettered event to ready and resets its attempts. It is
+// NON-DESTRUCTIVE on a past-retention entry: it refuses (return 0) WITHOUT deleting, so the
+// running server's Depths() prune stays the single pruning authority. This matters because the
+// CLI resolves retention from its OWN env; if that window is shorter than the server's, deleting
+// here would silently destroy an entry the server still retains. On a successful replay it also
+// clears the route-missing first-seen marker (KEYS[9]) so the re-queued event starts a fresh
+// bounded window rather than inheriting its pre-DLQ first-miss time.
 var replayDLQScript = rd.NewScript(`
 local payload = redis.call('HGET', KEYS[7], ARGV[1])
 if not payload then return 0 end
 local score = redis.call('ZSCORE', KEYS[6], ARGV[1])
 if not score or tonumber(score) <= tonumber(ARGV[4]) then
-	redis.call('ZREM', KEYS[6], ARGV[1])
-	redis.call('HDEL', KEYS[7], ARGV[1])
-	redis.call('HDEL', KEYS[8], ARGV[1])
 	return 0
 end
 redis.call('ZREM', KEYS[6], ARGV[1])
 redis.call('HDEL', KEYS[7], ARGV[1])
 redis.call('HDEL', KEYS[8], ARGV[1])
+redis.call('HDEL', KEYS[9], ARGV[1])
 redis.call('HSET', KEYS[3], ARGV[1], payload)
 redis.call('HSET', KEYS[4], ARGV[1], 0)
 redis.call('ZADD', KEYS[1], ARGV[2], ARGV[1])
@@ -185,6 +191,24 @@ redis.call('ZREMRANGEBYSCORE', KEYS[6], '-inf', ARGV[1])
 return #expired
 `)
 
+// routeMissingSinceScript records — once — when an event's route was first observed missing
+// at dispatch, and returns that timestamp (unix ms). KEYS[1] = route_missing_since hash;
+// ARGV[1] = event_id, ARGV[2] = now_ms, ARGV[3] = ttl_ms. HSETNX-then-read semantics: the
+// first miss stamps now, later misses read the stored stamp, so the bounded route-missing
+// window is measured from the FIRST miss (not from Event.ActedAt). The hash carries the live
+// TTL so a marker for an event that is delivered/dead-lettered and never replayed self-reaps;
+// event IDs never recur, so a leaked marker is harmless. ReplayDLQ clears the marker so a
+// replayed event starts a fresh window.
+var routeMissingSinceScript = rd.NewScript(`
+local v = redis.call('HGET', KEYS[1], ARGV[1])
+if not v then
+  redis.call('HSET', KEYS[1], ARGV[1], ARGV[2])
+  v = ARGV[2]
+end
+redis.call('PEXPIRE', KEYS[1], ARGV[3])
+return v
+`)
+
 func NewRedisQueue(client *rd.Client, cfg QueueConfig) (*RedisQueue, error) {
 	if client == nil {
 		return nil, errors.New("cardactiondispatch: Redis client is required")
@@ -199,14 +223,15 @@ func NewRedisQueue(client *rd.Client, cfg QueueConfig) (*RedisQueue, error) {
 	return &RedisQueue{
 		client: client,
 		keys: queueKeys{
-			ready:      base + "ready",
-			leased:     base + "leased",
-			payload:    base + "payload",
-			attempts:   base + "attempts",
-			tokens:     base + "tokens",
-			dlq:        base + "dlq",
-			dlqPayload: base + "dlq_payload",
-			dlqMeta:    base + "dlq_meta",
+			ready:             base + "ready",
+			leased:            base + "leased",
+			payload:           base + "payload",
+			attempts:          base + "attempts",
+			tokens:            base + "tokens",
+			dlq:               base + "dlq",
+			dlqPayload:        base + "dlq_payload",
+			dlqMeta:           base + "dlq_meta",
+			routeMissingSince: base + "route_missing_since",
 		},
 		liveTTL:      cfg.LiveTTL,
 		dlqRetention: cfg.DLQRetention,
@@ -386,7 +411,23 @@ func (q *RedisQueue) scriptKeys() []string {
 	return []string{
 		q.keys.ready, q.keys.leased, q.keys.payload, q.keys.attempts,
 		q.keys.tokens, q.keys.dlq, q.keys.dlqPayload, q.keys.dlqMeta,
+		q.keys.routeMissingSince,
 	}
+}
+
+// RouteMissingSeenAt records (once) and returns when this event's route was first observed
+// missing at dispatch. The bounded route-missing defer window is measured from this point —
+// NOT from Event.ActedAt — so an event that sat in the durable queue for a long time before
+// its first dispatch attempt (a long restart/outage/backlog window carried by the durable
+// queue) still gets the full self-heal window on its first transient miss, instead of being
+// dead-lettered immediately because its acted-at is already older than the window.
+func (q *RedisQueue) RouteMissingSeenAt(eventID int64, now time.Time) (time.Time, error) {
+	ms, err := routeMissingSinceScript.Run(q.client, []string{q.keys.routeMissingSince},
+		strconv.FormatInt(eventID, 10), unixMillis(now), durationMillis(q.liveTTL)).Int64()
+	if err != nil {
+		return time.Time{}, fmt.Errorf("cardactiondispatch: record route-missing first-seen: %w", err)
+	}
+	return time.UnixMilli(ms), nil
 }
 
 func newLeaseToken() (string, error) {

--- a/internal/cardactiondispatch/route_missing_queue_test.go
+++ b/internal/cardactiondispatch/route_missing_queue_test.go
@@ -2,6 +2,7 @@ package cardactiondispatch
 
 import (
 	"fmt"
+	"strconv"
 	"testing"
 	"time"
 
@@ -9,8 +10,9 @@ import (
 )
 
 // newRedisTestQueue builds a RedisQueue against a local Redis, skipping when none is reachable
-// (matching TestRedisQueueDLQRetentionIsPerEvent). It registers cleanup of the keyspace.
-func newRedisTestQueue(t *testing.T, name string) *RedisQueue {
+// (matching TestRedisQueueDLQRetentionIsPerEvent). It registers cleanup of the keyspace and
+// returns the client so a test can inspect low-level keys (e.g. the route_missing_since hash).
+func newRedisTestQueue(t *testing.T, name string) (*RedisQueue, *rd.Client) {
 	t.Helper()
 	client := rd.NewClient(&rd.Options{Addr: "127.0.0.1:6379"})
 	if err := client.Ping().Err(); err != nil {
@@ -27,7 +29,7 @@ func newRedisTestQueue(t *testing.T, name string) *RedisQueue {
 			_ = client.Del(keys...).Err()
 		}
 	})
-	return queue
+	return queue, client
 }
 
 // TestReplayDLQPastRetentionIsNonDestructive pins the fix for the CLI replay data-loss path:
@@ -35,7 +37,7 @@ func newRedisTestQueue(t *testing.T, name string) *RedisQueue {
 // delete it — the running server's Depths() prune is the single pruning authority. Otherwise a
 // CLI whose retention is shorter than the server's would silently destroy a recoverable entry.
 func TestReplayDLQPastRetentionIsNonDestructive(t *testing.T) {
-	queue := newRedisTestQueue(t, "card_action_replay_nondestructive")
+	queue, _ := newRedisTestQueue(t, "card_action_replay_nondestructive")
 	now := time.Now().Truncate(time.Millisecond)
 	event := testDispatchEvent()
 	if err := queue.Enqueue(event, now); err != nil {
@@ -72,7 +74,7 @@ func TestReplayDLQPastRetentionIsNonDestructive(t *testing.T) {
 // and returns that same time on later calls (so the bounded window is measured from the first
 // miss, not from a moving now), and ReplayDLQ clears it so a replayed event starts fresh.
 func TestRouteMissingSeenAtAnchorsOnFirstMiss(t *testing.T) {
-	queue := newRedisTestQueue(t, "card_action_first_miss")
+	queue, _ := newRedisTestQueue(t, "card_action_first_miss")
 	event := testDispatchEvent()
 	first := time.Now().Truncate(time.Millisecond)
 
@@ -115,5 +117,64 @@ func TestRouteMissingSeenAtAnchorsOnFirstMiss(t *testing.T) {
 	}
 	if !seen3.Equal(fresh) {
 		t.Fatalf("RouteMissingSeenAt after replay = %v, want fresh %v (marker must be cleared on replay)", seen3, fresh)
+	}
+}
+
+// TestRouteMissingMarkerClearedOnTerminalTransitions pins the marker lifecycle: the
+// route_missing_since field for an event must be removed on successful delivery (Ack) and on
+// terminal dead-letter (Nack). Otherwise the shared hash accumulates a field per completed event
+// under sustained route-missing traffic — a whole-hash TTL cannot expire individual fields, and
+// every new miss refreshes it, so the key never sheds orphaned fields (the leak Jerry-Xin caught).
+func TestRouteMissingMarkerClearedOnTerminalTransitions(t *testing.T) {
+	queue, client := newRedisTestQueue(t, "card_action_marker_lifecycle")
+	event := testDispatchEvent()
+	field := strconv.FormatInt(event.EventID, 10)
+	now := time.Now().Truncate(time.Millisecond)
+
+	markerExists := func() bool {
+		exists, err := client.HExists(queue.keys.routeMissingSince, field).Result()
+		if err != nil {
+			t.Fatalf("HExists() error = %v", err)
+		}
+		return exists
+	}
+
+	// Delivered path: marker present after the first miss, gone after Ack.
+	if _, err := queue.RouteMissingSeenAt(event.EventID, now); err != nil {
+		t.Fatalf("RouteMissingSeenAt() error = %v", err)
+	}
+	if !markerExists() {
+		t.Fatal("marker missing right after RouteMissingSeenAt")
+	}
+	if err := queue.Enqueue(event, now); err != nil {
+		t.Fatalf("Enqueue() error = %v", err)
+	}
+	lease, err := queue.Claim(now, time.Minute)
+	if err != nil || lease == nil {
+		t.Fatalf("Claim() = (%+v, %v)", lease, err)
+	}
+	if acked, err := queue.Ack(event.EventID, lease.Token); err != nil || !acked {
+		t.Fatalf("Ack() = (%v, %v), want (true, nil)", acked, err)
+	}
+	if markerExists() {
+		t.Fatal("route-missing marker still present after Ack; it must be cleared on delivery")
+	}
+
+	// Dead-letter path: marker re-created on a fresh miss, gone after terminal Nack.
+	if _, err := queue.RouteMissingSeenAt(event.EventID, now); err != nil {
+		t.Fatalf("RouteMissingSeenAt() error = %v", err)
+	}
+	if err := queue.Enqueue(event, now); err != nil {
+		t.Fatalf("Enqueue() error = %v", err)
+	}
+	lease, err = queue.Claim(now, time.Minute)
+	if err != nil || lease == nil {
+		t.Fatalf("Claim() = (%+v, %v)", lease, err)
+	}
+	if outcome, err := queue.Nack(*lease, now, time.Hour, 1, "route_missing"); err != nil || outcome != NackDeadLettered {
+		t.Fatalf("Nack() = (%q, %v), want dead_lettered", outcome, err)
+	}
+	if markerExists() {
+		t.Fatal("route-missing marker still present after terminal dead-letter; it must be cleared on DLQ")
 	}
 }

--- a/internal/cardactiondispatch/route_missing_queue_test.go
+++ b/internal/cardactiondispatch/route_missing_queue_test.go
@@ -1,0 +1,119 @@
+package cardactiondispatch
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	rd "github.com/go-redis/redis"
+)
+
+// newRedisTestQueue builds a RedisQueue against a local Redis, skipping when none is reachable
+// (matching TestRedisQueueDLQRetentionIsPerEvent). It registers cleanup of the keyspace.
+func newRedisTestQueue(t *testing.T, name string) *RedisQueue {
+	t.Helper()
+	client := rd.NewClient(&rd.Options{Addr: "127.0.0.1:6379"})
+	if err := client.Ping().Err(); err != nil {
+		t.Skipf("Redis unavailable: %v", err)
+	}
+	t.Cleanup(func() { _ = client.Close() })
+	prefix := fmt.Sprintf("test:%s:%d", name, time.Now().UnixNano())
+	queue, err := NewRedisQueue(client, QueueConfig{Prefix: prefix, LiveTTL: time.Hour, DLQRetention: 30 * 24 * time.Hour})
+	if err != nil {
+		t.Fatalf("NewRedisQueue() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if keys, _ := client.Keys(prefix + "*").Result(); len(keys) > 0 {
+			_ = client.Del(keys...).Err()
+		}
+	})
+	return queue
+}
+
+// TestReplayDLQPastRetentionIsNonDestructive pins the fix for the CLI replay data-loss path:
+// replaying an entry older than the resolved retention REFUSES it (returns false) but must NOT
+// delete it — the running server's Depths() prune is the single pruning authority. Otherwise a
+// CLI whose retention is shorter than the server's would silently destroy a recoverable entry.
+func TestReplayDLQPastRetentionIsNonDestructive(t *testing.T) {
+	queue := newRedisTestQueue(t, "card_action_replay_nondestructive")
+	now := time.Now().Truncate(time.Millisecond)
+	event := testDispatchEvent()
+	if err := queue.Enqueue(event, now); err != nil {
+		t.Fatalf("Enqueue() error = %v", err)
+	}
+	lease, err := queue.Claim(now, time.Minute)
+	if err != nil || lease == nil {
+		t.Fatalf("Claim() = (%+v, %v)", lease, err)
+	}
+	if outcome, err := queue.Nack(*lease, now, time.Hour, 1, "forced"); err != nil || outcome != NackDeadLettered {
+		t.Fatalf("Nack() = (%q, %v), want dead_lettered", outcome, err)
+	}
+
+	// A replay whose due is past the retention window judges the entry expired and refuses it,
+	// but must leave it in the DLQ.
+	if replayed, err := queue.ReplayDLQ(event.EventID, now.Add(30*24*time.Hour+time.Millisecond)); err != nil || replayed {
+		t.Fatalf("ReplayDLQ(past retention) = (%v, %v), want (false, nil)", replayed, err)
+	}
+	depths, err := queue.DepthsNoPrune()
+	if err != nil {
+		t.Fatalf("DepthsNoPrune() error = %v", err)
+	}
+	if depths.DLQ != 1 {
+		t.Fatalf("DLQ depth after a refused replay = %d, want 1 (the entry must survive, not be deleted)", depths.DLQ)
+	}
+
+	// Proof the entry really survived: a within-window replay now succeeds.
+	if replayed, err := queue.ReplayDLQ(event.EventID, now.Add(time.Hour)); err != nil || !replayed {
+		t.Fatalf("ReplayDLQ(within window) = (%v, %v), want (true, nil)", replayed, err)
+	}
+}
+
+// TestRouteMissingSeenAtAnchorsOnFirstMiss pins the first-observed-miss marker: it stamps once
+// and returns that same time on later calls (so the bounded window is measured from the first
+// miss, not from a moving now), and ReplayDLQ clears it so a replayed event starts fresh.
+func TestRouteMissingSeenAtAnchorsOnFirstMiss(t *testing.T) {
+	queue := newRedisTestQueue(t, "card_action_first_miss")
+	event := testDispatchEvent()
+	first := time.Now().Truncate(time.Millisecond)
+
+	seen1, err := queue.RouteMissingSeenAt(event.EventID, first)
+	if err != nil {
+		t.Fatalf("RouteMissingSeenAt(first) error = %v", err)
+	}
+	if !seen1.Equal(first) {
+		t.Fatalf("first RouteMissingSeenAt = %v, want %v", seen1, first)
+	}
+	// A later re-check must return the FIRST stamp — the window does not slide forward.
+	seen2, err := queue.RouteMissingSeenAt(event.EventID, first.Add(10*time.Minute))
+	if err != nil {
+		t.Fatalf("RouteMissingSeenAt(second) error = %v", err)
+	}
+	if !seen2.Equal(first) {
+		t.Fatalf("second RouteMissingSeenAt = %v, want the first stamp %v (window must anchor on first miss)", seen2, first)
+	}
+
+	// DLQ the event, then replay it: the marker must be cleared so a replayed event gets a
+	// fresh window rather than inheriting its pre-DLQ first-miss time.
+	if err := queue.Enqueue(event, first); err != nil {
+		t.Fatalf("Enqueue() error = %v", err)
+	}
+	lease, err := queue.Claim(first, time.Minute)
+	if err != nil || lease == nil {
+		t.Fatalf("Claim() = (%+v, %v)", lease, err)
+	}
+	if outcome, err := queue.Nack(*lease, first, time.Hour, 1, "forced"); err != nil || outcome != NackDeadLettered {
+		t.Fatalf("Nack() = (%q, %v), want dead_lettered", outcome, err)
+	}
+	if replayed, err := queue.ReplayDLQ(event.EventID, first.Add(time.Minute)); err != nil || !replayed {
+		t.Fatalf("ReplayDLQ() = (%v, %v), want (true, nil)", replayed, err)
+	}
+
+	fresh := first.Add(time.Hour)
+	seen3, err := queue.RouteMissingSeenAt(event.EventID, fresh)
+	if err != nil {
+		t.Fatalf("RouteMissingSeenAt(after replay) error = %v", err)
+	}
+	if !seen3.Equal(fresh) {
+		t.Fatalf("RouteMissingSeenAt after replay = %v, want fresh %v (marker must be cleared on replay)", seen3, fresh)
+	}
+}

--- a/internal/cardactiondispatch/route_missing_test.go
+++ b/internal/cardactiondispatch/route_missing_test.go
@@ -127,7 +127,69 @@ func TestRouteMissingDeadLettersAfterWindow(t *testing.T) {
 	}
 }
 
+// TestRouteMissingZeroActedAtDeadLetters proves a route-missing event whose ActedAt is
+// unset (0) dead-letters immediately instead of deferring forever. Enqueue validation does
+// not require ActedAt, so a legacy/malformed event with ActedAt<=0 is a reachable persisted
+// state; without this guard the defer loop would re-check it every routeMissingDeferInterval
+// indefinitely — never delivered, never dead-lettered — silently breaking the bounded window.
+func TestRouteMissingZeroActedAtDeadLetters(t *testing.T) {
+	registry, err := NewRegistry(nil, testGetenv)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	neverDeliver := callbackDelivererFunc(func(context.Context, *Route, DecisionRequest) (DecisionResult, error) {
+		t.Fatal("Deliver must not run when the route is missing")
+		return DecisionResult{}, nil
+	})
+	neverFinalize := FinalizerFunc(func(context.Context, Event, DecisionResult) error {
+		t.Fatal("Finalize must not run when the route is missing")
+		return nil
+	})
+
+	// ActedAt deliberately unset (0) → no basis to measure the wait → dead-letter now.
+	event := Event{
+		EventID: 1003002, SenderUID: "notification", Owner: "docs",
+		ActionType: "access_request.decision", ActedAt: 0,
+	}
+	queue := &concurrentLeaseQueue{
+		leases:   []Lease{{Event: event, Token: "lease", Attempt: 1}},
+		nacked:   make(chan nackCall, 1),
+		deferred: make(chan deferCall, 1),
+	}
+	dispatcher, err := NewDispatcher(queue, registry, neverDeliver, neverFinalize, DispatcherConfig{
+		LeaseDuration: time.Second,
+		PollInterval:  time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("NewDispatcher() error = %v", err)
+	}
+
+	processed, procErr := dispatcher.ProcessOne(context.Background(), time.Now())
+	if !processed || procErr != nil {
+		t.Fatalf("ProcessOne() = (%v, %v), want (true, nil)", processed, procErr)
+	}
+
+	select {
+	case dc := <-queue.deferred:
+		t.Fatalf("zero-ActedAt route-missing event was deferred (%+v); want an immediate dead-letter, not a permanent defer loop", dc)
+	default:
+	}
+	select {
+	case nc := <-queue.nacked:
+		if nc.reason != "route_missing" {
+			t.Fatalf("nack reason = %q, want route_missing", nc.reason)
+		}
+		if nc.leaseAttempt < nc.maxAttempts {
+			t.Fatalf("leaseAttempt=%d < maxAttempts=%d; want an immediate dead-letter", nc.leaseAttempt, nc.maxAttempts)
+		}
+	default:
+		t.Fatal("zero-ActedAt route-missing event was neither deferred nor dead-lettered")
+	}
+}
+
 // TestRouteMissingExpired covers the window boundary and the unset-timestamp guard.
+// A non-positive acted_at is EXPIRED (dead-letter immediately) rather than never-expired:
+// with no timestamp to measure the wait against, deferring forever would wedge the event.
 func TestRouteMissingExpired(t *testing.T) {
 	now := time.Unix(1_700_000_000, 0)
 	windowSecs := int64(routeMissingMaxWindow / time.Second)
@@ -136,8 +198,8 @@ func TestRouteMissingExpired(t *testing.T) {
 		actedAt int64
 		want    bool
 	}{
-		{"unset acted_at is never expired", 0, false},
-		{"negative acted_at is never expired", -5, false},
+		{"unset acted_at dead-letters immediately (never wedged in defer)", 0, true},
+		{"negative acted_at dead-letters immediately", -5, true},
 		{"just acted", now.Unix(), false},
 		{"one second before the window", now.Unix() - windowSecs + 1, false},
 		{"exactly at the window", now.Unix() - windowSecs, true},

--- a/internal/cardactiondispatch/route_missing_test.go
+++ b/internal/cardactiondispatch/route_missing_test.go
@@ -1,0 +1,153 @@
+package cardactiondispatch
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// TestRouteMissingDefersWithoutConsumingAttempt pins the hardened route-missing
+// behavior. An event only reaches this queue when its route existed at enqueue time,
+// so a miss at dispatch means the route was absent from THIS process's registry then
+// (a rolling deploy / restart that came up before OCTO_CARD_ACTION_ROUTES loaded it,
+// with the durable queue outliving that window). Within routeMissingMaxWindow the event
+// must be DEFERRED — not nacked — so it waits out the window and dispatches on its
+// ORIGINAL attempt budget once the route returns, instead of burning attempts (which
+// would trip attempts_exhausted the moment the route came back). Deliver/Finalize never
+// run while the route is missing.
+func TestRouteMissingDefersWithoutConsumingAttempt(t *testing.T) {
+	registry, err := NewRegistry(nil, testGetenv) // deliberately WITHOUT the docs route
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	neverDeliver := callbackDelivererFunc(func(context.Context, *Route, DecisionRequest) (DecisionResult, error) {
+		t.Fatal("Deliver must not run when the route is missing (docs-backend is never contacted)")
+		return DecisionResult{}, nil
+	})
+	neverFinalize := FinalizerFunc(func(context.Context, Event, DecisionResult) error {
+		t.Fatal("Finalize must not run when the route is missing (the card is never rewritten)")
+		return nil
+	})
+
+	// Fresh event (acted just now) → well inside routeMissingMaxWindow.
+	event := Event{
+		EventID: 1003002, SenderUID: "notification", Owner: "docs",
+		ActionType: "access_request.decision", ActedAt: time.Now().Unix(),
+	}
+	queue := &concurrentLeaseQueue{
+		leases:   []Lease{{Event: event, Token: "lease-1003002", Attempt: 1}},
+		nacked:   make(chan nackCall, 1),
+		deferred: make(chan deferCall, 1),
+	}
+	dispatcher, err := NewDispatcher(queue, registry, neverDeliver, neverFinalize, DispatcherConfig{
+		LeaseDuration: time.Second,
+		PollInterval:  time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("NewDispatcher() error = %v", err)
+	}
+
+	processed, procErr := dispatcher.ProcessOne(context.Background(), time.Now())
+	if !processed || procErr != nil {
+		t.Fatalf("ProcessOne() = (%v, %v), want (true, nil)", processed, procErr)
+	}
+
+	// Must DEFER (no attempt consumed), not nack/dead-letter.
+	select {
+	case dc := <-queue.deferred:
+		if dc.eventID != event.EventID || dc.token != "lease-1003002" {
+			t.Fatalf("defer targeted %+v, want event %d token lease-1003002", dc, event.EventID)
+		}
+	default:
+		t.Fatal("route-missing event was not deferred (attempt would be consumed by a nack)")
+	}
+	select {
+	case nc := <-queue.nacked:
+		t.Fatalf("route-missing event was nacked (%+v); a nack consumes an attempt and can trip attempts_exhausted when the route returns", nc)
+	default:
+	}
+}
+
+// TestRouteMissingDeadLettersAfterWindow: an event that has waited on a missing route
+// past routeMissingMaxWindow is a genuine misconfiguration — dead-letter it (immediate
+// DLQ, reason preserved) so it stays visible, instead of deferring forever.
+func TestRouteMissingDeadLettersAfterWindow(t *testing.T) {
+	registry, err := NewRegistry(nil, testGetenv)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	neverDeliver := callbackDelivererFunc(func(context.Context, *Route, DecisionRequest) (DecisionResult, error) {
+		t.Fatal("Deliver must not run when the route is missing")
+		return DecisionResult{}, nil
+	})
+	neverFinalize := FinalizerFunc(func(context.Context, Event, DecisionResult) error {
+		t.Fatal("Finalize must not run when the route is missing")
+		return nil
+	})
+
+	// Acted well past routeMissingMaxWindow ago.
+	event := Event{
+		EventID: 1003002, SenderUID: "notification", Owner: "docs",
+		ActionType: "access_request.decision",
+		ActedAt:    time.Now().Add(-routeMissingMaxWindow - time.Minute).Unix(),
+	}
+	queue := &concurrentLeaseQueue{
+		leases:   []Lease{{Event: event, Token: "lease", Attempt: 1}},
+		nacked:   make(chan nackCall, 1),
+		deferred: make(chan deferCall, 1),
+	}
+	dispatcher, err := NewDispatcher(queue, registry, neverDeliver, neverFinalize, DispatcherConfig{
+		LeaseDuration: time.Second,
+		PollInterval:  time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("NewDispatcher() error = %v", err)
+	}
+
+	processed, procErr := dispatcher.ProcessOne(context.Background(), time.Now())
+	if !processed || procErr != nil {
+		t.Fatalf("ProcessOne() = (%v, %v), want (true, nil)", processed, procErr)
+	}
+
+	select {
+	case dc := <-queue.deferred:
+		t.Fatalf("expired route-missing event was deferred (%+v); want a dead-letter after the window", dc)
+	default:
+	}
+	select {
+	case nc := <-queue.nacked:
+		if nc.reason != "route_missing" {
+			t.Fatalf("nack reason = %q, want route_missing", nc.reason)
+		}
+		if nc.leaseAttempt < nc.maxAttempts {
+			t.Fatalf("leaseAttempt=%d < maxAttempts=%d; want an immediate dead-letter", nc.leaseAttempt, nc.maxAttempts)
+		}
+	default:
+		t.Fatal("expired route-missing event was neither deferred nor dead-lettered")
+	}
+}
+
+// TestRouteMissingExpired covers the window boundary and the unset-timestamp guard.
+func TestRouteMissingExpired(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	windowSecs := int64(routeMissingMaxWindow / time.Second)
+	cases := []struct {
+		name    string
+		actedAt int64
+		want    bool
+	}{
+		{"unset acted_at is never expired", 0, false},
+		{"negative acted_at is never expired", -5, false},
+		{"just acted", now.Unix(), false},
+		{"one second before the window", now.Unix() - windowSecs + 1, false},
+		{"exactly at the window", now.Unix() - windowSecs, true},
+		{"past the window", now.Unix() - windowSecs - 60, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := routeMissingExpired(tc.actedAt, now); got != tc.want {
+				t.Fatalf("routeMissingExpired(%d, now) = %v, want %v", tc.actedAt, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/cardactiondispatch/route_missing_test.go
+++ b/internal/cardactiondispatch/route_missing_test.go
@@ -68,9 +68,10 @@ func TestRouteMissingDefersWithoutConsumingAttempt(t *testing.T) {
 	}
 }
 
-// TestRouteMissingDeadLettersAfterWindow: an event that has waited on a missing route
-// past routeMissingMaxWindow is a genuine misconfiguration — dead-letter it (immediate
-// DLQ, reason preserved) so it stays visible, instead of deferring forever.
+// TestRouteMissingDeadLettersAfterWindow: an event whose route was FIRST observed missing
+// more than routeMissingMaxWindow ago is a genuine misconfiguration — dead-letter it (immediate
+// DLQ, reason preserved) so it stays visible, instead of deferring forever. The window is
+// anchored on the first-observed miss (pre-seeded here), not on Event.ActedAt.
 func TestRouteMissingDeadLettersAfterWindow(t *testing.T) {
 	registry, err := NewRegistry(nil, testGetenv)
 	if err != nil {
@@ -85,16 +86,18 @@ func TestRouteMissingDeadLettersAfterWindow(t *testing.T) {
 		return nil
 	})
 
-	// Acted well past routeMissingMaxWindow ago.
 	event := Event{
 		EventID: 1003002, SenderUID: "notification", Owner: "docs",
-		ActionType: "access_request.decision",
-		ActedAt:    time.Now().Add(-routeMissingMaxWindow - time.Minute).Unix(),
+		ActionType: "access_request.decision", ActedAt: time.Now().Unix(),
 	}
 	queue := &concurrentLeaseQueue{
 		leases:   []Lease{{Event: event, Token: "lease", Attempt: 1}},
 		nacked:   make(chan nackCall, 1),
 		deferred: make(chan deferCall, 1),
+		// Route first observed missing well past the window → dead-letter on this claim.
+		routeMissingSince: map[int64]time.Time{
+			event.EventID: time.Now().Add(-routeMissingMaxWindow - time.Minute),
+		},
 	}
 	dispatcher, err := NewDispatcher(queue, registry, neverDeliver, neverFinalize, DispatcherConfig{
 		LeaseDuration: time.Second,
@@ -127,12 +130,14 @@ func TestRouteMissingDeadLettersAfterWindow(t *testing.T) {
 	}
 }
 
-// TestRouteMissingZeroActedAtDeadLetters proves a route-missing event whose ActedAt is
-// unset (0) dead-letters immediately instead of deferring forever. Enqueue validation does
-// not require ActedAt, so a legacy/malformed event with ActedAt<=0 is a reachable persisted
-// state; without this guard the defer loop would re-check it every routeMissingDeferInterval
-// indefinitely — never delivered, never dead-lettered — silently breaking the bounded window.
-func TestRouteMissingZeroActedAtDeadLetters(t *testing.T) {
+// TestRouteMissingOldActedAtDefersOnFirstMiss proves the window is anchored on the FIRST
+// observed miss, not on Event.ActedAt. An event that sat in the durable queue far longer than
+// routeMissingMaxWindow before its first dispatch attempt — a long restart / outage / backlog,
+// exactly the window this guards — must still DEFER on its first transient miss and get the full
+// self-heal window, not be dead-lettered immediately because its acted-at is already old. (An
+// unset ActedAt=0 is just an extreme of the same case: with no marker yet, the first miss stamps
+// now and the event defers — so it can never wedge in a permanent defer loop either.)
+func TestRouteMissingOldActedAtDefersOnFirstMiss(t *testing.T) {
 	registry, err := NewRegistry(nil, testGetenv)
 	if err != nil {
 		t.Fatalf("NewRegistry() error = %v", err)
@@ -146,15 +151,18 @@ func TestRouteMissingZeroActedAtDeadLetters(t *testing.T) {
 		return nil
 	})
 
-	// ActedAt deliberately unset (0) → no basis to measure the wait → dead-letter now.
+	// Acted (and enqueued) an hour ago, far past routeMissingMaxWindow, but this is its FIRST
+	// route miss — no first-seen marker yet, so the window starts now.
 	event := Event{
 		EventID: 1003002, SenderUID: "notification", Owner: "docs",
-		ActionType: "access_request.decision", ActedAt: 0,
+		ActionType: "access_request.decision",
+		ActedAt:    time.Now().Add(-time.Hour).Unix(),
 	}
 	queue := &concurrentLeaseQueue{
 		leases:   []Lease{{Event: event, Token: "lease", Attempt: 1}},
 		nacked:   make(chan nackCall, 1),
 		deferred: make(chan deferCall, 1),
+		// No routeMissingSince entry → first miss stamps now → full window ahead.
 	}
 	dispatcher, err := NewDispatcher(queue, registry, neverDeliver, neverFinalize, DispatcherConfig{
 		LeaseDuration: time.Second,
@@ -169,46 +177,40 @@ func TestRouteMissingZeroActedAtDeadLetters(t *testing.T) {
 		t.Fatalf("ProcessOne() = (%v, %v), want (true, nil)", processed, procErr)
 	}
 
+	// Must DEFER on its first miss despite the hour-old ActedAt.
 	select {
 	case dc := <-queue.deferred:
-		t.Fatalf("zero-ActedAt route-missing event was deferred (%+v); want an immediate dead-letter, not a permanent defer loop", dc)
+		if dc.eventID != event.EventID {
+			t.Fatalf("defer targeted %+v, want event %d", dc, event.EventID)
+		}
 	default:
+		t.Fatal("old-ActedAt event on its FIRST route miss was not deferred; the window must anchor on the first observed miss, not ActedAt")
 	}
 	select {
 	case nc := <-queue.nacked:
-		if nc.reason != "route_missing" {
-			t.Fatalf("nack reason = %q, want route_missing", nc.reason)
-		}
-		if nc.leaseAttempt < nc.maxAttempts {
-			t.Fatalf("leaseAttempt=%d < maxAttempts=%d; want an immediate dead-letter", nc.leaseAttempt, nc.maxAttempts)
-		}
+		t.Fatalf("old-ActedAt event was dead-lettered on its first miss (%+v); the window must anchor on the first observed miss, not ActedAt", nc)
 	default:
-		t.Fatal("zero-ActedAt route-missing event was neither deferred nor dead-lettered")
 	}
 }
 
-// TestRouteMissingExpired covers the window boundary and the unset-timestamp guard.
-// A non-positive acted_at is EXPIRED (dead-letter immediately) rather than never-expired:
-// with no timestamp to measure the wait against, deferring forever would wedge the event.
+// TestRouteMissingExpired covers the window boundary. The window is anchored on the first
+// observed miss (firstSeen), so it is a pure elapsed-time check with no unset-timestamp edge.
 func TestRouteMissingExpired(t *testing.T) {
 	now := time.Unix(1_700_000_000, 0)
-	windowSecs := int64(routeMissingMaxWindow / time.Second)
 	cases := []struct {
-		name    string
-		actedAt int64
-		want    bool
+		name      string
+		firstSeen time.Time
+		want      bool
 	}{
-		{"unset acted_at dead-letters immediately (never wedged in defer)", 0, true},
-		{"negative acted_at dead-letters immediately", -5, true},
-		{"just acted", now.Unix(), false},
-		{"one second before the window", now.Unix() - windowSecs + 1, false},
-		{"exactly at the window", now.Unix() - windowSecs, true},
-		{"past the window", now.Unix() - windowSecs - 60, true},
+		{"just observed missing", now, false},
+		{"one second before the window", now.Add(-routeMissingMaxWindow + time.Second), false},
+		{"exactly at the window", now.Add(-routeMissingMaxWindow), true},
+		{"past the window", now.Add(-routeMissingMaxWindow - time.Minute), true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := routeMissingExpired(tc.actedAt, now); got != tc.want {
-				t.Fatalf("routeMissingExpired(%d, now) = %v, want %v", tc.actedAt, got, tc.want)
+			if got := routeMissingExpired(tc.firstSeen, now); got != tc.want {
+				t.Fatalf("routeMissingExpired(%v, now) = %v, want %v", tc.firstSeen, got, tc.want)
 			}
 		})
 	}

--- a/main.go
+++ b/main.go
@@ -528,10 +528,13 @@ func installCardActionDispatch(ctx *config.Context) (*cardActionDispatchRuntime,
 		options.PoolSize = 10
 	})
 	dlqRetention := cardactiondispatch.DLQRetentionFromEnv(os.Getenv)
-	// Log the resolved retention so a typo'd OCTO_CARD_ACTION_DLQ_RETENTION_DAYS that
-	// silently fell back to the default is visible, and so operators can match the CLI.
+	// Log both the raw override and the resolved retention so a typo'd
+	// OCTO_CARD_ACTION_DLQ_RETENTION_DAYS that silently fell back to the default is visible
+	// (raw="90x" but retention=720h reveals the fallback), and so operators can match the CLI.
 	log.NewTLog("CardActionDispatch").Info("card action DLQ retention resolved",
-		zap.Duration("retention", dlqRetention), zap.String("env", cardactiondispatch.DLQRetentionEnv))
+		zap.Duration("retention", dlqRetention),
+		zap.String("env", cardactiondispatch.DLQRetentionEnv),
+		zap.String("raw", os.Getenv(cardactiondispatch.DLQRetentionEnv)))
 	queue, err := cardactiondispatch.NewRedisQueue(redisClient, cardactiondispatch.QueueConfig{
 		Prefix:       "card_action_dispatch",
 		LiveTTL:      ctx.GetConfig().Robot.MessageExpire,

--- a/main.go
+++ b/main.go
@@ -527,10 +527,15 @@ func installCardActionDispatch(ctx *config.Context) (*cardActionDispatchRuntime,
 		options.MaxRetries = 1
 		options.PoolSize = 10
 	})
+	dlqRetention := cardactiondispatch.DLQRetentionFromEnv(os.Getenv)
+	// Log the resolved retention so a typo'd OCTO_CARD_ACTION_DLQ_RETENTION_DAYS that
+	// silently fell back to the default is visible, and so operators can match the CLI.
+	log.NewTLog("CardActionDispatch").Info("card action DLQ retention resolved",
+		zap.Duration("retention", dlqRetention), zap.String("env", cardactiondispatch.DLQRetentionEnv))
 	queue, err := cardactiondispatch.NewRedisQueue(redisClient, cardactiondispatch.QueueConfig{
 		Prefix:       "card_action_dispatch",
 		LiveTTL:      ctx.GetConfig().Robot.MessageExpire,
-		DLQRetention: 30 * 24 * time.Hour,
+		DLQRetention: dlqRetention,
 	})
 	if err != nil {
 		_ = redisClient.Close()

--- a/tools/card-action-dlq/main.go
+++ b/tools/card-action-dlq/main.go
@@ -30,10 +30,11 @@ func main() {
 	client := octoredis.NewInstrumentedClient(cfg)
 	defer client.Close()
 	dlqRetention := cardactiondispatch.DLQRetentionFromEnv(os.Getenv)
-	// depth and replay both PRUNE the DLQ using this retention, so surface it: an
-	// operator running the CLI without the server's OCTO_CARD_ACTION_DLQ_RETENTION_DAYS
-	// would otherwise silently prune at the default window and delete recoverable events.
-	fmt.Fprintf(os.Stderr, "card-action-dlq: DLQ retention = %s (must match the server's %s)\n", dlqRetention, cardactiondispatch.DLQRetentionEnv)
+	// `depth` is read-only (DepthsNoPrune) and never prunes. Only `replay` applies this
+	// retention: it refuses (and prunes) an entry already past the window. Surface the
+	// resolved value so an operator replaying from a shell without the server's
+	// OCTO_CARD_ACTION_DLQ_RETENTION_DAYS notices a mismatch before acting on it.
+	fmt.Fprintf(os.Stderr, "card-action-dlq: DLQ retention = %s (replay only; must match the server's %s)\n", dlqRetention, cardactiondispatch.DLQRetentionEnv)
 	queue, err := cardactiondispatch.NewRedisQueue(client, cardactiondispatch.QueueConfig{
 		Prefix: "card_action_dispatch", LiveTTL: cfg.Robot.MessageExpire,
 		DLQRetention: dlqRetention,
@@ -44,7 +45,9 @@ func main() {
 
 	switch action {
 	case "depth":
-		depths, err := queue.Depths()
+		// DepthsNoPrune: inspecting the DLQ must never delete entries, so `depth` reads
+		// the current counts without pruning. The server prunes on its own schedule.
+		depths, err := queue.DepthsNoPrune()
 		if err != nil {
 			fatal(err)
 		}

--- a/tools/card-action-dlq/main.go
+++ b/tools/card-action-dlq/main.go
@@ -29,8 +29,14 @@ func main() {
 	}
 	client := octoredis.NewInstrumentedClient(cfg)
 	defer client.Close()
+	dlqRetention := cardactiondispatch.DLQRetentionFromEnv(os.Getenv)
+	// depth and replay both PRUNE the DLQ using this retention, so surface it: an
+	// operator running the CLI without the server's OCTO_CARD_ACTION_DLQ_RETENTION_DAYS
+	// would otherwise silently prune at the default window and delete recoverable events.
+	fmt.Fprintf(os.Stderr, "card-action-dlq: DLQ retention = %s (must match the server's %s)\n", dlqRetention, cardactiondispatch.DLQRetentionEnv)
 	queue, err := cardactiondispatch.NewRedisQueue(client, cardactiondispatch.QueueConfig{
-		Prefix: "card_action_dispatch", LiveTTL: cfg.Robot.MessageExpire, DLQRetention: 30 * 24 * time.Hour,
+		Prefix: "card_action_dispatch", LiveTTL: cfg.Robot.MessageExpire,
+		DLQRetention: dlqRetention,
 	})
 	if err != nil {
 		fatal(err)

--- a/tools/card-action-dlq/main.go
+++ b/tools/card-action-dlq/main.go
@@ -30,10 +30,11 @@ func main() {
 	client := octoredis.NewInstrumentedClient(cfg)
 	defer client.Close()
 	dlqRetention := cardactiondispatch.DLQRetentionFromEnv(os.Getenv)
-	// `depth` is read-only (DepthsNoPrune) and never prunes. Only `replay` applies this
-	// retention: it refuses (and prunes) an entry already past the window. Surface the
-	// resolved value so an operator replaying from a shell without the server's
-	// OCTO_CARD_ACTION_DLQ_RETENTION_DAYS notices a mismatch before acting on it.
+	// `depth` is read-only (DepthsNoPrune) and never prunes. `replay` is non-destructive too:
+	// it refuses an entry already past this retention window but does NOT delete it (the server
+	// is the sole pruning authority). Surface the resolved value so an operator replaying from a
+	// shell without the server's OCTO_CARD_ACTION_DLQ_RETENTION_DAYS notices a mismatch (a
+	// too-short window would refuse — not destroy — an entry the server still retains).
 	fmt.Fprintf(os.Stderr, "card-action-dlq: DLQ retention = %s (replay only; must match the server's %s)\n", dlqRetention, cardactiondispatch.DLQRetentionEnv)
 	queue, err := cardactiondispatch.NewRedisQueue(client, cardactiondispatch.QueueConfig{
 		Prefix: "card_action_dispatch", LiveTTL: cfg.Robot.MessageExpire,


### PR DESCRIPTION
## Summary

Two related card-action dispatch (`internal/cardactiondispatch`) reliability changes,
diagnosed from a production incident where docs access-request approve/deny cards never
updated after a click.

1. **`route_missing` at dispatch is now transient, not fatal.** An event only enters the
   dispatch queue when its route existed at *enqueue* time (`Registry.Resolve` returned a
   callback). A miss at *dispatch* therefore means the route was absent from this process's
   in-memory registry then — a rolling deploy, or a restart that came up before
   `OCTO_CARD_ACTION_ROUTES` loaded the route — while the durable Redis queue carried the
   event across that window. The old code dead-lettered on the first attempt, permanently
   losing a decision whose route existed moments later (on a single replica this read as
   "approve has no response"). The event is now **deferred** (no attempt consumed) and
   re-checked until the route returns; it dead-letters only after waiting past a bounded
   window measured from the **first observed miss**.
2. **DLQ retention is now configurable** (`OCTO_CARD_ACTION_DLQ_RETENTION_DAYS`, whole days
   1–365). The default stays **30 days** — the value the code already shipped with — so an
   upgrade that doesn't set the override keeps the existing recovery window; set the env to a
   smaller value (e.g. `7`) to opt into a shorter window.

## Related Issue

None — root-caused from a live DLQ investigation (DLQ entries: approve `1003002`, deny
`1001002`/`1001003`, all `route_missing`).

## Linked Spec

`.octospec/tasks/route-missing-retry/brief.md` (+ `context.yaml`, journal, pending learning).

## Changes

- `dispatcher.go`: `route_missing` **defers** (`d.queue.Defer`, no attempt consumed),
  re-checking every `routeMissingDeferInterval` (5s); it dead-letters (`reason=route_missing`)
  only after waiting past `routeMissingMaxWindow` (15m) measured from the **first observed
  miss** (`RouteMissingSeenAt`), not from `Event.ActedAt` — so an event that dwelt in the
  durable queue past the window before its first dispatch still gets the full self-heal window.
- `queue.go`: new `RouteMissingSeenAt` (durable per-event first-miss marker: `route_missing_since`
  hash, `HSETNX`-then-read); the marker is `HDEL`'d on every exit transition — `ackScript`,
  `nackScript` (requeue + dead-letter), and `replayDLQScript` — so the hash only holds markers for
  events currently in the defer loop and can't grow unbounded. New `DepthsNoPrune()` (ZCard only)
  so the CLI's read-only `depth` never prunes; `ReplayDLQ` is **non-destructive** on a
  past-retention entry (refuses without deleting). The running server's `Depths()` prune is the
  single pruning authority.
- `config.go`: shared `DLQRetentionFromEnv(getenv)` resolver (whole days, 1–365; empty/invalid
  → **30d** default), used by both `main.go` and `tools/card-action-dlq`; `main.go` logs the raw
  + resolved retention.
- Tests: `route_missing_test.go` (defer-not-nack guard, after-window DLQ, old-`ActedAt`
  first-miss defers, window boundary), `route_missing_queue_test.go` (Redis: first-miss anchor,
  non-destructive replay, marker lifecycle), `dlq_retention_test.go`.
- Docs: `docs/card-action-callback-dispatch.md`.

## Review rounds

- **Round 1** (4 reviewers — lml2468 APPROVE; Jerry-Xin, Octo-Q, yujiawei CHANGES_REQUESTED),
  folded into `e9eda69`:
  1. `route_missing` + non-positive `ActedAt` deferred forever → dead-letter (later subsumed by
     the round-2 first-miss anchor).
  2. DLQ default 30→7d silently pruned on deploy → default kept at **30d**; 7d opt-in via env.
  3. CLI `depth` pruned on a read → `DepthsNoPrune()`.
- **Round 2** (re-reviews), folded into `f2cbe1c`:
  4. 15m window anchored on `Event.ActedAt` (Jerry-Xin, Critical) → anchor on the **first
     observed miss** (durable marker); a queue-backlogged event now defers on its first miss.
     This removes the `ActedAt<=0` edge by construction.
  5. `replay` could delete a server-retained entry when the CLI's retention < server's
     (yujiawei, P1) → expiry branch is now non-destructive.
- **Round 3** (re-review of the marker), folded into `d0b0a87`:
  6. `route_missing_since` grew unbounded (Jerry-Xin, Critical) — a whole-hash TTL can't expire
     individual fields and refreshes on every miss, so completed-event markers accumulated. The
     marker is now `HDEL`'d on `Ack` and terminal `Nack` (replay already cleared it), with a
     Redis-backed lifecycle test.

The per-re-check `route_missing` metric is left as documented-intentional (it signals a route is
currently missing).

## Testing

- [x] Unit tests added/updated
- [x] Manually verified

`go build ./...` ✓ · `go test ./internal/cardactiondispatch/` ✓ (validated against a local Redis:
all Redis-backed tests + the existing lease/ack/nack/replay contract tests pass) · `go vet` ✓ ·
`golangci-lint run` **0 issues**.

## COMPREHENSION

1. **What it does to the load-bearing path** — In `ProcessOne`, a route-lookup miss no longer
   nacks (which consumed the shared `lease.Attempt` budget and forced an eventual DLQ). It
   defers with no attempt consumed and records the first-observed-miss time; when the route
   returns the event delivers on its *original* attempt budget. Only after waiting past
   `routeMissingMaxWindow` since that first miss does it dead-letter, reason preserved.

2. **What could break** — An earlier (nack-based) cut shared the attempt counter with delivery,
   so an event that waited longer than `route.MaxAttempts` retries would hit `attempts_exhausted`
   when its route returned; deferring removes that. Anchoring the window on `Event.ActedAt` (an
   earlier cut) would rob a queue-backlogged event of its self-heal window; the window is now
   anchored on the first observed miss (a durable marker), so any `ActedAt` (including unset) gets
   a full window and can't wedge in permanent defer. The marker is cleared on every exit transition
   so its hash can't grow unbounded. Trade-offs: a genuinely-unconfigured route dead-letters after
   ~15m of actual missing instead of immediately (still `route_missing`), and the `route_missing`
   metric increments per re-check while waiting — sized in the alerting doc. Re-delivery is safe:
   at-least-once path, consumer idempotent by `event_id`. The DLQ-retention default is unchanged
   from the pre-PR value (30d), so no existing DLQ entries are pruned on deploy; the CLI recovery
   tool is non-destructive. Enqueue resolution and the delivery-error retry path are untouched.

3. **How I know it works** — `TestRouteMissingDefersWithoutConsumingAttempt` (defers, is not
   nacked — fails on the old code), `TestRouteMissingOldActedAtDefersOnFirstMiss` (queue-backlogged
   old-`ActedAt` event defers on its first miss), `TestRouteMissingDeadLettersAfterWindow`
   (past-window DLQ), `TestRouteMissingExpired` (window boundary); Redis-backed
   `TestRouteMissingSeenAtAnchorsOnFirstMiss`, `TestReplayDLQPastRetentionIsNonDestructive`, and
   `TestRouteMissingMarkerClearedOnTerminalTransitions` (marker gone after Ack and terminal DLQ);
   plus a from-scratch repro of the original immediate-DLQ against the real package.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] PR description is in English
- [x] Added tests for my changes
- [x] Updated documentation
- [x] Followed commit message conventions (Conventional Commits)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WHgTEEbVNAuHVUjG4M7ZQb)_