### PR TITLE
feat(group): group new-member welcome message (群入群欢迎语)

### DIFF
--- a/.octospec/journal/shared/group-welcome-message.md
+++ b/.octospec/journal/shared/group-welcome-message.md
@@ -129,8 +129,45 @@ group admin opts that group in.
 reads `r.Enabled`; Space CRUD derives DB context from the request; a Space
 `DELETE`→enabled-global-fallback HTTP test.
 
+## Review round 2 (PR #655)
+
+Three reviewers cleared the design/security; the actionable fixes:
+
+- **e2e skip guard was ineffective** — `config.New()` defaults `WuKongIM.APIURL`
+  to `127.0.0.1:5001`, so the `APIURL==""` check never skipped and the package
+  failed hard on a box without a live IM. Now probes `<APIURL>/health` (verified:
+  SKIP when down, PASS when up).
+- **Event fan-out** offloaded to `EventPool.Work` + config read once per batch
+  (`handleMemberJoinBatch`), so a bulk invite no longer runs N sequential DB
+  round-trips on the shared event-dispatch goroutine before `commit`.
+- **Shutdown-safe post-send** — `casToSent`/`toUnknown` now use
+  `context.WithoutCancel`, so a `Stop()` after a successful send cannot strand a
+  delivered row in `dispatching`.
+- **CRUD gate** tightened to require `GroupStatusNormal` (parity with the space
+  welcome's `checkSpaceActive`).
+- **Batch coalesce timestamp** — all members of one `GroupMemberAdd` event share
+  one due time, so a slow insert can't split a sub-cap batch into two posts.
+- **Master switch re-checked** before each group's claim (tighter mid-wake kill).
+- A large batch of failure-branch / boundary / fairness / listener-entry tests.
+
+**Reverted a mis-step (P1):** an earlier fix classified a non-2xx as
+"definitely-not-delivered" and *retried* the coalesced post on it, to avoid a
+transient IM failure suppressing a whole batch. A reviewer correctly flagged that
+without a message-level idempotency key (and given the send may traverse a proxy
+that can 5xx *after* WuKongIM persisted), retrying a PUBLIC post can double-post a
+visible, unrecallable message. Reverted to the space engine's conservative policy:
+any post-send failure → terminal `unknown`, never auto-retried. For a public
+message, a missed welcome (invisible) is a safer failure than a duplicate one.
+
 ## Open items
 
+- **Batch blast radius (known limitation, fix-before-enable).** One send failure
+  marks the whole coalesced batch (≤50 winners) terminal-`unknown`; the reconciler
+  only re-enqueues rows with no ledger row, so those are not auto-recovered. This
+  is safe (no double-post) but suppresses the burst's welcome until an operator
+  acts. Proper fix before the master switch is enabled: attach a stable
+  idempotency key so WuKongIM de-dupes a retried post (needs verifying WuKongIM's
+  `client_msg_no` de-dup semantics), or a bounded operator-driven recovery.
 - Very large bursts (> per-post cap) spill their tail into later worker wakes (a
   few posts, not one) — natural rate-limit, `log()`-visible, acceptable.
 - `{member}` renders a plain-text name; a clickable WuKongIM @mention is a

--- a/.octospec/journal/shared/group-welcome-message.md
+++ b/.octospec/journal/shared/group-welcome-message.md
@@ -1,0 +1,139 @@
+---
+type: Journal
+title: "group-welcome-message: group new-member welcome (群入群欢迎语)"
+description: Per-group admin-configured welcome posted publicly into the group channel on a member's first join — mirrors the per-Space welcome engine (config store + delivery ledger + reconciler + worker), adds a platform master switch (default off) and burst coalescing (one post per batch of joiners), with a {member} placeholder.
+tags: [notify, group, onboarding, isolation, auth, acl, i18n, error-response, system-setting, migration, rate-limit, idempotency, observability, wire-contract, testing]
+timestamp: 2026-07-23T14:40:00Z
+---
+
+# group-welcome-message
+
+Branch `claude/group-welcome-message`. New feature: each group's owner/manager
+(role ∈ {creator, manager}) configures **one** welcome for **their** group, and
+on a human member's **first** join it is **posted publicly into the group
+channel** (`channel_type=GROUP`), at most once per `(group_no, uid)`. The body
+supports a `{member}` placeholder rendered to the joiner's display name.
+
+Diverges from the per-Space welcome on purpose: Space **DMs** the newcomer
+(private, per recipient); Group **posts into the channel** (public, seen by all),
+and there is **no platform-global content fallback** — a group with no enabled row
+gets no welcome.
+
+Ships **double-inert**: the platform master switch defaults off AND per-group
+configs default `enabled=false` — nothing happens until ops flips the switch and a
+group admin opts that group in.
+
+## What was done
+
+1. **Mirror, don't refactor.** The freshly-shipped, at-most-once per-Space engine
+   (PR #646) was copied into a parallel, group-scoped implementation rather than
+   generalized into a shared "container" abstraction (which would re-open that
+   reviewed surface). Only three things change: the container (`space_*` →
+   `group_*`), the sender (personal DM → group-channel post), and dropping the
+   global-content-fallback branch. Trivial helpers (sw* constants, the HTTP
+   sender, metrics, `isRetryableTxErr`) are shared verbatim; the space code is
+   otherwise untouched (bar 4 incidental polish items).
+2. **Config storage (`modules/common`)** — `octo_group_welcome_config` (one row
+   per group, `group_no` UNIQUE, COLLATE aligned to `group.group_no`) +
+   `GroupWelcomeConfigStore` with insert-then-lock `UpsertMerged` (idempotent
+   materialize → `SELECT … FOR UPDATE` → merge → UPDATE, bounded 1213/1205 retry)
+   so concurrent first-create and concurrent edits both keep all fields.
+   `active_from` stored as the RFC3339 string so `ParsedActiveFrom` /
+   `ValidateGroupWelcomeCombination` apply as pure validators.
+3. **CRUD API (`modules/group/api_welcome.go`)** — `GET/PUT/DELETE
+   /v1/groups/:group_no/welcome`, gated by a new `authorizeGroupWelcomeAdmin`
+   (group-active + `QueryIsGroupManagerOrCreator`, reusing existing group error
+   codes — no new codes). `PUT` is a prospective merge; `DELETE` hard-deletes →
+   group reverts to off. Mounted on auth + `SharedUIDRateLimiter`; all responses
+   via the `httperr` i18n envelope; handler file added to the group
+   `NoLegacyResponseError` guard.
+4. **Delivery (`modules/notify`)** — `octo_group_welcome_delivery` ledger
+   (`UNIQUE(group_no, uid)` as the at-most-once authority), event listener on
+   `event.GroupMemberAdd`, reconciler (catch-up over `group_member`), and a send
+   worker: cross-group `FOR UPDATE SKIP LOCKED` claim, CAS-on-`claim_owner`, 30s
+   lease, rotating cursor for fairness, cross-group sweep. Posts a `MsgSendReq` to
+   `channel_id=group_no`, `channel_type=GROUP`, from the fixed `notification`
+   identity; `{member}` renders at send time.
+5. **Platform master switch (design review add).** `system_setting
+   onboarding.group_welcome_enabled` (bool, default **off**), read via
+   `SystemSettings.GroupWelcomeEnabled()`, checked at enqueue + reconcile + worker
+   (the cross-group sweep still runs so in-flight rows terminate). It is
+   **enablement only** — no content fallback — the outer AND over each group's own
+   `enabled`. Hot-reloaded; flip-off is an instant, reversible kill that touches
+   no per-group rows.
+6. **Burst coalescing (design review add).** A batch invite arrives as one
+   `GroupMemberAdd` event → many rows; delivering one post each would spam the
+   channel. Instead a fresh row is held back until `now + coalesceWindow` (via
+   `next_retry_at`); the worker `claimBatch`es a group's due rows and
+   `dispatchBatch` posts **one** message whose `{member}` renders to the joined
+   name list (`张三、李四` / overflow → `…、nameK 等 N 人`). One coalesced post per
+   group per wake also rate-limits a single group's welcomes; per-row at-most-once
+   is preserved (each row keeps its own CAS transition, shares the one
+   `message_id`).
+
+## Structural learnings / gotchas
+
+- **A master *switch* is not a global *fallback*.** The locked "no global
+  fallback" decision was about **content** (body/target/default). A platform
+  enablement switch is orthogonal and was the right answer to "ship it dark / kill
+  it fast" — added without reintroducing any global content. Worth stating the
+  distinction explicitly in the brief so the two don't get conflated.
+- **`DATETIME(0)` rounds fractional seconds → a "due now" row can be ~0.5s in the
+  future.** Setting `next_retry_at = now` (coalesce window 0) and immediately
+  claiming with `WHERE next_retry_at <= now` returned **nothing**: MySQL rounds
+  the inserted fractional value up to the next whole second, so the stored due
+  time briefly exceeds the query `now`. Harmless in production (3s window + 5s
+  worker cadence absorb it) but it breaks a same-instant test. Fix: drive an
+  explicit clock and advance it between enqueue and claim (do not rely on wall
+  time within one sub-second). Promoted to learnings/pending.
+- **Coalescing lives in the worker, not the event handler.** Batching co-arriving
+  joins at the ledger/claim layer (`claimBatch` → one `dispatchBatch`) keeps a
+  single posting path for BOTH event-driven and reconciler-driven joins, and
+  keeps per-row at-most-once intact. The event handler stays a dumb per-uid
+  enqueue. `swWorkerWakeCap` is reused as a **posts**-per-wake budget for group
+  (it is a **rows**-per-wake budget for space) — same constant, documented
+  different unit.
+- **`group_member.created_at` resets on rejoin (unlike `space_member`).** So the
+  timestamp cannot be the first-join authority; the ledger `UNIQUE(group_no, uid)`
+  is. Leave→rejoin keeps the SENT row → no re-post. (One acceptable edge: someone
+  who joined before `active_from`, left, and rejoined after it newly qualifies.)
+- **`modules/common` is the DI hub** (both `group`-write and `notify`-read import
+  it; it imports neither) — the config store lives there to avoid a
+  `group`↔`notify` cycle. Same pattern as the Space store.
+
+## Verification
+
+- Gates: `go build ./...`, `go vet`, `golangci-lint` (0 issues), `gofmt`,
+  `make i18n-extract-check` + `make i18n-lint`, `git diff --check` — all clean.
+- `go test -race` green for `modules/common`, `modules/notify`, `modules/group`,
+  `modules/space` (each on a fresh DB; cross-package migration sets differ so the
+  shared `test` DB is dropped+recreated between packages).
+- New tests: config-store CRUD + `UpsertMerged` no-lost-update + concurrent-create
+  + validator; CRUD authz matrix (creator/manager/member/non-member/disbanded) +
+  prospective validation + partial-merge + delete; first-join at-most-once public
+  post to the correct channel; `{member}` render; leave/rejoin no re-post;
+  pre-`active_from` + robot/system-bot exclusion; multi-group no-crossing;
+  worker coalesce + fairness; cross-group sweep; **master switch off suppresses**
+  enqueue + post; **coalesced burst → one post**; name-list overflow render.
+- **Live e2e** (committed, `group_welcome_e2e_test.go`, skips without a live
+  WuKongIM): full pipeline against real WuKongIM — config + 2 first-join members →
+  enqueue → coalesce window → batch claim → ONE public post → ledger SENT.
+  Confirms the brief's open question end to end — the `notification` identity
+  **posts into a group channel it is not a member of** (real `message_id`
+  returned) — and proves coalescing by asserting both joiners share one
+  `message_id`.
+
+## Incidental polish (carried from #646)
+
+`Upsert` doc caveat (prod must use `UpsertMerged`); `notify` `enabledEffectiveConfigs`
+reads `r.Enabled`; Space CRUD derives DB context from the request; a Space
+`DELETE`→enabled-global-fallback HTTP test.
+
+## Open items
+
+- Very large bursts (> per-post cap) spill their tail into later worker wakes (a
+  few posts, not one) — natural rate-limit, `log()`-visible, acceptable.
+- `{member}` renders a plain-text name; a clickable WuKongIM @mention is a
+  possible fast-follow (needs the mention payload encoding).
+- `swWorkerWakeCap` unit differs between space (rows/wake) and group (posts/wake);
+  documented in-code. A group-specific alias is deferred as churn-for-no-gain.

--- a/.octospec/journal/shared/group-welcome-message.md
+++ b/.octospec/journal/shared/group-welcome-message.md
@@ -159,6 +159,19 @@ visible, unrecallable message. Reverted to the space engine's conservative polic
 any post-send failure → terminal `unknown`, never auto-retried. For a public
 message, a missed welcome (invisible) is a safer failure than a duplicate one.
 
+**Dispatch-time active_from re-check (round-3 blocker).** A reviewer found that a
+pending row was delivered without re-validating the CURRENT config's `active_from`
+— so an admin moving `active_from` forward, or deleting+recreating the config
+(DELETE does not discard pending rows), could post a welcome to someone whose join
+predates the new window. `precheckRecipient` now re-checks
+`group_member.created_at >= cfg.active_from` at send time and CAS-skips
+(`active_from_moved`) any row outside the current window. It re-checks only the
+join-time window, NOT membership — "post-then-leave still fires" is preserved, and
+rejoin dedup stays keyed on the ledger UNIQUE. (Note: neither engine re-checked
+active_from at dispatch before; group needed it more because, unlike space, it does
+not re-check membership either.) Also added a nil-`result`-on-nil-`err` guard on the
+sender boundary.
+
 ## Open items
 
 - **Batch blast radius (known limitation, fix-before-enable).** One send failure

--- a/.octospec/learnings/pending/datetime0-rounding-due-now.md
+++ b/.octospec/learnings/pending/datetime0-rounding-due-now.md
@@ -1,0 +1,57 @@
+---
+type: Learning
+title: "MySQL DATETIME(0) rounds fractional seconds — a zero-delay 'due now' row can be ~0.5s in the future"
+description: Writing next_retry_at = now into a DATETIME(0) column rounds up to the next whole second, so an immediate WHERE next_retry_at <= now claim can return nothing. Bites zero-delay tests; harmless in prod behind a real delay + poll cadence. Drive an explicit clock.
+tags: [time, mysql, datetime, scheduling, testing, correctness]
+timestamp: 2026-07-23T14:40:00Z
+status: pending
+---
+
+# DATETIME(0) rounds fractional seconds → a "due now" row can be in the future
+
+## Context
+
+The group/space welcome delivery ledgers gate claimability on a `next_retry_at
+DATETIME` column (no fractional precision): `WHERE status=pending AND
+(next_retry_at IS NULL OR next_retry_at <= ?)`. A coalesce/enqueue path writes
+`next_retry_at = now + window` (window can be 0). Both the write value and the
+claim's `?` are app-supplied Go `time.Time`s.
+
+## The trap
+
+MySQL **rounds** (not truncates) a fractional-second value inserted into a
+`DATETIME(0)` column to the nearest whole second. So `now = 13:24:20.6` stored
+as `next_retry_at` becomes `13:24:21`. A claim issued microseconds later with
+`? = 13:24:20.7` then evaluates `13:24:21 <= 13:24:20.7` → **false**, and the
+row that should be "due now" is skipped until the next whole second.
+
+Symptom seen: with `coalesceWindow = 0`, `enqueue` then an immediate
+`claimBatch` in the same instant delivered **nothing** (0 rows), even though the
+row was pending and "due". No error — just an empty claim.
+
+## Why it's harmless in production
+
+Real deployments use a positive delay (e.g. a 3s coalesce window) and a worker
+that wakes on a poll cadence (e.g. every 5s), so a ±0.5s rounding wobble on the
+due time is invisible — the row is always claimed on the next wake.
+
+## The rule
+
+- Do **not** assert delivery in a test that enqueues (`next_retry_at = now`) and
+  claims in the **same sub-second instant** — the rounding boundary makes it
+  flaky/empty. Drive an **explicit injected clock** and advance it between
+  enqueue and claim (e.g. `clock = clock.Add(time.Minute)`), so the claim's
+  `now` is unambiguously past any rounded due time.
+- If sub-second scheduling precision ever matters for real, give the column
+  fractional precision (`DATETIME(3)`) — but for human-facing delivery (welcome
+  posts, retries) whole-second precision + a positive delay is the simpler,
+  correct choice.
+- Keep in mind rounding is **up-or-down to nearest**, so a stored due time can be
+  either slightly before or slightly after the intended instant; never treat a
+  freshly-written `= now` due time as immediately claimable.
+
+## Promotion note
+
+Candidate for a `persistence`/`testing` rule (pairs with the existing
+`app-time-vs-now-column-epoch-compare` learning). Not auto-promoted — review
+separately.

--- a/.octospec/log.md
+++ b/.octospec/log.md
@@ -97,6 +97,39 @@ change-log convention (§7). Newest first.
   extend the pattern PR-1 established. `TestMain` grows to register the two
   new cards. See [journal](journal/shared/cardtmpl-l2a-summary-migration.md).
 
+## 2026-07-23 (group-welcome-message)
+
+- **Feature** — Group new-member welcome (群入群欢迎语): a group's
+  creator/manager configures **one** welcome via `GET/PUT/DELETE
+  /v1/groups/:group_no/welcome` (new `octo_group_welcome_config`, insert-then-lock
+  `UpsertMerged`), and on a human member's **first** join it is **posted publicly
+  into the group channel** (`channel_type=GROUP`), at most once per `(group_no,
+  uid)` via the new `octo_group_welcome_delivery` ledger. The body supports a
+  `{member}` placeholder rendered to the joiner's display name. Delivery mirrors
+  the per-Space engine (reconciler + worker + rotating cursor + `FOR UPDATE SKIP
+  LOCKED` + CAS/at-most-once) as a **parallel, group-scoped** copy — not a
+  refactor of the reviewed space code. **No platform-global content fallback**: a
+  group with no enabled row gets no welcome.
+- **Config** — new master switch `onboarding.group_welcome_enabled` (bool,
+  **default off** = dark launch), read via `SystemSettings.GroupWelcomeEnabled()`,
+  checked at enqueue/reconcile/worker. Enablement only — no content fallback;
+  flip-off is an instant, reversible kill that touches no per-group rows. Ships
+  double-inert (master off AND per-group `enabled=false` by default).
+- **Behavior** — burst coalescing: a batch invite (one `GroupMemberAdd` event → N
+  rows) is delivered as **one** public post naming everyone (`{member}` → joined
+  list; overflow → `…、nameK 等 N 人`) instead of N posts. Freshly-enqueued rows are
+  held a short coalesce window via `next_retry_at`; the worker `claimBatch`es a
+  group's due rows and posts once, preserving per-row at-most-once (shared
+  `message_id`). One coalesced post per group per wake also rate-limits a single
+  group's welcomes.
+- **Test** — full `-race` suites green for `common`/`notify`/`group`/`space`;
+  committed **live e2e** (`group_welcome_e2e_test.go`) drives the whole pipeline
+  against real WuKongIM, confirming `notification` posts into a group channel it
+  is not a member of and that a burst coalesces to one `message_id`. Incidental
+  polish carried from #646 (Upsert doc caveat, `r.Enabled` read, request-context
+  DB, DELETE→enabled-global-fallback test). See
+  [journal](journal/shared/group-welcome-message.md).
+
 ## 2026-07-23 (cardtmpl-l2a-migration PR-1)
 
 - **Feature** — Roadmap C first slice: `docs.commented@0.1.0` and

--- a/.octospec/tasks/group-welcome-message/brief.md
+++ b/.octospec/tasks/group-welcome-message/brief.md
@@ -52,8 +52,9 @@ Locked product decisions (design review, this task):
    `GroupMemberAdd` event → many `(group_no, uid)` rows at once; delivering one
    public post per joiner would spam the channel. Instead the worker claims a
    group's due rows as a batch and posts **one** message naming everyone
-   (`{member}` → the joined name list; a large batch collapses the tail to
-   `… 等 N 人`). At-most-once per `(group_no, uid)` is preserved (each row still
+   (`{member}` → the joined name list; a batch larger than
+   `groupWelcomeCoalesceNames` lists the first K names then appends `等 N 人`, e.g.
+   `张三、李四、…、王五 等 20 人`). At-most-once per `(group_no, uid)` is preserved (each row still
    transitions independently); a burst larger than the per-post cap spills its tail
    into later worker wakes (a few posts, not N).
 
@@ -187,8 +188,8 @@ refactor — explicitly out of scope here.)
   - New ledger table `octo_group_welcome_delivery`, `UNIQUE(group_no, uid)`, same
     state machine columns as `octo_space_welcome_delivery` (status, attempts,
     claim_owner, claim_expire_at, next_retry_at, error_class, timestamps), plus a
-    sweep index `(status, claim_expire_at)` and a claim index leading with
-    `(status, next_retry_at)` for the cross-group claim.
+    cross-group sweep index `(status, claim_expire_at)` and a per-group claim index
+    `(group_no, status, next_retry_at)` for the batch claim.
   - **Precedence (simpler than Space — no global fallback):** effective config for
     a group = the per-group row **iff present AND enabled**; else off. Deterministic,
     exactly one effective config per group.
@@ -231,12 +232,14 @@ refactor — explicitly out of scope here.)
     first-join human members past `active_from` lacking a ledger row, under a
     **global per-cycle cap** + per-group sub-cap + a **rotating start cursor**
     (fairness — no group starves another; copy the Space fix).
-  - Worker claims **across groups** (`status=pending AND next_retry_at<=?`,
-    `FOR UPDATE SKIP LOCKED`, index-backed), re-resolves the claimed row's group
-    config for the body, re-checks eligibility, then **posts to the group
-    channel**; cross-group sweep (`sweepClaimedAll`/`sweepDispatchingAll` + sweep
-    index) reclaims lease-expired rows. At-most-once, CAS-on-`claim_owner`, lease,
-    backoff, `unknown`/`failed` terminal handling — same contract as Space.
+  - Worker **rotates over the enabled groups** and, per group, **batch-claims**
+    that group's due rows (`group_no=? AND status=pending AND next_retry_at<=?`,
+    `FOR UPDATE SKIP LOCKED`, index-backed) and posts ONE coalesced message; it
+    re-resolves the group config for the body and re-checks eligibility first. The
+    **sweep** is cross-group (`sweepClaimedAll`/`sweepDispatchingAll` + sweep index)
+    and reclaims lease-expired rows regardless of group. At-most-once,
+    CAS-on-`claim_owner`, lease, backoff, `unknown`/`failed`/retry terminal
+    handling — same contract as Space (plus a definitive-reject→retry path, below).
   - **Enqueue idempotency:** `INSERT … ON DUPLICATE KEY UPDATE id=id` on
     `(group_no, uid)`.
   - **Platform master switch (tags: notify, observability).** A single bool
@@ -332,7 +335,7 @@ refactor — explicitly out of scope here.)
 
 ## Acceptance
 
-- **Group-admin CRUD authz.** `GET/PUT/DELETE /v1/group/:group_no/welcome` succeed
+- **Group-admin CRUD authz.** `GET/PUT/DELETE /v1/groups/:group_no/welcome` succeed
   for a creator/manager of that group; a plain member, a non-member, and a caller
   against a disbanded group all get the generic permission-denied path (no
   privilege-reason leak). A request affects only the path `:group_no`.
@@ -357,7 +360,8 @@ refactor — explicitly out of scope here.)
   turning it on lets delivery proceed; turning it back off stops new posts (a
   regression test asserts both directions). The switch adds no content fallback.
 - **Burst coalescing.** N members joining a group at once are delivered as **one**
-  public post naming all of them (`{member}` → joined list; overflow → `… 等 N 人`),
+  public post naming all of them (`{member}` → joined list; overflow lists the
+  first K names then `等 N 人`),
   not N posts; every joiner in the batch is marked SENT (at-most-once each). A
   group whose burst exceeds the per-post cap posts one coalesced batch per wake and
   spills the remainder to later wakes without starving other groups.
@@ -365,9 +369,10 @@ refactor — explicitly out of scope here.)
   members independently; disabling group A does not affect B; the reconciler
   catches up all enabled groups within a cycle under a global cap; a group kept
   over-cap does not starve others (rotating-cursor regression test).
-- **Cross-group claim.** The worker claims from any enabled group; the claim
-  predicate is index-backed (no full scan) — verified by a `(status, next_retry_at)`
-  -leading index. A claimed row posts with its own group's body.
+- **Per-group batch claim.** The worker rotates over enabled groups and batch-
+  claims each group's due rows; the claim predicate is index-backed (no full scan)
+  — backed by the `(group_no, status, next_retry_at)` claim index. A claimed batch
+  posts with its own group's body.
 - **Sender contract + placeholder.** The posted message's sender is the fixed
   server-chosen identity (not admin-forgeable); `payload.type=Text`, authoritative
   `payload.group_no`. The rendered body equals the configured message with the
@@ -405,7 +410,7 @@ refactor — explicitly out of scope here.)
   at-most-once public post to the correct group channel; `{member}` placeholder
   renders each joiner's own name (unknown tokens left verbatim); leave/rejoin no
   re-post; pre-`active_from` skip; human/system-bot exclusion; multi-group independent
-  delivery + per-group disable; cross-group claim single winner
+  delivery + per-group disable; per-group batch claim single winner
   (`FOR UPDATE SKIP LOCKED`); worker fair-rotation; migration executes on a fresh
   DB; UID rate-limit headers.
 

--- a/.octospec/tasks/group-welcome-message/brief.md
+++ b/.octospec/tasks/group-welcome-message/brief.md
@@ -40,9 +40,26 @@ Locked product decisions (design review, this task):
    **placeholder** that renders to the new member's display name / @mention at
    send time (公开欢迎语点名新成员) — the personalization the Space version
    deliberately omitted. This also makes the per-member post non-repetitive.
+5. **Platform master switch, default OFF (dark launch).** A single
+   `system_setting onboarding.group_welcome_enabled` (bool) gates the whole
+   feature: the event path enqueues nothing and the worker posts nothing while it
+   is off. It is **enablement only** — it does NOT introduce any platform-global
+   *content* fallback (decision #2 stands; a group's body always comes from its own
+   row). Flipping it back to off is an instant kill switch (no per-group rows
+   touched, converges across replicas within the settings snapshot TTL). This is
+   the outer AND over each group's own `enabled`.
+6. **Coalesce a burst of joins into ONE post.** A batch invite arrives as a single
+   `GroupMemberAdd` event → many `(group_no, uid)` rows at once; delivering one
+   public post per joiner would spam the channel. Instead the worker claims a
+   group's due rows as a batch and posts **one** message naming everyone
+   (`{member}` → the joined name list; a large batch collapses the tail to
+   `… 等 N 人`). At-most-once per `(group_no, uid)` is preserved (each row still
+   transitions independently); a burst larger than the per-post cap spills its tail
+   into later worker wakes (a few posts, not N).
 
-Ships with per-group configs defaulting to `enabled=false` (no behaviour change
-on deploy until a group admin opts in).
+Ships with the master switch **off** and per-group configs defaulting to
+`enabled=false` — double-inert on deploy: nothing happens until an operator turns
+on the platform switch AND a group admin opts that group in.
 
 **Architecture: mirror, don't refactor.** The per-Space welcome delivery engine
 (`modules/notify/space_welcome*.go` + `octo_space_welcome_delivery` ledger) is
@@ -222,6 +239,22 @@ refactor — explicitly out of scope here.)
     backoff, `unknown`/`failed` terminal handling — same contract as Space.
   - **Enqueue idempotency:** `INSERT … ON DUPLICATE KEY UPDATE id=id` on
     `(group_no, uid)`.
+  - **Platform master switch (tags: notify, observability).** A single bool
+    `system_setting onboarding.group_welcome_enabled` (registered in the schema,
+    read via `SystemSettings.GroupWelcomeEnabled()`, default **false**). Checked at
+    the event enqueue, the reconciler, and the worker (post-sweep) — off ⇒ no
+    enqueue, no post; the cross-group sweep still runs so in-flight rows reach a
+    terminal state. Enablement only, **no content fallback** (a group's body is
+    always its own row). Hot-reloaded with the snapshot; flip-off is an instant,
+    reversible kill that touches no per-group rows.
+  - **Burst coalescing (tags: notify, wire-contract).** A freshly-enqueued row is
+    held back from the worker until `now + coalesceWindow` (via `next_retry_at`) so
+    co-arriving joins collect; the worker `claimBatch`es a group's due rows (≤
+    `groupWelcomeCoalesceMax`) and `dispatchBatch` posts **one** message whose
+    `{member}` renders to the joined name list. One coalesced post per group per
+    wake also naturally rate-limits a single group's welcomes; a burst beyond the
+    cap spills into later wakes. Each row keeps its own CAS/at-most-once transition
+    and shares the one message's `message_id`.
 
 - **Group-channel send contract (tags: notify, wire-contract).**
   - The send builds a `config.MsgSendReq` to `channel_id=group_no`,
@@ -278,8 +311,11 @@ refactor — explicitly out of scope here.)
   otherwise untouched.
 - **Multiple welcome messages per group / audience targeting / scheduling** — one
   config per group, single plain-text body, no `welcome_id`.
-- **Global / platform-wide group welcome fallback** — deliberately none (per the
-  locked decision); no `system_setting` keys for group welcome.
+- **Global / platform-wide group welcome *content* fallback** — deliberately none
+  (per the locked decision): a group's body always comes from its own row. The
+  **one** `system_setting` key added (`onboarding.group_welcome_enabled`) is an
+  enablement master switch (decision #5), NOT a content fallback — it never
+  supplies a body, target, or default for any group.
 - **Delivery reliability semantics** — state machine, at-most-once, sweep,
   backoff, CAS, lease, `SELECT … FOR UPDATE SKIP LOCKED`, no leader election —
   copied unchanged from the Space engine, not re-designed.
@@ -316,6 +352,15 @@ refactor — explicitly out of scope here.)
 - **Isolation / eligibility (regression).** System bots/robots as joiners get no
   welcome; a disabled or absent config → no post; one group's backlog never posts
   into another group; fail-closed on any anomaly.
+- **Platform master switch.** With `onboarding.group_welcome_enabled=false` (the
+  default), an otherwise-deliverable enabled group produces no enqueue and no post;
+  turning it on lets delivery proceed; turning it back off stops new posts (a
+  regression test asserts both directions). The switch adds no content fallback.
+- **Burst coalescing.** N members joining a group at once are delivered as **one**
+  public post naming all of them (`{member}` → joined list; overflow → `… 等 N 人`),
+  not N posts; every joiner in the batch is marked SENT (at-most-once each). A
+  group whose burst exceeds the per-post cap posts one coalesced batch per wake and
+  spills the remainder to later wakes without starving other groups.
 - **Multi-group + fairness.** Two enabled groups each welcome their own first-join
   members independently; disabling group A does not affect B; the reconciler
   catches up all enabled groups within a cycle under a global cap; a group kept

--- a/.octospec/tasks/group-welcome-message/brief.md
+++ b/.octospec/tasks/group-welcome-message/brief.md
@@ -1,0 +1,388 @@
+---
+type: Task
+title: "Task: group-welcome-message"
+description: Add a per-group new-member welcome message — each group's owner/admin configures one welcome that is posted publicly into the group channel on a member's first join; mirrors the per-Space welcome infra but delivers to the group channel (not a DM) with no global fallback.
+tags: ["notify", "onboarding", "group", "isolation", "auth", "acl", "i18n", "error-response", "wire-contract", "migration", "rate-limit", "idempotency", "observability", "testing", "commit", "git"]
+timestamp: 2026-07-23T12:40:00+08:00
+# --- octospec extension fields ---
+slug: group-welcome-message
+upstream: self
+source: self
+---
+
+# Task: group-welcome-message
+
+> One task = one `.octospec/tasks/<slug>/` directory. This brief is the spec for
+> the work. AI may draft it from existing code; a human confirms it.
+
+## Goal
+
+Add a **group new-member welcome message (群入群欢迎语)**: each group's owner/admin
+manages **one** welcome config for **their** group, and when a human member joins
+that group **for the first time**, one welcome message is **posted publicly into
+the group channel** (visible to everyone), at most once per member.
+
+Locked product decisions (design review, this task):
+
+1. **Delivery = public group-channel post**, NOT a personal DM. The message is
+   sent to `channel_id = group_no`, `channel_type = GROUP (2)` — the whole group
+   sees it. (This is the key divergence from the per-Space welcome, which DMs the
+   newcomer via `channel_type = PERSON`.)
+2. **Config = one row per group, self-service by that group's owner/admin**
+   (`IsCreatorOrManager`); **no platform-global fallback** (unlike the Space
+   feature). A group with no enabled config → no welcome.
+3. **Trigger = first-time join only.** `active_from` cutoff + an at-most-once
+   delivery ledger keyed `(group_no, uid)` is the dedup authority, so leaving and
+   rejoining does **not** re-post for anyone already welcomed. (Note: unlike
+   `space_member`, `group_member.created_at` resets on rejoin — see Background;
+   the ledger, not the timestamp, guarantees at-most-once.)
+4. **Body may name the joining member.** The configured message supports a
+   **placeholder** that renders to the new member's display name / @mention at
+   send time (公开欢迎语点名新成员) — the personalization the Space version
+   deliberately omitted. This also makes the per-member post non-repetitive.
+
+Ships with per-group configs defaulting to `enabled=false` (no behaviour change
+on deploy until a group admin opts in).
+
+**Architecture: mirror, don't refactor.** The per-Space welcome delivery engine
+(`modules/notify/space_welcome*.go` + `octo_space_welcome_delivery` ledger) is
+freshly shipped (PR #646) and delicate (at-most-once). Rather than generalize it
+into a shared "container" abstraction — a large refactor that re-opens that
+reviewed surface — this task stands up a **parallel, group-scoped** copy of the
+same proven shape (config store + delivery ledger + reconciler + send worker +
+rotating cursor + CAS/at-most-once), swapping only (a) the container (`space_*` →
+`group_*`), (b) the sender (personal DM → group-channel post), and (c) dropping
+the global-fallback branch. Trivial pure helpers may be shared; the space code is
+otherwise untouched. (Generalizing both onto one engine is a possible future
+refactor — explicitly out of scope here.)
+
+## Background
+
+- **Prior art (the pattern this copies).** The per-Space new-member welcome:
+  - Delivery machinery: `octo_space_welcome_delivery` ledger
+    (`UNIQUE(space_id,uid)`), reconciler, send worker, notify-local HTTP sender,
+    rotating per-replica cursor, `FOR UPDATE SKIP LOCKED` claim + CAS-on-
+    `claim_owner`, at-most-once (`modules/notify/space_welcome*.go`).
+  - Per-container config: `octo_space_welcome_config` +
+    `common.SpaceWelcomeConfigStore` (`UpsertMerged` insert-then-lock),
+    `GET/PUT/DELETE /v1/space/:space_id/welcome`
+    (`modules/space/api_welcome.go`). Briefs:
+    `.octospec/tasks/space-welcome-per-space-admin-crud/brief.md` +
+    `space-new-user-welcome-message`.
+  - Key difference to internalize: Space **DMs** the newcomer (private, per
+    recipient); Group **posts into the channel** (public, seen by all). The
+    ledger `(container, uid)` dedup shape is identical (one welcome per member's
+    first join); the *send target* is the only delivery change.
+
+- **Group model anchors (verified by recon).**
+  - **Tables:** `group` (`group_no VARCHAR(40)` = the channel id, `status smallint`,
+    `creator`) and `group_member` (`group_no`, `uid`, `role smallint`, `status`,
+    `is_deleted`, `robot`, `created_at`, UNIQUE `(group_no, uid)`) —
+    `modules/group/sql/20191106000002_group_legacy01.sql`; models
+    `modules/group/db.go:648-717`.
+  - **Roles** (`modules/group/const.go:19-26`): `MemberRoleCommon=0`,
+    `MemberRoleCreator=1` (owner/creator), `MemberRoleManager=2`. **Admin = role ∈
+    {1,2}.** (Note: different numbering from space's `0=member/1=admin/2=owner`.)
+  - **Status** (`modules/group/const.go:3-11`): `GroupStatusDisabled=0`,
+    `GroupStatusNormal=1`, `GroupStatusDisband=2`. **Active = Normal(1).**
+  - **Admin gate (canonical):** `db.QueryIsGroupManagerOrCreator(groupNo, uid)`
+    (`modules/group/db.go:107-111`) = `is_deleted=0 AND is_external=0 AND
+    status=Normal AND role ∈ {creator,manager}`; service wrapper
+    `IsCreatorOrManager` (`service.go:571`). **There is NO HTTP-layer admin/active
+    helper for groups** (unlike space's `authorizeSpaceAdmin`); group handlers
+    inline the check + 403 (e.g. `api.go:1172,3540,3998`). → this task **builds a
+    `requireGroupWelcomeAdmin` + group-active wrapper** over these primitives.
+  - **Join event already published & multi-listener:** `event.GroupMemberAdd =
+    "group.memberadd"` (`modules/base/event/api.go:22-23`), published transactionally
+    at `modules/group/api.go:1852-1861` with payload
+    `config.MsgGroupMemberAddReq{Operator, GroupNo, Members []*UserBaseVo}`. The
+    builtin `handlerMap` leaves it uncommented→fanned-out to all
+    `AddEventListener` regs (`base/event/handler.go:26,41`); the message module
+    already subscribes (`modules/message/api.go:335`). A notify listener
+    subscribes identically — mirror how notify subscribes `event.SpaceMemberJoin`
+    (`modules/notify/api.go:146` → `handleMemberJoin`). **Coverage gap (parity with
+    space):** org/dept auto-add + scan-join partly bypass `GroupMemberAdd`
+    (`group/event.go:341,511`; `event.GroupMemberScanJoin` `api.go:2595`) — the
+    reconciler over `group_member` is what catches those (optionally also listen to
+    `GroupMemberScanJoin`).
+  - **Group-channel send (verified):** `ctx.SendMessage(&config.MsgSendReq{
+    ChannelID: group_no, ChannelType: common.ChannelTypeGroup.Uint8()/*=2*/,
+    FromUID: …, Payload: {type:1, content}})` — canonical at
+    `modules/group/event.go:381-395`. The notify sender's HTTP layer
+    (`space_welcome_sender.go send`, POST `/message/send`) is **container-agnostic
+    and reusable verbatim**; only the *request construction* changes from
+    `NewPersonalMsgSendReq` (channel_type=PERSON) to this group literal. `MsgSendReq`
+    also has a `Subscribers` field to scope visibility — **not used** here (delivery
+    is public per the locked decision).
+  - **⚠ First-join timestamp differs from space.** Space keys first-join on
+    `space_member.created_at`, which is **never reset on rejoin**. `group_member.
+    created_at` **IS reset on rejoin** (`recoverMemberTx` sets `created_at: Now()`,
+    `modules/group/db.go:246`). Consequence: the **ledger `UNIQUE(group_no, uid)`
+    remains the at-most-once authority** — anyone already welcomed keeps their
+    (SENT) ledger row, so leave→rejoin does NOT re-post (satisfies the "退群再进不
+    重复" decision). The only edge: a member who joined *before* `active_from` (never
+    enqueued, no ledger row), left, and rejoined *after* `active_from` would newly
+    qualify (fresh `created_at`) and get welcomed on that second join. Acceptable
+    under first-join-by-current-membership semantics; see Open questions.
+
+- **Sender identity for a public group post.** Path confirmed: build a
+  `config.MsgSendReq` and `ctx.SendMessage` it (the notify sender's HTTP layer is
+  reused). Sender is server-chosen and fixed (not admin-forgeable). Proposed
+  `from_uid = notification` (the system bot, as the Space welcome uses); existing
+  group tips instead post as the *operator* (a member) — `group/event.go:392`. The
+  **one remaining unknown** (implement-time verification, incl. real-wire): whether
+  the `notification` bot may post into a group channel it is not a member of, or
+  whether the post must use a member identity / a system-message path. This picks
+  the concrete `from_uid`; it does not change the rest of the design.
+
+## Load-bearing list
+
+- **Group isolation & authorization (tags: group, isolation, auth, acl).**
+  - A caller may read/write the welcome config for **only** a group where they are
+    creator/manager. Enforcement mirrors space: gate every CRUD handler on
+    `IsCreatorOrManager(:group_no, loginUID)` after a group-active check; reject
+    non-managers/non-members with a **generic** permission-denied code (anti-
+    enumeration: same 403 for non-member and under-privileged). The path
+    `:group_no` is the **only** group a request may affect. A disbanded/frozen
+    group → same reject path.
+  - Delivery isolation: a claimed ledger row is dispatched using **that row's**
+    `group_no` config and posts into **that** group's channel only; one group's
+    config or backlog can never post into another group. The trigger member must
+    be a **human** (system bots / robots excluded as joiners) and a real
+    first-join; fail-closed never posts on any anomaly.
+  - **Public-post consequence:** because delivery is a public channel post (not a
+    private DM), there is no per-recipient DM privacy check — but the *eligibility*
+    gate (group active, config enabled, member is a first-join human) still fully
+    governs whether the single post happens. A member who joined then left before
+    the post drains: **[open question]** still welcome them (dedup already keyed
+    (group,uid)) or skip — default: post is keyed to the first-join event, so it
+    fires once regardless of a later leave (matches "first join" semantics).
+
+- **Config storage migration (tags: migration).**
+  - New table `octo_group_welcome_config`, one row per group:
+    `group_no` (UNIQUE, length/charset/**COLLATE aligned to the group table's
+    group_no** to avoid MySQL 1267 on reconciler JOINs), `enabled TINYINT`,
+    `active_from VARCHAR(40)` (RFC3339 UTC string, `""` = unset — reuse the
+    Space store's string-typed approach so `ParsedActiveFrom` validators apply),
+    `message VARCHAR(2000)`, `updated_by VARCHAR(40)` (audit),
+    `created_at`/`updated_at DATETIME NOT NULL` (UTC, **app-written, never
+    `NOW()`**), `idx_enabled`. Migration under a module that embeds `sql/`.
+  - New ledger table `octo_group_welcome_delivery`, `UNIQUE(group_no, uid)`, same
+    state machine columns as `octo_space_welcome_delivery` (status, attempts,
+    claim_owner, claim_expire_at, next_retry_at, error_class, timestamps), plus a
+    sweep index `(status, claim_expire_at)` and a claim index leading with
+    `(status, next_retry_at)` for the cross-group claim.
+  - **Precedence (simpler than Space — no global fallback):** effective config for
+    a group = the per-group row **iff present AND enabled**; else off. Deterministic,
+    exactly one effective config per group.
+  - **Time discipline** identical to the Space ledger: all timestamps app-supplied
+    UTC bound params; no naked `NOW()`; `active_from` parsed RFC3339 UTC.
+
+- **Config write path + validation (tags: error-response, i18n, wire-contract).**
+  - Concurrent admin PUTs serialized by an insert-then-lock upsert (copy the
+    Space `UpsertMerged` idiom: idempotent INSERT → `SELECT … FOR UPDATE` → merge
+    → UPDATE, bounded 1213/1205 retry) so two managers editing the same group
+    can't lose fields and a first-create can't gap-lock-deadlock.
+  - Validation: `enabled=true` requires a parseable RFC3339 `active_from` and a
+    trimmed-non-empty `message` ≤ 2000 code points (reuse the Space combination
+    validator or a group analog); message + `active_from` column-width guards run
+    regardless of `enabled` (clean 400, not a driver 500 / silent truncation);
+    newlines preserved, plain text (no markdown). Partial `PUT` validates the
+    merged prospective config, not the patch alone.
+  - `PUT` upserts (增/改); `DELETE` hard-deletes → group reverts to off (no
+    fallback); `updated_by` records the acting admin.
+
+- **Error responses & i18n (tags: error-response, i18n, wire-contract).**
+  - All CRUD responses via the `pkg/httperr` i18n envelope with registered
+    `pkg/errcode` codes — reuse existing group permission/param codes where they
+    exist; add new codes only if none fit (each new code gets a zh-CN block in
+    `active.zh-CN.toml`). No raw `c.ResponseError`/`c.JSON` non-OK/`AbortWithStatusJSON`.
+  - `make i18n-extract-check` + `make i18n-lint` pass; new handler files added to
+    the owning module's `Test<Module>NoLegacyResponseError` source guard.
+
+- **Rate limiting (tags: rate-limit).**
+  - The group-admin CRUD route group mounts `SharedUIDRateLimiter` **after**
+    `AuthMiddleware`; no hand-rolled Redis counter. Route-hitting tests reset
+    `ratelimit:uid:*` in setup.
+
+- **Delivery drive loop — all-enabled-groups (tags: notify, onboarding, idempotency).**
+  - Event path: a notify listener on `event.GroupMemberAdd` resolves the group's
+    effective config and enqueues a pending `(group_no, uid)` row iff enabled +
+    the joiner is an eligible first-join human. Enqueue failure never blocks/rolls
+    back the completed join (fail-open on the join, fail-closed on the welcome).
+  - Reconciler iterates **every group with an enabled config**, scans each for
+    first-join human members past `active_from` lacking a ledger row, under a
+    **global per-cycle cap** + per-group sub-cap + a **rotating start cursor**
+    (fairness — no group starves another; copy the Space fix).
+  - Worker claims **across groups** (`status=pending AND next_retry_at<=?`,
+    `FOR UPDATE SKIP LOCKED`, index-backed), re-resolves the claimed row's group
+    config for the body, re-checks eligibility, then **posts to the group
+    channel**; cross-group sweep (`sweepClaimedAll`/`sweepDispatchingAll` + sweep
+    index) reclaims lease-expired rows. At-most-once, CAS-on-`claim_owner`, lease,
+    backoff, `unknown`/`failed` terminal handling — same contract as Space.
+  - **Enqueue idempotency:** `INSERT … ON DUPLICATE KEY UPDATE id=id` on
+    `(group_no, uid)`.
+
+- **Group-channel send contract (tags: notify, wire-contract).**
+  - The send builds a `config.MsgSendReq` to `channel_id=group_no`,
+    `channel_type=ChannelTypeGroup`, `payload.type=Text`, authoritative
+    `payload.group_no`, sender fixed and server-chosen (proposed `notification`;
+    admins cannot forge sender/payload). No rich text/cards/attachments/scheduled
+    send. `Subscribers` not set (public to the whole group).
+  - **Placeholder rendering (member name/@mention).** The stored body may contain
+    a single, documented placeholder token for the joining member (e.g.
+    `{member}`); at dispatch it renders to that member's display name — resolved
+    from the `user`/`group_member` nickname — for **that row's `uid`**. Rendering
+    happens **server-side at send time** (the stored config keeps the raw token;
+    the DB column bound is on the raw body). Unknown/other tokens are left
+    verbatim (no execution, no injection surface — the payload is plain text).
+    Length: the rendered body still fits the wire contract; guard/truncate the
+    rendered result if a long nickname could overflow.
+  - **Plain-name vs clickable @mention [implement-time detail].** v1 renders the
+    member's **display name as plain text**. A real clickable @mention (client
+    highlights + notifies) needs the WuKongIM mention payload encoding — see
+    `pkg/mentionrewrite` and existing mention payloads; adopt it if the encoding is
+    cheap, else ship plain-name naming and add clickable @mention as a fast-follow.
+    Either way the token and the "names the joiner" behaviour are delivered.
+
+- **Config cache & convergence (tags: notify).** Read-through by PK (like the
+  Space store — no snapshot TTL), so an admin write is visible on the next
+  delivery read across replicas. Reads atomic per group.
+
+- **Observability (tags: observability).** Mirror the Space counters/stages
+  (`enqueue_total`/`enqueue_dedup_total`/`config_invalid_total`/sweep counts),
+  per-group dimension `group_no` as a structured log field. Never log the welcome
+  body or raw upstream error strings.
+
+- **Incidental (附带) polish carried from the merged Space welcome (#646)** — small,
+  reviewer-requested, bundled here (tags: notify, space, testing):
+  1. Doc-caveat on exported `common.(*SpaceWelcomeConfigStore).Upsert` — production
+     must use `UpsertMerged` (concurrency); `Upsert` stays for single-writer/test.
+  2. `modules/notify/space_welcome.go enabledEffectiveConfigs`: read `r.Enabled`
+     instead of hardcoded `Enabled: true` (self-documenting; behaviour identical
+     since `ListEnabled` filters `enabled=1`).
+  3. Space CRUD handlers derive the DB context from `c.Request.Context()` (honour
+     client cancellation) instead of `context.Background()`.
+  4. Add an HTTP-level test asserting Space `DELETE` reverts to an **enabled**
+     global fallback (locks the response contract).
+
+- **Commit style (tags: commit, git).** Conventional Commits, English.
+
+## Out of scope
+
+- **Generalizing Space + Group welcome onto one shared delivery engine** — this
+  task mirrors the shape into a parallel group-scoped implementation; a unifying
+  refactor of the reviewed Space code is a separate future task.
+- **Any change to the Space welcome delivery/semantics** beyond the 4 incidental
+  polish items above — the Space ledger, state machine, sender, and CRUD are
+  otherwise untouched.
+- **Multiple welcome messages per group / audience targeting / scheduling** — one
+  config per group, single plain-text body, no `welcome_id`.
+- **Global / platform-wide group welcome fallback** — deliberately none (per the
+  locked decision); no `system_setting` keys for group welcome.
+- **Delivery reliability semantics** — state machine, at-most-once, sweep,
+  backoff, CAS, lease, `SELECT … FOR UPDATE SKIP LOCKED`, no leader election —
+  copied unchanged from the Space engine, not re-designed.
+- **Rich message features** — no cards/attachments/rich text. The single
+  member-name placeholder (§ Group-channel send contract) **is in scope**; a
+  general templating engine / multiple placeholders / arbitrary token language is
+  not. A clickable @mention (vs plain-name render) may be deferred to a fast-follow.
+- **Retroactive bulk post** to members who joined before a group's `active_from`.
+- **Client / admin UI** — server-side API + validation + delivery only.
+- **octo-lib changes** — the notify-local sender stays self-contained; if a
+  group-channel send helper is missing in octo-lib it is built server-side here.
+- **Group membership/permission model changes** — reuse `IsCreatorOrManager` +
+  the existing group status; no new roles or status.
+
+## Acceptance
+
+- **Group-admin CRUD authz.** `GET/PUT/DELETE /v1/group/:group_no/welcome` succeed
+  for a creator/manager of that group; a plain member, a non-member, and a caller
+  against a disbanded group all get the generic permission-denied path (no
+  privilege-reason leak). A request affects only the path `:group_no`.
+- **CRUD semantics.** `PUT` with no config inserts (增); `PUT` on an existing
+  config updates (改); `DELETE` removes (删) → group reverts to **off** (no
+  fallback). `updated_by` records the acting admin. Concurrent PUTs (edit +
+  first-create) lose no field (insert-then-lock regression tests, both cases).
+- **Write-path validation (prospective).** With `enabled=true`, an unparseable
+  `active_from`, empty-after-trim, or >2000-code-point `message` is rejected via
+  the i18n envelope; `active_from` over its column width is a clean field-too-long
+  400. A partial `PUT` is accepted iff the merged prospective config is valid.
+- **First-join, at-most-once, public delivery.** A human member's **first** join
+  to an enabled group results in **exactly one** `(group_no, uid)` ledger row and
+  **exactly one** message posted to that group's channel (`channel_type=GROUP`,
+  `channel_id=group_no`), with the group's configured body. Leaving and rejoining
+  does not re-post. A member who joined before `active_from` gets nothing.
+- **Isolation / eligibility (regression).** System bots/robots as joiners get no
+  welcome; a disabled or absent config → no post; one group's backlog never posts
+  into another group; fail-closed on any anomaly.
+- **Multi-group + fairness.** Two enabled groups each welcome their own first-join
+  members independently; disabling group A does not affect B; the reconciler
+  catches up all enabled groups within a cycle under a global cap; a group kept
+  over-cap does not starve others (rotating-cursor regression test).
+- **Cross-group claim.** The worker claims from any enabled group; the claim
+  predicate is index-backed (no full scan) — verified by a `(status, next_retry_at)`
+  -leading index. A claimed row posts with its own group's body.
+- **Sender contract + placeholder.** The posted message's sender is the fixed
+  server-chosen identity (not admin-forgeable); `payload.type=Text`, authoritative
+  `payload.group_no`. The rendered body equals the configured message with the
+  `{member}` placeholder replaced by the joining member's display name (non-token
+  text + newlines byte-preserved; unknown tokens left verbatim; two different
+  joiners get their own name rendered).
+- **Rate limiting.** The CRUD group carries `SharedUIDRateLimiter` after
+  `AuthMiddleware`; a burst test observes the `uid`-scope headers / `rate.limited`
+  envelope; setup resets `ratelimit:uid:*`.
+- **i18n / error contract.** `make i18n-extract-check` + `make i18n-lint` pass;
+  any new codes have zh-CN blocks; new handler files are in the module's
+  `Test<Module>NoLegacyResponseError` guard; no raw error responses.
+- **Time discipline & schema alignment.** No feature SQL uses naked `NOW()`;
+  `octo_group_welcome_config.group_no` / `octo_group_welcome_delivery.group_no`
+  match the group table's `group_no` length/charset/COLLATE; a JOIN smoke test
+  confirms no MySQL 1267.
+- **Incidental Space polish.** The 4 items land: `Upsert` doc caveat present;
+  `enabledEffectiveConfigs` reads `r.Enabled`; Space CRUD uses request context;
+  the Space DELETE→enabled-global-fallback HTTP test exists and passes.
+- **Backward compatibility.** No group has a welcome by default (`enabled=false`),
+  so deploy is inert until an admin opts in; existing `modules/group`,
+  `modules/notify`, `modules/common`, `modules/space` tests still pass; no change
+  to existing wire responses.
+- **Command-line verification.**
+  - `go test -race ./modules/notify/...`
+  - `go test -race ./modules/group/...`
+  - `go test -race ./modules/common/...`
+  - `go test -race ./modules/space/...`  (incidental polish regression)
+  - `make i18n-extract-check && make i18n-lint`
+  - `go test -race ./...`
+  - `git diff --check`
+- **Tests cover at minimum:** CRUD authz matrix (creator/manager/member/non-member/
+  disbanded); PUT insert-then-update + concurrent lost-update + concurrent
+  first-create; DELETE→off; prospective validation both directions; first-join
+  at-most-once public post to the correct group channel; `{member}` placeholder
+  renders each joiner's own name (unknown tokens left verbatim); leave/rejoin no
+  re-post; pre-`active_from` skip; human/system-bot exclusion; multi-group independent
+  delivery + per-group disable; cross-group claim single winner
+  (`FOR UPDATE SKIP LOCKED`); worker fair-rotation; migration executes on a fresh
+  DB; UID rate-limit headers.
+
+## Open questions (confirm before / during implement)
+
+- **Sender identity for a public group post** — can the `notification` system
+  identity post into a group channel it is not a member of, or must the post use a
+  member identity / system-message path? Resolved at implement time (source +
+  real-wire); picks the concrete `from_uid`, does not change the design.
+- **Placeholder token + render style** — token name (proposed `{member}`), and
+  plain-name render (v1) vs. a clickable WuKongIM @mention (fast-follow if the
+  mention encoding is non-trivial). Confirm the token; @mention richness may defer.
+- **Module placement (confirm)** — CRUD handler in `modules/group` (mirrors
+  `modules/space/api_welcome.go`, plus a new `requireGroupWelcomeAdmin` gate),
+  delivery in `modules/notify` (mirrors `space_welcome*.go`), config store +
+  ledger split as with Space (config store in `modules/common`, ledger migration
+  under `modules/notify/sql/`).
+- **Post-join-leave** — the post is keyed to the first-join enqueue and fires once
+  even if the member leaves before the worker drains (default), vs. skip if no
+  longer a member at send. (Space re-checks membership at send; for a *public*
+  post that names the joiner, either is defensible.)
+
+RESOLVED in this brief: delivery = public group-channel post; per-group admin
+config, no global fallback; first-join at-most-once via the ledger (not the
+rejoin-resettable `created_at`); body names the joiner via a placeholder.

--- a/.octospec/tasks/group-welcome-message/brief.md
+++ b/.octospec/tasks/group-welcome-message/brief.md
@@ -238,8 +238,11 @@ refactor — explicitly out of scope here.)
     re-resolves the group config for the body and re-checks eligibility first. The
     **sweep** is cross-group (`sweepClaimedAll`/`sweepDispatchingAll` + sweep index)
     and reclaims lease-expired rows regardless of group. At-most-once,
-    CAS-on-`claim_owner`, lease, backoff, `unknown`/`failed`/retry terminal
-    handling — same contract as Space (plus a definitive-reject→retry path, below).
+    CAS-on-`claim_owner`, lease, backoff, `unknown`/`failed` terminal handling —
+    same contract as Space. A post-send failure marks every winner `unknown` and
+    is **never auto-retried** (the coalesced post is PUBLIC and carries no
+    idempotency key, so a retry could double-post a visible, unrecallable
+    message) — see the known-limitation on batch blast radius in the journal.
   - **Enqueue idempotency:** `INSERT … ON DUPLICATE KEY UPDATE id=id` on
     `(group_no, uid)`.
   - **Platform master switch (tags: notify, observability).** A single bool

--- a/.octospec/tasks/group-welcome-message/context.yaml
+++ b/.octospec/tasks/group-welcome-message/context.yaml
@@ -1,0 +1,14 @@
+injected:
+  - id: space-isolation
+    source: repo
+  - id: error-handling
+    source: repo
+  - id: trust-boundary
+    source: repo
+  - id: rate-limit
+    source: repo
+  - id: testing
+    source: repo
+  - id: commit-style
+    source: repo
+brief: .octospec/tasks/group-welcome-message/brief.md

--- a/modules/common/group_welcome_config_store.go
+++ b/modules/common/group_welcome_config_store.go
@@ -1,0 +1,339 @@
+package common
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"github.com/gocraft/dbr/v2"
+)
+
+// Per-group new-member welcome config (task group-welcome-message).
+//
+// This is the group counterpart to the per-Space welcome config
+// (SpaceWelcomeConfigStore). A group owner/manager manages one row per group via
+// modules/group's /v1/group/:group_no/welcome CRUD; modules/notify reads the
+// effective config on the delivery path. The store is a stateless read-through
+// (PK-indexed), so an admin write is visible on the next read across replicas
+// with no snapshot TTL.
+//
+// Unlike the Space feature there is NO platform-global fallback: a group's
+// effective config is simply its own row iff present AND enabled, else off.
+//
+// Time discipline mirrors the delivery ledger: created_at/updated_at are
+// application-computed UTC values passed as bound parameters (never NOW());
+// active_from is stored as the RFC3339 UTC string so ParsedActiveFrom /
+// ValidateGroupWelcomeCombination apply on the string form.
+
+const (
+	// GroupWelcomeMessageMaxRunes bounds the welcome body in Unicode code points,
+	// enforced on the write path (protects the VARCHAR(2000) column).
+	GroupWelcomeMessageMaxRunes = 2000
+	// GroupWelcomeActiveFromMaxLen bounds the active_from string to its storage
+	// column width (VARCHAR(40)). Enforced on the write path independently of
+	// enabled/parse: a disabled config skips the RFC3339 parse, and time.Parse
+	// otherwise accepts arbitrarily long fractional seconds, so without this guard
+	// an over-column value could reach the upsert and fail as a driver 500 (strict
+	// sql_mode) or truncate silently (permissive).
+	GroupWelcomeActiveFromMaxLen = 40
+)
+
+const groupWelcomeConfigTable = "octo_group_welcome_config"
+
+const groupWelcomeConfigCols = "group_no, enabled, active_from, message, updated_by, created_at, updated_at"
+
+// GroupWelcomeConfig is one per-group welcome config row / the effective config
+// consumed by the delivery path.
+type GroupWelcomeConfig struct {
+	GroupNo       string
+	Enabled       bool
+	ActiveFromRaw string // RFC3339 UTC string; "" when unset
+	Message       string
+	UpdatedBy     string
+	CreatedAt     time.Time
+	UpdatedAt     time.Time
+}
+
+// ParsedActiveFrom parses ActiveFromRaw as RFC3339 and returns it in UTC. ok is
+// false when the value is empty or unparseable — callers treat that as an
+// invalid combination (fail closed) when the feature is enabled.
+func (c GroupWelcomeConfig) ParsedActiveFrom() (time.Time, bool) {
+	if c.ActiveFromRaw == "" {
+		return time.Time{}, false
+	}
+	t, err := time.Parse(time.RFC3339, c.ActiveFromRaw)
+	if err != nil {
+		return time.Time{}, false
+	}
+	return t.UTC(), true
+}
+
+// ValidateGroupWelcomeCombination validates the tuple as a coherent combination.
+//
+//   - When disabled it always passes (a partial/empty config is fine while off).
+//   - When enabled it requires a non-empty group_no, a parseable RFC3339
+//     active_from, and a message non-empty (after trim) within
+//     GroupWelcomeMessageMaxRunes.
+//
+// Returns the first offending field name ("" when valid). There is no group
+// existence check here — the CRUD write path has already confirmed the path
+// group is active via the authz gate.
+func ValidateGroupWelcomeCombination(cfg GroupWelcomeConfig) (field string) {
+	if !cfg.Enabled {
+		return ""
+	}
+	if strings.TrimSpace(cfg.GroupNo) == "" {
+		return "group_no"
+	}
+	if _, ok := cfg.ParsedActiveFrom(); !ok {
+		return "active_from"
+	}
+	if strings.TrimSpace(cfg.Message) == "" || utf8.RuneCountInString(cfg.Message) > GroupWelcomeMessageMaxRunes {
+		return "message"
+	}
+	return ""
+}
+
+// groupWelcomeConfigRow is the DB projection (active_from is a plain string
+// column: "" means unset, avoiding a nullable-scan dependency).
+type groupWelcomeConfigRow struct {
+	GroupNo    string    `db:"group_no"`
+	Enabled    int       `db:"enabled"`
+	ActiveFrom string    `db:"active_from"`
+	Message    string    `db:"message"`
+	UpdatedBy  string    `db:"updated_by"`
+	CreatedAt  time.Time `db:"created_at"`
+	UpdatedAt  time.Time `db:"updated_at"`
+}
+
+func (r groupWelcomeConfigRow) toConfig() GroupWelcomeConfig {
+	return GroupWelcomeConfig{
+		GroupNo:       r.GroupNo,
+		Enabled:       r.Enabled == 1,
+		ActiveFromRaw: r.ActiveFrom,
+		Message:       r.Message,
+		UpdatedBy:     r.UpdatedBy,
+		CreatedAt:     r.CreatedAt,
+		UpdatedAt:     r.UpdatedAt,
+	}
+}
+
+// GroupWelcomeConfigStore is the DB access layer for per-group welcome config.
+type GroupWelcomeConfigStore struct {
+	db *dbr.Session
+}
+
+// NewGroupWelcomeConfigStore builds a store over the given session.
+func NewGroupWelcomeConfigStore(db *dbr.Session) *GroupWelcomeConfigStore {
+	return &GroupWelcomeConfigStore{db: db}
+}
+
+// Get returns the per-group config row; found=false when absent (not an error).
+func (s *GroupWelcomeConfigStore) Get(ctx context.Context, groupNo string) (*GroupWelcomeConfig, bool, error) {
+	if groupNo == "" {
+		return nil, false, nil
+	}
+	var row groupWelcomeConfigRow
+	err := s.db.SelectBySql(
+		"SELECT "+groupWelcomeConfigCols+" FROM "+groupWelcomeConfigTable+" WHERE group_no=?",
+		groupNo,
+	).LoadOneContext(ctx, &row)
+	if err != nil {
+		if errors.Is(err, dbr.ErrNotFound) {
+			return nil, false, nil
+		}
+		return nil, false, fmt.Errorf("get group welcome config: %w", err)
+	}
+	cfg := row.toConfig()
+	return &cfg, true, nil
+}
+
+// Exists reports whether a per-group row exists for groupNo (any enabled value).
+func (s *GroupWelcomeConfigStore) Exists(ctx context.Context, groupNo string) (bool, error) {
+	if groupNo == "" {
+		return false, nil
+	}
+	var n int
+	err := s.db.SelectBySql(
+		"SELECT COUNT(*) FROM "+groupWelcomeConfigTable+" WHERE group_no=?",
+		groupNo,
+	).LoadOneContext(ctx, &n)
+	if err != nil && !errors.Is(err, dbr.ErrNotFound) {
+		return false, fmt.Errorf("exists group welcome config: %w", err)
+	}
+	return n > 0, nil
+}
+
+// Upsert inserts or updates the per-group config in a single statement.
+//
+// NOTE: this is a simple idempotent write for single-writer / test contexts.
+// Production admin CRUD MUST use UpsertMerged, which serializes concurrent PUTs
+// (insert-then-lock + deadlock retry) to prevent lost partial updates when two
+// managers edit the same group at once.
+func (s *GroupWelcomeConfigStore) Upsert(ctx context.Context, cfg GroupWelcomeConfig, now time.Time) error {
+	enabled := 0
+	if cfg.Enabled {
+		enabled = 1
+	}
+	_, err := s.db.InsertBySql(
+		"INSERT INTO "+groupWelcomeConfigTable+" (group_no, enabled, active_from, message, updated_by, created_at, updated_at) "+
+			"VALUES (?, ?, ?, ?, ?, ?, ?) "+
+			"ON DUPLICATE KEY UPDATE enabled=VALUES(enabled), active_from=VALUES(active_from), "+
+			"message=VALUES(message), updated_by=VALUES(updated_by), updated_at=VALUES(updated_at)",
+		cfg.GroupNo, enabled, cfg.ActiveFromRaw, cfg.Message, cfg.UpdatedBy, now, now,
+	).ExecContext(ctx)
+	if err != nil {
+		return fmt.Errorf("upsert group welcome config: %w", err)
+	}
+	return nil
+}
+
+// UpsertMerged performs a read-modify-write of the per-group config inside a
+// transaction, serialized so two managers PUTting the same group concurrently
+// never lose each other's fields — whether editing an existing config OR both
+// creating it for the first time. It uses the same insert-then-lock strategy as
+// the Space store: an idempotent INSERT ... ON DUPLICATE KEY UPDATE ensures the
+// row exists, then SELECT ... FOR UPDATE locks it before merge runs. Doing the
+// INSERT before any gap-locking read avoids the first-create gap-lock deadlock;
+// the single UNIQUE key makes concurrent same-key inserts a linear wait. A rare
+// transient deadlock/lock-timeout is retried (see isRetryableTxErr, shared with
+// the Space store).
+//
+// merge receives the current row (found=false when this PUT just created the
+// default row) and returns the config to persist; a non-nil merge error aborts
+// the write (tx rolls back) and is returned verbatim (never retried). On success
+// the persisted row, re-read inside the tx, is returned.
+func (s *GroupWelcomeConfigStore) UpsertMerged(
+	ctx context.Context,
+	groupNo string,
+	now time.Time,
+	merge func(cur *GroupWelcomeConfig, found bool) (GroupWelcomeConfig, error),
+) (*GroupWelcomeConfig, error) {
+	if groupNo == "" {
+		return nil, errors.New("group welcome upsert: empty group no")
+	}
+	var lastErr error
+	for attempt := 1; attempt <= 3; attempt++ {
+		cfg, err := s.upsertMergedOnce(ctx, groupNo, now, merge)
+		if err == nil {
+			return cfg, nil
+		}
+		if !isRetryableTxErr(err) {
+			return nil, err
+		}
+		lastErr = err
+	}
+	return nil, fmt.Errorf("upsert group welcome config: retries exhausted: %w", lastErr)
+}
+
+func (s *GroupWelcomeConfigStore) upsertMergedOnce(
+	ctx context.Context,
+	groupNo string,
+	now time.Time,
+	merge func(cur *GroupWelcomeConfig, found bool) (GroupWelcomeConfig, error),
+) (*GroupWelcomeConfig, error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("begin group welcome upsert tx: %w", err)
+	}
+	defer tx.RollbackUnlessCommitted()
+
+	// 1) Ensure the row exists (idempotent no-op if present; created_at untouched).
+	res, err := tx.InsertBySql(
+		"INSERT INTO "+groupWelcomeConfigTable+" (group_no, enabled, active_from, message, updated_by, created_at, updated_at) "+
+			"VALUES (?, 0, '', '', '', ?, ?) ON DUPLICATE KEY UPDATE group_no=group_no",
+		groupNo, now, now,
+	).ExecContext(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("ensure group welcome row: %w", err)
+	}
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return nil, fmt.Errorf("ensure group welcome row affected: %w", err)
+	}
+	created := affected == 1
+
+	// 2) Lock the now-existing row and read the current state under the lock.
+	var row groupWelcomeConfigRow
+	if err := tx.SelectBySql(
+		"SELECT "+groupWelcomeConfigCols+" FROM "+groupWelcomeConfigTable+" WHERE group_no=? FOR UPDATE",
+		groupNo,
+	).LoadOneContext(ctx, &row); err != nil {
+		return nil, fmt.Errorf("lock group welcome config: %w", err)
+	}
+
+	// 3) Merge. found=false when we just created the default row.
+	var cur *GroupWelcomeConfig
+	if !created {
+		c := row.toConfig()
+		cur = &c
+	}
+	next, err := merge(cur, !created)
+	if err != nil {
+		return nil, err // terminal (validation): surfaced verbatim, tx rolls back
+	}
+
+	// 4) Persist with a plain UPDATE (row guaranteed present; created_at preserved).
+	enabled := 0
+	if next.Enabled {
+		enabled = 1
+	}
+	if _, err := tx.UpdateBySql(
+		"UPDATE "+groupWelcomeConfigTable+" SET enabled=?, active_from=?, message=?, updated_by=?, updated_at=? WHERE group_no=?",
+		enabled, next.ActiveFromRaw, next.Message, next.UpdatedBy, now, groupNo,
+	).ExecContext(ctx); err != nil {
+		return nil, fmt.Errorf("update group welcome config: %w", err)
+	}
+
+	// 5) Re-read inside the tx for the persisted view, then commit.
+	var out groupWelcomeConfigRow
+	if err := tx.SelectBySql(
+		"SELECT "+groupWelcomeConfigCols+" FROM "+groupWelcomeConfigTable+" WHERE group_no=?",
+		groupNo,
+	).LoadOneContext(ctx, &out); err != nil {
+		return nil, fmt.Errorf("reload group welcome config: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("commit group welcome upsert tx: %w", err)
+	}
+	cfg := out.toConfig()
+	return &cfg, nil
+}
+
+// Delete hard-deletes the per-group config row. deleted=false when none existed
+// (idempotent). After a delete the group reverts to off (no fallback).
+func (s *GroupWelcomeConfigStore) Delete(ctx context.Context, groupNo string) (bool, error) {
+	if groupNo == "" {
+		return false, nil
+	}
+	res, err := s.db.DeleteFrom(groupWelcomeConfigTable).
+		Where("group_no=?", groupNo).ExecContext(ctx)
+	if err != nil {
+		return false, fmt.Errorf("delete group welcome config: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+	return n > 0, nil
+}
+
+// ListEnabled returns all enabled per-group configs, ordered by group_no, for
+// the reconciler / worker to iterate the set of groups with an active welcome.
+func (s *GroupWelcomeConfigStore) ListEnabled(ctx context.Context) ([]GroupWelcomeConfig, error) {
+	var rows []groupWelcomeConfigRow
+	_, err := s.db.SelectBySql(
+		"SELECT "+groupWelcomeConfigCols+" FROM "+groupWelcomeConfigTable+" WHERE enabled=1 ORDER BY group_no",
+	).LoadContext(ctx, &rows)
+	if err != nil {
+		return nil, fmt.Errorf("list enabled group welcome configs: %w", err)
+	}
+	out := make([]GroupWelcomeConfig, 0, len(rows))
+	for _, r := range rows {
+		out = append(out, r.toConfig())
+	}
+	return out, nil
+}

--- a/modules/common/group_welcome_config_store.go
+++ b/modules/common/group_welcome_config_store.go
@@ -15,7 +15,7 @@ import (
 //
 // This is the group counterpart to the per-Space welcome config
 // (SpaceWelcomeConfigStore). A group owner/manager manages one row per group via
-// modules/group's /v1/group/:group_no/welcome CRUD; modules/notify reads the
+// modules/group's /v1/groups/:group_no/welcome CRUD; modules/notify reads the
 // effective config on the delivery path. The store is a stateless read-through
 // (PK-indexed), so an admin write is visible on the next read across replicas
 // with no snapshot TTL.

--- a/modules/common/group_welcome_config_store_test.go
+++ b/modules/common/group_welcome_config_store_test.go
@@ -1,0 +1,196 @@
+package common
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestValidateGroupWelcomeCombination pins the pure validator (no DB).
+func TestValidateGroupWelcomeCombination(t *testing.T) {
+	af := time.Now().UTC().Format(time.RFC3339)
+	cases := []struct {
+		name string
+		cfg  GroupWelcomeConfig
+		want string
+	}{
+		{"disabled always ok", GroupWelcomeConfig{Enabled: false}, ""},
+		{"valid", GroupWelcomeConfig{Enabled: true, GroupNo: "g1", ActiveFromRaw: af, Message: "hi"}, ""},
+		{"missing group_no", GroupWelcomeConfig{Enabled: true, GroupNo: "", ActiveFromRaw: af, Message: "hi"}, "group_no"},
+		{"bad active_from", GroupWelcomeConfig{Enabled: true, GroupNo: "g1", ActiveFromRaw: "nope", Message: "hi"}, "active_from"},
+		{"empty message", GroupWelcomeConfig{Enabled: true, GroupNo: "g1", ActiveFromRaw: af, Message: "   "}, "message"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, ValidateGroupWelcomeCombination(tc.cfg))
+		})
+	}
+}
+
+// TestGroupWelcomeConfigStore_CRUD exercises the per-group config store end to end.
+func TestGroupWelcomeConfigStore_CRUD(t *testing.T) {
+	_, ctx := testutil.NewTestServer()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+	t.Cleanup(func() { _ = testutil.CleanAllTables(ctx) })
+
+	store := NewGroupWelcomeConfigStore(ctx.DB())
+	bg := context.Background()
+	now := time.Now().UTC()
+
+	_, found, err := store.Get(bg, "g_1")
+	require.NoError(t, err)
+	assert.False(t, found)
+
+	require.NoError(t, store.Upsert(bg, GroupWelcomeConfig{
+		GroupNo: "g_1", Enabled: true, ActiveFromRaw: "2026-07-10T00:00:00Z", Message: "欢迎 {member}", UpdatedBy: "admin",
+	}, now))
+
+	row, found, err := store.Get(bg, "g_1")
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.True(t, row.Enabled)
+	assert.Equal(t, "欢迎 {member}", row.Message)
+	assert.Equal(t, "admin", row.UpdatedBy)
+
+	// Update.
+	require.NoError(t, store.Upsert(bg, GroupWelcomeConfig{
+		GroupNo: "g_1", Enabled: false, ActiveFromRaw: "", Message: "updated", UpdatedBy: "admin2",
+	}, now.Add(time.Minute)))
+	row, _, err = store.Get(bg, "g_1")
+	require.NoError(t, err)
+	assert.False(t, row.Enabled)
+	assert.Equal(t, "updated", row.Message)
+
+	// ListEnabled returns only enabled rows.
+	require.NoError(t, store.Upsert(bg, GroupWelcomeConfig{
+		GroupNo: "g_2", Enabled: true, ActiveFromRaw: "2026-07-11T00:00:00Z", Message: "hi2", UpdatedBy: "a",
+	}, now))
+	list, err := store.ListEnabled(bg)
+	require.NoError(t, err)
+	got := map[string]bool{}
+	for _, c := range list {
+		got[c.GroupNo] = true
+	}
+	assert.True(t, got["g_2"], "enabled g_2 listed")
+	assert.False(t, got["g_1"], "disabled g_1 not listed")
+
+	// Delete is idempotent.
+	deleted, err := store.Delete(bg, "g_1")
+	require.NoError(t, err)
+	assert.True(t, deleted)
+	deleted, err = store.Delete(bg, "g_1")
+	require.NoError(t, err)
+	assert.False(t, deleted)
+}
+
+// TestGroupWelcomeConfigStore_UpsertMerged_NoLostUpdate: two admins patch DIFFERENT
+// fields of the same existing group config at once; the row lock serializes them
+// so BOTH patches survive.
+func TestGroupWelcomeConfigStore_UpsertMerged_NoLostUpdate(t *testing.T) {
+	_, ctx := testutil.NewTestServer()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+	t.Cleanup(func() { _ = testutil.CleanAllTables(ctx) })
+
+	store := NewGroupWelcomeConfigStore(ctx.DB())
+	bg := context.Background()
+	require.NoError(t, store.Upsert(bg, GroupWelcomeConfig{
+		GroupNo: "g_race", Enabled: true, ActiveFromRaw: "2026-07-10T00:00:00Z", Message: "orig", UpdatedBy: "seed",
+	}, time.Now().UTC()))
+
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		<-start
+		_, err := store.UpsertMerged(bg, "g_race", time.Now().UTC(),
+			func(cur *GroupWelcomeConfig, found bool) (GroupWelcomeConfig, error) {
+				next := GroupWelcomeConfig{GroupNo: "g_race"}
+				if cur != nil {
+					next = *cur
+				}
+				next.Message = "msg-A"
+				return next, nil
+			})
+		assert.NoError(t, err)
+	}()
+	go func() {
+		defer wg.Done()
+		<-start
+		_, err := store.UpsertMerged(bg, "g_race", time.Now().UTC(),
+			func(cur *GroupWelcomeConfig, found bool) (GroupWelcomeConfig, error) {
+				next := GroupWelcomeConfig{GroupNo: "g_race"}
+				if cur != nil {
+					next = *cur
+				}
+				next.Enabled = false
+				return next, nil
+			})
+		assert.NoError(t, err)
+	}()
+	close(start)
+	wg.Wait()
+
+	row, found, err := store.Get(bg, "g_race")
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Equal(t, "msg-A", row.Message, "admin A's message must not be lost")
+	assert.False(t, row.Enabled, "admin B's disable must not be lost")
+}
+
+// TestGroupWelcomeConfigStore_UpsertMerged_ConcurrentCreate: two admins issue the
+// FIRST PUT for the same absent config at once; insert-then-lock serializes them
+// so both disjoint fields survive with exactly one row and no error.
+func TestGroupWelcomeConfigStore_UpsertMerged_ConcurrentCreate(t *testing.T) {
+	_, ctx := testutil.NewTestServer()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+	t.Cleanup(func() { _ = testutil.CleanAllTables(ctx) })
+
+	store := NewGroupWelcomeConfigStore(ctx.DB())
+	bg := context.Background()
+
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		<-start
+		_, err := store.UpsertMerged(bg, "g_new", time.Now().UTC(),
+			func(cur *GroupWelcomeConfig, found bool) (GroupWelcomeConfig, error) {
+				next := GroupWelcomeConfig{GroupNo: "g_new"}
+				if cur != nil {
+					next = *cur
+				}
+				next.Message = "msg-A"
+				return next, nil
+			})
+		assert.NoError(t, err)
+	}()
+	go func() {
+		defer wg.Done()
+		<-start
+		_, err := store.UpsertMerged(bg, "g_new", time.Now().UTC(),
+			func(cur *GroupWelcomeConfig, found bool) (GroupWelcomeConfig, error) {
+				next := GroupWelcomeConfig{GroupNo: "g_new"}
+				if cur != nil {
+					next = *cur
+				}
+				next.Enabled = true
+				return next, nil
+			})
+		assert.NoError(t, err)
+	}()
+	close(start)
+	wg.Wait()
+
+	row, found, err := store.Get(bg, "g_new")
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Equal(t, "msg-A", row.Message, "message not lost on concurrent create")
+	assert.True(t, row.Enabled, "enable not lost on concurrent create")
+}

--- a/modules/common/group_welcome_config_store_test.go
+++ b/modules/common/group_welcome_config_store_test.go
@@ -11,6 +11,21 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestGroupWelcomeEnabled_DefaultOff: the platform master switch defaults OFF
+// (dark launch) when onboarding.group_welcome_enabled is absent — flipping the
+// getBool fallback to true would be a dark-launch regression this pins.
+func TestGroupWelcomeEnabled_DefaultOff(t *testing.T) {
+	_, ctx := testutil.NewTestServer()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+	settings := EnsureSystemSettings(ctx)
+	// Guarantee the key is absent regardless of CleanAllTables coverage.
+	_, err := ctx.DB().DeleteBySql(
+		"DELETE FROM system_setting WHERE category='onboarding' AND key_name='group_welcome_enabled'").Exec()
+	require.NoError(t, err)
+	require.NoError(t, settings.Reload())
+	assert.False(t, settings.GroupWelcomeEnabled(), "master switch defaults OFF when the key is absent")
+}
+
 // TestValidateGroupWelcomeCombination pins the pure validator (no DB).
 func TestValidateGroupWelcomeCombination(t *testing.T) {
 	af := time.Now().UTC().Format(time.RFC3339)

--- a/modules/common/space_welcome_config_store.go
+++ b/modules/common/space_welcome_config_store.go
@@ -125,9 +125,15 @@ func (s *SpaceWelcomeConfigStore) Exists(ctx context.Context, spaceID string) (b
 	return n > 0, nil
 }
 
-// Upsert inserts or updates the per-Space config. An empty ActiveFromRaw is
-// stored as the empty string ("" = unset). now is the application-computed UTC
-// value written to created_at (on insert) and updated_at (both).
+// Upsert inserts or updates the per-Space config in a single statement. An empty
+// ActiveFromRaw is stored as the empty string ("" = unset). now is the
+// application-computed UTC value written to created_at (on insert) and updated_at
+// (both).
+//
+// NOTE: this is a simple idempotent write for single-writer / test contexts.
+// Production admin CRUD MUST use UpsertMerged, which serializes concurrent PUTs
+// (insert-then-lock + deadlock retry) to prevent lost partial updates when two
+// admins edit the same Space at once; Upsert has no such protection.
 func (s *SpaceWelcomeConfigStore) Upsert(ctx context.Context, cfg SpaceWelcomeSpaceConfig, now time.Time) error {
 	enabled := 0
 	if cfg.Enabled {

--- a/modules/common/sql/20260723000001_add_octo_group_welcome_config.sql
+++ b/modules/common/sql/20260723000001_add_octo_group_welcome_config.sql
@@ -1,0 +1,27 @@
+-- +migrate Up
+
+-- Per-group 入群欢迎语配置（task group-welcome-message）。
+-- 每群至多一行；群主/管理员(role∈{creator,manager})经 /v1/group/:group_no/welcome
+-- 自助增删改。与 Space 版不同：本表【没有】平台级全局兜底 —— 一个 group 有该行且
+-- enabled 才有欢迎语，无行或未启用即关闭。
+-- 时间纪律：active_from 存 RFC3339 UTC 字符串（复用 ParsedActiveFrom /
+-- ValidateGroupWelcomeCombination）；created_at/updated_at 为应用侧写入的 UTC 值
+-- （time.Now().UTC() bound 参数），禁用 NOW()（DB 会话时区未在 DSN 固定），因此不设
+-- DEFAULT CURRENT_TIMESTAMP。
+-- COLLATE 显式对齐 group.group_no（legacy 群表用 DB 默认 utf8mb4_general_ci），避免
+-- 与 group / group_member 对账 JOIN 触发 MySQL 1267。
+CREATE TABLE `octo_group_welcome_config` (
+  `id`          BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+  `group_no`    VARCHAR(40)   NOT NULL DEFAULT ''  COMMENT '目标群（长度/字符集/COLLATE 对齐 group.group_no）',
+  `enabled`     TINYINT       NOT NULL DEFAULT 0   COMMENT '0=关闭 1=开启；开启需 active_from/message 构成有效组合',
+  `active_from` VARCHAR(40)   NOT NULL DEFAULT ''  COMMENT 'RFC3339 UTC 字符串（空=未设置）；仅 created_at>=此刻首次入群的成员会收到',
+  `message`     VARCHAR(2000) NOT NULL DEFAULT ''  COMMENT '欢迎语纯文本（trim 后非空，<=2000 code points；支持 {member} 占位符点名新成员；不渲染 markdown）',
+  `updated_by`  VARCHAR(40)   NOT NULL DEFAULT ''  COMMENT '最近修改的管理员 uid（审计）',
+  `created_at`  DATETIME      NOT NULL             COMMENT 'UTC；应用侧写入，禁 NOW()',
+  `updated_at`  DATETIME      NOT NULL             COMMENT 'UTC；应用侧写入，禁 NOW()',
+  UNIQUE KEY `uk_group` (`group_no`),
+  KEY `idx_enabled` (`enabled`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci COMMENT='per-group onboarding welcome config';
+
+-- +migrate Down
+DROP TABLE IF EXISTS `octo_group_welcome_config`;

--- a/modules/common/sql/20260723000001_add_octo_group_welcome_config.sql
+++ b/modules/common/sql/20260723000001_add_octo_group_welcome_config.sql
@@ -1,7 +1,7 @@
 -- +migrate Up
 
 -- Per-group 入群欢迎语配置（task group-welcome-message）。
--- 每群至多一行；群主/管理员(role∈{creator,manager})经 /v1/group/:group_no/welcome
+-- 每群至多一行；群主/管理员(role∈{creator,manager})经 /v1/groups/:group_no/welcome
 -- 自助增删改。与 Space 版不同：本表【没有】平台级全局兜底 —— 一个 group 有该行且
 -- enabled 才有欢迎语，无行或未启用即关闭。
 -- 时间纪律：active_from 存 RFC3339 UTC 字符串（复用 ParsedActiveFrom /

--- a/modules/common/system_setting_schema.go
+++ b/modules/common/system_setting_schema.go
@@ -232,6 +232,15 @@ var systemSettingSchema = []settingDef{
 	{Category: "onboarding", Key: "space_welcome_message", Type: settingTypeString, Description: "欢迎语文案（纯文本，所有人同一份，trim 后非空，≤2000 字符；支持换行 \\n，不渲染 markdown）",
 		Effective: func(s *SystemSettings) string { return s.SpaceWelcomeConfig().Message }},
 
+	// Group 入群欢迎语总开关（onboarding.group_welcome_enabled）— task
+	// group-welcome-message。平台级 dark-launch 开关：默认关闭；开启后，各群由群主/
+	// 管理员在 /v1/groups/:group_no/welcome 自助配置的欢迎语，才会在成员首次入群时被
+	// 公开发到群频道。回落 false 即为即时 kill（事件停写 + worker 停发，随快照多实例
+	// 收敛），且不触及任何 per-group 配置行。与 space_welcome_* 不同：此开关仅管「启用」，
+	// 没有平台级文案兜底（群文案恒来自各群自己的行）。是「总开关 AND 每群 enabled」的外层。
+	{Category: "onboarding", Key: "group_welcome_enabled", Type: settingTypeBool, Description: "是否开启「群入群欢迎语」总功能（默认关闭；开启后各群由群主/管理员自助配置的欢迎语才会在成员首次入群时公开发到群频道；关闭=即时停发，不影响各群已保存的配置）",
+		Effective: func(s *SystemSettings) string { return boolToCanonical(s.GroupWelcomeEnabled()) }},
+
 	// Email server config — formerly yaml-only (Support.* in config.go).
 	{Category: "support", Key: "email", Type: settingTypeString, Description: "技术支持邮箱（发件人）",
 		Effective: func(s *SystemSettings) string { return s.SupportEmail() }},

--- a/modules/common/system_settings.go
+++ b/modules/common/system_settings.go
@@ -573,9 +573,9 @@ func (s *SystemSettings) SupportEmailPwd() string {
 // systemSettingSchema 的 incomingwebhook 行；reciprocal sync 注释见
 // modules/incomingwebhook/api.go 的 New / allowPerWebhook / create。
 const (
-	envIncomingWebhookEnabled         = "DM_INCOMINGWEBHOOK_ENABLED"
-	envIncomingWebhookPerWebhookRPS   = "DM_INCOMINGWEBHOOK_RPS"
-	envIncomingWebhookPerWebhookBurst = "DM_INCOMINGWEBHOOK_BURST"
+	envIncomingWebhookEnabled          = "DM_INCOMINGWEBHOOK_ENABLED"
+	envIncomingWebhookPerWebhookRPS    = "DM_INCOMINGWEBHOOK_RPS"
+	envIncomingWebhookPerWebhookBurst  = "DM_INCOMINGWEBHOOK_BURST"
 	envIncomingWebhookMaxPerGroup      = "DM_INCOMINGWEBHOOK_MAX_PER_GROUP"
 	envIncomingWebhookMaxPerThread     = "DM_INCOMINGWEBHOOK_MAX_PER_THREAD"
 	envIncomingWebhookMaxPerCreator    = "DM_INCOMINGWEBHOOK_MAX_PER_CREATOR"
@@ -643,7 +643,7 @@ func (s *SystemSettings) IncomingWebhookPerWebhookBurst() int {
 	return v
 }
 
-// IncomingWebhookMaxPerGroup 群本体作用域（thread_short_id='')可创建的 webhook 数量上限。
+// IncomingWebhookMaxPerGroup 群本体作用域（thread_short_id=”)可创建的 webhook 数量上限。
 // 子区作用域另用 IncomingWebhookMaxPerThread（未配置时回退到本值），两者独立计数、不共享
 // 名额。DB → env → 默认 10。
 // 读侧防御：≤0 回退默认（max_per_group=0 会让每次 create 都 ErrQuotaExceeded，是
@@ -1219,4 +1219,25 @@ func ValidateSpaceWelcomeCombination(cfg SpaceWelcomeConfig, isActiveSpace func(
 		}
 	}
 	return "", nil
+}
+
+// ---------------------------------------------------------------------------
+// Group new-member welcome master switch (onboarding.group_welcome_enabled) —
+// task group-welcome-message
+// ---------------------------------------------------------------------------
+
+// GroupWelcomeEnabled is the platform master switch for the group new-member
+// welcome (群入群欢迎语). Default false (dark launch): the feature ships off, and an
+// operator flips onboarding.group_welcome_enabled to turn it on across every
+// group. Flipping it back is an instant kill switch — the event path stops
+// enqueuing and the send worker stops posting within the snapshot TTL — without
+// touching any per-group config row. Read from the SAME snapshot as every other
+// setting, so it hot-reloads and converges across replicas within reloadTTL.
+//
+// Unlike the Space welcome's onboarding keys this is enablement ONLY: there is no
+// platform-global content fallback, so a group's body always comes from its own
+// row (see brief: no global fallback). The per-group config.Enabled still gates
+// each group individually; this switch is the outer AND.
+func (s *SystemSettings) GroupWelcomeEnabled() bool {
+	return s.getBool(spaceWelcomeCategory, "group_welcome_enabled", false)
 }

--- a/modules/group/api.go
+++ b/modules/group/api.go
@@ -53,6 +53,8 @@ type Group struct {
 	groupService  IService
 	fileService   file.IService
 	commonService common2.IService
+	// welcomeStore backs the per-group 入群欢迎语 CRUD (task group-welcome-message).
+	welcomeStore *common2.GroupWelcomeConfigStore
 }
 
 // New New
@@ -67,6 +69,7 @@ func New(ctx *config.Context) *Group {
 		groupService:  NewService(ctx),
 		fileService:   file.NewService(ctx),
 		commonService: common2.NewService(ctx),
+		welcomeStore:  common2.NewGroupWelcomeConfigStore(ctx.DB()),
 	}
 	g.ctx.AddEventListener(event.GroupDisband, g.handleGroupDisbandEvent)
 	g.ctx.AddEventListener(event.EventUserRegister, g.handleRegisterUserEvent)
@@ -124,6 +127,14 @@ func (g *Group) Route(r *wkhttp.WKHttp) {
 	authGroups := r.Group("/v1/groups", g.ctx.AuthMiddleware(r))
 	{
 		authGroups.GET("/:group_no/scanjoin", g.groupScanJoin) // 扫码加入群（需要认证）
+	}
+	// 群入群欢迎语 CRUD（群主/管理员自助，task group-welcome-message）。挂 auth +
+	// SharedUIDRateLimiter：认证路由默认按登录用户公平限流（与 /v1/message 等一致）。
+	welcomeGroups := r.Group("/v1/groups", g.ctx.AuthMiddleware(r), appwkhttp.SharedUIDRateLimiter(r, g.ctx))
+	{
+		welcomeGroups.GET("/:group_no/welcome", g.getWelcome)
+		welcomeGroups.PUT("/:group_no/welcome", g.putWelcome)
+		welcomeGroups.DELETE("/:group_no/welcome", g.deleteWelcome)
 	}
 	// H5 公开落地页配套的认证接口：把公开 code（二维码 UUID）换成当前登录用户的 auth_code。
 	// 之后前端直接调用 /v1/groups/:group_no/scanjoin?auth_code=xxx 完成入群。

--- a/modules/group/api_i18n_test.go
+++ b/modules/group/api_i18n_test.go
@@ -28,7 +28,7 @@ func httperrL(c *wkhttp.Context, code codes.Code) {
 // guard. The c.ResponseError(common.ErrData.Error(), ...) zap LOG calls are not
 // responses and are intentionally allowed (they match neither banned token).
 func TestGroupNoLegacyResponseError(t *testing.T) {
-	files := []string{"api.go", "api_manager.go", "invite.go"}
+	files := []string{"api.go", "api_manager.go", "invite.go", "api_welcome.go"}
 	banned := []string{".ResponseError(", ".ResponseErrorf(", ".ResponseErrorWithStatus(", "c.Response(\""}
 	for _, f := range files {
 		t.Run(f, func(t *testing.T) {

--- a/modules/group/api_welcome.go
+++ b/modules/group/api_welcome.go
@@ -1,0 +1,229 @@
+package group
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	commonmod "github.com/Mininglamp-OSS/octo-server/modules/common"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
+	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
+	"go.uber.org/zap"
+)
+
+// Per-group 入群欢迎语 CRUD (task group-welcome-message). A group creator/manager
+// manages ONE welcome config for their own group:
+//
+//	GET    /v1/groups/:group_no/welcome  — read the config + what is in effect
+//	PUT    /v1/groups/:group_no/welcome  — create/update (增/改), prospective-validated
+//	DELETE /v1/groups/:group_no/welcome  — hard-delete (删); reverts to off
+//
+// Authorization: the group must be active (not disbanded) and the caller must be
+// creator/manager (role ∈ {creator, manager}); a request can only ever affect the
+// path :group_no (isolation). There is NO platform-global fallback (unlike the
+// per-Space welcome). All errors go through the httperr i18n envelope with
+// existing group error codes. Routes carry SharedUIDRateLimiter (see Route).
+
+// groupWelcomeConfigDBTimeout bounds each config DB call on the CRUD path.
+const groupWelcomeConfigDBTimeout = 3 * time.Second
+
+// errGroupWelcomeValidation is the sentinel a putWelcome merge closure returns
+// after it has already written a localized validation response; UpsertMerged
+// rolls the transaction back and putWelcome then just returns.
+var errGroupWelcomeValidation = errors.New("group welcome validation failed")
+
+// putGroupWelcomeReq is the PUT body. Pointer fields distinguish "omitted" (keep
+// the current value) from an explicit value, so a partial update is a valid patch
+// merged onto the existing row (prospective validation).
+type putGroupWelcomeReq struct {
+	Enabled    *bool   `json:"enabled"`
+	ActiveFrom *string `json:"active_from"` // RFC3339 UTC
+	Message    *string `json:"message"`
+}
+
+// groupWelcomeEffectiveResp describes the config actually in effect for the group
+// (per-group row iff present AND enabled; no global fallback).
+type groupWelcomeEffectiveResp struct {
+	Enabled    bool   `json:"enabled"`
+	Source     string `json:"source"`      // group | none
+	ActiveFrom string `json:"active_from"` // effective RFC3339 window start ("" when off)
+	Message    string `json:"message"`
+}
+
+// groupWelcomeConfigResp is the GET/PUT response.
+type groupWelcomeConfigResp struct {
+	Configured bool                      `json:"configured"` // a per-group row exists
+	Enabled    bool                      `json:"enabled"`
+	ActiveFrom string                    `json:"active_from"`
+	Message    string                    `json:"message"`
+	UpdatedBy  string                    `json:"updated_by,omitempty"`
+	UpdatedAt  string                    `json:"updated_at,omitempty"`
+	Effective  groupWelcomeEffectiveResp `json:"effective"`
+}
+
+// authorizeGroupWelcomeAdmin gates a per-group welcome request: the group must be
+// active (not disbanded) and the caller must be creator/manager. Reuses
+// getGroupInfo (active check) + QueryIsGroupManagerOrCreator (admin check). A
+// request can only ever affect the path :group_no, so isolation holds by
+// construction. Returns the caller uid and ok=false when a response was written.
+func (g *Group) authorizeGroupWelcomeAdmin(c *wkhttp.Context, groupNo string) (loginUID string, ok bool) {
+	loginUID = c.GetLoginUID()
+	if _, err := g.getGroupInfo(groupNo); err != nil {
+		respondGroupInfoError(c, err)
+		return "", false
+	}
+	isAdmin, err := g.db.QueryIsGroupManagerOrCreator(groupNo, loginUID)
+	if err != nil {
+		g.Error("查询群管理员身份失败", zap.Error(err), zap.String("group_no", groupNo))
+		httperr.ResponseErrorL(c, errcode.ErrGroupQueryFailed, nil, nil)
+		return "", false
+	}
+	if !isAdmin {
+		// Anti-enumeration: a non-member and an under-privileged member both get
+		// the same creator/manager-only 403 (no privilege-reason leak).
+		httperr.ResponseErrorL(c, errcode.ErrGroupCreatorOrManagerOnly, nil, nil)
+		return "", false
+	}
+	return loginUID, true
+}
+
+// getWelcome returns the per-group config (if any) plus what is in effect.
+func (g *Group) getWelcome(c *wkhttp.Context) {
+	groupNo := c.Param("group_no")
+	if _, ok := g.authorizeGroupWelcomeAdmin(c, groupNo); !ok {
+		return
+	}
+	ctx, cancel := context.WithTimeout(c.Request.Context(), groupWelcomeConfigDBTimeout)
+	defer cancel()
+	row, found, err := g.welcomeStore.Get(ctx, groupNo)
+	if err != nil {
+		g.Error("查询群欢迎语配置失败", zap.Error(err), zap.String("group_no", groupNo))
+		httperr.ResponseErrorL(c, errcode.ErrGroupQueryFailed, nil, nil)
+		return
+	}
+	c.Response(buildGroupWelcomeResp(row, found))
+}
+
+// putWelcome upserts the per-group config. Partial updates merge onto the
+// existing row (prospective validation). Concurrent PUTs are serialized by the
+// store's insert-then-lock UpsertMerged.
+func (g *Group) putWelcome(c *wkhttp.Context) {
+	groupNo := c.Param("group_no")
+	loginUID, ok := g.authorizeGroupWelcomeAdmin(c, groupNo)
+	if !ok {
+		return
+	}
+
+	var req putGroupWelcomeReq
+	if err := c.BindJSON(&req); err != nil {
+		respondGroupRequestInvalid(c, "")
+		return
+	}
+	if req.Enabled == nil && req.ActiveFrom == nil && req.Message == nil {
+		respondGroupRequestInvalid(c, "")
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(c.Request.Context(), groupWelcomeConfigDBTimeout)
+	defer cancel()
+
+	// Read-merge-write under a row lock (see store.UpsertMerged) so two managers
+	// PUTting the same group concurrently can't lose each other's fields.
+	// Validation runs inside the merge and, on failure, writes the localized
+	// response and returns errGroupWelcomeValidation so the tx aborts (no write).
+	persisted, err := g.welcomeStore.UpsertMerged(ctx, groupNo, time.Now().UTC(),
+		func(cur *commonmod.GroupWelcomeConfig, found bool) (commonmod.GroupWelcomeConfig, error) {
+			prospective := commonmod.GroupWelcomeConfig{GroupNo: groupNo}
+			if found {
+				prospective = *cur
+			}
+			prospective.GroupNo = groupNo
+			if req.Enabled != nil {
+				prospective.Enabled = *req.Enabled
+			}
+			if req.ActiveFrom != nil {
+				prospective.ActiveFromRaw = strings.TrimSpace(*req.ActiveFrom)
+			}
+			if req.Message != nil {
+				// Preserve internal newlines verbatim (plain text, no markdown);
+				// only the combination validator trims for the non-empty check.
+				prospective.Message = *req.Message
+			}
+
+			// Column-width guards run regardless of enabled (clean 400, not a
+			// driver 500 / silent truncation).
+			if utf8.RuneCountInString(prospective.Message) > commonmod.GroupWelcomeMessageMaxRunes {
+				respondGroupRequestInvalid(c, "message")
+				return commonmod.GroupWelcomeConfig{}, errGroupWelcomeValidation
+			}
+			if utf8.RuneCountInString(prospective.ActiveFromRaw) > commonmod.GroupWelcomeActiveFromMaxLen {
+				respondGroupRequestInvalid(c, "active_from")
+				return commonmod.GroupWelcomeConfig{}, errGroupWelcomeValidation
+			}
+			if field := commonmod.ValidateGroupWelcomeCombination(prospective); field != "" {
+				respondGroupRequestInvalid(c, field)
+				return commonmod.GroupWelcomeConfig{}, errGroupWelcomeValidation
+			}
+
+			prospective.UpdatedBy = loginUID
+			return prospective, nil
+		})
+	if err != nil {
+		if errors.Is(err, errGroupWelcomeValidation) {
+			return // the merge already wrote the localized validation response
+		}
+		g.Error("写入群欢迎语配置失败", zap.Error(err), zap.String("group_no", groupNo))
+		httperr.ResponseErrorL(c, errcode.ErrGroupStoreFailed, nil, nil)
+		return
+	}
+	g.Info("群欢迎语配置已更新", zap.String("operator_uid", loginUID), zap.String("group_no", groupNo), zap.Bool("enabled", persisted.Enabled))
+	c.Response(buildGroupWelcomeResp(persisted, true))
+}
+
+// deleteWelcome hard-deletes the per-group config; the group then reverts to off
+// (no fallback). Idempotent: deleting an absent config returns deleted=false 200.
+func (g *Group) deleteWelcome(c *wkhttp.Context) {
+	groupNo := c.Param("group_no")
+	loginUID, ok := g.authorizeGroupWelcomeAdmin(c, groupNo)
+	if !ok {
+		return
+	}
+	ctx, cancel := context.WithTimeout(c.Request.Context(), groupWelcomeConfigDBTimeout)
+	defer cancel()
+	deleted, err := g.welcomeStore.Delete(ctx, groupNo)
+	if err != nil {
+		g.Error("删除群欢迎语配置失败", zap.Error(err), zap.String("group_no", groupNo))
+		httperr.ResponseErrorL(c, errcode.ErrGroupStoreFailed, nil, nil)
+		return
+	}
+	g.Info("群欢迎语配置已删除", zap.String("operator_uid", loginUID), zap.String("group_no", groupNo), zap.Bool("deleted", deleted))
+	c.Response(map[string]interface{}{"deleted": deleted})
+}
+
+// buildGroupWelcomeResp assembles the response from the per-group row (if any).
+// Without a global fallback, the effective config is the row iff enabled.
+func buildGroupWelcomeResp(row *commonmod.GroupWelcomeConfig, found bool) groupWelcomeConfigResp {
+	resp := groupWelcomeConfigResp{Configured: found}
+	eff := groupWelcomeEffectiveResp{Source: "none"}
+	if found && row != nil {
+		resp.Enabled = row.Enabled
+		resp.ActiveFrom = row.ActiveFromRaw
+		resp.Message = row.Message
+		resp.UpdatedBy = row.UpdatedBy
+		if !row.UpdatedAt.IsZero() {
+			// Stable RFC3339 (UTC); updated_at is a second-precision DATETIME.
+			resp.UpdatedAt = row.UpdatedAt.UTC().Format(time.RFC3339)
+		}
+		if row.Enabled {
+			eff.Enabled = true
+			eff.Source = "group"
+			eff.ActiveFrom = row.ActiveFromRaw
+			eff.Message = row.Message
+		}
+	}
+	resp.Effective = eff
+	return resp
+}

--- a/modules/group/api_welcome.go
+++ b/modules/group/api_welcome.go
@@ -71,8 +71,17 @@ type groupWelcomeConfigResp struct {
 // construction. Returns the caller uid and ok=false when a response was written.
 func (g *Group) authorizeGroupWelcomeAdmin(c *wkhttp.Context, groupNo string) (loginUID string, ok bool) {
 	loginUID = c.GetLoginUID()
-	if _, err := g.getGroupInfo(groupNo); err != nil {
+	group, err := g.getGroupInfo(groupNo)
+	if err != nil {
 		respondGroupInfoError(c, err)
+		return "", false
+	}
+	// Require a Normal group (parity with the space welcome's checkSpaceActive):
+	// getGroupInfo already rejects Disband(2); also reject Disabled(0) so an
+	// admin-disabled group's welcome config cannot be read/written. Same
+	// not-found response as a disbanded group (no status-reason leak).
+	if group.Status != GroupStatusNormal {
+		respondGroupInfoError(c, errGroupInfoNotFound)
 		return "", false
 	}
 	isAdmin, err := g.db.QueryIsGroupManagerOrCreator(groupNo, loginUID)

--- a/modules/group/api_welcome_test.go
+++ b/modules/group/api_welcome_test.go
@@ -1,0 +1,227 @@
+package group
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
+	"github.com/Mininglamp-OSS/octo-lib/server"
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	"github.com/go-redis/redis"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Per-group 入群欢迎语 CRUD HTTP tests (task group-welcome-message). Auth is fixed
+// to testutil.UID via testutil.Token; the authz matrix is exercised by varying
+// that user's group role and the group status.
+
+func setupGroupWelcome(t *testing.T) (*Group, *server.Server) {
+	t.Helper()
+	s, ctx := newTestServer(t)
+	// module.Setup inside NewTestServer already mounts the group routes (incl.
+	// /welcome); construct a local Group only for the DB seed helpers. Calling
+	// f.Route again would double-register and panic.
+	f := New(ctx)
+	require.NoError(t, testutil.CleanAllTables(ctx))
+	wireI18nRendererForGroupTest(s)
+	return f, s
+}
+
+// resetGroupUIDRateLimit clears the per-UID SharedUIDRateLimiter bucket, which
+// persists in Redis and is NOT cleared by CleanAllTables.
+func resetGroupUIDRateLimit(t *testing.T, ctx *config.Context) {
+	t.Helper()
+	rds := redis.NewClient(&redis.Options{Addr: ctx.GetConfig().DB.RedisAddr, Password: ctx.GetConfig().DB.RedisPass})
+	defer rds.Close()
+	if keys, err := rds.Keys("ratelimit:uid:*").Result(); err == nil && len(keys) > 0 {
+		_ = rds.Del(keys...).Err()
+	}
+}
+
+// gwSeedGroup inserts a group (status) with testutil.UID as a member at callerRole
+// (MemberRoleCommon/Creator/Manager). Creator field is a different uid so the role
+// gate (not the creator field) is what's exercised.
+func gwSeedGroup(t *testing.T, f *Group, groupNo string, callerRole, status int) {
+	t.Helper()
+	require.NoError(t, f.db.Insert(&Model{GroupNo: groupNo, Name: groupNo, Creator: "creator_other", Status: status, Version: 1}))
+	require.NoError(t, f.db.InsertMember(&MemberModel{
+		GroupNo: groupNo, UID: testutil.UID, Role: callerRole, Status: 1, Version: 1, Vercode: util.GenerUUID(),
+	}))
+}
+
+func doGroupWelcome(t *testing.T, f *Group, s *server.Server, method, groupNo, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	resetGroupUIDRateLimit(t, f.ctx)
+	var r *strings.Reader
+	if body != "" {
+		r = strings.NewReader(body)
+	} else {
+		r = strings.NewReader("")
+	}
+	req, _ := http.NewRequest(method, "/v1/groups/"+groupNo+"/welcome", r)
+	req.Header.Set("token", testutil.Token)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	s.GetRoute().ServeHTTP(w, req)
+	return w
+}
+
+type gwWelcomeResp struct {
+	Configured bool   `json:"configured"`
+	Enabled    bool   `json:"enabled"`
+	ActiveFrom string `json:"active_from"`
+	Message    string `json:"message"`
+	Effective  struct {
+		Enabled    bool   `json:"enabled"`
+		Source     string `json:"source"`
+		ActiveFrom string `json:"active_from"`
+		Message    string `json:"message"`
+	} `json:"effective"`
+}
+
+func gwDecode(t *testing.T, w *httptest.ResponseRecorder) gwWelcomeResp {
+	t.Helper()
+	var resp gwWelcomeResp
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp), w.Body.String())
+	return resp
+}
+
+func gwAssertErrCode(t *testing.T, w *httptest.ResponseRecorder, want string) {
+	t.Helper()
+	var env struct {
+		Error struct {
+			Code string `json:"code"`
+		} `json:"error"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &env), w.Body.String())
+	assert.Equal(t, want, env.Error.Code, w.Body.String())
+}
+
+func TestGroupWelcomeCRUD_AuthzMatrix(t *testing.T) {
+	t.Run("creator can read", func(t *testing.T) {
+		f, s := setupGroupWelcome(t)
+		gwSeedGroup(t, f, "g_creator", MemberRoleCreator, GroupStatusNormal)
+		w := doGroupWelcome(t, f, s, http.MethodGet, "g_creator", "")
+		require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+		resp := gwDecode(t, w)
+		assert.False(t, resp.Configured)
+		assert.Equal(t, "none", resp.Effective.Source)
+	})
+
+	t.Run("manager can read", func(t *testing.T) {
+		f, s := setupGroupWelcome(t)
+		gwSeedGroup(t, f, "g_manager", MemberRoleManager, GroupStatusNormal)
+		w := doGroupWelcome(t, f, s, http.MethodGet, "g_manager", "")
+		require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	})
+
+	t.Run("plain member is denied", func(t *testing.T) {
+		f, s := setupGroupWelcome(t)
+		gwSeedGroup(t, f, "g_member", MemberRoleCommon, GroupStatusNormal)
+		w := doGroupWelcome(t, f, s, http.MethodGet, "g_member", "")
+		gwAssertErrCode(t, w, "err.server.group.creator_or_manager_only")
+	})
+
+	t.Run("non-member is denied", func(t *testing.T) {
+		f, s := setupGroupWelcome(t)
+		require.NoError(t, f.db.Insert(&Model{GroupNo: "g_nomember", Name: "g_nomember", Creator: "someone", Status: GroupStatusNormal, Version: 1}))
+		w := doGroupWelcome(t, f, s, http.MethodGet, "g_nomember", "")
+		gwAssertErrCode(t, w, "err.server.group.creator_or_manager_only")
+	})
+
+	t.Run("disbanded group is not found", func(t *testing.T) {
+		f, s := setupGroupWelcome(t)
+		gwSeedGroup(t, f, "g_dead", MemberRoleCreator, GroupStatusDisband)
+		w := doGroupWelcome(t, f, s, http.MethodGet, "g_dead", "")
+		gwAssertErrCode(t, w, "err.server.group.not_found")
+	})
+}
+
+func TestGroupWelcomePut_CreateThenGet(t *testing.T) {
+	f, s := setupGroupWelcome(t)
+	gwSeedGroup(t, f, "g_1", MemberRoleCreator, GroupStatusNormal)
+
+	body := `{"enabled":true,"active_from":"2026-07-10T00:00:00Z","message":"欢迎 {member} 入群"}`
+	w := doGroupWelcome(t, f, s, http.MethodPut, "g_1", body)
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	resp := gwDecode(t, w)
+	assert.True(t, resp.Configured)
+	assert.True(t, resp.Enabled)
+	assert.Equal(t, "欢迎 {member} 入群", resp.Message, "placeholder stored raw (rendered at send time)")
+	assert.Equal(t, "group", resp.Effective.Source)
+	assert.Equal(t, "欢迎 {member} 入群", resp.Effective.Message)
+
+	g := gwDecode(t, doGroupWelcome(t, f, s, http.MethodGet, "g_1", ""))
+	assert.True(t, g.Configured)
+	assert.True(t, g.Enabled)
+	assert.Equal(t, "欢迎 {member} 入群", g.Message)
+}
+
+func TestGroupWelcomePut_InvalidCombinationRejected(t *testing.T) {
+	f, s := setupGroupWelcome(t)
+	gwSeedGroup(t, f, "g_1", MemberRoleManager, GroupStatusNormal)
+
+	w := doGroupWelcome(t, f, s, http.MethodPut, "g_1", `{"enabled":true,"active_from":"2026-07-10T00:00:00Z","message":"   "}`)
+	gwAssertErrCode(t, w, "err.server.group.request_invalid")
+
+	w = doGroupWelcome(t, f, s, http.MethodPut, "g_1", `{"enabled":true,"active_from":"not-a-time","message":"hi"}`)
+	gwAssertErrCode(t, w, "err.server.group.request_invalid")
+}
+
+func TestGroupWelcomePut_MessageTooLong(t *testing.T) {
+	f, s := setupGroupWelcome(t)
+	gwSeedGroup(t, f, "g_1", MemberRoleCreator, GroupStatusNormal)
+	long := strings.Repeat("我", 2001)
+	w := doGroupWelcome(t, f, s, http.MethodPut, "g_1", `{"enabled":false,"message":"`+long+`"}`)
+	gwAssertErrCode(t, w, "err.server.group.request_invalid")
+}
+
+func TestGroupWelcomePut_EmptyPatchRejected(t *testing.T) {
+	f, s := setupGroupWelcome(t)
+	gwSeedGroup(t, f, "g_1", MemberRoleCreator, GroupStatusNormal)
+	w := doGroupWelcome(t, f, s, http.MethodPut, "g_1", `{}`)
+	gwAssertErrCode(t, w, "err.server.group.request_invalid")
+}
+
+func TestGroupWelcomePut_PartialMergePreservesMessage(t *testing.T) {
+	f, s := setupGroupWelcome(t)
+	gwSeedGroup(t, f, "g_1", MemberRoleCreator, GroupStatusNormal)
+	require.Equal(t, http.StatusOK,
+		doGroupWelcome(t, f, s, http.MethodPut, "g_1", `{"enabled":true,"active_from":"2026-07-10T00:00:00Z","message":"keep {member}"}`).Code)
+
+	w := doGroupWelcome(t, f, s, http.MethodPut, "g_1", `{"enabled":false}`)
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	resp := gwDecode(t, w)
+	assert.False(t, resp.Enabled)
+	assert.Equal(t, "keep {member}", resp.Message, "partial patch keeps the existing message")
+	assert.Equal(t, "none", resp.Effective.Source, "disabled -> nothing in effect")
+}
+
+func TestGroupWelcomeDelete_RevertsToOff(t *testing.T) {
+	f, s := setupGroupWelcome(t)
+	gwSeedGroup(t, f, "g_1", MemberRoleCreator, GroupStatusNormal)
+	require.Equal(t, http.StatusOK,
+		doGroupWelcome(t, f, s, http.MethodPut, "g_1", `{"enabled":true,"active_from":"2026-07-10T00:00:00Z","message":"bye {member}"}`).Code)
+
+	w := doGroupWelcome(t, f, s, http.MethodDelete, "g_1", "")
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	var del struct {
+		Deleted bool `json:"deleted"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &del), w.Body.String())
+	assert.True(t, del.Deleted)
+
+	g := gwDecode(t, doGroupWelcome(t, f, s, http.MethodGet, "g_1", ""))
+	assert.False(t, g.Configured)
+	assert.Equal(t, "none", g.Effective.Source)
+
+	w = doGroupWelcome(t, f, s, http.MethodDelete, "g_1", "")
+	require.Equal(t, http.StatusOK, w.Code)
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &del), w.Body.String())
+	assert.False(t, del.Deleted)
+}

--- a/modules/group/api_welcome_test.go
+++ b/modules/group/api_welcome_test.go
@@ -140,6 +140,15 @@ func TestGroupWelcomeCRUD_AuthzMatrix(t *testing.T) {
 		w := doGroupWelcome(t, f, s, http.MethodGet, "g_dead", "")
 		gwAssertErrCode(t, w, "err.server.group.not_found")
 	})
+
+	t.Run("disabled group is not found", func(t *testing.T) {
+		// Parity with the space welcome's checkSpaceActive: an admin-disabled
+		// (non-Normal) group must reject welcome CRUD, not just a disbanded one.
+		f, s := setupGroupWelcome(t)
+		gwSeedGroup(t, f, "g_disabled", MemberRoleCreator, GroupStatusDisabled)
+		w := doGroupWelcome(t, f, s, http.MethodGet, "g_disabled", "")
+		gwAssertErrCode(t, w, "err.server.group.not_found")
+	})
 }
 
 func TestGroupWelcomePut_CreateThenGet(t *testing.T) {

--- a/modules/notify/api.go
+++ b/modules/notify/api.go
@@ -77,6 +77,7 @@ type Notify struct {
 	internalToken string
 	docsToken     string
 	spaceWelcome  *spaceWelcomeService
+	groupWelcome  *groupWelcomeService
 	log.Log
 }
 
@@ -144,11 +145,27 @@ func New(ctx *config.Context) *Notify {
 
 	// 监听成员加入事件
 	ctx.AddEventListener(event.SpaceMemberJoin, n.handleSpaceMemberEvent)
+	// 监听群成员加入事件（群入群欢迎语 task group-welcome-message）。GroupMemberAdd
+	// 是多监听者事件（message/group 模块也监听），fan-out 到所有 AddEventListener。
+	ctx.AddEventListener(event.GroupMemberAdd, n.handleGroupMemberAddEvent)
 
 	// Space 新成员欢迎语（task space-new-user-welcome-message）。欢迎语是所有人
 	// 同一份纯文本（不区分语言）。服务对象在此构造，reconciler/worker goroutine
 	// 由模块 Start() 启动、Stop() 停止。
 	n.spaceWelcome = newSpaceWelcomeService(
+		ctx,
+		common.EnsureSystemSettings(ctx),
+		NotifyBotUID(),
+		func() bool {
+			n.ensureNotifyBotReady()
+			return n.botOK.Load()
+		},
+	)
+
+	// 群入群欢迎语（task group-welcome-message）：每群一条、群主/管理员自助，首次入群
+	// 时把管理员配置的欢迎语（支持 {member} 点名）公开发到群频道。复用同一个
+	// notification 发送身份；reconciler/worker 由模块 Start()/Stop() 管理。
+	n.groupWelcome = newGroupWelcomeService(
 		ctx,
 		common.EnsureSystemSettings(ctx),
 		NotifyBotUID(),
@@ -233,6 +250,27 @@ func (n *Notify) handleSpaceMemberEvent(data []byte, commit config.EventCommit) 
 	commit(nil)
 }
 
+// handleGroupMemberAddEvent 群成员加入时，为命中欢迎语配置的首次入群 human 成员各写
+// 一条 pending 行（群入群欢迎语 task group-welcome-message）。入队失败只记日志、绝不
+// 阻塞（reconciler 兜底）。GroupMemberAdd 是多监听者事件，commit(nil) 与既有 space
+// 处理保持一致。
+func (n *Notify) handleGroupMemberAddEvent(data []byte, commit config.EventCommit) {
+	var req config.MsgGroupMemberAddReq
+	if err := util.ReadJsonByByte(data, &req); err != nil {
+		n.Warn("解析GroupMemberAdd事件失败", zap.Error(err))
+		commit(nil)
+		return
+	}
+	if n.groupWelcome != nil && req.GroupNo != "" {
+		for _, m := range req.Members {
+			if m != nil && m.UID != "" {
+				n.groupWelcome.handleMemberJoin(req.GroupNo, m.UID)
+			}
+		}
+	}
+	commit(nil)
+}
+
 // Start 启动欢迎语的对账 + 发送 worker goroutine（模块生命周期钩子）。
 func (n *Notify) Start() error {
 	// 通知 Bot 的 provisioning 放在 Start()（而非 New()）：New() 现在于
@@ -253,6 +291,9 @@ func (n *Notify) Start() error {
 	if n.spaceWelcome != nil {
 		n.spaceWelcome.Start()
 	}
+	if n.groupWelcome != nil {
+		n.groupWelcome.Start()
+	}
 	return nil
 }
 
@@ -260,6 +301,9 @@ func (n *Notify) Start() error {
 func (n *Notify) Stop() error {
 	if n.spaceWelcome != nil {
 		n.spaceWelcome.Stop()
+	}
+	if n.groupWelcome != nil {
+		n.groupWelcome.Stop()
 	}
 	return nil
 }

--- a/modules/notify/api.go
+++ b/modules/notify/api.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/pool"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
 	"github.com/Mininglamp-OSS/octo-server/internal/cardactiondispatch"
@@ -255,20 +256,33 @@ func (n *Notify) handleSpaceMemberEvent(data []byte, commit config.EventCommit) 
 // 阻塞（reconciler 兜底）。GroupMemberAdd 是多监听者事件，commit(nil) 与既有 space
 // 处理保持一致。
 func (n *Notify) handleGroupMemberAddEvent(data []byte, commit config.EventCommit) {
-	var req config.MsgGroupMemberAddReq
-	if err := util.ReadJsonByByte(data, &req); err != nil {
-		n.Warn("解析GroupMemberAdd事件失败", zap.Error(err))
-		commit(nil)
-		return
-	}
-	if n.groupWelcome != nil && req.GroupNo != "" {
-		for _, m := range req.Members {
-			if m != nil && m.UID != "" {
-				n.groupWelcome.handleMemberJoin(req.GroupNo, m.UID)
+	// GroupMemberAdd is a multi-member batch event with no handlerMap entry, so
+	// listeners run sequentially on the shared event-dispatch goroutine. Offload
+	// the per-member fan-out (up to N DB round-trips) to the EventPool so this
+	// listener returns immediately and does not stall the sibling message/group
+	// listeners or back up the event queue on a bulk invite (mirrors the group
+	// module's own GroupMemberAdd listener).
+	n.ctx.EventPool.Work <- &pool.Job{
+		Data: data,
+		JobFunc: func(_ int64, d interface{}) {
+			var req config.MsgGroupMemberAddReq
+			if err := util.ReadJsonByByte(d.([]byte), &req); err != nil {
+				n.Warn("解析GroupMemberAdd事件失败", zap.Error(err))
+				commit(nil)
+				return
 			}
-		}
+			if n.groupWelcome != nil && req.GroupNo != "" {
+				uids := make([]string, 0, len(req.Members))
+				for _, m := range req.Members {
+					if m != nil && m.UID != "" {
+						uids = append(uids, m.UID)
+					}
+				}
+				n.groupWelcome.handleMemberJoinBatch(req.GroupNo, uids)
+			}
+			commit(nil)
+		},
 	}
-	commit(nil)
 }
 
 // Start 启动欢迎语的对账 + 发送 worker goroutine（模块生命周期钩子）。

--- a/modules/notify/group_welcome.go
+++ b/modules/notify/group_welcome.go
@@ -1,0 +1,679 @@
+package notify
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+	"unicode/utf8"
+
+	libcommon "github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
+	"github.com/Mininglamp-OSS/octo-server/modules/common"
+	spacepkg "github.com/Mininglamp-OSS/octo-server/pkg/space"
+	"go.uber.org/zap"
+)
+
+// group_welcome.go — orchestration for the group new-member welcome (群入群欢迎语).
+//
+// It mirrors the Space welcome engine (space_welcome.go) but:
+//   - delivery is a PUBLIC post into the group channel (channel_type=GROUP), not
+//     a personal DM;
+//   - there is no platform-global fallback — a group's effective config is simply
+//     its own row iff enabled;
+//   - the body supports a {member} placeholder rendered to the joining member's
+//     display name at send time.
+//
+// The shared status machine, tunables, sender, metrics and helpers
+// (sw* constants, callWithTimeout, claimOwnerID, spaceWelcomeSender,
+// spaceWelcomeMetrics) come from the space_welcome_* files (same package).
+
+// groupWelcomeMemberToken is the placeholder rendered to the joiner's display
+// name. Only this exact token is substituted; any other {...} text is left
+// verbatim (no templating engine, no injection surface — the payload is plain
+// text). Kept intentionally single and simple (see brief: no general templating).
+const groupWelcomeMemberToken = "{member}"
+
+// groupWelcomeRenderedMaxRunes bounds the rendered body so a config full of
+// {member} tokens cannot balloon pathologically (raw ≤2000, a name ≤100). This is
+// the trust-boundary "bound the payload" guard; truncation is on a rune boundary
+// (plain text — there is no markdown/richtext structure to corrupt).
+const groupWelcomeRenderedMaxRunes = 4096
+
+// renderGroupWelcomeBody substitutes the {member} placeholder with memberName and
+// bounds the result. memberName is a plain-text value carried as a JSON string in
+// the payload, so it cannot forge message structure; no markdown is rendered. For
+// a coalesced post memberName is a name LIST (see renderGroupWelcomeNameList).
+func renderGroupWelcomeBody(message, memberName string) string {
+	out := strings.ReplaceAll(message, groupWelcomeMemberToken, memberName)
+	if utf8.RuneCountInString(out) > groupWelcomeRenderedMaxRunes {
+		runes := []rune(out)
+		out = string(runes[:groupWelcomeRenderedMaxRunes])
+	}
+	return out
+}
+
+// renderGroupWelcomeNameList joins the joiner display names for the {member}
+// substitution of a coalesced post. Up to groupWelcomeCoalesceNames names are
+// listed verbatim ("、"-separated); a larger batch collapses the tail to
+// "name1、…、nameK 等 N 人" so one public post naming a big burst stays a single
+// short line. Each name is plain text (no markdown), so the joined list cannot
+// forge message structure.
+func renderGroupWelcomeNameList(names []string) string {
+	if len(names) <= groupWelcomeCoalesceNames {
+		return strings.Join(names, "、")
+	}
+	shown := strings.Join(names[:groupWelcomeCoalesceNames], "、")
+	return fmt.Sprintf("%s 等 %d 人", shown, len(names))
+}
+
+// groupWelcomeService owns the reconciler + worker goroutines and the enqueue
+// path for the group welcome. Constructed once by Notify.New; started/stopped via
+// the module Start/Stop hooks.
+type groupWelcomeService struct {
+	ctx      *config.Context
+	store    *groupWelcomeStore
+	cfgStore *common.GroupWelcomeConfigStore
+	settings *common.SystemSettings
+	metrics  *spaceWelcomeMetrics
+	fromUID  string
+	// sendFn posts one message (group channel). Defaults to the notify-local
+	// context-aware HTTP sender; overridable in tests.
+	sendFn func(ctx context.Context, req *config.MsgSendReq) (*swSendResult, error)
+	// botReady reports the notification sender's readiness. Not-ready is a
+	// definitive pre-IM failure.
+	botReady func() bool
+	// now returns the current time; injectable for tests. Always UTC.
+	now func() time.Time
+	// coalesceWindow holds a freshly-enqueued row back from the worker so a burst
+	// of joins collects into one post (see groupWelcomeCoalesceWindow). A field so
+	// tests can set it to 0 for deterministic immediate claiming.
+	coalesceWindow time.Duration
+
+	// reconcileCursor / workerCursor rotate the per-cycle / per-wake starting
+	// group so a shared budget cannot perpetually starve the tail of the enabled
+	// set. Each is touched by a single goroutine — no lock needed.
+	reconcileCursor int
+	workerCursor    int
+
+	mu     sync.Mutex
+	cancel context.CancelFunc
+	wait   sync.WaitGroup
+
+	log.Log
+}
+
+func newGroupWelcomeService(ctx *config.Context, settings *common.SystemSettings, fromUID string, botReady func() bool) *groupWelcomeService {
+	sender := newSpaceWelcomeSender(ctx) // generic *config.MsgSendReq HTTP sender
+	return &groupWelcomeService{
+		ctx:            ctx,
+		store:          newGroupWelcomeStore(ctx.DB(), claimOwnerID()),
+		cfgStore:       common.NewGroupWelcomeConfigStore(ctx.DB()),
+		settings:       settings,
+		metrics:        newSpaceWelcomeMetrics(),
+		fromUID:        fromUID,
+		sendFn:         sender.send,
+		botReady:       botReady,
+		now:            func() time.Time { return time.Now().UTC() },
+		coalesceWindow: groupWelcomeCoalesceWindow,
+		Log:            log.NewTLog("GroupWelcome"),
+	}
+}
+
+// Start launches the reconciler and worker goroutines. Idempotent.
+func (s *groupWelcomeService) Start() {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.cancel != nil {
+		return
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	s.cancel = cancel
+	s.wait.Add(2)
+	go s.reconcileLoop(ctx)
+	go s.workerLoop(ctx)
+	s.Info("group welcome service started", zap.String("claim_owner", s.store.claimOwner))
+}
+
+// Stop cancels the goroutines and waits for a clean shutdown.
+func (s *groupWelcomeService) Stop() {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	cancel := s.cancel
+	s.cancel = nil
+	s.mu.Unlock()
+	if cancel != nil {
+		cancel()
+		s.wait.Wait()
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Event path (low latency)
+// ---------------------------------------------------------------------------
+
+// effectiveConfig resolves the config in effect for groupNo: the per-group row iff
+// present, else an empty (disabled) config. No global fallback. A DB error is
+// returned so callers can fail closed.
+func (s *groupWelcomeService) effectiveConfig(ctx context.Context, groupNo string) (common.GroupWelcomeConfig, error) {
+	row, found, err := s.cfgStore.Get(ctx, groupNo)
+	if err != nil {
+		return common.GroupWelcomeConfig{}, err
+	}
+	if !found || row == nil {
+		return common.GroupWelcomeConfig{GroupNo: groupNo}, nil
+	}
+	return *row, nil
+}
+
+// enabledEffectiveConfigs returns the effective config for every group with an
+// enabled welcome row (no global fallback to fold in).
+func (s *groupWelcomeService) enabledEffectiveConfigs(ctx context.Context) ([]common.GroupWelcomeConfig, error) {
+	lc, cancel := context.WithTimeout(ctx, swDBCallTimeout)
+	defer cancel()
+	return s.cfgStore.ListEnabled(lc)
+}
+
+// handleMemberJoin is invoked from the GroupMemberAdd listener for each joining
+// uid. When the group's config is enabled and the joiner is a first-join human
+// member, it upserts a pending ledger row. Enqueue failure never blocks the join.
+func (s *groupWelcomeService) handleMemberJoin(groupNo, uid string) {
+	if s == nil || groupNo == "" || uid == "" {
+		return
+	}
+	// Platform master switch (dark-launch default off). When off the event path
+	// enqueues nothing, so no ledger rows accrue while the feature is dark.
+	if !s.settings.GroupWelcomeEnabled() {
+		return
+	}
+	cfgCtx, cancelCfg := context.WithTimeout(context.Background(), swDBCallTimeout)
+	cfg, err := s.effectiveConfig(cfgCtx, groupNo)
+	cancelCfg()
+	if err != nil {
+		s.Warn("group welcome enqueue effective config read failed",
+			zap.String("stage", swStageEnqueue), zap.String("group_no", groupNo), zap.String("uid", uid), zap.Error(err))
+		return
+	}
+	if !cfg.Enabled {
+		return
+	}
+	if field := common.ValidateGroupWelcomeCombination(cfg); field != "" {
+		s.metrics.incConfigInvalid()
+		return
+	}
+	activeFrom, ok := cfg.ParsedActiveFrom()
+	if !ok {
+		s.metrics.incConfigInvalid()
+		return
+	}
+	// System-bot exclusion is scoped strictly to the joiner uid.
+	if spacepkg.IsSystemBot(uid) {
+		return
+	}
+
+	callCtx, cancel := context.WithTimeout(context.Background(), swDBCallTimeout)
+	defer cancel()
+	eligible, err := s.store.firstJoinHumanMember(callCtx, groupNo, uid, activeFrom)
+	if err != nil {
+		s.Warn("group welcome enqueue eligibility check failed",
+			zap.String("stage", swStageEnqueue), zap.String("group_no", groupNo), zap.String("uid", uid), zap.Error(err))
+		return
+	}
+	if !eligible {
+		return
+	}
+	s.enqueue(callCtx, groupNo, uid, swSourceEvent)
+}
+
+// enqueue upserts a pending row and splits enqueue_total vs enqueue_dedup_total.
+// The row is held back from the worker until now+coalesceWindow so co-arriving
+// joins collect into one post (see claimBatch / dispatchBatch).
+func (s *groupWelcomeService) enqueue(ctx context.Context, groupNo, uid, source string) {
+	now := s.now()
+	inserted, err := s.store.upsertPending(ctx, groupNo, uid, now, now.Add(s.coalesceWindow))
+	if err != nil {
+		s.Warn("group welcome enqueue upsert failed",
+			zap.String("stage", swStageEnqueue), zap.String("source", source),
+			zap.String("group_no", groupNo), zap.String("uid", uid), zap.Error(err))
+		return
+	}
+	if inserted {
+		s.metrics.incEnqueue(source)
+	} else {
+		s.metrics.incEnqueueDedup(source)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Reconciler
+// ---------------------------------------------------------------------------
+
+func (s *groupWelcomeService) reconcileLoop(ctx context.Context) {
+	defer s.wait.Done()
+	ticker := time.NewTicker(swReconcileInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			s.safeRun("reconcile", func() { s.runReconcileOnce(ctx) })
+		}
+	}
+}
+
+// runReconcileOnce enumerates every group with an enabled config, re-validates
+// each (fail closed per group), and scans it for active human members lacking a
+// ledger row, enqueueing them under a shared global budget + per-group cap +
+// rotating start cursor (fairness).
+func (s *groupWelcomeService) runReconcileOnce(ctx context.Context) {
+	// Platform master switch (dark-launch default off): no catch-up enqueue while
+	// the feature is dark.
+	if !s.settings.GroupWelcomeEnabled() {
+		return
+	}
+	configs, err := s.enabledEffectiveConfigs(ctx)
+	if err != nil {
+		s.Warn("group welcome reconcile list enabled failed", zap.String("stage", swStageEnqueue), zap.Error(err))
+		return
+	}
+	n := len(configs)
+	if n == 0 {
+		return
+	}
+	start := s.reconcileCursor % n
+	s.reconcileCursor++
+	budget := swReconcileCap
+
+	for i := 0; i < n && budget > 0; i++ {
+		if ctx.Err() != nil {
+			return
+		}
+		cfg := configs[(start+i)%n]
+		if !s.validateRuntime(ctx, cfg) {
+			continue
+		}
+		activeFrom, _ := cfg.ParsedActiveFrom()
+		per := budget
+		if per > swReconcilePerSpaceCap {
+			per = swReconcilePerSpaceCap
+		}
+
+		scanCtx, cancel := context.WithTimeout(ctx, swDBCallTimeout)
+		uids, scanErr := s.store.reconcileScan(scanCtx, cfg.GroupNo, activeFrom, spacepkg.SystemBotList(), per)
+		cancel()
+		if scanErr != nil {
+			s.Warn("group welcome reconcile scan failed",
+				zap.String("stage", swStageEnqueue), zap.String("group_no", cfg.GroupNo), zap.Error(scanErr))
+			continue
+		}
+		for _, uid := range uids {
+			if ctx.Err() != nil {
+				return
+			}
+			callCtx, c := context.WithTimeout(ctx, swDBCallTimeout)
+			s.enqueue(callCtx, cfg.GroupNo, uid, swSourceReconciler)
+			c()
+		}
+		budget -= len(uids)
+		if len(uids) > 0 {
+			s.Info("group welcome reconcile enqueued",
+				zap.String("group_no", cfg.GroupNo), zap.Int("candidates", len(uids)))
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Send worker
+// ---------------------------------------------------------------------------
+
+func (s *groupWelcomeService) workerLoop(ctx context.Context) {
+	defer s.wait.Done()
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+		s.safeRun("worker", func() { s.runWorkerWake(ctx) })
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(swIdleSleep):
+		}
+	}
+}
+
+// runWorkerWake sweeps stale rows across ALL groups, then round-robins over the
+// enabled groups delivering ONE coalesced post per group per wake (up to
+// swWorkerWakeCap posts total). Each group's due pending rows are claimed as a
+// single batch and named in one post, so a burst of joins does not spam the
+// channel; a group whose burst exceeds groupWelcomeCoalesceMax simply spills its
+// tail into later wakes. Per-group enabled/validity is re-checked immediately
+// before the claim so an admin disable / delete mid-wake takes effect at once (a
+// batch already claimed completes). The rotating cursor keeps the enabled set
+// fairly served when there are more groups than the per-wake post budget.
+func (s *groupWelcomeService) runWorkerWake(ctx context.Context) {
+	// Cross-group sweep runs unconditionally (even with the master switch off, so
+	// lease-expired in-flight rows still reach a terminal/pending state).
+	s.sweepAll(ctx)
+
+	// Platform master switch (dark-launch default off): stop posting immediately.
+	if !s.settings.GroupWelcomeEnabled() {
+		return
+	}
+
+	configs, err := s.enabledEffectiveConfigs(ctx)
+	if err != nil {
+		s.Warn("group welcome worker list enabled failed", zap.String("stage", swStageClaim), zap.Error(err))
+		return
+	}
+	if len(configs) == 0 {
+		return
+	}
+
+	valid := make([]common.GroupWelcomeConfig, 0, len(configs))
+	for _, cfg := range configs {
+		if s.validateRuntime(ctx, cfg) {
+			valid = append(valid, cfg)
+		}
+	}
+	if len(valid) == 0 {
+		return
+	}
+
+	vn := len(valid)
+	wstart := s.workerCursor % vn
+	s.workerCursor++
+
+	posts := 0
+	for i := 0; i < vn; i++ {
+		if ctx.Err() != nil || posts >= swWorkerWakeCap {
+			return
+		}
+		cfg := valid[(wstart+i)%vn]
+
+		// Re-resolve the config right before claiming so a mid-wake disable/delete
+		// or message edit takes effect immediately (the fresh body is what dispatch
+		// posts).
+		curCtx, curCancel := context.WithTimeout(ctx, swDBCallTimeout)
+		cur, curErr := s.effectiveConfig(curCtx, cfg.GroupNo)
+		curCancel()
+		if curErr != nil {
+			s.Warn("group welcome worker config re-read failed", zap.String("stage", swStageClaim), zap.String("group_no", cfg.GroupNo), zap.Error(curErr))
+			continue
+		}
+		if !cur.Enabled {
+			continue // disabled/deleted mid-wake
+		}
+		if field := common.ValidateGroupWelcomeCombination(cur); field != "" {
+			s.metrics.incConfigInvalid()
+			continue
+		}
+
+		claimCtx, cancel := context.WithTimeout(ctx, swDBCallTimeout)
+		batch, claimErr := s.store.claimBatch(claimCtx, cur.GroupNo, groupWelcomeCoalesceMax, s.now())
+		cancel()
+		if claimErr != nil {
+			s.Warn("group welcome claim failed", zap.String("stage", swStageClaim), zap.String("group_no", cur.GroupNo), zap.Error(claimErr))
+			continue
+		}
+		if len(batch) == 0 {
+			continue // this group has nothing due — next group
+		}
+		posts++
+		s.dispatchBatch(ctx, cur, batch)
+	}
+}
+
+// sweepAll reclaims lease-expired claimed rows (-> pending) and promotes
+// lease-expired dispatching rows (-> unknown) across ALL groups.
+func (s *groupWelcomeService) sweepAll(ctx context.Context) {
+	now := s.now()
+	c1, cancel1 := context.WithTimeout(ctx, swDBCallTimeout)
+	reclaimed, err := s.store.sweepClaimedAll(c1, now)
+	cancel1()
+	if err != nil {
+		s.Warn("group welcome sweep claimed failed", zap.String("stage", swStageSweep), zap.Error(err))
+	} else {
+		s.metrics.addSweepClaimed(reclaimed)
+	}
+
+	c2, cancel2 := context.WithTimeout(ctx, swDBCallTimeout)
+	promoted, err := s.store.sweepDispatchingAll(c2, now)
+	cancel2()
+	if err != nil {
+		s.Warn("group welcome sweep dispatching failed", zap.String("stage", swStageSweep), zap.Error(err))
+	} else if promoted > 0 {
+		s.metrics.addSweepDispatching(promoted)
+		s.Warn("group welcome dispatching rows swept to unknown", zap.Int64("count", promoted))
+	}
+}
+
+// dispatch delivers a single claimed row (a batch of one). Retained as the
+// one-row entry point used by focused tests; the worker always uses dispatchBatch.
+func (s *groupWelcomeService) dispatch(ctx context.Context, cfg common.GroupWelcomeConfig, row *groupWelcomeRow) {
+	s.dispatchBatch(ctx, cfg, []*groupWelcomeRow{row})
+}
+
+// dispatchBatch takes a batch of rows claimed for ONE group through the pre-send
+// joiner re-check, the dispatching transition, a SINGLE coalesced group-channel
+// post naming every eligible joiner, and the terminal transitions. Coalescing is
+// what keeps a bulk invite from spamming the channel; each row still transitions
+// independently (its own CAS), so at-most-once per (group_no, uid) holds.
+func (s *groupWelcomeService) dispatchBatch(ctx context.Context, cfg common.GroupWelcomeConfig, rows []*groupWelcomeRow) {
+	if len(rows) == 0 {
+		return
+	}
+
+	// 1) Per-joiner pre-send re-check (bypasses cache; resolves the {member} name
+	//    + eligibility). Ineligible joiners are skipped individually and excluded
+	//    from the post; a DB error is a definitive pre-IM failure for that row.
+	type eligibleRow struct {
+		row  *groupWelcomeRow
+		name string
+	}
+	eligible := make([]eligibleRow, 0, len(rows))
+	for _, row := range rows {
+		pcCtx, cancel := context.WithTimeout(ctx, swDBCallTimeout)
+		pc, err := s.store.precheckRecipient(pcCtx, row.UID, spacepkg.IsSystemBot)
+		cancel()
+		if err != nil {
+			s.Warn("group welcome precheck failed", zap.String("stage", swStagePrecheck), zap.Int64("delivery_id", row.ID),
+				zap.String("group_no", cfg.GroupNo), zap.String("uid", row.UID), zap.Error(err))
+			s.preIMFailure(ctx, row, swErrConfigRead)
+			continue
+		}
+		if !pc.eligible {
+			s.skip(ctx, cfg, row, pc.errClass)
+			continue
+		}
+		eligible = append(eligible, eligibleRow{row: row, name: pc.name})
+	}
+	if len(eligible) == 0 {
+		return
+	}
+
+	// 2) Preflight the sender ONCE for the whole batch. Not ready / unconfigured is
+	//    a definitive pre-IM failure for every eligible row (they back off to
+	//    pending and are retried on a later wake).
+	if s.botReady != nil {
+		ready, ok := callWithTimeout(swBotReadyTimeout, s.botReady)
+		if !ok || !ready {
+			for _, e := range eligible {
+				s.preIMFailure(ctx, e.row, swErrBotNotReady)
+			}
+			return
+		}
+	}
+	if s.ctx.GetConfig().WuKongIM.APIURL == "" {
+		for _, e := range eligible {
+			s.preIMFailure(ctx, e.row, swErrConfigRead)
+		}
+		return
+	}
+
+	// 3) CAS each eligible row claimed -> dispatching. Only rows we still own are
+	//    delivered (a peer sweep after lease expiry could have reclaimed one). The
+	//    name list is built from the winners so the post names exactly who it is
+	//    delivered to.
+	winners := make([]*groupWelcomeRow, 0, len(eligible))
+	names := make([]string, 0, len(eligible))
+	for _, e := range eligible {
+		dsCtx, cancel := context.WithTimeout(ctx, swDBCallTimeout)
+		ok, err := s.store.casToDispatching(dsCtx, e.row.ID, s.now())
+		cancel()
+		if err != nil {
+			s.Warn("group welcome cas to dispatching failed", zap.String("stage", swStageDispatch), zap.Int64("delivery_id", e.row.ID), zap.Error(err))
+			s.preIMFailure(ctx, e.row, swErrConfigRead)
+			continue
+		}
+		if !ok {
+			s.Warn("group welcome dispatch ownership lost before send", zap.String("stage", swStageDispatch), zap.Int64("delivery_id", e.row.ID))
+			continue
+		}
+		winners = append(winners, e.row)
+		names = append(names, e.name)
+	}
+	if len(winners) == 0 {
+		return
+	}
+
+	// 4) ONE public group-channel post. The {member} placeholder renders to the
+	//    joined name list (plain-text, no markdown). payload.type=1 Text; the
+	//    notify-local sender base64-encodes Payload for /message/send.
+	body := renderGroupWelcomeBody(cfg.Message, renderGroupWelcomeNameList(names))
+	payload := map[string]interface{}{"type": 1, "content": body}
+	req := &config.MsgSendReq{
+		Header:      config.MsgHeader{RedDot: 1},
+		FromUID:     s.fromUID,
+		ChannelID:   cfg.GroupNo,
+		ChannelType: libcommon.ChannelTypeGroup.Uint8(),
+		Payload:     []byte(util.ToJson(payload)),
+	}
+
+	sendCtx := context.WithoutCancel(ctx)
+	result, sendErr := s.sendFn(sendCtx, req)
+	if sendErr != nil {
+		class := swErrIMTimeout
+		var se *swSendError
+		if errors.As(sendErr, &se) {
+			class = se.class
+		}
+		for _, row := range winners {
+			s.toUnknown(ctx, row, class)
+		}
+		return
+	}
+
+	// 5) Persist success on every winner, sharing the one message's identifiers.
+	for _, row := range winners {
+		persistCtx, cancel := context.WithTimeout(ctx, swDBCallTimeout)
+		sentOK, persistErr := s.store.casToSent(persistCtx, row.ID, result.messageID, result.clientMsgNo, s.now())
+		cancel()
+		if persistErr != nil {
+			s.Error("group welcome sent persist failed", zap.String("stage", swStagePersist), zap.Int64("delivery_id", row.ID), zap.Error(persistErr))
+			s.toUnknown(ctx, row, swErrSentPersist)
+			continue
+		}
+		if !sentOK {
+			s.Warn("group welcome sent persist ownership lost", zap.String("stage", swStagePersist), zap.Int64("delivery_id", row.ID))
+			continue
+		}
+		s.metrics.incSendSuccess()
+		s.Info("group welcome delivered", zap.String("stage", swStagePersist), zap.Int64("delivery_id", row.ID),
+			zap.String("group_no", cfg.GroupNo), zap.String("uid", row.UID))
+	}
+}
+
+// skip transitions a claimed row to skipped (joiner ineligible at pre-send) and
+// records the metric. Shared by the batch dispatch path.
+func (s *groupWelcomeService) skip(ctx context.Context, cfg common.GroupWelcomeConfig, row *groupWelcomeRow, errClass string) {
+	skCtx, c := context.WithTimeout(ctx, swDBCallTimeout)
+	ok, casErr := s.store.casToSkipped(skCtx, row.ID, errClass, s.now())
+	c()
+	if casErr != nil {
+		s.Warn("group welcome cas to skipped failed", zap.String("stage", swStagePrecheck), zap.Int64("delivery_id", row.ID), zap.Error(casErr))
+		return
+	}
+	if ok {
+		s.metrics.incSkipNonMember()
+		s.Info("group welcome joiner skipped", zap.String("stage", swStagePrecheck), zap.Int64("delivery_id", row.ID),
+			zap.String("group_no", cfg.GroupNo), zap.String("uid", row.UID), zap.String("error_class", errClass))
+	}
+}
+
+// preIMFailure records a definitive pre-IM failure (the only place attempts grows).
+func (s *groupWelcomeService) preIMFailure(ctx context.Context, row *groupWelcomeRow, class string) {
+	c, cancel := context.WithTimeout(ctx, swDBCallTimeout)
+	ok, err := s.store.casPreIMFailure(c, row.ID, row.Attempts, class, s.now())
+	cancel()
+	if err != nil {
+		s.Warn("group welcome cas pre-IM failure failed", zap.Int64("delivery_id", row.ID), zap.String("error_class", class), zap.Error(err))
+		return
+	}
+	if ok && row.Attempts+1 > swMaxPreIMAttempts {
+		s.metrics.incSendFailed()
+		s.Warn("group welcome delivery failed (retry budget exhausted)", zap.Int64("delivery_id", row.ID), zap.String("error_class", class))
+	}
+}
+
+// toUnknown records a transport-ambiguous outcome (never auto-retried).
+func (s *groupWelcomeService) toUnknown(ctx context.Context, row *groupWelcomeRow, class string) {
+	c, cancel := context.WithTimeout(ctx, swDBCallTimeout)
+	ok, err := s.store.casToUnknown(c, row.ID, class, s.now())
+	cancel()
+	if err != nil {
+		s.Error("group welcome cas to unknown failed", zap.Int64("delivery_id", row.ID), zap.String("error_class", class), zap.Error(err))
+		return
+	}
+	if ok {
+		s.metrics.incSendUnknown()
+		s.Warn("group welcome delivery outcome unknown", zap.String("stage", swStageDispatch), zap.Int64("delivery_id", row.ID), zap.String("error_class", class))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// validateRuntime re-validates the enabled config (static combination) and that
+// the target group exists and is active. Any failure fails the cycle closed; a
+// config failure also increments config_invalid_total.
+func (s *groupWelcomeService) validateRuntime(ctx context.Context, cfg common.GroupWelcomeConfig) bool {
+	if field := common.ValidateGroupWelcomeCombination(cfg); field != "" {
+		s.metrics.incConfigInvalid()
+		s.Warn("group welcome config invalid; failing closed", zap.String("group_no", cfg.GroupNo), zap.String("field", field))
+		return false
+	}
+	c, cancel := context.WithTimeout(ctx, swDBCallTimeout)
+	active, err := s.store.groupActive(c, cfg.GroupNo)
+	cancel()
+	if err != nil {
+		s.Warn("group welcome runtime group check failed", zap.String("group_no", cfg.GroupNo), zap.Error(err))
+		return false
+	}
+	if !active {
+		s.metrics.incConfigInvalid()
+		s.Warn("group welcome target group inactive; failing closed", zap.String("group_no", cfg.GroupNo))
+		return false
+	}
+	return true
+}
+
+// safeRun runs fn with panic recovery so one bad cycle cannot kill the loop.
+func (s *groupWelcomeService) safeRun(what string, fn func()) {
+	defer func() {
+		if r := recover(); r != nil {
+			s.Error("group welcome cycle panic", zap.String("cycle", what), zap.Any("recover", r))
+		}
+	}()
+	fn()
+}

--- a/modules/notify/group_welcome.go
+++ b/modules/notify/group_welcome.go
@@ -187,7 +187,18 @@ func (s *groupWelcomeService) enabledEffectiveConfigs(ctx context.Context) ([]co
 // uid. When the group's config is enabled and the joiner is a first-join human
 // member, it upserts a pending ledger row. Enqueue failure never blocks the join.
 func (s *groupWelcomeService) handleMemberJoin(groupNo, uid string) {
-	if s == nil || groupNo == "" || uid == "" {
+	s.handleMemberJoinBatch(groupNo, []string{uid})
+}
+
+// handleMemberJoinBatch is the GroupMemberAdd fan-out entry. A bulk invite arrives
+// as ONE event with many members, so it resolves the group's effective config +
+// active_from ONCE for the whole batch, then for each first-join human member
+// upserts a pending ledger row. Enqueue failure never blocks/rolls back the
+// completed join (the reconciler catches it up). The GroupMemberAdd listener runs
+// this off the shared event-dispatch goroutine (see handleGroupMemberAddEvent), so
+// the N per-member DB checks do not stall event delivery on a large invite.
+func (s *groupWelcomeService) handleMemberJoinBatch(groupNo string, uids []string) {
+	if s == nil || groupNo == "" || len(uids) == 0 {
 		return
 	}
 	// Platform master switch (dark-launch default off). When off the event path
@@ -200,7 +211,7 @@ func (s *groupWelcomeService) handleMemberJoin(groupNo, uid string) {
 	cancelCfg()
 	if err != nil {
 		s.Warn("group welcome enqueue effective config read failed",
-			zap.String("stage", swStageEnqueue), zap.String("group_no", groupNo), zap.String("uid", uid), zap.Error(err))
+			zap.String("stage", swStageEnqueue), zap.String("group_no", groupNo), zap.Error(err))
 		return
 	}
 	if !cfg.Enabled {
@@ -215,23 +226,26 @@ func (s *groupWelcomeService) handleMemberJoin(groupNo, uid string) {
 		s.metrics.incConfigInvalid()
 		return
 	}
-	// System-bot exclusion is scoped strictly to the joiner uid.
-	if spacepkg.IsSystemBot(uid) {
-		return
+	for _, uid := range uids {
+		// System-bot exclusion is scoped strictly to the joiner uid.
+		if uid == "" || spacepkg.IsSystemBot(uid) {
+			continue
+		}
+		callCtx, cancel := context.WithTimeout(context.Background(), swDBCallTimeout)
+		eligible, err := s.store.firstJoinHumanMember(callCtx, groupNo, uid, activeFrom)
+		if err != nil {
+			s.Warn("group welcome enqueue eligibility check failed",
+				zap.String("stage", swStageEnqueue), zap.String("group_no", groupNo), zap.String("uid", uid), zap.Error(err))
+			cancel()
+			continue
+		}
+		if !eligible {
+			cancel()
+			continue
+		}
+		s.enqueue(callCtx, groupNo, uid, swSourceEvent)
+		cancel()
 	}
-
-	callCtx, cancel := context.WithTimeout(context.Background(), swDBCallTimeout)
-	defer cancel()
-	eligible, err := s.store.firstJoinHumanMember(callCtx, groupNo, uid, activeFrom)
-	if err != nil {
-		s.Warn("group welcome enqueue eligibility check failed",
-			zap.String("stage", swStageEnqueue), zap.String("group_no", groupNo), zap.String("uid", uid), zap.Error(err))
-		return
-	}
-	if !eligible {
-		return
-	}
-	s.enqueue(callCtx, groupNo, uid, swSourceEvent)
 }
 
 // enqueue upserts a pending row and splits enqueue_total vs enqueue_dedup_total.
@@ -559,28 +573,43 @@ func (s *groupWelcomeService) dispatchBatch(ctx context.Context, cfg common.Grou
 		Payload:     []byte(util.ToJson(payload)),
 	}
 
-	sendCtx := context.WithoutCancel(ctx)
-	result, sendErr := s.sendFn(sendCtx, req)
+	// The IM call and everything after it are post-decision bookkeeping that must
+	// finish even if Stop() cancels the worker mid-batch — otherwise a delivered
+	// row is stranded in `dispatching` and only a peer sweep (falsely) promotes it
+	// to `unknown`. Derive the send + persist contexts from a non-cancellable base
+	// (the 15s HTTP timeout / swDBCallTimeout still bound them).
+	postSend := context.WithoutCancel(ctx)
+	result, sendErr := s.sendFn(postSend, req)
 	if sendErr != nil {
 		class := swErrIMTimeout
 		var se *swSendError
 		if errors.As(sendErr, &se) {
 			class = se.class
 		}
+		// A definitive reject (non-2xx) posted NOTHING → re-queue the whole batch
+		// (backoff, at-most-once-safe) instead of terminal-`unknown`-ing it, so one
+		// transient WuKongIM 5xx during a bulk invite cannot permanently suppress
+		// the coalesced welcome. Ambiguous errors (timeout / empty-200) stay
+		// `unknown` — they may have posted, and this is a PUBLIC message, so a retry
+		// could double-post.
 		for _, row := range winners {
-			s.toUnknown(ctx, row, class)
+			if class == swErrIMRejected {
+				s.dispatchRetry(postSend, row, class)
+			} else {
+				s.toUnknown(postSend, row, class)
+			}
 		}
 		return
 	}
 
 	// 5) Persist success on every winner, sharing the one message's identifiers.
 	for _, row := range winners {
-		persistCtx, cancel := context.WithTimeout(ctx, swDBCallTimeout)
+		persistCtx, cancel := context.WithTimeout(postSend, swDBCallTimeout)
 		sentOK, persistErr := s.store.casToSent(persistCtx, row.ID, result.messageID, result.clientMsgNo, s.now())
 		cancel()
 		if persistErr != nil {
 			s.Error("group welcome sent persist failed", zap.String("stage", swStagePersist), zap.Int64("delivery_id", row.ID), zap.Error(persistErr))
-			s.toUnknown(ctx, row, swErrSentPersist)
+			s.toUnknown(postSend, row, swErrSentPersist)
 			continue
 		}
 		if !sentOK {
@@ -590,6 +619,23 @@ func (s *groupWelcomeService) dispatchBatch(ctx context.Context, cfg common.Grou
 		s.metrics.incSendSuccess()
 		s.Info("group welcome delivered", zap.String("stage", swStagePersist), zap.Int64("delivery_id", row.ID),
 			zap.String("group_no", cfg.GroupNo), zap.String("uid", row.UID))
+	}
+}
+
+// dispatchRetry re-queues a dispatching row after a definitively-not-delivered
+// send (backoff to pending, or terminal `failed` after the retry budget). Shares
+// the pre-IM backoff schedule/budget; only fired for swErrIMRejected.
+func (s *groupWelcomeService) dispatchRetry(ctx context.Context, row *groupWelcomeRow, class string) {
+	c, cancel := context.WithTimeout(ctx, swDBCallTimeout)
+	ok, err := s.store.casDispatchingRetry(c, row.ID, row.Attempts, class, s.now())
+	cancel()
+	if err != nil {
+		s.Warn("group welcome cas dispatching retry failed", zap.Int64("delivery_id", row.ID), zap.String("error_class", class), zap.Error(err))
+		return
+	}
+	if ok && row.Attempts+1 > swMaxPreIMAttempts {
+		s.metrics.incSendFailed()
+		s.Warn("group welcome delivery failed (send-retry budget exhausted)", zap.Int64("delivery_id", row.ID), zap.String("error_class", class))
 	}
 }
 

--- a/modules/notify/group_welcome.go
+++ b/modules/notify/group_welcome.go
@@ -496,6 +496,19 @@ func (s *groupWelcomeService) dispatchBatch(ctx context.Context, cfg common.Grou
 		return
 	}
 
+	// The pre-send re-check validates each joiner against the CURRENT config's
+	// active_from window, so a pending row is never posted outside the
+	// currently-configured cutoff (admin moved active_from forward, or
+	// deleted+recreated the config). The worker only claims valid, enabled configs,
+	// so this parse succeeds; fail closed (skip the batch) if it ever does not.
+	activeFrom, ok := cfg.ParsedActiveFrom()
+	if !ok {
+		s.metrics.incConfigInvalid()
+		s.Warn("group welcome dispatch: config active_from unparseable; skipping batch",
+			zap.String("stage", swStagePrecheck), zap.String("group_no", cfg.GroupNo))
+		return
+	}
+
 	// 1) Per-joiner pre-send re-check (bypasses cache; resolves the {member} name
 	//    + eligibility). Ineligible joiners are skipped individually and excluded
 	//    from the post; a DB error is a definitive pre-IM failure for that row.
@@ -506,7 +519,7 @@ func (s *groupWelcomeService) dispatchBatch(ctx context.Context, cfg common.Grou
 	eligible := make([]eligibleRow, 0, len(rows))
 	for _, row := range rows {
 		pcCtx, cancel := context.WithTimeout(ctx, swDBCallTimeout)
-		pc, err := s.store.precheckRecipient(pcCtx, row.UID, spacepkg.IsSystemBot)
+		pc, err := s.store.precheckRecipient(pcCtx, cfg.GroupNo, row.UID, activeFrom, spacepkg.IsSystemBot)
 		cancel()
 		if err != nil {
 			s.Warn("group welcome precheck failed", zap.String("stage", swStagePrecheck), zap.Int64("delivery_id", row.ID),
@@ -605,6 +618,16 @@ func (s *groupWelcomeService) dispatchBatch(ctx context.Context, cfg common.Grou
 		}
 		for _, row := range winners {
 			s.toUnknown(postSend, row, class)
+		}
+		return
+	}
+	if result == nil {
+		// Defensive: a sender must return a non-nil result on nil error. Guard the
+		// boundary so a malformed sender response cannot panic the worker at
+		// result.messageID; treat it as transport-ambiguous (unknown).
+		s.Warn("group welcome sender returned nil result on nil error", zap.String("stage", swStagePersist), zap.String("group_no", cfg.GroupNo))
+		for _, row := range winners {
+			s.toUnknown(postSend, row, swErrIMBadResponse)
 		}
 		return
 	}

--- a/modules/notify/group_welcome.go
+++ b/modules/notify/group_welcome.go
@@ -226,6 +226,8 @@ func (s *groupWelcomeService) handleMemberJoinBatch(groupNo string, uids []strin
 		s.metrics.incConfigInvalid()
 		return
 	}
+	// One due time for the whole event so all its members coalesce into one post.
+	batchNow := s.now()
 	for _, uid := range uids {
 		// System-bot exclusion is scoped strictly to the joiner uid.
 		if uid == "" || spacepkg.IsSystemBot(uid) {
@@ -243,16 +245,17 @@ func (s *groupWelcomeService) handleMemberJoinBatch(groupNo string, uids []strin
 			cancel()
 			continue
 		}
-		s.enqueue(callCtx, groupNo, uid, swSourceEvent)
+		s.enqueue(callCtx, groupNo, uid, swSourceEvent, batchNow)
 		cancel()
 	}
 }
 
 // enqueue upserts a pending row and splits enqueue_total vs enqueue_dedup_total.
 // The row is held back from the worker until now+coalesceWindow so co-arriving
-// joins collect into one post (see claimBatch / dispatchBatch).
-func (s *groupWelcomeService) enqueue(ctx context.Context, groupNo, uid, source string) {
-	now := s.now()
+// joins collect into one post (see claimBatch / dispatchBatch). now is passed in
+// so every member of ONE GroupMemberAdd event shares a single due time (a batch's
+// rows must not straddle the coalesce window and split into multiple posts).
+func (s *groupWelcomeService) enqueue(ctx context.Context, groupNo, uid, source string, now time.Time) {
 	inserted, err := s.store.upsertPending(ctx, groupNo, uid, now, now.Add(s.coalesceWindow))
 	if err != nil {
 		s.Warn("group welcome enqueue upsert failed",
@@ -335,7 +338,7 @@ func (s *groupWelcomeService) runReconcileOnce(ctx context.Context) {
 				return
 			}
 			callCtx, c := context.WithTimeout(ctx, swDBCallTimeout)
-			s.enqueue(callCtx, cfg.GroupNo, uid, swSourceReconciler)
+			s.enqueue(callCtx, cfg.GroupNo, uid, swSourceReconciler, s.now())
 			c()
 		}
 		budget -= len(uids)
@@ -410,6 +413,12 @@ func (s *groupWelcomeService) runWorkerWake(ctx context.Context) {
 	posts := 0
 	for i := 0; i < vn; i++ {
 		if ctx.Err() != nil || posts >= swWorkerWakeCap {
+			return
+		}
+		// Re-check the master switch before each new group's claim so an operator
+		// flipping it off mid-wake stops further posts at once (a batch already
+		// claimed this wake still completes).
+		if !s.settings.GroupWelcomeEnabled() {
 			return
 		}
 		cfg := valid[(wstart+i)%vn]
@@ -581,23 +590,21 @@ func (s *groupWelcomeService) dispatchBatch(ctx context.Context, cfg common.Grou
 	postSend := context.WithoutCancel(ctx)
 	result, sendErr := s.sendFn(postSend, req)
 	if sendErr != nil {
+		// Any post-send failure is transport-ambiguous for a PUBLIC message: the
+		// coalesced post may or may not have appeared in the channel, and the send
+		// carries no idempotency key, so auto-retrying could double-post a visible,
+		// unrecallable welcome. Mirror the space engine: mark every winner `unknown`
+		// (terminal, never auto-retried) and leave recovery to an operator. This
+		// means one send failure suppresses the whole coalesced batch — a documented
+		// blast-radius limitation to revisit (with message-level idempotency) before
+		// the master switch is enabled.
 		class := swErrIMTimeout
 		var se *swSendError
 		if errors.As(sendErr, &se) {
 			class = se.class
 		}
-		// A definitive reject (non-2xx) posted NOTHING → re-queue the whole batch
-		// (backoff, at-most-once-safe) instead of terminal-`unknown`-ing it, so one
-		// transient WuKongIM 5xx during a bulk invite cannot permanently suppress
-		// the coalesced welcome. Ambiguous errors (timeout / empty-200) stay
-		// `unknown` — they may have posted, and this is a PUBLIC message, so a retry
-		// could double-post.
 		for _, row := range winners {
-			if class == swErrIMRejected {
-				s.dispatchRetry(postSend, row, class)
-			} else {
-				s.toUnknown(postSend, row, class)
-			}
+			s.toUnknown(postSend, row, class)
 		}
 		return
 	}
@@ -619,23 +626,6 @@ func (s *groupWelcomeService) dispatchBatch(ctx context.Context, cfg common.Grou
 		s.metrics.incSendSuccess()
 		s.Info("group welcome delivered", zap.String("stage", swStagePersist), zap.Int64("delivery_id", row.ID),
 			zap.String("group_no", cfg.GroupNo), zap.String("uid", row.UID))
-	}
-}
-
-// dispatchRetry re-queues a dispatching row after a definitively-not-delivered
-// send (backoff to pending, or terminal `failed` after the retry budget). Shares
-// the pre-IM backoff schedule/budget; only fired for swErrIMRejected.
-func (s *groupWelcomeService) dispatchRetry(ctx context.Context, row *groupWelcomeRow, class string) {
-	c, cancel := context.WithTimeout(ctx, swDBCallTimeout)
-	ok, err := s.store.casDispatchingRetry(c, row.ID, row.Attempts, class, s.now())
-	cancel()
-	if err != nil {
-		s.Warn("group welcome cas dispatching retry failed", zap.Int64("delivery_id", row.ID), zap.String("error_class", class), zap.Error(err))
-		return
-	}
-	if ok && row.Attempts+1 > swMaxPreIMAttempts {
-		s.metrics.incSendFailed()
-		s.Warn("group welcome delivery failed (send-retry budget exhausted)", zap.Int64("delivery_id", row.ID), zap.String("error_class", class))
 	}
 }
 

--- a/modules/notify/group_welcome_db.go
+++ b/modules/notify/group_welcome_db.go
@@ -1,0 +1,333 @@
+package notify
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/gocraft/dbr/v2"
+)
+
+// groupWelcomeStore is the DB access layer for the group welcome delivery ledger.
+// It mirrors spaceWelcomeStore (same status machine + CAS discipline) keyed by
+// group_no instead of space_id, and drops the per-recipient `lang` (the group
+// welcome is a single body posted to the channel, not a per-recipient DM).
+//
+// Time discipline: ALL timestamp writes take an application-computed UTC value as
+// a bound parameter (never NOW()).
+type groupWelcomeStore struct {
+	db         *dbr.Session
+	claimOwner string
+}
+
+func newGroupWelcomeStore(db *dbr.Session, claimOwner string) *groupWelcomeStore {
+	return &groupWelcomeStore{db: db, claimOwner: claimOwner}
+}
+
+// upsertPending inserts a pending row for (groupNo, uid) if absent. inserted=true
+// only when a new row was actually created; a duplicate hit reports false so the
+// caller can split enqueue_total vs enqueue_dedup_total. The UNIQUE(group_no,uid)
+// row is the at-most-once authority: leave→rejoin keeps the existing row, so the
+// welcome is posted at most once even though group_member.created_at resets.
+//
+// dueAt is written to next_retry_at so a freshly-enqueued row is held back from
+// the worker until the coalesce window elapses (see enqueue); co-arriving joins
+// thereby collect and are claimed together into one post. On a duplicate the
+// existing row (and its due time) is left untouched — a rejoin never re-arms the
+// window nor resurrects a delivered row.
+func (s *groupWelcomeStore) upsertPending(ctx context.Context, groupNo, uid string, now, dueAt time.Time) (inserted bool, err error) {
+	res, err := s.db.InsertBySql(
+		"INSERT INTO "+groupWelcomeTable+" (group_no, uid, status, attempts, next_retry_at, created_at, updated_at) "+
+			"VALUES (?, ?, ?, 0, ?, ?, ?) ON DUPLICATE KEY UPDATE id = id",
+		groupNo, uid, swStatusPending, dueAt, now, now,
+	).ExecContext(ctx)
+	if err != nil {
+		return false, fmt.Errorf("upsert pending group welcome row: %w", err)
+	}
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return false, fmt.Errorf("read affected rows: %w", err)
+	}
+	return affected > 0, nil
+}
+
+// claimBatch atomically claims up to `limit` due pending rows for groupNo
+// (SELECT ... FOR UPDATE SKIP LOCKED + one UPDATE ... WHERE id IN), leasing them
+// all to this owner. Returns the claimed rows, or nil when none are due. Claiming
+// a batch (not one row) is what lets a burst of joins coalesce into ONE post: the
+// worker locks every due row for the group in a single tx and delivers them
+// together. Each row still transitions independently afterwards (its own CAS), so
+// at-most-once per (group_no, uid) is preserved.
+func (s *groupWelcomeStore) claimBatch(ctx context.Context, groupNo string, limit int, now time.Time) ([]*groupWelcomeRow, error) {
+	if limit <= 0 {
+		return nil, nil
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("begin claim tx: %w", err)
+	}
+	defer tx.RollbackUnlessCommitted()
+
+	var rows []*groupWelcomeRow
+	if _, err = tx.SelectBySql(
+		"SELECT id, group_no, uid, attempts FROM "+groupWelcomeTable+" "+
+			"WHERE group_no=? AND status=? AND (next_retry_at IS NULL OR next_retry_at<=?) "+
+			"ORDER BY id LIMIT ? FOR UPDATE SKIP LOCKED",
+		groupNo, swStatusPending, now, limit,
+	).LoadContext(ctx, &rows); err != nil {
+		return nil, fmt.Errorf("select claimable group welcome rows: %w", err)
+	}
+	if len(rows) == 0 {
+		return nil, nil
+	}
+
+	ids := make([]int64, len(rows))
+	for i, r := range rows {
+		ids[i] = r.ID
+	}
+	if _, err = tx.UpdateBySql(
+		"UPDATE "+groupWelcomeTable+" SET status=?, claim_owner=?, claim_expire_at=?, updated_at=? WHERE id IN ?",
+		swStatusClaimed, s.claimOwner, now.Add(swClaimLease), now, ids,
+	).ExecContext(ctx); err != nil {
+		return nil, fmt.Errorf("mark group welcome rows claimed: %w", err)
+	}
+	if err = tx.Commit(); err != nil {
+		return nil, fmt.Errorf("commit claim tx: %w", err)
+	}
+	return rows, nil
+}
+
+// sweepClaimedAll recycles lease-expired claimed rows across ALL groups back to
+// pending (index-backed by idx_sweep). attempts untouched.
+func (s *groupWelcomeStore) sweepClaimedAll(ctx context.Context, now time.Time) (int64, error) {
+	res, err := s.db.UpdateBySql(
+		"UPDATE "+groupWelcomeTable+" SET status=?, next_retry_at=?, claim_owner=NULL, claim_expire_at=NULL, updated_at=? "+
+			"WHERE status=? AND claim_expire_at IS NOT NULL AND claim_expire_at<=?",
+		swStatusPending, now, now, swStatusClaimed, now,
+	).ExecContext(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("sweep claimed group welcome rows (all groups): %w", err)
+	}
+	return res.RowsAffected()
+}
+
+// sweepDispatchingAll promotes lease-expired dispatching rows across ALL groups
+// to unknown (transport-ambiguous; never auto-retried).
+func (s *groupWelcomeStore) sweepDispatchingAll(ctx context.Context, now time.Time) (int64, error) {
+	res, err := s.db.UpdateBySql(
+		"UPDATE "+groupWelcomeTable+" SET status=?, error_class=?, claim_owner=NULL, claim_expire_at=NULL, updated_at=? "+
+			"WHERE status=? AND claim_expire_at IS NOT NULL AND claim_expire_at<=?",
+		swStatusUnknown, swErrClaimExpired, now, swStatusDispatching, now,
+	).ExecContext(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("sweep dispatching group welcome rows (all groups): %w", err)
+	}
+	return res.RowsAffected()
+}
+
+// cas runs a CAS UPDATE guarded by id + expected status + claim_owner=self.
+func (s *groupWelcomeStore) cas(ctx context.Context, query string, args ...interface{}) (bool, error) {
+	res, err := s.db.UpdateBySql(query, args...).ExecContext(ctx)
+	if err != nil {
+		return false, err
+	}
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+	return affected > 0, nil
+}
+
+// casToDispatching transitions claimed -> dispatching, extending the lease.
+func (s *groupWelcomeStore) casToDispatching(ctx context.Context, id int64, now time.Time) (bool, error) {
+	ok, err := s.cas(ctx,
+		"UPDATE "+groupWelcomeTable+" SET status=?, claim_expire_at=?, updated_at=? "+
+			"WHERE id=? AND status=? AND claim_owner=?",
+		swStatusDispatching, now.Add(swClaimLease), now, id, swStatusClaimed, s.claimOwner,
+	)
+	if err != nil {
+		return false, fmt.Errorf("cas to dispatching: %w", err)
+	}
+	return ok, nil
+}
+
+// casToSent transitions dispatching -> sent, persisting the IM identifiers.
+func (s *groupWelcomeStore) casToSent(ctx context.Context, id int64, messageID int64, clientMsgNo string, now time.Time) (bool, error) {
+	ok, err := s.cas(ctx,
+		"UPDATE "+groupWelcomeTable+" SET status=?, message_id=?, client_msg_no=?, error_class=NULL, updated_at=? "+
+			"WHERE id=? AND status=? AND claim_owner=?",
+		swStatusSent, messageID, clientMsgNo, now, id, swStatusDispatching, s.claimOwner,
+	)
+	if err != nil {
+		return false, fmt.Errorf("cas to sent: %w", err)
+	}
+	return ok, nil
+}
+
+// casToSkipped transitions claimed -> skipped (joiner ineligible at pre-send).
+func (s *groupWelcomeStore) casToSkipped(ctx context.Context, id int64, errClass string, now time.Time) (bool, error) {
+	ok, err := s.cas(ctx,
+		"UPDATE "+groupWelcomeTable+" SET status=?, error_class=?, claim_owner=NULL, claim_expire_at=NULL, updated_at=? "+
+			"WHERE id=? AND status=? AND claim_owner=?",
+		swStatusSkipped, errClass, now, id, swStatusClaimed, s.claimOwner,
+	)
+	if err != nil {
+		return false, fmt.Errorf("cas to skipped: %w", err)
+	}
+	return ok, nil
+}
+
+// casToUnknown transitions dispatching -> unknown (transport-ambiguous).
+func (s *groupWelcomeStore) casToUnknown(ctx context.Context, id int64, errClass string, now time.Time) (bool, error) {
+	ok, err := s.cas(ctx,
+		"UPDATE "+groupWelcomeTable+" SET status=?, error_class=?, claim_owner=NULL, claim_expire_at=NULL, updated_at=? "+
+			"WHERE id=? AND status=? AND claim_owner=?",
+		swStatusUnknown, errClass, now, id, swStatusDispatching, s.claimOwner,
+	)
+	if err != nil {
+		return false, fmt.Errorf("cas to unknown: %w", err)
+	}
+	return ok, nil
+}
+
+// casPreIMFailure is the ONLY place attempts grows: back off to pending, or fail
+// terminally after the 4th consecutive pre-IM failure. CAS guarded by claim_owner.
+func (s *groupWelcomeStore) casPreIMFailure(ctx context.Context, id int64, attempts int, errClass string, now time.Time) (bool, error) {
+	newAttempts := attempts + 1
+	if newAttempts > swMaxPreIMAttempts {
+		ok, err := s.cas(ctx,
+			"UPDATE "+groupWelcomeTable+" SET status=?, attempts=?, error_class=?, claim_owner=NULL, claim_expire_at=NULL, updated_at=? "+
+				"WHERE id=? AND status=? AND claim_owner=?",
+			swStatusFailed, newAttempts, errClass, now, id, swStatusClaimed, s.claimOwner,
+		)
+		if err != nil {
+			return false, fmt.Errorf("cas to failed: %w", err)
+		}
+		return ok, nil
+	}
+	nextRetry := now.Add(swBackoff[newAttempts-1])
+	ok, err := s.cas(ctx,
+		"UPDATE "+groupWelcomeTable+" SET status=?, attempts=?, error_class=?, next_retry_at=?, claim_owner=NULL, claim_expire_at=NULL, updated_at=? "+
+			"WHERE id=? AND status=? AND claim_owner=?",
+		swStatusPending, newAttempts, errClass, nextRetry, now, id, swStatusClaimed, s.claimOwner,
+	)
+	if err != nil {
+		return false, fmt.Errorf("cas pre-IM retry: %w", err)
+	}
+	return ok, nil
+}
+
+// groupPrecheckResult is the outcome of the pre-send joiner re-check.
+type groupPrecheckResult struct {
+	eligible bool
+	errClass string // set when !eligible: human_filter | orphan_member
+	name     string // joiner display name for {member} rendering (set when eligible)
+}
+
+// userNameRow projects the joiner's robot flag + display name.
+type userNameRow struct {
+	Robot int    `db:"robot"`
+	Name  string `db:"name"`
+}
+
+// precheckRecipient re-checks the joiner with a direct DB read (bypassing any
+// cache): the user row must exist (not orphan), must not be a robot, and must not
+// be a system bot. It resolves the joiner's display name for the {member}
+// placeholder. It does NOT require current membership — the public group post is
+// keyed to the first-join event and fires even if the member has since left
+// (task group-welcome-message decision "post-then-leave still fires").
+func (s *groupWelcomeStore) precheckRecipient(ctx context.Context, uid string, isSystemBot func(string) bool) (groupPrecheckResult, error) {
+	if isSystemBot != nil && isSystemBot(uid) {
+		return groupPrecheckResult{eligible: false, errClass: swErrHumanFilter}, nil
+	}
+	var row userNameRow
+	err := s.db.SelectBySql("SELECT robot, name FROM `user` WHERE uid=?", uid).LoadOneContext(ctx, &row)
+	if err != nil {
+		if errors.Is(err, dbr.ErrNotFound) {
+			return groupPrecheckResult{eligible: false, errClass: swErrOrphanMember}, nil
+		}
+		return groupPrecheckResult{}, fmt.Errorf("precheck user: %w", err)
+	}
+	if row.Robot == 1 {
+		return groupPrecheckResult{eligible: false, errClass: swErrHumanFilter}, nil
+	}
+	name := row.Name
+	if name == "" {
+		name = uid // fall back to the uid if the display name is empty
+	}
+	return groupPrecheckResult{eligible: true, name: name}, nil
+}
+
+// firstJoinHumanMember reports whether uid is an active human member of groupNo
+// whose current join (group_member.created_at) is at/after activeFrom. Excludes
+// robots and orphan members (JOIN user). Used by the low-latency event path.
+//
+// NOTE: group_member.created_at is reset on rejoin (unlike space_member), so this
+// gate identifies "currently qualifies as a first-join-window human member"; the
+// ledger UNIQUE(group_no,uid) is what guarantees at-most-once across rejoins.
+//
+// TZ correctness: created_at is a session-wall-clock DATETIME while activeFrom is
+// a UTC instant; compare epoch-to-epoch via UNIX_TIMESTAMP (see the Space
+// firstJoinHumanMember for the full rationale).
+func (s *groupWelcomeStore) firstJoinHumanMember(ctx context.Context, groupNo, uid string, activeFrom time.Time) (bool, error) {
+	var n int
+	err := s.db.SelectBySql(
+		"SELECT COUNT(*) FROM group_member gm "+
+			"JOIN `user` u ON u.uid = gm.uid AND u.robot = 0 "+
+			"WHERE gm.group_no = ? AND gm.uid = ? AND gm.is_deleted = 0 AND gm.status = 1 AND UNIX_TIMESTAMP(gm.created_at) >= ?",
+		groupNo, uid, activeFrom.Unix(),
+	).LoadOneContext(ctx, &n)
+	if err != nil && !errors.Is(err, dbr.ErrNotFound) {
+		return false, fmt.Errorf("group enqueue eligibility check: %w", err)
+	}
+	return n > 0, nil
+}
+
+// reconcileScan returns up to `limit` uids that are active human members of
+// groupNo whose join is at/after activeFrom and still lack a ledger row. This is
+// the periodic catch-up for dropped events, restarts and org/dept auto-add paths
+// that bypass the GroupMemberAdd event.
+func (s *groupWelcomeStore) reconcileScan(ctx context.Context, groupNo string, activeFrom time.Time, systemBots []string, limit int) ([]string, error) {
+	builder := s.db.SelectBySql(
+		"SELECT gm.uid FROM group_member gm "+
+			"JOIN `user` u ON u.uid = gm.uid AND u.robot = 0 "+
+			"LEFT JOIN "+groupWelcomeTable+" d ON d.group_no = gm.group_no AND d.uid = gm.uid "+
+			"WHERE gm.group_no = ? AND gm.is_deleted = 0 AND gm.status = 1 AND UNIX_TIMESTAMP(gm.created_at) >= ? AND d.id IS NULL "+
+			"AND gm.uid NOT IN ? "+
+			"ORDER BY gm.created_at, gm.uid LIMIT ?",
+		groupNo, activeFrom.Unix(), systemBots, limit,
+	)
+	var uids []string
+	if _, err := builder.LoadContext(ctx, &uids); err != nil {
+		return nil, fmt.Errorf("group reconcile scan: %w", err)
+	}
+	return uids, nil
+}
+
+// groupActive reports whether groupNo refers to an existing, non-disbanded group
+// (status = GroupStatusNormal = 1). `group` is a reserved word (backticked).
+func (s *groupWelcomeStore) groupActive(ctx context.Context, groupNo string) (bool, error) {
+	if groupNo == "" {
+		return false, nil
+	}
+	var n int
+	err := s.db.SelectBySql("SELECT COUNT(*) FROM `group` WHERE group_no=? AND status=1", groupNo).LoadOneContext(ctx, &n)
+	if err != nil && !errors.Is(err, dbr.ErrNotFound) {
+		return false, fmt.Errorf("group active check: %w", err)
+	}
+	return n > 0, nil
+}
+
+// countByStatus returns the number of ledger rows for groupNo in the given status.
+func (s *groupWelcomeStore) countByStatus(ctx context.Context, groupNo string, status int) (int64, error) {
+	var n int64
+	err := s.db.SelectBySql(
+		"SELECT COUNT(*) FROM "+groupWelcomeTable+" WHERE group_no=? AND status=?",
+		groupNo, status,
+	).LoadOneContext(ctx, &n)
+	if err != nil && !errors.Is(err, dbr.ErrNotFound) {
+		return 0, err
+	}
+	return n, nil
+}

--- a/modules/notify/group_welcome_db.go
+++ b/modules/notify/group_welcome_db.go
@@ -237,7 +237,7 @@ type userNameRow struct {
 // placeholder. It does NOT require current membership — the public group post is
 // keyed to the first-join event and fires even if the member has since left
 // (task group-welcome-message decision "post-then-leave still fires").
-func (s *groupWelcomeStore) precheckRecipient(ctx context.Context, uid string, isSystemBot func(string) bool) (groupPrecheckResult, error) {
+func (s *groupWelcomeStore) precheckRecipient(ctx context.Context, groupNo, uid string, activeFrom time.Time, isSystemBot func(string) bool) (groupPrecheckResult, error) {
 	if isSystemBot != nil && isSystemBot(uid) {
 		return groupPrecheckResult{eligible: false, errClass: swErrHumanFilter}, nil
 	}
@@ -252,6 +252,28 @@ func (s *groupWelcomeStore) precheckRecipient(ctx context.Context, uid string, i
 	if row.Robot == 1 {
 		return groupPrecheckResult{eligible: false, errClass: swErrHumanFilter}, nil
 	}
+
+	// Re-validate the joiner against the CURRENT config's active_from window: a row
+	// enqueued under an earlier config must not be delivered after an admin moved
+	// active_from forward, or deleted+recreated the config with a later window
+	// (a DELETE does not discard pending rows). We check only the join-time window
+	// (`created_at >= active_from`), NOT current membership — leaving is intentional
+	// ("post-then-leave still fires"), and rejoin dedup stays keyed on the ledger
+	// UNIQUE, not this timestamp. created_at is a session-wall-clock DATETIME while
+	// activeFrom is a UTC instant, so compare epoch-to-epoch via UNIX_TIMESTAMP (see
+	// firstJoinHumanMember).
+	var inWindow int
+	err = s.db.SelectBySql(
+		"SELECT COUNT(*) FROM group_member WHERE group_no=? AND uid=? AND UNIX_TIMESTAMP(created_at) >= ?",
+		groupNo, uid, activeFrom.Unix(),
+	).LoadOneContext(ctx, &inWindow)
+	if err != nil && !errors.Is(err, dbr.ErrNotFound) {
+		return groupPrecheckResult{}, fmt.Errorf("precheck active_from window: %w", err)
+	}
+	if inWindow == 0 {
+		return groupPrecheckResult{eligible: false, errClass: swErrActiveFromMoved}, nil
+	}
+
 	name := row.Name
 	if name == "" {
 		name = uid // fall back to the uid if the display name is empty

--- a/modules/notify/group_welcome_db.go
+++ b/modules/notify/group_welcome_db.go
@@ -218,39 +218,6 @@ func (s *groupWelcomeStore) casPreIMFailure(ctx context.Context, id int64, attem
 	return ok, nil
 }
 
-// casDispatchingRetry transitions dispatching -> pending with backoff (or ->
-// failed after the retry budget), guarded by claim_owner. Used ONLY for a
-// definitively-not-delivered coalesced send (swErrIMRejected — a non-2xx from
-// WuKongIM that posted nothing): re-queuing is at-most-once-safe because the
-// public message never appeared, so the whole batch is re-attempted (re-coalesced)
-// on a later wake instead of being terminal-`unknown`-ed by one transient reject.
-// It mirrors casPreIMFailure's backoff/attempts machine but transitions from
-// `dispatching` (post-send) rather than `claimed` (pre-send).
-func (s *groupWelcomeStore) casDispatchingRetry(ctx context.Context, id int64, attempts int, errClass string, now time.Time) (bool, error) {
-	newAttempts := attempts + 1
-	if newAttempts > swMaxPreIMAttempts {
-		ok, err := s.cas(ctx,
-			"UPDATE "+groupWelcomeTable+" SET status=?, attempts=?, error_class=?, claim_owner=NULL, claim_expire_at=NULL, updated_at=? "+
-				"WHERE id=? AND status=? AND claim_owner=?",
-			swStatusFailed, newAttempts, errClass, now, id, swStatusDispatching, s.claimOwner,
-		)
-		if err != nil {
-			return false, fmt.Errorf("cas dispatching to failed: %w", err)
-		}
-		return ok, nil
-	}
-	nextRetry := now.Add(swBackoff[newAttempts-1])
-	ok, err := s.cas(ctx,
-		"UPDATE "+groupWelcomeTable+" SET status=?, attempts=?, error_class=?, next_retry_at=?, claim_owner=NULL, claim_expire_at=NULL, updated_at=? "+
-			"WHERE id=? AND status=? AND claim_owner=?",
-		swStatusPending, newAttempts, errClass, nextRetry, now, id, swStatusDispatching, s.claimOwner,
-	)
-	if err != nil {
-		return false, fmt.Errorf("cas dispatching retry: %w", err)
-	}
-	return ok, nil
-}
-
 // groupPrecheckResult is the outcome of the pre-send joiner re-check.
 type groupPrecheckResult struct {
 	eligible bool

--- a/modules/notify/group_welcome_db.go
+++ b/modules/notify/group_welcome_db.go
@@ -218,6 +218,39 @@ func (s *groupWelcomeStore) casPreIMFailure(ctx context.Context, id int64, attem
 	return ok, nil
 }
 
+// casDispatchingRetry transitions dispatching -> pending with backoff (or ->
+// failed after the retry budget), guarded by claim_owner. Used ONLY for a
+// definitively-not-delivered coalesced send (swErrIMRejected — a non-2xx from
+// WuKongIM that posted nothing): re-queuing is at-most-once-safe because the
+// public message never appeared, so the whole batch is re-attempted (re-coalesced)
+// on a later wake instead of being terminal-`unknown`-ed by one transient reject.
+// It mirrors casPreIMFailure's backoff/attempts machine but transitions from
+// `dispatching` (post-send) rather than `claimed` (pre-send).
+func (s *groupWelcomeStore) casDispatchingRetry(ctx context.Context, id int64, attempts int, errClass string, now time.Time) (bool, error) {
+	newAttempts := attempts + 1
+	if newAttempts > swMaxPreIMAttempts {
+		ok, err := s.cas(ctx,
+			"UPDATE "+groupWelcomeTable+" SET status=?, attempts=?, error_class=?, claim_owner=NULL, claim_expire_at=NULL, updated_at=? "+
+				"WHERE id=? AND status=? AND claim_owner=?",
+			swStatusFailed, newAttempts, errClass, now, id, swStatusDispatching, s.claimOwner,
+		)
+		if err != nil {
+			return false, fmt.Errorf("cas dispatching to failed: %w", err)
+		}
+		return ok, nil
+	}
+	nextRetry := now.Add(swBackoff[newAttempts-1])
+	ok, err := s.cas(ctx,
+		"UPDATE "+groupWelcomeTable+" SET status=?, attempts=?, error_class=?, next_retry_at=?, claim_owner=NULL, claim_expire_at=NULL, updated_at=? "+
+			"WHERE id=? AND status=? AND claim_owner=?",
+		swStatusPending, newAttempts, errClass, nextRetry, now, id, swStatusDispatching, s.claimOwner,
+	)
+	if err != nil {
+		return false, fmt.Errorf("cas dispatching retry: %w", err)
+	}
+	return ok, nil
+}
+
 // groupPrecheckResult is the outcome of the pre-send joiner re-check.
 type groupPrecheckResult struct {
 	eligible bool

--- a/modules/notify/group_welcome_e2e_test.go
+++ b/modules/notify/group_welcome_e2e_test.go
@@ -1,6 +1,7 @@
 package notify
 
 import (
+	"net/http"
 	"testing"
 	"time"
 
@@ -9,6 +10,23 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// liveWuKongIMReachable probes <APIURL>/health so the e2e SKIPS (not fails) when
+// no live WuKongIM is running. Checking APIURL != "" is not enough: config.New()
+// defaults APIURL to http://127.0.0.1:5001, so the empty-check never triggers and
+// the package would fail hard on a dev box without a live IM.
+func liveWuKongIMReachable(apiURL string) bool {
+	if apiURL == "" {
+		return false
+	}
+	client := &http.Client{Timeout: 2 * time.Second}
+	resp, err := client.Get(apiURL + "/health")
+	if err != nil {
+		return false
+	}
+	defer resp.Body.Close()
+	return resp.StatusCode == http.StatusOK
+}
 
 // TestGroupWelcome_E2E_LiveCoalescedPost drives the FULL group-welcome pipeline
 // against a live WuKongIM (the real sender is NOT stubbed): config + two first-join
@@ -21,8 +39,8 @@ import (
 // green; CI (which provisions WuKongIM) exercises the real wire.
 func TestGroupWelcome_E2E_LiveCoalescedPost(t *testing.T) {
 	ctx := swTestServer(t)
-	if ctx.GetConfig().WuKongIM.APIURL == "" {
-		t.Skip("no live WuKongIM APIURL configured")
+	if !liveWuKongIMReachable(ctx.GetConfig().WuKongIM.APIURL) {
+		t.Skip("no live WuKongIM reachable at APIURL/health — skipping live e2e")
 	}
 
 	const groupNo = "g_e2e"

--- a/modules/notify/group_welcome_e2e_test.go
+++ b/modules/notify/group_welcome_e2e_test.go
@@ -1,0 +1,77 @@
+package notify
+
+import (
+	"testing"
+	"time"
+
+	libcommon "github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGroupWelcome_E2E_LiveCoalescedPost drives the FULL group-welcome pipeline
+// against a live WuKongIM (the real sender is NOT stubbed): config + two first-join
+// members -> event enqueue -> coalesce window -> batch claim -> ONE public post to
+// the group channel -> ledger SENT. It also answers the brief's open question end
+// to end — the fixed `notification` sender posts into a group channel it is not a
+// member of — and proves coalescing by asserting both joiners share one message_id.
+//
+// Skips (does not fail) when no live WuKongIM is configured, so unit-only runs stay
+// green; CI (which provisions WuKongIM) exercises the real wire.
+func TestGroupWelcome_E2E_LiveCoalescedPost(t *testing.T) {
+	ctx := swTestServer(t)
+	if ctx.GetConfig().WuKongIM.APIURL == "" {
+		t.Skip("no live WuKongIM APIURL configured")
+	}
+
+	const groupNo = "g_e2e"
+	af := time.Now().UTC().Add(-time.Hour)
+	gwInsertGroup(t, ctx, groupNo, 1)
+	// Create the group's IM channel with members that do NOT include notification,
+	// so the post exercises "sender is not a group member".
+	require.NoError(t, ctx.IMCreateOrUpdateChannel(&config.ChannelCreateReq{
+		ChannelID:   groupNo,
+		ChannelType: libcommon.ChannelTypeGroup.Uint8(),
+		Subscribers: []string{"e2e_a", "e2e_b"},
+	}))
+	gwInsertUserNamed(t, ctx, "e2e_a", "Alice", 0)
+	gwInsertUserNamed(t, ctx, "e2e_b", "Bob", 0)
+	gwInsertGroupMember(t, ctx, groupNo, "e2e_a", 0, 1, time.Now().UTC())
+	gwInsertGroupMember(t, ctx, groupNo, "e2e_b", 0, 1, time.Now().UTC())
+	gwSetGroupConfig(t, ctx, groupNo, true, af, "欢迎 {member} 入群")
+
+	svc := gwNewService(t, ctx) // master switch ON; real sender (sendFn NOT stubbed)
+
+	// Event path enqueues both members; advance the clock past the coalesce window
+	// so the worker batch-claims them together.
+	clock := time.Now().UTC()
+	svc.now = func() time.Time { return clock }
+	svc.handleMemberJoin(groupNo, "e2e_a")
+	svc.handleMemberJoin(groupNo, "e2e_b")
+	ids := gwPendingIDs(t, ctx, groupNo)
+	require.Len(t, ids, 2, "both first-join members enqueued")
+	clock = clock.Add(time.Minute)
+
+	svc.runWorkerWake(bg())
+
+	sent, _ := svc.store.countByStatus(bg(), groupNo, swStatusSent)
+	assert.EqualValues(t, 2, sent, "both joiners delivered to the live group channel")
+
+	// Coalescing: both rows carry the SAME non-zero message_id => ONE public post.
+	_, midA := gwRowStatus(t, ctx, ids[0])
+	_, midB := gwRowStatus(t, ctx, ids[1])
+	assert.NotZero(t, midA, "live WuKongIM returned a message_id")
+	assert.Equal(t, midA, midB, "both joiners share one message => a single coalesced post")
+}
+
+// gwPendingIDs returns the ledger row ids for groupNo ordered by id (ascending).
+func gwPendingIDs(t *testing.T, ctx *config.Context, groupNo string) []int64 {
+	t.Helper()
+	var ids []int64
+	_, err := ctx.DB().SelectBySql(
+		"SELECT id FROM "+groupWelcomeTable+" WHERE group_no=? ORDER BY id", groupNo,
+	).Load(&ids)
+	require.NoError(t, err)
+	return ids
+}

--- a/modules/notify/group_welcome_model.go
+++ b/modules/notify/group_welcome_model.go
@@ -1,0 +1,46 @@
+package notify
+
+import "time"
+
+// Group new-member welcome delivery ledger — task group-welcome-message.
+//
+// The group welcome mirrors the Space welcome delivery engine but posts a PUBLIC
+// message into the group channel (channel_type=GROUP) instead of a personal DM,
+// and has no platform-global fallback. It reuses the shared status machine /
+// error_class / stage / tunable constants and the notify-local HTTP sender from
+// the space_welcome_* files (same package); only the ledger table, the row
+// projection, and the container-scoped SQL differ.
+
+const groupWelcomeTable = "octo_group_welcome_delivery"
+
+// Coalescing tunables — a burst of joins (a batch invite arrives as ONE
+// GroupMemberAdd event → many pending rows within milliseconds) is delivered as a
+// SINGLE public post naming everyone, instead of one post per joiner. This is the
+// group welcome's answer to bulk-invite spam; the Space welcome (personal DMs) has
+// no such concern and shares none of this.
+const (
+	// groupWelcomeCoalesceWindow holds a freshly-enqueued pending row back from the
+	// worker briefly so co-arriving joins collect before the first claim. New rows
+	// get next_retry_at = enqueue + window; the worker then batch-claims everything
+	// due for the group at once. A few seconds is invisible for a welcome and makes
+	// the "one event, N members" burst reliably coalesce even if the worker happens
+	// to wake mid-insert.
+	groupWelcomeCoalesceWindow = 3 * time.Second
+	// groupWelcomeCoalesceMax bounds ONE coalesced post: at most this many ledger
+	// rows are claimed + delivered together. A larger burst spills into later wakes
+	// (one post per group per wake) rather than building an unbounded message /
+	// transaction — which also naturally rate-limits a single group's posts.
+	groupWelcomeCoalesceMax = 50
+	// groupWelcomeCoalesceNames caps how many joiner names are listed verbatim in
+	// the {member} substitution; beyond it the tail collapses to "…、nameK 等 N 人"
+	// so even a max-size batch stays one short, readable line.
+	groupWelcomeCoalesceNames = 10
+)
+
+// groupWelcomeRow is the minimal claimed-row projection the worker needs.
+type groupWelcomeRow struct {
+	ID       int64  `db:"id"`
+	GroupNo  string `db:"group_no"`
+	UID      string `db:"uid"`
+	Attempts int    `db:"attempts"`
+}

--- a/modules/notify/group_welcome_test.go
+++ b/modules/notify/group_welcome_test.go
@@ -1,0 +1,397 @@
+package notify
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	libcommon "github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-server/modules/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	// Ensure the group migrations (`group` / `group_member`) run in the test DB;
+	// group does not import notify, so this blank import is cycle-free.
+	_ "github.com/Mininglamp-OSS/octo-server/modules/group"
+)
+
+// ---------------------------------------------------------------------------
+// Group welcome test harness (task group-welcome-message)
+// ---------------------------------------------------------------------------
+
+// gwNewService builds a group welcome service with the platform master switch
+// turned ON (the feature ships dark by default, so every delivery test must enable
+// it), reading the same SystemSettings singleton the production wiring uses.
+func gwNewService(t *testing.T, ctx *config.Context) *groupWelcomeService {
+	t.Helper()
+	gwSetGlobalWelcomeEnabled(t, ctx, true)
+	return newGroupWelcomeService(ctx, common.EnsureSystemSettings(ctx), NotifyBotUID(), func() bool { return true })
+}
+
+// gwSetGlobalWelcomeEnabled writes onboarding.group_welcome_enabled and reloads the
+// SystemSettings snapshot the service reads. Each test sets it explicitly so the
+// process-wide singleton is deterministic regardless of test order.
+func gwSetGlobalWelcomeEnabled(t *testing.T, ctx *config.Context, enabled bool) {
+	t.Helper()
+	v := "0"
+	if enabled {
+		v = "1"
+	}
+	_, err := ctx.DB().InsertBySql(
+		"INSERT INTO system_setting (category, key_name, value, value_type, description) "+
+			"VALUES ('onboarding','group_welcome_enabled',?,'bool','') "+
+			"ON DUPLICATE KEY UPDATE value=VALUES(value), value_type=VALUES(value_type)", v,
+	).Exec()
+	require.NoError(t, err)
+	require.NoError(t, common.EnsureSystemSettings(ctx).Reload())
+}
+
+func gwInsertGroup(t *testing.T, ctx *config.Context, groupNo string, status int) {
+	t.Helper()
+	_, err := ctx.DB().InsertBySql(
+		"INSERT INTO `group` (group_no, name, status, creator) VALUES (?, ?, ?, ?)",
+		groupNo, groupNo, status, "creator",
+	).Exec()
+	require.NoError(t, err)
+}
+
+func gwInsertUserNamed(t *testing.T, ctx *config.Context, uid, name string, robot int) {
+	t.Helper()
+	_, err := ctx.DB().InsertBySql(
+		"INSERT INTO `user` (uid, name, short_no, robot) VALUES (?, ?, ?, ?)", uid, name, uid, robot,
+	).Exec()
+	require.NoError(t, err)
+}
+
+func gwInsertGroupMember(t *testing.T, ctx *config.Context, groupNo, uid string, role, status int, createdAt time.Time) {
+	t.Helper()
+	// created_at via FROM_UNIXTIME so UNIX_TIMESTAMP round-trips regardless of the
+	// DB session TZ (mirrors swInsertMember).
+	_, err := ctx.DB().InsertBySql(
+		"INSERT INTO `group_member` (group_no, uid, role, status, is_deleted, robot, created_at, updated_at) "+
+			"VALUES (?, ?, ?, ?, 0, 0, FROM_UNIXTIME(?), FROM_UNIXTIME(?))",
+		groupNo, uid, role, status, createdAt.Unix(), createdAt.Unix(),
+	).Exec()
+	require.NoError(t, err)
+}
+
+func gwSetGroupConfig(t *testing.T, ctx *config.Context, groupNo string, enabled bool, activeFrom time.Time, msg string) {
+	t.Helper()
+	store := common.NewGroupWelcomeConfigStore(ctx.DB())
+	require.NoError(t, store.Upsert(bg(), common.GroupWelcomeConfig{
+		GroupNo:       groupNo,
+		Enabled:       enabled,
+		ActiveFromRaw: activeFrom.UTC().Format(time.RFC3339),
+		Message:       msg,
+		UpdatedBy:     "admin",
+	}, time.Now().UTC()))
+}
+
+func gwInsertGroupLedger(t *testing.T, ctx *config.Context, groupNo, uid string, status int, owner string, claimExpire *time.Time, attempts int) int64 {
+	t.Helper()
+	now := time.Now().UTC()
+	res, err := ctx.DB().InsertBySql(
+		"INSERT INTO "+groupWelcomeTable+" (group_no, uid, status, attempts, claim_owner, claim_expire_at, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+		groupNo, uid, status, attempts, owner, claimExpire, now, now,
+	).Exec()
+	require.NoError(t, err)
+	id, err := res.LastInsertId()
+	require.NoError(t, err)
+	return id
+}
+
+func gwRowStatus(t *testing.T, ctx *config.Context, id int64) (status int, messageID int64) {
+	t.Helper()
+	var row struct {
+		Status    int   `db:"status"`
+		MessageID int64 `db:"message_id"`
+	}
+	err := ctx.DB().SelectBySql(
+		"SELECT status, COALESCE(message_id,0) AS message_id FROM "+groupWelcomeTable+" WHERE id=?", id,
+	).LoadOne(&row)
+	require.NoError(t, err)
+	return row.Status, row.MessageID
+}
+
+func gwCountRows(t *testing.T, ctx *config.Context, groupNo string) int {
+	t.Helper()
+	var n int
+	err := ctx.DB().SelectBySql("SELECT COUNT(*) FROM "+groupWelcomeTable+" WHERE group_no=?", groupNo).LoadOne(&n)
+	require.NoError(t, err)
+	return n
+}
+
+// gwSeedPending seeds n deliverable pending rows (user + active member + ledger)
+// in groupNo, uids disambiguated by offset.
+func gwSeedPending(t *testing.T, ctx *config.Context, groupNo string, n, offset int) {
+	t.Helper()
+	for i := 0; i < n; i++ {
+		uid := fmt.Sprintf("%s_u%04d", groupNo, offset+i)
+		gwInsertUserNamed(t, ctx, uid, uid, 0)
+		gwInsertGroupMember(t, ctx, groupNo, uid, 0, 1, time.Now().UTC())
+		gwInsertGroupLedger(t, ctx, groupNo, uid, swStatusPending, "", nil, 0)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+// TestGroupWelcome_Dispatch_RendersMemberAndPostsToGroupChannel: dispatch posts a
+// PUBLIC group-channel message (channel_type=GROUP, channel_id=group_no) from the
+// notification identity, with the {member} placeholder rendered to the joiner's
+// display name.
+func TestGroupWelcome_Dispatch_RendersMemberAndPostsToGroupChannel(t *testing.T) {
+	ctx := swTestServer(t)
+	af := time.Now().UTC().Add(-time.Hour)
+	gwInsertGroup(t, ctx, "g_1", 1)
+	gwInsertUserNamed(t, ctx, "u_1", "Alice", 0)
+	gwInsertGroupMember(t, ctx, "g_1", "u_1", 0, 1, time.Now().UTC())
+	gwSetGroupConfig(t, ctx, "g_1", true, af, "欢迎 {member} 入群!")
+
+	svc := gwNewService(t, ctx)
+	var gotReq *config.MsgSendReq
+	svc.sendFn = func(_ context.Context, req *config.MsgSendReq) (*swSendResult, error) {
+		gotReq = req
+		return &swSendResult{messageID: 777, clientMsgNo: "c1"}, nil
+	}
+
+	cfg, err := svc.effectiveConfig(bg(), "g_1")
+	require.NoError(t, err)
+	id := gwInsertGroupLedger(t, ctx, "g_1", "u_1", swStatusClaimed, svc.store.claimOwner, ptrTime(time.Now().UTC().Add(time.Minute)), 0)
+	svc.dispatch(bg(), cfg, &groupWelcomeRow{ID: id, GroupNo: "g_1", UID: "u_1"})
+
+	st, messageID := gwRowStatus(t, ctx, id)
+	assert.Equal(t, swStatusSent, st)
+	assert.EqualValues(t, 777, messageID)
+	assert.EqualValues(t, 1, svc.metrics.sendSuccess.Load())
+
+	require.NotNil(t, gotReq)
+	assert.Equal(t, "notification", gotReq.FromUID, "server-chosen sender")
+	assert.Equal(t, "g_1", gotReq.ChannelID, "posts into the group channel")
+	assert.EqualValues(t, libcommon.ChannelTypeGroup.Uint8(), gotReq.ChannelType, "channel_type=GROUP (public)")
+	assert.EqualValues(t, 1, gotReq.Header.RedDot)
+	assert.Empty(t, gotReq.Subscribers, "public — not scoped to a subscriber")
+	assert.Contains(t, string(gotReq.Payload), "欢迎 Alice 入群!", "{member} rendered to the joiner's display name")
+	assert.NotContains(t, string(gotReq.Payload), "{member}", "no unrendered placeholder leaks")
+}
+
+// TestGroupWelcome_MultiGroupDelivery_NoCrossing: two groups each with an enabled
+// config welcome their own first-join member; each posts to ITS OWN channel with
+// ITS OWN body + its own member's name — no cross-group leakage.
+func TestGroupWelcome_MultiGroupDelivery_NoCrossing(t *testing.T) {
+	ctx := swTestServer(t)
+	af := time.Now().UTC().Add(-time.Hour)
+	gwInsertGroup(t, ctx, "g_a", 1)
+	gwInsertGroup(t, ctx, "g_b", 1)
+	gwInsertUserNamed(t, ctx, "ua", "Aaa", 0)
+	gwInsertUserNamed(t, ctx, "ub", "Bbb", 0)
+	gwInsertGroupMember(t, ctx, "g_a", "ua", 0, 1, time.Now().UTC())
+	gwInsertGroupMember(t, ctx, "g_b", "ub", 0, 1, time.Now().UTC())
+	gwSetGroupConfig(t, ctx, "g_a", true, af, "welcome {member} to A")
+	gwSetGroupConfig(t, ctx, "g_b", true, af, "welcome {member} to B")
+
+	svc := gwNewService(t, ctx)
+	// Drive an explicit clock: enqueue holds each row until now+coalesceWindow, so
+	// advance time between reconcile (enqueue) and the worker so the rows are due.
+	clock := time.Now().UTC()
+	svc.now = func() time.Time { return clock }
+	got := map[string]string{} // channel_id -> payload
+	svc.sendFn = func(_ context.Context, req *config.MsgSendReq) (*swSendResult, error) {
+		got[req.ChannelID] = string(req.Payload)
+		return &swSendResult{messageID: 1, clientMsgNo: "x"}, nil
+	}
+
+	svc.runReconcileOnce(bg())     // enqueue rows due at clock + coalesceWindow
+	clock = clock.Add(time.Minute) // time passes; the coalesce window has elapsed
+	svc.runWorkerWake(bg())
+
+	sentA, _ := svc.store.countByStatus(bg(), "g_a", swStatusSent)
+	sentB, _ := svc.store.countByStatus(bg(), "g_b", swStatusSent)
+	assert.EqualValues(t, 1, sentA, "g_a member welcomed exactly once")
+	assert.EqualValues(t, 1, sentB, "g_b member welcomed exactly once")
+	assert.Contains(t, got["g_a"], "welcome Aaa to A")
+	assert.Contains(t, got["g_b"], "welcome Bbb to B")
+	assert.NotContains(t, got["g_a"], "to B", "no cross-group body leakage")
+	assert.NotContains(t, got["g_a"], "Bbb", "no cross-group member leakage")
+}
+
+// TestGroupWelcome_FirstJoin_AtMostOnce: the event path enqueues exactly one row
+// for a first-join human member, and a repeated join (dedup / rejoin) does not add
+// another — the ledger UNIQUE(group_no,uid) is the at-most-once authority even
+// though group_member.created_at resets on rejoin.
+func TestGroupWelcome_FirstJoin_AtMostOnce(t *testing.T) {
+	ctx := swTestServer(t)
+	af := time.Now().UTC().Add(-time.Hour)
+	gwInsertGroup(t, ctx, "g_1", 1)
+	gwInsertUserNamed(t, ctx, "u_1", "Alice", 0)
+	gwInsertGroupMember(t, ctx, "g_1", "u_1", 0, 1, time.Now().UTC())
+	gwSetGroupConfig(t, ctx, "g_1", true, af, "hi {member}")
+
+	svc := gwNewService(t, ctx)
+	svc.handleMemberJoin("g_1", "u_1")
+	assert.Equal(t, 1, gwCountRows(t, ctx, "g_1"), "first join enqueues one row")
+	svc.handleMemberJoin("g_1", "u_1")
+	assert.Equal(t, 1, gwCountRows(t, ctx, "g_1"), "repeated join / rejoin does not re-enqueue (ledger dedup)")
+}
+
+// TestGroupWelcome_HandleMemberJoin_Filters: a robot joiner, a member of a group
+// with no enabled config, and a member joined before active_from each enqueue
+// nothing.
+func TestGroupWelcome_HandleMemberJoin_Filters(t *testing.T) {
+	ctx := swTestServer(t)
+	af := time.Now().UTC()
+	gwInsertGroup(t, ctx, "g_on", 1)
+	gwInsertGroup(t, ctx, "g_off", 1)
+	gwSetGroupConfig(t, ctx, "g_on", true, af, "hi {member}")
+	// g_off has no config.
+
+	// Robot joiner of the enabled group -> filtered.
+	gwInsertUserNamed(t, ctx, "bot", "bot", 1)
+	gwInsertGroupMember(t, ctx, "g_on", "bot", 0, 1, time.Now().UTC())
+	// Human who joined BEFORE active_from -> filtered.
+	gwInsertUserNamed(t, ctx, "early", "Early", 0)
+	gwInsertGroupMember(t, ctx, "g_on", "early", 0, 1, af.Add(-time.Hour))
+	// Human in the disabled/absent-config group -> filtered.
+	gwInsertUserNamed(t, ctx, "uoff", "Off", 0)
+	gwInsertGroupMember(t, ctx, "g_off", "uoff", 0, 1, time.Now().UTC())
+
+	svc := gwNewService(t, ctx)
+	svc.handleMemberJoin("g_on", "bot")
+	svc.handleMemberJoin("g_on", "early")
+	svc.handleMemberJoin("g_off", "uoff")
+
+	assert.Equal(t, 0, gwCountRows(t, ctx, "g_on"), "robot + pre-active_from enqueue nothing")
+	assert.Equal(t, 0, gwCountRows(t, ctx, "g_off"), "group without an enabled config enqueues nothing")
+}
+
+// TestGroupWelcome_Worker_CoalesceAndFairness: a single wake delivers ONE coalesced
+// post per group. g_a's burst exceeds groupWelcomeCoalesceMax so it is capped to
+// one batch (tail spills to a later wake), and — crucially — g_b is served in the
+// SAME wake rather than starved behind g_a's larger backlog.
+func TestGroupWelcome_Worker_CoalesceAndFairness(t *testing.T) {
+	ctx := swTestServer(t)
+	af := time.Now().UTC().Add(-time.Hour)
+	gwInsertGroup(t, ctx, "g_a", 1)
+	gwInsertGroup(t, ctx, "g_b", 1)
+	gwSetGroupConfig(t, ctx, "g_a", true, af, "A {member}")
+	gwSetGroupConfig(t, ctx, "g_b", true, af, "B {member}")
+
+	svc := gwNewService(t, ctx)
+	posts := map[string]int{} // channel_id -> number of posts
+	svc.sendFn = func(_ context.Context, req *config.MsgSendReq) (*swSendResult, error) {
+		posts[req.ChannelID]++
+		return &swSendResult{messageID: 1, clientMsgNo: "x"}, nil
+	}
+
+	gwSeedPending(t, ctx, "g_a", groupWelcomeCoalesceMax+5, 0) // exceeds one coalesced batch
+	gwSeedPending(t, ctx, "g_b", 3, 0)
+
+	svc.runWorkerWake(bg())
+
+	sentA, _ := svc.store.countByStatus(bg(), "g_a", swStatusSent)
+	sentB, _ := svc.store.countByStatus(bg(), "g_b", swStatusSent)
+	assert.EqualValues(t, groupWelcomeCoalesceMax, sentA, "g_a capped to one coalesced batch per wake")
+	assert.EqualValues(t, 3, sentB, "g_b served in the same wake, not starved behind g_a's backlog")
+	assert.Equal(t, 1, posts["g_a"], "g_a's burst is ONE public post, not many")
+	assert.Equal(t, 1, posts["g_b"], "g_b's members are ONE public post")
+}
+
+// TestGroupWelcome_Coalesce_BurstBecomesOnePost: several members due at once for a
+// group are delivered as a SINGLE post whose {member} renders to the joined name
+// list — the anti-spam guarantee for a batch invite.
+func TestGroupWelcome_Coalesce_BurstBecomesOnePost(t *testing.T) {
+	ctx := swTestServer(t)
+	af := time.Now().UTC().Add(-time.Hour)
+	gwInsertGroup(t, ctx, "g_1", 1)
+	gwSetGroupConfig(t, ctx, "g_1", true, af, "欢迎 {member} 入群")
+	for _, name := range []string{"Alice", "Bob", "Carol"} {
+		gwInsertUserNamed(t, ctx, name, name, 0)
+		gwInsertGroupMember(t, ctx, "g_1", name, 0, 1, time.Now().UTC())
+		gwInsertGroupLedger(t, ctx, "g_1", name, swStatusPending, "", nil, 0)
+	}
+
+	svc := gwNewService(t, ctx)
+	var payloads []string
+	svc.sendFn = func(_ context.Context, req *config.MsgSendReq) (*swSendResult, error) {
+		payloads = append(payloads, string(req.Payload))
+		return &swSendResult{messageID: 1, clientMsgNo: "x"}, nil
+	}
+
+	svc.runWorkerWake(bg())
+
+	require.Len(t, payloads, 1, "a burst of joins is ONE coalesced post, not one per joiner")
+	assert.Contains(t, payloads[0], "欢迎 Alice、Bob、Carol 入群", "{member} renders to the joined name list")
+	sent, _ := svc.store.countByStatus(bg(), "g_1", swStatusSent)
+	assert.EqualValues(t, 3, sent, "every joiner in the batch is marked sent (at-most-once each)")
+}
+
+// TestRenderGroupWelcomeNameList pins the {member} name-list rendering: small
+// batches list every name; a large batch collapses the tail to "… 等 N 人".
+func TestRenderGroupWelcomeNameList(t *testing.T) {
+	assert.Equal(t, "", renderGroupWelcomeNameList(nil))
+	assert.Equal(t, "Alice", renderGroupWelcomeNameList([]string{"Alice"}))
+	assert.Equal(t, "Alice、Bob", renderGroupWelcomeNameList([]string{"Alice", "Bob"}))
+
+	names := make([]string, groupWelcomeCoalesceNames+2)
+	for i := range names {
+		names[i] = fmt.Sprintf("u%d", i)
+	}
+	got := renderGroupWelcomeNameList(names)
+	want := strings.Join(names[:groupWelcomeCoalesceNames], "、") + fmt.Sprintf(" 等 %d 人", len(names))
+	assert.Equal(t, want, got, "overflow lists the first K names then the total count")
+}
+
+// TestGroupWelcome_GlobalSwitch_Off: with the platform master switch off the event
+// path enqueues nothing and the worker posts nothing, even for an otherwise
+// deliverable, enabled per-group config.
+func TestGroupWelcome_GlobalSwitch_Off(t *testing.T) {
+	ctx := swTestServer(t)
+	af := time.Now().UTC().Add(-time.Hour)
+	gwInsertGroup(t, ctx, "g_1", 1)
+	gwInsertUserNamed(t, ctx, "u_1", "Alice", 0)
+	gwInsertGroupMember(t, ctx, "g_1", "u_1", 0, 1, time.Now().UTC())
+	gwSetGroupConfig(t, ctx, "g_1", true, af, "hi {member}")
+
+	svc := gwNewService(t, ctx)              // switch ON
+	gwSetGlobalWelcomeEnabled(t, ctx, false) // now flip the master switch OFF
+	sent := false
+	svc.sendFn = func(_ context.Context, _ *config.MsgSendReq) (*swSendResult, error) {
+		sent = true
+		return &swSendResult{messageID: 1, clientMsgNo: "x"}, nil
+	}
+
+	// Event path: no enqueue while dark.
+	svc.handleMemberJoin("g_1", "u_1")
+	assert.Equal(t, 0, gwCountRows(t, ctx, "g_1"), "master off -> event path enqueues nothing")
+
+	// Worker: a pre-seeded pending row is not posted while dark.
+	id := gwInsertGroupLedger(t, ctx, "g_1", "u_1", swStatusPending, "", nil, 0)
+	svc.runWorkerWake(bg())
+	assert.False(t, sent, "master off -> worker posts nothing")
+	st, _ := gwRowStatus(t, ctx, id)
+	assert.Equal(t, swStatusPending, st, "the pending row is left untouched (delivered when re-enabled)")
+}
+
+// TestGroupWelcome_SweepAll_CrossGroup: lease-expired claimed rows in different
+// groups are all reclaimed by one cross-group sweep.
+func TestGroupWelcome_SweepAll_CrossGroup(t *testing.T) {
+	ctx := swTestServer(t)
+	gwInsertGroup(t, ctx, "g_a", 1)
+	gwInsertGroup(t, ctx, "g_b", 1)
+	svc := gwNewService(t, ctx)
+
+	expired := time.Now().UTC().Add(-time.Minute)
+	idA := gwInsertGroupLedger(t, ctx, "g_a", "ua", swStatusClaimed, "dead-owner", &expired, 0)
+	idB := gwInsertGroupLedger(t, ctx, "g_b", "ub", swStatusClaimed, "dead-owner", &expired, 0)
+
+	svc.sweepAll(bg())
+
+	stA, _ := gwRowStatus(t, ctx, idA)
+	stB, _ := gwRowStatus(t, ctx, idB)
+	assert.Equal(t, swStatusPending, stA, "lease-expired claimed row in g_a reclaimed")
+	assert.Equal(t, swStatusPending, stB, "lease-expired claimed row in g_b reclaimed")
+}

--- a/modules/notify/group_welcome_test.go
+++ b/modules/notify/group_welcome_test.go
@@ -6,9 +6,12 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	libcommon "github.com/Mininglamp-OSS/octo-lib/common"
 	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
 	"github.com/Mininglamp-OSS/octo-server/modules/common"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -394,4 +397,354 @@ func TestGroupWelcome_SweepAll_CrossGroup(t *testing.T) {
 	stB, _ := gwRowStatus(t, ctx, idB)
 	assert.Equal(t, swStatusPending, stA, "lease-expired claimed row in g_a reclaimed")
 	assert.Equal(t, swStatusPending, stB, "lease-expired claimed row in g_b reclaimed")
+}
+
+// ---------------------------------------------------------------------------
+// Review-hardening coverage (PR #655)
+// ---------------------------------------------------------------------------
+
+// gwRowFull returns status, attempts and error_class for a ledger row.
+func gwRowFull(t *testing.T, ctx *config.Context, id int64) (status, attempts int, errClass string) {
+	t.Helper()
+	var row struct {
+		Status   int    `db:"status"`
+		Attempts int    `db:"attempts"`
+		ErrClass string `db:"error_class"`
+	}
+	err := ctx.DB().SelectBySql(
+		"SELECT status, attempts, COALESCE(error_class,'') AS error_class FROM "+groupWelcomeTable+" WHERE id=?", id,
+	).LoadOne(&row)
+	require.NoError(t, err)
+	return row.Status, row.Attempts, row.ErrClass
+}
+
+func gwSetMemberLeft(t *testing.T, ctx *config.Context, groupNo, uid string) {
+	t.Helper()
+	_, err := ctx.DB().UpdateBySql("UPDATE `group_member` SET is_deleted=1 WHERE group_no=? AND uid=?", groupNo, uid).Exec()
+	require.NoError(t, err)
+}
+
+func gwSetMemberRejoined(t *testing.T, ctx *config.Context, groupNo, uid string, createdAt time.Time) {
+	t.Helper()
+	_, err := ctx.DB().UpdateBySql(
+		"UPDATE `group_member` SET is_deleted=0, created_at=FROM_UNIXTIME(?) WHERE group_no=? AND uid=?",
+		createdAt.Unix(), groupNo, uid,
+	).Exec()
+	require.NoError(t, err)
+}
+
+func gwWaitRows(t *testing.T, ctx *config.Context, groupNo string, want int) {
+	t.Helper()
+	for i := 0; i < 100; i++ {
+		if gwCountRows(t, ctx, groupNo) >= want {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	require.Equal(t, want, gwCountRows(t, ctx, groupNo), "expected %d rows for %s", want, groupNo)
+}
+
+// TestGroupWelcome_Coalesce_HoldsBackUntilWindow: a freshly-enqueued row is NOT
+// claimable until now+coalesceWindow (guards the hold-back that makes bursts
+// coalesce). Uses a whole-second clock so MySQL DATETIME(0) rounding cannot mask it.
+func TestGroupWelcome_Coalesce_HoldsBackUntilWindow(t *testing.T) {
+	ctx := swTestServer(t)
+	af := time.Now().UTC().Add(-time.Hour)
+	gwInsertGroup(t, ctx, "g_1", 1)
+	gwInsertUserNamed(t, ctx, "u_1", "Alice", 0)
+	gwInsertGroupMember(t, ctx, "g_1", "u_1", 0, 1, time.Now().UTC())
+	gwSetGroupConfig(t, ctx, "g_1", true, af, "hi {member}")
+
+	svc := gwNewService(t, ctx)
+	clock := time.Now().UTC().Truncate(time.Second)
+	svc.now = func() time.Time { return clock }
+	posts := 0
+	svc.sendFn = func(_ context.Context, _ *config.MsgSendReq) (*swSendResult, error) {
+		posts++
+		return &swSendResult{messageID: 1, clientMsgNo: "x"}, nil
+	}
+
+	svc.handleMemberJoin("g_1", "u_1") // enqueue, due at clock+coalesceWindow
+	svc.runWorkerWake(bg())            // same clock: not yet due
+	assert.Equal(t, 0, posts, "row held back until the coalesce window elapses")
+	sent, _ := svc.store.countByStatus(bg(), "g_1", swStatusSent)
+	assert.EqualValues(t, 0, sent)
+
+	clock = clock.Add(groupWelcomeCoalesceWindow + time.Second) // past the window
+	svc.runWorkerWake(bg())
+	assert.Equal(t, 1, posts, "claimable once the window has elapsed")
+	sent, _ = svc.store.countByStatus(bg(), "g_1", swStatusSent)
+	assert.EqualValues(t, 1, sent)
+}
+
+// TestGroupWelcome_LeaveRejoin_NoRepost: a full deliver → leave → rejoin (fresh
+// created_at) cycle re-posts NOTHING — the ledger UNIQUE(group_no,uid), not the
+// reset group_member.created_at, is the at-most-once authority.
+func TestGroupWelcome_LeaveRejoin_NoRepost(t *testing.T) {
+	ctx := swTestServer(t)
+	af := time.Now().UTC().Add(-time.Hour)
+	gwInsertGroup(t, ctx, "g_1", 1)
+	gwInsertUserNamed(t, ctx, "u_1", "Alice", 0)
+	gwInsertGroupMember(t, ctx, "g_1", "u_1", 0, 1, time.Now().UTC())
+	gwSetGroupConfig(t, ctx, "g_1", true, af, "hi {member}")
+
+	svc := gwNewService(t, ctx)
+	clock := time.Now().UTC().Truncate(time.Second)
+	svc.now = func() time.Time { return clock }
+	posts := 0
+	svc.sendFn = func(_ context.Context, _ *config.MsgSendReq) (*swSendResult, error) {
+		posts++
+		return &swSendResult{messageID: 1, clientMsgNo: "x"}, nil
+	}
+
+	svc.handleMemberJoin("g_1", "u_1")
+	clock = clock.Add(time.Minute)
+	svc.runWorkerWake(bg())
+	require.Equal(t, 1, posts)
+	ids := gwPendingIDs(t, ctx, "g_1")
+	require.Len(t, ids, 1)
+	st, _ := gwRowStatus(t, ctx, ids[0])
+	require.Equal(t, swStatusSent, st)
+
+	// Leave, then rejoin with a fresh created_at.
+	gwSetMemberLeft(t, ctx, "g_1", "u_1")
+	clock = clock.Add(time.Minute)
+	gwSetMemberRejoined(t, ctx, "g_1", "u_1", clock)
+
+	svc.handleMemberJoin("g_1", "u_1") // event path on rejoin
+	svc.runReconcileOnce(bg())         // reconciler catch-up
+	clock = clock.Add(time.Minute)
+	svc.runWorkerWake(bg())
+
+	assert.Equal(t, 1, posts, "rejoin does not re-post")
+	assert.Equal(t, 1, gwCountRows(t, ctx, "g_1"), "still exactly one ledger row")
+	st, _ = gwRowStatus(t, ctx, ids[0])
+	assert.Equal(t, swStatusSent, st, "the row stays SENT across leave/rejoin")
+}
+
+// TestGroupWelcome_HandleMemberJoinBatch_FanOutAndFilters: one batch call resolves
+// the config once and enqueues only the eligible humans (robot / pre-active_from /
+// system-bot / empty uid all filtered).
+func TestGroupWelcome_HandleMemberJoinBatch_FanOutAndFilters(t *testing.T) {
+	ctx := swTestServer(t)
+	af := time.Now().UTC()
+	gwInsertGroup(t, ctx, "g_1", 1)
+	gwSetGroupConfig(t, ctx, "g_1", true, af, "hi {member}")
+	gwInsertUserNamed(t, ctx, "h1", "H1", 0)
+	gwInsertGroupMember(t, ctx, "g_1", "h1", 0, 1, time.Now().UTC())
+	gwInsertUserNamed(t, ctx, "h2", "H2", 0)
+	gwInsertGroupMember(t, ctx, "g_1", "h2", 0, 1, time.Now().UTC())
+	gwInsertUserNamed(t, ctx, "bot", "bot", 1)
+	gwInsertGroupMember(t, ctx, "g_1", "bot", 0, 1, time.Now().UTC())
+	gwInsertUserNamed(t, ctx, "early", "E", 0)
+	gwInsertGroupMember(t, ctx, "g_1", "early", 0, 1, af.Add(-time.Hour))
+
+	svc := gwNewService(t, ctx)
+	svc.handleMemberJoinBatch("g_1", []string{"h1", "h2", "bot", "early", NotifyBotUID(), ""})
+	assert.Equal(t, 2, gwCountRows(t, ctx, "g_1"), "only the two eligible humans from the batch are enqueued")
+}
+
+// TestGroupWelcome_Event_ParsesFansOutAndCommits: the production listener entry
+// (JSON parse → fan-out → commit), driven through the real EventPool.
+func TestGroupWelcome_Event_ParsesFansOutAndCommits(t *testing.T) {
+	ctx := swTestServer(t)
+	af := time.Now().UTC().Add(-time.Hour)
+	gwInsertGroup(t, ctx, "g_1", 1)
+	gwInsertUserNamed(t, ctx, "u_1", "A", 0)
+	gwInsertGroupMember(t, ctx, "g_1", "u_1", 0, 1, time.Now().UTC())
+	gwInsertUserNamed(t, ctx, "u_2", "B", 0)
+	gwInsertGroupMember(t, ctx, "g_1", "u_2", 0, 1, time.Now().UTC())
+	gwSetGroupConfig(t, ctx, "g_1", true, af, "hi {member}")
+
+	svc := gwNewService(t, ctx)
+	n := &Notify{ctx: ctx, groupWelcome: svc, Log: log.NewTLog("gwtest")}
+
+	data := []byte(util.ToJson(config.MsgGroupMemberAddReq{
+		GroupNo: "g_1", Members: []*config.UserBaseVo{{UID: "u_1"}, {UID: "u_2"}},
+	}))
+	done := make(chan error, 1)
+	n.handleGroupMemberAddEvent(data, func(err error) { done <- err })
+	select {
+	case err := <-done:
+		require.NoError(t, err, "listener commits nil")
+	case <-time.After(3 * time.Second):
+		t.Fatal("GroupMemberAdd event not committed")
+	}
+	gwWaitRows(t, ctx, "g_1", 2)
+
+	// Malformed JSON still commits and does not crash / enqueue.
+	done2 := make(chan error, 1)
+	n.handleGroupMemberAddEvent([]byte("not json"), func(err error) { done2 <- err })
+	select {
+	case <-done2:
+	case <-time.After(3 * time.Second):
+		t.Fatal("malformed event not committed")
+	}
+}
+
+// TestGroupWelcome_Dispatch_SendTimeout_Unknown: an ambiguous send error
+// (timeout) terminals the row to `unknown` and is NEVER auto-retried.
+func TestGroupWelcome_Dispatch_SendTimeout_Unknown(t *testing.T) {
+	ctx := swTestServer(t)
+	af := time.Now().UTC().Add(-time.Hour)
+	gwInsertGroup(t, ctx, "g_1", 1)
+	gwInsertUserNamed(t, ctx, "u_1", "A", 0)
+	gwInsertGroupMember(t, ctx, "g_1", "u_1", 0, 1, time.Now().UTC())
+	gwSetGroupConfig(t, ctx, "g_1", true, af, "hi {member}")
+	id := gwInsertGroupLedger(t, ctx, "g_1", "u_1", swStatusPending, "", nil, 0)
+
+	svc := gwNewService(t, ctx)
+	calls := 0
+	svc.sendFn = func(_ context.Context, _ *config.MsgSendReq) (*swSendResult, error) {
+		calls++
+		return nil, &swSendError{class: swErrIMTimeout}
+	}
+	svc.runWorkerWake(bg())
+	st, _, ec := gwRowFull(t, ctx, id)
+	assert.Equal(t, swStatusUnknown, st, "ambiguous timeout -> unknown (terminal)")
+	assert.Equal(t, swErrIMTimeout, ec)
+	svc.runWorkerWake(bg())
+	assert.Equal(t, 1, calls, "unknown is never re-sent (avoids public double-post)")
+}
+
+// TestGroupWelcome_Dispatch_SendRejected_RetriesThenDelivers: a definitive reject
+// (non-2xx = nothing posted) re-queues with backoff and is delivered on a later
+// wake — exactly once, no double post.
+func TestGroupWelcome_Dispatch_SendRejected_RetriesThenDelivers(t *testing.T) {
+	ctx := swTestServer(t)
+	af := time.Now().UTC().Add(-time.Hour)
+	gwInsertGroup(t, ctx, "g_1", 1)
+	gwInsertUserNamed(t, ctx, "u_1", "A", 0)
+	gwInsertGroupMember(t, ctx, "g_1", "u_1", 0, 1, time.Now().UTC())
+	gwSetGroupConfig(t, ctx, "g_1", true, af, "hi {member}")
+	id := gwInsertGroupLedger(t, ctx, "g_1", "u_1", swStatusPending, "", nil, 0)
+
+	svc := gwNewService(t, ctx)
+	clock := time.Now().UTC().Truncate(time.Second)
+	svc.now = func() time.Time { return clock }
+	okSends, rejected := 0, false
+	svc.sendFn = func(_ context.Context, _ *config.MsgSendReq) (*swSendResult, error) {
+		if !rejected {
+			rejected = true
+			return nil, &swSendError{class: swErrIMRejected}
+		}
+		okSends++
+		return &swSendResult{messageID: 9, clientMsgNo: "x"}, nil
+	}
+
+	svc.runWorkerWake(bg()) // wake 1: rejected -> pending backoff
+	st, attempts, ec := gwRowFull(t, ctx, id)
+	assert.Equal(t, swStatusPending, st, "definitive reject -> retryable pending")
+	assert.Equal(t, 1, attempts)
+	assert.Equal(t, swErrIMRejected, ec)
+	assert.Equal(t, 0, okSends, "nothing posted on the rejected attempt")
+
+	clock = clock.Add(swBackoff[0] + time.Second) // past the retry backoff
+	svc.runWorkerWake(bg())                       // wake 2: re-claimed and delivered
+	st, _, _ = gwRowFull(t, ctx, id)
+	assert.Equal(t, swStatusSent, st, "retried post succeeds")
+	assert.Equal(t, 1, okSends, "delivered exactly once")
+}
+
+// TestGroupWelcome_Dispatch_OrphanJoiner_Skipped: a joiner with no user row is
+// skipped at pre-send re-check and never posted.
+func TestGroupWelcome_Dispatch_OrphanJoiner_Skipped(t *testing.T) {
+	ctx := swTestServer(t)
+	af := time.Now().UTC().Add(-time.Hour)
+	gwInsertGroup(t, ctx, "g_1", 1)
+	gwSetGroupConfig(t, ctx, "g_1", true, af, "hi {member}")
+	id := gwInsertGroupLedger(t, ctx, "g_1", "ghost", swStatusPending, "", nil, 0)
+
+	svc := gwNewService(t, ctx)
+	sent := false
+	svc.sendFn = func(_ context.Context, _ *config.MsgSendReq) (*swSendResult, error) {
+		sent = true
+		return &swSendResult{messageID: 1}, nil
+	}
+	svc.runWorkerWake(bg())
+	st, _, ec := gwRowFull(t, ctx, id)
+	assert.Equal(t, swStatusSkipped, st, "orphan joiner -> skipped")
+	assert.Equal(t, swErrOrphanMember, ec)
+	assert.False(t, sent, "no post for an ineligible joiner")
+}
+
+// TestGroupWelcome_SweepAll_DispatchingToUnknown: a lease-expired dispatching row
+// is promoted to unknown (transport-ambiguous) by the cross-group sweep.
+func TestGroupWelcome_SweepAll_DispatchingToUnknown(t *testing.T) {
+	ctx := swTestServer(t)
+	gwInsertGroup(t, ctx, "g_1", 1)
+	svc := gwNewService(t, ctx)
+	past := time.Now().UTC().Add(-time.Minute)
+	id := gwInsertGroupLedger(t, ctx, "g_1", "u_1", swStatusDispatching, "dead", &past, 0)
+	svc.sweepAll(bg())
+	st, _, ec := gwRowFull(t, ctx, id)
+	assert.Equal(t, swStatusUnknown, st, "lease-expired dispatching row -> unknown")
+	assert.Equal(t, swErrClaimExpired, ec)
+}
+
+// TestGroupWelcome_HandleMemberJoin_SystemBotExcluded: a system-bot uid enqueues
+// nothing even though the group's config is enabled and it is an active member.
+func TestGroupWelcome_HandleMemberJoin_SystemBotExcluded(t *testing.T) {
+	ctx := swTestServer(t)
+	af := time.Now().UTC().Add(-time.Hour)
+	gwInsertGroup(t, ctx, "g_1", 1)
+	gwSetGroupConfig(t, ctx, "g_1", true, af, "hi {member}")
+	gwInsertGroupMember(t, ctx, "g_1", NotifyBotUID(), 0, 1, time.Now().UTC())
+	svc := gwNewService(t, ctx)
+	svc.handleMemberJoin("g_1", NotifyBotUID())
+	assert.Equal(t, 0, gwCountRows(t, ctx, "g_1"), "system-bot joiner is excluded")
+}
+
+// TestGroupWelcome_ActiveFromBoundary_Inclusive: created_at == active_from is
+// eligible (>=); one second before is not.
+func TestGroupWelcome_ActiveFromBoundary_Inclusive(t *testing.T) {
+	ctx := swTestServer(t)
+	af := time.Now().UTC().Truncate(time.Second)
+	gwInsertGroup(t, ctx, "g_1", 1)
+	gwSetGroupConfig(t, ctx, "g_1", true, af, "hi {member}")
+	gwInsertUserNamed(t, ctx, "onedge", "Edge", 0)
+	gwInsertGroupMember(t, ctx, "g_1", "onedge", 0, 1, af) // exactly at active_from
+	gwInsertUserNamed(t, ctx, "before", "Before", 0)
+	gwInsertGroupMember(t, ctx, "g_1", "before", 0, 1, af.Add(-time.Second)) // 1s before
+
+	svc := gwNewService(t, ctx)
+	svc.handleMemberJoin("g_1", "onedge")
+	svc.handleMemberJoin("g_1", "before")
+	assert.Equal(t, 1, gwCountRows(t, ctx, "g_1"), "created_at == active_from eligible; 1s before excluded")
+}
+
+// TestGroupWelcome_Worker_RotationServesBeyondWakeCap: with more enabled groups
+// than the per-wake post cap, the rotating cursor serves every group across two
+// wakes (removing workerCursor++ would strand the tail groups).
+func TestGroupWelcome_Worker_RotationServesBeyondWakeCap(t *testing.T) {
+	ctx := swTestServer(t)
+	af := time.Now().UTC().Add(-time.Hour)
+	total := swWorkerWakeCap + 2
+	for i := 0; i < total; i++ {
+		g := fmt.Sprintf("g_r%02d", i)
+		gwInsertGroup(t, ctx, g, 1)
+		gwSetGroupConfig(t, ctx, g, true, af, "hi {member}")
+		gwSeedPending(t, ctx, g, 1, 0)
+	}
+	svc := gwNewService(t, ctx)
+	svc.sendFn = func(_ context.Context, _ *config.MsgSendReq) (*swSendResult, error) {
+		return &swSendResult{messageID: 1, clientMsgNo: "x"}, nil
+	}
+	svc.runWorkerWake(bg()) // per-wake post cap leaves 2 groups unserved
+	svc.runWorkerWake(bg()) // rotation serves the previously-skipped groups
+
+	got := 0
+	for i := 0; i < total; i++ {
+		s, _ := svc.store.countByStatus(bg(), fmt.Sprintf("g_r%02d", i), swStatusSent)
+		got += int(s)
+	}
+	assert.Equal(t, total, got, "rotating cursor serves every group across two wakes despite the per-wake post cap")
+}
+
+// TestRenderGroupWelcomeBody_TruncatesAtCap pins the rendered-body rune cap.
+func TestRenderGroupWelcomeBody_TruncatesAtCap(t *testing.T) {
+	long := strings.Repeat("x", groupWelcomeRenderedMaxRunes+500)
+	out := renderGroupWelcomeBody(long, "")
+	assert.Equal(t, groupWelcomeRenderedMaxRunes, utf8.RuneCountInString(out), "rendered body truncated to the rune cap")
+	assert.Equal(t, "欢迎 Alice", renderGroupWelcomeBody("欢迎 {member}", "Alice"), "under-cap body unchanged")
 }

--- a/modules/notify/group_welcome_test.go
+++ b/modules/notify/group_welcome_test.go
@@ -607,10 +607,11 @@ func TestGroupWelcome_Dispatch_SendTimeout_Unknown(t *testing.T) {
 	assert.Equal(t, 1, calls, "unknown is never re-sent (avoids public double-post)")
 }
 
-// TestGroupWelcome_Dispatch_SendRejected_RetriesThenDelivers: a definitive reject
-// (non-2xx = nothing posted) re-queues with backoff and is delivered on a later
-// wake — exactly once, no double post.
-func TestGroupWelcome_Dispatch_SendRejected_RetriesThenDelivers(t *testing.T) {
+// TestGroupWelcome_Dispatch_SendBadResponse_UnknownNotRetried: a non-2xx / ambiguous
+// send error is terminal `unknown` and is NEVER auto-retried — the send carries no
+// idempotency key and this is a PUBLIC post, so a retry could double-post a visible,
+// unrecallable welcome. Mirrors the space engine's conservative post-send policy.
+func TestGroupWelcome_Dispatch_SendBadResponse_UnknownNotRetried(t *testing.T) {
 	ctx := swTestServer(t)
 	af := time.Now().UTC().Add(-time.Hour)
 	gwInsertGroup(t, ctx, "g_1", 1)
@@ -620,30 +621,17 @@ func TestGroupWelcome_Dispatch_SendRejected_RetriesThenDelivers(t *testing.T) {
 	id := gwInsertGroupLedger(t, ctx, "g_1", "u_1", swStatusPending, "", nil, 0)
 
 	svc := gwNewService(t, ctx)
-	clock := time.Now().UTC().Truncate(time.Second)
-	svc.now = func() time.Time { return clock }
-	okSends, rejected := 0, false
+	calls := 0
 	svc.sendFn = func(_ context.Context, _ *config.MsgSendReq) (*swSendResult, error) {
-		if !rejected {
-			rejected = true
-			return nil, &swSendError{class: swErrIMRejected}
-		}
-		okSends++
-		return &swSendResult{messageID: 9, clientMsgNo: "x"}, nil
+		calls++
+		return nil, &swSendError{class: swErrIMBadResponse}
 	}
-
-	svc.runWorkerWake(bg()) // wake 1: rejected -> pending backoff
-	st, attempts, ec := gwRowFull(t, ctx, id)
-	assert.Equal(t, swStatusPending, st, "definitive reject -> retryable pending")
-	assert.Equal(t, 1, attempts)
-	assert.Equal(t, swErrIMRejected, ec)
-	assert.Equal(t, 0, okSends, "nothing posted on the rejected attempt")
-
-	clock = clock.Add(swBackoff[0] + time.Second) // past the retry backoff
-	svc.runWorkerWake(bg())                       // wake 2: re-claimed and delivered
-	st, _, _ = gwRowFull(t, ctx, id)
-	assert.Equal(t, swStatusSent, st, "retried post succeeds")
-	assert.Equal(t, 1, okSends, "delivered exactly once")
+	svc.runWorkerWake(bg())
+	st, _, ec := gwRowFull(t, ctx, id)
+	assert.Equal(t, swStatusUnknown, st, "post-send failure is terminal unknown for a public post")
+	assert.Equal(t, swErrIMBadResponse, ec)
+	svc.runWorkerWake(bg())
+	assert.Equal(t, 1, calls, "unknown is never re-sent — no public double-post risk")
 }
 
 // TestGroupWelcome_Dispatch_OrphanJoiner_Skipped: a joiner with no user row is

--- a/modules/notify/group_welcome_test.go
+++ b/modules/notify/group_welcome_test.go
@@ -736,3 +736,77 @@ func TestRenderGroupWelcomeBody_TruncatesAtCap(t *testing.T) {
 	assert.Equal(t, groupWelcomeRenderedMaxRunes, utf8.RuneCountInString(out), "rendered body truncated to the rune cap")
 	assert.Equal(t, "欢迎 Alice", renderGroupWelcomeBody("欢迎 {member}", "Alice"), "under-cap body unchanged")
 }
+
+// TestGroupWelcome_Dispatch_ActiveFromMovedForward_Skipped: a row enqueued under an
+// earlier window is NOT posted after an admin moves active_from past the joiner's
+// join time — the pre-send re-check enforces the CURRENT cutoff.
+func TestGroupWelcome_Dispatch_ActiveFromMovedForward_Skipped(t *testing.T) {
+	ctx := swTestServer(t)
+	base := time.Now().UTC().Truncate(time.Second)
+	gwInsertGroup(t, ctx, "g_1", 1)
+	gwInsertUserNamed(t, ctx, "u_1", "Alice", 0)
+	gwInsertGroupMember(t, ctx, "g_1", "u_1", 0, 1, base) // joined at base
+	gwSetGroupConfig(t, ctx, "g_1", true, base.Add(-time.Hour), "hi {member}")
+
+	svc := gwNewService(t, ctx)
+	clock := base
+	svc.now = func() time.Time { return clock }
+	sent := false
+	svc.sendFn = func(_ context.Context, _ *config.MsgSendReq) (*swSendResult, error) {
+		sent = true
+		return &swSendResult{messageID: 1}, nil
+	}
+
+	svc.handleMemberJoin("g_1", "u_1") // eligible under the current window → enqueued
+	ids := gwPendingIDs(t, ctx, "g_1")
+	require.Len(t, ids, 1)
+
+	// Admin moves active_from forward, past the joiner's created_at.
+	gwSetGroupConfig(t, ctx, "g_1", true, base.Add(time.Hour), "hi {member}")
+	clock = clock.Add(time.Minute) // past the coalesce window
+
+	svc.runWorkerWake(bg())
+	st, _, ec := gwRowFull(t, ctx, ids[0])
+	assert.Equal(t, swStatusSkipped, st, "pending row outside the current active_from window is skipped")
+	assert.Equal(t, swErrActiveFromMoved, ec)
+	assert.False(t, sent, "no public post outside the configured window")
+}
+
+// TestGroupWelcome_Dispatch_ConfigDeletedRecreated_WindowEnforced: DELETE does not
+// discard pending rows, but recreating the config with a later window does NOT
+// resurrect a stale welcome — the pre-send re-check skips rows outside the new
+// cutoff.
+func TestGroupWelcome_Dispatch_ConfigDeletedRecreated_WindowEnforced(t *testing.T) {
+	ctx := swTestServer(t)
+	base := time.Now().UTC().Truncate(time.Second)
+	gwInsertGroup(t, ctx, "g_1", 1)
+	gwInsertUserNamed(t, ctx, "u_1", "Alice", 0)
+	gwInsertGroupMember(t, ctx, "g_1", "u_1", 0, 1, base)
+	gwSetGroupConfig(t, ctx, "g_1", true, base.Add(-time.Hour), "old {member}")
+
+	svc := gwNewService(t, ctx)
+	clock := base
+	svc.now = func() time.Time { return clock }
+	sent := false
+	svc.sendFn = func(_ context.Context, _ *config.MsgSendReq) (*swSendResult, error) {
+		sent = true
+		return &swSendResult{messageID: 1}, nil
+	}
+
+	svc.handleMemberJoin("g_1", "u_1")
+	ids := gwPendingIDs(t, ctx, "g_1")
+	require.Len(t, ids, 1)
+
+	// Delete the config (the pending row remains), then recreate with a later window.
+	store := common.NewGroupWelcomeConfigStore(ctx.DB())
+	_, err := store.Delete(bg(), "g_1")
+	require.NoError(t, err)
+	gwSetGroupConfig(t, ctx, "g_1", true, base.Add(time.Hour), "new {member}")
+	clock = clock.Add(time.Minute)
+
+	svc.runWorkerWake(bg())
+	st, _, ec := gwRowFull(t, ctx, ids[0])
+	assert.Equal(t, swStatusSkipped, st, "resurrected pending row is skipped under the recreated (later) window")
+	assert.Equal(t, swErrActiveFromMoved, ec)
+	assert.False(t, sent, "delete+recreate does not resurrect a stale out-of-window welcome")
+}

--- a/modules/notify/space_welcome.go
+++ b/modules/notify/space_welcome.go
@@ -177,7 +177,10 @@ func (s *spaceWelcomeService) enabledEffectiveConfigs(ctx context.Context) ([]co
 	out := make([]common.SpaceWelcomeConfig, 0, len(rows)+1)
 	for _, r := range rows {
 		out = append(out, common.SpaceWelcomeConfig{
-			Enabled:       true,
+			// Read r.Enabled rather than hardcoding true: ListEnabled filters
+			// enabled=1 so this is always true today, but reading the row keeps the
+			// code self-documenting and resilient if that WHERE clause ever changes.
+			Enabled:       r.Enabled,
 			SpaceID:       r.SpaceID,
 			ActiveFromRaw: r.ActiveFromRaw,
 			Message:       r.Message,

--- a/modules/notify/space_welcome_model.go
+++ b/modules/notify/space_welcome_model.go
@@ -24,15 +24,20 @@ const (
 
 // error_class enumeration (structured log field + ledger column).
 const (
-	swErrBotNotReady   = "bot_not_ready"
-	swErrMemberLeft    = "member_left"
-	swErrHumanFilter   = "human_filter"
-	swErrOrphanMember  = "orphan_member"
-	swErrConfigRead    = "config_read"
-	swErrIMTimeout     = "im_timeout"
-	swErrIMBadResponse = "im_bad_response"
-	swErrSentPersist   = "sent_persist"
-	swErrClaimExpired  = "claim_expired"
+	swErrBotNotReady  = "bot_not_ready"
+	swErrMemberLeft   = "member_left"
+	swErrHumanFilter  = "human_filter"
+	swErrOrphanMember = "orphan_member"
+	// swErrActiveFromMoved (group only): a pending row's joiner no longer satisfies
+	// the CURRENT config's active_from at pre-send re-check (admin moved active_from
+	// forward, or deleted+recreated the config with a later window). CAS-skip so a
+	// welcome is never posted outside the currently-configured cutoff.
+	swErrActiveFromMoved = "active_from_moved"
+	swErrConfigRead      = "config_read"
+	swErrIMTimeout       = "im_timeout"
+	swErrIMBadResponse   = "im_bad_response"
+	swErrSentPersist     = "sent_persist"
+	swErrClaimExpired    = "claim_expired"
 )
 
 // stage enumeration (structured log field).

--- a/modules/notify/space_welcome_model.go
+++ b/modules/notify/space_welcome_model.go
@@ -31,15 +31,8 @@ const (
 	swErrConfigRead    = "config_read"
 	swErrIMTimeout     = "im_timeout"
 	swErrIMBadResponse = "im_bad_response"
-	// swErrIMRejected is a definitive non-2xx from WuKongIM /message/send: the
-	// request was rejected and NOTHING was posted, so it is safe to retry (unlike
-	// the transport-ambiguous swErrIMTimeout / empty-200 swErrIMBadResponse, which
-	// may have been delivered and must never be auto-retried). The group welcome
-	// uses this to retry a failed coalesced post instead of terminal-`unknown`-ing
-	// the whole batch; the space welcome treats it like any other send error.
-	swErrIMRejected   = "im_rejected"
-	swErrSentPersist  = "sent_persist"
-	swErrClaimExpired = "claim_expired"
+	swErrSentPersist   = "sent_persist"
+	swErrClaimExpired  = "claim_expired"
 )
 
 // stage enumeration (structured log field).

--- a/modules/notify/space_welcome_model.go
+++ b/modules/notify/space_welcome_model.go
@@ -31,8 +31,15 @@ const (
 	swErrConfigRead    = "config_read"
 	swErrIMTimeout     = "im_timeout"
 	swErrIMBadResponse = "im_bad_response"
-	swErrSentPersist   = "sent_persist"
-	swErrClaimExpired  = "claim_expired"
+	// swErrIMRejected is a definitive non-2xx from WuKongIM /message/send: the
+	// request was rejected and NOTHING was posted, so it is safe to retry (unlike
+	// the transport-ambiguous swErrIMTimeout / empty-200 swErrIMBadResponse, which
+	// may have been delivered and must never be auto-retried). The group welcome
+	// uses this to retry a failed coalesced post instead of terminal-`unknown`-ing
+	// the whole batch; the space welcome treats it like any other send error.
+	swErrIMRejected   = "im_rejected"
+	swErrSentPersist  = "sent_persist"
+	swErrClaimExpired = "claim_expired"
 )
 
 // stage enumeration (structured log field).

--- a/modules/notify/space_welcome_sender.go
+++ b/modules/notify/space_welcome_sender.go
@@ -101,12 +101,7 @@ func (s *spaceWelcomeSender) send(ctx context.Context, req *config.MsgSendReq) (
 		return nil, &swSendError{class: swErrIMTimeout, err: fmt.Errorf("read send response: %w", err)}
 	}
 	if resp.StatusCode != http.StatusOK {
-		// A definitive non-2xx: WuKongIM rejected the request and persisted
-		// nothing, so this is safe to retry (distinct from the ambiguous
-		// empty-200 / transport cases below). The space welcome still treats it as
-		// a send error; the group welcome uses this class to retry a failed
-		// coalesced post rather than terminal-unknown the whole batch.
-		return nil, &swSendError{class: swErrIMRejected, err: fmt.Errorf("IM /message/send status %d", resp.StatusCode)}
+		return nil, &swSendError{class: swErrIMBadResponse, err: fmt.Errorf("IM /message/send status %d", resp.StatusCode)}
 	}
 
 	// Parse the stable response shape { "data": { message_id, client_msg_no,

--- a/modules/notify/space_welcome_sender.go
+++ b/modules/notify/space_welcome_sender.go
@@ -101,7 +101,12 @@ func (s *spaceWelcomeSender) send(ctx context.Context, req *config.MsgSendReq) (
 		return nil, &swSendError{class: swErrIMTimeout, err: fmt.Errorf("read send response: %w", err)}
 	}
 	if resp.StatusCode != http.StatusOK {
-		return nil, &swSendError{class: swErrIMBadResponse, err: fmt.Errorf("IM /message/send status %d", resp.StatusCode)}
+		// A definitive non-2xx: WuKongIM rejected the request and persisted
+		// nothing, so this is safe to retry (distinct from the ambiguous
+		// empty-200 / transport cases below). The space welcome still treats it as
+		// a send error; the group welcome uses this class to retry a failed
+		// coalesced post rather than terminal-unknown the whole batch.
+		return nil, &swSendError{class: swErrIMRejected, err: fmt.Errorf("IM /message/send status %d", resp.StatusCode)}
 	}
 
 	// Parse the stable response shape { "data": { message_id, client_msg_no,

--- a/modules/notify/space_welcome_unit_test.go
+++ b/modules/notify/space_welcome_unit_test.go
@@ -58,7 +58,7 @@ func TestSpaceWelcomeSender_SetsHeadersAndParsesResult(t *testing.T) {
 	assert.EqualValues(t, 1, gotBody["channel_type"]) // ChannelTypePerson
 }
 
-func TestSpaceWelcomeSender_Non200IsRejected(t *testing.T) {
+func TestSpaceWelcomeSender_Non200IsBadResponse(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
 		_, _ = w.Write([]byte(`boom`))
@@ -70,9 +70,7 @@ func TestSpaceWelcomeSender_Non200IsRejected(t *testing.T) {
 	require.Error(t, err)
 	var se *swSendError
 	require.ErrorAs(t, err, &se)
-	// A definitive non-2xx is "rejected / not delivered" — distinct from the
-	// ambiguous empty-200 case below — so a caller may safely retry it.
-	assert.Equal(t, swErrIMRejected, se.class)
+	assert.Equal(t, swErrIMBadResponse, se.class)
 }
 
 func TestSpaceWelcomeSender_Empty200IsBadResponse(t *testing.T) {

--- a/modules/notify/space_welcome_unit_test.go
+++ b/modules/notify/space_welcome_unit_test.go
@@ -58,7 +58,7 @@ func TestSpaceWelcomeSender_SetsHeadersAndParsesResult(t *testing.T) {
 	assert.EqualValues(t, 1, gotBody["channel_type"]) // ChannelTypePerson
 }
 
-func TestSpaceWelcomeSender_Non200IsBadResponse(t *testing.T) {
+func TestSpaceWelcomeSender_Non200IsRejected(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
 		_, _ = w.Write([]byte(`boom`))
@@ -70,7 +70,9 @@ func TestSpaceWelcomeSender_Non200IsBadResponse(t *testing.T) {
 	require.Error(t, err)
 	var se *swSendError
 	require.ErrorAs(t, err, &se)
-	assert.Equal(t, swErrIMBadResponse, se.class)
+	// A definitive non-2xx is "rejected / not delivered" — distinct from the
+	// ambiguous empty-200 case below — so a caller may safely retry it.
+	assert.Equal(t, swErrIMRejected, se.class)
 }
 
 func TestSpaceWelcomeSender_Empty200IsBadResponse(t *testing.T) {

--- a/modules/notify/sql/20260723000001_add_octo_group_welcome_delivery.sql
+++ b/modules/notify/sql/20260723000001_add_octo_group_welcome_delivery.sql
@@ -1,0 +1,32 @@
+-- +migrate Up
+
+-- Group 入群欢迎语的投递账本（at-most-once）——task group-welcome-message。
+-- 唯一去重真源：一个 (group_no, uid) 至多一行、至多投递一次（公开发到群频道）。
+-- group_member.created_at 会在重新入群时被重置（不同于 space_member），因此
+-- 「首次入群、退群再进不重复」由本账本的 UNIQUE(group_no, uid) 保证，而非时间列。
+-- 时间纪律：所有时间列均为应用侧写入的 UTC 值（bound 参数），禁用 NOW()；因此不设
+-- DEFAULT CURRENT_TIMESTAMP。COLLATE 显式对齐 group / group_member / user 的 JOIN
+-- 键（utf8mb4_general_ci），避免对账 JOIN 触发 MySQL 1267。
+-- idx_sweep 直接建在 CREATE 里（新表，无需分步 ALTER）：跨群 sweep 走
+-- WHERE status=<claimed|dispatching> AND claim_expire_at<=?。
+CREATE TABLE `octo_group_welcome_delivery` (
+  `id`              BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+  `group_no`        VARCHAR(40)  NOT NULL DEFAULT ''         COMMENT '目标群（长度/字符集/COLLATE 对齐 group.group_no）',
+  `uid`             VARCHAR(40)  NOT NULL DEFAULT ''         COMMENT '触发首次入群的成员 UID（对齐 user.uid / group_member.uid）',
+  `status`          TINYINT      NOT NULL DEFAULT 0          COMMENT '0=pending 1=claimed 2=dispatching 3=sent 4=failed 5=skipped 6=unknown',
+  `attempts`        INT          NOT NULL DEFAULT 0          COMMENT '仅统计连续 pre-IM 失败次数；claim/sweep/precheck-skip/sent/unknown 均不消耗',
+  `next_retry_at`   DATETIME     NULL                        COMMENT 'UTC；应用侧写入，禁 NOW()；下一次可被 claim 的时间',
+  `message_id`      BIGINT       NULL                        COMMENT 'IM 返回的 message_id（成功时）',
+  `client_msg_no`   VARCHAR(100) NULL                        COMMENT 'IM 返回的 client_msg_no（对齐 message 表宽度）',
+  `claim_owner`     VARCHAR(128) NULL                        COMMENT '<hostname>:<pid>；每次 claim 后 update 的 CAS 断言',
+  `claim_expire_at` DATETIME     NULL                        COMMENT 'UTC；应用侧写入；claim 租约到期时间',
+  `error_class`     VARCHAR(64)  NULL                        COMMENT '错误分类：member_left/human_filter/orphan_member/config_read/im_timeout/im_bad_response/sent_persist/claim_expired',
+  `created_at`      DATETIME     NOT NULL                    COMMENT 'UTC；应用侧写入，禁 NOW()',
+  `updated_at`      DATETIME     NOT NULL                    COMMENT 'UTC；应用侧写入，禁 NOW()',
+  UNIQUE KEY `uk_group_uid` (`group_no`, `uid`),
+  KEY `idx_claim` (`group_no`, `status`, `next_retry_at`),
+  KEY `idx_sweep` (`status`, `claim_expire_at`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci COMMENT='onboarding group welcome delivery ledger';
+
+-- +migrate Down
+DROP TABLE IF EXISTS `octo_group_welcome_delivery`;

--- a/modules/notify/sql/20260723000001_add_octo_group_welcome_delivery.sql
+++ b/modules/notify/sql/20260723000001_add_octo_group_welcome_delivery.sql
@@ -20,7 +20,7 @@ CREATE TABLE `octo_group_welcome_delivery` (
   `client_msg_no`   VARCHAR(100) NULL                        COMMENT 'IM 返回的 client_msg_no（对齐 message 表宽度）',
   `claim_owner`     VARCHAR(128) NULL                        COMMENT '<hostname>:<pid>；每次 claim 后 update 的 CAS 断言',
   `claim_expire_at` DATETIME     NULL                        COMMENT 'UTC；应用侧写入；claim 租约到期时间',
-  `error_class`     VARCHAR(64)  NULL                        COMMENT '错误分类：member_left/human_filter/orphan_member/config_read/im_timeout/im_bad_response/sent_persist/claim_expired',
+  `error_class`     VARCHAR(64)  NULL                        COMMENT '错误分类：human_filter/orphan_member/config_read/bot_not_ready/im_timeout/im_bad_response/im_rejected/sent_persist/claim_expired',
   `created_at`      DATETIME     NOT NULL                    COMMENT 'UTC；应用侧写入，禁 NOW()',
   `updated_at`      DATETIME     NOT NULL                    COMMENT 'UTC；应用侧写入，禁 NOW()',
   UNIQUE KEY `uk_group_uid` (`group_no`, `uid`),

--- a/modules/space/api_welcome.go
+++ b/modules/space/api_welcome.go
@@ -90,7 +90,7 @@ func (s *Space) getWelcome(c *wkhttp.Context) {
 		return
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), welcomeConfigDBTimeout)
+	ctx, cancel := context.WithTimeout(c.Request.Context(), welcomeConfigDBTimeout)
 	defer cancel()
 	row, found, err := s.welcomeStore.Get(ctx, spaceId)
 	if err != nil {
@@ -122,7 +122,7 @@ func (s *Space) putWelcome(c *wkhttp.Context) {
 		return
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), welcomeConfigDBTimeout)
+	ctx, cancel := context.WithTimeout(c.Request.Context(), welcomeConfigDBTimeout)
 	defer cancel()
 
 	// Read-merge-write under a row lock so two admins PUTting the same Space
@@ -205,7 +205,7 @@ func (s *Space) deleteWelcome(c *wkhttp.Context) {
 		return
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), welcomeConfigDBTimeout)
+	ctx, cancel := context.WithTimeout(c.Request.Context(), welcomeConfigDBTimeout)
 	defer cancel()
 	deleted, err := s.welcomeStore.Delete(ctx, spaceId)
 	if err != nil {

--- a/modules/space/api_welcome_test.go
+++ b/modules/space/api_welcome_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/Mininglamp-OSS/octo-lib/testutil"
 	commonmod "github.com/Mininglamp-OSS/octo-server/modules/common"
@@ -187,6 +188,56 @@ func TestWelcomePut_PartialMergePreservesMessage(t *testing.T) {
 	resp := decodeWelcomeResp(t, w)
 	assert.False(t, resp.Enabled)
 	assert.Equal(t, "keep me", resp.Message, "partial patch keeps the existing message")
+}
+
+// setSpaceGlobalWelcome writes the platform-global onboarding.space_welcome_*
+// keys (enabled, naming spaceID) and reloads the settings singleton the handler
+// reads.
+func setSpaceGlobalWelcome(t *testing.T, spaceID string, activeFrom time.Time) {
+	t.Helper()
+	settings := commonmod.EnsureSystemSettings(testCtx)
+	kv := map[string]string{
+		"space_welcome_enabled":     "1",
+		"space_welcome_space_id":    spaceID,
+		"space_welcome_active_from": activeFrom.UTC().Format(time.RFC3339),
+		"space_welcome_message":     "global-welcome",
+	}
+	for k, v := range kv {
+		vt := "string"
+		if k == "space_welcome_enabled" {
+			vt = "bool"
+		}
+		_, err := testCtx.DB().InsertBySql(
+			"INSERT INTO system_setting (category, key_name, value, value_type, description) VALUES ('onboarding', ?, ?, ?, '') "+
+				"ON DUPLICATE KEY UPDATE value=VALUES(value), value_type=VALUES(value_type)",
+			k, v, vt,
+		).Exec()
+		require.NoError(t, err)
+	}
+	require.NoError(t, settings.Load())
+}
+
+// TestWelcomeDelete_RevertsToEnabledGlobalFallback (incidental polish, task
+// group-welcome-message): DELETE of a per-Space row reverts a Space to the
+// enabled platform-global fallback that names it — locking the full GET response
+// contract at the HTTP layer.
+func TestWelcomeDelete_RevertsToEnabledGlobalFallback(t *testing.T) {
+	setup(t)
+	seedWelcomeSpace(t, "spc_1", 1)
+	setSpaceGlobalWelcome(t, "spc_1", time.Now().UTC().Add(-time.Hour))
+
+	require.Equal(t, http.StatusOK,
+		doWelcome(t, http.MethodPut, "spc_1", `{"enabled":true,"active_from":"2026-07-10T00:00:00Z","message":"space-local"}`).Code)
+	require.Equal(t, "space", decodeWelcomeResp(t, doWelcome(t, http.MethodGet, "spc_1", "")).Effective.Source)
+
+	w := doWelcome(t, http.MethodDelete, "spc_1", "")
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	g := decodeWelcomeResp(t, doWelcome(t, http.MethodGet, "spc_1", ""))
+	assert.False(t, g.Configured, "per-Space row gone")
+	assert.Equal(t, "global", g.Effective.Source, "reverts to the enabled global fallback")
+	assert.True(t, g.Effective.Enabled)
+	assert.Equal(t, "global-welcome", g.Effective.Message)
 }
 
 func TestWelcomeDelete_RevertsToUnconfigured(t *testing.T) {


### PR DESCRIPTION
## Summary

Add a **group new-member welcome (群入群欢迎语)**: each group's owner/manager configures **one** welcome via `GET/PUT/DELETE /v1/groups/:group_no/welcome`, and on a human member's **first** join it is **posted publicly into the group channel** (`channel_type=GROUP`), at most once per `(group_no, uid)`. The body supports a `{member}` placeholder rendered to the joiner's display name.

Delivery mirrors the freshly-shipped per-Space welcome engine (#646) as a **parallel, group-scoped** copy — config store + delivery ledger + reconciler + send worker + rotating cursor + `FOR UPDATE SKIP LOCKED` + CAS/at-most-once — rather than refactoring that reviewed code. Key divergences: the send target is a **public group-channel post** (Space DMs the newcomer), and there is **no platform-global content fallback** (a group with no enabled row gets no welcome).

Ships **double-inert**: a platform master switch defaults off AND per-group configs default `enabled=false` — nothing happens on deploy until ops flips the switch and a group admin opts that group in.

## Related Issue

<!-- none linked -->

## Linked Spec

- `.octospec/tasks/group-welcome-message/brief.md`
- Journal: `.octospec/journal/shared/group-welcome-message.md`

## Changes

- **Config storage (`modules/common`)** — `octo_group_welcome_config` (one row per group; `group_no` UNIQUE, COLLATE aligned to `group.group_no`) + `GroupWelcomeConfigStore` with insert-then-lock `UpsertMerged` (concurrent first-create and concurrent edits both keep all fields). `active_from` stored as an RFC3339 string so `ParsedActiveFrom` / `ValidateGroupWelcomeCombination` are pure validators.
- **CRUD API (`modules/group/api_welcome.go`)** — `GET/PUT/DELETE /v1/groups/:group_no/welcome`, gated by a new `authorizeGroupWelcomeAdmin` (group-active + `QueryIsGroupManagerOrCreator`, reusing existing group error codes — no new codes). Mounted on auth + `SharedUIDRateLimiter`; all responses via the `httperr` i18n envelope; handler added to the group `NoLegacyResponseError` guard.
- **Delivery (`modules/notify`)** — `octo_group_welcome_delivery` ledger (`UNIQUE(group_no, uid)` = at-most-once authority), event listener on `event.GroupMemberAdd`, reconciler catch-up, and a send worker (cross-group claim, CAS-on-`claim_owner`, 30s lease, rotating cursor, cross-group sweep). Posts a `MsgSendReq` to `channel_id=group_no`, `channel_type=GROUP`, from the fixed `notification` identity; `{member}` renders at send time.
- **Platform master switch** — `system_setting onboarding.group_welcome_enabled` (bool, **default off**), read via `SystemSettings.GroupWelcomeEnabled()`, checked at enqueue/reconcile/worker (sweep still runs so in-flight rows terminate). **Enablement only — no content fallback**; flip-off is an instant, reversible kill that touches no per-group rows.
- **Burst coalescing** — a batch invite (one `GroupMemberAdd` event → N rows) is delivered as **one** public post naming everyone (`{member}` → joined list; overflow → `…、nameK 等 N 人`). Fresh rows are held a short coalesce window via `next_retry_at`; the worker `claimBatch`es a group's due rows and posts once, preserving per-row at-most-once (shared `message_id`). One coalesced post per group per wake also rate-limits a single group's welcomes.
- **Incidental polish carried from #646** — `Upsert` doc caveat (prod must use `UpsertMerged`); `notify` `enabledEffectiveConfigs` reads `r.Enabled`; Space CRUD derives DB context from the request; a Space `DELETE`→enabled-global-fallback HTTP test.

## Testing

```
go build ./...                              # clean
go vet ./... ; golangci-lint run            # 0 issues
gofmt -l (changed files)                     # clean
make i18n-extract-check && make i18n-lint    # OK
git diff --check                             # clean
go test -race ./modules/{common,notify,group,space}/   # all ok
```

- New tests: config-store CRUD + `UpsertMerged` no-lost-update + concurrent-create; CRUD authz matrix (creator/manager/member/non-member/disbanded) + prospective validation + partial-merge + delete; first-join at-most-once public post to the correct channel; `{member}` render; leave/rejoin no re-post; pre-`active_from` + robot/system-bot exclusion; multi-group no-crossing; worker coalesce + fairness; cross-group sweep; **master-switch-off suppresses** enqueue + post; **coalesced burst → one post**; name-list overflow render.
- **Live e2e** (`group_welcome_e2e_test.go`, skips without a live WuKongIM): full pipeline against real WuKongIM confirms the `notification` identity **posts into a group channel it is not a member of** (real `message_id`) and that a burst coalesces to one `message_id`.

- [x] Unit tests added/updated
- [x] Manually verified (live WuKongIM e2e)

## COMPREHENSION

1. **What does this change actually do to the load-bearing path?**
   It adds a new consumer of `event.GroupMemberAdd` (fan-out, multi-listener — existing `message`/`group` listeners are untouched) that enqueues an idempotent `(group_no, uid)` ledger row, and two background goroutines (reconciler + send worker) that drain the ledger and post one message into the group channel. Authorization for the new CRUD reuses the canonical `QueryIsGroupManagerOrCreator` gate behind a group-active check. It touches NO existing group/message/space wire response — the space welcome engine is copied, not modified (beyond 4 incidental polish items). Two new tables, one new bool `system_setting` key.

2. **What could break because of it (dependents + failure mode)?**
   - *Channel spam on bulk invites* — mitigated by coalescing (one post per batch/group/wake) + the double-inert default (master off + per-group off), so no group is affected until explicitly enabled.
   - *Delivery races (multi-replica, rejoin, post-then-leave)* — the ledger `UNIQUE(group_no, uid)` + CAS-on-`claim_owner` + lease give at-most-once; `group_member.created_at` resetting on rejoin is explicitly NOT the authority (the ledger is), so leave→rejoin never re-posts.
   - *Enqueue/DB hiccups* — fail-open on the join (enqueue failure never blocks the join), fail-closed on the welcome (any anomaly → no post); the reconciler catches dropped events. IM send failure after dispatch → `unknown` (never auto-retried, no double-post).
   - *Ops kill path* — flipping the master switch off stops new posts within the settings snapshot TTL without touching per-group rows.

3. **How do you know it works (specific test/repro/trace)?**
   Full `-race` suites for `common`/`notify`/`group`/`space` are green, plus a committed **live e2e** against real WuKongIM that drives config → 2 first-join members → enqueue → coalesce window → batch claim → one public post → ledger `SENT`, asserting both joiners share one `message_id` (proves coalescing) and that the post lands even though `notification` is not a group member (real `message_id` returned — this closed the brief's one open question). Isolation, master-switch-off suppression, and worker fairness each have dedicated regression tests.

## Checklist

- [x] PR description is in English
- [x] Added tests for my changes
- [x] Updated documentation (octospec brief + journal + changelog)
- [x] Followed commit message conventions (Conventional Commits)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XqkVUKZD3uEYYTvvqmnWio

---
_Generated by [Claude Code](https://claude.ai/code/session_01XqkVUKZD3uEYYTvvqmnWio)_