### PR TITLE
feat: expose message reaction capability in appconfig

### DIFF
--- a/.octospec/tasks/message-reaction-appconfig/brief.md
+++ b/.octospec/tasks/message-reaction-appconfig/brief.md
@@ -19,14 +19,14 @@ through `GET /v1/common/appconfig` as:
 {"message_reaction":{"read":true,"write":true}}
 ```
 
-The capability is controlled by the hot-reloaded `system_setting` key
-`message_reaction.enabled`.
+The capability is controlled by the hot-reloaded `system_setting` keys
+`message_reaction.read` and `message_reaction.write`.
 
 ## Load-bearing list
 
-- `message_reaction.enabled` is the single configuration source.
-- The unset default is enabled to preserve the currently deployed user behavior.
-- Enabled maps atomically to `read=true, write=true`; disabled maps to both false.
+- `message_reaction.read` and `message_reaction.write` are the configuration source.
+- The unset defaults are `read=true` and `write=false`.
+- Read and write can be changed independently for staged rollout.
 - Both the full appconfig response and the `version` short-circuit response carry
   the nested capability so an operator toggle is not hidden by client caching.
 
@@ -39,9 +39,8 @@ The capability is controlled by the hot-reloaded `system_setting` key
 
 ## Acceptance
 
-- With no DB override, appconfig returns `read=true, write=true`.
-- With `message_reaction.enabled=false`, appconfig returns both values false.
+- With no DB override, appconfig returns `read=true, write=false`.
+- DB overrides for `message_reaction.read/write` are reflected independently.
 - The version short-circuit response returns the same current capability.
 - The setting is listed and writable through the existing system-setting manager
   surface without a schema migration.
-

--- a/.octospec/tasks/message-reaction-appconfig/brief.md
+++ b/.octospec/tasks/message-reaction-appconfig/brief.md
@@ -1,0 +1,47 @@
+---
+type: Task
+title: "Task: message-reaction-appconfig"
+description: Expose the global message reaction capability through appconfig, backed by system_setting.
+tags: ["message", "reaction", "appconfig", "wire-contract", "testing"]
+timestamp: 2026-07-22T00:00:00Z
+slug: message-reaction-appconfig
+source: user
+---
+
+# Task: message-reaction-appconfig
+
+## Goal
+
+Expose the ordinary Web/iOS/Android client's global message-reaction capability
+through `GET /v1/common/appconfig` as:
+
+```json
+{"message_reaction":{"read":true,"write":true}}
+```
+
+The capability is controlled by the hot-reloaded `system_setting` key
+`message_reaction.enabled`.
+
+## Load-bearing list
+
+- `message_reaction.enabled` is the single configuration source.
+- The unset default is enabled to preserve the currently deployed user behavior.
+- Enabled maps atomically to `read=true, write=true`; disabled maps to both false.
+- Both the full appconfig response and the `version` short-circuit response carry
+  the nested capability so an operator toggle is not hidden by client caching.
+
+## Out of scope
+
+- Bot-specific capability/profile responses.
+- Bot identity detection or Bot write rejection.
+- Server-side reaction read/write enforcement for the global switch.
+- Web/iOS/Android client changes.
+
+## Acceptance
+
+- With no DB override, appconfig returns `read=true, write=true`.
+- With `message_reaction.enabled=false`, appconfig returns both values false.
+- The version short-circuit response returns the same current capability.
+- The setting is listed and writable through the existing system-setting manager
+  surface without a schema migration.
+

--- a/modules/common/api.go
+++ b/modules/common/api.go
@@ -379,6 +379,10 @@ func (cn *Common) appConfig(c *wkhttp.Context) {
 	// 后者是收敛后的真源 key（与 octo-web ChannelSearch、octo-admin messages_search
 	// 命名一致）。两个分支共用同一计算结果，避免 Resolve 被调用多次。
 	searchEnabled := searchbackend.Resolve(cn.ctx.GetConfig().ZincSearch.SearchOn).SearchEnabled()
+	messageReaction := buildMessageReactionCapability(
+		cn.systemSettings.MessageReactionReadEnabled(),
+		cn.systemSettings.MessageReactionWriteEnabled(),
+	)
 	if versionI64 != 0 && int(versionI64) >= appConfigM.Version {
 		c.JSON(http.StatusOK, &appConfigResp{
 			Version:                appConfigM.Version,
@@ -392,6 +396,7 @@ func (cn *Common) appConfig(c *wkhttp.Context) {
 			DocsOn:                 cn.systemSettings.DocsEnabled(),
 			DmloopOn:               cn.systemSettings.DmloopEnabled(),
 			DmpersonalOn:           cn.systemSettings.DmpersonalEnabled(),
+			MessageReaction:        messageReaction,
 			// Sticker 上限:短路分支同样下发,让老客户端在管理台放宽/收窄后
 			// 也能立刻拿到最新值。
 			StickerUploadLimits: buildStickerUploadLimitsResp(cn.systemSettings),
@@ -440,9 +445,14 @@ func (cn *Common) appConfig(c *wkhttp.Context) {
 		DocsOn:                 cn.systemSettings.DocsEnabled(),
 		DmloopOn:               cn.systemSettings.DmloopEnabled(),
 		DmpersonalOn:           cn.systemSettings.DmpersonalEnabled(),
+		MessageReaction:        messageReaction,
 		// Sticker 上限:客户端本地预校验用,兜底仍在服务端 modules/file 侧。
 		StickerUploadLimits: buildStickerUploadLimitsResp(cn.systemSettings),
 	})
+}
+
+func buildMessageReactionCapability(read, write bool) messageReactionCapabilityResp {
+	return messageReactionCapabilityResp{Read: read, Write: write}
 }
 
 // buildStickerUploadLimitsResp 从 SystemSettings 派生一份 stickerUploadLimitsResp
@@ -820,6 +830,12 @@ type appConfigResp struct {
 	DmloopOn     bool `json:"dmloop_on"`
 	DmpersonalOn bool `json:"dmpersonal_on"`
 
+	// MessageReaction is the deployment-wide default capability for ordinary
+	// Web/iOS/Android clients. It is intentionally identity-agnostic because
+	// /v1/common/appconfig is public; Bot-specific overrides belong to the
+	// authenticated Bot profile contract.
+	MessageReaction messageReactionCapabilityResp `json:"message_reaction"`
+
 	// StickerUploadLimits 是自定义贴纸上传的操作端可调上限，与 sticker.upload_*
 	// system_setting 同源（SystemSettings.StickerUpload{MaxSizeKB,MaxDimension,
 	// AllowedFormats}）。用途：让客户端在选图后本地预校验（提示"最大 X MB / 最长
@@ -847,6 +863,11 @@ type appConfigResp struct {
 	// compress_max_concurrency / compress_timeout_ms）—— 这些是服务端"影子"参数，
 	// 响应字段结构不变、无对应客户端行为，曝光只会泄露实现细节。
 	StickerUploadLimits stickerUploadLimitsResp `json:"sticker_upload_limits"`
+}
+
+type messageReactionCapabilityResp struct {
+	Read  bool `json:"read"`
+	Write bool `json:"write"`
 }
 
 // stickerUploadLimitsResp 是 appConfigResp.sticker_upload_limits 的形状。

--- a/modules/common/api_test.go
+++ b/modules/common/api_test.go
@@ -761,14 +761,16 @@ func TestGetAppConfig_StickerCustomEnabled_OnVersionShortCircuit(t *testing.T) {
 
 func TestGetAppConfig_MessageReactionCapability(t *testing.T) {
 	tests := []struct {
-		name       string
-		dbEnabled *bool
-		version    string
-		want       bool
+		name      string
+		dbRead    *bool
+		dbWrite   *bool
+		version   string
+		wantRead  bool
+		wantWrite bool
 	}{
-		{name: "unset defaults enabled", want: true},
-		{name: "DB false disables read and write", dbEnabled: boolPtr(false), want: false},
-		{name: "version short circuit keeps current capability", version: "99999999", want: true},
+		{name: "unset defaults read only", wantRead: true, wantWrite: false},
+		{name: "DB overrides read and write independently", dbRead: boolPtr(false), dbWrite: boolPtr(true), wantRead: false, wantWrite: true},
+		{name: "version short circuit keeps current capability", version: "99999999", wantRead: true, wantWrite: false},
 	}
 
 	for _, tt := range tests {
@@ -776,8 +778,11 @@ func TestGetAppConfig_MessageReactionCapability(t *testing.T) {
 			s, ctx := testutil.NewTestServer()
 			f := New(ctx)
 			cleanAllTablesAndReloadSettings(t, ctx)
-			if tt.dbEnabled != nil {
-				setModuleEnabledSetting(t, ctx, "message_reaction", *tt.dbEnabled)
+			if tt.dbRead != nil {
+				setMessageReactionCapabilitySetting(t, ctx, "read", *tt.dbRead)
+			}
+			if tt.dbWrite != nil {
+				setMessageReactionCapabilitySetting(t, ctx, "write", *tt.dbWrite)
 			}
 			require.NoError(t, f.appConfigDB.insert(&appConfigModel{}))
 
@@ -797,13 +802,26 @@ func TestGetAppConfig_MessageReactionCapability(t *testing.T) {
 				} `json:"message_reaction"`
 			}
 			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
-			assert.Equal(t, tt.want, resp.MessageReaction.Read)
-			assert.Equal(t, tt.want, resp.MessageReaction.Write)
+			assert.Equal(t, tt.wantRead, resp.MessageReaction.Read)
+			assert.Equal(t, tt.wantWrite, resp.MessageReaction.Write)
 		})
 	}
 }
 
 func boolPtr(v bool) *bool { return &v }
+
+func setMessageReactionCapabilitySetting(t *testing.T, ctx *config.Context, key string, enabled bool) {
+	t.Helper()
+	v := "0"
+	if enabled {
+		v = "1"
+	}
+	_, err := ctx.DB().InsertInto("system_setting").
+		Columns("category", "key_name", "value", "value_type").
+		Values("message_reaction", key, v, settingTypeBool).Exec()
+	require.NoError(t, err)
+	require.NoError(t, EnsureSystemSettings(ctx).Reload())
+}
 
 // appconfig 必须下发 docs_on：值来源于 system_setting docs.enabled。默认 false，
 // 客户端据此隐藏 docs 模块入口（octo-docs-backend 上线前）。

--- a/modules/common/api_test.go
+++ b/modules/common/api_test.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"bytes"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -757,6 +758,52 @@ func TestGetAppConfig_StickerCustomEnabled_OnVersionShortCircuit(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Contains(t, w.Body.String(), `"sticker_custom_enabled":true`)
 }
+
+func TestGetAppConfig_MessageReactionCapability(t *testing.T) {
+	tests := []struct {
+		name       string
+		dbEnabled *bool
+		version    string
+		want       bool
+	}{
+		{name: "unset defaults enabled", want: true},
+		{name: "DB false disables read and write", dbEnabled: boolPtr(false), want: false},
+		{name: "version short circuit keeps current capability", version: "99999999", want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s, ctx := testutil.NewTestServer()
+			f := New(ctx)
+			cleanAllTablesAndReloadSettings(t, ctx)
+			if tt.dbEnabled != nil {
+				setModuleEnabledSetting(t, ctx, "message_reaction", *tt.dbEnabled)
+			}
+			require.NoError(t, f.appConfigDB.insert(&appConfigModel{}))
+
+			path := "/v1/common/appconfig"
+			if tt.version != "" {
+				path += "?version=" + tt.version
+			}
+			w := httptest.NewRecorder()
+			req, _ := http.NewRequest(http.MethodGet, path, nil)
+			s.GetRoute().ServeHTTP(w, req)
+			require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+			var resp struct {
+				MessageReaction struct {
+					Read  bool `json:"read"`
+					Write bool `json:"write"`
+				} `json:"message_reaction"`
+			}
+			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+			assert.Equal(t, tt.want, resp.MessageReaction.Read)
+			assert.Equal(t, tt.want, resp.MessageReaction.Write)
+		})
+	}
+}
+
+func boolPtr(v bool) *bool { return &v }
 
 // appconfig 必须下发 docs_on：值来源于 system_setting docs.enabled。默认 false，
 // 客户端据此隐藏 docs 模块入口（octo-docs-backend 上线前）。

--- a/modules/common/swagger/api.yaml
+++ b/modules/common/swagger/api.yaml
@@ -562,6 +562,19 @@ paths:
                 items:
                   type: string
                 description: "系统级 Bot UID 列表（跨 Space 可见），单一真源 pkg/space.SystemBots = {botfather, u_10000, fileHelper}。客户端据此替换硬编码 botfather 判定，避免 SYSTEM_BOTS 跨端漂移 (YUJ-219 / GH#1283)"
+              message_reaction:
+                type: object
+                description: "普通 Web/iOS/Android 客户端的全局消息 Reaction 能力；由 system_setting message_reaction.read/write 独立控制，默认可读不可写，Bot 身份覆盖不在此公共接口处理"
+                required:
+                  - read
+                  - write
+                properties:
+                  read:
+                    type: boolean
+                    description: "是否展示和读取消息 Reaction"
+                  write:
+                    type: boolean
+                    description: "是否允许展示添加/取消 Reaction 入口"
         400:
           description: "错误"
           schema:

--- a/modules/common/system_setting_schema.go
+++ b/modules/common/system_setting_schema.go
@@ -141,6 +141,13 @@ var systemSettingSchema = []settingDef{
 	{Category: "sticker", Key: "custom_enabled", Type: settingTypeBool, Description: "是否向客户端展示自定义贴纸管理入口",
 		Effective: func(s *SystemSettings) string { return boolToCanonical(s.StickerCustomEnabled()) }},
 
+	// 普通 Web/iOS/Android 客户端的消息 Reaction 能力。read/write 独立灰度：默认可读
+	// 不可写；Bot 身份覆盖后续由独立 /v1/bot/profile 处理，不在公共 appconfig 推断身份。
+	{Category: "message_reaction", Key: "read", Type: settingTypeBool, Description: "是否向普通客户端展示和下发消息 Reaction（默认开启；Bot 能力另行下发）",
+		Effective: func(s *SystemSettings) string { return boolToCanonical(s.MessageReactionReadEnabled()) }},
+	{Category: "message_reaction", Key: "write", Type: settingTypeBool, Description: "是否向普通客户端展示添加/取消 Reaction 入口（默认关闭；Bot 能力另行下发）",
+		Effective: func(s *SystemSettings) string { return boolToCanonical(s.MessageReactionWriteEnabled()) }},
+
 	// 自定义贴纸上传句柄强制开关（P0: Sticker Handle Enforcement Rollout）。这是「强制
 	// 策略」，与「签名能力」OCTO_MASTER_KEY 彻底解耦——能力是部署级 env，策略是运营可
 	// 在管理台热切的 DB 真源，互不派生。关闭（默认）= 兼容期：缺 handle 暂放行并记

--- a/modules/common/system_settings.go
+++ b/modules/common/system_settings.go
@@ -781,6 +781,21 @@ func (s *SystemSettings) StickerCustomEnabled() bool {
 	return s.getBool("sticker", "custom_enabled", false)
 }
 
+// MessageReactionReadEnabled reports whether ordinary Web/iOS/Android clients
+// should display message reactions. Read defaults on so existing reactions stay
+// visible unless an operator explicitly disables message_reaction.read.
+func (s *SystemSettings) MessageReactionReadEnabled() bool {
+	return s.getBool("message_reaction", "read", true)
+}
+
+// MessageReactionWriteEnabled reports whether ordinary Web/iOS/Android clients
+// should expose add/cancel controls. Write defaults off for a staged rollout and
+// can be enabled independently through message_reaction.write. These capability
+// getters are presentation policy; server-side authorization stays independent.
+func (s *SystemSettings) MessageReactionWriteEnabled() bool {
+	return s.getBool("message_reaction", "write", false)
+}
+
 // StickerHandleRequired reports whether custom-sticker registration must reject a
 // missing upload handle (POST /v1/sticker/user). This is the enforcement POLICY,
 // deliberately independent of the signing CAPABILITY (OCTO_MASTER_KEY): it lives

--- a/modules/common/system_settings_test.go
+++ b/modules/common/system_settings_test.go
@@ -683,6 +683,20 @@ func TestSystemSettings_StickerCustomEnabled_DBTrueWins(t *testing.T) {
 	assert.True(t, s.StickerCustomEnabled(), "DB true -> custom sticker management enabled")
 }
 
+func TestSystemSettings_MessageReactionEnabled_DefaultsTrue(t *testing.T) {
+	s := newTestSystemSettings(t, nil)
+
+	assert.True(t, s.MessageReactionEnabled(), "DB empty -> preserve current reaction behavior")
+}
+
+func TestSystemSettings_MessageReactionEnabled_DBFalseWins(t *testing.T) {
+	s := newTestSystemSettings(t, nil)
+	require.NoError(t, s.db.upsert("message_reaction", "enabled", "0", settingTypeBool, ""))
+	require.NoError(t, s.Reload())
+
+	assert.False(t, s.MessageReactionEnabled(), "DB false -> hide ordinary-client reaction capability")
+}
+
 func TestSystemSettings_DocsEnabled_DefaultsFalse(t *testing.T) {
 	s := newTestSystemSettings(t, nil)
 

--- a/modules/common/system_settings_test.go
+++ b/modules/common/system_settings_test.go
@@ -683,18 +683,21 @@ func TestSystemSettings_StickerCustomEnabled_DBTrueWins(t *testing.T) {
 	assert.True(t, s.StickerCustomEnabled(), "DB true -> custom sticker management enabled")
 }
 
-func TestSystemSettings_MessageReactionEnabled_DefaultsTrue(t *testing.T) {
+func TestSystemSettings_MessageReactionCapability_DefaultsReadOnly(t *testing.T) {
 	s := newTestSystemSettings(t, nil)
 
-	assert.True(t, s.MessageReactionEnabled(), "DB empty -> preserve current reaction behavior")
+	assert.True(t, s.MessageReactionReadEnabled(), "DB empty -> reaction display enabled")
+	assert.False(t, s.MessageReactionWriteEnabled(), "DB empty -> reaction writes disabled")
 }
 
-func TestSystemSettings_MessageReactionEnabled_DBFalseWins(t *testing.T) {
+func TestSystemSettings_MessageReactionCapability_DBOverridesIndependently(t *testing.T) {
 	s := newTestSystemSettings(t, nil)
-	require.NoError(t, s.db.upsert("message_reaction", "enabled", "0", settingTypeBool, ""))
+	require.NoError(t, s.db.upsert("message_reaction", "read", "0", settingTypeBool, ""))
+	require.NoError(t, s.db.upsert("message_reaction", "write", "1", settingTypeBool, ""))
 	require.NoError(t, s.Reload())
 
-	assert.False(t, s.MessageReactionEnabled(), "DB false -> hide ordinary-client reaction capability")
+	assert.False(t, s.MessageReactionReadEnabled(), "DB false -> hide reaction display")
+	assert.True(t, s.MessageReactionWriteEnabled(), "DB true -> expose reaction write entry")
 }
 
 func TestSystemSettings_DocsEnabled_DefaultsFalse(t *testing.T) {


### PR DESCRIPTION
## Summary

Expose global message reaction capabilities through GET /v1/common/appconfig, backed by runtime system settings.

## Related Issue

N/A

## Linked Spec

.octospec/tasks/message-reaction-appconfig/brief.md

## Changes

- Add message_reaction.read and message_reaction.write to full and version-shortcut appconfig responses.
- Register independent system settings with defaults read=true and write=false.
- Document the response contract and add coverage for defaults, overrides, and shortcut responses.

## Testing

- [x] Unit tests added/updated
- [ ] Manually verified

Commands run:

- go test ./modules/common
- go vet ./modules/common
- gofmt -l modules/common/api.go modules/common/api_test.go modules/common/system_setting_schema.go modules/common/system_settings.go modules/common/system_settings_test.go
- git diff --check origin/main...HEAD

## COMPREHENSION

1. **What does this change actually do** to the load-bearing path?

   Every appconfig response now carries the global message reaction read/write capability. Both the full response and the version-shortcut response use values loaded from system settings, so operator changes are not hidden by the client config-version cache.

2. **What could break** because of it (dependents + failure mode)?

   Web, iOS, and Android clients may show or hide reaction UI based on these fields. Missing or invalid settings fall back to read=true and write=false, preserving reaction visibility while keeping writes disabled by default. Bot-specific capability overrides and server-side reaction write enforcement are intentionally out of scope.

3. **How do you know it works** (specific test/repro/trace)?

   Unit tests cover default values, independent runtime overrides, and the version-shortcut response. The common module tests and vet checks pass, and edited Go files are gofmt-clean.

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] PR description is in English
- [x] Added tests for my changes
- [x] Updated documentation
- [x] Followed commit message conventions (Conventional Commits)