### PR TITLE
feat(robot): add owned bots endpoint

### DIFF
--- a/modules/robot/api.go
+++ b/modules/robot/api.go
@@ -37,7 +37,9 @@ import (
 	octoi18n "github.com/Mininglamp-OSS/octo-server/pkg/i18n"
 	"github.com/Mininglamp-OSS/octo-server/pkg/mentionrewrite"
 	"github.com/Mininglamp-OSS/octo-server/pkg/richtext"
+	"github.com/Mininglamp-OSS/octo-server/pkg/space"
 	pkgutil "github.com/Mininglamp-OSS/octo-server/pkg/util"
+	appwkhttp "github.com/Mininglamp-OSS/octo-server/pkg/wkhttp"
 	"github.com/gin-gonic/gin"
 	"github.com/go-redis/redis"
 	"github.com/gocraft/dbr/v2"
@@ -334,6 +336,11 @@ func (rb *Robot) Route(r *wkhttp.WKHttp) {
 		auth.PUT("/robot/:robot_id/groups/:group_no/mention_pref", rb.setMentionPref)       // UPSERT 群级免@偏好
 		auth.DELETE("/robot/:robot_id/groups/:group_no/mention_pref", rb.deleteMentionPref) // 删除回退默认（幂等）
 		auth.GET("/robot/:robot_id/groups/:group_no/mention_pref", rb.getMentionPref)       // 读群级免@偏好
+	}
+
+	ownedBots := r.Group("/v1", rb.ctx.AuthMiddleware(r), appwkhttp.SharedUIDRateLimiter(r, rb.ctx), space.SpaceMiddleware(rb.ctx))
+	{
+		ownedBots.GET("/robot/owned_bots", rb.ownedBots)
 	}
 
 	robotAuth := r.Group("/v1/robots/:robot_id/:app_key", rb.authRobot()) // :robot_id即user的username
@@ -1657,6 +1664,53 @@ func (rb *Robot) myBots(c *wkhttp.Context) {
 			"description":  b.Description,
 			"creator_uid":  b.CreatorUID,
 			"creator_name": creatorNameMap[b.CreatorUID],
+			"bot_commands": b.BotCommands,
+		})
+	}
+	c.Response(results)
+}
+
+// ownedBots 我创建的 Bot — 仅返回【登录用户创建、robot.status=1、属于指定 Space 且 space_member.status=1】的 Bot。
+// 与 myBots(已加好友) / spaceBots(Space 全部) 区分：owner 语义。
+func (rb *Robot) ownedBots(c *wkhttp.Context) {
+	loginUID := c.GetLoginUID()
+	spaceID := space.GetSpaceID(c)
+	if spaceID == "" {
+		respondRobotRequestInvalid(c, "space_id")
+		return
+	}
+
+	// creator_uid=loginUID 与 space_id 双重过滤即 space 隔离点，均为占位符，不可绕过。
+	// 仅暴露 uid/name/description/bot_commands，绝不返回 token/凭据。
+	type ownedBotRow struct {
+		UID         string `db:"uid"`
+		Name        string `db:"name"`
+		Description string `db:"description"`
+		BotCommands string `db:"bot_commands"`
+	}
+	var bots []ownedBotRow
+	_, err := rb.ctx.DB().SelectBySql(`
+		SELECT r.robot_id as uid, IFNULL(u.name,'') as name,
+			IFNULL(r.description,'') as description,
+			IFNULL(r.bot_commands,'') as bot_commands
+		FROM robot r
+		INNER JOIN user u ON u.uid = r.robot_id AND u.robot = 1
+		INNER JOIN space_member sm ON sm.uid = r.robot_id AND sm.space_id = ? AND sm.status = 1
+		WHERE r.creator_uid = ? AND r.status = 1
+		ORDER BY r.created_at DESC
+	`, spaceID, loginUID).Load(&bots)
+	if err != nil {
+		rb.Error("查询我创建的 Bot 列表失败", zap.Error(err))
+		httperr.ResponseErrorL(c, errcode.ErrRobotQueryFailed, nil, nil)
+		return
+	}
+
+	results := make([]map[string]interface{}, 0, len(bots))
+	for _, b := range bots {
+		results = append(results, map[string]interface{}{
+			"uid":          b.UID,
+			"name":         b.Name,
+			"description":  b.Description,
 			"bot_commands": b.BotCommands,
 		})
 	}

--- a/modules/robot/api.go
+++ b/modules/robot/api.go
@@ -338,7 +338,7 @@ func (rb *Robot) Route(r *wkhttp.WKHttp) {
 		auth.GET("/robot/:robot_id/groups/:group_no/mention_pref", rb.getMentionPref)       // 读群级免@偏好
 	}
 
-	ownedBots := r.Group("/v1", rb.ctx.AuthMiddleware(r), appwkhttp.SharedUIDRateLimiter(r, rb.ctx), space.SpaceMiddleware(rb.ctx))
+	ownedBots := r.Group("/v1", rb.ctx.AuthMiddleware(r), appwkhttp.SharedUIDRateLimiter(r, rb.ctx))
 	{
 		ownedBots.GET("/robot/owned_bots", rb.ownedBots)
 	}
@@ -1674,9 +1674,20 @@ func (rb *Robot) myBots(c *wkhttp.Context) {
 // 与 myBots(已加好友) / spaceBots(Space 全部) 区分：owner 语义。
 func (rb *Robot) ownedBots(c *wkhttp.Context) {
 	loginUID := c.GetLoginUID()
-	spaceID := space.GetSpaceID(c)
+	spaceID := c.Query("space_id")
 	if spaceID == "" {
 		respondRobotRequestInvalid(c, "space_id")
+		return
+	}
+
+	isMember, err := space.CheckMembership(rb.ctx.DB(), spaceID, loginUID)
+	if err != nil {
+		rb.Error("校验 Space 成员身份失败", zap.Error(err))
+		httperr.ResponseErrorL(c, errcode.ErrRobotQueryFailed, nil, nil)
+		return
+	}
+	if !isMember {
+		httperr.ResponseErrorL(c, errcode.ErrSharedForbidden, nil, nil)
 		return
 	}
 
@@ -1689,7 +1700,7 @@ func (rb *Robot) ownedBots(c *wkhttp.Context) {
 		BotCommands string `db:"bot_commands"`
 	}
 	var bots []ownedBotRow
-	_, err := rb.ctx.DB().SelectBySql(`
+	_, err = rb.ctx.DB().SelectBySql(`
 		SELECT r.robot_id as uid, IFNULL(u.name,'') as name,
 			IFNULL(r.description,'') as description,
 			IFNULL(r.bot_commands,'') as bot_commands

--- a/modules/robot/api_test.go
+++ b/modules/robot/api_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/server"
 	"github.com/Mininglamp-OSS/octo-lib/testutil"
 	"github.com/Mininglamp-OSS/octo-server/modules/base/event"
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
 	pkgutil "github.com/Mininglamp-OSS/octo-server/pkg/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -296,6 +297,7 @@ func TestRobotProxyFileNewPath(t *testing.T) {
 // space_id must be a request-invalid error.
 func TestOwnedBots(t *testing.T) {
 	s, ctx := testutil.NewTestServer()
+	s.GetRoute().SetErrorRenderer(i18n.NewErrorRenderer(i18n.NewLocalizer(i18n.DefaultLanguage)))
 	require.NoError(t, testutil.CleanAllTables(ctx))
 	require.NoError(t, ctx.GetRedisConn().Del("ratelimit:uid:"+uid))
 	t.Cleanup(func() { _ = testutil.CleanAllTables(ctx) })
@@ -384,8 +386,22 @@ func TestOwnedBots(t *testing.T) {
 		return w
 	}
 
+	assertEnvelope := func(t *testing.T, w *httptest.ResponseRecorder, code string, semanticStatus int) {
+		t.Helper()
+		require.Equal(t, http.StatusBadRequest, w.Code)
+		var body struct {
+			Error struct {
+				Code       string `json:"code"`
+				HTTPStatus int    `json:"http_status"`
+			} `json:"error"`
+		}
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+		assert.Equal(t, code, body.Error.Code)
+		assert.Equal(t, semanticStatus, body.Error.HTTPStatus)
+	}
+
 	wMissing := request(t, "")
-	assert.NotEqual(t, http.StatusOK, wMissing.Code)
+	assertEnvelope(t, wMissing, "err.server.robot.request_invalid", http.StatusBadRequest)
 
 	for name, spaceID := range map[string]string{
 		"non-member":     nonMemberSpaceID,
@@ -393,7 +409,7 @@ func TestOwnedBots(t *testing.T) {
 		"disabled Space": disabledSpaceID,
 	} {
 		t.Run(name, func(t *testing.T) {
-			assert.Equal(t, http.StatusForbidden, request(t, spaceID).Code)
+			assertEnvelope(t, request(t, spaceID), "err.shared.auth.forbidden", http.StatusForbidden)
 		})
 	}
 
@@ -411,4 +427,32 @@ func TestOwnedBots(t *testing.T) {
 	assert.False(t, hasToken)
 	_, hasBotToken := results[0]["bot_token"]
 	assert.False(t, hasBotToken)
+}
+
+func TestOwnedBots_CheckMembershipDBError(t *testing.T) {
+	s, ctx := newTestServer()
+	s.GetRoute().SetErrorRenderer(i18n.NewErrorRenderer(i18n.NewLocalizer(i18n.DefaultLanguage)))
+	rb := New(ctx)
+	rb.Route(s.GetRoute())
+	require.NoError(t, ctx.GetRedisConn().Del("ratelimit:uid:"+uid))
+	t.Cleanup(func() { _ = ctx.GetRedisConn().Del("ratelimit:uid:" + uid) })
+
+	require.NoError(t, ctx.DB().Close())
+
+	w := httptest.NewRecorder()
+	req, err := http.NewRequest("GET", "/v1/robot/owned_bots?space_id=space_db_error_836", nil)
+	require.NoError(t, err)
+	req.Header.Set("token", token)
+	s.GetRoute().ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	var body struct {
+		Error struct {
+			Code       string `json:"code"`
+			HTTPStatus int    `json:"http_status"`
+		} `json:"error"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	assert.Equal(t, "err.server.robot.query_failed", body.Error.Code)
+	assert.Equal(t, http.StatusInternalServerError, body.Error.HTTPStatus)
 }

--- a/modules/robot/api_test.go
+++ b/modules/robot/api_test.go
@@ -13,12 +13,14 @@ import (
 	"testing"
 	"time"
 
-	pkgutil "github.com/Mininglamp-OSS/octo-server/pkg/util"
-	"github.com/Mininglamp-OSS/octo-server/modules/base/event"
 	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
 	"github.com/Mininglamp-OSS/octo-lib/server"
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	"github.com/Mininglamp-OSS/octo-server/modules/base/event"
+	pkgutil "github.com/Mininglamp-OSS/octo-server/pkg/util"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var uid = "10000"
@@ -285,4 +287,128 @@ func TestRobotProxyFileNewPath(t *testing.T) {
 	path := fmt.Sprintf("chat/%d/%s/file.xlsx", time.Now().Unix(), uuid)
 	got := pkgutil.ExtractFilenameFromPath(path)
 	assert.Equal(t, "file.xlsx", got)
+}
+
+// TestOwnedBots verifies /robot/owned_bots only returns bots created by the
+// login user, with robot.status=1 and an active space_member row in the given
+// Space. It must not leak bots from other spaces, bots created by others (even
+// if befriended), soft-deleted bots, or removed space members. Missing
+// space_id must be a request-invalid error.
+func TestOwnedBots(t *testing.T) {
+	s, ctx := testutil.NewTestServer()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+	require.NoError(t, ctx.GetRedisConn().Del("ratelimit:uid:"+uid))
+	t.Cleanup(func() { _ = testutil.CleanAllTables(ctx) })
+
+	db := ctx.DB()
+	testSpaceID := "space_owned_836"
+	otherSpaceID := "space_other_836"
+	nonMemberSpaceID := "space_nonmember_836"
+	removedMemberSpaceID := "space_removed_member_836"
+	disabledSpaceID := "space_disabled_836"
+	other := "other_user_836"
+
+	mine := "owned_mine_836"
+	mineOther := "owned_other_sp_836"
+	friendBot := "owned_friend_836"
+	deletedBot := "owned_deleted_836"
+	removedBot := "owned_removed_836"
+
+	spaceIDs := []string{testSpaceID, otherSpaceID, nonMemberSpaceID, removedMemberSpaceID, disabledSpaceID}
+	t.Cleanup(func() {
+		_ = ctx.GetRedisConn().Del("ratelimit:uid:" + uid)
+		for _, spaceID := range spaceIDs {
+			_ = ctx.GetRedisConn().Del("space:member:" + spaceID + ":" + uid)
+		}
+	})
+
+	_, err := db.InsertInto("user").Columns("uid", "name", "short_no", "status").Values(uid, "TestUser", uid, 1).Exec()
+	require.NoError(t, err)
+	_, err = db.InsertInto("user").Columns("uid", "name", "short_no", "status").Values(other, "OtherUser", other, 1).Exec()
+	require.NoError(t, err)
+
+	for _, fixture := range []struct {
+		spaceID string
+		status  int
+	}{
+		{testSpaceID, 1},
+		{otherSpaceID, 1},
+		{nonMemberSpaceID, 1},
+		{removedMemberSpaceID, 1},
+		{disabledSpaceID, 0},
+	} {
+		_, err = db.InsertInto("space").Columns("space_id", "name", "creator", "status").
+			Values(fixture.spaceID, fixture.spaceID, uid, fixture.status).Exec()
+		require.NoError(t, err)
+	}
+	for _, fixture := range []struct {
+		spaceID string
+		status  int
+	}{
+		{testSpaceID, 1},
+		{otherSpaceID, 1},
+		{removedMemberSpaceID, 0},
+		{disabledSpaceID, 1},
+	} {
+		_, err = db.InsertInto("space_member").Columns("space_id", "uid", "status").
+			Values(fixture.spaceID, uid, fixture.status).Exec()
+		require.NoError(t, err)
+	}
+
+	mkBot := func(botUID, name string, robotStatus int, creator, spaceID string, memberStatus int) {
+		_, err := db.InsertInto("user").Columns("uid", "name", "short_no", "robot", "status").Values(botUID, name, botUID, 1, 1).Exec()
+		require.NoError(t, err)
+		_, err = db.InsertInto("robot").Columns("robot_id", "status", "creator_uid", "description", "bot_commands").
+			Values(botUID, robotStatus, creator, name+" desc", "/start").Exec()
+		require.NoError(t, err)
+		_, err = db.InsertInto("space_member").Columns("space_id", "uid", "status").Values(spaceID, botUID, memberStatus).Exec()
+		require.NoError(t, err)
+	}
+
+	mkBot(mine, "MineBot", 1, uid, testSpaceID, 1)
+	mkBot(mineOther, "MineOtherSpace", 1, uid, otherSpaceID, 1)
+	mkBot(friendBot, "FriendBot", 1, other, testSpaceID, 1)
+	mkBot(deletedBot, "DeletedBot", 0, uid, testSpaceID, 1)
+	mkBot(removedBot, "RemovedBot", 1, uid, testSpaceID, 0)
+
+	_, err = db.InsertInto("friend").Columns("uid", "to_uid", "is_deleted").Values(uid, friendBot, 0).Exec()
+	require.NoError(t, err)
+
+	request := func(t *testing.T, spaceID string) *httptest.ResponseRecorder {
+		t.Helper()
+		w := httptest.NewRecorder()
+		req, err := http.NewRequest("GET", "/v1/robot/owned_bots?space_id="+spaceID, nil)
+		require.NoError(t, err)
+		req.Header.Set("token", token)
+		s.GetRoute().ServeHTTP(w, req)
+		return w
+	}
+
+	wMissing := request(t, "")
+	assert.NotEqual(t, http.StatusOK, wMissing.Code)
+
+	for name, spaceID := range map[string]string{
+		"non-member":     nonMemberSpaceID,
+		"removed member": removedMemberSpaceID,
+		"disabled Space": disabledSpaceID,
+	} {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, http.StatusForbidden, request(t, spaceID).Code)
+		})
+	}
+
+	w := request(t, testSpaceID)
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "uid", w.Header().Get("X-RateLimit-Scope"))
+
+	var results []map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &results))
+	require.Len(t, results, 1)
+	assert.Equal(t, mine, results[0]["uid"])
+	assert.Equal(t, "MineBot", results[0]["name"])
+	assert.Equal(t, "/start", results[0]["bot_commands"])
+	_, hasToken := results[0]["token"]
+	assert.False(t, hasToken)
+	_, hasBotToken := results[0]["bot_token"]
+	assert.False(t, hasBotToken)
 }


### PR DESCRIPTION
## Summary

Adds authenticated `GET /v1/robot/owned_bots?space_id=<space_id>` for listing Bots that satisfy all of these conditions:

- created by the current authenticated user (`creator_uid = loginUID`)
- active (`robot.status = 1`)
- active members of the requested Space (`space_member.status = 1`)

The response is intentionally limited to `uid`, `name`, `description`, and `bot_commands`; credentials and tokens are never selected or returned.

Authorization remains fail-closed:

- authentication and shared UID rate limiting run before the handler
- missing `space_id` returns the localized request-invalid envelope
- inactive/non-member users return the localized forbidden envelope
- membership/query failures return the localized query-failed envelope

## Linked Spec

- Global engineering standard: `octo-spec@1.2.0`
- Applicable repository rules: authentication/Space isolation, localized error-envelope handling, and credential non-disclosure
- No dedicated product spec or migration is required for this endpoint

## COMPREHENSION

### 1. What changes on the load-bearing path?

Before this PR, clients could list befriended Bots (`my_bots`) or all Bots in a Space (`space_bots`), but there was no server-side owner-scoped endpoint.

After this PR, `owned_bots` authenticates the caller, checks active Space membership with `space.CheckMembership`, and then queries by both server-resolved `creator_uid` and caller-supplied `space_id`. This makes owner and Space isolation explicit and non-bypassable. Error paths use the standard localized `error.code` / `error.http_status` envelope instead of raw JSON responses.

### 2. What could break?

- A missing, inactive, or removed Space membership must deny access rather than return data.
- A query or membership-check failure must not fail open or expose internal database errors.
- Incorrect owner/Space filters could leak another user's or another Space's Bots.
- Expanding the response projection could expose Bot credentials.
- Clients must provide `space_id` as a query parameter; this endpoint does not consume the `X-Space-ID` header.

No existing route, database schema, migration, or environment variable is changed.

### 3. How do we know it works?

Integration coverage exercises the real handler and verifies:

- only the caller's active Bot in the requested Space is returned
- cross-Space, foreign-owner/befriended, inactive, and removed-member Bots are excluded
- missing `space_id`, non-member, removed-member, disabled-Space, and DB-error paths return the expected localized error envelope
- response data contains no `token` or `bot_token`
- shared UID rate limiting remains active

## How verified

- [x] `go test ./modules/robot -run 'TestOwnedBots|TestOwnedBots_CheckMembershipDBError' -count=1`
- [x] `go test ./modules/robot -run TestInlineQueryEventsMapLockConsistency -count=1`
- [x] `go test ./modules/robot -run '^$' -count=1`
- [x] `go test ./pkg/space -count=1`
- [x] Robot module build and vet checks
- [x] `make i18n-extract-check`
- [x] i18n lint
- [x] direct-error-response lint
- [x] `git diff --check`
- [x] Independent code review: approved

## Deployment prerequisites / required environment variables

No new environment variables, database migrations, or configuration switches are introduced.
