### PR TITLE
feat(bot-api): add Registry template consumption

### DIFF
--- a/.octospec/journal/shared/bot-card-template-consumption.md
+++ b/.octospec/journal/shared/bot-card-template-consumption.md
@@ -1,0 +1,86 @@
+---
+type: Journal
+title: "Journal: bot-card-template-consumption (roadmap E1b)"
+description: Add an explicit Bot template catalog and Registry-backed template_ref send/edit modes while preserving the raw-card protocol.
+tags: ["cardtmpl", "bot-api", "template-ref", "wire-contract", "trust-boundary", "space-isolation", "testing", "e1b"]
+timestamp: 2026-07-24T15:10:16+08:00
+# --- octospec extension fields ---
+task: bot-card-template-consumption
+upstream: "PR #657; roadmap E1b"
+pr: 659
+source: self
+---
+
+# Journal: bot-card-template-consumption (roadmap E1b)
+
+## What was done
+
+- Extended the additive-only `GET /v1/bot/card/profile` response with a
+  `templating` subtree (`supported`, `wire=template-ref/v1`, explicit templates,
+  views, states, wire profiles, and Submit action IDs). The list is a
+  code-reviewed Bot allowlist, not `Registry.List()` and not an implicit grant
+  to internal docs/summary templates.
+- Added Registry mode to `POST /v1/bot/sendMessage`: callers provide an explicit
+  `template_ref`, outer `state`, and schema data; the server owns state-to-view
+  selection, profiles, rendered card metadata, authoritative Space, and plain
+  text. Existing mention/reply behavior survives the compilation boundary.
+- Added the symmetric Registry mode to `POST /v1/bot/message/edit`. It renders a
+  complete replacement frame and reuses `CardMutator` for the second ownership
+  and lifecycle lookup, positive `card_seq` CAS, idempotent replay, revision
+  policy, and CMD synchronization. Transient frames update/sync without entering
+  revision history.
+- Kept raw Model B behavior. Raw and Registry modes are total XORs; unlisted,
+  partial, cross-template/version, stale, forged, or malformed requests fail
+  closed with zero dispatch/mutation side effects.
+- Added server-authored top-level `template_ref` provenance. Raw send/edit cannot
+  forge it, and Registry edit requires both provenance and
+  `metadata.octo.template` to match the requested immutable id/version.
+- Moved JSON-template interaction-report consistency to registration: each v2
+  sample's rendered Submit/input surface must match its report before the
+  Registry can freeze and before the catalog can advertise it.
+
+## Load-bearing decisions
+
+- Capability discovery and usable send/edit wires land atomically; the server
+  never advertises an unusable template wire.
+- Version is mandatory on the wire. Registry defaults remain internal deployment
+  choices and cannot silently retarget an Agent request.
+- The outer `state` is authoritative for view selection. When `data.state`
+  exists it must exactly mirror the outer value, preventing two state authorities.
+- Registry edit may change state/view but cannot migrate template id/version.
+  Any future migration requires a separate explicit protocol.
+- Bot action clicks keep the existing `/v1/bot/events` `card_action` pull path;
+  this task does not add a callback RouteSpec or stop/retry orchestration.
+
+## Verification
+
+- Green focused race suites cover the E1b Bot API handlers/catalog,
+  `pkg/cardtmpl/...`, and `CardMutator`.
+- Green shared checks: `go test ./pkg/cardmsg/... ./internal/carddispatch/...`,
+  `go build ./...`, `go vet ./pkg/cardtmpl/... ./modules/bot_api/...`,
+  `make i18n-extract-check`, `make i18n-lint`, and `git diff --check`.
+- The local full-package Bot API race attempt is not green because the shared
+  local test database contains an unknown legacy migration
+  (`20191106000001_event_legacy01.sql`). The focused E1b race suite is green;
+  fresh-service CI evidence is required before merge.
+
+## Structural learnings / gotchas
+
+- A dual-mode JSON request must define mode by **key presence**, not by decoded
+  non-empty value. `content_edit:""` and `template_ref:null` still mean both
+  fields were supplied. Go zero values collapse those states unless custom
+  unmarshalling records raw field presence; the first implementation reached
+  the Registry snapshot path for a both-present request before the regression
+  test caught it.
+- The published `ai.reasoning-process@0.1.0` remains frozen and has no field-level
+  caps for its free-form strings or nested arrays. Platform body/node/final-size
+  budgets still fail closed, but a bounded successor and catalog cutover are a
+  production-enablement prerequisite, not an in-place edit to `0.1.0`.
+
+## Out of scope / follow-up
+
+- OpenClaw consumption, reasoning session registration, stop/retry semantics,
+  cross-repository E2E, and production gray rollout remain downstream.
+- Publish a bounded `ai.reasoning-process` successor and switch the explicit Bot
+  catalog before enabling Model A in production, unless the deployment keeps
+  `OCTO_BOT_CARD_ENABLED=false` during the intermediate server rollout.

--- a/.octospec/learnings/pending/bot-card-template-consumption.md
+++ b/.octospec/learnings/pending/bot-card-template-consumption.md
@@ -1,0 +1,48 @@
+---
+type: Learning
+title: "JSON mode XOR must use field presence, not decoded zero values"
+description: For mutually-exclusive JSON request modes, empty string, null, and omission are distinct wire states; record raw key presence before enforcing the XOR.
+tags: ["api", "json", "validation", "wire-contract", "trust-boundary", "go"]
+timestamp: 2026-07-24T15:10:16+08:00
+# --- octospec extension fields ---
+source: self
+origin_task: bot-card-template-consumption
+origin_pr: 659
+status: pending
+candidate_rule: trust-boundary
+---
+
+# JSON mode XOR must use field presence, not decoded zero values
+
+When one JSON request supports two mutually-exclusive wire modes, the XOR must
+be evaluated over whether each mode's discriminator key was **present in the
+JSON object**, not whether the decoded Go field looks non-empty.
+
+For example, this is still a both-present request and must be rejected before
+either mode performs reads or writes:
+
+```json
+{
+  "content_edit": "",
+  "template_ref": {"id": "ai.reasoning-process", "version": "0.1.0"}
+}
+```
+
+A plain Go struct loses the distinction:
+
+- omitted `content_edit` and `"content_edit":""` both decode to `string("")`;
+- omitted `template_ref` and `"template_ref":null` both decode to a nil map;
+- checking `strings.TrimSpace(ContentEdit) != ""` or `TemplateRef != nil`
+  therefore turns an explicit both-present caller bug into one apparently valid
+  mode.
+
+**Candidate rule:** when JSON key presence participates in authorization,
+dispatch mode, or a mutual-exclusion contract, record presence during
+`UnmarshalJSON` (for example through a `map[string]json.RawMessage`) and enforce
+the total XOR on those booleans. Validate each chosen mode's decoded value only
+after the XOR. Regression tests should cover empty string and null, and assert
+the invalid request performs zero downstream reads/writes.
+
+This refines the existing `dual-mode-request-mutual-exclusion` learning: the
+both-present branch is necessary, but it is only correct when “present” retains
+wire-level JSON semantics.

--- a/.octospec/log.md
+++ b/.octospec/log.md
@@ -4,6 +4,30 @@ Change history for this repo's `.octospec/`, following the
 [OKF](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md)
 change-log convention (§7). Newest first.
 
+## 2026-07-24 (bot-card-template-consumption, roadmap E1b)
+
+- **Protocol** — Added the explicit Bot Registry template catalog to
+  `/v1/bot/card/profile` and Registry-backed `template_ref + state + data`
+  modes to Bot send/edit. Server owns view/profile/render metadata/Space/plain;
+  raw Model B remains supported under a total XOR. See
+  [journal](journal/shared/bot-card-template-consumption.md) and
+  [brief](tasks/bot-card-template-consumption/brief.md).
+- **Mutation safety** — Registry edits retain immutable template id/version and
+  reuse `CardMutator` ownership, lifecycle, positive `card_seq` CAS, revision,
+  and CMD paths. Transient frames skip revision history. Server-authored
+  `template_ref` provenance plus metadata equality prevents raw cards from
+  entering the Registry edit path.
+- **Fail-close** — Only explicitly catalogued templates are advertised/accepted;
+  JSON-template interaction reports are checked against rendered v2 samples at
+  registration; invalid or forged requests have zero dispatch/mutation effects.
+- **Learning (pending)** — JSON mutual exclusion must use raw key presence, not
+  decoded zero values; otherwise empty string/null can bypass the both-present
+  guard. See
+  [learning](learnings/pending/bot-card-template-consumption.md).
+- **Rollout boundary** — frozen `ai.reasoning-process@0.1.0` remains registered,
+  but a bounded successor + Bot catalog cutover (or an explicitly disabled Bot
+  card sub-gate) is required before Model A production enablement.
+
 ## 2026-07-24 (bot-send-permission-error-classification)
 
 - **Error classification** — Bot API sends to a missing group or missing thread

--- a/.octospec/tasks/bot-card-template-consumption/brief.md
+++ b/.octospec/tasks/bot-card-template-consumption/brief.md
@@ -1,0 +1,410 @@
+---
+type: Task
+title: "Task: bot-card-template-consumption"
+description: Add Registry-backed template discovery and template_ref send/edit modes to the existing bot card capability and message APIs, while preserving the raw-card Model B path.
+tags: [card, cardtmpl, bot-api, wire-contract, trust-boundary, space, isolation, auth, testing]
+timestamp: 2026-07-24T13:51:54+08:00
+# --- octospec extension fields ---
+slug: bot-card-template-consumption
+upstream: "roadmap E1b; depends on octo-server PR #657"
+source: self
+---
+
+# Task: bot-card-template-consumption
+
+> One task = one `.octospec/tasks/<slug>/` directory. This brief is the spec for
+> the work. AI may draft it from existing code; a human confirms it.
+
+## Goal
+
+Add the first **server-compiled Bot template consumption protocol (Model A)**
+on top of the existing bot card protocol:
+
+1. Extend the existing additive-only `GET /v1/bot/card/profile` manifest with
+   one `templating` subtree that says this deployment can compile Registry
+   templates, identifies the wire as `template-ref/v1`, and lists the
+   explicitly Bot-callable `template id@version` entries and their views.
+2. Add a Registry mode to `POST /v1/bot/sendMessage`: the bot sends
+   `template_ref + state + data`; octo-server selects `state -> view/profile`,
+   validates `data` against the template schema, renders through
+   `cardtmpl.Registry.Render`, and sends the resulting type-17 envelope.
+3. Add the symmetric Registry mode to `POST /v1/bot/message/edit`: the bot
+   sends `template_ref + state + data + card_seq` (plus optional `transient`);
+   octo-server renders the replacement frame and reuses the existing bot
+   ownership, lifecycle, CAS, revision, and CMD-sync path.
+
+The existing raw-card path remains supported as **Model B**. Old bot SDKs ignore
+the additive `templating` manifest field and continue sending compiled
+`card/content_edit`; new SDKs prefer Model A only when the advertised template
+and wire are present.
+
+The first advertised template is `ai.reasoning-process@0.1.0` from PR #657.
+This task provides the server render/send/update protocol only; the OpenClaw
+producer and the stop/retry business behavior are separate downstream work.
+
+## Background
+
+### Current state
+
+- `pkg/cardtmpl.Registry` already owns registered templates and exposes
+  `List`, `Lookup`, `Render`, and `RenderCardWithProfiles`.
+- `GET /v1/bot/card/profile` currently advertises the Model B contract only:
+  card enablement, card/profile versions, element/input/action allowlists, and
+  payload limits. It does not advertise Registry compilation or templates.
+- `POST /v1/bot/sendMessage` currently accepts a caller-compiled payload map.
+  For type 17 it validates the supplied `card/profile/card_version`, injects
+  authoritative Space metadata, recomputes `plain`, and dispatches it.
+- `POST /v1/bot/message/edit` currently accepts a caller-compiled
+  `content_edit` string. It validates/normalizes the full frame, verifies bot
+  ownership and lifecycle, optionally applies `card_seq` CAS, records
+  non-transient revisions, and emits message-extra sync.
+- PR #657 registers `ai.reasoning-process@0.1.0` in the production Registry,
+  but registration alone gives bots no runtime wire for selecting it.
+
+### Why capability discovery and the wire land together
+
+Advertising a Registry template before a bot can send or update it creates a
+false capability. Conversely, landing an undiscoverable wire forces callers to
+probe with requests. This task therefore adds the manifest subtree and both
+send/edit modes atomically.
+
+The existing manifest remains additive-only. `enabled:false` still returns
+HTTP 200 and the complete capability manifest, including `templating`; the bot
+checks top-level `enabled` before sending and can still learn what a future
+enabled deployment supports.
+
+### Capability manifest addition
+
+The response adds one top-level field; all existing fields and meanings remain
+unchanged:
+
+```jsonc
+{
+  "enabled": true,
+  "card_version": "1.5",
+  "profiles": ["octo/v1", "octo/v2"],
+  "elements": ["..."],
+  "inputs": ["..."],
+  "actions": ["..."],
+  "limits": { "...": "existing fields unchanged" },
+  "templating": {
+    "supported": true,
+    "wire": "template-ref/v1",
+    "templates": [
+      {
+        "id": "ai.reasoning-process",
+        "version": "0.1.0",
+        "views": [
+          {
+            "name": "active",
+            "states": ["answering", "reasoning"],
+            "wire_profile": "octo/v2",
+            "submit_actions": ["reasoning_stop"]
+          },
+          {
+            "name": "error",
+            "states": ["error"],
+            "wire_profile": "octo/v2",
+            "submit_actions": ["reasoning_retry"]
+          },
+          {
+            "name": "result",
+            "states": ["completed", "stopped"],
+            "wire_profile": "octo/v1",
+            "submit_actions": []
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+Ordering is deterministic: templates by `id@version`, views by name, states and
+submit action IDs lexicographically. Consumers must still treat every array as
+an unordered capability set.
+
+`templates` is **not** an unfiltered dump of `Registry.List()`. A small,
+explicit, deployment-global Bot template catalog is the authorization boundary:
+
+- only catalogued `id@version` pairs are advertised and accepted by Bot
+  template-ref requests;
+- startup validates every catalog entry against the frozen Registry and fails
+  closed on a missing template, duplicate ref, empty view/state set, or
+  interaction-report mismatch;
+- internal notification templates such as `docs.access-request` and
+  `summary.*` remain registered but are not Bot-callable;
+- per-bot/per-owner template ACLs are deferred; v1 exposes the same explicit
+  catalog to every authenticated bot.
+
+`submit_actions` is derived from the registered view interaction report and
+contains only `Action.Submit` IDs. It tells a producer which callback actions it
+must understand before choosing the template. Local actions such as
+`Action.ToggleVisibility` continue to be negotiated by the existing top-level
+`actions` capability.
+
+### Send wire: raw Model B XOR Registry Model A
+
+Registry mode reuses the existing endpoint and type-17 envelope:
+
+```jsonc
+POST /v1/bot/sendMessage
+{
+  "channel_id": "g_xxx",
+  "channel_type": 2,
+  "payload": {
+    "type": 17,
+    "template_ref": {
+      "id": "ai.reasoning-process",
+      "version": "0.1.0"
+    },
+    "state": "reasoning",
+    "data": { "...": "matches the registered data schema" },
+    "mention": { "uids": ["u_xxx"] },
+    "reply": { "message_id": "optional-existing-contract" }
+  }
+}
+```
+
+Rules:
+
+- `template_ref.id`, `template_ref.version`, `state`, and `data` are required.
+  The version is explicit; wire callers never silently follow a moving Registry
+  default.
+- `data` must be a JSON object. If that object contains a `state` field, it must
+  be a string exactly equal to the outer wire `state`; a mismatch is a caller
+  error. `ai.reasoning-process@0.1.0` requires this mirrored field, so the first
+  producer sends both values identically. The outer field remains authoritative
+  for Registry view selection.
+- Callers send `state`, never `view` or `profile`. Registry metadata is the only
+  authority for `state -> view -> wire_profile/render_profile`.
+- Registry mode rejects caller-supplied render-owned fields: `card`, `plain`,
+  `profile`, `card_version`, `render_profile`, and `space_id`.
+- Existing orthogonal send-envelope features (`mention`, `reply`, and other
+  already-accepted non-render fields) keep their current behavior. The handler
+  carries only allowed existing fields onto the rendered payload before the
+  normal server enrichment/finalization path.
+- Raw Model B (`payload.card`) and Registry Model A (`payload.template_ref`)
+  are mutually exclusive. Both present, neither present for type 17, or partial
+  Registry fields all fail closed with the localized card-invalid response and
+  zero dispatch.
+- OBO/card exclusion, send authorization, Space resolution, mention rewrite,
+  server-authoritative `plain`, final-size recheck, and dispatch behavior remain
+  unchanged.
+
+### Edit wire: raw content_edit XOR Registry replacement
+
+Registry mode is additive to the existing edit request:
+
+```jsonc
+POST /v1/bot/message/edit
+{
+  "message_id": "8234567890123456789",
+  "channel_id": "g_xxx",
+  "channel_type": 2,
+  "template_ref": {
+    "id": "ai.reasoning-process",
+    "version": "0.1.0"
+  },
+  "state": "answering",
+  "data": { "...": "matches the registered data schema" },
+  "card_seq": 1,
+  "transient": true
+}
+```
+
+Rules:
+
+- `content_edit` raw mode and `template_ref` Registry mode are mutually
+  exclusive; both present, both absent, or partial Registry fields fail closed.
+- Registry edit requires a positive `card_seq`. It uses the existing CAS and
+  returns the existing localized 409 conflict on stale/out-of-order frames.
+- `transient:true` preserves the existing D10 meaning: apply and sync the frame
+  but do not append it to revision history. Terminal frames omit/false it.
+- The target must be an effective Registry-authored card whose stored
+  `metadata.octo.template.{id,version}` exactly matches the requested ref.
+  Cross-template and cross-version rewrites are rejected; a future migration
+  protocol must be explicit rather than smuggled through this endpoint.
+- Bot identity, original-message ownership, message-id/seq binding, channel and
+  thread lifecycle, revoke/delete guards, card gate, CAS, revision append, and
+  CMD sync reuse the existing edit path. Rendering must not bypass or weaken
+  any of those checks.
+- Every replacement is a complete frame rendered through
+  `Registry.RenderCardWithProfiles`; the caller cannot supply a view/profile,
+  metadata, raw card tree, or `plain` in Registry mode.
+
+### Error contract
+
+- Reuse `ErrBotAPICardDisabled`, `ErrBotAPICardInvalid`,
+  `ErrBotAPICardSeqConflict`, and the existing generic internal-error facade;
+  do not expose schema paths, template internals, or catalog membership through
+  detailed errors.
+- Unknown/unlisted template, unknown version/state, invalid data, malformed
+  dual-mode requests, outer/data state mismatch, and stored-template mismatch
+  map to the localized card-invalid envelope. A genuine server-side
+  render/composition failure maps to the generic internal 5xx envelope
+  (`Internal=true`), never to a caller 4xx. The exact cause is logged with
+  bounded template identity and `zap.Error`.
+- The frozen `ai.reasoning-process@0.1.0` schema lacks most string and array
+  caps. Existing HTTP-body, JSON-expansion, card-node, depth, and final-payload
+  budgets still fail closed before write, but a schema-valid oversized input can
+  currently surface as a render 5xx rather than a precise schema 400. A separate
+  hardened template version must land before production enablement; `0.1.0`
+  itself is never edited in place.
+- A render/validation failure is never downgraded to fallback text and never
+  dispatches or edits a message. Model A caller mistakes are 400 + zero write.
+
+## Load-bearing list
+
+- **Capability wire contract (`wire-contract`, `bot-api`)** —
+  `/v1/bot/card/profile` is additive-only. Existing keys are unchanged; the new
+  `templating` subtree and `template-ref/v1` request shapes become cross-repo
+  contracts consumed by bot SDKs and OpenClaw.
+- **Bot template authorization (`auth`, `bot-api`, `trust-boundary`)** — only
+  explicit Bot catalog refs may be advertised or rendered. `Registry.List()`
+  is broader than Bot authority and must never be used as an implicit allow-all.
+- **Dual-mode trust boundary (`trust-boundary`, `wire-contract`)** — raw and
+  Registry modes are total XORs. Both-present, neither-present, and partial
+  template requests fail closed; no branch silently ignores caller input.
+- **Server-authoritative rendering (`wire-contract`, `trust-boundary`)** —
+  callers choose only explicit template version, state, and schema data.
+  Registry owns view/profile/render profile/card metadata; cardmsg owns final
+  validation and authoritative `plain`.
+- **Space and ownership (`space`, `isolation`, `bot-api`, `auth`)** — template
+  send/edit reuse the existing bot-token identity, send authorization,
+  authoritative Space injection, thread/group lifecycle, and edit ownership
+  checks. No caller-provided Space or sender identity becomes authoritative.
+- **Edit identity/CAS/revision contract (`wire-contract`, `bot-api`)** —
+  Registry edits may only replace the same stored `id@version`, require
+  monotonic `card_seq`, preserve transient revision semantics, and keep the
+  existing message-extra/CMD synchronization path.
+- **Localized error envelope (`wire-contract`)** — all new rejection branches
+  use `httperr.ResponseErrorL` with existing registered codes; render/schema
+  internals remain log-only.
+- **Testing (`testing`)** — contract, security, source-of-truth, send/edit, and
+  zero-side-effect failure tests are required across `pkg/cardtmpl` and
+  `modules/bot_api`.
+
+## Out of scope
+
+- OpenClaw/channel-adapter changes, including field mapping, local-renderer
+  removal, feature detection, retry/fallback behavior, or release packaging.
+- `reasoning_stop` / `reasoning_retry` business semantics, active-run
+  cancellation, retry orchestration, or automatic reasoning card session
+  registration. Normal Bot actions continue to use existing `card_action`
+  polling; no `cardactiondispatch.RouteSpec` is added here.
+- Public `GET /v1/message/card/templates` or artifact/schema export endpoints
+  (roadmap B1/B2). The Bot capability contains a bounded runtime summary, not
+  manifests, JSON Schema, templates, samples, or goldens.
+- Internal notify envelope mode (roadmap E2) and any change to
+  `/v1/internal/notify`.
+- L2b enablement, `ext.*` owners, `manifest.visibility`, callback-domain
+  allowlists, or business-owned template upload.
+- Per-bot, per-owner, per-Space, or dynamic database-backed template ACLs. V1
+  uses one deployment-global, code-reviewed Bot catalog.
+- Implicit/default version selection, cross-template/version message migration,
+  template deletion lifecycle, or remote template loading.
+- Removing or weakening raw Model B, changing existing raw-card validation, or
+  changing client rendering behavior.
+- New database tables or migrations, new routes, new rate limiters, or new
+  error codes.
+
+## Acceptance
+
+### Capability manifest
+
+- `GET /v1/bot/card/profile` retains every existing field and adds exactly one
+  additive `templating` object with `supported`, `wire`, and `templates`.
+- The first catalog entry is `ai.reasoning-process@0.1.0`; its three views,
+  five states, wire profiles, and Submit action IDs match the frozen Registry
+  metadata and interaction reports.
+- Templates/views/states/action IDs have deterministic output ordering, and a
+  contract test pins field names/types while allowing future additive fields.
+- The catalog is an explicit allowlist: Registry-only docs/summary templates
+  are not advertised and template-ref requests for them are rejected.
+- Startup/catalog construction fails closed for missing or duplicate refs,
+  missing view/state metadata, or interaction-report drift.
+- `enabled:false` still returns HTTP 200 with the same full `templating`
+  capability; unauthenticated/bad-token behavior is unchanged.
+
+### Registry send mode
+
+- A valid `ai.reasoning-process@0.1.0` `reasoning` request dispatches exactly
+  one type-17 message rendered from the `active` view,
+  `profile=octo/v2`, `render_profile=octo-chat/v1`, explicit template
+  id/version, authoritative Space, and server-recomputed `plain`.
+- `completed` renders the `result` view with `profile=octo/v1`; the caller never
+  sends either the view or profile.
+- Existing allowed mention/reply behavior survives Registry rendering and the
+  final post-enrichment size check still runs on the actual wire payload.
+- Unknown/unlisted id, missing/unknown version, unknown state, schema-invalid
+  data, malformed JSON data, outer/data state mismatch, and partial template
+  mode return the localized card-invalid envelope and dispatch zero messages.
+  Internal render failures return the generic internal 5xx envelope and also
+  dispatch zero messages.
+- Raw+Registry both-present and type-17 neither-present are rejected; ordinary
+  raw Model B requests remain byte/behavior compatible.
+- Caller attempts to inject `card`, `plain`, profile fields, render metadata, or
+  `space_id` in Registry mode fail closed. Existing OBO card rejection and send
+  permission tests remain green.
+
+### Registry edit mode
+
+- A valid same-template update renders the requested state through Registry,
+  preserves authoritative `metadata.octo.template`, and writes/syncs one
+  complete replacement frame through the existing edit path.
+- Cross-template/version ref, non-Registry target, non-owner bot, message
+  id/seq mismatch, revoked/deleted target, disbanded group/deleted thread, and
+  invalid template data all fail closed with zero message-extra/revision/CMD
+  side effects.
+- Registry mode requires positive `card_seq`; a stale frame returns the
+  existing 409 code and does not overwrite the stored frame. An identical
+  retry at the same seq retains existing idempotent behavior.
+- `transient:true` updates the effective frame but appends no revision;
+  terminal/false appends according to the existing cap and tombstone rules.
+- Raw `content_edit` mode remains behavior compatible; raw+Registry
+  both-present and both-absent are rejected.
+
+### Verification
+
+- Focused tests pass:
+  `go test ./pkg/cardtmpl/... ./modules/bot_api/... -count=1`.
+- Shared card/message tests pass:
+  `go test ./pkg/cardmsg/... ./internal/carddispatch/... -count=1`.
+- `go test -race ./pkg/cardtmpl/... ./modules/bot_api/...` passes in the
+  required MySQL/Redis/WuKongIM test environment.
+- `go build ./...`, `go vet ./pkg/cardtmpl/... ./modules/bot_api/...`,
+  `make i18n-extract-check`, `make i18n-lint`, and `git diff --check` pass.
+- No database migration, new route, new rate limiter, or raw response pattern
+  is introduced.
+
+## Decisions for human confirmation
+
+- **D1 — atomic scope:** capability advertisement plus send and edit Registry
+  modes land in one server PR; no advertised-but-unusable intermediate state.
+- **D2 — same manifest:** extend `/v1/bot/card/profile`; do not create a second
+  capability endpoint.
+- **D3 — explicit catalog:** Bot availability is a code-reviewed allowlist over
+  the frozen Registry, not all of `Registry.List()`.
+- **D4 — explicit version:** every wire request pins `id@version`; Registry
+  defaults are not a cross-repo wire contract.
+- **D5 — state is caller input, view is server output:** callers never choose
+  view/profile/render profile.
+- **D6 — total XOR:** raw Model B and Registry Model A are mutually exclusive on
+  both send and edit, including explicit both-present rejection.
+- **D7 — immutable update identity:** Registry edit may change state/view but
+  not template id/version.
+- **D8 — mandatory edit CAS:** Registry edit requires positive `card_seq`; raw
+  mode keeps its current optional behavior.
+- **D9 — existing error codes:** detailed Registry/schema failures stay in
+  logs; the public API reuses card-invalid/disabled/seq-conflict envelopes.
+- **D10 — normal Bot action path:** advertised Submit IDs tell the producer what
+  it must support; click-back remains the existing `/v1/bot/events`
+  `card_action` flow, not a new RouteSpec.
+- **D11 — one state authority:** the outer wire `state` selects the Registry
+  view; when `data.state` exists it must exactly mirror the outer value, otherwise
+  the request fails as card-invalid with zero side effects.
+- **D12 — frozen schema hardening:** do not mutate published `0.1.0`; publish a
+  bounded successor and advertise that version before enabling Model A in
+  production. Cap values come from the producer/UX contract plus the platform
+  card budgets, not from an arbitrary E1b default.

--- a/.octospec/tasks/bot-card-template-consumption/brief.md
+++ b/.octospec/tasks/bot-card-template-consumption/brief.md
@@ -180,6 +180,10 @@ Rules:
   authority for `state -> view -> wire_profile/render_profile`.
 - Registry mode rejects caller-supplied render-owned fields: `card`, `plain`,
   `profile`, `card_version`, `render_profile`, and `space_id`.
+- The compiled outbound/effective envelope retains a server-authored
+  `template_ref` containing the exact catalogued `id@version`; request `state`
+  and `data` are consumed and omitted. Raw Model B send/edit rejects this field,
+  so it acts as provenance rather than trusting forgeable card metadata alone.
 - Existing orthogonal send-envelope features (`mention`, `reply`, and other
   already-accepted non-render fields) keep their current behavior. The handler
   carries only allowed existing fields onto the rendered payload before the
@@ -222,7 +226,8 @@ Rules:
 - `transient:true` preserves the existing D10 meaning: apply and sync the frame
   but do not append it to revision history. Terminal frames omit/false it.
 - The target must be an effective Registry-authored card whose stored
-  `metadata.octo.template.{id,version}` exactly matches the requested ref.
+  server-authored top-level `template_ref` and
+  `metadata.octo.template.{id,version}` both exactly match the requested ref.
   Cross-template and cross-version rewrites are rejected; a future migration
   protocol must be explicit rather than smuggled through this endpoint.
 - Bot identity, original-message ownership, message-id/seq binding, channel and
@@ -347,6 +352,8 @@ Rules:
 - Caller attempts to inject `card`, `plain`, profile fields, render metadata, or
   `space_id` in Registry mode fail closed. Existing OBO card rejection and send
   permission tests remain green.
+- The outbound frame retains only a server-authored `template_ref` as provenance;
+  request `state`/`data` are absent. Raw Model B cannot send or edit that marker.
 
 ### Registry edit mode
 

--- a/.octospec/tasks/bot-card-template-consumption/context.yaml
+++ b/.octospec/tasks/bot-card-template-consumption/context.yaml
@@ -1,0 +1,20 @@
+injected:
+  - id: space-isolation
+    source: repo
+    why: Bot send/edit 是多租户写入口；必须复用 bot-token 身份、属主校验、权威 Space 注入、群/子区生命周期门禁，禁止调用方提供的 Space 或 sender 成为权威值。
+  - id: trust-boundary
+    source: repo
+    why: template_ref/data 是外部 Bot 输入；显式 catalog、raw/Registry total XOR、server-owned view/profile/metadata、Registry 渲染后 cardmsg.Validate 与最终尺寸复检共同构成不可绕过边界。
+  - id: error-handling
+    source: repo
+    why: 新的 catalog/schema/双模式拒绝均复用 httperr.ResponseErrorL 与既有 errcode；模板/schema 内部细节只写日志，不向调用方泄露。
+  - id: rate-limit
+    source: repo
+    why: 复用既有 /v1/bot 路由及其限流链，不新增路由或手写限流器；能力发现仍是原只读端点的增量字段。
+  - id: testing
+    source: repo
+    why: 以契约、catalog fail-close、send/edit、属主/生命周期/CAS、provenance、零副作用失败和 race 测试覆盖承重路径。
+  - id: commit-style
+    source: repo
+    why: 分支提交使用英文 Conventional Commits；PR 使用英文模板、Linked Spec 与 COMPREHENSION。
+brief: .octospec/tasks/bot-card-template-consumption/brief.md

--- a/internal/carddispatch/mutation.go
+++ b/internal/carddispatch/mutation.go
@@ -219,8 +219,10 @@ func (m *CardMutator) Mutate(ctx context.Context, request CardMutationRequest) (
 	}
 	// Revision history and CMD fanout are secondary to the authoritative
 	// content_edit, matching the existing Bot API semantics.
-	if err := m.backend.AppendRevision(write); err != nil && m.logger != nil {
-		m.logger.Error("card mutation revision append failed", zap.Error(err), zap.String("message_id", request.MessageID))
+	if !cardmsg.TransientFromContentEdit(normalized) {
+		if err := m.backend.AppendRevision(write); err != nil && m.logger != nil {
+			m.logger.Error("card mutation revision append failed", zap.Error(err), zap.String("message_id", request.MessageID))
+		}
 	}
 	if err := m.backend.Sync(write); err != nil && m.logger != nil {
 		m.logger.Error("card mutation CMD sync failed", zap.Error(err), zap.String("message_id", request.MessageID))

--- a/internal/carddispatch/mutation_test.go
+++ b/internal/carddispatch/mutation_test.go
@@ -90,6 +90,32 @@ func TestCardMutatorPreservesOwnershipLifecycleCASAndReplay(t *testing.T) {
 		}
 	})
 
+	t.Run("transient frame skips revision but still syncs", func(t *testing.T) {
+		transient := testCardEnvelope(t, 43, false)
+		var envelope map[string]any
+		if err := json.Unmarshal(transient, &envelope); err != nil {
+			t.Fatal(err)
+		}
+		envelope["transient"] = true
+		transient, _ = json.Marshal(envelope)
+		backend := &fakeMutationBackend{message: storedCardMessage{
+			MessageID: "1001", MessageSeq: 7, FromUID: "notification", Payload: original,
+		}}
+		result, err := newCardMutator(backend).Mutate(context.Background(), CardMutationRequest{
+			SenderUID: "notification", MessageID: "1001", ChannelID: "user-b", ChannelType: 1,
+			ContentEdit: string(transient),
+		})
+		if err != nil || !result.Applied {
+			t.Fatalf("Mutate(transient) = (%+v, %v)", result, err)
+		}
+		if len(backend.writes) != 1 || len(backend.syncs) != 1 {
+			t.Fatalf("write/sync counts = %d/%d, want 1/1", len(backend.writes), len(backend.syncs))
+		}
+		if len(backend.revisions) != 0 {
+			t.Fatalf("transient revisions = %d, want 0", len(backend.revisions))
+		}
+	})
+
 	t.Run("byte identical frame is idempotent replay", func(t *testing.T) {
 		backend := &fakeMutationBackend{
 			message:    storedCardMessage{MessageID: "1001", MessageSeq: 7, FromUID: "notification", Payload: original},

--- a/modules/bot_api/bot_api.go
+++ b/modules/bot_api/bot_api.go
@@ -1,6 +1,7 @@
 package bot_api
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"strconv"
@@ -18,6 +19,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-server/modules/user"
 	"github.com/Mininglamp-OSS/octo-server/modules/voice_adapter"
 	"github.com/Mininglamp-OSS/octo-server/pkg/cardrevision"
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl"
 )
 
 const (
@@ -56,7 +58,11 @@ type BotAPI struct {
 	// cardMutator owns the card_seq CAS primitive shared with first-party
 	// callback finalization. Existing tests that construct BotAPI literals keep
 	// the legacy local fallback in cardSeqCASWrite when this field is nil.
-	cardMutator           *carddispatch.CardMutator
+	cardMutator botAPICardMutator
+	// cardTemplates is the deployment-global, code-reviewed Bot allowlist over
+	// the broader cardtmpl Registry. Production construction fails closed when
+	// any advertised ref is missing or internally inconsistent.
+	cardTemplates         *botCardTemplateCatalog
 	speechClient          *voice_adapter.SpeechClient
 	maxVoiceContextLength int
 	maxBodySize           int64
@@ -162,6 +168,16 @@ type BotAPI struct {
 	log.Log
 }
 
+// botAPICardMutator is the narrow mutation surface used by raw and Registry
+// edit modes. The interface keeps handler tests deterministic while production
+// uses carddispatch.CardMutator for ownership, lifecycle, CAS, revision, and
+// CMD synchronization.
+type botAPICardMutator interface {
+	Snapshot(context.Context, carddispatch.CardMutationTarget) (carddispatch.CardMutationSnapshot, error)
+	Mutate(context.Context, carddispatch.CardMutationRequest) (carddispatch.CardMutationResult, error)
+	WriteCAS(carddispatch.CardMutationCASRequest) (bool, error)
+}
+
 // dispatchMsgSendReq sends a built MsgSendReq to WuKongIM via ba.ctx, OR to a
 // test-injected dispatchOverride for handler-level integration tests.
 func (ba *BotAPI) dispatchMsgSendReq(req *config.MsgSendReq) (*config.MsgSendResp, error) {
@@ -204,6 +220,15 @@ func NewBotAPI(ctx *config.Context) *BotAPI {
 		}
 	}
 
+	var cardTemplates *botCardTemplateCatalog
+	if registry := cardtmpl.DefaultRegistry(); registry != nil {
+		var err error
+		cardTemplates, err = newBotCardTemplateCatalog(registry, defaultBotTemplateRefs())
+		if err != nil {
+			panic(fmt.Errorf("install Bot card template catalog: %w", err))
+		}
+	}
+
 	ba := &BotAPI{
 		ctx:                   ctx,
 		db:                    newBotAPIDB(ctx),
@@ -215,6 +240,7 @@ func NewBotAPI(ctx *config.Context) *BotAPI {
 		robotService:          robot.NewService(ctx),
 		cardRevisions:         cardrevision.NewStore(ctx.DB()),
 		cardMutator:           carddispatch.NewCardMutator(ctx),
+		cardTemplates:         cardTemplates,
 		speechClient:          voice_adapter.NewSpeechClient(speechURL, speechKey, time.Duration(timeoutSec)*time.Second),
 		maxVoiceContextLength: maxCtxLen,
 		maxBodySize:           maxBodySize,

--- a/modules/bot_api/card_profile.go
+++ b/modules/bot_api/card_profile.go
@@ -53,6 +53,11 @@ func (ba *BotAPI) botCardProfile(c *wkhttp.Context) {
 		// ToggleVisibility / CopyToClipboard 等 additive 新增本地动作。Action.Submit 属
 		// octo/v2 交互档，经 profiles 隐式发现、不在此列。
 		"actions": cardmsg.DisplayActions(),
+		// templating is additive to the raw-card Model B manifest. It advertises
+		// only the explicit Bot catalog, never the broader Registry.List(). A nil
+		// catalog occurs only in focused tests that do not install the production
+		// composition root and reports supported:false rather than inventing refs.
+		"templating": ba.cardTemplates.Capability(),
 		"limits": map[string]interface{}{
 			"max_payload_bytes":    cardmsg.MaxPayloadBytes,
 			"max_nodes":            cardmsg.MaxNodes,

--- a/modules/bot_api/card_profile_test.go
+++ b/modules/bot_api/card_profile_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
 	"github.com/Mininglamp-OSS/octo-lib/testutil"
 	"github.com/Mininglamp-OSS/octo-server/pkg/cardmsg"
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -26,6 +27,9 @@ const (
 
 func setupBotCardProfile(t *testing.T) (http.Handler, *config.Context) {
 	t.Helper()
+	previousRegistry := cardtmpl.DefaultRegistry()
+	cardtmpl.SetDefaultRegistry(testBotTemplateRegistry(t))
+	t.Cleanup(func() { cardtmpl.SetDefaultRegistry(previousRegistry) })
 	s, ctx := testutil.NewTestServer()
 	assert.NoError(t, testutil.CleanAllTables(ctx))
 	_, err := ctx.DB().InsertBySql(
@@ -50,12 +54,13 @@ func getCardProfile(t *testing.T, handler http.Handler, token string) *httptest.
 
 // cardProfileManifest pins the D12 wire shape (field names decode-checked).
 type cardProfileManifest struct {
-	Enabled     bool     `json:"enabled"`
-	CardVersion string   `json:"card_version"`
-	Profiles    []string `json:"profiles"`
-	Elements    []string `json:"elements"`
-	Inputs      []string `json:"inputs"`
-	Actions     []string `json:"actions"`
+	Enabled     bool                    `json:"enabled"`
+	CardVersion string                  `json:"card_version"`
+	Profiles    []string                `json:"profiles"`
+	Elements    []string                `json:"elements"`
+	Inputs      []string                `json:"inputs"`
+	Actions     []string                `json:"actions"`
+	Templating  botTemplatingCapability `json:"templating"`
 	Limits      struct {
 		MaxPayloadBytes   int `json:"max_payload_bytes"`
 		MaxNodes          int `json:"max_nodes"`
@@ -82,6 +87,9 @@ func TestBotCardProfile_ElementsInputsFromConstants(t *testing.T) {
 	assert.Equal(t, cardmsg.DisplayElements(), m.Elements)
 	assert.Equal(t, cardmsg.InputElements(), m.Inputs)
 	assert.Equal(t, cardmsg.DisplayActions(), m.Actions)
+	assert.True(t, m.Templating.Supported)
+	assert.Equal(t, botTemplateWireV1, m.Templating.Wire)
+	assert.Len(t, m.Templating.Templates, 1)
 }
 
 // TestBotCardProfile_ValuesFromConstants：清单每个值必须等于 pkg/cardmsg 常量
@@ -104,6 +112,7 @@ func TestBotCardProfile_ValuesFromConstants(t *testing.T) {
 	assert.Equal(t, cardmsg.MaxInputTextBytes, m.Limits.MaxInputTextBytes)
 	assert.Equal(t, cardmsg.MaxInputsBytes, m.Limits.MaxInputsBytes)
 	assert.Equal(t, cardmsg.MaxCopyTextBytes, m.Limits.MaxCopyTextBytes)
+	assert.Equal(t, newMustTestCatalog(t).Capability(), m.Templating)
 }
 
 // TestBotCardProfile_DisabledStillReturnsManifestAndSendRejects（D12.3）：rollout
@@ -123,6 +132,8 @@ func TestBotCardProfile_DisabledStillReturnsManifestAndSendRejects(t *testing.T)
 	assert.Equal(t, cardmsg.CardVersion, m.CardVersion, "关闭时仍返完整清单")
 	assert.Equal(t, cardmsg.AcceptedProfiles(), m.Profiles)
 	assert.Equal(t, cardmsg.MaxPayloadBytes, m.Limits.MaxPayloadBytes)
+	assert.True(t, m.Templating.Supported, "关闭时仍返完整模板清单")
+	assert.Len(t, m.Templating.Templates, 1)
 
 	// 半 2：send 路径对卡片仍拒绝（同源 bot 门禁 BotEnabled，此处经部署级总开关关闭
 	// 而生效，send.go —— 在 IM 派发前拒绝，无需 WuKongIM）。
@@ -161,6 +172,8 @@ func TestBotCardProfile_BotSubSwitchDisablesProfileAndSend(t *testing.T) {
 	assert.False(t, m.Enabled, "总开关开但 bot 子开关关 → profile.enabled:false")
 	assert.Equal(t, cardmsg.CardVersion, m.CardVersion, "子开关关时仍返完整清单")
 	assert.Equal(t, cardmsg.AcceptedProfiles(), m.Profiles)
+	assert.True(t, m.Templating.Supported, "bot 子开关关闭时仍返完整模板清单")
+	assert.Len(t, m.Templating.Templates, 1)
 
 	// 半 2：send 路径同源门禁（BotEnabled）→ 拒绝，与 profile 一致。
 	body := map[string]interface{}{
@@ -209,7 +222,7 @@ func TestBotCardProfile_AdditiveContractFieldSet(t *testing.T) {
 	for k := range raw {
 		gotTop = append(gotTop, k)
 	}
-	assert.ElementsMatch(t, []string{"enabled", "card_version", "profiles", "limits", "elements", "inputs", "actions"}, gotTop,
+	assert.ElementsMatch(t, []string{"enabled", "card_version", "profiles", "limits", "elements", "inputs", "actions", "templating"}, gotTop,
 		"D12 additive-only：顶层字段集冻结（新增新字段，绝不改名/删除）")
 
 	var limits map[string]json.RawMessage
@@ -222,4 +235,11 @@ func TestBotCardProfile_AdditiveContractFieldSet(t *testing.T) {
 		"max_payload_bytes", "max_nodes", "max_depth", "max_input_text_bytes", "max_inputs_bytes",
 		"max_copy_text_bytes",
 	}, gotLimits, "D12 additive-only：limits 字段集冻结")
+}
+
+func newMustTestCatalog(t *testing.T) *botCardTemplateCatalog {
+	t.Helper()
+	catalog, err := newBotCardTemplateCatalog(testBotTemplateRegistry(t), defaultBotTemplateRefs())
+	assert.NoError(t, err)
+	return catalog
 }

--- a/modules/bot_api/card_template_catalog.go
+++ b/modules/bot_api/card_template_catalog.go
@@ -196,12 +196,9 @@ func (c *botCardTemplateCatalog) RenderPayload(
 	if _, hasCard := inbound["card"]; hasCard {
 		return nil, fmt.Errorf("%w: raw card and template_ref are mutually exclusive", errBotTemplateRequestInvalid)
 	}
-	ref, err := parseBotTemplateRef(inbound["template_ref"])
+	ref, err := c.requireAllowedRef(inbound["template_ref"])
 	if err != nil {
 		return nil, err
-	}
-	if _, ok := c.allowed[ref]; !ok {
-		return nil, fmt.Errorf("%w: template is not Bot-callable", errBotTemplateRequestInvalid)
 	}
 	state, ok := inbound["state"].(string)
 	if !ok || state == "" || state != strings.TrimSpace(state) {
@@ -240,6 +237,23 @@ func (c *botCardTemplateCatalog) RenderPayload(
 		}
 	}
 	return rendered, nil
+}
+
+// requireAllowedRef is the single Bot catalog authorization boundary for a
+// caller-supplied template_ref. Call it before any target lookup so an unlisted
+// ref cannot use edit responses as a message existence or ownership oracle.
+func (c *botCardTemplateCatalog) requireAllowedRef(value any) (botTemplateRef, error) {
+	if c == nil || c.registry == nil {
+		return botTemplateRef{}, errBotTemplateCatalogUnavailable
+	}
+	ref, err := parseBotTemplateRef(value)
+	if err != nil {
+		return botTemplateRef{}, err
+	}
+	if _, ok := c.allowed[ref]; !ok {
+		return botTemplateRef{}, fmt.Errorf("%w: template is not Bot-callable", errBotTemplateRequestInvalid)
+	}
+	return ref, nil
 }
 
 func parseBotTemplateRef(value any) (botTemplateRef, error) {

--- a/modules/bot_api/card_template_catalog.go
+++ b/modules/bot_api/card_template_catalog.go
@@ -1,0 +1,301 @@
+package bot_api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardmsg"
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl"
+	aireasoningprocess "github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl/ai_reasoning_process"
+)
+
+const botTemplateWireV1 = "template-ref/v1"
+
+var (
+	errBotTemplateRequestInvalid     = errors.New("bot template request invalid")
+	errBotTemplateCatalogUnavailable = errors.New("bot template catalog unavailable")
+)
+
+type botTemplateRef struct {
+	ID      cardtmpl.ID `json:"id"`
+	Version string      `json:"version"`
+}
+
+type botTemplateViewCapability struct {
+	Name          string   `json:"name"`
+	States        []string `json:"states"`
+	WireProfile   string   `json:"wire_profile"`
+	SubmitActions []string `json:"submit_actions"`
+}
+
+type botTemplateCapability struct {
+	ID      string                      `json:"id"`
+	Version string                      `json:"version"`
+	Views   []botTemplateViewCapability `json:"views"`
+}
+
+type botTemplatingCapability struct {
+	Supported bool                    `json:"supported"`
+	Wire      string                  `json:"wire"`
+	Templates []botTemplateCapability `json:"templates"`
+}
+
+type botCardTemplateCatalog struct {
+	registry   *cardtmpl.Registry
+	allowed    map[botTemplateRef]struct{}
+	capability botTemplatingCapability
+}
+
+func defaultBotTemplateRefs() []botTemplateRef {
+	return []botTemplateRef{{
+		ID:      aireasoningprocess.TemplateID,
+		Version: aireasoningprocess.TemplateVersion,
+	}}
+}
+
+func newBotCardTemplateCatalog(registry *cardtmpl.Registry, refs []botTemplateRef) (*botCardTemplateCatalog, error) {
+	if registry == nil {
+		return nil, errBotTemplateCatalogUnavailable
+	}
+	if len(refs) == 0 {
+		return nil, fmt.Errorf("bot template catalog: empty allowlist")
+	}
+	catalog := &botCardTemplateCatalog{
+		registry: registry,
+		allowed:  make(map[botTemplateRef]struct{}, len(refs)),
+		capability: botTemplatingCapability{
+			Supported: true,
+			Wire:      botTemplateWireV1,
+			Templates: make([]botTemplateCapability, 0, len(refs)),
+		},
+	}
+	for _, ref := range refs {
+		if strings.TrimSpace(string(ref.ID)) == "" || strings.TrimSpace(ref.Version) == "" {
+			return nil, fmt.Errorf("bot template catalog: id and explicit version are required")
+		}
+		if _, duplicate := catalog.allowed[ref]; duplicate {
+			return nil, fmt.Errorf("bot template catalog: duplicate %s@%s", ref.ID, ref.Version)
+		}
+		tmpl, err := registry.Lookup(ref.ID, ref.Version)
+		if err != nil {
+			return nil, fmt.Errorf("bot template catalog: lookup %s@%s: %w", ref.ID, ref.Version, err)
+		}
+		meta := tmpl.Meta()
+		if meta.ID != ref.ID || meta.Version != ref.Version || len(meta.Views) == 0 {
+			return nil, fmt.Errorf("bot template catalog: incomplete metadata for %s@%s", ref.ID, ref.Version)
+		}
+
+		capability := botTemplateCapability{
+			ID: string(meta.ID), Version: meta.Version,
+			Views: make([]botTemplateViewCapability, 0, len(meta.Views)),
+		}
+		for view, spec := range meta.Views {
+			if strings.TrimSpace(string(view)) == "" || len(spec.States) == 0 {
+				return nil, fmt.Errorf("bot template catalog: %s@%s has empty view/state metadata", ref.ID, ref.Version)
+			}
+			viewCapability := botTemplateViewCapability{
+				Name:          string(view),
+				WireProfile:   spec.WireProfile,
+				States:        make([]string, 0, len(spec.States)),
+				SubmitActions: make([]string, 0),
+			}
+			for _, state := range spec.States {
+				if strings.TrimSpace(string(state)) == "" {
+					return nil, fmt.Errorf("bot template catalog: %s@%s view %s has empty state", ref.ID, ref.Version, view)
+				}
+				viewCapability.States = append(viewCapability.States, string(state))
+			}
+			sort.Strings(viewCapability.States)
+
+			if spec.WireProfile == cardmsg.ProfileV2 {
+				report, ok := meta.Interaction(view)
+				if !ok {
+					return nil, fmt.Errorf("bot template catalog: %s@%s view %s missing interaction report", ref.ID, ref.Version, view)
+				}
+				seenActions := make(map[string]struct{})
+				for _, action := range report.Actions {
+					if action.Type != "Action.Submit" {
+						continue
+					}
+					if strings.TrimSpace(action.ID) == "" {
+						return nil, fmt.Errorf("bot template catalog: %s@%s view %s has empty Submit id", ref.ID, ref.Version, view)
+					}
+					if _, duplicate := seenActions[action.ID]; duplicate {
+						return nil, fmt.Errorf("bot template catalog: %s@%s view %s has duplicate Submit id %q", ref.ID, ref.Version, view, action.ID)
+					}
+					seenActions[action.ID] = struct{}{}
+					viewCapability.SubmitActions = append(viewCapability.SubmitActions, action.ID)
+				}
+				sort.Strings(viewCapability.SubmitActions)
+			}
+			capability.Views = append(capability.Views, viewCapability)
+		}
+		sort.Slice(capability.Views, func(i, j int) bool {
+			return capability.Views[i].Name < capability.Views[j].Name
+		})
+		catalog.allowed[ref] = struct{}{}
+		catalog.capability.Templates = append(catalog.capability.Templates, capability)
+	}
+	sort.Slice(catalog.capability.Templates, func(i, j int) bool {
+		left, right := catalog.capability.Templates[i], catalog.capability.Templates[j]
+		if left.ID != right.ID {
+			return left.ID < right.ID
+		}
+		return left.Version < right.Version
+	})
+	return catalog, nil
+}
+
+func (c *botCardTemplateCatalog) Capability() botTemplatingCapability {
+	if c == nil {
+		return botTemplatingCapability{Supported: false, Wire: botTemplateWireV1, Templates: []botTemplateCapability{}}
+	}
+	out := botTemplatingCapability{
+		Supported: c.capability.Supported,
+		Wire:      c.capability.Wire,
+		Templates: make([]botTemplateCapability, len(c.capability.Templates)),
+	}
+	for i, template := range c.capability.Templates {
+		out.Templates[i] = botTemplateCapability{ID: template.ID, Version: template.Version, Views: make([]botTemplateViewCapability, len(template.Views))}
+		for j, view := range template.Views {
+			out.Templates[i].Views[j] = botTemplateViewCapability{
+				Name: view.Name, WireProfile: view.WireProfile,
+				States:        append(make([]string, 0, len(view.States)), view.States...),
+				SubmitActions: append(make([]string, 0, len(view.SubmitActions)), view.SubmitActions...),
+			}
+		}
+	}
+	return out
+}
+
+func (c *botCardTemplateCatalog) RenderPayload(
+	ctx context.Context,
+	inbound map[string]any,
+	env cardtmpl.BuildEnv,
+) (map[string]any, error) {
+	if c == nil || c.registry == nil {
+		return nil, errBotTemplateCatalogUnavailable
+	}
+	if !isInteractiveCardType(inbound["type"]) {
+		return nil, fmt.Errorf("%w: type must be 17", errBotTemplateRequestInvalid)
+	}
+	allowedKeys := map[string]struct{}{
+		"type": {}, "template_ref": {}, "state": {}, "data": {},
+		"mention": {}, "reply": {},
+	}
+	for key := range inbound {
+		if _, ok := allowedKeys[key]; !ok {
+			return nil, fmt.Errorf("%w: field %q is not accepted in Registry mode", errBotTemplateRequestInvalid, key)
+		}
+	}
+	if _, hasCard := inbound["card"]; hasCard {
+		return nil, fmt.Errorf("%w: raw card and template_ref are mutually exclusive", errBotTemplateRequestInvalid)
+	}
+	ref, err := parseBotTemplateRef(inbound["template_ref"])
+	if err != nil {
+		return nil, err
+	}
+	if _, ok := c.allowed[ref]; !ok {
+		return nil, fmt.Errorf("%w: template is not Bot-callable", errBotTemplateRequestInvalid)
+	}
+	state, ok := inbound["state"].(string)
+	if !ok || state == "" || state != strings.TrimSpace(state) {
+		return nil, fmt.Errorf("%w: state is required", errBotTemplateRequestInvalid)
+	}
+	data, ok := inbound["data"].(map[string]any)
+	if !ok || data == nil {
+		return nil, fmt.Errorf("%w: data must be an object", errBotTemplateRequestInvalid)
+	}
+	if mirrored, exists := data["state"]; exists {
+		mirroredState, ok := mirrored.(string)
+		if !ok || mirroredState != state {
+			return nil, fmt.Errorf("%w: data.state must equal state", errBotTemplateRequestInvalid)
+		}
+	}
+	rawData, err := json.Marshal(data)
+	if err != nil {
+		return nil, fmt.Errorf("%w: marshal data: %v", errBotTemplateRequestInvalid, err)
+	}
+	rendered, err := c.registry.Render(ctx, ref.ID, ref.Version, cardtmpl.State(state), rawData, env)
+	if err != nil {
+		if errors.Is(err, cardtmpl.ErrFieldsInvalid) || errors.Is(err, cardtmpl.ErrStateUnknown) || errors.Is(err, cardtmpl.ErrTemplateUnknown) {
+			return nil, fmt.Errorf("%w: %v", errBotTemplateRequestInvalid, err)
+		}
+		return nil, fmt.Errorf("bot template render %s@%s: %w", ref.ID, ref.Version, err)
+	}
+	for _, key := range []string{"mention", "reply"} {
+		if value, ok := inbound[key]; ok {
+			rendered[key] = value
+		}
+	}
+	return rendered, nil
+}
+
+func parseBotTemplateRef(value any) (botTemplateRef, error) {
+	object, ok := value.(map[string]any)
+	if !ok || len(object) != 2 {
+		return botTemplateRef{}, fmt.Errorf("%w: template_ref must contain id and version", errBotTemplateRequestInvalid)
+	}
+	id, idOK := object["id"].(string)
+	version, versionOK := object["version"].(string)
+	if !idOK || !versionOK || id == "" || version == "" || id != strings.TrimSpace(id) || version != strings.TrimSpace(version) {
+		return botTemplateRef{}, fmt.Errorf("%w: template_ref id/version are required", errBotTemplateRequestInvalid)
+	}
+	return botTemplateRef{ID: cardtmpl.ID(id), Version: version}, nil
+}
+
+func requireEffectiveCardTemplate(envelope []byte, want botTemplateRef) error {
+	decoder := json.NewDecoder(bytes.NewReader(envelope))
+	decoder.UseNumber()
+	var payload map[string]any
+	if err := decoder.Decode(&payload); err != nil || !cardmsg.IsCardPayload(payload) {
+		return fmt.Errorf("%w: effective target is not a card", errBotTemplateRequestInvalid)
+	}
+	card, _ := payload["card"].(map[string]any)
+	metadata, _ := card["metadata"].(map[string]any)
+	octo, _ := metadata["octo"].(map[string]any)
+	template, _ := octo["template"].(map[string]any)
+	id, _ := template["id"].(string)
+	version, _ := template["version"].(string)
+	if id != string(want.ID) || version != want.Version {
+		return fmt.Errorf("%w: effective template mismatch", errBotTemplateRequestInvalid)
+	}
+	return nil
+}
+
+func isInteractiveCardType(value any) bool {
+	switch typed := value.(type) {
+	case int:
+		return typed == cardmsg.InteractiveCard.Int()
+	case int8:
+		return int(typed) == cardmsg.InteractiveCard.Int()
+	case int16:
+		return int(typed) == cardmsg.InteractiveCard.Int()
+	case int32:
+		return int(typed) == cardmsg.InteractiveCard.Int()
+	case int64:
+		return typed == int64(cardmsg.InteractiveCard.Int())
+	case uint:
+		return typed == uint(cardmsg.InteractiveCard.Int())
+	case uint8:
+		return typed == uint8(cardmsg.InteractiveCard.Int())
+	case uint16:
+		return typed == uint16(cardmsg.InteractiveCard.Int())
+	case uint32:
+		return typed == uint32(cardmsg.InteractiveCard.Int())
+	case uint64:
+		return typed == uint64(cardmsg.InteractiveCard.Int())
+	case float64:
+		return typed == float64(cardmsg.InteractiveCard.Int())
+	case json.Number:
+		value, err := typed.Int64()
+		return err == nil && value == int64(cardmsg.InteractiveCard.Int())
+	default:
+		return false
+	}
+}

--- a/modules/bot_api/card_template_catalog.go
+++ b/modules/bot_api/card_template_catalog.go
@@ -181,7 +181,7 @@ func (c *botCardTemplateCatalog) RenderPayload(
 	if c == nil || c.registry == nil {
 		return nil, errBotTemplateCatalogUnavailable
 	}
-	if !isInteractiveCardType(inbound["type"]) {
+	if !cardmsg.IsCardPayload(inbound) {
 		return nil, fmt.Errorf("%w: type must be 17", errBotTemplateRequestInvalid)
 	}
 	allowedKeys := map[string]struct{}{
@@ -266,36 +266,4 @@ func requireEffectiveCardTemplate(envelope []byte, want botTemplateRef) error {
 		return fmt.Errorf("%w: effective template mismatch", errBotTemplateRequestInvalid)
 	}
 	return nil
-}
-
-func isInteractiveCardType(value any) bool {
-	switch typed := value.(type) {
-	case int:
-		return typed == cardmsg.InteractiveCard.Int()
-	case int8:
-		return int(typed) == cardmsg.InteractiveCard.Int()
-	case int16:
-		return int(typed) == cardmsg.InteractiveCard.Int()
-	case int32:
-		return int(typed) == cardmsg.InteractiveCard.Int()
-	case int64:
-		return typed == int64(cardmsg.InteractiveCard.Int())
-	case uint:
-		return typed == uint(cardmsg.InteractiveCard.Int())
-	case uint8:
-		return typed == uint8(cardmsg.InteractiveCard.Int())
-	case uint16:
-		return typed == uint16(cardmsg.InteractiveCard.Int())
-	case uint32:
-		return typed == uint32(cardmsg.InteractiveCard.Int())
-	case uint64:
-		return typed == uint64(cardmsg.InteractiveCard.Int())
-	case float64:
-		return typed == float64(cardmsg.InteractiveCard.Int())
-	case json.Number:
-		value, err := typed.Int64()
-		return err == nil && value == int64(cardmsg.InteractiveCard.Int())
-	default:
-		return false
-	}
 }

--- a/modules/bot_api/card_template_catalog.go
+++ b/modules/bot_api/card_template_catalog.go
@@ -228,6 +228,12 @@ func (c *botCardTemplateCatalog) RenderPayload(
 		}
 		return nil, fmt.Errorf("bot template render %s@%s: %w", ref.ID, ref.Version, err)
 	}
+	// Retain only the canonical ref as server-authored provenance. Raw Model B
+	// ingress rejects card+template_ref, so edit can distinguish a Registry frame
+	// from a caller-authored card that merely forged metadata.octo.template.
+	rendered["template_ref"] = map[string]any{
+		"id": string(ref.ID), "version": ref.Version,
+	}
 	for _, key := range []string{"mention", "reply"} {
 		if value, ok := inbound[key]; ok {
 			rendered[key] = value
@@ -255,6 +261,10 @@ func requireEffectiveCardTemplate(envelope []byte, want botTemplateRef) error {
 	var payload map[string]any
 	if err := decoder.Decode(&payload); err != nil || !cardmsg.IsCardPayload(payload) {
 		return fmt.Errorf("%w: effective target is not a card", errBotTemplateRequestInvalid)
+	}
+	provenance, err := parseBotTemplateRef(payload["template_ref"])
+	if err != nil || provenance != want {
+		return fmt.Errorf("%w: effective Registry provenance mismatch", errBotTemplateRequestInvalid)
 	}
 	card, _ := payload["card"].(map[string]any)
 	metadata, _ := card["metadata"].(map[string]any)

--- a/modules/bot_api/card_template_catalog_test.go
+++ b/modules/bot_api/card_template_catalog_test.go
@@ -104,7 +104,7 @@ func TestBotCardTemplateCatalogRenderPayload(t *testing.T) {
 		t.Fatal(err)
 	}
 	payload := map[string]any{
-		"type": int64(17),
+		"type": 17,
 		"template_ref": map[string]any{
 			"id":      string(aireasoningprocess.TemplateID),
 			"version": aireasoningprocess.TemplateVersion,
@@ -141,6 +141,67 @@ func TestBotCardTemplateCatalogRenderPayload(t *testing.T) {
 	template, _ := octo["template"].(map[string]any)
 	if template["id"] != string(aireasoningprocess.TemplateID) || template["version"] != aireasoningprocess.TemplateVersion {
 		t.Fatalf("authoritative template metadata = %#v", template)
+	}
+}
+
+func TestBotCardTemplateCatalogInvalidAndInternalRenderClassification(t *testing.T) {
+	registry := testBotTemplateRegistry(t)
+	catalog, err := newBotCardTemplateCatalog(registry, defaultBotTemplateRefs())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := (*botCardTemplateCatalog)(nil).Capability(); got.Supported || got.Wire != botTemplateWireV1 || got.Templates == nil {
+		t.Fatalf("nil catalog capability = %+v", got)
+	}
+	if _, err := newBotCardTemplateCatalog(registry, nil); err == nil {
+		t.Fatal("empty catalog must fail closed")
+	}
+	if _, err := newBotCardTemplateCatalog(nil, defaultBotTemplateRefs()); !errors.Is(err, errBotTemplateCatalogUnavailable) {
+		t.Fatalf("nil registry error = %v", err)
+	}
+
+	base := func() map[string]any {
+		return map[string]any{
+			"type": 17,
+			"template_ref": map[string]any{
+				"id": string(aireasoningprocess.TemplateID), "version": aireasoningprocess.TemplateVersion,
+			},
+			"state": "reasoning",
+			"data":  rawJSONToMap(t, testReasoningData(t, "reasoning")),
+		}
+	}
+	invalid := []struct {
+		name   string
+		mutate func(map[string]any)
+	}{
+		{name: "wrong type", mutate: func(p map[string]any) { p["type"] = 1 }},
+		{name: "missing ref", mutate: func(p map[string]any) { delete(p, "template_ref") }},
+		{name: "extra ref field", mutate: func(p map[string]any) { p["template_ref"].(map[string]any)["view"] = "active" }},
+		{name: "blank state", mutate: func(p map[string]any) { p["state"] = " " }},
+		{name: "schema invalid", mutate: func(p map[string]any) { delete(p["data"].(map[string]any), "title") }},
+		{name: "unknown state", mutate: func(p map[string]any) {
+			p["state"] = "unknown"
+			p["data"].(map[string]any)["state"] = "unknown"
+		}},
+	}
+	for _, tc := range invalid {
+		t.Run(tc.name, func(t *testing.T) {
+			payload := base()
+			tc.mutate(payload)
+			if _, err := catalog.RenderPayload(context.Background(), payload, cardtmpl.BuildEnv{}); !errors.Is(err, errBotTemplateRequestInvalid) {
+				t.Fatalf("error = %v, want request invalid", err)
+			}
+		})
+	}
+
+	// Schema-valid markdown reaches cardmsg.Validate and is a post-build render
+	// failure, not a caller-schema error. It remains zero-write and maps to the
+	// generic internal facade until the bounded successor schema lands.
+	malicious := base()
+	malicious["data"].(map[string]any)["progressText"] = "[tap](javascript:alert(1))"
+	_, err = catalog.RenderPayload(context.Background(), malicious, cardtmpl.BuildEnv{})
+	if err == nil || errors.Is(err, errBotTemplateRequestInvalid) {
+		t.Fatalf("post-build error classification = %v", err)
 	}
 }
 

--- a/modules/bot_api/card_template_catalog_test.go
+++ b/modules/bot_api/card_template_catalog_test.go
@@ -126,8 +126,8 @@ func TestBotCardTemplateCatalogRenderPayload(t *testing.T) {
 	if got["profile"] != "octo/v2" || got["render_profile"] != "octo-chat/v1" {
 		t.Fatalf("profiles = profile:%v render:%v", got["profile"], got["render_profile"])
 	}
-	if _, ok := got["template_ref"]; ok {
-		t.Fatal("template_ref must not reach the wire payload")
+	if !reflect.DeepEqual(got["template_ref"], payload["template_ref"]) {
+		t.Fatalf("server-authored template_ref = %#v", got["template_ref"])
 	}
 	if _, ok := got["data"]; ok {
 		t.Fatal("data must not reach the wire payload")
@@ -269,6 +269,11 @@ func TestEffectiveCardTemplateIdentity(t *testing.T) {
 	want := botTemplateRef{ID: aireasoningprocess.TemplateID, Version: aireasoningprocess.TemplateVersion}
 	if err := requireEffectiveCardTemplate(raw, want); err != nil {
 		t.Fatalf("requireEffectiveCardTemplate: %v", err)
+	}
+	delete(payload, "template_ref")
+	metadataOnly, _ := json.Marshal(payload)
+	if err := requireEffectiveCardTemplate(metadataOnly, want); !errors.Is(err, errBotTemplateRequestInvalid) {
+		t.Fatalf("metadata-only target error = %v", err)
 	}
 	if err := requireEffectiveCardTemplate(raw, botTemplateRef{ID: want.ID, Version: "9.9.9"}); !errors.Is(err, errBotTemplateRequestInvalid) {
 		t.Fatalf("mismatch error = %v", err)

--- a/modules/bot_api/card_template_catalog_test.go
+++ b/modules/bot_api/card_template_catalog_test.go
@@ -1,0 +1,227 @@
+package bot_api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl"
+	aireasoningprocess "github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl/ai_reasoning_process"
+	docsaccessrequest "github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl/docs_access_request"
+)
+
+func testBotTemplateRegistry(t *testing.T) *cardtmpl.Registry {
+	t.Helper()
+	r := cardtmpl.NewRegistry()
+	r.RegisterJSON(aireasoningprocess.Assets, aireasoningprocess.HandoffRoot)
+	r.SetDefault(aireasoningprocess.TemplateID, aireasoningprocess.TemplateVersion)
+	r.Register(docsaccessrequest.NewV3(), docsaccessrequest.Assets, docsaccessrequest.HandoffRootV3)
+	r.SetDefault(docsaccessrequest.TemplateID, docsaccessrequest.TemplateVersionV3)
+	r.Freeze()
+	return r
+}
+
+func testReasoningData(t *testing.T, state string) json.RawMessage {
+	t.Helper()
+	b, err := aireasoningprocess.Assets.ReadFile(
+		aireasoningprocess.HandoffRoot + "/samples/" + state + ".json",
+	)
+	if err != nil {
+		t.Fatalf("read reasoning sample %q: %v", state, err)
+	}
+	return json.RawMessage(b)
+}
+
+func TestBotCardTemplateCatalogCapability(t *testing.T) {
+	catalog, err := newBotCardTemplateCatalog(testBotTemplateRegistry(t), defaultBotTemplateRefs())
+	if err != nil {
+		t.Fatalf("newBotCardTemplateCatalog: %v", err)
+	}
+
+	got := catalog.Capability()
+	if !got.Supported || got.Wire != botTemplateWireV1 {
+		t.Fatalf("capability header = %+v", got)
+	}
+	if len(got.Templates) != 1 {
+		t.Fatalf("templates len = %d, want 1", len(got.Templates))
+	}
+	tpl := got.Templates[0]
+	if tpl.ID != string(aireasoningprocess.TemplateID) || tpl.Version != aireasoningprocess.TemplateVersion {
+		t.Fatalf("template = %+v", tpl)
+	}
+	wantViews := []botTemplateViewCapability{
+		{Name: "active", States: []string{"answering", "reasoning"}, WireProfile: "octo/v2", SubmitActions: []string{"reasoning_stop"}},
+		{Name: "error", States: []string{"error"}, WireProfile: "octo/v2", SubmitActions: []string{"reasoning_retry"}},
+		{Name: "result", States: []string{"completed", "stopped"}, WireProfile: "octo/v1", SubmitActions: []string{}},
+	}
+	if !reflect.DeepEqual(tpl.Views, wantViews) {
+		t.Fatalf("views = %#v, want %#v", tpl.Views, wantViews)
+	}
+
+	// Capability returns a defensive copy: a caller cannot mutate the catalog.
+	got.Templates[0].Views[0].States[0] = "tampered"
+	if again := catalog.Capability().Templates[0].Views[0].States[0]; again != "answering" {
+		t.Fatalf("catalog capability mutated through response: %q", again)
+	}
+}
+
+func TestBotCardTemplateCatalogFailsClosed(t *testing.T) {
+	registry := testBotTemplateRegistry(t)
+	tests := []struct {
+		name string
+		refs []botTemplateRef
+	}{
+		{
+			name: "duplicate",
+			refs: []botTemplateRef{
+				{ID: aireasoningprocess.TemplateID, Version: aireasoningprocess.TemplateVersion},
+				{ID: aireasoningprocess.TemplateID, Version: aireasoningprocess.TemplateVersion},
+			},
+		},
+		{
+			name: "missing registry entry",
+			refs: []botTemplateRef{{ID: "ai.missing", Version: "1.0.0"}},
+		},
+		{
+			name: "implicit version forbidden",
+			refs: []botTemplateRef{{ID: aireasoningprocess.TemplateID}},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := newBotCardTemplateCatalog(registry, tc.refs); err == nil {
+				t.Fatal("expected fail-closed catalog error")
+			}
+		})
+	}
+}
+
+func TestBotCardTemplateCatalogRenderPayload(t *testing.T) {
+	catalog, err := newBotCardTemplateCatalog(testBotTemplateRegistry(t), defaultBotTemplateRefs())
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload := map[string]any{
+		"type": int64(17),
+		"template_ref": map[string]any{
+			"id":      string(aireasoningprocess.TemplateID),
+			"version": aireasoningprocess.TemplateVersion,
+		},
+		"state": "reasoning",
+		"data":  rawJSONToMap(t, testReasoningData(t, "reasoning")),
+		"mention": map[string]any{
+			"uids": []any{"u-1"},
+		},
+		"reply": map[string]any{"message_id": "100"},
+	}
+
+	got, err := catalog.RenderPayload(context.Background(), payload, cardtmpl.BuildEnv{
+		Lang: "zh-CN", SpaceID: "space-1",
+	})
+	if err != nil {
+		t.Fatalf("RenderPayload: %v", err)
+	}
+	if got["profile"] != "octo/v2" || got["render_profile"] != "octo-chat/v1" {
+		t.Fatalf("profiles = profile:%v render:%v", got["profile"], got["render_profile"])
+	}
+	if _, ok := got["template_ref"]; ok {
+		t.Fatal("template_ref must not reach the wire payload")
+	}
+	if _, ok := got["data"]; ok {
+		t.Fatal("data must not reach the wire payload")
+	}
+	if !reflect.DeepEqual(got["mention"], payload["mention"]) || !reflect.DeepEqual(got["reply"], payload["reply"]) {
+		t.Fatalf("orthogonal envelope fields not preserved: %#v", got)
+	}
+	card, _ := got["card"].(map[string]any)
+	metadata, _ := card["metadata"].(map[string]any)
+	octo, _ := metadata["octo"].(map[string]any)
+	template, _ := octo["template"].(map[string]any)
+	if template["id"] != string(aireasoningprocess.TemplateID) || template["version"] != aireasoningprocess.TemplateVersion {
+		t.Fatalf("authoritative template metadata = %#v", template)
+	}
+}
+
+func TestBotCardTemplateCatalogRejectsCallerControlledInvalidModes(t *testing.T) {
+	catalog, err := newBotCardTemplateCatalog(testBotTemplateRegistry(t), defaultBotTemplateRefs())
+	if err != nil {
+		t.Fatal(err)
+	}
+	valid := func() map[string]any {
+		return map[string]any{
+			"type": float64(17),
+			"template_ref": map[string]any{
+				"id": string(aireasoningprocess.TemplateID), "version": aireasoningprocess.TemplateVersion,
+			},
+			"state": "reasoning",
+			"data":  rawJSONToMap(t, testReasoningData(t, "reasoning")),
+		}
+	}
+	tests := []struct {
+		name   string
+		mutate func(map[string]any)
+	}{
+		{name: "registered but unlisted", mutate: func(p map[string]any) {
+			p["template_ref"] = map[string]any{"id": string(docsaccessrequest.TemplateID), "version": docsaccessrequest.TemplateVersionV3}
+		}},
+		{name: "raw and registry both present", mutate: func(p map[string]any) { p["card"] = map[string]any{"type": "AdaptiveCard"} }},
+		{name: "state mismatch", mutate: func(p map[string]any) { p["state"] = "completed" }},
+		{name: "render owned plain", mutate: func(p map[string]any) { p["plain"] = "forged" }},
+		{name: "render owned profile", mutate: func(p map[string]any) { p["profile"] = "octo/v1" }},
+		{name: "render owned space", mutate: func(p map[string]any) { p["space_id"] = "forged" }},
+		{name: "unknown envelope field", mutate: func(p map[string]any) { p["content"] = "smuggled" }},
+		{name: "data must be object", mutate: func(p map[string]any) { p["data"] = []any{} }},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			p := valid()
+			tc.mutate(p)
+			if _, err := catalog.RenderPayload(context.Background(), p, cardtmpl.BuildEnv{}); !errors.Is(err, errBotTemplateRequestInvalid) {
+				t.Fatalf("error = %v, want errBotTemplateRequestInvalid", err)
+			}
+		})
+	}
+}
+
+func TestEffectiveCardTemplateIdentity(t *testing.T) {
+	catalog, err := newBotCardTemplateCatalog(testBotTemplateRegistry(t), defaultBotTemplateRefs())
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload, err := catalog.RenderPayload(context.Background(), map[string]any{
+		"type": float64(17),
+		"template_ref": map[string]any{
+			"id": string(aireasoningprocess.TemplateID), "version": aireasoningprocess.TemplateVersion,
+		},
+		"state": "reasoning",
+		"data":  rawJSONToMap(t, testReasoningData(t, "reasoning")),
+	}, cardtmpl.BuildEnv{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := botTemplateRef{ID: aireasoningprocess.TemplateID, Version: aireasoningprocess.TemplateVersion}
+	if err := requireEffectiveCardTemplate(raw, want); err != nil {
+		t.Fatalf("requireEffectiveCardTemplate: %v", err)
+	}
+	if err := requireEffectiveCardTemplate(raw, botTemplateRef{ID: want.ID, Version: "9.9.9"}); !errors.Is(err, errBotTemplateRequestInvalid) {
+		t.Fatalf("mismatch error = %v", err)
+	}
+	if err := requireEffectiveCardTemplate([]byte(`{"type":17,"card":{}}`), want); !errors.Is(err, errBotTemplateRequestInvalid) {
+		t.Fatalf("non-registry error = %v", err)
+	}
+}
+
+func rawJSONToMap(t *testing.T, raw json.RawMessage) map[string]any {
+	t.Helper()
+	var out map[string]any
+	if err := json.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("unmarshal fixture: %v", err)
+	}
+	return out
+}

--- a/modules/bot_api/card_template_edit_test.go
+++ b/modules/bot_api/card_template_edit_test.go
@@ -85,6 +85,48 @@ func TestBotMessageEditRegistryTemplateRendersSameIdentity(t *testing.T) {
 	}
 }
 
+func TestBotMessageEditRegistryTemplatePreservesAuthoritativeSpaceAcrossEdits(t *testing.T) {
+	t.Setenv(cardmsg.EnvEnabled, "true")
+	catalog, err := newBotCardTemplateCatalog(testBotTemplateRegistry(t), defaultBotTemplateRefs())
+	if err != nil {
+		t.Fatal(err)
+	}
+	effective := initialRegistryEnvelope(t, catalog)
+	tests := []struct {
+		state     string
+		cardSeq   int64
+		transient bool
+	}{
+		{state: "answering", cardSeq: 2, transient: true},
+		{state: "completed", cardSeq: 3, transient: false},
+	}
+	for _, tc := range tests {
+		mutator := &fakeBotCardMutator{
+			snapshot:     carddispatch.CardMutationSnapshot{Envelope: effective, CardSeq: tc.cardSeq - 1},
+			mutateResult: carddispatch.CardMutationResult{Applied: true},
+		}
+		ba := &BotAPI{
+			Log: log.NewTLog("BotAPI-template-edit-space"), cardTemplates: catalog, cardMutator: mutator,
+		}
+		recorder := invokeTemplateEdit(t, ba,
+			registryEditBody(t, tc.state, testReasoningData(t, tc.state), tc.cardSeq, tc.transient))
+		if recorder.Code != http.StatusOK || len(mutator.mutateRequests) != 1 {
+			t.Fatalf("state=%s status=%d mutations=%d body=%s",
+				tc.state, recorder.Code, len(mutator.mutateRequests), recorder.Body.String())
+		}
+		contentEdit := mutator.mutateRequests[0].ContentEdit
+		var frame map[string]any
+		if err := json.Unmarshal([]byte(contentEdit), &frame); err != nil {
+			t.Fatalf("state=%s decode replacement: %v", tc.state, err)
+		}
+		if got := frame["space_id"]; got != cardtmplBuildEnvForTest().SpaceID {
+			t.Fatalf("state=%s space_id=%v, want authoritative %q",
+				tc.state, got, cardtmplBuildEnvForTest().SpaceID)
+		}
+		effective = []byte(contentEdit)
+	}
+}
+
 func TestBotMessageEditRegistryTemplateRejectsUnlistedRefBeforeTargetLookup(t *testing.T) {
 	t.Setenv(cardmsg.EnvEnabled, "true")
 	catalog, err := newBotCardTemplateCatalog(testBotTemplateRegistry(t), defaultBotTemplateRefs())
@@ -349,6 +391,7 @@ func initialRegistryEnvelope(t *testing.T, catalog *botCardTemplateCatalog) []by
 	if err != nil {
 		t.Fatal(err)
 	}
+	payload["space_id"] = cardtmplBuildEnvForTest().SpaceID
 	payload["card_seq"] = int64(1)
 	if err := cardmsg.Finalize(payload); err != nil {
 		t.Fatal(err)

--- a/modules/bot_api/card_template_edit_test.go
+++ b/modules/bot_api/card_template_edit_test.go
@@ -126,12 +126,48 @@ func TestBotMessageEditRegistryTemplateFailsClosed(t *testing.T) {
 			},
 		},
 		{
+			name: "post build render failure",
+			body: func(t *testing.T) map[string]any {
+				body := registryEditBody(t, "reasoning", testReasoningData(t, "reasoning"), 2, false)
+				body["data"].(map[string]any)["progressText"] = "[tap](javascript:alert(1))"
+				return body
+			},
+		},
+		{
 			name: "stale card seq",
 			body: func(t *testing.T) map[string]any {
 				return registryEditBody(t, "completed", testReasoningData(t, "completed"), 2, false)
 			},
 			mutateErr:   carddispatch.ErrCardMutationConflict,
 			wantMessage: "stale card_seq",
+		},
+		{
+			name: "ownership changes between snapshot and mutate",
+			body: func(t *testing.T) map[string]any {
+				return registryEditBody(t, "completed", testReasoningData(t, "completed"), 2, false)
+			},
+			mutateErr: carddispatch.ErrCardMutationForbidden,
+		},
+		{
+			name: "target revoked between snapshot and mutate",
+			body: func(t *testing.T) map[string]any {
+				return registryEditBody(t, "completed", testReasoningData(t, "completed"), 2, false)
+			},
+			mutateErr: carddispatch.ErrCardMutationNotFound,
+		},
+		{
+			name: "replacement rejected by mutator",
+			body: func(t *testing.T) map[string]any {
+				return registryEditBody(t, "completed", testReasoningData(t, "completed"), 2, false)
+			},
+			mutateErr: carddispatch.ErrCardMutationInvalid,
+		},
+		{
+			name: "mutation infrastructure failure",
+			body: func(t *testing.T) map[string]any {
+				return registryEditBody(t, "completed", testReasoningData(t, "completed"), 2, false)
+			},
+			mutateErr: errors.New("store unavailable"),
 		},
 	}
 	for _, tc := range tests {
@@ -171,6 +207,7 @@ func TestBotMessageEditRegistryTemplateMapsOwnershipAndLifecycle(t *testing.T) {
 		{name: "not owner", err: carddispatch.ErrCardMutationForbidden},
 		{name: "revoked or deleted", err: carddispatch.ErrCardMutationNotFound},
 		{name: "non registry target", err: carddispatch.ErrCardMutationInvalid},
+		{name: "snapshot infrastructure failure", err: errors.New("lookup unavailable")},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -183,6 +220,46 @@ func TestBotMessageEditRegistryTemplateMapsOwnershipAndLifecycle(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestBotMessageEditRegistryTemplateDisabledAndWiringFailures(t *testing.T) {
+	catalog, err := newBotCardTemplateCatalog(testBotTemplateRegistry(t), defaultBotTemplateRefs())
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := registryEditBody(t, "completed", testReasoningData(t, "completed"), 2, false)
+
+	t.Run("disabled", func(t *testing.T) {
+		t.Setenv(cardmsg.EnvEnabled, "")
+		mutator := &fakeBotCardMutator{}
+		ba := &BotAPI{Log: log.NewTLog("BotAPI-template-edit-disabled"), cardTemplates: catalog, cardMutator: mutator}
+		recorder := invokeTemplateEdit(t, ba, body)
+		if recorder.Code != http.StatusBadRequest || mutator.snapshotCalls != 0 {
+			t.Fatalf("status=%d snapshots=%d body=%s", recorder.Code, mutator.snapshotCalls, recorder.Body.String())
+		}
+	})
+
+	t.Run("catalog missing", func(t *testing.T) {
+		t.Setenv(cardmsg.EnvEnabled, "true")
+		mutator := &fakeBotCardMutator{}
+		ba := &BotAPI{Log: log.NewTLog("BotAPI-template-edit-unwired"), cardMutator: mutator}
+		recorder := invokeTemplateEdit(t, ba, body)
+		if recorder.Code != http.StatusBadRequest || mutator.snapshotCalls != 0 {
+			t.Fatalf("status=%d snapshots=%d body=%s", recorder.Code, mutator.snapshotCalls, recorder.Body.String())
+		}
+	})
+
+	t.Run("malformed ref", func(t *testing.T) {
+		t.Setenv(cardmsg.EnvEnabled, "true")
+		mutator := &fakeBotCardMutator{}
+		ba := &BotAPI{Log: log.NewTLog("BotAPI-template-edit-ref"), cardTemplates: catalog, cardMutator: mutator}
+		bad := registryEditBody(t, "completed", testReasoningData(t, "completed"), 2, false)
+		bad["template_ref"].(map[string]any)["view"] = "result"
+		recorder := invokeTemplateEdit(t, ba, bad)
+		if recorder.Code != http.StatusBadRequest || mutator.snapshotCalls != 0 {
+			t.Fatalf("status=%d snapshots=%d body=%s", recorder.Code, mutator.snapshotCalls, recorder.Body.String())
+		}
+	})
 }
 
 func initialRegistryEnvelope(t *testing.T, catalog *botCardTemplateCatalog) []byte {
@@ -237,5 +314,3 @@ func invokeTemplateEdit(t *testing.T, ba *BotAPI, body map[string]any) *httptest
 func cardtmplBuildEnvForTest() cardtmpl.BuildEnv {
 	return cardtmpl.BuildEnv{Lang: "zh-CN", SpaceID: "space-1"}
 }
-
-var _ = errors.Is

--- a/modules/bot_api/card_template_edit_test.go
+++ b/modules/bot_api/card_template_edit_test.go
@@ -1,0 +1,241 @@
+package bot_api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/internal/carddispatch"
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardmsg"
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl"
+	aireasoningprocess "github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl/ai_reasoning_process"
+	"github.com/gin-gonic/gin"
+)
+
+type fakeBotCardMutator struct {
+	snapshot       carddispatch.CardMutationSnapshot
+	snapshotErr    error
+	mutateResult   carddispatch.CardMutationResult
+	mutateErr      error
+	snapshotCalls  int
+	mutateRequests []carddispatch.CardMutationRequest
+}
+
+func (m *fakeBotCardMutator) Snapshot(_ context.Context, _ carddispatch.CardMutationTarget) (carddispatch.CardMutationSnapshot, error) {
+	m.snapshotCalls++
+	return m.snapshot, m.snapshotErr
+}
+
+func (m *fakeBotCardMutator) Mutate(_ context.Context, request carddispatch.CardMutationRequest) (carddispatch.CardMutationResult, error) {
+	m.mutateRequests = append(m.mutateRequests, request)
+	return m.mutateResult, m.mutateErr
+}
+
+func (m *fakeBotCardMutator) WriteCAS(carddispatch.CardMutationCASRequest) (bool, error) {
+	return false, nil
+}
+
+func TestBotMessageEditRegistryTemplateRendersSameIdentity(t *testing.T) {
+	t.Setenv(cardmsg.EnvEnabled, "true")
+	catalog, err := newBotCardTemplateCatalog(testBotTemplateRegistry(t), defaultBotTemplateRefs())
+	if err != nil {
+		t.Fatal(err)
+	}
+	mutator := &fakeBotCardMutator{
+		snapshot:     carddispatch.CardMutationSnapshot{Envelope: initialRegistryEnvelope(t, catalog), CardSeq: 1},
+		mutateResult: carddispatch.CardMutationResult{Applied: true},
+	}
+	ba := &BotAPI{
+		Log:           log.NewTLog("BotAPI-template-edit"),
+		cardTemplates: catalog,
+		cardMutator:   mutator,
+	}
+	body := registryEditBody(t, "completed", testReasoningData(t, "completed"), 2, true)
+	recorder := invokeTemplateEdit(t, ba, body)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", recorder.Code, recorder.Body.String())
+	}
+	if mutator.snapshotCalls != 1 || len(mutator.mutateRequests) != 1 {
+		t.Fatalf("snapshot/mutate calls = %d/%d", mutator.snapshotCalls, len(mutator.mutateRequests))
+	}
+	request := mutator.mutateRequests[0]
+	var frame map[string]any
+	if err := json.Unmarshal([]byte(request.ContentEdit), &frame); err != nil {
+		t.Fatal(err)
+	}
+	if frame["profile"] != "octo/v1" || frame["card_seq"] != float64(2) || frame["transient"] != true {
+		t.Fatalf("replacement frame = %#v", frame)
+	}
+	if plain, _ := frame["plain"].(string); plain == "" {
+		t.Fatal("replacement plain missing")
+	}
+	if err := requireEffectiveCardTemplate([]byte(request.ContentEdit), botTemplateRef{
+		ID: aireasoningprocess.TemplateID, Version: aireasoningprocess.TemplateVersion,
+	}); err != nil {
+		t.Fatalf("replacement identity: %v", err)
+	}
+}
+
+func TestBotMessageEditRegistryTemplateFailsClosed(t *testing.T) {
+	t.Setenv(cardmsg.EnvEnabled, "true")
+	catalog, err := newBotCardTemplateCatalog(testBotTemplateRegistry(t), defaultBotTemplateRefs())
+	if err != nil {
+		t.Fatal(err)
+	}
+	tests := []struct {
+		name        string
+		body        func(*testing.T) map[string]any
+		snapshot    func(*testing.T) carddispatch.CardMutationSnapshot
+		mutateErr   error
+		wantMessage string
+	}{
+		{
+			name: "non positive card seq",
+			body: func(t *testing.T) map[string]any {
+				return registryEditBody(t, "completed", testReasoningData(t, "completed"), 0, false)
+			},
+		},
+		{
+			name: "outer data state mismatch",
+			body: func(t *testing.T) map[string]any {
+				return registryEditBody(t, "error", testReasoningData(t, "completed"), 2, false)
+			},
+		},
+		{
+			name: "cross version target",
+			body: func(t *testing.T) map[string]any {
+				return registryEditBody(t, "completed", testReasoningData(t, "completed"), 2, false)
+			},
+			snapshot: func(t *testing.T) carddispatch.CardMutationSnapshot {
+				frame := initialRegistryEnvelope(t, catalog)
+				var payload map[string]any
+				_ = json.Unmarshal(frame, &payload)
+				card := payload["card"].(map[string]any)
+				metadata := card["metadata"].(map[string]any)
+				octo := metadata["octo"].(map[string]any)
+				octo["template"].(map[string]any)["version"] = "9.9.9"
+				modified, _ := json.Marshal(payload)
+				return carddispatch.CardMutationSnapshot{Envelope: modified, CardSeq: 1}
+			},
+		},
+		{
+			name: "stale card seq",
+			body: func(t *testing.T) map[string]any {
+				return registryEditBody(t, "completed", testReasoningData(t, "completed"), 2, false)
+			},
+			mutateErr:   carddispatch.ErrCardMutationConflict,
+			wantMessage: "stale card_seq",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			snapshot := carddispatch.CardMutationSnapshot{Envelope: initialRegistryEnvelope(t, catalog), CardSeq: 1}
+			if tc.snapshot != nil {
+				snapshot = tc.snapshot(t)
+			}
+			mutator := &fakeBotCardMutator{snapshot: snapshot, mutateErr: tc.mutateErr}
+			ba := &BotAPI{
+				Log: log.NewTLog("BotAPI-template-edit-invalid"), cardTemplates: catalog, cardMutator: mutator,
+			}
+			recorder := invokeTemplateEdit(t, ba, tc.body(t))
+			if recorder.Code != http.StatusBadRequest {
+				t.Fatalf("status=%d body=%s", recorder.Code, recorder.Body.String())
+			}
+			if tc.wantMessage != "" && !bytes.Contains(recorder.Body.Bytes(), []byte(tc.wantMessage)) {
+				t.Fatalf("body=%s, want %q", recorder.Body.String(), tc.wantMessage)
+			}
+			if tc.mutateErr == nil && len(mutator.mutateRequests) != 0 {
+				t.Fatal("invalid Registry edit reached mutation")
+			}
+		})
+	}
+}
+
+func TestBotMessageEditRegistryTemplateMapsOwnershipAndLifecycle(t *testing.T) {
+	t.Setenv(cardmsg.EnvEnabled, "true")
+	catalog, err := newBotCardTemplateCatalog(testBotTemplateRegistry(t), defaultBotTemplateRefs())
+	if err != nil {
+		t.Fatal(err)
+	}
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{name: "not owner", err: carddispatch.ErrCardMutationForbidden},
+		{name: "revoked or deleted", err: carddispatch.ErrCardMutationNotFound},
+		{name: "non registry target", err: carddispatch.ErrCardMutationInvalid},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			mutator := &fakeBotCardMutator{snapshotErr: tc.err}
+			ba := &BotAPI{Log: log.NewTLog("BotAPI-template-edit-guard"), cardTemplates: catalog, cardMutator: mutator}
+			recorder := invokeTemplateEdit(t, ba,
+				registryEditBody(t, "completed", testReasoningData(t, "completed"), 2, false))
+			if recorder.Code != http.StatusBadRequest || len(mutator.mutateRequests) != 0 {
+				t.Fatalf("status=%d mutate=%d body=%s", recorder.Code, len(mutator.mutateRequests), recorder.Body.String())
+			}
+		})
+	}
+}
+
+func initialRegistryEnvelope(t *testing.T, catalog *botCardTemplateCatalog) []byte {
+	t.Helper()
+	payload, err := catalog.RenderPayload(context.Background(), registrySendBody(t,
+		"reasoning", testReasoningData(t, "reasoning"))["payload"].(map[string]any), cardtmplBuildEnvForTest())
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload["card_seq"] = int64(1)
+	if err := cardmsg.Finalize(payload); err != nil {
+		t.Fatal(err)
+	}
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return raw
+}
+
+func registryEditBody(t *testing.T, state string, data json.RawMessage, cardSeq int64, transient bool) map[string]any {
+	t.Helper()
+	return map[string]any{
+		"message_id": "1001", "message_seq": uint32(7),
+		"channel_id": "user_creator", "channel_type": common.ChannelTypePerson.Uint8(),
+		"template_ref": map[string]any{
+			"id": string(aireasoningprocess.TemplateID), "version": aireasoningprocess.TemplateVersion,
+		},
+		"state": state, "data": rawJSONToMap(t, data), "card_seq": cardSeq, "transient": transient,
+	}
+}
+
+func invokeTemplateEdit(t *testing.T, ba *BotAPI, body map[string]any) *httptest.ResponseRecorder {
+	t.Helper()
+	raw, err := json.Marshal(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodPost, "/v1/bot/message/edit", bytes.NewReader(raw))
+	request.Header.Set("Content-Type", "application/json")
+	ginContext, _ := gin.CreateTestContext(recorder)
+	ginContext.Request = request
+	ctx := &wkhttp.Context{Context: ginContext}
+	ctx.Set(CtxKeyRobotID, "bot-template")
+	ctx.Set(CtxKeyBotKind, BotKindUser)
+	ctx.Set(CtxKeyRobot, &robotModel{RobotID: "bot-template", CreatorUID: "user_creator"})
+	ba.botMessageEdit(ctx)
+	return recorder
+}
+
+func cardtmplBuildEnvForTest() cardtmpl.BuildEnv {
+	return cardtmpl.BuildEnv{Lang: "zh-CN", SpaceID: "space-1"}
+}
+
+var _ = errors.Is

--- a/modules/bot_api/card_template_edit_test.go
+++ b/modules/bot_api/card_template_edit_test.go
@@ -16,6 +16,8 @@ import (
 	"github.com/Mininglamp-OSS/octo-server/pkg/cardmsg"
 	"github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl"
 	aireasoningprocess "github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl/ai_reasoning_process"
+	docsaccessrequest "github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl/docs_access_request"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
 	"github.com/gin-gonic/gin"
 )
 
@@ -80,6 +82,61 @@ func TestBotMessageEditRegistryTemplateRendersSameIdentity(t *testing.T) {
 		ID: aireasoningprocess.TemplateID, Version: aireasoningprocess.TemplateVersion,
 	}); err != nil {
 		t.Fatalf("replacement identity: %v", err)
+	}
+}
+
+func TestBotMessageEditRegistryTemplateRejectsUnlistedRefBeforeTargetLookup(t *testing.T) {
+	t.Setenv(cardmsg.EnvEnabled, "true")
+	catalog, err := newBotCardTemplateCatalog(testBotTemplateRegistry(t), defaultBotTemplateRefs())
+	if err != nil {
+		t.Fatal(err)
+	}
+	validSnapshot := carddispatch.CardMutationSnapshot{
+		Envelope: initialRegistryEnvelope(t, catalog), CardSeq: 1,
+	}
+	tests := []struct {
+		name        string
+		snapshot    carddispatch.CardMutationSnapshot
+		snapshotErr error
+	}{
+		{name: "valid target", snapshot: validSnapshot},
+		{name: "missing target", snapshotErr: carddispatch.ErrCardMutationNotFound},
+		{name: "foreign target", snapshotErr: carddispatch.ErrCardMutationForbidden},
+	}
+	var firstEnvelope []byte
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			mutator := &fakeBotCardMutator{snapshot: tc.snapshot, snapshotErr: tc.snapshotErr}
+			ba := &BotAPI{
+				Log: log.NewTLog("BotAPI-template-edit-unlisted"), cardTemplates: catalog, cardMutator: mutator,
+			}
+			body := registryEditBody(t, "completed", testReasoningData(t, "completed"), 2, false)
+			body["template_ref"] = map[string]any{
+				"id": string(docsaccessrequest.TemplateID), "version": docsaccessrequest.TemplateVersionV3,
+			}
+
+			recorder := invokeTemplateEdit(t, ba, body)
+			if recorder.Code != http.StatusBadRequest {
+				t.Fatalf("status=%d body=%s", recorder.Code, recorder.Body.String())
+			}
+			var envelope errEnvelope
+			if err := json.Unmarshal(recorder.Body.Bytes(), &envelope); err != nil {
+				t.Fatalf("decode error envelope: %v; body=%s", err, recorder.Body.String())
+			}
+			if envelope.Msg != errcode.ErrBotAPICardInvalid.DefaultMessage || envelope.Status != http.StatusBadRequest {
+				t.Fatalf("error envelope=%+v, want card-invalid; body=%s", envelope, recorder.Body.String())
+			}
+			if mutator.snapshotCalls != 0 || len(mutator.mutateRequests) != 0 {
+				t.Fatalf("unlisted ref reached target state: snapshots=%d mutations=%d",
+					mutator.snapshotCalls, len(mutator.mutateRequests))
+			}
+			if firstEnvelope == nil {
+				firstEnvelope = append([]byte(nil), recorder.Body.Bytes()...)
+			} else if !bytes.Equal(firstEnvelope, recorder.Body.Bytes()) {
+				t.Fatalf("target state changed rejection envelope:\nfirst=%s\ncurrent=%s",
+					firstEnvelope, recorder.Body.Bytes())
+			}
+		})
 	}
 }
 

--- a/modules/bot_api/card_template_edit_test.go
+++ b/modules/bot_api/card_template_edit_test.go
@@ -262,6 +262,29 @@ func TestBotMessageEditRegistryTemplateDisabledAndWiringFailures(t *testing.T) {
 	})
 }
 
+func TestBotMessageEditRegistryTemplateRejectsDualModeByFieldPresence(t *testing.T) {
+	t.Setenv(cardmsg.EnvEnabled, "true")
+	catalog, err := newBotCardTemplateCatalog(testBotTemplateRegistry(t), defaultBotTemplateRefs())
+	if err != nil {
+		t.Fatal(err)
+	}
+	mutator := &fakeBotCardMutator{}
+	ba := &BotAPI{
+		Log: log.NewTLog("BotAPI-template-edit-dual-mode"), cardTemplates: catalog, cardMutator: mutator,
+	}
+	body := registryEditBody(t, "completed", testReasoningData(t, "completed"), 2, false)
+	body["content_edit"] = " "
+
+	recorder := invokeTemplateEdit(t, ba, body)
+	if recorder.Code != http.StatusBadRequest {
+		t.Fatalf("status=%d body=%s", recorder.Code, recorder.Body.String())
+	}
+	if mutator.snapshotCalls != 0 || len(mutator.mutateRequests) != 0 {
+		t.Fatalf("dual-mode request reached mutation path: snapshots=%d mutate=%d",
+			mutator.snapshotCalls, len(mutator.mutateRequests))
+	}
+}
+
 func initialRegistryEnvelope(t *testing.T, catalog *botCardTemplateCatalog) []byte {
 	t.Helper()
 	payload, err := catalog.RenderPayload(context.Background(), registrySendBody(t,

--- a/modules/bot_api/card_template_send_test.go
+++ b/modules/bot_api/card_template_send_test.go
@@ -1,0 +1,179 @@
+package bot_api
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardmsg"
+	aireasoningprocess "github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl/ai_reasoning_process"
+	"github.com/gin-gonic/gin"
+)
+
+func TestSendMessageRegistryTemplateRendersAndDispatches(t *testing.T) {
+	t.Setenv(cardmsg.EnvEnabled, "true")
+	gin.SetMode(gin.TestMode)
+
+	dispatch := &dispatchCapture{}
+	catalog, err := newBotCardTemplateCatalog(testBotTemplateRegistry(t), defaultBotTemplateRefs())
+	if err != nil {
+		t.Fatal(err)
+	}
+	ba := &BotAPI{
+		Log:              log.NewTLog("BotAPI-template-send"),
+		cardTemplates:    catalog,
+		spaceQuerier:     &fakeSpaceQuerier{defaultSpace: "space-authoritative"},
+		dispatchOverride: dispatch.hook,
+	}
+	body := registrySendBody(t, "reasoning", testReasoningData(t, "reasoning"))
+	payload := body["payload"].(map[string]any)
+	payload["mention"] = map[string]any{"uids": []any{"u-1"}}
+	payload["reply"] = map[string]any{"message_id": "100"}
+
+	recorder := invokeTemplateSend(t, ba, body, "")
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", recorder.Code, recorder.Body.String())
+	}
+	dispatch.mu.Lock()
+	captured := dispatch.captured
+	dispatch.mu.Unlock()
+	if captured == nil {
+		t.Fatal("expected exactly one dispatch")
+	}
+	var wire map[string]any
+	if err := json.Unmarshal(captured.Payload, &wire); err != nil {
+		t.Fatal(err)
+	}
+	if wire["profile"] != "octo/v2" || wire["render_profile"] != "octo-chat/v1" {
+		t.Fatalf("profiles = %v / %v", wire["profile"], wire["render_profile"])
+	}
+	if wire["space_id"] != "space-authoritative" {
+		t.Fatalf("space_id = %v", wire["space_id"])
+	}
+	if plain, _ := wire["plain"].(string); plain == "" {
+		t.Fatal("server-authoritative plain missing")
+	}
+	if _, ok := wire["template_ref"]; ok {
+		t.Fatal("template_ref leaked to outbound payload")
+	}
+	if _, ok := wire["data"]; ok {
+		t.Fatal("template data leaked to outbound payload")
+	}
+	if _, ok := wire["mention"].(map[string]any); !ok {
+		t.Fatalf("mention not preserved: %#v", wire["mention"])
+	}
+	if _, ok := wire["reply"].(map[string]any); !ok {
+		t.Fatalf("reply not preserved: %#v", wire["reply"])
+	}
+}
+
+func TestSendMessageRegistryTemplateRejectsInvalidWithoutDispatch(t *testing.T) {
+	t.Setenv(cardmsg.EnvEnabled, "true")
+	gin.SetMode(gin.TestMode)
+	catalog, err := newBotCardTemplateCatalog(testBotTemplateRegistry(t), defaultBotTemplateRefs())
+	if err != nil {
+		t.Fatal(err)
+	}
+	tests := []struct {
+		name   string
+		mutate func(map[string]any)
+	}{
+		{name: "outer data state mismatch", mutate: func(payload map[string]any) { payload["state"] = "completed" }},
+		{name: "registered but unlisted", mutate: func(payload map[string]any) {
+			payload["template_ref"] = map[string]any{"id": "docs.access-request", "version": "0.3.0"}
+		}},
+		{name: "raw and registry both present", mutate: func(payload map[string]any) { payload["card"] = map[string]any{} }},
+		{name: "render owned field", mutate: func(payload map[string]any) { payload["plain"] = "forged" }},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dispatch := &dispatchCapture{}
+			ba := &BotAPI{
+				Log:              log.NewTLog("BotAPI-template-send-invalid"),
+				cardTemplates:    catalog,
+				spaceQuerier:     &fakeSpaceQuerier{defaultSpace: "space-authoritative"},
+				dispatchOverride: dispatch.hook,
+			}
+			body := registrySendBody(t, "reasoning", testReasoningData(t, "reasoning"))
+			tc.mutate(body["payload"].(map[string]any))
+			recorder := invokeTemplateSend(t, ba, body, "")
+			if recorder.Code != http.StatusBadRequest {
+				t.Fatalf("status=%d body=%s", recorder.Code, recorder.Body.String())
+			}
+			dispatch.mu.Lock()
+			captured := dispatch.captured
+			dispatch.mu.Unlock()
+			if captured != nil {
+				t.Fatal("invalid template request dispatched a message")
+			}
+		})
+	}
+}
+
+func TestSendMessageRegistryTemplateKeepsOBOCardExclusion(t *testing.T) {
+	t.Setenv(cardmsg.EnvEnabled, "true")
+	catalog, err := newBotCardTemplateCatalog(testBotTemplateRegistry(t), defaultBotTemplateRefs())
+	if err != nil {
+		t.Fatal(err)
+	}
+	dispatch := &dispatchCapture{}
+	ba := &BotAPI{
+		Log:              log.NewTLog("BotAPI-template-send-obo"),
+		cardTemplates:    catalog,
+		spaceQuerier:     &fakeSpaceQuerier{defaultSpace: "space-authoritative"},
+		dispatchOverride: dispatch.hook,
+	}
+	recorder := invokeTemplateSend(t, ba,
+		registrySendBody(t, "reasoning", testReasoningData(t, "reasoning")), "user_creator")
+	if recorder.Code != http.StatusBadRequest || !bytes.Contains(recorder.Body.Bytes(), []byte("cannot be sent on behalf")) {
+		t.Fatalf("status=%d body=%s", recorder.Code, recorder.Body.String())
+	}
+	dispatch.mu.Lock()
+	defer dispatch.mu.Unlock()
+	if dispatch.captured != nil {
+		t.Fatal("OBO template request dispatched a message")
+	}
+}
+
+func registrySendBody(t *testing.T, state string, data json.RawMessage) map[string]any {
+	t.Helper()
+	return map[string]any{
+		"channel_id":   "user_creator",
+		"channel_type": common.ChannelTypePerson.Uint8(),
+		"payload": map[string]any{
+			"type": cardmsg.InteractiveCard.Int(),
+			"template_ref": map[string]any{
+				"id": string(aireasoningprocess.TemplateID), "version": aireasoningprocess.TemplateVersion,
+			},
+			"state": state,
+			"data":  rawJSONToMap(t, data),
+		},
+	}
+}
+
+func invokeTemplateSend(t *testing.T, ba *BotAPI, body map[string]any, onBehalfOf string) *httptest.ResponseRecorder {
+	t.Helper()
+	if onBehalfOf != "" {
+		body["on_behalf_of"] = onBehalfOf
+	}
+	raw, err := json.Marshal(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodPost, "/v1/bot/sendMessage", bytes.NewReader(raw))
+	request.Header.Set("Content-Type", "application/json")
+	ginContext, _ := gin.CreateTestContext(recorder)
+	ginContext.Request = request
+	ctx := &wkhttp.Context{Context: ginContext}
+	ctx.Set(CtxKeyRobotID, "bot-template")
+	ctx.Set(CtxKeyBotKind, BotKindUser)
+	ctx.Set(CtxKeyRobot, &robotModel{RobotID: "bot-template", CreatorUID: "user_creator"})
+	ba.sendMessage(ctx)
+	return recorder
+}

--- a/modules/bot_api/card_template_send_test.go
+++ b/modules/bot_api/card_template_send_test.go
@@ -58,8 +58,8 @@ func TestSendMessageRegistryTemplateRendersAndDispatches(t *testing.T) {
 	if plain, _ := wire["plain"].(string); plain == "" {
 		t.Fatal("server-authoritative plain missing")
 	}
-	if _, ok := wire["template_ref"]; ok {
-		t.Fatal("template_ref leaked to outbound payload")
+	if ref, ok := wire["template_ref"].(map[string]any); !ok || ref["id"] != string(aireasoningprocess.TemplateID) || ref["version"] != aireasoningprocess.TemplateVersion {
+		t.Fatalf("server-authored template_ref missing: %#v", wire["template_ref"])
 	}
 	if _, ok := wire["data"]; ok {
 		t.Fatal("template data leaked to outbound payload")
@@ -70,6 +70,35 @@ func TestSendMessageRegistryTemplateRendersAndDispatches(t *testing.T) {
 	if _, ok := wire["reply"].(map[string]any); !ok {
 		t.Fatalf("reply not preserved: %#v", wire["reply"])
 	}
+}
+
+func TestRawContentEditCannotForgeRegistryProvenance(t *testing.T) {
+	raw := imCardEnvelope("raw", 1)
+	raw["template_ref"] = map[string]any{
+		"id": string(aireasoningprocess.TemplateID), "version": aireasoningprocess.TemplateVersion,
+	}
+	encoded, err := json.Marshal(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !contentEditHasTemplateRef(string(encoded)) {
+		t.Fatal("raw content_edit provenance marker was not detected")
+	}
+	if !cardEnvelopeHasTemplateRef(encoded) {
+		t.Fatal("Registry-authored target provenance marker was not detected")
+	}
+	if contentEditHasTemplateRef(string(mustJSON(t, imCardEnvelope("raw", 1)))) {
+		t.Fatal("ordinary raw content_edit falsely detected as Registry provenance")
+	}
+}
+
+func mustJSON(t *testing.T, value any) []byte {
+	t.Helper()
+	raw, err := json.Marshal(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return raw
 }
 
 func TestSendMessageRegistryTemplateRejectsInvalidWithoutDispatch(t *testing.T) {

--- a/modules/bot_api/send.go
+++ b/modules/bot_api/send.go
@@ -1166,10 +1166,15 @@ func (ba *BotAPI) botMessageEditViaRegistry(c *wkhttp.Context, req *botMessageEd
 		httperr.ResponseErrorL(c, errcode.ErrSharedInternal, nil, nil)
 		return
 	}
-	ref, err := parseBotTemplateRef(req.TemplateRef)
+	ref, err := ba.cardTemplates.requireAllowedRef(req.TemplateRef)
 	if err != nil {
-		ba.Warn("Bot Registry edit template_ref 非法", zap.Error(err), zap.String("messageID", req.MessageID))
-		httperr.ResponseErrorL(c, errcode.ErrBotAPICardInvalid, nil, nil)
+		if errors.Is(err, errBotTemplateRequestInvalid) {
+			ba.Warn("Bot Registry edit template_ref 非法或未开放", zap.Error(err))
+			httperr.ResponseErrorL(c, errcode.ErrBotAPICardInvalid, nil, nil)
+			return
+		}
+		ba.Error("Bot Registry edit catalog 不可用", zap.Error(err))
+		httperr.ResponseErrorL(c, errcode.ErrSharedInternal, nil, nil)
 		return
 	}
 

--- a/modules/bot_api/send.go
+++ b/modules/bot_api/send.go
@@ -790,6 +790,26 @@ type botMessageEditReq struct {
 	Data        map[string]any `json:"data"`
 	CardSeq     int64          `json:"card_seq"`
 	Transient   bool           `json:"transient"`
+	// Presence is tracked separately from decoded values so the raw/Registry
+	// XOR cannot be bypassed with content_edit:"" or template_ref:null.
+	contentEditSet bool
+	templateRefSet bool
+}
+
+func (r *botMessageEditReq) UnmarshalJSON(data []byte) error {
+	type wire botMessageEditReq
+	var decoded wire
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		return err
+	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(data, &fields); err != nil {
+		return err
+	}
+	*r = botMessageEditReq(decoded)
+	_, r.contentEditSet = fields["content_edit"]
+	_, r.templateRefSet = fields["template_ref"]
+	return nil
 }
 
 // botMessageEdit handles POST /v1/bot/message/edit.
@@ -808,13 +828,17 @@ func (ba *BotAPI) botMessageEdit(c *wkhttp.Context) {
 		respondBotAPIRequestInvalid(c, "channel_id")
 		return
 	}
-	rawMode := strings.TrimSpace(req.ContentEdit) != ""
-	templateMode := req.TemplateRef != nil
+	rawMode := req.contentEditSet
+	templateMode := req.templateRefSet
 	if rawMode && templateMode {
 		httperr.ResponseErrorL(c, errcode.ErrBotAPICardInvalid, nil, nil)
 		return
 	}
 	if !rawMode && !templateMode {
+		respondBotAPIRequestInvalid(c, "content_edit")
+		return
+	}
+	if rawMode && strings.TrimSpace(req.ContentEdit) == "" {
 		respondBotAPIRequestInvalid(c, "content_edit")
 		return
 	}

--- a/modules/bot_api/send.go
+++ b/modules/bot_api/send.go
@@ -18,8 +18,10 @@ import (
 	"github.com/Mininglamp-OSS/octo-server/modules/group"
 	"github.com/Mininglamp-OSS/octo-server/pkg/cardmsg"
 	"github.com/Mininglamp-OSS/octo-server/pkg/cardrevision"
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl"
 	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
 	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
 	"github.com/Mininglamp-OSS/octo-server/pkg/mentionrewrite"
 	"github.com/Mininglamp-OSS/octo-server/pkg/richtext"
 	"github.com/go-sql-driver/mysql"
@@ -89,12 +91,20 @@ func (ba *BotAPI) sendMessage(c *wkhttp.Context) {
 		return
 	}
 
+	_, templateMode := req.Payload["template_ref"]
+	cardIntent := cardmsg.IsCardPayload(req.Payload) || templateMode
+	if templateMode && !cardmsg.IsCardPayload(req.Payload) {
+		ba.Warn("Bot Registry 卡片请求 type 非 17", zap.String("channelID", req.ChannelID))
+		httperr.ResponseErrorL(c, errcode.ErrBotAPICardInvalid, nil, nil)
+		return
+	}
+
 	// card-message-protocol P1：InteractiveCard(=17) 入站 gate。排序在
 	// checkSendPermission / checkOBO 之前：(a) Decision 2b 要求 OBO 卡片按
 	// 「请求意图」拦截、先于 grant 校验，且覆盖 grantorReplyBypass 子路径
 	// （该子路径 fromUID 仍是 bot —— 拒绝是刻意的过度拒绝，P2 复议）；
 	// (b) 脏卡片 fail-fast，鉴权路径不跑在毒输入上（与上方 OBO 保留键同序）。
-	if cardmsg.IsCardPayload(req.Payload) {
+	if cardIntent {
 		if !cardmsg.BotEnabled() {
 			// bot 侧有效门禁：总开关 OCTO_CARD_MESSAGE_ENABLED（Decision 2 rollout
 			// gate）AND bot 子开关 OCTO_BOT_CARD_ENABLED。与 /v1/bot/card/profile 的
@@ -106,10 +116,21 @@ func (ba *BotAPI) sendMessage(c *wkhttp.Context) {
 			httperr.ResponseErrorL(c, errcode.ErrBotAPICardOBOForbidden, nil, nil)
 			return
 		}
-		if err := cardmsg.Validate(req.Payload); err != nil {
-			ba.Warn("InteractiveCard payload 校验失败", zap.Error(err), zap.String("channelID", req.ChannelID))
-			httperr.ResponseErrorL(c, errcode.ErrBotAPICardInvalid, nil, nil)
-			return
+		if templateMode {
+			// Model A 与 Model B 是 total XOR。完整 Registry 字段校验和 schema
+			// render 在授权完成后执行；这里先拒绝最明显的双模式请求，避免让脏
+			// raw card 进入权限/Space 查询路径。
+			if _, hasRawCard := req.Payload["card"]; hasRawCard {
+				ba.Warn("Bot 卡片 raw/Registry 双模式同时出现", zap.String("channelID", req.ChannelID))
+				httperr.ResponseErrorL(c, errcode.ErrBotAPICardInvalid, nil, nil)
+				return
+			}
+		} else {
+			if err := cardmsg.Validate(req.Payload); err != nil {
+				ba.Warn("InteractiveCard payload 校验失败", zap.Error(err), zap.String("channelID", req.ChannelID))
+				httperr.ResponseErrorL(c, errcode.ErrBotAPICardInvalid, nil, nil)
+				return
+			}
 		}
 	}
 
@@ -215,7 +236,37 @@ func (ba *BotAPI) sendMessage(c *wkhttp.Context) {
 	// 理由：grant 仅授权身份替换，不应改变租户隔离边界 — bot 的 Space 归属
 	// 是部署时确定的，与 grantor 的 Space 归属解耦。
 	payload := req.Payload
-	if req.ChannelType == common.ChannelTypePerson.Uint8() {
+	if templateMode {
+		if ba.cardTemplates == nil {
+			ba.Error("Bot Registry 模板 catalog 未注入", zap.String("channelID", channelID))
+			httperr.ResponseErrorL(c, errcode.ErrSharedInternal, nil, nil)
+			return
+		}
+		spaceID := ba.resolveBotActiveSpaceID(c, robotID)
+		webLoginURL := ""
+		if ba.ctx != nil && ba.ctx.GetConfig() != nil {
+			webLoginURL = ba.ctx.GetConfig().External.WebLoginURL
+		}
+		rendered, renderErr := ba.cardTemplates.RenderPayload(c.Request.Context(), req.Payload, cardtmpl.BuildEnv{
+			WebLoginURL: webLoginURL,
+			Lang:        i18n.OutboundLanguage(c.Request.Context()),
+			SpaceID:     spaceID,
+		})
+		if renderErr != nil {
+			if errors.Is(renderErr, errBotTemplateRequestInvalid) {
+				ba.Warn("Bot Registry 模板请求非法", zap.Error(renderErr), zap.String("channelID", channelID))
+				httperr.ResponseErrorL(c, errcode.ErrBotAPICardInvalid, nil, nil)
+				return
+			}
+			ba.Error("Bot Registry 模板渲染失败", zap.Error(renderErr), zap.String("channelID", channelID))
+			httperr.ResponseErrorL(c, errcode.ErrSharedInternal, nil, nil)
+			return
+		}
+		payload = rendered
+		if req.ChannelType == common.ChannelTypePerson.Uint8() {
+			payload = ba.enrichBotPayloadWithResolvedSpaceID(robotID, payload, spaceID)
+		}
+	} else if req.ChannelType == common.ChannelTypePerson.Uint8() {
 		payload = ba.enrichBotPayloadWithSpaceID(c, robotID, payload)
 	}
 
@@ -725,16 +776,23 @@ func (ba *BotAPI) readReceipt(c *wkhttp.Context) {
 
 // ==================== Message Edit ====================
 
+type botMessageEditReq struct {
+	MessageID   string         `json:"message_id"`
+	MessageSeq  uint32         `json:"message_seq"`
+	ChannelID   string         `json:"channel_id"`
+	ChannelType uint8          `json:"channel_type"`
+	ContentEdit string         `json:"content_edit"`
+	TemplateRef map[string]any `json:"template_ref"`
+	State       string         `json:"state"`
+	Data        map[string]any `json:"data"`
+	CardSeq     int64          `json:"card_seq"`
+	Transient   bool           `json:"transient"`
+}
+
 // botMessageEdit handles POST /v1/bot/message/edit.
 func (ba *BotAPI) botMessageEdit(c *wkhttp.Context) {
 	c.Request.Body = http.MaxBytesReader(c.Writer, c.Request.Body, cardmsg.MaxSendBodyBytes)
-	var req struct {
-		MessageID   string `json:"message_id"`
-		MessageSeq  uint32 `json:"message_seq"`
-		ChannelID   string `json:"channel_id"`
-		ChannelType uint8  `json:"channel_type"`
-		ContentEdit string `json:"content_edit"`
-	}
+	var req botMessageEditReq
 	if err := c.BindJSON(&req); err != nil {
 		respondBotAPIRequestInvalid(c, "")
 		return
@@ -747,8 +805,18 @@ func (ba *BotAPI) botMessageEdit(c *wkhttp.Context) {
 		respondBotAPIRequestInvalid(c, "channel_id")
 		return
 	}
-	if strings.TrimSpace(req.ContentEdit) == "" {
+	rawMode := strings.TrimSpace(req.ContentEdit) != ""
+	templateMode := req.TemplateRef != nil
+	if rawMode && templateMode {
+		httperr.ResponseErrorL(c, errcode.ErrBotAPICardInvalid, nil, nil)
+		return
+	}
+	if !rawMode && !templateMode {
 		respondBotAPIRequestInvalid(c, "content_edit")
+		return
+	}
+	if templateMode && (strings.TrimSpace(req.State) == "" || req.Data == nil || req.CardSeq <= 0) {
+		httperr.ResponseErrorL(c, errcode.ErrBotAPICardInvalid, nil, nil)
 		return
 	}
 
@@ -785,6 +853,11 @@ func (ba *BotAPI) botMessageEdit(c *wkhttp.Context) {
 			httperr.ResponseErrorLWithStatus(c, errcode.ErrBotAPIGroupDisbanded, nil, nil)
 			return
 		}
+	}
+
+	if templateMode {
+		ba.botMessageEditViaRegistry(c, &req, robotID)
+		return
 	}
 
 	// Permission: bot can only edit its own messages
@@ -1039,6 +1112,148 @@ func (ba *BotAPI) botMessageEdit(c *wkhttp.Context) {
 	}
 
 	c.ResponseOK()
+}
+
+// botMessageEditViaRegistry compiles one complete replacement frame and hands
+// it to the same CardMutator used by first-party card updates. The mutator owns
+// the second authoritative lookup plus ownership/lifecycle/CAS/revision/CMD
+// checks; Snapshot is used only to pin the effective stored template identity
+// before rendering.
+func (ba *BotAPI) botMessageEditViaRegistry(c *wkhttp.Context, req *botMessageEditReq, robotID string) {
+	if !cardmsg.BotEnabled() {
+		httperr.ResponseErrorL(c, errcode.ErrBotAPICardDisabled, nil, nil)
+		return
+	}
+	if ba.cardTemplates == nil || ba.cardMutator == nil {
+		ba.Error("Bot Registry edit wiring unavailable", zap.String("messageID", req.MessageID))
+		httperr.ResponseErrorL(c, errcode.ErrSharedInternal, nil, nil)
+		return
+	}
+	ref, err := parseBotTemplateRef(req.TemplateRef)
+	if err != nil {
+		ba.Warn("Bot Registry edit template_ref 非法", zap.Error(err), zap.String("messageID", req.MessageID))
+		httperr.ResponseErrorL(c, errcode.ErrBotAPICardInvalid, nil, nil)
+		return
+	}
+
+	snapshot, err := ba.cardMutator.Snapshot(c.Request.Context(), carddispatch.CardMutationTarget{
+		SenderUID: robotID, MessageID: req.MessageID, MessageSeq: req.MessageSeq,
+		ChannelID: req.ChannelID, ChannelType: req.ChannelType,
+	})
+	if err != nil {
+		ba.respondBotTemplateSnapshotError(c, req.MessageID, err)
+		return
+	}
+	if err := requireEffectiveCardTemplate(snapshot.Envelope, ref); err != nil {
+		ba.Warn("Bot Registry edit 目标模板不匹配", zap.Error(err), zap.String("messageID", req.MessageID))
+		httperr.ResponseErrorL(c, errcode.ErrBotAPICardInvalid, nil, nil)
+		return
+	}
+
+	// Preserve the existing App Bot edit contract after target ownership is
+	// established: App Bots remain DM-only and the peer must be a friend.
+	if getBotKindFromContext(c) == BotKindApp {
+		if req.ChannelType != common.ChannelTypePerson.Uint8() {
+			httperr.ResponseErrorL(c, errcode.ErrBotAPIAppBotDMOnly, nil, nil)
+			return
+		}
+		isFriend, friendErr := ba.userService.IsFriend(robotID, req.ChannelID)
+		if friendErr != nil {
+			ba.Error("verify app bot friend failed", zap.Error(friendErr), zap.String("robotID", robotID), zap.String("channelID", req.ChannelID))
+			httperr.ResponseErrorL(c, errcode.ErrBotAPIQueryFailed, nil, nil)
+			return
+		}
+		if !isFriend {
+			httperr.ResponseErrorL(c, errcode.ErrBotAPIConversationNotStarted, nil, nil)
+			return
+		}
+	}
+
+	webLoginURL := ""
+	if ba.ctx != nil && ba.ctx.GetConfig() != nil {
+		webLoginURL = ba.ctx.GetConfig().External.WebLoginURL
+	}
+	rendered, err := ba.cardTemplates.RenderPayload(c.Request.Context(), map[string]any{
+		"type":         cardmsg.InteractiveCard.Int(),
+		"template_ref": req.TemplateRef,
+		"state":        req.State,
+		"data":         req.Data,
+	}, cardtmpl.BuildEnv{
+		WebLoginURL: webLoginURL,
+		Lang:        i18n.OutboundLanguage(c.Request.Context()),
+		SpaceID:     effectiveEnvelopeSpaceID(snapshot.Envelope),
+	})
+	if err != nil {
+		if errors.Is(err, errBotTemplateRequestInvalid) {
+			ba.Warn("Bot Registry edit 模板请求非法", zap.Error(err), zap.String("messageID", req.MessageID))
+			httperr.ResponseErrorL(c, errcode.ErrBotAPICardInvalid, nil, nil)
+			return
+		}
+		ba.Error("Bot Registry edit 模板渲染失败", zap.Error(err), zap.String("messageID", req.MessageID))
+		httperr.ResponseErrorL(c, errcode.ErrSharedInternal, nil, nil)
+		return
+	}
+	rendered["card_seq"] = req.CardSeq
+	if req.Transient {
+		rendered["transient"] = true
+	}
+	raw, err := json.Marshal(rendered)
+	if err != nil {
+		ba.Error("Bot Registry edit marshal 失败", zap.Error(err), zap.String("messageID", req.MessageID))
+		httperr.ResponseErrorL(c, errcode.ErrSharedInternal, nil, nil)
+		return
+	}
+	contentEdit, err := cardmsg.NormalizeContentEdit(string(raw))
+	if err != nil {
+		ba.Error("Bot Registry edit normalize 失败", zap.Error(err), zap.String("messageID", req.MessageID))
+		httperr.ResponseErrorL(c, errcode.ErrSharedInternal, nil, nil)
+		return
+	}
+
+	_, err = ba.cardMutator.Mutate(c.Request.Context(), carddispatch.CardMutationRequest{
+		SenderUID: robotID, MessageID: req.MessageID, MessageSeq: req.MessageSeq,
+		ChannelID: req.ChannelID, ChannelType: req.ChannelType, ContentEdit: contentEdit,
+	})
+	if err != nil {
+		switch {
+		case errors.Is(err, carddispatch.ErrCardMutationConflict):
+			httperr.ResponseErrorL(c, errcode.ErrBotAPICardSeqConflict, nil, nil)
+		case errors.Is(err, carddispatch.ErrCardMutationForbidden):
+			httperr.ResponseErrorL(c, errcode.ErrBotAPIMessageEditForbidden, nil, nil)
+		case errors.Is(err, carddispatch.ErrCardMutationNotFound):
+			httperr.ResponseErrorL(c, errcode.ErrBotAPIMessageNotFound, nil, nil)
+		case errors.Is(err, carddispatch.ErrCardMutationInvalid):
+			httperr.ResponseErrorL(c, errcode.ErrBotAPICardInvalid, nil, nil)
+		default:
+			ba.Error("Bot Registry edit mutation 失败", zap.Error(err), zap.String("messageID", req.MessageID))
+			httperr.ResponseErrorL(c, errcode.ErrBotAPIStoreFailed, nil, nil)
+		}
+		return
+	}
+	c.ResponseOK()
+}
+
+func (ba *BotAPI) respondBotTemplateSnapshotError(c *wkhttp.Context, messageID string, err error) {
+	switch {
+	case errors.Is(err, carddispatch.ErrCardMutationForbidden):
+		httperr.ResponseErrorL(c, errcode.ErrBotAPIMessageEditForbidden, nil, nil)
+	case errors.Is(err, carddispatch.ErrCardMutationNotFound):
+		httperr.ResponseErrorL(c, errcode.ErrBotAPIMessageNotFound, nil, nil)
+	case errors.Is(err, carddispatch.ErrCardMutationInvalid):
+		httperr.ResponseErrorL(c, errcode.ErrBotAPICardInvalid, nil, nil)
+	default:
+		ba.Error("Bot Registry edit snapshot 失败", zap.Error(err), zap.String("messageID", messageID))
+		httperr.ResponseErrorL(c, errcode.ErrBotAPIQueryFailed, nil, nil)
+	}
+}
+
+func effectiveEnvelopeSpaceID(raw json.RawMessage) string {
+	var payload map[string]any
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		return ""
+	}
+	spaceID, _ := payload["space_id"].(string)
+	return spaceID
 }
 
 // cardSeqCASMaxAttempts 是 D9 CAS 遇 InnoDB 死锁/锁等待超时的有界重试次数。

--- a/modules/bot_api/send.go
+++ b/modules/bot_api/send.go
@@ -242,7 +242,10 @@ func (ba *BotAPI) sendMessage(c *wkhttp.Context) {
 			httperr.ResponseErrorL(c, errcode.ErrSharedInternal, nil, nil)
 			return
 		}
-		spaceID := ba.resolveBotActiveSpaceID(c, robotID)
+		spaceID := ""
+		if req.ChannelType == common.ChannelTypePerson.Uint8() {
+			spaceID = ba.resolveBotActiveSpaceID(c, robotID)
+		}
 		webLoginURL := ""
 		if ba.ctx != nil && ba.ctx.GetConfig() != nil {
 			webLoginURL = ba.ctx.GetConfig().External.WebLoginURL

--- a/modules/bot_api/send.go
+++ b/modules/bot_api/send.go
@@ -956,6 +956,11 @@ func (ba *BotAPI) botMessageEdit(c *wkhttp.Context) {
 	// richtext（=14）原有路径。user/robot 编辑路径对卡片仍永久拒绝（各自守卫）。
 	origIsCard := cardmsg.IsCardRawPayload(msgPayload)
 	editIsCard := cardmsg.IsCardContentEdit(req.ContentEdit)
+	if origIsCard && cardEnvelopeHasTemplateRef(msgPayload) {
+		ba.Warn("raw card edit attempted to replace Registry-authored target", zap.String("messageID", req.MessageID))
+		httperr.ResponseErrorL(c, errcode.ErrBotAPICardInvalid, nil, nil)
+		return
+	}
 	if origIsCard != editIsCard {
 		ba.Warn("卡片编辑跨类型变异,拒绝", zap.String("messageID", req.MessageID),
 			zap.Bool("origIsCard", origIsCard), zap.Bool("editIsCard", editIsCard))
@@ -975,6 +980,11 @@ func (ba *BotAPI) botMessageEdit(c *wkhttp.Context) {
 		// 之前 fail-fast。
 		if !cardmsg.BotEnabled() {
 			httperr.ResponseErrorL(c, errcode.ErrBotAPICardDisabled, nil, nil)
+			return
+		}
+		if contentEditHasTemplateRef(req.ContentEdit) {
+			ba.Warn("raw card edit attempted to forge Registry provenance", zap.String("messageID", req.MessageID))
+			httperr.ResponseErrorL(c, errcode.ErrBotAPICardInvalid, nil, nil)
 			return
 		}
 		// P2（PR#548 review）：撤回/删除门禁 —— 已撤回或全局删除的卡片不可再编辑,
@@ -1257,6 +1267,19 @@ func effectiveEnvelopeSpaceID(raw json.RawMessage) string {
 	}
 	spaceID, _ := payload["space_id"].(string)
 	return spaceID
+}
+
+func contentEditHasTemplateRef(contentEdit string) bool {
+	return cardEnvelopeHasTemplateRef([]byte(contentEdit))
+}
+
+func cardEnvelopeHasTemplateRef(raw []byte) bool {
+	var payload map[string]any
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		return false
+	}
+	_, exists := payload["template_ref"]
+	return exists
 }
 
 // cardSeqCASMaxAttempts 是 D9 CAS 遇 InnoDB 死锁/锁等待超时的有界重试次数。

--- a/modules/bot_api/send.go
+++ b/modules/bot_api/send.go
@@ -1215,6 +1215,7 @@ func (ba *BotAPI) botMessageEditViaRegistry(c *wkhttp.Context, req *botMessageEd
 	if ba.ctx != nil && ba.ctx.GetConfig() != nil {
 		webLoginURL = ba.ctx.GetConfig().External.WebLoginURL
 	}
+	spaceID := effectiveEnvelopeSpaceID(snapshot.Envelope)
 	rendered, err := ba.cardTemplates.RenderPayload(c.Request.Context(), map[string]any{
 		"type":         cardmsg.InteractiveCard.Int(),
 		"template_ref": req.TemplateRef,
@@ -1223,7 +1224,7 @@ func (ba *BotAPI) botMessageEditViaRegistry(c *wkhttp.Context, req *botMessageEd
 	}, cardtmpl.BuildEnv{
 		WebLoginURL: webLoginURL,
 		Lang:        i18n.OutboundLanguage(c.Request.Context()),
-		SpaceID:     effectiveEnvelopeSpaceID(snapshot.Envelope),
+		SpaceID:     spaceID,
 	})
 	if err != nil {
 		if errors.Is(err, errBotTemplateRequestInvalid) {
@@ -1234,6 +1235,16 @@ func (ba *BotAPI) botMessageEditViaRegistry(c *wkhttp.Context, req *botMessageEd
 		ba.Error("Bot Registry edit 模板渲染失败", zap.Error(err), zap.String("messageID", req.MessageID))
 		httperr.ResponseErrorL(c, errcode.ErrSharedInternal, nil, nil)
 		return
+	}
+	// Registry.Render owns card content but intentionally does not emit the
+	// envelope-level Space identity. Preserve only the server-authored value
+	// pinned by Snapshot; never re-resolve from the bot's current Space or accept
+	// a caller-supplied value, either of which could move an existing DM card
+	// across tenant views. Delete first so an empty authoritative value remains
+	// fail-closed even if a future renderer starts returning a space_id field.
+	delete(rendered, "space_id")
+	if spaceID != "" {
+		rendered["space_id"] = spaceID
 	}
 	rendered["card_seq"] = req.CardSeq
 	if req.Transient {

--- a/modules/bot_api/space_inject.go
+++ b/modules/bot_api/space_inject.go
@@ -77,10 +77,17 @@ type botSpaceQuerier interface {
 // client 上送的 payload["space_id"]，并发监控 warn。这是 bot_api 层独立的 strip
 // 语义，不能依赖 message 层的 senderSpaceID="" strip（bot_api 不走 sendMsg）。
 func (ba *BotAPI) enrichBotPayloadWithSpaceID(c *wkhttp.Context, robotID string, payload map[string]interface{}) map[string]interface{} {
+	return ba.enrichBotPayloadWithResolvedSpaceID(robotID, payload, ba.resolveBotActiveSpaceID(c, robotID))
+}
+
+// enrichBotPayloadWithResolvedSpaceID applies a Space identity already resolved
+// by the caller. Registry rendering needs that same authoritative value in
+// BuildEnv, so this seam prevents a second DB lookup and guarantees the rendered
+// card and outbound envelope observe one Space snapshot.
+func (ba *BotAPI) enrichBotPayloadWithResolvedSpaceID(robotID string, payload map[string]interface{}, spaceID string) map[string]interface{} {
 	if payload == nil {
 		payload = make(map[string]interface{})
 	}
-	spaceID := ba.resolveBotActiveSpaceID(c, robotID)
 	if spaceID != "" {
 		payload["space_id"] = spaceID
 		return payload

--- a/pkg/cardtmpl/interaction_conformance.go
+++ b/pkg/cardtmpl/interaction_conformance.go
@@ -80,7 +80,7 @@ func walkInteractionNodes(value any, actions, inputs map[string]map[string]any) 
 				inputs[id] = node
 			}
 		}
-		for _, key := range []string{"body", "actions", "items", "columns", "rows", "cells", "selectAction"} {
+		for _, key := range []string{"body", "actions", "items", "columns", "rows", "cells", "selectAction", "inlineAction"} {
 			if child, ok := node[key]; ok {
 				walkInteractionNodes(child, actions, inputs)
 			}

--- a/pkg/cardtmpl/interaction_conformance.go
+++ b/pkg/cardtmpl/interaction_conformance.go
@@ -1,0 +1,110 @@
+package cardtmpl
+
+import (
+	"fmt"
+	"sort"
+)
+
+// assertInteractionReport locks the machine-readable v2 interaction report to
+// one rendered sample. Reports are consumed by capability discovery and SDKs,
+// so publishing an action or input that the card does not actually contain is
+// a startup-fatal contract error rather than a runtime compatibility surprise.
+func assertInteractionReport(payload map[string]any, report InteractionReport) error {
+	card, _ := payload["card"].(map[string]any)
+	if card == nil {
+		return fmt.Errorf("interaction conformance: card missing")
+	}
+
+	actualActions := make(map[string]map[string]any)
+	actualInputs := make(map[string]map[string]any)
+	walkInteractionNodes(card["body"], actualActions, actualInputs)
+	walkInteractionNodes(card["actions"], actualActions, actualInputs)
+	walkInteractionNodes(card["selectAction"], actualActions, actualInputs)
+
+	declaredActions := make(map[string]DeclaredAction)
+	for _, action := range report.Actions {
+		if action.Type == "Action.Submit" {
+			declaredActions[action.ID] = action
+		}
+	}
+	declaredInputs := make(map[string]DeclaredInput)
+	for _, input := range report.Inputs {
+		declaredInputs[input.ID] = input
+	}
+
+	if got, want := sortedMapKeys(actualActions), sortedMapKeys(declaredActions); !equalStrings(got, want) {
+		return fmt.Errorf("interaction conformance: Action.Submit ids got=%v want=%v", got, want)
+	}
+	if got, want := sortedMapKeys(actualInputs), sortedMapKeys(declaredInputs); !equalStrings(got, want) {
+		return fmt.Errorf("interaction conformance: Input ids got=%v want=%v", got, want)
+	}
+
+	for id, declared := range declaredActions {
+		action := actualActions[id]
+		data, _ := action["data"].(map[string]any)
+		gotKeys := sortedMapKeys(data)
+		wantKeys := append([]string(nil), declared.DataKeys...)
+		sort.Strings(wantKeys)
+		if !equalStrings(gotKeys, wantKeys) {
+			return fmt.Errorf("interaction conformance: Action.Submit %q data keys got=%v want=%v", id, gotKeys, wantKeys)
+		}
+		if declared.AssociatedInputs != "" {
+			got, _ := action["associatedInputs"].(string)
+			if got == "" {
+				got = "auto"
+			}
+			if got != declared.AssociatedInputs {
+				return fmt.Errorf("interaction conformance: Action.Submit %q associatedInputs=%q want=%q",
+					id, got, declared.AssociatedInputs)
+			}
+		}
+	}
+	return nil
+}
+
+func walkInteractionNodes(value any, actions, inputs map[string]map[string]any) {
+	switch node := value.(type) {
+	case []any:
+		for _, child := range node {
+			walkInteractionNodes(child, actions, inputs)
+		}
+	case map[string]any:
+		typeName, _ := node["type"].(string)
+		if typeName == "Action.Submit" {
+			if id, _ := node["id"].(string); id != "" {
+				actions[id] = node
+			}
+		}
+		if len(typeName) > len("Input.") && typeName[:len("Input.")] == "Input." {
+			if id, _ := node["id"].(string); id != "" {
+				inputs[id] = node
+			}
+		}
+		for _, key := range []string{"body", "actions", "items", "columns", "rows", "cells", "selectAction"} {
+			if child, ok := node[key]; ok {
+				walkInteractionNodes(child, actions, inputs)
+			}
+		}
+	}
+}
+
+func sortedMapKeys[V any](m map[string]V) []string {
+	out := make([]string, 0, len(m))
+	for key := range m {
+		out = append(out, key)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/cardtmpl/json_template_test.go
+++ b/pkg/cardtmpl/json_template_test.go
@@ -195,6 +195,52 @@ func TestRegisterJSON_InteractionReportDrift_FailClose(t *testing.T) {
 	}
 }
 
+// TestRegisterJSON_InlineActionInteractionReportDrift_FailClose proves the
+// registration guard sees Action.Submit when it is attached to Input.* via
+// inlineAction. Without that traversal, this fixture registers successfully
+// while publishing an interaction report that omits a real Submit action.
+func TestRegisterJSON_InlineActionInteractionReportDrift_FailClose(t *testing.T) {
+	rec := tryRegisterJSON("testdata/test.inlineaction-reportdrift@0.1.0")
+	if rec == nil {
+		t.Fatal("expected register-time panic for inlineAction interaction report drift")
+	}
+	got := toStr(rec)
+	if !strings.Contains(got, "Action.Submit ids") || !strings.Contains(got, "inline_action") {
+		t.Fatalf("want inlineAction Submit drift panic, got %v", rec)
+	}
+}
+
+// TestAssertActionContract_InlineAction keeps the action-contract walker in
+// lockstep with the interaction-report walker for the same supported surface.
+func TestAssertActionContract_InlineAction(t *testing.T) {
+	payload := map[string]any{
+		"card": map[string]any{
+			"body": []any{
+				map[string]any{
+					"type": "Input.Text",
+					"id":   "query",
+					"inlineAction": map[string]any{
+						"type": "Action.Submit",
+						"id":   "inline_action",
+						"data": map[string]any{
+							"owner":       "ai",
+							"action_type": "reasoning.control",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	err := assertActionContract(payload, TemplateActionContract{
+		Owner:      "ai",
+		ActionType: "reasoning.control",
+	})
+	if err != nil {
+		t.Fatalf("inlineAction Submit must satisfy action contract: %v", err)
+	}
+}
+
 func toStr(v any) string {
 	if e, ok := v.(error); ok {
 		return e.Error()

--- a/pkg/cardtmpl/json_template_test.go
+++ b/pkg/cardtmpl/json_template_test.go
@@ -181,6 +181,20 @@ func TestRegisterJSON_ViewMissingTemplate_FailClose(t *testing.T) {
 	}
 }
 
+// TestRegisterJSON_InteractionReportDrift_FailClose locks the production
+// guarantee consumed by the Bot template catalog: advertised Submit ids come
+// from the interaction report, so a report that differs from the rendered
+// sample must fail at registration instead of publishing a false capability.
+func TestRegisterJSON_InteractionReportDrift_FailClose(t *testing.T) {
+	rec := tryRegisterJSON("testdata/test.reportdrift@0.1.0")
+	if rec == nil {
+		t.Fatal("expected register-time panic for interaction report drift")
+	}
+	if !strings.Contains(toStr(rec), "interaction") {
+		t.Fatalf("want interaction drift panic, got %v", rec)
+	}
+}
+
 func toStr(v any) string {
 	if e, ok := v.(error); ok {
 		return e.Error()

--- a/pkg/cardtmpl/registry.go
+++ b/pkg/cardtmpl/registry.go
@@ -509,6 +509,13 @@ func (r *Registry) selfCheckSamples(t Template, meta TemplateMeta, samples map[s
 				return fmt.Errorf("sample %s: %w", name, err)
 			}
 		}
+		report, ok := meta.Interaction(view)
+		if !ok {
+			return fmt.Errorf("sample %s: interaction report missing for v2 view %s", name, view)
+		}
+		if err := assertInteractionReport(payload, report); err != nil {
+			return fmt.Errorf("sample %s: %w", name, err)
+		}
 	}
 	return nil
 }
@@ -580,7 +587,7 @@ func walkSubmitActions(value any, path string, visit func(string, map[string]any
 				return err
 			}
 		}
-		for _, key := range []string{"actions", "items", "columns", "selectAction"} {
+		for _, key := range []string{"body", "actions", "items", "columns", "rows", "cells", "selectAction"} {
 			if child, ok := node[key]; ok {
 				if err := walkSubmitActions(child, path+"."+key, visit); err != nil {
 					return err

--- a/pkg/cardtmpl/registry.go
+++ b/pkg/cardtmpl/registry.go
@@ -587,7 +587,7 @@ func walkSubmitActions(value any, path string, visit func(string, map[string]any
 				return err
 			}
 		}
-		for _, key := range []string{"body", "actions", "items", "columns", "rows", "cells", "selectAction"} {
+		for _, key := range []string{"body", "actions", "items", "columns", "rows", "cells", "selectAction", "inlineAction"} {
 			if child, ok := node[key]; ok {
 				if err := walkSubmitActions(child, path+"."+key, visit); err != nil {
 					return err

--- a/pkg/cardtmpl/testdata/test.inlineaction-reportdrift@0.1.0/contract/data.schema.json
+++ b/pkg/cardtmpl/testdata/test.inlineaction-reportdrift@0.1.0/contract/data.schema.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["state", "title"],
+  "properties": {
+    "state": {"type": "string", "const": "shown"},
+    "title": {"type": "string", "minLength": 1}
+  }
+}

--- a/pkg/cardtmpl/testdata/test.inlineaction-reportdrift@0.1.0/manifest.json
+++ b/pkg/cardtmpl/testdata/test.inlineaction-reportdrift@0.1.0/manifest.json
@@ -1,0 +1,13 @@
+{
+  "id": "test.inlineaction-reportdrift",
+  "version": "0.1.0",
+  "protocol": "octo-card@1.0",
+  "views": {
+    "shown": {
+      "wireProfile": "octo/v2",
+      "states": ["shown"],
+      "template": "templates/shown.template.json",
+      "samples": ["samples/shown.json"]
+    }
+  }
+}

--- a/pkg/cardtmpl/testdata/test.inlineaction-reportdrift@0.1.0/reports/shown.interaction.json
+++ b/pkg/cardtmpl/testdata/test.inlineaction-reportdrift@0.1.0/reports/shown.interaction.json
@@ -1,0 +1,11 @@
+{
+  "actions": [],
+  "inputs": [
+    {
+      "id": "query",
+      "type": "Input.Text",
+      "isRequired": false,
+      "isVisible": true
+    }
+  ]
+}

--- a/pkg/cardtmpl/testdata/test.inlineaction-reportdrift@0.1.0/samples/shown.json
+++ b/pkg/cardtmpl/testdata/test.inlineaction-reportdrift@0.1.0/samples/shown.json
@@ -1,0 +1,4 @@
+{
+  "state": "shown",
+  "title": "Inline action report drift fixture"
+}

--- a/pkg/cardtmpl/testdata/test.inlineaction-reportdrift@0.1.0/templates/shown.template.json
+++ b/pkg/cardtmpl/testdata/test.inlineaction-reportdrift@0.1.0/templates/shown.template.json
@@ -1,0 +1,24 @@
+{
+  "type": "AdaptiveCard",
+  "version": "1.5",
+  "body": [
+    {
+      "type": "TextBlock",
+      "text": "${title}"
+    },
+    {
+      "type": "Input.Text",
+      "id": "query",
+      "label": "Query",
+      "inlineAction": {
+        "type": "Action.Submit",
+        "id": "inline_action",
+        "title": "Run",
+        "associatedInputs": "none",
+        "data": {
+          "action": "run"
+        }
+      }
+    }
+  ]
+}

--- a/pkg/cardtmpl/testdata/test.reportdrift@0.1.0/contract/data.schema.json
+++ b/pkg/cardtmpl/testdata/test.reportdrift@0.1.0/contract/data.schema.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["state", "title"],
+  "properties": {
+    "state": {"type": "string", "const": "shown"},
+    "title": {"type": "string", "minLength": 1}
+  }
+}

--- a/pkg/cardtmpl/testdata/test.reportdrift@0.1.0/manifest.json
+++ b/pkg/cardtmpl/testdata/test.reportdrift@0.1.0/manifest.json
@@ -1,0 +1,15 @@
+{
+  "id": "test.reportdrift",
+  "version": "0.1.0",
+  "protocol": "octo-card@1.0",
+  "owner": "ai",
+  "actionType": "reasoning.control",
+  "views": {
+    "shown": {
+      "wireProfile": "octo/v2",
+      "states": ["shown"],
+      "template": "templates/shown.template.json",
+      "samples": ["samples/shown.json"]
+    }
+  }
+}

--- a/pkg/cardtmpl/testdata/test.reportdrift@0.1.0/reports/shown.interaction.json
+++ b/pkg/cardtmpl/testdata/test.reportdrift@0.1.0/reports/shown.interaction.json
@@ -1,0 +1,12 @@
+{
+  "actions": [
+    {
+      "id": "declared_action",
+      "type": "Action.Submit",
+      "associatedInputs": "none",
+      "dataKeys": ["owner", "action_type", "action"],
+      "inputIds": []
+    }
+  ],
+  "inputs": []
+}

--- a/pkg/cardtmpl/testdata/test.reportdrift@0.1.0/samples/shown.json
+++ b/pkg/cardtmpl/testdata/test.reportdrift@0.1.0/samples/shown.json
@@ -1,0 +1,4 @@
+{
+  "state": "shown",
+  "title": "Report drift fixture"
+}

--- a/pkg/cardtmpl/testdata/test.reportdrift@0.1.0/templates/shown.template.json
+++ b/pkg/cardtmpl/testdata/test.reportdrift@0.1.0/templates/shown.template.json
@@ -1,0 +1,20 @@
+{
+  "type": "AdaptiveCard",
+  "version": "1.5",
+  "body": [
+    {"type": "TextBlock", "text": "${title}"}
+  ],
+  "actions": [
+    {
+      "type": "Action.Submit",
+      "id": "actual_action",
+      "title": "Run",
+      "associatedInputs": "none",
+      "data": {
+        "owner": "ai",
+        "action_type": "reasoning.control",
+        "action": "run"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
> [!IMPORTANT]
> **Rollout condition:** this PR currently catalogs the frozen `ai.reasoning-process@0.1.0`, whose free-form strings and nested arrays are not schema-bounded. Do not enable Model A in production until a bounded successor is published and the explicit Bot catalog is switched to it, or the deployment explicitly keeps `OCTO_BOT_CARD_ENABLED=false` during the intermediate rollout.

## Summary

Add the server-side Bot template-consumption protocol (roadmap E1b) while preserving the existing raw-card path.

## Related Issue

Follow-up to #657. Roadmap item E1b; no separate GitHub issue.

## Linked Spec

`.octospec/tasks/bot-card-template-consumption/brief.md`

## Changes

- Extend `GET /v1/bot/card/profile` with additive `templating` capability discovery backed by an explicit Bot allowlist.
- Add Registry-backed `template_ref + state + data` send and edit modes, with raw/Registry total XOR and explicit version pinning.
- Preserve Bot ownership, Space authority, lifecycle, CAS, revision, and CMD synchronization through the existing mutation path.
- Validate interaction-report/rendered-card consistency at registration.
- Retain server-authored `template_ref` provenance and reject raw send/edit attempts to forge or replace Registry frames.
- Skip revision history for transient frames while still updating and synchronizing the effective frame.

## Octospec Finish

- Injected rules recorded in `.octospec/tasks/bot-card-template-consumption/context.yaml`.
- Shared journal: `.octospec/journal/shared/bot-card-template-consumption.md`.
- Pending learning: `.octospec/learnings/pending/bot-card-template-consumption.md`.
- Dated entry added to `.octospec/log.md`.

## Testing

- [x] Unit tests added/updated
- [ ] Manually verified
- `go test -race ./modules/bot_api -run '^(TestBotCardTemplateCatalog.*|TestEffectiveCardTemplateIdentity|TestSendMessageRegistryTemplate.*|TestRawContentEditCannotForgeRegistryProvenance|TestBotMessageEditRegistryTemplate.*)$' -count=1`
- `go test -race ./pkg/cardtmpl/... -count=1`
- `go test -race ./internal/carddispatch -run '^TestCardMutator' -count=1`
- `go test ./pkg/cardmsg/... ./internal/carddispatch/... -count=1`
- `go build ./...`
- `go vet ./pkg/cardtmpl/... ./modules/bot_api/...`
- `make i18n-extract-check`
- `make i18n-lint`
- `git diff --check origin/main...HEAD`

The local full-package Bot API test was attempted but the shared local test database is polluted by an unknown legacy migration (`20191106000001_event_legacy01.sql`). The focused E1b race target passes; the ready-for-review CI run uses fresh service databases and is the full-suite evidence.

## COMPREHENSION

1. **What does this change actually do to the load-bearing path?**

   It adds a second, server-compiled mode to the existing Bot card send/edit endpoints. Bots select only an explicitly cataloged template version and state; the Registry owns view/profile/render metadata and card compilation. Raw Model B remains available, but the two modes are mutually exclusive.

2. **What could break because of it (dependents + failure mode)?**

   OpenClaw/Bot SDKs will consume the additive manifest and new wire. A catalog/report mismatch fails startup; malformed, unlisted, cross-template, stale, or forged requests fail closed before dispatch/mutation. The current `0.1.0` schema is not bounded enough for production enablement, so rollout requires a bounded successor/catalog cutover or an explicitly disabled Bot card sub-gate.

3. **How do you know it works (specific test/repro/trace)?**

   Handler tests cover capability ordering, allowlist rejection, send/edit success, state/profile selection, ownership/lifecycle/CAS mapping, transient revision behavior, provenance forgery, field-presence XOR, and zero-side-effect failures. Registry tests cover report drift. Focused race tests, shared card tests, build, vet, i18n checks, and diff checks pass; fresh-service CI provides the full-suite gate.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] PR description is in English
- [x] Added tests for my changes
- [x] Updated documentation
- [x] Followed commit message conventions (Conventional Commits)
