### PR TITLE
feat(bot_api): add PUT thread rename endpoint (#664)

### DIFF
--- a/modules/bot_api/bot_api.go
+++ b/modules/bot_api/bot_api.go
@@ -291,6 +291,7 @@ func (ba *BotAPI) Route(r *wkhttp.WKHttp) {
 		botAPI.GET("/groups/:group_no/threads", ba.botListThreads)
 		botAPI.GET("/groups/:group_no/threads/:short_id", ba.botGetThread)
 		botAPI.DELETE("/groups/:group_no/threads/:short_id", ba.botDeleteThread)
+		botAPI.PUT("/groups/:group_no/threads/:short_id", ba.botUpdateThread)
 		botAPI.GET("/groups/:group_no/threads/:short_id/members", ba.botListThreadMembers)
 		botAPI.POST("/groups/:group_no/threads/:short_id/join", ba.botJoinThread)
 		botAPI.POST("/groups/:group_no/threads/:short_id/leave", ba.botLeaveThread)

--- a/modules/bot_api/threads.go
+++ b/modules/bot_api/threads.go
@@ -169,6 +169,28 @@ func (ba *BotAPI) botDeleteThread(c *wkhttp.Context) {
 	c.ResponseOK()
 }
 
+// botUpdateThread handles PUT /v1/bot/groups/:group_no/threads/:short_id.
+func (ba *BotAPI) botUpdateThread(c *wkhttp.Context) {
+	robotID, groupNo, shortID, ok := ba.validateBotThreadAccess(c)
+	if !ok {
+		return
+	}
+	var req struct {
+		Name string `json:"name" binding:"required,max=100"`
+	}
+	if err := c.BindJSON(&req); err != nil {
+		respondBotAPIRequestInvalid(c, "name")
+		return
+	}
+	err := ba.threadService.UpdateNameByBot(groupNo, shortID, robotID, req.Name)
+	if err != nil {
+		ba.Error("修改子区名称失败", zap.Error(err), zap.String("groupNo", groupNo), zap.String("shortID", shortID))
+		httperr.ResponseErrorL(c, errcode.ErrBotAPIStoreFailed, nil, nil)
+		return
+	}
+	c.ResponseOK()
+}
+
 // botListThreadMembers handles GET /v1/bot/groups/:group_no/threads/:short_id/members.
 func (ba *BotAPI) botListThreadMembers(c *wkhttp.Context) {
 	_, groupNo, shortID, ok := ba.validateBotThreadAccess(c)

--- a/modules/bot_api/threads_update_test.go
+++ b/modules/bot_api/threads_update_test.go
@@ -139,7 +139,9 @@ func TestBotUpdateThread_ThreadNotFound(t *testing.T) {
 	path := "/v1/bot/groups/" + utGroupNo + "/threads/" + utShortID
 
 	w := doBotPut(t, handler, path, map[string]string{"name": "new-name"})
-	assert.Equal(t, http.StatusInternalServerError, w.Code, "non-existent thread must return 500, body=%s", w.Body.String())
+	// ResponseErrorL legacy wire pins every code to 400 (see the NotGroupMember case above);
+	// ErrBotAPIStoreFailed's canonical 500 appears in the envelope, not on the wire.
+	assert.Equal(t, http.StatusBadRequest, w.Code, "non-existent thread must be rejected, body=%s", w.Body.String())
 	assert.Contains(t, w.Body.String(), utStoreFailedMsg)
 }
 

--- a/modules/bot_api/threads_update_test.go
+++ b/modules/bot_api/threads_update_test.go
@@ -1,0 +1,154 @@
+package bot_api
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	"github.com/Mininglamp-OSS/octo-server/modules/thread"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	utRobotID  = "bot_ut_update"
+	utBotToken = "bf_ut_update_token"
+	// 32-char hex (valid group_no)
+	utGroupNo = "abcdef0123456789abcdef0123456789"
+	// 18-digit numeric short_id
+	utShortID = "148910429168271399"
+)
+
+var utRequestInvalidMsg = errcode.ErrBotAPIRequestInvalid.DefaultMessage
+var utNotGroupMemberMsg = errcode.ErrBotAPINotGroupMember.DefaultMessage
+var utStoreFailedMsg = errcode.ErrBotAPIStoreFailed.DefaultMessage
+
+// setupBotUpdateThread seeds robot + group row + active group_member + one thread row.
+// nonMember=true skips the group_member insert (bot not in group).
+// noThread=true skips the thread insert (short_id points to nothing).
+func setupBotUpdateThread(t *testing.T, nonMember, noThread bool) (http.Handler, *config.Context) {
+	t.Helper()
+	s, ctx := testutil.NewTestServer()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+
+	_, err := ctx.DB().InsertBySql(
+		"INSERT INTO robot (robot_id, status, creator_uid, bot_token) VALUES (?, 1, ?, ?)",
+		utRobotID, "owner_ut", utBotToken,
+	).Exec()
+	require.NoError(t, err)
+
+	_, err = ctx.DB().InsertBySql(
+		"INSERT INTO `group` (group_no, name, status, version) VALUES (?, ?, 0, 1)",
+		utGroupNo, "ut-group",
+	).Exec()
+	require.NoError(t, err)
+
+	if !nonMember {
+		_, err = ctx.DB().InsertBySql(
+			"INSERT INTO group_member (group_no, uid, vercode, is_deleted, status, version) VALUES (?, ?, ?, 0, ?, 1)",
+			utGroupNo, utRobotID, util.GenerUUID(), int(common.GroupMemberStatusNormal),
+		).Exec()
+		require.NoError(t, err)
+	}
+
+	if !noThread {
+		tdb := thread.NewDB(ctx)
+		require.NoError(t, tdb.Insert(&thread.Model{
+			ShortID:    utShortID,
+			GroupNo:    utGroupNo,
+			Name:       "original-name",
+			CreatorUID: utRobotID,
+			Status:     thread.ThreadStatusActive,
+			Version:    1,
+		}))
+	}
+
+	return s.GetRoute(), ctx
+}
+
+func doBotPut(t *testing.T, handler http.Handler, path string, body interface{}) *httptest.ResponseRecorder {
+	t.Helper()
+	var buf bytes.Buffer
+	if body != nil {
+		require.NoError(t, json.NewEncoder(&buf).Encode(body))
+	}
+	w := httptest.NewRecorder()
+	req, err := http.NewRequest("PUT", path, &buf)
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+utBotToken)
+	req.Header.Set("Content-Type", "application/json")
+	handler.ServeHTTP(w, req)
+	return w
+}
+
+func doBotGet2(t *testing.T, handler http.Handler, path string) *httptest.ResponseRecorder {
+	t.Helper()
+	w := httptest.NewRecorder()
+	req, err := http.NewRequest("GET", path, nil)
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+utBotToken)
+	handler.ServeHTTP(w, req)
+	return w
+}
+
+func TestBotUpdateThread_Success(t *testing.T) {
+	handler, _ := setupBotUpdateThread(t, false, false)
+	path := "/v1/bot/groups/" + utGroupNo + "/threads/" + utShortID
+
+	w := doBotPut(t, handler, path, map[string]string{"name": "new-name"})
+	assert.Equal(t, http.StatusOK, w.Code, "rename must succeed, body=%s", w.Body.String())
+
+	gw := doBotGet2(t, handler, path)
+	require.Equal(t, http.StatusOK, gw.Code, "get after rename must succeed, body=%s", gw.Body.String())
+	var got struct {
+		Name string `json:"name"`
+	}
+	require.NoError(t, json.Unmarshal(gw.Body.Bytes(), &got))
+	assert.Equal(t, "new-name", got.Name, "thread name must reflect rename")
+}
+
+func TestBotUpdateThread_NotGroupMember(t *testing.T) {
+	handler, _ := setupBotUpdateThread(t, true, false)
+	path := "/v1/bot/groups/" + utGroupNo + "/threads/" + utShortID
+
+	w := doBotPut(t, handler, path, map[string]string{"name": "new-name"})
+	// ResponseErrorL legacy wire maps 403 to 400 on the HTTP layer (see threads_blacklist_test.go)
+	assert.Equal(t, http.StatusBadRequest, w.Code, "non-member bot must be denied, body=%s", w.Body.String())
+	assert.Contains(t, w.Body.String(), utNotGroupMemberMsg, "deny reason must be not_group_member")
+}
+
+func TestBotUpdateThread_EmptyName(t *testing.T) {
+	handler, _ := setupBotUpdateThread(t, false, false)
+	path := "/v1/bot/groups/" + utGroupNo + "/threads/" + utShortID
+
+	w := doBotPut(t, handler, path, map[string]string{"name": ""})
+	assert.Equal(t, http.StatusBadRequest, w.Code, "empty name must be rejected, body=%s", w.Body.String())
+	assert.Contains(t, w.Body.String(), utRequestInvalidMsg)
+}
+
+func TestBotUpdateThread_ThreadNotFound(t *testing.T) {
+	handler, _ := setupBotUpdateThread(t, false, true)
+	path := "/v1/bot/groups/" + utGroupNo + "/threads/" + utShortID
+
+	w := doBotPut(t, handler, path, map[string]string{"name": "new-name"})
+	assert.Equal(t, http.StatusInternalServerError, w.Code, "non-existent thread must return 500, body=%s", w.Body.String())
+	assert.Contains(t, w.Body.String(), utStoreFailedMsg)
+}
+
+func TestBotUpdateThread_NameTooLong(t *testing.T) {
+	handler, _ := setupBotUpdateThread(t, false, false)
+	path := "/v1/bot/groups/" + utGroupNo + "/threads/" + utShortID
+
+	longName := strings.Repeat("a", 101)
+	w := doBotPut(t, handler, path, map[string]string{"name": longName})
+	assert.Equal(t, http.StatusBadRequest, w.Code, "name > 100 chars must be rejected, body=%s", w.Body.String())
+	assert.Contains(t, w.Body.String(), utRequestInvalidMsg)
+}

--- a/modules/thread/service.go
+++ b/modules/thread/service.go
@@ -39,6 +39,8 @@ type IService interface {
 	CreateThread(req *CreateThreadReq) (*ThreadResp, error)
 	// UpdateName 修改子区名称
 	UpdateName(groupNo, shortID, operatorUID, name string) error
+	// UpdateNameByBot bot 修改子区名称（跳过 IsRobot 检查；调用方须已校验 bot 是群活跃成员）
+	UpdateNameByBot(groupNo, shortID, robotID, name string) error
 	// GetThreads 分页获取群下的子区，同时返回总数。
 	// statuses 决定包含的 status 集合（active / archived / 二者）；nil 或空一律按 active。
 	GetThreads(groupNo string, statuses []int, pageIndex, pageSize int64) ([]*ThreadResp, int64, error)
@@ -542,6 +544,37 @@ func (s *Service) UpdateName(groupNo, shortID, operatorUID, name string) error {
 
 	// 子区改名后失效离线推送标题缓存（推送标题含子区名），否则手机推送会沿用旧子区名直到
 	// TTL 过期。best-effort：失败仅告警，TTL 兜底。
+	channelID := BuildChannelID(groupNo, shortID)
+	if err := pushcache.InvalidateThreadName(s.ctx.GetRedisConn(), channelID); err != nil {
+		s.Warn("失效子区名推送缓存失败", zap.String("channel_id", channelID), zap.Error(err))
+	}
+	return nil
+}
+
+// UpdateNameByBot bot 修改子区名称（跳过 IsRobot/ExistMemberActiveInternal 检查，调用方须在 handler 层完成成员校验）
+func (s *Service) UpdateNameByBot(groupNo, shortID, robotID, name string) error {
+	if name == "" || len([]rune(name)) > 100 {
+		return errors.New("name is required and must not exceed 100 characters")
+	}
+	thread, err := s.db.QueryByGroupNoAndShortID(groupNo, shortID)
+	if err != nil {
+		return fmt.Errorf("query thread: %w", err)
+	}
+	if thread == nil {
+		return errors.New("thread not found")
+	}
+	if thread.Status == ThreadStatusDeleted {
+		return errors.New("thread has been deleted")
+	}
+	if err := s.db.UpdateName(shortID, name, s.threadVersionGen()); err != nil {
+		switch {
+		case errors.Is(err, ErrThreadNotFound):
+			return errors.New("thread not found")
+		case errors.Is(err, ErrThreadDeleted):
+			return errors.New("thread has been deleted")
+		}
+		return fmt.Errorf("update thread name: %w", err)
+	}
 	channelID := BuildChannelID(groupNo, shortID)
 	if err := pushcache.InvalidateThreadName(s.ctx.GetRedisConn(), channelID); err != nil {
 		s.Warn("失效子区名推送缓存失败", zap.String("channel_id", channelID), zap.Error(err))


### PR DESCRIPTION
Fixes #664

## 变更摘要
- 新增 Bot API 端点 `PUT /v1/bot/groups/:group_no/threads/:short_id`，支持 bot token 修改子区名称
- `modules/thread/service.go`：在 `IService` interface 新增 `UpdateNameByBot` 方法声明及实现；绕过 `IsRobot` 检查（人类侧 `UpdateName` 保持不变），复用 name 长度校验、thread 存在/未删除校验、`db.UpdateName`（含 CAS 重试）、`pushcache.InvalidateThreadName` 失效逻辑
- `modules/bot_api/bot_api.go`：在 DELETE threads 路由旁注册 PUT 路由
- `modules/bot_api/threads.go`：新增 `botUpdateThread` handler，复用 `validateBotThreadAccess` 门禁，错误码映射与现有 `botDeleteThread` 对齐
- 新增测试文件 `modules/bot_api/threads_update_test.go`，覆盖正向改名、空名/超长名拒绝、非群成员拒绝、子区不存在 5 个 case

## 验收证据
- `go build ./...` 全量编译通过
- `go vet ./modules/bot_api/... ./modules/thread/...` 无警告
- `git diff --check origin/main...HEAD` 无空白错误
- 路由注册：`grep -c 'botAPI.PUT("/groups/:group_no/threads/:short_id", ba.botUpdateThread)' modules/bot_api/bot_api.go` = 1
- 集成测试（需 MySQL/Redis 环境，与现有 bot_api 测试环境要求一致）：`go test ./modules/bot_api/... -run TestBotUpdateThread -v`

## Comprehension gate（改公开 API）
- **为什么改**：Bot facade 缺少子区改名端点，第三方无法通过 bot token 修改子区名称；用户端已有对应接口但有 `IsRobot` 检查拒 bot
- **旧代码行为**：Bot 无法通过任何端点修改子区名称；人类用户端 `UpdateName` 拒绝 robot 调用
- **新代码行为**：新增独立 `UpdateNameByBot` service 方法（不影响人类侧 `IsRobot` 守卫），Bot 经 `validateBotThreadAccess` 门禁后可改名
- **回滚方式**：revert 本 PR