### PR TITLE
feat(bot_api): add PUT thread rename endpoint (#664)

### DIFF
--- a/modules/bot_api/bot_api.go
+++ b/modules/bot_api/bot_api.go
@@ -291,6 +291,7 @@ func (ba *BotAPI) Route(r *wkhttp.WKHttp) {
 		botAPI.GET("/groups/:group_no/threads", ba.botListThreads)
 		botAPI.GET("/groups/:group_no/threads/:short_id", ba.botGetThread)
 		botAPI.DELETE("/groups/:group_no/threads/:short_id", ba.botDeleteThread)
+		botAPI.PUT("/groups/:group_no/threads/:short_id", ba.botRenameThread)
 		botAPI.GET("/groups/:group_no/threads/:short_id/members", ba.botListThreadMembers)
 		botAPI.POST("/groups/:group_no/threads/:short_id/join", ba.botJoinThread)
 		botAPI.POST("/groups/:group_no/threads/:short_id/leave", ba.botLeaveThread)

--- a/modules/bot_api/threads.go
+++ b/modules/bot_api/threads.go
@@ -171,7 +171,7 @@ func (ba *BotAPI) botDeleteThread(c *wkhttp.Context) {
 
 // botRenameThread handles PUT /v1/bot/groups/:group_no/threads/:short_id.
 func (ba *BotAPI) botRenameThread(c *wkhttp.Context) {
-	_, groupNo, shortID, ok := ba.validateBotThreadAccess(c)
+	robotID, groupNo, shortID, ok := ba.validateBotThreadAccess(c)
 	if !ok {
 		return
 	}
@@ -179,14 +179,14 @@ func (ba *BotAPI) botRenameThread(c *wkhttp.Context) {
 	var req struct {
 		Name string `json:"name" binding:"required,max=100"`
 	}
-	if err := c.BindJSON(&req); err != nil {
+	if err := c.ShouldBindJSON(&req); err != nil {
 		respondBotAPIRequestInvalid(c, "name")
 		return
 	}
 
-	err := ba.threadService.UpdateNameAsBot(groupNo, shortID, req.Name)
+	err := ba.threadService.UpdateNameAsBot(groupNo, shortID, robotID, strings.TrimSpace(req.Name))
 	if err != nil {
-		ba.Error("修改子区名称失败", zap.Error(err), zap.String("groupNo", groupNo), zap.String("shortID", shortID))
+		ba.Error("修改子区名称失败", zap.Error(err), zap.String("robotID", robotID), zap.String("groupNo", groupNo), zap.String("shortID", shortID))
 		httperr.ResponseErrorL(c, errcode.ErrBotAPIStoreFailed, nil, nil)
 		return
 	}

--- a/modules/bot_api/threads.go
+++ b/modules/bot_api/threads.go
@@ -171,7 +171,7 @@ func (ba *BotAPI) botDeleteThread(c *wkhttp.Context) {
 
 // botRenameThread handles PUT /v1/bot/groups/:group_no/threads/:short_id.
 func (ba *BotAPI) botRenameThread(c *wkhttp.Context) {
-	robotID, groupNo, shortID, ok := ba.validateBotThreadAccess(c)
+	_, groupNo, shortID, ok := ba.validateBotThreadAccess(c)
 	if !ok {
 		return
 	}
@@ -184,7 +184,7 @@ func (ba *BotAPI) botRenameThread(c *wkhttp.Context) {
 		return
 	}
 
-	err := ba.threadService.UpdateName(groupNo, shortID, robotID, req.Name)
+	err := ba.threadService.UpdateNameAsBot(groupNo, shortID, req.Name)
 	if err != nil {
 		ba.Error("修改子区名称失败", zap.Error(err), zap.String("groupNo", groupNo), zap.String("shortID", shortID))
 		httperr.ResponseErrorL(c, errcode.ErrBotAPIStoreFailed, nil, nil)

--- a/modules/bot_api/threads.go
+++ b/modules/bot_api/threads.go
@@ -169,6 +169,30 @@ func (ba *BotAPI) botDeleteThread(c *wkhttp.Context) {
 	c.ResponseOK()
 }
 
+// botRenameThread handles PUT /v1/bot/groups/:group_no/threads/:short_id.
+func (ba *BotAPI) botRenameThread(c *wkhttp.Context) {
+	robotID, groupNo, shortID, ok := ba.validateBotThreadAccess(c)
+	if !ok {
+		return
+	}
+
+	var req struct {
+		Name string `json:"name" binding:"required,max=100"`
+	}
+	if err := c.BindJSON(&req); err != nil {
+		respondBotAPIRequestInvalid(c, "name")
+		return
+	}
+
+	err := ba.threadService.UpdateName(groupNo, shortID, robotID, req.Name)
+	if err != nil {
+		ba.Error("修改子区名称失败", zap.Error(err), zap.String("groupNo", groupNo), zap.String("shortID", shortID))
+		httperr.ResponseErrorL(c, errcode.ErrBotAPIStoreFailed, nil, nil)
+		return
+	}
+	c.ResponseOK()
+}
+
 // botListThreadMembers handles GET /v1/bot/groups/:group_no/threads/:short_id/members.
 func (ba *BotAPI) botListThreadMembers(c *wkhttp.Context) {
 	_, groupNo, shortID, ok := ba.validateBotThreadAccess(c)

--- a/modules/bot_api/threads.go
+++ b/modules/bot_api/threads.go
@@ -184,7 +184,13 @@ func (ba *BotAPI) botRenameThread(c *wkhttp.Context) {
 		return
 	}
 
-	err := ba.threadService.UpdateNameAsBot(groupNo, shortID, robotID, strings.TrimSpace(req.Name))
+	trimmedName := strings.TrimSpace(req.Name)
+	if trimmedName == "" {
+		respondBotAPIRequestInvalid(c, "name")
+		return
+	}
+
+	err := ba.threadService.UpdateNameAsBot(groupNo, shortID, robotID, trimmedName)
 	if err != nil {
 		ba.Error("修改子区名称失败", zap.Error(err), zap.String("robotID", robotID), zap.String("groupNo", groupNo), zap.String("shortID", shortID))
 		httperr.ResponseErrorL(c, errcode.ErrBotAPIStoreFailed, nil, nil)

--- a/modules/bot_api/threads_blacklist_test.go
+++ b/modules/bot_api/threads_blacklist_test.go
@@ -4,7 +4,7 @@ package bot_api
 // Issue #352（PR #345 mandatory follow-up）— validateBotGroupAccess 黑名单门禁。
 //
 // 所有 bot 子区端点（botCreateThread/botListThreads/botGetThread/botDeleteThread/
-// botListThreadMembers/botJoinThread/botLeaveThread/botGetThreadMd/
+// botRenameThread/botListThreadMembers/botJoinThread/botLeaveThread/botGetThreadMd/
 // botUpdateThreadMd）共享 validateBotGroupAccess。该门禁必须用 ExistMemberActive
 // （is_deleted=0 AND status=Normal）：被拉黑（status=Blacklist）的 bot 不得再通过
 // bot API 读写子区。GROUP 级端点（groups.go）保持 permissive ExistMember 不动。

--- a/modules/bot_api/threads_rename_test.go
+++ b/modules/bot_api/threads_rename_test.go
@@ -19,8 +19,10 @@ import (
 )
 
 type fakeGroupServiceForRename struct {
-	existMemberActive bool
-	existMemberErr    error
+	existMemberActive         bool
+	existMemberErr            error
+	existMemberActiveInternal bool
+	existMemberActiveInternalErr error
 }
 
 func (f *fakeGroupServiceForRename) GetAllGroupCount() (int64, error) { return 0, nil }
@@ -52,9 +54,7 @@ func (f *fakeGroupServiceForRename) GetMemberExternalFields(groupNo, uid string)
 }
 func (f *fakeGroupServiceForRename) GetMember(groupNo, uid string) (*group.MemberResp, error) { return nil, nil }
 func (f *fakeGroupServiceForRename) GetBlacklistMemberUIDs(groupNo string) ([]string, error) { return nil, nil }
-func (f *fakeGroupServiceForRename) GetSubscribableMemberUIDs(groupNo string) ([]string, error) {
-	return nil, nil
-}
+func (f *fakeGroupServiceForRename) GetSubscribableMemberUIDs(groupNo string) ([]string, error) { return nil, nil }
 func (f *fakeGroupServiceForRename) GetMemberUIDsOfManager(groupNo string) ([]string, error) { return nil, nil }
 func (f *fakeGroupServiceForRename) IsCreatorOrManager(groupNo, uid string) (bool, error)    { return false, nil }
 func (f *fakeGroupServiceForRename) IsRobot(uid string) (bool, error)                        { return false, nil }
@@ -67,7 +67,9 @@ func (f *fakeGroupServiceForRename) ExistMember(groupNo, uid string) (bool, erro
 func (f *fakeGroupServiceForRename) ExistMemberActive(groupNo, uid string) (bool, error) {
 	return f.existMemberActive, f.existMemberErr
 }
-func (f *fakeGroupServiceForRename) ExistMemberActiveInternal(groupNo, uid string) (bool, error) { return false, nil }
+func (f *fakeGroupServiceForRename) ExistMemberActiveInternal(groupNo, uid string) (bool, error) {
+	return f.existMemberActiveInternal, f.existMemberActiveInternalErr
+}
 func (f *fakeGroupServiceForRename) ExistMembers(groupNos []string, uid string) ([]string, error) {
 	return nil, nil
 }
@@ -114,15 +116,17 @@ type fakeThreadServiceForRename struct {
 	updateNameAsBotErr error
 	calledGroupNo      string
 	calledShortID      string
+	calledRobotID      string
 	calledName         string
 }
 
 func (f *fakeThreadServiceForRename) UpdateName(groupNo, shortID, operatorUID, name string) error {
 	return nil
 }
-func (f *fakeThreadServiceForRename) UpdateNameAsBot(groupNo, shortID, name string) error {
+func (f *fakeThreadServiceForRename) UpdateNameAsBot(groupNo, shortID, robotID, name string) error {
 	f.calledGroupNo = groupNo
 	f.calledShortID = shortID
+	f.calledRobotID = robotID
 	f.calledName = name
 	return f.updateNameAsBotErr
 }
@@ -175,9 +179,18 @@ const (
 	trShortID = "148910429168271360"
 )
 
-func newRenameTestEngine(t *testing.T, groupSvc *fakeGroupServiceForRename, threadSvc *fakeThreadServiceForRename) *gin.Engine {
+type renameTestOpts struct {
+	botKind           string
+	existMemberActive bool
+}
+
+func newRenameTestEngine(t *testing.T, groupSvc *fakeGroupServiceForRename, threadSvc *fakeThreadServiceForRename, opts ...renameTestOpts) *gin.Engine {
 	t.Helper()
 	gin.SetMode(gin.TestMode)
+	botKind := BotKindUser
+	if len(opts) > 0 && opts[0].botKind != "" {
+		botKind = opts[0].botKind
+	}
 	ba := &BotAPI{
 		Log:           log.NewTLog("BotAPI-rename-test"),
 		groupService:  groupSvc,
@@ -189,7 +202,7 @@ func newRenameTestEngine(t *testing.T, groupSvc *fakeGroupServiceForRename, thre
 		auth := c.GetHeader("Authorization")
 		if strings.HasPrefix(auth, "Bearer ") {
 			c.Set(CtxKeyRobotID, trRobotID)
-			c.Set(CtxKeyBotKind, BotKindUser)
+			c.Set(CtxKeyBotKind, botKind)
 		}
 		c.Next()
 	})
@@ -223,9 +236,9 @@ func doRenamePUT(t *testing.T, r *gin.Engine, groupNo, shortID string, body inte
 	return w
 }
 
-// Happy path: valid params, service returns nil → 200 OK
+// Happy path: valid params, internal active member, service returns nil → 200 OK
 func TestBotRenameThread_HappyPath(t *testing.T) {
-	groupSvc := &fakeGroupServiceForRename{existMemberActive: true}
+	groupSvc := &fakeGroupServiceForRename{existMemberActive: true, existMemberActiveInternal: true}
 	threadSvc := &fakeThreadServiceForRename{}
 	r := newRenameTestEngine(t, groupSvc, threadSvc)
 
@@ -233,12 +246,13 @@ func TestBotRenameThread_HappyPath(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code, "happy path should return 200, body=%s", w.Body.String())
 	assert.Equal(t, trGroupNo, threadSvc.calledGroupNo)
 	assert.Equal(t, trShortID, threadSvc.calledShortID)
+	assert.Equal(t, trRobotID, threadSvc.calledRobotID)
 	assert.Equal(t, "new thread name", threadSvc.calledName)
 }
 
 // Error path: empty/missing name → 400 (bind error)
 func TestBotRenameThread_EmptyName(t *testing.T) {
-	groupSvc := &fakeGroupServiceForRename{existMemberActive: true}
+	groupSvc := &fakeGroupServiceForRename{existMemberActive: true, existMemberActiveInternal: true}
 	threadSvc := &fakeThreadServiceForRename{}
 	r := newRenameTestEngine(t, groupSvc, threadSvc)
 
@@ -247,9 +261,21 @@ func TestBotRenameThread_EmptyName(t *testing.T) {
 	assert.Contains(t, w.Body.String(), errcode.ErrBotAPIRequestInvalid.DefaultMessage)
 }
 
+// Error path: whitespace-only name → treated as empty after TrimSpace, service returns error → 400
+func TestBotRenameThread_WhitespaceName(t *testing.T) {
+	groupSvc := &fakeGroupServiceForRename{existMemberActive: true, existMemberActiveInternal: true}
+	threadSvc := &fakeThreadServiceForRename{updateNameAsBotErr: errors.New("name is required")}
+	r := newRenameTestEngine(t, groupSvc, threadSvc)
+
+	w := doRenamePUT(t, r, trGroupNo, trShortID, map[string]string{"name": "   "})
+	// binding:"required" passes for "   "; TrimSpace → ""; service rejects → ErrBotAPIStoreFailed
+	assert.Equal(t, http.StatusBadRequest, w.Code, "whitespace name should return 400, body=%s", w.Body.String())
+	assert.Contains(t, w.Body.String(), errcode.ErrBotAPIStoreFailed.DefaultMessage)
+}
+
 // Error path: invalid short_id (non-numeric) → 400
 func TestBotRenameThread_InvalidShortID(t *testing.T) {
-	groupSvc := &fakeGroupServiceForRename{existMemberActive: true}
+	groupSvc := &fakeGroupServiceForRename{existMemberActive: true, existMemberActiveInternal: true}
 	threadSvc := &fakeThreadServiceForRename{}
 	r := newRenameTestEngine(t, groupSvc, threadSvc)
 
@@ -260,7 +286,7 @@ func TestBotRenameThread_InvalidShortID(t *testing.T) {
 
 // Error path: invalid group_no (wrong length) → 400
 func TestBotRenameThread_InvalidGroupNo(t *testing.T) {
-	groupSvc := &fakeGroupServiceForRename{existMemberActive: true}
+	groupSvc := &fakeGroupServiceForRename{existMemberActive: true, existMemberActiveInternal: true}
 	threadSvc := &fakeThreadServiceForRename{}
 	r := newRenameTestEngine(t, groupSvc, threadSvc)
 
@@ -269,14 +295,47 @@ func TestBotRenameThread_InvalidGroupNo(t *testing.T) {
 	assert.Contains(t, w.Body.String(), errcode.ErrBotAPIRequestInvalid.DefaultMessage)
 }
 
-// Error path: service UpdateNameAsBot returns error → 500 (ErrBotAPIStoreFailed)
+// Error path: service UpdateNameAsBot returns error → 400 (ErrBotAPIStoreFailed, D14 legacy wire code)
 func TestBotRenameThread_ServiceError(t *testing.T) {
-	groupSvc := &fakeGroupServiceForRename{existMemberActive: true}
+	groupSvc := &fakeGroupServiceForRename{existMemberActive: true, existMemberActiveInternal: true}
 	threadSvc := &fakeThreadServiceForRename{updateNameAsBotErr: errors.New("db error")}
 	r := newRenameTestEngine(t, groupSvc, threadSvc)
 
 	w := doRenamePUT(t, r, trGroupNo, trShortID, map[string]string{"name": "new name"})
-	// ErrBotAPIStoreFailed via ResponseErrorL returns legacy 400 (D14 compatibility)
 	assert.Equal(t, http.StatusBadRequest, w.Code, "service error should return 400 (D14 legacy), body=%s", w.Body.String())
 	assert.Contains(t, w.Body.String(), errcode.ErrBotAPIStoreFailed.DefaultMessage)
+}
+
+// Error path: name exceeding 100 runes → 400 (bind max=100)
+func TestBotRenameThread_NameTooLong(t *testing.T) {
+	groupSvc := &fakeGroupServiceForRename{existMemberActive: true, existMemberActiveInternal: true}
+	threadSvc := &fakeThreadServiceForRename{}
+	r := newRenameTestEngine(t, groupSvc, threadSvc)
+
+	longName := strings.Repeat("世", 101) // 101 CJK runes
+	w := doRenamePUT(t, r, trGroupNo, trShortID, map[string]string{"name": longName})
+	assert.Equal(t, http.StatusBadRequest, w.Code, "name >100 runes should return 400, body=%s", w.Body.String())
+	assert.Contains(t, w.Body.String(), errcode.ErrBotAPIRequestInvalid.DefaultMessage)
+}
+
+// Error path: bot is not an active group member (e.g. not in group or removed) → not_group_member
+func TestBotRenameThread_NotGroupMember(t *testing.T) {
+	groupSvc := &fakeGroupServiceForRename{existMemberActive: false}
+	threadSvc := &fakeThreadServiceForRename{}
+	r := newRenameTestEngine(t, groupSvc, threadSvc)
+
+	w := doRenamePUT(t, r, trGroupNo, trShortID, map[string]string{"name": "new name"})
+	assert.Equal(t, http.StatusBadRequest, w.Code, "non-member bot should return 400, body=%s", w.Body.String())
+	assert.Contains(t, w.Body.String(), errcode.ErrBotAPINotGroupMember.DefaultMessage)
+}
+
+// Error path: App Bot (DM-only) is denied all group/thread operations → app_bot_unsupported
+func TestBotRenameThread_AppBotDenied(t *testing.T) {
+	groupSvc := &fakeGroupServiceForRename{existMemberActive: true}
+	threadSvc := &fakeThreadServiceForRename{}
+	r := newRenameTestEngine(t, groupSvc, threadSvc, renameTestOpts{botKind: BotKindApp})
+
+	w := doRenamePUT(t, r, trGroupNo, trShortID, map[string]string{"name": "new name"})
+	assert.Equal(t, http.StatusBadRequest, w.Code, "App Bot should return 400, body=%s", w.Body.String())
+	assert.Contains(t, w.Body.String(), errcode.ErrBotAPIAppBotUnsupported.DefaultMessage)
 }

--- a/modules/bot_api/threads_rename_test.go
+++ b/modules/bot_api/threads_rename_test.go
@@ -111,11 +111,20 @@ func (f *fakeGroupServiceForRename) UpdateGroupAvatarCustom(req *group.UpdateGro
 }
 
 type fakeThreadServiceForRename struct {
-	updateNameErr error
+	updateNameAsBotErr error
+	calledGroupNo      string
+	calledShortID      string
+	calledName         string
 }
 
 func (f *fakeThreadServiceForRename) UpdateName(groupNo, shortID, operatorUID, name string) error {
-	return f.updateNameErr
+	return nil
+}
+func (f *fakeThreadServiceForRename) UpdateNameAsBot(groupNo, shortID, name string) error {
+	f.calledGroupNo = groupNo
+	f.calledShortID = shortID
+	f.calledName = name
+	return f.updateNameAsBotErr
 }
 func (f *fakeThreadServiceForRename) CreateThread(req *thread.CreateThreadReq) (*thread.ThreadResp, error) {
 	return nil, nil
@@ -222,6 +231,9 @@ func TestBotRenameThread_HappyPath(t *testing.T) {
 
 	w := doRenamePUT(t, r, trGroupNo, trShortID, map[string]string{"name": "new thread name"})
 	assert.Equal(t, http.StatusOK, w.Code, "happy path should return 200, body=%s", w.Body.String())
+	assert.Equal(t, trGroupNo, threadSvc.calledGroupNo)
+	assert.Equal(t, trShortID, threadSvc.calledShortID)
+	assert.Equal(t, "new thread name", threadSvc.calledName)
 }
 
 // Error path: empty/missing name → 400 (bind error)
@@ -257,10 +269,10 @@ func TestBotRenameThread_InvalidGroupNo(t *testing.T) {
 	assert.Contains(t, w.Body.String(), errcode.ErrBotAPIRequestInvalid.DefaultMessage)
 }
 
-// Error path: service UpdateName returns error → 500 (ErrBotAPIStoreFailed)
+// Error path: service UpdateNameAsBot returns error → 500 (ErrBotAPIStoreFailed)
 func TestBotRenameThread_ServiceError(t *testing.T) {
 	groupSvc := &fakeGroupServiceForRename{existMemberActive: true}
-	threadSvc := &fakeThreadServiceForRename{updateNameErr: errors.New("db error")}
+	threadSvc := &fakeThreadServiceForRename{updateNameAsBotErr: errors.New("db error")}
 	r := newRenameTestEngine(t, groupSvc, threadSvc)
 
 	w := doRenamePUT(t, r, trGroupNo, trShortID, map[string]string{"name": "new name"})

--- a/modules/bot_api/threads_rename_test.go
+++ b/modules/bot_api/threads_rename_test.go
@@ -1,0 +1,270 @@
+package bot_api
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/modules/group"
+	"github.com/Mininglamp-OSS/octo-server/modules/thread"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+)
+
+type fakeGroupServiceForRename struct {
+	existMemberActive bool
+	existMemberErr    error
+}
+
+func (f *fakeGroupServiceForRename) GetAllGroupCount() (int64, error) { return 0, nil }
+func (f *fakeGroupServiceForRename) GetCreatedCountWithDate(date string) (int64, error) {
+	return 0, nil
+}
+func (f *fakeGroupServiceForRename) AddGroup(model *group.AddGroupReq) error { return nil }
+func (f *fakeGroupServiceForRename) GetGroupWithDateSpace(startDate, endDate string) (map[string]int64, error) {
+	return nil, nil
+}
+func (f *fakeGroupServiceForRename) GetGroupWithGroupNo(groupNo string) (*group.InfoResp, error) { return nil, nil }
+func (f *fakeGroupServiceForRename) GetGroups(groupNos []string) ([]*group.InfoResp, error)    { return nil, nil }
+func (f *fakeGroupServiceForRename) GetGroupDetails(groupNos []string, uid string) ([]*group.GroupResp, error) {
+	return nil, nil
+}
+func (f *fakeGroupServiceForRename) GetGroupDetail(groupNo, uid string) (*group.GroupResp, error) { return nil, nil }
+func (f *fakeGroupServiceForRename) GetSettings(groupNos []string, uid string) ([]*group.SettingResp, error) {
+	return nil, nil
+}
+func (f *fakeGroupServiceForRename) GetSettingsWithUIDs(groupNo string, uids []string) ([]*group.SettingResp, error) {
+	return nil, nil
+}
+func (f *fakeGroupServiceForRename) GetMembers(groupNo string) ([]*group.MemberResp, error) { return nil, nil }
+func (f *fakeGroupServiceForRename) GetMemberExternalMarkers(groupNo string) (map[string]group.MemberExternalMarker, error) {
+	return nil, nil
+}
+func (f *fakeGroupServiceForRename) GetMemberExternalFields(groupNo, uid string) (int, string, string, string, string, error) {
+	return 0, "", "", "", "", nil
+}
+func (f *fakeGroupServiceForRename) GetMember(groupNo, uid string) (*group.MemberResp, error) { return nil, nil }
+func (f *fakeGroupServiceForRename) GetBlacklistMemberUIDs(groupNo string) ([]string, error) { return nil, nil }
+func (f *fakeGroupServiceForRename) GetSubscribableMemberUIDs(groupNo string) ([]string, error) {
+	return nil, nil
+}
+func (f *fakeGroupServiceForRename) GetMemberUIDsOfManager(groupNo string) ([]string, error) { return nil, nil }
+func (f *fakeGroupServiceForRename) IsCreatorOrManager(groupNo, uid string) (bool, error)    { return false, nil }
+func (f *fakeGroupServiceForRename) IsRobot(uid string) (bool, error)                        { return false, nil }
+func (f *fakeGroupServiceForRename) GetMemberTotalAndOnlineCount(groupNo string) (int, int, error) {
+	return 0, 0, nil
+}
+func (f *fakeGroupServiceForRename) ExistMember(groupNo, uid string) (bool, error) {
+	return f.existMemberActive, f.existMemberErr
+}
+func (f *fakeGroupServiceForRename) ExistMemberActive(groupNo, uid string) (bool, error) {
+	return f.existMemberActive, f.existMemberErr
+}
+func (f *fakeGroupServiceForRename) ExistMemberActiveInternal(groupNo, uid string) (bool, error) { return false, nil }
+func (f *fakeGroupServiceForRename) ExistMembers(groupNos []string, uid string) ([]string, error) {
+	return nil, nil
+}
+func (f *fakeGroupServiceForRename) ExistMembersActive(groupNos []string, uid string) ([]string, error) {
+	return nil, nil
+}
+func (f *fakeGroupServiceForRename) GetGroupsWithMemberUID(uid string) ([]*group.InfoResp, error) { return nil, nil }
+func (f *fakeGroupServiceForRename) GetGroupMemberMaxVersion(groupNo string) (int64, error)      { return 0, nil }
+func (f *fakeGroupServiceForRename) GetUserSupers(uid string) ([]*group.InfoResp, error)        { return nil, nil }
+func (f *fakeGroupServiceForRename) AddMember(model *group.AddMemberReq) error                  { return nil }
+func (f *fakeGroupServiceForRename) GetMembersWithUIDAndGroupIds(uid string, groupNos []string) ([]*group.MemberResp, error) {
+	return nil, nil
+}
+func (f *fakeGroupServiceForRename) GetManagersWithGroupNos(groupNos []string) ([]*group.MemberResp, error) {
+	return nil, nil
+}
+func (f *fakeGroupServiceForRename) GetGroupMd(groupNo string) (*group.GroupMdResult, error) { return nil, nil }
+func (f *fakeGroupServiceForRename) UpdateGroupMd(groupNo, content, updatedBy string) (int64, error) {
+	return 0, nil
+}
+func (f *fakeGroupServiceForRename) DeleteGroupMd(groupNo string) (int64, error) { return 0, nil }
+func (f *fakeGroupServiceForRename) IsBotAdmin(groupNo, uid string) (bool, error) {
+	return false, nil
+}
+func (f *fakeGroupServiceForRename) GetBotMemberUIDs(groupNo string) ([]string, error) { return nil, nil }
+func (f *fakeGroupServiceForRename) CreateGroup(req *group.CreateGroupServiceReq) (*group.CreateGroupServiceResp, error) {
+	return nil, nil
+}
+func (f *fakeGroupServiceForRename) AddGroupMembers(req *group.AddGroupMembersServiceReq) (*group.AddGroupMembersServiceResp, error) {
+	return nil, nil
+}
+func (f *fakeGroupServiceForRename) RemoveGroupMembers(req *group.RemoveGroupMembersServiceReq) (*group.RemoveGroupMembersServiceResp, error) {
+	return nil, nil
+}
+func (f *fakeGroupServiceForRename) RemoveUserFromGroupThreads(groupNo, uid, spaceID string) {}
+func (f *fakeGroupServiceForRename) UpdateGroupInfo(req *group.UpdateGroupInfoServiceReq) error {
+	return nil
+}
+func (f *fakeGroupServiceForRename) UpdateGroupAvatarCustom(req *group.UpdateGroupAvatarCustomServiceReq) error {
+	return nil
+}
+
+type fakeThreadServiceForRename struct {
+	updateNameErr error
+}
+
+func (f *fakeThreadServiceForRename) UpdateName(groupNo, shortID, operatorUID, name string) error {
+	return f.updateNameErr
+}
+func (f *fakeThreadServiceForRename) CreateThread(req *thread.CreateThreadReq) (*thread.ThreadResp, error) {
+	return nil, nil
+}
+func (f *fakeThreadServiceForRename) GetThreads(groupNo string, statuses []int, pageIndex, pageSize int64) ([]*thread.ThreadResp, int64, error) {
+	return nil, 0, nil
+}
+func (f *fakeThreadServiceForRename) GetThread(groupNo, shortID, loginUID string) (*thread.ThreadResp, error) {
+	return nil, nil
+}
+func (f *fakeThreadServiceForRename) ArchiveThread(groupNo, shortID, operatorUID string) error   { return nil }
+func (f *fakeThreadServiceForRename) UnarchiveThread(groupNo, shortID, operatorUID string) error { return nil }
+func (f *fakeThreadServiceForRename) DeleteThread(groupNo, shortID, operatorUID string) error   { return nil }
+func (f *fakeThreadServiceForRename) CanDelete(groupNo, shortID, uid string) (bool, error)      { return false, nil }
+func (f *fakeThreadServiceForRename) ExistThread(groupNo, shortID string) (bool, error)         { return false, nil }
+func (f *fakeThreadServiceForRename) JoinThread(groupNo, shortID, uid string) error             { return nil }
+func (f *fakeThreadServiceForRename) LeaveThread(groupNo, shortID, uid string) error            { return nil }
+func (f *fakeThreadServiceForRename) GetMembers(groupNo, shortID string) ([]*thread.MemberResp, error) {
+	return nil, nil
+}
+func (f *fakeThreadServiceForRename) GetMemberUIDs(groupNo, shortID string) ([]string, error) { return nil, nil }
+func (f *fakeThreadServiceForRename) IsMember(groupNo, shortID, uid string) (bool, error)     { return false, nil }
+func (f *fakeThreadServiceForRename) GetThreadMd(groupNo, shortID string) (*thread.ThreadMdResult, error) {
+	return nil, nil
+}
+func (f *fakeThreadServiceForRename) UpdateThreadMd(groupNo, shortID, content, updatedBy string) (int64, error) {
+	return 0, nil
+}
+func (f *fakeThreadServiceForRename) DeleteThreadMd(groupNo, shortID, deletedBy string) (int64, error) {
+	return 0, nil
+}
+func (f *fakeThreadServiceForRename) CanEditThreadMd(groupNo, shortID, uid string) (bool, error) {
+	return false, nil
+}
+func (f *fakeThreadServiceForRename) UpdateSetting(groupNo, shortID, uid string, settings map[string]interface{}) error {
+	return nil
+}
+func (f *fakeThreadServiceForRename) GetSettingsWithUIDs(groupNo, shortID string, uids []string) ([]*thread.SettingResp, error) {
+	return nil, nil
+}
+
+const (
+	trBotToken = "bf_rename_test_token"
+	trRobotID  = "bot_rename_test"
+	// valid 32-hex groupNo
+	trGroupNo = "0123456789abcdef0123456789abcdef"
+	// valid 15-20 digit shortID
+	trShortID = "148910429168271360"
+)
+
+func newRenameTestEngine(t *testing.T, groupSvc *fakeGroupServiceForRename, threadSvc *fakeThreadServiceForRename) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	ba := &BotAPI{
+		Log:           log.NewTLog("BotAPI-rename-test"),
+		groupService:  groupSvc,
+		threadService: threadSvc,
+	}
+
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		auth := c.GetHeader("Authorization")
+		if strings.HasPrefix(auth, "Bearer ") {
+			c.Set(CtxKeyRobotID, trRobotID)
+			c.Set(CtxKeyBotKind, BotKindUser)
+		}
+		c.Next()
+	})
+	r.PUT("/v1/bot/groups/:group_no/threads/:short_id", func(gc *gin.Context) {
+		ba.botRenameThread(&wkhttp.Context{Context: gc})
+	})
+	return r
+}
+
+func doRenamePUT(t *testing.T, r *gin.Engine, groupNo, shortID string, body interface{}) *httptest.ResponseRecorder {
+	t.Helper()
+	var buf *bytes.Buffer
+	if body != nil {
+		b, err := json.Marshal(body)
+		if err != nil {
+			t.Fatalf("marshal body: %v", err)
+		}
+		buf = bytes.NewBuffer(b)
+	} else {
+		buf = &bytes.Buffer{}
+	}
+	path := "/v1/bot/groups/" + groupNo + "/threads/" + shortID
+	req, err := http.NewRequest(http.MethodPut, path, buf)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+trBotToken)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w
+}
+
+// Happy path: valid params, service returns nil → 200 OK
+func TestBotRenameThread_HappyPath(t *testing.T) {
+	groupSvc := &fakeGroupServiceForRename{existMemberActive: true}
+	threadSvc := &fakeThreadServiceForRename{}
+	r := newRenameTestEngine(t, groupSvc, threadSvc)
+
+	w := doRenamePUT(t, r, trGroupNo, trShortID, map[string]string{"name": "new thread name"})
+	assert.Equal(t, http.StatusOK, w.Code, "happy path should return 200, body=%s", w.Body.String())
+}
+
+// Error path: empty/missing name → 400 (bind error)
+func TestBotRenameThread_EmptyName(t *testing.T) {
+	groupSvc := &fakeGroupServiceForRename{existMemberActive: true}
+	threadSvc := &fakeThreadServiceForRename{}
+	r := newRenameTestEngine(t, groupSvc, threadSvc)
+
+	w := doRenamePUT(t, r, trGroupNo, trShortID, map[string]string{"name": ""})
+	assert.Equal(t, http.StatusBadRequest, w.Code, "empty name should return 400, body=%s", w.Body.String())
+	assert.Contains(t, w.Body.String(), errcode.ErrBotAPIRequestInvalid.DefaultMessage)
+}
+
+// Error path: invalid short_id (non-numeric) → 400
+func TestBotRenameThread_InvalidShortID(t *testing.T) {
+	groupSvc := &fakeGroupServiceForRename{existMemberActive: true}
+	threadSvc := &fakeThreadServiceForRename{}
+	r := newRenameTestEngine(t, groupSvc, threadSvc)
+
+	w := doRenamePUT(t, r, trGroupNo, "abc123", map[string]string{"name": "new name"})
+	assert.Equal(t, http.StatusBadRequest, w.Code, "invalid short_id should return 400, body=%s", w.Body.String())
+	assert.Contains(t, w.Body.String(), errcode.ErrBotAPIRequestInvalid.DefaultMessage)
+}
+
+// Error path: invalid group_no (wrong length) → 400
+func TestBotRenameThread_InvalidGroupNo(t *testing.T) {
+	groupSvc := &fakeGroupServiceForRename{existMemberActive: true}
+	threadSvc := &fakeThreadServiceForRename{}
+	r := newRenameTestEngine(t, groupSvc, threadSvc)
+
+	w := doRenamePUT(t, r, "shortgno", trShortID, map[string]string{"name": "new name"})
+	assert.Equal(t, http.StatusBadRequest, w.Code, "invalid group_no should return 400, body=%s", w.Body.String())
+	assert.Contains(t, w.Body.String(), errcode.ErrBotAPIRequestInvalid.DefaultMessage)
+}
+
+// Error path: service UpdateName returns error → 500 (ErrBotAPIStoreFailed)
+func TestBotRenameThread_ServiceError(t *testing.T) {
+	groupSvc := &fakeGroupServiceForRename{existMemberActive: true}
+	threadSvc := &fakeThreadServiceForRename{updateNameErr: errors.New("db error")}
+	r := newRenameTestEngine(t, groupSvc, threadSvc)
+
+	w := doRenamePUT(t, r, trGroupNo, trShortID, map[string]string{"name": "new name"})
+	// ErrBotAPIStoreFailed via ResponseErrorL returns legacy 400 (D14 compatibility)
+	assert.Equal(t, http.StatusBadRequest, w.Code, "service error should return 400 (D14 legacy), body=%s", w.Body.String())
+	assert.Contains(t, w.Body.String(), errcode.ErrBotAPIStoreFailed.DefaultMessage)
+}

--- a/modules/bot_api/threads_rename_test.go
+++ b/modules/bot_api/threads_rename_test.go
@@ -264,13 +264,13 @@ func TestBotRenameThread_EmptyName(t *testing.T) {
 // Error path: whitespace-only name → treated as empty after TrimSpace, service returns error → 400
 func TestBotRenameThread_WhitespaceName(t *testing.T) {
 	groupSvc := &fakeGroupServiceForRename{existMemberActive: true, existMemberActiveInternal: true}
-	threadSvc := &fakeThreadServiceForRename{updateNameAsBotErr: errors.New("name is required")}
+	threadSvc := &fakeThreadServiceForRename{}
 	r := newRenameTestEngine(t, groupSvc, threadSvc)
 
 	w := doRenamePUT(t, r, trGroupNo, trShortID, map[string]string{"name": "   "})
-	// binding:"required" passes for "   "; TrimSpace → ""; service rejects → ErrBotAPIStoreFailed
+	// binding:"required" passes for "   "; TrimSpace → ""; handler rejects → request_invalid
 	assert.Equal(t, http.StatusBadRequest, w.Code, "whitespace name should return 400, body=%s", w.Body.String())
-	assert.Contains(t, w.Body.String(), errcode.ErrBotAPIStoreFailed.DefaultMessage)
+	assert.Contains(t, w.Body.String(), errcode.ErrBotAPIRequestInvalid.DefaultMessage)
 }
 
 // Error path: invalid short_id (non-numeric) → 400

--- a/modules/bot_api/threads_rename_test.go
+++ b/modules/bot_api/threads_rename_test.go
@@ -261,7 +261,7 @@ func TestBotRenameThread_EmptyName(t *testing.T) {
 	assert.Contains(t, w.Body.String(), errcode.ErrBotAPIRequestInvalid.DefaultMessage)
 }
 
-// Error path: whitespace-only name → treated as empty after TrimSpace, service returns error → 400
+// Error path: whitespace-only name → treated as empty after TrimSpace, handler rejects before service → 400
 func TestBotRenameThread_WhitespaceName(t *testing.T) {
 	groupSvc := &fakeGroupServiceForRename{existMemberActive: true, existMemberActiveInternal: true}
 	threadSvc := &fakeThreadServiceForRename{}

--- a/modules/thread/rename_permission_matrix_test.go
+++ b/modules/thread/rename_permission_matrix_test.go
@@ -126,3 +126,46 @@ func TestThreadUpdateName_ExternalMember_Denied(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "原始子区名", got.Name, "外部成员被拒后子区名不变")
 }
+
+// TestThreadUpdateNameAsBot_NormalInternalBot_Allowed 覆盖 bot 改名正常路径：
+// bot 为父群内部活跃成员（is_external=0）→ 可改子区名。
+func TestThreadUpdateNameAsBot_NormalInternalBot_Allowed(t *testing.T) {
+	svc, groupNo, shortID, robotID := seedRenameThreadExternal(t, int(common.GroupMemberStatusNormal), 1, 0)
+
+	err := svc.UpdateNameAsBot(groupNo, shortID, robotID, "bot改的新名")
+	require.NoError(t, err, "内部活跃 bot 应能改子区名")
+
+	got, err := svc.GetThread(groupNo, shortID, robotID)
+	require.NoError(t, err)
+	require.Equal(t, "bot改的新名", got.Name)
+}
+
+// TestThreadUpdateNameAsBot_ExternalBot_Denied 覆盖安全边界（YUJ-231 / GH#1289）：
+// 跨 Space 外部 bot（is_external=1, robot=1）即便活跃，也禁止改子区名——
+// bot 路径必须与人类路径保持一致的 is_external=0 门禁。
+func TestThreadUpdateNameAsBot_ExternalBot_Denied(t *testing.T) {
+	svc, groupNo, shortID, robotID := seedRenameThreadExternal(t, int(common.GroupMemberStatusNormal), 1, 1)
+
+	err := svc.UpdateNameAsBot(groupNo, shortID, robotID, "外部bot改名")
+	require.Error(t, err, "外部 bot 应被拒绝改子区名")
+	require.Contains(t, err.Error(), "no permission")
+
+	got, err := svc.GetThread(groupNo, shortID, robotID)
+	require.NoError(t, err)
+	require.Equal(t, "原始子区名", got.Name, "外部 bot 被拒后子区名不变")
+}
+
+// TestThreadUpdateNameAsBot_BlacklistedBot_Denied 覆盖：
+// 被拉黑 bot（status=Blacklist）在 handler 层已被 ExistMemberActive 拦截，
+// 但若绕过 handler 直接调 service，ExistMemberActiveInternal 也应拒绝（fail-closed）。
+func TestThreadUpdateNameAsBot_BlacklistedBot_Denied(t *testing.T) {
+	svc, groupNo, shortID, robotID := seedRenameThreadExternal(t, int(common.GroupMemberStatusBlacklist), 1, 0)
+
+	err := svc.UpdateNameAsBot(groupNo, shortID, robotID, "黑名单bot改名")
+	require.Error(t, err, "被拉黑 bot 应被拒绝改子区名")
+	require.Contains(t, err.Error(), "no permission")
+
+	got, err := svc.GetThread(groupNo, shortID, robotID)
+	require.NoError(t, err)
+	require.Equal(t, "原始子区名", got.Name, "被拉黑 bot 被拒后子区名不变")
+}

--- a/modules/thread/service.go
+++ b/modules/thread/service.go
@@ -39,6 +39,8 @@ type IService interface {
 	CreateThread(req *CreateThreadReq) (*ThreadResp, error)
 	// UpdateName 修改子区名称
 	UpdateName(groupNo, shortID, operatorUID, name string) error
+	// UpdateNameAsBot Bot API 专用：修改子区名称（Bot 权限已在 handler 层校验，此处不做成员/机器人权限检查）
+	UpdateNameAsBot(groupNo, shortID, name string) error
 	// GetThreads 分页获取群下的子区，同时返回总数。
 	// statuses 决定包含的 status 集合（active / archived / 二者）；nil 或空一律按 active。
 	GetThreads(groupNo string, statuses []int, pageIndex, pageSize int64) ([]*ThreadResp, int64, error)
@@ -542,6 +544,42 @@ func (s *Service) UpdateName(groupNo, shortID, operatorUID, name string) error {
 
 	// 子区改名后失效离线推送标题缓存（推送标题含子区名），否则手机推送会沿用旧子区名直到
 	// TTL 过期。best-effort：失败仅告警，TTL 兜底。
+	channelID := BuildChannelID(groupNo, shortID)
+	if err := pushcache.InvalidateThreadName(s.ctx.GetRedisConn(), channelID); err != nil {
+		s.Warn("失效子区名推送缓存失败", zap.String("channel_id", channelID), zap.Error(err))
+	}
+	return nil
+}
+
+// UpdateNameAsBot Bot API 专用：修改子区名称。
+// Bot 权限已在 handler 层通过 validateBotThreadAccess 保证（bot 是群活跃成员），
+// 此处不做成员/机器人权限检查，仅做 name 校验、子区存在性检查和缓存失效。
+func (s *Service) UpdateNameAsBot(groupNo, shortID, name string) error {
+	if name == "" || len([]rune(name)) > 100 {
+		return errors.New("name is required and must not exceed 100 characters")
+	}
+
+	thread, err := s.db.QueryByGroupNoAndShortID(groupNo, shortID)
+	if err != nil {
+		return fmt.Errorf("query thread: %w", err)
+	}
+	if thread == nil {
+		return errors.New("thread not found")
+	}
+	if thread.Status == ThreadStatusDeleted {
+		return errors.New("thread has been deleted")
+	}
+
+	if err := s.db.UpdateName(shortID, name, s.threadVersionGen()); err != nil {
+		switch {
+		case errors.Is(err, ErrThreadNotFound):
+			return errors.New("thread not found")
+		case errors.Is(err, ErrThreadDeleted):
+			return errors.New("thread has been deleted")
+		}
+		return fmt.Errorf("update thread name: %w", err)
+	}
+
 	channelID := BuildChannelID(groupNo, shortID)
 	if err := pushcache.InvalidateThreadName(s.ctx.GetRedisConn(), channelID); err != nil {
 		s.Warn("失效子区名推送缓存失败", zap.String("channel_id", channelID), zap.Error(err))

--- a/modules/thread/service.go
+++ b/modules/thread/service.go
@@ -39,8 +39,12 @@ type IService interface {
 	CreateThread(req *CreateThreadReq) (*ThreadResp, error)
 	// UpdateName 修改子区名称
 	UpdateName(groupNo, shortID, operatorUID, name string) error
-	// UpdateNameAsBot Bot API 专用：修改子区名称（Bot 权限已在 handler 层校验，此处不做成员/机器人权限检查）
-	UpdateNameAsBot(groupNo, shortID, name string) error
+	// UpdateNameAsBot Bot API 专用：修改子区名称。
+	// Handler 层 validateBotThreadAccess 已保证 bot 是父群活跃成员且非 App Bot；
+	// 此处额外用 ExistMemberActiveInternal 校验 is_external=0，与人类端改名保持一致，
+	// 防止跨 Space 外部成员（is_external=1）越权改名（YUJ-231 / GH#1289，P1）。
+	// IsRobot 检查有意省略——bot 身份正是该方法的调用场景。
+	UpdateNameAsBot(groupNo, shortID, robotID, name string) error
 	// GetThreads 分页获取群下的子区，同时返回总数。
 	// statuses 决定包含的 status 集合（active / archived / 二者）；nil 或空一律按 active。
 	GetThreads(groupNo string, statuses []int, pageIndex, pageSize int64) ([]*ThreadResp, int64, error)
@@ -552,9 +556,11 @@ func (s *Service) UpdateName(groupNo, shortID, operatorUID, name string) error {
 }
 
 // UpdateNameAsBot Bot API 专用：修改子区名称。
-// Bot 权限已在 handler 层通过 validateBotThreadAccess 保证（bot 是群活跃成员），
-// 此处不做成员/机器人权限检查，仅做 name 校验、子区存在性检查和缓存失效。
-func (s *Service) UpdateNameAsBot(groupNo, shortID, name string) error {
+// Bot 权限在 handler 层通过 validateBotThreadAccess 保证（bot 是父群活跃成员，非 App Bot）；
+// 此处额外校验 is_external=0（ExistMemberActiveInternal），与人类端改名保持一致，
+// 防止跨 Space 外部 bot（is_external=1）越权改名（YUJ-231 / GH#1289，P1）。
+// IsRobot 检查有意省略——bot 身份正是该方法的调用场景。
+func (s *Service) UpdateNameAsBot(groupNo, shortID, robotID, name string) error {
 	if name == "" || len([]rune(name)) > 100 {
 		return errors.New("name is required and must not exceed 100 characters")
 	}
@@ -568,6 +574,14 @@ func (s *Service) UpdateNameAsBot(groupNo, shortID, name string) error {
 	}
 	if thread.Status == ThreadStatusDeleted {
 		return errors.New("thread has been deleted")
+	}
+
+	isInternal, err := s.groupService.ExistMemberActiveInternal(thread.GroupNo, robotID)
+	if err != nil {
+		return fmt.Errorf("check active membership: %w", err)
+	}
+	if !isInternal {
+		return errors.New("no permission to update")
 	}
 
 	if err := s.db.UpdateName(shortID, name, s.threadVersionGen()); err != nil {


### PR DESCRIPTION
Fixes #664

## 改动摘要
- 在 `modules/bot_api/bot_api.go` Thread API 路由组（DELETE thread 之后）注册 `PUT /v1/bot/groups/:group_no/threads/:short_id` → `botRenameThread`
- 在 `modules/thread/service.go` 新增 `IService.UpdateNameAsBot(groupNo, shortID, robotID, name string) error` 方法：bot 专用改名路径，handler 已通过 `validateBotThreadAccess` + `ExistMemberActive` 确认 bot 是群活跃成员；service 内部额外调用 `ExistMemberActiveInternal(thread.GroupNo, robotID)` 保持 `is_external=0` 边界（防止跨 Space 外部 bot 越权改名，对齐用户端 `UpdateName` 的 YUJ-231/GH#1289 P1 门禁）；跳过 `IsRobot` 检查（这是 bot 专用路径，handler 传入的就是 bot 身份）；保留 name 校验（非空、≤100 runes）、thread 存在/未删除校验、`db.UpdateName` 版本 CAS 调用、push-title 缓存失效逻辑
- 在 `modules/bot_api/threads.go` 新增 `botRenameThread` handler：
  - 先调 `validateBotThreadAccess` 做 bot 群成员门禁（`ExistMemberActive`、非 App Bot、非黑名单）
  - 用 `ShouldBindJSON` 解析 `{"name": "..."}`，`binding:"required,max=100"`
  - `strings.TrimSpace(name)` 后若为空直接返回 `request_invalid`（HTTP 400）
  - 调 `ba.threadService.UpdateNameAsBot(groupNo, shortID, robotID, trimmedName)`
  - 参数/service 错误返回 `ErrBotAPIStoreFailed`，成功返回 200 OK
  - error log 含 `robotID/groupNo/shortID`
- 人类端 `UpdateName` 的 `IsRobot` 拒绝权限逻辑和 `ExistMemberActiveInternal` 边界保持不变，bot 与人类路径互不干扰
- 新增单元测试：
  - `modules/bot_api/threads_rename_test.go`：9 个 handler 测试覆盖 happy path、empty name、whitespace-only name（→request_invalid）、invalid short_id、invalid group_no、service error、name too long（101 runes）、non-member bot（→not_group_member）、App Bot（→app_bot_unsupported）
  - `modules/thread/rename_permission_matrix_test.go`：3 个 service 测试覆盖内部活跃 bot 成功、外部 bot（is_external=1）拒绝、黑名单 bot 拒绝（需要 MySQL 环境）
  - `modules/bot_api/threads_blacklist_test.go`：doc comment 加入 `botRenameThread`

## 验收证据
1. 路由注册：
```
$ grep -n 'PUT("/groups/:group_no/threads/:short_id"' modules/bot_api/bot_api.go
294:		botAPI.PUT("/groups/:group_no/threads/:short_id", ba.botRenameThread)
```
（该路由在 `r.Group("/v1/bot", ba.authBot())` 下，完整路径为 `PUT /v1/bot/groups/:group_no/threads/:short_id`）

2. `go build ./... && go vet ./...` 通过（无输出即成功）

3. Handler 单元测试（无 MySQL 依赖）：`go test ./modules/bot_api/... -run "^TestBotRenameThread" -v`
```
=== RUN   TestBotRenameThread_HappyPath         --- PASS
=== RUN   TestBotRenameThread_EmptyName         --- PASS
=== RUN   TestBotRenameThread_WhitespaceName    --- PASS
=== RUN   TestBotRenameThread_InvalidShortID    --- PASS
=== RUN   TestBotRenameThread_InvalidGroupNo    --- PASS
=== RUN   TestBotRenameThread_ServiceError      --- PASS
=== RUN   TestBotRenameThread_NameTooLong       --- PASS
=== RUN   TestBotRenameThread_NotGroupMember    --- PASS
=== RUN   TestBotRenameThread_AppBotDenied      --- PASS
PASS
ok  	github.com/Mininglamp-OSS/octo-server/modules/bot_api	0.963s
```
（其他需要 MySQL 的集成测试在本地无 MySQL 环境下 panic，属既有环境问题，非本次改动引入；service 层 permission matrix 测试在 CI 有 MySQL 环境时执行）

## Comprehension gate
本改动是 Bot API facade 补全端点，新增 bot 专用 service 方法 `UpdateNameAsBot`。该方法：
- **绕过**用户端 `UpdateName` 的 `IsRobot` 检查（bot 权限已在 handler 层由 `validateBotThreadAccess` 保证，`IsRobot` 检查对 bot 路径是反向门禁）
- **保留** `ExistMemberActiveInternal`（is_external=0）边界，防止跨 Space 外部 bot 越权改名，与人类端权限边界一致（YUJ-231/GH#1289）
- 人类端 `UpdateName` 权限逻辑（IsRobot 拒绝 + ExistMemberActiveInternal）完全不变
- 无公开协议/schema/依赖变更，回滚方式：revert 本 PR

## Out of scope
- 未修改前端/文档/其他 bot 端点
- 未改人类端 `UpdateName` 权限逻辑
- 未做 error classification 精细化（store_failed 覆盖了 thread not found/deleted 等情况，属 legacy D14 行为，follow-up 可优化）
