### PR TITLE
docs(incomingwebhook): document max_per_thread + max_total_per_group knobs

### DIFF
--- a/modules/common/system_setting_schema.go
+++ b/modules/common/system_setting_schema.go
@@ -118,7 +118,7 @@ var systemSettingSchema = []settingDef{
 		Effective: func(s *SystemSettings) string { return strconv.Itoa(s.IncomingWebhookPerWebhookBurst()) }},
 	{Category: "incomingwebhook", Key: "max_per_group", Type: settingTypeInt, Description: "群本体作用域最多可创建的 Webhook 数量（子区另见 max_per_thread）", Positive: true,
 		Effective: func(s *SystemSettings) string { return strconv.Itoa(s.IncomingWebhookMaxPerGroup()) }},
-	{Category: "incomingwebhook", Key: "max_per_thread", Type: settingTypeInt, Description: "单个子区作用域最多可创建的 Webhook 数量（未配置时与群本体 max_per_group 一致）", Positive: true,
+	{Category: "incomingwebhook", Key: "max_per_thread", Type: settingTypeInt, Description: "单个子区作用域最多可创建的 Webhook 数量（未配置或 0/≤0 时回退到群本体 max_per_group，并非「禁止子区建 Webhook」；写入要求为正整数）", Positive: true,
 		Effective: func(s *SystemSettings) string { return strconv.Itoa(s.IncomingWebhookMaxPerThread()) }},
 	{Category: "incomingwebhook", Key: "max_per_creator", Type: settingTypeInt, Description: "单个普通成员/机器人在一个投递作用域（群本体或每个子区）内最多可创建的 Webhook 数量（群主/管理员不受限）", Positive: true,
 		Effective: func(s *SystemSettings) string { return strconv.Itoa(s.IncomingWebhookMaxPerCreator()) }},

--- a/modules/common/system_settings.go
+++ b/modules/common/system_settings.go
@@ -643,8 +643,9 @@ func (s *SystemSettings) IncomingWebhookPerWebhookBurst() int {
 	return v
 }
 
-// IncomingWebhookMaxPerGroup 单个【投递作用域】可创建的 webhook 数量上限：群本体与
-// 每个子区各按此上限独立计数（不共享名额）。DB → env → 默认 10。
+// IncomingWebhookMaxPerGroup 群本体作用域（thread_short_id='')可创建的 webhook 数量上限。
+// 子区作用域另用 IncomingWebhookMaxPerThread（未配置时回退到本值），两者独立计数、不共享
+// 名额。DB → env → 默认 10。
 // 读侧防御：≤0 回退默认（max_per_group=0 会让每次 create 都 ErrQuotaExceeded，是
 // 总开关之外一种更难诊断的「暗关」）。
 func (s *SystemSettings) IncomingWebhookMaxPerGroup() int {

--- a/modules/incomingwebhook/README.md
+++ b/modules/incomingwebhook/README.md
@@ -59,8 +59,8 @@ webhook 可被创建为绑定到某个子区，推送即投递进子区频道（
   锁仍锚父群行（避免空作用域首插的 gap-lock 死锁），锁粗、计数细，两者独立：
   - **作用域级**：群本体用 `incomingwebhook.max_per_group`（默认 10，env
     `DM_INCOMINGWEBHOOK_MAX_PER_GROUP`）；每个子区用 `incomingwebhook.max_per_thread`
-    （env `DM_INCOMINGWEBHOOK_MAX_PER_THREAD`，**未配置时回退到 `max_per_group`**）——二者
-    解耦，可分别精确设数（如群 10 / 每子区 3）。对所有人生效。
+    （env `DM_INCOMINGWEBHOOK_MAX_PER_THREAD`，**未配置或填 0/≤0 时回退到 `max_per_group`**，
+    并非「子区禁建」）——二者解耦，可分别精确设数（如群 10 / 每子区 3）。对所有人生效。
   - **per-creator**：普通成员/bot 在【本作用域】内另受 `incomingwebhook.max_per_creator`
     （默认 5，env `DM_INCOMINGWEBHOOK_MAX_PER_CREATOR`）约束，管理员豁免。
   - **群聚合天花板**：`incomingwebhook.max_total_per_group`（env

--- a/modules/incomingwebhook/README.md
+++ b/modules/incomingwebhook/README.md
@@ -54,12 +54,18 @@ webhook 可被创建为绑定到某个子区，推送即投递进子区频道（
 - 隐私提示：list 响应包含每个 webhook 的 `creator_uid`（供客户端判断"是否我创建的"
   并展示归属），即任意群成员可见全群 webhook 的创建者身份——群成员名册本就互相可见，
   属有意设计；token / 推送 URL 绝不出现在 list 中。对隐私敏感的部署请知悉此暴露面。
-- 配额双层，均按【投递作用域】`(group_no, thread_short_id)` 计——群本体与每个子区各有
-  独立配额、复用同一组 max 值、互不共享名额（子区多的群 / octo-loop 不被父群总量卡死）：
-  作用域级 `max_per_group`（默认 10）对所有人生效；普通成员/bot 另受 per-creator 配额
-  （system_setting `incomingwebhook.max_per_creator`，默认 5，env
-  `DM_INCOMINGWEBHOOK_MAX_PER_CREATOR`）约束，管理员豁免。超限 409。计数串行化锁仍锚
-  父群行（避免空作用域首插的 gap-lock 死锁），锁粗、计数细，两者独立。
+- 配额三层，均按【投递作用域】`(group_no, thread_short_id)` 计——群本体与每个子区各有
+  独立配额、互不共享名额（子区多的群 / octo-loop 不被父群总量卡死）。超限 409；计数串行化
+  锁仍锚父群行（避免空作用域首插的 gap-lock 死锁），锁粗、计数细，两者独立：
+  - **作用域级**：群本体用 `incomingwebhook.max_per_group`（默认 10，env
+    `DM_INCOMINGWEBHOOK_MAX_PER_GROUP`）；每个子区用 `incomingwebhook.max_per_thread`
+    （env `DM_INCOMINGWEBHOOK_MAX_PER_THREAD`，**未配置时回退到 `max_per_group`**）——二者
+    解耦，可分别精确设数（如群 10 / 每子区 3）。对所有人生效。
+  - **per-creator**：普通成员/bot 在【本作用域】内另受 `incomingwebhook.max_per_creator`
+    （默认 5，env `DM_INCOMINGWEBHOOK_MAX_PER_CREATOR`）约束，管理员豁免。
+  - **群聚合天花板**：`incomingwebhook.max_total_per_group`（env
+    `DM_INCOMINGWEBHOOK_MAX_TOTAL_PER_GROUP`，**默认 0 = 不启用**）封顶单群跨群本体 + 所有
+    子区的 webhook 总数，挡住「子区可无限建 → 总量 = 作用域上限 ×(子区数+1) 失控」。
 - **创建者退群即失效**：push 路径校验创建者仍是群内（内部、正常）成员，不满足则
   统一 401 并把该 webhook 懒级联禁用（status→0）；启用/regenerate/测试推送对
   创建者已退群的 webhook 返回 409（`mgmt_creator_left`），只能删除重建。创建者


### PR DESCRIPTION
## Summary

Documentation-only follow-up to #642 (per-scope webhook quota + the `max_per_thread` / `max_total_per_group` knobs), addressing the non-blocking doc notes raised in that PR's review. No behavior change.

## Related Issue

Follow-up to #642 (merged) / #640. Docs cleanup only — nothing functional.

## Changes

- **`modules/incomingwebhook/README.md`** — the quota section still described a "two-layer" quota. Rewritten to document the actual **three** layers, each with its env var: per-scope (`max_per_group` for the group, `max_per_thread` for each thread — falls back to `max_per_group` when unset), per-creator (`max_per_creator`), and the group-wide aggregate ceiling (`max_total_per_group`, `0`=disabled). _(raised by Jerry-Xin & Octo-Q)_
- **`modules/common/system_settings.go`** — `IncomingWebhookMaxPerGroup` doc comment said each thread also uses this limit; corrected to state it is the **group-self** scope cap and a configured thread uses `max_per_thread`. _(Jerry-Xin)_
- **`modules/common/system_setting_schema.go`** — `max_per_thread` schema description now clarifies that unset / `0` / `≤0` **falls back to `max_per_group`** and is NOT "disable thread webhooks" (distinguishing it from `max_total_per_group`'s `0`=disabled sentinel). _(Octo-Q P2)_

## Testing

- [x] `go vet ./modules/common/...` clean.
- Docs / comments / one schema description string only — no logic touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QqpYSJX4M73HBFKmJ1CQkQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01QqpYSJX4M73HBFKmJ1CQkQ)_