### PR TITLE
fix(cardaction): harden route-missing defer path — reclaim attempt-leak + LiveTTL floor (#623, #624)

### DIFF
--- a/.octospec/tasks/card-action-dispatch-defer-hardening/brief.md
+++ b/.octospec/tasks/card-action-dispatch-defer-hardening/brief.md
@@ -83,6 +83,12 @@ Both are follow-ups from the PR #621 review at head `d0b0a879`:
   retries stay bounded). Both pinned by
   `TestReclaimRefundsRouteMissingDeferAttemptLeak` (two subtests) and the unchanged
   `TestRedisQueueLeaseTokenRetryDLQAndReplay` (markerless reclaim still → attempt 2).
+- #623 (review-driven, #662): once the route RESOLVES at dispatch, the marker is dropped
+  (token-protected `ClearRouteMissing`) BEFORE delivery, so a hard crash during the ensuing
+  delivery is reclaimed as a real attempt (bound preserved), not refunded as a defer. Pinned by
+  `TestClearRouteMissingRestoresDeliveryReclaimBound` (Redis: token-mismatch cannot clear;
+  cleared marker → reclaim advances to attempt 2) and
+  `TestRoutePresentClearsRouteMissingMarkerBeforeDelivery` (dispatcher wiring).
 - #624: `NewRedisQueue` rejects `LiveTTL` at/below the floor with a descriptive error and
   accepts values at/above it. Pinned by `TestNewRedisQueueRejectsLiveTTLBelowDeferFloor`
   (rejects `routeMissingDeferInterval` and `minLiveTTL-1ns`; accepts `minLiveTTL` and `1h`).

--- a/.octospec/tasks/card-action-dispatch-defer-hardening/brief.md
+++ b/.octospec/tasks/card-action-dispatch-defer-hardening/brief.md
@@ -59,22 +59,46 @@ Both are follow-ups from the PR #621 review at head `d0b0a879`:
   attempt 2).
 - **`route_missing_since` marker lifecycle** (set by `RouteMissingSeenAt`, HDEL'd on
   `ack`/terminal `nack`/`replay`): reused here as the "in the defer loop" discriminator.
+- **Dispatch ordering around the marker clear** (`dispatcher.go`, review-driven): once
+  `Route()` resolves, `ClearRouteMissing` (token-protected) runs BEFORE the `MaxAttempts`
+  gate and `Deliver`, so a delivery lease is markerless and its reclaim is not refunded. The
+  route-absent branch returns earlier and never reaches it, keeping the marker the defer loop
+  needs. The `!cleared` result means the lease was reclaimed + re-leased, so the dispatcher
+  bails with `ack_lost` before `Deliver`/`Finalize` rather than doing a delivery whose terminal
+  `Ack` would fail — mirroring the existing `!deferred` lease-loss handling.
 - **`NewRedisQueue` construction contract** (boot-time; `main.go` returns its error): the
   new floor rejects only a pathological `LiveTTL`; all real/test configs (7d, 1h, 10m) clear it.
 - `touches: testing` — Redis-backed package unit tests.
 - `touches: commit` — Conventional Commits, English, `Fixes #62x` footer.
 
 ## Out of scope
-- The **capacity-defer** path's identical claim→Defer shape: pre-existing, its window is a
-  purely in-memory channel check (no I/O between claim and Defer), so exposure is negligible;
-  it carries no durable marker so the reclaim refund does not (and need not) cover it.
+- The **capacity-defer** path's identical claim→Defer shape (`dispatcher.go`): pre-existing
+  and NOT covered by this change. The marker-gated refund cannot reach it — `ClearRouteMissing`
+  runs before the capacity check, so a capacity-deferred lease is always markerless — and a
+  crash or lease expiry between claim and that `Defer` still leaks the `+1`. Note the window is
+  no longer the purely in-memory channel check it was when this task was drafted: the
+  `ClearRouteMissing` round-trip now sits between claim and the capacity `Defer`. Exposure is
+  still bounded (worst case a recoverable `attempts_exhausted` DLQ entry, replayable), but the
+  honest framing is deferred-to-follow-up, not negligible-by-construction. Closing it properly
+  means moving the speculative `+1` off `claim` — see the note below.
+- Relocating the attempt increment from `claimScript` to just before `Deliver`, which would
+  make BOTH defer paths net-zero without a discriminator and retire the marker's accounting
+  role entirely (subsuming this refund, the capacity-path gap above, and #680). It is the
+  cleaner shape but it moves a load-bearing off-by-one — the `lease.Attempt > MaxAttempts`
+  pre-delivery gate, `nackScript`'s `attempt >= maxAttempts` DLQ gate, and the replay reset all
+  shift together — so it needs its own review round rather than riding along with this P2.
 - Folding `RouteMissingSeenAt` + `Defer` into one atomic Lua transition (the other option
   the issue lists): it does not improve leak coverage over the marker-gated reclaim refund
   (the `+1` is at *claim*, before either call), so it was not pursued for this P2.
-- A route-level `MaxBackoff` vs `LiveTTL` guard: `NewRedisQueue` does not know per-route
-  backoff; the floor covers only the queue-level `routeMissingDeferInterval` constant.
-- Anything in `dispatcher.go`, the delivery-error retry path, enqueue resolution, or the
-  DLQ-retention/replay logic — all untouched.
+- A cross-config `LiveTTL` guard covering route-level `MaxBackoff` (up to 10m), the
+  dispatcher's `PollInterval` (no upper bound) and `LeaseDuration` (30s default). Each can
+  exceed `minLiveTTL`, so the floor does not make deferred-key expiry impossible in general —
+  only for the route-missing defer interval it is derived from. The values live on
+  `DispatcherConfig`, not `QueueConfig`, so the check belongs at dispatcher construction; the
+  `minLiveTTL` doc comment and the constructor error now state only what they enforce.
+- The delivery-error retry path, enqueue resolution, and the DLQ-retention/replay logic —
+  all untouched. `dispatcher.go` IS touched (see Load-bearing list) for the review-driven
+  marker clear and the pre-delivery lease-loss bail.
 
 ## Acceptance
 - #623: a reclaimed lease that carries a `route_missing_since` marker has its attempt

--- a/.octospec/tasks/card-action-dispatch-defer-hardening/brief.md
+++ b/.octospec/tasks/card-action-dispatch-defer-hardening/brief.md
@@ -1,0 +1,93 @@
+---
+type: Task
+title: "Task: card-action-dispatch-defer-hardening"
+description: Close two defensive gaps in the card-action dispatch queue's defer path — the claim→Defer attempt-increment leak on reclaim, and the missing LiveTTL lower bound relative to the defer interval.
+tags: ["card", "dispatch", "reliability", "queue", "testing"]
+timestamp: 2026-07-24T13:15:45+00:00
+# --- octospec extension fields ---
+slug: card-action-dispatch-defer-hardening
+upstream: Mininglamp-OSS/octo-server#623, Mininglamp-OSS/octo-server#624
+source: self
+---
+
+# Task: card-action-dispatch-defer-hardening
+
+> Follow-up hardening for the `route-missing-retry` task (PR #621). Both items were
+> raised in that PR's review (yujiawei, P2/P3) and filed as non-blocking issues so they
+> would not be lost.
+
+## Goal
+Two independent reliability fixes in `internal/cardactiondispatch/queue.go`, both about
+the queue's *defer* path (the route-missing self-heal loop PR #621 added):
+
+1. **#623 (P2) — attempt-increment leak on reclaim.** `claimScript` increments the
+   per-event attempt on every claim; only a completed `Defer` restores it, so a
+   claim→Defer re-check cycle is net-zero. If the worker crashes / Redis errors / the
+   lease expires in the window *between* claim and `Defer`, `ReclaimExpired` requeued the
+   event without undoing the `+1`. Across many cycles the counter creeps up until the
+   event reads `attempt > MaxAttempts` and dead-letters as `attempts_exhausted` on a route
+   it never got to try. `reclaimScript` now refunds the increment (floored at 0) for a
+   reclaimed lease that still carries a `route_missing_since` marker — the durable signal
+   that the event is in the defer loop — making a reclaimed defer cycle net-zero too.
+
+2. **#624 (P3) — missing LiveTTL floor.** `NewRedisQueue` validated only `LiveTTL > 0`.
+   A deferred event is rescheduled up to `routeMissingDeferInterval` (5s) ahead and every
+   queue op `PEXPIRE`s its ready/payload keys to `LiveTTL`; if `LiveTTL` did not comfortably
+   exceed that interval a deferred key could expire before the event became claimable,
+   silently dropping it. Add a `minLiveTTL` floor (`4 × routeMissingDeferInterval`) so a
+   pathological config fails fast at construction (server boot) instead of at runtime.
+
+## Background
+Both are follow-ups from the PR #621 review at head `d0b0a879`:
+- #623: the claim-then-transition shape *predates* #621 (the capacity-defer path shares
+  it); #621 only added more re-check cycles, marginally widening exposure. Worst case is a
+  **recoverable** DLQ entry (reason preserved, replayable), not silent loss, and the path is
+  already at-least-once with an idempotent consumer — hence P2, not P0/P1.
+- #624: `LiveTTL` is `Robot.MessageExpire`, which defaults to **7 days**. A sub-5-second
+  value would break card messaging broadly long before this dispatch path mattered, so this
+  is defensive hardening (a missing invariant), essentially zero live risk — hence P3.
+
+## Load-bearing list
+- **Reclaim requeue semantics** (`reclaimScript` in `queue.go`): what a reclaimed lease
+  does to the attempts hash. Previously it touched only `ready`/`leased`/`tokens`; it now
+  conditionally `HINCRBY -1` on `attempts`, gated on the `route_missing_since` marker.
+- **Attempt accounting as the retry bound** (`claimScript` `+1`, `deferScript` `-1`,
+  `nackScript`'s `attempt >= maxAttempts` DLQ gate, dispatcher's `lease.Attempt >
+  route.MaxAttempts` pre-delivery gate): the refund must NOT weaken the bound on real
+  delivery retries. Delivery leases carry no marker, so their accounting is untouched —
+  pinned by the existing `TestRedisQueueLeaseTokenRetryDLQAndReplay` (markerless reclaim →
+  attempt 2).
+- **`route_missing_since` marker lifecycle** (set by `RouteMissingSeenAt`, HDEL'd on
+  `ack`/terminal `nack`/`replay`): reused here as the "in the defer loop" discriminator.
+- **`NewRedisQueue` construction contract** (boot-time; `main.go` returns its error): the
+  new floor rejects only a pathological `LiveTTL`; all real/test configs (7d, 1h, 10m) clear it.
+- `touches: testing` — Redis-backed package unit tests.
+- `touches: commit` — Conventional Commits, English, `Fixes #62x` footer.
+
+## Out of scope
+- The **capacity-defer** path's identical claim→Defer shape: pre-existing, its window is a
+  purely in-memory channel check (no I/O between claim and Defer), so exposure is negligible;
+  it carries no durable marker so the reclaim refund does not (and need not) cover it.
+- Folding `RouteMissingSeenAt` + `Defer` into one atomic Lua transition (the other option
+  the issue lists): it does not improve leak coverage over the marker-gated reclaim refund
+  (the `+1` is at *claim*, before either call), so it was not pursued for this P2.
+- A route-level `MaxBackoff` vs `LiveTTL` guard: `NewRedisQueue` does not know per-route
+  backoff; the floor covers only the queue-level `routeMissingDeferInterval` constant.
+- Anything in `dispatcher.go`, the delivery-error retry path, enqueue resolution, or the
+  DLQ-retention/replay logic — all untouched.
+
+## Acceptance
+- #623: a reclaimed lease that carries a `route_missing_since` marker has its attempt
+  refunded (floored at 0), so its next claim returns to the SAME attempt (net-zero across a
+  crash), not a higher one. A reclaimed lease WITHOUT a marker keeps its attempt (delivery
+  retries stay bounded). Both pinned by
+  `TestReclaimRefundsRouteMissingDeferAttemptLeak` (two subtests) and the unchanged
+  `TestRedisQueueLeaseTokenRetryDLQAndReplay` (markerless reclaim still → attempt 2).
+- #624: `NewRedisQueue` rejects `LiveTTL` at/below the floor with a descriptive error and
+  accepts values at/above it. Pinned by `TestNewRedisQueueRejectsLiveTTLBelowDeferFloor`
+  (rejects `routeMissingDeferInterval` and `minLiveTTL-1ns`; accepts `minLiveTTL` and `1h`).
+- Green: `go test -tags integration ./internal/cardactiondispatch/` (unit + the 3 e2e
+  orchestration tests, run against live MySQL+Redis+WuKongIM); clean: `go build ./...`, `go vet`.
+- Tests: `internal/cardactiondispatch/route_missing_queue_test.go`
+  (`TestReclaimRefundsRouteMissingDeferAttemptLeak`, Redis-backed) and `coverage_test.go`
+  (`TestNewRedisQueueRejectsLiveTTLBelowDeferFloor`).

--- a/.octospec/tasks/card-action-dispatch-defer-hardening/context.yaml
+++ b/.octospec/tasks/card-action-dispatch-defer-hardening/context.yaml
@@ -74,11 +74,23 @@ notes:
     route-missing episode. The marker persists for the rest of the episode (cleared only on
     Ack/terminal-Nack/replay), so subsequent cycles are protected. One increment is far below
     MaxAttempts (typically 3–5) over a minutes-long, rare episode — acceptable for a P2.
-  - Edge (benign): an event that WAS route-missing then delivers (route returned) still carries
-    the marker until Ack/Nack clears it; if that delivery attempt's worker crashes and is reclaimed,
-    the refund fires on what was a delivery try. This only helps such an already-degraded event
-    start its retry fresh; the consumer is idempotent, so it is safe, and a poison event that crashes
-    the process on a plain HTTP callback is implausible.
+  - PR #662 review round (Jerry-Xin, BLOCKING) — FIXED. The route_missing_since marker is cleared
+    only on Ack/Nack/replay, so a once-route-missing event whose route RETURNS still carried the
+    marker while it delivered; a repeated hard crash during delivery (OOM / Redis connectivity loss —
+    not a poison callback) would have reclaimScript refund the attempt every time, pinning the counter
+    and asymmetrically exempting that event from the MaxAttempts bound. The PR had disclosed this as a
+    "benign edge"; the reviewer correctly argued it is a real bound bypass, not just a fresh start.
+    Fix: new token-protected clearRouteMissingScript / RedisQueue.ClearRouteMissing, called by the
+    dispatcher the moment Route() resolves (ok==true), BEFORE the attempt gate and Deliver — so a
+    delivery-phase reclaim advances the attempt like any delivery lease. Chose "clear the marker on
+    route resolution" over the reviewer's alternative "persist an explicit per-lease deferred state":
+    it reuses the existing marker + token machinery, adds one HDEL to the (low-QPS, human-click) route-
+    present path, and is semantically exact — the marker means "currently route-missing", which stops
+    being true the instant the route resolves. New tests: TestClearRouteMissingRestoresDeliveryReclaimBound
+    (Redis; token-mismatch cannot clear + cleared marker → reclaim advances attempt to 2) and
+    TestRoutePresentClearsRouteMissingMarkerBeforeDelivery (dispatcher wiring: route-present dispatch
+    clears the marker, then delivers + acks). The two other reviewers (lml2468, Octo-Q) APPROVED; the
+    lml2468 review ran a negative control (removing the refund block fails the #623 reproducer).
   - Design choice #624: floor = 4 × routeMissingDeferInterval (20s). The bare-correctness floor is
     1× (survive to the due instant); 4× is a comfort margin so the event can actually be claimed and
     processed after becoming due, not merely survive. Only rejects seconds-scale configs, which are

--- a/.octospec/tasks/card-action-dispatch-defer-hardening/context.yaml
+++ b/.octospec/tasks/card-action-dispatch-defer-hardening/context.yaml
@@ -1,0 +1,90 @@
+# Rules resolved for this task (octospec Implement phase).
+slug: card-action-dispatch-defer-hardening
+resolved_at: 2026-07-24T13:15:45+00:00
+
+# Files touched: internal/cardactiondispatch/queue.go,
+#                internal/cardactiondispatch/route_missing_queue_test.go,
+#                internal/cardactiondispatch/coverage_test.go
+# Path-glob matches: rate-limit (internal/**/*.go), space-isolation (internal/**/*.go),
+#                    testing (**/*_test.go), commit-style (**).
+
+rules_injected:
+  - id: space-isolation
+    tier: repo
+    load_bearing: true
+    why: >
+      Path glob internal/**/*.go matches. Checked for cross-space leakage.
+    applied:
+      - N/A — no data access and no Space boundary is crossed. Both changes are internal to
+        the Redis queue mechanics: reclaimScript decrements an integer attempt counter for an
+        event already space-validated at enqueue time, and NewRedisQueue adds a construction
+        pre-condition. No user data is read and nothing is granted.
+      - The refund does not widen access or re-target anything: it only adjusts the retry
+        budget of the exact same event; re-delivery still re-checks the consumer's own authz.
+  - id: rate-limit
+    tier: repo
+    load_bearing: true
+    why: >
+      Path glob internal/**/*.go matches; #623 touches the queue's attempt/reclaim path.
+    applied:
+      - N/A — not request-frequency limiting. The change refunds an attempt counter inside the
+        EXISTING reclaim Lua (reusing the route_missing_since marker the defer path already
+        maintains); no hand-rolled Redis INCR/TTL counter and no HTTP throttling is introduced.
+        #624 only adds a lower-bound assertion on a configured duration.
+  - id: testing
+    tier: repo
+    load_bearing: false
+    applied:
+      - Risk-proportional Redis-backed package unit tests added. #623:
+        TestReclaimRefundsRouteMissingDeferAttemptLeak with a positive case (marker → refund →
+        next claim attempt 1) AND a negative control (no marker → keep → next claim attempt 2),
+        so the test proves the gate, not just the happy path. #624:
+        TestNewRedisQueueRejectsLiveTTLBelowDeferFloor (boundary + reject/accept tables).
+      - The Redis-backed tests skip when no local Redis is reachable (t.Skipf), matching the
+        package's existing newRedisTestQueue / TestRedisQueue* pattern; they need no MySQL/IM.
+      - Verified against a live stack: go test -tags integration ./internal/cardactiondispatch/
+        (unit + the 3 e2e orchestration tests) green against real MySQL 8 + Redis + WuKongIM
+        (built from source at tag v2.2.4-20260313). The pinned TestRedisQueueLeaseTokenRetryDLQAndReplay
+        (markerless reclaim → attempt 2) still passes, confirming delivery accounting is untouched.
+  - id: commit-style
+    tier: repo
+    load_bearing: false
+    applied:
+      - Two Conventional Commits, English bodies, one per issue:
+        fix(cardaction): refund leaked attempt on reclaim of route-missing deferred lease (Fixes #623)
+        fix(cardaction): reject a LiveTTL below the route-missing defer floor (Fixes #624)
+      - Each issue linked in its commit footer (Fixes #62x); one PR for both (same file,
+        same subsystem), each fix independently reviewable as its own commit.
+
+notes:
+  - error-handling / i18n rule does NOT match: its paths are modules/**, pkg/errcode/**,
+    pkg/**/httperr/** — internal/** is excluded, and NewRedisQueue returns a plain Go error
+    surfaced at server boot (main.go), not a user-facing HTTP response. No error codes, no
+    make i18n-* required.
+  - trust-boundary rule does NOT match (adapter/webhook/richtext paths only).
+  - Design choice #623 (marker-gated reclaim refund vs atomic Lua transition): the issue lists
+    both. The refund is the option that actually addresses the leak — the speculative +1 happens
+    at CLAIM, before any transition, so folding RouteMissingSeenAt+Defer would only narrow a
+    sub-window while leaving the claim→transition window open. Gating the refund on the durable
+    route_missing_since marker is a faithful implementation of the issue's "undo the increment for
+    non-delivery (deferred) leases" — the marker is the only durable discriminator between a
+    deferred lease and a delivery lease.
+  - Residual (documented, accepted): a crash in the first-cycle window BEFORE the first marker is
+    written (claim → first RouteMissingSeenAt) can still leak at most ONE increment per
+    route-missing episode. The marker persists for the rest of the episode (cleared only on
+    Ack/terminal-Nack/replay), so subsequent cycles are protected. One increment is far below
+    MaxAttempts (typically 3–5) over a minutes-long, rare episode — acceptable for a P2.
+  - Edge (benign): an event that WAS route-missing then delivers (route returned) still carries
+    the marker until Ack/Nack clears it; if that delivery attempt's worker crashes and is reclaimed,
+    the refund fires on what was a delivery try. This only helps such an already-degraded event
+    start its retry fresh; the consumer is idempotent, so it is safe, and a poison event that crashes
+    the process on a plain HTTP callback is implausible.
+  - Design choice #624: floor = 4 × routeMissingDeferInterval (20s). The bare-correctness floor is
+    1× (survive to the due instant); 4× is a comfort margin so the event can actually be claimed and
+    processed after becoming due, not merely survive. Only rejects seconds-scale configs, which are
+    already broken for card messaging. queue.go references routeMissingDeferInterval (dispatcher.go,
+    same package) — a minor layering coupling, justified because the queue's TTL must accommodate the
+    dispatcher's defer cadence.
+  - The coverage bounds test (TestDecisionAndQueueInputBounds) constructed its "bounds" queue with
+    LiveTTL: time.Second; bumped to time.Minute to respect the new floor (that value was an
+    artificially small TTL the new invariant forbids, not a behavior the test was asserting).

--- a/.octospec/tasks/card-action-dispatch-defer-hardening/context.yaml
+++ b/.octospec/tasks/card-action-dispatch-defer-hardening/context.yaml
@@ -91,6 +91,20 @@ notes:
     TestRoutePresentClearsRouteMissingMarkerBeforeDelivery (dispatcher wiring: route-present dispatch
     clears the marker, then delivers + acks). The two other reviewers (lml2468, Octo-Q) APPROVED; the
     lml2468 review ran a negative control (removing the refund block fails the #623 reproducer).
+  - PR #662 re-review at fe386b40: all four reviewers (lml2468, Jerry-Xin, Octo-Q, yujiawei) APPROVED
+    the marker-clear fix. Three non-blocking P2 hardening notes were left; handling:
+    (a) FOLDED IN — ClearRouteMissing's bool return was discarded, so a token-mismatch (lease
+    reclaimed + re-leased before delivery) let a stale worker run a wasted Deliver/Finalize whose
+    terminal Ack fails as ack_lost. ProcessOne now bails on !cleared with a lease-ownership-lost error,
+    mirroring the Defer paths. Test: TestRoutePresentLeaseLostBeforeDeliveryDoesNotDeliver.
+    (b) FOLDED IN — reworded the reclaim comment: the pre-first-marker leak is "that cycle's +1", not
+    strictly "one per episode" (a pathological loop that dies before every marker write leaks per such
+    cycle; worst case still a recoverable DLQ entry, never silent loss).
+    (c) FOLLOW-UP ISSUE — token-guard the RouteMissingSeenAt marker WRITE too (routeMissingSinceScript),
+    symmetric to the token-guarded clear, closing an astronomically narrow re-plant corner (in-flight
+    marker write reordered past a lease expiry + reclaim + re-claim + route recovery + delivery crash).
+    Deferred per the reviewers' own "follow-up issue, not a merge blocker" framing; it is a signature
+    change (RouteMissingSeenAt gains a token param + interface + fakes + Lua).
   - Design choice #624: floor = 4 × routeMissingDeferInterval (20s). The bare-correctness floor is
     1× (survive to the due instant); 4× is a comfort margin so the event can actually be claimed and
     processed after becoming due, not merely survive. Only rejects seconds-scale configs, which are

--- a/internal/cardactiondispatch/coverage_test.go
+++ b/internal/cardactiondispatch/coverage_test.go
@@ -137,7 +137,9 @@ func TestDecisionAndQueueInputBounds(t *testing.T) {
 	if _, err := NewRedisQueue(client, QueueConfig{Prefix: "bad prefix", LiveTTL: time.Second, DLQRetention: time.Second}); err == nil {
 		t.Fatal("NewRedisQueue(bad prefix) error = nil")
 	}
-	queue, err := NewRedisQueue(client, QueueConfig{Prefix: "bounds", LiveTTL: time.Second, DLQRetention: time.Second})
+	// LiveTTL must clear minLiveTTL (see TestNewRedisQueueRejectsLiveTTLBelowDeferFloor); a
+	// second-scale TTL is a pathological config the constructor now rejects outright.
+	queue, err := NewRedisQueue(client, QueueConfig{Prefix: "bounds", LiveTTL: time.Minute, DLQRetention: time.Second})
 	if err != nil {
 		t.Fatalf("NewRedisQueue() error = %v", err)
 	}
@@ -152,6 +154,43 @@ func TestDecisionAndQueueInputBounds(t *testing.T) {
 	}
 	if _, err := queue.ReclaimExpired(time.Now(), 0); err == nil {
 		t.Fatal("ReclaimExpired(zero limit) error = nil")
+	}
+}
+
+// TestNewRedisQueueRejectsLiveTTLBelowDeferFloor pins the LiveTTL guard. A deferred event is
+// rescheduled up to routeMissingDeferInterval ahead and its keys are PEXPIRE'd to LiveTTL, so a
+// LiveTTL that does not comfortably clear that interval could let a deferred key expire before the
+// event becomes claimable — silently dropping it. The constructor now rejects such a config so it
+// fails fast at boot rather than at runtime. LiveTTL is Robot.MessageExpire (7-day default), so
+// this only ever fires on a pathological value.
+func TestNewRedisQueueRejectsLiveTTLBelowDeferFloor(t *testing.T) {
+	client := rd.NewClient(&rd.Options{Addr: "127.0.0.1:1"})
+	defer client.Close()
+
+	rejected := []struct {
+		name    string
+		liveTTL time.Duration
+	}{
+		{"equal to the defer interval", routeMissingDeferInterval},
+		{"just below the floor", minLiveTTL - time.Nanosecond},
+	}
+	for _, tc := range rejected {
+		if _, err := NewRedisQueue(client, QueueConfig{Prefix: "p", LiveTTL: tc.liveTTL, DLQRetention: time.Hour}); err == nil {
+			t.Fatalf("NewRedisQueue(LiveTTL %s: %s) error = nil, want a floor rejection", tc.liveTTL, tc.name)
+		}
+	}
+
+	accepted := []struct {
+		name    string
+		liveTTL time.Duration
+	}{
+		{"exactly at the floor", minLiveTTL},
+		{"comfortably above the floor", time.Hour},
+	}
+	for _, tc := range accepted {
+		if _, err := NewRedisQueue(client, QueueConfig{Prefix: "p", LiveTTL: tc.liveTTL, DLQRetention: time.Hour}); err != nil {
+			t.Fatalf("NewRedisQueue(LiveTTL %s: %s) error = %v, want success", tc.liveTTL, tc.name, err)
+		}
 	}
 }
 

--- a/internal/cardactiondispatch/coverage_test.go
+++ b/internal/cardactiondispatch/coverage_test.go
@@ -36,6 +36,7 @@ func (q *idleDispatchQueue) ReclaimExpired(time.Time, int) (int, error) {
 func (*idleDispatchQueue) RouteMissingSeenAt(_ int64, now time.Time) (time.Time, error) {
 	return now, nil
 }
+func (*idleDispatchQueue) ClearRouteMissing(int64, string) (bool, error) { return true, nil }
 
 func TestDispatcherLifecycleStartsStopsAndRejectsDoubleStart(t *testing.T) {
 	registry, err := NewRegistry([]RouteSpec{validRouteSpec()}, testGetenv)

--- a/internal/cardactiondispatch/dispatcher.go
+++ b/internal/cardactiondispatch/dispatcher.go
@@ -22,6 +22,10 @@ type dispatchQueue interface {
 	// observed missing at dispatch, so the bounded route-missing window is measured from
 	// that point rather than from Event.ActedAt.
 	RouteMissingSeenAt(eventID int64, now time.Time) (time.Time, error)
+	// ClearRouteMissing removes the route-missing first-seen marker once the route has
+	// resolved, so a lease that proceeds to delivery is reclaimed as a delivery attempt
+	// (preserving the MaxAttempts bound) rather than refunded as a defer.
+	ClearRouteMissing(eventID int64, token string) (bool, error)
 }
 
 type callbackDeliverer interface {
@@ -176,6 +180,17 @@ func (d *Dispatcher) ProcessOne(ctx context.Context, now time.Time) (bool, error
 		resultLabel = "deferred"
 		d.refreshDepthMetrics()
 		return true, nil
+	}
+	// The route resolved: this event is no longer route-missing, so drop its first-seen marker
+	// (token-protected) before delivery. Otherwise a once-route-missing event that reaches Deliver
+	// still carries the marker, and a hard crash during delivery (no Ack/Nack) would be reclaimed as
+	// a refunded defer — asymmetrically exempting it from the MaxAttempts bound. Clearing it here makes
+	// a delivery-phase crash advance the attempt like any delivery lease. A miss (route absent) never
+	// reaches this line, so the marker it needs for the defer loop is untouched.
+	if _, err := d.queue.ClearRouteMissing(lease.Event.EventID, lease.Token); err != nil {
+		d.metrics.observeError(owner, "queue_error")
+		d.refreshDepthMetrics()
+		return true, err
 	}
 	if lease.Attempt > route.MaxAttempts {
 		const category = "attempts_exhausted"

--- a/internal/cardactiondispatch/dispatcher.go
+++ b/internal/cardactiondispatch/dispatcher.go
@@ -187,10 +187,20 @@ func (d *Dispatcher) ProcessOne(ctx context.Context, now time.Time) (bool, error
 	// a refunded defer — asymmetrically exempting it from the MaxAttempts bound. Clearing it here makes
 	// a delivery-phase crash advance the attempt like any delivery lease. A miss (route absent) never
 	// reaches this line, so the marker it needs for the defer loop is untouched.
-	if _, err := d.queue.ClearRouteMissing(lease.Event.EventID, lease.Token); err != nil {
+	cleared, clearErr := d.queue.ClearRouteMissing(lease.Event.EventID, lease.Token)
+	if clearErr != nil {
 		d.metrics.observeError(owner, "queue_error")
 		d.refreshDepthMetrics()
-		return true, err
+		return true, clearErr
+	}
+	if !cleared {
+		// The token no longer matches: this lease expired and was reclaimed + re-leased to another
+		// worker (or already terminated). Bail before doing a wasted Deliver/Finalize whose terminal
+		// Ack would fail as ack_lost anyway; the current owner will process the event. This mirrors the
+		// lease-ownership-lost handling on the Defer paths above.
+		d.metrics.observeError(owner, "ack_lost")
+		d.refreshDepthMetrics()
+		return true, errors.New("cardactiondispatch: lease ownership lost before delivery")
 	}
 	if lease.Attempt > route.MaxAttempts {
 		const category = "attempts_exhausted"

--- a/internal/cardactiondispatch/dispatcher_test.go
+++ b/internal/cardactiondispatch/dispatcher_test.go
@@ -29,6 +29,9 @@ type concurrentLeaseQueue struct {
 	// cleared receives an event id each time ClearRouteMissing is called, so a test can assert the
 	// dispatcher drops the marker on the route-present path before delivery.
 	cleared chan int64
+	// clearRouteMissingLost makes ClearRouteMissing report lease loss (false) so a test can drive the
+	// token-mismatch path in ProcessOne (lease reclaimed + re-leased before delivery).
+	clearRouteMissingLost bool
 }
 
 type nackCall struct {
@@ -105,6 +108,9 @@ func (q *concurrentLeaseQueue) RouteMissingSeenAt(eventID int64, now time.Time) 
 	return now, nil
 }
 func (q *concurrentLeaseQueue) ClearRouteMissing(eventID int64, _ string) (bool, error) {
+	if q.clearRouteMissingLost {
+		return false, nil
+	}
 	q.mu.Lock()
 	delete(q.routeMissingSince, eventID)
 	q.mu.Unlock()

--- a/internal/cardactiondispatch/dispatcher_test.go
+++ b/internal/cardactiondispatch/dispatcher_test.go
@@ -26,6 +26,9 @@ type concurrentLeaseQueue struct {
 	// entry to simulate an event that has already waited (→ past the window); otherwise the
 	// first RouteMissingSeenAt call stamps `now`, mirroring the real HSETNX-then-read.
 	routeMissingSince map[int64]time.Time
+	// cleared receives an event id each time ClearRouteMissing is called, so a test can assert the
+	// dispatcher drops the marker on the route-present path before delivery.
+	cleared chan int64
 }
 
 type nackCall struct {
@@ -100,6 +103,15 @@ func (q *concurrentLeaseQueue) RouteMissingSeenAt(eventID int64, now time.Time) 
 	}
 	q.routeMissingSince[eventID] = now
 	return now, nil
+}
+func (q *concurrentLeaseQueue) ClearRouteMissing(eventID int64, _ string) (bool, error) {
+	q.mu.Lock()
+	delete(q.routeMissingSince, eventID)
+	q.mu.Unlock()
+	if q.cleared != nil {
+		q.cleared <- eventID
+	}
+	return true, nil
 }
 
 type capturingDeliverer struct {

--- a/internal/cardactiondispatch/queue.go
+++ b/internal/cardactiondispatch/queue.go
@@ -144,12 +144,30 @@ for i = 1, 5 do redis.call('PEXPIRE', KEYS[i], ARGV[6]) end
 return 1
 `)
 
+// reclaimScript requeues leases whose expiry passed without an Ack/Nack/Defer (a crashed,
+// hung, or errored worker), so a dropped lease can never wedge an event in the leased set.
+// KEYS[9] is the route_missing_since marker. When the reclaimed lease belonged to an event
+// still in the route-missing defer loop, refund the claim's speculative attempt +1: claimScript
+// increments on every claim and only a completed Defer restores it (a claim->Defer re-check cycle
+// is net-zero), so a crash / Redis error / lease expiry in the window BETWEEN claim and Defer
+// would otherwise leak that +1. Across many self-heal cycles the counter creeps up until the
+// event reads attempt > MaxAttempts and dead-letters as attempts_exhausted on a route it never
+// got to try. The refund (floored at 0) makes a reclaimed defer cycle net-zero too. It is gated
+// on the marker so DELIVERY leases — which carry no marker and whose attempt legitimately counts a
+// real delivery try that bounds retries — are untouched (see TestRedisQueueLeaseTokenRetryDLQAndReplay,
+// where a markerless reclaim still advances to attempt 2). A single miss window before the first
+// marker is written (claim -> first RouteMissingSeenAt) can still leak at most one increment per
+// route-missing episode, which never approaches MaxAttempts over a minutes-long episode.
 var reclaimScript = rd.NewScript(`
 local ids = redis.call('ZRANGEBYSCORE', KEYS[2], '-inf', ARGV[1], 'LIMIT', 0, ARGV[2])
 for _, id in ipairs(ids) do
   if redis.call('ZREM', KEYS[2], id) == 1 then
     redis.call('HDEL', KEYS[5], id)
     if redis.call('HEXISTS', KEYS[3], id) == 1 then
+      if redis.call('HEXISTS', KEYS[9], id) == 1 then
+        local attempt = tonumber(redis.call('HGET', KEYS[4], id) or '0')
+        if attempt > 0 then redis.call('HINCRBY', KEYS[4], id, -1) end
+      end
       redis.call('ZADD', KEYS[1], ARGV[1], id)
     end
   end

--- a/internal/cardactiondispatch/queue.go
+++ b/internal/cardactiondispatch/queue.go
@@ -155,9 +155,11 @@ return 1
 // got to try. The refund (floored at 0) makes a reclaimed defer cycle net-zero too. It is gated
 // on the marker so DELIVERY leases — which carry no marker and whose attempt legitimately counts a
 // real delivery try that bounds retries — are untouched (see TestRedisQueueLeaseTokenRetryDLQAndReplay,
-// where a markerless reclaim still advances to attempt 2). A single miss window before the first
-// marker is written (claim -> first RouteMissingSeenAt) can still leak at most one increment per
-// route-missing episode, which never approaches MaxAttempts over a minutes-long episode.
+// where a markerless reclaim still advances to attempt 2). A crash before the first marker is written
+// (claim -> first RouteMissingSeenAt) leaks that cycle's +1, since reclaim then finds no marker;
+// normally the marker persists across the rest of the episode so only the first cycle is exposed (one
+// increment), and even a pathological loop that dies before every marker write yields at worst a
+// recoverable DLQ entry (attempts_exhausted, replayable) rather than silent loss.
 var reclaimScript = rd.NewScript(`
 local ids = redis.call('ZRANGEBYSCORE', KEYS[2], '-inf', ARGV[1], 'LIMIT', 0, ARGV[2])
 for _, id in ipairs(ids) do

--- a/internal/cardactiondispatch/queue.go
+++ b/internal/cardactiondispatch/queue.go
@@ -219,11 +219,16 @@ return #expired
 // first miss stamps now, later misses read the stored stamp, so the bounded route-missing
 // window is measured from the FIRST miss (not from Event.ActedAt). The marker is explicitly
 // removed on every exit transition — ackScript, nackScript (both requeue and dead-letter),
-// and replayDLQScript all HDEL the field — so the hash only ever holds markers for events
-// currently waiting in the route-missing defer loop and CANNOT grow unbounded under sustained
-// route-missing traffic (a whole-hash PEXPIRE cannot expire individual fields, so relying on
-// TTL alone would leak). The hash-level TTL refreshed here to liveTTL is only a backstop that
-// reaps the whole key once misses stop.
+// and replayDLQScript all HDEL the field — so in the normal case the hash only holds markers
+// for events currently waiting in the route-missing defer loop. That is not a guarantee: this
+// write is NOT fenced by the lease token, so a stalled call that lands after its event already
+// terminated re-plants a field no exit transition will ever run to reap again, while the
+// PEXPIRE below keeps pushing the whole key's expiry out under sustained traffic. Orphan
+// accumulation is slow and needs an in-flight write reordered past a lease loss, but it is
+// possible — tracked together with the related refund corner in #680. Absent that corner the
+// hash-level TTL refreshed here to liveTTL is only a backstop that reaps the whole key once
+// misses stop (a whole-hash PEXPIRE cannot expire individual fields, so relying on TTL alone
+// would leak).
 var routeMissingSinceScript = rd.NewScript(`
 local v = redis.call('HGET', KEYS[1], ARGV[1])
 if not v then
@@ -245,15 +250,24 @@ redis.call('HDEL', KEYS[9], ARGV[1])
 return 1
 `)
 
-// minLiveTTL is the smallest LiveTTL NewRedisQueue accepts. A deferred event (a route-missing
-// re-check, or capacity backpressure) is re-scheduled up to routeMissingDeferInterval into the
-// future, and every queue operation PEXPIREs the event's ready/payload keys to LiveTTL. If LiveTTL
-// did not comfortably exceed that defer interval, a deferred key could expire BEFORE the event
-// became claimable — silently dropping the event instead of delivering it. The margin (4×) leaves
-// room to actually claim and process the event after it becomes due, not merely to survive to the
-// due instant. LiveTTL is Robot.MessageExpire, which defaults to 7 days and can never sensibly sit
-// in the seconds range (no user acts on a card that fast), so this only rejects a pathological
-// config — failing fast at construction (server boot) rather than dropping events at runtime.
+// minLiveTTL is the smallest LiveTTL NewRedisQueue accepts. It bounds exactly ONE window: a
+// route-missing re-check is re-scheduled routeMissingDeferInterval ahead while every queue
+// operation PEXPIREs the event's ready/payload keys to LiveTTL, so a LiveTTL at or below that
+// interval could let the deferred key expire BEFORE the event became claimable — silently
+// dropping it instead of delivering it. The margin (4×) leaves room to actually claim and
+// process the event after it becomes due, not merely to survive to the due instant.
+//
+// It deliberately does NOT establish that invariant for every schedule-ahead window in this
+// subsystem, and must not be read as doing so. Three others can exceed it: nackScript requeues
+// at now+retryBackoff (bounded by route.MaxBackoff — 1m by default, accepted up to 10m by
+// registry.go), the capacity-defer path re-schedules at now+DispatcherConfig.PollInterval (only
+// validated > 0, no upper bound), and DispatcherConfig.LeaseDuration defaults to 30s. Covering
+// those belongs in a cross-config check at dispatcher construction, where the values are known —
+// widening this constant to their ceiling would instead reject otherwise-valid
+// seconds-to-minutes configs. LiveTTL is Robot.MessageExpire, which defaults to 7 days and can
+// never sensibly sit in the seconds range (no user acts on a card that fast), so in practice
+// every real config clears all four; this floor only fails a pathological one fast at
+// construction (server boot) rather than dropping events at runtime.
 const minLiveTTL = 4 * routeMissingDeferInterval
 
 func NewRedisQueue(client *rd.Client, cfg QueueConfig) (*RedisQueue, error) {
@@ -267,7 +281,7 @@ func NewRedisQueue(client *rd.Client, cfg QueueConfig) (*RedisQueue, error) {
 		return nil, errors.New("cardactiondispatch: queue retention must be positive")
 	}
 	if cfg.LiveTTL < minLiveTTL {
-		return nil, fmt.Errorf("cardactiondispatch: LiveTTL %s is below the %s floor required to outlast the route-missing defer interval (%s); a deferred event could expire before it becomes claimable",
+		return nil, fmt.Errorf("cardactiondispatch: LiveTTL %s is below the %s floor required to outlast the route-missing defer interval (%s); a route-missing deferred event could expire before it becomes claimable",
 			cfg.LiveTTL, minLiveTTL, routeMissingDeferInterval)
 	}
 	base := cfg.Prefix + ":{queue}:"

--- a/internal/cardactiondispatch/queue.go
+++ b/internal/cardactiondispatch/queue.go
@@ -232,6 +232,17 @@ redis.call('PEXPIRE', KEYS[1], ARGV[3])
 return v
 `)
 
+// clearRouteMissingScript removes an event's route-missing first-seen marker once its route has
+// resolved at dispatch, so a lease that proceeds to delivery no longer looks like a deferred lease
+// to reclaimScript. It is token-protected (KEYS[5] = tokens): only the current lease owner may clear
+// the marker, so a stale worker whose lease was already reclaimed and re-leased cannot strip a marker
+// the newer owner still needs. KEYS[9] = route_missing_since. ARGV[1] = event_id, ARGV[2] = token.
+var clearRouteMissingScript = rd.NewScript(`
+if redis.call('HGET', KEYS[5], ARGV[1]) ~= ARGV[2] then return 0 end
+redis.call('HDEL', KEYS[9], ARGV[1])
+return 1
+`)
+
 // minLiveTTL is the smallest LiveTTL NewRedisQueue accepts. A deferred event (a route-missing
 // re-check, or capacity backpressure) is re-scheduled up to routeMissingDeferInterval into the
 // future, and every queue operation PEXPIREs the event's ready/payload keys to LiveTTL. If LiveTTL
@@ -466,6 +477,23 @@ func (q *RedisQueue) RouteMissingSeenAt(eventID int64, now time.Time) (time.Time
 		return time.Time{}, fmt.Errorf("cardactiondispatch: record route-missing first-seen: %w", err)
 	}
 	return time.UnixMilli(ms), nil
+}
+
+// ClearRouteMissing removes the durable route-missing first-seen marker for an event whose route has
+// resolved at dispatch. Once the route is present the event is no longer route-missing, so its lease
+// must be treated as a delivery lease by ReclaimExpired: without this, a once-route-missing event that
+// reaches delivery still carries the marker, and a hard crash during delivery (no Ack/Nack runs) would
+// have reclaimScript refund its attempt as though it were still a defer cycle — asymmetrically exempting
+// it from the MaxAttempts bound. Clearing the marker here makes a delivery-phase crash advance the
+// attempt like any delivery lease. Token-protected so only the current lease owner clears it; returns
+// true when this worker owned the lease.
+func (q *RedisQueue) ClearRouteMissing(eventID int64, token string) (bool, error) {
+	value, err := clearRouteMissingScript.Run(q.client, q.scriptKeys(),
+		strconv.FormatInt(eventID, 10), token).Int()
+	if err != nil {
+		return false, fmt.Errorf("cardactiondispatch: clear route-missing marker: %w", err)
+	}
+	return value == 1, nil
 }
 
 func newLeaseToken() (string, error) {

--- a/internal/cardactiondispatch/queue.go
+++ b/internal/cardactiondispatch/queue.go
@@ -232,6 +232,17 @@ redis.call('PEXPIRE', KEYS[1], ARGV[3])
 return v
 `)
 
+// minLiveTTL is the smallest LiveTTL NewRedisQueue accepts. A deferred event (a route-missing
+// re-check, or capacity backpressure) is re-scheduled up to routeMissingDeferInterval into the
+// future, and every queue operation PEXPIREs the event's ready/payload keys to LiveTTL. If LiveTTL
+// did not comfortably exceed that defer interval, a deferred key could expire BEFORE the event
+// became claimable — silently dropping the event instead of delivering it. The margin (4×) leaves
+// room to actually claim and process the event after it becomes due, not merely to survive to the
+// due instant. LiveTTL is Robot.MessageExpire, which defaults to 7 days and can never sensibly sit
+// in the seconds range (no user acts on a card that fast), so this only rejects a pathological
+// config — failing fast at construction (server boot) rather than dropping events at runtime.
+const minLiveTTL = 4 * routeMissingDeferInterval
+
 func NewRedisQueue(client *rd.Client, cfg QueueConfig) (*RedisQueue, error) {
 	if client == nil {
 		return nil, errors.New("cardactiondispatch: Redis client is required")
@@ -241,6 +252,10 @@ func NewRedisQueue(client *rd.Client, cfg QueueConfig) (*RedisQueue, error) {
 	}
 	if cfg.LiveTTL <= 0 || cfg.DLQRetention <= 0 {
 		return nil, errors.New("cardactiondispatch: queue retention must be positive")
+	}
+	if cfg.LiveTTL < minLiveTTL {
+		return nil, fmt.Errorf("cardactiondispatch: LiveTTL %s is below the %s floor required to outlast the route-missing defer interval (%s); a deferred event could expire before it becomes claimable",
+			cfg.LiveTTL, minLiveTTL, routeMissingDeferInterval)
 	}
 	base := cfg.Prefix + ":{queue}:"
 	return &RedisQueue{

--- a/internal/cardactiondispatch/route_missing_queue_test.go
+++ b/internal/cardactiondispatch/route_missing_queue_test.go
@@ -261,3 +261,60 @@ func TestReclaimRefundsRouteMissingDeferAttemptLeak(t *testing.T) {
 		}
 	})
 }
+
+// TestClearRouteMissingRestoresDeliveryReclaimBound pins the fix for the marker-discriminator gap:
+// the route_missing_since marker is cleared only on Ack/Nack/replay, so a once-route-missing event
+// whose route RETURNS still carries the marker while it delivers. Without clearing it on route
+// resolution, a hard crash during that delivery (no Ack/Nack) would have ReclaimExpired refund the
+// attempt — asymmetrically exempting the event from the MaxAttempts bound. ClearRouteMissing drops
+// the marker (token-protected) the moment the route resolves, so a delivery-phase crash reclaims as
+// a real attempt (the attempt advances) like any delivery lease.
+func TestClearRouteMissingRestoresDeliveryReclaimBound(t *testing.T) {
+	queue, client := newRedisTestQueue(t, "card_action_clear_marker")
+	event := testDispatchEvent()
+	event.EventID = 6230003
+	field := strconv.FormatInt(event.EventID, 10)
+	now := time.Now().Truncate(time.Millisecond)
+
+	if err := queue.Enqueue(event, now); err != nil {
+		t.Fatalf("Enqueue() error = %v", err)
+	}
+	lease, err := queue.Claim(now, time.Second)
+	if err != nil || lease == nil || lease.Attempt != 1 {
+		t.Fatalf("Claim() = (%+v, %v), want attempt 1", lease, err)
+	}
+	// The event was route-missing (marker set); then its route returned.
+	if _, err := queue.RouteMissingSeenAt(event.EventID, now); err != nil {
+		t.Fatalf("RouteMissingSeenAt() error = %v", err)
+	}
+
+	// A stale worker (wrong token) must NOT be able to clear the marker.
+	if cleared, err := queue.ClearRouteMissing(event.EventID, "wrong-token"); err != nil || cleared {
+		t.Fatalf("ClearRouteMissing(wrong token) = (%v, %v), want (false, nil)", cleared, err)
+	}
+	if exists, _ := client.HExists(queue.keys.routeMissingSince, field).Result(); !exists {
+		t.Fatal("marker cleared by a non-owner; the clear must be token-protected")
+	}
+
+	// The lease owner clears it on route resolution.
+	if cleared, err := queue.ClearRouteMissing(event.EventID, lease.Token); err != nil || !cleared {
+		t.Fatalf("ClearRouteMissing(owner) = (%v, %v), want (true, nil)", cleared, err)
+	}
+	if exists, _ := client.HExists(queue.keys.routeMissingSince, field).Result(); exists {
+		t.Fatal("marker still present after ClearRouteMissing by the lease owner")
+	}
+
+	// Simulate a hard crash during delivery: the lease (1s) expires and is reclaimed. With the marker
+	// gone the event is treated as a real delivery attempt, so the attempt ADVANCES to 2 (bound
+	// preserved) instead of being refunded to 1.
+	if reclaimed, err := queue.ReclaimExpired(now.Add(2*time.Second), 10); err != nil || reclaimed != 1 {
+		t.Fatalf("ReclaimExpired() = (%d, %v), want (1, nil)", reclaimed, err)
+	}
+	lease, err = queue.Claim(now.Add(2*time.Second), time.Second)
+	if err != nil || lease == nil {
+		t.Fatalf("re-Claim() = (%+v, %v)", lease, err)
+	}
+	if lease.Attempt != 2 {
+		t.Fatalf("attempt after reclaiming a delivery lease whose route-missing marker was cleared = %d, want 2 (the MaxAttempts bound must be preserved once the route returns)", lease.Attempt)
+	}
+}

--- a/internal/cardactiondispatch/route_missing_queue_test.go
+++ b/internal/cardactiondispatch/route_missing_queue_test.go
@@ -178,3 +178,86 @@ func TestRouteMissingMarkerClearedOnTerminalTransitions(t *testing.T) {
 		t.Fatal("route-missing marker still present after terminal dead-letter; it must be cleared on DLQ")
 	}
 }
+
+// TestReclaimRefundsRouteMissingDeferAttemptLeak pins the fix for the claim->Defer attempt leak.
+// claimScript speculatively increments the attempt on every claim and only a completed Defer
+// restores it, so a crash / Redis error / lease expiry BETWEEN claim and Defer during a
+// route-missing self-heal cycle would strand that +1: ReclaimExpired requeues the event but the
+// increment was never undone, and across cycles the counter creeps up until the event trips
+// attempts_exhausted on a route it never got to try. ReclaimExpired now refunds the increment for a
+// reclaimed lease that still carries a route_missing_since marker (the durable signal that the event
+// is in the defer loop), making a reclaimed defer cycle net-zero — while leaving DELIVERY leases
+// (no marker) counting their attempt, since that bounds real delivery retries.
+func TestReclaimRefundsRouteMissingDeferAttemptLeak(t *testing.T) {
+	t.Run("route-missing deferred lease is refunded on reclaim", func(t *testing.T) {
+		queue, client := newRedisTestQueue(t, "card_action_reclaim_refund")
+		event := testDispatchEvent()
+		event.EventID = 6230001
+		field := strconv.FormatInt(event.EventID, 10)
+		now := time.Now().Truncate(time.Millisecond)
+
+		if err := queue.Enqueue(event, now); err != nil {
+			t.Fatalf("Enqueue() error = %v", err)
+		}
+		lease, err := queue.Claim(now, time.Second)
+		if err != nil || lease == nil || lease.Attempt != 1 {
+			t.Fatalf("Claim() = (%+v, %v), want attempt 1", lease, err)
+		}
+		// The dispatcher stamps the first-miss marker before it would Defer. Simulate a crash in the
+		// window AFTER that stamp but BEFORE Defer: the marker is set, the lease is never released.
+		if _, err := queue.RouteMissingSeenAt(event.EventID, now); err != nil {
+			t.Fatalf("RouteMissingSeenAt() error = %v", err)
+		}
+
+		// The lease (1s) has expired by now+2s; reclaim requeues it and, seeing the marker, refunds
+		// the orphaned +1.
+		if reclaimed, err := queue.ReclaimExpired(now.Add(2*time.Second), 10); err != nil || reclaimed != 1 {
+			t.Fatalf("ReclaimExpired() = (%d, %v), want (1, nil)", reclaimed, err)
+		}
+		attempts, err := client.HGet(queue.keys.attempts, field).Int()
+		if err != nil {
+			t.Fatalf("HGet(attempts) error = %v", err)
+		}
+		if attempts != 0 {
+			t.Fatalf("attempts after reclaim = %d, want 0 (the crashed claim's +1 must be refunded)", attempts)
+		}
+
+		// The next claim re-consumes exactly one attempt, so the event is back to attempt 1 — NOT 2.
+		// Without the refund it would read attempt 2, and enough such cycles trip attempts_exhausted.
+		lease, err = queue.Claim(now.Add(2*time.Second), time.Second)
+		if err != nil || lease == nil {
+			t.Fatalf("re-Claim() = (%+v, %v)", lease, err)
+		}
+		if lease.Attempt != 1 {
+			t.Fatalf("attempt after reclaiming a route-missing deferred lease = %d, want 1 (the defer cycle must be net-zero even across a crash)", lease.Attempt)
+		}
+	})
+
+	t.Run("delivery lease without a marker keeps its attempt on reclaim", func(t *testing.T) {
+		queue, _ := newRedisTestQueue(t, "card_action_reclaim_keeps")
+		event := testDispatchEvent()
+		event.EventID = 6230002
+		now := time.Now().Truncate(time.Millisecond)
+
+		if err := queue.Enqueue(event, now); err != nil {
+			t.Fatalf("Enqueue() error = %v", err)
+		}
+		lease, err := queue.Claim(now, time.Second)
+		if err != nil || lease == nil || lease.Attempt != 1 {
+			t.Fatalf("Claim() = (%+v, %v), want attempt 1", lease, err)
+		}
+		// No RouteMissingSeenAt: this is an ordinary delivery lease whose worker crashed. Its attempt
+		// legitimately counts a real delivery try and must survive reclaim so MaxAttempts still bounds
+		// retries (mirrors the pinned TestRedisQueueLeaseTokenRetryDLQAndReplay contract).
+		if reclaimed, err := queue.ReclaimExpired(now.Add(2*time.Second), 10); err != nil || reclaimed != 1 {
+			t.Fatalf("ReclaimExpired() = (%d, %v), want (1, nil)", reclaimed, err)
+		}
+		lease, err = queue.Claim(now.Add(2*time.Second), time.Second)
+		if err != nil || lease == nil {
+			t.Fatalf("re-Claim() = (%+v, %v)", lease, err)
+		}
+		if lease.Attempt != 2 {
+			t.Fatalf("attempt after reclaiming a markerless delivery lease = %d, want 2 (delivery retries must still be bounded)", lease.Attempt)
+		}
+	})
+}

--- a/internal/cardactiondispatch/route_missing_test.go
+++ b/internal/cardactiondispatch/route_missing_test.go
@@ -193,6 +193,62 @@ func TestRouteMissingOldActedAtDefersOnFirstMiss(t *testing.T) {
 	}
 }
 
+// TestRoutePresentClearsRouteMissingMarkerBeforeDelivery pins the wiring for the delivery-bound fix
+// (Jerry-Xin, #662 review): when the route resolves at dispatch, ProcessOne must drop the
+// route_missing_since marker so a subsequent hard crash during delivery is reclaimed as a real
+// attempt (bound preserved), not refunded as a defer. Here the marker is pre-seeded (the event was
+// route-missing earlier); once the route is present the dispatcher clears it, then delivers and acks.
+func TestRoutePresentClearsRouteMissingMarkerBeforeDelivery(t *testing.T) {
+	registry, err := NewRegistry([]RouteSpec{validRouteSpec()}, testGetenv)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	event := testDispatchEvent()
+	deliverer := callbackDelivererFunc(func(context.Context, *Route, DecisionRequest) (DecisionResult, error) {
+		return DecisionResult{Disposition: DispositionApplied, State: StateApproved}, nil
+	})
+	finalizer := FinalizerFunc(func(context.Context, Event, DecisionResult) error { return nil })
+	queue := &concurrentLeaseQueue{
+		leases:  []Lease{{Event: event, Token: "lease-clear", Attempt: 1}},
+		acked:   make(chan int64, 1),
+		cleared: make(chan int64, 1),
+		// Pre-seed the marker: this event was route-missing before its route returned.
+		routeMissingSince: map[int64]time.Time{event.EventID: time.Now()},
+	}
+	dispatcher, err := NewDispatcher(queue, registry, deliverer, finalizer, DispatcherConfig{
+		LeaseDuration: time.Second,
+		PollInterval:  time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("NewDispatcher() error = %v", err)
+	}
+
+	processed, procErr := dispatcher.ProcessOne(context.Background(), time.Now())
+	if !processed || procErr != nil {
+		t.Fatalf("ProcessOne() = (%v, %v), want (true, nil)", processed, procErr)
+	}
+
+	select {
+	case id := <-queue.cleared:
+		if id != event.EventID {
+			t.Fatalf("cleared marker for event %d, want %d", id, event.EventID)
+		}
+	default:
+		t.Fatal("route-present dispatch did not clear the route_missing_since marker; a delivery crash would then be wrongly refunded")
+	}
+	queue.mu.Lock()
+	_, stillMarked := queue.routeMissingSince[event.EventID]
+	queue.mu.Unlock()
+	if stillMarked {
+		t.Fatal("route_missing_since marker still present after a route-present dispatch")
+	}
+	select {
+	case <-queue.acked:
+	default:
+		t.Fatal("event was not acked; the route-present path must still deliver after clearing the marker")
+	}
+}
+
 // TestRouteMissingExpired covers the window boundary. The window is anchored on the first
 // observed miss (firstSeen), so it is a pure elapsed-time check with no unset-timestamp edge.
 func TestRouteMissingExpired(t *testing.T) {

--- a/internal/cardactiondispatch/route_missing_test.go
+++ b/internal/cardactiondispatch/route_missing_test.go
@@ -249,6 +249,51 @@ func TestRoutePresentClearsRouteMissingMarkerBeforeDelivery(t *testing.T) {
 	}
 }
 
+// TestRoutePresentLeaseLostBeforeDeliveryDoesNotDeliver pins the lease-ownership bail on the
+// route-present path (#662 review, non-blocking): if ClearRouteMissing reports the token no longer
+// matches — the lease expired and was reclaimed + re-leased to another worker — ProcessOne must NOT
+// proceed to Deliver/Finalize (wasted work + a duplicate bot callback whose terminal Ack would fail
+// as ack_lost anyway); it bails with a lease-ownership-lost error, mirroring the Defer paths.
+func TestRoutePresentLeaseLostBeforeDeliveryDoesNotDeliver(t *testing.T) {
+	registry, err := NewRegistry([]RouteSpec{validRouteSpec()}, testGetenv)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	neverDeliver := callbackDelivererFunc(func(context.Context, *Route, DecisionRequest) (DecisionResult, error) {
+		t.Fatal("Deliver must not run once the lease is lost before delivery")
+		return DecisionResult{}, nil
+	})
+	neverFinalize := FinalizerFunc(func(context.Context, Event, DecisionResult) error {
+		t.Fatal("Finalize must not run once the lease is lost before delivery")
+		return nil
+	})
+	queue := &concurrentLeaseQueue{
+		leases:                []Lease{{Event: testDispatchEvent(), Token: "lease-lost", Attempt: 1}},
+		acked:                 make(chan int64, 1),
+		clearRouteMissingLost: true, // token mismatch: the lease was reclaimed + re-leased before delivery
+	}
+	dispatcher, err := NewDispatcher(queue, registry, neverDeliver, neverFinalize, DispatcherConfig{
+		LeaseDuration: time.Second,
+		PollInterval:  time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("NewDispatcher() error = %v", err)
+	}
+
+	processed, procErr := dispatcher.ProcessOne(context.Background(), time.Now())
+	if !processed {
+		t.Fatal("ProcessOne() processed = false, want true (a lost lease is still a handled event)")
+	}
+	if procErr == nil {
+		t.Fatal("ProcessOne() err = nil, want a lease-ownership-lost error before delivery")
+	}
+	select {
+	case <-queue.acked:
+		t.Fatal("a lost-lease event was acked; it must not deliver or ack")
+	default:
+	}
+}
+
 // TestRouteMissingExpired covers the window boundary. The window is anchored on the first
 // observed miss (firstSeen), so it is a pure elapsed-time check with no unset-timestamp edge.
 func TestRouteMissingExpired(t *testing.T) {


### PR DESCRIPTION
## Summary

Two defensive reliability fixes in the card-action dispatch queue
(`internal/cardactiondispatch/`), both follow-ups from the PR #621 review
(yujiawei, P2/P3) about the queue's **defer** path (the route-missing self-heal loop
that PR #621 added), plus a review-driven addendum in `dispatcher.go` that keeps the
`MaxAttempts` bound intact once a route recovers. Each is its own commit for independent
review.

1. **#623 (P2) — attempt-increment leak on reclaim.** `claimScript` increments the
   per-event attempt on every claim; only a completed `Defer` restores it, so a
   claim→Defer re-check cycle is net-zero. If the worker crashes / Redis errors / the
   lease expires in the window **between claim and `Defer`**, `ReclaimExpired` requeued
   the event **without** undoing the `+1`. Across many cycles the counter creeps up until
   the event reads `attempt > MaxAttempts` and dead-letters as `attempts_exhausted` on a
   route it never got to try.
2. **#624 (P3) — missing LiveTTL floor.** `NewRedisQueue` validated only `LiveTTL > 0`.
   A route-missing re-check is rescheduled `routeMissingDeferInterval` (5s) ahead and every
   queue op `PEXPIRE`s its ready/payload keys to `LiveTTL`; if `LiveTTL` did not
   comfortably exceed that interval, a deferred key could expire before the event became
   claimable — silently dropping it.

## Related Issue

Fixes #623
Fixes #624

## Linked Spec

`.octospec/tasks/card-action-dispatch-defer-hardening/brief.md` (+ `context.yaml`).
Follow-up to the `route-missing-retry` task (PR #621).

## Changes

- `queue.go` `reclaimScript`: when a reclaimed lease still carries a `route_missing_since`
  marker (the durable signal it is in the defer loop), refund the claim's speculative
  attempt `+1` (`HINCRBY -1`, floored at 0), making a reclaimed defer cycle net-zero.
  Delivery leases carry no marker, so their attempt accounting — which bounds real
  delivery retries — is untouched.
- `queue.go` `clearRouteMissingScript` + `RedisQueue.ClearRouteMissing` (**review-driven**):
  a token-fenced `HGET tokens[id] == token` → `HDEL route_missing_since[id]`, so only the
  current lease owner can clear the marker.
- `dispatcher.go` (**review-driven**): `dispatchQueue` gains `ClearRouteMissing`, and
  `ProcessOne` calls it the moment `Route()` resolves — **before** the `MaxAttempts` gate and
  `Deliver` — so a lease that proceeds to delivery is markerless and a delivery-phase reclaim
  advances the attempt like any delivery lease. A route miss returns earlier and never reaches
  the call, leaving the marker the defer loop needs intact. A `!cleared` result means the lease
  was reclaimed and re-leased, so the dispatcher records `ack_lost` and bails before
  `Deliver`/`Finalize` instead of doing a delivery whose terminal `Ack` would fail anyway —
  mirroring the existing `!deferred` lease-loss handling on both defer paths.
- `queue.go` `NewRedisQueue`: add a `minLiveTTL` floor (`4 × routeMissingDeferInterval`,
  20s) and reject a smaller `LiveTTL` with a descriptive construction error, so a
  pathological config fails fast at server boot instead of dropping events at runtime.
- Tests: `route_missing_queue_test.go` `TestReclaimRefundsRouteMissingDeferAttemptLeak`
  (Redis-backed; positive refund case + markerless negative control) and
  `TestClearRouteMissingRestoresDeliveryReclaimBound`; `route_missing_test.go`
  `TestRoutePresentClearsRouteMissingMarkerBeforeDelivery` and
  `TestRoutePresentLeaseLostBeforeDeliveryDoesNotDeliver`; `coverage_test.go`
  `TestNewRedisQueueRejectsLiveTTLBelowDeferFloor` (boundary + reject/accept tables). The
  existing `TestDecisionAndQueueInputBounds` "bounds" queue is bumped off its former
  second-scale `LiveTTL` to respect the new invariant.
- Docs-only follow-up (`a085126d`, no logic change): narrow the `minLiveTTL` comment and the
  constructor error so they claim only the route-missing interval they actually enforce;
  correct the `routeMissingSinceScript` "cannot grow unbounded" comment (the write is
  unfenced — see #680); refresh the brief's Load-bearing and Out-of-scope lists.
- `.octospec/tasks/card-action-dispatch-defer-hardening/{brief.md,context.yaml}`: task spec.

## Testing

Ran against a live stack (Redis + MySQL 8 + WuKongIM `v2.2.4-20260313` built from source):

```
go test -tags integration ./internal/cardactiondispatch/   # unit + 3 e2e orchestration tests — PASS
go build ./...                                              # clean
go vet ./internal/cardactiondispatch/                      # clean
```

Key cases: `TestReclaimRefundsRouteMissingDeferAttemptLeak` (both subtests),
`TestClearRouteMissingRestoresDeliveryReclaimBound`,
`TestRoutePresentClearsRouteMissingMarkerBeforeDelivery`,
`TestRoutePresentLeaseLostBeforeDeliveryDoesNotDeliver`,
`TestNewRedisQueueRejectsLiveTTLBelowDeferFloor`, the pinned
`TestRedisQueueLeaseTokenRetryDLQAndReplay` (markerless reclaim still advances to
attempt 2 → delivery accounting unchanged), and the three
`TestCardActionCallbackOrchestration*` e2e tests all pass.

CI on this head is green across all lanes, including `Unit Test` and the four `E2E Test`
shards — `internal/cardactiondispatch` is assigned to the E2E lane
(`ci/e2e-package-weights.tsv`), which provisions Redis, so the Redis-backed tests above
really run in CI rather than silently skipping.

- [x] Unit tests added/updated
- [x] Manually verified

## Compatibility

No migration, rollback-safe. `scriptKeys()` is unchanged and `route_missing_since` predates
this PR (#621), so no new Redis key or value shape is introduced; the new script only reuses
existing keys. A mixed-version rollout is benign — an old replica runs the refund-less
`reclaimScript`, whose worst case is the pre-fix behaviour. `dispatchQueue` is package-private,
so the new method breaks no external implementer, and `ack_lost` is already in the
`metricErrorCategory` allowlist, so no new metric label appears. The one fail-closed change is
the `LiveTTL` floor: `main.go` and `tools/card-action-dlq` both pass `Robot.MessageExpire`
(7-day default), so only a sub-20s configuration — already broken for card messaging — would
now fail at boot instead of dropping events at runtime.

## COMPREHENSION

1. **What does this change actually do to the load-bearing path?** In the reclaim path,
   an expired/crashed lease that is requeued now also has its attempt counter decremented
   by 1 (floored at 0) **iff** the event still carries a `route_missing_since` marker —
   i.e. it was in the route-missing defer loop, where a claim→Defer cycle is supposed to
   be net-zero. This makes a crash-interrupted defer cycle net-zero too, instead of
   leaking `+1` per interrupted cycle. In the dispatch path, the marker is cleared
   (token-fenced) the moment the route resolves, before the attempt gate and `Deliver`, so
   "carries a marker" means "is still in the defer loop" rather than "was in it at some
   point". In construction, `NewRedisQueue` now also asserts
   `LiveTTL ≥ 4 × routeMissingDeferInterval`.

2. **What could break (dependents + failure mode)?** The refund must not weaken the
   `MaxAttempts` bound on real delivery retries. Delivery leases are markerless — never
   route-missing, or cleared at `Route()` resolution — so the gate leaves their accounting
   exactly as before, pinned by the unchanged `TestRedisQueueLeaseTokenRetryDLQAndReplay`
   (markerless reclaim → attempt 2) and by
   `TestClearRouteMissingRestoresDeliveryReclaimBound`. Three residuals are known and
   accepted for a P2, none of them silent loss (worst case is a recoverable, replayable
   `attempts_exhausted` DLQ entry on an at-least-once path with an idempotent consumer):
   (a) a crash in the window between claim and the **first** marker write leaks that cycle's
   `+1`, since reclaim then finds no marker — the marker persists for the rest of the episode,
   so later cycles are protected; (b) the **capacity-defer** path (`dispatcher.go`) shares the
   claim→Defer shape and is *not* covered — `ClearRouteMissing` runs before the capacity check,
   so such a lease is always markerless; this predates #621 and is unchanged by this PR;
   (c) the marker write is not token-fenced, so a stalled write can be re-planted after a lease
   loss (#680), which also lets an orphan field outlive its event. All three dissolve if the
   speculative `+1` moves off `claim` to just before `Deliver`; that shifts a load-bearing
   off-by-one across the pre-delivery gate, `nackScript`'s DLQ gate and the replay reset, so it
   is filed for its own round rather than ridden along here. The `NewRedisQueue` floor only
   rejects seconds-scale `LiveTTL`; every real and test config (`MessageExpire` 7d, 1h, 10m)
   clears it — `main.go` surfaces the error at boot.

3. **How do you know it works?** `TestReclaimRefundsRouteMissingDeferAttemptLeak` proves
   the gate with two subtests sharing one reclaim path — marker present → attempt refunded
   → next claim returns to attempt 1; no marker → attempt kept → next claim is attempt 2.
   `TestClearRouteMissingRestoresDeliveryReclaimBound` proves a wrong-token caller cannot
   clear and that a cleared marker restores delivery-phase reclaim to attempt 2;
   `TestRoutePresentLeaseLostBeforeDeliveryDoesNotDeliver` asserts the `!cleared` bail runs no
   `Deliver`/`Finalize`/ack. `TestNewRedisQueueRejectsLiveTTLBelowDeferFloor` covers the
   boundary (rejects `routeMissingDeferInterval` and `minLiveTTL-1ns`, accepts `minLiveTTL`
   and `1h`). Reviewers additionally ran negative controls: deleting the `HEXISTS` refund block
   fails the reclaim test, and stubbing out `ClearRouteMissing` fails both dispatcher tests —
   the tests pin the fixes, not just the happy path. The full `-tags integration` suite
   (including the 3 live e2e orchestration tests) is green.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] PR description is in English
- [x] Added tests for my changes
- [x] Updated documentation
- [x] Followed commit message conventions (Conventional Commits)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VnUdMCUrnVP1E4bxNgo5Tu

---
_Generated by [Claude Code](https://claude.ai/code/session_01VnUdMCUrnVP1E4bxNgo5Tu)_