### PR TITLE
feat(notify): per-Space welcome message with admin CRUD

### DIFF
--- a/.octospec/journal/shared/space-welcome-per-space-admin-crud.md
+++ b/.octospec/journal/shared/space-welcome-per-space-admin-crud.md
@@ -1,0 +1,113 @@
+---
+type: Journal
+title: "space-welcome-per-space-admin-crud: per-Space welcome message with admin CRUD"
+description: Make the onboarding welcome message per-Space and self-service — space admins (Role>=1) CRUD one config per Space via /v1/space/:space_id/welcome; the platform-global config stays a superadmin fallback. Delivery driver goes single-Space to all-enabled-Spaces.
+tags: [notify, space, onboarding, isolation, auth, acl, i18n, error-response, system-setting, migration, rate-limit, idempotency, testing]
+timestamp: 2026-07-21T00:52:00Z
+---
+
+# space-welcome-per-space-admin-crud
+
+Branch `claude/space-welcome-per-space-admin-crud`. Product follow-up to
+#604/#606 (which shipped a single **platform-designated** welcome Space,
+superadmin-only). This lifts the origin brief's out-of-scope item
+("Multi-Space configuration with per-Space copy; per-Space admin self-service
+API") into scope: **one welcome config per Space, managed by that Space's own
+admins**, with the global config kept as a superadmin-managed fallback.
+
+Ships per-Space `enabled=false` by default; with no per-Space row written,
+behavior is identical to today.
+
+## What was done
+
+1. **Config storage (`modules/common`)** — new `octo_space_welcome_config`
+   table (one row per Space; migration under `common/sql/`) + stateless
+   `SpaceWelcomeConfigStore` (Get / Upsert / Delete / Exists / ListEnabled).
+   `ResolveEffectiveSpaceWelcome` encodes precedence: a **present per-Space row
+   wins outright — even when disabled** (lets an admin opt their Space out of a
+   global campaign); otherwise the global config applies iff enabled and it
+   names the Space; otherwise off. The resolver reuses the existing
+   `SpaceWelcomeConfig` shape, so `ValidateSpaceWelcomeCombination` /
+   `ParsedActiveFrom` apply unchanged. `active_from` is stored as the RFC3339
+   string (not DATETIME) precisely so those validators are reused verbatim.
+2. **CRUD API (`modules/space/api_welcome.go`)** — `GET/PUT/DELETE
+   /v1/space/:space_id/welcome`. Authz reuses the module's existing
+   `checkSpaceActive` + `requireSpaceAdmin` (Role>=1); a request can only ever
+   affect the path `:space_id`. `PUT` is a prospective merge (patch onto the
+   existing row, validate the composite). `DELETE` hard-deletes the row (reverts
+   to the global fallback or off). Mounted on the auth + `SharedUIDRateLimiter`
+   group; all errors via `httperr` with **existing** error codes (no new codes).
+3. **Delivery driver (`modules/notify`)** — went single-Space →
+   all-enabled-Spaces. The event path, reconciler and worker resolve the
+   per-Space **effective** config each cycle instead of a single global equality
+   filter. Reconciler and worker each rotate a per-replica cursor over the
+   enabled-Space set (fairness). Cross-space sweep (`sweepClaimedAll` /
+   `sweepDispatchingAll`, backed by a new `idx_sweep (status, claim_expire_at)`)
+   reclaims stale in-flight rows across Spaces — including a Space disabled while
+   rows were in flight. The ledger state machine, at-most-once semantics,
+   `FOR UPDATE SKIP LOCKED` claim, CAS-on-`claim_owner`, and the fixed
+   `notification` sender identity are **unchanged**.
+
+## Structural learnings / gotchas
+
+- **Reuse the effective-config shape, not a new type.** By having the per-Space
+  resolver return the same `common.SpaceWelcomeConfig` the single-Space code
+  already consumed, the entire notify delivery path kept using
+  `ValidateSpaceWelcomeCombination` / `ParsedActiveFrom` verbatim — the change
+  was "swap the config *source*", not "rewrite the path". Storing `active_from`
+  as an RFC3339 string (not DATETIME) was the enabling decision.
+- **`modules/common` is the DI hub.** Both `space` (write) and `notify` (read)
+  import `common`; `common` imports neither. Putting the shared store there
+  avoided a `space`↔`notify` import cycle.
+- **Multi-Space fairness needs a rotating cursor, not greedy drain.** First cut
+  drained enabled Spaces in `space_id` order; a Space that keeps saturating the
+  per-wake cap (20) starves later Spaces forever. The reconciler had a rotation
+  cursor; the worker did not. Fixed by mirroring the cursor into the worker
+  (commit 741641f) + a regression test that keeps the first Space over-cap and
+  asserts the second is still served. See learnings/pending.
+- **Cross-space sweep must be owner-agnostic but lease-gated.** `sweepAll` drops
+  the `space_id` filter (so a now-disabled Space's stale rows aren't stranded)
+  and, like the original, guards only on `claim_expire_at<=now` — it never
+  steals a healthy peer's live claim. Needed a `(status, claim_expire_at)` index
+  or it degrades to a full scan on the monotonically-growing ledger.
+- **Per-Space config is read-through (no snapshot).** Unlike the global
+  `SystemSettings` 60s snapshot, an admin PUT/DELETE is visible on the next read
+  across replicas immediately — strictly better convergence for the per-Space
+  path.
+- **WuKongIM verification gotchas (e2e).** `/message/send` returns a `message_id`
+  only on accept+persist, but persistence is **async** — an immediate
+  `/channel/messagesync` read races the write (poll it). A personal DM is stored
+  under `channel_id=<recipient>`, read via `messagesync{login_uid: notification,
+  channel_id: <recipient>}` — querying the peer's uid returns empty. The IM data
+  dir persists across test runs (only MySQL is reset), so real-wire e2e must use
+  run-unique uids.
+
+## Verification
+
+- Gates: `go build ./...`, `go vet`, `golangci-lint` (0 issues), `gofmt`,
+  `make i18n-extract-check` + `make i18n-lint`, `git diff --check` — all clean.
+- `go test -race` green for `modules/common`, `modules/notify`, `modules/space`
+  (each on a fresh DB — cross-package migration sets differ, so the shared
+  `test` DB is dropped+recreated between packages).
+- New tests: config-store CRUD; effective-config precedence (both directions);
+  multi-Space independent delivery + **no cross-Space body/space_id mixing**;
+  worker fair-rotation (starves without the fix); cross-space sweep; per-Space
+  event enqueue scoping; CRUD authz matrix (admin/member/non-member/inactive) +
+  prospective validation + partial-merge + delete.
+- **Real-wire e2e** (ad-hoc, not committed) against live MySQL/Redis/WuKongIM:
+  single-Space delivery (ledger SENT + real IM message_id) and two-Space
+  concurrent delivery, reading each recipient's channel back from WuKongIM to
+  confirm actual receipt and that each got ONLY their own Space's body +
+  authoritative `payload.space_id`.
+
+## Open items
+
+- DELETE is a hard-delete → revert to global fallback (confirmed default). If a
+  Space wants "off" while the global names it, PUT `enabled=false` (a present
+  disabled row overrides the global).
+- Per-replica `sweepAll` runs every wake (2 indexed UPDATEs / 5s / replica);
+  bounded write amplification at high replica counts — revisit only if it shows
+  up in DB load.
+- The per-Space enable gate inherits #604's production open questions
+  (at-most-once acceptability, `skipped` terminal, throughput vs peak join
+  rate), now applied per Space.

--- a/.octospec/learnings/pending/multi-space-worker-rotating-cursor.md
+++ b/.octospec/learnings/pending/multi-space-worker-rotating-cursor.md
@@ -1,0 +1,46 @@
+---
+type: Learning
+title: "A per-cycle worker over N resources needs a rotating start cursor, not greedy in-order drain"
+description: When one background worker drains work from N keyed resources under a per-cycle cap, iterating them in a fixed order lets a perpetually-busy first resource starve the rest; rotate the start index each cycle.
+tags: ["notify", "worker", "fairness", "starvation", "review", "concurrency"]
+timestamp: 2026-07-21T00:52:00Z
+# --- octospec extension fields ---
+source: self
+origin_task: space-welcome-per-space-admin-crud
+origin_pr: Mininglamp-OSS/octo-server#TBD
+status: pending
+candidate_rule: null
+---
+
+# A per-cycle worker over N resources needs a rotating start cursor
+
+## Context
+The Space-welcome send worker was generalized from one Space to "all enabled
+Spaces". Each wake it drained up to a global cap (`swWorkerWakeCap = 20`) claimed
+rows, iterating the enabled Spaces **in `space_id` order** and fully draining
+each before the next. Correct for a fixed backlog, but under **sustained** inflow
+a Space whose `space_id` sorts first and keeps producing >20 pending rows/wake
+consumes the entire cap every wake — later Spaces are **never** reached and their
+members never get welcomed. The sibling reconciler already rotated a cursor; the
+worker was written without one, silently contradicting the "round-robin / no
+starvation" contract in its own doc-comment and the task brief.
+
+## Rule of thumb
+When a single background worker services N keyed resources under a per-cycle
+budget:
+1. **Rotate the starting resource each cycle** (`start = cursor % n; cursor++`),
+   in-memory and per-replica — it's a fairness hint, not shared state, so no
+   lock and no correctness dependency (the DB claim already serializes work).
+2. **A per-cycle cap alone does not give fairness** — it bounds one cycle's work
+   but, without rotation, re-serves the same head resource every cycle.
+3. **Test starvation with sustained load, not a fixed backlog.** A fixed backlog
+   drains in-order eventually; the bug only appears when the head resource is
+   *topped back up over the cap before every cycle*. The regression test must
+   re-seed the head resource each wake and assert a tail resource still makes
+   progress (it fails without the cursor, passes with it).
+
+## Why worth a rule
+Fairness bugs in fan-out workers are invisible in unit tests with small fixed
+inputs and in single-resource legacy behavior; they only bite in production
+under load, as a specific tenant/resource going silently unserved. Cheap to
+prevent (one cursor), easy to miss (the cap *looks* like it bounds fairness).

--- a/.octospec/log.md
+++ b/.octospec/log.md
@@ -4,6 +4,30 @@ Change history for this repo's `.octospec/`, following the
 [OKF](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md)
 change-log convention (§7). Newest first.
 
+## 2026-07-21 (space-welcome-per-space-admin-crud)
+
+- **Feature** — The onboarding welcome message became **per-Space and
+  self-service**. Space admins (Role>=1) CRUD one config per Space via
+  `GET/PUT/DELETE /v1/space/:space_id/welcome` (new `octo_space_welcome_config`
+  table + `common.SpaceWelcomeConfigStore`). Follows #604/#606 which shipped a
+  single platform-designated Space, superadmin-only; lifts that task's
+  out-of-scope "per-Space admin self-service" item into scope.
+- **Precedence** — A present per-Space row wins over the platform-global config
+  outright, even when disabled (opt a Space out of a global campaign); no row →
+  the global config applies iff it names the Space; else off. Global config kept
+  as a superadmin fallback. Ships `enabled=false` per Space (no behavior change).
+- **Delivery driver** — notify's event/reconciler/worker went single-Space →
+  all-enabled-Spaces, resolving the per-Space effective config each cycle. Both
+  reconciler and worker rotate a per-replica cursor over the enabled set for
+  fairness (a greedy in-order worker starved tail Spaces under sustained load —
+  see [learning](learnings/pending/multi-space-worker-rotating-cursor.md)).
+  Cross-space sweep added (`idx_sweep`); ledger state machine / at-most-once /
+  sender identity unchanged.
+- **Verified** — all gates + `-race` suites green; real-wire e2e against live
+  MySQL/Redis/WuKongIM confirmed actual receipt and no cross-Space mixing (each
+  recipient's channel read back from the IM). See
+  [journal](journal/shared/space-welcome-per-space-admin-crud.md).
+
 ## 2026-07-20 (github-webhook-parity)
 
 - **Feature** — GitHub `pull_request`/`issues` InteractiveCards gained

--- a/.octospec/tasks/space-welcome-per-space-admin-crud/brief.md
+++ b/.octospec/tasks/space-welcome-per-space-admin-crud/brief.md
@@ -1,0 +1,300 @@
+---
+type: Task
+title: "Task: space-welcome-per-space-admin-crud"
+description: Make the Space new-user welcome message per-Space and self-service — each Space's admins create/update/delete their own welcome config; keep the platform-global config as a superadmin-managed fallback.
+tags: ["notify", "onboarding", "space", "isolation", "auth", "acl", "i18n", "error-response", "wire-contract", "system-setting", "migration", "rate-limit", "idempotency", "observability", "testing"]
+timestamp: 2026-07-20T23:32:44+08:00
+# --- octospec extension fields ---
+slug: space-welcome-per-space-admin-crud
+upstream: self
+source: self
+---
+
+# Task: space-welcome-per-space-admin-crud
+
+> One task = one `.octospec/tasks/<slug>/` directory. This brief is the spec for
+> the work. AI may draft it from existing code; a human confirms it.
+
+## Goal
+
+Turn the Space new-user welcome message from a **single platform-designated
+Space** (configured only by a platform superadmin) into a **per-Space,
+self-service** feature: each Space's own admins can create / update / delete
+**one** welcome config for **their** Space, and every Space with an enabled
+config independently welcomes its first-join human members.
+
+Scope is **one welcome config per Space** (single plain-text body, continuing
+the PR #606 model). `PUT` upserts (增/改), `DELETE` removes (删). The existing
+delivery ledger, state machine, at-most-once semantics, sender identity, and
+human/isolation filters are **reused unchanged**; only the config source and
+the drive loop's single-Space assumption change.
+
+The existing platform-global config (`onboarding.space_welcome_*`) is **kept as
+a superadmin-managed fallback**: a Space with no per-Space config falls back to
+the global config (if it names that Space), so nothing that works today breaks.
+
+Ships with per-Space configs defaulting to `enabled=false` (no behaviour change
+on deploy until a Space admin opts in).
+
+## Background
+
+- **Prior art (this feature's origin).**
+  - PR #604 `feat(notify): at-most-once Space new-user welcome DM` built the
+    delivery machinery (ledger `octo_space_welcome_delivery`, reconciler, send
+    worker, notify-local HTTP sender). Brief:
+    `.octospec/tasks/space-new-user-welcome-message/brief.md`.
+  - PR #606 `refactor(notify): single plain-text Space welcome message`
+    collapsed the bilingual split into one `onboarding.space_welcome_message`.
+  - The origin brief's **Out of scope** explicitly deferred: "Multi-Space
+    configuration with per-Space copy; per-Space admin self-service UI/API."
+    **This task lifts exactly that item into scope.**
+
+- **Current config is a global singleton** (`system_setting` KV, category
+  `onboarding`), read atomically via `common.SystemSettings.SpaceWelcomeConfig()`
+  (`modules/common/system_settings.go:1070`). Four keys, one target Space
+  (`space_welcome_space_id`), managed only through the platform manager API
+  (`modules/common/api_manager_system_setting.go`). Space admins have no access.
+  - Schema: `modules/common/system_setting_schema.go:213-220`.
+  - Combination validation: `common.ValidateSpaceWelcomeCombination`
+    (`modules/common/system_settings.go:1123`) — space active + `active_from`
+    parseable + message trimmed-non-empty ≤ 2000 code points. **Reusable.**
+
+- **The delivery core is already per-Space.** The ledger is keyed
+  `UNIQUE (space_id, uid)` with `idx_claim (space_id, status, next_retry_at)`
+  (`modules/notify/sql/20260716000001_add_octo_space_welcome_delivery.sql`). The
+  state machine, `sweep`, CAS-on-`claim_owner`, at-most-once, the 15s
+  notify-local sender, and the fixed `notification` sender identity are all
+  per-row and Space-agnostic. **No ledger schema change is required** for the
+  single-config-per-Space model.
+
+- **Only two layers assume a single Space and must change:**
+  1. **Config source.** `spaceWelcomeService` reads one global
+     `SpaceWelcomeConfig()` and hard-filters `spaceID != cfg.SpaceID`
+     (`modules/notify/space_welcome.go:151`); the reconciler scans one
+     `cfg.SpaceID` (`:233`); the worker claims scoped to one `cfg.SpaceID`
+     (`:302`) and sends `cfg.Message` (`:409`).
+  2. **Who can write.** No Space-scoped API exists; config is superadmin-only.
+
+- **Space-admin authz pattern already exists** and is the template to copy:
+  `searchMembers` does `queryMember(spaceId, loginUID)` then
+  `member.Role < spaceRoleAdmin` → `ErrSpacePermissionDenied`
+  (`modules/space/api_member_search.go:30-43`). Roles:
+  `0=member 1=admin 2=owner` (`modules/space/model.go:38`). Space user routes
+  are registered on the `/v1/space` auth group (`modules/space/api.go:70-98`).
+
+- **Confirmed product decisions for this task** (from design review):
+  - **One config per Space** (not multiple messages).
+  - **Admin scope = Role ≥ 1** (admin + owner), matching `searchMembers`.
+  - **Keep the platform-global config as a superadmin fallback** (not a full
+    replacement).
+  - **CRUD endpoints mount `SharedUIDRateLimiter`** (authenticated default).
+
+## Load-bearing list
+
+- **Space isolation & authorization (tags: space, isolation, auth, acl).**
+  - A Space admin may read/write the welcome config for **only** the Space(s)
+    where they hold `Role ≥ 1`. Enforcement mirrors `searchMembers`: resolve the
+    caller's membership row for the path `:space_id` via the space module's
+    `queryMember`, reject `Role < 1` with the generic
+    `ErrSpacePermissionDenied` (anti-enumeration: same 403 for non-member and
+    under-privileged). The path `:space_id` is the **only** Space a request may
+    affect; the Space must be active (`space.status=1`, dissolved/banned → same
+    reject path as `searchMembers`'s `checkSpaceActive`).
+  - The delivery path's existing isolation invariants are **preserved verbatim**:
+    per-`(space_id, uid, status=1)` membership re-check bypassing stale cache;
+    recipient-only `SystemBots`/`IsSystemBot` scoping (the `notification` sender
+    must never be self-filtered); orphan `space_member` (missing `user` row)
+    excluded; fail-closed never delivers cross-Space or to a non-member.
+  - Cross-Space worker: a claimed row is dispatched using **that row's**
+    `space_id` config and re-checked against **that** Space only; one Space's
+    config or backlog can never cause a send into another Space.
+
+- **Config storage migration (tags: system-setting, migration).**
+  - New table (single source of truth for per-Space config), one row per Space,
+    e.g. `octo_space_welcome_config`:
+    `space_id` (UNIQUE, length/charset/**COLLATE aligned to `space.space_id`**),
+    `enabled TINYINT`, `active_from DATETIME NULL` (UTC, app-written, **never
+    `NOW()`**), `message VARCHAR(2000)`, `updated_by VARCHAR(40)` (audit),
+    `created_at`/`updated_at DATETIME NOT NULL` (UTC, app-written). Migration in
+    `modules/notify/sql/` (the module already embeds `sql`).
+  - **Time discipline** identical to the ledger: all timestamps are
+    application-supplied UTC bound params; no naked `NOW()`; `active_from`
+    parsed as RFC3339 UTC. COLLATE must match the reconciler's JOIN partners
+    (`space`, `space_member`, `user` = `utf8mb4_general_ci`) to avoid MySQL 1267.
+  - **Precedence & fallback (contract):** effective config for a Space =
+    per-Space row if present, else the platform-global `onboarding.space_welcome_*`
+    **iff** its `space_welcome_space_id` names that Space. Exactly one effective
+    config per Space; the resolution is deterministic and documented.
+  - **Global config atomic read preserved:** `SpaceWelcomeConfig()` stays the
+    atomic snapshot reader for the global fallback; per-Space reads use the new
+    accessor. No caller reads the four global keys individually.
+
+- **Config validation (tags: error-response, i18n, wire-contract).**
+  - Reuse `common.ValidateSpaceWelcomeCombination` semantics: for the CRUD
+    write path the target Space is the path `:space_id` (already known
+    active via the authz gate), `active_from` must parse RFC3339 UTC, `message`
+    trimmed-non-empty ≤ 2000 code points, newlines preserved verbatim, no
+    markdown. Enabling with an invalid combination is rejected at the write path.
+  - **Runtime re-validation unchanged:** worker/reconciler re-validate the
+    effective config each cycle and fail closed (`config_invalid_total`) on a
+    bad combination (e.g. a Space later dissolved). Fail-closed applies from the
+    next cycle after the config cache refreshes, never mid-cycle.
+
+- **Error responses & i18n (tags: error-response, i18n, wire-contract).**
+  - All new CRUD responses go through the `pkg/httperr` i18n envelope with
+    registered `pkg/errcode` codes (reuse `ErrSpacePermissionDenied` /
+    `ErrSpaceNotMember` / a validation code — reuse
+    `err.server.common.space_welcome_config_invalid` or a space-scoped analog).
+    No raw `c.ResponseError` / `c.JSON` non-OK / `AbortWithStatusJSON`.
+  - `make i18n-extract-check` + `make i18n-lint` pass; new codes get a zh-CN
+    block in `pkg/i18n/locales/active.zh-CN.toml`; new handler files added to the
+    module's `Test<Module>NoLegacyResponseError` source guard.
+
+- **Rate limiting (tags: rate-limit).**
+  - The Space-admin CRUD route group mounts `SharedUIDRateLimiter` **after**
+    `AuthMiddleware` (per the repo rate-limit rule); no hand-rolled Redis
+    counter. Tests hitting the routes reset `ratelimit:uid:*` in setup.
+
+- **Delivery drive loop: single-Space → all-enabled-Spaces (tags: notify,
+  onboarding, idempotency).**
+  - Event path `handleMemberJoin(spaceID, uid)` resolves the **effective config
+    for that `spaceID`** (not a global equality filter) and enqueues iff enabled
+    + eligible. Enqueue failure never blocks/rolls back the completed join.
+  - Reconciler iterates **every Space with an enabled effective config**, scans
+    each for `status=1 AND created_at >= active_from` members lacking a ledger
+    row, under a **global per-cycle cap** (keep total bounded; do not let one
+    Space starve others).
+  - Worker claims **across Spaces**; on claim it resolves the claimed row's
+    Space config for the body + re-validates (fail-closed → skip / pre-IM). The
+    cross-Space claim predicate (`status=0 AND next_retry_at<=?`, no `space_id`)
+    needs an index that leads with `(status, next_retry_at)` — add it, or claim
+    per-Space round-robin — so claiming does not degrade to a full scan.
+  - **Enqueue idempotency preserved:** `INSERT ... ON DUPLICATE KEY UPDATE id=id`
+    on `(space_id, uid)`; `enqueue_total` counts only real inserts,
+    `enqueue_dedup_total` the rest.
+
+- **Config cache & convergence (tags: notify).**
+  - The global `SystemSettings` 60s snapshot no longer covers per-Space config.
+    Add a per-Space config cache (TTL + write-time invalidation, mirroring
+    `modules/notify/space_verify.go`'s `memberCache`) or read-through by PK.
+    Admin write refreshes/invalidates on the handling replica; peers converge
+    within the chosen TTL (document the window). Reads must be atomic per Space
+    (never straddle a refresh and combine fields from two snapshots).
+
+- **Observability (tags: observability).**
+  - Existing counters/gauges/`stage`/`error_class` are retained; per-Space
+    dimension is `space_id` (already a structured log field). Never log the
+    welcome body or raw upstream error strings. Reconciler/worker metrics stay
+    aggregate (per-Space label optional, not required for this task).
+
+- **Commit style (tags: commit, git).** Conventional Commits, English.
+
+## Out of scope
+
+- **Multiple welcome messages per Space** — this task is exactly one config per
+  Space. No `welcome_id`, no ledger `UNIQUE(space_id,uid,welcome_id)`, no
+  per-message audience/selection rules.
+- **Removing or reworking the platform-global config** — it stays as a
+  superadmin-managed fallback via the existing manager API and `system_setting`
+  keys; this task does not delete those keys or that endpoint.
+- **Delivery reliability semantics** — the state machine, at-most-once,
+  `unknown`/`failed` handling, sweep, backoff `{5s,30s,120s}`, CAS, 15s sender,
+  `SELECT ... FOR UPDATE SKIP LOCKED`, no leader election — all unchanged.
+- **Sender identity / wire protocol** — fixed `from_uid=notification`,
+  `channel_type=PERSON`, `red_dot=1`, `payload.type=Text`, authoritative
+  `payload.space_id`. Admins cannot choose/forge the sender or submit arbitrary
+  payload. Still plain text — no rich text, cards, attachments, placeholder
+  rendering (`{nickname}`), scheduled send, or audience targeting.
+- **Ledger schema change / archival / TTL** — ledger keeps
+  `UNIQUE(space_id,uid)`, grows monotonically, operator-cleaned via SQL. (Only
+  a possible **new claim index** `(status, next_retry_at)` for cross-Space
+  claiming is in scope; the columns are unchanged.)
+- **Retroactive bulk send** to members who joined before a Space's `active_from`.
+- **Client / admin UI** — server-side API + validation only. Frontend rendering,
+  conversation-list/red-dot rules, and per-client (Web/iOS/Android) logic are
+  out of scope.
+- **Per-Space multi-language copy** — the message stays a single language-
+  agnostic plain-text body (PR #606 model).
+- **BotFather Space welcome and `u_10000` register/login welcome** — untouched;
+  may coexist as today.
+- **octo-lib changes** — none; the notify-local sender remains self-contained.
+
+## Acceptance
+
+- **Space-admin CRUD authz.** `GET/PUT/DELETE /v1/space/:space_id/welcome`
+  succeed for a caller with `Role ≥ 1` in that Space; a member with `Role = 0`,
+  a non-member, and a caller against a dissolved/banned Space all get the
+  generic `ErrSpacePermissionDenied` / `ErrSpaceNotMember` path (no
+  privilege-reason leak). A request can affect only the path `:space_id`.
+- **CRUD semantics (single config per Space).** `PUT` on a Space with no config
+  inserts one (增); `PUT` on an existing config updates it (改); `DELETE` removes
+  it (删) and the Space reverts to the global fallback (or off). `updated_by`
+  records the acting admin uid.
+- **Write-path validation (prospective).** With `enabled=true`, writes with an
+  unparseable `active_from`, empty-after-trim, or > 2000 code point `message` are
+  rejected via the i18n envelope. A partial `PUT` is accepted iff the resulting
+  effective combination is valid (validate the merged prospective config, not
+  the incoming patch alone). The target Space is the path Space (already active).
+- **Precedence & fallback.** With a per-Space row present, it wins; with none, a
+  Space named by the global `space_welcome_space_id` uses the global config;
+  other Spaces have no welcome. A test asserts exactly one effective config per
+  Space and the deterministic resolution in each direction.
+- **Multi-Space delivery.** Two Spaces each with an enabled config each welcome
+  their own first-join human members: exactly one `(space_id, uid)` ledger row
+  per Space per member; no cross-Space delivery; disabling Space A does not
+  affect Space B. The reconciler catches up all enabled Spaces within one cycle;
+  a per-cycle global cap bounds work and no single Space starves the others.
+- **Isolation invariants preserved (regression).** Recipient re-check bypasses
+  stale cache; `notification` (sender) is never self-filtered; robots / system
+  bots (recipient) / orphan rows / pre-`active_from` / non-members receive
+  nothing; fail-closed on any anomaly.
+- **Cross-Space claim.** The worker claims rows from any enabled Space; the
+  claim predicate is index-backed (no full scan) — verified by the presence of a
+  `(status, next_retry_at)`-leading index (or documented per-Space round-robin).
+  A claimed row is dispatched with its own Space's `message` and re-validated
+  against its own Space.
+- **Config cache convergence.** An admin write takes effect immediately on the
+  handling replica (cache invalidated/refreshed); peers converge within the
+  documented TTL. A concurrent cache refresh never yields a half-updated
+  per-Space config to a cycle.
+- **Rate limiting.** The CRUD group carries `SharedUIDRateLimiter` mounted after
+  `AuthMiddleware`; a burst test observes the `uid` scope headers /
+  `rate.limited` envelope; test setup resets `ratelimit:uid:*`.
+- **i18n / error contract.** `make i18n-extract-check` and `make i18n-lint`
+  pass; new codes have zh-CN blocks; new handler files are in the module's
+  `Test<Module>NoLegacyResponseError` guard; no raw error responses.
+- **Time discipline & schema alignment.** No feature SQL uses naked `NOW()`;
+  `octo_space_welcome_config.space_id` matches the length/charset/COLLATE of
+  `space.space_id`; a JOIN smoke test confirms no MySQL 1267.
+- **Backward compatibility.** With no per-Space rows written, behaviour is
+  identical to today (global config still drives its one Space); existing tests
+  in `modules/notify`, `modules/common`, `modules/space`, and bot provisioning
+  continue to pass; no change to existing wire responses.
+- **Command-line verification.**
+  - `go test -race ./modules/notify/...`
+  - `go test -race ./modules/common/...`
+  - `go test -race ./modules/space/...`
+  - `make i18n-extract-check && make i18n-lint`
+  - `go test -race ./...`
+  - `git diff --check`
+- **Tests cover at minimum:** CRUD authz matrix (admin/owner/member/non-member/
+  inactive Space); PUT insert-then-update, DELETE→fallback; prospective
+  validation both directions; precedence per-Space-vs-global resolution;
+  multi-Space independent delivery + per-Space disable; cross-Space claim single
+  winner (`FOR UPDATE SKIP LOCKED`); recipient re-check + human/system-bot/orphan
+  exclusions with `notification` not self-filtered; config cache
+  invalidation/convergence; UID rate-limit headers; migration executes on a
+  fresh DB.
+
+## Open questions (product / operations sign-off before enabling)
+
+- **DELETE semantics** — hard-delete the row vs. soft (`enabled=0`). Default
+  proposed: hard-delete so "no per-Space config" and fallback are one code path;
+  audit lives in logs. Confirm no need to retain deleted copy.
+- **Fallback visibility** — when a per-Space `DELETE` reverts a Space to the
+  global fallback that still names it, that Space keeps receiving the global
+  welcome. Confirm this is intended (vs. `DELETE` meaning "off for this Space").
+- **Per-Space enable gate** — the origin task's production-enable open questions
+  (at-most-once acceptability, `skipped` terminal, throughput vs. peak join
+  rate) now apply **per Space**; enabling for a high-traffic Space still needs
+  the throughput envelope confirmed. Carried forward, not re-litigated here.

--- a/.octospec/tasks/space-welcome-per-space-admin-crud/context.yaml
+++ b/.octospec/tasks/space-welcome-per-space-admin-crud/context.yaml
@@ -1,0 +1,19 @@
+injected:
+  - id: space-isolation
+    source: repo        # load_bearing; per-Space admin authz + delivery isolation (core of this task)
+  - id: error-handling
+    source: repo        # load_bearing; CRUD errors via httperr + errcode i18n envelope
+  - id: rate-limit
+    source: repo        # load_bearing; CRUD group mounts SharedUIDRateLimiter after AuthMiddleware
+  - id: trust-boundary
+    source: repo        # matched via wire-contract tag; body is plain-text type:1 (no markdown render) — no adapter surface, kept for parity awareness
+  - id: testing
+    source: repo        # test setup/DB/migration conventions
+  - id: commit-style
+    source: repo        # Conventional Commits, English
+brief: .octospec/tasks/space-welcome-per-space-admin-crud/brief.md
+decisions:
+  - single config per Space (PUT upsert / DELETE hard-delete row)
+  - admin scope Role >= 1 (admin + owner)
+  - platform-global config kept as superadmin fallback; DELETE reverts to fallback
+  - CRUD mounts SharedUIDRateLimiter

--- a/modules/common/space_welcome_config_store.go
+++ b/modules/common/space_welcome_config_store.go
@@ -1,0 +1,198 @@
+package common
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/gocraft/dbr/v2"
+)
+
+// Per-Space onboarding welcome config (task space-welcome-per-space-admin-crud).
+//
+// This is the per-Space counterpart to the platform-global onboarding.space_*
+// keys in system_setting. A Space admin (Role>=1) manages one row per Space via
+// modules/space's /v1/space/:space_id/welcome CRUD; modules/notify reads the
+// effective config on the delivery path. The store is a stateless read-through
+// (PK-indexed), so an admin write is visible on the next read across replicas
+// with no snapshot TTL — unlike the global fallback, which retains the 60s
+// SystemSettings snapshot window.
+//
+// Time discipline mirrors the delivery ledger: created_at/updated_at are
+// application-computed UTC values passed as bound parameters (never NOW());
+// active_from is stored as the RFC3339 UTC string so ParsedActiveFrom /
+// ValidateSpaceWelcomeCombination apply unchanged.
+
+// SpaceWelcomeMessageMaxRunes is the max welcome body length in Unicode code
+// points, enforced on every write path (per-Space CRUD and the manager global
+// config). Exported so modules/space can bound its column write without
+// duplicating the constant.
+const SpaceWelcomeMessageMaxRunes = spaceWelcomeMessageMaxRunes
+
+const spaceWelcomeConfigTable = "octo_space_welcome_config"
+
+// SpaceWelcomeSpaceConfig is one per-Space welcome config row.
+type SpaceWelcomeSpaceConfig struct {
+	SpaceID       string
+	Enabled       bool
+	ActiveFromRaw string // RFC3339 UTC string; "" when unset
+	Message       string
+	UpdatedBy     string
+	CreatedAt     time.Time
+	UpdatedAt     time.Time
+}
+
+// spaceWelcomeConfigRow is the DB projection (active_from is a plain string
+// column: "" means unset, avoiding a nullable-scan dependency).
+type spaceWelcomeConfigRow struct {
+	SpaceID    string    `db:"space_id"`
+	Enabled    int       `db:"enabled"`
+	ActiveFrom string    `db:"active_from"`
+	Message    string    `db:"message"`
+	UpdatedBy  string    `db:"updated_by"`
+	CreatedAt  time.Time `db:"created_at"`
+	UpdatedAt  time.Time `db:"updated_at"`
+}
+
+func (r spaceWelcomeConfigRow) toConfig() SpaceWelcomeSpaceConfig {
+	return SpaceWelcomeSpaceConfig{
+		SpaceID:       r.SpaceID,
+		Enabled:       r.Enabled == 1,
+		ActiveFromRaw: r.ActiveFrom,
+		Message:       r.Message,
+		UpdatedBy:     r.UpdatedBy,
+		CreatedAt:     r.CreatedAt,
+		UpdatedAt:     r.UpdatedAt,
+	}
+}
+
+// SpaceWelcomeConfigStore is the DB access layer for per-Space welcome config.
+type SpaceWelcomeConfigStore struct {
+	db *dbr.Session
+}
+
+// NewSpaceWelcomeConfigStore builds a store over the given session.
+func NewSpaceWelcomeConfigStore(db *dbr.Session) *SpaceWelcomeConfigStore {
+	return &SpaceWelcomeConfigStore{db: db}
+}
+
+const spaceWelcomeConfigCols = "space_id, enabled, active_from, message, updated_by, created_at, updated_at"
+
+// Get returns the per-Space config row; found=false when absent (not an error).
+func (s *SpaceWelcomeConfigStore) Get(ctx context.Context, spaceID string) (*SpaceWelcomeSpaceConfig, bool, error) {
+	if spaceID == "" {
+		return nil, false, nil
+	}
+	var row spaceWelcomeConfigRow
+	err := s.db.SelectBySql(
+		"SELECT "+spaceWelcomeConfigCols+" FROM "+spaceWelcomeConfigTable+" WHERE space_id=?",
+		spaceID,
+	).LoadOneContext(ctx, &row)
+	if err != nil {
+		if errors.Is(err, dbr.ErrNotFound) {
+			return nil, false, nil
+		}
+		return nil, false, fmt.Errorf("get space welcome config: %w", err)
+	}
+	cfg := row.toConfig()
+	return &cfg, true, nil
+}
+
+// Exists reports whether a per-Space row exists for spaceID (any enabled value).
+// Used to decide whether the global fallback is overridden.
+func (s *SpaceWelcomeConfigStore) Exists(ctx context.Context, spaceID string) (bool, error) {
+	if spaceID == "" {
+		return false, nil
+	}
+	var n int
+	err := s.db.SelectBySql(
+		"SELECT COUNT(*) FROM "+spaceWelcomeConfigTable+" WHERE space_id=?",
+		spaceID,
+	).LoadOneContext(ctx, &n)
+	if err != nil && !errors.Is(err, dbr.ErrNotFound) {
+		return false, fmt.Errorf("exists space welcome config: %w", err)
+	}
+	return n > 0, nil
+}
+
+// Upsert inserts or updates the per-Space config. An empty ActiveFromRaw is
+// stored as the empty string ("" = unset). now is the application-computed UTC
+// value written to created_at (on insert) and updated_at (both).
+func (s *SpaceWelcomeConfigStore) Upsert(ctx context.Context, cfg SpaceWelcomeSpaceConfig, now time.Time) error {
+	enabled := 0
+	if cfg.Enabled {
+		enabled = 1
+	}
+	_, err := s.db.InsertBySql(
+		"INSERT INTO "+spaceWelcomeConfigTable+" (space_id, enabled, active_from, message, updated_by, created_at, updated_at) "+
+			"VALUES (?, ?, ?, ?, ?, ?, ?) "+
+			"ON DUPLICATE KEY UPDATE enabled=VALUES(enabled), active_from=VALUES(active_from), "+
+			"message=VALUES(message), updated_by=VALUES(updated_by), updated_at=VALUES(updated_at)",
+		cfg.SpaceID, enabled, cfg.ActiveFromRaw, cfg.Message, cfg.UpdatedBy, now, now,
+	).ExecContext(ctx)
+	if err != nil {
+		return fmt.Errorf("upsert space welcome config: %w", err)
+	}
+	return nil
+}
+
+// Delete hard-deletes the per-Space config row. deleted=false when none existed
+// (idempotent). After a delete the Space reverts to the global fallback (or off).
+func (s *SpaceWelcomeConfigStore) Delete(ctx context.Context, spaceID string) (bool, error) {
+	if spaceID == "" {
+		return false, nil
+	}
+	res, err := s.db.DeleteFrom(spaceWelcomeConfigTable).
+		Where("space_id=?", spaceID).ExecContext(ctx)
+	if err != nil {
+		return false, fmt.Errorf("delete space welcome config: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+	return n > 0, nil
+}
+
+// ListEnabled returns all enabled per-Space configs, ordered by space_id, for
+// the reconciler / worker to iterate the set of Spaces with an active welcome.
+func (s *SpaceWelcomeConfigStore) ListEnabled(ctx context.Context) ([]SpaceWelcomeSpaceConfig, error) {
+	var rows []spaceWelcomeConfigRow
+	_, err := s.db.SelectBySql(
+		"SELECT "+spaceWelcomeConfigCols+" FROM "+spaceWelcomeConfigTable+" WHERE enabled=1 ORDER BY space_id",
+	).LoadContext(ctx, &rows)
+	if err != nil {
+		return nil, fmt.Errorf("list enabled space welcome configs: %w", err)
+	}
+	out := make([]SpaceWelcomeSpaceConfig, 0, len(rows))
+	for _, r := range rows {
+		out = append(out, r.toConfig())
+	}
+	return out, nil
+}
+
+// ResolveEffectiveSpaceWelcome computes the config in effect for spaceID:
+//
+//   - a per-Space row (if present) wins outright, EVEN when disabled — a present
+//     row lets an admin opt their Space out of a global campaign;
+//   - otherwise the platform-global config applies iff it is enabled and its
+//     space_welcome_space_id names this Space;
+//   - otherwise the feature is off for this Space.
+//
+// The result reuses the SpaceWelcomeConfig shape so callers keep applying
+// ValidateSpaceWelcomeCombination / ParsedActiveFrom unchanged.
+func ResolveEffectiveSpaceWelcome(row *SpaceWelcomeSpaceConfig, found bool, global SpaceWelcomeConfig, spaceID string) SpaceWelcomeConfig {
+	if found && row != nil {
+		return SpaceWelcomeConfig{
+			Enabled:       row.Enabled,
+			SpaceID:       spaceID,
+			ActiveFromRaw: row.ActiveFromRaw,
+			Message:       row.Message,
+		}
+	}
+	if global.Enabled && global.SpaceID == spaceID {
+		return global
+	}
+	return SpaceWelcomeConfig{SpaceID: spaceID}
+}

--- a/modules/common/space_welcome_config_store.go
+++ b/modules/common/space_welcome_config_store.go
@@ -30,6 +30,14 @@ import (
 // duplicating the constant.
 const SpaceWelcomeMessageMaxRunes = spaceWelcomeMessageMaxRunes
 
+// SpaceWelcomeActiveFromMaxLen bounds the active_from string to its storage
+// column width (VARCHAR(40) in the config migration). Enforced on the write path
+// independently of enabled/parse: a disabled config skips the RFC3339 parse
+// entirely, and time.Parse otherwise accepts arbitrarily long fractional
+// seconds, so without this guard an over-column value could reach the upsert and
+// fail as a driver/store 500 (strict sql_mode) or truncate silently (permissive).
+const SpaceWelcomeActiveFromMaxLen = 40
+
 const spaceWelcomeConfigTable = "octo_space_welcome_config"
 
 // SpaceWelcomeSpaceConfig is one per-Space welcome config row.
@@ -135,6 +143,91 @@ func (s *SpaceWelcomeConfigStore) Upsert(ctx context.Context, cfg SpaceWelcomeSp
 		return fmt.Errorf("upsert space welcome config: %w", err)
 	}
 	return nil
+}
+
+// UpsertMerged performs a read-modify-write of the per-Space config inside a
+// single transaction that holds a row lock (SELECT ... FOR UPDATE), closing the
+// lost-update window when two admins PUT the same Space concurrently: the second
+// transaction blocks on the first's row lock, then re-reads the just-written
+// state before merge runs, so neither admin's fields are silently reverted.
+//
+// merge receives the current row (found=false when absent) and returns the
+// config to persist. A non-nil error from merge aborts the write (the tx rolls
+// back) and is returned verbatim — callers use this to surface validation
+// failures without writing. On success the persisted row, re-read inside the tx,
+// is returned. now is the app-computed UTC timestamp for created_at/updated_at.
+//
+// Note: FOR UPDATE only locks an existing row; two racing first-creates of the
+// same space_id are still resolved last-writer-wins by the UNIQUE key +
+// ON DUPLICATE KEY UPDATE (no torn state, no error). The lost-update the
+// reviewers flagged is co-admins editing an existing config, which the row lock
+// fully serializes.
+func (s *SpaceWelcomeConfigStore) UpsertMerged(
+	ctx context.Context,
+	spaceID string,
+	now time.Time,
+	merge func(cur *SpaceWelcomeSpaceConfig, found bool) (SpaceWelcomeSpaceConfig, error),
+) (*SpaceWelcomeSpaceConfig, error) {
+	if spaceID == "" {
+		return nil, errors.New("space welcome upsert: empty space id")
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("begin space welcome upsert tx: %w", err)
+	}
+	defer tx.RollbackUnlessCommitted()
+
+	var row spaceWelcomeConfigRow
+	found := true
+	if err := tx.SelectBySql(
+		"SELECT "+spaceWelcomeConfigCols+" FROM "+spaceWelcomeConfigTable+" WHERE space_id=? FOR UPDATE",
+		spaceID,
+	).LoadOneContext(ctx, &row); err != nil {
+		if errors.Is(err, dbr.ErrNotFound) {
+			found = false
+		} else {
+			return nil, fmt.Errorf("lock space welcome config: %w", err)
+		}
+	}
+
+	var cur *SpaceWelcomeSpaceConfig
+	if found {
+		c := row.toConfig()
+		cur = &c
+	}
+	next, err := merge(cur, found)
+	if err != nil {
+		return nil, err
+	}
+
+	enabled := 0
+	if next.Enabled {
+		enabled = 1
+	}
+	if _, err := tx.InsertBySql(
+		"INSERT INTO "+spaceWelcomeConfigTable+" (space_id, enabled, active_from, message, updated_by, created_at, updated_at) "+
+			"VALUES (?, ?, ?, ?, ?, ?, ?) "+
+			"ON DUPLICATE KEY UPDATE enabled=VALUES(enabled), active_from=VALUES(active_from), "+
+			"message=VALUES(message), updated_by=VALUES(updated_by), updated_at=VALUES(updated_at)",
+		next.SpaceID, enabled, next.ActiveFromRaw, next.Message, next.UpdatedBy, now, now,
+	).ExecContext(ctx); err != nil {
+		return nil, fmt.Errorf("upsert space welcome config: %w", err)
+	}
+
+	// Re-read inside the tx so the returned view reflects the persisted row
+	// (created_at from the original insert, updated_at=now).
+	var out spaceWelcomeConfigRow
+	if err := tx.SelectBySql(
+		"SELECT "+spaceWelcomeConfigCols+" FROM "+spaceWelcomeConfigTable+" WHERE space_id=?",
+		spaceID,
+	).LoadOneContext(ctx, &out); err != nil {
+		return nil, fmt.Errorf("reload space welcome config: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("commit space welcome upsert tx: %w", err)
+	}
+	cfg := out.toConfig()
+	return &cfg, nil
 }
 
 // Delete hard-deletes the per-Space config row. deleted=false when none existed

--- a/modules/common/space_welcome_config_store.go
+++ b/modules/common/space_welcome_config_store.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"time"
 
+	mysql "github.com/go-sql-driver/mysql"
 	"github.com/gocraft/dbr/v2"
 )
 
@@ -145,23 +146,33 @@ func (s *SpaceWelcomeConfigStore) Upsert(ctx context.Context, cfg SpaceWelcomeSp
 	return nil
 }
 
+// spaceWelcomeUpsertMaxAttempts bounds the insert-then-lock retry on a transient
+// InnoDB deadlock / lock-wait-timeout (see UpsertMerged).
+const spaceWelcomeUpsertMaxAttempts = 3
+
 // UpsertMerged performs a read-modify-write of the per-Space config inside a
-// single transaction that holds a row lock (SELECT ... FOR UPDATE), closing the
-// lost-update window when two admins PUT the same Space concurrently: the second
-// transaction blocks on the first's row lock, then re-reads the just-written
-// state before merge runs, so neither admin's fields are silently reverted.
+// transaction, serialized so that two admins PUTting the same Space concurrently
+// never lose each other's fields — whether they are editing an existing config
+// OR both creating it for the first time.
 //
-// merge receives the current row (found=false when absent) and returns the
-// config to persist. A non-nil error from merge aborts the write (the tx rolls
-// back) and is returned verbatim — callers use this to surface validation
-// failures without writing. On success the persisted row, re-read inside the tx,
-// is returned. now is the app-computed UTC timestamp for created_at/updated_at.
+// It uses an insert-then-lock strategy: first an idempotent INSERT ... ON
+// DUPLICATE KEY UPDATE ensures the row exists (no-op if it already does), THEN a
+// SELECT ... FOR UPDATE locks that now-guaranteed row before merge runs. This is
+// the fix for concurrent FIRST creates: a plain SELECT ... FOR UPDATE cannot
+// lock a row that does not exist yet, so two creators would both merge onto
+// defaults and the later write would clobber the earlier's disjoint field (or
+// gap-lock deadlock under REPEATABLE READ). Doing the INSERT first — without a
+// preceding gap-locking SELECT — gives the lock a real row to serialize on and
+// avoids the gap-lock deadlock (the config table has a single UNIQUE key, so
+// concurrent same-key inserts are a linear wait, not a cycle). A rare transient
+// deadlock/lock-timeout is retried up to spaceWelcomeUpsertMaxAttempts.
 //
-// Note: FOR UPDATE only locks an existing row; two racing first-creates of the
-// same space_id are still resolved last-writer-wins by the UNIQUE key +
-// ON DUPLICATE KEY UPDATE (no torn state, no error). The lost-update the
-// reviewers flagged is co-admins editing an existing config, which the row lock
-// fully serializes.
+// merge receives the current row (found=false when this PUT just created the
+// default row) and returns the config to persist. A non-nil error from merge
+// aborts the write (tx rolls back) and is returned verbatim — callers use it to
+// surface validation failures without writing, and it is never retried. On
+// success the persisted row, re-read inside the tx, is returned. now is the
+// app-computed UTC timestamp for created_at/updated_at.
 func (s *SpaceWelcomeConfigStore) UpsertMerged(
 	ctx context.Context,
 	spaceID string,
@@ -171,51 +182,87 @@ func (s *SpaceWelcomeConfigStore) UpsertMerged(
 	if spaceID == "" {
 		return nil, errors.New("space welcome upsert: empty space id")
 	}
+	var lastErr error
+	for attempt := 1; attempt <= spaceWelcomeUpsertMaxAttempts; attempt++ {
+		cfg, err := s.upsertMergedOnce(ctx, spaceID, now, merge)
+		if err == nil {
+			return cfg, nil
+		}
+		// A merge (validation) error and any non-transient DB error are terminal
+		// and surfaced verbatim so the caller's errors.Is checks still work.
+		if !isRetryableTxErr(err) {
+			return nil, err
+		}
+		lastErr = err
+	}
+	return nil, fmt.Errorf("upsert space welcome config: retries exhausted: %w", lastErr)
+}
+
+// upsertMergedOnce is a single insert-then-lock attempt; see UpsertMerged.
+func (s *SpaceWelcomeConfigStore) upsertMergedOnce(
+	ctx context.Context,
+	spaceID string,
+	now time.Time,
+	merge func(cur *SpaceWelcomeSpaceConfig, found bool) (SpaceWelcomeSpaceConfig, error),
+) (*SpaceWelcomeSpaceConfig, error) {
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return nil, fmt.Errorf("begin space welcome upsert tx: %w", err)
 	}
 	defer tx.RollbackUnlessCommitted()
 
+	// 1) Ensure the row exists (idempotent). The ON DUPLICATE clause is a no-op
+	//    (space_id=space_id) so an existing row's fields — and its created_at —
+	//    are untouched. affected==1 => inserted (this PUT is a first create);
+	//    affected==0 => the row already existed.
+	res, err := tx.InsertBySql(
+		"INSERT INTO "+spaceWelcomeConfigTable+" (space_id, enabled, active_from, message, updated_by, created_at, updated_at) "+
+			"VALUES (?, 0, '', '', '', ?, ?) ON DUPLICATE KEY UPDATE space_id=space_id",
+		spaceID, now, now,
+	).ExecContext(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("ensure space welcome row: %w", err)
+	}
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return nil, fmt.Errorf("ensure space welcome row affected: %w", err)
+	}
+	created := affected == 1
+
+	// 2) Lock the now-existing row and read the current state under the lock.
 	var row spaceWelcomeConfigRow
-	found := true
 	if err := tx.SelectBySql(
 		"SELECT "+spaceWelcomeConfigCols+" FROM "+spaceWelcomeConfigTable+" WHERE space_id=? FOR UPDATE",
 		spaceID,
 	).LoadOneContext(ctx, &row); err != nil {
-		if errors.Is(err, dbr.ErrNotFound) {
-			found = false
-		} else {
-			return nil, fmt.Errorf("lock space welcome config: %w", err)
-		}
+		return nil, fmt.Errorf("lock space welcome config: %w", err)
 	}
 
+	// 3) Merge. found=false when we just created the default row, so the caller
+	//    starts from its own defaults (identical to the inserted default row).
 	var cur *SpaceWelcomeSpaceConfig
-	if found {
+	if !created {
 		c := row.toConfig()
 		cur = &c
 	}
-	next, err := merge(cur, found)
+	next, err := merge(cur, !created)
 	if err != nil {
-		return nil, err
+		return nil, err // terminal (validation): surfaced verbatim, tx rolls back
 	}
 
+	// 4) Persist with a plain UPDATE (row guaranteed present; created_at preserved).
 	enabled := 0
 	if next.Enabled {
 		enabled = 1
 	}
-	if _, err := tx.InsertBySql(
-		"INSERT INTO "+spaceWelcomeConfigTable+" (space_id, enabled, active_from, message, updated_by, created_at, updated_at) "+
-			"VALUES (?, ?, ?, ?, ?, ?, ?) "+
-			"ON DUPLICATE KEY UPDATE enabled=VALUES(enabled), active_from=VALUES(active_from), "+
-			"message=VALUES(message), updated_by=VALUES(updated_by), updated_at=VALUES(updated_at)",
-		next.SpaceID, enabled, next.ActiveFromRaw, next.Message, next.UpdatedBy, now, now,
+	if _, err := tx.UpdateBySql(
+		"UPDATE "+spaceWelcomeConfigTable+" SET enabled=?, active_from=?, message=?, updated_by=?, updated_at=? WHERE space_id=?",
+		enabled, next.ActiveFromRaw, next.Message, next.UpdatedBy, now, spaceID,
 	).ExecContext(ctx); err != nil {
-		return nil, fmt.Errorf("upsert space welcome config: %w", err)
+		return nil, fmt.Errorf("update space welcome config: %w", err)
 	}
 
-	// Re-read inside the tx so the returned view reflects the persisted row
-	// (created_at from the original insert, updated_at=now).
+	// 5) Re-read inside the tx so the returned view reflects the persisted row.
 	var out spaceWelcomeConfigRow
 	if err := tx.SelectBySql(
 		"SELECT "+spaceWelcomeConfigCols+" FROM "+spaceWelcomeConfigTable+" WHERE space_id=?",
@@ -228,6 +275,16 @@ func (s *SpaceWelcomeConfigStore) UpsertMerged(
 	}
 	cfg := out.toConfig()
 	return &cfg, nil
+}
+
+// isRetryableTxErr reports whether err is a transient InnoDB deadlock (1213) or
+// lock-wait timeout (1205) that a fresh attempt may resolve.
+func isRetryableTxErr(err error) bool {
+	var myErr *mysql.MySQLError
+	if errors.As(err, &myErr) {
+		return myErr.Number == 1213 || myErr.Number == 1205
+	}
+	return false
 }
 
 // Delete hard-deletes the per-Space config row. deleted=false when none existed

--- a/modules/common/space_welcome_config_store_test.go
+++ b/modules/common/space_welcome_config_store_test.go
@@ -1,0 +1,90 @@
+package common
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSpaceWelcomeConfigStore_CRUD exercises the per-Space config store end to
+// end against a real DB (task space-welcome-per-space-admin-crud).
+func TestSpaceWelcomeConfigStore_CRUD(t *testing.T) {
+	_, ctx := testutil.NewTestServer()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+	t.Cleanup(func() { _ = testutil.CleanAllTables(ctx) })
+
+	store := NewSpaceWelcomeConfigStore(ctx.DB())
+	bg := context.Background()
+	now := time.Now().UTC()
+
+	// Absent -> found=false, no error.
+	_, found, err := store.Get(bg, "spc_1")
+	require.NoError(t, err)
+	assert.False(t, found)
+	exists, err := store.Exists(bg, "spc_1")
+	require.NoError(t, err)
+	assert.False(t, exists)
+
+	// Insert.
+	require.NoError(t, store.Upsert(bg, SpaceWelcomeSpaceConfig{
+		SpaceID:       "spc_1",
+		Enabled:       true,
+		ActiveFromRaw: "2026-07-10T00:00:00Z",
+		Message:       "欢迎\n多行",
+		UpdatedBy:     "u_admin",
+	}, now))
+
+	row, found, err := store.Get(bg, "spc_1")
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.True(t, row.Enabled)
+	assert.Equal(t, "2026-07-10T00:00:00Z", row.ActiveFromRaw)
+	assert.Equal(t, "欢迎\n多行", row.Message, "internal newline preserved verbatim")
+	assert.Equal(t, "u_admin", row.UpdatedBy)
+	exists, err = store.Exists(bg, "spc_1")
+	require.NoError(t, err)
+	assert.True(t, exists)
+
+	// Update (upsert on the same space): flip enabled, change body, clear active_from.
+	require.NoError(t, store.Upsert(bg, SpaceWelcomeSpaceConfig{
+		SpaceID:       "spc_1",
+		Enabled:       false,
+		ActiveFromRaw: "",
+		Message:       "updated",
+		UpdatedBy:     "u_admin2",
+	}, now.Add(time.Minute)))
+	row, _, err = store.Get(bg, "spc_1")
+	require.NoError(t, err)
+	assert.False(t, row.Enabled)
+	assert.Equal(t, "", row.ActiveFromRaw, "empty active_from stored as empty string")
+	assert.Equal(t, "updated", row.Message)
+	assert.Equal(t, "u_admin2", row.UpdatedBy)
+
+	// ListEnabled returns only enabled rows.
+	require.NoError(t, store.Upsert(bg, SpaceWelcomeSpaceConfig{
+		SpaceID: "spc_2", Enabled: true, ActiveFromRaw: "2026-07-11T00:00:00Z", Message: "hi2", UpdatedBy: "u_a",
+	}, now))
+	list, err := store.ListEnabled(bg)
+	require.NoError(t, err)
+	got := map[string]bool{}
+	for _, c := range list {
+		got[c.SpaceID] = true
+	}
+	assert.True(t, got["spc_2"], "enabled spc_2 listed")
+	assert.False(t, got["spc_1"], "disabled spc_1 must not be listed")
+
+	// Delete is idempotent and reverts the space to unconfigured.
+	deleted, err := store.Delete(bg, "spc_1")
+	require.NoError(t, err)
+	assert.True(t, deleted)
+	deleted, err = store.Delete(bg, "spc_1")
+	require.NoError(t, err)
+	assert.False(t, deleted, "deleting an absent row is a no-op success")
+	_, found, err = store.Get(bg, "spc_1")
+	require.NoError(t, err)
+	assert.False(t, found)
+}

--- a/modules/common/space_welcome_config_store_test.go
+++ b/modules/common/space_welcome_config_store_test.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 
@@ -87,4 +88,75 @@ func TestSpaceWelcomeConfigStore_CRUD(t *testing.T) {
 	_, found, err = store.Get(bg, "spc_1")
 	require.NoError(t, err)
 	assert.False(t, found)
+}
+
+// TestSpaceWelcomeConfigStore_UpsertMerged_NoLostUpdate is the concurrent
+// partial-update regression (reviewer-requested). Two admins patch DIFFERENT
+// fields of the same Space simultaneously. UpsertMerged reads under a row lock
+// (SELECT ... FOR UPDATE), so whichever transaction runs second merges onto the
+// first's committed write — the final row must reflect BOTH patches regardless
+// of interleaving. Without the lock, one admin's field would be silently lost.
+func TestSpaceWelcomeConfigStore_UpsertMerged_NoLostUpdate(t *testing.T) {
+	_, ctx := testutil.NewTestServer()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+	t.Cleanup(func() { _ = testutil.CleanAllTables(ctx) })
+
+	store := NewSpaceWelcomeConfigStore(ctx.DB())
+	bg := context.Background()
+
+	// Seed the enabled config both admins start from.
+	require.NoError(t, store.Upsert(bg, SpaceWelcomeSpaceConfig{
+		SpaceID:       "spc_race",
+		Enabled:       true,
+		ActiveFromRaw: "2026-07-10T00:00:00Z",
+		Message:       "orig",
+		UpdatedBy:     "seed",
+	}, time.Now().UTC()))
+
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	// Admin A: change only the message, preserving whatever enabled it reads.
+	go func() {
+		defer wg.Done()
+		<-start
+		_, err := store.UpsertMerged(bg, "spc_race", time.Now().UTC(),
+			func(cur *SpaceWelcomeSpaceConfig, found bool) (SpaceWelcomeSpaceConfig, error) {
+				next := SpaceWelcomeSpaceConfig{SpaceID: "spc_race"}
+				if cur != nil {
+					next = *cur
+				}
+				next.Message = "msg-A"
+				next.UpdatedBy = "admin_A"
+				return next, nil
+			})
+		assert.NoError(t, err)
+	}()
+
+	// Admin B: disable, preserving whatever message it reads.
+	go func() {
+		defer wg.Done()
+		<-start
+		_, err := store.UpsertMerged(bg, "spc_race", time.Now().UTC(),
+			func(cur *SpaceWelcomeSpaceConfig, found bool) (SpaceWelcomeSpaceConfig, error) {
+				next := SpaceWelcomeSpaceConfig{SpaceID: "spc_race"}
+				if cur != nil {
+					next = *cur
+				}
+				next.Enabled = false
+				next.UpdatedBy = "admin_B"
+				return next, nil
+			})
+		assert.NoError(t, err)
+	}()
+
+	close(start) // release both goroutines to contend on the row lock
+	wg.Wait()
+
+	row, found, err := store.Get(bg, "spc_race")
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Equal(t, "msg-A", row.Message, "admin A's message must not be lost")
+	assert.False(t, row.Enabled, "admin B's disable must not be lost")
 }

--- a/modules/common/space_welcome_config_store_test.go
+++ b/modules/common/space_welcome_config_store_test.go
@@ -160,3 +160,69 @@ func TestSpaceWelcomeConfigStore_UpsertMerged_NoLostUpdate(t *testing.T) {
 	assert.Equal(t, "msg-A", row.Message, "admin A's message must not be lost")
 	assert.False(t, row.Enabled, "admin B's disable must not be lost")
 }
+
+// TestSpaceWelcomeConfigStore_UpsertMerged_ConcurrentCreate is the concurrent
+// FIRST-create regression (reviewer-requested): two admins issue the first PUT
+// for the SAME absent config at once, each patching a different field. A plain
+// SELECT ... FOR UPDATE cannot lock a not-yet-existing row, so without the
+// insert-then-lock strategy both would merge onto defaults and the later write
+// would clobber the earlier's field. With it, the second create serializes on
+// the row the first inserted and merges onto its committed state — both fields
+// survive and there is exactly one row (no duplicate, no error).
+func TestSpaceWelcomeConfigStore_UpsertMerged_ConcurrentCreate(t *testing.T) {
+	_, ctx := testutil.NewTestServer()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+	t.Cleanup(func() { _ = testutil.CleanAllTables(ctx) })
+
+	store := NewSpaceWelcomeConfigStore(ctx.DB())
+	bg := context.Background()
+
+	// No seed row: this is a first-time create race for an ABSENT config.
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	// Admin A: create with a message only (leaves enabled at default false).
+	go func() {
+		defer wg.Done()
+		<-start
+		_, err := store.UpsertMerged(bg, "spc_new", time.Now().UTC(),
+			func(cur *SpaceWelcomeSpaceConfig, found bool) (SpaceWelcomeSpaceConfig, error) {
+				next := SpaceWelcomeSpaceConfig{SpaceID: "spc_new"}
+				if cur != nil {
+					next = *cur
+				}
+				next.Message = "msg-A"
+				next.UpdatedBy = "admin_A"
+				return next, nil
+			})
+		assert.NoError(t, err)
+	}()
+
+	// Admin B: create with enabled=true only (leaves message at default "").
+	go func() {
+		defer wg.Done()
+		<-start
+		_, err := store.UpsertMerged(bg, "spc_new", time.Now().UTC(),
+			func(cur *SpaceWelcomeSpaceConfig, found bool) (SpaceWelcomeSpaceConfig, error) {
+				next := SpaceWelcomeSpaceConfig{SpaceID: "spc_new"}
+				if cur != nil {
+					next = *cur
+				}
+				next.Enabled = true
+				next.UpdatedBy = "admin_B"
+				return next, nil
+			})
+		assert.NoError(t, err)
+	}()
+
+	close(start)
+	wg.Wait()
+
+	// Exactly one row, and neither admin's field was lost.
+	row, found, err := store.Get(bg, "spc_new")
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Equal(t, "msg-A", row.Message, "admin A's message must not be lost on concurrent create")
+	assert.True(t, row.Enabled, "admin B's enable must not be lost on concurrent create")
+}

--- a/modules/common/space_welcome_effective_test.go
+++ b/modules/common/space_welcome_effective_test.go
@@ -1,0 +1,81 @@
+package common
+
+import "testing"
+
+// TestResolveEffectiveSpaceWelcome pins the precedence contract between a
+// per-Space config row and the platform-global fallback (task
+// space-welcome-per-space-admin-crud). Pure function — no DB.
+func TestResolveEffectiveSpaceWelcome(t *testing.T) {
+	globalOn := SpaceWelcomeConfig{
+		Enabled:       true,
+		SpaceID:       "spc_global",
+		ActiveFromRaw: "2026-07-01T00:00:00Z",
+		Message:       "global hi",
+	}
+	globalOff := SpaceWelcomeConfig{Enabled: false, SpaceID: "spc_global"}
+
+	row := func(enabled bool, msg string) *SpaceWelcomeSpaceConfig {
+		return &SpaceWelcomeSpaceConfig{
+			SpaceID:       "spc_x",
+			Enabled:       enabled,
+			ActiveFromRaw: "2026-07-10T00:00:00Z",
+			Message:       msg,
+		}
+	}
+
+	cases := []struct {
+		name        string
+		row         *SpaceWelcomeSpaceConfig
+		found       bool
+		global      SpaceWelcomeConfig
+		spaceID     string
+		wantEnabled bool
+		wantMessage string
+	}{
+		{
+			name: "per-space enabled row wins over global",
+			row:  row(true, "space hi"), found: true, global: globalOn, spaceID: "spc_x",
+			wantEnabled: true, wantMessage: "space hi",
+		},
+		{
+			name: "per-space DISABLED row overrides global that names this space",
+			// Even when the global config names spc_x and is on, a present row
+			// (disabled) opts the space OUT — a present row always wins.
+			row:         &SpaceWelcomeSpaceConfig{SpaceID: "spc_x", Enabled: false},
+			found:       true,
+			global:      SpaceWelcomeConfig{Enabled: true, SpaceID: "spc_x", ActiveFromRaw: "2026-07-01T00:00:00Z", Message: "global"},
+			spaceID:     "spc_x",
+			wantEnabled: false, wantMessage: "",
+		},
+		{
+			name: "no row, global enabled and names this space -> global applies",
+			row:  nil, found: false, global: globalOn, spaceID: "spc_global",
+			wantEnabled: true, wantMessage: "global hi",
+		},
+		{
+			name: "no row, global enabled but names a DIFFERENT space -> off",
+			row:  nil, found: false, global: globalOn, spaceID: "spc_other",
+			wantEnabled: false, wantMessage: "",
+		},
+		{
+			name: "no row, global disabled -> off",
+			row:  nil, found: false, global: globalOff, spaceID: "spc_global",
+			wantEnabled: false, wantMessage: "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ResolveEffectiveSpaceWelcome(tc.row, tc.found, tc.global, tc.spaceID)
+			if got.Enabled != tc.wantEnabled {
+				t.Fatalf("Enabled = %v, want %v", got.Enabled, tc.wantEnabled)
+			}
+			if got.Message != tc.wantMessage {
+				t.Fatalf("Message = %q, want %q", got.Message, tc.wantMessage)
+			}
+			if got.SpaceID != tc.spaceID {
+				t.Fatalf("SpaceID = %q, want %q (effective config always carries the queried space)", got.SpaceID, tc.spaceID)
+			}
+		})
+	}
+}

--- a/modules/common/sql/20260720000001_add_octo_space_welcome_config.sql
+++ b/modules/common/sql/20260720000001_add_octo_space_welcome_config.sql
@@ -1,0 +1,29 @@
+-- +migrate Up
+
+-- Per-Space 新成员欢迎语配置（task space-welcome-per-space-admin-crud）。
+-- 每空间至多一行；空间管理员(Role>=1)经 /v1/space/:space_id/welcome 自助增删改。
+-- 与平台级全局配置(system_setting onboarding.space_welcome_*)的关系：本表存在该
+-- space 的行即「覆盖」全局（无论 enabled——管理员可借 enabled=0 让本空间退出全局
+-- 活动），无行则「回落」全局兜底（仅当全局 enabled 且其 space_welcome_space_id
+-- 点名该 space）。有效配置每空间恰好一份、解析确定。
+-- 时间纪律：active_from 存 RFC3339 UTC 字符串（复用 ParsedActiveFrom /
+-- ValidateSpaceWelcomeCombination，与 active_from(RFC3339 UTC) 语义一致）；
+-- created_at/updated_at 为应用侧写入的 UTC 值（time.Now().UTC() bound 参数），
+-- 禁用 NOW()（DB 会话时区未在 DSN 固定），因此不设 DEFAULT CURRENT_TIMESTAMP。
+-- COLLATE 显式对齐 space.space_id（utf8mb4_general_ci），避免与 space/space_member
+-- 对账 JOIN 触发 MySQL 1267。
+CREATE TABLE `octo_space_welcome_config` (
+  `id`          BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+  `space_id`    VARCHAR(40)   NOT NULL DEFAULT ''  COMMENT '目标 Space（长度/字符集/COLLATE 对齐 space.space_id）',
+  `enabled`     TINYINT       NOT NULL DEFAULT 0   COMMENT '0=关闭 1=开启；开启需 active_from/message 构成有效组合',
+  `active_from` VARCHAR(40)   NOT NULL DEFAULT ''  COMMENT 'RFC3339 UTC 字符串（空=未设置）；仅 created_at>=此刻首次加入的成员会收到',
+  `message`     VARCHAR(2000) NOT NULL DEFAULT ''  COMMENT '欢迎语纯文本（trim 后非空，<=2000 code points；支持换行，不渲染 markdown）',
+  `updated_by`  VARCHAR(40)   NOT NULL DEFAULT ''  COMMENT '最近修改的管理员 uid（审计）',
+  `created_at`  DATETIME      NOT NULL             COMMENT 'UTC；应用侧写入，禁 NOW()',
+  `updated_at`  DATETIME      NOT NULL             COMMENT 'UTC；应用侧写入，禁 NOW()',
+  UNIQUE KEY `uk_space` (`space_id`),
+  KEY `idx_enabled` (`enabled`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci COMMENT='per-space onboarding welcome config';
+
+-- +migrate Down
+DROP TABLE IF EXISTS `octo_space_welcome_config`;

--- a/modules/notify/space_welcome.go
+++ b/modules/notify/space_welcome.go
@@ -56,6 +56,7 @@ func callWithTimeout[T any](d time.Duration, fn func() T) (T, bool) {
 type spaceWelcomeService struct {
 	ctx      *config.Context
 	store    *spaceWelcomeStore
+	cfgStore *common.SpaceWelcomeConfigStore
 	settings *common.SystemSettings
 	metrics  *spaceWelcomeMetrics
 	fromUID  string
@@ -67,6 +68,11 @@ type spaceWelcomeService struct {
 	botReady func() bool
 	// now returns the current time; injectable for tests. Always UTC.
 	now func() time.Time
+
+	// reconcileCursor rotates the reconciler's per-cycle starting Space so a
+	// shared global budget cannot perpetually starve the tail of the enabled-Space
+	// list. Touched only by the single reconcile goroutine — no lock needed.
+	reconcileCursor int
 
 	mu     sync.Mutex
 	cancel context.CancelFunc
@@ -81,6 +87,7 @@ func newSpaceWelcomeService(ctx *config.Context, settings *common.SystemSettings
 	return &spaceWelcomeService{
 		ctx:      ctx,
 		store:    newSpaceWelcomeStore(ctx.DB(), owner),
+		cfgStore: common.NewSpaceWelcomeConfigStore(ctx.DB()),
 		settings: settings,
 		metrics:  newSpaceWelcomeMetrics(),
 		fromUID:  fromUID,
@@ -138,17 +145,72 @@ func (s *spaceWelcomeService) Stop() {
 // Event path (low latency)
 // ---------------------------------------------------------------------------
 
-// handleMemberJoin is invoked from the SpaceMemberJoin listener. When the event
-// matches the enabled config and the recipient is a first-join human member of
-// the target Space, it upserts a pending ledger row. Enqueue failure never
-// blocks or rolls back the completed join — it is logged and dropped (the
-// reconciler will catch it up).
+// effectiveConfig resolves the config in effect for spaceID: a per-Space row (if
+// present) overrides the platform-global fallback outright, else the global
+// config applies iff it is enabled and names spaceID. A DB error is returned so
+// callers can fail closed. The returned SpaceWelcomeConfig reuses the existing
+// shape, so ValidateSpaceWelcomeCombination / ParsedActiveFrom apply unchanged.
+func (s *spaceWelcomeService) effectiveConfig(ctx context.Context, spaceID string) (common.SpaceWelcomeConfig, error) {
+	row, found, err := s.cfgStore.Get(ctx, spaceID)
+	if err != nil {
+		return common.SpaceWelcomeConfig{}, err
+	}
+	return common.ResolveEffectiveSpaceWelcome(row, found, s.settings.SpaceWelcomeConfig(), spaceID), nil
+}
+
+// enabledEffectiveConfigs returns the effective config for every Space that has
+// an active welcome: each enabled per-Space row, plus the global-fallback Space
+// iff it is enabled AND has no per-Space row overriding it (a present row wins
+// regardless of its enabled flag). DB calls are individually bounded.
+func (s *spaceWelcomeService) enabledEffectiveConfigs(ctx context.Context) ([]common.SpaceWelcomeConfig, error) {
+	lc, cancel := context.WithTimeout(ctx, swDBCallTimeout)
+	rows, err := s.cfgStore.ListEnabled(lc)
+	cancel()
+	if err != nil {
+		return nil, err
+	}
+	out := make([]common.SpaceWelcomeConfig, 0, len(rows)+1)
+	for _, r := range rows {
+		out = append(out, common.SpaceWelcomeConfig{
+			Enabled:       true,
+			SpaceID:       r.SpaceID,
+			ActiveFromRaw: r.ActiveFromRaw,
+			Message:       r.Message,
+		})
+	}
+	global := s.settings.SpaceWelcomeConfig()
+	if global.Enabled && global.SpaceID != "" {
+		ec, cancel2 := context.WithTimeout(ctx, swDBCallTimeout)
+		exists, err := s.cfgStore.Exists(ec, global.SpaceID)
+		cancel2()
+		if err != nil {
+			return nil, err
+		}
+		if !exists {
+			out = append(out, global)
+		}
+	}
+	return out, nil
+}
+
+// handleMemberJoin is invoked from the SpaceMemberJoin listener. When the target
+// Space's effective config is enabled and the recipient is a first-join human
+// member, it upserts a pending ledger row. Enqueue failure never blocks or rolls
+// back the completed join — it is logged and dropped (the reconciler catches it
+// up).
 func (s *spaceWelcomeService) handleMemberJoin(spaceID, uid string) {
 	if s == nil || spaceID == "" || uid == "" {
 		return
 	}
-	cfg := s.settings.SpaceWelcomeConfig()
-	if !cfg.Enabled || spaceID != cfg.SpaceID {
+	cfgCtx, cancelCfg := context.WithTimeout(context.Background(), swDBCallTimeout)
+	cfg, err := s.effectiveConfig(cfgCtx, spaceID)
+	cancelCfg()
+	if err != nil {
+		s.Warn("welcome enqueue effective config read failed",
+			zap.String("stage", swStageEnqueue), zap.String("space_id", spaceID), zap.String("uid", uid), zap.Error(err))
+		return
+	}
+	if !cfg.Enabled {
 		return
 	}
 	// Static combination re-validation (no space-existence DB check on the hot
@@ -170,16 +232,16 @@ func (s *spaceWelcomeService) handleMemberJoin(spaceID, uid string) {
 
 	callCtx, cancel := context.WithTimeout(context.Background(), swDBCallTimeout)
 	defer cancel()
-	eligible, err := s.store.firstJoinHumanMember(callCtx, cfg.SpaceID, uid, activeFrom)
+	eligible, err := s.store.firstJoinHumanMember(callCtx, spaceID, uid, activeFrom)
 	if err != nil {
 		s.Warn("welcome enqueue eligibility check failed",
-			zap.String("stage", swStageEnqueue), zap.String("space_id", cfg.SpaceID), zap.String("uid", uid), zap.Error(err))
+			zap.String("stage", swStageEnqueue), zap.String("space_id", spaceID), zap.String("uid", uid), zap.Error(err))
 		return
 	}
 	if !eligible {
 		return
 	}
-	s.enqueue(callCtx, cfg.SpaceID, uid, swSourceEvent)
+	s.enqueue(callCtx, spaceID, uid, swSourceEvent)
 }
 
 // enqueue upserts a pending row and splits enqueue_total vs enqueue_dedup_total.
@@ -216,38 +278,62 @@ func (s *spaceWelcomeService) reconcileLoop(ctx context.Context) {
 	}
 }
 
-// runReconcileOnce reads the config, re-validates (fail closed), scans the
-// target Space for active human members lacking a ledger row, and enqueues up
-// to swReconcileCap of them.
+// runReconcileOnce enumerates every Space with an enabled effective config,
+// re-validates each (fail closed per Space), and scans it for active human
+// members lacking a ledger row, enqueueing them. A shared global budget
+// (swReconcileCap) bounds total work per cycle, each Space is capped at
+// swReconcilePerSpaceCap, and the starting Space rotates (reconcileCursor) so a
+// backlogged head Space cannot perpetually starve the tail.
 func (s *spaceWelcomeService) runReconcileOnce(ctx context.Context) {
-	cfg := s.settings.SpaceWelcomeConfig()
-	if !cfg.Enabled {
-		return
-	}
-	if !s.validateRuntime(ctx, cfg) {
-		return
-	}
-	activeFrom, _ := cfg.ParsedActiveFrom()
-
-	scanCtx, cancel := context.WithTimeout(ctx, swDBCallTimeout)
-	uids, err := s.store.reconcileScan(scanCtx, cfg.SpaceID, activeFrom, spacepkg.SystemBotList(), swReconcileCap)
-	cancel()
+	configs, err := s.enabledEffectiveConfigs(ctx)
 	if err != nil {
-		s.Warn("welcome reconcile scan failed",
-			zap.String("stage", swStageEnqueue), zap.String("space_id", cfg.SpaceID), zap.Error(err))
+		s.Warn("welcome reconcile list enabled failed", zap.String("stage", swStageEnqueue), zap.Error(err))
 		return
 	}
-	for _, uid := range uids {
+	n := len(configs)
+	if n == 0 {
+		return
+	}
+	start := s.reconcileCursor % n
+	s.reconcileCursor++
+	budget := swReconcileCap
+
+	for i := 0; i < n && budget > 0; i++ {
 		if ctx.Err() != nil {
 			return
 		}
-		callCtx, c := context.WithTimeout(ctx, swDBCallTimeout)
-		s.enqueue(callCtx, cfg.SpaceID, uid, swSourceReconciler)
-		c()
-	}
-	if len(uids) > 0 {
-		s.Info("welcome reconcile enqueued",
-			zap.String("space_id", cfg.SpaceID), zap.Int("candidates", len(uids)))
+		cfg := configs[(start+i)%n]
+		// Per-Space runtime re-validation (space active + static combination).
+		if !s.validateRuntime(ctx, cfg) {
+			continue
+		}
+		activeFrom, _ := cfg.ParsedActiveFrom()
+		per := budget
+		if per > swReconcilePerSpaceCap {
+			per = swReconcilePerSpaceCap
+		}
+
+		scanCtx, cancel := context.WithTimeout(ctx, swDBCallTimeout)
+		uids, scanErr := s.store.reconcileScan(scanCtx, cfg.SpaceID, activeFrom, spacepkg.SystemBotList(), per)
+		cancel()
+		if scanErr != nil {
+			s.Warn("welcome reconcile scan failed",
+				zap.String("stage", swStageEnqueue), zap.String("space_id", cfg.SpaceID), zap.Error(scanErr))
+			continue
+		}
+		for _, uid := range uids {
+			if ctx.Err() != nil {
+				return
+			}
+			callCtx, c := context.WithTimeout(ctx, swDBCallTimeout)
+			s.enqueue(callCtx, cfg.SpaceID, uid, swSourceReconciler)
+			c()
+		}
+		budget -= len(uids)
+		if len(uids) > 0 {
+			s.Info("welcome reconcile enqueued",
+				zap.String("space_id", cfg.SpaceID), zap.Int("candidates", len(uids)))
+		}
 	}
 }
 
@@ -270,69 +356,100 @@ func (s *spaceWelcomeService) workerLoop(ctx context.Context) {
 	}
 }
 
-// runWorkerWake sweeps stale rows (always, even when disabled, so lease-expired
-// rows still reach a terminal state), then — when enabled and valid — drains up
-// to swWorkerWakeCap claimed rows. The per-wake cap is a safety valve; the next
-// wake resumes after the idle sleep.
+// runWorkerWake sweeps stale rows across ALL Spaces (always, even when every
+// Space is disabled, so lease-expired rows still reach a terminal state), then
+// round-robins over the enabled Spaces draining up to swWorkerWakeCap claimed
+// rows total. The per-wake cap is a safety valve; the next wake resumes after
+// the idle sleep. Per-Space enabled/validity is snapshotted at wake start —
+// disabling a Space stops NEW claims from the next wake; rows already claimed
+// this wake are allowed to complete (mirrors "in-flight dispatch completes").
 func (s *spaceWelcomeService) runWorkerWake(ctx context.Context) {
-	cfg := s.settings.SpaceWelcomeConfig()
+	// Cross-space sweep runs unconditionally: a Space disabled while rows were
+	// in-flight still has its lease-expired claimed/dispatching rows promoted.
+	s.sweepAll(ctx)
 
-	// Sweep runs against the configured Space regardless of enabled, so that a
-	// disabled feature still promotes stale claimed/dispatching rows.
-	if cfg.SpaceID != "" {
-		s.sweep(ctx, cfg.SpaceID)
+	configs, err := s.enabledEffectiveConfigs(ctx)
+	if err != nil {
+		s.Warn("welcome worker list enabled failed", zap.String("stage", swStageClaim), zap.Error(err))
+		return
 	}
-
-	if !cfg.Enabled || !s.validateRuntime(ctx, cfg) {
+	if len(configs) == 0 {
 		return
 	}
 
-	for claimed := 0; claimed < swWorkerWakeCap; claimed++ {
-		if ctx.Err() != nil {
-			return
+	// Per-Space runtime re-validation once per wake (space active + static
+	// combination). Only valid Spaces are claimed from.
+	valid := make([]common.SpaceWelcomeConfig, 0, len(configs))
+	for _, cfg := range configs {
+		if s.validateRuntime(ctx, cfg) {
+			valid = append(valid, cfg)
 		}
-		// Re-read the config each iteration (a cheap atomic snapshot read) so an
-		// admin disable or Space switch stops NEW claims immediately on this
-		// replica, rather than after the current wake's 20-row budget drains.
-		cur := s.settings.SpaceWelcomeConfig()
-		if !cur.Enabled || cur.SpaceID != cfg.SpaceID {
-			return
+	}
+
+	claimed := 0
+	for _, cfg := range valid {
+		for {
+			if ctx.Err() != nil || claimed >= swWorkerWakeCap {
+				return
+			}
+			// Re-resolve this Space's effective config before every NEW claim so an
+			// admin disable / delete / message edit mid-wake takes effect
+			// immediately on this replica (a claimed row already in flight is still
+			// allowed to complete). This mirrors the single-Space worker's
+			// per-iteration re-read; the fresh config also supplies the current
+			// message body passed to dispatch.
+			curCtx, curCancel := context.WithTimeout(ctx, swDBCallTimeout)
+			cur, curErr := s.effectiveConfig(curCtx, cfg.SpaceID)
+			curCancel()
+			if curErr != nil {
+				s.Warn("welcome worker config re-read failed", zap.String("stage", swStageClaim), zap.String("space_id", cfg.SpaceID), zap.Error(curErr))
+				break
+			}
+			if !cur.Enabled {
+				break // disabled/deleted mid-wake — stop claiming this Space
+			}
+			if field, _ := common.ValidateSpaceWelcomeCombination(cur, nil); field != "" {
+				s.metrics.incConfigInvalid()
+				break
+			}
+			claimCtx, cancel := context.WithTimeout(ctx, swDBCallTimeout)
+			row, claimErr := s.store.claimOne(claimCtx, cur.SpaceID, s.now())
+			cancel()
+			if claimErr != nil {
+				s.Warn("welcome claim failed", zap.String("stage", swStageClaim), zap.String("space_id", cur.SpaceID), zap.Error(claimErr))
+				break // move on to the next Space
+			}
+			if row == nil {
+				break // this Space drained — next Space
+			}
+			claimed++
+			s.dispatch(ctx, cur, row)
 		}
-		claimCtx, cancel := context.WithTimeout(ctx, swDBCallTimeout)
-		row, err := s.store.claimOne(claimCtx, cfg.SpaceID, s.now())
-		cancel()
-		if err != nil {
-			s.Warn("welcome claim failed", zap.String("stage", swStageClaim), zap.String("space_id", cfg.SpaceID), zap.Error(err))
-			return
-		}
-		if row == nil {
-			return // idle — fall through to sleep
-		}
-		s.dispatch(ctx, cfg, row)
 	}
 }
 
-// sweep reclaims lease-expired claimed rows (-> pending) and promotes
-// lease-expired dispatching rows (-> unknown). Runs once per wake.
-func (s *spaceWelcomeService) sweep(ctx context.Context, spaceID string) {
+// sweepAll reclaims lease-expired claimed rows (-> pending) and promotes
+// lease-expired dispatching rows (-> unknown) across ALL Spaces. Runs once per
+// wake. Cross-space so a now-disabled Space's stale rows are not stranded.
+func (s *spaceWelcomeService) sweepAll(ctx context.Context) {
 	now := s.now()
 	c1, cancel1 := context.WithTimeout(ctx, swDBCallTimeout)
-	reclaimed, err := s.store.sweepClaimed(c1, spaceID, now)
+	reclaimed, err := s.store.sweepClaimedAll(c1, now)
 	cancel1()
 	if err != nil {
-		s.Warn("welcome sweep claimed failed", zap.String("stage", swStageSweep), zap.String("space_id", spaceID), zap.Error(err))
+		s.Warn("welcome sweep claimed failed", zap.String("stage", swStageSweep), zap.Error(err))
 	} else {
 		s.metrics.addSweepClaimed(reclaimed)
 	}
 
 	c2, cancel2 := context.WithTimeout(ctx, swDBCallTimeout)
-	promoted, err := s.store.sweepDispatching(c2, spaceID, now)
+	promoted, err := s.store.sweepDispatchingAll(c2, now)
 	cancel2()
 	if err != nil {
-		s.Warn("welcome sweep dispatching failed", zap.String("stage", swStageSweep), zap.String("space_id", spaceID), zap.Error(err))
+		s.Warn("welcome sweep dispatching failed", zap.String("stage", swStageSweep), zap.Error(err))
 	} else if promoted > 0 {
 		s.metrics.addSweepDispatching(promoted)
-		s.Warn("welcome dispatching rows swept to unknown", zap.String("space_id", spaceID), zap.Int64("count", promoted))
+		s.Warn("welcome dispatching rows swept to unknown", zap.Int64("count", promoted))
 	}
 }
 

--- a/modules/notify/space_welcome.go
+++ b/modules/notify/space_welcome.go
@@ -73,6 +73,11 @@ type spaceWelcomeService struct {
 	// shared global budget cannot perpetually starve the tail of the enabled-Space
 	// list. Touched only by the single reconcile goroutine — no lock needed.
 	reconcileCursor int
+	// workerCursor rotates the send worker's per-wake starting Space for the same
+	// reason: without it, a Space that keeps saturating the per-wake claim cap
+	// (ordered first by space_id) would starve later Spaces. Touched only by the
+	// single worker goroutine — no lock needed.
+	workerCursor int
 
 	mu     sync.Mutex
 	cancel context.CancelFunc
@@ -385,9 +390,20 @@ func (s *spaceWelcomeService) runWorkerWake(ctx context.Context) {
 			valid = append(valid, cfg)
 		}
 	}
+	if len(valid) == 0 {
+		return
+	}
+
+	// Rotate the starting Space each wake so a Space that keeps saturating the
+	// per-wake cap cannot perpetually starve the others (the cap bounds one wake;
+	// the rotation bounds a starved Space's wait to len(valid) wakes).
+	vn := len(valid)
+	wstart := s.workerCursor % vn
+	s.workerCursor++
 
 	claimed := 0
-	for _, cfg := range valid {
+	for i := 0; i < vn; i++ {
+		cfg := valid[(wstart+i)%vn]
 		for {
 			if ctx.Err() != nil || claimed >= swWorkerWakeCap {
 				return

--- a/modules/notify/space_welcome_db.go
+++ b/modules/notify/space_welcome_db.go
@@ -83,36 +83,6 @@ func (s *spaceWelcomeStore) claimOne(ctx context.Context, spaceID string, now ti
 	return &row, nil
 }
 
-// sweepClaimed recycles claimed rows whose lease expired back to pending. Safe
-// because the IM call was not yet started; attempts is not decremented (and was
-// not incremented at claim). next_retry_at is set to now so the row is
-// immediately re-claimable.
-func (s *spaceWelcomeStore) sweepClaimed(ctx context.Context, spaceID string, now time.Time) (int64, error) {
-	res, err := s.db.UpdateBySql(
-		"UPDATE "+spaceWelcomeTable+" SET status=?, next_retry_at=?, claim_owner=NULL, claim_expire_at=NULL, updated_at=? "+
-			"WHERE space_id=? AND status=? AND claim_expire_at IS NOT NULL AND claim_expire_at<=?",
-		swStatusPending, now, now, spaceID, swStatusClaimed, now,
-	).ExecContext(ctx)
-	if err != nil {
-		return 0, fmt.Errorf("sweep claimed welcome rows: %w", err)
-	}
-	return res.RowsAffected()
-}
-
-// sweepDispatching promotes dispatching rows whose lease expired to unknown
-// (we cannot prove whether the IM call happened). Never auto-retried.
-func (s *spaceWelcomeStore) sweepDispatching(ctx context.Context, spaceID string, now time.Time) (int64, error) {
-	res, err := s.db.UpdateBySql(
-		"UPDATE "+spaceWelcomeTable+" SET status=?, error_class=?, claim_owner=NULL, claim_expire_at=NULL, updated_at=? "+
-			"WHERE space_id=? AND status=? AND claim_expire_at IS NOT NULL AND claim_expire_at<=?",
-		swStatusUnknown, swErrClaimExpired, now, spaceID, swStatusDispatching, now,
-	).ExecContext(ctx)
-	if err != nil {
-		return 0, fmt.Errorf("sweep dispatching welcome rows: %w", err)
-	}
-	return res.RowsAffected()
-}
-
 // sweepClaimedAll recycles lease-expired claimed rows across ALL Spaces back to
 // pending. The multi-space worker (task space-welcome-per-space-admin-crud)
 // claims only from currently-enabled Spaces, so a per-enabled-space sweep would

--- a/modules/notify/space_welcome_db.go
+++ b/modules/notify/space_welcome_db.go
@@ -113,6 +113,40 @@ func (s *spaceWelcomeStore) sweepDispatching(ctx context.Context, spaceID string
 	return res.RowsAffected()
 }
 
+// sweepClaimedAll recycles lease-expired claimed rows across ALL Spaces back to
+// pending. The multi-space worker (task space-welcome-per-space-admin-crud)
+// claims only from currently-enabled Spaces, so a per-enabled-space sweep would
+// never promote stale rows left behind by a Space that was disabled while rows
+// were in-flight. Sweeping every Space is safe (the per-row claim_owner CAS
+// still protects correctness) and index-backed by idx_sweep (status,
+// claim_expire_at). attempts is not touched (it was not incremented at claim).
+func (s *spaceWelcomeStore) sweepClaimedAll(ctx context.Context, now time.Time) (int64, error) {
+	res, err := s.db.UpdateBySql(
+		"UPDATE "+spaceWelcomeTable+" SET status=?, next_retry_at=?, claim_owner=NULL, claim_expire_at=NULL, updated_at=? "+
+			"WHERE status=? AND claim_expire_at IS NOT NULL AND claim_expire_at<=?",
+		swStatusPending, now, now, swStatusClaimed, now,
+	).ExecContext(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("sweep claimed welcome rows (all spaces): %w", err)
+	}
+	return res.RowsAffected()
+}
+
+// sweepDispatchingAll promotes lease-expired dispatching rows across ALL Spaces
+// to unknown (transport-ambiguous; never auto-retried). See sweepClaimedAll for
+// why the sweep is cross-space.
+func (s *spaceWelcomeStore) sweepDispatchingAll(ctx context.Context, now time.Time) (int64, error) {
+	res, err := s.db.UpdateBySql(
+		"UPDATE "+spaceWelcomeTable+" SET status=?, error_class=?, claim_owner=NULL, claim_expire_at=NULL, updated_at=? "+
+			"WHERE status=? AND claim_expire_at IS NOT NULL AND claim_expire_at<=?",
+		swStatusUnknown, swErrClaimExpired, now, swStatusDispatching, now,
+	).ExecContext(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("sweep dispatching welcome rows (all spaces): %w", err)
+	}
+	return res.RowsAffected()
+}
+
 // cas runs a CAS UPDATE guarded by id + expected status + claim_owner=self, so a
 // lease-expired sweep on another replica cannot be overwritten by this replica.
 // Returns ok=false when no row matched (ownership lost / status moved on).

--- a/modules/notify/space_welcome_integration_test.go
+++ b/modules/notify/space_welcome_integration_test.go
@@ -227,7 +227,7 @@ func TestStore_SweepClaimed_BackToPending(t *testing.T) {
 	past := now.Add(-time.Minute)
 	id := swInsertLedger(t, ctx, "spc_1", "u_1", swStatusClaimed, "owner-dead", &past, 2)
 
-	n, err := store.sweepClaimed(bg(), "spc_1", now)
+	n, err := store.sweepClaimedAll(bg(), now)
 	require.NoError(t, err)
 	assert.EqualValues(t, 1, n)
 
@@ -243,7 +243,7 @@ func TestStore_SweepDispatching_ToUnknown(t *testing.T) {
 	past := now.Add(-time.Minute)
 	id := swInsertLedger(t, ctx, "spc_1", "u_1", swStatusDispatching, "owner-dead", &past, 0)
 
-	n, err := store.sweepDispatching(bg(), "spc_1", now)
+	n, err := store.sweepDispatchingAll(bg(), now)
 	require.NoError(t, err)
 	assert.EqualValues(t, 1, n)
 
@@ -261,7 +261,7 @@ func TestStore_Sweep_RespectsLease(t *testing.T) {
 	future := now.Add(time.Minute)
 	id := swInsertLedger(t, ctx, "spc_1", "u_1", swStatusClaimed, "owner-live", &future, 0)
 
-	n, err := store.sweepClaimed(bg(), "spc_1", now)
+	n, err := store.sweepClaimedAll(bg(), now)
 	require.NoError(t, err)
 	assert.EqualValues(t, 0, n)
 	status, _, _, _, _ := swRowStatus(t, ctx, id)

--- a/modules/notify/space_welcome_model.go
+++ b/modules/notify/space_welcome_model.go
@@ -55,8 +55,14 @@ const (
 	swClaimLease = 30 * time.Second
 	// swReconcileInterval is the reconciler cadence (compile-time constant).
 	swReconcileInterval = 60 * time.Second
-	// swReconcileCap bounds rows enqueued per reconcile cycle.
+	// swReconcileCap bounds rows enqueued per reconcile cycle across ALL Spaces
+	// (shared global budget for the multi-Space reconciler).
 	swReconcileCap = 500
+	// swReconcilePerSpaceCap bounds rows enqueued for a single Space in one
+	// reconcile cycle so one backlogged Space cannot consume the whole global
+	// budget in a single pass; the rotating cursor + this sub-cap keep the
+	// enabled-Space set fairly served.
+	swReconcilePerSpaceCap = 200
 	// swWorkerWakeCap is the per-wake safety valve: after this many successful
 	// claims in one wake the worker falls through to the idle sleep so a single
 	// goroutine cannot monopolise the shared DB session.

--- a/modules/notify/space_welcome_perspace_test.go
+++ b/modules/notify/space_welcome_perspace_test.go
@@ -2,6 +2,7 @@ package notify
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -10,6 +11,18 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// swSeedPending seeds n deliverable pending rows (user + active member + ledger)
+// in spaceID, with uids disambiguated by offset so repeated top-ups don't collide.
+func swSeedPending(t *testing.T, ctx *config.Context, spaceID string, n, offset int) {
+	t.Helper()
+	for i := 0; i < n; i++ {
+		uid := fmt.Sprintf("%s_u%04d", spaceID, offset+i)
+		swInsertUser(t, ctx, uid, 0)
+		swInsertMember(t, ctx, spaceID, uid, 1, time.Now().UTC())
+		swInsertLedger(t, ctx, spaceID, uid, swStatusPending, "", nil, 0)
+	}
+}
 
 // Per-Space welcome config + multi-Space delivery
 // (task space-welcome-per-space-admin-crud).
@@ -155,6 +168,38 @@ func TestPerSpace_HandleMemberJoin_ScopedToConfiguredSpace(t *testing.T) {
 
 	assert.Equal(t, 1, swCountRows(t, ctx, "spc_a"))
 	assert.Equal(t, 0, swCountRows(t, ctx, "spc_b"), "a Space with no enabled config enqueues nothing")
+}
+
+// TestPerSpace_Worker_FairRotation: a Space that keeps saturating the per-wake
+// cap must not starve the others. spc_a is kept over-cap before every wake;
+// without the rotating worker cursor it (ordered first) would consume the whole
+// cap every wake and spc_b would never be served. With rotation, spc_b's small
+// backlog is drained within len(spaces) wakes.
+func TestPerSpace_Worker_FairRotation(t *testing.T) {
+	ctx := swTestServer(t)
+	settings := common.EnsureSystemSettings(ctx)
+	af := time.Now().UTC().Add(-time.Hour)
+	swInsertSpace(t, ctx, "spc_a", 1)
+	swInsertSpace(t, ctx, "spc_b", 1)
+	swSetSpaceConfig(t, ctx, "spc_a", true, af, "A")
+	swSetSpaceConfig(t, ctx, "spc_b", true, af, "B")
+
+	svc := swNewService(ctx, settings)
+	svc.sendFn = func(_ context.Context, _ *config.MsgSendReq) (*swSendResult, error) {
+		return &swSendResult{messageID: 1, clientMsgNo: "x"}, nil
+	}
+
+	swSeedPending(t, ctx, "spc_b", 3, 0) // small fixed backlog
+
+	off := 0
+	for w := 0; w < 2; w++ {
+		swSeedPending(t, ctx, "spc_a", swWorkerWakeCap+5, off) // keep spc_a saturated
+		off += swWorkerWakeCap + 5
+		svc.runWorkerWake(bg())
+	}
+
+	sentB, _ := svc.store.countByStatus(bg(), "spc_b", swStatusSent)
+	assert.EqualValues(t, 3, sentB, "rotation serves spc_b despite spc_a saturating the per-wake cap")
 }
 
 // TestPerSpace_SweepAll_CrossSpace: lease-expired claimed rows in different

--- a/modules/notify/space_welcome_perspace_test.go
+++ b/modules/notify/space_welcome_perspace_test.go
@@ -1,0 +1,180 @@
+package notify
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-server/modules/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Per-Space welcome config + multi-Space delivery
+// (task space-welcome-per-space-admin-crud).
+
+// swSetSpaceConfig upserts a per-Space welcome config row.
+func swSetSpaceConfig(t *testing.T, ctx *config.Context, spaceID string, enabled bool, activeFrom time.Time, msg string) {
+	t.Helper()
+	store := common.NewSpaceWelcomeConfigStore(ctx.DB())
+	require.NoError(t, store.Upsert(context.Background(), common.SpaceWelcomeSpaceConfig{
+		SpaceID:       spaceID,
+		Enabled:       enabled,
+		ActiveFromRaw: activeFrom.UTC().Format(time.RFC3339),
+		Message:       msg,
+		UpdatedBy:     "u_admin",
+	}, time.Now().UTC()))
+}
+
+// TestPerSpace_EffectiveConfig_RowOverridesGlobal: a present per-Space row wins
+// over the global fallback, even when it opts the Space OUT (disabled).
+func TestPerSpace_EffectiveConfig_RowOverridesGlobal(t *testing.T) {
+	ctx := swTestServer(t)
+	settings := common.EnsureSystemSettings(ctx)
+	activeFrom := time.Now().UTC().Add(-time.Hour)
+	swInsertSpace(t, ctx, "spc_1", 1)
+	// Global fallback names spc_1 and is enabled.
+	swSetConfig(t, ctx, settings, swEnabledConfig("spc_1", activeFrom))
+	svc := swNewService(ctx, settings)
+
+	// No per-Space row yet -> effective is the global config.
+	eff, err := svc.effectiveConfig(bg(), "spc_1")
+	require.NoError(t, err)
+	assert.True(t, eff.Enabled)
+
+	// A disabled per-Space row overrides the global -> effective is off.
+	swSetSpaceConfig(t, ctx, "spc_1", false, activeFrom, "")
+	eff, err = svc.effectiveConfig(bg(), "spc_1")
+	require.NoError(t, err)
+	assert.False(t, eff.Enabled, "present (disabled) row must override the enabled global fallback")
+
+	// An enabled per-Space row supplies its OWN message.
+	swSetSpaceConfig(t, ctx, "spc_1", true, activeFrom, "space-local hi")
+	eff, err = svc.effectiveConfig(bg(), "spc_1")
+	require.NoError(t, err)
+	assert.True(t, eff.Enabled)
+	assert.Equal(t, "space-local hi", eff.Message)
+}
+
+// TestPerSpace_EnabledEffectiveConfigs: the enabled set = enabled per-Space rows
+// plus the global-fallback Space iff it has no per-Space row overriding it.
+func TestPerSpace_EnabledEffectiveConfigs(t *testing.T) {
+	ctx := swTestServer(t)
+	settings := common.EnsureSystemSettings(ctx)
+	activeFrom := time.Now().UTC().Add(-time.Hour)
+	swInsertSpace(t, ctx, "spc_global", 1)
+	swInsertSpace(t, ctx, "spc_a", 1)
+	// Global names spc_global.
+	swSetConfig(t, ctx, settings, swEnabledConfig("spc_global", activeFrom))
+	// Per-Space enabled row for spc_a.
+	swSetSpaceConfig(t, ctx, "spc_a", true, activeFrom, "a hi")
+
+	svc := swNewService(ctx, settings)
+	configs, err := svc.enabledEffectiveConfigs(bg())
+	require.NoError(t, err)
+	set := map[string]bool{}
+	for _, c := range configs {
+		set[c.SpaceID] = true
+	}
+	assert.True(t, set["spc_a"], "enabled per-space row included")
+	assert.True(t, set["spc_global"], "global fallback included (no overriding row)")
+
+	// Add a disabled per-Space row for spc_global -> global fallback suppressed.
+	swSetSpaceConfig(t, ctx, "spc_global", false, activeFrom, "")
+	configs, err = svc.enabledEffectiveConfigs(bg())
+	require.NoError(t, err)
+	set = map[string]bool{}
+	for _, c := range configs {
+		set[c.SpaceID] = true
+	}
+	assert.True(t, set["spc_a"])
+	assert.False(t, set["spc_global"], "a present (disabled) row overrides the global fallback")
+}
+
+// TestPerSpace_MultiSpaceDelivery: two Spaces each with their own enabled
+// per-Space config independently welcome their first-join human members; the
+// reconciler enqueues both and one worker wake dispatches both, with each
+// recipient receiving its own Space's message and no cross-Space delivery.
+func TestPerSpace_MultiSpaceDelivery(t *testing.T) {
+	ctx := swTestServer(t)
+	settings := common.EnsureSystemSettings(ctx)
+	activeFrom := time.Now().UTC().Add(-time.Hour)
+
+	swInsertSpace(t, ctx, "spc_a", 1)
+	swInsertSpace(t, ctx, "spc_b", 1)
+	swInsertUser(t, ctx, "ua", 0)
+	swInsertUser(t, ctx, "ub", 0)
+	swInsertMember(t, ctx, "spc_a", "ua", 1, time.Now().UTC())
+	swInsertMember(t, ctx, "spc_b", "ub", 1, time.Now().UTC())
+
+	swSetSpaceConfig(t, ctx, "spc_a", true, activeFrom, "welcome A")
+	swSetSpaceConfig(t, ctx, "spc_b", true, activeFrom, "welcome B")
+
+	svc := swNewService(ctx, settings)
+	got := map[string]string{} // recipient uid -> message body seen on the wire
+	svc.sendFn = func(_ context.Context, req *config.MsgSendReq) (*swSendResult, error) {
+		// Personal DM: ChannelID is the recipient uid (NewPersonalMsgSendReq's
+		// first arg = row.UID).
+		got[req.ChannelID] = string(req.Payload)
+		return &swSendResult{messageID: 1, clientMsgNo: "x"}, nil
+	}
+
+	// Reconciler catches up both Spaces; worker drains both.
+	svc.runReconcileOnce(bg())
+	svc.runWorkerWake(bg())
+
+	sentA, _ := svc.store.countByStatus(bg(), "spc_a", swStatusSent)
+	sentB, _ := svc.store.countByStatus(bg(), "spc_b", swStatusSent)
+	assert.EqualValues(t, 1, sentA, "spc_a member welcomed exactly once")
+	assert.EqualValues(t, 1, sentB, "spc_b member welcomed exactly once")
+	assert.Contains(t, got["ua"], "welcome A", "spc_a recipient gets spc_a's body")
+	assert.Contains(t, got["ub"], "welcome B", "spc_b recipient gets spc_b's body")
+	assert.NotContains(t, got["ua"], "welcome B", "no cross-space body leakage")
+}
+
+// TestPerSpace_HandleMemberJoin_ScopedToConfiguredSpace: the event path enqueues
+// only for a Space whose effective config is enabled.
+func TestPerSpace_HandleMemberJoin_ScopedToConfiguredSpace(t *testing.T) {
+	ctx := swTestServer(t)
+	settings := common.EnsureSystemSettings(ctx)
+	activeFrom := time.Now().UTC().Add(-time.Hour)
+	swInsertSpace(t, ctx, "spc_a", 1)
+	swInsertSpace(t, ctx, "spc_b", 1)
+	swInsertUser(t, ctx, "ua", 0)
+	swInsertUser(t, ctx, "ub", 0)
+	swInsertMember(t, ctx, "spc_a", "ua", 1, time.Now().UTC())
+	swInsertMember(t, ctx, "spc_b", "ub", 1, time.Now().UTC())
+
+	// Only spc_a has an enabled config.
+	swSetSpaceConfig(t, ctx, "spc_a", true, activeFrom, "hi A")
+
+	svc := swNewService(ctx, settings)
+	svc.handleMemberJoin("spc_a", "ua") // enqueued
+	svc.handleMemberJoin("spc_b", "ub") // no config -> ignored
+
+	assert.Equal(t, 1, swCountRows(t, ctx, "spc_a"))
+	assert.Equal(t, 0, swCountRows(t, ctx, "spc_b"), "a Space with no enabled config enqueues nothing")
+}
+
+// TestPerSpace_SweepAll_CrossSpace: lease-expired claimed rows in different
+// Spaces are all reclaimed by one cross-space sweep, even for a Space whose
+// config is absent/disabled (stale in-flight rows must not be stranded).
+func TestPerSpace_SweepAll_CrossSpace(t *testing.T) {
+	ctx := swTestServer(t)
+	settings := common.EnsureSystemSettings(ctx)
+	swInsertSpace(t, ctx, "spc_a", 1)
+	swInsertSpace(t, ctx, "spc_b", 1)
+	svc := swNewService(ctx, settings)
+
+	expired := time.Now().UTC().Add(-time.Minute)
+	idA := swInsertLedger(t, ctx, "spc_a", "ua", swStatusClaimed, "dead-owner", &expired, 0)
+	idB := swInsertLedger(t, ctx, "spc_b", "ub", swStatusClaimed, "dead-owner", &expired, 0)
+
+	svc.sweepAll(bg())
+
+	stA, _, _, _, _ := swRowStatus(t, ctx, idA)
+	stB, _, _, _, _ := swRowStatus(t, ctx, idB)
+	assert.Equal(t, swStatusPending, stA, "lease-expired claimed row in spc_a reclaimed")
+	assert.Equal(t, swStatusPending, stB, "lease-expired claimed row in spc_b reclaimed")
+}

--- a/modules/notify/sql/20260720000001_add_welcome_delivery_sweep_index.sql
+++ b/modules/notify/sql/20260720000001_add_welcome_delivery_sweep_index.sql
@@ -1,0 +1,13 @@
+-- +migrate Up
+
+-- Cross-space sweep support (task space-welcome-per-space-admin-crud).
+-- The per-space idx_claim (space_id, status, next_retry_at) leads with space_id,
+-- so a space-less sweep of lease-expired claimed/dispatching rows across ALL
+-- Spaces would degrade to a full scan on a monotonically-growing ledger. This
+-- (status, claim_expire_at) index keeps the multi-space worker's sweep
+-- index-backed: WHERE status=<claimed|dispatching> AND claim_expire_at<=?.
+ALTER TABLE `octo_space_welcome_delivery`
+  ADD INDEX `idx_sweep` (`status`, `claim_expire_at`);
+
+-- +migrate Down
+ALTER TABLE `octo_space_welcome_delivery` DROP INDEX `idx_sweep`;

--- a/modules/space/api.go
+++ b/modules/space/api.go
@@ -36,15 +36,22 @@ type Space struct {
 	log.Log
 	db  *DB
 	mdb *managerDB // 用户侧需要复用管理端按 space_id 作用域的邀请码写操作时使用
+	// settings / welcomeStore back the per-Space onboarding welcome CRUD
+	// (task space-welcome-per-space-admin-crud). settings supplies the platform
+	// global fallback; welcomeStore is the per-Space config source of truth.
+	settings     *commonmod.SystemSettings
+	welcomeStore *commonmod.SpaceWelcomeConfigStore
 }
 
 // New 创建Space实例
 func New(ctx *config.Context) *Space {
 	return &Space{
-		ctx: ctx,
-		Log: log.NewTLog("Space"),
-		db:  NewDB(ctx),
-		mdb: newManagerDB(ctx.DB()),
+		ctx:          ctx,
+		Log:          log.NewTLog("Space"),
+		db:           NewDB(ctx),
+		mdb:          newManagerDB(ctx.DB()),
+		settings:     commonmod.EnsureSystemSettings(ctx),
+		welcomeStore: commonmod.NewSpaceWelcomeConfigStore(ctx.DB()),
 	}
 }
 
@@ -100,6 +107,13 @@ func (s *Space) Route(r *wkhttp.WKHttp) {
 	search := r.Group("/v1/space", s.ctx.AuthMiddleware(r), appwkhttp.SharedUIDRateLimiter(r, s.ctx))
 	{
 		search.GET("/:space_id/members/search", s.searchMembers)
+
+		// Per-Space onboarding welcome config CRUD (space admin, Role>=1). Shares
+		// the authenticated + UID-rate-limited group; per-Space authorization is
+		// enforced in each handler via requireSpaceAdmin.
+		search.GET("/:space_id/welcome", s.getWelcome)
+		search.PUT("/:space_id/welcome", s.putWelcome)
+		search.DELETE("/:space_id/welcome", s.deleteWelcome)
 	}
 
 	// 邀请码预览端点（公开无认证）严格 per-IP 限流：防枚举 + 暴破（issue #1000）。

--- a/modules/space/api_i18n_test.go
+++ b/modules/space/api_i18n_test.go
@@ -27,6 +27,7 @@ func TestSpaceNoLegacyResponseError(t *testing.T) {
 	files := []string{
 		"api.go",
 		"api_member_search.go",
+		"api_welcome.go",
 		"api_manager.go",
 		"api_email_invite.go",
 		"api_email_invite_public.go",

--- a/modules/space/api_welcome.go
+++ b/modules/space/api_welcome.go
@@ -2,6 +2,7 @@ package space
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"time"
 	"unicode/utf8"
@@ -13,6 +14,11 @@ import (
 	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
 	"go.uber.org/zap"
 )
+
+// errWelcomeValidation is the sentinel a putWelcome merge closure returns after
+// it has already written a localized validation response; UpsertMerged rolls the
+// transaction back and putWelcome then just returns without a second response.
+var errWelcomeValidation = errors.New("space welcome validation failed")
 
 // Per-Space onboarding welcome config CRUD (task
 // space-welcome-per-space-admin-crud). A Space admin (Role>=1) manages ONE
@@ -118,69 +124,74 @@ func (s *Space) putWelcome(c *wkhttp.Context) {
 	ctx, cancel := context.WithTimeout(context.Background(), welcomeConfigDBTimeout)
 	defer cancel()
 
-	// Start from the existing row (or defaults) and overlay the provided fields.
-	row, found, err := s.welcomeStore.Get(ctx, spaceId)
+	// Read-merge-write under a row lock so two admins PUTting the same Space
+	// concurrently can't lose each other's fields: the second PUT blocks on the
+	// lock and merges onto the first's committed write. Validation runs inside the
+	// merge (against the locked current row) and, on failure, writes the localized
+	// response and returns errWelcomeValidation so the tx aborts and no row is
+	// written.
+	persisted, err := s.welcomeStore.UpsertMerged(ctx, spaceId, time.Now().UTC(),
+		func(cur *commonmod.SpaceWelcomeSpaceConfig, found bool) (commonmod.SpaceWelcomeSpaceConfig, error) {
+			// Start from the existing row (or defaults) and overlay the provided fields.
+			prospective := commonmod.SpaceWelcomeSpaceConfig{SpaceID: spaceId}
+			if found {
+				prospective = *cur
+			}
+			prospective.SpaceID = spaceId
+			if req.Enabled != nil {
+				prospective.Enabled = *req.Enabled
+			}
+			if req.ActiveFrom != nil {
+				prospective.ActiveFromRaw = strings.TrimSpace(*req.ActiveFrom)
+			}
+			if req.Message != nil {
+				// Preserve internal newlines verbatim (plain text, no markdown); only
+				// the composite validator trims for the non-empty check.
+				prospective.Message = *req.Message
+			}
+
+			// Column guards: bound message and active_from to their VARCHAR widths
+			// regardless of enabled, so an oversized value is rejected with a clean
+			// 400 instead of a driver/store failure (strict sql_mode) or a silent
+			// truncation (permissive), even for a disabled config that skips parsing.
+			if utf8.RuneCountInString(prospective.Message) > commonmod.SpaceWelcomeMessageMaxRunes {
+				respondSpaceFieldTooLong(c, "message", commonmod.SpaceWelcomeMessageMaxRunes)
+				return commonmod.SpaceWelcomeSpaceConfig{}, errWelcomeValidation
+			}
+			if utf8.RuneCountInString(prospective.ActiveFromRaw) > commonmod.SpaceWelcomeActiveFromMaxLen {
+				respondSpaceFieldTooLong(c, "active_from", commonmod.SpaceWelcomeActiveFromMaxLen)
+				return commonmod.SpaceWelcomeSpaceConfig{}, errWelcomeValidation
+			}
+
+			// Composite validation via the shared validator. nil isActiveSpace: the
+			// target Space is the path Space, already confirmed active by
+			// requireSpaceAdmin, so no second existence check is needed.
+			combo := commonmod.SpaceWelcomeConfig{
+				Enabled:       prospective.Enabled,
+				SpaceID:       spaceId,
+				ActiveFromRaw: prospective.ActiveFromRaw,
+				Message:       prospective.Message,
+			}
+			if field, _ := commonmod.ValidateSpaceWelcomeCombination(combo, nil); field != "" {
+				httperr.ResponseErrorL(c, errcode.ErrSpaceWelcomeConfigInvalid, nil, i18n.Details{"field": welcomeClientField(field)})
+				return commonmod.SpaceWelcomeSpaceConfig{}, errWelcomeValidation
+			}
+
+			prospective.UpdatedBy = loginUID
+			return prospective, nil
+		})
 	if err != nil {
-		s.Error("查询空间欢迎语配置失败", zap.Error(err), zap.String("space_id", spaceId))
-		httperr.ResponseErrorL(c, errcode.ErrSpaceQueryFailed, nil, nil)
-		return
-	}
-	prospective := commonmod.SpaceWelcomeSpaceConfig{SpaceID: spaceId}
-	if found {
-		prospective = *row
-	}
-	prospective.SpaceID = spaceId
-	if req.Enabled != nil {
-		prospective.Enabled = *req.Enabled
-	}
-	if req.ActiveFrom != nil {
-		prospective.ActiveFromRaw = strings.TrimSpace(*req.ActiveFrom)
-	}
-	if req.Message != nil {
-		// Preserve internal newlines verbatim (plain text, no markdown); only the
-		// composite validator trims for the non-empty check.
-		prospective.Message = *req.Message
-	}
-
-	// Column guard: bound the message length regardless of enabled so an
-	// oversized body is rejected even for a disabled config (protects the
-	// VARCHAR(2000) column and avoids silent truncation).
-	if utf8.RuneCountInString(prospective.Message) > commonmod.SpaceWelcomeMessageMaxRunes {
-		respondSpaceFieldTooLong(c, "message", commonmod.SpaceWelcomeMessageMaxRunes)
-		return
-	}
-
-	// Composite validation via the shared validator. nil isActiveSpace: the
-	// target Space is the path Space, already confirmed active by
-	// requireSpaceAdmin, so no second existence check is needed.
-	eff := commonmod.SpaceWelcomeConfig{
-		Enabled:       prospective.Enabled,
-		SpaceID:       spaceId,
-		ActiveFromRaw: prospective.ActiveFromRaw,
-		Message:       prospective.Message,
-	}
-	if field, _ := commonmod.ValidateSpaceWelcomeCombination(eff, nil); field != "" {
-		httperr.ResponseErrorL(c, errcode.ErrSpaceWelcomeConfigInvalid, nil, i18n.Details{"field": welcomeClientField(field)})
-		return
-	}
-
-	prospective.UpdatedBy = loginUID
-	if err := s.welcomeStore.Upsert(ctx, prospective, time.Now().UTC()); err != nil {
+		if errors.Is(err, errWelcomeValidation) {
+			return // the merge already wrote the localized validation response
+		}
 		s.Error("写入空间欢迎语配置失败", zap.Error(err), zap.String("space_id", spaceId))
 		httperr.ResponseErrorL(c, errcode.ErrSpaceStoreFailed, nil, nil)
 		return
 	}
-	s.Info("空间欢迎语配置已更新", zap.String("operator_uid", loginUID), zap.String("space_id", spaceId), zap.Bool("enabled", prospective.Enabled))
+	s.Info("空间欢迎语配置已更新", zap.String("operator_uid", loginUID), zap.String("space_id", spaceId), zap.Bool("enabled", persisted.Enabled))
 
-	// Re-read so the response carries the persisted updated_at / effective view.
-	row, found, err = s.welcomeStore.Get(ctx, spaceId)
-	if err != nil {
-		s.Error("回读空间欢迎语配置失败", zap.Error(err), zap.String("space_id", spaceId))
-		httperr.ResponseErrorL(c, errcode.ErrSpaceQueryFailed, nil, nil)
-		return
-	}
-	eff2 := commonmod.ResolveEffectiveSpaceWelcome(row, found, s.settings.SpaceWelcomeConfig(), spaceId)
-	c.Response(buildWelcomeResp(row, found, eff2))
+	eff := commonmod.ResolveEffectiveSpaceWelcome(persisted, true, s.settings.SpaceWelcomeConfig(), spaceId)
+	c.Response(buildWelcomeResp(persisted, true, eff))
 }
 
 // deleteWelcome hard-deletes the per-Space config; the Space then reverts to the
@@ -215,7 +226,10 @@ func buildWelcomeResp(row *commonmod.SpaceWelcomeSpaceConfig, found bool, eff co
 		resp.Message = row.Message
 		resp.UpdatedBy = row.UpdatedBy
 		if !row.UpdatedAt.IsZero() {
-			resp.UpdatedAt = row.UpdatedAt.String()
+			// Stable, client-parseable RFC3339 (UTC) rather than Go's
+			// time.Time.String() representation. updated_at is a second-precision
+			// DATETIME, so RFC3339 is exact.
+			resp.UpdatedAt = row.UpdatedAt.UTC().Format(time.RFC3339)
 		}
 	}
 	resp.Effective = welcomeEffectiveResp{

--- a/modules/space/api_welcome.go
+++ b/modules/space/api_welcome.go
@@ -1,0 +1,255 @@
+package space
+
+import (
+	"context"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	commonmod "github.com/Mininglamp-OSS/octo-server/modules/common"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
+	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
+	"go.uber.org/zap"
+)
+
+// Per-Space onboarding welcome config CRUD (task
+// space-welcome-per-space-admin-crud). A Space admin (Role>=1) manages ONE
+// welcome config for their own Space:
+//
+//	GET    /v1/space/:space_id/welcome  — read the per-Space config + what is in effect
+//	PUT    /v1/space/:space_id/welcome  — create/update (增/改), prospective-validated
+//	DELETE /v1/space/:space_id/welcome  — hard-delete (删); reverts to global fallback
+//
+// Authorization mirrors searchMembers: the caller must be an active member of
+// the path Space with Role>=admin, and the Space must be active. A request can
+// only ever affect the path :space_id (space isolation). All errors go through
+// the httperr i18n envelope. The routes carry SharedUIDRateLimiter (see Route).
+
+// welcomeConfigDBTimeout bounds each config DB call on the CRUD path.
+const welcomeConfigDBTimeout = 3 * time.Second
+
+// putWelcomeReq is the PUT body. Pointer fields distinguish "omitted" (keep the
+// current value) from an explicit value, so a partial update is a valid patch
+// merged onto the existing row (prospective validation).
+type putWelcomeReq struct {
+	Enabled    *bool   `json:"enabled"`
+	ActiveFrom *string `json:"active_from"` // RFC3339 UTC
+	Message    *string `json:"message"`
+}
+
+// welcomeEffectiveResp describes the config actually in effect for the Space,
+// after resolving per-Space over global fallback.
+type welcomeEffectiveResp struct {
+	Enabled bool   `json:"enabled"`
+	Source  string `json:"source"` // space | global | none
+	Message string `json:"message"`
+}
+
+// welcomeConfigResp is the GET/PUT response.
+type welcomeConfigResp struct {
+	Configured bool                 `json:"configured"` // a per-Space row exists
+	Enabled    bool                 `json:"enabled"`
+	ActiveFrom string               `json:"active_from"`
+	Message    string               `json:"message"`
+	UpdatedBy  string               `json:"updated_by,omitempty"`
+	UpdatedAt  string               `json:"updated_at,omitempty"`
+	Effective  welcomeEffectiveResp `json:"effective"`
+}
+
+// authorizeSpaceAdmin gates a per-Space welcome request: the Space must be
+// active and the caller must be an admin/owner (Role>=1). It reuses the module's
+// checkSpaceActive + requireSpaceAdmin helpers (both write the localized
+// response and report "handled" on failure). A request can only ever affect the
+// path :space_id, so space isolation is enforced by construction. Returns the
+// caller uid and ok=false when a response was already written.
+func (s *Space) authorizeSpaceAdmin(c *wkhttp.Context, spaceId string) (loginUID string, ok bool) {
+	loginUID = c.GetLoginUID()
+	if s.checkSpaceActive(c, spaceId) {
+		return "", false
+	}
+	if s.requireSpaceAdmin(c, spaceId, loginUID) {
+		return "", false
+	}
+	return loginUID, true
+}
+
+// getWelcome returns the per-Space config (if any) plus the effective config so
+// the admin UI can show whether a global fallback is in play.
+func (s *Space) getWelcome(c *wkhttp.Context) {
+	spaceId := c.Param("space_id")
+	if _, ok := s.authorizeSpaceAdmin(c, spaceId); !ok {
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), welcomeConfigDBTimeout)
+	defer cancel()
+	row, found, err := s.welcomeStore.Get(ctx, spaceId)
+	if err != nil {
+		s.Error("查询空间欢迎语配置失败", zap.Error(err), zap.String("space_id", spaceId))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceQueryFailed, nil, nil)
+		return
+	}
+	eff := commonmod.ResolveEffectiveSpaceWelcome(row, found, s.settings.SpaceWelcomeConfig(), spaceId)
+	c.Response(buildWelcomeResp(row, found, eff))
+}
+
+// putWelcome upserts the per-Space config. Partial updates merge onto the
+// existing row (prospective validation): the patch is accepted iff the merged
+// combination is valid. The target Space is the path Space (already active).
+func (s *Space) putWelcome(c *wkhttp.Context) {
+	spaceId := c.Param("space_id")
+	loginUID, ok := s.authorizeSpaceAdmin(c, spaceId)
+	if !ok {
+		return
+	}
+
+	var req putWelcomeReq
+	if err := c.BindJSON(&req); err != nil {
+		respondSpaceRequestInvalid(c, "")
+		return
+	}
+	if req.Enabled == nil && req.ActiveFrom == nil && req.Message == nil {
+		respondSpaceRequestInvalid(c, "")
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), welcomeConfigDBTimeout)
+	defer cancel()
+
+	// Start from the existing row (or defaults) and overlay the provided fields.
+	row, found, err := s.welcomeStore.Get(ctx, spaceId)
+	if err != nil {
+		s.Error("查询空间欢迎语配置失败", zap.Error(err), zap.String("space_id", spaceId))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceQueryFailed, nil, nil)
+		return
+	}
+	prospective := commonmod.SpaceWelcomeSpaceConfig{SpaceID: spaceId}
+	if found {
+		prospective = *row
+	}
+	prospective.SpaceID = spaceId
+	if req.Enabled != nil {
+		prospective.Enabled = *req.Enabled
+	}
+	if req.ActiveFrom != nil {
+		prospective.ActiveFromRaw = strings.TrimSpace(*req.ActiveFrom)
+	}
+	if req.Message != nil {
+		// Preserve internal newlines verbatim (plain text, no markdown); only the
+		// composite validator trims for the non-empty check.
+		prospective.Message = *req.Message
+	}
+
+	// Column guard: bound the message length regardless of enabled so an
+	// oversized body is rejected even for a disabled config (protects the
+	// VARCHAR(2000) column and avoids silent truncation).
+	if utf8.RuneCountInString(prospective.Message) > commonmod.SpaceWelcomeMessageMaxRunes {
+		respondSpaceFieldTooLong(c, "message", commonmod.SpaceWelcomeMessageMaxRunes)
+		return
+	}
+
+	// Composite validation via the shared validator. nil isActiveSpace: the
+	// target Space is the path Space, already confirmed active by
+	// requireSpaceAdmin, so no second existence check is needed.
+	eff := commonmod.SpaceWelcomeConfig{
+		Enabled:       prospective.Enabled,
+		SpaceID:       spaceId,
+		ActiveFromRaw: prospective.ActiveFromRaw,
+		Message:       prospective.Message,
+	}
+	if field, _ := commonmod.ValidateSpaceWelcomeCombination(eff, nil); field != "" {
+		httperr.ResponseErrorL(c, errcode.ErrSpaceWelcomeConfigInvalid, nil, i18n.Details{"field": welcomeClientField(field)})
+		return
+	}
+
+	prospective.UpdatedBy = loginUID
+	if err := s.welcomeStore.Upsert(ctx, prospective, time.Now().UTC()); err != nil {
+		s.Error("写入空间欢迎语配置失败", zap.Error(err), zap.String("space_id", spaceId))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceStoreFailed, nil, nil)
+		return
+	}
+	s.Info("空间欢迎语配置已更新", zap.String("operator_uid", loginUID), zap.String("space_id", spaceId), zap.Bool("enabled", prospective.Enabled))
+
+	// Re-read so the response carries the persisted updated_at / effective view.
+	row, found, err = s.welcomeStore.Get(ctx, spaceId)
+	if err != nil {
+		s.Error("回读空间欢迎语配置失败", zap.Error(err), zap.String("space_id", spaceId))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceQueryFailed, nil, nil)
+		return
+	}
+	eff2 := commonmod.ResolveEffectiveSpaceWelcome(row, found, s.settings.SpaceWelcomeConfig(), spaceId)
+	c.Response(buildWelcomeResp(row, found, eff2))
+}
+
+// deleteWelcome hard-deletes the per-Space config; the Space then reverts to the
+// platform-global fallback (if it names this Space) or off. Idempotent: deleting
+// an absent config returns deleted=false with 200.
+func (s *Space) deleteWelcome(c *wkhttp.Context) {
+	spaceId := c.Param("space_id")
+	loginUID, ok := s.authorizeSpaceAdmin(c, spaceId)
+	if !ok {
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), welcomeConfigDBTimeout)
+	defer cancel()
+	deleted, err := s.welcomeStore.Delete(ctx, spaceId)
+	if err != nil {
+		s.Error("删除空间欢迎语配置失败", zap.Error(err), zap.String("space_id", spaceId))
+		httperr.ResponseErrorL(c, errcode.ErrSpaceStoreFailed, nil, nil)
+		return
+	}
+	s.Info("空间欢迎语配置已删除", zap.String("operator_uid", loginUID), zap.String("space_id", spaceId), zap.Bool("deleted", deleted))
+	c.Response(map[string]interface{}{"deleted": deleted})
+}
+
+// buildWelcomeResp assembles the response from the per-Space row (if present)
+// and the resolved effective config.
+func buildWelcomeResp(row *commonmod.SpaceWelcomeSpaceConfig, found bool, eff commonmod.SpaceWelcomeConfig) welcomeConfigResp {
+	resp := welcomeConfigResp{Configured: found}
+	if found {
+		resp.Enabled = row.Enabled
+		resp.ActiveFrom = row.ActiveFromRaw
+		resp.Message = row.Message
+		resp.UpdatedBy = row.UpdatedBy
+		if !row.UpdatedAt.IsZero() {
+			resp.UpdatedAt = row.UpdatedAt.String()
+		}
+	}
+	resp.Effective = welcomeEffectiveResp{
+		Enabled: eff.Enabled,
+		Message: eff.Message,
+		Source:  welcomeSource(found, eff),
+	}
+	return resp
+}
+
+// welcomeSource names where the effective config comes from: a present per-Space
+// row is always authoritative ("space"); otherwise an active global fallback is
+// "global"; otherwise "none".
+func welcomeSource(found bool, eff commonmod.SpaceWelcomeConfig) string {
+	if found {
+		return "space"
+	}
+	if eff.Enabled {
+		return "global"
+	}
+	return "none"
+}
+
+// welcomeClientField maps the shared validator's offending key
+// (space_welcome_*) to the client-facing PUT field name.
+func welcomeClientField(field string) string {
+	switch field {
+	case "space_welcome_active_from":
+		return "active_from"
+	case "space_welcome_message":
+		return "message"
+	case "space_welcome_space_id":
+		return "space_id"
+	default:
+		return field
+	}
+}

--- a/modules/space/api_welcome.go
+++ b/modules/space/api_welcome.go
@@ -48,9 +48,10 @@ type putWelcomeReq struct {
 // welcomeEffectiveResp describes the config actually in effect for the Space,
 // after resolving per-Space over global fallback.
 type welcomeEffectiveResp struct {
-	Enabled bool   `json:"enabled"`
-	Source  string `json:"source"` // space | global | none
-	Message string `json:"message"`
+	Enabled    bool   `json:"enabled"`
+	Source     string `json:"source"`      // space | global | none
+	ActiveFrom string `json:"active_from"` // effective RFC3339 window start ("" when off/unset)
+	Message    string `json:"message"`
 }
 
 // welcomeConfigResp is the GET/PUT response.
@@ -233,9 +234,10 @@ func buildWelcomeResp(row *commonmod.SpaceWelcomeSpaceConfig, found bool, eff co
 		}
 	}
 	resp.Effective = welcomeEffectiveResp{
-		Enabled: eff.Enabled,
-		Message: eff.Message,
-		Source:  welcomeSource(found, eff),
+		Enabled:    eff.Enabled,
+		Message:    eff.Message,
+		Source:     welcomeSource(found, eff),
+		ActiveFrom: eff.ActiveFromRaw,
 	}
 	return resp
 }

--- a/modules/space/api_welcome_test.go
+++ b/modules/space/api_welcome_test.go
@@ -1,0 +1,203 @@
+package space
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Per-Space welcome config CRUD HTTP tests
+// (task space-welcome-per-space-admin-crud). Auth is fixed to testutil.UID via
+// testutil.Token; the authz matrix is exercised by varying that user's
+// membership/role and the Space status.
+
+func doWelcome(t *testing.T, method, spaceId, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	resetSpaceUIDRateLimit(t, testCtx)
+	var r *strings.Reader
+	if body != "" {
+		r = strings.NewReader(body)
+	} else {
+		r = strings.NewReader("")
+	}
+	req, _ := http.NewRequest(method, "/v1/space/"+spaceId+"/welcome", r)
+	req.Header.Set("token", testutil.Token)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	testSrv.GetRoute().ServeHTTP(w, req)
+	return w
+}
+
+type welcomeRespForTest struct {
+	Configured bool   `json:"configured"`
+	Enabled    bool   `json:"enabled"`
+	ActiveFrom string `json:"active_from"`
+	Message    string `json:"message"`
+	UpdatedBy  string `json:"updated_by"`
+	Effective  struct {
+		Enabled bool   `json:"enabled"`
+		Source  string `json:"source"`
+		Message string `json:"message"`
+	} `json:"effective"`
+}
+
+func decodeWelcomeResp(t *testing.T, w *httptest.ResponseRecorder) welcomeRespForTest {
+	t.Helper()
+	var resp welcomeRespForTest
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp), w.Body.String())
+	return resp
+}
+
+// seedWelcomeSpace creates an active Space with testutil.UID at the given role.
+func seedWelcomeSpace(t *testing.T, spaceId string, role int) {
+	t.Helper()
+	require.NoError(t, testSpaceDB.insertSpaceNoTx(&SpaceModel{
+		SpaceId: spaceId, Name: spaceId, Creator: testutil.UID, Status: SpaceStatusNormal,
+	}))
+	require.NoError(t, testSpaceDB.insertMemberNoTx(&MemberModel{
+		SpaceId: spaceId, UID: testutil.UID, Role: role, Status: 1,
+	}))
+}
+
+func TestWelcomeCRUD_AuthzMatrix(t *testing.T) {
+	t.Run("admin can read", func(t *testing.T) {
+		setup(t)
+		seedWelcomeSpace(t, "spc_admin", 1) // Role=admin
+		w := doWelcome(t, http.MethodGet, "spc_admin", "")
+		require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+		resp := decodeWelcomeResp(t, w)
+		assert.False(t, resp.Configured, "no per-space row yet")
+		assert.Equal(t, "none", resp.Effective.Source)
+	})
+
+	t.Run("plain member is denied", func(t *testing.T) {
+		setup(t)
+		seedWelcomeSpace(t, "spc_member", 0) // Role=member
+		w := doWelcome(t, http.MethodGet, "spc_member", "")
+		assertSpaceErrorCode(t, w, "err.server.space.permission_denied")
+	})
+
+	t.Run("non-member is denied", func(t *testing.T) {
+		setup(t)
+		// Space exists but testutil.UID is NOT a member.
+		require.NoError(t, testSpaceDB.insertSpaceNoTx(&SpaceModel{
+			SpaceId: "spc_nomember", Name: "spc_nomember", Creator: "someone_else", Status: SpaceStatusNormal,
+		}))
+		w := doWelcome(t, http.MethodGet, "spc_nomember", "")
+		assertSpaceErrorCode(t, w, "err.server.space.permission_denied")
+	})
+
+	t.Run("inactive space is rejected", func(t *testing.T) {
+		setup(t)
+		require.NoError(t, testSpaceDB.insertSpaceNoTx(&SpaceModel{
+			SpaceId: "spc_dead", Name: "spc_dead", Creator: testutil.UID, Status: 2, // banned
+		}))
+		require.NoError(t, testSpaceDB.insertMemberNoTx(&MemberModel{
+			SpaceId: "spc_dead", UID: testutil.UID, Role: 2, Status: 1,
+		}))
+		w := doWelcome(t, http.MethodGet, "spc_dead", "")
+		assertSpaceErrorCode(t, w, "err.server.space.not_found")
+	})
+}
+
+func TestWelcomePut_CreateThenGet(t *testing.T) {
+	setup(t)
+	seedWelcomeSpace(t, "spc_1", 2) // owner
+
+	body := `{"enabled":true,"active_from":"2026-07-10T00:00:00Z","message":"欢迎\n多行"}`
+	w := doWelcome(t, http.MethodPut, "spc_1", body)
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	resp := decodeWelcomeResp(t, w)
+	assert.True(t, resp.Configured)
+	assert.True(t, resp.Enabled)
+	assert.Equal(t, "欢迎\n多行", resp.Message, "newline preserved verbatim")
+	assert.Equal(t, testutil.UID, resp.UpdatedBy)
+	assert.Equal(t, "space", resp.Effective.Source)
+
+	// GET reflects the stored config.
+	g := decodeWelcomeResp(t, doWelcome(t, http.MethodGet, "spc_1", ""))
+	assert.True(t, g.Configured)
+	assert.True(t, g.Enabled)
+	assert.Equal(t, "欢迎\n多行", g.Message)
+}
+
+func TestWelcomePut_InvalidCombinationRejected(t *testing.T) {
+	setup(t)
+	seedWelcomeSpace(t, "spc_1", 1)
+
+	// enabled=true with an empty message is an invalid combination.
+	body := `{"enabled":true,"active_from":"2026-07-10T00:00:00Z","message":"   "}`
+	w := doWelcome(t, http.MethodPut, "spc_1", body)
+	assertSpaceErrorCode(t, w, "err.server.common.space_welcome_config_invalid")
+
+	// enabled=true with an unparseable active_from is also invalid.
+	body = `{"enabled":true,"active_from":"not-a-time","message":"hi"}`
+	w = doWelcome(t, http.MethodPut, "spc_1", body)
+	assertSpaceErrorCode(t, w, "err.server.common.space_welcome_config_invalid")
+}
+
+func TestWelcomePut_MessageTooLong(t *testing.T) {
+	setup(t)
+	seedWelcomeSpace(t, "spc_1", 1)
+
+	long := strings.Repeat("我", 2001) // > 2000 code points
+	body := `{"enabled":false,"message":"` + long + `"}`
+	w := doWelcome(t, http.MethodPut, "spc_1", body)
+	assertSpaceErrorCode(t, w, "err.server.space.field_too_long")
+}
+
+func TestWelcomePut_EmptyPatchRejected(t *testing.T) {
+	setup(t)
+	seedWelcomeSpace(t, "spc_1", 1)
+	w := doWelcome(t, http.MethodPut, "spc_1", `{}`)
+	assertSpaceErrorCode(t, w, "err.server.space.request_invalid")
+}
+
+func TestWelcomePut_PartialMergePreservesMessage(t *testing.T) {
+	setup(t)
+	seedWelcomeSpace(t, "spc_1", 1)
+
+	// Create enabled config with a message.
+	require.Equal(t, http.StatusOK,
+		doWelcome(t, http.MethodPut, "spc_1", `{"enabled":true,"active_from":"2026-07-10T00:00:00Z","message":"keep me"}`).Code)
+
+	// Patch only enabled=false; message must be preserved and stay valid.
+	w := doWelcome(t, http.MethodPut, "spc_1", `{"enabled":false}`)
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	resp := decodeWelcomeResp(t, w)
+	assert.False(t, resp.Enabled)
+	assert.Equal(t, "keep me", resp.Message, "partial patch keeps the existing message")
+}
+
+func TestWelcomeDelete_RevertsToUnconfigured(t *testing.T) {
+	setup(t)
+	seedWelcomeSpace(t, "spc_1", 1)
+
+	require.Equal(t, http.StatusOK,
+		doWelcome(t, http.MethodPut, "spc_1", `{"enabled":true,"active_from":"2026-07-10T00:00:00Z","message":"bye soon"}`).Code)
+
+	// Delete returns deleted=true.
+	w := doWelcome(t, http.MethodDelete, "spc_1", "")
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	var del struct {
+		Deleted bool `json:"deleted"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &del), w.Body.String())
+	assert.True(t, del.Deleted)
+
+	// GET now shows unconfigured.
+	g := decodeWelcomeResp(t, doWelcome(t, http.MethodGet, "spc_1", ""))
+	assert.False(t, g.Configured)
+
+	// Deleting again is an idempotent no-op.
+	w = doWelcome(t, http.MethodDelete, "spc_1", "")
+	require.Equal(t, http.StatusOK, w.Code)
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &del), w.Body.String())
+	assert.False(t, del.Deleted)
+}

--- a/modules/space/api_welcome_test.go
+++ b/modules/space/api_welcome_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	commonmod "github.com/Mininglamp-OSS/octo-server/modules/common"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -148,6 +149,19 @@ func TestWelcomePut_MessageTooLong(t *testing.T) {
 
 	long := strings.Repeat("我", 2001) // > 2000 code points
 	body := `{"enabled":false,"message":"` + long + `"}`
+	w := doWelcome(t, http.MethodPut, "spc_1", body)
+	assertSpaceErrorCode(t, w, "err.server.space.field_too_long")
+}
+
+func TestWelcomePut_ActiveFromTooLong(t *testing.T) {
+	setup(t)
+	seedWelcomeSpace(t, "spc_1", 1)
+
+	// Over the active_from VARCHAR(40) column width. enabled=false skips the
+	// RFC3339 parse, so the column guard (not the combination validator) must
+	// reject it with a clean field-too-long 400 rather than a store 500.
+	long := strings.Repeat("9", commonmod.SpaceWelcomeActiveFromMaxLen+10)
+	body := `{"enabled":false,"active_from":"` + long + `"}`
 	w := doWelcome(t, http.MethodPut, "spc_1", body)
 	assertSpaceErrorCode(t, w, "err.server.space.field_too_long")
 }

--- a/modules/space/api_welcome_unit_test.go
+++ b/modules/space/api_welcome_unit_test.go
@@ -65,8 +65,8 @@ func TestBuildWelcomeResp(t *testing.T) {
 		if resp.Message != "hello\nworld" {
 			t.Fatalf("Message = %q, want newline preserved verbatim", resp.Message)
 		}
-		if resp.UpdatedBy != "u_admin" || resp.UpdatedAt == "" {
-			t.Fatalf("audit fields not surfaced: %+v", resp)
+		if resp.UpdatedBy != "u_admin" || resp.UpdatedAt != "2026-07-10T01:02:03Z" {
+			t.Fatalf("audit fields not surfaced/formatted (want RFC3339 updated_at): %+v", resp)
 		}
 		if resp.Effective.Source != "space" || !resp.Effective.Enabled {
 			t.Fatalf("effective = %+v, want source=space enabled=true", resp.Effective)

--- a/modules/space/api_welcome_unit_test.go
+++ b/modules/space/api_welcome_unit_test.go
@@ -57,7 +57,7 @@ func TestBuildWelcomeResp(t *testing.T) {
 			UpdatedBy:     "u_admin",
 			UpdatedAt:     time.Date(2026, 7, 10, 1, 2, 3, 0, time.UTC),
 		}
-		eff := commonmod.SpaceWelcomeConfig{Enabled: true, SpaceID: "spc_1", Message: "hello\nworld"}
+		eff := commonmod.SpaceWelcomeConfig{Enabled: true, SpaceID: "spc_1", ActiveFromRaw: "2026-07-10T00:00:00Z", Message: "hello\nworld"}
 		resp := buildWelcomeResp(row, true, eff)
 		if !resp.Configured || !resp.Enabled {
 			t.Fatalf("Configured/Enabled = %v/%v, want true/true", resp.Configured, resp.Enabled)
@@ -70,6 +70,9 @@ func TestBuildWelcomeResp(t *testing.T) {
 		}
 		if resp.Effective.Source != "space" || !resp.Effective.Enabled {
 			t.Fatalf("effective = %+v, want source=space enabled=true", resp.Effective)
+		}
+		if resp.Effective.ActiveFrom != "2026-07-10T00:00:00Z" {
+			t.Fatalf("effective active_from = %q, want the resolved window start", resp.Effective.ActiveFrom)
 		}
 	})
 

--- a/modules/space/api_welcome_unit_test.go
+++ b/modules/space/api_welcome_unit_test.go
@@ -1,0 +1,86 @@
+package space
+
+import (
+	"testing"
+	"time"
+
+	commonmod "github.com/Mininglamp-OSS/octo-server/modules/common"
+)
+
+// TestWelcomeSource pins the source label shown to admins (task
+// space-welcome-per-space-admin-crud). Pure — no DB.
+func TestWelcomeSource(t *testing.T) {
+	cases := []struct {
+		name  string
+		found bool
+		eff   commonmod.SpaceWelcomeConfig
+		want  string
+	}{
+		{"present row is always source=space (even disabled)", true, commonmod.SpaceWelcomeConfig{Enabled: false}, "space"},
+		{"present enabled row is source=space", true, commonmod.SpaceWelcomeConfig{Enabled: true}, "space"},
+		{"no row, global in effect is source=global", false, commonmod.SpaceWelcomeConfig{Enabled: true}, "global"},
+		{"no row, nothing in effect is source=none", false, commonmod.SpaceWelcomeConfig{Enabled: false}, "none"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := welcomeSource(tc.found, tc.eff); got != tc.want {
+				t.Fatalf("welcomeSource(%v, enabled=%v) = %q, want %q", tc.found, tc.eff.Enabled, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestWelcomeClientField maps the shared validator's key to the PUT field name.
+func TestWelcomeClientField(t *testing.T) {
+	cases := map[string]string{
+		"space_welcome_active_from": "active_from",
+		"space_welcome_message":     "message",
+		"space_welcome_space_id":    "space_id",
+		"unknown_key":               "unknown_key",
+	}
+	for in, want := range cases {
+		if got := welcomeClientField(in); got != want {
+			t.Fatalf("welcomeClientField(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// TestBuildWelcomeResp checks the response assembly for both the configured and
+// fallback shapes.
+func TestBuildWelcomeResp(t *testing.T) {
+	t.Run("configured row surfaces its fields + source=space", func(t *testing.T) {
+		row := &commonmod.SpaceWelcomeSpaceConfig{
+			SpaceID:       "spc_1",
+			Enabled:       true,
+			ActiveFromRaw: "2026-07-10T00:00:00Z",
+			Message:       "hello\nworld",
+			UpdatedBy:     "u_admin",
+			UpdatedAt:     time.Date(2026, 7, 10, 1, 2, 3, 0, time.UTC),
+		}
+		eff := commonmod.SpaceWelcomeConfig{Enabled: true, SpaceID: "spc_1", Message: "hello\nworld"}
+		resp := buildWelcomeResp(row, true, eff)
+		if !resp.Configured || !resp.Enabled {
+			t.Fatalf("Configured/Enabled = %v/%v, want true/true", resp.Configured, resp.Enabled)
+		}
+		if resp.Message != "hello\nworld" {
+			t.Fatalf("Message = %q, want newline preserved verbatim", resp.Message)
+		}
+		if resp.UpdatedBy != "u_admin" || resp.UpdatedAt == "" {
+			t.Fatalf("audit fields not surfaced: %+v", resp)
+		}
+		if resp.Effective.Source != "space" || !resp.Effective.Enabled {
+			t.Fatalf("effective = %+v, want source=space enabled=true", resp.Effective)
+		}
+	})
+
+	t.Run("no row, global fallback in effect -> not configured, source=global", func(t *testing.T) {
+		eff := commonmod.SpaceWelcomeConfig{Enabled: true, SpaceID: "spc_1", Message: "global"}
+		resp := buildWelcomeResp(nil, false, eff)
+		if resp.Configured {
+			t.Fatalf("Configured = true, want false (no per-space row)")
+		}
+		if resp.Effective.Source != "global" || resp.Effective.Message != "global" {
+			t.Fatalf("effective = %+v, want source=global message=global", resp.Effective)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Make the onboarding welcome message **per-Space and self-service**. Each Space's
admins (Role ≥ 1) manage **one** welcome config for **their** Space via
`GET/PUT/DELETE /v1/space/:space_id/welcome`; the platform-global config
(`system_setting onboarding.space_welcome_*`) is kept as a **superadmin
fallback**.

Product follow-up to #604 / #606, which shipped a single **platform-designated**
welcome Space, superadmin-only. This lifts that task's out-of-scope item
("Multi-Space configuration with per-Space copy; per-Space admin self-service
API") into scope. Ships `enabled=false` per Space by default — with no per-Space
row written, behavior is identical to today.

## Related Issue

N/A (product follow-up to #604 / #606).

## Linked Spec

`.octospec/tasks/space-welcome-per-space-admin-crud/brief.md`

## Changes

- **Config storage (`modules/common`)** — new `octo_space_welcome_config` table
  (one row per Space) + stateless `SpaceWelcomeConfigStore`
  (Get/Upsert/Delete/Exists/ListEnabled). `ResolveEffectiveSpaceWelcome`
  precedence: **a present per-Space row wins outright, even when disabled**
  (opt a Space out of a global campaign); else the global config applies iff it
  is enabled and names the Space; else off. Reuses the existing
  `SpaceWelcomeConfig` shape so `ValidateSpaceWelcomeCombination` /
  `ParsedActiveFrom` apply unchanged (`active_from` stored as the RFC3339 string
  to enable that reuse).
- **CRUD API (`modules/space/api_welcome.go`)** — `GET/PUT/DELETE
  /v1/space/:space_id/welcome`. Authz reuses `checkSpaceActive` +
  `requireSpaceAdmin` (Role ≥ 1); a request can only affect the path
  `:space_id`. `PUT` is a prospective merge (patch onto the existing row,
  validate the composite). `DELETE` hard-deletes the row (reverts to the global
  fallback or off). Mounted on the auth + `SharedUIDRateLimiter` group; all
  errors via `httperr` with **existing** error codes (no new codes).
- **Delivery driver (`modules/notify`)** — single-Space → all-enabled-Spaces.
  The event path, reconciler, and worker resolve the per-Space **effective**
  config each cycle. Reconciler **and** worker rotate a per-replica cursor over
  the enabled-Space set (fairness). Cross-space sweep (`sweepClaimedAll` /
  `sweepDispatchingAll`, backed by a new `idx_sweep (status, claim_expire_at)`)
  reclaims stale in-flight rows across Spaces. Ledger state machine,
  at-most-once, `FOR UPDATE SKIP LOCKED` claim, CAS-on-`claim_owner`, and the
  fixed `notification` sender identity are **unchanged**.

## Testing

- `go build ./...`, `go vet`, `golangci-lint` (0 issues), `gofmt`,
  `make i18n-extract-check` + `make i18n-lint`, `git diff --check` — all clean.
- `go test -race` green for `modules/common`, `modules/notify`, `modules/space`
  (each on a fresh DB — cross-package migration sets differ, so the shared
  `test` DB is dropped + recreated between packages).
- New tests: config-store CRUD; effective-config precedence (both directions);
  multi-Space independent delivery + **no cross-Space body / space_id mixing**;
  worker fair-rotation (fails without the cursor fix); cross-space sweep;
  per-Space event enqueue scoping; CRUD authz matrix
  (admin/member/non-member/inactive) + prospective validation + partial-merge +
  delete.
- **Real-wire e2e** (ad-hoc, not committed) against live MySQL/Redis/WuKongIM:
  single-Space delivery (ledger SENT + real IM `message_id`) and two-Space
  concurrent delivery, reading each recipient's channel back from WuKongIM to
  confirm actual receipt and that each got ONLY their own Space's body +
  authoritative `payload.space_id`.

- [x] Unit tests added/updated
- [x] Manually verified (integration + real-wire e2e against live MySQL/Redis/WuKongIM)

## COMPREHENSION

1. **What does this change actually do to the load-bearing path?**
   It changes the welcome feature's config *source* from a single global tuple
   to per-Space (with global fallback), and generalizes the delivery driver from
   one Space to every enabled Space. The **delivery reliability core is
   untouched**: the same `octo_space_welcome_delivery` ledger (`UNIQUE(space_id,
   uid)`), the same state machine, `FOR UPDATE SKIP LOCKED` claim, CAS on
   `claim_owner`, at-most-once, and `notification` sender identity. Space
   isolation is enforced two ways: (a) CRUD authz resolves the caller's
   membership for the **path** `:space_id` and requires Role ≥ 1, and a request
   can only affect that Space; (b) the worker dispatches each claimed row using
   **that row's own** Space effective config and re-checks membership against
   that Space, so one Space's config or backlog can never deliver into another.
   Error responses touch the wire contract only through the existing i18n
   `httperr` envelope with already-registered codes (no new codes).

2. **What could break because of it (dependents + failure mode)?**
   - Dependents: the `SpaceMemberJoin` listener and the notify reconciler/worker
     now read the per-Space config table (read-through) instead of one global
     snapshot; a DB error there fails closed (logged, no enqueue/send — never
     blocks the join). The global `system_setting` write path and schema are
     untouched.
   - Multi-replica / rolling update: unchanged at-most-once machinery. Concurrent
     claim → exactly one winner (`SKIP LOCKED`); concurrent enqueue → one row
     (`ON DUPLICATE KEY`). `sweepAll` reclaims only **lease-expired**
     (`claim_expire_at<=now`) rows, so it never steals a healthy peer's live
     claim; a replica dying mid-dispatch leaves a `dispatching` row that a peer
     sweeps to `unknown` (not retried → no double-send).
   - Fairness: a naive greedy worker would starve tail Spaces under sustained
     load; fixed with a rotating cursor (see commit 741641f + regression test).
   - Feature ships `enabled=false` per Space; with no per-Space row, the global
     config still drives its one Space exactly as before.

3. **How do you know it works (specific test/repro/trace)?**
   `go test -race ./modules/{common,notify,space}/...` exercises the full state
   machine and the new paths against real MySQL: store CRUD, effective-config
   precedence both directions, `TestPerSpace_MultiSpaceDelivery` (each recipient
   gets only their Space's body), `TestPerSpace_Worker_FairRotation` (keeps the
   head Space over-cap every wake and asserts the tail Space is still served —
   fails without the cursor), `TestPerSpace_SweepAll_CrossSpace`, and the CRUD
   authz/validation matrix. Additionally a real-wire e2e drove two Spaces'
   delivery through the notify-local HTTP sender into a running WuKongIM and read
   each recipient's channel back from the IM: `ua` received exactly
   `WELCOME-ALPHA`/`space_id=spcA…`, `ub` exactly `WELCOME-BRAVO`/`space_id=spcB…`
   — actual receipt, no crossing.

## Checklist

- [x] PR description is in English
- [x] Added tests for my changes
- [x] Followed commit message conventions (Conventional Commits)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XqkVUKZD3uEYYTvvqmnWio)_