### PR TITLE
fix(space): createInvite accepts duration param, returns expire field

### DIFF
--- a/modules/space/api.go
+++ b/modules/space/api.go
@@ -20,6 +20,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
 	"github.com/Mininglamp-OSS/octo-server/modules/base/event"
 	commonmod "github.com/Mininglamp-OSS/octo-server/modules/common"
+	"github.com/Mininglamp-OSS/octo-server/pkg/db"
 	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
 	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
 	octoredis "github.com/Mininglamp-OSS/octo-server/pkg/redis"

--- a/modules/space/api.go
+++ b/modules/space/api.go
@@ -901,6 +901,14 @@ func (s *Space) updateMemberRole(c *wkhttp.Context) {
 }
 
 // createInvite 创建邀请链接
+// createInviteReq 创建邀请码请求体。
+//
+// Duration 可选，单位秒；0 或缺省表示「永久」（不过期）。
+// 正值按秒计算过期时刻；超长值（> 10 年）在写入层截断，不在此处校验。
+type createInviteReq struct {
+	Duration *int64 `json:"duration"`
+}
+
 func (s *Space) createInvite(c *wkhttp.Context) {
 	loginUID := c.GetLoginUID()
 	spaceId := c.Param("space_id")
@@ -919,12 +927,33 @@ func (s *Space) createInvite(c *wkhttp.Context) {
 		return
 	}
 
+	// 解析可选 duration 字段；body 缺失或解析失败时退化为默认行为。
+	var req createInviteReq
+	_ = c.BindJSON(&req)
+
+	now := time.Now()
 	inviteModel := &InvitationModel{
 		SpaceId: spaceId,
 		Creator: loginUID,
 		Status:  1,
 	}
-	applyAutoInviteDefaults(inviteModel, time.Now())
+
+	if req.Duration != nil {
+		if *req.Duration == 0 {
+			// 0 = 永久，ExpiresAt 保持 nil
+		} else if *req.Duration > 0 {
+			t := db.Time(now.Add(time.Duration(*req.Duration) * time.Second))
+			inviteModel.ExpiresAt = &t
+		} else {
+			// 负值：拒绝，duration 无意义
+			respondSpaceRequestInvalid(c, "duration")
+			return
+		}
+	} else {
+		// 未传 duration：使用环境变量 / 默认 TTL（72h）
+		applyAutoInviteDefaults(inviteModel, now)
+	}
+
 	inviteCode, err := s.insertInvitationWithRetry(inviteModel)
 	if err != nil {
 		s.Error("创建邀请链接失败", zap.Error(err), zap.String("spaceId", spaceId))
@@ -932,8 +961,15 @@ func (s *Space) createInvite(c *wkhttp.Context) {
 		return
 	}
 
+	// 构造 expire 字段：永久返回空字符串，有过期时间返回 RFC3339。
+	expireStr := ""
+	if inviteModel.ExpiresAt != nil {
+		expireStr = time.Time(*inviteModel.ExpiresAt).UTC().Format(time.RFC3339)
+	}
+
 	c.Response(map[string]string{
 		"invite_code": inviteCode,
+		"expire":      expireStr,
 	})
 }
 

--- a/modules/space/api.go
+++ b/modules/space/api.go
@@ -911,14 +911,15 @@ type createInviteReq struct {
 	Duration *int64 `json:"duration"`
 }
 
+// mysqlTimestampMax 是 MySQL TIMESTAMP 列的最大可表示时刻（2038-01-19 03:14:07 UTC）。
+// space_invitation.expires_at 使用 TIMESTAMP 类型，超出此时刻的值
+// 会因 sql_mode 不同而报错或被截断为错误值。
+// 所有写入 expires_at 的路径均应确保 time.Time <= mysqlTimestampMax。
+var mysqlTimestampMax = time.Date(2038, 1, 19, 3, 14, 7, 0, time.UTC)
+
 // maxInviteDurationSeconds 邀请码最大有效期（秒）。
-//
-// 约 10 年（3650 天），满足以下约束：
-//   - 远低于 time.Duration（int64 纳秒）溢出点（~292 年）。
-//   - 加上当前时间后不超过 MySQL TIMESTAMP 上限（2038-01-19），
-//     只要在 2028 年以前调用本接口即成立（最坏情况：2028 + 10 = 2038）。
-//
-// 如需修改，请同时评估数据库列类型（当前 TIMESTAMP，上限 2038-01-19）。
+// 约 10 年（3650 天），远低于 time.Duration（int64 纳秒）溢出点（~292 年）。
+// 仅防溢出；MySQL TIMESTAMP 上限由 createInvite 中对 mysqlTimestampMax 的绝对校验负责。
 const maxInviteDurationSeconds = int64(3650 * 24 * 3600) // ~10 年
 
 func (s *Space) createInvite(c *wkhttp.Context) {
@@ -969,8 +970,13 @@ func (s *Space) createInvite(c *wkhttp.Context) {
 			// 永久：清除默认 ExpiresAt
 			inviteModel.ExpiresAt = nil
 		default:
-			// 正整数：覆盖默认 ExpiresAt
-			t := db.Time(now.Add(time.Duration(*req.Duration) * time.Second))
+			// 正整数：校验绝对上限，防止超出 MySQL TIMESTAMP 范围（2038-01-19）。
+			candidate := now.Add(time.Duration(*req.Duration) * time.Second)
+			if candidate.After(mysqlTimestampMax) {
+				respondSpaceRequestInvalid(c, "duration")
+				return
+			}
+			t := db.Time(candidate)
 			inviteModel.ExpiresAt = &t
 		}
 	}

--- a/modules/space/api.go
+++ b/modules/space/api.go
@@ -904,11 +904,22 @@ func (s *Space) updateMemberRole(c *wkhttp.Context) {
 // createInvite 创建邀请链接
 // createInviteReq 创建邀请码请求体。
 //
-// Duration 可选，单位秒；0 或缺省表示「永久」（不过期）。
-// 正值按秒计算过期时刻；超长值（> 10 年）在写入层截断，不在此处校验。
+// Duration 可选，单位秒；0 表示「永久」（不过期）；正整数按秒计算过期时刻。
+// 上限为 maxInviteDurationSeconds（约 10 年），超出或负值返回 400。
+// 字段缺省时沿用运营配置默认 TTL（DM_SPACE_INVITE_DEFAULT_TTL，默认 72h）。
 type createInviteReq struct {
 	Duration *int64 `json:"duration"`
 }
+
+// maxInviteDurationSeconds 邀请码最大有效期（秒）。
+//
+// 约 10 年（3650 天），满足以下约束：
+//   - 远低于 time.Duration（int64 纳秒）溢出点（~292 年）。
+//   - 加上当前时间后不超过 MySQL TIMESTAMP 上限（2038-01-19），
+//     只要在 2028 年以前调用本接口即成立（最坏情况：2028 + 10 = 2038）。
+//
+// 如需修改，请同时评估数据库列类型（当前 TIMESTAMP，上限 2038-01-19）。
+const maxInviteDurationSeconds = int64(3650 * 24 * 3600) // ~10 年
 
 func (s *Space) createInvite(c *wkhttp.Context) {
 	loginUID := c.GetLoginUID()
@@ -928,9 +939,10 @@ func (s *Space) createInvite(c *wkhttp.Context) {
 		return
 	}
 
-	// 解析可选 duration 字段；body 缺失或解析失败时退化为默认行为。
+	// ShouldBindJSON：body 缺失/EOF 时不写 4xx，仅返回 error；
+	// 与 BindJSON(MustBindWith) 不同，不会在 empty body 时 abort 请求。
 	var req createInviteReq
-	_ = c.BindJSON(&req)
+	_ = c.ShouldBindJSON(&req)
 
 	now := time.Now()
 	inviteModel := &InvitationModel{
@@ -939,21 +951,30 @@ func (s *Space) createInvite(c *wkhttp.Context) {
 		Status:  1,
 	}
 
+	// 始终先应用运营默认值（MaxUses + 默认 ExpiresAt），
+	// 再按 duration 字段覆盖 ExpiresAt，确保 MaxUses 策略始终生效。
+	applyAutoInviteDefaults(inviteModel, now)
+
 	if req.Duration != nil {
-		if *req.Duration == 0 {
-			// 0 = 永久，ExpiresAt 保持 nil
-		} else if *req.Duration > 0 {
-			t := db.Time(now.Add(time.Duration(*req.Duration) * time.Second))
-			inviteModel.ExpiresAt = &t
-		} else {
-			// 负值：拒绝，duration 无意义
+		switch {
+		case *req.Duration < 0:
+			// 负值无意义，拒绝
 			respondSpaceRequestInvalid(c, "duration")
 			return
+		case *req.Duration > maxInviteDurationSeconds:
+			// 超出上限，防止 time.Duration 溢出及 MySQL TIMESTAMP 越界
+			respondSpaceRequestInvalid(c, "duration")
+			return
+		case *req.Duration == 0:
+			// 永久：清除默认 ExpiresAt
+			inviteModel.ExpiresAt = nil
+		default:
+			// 正整数：覆盖默认 ExpiresAt
+			t := db.Time(now.Add(time.Duration(*req.Duration) * time.Second))
+			inviteModel.ExpiresAt = &t
 		}
-	} else {
-		// 未传 duration：使用环境变量 / 默认 TTL（72h）
-		applyAutoInviteDefaults(inviteModel, now)
 	}
+	// duration 缺省：保留 applyAutoInviteDefaults 写入的默认 ExpiresAt
 
 	inviteCode, err := s.insertInvitationWithRetry(inviteModel)
 	if err != nil {


### PR DESCRIPTION
## Summary

`createInvite` (`POST /v1/space/:space_id/invite`) previously ignored the request body and always applied the default TTL (72 h via `applyAutoInviteDefaults`). The frontend duration picker in octo-web PR #972 therefore had no effect.

## Changes

**`modules/space/api.go`**

- Add `createInviteReq` struct with optional `Duration *int64` field (seconds; `0` = permanent).
- `createInvite` handler now:
  - Parses request body (best-effort; missing/malformed body falls back to default TTL — no breaking change for existing callers).
  - `duration = 0` → `ExpiresAt = nil` (permanent link).
  - `duration > 0` → `ExpiresAt = now + duration`.
  - `duration < 0` → 400 Bad Request (`duration` field invalid).
  - `duration` omitted → calls `applyAutoInviteDefaults` (env `DM_SPACE_INVITE_DEFAULT_TTL` / 72 h), preserving existing behaviour.
- Response now includes `"expire"` field: RFC 3339 string, or `""` for permanent links.

## Pairing

Frontend: Mininglamp-OSS/octo-web#972 (`fix(space): pass duration to invite API; show expiry; add duration picker`)

## Backward Compatibility

- Callers that send an empty body continue to receive the default TTL behaviour unchanged.
- New `"expire"` field is additive; existing consumers can ignore it.
