### PR TITLE
feat(cardtmpl): close post-#633 interactive-card loop (updater + callback envelope + docs.access-request@0.3.0 + metrics)

### DIFF
--- a/.octospec/journal/shared/cardtmpl-interaction-closure.md
+++ b/.octospec/journal/shared/cardtmpl-interaction-closure.md
@@ -1,0 +1,127 @@
+---
+type: Journal
+title: "Journal: cardtmpl-interaction-closure"
+description: Closed the post-#633 interactive-card loop. One commit ships CardUpdater (authoritative ReplaceView + progress-frame Append over the existing CardMutator CAS/revision/CMD path), a route-versioned callback envelope (legacy default, opt-in octo-card-v1), docs.access-request@0.3.0 with an approved/rejected result view registered beside the frozen 0.2.0, and two bounded Prometheus counters. In-flight 0.2.0 pending cards are authoritatively upgraded to 0.3.0/result in place; missing decorative fields are omitted, not fabricated.
+tags: ["cardtmpl", "platform", "docs-access-request", "wire-contract", "trust-boundary", "callback", "card-update", "auth", "space", "i18n", "metrics", "testing"]
+timestamp: 2026-07-22T16:40:00+08:00
+# --- octospec extension fields ---
+task: cardtmpl-interaction-closure
+upstream: octo-server#633
+source: self
+---
+
+# Journal: cardtmpl-interaction-closure
+
+## What was done
+
+One commit (`4336a01c`) on `cardtmpl-interaction-closure` closing roadmap
+group A — the "read-only notification → interactive terminal" gap left open by
+#633. Four tightly-coupled pieces:
+
+1. **A1 `CardUpdater`** (`pkg/cardtmpl/updater.go`)
+   - `ReplaceView`: authoritative pending→result re-render via
+     `Registry.RenderCard`, persisted through the existing
+     `carddispatch.CardMutator`. Message ID / channel binding / sender / Space
+     / `card_seq` come from the stored message + action event, never callback
+     display fields. Returns typed render/mutation errors with no fallback
+     write.
+   - `Append`: reads the *effective* card (`message_extra.content_edit` when
+     present, else original payload), appends exactly one JSON object to
+     `card.body`, re-runs `cardmsg.Validate/Finalize`, and mutates through the
+     same path. Enforces a strictly consecutive `card_seq`
+     (`target.CardSeq == snapshot.CardSeq + 1`). Non-object elements, non-card
+     sources, stale sequences, and revoked/deleted targets fail closed.
+   - Both compose `CardMutator` (CAS + idempotent replay + best-effort
+     revision append + CMD sync); no new write transport was created.
+
+2. **A2 standardized callback envelope** (`internal/cardactiondispatch`)
+   - Routes default to the legacy flat `DecisionRequest` body (byte-compatible;
+     queue rows created before this change still decode). A validated route
+     option `octo-card-v1` selects the nested envelope: `protocol`,
+     `type=card.action`, `action.{id,data,inputs}`,
+     `card.{template_id,template_version,view,message_id,channel_id,channel_type}`,
+     `actor.uid`, opaque `trigger_id` derived from the durable event ID. HMAC
+     continues to cover the exact request body.
+   - `response_url` is deliberately NOT emitted — §7 defines no authenticated
+     response request body, so no unusable URL is published.
+   - Ingress (`modules/message/api_card_action.go`
+     `resolveRegistryCardContext`) enriches the internal event only from the
+     effective server-authored frame + Registry: template identity from
+     `metadata.octo.template`, view from `Registry.ActionView`. Corrupt/partial
+     metadata or an action not declared for the resolved view fails closed
+     *before* enqueue; legacy cards without template metadata retain the
+     existing zero-context path.
+
+3. **A3 `docs.access-request@0.3.0`** (`pkg/cardtmpl/docs_access_request/v3.go`)
+   - New `result` view (`approved`/`rejected`, `octo/v1`) registered *beside*
+     the frozen `0.2.0`. `pending` view stays `octo/v2` with the same action
+     structure; the interaction report only *adds* optional `Action.data`
+     context keys (avatar/reason/time/permission/source) — a purely additive,
+     backward-compatible evolution.
+   - The docs finalizer (`modules/notify/action_finalizer.go`) now calls
+     `CardUpdater.ReplaceView` with target version `0.3.0` for
+     approved/denied; `cancelled`/`unavailable` stay on the legacy fallback
+     (`0.3.0` does not declare those states). Denial reason is rune-bounded
+     before rendering.
+   - The `0.2.0` handoff tree has **zero diff** vs merge commit `2917e6a6`.
+
+4. **A4 bounded metrics** (`pkg/cardtmpl/metrics.go`)
+   - `dmwork_cardtmpl_callback_total{template_id,version,action_id,result=ok|rejected|error}`
+     and `dmwork_cardtmpl_update_total{template_id,version,result=ok|error}`.
+     Labels come only from registered metadata + declared interactions — no
+     UID, message ID, doc ID, URL, arbitrary input, or error text.
+
+## Structural learning
+
+- **Published L1 versions are frozen; evolution is a new version registered
+  side-by-side.** `0.2.0` and `0.3.0` are both live; `SetDefault` moved new
+  sends to `0.3.0` only after its register-time self-check passed (fail-close:
+  a failing self-check panics `main.go` at boot). An in-flight `0.2.0/pending`
+  message is authoritatively replaced by `0.3.0/result` — message ID and
+  channel binding stay, only `metadata.octo.template.version` changes. This is
+  the reusable shape for every future card version bump.
+- **`CardUpdater` composes the mutator, it is not a second write path.** All
+  authority (sender, message ID, channel, Space, `card_seq`) is re-derived from
+  stored state inside `CardMutator`; the updater only supplies rendered content
+  + the target coordinates. Callback display fields never influence the write.
+
+## Gotchas worth remembering
+
+- **`card_seq` for the docs `ReplaceView` is sourced from `event.EventID`**
+  (`action_finalizer.go`). This leans on the durable event ID being
+  monotonic to satisfy the mutator's `card_seq` CAS ordering. It holds for the
+  current snowflake-style IDs, but it is an *implicit* contract: swapping the
+  event-ID generator for a non-monotonic scheme would silently break update
+  ordering. Promoted to a pending learning.
+- **Docs uses the in-process finalizer, which does NOT go through the HTTP
+  callback envelope.** A2's `legacy`/`octo-card-v1` route option only affects
+  external server-to-server HTTP consumers. Do not assume the envelope format
+  changes the docs approval path — that path is `DocsActionFinalizer.Finalize`
+  called directly by the dispatcher.
+- **Two label vocabularies still exist** (pilot `resultLabels` + notify
+  `docsLabelsFor`); A3 added a third copy for the result view. Bounded by tests
+  today; folding into an i18n locale source is deferred to roadmap C (G4).
+
+## Verification (this run)
+
+Locally green: `go vet` (focused), `pkg/cardtmpl` `-race -cover`
+(80.5% / 85.8%), `internal/cardactiondispatch` envelope, `pkg/cardmsg`
+template-context, `internal/carddispatch` mutation CAS, `modules/notify`
+finalizer + v3 result, `modules/message` `resolveRegistryCardContext`,
+`make i18n-extract-check`, `make i18n-lint`.
+
+Not run here, with an honest note on where they run:
+- `golangci-lint` — not installed on this host; the CI Vet/lint lane covers it.
+- The `//go:build integration` card-action orchestration in `modules/message`
+  (`TestCardActionEndToEndAndIdempotency`, `…TrustModel`, `…SenderBound…`, etc.)
+  runs neither here nor in CI. Under `-tags integration` the `message` test
+  binary hits a **compile-time import cycle** (message test → app_bot →
+  bot_api → messages_search → message), and the CI test lane deliberately runs
+  the DEFAULT build **without** `-tags integration` (`ci.yml`, ref #557 — the
+  integration suite needs a separately-provisioned `conv_ext_test` DB). Per the
+  in-source note, that path's D6/D9 CAS is covered by `modules/bot_api` IM
+  cases; the `message` e2e files require the dmworkim `make env-test`
+  environment to execute. A's own `message`-level regression coverage here is
+  the non-integration `TestResolveRegistryCardContextUsesEffectiveMetadataAndReport`,
+  which ran green in the default lane. The pre-existing orchestration e2e was
+  therefore NOT re-verified in this finish.

--- a/.octospec/learnings/pending/cardtmpl-interaction-closure.md
+++ b/.octospec/learnings/pending/cardtmpl-interaction-closure.md
@@ -1,0 +1,66 @@
+---
+type: Learning
+title: "Authoritative card updates need a monotonic card_seq source — reusing event IDs is an implicit contract, assert or annotate it"
+description: CardMutator orders card updates by a CAS on card_seq — a later write must carry a strictly greater card_seq than the stored frame, or it is rejected as a conflict / collapsed as a replay. The docs finalizer sources that card_seq from event.EventID. This is correct only while event IDs are monotonically increasing; nothing in the type system enforces it. Any CardUpdater caller that derives card_seq from an external ID inherits a silent-corruption risk if that ID generator ever becomes non-monotonic. Make the monotonicity requirement explicit at the call site.
+tags: ["cardtmpl", "card-update", "wire-contract", "trust-boundary", "cas", "idempotency"]
+timestamp: 2026-07-22T16:45:00+08:00
+# --- octospec extension fields ---
+source: self
+origin_task: cardtmpl-interaction-closure
+origin_pr: self
+status: pending
+candidate_rule: card-update
+---
+
+# card_seq must come from a monotonic source
+
+## Context
+
+`carddispatch.CardMutator` serializes competing card updates with a CAS on
+`card_seq`: a write whose `card_seq` is not strictly greater than the stored
+frame's `card_seq` is either rejected (`conflict`) or, when the frame hashes
+identically, collapsed into an idempotent replay. This is the whole
+correctness story for concurrent/retried updates — no duplicate revision, no
+duplicate CMD.
+
+`CardUpdater.ReplaceView` / `Append` take the `card_seq` from the caller. The
+docs finalizer (`modules/notify/action_finalizer.go`) passes
+`CardSeq: event.EventID`.
+
+## The trap
+
+`event.EventID` works as a `card_seq` **only because the durable event ID is
+monotonically increasing** under the current snowflake-style generator. That
+property is load-bearing but invisible:
+
+- Nothing in `UpdateTarget` or `CardMutator` declares "this field must be
+  monotonic." It is just an `int64`.
+- If the event-ID generator is ever swapped (per-shard counters, UUID→hash,
+  clock-rollback under NTP correction, a test double that returns a constant),
+  the CAS silently misbehaves: a legitimate later update carrying a *smaller*
+  ID looks like a stale conflict and is dropped; two updates with the same ID
+  look like a replay and the second is swallowed. No error, no log, no metric
+  — the terminal card just fails to appear.
+
+## What to do
+
+1. **At every `CardUpdater` call site, document why the chosen `card_seq`
+   source is monotonic.** For the docs finalizer: "event IDs are
+   monotonic snowflakes; used directly as card_seq." One comment closes the
+   gap for the next reader.
+2. **Prefer a source whose monotonicity is a stated invariant** (message
+   sequence, a dedicated per-message revision counter) over an ambient ID that
+   happens to increase today.
+3. **Consider asserting it in `CardMutator`** when cheap — e.g. reject a
+   `card_seq <= 0`, and where a prior frame is loaded, treat a *lower* incoming
+   `card_seq` as a typed conflict (already done) but log at a level that would
+   surface a systemic regression, not just a benign race.
+4. **Never derive `card_seq` from a client-supplied or display field.** It is
+   part of the authoritative write ordering, not presentation.
+
+## Candidate rule promotion
+
+Fits a `card-update` rule (invariants for authoritative card mutation:
+authority re-derived from stored state, monotonic `card_seq`, mutator-composed
+writes only). Discuss scope in the promotion PR — it may instead extend the
+existing trust-boundary guidance rather than stand alone.

--- a/.octospec/log.md
+++ b/.octospec/log.md
@@ -4,6 +4,28 @@ Change history for this repo's `.octospec/`, following the
 [OKF](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md)
 change-log convention (§7). Newest first.
 
+## 2026-07-22 (cardtmpl-interaction-closure)
+
+- **Feature** — Closed the post-#633 interactive-card loop (roadmap group A).
+  `CardUpdater` (`ReplaceView` + progress-frame `Append`) composes the existing
+  `CardMutator` CAS/revision/CMD path; `docs.access-request@0.3.0` adds an
+  `approved`/`rejected` `result` view (`octo/v1`) registered beside the frozen
+  `0.2.0`; the docs finalizer now upgrades approved/denied cards in place to
+  `0.3.0/result`. In-flight `0.2.0` pending cards upgrade too — missing
+  decorative fields are omitted, not fabricated.
+- **Contract** — Route-versioned callback envelope: `legacy` flat body remains
+  the default (byte-compatible), `octo-card-v1` opt-in nested envelope carries
+  `protocol`/`type=card.action`/`card.{…}`/`trigger_id`; `response_url` stays
+  reserved (no authenticated response body defined in §7). See
+  [journal](journal/shared/cardtmpl-interaction-closure.md).
+- **Observability** — Bounded counters `dmwork_cardtmpl_callback_total`
+  (`ok|rejected|error`) + `dmwork_cardtmpl_update_total` (`ok|error`); labels
+  only from registered metadata + declared interactions.
+- **Learning (pending)** — `card_seq` for authoritative updates must come from
+  a monotonic source; the docs finalizer reuses `event.EventID`, an implicit
+  contract now documented. See
+  [learning](learnings/pending/cardtmpl-interaction-closure.md).
+
 ## 2026-07-22 (cardtmpl-registry-pilot)
 
 - **Feature** — Introduced the octo-card@1.0 platform base

--- a/.octospec/tasks/cardtmpl-interaction-closure/brief.md
+++ b/.octospec/tasks/cardtmpl-interaction-closure/brief.md
@@ -1,0 +1,200 @@
+---
+type: Task
+title: "Task: cardtmpl-interaction-closure"
+description: Close the post-633 interactive-card loop with versioned result rendering, authoritative message updates, callback envelopes, and bounded metrics.
+tags: [wire-contract, trust-boundary, error-response, i18n, space, auth, testing, commit, callback, card-update]
+timestamp: 2026-07-22T16:03:51+08:00
+# --- octospec extension fields ---
+slug: cardtmpl-interaction-closure
+upstream: octo-server#633
+source: self
+---
+
+# Task: cardtmpl-interaction-closure
+
+> Post-#633 roadmap group A: A1 `CardUpdater`, A2 standardized callback
+> envelope, A3 `docs.access-request@0.3.0` result view, and A4 callback/update
+> metrics. PR #633 merged as `2917e6a6`; its `docs.access-request@0.2.0`
+> contract is published and immutable.
+
+## Goal
+
+Close the first platform-template interaction loop:
+
+1. a `docs.access-request@0.2.0` or `@0.3.0` pending card is clicked;
+2. the existing authenticated `/v1/message/card/action` ingress validates the
+   effective frame and enqueues one authoritative action event;
+3. a callback consumer receives either the byte-compatible legacy request or
+   the opt-in `octo-card@1.0` nested envelope;
+4. the docs finalizer renders `docs.access-request@0.3.0` in the
+   `result` view (`approved` or `rejected`, `octo/v1`) and replaces the
+   original message through the existing card mutation CAS/revision/CMD path;
+5. callback and update outcomes are observable through bounded Prometheus
+   counters.
+
+The result visual is implemented as Go `Template.Build` code using the attached
+backend handoff's `result.template.json`, approved/rejected samples, reports,
+and goldens as the design input. This task does not introduce the `${}` JSON
+template engine.
+
+## Background
+
+- PR #633 published `docs.access-request@0.2.0` with only the interactive
+  `pending` view. The original design handoff also contained a `result` view,
+  but it was deliberately excluded because the pilot had no updater/finalizer
+  integration and no JSON expression engine.
+- `modules/notify.DocsActionFinalizer` already rebuilds a terminal card and
+  calls `internal/carddispatch.CardMutator.Mutate`, but it bypasses
+  `Registry.Render`, manually builds the type-17 envelope, fixes the profile to
+  `octo/v2`, and emits no cardtmpl update metric.
+- `CardMutator` already owns sender binding, active-message lifecycle checks,
+  card normalization, `card_seq` CAS, idempotent replay, revision append, and
+  CMD sync. `CardUpdater` must compose this path, not create another write
+  transport.
+- The current callback HTTP body is the flat `DecisionRequest`. The public
+  client action request remains unchanged; the standardized envelope is a
+  server-to-server callback format and must be route-versioned so an upgrade
+  cannot silently break an existing strict callback consumer.
+- The merged `0.2.0` action data contains enough authoritative identity for a
+  safe terminal update (`doc_id`, `request_id`, `doc_title`, requester display
+  name), but not every decorative result field from the design sample. The
+  `0.3.0` result renderer therefore treats avatar/reason/time/permission copy as
+  optional and omits unavailable blocks for in-flight `0.2.0` cards.
+
+## Load-bearing list
+
+- **Published L1 wire contract (`wire-contract`)**: do not modify any byte under
+  `pkg/cardtmpl/docs_access_request/handoff/docs.access-request@0.2.0/`.
+  Register `0.2.0` and `0.3.0` concurrently. New sends may move to the `0.3.0`
+  default only after its register-time self-check passes.
+- **Template identity/version transition (`wire-contract`)**: an in-flight
+  `0.2.0/pending` message may be authoritatively replaced by
+  `0.3.0/result`; the message ID and channel binding stay unchanged while
+  `metadata.octo.template.version` becomes `0.3.0`.
+- **State vocabulary (`wire-contract`)**: callback `StateApproved` maps to
+  template state `approved`; callback `StateDenied` maps to template state
+  `rejected`. `cancelled` is not declared by the `0.3.0` result contract and
+  retains the existing legacy terminal fallback.
+- **Card mutation authority (`trust-boundary`, `auth`, `space`)**:
+  `sender_uid`, `message_id`, channel, channel type, Space, and monotonic
+  `card_seq` come from the stored message/action event, never callback display
+  fields. Wrong sender, revoked/deleted message, non-card source, stale sequence,
+  or channel mismatch fails closed through `CardMutator`.
+- **Effective-frame semantics (`wire-contract`)**: Append reads the current
+  effective card (`message_extra.content_edit` when present, otherwise original
+  payload), appends one element to `card.body`, then runs the same
+  `cardmsg.Validate/Finalize` and CAS mutation path. It never edits the original
+  payload directly and never bypasses revision history.
+- **Revision/CMD semantics**: authoritative `content_edit` persistence remains
+  primary; revision append and CMD sync remain best-effort exactly as in the
+  existing `CardMutator`. Replays do not append a duplicate revision or send a
+  duplicate CMD.
+- **Client action ingress (`wire-contract`, `error-response`, `i18n`, `auth`,
+  `space`)**: `POST /v1/message/card/action` request and response shapes,
+  anti-IDOR checks, visibility gates, input validation, UID rate limiting, and
+  Redis idempotency are unchanged.
+- **Callback trust boundary (`trust-boundary`, `wire-contract`)**: action data
+  is extracted from the effective server-authored frame; inputs are the
+  existing allowlisted/typed map; template ID/version come from
+  `metadata.octo.template`; view is resolved from the registered interaction
+  report and matching action ID. Client-supplied `data`, template identity, or
+  view are never trusted.
+- **Callback compatibility (`wire-contract`)**: existing routes default to the
+  legacy flat request. A validated route option explicitly selects the nested
+  `octo-card@1.0` payload. HMAC continues to cover the exact request body and
+  event ID headers. Queue rows created before this change still decode.
+- **Callback envelope**: the new format contains `protocol`,
+  `type=card.action`, `action.{id,data,inputs}`,
+  `card.{template_id,template_version,view,message_id,channel_id,channel_type}`,
+  `actor.uid`, and an opaque `trigger_id` derived from the durable event ID.
+  `response_url` remains optional/reserved because §7 defines no authenticated
+  response request body; no unusable URL is emitted.
+- **Localization (`i18n`)**: result labels are selected from
+  `BuildEnv.Lang`; business/display fields are escaped, rune-bounded, and never
+  treated as trusted card JSON. Existing applicant notification localization
+  and denial-reason behavior remain intact.
+- **Metrics cardinality**: `template_id`/`version` come from registered metadata,
+  `action_id` comes from a declared interaction, and result values are closed
+  enums. Metrics do not record arbitrary user input, UID, message ID, document
+  ID, URL, or error text.
+- **Testing (`testing`)**: use TDD; unit tests cover render/update/envelope/error
+  branches, integration tests cover finalizer-to-CAS behavior, and the existing
+  full card-action orchestration remains green.
+- **Git/PR (`commit`)**: English Conventional Commit messages and English PR
+  description; link this brief in the PR.
+
+## Out of scope
+
+- No modifications to the frozen `docs.access-request@0.2.0` assets or behavior.
+- No `${}` JSON template engine and no runtime loading of `templates/*.json`.
+- No capability-discovery/export endpoints (roadmap B).
+- No migration of docs shared/commented, summary, or generic approval cards
+  (roadmap C).
+- No `ext.*`/L2b production channel, owner registry, or private visibility
+  rollout (roadmap D).
+- No explicit notify envelope replacing `NotifyReq` (roadmap E2).
+- No public/signed `response_url` execution endpoint. The field remains absent
+  until its request schema, authorization, TTL/replay semantics, and operational
+  ownership are specified in a separate brief.
+- No change to generic `StandardActionFinalizer` rendering; only the docs
+  binding adopts the registry-backed `0.3.0` result view.
+- No database migration. Existing `message_extra` and
+  `octo_message_card_revision` storage remains authoritative.
+- No change to applicant outcome-card delivery semantics; callback retries may
+  still retry the applicant notification under the existing at-least-once
+  boundary.
+- G1/G2/G3 technical-debt refactors remain separate unless a minimal local
+  adjustment is required to compile the A implementation.
+
+## Acceptance
+
+- A new `pkg/cardtmpl/docs_access_request` version `0.3.0` is registered beside
+  `0.2.0`; its manifest declares `pending: octo/v2` and
+  `result: octo/v1` with states `approved`/`rejected`.
+- `0.3.0` carries hardened schema/samples/reports for all three states; every
+  sample passes register-time self-check and the shared conformance suite.
+- Approved/rejected `Registry.RenderCard` output has
+  `metadata.octo.template={id:"docs.access-request",version:"0.3.0"}`, the
+  expected result variant, no `Action.Submit`/`Input.*`, and passes
+  `cardmsg.Validate` under `octo/v1`.
+- The `0.2.0` handoff tree has no diff against merge commit `2917e6a6`.
+- `CardUpdater.ReplaceView` accepts an authoritative update target containing
+  sender UID, message ID, channel, channel type, Space, message sequence
+  (optional lookup optimization), and positive card sequence; it renders via
+  Registry, persists through `CardMutator`, preserves message ID, and returns
+  typed render/mutation errors without fallback writes.
+- `CardUpdater.Append` reads the effective card, appends exactly one JSON object
+  to `card.body`, preserves template metadata/profile/Space, uses the supplied
+  positive `card_seq`, validates the full envelope, and persists through the
+  same mutator. Non-object elements, non-card sources, stale sequences,
+  revoked/deleted targets, and invalid post-append cards fail closed.
+- Repeating an identical ReplaceView/Append frame is an idempotent replay with
+  no duplicate revision/CMD. Competing different frames with the same or lower
+  `card_seq` return the existing conflict error.
+- Docs approved/denied finalization calls `CardUpdater.ReplaceView` with target
+  version `0.3.0`; approved maps to `approved`, denied maps to `rejected`, and
+  the denial reason is bounded before rendering. Existing cancelled/unavailable
+  behavior stays on the legacy fallback.
+- A `0.2.0` pending event with only the currently published action-data keys can
+  be finalized into a valid `0.3.0/result` card; missing decorative fields are
+  omitted rather than fabricated.
+- The action ingress enriches internal callback events only from the effective
+  card and Registry. Invalid/unknown template metadata or an action not declared
+  for the resolved view is rejected before enqueue for the registry-backed
+  route; legacy cards without template metadata retain the existing path.
+- Route config accepts only `legacy` (default) or `octo-card-v1` callback
+  formats. Legacy callback body tests remain byte-compatible; the new format
+  matches the nested envelope above, preserves HMAC verification, and carries a
+  stable string trigger ID without treating it as authorization.
+- `dmwork_cardtmpl_callback_total{template_id,version,action_id,result}` records
+  one of `ok|rejected|error`; `dmwork_cardtmpl_update_total{template_id,version,result}`
+  records `ok|error`. Tests prove registration, increments, and bounded labels.
+- Focused RED tests fail for missing `0.3.0`, updater, envelope, and metrics
+  behavior before production implementation is added; the same tests pass
+  after implementation.
+- Required verification passes: focused `pkg/cardtmpl`,
+  `internal/carddispatch`, `internal/cardactiondispatch`, `modules/message`, and
+  `modules/notify` tests; `go test -race -cover` for the new updater/template
+  packages with at least 80% statement coverage for new production code;
+  `go vet ./...`; `golangci-lint run ./...`; `make i18n-extract-check`;
+  `make i18n-lint`; and `go test ./...` when MySQL/Redis/WuKongIM are available.

--- a/.octospec/tasks/cardtmpl-interaction-closure/context.yaml
+++ b/.octospec/tasks/cardtmpl-interaction-closure/context.yaml
@@ -1,0 +1,14 @@
+injected:
+  - id: space-isolation
+    source: repo
+  - id: trust-boundary
+    source: repo
+  - id: error-handling
+    source: repo
+  - id: rate-limit
+    source: repo
+  - id: testing
+    source: repo
+  - id: commit-style
+    source: repo
+brief: .octospec/tasks/cardtmpl-interaction-closure/brief.md

--- a/docs/platform-card-base.md
+++ b/docs/platform-card-base.md
@@ -4,7 +4,8 @@
 > `pkg/cardtmpl/{template,registry,helpers,updater,metrics}.go`、`pkg/cardmsg/`、
 > `internal/carddispatch/`、`internal/cardactiondispatch/` 的实现互为镜像 ——
 > 两者如有出入,以代码为准并视为本文档的 bug。规范源头:
-> `.octospec/tasks/cardtmpl-registry-pilot/brief.md`(基座落地 + docs.access-request pilot);
+> `.octospec/tasks/cardtmpl-registry-pilot/brief.md`(基座落地 + docs.access-request pilot)与
+> `.octospec/tasks/cardtmpl-interaction-closure/brief.md`(post-#633 交互闭环);
 > 分层与生命周期规则见 §2。
 >
 > **读者**:业务后端(docs-backend / summary-backend / 未来 L2b 业务方)、octo-web、
@@ -13,7 +14,8 @@
 
 > 本文定义 octo-server 卡片消息的平台级基座契约（L0），所有业务卡片（文档/智能总结/审批/Git/...）都在此基座上以版本化模板（L1）形式注册与运行。
 >
-> 首个验证样板：`docs.access-request@0.2.0`（web 侧起草）。
+> 首个验证样板：冻结的 `docs.access-request@0.2.0/pending`，以及兼容演进的
+> `docs.access-request@0.3.0`（`pending` + `approved/rejected` result）。
 >
 > 对齐参考：Slack Block Kit、飞书卡片 JSON 2.0；复用现有 octo 实现，不重复造轮子。
 
@@ -200,7 +202,7 @@
     }
     // 注:0.2.0 pilot 只注册 pending 单视图 (octo/v2 交互档)。
     // 终态 result 视图 (approved/rejected,octo/v1) 与其 approved/rejected
-    // samples 由后续 outcome PR 以新版本 docs.access-request@0.3.0 发布,
+    // samples 已由后续交互闭环以新版本 docs.access-request@0.3.0 发布,
     // 老版本目录一经发布即冻结不改 (§2.1 L1 变更规则)。
   }
 }
@@ -479,7 +481,11 @@ func (r *Registry) RegisteredForTest() []Template
 
 ## 7. 统一交互回调契约
 
-复用 `internal/cardactiondispatch`，统一回调 payload 顶层结构（对齐 Slack/飞书交互 payload 结构）：
+复用 `internal/cardactiondispatch`。现有 route 默认 `callback_format=legacy`，保持扁平
+`DecisionRequest` 字节兼容；只有 route 显式配置 `callback_format=octo-card-v1` 时才发送
+下列标准 envelope。升级后的 route 遇到完全没有模板 metadata 的在途 legacy 卡时仍发送
+扁平 payload；部分/损坏 metadata 则 fail-close。两种格式均对最终 HTTP body 原始字节
+做现有 HMAC 签名。
 
 ```jsonc
 {
@@ -498,40 +504,50 @@ func (r *Registry) RegisteredForTest() []Template
   },
   "card": {
     "template_id": "docs.access-request",
-    "template_version": "0.2.0",
+    "template_version": "0.3.0",
     "view": "pending",
-    "message_id": 12345,
+    "message_id": "12345",
     "channel_id": "uid_xxx",
     "channel_type": 1
   },
   "actor": { "uid": "uid_xxx" },
-  "trigger_id": "...",                  // 短期令牌,用于 modal/延迟响应
-  "response_url": "..."                 // 异步更新卡片用,5min 有效
+  "trigger_id": "..."                   // durable event_id 的稳定字符串；关联用，不是授权凭据
 }
 ```
 
+`response_url` 当前为保留能力，不会出现在 payload 中。其请求体、鉴权、TTL、重放与
+运维归属尚未形成独立契约，在此之前不得发布不可调用的伪 URL。
+
 ### 业务方回调处理
 - 业务方实现 `cardactiondispatch.Finalizer`（复用现有 finalizer 机制），按 `(owner, action_type)` 绑定；
-- Finalizer 调用 `Registry.Lookup(templateId, version)` → 校验业务状态 → 调用 `Build(resultState, resultFields, env)` → 通过 `CardUpdater` 更新原消息（切换视图/替换 body），对齐 Slack response_url / 飞书流式更新体验。
+- Finalizer 校验业务状态后，通过 `CardUpdater.ReplaceView` 走
+  `Registry.RenderCard → CardMutator` 更新原消息；调用方不得自行拼 type-17 envelope。
 
 ---
 
 ## 8. 统一更新接口（视图切换/终态）
 
 ```go
-// pkg/cardtmpl/updater.go (在现有 pkg/cardrevision 与 carddispatch 之上封装)
-type CardUpdater interface {
-    // ReplaceView 切换到同模板另一视图(如 pending → result),
-    // 服务端权威重渲染,替换原消息 body,保持 message_id 不变。
-    ReplaceView(ctx context.Context, target carddispatch.Target,
-        templateID ID, version string, newState string, fields json.RawMessage) error
+type UpdateTarget struct {
+    Target     carddispatch.Target // 权威 Space/channel/channel_type
+    SenderUID  string
+    MessageID  string
+    MessageSeq uint32              // 可选查询优化
+    CardSeq    int64               // 正数、单调递增
+}
 
-    // Append 追加内容到卡片底部(如进度帧),不替换原 body;v1/v2 均支持。
-    Append(ctx context.Context, target carddispatch.Target, element json.RawMessage) error
+type CardUpdater interface {
+    ReplaceView(ctx context.Context, target UpdateTarget,
+        templateID ID, version string, newState State,
+        fields json.RawMessage, env BuildEnv) error
+
+    Append(ctx context.Context, target UpdateTarget, element json.RawMessage) error
 }
 ```
 
-底层复用现有 `pkg/cardrevision` 修订账本 + `carddispatch` 发送层，不新造通路。
+`ReplaceView` 服务端权威重渲染并保持 `message_id`；`Append` 读取当前生效帧，只允许
+`target.CardSeq == snapshot.CardSeq + 1`，追加一个 JSON object 后重验完整卡片。两者均
+复用 `CardMutator` 的 sender/lifecycle/CAS、修订账本与 CMD 同步，不新造写通路。
 
 ---
 
@@ -588,9 +604,9 @@ type CardUpdater interface {
 
 | 指标 | labels | 说明 |
 |---|---|---|
-| `cardtmpl_build_total` | template_id, version, view, result=ok\|fields_invalid\|render_error | Build 结果；fields_invalid 应在 400 返回前就拦截，本指标反映防线穿透情况。 |
-| `cardtmpl_callback_total` | template_id, version, action_id, result=ok\|rejected\|error | 交互回调结果。 |
-| `cardtmpl_update_total` | template_id, version, result=ok\|error | 卡片更新（视图切换/追加）结果。 |
+| `dmwork_cardtmpl_build_total` | template_id, version, view, result=ok\|fields_invalid\|render_error | Build 结果；fields_invalid 应在 400 返回前就拦截，本指标反映防线穿透情况。 |
+| `dmwork_cardtmpl_callback_total` | template_id, version, action_id, result=ok\|rejected\|error | 交互回调结果。 |
+| `dmwork_cardtmpl_update_total` | template_id, version, result=ok\|error | 卡片更新（视图切换/追加）结果。 |
 
 label `template_id` 基数 = 注册表大小（硬编码），无基数爆炸。
 
@@ -602,7 +618,7 @@ label `template_id` 基数 = 注册表大小（硬编码），无基数爆炸。
 |---|---|---|
 | AdaptiveCard 构建/校验/白名单 | `pkg/cardmsg/*` | 不动，复用 |
 | 派发/bot 身份/空间鉴权 | `internal/carddispatch/*` | 不动；Sender.Send 接受的 Card.Profile 从 Registry 拿 |
-| 回调路由/finalizer | `internal/cardactiondispatch/*` | 回调 payload 顶层结构标准化（第 7 节），RouteSpec 不动 |
+| 回调路由/finalizer | `internal/cardactiondispatch/*` | `RouteSpec.CallbackFormat` 显式 opt-in 标准 envelope；默认 legacy |
 | 信任边界/签名校验 | `modules/cardtrust/*` | 不动 |
 | 业务 builder | `pkg/cardtmpl/{resource,approval_request,approval_result,docs_action}.go` | 保留为 L2 实现；抽出 Template 接口、Registry、helpers |
 | notify 入口/能力准入 | `modules/notify/{api,card,approval_card}.go` | 方案 B：外壳不动，内部 `deliver*` 改为 `Lookup→Build`；docs 通路 card.go 分支改造，保持 `notifyCapabilityAllows` 准入 |
@@ -645,8 +661,16 @@ label `template_id` 基数 = 注册表大小（硬编码），无基数爆炸。
    - 更新 `.octospec/tasks/card-message-internal-dispatch/docs-notify-contract.md`,引用本基座文档和 handoff 路径;
    - 本基座文档已随 pilot PR 迁入 `docs/platform-card-base.md`(仓库权威路径),不再等 PR-2。
 
-3. **后续 PR(非 pilot)**
-   - 迁 `docs.shared/commented`、`summary.completed/failed`、`generic.approval`、`docs.access.outcome` 到 Registry;outcome 与 `pkg/cardrevision` + `standard_action_finalizer` 联动,同一 PR 引入 `CardUpdater`;
+3. **post-#633 交互闭环（cardtmpl-interaction-closure task）**
+   - 新增并同时注册 `docs.access-request@0.3.0`；`pending` 使用 `octo/v2`，
+     `approved/rejected` result 使用 `octo/v1`；冻结的 `0.2.0` 字节不修改；
+   - 引入 `CardUpdater.ReplaceView/Append`，docs terminal finalizer 用 `0.3.0/result`
+     原消息更新；旧 `0.2.0/pending` action data 缺少装饰字段时安全省略；
+   - callback route 默认 legacy，显式 `octo-card-v1` 才发送标准 envelope；
+   - 增加 callback/update 两个有界指标，且不发布 `response_url`。
+
+4. **后续 PR**
+   - 迁 `docs.shared/commented`、`summary.completed/failed`、`generic.approval` 等模板到 Registry；
    - 开放 `/v1/message/card/templates` 只读端点(涉及 per-owner 可见性 / i18n 文案透出);
    - 开放 JSON 模板模式(`templates/*.template.json` + 表达式引擎);
    - 开放 envelope 模式(调用方显式传 `template_id`),替换 `NotifyReq` 四选一;
@@ -654,9 +678,10 @@ label `template_id` 基数 = 注册表大小（硬编码），无基数爆炸。
 
 ---
 
-## 16. 不做什么（Out of scope, 对齐 brief）
+## 16. #633 pilot 当时不做什么（历史记录）
 
-本 PR (cardtmpl-registry-pilot) 明确不做,后续 PR 承接:
+以下条目描述 #633 pilot 的边界；其中 `CardUpdater` 与 `0.3.0/result` 已由 §15.3
+承接完成，其余仍按独立 brief 推进：
 
 - 不引入 `${}` 表达式引擎(PR-1 阶段);
 - 不改 `NotifyReq` 外部形状(方案 B);
@@ -681,6 +706,6 @@ label `template_id` 基数 = 注册表大小（硬编码），无基数爆炸。
 | 组件白名单 | 官方 block types | 官方 `tag` | `pkg/cardmsg/whitelist.go` |
 | 交互元素 ID | `block_id` + `action_id` | `element_id` 全局唯一 | `DeclaredAction.ID` / `DeclaredInput.ID`，机读 interaction report |
 | 回调 | block_actions 事件 | action 回调 | `POST /v1/message/card/action`,payload 第 7 节 |
-| response_url 更新 | response_url(5min) | 延迟更新/流式更新 | `CardUpdater.ReplaceView/Append` + response_url 预留 |
+| response_url 更新 | response_url(5min) | 延迟更新/流式更新 | `CardUpdater.ReplaceView/Append` 已落地；response_url 仅保留、不发出 |
 | 降级 | 未知 block 忽略 + text fallback | schema 不兼容提示升级 | Profile 分档 + FallbackText（第 10 节） |
 | 能力分档 | 全量交互 | 全量交互 | octo/v1 展示 / octo/v2 交互 |

--- a/internal/cardactiondispatch/config.go
+++ b/internal/cardactiondispatch/config.go
@@ -59,6 +59,7 @@ type routeJSON struct {
 	BaseBackoffMS  int64  `json:"base_backoff_ms"`
 	MaxBackoffMS   int64  `json:"max_backoff_ms"`
 	MaxInFlight    int    `json:"max_in_flight"`
+	CallbackFormat string `json:"callback_format"`
 }
 
 func LoadRouteSpecs(raw string) ([]RouteSpec, error) {
@@ -80,6 +81,10 @@ func LoadRouteSpecs(raw string) ([]RouteSpec, error) {
 		if item.TimeoutMS < 0 || item.BaseBackoffMS < 0 || item.MaxBackoffMS < 0 {
 			return nil, errors.New("cardactiondispatch: route durations must not be negative")
 		}
+		format := CallbackFormat(item.CallbackFormat)
+		if format != "" && format != CallbackFormatLegacy && format != CallbackFormatOctoCardV1 {
+			return nil, errors.New("cardactiondispatch: invalid callback_format")
+		}
 		spec := RouteSpec{
 			SenderUID:      item.SenderUID,
 			Owner:          item.Owner,
@@ -89,6 +94,7 @@ func LoadRouteSpecs(raw string) ([]RouteSpec, error) {
 			NotifyTokenEnv: item.NotifyTokenEnv,
 			MaxAttempts:    item.MaxAttempts,
 			MaxInFlight:    item.MaxInFlight,
+			CallbackFormat: format,
 		}
 		if item.TimeoutMS > 0 {
 			spec.Timeout = time.Duration(item.TimeoutMS) * time.Millisecond

--- a/internal/cardactiondispatch/contract.go
+++ b/internal/cardactiondispatch/contract.go
@@ -46,7 +46,23 @@ type Event struct {
 	ActedAt     int64                  `json:"acted_at"`
 	Inputs      map[string]interface{} `json:"inputs"`
 	Data        map[string]interface{} `json:"data,omitempty"`
+	Card        CardContext            `json:"card,omitempty"`
 }
+
+// CardContext is derived from the effective server-authored card frame before
+// enqueue. Zero value means a legacy card without registry metadata.
+type CardContext struct {
+	TemplateID      string `json:"template_id,omitempty"`
+	TemplateVersion string `json:"template_version,omitempty"`
+	View            string `json:"view,omitempty"`
+}
+
+type CallbackFormat string
+
+const (
+	CallbackFormatLegacy     CallbackFormat = "legacy"
+	CallbackFormatOctoCardV1 CallbackFormat = "octo-card-v1"
+)
 
 type DecisionRequest struct {
 	EventID     int64                  `json:"event_id,string"`
@@ -62,6 +78,7 @@ type DecisionRequest struct {
 	ChannelType uint8                  `json:"channel_type"`
 	SpaceID     string                 `json:"space_id,omitempty"`
 	ActedAt     int64                  `json:"acted_at"`
+	event       *Event
 }
 
 type DecisionResult struct {
@@ -76,7 +93,7 @@ func DecisionRequestFromEvent(event Event) DecisionRequest {
 	if inputs == nil {
 		inputs = map[string]interface{}{}
 	}
-	return DecisionRequest{
+	request := DecisionRequest{
 		EventID:     event.EventID,
 		ActionID:    event.ActionID,
 		Decision:    stringField(event.Data, "decision"),
@@ -91,6 +108,85 @@ func DecisionRequestFromEvent(event Event) DecisionRequest {
 		SpaceID:     event.SpaceID,
 		ActedAt:     event.ActedAt,
 	}
+	request.event = &event
+	return request
+}
+
+type callbackEnvelope struct {
+	Protocol  string         `json:"protocol"`
+	Type      string         `json:"type"`
+	Action    callbackAction `json:"action"`
+	Card      callbackCard   `json:"card"`
+	Actor     callbackActor  `json:"actor"`
+	TriggerID string         `json:"trigger_id"`
+}
+
+type callbackAction struct {
+	ID     string                 `json:"id"`
+	Data   map[string]interface{} `json:"data,omitempty"`
+	Inputs map[string]interface{} `json:"inputs"`
+}
+
+type callbackCard struct {
+	TemplateID      string `json:"template_id"`
+	TemplateVersion string `json:"template_version"`
+	View            string `json:"view"`
+	MessageID       string `json:"message_id"`
+	ChannelID       string `json:"channel_id"`
+	ChannelType     uint8  `json:"channel_type"`
+}
+
+type callbackActor struct {
+	UID string `json:"uid"`
+}
+
+// MarshalCallbackRequest encodes either the frozen flat request or the
+// route-opted-in octo-card envelope. response_url is intentionally absent until
+// a signed inbound response contract exists.
+func MarshalCallbackRequest(event Event, format CallbackFormat) ([]byte, error) {
+	if format == "" || format == CallbackFormatLegacy {
+		return json.Marshal(DecisionRequestFromEvent(event))
+	}
+	if format != CallbackFormatOctoCardV1 {
+		return nil, errors.New("cardactiondispatch: unsupported callback format")
+	}
+	if event.EventID <= 0 || event.Card.TemplateID == "" || event.Card.TemplateVersion == "" || event.Card.View == "" {
+		return nil, errors.New("cardactiondispatch: octo-card callback context is incomplete")
+	}
+	inputs := event.Inputs
+	if inputs == nil {
+		inputs = map[string]interface{}{}
+	}
+	return json.Marshal(callbackEnvelope{
+		Protocol: "octo-card@1.0",
+		Type:     "card.action",
+		Action: callbackAction{
+			ID: event.ActionID, Data: event.Data, Inputs: inputs,
+		},
+		Card: callbackCard{
+			TemplateID: event.Card.TemplateID, TemplateVersion: event.Card.TemplateVersion, View: event.Card.View,
+			MessageID: event.MessageID, ChannelID: event.ChannelID, ChannelType: event.ChannelType,
+		},
+		Actor:     callbackActor{UID: event.OperatorUID},
+		TriggerID: fmt.Sprintf("%d", event.EventID),
+	})
+}
+
+func marshalDecisionRequest(request DecisionRequest, format CallbackFormat) ([]byte, error) {
+	if format == "" || format == CallbackFormatLegacy {
+		return json.Marshal(request)
+	}
+	if request.event == nil {
+		return nil, errors.New("cardactiondispatch: callback request has no source event")
+	}
+	// Routes may opt into the new format while pre-registry cards are still in
+	// flight. A completely absent CardContext identifies that legacy path and
+	// preserves its flat payload; partial context still reaches
+	// MarshalCallbackRequest and fails closed as corrupt/incomplete metadata.
+	if format == CallbackFormatOctoCardV1 && request.event.Card == (CardContext{}) {
+		return json.Marshal(request)
+	}
+	return MarshalCallbackRequest(*request.event, format)
 }
 
 func DecodeDecisionResult(reader io.Reader) (DecisionResult, error) {

--- a/internal/cardactiondispatch/dispatcher.go
+++ b/internal/cardactiondispatch/dispatcher.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl"
 	"go.uber.org/zap"
 )
 
@@ -212,6 +213,7 @@ func (d *Dispatcher) ProcessOne(ctx context.Context, now time.Time) (bool, error
 	workCtx := context.WithoutCancel(ctx)
 	result, err := d.deliverer.Deliver(workCtx, route, DecisionRequestFromEvent(lease.Event))
 	if err != nil {
+		recordTemplateCallback(lease.Event, callbackMetricResultForError(err))
 		category := errorCategory(err)
 		d.metrics.observeError(owner, category)
 		retry := Retryable(err)
@@ -224,6 +226,11 @@ func (d *Dispatcher) ProcessOne(ctx context.Context, now time.Time) (bool, error
 		d.refreshDepthMetrics()
 		return true, nackErr
 	}
+	callbackResult := "ok"
+	if result.Disposition != DispositionApplied && result.Disposition != DispositionReplayed {
+		callbackResult = "rejected"
+	}
+	recordTemplateCallback(lease.Event, callbackResult)
 	stopHeartbeat := d.startLeaseHeartbeat(*lease)
 	finalizeErr := d.finalizer.Finalize(workCtx, lease.Event, result)
 	if renewErr := stopHeartbeat(); renewErr != nil {
@@ -258,6 +265,21 @@ func (d *Dispatcher) ProcessOne(ctx context.Context, now time.Time) (bool, error
 	resultLabel = "ok"
 	d.refreshDepthMetrics()
 	return true, nil
+}
+
+func recordTemplateCallback(event Event, result string) {
+	if event.Card.TemplateID == "" || event.Card.TemplateVersion == "" || event.ActionID == "" {
+		return
+	}
+	cardtmpl.RecordCallback(cardtmpl.ID(event.Card.TemplateID), event.Card.TemplateVersion, event.ActionID, result)
+}
+
+func callbackMetricResultForError(err error) string {
+	var deliveryErr *DeliveryError
+	if errors.As(err, &deliveryErr) && deliveryErr.Status >= 400 && deliveryErr.Status < 500 {
+		return "rejected"
+	}
+	return "error"
 }
 
 func (d *Dispatcher) startLeaseHeartbeat(lease Lease) func() error {

--- a/internal/cardactiondispatch/envelope_test.go
+++ b/internal/cardactiondispatch/envelope_test.go
@@ -1,0 +1,138 @@
+package cardactiondispatch
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestMarshalCallbackRequestSupportsLegacyAndOctoCardEnvelope(t *testing.T) {
+	event := Event{
+		EventID: 9007199254740993, SenderUID: "notification", Owner: "docs", ActionType: "access_request.decision",
+		MessageID: "1001", ChannelID: "user-b", ChannelType: 1, SpaceID: "space-1",
+		ActionID: "docs-access-approve", OperatorUID: "reviewer-1", ActedAt: 123,
+		Inputs: map[string]any{}, Data: map[string]any{"owner": "docs", "action_type": "access_request.decision", "decision": "approve"},
+		Card: CardContext{TemplateID: "docs.access-request", TemplateVersion: "0.2.0", View: "pending"},
+	}
+	legacy, err := MarshalCallbackRequest(event, CallbackFormatLegacy)
+	if err != nil {
+		t.Fatalf("MarshalCallbackRequest(legacy): %v", err)
+	}
+	wantLegacy := `{"event_id":"9007199254740993","action_id":"docs-access-approve","decision":"approve","operator_uid":"reviewer-1","inputs":{},"data":{"action_type":"access_request.decision","decision":"approve","owner":"docs"},"message_id":"1001","channel_id":"user-b","channel_type":1,"space_id":"space-1","acted_at":123}`
+	if string(legacy) != wantLegacy {
+		t.Fatalf("legacy body drifted:\n got %s\nwant %s", legacy, wantLegacy)
+	}
+	legacyEvent := event
+	legacyEvent.Card = CardContext{}
+	legacyOnUpgradedRoute, err := marshalDecisionRequest(DecisionRequestFromEvent(legacyEvent), CallbackFormatOctoCardV1)
+	if err != nil {
+		t.Fatalf("legacy card on upgraded route: %v", err)
+	}
+	if string(legacyOnUpgradedRoute) != wantLegacy {
+		t.Fatalf("legacy card compatibility body drifted:\n got %s\nwant %s", legacyOnUpgradedRoute, wantLegacy)
+	}
+	partialEvent := legacyEvent
+	partialEvent.Card.TemplateID = "docs.access-request"
+	if _, err := marshalDecisionRequest(DecisionRequestFromEvent(partialEvent), CallbackFormatOctoCardV1); err == nil {
+		t.Fatal("partial callback CardContext must fail closed")
+	}
+
+	standard, err := MarshalCallbackRequest(event, CallbackFormatOctoCardV1)
+	if err != nil {
+		t.Fatalf("MarshalCallbackRequest(octo-card-v1): %v", err)
+	}
+	var body map[string]any
+	if err := json.Unmarshal(standard, &body); err != nil {
+		t.Fatalf("decode standard body: %v", err)
+	}
+	if body["protocol"] != "octo-card@1.0" || body["type"] != "card.action" || body["trigger_id"] != "9007199254740993" {
+		t.Fatalf("standard envelope header = %+v", body)
+	}
+	action := body["action"].(map[string]any)
+	if action["id"] != event.ActionID {
+		t.Fatalf("action = %+v", action)
+	}
+	card := body["card"].(map[string]any)
+	if card["template_id"] != event.Card.TemplateID || card["template_version"] != event.Card.TemplateVersion || card["view"] != "pending" {
+		t.Fatalf("card context = %+v", card)
+	}
+	actor := body["actor"].(map[string]any)
+	if actor["uid"] != event.OperatorUID {
+		t.Fatalf("actor = %+v", actor)
+	}
+	if _, exists := body["response_url"]; exists {
+		t.Fatal("response_url must not be emitted before a signed response contract exists")
+	}
+}
+
+func TestLoadRouteSpecsCallbackFormatDefaultsLegacyAndRejectsUnknown(t *testing.T) {
+	specs, err := LoadRouteSpecs(`[{
+		"sender_uid":"notification","owner":"docs","action_type":"access_request.decision",
+		"url":"https://docs.internal/callback","secret_env":"SECRET"
+	}]`)
+	if err != nil {
+		t.Fatalf("LoadRouteSpecs(default): %v", err)
+	}
+	if len(specs) != 1 || specs[0].CallbackFormat != CallbackFormatLegacy {
+		t.Fatalf("default callback format = %+v", specs)
+	}
+	specs, err = LoadRouteSpecs(`[{
+		"sender_uid":"notification","owner":"docs","action_type":"access_request.decision",
+		"url":"https://docs.internal/callback","secret_env":"SECRET","callback_format":"octo-card-v1"
+	}]`)
+	if err != nil || specs[0].CallbackFormat != CallbackFormatOctoCardV1 {
+		t.Fatalf("LoadRouteSpecs(octo-card-v1) = (%+v, %v)", specs, err)
+	}
+	if _, err := LoadRouteSpecs(`[{
+		"sender_uid":"notification","owner":"docs","action_type":"access_request.decision",
+		"url":"https://docs.internal/callback","secret_env":"SECRET","callback_format":"future"
+	}]`); err == nil {
+		t.Fatal("LoadRouteSpecs(unknown callback format) error = nil")
+	}
+}
+
+func TestHTTPDelivererSignsExactOctoCardEnvelope(t *testing.T) {
+	var signatureOK atomic.Bool
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer r.Body.Close()
+		raw, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("read callback body: %v", err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		if Verify(testCallbackSecret, r.Header.Get(HeaderSignature), r.Method, r.URL.EscapedPath(),
+			r.Header.Get(HeaderTimestamp), r.Header.Get(HeaderEventID), raw) {
+			signatureOK.Store(true)
+		}
+		var envelope map[string]any
+		if err := json.Unmarshal(raw, &envelope); err != nil || envelope["protocol"] != "octo-card@1.0" {
+			t.Errorf("octo-card callback body = %s, error = %v", raw, err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"disposition":"applied","state":"approved","requester_uid":"user-a"}`))
+	}))
+	defer server.Close()
+
+	event := testDispatchEvent()
+	event.ActionID = "docs-access-approve"
+	event.Card = CardContext{TemplateID: "docs.access-request", TemplateVersion: "0.3.0", View: "pending"}
+	route := &Route{
+		URL: server.URL + "/v1/card-actions/decide", Timeout: time.Second,
+		CallbackFormat: CallbackFormatOctoCardV1, secret: testCallbackSecret,
+	}
+	deliverer := NewHTTPDeliverer(server.Client().Transport, func() time.Time {
+		return time.Unix(1_784_073_600, 0)
+	})
+	if _, err := deliverer.Deliver(context.Background(), route, DecisionRequestFromEvent(event)); err != nil {
+		t.Fatalf("Deliver(octo-card-v1): %v", err)
+	}
+	if !signatureOK.Load() {
+		t.Fatal("octo-card callback signature did not verify against the exact body")
+	}
+}

--- a/internal/cardactiondispatch/http.go
+++ b/internal/cardactiondispatch/http.go
@@ -3,7 +3,6 @@ package cardactiondispatch
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -72,7 +71,7 @@ func (d *HTTPDeliverer) Deliver(ctx context.Context, route *Route, request Decis
 	if ctx == nil || route == nil {
 		return DecisionResult{}, &DeliveryError{Category: "invalid_request"}
 	}
-	body, err := json.Marshal(request)
+	body, err := marshalDecisionRequest(request, route.CallbackFormat)
 	if err != nil {
 		return DecisionResult{}, &DeliveryError{Category: "encode_failed", cause: err}
 	}

--- a/internal/cardactiondispatch/registry.go
+++ b/internal/cardactiondispatch/registry.go
@@ -46,18 +46,20 @@ type RouteSpec struct {
 	BaseBackoff    time.Duration
 	MaxBackoff     time.Duration
 	MaxInFlight    int
+	CallbackFormat CallbackFormat
 }
 
 type Route struct {
-	SenderUID   string
-	Owner       string
-	ActionType  string
-	URL         string
-	Timeout     time.Duration
-	MaxAttempts int
-	BaseBackoff time.Duration
-	MaxBackoff  time.Duration
-	MaxInFlight int
+	SenderUID      string
+	Owner          string
+	ActionType     string
+	URL            string
+	Timeout        time.Duration
+	MaxAttempts    int
+	BaseBackoff    time.Duration
+	MaxBackoff     time.Duration
+	MaxInFlight    int
+	CallbackFormat CallbackFormat
 
 	secret string
 }
@@ -118,16 +120,17 @@ func NewRegistry(specs []RouteSpec, getenv func(string) string) (*Registry, erro
 		}
 		callbackSecret := getenv(spec.SecretEnv)
 		registry.routes[key] = &Route{
-			SenderUID:   spec.SenderUID,
-			Owner:       spec.Owner,
-			ActionType:  spec.ActionType,
-			URL:         spec.URL,
-			Timeout:     spec.Timeout,
-			MaxAttempts: spec.MaxAttempts,
-			BaseBackoff: spec.BaseBackoff,
-			MaxBackoff:  spec.MaxBackoff,
-			MaxInFlight: spec.MaxInFlight,
-			secret:      callbackSecret,
+			SenderUID:      spec.SenderUID,
+			Owner:          spec.Owner,
+			ActionType:     spec.ActionType,
+			URL:            spec.URL,
+			Timeout:        spec.Timeout,
+			MaxAttempts:    spec.MaxAttempts,
+			BaseBackoff:    spec.BaseBackoff,
+			MaxBackoff:     spec.MaxBackoff,
+			MaxInFlight:    spec.MaxInFlight,
+			CallbackFormat: spec.CallbackFormat,
+			secret:         callbackSecret,
 		}
 		registry.callbackSecrets[callbackSecret] = struct{}{}
 		registry.internalSenders[spec.SenderUID] = struct{}{}
@@ -270,6 +273,9 @@ func withRouteDefaults(spec RouteSpec) RouteSpec {
 	if spec.MaxInFlight == 0 {
 		spec.MaxInFlight = defaultMaxInFlight
 	}
+	if spec.CallbackFormat == "" {
+		spec.CallbackFormat = CallbackFormatLegacy
+	}
 	return spec
 }
 
@@ -282,6 +288,9 @@ func validateRouteSpec(spec RouteSpec, getenv func(string) string) error {
 	}
 	if !actionTypePattern.MatchString(spec.ActionType) {
 		return errors.New("invalid action_type")
+	}
+	if spec.CallbackFormat != CallbackFormatLegacy && spec.CallbackFormat != CallbackFormatOctoCardV1 {
+		return errors.New("invalid callback_format")
 	}
 	if _, err := validateCallbackURL(spec.URL); err != nil {
 		return err

--- a/internal/carddispatch/mutation.go
+++ b/internal/carddispatch/mutation.go
@@ -2,6 +2,7 @@ package carddispatch
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strconv"
@@ -41,6 +42,23 @@ type CardMutationResult struct {
 	Replay  bool
 }
 
+// CardMutationTarget identifies an existing message using only authoritative
+// server-side values. MessageSeq is an optional lookup optimization.
+type CardMutationTarget struct {
+	SenderUID   string
+	MessageID   string
+	MessageSeq  uint32
+	ChannelID   string
+	ChannelType uint8
+}
+
+// CardMutationSnapshot is the current effective type-17 frame. Envelope is
+// content_edit when present, otherwise the immutable original payload.
+type CardMutationSnapshot struct {
+	Envelope json.RawMessage
+	CardSeq  int64
+}
+
 type CardMutationCASRequest struct {
 	MessageID   string
 	MessageSeq  uint32
@@ -78,6 +96,7 @@ type cardMutationWrite struct {
 type cardMutationBackend interface {
 	Lookup(context.Context, CardMutationRequest) (storedCardMessage, error)
 	Lifecycle(messageID string) (revoked bool, deleted bool, err error)
+	EffectiveContent(messageID string) (content string, cardSeq int64, found bool, err error)
 	ContentHashExists(messageID, hash string) (bool, error)
 	CASWrite(cardMutationWrite) (conflict bool, replay bool, err error)
 	AppendRevision(cardMutationWrite) error
@@ -97,6 +116,52 @@ func NewCardMutator(ctx *config.Context) *CardMutator {
 
 func newCardMutator(backend cardMutationBackend) *CardMutator {
 	return &CardMutator{backend: backend}
+}
+
+// Snapshot returns the active effective card after applying the same sender and
+// lifecycle gates as Mutate. It exists for read-modify-write operations such as
+// CardUpdater.Append; the subsequent Mutate still performs all checks again and
+// owns the CAS.
+func (m *CardMutator) Snapshot(ctx context.Context, target CardMutationTarget) (CardMutationSnapshot, error) {
+	if m == nil || m.backend == nil || ctx == nil || target.SenderUID == "" || target.MessageID == "" || target.ChannelID == "" {
+		return CardMutationSnapshot{}, ErrCardMutationInvalid
+	}
+	request := CardMutationRequest{
+		SenderUID: target.SenderUID, MessageID: target.MessageID, MessageSeq: target.MessageSeq,
+		ChannelID: target.ChannelID, ChannelType: target.ChannelType,
+	}
+	message, err := m.backend.Lookup(ctx, request)
+	if err != nil {
+		return CardMutationSnapshot{}, err
+	}
+	if message.MessageID != target.MessageID || message.FromUID != target.SenderUID {
+		return CardMutationSnapshot{}, ErrCardMutationForbidden
+	}
+	if !cardmsg.IsCardRawPayload(message.Payload) {
+		return CardMutationSnapshot{}, ErrCardMutationInvalid
+	}
+	revoked, deleted, err := m.backend.Lifecycle(target.MessageID)
+	if err != nil {
+		return CardMutationSnapshot{}, fmt.Errorf("carddispatch: query card lifecycle: %w", err)
+	}
+	if revoked || deleted {
+		return CardMutationSnapshot{}, ErrCardMutationNotFound
+	}
+	content, seq, found, err := m.backend.EffectiveContent(target.MessageID)
+	if err != nil {
+		return CardMutationSnapshot{}, fmt.Errorf("carddispatch: query effective card: %w", err)
+	}
+	if !found {
+		return CardMutationSnapshot{Envelope: append(json.RawMessage(nil), message.Payload...)}, nil
+	}
+	if !cardmsg.IsCardContentEdit(content) {
+		return CardMutationSnapshot{}, ErrCardMutationInvalid
+	}
+	parsedSeq, ok := cardmsg.CardSeqFromContentEdit(content)
+	if !ok || parsedSeq <= 0 || parsedSeq != seq {
+		return CardMutationSnapshot{}, ErrCardMutationInvalid
+	}
+	return CardMutationSnapshot{Envelope: json.RawMessage(content), CardSeq: seq}, nil
 }
 
 func (m *CardMutator) Mutate(ctx context.Context, request CardMutationRequest) (CardMutationResult, error) {
@@ -239,6 +304,27 @@ func (b *productionMutationBackend) Lifecycle(messageID string) (bool, bool, err
 		return false, false, nil
 	}
 	return lifecycle.Revoke == 1, lifecycle.IsDeleted == 1, err
+}
+
+func (b *productionMutationBackend) EffectiveContent(messageID string) (string, int64, bool, error) {
+	var current struct {
+		Content dbr.NullString `db:"content_edit"`
+		CardSeq dbr.NullInt64  `db:"card_seq"`
+	}
+	err := b.ctx.DB().Select("content_edit", "card_seq").From("message_extra").Where("message_id=?", messageID).LoadOne(&current)
+	if err == dbr.ErrNotFound {
+		return "", 0, false, nil
+	}
+	if err != nil {
+		return "", 0, false, err
+	}
+	if !current.Content.Valid || current.Content.String == "" {
+		return "", 0, false, nil
+	}
+	if !current.CardSeq.Valid {
+		return current.Content.String, 0, true, nil
+	}
+	return current.Content.String, current.CardSeq.Int64, true, nil
 }
 
 func (b *productionMutationBackend) ContentHashExists(messageID, hash string) (bool, error) {

--- a/internal/carddispatch/mutation_test.go
+++ b/internal/carddispatch/mutation_test.go
@@ -23,6 +23,14 @@ type fakeMutationBackend struct {
 	writes        []cardMutationWrite
 	revisions     []cardMutationWrite
 	syncs         []cardMutationWrite
+	effective     string
+	effectiveSeq  int64
+	effectiveSet  bool
+	effectiveErr  error
+}
+
+func (b *fakeMutationBackend) EffectiveContent(string) (string, int64, bool, error) {
+	return b.effective, b.effectiveSeq, b.effectiveSet, b.effectiveErr
 }
 
 func (b *fakeMutationBackend) Lookup(_ context.Context, _ CardMutationRequest) (storedCardMessage, error) {

--- a/main.go
+++ b/main.go
@@ -701,8 +701,8 @@ func replaceWebConfig(cfg *config.Config) {
 }
 
 // installCardTmplRegistry 装配 L0 cardtmpl.Registry 并注入到 pkg-scoped default。
-// 本 PR (cardtmpl-registry-pilot) 只注册 docs.access-request@0.2.0 一张 L2a 卡;
-// 后续 PR 逐张迁移 summary/docs.shared/generic.approval 到本函数。
+// 同时保留已发布冻结的 0.2.0 与带 result 视图的 0.3.0;新消息默认 0.3.0,
+// 旧 0.2.0 pending 消息仍可由 finalizer 升级成 0.3.0/result。
 //
 // Fail-close 契约:任一 Register/SetDefault 失败 → panic(与 main.go:521 现有的
 // docs approval callback route 校验同源)。init 期 schema/manifest 语法错无
@@ -710,7 +710,8 @@ func replaceWebConfig(cfg *config.Config) {
 func installCardTmplRegistry() {
 	registry := cardtmpl.NewRegistry()
 	registry.Register(docsaccessrequest.New(), docsaccessrequest.Assets, docsaccessrequest.HandoffRoot)
-	registry.SetDefault(docsaccessrequest.TemplateID, docsaccessrequest.TemplateVersion)
+	registry.Register(docsaccessrequest.NewV3(), docsaccessrequest.Assets, docsaccessrequest.HandoffRootV3)
+	registry.SetDefault(docsaccessrequest.TemplateID, docsaccessrequest.TemplateVersionV3)
 	registry.Freeze()
 	cardtmpl.SetGlobalMetrics(cardtmpl.NewMetrics(prometheus.DefaultRegisterer))
 	cardtmpl.SetDefaultRegistry(registry)

--- a/modules/message/api_card_action.go
+++ b/modules/message/api_card_action.go
@@ -35,6 +35,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-server/modules/group"
 	"github.com/Mininglamp-OSS/octo-server/modules/thread"
 	"github.com/Mininglamp-OSS/octo-server/pkg/cardmsg"
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl"
 	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
 	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
 	"github.com/Mininglamp-OSS/octo-server/pkg/i18n/codes"
@@ -218,6 +219,14 @@ func (m *Message) cardAction(c *wkhttp.Context) {
 		httperr.ResponseErrorL(c, errcode.ErrMessageCardActionInvalid, nil, nil)
 		return
 	}
+	cardContext, err := resolveRegistryCardContext(effective, req.ActionID)
+	if err != nil {
+		m.releaseCardClaim(idemKey)
+		m.Warn("registry 卡片 action 与已发布交互契约不一致,拒绝",
+			zap.Error(err), zap.String("messageID", req.MessageID), zap.String("actionID", req.ActionID))
+		httperr.ResponseErrorL(c, errcode.ErrMessageCardActionInvalid, nil, nil)
+		return
+	}
 
 	// D5 投递 card_action（event_data 形状由 brief 冻结：只许增字段）。
 	//   - data：匹配 Action.Submit 的作者静态对象，从生效帧提取（D11，仅当声明了
@@ -262,6 +271,7 @@ func (m *Message) cardAction(c *wkhttp.Context) {
 		ActedAt:     eventData["acted_at"].(int64),
 		Inputs:      req.Inputs,
 		Data:        actionData,
+		Card:        cardContext,
 	})
 	if err != nil {
 		m.releaseCardClaim(idemKey)
@@ -281,6 +291,30 @@ func (m *Message) cardAction(c *wkhttp.Context) {
 		m.Warn("卡片动作幂等 confirm 未生效", zap.Bool("ok", ok), zap.Error(err), zap.String("key", idemKey))
 	}
 	c.Response(map[string]interface{}{"accepted": true, "replay": false})
+}
+
+// resolveRegistryCardContext binds callback context to metadata and interaction
+// reports from the effective server-authored frame. Cards without octo-card
+// template metadata retain the legacy zero context.
+func resolveRegistryCardContext(effective []byte, actionID string) (cardactiondispatch.CardContext, error) {
+	ref, ok := cardmsg.CardTemplateContext(effective)
+	if !ok {
+		if cardmsg.HasCardTemplateMetadata(effective) {
+			return cardactiondispatch.CardContext{}, errors.New("message: card template metadata is incomplete")
+		}
+		return cardactiondispatch.CardContext{}, nil
+	}
+	registry := cardtmpl.DefaultRegistry()
+	if registry == nil {
+		return cardactiondispatch.CardContext{}, errors.New("message: cardtmpl registry unavailable")
+	}
+	view, err := registry.ActionView(cardtmpl.ID(ref.ID), ref.Version, actionID)
+	if err != nil {
+		return cardactiondispatch.CardContext{}, err
+	}
+	return cardactiondispatch.CardContext{
+		TemplateID: ref.ID, TemplateVersion: ref.Version, View: string(view),
+	}, nil
 }
 
 var errInternalCardActionRouteRejected = errors.New("internal card action route rejected")

--- a/modules/message/api_card_action.go
+++ b/modules/message/api_card_action.go
@@ -219,7 +219,7 @@ func (m *Message) cardAction(c *wkhttp.Context) {
 		httperr.ResponseErrorL(c, errcode.ErrMessageCardActionInvalid, nil, nil)
 		return
 	}
-	cardContext, err := resolveRegistryCardContext(effective, req.ActionID)
+	cardContext, err := resolveRegistryCardContext(effective, req.ActionID, actionData)
 	if err != nil {
 		m.releaseCardClaim(idemKey)
 		m.Warn("registry 卡片 action 与已发布交互契约不一致,拒绝",
@@ -296,7 +296,7 @@ func (m *Message) cardAction(c *wkhttp.Context) {
 // resolveRegistryCardContext binds callback context to metadata and interaction
 // reports from the effective server-authored frame. Cards without octo-card
 // template metadata retain the legacy zero context.
-func resolveRegistryCardContext(effective []byte, actionID string) (cardactiondispatch.CardContext, error) {
+func resolveRegistryCardContext(effective []byte, actionID string, actionData map[string]interface{}) (cardactiondispatch.CardContext, error) {
 	ref, ok := cardmsg.CardTemplateContext(effective)
 	if !ok {
 		if cardmsg.HasCardTemplateMetadata(effective) {
@@ -311,6 +311,22 @@ func resolveRegistryCardContext(effective []byte, actionID string) (cardactiondi
 	view, err := registry.ActionView(cardtmpl.ID(ref.ID), ref.Version, actionID)
 	if err != nil {
 		return cardactiondispatch.CardContext{}, err
+	}
+	// 交叉校验(PR#641 review P2):envelope 携带的模板身份(metadata.octo)必须与该
+	// 动作实际选路的 owner 一致。route owner 取自生效帧 Action.Submit.data.owner
+	// (cardActionRouteMetadata 据此选路)。对 Registry.Render 产的卡,
+	// assertActionContract 已强制 data.owner==template owner,故此断言只挡手工构造的
+	// 错配卡:防止一张 metadata 声明 docs 模板、data.owner 却指向别的已注册路由的卡,
+	// 把带 docs 身份的 octo-card-v1 信封投递到错误路由。
+	tmpl, err := registry.Lookup(cardtmpl.ID(ref.ID), ref.Version)
+	if err != nil {
+		return cardactiondispatch.CardContext{}, err
+	}
+	if contract := tmpl.Meta().ActionContract; contract != nil {
+		routeOwner, _ := actionData["owner"].(string)
+		if strings.TrimSpace(routeOwner) != contract.Owner {
+			return cardactiondispatch.CardContext{}, errors.New("message: card template owner does not match action route owner")
+		}
 	}
 	return cardactiondispatch.CardContext{
 		TemplateID: ref.ID, TemplateVersion: ref.Version, View: string(view),

--- a/modules/message/card_action_template_context_test.go
+++ b/modules/message/card_action_template_context_test.go
@@ -1,0 +1,55 @@
+package message
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-server/internal/cardactiondispatch"
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl"
+	docsaccessrequest "github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl/docs_access_request"
+)
+
+func TestResolveRegistryCardContextUsesEffectiveMetadataAndReport(t *testing.T) {
+	registry := cardtmpl.NewRegistry()
+	registry.Register(docsaccessrequest.New(), docsaccessrequest.Assets, docsaccessrequest.HandoffRoot)
+	registry.SetDefault(docsaccessrequest.TemplateID, docsaccessrequest.TemplateVersion)
+	registry.Freeze()
+	cardtmpl.SetDefaultRegistry(registry)
+	t.Cleanup(func() { cardtmpl.SetDefaultRegistry(nil) })
+	sample, err := docsaccessrequest.Assets.ReadFile(docsaccessrequest.HandoffRoot + "/samples/pending.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload, err := registry.Render(context.Background(), docsaccessrequest.TemplateID, "",
+		docsaccessrequest.StatePending, sample,
+		cardtmpl.BuildEnv{WebLoginURL: "https://web.example.com", Lang: "en", SpaceID: "space-1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, _ := json.Marshal(payload)
+	got, err := resolveRegistryCardContext(raw, cardtmpl.DocsApproveActionID)
+	if err != nil {
+		t.Fatalf("resolveRegistryCardContext: %v", err)
+	}
+	want := cardactiondispatch.CardContext{TemplateID: "docs.access-request", TemplateVersion: "0.2.0", View: "pending"}
+	if got != want {
+		t.Fatalf("card context = %+v, want %+v", got, want)
+	}
+	if _, err := resolveRegistryCardContext(raw, "missing"); err == nil {
+		t.Fatal("undeclared action resolved without error")
+	}
+	card := payload["card"].(map[string]any)
+	metadata := card["metadata"].(map[string]any)
+	octo := metadata["octo"].(map[string]any)
+	template := octo["template"].(map[string]any)
+	delete(template, "version")
+	partialRaw, _ := json.Marshal(payload)
+	if _, err := resolveRegistryCardContext(partialRaw, cardtmpl.DocsApproveActionID); err == nil {
+		t.Fatal("partial registry metadata resolved as a legacy card")
+	}
+	legacy, err := resolveRegistryCardContext([]byte(`{"type":17,"card":{"body":[]}}`), "legacy")
+	if err != nil || legacy != (cardactiondispatch.CardContext{}) {
+		t.Fatalf("legacy context = (%+v, %v)", legacy, err)
+	}
+}

--- a/modules/message/card_action_template_context_test.go
+++ b/modules/message/card_action_template_context_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/Mininglamp-OSS/octo-server/internal/cardactiondispatch"
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardmsg"
 	"github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl"
 	docsaccessrequest "github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl/docs_access_request"
 )
@@ -28,7 +29,11 @@ func TestResolveRegistryCardContextUsesEffectiveMetadataAndReport(t *testing.T) 
 		t.Fatal(err)
 	}
 	raw, _ := json.Marshal(payload)
-	got, err := resolveRegistryCardContext(raw, cardtmpl.DocsApproveActionID)
+	actionData, ok := cardmsg.SubmitAction(raw, cardtmpl.DocsApproveActionID)
+	if !ok {
+		t.Fatal("approve action not found in rendered card")
+	}
+	got, err := resolveRegistryCardContext(raw, cardtmpl.DocsApproveActionID, actionData)
 	if err != nil {
 		t.Fatalf("resolveRegistryCardContext: %v", err)
 	}
@@ -36,19 +41,39 @@ func TestResolveRegistryCardContextUsesEffectiveMetadataAndReport(t *testing.T) 
 	if got != want {
 		t.Fatalf("card context = %+v, want %+v", got, want)
 	}
-	if _, err := resolveRegistryCardContext(raw, "missing"); err == nil {
+	if _, err := resolveRegistryCardContext(raw, "missing", nil); err == nil {
 		t.Fatal("undeclared action resolved without error")
 	}
+
+	// P2-b(PR#641 review):route owner(Action.data.owner)与 template owner 不一致
+	// 必须拒绝 —— 防止带 docs 身份的信封投递到别的路由。
+	if _, err := resolveRegistryCardContext(raw, cardtmpl.DocsApproveActionID,
+		map[string]interface{}{"owner": "summary", "action_type": "access_request.decision"}); err == nil {
+		t.Fatal("owner mismatch resolved without error")
+	}
+
+	// partial metadata(缺 version)→ 不能退化成 legacy。
 	card := payload["card"].(map[string]any)
 	metadata := card["metadata"].(map[string]any)
 	octo := metadata["octo"].(map[string]any)
 	template := octo["template"].(map[string]any)
 	delete(template, "version")
 	partialRaw, _ := json.Marshal(payload)
-	if _, err := resolveRegistryCardContext(partialRaw, cardtmpl.DocsApproveActionID); err == nil {
+	if _, err := resolveRegistryCardContext(partialRaw, cardtmpl.DocsApproveActionID, actionData); err == nil {
 		t.Fatal("partial registry metadata resolved as a legacy card")
 	}
-	legacy, err := resolveRegistryCardContext([]byte(`{"type":17,"card":{"body":[]}}`), "legacy")
+
+	// P2-a(PR#641 review):metadata.octo 是损坏的非对象 → fail closed,不当 legacy。
+	corrupt := map[string]any{"type": 17, "card": map[string]any{
+		"body":     []any{},
+		"metadata": map[string]any{"octo": "corrupt"},
+	}}
+	corruptRaw, _ := json.Marshal(corrupt)
+	if _, err := resolveRegistryCardContext(corruptRaw, "any", nil); err == nil {
+		t.Fatal("corrupt octo metadata resolved as a legacy card")
+	}
+
+	legacy, err := resolveRegistryCardContext([]byte(`{"type":17,"card":{"body":[]}}`), "legacy", nil)
 	if err != nil || legacy != (cardactiondispatch.CardContext{}) {
 		t.Fatalf("legacy context = (%+v, %v)", legacy, err)
 	}

--- a/modules/notify/action_finalizer.go
+++ b/modules/notify/action_finalizer.go
@@ -13,6 +13,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-server/internal/carddispatch"
 	"github.com/Mininglamp-OSS/octo-server/pkg/cardmsg"
 	"github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl"
+	docsaccessrequest "github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl/docs_access_request"
 	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
 )
 
@@ -23,6 +24,7 @@ type cardActionMutator interface {
 type DocsActionFinalizer struct {
 	ctx     *config.Context
 	mutator cardActionMutator
+	updater cardtmpl.CardUpdater
 	sender  carddispatch.Sender
 }
 
@@ -42,12 +44,24 @@ func NewDocsActionFinalizer(ctx *config.Context, mutator cardActionMutator, send
 	return &DocsActionFinalizer{ctx: ctx, mutator: mutator, sender: sender}, nil
 }
 
+func NewDocsActionFinalizerWithUpdater(ctx *config.Context, updater cardtmpl.CardUpdater, mutator cardActionMutator, sender carddispatch.Sender) (*DocsActionFinalizer, error) {
+	if ctx == nil || updater == nil || mutator == nil || sender == nil {
+		return nil, errors.New("notify: docs action finalizer dependencies are required")
+	}
+	return &DocsActionFinalizer{ctx: ctx, updater: updater, mutator: mutator, sender: sender}, nil
+}
+
 func NewDocsActionFinalizerFromContext(ctx *config.Context) (*DocsActionFinalizer, error) {
 	sender, err := carddispatch.SenderFromContext(ctx, docsNotifyProducerID)
 	if err != nil {
 		return nil, err
 	}
-	return NewDocsActionFinalizer(ctx, carddispatch.NewCardMutator(ctx), sender)
+	mutator := carddispatch.NewCardMutator(ctx)
+	updater, err := cardtmpl.NewCardUpdater(cardtmpl.DefaultRegistry(), mutator)
+	if err != nil {
+		return nil, err
+	}
+	return NewDocsActionFinalizerWithUpdater(ctx, updater, mutator, sender)
 }
 
 func (f *DocsActionFinalizer) Finalize(ctx context.Context, event cardactiondispatch.Event, result cardactiondispatch.DecisionResult) error {
@@ -72,6 +86,9 @@ func (f *DocsActionFinalizer) Finalize(ctx context.Context, event cardactiondisp
 	lang := i18n.OutboundLanguage(ctx)
 	title := strings.TrimSpace(result.Display["title"])
 	if title == "" {
+		title, _ = event.Data["doc_title"].(string)
+	}
+	if strings.TrimSpace(title) == "" {
 		title = docID
 	}
 	// The reviewer deny reason (if any) rode in as a declared input; surface it on
@@ -80,21 +97,28 @@ func (f *DocsActionFinalizer) Finalize(ctx context.Context, event cardactiondisp
 	if v, ok := event.Inputs[cardtmpl.DocsDenyReasonInputID].(string); ok {
 		denyReason = strings.TrimSpace(v)
 	}
-	terminalDocument, err := f.buildTerminalDocument(ctx, lang, docID, event.SpaceID, title, denyReason, result)
-	if err != nil {
-		return err
+	terminal := result.State == cardactiondispatch.StateApproved || result.State == cardactiondispatch.StateDenied
+	if terminal && f.updater != nil {
+		if err := f.replaceWithRegistryResult(ctx, event, result, channelID, lang, title, denyReason); err != nil {
+			return err
+		}
+	} else {
+		terminalDocument, err := f.buildTerminalDocument(ctx, lang, docID, event.SpaceID, title, denyReason, result)
+		if err != nil {
+			return err
+		}
+		contentEdit, err := buildTerminalEnvelope(terminalDocument, event.SpaceID, event.EventID)
+		if err != nil {
+			return err
+		}
+		if _, err := f.mutator.Mutate(ctx, carddispatch.CardMutationRequest{
+			SenderUID: event.SenderUID, MessageID: event.MessageID, ChannelID: channelID,
+			ChannelType: event.ChannelType, ContentEdit: contentEdit,
+		}); err != nil {
+			return err
+		}
 	}
-	contentEdit, err := buildTerminalEnvelope(terminalDocument, event.SpaceID, event.EventID)
-	if err != nil {
-		return err
-	}
-	if _, err := f.mutator.Mutate(ctx, carddispatch.CardMutationRequest{
-		SenderUID: event.SenderUID, MessageID: event.MessageID, ChannelID: channelID,
-		ChannelType: event.ChannelType, ContentEdit: contentEdit,
-	}); err != nil {
-		return err
-	}
-	if result.State != cardactiondispatch.StateApproved && result.State != cardactiondispatch.StateDenied {
+	if !terminal {
 		return nil
 	}
 	outcomeDocument, err := f.buildOutcomeDocument(ctx, lang, docID, event.SpaceID, title, denyReason, result.State)
@@ -108,6 +132,82 @@ func (f *DocsActionFinalizer) Finalize(ctx context.Context, event cardactiondisp
 		return &actionFinalizeError{category: "applicant_notify_failed", err: err}
 	}
 	return nil
+}
+
+func (f *DocsActionFinalizer) replaceWithRegistryResult(ctx context.Context, event cardactiondispatch.Event,
+	result cardactiondispatch.DecisionResult, channelID, lang, title, denyReason string) error {
+	state := docsaccessrequest.StateApproved
+	wireState := "approved"
+	if result.State == cardactiondispatch.StateDenied {
+		state = docsaccessrequest.StateRejected
+		wireState = "rejected"
+	}
+	if runes := []rune(denyReason); len(runes) > cardtmpl.MaxExcerptRunes {
+		denyReason = string(runes[:cardtmpl.MaxExcerptRunes])
+	}
+	requestID, _ := event.Data["request_id"].(string)
+	actor, _ := event.Data["actor"].(string)
+	operatorName := strings.TrimSpace(result.Display["operator_name"])
+	if operatorName == "" {
+		operatorName = event.OperatorUID
+	}
+	document := map[string]any{
+		"docId": strings.TrimSpace(stringEventData(event.Data, "doc_id")), "title": strings.TrimSpace(title),
+	}
+	requester := map[string]any{"name": strings.TrimSpace(actor)}
+	if value := strings.TrimSpace(stringEventData(event.Data, "source_name")); value != "" {
+		document["sourceName"] = value
+	}
+	if value := strings.TrimSpace(stringEventData(event.Data, "actor_avatar_url")); value != "" {
+		requester["avatarUrl"] = value
+	}
+	fields := map[string]any{
+		"requestId": strings.TrimSpace(requestID),
+		"state":     wireState,
+		"document":  document,
+		"requester": requester,
+		"decision": map[string]any{
+			"operatorName": operatorName, "decidedAtDisplay": strings.TrimSpace(result.Display["decided_at"]),
+		},
+	}
+	for destination, source := range map[string]string{
+		"requestReason": "request_reason", "requestedAtDisplay": "requested_at_display",
+		"messageTimeDisplay": "message_time_display",
+	} {
+		if value := strings.TrimSpace(stringEventData(event.Data, source)); value != "" {
+			fields[destination] = value
+		}
+	}
+	permission := make(map[string]any, 2)
+	if value := strings.TrimSpace(stringEventData(event.Data, "permission_label")); value != "" {
+		permission["label"] = value
+	}
+	if value := strings.TrimSpace(stringEventData(event.Data, "permission_role_label")); value != "" {
+		permission["roleLabel"] = value
+	}
+	if len(permission) > 0 {
+		fields["permission"] = permission
+	}
+	if wireState == "rejected" && denyReason != "" {
+		fields["decision"].(map[string]any)["rejectionReason"] = denyReason
+	}
+	raw, err := json.Marshal(fields)
+	if err != nil {
+		return fmt.Errorf("notify: marshal registry result fields: %w", err)
+	}
+	return f.updater.ReplaceView(ctx, cardtmpl.UpdateTarget{
+		Target: carddispatch.Target{
+			SpaceID: event.SpaceID, ChannelID: channelID, ChannelType: event.ChannelType,
+		},
+		SenderUID: event.SenderUID, MessageID: event.MessageID, CardSeq: event.EventID,
+	}, docsaccessrequest.TemplateID, docsaccessrequest.TemplateVersionV3, state, raw, cardtmpl.BuildEnv{
+		WebLoginURL: f.ctx.GetConfig().External.WebLoginURL, Lang: lang, SpaceID: event.SpaceID,
+	})
+}
+
+func stringEventData(data map[string]interface{}, key string) string {
+	value, _ := data[key].(string)
+	return value
 }
 
 func (f *DocsActionFinalizer) buildTerminalDocument(ctx context.Context, lang, docID, spaceID, title, denyReason string, result cardactiondispatch.DecisionResult) (json.RawMessage, error) {

--- a/modules/notify/action_finalizer.go
+++ b/modules/notify/action_finalizer.go
@@ -134,6 +134,30 @@ func (f *DocsActionFinalizer) Finalize(ctx context.Context, event cardactiondisp
 	return nil
 }
 
+// 0.3.0 result view schema 的各字段 rune 上限(见
+// handoff/docs.access-request@0.3.0/contract/data.schema.json)。回调 Display 与
+// event.Data 的值合法可达 500 runes(cardactiondispatch 契约),必须在渲染前截断
+// 到各自 schema cap —— 否则 RenderCard 的 InputSchema 校验返回 ErrFieldsInvalid,
+// ReplaceView 确定性失败,审批卡永远停在 pending 且申请人漏通知(PR#641 review P1)。
+// 截断而非编造,与 denyReason 既有做法一致。
+const (
+	capResultTitle      = 200                     // document.title / document.sourceName
+	capResultName       = 120                     // requester.name / decision.operatorName
+	capResultShortLabel = 80                      // decidedAt/requestedAt/messageTime/permission.*
+	capResultReason     = cardtmpl.MaxExcerptRunes // requestReason / rejectionReason (= 300)
+)
+
+// truncRunes 按 rune 截断到 max(max<=0 视为不限)。
+func truncRunes(s string, max int) string {
+	if max <= 0 {
+		return s
+	}
+	if r := []rune(s); len(r) > max {
+		return string(r[:max])
+	}
+	return s
+}
+
 func (f *DocsActionFinalizer) replaceWithRegistryResult(ctx context.Context, event cardactiondispatch.Event,
 	result cardactiondispatch.DecisionResult, channelID, lang, title, denyReason string) error {
 	state := docsaccessrequest.StateApproved
@@ -142,8 +166,8 @@ func (f *DocsActionFinalizer) replaceWithRegistryResult(ctx context.Context, eve
 		state = docsaccessrequest.StateRejected
 		wireState = "rejected"
 	}
-	if runes := []rune(denyReason); len(runes) > cardtmpl.MaxExcerptRunes {
-		denyReason = string(runes[:cardtmpl.MaxExcerptRunes])
+	if runes := []rune(denyReason); len(runes) > capResultReason {
+		denyReason = string(runes[:capResultReason])
 	}
 	requestID, _ := event.Data["request_id"].(string)
 	actor, _ := event.Data["actor"].(string)
@@ -152,13 +176,15 @@ func (f *DocsActionFinalizer) replaceWithRegistryResult(ctx context.Context, eve
 		operatorName = event.OperatorUID
 	}
 	document := map[string]any{
-		"docId": strings.TrimSpace(stringEventData(event.Data, "doc_id")), "title": strings.TrimSpace(title),
+		"docId": strings.TrimSpace(stringEventData(event.Data, "doc_id")),
+		"title": truncRunes(strings.TrimSpace(title), capResultTitle),
 	}
-	requester := map[string]any{"name": strings.TrimSpace(actor)}
+	requester := map[string]any{"name": truncRunes(strings.TrimSpace(actor), capResultName)}
 	if value := strings.TrimSpace(stringEventData(event.Data, "source_name")); value != "" {
-		document["sourceName"] = value
+		document["sourceName"] = truncRunes(value, capResultTitle)
 	}
 	if value := strings.TrimSpace(stringEventData(event.Data, "actor_avatar_url")); value != "" {
+		// URL 不截断:schema 无 maxLength(https 由渲染层校验),截断会破坏链接。
 		requester["avatarUrl"] = value
 	}
 	fields := map[string]any{
@@ -167,23 +193,29 @@ func (f *DocsActionFinalizer) replaceWithRegistryResult(ctx context.Context, eve
 		"document":  document,
 		"requester": requester,
 		"decision": map[string]any{
-			"operatorName": operatorName, "decidedAtDisplay": strings.TrimSpace(result.Display["decided_at"]),
+			"operatorName":     truncRunes(operatorName, capResultName),
+			"decidedAtDisplay": truncRunes(strings.TrimSpace(result.Display["decided_at"]), capResultShortLabel),
 		},
+	}
+	dataCaps := map[string]int{
+		"requestReason":      capResultReason,
+		"requestedAtDisplay": capResultShortLabel,
+		"messageTimeDisplay": capResultShortLabel,
 	}
 	for destination, source := range map[string]string{
 		"requestReason": "request_reason", "requestedAtDisplay": "requested_at_display",
 		"messageTimeDisplay": "message_time_display",
 	} {
 		if value := strings.TrimSpace(stringEventData(event.Data, source)); value != "" {
-			fields[destination] = value
+			fields[destination] = truncRunes(value, dataCaps[destination])
 		}
 	}
 	permission := make(map[string]any, 2)
 	if value := strings.TrimSpace(stringEventData(event.Data, "permission_label")); value != "" {
-		permission["label"] = value
+		permission["label"] = truncRunes(value, capResultShortLabel)
 	}
 	if value := strings.TrimSpace(stringEventData(event.Data, "permission_role_label")); value != "" {
-		permission["roleLabel"] = value
+		permission["roleLabel"] = truncRunes(value, capResultShortLabel)
 	}
 	if len(permission) > 0 {
 		fields["permission"] = permission
@@ -199,6 +231,10 @@ func (f *DocsActionFinalizer) replaceWithRegistryResult(ctx context.Context, eve
 		Target: carddispatch.Target{
 			SpaceID: event.SpaceID, ChannelID: channelID, ChannelType: event.ChannelType,
 		},
+		// card_seq 单调性来源:event.EventID 是全局单调递增的 snowflake,直接用作
+		// card_seq 满足 CardMutator CAS 的严格递增要求(见
+		// .octospec/learnings/pending/cardtmpl-interaction-closure.md)。若未来 event
+		// ID 生成器改为非单调,CAS 会静默丢弃合法更新——务必同步复核。
 		SenderUID: event.SenderUID, MessageID: event.MessageID, CardSeq: event.EventID,
 	}, docsaccessrequest.TemplateID, docsaccessrequest.TemplateVersionV3, state, raw, cardtmpl.BuildEnv{
 		WebLoginURL: f.ctx.GetConfig().External.WebLoginURL, Lang: lang, SpaceID: event.SpaceID,

--- a/modules/notify/action_finalizer_v3_test.go
+++ b/modules/notify/action_finalizer_v3_test.go
@@ -3,6 +3,7 @@ package notify
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/Mininglamp-OSS/octo-server/internal/cardactiondispatch"
@@ -128,5 +129,67 @@ func TestDocsActionFinalizerV3OmitsUnavailableV2Decoration(t *testing.T) {
 	}
 	if _, exists := requester["avatarUrl"]; exists {
 		t.Errorf("legacy 0.2 data fabricated avatarUrl: %+v", requester)
+	}
+}
+
+// okMutator 是 cardtmpl.mutationGateway 的最小实现:ReplaceView 只调 Mutate,
+// 让真实 updater 走完 RenderCard(触发 0.3.0 InputSchema 校验)。
+type okMutator struct{ mutated bool }
+
+func (m *okMutator) Snapshot(context.Context, carddispatch.CardMutationTarget) (carddispatch.CardMutationSnapshot, error) {
+	return carddispatch.CardMutationSnapshot{}, nil
+}
+
+func (m *okMutator) Mutate(context.Context, carddispatch.CardMutationRequest) (carddispatch.CardMutationResult, error) {
+	m.mutated = true
+	return carddispatch.CardMutationResult{}, nil
+}
+
+// P1(PR#641 review):回调 Display / event.Data 的合法长值(≤500 runes)必须在渲染
+// 前截断到 0.3.0 schema cap。用真实 updater 驱动 RenderCard —— 若不截断,超长字段
+// 会命中 InputSchema.Validate 的 maxLength → ErrFieldsInvalid,ReplaceView 确定性
+// 失败(审批卡卡在 pending、申请人漏通知)。截断后必须渲染成功并写入 mutator。
+func TestDocsActionFinalizerV3TruncatesOversizedDisplayFields(t *testing.T) {
+	wk := newWuKongServer()
+	defer wk.close()
+	ctx := newTestContext(t, wk)
+	ctx.GetConfig().External.WebLoginURL = "https://im.example.com/login"
+
+	registry := cardtmpl.NewRegistry()
+	registry.Register(docsaccessrequest.New(), docsaccessrequest.Assets, docsaccessrequest.HandoffRoot)
+	registry.Register(docsaccessrequest.NewV3(), docsaccessrequest.Assets, docsaccessrequest.HandoffRootV3)
+	registry.SetDefault(docsaccessrequest.TemplateID, docsaccessrequest.TemplateVersionV3)
+	registry.Freeze()
+	mut := &okMutator{}
+	realUpdater, err := cardtmpl.NewCardUpdater(registry, mut)
+	if err != nil {
+		t.Fatalf("NewCardUpdater: %v", err)
+	}
+	finalizer := &DocsActionFinalizer{ctx: ctx, updater: realUpdater}
+
+	// 每个来源字段都超出对应 schema cap,但都在 ≤500 rune 的回调契约内。
+	over := func(n int) string { return strings.Repeat("字", n) }
+	event := cardactiondispatch.Event{
+		EventID: 44, SenderUID: NotifyBotUIDValue, MessageID: "1003", ChannelID: NotifyBotUIDValue,
+		ChannelType: 1, SpaceID: "space-1", OperatorUID: "reviewer-1",
+		Data: map[string]any{
+			"doc_id": "doc-3", "request_id": "request-3", "actor": over(200),
+			"actor_avatar_url": "https://cdn.example.com/a.png", "source_name": over(300),
+			"request_reason": over(400), "requested_at_display": over(200), "message_time_display": over(200),
+			"permission_label": over(200), "permission_role_label": over(200),
+		},
+	}
+	result := cardactiondispatch.DecisionResult{
+		State: cardactiondispatch.StateDenied,
+		Display: map[string]string{
+			"operator_name": over(200), "decided_at": over(200), "title": over(400),
+		},
+	}
+	if err := finalizer.replaceWithRegistryResult(context.Background(), event, result,
+		NotifyBotUIDValue, "en", over(400), over(400)); err != nil {
+		t.Fatalf("replaceWithRegistryResult with oversized display fields must succeed after truncation: %v", err)
+	}
+	if !mut.mutated {
+		t.Fatal("mutator was never called — terminal update did not persist")
 	}
 }

--- a/modules/notify/action_finalizer_v3_test.go
+++ b/modules/notify/action_finalizer_v3_test.go
@@ -1,0 +1,132 @@
+package notify
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-server/internal/cardactiondispatch"
+	"github.com/Mininglamp-OSS/octo-server/internal/carddispatch"
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl"
+	docsaccessrequest "github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl/docs_access_request"
+)
+
+type captureViewUpdater struct {
+	target  cardtmpl.UpdateTarget
+	id      cardtmpl.ID
+	version string
+	state   cardtmpl.State
+	fields  json.RawMessage
+	env     cardtmpl.BuildEnv
+}
+
+func (u *captureViewUpdater) ReplaceView(_ context.Context, target cardtmpl.UpdateTarget, id cardtmpl.ID,
+	version string, state cardtmpl.State, fields json.RawMessage, env cardtmpl.BuildEnv) error {
+	u.target, u.id, u.version, u.state, u.fields, u.env = target, id, version, state, fields, env
+	return nil
+}
+
+func (u *captureViewUpdater) Append(context.Context, cardtmpl.UpdateTarget, json.RawMessage) error {
+	return nil
+}
+
+func TestDocsActionFinalizerUsesV3RegistryResultForTerminalStates(t *testing.T) {
+	wk := newWuKongServer()
+	defer wk.close()
+	ctx := newTestContext(t, wk)
+	ctx.GetConfig().External.WebLoginURL = "https://im.example.com/login"
+	updater := &captureViewUpdater{}
+	legacyMutator := &captureCardMutator{}
+	finalizer, err := NewDocsActionFinalizerWithUpdater(ctx, updater, legacyMutator, &capturingCardSender{})
+	if err != nil {
+		t.Fatalf("NewDocsActionFinalizerWithUpdater: %v", err)
+	}
+	event := cardactiondispatch.Event{
+		EventID: 42, SenderUID: NotifyBotUIDValue, Owner: "docs", ActionType: "access_request.decision",
+		MessageID: "1001", ChannelID: NotifyBotUIDValue, ChannelType: 1, SpaceID: "space-1", OperatorUID: "reviewer-1",
+		Inputs: map[string]any{cardtmpl.DocsDenyReasonInputID: "scope mismatch"},
+		Data: map[string]any{
+			"doc_id": "doc-1", "request_id": "request-1", "doc_title": "Roadmap", "actor": "Alice",
+			"actor_avatar_url": "https://cdn.example.com/alice.png", "request_reason": "Need quarterly access",
+			"requested_at_display": "2026-07-22 10:00", "message_time_display": "10:03",
+			"permission_label": "Access", "permission_role_label": "Editor", "source_name": "Docs",
+		},
+	}
+	result := cardactiondispatch.DecisionResult{
+		Disposition: cardactiondispatch.DispositionApplied, State: cardactiondispatch.StateDenied,
+		RequesterUID: "user-a", Display: map[string]string{"title": "Roadmap"},
+	}
+	if err := finalizer.Finalize(context.Background(), event, result); err != nil {
+		t.Fatalf("Finalize: %v", err)
+	}
+	if len(legacyMutator.requests) != 0 {
+		t.Fatalf("terminal V3 path used legacy mutator: %+v", legacyMutator.requests)
+	}
+	if updater.target.MessageID != event.MessageID || updater.target.CardSeq != event.EventID || updater.target.SenderUID != event.SenderUID {
+		t.Fatalf("update target = %+v", updater.target)
+	}
+	if updater.id != docsaccessrequest.TemplateID || updater.version != docsaccessrequest.TemplateVersionV3 || updater.state != docsaccessrequest.StateRejected {
+		t.Fatalf("update selection = %s@%s/%s", updater.id, updater.version, updater.state)
+	}
+	var fields map[string]any
+	if err := json.Unmarshal(updater.fields, &fields); err != nil {
+		t.Fatalf("decode fields: %v", err)
+	}
+	if fields["state"] != "rejected" || fields["requestId"] != "request-1" {
+		t.Fatalf("result fields = %+v", fields)
+	}
+	decision := fields["decision"].(map[string]any)
+	if decision["operatorName"] != event.OperatorUID || decision["rejectionReason"] != "scope mismatch" {
+		t.Fatalf("decision fields = %+v", decision)
+	}
+	document := fields["document"].(map[string]any)
+	requester := fields["requester"].(map[string]any)
+	permission := fields["permission"].(map[string]any)
+	if document["sourceName"] != "Docs" || requester["avatarUrl"] != "https://cdn.example.com/alice.png" ||
+		permission["label"] != "Access" || permission["roleLabel"] != "Editor" ||
+		fields["requestReason"] != "Need quarterly access" || fields["requestedAtDisplay"] != "2026-07-22 10:00" ||
+		fields["messageTimeDisplay"] != "10:03" {
+		t.Fatalf("result context fields = %+v", fields)
+	}
+	if updater.env.SpaceID != event.SpaceID {
+		t.Fatalf("BuildEnv = %+v", updater.env)
+	}
+	_ = carddispatch.CardMutationResult{}
+}
+
+func TestDocsActionFinalizerV3OmitsUnavailableV2Decoration(t *testing.T) {
+	wk := newWuKongServer()
+	defer wk.close()
+	ctx := newTestContext(t, wk)
+	updater := &captureViewUpdater{}
+	finalizer := &DocsActionFinalizer{ctx: ctx, updater: updater}
+	event := cardactiondispatch.Event{
+		EventID: 43, SenderUID: NotifyBotUIDValue, MessageID: "1002", ChannelID: NotifyBotUIDValue,
+		ChannelType: 1, SpaceID: "space-1", OperatorUID: "reviewer-1",
+		Data: map[string]any{
+			"doc_id": "doc-2", "request_id": "request-2", "doc_title": "Legacy Roadmap", "actor": "Bob",
+		},
+	}
+	result := cardactiondispatch.DecisionResult{State: cardactiondispatch.StateApproved}
+	if err := finalizer.replaceWithRegistryResult(context.Background(), event, result,
+		NotifyBotUIDValue, "en", "Legacy Roadmap", ""); err != nil {
+		t.Fatalf("replaceWithRegistryResult(v2 minimum): %v", err)
+	}
+	var fields map[string]any
+	if err := json.Unmarshal(updater.fields, &fields); err != nil {
+		t.Fatal(err)
+	}
+	for _, key := range []string{"permission", "requestReason", "requestedAtDisplay", "messageTimeDisplay"} {
+		if _, exists := fields[key]; exists {
+			t.Errorf("legacy 0.2 data fabricated optional %q: %+v", key, fields)
+		}
+	}
+	document := fields["document"].(map[string]any)
+	requester := fields["requester"].(map[string]any)
+	if _, exists := document["sourceName"]; exists {
+		t.Errorf("legacy 0.2 data fabricated sourceName: %+v", document)
+	}
+	if _, exists := requester["avatarUrl"]; exists {
+		t.Errorf("legacy 0.2 data fabricated avatarUrl: %+v", requester)
+	}
+}

--- a/modules/notify/card_via_registry.go
+++ b/modules/notify/card_via_registry.go
@@ -72,7 +72,7 @@ func preflightDocsAccessRequestSchema(card *DocsCardFields) error {
 	if err := tmpl.Meta().InputSchema.Validate(parsed); err != nil {
 		// R2-8: preflight schema 失败也打 fields_invalid metric (Render 未被触发,
 		// 否则 metric 永远漏这条最"合法"的 400 路径)。
-		cardtmpl.RecordFieldsInvalid(docsaccessrequest.TemplateID, docsaccessrequest.TemplateVersion)
+		cardtmpl.RecordFieldsInvalid(docsaccessrequest.TemplateID, tmpl.Meta().Version)
 		return fmt.Errorf("%w: %v", cardtmpl.ErrFieldsInvalid, err)
 	}
 	// R3-1: schema 的 avatarUrl pattern 只做粗粒度前缀防护,正则无法可靠判定 host
@@ -88,7 +88,7 @@ func preflightDocsAccessRequestSchema(card *DocsCardFields) error {
 	// 让基座统一前置校验,消除这条硬编码耦合。
 	if avatar := strings.TrimSpace(card.ActorAvatarURL); avatar != "" {
 		if err := cardtmpl.AbsoluteHTTPSURL(avatar); err != nil {
-			cardtmpl.RecordFieldsInvalid(docsaccessrequest.TemplateID, docsaccessrequest.TemplateVersion)
+			cardtmpl.RecordFieldsInvalid(docsaccessrequest.TemplateID, tmpl.Meta().Version)
 			return fmt.Errorf("%w: actor_avatar_url: %v", cardtmpl.ErrFieldsInvalid, err)
 		}
 	}

--- a/pkg/cardmsg/interactive.go
+++ b/pkg/cardmsg/interactive.go
@@ -14,6 +14,56 @@ import (
 	"strings"
 )
 
+// TemplateContext is the immutable registry identity embedded by
+// cardtmpl.Registry.Render in metadata.octo. It is read only from the effective
+// server-authored card frame; clients never provide it to the action ingress.
+type TemplateContext struct {
+	Protocol string
+	ID       string
+	Version  string
+}
+
+// CardTemplateContext extracts a complete octo-card template identity from a
+// type-17 envelope. Partial, malformed, or foreign-protocol metadata is absent.
+func CardTemplateContext(envelopeRaw []byte) (TemplateContext, bool) {
+	payload, err := decodeEnvelope(string(envelopeRaw))
+	if err != nil || !IsCardPayload(payload) {
+		return TemplateContext{}, false
+	}
+	card, _ := payload["card"].(map[string]interface{})
+	metadata, _ := card["metadata"].(map[string]interface{})
+	octo, _ := metadata["octo"].(map[string]interface{})
+	template, _ := octo["template"].(map[string]interface{})
+	ctx := TemplateContext{}
+	ctx.Protocol, _ = octo["protocol"].(string)
+	ctx.ID, _ = template["id"].(string)
+	ctx.Version, _ = template["version"].(string)
+	if ctx.Protocol != "octo-card@1.0" || strings.TrimSpace(ctx.ID) != ctx.ID || ctx.ID == "" ||
+		strings.TrimSpace(ctx.Version) != ctx.Version || ctx.Version == "" {
+		return TemplateContext{}, false
+	}
+	return ctx, true
+}
+
+// HasCardTemplateMetadata distinguishes a truly legacy card from a card that
+// declares protocol/template metadata but cannot produce a complete trusted
+// TemplateContext. Callers use this to fail closed on partial/corrupt identity.
+func HasCardTemplateMetadata(envelopeRaw []byte) bool {
+	payload, err := decodeEnvelope(string(envelopeRaw))
+	if err != nil || !IsCardPayload(payload) {
+		return false
+	}
+	card, _ := payload["card"].(map[string]interface{})
+	metadata, _ := card["metadata"].(map[string]interface{})
+	octo, _ := metadata["octo"].(map[string]interface{})
+	if octo == nil {
+		return false
+	}
+	_, hasProtocol := octo["protocol"]
+	_, hasTemplate := octo["template"]
+	return hasProtocol || hasTemplate
+}
+
 const (
 	// ProfileV2 octo/v2：在 v1 展示集之上增加 Action.Submit（含 selectAction 携带）
 	// 与 Input.Text / Input.Toggle / Input.ChoiceSet（P2 D1/D2）。Action.Execute /

--- a/pkg/cardmsg/interactive.go
+++ b/pkg/cardmsg/interactive.go
@@ -55,9 +55,16 @@ func HasCardTemplateMetadata(envelopeRaw []byte) bool {
 	}
 	card, _ := payload["card"].(map[string]interface{})
 	metadata, _ := card["metadata"].(map[string]interface{})
-	octo, _ := metadata["octo"].(map[string]interface{})
-	if octo == nil {
+	octoRaw, hasOcto := metadata["octo"]
+	if !hasOcto {
 		return false
+	}
+	octo, ok := octoRaw.(map[string]interface{})
+	if !ok {
+		// metadata.octo 存在但非对象(损坏)→ 视为"声明了模板元数据但无法产出
+		// 完整可信身份",fail closed:调用方据此拒绝,而非退化成 legacy 空上下文
+		// (PR#641 review P2)。
+		return true
 	}
 	_, hasProtocol := octo["protocol"]
 	_, hasTemplate := octo["template"]

--- a/pkg/cardmsg/template_context_test.go
+++ b/pkg/cardmsg/template_context_test.go
@@ -1,0 +1,25 @@
+package cardmsg
+
+import "testing"
+
+func TestCardTemplateContextReadsOnlyTypedMetadata(t *testing.T) {
+	raw := []byte(`{
+		"type":17,"profile":"octo/v2","card_version":"1.5",
+		"card":{"type":"AdaptiveCard","version":"1.5","body":[],"metadata":{"octo":{
+			"protocol":"octo-card@1.0","template":{"id":"docs.access-request","version":"0.2.0"}
+		}}}
+	}`)
+	ctx, ok := CardTemplateContext(raw)
+	if !ok || ctx.ID != "docs.access-request" || ctx.Version != "0.2.0" || ctx.Protocol != "octo-card@1.0" {
+		t.Fatalf("CardTemplateContext() = (%+v, %v)", ctx, ok)
+	}
+	for _, malformed := range [][]byte{
+		[]byte(`{"type":17,"card":{"metadata":{"octo":{"template":{"id":"docs.access-request"}}}}}`),
+		[]byte(`{"type":17,"card":{"metadata":{"octo":{"protocol":"other","template":{"id":"docs.access-request","version":"0.2.0"}}}}}`),
+		[]byte(`not-json`),
+	} {
+		if got, ok := CardTemplateContext(malformed); ok {
+			t.Errorf("CardTemplateContext(%s) = %+v, want absent", malformed, got)
+		}
+	}
+}

--- a/pkg/cardtmpl/action_view_test.go
+++ b/pkg/cardtmpl/action_view_test.go
@@ -1,0 +1,28 @@
+package cardtmpl_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl"
+	docsaccessrequest "github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl/docs_access_request"
+)
+
+func TestRegistryActionViewResolvesDeclaredSubmitOnly(t *testing.T) {
+	r := cardtmpl.NewRegistry()
+	r.Register(docsaccessrequest.New(), docsaccessrequest.Assets, docsaccessrequest.HandoffRoot)
+	r.Register(docsaccessrequest.NewV3(), docsaccessrequest.Assets, docsaccessrequest.HandoffRootV3)
+	r.SetDefault(docsaccessrequest.TemplateID, docsaccessrequest.TemplateVersionV3)
+	r.Freeze()
+
+	view, err := r.ActionView(docsaccessrequest.TemplateID, "0.2.0", cardtmpl.DocsApproveActionID)
+	if err != nil || view != "pending" {
+		t.Fatalf("ActionView(0.2 approve) = (%q, %v)", view, err)
+	}
+	if _, err := r.ActionView(docsaccessrequest.TemplateID, "0.3.0", "view_document"); !errors.Is(err, cardtmpl.ErrActionUnknown) {
+		t.Fatalf("ActionView(OpenUrl) error = %v, want ErrActionUnknown", err)
+	}
+	if _, err := r.ActionView(docsaccessrequest.TemplateID, "0.3.0", "missing"); !errors.Is(err, cardtmpl.ErrActionUnknown) {
+		t.Fatalf("ActionView(missing) error = %v, want ErrActionUnknown", err)
+	}
+}

--- a/pkg/cardtmpl/conformance_test.go
+++ b/pkg/cardtmpl/conformance_test.go
@@ -523,7 +523,8 @@ func freshRegistry(t *testing.T) *cardtmpl.Registry {
 	t.Helper()
 	r := cardtmpl.NewRegistry()
 	r.Register(docsaccessrequest.New(), docsaccessrequest.Assets, docsaccessrequest.HandoffRoot)
-	r.SetDefault(docsaccessrequest.TemplateID, docsaccessrequest.TemplateVersion)
+	r.Register(docsaccessrequest.NewV3(), docsaccessrequest.Assets, docsaccessrequest.HandoffRootV3)
+	r.SetDefault(docsaccessrequest.TemplateID, docsaccessrequest.TemplateVersionV3)
 	r.Freeze()
 	return r
 }
@@ -535,6 +536,9 @@ func loadSampleForState(t *testing.T, tmpl cardtmpl.Template, state cardtmpl.Sta
 	// docsaccessrequest 的 samples 命名与 state 值同名
 	fs := docsaccessrequest.Assets
 	root := docsaccessrequest.HandoffRoot
+	if tmpl.Meta().Version == docsaccessrequest.TemplateVersionV3 {
+		root = docsaccessrequest.HandoffRootV3
+	}
 	b, err := fs.ReadFile(root + "/samples/" + string(state) + ".json")
 	if err != nil {
 		t.Fatalf("read sample for state %q: %v", state, err)

--- a/pkg/cardtmpl/docs_access_request/handoff/docs.access-request@0.3.0/contract/data.schema.json
+++ b/pkg/cardtmpl/docs_access_request/handoff/docs.access-request@0.3.0/contract/data.schema.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "文档访问申请卡数据契约 0.3.0",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["requestId", "state", "document"],
+  "properties": {
+    "requestId": {"type": "string", "minLength": 1, "maxLength": 200},
+    "state": {"type": "string", "enum": ["pending", "approved", "rejected"]},
+    "document": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["title"],
+      "properties": {
+        "docId": {"type": "string", "maxLength": 200},
+        "title": {"type": "string", "minLength": 1, "maxLength": 200},
+        "url": {"type": "string", "maxLength": 2048},
+        "sourceName": {"type": "string", "maxLength": 200}
+      }
+    },
+    "requester": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": {"type": "string", "maxLength": 120},
+        "avatarUrl": {"type": "string", "maxLength": 2048, "pattern": "^(|https://[^/].*)$"}
+      }
+    },
+    "permission": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {"type": "string", "maxLength": 80},
+        "roleLabel": {"type": "string", "maxLength": 80}
+      }
+    },
+    "requestReason": {"type": "string", "maxLength": 300},
+    "requestedAtDisplay": {"type": "string", "maxLength": 80},
+    "messageTimeDisplay": {"type": "string", "maxLength": 80},
+    "decision": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["operatorName"],
+      "properties": {
+        "operatorName": {"type": "string", "minLength": 1, "maxLength": 120},
+        "decidedAtDisplay": {"type": "string", "maxLength": 80},
+        "rejectionReason": {"type": "string", "maxLength": 300}
+      }
+    }
+  },
+  "allOf": [
+    {
+      "if": {"properties": {"state": {"enum": ["approved", "rejected"]}}},
+      "then": {"required": ["decision"]}
+    }
+  ]
+}

--- a/pkg/cardtmpl/docs_access_request/handoff/docs.access-request@0.3.0/manifest.json
+++ b/pkg/cardtmpl/docs_access_request/handoff/docs.access-request@0.3.0/manifest.json
@@ -1,0 +1,27 @@
+{
+  "schemaVersion": 2,
+  "id": "docs.access-request",
+  "name": "文档访问申请",
+  "version": "0.3.0",
+  "contractVersion": "1.1.0",
+  "protocol": "octo-card@1.0",
+  "adaptiveCardVersion": "1.5",
+  "renderProfile": "octo-chat@1.0.0",
+  "defaultLocale": "zh-CN",
+  "owner": "docs",
+  "actionType": "access_request.decision",
+  "sourceLabel": "文档",
+  "dataSchema": "contract/data.schema.json",
+  "views": {
+    "pending": {
+      "wireProfile": "octo/v2",
+      "states": ["pending"],
+      "samples": ["samples/pending.json"]
+    },
+    "result": {
+      "wireProfile": "octo/v1",
+      "states": ["approved", "rejected"],
+      "samples": ["samples/approved.json", "samples/rejected.json"]
+    }
+  }
+}

--- a/pkg/cardtmpl/docs_access_request/handoff/docs.access-request@0.3.0/reports/pending.interaction.json
+++ b/pkg/cardtmpl/docs_access_request/handoff/docs.access-request@0.3.0/reports/pending.interaction.json
@@ -1,0 +1,19 @@
+{
+  "actions": [
+    {"id": "view_document", "type": "Action.OpenUrl", "dataKeys": [], "inputIds": []},
+    {
+      "id": "docs-access-deny", "type": "Action.Submit", "associatedInputs": "auto",
+      "dataKeys": ["owner", "action_type", "doc_id", "request_id", "doc_title", "actor", "decision", "actor_avatar_url", "request_reason", "requested_at_display", "message_time_display", "permission_label", "permission_role_label", "source_name"],
+      "inputIds": ["deny_reason"]
+    },
+    {
+      "id": "docs-access-approve", "type": "Action.Submit", "associatedInputs": "auto",
+      "dataKeys": ["owner", "action_type", "doc_id", "request_id", "doc_title", "actor", "decision", "actor_avatar_url", "request_reason", "requested_at_display", "message_time_display", "permission_label", "permission_role_label", "source_name"],
+      "inputIds": []
+    }
+  ],
+  "inputs": [
+    {"id": "deny_reason", "type": "Input.Text", "isRequired": false, "isVisible": false, "maxLength": 300}
+  ],
+  "toggles": []
+}

--- a/pkg/cardtmpl/docs_access_request/handoff/docs.access-request@0.3.0/reports/result.interaction.json
+++ b/pkg/cardtmpl/docs_access_request/handoff/docs.access-request@0.3.0/reports/result.interaction.json
@@ -1,0 +1,7 @@
+{
+  "actions": [
+    {"id": "view_document", "type": "Action.OpenUrl", "dataKeys": [], "inputIds": []}
+  ],
+  "inputs": [],
+  "toggles": []
+}

--- a/pkg/cardtmpl/docs_access_request/handoff/docs.access-request@0.3.0/samples/approved.json
+++ b/pkg/cardtmpl/docs_access_request/handoff/docs.access-request@0.3.0/samples/approved.json
@@ -1,0 +1,11 @@
+{
+  "requestId": "DOC-REQ-024",
+  "state": "approved",
+  "document": {"docId": "d_2026-q3-okr", "title": "2026 Q3 OKR", "sourceName": "Q3 产品规划"},
+  "requester": {"name": "张三"},
+  "permission": {"label": "协作权限", "roleLabel": "协作者"},
+  "requestReason": "希望加入协作，以补充 KR3 数据。",
+  "requestedAtDisplay": "2026-07-16 11:00",
+  "messageTimeDisplay": "刚刚",
+  "decision": {"operatorName": "林澈", "decidedAtDisplay": "刚刚"}
+}

--- a/pkg/cardtmpl/docs_access_request/handoff/docs.access-request@0.3.0/samples/pending.json
+++ b/pkg/cardtmpl/docs_access_request/handoff/docs.access-request@0.3.0/samples/pending.json
@@ -1,0 +1,18 @@
+{
+  "requestId": "DOC-REQ-024",
+  "state": "pending",
+  "document": {
+    "docId": "d_2026-q3-okr",
+    "title": "2026 Q3 OKR",
+    "url": "https://example.com/documents/2026-q3-okr",
+    "sourceName": "Q3 产品规划"
+  },
+  "requester": {
+    "name": "张三",
+    "avatarUrl": "https://api.dicebear.com/9.x/initials/svg?seed=Zhang%20San&backgroundColor=f2f3f4&fontSize=40"
+  },
+  "permission": {"label": "协作权限", "roleLabel": "协作者"},
+  "requestReason": "希望加入协作，以补充 KR3 数据。",
+  "requestedAtDisplay": "2026-07-16 11:00",
+  "messageTimeDisplay": "11:03"
+}

--- a/pkg/cardtmpl/docs_access_request/handoff/docs.access-request@0.3.0/samples/rejected.json
+++ b/pkg/cardtmpl/docs_access_request/handoff/docs.access-request@0.3.0/samples/rejected.json
@@ -1,0 +1,11 @@
+{
+  "requestId": "DOC-REQ-025",
+  "state": "rejected",
+  "document": {"docId": "d_2026-q3-roadmap", "title": "2026 Q3 产品路线图", "sourceName": "Q3 产品规划"},
+  "requester": {"name": "李四"},
+  "permission": {"label": "查看权限", "roleLabel": "查看者"},
+  "requestReason": "申请查看权限，用于对齐 Q3 交付节奏。",
+  "requestedAtDisplay": "2026-07-16 11:15",
+  "messageTimeDisplay": "刚刚",
+  "decision": {"operatorName": "林澈", "decidedAtDisplay": "刚刚", "rejectionReason": "信息不完整，请补充用途说明。"}
+}

--- a/pkg/cardtmpl/docs_access_request/v3.go
+++ b/pkg/cardtmpl/docs_access_request/v3.go
@@ -1,0 +1,180 @@
+package docsaccessrequest
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl"
+)
+
+const (
+	HandoffRootV3     = "handoff/docs.access-request@0.3.0"
+	TemplateVersionV3 = "0.3.0"
+
+	StateApproved cardtmpl.State = "approved"
+	StateRejected cardtmpl.State = "rejected"
+
+	VariantApproved = "docs.access_approved"
+	VariantRejected = "docs.access_denied"
+)
+
+type TemplateV3 struct {
+	meta cardtmpl.TemplateMeta
+}
+
+func NewV3() *TemplateV3 { return &TemplateV3{} }
+
+func (t *TemplateV3) SetMeta(meta cardtmpl.TemplateMeta) { t.meta = meta }
+
+func (t *TemplateV3) Meta() cardtmpl.TemplateMeta { return t.meta.Clone() }
+
+type v3Fields struct {
+	RequestID string `json:"requestId"`
+	State     string `json:"state"`
+	Document  struct {
+		DocID      string `json:"docId"`
+		Title      string `json:"title"`
+		URL        string `json:"url"`
+		SourceName string `json:"sourceName"`
+	} `json:"document"`
+	Requester struct {
+		Name      string `json:"name"`
+		AvatarURL string `json:"avatarUrl"`
+	} `json:"requester"`
+	Permission struct {
+		Label     string `json:"label"`
+		RoleLabel string `json:"roleLabel"`
+	} `json:"permission"`
+	RequestReason      string `json:"requestReason"`
+	RequestedAtDisplay string `json:"requestedAtDisplay"`
+	MessageTimeDisplay string `json:"messageTimeDisplay"`
+	Decision           struct {
+		OperatorName     string `json:"operatorName"`
+		DecidedAtDisplay string `json:"decidedAtDisplay"`
+		RejectionReason  string `json:"rejectionReason"`
+	} `json:"decision"`
+}
+
+func (t *TemplateV3) Build(ctx context.Context, state cardtmpl.State, fields json.RawMessage, env cardtmpl.BuildEnv) (cardtmpl.BuildResult, error) {
+	if err := ctx.Err(); err != nil {
+		return cardtmpl.BuildResult{}, err
+	}
+	if state == StatePending {
+		var input pendingFields
+		if err := json.Unmarshal(fields, &input); err != nil {
+			return cardtmpl.BuildResult{}, fmt.Errorf("docs.access-request@0.3.0: unmarshal pending fields: %w", err)
+		}
+		result, err := New().Build(ctx, state, fields, env)
+		if err != nil {
+			return cardtmpl.BuildResult{}, err
+		}
+		for _, action := range result.Actions {
+			action, ok := action.(map[string]interface{})
+			if !ok || action["type"] != "Action.Submit" {
+				continue
+			}
+			data, ok := action["data"].(map[string]interface{})
+			if !ok {
+				return cardtmpl.BuildResult{}, errors.New("docs.access-request@0.3.0: pending submit action data is invalid")
+			}
+			data["actor_avatar_url"] = input.Requester.AvatarURL
+			data["request_reason"] = input.RequestReason
+			data["requested_at_display"] = input.RequestedAtDisplay
+			data["message_time_display"] = input.MessageTimeDisplay
+			data["permission_label"] = input.Permission.Label
+			data["permission_role_label"] = input.Permission.RoleLabel
+			data["source_name"] = input.Document.SourceName
+		}
+		return result, nil
+	}
+	if state != StateApproved && state != StateRejected {
+		return cardtmpl.BuildResult{}, fmt.Errorf("docs.access-request@0.3.0: unsupported state %q", state)
+	}
+	var input v3Fields
+	if err := json.Unmarshal(fields, &input); err != nil {
+		return cardtmpl.BuildResult{}, fmt.Errorf("docs.access-request@0.3.0: unmarshal fields: %w", err)
+	}
+	docID := strings.TrimSpace(input.Document.DocID)
+	if docID == "" {
+		docID = input.RequestID
+	}
+	labels := resultLabels(env.Lang, state == StateRejected)
+	variant := VariantApproved
+	if state == StateRejected {
+		variant = VariantRejected
+	}
+	body, deepLink, err := cardtmpl.BuildDocsApprovalOutcomeBodyWithLang(env.Lang, env.WebLoginURL, docID, env.SpaceID, cardtmpl.DocsOutcomeContent{
+		Title: input.Document.Title, Variant: variant, Denied: state == StateRejected,
+		HeaderLabel: labels.header, SourceName: input.Document.SourceName,
+		StatusLabel: labels.status, PermissionLabel: input.Permission.Label, ResultText: labels.result,
+		ReasonLabel: labels.reason, Reason: input.Decision.RejectionReason,
+		Actor: input.Requester.Name, ActorAvatar: input.Requester.AvatarURL,
+		RequestedAtDisplay: input.RequestedAtDisplay, RequestReason: input.RequestReason,
+		BannerSuffix: labels.banner(input.Permission.RoleLabel), RoleLabel: labels.role,
+		RequestReasonLabel: labels.requestReason, MessageTimeLabel: labels.processedAt,
+		MessageTimeDisplay: input.MessageTimeDisplay,
+		DecisionSummary:    strings.Trim(strings.TrimSpace(input.Decision.OperatorName)+" · "+strings.TrimSpace(input.Decision.DecidedAtDisplay), " ·"),
+	})
+	if err != nil {
+		return cardtmpl.BuildResult{}, err
+	}
+	source := sourceForLang(env.Lang)
+	return cardtmpl.BuildResult{Body: body, Variant: variant, DeepLink: deepLink, Source: &source}, nil
+}
+
+func (t *TemplateV3) FallbackText(state cardtmpl.State, fields json.RawMessage, lang string) (string, error) {
+	if state == StatePending {
+		return New().FallbackText(state, fields, lang)
+	}
+	if state != StateApproved && state != StateRejected {
+		return "", fmt.Errorf("docs.access-request@0.3.0: unsupported fallback state %q", state)
+	}
+	var input v3Fields
+	if err := json.Unmarshal(fields, &input); err != nil {
+		return "", err
+	}
+	labels := resultLabels(lang, state == StateRejected)
+	return strings.TrimSpace(input.Document.Title) + " - " + labels.status, nil
+}
+
+type resultLabelSet struct {
+	header        string
+	status        string
+	result        string
+	reason        string
+	role          string
+	requestReason string
+	processedAt   string
+	zh            bool
+}
+
+func (l resultLabelSet) banner(role string) string {
+	role = strings.TrimSpace(role)
+	if l.zh {
+		if role == "" {
+			role = "查看者"
+		}
+		return "申请成为此文档的" + role + "。"
+	}
+	if role == "" {
+		role = "viewer"
+	}
+	return "requested " + role + " access to this document."
+}
+
+func resultLabels(lang string, denied bool) resultLabelSet {
+	zh := strings.EqualFold(lang, "zh-CN") || strings.HasPrefix(strings.ToLower(lang), "zh")
+	if zh {
+		if denied {
+			return resultLabelSet{header: "文档申请", status: "已拒绝", result: "本次访问申请已拒绝，权限状态已更新。", reason: "拒绝原因", role: "申请人", requestReason: "申请原因", processedAt: "处理于", zh: true}
+		}
+		return resultLabelSet{header: "文档申请", status: "已允许", result: "申请人已获得所申请的文档权限。", reason: "拒绝原因", role: "申请人", requestReason: "申请原因", processedAt: "处理于", zh: true}
+	}
+	if denied {
+		return resultLabelSet{header: "Document access", status: "Denied", result: "The access request was denied.", reason: "Reason", role: "Requester", requestReason: "Reason", processedAt: "Processed at"}
+	}
+	return resultLabelSet{header: "Document access", status: "Approved", result: "The requester now has access to the document.", reason: "Reason", role: "Requester", requestReason: "Reason", processedAt: "Processed at"}
+}

--- a/pkg/cardtmpl/docs_access_request/v3_test.go
+++ b/pkg/cardtmpl/docs_access_request/v3_test.go
@@ -1,0 +1,162 @@
+package docsaccessrequest_test
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardmsg"
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl"
+	docsaccessrequest "github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl/docs_access_request"
+)
+
+func TestV3RegistersPendingAndResultWithoutMutatingV2(t *testing.T) {
+	r := cardtmpl.NewRegistry()
+	r.Register(docsaccessrequest.New(), docsaccessrequest.Assets, docsaccessrequest.HandoffRoot)
+	r.Register(docsaccessrequest.NewV3(), docsaccessrequest.Assets, docsaccessrequest.HandoffRootV3)
+	r.SetDefault(docsaccessrequest.TemplateID, docsaccessrequest.TemplateVersionV3)
+	r.Freeze()
+
+	if got := docsaccessrequest.TemplateVersion; got != "0.2.0" {
+		t.Fatalf("frozen TemplateVersion = %q, want 0.2.0", got)
+	}
+	env := cardtmpl.BuildEnv{WebLoginURL: "https://web.example.com", Lang: "zh-CN", SpaceID: "space-1"}
+	for _, tc := range []struct {
+		state      cardtmpl.State
+		profile    string
+		variant    string
+		permission string
+	}{
+		{docsaccessrequest.StatePending, cardmsg.ProfileV2, docsaccessrequest.Variant, ""},
+		{docsaccessrequest.StateApproved, cardmsg.ProfileV1, docsaccessrequest.VariantApproved, "协作权限"},
+		{docsaccessrequest.StateRejected, cardmsg.ProfileV1, docsaccessrequest.VariantRejected, "查看权限"},
+	} {
+		sample, err := docsaccessrequest.Assets.ReadFile(docsaccessrequest.HandoffRootV3 + "/samples/" + string(tc.state) + ".json")
+		if err != nil {
+			t.Fatalf("read sample %s: %v", tc.state, err)
+		}
+		card, profile, err := r.RenderCard(context.Background(), docsaccessrequest.TemplateID, "", tc.state, sample, env)
+		if err != nil {
+			t.Fatalf("RenderCard(%s): %v", tc.state, err)
+		}
+		if profile != tc.profile {
+			t.Errorf("RenderCard(%s) profile = %q, want %q", tc.state, profile, tc.profile)
+		}
+		var document map[string]any
+		if err := json.Unmarshal(card, &document); err != nil {
+			t.Fatalf("decode %s card: %v", tc.state, err)
+		}
+		metadata, _ := document["metadata"].(map[string]any)
+		octo, _ := metadata["octo"].(map[string]any)
+		template, _ := octo["template"].(map[string]any)
+		if template["version"] != docsaccessrequest.TemplateVersionV3 {
+			t.Errorf("RenderCard(%s) template.version = %v", tc.state, template["version"])
+		}
+		if octo["variant"] != tc.variant {
+			t.Errorf("RenderCard(%s) variant = %v, want %q", tc.state, octo["variant"], tc.variant)
+		}
+		if tc.profile == cardmsg.ProfileV1 {
+			if _, ok := document["actions"]; ok {
+				t.Errorf("RenderCard(%s) result view must not contain top-level actions", tc.state)
+			}
+			text := string(card)
+			if !strings.Contains(text, "申请原因") || !strings.Contains(text, "林澈") {
+				t.Errorf("RenderCard(%s) dropped result handoff context: %s", tc.state, text)
+			}
+			if !strings.Contains(text, "Q3 产品规划") || !strings.Contains(text, tc.permission) ||
+				!strings.Contains(text, "处理于 刚刚") {
+				t.Errorf("RenderCard(%s) dropped source/permission context: %s", tc.state, text)
+			}
+			if tc.state == docsaccessrequest.StateRejected && !strings.Contains(text, "信息不完整") {
+				t.Errorf("RenderCard(rejected) dropped rejection reason: %s", text)
+			}
+		}
+	}
+}
+
+func TestV3ResultAcceptsPublishedV2ActionDataMinimum(t *testing.T) {
+	r := cardtmpl.NewRegistry()
+	r.Register(docsaccessrequest.NewV3(), docsaccessrequest.Assets, docsaccessrequest.HandoffRootV3)
+	r.SetDefault(docsaccessrequest.TemplateID, docsaccessrequest.TemplateVersionV3)
+	r.Freeze()
+	fields := json.RawMessage(`{
+		"requestId":"request-1","state":"rejected",
+		"document":{"docId":"doc-1","title":"Roadmap"},
+		"requester":{"name":"Alice"},
+		"decision":{"operatorName":"reviewer-1","rejectionReason":"scope mismatch"}
+	}`)
+	card, profile, err := r.RenderCard(context.Background(), docsaccessrequest.TemplateID, "",
+		docsaccessrequest.StateRejected, fields,
+		cardtmpl.BuildEnv{WebLoginURL: "https://web.example.com", Lang: "en", SpaceID: "space-1"})
+	if err != nil {
+		t.Fatalf("RenderCard(minimum legacy fields): %v", err)
+	}
+	if profile != cardmsg.ProfileV1 {
+		t.Fatalf("profile = %q, want %q", profile, cardmsg.ProfileV1)
+	}
+	if len(card) == 0 {
+		t.Fatal("result card is empty")
+	}
+}
+
+func TestV3PendingCarriesResultContextInServerAuthoredActionData(t *testing.T) {
+	r := cardtmpl.NewRegistry()
+	r.Register(docsaccessrequest.NewV3(), docsaccessrequest.Assets, docsaccessrequest.HandoffRootV3)
+	r.SetDefault(docsaccessrequest.TemplateID, docsaccessrequest.TemplateVersionV3)
+	r.Freeze()
+	sample, err := docsaccessrequest.Assets.ReadFile(docsaccessrequest.HandoffRootV3 + "/samples/pending.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload, err := r.Render(context.Background(), docsaccessrequest.TemplateID, "", docsaccessrequest.StatePending, sample,
+		cardtmpl.BuildEnv{WebLoginURL: "https://web.example.com", Lang: "zh-CN", SpaceID: "space-1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, _ := json.Marshal(payload)
+	data, found := cardmsg.SubmitAction(raw, cardtmpl.DocsApproveActionID)
+	if !found {
+		t.Fatal("approve action missing")
+	}
+	for _, key := range []string{"actor_avatar_url", "request_reason", "requested_at_display", "message_time_display", "permission_label", "permission_role_label", "source_name"} {
+		if _, ok := data[key]; !ok {
+			t.Errorf("V3 action data missing %q: %+v", key, data)
+		}
+	}
+}
+
+func TestV3FallbackTextLocalizesResultsAndRejectsUnknownState(t *testing.T) {
+	tmpl := docsaccessrequest.NewV3()
+	fields := json.RawMessage(`{
+		"requestId":"request-1","state":"approved",
+		"document":{"docId":"doc-1","title":"Roadmap"},
+		"decision":{"operatorName":"reviewer-1"}
+	}`)
+	text, err := tmpl.FallbackText(docsaccessrequest.StateApproved, fields, "en")
+	if err != nil {
+		t.Fatalf("FallbackText(approved): %v", err)
+	}
+	if text != "Roadmap - Approved" {
+		t.Fatalf("FallbackText(approved) = %q", text)
+	}
+	if _, err := tmpl.FallbackText(cardtmpl.State("future"), fields, "en"); err == nil {
+		t.Fatal("FallbackText(unknown state) error = nil")
+	}
+	if _, err := tmpl.FallbackText(docsaccessrequest.StateRejected, json.RawMessage(`{`), "en"); err == nil {
+		t.Fatal("FallbackText(invalid fields) error = nil")
+	}
+}
+
+func TestV3MetaIsPopulatedByRegistry(t *testing.T) {
+	r := cardtmpl.NewRegistry()
+	r.Register(docsaccessrequest.NewV3(), docsaccessrequest.Assets, docsaccessrequest.HandoffRootV3)
+	tmpl, err := r.Lookup(docsaccessrequest.TemplateID, docsaccessrequest.TemplateVersionV3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	meta := tmpl.Meta()
+	if meta.ID != docsaccessrequest.TemplateID || meta.Version != docsaccessrequest.TemplateVersionV3 {
+		t.Fatalf("Meta() = %+v", meta)
+	}
+}

--- a/pkg/cardtmpl/docs_action.go
+++ b/pkg/cardtmpl/docs_action.go
@@ -61,19 +61,32 @@ type DocsApprovalContent struct {
 }
 
 // DocsOutcomeContent carries the enriched terminal (已允许 / 已拒绝) card fields.
-// The finalizer only has title + decision (+ the reviewer reason for denials), so
-// this state renders header + title + a result box — not the full requester row.
+// Optional requester/source/permission/time fields let registry-backed 0.3
+// results preserve the pending-card context; legacy callers may leave them empty.
 type DocsOutcomeContent struct {
 	Title   string
 	Variant string
 	Source  Source
 	Denied  bool // true => denied (attention), false => approved (good)
 
-	HeaderLabel string // "文档申请"
-	StatusLabel string // "已允许" / "已拒绝"
-	ResultText  string // "申请人已获得所申请的文档权限。" / "申请已被拒绝。"
-	ReasonLabel string // "拒绝原因"
-	Reason      string // reviewer deny reason (denied only); "" => omit
+	HeaderLabel     string // "文档申请"
+	SourceName      string // optional document/source display name
+	StatusLabel     string // "已允许" / "已拒绝"
+	PermissionLabel string // optional permission vocabulary beside status
+	ResultText      string // "申请人已获得所申请的文档权限。" / "申请已被拒绝。"
+	ReasonLabel     string // "拒绝原因"
+	Reason          string // reviewer deny reason (denied only); "" => omit
+
+	Actor              string
+	ActorAvatar        string
+	RequestedAtDisplay string
+	RequestReason      string
+	BannerSuffix       string
+	RoleLabel          string
+	RequestReasonLabel string
+	DecisionSummary    string
+	MessageTimeLabel   string
+	MessageTimeDisplay string
 }
 
 // BuildDocsAccessRequestCard renders the enriched docs access-request approval
@@ -215,39 +228,11 @@ func BuildDocsApprovalOutcomeCard(
 	spaceID string,
 	content DocsOutcomeContent,
 ) (json.RawMessage, error) {
-	if strings.TrimSpace(content.Title) == "" || utf8.RuneCountInString(content.Title) > maxTitleRunes {
-		return nil, errors.New("cardtmpl: resource title is invalid")
-	}
-	if content.Source.IconURL != "" {
-		if err := requireHTTPS(content.Source.IconURL); err != nil {
-			return nil, fmt.Errorf("cardtmpl: source icon URL: %w", err)
-		}
-	}
-	deepLink, err := docsDeepLink(webLoginURL, docID, spaceID)
+	body, deepLink, err := BuildDocsApprovalOutcomeBodyWithLang(
+		i18n.OutboundLanguage(ctx), webLoginURL, docID, spaceID, content,
+	)
 	if err != nil {
 		return nil, err
-	}
-	lang := i18n.OutboundLanguage(ctx)
-	labels := labelsForLanguage(lang)
-
-	statusColor := "Good"
-	boxStyle := "good"
-	if content.Denied {
-		statusColor, boxStyle = "Attention", "attention"
-	}
-	body := []interface{}{
-		docsApprovalHeader(content.HeaderLabel, content.StatusLabel, statusColor),
-		docsApprovalTitle(content.Title),
-		docsResultBox(boxStyle, statusColor, content.ResultText, content.ReasonLabel, content.Reason),
-		// view-details rides as a body ActionSet (not a root action) so the
-		// terminal card carries no decision/submit actions — the approve/deny
-		// buttons are gone once the request is resolved.
-		map[string]interface{}{
-			"type": "ActionSet",
-			"actions": []interface{}{
-				map[string]interface{}{"type": "Action.OpenUrl", "title": labels.viewDetails, "url": deepLink},
-			},
-		},
 	}
 	document := map[string]interface{}{
 		"type":     "AdaptiveCard",
@@ -260,6 +245,135 @@ func BuildDocsApprovalOutcomeCard(
 		return nil, fmt.Errorf("cardtmpl: marshal docs outcome card: %w", err)
 	}
 	return raw, nil
+}
+
+// BuildDocsApprovalOutcomeBodyWithLang is the fragment-only counterpart used
+// by registry-backed result views. Registry.Render owns metadata and envelope.
+func BuildDocsApprovalOutcomeBodyWithLang(
+	lang string,
+	webLoginURL string,
+	docID string,
+	spaceID string,
+	content DocsOutcomeContent,
+) ([]interface{}, string, error) {
+	if strings.TrimSpace(content.Title) == "" || utf8.RuneCountInString(content.Title) > maxTitleRunes {
+		return nil, "", errors.New("cardtmpl: resource title is invalid")
+	}
+	if content.Source.IconURL != "" {
+		if err := requireHTTPS(content.Source.IconURL); err != nil {
+			return nil, "", fmt.Errorf("cardtmpl: source icon URL: %w", err)
+		}
+	}
+	if content.ActorAvatar != "" {
+		if err := requireHTTPS(content.ActorAvatar); err != nil {
+			return nil, "", fmt.Errorf("cardtmpl: actor avatar URL: %w", err)
+		}
+	}
+	deepLink, err := docsDeepLink(webLoginURL, docID, spaceID)
+	if err != nil {
+		return nil, "", err
+	}
+	labels := labelsForLanguage(lang)
+
+	statusColor := "Good"
+	boxStyle := "good"
+	if content.Denied {
+		statusColor, boxStyle = "Attention", "attention"
+	}
+	body := []interface{}{
+		docsOutcomeHeader(content.HeaderLabel, content.SourceName, content.StatusLabel, content.PermissionLabel, statusColor),
+		docsApprovalTitle(content.Title),
+	}
+	if strings.TrimSpace(content.Actor) != "" || strings.TrimSpace(content.BannerSuffix) != "" {
+		body = append(body, docsBanner(content.Actor, content.BannerSuffix))
+	}
+	if row := docsRequesterRow(content.Actor, content.ActorAvatar, content.RoleLabel, content.RequestedAtDisplay); row != nil {
+		body = append(body, row)
+	}
+	if box := docsReasonBox(content.RequestReasonLabel, content.RequestReason); box != nil {
+		body = append(body, box)
+	}
+	body = append(body,
+		docsResultBox(boxStyle, statusColor, content.ResultText, content.DecisionSummary, content.ReasonLabel, content.Reason),
+		docsOutcomeFooter(content.MessageTimeLabel, content.MessageTimeDisplay, labels.viewDetails, deepLink),
+	)
+	return body, deepLink, nil
+}
+
+func docsOutcomeHeader(headerLabel, sourceName, statusLabel, permissionLabel, statusColor string) map[string]interface{} {
+	sourceName = truncateRunes(strings.TrimSpace(sourceName), maxTitleRunes)
+	permissionLabel = truncateRunes(strings.TrimSpace(permissionLabel), maxTimestampRunes)
+	leftWidth := "stretch"
+	if sourceName != "" {
+		leftWidth = "auto"
+	}
+	columns := []interface{}{
+		map[string]interface{}{
+			"type": "Column", "width": leftWidth,
+			"items": []interface{}{map[string]interface{}{
+				"type": "TextBlock", "text": escapeMarkdown(headerLabel), "size": "Small",
+				"weight": "Bolder", "spacing": "None", "wrap": false,
+			}},
+		},
+	}
+	if sourceName != "" {
+		columns = append(columns, map[string]interface{}{
+			"type": "Column", "width": "stretch", "spacing": "Small",
+			"items": []interface{}{map[string]interface{}{
+				"type": "TextBlock", "text": escapeMarkdown("· " + sourceName), "size": "Small",
+				"isSubtle": true, "spacing": "None", "wrap": false,
+			}},
+		})
+	}
+	if strings.TrimSpace(statusLabel) != "" {
+		columns = append(columns, map[string]interface{}{
+			"type": "Column", "width": "auto",
+			"items": []interface{}{map[string]interface{}{
+				"type": "TextBlock", "text": escapeMarkdown(statusLabel), "size": "Small",
+				"weight": "Bolder", "color": statusColor, "spacing": "None", "wrap": false,
+			}},
+		})
+	}
+	if permissionLabel != "" {
+		columns = append(columns, map[string]interface{}{
+			"type": "Column", "width": "auto", "spacing": "Small",
+			"items": []interface{}{map[string]interface{}{
+				"type": "TextBlock", "text": escapeMarkdown(permissionLabel), "size": "Small",
+				"isSubtle": true, "spacing": "None", "wrap": false,
+			}},
+		})
+	}
+	return map[string]interface{}{"type": "ColumnSet", "spacing": "None", "columns": columns}
+}
+
+// docsOutcomeFooter keeps the terminal card free of submit actions while
+// preserving the handoff's processed-time context and view-details link.
+func docsOutcomeFooter(timeLabel, timeDisplay, viewDetails, deepLink string) map[string]interface{} {
+	actionSet := map[string]interface{}{
+		"type": "ActionSet", "spacing": "None",
+		"actions": []interface{}{
+			map[string]interface{}{"type": "Action.OpenUrl", "id": "view_document", "title": viewDetails, "url": deepLink},
+		},
+	}
+	timeDisplay = truncateRunes(strings.TrimSpace(timeDisplay), maxTimestampRunes)
+	if timeDisplay == "" {
+		return actionSet
+	}
+	processedAt := strings.TrimSpace(timeLabel + " " + timeDisplay)
+	return map[string]interface{}{
+		"type": "ColumnSet", "spacing": "Medium", "columns": []interface{}{
+			map[string]interface{}{
+				"type": "Column", "width": "stretch", "verticalContentAlignment": "Center",
+				"items": []interface{}{map[string]interface{}{
+					"type": "TextBlock", "text": escapeMarkdown(processedAt), "size": "Small",
+					"isSubtle": true, "spacing": "None", "wrap": false,
+				}},
+			},
+			map[string]interface{}{
+				"type": "Column", "width": "auto", "items": []interface{}{actionSet},
+			},
+		},
+	}
 }
 
 // docsApprovalHeader is the shared top row: a bold source label on the left and a
@@ -398,12 +512,18 @@ func docsReasonBox(label, reason string) map[string]interface{} {
 
 // docsResultBox is the terminal good/attention result section. For denials it
 // appends the reviewer reason as a labeled sub-line.
-func docsResultBox(boxStyle, textColor, resultText, reasonLabel, reason string) map[string]interface{} {
+func docsResultBox(boxStyle, textColor, resultText, decisionSummary, reasonLabel, reason string) map[string]interface{} {
 	items := []interface{}{
 		map[string]interface{}{
 			"type": "TextBlock", "text": escapeMarkdown(strings.TrimSpace(resultText)),
 			"size": "Medium", "weight": "Bolder", "color": textColor, "wrap": true, "spacing": "None",
 		},
+	}
+	if summary := truncateRunes(strings.TrimSpace(decisionSummary), maxTitleRunes); summary != "" {
+		items = append(items, map[string]interface{}{
+			"type": "TextBlock", "text": escapeMarkdown(summary),
+			"size": "Small", "isSubtle": true, "spacing": "Small",
+		})
 	}
 	if r := truncateRunes(strings.TrimSpace(reason), maxReasonRunes); r != "" {
 		label := strings.TrimSpace(reasonLabel)

--- a/pkg/cardtmpl/metrics.go
+++ b/pkg/cardtmpl/metrics.go
@@ -12,7 +12,9 @@ import (
 // label 基数 = 注册表大小 (template_id 值只来自 Template.ID() 硬编码),天花板
 // 可预期 <20,无基数爆炸风险 (§13)。
 type Metrics struct {
-	build *prometheus.CounterVec
+	build    *prometheus.CounterVec
+	callback *prometheus.CounterVec
+	update   *prometheus.CounterVec
 }
 
 // NewMetrics 构造并注册指标。传 nil registerer 得到 no-op 实例。
@@ -25,9 +27,39 @@ func NewMetrics(reg prometheus.Registerer) *Metrics {
 			Name: "dmwork_cardtmpl_build_total",
 			Help: "Total cardtmpl Registry.Render outcomes by template_id/version/view/result.",
 		}, []string{"template_id", "version", "view", "result"}),
+		callback: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "dmwork_cardtmpl_callback_total",
+			Help: "Total card template callback outcomes by template_id/version/action_id/result.",
+		}, []string{"template_id", "version", "action_id", "result"}),
+		update: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "dmwork_cardtmpl_update_total",
+			Help: "Total card template update outcomes by template_id/version/result.",
+		}, []string{"template_id", "version", "result"}),
 	}
-	reg.MustRegister(m.build)
+	reg.MustRegister(m.build, m.callback, m.update)
 	return m
+}
+
+func (m *Metrics) callbackResult(templateID, version, actionID, result string) {
+	if m == nil {
+		return
+	}
+	switch result {
+	case "ok", "rejected", "error":
+	default:
+		result = "error"
+	}
+	m.callback.WithLabelValues(templateID, version, actionID, result).Inc()
+}
+
+func (m *Metrics) updateResult(templateID, version, result string) {
+	if m == nil {
+		return
+	}
+	if result != "ok" {
+		result = "error"
+	}
+	m.update.WithLabelValues(templateID, version, result).Inc()
 }
 
 // buildResult 记录一次 Render 的结果。view 可能为空 (若在决定 view 前失败)。
@@ -69,4 +101,21 @@ func metricBuildResult(id ID, version, view, result string) {
 // 用法与直接调 metricBuildResult 等价,只是限定为 preflight 场景避免误用。
 func RecordFieldsInvalid(id ID, version string) {
 	metricBuildResult(id, version, "", "fields_invalid")
+}
+
+// RecordCallback records a bounded callback outcome for a registry-backed card.
+// Callers must only pass template/action identifiers resolved from registered
+// metadata and the effective server-authored frame.
+func RecordCallback(id ID, version, actionID, result string) {
+	globalMetricsMu.RLock()
+	m := globalMetrics
+	globalMetricsMu.RUnlock()
+	m.callbackResult(string(id), version, actionID, result)
+}
+
+func recordUpdate(id ID, version, result string) {
+	globalMetricsMu.RLock()
+	m := globalMetrics
+	globalMetricsMu.RUnlock()
+	m.updateResult(string(id), version, result)
 }

--- a/pkg/cardtmpl/metrics_a_test.go
+++ b/pkg/cardtmpl/metrics_a_test.go
@@ -1,0 +1,112 @@
+package cardtmpl
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-server/internal/carddispatch"
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardmsg"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+type metricMutationGateway struct {
+	snapshot CardMutationSnapshot
+}
+
+type CardMutationSnapshot = carddispatch.CardMutationSnapshot
+
+func (g *metricMutationGateway) Snapshot(context.Context, carddispatch.CardMutationTarget) (carddispatch.CardMutationSnapshot, error) {
+	return g.snapshot, nil
+}
+
+func (*metricMutationGateway) Mutate(context.Context, carddispatch.CardMutationRequest) (carddispatch.CardMutationResult, error) {
+	return carddispatch.CardMutationResult{Applied: true}, nil
+}
+
+func TestMetricsExposeCallbackAndUpdateCounters(t *testing.T) {
+	registry := prometheus.NewRegistry()
+	metrics := NewMetrics(registry)
+	metrics.callbackResult("docs.access-request", "0.3.0", "docs-access-approve", "ok")
+	metrics.updateResult("docs.access-request", "0.3.0", "ok")
+	metrics.callbackResult("docs.access-request", "0.3.0", "docs-access-approve", "future")
+	metrics.updateResult("docs.access-request", "0.3.0", "future")
+
+	if got := testutil.ToFloat64(metrics.callback.WithLabelValues(
+		"docs.access-request", "0.3.0", "docs-access-approve", "ok")); got != 1 {
+		t.Fatalf("callback counter = %v, want 1", got)
+	}
+	if got := testutil.ToFloat64(metrics.update.WithLabelValues("docs.access-request", "0.3.0", "ok")); got != 1 {
+		t.Fatalf("update counter = %v, want 1", got)
+	}
+	if got := testutil.ToFloat64(metrics.callback.WithLabelValues(
+		"docs.access-request", "0.3.0", "docs-access-approve", "error")); got != 1 {
+		t.Fatalf("bounded callback error counter = %v, want 1", got)
+	}
+	if got := testutil.ToFloat64(metrics.update.WithLabelValues("docs.access-request", "0.3.0", "error")); got != 1 {
+		t.Fatalf("bounded update error counter = %v, want 1", got)
+	}
+}
+
+func TestUpdateMetricsOnlyUseRegisteredTemplateLabels(t *testing.T) {
+	t.Run("replace unknown template", func(t *testing.T) {
+		promRegistry := prometheus.NewRegistry()
+		metrics := NewMetrics(promRegistry)
+		SetGlobalMetrics(metrics)
+		t.Cleanup(func() { SetGlobalMetrics(nil) })
+
+		updater, err := NewCardUpdater(NewRegistry(), &metricMutationGateway{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = updater.ReplaceView(context.Background(), UpdateTarget{
+			Target:    carddispatch.Target{SpaceID: "space-1", ChannelID: "user-b", ChannelType: 1},
+			SenderUID: "notification", MessageID: "1001", CardSeq: 1,
+		}, ID("untrusted.template"), "999.999.999", State("done"), json.RawMessage(`{}`), BuildEnv{SpaceID: "space-1"})
+		if !errors.Is(err, ErrTemplateUnknown) {
+			t.Fatalf("ReplaceView(unknown) error = %v, want %v", err, ErrTemplateUnknown)
+		}
+		if got := testutil.CollectAndCount(metrics.update); got != 0 {
+			t.Fatalf("unknown template created %d update metric series, want 0", got)
+		}
+	})
+
+	t.Run("append unregistered metadata", func(t *testing.T) {
+		promRegistry := prometheus.NewRegistry()
+		metrics := NewMetrics(promRegistry)
+		SetGlobalMetrics(metrics)
+		t.Cleanup(func() { SetGlobalMetrics(nil) })
+
+		envelope, err := json.Marshal(map[string]any{
+			"type": cardmsg.InteractiveCard.Int(), "card_version": cardmsg.CardVersion,
+			"profile": cardmsg.ProfileV1, "space_id": "space-1",
+			"card": map[string]any{
+				"type": "AdaptiveCard", "version": cardmsg.CardVersion,
+				"body": []any{map[string]any{"type": "TextBlock", "text": "before"}},
+				"metadata": map[string]any{"octo": map[string]any{
+					"protocol": Protocol, "template": map[string]any{"id": "untrusted.template", "version": "999.999.999"},
+				}},
+			},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		gateway := &metricMutationGateway{snapshot: carddispatch.CardMutationSnapshot{Envelope: envelope}}
+		updater, err := NewCardUpdater(NewRegistry(), gateway)
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = updater.Append(context.Background(), UpdateTarget{
+			Target:    carddispatch.Target{SpaceID: "space-1", ChannelID: "user-b", ChannelType: 1},
+			SenderUID: "notification", MessageID: "1001", CardSeq: 1,
+		}, json.RawMessage(`{"type":"TextBlock","text":"after"}`))
+		if err != nil {
+			t.Fatalf("Append(unregistered metadata): %v", err)
+		}
+		if got := testutil.CollectAndCount(metrics.update); got != 0 {
+			t.Fatalf("unregistered metadata created %d update metric series, want 0", got)
+		}
+	})
+}

--- a/pkg/cardtmpl/registry.go
+++ b/pkg/cardtmpl/registry.go
@@ -34,6 +34,7 @@ var (
 	ErrFieldsInvalid   = errors.New("cardtmpl: fields did not pass input schema")
 	ErrRenderFailed    = errors.New("cardtmpl: render failed post-build")
 	ErrRegistryFrozen  = errors.New("cardtmpl: registry frozen")
+	ErrActionUnknown   = errors.New("cardtmpl: action not declared by template")
 )
 
 // manifestFile 是 Registry 从 assets FS 解析的 manifest.json 形状。
@@ -53,6 +54,35 @@ type manifestFile struct {
 	// SourceLabel / SourceIconURL 可选,若手动指定则覆盖 Template 默认 Source。
 	SourceLabel   string `json:"sourceLabel,omitempty"`
 	SourceIconURL string `json:"sourceIconUrl,omitempty"`
+}
+
+// ActionView resolves one declared Action.Submit to its registered view. It is
+// used by the action ingress after extracting template identity from the
+// effective server-authored frame; OpenUrl and undeclared actions are rejected.
+func (r *Registry) ActionView(id ID, version, actionID string) (ViewKey, error) {
+	if strings.TrimSpace(actionID) == "" {
+		return "", ErrActionUnknown
+	}
+	e, err := r.entryOf(id, version)
+	if err != nil {
+		return "", err
+	}
+	var matched ViewKey
+	for view, report := range e.meta.interactions {
+		for _, action := range report.Actions {
+			if action.Type != "Action.Submit" || action.ID != actionID {
+				continue
+			}
+			if matched != "" && matched != view {
+				return "", fmt.Errorf("%w: %s@%s action %q is ambiguous", ErrActionUnknown, id, version, actionID)
+			}
+			matched = view
+		}
+	}
+	if matched == "" {
+		return "", fmt.Errorf("%w: %s@%s action %q", ErrActionUnknown, id, version, actionID)
+	}
+	return matched, nil
 }
 
 // Registry 是进程内模板注册中心。

--- a/pkg/cardtmpl/updater.go
+++ b/pkg/cardtmpl/updater.go
@@ -1,0 +1,179 @@
+package cardtmpl
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/Mininglamp-OSS/octo-server/internal/carddispatch"
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardmsg"
+)
+
+var ErrUpdateInvalid = errors.New("cardtmpl: invalid card update")
+
+// UpdateTarget binds a render/update to one authoritative stored message.
+// CardSeq is the positive monotonic sequence persisted by CardMutator CAS.
+type UpdateTarget struct {
+	Target     carddispatch.Target
+	SenderUID  string
+	MessageID  string
+	MessageSeq uint32
+	CardSeq    int64
+}
+
+type mutationGateway interface {
+	Snapshot(context.Context, carddispatch.CardMutationTarget) (carddispatch.CardMutationSnapshot, error)
+	Mutate(context.Context, carddispatch.CardMutationRequest) (carddispatch.CardMutationResult, error)
+}
+
+type CardUpdater interface {
+	ReplaceView(context.Context, UpdateTarget, ID, string, State, json.RawMessage, BuildEnv) error
+	Append(context.Context, UpdateTarget, json.RawMessage) error
+}
+
+type updater struct {
+	registry *Registry
+	mutator  mutationGateway
+}
+
+func NewCardUpdater(registry *Registry, mutator mutationGateway) (CardUpdater, error) {
+	if registry == nil || mutator == nil {
+		return nil, errors.New("cardtmpl: updater dependencies are required")
+	}
+	return &updater{registry: registry, mutator: mutator}, nil
+}
+
+func (u *updater) ReplaceView(ctx context.Context, target UpdateTarget, id ID, version string,
+	state State, fields json.RawMessage, env BuildEnv) (err error) {
+	if err := validateUpdateTarget(ctx, target); err != nil {
+		return err
+	}
+	if id == "" || version == "" || env.SpaceID != target.Target.SpaceID {
+		return ErrUpdateInvalid
+	}
+	if _, err := u.registry.Lookup(id, version); err != nil {
+		return err
+	}
+	defer func() {
+		result := "ok"
+		if err != nil {
+			result = "error"
+		}
+		recordUpdate(id, version, result)
+	}()
+	document, profile, err := u.registry.RenderCard(ctx, id, version, state, fields, env)
+	if err != nil {
+		return err
+	}
+	contentEdit, err := updateEnvelope(document, profile, target.Target.SpaceID, target.CardSeq)
+	if err != nil {
+		return err
+	}
+	_, err = u.mutator.Mutate(ctx, mutationRequest(target, contentEdit))
+	return err
+}
+
+func (u *updater) Append(ctx context.Context, target UpdateTarget, element json.RawMessage) (err error) {
+	var metricID ID
+	var metricVersion string
+	defer func() {
+		if metricID == "" {
+			return
+		}
+		result := "ok"
+		if err != nil {
+			result = "error"
+		}
+		recordUpdate(metricID, metricVersion, result)
+	}()
+	if err := validateUpdateTarget(ctx, target); err != nil {
+		return err
+	}
+	var appended map[string]interface{}
+	if err := json.Unmarshal(element, &appended); err != nil || appended == nil {
+		return ErrUpdateInvalid
+	}
+	snapshot, err := u.mutator.Snapshot(ctx, mutationTarget(target))
+	if err != nil {
+		return err
+	}
+	if snapshot.CardSeq < 0 || target.CardSeq-1 != snapshot.CardSeq {
+		return carddispatch.ErrCardMutationConflict
+	}
+	if template, ok := cardmsg.CardTemplateContext(snapshot.Envelope); ok {
+		if _, lookupErr := u.registry.Lookup(ID(template.ID), template.Version); lookupErr == nil {
+			metricID, metricVersion = ID(template.ID), template.Version
+		}
+	}
+	decoder := json.NewDecoder(bytes.NewReader(snapshot.Envelope))
+	decoder.UseNumber()
+	var envelope map[string]interface{}
+	if err := decoder.Decode(&envelope); err != nil || !cardmsg.IsCardPayload(envelope) {
+		return ErrUpdateInvalid
+	}
+	spaceID, _ := envelope["space_id"].(string)
+	if spaceID != target.Target.SpaceID {
+		return ErrUpdateInvalid
+	}
+	card, _ := envelope["card"].(map[string]interface{})
+	body, ok := card["body"].([]interface{})
+	if !ok {
+		return ErrUpdateInvalid
+	}
+	card["body"] = append(body, appended)
+	envelope["card_seq"] = target.CardSeq
+	raw, err := json.Marshal(envelope)
+	if err != nil {
+		return fmt.Errorf("%w: marshal append frame: %v", ErrUpdateInvalid, err)
+	}
+	normalized, err := cardmsg.NormalizeContentEdit(string(raw))
+	if err != nil {
+		return fmt.Errorf("%w: validate append frame: %v", ErrUpdateInvalid, err)
+	}
+	_, err = u.mutator.Mutate(ctx, mutationRequest(target, normalized))
+	return err
+}
+
+func validateUpdateTarget(ctx context.Context, target UpdateTarget) error {
+	if ctx == nil || target.SenderUID == "" || target.MessageID == "" || target.Target.SpaceID == "" ||
+		target.Target.ChannelID == "" || target.Target.ChannelType == 0 || target.CardSeq <= 0 {
+		return ErrUpdateInvalid
+	}
+	return nil
+}
+
+func mutationTarget(target UpdateTarget) carddispatch.CardMutationTarget {
+	return carddispatch.CardMutationTarget{
+		SenderUID: target.SenderUID, MessageID: target.MessageID, MessageSeq: target.MessageSeq,
+		ChannelID: target.Target.ChannelID, ChannelType: target.Target.ChannelType,
+	}
+}
+
+func mutationRequest(target UpdateTarget, contentEdit string) carddispatch.CardMutationRequest {
+	return carddispatch.CardMutationRequest{
+		SenderUID: target.SenderUID, MessageID: target.MessageID, MessageSeq: target.MessageSeq,
+		ChannelID: target.Target.ChannelID, ChannelType: target.Target.ChannelType, ContentEdit: contentEdit,
+	}
+}
+
+func updateEnvelope(document json.RawMessage, profile, spaceID string, cardSeq int64) (string, error) {
+	var card map[string]interface{}
+	if err := json.Unmarshal(document, &card); err != nil || card == nil {
+		return "", fmt.Errorf("%w: decode rendered card", ErrUpdateInvalid)
+	}
+	envelope := map[string]interface{}{
+		"type": cardmsg.InteractiveCard.Int(), "card_version": cardmsg.CardVersion,
+		"profile": profile, "space_id": spaceID, "card_seq": cardSeq, "card": card,
+	}
+	raw, err := json.Marshal(envelope)
+	if err != nil {
+		return "", fmt.Errorf("%w: marshal replacement frame: %v", ErrUpdateInvalid, err)
+	}
+	normalized, err := cardmsg.NormalizeContentEdit(string(raw))
+	if err != nil {
+		return "", fmt.Errorf("%w: validate replacement frame: %v", ErrUpdateInvalid, err)
+	}
+	return normalized, nil
+}

--- a/pkg/cardtmpl/updater.go
+++ b/pkg/cardtmpl/updater.go
@@ -14,7 +14,11 @@ import (
 var ErrUpdateInvalid = errors.New("cardtmpl: invalid card update")
 
 // UpdateTarget binds a render/update to one authoritative stored message.
-// CardSeq is the positive monotonic sequence persisted by CardMutator CAS.
+// CardSeq is the positive sequence enforced by the CardMutator CAS. ReplaceView
+// requires it strictly greater than the stored frame's card_seq (monotonic, as
+// the CAS mandates). Append additionally requires it to be exactly consecutive
+// (snapshot.CardSeq+1): a progress-frame appender owns its own frame numbering,
+// so a gap signals a lost/out-of-order frame and is rejected as a conflict.
 type UpdateTarget struct {
 	Target     carddispatch.Target
 	SenderUID  string

--- a/pkg/cardtmpl/updater_test.go
+++ b/pkg/cardtmpl/updater_test.go
@@ -1,0 +1,210 @@
+package cardtmpl_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-server/internal/carddispatch"
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardmsg"
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl"
+	docsaccessrequest "github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl/docs_access_request"
+)
+
+type captureMutationGateway struct {
+	snapshot carddispatch.CardMutationSnapshot
+	requests []carddispatch.CardMutationRequest
+	result   carddispatch.CardMutationResult
+	err      error
+}
+
+func (g *captureMutationGateway) Snapshot(_ context.Context, _ carddispatch.CardMutationTarget) (carddispatch.CardMutationSnapshot, error) {
+	return g.snapshot, g.err
+}
+
+func (g *captureMutationGateway) Mutate(_ context.Context, req carddispatch.CardMutationRequest) (carddispatch.CardMutationResult, error) {
+	g.requests = append(g.requests, req)
+	return g.result, g.err
+}
+
+func TestCardUpdaterReplaceViewRendersV3AndPreservesMessageIdentity(t *testing.T) {
+	r := cardtmpl.NewRegistry()
+	r.Register(docsaccessrequest.NewV3(), docsaccessrequest.Assets, docsaccessrequest.HandoffRootV3)
+	r.SetDefault(docsaccessrequest.TemplateID, docsaccessrequest.TemplateVersionV3)
+	r.Freeze()
+	gateway := &captureMutationGateway{result: carddispatch.CardMutationResult{Applied: true}}
+	updater, err := cardtmpl.NewCardUpdater(r, gateway)
+	if err != nil {
+		t.Fatalf("NewCardUpdater: %v", err)
+	}
+	target := cardtmpl.UpdateTarget{
+		Target:    carddispatch.Target{SpaceID: "space-1", ChannelID: "user-b", ChannelType: 1},
+		SenderUID: "notification", MessageID: "1001", MessageSeq: 7, CardSeq: 42,
+	}
+	fields := json.RawMessage(`{
+		"requestId":"request-1","state":"approved",
+		"document":{"docId":"doc-1","title":"Roadmap"},
+		"requester":{"name":"Alice"},"decision":{"operatorName":"Bob"}
+	}`)
+	if err := updater.ReplaceView(context.Background(), target, docsaccessrequest.TemplateID,
+		docsaccessrequest.TemplateVersionV3, docsaccessrequest.StateApproved, fields,
+		cardtmpl.BuildEnv{WebLoginURL: "https://web.example.com", Lang: "en", SpaceID: "space-1"}); err != nil {
+		t.Fatalf("ReplaceView: %v", err)
+	}
+	if len(gateway.requests) != 1 {
+		t.Fatalf("mutation count = %d, want 1", len(gateway.requests))
+	}
+	req := gateway.requests[0]
+	if req.SenderUID != target.SenderUID || req.MessageID != target.MessageID || req.MessageSeq != target.MessageSeq ||
+		req.ChannelID != target.Target.ChannelID || req.ChannelType != target.Target.ChannelType {
+		t.Fatalf("mutation target = %+v, want %+v", req, target)
+	}
+	assertUpdateEnvelope(t, req.ContentEdit, 42, cardmsg.ProfileV1, docsaccessrequest.TemplateVersionV3)
+}
+
+func TestCardUpdaterAppendUsesEffectiveFrameAndValidatesWholeCard(t *testing.T) {
+	original := map[string]any{
+		"type": 17, "card_version": cardmsg.CardVersion, "profile": cardmsg.ProfileV1,
+		"space_id": "space-1", "card_seq": 4,
+		"card": map[string]any{
+			"type": "AdaptiveCard", "version": cardmsg.CardVersion,
+			"body": []any{map[string]any{"type": "TextBlock", "text": "before"}},
+			"metadata": map[string]any{"webUrl": "https://web.example.com/d/1", "octo": map[string]any{
+				"protocol": cardtmpl.Protocol, "template": map[string]any{"id": "docs.access-request", "version": "0.3.0"},
+			}},
+		},
+	}
+	raw, _ := json.Marshal(original)
+	gateway := &captureMutationGateway{
+		snapshot: carddispatch.CardMutationSnapshot{Envelope: raw, CardSeq: 4},
+		result:   carddispatch.CardMutationResult{Applied: true},
+	}
+	updater, err := cardtmpl.NewCardUpdater(cardtmpl.NewRegistry(), gateway)
+	if err != nil {
+		t.Fatalf("NewCardUpdater: %v", err)
+	}
+	target := cardtmpl.UpdateTarget{
+		Target:    carddispatch.Target{SpaceID: "space-1", ChannelID: "user-b", ChannelType: 1},
+		SenderUID: "notification", MessageID: "1001", CardSeq: 5,
+	}
+	element := json.RawMessage(`{"type":"TextBlock","text":"after"}`)
+	if err := updater.Append(context.Background(), target, element); err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+	if len(gateway.requests) != 1 {
+		t.Fatalf("mutation count = %d, want 1", len(gateway.requests))
+	}
+	var envelope map[string]any
+	if err := json.Unmarshal([]byte(gateway.requests[0].ContentEdit), &envelope); err != nil {
+		t.Fatalf("decode content_edit: %v", err)
+	}
+	card := envelope["card"].(map[string]any)
+	body := card["body"].([]any)
+	if len(body) != 2 || body[1].(map[string]any)["text"] != "after" {
+		t.Fatalf("appended body = %#v", body)
+	}
+	assertUpdateEnvelope(t, gateway.requests[0].ContentEdit, 5, cardmsg.ProfileV1, "0.3.0")
+}
+
+func TestCardUpdaterAppendRejectsNonContiguousCardSequence(t *testing.T) {
+	original := map[string]any{
+		"type": 17, "card_version": cardmsg.CardVersion, "profile": cardmsg.ProfileV1,
+		"space_id": "space-1", "card_seq": 4,
+		"card": map[string]any{
+			"type": "AdaptiveCard", "version": cardmsg.CardVersion,
+			"body": []any{map[string]any{"type": "TextBlock", "text": "current"}},
+		},
+	}
+	raw, _ := json.Marshal(original)
+	gateway := &captureMutationGateway{
+		snapshot: carddispatch.CardMutationSnapshot{Envelope: raw, CardSeq: 4},
+		result:   carddispatch.CardMutationResult{Applied: true},
+	}
+	updater, err := cardtmpl.NewCardUpdater(cardtmpl.NewRegistry(), gateway)
+	if err != nil {
+		t.Fatalf("NewCardUpdater: %v", err)
+	}
+	target := cardtmpl.UpdateTarget{
+		Target:    carddispatch.Target{SpaceID: "space-1", ChannelID: "user-b", ChannelType: 1},
+		SenderUID: "notification", MessageID: "1001", CardSeq: 6,
+	}
+	err = updater.Append(context.Background(), target, json.RawMessage(`{"type":"TextBlock","text":"stale append"}`))
+	if !errors.Is(err, carddispatch.ErrCardMutationConflict) {
+		t.Fatalf("Append(non-contiguous card_seq) error = %v, want %v", err, carddispatch.ErrCardMutationConflict)
+	}
+	if len(gateway.requests) != 0 {
+		t.Fatalf("stale append wrote mutations: %+v", gateway.requests)
+	}
+}
+
+func TestCardUpdaterFailsClosedOnInvalidInputsAndDependencies(t *testing.T) {
+	gateway := &captureMutationGateway{}
+	if _, err := cardtmpl.NewCardUpdater(nil, gateway); err == nil {
+		t.Fatal("NewCardUpdater(nil registry) error = nil")
+	}
+	if _, err := cardtmpl.NewCardUpdater(cardtmpl.NewRegistry(), nil); err == nil {
+		t.Fatal("NewCardUpdater(nil mutator) error = nil")
+	}
+
+	r := cardtmpl.NewRegistry()
+	r.Register(docsaccessrequest.NewV3(), docsaccessrequest.Assets, docsaccessrequest.HandoffRootV3)
+	r.SetDefault(docsaccessrequest.TemplateID, docsaccessrequest.TemplateVersionV3)
+	r.Freeze()
+	updater, err := cardtmpl.NewCardUpdater(r, gateway)
+	if err != nil {
+		t.Fatal(err)
+	}
+	target := cardtmpl.UpdateTarget{
+		Target:    carddispatch.Target{SpaceID: "space-1", ChannelID: "user-b", ChannelType: 1},
+		SenderUID: "notification", MessageID: "1001", CardSeq: 1,
+	}
+	validFields := json.RawMessage(`{
+		"requestId":"request-1","state":"approved",
+		"document":{"docId":"doc-1","title":"Roadmap"},
+		"decision":{"operatorName":"reviewer-1"}
+	}`)
+
+	if err := updater.ReplaceView(context.Background(), target, docsaccessrequest.TemplateID,
+		docsaccessrequest.TemplateVersionV3, docsaccessrequest.StateApproved, validFields,
+		cardtmpl.BuildEnv{WebLoginURL: "https://web.example.com", SpaceID: "other"}); !errors.Is(err, cardtmpl.ErrUpdateInvalid) {
+		t.Fatalf("ReplaceView(space mismatch) error = %v, want %v", err, cardtmpl.ErrUpdateInvalid)
+	}
+	if err := updater.ReplaceView(context.Background(), target, docsaccessrequest.TemplateID,
+		docsaccessrequest.TemplateVersionV3, docsaccessrequest.StateApproved, json.RawMessage(`{}`),
+		cardtmpl.BuildEnv{WebLoginURL: "https://web.example.com", SpaceID: "space-1"}); !errors.Is(err, cardtmpl.ErrFieldsInvalid) {
+		t.Fatalf("ReplaceView(invalid fields) error = %v, want %v", err, cardtmpl.ErrFieldsInvalid)
+	}
+
+	if err := updater.Append(context.Background(), target, json.RawMessage(`[]`)); !errors.Is(err, cardtmpl.ErrUpdateInvalid) {
+		t.Fatalf("Append(non-object) error = %v, want %v", err, cardtmpl.ErrUpdateInvalid)
+	}
+	snapshotErr := errors.New("snapshot failed")
+	gateway.err = snapshotErr
+	if err := updater.Append(context.Background(), target, json.RawMessage(`{"type":"TextBlock","text":"after"}`)); !errors.Is(err, snapshotErr) {
+		t.Fatalf("Append(snapshot error) = %v, want %v", err, snapshotErr)
+	}
+	gateway.err = nil
+	gateway.snapshot = carddispatch.CardMutationSnapshot{Envelope: json.RawMessage(`{"type":17}`)}
+	if err := updater.Append(context.Background(), target, json.RawMessage(`{"type":"TextBlock","text":"after"}`)); !errors.Is(err, cardtmpl.ErrUpdateInvalid) {
+		t.Fatalf("Append(invalid effective frame) = %v, want %v", err, cardtmpl.ErrUpdateInvalid)
+	}
+}
+
+func assertUpdateEnvelope(t *testing.T, raw string, seq int64, profile, version string) {
+	t.Helper()
+	var envelope map[string]any
+	if err := json.Unmarshal([]byte(raw), &envelope); err != nil {
+		t.Fatalf("decode content_edit: %v", err)
+	}
+	if envelope["card_seq"] != float64(seq) || envelope["profile"] != profile || envelope["space_id"] != "space-1" {
+		t.Fatalf("envelope = %+v", envelope)
+	}
+	card := envelope["card"].(map[string]any)
+	metadata := card["metadata"].(map[string]any)
+	octo := metadata["octo"].(map[string]any)
+	template := octo["template"].(map[string]any)
+	if template["version"] != version {
+		t.Fatalf("template.version = %v, want %q", template["version"], version)
+	}
+}


### PR DESCRIPTION
## Summary

Closes the post-#633 interactive-card loop (roadmap group A). #633 shipped the
L0 platform base and `docs.access-request@0.2.0` with a **read-only** `pending`
view. This PR adds the missing "interactive → authoritative terminal" half:
server-authoritative card updates, a route-versioned callback envelope, a
`0.3.0` result view registered beside the frozen `0.2.0`, and two bounded
metrics.

## Related Issue

Follow-up to #633 (roadmap group A). No standalone issue.

## Linked Spec

`.octospec/tasks/cardtmpl-interaction-closure/brief.md`

## Changes

- **A1 `CardUpdater`** (`pkg/cardtmpl/updater.go`): `ReplaceView` (authoritative
  pending→result re-render, preserves message ID) and `Append` (progress frame,
  strictly consecutive `card_seq`). Both compose the existing
  `carddispatch.CardMutator` (CAS + idempotent replay + revision + CMD); no new
  write transport. All write authority (sender, message ID, channel, Space,
  `card_seq`) is re-derived from stored state, never from callback display
  fields.
- **A2 callback envelope** (`internal/cardactiondispatch`): routes default to
  the legacy flat body (byte-compatible; old queue rows still decode); an
  opt-in `octo-card-v1` route option selects the nested envelope
  (`protocol` / `type=card.action` / `card.{…}` / `trigger_id`). HMAC still
  covers the exact body. `response_url` is reserved, not emitted. Ingress
  (`modules/message/api_card_action.go`) enriches the internal event only from
  the effective server-authored frame + Registry; corrupt/partial metadata or
  an undeclared action fails closed before enqueue; legacy cards keep the
  existing zero-context path.
- **A3 `docs.access-request@0.3.0`** (`pkg/cardtmpl/docs_access_request/v3.go`):
  new `result` view (`approved`/`rejected`, `octo/v1`) beside the frozen
  `0.2.0`. `pending` stays `octo/v2` with the same actions (only additive
  optional `Action.data` context keys). Docs finalizer upgrades approved/denied
  cards in place to `0.3.0/result`; `cancelled`/`unavailable` stay on the legacy
  fallback. In-flight `0.2.0` cards upgrade too — missing decorative fields are
  omitted, not fabricated. **`0.2.0` handoff tree has zero diff vs `2917e6a6`.**
- **A4 metrics** (`pkg/cardtmpl/metrics.go`):
  `dmwork_cardtmpl_callback_total{…,result=ok|rejected|error}` and
  `dmwork_cardtmpl_update_total{…,result=ok|error}`; labels only from registered
  metadata + declared interactions.
- Docs: `docs/platform-card-base.md` updated; octospec journal/log/learning
  under `.octospec/`.

## Testing

Verified green locally (this branch, MySQL/Redis/WuKongIM available):

- `go vet` (focused packages)
- `pkg/cardtmpl` `go test -race -cover` → **80.5% / 85.8%**
- `internal/cardactiondispatch` (callback envelope), `pkg/cardmsg`
  (template-context), `internal/carddispatch` (mutation CAS),
  `modules/notify` (finalizer + v3 result),
  `modules/message` (`TestResolveRegistryCardContext…`)
- `make i18n-extract-check`, `make i18n-lint`

Honest gaps (not run here):

- `golangci-lint` — not installed on the dev host; **covered by the CI lint
  lane**.
- The `//go:build integration` card-action **orchestration** e2e in
  `modules/message` (`TestCardActionEndToEnd…`, `…TrustModel`, etc.) was **not**
  re-verified: under `-tags integration` the `message` test binary hits a
  pre-existing compile-time import cycle (message→app_bot→bot_api→
  messages_search→message), and the CI test lane deliberately runs the default
  build **without** `-tags integration` (see `ci.yml`, ref #557). Per the
  in-source note that path's CAS is covered by `modules/bot_api` IM cases; full
  execution needs the dmworkim `make env-test` environment. This is a
  pre-existing test-infra constraint, not introduced by this PR.

- [x] Unit tests added/updated
- [x] Manually verified (focused suites above)

## COMPREHENSION

1. **What does this change actually do to the load-bearing path?**
   It adds a second lifecycle stage to platform cards: after the existing
   authenticated `/v1/message/card/action` ingress enqueues an action event,
   the docs finalizer now re-renders the card through `Registry` as
   `docs.access-request@0.3.0/result` and replaces the original message
   **in place** via `CardMutator` (message ID / channel / sender / Space /
   `card_seq` all re-derived from stored state). New sends default to `0.3.0`;
   the frozen `0.2.0` stays registered so in-flight pending cards keep working
   and are upgraded on decision. The callback wire format becomes
   route-versioned (legacy default, opt-in `octo-card-v1`).

2. **What could break (dependents + failure mode)?**
   - *Boot*: `0.3.0`'s register-time self-check is fail-close — a bad
     sample/manifest panics `main.go` at startup. Mitigation: self-check +
     conformance suite pass in tests.
   - *In-flight `0.2.0` cards*: click still accepted only because `0.2.0`
     stays registered (`ActionView` resolves it); if it were dropped, existing
     pending cards would 400 on click. Kept registered + tested.
   - *Terminal card visual change*: approved/denied now render the `0.3.0`
     result (octo/v1) instead of the legacy octo/v2 outcome card. Front-end must
     render `octo/v1` result; interactive `pending` (octo/v2) web rendering is a
     pre-existing gate tracked outside this PR.
   - *Callback consumers*: unchanged unless a route explicitly opts into
     `octo-card-v1`; default stays byte-compatible.
   - *Update ordering*: `card_seq` for the docs `ReplaceView` is sourced from
     `event.EventID`, which is load-bearingly monotonic today — flagged as a
     pending learning.

3. **How do you know it works (specific test/repro/trace)?**
   `updater_test.go` covers ReplaceView/Append happy paths + fail-closed
   branches (non-object append, stale/lower `card_seq` conflict, idempotent
   replay with no duplicate revision/CMD). `v3_test.go` + the conformance suite
   assert `0.3.0` approved/rejected render with correct
   `metadata.octo.template`, no `Action.Submit`/`Input.*`, and pass
   `cardmsg.Validate` under `octo/v1`. `action_finalizer_v3_test.go` proves
   approved→approved / denied→rejected mapping and the minimal-field `0.2.0`→
   `0.3.0` upgrade. `envelope_test.go` covers legacy-vs-`octo-card-v1` bodies +
   HMAC. `metrics_a_test.go` proves registration, increments, and bounded
   labels. All ran green locally (see Testing).

## Checklist

- [x] PR description is in English
- [x] Added tests for my changes
- [x] Updated documentation (`docs/platform-card-base.md`, `.octospec/`)
- [x] Followed commit message conventions (Conventional Commits)
