### PR TITLE
fix(message): stop leaking revoked message content on sync endpoints

### DIFF
--- a/modules/message/api.go
+++ b/modules/message/api.go
@@ -113,6 +113,27 @@ func placeholderPayload() map[string]interface{} {
 	}
 }
 
+// revokedPayload 返回撤回消息对外下发的最小 payload：仅保留原始 type，剥离 content
+// 及一切内容承载字段（url / name / reply / content.users …）。
+//
+// 背景（撤回原文泄漏）：Octo 撤回是 message_extra.revoke=1 的软删除，WuKongIM 里
+// 原始 payload 仍在。sync 路径此前把 revoke=1 与「完整原始 payload」一起下发，
+// 原文因此保留在客户端内存（message.content），恶意插件可从 React props 反查还原。
+// 单条直读 api_message_get.go 对 revoke==1 直接返回 404，本函数补上 sync 路径同口径的缺口。
+//
+// 保留 type 而不整条清空：撤回对所有人生效，前端仅凭 revoke=1 渲染撤回提示、不读
+// payload（撤回者名由 revoker UID 单独查，见 octo-web RevokeCell）；保留 type 只为
+// 兼容按 type 分支的老客户端渲染路径，type 本身不含消息正文。
+func revokedPayload(original map[string]interface{}) map[string]interface{} {
+	stripped := map[string]interface{}{}
+	if t, ok := original["type"]; ok {
+		stripped["type"] = t
+	} else {
+		stripped["type"] = common.ContentError.Int()
+	}
+	return stripped
+}
+
 // isTextType 判断 payload type 是否为 common.Text（=1）。兼容 json.Number / float64 / int
 // 几种反序列化结果；string 类型的 "1" 不识别为 Text，避免误命中。
 func isTextType(m map[string]interface{}) bool {
@@ -3315,6 +3336,23 @@ func (m *MsgSyncResp) from(msgResp *config.MessageResp, loginUID string, message
 			streams = append(streams, newStreamItemResp(streamItem))
 		}
 		m.Streams = streams
+	}
+
+	// 撤回消息内容脱敏：撤回对所有人生效，任何客户端都不该再拿到原文。剥离 payload
+	// 正文、加密 signal 密文与流式 blob，只保留 revoke=1 / revoker 供前端渲染撤回
+	// 提示。与单条直读 api_message_get.go 对 revoke==1 返回 404 同口径；这里补上
+	// /message/channel/sync 与 /conversation/sync（两者共用 from()）此前遗漏的缺口。
+	// 必须放在 Payload / SignalPayload / Streams / MessageExtra 全部赋值之后。
+	if m.Revoke == 1 {
+		m.Payload = revokedPayload(m.Payload)
+		m.SignalPayload = ""
+		m.Streams = nil
+		// message_extra.content_edit 是「编辑后的正文」，同样是原文载体：撤回后必须
+		// 一并剥离，否则编辑过的消息被撤回时仍会经 content_edit 把原文下发。
+		if m.MessageExtra != nil {
+			m.MessageExtra.ContentEdit = nil
+			m.MessageExtra.EditedAt = 0
+		}
 	}
 
 }

--- a/modules/message/api.go
+++ b/modules/message/api.go
@@ -1397,7 +1397,12 @@ func (m *Message) syncChannelMessage(c *wkhttp.Context) {
 	if len(channelSettings) > 0 && channelSettings[0].OffsetMessageSeq > 0 {
 		channelOffsetMessageSeq = channelSettings[0].OffsetMessageSeq
 	}
-	syncResp := newSyncChannelMessageResp(resp, c.GetLoginUID(), req.DeviceUUID, req.ChannelID, req.ChannelType, m.messageExtraDB, m.messageUserExtraDB, m.messageReactionDB, m.channelOffsetDB, m.deviceOffsetDB, channelOffsetMessageSeq)
+	syncResp, err := newSyncChannelMessageResp(resp, c.GetLoginUID(), req.DeviceUUID, req.ChannelID, req.ChannelType, m.messageExtraDB, m.messageUserExtraDB, m.messageReactionDB, m.channelOffsetDB, m.deviceOffsetDB, channelOffsetMessageSeq)
+	if err != nil {
+		m.Error("构建同步消息响应失败", zap.Error(err))
+		httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
+		return
+	}
 
 	// 群消息中的 ThreadCreated 消息：用实时数据覆盖 payload 中的快照字段
 	if req.ChannelType == common.ChannelTypeGroup.Uint8() {
@@ -2982,7 +2987,7 @@ type syncChannelMessageResp struct {
 	Messages        []*MsgSyncResp  `json:"messages"`          // 消息数据
 }
 
-func newSyncChannelMessageResp(resp *config.SyncChannelMessageResp, loginUID string, deviceUUID string, channelID string, channelType uint8, messageExtraDB *messageExtraDB, messageUserExtraDB *messageUserExtraDB, messageReactionDB *messageReactionDB, channelOffsetDB *channelOffsetDB, deviceOffsetDB *deviceOffsetDB, channelOffsetMessageSeq uint32) *syncChannelMessageResp {
+func newSyncChannelMessageResp(resp *config.SyncChannelMessageResp, loginUID string, deviceUUID string, channelID string, channelType uint8, messageExtraDB *messageExtraDB, messageUserExtraDB *messageUserExtraDB, messageReactionDB *messageReactionDB, channelOffsetDB *channelOffsetDB, deviceOffsetDB *deviceOffsetDB, channelOffsetMessageSeq uint32) (*syncChannelMessageResp, error) {
 	messages := make([]*MsgSyncResp, 0, len(resp.Messages))
 	if len(resp.Messages) > 0 {
 		messageIDs := make([]string, 0, len(resp.Messages))
@@ -3012,7 +3017,12 @@ func newSyncChannelMessageResp(resp *config.SyncChannelMessageResp, loginUID str
 		// 消息全局扩张
 		messageExtras, err := messageExtraDB.queryWithMessageIDsAndUID(messageIDs, loginUID)
 		if err != nil {
+			// fail-closed：撤回脱敏依赖 message_extra.revoke。查询失败则 messageExtraMap
+			// 为空，from() 拿不到 Revoke=1、会漏做脱敏并原样下发撤回原文。此处中止整个
+			// 同步、把 error 冒泡给调用方返回错误响应，与单条直查 api_message_get.go 同口径，
+			// 绝不带着不完整的撤回信息继续。
 			log.Error("查询消息扩展字段失败！", zap.Error(err))
+			return nil, err
 		}
 		// 修改消息扩展字段
 		for _, message := range resp.Messages {
@@ -3122,7 +3132,7 @@ func newSyncChannelMessageResp(resp *config.SyncChannelMessageResp, loginUID str
 		EndMessageSeq:   resp.EndMessageSeq,
 		PullMode:        resp.PullMode,
 		Messages:        messages,
-	}
+	}, nil
 }
 
 // 消息头

--- a/modules/message/api.go
+++ b/modules/message/api.go
@@ -124,14 +124,33 @@ func placeholderPayload() map[string]interface{} {
 // 保留 type 而不整条清空：撤回对所有人生效，前端仅凭 revoke=1 渲染撤回提示、不读
 // payload（撤回者名由 revoker UID 单独查，见 octo-web RevokeCell）；保留 type 只为
 // 兼容按 type 分支的老客户端渲染路径，type 本身不含消息正文。
+//
+// type 必须规范化为数字标量（scalarContentType）：payload 是不可信的调用方 JSON，
+// send 路径不约束 type 必须是数字（只剥 __obo_* / 处理 mention/space_id/richtext），
+// 若原样透传，攻击者可把正文藏进 type（字符串 / 对象 / 数组）绕过脱敏原样下发。
+// 服务端所有 type 消费方（isTextType / payloadMsgType）都严格按数字读取、非数字一律
+// 视为未知，故强制数字标量、非数字 fallback ContentError 不影响任何合法渲染（D23 安全整改）。
 func revokedPayload(original map[string]interface{}) map[string]interface{} {
-	stripped := map[string]interface{}{}
-	if t, ok := original["type"]; ok {
-		stripped["type"] = t
-	} else {
-		stripped["type"] = common.ContentError.Int()
+	return map[string]interface{}{
+		"type": scalarContentType(original["type"]),
 	}
-	return stripped
+}
+
+// scalarContentType 把 payload 的 type 归一为已识别的数字 content-type：
+// float64 / int / json.Number 三种反序列化结果转 int，其余（string / map / array / 缺失）
+// 一律 fallback common.ContentError，杜绝非标量 type 承载正文逃逸。
+func scalarContentType(v interface{}) int {
+	switch t := v.(type) {
+	case float64:
+		return int(t)
+	case int:
+		return t
+	case json.Number:
+		if i, err := t.Int64(); err == nil {
+			return int(i)
+		}
+	}
+	return common.ContentError.Int()
 }
 
 // isTextType 判断 payload type 是否为 common.Text（=1）。兼容 json.Number / float64 / int
@@ -1993,7 +2012,12 @@ func (m *Message) sync(c *wkhttp.Context) {
 	// 全局扩充数据
 	messageExtras, err := m.messageExtraDB.queryWithMessageIDsAndUID(messageIDs, c.GetLoginUID())
 	if err != nil {
-		log.Error("查询消息扩展字段失败！", zap.Error(err))
+		// fail-closed：撤回脱敏依赖 message_extra.revoke。查询失败则 messageExtraMap 为空，
+		// from() 拿不到 Revoke=1、会漏做脱敏并原样下发撤回原文。与 /message/channel/sync、
+		// /conversation/sync 及单条直查 api_message_get.go 同口径，中止请求而非继续。
+		m.Error("查询消息扩展字段失败！", zap.Error(err))
+		httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
+		return
 	}
 	messageExtraMap := map[string]*messageExtraDetailModel{}
 	if len(messageExtras) > 0 {

--- a/modules/message/api_conversation.go
+++ b/modules/message/api_conversation.go
@@ -718,7 +718,12 @@ func (co *Conversation) syncUserConversation(c *wkhttp.Context) {
 			channelOffsetM := channelOffsetModelMap[channelKey]
 			deviceOffsetM := deviceOffsetModelMap[channelKey]
 			extra := conversationExtraMap[channelKey]
-			syncUserConversationResp := newSyncUserConversationResp(conversation, extra, loginUID, co.messageExtraDB, co.messageReactionDB, co.messageUserExtraDB, mute, stick, channelOffsetM, deviceOffsetM, channelOffsetMessageSeq)
+			syncUserConversationResp, err := newSyncUserConversationResp(conversation, extra, loginUID, co.messageExtraDB, co.messageReactionDB, co.messageUserExtraDB, mute, stick, channelOffsetM, deviceOffsetM, channelOffsetMessageSeq)
+			if err != nil {
+				log.Error("构建会话同步响应失败", zap.Error(err), zap.String("channelID", conversation.ChannelID))
+				httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
+				return
+			}
 			// 填充群组分类信息
 			if conversation.ChannelType == common.ChannelTypeGroup.Uint8() {
 				if categorySetting := groupCategoryMap[conversation.ChannelID]; categorySetting != nil {
@@ -1472,7 +1477,7 @@ type SyncUserConversationResp struct {
 	BotType          string                 `json:"bot_type,omitempty"`           // Bot 类型（"app_bot" 表示应用 Bot）
 }
 
-func newSyncUserConversationResp(resp *config.SyncUserConversationResp, extra *conversationExtraResp, loginUID string, messageExtraDB *messageExtraDB, messageReactionDB *messageReactionDB, messageUserExtraDB *messageUserExtraDB, mute int, stick int, channelOffsetM *channelOffsetModel, deviceOffsetM *deviceOffsetModel, channelOffsetMessageSeq uint32) *SyncUserConversationResp {
+func newSyncUserConversationResp(resp *config.SyncUserConversationResp, extra *conversationExtraResp, loginUID string, messageExtraDB *messageExtraDB, messageReactionDB *messageReactionDB, messageUserExtraDB *messageUserExtraDB, mute int, stick int, channelOffsetM *channelOffsetModel, deviceOffsetM *deviceOffsetModel, channelOffsetMessageSeq uint32) (*SyncUserConversationResp, error) {
 	recents := make([]*MsgSyncResp, 0, len(resp.Recents))
 	lastClientMsgNo := "" // 最新未被删除的消息的clientMsgNo
 	if len(resp.Recents) > 0 {
@@ -1496,7 +1501,11 @@ func newSyncUserConversationResp(resp *config.SyncUserConversationResp, extra *c
 		// 消息扩充数据
 		messageExtras, err := messageExtraDB.queryWithMessageIDsAndUID(messageIDs, loginUID)
 		if err != nil {
+			// fail-closed：撤回脱敏依赖 message_extra.revoke。查询失败则 messageExtraMap
+			// 为空，from() 拿不到 Revoke=1、会漏做脱敏并原样下发撤回原文。冒泡给调用方
+			// 中止整个会话同步，与单条直查 api_message_get.go 同口径。
 			log.Error("查询消息扩展字段失败！", zap.Error(err))
+			return nil, err
 		}
 		messageExtraMap := map[string]*messageExtraDetailModel{}
 		if len(messageExtras) > 0 {
@@ -1561,7 +1570,7 @@ func newSyncUserConversationResp(resp *config.SyncUserConversationResp, extra *c
 		Stick:           stick,
 		Recents:         recents,
 		Extra:           extra,
-	}
+	}, nil
 }
 
 // threadMetaResp 子区元数据（仅 thread 频道返回）

--- a/modules/message/api_conversation.go
+++ b/modules/message/api_conversation.go
@@ -888,7 +888,7 @@ func (co *Conversation) syncUserConversation(c *wkhttp.Context) {
 	// Space 过滤
 	if hasSpaceFilter {
 		// Person 频道：计算 per-Space 未读计数（在过滤之前，需要原始会话数据）
-		fillPersonSpaceUnread(syncUserConversationResps, conversations, filterSpaceID, defaultSpaceID, loginUID, co.ctx)
+		fillPersonSpaceUnread(syncUserConversationResps, conversations, filterSpaceID, defaultSpaceID, loginUID, co.ctx, co.messageExtraDB)
 
 		syncUserConversationResps = FilterConversationsBySpace(
 			syncUserConversationResps, filterSpaceID, loginUID, co.ctx, co.groupService,

--- a/modules/message/revoke_payload_strip_test.go
+++ b/modules/message/revoke_payload_strip_test.go
@@ -33,6 +33,36 @@ func TestRevokedPayload(t *testing.T) {
 		assert.Equal(t, common.ContentError.Int(), out["type"])
 		assert.Len(t, out, 1)
 	})
+
+	// 安全回归：type 是不可信调用方数据，send 路径不约束其为数字标量。若把正文藏进
+	// 非标量 type（字符串 / 对象 / 数组），必须被规范化为 ContentError 而非原样透传，
+	// 否则撤回脱敏可被绕过（D23 整改 / PR #628 review by Jerry-Xin + yujiawei）。
+	t.Run("non-scalar type carrying content is normalized, never leaked", func(t *testing.T) {
+		const secret = "secret hidden in type field"
+		cases := map[string]interface{}{
+			"string type": secret,
+			"object type": map[string]interface{}{"nested": secret},
+			"array type":  []interface{}{secret},
+			"bool type":   true,
+		}
+		for name, badType := range cases {
+			t.Run(name, func(t *testing.T) {
+				out := revokedPayload(map[string]interface{}{"type": badType, "content": secret})
+				assert.Equal(t, common.ContentError.Int(), out["type"], "non-scalar type must fall back to ContentError")
+				assert.Len(t, out, 1)
+				body, err := json.Marshal(out)
+				assert.NoError(t, err)
+				assert.NotContains(t, string(body), secret, "no content may survive via the type field")
+			})
+		}
+	})
+
+	// 合法数字 type 的三种反序列化结果都必须原样保留（不会被误判为 ContentError）。
+	t.Run("numeric type is preserved across float64/int/json.Number", func(t *testing.T) {
+		assert.Equal(t, common.Text.Int(), revokedPayload(map[string]interface{}{"type": float64(common.Text.Int())})["type"])
+		assert.Equal(t, common.Text.Int(), revokedPayload(map[string]interface{}{"type": common.Text.Int()})["type"])
+		assert.Equal(t, common.Text.Int(), revokedPayload(map[string]interface{}{"type": json.Number("1")})["type"])
+	})
 }
 
 // TestMsgSyncRespFrom_RevokedStripsContent 是核心回归：撤回消息经 from()

--- a/modules/message/revoke_payload_strip_test.go
+++ b/modules/message/revoke_payload_strip_test.go
@@ -1,0 +1,250 @@
+package message
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestRevokedPayload 校验 revokedPayload 只保留 type、剥离一切内容承载字段。
+func TestRevokedPayload(t *testing.T) {
+	t.Run("strips content and every non-type field", func(t *testing.T) {
+		out := revokedPayload(map[string]interface{}{
+			"type":    common.Text.Int(),
+			"content": "secret original text",
+			"url":     "https://example.com/private.png",
+			"name":    "私密文件.pdf",
+			"reply":   map[string]interface{}{"content": "quoted secret"},
+		})
+		assert.Equal(t, common.Text.Int(), out["type"])
+		assert.Len(t, out, 1, "only type should remain")
+		for _, k := range []string{"content", "url", "name", "reply"} {
+			_, ok := out[k]
+			assert.Falsef(t, ok, "%q must be stripped", k)
+		}
+	})
+
+	t.Run("missing type falls back to ContentError", func(t *testing.T) {
+		out := revokedPayload(map[string]interface{}{"content": "x"})
+		assert.Equal(t, common.ContentError.Int(), out["type"])
+		assert.Len(t, out, 1)
+	})
+}
+
+// TestMsgSyncRespFrom_RevokedStripsContent 是核心回归：撤回消息经 from()
+// 组装后，原始正文不得出现在下发的任何字段里，而 revoke/revoker 元数据保留。
+// 覆盖 /v1/message/channel/sync 与 /v1/conversation/sync（两者共用 from()）。
+func TestMsgSyncRespFrom_RevokedStripsContent(t *testing.T) {
+	const secret = "top secret revoked message body"
+	payload, err := json.Marshal(map[string]interface{}{
+		"type":    common.Text.Int(),
+		"content": secret,
+	})
+	assert.NoError(t, err)
+
+	msgResp := &config.MessageResp{
+		MessageID:   12345,
+		MessageSeq:  10,
+		FromUID:     "sender1",
+		ChannelID:   "chan1",
+		ChannelType: common.ChannelTypePerson.Uint8(),
+		Payload:     payload,
+	}
+	extra := &messageExtraDetailModel{}
+	extra.MessageID = "12345"
+	extra.Revoke = 1
+	extra.Revoker = "admin1"
+	extra.Version = 7
+
+	m := &MsgSyncResp{}
+	m.from(msgResp, "viewer1", extra, nil, nil, 0)
+
+	assert.Equal(t, 1, m.Revoke, "revoke flag must be preserved for the tip")
+	assert.Equal(t, "admin1", m.Revoker, "revoker must be preserved for the tip")
+
+	_, hasContent := m.Payload["content"]
+	assert.False(t, hasContent, "revoked message must not ship original content")
+	assert.Len(t, m.Payload, 1, "only type should remain in the payload")
+
+	// Belt-and-suspenders: the secret must not appear anywhere in the wire body.
+	body, err := json.Marshal(m)
+	assert.NoError(t, err)
+	assert.NotContains(t, string(body), secret,
+		"revoked original content leaked into the sync response")
+}
+
+// TestMsgSyncRespFrom_RevokedStripsContentEdit 校验「编辑后又撤回」的消息不再经
+// message_extra.content_edit 下发编辑后的原文。
+func TestMsgSyncRespFrom_RevokedStripsContentEdit(t *testing.T) {
+	const editedSecret = "edited secret body that was later revoked"
+	payload, err := json.Marshal(map[string]interface{}{"type": common.Text.Int(), "content": "orig"})
+	assert.NoError(t, err)
+
+	msgResp := &config.MessageResp{
+		MessageID:   555,
+		MessageSeq:  6,
+		FromUID:     "sender1",
+		ChannelID:   "chan1",
+		ChannelType: common.ChannelTypePerson.Uint8(),
+		Payload:     payload,
+	}
+	extra := &messageExtraDetailModel{}
+	extra.MessageID = "555"
+	extra.Revoke = 1
+	extra.Revoker = "admin1"
+	extra.EditedAt = 1700000000
+	contentEdit, err := json.Marshal(map[string]interface{}{"type": common.Text.Int(), "content": editedSecret})
+	assert.NoError(t, err)
+	extra.ContentEdit.Valid = true
+	extra.ContentEdit.String = string(contentEdit)
+
+	m := &MsgSyncResp{}
+	m.from(msgResp, "viewer1", extra, nil, nil, 0)
+
+	assert.Equal(t, 1, m.Revoke)
+	if assert.NotNil(t, m.MessageExtra) {
+		assert.Nil(t, m.MessageExtra.ContentEdit, "revoked message must not ship content_edit")
+		assert.Equal(t, 0, m.MessageExtra.EditedAt)
+	}
+	body, err := json.Marshal(m)
+	assert.NoError(t, err)
+	assert.NotContains(t, string(body), editedSecret,
+		"revoked edited content leaked via content_edit")
+}
+
+// TestMsgSyncRespFrom_RevokedClearsSignalPayload 校验撤回的 signal 加密消息
+// 不再下发密文 blob（signal_payload）。
+func TestMsgSyncRespFrom_RevokedClearsSignalPayload(t *testing.T) {
+	cipher := []byte("encrypted-cipher-bytes-of-revoked-msg")
+	msgResp := &config.MessageResp{
+		MessageID:   333,
+		MessageSeq:  4,
+		FromUID:     "sender1",
+		ChannelID:   "chan1",
+		ChannelType: common.ChannelTypePerson.Uint8(),
+		Setting:     config.Setting{Signal: true}.ToUint8(),
+		Payload:     cipher,
+	}
+	extra := &messageExtraDetailModel{}
+	extra.MessageID = "333"
+	extra.Revoke = 1
+	extra.Revoker = "admin1"
+
+	m := &MsgSyncResp{}
+	m.from(msgResp, "viewer1", extra, nil, nil, 0)
+
+	assert.Equal(t, 1, m.Revoke)
+	assert.Empty(t, m.SignalPayload, "revoked signal ciphertext must be cleared")
+
+	body, err := json.Marshal(m)
+	assert.NoError(t, err)
+	assert.NotContains(t, string(body), base64.StdEncoding.EncodeToString(cipher),
+		"revoked signal ciphertext leaked into the sync response")
+}
+
+// TestMsgSyncRespFrom_RevokedClearsStreams 校验撤回的流式消息不再下发 stream blob。
+func TestMsgSyncRespFrom_RevokedClearsStreams(t *testing.T) {
+	const streamSecret = "streamed secret token"
+	payload, err := json.Marshal(map[string]interface{}{"type": common.Text.Int(), "content": "x"})
+	assert.NoError(t, err)
+
+	msgResp := &config.MessageResp{
+		MessageID:   444,
+		MessageSeq:  5,
+		FromUID:     "sender1",
+		ChannelID:   "chan1",
+		ChannelType: common.ChannelTypePerson.Uint8(),
+		Payload:     payload,
+		Streams: []*config.StreamItemResp{
+			{StreamSeq: 1, ClientMsgNo: "c1", Blob: []byte(`{"content":"` + streamSecret + `"}`)},
+		},
+	}
+	extra := &messageExtraDetailModel{}
+	extra.MessageID = "444"
+	extra.Revoke = 1
+	extra.Revoker = "admin1"
+
+	m := &MsgSyncResp{}
+	m.from(msgResp, "viewer1", extra, nil, nil, 0)
+
+	assert.Nil(t, m.Streams, "revoked stream blobs must be cleared")
+	body, err := json.Marshal(m)
+	assert.NoError(t, err)
+	assert.NotContains(t, string(body), streamSecret)
+}
+
+// TestMsgSyncRespFrom_NotRevokedKeepsContent 反向回归：未撤回消息内容原样保留，
+// 确保脱敏逻辑不误伤正常消息。
+func TestMsgSyncRespFrom_NotRevokedKeepsContent(t *testing.T) {
+	const visible = "normal visible message content"
+	payload, err := json.Marshal(map[string]interface{}{
+		"type":    common.Text.Int(),
+		"content": visible,
+	})
+	assert.NoError(t, err)
+
+	msgResp := &config.MessageResp{
+		MessageID:   222,
+		MessageSeq:  3,
+		FromUID:     "sender1",
+		ChannelID:   "chan1",
+		ChannelType: common.ChannelTypePerson.Uint8(),
+		Payload:     payload,
+	}
+
+	// no extra -> not revoked
+	m := &MsgSyncResp{}
+	m.from(msgResp, "viewer1", nil, nil, nil, 0)
+
+	assert.Equal(t, 0, m.Revoke)
+	assert.Equal(t, visible, m.Payload["content"], "non-revoked content must be preserved")
+}
+
+// TestSelectSpaceLastMessage_SkipsRevoked 校验 space_last_message 兜底选取会跳过
+// 已撤回消息，避免把撤回原文当作「最后一条消息」预览下发（/conversation/sync
+// SpaceLastMessage 字段的残余泄漏点）。
+func TestSelectSpaceLastMessage_SkipsRevoked(t *testing.T) {
+	mk := func(id int64, spaceID string) *config.MessageResp {
+		payload, _ := json.Marshal(map[string]interface{}{
+			"type":     common.Text.Int(),
+			"content":  "msg content",
+			"space_id": spaceID,
+		})
+		return &config.MessageResp{MessageID: id, Payload: payload}
+	}
+	// 顺序（旧 -> 新）：#1 spaceA(正常), #2 spaceA(撤回)。倒序遍历先命中 #2。
+	messages := []*config.MessageResp{mk(1, "spaceA"), mk(2, "spaceA")}
+
+	t.Run("revoked newest is skipped, older non-revoked chosen", func(t *testing.T) {
+		revoked := map[string]bool{"2": true}
+		got := selectSpaceLastMessage(messages, revoked, "spaceA", "", false)
+		if assert.NotNil(t, got) {
+			assert.Equal(t, int64(1), got.MessageID, "must skip revoked #2 and return #1")
+		}
+	})
+
+	t.Run("no revoked -> newest chosen", func(t *testing.T) {
+		got := selectSpaceLastMessage(messages, map[string]bool{}, "spaceA", "", false)
+		if assert.NotNil(t, got) {
+			assert.Equal(t, int64(2), got.MessageID)
+		}
+	})
+
+	t.Run("all revoked -> nil (nothing previewed)", func(t *testing.T) {
+		revoked := map[string]bool{"1": true, "2": true}
+		got := selectSpaceLastMessage(messages, revoked, "spaceA", "", false)
+		assert.Nil(t, got, "no non-revoked space message must yield no preview")
+	})
+}
+
+// TestRevokedMessageIDSet_NilDB 校验注入的 messageExtraDB 为空时返回空集合（不跳过），
+// 保证纯逻辑单测路径不依赖 DB。
+func TestRevokedMessageIDSet_NilDB(t *testing.T) {
+	msgs := []*config.MessageResp{{MessageID: 1}, {MessageID: 2}}
+	assert.Empty(t, revokedMessageIDSet(msgs, nil))
+	assert.Empty(t, revokedMessageIDSet(nil, nil))
+}

--- a/modules/message/revoke_payload_strip_test.go
+++ b/modules/message/revoke_payload_strip_test.go
@@ -241,10 +241,17 @@ func TestSelectSpaceLastMessage_SkipsRevoked(t *testing.T) {
 	})
 }
 
-// TestRevokedMessageIDSet_NilDB 校验注入的 messageExtraDB 为空时返回空集合（不跳过），
-// 保证纯逻辑单测路径不依赖 DB。
+// TestRevokedMessageIDSet_NilDB 校验注入的 messageExtraDB 为空时返回空集合、nil error
+// （不跳过），保证纯逻辑单测路径不依赖 DB。查询出错的 fail-closed 语义（返回 error →
+// findSpaceLastMessageFallback 跳过预览兜底）依赖真实 DB，由 infra-gated 集成测试覆盖。
 func TestRevokedMessageIDSet_NilDB(t *testing.T) {
 	msgs := []*config.MessageResp{{MessageID: 1}, {MessageID: 2}}
-	assert.Empty(t, revokedMessageIDSet(msgs, nil))
-	assert.Empty(t, revokedMessageIDSet(nil, nil))
+
+	set, err := revokedMessageIDSet(msgs, nil)
+	assert.NoError(t, err)
+	assert.Empty(t, set)
+
+	set, err = revokedMessageIDSet(nil, nil)
+	assert.NoError(t, err)
+	assert.Empty(t, set)
 }

--- a/modules/message/space_unread.go
+++ b/modules/message/space_unread.go
@@ -26,6 +26,7 @@ func fillPersonSpaceUnread(
 	defaultSpaceID string,
 	loginUID string,
 	ctx *config.Context,
+	messageExtraDB *messageExtraDB,
 ) {
 	if spaceID == "" || len(conversations) == 0 {
 		return
@@ -61,6 +62,7 @@ func fillPersonSpaceUnread(
 				fallbackMsg := findSpaceLastMessageFallback(
 					conv.ChannelID, conv.ChannelType,
 					loginUID, spaceID, defaultSpaceID, isSysBot, uint32(raw.LastMsgSeq), ctx,
+					messageExtraDB,
 				)
 				if fallbackMsg != nil {
 					conv.SpaceLastMessage = fallbackMsg
@@ -166,6 +168,7 @@ func findSpaceLastMessageFallback(
 	channelID string, channelType uint8,
 	loginUID string, spaceID, defaultSpaceID string,
 	isSysBot bool, lastMsgSeq uint32, ctx *config.Context,
+	messageExtraDB *messageExtraDB,
 ) *MsgSyncResp {
 	if lastMsgSeq == 0 {
 		return nil
@@ -195,10 +198,32 @@ func findSpaceLastMessageFallback(
 		return nil
 	}
 
-	// 从最新到最旧遍历，找第一条匹配的（跳过已删除消息）
-	for i := len(resp.Messages) - 1; i >= 0; i-- {
-		msg := resp.Messages[i]
+	// 撤回消息不得作为 space_last_message 预览下发：兜底路径用 msgRespToSyncResp 直拼
+	// payload，绕过了主 sync 路径 from() 的撤回脱敏，会把撤回原文当成「最后一条消息」
+	// 泄漏。批量查出撤回集合，遍历时与已删除消息一并跳过（与 api_channel_files.go
+	// 过滤撤回消息同口径）。
+	revokedSet := revokedMessageIDSet(resp.Messages, messageExtraDB)
+	chosen := selectSpaceLastMessage(resp.Messages, revokedSet, spaceID, defaultSpaceID, isSysBot)
+	if chosen == nil {
+		return nil
+	}
+	return msgRespToSyncResp(chosen)
+}
+
+// selectSpaceLastMessage 从最新到最旧遍历，返回第一条归属 spaceID、且未删除/未撤回的
+// 消息。纯函数（不做 IO），便于单测；撤回集合由调用方预先查好传入。
+func selectSpaceLastMessage(
+	messages []*config.MessageResp,
+	revoked map[string]bool,
+	spaceID, defaultSpaceID string,
+	isSysBot bool,
+) *config.MessageResp {
+	for i := len(messages) - 1; i >= 0; i-- {
+		msg := messages[i]
 		if msg.IsDeleted == 1 {
+			continue
+		}
+		if revoked[strconv.FormatInt(msg.MessageID, 10)] {
 			continue
 		}
 		payloadMap, err := msg.GetPayloadMap()
@@ -206,10 +231,32 @@ func findSpaceLastMessageFallback(
 			continue
 		}
 		if dmSpaceMatch(dmMessageSpaceID(payloadMap), spaceID, defaultSpaceID, isSysBot) {
-			return msgRespToSyncResp(msg)
+			return msg
 		}
 	}
 	return nil
+}
+
+// revokedMessageIDSet 批量查询给定消息里已撤回（message_extra.revoke=1）的 message_id 集合。
+// messageExtraDB 为空（如单测未注入）时返回空集合，即不跳过任何消息。
+func revokedMessageIDSet(messages []*config.MessageResp, messageExtraDB *messageExtraDB) map[string]bool {
+	set := make(map[string]bool)
+	if messageExtraDB == nil || len(messages) == 0 {
+		return set
+	}
+	ids := make([]string, 0, len(messages))
+	for _, msg := range messages {
+		ids = append(ids, strconv.FormatInt(msg.MessageID, 10))
+	}
+	revoked, err := messageExtraDB.queryRevokedWithMessageIDs(ids)
+	if err != nil {
+		log.Warn("revokedMessageIDSet: 查询撤回消息失败", zap.Error(err))
+		return set
+	}
+	for _, e := range revoked {
+		set[e.MessageID] = true
+	}
+	return set
 }
 
 // msgRespToSyncResp 将 config.MessageResp 转换为 MsgSyncResp（用于预览）。

--- a/modules/message/space_unread.go
+++ b/modules/message/space_unread.go
@@ -202,7 +202,18 @@ func findSpaceLastMessageFallback(
 	// payload，绕过了主 sync 路径 from() 的撤回脱敏，会把撤回原文当成「最后一条消息」
 	// 泄漏。批量查出撤回集合，遍历时与已删除消息一并跳过（与 api_channel_files.go
 	// 过滤撤回消息同口径）。
-	revokedSet := revokedMessageIDSet(resp.Messages, messageExtraDB)
+	//
+	// fail-closed：撤回集合查询失败时，无法判定哪些消息已撤回，宁可不下发预览兜底，
+	// 也不能把可能已撤回的原文当成 space_last_message 泄漏（与 api_channel_files.go
+	// filterMessages 出错即中止、绝不下发未过滤数据同口径）。
+	revokedSet, err := revokedMessageIDSet(resp.Messages, messageExtraDB)
+	if err != nil {
+		log.Warn("findSpaceLastMessageFallback: 查询撤回集合失败，跳过预览兜底",
+			zap.Error(err),
+			zap.String("channelID", channelID),
+			zap.String("loginUID", loginUID))
+		return nil
+	}
 	chosen := selectSpaceLastMessage(resp.Messages, revokedSet, spaceID, defaultSpaceID, isSysBot)
 	if chosen == nil {
 		return nil
@@ -238,11 +249,13 @@ func selectSpaceLastMessage(
 }
 
 // revokedMessageIDSet 批量查询给定消息里已撤回（message_extra.revoke=1）的 message_id 集合。
-// messageExtraDB 为空（如单测未注入）时返回空集合，即不跳过任何消息。
-func revokedMessageIDSet(messages []*config.MessageResp, messageExtraDB *messageExtraDB) map[string]bool {
+// messageExtraDB 为空（如单测未注入）或消息为空时返回空集合、nil error，即不跳过任何消息。
+// 查询出错时返回 error（fail-closed）：调用方须据此中止预览兜底，绝不能拿一个「谁都没撤回」
+// 的空集合继续，否则会把已撤回原文当成 space_last_message 下发（见 findSpaceLastMessageFallback）。
+func revokedMessageIDSet(messages []*config.MessageResp, messageExtraDB *messageExtraDB) (map[string]bool, error) {
 	set := make(map[string]bool)
 	if messageExtraDB == nil || len(messages) == 0 {
-		return set
+		return set, nil
 	}
 	ids := make([]string, 0, len(messages))
 	for _, msg := range messages {
@@ -250,13 +263,12 @@ func revokedMessageIDSet(messages []*config.MessageResp, messageExtraDB *message
 	}
 	revoked, err := messageExtraDB.queryRevokedWithMessageIDs(ids)
 	if err != nil {
-		log.Warn("revokedMessageIDSet: 查询撤回消息失败", zap.Error(err))
-		return set
+		return nil, err
 	}
 	for _, e := range revoked {
 		set[e.MessageID] = true
 	}
-	return set
+	return set, nil
 }
 
 // msgRespToSyncResp 将 config.MessageResp 转换为 MsgSyncResp（用于预览）。

--- a/modules/message/space_unread_test.go
+++ b/modules/message/space_unread_test.go
@@ -123,7 +123,7 @@ func TestFillPersonSpaceUnread_OnlyPersonChannels(t *testing.T) {
 		},
 	}
 
-	fillPersonSpaceUnread(convs, rawConvs, "spaceA", "", "me", nil)
+	fillPersonSpaceUnread(convs, rawConvs, "spaceA", "", "me", nil, nil)
 
 	// Group 不应有 space_unread
 	assert.Nil(t, convs[0].SpaceUnread)
@@ -140,7 +140,7 @@ func TestFillPersonSpaceUnread_ZeroUnread(t *testing.T) {
 		{ChannelID: "user1", ChannelType: common.ChannelTypePerson.Uint8(), Unread: 0, LastMsgSeq: 10},
 	}
 
-	fillPersonSpaceUnread(convs, rawConvs, "spaceA", "", "me", nil)
+	fillPersonSpaceUnread(convs, rawConvs, "spaceA", "", "me", nil, nil)
 	assert.Nil(t, convs[0].SpaceUnread)
 }
 
@@ -149,7 +149,7 @@ func TestFillPersonSpaceUnread_EmptySpaceID(t *testing.T) {
 		{ChannelID: "user1", ChannelType: common.ChannelTypePerson.Uint8(), Unread: 3},
 	}
 
-	fillPersonSpaceUnread(convs, nil, "", "", "me", nil)
+	fillPersonSpaceUnread(convs, nil, "", "", "me", nil, nil)
 	assert.Nil(t, convs[0].SpaceUnread)
 }
 
@@ -173,7 +173,7 @@ func TestFillPersonSpaceUnread_RecentsCoversAllUnread(t *testing.T) {
 	}
 
 	// readSeq = 20 - 3 = 17, 未读: seq 18(A), 19(B), 20(A) → spaceA=2
-	fillPersonSpaceUnread(convs, rawConvs, "spaceA", "", "me", nil)
+	fillPersonSpaceUnread(convs, rawConvs, "spaceA", "", "me", nil, nil)
 	assert.NotNil(t, convs[0].SpaceUnread)
 	assert.Equal(t, 2, *convs[0].SpaceUnread)
 }
@@ -194,7 +194,7 @@ func TestFillPersonSpaceUnread_AllUnreadInDifferentSpace(t *testing.T) {
 	}
 
 	// readSeq = 5 - 2 = 3, 未读 seq 4(B) 5(B) → spaceA=0
-	fillPersonSpaceUnread(convs, rawConvs, "spaceA", "", "me", nil)
+	fillPersonSpaceUnread(convs, rawConvs, "spaceA", "", "me", nil, nil)
 	assert.NotNil(t, convs[0].SpaceUnread)
 	assert.Equal(t, 0, *convs[0].SpaceUnread)
 }
@@ -206,7 +206,7 @@ func TestFillPersonSpaceUnread_NoRawConversation(t *testing.T) {
 	}
 	rawConvs := []*config.SyncUserConversationResp{}
 
-	fillPersonSpaceUnread(convs, rawConvs, "spaceA", "", "me", nil)
+	fillPersonSpaceUnread(convs, rawConvs, "spaceA", "", "me", nil, nil)
 	assert.Nil(t, convs[0].SpaceUnread)
 }
 
@@ -311,14 +311,14 @@ func TestFillPersonSpaceUnread_SystemBotUntaggedExcluded(t *testing.T) {
 
 	// System bot ("botfather"): untagged excluded from default-Space preview + unread.
 	botConvs, botRaw := mkConv("botfather")
-	fillPersonSpaceUnread(botConvs, botRaw, def, def, "login", nil)
+	fillPersonSpaceUnread(botConvs, botRaw, def, def, "login", nil, nil)
 	assert.Nil(t, botConvs[0].SpaceLastMessage, "system-bot untagged → no default-space preview")
 	assert.NotNil(t, botConvs[0].SpaceUnread)
 	assert.Equal(t, 0, *botConvs[0].SpaceUnread, "system-bot untagged → 0 default-space unread")
 
 	// Regular DM: the same untagged messages DO belong to the default Space.
 	regConvs, regRaw := mkConv("regular-peer")
-	fillPersonSpaceUnread(regConvs, regRaw, def, def, "login", nil)
+	fillPersonSpaceUnread(regConvs, regRaw, def, def, "login", nil, nil)
 	assert.NotNil(t, regConvs[0].SpaceLastMessage, "regular DM untagged → default-space preview")
 	assert.NotNil(t, regConvs[0].SpaceUnread)
 	assert.Equal(t, 2, *regConvs[0].SpaceUnread, "regular DM untagged → counted as default-space unread")
@@ -337,7 +337,7 @@ func TestFillPersonSpaceUnread_SetsSpaceLastMessage(t *testing.T) {
 		},
 	}
 
-	fillPersonSpaceUnread(convs, nil, "spaceA", "", "login", nil)
+	fillPersonSpaceUnread(convs, nil, "spaceA", "", "login", nil, nil)
 
 	// SpaceLastMessage 应为 spaceA 的消息 "111"
 	assert.NotNil(t, convs[0].SpaceLastMessage)


### PR DESCRIPTION
## Summary

Revoked messages were returned with `revoke=1` **and** their full original payload on `/v1/message/channel/sync` and `/v1/conversation/sync` (both share `MsgSyncResp.from`). The original text therefore stayed recoverable in the client's page memory even though the row is only rendered as a "message revoked" tip — a browser extension can read it straight off the React props. The single-message read path (`api_message_get.go`) already `404`s on `revoke==1`; this PR closes the same gap on the sync paths so revoked content is never shipped.

## Related Issue

None filed — reported directly as a data-leak on the two sync endpoints above.

## Linked Spec

No `.octospec/tasks/<slug>/brief.md` (direct security report, no pre-existing brief). Load-bearing path affected: **message sync response assembly** — `MsgSyncResp.from` (`modules/message/api.go`), shared by both sync endpoints, plus the `SpaceLastMessage` preview fallback in `modules/message/space_unread.go`.

## Changes

- **`MsgSyncResp.from` — revoke content redaction:** when `revoke==1`, strip the outgoing `payload` down to its `type` only, and clear the `signal_payload` (ciphertext), `streams` (stream blobs), and `message_extra.content_edit` (edited body) — all original-content carriers. Revoke metadata (`revoke`, `revoker`) is preserved so the tip still renders.
- **`/conversation/sync` `SpaceLastMessage` fallback:** `findSpaceLastMessageFallback` hand-built the preview via `msgRespToSyncResp`, bypassing `from()`'s redaction. It now skips revoked candidates (batch `queryRevokedWithMessageIDs`, mirroring the revoke filter in `api_channel_files.go`), so a revoked message is never surfaced as a last-message preview. Selection logic factored into a pure, unit-testable `selectSpaceLastMessage`.
- **Tests:** added `revoke_payload_strip_test.go` covering payload / `content_edit` / signal / stream stripping and revoked-preview skipping.

## Testing

```
go build ./modules/message/      # ok
go vet ./modules/message/        # ok
go test ./modules/message/ -run 'TestRevokedPayload|TestMsgSyncRespFrom_|TestSelectSpaceLastMessage_|TestRevokedMessageIDSet_'   # PASS
go test ./modules/message/ -run 'NoLegacyResponseError'   # PASS (source guard)
```

All new tests are pure unit tests (construct `config.MessageResp` + `messageExtraDetailModel`, call `from()` directly) — no MySQL/Redis/WuKongIM needed. Existing `space_unread` unit tests (incl. `TestFillPersonSpaceUnread_*`) still pass after the signature change.

- [x] Unit tests added/updated
- [ ] Manually verified end-to-end — the live sync path needs MySQL+Redis+WuKongIM (CI); verified here by exercising `from()` directly at unit level.

## COMPREHENSION

1. **What does this change actually do to the load-bearing path?** In the single funnel every synced message passes through (`MsgSyncResp.from`), it adds a post-assembly redaction step gated on `revoke==1`: the payload is replaced with `{type}` only and the other content carriers (signal ciphertext, stream blobs, `content_edit`) are cleared. It does **not** touch non-revoked messages, and it does not change which messages are returned — only the content of already-revoked ones. The conversation-sync preview fallback additionally skips revoked candidates instead of emitting them.

2. **What could break (dependents + failure mode)?** Any client that (incorrectly) reads a revoked message's `payload.content` instead of gating on `revoke=1`. Verified on octo-web: the revoke tip (`RevokeCell`) renders purely from `revoke` + `revoker` (revoker name resolved by UID via the channel manager), never from payload, and there is no "re-edit revoked text" feature — so no legitimate consumer loses data. Worst case for an odd client is an empty bubble on an already-revoked row (still gated away by `revoke=1`). The preview fallback change means a channel whose newest space message is revoked now previews the last *non-revoked* message (or nothing) instead of leaking the revoked text.

3. **How do you know it works?** `TestMsgSyncRespFrom_RevokedStripsContent` asserts the secret is absent from the entire marshaled response and only `{type}` remains; sibling tests cover `content_edit`, `signal_payload`, and `streams`; `TestMsgSyncRespFrom_NotRevokedKeepsContent` guards against over-redaction; `TestSelectSpaceLastMessage_SkipsRevoked` covers the preview-skip (skip newest-revoked, pick older; all-revoked → nil). Consistency anchor: `api_message_get.go:241` already returns `404` on `revoke==1`, so this only extends an existing, intended invariant to the sync paths.

## Checklist

- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] PR description is in English
- [x] Added tests for my changes
- [ ] Updated documentation (not applicable — no doc-facing change)
- [x] Followed commit message conventions (Conventional Commits)

---

### Related findings (not addressed here — same class, awaiting decision)

The identical sync funnel also ships full payloads for other not-visible-to-requester messages, and `api_message_get.go` already blocks these on the single-read path too:
- **Globally deleted** messages (`message_extra.is_deleted=1`) ship full payload with `is_deleted=1`.
- **`visibles`-restricted** messages ship full payload to non-whitelisted users (`api.go` only sets `is_deleted=1`, doesn't strip).
- **Reply-quote snapshots** embed a revoked/edited parent's content in the replying message's `reply` preview.

Scoped out of this PR because they touch delete/visibility/reply rendering paths whose frontend impact wasn't verified for this change. Happy to follow up under the same redaction contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AupxRE4tVPQ4fS2bzi3msA

---
_Generated by [Claude Code](https://claude.ai/code/session_01AupxRE4tVPQ4fS2bzi3msA)_