### PR TITLE
fix(notify): unify docs access result cards

### DIFF
--- a/.octospec/tasks/docs-access-result-card-consistency/brief.md
+++ b/.octospec/tasks/docs-access-result-card-consistency/brief.md
@@ -1,0 +1,57 @@
+---
+type: Task
+title: "Task: docs-access-result-card-consistency"
+description: Render clicked and sibling docs access decisions through the same V3 Registry result path without exposing raw operator UIDs.
+tags: [card, wire-contract, trust-boundary, space, testing, commit]
+timestamp: 2026-07-24T17:00:00+08:00
+slug: docs-access-result-card-consistency
+upstream: octo-server#635
+source: self
+---
+
+# Task: docs-access-result-card-consistency
+
+## Goal
+
+When one docs approver decides an access request, render both the clicked card
+and every sibling approver card through `docs.access-request@0.3.0/result`.
+Never surface a raw `operator_uid` when the callback omits the operator's
+display name.
+
+## Load-bearing behavior
+
+- The clicked-card finalizer and `POST /v1/internal/cards/mutate` share one
+  bounded mapping into the published V3 result fields.
+- Sibling context is recovered only from the stored, server-authored pending
+  card action data; caller values cannot replace its request/document identity.
+- The existing `docs.access_*` target-card gate, sender binding, lifecycle
+  checks, channel/message coordinates, Space binding, and monotonic `card_seq`
+  mutation path remain fail-closed.
+- Approved maps to V3 `approved`; denied maps to V3 `rejected`, preserving the
+  bounded denial reason.
+- `operator_name` and `decided_at_display` are optional additive internal
+  mutation fields. A missing operator name uses localized generic copy, never
+  the raw UID.
+- The frozen `docs.access-request@0.2.0` handoff is not modified.
+
+## Out of scope
+
+- No docs-backend change in this workspace.
+- No database migration, new route, new public API, or generic template-mutate
+  endpoint.
+- No changes to applicant outcome-card delivery.
+- No migration of unrelated notification card families.
+
+## Acceptance
+
+- Sibling mutations select `docs.access-request@0.3.0` and the V3
+  approved/rejected state through `CardUpdater.ReplaceView`.
+- Stored pending action data supplies request ID, document identity, requester,
+  permission, reason, and display timestamps to the sibling result.
+- Missing operator display name produces localized `审批人` / `Reviewer` and
+  rendered fields never contain the operator UID.
+- A mismatched Space or document ID fails before mutation.
+- Existing target-family containment and mutation error envelopes remain
+  unchanged.
+- Focused notify tests cover approved, denied, V3 selection, context recovery,
+  UID non-disclosure, and invalid stored context; relevant module tests pass.

--- a/modules/notify/action_finalizer.go
+++ b/modules/notify/action_finalizer.go
@@ -291,10 +291,8 @@ func stringEventData(data map[string]interface{}, key string) string {
 func (f *DocsActionFinalizer) buildTerminalDocument(ctx context.Context, lang, docID, spaceID, title, denyReason string, result cardactiondispatch.DecisionResult) (json.RawMessage, error) {
 	labels := docsLabelsFor(lang)
 	webLoginURL := f.ctx.GetConfig().External.WebLoginURL
-	// Approved / denied get the enriched outcome card (header + title + result
-	// box); the denied box surfaces the reviewer reason. Rendered through the
-	// shared builder so the click-driven terminal card and the sibling cards the
-	// access-decision card-sync endpoint mutates are byte-identical.
+	// The legacy/no-updater fallback still emits the enriched outcome card; the
+	// normal finalizer and sibling mutation paths render V3 through the Registry.
 	switch result.State {
 	case cardactiondispatch.StateApproved:
 		return buildDocsDecisionTerminalDocument(ctx, webLoginURL, lang, docID, spaceID, title, denyReason, false)
@@ -312,10 +310,8 @@ func (f *DocsActionFinalizer) buildTerminalDocument(ctx context.Context, lang, d
 	})
 }
 
-// buildDocsDecisionTerminalDocument renders the enriched approved/denied outcome
-// card. Shared by the click-driven finalizer (buildTerminalDocument) and the
-// access-decision card-sync endpoint (mutateDocsCard) so the terminal card a
-// clicker sees and the sibling cards other approvers see are byte-identical.
+// buildDocsDecisionTerminalDocument renders the legacy/no-updater fallback for
+// approved/denied outcomes. Production V3 result updates use CardUpdater.
 func buildDocsDecisionTerminalDocument(ctx context.Context, webLoginURL, lang, docID, spaceID, title, denyReason string, denied bool) (json.RawMessage, error) {
 	labels := docsLabelsFor(lang)
 	if denied {

--- a/modules/notify/action_finalizer.go
+++ b/modules/notify/action_finalizer.go
@@ -141,9 +141,9 @@ func (f *DocsActionFinalizer) Finalize(ctx context.Context, event cardactiondisp
 // ReplaceView 确定性失败,审批卡永远停在 pending 且申请人漏通知(PR#641 review P1)。
 // 截断而非编造,与 denyReason 既有做法一致。
 const (
-	capResultTitle      = 200                     // document.title / document.sourceName
-	capResultName       = 120                     // requester.name / decision.operatorName
-	capResultShortLabel = 80                      // decidedAt/requestedAt/messageTime/permission.*
+	capResultTitle      = 200                      // document.title / document.sourceName
+	capResultName       = 120                      // requester.name / decision.operatorName
+	capResultShortLabel = 80                       // decidedAt/requestedAt/messageTime/permission.*
 	capResultReason     = cardtmpl.MaxExcerptRunes // requestReason / rejectionReason (= 300)
 )
 
@@ -160,41 +160,94 @@ func truncRunes(s string, max int) string {
 
 func (f *DocsActionFinalizer) replaceWithRegistryResult(ctx context.Context, event cardactiondispatch.Event,
 	result cardactiondispatch.DecisionResult, channelID, lang, title, denyReason string) error {
-	state := docsaccessrequest.StateApproved
-	wireState := "approved"
-	if result.State == cardactiondispatch.StateDenied {
-		state = docsaccessrequest.StateRejected
-		wireState = "rejected"
+	fields, state, err := buildDocsAccessResultFields(lang, docsResultRenderInput{
+		Data:             event.Data,
+		Title:            title,
+		OperatorName:     result.Display["operator_name"],
+		DecidedAtDisplay: result.Display["decided_at"],
+		DenyReason:       denyReason,
+		Denied:           result.State == cardactiondispatch.StateDenied,
+	})
+	if err != nil {
+		return err
 	}
+	return f.updater.ReplaceView(ctx, cardtmpl.UpdateTarget{
+		Target: carddispatch.Target{
+			SpaceID: event.SpaceID, ChannelID: channelID, ChannelType: event.ChannelType,
+		},
+		// card_seq 单调性来源:event.EventID 是全局单调递增的 snowflake,直接用作
+		// card_seq 满足 CardMutator CAS 的严格递增要求(见
+		// .octospec/learnings/pending/cardtmpl-interaction-closure.md)。若未来 event
+		// ID 生成器改为非单调,CAS 会静默丢弃合法更新——务必同步复核。
+		SenderUID: event.SenderUID, MessageID: event.MessageID, CardSeq: event.EventID,
+	}, docsaccessrequest.TemplateID, docsaccessrequest.TemplateVersionV3, state, fields, cardtmpl.BuildEnv{
+		WebLoginURL: f.ctx.GetConfig().External.WebLoginURL, Lang: lang, SpaceID: event.SpaceID,
+	})
+}
+
+// docsResultRenderInput is the single bounded mapping input used by both the
+// click-driven finalizer and the sibling-card mutation endpoint. Data must come
+// from the stored server-authored Action.Submit payload, never caller display
+// JSON, so request/document identity cannot be rewritten during a mutation.
+type docsResultRenderInput struct {
+	Data             map[string]interface{}
+	Title            string
+	OperatorName     string
+	DecidedAtDisplay string
+	DenyReason       string
+	Denied           bool
+}
+
+func buildDocsAccessResultFields(lang string, input docsResultRenderInput) (json.RawMessage, cardtmpl.State, error) {
+	requestID := strings.TrimSpace(stringEventData(input.Data, "request_id"))
+	docID := strings.TrimSpace(stringEventData(input.Data, "doc_id"))
+	if requestID == "" || docID == "" {
+		return nil, "", errors.New("notify: docs result is missing stored request identity")
+	}
+	title := strings.TrimSpace(input.Title)
+	if title == "" {
+		title = strings.TrimSpace(stringEventData(input.Data, "doc_title"))
+	}
+	if title == "" {
+		title = docID
+	}
+	operatorName := strings.TrimSpace(input.OperatorName)
+	if operatorName == "" {
+		// A UID is an internal identifier, not display copy. Use stable localized
+		// generic text when the callback does not provide an operator name.
+		operatorName = docsLabelsFor(lang).decisionActor
+	}
+	denyReason := strings.TrimSpace(input.DenyReason)
 	if runes := []rune(denyReason); len(runes) > capResultReason {
 		denyReason = string(runes[:capResultReason])
 	}
-	requestID, _ := event.Data["request_id"].(string)
-	actor, _ := event.Data["actor"].(string)
-	operatorName := strings.TrimSpace(result.Display["operator_name"])
-	if operatorName == "" {
-		operatorName = event.OperatorUID
+	state := docsaccessrequest.StateApproved
+	wireState := "approved"
+	if input.Denied {
+		state = docsaccessrequest.StateRejected
+		wireState = "rejected"
 	}
+	actor := stringEventData(input.Data, "actor")
 	document := map[string]any{
-		"docId": strings.TrimSpace(stringEventData(event.Data, "doc_id")),
+		"docId": docID,
 		"title": truncRunes(strings.TrimSpace(title), capResultTitle),
 	}
 	requester := map[string]any{"name": truncRunes(strings.TrimSpace(actor), capResultName)}
-	if value := strings.TrimSpace(stringEventData(event.Data, "source_name")); value != "" {
+	if value := strings.TrimSpace(stringEventData(input.Data, "source_name")); value != "" {
 		document["sourceName"] = truncRunes(value, capResultTitle)
 	}
-	if value := strings.TrimSpace(stringEventData(event.Data, "actor_avatar_url")); value != "" {
+	if value := strings.TrimSpace(stringEventData(input.Data, "actor_avatar_url")); value != "" {
 		// URL 不截断:schema 无 maxLength(https 由渲染层校验),截断会破坏链接。
 		requester["avatarUrl"] = value
 	}
 	fields := map[string]any{
-		"requestId": strings.TrimSpace(requestID),
+		"requestId": requestID,
 		"state":     wireState,
 		"document":  document,
 		"requester": requester,
 		"decision": map[string]any{
 			"operatorName":     truncRunes(operatorName, capResultName),
-			"decidedAtDisplay": truncRunes(strings.TrimSpace(result.Display["decided_at"]), capResultShortLabel),
+			"decidedAtDisplay": truncRunes(strings.TrimSpace(input.DecidedAtDisplay), capResultShortLabel),
 		},
 	}
 	dataCaps := map[string]int{
@@ -206,15 +259,15 @@ func (f *DocsActionFinalizer) replaceWithRegistryResult(ctx context.Context, eve
 		"requestReason": "request_reason", "requestedAtDisplay": "requested_at_display",
 		"messageTimeDisplay": "message_time_display",
 	} {
-		if value := strings.TrimSpace(stringEventData(event.Data, source)); value != "" {
+		if value := strings.TrimSpace(stringEventData(input.Data, source)); value != "" {
 			fields[destination] = truncRunes(value, dataCaps[destination])
 		}
 	}
 	permission := make(map[string]any, 2)
-	if value := strings.TrimSpace(stringEventData(event.Data, "permission_label")); value != "" {
+	if value := strings.TrimSpace(stringEventData(input.Data, "permission_label")); value != "" {
 		permission["label"] = truncRunes(value, capResultShortLabel)
 	}
-	if value := strings.TrimSpace(stringEventData(event.Data, "permission_role_label")); value != "" {
+	if value := strings.TrimSpace(stringEventData(input.Data, "permission_role_label")); value != "" {
 		permission["roleLabel"] = truncRunes(value, capResultShortLabel)
 	}
 	if len(permission) > 0 {
@@ -225,20 +278,9 @@ func (f *DocsActionFinalizer) replaceWithRegistryResult(ctx context.Context, eve
 	}
 	raw, err := json.Marshal(fields)
 	if err != nil {
-		return fmt.Errorf("notify: marshal registry result fields: %w", err)
+		return nil, "", fmt.Errorf("notify: marshal registry result fields: %w", err)
 	}
-	return f.updater.ReplaceView(ctx, cardtmpl.UpdateTarget{
-		Target: carddispatch.Target{
-			SpaceID: event.SpaceID, ChannelID: channelID, ChannelType: event.ChannelType,
-		},
-		// card_seq 单调性来源:event.EventID 是全局单调递增的 snowflake,直接用作
-		// card_seq 满足 CardMutator CAS 的严格递增要求(见
-		// .octospec/learnings/pending/cardtmpl-interaction-closure.md)。若未来 event
-		// ID 生成器改为非单调,CAS 会静默丢弃合法更新——务必同步复核。
-		SenderUID: event.SenderUID, MessageID: event.MessageID, CardSeq: event.EventID,
-	}, docsaccessrequest.TemplateID, docsaccessrequest.TemplateVersionV3, state, raw, cardtmpl.BuildEnv{
-		WebLoginURL: f.ctx.GetConfig().External.WebLoginURL, Lang: lang, SpaceID: event.SpaceID,
-	})
+	return raw, state, nil
 }
 
 func stringEventData(data map[string]interface{}, key string) string {

--- a/modules/notify/action_finalizer_v3_test.go
+++ b/modules/notify/action_finalizer_v3_test.go
@@ -77,8 +77,11 @@ func TestDocsActionFinalizerUsesV3RegistryResultForTerminalStates(t *testing.T) 
 		t.Fatalf("result fields = %+v", fields)
 	}
 	decision := fields["decision"].(map[string]any)
-	if decision["operatorName"] != event.OperatorUID || decision["rejectionReason"] != "scope mismatch" {
+	if decision["operatorName"] != "审批人" || decision["rejectionReason"] != "scope mismatch" {
 		t.Fatalf("decision fields = %+v", decision)
+	}
+	if strings.Contains(string(updater.fields), event.OperatorUID) {
+		t.Fatalf("result fields exposed raw operator uid: %s", updater.fields)
 	}
 	document := fields["document"].(map[string]any)
 	requester := fields["requester"].(map[string]any)

--- a/modules/notify/card.go
+++ b/modules/notify/card.go
@@ -775,6 +775,7 @@ type docsLabels struct {
 	denyReasonLabel     string // "拒绝原因" / "Reason for denial"
 	approvedResult      string // result-box copy on approval
 	deniedResult        string // result-box copy on denial
+	decisionActor       string // safe generic when callback omits operator display name
 }
 
 func docsLabelsFor(lang string) docsLabels {
@@ -808,6 +809,7 @@ func docsLabelsFor(lang string) docsLabels {
 			denyReasonLabel:           "拒绝原因",
 			approvedResult:            "申请人已获得所申请的文档权限。",
 			deniedResult:              "申请已被拒绝。",
+			decisionActor:             "审批人",
 		}
 	}
 	return docsLabels{
@@ -839,6 +841,7 @@ func docsLabelsFor(lang string) docsLabels {
 		denyReasonLabel:           "Reason for denial",
 		approvedResult:            "The requester now has the requested document access.",
 		deniedResult:              "The access request was denied.",
+		decisionActor:             "Reviewer",
 	}
 }
 

--- a/modules/notify/card_mutate_api.go
+++ b/modules/notify/card_mutate_api.go
@@ -47,6 +47,21 @@ func docsAccessCardVariant(envelope []byte) (variant string, isDocsAccess bool) 
 	return variant, strings.HasPrefix(variant, docsAccessVariantPrefix)
 }
 
+// docsAccessMutationDisposition protects retry idempotency after the first
+// successful mutation has removed the pending Submit actions. A repeated
+// decision for the same terminal state is already applied; the opposite state
+// is a conflict and must never overwrite a committed decision.
+func docsAccessMutationDisposition(variant, kind string) (alreadyApplied, conflict bool) {
+	switch variant {
+	case docsaccessrequest.VariantApproved:
+		return kind == DocsCardKindAccessGranted, kind == DocsCardKindAccessDenied
+	case docsaccessrequest.VariantRejected:
+		return kind == DocsCardKindAccessDenied, kind == DocsCardKindAccessGranted
+	default:
+		return false, false
+	}
+}
+
 // CardMutateReq is the access-decision card-sync request (task
 // docs-access-decision-card-sync). docs-backend calls this once per sibling
 // approver card after a decision commits, to drive that card to its terminal
@@ -144,6 +159,16 @@ func (n *Notify) mutateCard(c *wkhttp.Context) {
 			zap.String("space_id", req.SpaceID), zap.String("message_id", req.MessageID),
 			zap.String("variant", variant))
 		httperr.ResponseErrorL(c, errcode.ErrNotifyCardMutateForbidden, nil, nil)
+		return
+	}
+	if alreadyApplied, conflict := docsAccessMutationDisposition(variant, req.Kind); alreadyApplied {
+		c.Response(CardMutateResp{Mutated: true})
+		return
+	} else if conflict {
+		n.Warn("card mutate rejected: target already has opposite terminal state",
+			zap.String("space_id", req.SpaceID), zap.String("message_id", req.MessageID),
+			zap.String("variant", variant), zap.String("kind", req.Kind))
+		httperr.ResponseErrorL(c, errcode.ErrNotifyCardMutateFailed, nil, nil)
 		return
 	}
 

--- a/modules/notify/card_mutate_api.go
+++ b/modules/notify/card_mutate_api.go
@@ -96,8 +96,8 @@ type CardMutateResp struct {
 
 // mutateCard handles POST /v1/internal/cards/mutate. It drives one already-
 // delivered docs access card to its terminal (approved/denied) state in place,
-// reusing the exact terminal-card builder the click-driven finalizer uses so a
-// clicker's card and the sibling cards stay byte-identical. Docs capability only.
+// reusing the same V3 Registry field mapping as the click-driven finalizer.
+// Docs capability only.
 func (n *Notify) mutateCard(c *wkhttp.Context) {
 	capability, _ := c.Get(notifyCapabilityContextKey)
 	typedCapability, _ := capability.(notifyCapability)

--- a/modules/notify/card_mutate_api.go
+++ b/modules/notify/card_mutate_api.go
@@ -1,13 +1,18 @@
 package notify
 
 import (
+	"context"
+	"encoding/json"
 	"errors"
+	"fmt"
 	"strings"
 
 	"github.com/Mininglamp-OSS/octo-lib/common"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
 	"github.com/Mininglamp-OSS/octo-server/internal/carddispatch"
 	"github.com/Mininglamp-OSS/octo-server/pkg/cardmsg"
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl"
+	docsaccessrequest "github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl/docs_access_request"
 	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
 	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
 	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
@@ -28,6 +33,8 @@ const docsCardMutateSeqKey = common.MessageExtraSeqKey + ":docs-card-mutate"
 // "docs.access_requested" / "docs.access_granted") is the authoritative
 // docs-domain discriminator; only cards in this family may be touched.
 const docsAccessVariantPrefix = "docs.access_"
+
+var errDocsSiblingContextInvalid = errors.New("notify: invalid stored docs sibling context")
 
 // docsAccessCardVariant reports the target card's variant and whether it belongs
 // to the docs access family, from the effective card envelope. Pure so the
@@ -60,6 +67,11 @@ type CardMutateReq struct {
 	DocID       string `json:"doc_id"`
 	Title       string `json:"title"`
 	DenyReason  string `json:"deny_reason"` // surfaced on the denied terminal card; empty on approve
+	// OperatorName / DecidedAtDisplay are optional additive display fields.
+	// Older callers omit them and receive localized generic operator copy; raw
+	// UIDs are never derived as display copy by this endpoint.
+	OperatorName     string `json:"operator_name"`
+	DecidedAtDisplay string `json:"decided_at_display"`
 }
 
 // CardMutateResp reports whether the card is now terminal.
@@ -89,8 +101,6 @@ func (n *Notify) mutateCard(c *wkhttp.Context) {
 		httperr.ResponseErrorL(c, errcode.ErrNotifyCardMutateInvalid, nil, nil)
 		return
 	}
-	denied := req.Kind == DocsCardKindAccessDenied
-
 	ctx := c.Request.Context()
 	channelType := req.ChannelType
 	if channelType == 0 {
@@ -137,45 +147,32 @@ func (n *Notify) mutateCard(c *wkhttp.Context) {
 		return
 	}
 
-	lang := i18n.OutboundLanguage(ctx)
-	document, err := buildDocsDecisionTerminalDocument(
-		ctx, n.ctx.GetConfig().External.WebLoginURL, lang, req.DocID, req.SpaceID, req.Title, req.DenyReason, denied)
-	if err != nil {
-		n.Warn("build terminal card for mutate failed",
-			zap.Error(err), zap.String("doc_id", req.DocID), zap.String("space_id", req.SpaceID))
-		httperr.ResponseErrorL(c, errcode.ErrNotifyCardMutateInvalid, nil, nil)
-		return
-	}
-
 	cardSeq, err := n.ctx.GenSeq(docsCardMutateSeqKey)
 	if err != nil {
 		n.Error("gen card_seq for mutate failed", zap.Error(err), zap.String("message_id", req.MessageID))
 		httperr.ResponseErrorL(c, errcode.ErrNotifyCardMutateFailed, nil, nil)
 		return
 	}
-	contentEdit, err := buildTerminalEnvelope(document, req.SpaceID, cardSeq)
+	updater, err := cardtmpl.NewCardUpdater(cardtmpl.DefaultRegistry(), mutator)
 	if err != nil {
-		n.Warn("build terminal envelope for mutate failed",
-			zap.Error(err), zap.String("doc_id", req.DocID))
-		httperr.ResponseErrorL(c, errcode.ErrNotifyCardMutateInvalid, nil, nil)
+		n.Error("create card updater for mutate failed", zap.Error(err))
+		httperr.ResponseErrorL(c, errcode.ErrNotifyCardMutateFailed, nil, nil)
 		return
 	}
-
-	// SenderUID = docs producer bot, resolved server-side (see type doc). Never
-	// caller-supplied. Snapshot above already confirmed this is that bot's card.
-	if _, err = mutator.Mutate(ctx, carddispatch.CardMutationRequest{
-		SenderUID:   NotifyBotUIDValue,
-		MessageID:   req.MessageID,
-		ChannelID:   req.ChannelID,
-		ChannelType: channelType,
-		ContentEdit: contentEdit,
-	}); err != nil {
+	req.ChannelType = channelType
+	if err = replaceSiblingWithRegistryResult(
+		ctx, updater, req, snap, cardSeq, cardtmpl.BuildEnv{
+			WebLoginURL: n.ctx.GetConfig().External.WebLoginURL,
+			Lang:        i18n.OutboundLanguage(ctx),
+			SpaceID:     req.SpaceID,
+		}); err != nil {
 		// A malformed edit is the caller's bug (400). Not-found / sender-mismatch
 		// / stale / backend errors are transient-or-benign from the caller's view
 		// (409): it retries or falls back to re-notify. The decision itself is
 		// already committed and protected by the docs-backend pending guard, so a
 		// mutate miss never corrupts state — it only leaves one stale card.
-		if errors.Is(err, carddispatch.ErrCardMutationInvalid) {
+		if errors.Is(err, errDocsSiblingContextInvalid) || errors.Is(err, carddispatch.ErrCardMutationInvalid) ||
+			errors.Is(err, cardtmpl.ErrFieldsInvalid) || errors.Is(err, cardtmpl.ErrUpdateInvalid) {
 			n.Warn("card mutate invalid",
 				zap.Error(err), zap.String("space_id", req.SpaceID), zap.String("message_id", req.MessageID))
 			httperr.ResponseErrorL(c, errcode.ErrNotifyCardMutateInvalid, nil, nil)
@@ -188,4 +185,52 @@ func (n *Notify) mutateCard(c *wkhttp.Context) {
 		return
 	}
 	c.Response(CardMutateResp{Mutated: true})
+}
+
+// replaceSiblingWithRegistryResult recovers the original request display
+// context from the stored server-authored pending card, then renders the same
+// docs.access-request@0.3.0/result view used by the click-driven finalizer.
+// Caller-supplied Space/document identity must match the stored frame.
+func replaceSiblingWithRegistryResult(ctx context.Context, updater cardtmpl.CardUpdater, req CardMutateReq,
+	snapshot carddispatch.CardMutationSnapshot, cardSeq int64, env cardtmpl.BuildEnv,
+) error {
+	if ctx == nil || updater == nil || cardSeq <= 0 || env.SpaceID != req.SpaceID {
+		return errDocsSiblingContextInvalid
+	}
+	var envelope struct {
+		SpaceID string `json:"space_id"`
+	}
+	if err := json.Unmarshal(snapshot.Envelope, &envelope); err != nil ||
+		strings.TrimSpace(envelope.SpaceID) == "" || envelope.SpaceID != req.SpaceID {
+		return fmt.Errorf("%w: space mismatch", errDocsSiblingContextInvalid)
+	}
+	data, found := cardmsg.SubmitAction(snapshot.Envelope, cardtmpl.DocsApproveActionID)
+	if !found {
+		data, found = cardmsg.SubmitAction(snapshot.Envelope, cardtmpl.DocsDenyActionID)
+	}
+	if !found || data == nil {
+		return fmt.Errorf("%w: pending action data not found", errDocsSiblingContextInvalid)
+	}
+	storedDocID := strings.TrimSpace(stringEventData(data, "doc_id"))
+	if storedDocID == "" || storedDocID != strings.TrimSpace(req.DocID) {
+		return fmt.Errorf("%w: document mismatch", errDocsSiblingContextInvalid)
+	}
+	denied := req.Kind == DocsCardKindAccessDenied
+	fields, state, err := buildDocsAccessResultFields(env.Lang, docsResultRenderInput{
+		Data:             data,
+		Title:            req.Title,
+		OperatorName:     req.OperatorName,
+		DecidedAtDisplay: req.DecidedAtDisplay,
+		DenyReason:       req.DenyReason,
+		Denied:           denied,
+	})
+	if err != nil {
+		return fmt.Errorf("%w: %v", errDocsSiblingContextInvalid, err)
+	}
+	return updater.ReplaceView(ctx, cardtmpl.UpdateTarget{
+		Target: carddispatch.Target{
+			SpaceID: req.SpaceID, ChannelID: req.ChannelID, ChannelType: req.ChannelType,
+		},
+		SenderUID: NotifyBotUIDValue, MessageID: req.MessageID, CardSeq: cardSeq,
+	}, docsaccessrequest.TemplateID, docsaccessrequest.TemplateVersionV3, state, fields, env)
 }

--- a/modules/notify/card_mutate_api_test.go
+++ b/modules/notify/card_mutate_api_test.go
@@ -1,6 +1,13 @@
 package notify
 
-import "testing"
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-server/internal/carddispatch"
+	docsaccessrequest "github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl/docs_access_request"
+)
 
 // TestDocsAccessCardVariant is the capability-containment guard for the docs
 // card-mutate endpoint (PR review P0): the shared `notification` bot sends docs,
@@ -42,5 +49,140 @@ func TestDocsAccessCardVariant(t *testing.T) {
 				t.Fatalf("docsAccessCardVariant variant = %q, want %q", variant, tc.wantVariant)
 			}
 		})
+	}
+}
+
+func TestReplaceSiblingWithRegistryResultUsesV3AndStoredContext(t *testing.T) {
+	updater := &captureViewUpdater{}
+	snapshot := carddispatch.CardMutationSnapshot{Envelope: json.RawMessage(`{
+		"type":17,
+		"profile":"octo/v2",
+		"space_id":"space-1",
+		"card":{
+			"metadata":{"octo":{"variant":"docs.access_requested"}},
+			"actions":[{
+				"type":"Action.Submit",
+				"id":"docs-access-approve",
+				"data":{
+					"owner":"docs",
+					"action_type":"access_request.decision",
+					"decision":"approve",
+					"doc_id":"doc-1",
+					"request_id":"request-1",
+					"doc_title":"Roadmap",
+					"actor":"Alice",
+					"actor_avatar_url":"https://cdn.example.com/alice.png",
+					"request_reason":"Need quarterly access",
+					"requested_at_display":"2026-07-24 10:00",
+					"message_time_display":"10:01",
+					"permission_label":"Access",
+					"permission_role_label":"Viewer",
+					"source_name":"Docs"
+				}
+			}]
+		}
+	}`)}
+	req := CardMutateReq{
+		SpaceID: "space-1", ChannelID: "reviewer-b", ChannelType: 1,
+		MessageID: "1002", Kind: DocsCardKindAccessGranted, DocID: "doc-1", Title: "caller title ignored",
+	}
+
+	if err := replaceSiblingWithRegistryResult(context.Background(), updater, req, snapshot, 99, "en"); err != nil {
+		t.Fatalf("replaceSiblingWithRegistryResult: %v", err)
+	}
+	if updater.id != docsaccessrequest.TemplateID || updater.version != docsaccessrequest.TemplateVersionV3 ||
+		updater.state != docsaccessrequest.StateApproved {
+		t.Fatalf("update selection = %s@%s/%s", updater.id, updater.version, updater.state)
+	}
+	if updater.target.MessageID != req.MessageID || updater.target.CardSeq != 99 || updater.target.Target.SpaceID != req.SpaceID {
+		t.Fatalf("update target = %+v", updater.target)
+	}
+	var fields map[string]any
+	if err := json.Unmarshal(updater.fields, &fields); err != nil {
+		t.Fatalf("decode fields: %v", err)
+	}
+	if fields["requestId"] != "request-1" || fields["state"] != "approved" {
+		t.Fatalf("result fields = %+v", fields)
+	}
+	document := fields["document"].(map[string]any)
+	requester := fields["requester"].(map[string]any)
+	permission := fields["permission"].(map[string]any)
+	decision := fields["decision"].(map[string]any)
+	if document["docId"] != "doc-1" || document["title"] != "Roadmap" || document["sourceName"] != "Docs" ||
+		requester["name"] != "Alice" || requester["avatarUrl"] != "https://cdn.example.com/alice.png" ||
+		permission["label"] != "Access" || permission["roleLabel"] != "Viewer" ||
+		fields["requestReason"] != "Need quarterly access" || fields["requestedAtDisplay"] != "2026-07-24 10:00" ||
+		fields["messageTimeDisplay"] != "10:01" || decision["operatorName"] != "Reviewer" {
+		t.Fatalf("stored result context = %+v", fields)
+	}
+}
+
+func TestReplaceSiblingWithRegistryResultRejectsCallerIdentityMismatch(t *testing.T) {
+	snapshot := carddispatch.CardMutationSnapshot{Envelope: json.RawMessage(`{
+		"type":17,
+		"profile":"octo/v2",
+		"space_id":"space-1",
+		"card":{"metadata":{"octo":{"variant":"docs.access_requested"}},"actions":[{
+			"type":"Action.Submit","id":"docs-access-approve",
+			"data":{"doc_id":"doc-1","request_id":"request-1","doc_title":"Roadmap","actor":"Alice"}
+		}]}
+	}`)}
+	tests := []struct {
+		name string
+		req  CardMutateReq
+	}{
+		{
+			name: "space mismatch",
+			req: CardMutateReq{SpaceID: "space-2", ChannelID: "reviewer-b", ChannelType: 1,
+				MessageID: "1002", Kind: DocsCardKindAccessGranted, DocID: "doc-1"},
+		},
+		{
+			name: "document mismatch",
+			req: CardMutateReq{SpaceID: "space-1", ChannelID: "reviewer-b", ChannelType: 1,
+				MessageID: "1002", Kind: DocsCardKindAccessGranted, DocID: "doc-2"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := replaceSiblingWithRegistryResult(context.Background(), &captureViewUpdater{}, tt.req, snapshot, 99, "en")
+			if err == nil {
+				t.Fatal("replaceSiblingWithRegistryResult error = nil")
+			}
+		})
+	}
+}
+
+func TestReplaceSiblingWithRegistryResultMapsDeniedState(t *testing.T) {
+	updater := &captureViewUpdater{}
+	snapshot := carddispatch.CardMutationSnapshot{Envelope: json.RawMessage(`{
+		"type":17,
+		"profile":"octo/v2",
+		"space_id":"space-1",
+		"card":{"metadata":{"octo":{"variant":"docs.access_requested"}},"actions":[{
+			"type":"Action.Submit","id":"docs-access-deny",
+			"data":{"doc_id":"doc-1","request_id":"request-1","doc_title":"Roadmap","actor":"Alice"}
+		}]}
+	}`)}
+	req := CardMutateReq{SpaceID: "space-1", ChannelID: "reviewer-b", ChannelType: 1,
+		MessageID: "1002", Kind: DocsCardKindAccessDenied, DocID: "doc-1", DenyReason: "Out of scope"}
+
+	if err := replaceSiblingWithRegistryResult(context.Background(), updater, req, snapshot, 100, "en"); err != nil {
+		t.Fatalf("replaceSiblingWithRegistryResult: %v", err)
+	}
+	if updater.state != docsaccessrequest.StateRejected {
+		t.Fatalf("state = %q, want %q", updater.state, docsaccessrequest.StateRejected)
+	}
+	var fields struct {
+		State    string `json:"state"`
+		Decision struct {
+			OperatorName    string `json:"operatorName"`
+			RejectionReason string `json:"rejectionReason"`
+		} `json:"decision"`
+	}
+	if err := json.Unmarshal(updater.fields, &fields); err != nil {
+		t.Fatal(err)
+	}
+	if fields.State != "rejected" || fields.Decision.OperatorName != "Reviewer" || fields.Decision.RejectionReason != "Out of scope" {
+		t.Fatalf("fields = %+v", fields)
 	}
 }

--- a/modules/notify/card_mutate_api_test.go
+++ b/modules/notify/card_mutate_api_test.go
@@ -53,6 +53,45 @@ func TestDocsAccessCardVariant(t *testing.T) {
 	}
 }
 
+func TestDocsAccessMutationDisposition(t *testing.T) {
+	tests := []struct {
+		name         string
+		variant      string
+		kind         string
+		wantApplied  bool
+		wantConflict bool
+	}{
+		{
+			name: "pending approval", variant: "docs.access_requested", kind: DocsCardKindAccessGranted,
+		},
+		{
+			name: "approved retry", variant: "docs.access_approved", kind: DocsCardKindAccessGranted,
+			wantApplied: true,
+		},
+		{
+			name: "denied retry", variant: "docs.access_denied", kind: DocsCardKindAccessDenied,
+			wantApplied: true,
+		},
+		{
+			name: "approved cannot become denied", variant: "docs.access_approved", kind: DocsCardKindAccessDenied,
+			wantConflict: true,
+		},
+		{
+			name: "denied cannot become approved", variant: "docs.access_denied", kind: DocsCardKindAccessGranted,
+			wantConflict: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			applied, conflict := docsAccessMutationDisposition(tt.variant, tt.kind)
+			if applied != tt.wantApplied || conflict != tt.wantConflict {
+				t.Fatalf("disposition = applied:%v conflict:%v, want applied:%v conflict:%v",
+					applied, conflict, tt.wantApplied, tt.wantConflict)
+			}
+		})
+	}
+}
+
 func TestReplaceSiblingWithRegistryResultUsesV3AndStoredContext(t *testing.T) {
 	updater := &captureViewUpdater{}
 	snapshot := carddispatch.CardMutationSnapshot{Envelope: json.RawMessage(`{

--- a/modules/notify/card_mutate_api_test.go
+++ b/modules/notify/card_mutate_api_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/Mininglamp-OSS/octo-server/internal/carddispatch"
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl"
 	docsaccessrequest "github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl/docs_access_request"
 )
 
@@ -84,10 +85,11 @@ func TestReplaceSiblingWithRegistryResultUsesV3AndStoredContext(t *testing.T) {
 	}`)}
 	req := CardMutateReq{
 		SpaceID: "space-1", ChannelID: "reviewer-b", ChannelType: 1,
-		MessageID: "1002", Kind: DocsCardKindAccessGranted, DocID: "doc-1", Title: "caller title ignored",
+		MessageID: "1002", Kind: DocsCardKindAccessGranted, DocID: "doc-1", Title: "Current Roadmap",
 	}
 
-	if err := replaceSiblingWithRegistryResult(context.Background(), updater, req, snapshot, 99, "en"); err != nil {
+	if err := replaceSiblingWithRegistryResult(context.Background(), updater, req, snapshot, 99,
+		cardtmpl.BuildEnv{WebLoginURL: "https://im.example.com/login", Lang: "en", SpaceID: "space-1"}); err != nil {
 		t.Fatalf("replaceSiblingWithRegistryResult: %v", err)
 	}
 	if updater.id != docsaccessrequest.TemplateID || updater.version != docsaccessrequest.TemplateVersionV3 ||
@@ -108,7 +110,7 @@ func TestReplaceSiblingWithRegistryResultUsesV3AndStoredContext(t *testing.T) {
 	requester := fields["requester"].(map[string]any)
 	permission := fields["permission"].(map[string]any)
 	decision := fields["decision"].(map[string]any)
-	if document["docId"] != "doc-1" || document["title"] != "Roadmap" || document["sourceName"] != "Docs" ||
+	if document["docId"] != "doc-1" || document["title"] != "Current Roadmap" || document["sourceName"] != "Docs" ||
 		requester["name"] != "Alice" || requester["avatarUrl"] != "https://cdn.example.com/alice.png" ||
 		permission["label"] != "Access" || permission["roleLabel"] != "Viewer" ||
 		fields["requestReason"] != "Need quarterly access" || fields["requestedAtDisplay"] != "2026-07-24 10:00" ||
@@ -144,7 +146,8 @@ func TestReplaceSiblingWithRegistryResultRejectsCallerIdentityMismatch(t *testin
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := replaceSiblingWithRegistryResult(context.Background(), &captureViewUpdater{}, tt.req, snapshot, 99, "en")
+			err := replaceSiblingWithRegistryResult(context.Background(), &captureViewUpdater{}, tt.req, snapshot, 99,
+				cardtmpl.BuildEnv{WebLoginURL: "https://im.example.com/login", Lang: "en", SpaceID: tt.req.SpaceID})
 			if err == nil {
 				t.Fatal("replaceSiblingWithRegistryResult error = nil")
 			}
@@ -166,7 +169,8 @@ func TestReplaceSiblingWithRegistryResultMapsDeniedState(t *testing.T) {
 	req := CardMutateReq{SpaceID: "space-1", ChannelID: "reviewer-b", ChannelType: 1,
 		MessageID: "1002", Kind: DocsCardKindAccessDenied, DocID: "doc-1", DenyReason: "Out of scope"}
 
-	if err := replaceSiblingWithRegistryResult(context.Background(), updater, req, snapshot, 100, "en"); err != nil {
+	if err := replaceSiblingWithRegistryResult(context.Background(), updater, req, snapshot, 100,
+		cardtmpl.BuildEnv{WebLoginURL: "https://im.example.com/login", Lang: "en", SpaceID: "space-1"}); err != nil {
 		t.Fatalf("replaceSiblingWithRegistryResult: %v", err)
 	}
 	if updater.state != docsaccessrequest.StateRejected {


### PR DESCRIPTION
## Summary

Unify docs access decision cards so the clicked card and all sibling approver cards render through `docs.access-request@0.3.0/result`, while preventing raw operator UIDs from leaking into user-visible card copy.

## Related Issue

Closes #661.

Runtime regression follow-up to #635.

## Linked Spec

`.octospec/tasks/docs-access-result-card-consistency/brief.md`

## Changes

- Route sibling access-decision mutations through `CardUpdater.ReplaceView` and the V3 Registry result template instead of the legacy outcome-card builder.
- Recover requester, permission, reason, and timestamp context from the stored server-authored pending card action data; reject Space or document identity mismatches.
- Replace the raw `operator_uid` fallback with localized `审批人` / `Reviewer` copy when no display name is available.
- Preserve idempotent same-state mutation retries and reject attempts to overwrite an opposite terminal decision.
- Add focused approved, denied, context recovery, UID non-disclosure, identity mismatch, and retry regression tests.

## Testing

- [x] Unit tests added/updated
- [ ] Manually verified

Commands run:

- `go test -cover ./modules/notify/...` — pass, 70.0% package coverage
- `go test -race ./modules/notify -run 'TestDocsActionFinalizerUsesV3RegistryResultForTerminalStates|TestDocsActionFinalizerV3OmitsUnavailableV2Decoration|TestDocsActionFinalizerV3TruncatesOversizedDisplayFields|TestReplaceSiblingWithRegistryResult|TestDocsAccessCardVariant|TestDocsAccessMutationDisposition' -count=1`
- `go test ./pkg/cardtmpl/... ./pkg/cardmsg/... ./internal/carddispatch/...`
- `go vet ./modules/notify ./pkg/cardtmpl/... ./pkg/cardmsg ./internal/carddispatch`
- `golangci-lint run ./modules/notify/... ./pkg/cardtmpl/... ./pkg/cardmsg/... ./internal/carddispatch/...` — 0 issues

The shared local `test` database and `octo-test-redis` were reset before the full notify run to remove a stale migration ledger entry.

## COMPREHENSION

1. **What does this change actually do to the load-bearing path?**

   The click-driven finalizer and the internal sibling-card mutation endpoint now share one bounded mapping into `docs.access-request@0.3.0/result`. Sibling rendering uses the stored, server-authored pending action data and persists through the existing Registry -> CardUpdater -> CardMutator CAS/revision/CMD path.

2. **What could break because of it (dependents + failure mode)?**

   A malformed or non-matching stored pending card can no longer be rewritten from caller display fields; it fails closed with the existing mutation error envelope. Already-mutated legacy terminal cards are not retroactively restyled. Older callers remain compatible because the new operator display fields are optional and fall back to localized generic copy.

3. **How do you know it works (specific test/repro/trace)?**

   RED tests reproduced the legacy sibling renderer and raw UID fallback before the fix. The GREEN tests assert V3 template/version/state selection, stored-context recovery, approved/denied rendering fields, UID non-disclosure, Space/document mismatch rejection, and same-state retry idempotency. The full notify package passed after resetting the local test database.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] PR description is in English
- [x] Added tests for my changes
- [x] Updated documentation
- [x] Followed commit message conventions (Conventional Commits)
