### PR TITLE
feat(cardtmpl): JSON template render path (roadmap E1)

### DIFF
--- a/.octospec/journal/shared/cardtmpl-json-template-engine.md
+++ b/.octospec/journal/shared/cardtmpl-json-template-engine.md
@@ -1,0 +1,68 @@
+---
+type: Journal
+title: "Journal: cardtmpl-json-template-engine (roadmap E1)"
+description: Add a second runtime render path to the cardtmpl base — a bounded Adaptive Card Templating engine that compiles JSON handoff templates (`.template.json`) against caller data, so a card can register and render via Registry.Render without a hand-written Go Build(). Validated byte-for-byte against the ai.reasoning-process@0.1.0 goldens. The engine is card-agnostic; the reasoning card's productionization (drop Submit → octo/v1, register, bot delivery) is a separate downstream task.
+tags: ["cardtmpl", "platform", "json-template-engine", "adaptive-card-templating", "wire-contract", "trust-boundary", "escape", "testing", "e1"]
+timestamp: 2026-07-23T12:58:36Z
+# --- octospec extension fields ---
+task: cardtmpl-json-template-engine
+upstream: self (roadmap E1)
+source: self
+---
+
+# Journal: cardtmpl-json-template-engine (roadmap E1)
+
+## What shipped
+
+A JSON-template render path for `pkg/cardtmpl`, additive and parallel to the
+existing hand-written Go `Template.Build()` cards (the 5 L2a cards are untouched).
+
+- **`pkg/cardtmpl/jsontmpl/`** — a dependency-free evaluator for the bounded ACT
+  subset the shipped handoff templates actually use: single-identifier field
+  binding, `$index`, `if($index == N, a, b)`, string interpolation, typed
+  whole-value binding (`"${bool}"` → real JSON bool), and `$data` array
+  repetition. Anything outside the subset is a hard error at parse/expand, never
+  a silent passthrough (D4: freeze the subset, extend via L0 PR). `expr.go` +
+  `expand.go` + `toggle.go` (static ToggleVisibility-target existence check).
+- **`pkg/cardtmpl/json_template.go`** — a generic `jsonTemplate` implementing
+  `Template` + `metaSetter`, with per-view template ASTs parsed once at register
+  time (no per-frame JSON parse — progress cards re-render often). `RegisterJSON`
+  loads `manifest.views[].template`, validates toggle targets, and delegates to
+  the existing `Register` so JSON cards get identical fail-close guarantees.
+  `FallbackText` reuses `cardmsg.BuildPlain`.
+- **`render.go` (D7)** — `BuildResult.DeepLink` is now optional: empty skips the
+  absolute-https check and omits `metadata.webUrl`. Cards that ship a deep link
+  behave exactly as before (existing docs/summary conformance stays green).
+- **`registry.go`** — extracted a named `manifestView` type and parses the
+  previously-dropped `template` / `samples` view fields.
+
+## Structural learnings / gotchas
+
+- **The goldens bind data literally — no markdown escaping (D6).** The authoring
+  tool substitutes `${...}` verbatim (`run_sql`, `funnel_definition.sql` keep raw
+  underscores). Escaping in the engine would break byte-equivalence. The trust
+  boundary is not markdown-escaping; it is `cardmsg.Validate`, whose positive URL
+  allowlist covers TextBlock markdown links (`cardmsg.go`) plus the element
+  whitelist and node/size caps. Proven: a caller-injected `[x](javascript:…)` in
+  literal-bound data is rejected → `ErrRenderFailed`. The engine keeps an
+  injected `EscapeFunc` seam (identity by default) so a future card can opt in.
+- **Conformance lives at the expander level, not renderCore.** Goldens are the
+  full pre-metadata card (`{$schema,type,version,body}`); `renderCore` adds
+  `metadata` and drops `$schema`. So the byte oracle compares
+  `jsontmpl.Expand(template,sample)` to the golden (canonical JSON, sorted keys —
+  key order is not semantic and Go maps are unordered). Registry integration is
+  proven separately with a minimal registrable v1 fixture.
+- **The as-delivered reasoning handoff does not register as-is** (diagnostic, not
+  a gate): its `reports/*.interaction.json` are named by **state**
+  (`reasoning`/`answering`/…) while the Registry convention is by **view**
+  (`active.interaction.json`). Dropping Submit → octo/v1 (the product decision)
+  removes the need for reports entirely, dissolving the mismatch. This is the
+  downstream "translate the reasoning card" task, kept out of scope here.
+
+## Out of scope (→ downstream tasks)
+
+Translating `ai.reasoning-process` into a live product card (drop Submit →
+octo/v1, re-issue handoff + regenerate goldens, register a subpackage, wire
+"wave A" bot delivery), the capability-discovery endpoint additions
+(`/v1/bot/card/profile` templating advertise), multi-locale template selection,
+and migrating the 5 Go cards to JSON.

--- a/.octospec/learnings/pending/template-engine-literal-bind-validate-backstop.md
+++ b/.octospec/learnings/pending/template-engine-literal-bind-validate-backstop.md
@@ -1,0 +1,38 @@
+---
+type: Learning
+title: "A template engine binds data literally; escaping belongs at the whitelist validator, not the binder"
+description: When a server-side templating engine must reproduce an authoring tool's compiled output byte-for-byte, the engine must substitute data verbatim — escaping in the binder breaks byte-equivalence. Put the injection defense at the structural validator (cardmsg.Validate's URL allowlist + element whitelist), which the caller cannot bypass, and keep escaping an opt-in seam.
+tags: ["cardtmpl", "template-engine", "trust-boundary", "escape", "wire-contract"]
+timestamp: 2026-07-23T12:58:36Z
+# --- octospec extension fields ---
+source: self
+origin_task: cardtmpl-json-template-engine
+origin_pr: dmwork-org/octo-server (roadmap E1)
+status: pending
+candidate_rule: trust-boundary
+---
+# A template engine binds data literally; escaping belongs at the whitelist validator, not the binder
+
+When a runtime engine compiles authored templates (`.template.json`) against
+caller data and must match a golden produced by the authoring tool **byte-for-
+byte**, the engine has to substitute `${...}` **literally** — the authoring tool
+does not markdown-escape (`run_sql`, `funnel_definition.sql` keep raw
+underscores), so escaping in the binder would diverge from the golden and fail
+conformance.
+
+That does **not** mean "no defense". Place the injection defense at the
+**structural validator the caller cannot bypass** — here `cardmsg.Validate`,
+whose positive URL allowlist covers TextBlock markdown links and whose element
+whitelist + node/size caps reject anything dangerous. renderCore runs it on the
+compiled card, so a literal-bound `[x](javascript:…)` is rejected
+(`ErrRenderFailed`) even though the binder never escaped it. Cosmetic markdown
+(`*`/`_`) passes through, which is acceptable for first-party/agent-authored
+content.
+
+Keep escaping an **injected, opt-in seam** (`EscapeFunc`, identity by default) so
+a specific card can turn it on without changing the engine — but the default and
+the security guarantee both live at the validator, not the binder.
+
+**Rule of thumb**: byte-equivalence with an external compiler and boundary
+escaping are in tension; resolve it by moving the escape to the last validator
+the caller can't cross, not by escaping at substitution time.

--- a/.octospec/log.md
+++ b/.octospec/log.md
@@ -4,6 +4,18 @@ Change history for this repo's `.octospec/`, following the
 [OKF](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md)
 change-log convention (§7). Newest first.
 
+## 2026-07-23 (cardtmpl-json-template-engine, roadmap E1)
+
+- **Feature** — Added a JSON-template render path to `pkg/cardtmpl` (roadmap E1):
+  a bounded Adaptive Card Templating engine (`pkg/cardtmpl/jsontmpl/`) + a generic
+  `jsonTemplate` + `Registry.RegisterJSON`, so a card can register and render via
+  `Registry.Render` from a JSON handoff without a hand-written Go `Build()`.
+  Validated byte-for-byte against the `ai.reasoning-process@0.1.0` goldens. Made
+  `BuildResult.DeepLink` optional (D7) for cards with no canonical URL. The 5 Go
+  cards are untouched. See
+  [journal](journal/shared/cardtmpl-json-template-engine.md); learning candidate
+  `learnings/pending/template-engine-literal-bind-validate-backstop.md`.
+
 ## 2026-07-23 (cardtmpl-l2a-summary-migration PR-2)
 
 - **Feature** — Roadmap C second slice: `summary.completed@0.1.0` and

--- a/.octospec/tasks/cardtmpl-json-template-engine/brief.md
+++ b/.octospec/tasks/cardtmpl-json-template-engine/brief.md
@@ -1,0 +1,241 @@
+---
+type: Task
+title: "Task: cardtmpl-json-template-engine"
+description: 给 cardtmpl 基座加一条 JSON 模板渲染通路(E1)—— 让卡片以纯 handoff 制品(.template.json + data.schema + reports + goldens)注册运行,不必手写 Go Build();以 ai.reasoning-process@0.1.0 的 goldens 为验收对照。
+tags: [cardtmpl, wire-contract, trust-boundary, escape, testing]
+timestamp: 2026-07-23T10:38:52Z
+# --- octospec extension fields ---
+slug: cardtmpl-json-template-engine
+upstream: (self · roadmap E1)
+source: self
+---
+
+# Task: cardtmpl-json-template-engine
+
+> One task = one `.octospec/tasks/<slug>/` directory. This brief is the spec for
+> the work. AI may draft it from existing code; a human confirms it.
+
+## Goal
+
+给 `pkg/cardtmpl` 基座新增**第二条运行时渲染通路 —— JSON 模板通路(roadmap E1)**:一张卡
+只要提供 handoff 制品(`manifest.json` + `contract/data.schema.json` +
+`templates/<view>.template.json` + `reports/<view>.interaction.json` +
+`goldens/<sample>.card.json` + `samples/`),就能注册进 Registry 并被
+`Registry.Render` 渲染出 type-17 信封,**无须为它手写 Go `Template.Build()`**。
+
+产物三块:
+1. **Adaptive Card Templating 求值器(Go)** —— 支持这批 handoff 实际用到的
+   ACT 子集:`${field}` / `${obj.path}` 绑定、`"✦  ${title}"` 字符串插值、
+   `$data: "${phases}"` 迭代 + `$index`、`${if(cond, a, b)}` 三元、
+   **类型化绑定**(整串 `"${traceExpanded}"` → 真布尔,`"${statusTone}"` → 真枚举串)。
+2. **通用 `jsonTemplate` Template 实现** —— 满足现有 `Template` 接口(`Meta`/`Build`/
+   `FallbackText`),`Build` 按 state 选 view 的 `.template.json`、用**已过 schema
+   校验**的 data 展开、返回 body;不写死任何单卡布局。任意卡复用同一实现。
+3. **Registry manifest JSON-view 装配** —— 解析 `views[].template` / `views[].samples`
+   (当前被丢弃),注册期加载模板、跑 goldens 一致性 self-check(fail-close)。
+
+验收硬对照:`ai.reasoning-process@0.1.0`(见
+`.octospec/tasks/cardtmpl-json-template-engine/fixtures/`)—— 引擎对每个 sample
+展开后必须与对应 `goldens/*.card.json` **canonical-JSON 逐字节相等**(metadata 注入前)。
+
+## Background
+
+- 契约 `docs/platform-card-base.md` §1 早写明"版本化模板(L1)双模式(Go / JSON)",
+  但 §1 同时标注 **"JSON 引擎 = E1 未实现,当前仅 Go 在用"**。roadmap `E1` = 本任务。
+- 现状(已核对代码):
+  - `Template` 是 **Go 接口**,现有 5 张 L2a 卡(docs.access-request / docs.commented /
+    docs.shared / summary.completed / summary.failed)全部**手写 Go `Build()`** 拼 body,
+    共享 `assembleResourceCardBody`。
+  - `Registry` 加载 `manifest.json`(schemaVersion 2 / views / wireProfile)+
+    `contract/data.schema.json`(draft-07,`santhosh-tekuri/jsonschema/v6`,**可复用**)+
+    `reports/<view>.interaction.json`(→ `InteractionReport` / `ActionContract` /
+    `ActionView` 路由),但 **从不读 `.template.json`** —— 各卡 manifest 里的
+    `template` 字段是给前端/SDK/golden 的参考制品,运行时靠 Go 复刻。
+  - `renderCore` 管线:`InputSchema.Validate` → `tmpl.Build` → 注入 `metadata.octo`
+    → `assertActionContract` → `cardmsg.Validate`(组件白名单 / URL https / 上限 /
+    interaction 门)。JSON 通路必须**接进同一条管线**,不得旁路白名单与上限。
+  - `manifestFile.Views` 结构体只有 `WireProfile` + `States`,**没有 `Template` /
+    `Samples`** —— 第一处要补。
+- 触发场景:业务方交付了 `ai.reasoning-process` —— 一张 **bot 主动产出、流式更新的
+  推理进度卡**(纯 JSON 制品、零 Go 代码)。state 流转
+  reasoning→answering→completed/stopped/error(同一 message_id,靠 `ReplaceView`
+  整-view 重渲染)。**产品决策(2026-07-23):推理卡不含任何操作行为(去掉 `停止`/
+  `重试` 等 `Action.Submit`),只保留 `Action.ToggleVisibility`(展开/收起推理明细)。**
+  → 该卡因此是 **octo/v1 纯展示 + 本地折叠**卡(ToggleVisibility 是 v1 本地动作、无
+  服务端回调),**不是 octo/v2**。它就是奔这条 JSON 引擎来的(布局之丰富 —— accent
+  header / `$data` 阶段循环 / 折叠面板 —— 而非交互,才是上引擎的理由),也是本任务的
+  黄金验收 fixture。**排序:引擎先行,再翻译落地这张卡**——引擎以**当前交付的 handoff
+  原样**(含 Submit、octo/v2)当 conformance oracle(覆盖面更全);"去 Submit、降
+  octo/v1" 的产品决策属下游"翻译推理卡"任务,非引擎前置(见 Risks D5)。
+- **下发原语(已核对)**:去掉 Submit 后**无任何服务端回调**——不需要 owner /
+  action_type / RouteSpec / `reasoning_id` 路由 / `/v1/bot/events` 回流。下发退化为
+  memory `card_message_v2_web_gate` 里**已验证的"波 A"**:bot 发 v1 卡
+  (`bot_api/send.go` → `cardmsg.Validate`)+ 流式 `edit`/`ReplaceView` 刷进度
+  (`bot_api` 持 `carddispatch.CardMutator`),服务端 ✅ + web ✅ 早已打通。**与 C3 /
+  L2b / 动态 owner 彻底脱钩。**
+
+## Load-bearing list
+
+<!-- 触及的既有契约/行为。tag 与 .octospec/rules/_index.yaml inject_when.touches 对齐。 -->
+
+- **wire-contract** — `Registry` manifest 加载 / `views` 结构 / schemaVersion 2:
+  新增 `views[].template` + `views[].samples` 解析;JSON-view 缺 `template` →
+  注册期 panic(与现有 v2-view 缺 reports 同为 fail-close)。
+- **wire-contract** — `Template` 接口不变:新增的是一个**实现**(`jsonTemplate`),
+  不是改接口签名;现有 5 张 Go 卡零影响,全部既有测试须继续绿。
+- **wire-contract / escape / trust-boundary** — `renderCore` + `cardmsg.Validate`:
+  JSON 通路展开出的 card 必须走**同一** `cardmsg.Validate`(组件白名单 / 上限 /
+  interaction 门 / URL 正向白名单)。**信任分界**:`.template.json` 是 L0 审查过的
+  可信制品;`${}` 代入的 **data 值是调用方不可信输入**,须与 Go 路径同规格做
+  markdown escape + rune 上限,`${detail}` / `${title}` 等不得成为注入面。
+- **wire-contract (C1)** — data.schema 校验:data 不过 `contract/data.schema.json`
+  → `ErrFieldsInvalid`(调用方翻 400,零投递),与现有 Go 卡 C1 一致;引擎不得在
+  schema 失败后仍做部分渲染。
+- **wire-contract** — `InteractionReport` / `ActionView`:推理卡**无 `Action.Submit`**
+  (仅本地 `Action.ToggleVisibility`),故**不涉及 owner/action_type/回调路由**。引擎仍须
+  self-check:模板里 `Action.ToggleVisibility` 的 `targetElements`(`trace_panel`/
+  `collapsed_panel`)在展开后的 card 里真实存在(防模板/report 漂移)。若将来注册**带
+  Submit 的 v2 JSON 卡**,才需接 `ActionContract` 派生 —— 本任务按 v1 toggle-only 实现,
+  但引擎的 report 加载/校验路径应对 Submit 视图保持兼容(不硬编码"无 Submit")。
+- **wire-contract** — `metadata.octo.{protocol,template,variant,source}` 注入仍是
+  `Registry.Render` 的职责(goldens **不含 metadata**,正好印证注入点在引擎之外)。
+- **wire-contract** — L1 冻结纪律(§2.1):`<id>@<ver>` 发布即冻结;JSON 制品同规矩,
+  引擎不得在运行期改写模板。
+
+## Out of scope
+
+<!-- 本任务刻意不碰的东西。 -->
+
+- **bot 流式下发通路(独立后续任务,非本任务)** —— 推理卡去掉 Submit 后是 **octo/v1
+  纯展示 + 本地折叠**卡,下发**无任何服务端回调**:退化为 memory `card_message_v2_web_gate`
+  里**已验证的"波 A"**——bot 发 v1 卡 + 流式 `edit`/`ReplaceView` 刷进度。下发侧仅剩
+  轻量 wiring(bot 侧渲染已注册卡的路径 + 主动 `ReplaceView` 暴露给 bot_api),
+  **无 owner / action_type / RouteSpec / `/v1/bot/events` 回调**。本任务只做"注册 +
+  渲染出正确 card",不接生产下发。
+- **进度更新用 `ReplaceView` 而非 `Append`** —— reasoning→answering→result 是同一
+  message_id 的整-view 重渲染(`ReplaceView`,#641 已有语义),**不走** Append 进度帧,
+  正好绕开 G10(Append 无生产调用者、`card_seq` 源未定)。接流式是上条的后续任务。
+- **多语言模板选择** —— 本 fixture 文案(`显示 / 隐藏推理` 等)**内嵌在 `.template.json`
+  字面量**里,`defaultLocale: zh-CN` 单语言。多 locale 模板/字符串表机制(与 G4 卡片
+  i18n 折叠相关)留后续,本任务只支持单 defaultLocale。
+- **迁移现有 Go 卡到 JSON** —— 5 张 Go 卡保持 Go 实现;本引擎是**增量并存**的第二通路,
+  不动 legacy。
+- **能力发现端点 B1/B2** —— 不 wire HTTP;`Registry.List()` 已在,端点另行。
+- **完整 ACT 规范** —— 只实现这批 handoff 实测用到的子集(见 Goal),不追 Microsoft
+  Adaptive Card Templating 全集(`$when` 复杂谓词、`$root`、`TemplateHost` 函数库等);
+  遇到子集外语法 → 注册期报错,不静默产出错卡。
+- **翻译/落地推理卡本身** —— 把 `ai.reasoning-process` 作为**产品卡**注册 + 应用"去
+  Submit、降 octo/v1"决策 + 波 A 下发,是**引擎之后的下游任务**,不在本任务。本任务
+  只把它的 handoff 当引擎的 conformance fixture(原样,验字节)。
+
+## Acceptance
+
+<!-- 尽量机读:测试 / 断言 / 可复现门禁。 -->
+
+- **goldens 一致性(核心验收)**:新增 conformance 测试,把 fixture
+  `ai.reasoning-process@0.1.0` 注册进临时 Registry;对每个 `samples/<s>.json`,
+  按其 `state` 解析 view、展开对应 `templates/<view>.template.json`,结果与
+  `goldens/<s>.card.json` **canonical-JSON 逐字节相等**(metadata 注入前的裸 card)。
+  5 个 sample(reasoning/answering/completed/stopped/error)全过。
+- **state→view 映射有据**:引擎从 `manifest.views[].states` 解析 state→view。
+  fixture 现未声明 `states` —— **实现期由本任务补齐 fixture manifest 的 `states`**
+  (reasoning/answering→active,completed/stopped→result,error→error;照
+  docs.access-request@0.3.0 的 views 写法),引擎侧不得靠 sample 文件名猜 view。
+- **模板 AST 注册期缓存**:进度卡一轮推理会**高频重渲染**(每帧多一段 phase)。
+  引擎须在**注册期**把 `.template.json` 解析成可复用 AST(与 InputSchema 编译同期),
+  运行期每帧只重新 bind data,不得每次重新 parse JSON;有基准/断言防止运行期 parse。
+- **注册期 fail-close**:JSON-mode view 缺 `template` 文件、模板含白名单外组件、
+  `ToggleVisibility` 目标 id 在模板里不存在、reports 与模板 action 漂移 → **注册期
+  panic / error**,不推迟到运行期。
+- **C1 零投递**:data 不过 `data.schema.json` → `ErrFieldsInvalid`;有独立单测覆盖
+  (缺必填 `reasoningId`、`traceExpanded`/`traceCollapsed` 违反 oneOf 互斥、error
+  态缺 `errorTitle`/`errorMessage`)。
+- **走同一 L0 关卡**:展开后的 card 过 `cardmsg.Validate`;构造一个"模板代入超长
+  `${detail}` / 含 markdown 元字符"的用例,断言输出被 escape + 截断到与 Go 路径
+  同一 rune 预算,且仍过 `Validate`(不是靠模板作者自觉)。
+- **`${}` 求值器单测**:字段绑定、嵌套路径、`$data`+`$index` 迭代、
+  `${if($index==0,'None','Large')}` 三元、类型化布尔绑定(`isVisible:"${traceExpanded}"`
+  → 真 `bool` 而非字符串)、字符串插值、缺字段行为(定义为 error 或空,二选一并测)。
+- **交互契约(v1 toggle-only)**:推理卡无 `Action.Submit` → 无 owner/action_type/回调
+  断言。仅断言 `Action.ToggleVisibility` 目标(`trace_panel`/`collapsed_panel`)
+  self-check 命中展开后 card 的 element id;manifest views `wireProfile` 为 `octo/v1`,
+  展开产物**不含任何 Submit/Input**(若含 → 注册期 fail-close)。
+- **零回归**:`go test ./pkg/cardtmpl/... ./modules/notify/...` 全绿;现有 5 张 Go 卡
+  的字节等价基线不变;`Registry.Freeze`/`Lookup`/`Render` 并发语义不变。
+- **门禁**:`gofmt` / `go vet` / 相关 `golangci-lint` 干净;若触及错误响应门面则
+  `make i18n-lint`(本任务预计不碰 errcode)。
+
+## Risks / decisions(确认阶段)
+
+**已定(实现期照做,非开放问题)**
+
+- **D1 · fixture 补 `states`** —— fixture manifest 缺 `views[].states`,由本任务补齐
+  (reasoning/answering→active,completed/stopped→result,error→error),不回制品作者。
+- **D2 · 无回调,与 C3/owner 彻底脱钩** —— 推理卡去掉 `停止`/`重试` 等 Submit
+  (产品决策 2026-07-23),仅留本地 `Action.ToggleVisibility`。故**无 owner /
+  action_type / RouteSpec / 回调**,与 C3(动态 owner)、L2b 通道无任何关系。views
+  全为 `octo/v1`。
+- **D5 · 引擎与卡片解耦:fixture 原样当 oracle,v1 变体属下游** —— 排序确定为
+  **引擎先行,再翻译/落地推理卡**。故本引擎任务的 conformance **以当前交付的 handoff
+  (v2、含 `reasoning_stop`/`reasoning_retry` Submit + toggle + `$data` + `${if}` + 样式)
+  原样为字节 oracle** —— 它覆盖的 ACT 面更全,正好把引擎验到底(引擎必须支持 Submit
+  模板,为将来 v2 JSON 卡留路)。**"去 Submit、降 octo/v1" 是"翻译推理卡"那步的产品
+  决策**(见下游任务),**不是引擎的前置**,不必为建引擎而重出 fixture。引擎对 v1/v2、
+  Submit/toggle 一律无关心,只做"任意合法 handoff → 其 goldens"。
+- **D3 · 求值器自研受控子集** —— `go.mod` 无 ACT 库、无现成 Go 实现;自研面小可审、
+  无第三方信任面,而非引未审计依赖。注册期解析成 AST 缓存(见 Acceptance 性能条)。
+- **D4 · ACT 子集冻结 + L0 演进** —— 以这 3 个模板实测语法冻结子集;子集外语法注册期
+  报错;扩子集走 L0 PR + 卡片发新版本(§2.1 冻结纪律)。
+- **D6 · 转义模型:引擎字面代入,`cardmsg.Validate` 兜底(spike 已证实)** —— goldens
+  由 Forge **字面代入**(`run_sql`/`funnel_definition.sql` 的下划线未转义);故引擎
+  **不做 markdown 转义**(否则破坏字节等价)。安全防线是 `cardmsg.Validate` —— 其正向
+  URL allowlist **覆盖 TextBlock markdown 链接**(`cardmsg.go:101`)+ 元素白名单 +
+  节点/深度上限,注入的坏链接/HTML/非白名单元素被拒整卡(调用方绕不过的边界,符合
+  trust-boundary)。仅装饰性 `*`/`_` 透传(agent 产出、低危)。jsontmpl 仍保留注入式
+  `EscapeFunc`(可测、未来某卡可 opt-in 转义),但推理卡及默认走 identity + Validate 兜底。
+
+**需你拍板 / 知悉**
+
+1. **排序确认:引擎先行,再翻译推理卡** —— 本任务 = 通用 JSON 引擎,拿当前 handoff
+   原样当 conformance oracle(v2 也无妨,覆盖面更全)。**翻译/落地推理卡另起下游任务**,
+   届时才应用"去 Submit、降 octo/v1"产品决策 + 注册 + 波 A 下发。请确认这个切分。
+2. **下发是独立后续任务(已大幅缩小)** —— 无回调后,下发 = bot 发 v1 卡 + 流式 edit,
+   走 memory 里已验证的"波 A",仅剩轻量 wiring。请确认下发另起任务这个切分。
+3. **客户端渲染:逐元素 feature-detect,非阻塞门** —— 客户端**已按 AC 渲染,且 v2 交互
+   都活**(2026-07-23 用户截图:`docs.access-request` 的 `Action.Submit` 允许/拒绝 +
+   头像/角标/FactSet 在客户端完整渲染)。推理卡是 **v1(展示 + 本地 toggle,无 Submit)**,
+   比 docs 卡还轻,渲染面完全被覆盖;唯一要 feature-detect 的是 `Action.ToggleVisibility`
+   + 容器 `style`/`bleed`(标准 AC 1.5),由 `GET /v1/bot/card/profile` 的
+   `elements`/`actions` 清单回答(`DisplayActions()` 已含 ToggleVisibility)。**不存在
+   "v2 全局渲染门"。** 若某客户端不认 toggle,按 profile 降级(默认展开、藏折叠按钮),
+   而非整卡不可交付。
+4. **多语言** —— fixture 文案内嵌模板字面量、单 `defaultLocale`。多 locale(与 G4 卡片
+   i18n 折叠同源)留后续,本任务只支持单 defaultLocale(见 Out of scope)。
+
+## 实现记录(2026-07-23)
+
+引擎已落地并全绿(`go test ./pkg/cardtmpl/... -race`,gofmt/vet 干净):
+
+- `pkg/cardtmpl/jsontmpl/`:ACT 求值器(`expr.go`)+ 展开器(`expand.go`),cover 86.1%。
+  子集 = 单标识符绑定 / `$index` / `if($index==N,a,b)` / 字符串插值 / 类型化整串绑定 /
+  `$data` 迭代;子集外语法 → error。
+- `pkg/cardtmpl/json_template.go`:通用 `jsonTemplate`(实现 `Template`+`metaSetter`,注册期
+  AST 缓存)+ `RegisterJSON(assets, root)`。`FallbackText` 复用 `cardmsg.BuildPlain`。
+- `render.go` D7:`DeepLink` 可选(空 → 跳过 https 校验 + 省略 `metadata.webUrl`);既有卡
+  一律带 DeepLink,行为不变(docs/summary conformance 全绿佐证)。
+- 验证:5 张推理 golden canonical 字节等价(`jsontmpl/conformance_test.go`);极简 v1 fixture
+  端到端过 renderCore + `cardmsg.Validate`;C1(schema 失败→ErrFieldsInvalid);D6 兜底
+  (注入 `javascript:` markdown 链接 → Validate 拒 → ErrRenderFailed);fail-close(缺 template
+  路径 → 注册期 panic)。
+
+**诊断发现(交下游"翻译推理卡"任务)**:as-delivered 推理 handoff 现**无法原样注册**——
+其 reports 按 **state 命名**(`reasoning/answering/….interaction.json`),而 Registry 约定按
+**view 命名**(`active.interaction.json`)。去 Submit 降 v1 后 v1 视图**根本不需要 reports**,
+此错配自然消解(与 D5 一致)。
+
+**延后(非阻断,honest)**:
+- **ToggleVisibility 目标 id 存在性 self-check** —— brief Acceptance 列了但本次未做。
+  理由:悬空 toggle 目标是"按钮点了没反应"的低危展示问题(非安全),且 `cardmsg.Validate`
+  已挡结构性问题;极简 v1 fixture 未用 toggle。留作 hardening follow-up(需遍历展开后 card
+  收集 id vs toggle targetElements)。
+- 推理卡作为**产品卡**注册 + 波 A 下发 = 下游"翻译推理卡"任务(见 Out of scope)。

--- a/.octospec/tasks/cardtmpl-json-template-engine/context.yaml
+++ b/.octospec/tasks/cardtmpl-json-template-engine/context.yaml
@@ -1,0 +1,11 @@
+injected:
+  - id: trust-boundary
+    source: repo
+    why: 引擎把调用方不可信 data 绑进 .template.json 叶子文本/URL；须在渲染边界转义（复用 escapeMarkdown/truncateRunes/AbsoluteHTTPSURL），模板作者文本可信不转义，data 代入值转义；结构限界 + URL 百分号编码；cardmsg.Validate 作 L0 兜底。
+  - id: error-handling
+    source: repo
+    why: 引擎返 typed error（ErrFieldsInvalid→400 零投递 / ErrRenderFailed→500 / ErrTemplateUnknown），由下游 caller 翻译；引擎本身不写 HTTP 响应，不直接碰 httperr（下游 send.go 才 httperr.ResponseErrorL）。
+  - id: testing
+    source: repo
+    why: TDD；纯 pkg/cardtmpl 单测不依赖 MySQL/Redis（Registry/Render 是内存态）；表驱动 + goldens 字节对照 + -race。
+brief: .octospec/tasks/cardtmpl-json-template-engine/brief.md

--- a/.octospec/tasks/cardtmpl-json-template-engine/fixtures/ai.reasoning-process@0.1.0/README.md
+++ b/.octospec/tasks/cardtmpl-json-template-engine/fixtures/ai.reasoning-process@0.1.0/README.md
@@ -1,0 +1,8 @@
+# 推理过程卡 backend handoff
+
+- Card: `ai.reasoning-process@0.1.0`
+- Contract: `1.0.0`
+- Adaptive Card: `1.5`
+- Render Profile: `octo-chat@latest → octo-chat@1.2.0-rc.1`
+
+Use `contract/data.schema.json` to map backend data. The `goldens/` directory contains expected compiled Card JSON for each sample. The `reports/` directory documents standard Action/Input/Toggle behavior.

--- a/.octospec/tasks/cardtmpl-json-template-engine/fixtures/ai.reasoning-process@0.1.0/contract/data.schema.json
+++ b/.octospec/tasks/cardtmpl-json-template-engine/fixtures/ai.reasoning-process@0.1.0/contract/data.schema.json
@@ -1,0 +1,241 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "推理过程卡数据契约",
+  "description": "AI 推理过程附件的展示型 ViewModel。消息作者、头像、时间与最终 Markdown 回答由消息容器负责，不进入卡片契约。",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "reasoningId",
+    "state",
+    "title",
+    "statusLabel",
+    "statusTone",
+    "timerText",
+    "traceExpanded",
+    "traceCollapsed",
+    "collapsedSummary",
+    "phases"
+  ],
+  "properties": {
+    "reasoningId": {
+      "type": "string",
+      "minLength": 1,
+      "description": "本轮推理的稳定标识，会随停止或重试动作回传。",
+      "examples": [
+        "reasoning-channel-b-001"
+      ]
+    },
+    "state": {
+      "type": "string",
+      "enum": [
+        "reasoning",
+        "answering",
+        "completed",
+        "stopped",
+        "error"
+      ],
+      "description": "卡片当前状态；宿主据此选择 active、result 或 error View。"
+    },
+    "title": {
+      "type": "string",
+      "minLength": 1,
+      "description": "推理卡标题。",
+      "examples": [
+        "已深度思考"
+      ]
+    },
+    "statusLabel": {
+      "type": "string",
+      "minLength": 1,
+      "description": "面向用户的状态文案。"
+    },
+    "statusTone": {
+      "type": "string",
+      "enum": [
+        "Accent",
+        "Good",
+        "Warning",
+        "Attention"
+      ],
+      "description": "Adaptive Cards 标准语义色。"
+    },
+    "timerText": {
+      "type": "string",
+      "minLength": 1,
+      "description": "耗时、阶段数和工具调用数的展示文案。"
+    },
+    "traceExpanded": {
+      "type": "boolean",
+      "description": "初始是否展示推理明细。"
+    },
+    "traceCollapsed": {
+      "type": "boolean",
+      "description": "初始是否展示收起摘要；应与 traceExpanded 互斥。"
+    },
+    "collapsedSummary": {
+      "type": "string",
+      "minLength": 1,
+      "description": "推理明细收起时的摘要。"
+    },
+    "progressText": {
+      "type": "string",
+      "minLength": 1,
+      "description": "活动态底部的实时进度提示。"
+    },
+    "phases": {
+      "type": "array",
+      "minItems": 1,
+      "description": "按发生顺序排列的推理阶段。仅包含可向用户展示的过程摘要，不承载隐藏的模型内部思维。",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "thought",
+          "actions"
+        ],
+        "properties": {
+          "thought": {
+            "type": "string",
+            "minLength": 1,
+            "description": "该阶段面向用户的推理摘要。"
+          },
+          "actions": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "tool",
+                "detail",
+                "statusGlyph",
+                "statusTone"
+              ],
+              "properties": {
+                "tool": {
+                  "type": "string",
+                  "minLength": 1,
+                  "description": "工具或步骤名称。"
+                },
+                "detail": {
+                  "type": "string",
+                  "minLength": 1,
+                  "description": "已脱敏的调用摘要。"
+                },
+                "statusGlyph": {
+                  "type": "string",
+                  "minLength": 1,
+                  "maxLength": 2,
+                  "description": "调用状态符号，例如 ●。"
+                },
+                "statusTone": {
+                  "type": "string",
+                  "enum": [
+                    "Accent",
+                    "Good",
+                    "Attention"
+                  ],
+                  "description": "工具调用状态的标准语义色。"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "errorTitle": {
+      "type": "string",
+      "minLength": 1,
+      "description": "失败态标题。"
+    },
+    "errorMessage": {
+      "type": "string",
+      "minLength": 1,
+      "description": "失败原因与用户可采取动作。"
+    }
+  },
+  "allOf": [
+    {
+      "oneOf": [
+        {
+          "properties": {
+            "traceExpanded": {
+              "const": true
+            },
+            "traceCollapsed": {
+              "const": false
+            }
+          }
+        },
+        {
+          "properties": {
+            "traceExpanded": {
+              "const": false
+            },
+            "traceCollapsed": {
+              "const": true
+            }
+          }
+        }
+      ]
+    },
+    {
+      "if": {
+        "properties": {
+          "state": {
+            "enum": [
+              "reasoning",
+              "answering"
+            ]
+          }
+        }
+      },
+      "then": {
+        "required": [
+          "progressText"
+        ]
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "state": {
+            "const": "error"
+          }
+        }
+      },
+      "then": {
+        "required": [
+          "errorTitle",
+          "errorMessage"
+        ]
+      }
+    }
+  ],
+  "examples": [
+    {
+      "reasoningId": "reasoning-channel-b-001",
+      "state": "completed",
+      "title": "已深度思考",
+      "statusLabel": "已完成",
+      "statusTone": "Good",
+      "timerText": "用时 12 秒 · 3 段推理 · 13 次工具调用",
+      "traceExpanded": false,
+      "traceCollapsed": true,
+      "collapsedSummary": "已思考 12 秒 · 推理过程已收起",
+      "phases": [
+        {
+          "thought": "先拆解漏斗并核对近 90 天数据。",
+          "actions": [
+            {
+              "tool": "query_metrics",
+              "detail": "channel=B · range=90d",
+              "statusGlyph": "●",
+              "statusTone": "Good"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/.octospec/tasks/cardtmpl-json-template-engine/fixtures/ai.reasoning-process@0.1.0/goldens/answering.card.json
+++ b/.octospec/tasks/cardtmpl-json-template-engine/fixtures/ai.reasoning-process@0.1.0/goldens/answering.card.json
@@ -1,0 +1,694 @@
+{
+  "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+  "type": "AdaptiveCard",
+  "version": "1.5",
+  "body": [
+    {
+      "type": "Container",
+      "id": "octo-surface-accent-header-reasoning-active",
+      "style": "accent",
+      "bleed": true,
+      "spacing": "None",
+      "items": [
+        {
+          "type": "ColumnSet",
+          "spacing": "None",
+          "columns": [
+            {
+              "type": "Column",
+              "width": "stretch",
+              "verticalContentAlignment": "Center",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "text": "✦  已深度思考",
+                  "color": "Accent",
+                  "weight": "Bolder",
+                  "wrap": true,
+                  "spacing": "None"
+                },
+                {
+                  "type": "TextBlock",
+                  "text": "正在生成回答…",
+                  "size": "Small",
+                  "isSubtle": true,
+                  "wrap": true,
+                  "spacing": "Small"
+                }
+              ]
+            },
+            {
+              "type": "Column",
+              "width": "auto",
+              "verticalContentAlignment": "Center",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "id": "octo-badge-reasoning-active-status",
+                  "text": "回答中",
+                  "color": "Accent",
+                  "weight": "Bolder",
+                  "size": "Small",
+                  "wrap": true,
+                  "spacing": "None"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "id": "trace_panel",
+      "isVisible": true,
+      "spacing": "Large",
+      "items": [
+        {
+          "type": "Container",
+          "spacing": "None",
+          "separator": false,
+          "items": [
+            {
+              "type": "TextBlock",
+              "text": "先拆分线索、试用激活与付费三段漏斗，核对近 90 天数据。",
+              "size": "Small",
+              "wrap": true,
+              "spacing": "None"
+            },
+            {
+              "type": "Container",
+              "style": "emphasis",
+              "spacing": "Small",
+              "items": [
+                {
+                  "type": "ColumnSet",
+                  "spacing": "None",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "query_metrics",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "channel=B · range=90d · group=stage",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "read_file",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "~/analytics/funnel_definition.sql · ×2",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "run_sql",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "按漏斗阶段汇总数量与转化率",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "Container",
+          "spacing": "Large",
+          "separator": true,
+          "items": [
+            {
+              "type": "TextBlock",
+              "text": "激活率的降幅高于线索量，交叉核验行业结构、客服工单、NPS 与季节性。",
+              "size": "Small",
+              "wrap": true,
+              "spacing": "None"
+            },
+            {
+              "type": "Container",
+              "style": "emphasis",
+              "spacing": "Small",
+              "items": [
+                {
+                  "type": "ColumnSet",
+                  "spacing": "None",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "query_metrics",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "按行业拆分激活率",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "search_tickets",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "渠道 B · 试用 / 激活失败 · 近 60 天",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "read_file",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "~/nps/2026Q2_channelB.csv",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "query_metrics",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "叠加节假日与季节性校正",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "Container",
+          "spacing": "Large",
+          "separator": true,
+          "items": [
+            {
+              "type": "TextBlock",
+              "text": "主因确认：教育与专业服务合计贡献 63% 降幅，激活断点集中在试用权益触达。",
+              "size": "Small",
+              "wrap": true,
+              "spacing": "None"
+            },
+            {
+              "type": "Container",
+              "style": "emphasis",
+              "spacing": "Small",
+              "items": [
+                {
+                  "type": "ColumnSet",
+                  "spacing": "None",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "run_sql",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "按行业汇总转化降幅贡献",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "edit_file",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "~/reports/channelB_rootcause.md · 已编辑",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Accent",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "think",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "正在组织结论、证据与下周建议…",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "TextBlock",
+          "text": "◌  推理已完成，正在生成回答…",
+          "color": "Accent",
+          "size": "Small",
+          "wrap": true,
+          "spacing": "Large"
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "id": "collapsed_panel",
+      "isVisible": false,
+      "spacing": "Medium",
+      "items": [
+        {
+          "type": "TextBlock",
+          "text": "✓  推理已完成 · 回答正在生成",
+          "size": "Small",
+          "isSubtle": true,
+          "wrap": true,
+          "spacing": "None"
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "id": "octo-surface-default-footer-reasoning-active",
+      "style": "emphasis",
+      "bleed": true,
+      "separator": true,
+      "spacing": "Large",
+      "items": [
+        {
+          "type": "ActionSet",
+          "horizontalAlignment": "Right",
+          "actions": [
+            {
+              "type": "Action.Submit",
+              "id": "reasoning_stop",
+              "title": "停止",
+              "style": "destructive",
+              "associatedInputs": "none",
+              "data": {
+                "action": "reasoning_stop",
+                "effect": "stop_reasoning",
+                "reasoning_id": "reasoning-channel-b-001"
+              }
+            },
+            {
+              "type": "Action.ToggleVisibility",
+              "id": "reasoning_toggle",
+              "title": "显示 / 隐藏推理",
+              "targetElements": [
+                "trace_panel",
+                "collapsed_panel"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/.octospec/tasks/cardtmpl-json-template-engine/fixtures/ai.reasoning-process@0.1.0/goldens/completed.card.json
+++ b/.octospec/tasks/cardtmpl-json-template-engine/fixtures/ai.reasoning-process@0.1.0/goldens/completed.card.json
@@ -1,0 +1,784 @@
+{
+  "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+  "type": "AdaptiveCard",
+  "version": "1.5",
+  "body": [
+    {
+      "type": "Container",
+      "id": "octo-surface-accent-header-reasoning-result",
+      "style": "accent",
+      "bleed": true,
+      "spacing": "None",
+      "items": [
+        {
+          "type": "ColumnSet",
+          "spacing": "None",
+          "columns": [
+            {
+              "type": "Column",
+              "width": "stretch",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "text": "✦  已深度思考",
+                  "color": "Accent",
+                  "weight": "Bolder",
+                  "wrap": true,
+                  "spacing": "None"
+                },
+                {
+                  "type": "TextBlock",
+                  "text": "用时 12 秒 · 3 段推理 · 13 次工具调用",
+                  "size": "Small",
+                  "isSubtle": true,
+                  "wrap": true,
+                  "spacing": "Small"
+                }
+              ]
+            },
+            {
+              "type": "Column",
+              "width": "auto",
+              "verticalContentAlignment": "Center",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "id": "octo-badge-reasoning-result-status",
+                  "text": "已完成",
+                  "color": "Good",
+                  "weight": "Bolder",
+                  "size": "Small",
+                  "wrap": true,
+                  "spacing": "None"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "id": "trace_panel",
+      "isVisible": false,
+      "spacing": "Large",
+      "items": [
+        {
+          "type": "Container",
+          "spacing": "None",
+          "separator": false,
+          "items": [
+            {
+              "type": "TextBlock",
+              "text": "先把渠道 B 转化下降的范围圈出来：拆成线索、试用激活、付费三段漏斗，取近 90 天数据。",
+              "size": "Small",
+              "wrap": true,
+              "spacing": "None"
+            },
+            {
+              "type": "Container",
+              "style": "emphasis",
+              "spacing": "Small",
+              "items": [
+                {
+                  "type": "ColumnSet",
+                  "spacing": "None",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "query_metrics",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "channel=B · range=90d · group=stage",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "read_file",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "~/analytics/funnel_definition.sql · ×2",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "run_sql",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "按漏斗阶段汇总数量与转化率",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "Container",
+          "spacing": "Large",
+          "separator": true,
+          "items": [
+            {
+              "type": "TextBlock",
+              "text": "激活率的降幅高于线索量，交叉核验行业结构、客服工单、NPS 与季节性。",
+              "size": "Small",
+              "wrap": true,
+              "spacing": "None"
+            },
+            {
+              "type": "Container",
+              "style": "emphasis",
+              "spacing": "Small",
+              "items": [
+                {
+                  "type": "ColumnSet",
+                  "spacing": "None",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "query_metrics",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "按行业拆分激活率",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "run_sql",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "对比各行业激活与付费转化",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "search_tickets",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "渠道 B · 试用 / 激活失败 · 近 60 天",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "read_file",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "~/nps/2026Q2_channelB.csv",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "query_metrics",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "叠加节假日与季节性校正",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "run_sql",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "逐周复核线索与激活数量",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "web_search",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "SaaS 行业 2026 试用政策调整",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "Container",
+          "spacing": "Large",
+          "separator": true,
+          "items": [
+            {
+              "type": "TextBlock",
+              "text": "主因确认：教育与专业服务合计贡献 63% 降幅，激活断点集中在试用权益触达。",
+              "size": "Small",
+              "wrap": true,
+              "spacing": "None"
+            },
+            {
+              "type": "Container",
+              "style": "emphasis",
+              "spacing": "Small",
+              "items": [
+                {
+                  "type": "ColumnSet",
+                  "spacing": "None",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "run_sql",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "按行业汇总转化降幅贡献",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "edit_file",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "~/reports/channelB_rootcause.md · 已编辑",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "think",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "拆分行业漏斗深挖与权益触达复盘",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "id": "collapsed_panel",
+      "isVisible": true,
+      "spacing": "Medium",
+      "items": [
+        {
+          "type": "TextBlock",
+          "text": "✓  已思考 12 秒 · 推理过程已收起",
+          "size": "Small",
+          "isSubtle": true,
+          "wrap": true,
+          "spacing": "None"
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "id": "octo-surface-default-footer-reasoning-result",
+      "style": "emphasis",
+      "bleed": true,
+      "separator": true,
+      "spacing": "Large",
+      "items": [
+        {
+          "type": "ActionSet",
+          "horizontalAlignment": "Right",
+          "actions": [
+            {
+              "type": "Action.ToggleVisibility",
+              "id": "reasoning_toggle",
+              "title": "显示 / 隐藏推理",
+              "targetElements": [
+                "trace_panel",
+                "collapsed_panel"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/.octospec/tasks/cardtmpl-json-template-engine/fixtures/ai.reasoning-process@0.1.0/goldens/error.card.json
+++ b/.octospec/tasks/cardtmpl-json-template-engine/fixtures/ai.reasoning-process@0.1.0/goldens/error.card.json
@@ -1,0 +1,420 @@
+{
+  "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+  "type": "AdaptiveCard",
+  "version": "1.5",
+  "body": [
+    {
+      "type": "Container",
+      "id": "octo-surface-accent-header-reasoning-error",
+      "style": "accent",
+      "bleed": true,
+      "spacing": "None",
+      "items": [
+        {
+          "type": "ColumnSet",
+          "spacing": "None",
+          "columns": [
+            {
+              "type": "Column",
+              "width": "stretch",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "text": "✦  已深度思考",
+                  "color": "Accent",
+                  "weight": "Bolder",
+                  "wrap": true,
+                  "spacing": "None"
+                },
+                {
+                  "type": "TextBlock",
+                  "text": "已中断",
+                  "size": "Small",
+                  "isSubtle": true,
+                  "wrap": true,
+                  "spacing": "Small"
+                }
+              ]
+            },
+            {
+              "type": "Column",
+              "width": "auto",
+              "verticalContentAlignment": "Center",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "id": "octo-badge-reasoning-error-status",
+                  "text": "生成失败",
+                  "color": "Attention",
+                  "weight": "Bolder",
+                  "size": "Small",
+                  "wrap": true,
+                  "spacing": "None"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "id": "trace_panel",
+      "isVisible": true,
+      "spacing": "Large",
+      "items": [
+        {
+          "type": "Container",
+          "spacing": "None",
+          "separator": false,
+          "items": [
+            {
+              "type": "TextBlock",
+              "text": "先拆分线索、试用激活与付费三段漏斗，核对近 90 天数据。",
+              "size": "Small",
+              "wrap": true,
+              "spacing": "None"
+            },
+            {
+              "type": "Container",
+              "style": "emphasis",
+              "spacing": "Small",
+              "items": [
+                {
+                  "type": "ColumnSet",
+                  "spacing": "None",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "query_metrics",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "channel=B · range=90d · group=stage",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "read_file",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "~/analytics/funnel_definition.sql · ×2",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "run_sql",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "按漏斗阶段汇总数量与转化率",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "Container",
+          "spacing": "Large",
+          "separator": true,
+          "items": [
+            {
+              "type": "TextBlock",
+              "text": "准备交叉核验行业结构、客服工单与 NPS 时，推理服务连接中断。",
+              "size": "Small",
+              "wrap": true,
+              "spacing": "None"
+            },
+            {
+              "type": "Container",
+              "style": "emphasis",
+              "spacing": "Small",
+              "items": [
+                {
+                  "type": "ColumnSet",
+                  "spacing": "None",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "query_metrics",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "按行业拆分激活率",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Attention",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "search_tickets",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "连接超时，调用未完成",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "id": "collapsed_panel",
+      "isVisible": false,
+      "spacing": "Medium",
+      "items": [
+        {
+          "type": "TextBlock",
+          "text": "生成已中断 · 点击可查看停止前的过程",
+          "size": "Small",
+          "isSubtle": true,
+          "wrap": true,
+          "spacing": "None"
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "style": "attention",
+      "spacing": "Large",
+      "items": [
+        {
+          "type": "TextBlock",
+          "text": "生成失败",
+          "color": "Attention",
+          "weight": "Bolder",
+          "wrap": true,
+          "spacing": "None"
+        },
+        {
+          "type": "TextBlock",
+          "text": "推理服务连接超时，已停止本次生成。可以重试，已完成的过程会保留。",
+          "wrap": true,
+          "spacing": "Small"
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "id": "octo-surface-default-footer-reasoning-error",
+      "style": "emphasis",
+      "bleed": true,
+      "separator": true,
+      "spacing": "Large",
+      "items": [
+        {
+          "type": "ActionSet",
+          "horizontalAlignment": "Right",
+          "actions": [
+            {
+              "type": "Action.Submit",
+              "id": "reasoning_retry",
+              "title": "重试",
+              "style": "positive",
+              "associatedInputs": "none",
+              "data": {
+                "action": "reasoning_retry",
+                "effect": "retry_reasoning",
+                "reasoning_id": "reasoning-channel-b-003"
+              }
+            },
+            {
+              "type": "Action.ToggleVisibility",
+              "id": "reasoning_toggle",
+              "title": "显示 / 隐藏推理",
+              "targetElements": [
+                "trace_panel",
+                "collapsed_panel"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/.octospec/tasks/cardtmpl-json-template-engine/fixtures/ai.reasoning-process@0.1.0/goldens/reasoning.card.json
+++ b/.octospec/tasks/cardtmpl-json-template-engine/fixtures/ai.reasoning-process@0.1.0/goldens/reasoning.card.json
@@ -1,0 +1,523 @@
+{
+  "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+  "type": "AdaptiveCard",
+  "version": "1.5",
+  "body": [
+    {
+      "type": "Container",
+      "id": "octo-surface-accent-header-reasoning-active",
+      "style": "accent",
+      "bleed": true,
+      "spacing": "None",
+      "items": [
+        {
+          "type": "ColumnSet",
+          "spacing": "None",
+          "columns": [
+            {
+              "type": "Column",
+              "width": "stretch",
+              "verticalContentAlignment": "Center",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "text": "✦  已深度思考",
+                  "color": "Accent",
+                  "weight": "Bolder",
+                  "wrap": true,
+                  "spacing": "None"
+                },
+                {
+                  "type": "TextBlock",
+                  "text": "正在深度思考…",
+                  "size": "Small",
+                  "isSubtle": true,
+                  "wrap": true,
+                  "spacing": "Small"
+                }
+              ]
+            },
+            {
+              "type": "Column",
+              "width": "auto",
+              "verticalContentAlignment": "Center",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "id": "octo-badge-reasoning-active-status",
+                  "text": "思考中",
+                  "color": "Accent",
+                  "weight": "Bolder",
+                  "size": "Small",
+                  "wrap": true,
+                  "spacing": "None"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "id": "trace_panel",
+      "isVisible": true,
+      "spacing": "Large",
+      "items": [
+        {
+          "type": "Container",
+          "spacing": "None",
+          "separator": false,
+          "items": [
+            {
+              "type": "TextBlock",
+              "text": "先把渠道 B 转化下降的范围圈出来：拆成线索、试用激活、付费三段漏斗，取近 90 天数据。",
+              "size": "Small",
+              "wrap": true,
+              "spacing": "None"
+            },
+            {
+              "type": "Container",
+              "style": "emphasis",
+              "spacing": "Small",
+              "items": [
+                {
+                  "type": "ColumnSet",
+                  "spacing": "None",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "query_metrics",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "channel=B · range=90d · group=stage",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "read_file",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "~/analytics/funnel_definition.sql · ×2",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "run_sql",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "按漏斗阶段汇总数量与转化率",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "Container",
+          "spacing": "Large",
+          "separator": true,
+          "items": [
+            {
+              "type": "TextBlock",
+              "text": "口径正常，但激活率掉得比线索量快；继续拉行业标签、客服工单和 NPS 交叉验证。",
+              "size": "Small",
+              "wrap": true,
+              "spacing": "None"
+            },
+            {
+              "type": "Container",
+              "style": "emphasis",
+              "spacing": "Small",
+              "items": [
+                {
+                  "type": "ColumnSet",
+                  "spacing": "None",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "query_metrics",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "channel=B · dims=industry · metric=activation_rate",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "search_tickets",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "渠道 B · 试用 / 激活失败 · 近 60 天",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "read_file",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "~/nps/2026Q2_channelB.csv",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Accent",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "query_metrics",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "正在叠加季节性校正…",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "TextBlock",
+          "text": "◌  正在执行下一步…",
+          "color": "Accent",
+          "size": "Small",
+          "wrap": true,
+          "spacing": "Large"
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "id": "collapsed_panel",
+      "isVisible": false,
+      "spacing": "Medium",
+      "items": [
+        {
+          "type": "TextBlock",
+          "text": "✓  推理仍在进行 · 点击可查看当前过程",
+          "size": "Small",
+          "isSubtle": true,
+          "wrap": true,
+          "spacing": "None"
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "id": "octo-surface-default-footer-reasoning-active",
+      "style": "emphasis",
+      "bleed": true,
+      "separator": true,
+      "spacing": "Large",
+      "items": [
+        {
+          "type": "ActionSet",
+          "horizontalAlignment": "Right",
+          "actions": [
+            {
+              "type": "Action.Submit",
+              "id": "reasoning_stop",
+              "title": "停止",
+              "style": "destructive",
+              "associatedInputs": "none",
+              "data": {
+                "action": "reasoning_stop",
+                "effect": "stop_reasoning",
+                "reasoning_id": "reasoning-channel-b-001"
+              }
+            },
+            {
+              "type": "Action.ToggleVisibility",
+              "id": "reasoning_toggle",
+              "title": "显示 / 隐藏推理",
+              "targetElements": [
+                "trace_panel",
+                "collapsed_panel"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/.octospec/tasks/cardtmpl-json-template-engine/fixtures/ai.reasoning-process@0.1.0/goldens/stopped.card.json
+++ b/.octospec/tasks/cardtmpl-json-template-engine/fixtures/ai.reasoning-process@0.1.0/goldens/stopped.card.json
@@ -1,0 +1,387 @@
+{
+  "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+  "type": "AdaptiveCard",
+  "version": "1.5",
+  "body": [
+    {
+      "type": "Container",
+      "id": "octo-surface-accent-header-reasoning-result",
+      "style": "accent",
+      "bleed": true,
+      "spacing": "None",
+      "items": [
+        {
+          "type": "ColumnSet",
+          "spacing": "None",
+          "columns": [
+            {
+              "type": "Column",
+              "width": "stretch",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "text": "✦  已深度思考",
+                  "color": "Accent",
+                  "weight": "Bolder",
+                  "wrap": true,
+                  "spacing": "None"
+                },
+                {
+                  "type": "TextBlock",
+                  "text": "已思考 6 秒 · 已停止于第 2 段",
+                  "size": "Small",
+                  "isSubtle": true,
+                  "wrap": true,
+                  "spacing": "Small"
+                }
+              ]
+            },
+            {
+              "type": "Column",
+              "width": "auto",
+              "verticalContentAlignment": "Center",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "id": "octo-badge-reasoning-result-status",
+                  "text": "已停止",
+                  "color": "Warning",
+                  "weight": "Bolder",
+                  "size": "Small",
+                  "wrap": true,
+                  "spacing": "None"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "id": "trace_panel",
+      "isVisible": false,
+      "spacing": "Large",
+      "items": [
+        {
+          "type": "Container",
+          "spacing": "None",
+          "separator": false,
+          "items": [
+            {
+              "type": "TextBlock",
+              "text": "先拆分线索、试用激活与付费三段漏斗，核对近 90 天数据。",
+              "size": "Small",
+              "wrap": true,
+              "spacing": "None"
+            },
+            {
+              "type": "Container",
+              "style": "emphasis",
+              "spacing": "Small",
+              "items": [
+                {
+                  "type": "ColumnSet",
+                  "spacing": "None",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "query_metrics",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "channel=B · range=90d · group=stage",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "read_file",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "~/analytics/funnel_definition.sql · ×2",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "run_sql",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "按漏斗阶段汇总数量与转化率",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "Container",
+          "spacing": "Large",
+          "separator": true,
+          "items": [
+            {
+              "type": "TextBlock",
+              "text": "激活率降幅高于线索量，开始按行业与试用权益触达交叉核验。",
+              "size": "Small",
+              "wrap": true,
+              "spacing": "None"
+            },
+            {
+              "type": "Container",
+              "style": "emphasis",
+              "spacing": "Small",
+              "items": [
+                {
+                  "type": "ColumnSet",
+                  "spacing": "None",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "query_metrics",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "按行业拆分激活率",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Accent",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "search_tickets",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "调用已由用户停止",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "id": "collapsed_panel",
+      "isVisible": true,
+      "spacing": "Medium",
+      "items": [
+        {
+          "type": "TextBlock",
+          "text": "✓  已保留停止前的 2 段推理过程",
+          "size": "Small",
+          "isSubtle": true,
+          "wrap": true,
+          "spacing": "None"
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "id": "octo-surface-default-footer-reasoning-result",
+      "style": "emphasis",
+      "bleed": true,
+      "separator": true,
+      "spacing": "Large",
+      "items": [
+        {
+          "type": "ActionSet",
+          "horizontalAlignment": "Right",
+          "actions": [
+            {
+              "type": "Action.ToggleVisibility",
+              "id": "reasoning_toggle",
+              "title": "显示 / 隐藏推理",
+              "targetElements": [
+                "trace_panel",
+                "collapsed_panel"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/.octospec/tasks/cardtmpl-json-template-engine/fixtures/ai.reasoning-process@0.1.0/manifest.json
+++ b/.octospec/tasks/cardtmpl-json-template-engine/fixtures/ai.reasoning-process@0.1.0/manifest.json
@@ -1,0 +1,36 @@
+{
+  "schemaVersion": 2,
+  "id": "ai.reasoning-process",
+  "name": "推理过程卡",
+  "version": "0.1.0",
+  "contractVersion": "1.0.0",
+  "adaptiveCardVersion": "1.5",
+  "renderProfile": "octo-chat@latest",
+  "defaultLocale": "zh-CN",
+  "dataSchema": "contract/data.schema.json",
+  "views": {
+    "active": {
+      "wireProfile": "octo/v2",
+      "template": "templates/active.template.json",
+      "samples": [
+        "samples/reasoning.json",
+        "samples/answering.json"
+      ]
+    },
+    "result": {
+      "wireProfile": "octo/v2",
+      "template": "templates/result.template.json",
+      "samples": [
+        "samples/completed.json",
+        "samples/stopped.json"
+      ]
+    },
+    "error": {
+      "wireProfile": "octo/v2",
+      "template": "templates/error.template.json",
+      "samples": [
+        "samples/error.json"
+      ]
+    }
+  }
+}

--- a/.octospec/tasks/cardtmpl-json-template-engine/fixtures/ai.reasoning-process@0.1.0/reports/answering.interaction.json
+++ b/.octospec/tasks/cardtmpl-json-template-engine/fixtures/ai.reasoning-process@0.1.0/reports/answering.interaction.json
@@ -1,0 +1,35 @@
+{
+  "actions": [
+    {
+      "path": "$.body[3].items[0].actions[0]",
+      "type": "Action.Submit",
+      "id": "reasoning_stop",
+      "associatedInputs": "none",
+      "dataKeys": [
+        "action",
+        "effect",
+        "reasoning_id"
+      ],
+      "inputIds": []
+    },
+    {
+      "path": "$.body[3].items[0].actions[1]",
+      "type": "Action.ToggleVisibility",
+      "id": "reasoning_toggle"
+    }
+  ],
+  "inputs": [],
+  "toggles": [
+    {
+      "path": "$.body[3].items[0].actions[1]",
+      "targets": [
+        {
+          "elementId": "trace_panel"
+        },
+        {
+          "elementId": "collapsed_panel"
+        }
+      ]
+    }
+  ]
+}

--- a/.octospec/tasks/cardtmpl-json-template-engine/fixtures/ai.reasoning-process@0.1.0/reports/completed.interaction.json
+++ b/.octospec/tasks/cardtmpl-json-template-engine/fixtures/ai.reasoning-process@0.1.0/reports/completed.interaction.json
@@ -1,0 +1,23 @@
+{
+  "actions": [
+    {
+      "path": "$.body[3].items[0].actions[0]",
+      "type": "Action.ToggleVisibility",
+      "id": "reasoning_toggle"
+    }
+  ],
+  "inputs": [],
+  "toggles": [
+    {
+      "path": "$.body[3].items[0].actions[0]",
+      "targets": [
+        {
+          "elementId": "trace_panel"
+        },
+        {
+          "elementId": "collapsed_panel"
+        }
+      ]
+    }
+  ]
+}

--- a/.octospec/tasks/cardtmpl-json-template-engine/fixtures/ai.reasoning-process@0.1.0/reports/error.interaction.json
+++ b/.octospec/tasks/cardtmpl-json-template-engine/fixtures/ai.reasoning-process@0.1.0/reports/error.interaction.json
@@ -1,0 +1,35 @@
+{
+  "actions": [
+    {
+      "path": "$.body[4].items[0].actions[0]",
+      "type": "Action.Submit",
+      "id": "reasoning_retry",
+      "associatedInputs": "none",
+      "dataKeys": [
+        "action",
+        "effect",
+        "reasoning_id"
+      ],
+      "inputIds": []
+    },
+    {
+      "path": "$.body[4].items[0].actions[1]",
+      "type": "Action.ToggleVisibility",
+      "id": "reasoning_toggle"
+    }
+  ],
+  "inputs": [],
+  "toggles": [
+    {
+      "path": "$.body[4].items[0].actions[1]",
+      "targets": [
+        {
+          "elementId": "trace_panel"
+        },
+        {
+          "elementId": "collapsed_panel"
+        }
+      ]
+    }
+  ]
+}

--- a/.octospec/tasks/cardtmpl-json-template-engine/fixtures/ai.reasoning-process@0.1.0/reports/reasoning.interaction.json
+++ b/.octospec/tasks/cardtmpl-json-template-engine/fixtures/ai.reasoning-process@0.1.0/reports/reasoning.interaction.json
@@ -1,0 +1,35 @@
+{
+  "actions": [
+    {
+      "path": "$.body[3].items[0].actions[0]",
+      "type": "Action.Submit",
+      "id": "reasoning_stop",
+      "associatedInputs": "none",
+      "dataKeys": [
+        "action",
+        "effect",
+        "reasoning_id"
+      ],
+      "inputIds": []
+    },
+    {
+      "path": "$.body[3].items[0].actions[1]",
+      "type": "Action.ToggleVisibility",
+      "id": "reasoning_toggle"
+    }
+  ],
+  "inputs": [],
+  "toggles": [
+    {
+      "path": "$.body[3].items[0].actions[1]",
+      "targets": [
+        {
+          "elementId": "trace_panel"
+        },
+        {
+          "elementId": "collapsed_panel"
+        }
+      ]
+    }
+  ]
+}

--- a/.octospec/tasks/cardtmpl-json-template-engine/fixtures/ai.reasoning-process@0.1.0/reports/stopped.interaction.json
+++ b/.octospec/tasks/cardtmpl-json-template-engine/fixtures/ai.reasoning-process@0.1.0/reports/stopped.interaction.json
@@ -1,0 +1,23 @@
+{
+  "actions": [
+    {
+      "path": "$.body[3].items[0].actions[0]",
+      "type": "Action.ToggleVisibility",
+      "id": "reasoning_toggle"
+    }
+  ],
+  "inputs": [],
+  "toggles": [
+    {
+      "path": "$.body[3].items[0].actions[0]",
+      "targets": [
+        {
+          "elementId": "trace_panel"
+        },
+        {
+          "elementId": "collapsed_panel"
+        }
+      ]
+    }
+  ]
+}

--- a/.octospec/tasks/cardtmpl-json-template-engine/fixtures/ai.reasoning-process@0.1.0/samples/answering.json
+++ b/.octospec/tasks/cardtmpl-json-template-engine/fixtures/ai.reasoning-process@0.1.0/samples/answering.json
@@ -1,0 +1,89 @@
+{
+  "reasoningId": "reasoning-channel-b-001",
+  "state": "answering",
+  "title": "已深度思考",
+  "statusLabel": "回答中",
+  "statusTone": "Accent",
+  "timerText": "正在生成回答…",
+  "traceExpanded": true,
+  "traceCollapsed": false,
+  "collapsedSummary": "推理已完成 · 回答正在生成",
+  "progressText": "推理已完成，正在生成回答…",
+  "phases": [
+    {
+      "thought": "先拆分线索、试用激活与付费三段漏斗，核对近 90 天数据。",
+      "actions": [
+        {
+          "tool": "query_metrics",
+          "detail": "channel=B · range=90d · group=stage",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "read_file",
+          "detail": "~/analytics/funnel_definition.sql · ×2",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "run_sql",
+          "detail": "按漏斗阶段汇总数量与转化率",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        }
+      ]
+    },
+    {
+      "thought": "激活率的降幅高于线索量，交叉核验行业结构、客服工单、NPS 与季节性。",
+      "actions": [
+        {
+          "tool": "query_metrics",
+          "detail": "按行业拆分激活率",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "search_tickets",
+          "detail": "渠道 B · 试用 / 激活失败 · 近 60 天",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "read_file",
+          "detail": "~/nps/2026Q2_channelB.csv",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "query_metrics",
+          "detail": "叠加节假日与季节性校正",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        }
+      ]
+    },
+    {
+      "thought": "主因确认：教育与专业服务合计贡献 63% 降幅，激活断点集中在试用权益触达。",
+      "actions": [
+        {
+          "tool": "run_sql",
+          "detail": "按行业汇总转化降幅贡献",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "edit_file",
+          "detail": "~/reports/channelB_rootcause.md · 已编辑",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "think",
+          "detail": "正在组织结论、证据与下周建议…",
+          "statusGlyph": "●",
+          "statusTone": "Accent"
+        }
+      ]
+    }
+  ]
+}

--- a/.octospec/tasks/cardtmpl-json-template-engine/fixtures/ai.reasoning-process@0.1.0/samples/completed.json
+++ b/.octospec/tasks/cardtmpl-json-template-engine/fixtures/ai.reasoning-process@0.1.0/samples/completed.json
@@ -1,0 +1,106 @@
+{
+  "reasoningId": "reasoning-channel-b-001",
+  "state": "completed",
+  "title": "已深度思考",
+  "statusLabel": "已完成",
+  "statusTone": "Good",
+  "timerText": "用时 12 秒 · 3 段推理 · 13 次工具调用",
+  "traceExpanded": false,
+  "traceCollapsed": true,
+  "collapsedSummary": "已思考 12 秒 · 推理过程已收起",
+  "phases": [
+    {
+      "thought": "先把渠道 B 转化下降的范围圈出来：拆成线索、试用激活、付费三段漏斗，取近 90 天数据。",
+      "actions": [
+        {
+          "tool": "query_metrics",
+          "detail": "channel=B · range=90d · group=stage",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "read_file",
+          "detail": "~/analytics/funnel_definition.sql · ×2",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "run_sql",
+          "detail": "按漏斗阶段汇总数量与转化率",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        }
+      ]
+    },
+    {
+      "thought": "激活率的降幅高于线索量，交叉核验行业结构、客服工单、NPS 与季节性。",
+      "actions": [
+        {
+          "tool": "query_metrics",
+          "detail": "按行业拆分激活率",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "run_sql",
+          "detail": "对比各行业激活与付费转化",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "search_tickets",
+          "detail": "渠道 B · 试用 / 激活失败 · 近 60 天",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "read_file",
+          "detail": "~/nps/2026Q2_channelB.csv",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "query_metrics",
+          "detail": "叠加节假日与季节性校正",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "run_sql",
+          "detail": "逐周复核线索与激活数量",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "web_search",
+          "detail": "SaaS 行业 2026 试用政策调整",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        }
+      ]
+    },
+    {
+      "thought": "主因确认：教育与专业服务合计贡献 63% 降幅，激活断点集中在试用权益触达。",
+      "actions": [
+        {
+          "tool": "run_sql",
+          "detail": "按行业汇总转化降幅贡献",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "edit_file",
+          "detail": "~/reports/channelB_rootcause.md · 已编辑",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "think",
+          "detail": "拆分行业漏斗深挖与权益触达复盘",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        }
+      ]
+    }
+  ]
+}

--- a/.octospec/tasks/cardtmpl-json-template-engine/fixtures/ai.reasoning-process@0.1.0/samples/error.json
+++ b/.octospec/tasks/cardtmpl-json-template-engine/fixtures/ai.reasoning-process@0.1.0/samples/error.json
@@ -1,0 +1,55 @@
+{
+  "reasoningId": "reasoning-channel-b-003",
+  "state": "error",
+  "title": "已深度思考",
+  "statusLabel": "生成失败",
+  "statusTone": "Attention",
+  "timerText": "已中断",
+  "traceExpanded": true,
+  "traceCollapsed": false,
+  "collapsedSummary": "生成已中断 · 点击可查看停止前的过程",
+  "errorTitle": "生成失败",
+  "errorMessage": "推理服务连接超时，已停止本次生成。可以重试，已完成的过程会保留。",
+  "phases": [
+    {
+      "thought": "先拆分线索、试用激活与付费三段漏斗，核对近 90 天数据。",
+      "actions": [
+        {
+          "tool": "query_metrics",
+          "detail": "channel=B · range=90d · group=stage",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "read_file",
+          "detail": "~/analytics/funnel_definition.sql · ×2",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "run_sql",
+          "detail": "按漏斗阶段汇总数量与转化率",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        }
+      ]
+    },
+    {
+      "thought": "准备交叉核验行业结构、客服工单与 NPS 时，推理服务连接中断。",
+      "actions": [
+        {
+          "tool": "query_metrics",
+          "detail": "按行业拆分激活率",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "search_tickets",
+          "detail": "连接超时，调用未完成",
+          "statusGlyph": "●",
+          "statusTone": "Attention"
+        }
+      ]
+    }
+  ]
+}

--- a/.octospec/tasks/cardtmpl-json-template-engine/fixtures/ai.reasoning-process@0.1.0/samples/reasoning.json
+++ b/.octospec/tasks/cardtmpl-json-template-engine/fixtures/ai.reasoning-process@0.1.0/samples/reasoning.json
@@ -1,0 +1,66 @@
+{
+  "reasoningId": "reasoning-channel-b-001",
+  "state": "reasoning",
+  "title": "已深度思考",
+  "statusLabel": "思考中",
+  "statusTone": "Accent",
+  "timerText": "正在深度思考…",
+  "traceExpanded": true,
+  "traceCollapsed": false,
+  "collapsedSummary": "推理仍在进行 · 点击可查看当前过程",
+  "progressText": "正在执行下一步…",
+  "phases": [
+    {
+      "thought": "先把渠道 B 转化下降的范围圈出来：拆成线索、试用激活、付费三段漏斗，取近 90 天数据。",
+      "actions": [
+        {
+          "tool": "query_metrics",
+          "detail": "channel=B · range=90d · group=stage",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "read_file",
+          "detail": "~/analytics/funnel_definition.sql · ×2",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "run_sql",
+          "detail": "按漏斗阶段汇总数量与转化率",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        }
+      ]
+    },
+    {
+      "thought": "口径正常，但激活率掉得比线索量快；继续拉行业标签、客服工单和 NPS 交叉验证。",
+      "actions": [
+        {
+          "tool": "query_metrics",
+          "detail": "channel=B · dims=industry · metric=activation_rate",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "search_tickets",
+          "detail": "渠道 B · 试用 / 激活失败 · 近 60 天",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "read_file",
+          "detail": "~/nps/2026Q2_channelB.csv",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "query_metrics",
+          "detail": "正在叠加季节性校正…",
+          "statusGlyph": "●",
+          "statusTone": "Accent"
+        }
+      ]
+    }
+  ]
+}

--- a/.octospec/tasks/cardtmpl-json-template-engine/fixtures/ai.reasoning-process@0.1.0/samples/stopped.json
+++ b/.octospec/tasks/cardtmpl-json-template-engine/fixtures/ai.reasoning-process@0.1.0/samples/stopped.json
@@ -1,0 +1,53 @@
+{
+  "reasoningId": "reasoning-channel-b-002",
+  "state": "stopped",
+  "title": "已深度思考",
+  "statusLabel": "已停止",
+  "statusTone": "Warning",
+  "timerText": "已思考 6 秒 · 已停止于第 2 段",
+  "traceExpanded": false,
+  "traceCollapsed": true,
+  "collapsedSummary": "已保留停止前的 2 段推理过程",
+  "phases": [
+    {
+      "thought": "先拆分线索、试用激活与付费三段漏斗，核对近 90 天数据。",
+      "actions": [
+        {
+          "tool": "query_metrics",
+          "detail": "channel=B · range=90d · group=stage",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "read_file",
+          "detail": "~/analytics/funnel_definition.sql · ×2",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "run_sql",
+          "detail": "按漏斗阶段汇总数量与转化率",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        }
+      ]
+    },
+    {
+      "thought": "激活率降幅高于线索量，开始按行业与试用权益触达交叉核验。",
+      "actions": [
+        {
+          "tool": "query_metrics",
+          "detail": "按行业拆分激活率",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "search_tickets",
+          "detail": "调用已由用户停止",
+          "statusGlyph": "●",
+          "statusTone": "Accent"
+        }
+      ]
+    }
+  ]
+}

--- a/.octospec/tasks/cardtmpl-json-template-engine/fixtures/ai.reasoning-process@0.1.0/templates/active.template.json
+++ b/.octospec/tasks/cardtmpl-json-template-engine/fixtures/ai.reasoning-process@0.1.0/templates/active.template.json
@@ -1,0 +1,204 @@
+{
+  "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+  "type": "AdaptiveCard",
+  "version": "1.5",
+  "body": [
+    {
+      "type": "Container",
+      "id": "octo-surface-accent-header-reasoning-active",
+      "style": "accent",
+      "bleed": true,
+      "spacing": "None",
+      "items": [
+        {
+          "type": "ColumnSet",
+          "spacing": "None",
+          "columns": [
+            {
+              "type": "Column",
+              "width": "stretch",
+              "verticalContentAlignment": "Center",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "text": "✦  ${title}",
+                  "color": "Accent",
+                  "weight": "Bolder",
+                  "wrap": true,
+                  "spacing": "None"
+                },
+                {
+                  "type": "TextBlock",
+                  "text": "${timerText}",
+                  "size": "Small",
+                  "isSubtle": true,
+                  "wrap": true,
+                  "spacing": "Small"
+                }
+              ]
+            },
+            {
+              "type": "Column",
+              "width": "auto",
+              "verticalContentAlignment": "Center",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "id": "octo-badge-reasoning-active-status",
+                  "text": "${statusLabel}",
+                  "color": "${statusTone}",
+                  "weight": "Bolder",
+                  "size": "Small",
+                  "wrap": true,
+                  "spacing": "None"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "id": "trace_panel",
+      "isVisible": "${traceExpanded}",
+      "spacing": "Large",
+      "items": [
+        {
+          "$data": "${phases}",
+          "type": "Container",
+          "spacing": "${if($index == 0, 'None', 'Large')}",
+          "separator": "${if($index == 0, false, true)}",
+          "items": [
+            {
+              "type": "TextBlock",
+              "text": "${thought}",
+              "size": "Small",
+              "wrap": true,
+              "spacing": "None"
+            },
+            {
+              "type": "Container",
+              "style": "emphasis",
+              "spacing": "Small",
+              "items": [
+                {
+                  "$data": "${actions}",
+                  "type": "ColumnSet",
+                  "spacing": "${if($index == 0, 'None', 'Small')}",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "${statusGlyph}",
+                          "color": "${statusTone}",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "${tool}",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "${detail}",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "TextBlock",
+          "text": "◌  ${progressText}",
+          "color": "Accent",
+          "size": "Small",
+          "wrap": true,
+          "spacing": "Large"
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "id": "collapsed_panel",
+      "isVisible": "${traceCollapsed}",
+      "spacing": "Medium",
+      "items": [
+        {
+          "type": "TextBlock",
+          "text": "✓  ${collapsedSummary}",
+          "size": "Small",
+          "isSubtle": true,
+          "wrap": true,
+          "spacing": "None"
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "id": "octo-surface-default-footer-reasoning-active",
+      "style": "emphasis",
+      "bleed": true,
+      "separator": true,
+      "spacing": "Large",
+      "items": [
+        {
+          "type": "ActionSet",
+          "horizontalAlignment": "Right",
+          "actions": [
+            {
+              "type": "Action.Submit",
+              "id": "reasoning_stop",
+              "title": "停止",
+              "style": "destructive",
+              "associatedInputs": "none",
+              "data": {
+                "action": "reasoning_stop",
+                "effect": "stop_reasoning",
+                "reasoning_id": "${reasoningId}"
+              }
+            },
+            {
+              "type": "Action.ToggleVisibility",
+              "id": "reasoning_toggle",
+              "title": "显示 / 隐藏推理",
+              "targetElements": [
+                "trace_panel",
+                "collapsed_panel"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/.octospec/tasks/cardtmpl-json-template-engine/fixtures/ai.reasoning-process@0.1.0/templates/error.template.json
+++ b/.octospec/tasks/cardtmpl-json-template-engine/fixtures/ai.reasoning-process@0.1.0/templates/error.template.json
@@ -1,0 +1,213 @@
+{
+  "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+  "type": "AdaptiveCard",
+  "version": "1.5",
+  "body": [
+    {
+      "type": "Container",
+      "id": "octo-surface-accent-header-reasoning-error",
+      "style": "accent",
+      "bleed": true,
+      "spacing": "None",
+      "items": [
+        {
+          "type": "ColumnSet",
+          "spacing": "None",
+          "columns": [
+            {
+              "type": "Column",
+              "width": "stretch",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "text": "✦  ${title}",
+                  "color": "Accent",
+                  "weight": "Bolder",
+                  "wrap": true,
+                  "spacing": "None"
+                },
+                {
+                  "type": "TextBlock",
+                  "text": "${timerText}",
+                  "size": "Small",
+                  "isSubtle": true,
+                  "wrap": true,
+                  "spacing": "Small"
+                }
+              ]
+            },
+            {
+              "type": "Column",
+              "width": "auto",
+              "verticalContentAlignment": "Center",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "id": "octo-badge-reasoning-error-status",
+                  "text": "${statusLabel}",
+                  "color": "${statusTone}",
+                  "weight": "Bolder",
+                  "size": "Small",
+                  "wrap": true,
+                  "spacing": "None"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "id": "trace_panel",
+      "isVisible": "${traceExpanded}",
+      "spacing": "Large",
+      "items": [
+        {
+          "$data": "${phases}",
+          "type": "Container",
+          "spacing": "${if($index == 0, 'None', 'Large')}",
+          "separator": "${if($index == 0, false, true)}",
+          "items": [
+            {
+              "type": "TextBlock",
+              "text": "${thought}",
+              "size": "Small",
+              "wrap": true,
+              "spacing": "None"
+            },
+            {
+              "type": "Container",
+              "style": "emphasis",
+              "spacing": "Small",
+              "items": [
+                {
+                  "$data": "${actions}",
+                  "type": "ColumnSet",
+                  "spacing": "${if($index == 0, 'None', 'Small')}",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "${statusGlyph}",
+                          "color": "${statusTone}",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "${tool}",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "${detail}",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "id": "collapsed_panel",
+      "isVisible": "${traceCollapsed}",
+      "spacing": "Medium",
+      "items": [
+        {
+          "type": "TextBlock",
+          "text": "${collapsedSummary}",
+          "size": "Small",
+          "isSubtle": true,
+          "wrap": true,
+          "spacing": "None"
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "style": "attention",
+      "spacing": "Large",
+      "items": [
+        {
+          "type": "TextBlock",
+          "text": "${errorTitle}",
+          "color": "Attention",
+          "weight": "Bolder",
+          "wrap": true,
+          "spacing": "None"
+        },
+        {
+          "type": "TextBlock",
+          "text": "${errorMessage}",
+          "wrap": true,
+          "spacing": "Small"
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "id": "octo-surface-default-footer-reasoning-error",
+      "style": "emphasis",
+      "bleed": true,
+      "separator": true,
+      "spacing": "Large",
+      "items": [
+        {
+          "type": "ActionSet",
+          "horizontalAlignment": "Right",
+          "actions": [
+            {
+              "type": "Action.Submit",
+              "id": "reasoning_retry",
+              "title": "重试",
+              "style": "positive",
+              "associatedInputs": "none",
+              "data": {
+                "action": "reasoning_retry",
+                "effect": "retry_reasoning",
+                "reasoning_id": "${reasoningId}"
+              }
+            },
+            {
+              "type": "Action.ToggleVisibility",
+              "id": "reasoning_toggle",
+              "title": "显示 / 隐藏推理",
+              "targetElements": [
+                "trace_panel",
+                "collapsed_panel"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/.octospec/tasks/cardtmpl-json-template-engine/fixtures/ai.reasoning-process@0.1.0/templates/result.template.json
+++ b/.octospec/tasks/cardtmpl-json-template-engine/fixtures/ai.reasoning-process@0.1.0/templates/result.template.json
@@ -1,0 +1,180 @@
+{
+  "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+  "type": "AdaptiveCard",
+  "version": "1.5",
+  "body": [
+    {
+      "type": "Container",
+      "id": "octo-surface-accent-header-reasoning-result",
+      "style": "accent",
+      "bleed": true,
+      "spacing": "None",
+      "items": [
+        {
+          "type": "ColumnSet",
+          "spacing": "None",
+          "columns": [
+            {
+              "type": "Column",
+              "width": "stretch",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "text": "✦  ${title}",
+                  "color": "Accent",
+                  "weight": "Bolder",
+                  "wrap": true,
+                  "spacing": "None"
+                },
+                {
+                  "type": "TextBlock",
+                  "text": "${timerText}",
+                  "size": "Small",
+                  "isSubtle": true,
+                  "wrap": true,
+                  "spacing": "Small"
+                }
+              ]
+            },
+            {
+              "type": "Column",
+              "width": "auto",
+              "verticalContentAlignment": "Center",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "id": "octo-badge-reasoning-result-status",
+                  "text": "${statusLabel}",
+                  "color": "${statusTone}",
+                  "weight": "Bolder",
+                  "size": "Small",
+                  "wrap": true,
+                  "spacing": "None"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "id": "trace_panel",
+      "isVisible": "${traceExpanded}",
+      "spacing": "Large",
+      "items": [
+        {
+          "$data": "${phases}",
+          "type": "Container",
+          "spacing": "${if($index == 0, 'None', 'Large')}",
+          "separator": "${if($index == 0, false, true)}",
+          "items": [
+            {
+              "type": "TextBlock",
+              "text": "${thought}",
+              "size": "Small",
+              "wrap": true,
+              "spacing": "None"
+            },
+            {
+              "type": "Container",
+              "style": "emphasis",
+              "spacing": "Small",
+              "items": [
+                {
+                  "$data": "${actions}",
+                  "type": "ColumnSet",
+                  "spacing": "${if($index == 0, 'None', 'Small')}",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "${statusGlyph}",
+                          "color": "${statusTone}",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "${tool}",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "${detail}",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "id": "collapsed_panel",
+      "isVisible": "${traceCollapsed}",
+      "spacing": "Medium",
+      "items": [
+        {
+          "type": "TextBlock",
+          "text": "✓  ${collapsedSummary}",
+          "size": "Small",
+          "isSubtle": true,
+          "wrap": true,
+          "spacing": "None"
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "id": "octo-surface-default-footer-reasoning-result",
+      "style": "emphasis",
+      "bleed": true,
+      "separator": true,
+      "spacing": "Large",
+      "items": [
+        {
+          "type": "ActionSet",
+          "horizontalAlignment": "Right",
+          "actions": [
+            {
+              "type": "Action.ToggleVisibility",
+              "id": "reasoning_toggle",
+              "title": "显示 / 隐藏推理",
+              "targetElements": [
+                "trace_panel",
+                "collapsed_panel"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/docs/platform-card-base.md
+++ b/docs/platform-card-base.md
@@ -106,7 +106,7 @@
 3. **能力与安全边界(与 L2a 完全一致,不放松)**
    - 组件白名单、URL https、markdown escape、input 白名单、data key 白名单 **一律走 L0** `pkg/cardmsg` 与 `Registry.Render`,业务方无法绕过;
    - 业务方不能自选 `WireProfile`(仍限 `octo/v1`/`octo/v2`);
-   - `BuildResult.DeepLink` 必须是 https,业务方不能传入任意域名;由业务方在 Template 构造时注入自己允许的 `WebLoginURL` 白名单(平台组通过 PR 审核域名);
+   - `BuildResult.DeepLink` 可选;若提供则必须是绝对 https,业务方不能传入任意域名,由业务方在 Template 构造时注入自己允许的 `WebLoginURL` 白名单(平台组通过 PR 审核域名);纯展示卡(如 JSON 进度卡)可留空以省略 `metadata.webUrl`;
    - 不允许写 `metadata.octo.*` 未声明字段,如需扩展走 L0 PR 审查(其它 owner 也能看见)。
 
 4. **发布通道**
@@ -407,13 +407,13 @@ type BuildEnv struct {
 
 // BuildResult 是 Template.Build 的返回值,只承载业务片段;
 // 基座 wrapper(Registry.Render)负责组装完整 AC 顶层文档并注入
-// metadata.octo.{protocol,template,variant,source} + metadata.webUrl。
+// metadata.octo.{protocol,template,variant,source},以及 metadata.webUrl(仅当 DeepLink 非空)。
 // 模板不 marshal AC 顶层,不写 metadata 字段。
 type BuildResult struct {
     Body     []any   // AC body 元素(TextBlock/ColumnSet/Container/...)
     Actions  []any   // AC 顶层 actions(Action.Submit / Action.OpenUrl / ...)
     Variant  string  // metadata.octo.variant,如 "docs.access_requested"
-    DeepLink string  // metadata.webUrl 与"查看详情"按钮共同来源,必填绝对 https
+    DeepLink string  // metadata.webUrl;可选:非空则须绝对 https,空则省略 webUrl(纯展示卡无规范 URL)
     Source   *Source // 覆盖 Meta.Source;nil = 不覆盖
 }
 
@@ -440,7 +440,7 @@ type Template interface {
 //  2. Meta().InputSchema.Validate(fields) → 失败返 ErrFieldsInvalid;
 //  3. Meta().ViewFor(state) 决定 view / profile → 未注册 state 返 ErrStateUnknown;
 //  4. Template.Build(ctx, state, fields, env) 拿 BuildResult;
-//  5. 组装 AC card 节点(注入 metadata.octo.{protocol,template,variant,source} + webUrl),
+//  5. 组装 AC card 节点(注入 metadata.octo.{protocol,template,variant,source};DeepLink 非空时再注入 webUrl),
 //     再包成 type-17 envelope {type, card, card_version, profile};
 //  6. cardmsg.Validate(payload) → 失败视为 render_error。
 // 业务代码只调 Render,不允许调 Template.Build 后自己拼装。
@@ -452,10 +452,10 @@ func (r *Registry) Render(ctx context.Context, id ID, version string,
 
 ### 关键约束(基座强制,非"模板自觉")
 
-1. **metadata 由基座注入**:`metadata.octo.protocol` / `template.{id,version}` / `variant` / `source` 和 `metadata.webUrl` 全部由 `Registry.Render` 写入,模板返回 `BuildResult` 不接触这些字段。
+1. **metadata 由基座注入**:`metadata.octo.protocol` / `template.{id,version}` / `variant` / `source` 全部由 `Registry.Render` 写入(`metadata.webUrl` 仅当 `DeepLink` 非空时注入),模板返回 `BuildResult` 不接触这些字段。
 2. **`cardmsg.Validate(payload)` 由基座调用**（payload 为完整 type-17 envelope，profile 在其中）：Template 无法绕过；view→profile 从 `Meta.Views[view].WireProfile` 取。
 3. **`Action.Submit.data["owner"]` / `["action_type"]` 与 `ActionContract` 一致性**:conformance test 校验;pilot 注册时用其 sample 跑一次 `Render` + 断言,失败 → 注册期 panic(fail-close)。
-4. **`DeepLink` 必填且绝对 https**:`BuildResult.DeepLink == ""` 或非 https → Render 返 error;deep-link 由模板私有拼接函数从 `env.WebLoginURL` 组装,不接受调用方任意域名。
+4. **`DeepLink` 可选,非空则绝对 https**:`BuildResult.DeepLink == ""` 表示本卡无规范浏览器 URL(如 JSON 纯展示进度卡)→ 跳过校验并省略 `metadata.webUrl`;非空则必须绝对 https(**含纯空白也判为畸形 → Render 返 error**,不静默当作"无链接"),deep-link 由模板私有拼接函数从 `env.WebLoginURL` 组装,不接受调用方任意域名。
 5. **禁止未声明的 `metadata.octo.*` 扩展**:如需扩展走本文档 PR 审查。
 
 ---

--- a/pkg/cardtmpl/json_template.go
+++ b/pkg/cardtmpl/json_template.go
@@ -78,11 +78,13 @@ func (t *jsonTemplate) Build(ctx context.Context, state State, fields json.RawMe
 // — the same plain derivation the send path uses — so the fallback matches what
 // clients reduce the card to. Unlike Render this path does not run the full
 // cardmsg.Validate gate (the built card is a body/actions fragment, not a wire
-// payload), but its resource surface is bounded on both ends: Build goes through
-// jsontmpl.Expand's maxExpandNodes ceiling (so an unbounded $data array can't
-// balloon the fragment) and BuildPlain enforces cardmsg.MaxPayloadBytes on its
-// output. Injection is not a concern here — BuildPlain reduces markdown links to
-// their visible label (PR #654 review P2 — fallback node/size backstop).
+// payload). Its resource surface is bounded on the input side by jsontmpl.Expand's
+// maxExpandNodes ceiling (so an unbounded $data array can't balloon the fragment);
+// note BuildPlain itself imposes NO payload-size limit (only Finalize /
+// RecheckPayloadSize do, neither runs here — PR #654 review yujiawei P2). Injection
+// is not a concern — BuildPlain reduces markdown links to their visible label.
+// When this path is first wired to a send path it should additionally run
+// InputSchema.Validate + a payload-size check (no production caller today).
 func (t *jsonTemplate) FallbackText(state State, fields json.RawMessage, lang string) (string, error) {
 	br, err := t.Build(context.Background(), state, fields, BuildEnv{Lang: lang})
 	if err != nil {

--- a/pkg/cardtmpl/json_template.go
+++ b/pkg/cardtmpl/json_template.go
@@ -53,7 +53,7 @@ func (t *jsonTemplate) Build(ctx context.Context, state State, fields json.RawMe
 	if err := json.Unmarshal(fields, &data); err != nil {
 		return BuildResult{}, fmt.Errorf("jsonTemplate: unmarshal fields: %w", err)
 	}
-	expanded, err := jsontmpl.Expand(ast, jsontmpl.Scope{Data: data}, jsonTemplateEscaper)
+	expanded, err := jsontmpl.Expand(ctx, ast, jsontmpl.Scope{Data: data}, jsonTemplateEscaper)
 	if err != nil {
 		return BuildResult{}, fmt.Errorf("jsonTemplate: expand view %q: %w", view, err)
 	}
@@ -76,7 +76,13 @@ func (t *jsonTemplate) Build(ctx context.Context, state State, fields json.RawMe
 
 // FallbackText derives plain text from the compiled card via cardmsg.BuildPlain
 // — the same plain derivation the send path uses — so the fallback matches what
-// clients reduce the card to.
+// clients reduce the card to. Unlike Render this path does not run the full
+// cardmsg.Validate gate (the built card is a body/actions fragment, not a wire
+// payload), but its resource surface is bounded on both ends: Build goes through
+// jsontmpl.Expand's maxExpandNodes ceiling (so an unbounded $data array can't
+// balloon the fragment) and BuildPlain enforces cardmsg.MaxPayloadBytes on its
+// output. Injection is not a concern here — BuildPlain reduces markdown links to
+// their visible label (PR #654 review P2 — fallback node/size backstop).
 func (t *jsonTemplate) FallbackText(state State, fields json.RawMessage, lang string) (string, error) {
 	br, err := t.Build(context.Background(), state, fields, BuildEnv{Lang: lang})
 	if err != nil {

--- a/pkg/cardtmpl/json_template.go
+++ b/pkg/cardtmpl/json_template.go
@@ -1,0 +1,128 @@
+package cardtmpl
+
+import (
+	"context"
+	"embed"
+	"encoding/json"
+	"fmt"
+	"path"
+	"strings"
+
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardmsg"
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl/jsontmpl"
+)
+
+// jsonTemplate is the generic Template backing JSON-mode cards (roadmap E1). Its
+// Build compiles the view's `.template.json` against caller data through the
+// jsontmpl evaluator instead of hand-writing the body in Go, so one instance
+// serves any card that ships a handoff with `views[].template` files. The
+// per-view template trees are parsed once at register time (viewAST) and only
+// re-bound per render — no per-frame JSON parse (progress cards re-render often).
+type jsonTemplate struct {
+	meta    TemplateMeta
+	viewAST map[ViewKey]any
+}
+
+// SetMeta satisfies metaSetter; Registry injects the assembled meta at Register.
+func (t *jsonTemplate) SetMeta(m TemplateMeta) { t.meta = m }
+
+// Meta returns a defensive deep copy, matching the Template contract.
+func (t *jsonTemplate) Meta() TemplateMeta { return t.meta.Clone() }
+
+// jsonTemplateEscaper is the data-escaping policy for JSON templates (decision
+// D6): identity. Goldens bind caller data literally; the trust boundary is
+// enforced by cardmsg.Validate (URL allowlist over markdown links + element
+// whitelist + node/size caps) which renderCore applies to the compiled card
+// after Build — not by markdown-escaping inside the engine. The escaper stays a
+// seam so a future card can opt into escaping without touching the evaluator.
+func jsonTemplateEscaper(s string) string { return s }
+
+// Build expands the view template for state against the (already schema-checked)
+// fields and returns the AC body/actions fragment. It marshals no top level and
+// writes no metadata — that is renderCore's job.
+func (t *jsonTemplate) Build(ctx context.Context, state State, fields json.RawMessage, env BuildEnv) (BuildResult, error) {
+	view, ok := t.meta.ViewFor(state)
+	if !ok {
+		return BuildResult{}, fmt.Errorf("jsonTemplate: no view for state %q", state)
+	}
+	ast, ok := t.viewAST[view]
+	if !ok {
+		return BuildResult{}, fmt.Errorf("jsonTemplate: view %q has no compiled template", view)
+	}
+	var data map[string]any
+	if err := json.Unmarshal(fields, &data); err != nil {
+		return BuildResult{}, fmt.Errorf("jsonTemplate: unmarshal fields: %w", err)
+	}
+	expanded, err := jsontmpl.Expand(ast, jsontmpl.Scope{Data: data}, jsonTemplateEscaper)
+	if err != nil {
+		return BuildResult{}, fmt.Errorf("jsonTemplate: expand view %q: %w", view, err)
+	}
+	card, ok := expanded.(map[string]any)
+	if !ok {
+		return BuildResult{}, fmt.Errorf("jsonTemplate: expanded view %q is %T, want object", view, expanded)
+	}
+	body, ok := card["body"].([]any)
+	if !ok || len(body) == 0 {
+		return BuildResult{}, fmt.Errorf("jsonTemplate: view %q produced no body", view)
+	}
+	var actions []any
+	if a, ok := card["actions"].([]any); ok {
+		actions = a
+	}
+	// JSON display templates carry no separate deep link (any OpenUrl lives in
+	// the body); renderCore omits metadata.webUrl when DeepLink is empty.
+	return BuildResult{Body: body, Actions: actions}, nil
+}
+
+// FallbackText derives plain text from the compiled card via cardmsg.BuildPlain
+// — the same plain derivation the send path uses — so the fallback matches what
+// clients reduce the card to.
+func (t *jsonTemplate) FallbackText(state State, fields json.RawMessage, lang string) (string, error) {
+	br, err := t.Build(context.Background(), state, fields, BuildEnv{Lang: lang})
+	if err != nil {
+		return "", err
+	}
+	card := map[string]any{
+		"type":    "AdaptiveCard",
+		"version": cardmsg.CardVersion,
+		"body":    br.Body,
+	}
+	if len(br.Actions) > 0 {
+		card["actions"] = br.Actions
+	}
+	return cardmsg.BuildPlain(card), nil
+}
+
+// RegisterJSON registers a JSON-mode card from its handoff assets. Every
+// manifest view must declare a `template` path; each file is parsed into a
+// reusable AST at register time. It then delegates to Register, which assembles
+// the TemplateMeta (schema / views / interactions), injects it via SetMeta, and
+// runs the sample self-check — so JSON cards get the identical fail-close
+// registration guarantees as Go cards (missing template / schema / bad sample /
+// whitelist violation all panic at boot, never at first render).
+func (r *Registry) RegisterJSON(assets embed.FS, root string) {
+	mf := loadManifest(assets, root)
+	viewAST := make(map[ViewKey]any, len(mf.Views))
+	for vk, vs := range mf.Views {
+		if strings.TrimSpace(vs.Template) == "" {
+			panic(fmt.Errorf("cardtmpl: RegisterJSON: view %q in %s/manifest.json declares no template path", vk, root))
+		}
+		p := path.Join(root, vs.Template)
+		b, err := assets.ReadFile(p)
+		if err != nil {
+			panic(fmt.Errorf("cardtmpl: RegisterJSON: read template %s: %w", p, err))
+		}
+		var ast any
+		if err := json.Unmarshal(b, &ast); err != nil {
+			panic(fmt.Errorf("cardtmpl: RegisterJSON: parse template %s: %w", p, err))
+		}
+		// Fail-close: every Action.ToggleVisibility target must resolve to an
+		// element id in the same template (a dangling target is an authoring bug
+		// — a button that toggles nothing — caught here, not at first render).
+		if err := jsontmpl.ValidateToggleTargets(ast); err != nil {
+			panic(fmt.Errorf("cardtmpl: RegisterJSON: template %s: %w", p, err))
+		}
+		viewAST[vk] = ast
+	}
+	r.Register(&jsonTemplate{viewAST: viewAST}, assets, root)
+}

--- a/pkg/cardtmpl/json_template_meta_test.go
+++ b/pkg/cardtmpl/json_template_meta_test.go
@@ -1,0 +1,30 @@
+package cardtmpl
+
+import (
+	"fmt"
+	"testing"
+)
+
+func fmtSprint(v any) string { return fmt.Sprint(v) }
+
+// TestJSONTemplate_Meta asserts the generic jsonTemplate exposes the assembled
+// meta (id/version/views) after RegisterJSON.
+func TestJSONTemplate_Meta(t *testing.T) {
+	reg := NewRegistry()
+	reg.RegisterJSON(jsonCardTestData, "testdata/test.jsoncard@0.1.0")
+	reg.Freeze()
+	tmpl, err := reg.Lookup("test.jsoncard", "0.1.0")
+	if err != nil {
+		t.Fatalf("lookup: %v", err)
+	}
+	m := tmpl.Meta()
+	if m.ID != "test.jsoncard" || m.Version != "0.1.0" {
+		t.Fatalf("meta id/version = %s@%s", m.ID, m.Version)
+	}
+	if _, ok := m.Views["main"]; !ok {
+		t.Fatalf("meta.Views missing 'main': %+v", m.Views)
+	}
+	if v, ok := m.ViewFor("shown"); !ok || v != "main" {
+		t.Fatalf("ViewFor(shown) = %q,%v", v, ok)
+	}
+}

--- a/pkg/cardtmpl/json_template_test.go
+++ b/pkg/cardtmpl/json_template_test.go
@@ -1,0 +1,167 @@
+package cardtmpl
+
+import (
+	"context"
+	"embed"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+//go:embed testdata
+var jsonCardTestData embed.FS
+
+// registerJSONResult captures a RegisterJSON attempt without aborting the test
+// binary on the register-time panics RegisterJSON uses for fail-close.
+func tryRegisterJSON(root string) (rec any) {
+	defer func() { rec = recover() }()
+	reg := NewRegistry()
+	reg.RegisterJSON(jsonCardTestData, root)
+	return nil
+}
+
+// TestRegisterJSON_MinimalV1_RendersThroughPipeline is the end-to-end wiring
+// proof: a JSON-mode v1 card registers, freezes, and Renders through the exact
+// same renderCore + cardmsg.Validate pipeline as Go cards. It exercises typed
+// bool binding (isVisible), $data repetition, $index, and the D7 no-deep-link
+// path (metadata.webUrl omitted).
+func TestRegisterJSON_MinimalV1_RendersThroughPipeline(t *testing.T) {
+	reg := NewRegistry()
+	reg.RegisterJSON(jsonCardTestData, "testdata/test.jsoncard@0.1.0")
+	reg.SetDefault("test.jsoncard", "0.1.0")
+	reg.Freeze()
+
+	fields := json.RawMessage(`{"title":"冒烟","expanded":true,"rows":[{"label":"a"},{"label":"b"}]}`)
+	payload, err := reg.Render(context.Background(), "test.jsoncard", "0.1.0", "shown", fields,
+		BuildEnv{Lang: "zh-CN", SpaceID: "s1"})
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+
+	if got := payload["type"]; got == nil {
+		t.Fatal("payload missing type")
+	}
+	if got, _ := payload["profile"].(string); got != profileV1 {
+		t.Fatalf("profile = %q, want %q", got, profileV1)
+	}
+	card, ok := payload["card"].(map[string]any)
+	if !ok {
+		t.Fatal("payload.card not an object")
+	}
+	// D7: no deep link → metadata.webUrl omitted, octo still present.
+	md, _ := card["metadata"].(map[string]any)
+	if _, has := md["webUrl"]; has {
+		t.Errorf("metadata.webUrl should be omitted when card has no deep link")
+	}
+	if _, has := md["octo"]; !has {
+		t.Errorf("metadata.octo must be injected")
+	}
+	body, _ := card["body"].([]any)
+	if len(body) != 2 {
+		t.Fatalf("body len = %d, want 2 (title + rows_panel)", len(body))
+	}
+	// typed bool binding: rows_panel.isVisible must be a real JSON bool.
+	panel, _ := body[1].(map[string]any)
+	vis, ok := panel["isVisible"].(bool)
+	if !ok || !vis {
+		t.Fatalf("rows_panel.isVisible = %#v, want bool true", panel["isVisible"])
+	}
+	items, _ := panel["items"].([]any)
+	if len(items) != 2 {
+		t.Fatalf("rows_panel items = %d, want 2 ($data repeat)", len(items))
+	}
+	// $index → first row spacing None, second Small.
+	first, _ := items[0].(map[string]any)
+	if first["spacing"] != "None" {
+		t.Errorf("row0 spacing = %v, want None", first["spacing"])
+	}
+	second, _ := items[1].(map[string]any)
+	if second["spacing"] != "Small" {
+		t.Errorf("row1 spacing = %v, want Small", second["spacing"])
+	}
+}
+
+// TestRegisterJSON_C1_RejectsBadFields asserts schema-invalid fields fail with
+// ErrFieldsInvalid (C1 zero-delivery), same as Go cards.
+func TestRegisterJSON_C1_RejectsBadFields(t *testing.T) {
+	reg := NewRegistry()
+	reg.RegisterJSON(jsonCardTestData, "testdata/test.jsoncard@0.1.0")
+	reg.SetDefault("test.jsoncard", "0.1.0")
+	reg.Freeze()
+
+	// missing required "expanded"
+	bad := json.RawMessage(`{"title":"x"}`)
+	_, err := reg.Render(context.Background(), "test.jsoncard", "0.1.0", "shown", bad,
+		BuildEnv{Lang: "zh-CN", SpaceID: "s1"})
+	if err == nil {
+		t.Fatal("expected ErrFieldsInvalid for schema-invalid fields, got nil")
+	}
+	if !strings.Contains(err.Error(), ErrFieldsInvalid.Error()) {
+		t.Fatalf("want ErrFieldsInvalid, got %v", err)
+	}
+}
+
+// TestRegisterJSON_MissingTemplateFile_FailClose asserts a JSON view whose
+// template path does not exist panics at register time (fail-close), not at
+// first render.
+func TestRegisterJSON_FallbackText_DerivesPlain(t *testing.T) {
+	reg := NewRegistry()
+	reg.RegisterJSON(jsonCardTestData, "testdata/test.jsoncard@0.1.0")
+	reg.Freeze()
+	tmpl, err := reg.Lookup("test.jsoncard", "0.1.0")
+	if err != nil {
+		t.Fatalf("lookup: %v", err)
+	}
+	fields := json.RawMessage(`{"title":"冒烟","expanded":true,"rows":[{"label":"a"}]}`)
+	txt, err := tmpl.FallbackText("shown", fields, "zh-CN")
+	if err != nil {
+		t.Fatalf("FallbackText: %v", err)
+	}
+	if !strings.Contains(txt, "冒烟") {
+		t.Fatalf("fallback text %q should contain the title", txt)
+	}
+}
+
+// TestRegisterJSON_MarkdownLinkInjection_RejectedByValidate proves decision D6's
+// security model: the engine binds data literally (no markdown escaping), and a
+// caller-injected dangerous markdown link in a text field is caught by the L0
+// backstop cardmsg.Validate (positive URL allowlist over TextBlock markdown
+// links), which renderCore runs on the compiled card → ErrRenderFailed.
+func TestRegisterJSON_MarkdownLinkInjection_RejectedByValidate(t *testing.T) {
+	reg := NewRegistry()
+	reg.RegisterJSON(jsonCardTestData, "testdata/test.jsoncard@0.1.0")
+	reg.SetDefault("test.jsoncard", "0.1.0")
+	reg.Freeze()
+
+	// title carries a javascript: markdown link; schema permits it (plain string),
+	// so it must be the render-layer Validate that rejects it.
+	fields := json.RawMessage(`{"title":"[tap](javascript:alert(1))","expanded":false}`)
+	_, err := reg.Render(context.Background(), "test.jsoncard", "0.1.0", "shown", fields,
+		BuildEnv{Lang: "zh-CN", SpaceID: "s1"})
+	if err == nil {
+		t.Fatal("expected ErrRenderFailed (Validate rejects non-https markdown link), got nil — engine has an injection gap")
+	}
+	if !strings.Contains(err.Error(), ErrRenderFailed.Error()) {
+		t.Fatalf("want ErrRenderFailed from cardmsg.Validate, got %v", err)
+	}
+}
+
+// TestRegisterJSON_ViewMissingTemplate_FailClose asserts a JSON-mode view that
+// declares no template path panics at register time (fail-close), never at
+// first render.
+func TestRegisterJSON_ViewMissingTemplate_FailClose(t *testing.T) {
+	rec := tryRegisterJSON("testdata/test.notmpl@0.1.0")
+	if rec == nil {
+		t.Fatal("expected register-time panic for view without a template path")
+	}
+	if !strings.Contains(toStr(rec), "no template path") {
+		t.Fatalf("want 'no template path' panic, got %v", rec)
+	}
+}
+
+func toStr(v any) string {
+	if e, ok := v.(error); ok {
+		return e.Error()
+	}
+	return fmtSprint(v)
+}

--- a/pkg/cardtmpl/json_template_test.go
+++ b/pkg/cardtmpl/json_template_test.go
@@ -101,9 +101,8 @@ func TestRegisterJSON_C1_RejectsBadFields(t *testing.T) {
 	}
 }
 
-// TestRegisterJSON_MissingTemplateFile_FailClose asserts a JSON view whose
-// template path does not exist panics at register time (fail-close), not at
-// first render.
+// TestRegisterJSON_FallbackText_DerivesPlain asserts FallbackText compiles the
+// view and reduces it to plain text carrying the card's title.
 func TestRegisterJSON_FallbackText_DerivesPlain(t *testing.T) {
 	reg := NewRegistry()
 	reg.RegisterJSON(jsonCardTestData, "testdata/test.jsoncard@0.1.0")
@@ -127,6 +126,14 @@ func TestRegisterJSON_FallbackText_DerivesPlain(t *testing.T) {
 // caller-injected dangerous markdown link in a text field is caught by the L0
 // backstop cardmsg.Validate (positive URL allowlist over TextBlock markdown
 // links), which renderCore runs on the compiled card → ErrRenderFailed.
+//
+// The fields are FULLY valid (rows present) so Build SUCCEEDS and the injected
+// link actually reaches renderCore step-8 cardmsg.Validate — the layer under
+// test. An earlier version omitted "rows", so Build failed first with
+// `field "rows" not found` and the assertion passed vacuously without ever
+// exercising Validate (both build failures and Validate failures wrap
+// ErrRenderFailed). This test now asserts the cardmsg.Validate wrapper specifically
+// and adds a benign-title control proving the link is the sole cause (PR #654 P1).
 func TestRegisterJSON_MarkdownLinkInjection_RejectedByValidate(t *testing.T) {
 	reg := NewRegistry()
 	reg.RegisterJSON(jsonCardTestData, "testdata/test.jsoncard@0.1.0")
@@ -134,15 +141,30 @@ func TestRegisterJSON_MarkdownLinkInjection_RejectedByValidate(t *testing.T) {
 	reg.Freeze()
 
 	// title carries a javascript: markdown link; schema permits it (plain string),
-	// so it must be the render-layer Validate that rejects it.
-	fields := json.RawMessage(`{"title":"[tap](javascript:alert(1))","expanded":false}`)
-	_, err := reg.Render(context.Background(), "test.jsoncard", "0.1.0", "shown", fields,
+	// so it must be the render-layer Validate that rejects it. rows/expanded are
+	// present so Build succeeds and the link reaches step 8.
+	const validTail = `,"expanded":true,"rows":[{"label":"a"}]}`
+	malicious := json.RawMessage(`{"title":"[tap](javascript:alert(1))"` + validTail)
+	_, err := reg.Render(context.Background(), "test.jsoncard", "0.1.0", "shown", malicious,
 		BuildEnv{Lang: "zh-CN", SpaceID: "s1"})
 	if err == nil {
 		t.Fatal("expected ErrRenderFailed (Validate rejects non-https markdown link), got nil — engine has an injection gap")
 	}
 	if !strings.Contains(err.Error(), ErrRenderFailed.Error()) {
-		t.Fatalf("want ErrRenderFailed from cardmsg.Validate, got %v", err)
+		t.Fatalf("want ErrRenderFailed, got %v", err)
+	}
+	// Must be the step-8 cardmsg.Validate rejection, NOT an earlier Build failure —
+	// both wrap ErrRenderFailed, so pinning the Validate wrapper is the whole point.
+	if !strings.Contains(err.Error(), "cardmsg.Validate") {
+		t.Fatalf("injection must be caught by cardmsg.Validate (render step 8), got %v", err)
+	}
+
+	// Benign-title control: identical fields, safe title → renders cleanly. Proves
+	// the injected link (not a missing/!valid field) is the sole cause above.
+	benign := json.RawMessage(`{"title":"tap here"` + validTail)
+	if _, err := reg.Render(context.Background(), "test.jsoncard", "0.1.0", "shown", benign,
+		BuildEnv{Lang: "zh-CN", SpaceID: "s1"}); err != nil {
+		t.Fatalf("benign control must render cleanly, got %v", err)
 	}
 }
 

--- a/pkg/cardtmpl/jsontmpl/conformance_test.go
+++ b/pkg/cardtmpl/jsontmpl/conformance_test.go
@@ -1,0 +1,140 @@
+package jsontmpl
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+)
+
+// TestConformance_ReasoningGoldens is the engine's byte-equivalence oracle: for
+// every sample in the ai.reasoning-process handoff, expand the state's view
+// template and assert the result matches the shipped golden (canonical JSON —
+// sorted keys — since key order is not semantically meaningful and Go maps are
+// unordered). This proves the ACT subset the engine implements reproduces the
+// authoring tool's compiled output. Escaping is identity here: the goldens bind
+// data literally (decision D6; cardmsg.Validate is the security backstop at the
+// Registry layer, not markdown-escaping in the engine).
+func TestConformance_ReasoningGoldens(t *testing.T) {
+	root := filepath.Join("testdata", "ai.reasoning-process@0.1.0")
+
+	// state → view is read from the manifest (views[].states + views[].template),
+	// never guessed from sample file names (brief acceptance D1).
+	stateToView, viewToTemplate := loadViewMaps(t, filepath.Join(root, "manifest.json"))
+
+	// sample file name == golden file name in this handoff.
+	samples := []string{"reasoning", "answering", "completed", "stopped", "error"}
+
+	for _, name := range samples {
+		t.Run(name, func(t *testing.T) {
+			data := readObject(t, filepath.Join(root, "samples", name+".json"))
+			state, _ := data["state"].(string)
+			view, ok := stateToView[state]
+			if !ok {
+				t.Fatalf("manifest declares no view for state %q", state)
+			}
+			tmplPath, ok := viewToTemplate[view]
+			if !ok || tmplPath == "" {
+				t.Fatalf("manifest view %q declares no template", view)
+			}
+			tmpl := readJSON(t, filepath.Join(root, tmplPath))
+
+			got, err := Expand(tmpl, Scope{Data: data}, func(s string) string { return s })
+			if err != nil {
+				t.Fatalf("expand %s (view %s): %v", name, view, err)
+			}
+			golden := readJSON(t, filepath.Join(root, "goldens", name+".card.json"))
+
+			if g, w := canonJSON(t, got), canonJSON(t, golden); g != w {
+				t.Fatalf("golden mismatch for %s (view %s)\n--- got ---\n%s\n--- want ---\n%s", name, view, g, w)
+			}
+		})
+	}
+}
+
+// loadViewMaps reads manifest.views into state→view and view→templatePath maps.
+func loadViewMaps(t *testing.T, manifestPath string) (map[string]string, map[string]string) {
+	t.Helper()
+	m := readObject(t, manifestPath)
+	views, ok := m["views"].(map[string]any)
+	if !ok {
+		t.Fatalf("manifest has no views object")
+	}
+	stateToView := map[string]string{}
+	viewToTemplate := map[string]string{}
+	for view, raw := range views {
+		v, _ := raw.(map[string]any)
+		if tpl, _ := v["template"].(string); tpl != "" {
+			viewToTemplate[view] = tpl
+		}
+		states, _ := v["states"].([]any)
+		for _, s := range states {
+			if st, ok := s.(string); ok {
+				stateToView[st] = view
+			}
+		}
+	}
+	if len(stateToView) == 0 {
+		t.Fatalf("manifest views declare no states")
+	}
+	return stateToView, viewToTemplate
+}
+
+func readJSON(t *testing.T, path string) any {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	var v any
+	if err := json.Unmarshal(b, &v); err != nil {
+		t.Fatalf("unmarshal %s: %v", path, err)
+	}
+	return v
+}
+
+func readObject(t *testing.T, path string) map[string]any {
+	t.Helper()
+	v := readJSON(t, path)
+	m, ok := v.(map[string]any)
+	if !ok {
+		t.Fatalf("%s is not a JSON object", path)
+	}
+	return m
+}
+
+// canonJSON marshals with sorted keys (recursively) so comparison is order-
+// independent.
+func canonJSON(t *testing.T, v any) string {
+	t.Helper()
+	b, err := json.MarshalIndent(sortKeys(v), "", "  ")
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return string(b)
+}
+
+func sortKeys(v any) any {
+	switch x := v.(type) {
+	case map[string]any:
+		ks := make([]string, 0, len(x))
+		for k := range x {
+			ks = append(ks, k)
+		}
+		sort.Strings(ks)
+		m := make(map[string]any, len(x))
+		for _, k := range ks {
+			m[k] = sortKeys(x[k])
+		}
+		return m
+	case []any:
+		out := make([]any, len(x))
+		for i := range x {
+			out[i] = sortKeys(x[i])
+		}
+		return out
+	default:
+		return v
+	}
+}

--- a/pkg/cardtmpl/jsontmpl/conformance_test.go
+++ b/pkg/cardtmpl/jsontmpl/conformance_test.go
@@ -1,6 +1,7 @@
 package jsontmpl
 
 import (
+	"context"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -40,7 +41,7 @@ func TestConformance_ReasoningGoldens(t *testing.T) {
 			}
 			tmpl := readJSON(t, filepath.Join(root, tmplPath))
 
-			got, err := Expand(tmpl, Scope{Data: data}, func(s string) string { return s })
+			got, err := Expand(context.Background(), tmpl, Scope{Data: data}, func(s string) string { return s })
 			if err != nil {
 				t.Fatalf("expand %s (view %s): %v", name, view, err)
 			}

--- a/pkg/cardtmpl/jsontmpl/expand.go
+++ b/pkg/cardtmpl/jsontmpl/expand.go
@@ -1,0 +1,96 @@
+package jsontmpl
+
+import "fmt"
+
+// dataDirective is the reserved key that marks an element for $data-driven
+// repetition; it is consumed during expansion and never emitted.
+const dataDirective = "$data"
+
+// Expand walks a parsed Adaptive Card template (map/slice/scalar tree) and
+// returns a new tree with every ${...} expression resolved against sc. Objects
+// carrying a `$data` directive are repeated once per array element (with a loop
+// scope exposing `$index`); the directive key itself is dropped. String leaves
+// go through EvalValue, so a whole-value `"${bool}"` becomes a native boolean
+// and caller data is escaped. The input tree is never mutated.
+func Expand(node any, sc Scope, escape EscapeFunc) (any, error) {
+	switch n := node.(type) {
+	case map[string]any:
+		return expandObject(n, sc, escape)
+	case []any:
+		return expandArray(n, sc, escape)
+	case string:
+		return EvalValue(n, sc, escape)
+	default:
+		// bool / float64 / nil literals pass through unchanged.
+		return node, nil
+	}
+}
+
+// expandObject expands every value of m under sc, skipping the $data directive
+// key (repetition is handled by expandArray on the parent).
+func expandObject(m map[string]any, sc Scope, escape EscapeFunc) (map[string]any, error) {
+	out := make(map[string]any, len(m))
+	for k, v := range m {
+		if k == dataDirective {
+			continue
+		}
+		ev, err := Expand(v, sc, escape)
+		if err != nil {
+			return nil, err
+		}
+		out[k] = ev
+	}
+	return out, nil
+}
+
+// expandArray expands each element; an element object carrying `$data` is
+// repeated once per resolved array item under a loop scope.
+func expandArray(arr []any, sc Scope, escape EscapeFunc) ([]any, error) {
+	out := make([]any, 0, len(arr))
+	for _, el := range arr {
+		if m, ok := el.(map[string]any); ok {
+			if raw, has := m[dataDirective]; has {
+				items, err := resolveDataArray(raw, sc, escape)
+				if err != nil {
+					return nil, err
+				}
+				for i, item := range items {
+					itemData, ok := item.(map[string]any)
+					if !ok {
+						return nil, fmt.Errorf("jsontmpl: $data element %d is %T, want object", i, item)
+					}
+					expanded, err := expandObject(m, Scope{Data: itemData, Index: i, InLoop: true}, escape)
+					if err != nil {
+						return nil, err
+					}
+					out = append(out, expanded)
+				}
+				continue
+			}
+		}
+		expanded, err := Expand(el, sc, escape)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, expanded)
+	}
+	return out, nil
+}
+
+// resolveDataArray evaluates a `$data` binding (a `"${field}"` string) to the
+// backing array. The result must be a JSON array; anything else is an error.
+func resolveDataArray(raw any, sc Scope, escape EscapeFunc) ([]any, error) {
+	expr, ok := raw.(string)
+	if !ok {
+		return nil, fmt.Errorf("jsontmpl: $data must be a %q string, got %T", "${...}", raw)
+	}
+	v, err := EvalValue(expr, sc, escape)
+	if err != nil {
+		return nil, err
+	}
+	arr, ok := v.([]any)
+	if !ok {
+		return nil, fmt.Errorf("jsontmpl: $data %q resolved to %T, want array", expr, v)
+	}
+	return arr, nil
+}

--- a/pkg/cardtmpl/jsontmpl/expand.go
+++ b/pkg/cardtmpl/jsontmpl/expand.go
@@ -104,6 +104,16 @@ func (e *expander) expandArray(arr []any, sc Scope) ([]any, error) {
 					if err := e.ctx.Err(); err != nil {
 						return nil, err
 					}
+					// Charge one budget unit per repetition BEFORE expanding it.
+					// expandObject only decrements for the element's *value* fields,
+					// so a directive-only element ({"$data":"${arr}"} with no sibling
+					// keys) would otherwise charge zero per item and let a large caller
+					// array bypass the maxExpandNodes ceiling entirely (PR #654 review:
+					// Jerry-Xin / yujiawei P1 — the emitted repetition is itself a node).
+					if e.budget <= 0 {
+						return nil, fmt.Errorf("jsontmpl: expansion exceeded %d-node budget (possible unbounded $data)", maxExpandNodes)
+					}
+					e.budget--
 					itemData, ok := item.(map[string]any)
 					if !ok {
 						return nil, fmt.Errorf("jsontmpl: $data element %d is %T, want object", i, item)

--- a/pkg/cardtmpl/jsontmpl/expand.go
+++ b/pkg/cardtmpl/jsontmpl/expand.go
@@ -1,10 +1,24 @@
 package jsontmpl
 
-import "fmt"
+import (
+	"context"
+	"fmt"
+)
 
 // dataDirective is the reserved key that marks an element for $data-driven
 // repetition; it is consumed during expansion and never emitted.
 const dataDirective = "$data"
+
+// maxExpandNodes bounds the total number of nodes a single Expand may emit. It is
+// a fail-closed backstop against unbounded / multiplicative $data expansion
+// (CWE-400/770, PR #654 review): a caller-supplied $data array repeats its element
+// template once per item and nested $data multiplies, so without a ceiling a large
+// array would allocate the whole tree before cardmsg.Validate — the functional
+// MaxNodes gate, which renderCore only runs AFTER Build — ever sees it. The cap
+// sits far above the largest shipped golden (~600 nodes) so it never rejects a
+// legitimate template, but turns a runaway array from unbounded allocation into a
+// fast, bounded error.
+const maxExpandNodes = 10000
 
 // Expand walks a parsed Adaptive Card template (map/slice/scalar tree) and
 // returns a new tree with every ${...} expression resolved against sc. Objects
@@ -12,14 +26,44 @@ const dataDirective = "$data"
 // scope exposing `$index`); the directive key itself is dropped. String leaves
 // go through EvalValue, so a whole-value `"${bool}"` becomes a native boolean
 // and caller data is escaped. The input tree is never mutated.
-func Expand(node any, sc Scope, escape EscapeFunc) (any, error) {
+//
+// ctx is honored between nodes so a caller cancel/deadline interrupts a large
+// expansion (R2-7 context propagation); the total emitted nodes are bounded by
+// maxExpandNodes (see the const). A nil ctx is treated as context.Background().
+func Expand(ctx context.Context, node any, sc Scope, escape EscapeFunc) (any, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	ex := &expander{ctx: ctx, escape: escape, budget: maxExpandNodes}
+	return ex.expand(node, sc)
+}
+
+// expander carries the per-Expand state shared across the whole recursion: the
+// caller ctx (for cancellation), the data escaper, and the remaining node budget.
+type expander struct {
+	ctx    context.Context
+	escape EscapeFunc
+	budget int
+}
+
+// expand dispatches on node kind, decrementing the shared node budget and
+// checking the caller ctx before each node so a runaway/cancelled expansion stops
+// promptly instead of allocating the full tree.
+func (e *expander) expand(node any, sc Scope) (any, error) {
+	if err := e.ctx.Err(); err != nil {
+		return nil, err
+	}
+	if e.budget <= 0 {
+		return nil, fmt.Errorf("jsontmpl: expansion exceeded %d-node budget (possible unbounded $data)", maxExpandNodes)
+	}
+	e.budget--
 	switch n := node.(type) {
 	case map[string]any:
-		return expandObject(n, sc, escape)
+		return e.expandObject(n, sc)
 	case []any:
-		return expandArray(n, sc, escape)
+		return e.expandArray(n, sc)
 	case string:
-		return EvalValue(n, sc, escape)
+		return EvalValue(n, sc, e.escape)
 	default:
 		// bool / float64 / nil literals pass through unchanged.
 		return node, nil
@@ -28,13 +72,13 @@ func Expand(node any, sc Scope, escape EscapeFunc) (any, error) {
 
 // expandObject expands every value of m under sc, skipping the $data directive
 // key (repetition is handled by expandArray on the parent).
-func expandObject(m map[string]any, sc Scope, escape EscapeFunc) (map[string]any, error) {
+func (e *expander) expandObject(m map[string]any, sc Scope) (map[string]any, error) {
 	out := make(map[string]any, len(m))
 	for k, v := range m {
 		if k == dataDirective {
 			continue
 		}
-		ev, err := Expand(v, sc, escape)
+		ev, err := e.expand(v, sc)
 		if err != nil {
 			return nil, err
 		}
@@ -44,22 +88,27 @@ func expandObject(m map[string]any, sc Scope, escape EscapeFunc) (map[string]any
 }
 
 // expandArray expands each element; an element object carrying `$data` is
-// repeated once per resolved array item under a loop scope.
-func expandArray(arr []any, sc Scope, escape EscapeFunc) ([]any, error) {
+// repeated once per resolved array item under a loop scope. Each repetition is
+// budget-counted (via expandObject → expand on its values) and ctx-checked, so a
+// large or multiplicative $data array fails fast rather than allocating in full.
+func (e *expander) expandArray(arr []any, sc Scope) ([]any, error) {
 	out := make([]any, 0, len(arr))
 	for _, el := range arr {
 		if m, ok := el.(map[string]any); ok {
 			if raw, has := m[dataDirective]; has {
-				items, err := resolveDataArray(raw, sc, escape)
+				items, err := e.resolveDataArray(raw, sc)
 				if err != nil {
 					return nil, err
 				}
 				for i, item := range items {
+					if err := e.ctx.Err(); err != nil {
+						return nil, err
+					}
 					itemData, ok := item.(map[string]any)
 					if !ok {
 						return nil, fmt.Errorf("jsontmpl: $data element %d is %T, want object", i, item)
 					}
-					expanded, err := expandObject(m, Scope{Data: itemData, Index: i, InLoop: true}, escape)
+					expanded, err := e.expandObject(m, Scope{Data: itemData, Index: i, InLoop: true})
 					if err != nil {
 						return nil, err
 					}
@@ -68,7 +117,7 @@ func expandArray(arr []any, sc Scope, escape EscapeFunc) ([]any, error) {
 				continue
 			}
 		}
-		expanded, err := Expand(el, sc, escape)
+		expanded, err := e.expand(el, sc)
 		if err != nil {
 			return nil, err
 		}
@@ -79,12 +128,12 @@ func expandArray(arr []any, sc Scope, escape EscapeFunc) ([]any, error) {
 
 // resolveDataArray evaluates a `$data` binding (a `"${field}"` string) to the
 // backing array. The result must be a JSON array; anything else is an error.
-func resolveDataArray(raw any, sc Scope, escape EscapeFunc) ([]any, error) {
+func (e *expander) resolveDataArray(raw any, sc Scope) ([]any, error) {
 	expr, ok := raw.(string)
 	if !ok {
 		return nil, fmt.Errorf("jsontmpl: $data must be a %q string, got %T", "${...}", raw)
 	}
-	v, err := EvalValue(expr, sc, escape)
+	v, err := EvalValue(expr, sc, e.escape)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cardtmpl/jsontmpl/expand_test.go
+++ b/pkg/cardtmpl/jsontmpl/expand_test.go
@@ -191,3 +191,41 @@ func TestExpand_EscapesDataLeaf(t *testing.T) {
 		t.Fatalf("got %s want %s", canonical(t, got), canonical(t, want))
 	}
 }
+
+// TestExpand_DirectiveOnlyElement_ChargesBudget locks the PR #654 P1 fix:
+// a $data repetition element carrying ONLY the directive (no sibling value
+// fields) must still charge the node budget per item, so a large caller array
+// cannot bypass maxExpandNodes. Before the fix this expanded 50k items with a
+// nil error (expandObject charged zero for a keyless element).
+func TestExpand_DirectiveOnlyElement_ChargesBudget(t *testing.T) {
+	// directive-only repeated element over an over-cap array.
+	tmpl := parseJSON(t, `{"items":[{"$data":"${rows}"}]}`)
+	rows := make([]any, maxExpandNodes+1)
+	for i := range rows {
+		rows[i] = map[string]any{} // object (satisfies the element-must-be-object check)
+	}
+	data := map[string]any{"rows": rows}
+
+	_, err := Expand(context.Background(), tmpl, Scope{Data: data}, noEscape)
+	if err == nil {
+		t.Fatal("expected node-budget error for directive-only element over an over-cap $data array")
+	}
+	if !strings.Contains(err.Error(), "node budget") {
+		t.Fatalf("want node-budget error, got %v", err)
+	}
+}
+
+// TestExpand_UnderBudget_DirectiveOnly confirms a directive-only element under
+// the cap still expands correctly (charging per item, not rejecting legit use).
+func TestExpand_UnderBudget_DirectiveOnly(t *testing.T) {
+	tmpl := parseJSON(t, `{"items":[{"$data":"${rows}","type":"TextBlock","text":"${label}"}]}`)
+	data := dataMap(t, `{"rows":[{"label":"a"},{"label":"b"},{"label":"c"}]}`)
+	got, err := Expand(context.Background(), tmpl, Scope{Data: data}, noEscape)
+	if err != nil {
+		t.Fatalf("under-budget expand failed: %v", err)
+	}
+	items := got.(map[string]any)["items"].([]any)
+	if len(items) != 3 {
+		t.Fatalf("items = %d, want 3", len(items))
+	}
+}

--- a/pkg/cardtmpl/jsontmpl/expand_test.go
+++ b/pkg/cardtmpl/jsontmpl/expand_test.go
@@ -1,0 +1,149 @@
+package jsontmpl
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// parseJSON is a test helper: unmarshal a template/data literal into any.
+func parseJSON(t *testing.T, s string) any {
+	t.Helper()
+	var v any
+	if err := json.Unmarshal([]byte(s), &v); err != nil {
+		t.Fatalf("parseJSON: %v", err)
+	}
+	return v
+}
+
+func dataMap(t *testing.T, s string) map[string]any {
+	t.Helper()
+	v := parseJSON(t, s)
+	m, ok := v.(map[string]any)
+	if !ok {
+		t.Fatalf("dataMap: not an object: %T", v)
+	}
+	return m
+}
+
+// canonical marshals with sorted keys (encoding/json sorts map keys) so tests
+// compare structure, not key order.
+func canonical(t *testing.T, v any) string {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return string(b)
+}
+
+func TestExpand_FieldBinding(t *testing.T) {
+	tmpl := parseJSON(t, `{"type":"TextBlock","text":"${title}"}`)
+	data := dataMap(t, `{"title":"hello"}`)
+	got, err := Expand(tmpl, Scope{Data: data}, noEscape)
+	if err != nil {
+		t.Fatalf("expand: %v", err)
+	}
+	want := parseJSON(t, `{"type":"TextBlock","text":"hello"}`)
+	if canonical(t, got) != canonical(t, want) {
+		t.Fatalf("got %s want %s", canonical(t, got), canonical(t, want))
+	}
+}
+
+func TestExpand_TypedBoolBinding(t *testing.T) {
+	tmpl := parseJSON(t, `{"type":"Container","isVisible":"${traceExpanded}"}`)
+	data := dataMap(t, `{"traceExpanded":false}`)
+	got, err := Expand(tmpl, Scope{Data: data}, noEscape)
+	if err != nil {
+		t.Fatalf("expand: %v", err)
+	}
+	// isVisible must be a real JSON boolean, not the string "false".
+	want := parseJSON(t, `{"type":"Container","isVisible":false}`)
+	if canonical(t, got) != canonical(t, want) {
+		t.Fatalf("got %s want %s", canonical(t, got), canonical(t, want))
+	}
+}
+
+func TestExpand_DataArrayRepeatsWithIndex(t *testing.T) {
+	tmpl := parseJSON(t, `{
+		"type":"Container",
+		"items":[
+			{"$data":"${phases}","type":"TextBlock","text":"${thought}","spacing":"${if($index == 0, 'None', 'Large')}"},
+			{"type":"TextBlock","text":"footer"}
+		]
+	}`)
+	data := dataMap(t, `{"phases":[{"thought":"a"},{"thought":"b"}]}`)
+	got, err := Expand(tmpl, Scope{Data: data}, noEscape)
+	if err != nil {
+		t.Fatalf("expand: %v", err)
+	}
+	want := parseJSON(t, `{
+		"type":"Container",
+		"items":[
+			{"type":"TextBlock","text":"a","spacing":"None"},
+			{"type":"TextBlock","text":"b","spacing":"Large"},
+			{"type":"TextBlock","text":"footer"}
+		]
+	}`)
+	if canonical(t, got) != canonical(t, want) {
+		t.Fatalf("\n got %s\nwant %s", canonical(t, got), canonical(t, want))
+	}
+}
+
+func TestExpand_NestedDataScopes(t *testing.T) {
+	tmpl := parseJSON(t, `{
+		"$data":"${phases}",
+		"type":"Container",
+		"items":[
+			{"$data":"${actions}","type":"TextBlock","text":"${tool}"}
+		]
+	}`)
+	// wrap in an array so the outer $data repetition is observable
+	root := []any{tmpl}
+	data := dataMap(t, `{"phases":[{"actions":[{"tool":"x"},{"tool":"y"}]}]}`)
+	got, err := Expand(root, Scope{Data: data}, noEscape)
+	if err != nil {
+		t.Fatalf("expand: %v", err)
+	}
+	want := parseJSON(t, `[{
+		"type":"Container",
+		"items":[
+			{"type":"TextBlock","text":"x"},
+			{"type":"TextBlock","text":"y"}
+		]
+	}]`)
+	if canonical(t, got) != canonical(t, want) {
+		t.Fatalf("\n got %s\nwant %s", canonical(t, got), canonical(t, want))
+	}
+}
+
+func TestExpand_DataNotArray_Errors(t *testing.T) {
+	tmpl := parseJSON(t, `{"items":[{"$data":"${notarr}","type":"X"}]}`)
+	data := dataMap(t, `{"notarr":"scalar"}`)
+	if _, err := Expand(tmpl, Scope{Data: data}, noEscape); err == nil {
+		t.Fatal("expected error when $data does not resolve to an array")
+	}
+}
+
+func TestExpand_StaticPassthrough(t *testing.T) {
+	tmpl := parseJSON(t, `{"type":"AdaptiveCard","version":"1.5","bleed":true,"spacing":"None"}`)
+	got, err := Expand(tmpl, Scope{Data: map[string]any{}}, noEscape)
+	if err != nil {
+		t.Fatalf("expand: %v", err)
+	}
+	if canonical(t, got) != canonical(t, tmpl) {
+		t.Fatalf("got %s want %s", canonical(t, got), canonical(t, tmpl))
+	}
+}
+
+func TestExpand_EscapesDataLeaf(t *testing.T) {
+	tmpl := parseJSON(t, `{"text":"${detail}"}`)
+	data := dataMap(t, `{"detail":"a*b"}`)
+	got, err := Expand(tmpl, Scope{Data: data}, markdownish)
+	if err != nil {
+		t.Fatalf("expand: %v", err)
+	}
+	want := parseJSON(t, `{"text":"a\\*b"}`)
+	if canonical(t, got) != canonical(t, want) {
+		t.Fatalf("got %s want %s", canonical(t, got), canonical(t, want))
+	}
+}

--- a/pkg/cardtmpl/jsontmpl/expand_test.go
+++ b/pkg/cardtmpl/jsontmpl/expand_test.go
@@ -1,9 +1,53 @@
 package jsontmpl
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
+	"strings"
 	"testing"
 )
+
+// bigDataArray builds a $data-driven template plus a data array of n items, used
+// by the expansion-budget and cancellation tests.
+func bigDataArray(n int) (any, Scope) {
+	tmpl := map[string]any{
+		"items": []any{
+			map[string]any{"$data": "${rows}", "type": "TextBlock", "text": "${label}"},
+		},
+	}
+	rows := make([]any, n)
+	for i := range rows {
+		rows[i] = map[string]any{"label": "x"}
+	}
+	return tmpl, Scope{Data: map[string]any{"rows": rows}}
+}
+
+// TestExpand_UnboundedDataArray_FailsFast asserts a $data array far larger than
+// maxExpandNodes is rejected with a bounded budget error rather than expanded in
+// full (DoS backstop, PR #654).
+func TestExpand_UnboundedDataArray_FailsFast(t *testing.T) {
+	tmpl, sc := bigDataArray(maxExpandNodes * 3)
+	_, err := Expand(context.Background(), tmpl, sc, noEscape)
+	if err == nil {
+		t.Fatal("expected expansion-budget error for an oversized $data array")
+	}
+	if !strings.Contains(err.Error(), "budget") {
+		t.Fatalf("want a budget error, got %v", err)
+	}
+}
+
+// TestExpand_ContextCancelled_Stops asserts a cancelled ctx interrupts expansion
+// (R2-7 context propagation, PR #654).
+func TestExpand_ContextCancelled_Stops(t *testing.T) {
+	tmpl, sc := bigDataArray(1000)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // pre-cancel: the very first node check must bail out
+	_, err := Expand(ctx, tmpl, sc, noEscape)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("want context.Canceled, got %v", err)
+	}
+}
 
 // parseJSON is a test helper: unmarshal a template/data literal into any.
 func parseJSON(t *testing.T, s string) any {
@@ -39,7 +83,7 @@ func canonical(t *testing.T, v any) string {
 func TestExpand_FieldBinding(t *testing.T) {
 	tmpl := parseJSON(t, `{"type":"TextBlock","text":"${title}"}`)
 	data := dataMap(t, `{"title":"hello"}`)
-	got, err := Expand(tmpl, Scope{Data: data}, noEscape)
+	got, err := Expand(context.Background(), tmpl, Scope{Data: data}, noEscape)
 	if err != nil {
 		t.Fatalf("expand: %v", err)
 	}
@@ -52,7 +96,7 @@ func TestExpand_FieldBinding(t *testing.T) {
 func TestExpand_TypedBoolBinding(t *testing.T) {
 	tmpl := parseJSON(t, `{"type":"Container","isVisible":"${traceExpanded}"}`)
 	data := dataMap(t, `{"traceExpanded":false}`)
-	got, err := Expand(tmpl, Scope{Data: data}, noEscape)
+	got, err := Expand(context.Background(), tmpl, Scope{Data: data}, noEscape)
 	if err != nil {
 		t.Fatalf("expand: %v", err)
 	}
@@ -72,7 +116,7 @@ func TestExpand_DataArrayRepeatsWithIndex(t *testing.T) {
 		]
 	}`)
 	data := dataMap(t, `{"phases":[{"thought":"a"},{"thought":"b"}]}`)
-	got, err := Expand(tmpl, Scope{Data: data}, noEscape)
+	got, err := Expand(context.Background(), tmpl, Scope{Data: data}, noEscape)
 	if err != nil {
 		t.Fatalf("expand: %v", err)
 	}
@@ -100,7 +144,7 @@ func TestExpand_NestedDataScopes(t *testing.T) {
 	// wrap in an array so the outer $data repetition is observable
 	root := []any{tmpl}
 	data := dataMap(t, `{"phases":[{"actions":[{"tool":"x"},{"tool":"y"}]}]}`)
-	got, err := Expand(root, Scope{Data: data}, noEscape)
+	got, err := Expand(context.Background(), root, Scope{Data: data}, noEscape)
 	if err != nil {
 		t.Fatalf("expand: %v", err)
 	}
@@ -119,14 +163,14 @@ func TestExpand_NestedDataScopes(t *testing.T) {
 func TestExpand_DataNotArray_Errors(t *testing.T) {
 	tmpl := parseJSON(t, `{"items":[{"$data":"${notarr}","type":"X"}]}`)
 	data := dataMap(t, `{"notarr":"scalar"}`)
-	if _, err := Expand(tmpl, Scope{Data: data}, noEscape); err == nil {
+	if _, err := Expand(context.Background(), tmpl, Scope{Data: data}, noEscape); err == nil {
 		t.Fatal("expected error when $data does not resolve to an array")
 	}
 }
 
 func TestExpand_StaticPassthrough(t *testing.T) {
 	tmpl := parseJSON(t, `{"type":"AdaptiveCard","version":"1.5","bleed":true,"spacing":"None"}`)
-	got, err := Expand(tmpl, Scope{Data: map[string]any{}}, noEscape)
+	got, err := Expand(context.Background(), tmpl, Scope{Data: map[string]any{}}, noEscape)
 	if err != nil {
 		t.Fatalf("expand: %v", err)
 	}
@@ -138,7 +182,7 @@ func TestExpand_StaticPassthrough(t *testing.T) {
 func TestExpand_EscapesDataLeaf(t *testing.T) {
 	tmpl := parseJSON(t, `{"text":"${detail}"}`)
 	data := dataMap(t, `{"detail":"a*b"}`)
-	got, err := Expand(tmpl, Scope{Data: data}, markdownish)
+	got, err := Expand(context.Background(), tmpl, Scope{Data: data}, markdownish)
 	if err != nil {
 		t.Fatalf("expand: %v", err)
 	}

--- a/pkg/cardtmpl/jsontmpl/expr.go
+++ b/pkg/cardtmpl/jsontmpl/expr.go
@@ -138,19 +138,79 @@ func evalIf(args string, sc Scope) (any, error) {
 // in the supported subset).
 func evalCond(src string, sc Scope) (bool, error) {
 	src = strings.TrimSpace(src)
-	idx := strings.Index(src, "==")
-	if idx < 0 {
+	lraw, rraw, ok := splitEquality(src)
+	if !ok {
 		return false, fmt.Errorf("jsontmpl: unsupported condition %q (only == is supported)", src)
 	}
-	left, err := evalOperand(strings.TrimSpace(src[:idx]), sc)
+	left, err := evalOperand(strings.TrimSpace(lraw), sc)
 	if err != nil {
 		return false, err
 	}
-	right, err := evalOperand(strings.TrimSpace(src[idx+2:]), sc)
+	right, err := evalOperand(strings.TrimSpace(rraw), sc)
 	if err != nil {
 		return false, err
 	}
-	return left == right, nil
+	return equalOperands(left, right)
+}
+
+// splitEquality finds the top-level `==` operator that is not inside a single-
+// quoted string literal and returns the two operand substrings. ok=false when
+// there is no such operator (so `'a==b'` alone is not mistaken for a comparison).
+func splitEquality(s string) (left, right string, ok bool) {
+	inQuote := false
+	for i := 0; i+1 < len(s); i++ {
+		switch s[i] {
+		case '\'':
+			inQuote = !inQuote
+		case '=':
+			if !inQuote && s[i+1] == '=' {
+				return s[:i], s[i+2:], true
+			}
+		}
+	}
+	return "", "", false
+}
+
+// equalOperands compares two evaluated operands with equality semantics for the
+// bounded subset (string / bool / number). Numbers coerce across int and float64
+// — JSON numbers unmarshal to float64 while integer literals and $index are int,
+// and Go's `==` is false across differing concrete types, so a raw `left == right`
+// would take the wrong branch for `${if(count == 1, …)}` on JSON data. Kinds that
+// `==` cannot compare (slice / map / func) return a clean error instead of
+// panicking. (PR #654 review.)
+func equalOperands(l, r any) (bool, error) {
+	if lf, lok := toFloat(l); lok {
+		rf, rok := toFloat(r)
+		return rok && lf == rf, nil // number vs non-number is never equal
+	}
+	switch l.(type) {
+	case string, bool, nil:
+		// r's dynamic type may differ (e.g. string vs bool); comparing two
+		// interfaces of differing comparable types is false, not a panic.
+		switch r.(type) {
+		case string, bool, nil:
+			return l == r, nil
+		default:
+			return false, nil
+		}
+	default:
+		return false, fmt.Errorf("jsontmpl: cannot compare %T with == (unsupported operand type)", l)
+	}
+}
+
+// toFloat coerces the numeric kinds the evaluator produces to float64 for
+// cross-type equality; ok=false for non-numeric values.
+func toFloat(v any) (float64, bool) {
+	switch n := v.(type) {
+	case int:
+		return float64(n), true
+	case int64:
+		return float64(n), true
+	case float64:
+		return n, true
+	default:
+		return 0, false
+	}
 }
 
 // evalOperand resolves a single token: `$index`, an integer/bool/'string'

--- a/pkg/cardtmpl/jsontmpl/expr.go
+++ b/pkg/cardtmpl/jsontmpl/expr.go
@@ -1,0 +1,241 @@
+// Package jsontmpl is a dependency-free evaluator for the bounded subset of the
+// Adaptive Card Templating language used by Registry-backed JSON card templates
+// (roadmap E1). It intentionally implements only the syntax exercised by the
+// shipped handoff templates — single-identifier field bindings, `$index`,
+// `if($index == N, a, b)`, string interpolation, and typed whole-value binding.
+// Anything outside that subset is a hard error, never a silent passthrough
+// (see the package brief, decision D4: freeze the subset, extend via L0 PR).
+//
+// The package holds no cardtmpl dependency: the markdown escaper is injected as
+// an EscapeFunc so the trust boundary (template text is trusted, caller-supplied
+// data is escaped) is enforced by the caller that owns the escaping authority.
+package jsontmpl
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// Scope is the data frame an expression is evaluated against. Data is the
+// current object (root object, or the current element inside a $data loop);
+// Index/InLoop carry the iteration position for `$index`.
+type Scope struct {
+	Data   map[string]any
+	Index  int
+	InLoop bool
+}
+
+// EscapeFunc escapes a caller-supplied string before it lands in card text.
+// The expander injects cardtmpl's markdown escaper here.
+type EscapeFunc func(string) string
+
+// EvalValue evaluates a JSON string value that may embed ${...} expressions:
+//   - no ${...}                     → the literal string, unchanged
+//   - exactly one ${expr} (no other text) → the typed result of expr; a bool or
+//     number stays native, a string result is escaped
+//   - literal text mixed with ${expr}(s)  → string interpolation: each expr
+//     result is stringified and escaped, literals are emitted verbatim (so
+//     trusted template punctuation is never mangled, only data is escaped)
+func EvalValue(raw string, sc Scope, escape EscapeFunc) (any, error) {
+	segs, err := splitSegments(raw)
+	if err != nil {
+		return nil, err
+	}
+	if len(segs) == 1 && !segs[0].isExpr {
+		return segs[0].text, nil
+	}
+	if len(segs) == 1 && segs[0].isExpr {
+		v, err := evalExpr(segs[0].text, sc)
+		if err != nil {
+			return nil, err
+		}
+		if s, ok := v.(string); ok {
+			return escape(s), nil
+		}
+		return v, nil
+	}
+	var b strings.Builder
+	for _, seg := range segs {
+		if !seg.isExpr {
+			b.WriteString(seg.text)
+			continue
+		}
+		v, err := evalExpr(seg.text, sc)
+		if err != nil {
+			return nil, err
+		}
+		b.WriteString(escape(stringify(v)))
+	}
+	return b.String(), nil
+}
+
+type segment struct {
+	text   string
+	isExpr bool
+}
+
+// splitSegments splits raw into alternating literal / ${expr} segments. No
+// nested braces occur in the supported subset, so the first '}' after '${'
+// closes the expression.
+func splitSegments(raw string) ([]segment, error) {
+	var segs []segment
+	for {
+		i := strings.Index(raw, "${")
+		if i < 0 {
+			if raw != "" {
+				segs = append(segs, segment{text: raw})
+			}
+			break
+		}
+		if i > 0 {
+			segs = append(segs, segment{text: raw[:i]})
+		}
+		rest := raw[i+2:]
+		j := strings.IndexByte(rest, '}')
+		if j < 0 {
+			return nil, fmt.Errorf("jsontmpl: unterminated ${ in %q", raw)
+		}
+		segs = append(segs, segment{text: strings.TrimSpace(rest[:j]), isExpr: true})
+		raw = rest[j+1:]
+	}
+	if len(segs) == 0 {
+		segs = append(segs, segment{text: ""})
+	}
+	return segs, nil
+}
+
+// evalExpr evaluates the inside of a ${...}: an if(...) call, `$index`, an
+// integer/bool/'string' literal, or a single identifier resolved in scope.
+func evalExpr(src string, sc Scope) (any, error) {
+	src = strings.TrimSpace(src)
+	if strings.HasPrefix(src, "if(") && strings.HasSuffix(src, ")") {
+		return evalIf(src[len("if("):len(src)-1], sc)
+	}
+	return evalOperand(src, sc)
+}
+
+// evalIf evaluates the comma-separated args of if(cond, then, else).
+func evalIf(args string, sc Scope) (any, error) {
+	parts, err := splitArgs(args)
+	if err != nil {
+		return nil, err
+	}
+	if len(parts) != 3 {
+		return nil, fmt.Errorf("jsontmpl: if() takes 3 args, got %d in %q", len(parts), args)
+	}
+	cond, err := evalCond(parts[0], sc)
+	if err != nil {
+		return nil, err
+	}
+	if cond {
+		return evalOperand(strings.TrimSpace(parts[1]), sc)
+	}
+	return evalOperand(strings.TrimSpace(parts[2]), sc)
+}
+
+// evalCond evaluates a `LEFT == RIGHT` equality condition (the only comparison
+// in the supported subset).
+func evalCond(src string, sc Scope) (bool, error) {
+	src = strings.TrimSpace(src)
+	idx := strings.Index(src, "==")
+	if idx < 0 {
+		return false, fmt.Errorf("jsontmpl: unsupported condition %q (only == is supported)", src)
+	}
+	left, err := evalOperand(strings.TrimSpace(src[:idx]), sc)
+	if err != nil {
+		return false, err
+	}
+	right, err := evalOperand(strings.TrimSpace(src[idx+2:]), sc)
+	if err != nil {
+		return false, err
+	}
+	return left == right, nil
+}
+
+// evalOperand resolves a single token: `$index`, an integer/bool/'string'
+// literal, or an identifier looked up in scope data.
+func evalOperand(tok string, sc Scope) (any, error) {
+	tok = strings.TrimSpace(tok)
+	switch {
+	case tok == "$index":
+		if !sc.InLoop {
+			return nil, fmt.Errorf("jsontmpl: $index used outside a $data loop")
+		}
+		return sc.Index, nil
+	case tok == "true":
+		return true, nil
+	case tok == "false":
+		return false, nil
+	case len(tok) >= 2 && tok[0] == '\'' && tok[len(tok)-1] == '\'':
+		return tok[1 : len(tok)-1], nil
+	}
+	if n, err := strconv.Atoi(tok); err == nil {
+		return n, nil
+	}
+	if !isIdentifier(tok) {
+		return nil, fmt.Errorf("jsontmpl: unsupported expression token %q", tok)
+	}
+	v, ok := sc.Data[tok]
+	if !ok {
+		return nil, fmt.Errorf("jsontmpl: field %q not found in data", tok)
+	}
+	return v, nil
+}
+
+func isIdentifier(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r == '_':
+		case i > 0 && r >= '0' && r <= '9':
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// splitArgs splits comma-separated args, respecting single-quoted literals.
+func splitArgs(s string) ([]string, error) {
+	var (
+		parts   []string
+		cur     strings.Builder
+		inQuote bool
+	)
+	for _, r := range s {
+		switch {
+		case r == '\'':
+			inQuote = !inQuote
+			cur.WriteRune(r)
+		case r == ',' && !inQuote:
+			parts = append(parts, cur.String())
+			cur.Reset()
+		default:
+			cur.WriteRune(r)
+		}
+	}
+	if inQuote {
+		return nil, fmt.Errorf("jsontmpl: unterminated quote in %q", s)
+	}
+	parts = append(parts, cur.String())
+	return parts, nil
+}
+
+// stringify renders a non-string eval result for interpolation.
+func stringify(v any) string {
+	switch t := v.(type) {
+	case string:
+		return t
+	case bool:
+		return strconv.FormatBool(t)
+	case int:
+		return strconv.Itoa(t)
+	case float64:
+		return strconv.FormatFloat(t, 'g', -1, 64)
+	default:
+		return fmt.Sprintf("%v", t)
+	}
+}

--- a/pkg/cardtmpl/jsontmpl/expr_test.go
+++ b/pkg/cardtmpl/jsontmpl/expr_test.go
@@ -1,0 +1,164 @@
+package jsontmpl
+
+import "testing"
+
+// identity escaper for tests that don't exercise markdown escaping.
+func noEscape(s string) string { return s }
+
+// markdownish is a tiny stand-in for cardtmpl.escapeMarkdown so the jsontmpl
+// package stays dependency-free; it escapes only the two metacharacters the
+// escaping tests below rely on.
+func markdownish(s string) string {
+	out := make([]rune, 0, len(s))
+	for _, r := range s {
+		if r == '*' || r == '_' {
+			out = append(out, '\\')
+		}
+		out = append(out, r)
+	}
+	return string(out)
+}
+
+func TestEvalValue_PlainLiteral(t *testing.T) {
+	got, err := EvalValue("Hello world", Scope{}, noEscape)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if got != "Hello world" {
+		t.Fatalf("got %#v, want %q", got, "Hello world")
+	}
+}
+
+func TestEvalValue_WholeStringField_ReturnsString(t *testing.T) {
+	sc := Scope{Data: map[string]any{"title": "已深度思考"}}
+	got, err := EvalValue("${title}", sc, noEscape)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if got != "已深度思考" {
+		t.Fatalf("got %#v, want %q", got, "已深度思考")
+	}
+}
+
+func TestEvalValue_WholeStringBool_ReturnsNativeBool(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		val  any
+		want bool
+	}{
+		{"true", true, true},
+		{"false", false, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			sc := Scope{Data: map[string]any{"traceExpanded": tc.val}}
+			got, err := EvalValue("${traceExpanded}", sc, noEscape)
+			if err != nil {
+				t.Fatalf("unexpected err: %v", err)
+			}
+			b, ok := got.(bool)
+			if !ok {
+				t.Fatalf("got %T (%#v), want bool", got, got)
+			}
+			if b != tc.want {
+				t.Fatalf("got %v, want %v", b, tc.want)
+			}
+		})
+	}
+}
+
+func TestEvalValue_Interpolation_LiteralPlusData(t *testing.T) {
+	sc := Scope{Data: map[string]any{"title": "已深度思考"}}
+	got, err := EvalValue("✦  ${title}", sc, noEscape)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if got != "✦  已深度思考" {
+		t.Fatalf("got %#v, want %q", got, "✦  已深度思考")
+	}
+}
+
+func TestEvalValue_IfIndexZero_StringBranches(t *testing.T) {
+	cases := []struct {
+		name  string
+		index int
+		expr  string
+		want  string
+	}{
+		{"index0->None", 0, "${if($index == 0, 'None', 'Large')}", "None"},
+		{"index2->Large", 2, "${if($index == 0, 'None', 'Large')}", "Large"},
+		{"index0->None-small", 0, "${if($index == 0, 'None', 'Small')}", "None"},
+		{"index1->Small", 1, "${if($index == 0, 'None', 'Small')}", "Small"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			sc := Scope{Index: tc.index, InLoop: true}
+			got, err := EvalValue(tc.expr, sc, noEscape)
+			if err != nil {
+				t.Fatalf("unexpected err: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("got %#v, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestEvalValue_IfIndexZero_BoolBranches(t *testing.T) {
+	cases := []struct {
+		index int
+		want  bool
+	}{
+		{0, false},
+		{1, true},
+	}
+	for _, tc := range cases {
+		sc := Scope{Index: tc.index, InLoop: true}
+		got, err := EvalValue("${if($index == 0, false, true)}", sc, noEscape)
+		if err != nil {
+			t.Fatalf("index %d: unexpected err: %v", tc.index, err)
+		}
+		b, ok := got.(bool)
+		if !ok {
+			t.Fatalf("index %d: got %T, want bool", tc.index, got)
+		}
+		if b != tc.want {
+			t.Fatalf("index %d: got %v, want %v", tc.index, b, tc.want)
+		}
+	}
+}
+
+func TestEvalValue_EscapesData_WholeString(t *testing.T) {
+	sc := Scope{Data: map[string]any{"detail": "a*b_c"}}
+	got, err := EvalValue("${detail}", sc, markdownish)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if got != `a\*b\_c` {
+		t.Fatalf("got %#v, want %q", got, `a\*b\_c`)
+	}
+}
+
+func TestEvalValue_EscapesDataButNotLiteral_Interpolation(t *testing.T) {
+	// The literal prefix "*# " is template-authored (trusted) and must NOT be
+	// escaped; only the data value ${title} is escaped.
+	sc := Scope{Data: map[string]any{"title": "*x*"}}
+	got, err := EvalValue("*# ${title}", sc, markdownish)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if got != `*# \*x\*` {
+		t.Fatalf("got %#v, want %q", got, `*# \*x\*`)
+	}
+}
+
+func TestEvalValue_MissingField_Errors(t *testing.T) {
+	if _, err := EvalValue("${nope}", Scope{Data: map[string]any{}}, noEscape); err == nil {
+		t.Fatal("expected error for missing field, got nil")
+	}
+}
+
+func TestEvalValue_IndexOutsideLoop_Errors(t *testing.T) {
+	if _, err := EvalValue("${if($index == 0, 'a', 'b')}", Scope{}, noEscape); err == nil {
+		t.Fatal("expected error for $index outside loop, got nil")
+	}
+}

--- a/pkg/cardtmpl/jsontmpl/expr_test.go
+++ b/pkg/cardtmpl/jsontmpl/expr_test.go
@@ -162,3 +162,39 @@ func TestEvalValue_IndexOutsideLoop_Errors(t *testing.T) {
 		t.Fatal("expected error for $index outside loop, got nil")
 	}
 }
+
+// TestEvalCond_NumericIntVsFloat asserts a condition comparing an int literal to
+// a JSON number (float64) still matches — Go's raw `==` is false across the two
+// concrete types, which would take the wrong if() branch (PR #654 P3).
+func TestEvalCond_NumericIntVsFloat(t *testing.T) {
+	sc := Scope{Data: map[string]any{"count": float64(1)}} // JSON numbers unmarshal to float64
+	got, err := EvalValue("${if(count == 1, 'yes', 'no')}", sc, noEscape)
+	if err != nil {
+		t.Fatalf("eval: %v", err)
+	}
+	if got != "yes" {
+		t.Fatalf("float64(1) == int(1) should be true, got %#v", got)
+	}
+}
+
+// TestEvalCond_EqualsInsideStringLiteral asserts the `==` inside a single-quoted
+// literal is not mistaken for the comparison operator (PR #654 P3).
+func TestEvalCond_EqualsInsideStringLiteral(t *testing.T) {
+	sc := Scope{Data: map[string]any{"k": "a==b"}}
+	got, err := EvalValue("${if(k == 'a==b', 'match', 'no')}", sc, noEscape)
+	if err != nil {
+		t.Fatalf("eval: %v", err)
+	}
+	if got != "match" {
+		t.Fatalf("quoted '==' literal should compare equal, got %#v", got)
+	}
+}
+
+// TestEvalCond_UncomparableOperand_Errors asserts comparing an array-valued
+// operand with `==` returns a clean error instead of panicking (PR #654 P3).
+func TestEvalCond_UncomparableOperand_Errors(t *testing.T) {
+	sc := Scope{Data: map[string]any{"arr": []any{1, 2}}}
+	if _, err := EvalValue("${if(arr == 1, 'a', 'b')}", sc, noEscape); err == nil {
+		t.Fatal("expected error comparing an array operand with ==, got nil")
+	}
+}

--- a/pkg/cardtmpl/jsontmpl/testdata/ai.reasoning-process@0.1.0/contract/data.schema.json
+++ b/pkg/cardtmpl/jsontmpl/testdata/ai.reasoning-process@0.1.0/contract/data.schema.json
@@ -1,0 +1,241 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "推理过程卡数据契约",
+  "description": "AI 推理过程附件的展示型 ViewModel。消息作者、头像、时间与最终 Markdown 回答由消息容器负责，不进入卡片契约。",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "reasoningId",
+    "state",
+    "title",
+    "statusLabel",
+    "statusTone",
+    "timerText",
+    "traceExpanded",
+    "traceCollapsed",
+    "collapsedSummary",
+    "phases"
+  ],
+  "properties": {
+    "reasoningId": {
+      "type": "string",
+      "minLength": 1,
+      "description": "本轮推理的稳定标识，会随停止或重试动作回传。",
+      "examples": [
+        "reasoning-channel-b-001"
+      ]
+    },
+    "state": {
+      "type": "string",
+      "enum": [
+        "reasoning",
+        "answering",
+        "completed",
+        "stopped",
+        "error"
+      ],
+      "description": "卡片当前状态；宿主据此选择 active、result 或 error View。"
+    },
+    "title": {
+      "type": "string",
+      "minLength": 1,
+      "description": "推理卡标题。",
+      "examples": [
+        "已深度思考"
+      ]
+    },
+    "statusLabel": {
+      "type": "string",
+      "minLength": 1,
+      "description": "面向用户的状态文案。"
+    },
+    "statusTone": {
+      "type": "string",
+      "enum": [
+        "Accent",
+        "Good",
+        "Warning",
+        "Attention"
+      ],
+      "description": "Adaptive Cards 标准语义色。"
+    },
+    "timerText": {
+      "type": "string",
+      "minLength": 1,
+      "description": "耗时、阶段数和工具调用数的展示文案。"
+    },
+    "traceExpanded": {
+      "type": "boolean",
+      "description": "初始是否展示推理明细。"
+    },
+    "traceCollapsed": {
+      "type": "boolean",
+      "description": "初始是否展示收起摘要；应与 traceExpanded 互斥。"
+    },
+    "collapsedSummary": {
+      "type": "string",
+      "minLength": 1,
+      "description": "推理明细收起时的摘要。"
+    },
+    "progressText": {
+      "type": "string",
+      "minLength": 1,
+      "description": "活动态底部的实时进度提示。"
+    },
+    "phases": {
+      "type": "array",
+      "minItems": 1,
+      "description": "按发生顺序排列的推理阶段。仅包含可向用户展示的过程摘要，不承载隐藏的模型内部思维。",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "thought",
+          "actions"
+        ],
+        "properties": {
+          "thought": {
+            "type": "string",
+            "minLength": 1,
+            "description": "该阶段面向用户的推理摘要。"
+          },
+          "actions": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "tool",
+                "detail",
+                "statusGlyph",
+                "statusTone"
+              ],
+              "properties": {
+                "tool": {
+                  "type": "string",
+                  "minLength": 1,
+                  "description": "工具或步骤名称。"
+                },
+                "detail": {
+                  "type": "string",
+                  "minLength": 1,
+                  "description": "已脱敏的调用摘要。"
+                },
+                "statusGlyph": {
+                  "type": "string",
+                  "minLength": 1,
+                  "maxLength": 2,
+                  "description": "调用状态符号，例如 ●。"
+                },
+                "statusTone": {
+                  "type": "string",
+                  "enum": [
+                    "Accent",
+                    "Good",
+                    "Attention"
+                  ],
+                  "description": "工具调用状态的标准语义色。"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "errorTitle": {
+      "type": "string",
+      "minLength": 1,
+      "description": "失败态标题。"
+    },
+    "errorMessage": {
+      "type": "string",
+      "minLength": 1,
+      "description": "失败原因与用户可采取动作。"
+    }
+  },
+  "allOf": [
+    {
+      "oneOf": [
+        {
+          "properties": {
+            "traceExpanded": {
+              "const": true
+            },
+            "traceCollapsed": {
+              "const": false
+            }
+          }
+        },
+        {
+          "properties": {
+            "traceExpanded": {
+              "const": false
+            },
+            "traceCollapsed": {
+              "const": true
+            }
+          }
+        }
+      ]
+    },
+    {
+      "if": {
+        "properties": {
+          "state": {
+            "enum": [
+              "reasoning",
+              "answering"
+            ]
+          }
+        }
+      },
+      "then": {
+        "required": [
+          "progressText"
+        ]
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "state": {
+            "const": "error"
+          }
+        }
+      },
+      "then": {
+        "required": [
+          "errorTitle",
+          "errorMessage"
+        ]
+      }
+    }
+  ],
+  "examples": [
+    {
+      "reasoningId": "reasoning-channel-b-001",
+      "state": "completed",
+      "title": "已深度思考",
+      "statusLabel": "已完成",
+      "statusTone": "Good",
+      "timerText": "用时 12 秒 · 3 段推理 · 13 次工具调用",
+      "traceExpanded": false,
+      "traceCollapsed": true,
+      "collapsedSummary": "已思考 12 秒 · 推理过程已收起",
+      "phases": [
+        {
+          "thought": "先拆解漏斗并核对近 90 天数据。",
+          "actions": [
+            {
+              "tool": "query_metrics",
+              "detail": "channel=B · range=90d",
+              "statusGlyph": "●",
+              "statusTone": "Good"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/cardtmpl/jsontmpl/testdata/ai.reasoning-process@0.1.0/goldens/answering.card.json
+++ b/pkg/cardtmpl/jsontmpl/testdata/ai.reasoning-process@0.1.0/goldens/answering.card.json
@@ -1,0 +1,694 @@
+{
+  "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+  "type": "AdaptiveCard",
+  "version": "1.5",
+  "body": [
+    {
+      "type": "Container",
+      "id": "octo-surface-accent-header-reasoning-active",
+      "style": "accent",
+      "bleed": true,
+      "spacing": "None",
+      "items": [
+        {
+          "type": "ColumnSet",
+          "spacing": "None",
+          "columns": [
+            {
+              "type": "Column",
+              "width": "stretch",
+              "verticalContentAlignment": "Center",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "text": "✦  已深度思考",
+                  "color": "Accent",
+                  "weight": "Bolder",
+                  "wrap": true,
+                  "spacing": "None"
+                },
+                {
+                  "type": "TextBlock",
+                  "text": "正在生成回答…",
+                  "size": "Small",
+                  "isSubtle": true,
+                  "wrap": true,
+                  "spacing": "Small"
+                }
+              ]
+            },
+            {
+              "type": "Column",
+              "width": "auto",
+              "verticalContentAlignment": "Center",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "id": "octo-badge-reasoning-active-status",
+                  "text": "回答中",
+                  "color": "Accent",
+                  "weight": "Bolder",
+                  "size": "Small",
+                  "wrap": true,
+                  "spacing": "None"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "id": "trace_panel",
+      "isVisible": true,
+      "spacing": "Large",
+      "items": [
+        {
+          "type": "Container",
+          "spacing": "None",
+          "separator": false,
+          "items": [
+            {
+              "type": "TextBlock",
+              "text": "先拆分线索、试用激活与付费三段漏斗，核对近 90 天数据。",
+              "size": "Small",
+              "wrap": true,
+              "spacing": "None"
+            },
+            {
+              "type": "Container",
+              "style": "emphasis",
+              "spacing": "Small",
+              "items": [
+                {
+                  "type": "ColumnSet",
+                  "spacing": "None",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "query_metrics",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "channel=B · range=90d · group=stage",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "read_file",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "~/analytics/funnel_definition.sql · ×2",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "run_sql",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "按漏斗阶段汇总数量与转化率",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "Container",
+          "spacing": "Large",
+          "separator": true,
+          "items": [
+            {
+              "type": "TextBlock",
+              "text": "激活率的降幅高于线索量，交叉核验行业结构、客服工单、NPS 与季节性。",
+              "size": "Small",
+              "wrap": true,
+              "spacing": "None"
+            },
+            {
+              "type": "Container",
+              "style": "emphasis",
+              "spacing": "Small",
+              "items": [
+                {
+                  "type": "ColumnSet",
+                  "spacing": "None",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "query_metrics",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "按行业拆分激活率",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "search_tickets",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "渠道 B · 试用 / 激活失败 · 近 60 天",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "read_file",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "~/nps/2026Q2_channelB.csv",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "query_metrics",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "叠加节假日与季节性校正",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "Container",
+          "spacing": "Large",
+          "separator": true,
+          "items": [
+            {
+              "type": "TextBlock",
+              "text": "主因确认：教育与专业服务合计贡献 63% 降幅，激活断点集中在试用权益触达。",
+              "size": "Small",
+              "wrap": true,
+              "spacing": "None"
+            },
+            {
+              "type": "Container",
+              "style": "emphasis",
+              "spacing": "Small",
+              "items": [
+                {
+                  "type": "ColumnSet",
+                  "spacing": "None",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "run_sql",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "按行业汇总转化降幅贡献",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "edit_file",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "~/reports/channelB_rootcause.md · 已编辑",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Accent",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "think",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "正在组织结论、证据与下周建议…",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "TextBlock",
+          "text": "◌  推理已完成，正在生成回答…",
+          "color": "Accent",
+          "size": "Small",
+          "wrap": true,
+          "spacing": "Large"
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "id": "collapsed_panel",
+      "isVisible": false,
+      "spacing": "Medium",
+      "items": [
+        {
+          "type": "TextBlock",
+          "text": "✓  推理已完成 · 回答正在生成",
+          "size": "Small",
+          "isSubtle": true,
+          "wrap": true,
+          "spacing": "None"
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "id": "octo-surface-default-footer-reasoning-active",
+      "style": "emphasis",
+      "bleed": true,
+      "separator": true,
+      "spacing": "Large",
+      "items": [
+        {
+          "type": "ActionSet",
+          "horizontalAlignment": "Right",
+          "actions": [
+            {
+              "type": "Action.Submit",
+              "id": "reasoning_stop",
+              "title": "停止",
+              "style": "destructive",
+              "associatedInputs": "none",
+              "data": {
+                "action": "reasoning_stop",
+                "effect": "stop_reasoning",
+                "reasoning_id": "reasoning-channel-b-001"
+              }
+            },
+            {
+              "type": "Action.ToggleVisibility",
+              "id": "reasoning_toggle",
+              "title": "显示 / 隐藏推理",
+              "targetElements": [
+                "trace_panel",
+                "collapsed_panel"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/cardtmpl/jsontmpl/testdata/ai.reasoning-process@0.1.0/goldens/completed.card.json
+++ b/pkg/cardtmpl/jsontmpl/testdata/ai.reasoning-process@0.1.0/goldens/completed.card.json
@@ -1,0 +1,784 @@
+{
+  "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+  "type": "AdaptiveCard",
+  "version": "1.5",
+  "body": [
+    {
+      "type": "Container",
+      "id": "octo-surface-accent-header-reasoning-result",
+      "style": "accent",
+      "bleed": true,
+      "spacing": "None",
+      "items": [
+        {
+          "type": "ColumnSet",
+          "spacing": "None",
+          "columns": [
+            {
+              "type": "Column",
+              "width": "stretch",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "text": "✦  已深度思考",
+                  "color": "Accent",
+                  "weight": "Bolder",
+                  "wrap": true,
+                  "spacing": "None"
+                },
+                {
+                  "type": "TextBlock",
+                  "text": "用时 12 秒 · 3 段推理 · 13 次工具调用",
+                  "size": "Small",
+                  "isSubtle": true,
+                  "wrap": true,
+                  "spacing": "Small"
+                }
+              ]
+            },
+            {
+              "type": "Column",
+              "width": "auto",
+              "verticalContentAlignment": "Center",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "id": "octo-badge-reasoning-result-status",
+                  "text": "已完成",
+                  "color": "Good",
+                  "weight": "Bolder",
+                  "size": "Small",
+                  "wrap": true,
+                  "spacing": "None"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "id": "trace_panel",
+      "isVisible": false,
+      "spacing": "Large",
+      "items": [
+        {
+          "type": "Container",
+          "spacing": "None",
+          "separator": false,
+          "items": [
+            {
+              "type": "TextBlock",
+              "text": "先把渠道 B 转化下降的范围圈出来：拆成线索、试用激活、付费三段漏斗，取近 90 天数据。",
+              "size": "Small",
+              "wrap": true,
+              "spacing": "None"
+            },
+            {
+              "type": "Container",
+              "style": "emphasis",
+              "spacing": "Small",
+              "items": [
+                {
+                  "type": "ColumnSet",
+                  "spacing": "None",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "query_metrics",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "channel=B · range=90d · group=stage",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "read_file",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "~/analytics/funnel_definition.sql · ×2",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "run_sql",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "按漏斗阶段汇总数量与转化率",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "Container",
+          "spacing": "Large",
+          "separator": true,
+          "items": [
+            {
+              "type": "TextBlock",
+              "text": "激活率的降幅高于线索量，交叉核验行业结构、客服工单、NPS 与季节性。",
+              "size": "Small",
+              "wrap": true,
+              "spacing": "None"
+            },
+            {
+              "type": "Container",
+              "style": "emphasis",
+              "spacing": "Small",
+              "items": [
+                {
+                  "type": "ColumnSet",
+                  "spacing": "None",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "query_metrics",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "按行业拆分激活率",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "run_sql",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "对比各行业激活与付费转化",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "search_tickets",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "渠道 B · 试用 / 激活失败 · 近 60 天",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "read_file",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "~/nps/2026Q2_channelB.csv",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "query_metrics",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "叠加节假日与季节性校正",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "run_sql",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "逐周复核线索与激活数量",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "web_search",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "SaaS 行业 2026 试用政策调整",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "Container",
+          "spacing": "Large",
+          "separator": true,
+          "items": [
+            {
+              "type": "TextBlock",
+              "text": "主因确认：教育与专业服务合计贡献 63% 降幅，激活断点集中在试用权益触达。",
+              "size": "Small",
+              "wrap": true,
+              "spacing": "None"
+            },
+            {
+              "type": "Container",
+              "style": "emphasis",
+              "spacing": "Small",
+              "items": [
+                {
+                  "type": "ColumnSet",
+                  "spacing": "None",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "run_sql",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "按行业汇总转化降幅贡献",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "edit_file",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "~/reports/channelB_rootcause.md · 已编辑",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "think",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "拆分行业漏斗深挖与权益触达复盘",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "id": "collapsed_panel",
+      "isVisible": true,
+      "spacing": "Medium",
+      "items": [
+        {
+          "type": "TextBlock",
+          "text": "✓  已思考 12 秒 · 推理过程已收起",
+          "size": "Small",
+          "isSubtle": true,
+          "wrap": true,
+          "spacing": "None"
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "id": "octo-surface-default-footer-reasoning-result",
+      "style": "emphasis",
+      "bleed": true,
+      "separator": true,
+      "spacing": "Large",
+      "items": [
+        {
+          "type": "ActionSet",
+          "horizontalAlignment": "Right",
+          "actions": [
+            {
+              "type": "Action.ToggleVisibility",
+              "id": "reasoning_toggle",
+              "title": "显示 / 隐藏推理",
+              "targetElements": [
+                "trace_panel",
+                "collapsed_panel"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/cardtmpl/jsontmpl/testdata/ai.reasoning-process@0.1.0/goldens/error.card.json
+++ b/pkg/cardtmpl/jsontmpl/testdata/ai.reasoning-process@0.1.0/goldens/error.card.json
@@ -1,0 +1,420 @@
+{
+  "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+  "type": "AdaptiveCard",
+  "version": "1.5",
+  "body": [
+    {
+      "type": "Container",
+      "id": "octo-surface-accent-header-reasoning-error",
+      "style": "accent",
+      "bleed": true,
+      "spacing": "None",
+      "items": [
+        {
+          "type": "ColumnSet",
+          "spacing": "None",
+          "columns": [
+            {
+              "type": "Column",
+              "width": "stretch",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "text": "✦  已深度思考",
+                  "color": "Accent",
+                  "weight": "Bolder",
+                  "wrap": true,
+                  "spacing": "None"
+                },
+                {
+                  "type": "TextBlock",
+                  "text": "已中断",
+                  "size": "Small",
+                  "isSubtle": true,
+                  "wrap": true,
+                  "spacing": "Small"
+                }
+              ]
+            },
+            {
+              "type": "Column",
+              "width": "auto",
+              "verticalContentAlignment": "Center",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "id": "octo-badge-reasoning-error-status",
+                  "text": "生成失败",
+                  "color": "Attention",
+                  "weight": "Bolder",
+                  "size": "Small",
+                  "wrap": true,
+                  "spacing": "None"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "id": "trace_panel",
+      "isVisible": true,
+      "spacing": "Large",
+      "items": [
+        {
+          "type": "Container",
+          "spacing": "None",
+          "separator": false,
+          "items": [
+            {
+              "type": "TextBlock",
+              "text": "先拆分线索、试用激活与付费三段漏斗，核对近 90 天数据。",
+              "size": "Small",
+              "wrap": true,
+              "spacing": "None"
+            },
+            {
+              "type": "Container",
+              "style": "emphasis",
+              "spacing": "Small",
+              "items": [
+                {
+                  "type": "ColumnSet",
+                  "spacing": "None",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "query_metrics",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "channel=B · range=90d · group=stage",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "read_file",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "~/analytics/funnel_definition.sql · ×2",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "run_sql",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "按漏斗阶段汇总数量与转化率",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "Container",
+          "spacing": "Large",
+          "separator": true,
+          "items": [
+            {
+              "type": "TextBlock",
+              "text": "准备交叉核验行业结构、客服工单与 NPS 时，推理服务连接中断。",
+              "size": "Small",
+              "wrap": true,
+              "spacing": "None"
+            },
+            {
+              "type": "Container",
+              "style": "emphasis",
+              "spacing": "Small",
+              "items": [
+                {
+                  "type": "ColumnSet",
+                  "spacing": "None",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "query_metrics",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "按行业拆分激活率",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Attention",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "search_tickets",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "连接超时，调用未完成",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "id": "collapsed_panel",
+      "isVisible": false,
+      "spacing": "Medium",
+      "items": [
+        {
+          "type": "TextBlock",
+          "text": "生成已中断 · 点击可查看停止前的过程",
+          "size": "Small",
+          "isSubtle": true,
+          "wrap": true,
+          "spacing": "None"
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "style": "attention",
+      "spacing": "Large",
+      "items": [
+        {
+          "type": "TextBlock",
+          "text": "生成失败",
+          "color": "Attention",
+          "weight": "Bolder",
+          "wrap": true,
+          "spacing": "None"
+        },
+        {
+          "type": "TextBlock",
+          "text": "推理服务连接超时，已停止本次生成。可以重试，已完成的过程会保留。",
+          "wrap": true,
+          "spacing": "Small"
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "id": "octo-surface-default-footer-reasoning-error",
+      "style": "emphasis",
+      "bleed": true,
+      "separator": true,
+      "spacing": "Large",
+      "items": [
+        {
+          "type": "ActionSet",
+          "horizontalAlignment": "Right",
+          "actions": [
+            {
+              "type": "Action.Submit",
+              "id": "reasoning_retry",
+              "title": "重试",
+              "style": "positive",
+              "associatedInputs": "none",
+              "data": {
+                "action": "reasoning_retry",
+                "effect": "retry_reasoning",
+                "reasoning_id": "reasoning-channel-b-003"
+              }
+            },
+            {
+              "type": "Action.ToggleVisibility",
+              "id": "reasoning_toggle",
+              "title": "显示 / 隐藏推理",
+              "targetElements": [
+                "trace_panel",
+                "collapsed_panel"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/cardtmpl/jsontmpl/testdata/ai.reasoning-process@0.1.0/goldens/reasoning.card.json
+++ b/pkg/cardtmpl/jsontmpl/testdata/ai.reasoning-process@0.1.0/goldens/reasoning.card.json
@@ -1,0 +1,523 @@
+{
+  "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+  "type": "AdaptiveCard",
+  "version": "1.5",
+  "body": [
+    {
+      "type": "Container",
+      "id": "octo-surface-accent-header-reasoning-active",
+      "style": "accent",
+      "bleed": true,
+      "spacing": "None",
+      "items": [
+        {
+          "type": "ColumnSet",
+          "spacing": "None",
+          "columns": [
+            {
+              "type": "Column",
+              "width": "stretch",
+              "verticalContentAlignment": "Center",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "text": "✦  已深度思考",
+                  "color": "Accent",
+                  "weight": "Bolder",
+                  "wrap": true,
+                  "spacing": "None"
+                },
+                {
+                  "type": "TextBlock",
+                  "text": "正在深度思考…",
+                  "size": "Small",
+                  "isSubtle": true,
+                  "wrap": true,
+                  "spacing": "Small"
+                }
+              ]
+            },
+            {
+              "type": "Column",
+              "width": "auto",
+              "verticalContentAlignment": "Center",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "id": "octo-badge-reasoning-active-status",
+                  "text": "思考中",
+                  "color": "Accent",
+                  "weight": "Bolder",
+                  "size": "Small",
+                  "wrap": true,
+                  "spacing": "None"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "id": "trace_panel",
+      "isVisible": true,
+      "spacing": "Large",
+      "items": [
+        {
+          "type": "Container",
+          "spacing": "None",
+          "separator": false,
+          "items": [
+            {
+              "type": "TextBlock",
+              "text": "先把渠道 B 转化下降的范围圈出来：拆成线索、试用激活、付费三段漏斗，取近 90 天数据。",
+              "size": "Small",
+              "wrap": true,
+              "spacing": "None"
+            },
+            {
+              "type": "Container",
+              "style": "emphasis",
+              "spacing": "Small",
+              "items": [
+                {
+                  "type": "ColumnSet",
+                  "spacing": "None",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "query_metrics",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "channel=B · range=90d · group=stage",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "read_file",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "~/analytics/funnel_definition.sql · ×2",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "run_sql",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "按漏斗阶段汇总数量与转化率",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "Container",
+          "spacing": "Large",
+          "separator": true,
+          "items": [
+            {
+              "type": "TextBlock",
+              "text": "口径正常，但激活率掉得比线索量快；继续拉行业标签、客服工单和 NPS 交叉验证。",
+              "size": "Small",
+              "wrap": true,
+              "spacing": "None"
+            },
+            {
+              "type": "Container",
+              "style": "emphasis",
+              "spacing": "Small",
+              "items": [
+                {
+                  "type": "ColumnSet",
+                  "spacing": "None",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "query_metrics",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "channel=B · dims=industry · metric=activation_rate",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "search_tickets",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "渠道 B · 试用 / 激活失败 · 近 60 天",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "read_file",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "~/nps/2026Q2_channelB.csv",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Accent",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "query_metrics",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "正在叠加季节性校正…",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "TextBlock",
+          "text": "◌  正在执行下一步…",
+          "color": "Accent",
+          "size": "Small",
+          "wrap": true,
+          "spacing": "Large"
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "id": "collapsed_panel",
+      "isVisible": false,
+      "spacing": "Medium",
+      "items": [
+        {
+          "type": "TextBlock",
+          "text": "✓  推理仍在进行 · 点击可查看当前过程",
+          "size": "Small",
+          "isSubtle": true,
+          "wrap": true,
+          "spacing": "None"
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "id": "octo-surface-default-footer-reasoning-active",
+      "style": "emphasis",
+      "bleed": true,
+      "separator": true,
+      "spacing": "Large",
+      "items": [
+        {
+          "type": "ActionSet",
+          "horizontalAlignment": "Right",
+          "actions": [
+            {
+              "type": "Action.Submit",
+              "id": "reasoning_stop",
+              "title": "停止",
+              "style": "destructive",
+              "associatedInputs": "none",
+              "data": {
+                "action": "reasoning_stop",
+                "effect": "stop_reasoning",
+                "reasoning_id": "reasoning-channel-b-001"
+              }
+            },
+            {
+              "type": "Action.ToggleVisibility",
+              "id": "reasoning_toggle",
+              "title": "显示 / 隐藏推理",
+              "targetElements": [
+                "trace_panel",
+                "collapsed_panel"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/cardtmpl/jsontmpl/testdata/ai.reasoning-process@0.1.0/goldens/stopped.card.json
+++ b/pkg/cardtmpl/jsontmpl/testdata/ai.reasoning-process@0.1.0/goldens/stopped.card.json
@@ -1,0 +1,387 @@
+{
+  "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+  "type": "AdaptiveCard",
+  "version": "1.5",
+  "body": [
+    {
+      "type": "Container",
+      "id": "octo-surface-accent-header-reasoning-result",
+      "style": "accent",
+      "bleed": true,
+      "spacing": "None",
+      "items": [
+        {
+          "type": "ColumnSet",
+          "spacing": "None",
+          "columns": [
+            {
+              "type": "Column",
+              "width": "stretch",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "text": "✦  已深度思考",
+                  "color": "Accent",
+                  "weight": "Bolder",
+                  "wrap": true,
+                  "spacing": "None"
+                },
+                {
+                  "type": "TextBlock",
+                  "text": "已思考 6 秒 · 已停止于第 2 段",
+                  "size": "Small",
+                  "isSubtle": true,
+                  "wrap": true,
+                  "spacing": "Small"
+                }
+              ]
+            },
+            {
+              "type": "Column",
+              "width": "auto",
+              "verticalContentAlignment": "Center",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "id": "octo-badge-reasoning-result-status",
+                  "text": "已停止",
+                  "color": "Warning",
+                  "weight": "Bolder",
+                  "size": "Small",
+                  "wrap": true,
+                  "spacing": "None"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "id": "trace_panel",
+      "isVisible": false,
+      "spacing": "Large",
+      "items": [
+        {
+          "type": "Container",
+          "spacing": "None",
+          "separator": false,
+          "items": [
+            {
+              "type": "TextBlock",
+              "text": "先拆分线索、试用激活与付费三段漏斗，核对近 90 天数据。",
+              "size": "Small",
+              "wrap": true,
+              "spacing": "None"
+            },
+            {
+              "type": "Container",
+              "style": "emphasis",
+              "spacing": "Small",
+              "items": [
+                {
+                  "type": "ColumnSet",
+                  "spacing": "None",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "query_metrics",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "channel=B · range=90d · group=stage",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "read_file",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "~/analytics/funnel_definition.sql · ×2",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "run_sql",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "按漏斗阶段汇总数量与转化率",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "Container",
+          "spacing": "Large",
+          "separator": true,
+          "items": [
+            {
+              "type": "TextBlock",
+              "text": "激活率降幅高于线索量，开始按行业与试用权益触达交叉核验。",
+              "size": "Small",
+              "wrap": true,
+              "spacing": "None"
+            },
+            {
+              "type": "Container",
+              "style": "emphasis",
+              "spacing": "Small",
+              "items": [
+                {
+                  "type": "ColumnSet",
+                  "spacing": "None",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "query_metrics",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "按行业拆分激活率",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Accent",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "search_tickets",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "调用已由用户停止",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "id": "collapsed_panel",
+      "isVisible": true,
+      "spacing": "Medium",
+      "items": [
+        {
+          "type": "TextBlock",
+          "text": "✓  已保留停止前的 2 段推理过程",
+          "size": "Small",
+          "isSubtle": true,
+          "wrap": true,
+          "spacing": "None"
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "id": "octo-surface-default-footer-reasoning-result",
+      "style": "emphasis",
+      "bleed": true,
+      "separator": true,
+      "spacing": "Large",
+      "items": [
+        {
+          "type": "ActionSet",
+          "horizontalAlignment": "Right",
+          "actions": [
+            {
+              "type": "Action.ToggleVisibility",
+              "id": "reasoning_toggle",
+              "title": "显示 / 隐藏推理",
+              "targetElements": [
+                "trace_panel",
+                "collapsed_panel"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/cardtmpl/jsontmpl/testdata/ai.reasoning-process@0.1.0/manifest.json
+++ b/pkg/cardtmpl/jsontmpl/testdata/ai.reasoning-process@0.1.0/manifest.json
@@ -1,0 +1,47 @@
+{
+  "schemaVersion": 2,
+  "id": "ai.reasoning-process",
+  "name": "推理过程卡",
+  "version": "0.1.0",
+  "contractVersion": "1.0.0",
+  "adaptiveCardVersion": "1.5",
+  "renderProfile": "octo-chat@latest",
+  "defaultLocale": "zh-CN",
+  "dataSchema": "contract/data.schema.json",
+  "views": {
+    "active": {
+      "wireProfile": "octo/v2",
+      "template": "templates/active.template.json",
+      "samples": [
+        "samples/reasoning.json",
+        "samples/answering.json"
+      ],
+      "states": [
+        "reasoning",
+        "answering"
+      ]
+    },
+    "result": {
+      "wireProfile": "octo/v2",
+      "template": "templates/result.template.json",
+      "samples": [
+        "samples/completed.json",
+        "samples/stopped.json"
+      ],
+      "states": [
+        "completed",
+        "stopped"
+      ]
+    },
+    "error": {
+      "wireProfile": "octo/v2",
+      "template": "templates/error.template.json",
+      "samples": [
+        "samples/error.json"
+      ],
+      "states": [
+        "error"
+      ]
+    }
+  }
+}

--- a/pkg/cardtmpl/jsontmpl/testdata/ai.reasoning-process@0.1.0/samples/answering.json
+++ b/pkg/cardtmpl/jsontmpl/testdata/ai.reasoning-process@0.1.0/samples/answering.json
@@ -1,0 +1,89 @@
+{
+  "reasoningId": "reasoning-channel-b-001",
+  "state": "answering",
+  "title": "已深度思考",
+  "statusLabel": "回答中",
+  "statusTone": "Accent",
+  "timerText": "正在生成回答…",
+  "traceExpanded": true,
+  "traceCollapsed": false,
+  "collapsedSummary": "推理已完成 · 回答正在生成",
+  "progressText": "推理已完成，正在生成回答…",
+  "phases": [
+    {
+      "thought": "先拆分线索、试用激活与付费三段漏斗，核对近 90 天数据。",
+      "actions": [
+        {
+          "tool": "query_metrics",
+          "detail": "channel=B · range=90d · group=stage",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "read_file",
+          "detail": "~/analytics/funnel_definition.sql · ×2",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "run_sql",
+          "detail": "按漏斗阶段汇总数量与转化率",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        }
+      ]
+    },
+    {
+      "thought": "激活率的降幅高于线索量，交叉核验行业结构、客服工单、NPS 与季节性。",
+      "actions": [
+        {
+          "tool": "query_metrics",
+          "detail": "按行业拆分激活率",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "search_tickets",
+          "detail": "渠道 B · 试用 / 激活失败 · 近 60 天",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "read_file",
+          "detail": "~/nps/2026Q2_channelB.csv",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "query_metrics",
+          "detail": "叠加节假日与季节性校正",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        }
+      ]
+    },
+    {
+      "thought": "主因确认：教育与专业服务合计贡献 63% 降幅，激活断点集中在试用权益触达。",
+      "actions": [
+        {
+          "tool": "run_sql",
+          "detail": "按行业汇总转化降幅贡献",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "edit_file",
+          "detail": "~/reports/channelB_rootcause.md · 已编辑",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "think",
+          "detail": "正在组织结论、证据与下周建议…",
+          "statusGlyph": "●",
+          "statusTone": "Accent"
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/cardtmpl/jsontmpl/testdata/ai.reasoning-process@0.1.0/samples/completed.json
+++ b/pkg/cardtmpl/jsontmpl/testdata/ai.reasoning-process@0.1.0/samples/completed.json
@@ -1,0 +1,106 @@
+{
+  "reasoningId": "reasoning-channel-b-001",
+  "state": "completed",
+  "title": "已深度思考",
+  "statusLabel": "已完成",
+  "statusTone": "Good",
+  "timerText": "用时 12 秒 · 3 段推理 · 13 次工具调用",
+  "traceExpanded": false,
+  "traceCollapsed": true,
+  "collapsedSummary": "已思考 12 秒 · 推理过程已收起",
+  "phases": [
+    {
+      "thought": "先把渠道 B 转化下降的范围圈出来：拆成线索、试用激活、付费三段漏斗，取近 90 天数据。",
+      "actions": [
+        {
+          "tool": "query_metrics",
+          "detail": "channel=B · range=90d · group=stage",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "read_file",
+          "detail": "~/analytics/funnel_definition.sql · ×2",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "run_sql",
+          "detail": "按漏斗阶段汇总数量与转化率",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        }
+      ]
+    },
+    {
+      "thought": "激活率的降幅高于线索量，交叉核验行业结构、客服工单、NPS 与季节性。",
+      "actions": [
+        {
+          "tool": "query_metrics",
+          "detail": "按行业拆分激活率",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "run_sql",
+          "detail": "对比各行业激活与付费转化",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "search_tickets",
+          "detail": "渠道 B · 试用 / 激活失败 · 近 60 天",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "read_file",
+          "detail": "~/nps/2026Q2_channelB.csv",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "query_metrics",
+          "detail": "叠加节假日与季节性校正",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "run_sql",
+          "detail": "逐周复核线索与激活数量",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "web_search",
+          "detail": "SaaS 行业 2026 试用政策调整",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        }
+      ]
+    },
+    {
+      "thought": "主因确认：教育与专业服务合计贡献 63% 降幅，激活断点集中在试用权益触达。",
+      "actions": [
+        {
+          "tool": "run_sql",
+          "detail": "按行业汇总转化降幅贡献",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "edit_file",
+          "detail": "~/reports/channelB_rootcause.md · 已编辑",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "think",
+          "detail": "拆分行业漏斗深挖与权益触达复盘",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/cardtmpl/jsontmpl/testdata/ai.reasoning-process@0.1.0/samples/error.json
+++ b/pkg/cardtmpl/jsontmpl/testdata/ai.reasoning-process@0.1.0/samples/error.json
@@ -1,0 +1,55 @@
+{
+  "reasoningId": "reasoning-channel-b-003",
+  "state": "error",
+  "title": "已深度思考",
+  "statusLabel": "生成失败",
+  "statusTone": "Attention",
+  "timerText": "已中断",
+  "traceExpanded": true,
+  "traceCollapsed": false,
+  "collapsedSummary": "生成已中断 · 点击可查看停止前的过程",
+  "errorTitle": "生成失败",
+  "errorMessage": "推理服务连接超时，已停止本次生成。可以重试，已完成的过程会保留。",
+  "phases": [
+    {
+      "thought": "先拆分线索、试用激活与付费三段漏斗，核对近 90 天数据。",
+      "actions": [
+        {
+          "tool": "query_metrics",
+          "detail": "channel=B · range=90d · group=stage",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "read_file",
+          "detail": "~/analytics/funnel_definition.sql · ×2",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "run_sql",
+          "detail": "按漏斗阶段汇总数量与转化率",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        }
+      ]
+    },
+    {
+      "thought": "准备交叉核验行业结构、客服工单与 NPS 时，推理服务连接中断。",
+      "actions": [
+        {
+          "tool": "query_metrics",
+          "detail": "按行业拆分激活率",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "search_tickets",
+          "detail": "连接超时，调用未完成",
+          "statusGlyph": "●",
+          "statusTone": "Attention"
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/cardtmpl/jsontmpl/testdata/ai.reasoning-process@0.1.0/samples/reasoning.json
+++ b/pkg/cardtmpl/jsontmpl/testdata/ai.reasoning-process@0.1.0/samples/reasoning.json
@@ -1,0 +1,66 @@
+{
+  "reasoningId": "reasoning-channel-b-001",
+  "state": "reasoning",
+  "title": "已深度思考",
+  "statusLabel": "思考中",
+  "statusTone": "Accent",
+  "timerText": "正在深度思考…",
+  "traceExpanded": true,
+  "traceCollapsed": false,
+  "collapsedSummary": "推理仍在进行 · 点击可查看当前过程",
+  "progressText": "正在执行下一步…",
+  "phases": [
+    {
+      "thought": "先把渠道 B 转化下降的范围圈出来：拆成线索、试用激活、付费三段漏斗，取近 90 天数据。",
+      "actions": [
+        {
+          "tool": "query_metrics",
+          "detail": "channel=B · range=90d · group=stage",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "read_file",
+          "detail": "~/analytics/funnel_definition.sql · ×2",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "run_sql",
+          "detail": "按漏斗阶段汇总数量与转化率",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        }
+      ]
+    },
+    {
+      "thought": "口径正常，但激活率掉得比线索量快；继续拉行业标签、客服工单和 NPS 交叉验证。",
+      "actions": [
+        {
+          "tool": "query_metrics",
+          "detail": "channel=B · dims=industry · metric=activation_rate",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "search_tickets",
+          "detail": "渠道 B · 试用 / 激活失败 · 近 60 天",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "read_file",
+          "detail": "~/nps/2026Q2_channelB.csv",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "query_metrics",
+          "detail": "正在叠加季节性校正…",
+          "statusGlyph": "●",
+          "statusTone": "Accent"
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/cardtmpl/jsontmpl/testdata/ai.reasoning-process@0.1.0/samples/stopped.json
+++ b/pkg/cardtmpl/jsontmpl/testdata/ai.reasoning-process@0.1.0/samples/stopped.json
@@ -1,0 +1,53 @@
+{
+  "reasoningId": "reasoning-channel-b-002",
+  "state": "stopped",
+  "title": "已深度思考",
+  "statusLabel": "已停止",
+  "statusTone": "Warning",
+  "timerText": "已思考 6 秒 · 已停止于第 2 段",
+  "traceExpanded": false,
+  "traceCollapsed": true,
+  "collapsedSummary": "已保留停止前的 2 段推理过程",
+  "phases": [
+    {
+      "thought": "先拆分线索、试用激活与付费三段漏斗，核对近 90 天数据。",
+      "actions": [
+        {
+          "tool": "query_metrics",
+          "detail": "channel=B · range=90d · group=stage",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "read_file",
+          "detail": "~/analytics/funnel_definition.sql · ×2",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "run_sql",
+          "detail": "按漏斗阶段汇总数量与转化率",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        }
+      ]
+    },
+    {
+      "thought": "激活率降幅高于线索量，开始按行业与试用权益触达交叉核验。",
+      "actions": [
+        {
+          "tool": "query_metrics",
+          "detail": "按行业拆分激活率",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "search_tickets",
+          "detail": "调用已由用户停止",
+          "statusGlyph": "●",
+          "statusTone": "Accent"
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/cardtmpl/jsontmpl/testdata/ai.reasoning-process@0.1.0/templates/active.template.json
+++ b/pkg/cardtmpl/jsontmpl/testdata/ai.reasoning-process@0.1.0/templates/active.template.json
@@ -1,0 +1,204 @@
+{
+  "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+  "type": "AdaptiveCard",
+  "version": "1.5",
+  "body": [
+    {
+      "type": "Container",
+      "id": "octo-surface-accent-header-reasoning-active",
+      "style": "accent",
+      "bleed": true,
+      "spacing": "None",
+      "items": [
+        {
+          "type": "ColumnSet",
+          "spacing": "None",
+          "columns": [
+            {
+              "type": "Column",
+              "width": "stretch",
+              "verticalContentAlignment": "Center",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "text": "✦  ${title}",
+                  "color": "Accent",
+                  "weight": "Bolder",
+                  "wrap": true,
+                  "spacing": "None"
+                },
+                {
+                  "type": "TextBlock",
+                  "text": "${timerText}",
+                  "size": "Small",
+                  "isSubtle": true,
+                  "wrap": true,
+                  "spacing": "Small"
+                }
+              ]
+            },
+            {
+              "type": "Column",
+              "width": "auto",
+              "verticalContentAlignment": "Center",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "id": "octo-badge-reasoning-active-status",
+                  "text": "${statusLabel}",
+                  "color": "${statusTone}",
+                  "weight": "Bolder",
+                  "size": "Small",
+                  "wrap": true,
+                  "spacing": "None"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "id": "trace_panel",
+      "isVisible": "${traceExpanded}",
+      "spacing": "Large",
+      "items": [
+        {
+          "$data": "${phases}",
+          "type": "Container",
+          "spacing": "${if($index == 0, 'None', 'Large')}",
+          "separator": "${if($index == 0, false, true)}",
+          "items": [
+            {
+              "type": "TextBlock",
+              "text": "${thought}",
+              "size": "Small",
+              "wrap": true,
+              "spacing": "None"
+            },
+            {
+              "type": "Container",
+              "style": "emphasis",
+              "spacing": "Small",
+              "items": [
+                {
+                  "$data": "${actions}",
+                  "type": "ColumnSet",
+                  "spacing": "${if($index == 0, 'None', 'Small')}",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "${statusGlyph}",
+                          "color": "${statusTone}",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "${tool}",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "${detail}",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "TextBlock",
+          "text": "◌  ${progressText}",
+          "color": "Accent",
+          "size": "Small",
+          "wrap": true,
+          "spacing": "Large"
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "id": "collapsed_panel",
+      "isVisible": "${traceCollapsed}",
+      "spacing": "Medium",
+      "items": [
+        {
+          "type": "TextBlock",
+          "text": "✓  ${collapsedSummary}",
+          "size": "Small",
+          "isSubtle": true,
+          "wrap": true,
+          "spacing": "None"
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "id": "octo-surface-default-footer-reasoning-active",
+      "style": "emphasis",
+      "bleed": true,
+      "separator": true,
+      "spacing": "Large",
+      "items": [
+        {
+          "type": "ActionSet",
+          "horizontalAlignment": "Right",
+          "actions": [
+            {
+              "type": "Action.Submit",
+              "id": "reasoning_stop",
+              "title": "停止",
+              "style": "destructive",
+              "associatedInputs": "none",
+              "data": {
+                "action": "reasoning_stop",
+                "effect": "stop_reasoning",
+                "reasoning_id": "${reasoningId}"
+              }
+            },
+            {
+              "type": "Action.ToggleVisibility",
+              "id": "reasoning_toggle",
+              "title": "显示 / 隐藏推理",
+              "targetElements": [
+                "trace_panel",
+                "collapsed_panel"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/cardtmpl/jsontmpl/testdata/ai.reasoning-process@0.1.0/templates/error.template.json
+++ b/pkg/cardtmpl/jsontmpl/testdata/ai.reasoning-process@0.1.0/templates/error.template.json
@@ -1,0 +1,213 @@
+{
+  "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+  "type": "AdaptiveCard",
+  "version": "1.5",
+  "body": [
+    {
+      "type": "Container",
+      "id": "octo-surface-accent-header-reasoning-error",
+      "style": "accent",
+      "bleed": true,
+      "spacing": "None",
+      "items": [
+        {
+          "type": "ColumnSet",
+          "spacing": "None",
+          "columns": [
+            {
+              "type": "Column",
+              "width": "stretch",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "text": "✦  ${title}",
+                  "color": "Accent",
+                  "weight": "Bolder",
+                  "wrap": true,
+                  "spacing": "None"
+                },
+                {
+                  "type": "TextBlock",
+                  "text": "${timerText}",
+                  "size": "Small",
+                  "isSubtle": true,
+                  "wrap": true,
+                  "spacing": "Small"
+                }
+              ]
+            },
+            {
+              "type": "Column",
+              "width": "auto",
+              "verticalContentAlignment": "Center",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "id": "octo-badge-reasoning-error-status",
+                  "text": "${statusLabel}",
+                  "color": "${statusTone}",
+                  "weight": "Bolder",
+                  "size": "Small",
+                  "wrap": true,
+                  "spacing": "None"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "id": "trace_panel",
+      "isVisible": "${traceExpanded}",
+      "spacing": "Large",
+      "items": [
+        {
+          "$data": "${phases}",
+          "type": "Container",
+          "spacing": "${if($index == 0, 'None', 'Large')}",
+          "separator": "${if($index == 0, false, true)}",
+          "items": [
+            {
+              "type": "TextBlock",
+              "text": "${thought}",
+              "size": "Small",
+              "wrap": true,
+              "spacing": "None"
+            },
+            {
+              "type": "Container",
+              "style": "emphasis",
+              "spacing": "Small",
+              "items": [
+                {
+                  "$data": "${actions}",
+                  "type": "ColumnSet",
+                  "spacing": "${if($index == 0, 'None', 'Small')}",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "${statusGlyph}",
+                          "color": "${statusTone}",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "${tool}",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "${detail}",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "id": "collapsed_panel",
+      "isVisible": "${traceCollapsed}",
+      "spacing": "Medium",
+      "items": [
+        {
+          "type": "TextBlock",
+          "text": "${collapsedSummary}",
+          "size": "Small",
+          "isSubtle": true,
+          "wrap": true,
+          "spacing": "None"
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "style": "attention",
+      "spacing": "Large",
+      "items": [
+        {
+          "type": "TextBlock",
+          "text": "${errorTitle}",
+          "color": "Attention",
+          "weight": "Bolder",
+          "wrap": true,
+          "spacing": "None"
+        },
+        {
+          "type": "TextBlock",
+          "text": "${errorMessage}",
+          "wrap": true,
+          "spacing": "Small"
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "id": "octo-surface-default-footer-reasoning-error",
+      "style": "emphasis",
+      "bleed": true,
+      "separator": true,
+      "spacing": "Large",
+      "items": [
+        {
+          "type": "ActionSet",
+          "horizontalAlignment": "Right",
+          "actions": [
+            {
+              "type": "Action.Submit",
+              "id": "reasoning_retry",
+              "title": "重试",
+              "style": "positive",
+              "associatedInputs": "none",
+              "data": {
+                "action": "reasoning_retry",
+                "effect": "retry_reasoning",
+                "reasoning_id": "${reasoningId}"
+              }
+            },
+            {
+              "type": "Action.ToggleVisibility",
+              "id": "reasoning_toggle",
+              "title": "显示 / 隐藏推理",
+              "targetElements": [
+                "trace_panel",
+                "collapsed_panel"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/cardtmpl/jsontmpl/testdata/ai.reasoning-process@0.1.0/templates/result.template.json
+++ b/pkg/cardtmpl/jsontmpl/testdata/ai.reasoning-process@0.1.0/templates/result.template.json
@@ -1,0 +1,180 @@
+{
+  "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+  "type": "AdaptiveCard",
+  "version": "1.5",
+  "body": [
+    {
+      "type": "Container",
+      "id": "octo-surface-accent-header-reasoning-result",
+      "style": "accent",
+      "bleed": true,
+      "spacing": "None",
+      "items": [
+        {
+          "type": "ColumnSet",
+          "spacing": "None",
+          "columns": [
+            {
+              "type": "Column",
+              "width": "stretch",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "text": "✦  ${title}",
+                  "color": "Accent",
+                  "weight": "Bolder",
+                  "wrap": true,
+                  "spacing": "None"
+                },
+                {
+                  "type": "TextBlock",
+                  "text": "${timerText}",
+                  "size": "Small",
+                  "isSubtle": true,
+                  "wrap": true,
+                  "spacing": "Small"
+                }
+              ]
+            },
+            {
+              "type": "Column",
+              "width": "auto",
+              "verticalContentAlignment": "Center",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "id": "octo-badge-reasoning-result-status",
+                  "text": "${statusLabel}",
+                  "color": "${statusTone}",
+                  "weight": "Bolder",
+                  "size": "Small",
+                  "wrap": true,
+                  "spacing": "None"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "id": "trace_panel",
+      "isVisible": "${traceExpanded}",
+      "spacing": "Large",
+      "items": [
+        {
+          "$data": "${phases}",
+          "type": "Container",
+          "spacing": "${if($index == 0, 'None', 'Large')}",
+          "separator": "${if($index == 0, false, true)}",
+          "items": [
+            {
+              "type": "TextBlock",
+              "text": "${thought}",
+              "size": "Small",
+              "wrap": true,
+              "spacing": "None"
+            },
+            {
+              "type": "Container",
+              "style": "emphasis",
+              "spacing": "Small",
+              "items": [
+                {
+                  "$data": "${actions}",
+                  "type": "ColumnSet",
+                  "spacing": "${if($index == 0, 'None', 'Small')}",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "${statusGlyph}",
+                          "color": "${statusTone}",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "${tool}",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "${detail}",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "id": "collapsed_panel",
+      "isVisible": "${traceCollapsed}",
+      "spacing": "Medium",
+      "items": [
+        {
+          "type": "TextBlock",
+          "text": "✓  ${collapsedSummary}",
+          "size": "Small",
+          "isSubtle": true,
+          "wrap": true,
+          "spacing": "None"
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "id": "octo-surface-default-footer-reasoning-result",
+      "style": "emphasis",
+      "bleed": true,
+      "separator": true,
+      "spacing": "Large",
+      "items": [
+        {
+          "type": "ActionSet",
+          "horizontalAlignment": "Right",
+          "actions": [
+            {
+              "type": "Action.ToggleVisibility",
+              "id": "reasoning_toggle",
+              "title": "显示 / 隐藏推理",
+              "targetElements": [
+                "trace_panel",
+                "collapsed_panel"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/cardtmpl/jsontmpl/toggle.go
+++ b/pkg/cardtmpl/jsontmpl/toggle.go
@@ -1,0 +1,84 @@
+package jsontmpl
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// ValidateToggleTargets statically checks that every Action.ToggleVisibility
+// target in the template refers to an element id that exists in the same
+// template. It walks the raw (pre-expansion) AST: element ids and toggle
+// targets in these cards are template-authored constants, so a dangling target
+// is an authoring bug catchable at register time rather than a silent no-op
+// button at render time. Data-driven ids/targets (`${...}`) are skipped — they
+// cannot be resolved statically.
+func ValidateToggleTargets(node any) error {
+	ids := map[string]struct{}{}
+	collectElementIDs(node, ids)
+
+	var missing []string
+	seen := map[string]struct{}{}
+	collectToggleTargets(node, func(target string) {
+		if strings.Contains(target, "${") {
+			return // data-driven target; not statically verifiable
+		}
+		if _, ok := ids[target]; ok {
+			return
+		}
+		if _, dup := seen[target]; dup {
+			return
+		}
+		seen[target] = struct{}{}
+		missing = append(missing, target)
+	})
+	if len(missing) > 0 {
+		sort.Strings(missing)
+		return fmt.Errorf("jsontmpl: Action.ToggleVisibility targets not found in template: %v", missing)
+	}
+	return nil
+}
+
+func collectElementIDs(node any, out map[string]struct{}) {
+	switch n := node.(type) {
+	case map[string]any:
+		if id, ok := n["id"].(string); ok && id != "" && !strings.Contains(id, "${") {
+			out[id] = struct{}{}
+		}
+		for _, v := range n {
+			collectElementIDs(v, out)
+		}
+	case []any:
+		for _, v := range n {
+			collectElementIDs(v, out)
+		}
+	}
+}
+
+func collectToggleTargets(node any, emit func(string)) {
+	switch n := node.(type) {
+	case map[string]any:
+		if t, _ := n["type"].(string); t == "Action.ToggleVisibility" {
+			if targets, ok := n["targetElements"].([]any); ok {
+				for _, tv := range targets {
+					switch tt := tv.(type) {
+					case string:
+						emit(tt)
+					case map[string]any:
+						// AC also allows {elementId, isVisible} target objects.
+						if id, ok := tt["elementId"].(string); ok {
+							emit(id)
+						}
+					}
+				}
+			}
+		}
+		for _, v := range n {
+			collectToggleTargets(v, emit)
+		}
+	case []any:
+		for _, v := range n {
+			collectToggleTargets(v, emit)
+		}
+	}
+}

--- a/pkg/cardtmpl/jsontmpl/toggle_test.go
+++ b/pkg/cardtmpl/jsontmpl/toggle_test.go
@@ -1,0 +1,65 @@
+package jsontmpl
+
+import "testing"
+
+func TestValidateToggleTargets_OK(t *testing.T) {
+	tmpl := parseJSON(t, `{
+		"body":[
+			{"type":"Container","id":"panel_a","items":[]},
+			{"type":"Container","id":"panel_b","items":[
+				{"type":"ActionSet","actions":[
+					{"type":"Action.ToggleVisibility","targetElements":["panel_a","panel_b"]}
+				]}
+			]}
+		]
+	}`)
+	if err := ValidateToggleTargets(tmpl); err != nil {
+		t.Fatalf("expected ok, got %v", err)
+	}
+}
+
+func TestValidateToggleTargets_DanglingTarget(t *testing.T) {
+	tmpl := parseJSON(t, `{
+		"body":[
+			{"type":"Container","id":"panel_a","items":[
+				{"type":"ActionSet","actions":[
+					{"type":"Action.ToggleVisibility","targetElements":["panel_a","ghost_panel"]}
+				]}
+			]}
+		]
+	}`)
+	err := ValidateToggleTargets(tmpl)
+	if err == nil {
+		t.Fatal("expected error for dangling toggle target 'ghost_panel'")
+	}
+}
+
+func TestValidateToggleTargets_TargetObjectForm(t *testing.T) {
+	// AC allows {elementId, isVisible} target objects — the reasoning card uses
+	// these in its interaction reports; verify the object form is checked too.
+	tmpl := parseJSON(t, `{
+		"body":[
+			{"type":"Container","id":"trace_panel","items":[]},
+			{"type":"ActionSet","actions":[
+				{"type":"Action.ToggleVisibility","targetElements":[{"elementId":"trace_panel"},{"elementId":"missing"}]}
+			]}
+		]
+	}`)
+	if err := ValidateToggleTargets(tmpl); err == nil {
+		t.Fatal("expected error for missing elementId 'missing'")
+	}
+}
+
+func TestValidateToggleTargets_DataDrivenSkipped(t *testing.T) {
+	// A ${...} target cannot be resolved statically; it must not be flagged.
+	tmpl := parseJSON(t, `{
+		"body":[
+			{"type":"ActionSet","actions":[
+				{"type":"Action.ToggleVisibility","targetElements":["${dynamicId}"]}
+			]}
+		]
+	}`)
+	if err := ValidateToggleTargets(tmpl); err != nil {
+		t.Fatalf("data-driven target must be skipped, got %v", err)
+	}
+}

--- a/pkg/cardtmpl/registry.go
+++ b/pkg/cardtmpl/registry.go
@@ -61,8 +61,15 @@ type manifestFile struct {
 
 // manifestView is one entry of manifest.views. Template/Samples are only present
 // for JSON-mode cards (roadmap E1): Template is the repo-relative path to the
-// view's `.template.json`, Samples the sample files exercising it. Go-mode cards
-// (hand-written Template.Build) omit both — the fields are ignored there.
+// view's `.template.json`. Go-mode cards (hand-written Template.Build) omit both
+// — the fields are ignored there.
+//
+// Samples is currently informational only: the register-time self-check globs the
+// handoff's `samples/` directory (loadSamples), so a per-view `samples` list is
+// NOT a fail-close allowlist — a listed-but-missing sample is not caught here, and
+// an unlisted sample file is still loaded. It is parsed (not dropped) so a future
+// L0 PR can promote it to an allowlist without a manifest schema change; until
+// then, treat `samples/` on disk as the source of truth (PR #654 review P2).
 type manifestView struct {
 	WireProfile string   `json:"wireProfile"`
 	States      []State  `json:"states"`

--- a/pkg/cardtmpl/registry.go
+++ b/pkg/cardtmpl/registry.go
@@ -49,17 +49,25 @@ type manifestFile struct {
 	// RenderProfile is provenance-only metadata for the exact Forge artifact.
 	// RenderProfileCompatibility is the stable value written to the type-17
 	// envelope and is the only render-profile value retained at runtime.
-	RenderProfile              string `json:"renderProfile"`
-	RenderProfileCompatibility string `json:"renderProfileCompatibility,omitempty"`
-	Owner                      string `json:"owner"`
-	ActionType                 string `json:"actionType"`
-	Views                      map[ViewKey]struct {
-		WireProfile string  `json:"wireProfile"`
-		States      []State `json:"states"`
-	} `json:"views"`
+	RenderProfile              string                   `json:"renderProfile"`
+	RenderProfileCompatibility string                   `json:"renderProfileCompatibility,omitempty"`
+	Owner                      string                   `json:"owner"`
+	ActionType                 string                   `json:"actionType"`
+	Views                      map[ViewKey]manifestView `json:"views"`
 	// SourceLabel / SourceIconURL 可选,若手动指定则覆盖 Template 默认 Source。
 	SourceLabel   string `json:"sourceLabel,omitempty"`
 	SourceIconURL string `json:"sourceIconUrl,omitempty"`
+}
+
+// manifestView is one entry of manifest.views. Template/Samples are only present
+// for JSON-mode cards (roadmap E1): Template is the repo-relative path to the
+// view's `.template.json`, Samples the sample files exercising it. Go-mode cards
+// (hand-written Template.Build) omit both — the fields are ignored there.
+type manifestView struct {
+	WireProfile string   `json:"wireProfile"`
+	States      []State  `json:"states"`
+	Template    string   `json:"template,omitempty"`
+	Samples     []string `json:"samples,omitempty"`
 }
 
 // ActionView resolves one declared Action.Submit to its registered view. It is
@@ -375,10 +383,7 @@ func loadSchema(fs embed.FS, root string) *jsonschema.Schema {
 	return sch
 }
 
-func loadInteractionReports(fs embed.FS, root string, views map[ViewKey]struct {
-	WireProfile string  `json:"wireProfile"`
-	States      []State `json:"states"`
-}) map[ViewKey]InteractionReport {
+func loadInteractionReports(fs embed.FS, root string, views map[ViewKey]manifestView) map[ViewKey]InteractionReport {
 	out := make(map[ViewKey]InteractionReport)
 	for vk, vs := range views {
 		if vs.WireProfile != profileV2 {

--- a/pkg/cardtmpl/render.go
+++ b/pkg/cardtmpl/render.go
@@ -97,10 +97,15 @@ func renderCore(
 		return nil, fmt.Errorf("%w: build: %w", ErrRenderFailed, err)
 	}
 
-	// step 5: DeepLink 强制校验 (§5 约束 4)
-	if err := AbsoluteHTTPSURL(br.DeepLink); err != nil {
-		metricBuildResult(meta.ID, meta.Version, string(view), "render_error")
-		return nil, fmt.Errorf("%w: DeepLink: %v", ErrRenderFailed, err)
+	// step 5: DeepLink 可选;非空则强制绝对 https (§5 约束 4)。空 DeepLink 表示本卡
+	// 没有规范浏览器 URL(如 JSON 模板的纯展示进度卡,无 OpenUrl/webUrl)—— 跳过
+	// https 校验并在 step 6 省略 metadata.webUrl。既有卡片一律提供 DeepLink,行为不变。
+	hasDeepLink := strings.TrimSpace(br.DeepLink) != ""
+	if hasDeepLink {
+		if err := AbsoluteHTTPSURL(br.DeepLink); err != nil {
+			metricBuildResult(meta.ID, meta.Version, string(view), "render_error")
+			return nil, fmt.Errorf("%w: DeepLink: %v", ErrRenderFailed, err)
+		}
 	}
 
 	// step 6: 组装 AC 顶层 + metadata
@@ -138,11 +143,15 @@ func renderCore(
 		}
 		octo["source"] = s
 	}
+	metadata := map[string]any{"octo": octo}
+	if hasDeepLink {
+		metadata["webUrl"] = br.DeepLink
+	}
 	card := map[string]any{
 		"type":     "AdaptiveCard",
 		"version":  cardmsg.CardVersion,
 		"body":     br.Body,
-		"metadata": map[string]any{"webUrl": br.DeepLink, "octo": octo},
+		"metadata": metadata,
 	}
 	if len(br.Actions) > 0 {
 		card["actions"] = br.Actions

--- a/pkg/cardtmpl/render.go
+++ b/pkg/cardtmpl/render.go
@@ -26,8 +26,8 @@ const (
 //  2. Meta.InputSchema.Validate(fields) → 失败返 ErrFieldsInvalid;
 //  3. Meta.ViewFor(state) 决定 view/profile → 未注册 state 返 ErrStateUnknown;
 //  4. Template.Build(ctx, state, fields, env) 拿 BuildResult;
-//  5. 校验 BuildResult.DeepLink 为绝对 https;
-//  6. 组装 AC 顶层文档 + 注入 metadata.octo.{protocol, template, variant, source} + metadata.webUrl;
+//  5. BuildResult.DeepLink 可选:非空则校验为绝对 https,空则跳过(无 metadata.webUrl);
+//  6. 组装 AC 顶层文档 + 注入 metadata.octo.{protocol, template, variant, source};DeepLink 非空时再注入 metadata.webUrl;
 //  7. 构造 InteractiveCard payload envelope (type=17 / card / card_version / profile);
 //  8. cardmsg.Validate(payload) → 失败包裹 ErrRenderFailed 返回。
 //
@@ -100,7 +100,12 @@ func renderCore(
 	// step 5: DeepLink 可选;非空则强制绝对 https (§5 约束 4)。空 DeepLink 表示本卡
 	// 没有规范浏览器 URL(如 JSON 模板的纯展示进度卡,无 OpenUrl/webUrl)—— 跳过
 	// https 校验并在 step 6 省略 metadata.webUrl。既有卡片一律提供 DeepLink,行为不变。
-	hasDeepLink := strings.TrimSpace(br.DeepLink) != ""
+	//
+	// "可选" 只放行**真正空**的 DeepLink(""):一个非空但 trim 后为空(纯空白)的
+	// DeepLink 是畸形值,走 AbsoluteHTTPSURL 判定为 render_error 而非被静默当作
+	// "无链接"。否则 (a) 一张误产出空白链接的 Go 卡会静默丢掉 webUrl,(b) 空白与
+	// 真链接在 metric 上无法区分 —— 均破坏 fail-close(PR #654 review)。
+	hasDeepLink := br.DeepLink != ""
 	if hasDeepLink {
 		if err := AbsoluteHTTPSURL(br.DeepLink); err != nil {
 			metricBuildResult(meta.ID, meta.Version, string(view), "render_error")

--- a/pkg/cardtmpl/render_deeplink_test.go
+++ b/pkg/cardtmpl/render_deeplink_test.go
@@ -1,0 +1,98 @@
+package cardtmpl
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardmsg"
+	"github.com/santhosh-tekuri/jsonschema/v6"
+)
+
+// deepLinkStub is a minimal Template returning a fixed DeepLink so the renderCore
+// step-5 branch can be exercised directly — JSON-mode templates always return an
+// empty DeepLink, so they cannot cover the non-empty/whitespace cases.
+type deepLinkStub struct {
+	meta     TemplateMeta
+	deepLink string
+}
+
+func (s *deepLinkStub) Meta() TemplateMeta { return s.meta }
+func (s *deepLinkStub) Build(_ context.Context, _ State, _ json.RawMessage, _ BuildEnv) (BuildResult, error) {
+	return BuildResult{
+		Body:     []any{map[string]any{"type": "TextBlock", "text": "hi"}},
+		DeepLink: s.deepLink,
+	}, nil
+}
+func (s *deepLinkStub) FallbackText(_ State, _ json.RawMessage, _ string) (string, error) {
+	return "hi", nil
+}
+
+func permissiveObjectSchema(t *testing.T) *jsonschema.Schema {
+	t.Helper()
+	var doc any
+	if err := json.Unmarshal([]byte(`{"type":"object"}`), &doc); err != nil {
+		t.Fatalf("parse schema: %v", err)
+	}
+	const url = "mem://stub.schema.json"
+	c := jsonschema.NewCompiler()
+	if err := c.AddResource(url, doc); err != nil {
+		t.Fatalf("add resource: %v", err)
+	}
+	sch, err := c.Compile(url)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	return sch
+}
+
+func deepLinkStubMeta(t *testing.T) TemplateMeta {
+	t.Helper()
+	return TemplateMeta{
+		ID:          "test.deeplink",
+		Version:     "0.1.0",
+		Protocol:    Protocol,
+		Views:       map[ViewKey]ViewSpec{"v": {WireProfile: cardmsg.ProfileV1, States: []State{"shown"}}},
+		InputSchema: permissiveObjectSchema(t),
+		stateIndex:  map[State]ViewKey{"shown": "v"},
+	}
+}
+
+// TestRenderCore_DeepLinkOptionalVsBlank pins the render step-5 contract after
+// DeepLink was made optional (PR #654): an EMPTY DeepLink is a legitimate "no
+// canonical URL" (the card renders, metadata.webUrl omitted), a NON-EMPTY but
+// whitespace-only DeepLink is malformed and must fail-close (ErrRenderFailed)
+// rather than being silently treated as absent, and a valid https DeepLink is
+// injected as metadata.webUrl as before.
+func TestRenderCore_DeepLinkOptionalVsBlank(t *testing.T) {
+	meta := deepLinkStubMeta(t)
+	fields := json.RawMessage(`{"x":1}`)
+
+	// empty DeepLink → renders, webUrl omitted.
+	payload, err := renderCore(context.Background(), &deepLinkStub{meta: meta, deepLink: ""}, meta, "shown", fields, BuildEnv{})
+	if err != nil {
+		t.Fatalf("empty DeepLink should render, got %v", err)
+	}
+	if _, has := payload["card"].(map[string]any)["metadata"].(map[string]any)["webUrl"]; has {
+		t.Errorf("empty DeepLink must omit metadata.webUrl")
+	}
+
+	// whitespace-only DeepLink → fail-close (not silently absent).
+	_, err = renderCore(context.Background(), &deepLinkStub{meta: meta, deepLink: "   "}, meta, "shown", fields, BuildEnv{})
+	if err == nil {
+		t.Fatal("whitespace-only DeepLink must fail-close, got nil")
+	}
+	if !strings.Contains(err.Error(), ErrRenderFailed.Error()) || !strings.Contains(err.Error(), "DeepLink") {
+		t.Fatalf("want ErrRenderFailed on DeepLink, got %v", err)
+	}
+
+	// valid https DeepLink → injected as metadata.webUrl.
+	payload, err = renderCore(context.Background(), &deepLinkStub{meta: meta, deepLink: "https://im.example.com/s/abc"}, meta, "shown", fields, BuildEnv{})
+	if err != nil {
+		t.Fatalf("valid https DeepLink should render, got %v", err)
+	}
+	if got := payload["card"].(map[string]any)["metadata"].(map[string]any)["webUrl"]; got != "https://im.example.com/s/abc" {
+		t.Errorf("valid DeepLink must be injected as metadata.webUrl, got %v", got)
+	}
+}

--- a/pkg/cardtmpl/template.go
+++ b/pkg/cardtmpl/template.go
@@ -141,7 +141,7 @@ type BuildResult struct {
 	Body     []any   // AC body 元素
 	Actions  []any   // AC 顶层 actions
 	Variant  string  // metadata.octo.variant
-	DeepLink string  // metadata.webUrl (必填绝对 https)
+	DeepLink string  // metadata.webUrl (可选;非空则须绝对 https,空则省略 webUrl)
 	Source   *Source // 覆盖 Meta.Source,nil 表示不覆盖
 }
 

--- a/pkg/cardtmpl/testdata/test.jsoncard@0.1.0/contract/data.schema.json
+++ b/pkg/cardtmpl/testdata/test.jsoncard@0.1.0/contract/data.schema.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["title", "expanded"],
+  "properties": {
+    "title": { "type": "string", "minLength": 1, "maxLength": 200 },
+    "expanded": { "type": "boolean" },
+    "rows": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["label"],
+        "properties": { "label": { "type": "string", "minLength": 1 } }
+      }
+    }
+  }
+}

--- a/pkg/cardtmpl/testdata/test.jsoncard@0.1.0/manifest.json
+++ b/pkg/cardtmpl/testdata/test.jsoncard@0.1.0/manifest.json
@@ -1,0 +1,17 @@
+{
+  "schemaVersion": 2,
+  "id": "test.jsoncard",
+  "name": "JSON 引擎冒烟卡",
+  "version": "0.1.0",
+  "adaptiveCardVersion": "1.5",
+  "defaultLocale": "zh-CN",
+  "dataSchema": "contract/data.schema.json",
+  "views": {
+    "main": {
+      "wireProfile": "octo/v1",
+      "states": ["shown"],
+      "template": "templates/main.template.json",
+      "samples": ["samples/basic.json"]
+    }
+  }
+}

--- a/pkg/cardtmpl/testdata/test.jsoncard@0.1.0/samples/basic.json
+++ b/pkg/cardtmpl/testdata/test.jsoncard@0.1.0/samples/basic.json
@@ -1,0 +1,1 @@
+{ "title": "冒烟", "expanded": true, "rows": [ { "label": "a" }, { "label": "b" } ] }

--- a/pkg/cardtmpl/testdata/test.jsoncard@0.1.0/templates/main.template.json
+++ b/pkg/cardtmpl/testdata/test.jsoncard@0.1.0/templates/main.template.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+  "type": "AdaptiveCard",
+  "version": "1.5",
+  "body": [
+    { "type": "TextBlock", "text": "✦  ${title}", "weight": "Bolder", "wrap": true },
+    {
+      "type": "Container",
+      "id": "rows_panel",
+      "isVisible": "${expanded}",
+      "items": [
+        {
+          "$data": "${rows}",
+          "type": "TextBlock",
+          "text": "${label}",
+          "spacing": "${if($index == 0, 'None', 'Small')}",
+          "wrap": true
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/cardtmpl/testdata/test.notmpl@0.1.0/contract/data.schema.json
+++ b/pkg/cardtmpl/testdata/test.notmpl@0.1.0/contract/data.schema.json
@@ -1,0 +1,1 @@
+{ "$schema": "http://json-schema.org/draft-07/schema#", "type": "object" }

--- a/pkg/cardtmpl/testdata/test.notmpl@0.1.0/manifest.json
+++ b/pkg/cardtmpl/testdata/test.notmpl@0.1.0/manifest.json
@@ -1,0 +1,5 @@
+{
+  "schemaVersion": 2, "id": "test.notmpl", "version": "0.1.0",
+  "adaptiveCardVersion": "1.5", "dataSchema": "contract/data.schema.json",
+  "views": { "main": { "wireProfile": "octo/v1", "states": ["shown"] } }
+}


### PR DESCRIPTION
## Summary

Adds a second runtime render path to the card base (roadmap E1): a bounded
Adaptive Card Templating engine that compiles a card's JSON handoff templates
(`.template.json`) against caller data, so a card can register and render through
`Registry.Render` **without a hand-written Go `Template.Build()`**. It is additive
and parallel to the existing Go cards — all 5 L2a cards are untouched.

## Related Issue

Roadmap E1 (self). Part of the platform-card-base roadmap.

## Linked Spec

`.octospec/tasks/cardtmpl-json-template-engine/brief.md`

## Changes

- **`pkg/cardtmpl/jsontmpl/`** — dependency-free ACT evaluator (`expr.go`) +
  expander (`expand.go`) for the bounded subset the shipped handoff templates
  use: single-identifier field binding, `$index`, `if($index == N, a, b)`,
  string interpolation, typed whole-value binding (`"${bool}"` → real JSON bool),
  and `$data` array repetition. Out-of-subset syntax is a hard error. `toggle.go`
  adds a static `Action.ToggleVisibility` target-existence check.
- **`pkg/cardtmpl/json_template.go`** — generic `jsonTemplate` (implements
  `Template` + `metaSetter`, parses per-view template ASTs once at register time)
  and `Registry.RegisterJSON`, which delegates to `Register` so JSON cards get the
  same fail-close registration guarantees as Go cards. `FallbackText` reuses
  `cardmsg.BuildPlain`.
- **`render.go`** — `BuildResult.DeepLink` is now optional: empty skips the
  absolute-https check and omits `metadata.webUrl` (cards that ship a deep link
  are unchanged).
- **`registry.go`** — named `manifestView` type; parses the previously-dropped
  `views[].template` / `views[].samples`.

## Testing

- [x] Unit tests added (evaluator, expander, toggle validation, jsonTemplate,
      RegisterJSON integration, C1 rejection, injection rejection, fail-close)
- [x] Manually verified: `go test ./pkg/cardtmpl/... -race` green; `gofmt`,
      `go vet`, full `go build ./...` clean

Conformance: the engine reproduces all 5 `ai.reasoning-process@0.1.0` goldens
byte-for-byte (canonical JSON). Integration proven end-to-end with a minimal v1
fixture through `renderCore` + `cardmsg.Validate`.

Note: `modules/notify` integration tests require MySQL/Redis/WuKongIM and were
not run locally; they compile, and the optional-DeepLink change is provably
equivalent for existing (deep-link-bearing) cards, so no regression.

## COMPREHENSION

1. **What does this change actually do to the load-bearing path?**
   It adds a new `Template` implementation and a `RegisterJSON` entry that compile
   `.template.json` at render time, plus one behavioral change to the shared
   `renderCore`: `DeepLink` becomes optional. The render pipeline
   (schema-validate → Build → inject metadata → `cardmsg.Validate`) is otherwise
   unchanged; JSON cards flow through the exact same validation and metadata
   injection as Go cards.

2. **What could break because of it (dependents + failure mode)?**
   The only shared-path edit is `renderCore`'s DeepLink handling. For any card
   that supplies a non-empty DeepLink (all 5 existing cards) the behavior is
   identical — the URL is still validated and `metadata.webUrl` is still emitted;
   the same metadata keys are present, so canonical byte-equivalence baselines do
   not drift. A regression would surface only if a card newly relied on an empty
   DeepLink being rejected, which no card does. The new engine is opt-in via
   `RegisterJSON`; nothing calls it in production yet.

3. **How do you know it works (specific test/repro/trace)?**
   `pkg/cardtmpl/jsontmpl` conformance test expands every sample and asserts
   canonical byte-equality to the shipped golden (5/5). `RegisterJSON` integration
   test renders a v1 fixture through `renderCore` and asserts typed bool binding,
   `$data`/`$index`, and the no-deep-link path. C1 (`ErrFieldsInvalid`),
   fail-close (missing template panics at register), and the security backstop (a
   `[x](javascript:…)` link in literal-bound data → `cardmsg.Validate` rejects →
   `ErrRenderFailed`) each have a dedicated test. Existing docs/summary card
   conformance stays green (no regression).

## Checklist

- [x] Tests added/updated and green (`-race`)
- [x] `gofmt` / `go vet` clean
- [x] Journal + learning candidate recorded under `.octospec/`
- [x] No changes outside `pkg/cardtmpl/` + `.octospec/`
