### PR TITLE
fix: make reaction emoji identity byte-exact

### DIFF
--- a/.octospec/tasks/message-reaction-emoji-binary-collation/brief.md
+++ b/.octospec/tasks/message-reaction-emoji-binary-collation/brief.md
@@ -1,0 +1,61 @@
+---
+type: Task
+title: "Task: message-reaction-emoji-binary-collation"
+description: Make reaction emoji identity byte-exact in MySQL and return the persisted toggle result.
+tags: ["message", "reaction", "mysql", "migration", "wire-contract", "testing"]
+timestamp: 2026-07-22T00:00:00Z
+slug: message-reaction-emoji-binary-collation
+upstream: production reaction collision report
+source: self
+---
+
+# Task: message-reaction-emoji-binary-collation
+
+## User journey
+
+As a user who already reacted with one emoji, I want a different emoji to create
+an independent reaction, so that adding or cancelling it never mutates the first
+reaction and every write response matches the durable server state.
+
+## Root cause
+
+`reaction_users.emoji` inherits `utf8mb4_general_ci`. On the deployed MySQL-compatible
+database that collation compares `👍` and `🎉` as equal. The five-column unique
+index therefore treats the second emoji as a duplicate, and the atomic upsert
+toggles the existing `👍` row while the handler echoes the requested `🎉`.
+
+## Load-bearing changes
+
+- Add a new forward migration that changes only `reaction_users.emoji` to
+  `utf8mb4_bin`; do not edit an already-applied migration or change the table-wide
+  collation.
+- Keep `(channel_id, channel_type, message_id, uid, emoji)` as the unique key.
+- Make `toggleReaction` return the persisted `emoji`, `seq`, and `is_deleted` from
+  its existing post-upsert read.
+- Build the sync command and HTTP response from that persisted result. Treat a
+  requested/persisted emoji mismatch as a storage invariant failure.
+
+## Out of scope
+
+- Unicode normalization or collapsing visually similar but byte-distinct emoji
+  sequences such as `❤` and `❤️`.
+- Reconstructing historical reactions that were never persisted.
+- Changing reaction authorization, visibility, Space isolation, or rate limits.
+- Changing the remaining `reaction_users` column collations.
+
+## Acceptance
+
+- The `emoji` column reports `utf8mb4_bin` after migrations.
+- Adding `👍` and then `🎉` creates two active rows and sync returns both.
+- Clicking `🎉` again changes only the `🎉` row to deleted; `👍` stays active.
+- Write responses and sync commands use the persisted emoji/seq/deleted state.
+- Focused integration and DB-helper tests, `go test ./modules/message`, race,
+  `go vet`, formatting, and migration checks pass.
+
+## Rollout and rollback
+
+- Check the production table size before rollout because a collation change may
+  rebuild the table or hold a metadata lock.
+- Application rollback is compatible with the binary collation. The migration
+  Down path is intentionally a no-op: reverting to `general_ci` can fail once
+  byte-distinct emoji rows coexist under the unique index.

--- a/modules/message/api.go
+++ b/modules/message/api.go
@@ -2162,7 +2162,7 @@ func (m *Message) addOrCancelReaction(c *wkhttp.Context) {
 	}
 	// 多 reaction：按 (uid, message_id, channel, emoji) 原子 toggle。同 emoji 命中唯一键翻转
 	// is_deleted，不同 emoji 落各自独立行（追加）。返回最终 is_deleted 供 Web 乐观更新对账。
-	isDeleted, err := m.messageReactionDB.toggleReaction(&reactionModel{
+	toggleResult, err := m.messageReactionDB.toggleReaction(&reactionModel{
 		ChannelID:   fakeChannelID,
 		ChannelType: req.ChannelType,
 		UID:         loginUID,
@@ -2173,6 +2173,17 @@ func (m *Message) addOrCancelReaction(c *wkhttp.Context) {
 	})
 	if err != nil {
 		m.Error("写入消息回应失败", zap.Error(err), zap.String("channel_id", fakeChannelID), zap.String("message_id", req.MessageID))
+		httperr.ResponseErrorL(c, errcode.ErrMessageStoreFailed, nil, nil)
+		return
+	}
+	if toggleResult.Emoji != req.Emoji {
+		m.Error("reaction 持久化结果与请求 emoji 不一致",
+			zap.String("channel_id", fakeChannelID),
+			zap.String("message_id", req.MessageID),
+			zap.String("uid", loginUID),
+			zap.String("requested_emoji", req.Emoji),
+			zap.String("persisted_emoji", toggleResult.Emoji),
+			zap.Int64("persisted_seq", toggleResult.Seq))
 		httperr.ResponseErrorL(c, errcode.ErrMessageStoreFailed, nil, nil)
 		return
 	}
@@ -2189,8 +2200,8 @@ func (m *Message) addOrCancelReaction(c *wkhttp.Context) {
 			"message_id":   req.MessageID,
 			"channel_id":   req.ChannelID,
 			"channel_type": req.ChannelType,
-			"emoji":        req.Emoji,
-			"seq":          seq,
+			"emoji":        toggleResult.Emoji,
+			"seq":          toggleResult.Seq,
 		},
 	})
 	if err != nil {
@@ -2203,9 +2214,9 @@ func (m *Message) addOrCancelReaction(c *wkhttp.Context) {
 		MessageID:   req.MessageID,
 		ChannelID:   req.ChannelID,
 		ChannelType: req.ChannelType,
-		Emoji:       req.Emoji,
-		Seq:         seq,
-		IsDeleted:   isDeleted,
+		Emoji:       toggleResult.Emoji,
+		Seq:         toggleResult.Seq,
+		IsDeleted:   toggleResult.IsDeleted,
 	})
 }
 

--- a/modules/message/api_reaction_integration_test.go
+++ b/modules/message/api_reaction_integration_test.go
@@ -89,7 +89,7 @@ func queryReactionRow(t *testing.T, ctx *config.Context, messageID int64, channe
 	t.Helper()
 	var model *reactionModel
 	_, err := ctx.DB().Select("*").From("reaction_users").
-		Where("channel_id=? and channel_type=? and message_id=? and uid=? and emoji=?",
+		Where("channel_id=? and channel_type=? and message_id=? and uid=? and BINARY emoji=BINARY ?",
 			channelID, channelType, strconv.FormatInt(messageID, 10), testutil.UID, emoji).
 		Load(&model)
 	require.NoError(t, err)
@@ -103,6 +103,17 @@ func decodeToggleResp(t *testing.T, w *httptest.ResponseRecorder) reactionToggle
 	var resp reactionToggleResp
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp), w.Body.String())
 	return resp
+}
+
+func TestReactionEmojiColumnUsesBinaryCollation(t *testing.T) {
+	_, ctx, _ := setupGroupTestData(t)
+
+	var collation string
+	err := ctx.DB().Select("collation_name").From("information_schema.columns").
+		Where("table_schema=database() and table_name='reaction_users' and column_name='emoji'").
+		LoadOne(&collation)
+	require.NoError(t, err)
+	require.Equal(t, "utf8mb4_bin", collation)
 }
 
 func TestReactionAcceptsVisibleMessageAndToggles(t *testing.T) {
@@ -151,21 +162,65 @@ func TestReactionMultipleEmojisIndependent(t *testing.T) {
 		return postReaction(t, s, b)
 	}
 
-	// 点 👍 → 一行
-	require.Equal(t, http.StatusOK, post("👍").Code)
+	// utf8mb4_general_ci 会错误地把两个补充平面 emoji 判等；binary collation
+	// 必须让它们成为两个独立 reaction。
+	thumbsUpResp := post("👍")
+	require.Equal(t, http.StatusOK, thumbsUpResp.Code, thumbsUpResp.Body.String())
+	thumbsUpToggle := decodeToggleResp(t, thumbsUpResp)
+	require.Equal(t, "👍", thumbsUpToggle.Emoji)
+	require.Equal(t, 0, thumbsUpToggle.IsDeleted)
 	assert.Equal(t, 1, countReactionRows(t, ctx, mid))
 
-	// 点 ❤️（不同 emoji）→ 追加独立第二行，两行均 is_deleted=0
-	require.Equal(t, http.StatusOK, post("❤️").Code)
-	assert.Equal(t, 2, countReactionRows(t, ctx, mid))
-	assert.Equal(t, 0, queryReactionRow(t, ctx, mid, groupNo, ct, "👍").IsDeleted)
-	assert.Equal(t, 0, queryReactionRow(t, ctx, mid, groupNo, ct, "❤️").IsDeleted)
+	partyResp := post("🎉")
+	require.Equal(t, http.StatusOK, partyResp.Code, partyResp.Body.String())
+	partyToggle := decodeToggleResp(t, partyResp)
+	require.Equal(t, "🎉", partyToggle.Emoji)
+	require.Equal(t, 0, partyToggle.IsDeleted)
+	require.Equal(t, 2, countReactionRows(t, ctx, mid))
+	thumbsUp := queryReactionRow(t, ctx, mid, groupNo, ct, "👍")
+	party := queryReactionRow(t, ctx, mid, groupNo, ct, "🎉")
+	require.Equal(t, 0, thumbsUp.IsDeleted)
+	require.Equal(t, 0, party.IsDeleted)
+	require.Equal(t, partyToggle.Seq, party.Seq)
 
-	// 再点 👍 → 仅 👍 行 toggle 取消，❤️ 不受影响
-	require.Equal(t, http.StatusOK, post("👍").Code)
-	assert.Equal(t, 1, queryReactionRow(t, ctx, mid, groupNo, ct, "👍").IsDeleted, "👍 独立取消")
-	assert.Equal(t, 0, queryReactionRow(t, ctx, mid, groupNo, ct, "❤️").IsDeleted, "❤️ 不受影响")
-	assert.Equal(t, 2, countReactionRows(t, ctx, mid), "仍是两行，独立 toggle 不新增")
+	w := postReactionSync(t, s, map[string]interface{}{
+		"channel_id": groupNo, "channel_type": ct, "seq": 0,
+	})
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	var synced []reactionResp
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &synced), w.Body.String())
+	active := make(map[string]int)
+	for _, reaction := range synced {
+		if reaction.MessageID == strconv.FormatInt(mid, 10) {
+			active[reaction.Emoji] = reaction.IsDeleted
+		}
+	}
+	require.Equal(t, map[string]int{"👍": 0, "🎉": 0}, active)
+
+	// 再点 🎉 → 仅 🎉 行 toggle 取消，👍 不受影响；增量 sync 返回持久化的 🎉 最终态。
+	partyCancelResp := post("🎉")
+	require.Equal(t, http.StatusOK, partyCancelResp.Code, partyCancelResp.Body.String())
+	partyCancel := decodeToggleResp(t, partyCancelResp)
+	require.Equal(t, "🎉", partyCancel.Emoji)
+	require.Equal(t, 1, partyCancel.IsDeleted)
+	require.Greater(t, partyCancel.Seq, partyToggle.Seq)
+	thumbsUp = queryReactionRow(t, ctx, mid, groupNo, ct, "👍")
+	party = queryReactionRow(t, ctx, mid, groupNo, ct, "🎉")
+	require.Equal(t, 0, thumbsUp.IsDeleted, "🎉 toggle must not change 👍")
+	require.Equal(t, 1, party.IsDeleted)
+	require.Equal(t, partyCancel.Seq, party.Seq)
+	require.Equal(t, 2, countReactionRows(t, ctx, mid), "different emoji keep independent rows")
+
+	w = postReactionSync(t, s, map[string]interface{}{
+		"channel_id": groupNo, "channel_type": ct, "seq": partyToggle.Seq,
+	})
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	synced = nil
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &synced), w.Body.String())
+	require.Len(t, synced, 1)
+	require.Equal(t, "🎉", synced[0].Emoji)
+	require.Equal(t, partyCancel.Seq, synced[0].Seq)
+	require.Equal(t, 1, synced[0].IsDeleted)
 }
 
 func TestReactionSameEmojiUpsertNoDuplicate(t *testing.T) {
@@ -278,6 +333,19 @@ func seedReactionFriend(t *testing.T, ctx *config.Context, uid, toUID string) {
 	require.NoError(t, err)
 }
 
+func seedReactionSpaceMember(t *testing.T, ctx *config.Context, spaceID, uid, createdAt string) {
+	t.Helper()
+	_, err := ctx.DB().InsertBySql(
+		"INSERT INTO `space` (space_id, name, creator, status, created_at, updated_at) VALUES (?,?,?,1,?,?)",
+		spaceID, spaceID, uid, createdAt, createdAt).Exec()
+	require.NoError(t, err)
+	_, err = ctx.DB().InsertBySql(
+		"INSERT INTO `space_member` (space_id, uid, role, status, created_at, updated_at) VALUES (?,?,0,1,?,?)",
+		spaceID, uid, createdAt, createdAt).Exec()
+	require.NoError(t, err)
+	_ = ctx.GetRedisConn().Del("space:member:" + spaceID + ":" + uid)
+}
+
 // insertPersonMessageWithSpace 在 DM 物理频道(fakeChannelID)插入一条带 space_id 的纯文本消息。
 func insertPersonMessageWithSpace(t *testing.T, ctx *config.Context, fakeChannelID string, mid int64, spaceID string) {
 	t.Helper()
@@ -313,8 +381,8 @@ func setupCrossSpaceDM(t *testing.T) (*server.Server, *config.Context, string, i
 	s, ctx := testutil.NewTestServer()
 	resetReactionUIDRateLimit(t, ctx)
 	spaceA, spaceB := "spcA"+strconv.FormatInt(nextShortID.Add(1), 10), "spcB"+strconv.FormatInt(nextShortID.Add(1), 10)
-	seedSpaceMemberRepro(t, ctx, spaceA, testutil.UID, "2020-01-01 00:00:00")
-	seedSpaceMemberRepro(t, ctx, spaceB, testutil.UID, "2020-06-01 00:00:00")
+	seedReactionSpaceMember(t, ctx, spaceA, testutil.UID, "2020-01-01 00:00:00")
+	seedReactionSpaceMember(t, ctx, spaceB, testutil.UID, "2020-06-01 00:00:00")
 	seedReactionFriend(t, ctx, testutil.UID, reactionPeerUID)
 	fakeChannelID := common.GetFakeChannelIDWith(testutil.UID, reactionPeerUID)
 	const mid int64 = 920001

--- a/modules/message/db_message_reaction.go
+++ b/modules/message/db_message_reaction.go
@@ -49,8 +49,9 @@ func (d *messageReactionDB) queryWithMessageIDsInChannel(channelID string, chann
 // 多 reaction 语义：不同 emoji 命中不同唯一键 → 各自独立行，互不影响（追加），
 // 不再有"改 emoji 覆盖"分支。
 //
-// upsert 后回读该行最终 is_deleted 返回，供 Web 乐观更新对账（盲翻转 + 并发下需知道结果）。
-func (d *messageReactionDB) toggleReaction(model *reactionModel) (int, error) {
+// upsert 后回读该行持久化的 emoji/seq/is_deleted，供 Web 乐观更新对账。调用方必须
+// 使用这份结果构造 CMD 与 HTTP 响应，不能回显请求值掩盖存储层不变量漂移。
+func (d *messageReactionDB) toggleReaction(model *reactionModel) (*reactionToggleResult, error) {
 	_, err := d.session.InsertBySql(
 		"INSERT INTO reaction_users (message_id, seq, channel_id, channel_type, uid, name, emoji, is_deleted) "+
 			"VALUES (?,?,?,?,?,?,?,0) "+
@@ -58,14 +59,23 @@ func (d *messageReactionDB) toggleReaction(model *reactionModel) (int, error) {
 		model.MessageID, model.Seq, model.ChannelID, model.ChannelType, model.UID, model.Name, model.Emoji,
 	).Exec()
 	if err != nil {
-		return 0, err
+		return nil, err
 	}
-	var isDeleted int
-	err = d.session.Select("is_deleted").From("reaction_users").
+	result := &reactionToggleResult{}
+	err = d.session.Select("emoji", "seq", "is_deleted").From("reaction_users").
 		Where("channel_id=? and channel_type=? and message_id=? and uid=? and emoji=?",
 			model.ChannelID, model.ChannelType, model.MessageID, model.UID, model.Emoji).
-		LoadOne(&isDeleted)
-	return isDeleted, err
+		LoadOne(result)
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+type reactionToggleResult struct {
+	Emoji     string
+	Seq       int64
+	IsDeleted int
 }
 
 type reactionModel struct {

--- a/modules/message/db_message_reaction_test.go
+++ b/modules/message/db_message_reaction_test.go
@@ -47,15 +47,17 @@ func TestMessageReactionDB_ToggleReactionUpsertsAndReadsBack(t *testing.T) {
 	// dbr 默认客户端插值，sqlmock 收到的是已内联值的语句（无占位参数）。
 	mock.ExpectExec("INSERT INTO reaction_users .*VALUES \\('9001',7,'group-a',2,'u1','User 1','👍',0\\) ON DUPLICATE KEY UPDATE is_deleted = 1 - is_deleted").
 		WillReturnResult(sqlmock.NewResult(1, 1))
-	// 回读该 (channel, message, uid, emoji) 行的最终 is_deleted。
-	mock.ExpectQuery("SELECT is_deleted FROM reaction_users WHERE \\(channel_id='group-a' and channel_type=2 and message_id='9001' and uid='u1' and emoji='👍'\\)").
-		WillReturnRows(sqlmock.NewRows([]string{"is_deleted"}).AddRow(1))
+	// 回读该 (channel, message, uid, emoji) 行的持久化最终态，避免写响应回显请求值。
+	mock.ExpectQuery("SELECT emoji, seq, is_deleted FROM reaction_users WHERE \\(channel_id='group-a' and channel_type=2 and message_id='9001' and uid='u1' and emoji='👍'\\)").
+		WillReturnRows(sqlmock.NewRows([]string{"emoji", "seq", "is_deleted"}).AddRow("👍", 7, 1))
 
-	isDeleted, err := db.toggleReaction(&reactionModel{
+	result, err := db.toggleReaction(&reactionModel{
 		ChannelID: "group-a", ChannelType: 2, UID: "u1", Name: "User 1",
 		MessageID: "9001", Emoji: "👍", Seq: 7,
 	})
 	require.NoError(t, err)
-	require.Equal(t, 1, isDeleted)
+	require.Equal(t, "👍", result.Emoji)
+	require.Equal(t, int64(7), result.Seq)
+	require.Equal(t, 1, result.IsDeleted)
 	require.NoError(t, mock.ExpectationsWereMet())
 }

--- a/modules/message/db_message_reaction_test.go
+++ b/modules/message/db_message_reaction_test.go
@@ -1,6 +1,7 @@
 package message
 
 import (
+	"errors"
 	"testing"
 	"time"
 
@@ -59,5 +60,35 @@ func TestMessageReactionDB_ToggleReactionUpsertsAndReadsBack(t *testing.T) {
 	require.Equal(t, "👍", result.Emoji)
 	require.Equal(t, int64(7), result.Seq)
 	require.Equal(t, 1, result.IsDeleted)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestMessageReactionDB_ToggleReactionReturnsInsertError(t *testing.T) {
+	db, mock, cleanup := newMockReactionDB(t)
+	defer cleanup()
+
+	mock.ExpectExec("INSERT INTO reaction_users").WillReturnError(errors.New("insert failed"))
+	result, err := db.toggleReaction(&reactionModel{
+		ChannelID: "group-a", ChannelType: 2, UID: "u1", Name: "User 1",
+		MessageID: "9001", Emoji: "👍", Seq: 7,
+	})
+	require.EqualError(t, err, "insert failed")
+	require.Nil(t, result)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestMessageReactionDB_ToggleReactionReturnsReadBackError(t *testing.T) {
+	db, mock, cleanup := newMockReactionDB(t)
+	defer cleanup()
+
+	mock.ExpectExec("INSERT INTO reaction_users").WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectQuery("SELECT emoji, seq, is_deleted FROM reaction_users").
+		WillReturnError(errors.New("read back failed"))
+	result, err := db.toggleReaction(&reactionModel{
+		ChannelID: "group-a", ChannelType: 2, UID: "u1", Name: "User 1",
+		MessageID: "9001", Emoji: "👍", Seq: 7,
+	})
+	require.EqualError(t, err, "read back failed")
+	require.Nil(t, result)
 	require.NoError(t, mock.ExpectationsWereMet())
 }

--- a/modules/message/sql/20260722000001_message_reaction_emoji_binary.sql
+++ b/modules/message/sql/20260722000001_message_reaction_emoji_binary.sql
@@ -1,0 +1,20 @@
+-- +migrate Up
+
+-- Reaction identity is the exact emoji string. utf8mb4_general_ci treats some
+-- distinct supplementary-plane emoji (for example 👍 and 🎉) as equal, so the
+-- five-column unique key can route a new emoji into another emoji's upsert row.
+-- Change only this identity column to a byte-exact collation; the existing
+-- reaction_users_channel_msg_uid_emoji_uidx index is rebuilt with that comparison
+-- semantics automatically.
+ALTER TABLE `reaction_users`
+    MODIFY COLUMN `emoji` VARCHAR(20)
+    CHARACTER SET utf8mb4 COLLATE utf8mb4_bin
+    NOT NULL DEFAULT '';
+
+-- +migrate Down
+
+-- Forward-only: after this migration, byte-distinct emoji rows may coexist while
+-- comparing equal under utf8mb4_general_ci. Reverting the collation could fail the
+-- unique index or require destructive deduplication, so application rollback keeps
+-- the safer binary collation.
+SELECT 1;


### PR DESCRIPTION
## Summary

Fix message reaction collisions caused by linguistic collation treating distinct emoji as equal.

## Related Issue

Fixes #636

## Linked Spec

.octospec/tasks/message-reaction-emoji-binary-collation/brief.md

## Changes

- Add a forward-only migration that changes only reaction_users.emoji to utf8mb4_bin.
- Return the persisted emoji, sequence, and deletion state from the atomic toggle helper.
- Build the sync command and HTTP response from the persisted result and fail closed on an emoji mismatch.
- Add regression coverage for independent 👍 and 🎉 creation, sync, and cancellation.
- Cover DB insert and read-back error paths.

## Testing

- [x] Unit tests added/updated
- [x] Manually verified

Commands and checks run:

- go test -race -shuffle=on -count=1 ./modules/message
- Focused MySQL integration tests for TestReactionEmojiColumnUsesBinaryCollation and TestReactionMultipleEmojisIndependent
- Focused integration tests with the race detector
- go build ./modules/message
- go vet ./modules/message
- gofmt and git diff --check
- Verified utf8mb4_bin and the five-column unique index in MySQL
- Verified an existing reaction row survives the collation migration

The repository-wide integration-tag suite has a pre-existing test import cycle. The reaction integration tests were executed through an isolated same-package source set so the real handlers, migrations, MySQL, Redis, and sync path still ran.

## COMPREHENSION

1. **What does this change actually do** to the load-bearing path?

   Reaction emoji identity becomes byte-exact at the storage layer. The existing atomic upsert continues to use the five-column unique key, but distinct emoji no longer collide under utf8mb4_general_ci. The write path also returns and broadcasts the persisted result instead of echoing request values.

2. **What could break** because of it (dependents + failure mode)?

   The ALTER TABLE may rebuild reaction_users or wait for a metadata lock, so production table size must be checked before rollout. Byte-distinct but visually similar Unicode sequences become independent reactions by design. The schema migration is forward-only because reverting to general_ci can conflict after distinct emoji rows coexist.

3. **How do you know it works** (specific test/repro/trace)?

   The RED test reproduced utf8mb4_general_ci and the 👍 versus 🎉 collision. After the migration, MySQL reports utf8mb4_bin, the unique index remains channel_id/channel_type/message_id/uid/emoji, both rows persist and sync independently, and cancelling 🎉 leaves 👍 active. The DB helper success and failure paths are covered, with the helper at 100 percent statement coverage.

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] PR description is in English
- [x] Added tests for my changes
- [x] Updated documentation
- [x] Followed commit message conventions (Conventional Commits)