### PR TITLE
feat(message): transactional message_extra version allocator + schema (#627)

### DIFF
--- a/.octospec/tasks/message-extra-transactional-version/brief.md
+++ b/.octospec/tasks/message-extra-transactional-version/brief.md
@@ -1,0 +1,596 @@
+---
+type: Task
+title: "Task: message-extra-transactional-version"
+description: Make message_extra delta-sync versions unique and commit-ordered per storage channel across octo-server replicas.
+tags: ["message", "delta-sync", "wire-contract", "database", "migration", "concurrency", "multi-replica", "card", "bot-api", "observability", "testing"]
+timestamp: 2026-07-21T17:38:17+08:00
+# --- octospec extension fields ---
+slug: message-extra-transactional-version
+upstream: "Mininglamp-OSS/octo-server#627"
+source: self
+---
+
+# Task: message-extra-transactional-version
+
+> One task = one `.octospec/tasks/<slug>/` directory. This brief is the spec for
+> the work. AI may draft it from existing code; a human confirms it.
+
+## Goal
+
+Make `message_extra.version` a unique, commit-ordered cursor within each
+persisted channel so `/v1/message/extra/sync` cannot permanently skip a later
+committed mutation in a multi-replica deployment.
+
+The implementation introduces a message-extra-specific transactional sequence
+in octo-server. Every authoritative `message_extra` mutation reserves its
+version from the channel sequence and writes the business row in the **same
+MySQL transaction**, while holding the sequence-row lock until commit. This
+preserves the existing client wire contract (`extra_version`, ascending
+pagination, and `CMDSyncMessageExtra`) while fixing the ordering invariant at
+its source.
+
+## Background
+
+- Delta sync reads one storage channel with
+  `WHERE channel_id=? AND channel_type=? AND version>? ORDER BY version ASC
+  LIMIT ?` (`modules/message/db_message_extra.go`). Once a client advances its
+  cursor, a row later committed with `version <= cursor` is invisible to that
+  incremental path.
+- Current writers allocate versions through octo-lib `Context.GenSeq`. That
+  allocator keeps a process-local `seqMap` and reserves blocks of 1000 values;
+  the database stores only the block ceiling. Therefore allocation order is
+  not globally ordered across octo-server replicas.
+- The current block reservation is also a read-then-overwrite operation. Two
+  processes initializing the same key concurrently can reserve the same block,
+  so cross-process uniqueness is not guaranteed either. Duplicate versions are
+  unsafe for `version > cursor` pagination when a page boundary splits rows
+  sharing the same value.
+- Card edits already serialize competing writes to the same `message_id` and
+  allocate after taking that row lock. This closes the single-process race but
+  cannot close the cross-process HiLo range problem. `card_seq` protects which
+  content wins; it does not make the channel delta-sync cursor monotonic.
+- A concrete failure is: replica B commits an intermediate card frame with a
+  higher HiLo value; the client syncs it and advances its cursor; replica A then
+  commits the accepted terminal frame from an older block. The database stores
+  the correct terminal content, but the generic CMD carries neither content nor
+  version and the subsequent `version > cursor` read cannot return that row.
+- The defect is broader than cards. User/bot/robot edits, callback card
+  mutation, revoke/delete, pin changes, manager deletion, and read-receipt count
+  materialization all write the same cursor domain.
+- Merely replacing HiLo with MySQL `AUTO_INCREMENT` or Redis `INCR` is not a
+  root fix. Those primitives order allocation, not transaction commit: a
+  transaction holding a lower allocated value can still commit after a higher
+  value and be skipped.
+
+## Decisions
+
+### D1. Cursor invariant and scope
+
+For each persisted storage-channel key `(channel_id, channel_type)`:
+
+1. Every committed authoritative `message_extra` mutation has one version
+   strictly greater than every mutation that committed before it in that key.
+2. No two committed mutations in that key share a version.
+3. A transaction that rolls back exposes neither its business mutation nor its
+   sequence advance. Reuse of a rolled-back value is allowed because it was
+   never visible; gaps are also allowed and carry no protocol meaning.
+4. Ordering is per storage channel, not global. Personal chats use the existing
+   fake channel ID derived before persistence; group/topic channels use their
+   persisted channel ID and current `channel_type` unchanged.
+
+This is the invariant required by the existing channel-scoped delta cursor. A
+per-message monotonic value is insufficient because a client cursor can advance
+past that message due to a mutation on another message in the same channel.
+
+### D2. Transactional channel-sequence and allocator-state tables
+
+Add a message module migration creating the per-channel sequence table and one
+database-authoritative allocator-state row:
+
+```sql
+CREATE TABLE `octo_message_extra_channel_seq` (
+  `channel_id`   VARCHAR(100)     NOT NULL DEFAULT '' COMMENT '存储行频道ID(person=fakeChannelID)',
+  `channel_type` SMALLINT         NOT NULL DEFAULT 0  COMMENT '频道类型',
+  `last_version` BIGINT           NOT NULL DEFAULT 0  COMMENT '该频道已分配的最大 message_extra 版本',
+  PRIMARY KEY (`channel_id`,`channel_type`)
+) ENGINE=InnoDB DEFAULT CHARSET=<match message_extra.channel_id> COLLATE=<match> COMMENT='message_extra 每频道事务序列(#627)';
+
+CREATE TABLE `octo_message_extra_version_state` (
+  `singleton_id`  TINYINT UNSIGNED NOT NULL COMMENT '恒为1的单例键',
+  `mode`          TINYINT          NOT NULL DEFAULT 0 COMMENT '0=legacy,1=transactional',
+  `epoch`         BIGINT UNSIGNED  NOT NULL DEFAULT 0 COMMENT '换代计数(operator CAS 递增)',
+  `cutover_floor` BIGINT           NOT NULL DEFAULT 0 COMMENT 'cutover 校验后的版本下界',
+  PRIMARY KEY (`singleton_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci COMMENT='message_extra allocator 全局状态单例(#627)';
+
+INSERT INTO `octo_message_extra_version_state`
+  (`singleton_id`, `mode`, `epoch`, `cutover_floor`)
+VALUES (1, 0, 0, 0);
+```
+
+- Table names use the `octo_` prefix required for all new tables in this repo
+  (existing prefix-less tables such as `message_extra` are not touched); the
+  migration file follows `modules/message/sql/<yyyyMMdd>-<seq>_<name>.sql`,
+  embedded via `//go:embed sql`, and matches the repo DDL style of the most
+  recent new table (`octo_message_card_revision`): inline `PRIMARY KEY`/`KEY`,
+  per-column `COMMENT`, and an `ENGINE=InnoDB DEFAULT CHARSET=... COLLATE=...
+  COMMENT=...` suffix.
+- `octo_message_extra_channel_seq.channel_id` charset **and** collation must match
+  `message_extra.channel_id`, and `channel_type` its persisted domain. Note
+  `message_extra` declares no explicit charset/collation (it inherits the schema
+  default), so the implementation must read the **effective** charset/collation
+  of `message_extra.channel_id` from the live schema and pin the new table to it
+  — do not assume `utf8mb4_general_ci`. The state table carries no channel key,
+  so it may use the standard `utf8mb4`/`utf8mb4_general_ci`.
+- The channel-sequence table contains no business content and has one hot row
+  per active storage channel, avoiding a process-wide or deployment-wide
+  sequence bottleneck. Both new tables are empty/tiny at creation, so their
+  `CREATE TABLE` statements are cheap and need no online DDL tooling.
+- `octo_message_extra_version_state` is the sole allocator-mode/floor source of
+  truth for every upgraded binary. Exactly one row (`singleton_id=1`) must
+  exist. A **missing** row defaults to `legacy` — the safe pre-migration
+  behavior (existing `GenSeq`), which a deploy also sees before the migration
+  seeds the row and which test setups leave after `CleanAllTables`; this is not
+  fail-closed. An unrecognized `mode` value or an unreadable row **does** fail
+  closed. `epoch` is never a write-abort condition (see D3). Guarding against a
+  row deleted while in transactional mode is the job of the optional
+  expected-mode config check (D9), not this read; the mode gauge still surfaces
+  `legacy` so an operator can detect an unexpected state. Environment variables
+  may assert an expected mode for rollout diagnostics, but must never select an
+  allocator independently of this DB row.
+- Separately, add on the **existing `message_extra` table** the composite index
+  the delta-sync read path needs: `(channel_id, channel_type, version)`. Today
+  `message_extra` carries only `channel_idx (channel_id, channel_type)`, so the
+  `WHERE channel_id=? AND channel_type=? AND version>? ORDER BY version ASC`
+  scan cannot resolve the `version` range/ordering from the index. This index is
+  the one with real DDL cost: because `message_extra` is a large, live table, the
+  migration must use the deployment's approved online-schema-change path when the
+  target MySQL version cannot add it online without a table rebuild or blocking
+  writes. (This is a read-path optimization independent of the sequence rework;
+  land it in the same task since both touch the cursor domain.)
+- Do not modify octo-lib `GenSeq` in this task. Its other callers have separate
+  compatibility and ordering contracts. During the Prepare phase, the one
+  centralized version store may retain a transitional legacy adapter; business
+  writers must no longer call `GenSeq(MessageExtraSeqKey, ...)` directly, and
+  transactional mode must never call it.
+
+### D3. Reservation API and transaction ownership
+
+Introduce one shared message-extra version store, usable from `modules/message`,
+`modules/bot_api`, `modules/robot`, and `internal/carddispatch`, with semantics
+equivalent to:
+
+```go
+ReserveTx(tx *dbr.Tx, storageChannelID string, channelType uint8, count int) (versions []int64, err error)
+```
+
+`versions` always has `len == count`, in assignment order. In transactional mode
+it is a contiguous ascending range; in legacy mode it is `count` distinct values
+from `GenSeq` (contiguity is not guaranteed under concurrency — matching pre-task
+per-message behavior). Returning explicit per-item values, rather than a single
+`first`, keeps callers mode-agnostic and behavior-preserving across the Prepare
+window (a `first`+`first..first+N-1` assignment would be unsafe in legacy mode).
+
+The store must live in a neutral package that all four callers can import
+without an import cycle (e.g. `internal/msgextraseq` or a `pkg/` package), not in
+`modules/message` itself if that would clash with existing dependency direction
+between `modules/message`, `modules/bot_api`, `modules/robot`, and
+`internal/carddispatch`. Confirm the dependency direction before placing it.
+
+- `count` must be positive and must not exceed a fixed upper bound of **1000**
+  (aligned with this module's existing chunk magnitude). `ReserveTx` rejects
+  `count <= 0` or `count > 1000` before touching any row. Callers handle the cap
+  by semantics: client-supplied batches (e.g. manager delete `req.List`) reject
+  oversized input through the existing localized error contract; internal batch
+  paths that must not drop work (e.g. read-receipt materialization) reserve in
+  `<=1000` chunks — repeated reservations on the same channel stay monotonic.
+  This keeps a pathological batch from reserving a huge range while holding the
+  hot sequence-row lock.
+- The caller starts and owns the business transaction. The allocator must not
+  open or commit an independent transaction. The design must be correct under
+  the repo's ambient isolation level (MySQL default `REPEATABLE READ` on pooled
+  dbr connections); the race-safe initializer below removes the need for a
+  gap-lock-avoiding level. Do **not** silently `SET TRANSACTION ISOLATION
+  LEVEL` per call: that leaks to the next user of a pooled connection. If a
+  future need for `READ COMMITTED` is proven, it must be set at transaction
+  granularity by every migrated caller and reset before the connection returns
+  to the pool, and stated explicitly — not assumed.
+- Before choosing an allocator, every upgraded writer performs a current locking
+  read of `octo_message_extra_version_state(singleton_id=1)` in the same business
+  transaction (`SELECT ... FOR SHARE`) and holds that shared lock until
+  commit/rollback. Shared locks are compatible across writers, so this does not
+  serialize normal traffic; the exclusive mode flip waits for all upgraded
+  in-flight writers to finish. This per-transaction locking read is the drain
+  barrier, so the state row is deliberately not cached across transactions.
+  `mode=0` is the only state that may call the centralized legacy adapter;
+  `mode=1` must use the transactional channel sequence. A **missing** state row
+  defaults to `legacy` (safe pre-migration behavior; see D2). A write aborts and
+  marks readiness unhealthy only on: more than one row, a `mode` value outside
+  the known set, or a state read failure. An optional expected-mode config
+  mismatch also fails closed. `epoch` is not validated by writers and is never a
+  write-abort condition.
+- `epoch` is a monotonic generation counter owned exclusively by the operator
+  activation/emergency tool. It is bumped only inside the guarded exclusive state
+  transition via compare-and-set (assert expected epoch `N`, set `N+1`), which
+  prevents a stale or double activation from racing operators or a reran tool.
+  Business writers record the epoch they read for observability (D8) and never
+  compare it against a compiled-in value; the allocator is selected solely by
+  `mode`. Cross-generation safety is provided by the per-allocation floor raise
+  below plus the preflight floor bound (D9), not by epoch.
+- The first allocation for a channel initializes `last_version` to the maximum
+  of:
+  1. the deployment's verified `cutover_floor`;
+  2. the current maximum `message_extra.version` for that channel/type; and
+  3. the legacy octo-lib `seq.min_seq` value for the corresponding
+     `MessageExtraSeqKey` channel key, when present.
+  The legacy `seq.min_seq` value is evidence, not a sufficient safety boundary:
+  its current read-then-overwrite implementation can move backward when an old
+  replica extends a stale block. `cutover_floor` is the authoritative boundary
+  derived by the deployment preflight in D9.
+- On every transactional allocation, including for an already-existing channel
+  row, the locked `last_version` is first raised to at least the current state
+  row's `cutover_floor`. This makes a later transactional epoch/cutover safe even
+  when the per-channel row survived an emergency legacy interval.
+- Initialization must be concurrency-safe through the table's primary key. A
+  bare `SELECT ... FOR UPDATE` on a not-yet-existing row does **not** block, and
+  two initializers that both read empty then `INSERT` will collide: the loser
+  gets MySQL error 1062 (duplicate key), not a wait. The implementation must use
+  a race-safe upsert — e.g. `INSERT ... ON DUPLICATE KEY UPDATE
+  last_version=last_version` (a no-op placeholder to materialize the row), then
+  `SELECT ... FOR UPDATE` to reload and lock the winning row — or explicitly
+  catch 1062 and re-`SELECT ... FOR UPDATE`. A duplicate initializer must
+  reload the winning row, never proceed on a private baseline.
+- Reservation locks the sequence row with `SELECT ... FOR UPDATE`. Acquiring the
+  lock and advancing the counter are distinct steps: the writer takes the lock,
+  performs any accept/reject decision that depends on the message row (e.g. a
+  card CAS check), and only advances `last_version` by `count` when the mutation
+  is actually going to be written. On accept it returns the contiguous range
+  `old+1 ... old+count`; a rejected/stale path releases the lock on rollback
+  without consuming any version (gaps are allowed by D1.3). The lock remains held
+  until the caller commits or rolls back the business transaction.
+- Reservation fails before mutation when `last_version+count` would overflow
+  `int64` or exceed `2^53-1`; this preserves exact cursor representation for
+  existing JavaScript clients instead of silently emitting lossy JSON numbers.
+- Batch writers reserve once and assign values deterministically. They must not
+  perform one sequence round trip per message.
+
+### D4. Lock ordering and retries
+
+- Every migrated writer acquires locks in this order:
+  1. the singleton allocator-state row in shared mode;
+  2. channel-sequence rows, sorted by `(channel_id, channel_type)` if a
+     transaction touches more than one channel;
+  3. `message_extra` rows, sorted by `message_id` for batches;
+  4. any secondary rows already required by that operation.
+  This order is uniform across all writers, and the mode flip takes only the
+  exclusive state-row lock (it never acquires sequence or `message_extra` locks),
+  so no writer/writer or writer/flip lock cycle can form.
+- The current card CAS/LWW paths must be reordered from "message row then
+  GenSeq" to "channel sequence then message row". A stale `card_seq` conflict
+  rolls back without consuming a committed version.
+- Map iteration order must never determine lock order. In particular, the
+  read-receipt event path groups work by channel today and must sort the keys
+  before reserving ranges.
+- MySQL errors 1213 (deadlock) and 1205 (lock wait timeout) receive one bounded
+  retry policy around the **whole business transaction**. Do not nest allocator,
+  card-mutator, and handler retry loops. Exhaustion fails the operation using
+  its existing localized error/logging contract; it must not send a CMD for an
+  uncommitted mutation.
+
+### D5. Complete writer cutover
+
+The following production paths, including any helper they call, move to the
+shared transactional allocator:
+
+- user message edit, mutual/global delete, revoke, and other
+  `modules/message/api.go` mutations;
+- pin/unpin and bulk pin removal in `modules/message/api_pinned.go`;
+- read-receipt count materialization in `modules/message/event.go`;
+- manager message-extra deletion in `modules/message/api_manager.go` — this
+  path currently accepts a client-supplied `req.List` with only an empty check
+  and no upper bound; add a `len(req.List) <= 1000` guard (existing localized
+  error contract) as part of the cutover so the batch reservation is bounded;
+- bot edit with `card_seq`, bot edit without `card_seq`, and non-card bot edits
+  in `modules/bot_api/send.go`;
+- internal callback terminal-card mutation in
+  `internal/carddispatch/mutation.go`;
+- legacy robot edit in `modules/robot/api.go`.
+
+Implementation-time source search is authoritative: no business writer may
+call `GenSeq` with `common.MessageExtraSeqKey`. At most one call may remain in
+the centralized, explicitly named transitional legacy adapter used only during
+the Prepare/rollback mode; transactional mode and all test production paths
+must bypass it. A source-guard test must enforce this allowlist so a new writer
+cannot silently reintroduce the incompatible allocator.
+
+All affected operations must write `message_extra` transactionally. A path that
+currently performs a single autocommit upsert must be converted to begin →
+reserve → mutate → commit before CMD fan-out.
+
+### D6. Existing business and wire semantics remain unchanged
+
+- `/v1/message/extra/sync` request/response fields, ordering, default/max limit,
+  membership checks, fake-channel derivation, and Redis cursor cache are not
+  changed.
+- `CMDSyncMessageExtra` remains a best-effort notification sent only after the
+  authoritative transaction commits. It does not gain card content, message ID,
+  or version in this task.
+- `card_seq` conflict/replay semantics, content hash deduplication, card revision
+  history, edit ownership, revoke/delete gates, and user-facing i18n envelopes
+  remain unchanged.
+- Existing Space/Auth/Bot ownership checks remain before mutation. Moving the
+  version allocator must not create a bypass or a cross-Space lookup.
+- Sequence allocation failure is an internal storage failure. Existing endpoint
+  error codes are reused; this task does not introduce raw error responses or
+  expose DB/lock details to clients.
+
+### D7. Performance and bounded contention
+
+- Serialization is deliberately per storage channel because that is the cursor
+  consistency domain. Different channels must allocate independently.
+- Batch paths reserve a range once. The implementation must keep transactions
+  free of network calls and other unbounded work while holding the sequence-row
+  lock; WuKongIM/CMD calls and search event commits happen after DB commit as
+  their current contracts require.
+- The sequence lock adds a write hotspot for very active channels. Before
+  rollout, run a concurrency test representative of large-group read receipts
+  and card edits; record p50/p95/p99 sequence-lock wait and transaction latency.
+  No fixed throughput SLA is invented by this brief, but an unexplained
+  regression relative to the legacy path blocks rollout.
+- The per-write shared lock on the singleton state row is part of the measured
+  path. It is compatible across writers (no steady-state serialization) and
+  costs one extra small primary-key lookup per business transaction — amortized
+  across a batch writer, not paid per message. The concurrency test records
+  state-row shared-lock wait (p50/p95/p99) and the added per-transaction latency
+  versus the legacy path alongside the sequence-row metrics.
+
+### D8. Observability
+
+Add low-cardinality metrics for the shared allocator:
+
+- `message_extra_version_reserve_total{result=success|retry|failure}`;
+- `message_extra_version_reserve_seconds` histogram;
+- `message_extra_version_lock_wait_seconds` histogram;
+- `message_extra_version_state_lock_wait_seconds` histogram (shared state-row
+  wait, kept separate from the sequence-row lock);
+- `message_extra_version_batch_size` histogram;
+- `message_extra_version_allocator_mode{mode=legacy|transactional}` gauge;
+- `message_extra_version_allocator_epoch` gauge;
+- `message_extra_version_cutover_floor` gauge;
+- `message_extra_version_invariant_violation_total` counter, incremented when a
+  defensive check observes a candidate version not greater than the currently
+  locked row version or a duplicate result.
+
+Structured failure logs include `channel_id`, `channel_type`, operation,
+attempt, MySQL error number, and stage
+(`state|initialize|lock|reserve|write|commit|activate`). They must not include
+message content, card payload, credentials, or raw request bodies.
+
+### D9. Deployment, rollback, and historical state
+
+The allocator change is not safe to activate while any pre-task binary can
+still write from a cached legacy HiLo block. The DB state row is authoritative
+for upgraded binaries, but old binaries do not know it exists; the deployment
+must prove their replica count is zero before activation.
+
+Deployment is two-phase:
+
+1. **Prepare** — apply both new tables and the `message_extra` index. The
+   migration seeds state `(mode=legacy, epoch=0, cutover_floor=0)`. Deploy the
+   dual-capable binary everywhere; every upgraded writer reads the DB state row
+   and therefore continues through the one centralized legacy adapter. Confirm
+   image digests/versions, readiness, migrations, and focused tests on every
+   replica.
+2. **Cut over** — drain message-extra write traffic, wait for in-flight requests,
+   and confirm no pre-task binary remains. Run the final preflight, then use the
+   operator tool to take an exclusive lock on the state row, assert its expected
+   mode/epoch, and atomically set `cutover_floor=<verified floor>`, increment
+   `epoch`, and set `mode=transactional`. The activation transition runs with a
+   short `innodb_lock_wait_timeout` on its own session: if it is issued before
+   the write drain completes, the exclusive state-row lock fails fast and reports
+   the in-flight writers instead of stalling live message-extra writes. Because
+   the flip only ever runs after the documented drain, steady-state writers are
+   not affected. Upgraded writers hold a shared state lock for their transaction,
+   so this flip waits for any upgraded in-flight legacy writer and no later
+   upgraded writer can independently choose legacy. Resume traffic only after
+   readiness and allocator metrics report the new DB mode/epoch/floor on every
+   replica.
+
+The DB state row, not an environment variable, selects the allocator. An
+optional deployment setting may declare an **expected** mode/epoch and fail
+startup/readiness on mismatch, but it cannot override DB state. Missing,
+duplicate, or unreadable state and an unrecognized `mode` value fail
+message-extra writes closed; `epoch` never fails a write and is validated only
+by the operator tool's compare-and-set during a transition. The transactional
+`cutover_floor` must be positive and no greater than `2^53-1` so existing
+JavaScript clients can continue to represent JSON integer cursors exactly.
+
+An operator first runs the preflight before draining to estimate the floor and
+validate scan cost. After write traffic and in-flight requests are drained, the
+operator reruns it authoritatively; no message-extra writer may resume between
+that final scan and transactional activation. The tool uses Redis
+`SCAN`/`HSCAN` (never `KEYS`) and bounded DB queries to find the observed
+maximum across:
+
+1. `message_extra.version`;
+2. matching legacy `seq.min_seq` rows; and
+3. every cached `messageExtraVersion:*` hash field.
+
+The task delivers an operator command under `tools/`: its default/read-only
+preflight computes these maxima and validates an operator-supplied floor; an
+explicit activation action performs only the guarded state-row transition
+described above. The chosen `cutover_floor` is strictly greater than the
+observed maximum, with documented
+headroom for future increments while remaining below the safe integer limit. If
+the observed maximum leaves no safe headroom, cutover fails closed and requires
+a separately approved cursor-wire migration. Preflight output records counts,
+maxima, and the selected floor without printing UIDs, source identifiers,
+channel IDs, or other Redis values. Startup logs and low-cardinality gauges
+expose the DB-authoritative mode, epoch, and floor.
+
+**Allocator cutover is one-way for normal rollback.** Business/application code
+may roll back only to a binary that still understands the state row and
+transactional allocator; DB mode remains `transactional`, and the version
+allocator is not rolled back. A pre-task binary is not a supported normal
+rollback target. This is intentional: returning a multi-replica deployment to
+the old HiLo allocator necessarily reopens the duplicate-range and commit-order
+defects fixed by this task.
+
+If a defect in the transactional allocator itself forces an emergency return to
+a pre-task binary, the runbook must use this explicitly degraded procedure:
+
+1. drain all message-extra writes, wait for in-flight requests, and scale every
+   octo-server replica to zero;
+2. for each legacy key (which is keyed by storage `channel_id` without
+   `channel_type`), compute one watermark equal to the maximum of legacy
+   `seq.min_seq`, `message_extra.version`, cached Redis client cursors, the state
+   row floor, and every `octo_message_extra_channel_seq.last_version` across all
+   channel types sharing that channel ID;
+3. upsert legacy `seq.min_seq` to at least that watermark, record the emergency
+   in the state row as `mode=legacy` with an incremented epoch, and verify no
+   watermark exceeds the JavaScript safe-integer boundary;
+4. start the pre-task binary at **exactly one replica**. Multi-replica legacy
+   mode is forbidden because watermark reconciliation cannot repair HiLo's
+   ongoing duplicate-block/commit-order behavior;
+5. before returning to transactional mode, drain and scale to zero again, rerun
+   the complete preflight, choose a new higher floor, increment the state epoch,
+   and perform the full transactional cutover. Existing channel rows adopt the
+   new floor per D3.
+
+Emergency legacy operation may still require targeted stale-client recovery and
+is not a normal availability-preserving rollback. The allocator must never be
+alternated while traffic is live.
+
+Existing `message_extra` rows remain valid and are not rewritten by the schema
+migration. The first transactional value is above the preflight-observed DB,
+legacy-seq, and cached-client maxima, so future mutations are visible to
+existing cursors. Automatically rewriting every historical row and fanning out
+every channel is deliberately excluded from this task because it can create an
+unbounded DB/WS storm and personal fake channels do not retain enough
+addressing data for a safe generic broadcast. The rollout runbook must state
+that already-stale clients require a separately approved recovery action
+(client full refresh/source reset, a targeted row bump through the new
+allocator, or a future exact-refresh protocol).
+
+## Load-bearing list
+
+- **Delta-sync cursor contract** — `version > cursor`, ascending pagination,
+  and client cursor advancement require unique commit order per storage
+  channel.
+- **Cross-replica transaction ordering** — sequence reservation and business
+  write are atomic and serialized through one InnoDB row per channel.
+- **All message-extra producers** — no writer may bypass the shared allocator;
+  a single legacy path can poison the cursor domain for every client.
+- **DB-authoritative allocator state** — every upgraded writer holds the
+  singleton state row in shared mode; a missing row defaults to legacy while an
+  invalid/unsupported/unreadable row fails closed, and only a guarded exclusive
+  transition changes mode/epoch/floor.
+- **Card correctness** — accepted terminal `card_seq` content remains
+  authoritative and becomes incrementally visible; CAS/replay behavior is not
+  weakened.
+- **Batch and lock discipline** — deterministic multi-channel/message ordering,
+  one range reservation per batch, and bounded whole-transaction retry prevent
+  deadlock amplification.
+- **Wire compatibility** — no request/response/CMD shape change and no required
+  client release.
+- **Multi-tenant boundaries** — storage-channel derivation and existing
+  Auth/Space/Bot ownership gates stay authoritative.
+- **Production migration** — online DDL assessment, no mixed allocator mode,
+  explicit drain/cutover/rollback, and a verified cutover-floor bootstrap.
+- **Operational visibility** — lock contention, retries, failures, batch sizes,
+  and invariant violations are observable without logging message content.
+
+## Out of scope
+
+- Changing octo-lib `GenSeq` or auditing every non-message-extra sequence user.
+- Replacing delta sync with an append-only change log, binlog/CDC stream, or a
+  composite cursor.
+- Adding content/message/version to `CMDSyncMessageExtra` or changing web,
+  desktop, iOS, or Android refresh behavior.
+- Changing the Redis cursor cache or defining reconnect/foreground source-reset
+  semantics.
+- Automatically re-versioning all historical `message_extra` rows during
+  migration or broadcasting a fleet-wide forced resync.
+- Changing card rendering, callback delivery, revision history, `card_seq`,
+  edit permissions, rate limits, or user-facing error codes.
+- Introducing a global distributed lock or leader election.
+- Treating a pre-task binary or the legacy HiLo allocator as a supported normal
+  rollback target after transactional activation.
+
+## Acceptance
+
+- A deterministic two-session MySQL integration test proves that two concurrent
+  transactions for the same storage channel commit with unique increasing
+  versions. The second allocator blocks behind the first sequence lock and
+  receives the next value only after the first commits.
+- A rollback test proves a failed business transaction leaves neither a
+  `message_extra` mutation nor a committed sequence advance visible.
+- A different-channel concurrency test proves sequence rows do not introduce a
+  global lock.
+- A personal-chat test proves the sequence key `channel_id` derived by the
+  allocator is byte-identical to the fake `message_extra.channel_id` persisted on
+  the same mutation, so the seq row and the delta-sync read path never diverge.
+- A batch test reserves N values once, assigns a deterministic contiguous range,
+  and paginates all resulting rows through repeated `version > cursor` reads
+  without duplicates or omissions.
+- A regression test reproduces the card scenario with two independent writer
+  contexts: after the client observes the intermediate frame, the accepted
+  terminal frame is returned by the next delta sync and has a greater version.
+- Card CAS tests continue to prove stale `card_seq` rejection, identical-frame
+  replay, mixed CAS/LWW behavior, and final-content correctness.
+- Focused tests cover user edit, bot edit, callback mutation, robot edit,
+  revoke/delete, pin, manager delete, and batched read-receipt writers using the
+  shared transactional allocator.
+- A source guard fails if any business writer calls `GenSeq` with
+  `common.MessageExtraSeqKey`, or if more than the single allowlisted
+  transitional legacy adapter contains that call.
+- First-use bootstrap tests cover: legacy seq row present, legacy row absent,
+  existing message-extra maximum above the legacy seq value, and two concurrent
+  initializers. The concurrent-initializer test asserts the loser reloads the
+  winning row (no 1062 leaking out, no private baseline, no init deadlock under
+  the repo's ambient isolation level).
+- Boundary tests prove allocation rejects `count <= 0`, `count > 1000`,
+  `int64` overflow, and crossing `2^53-1` without mutating the sequence or
+  business row. A test proves manager delete rejects an oversized `req.List`
+  (> 1000) through the existing localized error contract, and that read-receipt
+  materialization chunks a > 1000-message channel group into monotonic
+  reservations without gaps or duplicates.
+- Deadlock/lock-timeout tests prove one bounded whole-transaction retry policy
+  and no CMD before a successful commit.
+- Migration validation covers a clean database and a populated database,
+  verifies both new `octo_` tables plus the singleton legacy-mode seed row, and
+  verifies the new `(channel_id, channel_type, version)` index exists on
+  `message_extra`; the production DDL plan documents whether native online DDL
+  is supported or an external online-schema-change tool is required for that
+  index on the live table.
+- State-control integration tests prove concurrent upgraded writers can hold
+  compatible shared state locks, an exclusive cutover waits for in-flight
+  writers, and every write beginning after the flip selects transactional mode.
+  A missing state row defaults to legacy (write succeeds via GenSeq, transactional
+  table untouched); a duplicate row, an unrecognized `mode` value, a state read
+  failure, and an optional expected-mode mismatch all fail writes closed and mark
+  readiness unhealthy; a bumped `epoch` alone never fails a write; and no local
+  environment value can override DB mode.
+- Cutover-preflight/activation tests cover DB/legacy-seq/Redis maxima, stale or
+  regressed `seq.min_seq`, safe-integer overflow rejection, redacted output,
+  expected mode/epoch compare-and-set, atomic DB mode/floor/epoch transition,
+  and transactional refusal when DB state is missing or malformed.
+- Rollback tests prove normal application rollback keeps DB mode transactional
+  and accepts only a transactional-capable binary. Emergency-tool tests merge
+  all `channel_type` rows into the legacy channel-ID key, reconcile the maximum
+  DB/Redis/legacy/new-sequence watermark, require zero running replicas before
+  mutation, and require the next transactional activation to use a higher floor
+  and epoch. The runbook pins emergency legacy operation to one replica.
+- Allocator metrics and structured logs are asserted without message/card
+  content or credentials.
+- At minimum, focused suites pass for `./modules/message/...`,
+  `./modules/bot_api/...`, `./modules/robot/...`, and
+  `./internal/carddispatch/...`; broader `go test ./...` is run when the
+  MySQL/Redis/WuKongIM test environment is available.
+- The rollout artifact includes Prepare, drain, DB-state activation,
+  verification, normal transactional-capable application rollback, targeted
+  stale-client recovery, emergency single-replica legacy rollback, and full
+  re-cutover steps. Verification queries assert that no newly committed row
+  version is at or below the transactional channel's previous committed value,
+  every upgraded replica reports the DB mode/epoch/floor, no pre-task binary is
+  running, and invariant-violation metrics stay zero.

--- a/.octospec/tasks/message-extra-transactional-version/brief.md
+++ b/.octospec/tasks/message-extra-transactional-version/brief.md
@@ -132,12 +132,13 @@ VALUES (1, 0, 0, 0);
   behavior (existing `GenSeq`), which a deploy also sees before the migration
   seeds the row and which test setups leave after `CleanAllTables`; this is not
   fail-closed. An unrecognized `mode` value or an unreadable row **does** fail
-  closed. `epoch` is never a write-abort condition (see D3). Guarding against a
-  row deleted while in transactional mode is the job of the optional
-  expected-mode config check (D9), not this read; the mode gauge still surfaces
-  `legacy` so an operator can detect an unexpected state. Environment variables
-  may assert an expected mode for rollout diagnostics, but must never select an
-  allocator independently of this DB row.
+  closed. `epoch` is never a write-abort condition (see D3). A row deleted while
+  in transactional mode is guarded by the **expected-mode check** on the state
+  read (`OCTO_MESSAGE_EXTRA_VERSION_EXPECTED_MODE`): when a deployment declares
+  `transactional`, a resolved mode that is not transactional (including a missing
+  row → legacy) fails closed. Unset makes no assertion (pre-migration deploys and
+  test setups keep the legacy default). Environment variables assert an expected
+  mode but must never select an allocator independently of this DB row.
 - Separately, add on the **existing `message_extra` table** the composite index
   the delta-sync read path needs: `(channel_id, channel_type, version)`. Today
   `message_extra` carries only `channel_idx (channel_id, channel_type)`, so the

--- a/.octospec/tasks/message-extra-transactional-version/context.yaml
+++ b/.octospec/tasks/message-extra-transactional-version/context.yaml
@@ -1,0 +1,31 @@
+injected:
+  - id: error-handling
+    source: repo
+  - id: space-isolation
+    source: repo
+  - id: testing
+    source: repo
+brief: .octospec/tasks/message-extra-transactional-version/brief.md
+
+# PR-1 scope: schema migration (octo_message_extra_channel_seq +
+# octo_message_extra_version_state + message_extra composite index) and the new
+# leaf package internal/msgextraseq (ReserveTx / state dispatch / legacy adapter
+# / metrics). Production stays inert (mode=legacy). No writer cutover here.
+#
+# rule notes:
+#   - error-handling: allocator returns plain Go errors; user-facing envelope is
+#     the writer's job (PR-2 reuses existing errcode via httperr.ResponseErrorL).
+#     No raw responses introduced.
+#   - space-isolation: allocator takes an already-derived storage channel key and
+#     does no cross-Space lookup; ownership/Space gates stay in the callers (D6).
+#   - testing: real MySQL required; tests use testutil.NewTestServer +
+#     CleanAllTables; migration file follows modules/message/sql/ naming.
+#
+# API refinement flagged for human review (deviation from brief D3):
+#   ReserveTx returns []int64 (the assigned versions in order), NOT a single
+#   `first int64`. Rationale: a contiguous range is only guaranteeable in
+#   transactional mode (row lock). In legacy mode the values come from N
+#   ctx.GenSeq calls and are NOT contiguity-guaranteed under concurrency, so
+#   returning `first` + caller assigning first..first+N-1 would be unsafe during
+#   the Prepare window. []int64 is behavior-preserving in both modes and keeps
+#   callers mode-agnostic. brief D3 signature to be updated if accepted.

--- a/.octospec/tasks/message-extra-transactional-version/plan.md
+++ b/.octospec/tasks/message-extra-transactional-version/plan.md
@@ -1,0 +1,169 @@
+# Implementation plan — message-extra-transactional-version
+
+> 配套 `brief.md`(spec)。本文件只讲**落地步骤 / 文件清单 / 顺序**,不含代码。
+> 事实基线来自对现有写入方事务边界的源码勘察(见文末「勘察结论」)。
+
+## 进度(2026-07-21)
+
+- **PR-1 ✅ 完成**(未提交):迁移 `20260721000001_message_extra_version.sql` + 叶子包
+  `internal/msgextraseq`(store/metrics)+ 15 个集成测试(全绿、-race 干净、覆盖 78%)。
+  迁移经真实 sql-migrate 全量流程验证可 apply,建出的 `channel_id` collation =
+  utf8mb4_general_ci(与 message_extra 一致)。API 采纳 `[]int64`(brief D3 已同步)。
+- **PR-2a ✅ 代码+测试完成**(未提交):message 模块 6 处写入方全部经 `Store.ReserveTx`
+  收口;两个 autocommit 路径(mutualDelete/无 robot)已事务化;pin/revoke 锁序死锁已修
+  (seq 先于 pinned);批量路径(clearPinned/readed/manager)改为一次性区间预留 + 排序 key;
+  manager `req.List` 加 ≤1000 守卫;删除两处 `genMessageExtraSeq` 与死代码 `insertOrUpdateDeleted`。
+  新增 `modules/message/msgextra_writer_test.go`(3 测:分块 `reserveVersions`、legacy、
+  `insertOrUpdateDeletedTx` upsert)。全量 build/vet 干净;各包单独跑绿(message 包既有测试无回归)。
+  注:跨包 `go test ./...` 在本地共享未迁移 `test` 库下有 schema 耦合冲突(CI 全量迁移无此问题)。
+- **待办**:PR-2b(bot_api+carddispatch)、PR-2c(robot+源码守卫)、PR-4(preflight/activation 工具)、
+  PR-5(runbook);PR-2a/2b 的 writer 级 focused 测试(brief Acceptance)需在此后补齐。
+
+---
+
+## 0. 总体策略
+
+- **代码全部可在 `mode=legacy` 下先合并**:allocator 内部按 DB 状态行分流,legacy 分支仍调用 `ctx.GenSeq`,生产行为不变。真正的「cut over」是**运维动作**(跑工具翻转状态行),不是代码发布。
+- 按**叶子包 + 分流器**收口:所有写入方改成调用共享 `internal/msgextraseq.Store`,由它按 `mode` 决定走 legacy adapter 还是事务序列。源码守卫强制「除该 adapter 外无人再调 `GenSeq(MessageExtraSeqKey)`」。
+- 分 5 个可独立 review 的 PR(PR-2 再拆 3 个子 PR),源码守卫随**最后一个**写入方一起落地(否则守卫无法通过)。
+
+## 1. 落地顺序(PR 切分)
+
+```
+PR-1  schema + allocator 内核(inert)         ← 先行,生产无感
+  └─ PR-2a  message 模块写入方(7 处中的 6 处)
+       └─ PR-2b  bot_api + carddispatch(3 处,已近目标形态)
+            └─ PR-2c  robot(1 处)+ 源码守卫(allowlist 收口)
+  └─ PR-4  cutover preflight/activation 工具   ← 依赖 PR-1 的状态表
+  └─ PR-5  rollout runbook 文档
+────────────────────────────────────────────
+[运维] 全部合并+部署(mode=legacy)后,drain→跑工具翻 mode=transactional
+```
+
+PR-4/PR-5 与 PR-2 无代码依赖,可并行推进,只依赖 PR-1 的表结构。
+
+---
+
+## 2. PR-1 — schema + allocator 内核(生产 inert)
+
+### 2.1 迁移文件
+`modules/message/sql/20260721NNNNNN_message_extra_version.sql`(HHMMSS 序号按目录内既有最大值 +1;`--go:embed sql` 已覆盖)
+- `CREATE TABLE octo_message_extra_channel_seq`(per-channel 序列)
+- `CREATE TABLE octo_message_extra_version_state`(单例状态)+ seed `(1,0,0,0)`
+- **`message_extra` 上新增复合索引 `(channel_id, channel_type, version)`** —— 大表在线 DDL 项,单独一条 DDL 语句,便于运维用 OSC 工具单独处理。
+- 风格:内联 `PRIMARY KEY`/`KEY` + 列级 `COMMENT` + `ENGINE=InnoDB DEFAULT CHARSET=... COLLATE=... COMMENT=...`,对齐 `octo_message_card_revision`。
+- ⚠️ **开工前先实测** `message_extra.channel_id` 的**有效** charset/collation(它未显式声明,继承库默认),把 `octo_message_extra_channel_seq.channel_id` 钉成一致,不得假设 `utf8mb4_general_ci`。
+
+### 2.2 新叶子包 `internal/msgextraseq/`
+只依赖 octo-lib(`config.Context` / `GenSeq` / `DB`)+ `common`,**不 import 任何 `modules/*`**(勘察确认:message→robot、bot_api→carddispatch+robot、carddispatch 不 import 三者;叶子包对四者都安全)。文件建议:
+- `store.go` — `Store` 结构 + 构造(持 `*config.Context`)。
+- `reserve.go` — `ReserveTx(tx *dbr.Tx, channelID string, channelType uint8, count int) (first int64, err error)`:
+  1. `count` 校验(>0、≤ 上限);
+  2. state 行 `SELECT ... FOR SHARE`(见 `state.go`)→ 得 `(mode, epoch, floor)`;
+  3. `mode=legacy` → 调 `legacyAdapter`;`mode=transactional` → 事务序列;
+  4. 事务序列:init 竞争安全 upsert(`INSERT ... ON DUPLICATE KEY UPDATE last_version=last_version` 占位 → `SELECT ... FOR UPDATE` 复读)→ 首用 `last_version = max(floor, max(message_extra.version WHERE channel), legacy seq.min_seq)` → **每次分配先把 `last_version` 抬到 ≥ floor** → 加锁后判定接受再 `+count` → 返回 `old+1..old+count`;
+  5. 溢出守卫:`last_version+count > 2^53-1`(或 int64)在变更前失败。
+- `state.go` — 状态行读取 + fail-closed 规则(缺行/多行/未知 mode/读失败 → error;epoch 只读不校验);可选 expected-mode 断言。
+- `legacy_adapter.go` — **唯一允许**的 `ctx.GenSeq(MessageExtraSeqKey:channelID)` 调用点(源码守卫 allowlist 目标)。
+- `metrics.go` — D8 指标(reserve_total/seconds、lock_wait_seconds、state_lock_wait_seconds、batch_size、allocator_mode/epoch/cutover_floor gauge、invariant_violation_total)。
+
+### 2.3 隔离级别
+按仓库 ambient RR 设计;初始化竞争由 upsert 兜底。**不**在池化连接上裸 `SET TRANSACTION ISOLATION LEVEL`。
+
+### 2.4 PR-1 测试(`internal/msgextraseq/*_test.go`,需真 MySQL)
+两会话并发唯一递增 / 回滚不可见 / 异 channel 无全局锁 / 首用 bootstrap 四态 / 两并发 initializer(无 1062 外泄、无死锁)/ batch 一次预留连续区间 / 边界(count≤0、超上限、int64、2^53-1)。allocator 指标断言无内容泄漏。
+
+---
+
+## 3. PR-2 — 写入方 cutover(全 7 处走 Store)
+
+三类改造(按难度):
+
+**A. 已是「锁内分配」目标形态,最小改动(只换分配来源)** — 5a `cardSeqCASWrite`(send.go:1031)、5b `cardVersionInLockWrite`(send.go:1095)、6 `casWriteOnce`(carddispatch/mutation.go:263)。已在 tx 内、已持 `SELECT ... FOR UPDATE` 行锁、CAS 后才分配。改动:`GenSeq(...)` → `store.ReserveTx(tx, ...)`;并在 tx 顶部加 state 行 `FOR SHARE`(D4 锁序第 1)。
+
+**B. tx 已存在但 version 在锁外前置分配(挪进事务序、调锁序)** — 1a `messageEdit`(api.go:806,tx 933/991)、1c `revoke`(api.go:2981,tx 3106/3182)、2a `pinnedMessage`(api_pinned.go:25,tx 177/246)。改动:把 `genMessageExtraSeq` 从 tx 外前置调用改为 tx 内 `store.ReserveTx`,置于 state `FOR SHARE` 之后、写 message_extra 之前。
+
+**C. autocommit,需引入事务(工作量最大)** — 1b `mutualDelete`(api.go:2394,`insertOrUpdateDeleted` 用裸 session)、7 `botMessageEdit`(robot/api.go:1920,裸 `ctx.DB().InsertBySql`)。改动:`begin → state FOR SHARE → ReserveTx → mutate(tx) → commit → CMD`。需给 `insertOrUpdateDeleted` 增 tx 版本(`db_message_extra.go`),robot 裸 upsert 改成 tx 内。
+
+**批量路径(循环内逐条分配)** — 2b `clearPinnedMessage`(api_pinned.go:336)、3 `handleReadedMessageCount`(event.go:59,双层循环)、4 `Manager.delete`(api_manager.go:118)。改动:**先对 key 排序**(D4:map 迭代序不得决定锁序)→ 每 channel **一次** `ReserveTx(count=N)` 取连续区间 → 循环内按序赋值,不再逐条 round-trip。注:这些路径今天已是「每消息一个 GenSeq」→ 每行 version 本就不同,批量化是**减少往返 + 修锁序**,非修重复。
+
+**统一项**:
+- 回滚风格统一为 `defer tx.RollbackUnlessCommitted()`(老 handler 目前逐处手动 `tx.Rollback()`)。
+- 1213/1205 有界重试**只包整事务一层**(D4),不嵌套。
+- CMD/EventCommit 仍在 commit 之后。
+
+### 3.1 PR-2 子拆分
+- **PR-2a**:message 模块 6 处(1a/1b/1c/2a/2b/3/4)。含 `db_message_extra.go` 加 `insertOrUpdateDeletedTx`。
+- **PR-2b**:bot_api + carddispatch 3 处(5a/5b/6)。
+- **PR-2c**:robot 1 处(7)+ **源码守卫测试**(禁止 `GenSeq(common.MessageExtraSeqKey)` 出现在 `internal/msgextraseq/legacy_adapter.go` 以外)。守卫必须随最后一个写入方落地。
+
+### 3.2 PR-2 测试
+每写入方 focused 测试(user edit / bot edit / callback / robot / revoke / delete / pin / manager delete / 批量读回执)走事务序列;卡片 CAS 回归(stale 拒绝、同帧 replay、CAS/LWW 混合、终态内容正确);#627 卡片跨副本回归(中间帧被 observe 后终态帧 version 更大且可被下次 delta sync 拉到);死锁/超时重试与「commit 前不发 CMD」。
+
+---
+
+## 4. PR-4 — cutover preflight/activation 工具
+
+`tools/msgextra-version/`(新目录,读多写少,独立 main):
+- 默认/只读 **preflight**:Redis `SCAN`/`HSCAN`(禁 `KEYS`)+ 有界 DB 查询,求三源最大值(`message_extra.version` / 匹配 `seq.min_seq` / `messageExtraVersion:*` hash),校验 operator 给的 floor(严格 > 观测最大值、≤ 2^53-1、有余量);输出脱敏(不打 UID/source/channelID/Redis 值)。
+- **activation** 动作:短 `innodb_lock_wait_timeout` 会话 → state 行 `FOR UPDATE` → 断言 expected mode/epoch(CAS)→ 原子 set `mode=1, cutover_floor=F, epoch+1`。
+- **emergency** 动作:合并同 channel_id 所有 channel_type 的 watermark(DB/Redis/legacy/`octo_message_extra_channel_seq.last_version`/floor 取 max)→ upsert legacy `seq.min_seq` ≥ watermark → state 记 `mode=0, epoch+1` → 要求 0 running replica。
+
+### 4.1 PR-4 测试
+DB/legacy-seq/Redis 最大值、`seq.min_seq` 陈旧/倒退、2^53 溢出拒绝、脱敏、expected mode/epoch CAS、原子转换、state 缺失/损坏时事务态拒写;emergency watermark 合并 + 单副本约束 + 再 cutover 用更高 floor/epoch。
+
+---
+
+## 5. PR-5 — rollout runbook
+
+`.octospec/tasks/message-extra-transactional-version/runbook.md`(或 docs 目录):
+Prepare(建表建索引/部署双能力二进制/确认镜像与就绪)→ drain(停 message-extra 写、等在途)→ preflight 权威复跑 → activation → 校验(每副本上报 mode/epoch/floor、无 pre-task 二进制、invariant_violation=0、无新行 version ≤ 该 channel 前值)→ 正常应用回滚(只回退到 transactional-capable 二进制)→ 目标 stale-client recovery → 应急单副本 legacy + 再 cutover。
+
+---
+
+## 6. 开工前需实测/确认(阻塞项)—— 探查结果
+
+1. **`message_extra.channel_id` 有效 collation → `utf8mb4 / utf8mb4_general_ci`(已实测)。**
+   本地 `octo-test-mysql`(mysql:8.0)实测:`channel_id varchar(100) utf8mb4 utf8mb4_general_ci`、`channel_type smallint`;`octo_message_card_revision.channel_id` 同为 `utf8mb4_general_ci`。CI 亦显式用 `CREATE DATABASE ... COLLATE utf8mb4_general_ci` 重建 test 库(mysql:8.0 服务端默认是 `utf8mb4_0900_ai_ci`,被特意改成 general_ci 以兼容 legacy 表)。
+   → 新表 `channel_id` 钉 `VARCHAR(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci`。
+   ⚠️ **仍需在生产库确认一次**:`SELECT collation_name FROM information_schema.columns WHERE table_name='message_extra' AND column_name='channel_id'`。若生产历史库不是 general_ci(如老 utf8mb3),以生产实测值为准对齐,不要照抄本值。
+
+2. **MySQL 8.0(已确认)→ 复合索引原生在线,无需外部 OSC。**
+   CI `mysql:8.0` + 本地容器 `mysql:8.0`;仓库约定「8.0 ADD INDEX 默认在线,别 pin `ALGORITHM=INPLACE,LOCK=NONE`」。`message_extra` 加 `(channel_id,channel_type,version)` 走朴素 `CREATE INDEX` 即 INPLACE/LOCK=NONE 在线,不阻塞 DML,无需 gh-ost/pt-osc。
+   ⚠️ 大表 INPLACE 建索引仍会在负载下持续一段时间,运维应安排低峰窗口 + 监控;这是「时长」问题不是「阻塞」问题。
+
+3. **`count` 上限 → 建议常量 `1000`(对齐本模块既有分块幅度 api_manager.go:763)。** 三批量路径实测:
+   - **pin(2a/2b)**:每频道 ≤ `maxCount`(默认 **10**,`ChannelPinnedMessageMaxCount` 可配),天然远低于上限,无需额外处理。
+   - **manager 删除(4)**:`req.List` **客户端可控、当前仅 `len==0` 守卫、无上限** → 需加显式上限校验:`len(req.List) > 1000` 用既有本地化错误契约拒绝(或分块)。
+   - **读回执(3)**:每频道 group 大小 = 该 tick 内该频道待物化的消息数,**随流量累积、无硬上限**,且是内部路径不能丢 → **按 ≤1000 分块预留**(不 reject);同一频道多次 `ReserveTx` 仍单调。
+   → allocator `ReserveTx` 对 `count > 上限` 返回错误;调用方按语义选择「拒绝」(客户端输入)或「分块」(内部批量)。
+
+4. **叶子包命名 → 采用 `internal/msgextraseq`**(语义直白、与现有 `internal/carddispatch`/`internal/cardactiondispatch` 命名风格一致)。仅此一项为纯决策,无需探查。
+
+### 阻塞项状态:1/2/3 已探明并给出取值,3 附带发现「manager 删除批量无上限」应顺带修;仅生产库 collation 需上线前再确认一次(非本地可解)。
+
+## 7. 验收锚点(对齐 brief §Acceptance)
+
+至少 `./modules/message/... ./modules/bot_api/... ./modules/robot/... ./internal/carddispatch/... ./internal/msgextraseq/...` focused 通过;有 MySQL/Redis/WuKongIM 环境时跑 `go test ./...`;`golangci-lint run ./...`;`make i18n-extract-check` + `make i18n-lint`(未新增错误码,但改动了 message 模块 handler 需过 D23 守卫)。
+
+---
+
+## 附:写入方事务边界勘察结论
+
+| # | 函数 (文件:行) | 事务 | Begin/Commit | version 分配 | 改造类 |
+|---|---|---|---|---|---|
+| 1a | `messageEdit` api.go:806 | tx | 933/991 | 事务内(锁外前置) | B |
+| 1b | `mutualDelete` api.go:2394 | **autocommit** | 无 | 裸调用前 | **C** |
+| 1c | `revoke` api.go:2981 | tx | 3106/3182 | 事务内(锁外前置) | B |
+| 2a | `pinnedMessage` api_pinned.go:25 | tx | 177/246 | 事务内(锁外前置) | B |
+| 2b | `clearPinnedMessage` api_pinned.go:336 | tx | 463/507 | 事务内,循环逐条 | B+批量 |
+| 3 | `handleReadedMessageCount` event.go:59 | tx | 122/221 | 事务内,双层循环 | B+批量 |
+| 4 | `Manager.delete` api_manager.go:118 | tx | 184/274 | 事务内,循环逐条 | B+批量 |
+| 5a | `cardSeqCASWrite` send.go:1031 | tx | 1039/1074 | **锁内**(目标形态) | A |
+| 5b | `cardVersionInLockWrite` send.go:1095 | tx | 1096/1119 | **锁内** | A |
+| 6 | `casWriteOnce` mutation.go:263 | tx | 264/297 | **锁内** | A |
+| 7 | `botMessageEdit` robot/api.go:1920 | **autocommit** | 无 | 裸 insert 前 | **C** |
+
+依赖方向:`message→robot`;`bot_api→carddispatch+robot`;`carddispatch→{botidentity,group,thread}`(不 import 三者)。→ 共享包必须是不 import `modules/*` 的叶子包。
+
+dbr 事务范例:`ctx.DB().Begin()` / `session.Begin()` + `defer tx.RollbackUnlessCommitted()` + `tx.Commit()`(最贴目标形态:`internal/carddispatch/mutation.go:264-297`)。

--- a/internal/msgextraseq/metrics.go
+++ b/internal/msgextraseq/metrics.go
@@ -1,0 +1,88 @@
+package msgextraseq
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+// 本文件登记共享 message_extra 版本分配器的 Prometheus 指标(brief D8)。
+//
+// 设计取舍:
+//   - 注册到全局默认 Registry(promauto.New*),由基础设施 PR 暴露 /metrics。
+//   - 低基维:绝不加 channel_id / uid label(会爆 Prometheus)。reserve_total 仅
+//     带 result 维度切分成功/重试/失败。
+//   - lock_wait 与 state_lock_wait 分开:前者是每频道 sequence 行 X 锁,后者是全局
+//     state 行 S 锁(brief C2:后者互相兼容,单独观测其争用)。
+//   - mode/epoch/floor 为 gauge,启用后由每次 state 读刷新,反映当前生效的分配代。
+
+const metricNamespace = "message_extra_version"
+
+var (
+	// reserve 结果计数。result=success|retry|failure。retry 由调用方在整事务
+	// 1213/1205 重试时上报;分配器本身只区分 success/failure。
+	metricReserveTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: metricNamespace,
+		Name:      "reserve_total",
+		Help:      "message_extra version reservations by result",
+	}, []string{"result"})
+
+	// 一次 ReserveTx 全程耗时(含 state 读 + 序列锁 + 分配)。
+	metricReserveSeconds = promauto.NewHistogram(prometheus.HistogramOpts{
+		Namespace: metricNamespace,
+		Name:      "reserve_seconds",
+		Help:      "wall time of a single ReserveTx call",
+		Buckets:   prometheus.DefBuckets,
+	})
+
+	// 获取每频道 sequence 行 FOR UPDATE 的等待耗时(近似:SELECT ... FOR UPDATE 时长)。
+	metricLockWaitSeconds = promauto.NewHistogram(prometheus.HistogramOpts{
+		Namespace: metricNamespace,
+		Name:      "lock_wait_seconds",
+		Help:      "wait to acquire the per-channel sequence row lock",
+		Buckets:   prometheus.DefBuckets,
+	})
+
+	// 获取全局 state 行 FOR SHARE 的等待耗时(与 sequence 锁分开,brief C2)。
+	metricStateLockWaitSeconds = promauto.NewHistogram(prometheus.HistogramOpts{
+		Namespace: metricNamespace,
+		Name:      "state_lock_wait_seconds",
+		Help:      "wait to acquire the shared allocator-state row lock",
+		Buckets:   prometheus.DefBuckets,
+	})
+
+	// 每次预留的批量大小(count)。
+	metricBatchSize = promauto.NewHistogram(prometheus.HistogramOpts{
+		Namespace: metricNamespace,
+		Name:      "batch_size",
+		Help:      "count requested per ReserveTx call",
+		Buckets:   []float64{1, 2, 5, 10, 50, 100, 500, 1000},
+	})
+
+	// 当前生效的 allocator 模式(0=legacy,1=transactional)。每次 state 读刷新。
+	metricAllocatorMode = promauto.NewGauge(prometheus.GaugeOpts{
+		Namespace: metricNamespace,
+		Name:      "allocator_mode",
+		Help:      "active allocator mode: 0=legacy, 1=transactional",
+	})
+
+	// 当前 allocator 代(state.epoch)。仅观测,不参与判定(brief C1)。
+	metricAllocatorEpoch = promauto.NewGauge(prometheus.GaugeOpts{
+		Namespace: metricNamespace,
+		Name:      "allocator_epoch",
+		Help:      "active allocator epoch (observability only)",
+	})
+
+	// 当前生效的 cutover_floor。
+	metricCutoverFloor = promauto.NewGauge(prometheus.GaugeOpts{
+		Namespace: metricNamespace,
+		Name:      "cutover_floor",
+		Help:      "active transactional cutover floor",
+	})
+
+	// 防御性不变量违反计数:观测到候选版本未严格大于锁定行、或分配后行消失等。
+	metricInvariantViolationTotal = promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: metricNamespace,
+		Name:      "invariant_violation_total",
+		Help:      "defensive invariant violations observed by the allocator",
+	})
+)

--- a/internal/msgextraseq/metrics.go
+++ b/internal/msgextraseq/metrics.go
@@ -58,12 +58,13 @@ var (
 		Buckets:   []float64{1, 2, 5, 10, 50, 100, 500, 1000},
 	})
 
-	// 当前生效的 allocator 模式(0=legacy,1=transactional)。每次 state 读刷新。
-	metricAllocatorMode = promauto.NewGauge(prometheus.GaugeOpts{
+	// 当前生效的 allocator 模式,带 mode label(D8 契约:mode=legacy|transactional)。
+	// 每次 state 读把生效模式置 1、另一个置 0,dashboard 可稳定枚举两条序列。
+	metricAllocatorMode = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: metricNamespace,
 		Name:      "allocator_mode",
-		Help:      "active allocator mode: 0=legacy, 1=transactional",
-	})
+		Help:      "active allocator mode (1 on the active label)",
+	}, []string{"mode"})
 
 	// 当前 allocator 代(state.epoch)。仅观测,不参与判定(brief C1)。
 	metricAllocatorEpoch = promauto.NewGauge(prometheus.GaugeOpts{
@@ -86,3 +87,16 @@ var (
 		Help:      "defensive invariant violations observed by the allocator",
 	})
 )
+
+// setAllocatorModeGauge sets the active mode label to 1 and the other to 0, so
+// both series are always present for dashboards (D8 mode=legacy|transactional).
+func setAllocatorModeGauge(mode int) {
+	legacy, transactional := 0.0, 0.0
+	if mode == ModeTransactional {
+		transactional = 1
+	} else {
+		legacy = 1
+	}
+	metricAllocatorMode.WithLabelValues("legacy").Set(legacy)
+	metricAllocatorMode.WithLabelValues("transactional").Set(transactional)
+}

--- a/internal/msgextraseq/store.go
+++ b/internal/msgextraseq/store.go
@@ -1,0 +1,360 @@
+package msgextraseq
+
+// Package msgextraseq is the shared, transactional message_extra version
+// allocator for octo-server (#627). It is a leaf package: it depends only on
+// octo-lib (config.Context / GenSeq / DB) and common, and imports no modules/*
+// package, so modules/message, modules/bot_api, modules/robot and
+// internal/carddispatch can all import it without an import cycle.
+//
+// The allocator is selected at runtime by the DB-authoritative state row
+// octo_message_extra_version_state (brief D2/D9). In mode=legacy it delegates to
+// the process-local octo-lib GenSeq HiLo allocator (the single allowlisted
+// GenSeq(MessageExtraSeqKey) call site in the codebase); in mode=transactional
+// it reserves versions from octo_message_extra_channel_seq under a row lock held
+// until the caller commits, so commit order == version order and versions are
+// unique per storage channel across replicas.
+//
+// The caller starts and owns the business transaction. ReserveTx never opens or
+// commits an independent transaction, and holds every lock it takes until the
+// caller commits/rolls back.
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	liblog "github.com/Mininglamp-OSS/octo-lib/pkg/log"
+	"github.com/go-sql-driver/mysql"
+	"github.com/gocraft/dbr/v2"
+	"go.uber.org/zap"
+)
+
+// Allocator modes, mirroring octo_message_extra_version_state.mode.
+const (
+	ModeLegacy        = 0
+	ModeTransactional = 1
+)
+
+// stateSingletonID is the fixed primary key of the single allocator-state row.
+const stateSingletonID = 1
+
+// MaxReserveCount bounds a single reservation (brief D3). It matches this
+// module's existing chunk magnitude (api_manager.go). Callers that exceed it
+// either reject client input or reserve in chunks.
+const MaxReserveCount = 1000
+
+// maxSafeInteger is 2^53-1: the largest integer a JavaScript client can
+// represent exactly in JSON. Versions must never cross it (brief D3/D9).
+const maxSafeInteger int64 = 1<<53 - 1
+
+// Sentinel errors. Callers map these to their existing localized error contract;
+// the allocator never writes an HTTP response itself (error-handling rule).
+var (
+	// ErrInvalidCount is returned when count <= 0 or count > MaxReserveCount.
+	ErrInvalidCount = errors.New("msgextraseq: count out of range")
+	// ErrOverflow is returned when a reservation would cross maxSafeInteger.
+	ErrOverflow = errors.New("msgextraseq: version would exceed 2^53-1")
+	// ErrUnknownMode is returned when the state row carries an unrecognized mode.
+	ErrUnknownMode = errors.New("msgextraseq: unknown allocator mode")
+	// ErrInvariantViolation is returned when a defensive post-write check fails.
+	ErrInvariantViolation = errors.New("msgextraseq: allocator invariant violated")
+)
+
+// State is the decoded allocator-state row. epoch is surfaced for observability
+// only and is never a write-abort condition (brief C1).
+type State struct {
+	Mode         int
+	Epoch        uint64
+	CutoverFloor int64
+}
+
+// Store is the shared allocator. Construct with New and reuse; it is safe for
+// concurrent use (all mutable state lives in MySQL).
+type Store struct {
+	ctx    *config.Context
+	logger interface {
+		Error(string, ...zap.Field)
+		Warn(string, ...zap.Field)
+	}
+}
+
+// New builds a Store bound to the given octo-lib context.
+func New(ctx *config.Context) *Store {
+	return &Store{ctx: ctx, logger: liblog.NewTLog("MsgExtraSeq")}
+}
+
+// ReserveTx reserves count message_extra versions for the given storage channel
+// within the caller's transaction and returns them in assignment order.
+//
+// The returned slice always has len == count. In transactional mode the values
+// are a contiguous ascending range; in legacy mode they are count distinct
+// values from GenSeq (contiguity is not guaranteed under concurrency, matching
+// pre-task behavior). Returning explicit per-item values — rather than a single
+// "first" — keeps callers mode-agnostic and behavior-preserving across the
+// Prepare window; see context.yaml.
+//
+// channelID must be the already-derived storage-channel id (personal chats pass
+// the fake channel id). The allocator does no Space/ownership lookup; those
+// gates stay in the caller (brief D6, space-isolation rule).
+func (s *Store) ReserveTx(tx *dbr.Tx, channelID string, channelType uint8, count int) ([]int64, error) {
+	start := time.Now()
+	if count <= 0 || count > MaxReserveCount {
+		metricReserveTotal.WithLabelValues("failure").Inc()
+		return nil, ErrInvalidCount
+	}
+	metricBatchSize.Observe(float64(count))
+
+	st, err := s.readStateForShare(tx)
+	if err != nil {
+		metricReserveTotal.WithLabelValues("failure").Inc()
+		s.logFailure("state", channelID, channelType, err)
+		return nil, err
+	}
+
+	var versions []int64
+	switch st.Mode {
+	case ModeLegacy:
+		versions, err = s.reserveLegacy(channelID, count)
+	case ModeTransactional:
+		versions, err = s.reserveTransactional(tx, channelID, channelType, count, st.CutoverFloor)
+	default:
+		metricReserveTotal.WithLabelValues("failure").Inc()
+		s.logFailure("state", channelID, channelType, fmt.Errorf("%w: %d", ErrUnknownMode, st.Mode))
+		return nil, ErrUnknownMode
+	}
+	if err != nil {
+		metricReserveTotal.WithLabelValues("failure").Inc()
+		return nil, err
+	}
+
+	metricReserveTotal.WithLabelValues("success").Inc()
+	metricReserveSeconds.Observe(time.Since(start).Seconds())
+	return versions, nil
+}
+
+// readStateForShare loads the singleton allocator-state row under a shared lock
+// held until the caller's transaction ends. The shared lock is the drain
+// barrier for cutover: it is compatible across writers, but the exclusive
+// cutover flip waits for all in-flight writers (brief D3/D9). A missing row
+// defaults to legacy (the safe pre-task/pre-migration default); an unrecognized
+// mode value or an unreadable row fails closed; epoch is not validated.
+func (s *Store) readStateForShare(tx *dbr.Tx) (State, error) {
+	lockStart := time.Now()
+	var row struct {
+		Mode         int   `db:"mode"`
+		Epoch        int64 `db:"epoch"`
+		CutoverFloor int64 `db:"cutover_floor"`
+	}
+	err := tx.SelectBySql(
+		"SELECT `mode`, `epoch`, `cutover_floor` FROM `octo_message_extra_version_state` WHERE `singleton_id`=? FOR SHARE",
+		stateSingletonID,
+	).LoadOne(&row)
+	metricStateLockWaitSeconds.Observe(time.Since(lockStart).Seconds())
+	if err != nil {
+		if errors.Is(err, dbr.ErrNotFound) {
+			// A missing state row defaults to legacy — the safe pre-task behavior
+			// (GenSeq), which is also what a deploy sees before the migration seeds
+			// the row, and what test setups leave after CleanAllTables. This is NOT
+			// fail-closed: legacy is the conservative default. Guarding against a row
+			// deleted while in transactional mode is the job of the optional
+			// expected-mode config check (D9), not this read. The gauge below still
+			// surfaces mode=legacy so an operator can detect an unexpected state.
+			st := State{Mode: ModeLegacy}
+			metricAllocatorMode.Set(float64(st.Mode))
+			metricCutoverFloor.Set(0)
+			return st, nil
+		}
+		return State{}, fmt.Errorf("msgextraseq: read state: %w", err)
+	}
+	if row.Mode != ModeLegacy && row.Mode != ModeTransactional {
+		return State{}, fmt.Errorf("%w: %d", ErrUnknownMode, row.Mode)
+	}
+	st := State{Mode: row.Mode, Epoch: uint64(row.Epoch), CutoverFloor: row.CutoverFloor}
+	// Refresh observability gauges from the authoritative row.
+	metricAllocatorMode.Set(float64(st.Mode))
+	metricAllocatorEpoch.Set(float64(st.Epoch))
+	metricCutoverFloor.Set(float64(st.CutoverFloor))
+	return st, nil
+}
+
+// reserveLegacy delegates to the process-local octo-lib GenSeq allocator. This
+// is the ONLY call site allowed to call GenSeq with MessageExtraSeqKey; the
+// source-guard test (PR-2c) enforces the allowlist. count GenSeq calls yield
+// count distinct values, matching pre-task per-message behavior.
+func (s *Store) reserveLegacy(channelID string, count int) ([]int64, error) {
+	key := fmt.Sprintf("%s:%s", common.MessageExtraSeqKey, channelID)
+	versions := make([]int64, 0, count)
+	for i := 0; i < count; i++ {
+		v, err := s.ctx.GenSeq(key)
+		if err != nil {
+			return nil, fmt.Errorf("msgextraseq: legacy GenSeq: %w", err)
+		}
+		versions = append(versions, v)
+	}
+	return versions, nil
+}
+
+// reserveTransactional locks the per-channel sequence row FOR UPDATE, raises it
+// to at least the cutover floor, advances it by count, and returns the
+// contiguous range. The lock is held until the caller commits (brief D3/D4).
+func (s *Store) reserveTransactional(tx *dbr.Tx, channelID string, channelType uint8, count int, floor int64) ([]int64, error) {
+	cur, err := s.lockSequenceRow(tx, channelID, channelType, floor)
+	if err != nil {
+		return nil, err
+	}
+	// Per-allocation floor raise: makes a later (higher) cutover safe even when
+	// the per-channel row survived an emergency legacy interval (brief D3).
+	if cur < floor {
+		cur = floor
+	}
+	// Overflow guard before any mutation (brief D3): preserve exact JS cursors.
+	if cur > maxSafeInteger-int64(count) {
+		s.logFailure("reserve", channelID, channelType, ErrOverflow)
+		return nil, ErrOverflow
+	}
+	next := cur + int64(count)
+
+	res, err := tx.UpdateBySql(
+		"UPDATE `octo_message_extra_channel_seq` SET `last_version`=? WHERE `channel_id`=? AND `channel_type`=?",
+		next, channelID, channelType,
+	).Exec()
+	if err != nil {
+		s.logFailure("write", channelID, channelType, err)
+		return nil, fmt.Errorf("msgextraseq: advance sequence: %w", err)
+	}
+	if n, aerr := res.RowsAffected(); aerr == nil && n == 0 {
+		// The row we locked vanished — should be impossible under the lock.
+		metricInvariantViolationTotal.Inc()
+		s.logFailure("write", channelID, channelType, ErrInvariantViolation)
+		return nil, ErrInvariantViolation
+	}
+
+	versions := make([]int64, count)
+	for i := 0; i < count; i++ {
+		versions[i] = cur + int64(i) + 1
+	}
+	return versions, nil
+}
+
+// lockSequenceRow returns the current last_version for the channel with the
+// sequence row locked FOR UPDATE. If the row does not exist it is initialized
+// concurrency-safely (brief D3): a race-safe upsert materializes it at the
+// bootstrap baseline, then a locking re-read returns the winning row so a
+// duplicate initializer never proceeds on a private baseline.
+func (s *Store) lockSequenceRow(tx *dbr.Tx, channelID string, channelType uint8, floor int64) (int64, error) {
+	lockStart := time.Now()
+	cur, found, err := s.selectSequenceForUpdate(tx, channelID, channelType)
+	if err != nil {
+		s.logFailure("lock", channelID, channelType, err)
+		return 0, err
+	}
+	if found {
+		metricLockWaitSeconds.Observe(time.Since(lockStart).Seconds())
+		return cur, nil
+	}
+
+	// First use: compute the bootstrap baseline, materialize the row race-safely,
+	// then re-read under the lock.
+	baseline, err := s.computeBootstrap(tx, channelID, channelType, floor)
+	if err != nil {
+		s.logFailure("initialize", channelID, channelType, err)
+		return 0, err
+	}
+	if _, err := tx.InsertBySql(
+		"INSERT INTO `octo_message_extra_channel_seq` (`channel_id`,`channel_type`,`last_version`) VALUES (?,?,?) ON DUPLICATE KEY UPDATE `last_version`=`last_version`",
+		channelID, channelType, baseline,
+	).Exec(); err != nil {
+		s.logFailure("initialize", channelID, channelType, err)
+		return 0, fmt.Errorf("msgextraseq: initialize sequence: %w", err)
+	}
+	cur, found, err = s.selectSequenceForUpdate(tx, channelID, channelType)
+	if err != nil {
+		s.logFailure("lock", channelID, channelType, err)
+		return 0, err
+	}
+	if !found {
+		// Row must exist after the upsert; treat as an invariant violation.
+		metricInvariantViolationTotal.Inc()
+		s.logFailure("initialize", channelID, channelType, ErrInvariantViolation)
+		return 0, ErrInvariantViolation
+	}
+	metricLockWaitSeconds.Observe(time.Since(lockStart).Seconds())
+	return cur, nil
+}
+
+// selectSequenceForUpdate reads and locks the channel sequence row. found is
+// false (with nil error) when the row does not yet exist.
+func (s *Store) selectSequenceForUpdate(tx *dbr.Tx, channelID string, channelType uint8) (int64, bool, error) {
+	var row struct {
+		LastVersion int64 `db:"last_version"`
+	}
+	err := tx.SelectBySql(
+		"SELECT `last_version` FROM `octo_message_extra_channel_seq` WHERE `channel_id`=? AND `channel_type`=? FOR UPDATE",
+		channelID, channelType,
+	).LoadOne(&row)
+	if err != nil {
+		if errors.Is(err, dbr.ErrNotFound) {
+			return 0, false, nil
+		}
+		return 0, false, fmt.Errorf("msgextraseq: lock sequence: %w", err)
+	}
+	return row.LastVersion, true, nil
+}
+
+// computeBootstrap derives the first-use baseline as the maximum of the cutover
+// floor, the current maximum message_extra.version for the channel, and the
+// legacy octo-lib seq.min_seq for the corresponding MessageExtraSeqKey channel
+// key (brief D3). The legacy value is evidence, not a safety boundary; the floor
+// is the authoritative one.
+func (s *Store) computeBootstrap(tx *dbr.Tx, channelID string, channelType uint8, floor int64) (int64, error) {
+	baseline := floor
+
+	var maxExtra int64
+	if err := tx.SelectBySql(
+		"SELECT COALESCE(MAX(`version`),0) FROM `message_extra` WHERE `channel_id`=? AND `channel_type`=?",
+		channelID, channelType,
+	).LoadOne(&maxExtra); err != nil && !errors.Is(err, dbr.ErrNotFound) {
+		return 0, fmt.Errorf("msgextraseq: bootstrap max message_extra: %w", err)
+	}
+	if maxExtra > baseline {
+		baseline = maxExtra
+	}
+
+	// Legacy seq key has no channel_type: seq.key = "seq:messageExtra:<channelID>".
+	legacyKey := fmt.Sprintf("seq:%s:%s", common.MessageExtraSeqKey, channelID)
+	var legacyMin int64
+	if err := tx.SelectBySql(
+		"SELECT COALESCE(`min_seq`,0) FROM `seq` WHERE `key`=?",
+		legacyKey,
+	).LoadOne(&legacyMin); err != nil && !errors.Is(err, dbr.ErrNotFound) {
+		return 0, fmt.Errorf("msgextraseq: bootstrap legacy seq: %w", err)
+	}
+	if legacyMin > baseline {
+		baseline = legacyMin
+	}
+	return baseline, nil
+}
+
+// logFailure emits a redacted structured failure log (brief D8): channel key,
+// stage, and MySQL error number only — never message/card content or payloads.
+func (s *Store) logFailure(stage, channelID string, channelType uint8, err error) {
+	s.logger.Error("message_extra version allocation failed",
+		zap.String("stage", stage),
+		zap.String("channel_id", channelID),
+		zap.Uint8("channel_type", channelType),
+		zap.Uint16("mysql_errno", mysqlErrno(err)),
+		zap.Error(err),
+	)
+}
+
+// mysqlErrno best-effort extracts the MySQL error number for logging; 0 when the
+// error is not a driver error.
+func mysqlErrno(err error) uint16 {
+	var myErr *mysql.MySQLError
+	if errors.As(err, &myErr) {
+		return myErr.Number
+	}
+	return 0
+}

--- a/internal/msgextraseq/store.go
+++ b/internal/msgextraseq/store.go
@@ -100,6 +100,9 @@ func New(ctx *config.Context) *Store {
 // gates stay in the caller (brief D6, space-isolation rule).
 func (s *Store) ReserveTx(tx *dbr.Tx, channelID string, channelType uint8, count int) ([]int64, error) {
 	start := time.Now()
+	// Observe latency on every path (success, failure, blocked) so failed/blocked
+	// reservations are not excluded from the histogram.
+	defer func() { metricReserveSeconds.Observe(time.Since(start).Seconds()) }()
 	if count <= 0 || count > MaxReserveCount {
 		metricReserveTotal.WithLabelValues("failure").Inc()
 		return nil, ErrInvalidCount
@@ -130,7 +133,6 @@ func (s *Store) ReserveTx(tx *dbr.Tx, channelID string, channelType uint8, count
 	}
 
 	metricReserveTotal.WithLabelValues("success").Inc()
-	metricReserveSeconds.Observe(time.Since(start).Seconds())
 	return versions, nil
 }
 
@@ -162,7 +164,7 @@ func (s *Store) readStateForShare(tx *dbr.Tx) (State, error) {
 			// expected-mode config check (D9), not this read. The gauge below still
 			// surfaces mode=legacy so an operator can detect an unexpected state.
 			st := State{Mode: ModeLegacy}
-			metricAllocatorMode.Set(float64(st.Mode))
+			setAllocatorModeGauge(st.Mode)
 			metricCutoverFloor.Set(0)
 			return st, nil
 		}
@@ -173,7 +175,7 @@ func (s *Store) readStateForShare(tx *dbr.Tx) (State, error) {
 	}
 	st := State{Mode: row.Mode, Epoch: uint64(row.Epoch), CutoverFloor: row.CutoverFloor}
 	// Refresh observability gauges from the authoritative row.
-	metricAllocatorMode.Set(float64(st.Mode))
+	setAllocatorModeGauge(st.Mode)
 	metricAllocatorEpoch.Set(float64(st.Epoch))
 	metricCutoverFloor.Set(float64(st.CutoverFloor))
 	return st, nil
@@ -241,47 +243,71 @@ func (s *Store) reserveTransactional(tx *dbr.Tx, channelID string, channelType u
 // lockSequenceRow returns the current last_version for the channel with the
 // sequence row locked FOR UPDATE. If the row does not exist it is initialized
 // concurrency-safely (brief D3): a race-safe upsert materializes it at the
-// bootstrap baseline, then a locking re-read returns the winning row so a
-// duplicate initializer never proceeds on a private baseline.
+// bootstrap baseline, then the locking read below locks an already-existing row.
+//
+// Ordering matters for deadlock-freedom: we must NEVER issue SELECT ... FOR
+// UPDATE against a not-yet-existing row. Under REPEATABLE READ that takes a gap
+// lock, and two concurrent first-use initializers holding compatible gap locks
+// deadlock (MySQL 1213) on the subsequent insert. So a non-locking existence
+// read gates the materialize step, and the FOR UPDATE only ever targets a row
+// that already exists (a record lock — no gap, no first-use deadlock).
 func (s *Store) lockSequenceRow(tx *dbr.Tx, channelID string, channelType uint8, floor int64) (int64, error) {
 	lockStart := time.Now()
+	if _, found, err := s.selectSequence(tx, channelID, channelType); err != nil {
+		s.logFailure("lock", channelID, channelType, err)
+		return 0, err
+	} else if !found {
+		// First use: compute the bootstrap baseline and materialize the row with a
+		// race-safe upsert. INSERT ... ON DUPLICATE KEY UPDATE serializes concurrent
+		// initializers on the row/insert-intention lock (they wait, they do not
+		// deadlock) and never leaves a duplicate initializer on a private baseline.
+		baseline, berr := s.computeBootstrap(tx, channelID, channelType, floor)
+		if berr != nil {
+			s.logFailure("initialize", channelID, channelType, berr)
+			return 0, berr
+		}
+		if _, ierr := tx.InsertBySql(
+			"INSERT INTO `octo_message_extra_channel_seq` (`channel_id`,`channel_type`,`last_version`) VALUES (?,?,?) ON DUPLICATE KEY UPDATE `last_version`=`last_version`",
+			channelID, channelType, baseline,
+		).Exec(); ierr != nil {
+			s.logFailure("initialize", channelID, channelType, ierr)
+			return 0, fmt.Errorf("msgextraseq: initialize sequence: %w", ierr)
+		}
+	}
+	// The row now exists (pre-existing or just materialized): lock it.
 	cur, found, err := s.selectSequenceForUpdate(tx, channelID, channelType)
 	if err != nil {
 		s.logFailure("lock", channelID, channelType, err)
 		return 0, err
 	}
-	if found {
-		metricLockWaitSeconds.Observe(time.Since(lockStart).Seconds())
-		return cur, nil
-	}
-
-	// First use: compute the bootstrap baseline, materialize the row race-safely,
-	// then re-read under the lock.
-	baseline, err := s.computeBootstrap(tx, channelID, channelType, floor)
-	if err != nil {
-		s.logFailure("initialize", channelID, channelType, err)
-		return 0, err
-	}
-	if _, err := tx.InsertBySql(
-		"INSERT INTO `octo_message_extra_channel_seq` (`channel_id`,`channel_type`,`last_version`) VALUES (?,?,?) ON DUPLICATE KEY UPDATE `last_version`=`last_version`",
-		channelID, channelType, baseline,
-	).Exec(); err != nil {
-		s.logFailure("initialize", channelID, channelType, err)
-		return 0, fmt.Errorf("msgextraseq: initialize sequence: %w", err)
-	}
-	cur, found, err = s.selectSequenceForUpdate(tx, channelID, channelType)
-	if err != nil {
-		s.logFailure("lock", channelID, channelType, err)
-		return 0, err
-	}
 	if !found {
-		// Row must exist after the upsert; treat as an invariant violation.
+		// Must exist after the upsert; a vanished row is an invariant violation.
 		metricInvariantViolationTotal.Inc()
 		s.logFailure("initialize", channelID, channelType, ErrInvariantViolation)
 		return 0, ErrInvariantViolation
 	}
 	metricLockWaitSeconds.Observe(time.Since(lockStart).Seconds())
 	return cur, nil
+}
+
+// selectSequence reads the channel sequence row WITHOUT locking (no FOR UPDATE),
+// so a missing row does not take a gap lock. found is false (nil error) when the
+// row does not exist.
+func (s *Store) selectSequence(tx *dbr.Tx, channelID string, channelType uint8) (int64, bool, error) {
+	var row struct {
+		LastVersion int64 `db:"last_version"`
+	}
+	err := tx.SelectBySql(
+		"SELECT `last_version` FROM `octo_message_extra_channel_seq` WHERE `channel_id`=? AND `channel_type`=?",
+		channelID, channelType,
+	).LoadOne(&row)
+	if err != nil {
+		if errors.Is(err, dbr.ErrNotFound) {
+			return 0, false, nil
+		}
+		return 0, false, fmt.Errorf("msgextraseq: read sequence: %w", err)
+	}
+	return row.LastVersion, true, nil
 }
 
 // selectSequenceForUpdate reads and locks the channel sequence row. found is

--- a/internal/msgextraseq/store.go
+++ b/internal/msgextraseq/store.go
@@ -8,9 +8,11 @@ package msgextraseq
 //
 // The allocator is selected at runtime by the DB-authoritative state row
 // octo_message_extra_version_state (brief D2/D9). In mode=legacy it delegates to
-// the process-local octo-lib GenSeq HiLo allocator (the single allowlisted
-// GenSeq(MessageExtraSeqKey) call site in the codebase); in mode=transactional
-// it reserves versions from octo_message_extra_channel_seq under a row lock held
+// the process-local octo-lib GenSeq HiLo allocator; reserveLegacy here will
+// become the single allowlisted GenSeq(MessageExtraSeqKey) call site once the
+// existing production callers are migrated and the PR-2c source-guard test lands
+// (today those callers still call GenSeq directly). In mode=transactional it
+// reserves versions from octo_message_extra_channel_seq under a row lock held
 // until the caller commits, so commit order == version order and versions are
 // unique per storage channel across replicas.
 //
@@ -21,6 +23,7 @@ package msgextraseq
 import (
 	"errors"
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/Mininglamp-OSS/octo-lib/common"
@@ -40,6 +43,11 @@ const (
 // stateSingletonID is the fixed primary key of the single allocator-state row.
 const stateSingletonID = 1
 
+// envExpectedMode optionally declares the allocator mode a deployment expects.
+// Unset makes no assertion; "legacy"/"transactional" fail closed on mismatch
+// (brief D9 read-side guard).
+const envExpectedMode = "OCTO_MESSAGE_EXTRA_VERSION_EXPECTED_MODE"
+
 // MaxReserveCount bounds a single reservation (brief D3). It matches this
 // module's existing chunk magnitude (api_manager.go). Callers that exceed it
 // either reject client input or reserve in chunks.
@@ -58,6 +66,9 @@ var (
 	ErrOverflow = errors.New("msgextraseq: version would exceed 2^53-1")
 	// ErrUnknownMode is returned when the state row carries an unrecognized mode.
 	ErrUnknownMode = errors.New("msgextraseq: unknown allocator mode")
+	// ErrExpectedModeMismatch is returned when the resolved mode does not match the
+	// deployment's OCTO_MESSAGE_EXTRA_VERSION_EXPECTED_MODE (or that env is malformed).
+	ErrExpectedModeMismatch = errors.New("msgextraseq: allocator mode does not match expected")
 	// ErrInvariantViolation is returned when a defensive post-write check fails.
 	ErrInvariantViolation = errors.New("msgextraseq: allocator invariant violated")
 )
@@ -78,11 +89,26 @@ type Store struct {
 		Error(string, ...zap.Field)
 		Warn(string, ...zap.Field)
 	}
+	// expected-mode guard, parsed once from envExpectedMode at construction.
+	expectedModeSet       bool
+	expectedMode          int
+	expectedModeMalformed bool
 }
 
 // New builds a Store bound to the given octo-lib context.
 func New(ctx *config.Context) *Store {
-	return &Store{ctx: ctx, logger: liblog.NewTLog("MsgExtraSeq")}
+	s := &Store{ctx: ctx, logger: liblog.NewTLog("MsgExtraSeq")}
+	switch os.Getenv(envExpectedMode) {
+	case "":
+		// no assertion
+	case "legacy":
+		s.expectedModeSet, s.expectedMode = true, ModeLegacy
+	case "transactional":
+		s.expectedModeSet, s.expectedMode = true, ModeTransactional
+	default:
+		s.expectedModeSet, s.expectedModeMalformed = true, true
+	}
+	return s
 }
 
 // ReserveTx reserves count message_extra versions for the given storage channel
@@ -154,36 +180,60 @@ func (s *Store) readStateForShare(tx *dbr.Tx) (State, error) {
 		stateSingletonID,
 	).LoadOne(&row)
 	metricStateLockWaitSeconds.Observe(time.Since(lockStart).Seconds())
+	var st State
 	if err != nil {
 		if errors.Is(err, dbr.ErrNotFound) {
 			// A missing state row defaults to legacy — the safe pre-task behavior
 			// (GenSeq), which is also what a deploy sees before the migration seeds
 			// the row, and what test setups leave after CleanAllTables. This is NOT
-			// fail-closed: legacy is the conservative default. Guarding against a row
-			// deleted while in transactional mode is the job of the optional
-			// expected-mode config check (D9), not this read. The gauge below still
-			// surfaces mode=legacy so an operator can detect an unexpected state.
-			st := State{Mode: ModeLegacy}
-			setAllocatorModeGauge(st.Mode)
-			metricCutoverFloor.Set(0)
-			return st, nil
+			// fail-closed by itself; the expected-mode guard below is what makes a
+			// lost/deleted row safe once a deployment expects transactional.
+			st = State{Mode: ModeLegacy}
+		} else {
+			return State{}, fmt.Errorf("msgextraseq: read state: %w", err)
 		}
-		return State{}, fmt.Errorf("msgextraseq: read state: %w", err)
+	} else {
+		if row.Mode != ModeLegacy && row.Mode != ModeTransactional {
+			return State{}, fmt.Errorf("%w: %d", ErrUnknownMode, row.Mode)
+		}
+		st = State{Mode: row.Mode, Epoch: uint64(row.Epoch), CutoverFloor: row.CutoverFloor}
 	}
-	if row.Mode != ModeLegacy && row.Mode != ModeTransactional {
-		return State{}, fmt.Errorf("%w: %d", ErrUnknownMode, row.Mode)
+	// Expected-mode guard (brief D9 read side): a deployment declares the mode it
+	// expects via OCTO_MESSAGE_EXTRA_VERSION_EXPECTED_MODE. If the resolved mode
+	// (including a missing row → legacy) does not match, fail closed. This is the
+	// durable safety net that stops a lost/deleted state row from silently
+	// re-enabling the legacy allocator after a transactional cutover. Unset (the
+	// default, and what tests use) makes no assertion, preserving the legacy
+	// default for pre-migration deploys and CleanAllTables-based test setups.
+	if err := s.assertExpectedMode(st.Mode); err != nil {
+		return State{}, err
 	}
-	st := State{Mode: row.Mode, Epoch: uint64(row.Epoch), CutoverFloor: row.CutoverFloor}
-	// Refresh observability gauges from the authoritative row.
+	// Refresh observability gauges from the resolved state.
 	setAllocatorModeGauge(st.Mode)
 	metricAllocatorEpoch.Set(float64(st.Epoch))
 	metricCutoverFloor.Set(float64(st.CutoverFloor))
 	return st, nil
 }
 
-// reserveLegacy delegates to the process-local octo-lib GenSeq allocator. This
-// is the ONLY call site allowed to call GenSeq with MessageExtraSeqKey; the
-// source-guard test (PR-2c) enforces the allowlist. count GenSeq calls yield
+// assertExpectedMode enforces the optional OCTO_MESSAGE_EXTRA_VERSION_EXPECTED_MODE
+// deployment guard. Unset → no assertion. A malformed value, or a resolved mode
+// that differs from the expectation, fails closed.
+func (s *Store) assertExpectedMode(mode int) error {
+	if !s.expectedModeSet {
+		return nil
+	}
+	if s.expectedModeMalformed {
+		return fmt.Errorf("%w: malformed %s", ErrExpectedModeMismatch, envExpectedMode)
+	}
+	if mode != s.expectedMode {
+		return fmt.Errorf("%w: expected %d, resolved %d", ErrExpectedModeMismatch, s.expectedMode, mode)
+	}
+	return nil
+}
+
+// reserveLegacy delegates to the process-local octo-lib GenSeq allocator. After
+// the writer cutover this becomes the single allowlisted GenSeq(MessageExtraSeqKey)
+// call site, enforced by the PR-2c source-guard test. count GenSeq calls yield
 // count distinct values, matching pre-task per-message behavior.
 func (s *Store) reserveLegacy(channelID string, count int) ([]int64, error) {
 	key := fmt.Sprintf("%s:%s", common.MessageExtraSeqKey, channelID)

--- a/internal/msgextraseq/store_test.go
+++ b/internal/msgextraseq/store_test.go
@@ -547,3 +547,57 @@ func TestReserveTx_BatchPaginatesViaCursor(t *testing.T) {
 		}
 	}
 }
+
+// TestExpectedModeGuard proves the D9 read-side safety net: a deployment that
+// declares OCTO_MESSAGE_EXTRA_VERSION_EXPECTED_MODE=transactional fails closed
+// when the resolved mode (including a missing row → legacy) is not transactional,
+// so a lost/deleted state row cannot silently revert to legacy after cutover.
+// Unset (the default used by every other test) makes no assertion.
+func TestExpectedModeGuard(t *testing.T) {
+	const env = "OCTO_MESSAGE_EXTRA_VERSION_EXPECTED_MODE"
+
+	t.Run("expected transactional, missing row fails closed", func(t *testing.T) {
+		ctx := setup(t, msgextraseq.ModeTransactional, 1000)
+		if _, err := ctx.DB().UpdateBySql("DELETE FROM `octo_message_extra_version_state`").Exec(); err != nil {
+			t.Fatalf("delete state: %v", err)
+		}
+		t.Setenv(env, "transactional")
+		s := msgextraseq.New(ctx)
+		tx, _ := ctx.DB().Begin()
+		if _, err := s.ReserveTx(tx, "c-x", 2, 1); !errors.Is(err, msgextraseq.ErrExpectedModeMismatch) {
+			t.Fatalf("err=%v want ErrExpectedModeMismatch", err)
+		}
+		_ = tx.Rollback()
+	})
+
+	t.Run("expected transactional, transactional row ok", func(t *testing.T) {
+		ctx := setup(t, msgextraseq.ModeTransactional, 1000)
+		t.Setenv(env, "transactional")
+		s := msgextraseq.New(ctx)
+		if got := reserveCommitted(t, ctx, s, "c-ok", 2, 1); len(got) != 1 {
+			t.Fatalf("len=%d want 1", len(got))
+		}
+	})
+
+	t.Run("expected legacy, transactional row fails closed", func(t *testing.T) {
+		ctx := setup(t, msgextraseq.ModeTransactional, 1000)
+		t.Setenv(env, "legacy")
+		s := msgextraseq.New(ctx)
+		tx, _ := ctx.DB().Begin()
+		if _, err := s.ReserveTx(tx, "c-x", 2, 1); !errors.Is(err, msgextraseq.ErrExpectedModeMismatch) {
+			t.Fatalf("err=%v want ErrExpectedModeMismatch", err)
+		}
+		_ = tx.Rollback()
+	})
+
+	t.Run("malformed expected fails closed", func(t *testing.T) {
+		ctx := setup(t, msgextraseq.ModeLegacy, 0)
+		t.Setenv(env, "bogus")
+		s := msgextraseq.New(ctx)
+		tx, _ := ctx.DB().Begin()
+		if _, err := s.ReserveTx(tx, "c-x", 2, 1); !errors.Is(err, msgextraseq.ErrExpectedModeMismatch) {
+			t.Fatalf("err=%v want ErrExpectedModeMismatch", err)
+		}
+		_ = tx.Rollback()
+	})
+}

--- a/internal/msgextraseq/store_test.go
+++ b/internal/msgextraseq/store_test.go
@@ -38,7 +38,7 @@ func ensureSchema(t *testing.T, db *dbr.Session) {
 		"CREATE TABLE IF NOT EXISTS `seq` (`key` VARCHAR(100) NOT NULL, `min_seq` BIGINT NOT NULL DEFAULT 0, `step` INT NOT NULL DEFAULT 0, PRIMARY KEY (`key`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci",
 		"CREATE TABLE IF NOT EXISTS `message_extra` (`id` BIGINT NOT NULL AUTO_INCREMENT, `message_id` VARCHAR(20) NOT NULL DEFAULT '', `message_seq` BIGINT NOT NULL DEFAULT 0, `channel_id` VARCHAR(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL DEFAULT '', `channel_type` SMALLINT NOT NULL DEFAULT 0, `is_deleted` SMALLINT NOT NULL DEFAULT 0, `version` BIGINT NOT NULL DEFAULT 0, PRIMARY KEY (`id`), UNIQUE KEY `message_id` (`message_id`), KEY `channel_version_idx` (`channel_id`,`channel_type`,`version`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci",
 		"CREATE TABLE IF NOT EXISTS `octo_message_extra_channel_seq` (`channel_id` VARCHAR(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL DEFAULT '', `channel_type` SMALLINT NOT NULL DEFAULT 0, `last_version` BIGINT NOT NULL DEFAULT 0, PRIMARY KEY (`channel_id`,`channel_type`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci",
-		"CREATE TABLE IF NOT EXISTS `octo_message_extra_version_state` (`singleton_id` TINYINT UNSIGNED NOT NULL, `mode` TINYINT NOT NULL DEFAULT 0, `epoch` BIGINT UNSIGNED NOT NULL DEFAULT 0, `cutover_floor` BIGINT NOT NULL DEFAULT 0, PRIMARY KEY (`singleton_id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci",
+		"CREATE TABLE IF NOT EXISTS `octo_message_extra_version_state` (`singleton_id` TINYINT UNSIGNED NOT NULL, `mode` TINYINT NOT NULL DEFAULT 0, `epoch` BIGINT UNSIGNED NOT NULL DEFAULT 0, `cutover_floor` BIGINT NOT NULL DEFAULT 0, PRIMARY KEY (`singleton_id`), CONSTRAINT `chk_message_extra_version_singleton` CHECK (`singleton_id` = 1)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci",
 	}
 	for _, s := range stmts {
 		if _, err := db.UpdateBySql(s).Exec(); err != nil {
@@ -483,4 +483,67 @@ func TestReserveTx_StateDefaultsAndFailClosed(t *testing.T) {
 		}
 		_ = tx.Rollback()
 	})
+}
+
+// TestStateSingletonConstraint proves the schema structurally forbids a second
+// state row (CHECK singleton_id=1), so the "duplicate row" case the spec requires
+// to fail closed cannot arise (the reader only trusts id=1).
+func TestStateSingletonConstraint(t *testing.T) {
+	ctx := setup(t, msgextraseq.ModeTransactional, 1000)
+	if _, err := ctx.DB().InsertBySql(
+		"INSERT INTO `octo_message_extra_version_state` (`singleton_id`,`mode`,`epoch`,`cutover_floor`) VALUES (2,1,0,0)",
+	).Exec(); err == nil {
+		t.Fatal("inserting a second state row (singleton_id=2) succeeded; CHECK (singleton_id=1) not enforced")
+	}
+}
+
+// TestReserveTx_BatchPaginatesViaCursor exercises the real delta-sync read
+// contract: reserve a range, persist message_extra rows carrying those versions,
+// then page through them with `version > cursor ORDER BY version ASC LIMIT k`
+// over the composite index and assert every version is returned exactly once,
+// in order, with no gaps or duplicates.
+func TestReserveTx_BatchPaginatesViaCursor(t *testing.T) {
+	floor := int64(1000)
+	ctx := setup(t, msgextraseq.ModeTransactional, floor)
+	s := msgextraseq.New(ctx)
+	ch, ct := "c-cursor", uint8(2)
+	const n = 7
+
+	versions := reserveCommitted(t, ctx, s, ch, ct, n)
+	for i, v := range versions {
+		if _, err := ctx.DB().InsertBySql(
+			"INSERT INTO `message_extra` (`message_id`,`message_seq`,`channel_id`,`channel_type`,`version`) VALUES (?,?,?,?,?)",
+			fmt.Sprintf("cur-%d", i), i+1, ch, ct, v,
+		).Exec(); err != nil {
+			t.Fatalf("seed message_extra: %v", err)
+		}
+	}
+
+	// Page through with limit=3, advancing the cursor like the sync endpoint.
+	var got []int64
+	cursor := floor // start below the first reserved version
+	for {
+		var page []int64
+		_, err := ctx.DB().SelectBySql(
+			"SELECT `version` FROM `message_extra` WHERE `channel_id`=? AND `channel_type`=? AND `version`>? ORDER BY `version` ASC LIMIT 3",
+			ch, ct, cursor,
+		).Load(&page)
+		if err != nil {
+			t.Fatalf("paginate: %v", err)
+		}
+		if len(page) == 0 {
+			break
+		}
+		got = append(got, page...)
+		cursor = page[len(page)-1]
+	}
+
+	if len(got) != n {
+		t.Fatalf("paginated %d rows want %d (gaps or duplicates)", len(got), n)
+	}
+	for i, v := range got {
+		if v != versions[i] {
+			t.Fatalf("page[%d]=%d want %d (order/coverage mismatch)", i, v, versions[i])
+		}
+	}
 }

--- a/internal/msgextraseq/store_test.go
+++ b/internal/msgextraseq/store_test.go
@@ -1,0 +1,486 @@
+package msgextraseq_test
+
+// Integration tests for the shared message_extra version allocator. They need a
+// live MySQL, addressed via testutil.NewTestContext (which does NOT run
+// module.Setup/migrations — avoiding the local migration-ledger fragility).
+// The tables the allocator touches are ensured with CREATE TABLE IF NOT EXISTS,
+// a no-op in CI where the real migration has already created them. Each test
+// starts from empty tables and re-seeds the allocator-state singleton it needs.
+//
+// Override the DSN with OCTO_TEST_MYSQL_ADDR when the local MySQL is elsewhere.
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	"github.com/Mininglamp-OSS/octo-server/internal/msgextraseq"
+	"github.com/gocraft/dbr/v2"
+)
+
+func testMySQLAddr() string {
+	if v := os.Getenv("OCTO_TEST_MYSQL_ADDR"); v != "" {
+		return v
+	}
+	return "root:demo@tcp(127.0.0.1)/test?charset=utf8mb4&parseTime=true"
+}
+
+// ensureSchema creates the tables the allocator reads/writes if they are absent.
+// In CI they already exist (real migration), so every statement is a no-op.
+func ensureSchema(t *testing.T, db *dbr.Session) {
+	t.Helper()
+	stmts := []string{
+		"CREATE TABLE IF NOT EXISTS `seq` (`key` VARCHAR(100) NOT NULL, `min_seq` BIGINT NOT NULL DEFAULT 0, `step` INT NOT NULL DEFAULT 0, PRIMARY KEY (`key`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci",
+		"CREATE TABLE IF NOT EXISTS `message_extra` (`id` BIGINT NOT NULL AUTO_INCREMENT, `message_id` VARCHAR(20) NOT NULL DEFAULT '', `message_seq` BIGINT NOT NULL DEFAULT 0, `channel_id` VARCHAR(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL DEFAULT '', `channel_type` SMALLINT NOT NULL DEFAULT 0, `is_deleted` SMALLINT NOT NULL DEFAULT 0, `version` BIGINT NOT NULL DEFAULT 0, PRIMARY KEY (`id`), UNIQUE KEY `message_id` (`message_id`), KEY `channel_version_idx` (`channel_id`,`channel_type`,`version`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci",
+		"CREATE TABLE IF NOT EXISTS `octo_message_extra_channel_seq` (`channel_id` VARCHAR(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL DEFAULT '', `channel_type` SMALLINT NOT NULL DEFAULT 0, `last_version` BIGINT NOT NULL DEFAULT 0, PRIMARY KEY (`channel_id`,`channel_type`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci",
+		"CREATE TABLE IF NOT EXISTS `octo_message_extra_version_state` (`singleton_id` TINYINT UNSIGNED NOT NULL, `mode` TINYINT NOT NULL DEFAULT 0, `epoch` BIGINT UNSIGNED NOT NULL DEFAULT 0, `cutover_floor` BIGINT NOT NULL DEFAULT 0, PRIMARY KEY (`singleton_id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci",
+	}
+	for _, s := range stmts {
+		if _, err := db.UpdateBySql(s).Exec(); err != nil {
+			t.Fatalf("ensure schema: %v", err)
+		}
+	}
+}
+
+// setup returns a live context with the allocator-state singleton seeded to the
+// given mode/floor and the allocator tables emptied.
+func setup(t *testing.T, mode int, floor int64) *config.Context {
+	t.Helper()
+	cfg := config.New()
+	cfg.Test = true
+	cfg.DB.MySQLAddr = testMySQLAddr()
+	cfg.DB.Migration = false
+	ctx := testutil.NewTestContext(cfg)
+	db := ctx.DB()
+	ensureSchema(t, db)
+	for _, tbl := range []string{"octo_message_extra_channel_seq", "octo_message_extra_version_state", "message_extra", "seq"} {
+		if _, err := db.UpdateBySql("DELETE FROM `" + tbl + "`").Exec(); err != nil {
+			t.Fatalf("clean %s: %v", tbl, err)
+		}
+	}
+	if _, err := db.InsertBySql(
+		"INSERT INTO `octo_message_extra_version_state` (`singleton_id`,`mode`,`epoch`,`cutover_floor`) VALUES (1,?,0,?)",
+		mode, floor,
+	).Exec(); err != nil {
+		t.Fatalf("seed state: %v", err)
+	}
+	return ctx
+}
+
+// lastVersion reads the persisted sequence cursor for a channel (0 if absent).
+func lastVersion(t *testing.T, ctx *config.Context, channelID string, channelType uint8) int64 {
+	t.Helper()
+	var v int64
+	err := ctx.DB().SelectBySql(
+		"SELECT COALESCE(`last_version`,0) FROM `octo_message_extra_channel_seq` WHERE `channel_id`=? AND `channel_type`=?",
+		channelID, channelType,
+	).LoadOne(&v)
+	if err != nil && err != dbr.ErrNotFound {
+		t.Fatalf("read last_version: %v", err)
+	}
+	return v
+}
+
+// reserveCommitted runs one ReserveTx in its own committed transaction.
+func reserveCommitted(t *testing.T, ctx *config.Context, s *msgextraseq.Store, channelID string, channelType uint8, count int) []int64 {
+	t.Helper()
+	tx, err := ctx.DB().Begin()
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	defer tx.RollbackUnlessCommitted()
+	versions, err := s.ReserveTx(tx, channelID, channelType, count)
+	if err != nil {
+		t.Fatalf("ReserveTx: %v", err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+	return versions
+}
+
+func TestReserveTx_TransactionalUniqueIncreasing(t *testing.T) {
+	ctx := setup(t, msgextraseq.ModeTransactional, 1000)
+	s := msgextraseq.New(ctx)
+	ch, ct := "c-uniq", uint8(2)
+
+	seen := map[int64]bool{}
+	var prev int64
+	for i := 0; i < 5; i++ {
+		v := reserveCommitted(t, ctx, s, ch, ct, 1)[0]
+		if seen[v] {
+			t.Fatalf("duplicate version %d", v)
+		}
+		if v <= prev {
+			t.Fatalf("version %d not greater than prev %d", v, prev)
+		}
+		seen[v], prev = true, v
+	}
+	if got := lastVersion(t, ctx, ch, ct); got != prev {
+		t.Fatalf("last_version=%d want %d", got, prev)
+	}
+}
+
+func TestReserveTx_BatchContiguous(t *testing.T) {
+	ctx := setup(t, msgextraseq.ModeTransactional, 1000)
+	s := msgextraseq.New(ctx)
+	ch, ct := "c-batch", uint8(2)
+
+	versions := reserveCommitted(t, ctx, s, ch, ct, 5)
+	if len(versions) != 5 {
+		t.Fatalf("len=%d want 5", len(versions))
+	}
+	for i := 1; i < len(versions); i++ {
+		if versions[i] != versions[i-1]+1 {
+			t.Fatalf("not contiguous: %v", versions)
+		}
+	}
+	// A following single reservation continues immediately after the range.
+	next := reserveCommitted(t, ctx, s, ch, ct, 1)[0]
+	if next != versions[4]+1 {
+		t.Fatalf("next=%d want %d", next, versions[4]+1)
+	}
+}
+
+func TestReserveTx_Rollback(t *testing.T) {
+	ctx := setup(t, msgextraseq.ModeTransactional, 1000)
+	s := msgextraseq.New(ctx)
+	ch, ct := "c-rollback", uint8(2)
+
+	// Establish the row.
+	first := reserveCommitted(t, ctx, s, ch, ct, 1)[0]
+	before := lastVersion(t, ctx, ch, ct)
+
+	tx, err := ctx.DB().Begin()
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	if _, err := s.ReserveTx(tx, ch, ct, 3); err != nil {
+		t.Fatalf("ReserveTx: %v", err)
+	}
+	if err := tx.Rollback(); err != nil {
+		t.Fatalf("rollback: %v", err)
+	}
+	if got := lastVersion(t, ctx, ch, ct); got != before {
+		t.Fatalf("rollback leaked advance: last_version=%d want %d", got, before)
+	}
+	// The next committed reservation reuses the rolled-back range (gaps allowed).
+	next := reserveCommitted(t, ctx, s, ch, ct, 1)[0]
+	if next != first+1 {
+		t.Fatalf("next=%d want %d", next, first+1)
+	}
+}
+
+func TestReserveTx_TwoSessionSerialization(t *testing.T) {
+	ctx := setup(t, msgextraseq.ModeTransactional, 1000)
+	s := msgextraseq.New(ctx)
+	ch, ct := "c-serialize", uint8(2)
+	reserveCommitted(t, ctx, s, ch, ct, 1) // materialize row
+
+	tx1, err := ctx.DB().Begin()
+	if err != nil {
+		t.Fatalf("begin tx1: %v", err)
+	}
+	defer tx1.RollbackUnlessCommitted()
+	v1, err := s.ReserveTx(tx1, ch, ct, 1)
+	if err != nil {
+		t.Fatalf("tx1 reserve: %v", err)
+	}
+
+	done := make(chan int64, 1)
+	errc := make(chan error, 1)
+	go func() {
+		tx2, err := ctx.DB().Begin()
+		if err != nil {
+			errc <- err
+			return
+		}
+		defer tx2.RollbackUnlessCommitted()
+		v2, err := s.ReserveTx(tx2, ch, ct, 1) // must block on tx1's row lock
+		if err != nil {
+			errc <- err
+			return
+		}
+		if err := tx2.Commit(); err != nil {
+			errc <- err
+			return
+		}
+		done <- v2[0]
+	}()
+
+	// tx2 must not proceed while tx1 holds the lock.
+	select {
+	case <-done:
+		t.Fatal("tx2 acquired the sequence before tx1 committed")
+	case err := <-errc:
+		t.Fatalf("tx2 error: %v", err)
+	case <-time.After(300 * time.Millisecond):
+	}
+
+	if err := tx1.Commit(); err != nil {
+		t.Fatalf("tx1 commit: %v", err)
+	}
+
+	select {
+	case v2 := <-done:
+		if v2 <= v1[0] {
+			t.Fatalf("v2=%d not greater than v1=%d", v2, v1[0])
+		}
+	case err := <-errc:
+		t.Fatalf("tx2 error: %v", err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("tx2 did not proceed after tx1 committed")
+	}
+}
+
+func TestReserveTx_DifferentChannelsNoGlobalLock(t *testing.T) {
+	ctx := setup(t, msgextraseq.ModeTransactional, 1000)
+	s := msgextraseq.New(ctx)
+	reserveCommitted(t, ctx, s, "c-A", 2, 1)
+	reserveCommitted(t, ctx, s, "c-B", 2, 1)
+
+	// Hold channel A's lock open; a reservation on channel B must not block.
+	txA, err := ctx.DB().Begin()
+	if err != nil {
+		t.Fatalf("begin A: %v", err)
+	}
+	defer txA.RollbackUnlessCommitted()
+	if _, err := s.ReserveTx(txA, "c-A", 2, 1); err != nil {
+		t.Fatalf("reserve A: %v", err)
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		txB, err := ctx.DB().Begin()
+		if err != nil {
+			done <- err
+			return
+		}
+		defer txB.RollbackUnlessCommitted()
+		if _, err := s.ReserveTx(txB, "c-B", 2, 1); err != nil {
+			done <- err
+			return
+		}
+		done <- txB.Commit()
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("channel B blocked/errored behind channel A: %v", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("channel B blocked behind channel A's lock (unexpected global lock)")
+	}
+	_ = txA.Commit()
+}
+
+func TestReserveTx_ConcurrentInitializers(t *testing.T) {
+	ctx := setup(t, msgextraseq.ModeTransactional, 1000)
+	s := msgextraseq.New(ctx)
+	ch, ct := "c-init-race", uint8(2)
+
+	const n = 4
+	var wg sync.WaitGroup
+	results := make([][]int64, n)
+	errs := make([]error, n)
+	start := make(chan struct{})
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-start
+			tx, err := ctx.DB().Begin()
+			if err != nil {
+				errs[i] = err
+				return
+			}
+			defer tx.RollbackUnlessCommitted()
+			v, err := s.ReserveTx(tx, ch, ct, 1)
+			if err != nil {
+				errs[i] = err
+				return
+			}
+			if err := tx.Commit(); err != nil {
+				errs[i] = err
+				return
+			}
+			results[i] = v
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	seen := map[int64]bool{}
+	for i := 0; i < n; i++ {
+		if errs[i] != nil {
+			t.Fatalf("initializer %d: %v (no 1062/private-baseline expected)", i, errs[i])
+		}
+		v := results[i][0]
+		if seen[v] {
+			t.Fatalf("duplicate version %d across concurrent initializers", v)
+		}
+		seen[v] = true
+	}
+	if got := lastVersion(t, ctx, ch, ct); got != int64(1000+n) {
+		t.Fatalf("last_version=%d want %d", got, 1000+n)
+	}
+}
+
+func TestReserveTx_Bootstrap(t *testing.T) {
+	t.Run("floor wins when no evidence", func(t *testing.T) {
+		ctx := setup(t, msgextraseq.ModeTransactional, 5000)
+		s := msgextraseq.New(ctx)
+		v := reserveCommitted(t, ctx, s, "c-boot-floor", 2, 1)[0]
+		if v != 5001 {
+			t.Fatalf("first version=%d want 5001 (floor+1)", v)
+		}
+	})
+
+	t.Run("existing message_extra max above floor wins", func(t *testing.T) {
+		ctx := setup(t, msgextraseq.ModeTransactional, 1000)
+		s := msgextraseq.New(ctx)
+		ch, ct := "c-boot-extra", uint8(2)
+		if _, err := ctx.DB().InsertBySql(
+			"INSERT INTO `message_extra` (`message_id`,`channel_id`,`channel_type`,`version`) VALUES (?,?,?,?)",
+			"m1", ch, ct, 7777,
+		).Exec(); err != nil {
+			t.Fatalf("seed message_extra: %v", err)
+		}
+		v := reserveCommitted(t, ctx, s, ch, ct, 1)[0]
+		if v != 7778 {
+			t.Fatalf("first version=%d want 7778 (maxExtra+1)", v)
+		}
+	})
+
+	t.Run("legacy seq min_seq above floor wins", func(t *testing.T) {
+		ctx := setup(t, msgextraseq.ModeTransactional, 1000)
+		s := msgextraseq.New(ctx)
+		ch, ct := "c-boot-legacy", uint8(2)
+		if _, err := ctx.DB().InsertBySql(
+			"INSERT INTO `seq` (`key`,`min_seq`,`step`) VALUES (?,?,1000)",
+			fmt.Sprintf("seq:messageExtra:%s", ch), 9000,
+		).Exec(); err != nil {
+			t.Fatalf("seed seq: %v", err)
+		}
+		v := reserveCommitted(t, ctx, s, ch, ct, 1)[0]
+		if v != 9001 {
+			t.Fatalf("first version=%d want 9001 (legacySeq+1)", v)
+		}
+	})
+}
+
+func TestReserveTx_FloorRaiseOnExistingRow(t *testing.T) {
+	ctx := setup(t, msgextraseq.ModeTransactional, 1000)
+	s := msgextraseq.New(ctx)
+	ch, ct := "c-floor-raise", uint8(2)
+	// Simulate a row that survived an emergency legacy interval below a new floor.
+	if _, err := ctx.DB().InsertBySql(
+		"INSERT INTO `octo_message_extra_channel_seq` (`channel_id`,`channel_type`,`last_version`) VALUES (?,?,?)",
+		ch, ct, 500,
+	).Exec(); err != nil {
+		t.Fatalf("seed seq row: %v", err)
+	}
+	v := reserveCommitted(t, ctx, s, ch, ct, 1)[0]
+	if v != 1001 {
+		t.Fatalf("version=%d want 1001 (raised to floor+1)", v)
+	}
+}
+
+func TestReserveTx_CountBounds(t *testing.T) {
+	ctx := setup(t, msgextraseq.ModeTransactional, 1000)
+	s := msgextraseq.New(ctx)
+	ch, ct := "c-bounds", uint8(2)
+	for _, count := range []int{0, -1, msgextraseq.MaxReserveCount + 1} {
+		tx, err := ctx.DB().Begin()
+		if err != nil {
+			t.Fatalf("begin: %v", err)
+		}
+		if _, err := s.ReserveTx(tx, ch, ct, count); err != msgextraseq.ErrInvalidCount {
+			t.Fatalf("count=%d err=%v want ErrInvalidCount", count, err)
+		}
+		_ = tx.Rollback()
+	}
+	if got := lastVersion(t, ctx, ch, ct); got != 0 {
+		t.Fatalf("rejected counts mutated the row: last_version=%d", got)
+	}
+}
+
+func TestReserveTx_Overflow(t *testing.T) {
+	floor := int64(1)<<53 - 2 // 2^53-2: room for exactly one value.
+	ctx := setup(t, msgextraseq.ModeTransactional, floor)
+	s := msgextraseq.New(ctx)
+	ch, ct := "c-overflow", uint8(2)
+
+	// count=1 lands exactly on 2^53-1 and is allowed.
+	if v := reserveCommitted(t, ctx, s, ch, ct, 1)[0]; v != floor+1 {
+		t.Fatalf("version=%d want %d", v, floor+1)
+	}
+	// The next reservation would cross 2^53-1 and must fail without mutation.
+	before := lastVersion(t, ctx, ch, ct)
+	tx, err := ctx.DB().Begin()
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	if _, err := s.ReserveTx(tx, ch, ct, 1); err != msgextraseq.ErrOverflow {
+		t.Fatalf("err=%v want ErrOverflow", err)
+	}
+	_ = tx.Rollback()
+	if got := lastVersion(t, ctx, ch, ct); got != before {
+		t.Fatalf("overflow mutated the row: last_version=%d want %d", got, before)
+	}
+}
+
+func TestReserveTx_LegacyModeDistinct(t *testing.T) {
+	ctx := setup(t, msgextraseq.ModeLegacy, 0)
+	s := msgextraseq.New(ctx)
+	// Legacy mode must not touch the transactional table.
+	versions := reserveCommitted(t, ctx, s, "c-legacy", 2, 3)
+	if len(versions) != 3 {
+		t.Fatalf("len=%d want 3", len(versions))
+	}
+	seen := map[int64]bool{}
+	for _, v := range versions {
+		if seen[v] {
+			t.Fatalf("legacy duplicate %d", v)
+		}
+		seen[v] = true
+	}
+	if got := lastVersion(t, ctx, "c-legacy", 2); got != 0 {
+		t.Fatalf("legacy mode wrote the transactional table: last_version=%d", got)
+	}
+}
+
+func TestReserveTx_StateDefaultsAndFailClosed(t *testing.T) {
+	t.Run("missing state row defaults to legacy", func(t *testing.T) {
+		ctx := setup(t, msgextraseq.ModeTransactional, 1000)
+		if _, err := ctx.DB().UpdateBySql("DELETE FROM `octo_message_extra_version_state`").Exec(); err != nil {
+			t.Fatalf("delete state: %v", err)
+		}
+		s := msgextraseq.New(ctx)
+		// No row → legacy default (safe pre-migration behavior): reservation
+		// succeeds via GenSeq and does not touch the transactional table.
+		versions := reserveCommitted(t, ctx, s, "c-missing", 2, 1)
+		if len(versions) != 1 {
+			t.Fatalf("len=%d want 1", len(versions))
+		}
+		if got := lastVersion(t, ctx, "c-missing", 2); got != 0 {
+			t.Fatalf("missing-row default wrote the transactional table: last_version=%d", got)
+		}
+	})
+
+	t.Run("unknown mode fails closed", func(t *testing.T) {
+		ctx := setup(t, 9 /* unknown */, 1000)
+		s := msgextraseq.New(ctx)
+		tx, _ := ctx.DB().Begin()
+		if _, err := s.ReserveTx(tx, "c-x", 2, 1); !errors.Is(err, msgextraseq.ErrUnknownMode) {
+			t.Fatalf("err=%v want ErrUnknownMode", err)
+		}
+		_ = tx.Rollback()
+	})
+}

--- a/modules/message/sql/20260721000001_message_extra_version.sql
+++ b/modules/message/sql/20260721000001_message_extra_version.sql
@@ -35,3 +35,10 @@ VALUES (1, 0, 0, 0);
 -- MySQL 8.0 下朴素 CREATE INDEX 即 INPLACE/LOCK=NONE 在线(不 pin 算法，遵仓库约定)；
 -- message_extra 为大表，运维应安排低峰窗口 + 监控(时长问题，非阻塞)。
 CREATE INDEX `channel_version_idx` ON `message_extra` (`channel_id`,`channel_type`,`version`);
+
+-- +migrate Down
+
+-- 逆向:删索引 + 两张新表(纯增量,回滚无数据迁移)。message_extra 现有行不受影响。
+DROP INDEX `channel_version_idx` ON `message_extra`;
+DROP TABLE IF EXISTS `octo_message_extra_version_state`;
+DROP TABLE IF EXISTS `octo_message_extra_channel_seq`;

--- a/modules/message/sql/20260721000001_message_extra_version.sql
+++ b/modules/message/sql/20260721000001_message_extra_version.sql
@@ -22,7 +22,8 @@ CREATE TABLE `octo_message_extra_version_state` (
   `mode`          TINYINT          NOT NULL DEFAULT 0 COMMENT '0=legacy,1=transactional',
   `epoch`         BIGINT UNSIGNED  NOT NULL DEFAULT 0 COMMENT '换代计数(operator CAS 递增,仅观测)',
   `cutover_floor` BIGINT           NOT NULL DEFAULT 0 COMMENT 'cutover 校验后的版本下界',
-  PRIMARY KEY (`singleton_id`)
+  PRIMARY KEY (`singleton_id`),
+  CONSTRAINT `chk_message_extra_version_singleton` CHECK (`singleton_id` = 1)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci COMMENT='message_extra allocator 全局状态单例(#627)';
 
 INSERT INTO `octo_message_extra_version_state`

--- a/modules/message/sql/20260721000001_message_extra_version.sql
+++ b/modules/message/sql/20260721000001_message_extra_version.sql
@@ -1,0 +1,36 @@
+-- +migrate Up
+
+-- message-extra-transactional-version (#627) PR-1：为 message_extra 增量同步游标
+-- 引入「每存储频道事务序列」。version 分配改为在业务事务内经序列行 FOR UPDATE 保留、
+-- 持锁到 commit，使提交序=版本序、跨副本唯一（根因见 brief D1/D2）。本迁移仅建表 + 索引，
+-- 不回写历史行；生产在 mode=legacy 下 inert，真正启用是运维 cutover 动作（brief D9）。
+
+-- 每存储频道一行的事务序列。channel_id/charset/collation 对齐 message_extra.channel_id
+-- （实测 utf8mb4/utf8mb4_general_ci；生产上线前须再核一次）；channel_type 对齐其持久域(smallint)。
+CREATE TABLE `octo_message_extra_channel_seq` (
+  `channel_id`   VARCHAR(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL DEFAULT '' COMMENT '存储行频道ID(person=fakeChannelID)',
+  `channel_type` SMALLINT     NOT NULL DEFAULT 0 COMMENT '频道类型(对齐 message_extra.channel_type)',
+  `last_version` BIGINT       NOT NULL DEFAULT 0 COMMENT '该频道已分配的最大 message_extra 版本',
+  PRIMARY KEY (`channel_id`,`channel_type`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci COMMENT='message_extra 每频道事务序列(#627)';
+
+-- allocator 全局状态单例(brief D2/D9)：mode/epoch/floor 的唯一权威源。恒 1 行(singleton_id=1)。
+-- 每个升级后的写入方在业务事务内 FOR SHARE 读本行选择 allocator；cutover 由 operator 工具
+-- 对本行取 X 锁做 compare-and-set。seed 为 legacy，保证 Prepare 阶段生产行为不变。
+CREATE TABLE `octo_message_extra_version_state` (
+  `singleton_id`  TINYINT UNSIGNED NOT NULL COMMENT '恒为1的单例键',
+  `mode`          TINYINT          NOT NULL DEFAULT 0 COMMENT '0=legacy,1=transactional',
+  `epoch`         BIGINT UNSIGNED  NOT NULL DEFAULT 0 COMMENT '换代计数(operator CAS 递增,仅观测)',
+  `cutover_floor` BIGINT           NOT NULL DEFAULT 0 COMMENT 'cutover 校验后的版本下界',
+  PRIMARY KEY (`singleton_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci COMMENT='message_extra allocator 全局状态单例(#627)';
+
+INSERT INTO `octo_message_extra_version_state`
+  (`singleton_id`, `mode`, `epoch`, `cutover_floor`)
+VALUES (1, 0, 0, 0);
+
+-- 增量同步读路径 `WHERE channel_id=? AND channel_type=? AND version>? ORDER BY version ASC`
+-- 现仅有 channel_idx(channel_id,channel_type)，version 的 range/order 无法走索引。补复合索引。
+-- MySQL 8.0 下朴素 CREATE INDEX 即 INPLACE/LOCK=NONE 在线(不 pin 算法，遵仓库约定)；
+-- message_extra 为大表，运维应安排低峰窗口 + 监控(时长问题，非阻塞)。
+CREATE INDEX `channel_version_idx` ON `message_extra` (`channel_id`,`channel_type`,`version`);


### PR DESCRIPTION
## Summary

Introduce a per-storage-channel **transactional** version allocator for
`message_extra`, so delta-sync versions are unique and commit-ordered across
octo-server replicas. This PR lands the **schema + allocator core only**;
production stays inert (`mode=legacy`, delegating to the existing `GenSeq`) until
a separate operator cutover. No writer is switched over and no wire/CMD shape
changes in this PR.

## Related Issue

Part of #627 — **this PR does not close the issue.** It only lands the schema
and the inert allocator (mode=legacy). #627 is resolved only after the writer
cutover (PR-2) and the operator activation/cutover (later PRs) ship. Do not use
a closing keyword when merging.

## Linked Spec

`.octospec/tasks/message-extra-transactional-version/brief.md` (included in this
PR, with `plan.md` describing the staged PR-1..PR-5 rollout).

## Changes

- Migration `modules/message/sql/20260721000001_message_extra_version.sql`:
  - `octo_message_extra_channel_seq` — one hot row per storage channel.
  - `octo_message_extra_version_state` — DB-authoritative allocator mode/floor
    singleton, **seeded to legacy** so behavior is unchanged on deploy.
  - `message_extra (channel_id, channel_type, version)` composite index for the
    delta-sync read path (online `CREATE INDEX` on MySQL 8.0).
- New leaf package `internal/msgextraseq` (depends only on octo-lib, imports no
  `modules/*`, so all writers can share it without an import cycle):
  - `ReserveTx` reserves N versions under a per-channel row lock held until the
    caller commits → commit order == version order, unique per channel.
  - Allocator selected by the state row read `FOR SHARE` inside the caller's tx
    (the cutover drain barrier); `mode=legacy` delegates to the existing
    `GenSeq` (the single allowlisted call site).
  - Race-safe first-use bootstrap (max of floor / `message_extra` max / legacy
    `seq.min_seq`), `2^53-1` overflow guard, low-cardinality Prometheus metrics.
  - Returns `[]int64` (per-item versions) so callers stay mode-agnostic.

## Testing

Focused suite `./internal/msgextraseq/` against MySQL 8.0 (per-package, green;
`-race` clean). Covers: two-session serialization (second tx blocks on the
first's row lock), rollback isolation, cross-channel independence (no global
lock), batch contiguity + `version > cursor` pagination, first-use bootstrap
variants + two concurrent initializers, `count`/`int64`/`2^53-1` bounds, and
and state handling: an unrecognized `mode` value or an unreadable row fails closed, while a **missing** row defaults to legacy (safe pre-migration behavior) and is guarded by the expected-mode check (`OCTO_MESSAGE_EXTRA_VERSION_EXPECTED_MODE`) so a transactional deployment fails closed on a lost row. Migration applies cleanly via the
real sql-migrate flow. `go build ./...`, `go vet`, `make i18n-lint`,
`make i18n-extract-check` all pass.

- [x] Unit tests added/updated
- [x] Manually verified (migration apply + allocator behavior on MySQL 8.0)

## COMPREHENSION

1. **What does this change actually do to the load-bearing path?**
   It adds the storage tables and a shared allocator, but does **not** change any
   runtime write path yet: the seed `mode=legacy` makes `ReserveTx` delegate to
   today's `GenSeq`, and no writer calls the new allocator in this PR. The only
   live effect is two new empty tables and a new `message_extra` index. The
   transactional path (row-lock-held-to-commit ordering) is exercised by tests
   but gated off in production behind the DB state row.

2. **What could break because of it (dependents + failure mode)?**
   The `message_extra` index add runs on a large live table — mitigated by MySQL
   8.0 online `CREATE INDEX` (LOCK=NONE) and a low-traffic window. The tables are
   additive with no FKs, so rollback is a no-op drop. No code reads the state row
   in production yet, so a mis-seed cannot affect writes in this PR. The `channel_id`
   collation is pinned to match `message_extra` (`utf8mb4_general_ci`, verified).

3. **How do you know it works (specific test/repro/trace)?**
   `TestReserveTx_TwoSessionSerialization` proves the second transaction blocks on
   the first's sequence-row lock and only gets the next value after commit;
   `TestReserveTx_Rollback` proves a rolled-back tx leaves neither the business
   row nor the sequence advance; `TestReserveTx_BatchContiguous` paginates a
   reserved range through `version > cursor` with no gaps/dupes;
   `TestReserveTx_ConcurrentInitializers` proves the first-use race yields unique
   versions with no duplicate-key leak. Migration verified to apply via
   sql-migrate on a clean MySQL 8.0 `test` schema.

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] PR description is in English
- [x] Added tests for my changes
- [x] Updated documentation (task brief/plan under `.octospec/`)
- [x] Followed commit message conventions (Conventional Commits)

<!-- sprint: W30 set on Octo Board; re-triggering check-sprint -->

