### PR TITLE
feat(cardtmpl): onboard ai.reasoning-process JSON card (roadmap E1a)

### DIFF
--- a/.octospec/journal/shared/cardtmpl-reasoning-progress-card.md
+++ b/.octospec/journal/shared/cardtmpl-reasoning-progress-card.md
@@ -1,0 +1,66 @@
+---
+type: Journal
+title: "Journal: cardtmpl-reasoning-progress-card (roadmap E1a)"
+description: Onboard the ai.reasoning-process handoff as the first live JSON-mode card on the E1 engine (#654). Decision A — keep the producer's action buttons (reasoning_stop / reasoning_retry Submit + toggle), fixed owner "ai" / action_type "reasoning.control", active/error octo/v2, result octo/v1. Registered + renderable; the stop/retry handler + RouteSpec + bot streaming delivery are downstream.
+tags: ["cardtmpl", "platform", "ai-reasoning-process", "json-template", "wire-contract", "trust-boundary", "testing", "e1a"]
+timestamp: 2026-07-24T04:33:57Z
+# --- octospec extension fields ---
+task: cardtmpl-reasoning-progress-card
+upstream: self (roadmap E1a; depends on #654)
+source: self
+---
+
+# Journal: cardtmpl-reasoning-progress-card (roadmap E1a)
+
+## What shipped
+
+The first live JSON-mode card on the E1 engine (#654): `ai.reasoning-process@0.1.0`
+registered via `Registry.RegisterJSON`, no hand-written Go `Build()`.
+
+- **`pkg/cardtmpl/ai_reasoning_process/`** — embeds the handoff (manifest +
+  contract + templates + view-named reports + samples + goldens) and exposes
+  `Assets` / `HandoffRoot` / `TemplateID` / `TemplateVersion`. No Template struct.
+- **`registry.go`** — `ai` added to the L2a owner allowlist (new platform card
+  family).
+- **`main.go`** — `RegisterJSON` + `SetDefault` in the composition root.
+
+## Decision A — keep the buttons (translate the handoff faithfully)
+
+The handoff ships `reasoning_stop` (active) and `reasoning_retry` (error)
+`Action.Submit` buttons plus `reasoning_toggle`. Per the user's decision the card
+is translated **as delivered** (buttons kept), not stripped to a v1 display card.
+Consequences resolved here:
+
+- **Fixed owner `ai` / action_type `reasoning.control`.** Not the C3 dynamic-owner
+  problem — the template is platform-owned, stable; `reasoning_id` is a Submit
+  data field, not the routing key.
+- **`Submit.data` carries `owner` + `action_type`.** The base ActionContract
+  self-check asserts every `Action.Submit.data.{owner,action_type}` matches the
+  manifest contract (same as docs.access-request). This is the one deviation from
+  byte-identical-to-as-delivered; goldens carry the same two static keys so
+  `engine(template) == golden` stays self-consistent.
+- **`active`/`error` = octo/v2, `result` = octo/v1.** A v2 view with no Submit
+  fails the self-check (`seenSubmit == 0`), so the display-only result view is
+  v1 — mirroring the docs.access-request 0.3.0 pending-v2 / result-v1 split. The
+  two v2 views carry view-named interaction reports; the v1 result view needs none.
+
+## Out of scope (downstream)
+
+The button **handler + `cardactiondispatch` RouteSpec** (actually stop / retry a
+reasoning run) and **bot streaming delivery** (send + `ReplaceView`
+reasoning→answering→result). This PR registers a card whose buttons render and
+carry a routable contract, but a click has no route until the handler lands —
+deliberate, documented in the PR body so a reviewer doesn't read it as a gap.
+
+## Tests
+
+`TestRegisters` (RegisterJSON success == ActionContract self-check passing),
+`TestRenderAllStates` (5 states, correct v2/v1 profiles), `TestConformance`
+(RenderCard minus metadata == golden minus $schema, 5/5). `go build ./...` +
+`go test ./pkg/cardtmpl/... -race` green.
+
+## Git
+
+Built on the E1 branch; after #654 squash-merged to main, rebased
+`--onto origin/main` so the PR diff is reasoning-card-only (single commit, engine
+commits dropped into main). Mirrors the #650-onto-#649 rebase pattern.

--- a/.octospec/log.md
+++ b/.octospec/log.md
@@ -26,6 +26,19 @@ change-log convention (§7). Newest first.
   internal diagnostic signal and emit it once at the request boundary. See
   [learning](learnings/pending/fail-closed-diagnostic-signal.md).
 
+## 2026-07-24 (cardtmpl-reasoning-progress-card, roadmap E1a)
+
+- **Feature** — Onboarded `ai.reasoning-process@0.1.0` as the first live JSON-mode
+  card on the E1 engine (#654), via `Registry.RegisterJSON` (no Go `Build()`).
+  Decision A: the producer's action buttons are kept (`reasoning_stop` /
+  `reasoning_retry` `Action.Submit` + toggle) under a fixed owner `ai` /
+  action_type `reasoning.control` (added `ai` to the L2a allowlist); `active`/
+  `error` are octo/v2, the display-only `result` view is octo/v1 (mirrors
+  docs.access-request 0.3.0). `Submit.data` carries owner/action_type so the
+  ActionContract self-check passes; goldens synced. The button handler +
+  RouteSpec + bot streaming delivery are downstream — the card is registered and
+  renderable only. See [journal](journal/shared/cardtmpl-reasoning-progress-card.md).
+
 ## 2026-07-23 (cardtmpl-json-template-engine, roadmap E1)
 
 - **Feature** — Added a JSON-template render path to `pkg/cardtmpl` (roadmap E1):

--- a/.octospec/tasks/cardtmpl-reasoning-progress-card/brief.md
+++ b/.octospec/tasks/cardtmpl-reasoning-progress-card/brief.md
@@ -1,0 +1,103 @@
+---
+type: Task
+title: "Task: cardtmpl-reasoning-progress-card"
+description: 把 ai.reasoning-process handoff 翻译成一张 live 平台卡 —— 应用"无操作行为"产品决策(去 reasoning_stop/reasoning_retry 两个 Submit,降 octo/v1,只留 ToggleVisibility 折叠),重出 v1 handoff + 重编 goldens,建子包并经 RegisterJSON 注册,证明经 Registry.Render 正确渲染。依赖 E1 引擎(PR #654)。
+tags: [cardtmpl, ai-reasoning-process, json-template, wire-contract, trust-boundary, testing]
+timestamp: 2026-07-23T14:30:27Z
+# --- octospec extension fields ---
+slug: cardtmpl-reasoning-progress-card
+upstream: (self · roadmap E1 下游 · 依赖 PR #654)
+source: self
+---
+
+# Task: cardtmpl-reasoning-progress-card
+
+> One task = one `.octospec/tasks/<slug>/` directory. This brief is the spec for
+> the work. AI may draft it from existing code; a human confirms it.
+
+## Goal
+
+把业务方交付的 `ai.reasoning-process` handoff **原样翻译成一张已注册、可渲染的 live 平台卡**
+(决策 A,2026-07-23):**保留 handoff 自带的操作按钮**(`reasoning_stop` / `reasoning_retry`
+`Action.Submit` + `Action.ToggleVisibility`),视图维持 **octo/v2**。在 E1 JSON 模板引擎
+(PR #654)之上注册,证明经 `Registry.Render` + `cardmsg.Validate` 三态正确渲染,且按钮
+契约合法可路由。
+
+**按钮的 handler(真正停止/重推理逻辑)+ RouteSpec + bot 下发不做**(下游任务)——本任务
+交付"按钮存在、ActionContract 合法可路由、能渲染"的卡;点击的服务端 handler 后续补。
+
+产物:
+1. **子包 `pkg/cardtmpl/ai_reasoning_process/`** 内嵌 handoff(manifest + contract +
+   templates + view 命名 reports + samples + goldens),导出 `Assets`/`HandoffRoot`/
+   `TemplateID`/`TemplateVersion`;
+2. **owner `ai`**:加入 `l2aOwnerAllowlist`(L0 小改),manifest `owner: ai` +
+   `actionType: reasoning.control`;Submit.data 补 `owner`/`action_type`(基座 ActionContract
+   self-check 要求,与 docs 卡一致);
+3. **注册**:`main.go` 经 `Registry.RegisterJSON` + `SetDefault`;
+4. **验证**:conformance(sample → golden 字节等价)+ 三态经 `Registry.Render` 渲染 +
+   ActionContract self-check 通过。
+
+## Background
+
+- E1(PR #654)已交付通用 JSON 引擎(`pkg/cardtmpl/jsontmpl` + `jsonTemplate` +
+  `Registry.RegisterJSON`)。**本任务是下游**:把这张卡接进生产 Registry。
+- as-delivered handoff 现**不能原样注册**,本任务负责补齐(**不改卡片视觉/按钮**):
+  1. manifest **无 owner/actionType** → 加 `owner: ai` + `actionType: reasoning.control`,
+     `ai` 入 L2a 白名单;Submit.data 补 `owner`/`action_type` 让 self-check 通过(唯一对
+     handoff 字节的偏离,按钮可路由的必要前提,goldens 同步);
+  2. reports 按 **state 命名** → 合并/改成 **view 命名**(`active` = reasoning_stop+toggle,
+     `result` = toggle,`error` = reasoning_retry+toggle),内容不变。
+- 客户端已渲染 v2 交互 AC(memory `card_message_v2_web_gate`,2026-07-23 更新:docs 允许/
+  拒绝 Submit 实测活),推理卡按钮渲染无门。
+
+## Load-bearing list
+
+- **wire-contract** — `Registry.RegisterJSON` / `manifest.views` / v2 view 需 view 命名
+  interaction report;`views[].states` 齐全供 state→view;缺项 → 注册期 fail-close。
+- **wire-contract** — `l2aOwnerAllowlist` 增 `ai`(L0):新平台卡 owner 家族;不放松 L2b
+  `ext.*` 拒绝逻辑。
+- **wire-contract** — ActionContract:manifest `owner`+`actionType` 派生 contract,注册期
+  self-check 断言每个 Submit.data.{owner,action_type} 一致 → Submit.data 必须携带这两键。
+- **wire-contract / trust-boundary** — 经 `Registry.Render` + `cardmsg.Validate` 同一管线
+  (组件白名单 / URL allowlist / 上限);data 字面绑定 + Validate 兜底(E1 D6)。
+- **wire-contract** — `main.go` composition root:新增一处 `RegisterJSON` + `SetDefault`,
+  Freeze 前;不改既有卡。
+
+## Out of scope
+
+- **按钮 handler + RouteSpec + bot 下发** —— 停止/重推理的服务端 handler、
+  `cardactiondispatch` RouteSpec、bot 发卡 + 流式 `ReplaceView` 全部**下游任务**。本任务
+  按钮点击暂无 route(handler 落地前)。
+- **Model A 能力发现广播**(`/v1/bot/card/profile` templating)。
+- **多语言**(单 `defaultLocale: zh-CN`);**改 E1 引擎**(已冻结,只消费)。
+
+## Acceptance
+
+- **形态忠实 handoff**:3 个模板保留 `reasoning_stop`/`reasoning_retry`/`reasoning_toggle`
+  三种 action;3 view `wireProfile` 均 `octo/v2`;`views[].states` 齐全
+  (reasoning/answering→active,completed/stopped→result,error→error);view 命名 reports 齐。
+- **ActionContract**:manifest `owner: ai` + `actionType: reasoning.control`;`ai` 已入
+  L2a 白名单;每个 Submit.data 携带 `owner: ai` + `action_type: reasoning.control`;注册期
+  self-check 通过。
+- **conformance**:子包 conformance 测试 —— 每 sample 按 state 选 view 展开 → 与 goldens
+  canonical 字节等价(goldens = as-delivered + Submit.data 补 owner/action_type,机械同步)。
+- **端到端渲染**:`Registry.Render` 渲染 active(reasoning/answering)、result
+  (completed/stopped)、error 三态成功,payload profile=`octo/v2`,过 `cardmsg.Validate`。
+- **注册生效**:`main.go` 注册 + `SetDefault`;boot 不 panic;`Registry.List()` 含
+  `ai.reasoning-process`。
+- **零回归**:`go test ./pkg/cardtmpl/... -race` + `go build ./...` 全绿;既有卡不受影响。
+- **门禁**:gofmt / go vet 干净。
+
+## Risks / decisions(已定)
+
+- **D1 · 决策 A** —— 保留按钮、v2 原样翻(用户 2026-07-23 定)。
+- **D2 · handler 不做** —— 按钮契约合法可路由,但停止/重推理 handler + RouteSpec + bot
+  下发是下游;本任务按钮点击暂无 route(用户 2026-07-23 定)。
+- **D3 · owner `ai`** —— 加 L2a 白名单,actionType `reasoning.control`;两个按钮
+  (stop/retry)共用该 route,靠 Submit.data `effect`(stop_reasoning/retry_reasoning)区分。
+- **D4 · 版本 `0.1.0`** —— as-delivered 从未 publish,直接以其版本号落生产(视觉/按钮不变,
+  仅补注册必需的 owner/action_type + reports 改名)。
+- **D5 · goldens 机械同步** —— templates 与 goldens 同步加 `owner`/`action_type` 两个静态
+  键(非 `${}`,引擎原样透传),engine(template)==golden 自洽;PR 显式标注该 diff。
+- **依赖 PR #654** —— 基于 E1 分支尖;开 PR 前 rebase 到合并后 main,丢引擎 commit(同 #650)。
+

--- a/main.go
+++ b/main.go
@@ -33,6 +33,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-server/pkg/avatarrender"
 	"github.com/Mininglamp-OSS/octo-server/pkg/cardmsg"
 	"github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl"
+	aireasoningprocess "github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl/ai_reasoning_process"
 	docsaccessrequest "github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl/docs_access_request"
 	docscommented "github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl/docs_commented"
 	docsshared "github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl/docs_shared"
@@ -728,6 +729,12 @@ func installCardTmplRegistry() {
 	registry.SetDefault(summarycompleted.TemplateID, summarycompleted.TemplateVersion)
 	registry.Register(summaryfailed.New(), summaryfailed.Assets, summaryfailed.HandoffRoot)
 	registry.SetDefault(summaryfailed.TemplateID, summaryfailed.TemplateVersion)
+	// roadmap E1:首张 JSON 模板卡 —— ai.reasoning-process 走 RegisterJSON,由基座
+	// 编译 .template.json,无手写 Go Build()。active/error 为 octo/v2(带 Submit,
+	// owner=ai),result 为 octo/v1(仅折叠)。按钮的 handler + RouteSpec + bot 流式
+	// 下发是下游任务,本卡先注册可渲染。
+	registry.RegisterJSON(aireasoningprocess.Assets, aireasoningprocess.HandoffRoot)
+	registry.SetDefault(aireasoningprocess.TemplateID, aireasoningprocess.TemplateVersion)
 	registry.Freeze()
 	cardtmpl.SetGlobalMetrics(cardtmpl.NewMetrics(prometheus.DefaultRegisterer))
 	cardtmpl.SetDefaultRegistry(registry)

--- a/pkg/cardtmpl/ai_reasoning_process/card.go
+++ b/pkg/cardtmpl/ai_reasoning_process/card.go
@@ -1,0 +1,40 @@
+// Package aireasoningprocess wires the AI reasoning-process progress card
+// (ai.reasoning-process@0.1.0) into the cardtmpl base. Unlike the Go-authored
+// L2a cards, this card ships as a pure JSON handoff (roadmap E1): it has no
+// hand-written Template — the base compiles its `.template.json` views via
+// Registry.RegisterJSON. This package only embeds the handoff assets and
+// exposes their identity for the composition root.
+//
+// Registration (in the composition root):
+//
+//	registry.RegisterJSON(aireasoningprocess.Assets, aireasoningprocess.HandoffRoot)
+//	registry.SetDefault(aireasoningprocess.TemplateID, aireasoningprocess.TemplateVersion)
+//
+// Layering: L1 JSON artifacts live under handoff/. The card carries the
+// producer's own action buttons (reasoning_stop / reasoning_retry Submit +
+// reasoning_toggle) under a fixed platform owner "ai" / action_type
+// "reasoning.control"; the active/error views are octo/v2, the display-only
+// result view is octo/v1. The server-side handler + RouteSpec that make the
+// buttons act (stop / retry a reasoning run) and the bot streaming delivery are
+// deliberately downstream — see the task brief cardtmpl-reasoning-progress-card.
+package aireasoningprocess
+
+import (
+	"embed"
+
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl"
+)
+
+// Assets embeds the handoff contract resources, loaded by Registry.RegisterJSON.
+//
+//go:embed all:handoff
+var Assets embed.FS
+
+const (
+	// HandoffRoot is the root path of the embedded handoff assets.
+	HandoffRoot = "handoff/ai.reasoning-process@0.1.0"
+	// TemplateID is the stable card identifier.
+	TemplateID cardtmpl.ID = "ai.reasoning-process"
+	// TemplateVersion is this card's current version.
+	TemplateVersion = "0.1.0"
+)

--- a/pkg/cardtmpl/ai_reasoning_process/card_test.go
+++ b/pkg/cardtmpl/ai_reasoning_process/card_test.go
@@ -1,0 +1,171 @@
+package aireasoningprocess_test
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl"
+	aireasoningprocess "github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl/ai_reasoning_process"
+)
+
+func newRegistry(t *testing.T) *cardtmpl.Registry {
+	t.Helper()
+	reg := cardtmpl.NewRegistry()
+	// Successful RegisterJSON is itself the fail-close assertion: it runs the
+	// sample self-check, which for the v2 views (active/error) verifies every
+	// Action.Submit.data carries {owner: ai, action_type: reasoning.control}.
+	reg.RegisterJSON(aireasoningprocess.Assets, aireasoningprocess.HandoffRoot)
+	reg.SetDefault(aireasoningprocess.TemplateID, aireasoningprocess.TemplateVersion)
+	reg.Freeze()
+	return reg
+}
+
+func TestRegisters(t *testing.T) {
+	reg := newRegistry(t)
+	found := false
+	for _, m := range reg.List() {
+		if m.ID == aireasoningprocess.TemplateID {
+			found = true
+			if m.ActionContract == nil || m.ActionContract.Owner != "ai" ||
+				m.ActionContract.ActionType != "reasoning.control" {
+				t.Fatalf("ActionContract = %+v, want {ai, reasoning.control}", m.ActionContract)
+			}
+		}
+	}
+	if !found {
+		t.Fatal("ai.reasoning-process not in Registry.List()")
+	}
+}
+
+func TestRenderAllStates(t *testing.T) {
+	reg := newRegistry(t)
+	cases := []struct {
+		state   cardtmpl.State
+		profile string
+	}{
+		{"reasoning", "octo/v2"},
+		{"answering", "octo/v2"},
+		{"completed", "octo/v1"},
+		{"stopped", "octo/v1"},
+		{"error", "octo/v2"},
+	}
+	for _, tc := range cases {
+		t.Run(string(tc.state), func(t *testing.T) {
+			fields := readSample(t, string(tc.state))
+			payload, err := reg.Render(context.Background(), aireasoningprocess.TemplateID,
+				aireasoningprocess.TemplateVersion, tc.state, fields,
+				cardtmpl.BuildEnv{Lang: "zh-CN", SpaceID: "space-x"})
+			if err != nil {
+				t.Fatalf("Render(%s): %v", tc.state, err)
+			}
+			if got, _ := payload["profile"].(string); got != tc.profile {
+				t.Fatalf("profile = %q, want %q", got, tc.profile)
+			}
+		})
+	}
+}
+
+// TestConformance renders each sample and asserts the card node (minus the
+// base-injected metadata) matches the shipped golden (minus its $schema),
+// canonical JSON. Goldens carry the owner/action_type keys injected into every
+// Submit.data, so this also locks that the rendered card carries them.
+func TestConformance(t *testing.T) {
+	reg := newRegistry(t)
+	samples := []string{"reasoning", "answering", "completed", "stopped", "error"}
+	for _, name := range samples {
+		t.Run(name, func(t *testing.T) {
+			fields := readSample(t, name)
+			state := cardtmpl.State(mustState(t, fields))
+			cardRaw, _, err := reg.RenderCard(context.Background(), aireasoningprocess.TemplateID,
+				aireasoningprocess.TemplateVersion, state, fields,
+				cardtmpl.BuildEnv{Lang: "zh-CN", SpaceID: "space-x"})
+			if err != nil {
+				t.Fatalf("RenderCard(%s): %v", name, err)
+			}
+			var card map[string]any
+			if err := json.Unmarshal(cardRaw, &card); err != nil {
+				t.Fatalf("unmarshal card: %v", err)
+			}
+			delete(card, "metadata") // base-injected; not in golden
+
+			golden := readGolden(t, name)
+			delete(golden, "$schema") // authoring-tool artifact; not emitted by renderCore
+
+			if g, w := canon(t, card), canon(t, golden); g != w {
+				t.Fatalf("golden mismatch for %s\n--- got ---\n%s\n--- want ---\n%s", name, g, w)
+			}
+		})
+	}
+}
+
+func readSample(t *testing.T, name string) json.RawMessage {
+	t.Helper()
+	b, err := os.ReadFile(filepath.Join("handoff", "ai.reasoning-process@0.1.0", "samples", name+".json"))
+	if err != nil {
+		t.Fatalf("read sample %s: %v", name, err)
+	}
+	return json.RawMessage(b)
+}
+
+func readGolden(t *testing.T, name string) map[string]any {
+	t.Helper()
+	b, err := os.ReadFile(filepath.Join("handoff", "ai.reasoning-process@0.1.0", "goldens", name+".card.json"))
+	if err != nil {
+		t.Fatalf("read golden %s: %v", name, err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(b, &m); err != nil {
+		t.Fatalf("unmarshal golden %s: %v", name, err)
+	}
+	return m
+}
+
+func mustState(t *testing.T, fields json.RawMessage) string {
+	t.Helper()
+	var m map[string]any
+	if err := json.Unmarshal(fields, &m); err != nil {
+		t.Fatalf("unmarshal fields: %v", err)
+	}
+	s, _ := m["state"].(string)
+	if s == "" {
+		t.Fatal("sample missing state")
+	}
+	return s
+}
+
+func canon(t *testing.T, v any) string {
+	t.Helper()
+	b, err := json.MarshalIndent(sortKeys(v), "", "  ")
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return string(b)
+}
+
+func sortKeys(v any) any {
+	switch x := v.(type) {
+	case map[string]any:
+		ks := make([]string, 0, len(x))
+		for k := range x {
+			ks = append(ks, k)
+		}
+		sort.Strings(ks)
+		m := make(map[string]any, len(x))
+		for _, k := range ks {
+			m[k] = sortKeys(x[k])
+		}
+		return m
+	case []any:
+		out := make([]any, len(x))
+		for i := range x {
+			out[i] = sortKeys(x[i])
+		}
+		return out
+	default:
+		return v
+	}
+}

--- a/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.1.0/contract/data.schema.json
+++ b/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.1.0/contract/data.schema.json
@@ -1,0 +1,241 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "推理过程卡数据契约",
+  "description": "AI 推理过程附件的展示型 ViewModel。消息作者、头像、时间与最终 Markdown 回答由消息容器负责，不进入卡片契约。",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "reasoningId",
+    "state",
+    "title",
+    "statusLabel",
+    "statusTone",
+    "timerText",
+    "traceExpanded",
+    "traceCollapsed",
+    "collapsedSummary",
+    "phases"
+  ],
+  "properties": {
+    "reasoningId": {
+      "type": "string",
+      "minLength": 1,
+      "description": "本轮推理的稳定标识，会随停止或重试动作回传。",
+      "examples": [
+        "reasoning-channel-b-001"
+      ]
+    },
+    "state": {
+      "type": "string",
+      "enum": [
+        "reasoning",
+        "answering",
+        "completed",
+        "stopped",
+        "error"
+      ],
+      "description": "卡片当前状态；宿主据此选择 active、result 或 error View。"
+    },
+    "title": {
+      "type": "string",
+      "minLength": 1,
+      "description": "推理卡标题。",
+      "examples": [
+        "已深度思考"
+      ]
+    },
+    "statusLabel": {
+      "type": "string",
+      "minLength": 1,
+      "description": "面向用户的状态文案。"
+    },
+    "statusTone": {
+      "type": "string",
+      "enum": [
+        "Accent",
+        "Good",
+        "Warning",
+        "Attention"
+      ],
+      "description": "Adaptive Cards 标准语义色。"
+    },
+    "timerText": {
+      "type": "string",
+      "minLength": 1,
+      "description": "耗时、阶段数和工具调用数的展示文案。"
+    },
+    "traceExpanded": {
+      "type": "boolean",
+      "description": "初始是否展示推理明细。"
+    },
+    "traceCollapsed": {
+      "type": "boolean",
+      "description": "初始是否展示收起摘要；应与 traceExpanded 互斥。"
+    },
+    "collapsedSummary": {
+      "type": "string",
+      "minLength": 1,
+      "description": "推理明细收起时的摘要。"
+    },
+    "progressText": {
+      "type": "string",
+      "minLength": 1,
+      "description": "活动态底部的实时进度提示。"
+    },
+    "phases": {
+      "type": "array",
+      "minItems": 1,
+      "description": "按发生顺序排列的推理阶段。仅包含可向用户展示的过程摘要，不承载隐藏的模型内部思维。",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "thought",
+          "actions"
+        ],
+        "properties": {
+          "thought": {
+            "type": "string",
+            "minLength": 1,
+            "description": "该阶段面向用户的推理摘要。"
+          },
+          "actions": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "tool",
+                "detail",
+                "statusGlyph",
+                "statusTone"
+              ],
+              "properties": {
+                "tool": {
+                  "type": "string",
+                  "minLength": 1,
+                  "description": "工具或步骤名称。"
+                },
+                "detail": {
+                  "type": "string",
+                  "minLength": 1,
+                  "description": "已脱敏的调用摘要。"
+                },
+                "statusGlyph": {
+                  "type": "string",
+                  "minLength": 1,
+                  "maxLength": 2,
+                  "description": "调用状态符号，例如 ●。"
+                },
+                "statusTone": {
+                  "type": "string",
+                  "enum": [
+                    "Accent",
+                    "Good",
+                    "Attention"
+                  ],
+                  "description": "工具调用状态的标准语义色。"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "errorTitle": {
+      "type": "string",
+      "minLength": 1,
+      "description": "失败态标题。"
+    },
+    "errorMessage": {
+      "type": "string",
+      "minLength": 1,
+      "description": "失败原因与用户可采取动作。"
+    }
+  },
+  "allOf": [
+    {
+      "oneOf": [
+        {
+          "properties": {
+            "traceExpanded": {
+              "const": true
+            },
+            "traceCollapsed": {
+              "const": false
+            }
+          }
+        },
+        {
+          "properties": {
+            "traceExpanded": {
+              "const": false
+            },
+            "traceCollapsed": {
+              "const": true
+            }
+          }
+        }
+      ]
+    },
+    {
+      "if": {
+        "properties": {
+          "state": {
+            "enum": [
+              "reasoning",
+              "answering"
+            ]
+          }
+        }
+      },
+      "then": {
+        "required": [
+          "progressText"
+        ]
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "state": {
+            "const": "error"
+          }
+        }
+      },
+      "then": {
+        "required": [
+          "errorTitle",
+          "errorMessage"
+        ]
+      }
+    }
+  ],
+  "examples": [
+    {
+      "reasoningId": "reasoning-channel-b-001",
+      "state": "completed",
+      "title": "已深度思考",
+      "statusLabel": "已完成",
+      "statusTone": "Good",
+      "timerText": "用时 12 秒 · 3 段推理 · 13 次工具调用",
+      "traceExpanded": false,
+      "traceCollapsed": true,
+      "collapsedSummary": "已思考 12 秒 · 推理过程已收起",
+      "phases": [
+        {
+          "thought": "先拆解漏斗并核对近 90 天数据。",
+          "actions": [
+            {
+              "tool": "query_metrics",
+              "detail": "channel=B · range=90d",
+              "statusGlyph": "●",
+              "statusTone": "Good"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.1.0/goldens/answering.card.json
+++ b/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.1.0/goldens/answering.card.json
@@ -1,0 +1,696 @@
+{
+  "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+  "type": "AdaptiveCard",
+  "version": "1.5",
+  "body": [
+    {
+      "type": "Container",
+      "id": "octo-surface-accent-header-reasoning-active",
+      "style": "accent",
+      "bleed": true,
+      "spacing": "None",
+      "items": [
+        {
+          "type": "ColumnSet",
+          "spacing": "None",
+          "columns": [
+            {
+              "type": "Column",
+              "width": "stretch",
+              "verticalContentAlignment": "Center",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "text": "✦  已深度思考",
+                  "color": "Accent",
+                  "weight": "Bolder",
+                  "wrap": true,
+                  "spacing": "None"
+                },
+                {
+                  "type": "TextBlock",
+                  "text": "正在生成回答…",
+                  "size": "Small",
+                  "isSubtle": true,
+                  "wrap": true,
+                  "spacing": "Small"
+                }
+              ]
+            },
+            {
+              "type": "Column",
+              "width": "auto",
+              "verticalContentAlignment": "Center",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "id": "octo-badge-reasoning-active-status",
+                  "text": "回答中",
+                  "color": "Accent",
+                  "weight": "Bolder",
+                  "size": "Small",
+                  "wrap": true,
+                  "spacing": "None"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "id": "trace_panel",
+      "isVisible": true,
+      "spacing": "Large",
+      "items": [
+        {
+          "type": "Container",
+          "spacing": "None",
+          "separator": false,
+          "items": [
+            {
+              "type": "TextBlock",
+              "text": "先拆分线索、试用激活与付费三段漏斗，核对近 90 天数据。",
+              "size": "Small",
+              "wrap": true,
+              "spacing": "None"
+            },
+            {
+              "type": "Container",
+              "style": "emphasis",
+              "spacing": "Small",
+              "items": [
+                {
+                  "type": "ColumnSet",
+                  "spacing": "None",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "query_metrics",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "channel=B · range=90d · group=stage",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "read_file",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "~/analytics/funnel_definition.sql · ×2",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "run_sql",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "按漏斗阶段汇总数量与转化率",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "Container",
+          "spacing": "Large",
+          "separator": true,
+          "items": [
+            {
+              "type": "TextBlock",
+              "text": "激活率的降幅高于线索量，交叉核验行业结构、客服工单、NPS 与季节性。",
+              "size": "Small",
+              "wrap": true,
+              "spacing": "None"
+            },
+            {
+              "type": "Container",
+              "style": "emphasis",
+              "spacing": "Small",
+              "items": [
+                {
+                  "type": "ColumnSet",
+                  "spacing": "None",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "query_metrics",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "按行业拆分激活率",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "search_tickets",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "渠道 B · 试用 / 激活失败 · 近 60 天",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "read_file",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "~/nps/2026Q2_channelB.csv",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "query_metrics",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "叠加节假日与季节性校正",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "Container",
+          "spacing": "Large",
+          "separator": true,
+          "items": [
+            {
+              "type": "TextBlock",
+              "text": "主因确认：教育与专业服务合计贡献 63% 降幅，激活断点集中在试用权益触达。",
+              "size": "Small",
+              "wrap": true,
+              "spacing": "None"
+            },
+            {
+              "type": "Container",
+              "style": "emphasis",
+              "spacing": "Small",
+              "items": [
+                {
+                  "type": "ColumnSet",
+                  "spacing": "None",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "run_sql",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "按行业汇总转化降幅贡献",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "edit_file",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "~/reports/channelB_rootcause.md · 已编辑",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Accent",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "think",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "正在组织结论、证据与下周建议…",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "TextBlock",
+          "text": "◌  推理已完成，正在生成回答…",
+          "color": "Accent",
+          "size": "Small",
+          "wrap": true,
+          "spacing": "Large"
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "id": "collapsed_panel",
+      "isVisible": false,
+      "spacing": "Medium",
+      "items": [
+        {
+          "type": "TextBlock",
+          "text": "✓  推理已完成 · 回答正在生成",
+          "size": "Small",
+          "isSubtle": true,
+          "wrap": true,
+          "spacing": "None"
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "id": "octo-surface-default-footer-reasoning-active",
+      "style": "emphasis",
+      "bleed": true,
+      "separator": true,
+      "spacing": "Large",
+      "items": [
+        {
+          "type": "ActionSet",
+          "horizontalAlignment": "Right",
+          "actions": [
+            {
+              "type": "Action.Submit",
+              "id": "reasoning_stop",
+              "title": "停止",
+              "style": "destructive",
+              "associatedInputs": "none",
+              "data": {
+                "action": "reasoning_stop",
+                "effect": "stop_reasoning",
+                "reasoning_id": "reasoning-channel-b-001",
+                "owner": "ai",
+                "action_type": "reasoning.control"
+              }
+            },
+            {
+              "type": "Action.ToggleVisibility",
+              "id": "reasoning_toggle",
+              "title": "显示 / 隐藏推理",
+              "targetElements": [
+                "trace_panel",
+                "collapsed_panel"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.1.0/goldens/completed.card.json
+++ b/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.1.0/goldens/completed.card.json
@@ -1,0 +1,784 @@
+{
+  "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+  "type": "AdaptiveCard",
+  "version": "1.5",
+  "body": [
+    {
+      "type": "Container",
+      "id": "octo-surface-accent-header-reasoning-result",
+      "style": "accent",
+      "bleed": true,
+      "spacing": "None",
+      "items": [
+        {
+          "type": "ColumnSet",
+          "spacing": "None",
+          "columns": [
+            {
+              "type": "Column",
+              "width": "stretch",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "text": "✦  已深度思考",
+                  "color": "Accent",
+                  "weight": "Bolder",
+                  "wrap": true,
+                  "spacing": "None"
+                },
+                {
+                  "type": "TextBlock",
+                  "text": "用时 12 秒 · 3 段推理 · 13 次工具调用",
+                  "size": "Small",
+                  "isSubtle": true,
+                  "wrap": true,
+                  "spacing": "Small"
+                }
+              ]
+            },
+            {
+              "type": "Column",
+              "width": "auto",
+              "verticalContentAlignment": "Center",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "id": "octo-badge-reasoning-result-status",
+                  "text": "已完成",
+                  "color": "Good",
+                  "weight": "Bolder",
+                  "size": "Small",
+                  "wrap": true,
+                  "spacing": "None"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "id": "trace_panel",
+      "isVisible": false,
+      "spacing": "Large",
+      "items": [
+        {
+          "type": "Container",
+          "spacing": "None",
+          "separator": false,
+          "items": [
+            {
+              "type": "TextBlock",
+              "text": "先把渠道 B 转化下降的范围圈出来：拆成线索、试用激活、付费三段漏斗，取近 90 天数据。",
+              "size": "Small",
+              "wrap": true,
+              "spacing": "None"
+            },
+            {
+              "type": "Container",
+              "style": "emphasis",
+              "spacing": "Small",
+              "items": [
+                {
+                  "type": "ColumnSet",
+                  "spacing": "None",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "query_metrics",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "channel=B · range=90d · group=stage",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "read_file",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "~/analytics/funnel_definition.sql · ×2",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "run_sql",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "按漏斗阶段汇总数量与转化率",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "Container",
+          "spacing": "Large",
+          "separator": true,
+          "items": [
+            {
+              "type": "TextBlock",
+              "text": "激活率的降幅高于线索量，交叉核验行业结构、客服工单、NPS 与季节性。",
+              "size": "Small",
+              "wrap": true,
+              "spacing": "None"
+            },
+            {
+              "type": "Container",
+              "style": "emphasis",
+              "spacing": "Small",
+              "items": [
+                {
+                  "type": "ColumnSet",
+                  "spacing": "None",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "query_metrics",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "按行业拆分激活率",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "run_sql",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "对比各行业激活与付费转化",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "search_tickets",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "渠道 B · 试用 / 激活失败 · 近 60 天",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "read_file",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "~/nps/2026Q2_channelB.csv",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "query_metrics",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "叠加节假日与季节性校正",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "run_sql",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "逐周复核线索与激活数量",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "web_search",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "SaaS 行业 2026 试用政策调整",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "Container",
+          "spacing": "Large",
+          "separator": true,
+          "items": [
+            {
+              "type": "TextBlock",
+              "text": "主因确认：教育与专业服务合计贡献 63% 降幅，激活断点集中在试用权益触达。",
+              "size": "Small",
+              "wrap": true,
+              "spacing": "None"
+            },
+            {
+              "type": "Container",
+              "style": "emphasis",
+              "spacing": "Small",
+              "items": [
+                {
+                  "type": "ColumnSet",
+                  "spacing": "None",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "run_sql",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "按行业汇总转化降幅贡献",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "edit_file",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "~/reports/channelB_rootcause.md · 已编辑",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "think",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "拆分行业漏斗深挖与权益触达复盘",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "id": "collapsed_panel",
+      "isVisible": true,
+      "spacing": "Medium",
+      "items": [
+        {
+          "type": "TextBlock",
+          "text": "✓  已思考 12 秒 · 推理过程已收起",
+          "size": "Small",
+          "isSubtle": true,
+          "wrap": true,
+          "spacing": "None"
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "id": "octo-surface-default-footer-reasoning-result",
+      "style": "emphasis",
+      "bleed": true,
+      "separator": true,
+      "spacing": "Large",
+      "items": [
+        {
+          "type": "ActionSet",
+          "horizontalAlignment": "Right",
+          "actions": [
+            {
+              "type": "Action.ToggleVisibility",
+              "id": "reasoning_toggle",
+              "title": "显示 / 隐藏推理",
+              "targetElements": [
+                "trace_panel",
+                "collapsed_panel"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.1.0/goldens/error.card.json
+++ b/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.1.0/goldens/error.card.json
@@ -1,0 +1,422 @@
+{
+  "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+  "type": "AdaptiveCard",
+  "version": "1.5",
+  "body": [
+    {
+      "type": "Container",
+      "id": "octo-surface-accent-header-reasoning-error",
+      "style": "accent",
+      "bleed": true,
+      "spacing": "None",
+      "items": [
+        {
+          "type": "ColumnSet",
+          "spacing": "None",
+          "columns": [
+            {
+              "type": "Column",
+              "width": "stretch",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "text": "✦  已深度思考",
+                  "color": "Accent",
+                  "weight": "Bolder",
+                  "wrap": true,
+                  "spacing": "None"
+                },
+                {
+                  "type": "TextBlock",
+                  "text": "已中断",
+                  "size": "Small",
+                  "isSubtle": true,
+                  "wrap": true,
+                  "spacing": "Small"
+                }
+              ]
+            },
+            {
+              "type": "Column",
+              "width": "auto",
+              "verticalContentAlignment": "Center",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "id": "octo-badge-reasoning-error-status",
+                  "text": "生成失败",
+                  "color": "Attention",
+                  "weight": "Bolder",
+                  "size": "Small",
+                  "wrap": true,
+                  "spacing": "None"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "id": "trace_panel",
+      "isVisible": true,
+      "spacing": "Large",
+      "items": [
+        {
+          "type": "Container",
+          "spacing": "None",
+          "separator": false,
+          "items": [
+            {
+              "type": "TextBlock",
+              "text": "先拆分线索、试用激活与付费三段漏斗，核对近 90 天数据。",
+              "size": "Small",
+              "wrap": true,
+              "spacing": "None"
+            },
+            {
+              "type": "Container",
+              "style": "emphasis",
+              "spacing": "Small",
+              "items": [
+                {
+                  "type": "ColumnSet",
+                  "spacing": "None",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "query_metrics",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "channel=B · range=90d · group=stage",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "read_file",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "~/analytics/funnel_definition.sql · ×2",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "run_sql",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "按漏斗阶段汇总数量与转化率",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "Container",
+          "spacing": "Large",
+          "separator": true,
+          "items": [
+            {
+              "type": "TextBlock",
+              "text": "准备交叉核验行业结构、客服工单与 NPS 时，推理服务连接中断。",
+              "size": "Small",
+              "wrap": true,
+              "spacing": "None"
+            },
+            {
+              "type": "Container",
+              "style": "emphasis",
+              "spacing": "Small",
+              "items": [
+                {
+                  "type": "ColumnSet",
+                  "spacing": "None",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "query_metrics",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "按行业拆分激活率",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Attention",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "search_tickets",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "连接超时，调用未完成",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "id": "collapsed_panel",
+      "isVisible": false,
+      "spacing": "Medium",
+      "items": [
+        {
+          "type": "TextBlock",
+          "text": "生成已中断 · 点击可查看停止前的过程",
+          "size": "Small",
+          "isSubtle": true,
+          "wrap": true,
+          "spacing": "None"
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "style": "attention",
+      "spacing": "Large",
+      "items": [
+        {
+          "type": "TextBlock",
+          "text": "生成失败",
+          "color": "Attention",
+          "weight": "Bolder",
+          "wrap": true,
+          "spacing": "None"
+        },
+        {
+          "type": "TextBlock",
+          "text": "推理服务连接超时，已停止本次生成。可以重试，已完成的过程会保留。",
+          "wrap": true,
+          "spacing": "Small"
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "id": "octo-surface-default-footer-reasoning-error",
+      "style": "emphasis",
+      "bleed": true,
+      "separator": true,
+      "spacing": "Large",
+      "items": [
+        {
+          "type": "ActionSet",
+          "horizontalAlignment": "Right",
+          "actions": [
+            {
+              "type": "Action.Submit",
+              "id": "reasoning_retry",
+              "title": "重试",
+              "style": "positive",
+              "associatedInputs": "none",
+              "data": {
+                "action": "reasoning_retry",
+                "effect": "retry_reasoning",
+                "reasoning_id": "reasoning-channel-b-003",
+                "owner": "ai",
+                "action_type": "reasoning.control"
+              }
+            },
+            {
+              "type": "Action.ToggleVisibility",
+              "id": "reasoning_toggle",
+              "title": "显示 / 隐藏推理",
+              "targetElements": [
+                "trace_panel",
+                "collapsed_panel"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.1.0/goldens/reasoning.card.json
+++ b/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.1.0/goldens/reasoning.card.json
@@ -1,0 +1,525 @@
+{
+  "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+  "type": "AdaptiveCard",
+  "version": "1.5",
+  "body": [
+    {
+      "type": "Container",
+      "id": "octo-surface-accent-header-reasoning-active",
+      "style": "accent",
+      "bleed": true,
+      "spacing": "None",
+      "items": [
+        {
+          "type": "ColumnSet",
+          "spacing": "None",
+          "columns": [
+            {
+              "type": "Column",
+              "width": "stretch",
+              "verticalContentAlignment": "Center",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "text": "✦  已深度思考",
+                  "color": "Accent",
+                  "weight": "Bolder",
+                  "wrap": true,
+                  "spacing": "None"
+                },
+                {
+                  "type": "TextBlock",
+                  "text": "正在深度思考…",
+                  "size": "Small",
+                  "isSubtle": true,
+                  "wrap": true,
+                  "spacing": "Small"
+                }
+              ]
+            },
+            {
+              "type": "Column",
+              "width": "auto",
+              "verticalContentAlignment": "Center",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "id": "octo-badge-reasoning-active-status",
+                  "text": "思考中",
+                  "color": "Accent",
+                  "weight": "Bolder",
+                  "size": "Small",
+                  "wrap": true,
+                  "spacing": "None"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "id": "trace_panel",
+      "isVisible": true,
+      "spacing": "Large",
+      "items": [
+        {
+          "type": "Container",
+          "spacing": "None",
+          "separator": false,
+          "items": [
+            {
+              "type": "TextBlock",
+              "text": "先把渠道 B 转化下降的范围圈出来：拆成线索、试用激活、付费三段漏斗，取近 90 天数据。",
+              "size": "Small",
+              "wrap": true,
+              "spacing": "None"
+            },
+            {
+              "type": "Container",
+              "style": "emphasis",
+              "spacing": "Small",
+              "items": [
+                {
+                  "type": "ColumnSet",
+                  "spacing": "None",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "query_metrics",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "channel=B · range=90d · group=stage",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "read_file",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "~/analytics/funnel_definition.sql · ×2",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "run_sql",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "按漏斗阶段汇总数量与转化率",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "Container",
+          "spacing": "Large",
+          "separator": true,
+          "items": [
+            {
+              "type": "TextBlock",
+              "text": "口径正常，但激活率掉得比线索量快；继续拉行业标签、客服工单和 NPS 交叉验证。",
+              "size": "Small",
+              "wrap": true,
+              "spacing": "None"
+            },
+            {
+              "type": "Container",
+              "style": "emphasis",
+              "spacing": "Small",
+              "items": [
+                {
+                  "type": "ColumnSet",
+                  "spacing": "None",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "query_metrics",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "channel=B · dims=industry · metric=activation_rate",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "search_tickets",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "渠道 B · 试用 / 激活失败 · 近 60 天",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "read_file",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "~/nps/2026Q2_channelB.csv",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Accent",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "query_metrics",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "正在叠加季节性校正…",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "TextBlock",
+          "text": "◌  正在执行下一步…",
+          "color": "Accent",
+          "size": "Small",
+          "wrap": true,
+          "spacing": "Large"
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "id": "collapsed_panel",
+      "isVisible": false,
+      "spacing": "Medium",
+      "items": [
+        {
+          "type": "TextBlock",
+          "text": "✓  推理仍在进行 · 点击可查看当前过程",
+          "size": "Small",
+          "isSubtle": true,
+          "wrap": true,
+          "spacing": "None"
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "id": "octo-surface-default-footer-reasoning-active",
+      "style": "emphasis",
+      "bleed": true,
+      "separator": true,
+      "spacing": "Large",
+      "items": [
+        {
+          "type": "ActionSet",
+          "horizontalAlignment": "Right",
+          "actions": [
+            {
+              "type": "Action.Submit",
+              "id": "reasoning_stop",
+              "title": "停止",
+              "style": "destructive",
+              "associatedInputs": "none",
+              "data": {
+                "action": "reasoning_stop",
+                "effect": "stop_reasoning",
+                "reasoning_id": "reasoning-channel-b-001",
+                "owner": "ai",
+                "action_type": "reasoning.control"
+              }
+            },
+            {
+              "type": "Action.ToggleVisibility",
+              "id": "reasoning_toggle",
+              "title": "显示 / 隐藏推理",
+              "targetElements": [
+                "trace_panel",
+                "collapsed_panel"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.1.0/goldens/stopped.card.json
+++ b/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.1.0/goldens/stopped.card.json
@@ -1,0 +1,387 @@
+{
+  "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+  "type": "AdaptiveCard",
+  "version": "1.5",
+  "body": [
+    {
+      "type": "Container",
+      "id": "octo-surface-accent-header-reasoning-result",
+      "style": "accent",
+      "bleed": true,
+      "spacing": "None",
+      "items": [
+        {
+          "type": "ColumnSet",
+          "spacing": "None",
+          "columns": [
+            {
+              "type": "Column",
+              "width": "stretch",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "text": "✦  已深度思考",
+                  "color": "Accent",
+                  "weight": "Bolder",
+                  "wrap": true,
+                  "spacing": "None"
+                },
+                {
+                  "type": "TextBlock",
+                  "text": "已思考 6 秒 · 已停止于第 2 段",
+                  "size": "Small",
+                  "isSubtle": true,
+                  "wrap": true,
+                  "spacing": "Small"
+                }
+              ]
+            },
+            {
+              "type": "Column",
+              "width": "auto",
+              "verticalContentAlignment": "Center",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "id": "octo-badge-reasoning-result-status",
+                  "text": "已停止",
+                  "color": "Warning",
+                  "weight": "Bolder",
+                  "size": "Small",
+                  "wrap": true,
+                  "spacing": "None"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "id": "trace_panel",
+      "isVisible": false,
+      "spacing": "Large",
+      "items": [
+        {
+          "type": "Container",
+          "spacing": "None",
+          "separator": false,
+          "items": [
+            {
+              "type": "TextBlock",
+              "text": "先拆分线索、试用激活与付费三段漏斗，核对近 90 天数据。",
+              "size": "Small",
+              "wrap": true,
+              "spacing": "None"
+            },
+            {
+              "type": "Container",
+              "style": "emphasis",
+              "spacing": "Small",
+              "items": [
+                {
+                  "type": "ColumnSet",
+                  "spacing": "None",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "query_metrics",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "channel=B · range=90d · group=stage",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "read_file",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "~/analytics/funnel_definition.sql · ×2",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "run_sql",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "按漏斗阶段汇总数量与转化率",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "Container",
+          "spacing": "Large",
+          "separator": true,
+          "items": [
+            {
+              "type": "TextBlock",
+              "text": "激活率降幅高于线索量，开始按行业与试用权益触达交叉核验。",
+              "size": "Small",
+              "wrap": true,
+              "spacing": "None"
+            },
+            {
+              "type": "Container",
+              "style": "emphasis",
+              "spacing": "Small",
+              "items": [
+                {
+                  "type": "ColumnSet",
+                  "spacing": "None",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "query_metrics",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "按行业拆分激活率",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Accent",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "search_tickets",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "调用已由用户停止",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "id": "collapsed_panel",
+      "isVisible": true,
+      "spacing": "Medium",
+      "items": [
+        {
+          "type": "TextBlock",
+          "text": "✓  已保留停止前的 2 段推理过程",
+          "size": "Small",
+          "isSubtle": true,
+          "wrap": true,
+          "spacing": "None"
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "id": "octo-surface-default-footer-reasoning-result",
+      "style": "emphasis",
+      "bleed": true,
+      "separator": true,
+      "spacing": "Large",
+      "items": [
+        {
+          "type": "ActionSet",
+          "horizontalAlignment": "Right",
+          "actions": [
+            {
+              "type": "Action.ToggleVisibility",
+              "id": "reasoning_toggle",
+              "title": "显示 / 隐藏推理",
+              "targetElements": [
+                "trace_panel",
+                "collapsed_panel"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.1.0/manifest.json
+++ b/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.1.0/manifest.json
@@ -1,0 +1,51 @@
+{
+  "schemaVersion": 2,
+  "id": "ai.reasoning-process",
+  "name": "推理过程卡",
+  "version": "0.1.0",
+  "contractVersion": "1.0.0",
+  "protocol": "octo-card@1.0",
+  "adaptiveCardVersion": "1.5",
+  "renderProfile": "octo-chat@1.2.0-rc.1",
+  "renderProfileCompatibility": "octo-chat/v1",
+  "defaultLocale": "zh-CN",
+  "owner": "ai",
+  "actionType": "reasoning.control",
+  "dataSchema": "contract/data.schema.json",
+  "views": {
+    "active": {
+      "wireProfile": "octo/v2",
+      "states": [
+        "reasoning",
+        "answering"
+      ],
+      "template": "templates/active.template.json",
+      "samples": [
+        "samples/reasoning.json",
+        "samples/answering.json"
+      ]
+    },
+    "result": {
+      "wireProfile": "octo/v1",
+      "states": [
+        "completed",
+        "stopped"
+      ],
+      "template": "templates/result.template.json",
+      "samples": [
+        "samples/completed.json",
+        "samples/stopped.json"
+      ]
+    },
+    "error": {
+      "wireProfile": "octo/v2",
+      "states": [
+        "error"
+      ],
+      "template": "templates/error.template.json",
+      "samples": [
+        "samples/error.json"
+      ]
+    }
+  }
+}

--- a/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.1.0/reports/active.interaction.json
+++ b/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.1.0/reports/active.interaction.json
@@ -1,0 +1,22 @@
+{
+  "actions": [
+    {
+      "id": "reasoning_stop",
+      "type": "Action.Submit",
+      "associatedInputs": "none",
+      "dataKeys": [
+        "action",
+        "effect",
+        "reasoning_id",
+        "owner",
+        "action_type"
+      ],
+      "inputIds": []
+    },
+    {
+      "id": "reasoning_toggle",
+      "type": "Action.ToggleVisibility"
+    }
+  ],
+  "inputs": []
+}

--- a/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.1.0/reports/error.interaction.json
+++ b/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.1.0/reports/error.interaction.json
@@ -1,0 +1,22 @@
+{
+  "actions": [
+    {
+      "id": "reasoning_retry",
+      "type": "Action.Submit",
+      "associatedInputs": "none",
+      "dataKeys": [
+        "action",
+        "effect",
+        "reasoning_id",
+        "owner",
+        "action_type"
+      ],
+      "inputIds": []
+    },
+    {
+      "id": "reasoning_toggle",
+      "type": "Action.ToggleVisibility"
+    }
+  ],
+  "inputs": []
+}

--- a/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.1.0/samples/answering.json
+++ b/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.1.0/samples/answering.json
@@ -1,0 +1,89 @@
+{
+  "reasoningId": "reasoning-channel-b-001",
+  "state": "answering",
+  "title": "已深度思考",
+  "statusLabel": "回答中",
+  "statusTone": "Accent",
+  "timerText": "正在生成回答…",
+  "traceExpanded": true,
+  "traceCollapsed": false,
+  "collapsedSummary": "推理已完成 · 回答正在生成",
+  "progressText": "推理已完成，正在生成回答…",
+  "phases": [
+    {
+      "thought": "先拆分线索、试用激活与付费三段漏斗，核对近 90 天数据。",
+      "actions": [
+        {
+          "tool": "query_metrics",
+          "detail": "channel=B · range=90d · group=stage",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "read_file",
+          "detail": "~/analytics/funnel_definition.sql · ×2",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "run_sql",
+          "detail": "按漏斗阶段汇总数量与转化率",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        }
+      ]
+    },
+    {
+      "thought": "激活率的降幅高于线索量，交叉核验行业结构、客服工单、NPS 与季节性。",
+      "actions": [
+        {
+          "tool": "query_metrics",
+          "detail": "按行业拆分激活率",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "search_tickets",
+          "detail": "渠道 B · 试用 / 激活失败 · 近 60 天",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "read_file",
+          "detail": "~/nps/2026Q2_channelB.csv",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "query_metrics",
+          "detail": "叠加节假日与季节性校正",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        }
+      ]
+    },
+    {
+      "thought": "主因确认：教育与专业服务合计贡献 63% 降幅，激活断点集中在试用权益触达。",
+      "actions": [
+        {
+          "tool": "run_sql",
+          "detail": "按行业汇总转化降幅贡献",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "edit_file",
+          "detail": "~/reports/channelB_rootcause.md · 已编辑",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "think",
+          "detail": "正在组织结论、证据与下周建议…",
+          "statusGlyph": "●",
+          "statusTone": "Accent"
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.1.0/samples/completed.json
+++ b/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.1.0/samples/completed.json
@@ -1,0 +1,106 @@
+{
+  "reasoningId": "reasoning-channel-b-001",
+  "state": "completed",
+  "title": "已深度思考",
+  "statusLabel": "已完成",
+  "statusTone": "Good",
+  "timerText": "用时 12 秒 · 3 段推理 · 13 次工具调用",
+  "traceExpanded": false,
+  "traceCollapsed": true,
+  "collapsedSummary": "已思考 12 秒 · 推理过程已收起",
+  "phases": [
+    {
+      "thought": "先把渠道 B 转化下降的范围圈出来：拆成线索、试用激活、付费三段漏斗，取近 90 天数据。",
+      "actions": [
+        {
+          "tool": "query_metrics",
+          "detail": "channel=B · range=90d · group=stage",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "read_file",
+          "detail": "~/analytics/funnel_definition.sql · ×2",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "run_sql",
+          "detail": "按漏斗阶段汇总数量与转化率",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        }
+      ]
+    },
+    {
+      "thought": "激活率的降幅高于线索量，交叉核验行业结构、客服工单、NPS 与季节性。",
+      "actions": [
+        {
+          "tool": "query_metrics",
+          "detail": "按行业拆分激活率",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "run_sql",
+          "detail": "对比各行业激活与付费转化",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "search_tickets",
+          "detail": "渠道 B · 试用 / 激活失败 · 近 60 天",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "read_file",
+          "detail": "~/nps/2026Q2_channelB.csv",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "query_metrics",
+          "detail": "叠加节假日与季节性校正",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "run_sql",
+          "detail": "逐周复核线索与激活数量",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "web_search",
+          "detail": "SaaS 行业 2026 试用政策调整",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        }
+      ]
+    },
+    {
+      "thought": "主因确认：教育与专业服务合计贡献 63% 降幅，激活断点集中在试用权益触达。",
+      "actions": [
+        {
+          "tool": "run_sql",
+          "detail": "按行业汇总转化降幅贡献",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "edit_file",
+          "detail": "~/reports/channelB_rootcause.md · 已编辑",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "think",
+          "detail": "拆分行业漏斗深挖与权益触达复盘",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.1.0/samples/error.json
+++ b/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.1.0/samples/error.json
@@ -1,0 +1,55 @@
+{
+  "reasoningId": "reasoning-channel-b-003",
+  "state": "error",
+  "title": "已深度思考",
+  "statusLabel": "生成失败",
+  "statusTone": "Attention",
+  "timerText": "已中断",
+  "traceExpanded": true,
+  "traceCollapsed": false,
+  "collapsedSummary": "生成已中断 · 点击可查看停止前的过程",
+  "errorTitle": "生成失败",
+  "errorMessage": "推理服务连接超时，已停止本次生成。可以重试，已完成的过程会保留。",
+  "phases": [
+    {
+      "thought": "先拆分线索、试用激活与付费三段漏斗，核对近 90 天数据。",
+      "actions": [
+        {
+          "tool": "query_metrics",
+          "detail": "channel=B · range=90d · group=stage",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "read_file",
+          "detail": "~/analytics/funnel_definition.sql · ×2",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "run_sql",
+          "detail": "按漏斗阶段汇总数量与转化率",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        }
+      ]
+    },
+    {
+      "thought": "准备交叉核验行业结构、客服工单与 NPS 时，推理服务连接中断。",
+      "actions": [
+        {
+          "tool": "query_metrics",
+          "detail": "按行业拆分激活率",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "search_tickets",
+          "detail": "连接超时，调用未完成",
+          "statusGlyph": "●",
+          "statusTone": "Attention"
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.1.0/samples/reasoning.json
+++ b/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.1.0/samples/reasoning.json
@@ -1,0 +1,66 @@
+{
+  "reasoningId": "reasoning-channel-b-001",
+  "state": "reasoning",
+  "title": "已深度思考",
+  "statusLabel": "思考中",
+  "statusTone": "Accent",
+  "timerText": "正在深度思考…",
+  "traceExpanded": true,
+  "traceCollapsed": false,
+  "collapsedSummary": "推理仍在进行 · 点击可查看当前过程",
+  "progressText": "正在执行下一步…",
+  "phases": [
+    {
+      "thought": "先把渠道 B 转化下降的范围圈出来：拆成线索、试用激活、付费三段漏斗，取近 90 天数据。",
+      "actions": [
+        {
+          "tool": "query_metrics",
+          "detail": "channel=B · range=90d · group=stage",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "read_file",
+          "detail": "~/analytics/funnel_definition.sql · ×2",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "run_sql",
+          "detail": "按漏斗阶段汇总数量与转化率",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        }
+      ]
+    },
+    {
+      "thought": "口径正常，但激活率掉得比线索量快；继续拉行业标签、客服工单和 NPS 交叉验证。",
+      "actions": [
+        {
+          "tool": "query_metrics",
+          "detail": "channel=B · dims=industry · metric=activation_rate",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "search_tickets",
+          "detail": "渠道 B · 试用 / 激活失败 · 近 60 天",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "read_file",
+          "detail": "~/nps/2026Q2_channelB.csv",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "query_metrics",
+          "detail": "正在叠加季节性校正…",
+          "statusGlyph": "●",
+          "statusTone": "Accent"
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.1.0/samples/stopped.json
+++ b/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.1.0/samples/stopped.json
@@ -1,0 +1,53 @@
+{
+  "reasoningId": "reasoning-channel-b-002",
+  "state": "stopped",
+  "title": "已深度思考",
+  "statusLabel": "已停止",
+  "statusTone": "Warning",
+  "timerText": "已思考 6 秒 · 已停止于第 2 段",
+  "traceExpanded": false,
+  "traceCollapsed": true,
+  "collapsedSummary": "已保留停止前的 2 段推理过程",
+  "phases": [
+    {
+      "thought": "先拆分线索、试用激活与付费三段漏斗，核对近 90 天数据。",
+      "actions": [
+        {
+          "tool": "query_metrics",
+          "detail": "channel=B · range=90d · group=stage",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "read_file",
+          "detail": "~/analytics/funnel_definition.sql · ×2",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "run_sql",
+          "detail": "按漏斗阶段汇总数量与转化率",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        }
+      ]
+    },
+    {
+      "thought": "激活率降幅高于线索量，开始按行业与试用权益触达交叉核验。",
+      "actions": [
+        {
+          "tool": "query_metrics",
+          "detail": "按行业拆分激活率",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "search_tickets",
+          "detail": "调用已由用户停止",
+          "statusGlyph": "●",
+          "statusTone": "Accent"
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.1.0/templates/active.template.json
+++ b/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.1.0/templates/active.template.json
@@ -1,0 +1,206 @@
+{
+  "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+  "type": "AdaptiveCard",
+  "version": "1.5",
+  "body": [
+    {
+      "type": "Container",
+      "id": "octo-surface-accent-header-reasoning-active",
+      "style": "accent",
+      "bleed": true,
+      "spacing": "None",
+      "items": [
+        {
+          "type": "ColumnSet",
+          "spacing": "None",
+          "columns": [
+            {
+              "type": "Column",
+              "width": "stretch",
+              "verticalContentAlignment": "Center",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "text": "✦  ${title}",
+                  "color": "Accent",
+                  "weight": "Bolder",
+                  "wrap": true,
+                  "spacing": "None"
+                },
+                {
+                  "type": "TextBlock",
+                  "text": "${timerText}",
+                  "size": "Small",
+                  "isSubtle": true,
+                  "wrap": true,
+                  "spacing": "Small"
+                }
+              ]
+            },
+            {
+              "type": "Column",
+              "width": "auto",
+              "verticalContentAlignment": "Center",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "id": "octo-badge-reasoning-active-status",
+                  "text": "${statusLabel}",
+                  "color": "${statusTone}",
+                  "weight": "Bolder",
+                  "size": "Small",
+                  "wrap": true,
+                  "spacing": "None"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "id": "trace_panel",
+      "isVisible": "${traceExpanded}",
+      "spacing": "Large",
+      "items": [
+        {
+          "$data": "${phases}",
+          "type": "Container",
+          "spacing": "${if($index == 0, 'None', 'Large')}",
+          "separator": "${if($index == 0, false, true)}",
+          "items": [
+            {
+              "type": "TextBlock",
+              "text": "${thought}",
+              "size": "Small",
+              "wrap": true,
+              "spacing": "None"
+            },
+            {
+              "type": "Container",
+              "style": "emphasis",
+              "spacing": "Small",
+              "items": [
+                {
+                  "$data": "${actions}",
+                  "type": "ColumnSet",
+                  "spacing": "${if($index == 0, 'None', 'Small')}",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "${statusGlyph}",
+                          "color": "${statusTone}",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "${tool}",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "${detail}",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "TextBlock",
+          "text": "◌  ${progressText}",
+          "color": "Accent",
+          "size": "Small",
+          "wrap": true,
+          "spacing": "Large"
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "id": "collapsed_panel",
+      "isVisible": "${traceCollapsed}",
+      "spacing": "Medium",
+      "items": [
+        {
+          "type": "TextBlock",
+          "text": "✓  ${collapsedSummary}",
+          "size": "Small",
+          "isSubtle": true,
+          "wrap": true,
+          "spacing": "None"
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "id": "octo-surface-default-footer-reasoning-active",
+      "style": "emphasis",
+      "bleed": true,
+      "separator": true,
+      "spacing": "Large",
+      "items": [
+        {
+          "type": "ActionSet",
+          "horizontalAlignment": "Right",
+          "actions": [
+            {
+              "type": "Action.Submit",
+              "id": "reasoning_stop",
+              "title": "停止",
+              "style": "destructive",
+              "associatedInputs": "none",
+              "data": {
+                "action": "reasoning_stop",
+                "effect": "stop_reasoning",
+                "reasoning_id": "${reasoningId}",
+                "owner": "ai",
+                "action_type": "reasoning.control"
+              }
+            },
+            {
+              "type": "Action.ToggleVisibility",
+              "id": "reasoning_toggle",
+              "title": "显示 / 隐藏推理",
+              "targetElements": [
+                "trace_panel",
+                "collapsed_panel"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.1.0/templates/error.template.json
+++ b/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.1.0/templates/error.template.json
@@ -1,0 +1,215 @@
+{
+  "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+  "type": "AdaptiveCard",
+  "version": "1.5",
+  "body": [
+    {
+      "type": "Container",
+      "id": "octo-surface-accent-header-reasoning-error",
+      "style": "accent",
+      "bleed": true,
+      "spacing": "None",
+      "items": [
+        {
+          "type": "ColumnSet",
+          "spacing": "None",
+          "columns": [
+            {
+              "type": "Column",
+              "width": "stretch",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "text": "✦  ${title}",
+                  "color": "Accent",
+                  "weight": "Bolder",
+                  "wrap": true,
+                  "spacing": "None"
+                },
+                {
+                  "type": "TextBlock",
+                  "text": "${timerText}",
+                  "size": "Small",
+                  "isSubtle": true,
+                  "wrap": true,
+                  "spacing": "Small"
+                }
+              ]
+            },
+            {
+              "type": "Column",
+              "width": "auto",
+              "verticalContentAlignment": "Center",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "id": "octo-badge-reasoning-error-status",
+                  "text": "${statusLabel}",
+                  "color": "${statusTone}",
+                  "weight": "Bolder",
+                  "size": "Small",
+                  "wrap": true,
+                  "spacing": "None"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "id": "trace_panel",
+      "isVisible": "${traceExpanded}",
+      "spacing": "Large",
+      "items": [
+        {
+          "$data": "${phases}",
+          "type": "Container",
+          "spacing": "${if($index == 0, 'None', 'Large')}",
+          "separator": "${if($index == 0, false, true)}",
+          "items": [
+            {
+              "type": "TextBlock",
+              "text": "${thought}",
+              "size": "Small",
+              "wrap": true,
+              "spacing": "None"
+            },
+            {
+              "type": "Container",
+              "style": "emphasis",
+              "spacing": "Small",
+              "items": [
+                {
+                  "$data": "${actions}",
+                  "type": "ColumnSet",
+                  "spacing": "${if($index == 0, 'None', 'Small')}",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "${statusGlyph}",
+                          "color": "${statusTone}",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "${tool}",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "${detail}",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "id": "collapsed_panel",
+      "isVisible": "${traceCollapsed}",
+      "spacing": "Medium",
+      "items": [
+        {
+          "type": "TextBlock",
+          "text": "${collapsedSummary}",
+          "size": "Small",
+          "isSubtle": true,
+          "wrap": true,
+          "spacing": "None"
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "style": "attention",
+      "spacing": "Large",
+      "items": [
+        {
+          "type": "TextBlock",
+          "text": "${errorTitle}",
+          "color": "Attention",
+          "weight": "Bolder",
+          "wrap": true,
+          "spacing": "None"
+        },
+        {
+          "type": "TextBlock",
+          "text": "${errorMessage}",
+          "wrap": true,
+          "spacing": "Small"
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "id": "octo-surface-default-footer-reasoning-error",
+      "style": "emphasis",
+      "bleed": true,
+      "separator": true,
+      "spacing": "Large",
+      "items": [
+        {
+          "type": "ActionSet",
+          "horizontalAlignment": "Right",
+          "actions": [
+            {
+              "type": "Action.Submit",
+              "id": "reasoning_retry",
+              "title": "重试",
+              "style": "positive",
+              "associatedInputs": "none",
+              "data": {
+                "action": "reasoning_retry",
+                "effect": "retry_reasoning",
+                "reasoning_id": "${reasoningId}",
+                "owner": "ai",
+                "action_type": "reasoning.control"
+              }
+            },
+            {
+              "type": "Action.ToggleVisibility",
+              "id": "reasoning_toggle",
+              "title": "显示 / 隐藏推理",
+              "targetElements": [
+                "trace_panel",
+                "collapsed_panel"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.1.0/templates/result.template.json
+++ b/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.1.0/templates/result.template.json
@@ -1,0 +1,180 @@
+{
+  "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+  "type": "AdaptiveCard",
+  "version": "1.5",
+  "body": [
+    {
+      "type": "Container",
+      "id": "octo-surface-accent-header-reasoning-result",
+      "style": "accent",
+      "bleed": true,
+      "spacing": "None",
+      "items": [
+        {
+          "type": "ColumnSet",
+          "spacing": "None",
+          "columns": [
+            {
+              "type": "Column",
+              "width": "stretch",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "text": "✦  ${title}",
+                  "color": "Accent",
+                  "weight": "Bolder",
+                  "wrap": true,
+                  "spacing": "None"
+                },
+                {
+                  "type": "TextBlock",
+                  "text": "${timerText}",
+                  "size": "Small",
+                  "isSubtle": true,
+                  "wrap": true,
+                  "spacing": "Small"
+                }
+              ]
+            },
+            {
+              "type": "Column",
+              "width": "auto",
+              "verticalContentAlignment": "Center",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "id": "octo-badge-reasoning-result-status",
+                  "text": "${statusLabel}",
+                  "color": "${statusTone}",
+                  "weight": "Bolder",
+                  "size": "Small",
+                  "wrap": true,
+                  "spacing": "None"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "id": "trace_panel",
+      "isVisible": "${traceExpanded}",
+      "spacing": "Large",
+      "items": [
+        {
+          "$data": "${phases}",
+          "type": "Container",
+          "spacing": "${if($index == 0, 'None', 'Large')}",
+          "separator": "${if($index == 0, false, true)}",
+          "items": [
+            {
+              "type": "TextBlock",
+              "text": "${thought}",
+              "size": "Small",
+              "wrap": true,
+              "spacing": "None"
+            },
+            {
+              "type": "Container",
+              "style": "emphasis",
+              "spacing": "Small",
+              "items": [
+                {
+                  "$data": "${actions}",
+                  "type": "ColumnSet",
+                  "spacing": "${if($index == 0, 'None', 'Small')}",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "${statusGlyph}",
+                          "color": "${statusTone}",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "${tool}",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "${detail}",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "id": "collapsed_panel",
+      "isVisible": "${traceCollapsed}",
+      "spacing": "Medium",
+      "items": [
+        {
+          "type": "TextBlock",
+          "text": "✓  ${collapsedSummary}",
+          "size": "Small",
+          "isSubtle": true,
+          "wrap": true,
+          "spacing": "None"
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "id": "octo-surface-default-footer-reasoning-result",
+      "style": "emphasis",
+      "bleed": true,
+      "separator": true,
+      "spacing": "Large",
+      "items": [
+        {
+          "type": "ActionSet",
+          "horizontalAlignment": "Right",
+          "actions": [
+            {
+              "type": "Action.ToggleVisibility",
+              "id": "reasoning_toggle",
+              "title": "显示 / 隐藏推理",
+              "targetElements": [
+                "trace_panel",
+                "collapsed_panel"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/cardtmpl/registry.go
+++ b/pkg/cardtmpl/registry.go
@@ -22,6 +22,7 @@ var l2aOwnerAllowlist = map[string]struct{}{
 	"summary": {},
 	"notify":  {},
 	"action":  {},
+	"ai":      {}, // AI reasoning-process progress card family (roadmap E1 downstream)
 }
 
 // L2b owner 前缀。前缀合规但清单不在 docs/l2b-owners.md 里 → Register 拒绝。


### PR DESCRIPTION
## Summary

Onboards `ai.reasoning-process@0.1.0` — the AI reasoning-process progress card —
as the first **live** JSON-mode card on the E1 template engine (#654). It
registers via `Registry.RegisterJSON` (the base compiles its `.template.json`
views) with **no hand-written Go `Build()`**. This is the "engine first, land the
card" follow-up to #654.

## Related Issue

Roadmap E1a (self); depends on #654 (merged).

## Linked Spec

`.octospec/tasks/cardtmpl-reasoning-progress-card/brief.md`

## Changes

- **`pkg/cardtmpl/ai_reasoning_process/`** — embeds the handoff (manifest +
  `contract/data.schema.json` + templates + view-named interaction reports +
  samples + goldens) and exposes `Assets` / `HandoffRoot` / `TemplateID` /
  `TemplateVersion`. No Template struct — the engine compiles the views.
- **`registry.go`** — add `ai` to the L2a owner allowlist (new platform card
  family).
- **`main.go`** — `RegisterJSON` + `SetDefault` in the composition root.

The card is translated **as delivered**, keeping its action buttons
(`reasoning_stop` on `active`, `reasoning_retry` on `error`, plus
`reasoning_toggle`). Fixed owner `ai` / action_type `reasoning.control`;
`Submit.data` carries `owner`/`action_type` so the base ActionContract
self-check passes (same shape docs.access-request uses; goldens synced). The two
Submit-bearing views are `octo/v2`; the display-only `result` view is `octo/v1`
(mirrors docs.access-request 0.3.0 pending-v2 / result-v1).

## Testing

- [x] Unit tests: `TestRegisters` (registration == ActionContract self-check),
      `TestRenderAllStates` (5 states, correct v2/v1 profiles), `TestConformance`
      (rendered card minus metadata == golden minus `$schema`, 5/5)
- [x] `go build ./...` + `go test ./pkg/cardtmpl/... -race` green; gofmt/vet clean

## Scope boundary (deliberate, not a gap)

The buttons **render and carry a routable ActionContract**, but the server-side
**handler + `cardactiondispatch` RouteSpec** that actually stop/retry a reasoning
run, and the **bot streaming delivery** (send + `ReplaceView`
reasoning→answering→result), are **downstream tasks** — a click has no route
until the handler lands. This PR delivers a registered, renderable card only.

## COMPREHENSION

1. **What does this change actually do to the load-bearing path?**
   Registers one JSON-mode card in the composition-root Registry and adds `ai`
   to the owner allowlist. It touches no shared render/validate logic (that
   landed in #654). At boot, `RegisterJSON` compiles the three views, runs the
   sample self-check (schema + ActionContract + toggle-target existence), and
   fails closed on any authoring error — same guarantees as the Go cards.

2. **What could break because of it (dependents + failure mode)?**
   The only cross-cutting edit is one allowlist entry. If the handoff were
   malformed the process would panic at boot (fail-close), not serve a broken
   card — caught by the self-check and by CI. No existing card is touched; the
   new card has no production sender yet, so runtime blast radius is nil until
   the downstream delivery task wires it.

3. **How do you know it works (specific test/repro/trace)?**
   `TestConformance` renders all five sample states through
   `RegisterJSON → renderCore → cardmsg.Validate` and asserts the card node
   equals the shipped golden (canonical JSON). `TestRegisters` proves the
   ActionContract self-check accepts the owner/action_type-bearing Submit data;
   `TestRenderAllStates` pins the v2/v1 profile per state. All green under
   `-race`.

## Checklist

- [x] Tests added/updated and green (`-race`)
- [x] `gofmt` / `go vet` clean
- [x] Journal + log recorded under `.octospec/`
- [x] Rebased onto merged main; PR diff is reasoning-card-only
