### PR TITLE
fix(space): support permanent invite (NULL expires_at) in createInvite and updateInvite

### DIFF
--- a/modules/space/api.go
+++ b/modules/space/api.go
@@ -1497,16 +1497,21 @@ func (s *Space) updateInvite(c *wkhttp.Context) {
 	}
 
 	// 解析过期时间：与管理端 parseInviteExpiresAt 共用 time.Local 约定，避免双路径写库时区漂移。
-	expiresAt, err := parseInviteExpiresAt(req.ExpiresAt)
+	expiresResult, err := parseInviteExpiresAt(req.ExpiresAt)
 	if err != nil {
 		respondSpaceRequestInvalid(c, "expires_at")
 		return
+	}
+	clearExpires := !expiresResult.notProvided && expiresResult.expiresAt == nil
+	var updateExpiresAt *time.Time
+	if !expiresResult.notProvided {
+		updateExpiresAt = expiresResult.expiresAt
 	}
 
 	// 复用管理端的 updateInvitationAdmin：
 	//   - WHERE 无 status=1 限制，可对已禁用邀请码重启用（status=1）
 	//   - 按 space_id + invite_code 双匹配，天然防跨空间越权
-	affected, err := s.mdb.updateInvitationAdmin(spaceId, code, req.MaxUses, expiresAt, req.Status)
+	affected, err := s.mdb.updateInvitationAdmin(spaceId, code, req.MaxUses, updateExpiresAt, clearExpires, req.Status)
 	if err != nil {
 		httperr.ResponseErrorL(c, errcode.ErrSpaceStoreFailed, nil, nil)
 		return

--- a/modules/space/api.go
+++ b/modules/space/api.go
@@ -1502,11 +1502,7 @@ func (s *Space) updateInvite(c *wkhttp.Context) {
 		respondSpaceRequestInvalid(c, "expires_at")
 		return
 	}
-	clearExpires := !expiresResult.notProvided && expiresResult.expiresAt == nil
-	var updateExpiresAt *time.Time
-	if !expiresResult.notProvided {
-		updateExpiresAt = expiresResult.expiresAt
-	}
+	updateExpiresAt, clearExpires := expiresResult.updateArgs()
 
 	// 复用管理端的 updateInvitationAdmin：
 	//   - WHERE 无 status=1 限制，可对已禁用邀请码重启用（status=1）

--- a/modules/space/api_email_invite.go
+++ b/modules/space/api_email_invite.go
@@ -44,7 +44,8 @@ func (s *Space) createMemberEmailInvite(c *wkhttp.Context) {
 		respondSpaceRequestInvalid(c, "")
 		return
 	}
-	expiresAt, err := parseInviteExpiresAt(req.ExpiresAt)
+	expiresResult, err := parseInviteExpiresAt(req.ExpiresAt)
+	expiresAt := expiresResult.expiresAt // email invite 不区分"未传"与"永久"，直接取 *time.Time
 	if err != nil {
 		respondSpaceRequestInvalid(c, "expires_at")
 		return

--- a/modules/space/api_email_invite.go
+++ b/modules/space/api_email_invite.go
@@ -45,11 +45,16 @@ func (s *Space) createMemberEmailInvite(c *wkhttp.Context) {
 		return
 	}
 	expiresResult, err := parseInviteExpiresAt(req.ExpiresAt)
-	expiresAt := expiresResult.expiresAt // email invite 不区分"未传"与"永久"，直接取 *time.Time
 	if err != nil {
 		respondSpaceRequestInvalid(c, "expires_at")
 		return
 	}
+	// email invite 不提供"永久"选项；若客户端显式传 "never"，拒绝请求（恢复旧 400 行为）。
+	if !expiresResult.notProvided && expiresResult.expiresAt == nil {
+		respondSpaceRequestInvalid(c, "expires_at")
+		return
+	}
+	expiresAt := expiresResult.expiresAt
 
 	rawToken, tokenHash, err := generateEmailInviteToken()
 	if err != nil {

--- a/modules/space/api_manager.go
+++ b/modules/space/api_manager.go
@@ -896,7 +896,7 @@ func (m *Manager) createInvite(c *wkhttp.Context) {
 			return
 		}
 	}
-	expiresAt, err := parseInviteExpiresAt(req.ExpiresAt)
+	expiresResult, err := parseInviteExpiresAt(req.ExpiresAt)
 	if err != nil {
 		respondSpaceRequestInvalid(c, "expires_at")
 		return
@@ -920,10 +920,15 @@ func (m *Manager) createInvite(c *wkhttp.Context) {
 	} else {
 		model.MaxUses = defMaxUses
 	}
-	if expiresAt != nil {
-		t := db.Time(*expiresAt)
-		model.ExpiresAt = &t
+	if !expiresResult.notProvided {
+		// 客户端显式传了 expires_at（含 "never" 永久）：直接使用，不套默认。
+		if expiresResult.expiresAt != nil {
+			t := db.Time(*expiresResult.expiresAt)
+			model.ExpiresAt = &t
+		}
+		// expiresResult.expiresAt == nil 即永久：model.ExpiresAt 保持 nil，落库为 NULL。
 	} else if defExpiresAt != nil {
+		// 未传 expires_at：套环境变量默认值。
 		t := db.Time(*defExpiresAt)
 		model.ExpiresAt = &t
 	}
@@ -987,13 +992,22 @@ func (m *Manager) updateInvite(c *wkhttp.Context) {
 		respondSpaceRequestInvalid(c, "status")
 		return
 	}
-	expiresAt, err := parseInviteExpiresAt(req.ExpiresAt)
+	expiresResult, err := parseInviteExpiresAt(req.ExpiresAt)
 	if err != nil {
 		respondSpaceRequestInvalid(c, "expires_at")
 		return
 	}
+	// updateInvitationAdmin 三态：
+	//   notProvided=true  → updateExpiresAt=nil, clearExpiresAt=false → 字段不变
+	//   notProvided=false, expiresAt!=nil → 写入具体时间
+	//   notProvided=false, expiresAt==nil → clearExpiresAt=true → 写 NULL（永久）
+	clearExpires := !expiresResult.notProvided && expiresResult.expiresAt == nil
+	var updateExpiresAt *time.Time
+	if !expiresResult.notProvided {
+		updateExpiresAt = expiresResult.expiresAt
+	}
 
-	affected, err := m.managerDB.updateInvitationAdmin(spaceId, code, req.MaxUses, expiresAt, req.Status)
+	affected, err := m.managerDB.updateInvitationAdmin(spaceId, code, req.MaxUses, updateExpiresAt, clearExpires, req.Status)
 	if err != nil {
 		m.Error("修改邀请码失败", zap.Error(err), zap.String("spaceId", spaceId), zap.String("code", code))
 		httperr.ResponseErrorL(c, errcode.ErrSpaceStoreFailed, nil, nil)
@@ -1016,18 +1030,35 @@ func (m *Manager) updateInvite(c *wkhttp.Context) {
 // 用户侧 updateInvite 与管理端 create/updateInvite 共用此常量，避免双写路径漂移。
 const inviteTimeLayout = "2006-01-02 15:04:05"
 
-// parseInviteExpiresAt 解析 expires_at 字符串，空字符串视为未传。
+// inviteExpiresAtNeverSentinel 客户端传此值表示「显式永久」。
+// 空字符串 / nil 表示「未传，由服务端套默认值」；"never" 表示「明确不要过期时间」。
+const inviteExpiresAtNeverSentinel = "never"
+
+// inviteExpiresResult 解析结果，三态：
+//   - notProvided=true : 客户端未传 expires_at（nil 或空字符串），走默认值
+//   - notProvided=false, expiresAt=nil : 客户端显式要求永久（"never"）
+//   - notProvided=false, expiresAt!=nil : 客户端给定具体时间
+type inviteExpiresResult struct {
+	notProvided bool
+	expiresAt   *time.Time
+}
+
+// parseInviteExpiresAt 解析 expires_at 字符串，三态处理。
 // 时区采用服务器 time.Local——管理端与用户侧统一共用本函数。
 // 部署环境应显式设置 TZ，确保客户端发送的"服务器本地时间"解释一致。
-func parseInviteExpiresAt(raw *string) (*time.Time, error) {
+func parseInviteExpiresAt(raw *string) (inviteExpiresResult, error) {
 	if raw == nil || *raw == "" {
-		return nil, nil
+		return inviteExpiresResult{notProvided: true}, nil
+	}
+	if *raw == inviteExpiresAtNeverSentinel {
+		// 显式永久：expiresAt = nil，notProvided = false
+		return inviteExpiresResult{notProvided: false, expiresAt: nil}, nil
 	}
 	t, err := time.ParseInLocation(inviteTimeLayout, *raw, time.Local)
 	if err != nil {
-		return nil, errors.New("过期时间格式错误，请使用 2006-01-02 15:04:05 格式")
+		return inviteExpiresResult{}, errors.New(`过期时间格式错误，请使用 2006-01-02 15:04:05 格式或 "never" 表示永久`)
 	}
-	return &t, nil
+	return inviteExpiresResult{notProvided: false, expiresAt: &t}, nil
 }
 
 // disableInvite 禁用邀请码

--- a/modules/space/api_manager.go
+++ b/modules/space/api_manager.go
@@ -829,7 +829,7 @@ func (m *Manager) listInvites(c *wkhttp.Context) {
 	}
 	resp := make([]*managerInviteResp, 0, len(list))
 	for _, inv := range list {
-		expiresAt := ""
+		expiresAt := inviteExpiresAtNeverSentinel // 永久邀请
 		if inv.ExpiresAt != nil {
 			expiresAt = inv.ExpiresAt.String()
 		}
@@ -946,9 +946,8 @@ func (m *Manager) createInvite(c *wkhttp.Context) {
 		zap.String("operator", operator),
 	)
 
-	// 显式 Format 保证响应格式与 parseInviteExpiresAt 接受的输入格式一致，
-	// 避免客户端拿到响应后回传被 parse 拒绝。
-	expiresStr := ""
+	// 序列化 expires_at：永久（NULL）返回 "never" 哨兵，与输入格式对称，客户端可安全回传。
+	expiresStr := inviteExpiresAtNeverSentinel // 永久邀请
 	if model.ExpiresAt != nil {
 		expiresStr = time.Time(*model.ExpiresAt).Format(inviteTimeLayout)
 	}
@@ -997,16 +996,7 @@ func (m *Manager) updateInvite(c *wkhttp.Context) {
 		respondSpaceRequestInvalid(c, "expires_at")
 		return
 	}
-	// updateInvitationAdmin 三态：
-	//   notProvided=true  → updateExpiresAt=nil, clearExpiresAt=false → 字段不变
-	//   notProvided=false, expiresAt!=nil → 写入具体时间
-	//   notProvided=false, expiresAt==nil → clearExpiresAt=true → 写 NULL（永久）
-	clearExpires := !expiresResult.notProvided && expiresResult.expiresAt == nil
-	var updateExpiresAt *time.Time
-	if !expiresResult.notProvided {
-		updateExpiresAt = expiresResult.expiresAt
-	}
-
+	updateExpiresAt, clearExpires := expiresResult.updateArgs()
 	affected, err := m.managerDB.updateInvitationAdmin(spaceId, code, req.MaxUses, updateExpiresAt, clearExpires, req.Status)
 	if err != nil {
 		m.Error("修改邀请码失败", zap.Error(err), zap.String("spaceId", spaceId), zap.String("code", code))
@@ -1043,6 +1033,16 @@ type inviteExpiresResult struct {
 	expiresAt   *time.Time
 }
 
+// updateArgs 从三态解析结果中派生 updateInvitationAdmin 所需参数，
+// 避免 Manager.updateInvite 与 Space.updateInvite 各自重复同一段逻辑导致实现漂移。
+func (r inviteExpiresResult) updateArgs() (expiresAt *time.Time, clearExpiresAt bool) {
+	clearExpiresAt = !r.notProvided && r.expiresAt == nil
+	if !r.notProvided {
+		expiresAt = r.expiresAt
+	}
+	return
+}
+
 // parseInviteExpiresAt 解析 expires_at 字符串，三态处理。
 // 时区采用服务器 time.Local——管理端与用户侧统一共用本函数。
 // 部署环境应显式设置 TZ，确保客户端发送的"服务器本地时间"解释一致。
@@ -1050,7 +1050,7 @@ func parseInviteExpiresAt(raw *string) (inviteExpiresResult, error) {
 	if raw == nil || *raw == "" {
 		return inviteExpiresResult{notProvided: true}, nil
 	}
-	if *raw == inviteExpiresAtNeverSentinel {
+	if strings.ToLower(strings.TrimSpace(*raw)) == inviteExpiresAtNeverSentinel {
 		// 显式永久：expiresAt = nil，notProvided = false
 		return inviteExpiresResult{notProvided: false, expiresAt: nil}, nil
 	}

--- a/modules/space/api_manager_email_invite.go
+++ b/modules/space/api_manager_email_invite.go
@@ -59,11 +59,16 @@ func (m *Manager) createSpaceOwnerEmailInvite(c *wkhttp.Context) {
 		return
 	}
 	expiresResult, err := parseInviteExpiresAt(req.ExpiresAt)
-	expiresAt := expiresResult.expiresAt // email invite 不区分"未传"与"永久"，直接取 *time.Time
 	if err != nil {
 		respondSpaceRequestInvalid(c, "expires_at")
 		return
 	}
+	// email invite 不提供"永久"选项；若客户端显式传 "never"，拒绝请求（恢复旧 400 行为）。
+	if !expiresResult.notProvided && expiresResult.expiresAt == nil {
+		respondSpaceRequestInvalid(c, "expires_at")
+		return
+	}
+	expiresAt := expiresResult.expiresAt
 
 	rawToken, tokenHash, err := generateEmailInviteToken()
 	if err != nil {

--- a/modules/space/api_manager_email_invite.go
+++ b/modules/space/api_manager_email_invite.go
@@ -58,7 +58,8 @@ func (m *Manager) createSpaceOwnerEmailInvite(c *wkhttp.Context) {
 		respondSpaceRequestInvalid(c, "")
 		return
 	}
-	expiresAt, err := parseInviteExpiresAt(req.ExpiresAt)
+	expiresResult, err := parseInviteExpiresAt(req.ExpiresAt)
+	expiresAt := expiresResult.expiresAt // email invite 不区分"未传"与"永久"，直接取 *time.Time
 	if err != nil {
 		respondSpaceRequestInvalid(c, "expires_at")
 		return

--- a/modules/space/api_manager_test.go
+++ b/modules/space/api_manager_test.go
@@ -1784,3 +1784,135 @@ func TestManager_UpdateMemberRoleIdempotent(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, 2, owner.Role)
 }
+
+// ──────────────────────────────────────────────────────────────────────────────
+// parseInviteExpiresAt 三态单元测试（review #653 P2 回归）
+// ──────────────────────────────────────────────────────────────────────────────
+
+func TestParseInviteExpiresAt_ThreeState(t *testing.T) {
+	t.Run("nil → notProvided", func(t *testing.T) {
+		r, err := parseInviteExpiresAt(nil)
+		assert.NoError(t, err)
+		assert.True(t, r.notProvided)
+		assert.Nil(t, r.expiresAt)
+	})
+	t.Run("empty string → notProvided", func(t *testing.T) {
+		s := ""
+		r, err := parseInviteExpiresAt(&s)
+		assert.NoError(t, err)
+		assert.True(t, r.notProvided)
+		assert.Nil(t, r.expiresAt)
+	})
+	t.Run(`"never" → permanent`, func(t *testing.T) {
+		s := "never"
+		r, err := parseInviteExpiresAt(&s)
+		assert.NoError(t, err)
+		assert.False(t, r.notProvided)
+		assert.Nil(t, r.expiresAt, "explicit permanent: expiresAt must be nil")
+	})
+	t.Run(`"Never" (mixed-case) → permanent`, func(t *testing.T) {
+		s := "Never"
+		r, err := parseInviteExpiresAt(&s)
+		assert.NoError(t, err)
+		assert.False(t, r.notProvided)
+		assert.Nil(t, r.expiresAt)
+	})
+	t.Run(`" never " (padded) → permanent`, func(t *testing.T) {
+		s := " never "
+		r, err := parseInviteExpiresAt(&s)
+		assert.NoError(t, err)
+		assert.False(t, r.notProvided)
+		assert.Nil(t, r.expiresAt)
+	})
+	t.Run("valid timestamp → specific time", func(t *testing.T) {
+		s := "2030-06-15 12:00:00"
+		r, err := parseInviteExpiresAt(&s)
+		assert.NoError(t, err)
+		assert.False(t, r.notProvided)
+		assert.NotNil(t, r.expiresAt)
+	})
+	t.Run("invalid string → error", func(t *testing.T) {
+		s := "not-a-date"
+		_, err := parseInviteExpiresAt(&s)
+		assert.Error(t, err)
+	})
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Manager.createInvite "never" → DB NULL 集成测试（review #653 P2 回归）
+// ──────────────────────────────────────────────────────────────────────────────
+
+func TestManager_CreateInvite_Never_DBNull(t *testing.T) {
+	s, _, err := setup(t)
+	assert.NoError(t, err)
+	token := adminToken(t)
+
+	seedSpace(t, "mgr-inv-never1", "inv never create", "u-owner", SpaceStatusNormal)
+
+	body := `{"expires_at":"never"}`
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/v1/manager/spaces/mgr-inv-never1/invites", bytes.NewBufferString(body))
+	req.Header.Set("token", token)
+	req.Header.Set("Content-Type", "application/json")
+	s.GetRoute().ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code, "create with never should succeed: %s", w.Body.String())
+
+	var resp struct {
+		InviteCode string `json:"invite_code"`
+		ExpiresAt  string `json:"expires_at"`
+	}
+	assert.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, "never", resp.ExpiresAt, `response expires_at must be "never" for permanent invite`)
+
+	inv, err := testSpaceDB.queryInvitationByCode(resp.InviteCode)
+	assert.NoError(t, err)
+	assert.NotNil(t, inv)
+	assert.Nil(t, inv.ExpiresAt, "DB expires_at must be NULL for permanent invite")
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Manager.updateInvite "never" → DB NULL 集成测试（review #653 P2 回归）
+// ──────────────────────────────────────────────────────────────────────────────
+
+func TestManager_UpdateInvite_ClearExpiry_Never(t *testing.T) {
+	s, _, err := setup(t)
+	assert.NoError(t, err)
+	token := adminToken(t)
+
+	seedSpace(t, "mgr-inv-never2", "inv never update", "u-owner", SpaceStatusNormal)
+
+	// 先建一个有具体过期时间的邀请码
+	bodyCreate := `{"expires_at":"2030-01-01 00:00:00","max_uses":10}`
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/v1/manager/spaces/mgr-inv-never2/invites", bytes.NewBufferString(bodyCreate))
+	req.Header.Set("token", token)
+	req.Header.Set("Content-Type", "application/json")
+	s.GetRoute().ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var createResp struct {
+		InviteCode string `json:"invite_code"`
+	}
+	assert.NoError(t, json.Unmarshal(w.Body.Bytes(), &createResp))
+	code := createResp.InviteCode
+	assert.NotEmpty(t, code)
+
+	// 验证创建后 expires_at 非 NULL
+	inv, err := testSpaceDB.queryInvitationByCode(code)
+	assert.NoError(t, err)
+	assert.NotNil(t, inv.ExpiresAt, "before update: should have a concrete expiry")
+
+	// 用 "never" 更新为永久
+	bodyUpdate := `{"expires_at":"never"}`
+	w2 := httptest.NewRecorder()
+	req2, _ := http.NewRequest("PUT", "/v1/manager/spaces/mgr-inv-never2/invites/"+code, bytes.NewBufferString(bodyUpdate))
+	req2.Header.Set("token", token)
+	req2.Header.Set("Content-Type", "application/json")
+	s.GetRoute().ServeHTTP(w2, req2)
+	assert.Equal(t, http.StatusOK, w2.Code, "update to never should succeed: %s", w2.Body.String())
+
+	// 验证 DB expires_at 已被清为 NULL
+	inv2, err := testSpaceDB.queryInvitationByCode(code)
+	assert.NoError(t, err)
+	assert.Nil(t, inv2.ExpiresAt, "after update with never: DB expires_at must be NULL")
+}

--- a/modules/space/db_manager.go
+++ b/modules/space/db_manager.go
@@ -560,14 +560,21 @@ func (d *managerDB) disableInvitation(spaceId, code string) (int64, error) {
 // 有意设计：WHERE 不限制 status，管理员可以对已禁用（status=0）的邀请码执行 PUT，
 // 包括通过 {"status": 1} 重新启用——这是管理操作的必要能力（如误禁恢复）。
 // 若要禁止重新启用，应在 API 层决策，不在此函数加 AND status=1。
-func (d *managerDB) updateInvitationAdmin(spaceId, code string, maxUses *int, expiresAt *time.Time, status *int) (int64, error) {
+// updateInvitationAdmin 更新邀请码字段。
+// clearExpiresAt=true 时将 expires_at 置为 NULL（永久），优先级高于 expiresAt。
+// expiresAt!=nil 时写入具体时间；两者均为零值时该列保持不变。
+func (d *managerDB) updateInvitationAdmin(spaceId, code string, maxUses *int, expiresAt *time.Time, clearExpiresAt bool, status *int) (int64, error) {
 	builder := d.session.Update("space_invitation")
 	changed := false
 	if maxUses != nil {
 		builder = builder.Set("max_uses", *maxUses)
 		changed = true
 	}
-	if expiresAt != nil {
+	if clearExpiresAt {
+		// 显式永久：写 NULL
+		builder = builder.Set("expires_at", nil)
+		changed = true
+	} else if expiresAt != nil {
 		builder = builder.Set("expires_at", *expiresAt)
 		changed = true
 	}

--- a/modules/space/db_manager.go
+++ b/modules/space/db_manager.go
@@ -554,15 +554,16 @@ func (d *managerDB) disableInvitation(spaceId, code string) (int64, error) {
 	return result.RowsAffected()
 }
 
-// updateInvitationAdmin 管理端可修改 max_uses / expires_at / status，nil 字段不变更。
-// 返回 affected rows，0 表示记录不存在。
+// updateInvitationAdmin 管理端更新邀请码字段。返回 affected rows，0 表示记录不存在。
 //
-// 有意设计：WHERE 不限制 status，管理员可以对已禁用（status=0）的邀请码执行 PUT，
-// 包括通过 {"status": 1} 重新启用——这是管理操作的必要能力（如误禁恢复）。
+// expires_at 三态行为：
+//   - clearExpiresAt=true               → SET expires_at = NULL（永久），优先级最高
+//   - clearExpiresAt=false, expiresAt!=nil → 写入具体时间
+//   - clearExpiresAt=false, expiresAt==nil → 列保持不变
+//
+// 有意设计：WHERE 不限制 status，管理员可对已禁用（status=0）的邀请码执行 PUT，
+// 包括通过 {"status": 1} 重新启用——管理操作的必要能力（如误禁恢复）。
 // 若要禁止重新启用，应在 API 层决策，不在此函数加 AND status=1。
-// updateInvitationAdmin 更新邀请码字段。
-// clearExpiresAt=true 时将 expires_at 置为 NULL（永久），优先级高于 expiresAt。
-// expiresAt!=nil 时写入具体时间；两者均为零值时该列保持不变。
 func (d *managerDB) updateInvitationAdmin(spaceId, code string, maxUses *int, expiresAt *time.Time, clearExpiresAt bool, status *int) (int64, error) {
 	builder := d.session.Update("space_invitation")
 	changed := false


### PR DESCRIPTION
## Summary

Fixes the report: **"selecting permanent still expires after 72 h"**.

## Root Cause

The admin UI (`octo-admin / SpaceInvitesPanel`) has a 7d/14d/30d/**never** expiry picker. When the user picks **never**, the frontend previously sent an empty `expires_at` string. The server treated empty string as "not provided" and applied the env-var default TTL (72 h). There was also no path to *clear* an existing `expires_at` back to `NULL`.

## Changes

### `parseInviteExpiresAt` — three-state result

| Input | Result | Meaning |
|---|---|---|
| `nil` / `""` | `notProvided=true` | Field not sent; server applies default TTL |
| `"never"` | `notProvided=false, expiresAt=nil` | Explicit permanent — write `NULL` |
| timestamp string | `notProvided=false, expiresAt=&t` | Specific expiry time |

### `manager.createInvite`
- Explicit `expires_at` (including `"never"`) **bypasses** the env-var default branch.
- `"never"` → `model.ExpiresAt = nil` → DB row gets `NULL`.

### `manager.updateInvite` + `Space.updateInvite`
- Derive `clearExpiresAt` flag from three-state result.
- Pass to `updateInvitationAdmin`.

### `updateInvitationAdmin` (DB layer)
- New `clearExpiresAt bool` parameter.
- When `true`: `SET expires_at = NULL` (true permanent).
- When `false` and `expiresAt != nil`: write the specific time.
- When both zero: column unchanged (existing behaviour).

### Email-invite paths
- Adapted to new return type; semantics unchanged (no "never" UX there).

## Companion PR

octo-admin fix: `xiaokenbot:fix/space-invite-permanent-expiry`

## Testing

- `go build ./modules/space/` passes clean.
- Manual: POST `{"expires_at": "never"}` → DB `expires_at IS NULL`; POST `{}` → DB gets default TTL; PUT `{"expires_at": "never"}` → existing row updated to `NULL`.