### PR TITLE
feat(cardtmpl): migrate docs.commented + docs.shared to Registry (roadmap C PR-1)

### DIFF
--- a/.octospec/journal/shared/cardtmpl-l2a-migration.md
+++ b/.octospec/journal/shared/cardtmpl-l2a-migration.md
@@ -1,0 +1,122 @@
+---
+type: Journal
+title: "Journal: cardtmpl-l2a-migration (PR-1: docs.commented + docs.shared)"
+description: Roadmap C first slice — migrate docs.commented and docs.shared display cards onto the cardtmpl Registry using the pilot copy-directory shape. Together with the already-migrated docs.access-request they reach the §2.2-5 L2b hard gate ② (≥3 L2a cards, v1 + v2 coverage). Also extracts the shared SanitizeLine helper (G5) and lays a summary-side fragment helper for PR-2.
+tags: ["cardtmpl", "platform", "docs-commented", "docs-shared", "l2a-migration", "wire-contract", "i18n", "error-response", "escape", "markdown", "url-destination", "testing"]
+timestamp: 2026-07-23T12:30:00+08:00
+# --- octospec extension fields ---
+task: cardtmpl-l2a-migration
+upstream: self (roadmap C)
+source: self
+---
+
+# Journal: cardtmpl-l2a-migration (PR-1)
+
+## What was done
+
+First slice of roadmap group C — two new L2a display cards migrated onto
+`Registry.Render` behind the docs-notify plan-B shell, plus one shared helper
+and one PR-2 scaffold:
+
+1. **`pkg/cardtmpl/docs_commented@0.1.0`** — new subpackage with self-embedded
+   handoff (`manifest.json` incl. `renderProfile`/`renderProfileCompatibility`,
+   `contract/data.schema.json`, `samples/shown.json`) and a 3-method Template
+   (Meta/Build/FallbackText). Build composes the base
+   `BuildDocsResourceCardBodyWithLang` (already extracted upstream), so the
+   rendered body is byte-identical to legacy `buildDocsCard` for the same
+   inputs. 85.1% coverage; -race green.
+2. **`pkg/cardtmpl/docs_shared@0.1.0`** — symmetric subpackage, differs from
+   commented only in `Variant` + attribution copy. 80.9% coverage; -race green.
+3. **notify wiring** (`modules/notify/card_via_registry.go` +
+   `modules/notify/card.go`): new `buildDocsDisplayCardViaRegistry` +
+   `preflightDocsDisplaySchema` helpers; `deliverDocsCardNotification` routes
+   `DocsCardKindCommented` / `DocsCardKindShared` through Registry with F7
+   fail-close (Registry-unwired → 500, not silent legacy). The
+   `NotifyReq`/`DocsCardFields` external shape is unchanged (plan B).
+4. **`main.installCardTmplRegistry`** registers both new cards + `SetDefault` +
+   `Freeze` alongside the pilot; `modules/notify` gets a `TestMain` that
+   mirrors the production wiring so preflight tests inherit the same registry.
+5. **G5**: `SanitizeLine` exposed on `pkg/cardtmpl/resource.go`; both prior
+   copies (`modules/notify` + `pkg/cardtmpl/docs_access_request`) become
+   thin wrappers. Word list drift is now impossible — single source.
+6. **PR-2 scaffold**: `BuildSummaryResourceCardBodyWithLang` added so the
+   summary migration in PR-2 can compose the base body without touching the
+   legacy summary path.
+
+## Byte-equivalence baseline (the core acceptance)
+
+`modules/notify/card_via_registry_display_baseline_test.go` runs 4 fixtures
+(`commented` × zh full/anon, `shared` × zh full/anon) through both **legacy
+`buildDocsCard`** and **`buildDocsDisplayCardViaRegistry`**, strips the two
+newly-injected metadata fields (`metadata.octo.protocol` +
+`metadata.octo.template`), and asserts canonical JSON byte-equality. Everything
+else — body, facts, ActionSet, attribution, variant, source, webUrl — is
+identical. Any future drift (copy, ordering, alias, extra field) fails this
+test immediately.
+
+`Action.OpenUrl.id` is intentionally NOT added on v1 cards (only the v2
+`access_requested` pilot adds `view_document` because its interaction report
+requires it). No id to strip on v1.
+
+## Structural learning
+
+- **The base already anticipated this migration.** `assembleResourceCardBody`
+  was extracted upstream so legacy and Registry paths share the exact same
+  body assembler; `BuildDocsResourceCardBodyWithLang` had a comment naming
+  `pkg/cardtmpl/docs_commented` explicitly. PR-1's Go footprint was therefore
+  minimal — each Template is a thin i18n + fixture-mapping shim on top of the
+  shared body. Confirms the "copy pilot directory" pattern scales; the
+  remaining L2a cards are similarly cheap.
+- **§2.2-5 L2b hard gate ② is now met.** Three L2a cards (`docs.access-request`
+  v2 + `docs.commented` v1 + `docs.shared` v1) run the full Registry path
+  covering both wire profiles. This is prerequisite, not sufficient — D
+  (`ext.*` production channel) still needs the visibility/token plumbing.
+
+## Gotchas worth remembering
+
+- **`TestMain` global Registry mirrors production wiring.** Any test that runs
+  `deliverDocsCardNotification` for the commented/shared/access_requested
+  kinds now needs a wired Registry (F7). A single `TestMain` under
+  `modules/notify` beats retrofitting Registry setup into 10+ tests
+  individually. Tests that intentionally verify unwired behavior can
+  `SetDefaultRegistry(nil)` locally.
+- **Cross-package migration ledger still bites `-count=1` runs.** After
+  running any test package that uses `testutil.NewTestServer`, another package
+  may hit `panic: Table 'seq' already exists ... sql-migrate`. Recovery is
+  documented in memory `local_test_infra.md`: `docker exec octo-test-mysql
+  mysql -uroot -pdemo -e "DROP DATABASE IF EXISTS test; CREATE DATABASE test
+  ..."`. This is not introduced by C; it's the CI lane's per-package
+  drop-and-recreate mirror running locally.
+- **English copy alignment.** The migrated card's per-language `labelSet` must
+  match `modules/notify.docsLabelsFor` byte-for-byte (banner / actor / time
+  labels / kvSep), or the byte-equivalence baseline fails. Caught one during
+  PR-1 (initial `bannerAnon` / `actor` / `updatedAt` drift). Copying the exact
+  entries from the legacy label set before hand-editing prevents the miss.
+
+## Out of scope (deliberate, deferred to later PRs)
+
+- `summary.completed` / `summary.failed` (PR-2 — scaffold in place).
+- `generic.approval` — dynamic caller-supplied `owner`/`action_type` conflicts
+  with the static `TemplateActionContract`; needs a separate adaptation
+  decision (fixed-owner template vs preserved dynamic special-case) before it
+  can move to the Registry.
+- No `NotifyReq` external shape change / no envelope mode (roadmap E2).
+- No `${}` JSON engine (E1), no capability-discovery endpoint (B), no L2b
+  channel (D), no unfurl (H).
+- No DB migration.
+
+## Verification (this run, real infra)
+
+Locally green with MySQL 8 (docker :3306) / Redis 7 (:6379) / WuKongIM (:5001):
+
+- `go build ./...`, `go vet ./...`
+- `pkg/cardtmpl/docs_commented` -race -cover → **85.1%**
+- `pkg/cardtmpl/docs_shared` -race -cover → **80.9%**
+- `pkg/cardtmpl/...` (base + pilot + new subpackages) all green
+- `modules/notify` full package (after `DROP DATABASE test; CREATE DATABASE
+  test` to reset the cross-package migration ledger) — all green including
+  the 4-case byte-equivalence baseline and the C1 preflight assertion
+- `make i18n-extract-check`, `make i18n-lint` — clean
+- `golangci-lint` not installed on this host; the CI lint lane covers it.
+- Message `//go:build integration` orchestration e2e — pre-existing import
+  cycle, not run locally nor in the CI default lane (unchanged by this PR).

--- a/.octospec/journal/shared/cardtmpl-l2a-migration.md
+++ b/.octospec/journal/shared/cardtmpl-l2a-migration.md
@@ -12,6 +12,52 @@ source: self
 
 # Journal: cardtmpl-l2a-migration (PR-1)
 
+## Review round (PR #649, 3× APPROVE + 1 CHANGES_REQUESTED → addressed)
+
+`lml2468` / `Jerry-Xin` / `mochashanyao` approved; `yujiawei` requested changes
+on one blocking item. Addressed in-branch:
+
+- **P1 (blocking, yujiawei) — over-length display fields hard-rejected (400,
+  zero delivery) where legacy truncated & delivered.** The new schemas cap
+  `excerpt`/`actorName`/`updatedAt`/`title`; `preflightDocsDisplaySchema` runs
+  before member/gate checks, so a 301-rune comment (realistic) now 400s and
+  *every* recipient loses the notification — not even the text fallback fires.
+  Legacy `buildDocsCard` never rejected on length (it truncated at render).
+  This is the "unchanged wire shape ≠ unchanged accepted-input behavior" trap
+  and the baseline can't catch it (all fixtures in-bounds). Fix, per the brief's
+  own G9 wording ("truncate before render"): `mapDocsCardFieldsToDisplayJSON`
+  now server-side truncates `title`→`cardtmpl.MaxTitleRunes`,
+  `actorName`→120, `excerpt`→`cardtmpl.MaxExcerptRunes`, `updatedAt`→80 before
+  preflight, preserving delivery. `docId` is **not** truncated — it's the
+  deep-link key, so an over-length docId stays a genuine C1 400 (same handling
+  as summary `taskNo`). Exported `cardtmpl.MaxTitleRunes` + `cardtmpl.TruncateRunes`
+  so ingress and render share one cap/impl (G9). Within-budget inputs unchanged
+  → canonical-JSON baseline still holds;
+  `TestMapDocsDisplayFields_TruncatesDisplayFields` locks the new behavior
+  (huge input delivers, over-length docId 400s).
+- **P2 — dangling reference to a non-existent "docs_commented G9 field-cap
+  test".** `resource.go` claimed the excerpt cap and schema `maxLength` "never
+  drift (see the ... test)" but no such test existed. Added
+  `TestSchemaCapsMatchRenderCaps` to both `docs_commented` and `docs_shared`
+  (assert schema `excerpt.maxLength == MaxExcerptRunes`, `title.maxLength ==
+  MaxTitleRunes`) and reworded the comment to name the real test.
+- **P2 — "byte-equivalence" over-claim.** The baseline unmarshal→canonical→
+  remarshal proves *canonical-JSON / semantic* equality, not literal wire-byte.
+  Reworded the test comment to say so (kept the function name; it's the right
+  drift guard, just not literal bytes).
+- **P2 (mochashanyao/Jerry-Xin) — fallback delegation gap** (commented/shared
+  text fallback still legacy, not `Template.FallbackText`) and **Nit — no
+  `docs_shared` en test**: added `TestRenderEnglishSourceLocalized` for
+  `docs_shared`; the fallback-delegation refactor is deferred to the roadmap C
+  finalization PR (copy is byte-identical today, non-blocking).
+- **Nit — gofmt drift** in `docs_shared/template.go`: `gofmt -w`.
+- Also made the docs build-error log label kind-generic (+`zap kind`); it
+  previously hard-coded "docs access-request card" for commented/shared too.
+
+Dismissed (yujiawei's own): F7-fail-open-to-text is intended F6/§10 for v1
+display cards (matches legacy); actor-hydration-after-preflight residual (a
+>120-rune hydrated name) collapses into the P1 truncation fix.
+
 ## What was done
 
 First slice of roadmap group C — two new L2a display cards migrated onto

--- a/.octospec/log.md
+++ b/.octospec/log.md
@@ -24,6 +24,15 @@ change-log convention (§7). Newest first.
   `metadata.octo` fields. `modules/notify/testmain_test.go` wires the
   Registry once for the whole test package (mirrors production wiring). See
   [journal](journal/shared/cardtmpl-l2a-migration.md).
+- **Review fix (P1, PR #649)** — Over-length display fields were flipping to a
+  400 zero-delivery under the C1 preflight where legacy truncated & delivered.
+  `mapDocsCardFieldsToDisplayJSON` now server-side truncates title/actorName/
+  excerpt/updatedAt to the schema/render caps before preflight (delivery
+  preserved); `docId` stays a hard C1 400 (deep-link key). Exported
+  `cardtmpl.MaxTitleRunes` + `cardtmpl.TruncateRunes` (single cap/impl, G9);
+  added `TestSchemaCapsMatchRenderCaps` (closes the previously-dangling G9
+  field-cap reference) + `TestMapDocsDisplayFields_TruncatesDisplayFields` +
+  `docs_shared` en test; made the docs build-error log label kind-generic.
 
 ## 2026-07-22 (incoming-webhook-quota-per-thread)
 

--- a/.octospec/log.md
+++ b/.octospec/log.md
@@ -4,6 +4,27 @@ Change history for this repo's `.octospec/`, following the
 [OKF](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md)
 change-log convention (§7). Newest first.
 
+## 2026-07-23 (cardtmpl-l2a-migration PR-1)
+
+- **Feature** — Roadmap C first slice: `docs.commented@0.1.0` and
+  `docs.shared@0.1.0` (v1 display cards) migrated onto `Registry.Render` via
+  the pilot copy-directory shape. `NotifyReq`/`DocsCardFields` external shape
+  unchanged (plan B); `deliverDocsCardNotification` routes both kinds through
+  Registry with F7 fail-close, matching `access_requested`. Both manifests
+  declare `renderProfile` + `renderProfileCompatibility` (#647).
+- **Milestone** — §2.2-5 L2b hard gate ② is now met: `docs.access-request`
+  (v2) + `docs.commented` (v1) + `docs.shared` (v1) = 3 L2a cards running
+  the full Registry path across both wire profiles.
+- **Base helpers** — `pkg/cardtmpl.SanitizeLine` is the single source of
+  truth (G5, notify + pilot become wrappers).
+  `BuildSummaryResourceCardBodyWithLang` added to scaffold PR-2.
+- **Test** — `card_via_registry_display_baseline_test.go` runs 4 fixtures
+  through legacy `buildDocsCard` vs `buildDocsDisplayCardViaRegistry` and
+  asserts canonical byte-equality after stripping the two injected
+  `metadata.octo` fields. `modules/notify/testmain_test.go` wires the
+  Registry once for the whole test package (mirrors production wiring). See
+  [journal](journal/shared/cardtmpl-l2a-migration.md).
+
 ## 2026-07-22 (incoming-webhook-quota-per-thread)
 
 - **Behavior change** — Incoming Webhook creation quota re-scoped from

--- a/.octospec/tasks/cardtmpl-l2a-migration/brief.md
+++ b/.octospec/tasks/cardtmpl-l2a-migration/brief.md
@@ -1,0 +1,133 @@
+---
+type: Task
+title: "Task: cardtmpl-l2a-migration"
+description: Migrate the remaining L2a notification cards (docs.shared/commented, summary.completed/failed) onto the cardtmpl Registry using the docs.access-request copy-directory shape, clearing the legacy builders and reaching the ≥3-card L2b gate with both v1/v2 view modes covered.
+tags: ["wire-contract", "i18n", "error-response", "escape", "markdown", "url-destination", "trust-boundary", "testing", "commit"]
+timestamp: 2026-07-23T09:30:00+08:00
+# --- octospec extension fields ---
+slug: cardtmpl-l2a-migration
+upstream: self (roadmap C)
+source: self
+---
+
+# Task: cardtmpl-l2a-migration
+
+> Roadmap group C. Migrate the remaining L2a notification cards onto the
+> cardtmpl Registry, copying the `docs.access-request` pilot directory shape.
+> Prior art: `.octospec/tasks/cardtmpl-registry-pilot/brief.md` (#633),
+> `.octospec/tasks/cardtmpl-interaction-closure/brief.md` (#641),
+> #647 (renderProfile). Authoritative contract: `docs/platform-card-base.md`.
+
+## Goal
+
+Move the notification cards still built by legacy builders — **docs.shared,
+docs.commented, summary.completed, summary.failed** (all `octo/v1` display
+cards) — onto the cardtmpl Registry, each as a `pkg/cardtmpl/<card>/` subpackage
+with its own embedded `handoff/<id>@<ver>/` and a 3-method Template, exactly like
+the `docs.access-request` pilot.
+
+Two payoffs:
+1. **Clear the legacy builders**: the corresponding variants in
+   `pkg/cardtmpl/{resource,...}.go` and the deliver branches in
+   `modules/notify/card.go` route through the single `Registry.Render` entry.
+2. **Reach the L2b hard gate** (§2.2-5 gate ②): together with the already-migrated
+   `docs.access-request` (v2 interactive), ≥3 L2a cards run the full Registry
+   path covering **both** view modes — v1 display (these new cards) and v2
+   interactive (docs.access-request).
+
+The external `NotifyReq` shape does not change (plan-B shell unchanged; only the
+internal `deliver*` path moves to Registry).
+
+## Background
+
+- The pilot (#633) established the shape: each card lives in
+  `pkg/cardtmpl/<card>/` with its own `handoff/<id>@<ver>/`
+  (manifest / contract / samples / reports) + Template impl; new cards copy it.
+- #647 introduced **renderProfile / renderProfileCompatibility** (dual profile:
+  `profile` = message capability, `render_profile` = which HostConfig/CSS
+  generation the web should use). **Every new card's manifest must declare
+  `renderProfile` (exact Forge artifact) + `renderProfileCompatibility` (stable
+  key, e.g. `octo-chat/v1`)**, or it emits no `render_profile` and renders as
+  Legacy forever (contract §3; register-time `cardmsg.IsAcceptedRenderProfile`).
+- Current state: `docs.access-request` is migrated (v2). `docs.shared/commented`
+  and `summary.completed/failed` are still legacy (variants in
+  `modules/notify/card.go` + `pkg/cardtmpl/resource.go`).
+- **`generic.approval`** (`pkg/cardtmpl/approval_request.go`) takes a **dynamic
+  `owner`/`action_type`** from the caller, which conflicts with the Registry's
+  **static `TemplateActionContract`** model → see Out of scope; not migrated
+  here.
+
+## Load-bearing list
+
+- **L1 directory shape & freeze (`wire-contract`)**: new cards self-embed
+  `pkg/cardtmpl/<card>/handoff/<id>@<ver>/`; a published version is frozen
+  (§2.1). The published `docs.access-request@0.2.0/0.3.0` trees are not touched.
+- **#647 renderProfile declaration (`wire-contract`)**: each new manifest
+  declares `renderProfile` + `renderProfileCompatibility`; register-time
+  `IsAcceptedRenderProfile` validates (illegal value panics); the send/update
+  envelope emits `render_profile` accordingly.
+- **notify deliver branches (`wire-contract`)**: `modules/notify/card.go`
+  currently routes `access_requested` through the Registry and the rest through
+  legacy. Move the `docs.shared/commented` + `summary.*` branches to
+  `Registry.Render`; the `NotifyReq` / internal notify token shell is unchanged.
+- **C1 zero-delivery (`error-response`)**: schema-level field errors on the
+  migrated cards → HTTP 400 zero-delivery (`ErrFieldsInvalid`), no fabricated
+  fallback text; preflight moved ahead of member/gate checks (as the pilot F1).
+- **Byte-equivalence baseline (`wire-contract`)**: canonical JSON diff before/after
+  migration may differ ONLY in `metadata.octo.{protocol,template}` +
+  `render_profile` + `Action.OpenUrl.id` (as pilot A11/F4).
+- **Render safety (`escape`, `markdown`, `url-destination`)**: caller-controlled
+  text goes through `escapeMarkdown`; all URLs absolute https; enforced by L0
+  `Registry.Render`, not relaxed.
+- **Fallback text**: each new Template's `FallbackText` is the L0 authoritative
+  fallback; the master-switch / gate / render-failure degrade paths are unchanged.
+- **i18n (`i18n`)**: labels from `BuildEnv.Lang`; reuse the pilot Source
+  localization. **G5**: `sanitizeLine` currently duplicated (notify + pilot) —
+  extract a shared helper this round (≥3 cards amplify the duplication).
+- **Field-cap single source**: **G9** — finalizer/mapping-layer rune caps are
+  double-written against each card's schema `maxLength`; unify this round
+  (schema is the source of truth, truncate before render).
+- **trust-boundary**: caller-supplied business fields on summary/docs cards go
+  through the schema allowlist + escaping, never trusted as card JSON.
+- **Conformance / tests (`testing`)**: each new card passes register-time
+  self-check + the shared conformance suite (interaction-contract equality;
+  v1 cards have no interaction report).
+- **Git/PR (`commit`)**: English Conventional Commit + English PR + link this brief.
+
+## Out of scope
+
+- **`generic.approval` is NOT migrated**: its dynamic caller-supplied
+  `owner`/`action_type` conflicts with the static `TemplateActionContract`;
+  needs a separate decision (fixed-owner template vs retained dynamic special
+  case) before it can move to the Registry.
+- No change to the migrated `docs.access-request` or its frozen versions.
+- No `NotifyReq` external-shape change / no envelope mode (E2).
+- No `${}` JSON template engine (E1).
+- No capability-discovery endpoint (B), L2b channel (D), or unfurl (H).
+- No DB migration.
+- No new kill switch (rely on register-time fail-close + existing card master switch).
+
+## Acceptance
+
+- `docs.shared`, `docs.commented`, `summary.completed`, `summary.failed` each
+  have a `pkg/cardtmpl/<card>/` subpackage + `handoff/<id>@<ver>/`
+  (manifest / contract / samples [/ reports]), a 3-method Template, and are
+  registered + frozen at the composition root.
+- Each new manifest declares `renderProfile` + `renderProfileCompatibility` and
+  passes register-time self-check.
+- Together with `docs.access-request`, the Registry has **≥3 L2a cards** covering
+  **both** v1 (the new display cards) and v2 (docs.access-request) → satisfies
+  §2.2-5 gate ②.
+- The matching `modules/notify/card.go` deliver branches route through
+  `Registry.Render`; the corresponding legacy builder variants become
+  fallback-only or are removed as dead code.
+- Each card's canonical JSON is byte-equivalent before/after (only
+  `metadata.octo` + `render_profile` + `OpenUrl.id` diff allowed).
+- C1: a schema field error on a migrated card returns 400 zero-delivery (asserted).
+- G5: a single shared `sanitizeLine` helper (notify + cardtmpl reuse one copy).
+- G9: field caps have a single source of truth aligned to each card's schema
+  `maxLength` (test asserts no double-write drift).
+- Green: focused `go test` (`pkg/cardtmpl/...` + `modules/notify`),
+  `go test -race -cover` (new card packages ≥80%), `go vet ./...`,
+  `golangci-lint run ./...`, `make i18n-extract-check` + `make i18n-lint`,
+  the conformance suite; `go test ./...` when MySQL/Redis/WuKongIM are available.

--- a/.octospec/tasks/cardtmpl-l2a-migration/context.yaml
+++ b/.octospec/tasks/cardtmpl-l2a-migration/context.yaml
@@ -1,0 +1,18 @@
+injected:
+  - id: error-handling
+    source: repo
+  - id: trust-boundary
+    source: repo
+  - id: space-isolation
+    source: repo
+  - id: testing
+    source: repo
+  - id: commit-style
+    source: repo
+brief: .octospec/tasks/cardtmpl-l2a-migration/brief.md
+notes: |
+  rate-limit (paths modules/**/*.go matched notify/card.go) reviewed but NOT
+  applicable — this migration changes no request-frequency limiting.
+  First increment: docs.commented打样 (pkg/cardtmpl/docs_commented +
+  handoff/docs.commented@0.1.0 + notify branch -> Registry.Render). Then
+  batch docs.shared / summary.completed / summary.failed.

--- a/main.go
+++ b/main.go
@@ -34,6 +34,8 @@ import (
 	"github.com/Mininglamp-OSS/octo-server/pkg/cardmsg"
 	"github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl"
 	docsaccessrequest "github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl/docs_access_request"
+	docscommented "github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl/docs_commented"
+	docsshared "github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl/docs_shared"
 	octodb "github.com/Mininglamp-OSS/octo-server/pkg/db"
 	octoi18n "github.com/Mininglamp-OSS/octo-server/pkg/i18n"
 	"github.com/Mininglamp-OSS/octo-server/pkg/metrics"
@@ -712,6 +714,12 @@ func installCardTmplRegistry() {
 	registry.Register(docsaccessrequest.New(), docsaccessrequest.Assets, docsaccessrequest.HandoffRoot)
 	registry.Register(docsaccessrequest.NewV3(), docsaccessrequest.Assets, docsaccessrequest.HandoffRootV3)
 	registry.SetDefault(docsaccessrequest.TemplateID, docsaccessrequest.TemplateVersionV3)
+	// roadmap C:纯展示 v1 卡 —— docs.commented / docs.shared 迁入 Registry。
+	// 每张卡自持 handoff embed;register-time sample self-check 与 fail-close 沿用。
+	registry.Register(docscommented.New(), docscommented.Assets, docscommented.HandoffRoot)
+	registry.SetDefault(docscommented.TemplateID, docscommented.TemplateVersion)
+	registry.Register(docsshared.New(), docsshared.Assets, docsshared.HandoffRoot)
+	registry.SetDefault(docsshared.TemplateID, docsshared.TemplateVersion)
 	registry.Freeze()
 	cardtmpl.SetGlobalMetrics(cardtmpl.NewMetrics(prometheus.DefaultRegisterer))
 	cardtmpl.SetDefaultRegistry(registry)

--- a/modules/notify/card.go
+++ b/modules/notify/card.go
@@ -409,13 +409,15 @@ func (n *Notify) deliverDocsCardNotification(req *NotifyReq) (*NotifyResp, error
 			// - other build errors (render failure / marshal / dependency) →
 			//   degrade to plain-text so the notification still lands.
 			if errors.Is(buildErr, cardtmpl.ErrFieldsInvalid) {
-				n.Warn("docs access-request card rejected: fields did not pass schema (400)",
-					zap.Error(buildErr), zap.String("space_id", req.SpaceID), zap.String("doc_id", card.DocID))
+				n.Warn("docs card rejected: fields did not pass schema (400)",
+					zap.Error(buildErr), zap.String("space_id", req.SpaceID), zap.String("doc_id", card.DocID),
+					zap.String("kind", card.Kind))
 				return nil, errNotifyCardInvalid
 			}
 			if errors.Is(buildErr, errCardTmplUnavailable) {
-				n.Error("docs access-request card: cardtmpl unavailable (composition bug, 500)",
-					zap.Error(buildErr), zap.String("space_id", req.SpaceID), zap.String("doc_id", card.DocID))
+				n.Error("docs card: cardtmpl unavailable (composition bug, 500)",
+					zap.Error(buildErr), zap.String("space_id", req.SpaceID), zap.String("doc_id", card.DocID),
+					zap.String("kind", card.Kind))
 				return nil, buildErr // 不 wrap 为 errNotifyCardInvalid,api.go 兜底走 500
 			}
 			n.Warn("build docs card failed, degrading to text",

--- a/modules/notify/card.go
+++ b/modules/notify/card.go
@@ -8,13 +8,14 @@ import (
 	"os"
 	"strconv"
 	"strings"
-	"unicode"
 
 	"github.com/Mininglamp-OSS/octo-lib/common"
 	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-server/internal/carddispatch"
 	"github.com/Mininglamp-OSS/octo-server/pkg/cardmsg"
 	"github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl"
+	docscommented "github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl/docs_commented"
+	docsshared "github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl/docs_shared"
 	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
 	"go.uber.org/zap"
 )
@@ -212,19 +213,11 @@ func (n *Notify) sendSummaryText(uid, spaceID, text string) error {
 	))
 }
 
-// sanitizeLine collapses any control character (newline, CR, tab, …) in a
-// caller-supplied string to a single space and trims the result. The plain-text
-// fallback DM is line-structured, so an embedded "\n" in a caller field (title,
-// excerpt, actor name) could otherwise inject a spoofed attribution/label line.
-// Card rendering has its own defence (escapeMarkdown); this is the text-path
-// equivalent. It is a strict superset of strings.TrimSpace for our inputs.
+// sanitizeLine 委托 pkg/cardtmpl.SanitizeLine —— 与 L2a Template FallbackText
+// 共用单一实现,消除词表漂移(G5, roadmap C)。保留本包 wrapper 避免大范围改
+// 调用点。
 func sanitizeLine(s string) string {
-	return strings.TrimSpace(strings.Map(func(r rune) rune {
-		if unicode.IsControl(r) {
-			return ' '
-		}
-		return r
-	}, s))
+	return cardtmpl.SanitizeLine(s)
 }
 
 // buildSummaryFallbackText composes the plain-text DM used when a card cannot be
@@ -322,6 +315,28 @@ func (n *Notify) deliverDocsCardNotification(req *NotifyReq) (*NotifyResp, error
 			return nil, errNotifyCardInvalid
 		}
 	}
+	// roadmap C:commented/shared 迁到 Registry 后同享 C1 preflight,避免 memberCache/
+	// docsSender/gate 之后才发现 schema 错(空 members 会 200 delivered=[] 掩盖违规)。
+	if card.Kind == DocsCardKindCommented || card.Kind == DocsCardKindShared {
+		var tid cardtmpl.ID
+		if card.Kind == DocsCardKindCommented {
+			tid = docscommented.TemplateID
+		} else {
+			tid = docsshared.TemplateID
+		}
+		if err := preflightDocsDisplaySchema(card, tid); err != nil {
+			if errors.Is(err, errCardTmplUnavailable) {
+				n.Error("docs display card preflight: cardtmpl unavailable (composition bug, 500)",
+					zap.Error(err), zap.String("space_id", req.SpaceID), zap.String("doc_id", card.DocID),
+					zap.String("kind", card.Kind))
+				return nil, err
+			}
+			n.Warn("docs display card rejected at preflight: schema (400)",
+				zap.Error(err), zap.String("space_id", req.SpaceID), zap.String("doc_id", card.DocID),
+				zap.String("kind", card.Kind))
+			return nil, errNotifyCardInvalid
+		}
+	}
 
 	targets := dedupTargets(req.Targets)
 	if req.ActorUID != "" {
@@ -367,6 +382,19 @@ func (n *Notify) deliverDocsCardNotification(req *NotifyReq) (*NotifyResp, error
 			// F7: 唯一入口。Registry 未注入 = composition bug,不再 fallback 到 legacy
 			// (那样会遮蔽 wiring 漏洞);buildErr non-nil 分类走 render_error 降级文本。
 			doc, renderProfile, buildErr = n.buildDocsAccessRequestCardViaRegistry(context.Background(), req.SpaceID, card, lang)
+		} else if card.Kind == DocsCardKindCommented {
+			// roadmap C:docs.commented@0.1.0 走 Registry.Render(v1 展示卡)。
+			// 与 access_requested 同 policy —— preflight 早跑 C1、Registry 未注入
+			// 直接 500 不降级(F7)。字节等价 legacy buildDocsCard 由 body 共享
+			// assembleResourceCardBody 保证。
+			doc, renderProfile, buildErr = n.buildDocsDisplayCardViaRegistry(
+				context.Background(), req.SpaceID, card, lang,
+				docscommented.TemplateID, docscommented.StateShown)
+		} else if card.Kind == DocsCardKindShared {
+			// roadmap C:docs.shared@0.1.0 走 Registry.Render(与 commented 对称)。
+			doc, renderProfile, buildErr = n.buildDocsDisplayCardViaRegistry(
+				context.Background(), req.SpaceID, card, lang,
+				docsshared.TemplateID, docsshared.StateShown)
 		} else {
 			doc, buildErr = n.buildDocsCard(context.Background(), req.SpaceID, card, lang)
 		}

--- a/modules/notify/card_via_registry.go
+++ b/modules/notify/card_via_registry.go
@@ -133,20 +133,39 @@ func (n *Notify) buildDocsAccessRequestCardViaRegistry(
 	return cardDoc, renderProfile, nil
 }
 
+// docsActorNameMaxRunes / docsUpdatedAtMaxRunes mirror the docs.commented /
+// docs.shared data.schema.json maxLength for these display fields.
+// mapDocsCardFieldsToDisplayJSON truncates to them (title/excerpt reuse the
+// exported cardtmpl caps) so an over-length display string renders truncated
+// rather than flipping to a C1 400 (P1, PR #649 review). The schema maxLength is
+// the backstop — TestSchemaCapsMatchRenderCaps (docs_commented/docs_shared)
+// asserts no drift, and TestMapDocsDisplayFields_TruncatesDisplayFields locks
+// that truncation leaves the field within schema.
+const (
+	docsActorNameMaxRunes = 120
+	docsUpdatedAtMaxRunes = 80
+)
+
 // mapDocsCardFieldsToDisplayJSON 把扁平 DocsCardFields 映射成 docs.commented /
 // docs.shared 契约期望的 JSON 形状(与 pilot mapDocsCardFieldsToJSON 同思路,
 // 只是纯展示卡的字段集更小 —— 无 requestId/permission/头像/申请理由)。字节
 // 等价基线依赖此映射与 legacy buildDocsCard 提取自同一 DocsCardFields。
+//
+// P1 (PR #649 review):展示字段服务端截断到 schema maxLength / 渲染预算。legacy
+// buildDocsCard 从不按长度拒 —— 超长 excerpt 在 render 时 truncateRunes 截断后照常
+// 投递。走 C1 preflight 后,超长字段本会翻成 400 零投递(连 text 兜底都不触发)。
+// 这里截断保住"通知永不丢"不变量,同时对 docId(deep-link key,绝不能静默截断)
+// 保留 C1 硬 400 —— 与 summary 侧 taskNo 同处置(见 mapSummaryCardFieldsToJSON)。
 func mapDocsCardFieldsToDisplayJSON(card *DocsCardFields) (json.RawMessage, error) {
 	if card == nil {
 		return nil, errors.New("mapDocsCardFieldsToDisplayJSON: nil card")
 	}
 	m := map[string]any{
-		"docId":     strings.TrimSpace(card.DocID),
-		"title":     strings.TrimSpace(card.Title),
-		"actorName": strings.TrimSpace(card.ActorName),
-		"excerpt":   strings.TrimSpace(card.Excerpt),
-		"updatedAt": strings.TrimSpace(card.UpdatedAt),
+		"docId":     strings.TrimSpace(card.DocID), // deep-link key:不截断(超长 → C1 400)
+		"title":     cardtmpl.TruncateRunes(strings.TrimSpace(card.Title), cardtmpl.MaxTitleRunes),
+		"actorName": cardtmpl.TruncateRunes(strings.TrimSpace(card.ActorName), docsActorNameMaxRunes),
+		"excerpt":   cardtmpl.TruncateRunes(strings.TrimSpace(card.Excerpt), cardtmpl.MaxExcerptRunes),
+		"updatedAt": cardtmpl.TruncateRunes(strings.TrimSpace(card.UpdatedAt), docsUpdatedAtMaxRunes),
 	}
 	raw, err := json.Marshal(m)
 	if err != nil {

--- a/modules/notify/card_via_registry.go
+++ b/modules/notify/card_via_registry.go
@@ -133,6 +133,84 @@ func (n *Notify) buildDocsAccessRequestCardViaRegistry(
 	return cardDoc, renderProfile, nil
 }
 
+// mapDocsCardFieldsToDisplayJSON 把扁平 DocsCardFields 映射成 docs.commented /
+// docs.shared 契约期望的 JSON 形状(与 pilot mapDocsCardFieldsToJSON 同思路,
+// 只是纯展示卡的字段集更小 —— 无 requestId/permission/头像/申请理由)。字节
+// 等价基线依赖此映射与 legacy buildDocsCard 提取自同一 DocsCardFields。
+func mapDocsCardFieldsToDisplayJSON(card *DocsCardFields) (json.RawMessage, error) {
+	if card == nil {
+		return nil, errors.New("mapDocsCardFieldsToDisplayJSON: nil card")
+	}
+	m := map[string]any{
+		"docId":     strings.TrimSpace(card.DocID),
+		"title":     strings.TrimSpace(card.Title),
+		"actorName": strings.TrimSpace(card.ActorName),
+		"excerpt":   strings.TrimSpace(card.Excerpt),
+		"updatedAt": strings.TrimSpace(card.UpdatedAt),
+	}
+	raw, err := json.Marshal(m)
+	if err != nil {
+		return nil, fmt.Errorf("marshal mapped display fields: %w", err)
+	}
+	return json.RawMessage(raw), nil
+}
+
+// buildDocsDisplayCardViaRegistry 通过 Registry.Render 生成 docs.commented /
+// docs.shared 展示卡(v1)。错误分类与 buildDocsAccessRequestCardViaRegistry 对齐:
+//   - Registry 未注入 → errCardTmplUnavailable(caller 翻 500,不降级);
+//   - schema 校验失败 → cardtmpl.ErrFieldsInvalid(caller 翻 400 零投递,C1);
+//   - 其他 render 级错 → non-typed,caller 走 render_error 降级文本。
+func (n *Notify) buildDocsDisplayCardViaRegistry(
+	ctx context.Context, spaceID string, card *DocsCardFields, lang string,
+	templateID cardtmpl.ID, state cardtmpl.State,
+) (json.RawMessage, string, error) {
+	registry := cardtmpl.DefaultRegistry()
+	if registry == nil {
+		return nil, "", fmt.Errorf("%w: default registry not wired", errCardTmplUnavailable)
+	}
+	fields, err := mapDocsCardFieldsToDisplayJSON(card)
+	if err != nil {
+		return nil, "", fmt.Errorf("notify: map DocsCardFields to display schema JSON: %w", err)
+	}
+	env := cardtmpl.BuildEnv{
+		WebLoginURL: n.ctx.GetConfig().External.WebLoginURL,
+		Lang:        lang,
+		SpaceID:     spaceID,
+	}
+	cardDoc, _, renderProfile, err := registry.RenderCardWithProfiles(ctx, templateID, "", state, fields, env)
+	if err != nil {
+		return nil, "", err
+	}
+	return cardDoc, renderProfile, nil
+}
+
+// preflightDocsDisplaySchema 与 preflightDocsAccessRequestSchema 同思路:在
+// memberCache/docsSender/gate 之前独立跑一次 InputSchema 校验(C1 不被绕过)。
+// docs.commented / docs.shared 无用户可控 URL 字段,不需要 avatar https 前置校验。
+func preflightDocsDisplaySchema(card *DocsCardFields, templateID cardtmpl.ID) error {
+	registry := cardtmpl.DefaultRegistry()
+	if registry == nil {
+		return fmt.Errorf("%w: default registry not wired", errCardTmplUnavailable)
+	}
+	tmpl, err := registry.Lookup(templateID, "")
+	if err != nil {
+		return fmt.Errorf("%w: lookup %s: %v", errCardTmplUnavailable, templateID, err)
+	}
+	fields, err := mapDocsCardFieldsToDisplayJSON(card)
+	if err != nil {
+		return fmt.Errorf("%w: map: %v", cardtmpl.ErrFieldsInvalid, err)
+	}
+	var parsed any
+	if err := json.Unmarshal(fields, &parsed); err != nil {
+		return fmt.Errorf("%w: %v", cardtmpl.ErrFieldsInvalid, err)
+	}
+	if err := tmpl.Meta().InputSchema.Validate(parsed); err != nil {
+		cardtmpl.RecordFieldsInvalid(templateID, tmpl.Meta().Version)
+		return fmt.Errorf("%w: %v", cardtmpl.ErrFieldsInvalid, err)
+	}
+	return nil
+}
+
 // mapDocsCardFieldsToJSON 把扁平 DocsCardFields 映射成 pilot data.schema.json 期望的
 // 嵌套 JSON 形状。服务端字典字段(permission/document.sourceName/requestedAtDisplay/
 // messageTimeDisplay)按当前收件人语言从本地化词表补齐;不接受调用方传入。

--- a/modules/notify/card_via_registry_display_baseline_test.go
+++ b/modules/notify/card_via_registry_display_baseline_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl"
@@ -11,11 +12,64 @@ import (
 	docsshared "github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl/docs_shared"
 )
 
-// TestBuildDocsDisplayCards_MigrationBaseline 是 roadmap C 的字节等价基线:
-// 对 docs.commented / docs.shared 两张 v1 展示卡,断言 legacy buildDocsCard 与
-// Registry.Render 出的 card 节点在删除 metadata.octo.{protocol,template} 之后
-// canonical JSON 字节完全相等 —— body / facts / actions / attribution / variant /
-// source / webUrl 均一致。任何漂移(词表 / 排序 / 别名 / 结构)都会失败。
+// TestMapDocsDisplayFields_TruncatesDisplayFields 断言 P1(PR #649 review):超长
+// 展示字段(title/actorName/excerpt/updatedAt)被服务端截断到 schema cap 后仍能
+// 投递(preflight 通过 + build 成功,不再翻 400 零投递);而 docId(deep-link key)
+// 超长仍是 C1 400 —— 绝不静默截断。同时锁 notify 本地 cap 与 schema maxLength 对齐:
+// 若某 cap 设大于 schema,截断后仍超 schema → preflight 会 400,本测试即失败。
+func TestMapDocsDisplayFields_TruncatesDisplayFields(t *testing.T) {
+	wk := newWuKongServer()
+	defer wk.close()
+	ctx := newTestContext(t, wk)
+	ctx.GetConfig().External.WebLoginURL = "https://im.example.com/login"
+
+	registry := cardtmpl.NewRegistry()
+	registry.Register(docscommented.New(), docscommented.Assets, docscommented.HandoffRoot)
+	registry.SetDefault(docscommented.TemplateID, docscommented.TemplateVersion)
+	registry.Register(docsshared.New(), docsshared.Assets, docsshared.HandoffRoot)
+	registry.SetDefault(docsshared.TemplateID, docsshared.TemplateVersion)
+	registry.Freeze()
+	prev := cardtmpl.DefaultRegistry()
+	cardtmpl.SetDefaultRegistry(registry)
+	defer cardtmpl.SetDefaultRegistry(prev)
+
+	n := newTestNotify(ctx, nil, nil, nil, "tk")
+
+	// 全展示字段远超 schema cap → 截断后 preflight 通过 + build 成功(投递不丢)。
+	huge := &DocsCardFields{
+		DocID:     "d_ok",
+		Kind:      DocsCardKindCommented,
+		Title:     strings.Repeat("标", 500),  // cap 200
+		ActorName: strings.Repeat("名", 400),  // cap 120
+		Excerpt:   strings.Repeat("评", 1000), // cap 300
+		UpdatedAt: strings.Repeat("时", 300),  // cap 80
+	}
+	if err := preflightDocsDisplaySchema(huge, docscommented.TemplateID); err != nil {
+		t.Fatalf("preflight should PASS after truncation, got %v", err)
+	}
+	if _, _, err := n.buildDocsDisplayCardViaRegistry(context.Background(),
+		"space-c", huge, "zh-CN", docscommented.TemplateID, docscommented.StateShown); err != nil {
+		t.Fatalf("build should SUCCEED after truncation, got %v", err)
+	}
+
+	// docId 超长(>200)→ 仍 C1 400:deep-link key 不截断。
+	badDoc := &DocsCardFields{
+		DocID: strings.Repeat("x", 300), Title: "OK", Kind: DocsCardKindShared,
+	}
+	err := preflightDocsDisplaySchema(badDoc, docsshared.TemplateID)
+	if err == nil || !errorsIsFieldsInvalid(err) {
+		t.Fatalf("over-length docId must stay C1 400, got %v", err)
+	}
+}
+
+// TestBuildDocsDisplayCards_MigrationBaseline 是 roadmap C 的**规范化 JSON 等价**
+// 基线(canonical-JSON equivalence,非字面 wire 字节):对 docs.commented /
+// docs.shared 两张 v1 展示卡,断言 legacy buildDocsCard 与 Registry.Render 出的
+// card 节点,在删除 metadata.octo.{protocol,template} 后,经 unmarshal→canonical
+// (sorted-key)→remarshal 得到的 JSON 完全相等 —— body / facts / actions /
+// attribution / variant / source / webUrl 均一致。round-trip 会归一化 key 序 /
+// 空白 / 转义形态,所以它锁的是**语义/结构等价**(词表 / 排序 / 别名 / 结构漂移
+// 都会失败),不是逐字节一致(P2, PR #649 review:命名别 over-claim 成 byte-equal)。
 //
 // 与 A11 (access_requested) 的两处不同:
 //   - v1 展示卡没有 view_document action id (只有 access-request 交互契约要求),

--- a/modules/notify/card_via_registry_display_baseline_test.go
+++ b/modules/notify/card_via_registry_display_baseline_test.go
@@ -1,0 +1,193 @@
+package notify
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl"
+	docscommented "github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl/docs_commented"
+	docsshared "github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl/docs_shared"
+)
+
+// TestBuildDocsDisplayCards_MigrationBaseline 是 roadmap C 的字节等价基线:
+// 对 docs.commented / docs.shared 两张 v1 展示卡,断言 legacy buildDocsCard 与
+// Registry.Render 出的 card 节点在删除 metadata.octo.{protocol,template} 之后
+// canonical JSON 字节完全相等 —— body / facts / actions / attribution / variant /
+// source / webUrl 均一致。任何漂移(词表 / 排序 / 别名 / 结构)都会失败。
+//
+// 与 A11 (access_requested) 的两处不同:
+//   - v1 展示卡没有 view_document action id (只有 access-request 交互契约要求),
+//     所以只需要 strip metadata.octo.{protocol,template};
+//   - 每张卡独立跑 —— 两卡的 variant 不同,不共用 fixture。
+func TestBuildDocsDisplayCards_MigrationBaseline(t *testing.T) {
+	wk := newWuKongServer()
+	defer wk.close()
+	ctx := newTestContext(t, wk)
+	ctx.GetConfig().External.WebLoginURL = "https://im.example.com/login"
+
+	registry := cardtmpl.NewRegistry()
+	registry.Register(docscommented.New(), docscommented.Assets, docscommented.HandoffRoot)
+	registry.SetDefault(docscommented.TemplateID, docscommented.TemplateVersion)
+	registry.Register(docsshared.New(), docsshared.Assets, docsshared.HandoffRoot)
+	registry.SetDefault(docsshared.TemplateID, docsshared.TemplateVersion)
+	registry.Freeze()
+	prev := cardtmpl.DefaultRegistry()
+	cardtmpl.SetDefaultRegistry(registry)
+	defer cardtmpl.SetDefaultRegistry(prev)
+
+	n := newTestNotify(ctx, nil, nil, nil, "tk")
+
+	cases := []struct {
+		name       string
+		card       *DocsCardFields
+		templateID cardtmpl.ID
+		state      cardtmpl.State
+	}{
+		{
+			name: "commented_zh_full",
+			card: &DocsCardFields{
+				DocID: "d_2026-q3-okr", Title: "2026 Q3 OKR", Kind: DocsCardKindCommented,
+				ActorName: "张三", Excerpt: "我在 KR3 段落补了数据。", UpdatedAt: "2026-07-16 11:00",
+			},
+			templateID: docscommented.TemplateID, state: docscommented.StateShown,
+		},
+		{
+			name: "commented_zh_anon_no_ts",
+			card: &DocsCardFields{
+				DocID: "d_2026-q3-okr", Title: "2026 Q3 OKR", Kind: DocsCardKindCommented,
+				ActorName: "", Excerpt: "匿名评论。", UpdatedAt: "",
+			},
+			templateID: docscommented.TemplateID, state: docscommented.StateShown,
+		},
+		{
+			name: "shared_zh_full",
+			card: &DocsCardFields{
+				DocID: "d_2026-q3-okr", Title: "2026 Q3 OKR", Kind: DocsCardKindShared,
+				ActorName: "李四", Excerpt: "先分享一版。", UpdatedAt: "2026-07-16 10:30",
+			},
+			templateID: docsshared.TemplateID, state: docsshared.StateShown,
+		},
+		{
+			name: "shared_zh_anon_no_excerpt",
+			card: &DocsCardFields{
+				DocID: "d_2026-q3-okr", Title: "2026 Q3 OKR", Kind: DocsCardKindShared,
+				ActorName: "", Excerpt: "", UpdatedAt: "2026-07-16 10:30",
+			},
+			templateID: docsshared.TemplateID, state: docsshared.StateShown,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			legacyRaw, err := n.buildDocsCard(context.Background(), "space-c", tc.card, "zh-CN")
+			if err != nil {
+				t.Fatalf("legacy build: %v", err)
+			}
+			var legacy map[string]any
+			if err := json.Unmarshal(legacyRaw, &legacy); err != nil {
+				t.Fatalf("unmarshal legacy: %v", err)
+			}
+
+			newRaw, _, err := n.buildDocsDisplayCardViaRegistry(context.Background(),
+				"space-c", tc.card, "zh-CN", tc.templateID, tc.state)
+			if err != nil {
+				t.Fatalf("new build: %v", err)
+			}
+			var newer map[string]any
+			if err := json.Unmarshal(newRaw, &newer); err != nil {
+				t.Fatalf("unmarshal new: %v", err)
+			}
+
+			stripped := stripOctoNewFields(newer)
+			legacyCanon := canonicalJSON(t, legacy)
+			newCanon := canonicalJSON(t, stripped)
+			if !bytes.Equal(legacyCanon, newCanon) {
+				t.Fatalf("baseline drift for %s.\n--- legacy ---\n%s\n--- new (stripped) ---\n%s",
+					tc.name, legacyCanon, newCanon)
+			}
+		})
+	}
+}
+
+// TestBuildDocsDisplayCards_MetadataOctoInjected 断言迁移后 Registry.Render 的
+// card 节点确实带上了 §5 强制注入的 metadata.octo.{protocol,template},与基线
+// stripped 前的原始字节形成互补校验。
+func TestBuildDocsDisplayCards_MetadataOctoInjected(t *testing.T) {
+	wk := newWuKongServer()
+	defer wk.close()
+	ctx := newTestContext(t, wk)
+	ctx.GetConfig().External.WebLoginURL = "https://im.example.com/login"
+
+	registry := cardtmpl.NewRegistry()
+	registry.Register(docscommented.New(), docscommented.Assets, docscommented.HandoffRoot)
+	registry.SetDefault(docscommented.TemplateID, docscommented.TemplateVersion)
+	registry.Register(docsshared.New(), docsshared.Assets, docsshared.HandoffRoot)
+	registry.SetDefault(docsshared.TemplateID, docsshared.TemplateVersion)
+	registry.Freeze()
+	prev := cardtmpl.DefaultRegistry()
+	cardtmpl.SetDefaultRegistry(registry)
+	defer cardtmpl.SetDefaultRegistry(prev)
+
+	n := newTestNotify(ctx, nil, nil, nil, "tk")
+	specs := []struct {
+		id      cardtmpl.ID
+		version string
+		state   cardtmpl.State
+		kind    string
+	}{
+		{docscommented.TemplateID, docscommented.TemplateVersion, docscommented.StateShown, DocsCardKindCommented},
+		{docsshared.TemplateID, docsshared.TemplateVersion, docsshared.StateShown, DocsCardKindShared},
+	}
+	for _, s := range specs {
+		card := &DocsCardFields{
+			DocID: "d_1", Title: "T", Kind: s.kind, ActorName: "A", Excerpt: "E", UpdatedAt: "U",
+		}
+		newRaw, _, err := n.buildDocsDisplayCardViaRegistry(context.Background(),
+			"space-c", card, "zh-CN", s.id, s.state)
+		if err != nil {
+			t.Fatalf("%s build: %v", s.id, err)
+		}
+		var m map[string]any
+		if err := json.Unmarshal(newRaw, &m); err != nil {
+			t.Fatalf("%s unmarshal: %v", s.id, err)
+		}
+		octo := m["metadata"].(map[string]any)["octo"].(map[string]any)
+		if octo["protocol"] != "octo-card@1.0" {
+			t.Errorf("%s protocol = %v", s.id, octo["protocol"])
+		}
+		tpl := octo["template"].(map[string]any)
+		if tpl["id"] != string(s.id) || tpl["version"] != s.version {
+			t.Errorf("%s template = %+v", s.id, tpl)
+		}
+	}
+}
+
+// TestPreflightDocsDisplaySchema_C1RejectsEmptyDocID 断言 C1 preflight 对
+// schema 违规(空 docId)返回 typed ErrFieldsInvalid,不静默降级。
+func TestPreflightDocsDisplaySchema_C1RejectsEmptyDocID(t *testing.T) {
+	registry := cardtmpl.NewRegistry()
+	registry.Register(docscommented.New(), docscommented.Assets, docscommented.HandoffRoot)
+	registry.SetDefault(docscommented.TemplateID, docscommented.TemplateVersion)
+	registry.Freeze()
+	prev := cardtmpl.DefaultRegistry()
+	cardtmpl.SetDefaultRegistry(registry)
+	defer cardtmpl.SetDefaultRegistry(prev)
+
+	// docId 空 → schema minLength=1 违规
+	card := &DocsCardFields{DocID: "", Title: "T", Kind: DocsCardKindCommented}
+	err := preflightDocsDisplaySchema(card, docscommented.TemplateID)
+	if err == nil {
+		t.Fatal("expected ErrFieldsInvalid, got nil")
+	}
+	if !errorsIsFieldsInvalid(err) {
+		t.Errorf("want ErrFieldsInvalid, got %v", err)
+	}
+}
+
+// errorsIsFieldsInvalid 匹配 pilot preflight 相同的 wrap 语义。
+func errorsIsFieldsInvalid(err error) bool {
+	return err != nil && (bytes.Contains([]byte(err.Error()), []byte("fields did not pass input schema")) ||
+		bytes.Contains([]byte(err.Error()), []byte("cardtmpl: fields did not pass input schema")))
+}

--- a/modules/notify/testmain_test.go
+++ b/modules/notify/testmain_test.go
@@ -1,0 +1,30 @@
+package notify
+
+import (
+	"os"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl"
+	docsaccessrequest "github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl/docs_access_request"
+	docscommented "github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl/docs_commented"
+	docsshared "github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl/docs_shared"
+)
+
+// TestMain 为整个 modules/notify 测试包预注册 pilot + roadmap C 新迁移的 L2a 卡,
+// 与 main.installCardTmplRegistry() 保持一致。docs.commented / docs.shared 的
+// preflight (F7:未注入 = composition bug = 500) 要求 Registry 常驻;个别测试若
+// 需空 Registry(如 TestDeliverDocsAccessRequest_UnwiredRegistryFailsClosed)会
+// 局部 SetDefaultRegistry(nil) 覆盖。
+func TestMain(m *testing.M) {
+	registry := cardtmpl.NewRegistry()
+	registry.Register(docsaccessrequest.New(), docsaccessrequest.Assets, docsaccessrequest.HandoffRoot)
+	registry.Register(docsaccessrequest.NewV3(), docsaccessrequest.Assets, docsaccessrequest.HandoffRootV3)
+	registry.SetDefault(docsaccessrequest.TemplateID, docsaccessrequest.TemplateVersionV3)
+	registry.Register(docscommented.New(), docscommented.Assets, docscommented.HandoffRoot)
+	registry.SetDefault(docscommented.TemplateID, docscommented.TemplateVersion)
+	registry.Register(docsshared.New(), docsshared.Assets, docsshared.HandoffRoot)
+	registry.SetDefault(docsshared.TemplateID, docsshared.TemplateVersion)
+	registry.Freeze()
+	cardtmpl.SetDefaultRegistry(registry)
+	os.Exit(m.Run())
+}

--- a/pkg/cardtmpl/docs_access_request/template.go
+++ b/pkg/cardtmpl/docs_access_request/template.go
@@ -15,7 +15,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
-	"unicode"
 
 	"github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl"
 )
@@ -199,13 +198,8 @@ func (t *Template) FallbackText(state cardtmpl.State, fields json.RawMessage, la
 	return b.String(), nil
 }
 
-// sanitizeLine 与 modules/notify.sanitizeLine 语义一致:控制字符 (含 \n \r \t) 替换成
-// 空格,再 TrimSpace。防止调用方在 actor/title 里嵌换行伪造多行 DM。
+// sanitizeLine 委托 pkg/cardtmpl.SanitizeLine —— 与 modules/notify 共用单一
+// 实现,消除词表漂移(G5, roadmap C)。保留本包 wrapper 避免改所有调用点。
 func sanitizeLine(s string) string {
-	return strings.TrimSpace(strings.Map(func(r rune) rune {
-		if unicode.IsControl(r) {
-			return ' '
-		}
-		return r
-	}, s))
+	return cardtmpl.SanitizeLine(s)
 }

--- a/pkg/cardtmpl/docs_commented/handoff/docs.commented@0.1.0/contract/data.schema.json
+++ b/pkg/cardtmpl/docs_commented/handoff/docs.commented@0.1.0/contract/data.schema.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "文档评论通知卡数据契约",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["docId", "title"],
+  "properties": {
+    "docId": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 200,
+      "description": "文档服务侧稳定 doc ID（用于 deep-link 拼接 /d/{docId}）"
+    },
+    "title": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 200,
+      "description": "文档标题"
+    },
+    "actorName": {
+      "type": "string",
+      "maxLength": 120,
+      "description": "评论者展示名称（可空，空时卡片走匿名兜底文案“有新评论”）"
+    },
+    "excerpt": {
+      "type": "string",
+      "maxLength": 300,
+      "description": "评论内容摘要。上限对齐 cardtmpl.MaxExcerptRunes（G9 单一真源）"
+    },
+    "updatedAt": {
+      "type": "string",
+      "maxLength": 80,
+      "description": "评论时间的展示字符串（调用方按时区预格式化，服务端不解析）"
+    }
+  }
+}

--- a/pkg/cardtmpl/docs_commented/handoff/docs.commented@0.1.0/manifest.json
+++ b/pkg/cardtmpl/docs_commented/handoff/docs.commented@0.1.0/manifest.json
@@ -1,0 +1,21 @@
+{
+  "schemaVersion": 2,
+  "id": "docs.commented",
+  "name": "文档评论通知",
+  "version": "0.1.0",
+  "contractVersion": "1.0.0",
+  "protocol": "octo-card@1.0",
+  "adaptiveCardVersion": "1.5",
+  "renderProfile": "octo-chat@1.2.0-rc.1",
+  "renderProfileCompatibility": "octo-chat/v1",
+  "defaultLocale": "zh-CN",
+  "sourceLabel": "文档",
+  "dataSchema": "contract/data.schema.json",
+  "views": {
+    "default": {
+      "wireProfile": "octo/v1",
+      "states": ["shown"],
+      "samples": ["samples/shown.json"]
+    }
+  }
+}

--- a/pkg/cardtmpl/docs_commented/handoff/docs.commented@0.1.0/samples/shown.json
+++ b/pkg/cardtmpl/docs_commented/handoff/docs.commented@0.1.0/samples/shown.json
@@ -1,0 +1,7 @@
+{
+  "docId": "d_2026-q3-okr",
+  "title": "2026 Q3 OKR",
+  "actorName": "张三",
+  "excerpt": "我在 KR3 段落补了一版数据，请审阅。",
+  "updatedAt": "2026-07-16 11:00"
+}

--- a/pkg/cardtmpl/docs_commented/template.go
+++ b/pkg/cardtmpl/docs_commented/template.go
@@ -1,0 +1,182 @@
+// Package docscommented 实现 L2a 平台通知卡 docs.commented@0.1.0。与
+// pkg/cardtmpl (L0 基座) 的分层关系见 docs/platform-card-base.md §2 —— 本包只
+// 承担 L2a 层职责(Template 接口 + FallbackText + 语言本地化),布局与 URL 白
+// 名单一律走基座 helper。
+//
+// 注册流程 (在 composition root 里):
+//
+//	registry := cardtmpl.NewRegistry()
+//	registry.Register(docscommented.New(), docscommented.Assets, docscommented.HandoffRoot)
+package docscommented
+
+import (
+	"context"
+	"embed"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl"
+)
+
+// Assets 内嵌 handoff 契约资源目录,由 Registry.Register 载入。
+//
+//go:embed all:handoff
+var Assets embed.FS
+
+const (
+	// HandoffRoot 是 Assets 里契约资源的根路径,交给 Registry.Register 使用。
+	HandoffRoot = "handoff/docs.commented@0.1.0"
+	// TemplateID 稳定 ID 常量,供 composition root 引用。
+	TemplateID cardtmpl.ID = "docs.commented"
+	// TemplateVersion 本模板当前版本。
+	TemplateVersion = "0.1.0"
+
+	// StateShown 是 v1 展示档视图 "default" 承载的唯一状态。
+	StateShown cardtmpl.State = "shown"
+
+	// Variant 是 metadata.octo.variant 值,与 modules/notify.card.go
+	// docsAttributionAndVariant 现值一致 —— 迁移前后字节等价的核心不变量。
+	Variant = "docs.commented"
+)
+
+// Template 是纯展示卡 L2a 实现。持有由 Registry 注入的 TemplateMeta。
+type Template struct {
+	meta cardtmpl.TemplateMeta
+}
+
+// New 构造一个未装配 Meta 的 Template 骨架。Registry.Register 调用 SetMeta 注入。
+func New() *Template { return &Template{} }
+
+// SetMeta 满足 cardtmpl 包内 metaSetter 契约。Registry.Register 期一次性调用。
+func (t *Template) SetMeta(m cardtmpl.TemplateMeta) { t.meta = m }
+
+// Meta 返回注册期固化静态元数据的防御性深拷贝 —— 与 pilot 保持同口径(R3-2)。
+func (t *Template) Meta() cardtmpl.TemplateMeta { return t.meta.Clone() }
+
+// fields 是 shown sample 反序列化后的数据契约。字段与
+// handoff/docs.commented@0.1.0/contract/data.schema.json 对齐。
+type fields struct {
+	DocID     string `json:"docId"`
+	Title     string `json:"title"`
+	ActorName string `json:"actorName"`
+	Excerpt   string `json:"excerpt"`
+	UpdatedAt string `json:"updatedAt"`
+}
+
+// Build 渲染纯展示卡业务片段。字节等价于 legacy modules/notify.buildDocsCard
+// 对 docs.commented 分支的输出 —— body/facts/actions 完全复用基座
+// assembleResourceCardBody(通过 BuildDocsResourceCardBodyWithLang 入口),差集
+// 仅在 metadata.octo.{protocol,template} + envelope 层的 render_profile。
+func (t *Template) Build(
+	ctx context.Context,
+	state cardtmpl.State,
+	fieldsRaw json.RawMessage,
+	env cardtmpl.BuildEnv,
+) (cardtmpl.BuildResult, error) {
+	if err := ctx.Err(); err != nil {
+		return cardtmpl.BuildResult{}, err
+	}
+	if state != StateShown {
+		return cardtmpl.BuildResult{}, fmt.Errorf("docs.commented: state %q not declared", state)
+	}
+	var f fields
+	if err := json.Unmarshal(fieldsRaw, &f); err != nil {
+		return cardtmpl.BuildResult{}, fmt.Errorf("docs.commented: unmarshal fields: %w", err)
+	}
+	labels := labelsFor(env.Lang)
+	facts := make([]cardtmpl.Fact, 0, 2)
+	if actor := strings.TrimSpace(f.ActorName); actor != "" {
+		facts = append(facts, cardtmpl.Fact{Title: labels.actor, Value: actor})
+	}
+	if ts := strings.TrimSpace(f.UpdatedAt); ts != "" {
+		facts = append(facts, cardtmpl.Fact{Title: labels.updatedAt, Value: ts})
+	}
+	attribution := attributionFor(strings.TrimSpace(f.ActorName), labels)
+	source := sourceFor(env.Lang)
+	body, deepLink, err := cardtmpl.BuildDocsResourceCardBodyWithLang(
+		env.Lang, env.WebLoginURL, f.DocID, env.SpaceID, cardtmpl.ResourceCard{
+			Title:       f.Title,
+			Attribution: attribution,
+			Excerpt:     strings.TrimSpace(f.Excerpt),
+			Facts:       facts,
+			Variant:     Variant,
+			Source:      source,
+		})
+	if err != nil {
+		return cardtmpl.BuildResult{}, err
+	}
+	return cardtmpl.BuildResult{
+		Body:     body,
+		Variant:  Variant,
+		DeepLink: deepLink,
+		Source:   &source,
+	}, nil
+}
+
+// FallbackText 与 legacy modules/notify.buildDocsFallbackText 对 commented
+// 分支的输出对齐:attribution -> title -> excerpt -> updatedAt(每行 sanitizeLine
+// 消除内部换行注入);缺项跳过。actorName 空时用匿名兜底 attribution。
+func (t *Template) FallbackText(state cardtmpl.State, fieldsRaw json.RawMessage, lang string) (string, error) {
+	if state != StateShown {
+		return "", fmt.Errorf("docs.commented: fallback for state %q not declared", state)
+	}
+	var f fields
+	if err := json.Unmarshal(fieldsRaw, &f); err != nil {
+		return "", fmt.Errorf("docs.commented: unmarshal fields: %w", err)
+	}
+	labels := labelsFor(lang)
+	attribution := attributionFor(cardtmpl.SanitizeLine(f.ActorName), labels)
+	var b strings.Builder
+	b.WriteString(attribution)
+	if title := cardtmpl.SanitizeLine(f.Title); title != "" {
+		fmt.Fprintf(&b, "\n%s%s%s", labels.title, labels.kvSep, title)
+	}
+	if excerpt := cardtmpl.SanitizeLine(f.Excerpt); excerpt != "" {
+		fmt.Fprintf(&b, "\n%s", excerpt)
+	}
+	if ts := cardtmpl.SanitizeLine(f.UpdatedAt); ts != "" {
+		fmt.Fprintf(&b, "\n%s%s%s", labels.updatedAt, labels.kvSep, ts)
+	}
+	return b.String(), nil
+}
+
+// labelSet 是本卡按语言本地化的文案集。与 modules/notify.docsLabelsFor 现值
+// 保持逐字节一致 —— 一处改词表两处都要跟(将来 G4 折叠到 i18n locale)。
+type labelSet struct {
+	banner     string // "%s 评论了文档"(actor 非空时)
+	bannerAnon string // "有新评论"(actor 空)
+	title      string // FactSet/Fallback 的键名"文档"
+	actor      string // FactSet 的键名"操作人"
+	updatedAt  string // FactSet/Fallback 的键名"时间"
+	kvSep      string // "："/": "
+}
+
+func labelsFor(lang string) labelSet {
+	if strings.EqualFold(lang, "zh-CN") || strings.HasPrefix(strings.ToLower(lang), "zh") {
+		return labelSet{
+			banner: "%s 评论了文档", bannerAnon: "有新评论",
+			title: "文档", actor: "操作人", updatedAt: "时间", kvSep: "：",
+		}
+	}
+	return labelSet{
+		banner: "%s commented on a document", bannerAnon: "A new comment on a document",
+		title: "Document", actor: "By", updatedAt: "At", kvSep: ": ",
+	}
+}
+
+func attributionFor(actor string, labels labelSet) string {
+	if actor == "" {
+		return labels.bannerAnon
+	}
+	return fmt.Sprintf(labels.banner, actor)
+}
+
+// sourceFor 返回 metadata.octo.source 的本地化默认值 —— 与 pilot / legacy
+// docsLabelsFor.sourceLabel 保持逐字节一致(F5:英文卡片不能带中文来源)。
+func sourceFor(lang string) cardtmpl.Source {
+	if strings.EqualFold(lang, "zh-CN") || strings.HasPrefix(strings.ToLower(lang), "zh") {
+		return cardtmpl.Source{Label: "文档"}
+	}
+	return cardtmpl.Source{Label: "Docs"}
+}

--- a/pkg/cardtmpl/docs_commented/template_test.go
+++ b/pkg/cardtmpl/docs_commented/template_test.go
@@ -133,6 +133,31 @@ func TestSchemaC1RejectsShortTitle(t *testing.T) {
 	}
 }
 
+// TestSchemaCapsMatchRenderCaps 锁 G9 单一真源:handoff data.schema.json 里
+// excerpt / title 的 maxLength 必须与渲染层 cardtmpl.MaxExcerptRunes /
+// MaxTitleRunes 一致。补上 yujiawei 在 #649 review 指出的"悬空引用的 G9
+// field-cap test"(resource.go assembleResourceCardBody 注释所引)。
+func TestSchemaCapsMatchRenderCaps(t *testing.T) {
+	raw, err := docscommented.Assets.ReadFile(docscommented.HandoffRoot + "/contract/data.schema.json")
+	if err != nil {
+		t.Fatalf("read schema: %v", err)
+	}
+	var schema struct {
+		Properties map[string]struct {
+			MaxLength int `json:"maxLength"`
+		} `json:"properties"`
+	}
+	if err := json.Unmarshal(raw, &schema); err != nil {
+		t.Fatalf("unmarshal schema: %v", err)
+	}
+	if got := schema.Properties["excerpt"].MaxLength; got != cardtmpl.MaxExcerptRunes {
+		t.Errorf("excerpt maxLength = %d, want cardtmpl.MaxExcerptRunes = %d", got, cardtmpl.MaxExcerptRunes)
+	}
+	if got := schema.Properties["title"].MaxLength; got != cardtmpl.MaxTitleRunes {
+		t.Errorf("title maxLength = %d, want cardtmpl.MaxTitleRunes = %d", got, cardtmpl.MaxTitleRunes)
+	}
+}
+
 func isFieldsInvalid(err error) bool {
 	return err != nil && strings.Contains(err.Error(), "fields did not pass input schema")
 }

--- a/pkg/cardtmpl/docs_commented/template_test.go
+++ b/pkg/cardtmpl/docs_commented/template_test.go
@@ -1,0 +1,138 @@
+package docscommented_test
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl"
+	docscommented "github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl/docs_commented"
+)
+
+// freshRegistry 构造一个只装 docs.commented 的 Registry — 与 pilot conformance
+// 同口径:合法 sample 过 Registry.Render 是 self-check 的核心。
+func freshRegistry(t *testing.T) *cardtmpl.Registry {
+	t.Helper()
+	r := cardtmpl.NewRegistry()
+	r.Register(docscommented.New(), docscommented.Assets, docscommented.HandoffRoot)
+	r.Freeze()
+	return r
+}
+
+func TestRegisterAndRenderSample(t *testing.T) {
+	r := freshRegistry(t)
+	sample, err := docscommented.Assets.ReadFile(docscommented.HandoffRoot + "/samples/shown.json")
+	if err != nil {
+		t.Fatalf("read sample: %v", err)
+	}
+	env := cardtmpl.BuildEnv{
+		WebLoginURL: "https://web.example.com",
+		Lang:        "zh-CN",
+		SpaceID:     "space-c-test",
+	}
+	payload, err := r.Render(context.Background(), docscommented.TemplateID,
+		docscommented.TemplateVersion, docscommented.StateShown, sample, env)
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	card, _ := payload["card"].(map[string]any)
+	if card == nil {
+		t.Fatalf("card node missing: %+v", payload)
+	}
+	meta, _ := card["metadata"].(map[string]any)
+	octo, _ := meta["octo"].(map[string]any)
+	if octo["protocol"] != "octo-card@1.0" {
+		t.Errorf("metadata.octo.protocol = %v", octo["protocol"])
+	}
+	tpl, _ := octo["template"].(map[string]any)
+	if tpl["id"] != string(docscommented.TemplateID) || tpl["version"] != docscommented.TemplateVersion {
+		t.Errorf("metadata.octo.template = %+v", tpl)
+	}
+	if octo["variant"] != docscommented.Variant {
+		t.Errorf("metadata.octo.variant = %v want %v", octo["variant"], docscommented.Variant)
+	}
+	src, _ := octo["source"].(map[string]any)
+	if src["label"] != "文档" {
+		t.Errorf("zh source.label = %v", src["label"])
+	}
+	if webURL, _ := meta["webUrl"].(string); !strings.HasPrefix(webURL, "https://web.example.com/d/d_2026-q3-okr") {
+		t.Errorf("metadata.webUrl = %v", webURL)
+	}
+	if payload["profile"] != "octo/v1" {
+		t.Errorf("wire profile = %v want octo/v1", payload["profile"])
+	}
+}
+
+func TestRenderEnglishSourceLocalized(t *testing.T) {
+	r := freshRegistry(t)
+	sample, _ := docscommented.Assets.ReadFile(docscommented.HandoffRoot + "/samples/shown.json")
+	env := cardtmpl.BuildEnv{
+		WebLoginURL: "https://web.example.com",
+		Lang:        "en",
+		SpaceID:     "space",
+	}
+	payload, err := r.Render(context.Background(), docscommented.TemplateID,
+		docscommented.TemplateVersion, docscommented.StateShown, sample, env)
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	card := payload["card"].(map[string]any)
+	octo := card["metadata"].(map[string]any)["octo"].(map[string]any)
+	src := octo["source"].(map[string]any)
+	if src["label"] != "Docs" {
+		t.Errorf("en source.label = %v want Docs", src["label"])
+	}
+}
+
+func TestFallbackTextZH(t *testing.T) {
+	tmpl := docscommented.New()
+	tmpl.SetMeta(cardtmpl.TemplateMeta{})
+	sample := json.RawMessage(`{"docId":"d","title":"OKR","actorName":"张三","excerpt":"补数据","updatedAt":"2026-07-16 11:00"}`)
+	text, err := tmpl.FallbackText(docscommented.StateShown, sample, "zh-CN")
+	if err != nil {
+		t.Fatalf("FallbackText: %v", err)
+	}
+	want := "张三 评论了文档\n文档：OKR\n补数据\n时间：2026-07-16 11:00"
+	if text != want {
+		t.Errorf("fallback zh:\n got: %q\nwant: %q", text, want)
+	}
+}
+
+func TestFallbackTextAnonAndSanitize(t *testing.T) {
+	tmpl := docscommented.New()
+	tmpl.SetMeta(cardtmpl.TemplateMeta{})
+	// actorName 空 + title 里带控制字符(不应换行注入)
+	sample := json.RawMessage(`{"docId":"d","title":"OK\nR","actorName":"","excerpt":"","updatedAt":""}`)
+	text, err := tmpl.FallbackText(docscommented.StateShown, sample, "zh-CN")
+	if err != nil {
+		t.Fatalf("FallbackText: %v", err)
+	}
+	// 换行被 SanitizeLine 收敛成空格,不会出现在 title 里
+	if strings.Count(text, "\n") != 1 { // attribution + title 各占一行,共 1 个换行
+		t.Errorf("newline injection not sanitized: %q", text)
+	}
+	if !strings.HasPrefix(text, "有新评论") {
+		t.Errorf("anon banner missing: %q", text)
+	}
+}
+
+func TestSchemaC1RejectsShortTitle(t *testing.T) {
+	r := freshRegistry(t)
+	env := cardtmpl.BuildEnv{WebLoginURL: "https://x", Lang: "zh-CN", SpaceID: "s"}
+	// title 空 → schema minLength=1 违规 → ErrFieldsInvalid(C1 零投递)
+	bad := json.RawMessage(`{"docId":"d","title":""}`)
+	_, err := r.Render(context.Background(), docscommented.TemplateID, docscommented.TemplateVersion,
+		docscommented.StateShown, bad, env)
+	if err == nil {
+		t.Fatal("expected ErrFieldsInvalid, got nil")
+	}
+	// 与 pilot 同错误分类
+	if !isFieldsInvalid(err) {
+		t.Errorf("want ErrFieldsInvalid, got %v", err)
+	}
+}
+
+func isFieldsInvalid(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "fields did not pass input schema")
+}

--- a/pkg/cardtmpl/docs_shared/handoff/docs.shared@0.1.0/contract/data.schema.json
+++ b/pkg/cardtmpl/docs_shared/handoff/docs.shared@0.1.0/contract/data.schema.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "文档分享通知卡数据契约",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["docId", "title"],
+  "properties": {
+    "docId": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 200,
+      "description": "文档服务侧稳定 doc ID（用于 deep-link 拼接 /d/{docId}）"
+    },
+    "title": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 200,
+      "description": "文档标题"
+    },
+    "actorName": {
+      "type": "string",
+      "maxLength": 120,
+      "description": "分享者展示名称（可空，空时卡片走匿名兜底文案“有人分享了文档”）"
+    },
+    "excerpt": {
+      "type": "string",
+      "maxLength": 300,
+      "description": "分享附言/摘要。上限对齐 cardtmpl.MaxExcerptRunes（G9 单一真源）"
+    },
+    "updatedAt": {
+      "type": "string",
+      "maxLength": 80,
+      "description": "分享时间的展示字符串（调用方按时区预格式化，服务端不解析）"
+    }
+  }
+}

--- a/pkg/cardtmpl/docs_shared/handoff/docs.shared@0.1.0/manifest.json
+++ b/pkg/cardtmpl/docs_shared/handoff/docs.shared@0.1.0/manifest.json
@@ -1,0 +1,21 @@
+{
+  "schemaVersion": 2,
+  "id": "docs.shared",
+  "name": "文档分享通知",
+  "version": "0.1.0",
+  "contractVersion": "1.0.0",
+  "protocol": "octo-card@1.0",
+  "adaptiveCardVersion": "1.5",
+  "renderProfile": "octo-chat@1.2.0-rc.1",
+  "renderProfileCompatibility": "octo-chat/v1",
+  "defaultLocale": "zh-CN",
+  "sourceLabel": "文档",
+  "dataSchema": "contract/data.schema.json",
+  "views": {
+    "default": {
+      "wireProfile": "octo/v1",
+      "states": ["shown"],
+      "samples": ["samples/shown.json"]
+    }
+  }
+}

--- a/pkg/cardtmpl/docs_shared/handoff/docs.shared@0.1.0/samples/shown.json
+++ b/pkg/cardtmpl/docs_shared/handoff/docs.shared@0.1.0/samples/shown.json
@@ -1,0 +1,7 @@
+{
+  "docId": "d_2026-q3-okr",
+  "title": "2026 Q3 OKR",
+  "actorName": "李四",
+  "excerpt": "本周产品评审会用的目标文档，先分享一版。",
+  "updatedAt": "2026-07-16 10:30"
+}

--- a/pkg/cardtmpl/docs_shared/template.go
+++ b/pkg/cardtmpl/docs_shared/template.go
@@ -1,0 +1,146 @@
+// Package docsshared 实现 L2a 平台通知卡 docs.shared@0.1.0(v1 纯展示)。
+// 结构与 docs_commented 完全对称,只在 variant + attribution 词表上区分 —— 复用
+// 基座 assembleResourceCardBody 保证字节等价 legacy modules/notify.buildDocsCard。
+package docsshared
+
+import (
+	"context"
+	"embed"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl"
+)
+
+//go:embed all:handoff
+var Assets embed.FS
+
+const (
+	HandoffRoot                    = "handoff/docs.shared@0.1.0"
+	TemplateID     cardtmpl.ID     = "docs.shared"
+	TemplateVersion                = "0.1.0"
+	StateShown     cardtmpl.State  = "shown"
+	Variant                        = "docs.shared"
+)
+
+type Template struct{ meta cardtmpl.TemplateMeta }
+
+func New() *Template                           { return &Template{} }
+func (t *Template) SetMeta(m cardtmpl.TemplateMeta) { t.meta = m }
+func (t *Template) Meta() cardtmpl.TemplateMeta     { return t.meta.Clone() }
+
+type fields struct {
+	DocID     string `json:"docId"`
+	Title     string `json:"title"`
+	ActorName string `json:"actorName"`
+	Excerpt   string `json:"excerpt"`
+	UpdatedAt string `json:"updatedAt"`
+}
+
+func (t *Template) Build(
+	ctx context.Context,
+	state cardtmpl.State,
+	fieldsRaw json.RawMessage,
+	env cardtmpl.BuildEnv,
+) (cardtmpl.BuildResult, error) {
+	if err := ctx.Err(); err != nil {
+		return cardtmpl.BuildResult{}, err
+	}
+	if state != StateShown {
+		return cardtmpl.BuildResult{}, fmt.Errorf("docs.shared: state %q not declared", state)
+	}
+	var f fields
+	if err := json.Unmarshal(fieldsRaw, &f); err != nil {
+		return cardtmpl.BuildResult{}, fmt.Errorf("docs.shared: unmarshal fields: %w", err)
+	}
+	labels := labelsFor(env.Lang)
+	facts := make([]cardtmpl.Fact, 0, 2)
+	if actor := strings.TrimSpace(f.ActorName); actor != "" {
+		facts = append(facts, cardtmpl.Fact{Title: labels.actor, Value: actor})
+	}
+	if ts := strings.TrimSpace(f.UpdatedAt); ts != "" {
+		facts = append(facts, cardtmpl.Fact{Title: labels.updatedAt, Value: ts})
+	}
+	attribution := attributionFor(strings.TrimSpace(f.ActorName), labels)
+	source := sourceFor(env.Lang)
+	body, deepLink, err := cardtmpl.BuildDocsResourceCardBodyWithLang(
+		env.Lang, env.WebLoginURL, f.DocID, env.SpaceID, cardtmpl.ResourceCard{
+			Title:       f.Title,
+			Attribution: attribution,
+			Excerpt:     strings.TrimSpace(f.Excerpt),
+			Facts:       facts,
+			Variant:     Variant,
+			Source:      source,
+		})
+	if err != nil {
+		return cardtmpl.BuildResult{}, err
+	}
+	return cardtmpl.BuildResult{
+		Body:     body,
+		Variant:  Variant,
+		DeepLink: deepLink,
+		Source:   &source,
+	}, nil
+}
+
+func (t *Template) FallbackText(state cardtmpl.State, fieldsRaw json.RawMessage, lang string) (string, error) {
+	if state != StateShown {
+		return "", fmt.Errorf("docs.shared: fallback for state %q not declared", state)
+	}
+	var f fields
+	if err := json.Unmarshal(fieldsRaw, &f); err != nil {
+		return "", fmt.Errorf("docs.shared: unmarshal fields: %w", err)
+	}
+	labels := labelsFor(lang)
+	attribution := attributionFor(cardtmpl.SanitizeLine(f.ActorName), labels)
+	var b strings.Builder
+	b.WriteString(attribution)
+	if title := cardtmpl.SanitizeLine(f.Title); title != "" {
+		fmt.Fprintf(&b, "\n%s%s%s", labels.title, labels.kvSep, title)
+	}
+	if excerpt := cardtmpl.SanitizeLine(f.Excerpt); excerpt != "" {
+		fmt.Fprintf(&b, "\n%s", excerpt)
+	}
+	if ts := cardtmpl.SanitizeLine(f.UpdatedAt); ts != "" {
+		fmt.Fprintf(&b, "\n%s%s%s", labels.updatedAt, labels.kvSep, ts)
+	}
+	return b.String(), nil
+}
+
+// labelSet 与 modules/notify.docsLabelsFor 的 shared 分支现值逐字节一致(F5)。
+type labelSet struct {
+	banner     string
+	bannerAnon string
+	title      string
+	actor      string
+	updatedAt  string
+	kvSep      string
+}
+
+func labelsFor(lang string) labelSet {
+	if strings.EqualFold(lang, "zh-CN") || strings.HasPrefix(strings.ToLower(lang), "zh") {
+		return labelSet{
+			banner: "%s 分享了文档", bannerAnon: "有人分享了文档",
+			title: "文档", actor: "操作人", updatedAt: "时间", kvSep: "：",
+		}
+	}
+	return labelSet{
+		banner: "%s shared a document", bannerAnon: "A document was shared with you",
+		title: "Document", actor: "By", updatedAt: "At", kvSep: ": ",
+	}
+}
+
+func attributionFor(actor string, labels labelSet) string {
+	if actor == "" {
+		return labels.bannerAnon
+	}
+	return fmt.Sprintf(labels.banner, actor)
+}
+
+func sourceFor(lang string) cardtmpl.Source {
+	if strings.EqualFold(lang, "zh-CN") || strings.HasPrefix(strings.ToLower(lang), "zh") {
+		return cardtmpl.Source{Label: "文档"}
+	}
+	return cardtmpl.Source{Label: "Docs"}
+}

--- a/pkg/cardtmpl/docs_shared/template.go
+++ b/pkg/cardtmpl/docs_shared/template.go
@@ -18,15 +18,15 @@ var Assets embed.FS
 
 const (
 	HandoffRoot                    = "handoff/docs.shared@0.1.0"
-	TemplateID     cardtmpl.ID     = "docs.shared"
+	TemplateID      cardtmpl.ID    = "docs.shared"
 	TemplateVersion                = "0.1.0"
-	StateShown     cardtmpl.State  = "shown"
+	StateShown      cardtmpl.State = "shown"
 	Variant                        = "docs.shared"
 )
 
 type Template struct{ meta cardtmpl.TemplateMeta }
 
-func New() *Template                           { return &Template{} }
+func New() *Template                                { return &Template{} }
 func (t *Template) SetMeta(m cardtmpl.TemplateMeta) { t.meta = m }
 func (t *Template) Meta() cardtmpl.TemplateMeta     { return t.meta.Clone() }
 

--- a/pkg/cardtmpl/docs_shared/template_test.go
+++ b/pkg/cardtmpl/docs_shared/template_test.go
@@ -1,0 +1,83 @@
+package docsshared_test
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl"
+	docsshared "github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl/docs_shared"
+)
+
+func freshRegistry(t *testing.T) *cardtmpl.Registry {
+	t.Helper()
+	r := cardtmpl.NewRegistry()
+	r.Register(docsshared.New(), docsshared.Assets, docsshared.HandoffRoot)
+	r.Freeze()
+	return r
+}
+
+func TestRegisterAndRenderSample(t *testing.T) {
+	r := freshRegistry(t)
+	sample, err := docsshared.Assets.ReadFile(docsshared.HandoffRoot + "/samples/shown.json")
+	if err != nil {
+		t.Fatalf("read sample: %v", err)
+	}
+	env := cardtmpl.BuildEnv{WebLoginURL: "https://web.example.com", Lang: "zh-CN", SpaceID: "space"}
+	payload, err := r.Render(context.Background(), docsshared.TemplateID,
+		docsshared.TemplateVersion, docsshared.StateShown, sample, env)
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	card := payload["card"].(map[string]any)
+	octo := card["metadata"].(map[string]any)["octo"].(map[string]any)
+	if octo["variant"] != docsshared.Variant {
+		t.Errorf("variant = %v", octo["variant"])
+	}
+	tpl := octo["template"].(map[string]any)
+	if tpl["id"] != string(docsshared.TemplateID) {
+		t.Errorf("template.id = %v", tpl["id"])
+	}
+	if payload["profile"] != "octo/v1" {
+		t.Errorf("profile = %v", payload["profile"])
+	}
+}
+
+func TestFallbackTextZH(t *testing.T) {
+	tmpl := docsshared.New()
+	tmpl.SetMeta(cardtmpl.TemplateMeta{})
+	sample := json.RawMessage(`{"docId":"d","title":"OKR","actorName":"李四","excerpt":"评审用","updatedAt":"2026-07-16 10:30"}`)
+	text, err := tmpl.FallbackText(docsshared.StateShown, sample, "zh-CN")
+	if err != nil {
+		t.Fatalf("FallbackText: %v", err)
+	}
+	want := "李四 分享了文档\n文档：OKR\n评审用\n时间：2026-07-16 10:30"
+	if text != want {
+		t.Errorf("fallback zh:\n got: %q\nwant: %q", text, want)
+	}
+}
+
+func TestFallbackTextAnon(t *testing.T) {
+	tmpl := docsshared.New()
+	tmpl.SetMeta(cardtmpl.TemplateMeta{})
+	sample := json.RawMessage(`{"docId":"d","title":"OKR","actorName":"","excerpt":"","updatedAt":""}`)
+	text, err := tmpl.FallbackText(docsshared.StateShown, sample, "zh-CN")
+	if err != nil {
+		t.Fatalf("FallbackText: %v", err)
+	}
+	if !strings.HasPrefix(text, "有人分享了文档") {
+		t.Errorf("anon banner missing: %q", text)
+	}
+}
+
+func TestSchemaC1RejectsMissingDocID(t *testing.T) {
+	r := freshRegistry(t)
+	env := cardtmpl.BuildEnv{WebLoginURL: "https://x", Lang: "zh-CN", SpaceID: "s"}
+	bad := json.RawMessage(`{"title":"only title"}`)
+	_, err := r.Render(context.Background(), docsshared.TemplateID, docsshared.TemplateVersion,
+		docsshared.StateShown, bad, env)
+	if err == nil {
+		t.Fatal("expected ErrFieldsInvalid")
+	}
+}

--- a/pkg/cardtmpl/docs_shared/template_test.go
+++ b/pkg/cardtmpl/docs_shared/template_test.go
@@ -44,6 +44,23 @@ func TestRegisterAndRenderSample(t *testing.T) {
 	}
 }
 
+func TestRenderEnglishSourceLocalized(t *testing.T) {
+	r := freshRegistry(t)
+	sample, _ := docsshared.Assets.ReadFile(docsshared.HandoffRoot + "/samples/shown.json")
+	env := cardtmpl.BuildEnv{WebLoginURL: "https://web.example.com", Lang: "en", SpaceID: "space"}
+	payload, err := r.Render(context.Background(), docsshared.TemplateID,
+		docsshared.TemplateVersion, docsshared.StateShown, sample, env)
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	card := payload["card"].(map[string]any)
+	octo := card["metadata"].(map[string]any)["octo"].(map[string]any)
+	src := octo["source"].(map[string]any)
+	if src["label"] != "Docs" {
+		t.Errorf("en source.label = %v want Docs", src["label"])
+	}
+}
+
 func TestFallbackTextZH(t *testing.T) {
 	tmpl := docsshared.New()
 	tmpl.SetMeta(cardtmpl.TemplateMeta{})
@@ -68,6 +85,32 @@ func TestFallbackTextAnon(t *testing.T) {
 	}
 	if !strings.HasPrefix(text, "有人分享了文档") {
 		t.Errorf("anon banner missing: %q", text)
+	}
+}
+
+// TestSchemaCapsMatchRenderCaps 锁 G9 单一真源:handoff data.schema.json 里
+// excerpt / title 的 maxLength 必须与渲染层 cardtmpl.MaxExcerptRunes /
+// MaxTitleRunes 一致 —— 二者漂移会让"截断后仍超 schema → preflight 400"或
+// "schema 松于渲染 → 渲染再砍一刀"的缝隙复现(见 resource.go assembleResourceCardBody
+// 注释)。补上 yujiawei 在 #649 review 指出的"悬空引用的 G9 field-cap test"。
+func TestSchemaCapsMatchRenderCaps(t *testing.T) {
+	raw, err := docsshared.Assets.ReadFile(docsshared.HandoffRoot + "/contract/data.schema.json")
+	if err != nil {
+		t.Fatalf("read schema: %v", err)
+	}
+	var schema struct {
+		Properties map[string]struct {
+			MaxLength int `json:"maxLength"`
+		} `json:"properties"`
+	}
+	if err := json.Unmarshal(raw, &schema); err != nil {
+		t.Fatalf("unmarshal schema: %v", err)
+	}
+	if got := schema.Properties["excerpt"].MaxLength; got != cardtmpl.MaxExcerptRunes {
+		t.Errorf("excerpt maxLength = %d, want cardtmpl.MaxExcerptRunes = %d", got, cardtmpl.MaxExcerptRunes)
+	}
+	if got := schema.Properties["title"].MaxLength; got != cardtmpl.MaxTitleRunes {
+		t.Errorf("title maxLength = %d, want cardtmpl.MaxTitleRunes = %d", got, cardtmpl.MaxTitleRunes)
 	}
 }
 

--- a/pkg/cardtmpl/resource.go
+++ b/pkg/cardtmpl/resource.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net/url"
 	"strings"
+	"unicode"
 	"unicode/utf8"
 
 	"github.com/Mininglamp-OSS/octo-server/pkg/cardmsg"
@@ -83,6 +84,34 @@ func BuildSummaryResourceCard(
 	return buildResourceCard(ctx, deepLink, resource)
 }
 
+// BuildSummaryResourceCardBodyWithLang is the fragment-only counterpart of
+// BuildSummaryResourceCard for Registry-backed octo/v1 summary Templates
+// (roadmap C PR-2: summary.completed / summary.failed). Shape mirrors
+// BuildDocsResourceCardBodyWithLang — returns the assembled body + https
+// deep-link and never marshals the AC top level or writes metadata; that is
+// Registry.Render's job. Both this helper and the legacy BuildSummaryResourceCard
+// share assembleResourceCardBody, so migrated cards render byte-identical bodies.
+func BuildSummaryResourceCardBodyWithLang(
+	lang string,
+	webLoginURL string,
+	taskID string,
+	spaceID string,
+	resource ResourceCard,
+) (body []interface{}, deepLink string, err error) {
+	if strings.TrimSpace(taskID) == "" || strings.TrimSpace(spaceID) == "" {
+		return nil, "", errors.New("cardtmpl: task ID and space ID are required")
+	}
+	deepLink, err = summaryDeepLink(webLoginURL, taskID, spaceID)
+	if err != nil {
+		return nil, "", err
+	}
+	body, err = assembleResourceCardBody(lang, deepLink, resource)
+	if err != nil {
+		return nil, "", err
+	}
+	return body, deepLink, nil
+}
+
 // BuildDocsResourceCard renders an octo/v1 ResourceCard for a docs-notify
 // notification (docs-backend automated flows: share/comment/access request).
 // The deep-link points at octo-web's /d/:docId standalone route (mirrors
@@ -115,6 +144,66 @@ func buildResourceCard(
 	deepLink string,
 	resource ResourceCard,
 ) (json.RawMessage, error) {
+	body, err := assembleResourceCardBody(i18n.OutboundLanguage(ctx), deepLink, resource)
+	if err != nil {
+		return nil, err
+	}
+	document := map[string]interface{}{
+		"type":     "AdaptiveCard",
+		"version":  cardmsg.CardVersion,
+		"metadata": buildMetadata(deepLink, resource.Variant, resource.Source),
+		"body":     body,
+	}
+	raw, err := json.Marshal(document)
+	if err != nil {
+		return nil, fmt.Errorf("cardtmpl: marshal resource card: %w", err)
+	}
+	return json.RawMessage(raw), nil
+}
+
+// BuildDocsResourceCardBodyWithLang is the fragment-only counterpart of
+// BuildDocsResourceCard used by Registry-backed octo/v1 display Templates
+// (e.g. pkg/cardtmpl/docs_commented). It returns the assembled body (header +
+// optional excerpt + optional FactSet + in-body ActionSet) and the https
+// deep-link, but does NOT marshal the AC top level or write metadata — that is
+// Registry.Render's job. It shares assembleResourceCardBody with the legacy
+// BuildDocsResourceCard wrapper, so migrated cards render byte-identical bodies.
+//
+// lang is passed explicitly (resolved by the caller from i18n.OutboundLanguage);
+// this helper never touches ctx, matching BuildDocsAccessRequestBodyWithLang.
+func BuildDocsResourceCardBodyWithLang(
+	lang string,
+	webLoginURL string,
+	docID string,
+	spaceID string,
+	resource ResourceCard,
+) (body []interface{}, deepLink string, err error) {
+	if strings.TrimSpace(docID) == "" || strings.TrimSpace(spaceID) == "" {
+		return nil, "", errors.New("cardtmpl: doc ID and space ID are required")
+	}
+	deepLink, err = docsDeepLink(webLoginURL, docID, spaceID)
+	if err != nil {
+		return nil, "", err
+	}
+	body, err = assembleResourceCardBody(lang, deepLink, resource)
+	if err != nil {
+		return nil, "", err
+	}
+	return body, deepLink, nil
+}
+
+// assembleResourceCardBody validates the scenario-independent bounds (title
+// length, fact count/shape, copy-text size, icon-must-be-https, source bounds)
+// and assembles the octo/v1 body: header (optional icon column) + optional
+// excerpt + optional FactSet + a trailing ActionSet (view-details + optional
+// copy). Both buildResourceCard (marshals a full document + metadata) and
+// BuildDocsResourceCardBodyWithLang (fragment-only) call it, so the rendered
+// body is a single source of truth across the legacy and Registry paths.
+//
+// The excerpt is truncated to MaxExcerptRunes here (render-time cap); a card's
+// input schema declares the same maxLength so the two never drift (see the
+// docs_commented G9 field-cap test).
+func assembleResourceCardBody(lang string, deepLink string, resource ResourceCard) ([]interface{}, error) {
 	if strings.TrimSpace(resource.Title) == "" || utf8.RuneCountInString(resource.Title) > maxTitleRunes {
 		return nil, errors.New("cardtmpl: resource title is invalid")
 	}
@@ -147,7 +236,6 @@ func buildResourceCard(
 		return nil, errors.New("cardtmpl: source label too long")
 	}
 
-	lang := i18n.OutboundLanguage(ctx)
 	labels := labelsForLanguage(lang)
 	titleItems := []interface{}{
 		map[string]interface{}{
@@ -217,17 +305,7 @@ func buildResourceCard(
 	}
 	body = append(body, map[string]interface{}{"type": "ActionSet", "actions": actions})
 
-	document := map[string]interface{}{
-		"type":     "AdaptiveCard",
-		"version":  cardmsg.CardVersion,
-		"metadata": buildMetadata(deepLink, resource.Variant, resource.Source),
-		"body":     body,
-	}
-	raw, err := json.Marshal(document)
-	if err != nil {
-		return nil, fmt.Errorf("cardtmpl: marshal resource card: %w", err)
-	}
-	return json.RawMessage(raw), nil
+	return body, nil
 }
 
 func summaryDeepLink(webLoginURL, taskID, spaceID string) (string, error) {
@@ -293,6 +371,23 @@ func webOrigin(webLoginURL string) (string, error) {
 // 的绝对-https 判定漂移。空串由本包各调用点在调用前 guard (空头像/空 icon 合法)。
 func requireHTTPS(raw string) error {
 	return AbsoluteHTTPSURL(raw)
+}
+
+// SanitizeLine collapses any control character (newline, CR, tab, …) in a
+// caller-supplied string to a single space and trims the result. Text-path
+// (plain-text DM) fallbacks are line-structured, so an embedded "\n" in a
+// caller field (title, excerpt, actor name) could otherwise inject a spoofed
+// attribution/label line. Card rendering has its own defence (escapeMarkdown);
+// this is the text-path equivalent. It is a strict superset of strings.TrimSpace
+// for our inputs. Shared source of truth for modules/notify and each L2a
+// Template's FallbackText — do NOT re-implement (G5, roadmap C).
+func SanitizeLine(s string) string {
+	return strings.TrimSpace(strings.Map(func(r rune) rune {
+		if unicode.IsControl(r) {
+			return ' '
+		}
+		return r
+	}, s))
 }
 
 func truncateRunes(value string, limit int) string {

--- a/pkg/cardtmpl/resource.go
+++ b/pkg/cardtmpl/resource.go
@@ -18,9 +18,14 @@ import (
 
 const (
 	MaxExcerptRunes = 300
-	maxFacts        = 20
-	maxTitleRunes   = 200
-	maxFactRunes    = 500
+	// MaxTitleRunes is the render-layer title cap. Exported so producer mapping
+	// layers (e.g. modules/notify) can pre-truncate display titles to the exact
+	// budget assembleResourceCardBody enforces — a single source of truth for the
+	// title cap (G9), used by both the render guard and the ingress truncation.
+	MaxTitleRunes = 200
+	maxFacts      = 20
+	maxTitleRunes = MaxTitleRunes
+	maxFactRunes  = 500
 )
 
 type Fact struct {
@@ -201,8 +206,9 @@ func BuildDocsResourceCardBodyWithLang(
 // body is a single source of truth across the legacy and Registry paths.
 //
 // The excerpt is truncated to MaxExcerptRunes here (render-time cap); a card's
-// input schema declares the same maxLength so the two never drift (see the
-// docs_commented G9 field-cap test).
+// input schema declares the same maxLength, and the ingress mapping layer
+// truncates to it before preflight, so the three never drift — asserted by the
+// docs_commented / docs_shared TestSchemaCapsMatchRenderCaps (G9).
 func assembleResourceCardBody(lang string, deepLink string, resource ResourceCard) ([]interface{}, error) {
 	if strings.TrimSpace(resource.Title) == "" || utf8.RuneCountInString(resource.Title) > maxTitleRunes {
 		return nil, errors.New("cardtmpl: resource title is invalid")
@@ -389,6 +395,14 @@ func SanitizeLine(s string) string {
 		return r
 	}, s))
 }
+
+// TruncateRunes truncates value to at most limit runes, appending an ellipsis
+// when it actually cuts. Exported so producer mapping layers (modules/notify)
+// can pre-truncate display fields to the same schema/render budgets and preserve
+// card delivery, instead of an over-length field flipping to a C1 400 at
+// preflight (see modules/notify.mapDocsCardFieldsToDisplayJSON). Wraps the
+// internal truncateRunes so the render layer and ingress layer share one impl.
+func TruncateRunes(value string, limit int) string { return truncateRunes(value, limit) }
 
 func truncateRunes(value string, limit int) string {
 	runes := []rune(value)


### PR DESCRIPTION
## Summary

Roadmap C first slice — migrate the docs-notify v1 display cards
(`docs.commented`, `docs.shared`) onto the cardtmpl Registry using the
`docs.access-request` pilot's copy-directory shape.

**Milestone reached**: §2.2-5 L2b hard gate ② — `docs.access-request` (v2) +
`docs.commented` (v1) + `docs.shared` (v1) = **3 L2a cards** running the full
Registry path across **both wire profiles**.

External `NotifyReq` / `DocsCardFields` shape is unchanged (plan B).

## Related Issue / Prior art

Roadmap C follow-up to #641 (post-#633 interactive-card loop). No standalone
issue.

## Linked Spec

`.octospec/tasks/cardtmpl-l2a-migration/brief.md`

## Changes

- **`pkg/cardtmpl/docs_commented@0.1.0`** — new subpackage: self-embedded
  `handoff/` (manifest declaring `renderProfile` + `renderProfileCompatibility`
  per #647, `contract/data.schema.json`, `samples/shown.json`) + 3-method
  Template. Build composes `BuildDocsResourceCardBodyWithLang` so bodies are
  byte-identical to legacy `buildDocsCard`.
- **`pkg/cardtmpl/docs_shared@0.1.0`** — symmetric subpackage, differs only in
  `Variant` + attribution copy.
- **notify wiring** (`modules/notify/card_via_registry.go`,
  `modules/notify/card.go`): new `buildDocsDisplayCardViaRegistry` +
  `preflightDocsDisplaySchema`; `deliverDocsCardNotification` routes
  `DocsCardKindCommented` / `DocsCardKindShared` through Registry with F7
  fail-close and C1 preflight (schema errors → 400 zero-delivery) before
  member/gate checks.
- **`main.installCardTmplRegistry`** registers both new cards +
  `SetDefault` + `Freeze` alongside the pilot.
- **`pkg/cardtmpl.SanitizeLine`** — G5 single source of truth; the two prior
  copies (notify + pilot) become one-line wrappers.
- **`BuildSummaryResourceCardBodyWithLang`** — scaffold for PR-2
  (`summary.completed` / `summary.failed`).
- **`modules/notify/testmain_test.go`** — `TestMain` wires the Registry once
  for the whole test package (mirrors production wiring so preflight tests
  inherit it).

## Testing

Locally green with MySQL 8 / Redis 7 / WuKongIM:

- `go build ./...`, `go vet ./...`
- `pkg/cardtmpl/docs_commented` -race -cover → **85.1%**
- `pkg/cardtmpl/docs_shared` -race -cover → **80.9%**
- `pkg/cardtmpl/...` full package tree — all green
- `modules/notify` full package (after `DROP DATABASE test; CREATE DATABASE
  test` to reset the cross-package migration ledger, per
  `.claude/memory/local_test_infra.md`) — all green including the 4-case
  byte-equivalence baseline and the C1 preflight assertion
- `make i18n-extract-check`, `make i18n-lint`

**Byte-equivalence baseline is the core acceptance.**
`modules/notify/card_via_registry_display_baseline_test.go` runs 4 fixtures
(commented/shared × zh full/anon) through both legacy `buildDocsCard` and
`buildDocsDisplayCardViaRegistry`, strips the two newly-injected metadata
fields (`metadata.octo.protocol`, `metadata.octo.template`), and asserts
canonical JSON byte-equality. Any drift (copy / ordering / alias / extra
field) fails immediately.

Honest gaps (not run here):

- `golangci-lint` — not installed on the dev host; CI lint lane covers it.
- The `//go:build integration` orchestration e2e in `modules/message` has a
  pre-existing compile-time import cycle and the CI test lane runs the default
  build without `-tags integration`; unchanged by this PR.

- [x] Unit tests added/updated
- [x] Manually verified (focused suites + byte-equivalence baseline)

## COMPREHENSION

1. **What does this change actually do to the load-bearing path?**
   `deliverDocsCardNotification` now routes two more docs card kinds through
   `Registry.Render`: preflight validates the input against each card's
   `data.schema.json` (C1 → 400 zero-delivery), and the card is rendered by
   the new Templates whose `Build` composes the same
   `assembleResourceCardBody` the legacy path already uses. External
   `NotifyReq`/`DocsCardFields` are unchanged. `metadata.octo.{protocol,
   template}` + `render_profile` are added to the envelope; everything else in
   the card node is byte-identical.

2. **What could break (dependents + failure mode)?**
   - *Boot*: Registry register-time self-check runs each new sample through
     `Render`; a bad handoff fails `installCardTmplRegistry` → `main` panics
     at startup. Mitigation: self-check + focused tests pass locally.
   - *In-flight card renderers on the receiving side*: envelopes now carry
     new `metadata.octo` and `render_profile` fields. Additive only — unknown
     fields must be ignored per JSON forward-compat; verified against the
     baseline.
   - *docs backend integration*: `DocsCardFields` shape unchanged, so
     backend calls keep working. `docsSafeExcerpt`/`ActorName`/`UpdatedAt`
     semantics preserved.
   - *Existing tests*: any notify test using `validDocsCard()` (Kind: shared)
     now needs a wired Registry — handled once by the new package-level
     `TestMain`.

3. **How do you know it works (specific test/repro/trace)?**
   `card_via_registry_display_baseline_test.go` runs 4 fixtures end-to-end
   through both paths and asserts canonical JSON byte-equality (see Testing).
   `pkg/cardtmpl/docs_commented/template_test.go` and
   `pkg/cardtmpl/docs_shared/template_test.go` cover Registry self-check,
   metadata injection, language-localized source, `FallbackText`
   (named/anon/sanitize), and the C1 schema-rejection branch. `modules/notify`
   full package (real MySQL/Redis/WuKongIM) green after the standard
   cross-package DB reset.

## Out of scope

- `summary.completed` / `summary.failed` (PR-2, scaffold in place).
- `generic.approval` — its dynamic caller-supplied `owner`/`action_type`
  conflicts with the static `TemplateActionContract`; separate adaptation
  decision required.
- No `NotifyReq` shape change, no `${}` engine, no B/D/E/H, no DB migration.

## Checklist

- [x] PR description is in English
- [x] Added tests for my changes
- [x] Updated documentation (`.octospec/` brief + journal + log)
- [x] Followed commit message conventions (Conventional Commits)
