### PR TITLE
feat(cardtmpl): publish bounded reasoning template successor

### DIFF
--- a/.octospec/tasks/cardtmpl-reasoning-schema-successor/brief.md
+++ b/.octospec/tasks/cardtmpl-reasoning-schema-successor/brief.md
@@ -1,0 +1,322 @@
+---
+type: Task
+title: "Task: cardtmpl-reasoning-schema-successor"
+description: Publish a bounded ai.reasoning-process successor, keep 0.1.0 immutable, and cut Bot discovery/send to the successor without stranding legacy Registry edits.
+tags: [card, cardtmpl, ai-reasoning-process, json-template, bot-api, wire-contract, trust-boundary, space, isolation, auth, testing]
+timestamp: 2026-07-25T12:47:51+08:00
+# --- octospec extension fields ---
+slug: cardtmpl-reasoning-schema-successor
+upstream: "roadmap E1c; follows PR #657 and PR #659"
+source: self
+---
+
+# Task: cardtmpl-reasoning-schema-successor
+
+> One task = one `.octospec/tasks/<slug>/` directory. This brief is the spec for
+> the work. AI may draft it from existing code; a human confirms it.
+
+## Goal
+
+发布 `ai.reasoning-process` 的有界 successor（建议
+`ai.reasoning-process@0.2.0`），在不修改已发布 `0.1.0`、不改变卡片视觉和
+`template-ref/v1` wire 形状的前提下完成三件事：
+
+1. 为所有非枚举自由字符串补 `maxLength`，为 `phases`、每个 phase 的 `actions`
+   补 `maxItems`，并在进入 JSON 模板展开前强制“所有 phase 的 actions 合计不超过
+   12”这一聚合约束；
+2. 在 Registry 中同时注册冻结的 `0.1.0` 和 successor，并把该模板的 Registry
+   default 切到 successor；
+3. Bot capability 与新 send 只广告/接受 successor，同时保留对已存在
+   `0.1.0` Registry 卡的同版本 edit 能力，避免 catalog 切换直接冻结在途卡。
+
+本任务是 Model A 生产启用前的 schema/cutover 硬化，不负责打开生产开关。
+`OCTO_BOT_CARD_ENABLED` 在生产仍保持 `false`；stop/retry 真实业务闭环仍由 roadmap
+E1e 承接。
+
+## Background
+
+### 已交付基线
+
+- PR #657 发布并注册了 `ai.reasoning-process@0.1.0`；该版本的五个 state、三个
+  view、模板、actions、samples 和 goldens 已冻结。
+- PR #659（squash `a8575cd2`）交付 `template-ref/v1` 的 capability、send 和 edit
+  协议。Bot catalog 是显式授权边界，不等于 `Registry.List()`。
+- `0.1.0` 已完成一次实验环境 Model A lifecycle 验证，但这不代表生产已启用，也不
+  解除 schema hardening 与 stop/retry 业务闭环门槛。
+
+### 为什么必须发新版本
+
+`0.1.0` 的 `state`、`statusTone`、action `statusTone` 已由 enum 有界，
+`statusGlyph.maxLength=2`；但以下 11 个自由字符串仍无 `maxLength`：
+
+- `reasoningId`
+- `title`
+- `statusLabel`
+- `timerText`
+- `collapsedSummary`
+- `progressText`
+- `phases[].thought`
+- `phases[].actions[].tool`
+- `phases[].actions[].detail`
+- `errorTitle`
+- `errorMessage`
+
+`phases` 与 `phases[].actions` 也只有 `minItems: 1`，没有 `maxItems`。现有 HTTP
+body、JSON 展开、card node/depth 和最终 payload 上限仍会 fail-close，但病理输入可以
+先通过 schema、消耗模板展开，再以笼统 render error 失败。调用方数据造成的确定性超限
+应在 Build 前归类为 `ErrFieldsInvalid`，不能伪装成服务端 5xx。
+
+平台 L1 冻结规则明确要求：同一 `id@version` 发布后，contract/samples/reports 不再
+修改；需要收紧 schema 必须发布新版本，旧目录原样保留。因此禁止直接修补
+`ai.reasoning-process@0.1.0/contract/data.schema.json`。
+
+### producer 证据快照
+
+cap 依据来自本机 OpenClaw Octo consumer checkout
+`/Users/fangling/conductor/workspaces/openclaw-channel-octo/gaborone` 的
+`src/reasoning-process.ts` / `src/card-render.ts`，快照 commit
+`530bc2dcac4a09ce9fb488c1799e266b610d461c`。该分支尚不能视为已合并/发布；这里只把
+它作为当前真实 producer 行为证据：
+
+- `THOUGHT_MAX=280`，超长时 `slice(0, 280) + "…"`，实际输出上限为 281 个
+  UTF-16 code units；
+- `TOOL_NAME_MAX=80`，同样因追加省略号，实际输出上限为 81；
+- `MAX_RENDERED_PHASES=6`；
+- `MAX_RENDERED_ACTIONS=12`，是所有保留 phase 的 action 合计，而不是每个 phase 12；
+- 参数摘要最多 64 后追加省略号（输出至多 65），错误摘要最多 120 后追加省略号
+  （输出至多 121）；二者以 `" · "` 合并时当前 `detail` 上限为 189；
+- `errorMessage` 走同一 120+省略号清洗，上限为 121；
+- `reasoningId = sessionKey + ":" + runId` 当前没有 producer 本地 cap。
+
+JSON Schema `maxLength` 按 Unicode 字符/rune 计数；JavaScript 当前按 UTF-16 code
+unit 截断。由于 code point 数不会大于 code unit 数，下表给
+`thought/tool/errorMessage` 预留追加省略号后的值，可兼容当前 producer。producer
+后续若改为 code-point-aware 截断，也必须继续满足 successor schema。
+
+### 建议 cap 表（待 D2 人工确认）
+
+| 路径 | successor 建议上限 | 依据/边界 |
+| --- | ---: | --- |
+| `reasoningId` | 512 | 平台建议值；producer 当前无 cap。超限不得盲目截断导致 ID 碰撞，应 fail closed 或改用稳定摘要 ID |
+| `title` | 64 | 单行标题产品上限建议；当前 producer 为固定短文案 |
+| `statusLabel` | 32 | badge 短文案产品上限建议 |
+| `timerText` | 128 | 单行耗时/计数文案产品上限建议 |
+| `collapsedSummary` | 160 | 收起态单行摘要产品上限建议 |
+| `progressText` | 160 | 活动态单行进度文案产品上限建议 |
+| `phases` | 6 items | 当前 producer `MAX_RENDERED_PHASES` |
+| `phases[].thought` | 281 | 当前 producer 280 + `…` |
+| `phases[].actions` | 12 items/phase | 嵌套数组必须自身有界；另有全卡 aggregate 12 |
+| 所有 `phases[].actions` 合计 | 12 items | 当前 producer `MAX_RENDERED_ACTIONS`；draft-07 不能仅靠普通 `maxItems` 表达 |
+| `phases[].actions[].tool` | 81 | 当前 producer 80 + `…` |
+| `phases[].actions[].detail` | 192 | 当前最大 189（65 + 3 + 121），向上取整留 3 字符余量 |
+| `errorTitle` | 64 | 单行错误标题产品上限建议；当前 producer 为固定短文案 |
+| `errorMessage` | 121 | 当前 producer 120 + `…` |
+
+上表中 producer 已有依据的值可以直接锁定；`reasoningId` 与几类固定/单行文案是本
+brief 的平台建议值，不伪装成既有产品契约。D2 未确认前不进入实现。
+
+### 聚合 action 上限不能只写 schema `maxItems`
+
+draft-07 可以表达 `phases.maxItems=6` 和每个 `actions.maxItems=12`，但不能直接表达
+“所有 phase 的 actions 总数不超过 12”。只写两个 `maxItems` 会允许最多 72 个
+action；该输入虽有界，仍可能通过 schema 后撞上 `cardmsg.MaxNodes=200`，把调用方错误
+误归类成 render failure。
+
+最小落地方式是给 `RegisterJSON` 增加 opt-in 的模板级、Build 前语义校验 seam：
+
+1. 先完成现有 JSON decode + draft-07 schema 校验；
+2. successor schema 以 namespaced 机读扩展声明聚合约束，建议形状如下；该扩展是
+   aggregate limit 的单一真源，不能只把 `12` 写在 Go 常量或 Markdown：
+
+   ```json
+   "x-octo-constraints": {
+     "aggregateArrayLimits": [
+       {
+         "parentArray": "phases",
+         "childArray": "actions",
+         "maxTotalItems": 12
+       }
+     ]
+   }
+   ```
+
+3. `RegisterJSON` 只识别上述窄扩展；缺字段、非正数、目标字段不存在/不是数组等配置错误
+   在注册期 panic。没有该扩展的既有模板行为不变；
+4. successor 的 validator 只读取已解析的 `phases[].actions`，累计超过扩展值即返回字段
+   非法；
+5. 该错误统一包成 `ErrFieldsInvalid`，计入既有 `fields_invalid`，不得进入模板展开；
+6. handler/Bot API 不写 `ai.reasoning-process` 特判；所有 Registry 消费路径获得同一约束。
+
+具体 Go API 可在实现中保持最小，但不能把聚合检查只塞进 send handler，或只依赖
+`cardmsg.Validate` 的后置节点预算。
+
+### catalog cutover 与在途编辑
+
+E1b 的 catalog 当前用同一 ref 集合同时承担“广告给新消息”“允许 send”“允许 edit”。
+如果简单把 `0.1.0` 替换成 successor，所有已经发出的 `0.1.0` Model A 卡都会失去 edit
+能力；如果同时广告两个版本，当前 OpenClaw selector 因“存在多个兼容条目”会 fail
+closed 回 Model B。
+
+本任务采用两个显式、代码评审的集合：
+
+- **advertised/send refs**：只有 successor；用于 capability 输出和新 send 授权；
+- **edit-compatible refs**：`0.1.0` + successor；只用于 edit 前置授权。
+
+legacy edit 仍必须在目标查询前先过 edit allowlist，随后继续核对 stored 顶层
+`template_ref`、`metadata.octo.template`、Bot owner、Space/lifecycle 和 CAS。它只允许
+“已有 `0.1.0` 卡继续以 `0.1.0` 编辑”，不能创建新 `0.1.0` 卡，也不能跨版本改写。
+
+capability 只返回一个 successor 条目，保持现有 consumer 选择无歧义。`0.1.0` 继续在
+Registry 注册，但不再广告，也不再接受新 Bot send。
+
+## Load-bearing list
+
+- **L1 冻结与版本身份（`cardtmpl`, `wire-contract`）** — `0.1.0` 的 manifest、schema、
+  reports、samples、templates、goldens 必须零字节修改；successor 使用新目录和显式版本。
+- **schema/语义前置校验（`cardtmpl`, `trust-boundary`）** — 每个自由字符串与数组有
+  明确上限；聚合 action 约束由 schema namespaced extension 机读声明，在 JSON 模板
+  展开前执行并映射为 `ErrFieldsInvalid`。
+- **JSON 模板资源预算（`cardtmpl`, `trust-boundary`）** — 合法最大 fixture（6 phases、
+  12 actions 合计、字符串均到 cap）必须仍低于 `cardmsg` 节点/深度/payload 上限；不能
+  用一个必然 render 失败的 schema 上限冒充可用契约。
+- **Registry 多版本（`cardtmpl`, `wire-contract`）** — `0.1.0` 与 successor 同时注册，
+  默认版本切 successor；历史消息继续按 stored version 运行。
+- **Bot catalog 授权（`bot-api`, `auth`, `trust-boundary`）** — capability/send 与
+  legacy edit 使用两个最小 allowlist；两者都不是 `Registry.List()` 全量授权。
+- **edit 身份与防枚举（`bot-api`, `space`, `isolation`, `auth`）** — legacy ref 必须先
+  过 edit allowlist，再查询目标；stored provenance、owner、Space/lifecycle、CAS/revision/
+  CMD sync 规则不变。
+- **capability wire（`bot-api`, `wire-contract`）** — `templating.templates` 只广告一个
+  successor；view/state/wire profile/submit action 集合与 `0.1.0` 保持一致，数组顺序仍只
+  是确定性输出，不承载推荐语义。
+- **错误契约（`wire-contract`, `i18n`）** — schema、字符串/数组 cap、聚合 cap 违规均
+  复用 `ErrBotAPICardInvalid` 的 localized 400，零 send/edit；不暴露 schema path、cap
+  内部或 catalog 成员关系。真实 composition failure 仍走 generic internal error。
+- **部署与回滚（`bot-api`, `wire-contract`）** — 本任务不启用生产 gate；新旧二进制对
+  successor edit 的能力非对称，必须显式记录回滚边界。
+- **测试（`testing`）** — cap 边界、聚合约束、多版本注册、catalog 分离、send/edit
+  零副作用及 race 回归均需自动化覆盖。
+
+## Out of scope
+
+- 修改或删除 `ai.reasoning-process@0.1.0` 的任何已发布制品。
+- 改卡片布局、文案、五个 state、三个 view、wire/render profile、Submit/Toggle action
+  ID/data keys 或 `template-ref/v1` 请求形状。
+- OpenClaw consumer 实现、配置 schema、package/release 或默认启用；本任务只使用其
+  当前源码作为 cap 证据。producer 对 `reasoningId` 超限的稳定摘要策略由 E1d 对齐，
+  不在 octo-server PR 中跨仓修改。
+- `reasoning_stop` / `reasoning_retry` 的取消、重试、active-run 注册表或成功状态写回
+  （roadmap E1e）。
+- 打开生产 `OCTO_BOT_CARD_ENABLED`、生产流量灰度或把既有实验 E2E 宣称为生产验收。
+- 新 route、数据库表/迁移、rate limiter、错误码、i18n 文案、动态数据库 catalog、
+  per-bot/per-Space 模板 ACL 或远程模板加载。
+- 通用跨版本 message migration；edit 仍只能保持 stored `id@version` 不变。
+
+## Acceptance
+
+### successor 制品与冻结纪律
+
+- 新增建议目录
+  `pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.2.0/`；manifest
+  `id` 不变，`version=0.2.0`。建议 `contractVersion=1.1.0`，最终值由 D1 确认。
+- `0.2.0` 的 templates、reports、samples、goldens 与 `0.1.0` canonical/字节内容保持
+  一致；允许差异仅限新 manifest 版本元数据和 data schema cap。
+- `git diff origin/main --
+  pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.1.0` 为空；不得通过
+  “顺手格式化”改变冻结目录。
+- Registry 同时能 Lookup 两个版本；default 显式为 successor；五个 state 在两个版本
+  均保持原 view/profile 映射。
+
+### schema 与聚合边界
+
+- 11 个自由字符串均有上表确认后的 `maxLength`；enum 字符串继续由 enum 有界，
+  `statusGlyph.maxLength=2` 不变；所有对象继续 `additionalProperties:false`。
+- successor schema 含确认后的 `x-octo-constraints.aggregateArrayLimits`；注册期从该扩展
+  读取 aggregate 12，malformed/unknown target fail closed。运行期不得另抄一个可能漂移
+  的 magic number。
+- 每个字段用 table-driven test 证明：恰好 cap 个 Unicode 字符通过，cap+1 返回
+  `ErrFieldsInvalid`；至少包含 ASCII、CJK 和 astral emoji 用例，避免误判 rune/byte/
+  UTF-16 语义。
+- `phases=6` 通过、`7` 拒绝；单 phase `actions=12` 通过、`13` 拒绝。
+- actions 合计 12 在单 phase 与跨 6 phases 两种分布都通过；合计 13 即使每个 phase
+  均未超过 12，也必须在 Build/Expand 前以 `ErrFieldsInvalid` 拒绝。
+- 合法最坏 fixture（6 phases、12 actions 合计、所有自由字符串恰到 cap）在 active、
+  result、error view 均能完成 Registry render 并通过 `cardmsg.Validate`，不超过 node、
+  depth 或 payload budget。
+- 聚合 validator 的失败计入既有 `fields_invalid`，不计 `render_error`，且日志/响应不
+  输出完整 caller data。
+
+### conformance 与多版本注册
+
+- successor 的 reasoning、answering、completed、stopped、error 五份 sample 均通过
+  schema、注册期 self-check 与 canonical golden conformance。
+- active/error 的 `submit_actions` 仍分别为 `reasoning_stop` / `reasoning_retry`，result
+  为空；`inlineAction` 等完整 report-drift 遍历面不回退。
+- 现有 `0.1.0` conformance 与 render tests 继续通过，证明新 validator 不被错误应用到
+  legacy 版本或其他 JSON/Go templates。
+
+### capability、send 与 edit cutover
+
+- `GET /v1/bot/card/profile` 的 templating catalog 只含一个
+  `ai.reasoning-process@0.2.0`；views/states/profiles/actions 与冻结版本一致；
+  `enabled:false` 时仍返回同一完整 capability。
+- successor 的 Registry send 成功并保留 server-authored `template_ref@0.2.0`；新 send
+  请求 `0.1.0` 或其他未广告 ref 返回现有 card-invalid，dispatch 为零。
+- successor 卡只能以 `0.2.0` 继续 edit；试图用 `0.1.0` ref 跨版本改写失败，且 revision/
+  message-extra/CMD side effect 均为零。
+- 一个已存、provenance 完整的 `0.1.0` Registry 卡仍可用 `0.1.0` ref edit；该 ref 不
+  出现在 capability，也不能用于新 send。
+- 不在 edit-compatible allowlist 的 ref 在目标 lookup 前 fail closed；现有防消息存在性/
+  owner oracle 顺序不回退。
+- raw Model B send/edit、Registry/raw total XOR、Bot ownership、Space/lifecycle、CAS、
+  transient/revision 与 authoritative `plain` 行为全部保持兼容。
+
+### 验证命令
+
+- `go test ./pkg/cardtmpl/... ./modules/bot_api/... -count=1`
+- `go test ./pkg/cardmsg/... ./internal/carddispatch/... ./internal/cardactiondispatch/... -count=1`
+- `go test -race ./pkg/cardtmpl/... ./modules/bot_api/... -count=1`
+- `go test -race ./internal/carddispatch/... ./internal/cardactiondispatch/... -count=1`
+- `go build ./...`
+- `go vet ./pkg/cardtmpl/... ./modules/bot_api/... ./internal/carddispatch/... ./internal/cardactiondispatch/...`
+- `make i18n-extract-check`
+- `make i18n-lint`
+- `git diff --check`
+
+需要 MySQL/Redis/WuKongIM 的测试按仓库 test environment 执行；若本地依赖不可用，必须
+明确记录未执行项并以 CI 结果补齐，不能写成已验证。
+
+## Rollout / rollback
+
+1. 先以 `OCTO_BOT_CARD_ENABLED=false` 部署包含两个 Registry 版本和新 catalog policy
+   的二进制，等待所有副本 rollout 完成；部署期间不允许生产 Model A 新 send。
+2. capability 即使 gate 关闭也会展示 successor，这是既有 discovery 语义；consumer
+   仍必须先检查顶层 `enabled`。
+3. rollout 后可在隔离实验环境用 successor 重跑 reasoning → answering → completed/error
+   baseline；该验证不打开生产 gate。
+4. 回滚到 E1c 之前的二进制后，已发 successor 卡不能继续 edit，因为旧二进制未注册
+   `0.2.0`。生产 gate 本任务始终关闭，因此不应产生生产 successor 在途卡；实验环境回滚
+   时接受“最后成功帧冻结并告警”，恢复编辑应 roll forward。
+5. 若部署前确认某环境已把 `0.1.0` Model A 当成受支持生产能力，或无法接受上述 rollback
+   边界，则本 brief 的 rollout 假设不成立：必须暂停 cutover，改为两阶段兼容部署/独立
+   active-version 开关后再实施，不能直接合并并启用。
+
+## Decisions for human confirmation
+
+- **D1 — successor identity：**建议模板版本 `0.2.0`、`contractVersion=1.1.0`；
+  `0.1.0` 永久冻结并继续注册。
+- **D2 — exact caps：**确认“建议 cap 表”的全部数值，尤其是目前没有上游产品约束的
+  `reasoningId=512` 和短文案上限。未确认前不实现。
+- **D3 — aggregate actions：**总 action 上限为 12；由 schema 的
+  `x-octo-constraints.aggregateArrayLimits` 作为单一真源，Registry/JSON-template 在
+  pre-Build 执行，拒绝 handler 特判、Go/JSON 双写和 post-render budget 兜底方案。
+- **D4 — catalog policy：**capability + new send 只允许 successor；edit-compatible 集合
+  同时允许 `0.1.0` 与 successor，以保留 legacy 在途编辑但禁止新建 legacy 卡。
+- **D5 — one advertised version：**不同时广告两个兼容版本；当前 consumer 在多版本时
+  fail closed，catalog 必须保持唯一选择。
+- **D6 — immutable edit identity：**不新增跨版本 migration；每条消息从首帧到终态固定
+  stored `id@version`。
+- **D7 — existing public errors：**所有 cap/aggregate 违规继续使用现有 localized
+  card-invalid 400，零副作用；不新增错误码或暴露 schema 内部。
+- **D8 — production gate：**E1c 合并/部署不等于生产启用。生产 gate、E1d consumer
+  release、E1e stop/retry 与跨仓生产级 E2E 仍是后续独立 go/no-go 条件。

--- a/.octospec/tasks/cardtmpl-reasoning-schema-successor/brief.md
+++ b/.octospec/tasks/cardtmpl-reasoning-schema-successor/brief.md
@@ -23,7 +23,7 @@ source: self
 
 1. 为所有非枚举自由字符串补 `maxLength`，为 `phases`、每个 phase 的 `actions`
    补 `maxItems`，并在进入 JSON 模板展开前强制“所有 phase 的 actions 合计不超过
-   12”这一聚合约束；
+   13”这一聚合约束；
 2. 在 Registry 中同时注册冻结的 `0.1.0` 和 successor，并把该模板的 Registry
    default 切到 successor；
 3. Bot capability 与新 send 只广告/接受 successor，同时保留对已存在
@@ -88,6 +88,12 @@ cap 依据来自本机 OpenClaw Octo consumer checkout
 - `errorMessage` 走同一 120+省略号清洗，上限为 121；
 - `reasoningId = sessionKey + ":" + runId` 当前没有 producer 本地 cap。
 
+冻结的 `0.1.0` 五态 fixture 还提供了一个必须优先满足的兼容证据：
+`completed` sample 的三个 phase 分别有 `3 + 7 + 3 = 13` 个 actions。successor 又要求
+samples/goldens 与 `0.1.0` 字节一致，因此 aggregate 不能设为 12，否则 successor 会在
+注册期 self-check 直接失败。successor 的平台兼容上限据此取 13；当前 producer 的
+`MAX_RENDERED_ACTIONS=12` 仍是更严格的 producer 侧上限，无需放宽。
+
 JSON Schema `maxLength` 按 Unicode 字符/rune 计数；JavaScript 当前按 UTF-16 code
 unit 截断。由于 code point 数不会大于 code unit 数，下表给
 `thought/tool/errorMessage` 预留追加省略号后的值，可兼容当前 producer。producer
@@ -105,8 +111,8 @@ unit 截断。由于 code point 数不会大于 code unit 数，下表给
 | `progressText` | 160 | 活动态单行进度文案产品上限建议 |
 | `phases` | 6 items | 当前 producer `MAX_RENDERED_PHASES` |
 | `phases[].thought` | 281 | 当前 producer 280 + `…` |
-| `phases[].actions` | 12 items/phase | 嵌套数组必须自身有界；另有全卡 aggregate 12 |
-| 所有 `phases[].actions` 合计 | 12 items | 当前 producer `MAX_RENDERED_ACTIONS`；draft-07 不能仅靠普通 `maxItems` 表达 |
+| `phases[].actions` | 12 items/phase | 嵌套数组必须自身有界；另有全卡 aggregate 13 |
+| 所有 `phases[].actions` 合计 | 13 items | 冻结 `completed` fixture 为 13；当前 producer 的 12 仍天然满足；draft-07 不能仅靠普通 `maxItems` 表达 |
 | `phases[].actions[].tool` | 81 | 当前 producer 80 + `…` |
 | `phases[].actions[].detail` | 192 | 当前最大 189（65 + 3 + 121），向上取整留 3 字符余量 |
 | `errorTitle` | 64 | 单行错误标题产品上限建议；当前 producer 为固定短文案 |
@@ -118,7 +124,7 @@ brief 的平台建议值，不伪装成既有产品契约。D2 未确认前不�
 ### 聚合 action 上限不能只写 schema `maxItems`
 
 draft-07 可以表达 `phases.maxItems=6` 和每个 `actions.maxItems=12`，但不能直接表达
-“所有 phase 的 actions 总数不超过 12”。只写两个 `maxItems` 会允许最多 72 个
+“所有 phase 的 actions 总数不超过 13”。只写两个 `maxItems` 会允许最多 72 个
 action；该输入虽有界，仍可能通过 schema 后撞上 `cardmsg.MaxNodes=200`，把调用方错误
 误归类成 render failure。
 
@@ -126,7 +132,7 @@ action；该输入虽有界，仍可能通过 schema 后撞上 `cardmsg.MaxNodes
 
 1. 先完成现有 JSON decode + draft-07 schema 校验；
 2. successor schema 以 namespaced 机读扩展声明聚合约束，建议形状如下；该扩展是
-   aggregate limit 的单一真源，不能只把 `12` 写在 Go 常量或 Markdown：
+   aggregate limit 的单一真源，不能只把 `13` 写在 Go 常量或 Markdown：
 
    ```json
    "x-octo-constraints": {
@@ -134,7 +140,7 @@ action；该输入虽有界，仍可能通过 schema 后撞上 `cardmsg.MaxNodes
        {
          "parentArray": "phases",
          "childArray": "actions",
-         "maxTotalItems": 12
+         "maxTotalItems": 13
        }
      ]
    }
@@ -177,7 +183,7 @@ Registry 注册，但不再广告，也不再接受新 Bot send。
   明确上限；聚合 action 约束由 schema namespaced extension 机读声明，在 JSON 模板
   展开前执行并映射为 `ErrFieldsInvalid`。
 - **JSON 模板资源预算（`cardtmpl`, `trust-boundary`）** — 合法最大 fixture（6 phases、
-  12 actions 合计、字符串均到 cap）必须仍低于 `cardmsg` 节点/深度/payload 上限；不能
+  13 actions 合计、字符串均到 cap）必须仍低于 `cardmsg` 节点/深度/payload 上限；不能
   用一个必然 render 失败的 schema 上限冒充可用契约。
 - **Registry 多版本（`cardtmpl`, `wire-contract`）** — `0.1.0` 与 successor 同时注册，
   默认版本切 successor；历史消息继续按 stored version 运行。
@@ -232,15 +238,16 @@ Registry 注册，但不再广告，也不再接受新 Bot send。
 - 11 个自由字符串均有上表确认后的 `maxLength`；enum 字符串继续由 enum 有界，
   `statusGlyph.maxLength=2` 不变；所有对象继续 `additionalProperties:false`。
 - successor schema 含确认后的 `x-octo-constraints.aggregateArrayLimits`；注册期从该扩展
-  读取 aggregate 12，malformed/unknown target fail closed。运行期不得另抄一个可能漂移
+  读取 aggregate 13，malformed/unknown target fail closed。运行期不得另抄一个可能漂移
   的 magic number。
 - 每个字段用 table-driven test 证明：恰好 cap 个 Unicode 字符通过，cap+1 返回
   `ErrFieldsInvalid`；至少包含 ASCII、CJK 和 astral emoji 用例，避免误判 rune/byte/
   UTF-16 语义。
 - `phases=6` 通过、`7` 拒绝；单 phase `actions=12` 通过、`13` 拒绝。
-- actions 合计 12 在单 phase 与跨 6 phases 两种分布都通过；合计 13 即使每个 phase
-  均未超过 12，也必须在 Build/Expand 前以 `ErrFieldsInvalid` 拒绝。
-- 合法最坏 fixture（6 phases、12 actions 合计、所有自由字符串恰到 cap）在 active、
+- actions 合计 12 在单 phase 与跨 6 phases 两种分布都通过；合计 13 在跨 6 phases
+  分布时也通过；合计 14 即使每个 phase 均未超过 12，也必须在 Build/Expand 前以
+  `ErrFieldsInvalid` 拒绝。
+- 合法最坏 fixture（6 phases、13 actions 合计、所有自由字符串恰到 cap）在 active、
   result、error view 均能完成 Registry render 并通过 `cardmsg.Validate`，不超过 node、
   depth 或 payload budget。
 - 聚合 validator 的失败计入既有 `fields_invalid`，不计 `render_error`，且日志/响应不
@@ -307,7 +314,8 @@ Registry 注册，但不再广告，也不再接受新 Bot send。
   `0.1.0` 永久冻结并继续注册。
 - **D2 — exact caps：**确认“建议 cap 表”的全部数值，尤其是目前没有上游产品约束的
   `reasoningId=512` 和短文案上限。未确认前不实现。
-- **D3 — aggregate actions：**总 action 上限为 12；由 schema 的
+- **D3 — aggregate actions：**总 action 上限为 13（兼容冻结 `completed` fixture；当前
+  producer 仍最多输出 12）；由 schema 的
   `x-octo-constraints.aggregateArrayLimits` 作为单一真源，Registry/JSON-template 在
   pre-Build 执行，拒绝 handler 特判、Go/JSON 双写和 post-render budget 兜底方案。
 - **D4 — catalog policy：**capability + new send 只允许 successor；edit-compatible 集合

--- a/main.go
+++ b/main.go
@@ -729,12 +729,12 @@ func installCardTmplRegistry() {
 	registry.SetDefault(summarycompleted.TemplateID, summarycompleted.TemplateVersion)
 	registry.Register(summaryfailed.New(), summaryfailed.Assets, summaryfailed.HandoffRoot)
 	registry.SetDefault(summaryfailed.TemplateID, summaryfailed.TemplateVersion)
-	// roadmap E1:首张 JSON 模板卡 —— ai.reasoning-process 走 RegisterJSON,由基座
-	// 编译 .template.json,无手写 Go Build()。active/error 为 octo/v2(带 Submit,
-	// owner=ai),result 为 octo/v1(仅折叠)。按钮的 handler + RouteSpec + bot 流式
-	// 下发是下游任务,本卡先注册可渲染。
-	registry.RegisterJSON(aireasoningprocess.Assets, aireasoningprocess.HandoffRoot)
-	registry.SetDefault(aireasoningprocess.TemplateID, aireasoningprocess.TemplateVersion)
+	// roadmap E1/E1c:保留冻结的 0.1.0 供历史消息按原契约编辑，同时注册有界的
+	// 0.2.0 successor 并设为新默认。Bot 新发/legacy edit 的授权集合由 bot_api
+	// catalog 独立收口；Registry 多版本只提供渲染能力，不隐式开放 Bot 权限。
+	registry.RegisterJSON(aireasoningprocess.Assets, aireasoningprocess.HandoffRootV1)
+	registry.RegisterJSON(aireasoningprocess.Assets, aireasoningprocess.HandoffRootV2)
+	registry.SetDefault(aireasoningprocess.TemplateID, aireasoningprocess.TemplateVersionV2)
 	registry.Freeze()
 	cardtmpl.SetGlobalMetrics(cardtmpl.NewMetrics(prometheus.DefaultRegisterer))
 	cardtmpl.SetDefaultRegistry(registry)

--- a/modules/bot_api/bot_api.go
+++ b/modules/bot_api/bot_api.go
@@ -223,7 +223,7 @@ func NewBotAPI(ctx *config.Context) *BotAPI {
 	var cardTemplates *botCardTemplateCatalog
 	if registry := cardtmpl.DefaultRegistry(); registry != nil {
 		var err error
-		cardTemplates, err = newBotCardTemplateCatalog(registry, defaultBotTemplateRefs())
+		cardTemplates, err = newBotCardTemplateCatalogWithPolicy(registry, defaultBotTemplatePolicy())
 		if err != nil {
 			panic(fmt.Errorf("install Bot card template catalog: %w", err))
 		}

--- a/modules/bot_api/card_template_catalog.go
+++ b/modules/bot_api/card_template_catalog.go
@@ -26,6 +26,11 @@ type botTemplateRef struct {
 	Version string      `json:"version"`
 }
 
+type botTemplatePolicy struct {
+	AdvertisedSend []botTemplateRef
+	EditCompatible []botTemplateRef
+}
+
 type botTemplateViewCapability struct {
 	Name          string   `json:"name"`
 	States        []string `json:"states"`
@@ -46,40 +51,65 @@ type botTemplatingCapability struct {
 }
 
 type botCardTemplateCatalog struct {
-	registry   *cardtmpl.Registry
-	allowed    map[botTemplateRef]struct{}
-	capability botTemplatingCapability
+	registry    *cardtmpl.Registry
+	sendAllowed map[botTemplateRef]struct{}
+	editAllowed map[botTemplateRef]struct{}
+	capability  botTemplatingCapability
 }
 
 func defaultBotTemplateRefs() []botTemplateRef {
 	return []botTemplateRef{{
 		ID:      aireasoningprocess.TemplateID,
-		Version: aireasoningprocess.TemplateVersion,
+		Version: aireasoningprocess.TemplateVersionV2,
 	}}
 }
 
+func defaultBotTemplatePolicy() botTemplatePolicy {
+	return botTemplatePolicy{
+		AdvertisedSend: defaultBotTemplateRefs(),
+		EditCompatible: []botTemplateRef{
+			{ID: aireasoningprocess.TemplateID, Version: aireasoningprocess.TemplateVersionV1},
+			{ID: aireasoningprocess.TemplateID, Version: aireasoningprocess.TemplateVersionV2},
+		},
+	}
+}
+
 func newBotCardTemplateCatalog(registry *cardtmpl.Registry, refs []botTemplateRef) (*botCardTemplateCatalog, error) {
+	return newBotCardTemplateCatalogWithPolicy(registry, botTemplatePolicy{
+		AdvertisedSend: refs,
+		EditCompatible: refs,
+	})
+}
+
+func newBotCardTemplateCatalogWithPolicy(
+	registry *cardtmpl.Registry,
+	policy botTemplatePolicy,
+) (*botCardTemplateCatalog, error) {
 	if registry == nil {
 		return nil, errBotTemplateCatalogUnavailable
 	}
-	if len(refs) == 0 {
-		return nil, fmt.Errorf("bot template catalog: empty allowlist")
+	if len(policy.AdvertisedSend) == 0 {
+		return nil, fmt.Errorf("bot template catalog: empty advertised/send allowlist")
+	}
+	if len(policy.EditCompatible) == 0 {
+		return nil, fmt.Errorf("bot template catalog: empty edit-compatible allowlist")
 	}
 	catalog := &botCardTemplateCatalog{
-		registry: registry,
-		allowed:  make(map[botTemplateRef]struct{}, len(refs)),
+		registry:    registry,
+		sendAllowed: make(map[botTemplateRef]struct{}, len(policy.AdvertisedSend)),
+		editAllowed: make(map[botTemplateRef]struct{}, len(policy.EditCompatible)),
 		capability: botTemplatingCapability{
 			Supported: true,
 			Wire:      botTemplateWireV1,
-			Templates: make([]botTemplateCapability, 0, len(refs)),
+			Templates: make([]botTemplateCapability, 0, len(policy.AdvertisedSend)),
 		},
 	}
-	for _, ref := range refs {
+	for _, ref := range policy.AdvertisedSend {
 		if strings.TrimSpace(string(ref.ID)) == "" || strings.TrimSpace(ref.Version) == "" {
 			return nil, fmt.Errorf("bot template catalog: id and explicit version are required")
 		}
-		if _, duplicate := catalog.allowed[ref]; duplicate {
-			return nil, fmt.Errorf("bot template catalog: duplicate %s@%s", ref.ID, ref.Version)
+		if _, duplicate := catalog.sendAllowed[ref]; duplicate {
+			return nil, fmt.Errorf("bot template catalog: duplicate advertised/send %s@%s", ref.ID, ref.Version)
 		}
 		tmpl, err := registry.Lookup(ref.ID, ref.Version)
 		if err != nil {
@@ -138,8 +168,30 @@ func newBotCardTemplateCatalog(registry *cardtmpl.Registry, refs []botTemplateRe
 		sort.Slice(capability.Views, func(i, j int) bool {
 			return capability.Views[i].Name < capability.Views[j].Name
 		})
-		catalog.allowed[ref] = struct{}{}
+		catalog.sendAllowed[ref] = struct{}{}
 		catalog.capability.Templates = append(catalog.capability.Templates, capability)
+	}
+	for _, ref := range policy.EditCompatible {
+		if strings.TrimSpace(string(ref.ID)) == "" || strings.TrimSpace(ref.Version) == "" {
+			return nil, fmt.Errorf("bot template catalog: edit-compatible id and explicit version are required")
+		}
+		if _, duplicate := catalog.editAllowed[ref]; duplicate {
+			return nil, fmt.Errorf("bot template catalog: duplicate edit-compatible %s@%s", ref.ID, ref.Version)
+		}
+		tmpl, err := registry.Lookup(ref.ID, ref.Version)
+		if err != nil {
+			return nil, fmt.Errorf("bot template catalog: edit-compatible lookup %s@%s: %w", ref.ID, ref.Version, err)
+		}
+		meta := tmpl.Meta()
+		if meta.ID != ref.ID || meta.Version != ref.Version || len(meta.Views) == 0 {
+			return nil, fmt.Errorf("bot template catalog: incomplete edit-compatible metadata for %s@%s", ref.ID, ref.Version)
+		}
+		catalog.editAllowed[ref] = struct{}{}
+	}
+	for ref := range catalog.sendAllowed {
+		if _, editable := catalog.editAllowed[ref]; !editable {
+			return nil, fmt.Errorf("bot template catalog: advertised/send %s@%s is not edit-compatible", ref.ID, ref.Version)
+		}
 	}
 	sort.Slice(catalog.capability.Templates, func(i, j int) bool {
 		left, right := catalog.capability.Templates[i], catalog.capability.Templates[j]
@@ -178,6 +230,30 @@ func (c *botCardTemplateCatalog) RenderPayload(
 	inbound map[string]any,
 	env cardtmpl.BuildEnv,
 ) (map[string]any, error) {
+	if c == nil {
+		return nil, errBotTemplateCatalogUnavailable
+	}
+	return c.renderPayload(ctx, inbound, env, c.sendAllowed, "not Bot-callable for new send")
+}
+
+func (c *botCardTemplateCatalog) RenderEditPayload(
+	ctx context.Context,
+	inbound map[string]any,
+	env cardtmpl.BuildEnv,
+) (map[string]any, error) {
+	if c == nil {
+		return nil, errBotTemplateCatalogUnavailable
+	}
+	return c.renderPayload(ctx, inbound, env, c.editAllowed, "not edit-compatible")
+}
+
+func (c *botCardTemplateCatalog) renderPayload(
+	ctx context.Context,
+	inbound map[string]any,
+	env cardtmpl.BuildEnv,
+	allowed map[botTemplateRef]struct{},
+	denialReason string,
+) (map[string]any, error) {
 	if c == nil || c.registry == nil {
 		return nil, errBotTemplateCatalogUnavailable
 	}
@@ -196,7 +272,7 @@ func (c *botCardTemplateCatalog) RenderPayload(
 	if _, hasCard := inbound["card"]; hasCard {
 		return nil, fmt.Errorf("%w: raw card and template_ref are mutually exclusive", errBotTemplateRequestInvalid)
 	}
-	ref, err := c.requireAllowedRef(inbound["template_ref"])
+	ref, err := c.requireRef(inbound["template_ref"], allowed, denialReason)
 	if err != nil {
 		return nil, err
 	}
@@ -239,10 +315,21 @@ func (c *botCardTemplateCatalog) RenderPayload(
 	return rendered, nil
 }
 
-// requireAllowedRef is the single Bot catalog authorization boundary for a
+// requireEditableRef is the edit catalog authorization boundary for a
 // caller-supplied template_ref. Call it before any target lookup so an unlisted
 // ref cannot use edit responses as a message existence or ownership oracle.
-func (c *botCardTemplateCatalog) requireAllowedRef(value any) (botTemplateRef, error) {
+func (c *botCardTemplateCatalog) requireEditableRef(value any) (botTemplateRef, error) {
+	if c == nil {
+		return botTemplateRef{}, errBotTemplateCatalogUnavailable
+	}
+	return c.requireRef(value, c.editAllowed, "template is not edit-compatible")
+}
+
+func (c *botCardTemplateCatalog) requireRef(
+	value any,
+	allowed map[botTemplateRef]struct{},
+	denialReason string,
+) (botTemplateRef, error) {
 	if c == nil || c.registry == nil {
 		return botTemplateRef{}, errBotTemplateCatalogUnavailable
 	}
@@ -250,8 +337,8 @@ func (c *botCardTemplateCatalog) requireAllowedRef(value any) (botTemplateRef, e
 	if err != nil {
 		return botTemplateRef{}, err
 	}
-	if _, ok := c.allowed[ref]; !ok {
-		return botTemplateRef{}, fmt.Errorf("%w: template is not Bot-callable", errBotTemplateRequestInvalid)
+	if _, ok := allowed[ref]; !ok {
+		return botTemplateRef{}, fmt.Errorf("%w: %s", errBotTemplateRequestInvalid, denialReason)
 	}
 	return ref, nil
 }

--- a/modules/bot_api/card_template_catalog_test.go
+++ b/modules/bot_api/card_template_catalog_test.go
@@ -89,6 +89,55 @@ func TestBotCardTemplatePolicyRequiresEverySendRefToRemainEditable(t *testing.T)
 	}
 }
 
+func TestBotCardTemplatePolicyFailsClosed(t *testing.T) {
+	registry := testBotTemplateRegistry(t)
+	successor := botTemplateRef{
+		ID: aireasoningprocess.TemplateID, Version: aireasoningprocess.TemplateVersionV2,
+	}
+	missing := botTemplateRef{ID: "ai.missing", Version: "1.0.0"}
+	tests := []struct {
+		name   string
+		policy botTemplatePolicy
+	}{
+		{
+			name:   "empty advertised send",
+			policy: botTemplatePolicy{EditCompatible: []botTemplateRef{successor}},
+		},
+		{
+			name:   "empty edit compatible",
+			policy: botTemplatePolicy{AdvertisedSend: []botTemplateRef{successor}},
+		},
+		{
+			name: "duplicate edit compatible",
+			policy: botTemplatePolicy{
+				AdvertisedSend: []botTemplateRef{successor},
+				EditCompatible: []botTemplateRef{successor, successor},
+			},
+		},
+		{
+			name: "missing edit registry entry",
+			policy: botTemplatePolicy{
+				AdvertisedSend: []botTemplateRef{successor},
+				EditCompatible: []botTemplateRef{successor, missing},
+			},
+		},
+		{
+			name: "blank edit ref",
+			policy: botTemplatePolicy{
+				AdvertisedSend: []botTemplateRef{successor},
+				EditCompatible: []botTemplateRef{successor, {}},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := newBotCardTemplateCatalogWithPolicy(registry, tt.policy); err == nil {
+				t.Fatal("catalog accepted invalid policy")
+			}
+		})
+	}
+}
+
 func TestBotCardTemplateCatalogCapability(t *testing.T) {
 	catalog, err := newBotCardTemplateCatalog(testBotTemplateRegistry(t), defaultBotTemplateRefs())
 	if err != nil {
@@ -251,7 +300,7 @@ func TestBotCardTemplateCatalogInvalidAndInternalRenderClassification(t *testing
 
 	// Schema-valid markdown reaches cardmsg.Validate and is a post-build render
 	// failure, not a caller-schema error. It remains zero-write and maps to the
-	// generic internal facade until the bounded successor schema lands.
+	// generic internal facade.
 	malicious := base()
 	malicious["data"].(map[string]any)["progressText"] = "[tap](javascript:alert(1))"
 	_, err = catalog.RenderPayload(context.Background(), malicious, cardtmpl.BuildEnv{})

--- a/modules/bot_api/card_template_catalog_test.go
+++ b/modules/bot_api/card_template_catalog_test.go
@@ -15,8 +15,9 @@ import (
 func testBotTemplateRegistry(t *testing.T) *cardtmpl.Registry {
 	t.Helper()
 	r := cardtmpl.NewRegistry()
-	r.RegisterJSON(aireasoningprocess.Assets, aireasoningprocess.HandoffRoot)
-	r.SetDefault(aireasoningprocess.TemplateID, aireasoningprocess.TemplateVersion)
+	r.RegisterJSON(aireasoningprocess.Assets, aireasoningprocess.HandoffRootV1)
+	r.RegisterJSON(aireasoningprocess.Assets, aireasoningprocess.HandoffRootV2)
+	r.SetDefault(aireasoningprocess.TemplateID, aireasoningprocess.TemplateVersionV2)
 	r.Register(docsaccessrequest.NewV3(), docsaccessrequest.Assets, docsaccessrequest.HandoffRootV3)
 	r.SetDefault(docsaccessrequest.TemplateID, docsaccessrequest.TemplateVersionV3)
 	r.Freeze()
@@ -24,14 +25,68 @@ func testBotTemplateRegistry(t *testing.T) *cardtmpl.Registry {
 }
 
 func testReasoningData(t *testing.T, state string) json.RawMessage {
+	return testReasoningDataVersion(t, aireasoningprocess.HandoffRootV2, state)
+}
+
+func testReasoningDataVersion(t *testing.T, root, state string) json.RawMessage {
 	t.Helper()
 	b, err := aireasoningprocess.Assets.ReadFile(
-		aireasoningprocess.HandoffRoot + "/samples/" + state + ".json",
+		root + "/samples/" + state + ".json",
 	)
 	if err != nil {
 		t.Fatalf("read reasoning sample %q: %v", state, err)
 	}
 	return json.RawMessage(b)
+}
+
+func TestBotCardTemplateCatalogSeparatesNewSendFromLegacyEdit(t *testing.T) {
+	catalog, err := newBotCardTemplateCatalogWithPolicy(testBotTemplateRegistry(t), defaultBotTemplatePolicy())
+	if err != nil {
+		t.Fatalf("newBotCardTemplateCatalogWithPolicy: %v", err)
+	}
+
+	capability := catalog.Capability()
+	if len(capability.Templates) != 1 || capability.Templates[0].Version != aireasoningprocess.TemplateVersionV2 {
+		t.Fatalf("advertised templates = %+v, want successor only", capability.Templates)
+	}
+
+	legacyRef := map[string]any{
+		"id": string(aireasoningprocess.TemplateID), "version": aireasoningprocess.TemplateVersionV1,
+	}
+	legacyPayload := map[string]any{
+		"type":         17,
+		"template_ref": legacyRef,
+		"state":        "reasoning",
+		"data": rawJSONToMap(t, testReasoningDataVersion(t,
+			aireasoningprocess.HandoffRootV1, "reasoning")),
+	}
+	if _, err := catalog.RenderPayload(context.Background(), legacyPayload, cardtmpl.BuildEnv{}); !errors.Is(err, errBotTemplateRequestInvalid) {
+		t.Fatalf("legacy send error = %v, want request invalid", err)
+	}
+	if ref, err := catalog.requireEditableRef(legacyRef); err != nil || ref.Version != aireasoningprocess.TemplateVersionV1 {
+		t.Fatalf("legacy edit ref = %+v, error = %v", ref, err)
+	}
+	rendered, err := catalog.RenderEditPayload(context.Background(), legacyPayload, cardtmpl.BuildEnv{})
+	if err != nil {
+		t.Fatalf("RenderEditPayload(legacy): %v", err)
+	}
+	if got := rendered["template_ref"].(map[string]any)["version"]; got != aireasoningprocess.TemplateVersionV1 {
+		t.Fatalf("legacy edit rendered version = %v", got)
+	}
+}
+
+func TestBotCardTemplatePolicyRequiresEverySendRefToRemainEditable(t *testing.T) {
+	_, err := newBotCardTemplateCatalogWithPolicy(testBotTemplateRegistry(t), botTemplatePolicy{
+		AdvertisedSend: []botTemplateRef{{
+			ID: aireasoningprocess.TemplateID, Version: aireasoningprocess.TemplateVersionV2,
+		}},
+		EditCompatible: []botTemplateRef{{
+			ID: aireasoningprocess.TemplateID, Version: aireasoningprocess.TemplateVersionV1,
+		}},
+	})
+	if err == nil {
+		t.Fatal("catalog accepted an advertised send ref that cannot be edited")
+	}
 }
 
 func TestBotCardTemplateCatalogCapability(t *testing.T) {

--- a/modules/bot_api/card_template_edit_test.go
+++ b/modules/bot_api/card_template_edit_test.go
@@ -85,6 +85,41 @@ func TestBotMessageEditRegistryTemplateRendersSameIdentity(t *testing.T) {
 	}
 }
 
+func TestBotMessageEditRegistryTemplateKeepsLegacyVersionEditable(t *testing.T) {
+	t.Setenv(cardmsg.EnvEnabled, "true")
+	catalog, err := newBotCardTemplateCatalogWithPolicy(testBotTemplateRegistry(t), defaultBotTemplatePolicy())
+	if err != nil {
+		t.Fatal(err)
+	}
+	mutator := &fakeBotCardMutator{
+		snapshot: carddispatch.CardMutationSnapshot{
+			Envelope: initialRegistryEnvelopeVersion(t, catalog, aireasoningprocess.TemplateVersionV1, "reasoning"),
+			CardSeq:  1,
+		},
+		mutateResult: carddispatch.CardMutationResult{Applied: true},
+	}
+	ba := &BotAPI{
+		Log:           log.NewTLog("BotAPI-template-edit-legacy"),
+		cardTemplates: catalog,
+		cardMutator:   mutator,
+	}
+	body := registryEditBodyVersion(t, aireasoningprocess.TemplateVersionV1, "completed",
+		testReasoningDataVersion(t, aireasoningprocess.HandoffRootV1, "completed"), 2, false)
+
+	recorder := invokeTemplateEdit(t, ba, body)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", recorder.Code, recorder.Body.String())
+	}
+	if mutator.snapshotCalls != 1 || len(mutator.mutateRequests) != 1 {
+		t.Fatalf("snapshot/mutate calls = %d/%d", mutator.snapshotCalls, len(mutator.mutateRequests))
+	}
+	if err := requireEffectiveCardTemplate([]byte(mutator.mutateRequests[0].ContentEdit), botTemplateRef{
+		ID: aireasoningprocess.TemplateID, Version: aireasoningprocess.TemplateVersionV1,
+	}); err != nil {
+		t.Fatalf("legacy replacement identity: %v", err)
+	}
+}
+
 func TestBotMessageEditRegistryTemplatePreservesAuthoritativeSpaceAcrossEdits(t *testing.T) {
 	t.Setenv(cardmsg.EnvEnabled, "true")
 	catalog, err := newBotCardTemplateCatalog(testBotTemplateRegistry(t), defaultBotTemplateRefs())
@@ -403,13 +438,56 @@ func initialRegistryEnvelope(t *testing.T, catalog *botCardTemplateCatalog) []by
 	return raw
 }
 
+func initialRegistryEnvelopeVersion(
+	t *testing.T,
+	catalog *botCardTemplateCatalog,
+	version string,
+	state string,
+) []byte {
+	t.Helper()
+	root := aireasoningprocess.HandoffRootV2
+	if version == aireasoningprocess.TemplateVersionV1 {
+		root = aireasoningprocess.HandoffRootV1
+	}
+	data := testReasoningDataVersion(t, root, state)
+	payload, err := catalog.registry.Render(context.Background(), aireasoningprocess.TemplateID,
+		version, cardtmpl.State(state), data, cardtmplBuildEnvForTest())
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload["template_ref"] = map[string]any{
+		"id": string(aireasoningprocess.TemplateID), "version": version,
+	}
+	payload["space_id"] = cardtmplBuildEnvForTest().SpaceID
+	payload["card_seq"] = int64(1)
+	if err := cardmsg.Finalize(payload); err != nil {
+		t.Fatal(err)
+	}
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return raw
+}
+
 func registryEditBody(t *testing.T, state string, data json.RawMessage, cardSeq int64, transient bool) map[string]any {
+	return registryEditBodyVersion(t, aireasoningprocess.TemplateVersion, state, data, cardSeq, transient)
+}
+
+func registryEditBodyVersion(
+	t *testing.T,
+	version string,
+	state string,
+	data json.RawMessage,
+	cardSeq int64,
+	transient bool,
+) map[string]any {
 	t.Helper()
 	return map[string]any{
 		"message_id": "1001", "message_seq": uint32(7),
 		"channel_id": "user_creator", "channel_type": common.ChannelTypePerson.Uint8(),
 		"template_ref": map[string]any{
-			"id": string(aireasoningprocess.TemplateID), "version": aireasoningprocess.TemplateVersion,
+			"id": string(aireasoningprocess.TemplateID), "version": version,
 		},
 		"state": state, "data": rawJSONToMap(t, data), "card_seq": cardSeq, "transient": transient,
 	}

--- a/modules/bot_api/card_template_edit_test.go
+++ b/modules/bot_api/card_template_edit_test.go
@@ -243,6 +243,14 @@ func TestBotMessageEditRegistryTemplateFailsClosed(t *testing.T) {
 			},
 		},
 		{
+			name: "aggregate action overflow",
+			body: func(t *testing.T) map[string]any {
+				body := registryEditBody(t, "reasoning", testReasoningData(t, "reasoning"), 2, false)
+				body["data"].(map[string]any)["phases"] = reasoningPhasesForBotTest(4, 2, 2, 2, 2, 2)
+				return body
+			},
+		},
+		{
 			name: "cross version target",
 			body: func(t *testing.T) map[string]any {
 				return registryEditBody(t, "completed", testReasoningData(t, "completed"), 2, false)

--- a/modules/bot_api/card_template_send_test.go
+++ b/modules/bot_api/card_template_send_test.go
@@ -72,6 +72,35 @@ func TestSendMessageRegistryTemplateRendersAndDispatches(t *testing.T) {
 	}
 }
 
+func TestSendMessageRegistryTemplateRejectsLegacyVersionWithoutDispatch(t *testing.T) {
+	t.Setenv(cardmsg.EnvEnabled, "true")
+	gin.SetMode(gin.TestMode)
+
+	dispatch := &dispatchCapture{}
+	catalog, err := newBotCardTemplateCatalogWithPolicy(testBotTemplateRegistry(t), defaultBotTemplatePolicy())
+	if err != nil {
+		t.Fatal(err)
+	}
+	ba := &BotAPI{
+		Log:              log.NewTLog("BotAPI-template-send-legacy"),
+		cardTemplates:    catalog,
+		spaceQuerier:     &fakeSpaceQuerier{defaultSpace: "space-authoritative"},
+		dispatchOverride: dispatch.hook,
+	}
+	body := registrySendBodyVersion(t, aireasoningprocess.TemplateVersionV1,
+		"reasoning", testReasoningDataVersion(t, aireasoningprocess.HandoffRootV1, "reasoning"))
+
+	recorder := invokeTemplateSend(t, ba, body, "")
+	if recorder.Code != http.StatusBadRequest {
+		t.Fatalf("status=%d body=%s", recorder.Code, recorder.Body.String())
+	}
+	dispatch.mu.Lock()
+	defer dispatch.mu.Unlock()
+	if dispatch.captured != nil {
+		t.Fatal("legacy template ref dispatched a new message")
+	}
+}
+
 func TestRawContentEditCannotForgeRegistryProvenance(t *testing.T) {
 	raw := imCardEnvelope("raw", 1)
 	raw["template_ref"] = map[string]any{
@@ -118,6 +147,9 @@ func TestSendMessageRegistryTemplateRejectsInvalidWithoutDispatch(t *testing.T) 
 		}},
 		{name: "raw and registry both present", mutate: func(payload map[string]any) { payload["card"] = map[string]any{} }},
 		{name: "render owned field", mutate: func(payload map[string]any) { payload["plain"] = "forged" }},
+		{name: "aggregate action overflow", mutate: func(payload map[string]any) {
+			payload["data"].(map[string]any)["phases"] = reasoningPhasesForBotTest(3, 2, 2, 2, 2, 2)
+		}},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -170,6 +202,10 @@ func TestSendMessageRegistryTemplateKeepsOBOCardExclusion(t *testing.T) {
 }
 
 func registrySendBody(t *testing.T, state string, data json.RawMessage) map[string]any {
+	return registrySendBodyVersion(t, aireasoningprocess.TemplateVersion, state, data)
+}
+
+func registrySendBodyVersion(t *testing.T, version, state string, data json.RawMessage) map[string]any {
 	t.Helper()
 	return map[string]any{
 		"channel_id":   "user_creator",
@@ -177,12 +213,29 @@ func registrySendBody(t *testing.T, state string, data json.RawMessage) map[stri
 		"payload": map[string]any{
 			"type": cardmsg.InteractiveCard.Int(),
 			"template_ref": map[string]any{
-				"id": string(aireasoningprocess.TemplateID), "version": aireasoningprocess.TemplateVersion,
+				"id": string(aireasoningprocess.TemplateID), "version": version,
 			},
 			"state": state,
 			"data":  rawJSONToMap(t, data),
 		},
 	}
+}
+
+func reasoningPhasesForBotTest(actionCounts ...int) []any {
+	phases := make([]any, 0, len(actionCounts))
+	for _, actionCount := range actionCounts {
+		actions := make([]any, 0, actionCount)
+		for i := 0; i < actionCount; i++ {
+			actions = append(actions, map[string]any{
+				"tool":        "tool",
+				"detail":      "detail",
+				"statusGlyph": "●",
+				"statusTone":  "Good",
+			})
+		}
+		phases = append(phases, map[string]any{"thought": "thought", "actions": actions})
+	}
+	return phases
 }
 
 func invokeTemplateSend(t *testing.T, ba *BotAPI, body map[string]any, onBehalfOf string) *httptest.ResponseRecorder {

--- a/modules/bot_api/card_template_send_test.go
+++ b/modules/bot_api/card_template_send_test.go
@@ -148,7 +148,7 @@ func TestSendMessageRegistryTemplateRejectsInvalidWithoutDispatch(t *testing.T) 
 		{name: "raw and registry both present", mutate: func(payload map[string]any) { payload["card"] = map[string]any{} }},
 		{name: "render owned field", mutate: func(payload map[string]any) { payload["plain"] = "forged" }},
 		{name: "aggregate action overflow", mutate: func(payload map[string]any) {
-			payload["data"].(map[string]any)["phases"] = reasoningPhasesForBotTest(3, 2, 2, 2, 2, 2)
+			payload["data"].(map[string]any)["phases"] = reasoningPhasesForBotTest(4, 2, 2, 2, 2, 2)
 		}},
 	}
 	for _, tc := range tests {

--- a/modules/bot_api/send.go
+++ b/modules/bot_api/send.go
@@ -1166,7 +1166,7 @@ func (ba *BotAPI) botMessageEditViaRegistry(c *wkhttp.Context, req *botMessageEd
 		httperr.ResponseErrorL(c, errcode.ErrSharedInternal, nil, nil)
 		return
 	}
-	ref, err := ba.cardTemplates.requireAllowedRef(req.TemplateRef)
+	ref, err := ba.cardTemplates.requireEditableRef(req.TemplateRef)
 	if err != nil {
 		if errors.Is(err, errBotTemplateRequestInvalid) {
 			ba.Warn("Bot Registry edit template_ref 非法或未开放", zap.Error(err))
@@ -1216,7 +1216,7 @@ func (ba *BotAPI) botMessageEditViaRegistry(c *wkhttp.Context, req *botMessageEd
 		webLoginURL = ba.ctx.GetConfig().External.WebLoginURL
 	}
 	spaceID := effectiveEnvelopeSpaceID(snapshot.Envelope)
-	rendered, err := ba.cardTemplates.RenderPayload(c.Request.Context(), map[string]any{
+	rendered, err := ba.cardTemplates.RenderEditPayload(c.Request.Context(), map[string]any{
 		"type":         cardmsg.InteractiveCard.Int(),
 		"template_ref": req.TemplateRef,
 		"state":        req.State,

--- a/pkg/cardtmpl/ai_reasoning_process/card.go
+++ b/pkg/cardtmpl/ai_reasoning_process/card.go
@@ -1,14 +1,16 @@
 // Package aireasoningprocess wires the AI reasoning-process progress card
-// (ai.reasoning-process@0.1.0) into the cardtmpl base. Unlike the Go-authored
-// L2a cards, this card ships as a pure JSON handoff (roadmap E1): it has no
+// (ai.reasoning-process@0.1.0 and its bounded 0.2.0 successor) into the cardtmpl
+// base. Unlike the Go-authored L2a cards, this card ships as a pure JSON handoff
+// (roadmap E1): it has no
 // hand-written Template — the base compiles its `.template.json` views via
 // Registry.RegisterJSON. This package only embeds the handoff assets and
 // exposes their identity for the composition root.
 //
 // Registration (in the composition root):
 //
-//	registry.RegisterJSON(aireasoningprocess.Assets, aireasoningprocess.HandoffRoot)
-//	registry.SetDefault(aireasoningprocess.TemplateID, aireasoningprocess.TemplateVersion)
+//	registry.RegisterJSON(aireasoningprocess.Assets, aireasoningprocess.HandoffRootV1)
+//	registry.RegisterJSON(aireasoningprocess.Assets, aireasoningprocess.HandoffRootV2)
+//	registry.SetDefault(aireasoningprocess.TemplateID, aireasoningprocess.TemplateVersionV2)
 //
 // Layering: L1 JSON artifacts live under handoff/. The card carries the
 // producer's own action buttons (reasoning_stop / reasoning_retry Submit +
@@ -31,10 +33,18 @@ import (
 var Assets embed.FS
 
 const (
-	// HandoffRoot is the root path of the embedded handoff assets.
-	HandoffRoot = "handoff/ai.reasoning-process@0.1.0"
 	// TemplateID is the stable card identifier.
 	TemplateID cardtmpl.ID = "ai.reasoning-process"
-	// TemplateVersion is this card's current version.
-	TemplateVersion = "0.1.0"
+
+	// HandoffRootV1 and TemplateVersionV1 identify the frozen first release.
+	HandoffRootV1     = "handoff/ai.reasoning-process@0.1.0"
+	TemplateVersionV1 = "0.1.0"
+	// HandoffRootV2 and TemplateVersionV2 identify the bounded successor.
+	HandoffRootV2     = "handoff/ai.reasoning-process@0.2.0"
+	TemplateVersionV2 = "0.2.0"
+
+	// HandoffRoot and TemplateVersion retain the package's current-version
+	// aliases for callers that do not need an explicit historical version.
+	HandoffRoot     = HandoffRootV2
+	TemplateVersion = TemplateVersionV2
 )

--- a/pkg/cardtmpl/ai_reasoning_process/card_test.go
+++ b/pkg/cardtmpl/ai_reasoning_process/card_test.go
@@ -175,7 +175,8 @@ func TestSuccessorArrayAndAggregateBounds(t *testing.T) {
 		{name: "twelve actions in one phase", actionCounts: []int{12}},
 		{name: "thirteen actions in one phase", actionCounts: []int{13}, wantErr: true},
 		{name: "twelve actions across six phases", actionCounts: []int{2, 2, 2, 2, 2, 2}},
-		{name: "aggregate thirteen with each phase under per-phase max", actionCounts: []int{3, 2, 2, 2, 2, 2}, wantErr: true},
+		{name: "aggregate thirteen with each phase under per-phase max", actionCounts: []int{3, 2, 2, 2, 2, 2}},
+		{name: "aggregate fourteen with each phase under per-phase max", actionCounts: []int{4, 2, 2, 2, 2, 2}, wantErr: true},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -274,7 +275,7 @@ func phasesWithActionCounts(counts ...int) []any {
 }
 
 func worstCasePhases() []any {
-	phases := phasesWithActionCounts(2, 2, 2, 2, 2, 2)
+	phases := phasesWithActionCounts(3, 2, 2, 2, 2, 2)
 	for _, rawPhase := range phases {
 		phase := rawPhase.(map[string]any)
 		phase["thought"] = strings.Repeat("思", 281)

--- a/pkg/cardtmpl/ai_reasoning_process/card_test.go
+++ b/pkg/cardtmpl/ai_reasoning_process/card_test.go
@@ -1,171 +1,389 @@
 package aireasoningprocess_test
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
-	"os"
-	"path/filepath"
+	"errors"
 	"sort"
+	"strings"
 	"testing"
 
 	"github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl"
 	aireasoningprocess "github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl/ai_reasoning_process"
 )
 
+var reasoningStates = []struct {
+	state   cardtmpl.State
+	profile string
+}{
+	{"reasoning", "octo/v2"},
+	{"answering", "octo/v2"},
+	{"completed", "octo/v1"},
+	{"stopped", "octo/v1"},
+	{"error", "octo/v2"},
+}
+
+var reasoningVersions = []struct {
+	version string
+	root    string
+}{
+	{aireasoningprocess.TemplateVersionV1, aireasoningprocess.HandoffRootV1},
+	{aireasoningprocess.TemplateVersionV2, aireasoningprocess.HandoffRootV2},
+}
+
 func newRegistry(t *testing.T) *cardtmpl.Registry {
 	t.Helper()
 	reg := cardtmpl.NewRegistry()
-	// Successful RegisterJSON is itself the fail-close assertion: it runs the
-	// sample self-check, which for the v2 views (active/error) verifies every
-	// Action.Submit.data carries {owner: ai, action_type: reasoning.control}.
-	reg.RegisterJSON(aireasoningprocess.Assets, aireasoningprocess.HandoffRoot)
-	reg.SetDefault(aireasoningprocess.TemplateID, aireasoningprocess.TemplateVersion)
+	reg.RegisterJSON(aireasoningprocess.Assets, aireasoningprocess.HandoffRootV1)
+	reg.RegisterJSON(aireasoningprocess.Assets, aireasoningprocess.HandoffRootV2)
+	reg.SetDefault(aireasoningprocess.TemplateID, aireasoningprocess.TemplateVersionV2)
 	reg.Freeze()
 	return reg
 }
 
-func TestRegisters(t *testing.T) {
+func TestRegistersBothVersionsAndDefaultsToSuccessor(t *testing.T) {
 	reg := newRegistry(t)
-	found := false
-	for _, m := range reg.List() {
-		if m.ID == aireasoningprocess.TemplateID {
-			found = true
-			if m.ActionContract == nil || m.ActionContract.Owner != "ai" ||
-				m.ActionContract.ActionType != "reasoning.control" {
-				t.Fatalf("ActionContract = %+v, want {ai, reasoning.control}", m.ActionContract)
-			}
+	var versions []string
+	for _, meta := range reg.List() {
+		if meta.ID != aireasoningprocess.TemplateID {
+			continue
+		}
+		versions = append(versions, meta.Version)
+		if meta.ActionContract == nil || meta.ActionContract.Owner != "ai" ||
+			meta.ActionContract.ActionType != "reasoning.control" {
+			t.Fatalf("%s ActionContract = %+v, want {ai, reasoning.control}", meta.Version, meta.ActionContract)
 		}
 	}
-	if !found {
-		t.Fatal("ai.reasoning-process not in Registry.List()")
+	sort.Strings(versions)
+	wantVersions := []string{aireasoningprocess.TemplateVersionV1, aireasoningprocess.TemplateVersionV2}
+	if !equalStrings(versions, wantVersions) {
+		t.Fatalf("registered versions = %v, want %v", versions, wantVersions)
+	}
+
+	tmpl, err := reg.Lookup(aireasoningprocess.TemplateID, "")
+	if err != nil {
+		t.Fatalf("Lookup(default): %v", err)
+	}
+	if got := tmpl.Meta().Version; got != aireasoningprocess.TemplateVersionV2 {
+		t.Fatalf("default version = %q, want %q", got, aireasoningprocess.TemplateVersionV2)
 	}
 }
 
-func TestRenderAllStates(t *testing.T) {
+func TestRenderAllStatesForBothVersions(t *testing.T) {
 	reg := newRegistry(t)
-	cases := []struct {
-		state   cardtmpl.State
-		profile string
+	for _, version := range reasoningVersions {
+		for _, tc := range reasoningStates {
+			t.Run(version.version+"/"+string(tc.state), func(t *testing.T) {
+				fields := readSample(t, version.root, string(tc.state))
+				payload, err := reg.Render(context.Background(), aireasoningprocess.TemplateID,
+					version.version, tc.state, fields,
+					cardtmpl.BuildEnv{Lang: "zh-CN", SpaceID: "space-x"})
+				if err != nil {
+					t.Fatalf("Render(%s@%s): %v", tc.state, version.version, err)
+				}
+				if got, _ := payload["profile"].(string); got != tc.profile {
+					t.Fatalf("profile = %q, want %q", got, tc.profile)
+				}
+			})
+		}
+	}
+}
+
+func TestConformanceForBothVersions(t *testing.T) {
+	reg := newRegistry(t)
+	for _, version := range reasoningVersions {
+		for _, tc := range reasoningStates {
+			name := string(tc.state)
+			t.Run(version.version+"/"+name, func(t *testing.T) {
+				fields := readSample(t, version.root, name)
+				state := cardtmpl.State(mustState(t, fields))
+				cardRaw, _, err := reg.RenderCard(context.Background(), aireasoningprocess.TemplateID,
+					version.version, state, fields,
+					cardtmpl.BuildEnv{Lang: "zh-CN", SpaceID: "space-x"})
+				if err != nil {
+					t.Fatalf("RenderCard(%s@%s): %v", name, version.version, err)
+				}
+				var card map[string]any
+				if err := json.Unmarshal(cardRaw, &card); err != nil {
+					t.Fatalf("unmarshal card: %v", err)
+				}
+				delete(card, "metadata")
+
+				golden := readGolden(t, version.root, name)
+				delete(golden, "$schema")
+
+				if g, w := canon(t, card), canon(t, golden); g != w {
+					t.Fatalf("golden mismatch for %s@%s\n--- got ---\n%s\n--- want ---\n%s",
+						name, version.version, g, w)
+				}
+			})
+		}
+	}
+}
+
+func TestSuccessorFreeStringBounds(t *testing.T) {
+	reg := newRegistry(t)
+	setTop := func(key string) func(map[string]any, string) {
+		return func(data map[string]any, value string) { data[key] = value }
+	}
+	tests := []struct {
+		name  string
+		limit int
+		set   func(map[string]any, string)
 	}{
-		{"reasoning", "octo/v2"},
-		{"answering", "octo/v2"},
-		{"completed", "octo/v1"},
-		{"stopped", "octo/v1"},
-		{"error", "octo/v2"},
+		{name: "reasoningId", limit: 512, set: setTop("reasoningId")},
+		{name: "title", limit: 64, set: setTop("title")},
+		{name: "statusLabel", limit: 32, set: setTop("statusLabel")},
+		{name: "timerText", limit: 128, set: setTop("timerText")},
+		{name: "collapsedSummary", limit: 160, set: setTop("collapsedSummary")},
+		{name: "progressText", limit: 160, set: setTop("progressText")},
+		{name: "thought", limit: 281, set: setFirstThought},
+		{name: "tool", limit: 81, set: setFirstActionField("tool")},
+		{name: "detail", limit: 192, set: setFirstActionField("detail")},
+		{name: "errorTitle", limit: 64, set: setTop("errorTitle")},
+		{name: "errorMessage", limit: 121, set: setTop("errorMessage")},
 	}
-	for _, tc := range cases {
-		t.Run(string(tc.state), func(t *testing.T) {
-			fields := readSample(t, string(tc.state))
-			payload, err := reg.Render(context.Background(), aireasoningprocess.TemplateID,
-				aireasoningprocess.TemplateVersion, tc.state, fields,
-				cardtmpl.BuildEnv{Lang: "zh-CN", SpaceID: "space-x"})
-			if err != nil {
-				t.Fatalf("Render(%s): %v", tc.state, err)
+	units := []string{"x", "界", "😀"}
+	for i, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			unit := units[i%len(units)]
+			exact := readSampleMap(t, aireasoningprocess.HandoffRootV2, "reasoning")
+			tc.set(exact, strings.Repeat(unit, tc.limit))
+			if err := renderData(reg, "reasoning", exact); err != nil {
+				t.Fatalf("exact %d-rune value rejected: %v", tc.limit, err)
 			}
-			if got, _ := payload["profile"].(string); got != tc.profile {
-				t.Fatalf("profile = %q, want %q", got, tc.profile)
+
+			over := readSampleMap(t, aireasoningprocess.HandoffRootV2, "reasoning")
+			tc.set(over, strings.Repeat(unit, tc.limit+1))
+			if err := renderData(reg, "reasoning", over); !errors.Is(err, cardtmpl.ErrFieldsInvalid) {
+				t.Fatalf("%d-rune value error = %v, want ErrFieldsInvalid", tc.limit+1, err)
 			}
 		})
 	}
 }
 
-// TestConformance renders each sample and asserts the card node (minus the
-// base-injected metadata) matches the shipped golden (minus its $schema),
-// canonical JSON. Goldens carry the owner/action_type keys injected into every
-// Submit.data, so this also locks that the rendered card carries them.
-func TestConformance(t *testing.T) {
+func TestSuccessorArrayAndAggregateBounds(t *testing.T) {
 	reg := newRegistry(t)
-	samples := []string{"reasoning", "answering", "completed", "stopped", "error"}
-	for _, name := range samples {
-		t.Run(name, func(t *testing.T) {
-			fields := readSample(t, name)
-			state := cardtmpl.State(mustState(t, fields))
-			cardRaw, _, err := reg.RenderCard(context.Background(), aireasoningprocess.TemplateID,
-				aireasoningprocess.TemplateVersion, state, fields,
-				cardtmpl.BuildEnv{Lang: "zh-CN", SpaceID: "space-x"})
+	tests := []struct {
+		name         string
+		actionCounts []int
+		wantErr      bool
+	}{
+		{name: "six phases", actionCounts: []int{1, 1, 1, 1, 1, 1}},
+		{name: "seven phases", actionCounts: []int{1, 1, 1, 1, 1, 1, 1}, wantErr: true},
+		{name: "twelve actions in one phase", actionCounts: []int{12}},
+		{name: "thirteen actions in one phase", actionCounts: []int{13}, wantErr: true},
+		{name: "twelve actions across six phases", actionCounts: []int{2, 2, 2, 2, 2, 2}},
+		{name: "aggregate thirteen with each phase under per-phase max", actionCounts: []int{3, 2, 2, 2, 2, 2}, wantErr: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			data := readSampleMap(t, aireasoningprocess.HandoffRootV2, "reasoning")
+			data["phases"] = phasesWithActionCounts(tc.actionCounts...)
+			err := renderData(reg, "reasoning", data)
+			if tc.wantErr {
+				if !errors.Is(err, cardtmpl.ErrFieldsInvalid) {
+					t.Fatalf("Render error = %v, want ErrFieldsInvalid", err)
+				}
+				return
+			}
 			if err != nil {
-				t.Fatalf("RenderCard(%s): %v", name, err)
-			}
-			var card map[string]any
-			if err := json.Unmarshal(cardRaw, &card); err != nil {
-				t.Fatalf("unmarshal card: %v", err)
-			}
-			delete(card, "metadata") // base-injected; not in golden
-
-			golden := readGolden(t, name)
-			delete(golden, "$schema") // authoring-tool artifact; not emitted by renderCore
-
-			if g, w := canon(t, card), canon(t, golden); g != w {
-				t.Fatalf("golden mismatch for %s\n--- got ---\n%s\n--- want ---\n%s", name, g, w)
+				t.Fatalf("Render: %v", err)
 			}
 		})
 	}
 }
 
-func readSample(t *testing.T, name string) json.RawMessage {
-	t.Helper()
-	b, err := os.ReadFile(filepath.Join("handoff", "ai.reasoning-process@0.1.0", "samples", name+".json"))
-	if err != nil {
-		t.Fatalf("read sample %s: %v", name, err)
+func TestSuccessorWorstCaseRendersEveryView(t *testing.T) {
+	reg := newRegistry(t)
+	for _, tc := range reasoningStates {
+		t.Run(string(tc.state), func(t *testing.T) {
+			data := readSampleMap(t, aireasoningprocess.HandoffRootV2, "reasoning")
+			data["state"] = string(tc.state)
+			data["reasoningId"] = strings.Repeat("r", 512)
+			data["title"] = strings.Repeat("题", 64)
+			data["statusLabel"] = strings.Repeat("状", 32)
+			data["timerText"] = strings.Repeat("时", 128)
+			data["collapsedSummary"] = strings.Repeat("摘", 160)
+			data["progressText"] = strings.Repeat("进", 160)
+			data["errorTitle"] = strings.Repeat("错", 64)
+			data["errorMessage"] = strings.Repeat("误", 121)
+			data["phases"] = worstCasePhases()
+
+			if err := renderData(reg, tc.state, data); err != nil {
+				t.Fatalf("worst-case %s render: %v", tc.state, err)
+			}
+		})
 	}
-	return json.RawMessage(b)
 }
 
-func readGolden(t *testing.T, name string) map[string]any {
-	t.Helper()
-	b, err := os.ReadFile(filepath.Join("handoff", "ai.reasoning-process@0.1.0", "goldens", name+".card.json"))
-	if err != nil {
-		t.Fatalf("read golden %s: %v", name, err)
+func TestSuccessorPreservesVisualContractArtifacts(t *testing.T) {
+	identical := []string{
+		"templates/active.template.json",
+		"templates/error.template.json",
+		"templates/result.template.json",
+		"reports/active.interaction.json",
+		"reports/error.interaction.json",
 	}
-	var m map[string]any
-	if err := json.Unmarshal(b, &m); err != nil {
+	for _, state := range []string{"reasoning", "answering", "completed", "stopped", "error"} {
+		identical = append(identical, "samples/"+state+".json", "goldens/"+state+".card.json")
+	}
+	for _, relative := range identical {
+		t.Run(relative, func(t *testing.T) {
+			legacy := readAsset(t, aireasoningprocess.HandoffRootV1+"/"+relative)
+			successor := readAsset(t, aireasoningprocess.HandoffRootV2+"/"+relative)
+			if !bytes.Equal(legacy, successor) {
+				t.Fatalf("successor artifact %s drifted from frozen 0.1.0", relative)
+			}
+		})
+	}
+}
+
+func setFirstThought(data map[string]any, value string) {
+	phase := data["phases"].([]any)[0].(map[string]any)
+	phase["thought"] = value
+}
+
+func setFirstActionField(key string) func(map[string]any, string) {
+	return func(data map[string]any, value string) {
+		phase := data["phases"].([]any)[0].(map[string]any)
+		action := phase["actions"].([]any)[0].(map[string]any)
+		action[key] = value
+	}
+}
+
+func phasesWithActionCounts(counts ...int) []any {
+	phases := make([]any, 0, len(counts))
+	for phaseIndex, actionCount := range counts {
+		actions := make([]any, 0, actionCount)
+		for actionIndex := 0; actionIndex < actionCount; actionIndex++ {
+			actions = append(actions, map[string]any{
+				"tool":        "tool",
+				"detail":      "detail",
+				"statusGlyph": "●",
+				"statusTone":  "Good",
+			})
+		}
+		phases = append(phases, map[string]any{
+			"thought": "phase " + string(rune('a'+phaseIndex)),
+			"actions": actions,
+		})
+	}
+	return phases
+}
+
+func worstCasePhases() []any {
+	phases := phasesWithActionCounts(2, 2, 2, 2, 2, 2)
+	for _, rawPhase := range phases {
+		phase := rawPhase.(map[string]any)
+		phase["thought"] = strings.Repeat("思", 281)
+		for _, rawAction := range phase["actions"].([]any) {
+			action := rawAction.(map[string]any)
+			action["tool"] = strings.Repeat("工", 81)
+			action["detail"] = strings.Repeat("详", 192)
+		}
+	}
+	return phases
+}
+
+func renderData(reg *cardtmpl.Registry, state cardtmpl.State, data map[string]any) error {
+	raw, err := json.Marshal(data)
+	if err != nil {
+		return err
+	}
+	_, err = reg.Render(context.Background(), aireasoningprocess.TemplateID,
+		aireasoningprocess.TemplateVersionV2, state, raw,
+		cardtmpl.BuildEnv{Lang: "zh-CN", SpaceID: "space-x"})
+	return err
+}
+
+func readSampleMap(t *testing.T, root, name string) map[string]any {
+	t.Helper()
+	var data map[string]any
+	if err := json.Unmarshal(readSample(t, root, name), &data); err != nil {
+		t.Fatalf("unmarshal sample %s: %v", name, err)
+	}
+	return data
+}
+
+func readSample(t *testing.T, root, name string) json.RawMessage {
+	t.Helper()
+	return json.RawMessage(readAsset(t, root+"/samples/"+name+".json"))
+}
+
+func readGolden(t *testing.T, root, name string) map[string]any {
+	t.Helper()
+	var golden map[string]any
+	if err := json.Unmarshal(readAsset(t, root+"/goldens/"+name+".card.json"), &golden); err != nil {
 		t.Fatalf("unmarshal golden %s: %v", name, err)
 	}
-	return m
+	return golden
+}
+
+func readAsset(t *testing.T, name string) []byte {
+	t.Helper()
+	b, err := aireasoningprocess.Assets.ReadFile(name)
+	if err != nil {
+		t.Fatalf("read asset %s: %v", name, err)
+	}
+	return b
 }
 
 func mustState(t *testing.T, fields json.RawMessage) string {
 	t.Helper()
-	var m map[string]any
-	if err := json.Unmarshal(fields, &m); err != nil {
+	var data map[string]any
+	if err := json.Unmarshal(fields, &data); err != nil {
 		t.Fatalf("unmarshal fields: %v", err)
 	}
-	s, _ := m["state"].(string)
-	if s == "" {
+	state, _ := data["state"].(string)
+	if state == "" {
 		t.Fatal("sample missing state")
 	}
-	return s
+	return state
 }
 
-func canon(t *testing.T, v any) string {
+func equalStrings(left, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for i := range left {
+		if left[i] != right[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func canon(t *testing.T, value any) string {
 	t.Helper()
-	b, err := json.MarshalIndent(sortKeys(v), "", "  ")
+	b, err := json.MarshalIndent(sortKeys(value), "", "  ")
 	if err != nil {
 		t.Fatalf("marshal: %v", err)
 	}
 	return string(b)
 }
 
-func sortKeys(v any) any {
-	switch x := v.(type) {
+func sortKeys(value any) any {
+	switch typed := value.(type) {
 	case map[string]any:
-		ks := make([]string, 0, len(x))
-		for k := range x {
-			ks = append(ks, k)
+		keys := make([]string, 0, len(typed))
+		for key := range typed {
+			keys = append(keys, key)
 		}
-		sort.Strings(ks)
-		m := make(map[string]any, len(x))
-		for _, k := range ks {
-			m[k] = sortKeys(x[k])
+		sort.Strings(keys)
+		out := make(map[string]any, len(typed))
+		for _, key := range keys {
+			out[key] = sortKeys(typed[key])
 		}
-		return m
+		return out
 	case []any:
-		out := make([]any, len(x))
-		for i := range x {
-			out[i] = sortKeys(x[i])
+		out := make([]any, len(typed))
+		for i := range typed {
+			out[i] = sortKeys(typed[i])
 		}
 		return out
 	default:
-		return v
+		return value
 	}
 }

--- a/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.2.0/contract/data.schema.json
+++ b/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.2.0/contract/data.schema.json
@@ -1,0 +1,263 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "推理过程卡数据契约",
+  "description": "AI 推理过程附件的展示型 ViewModel。消息作者、头像、时间与最终 Markdown 回答由消息容器负责，不进入卡片契约。",
+  "type": "object",
+  "additionalProperties": false,
+  "x-octo-constraints": {
+    "aggregateArrayLimits": [
+      {
+        "parentArray": "phases",
+        "childArray": "actions",
+        "maxTotalItems": 13
+      }
+    ]
+  },
+  "required": [
+    "reasoningId",
+    "state",
+    "title",
+    "statusLabel",
+    "statusTone",
+    "timerText",
+    "traceExpanded",
+    "traceCollapsed",
+    "collapsedSummary",
+    "phases"
+  ],
+  "properties": {
+    "reasoningId": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 512,
+      "description": "本轮推理的稳定标识，会随停止或重试动作回传。",
+      "examples": [
+        "reasoning-channel-b-001"
+      ]
+    },
+    "state": {
+      "type": "string",
+      "enum": [
+        "reasoning",
+        "answering",
+        "completed",
+        "stopped",
+        "error"
+      ],
+      "description": "卡片当前状态；宿主据此选择 active、result 或 error View。"
+    },
+    "title": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 64,
+      "description": "推理卡标题。",
+      "examples": [
+        "已深度思考"
+      ]
+    },
+    "statusLabel": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 32,
+      "description": "面向用户的状态文案。"
+    },
+    "statusTone": {
+      "type": "string",
+      "enum": [
+        "Accent",
+        "Good",
+        "Warning",
+        "Attention"
+      ],
+      "description": "Adaptive Cards 标准语义色。"
+    },
+    "timerText": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 128,
+      "description": "耗时、阶段数和工具调用数的展示文案。"
+    },
+    "traceExpanded": {
+      "type": "boolean",
+      "description": "初始是否展示推理明细。"
+    },
+    "traceCollapsed": {
+      "type": "boolean",
+      "description": "初始是否展示收起摘要；应与 traceExpanded 互斥。"
+    },
+    "collapsedSummary": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 160,
+      "description": "推理明细收起时的摘要。"
+    },
+    "progressText": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 160,
+      "description": "活动态底部的实时进度提示。"
+    },
+    "phases": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 6,
+      "description": "按发生顺序排列的推理阶段。仅包含可向用户展示的过程摘要，不承载隐藏的模型内部思维。",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "thought",
+          "actions"
+        ],
+        "properties": {
+          "thought": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 281,
+            "description": "该阶段面向用户的推理摘要。"
+          },
+          "actions": {
+            "type": "array",
+            "minItems": 1,
+            "maxItems": 12,
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "tool",
+                "detail",
+                "statusGlyph",
+                "statusTone"
+              ],
+              "properties": {
+                "tool": {
+                  "type": "string",
+                  "minLength": 1,
+                  "maxLength": 81,
+                  "description": "工具或步骤名称。"
+                },
+                "detail": {
+                  "type": "string",
+                  "minLength": 1,
+                  "maxLength": 192,
+                  "description": "已脱敏的调用摘要。"
+                },
+                "statusGlyph": {
+                  "type": "string",
+                  "minLength": 1,
+                  "maxLength": 2,
+                  "description": "调用状态符号，例如 ●。"
+                },
+                "statusTone": {
+                  "type": "string",
+                  "enum": [
+                    "Accent",
+                    "Good",
+                    "Attention"
+                  ],
+                  "description": "工具调用状态的标准语义色。"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "errorTitle": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 64,
+      "description": "失败态标题。"
+    },
+    "errorMessage": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 121,
+      "description": "失败原因与用户可采取动作。"
+    }
+  },
+  "allOf": [
+    {
+      "oneOf": [
+        {
+          "properties": {
+            "traceExpanded": {
+              "const": true
+            },
+            "traceCollapsed": {
+              "const": false
+            }
+          }
+        },
+        {
+          "properties": {
+            "traceExpanded": {
+              "const": false
+            },
+            "traceCollapsed": {
+              "const": true
+            }
+          }
+        }
+      ]
+    },
+    {
+      "if": {
+        "properties": {
+          "state": {
+            "enum": [
+              "reasoning",
+              "answering"
+            ]
+          }
+        }
+      },
+      "then": {
+        "required": [
+          "progressText"
+        ]
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "state": {
+            "const": "error"
+          }
+        }
+      },
+      "then": {
+        "required": [
+          "errorTitle",
+          "errorMessage"
+        ]
+      }
+    }
+  ],
+  "examples": [
+    {
+      "reasoningId": "reasoning-channel-b-001",
+      "state": "completed",
+      "title": "已深度思考",
+      "statusLabel": "已完成",
+      "statusTone": "Good",
+      "timerText": "用时 12 秒 · 3 段推理 · 13 次工具调用",
+      "traceExpanded": false,
+      "traceCollapsed": true,
+      "collapsedSummary": "已思考 12 秒 · 推理过程已收起",
+      "phases": [
+        {
+          "thought": "先拆解漏斗并核对近 90 天数据。",
+          "actions": [
+            {
+              "tool": "query_metrics",
+              "detail": "channel=B · range=90d",
+              "statusGlyph": "●",
+              "statusTone": "Good"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.2.0/goldens/answering.card.json
+++ b/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.2.0/goldens/answering.card.json
@@ -1,0 +1,696 @@
+{
+  "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+  "type": "AdaptiveCard",
+  "version": "1.5",
+  "body": [
+    {
+      "type": "Container",
+      "id": "octo-surface-accent-header-reasoning-active",
+      "style": "accent",
+      "bleed": true,
+      "spacing": "None",
+      "items": [
+        {
+          "type": "ColumnSet",
+          "spacing": "None",
+          "columns": [
+            {
+              "type": "Column",
+              "width": "stretch",
+              "verticalContentAlignment": "Center",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "text": "✦  已深度思考",
+                  "color": "Accent",
+                  "weight": "Bolder",
+                  "wrap": true,
+                  "spacing": "None"
+                },
+                {
+                  "type": "TextBlock",
+                  "text": "正在生成回答…",
+                  "size": "Small",
+                  "isSubtle": true,
+                  "wrap": true,
+                  "spacing": "Small"
+                }
+              ]
+            },
+            {
+              "type": "Column",
+              "width": "auto",
+              "verticalContentAlignment": "Center",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "id": "octo-badge-reasoning-active-status",
+                  "text": "回答中",
+                  "color": "Accent",
+                  "weight": "Bolder",
+                  "size": "Small",
+                  "wrap": true,
+                  "spacing": "None"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "id": "trace_panel",
+      "isVisible": true,
+      "spacing": "Large",
+      "items": [
+        {
+          "type": "Container",
+          "spacing": "None",
+          "separator": false,
+          "items": [
+            {
+              "type": "TextBlock",
+              "text": "先拆分线索、试用激活与付费三段漏斗，核对近 90 天数据。",
+              "size": "Small",
+              "wrap": true,
+              "spacing": "None"
+            },
+            {
+              "type": "Container",
+              "style": "emphasis",
+              "spacing": "Small",
+              "items": [
+                {
+                  "type": "ColumnSet",
+                  "spacing": "None",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "query_metrics",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "channel=B · range=90d · group=stage",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "read_file",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "~/analytics/funnel_definition.sql · ×2",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "run_sql",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "按漏斗阶段汇总数量与转化率",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "Container",
+          "spacing": "Large",
+          "separator": true,
+          "items": [
+            {
+              "type": "TextBlock",
+              "text": "激活率的降幅高于线索量，交叉核验行业结构、客服工单、NPS 与季节性。",
+              "size": "Small",
+              "wrap": true,
+              "spacing": "None"
+            },
+            {
+              "type": "Container",
+              "style": "emphasis",
+              "spacing": "Small",
+              "items": [
+                {
+                  "type": "ColumnSet",
+                  "spacing": "None",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "query_metrics",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "按行业拆分激活率",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "search_tickets",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "渠道 B · 试用 / 激活失败 · 近 60 天",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "read_file",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "~/nps/2026Q2_channelB.csv",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "query_metrics",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "叠加节假日与季节性校正",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "Container",
+          "spacing": "Large",
+          "separator": true,
+          "items": [
+            {
+              "type": "TextBlock",
+              "text": "主因确认：教育与专业服务合计贡献 63% 降幅，激活断点集中在试用权益触达。",
+              "size": "Small",
+              "wrap": true,
+              "spacing": "None"
+            },
+            {
+              "type": "Container",
+              "style": "emphasis",
+              "spacing": "Small",
+              "items": [
+                {
+                  "type": "ColumnSet",
+                  "spacing": "None",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "run_sql",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "按行业汇总转化降幅贡献",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "edit_file",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "~/reports/channelB_rootcause.md · 已编辑",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Accent",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "think",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "正在组织结论、证据与下周建议…",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "TextBlock",
+          "text": "◌  推理已完成，正在生成回答…",
+          "color": "Accent",
+          "size": "Small",
+          "wrap": true,
+          "spacing": "Large"
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "id": "collapsed_panel",
+      "isVisible": false,
+      "spacing": "Medium",
+      "items": [
+        {
+          "type": "TextBlock",
+          "text": "✓  推理已完成 · 回答正在生成",
+          "size": "Small",
+          "isSubtle": true,
+          "wrap": true,
+          "spacing": "None"
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "id": "octo-surface-default-footer-reasoning-active",
+      "style": "emphasis",
+      "bleed": true,
+      "separator": true,
+      "spacing": "Large",
+      "items": [
+        {
+          "type": "ActionSet",
+          "horizontalAlignment": "Right",
+          "actions": [
+            {
+              "type": "Action.Submit",
+              "id": "reasoning_stop",
+              "title": "停止",
+              "style": "destructive",
+              "associatedInputs": "none",
+              "data": {
+                "action": "reasoning_stop",
+                "effect": "stop_reasoning",
+                "reasoning_id": "reasoning-channel-b-001",
+                "owner": "ai",
+                "action_type": "reasoning.control"
+              }
+            },
+            {
+              "type": "Action.ToggleVisibility",
+              "id": "reasoning_toggle",
+              "title": "显示 / 隐藏推理",
+              "targetElements": [
+                "trace_panel",
+                "collapsed_panel"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.2.0/goldens/completed.card.json
+++ b/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.2.0/goldens/completed.card.json
@@ -1,0 +1,784 @@
+{
+  "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+  "type": "AdaptiveCard",
+  "version": "1.5",
+  "body": [
+    {
+      "type": "Container",
+      "id": "octo-surface-accent-header-reasoning-result",
+      "style": "accent",
+      "bleed": true,
+      "spacing": "None",
+      "items": [
+        {
+          "type": "ColumnSet",
+          "spacing": "None",
+          "columns": [
+            {
+              "type": "Column",
+              "width": "stretch",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "text": "✦  已深度思考",
+                  "color": "Accent",
+                  "weight": "Bolder",
+                  "wrap": true,
+                  "spacing": "None"
+                },
+                {
+                  "type": "TextBlock",
+                  "text": "用时 12 秒 · 3 段推理 · 13 次工具调用",
+                  "size": "Small",
+                  "isSubtle": true,
+                  "wrap": true,
+                  "spacing": "Small"
+                }
+              ]
+            },
+            {
+              "type": "Column",
+              "width": "auto",
+              "verticalContentAlignment": "Center",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "id": "octo-badge-reasoning-result-status",
+                  "text": "已完成",
+                  "color": "Good",
+                  "weight": "Bolder",
+                  "size": "Small",
+                  "wrap": true,
+                  "spacing": "None"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "id": "trace_panel",
+      "isVisible": false,
+      "spacing": "Large",
+      "items": [
+        {
+          "type": "Container",
+          "spacing": "None",
+          "separator": false,
+          "items": [
+            {
+              "type": "TextBlock",
+              "text": "先把渠道 B 转化下降的范围圈出来：拆成线索、试用激活、付费三段漏斗，取近 90 天数据。",
+              "size": "Small",
+              "wrap": true,
+              "spacing": "None"
+            },
+            {
+              "type": "Container",
+              "style": "emphasis",
+              "spacing": "Small",
+              "items": [
+                {
+                  "type": "ColumnSet",
+                  "spacing": "None",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "query_metrics",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "channel=B · range=90d · group=stage",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "read_file",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "~/analytics/funnel_definition.sql · ×2",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "run_sql",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "按漏斗阶段汇总数量与转化率",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "Container",
+          "spacing": "Large",
+          "separator": true,
+          "items": [
+            {
+              "type": "TextBlock",
+              "text": "激活率的降幅高于线索量，交叉核验行业结构、客服工单、NPS 与季节性。",
+              "size": "Small",
+              "wrap": true,
+              "spacing": "None"
+            },
+            {
+              "type": "Container",
+              "style": "emphasis",
+              "spacing": "Small",
+              "items": [
+                {
+                  "type": "ColumnSet",
+                  "spacing": "None",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "query_metrics",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "按行业拆分激活率",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "run_sql",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "对比各行业激活与付费转化",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "search_tickets",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "渠道 B · 试用 / 激活失败 · 近 60 天",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "read_file",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "~/nps/2026Q2_channelB.csv",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "query_metrics",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "叠加节假日与季节性校正",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "run_sql",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "逐周复核线索与激活数量",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "web_search",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "SaaS 行业 2026 试用政策调整",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "Container",
+          "spacing": "Large",
+          "separator": true,
+          "items": [
+            {
+              "type": "TextBlock",
+              "text": "主因确认：教育与专业服务合计贡献 63% 降幅，激活断点集中在试用权益触达。",
+              "size": "Small",
+              "wrap": true,
+              "spacing": "None"
+            },
+            {
+              "type": "Container",
+              "style": "emphasis",
+              "spacing": "Small",
+              "items": [
+                {
+                  "type": "ColumnSet",
+                  "spacing": "None",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "run_sql",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "按行业汇总转化降幅贡献",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "edit_file",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "~/reports/channelB_rootcause.md · 已编辑",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "think",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "拆分行业漏斗深挖与权益触达复盘",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "id": "collapsed_panel",
+      "isVisible": true,
+      "spacing": "Medium",
+      "items": [
+        {
+          "type": "TextBlock",
+          "text": "✓  已思考 12 秒 · 推理过程已收起",
+          "size": "Small",
+          "isSubtle": true,
+          "wrap": true,
+          "spacing": "None"
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "id": "octo-surface-default-footer-reasoning-result",
+      "style": "emphasis",
+      "bleed": true,
+      "separator": true,
+      "spacing": "Large",
+      "items": [
+        {
+          "type": "ActionSet",
+          "horizontalAlignment": "Right",
+          "actions": [
+            {
+              "type": "Action.ToggleVisibility",
+              "id": "reasoning_toggle",
+              "title": "显示 / 隐藏推理",
+              "targetElements": [
+                "trace_panel",
+                "collapsed_panel"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.2.0/goldens/error.card.json
+++ b/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.2.0/goldens/error.card.json
@@ -1,0 +1,422 @@
+{
+  "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+  "type": "AdaptiveCard",
+  "version": "1.5",
+  "body": [
+    {
+      "type": "Container",
+      "id": "octo-surface-accent-header-reasoning-error",
+      "style": "accent",
+      "bleed": true,
+      "spacing": "None",
+      "items": [
+        {
+          "type": "ColumnSet",
+          "spacing": "None",
+          "columns": [
+            {
+              "type": "Column",
+              "width": "stretch",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "text": "✦  已深度思考",
+                  "color": "Accent",
+                  "weight": "Bolder",
+                  "wrap": true,
+                  "spacing": "None"
+                },
+                {
+                  "type": "TextBlock",
+                  "text": "已中断",
+                  "size": "Small",
+                  "isSubtle": true,
+                  "wrap": true,
+                  "spacing": "Small"
+                }
+              ]
+            },
+            {
+              "type": "Column",
+              "width": "auto",
+              "verticalContentAlignment": "Center",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "id": "octo-badge-reasoning-error-status",
+                  "text": "生成失败",
+                  "color": "Attention",
+                  "weight": "Bolder",
+                  "size": "Small",
+                  "wrap": true,
+                  "spacing": "None"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "id": "trace_panel",
+      "isVisible": true,
+      "spacing": "Large",
+      "items": [
+        {
+          "type": "Container",
+          "spacing": "None",
+          "separator": false,
+          "items": [
+            {
+              "type": "TextBlock",
+              "text": "先拆分线索、试用激活与付费三段漏斗，核对近 90 天数据。",
+              "size": "Small",
+              "wrap": true,
+              "spacing": "None"
+            },
+            {
+              "type": "Container",
+              "style": "emphasis",
+              "spacing": "Small",
+              "items": [
+                {
+                  "type": "ColumnSet",
+                  "spacing": "None",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "query_metrics",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "channel=B · range=90d · group=stage",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "read_file",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "~/analytics/funnel_definition.sql · ×2",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "run_sql",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "按漏斗阶段汇总数量与转化率",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "Container",
+          "spacing": "Large",
+          "separator": true,
+          "items": [
+            {
+              "type": "TextBlock",
+              "text": "准备交叉核验行业结构、客服工单与 NPS 时，推理服务连接中断。",
+              "size": "Small",
+              "wrap": true,
+              "spacing": "None"
+            },
+            {
+              "type": "Container",
+              "style": "emphasis",
+              "spacing": "Small",
+              "items": [
+                {
+                  "type": "ColumnSet",
+                  "spacing": "None",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "query_metrics",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "按行业拆分激活率",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Attention",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "search_tickets",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "连接超时，调用未完成",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "id": "collapsed_panel",
+      "isVisible": false,
+      "spacing": "Medium",
+      "items": [
+        {
+          "type": "TextBlock",
+          "text": "生成已中断 · 点击可查看停止前的过程",
+          "size": "Small",
+          "isSubtle": true,
+          "wrap": true,
+          "spacing": "None"
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "style": "attention",
+      "spacing": "Large",
+      "items": [
+        {
+          "type": "TextBlock",
+          "text": "生成失败",
+          "color": "Attention",
+          "weight": "Bolder",
+          "wrap": true,
+          "spacing": "None"
+        },
+        {
+          "type": "TextBlock",
+          "text": "推理服务连接超时，已停止本次生成。可以重试，已完成的过程会保留。",
+          "wrap": true,
+          "spacing": "Small"
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "id": "octo-surface-default-footer-reasoning-error",
+      "style": "emphasis",
+      "bleed": true,
+      "separator": true,
+      "spacing": "Large",
+      "items": [
+        {
+          "type": "ActionSet",
+          "horizontalAlignment": "Right",
+          "actions": [
+            {
+              "type": "Action.Submit",
+              "id": "reasoning_retry",
+              "title": "重试",
+              "style": "positive",
+              "associatedInputs": "none",
+              "data": {
+                "action": "reasoning_retry",
+                "effect": "retry_reasoning",
+                "reasoning_id": "reasoning-channel-b-003",
+                "owner": "ai",
+                "action_type": "reasoning.control"
+              }
+            },
+            {
+              "type": "Action.ToggleVisibility",
+              "id": "reasoning_toggle",
+              "title": "显示 / 隐藏推理",
+              "targetElements": [
+                "trace_panel",
+                "collapsed_panel"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.2.0/goldens/reasoning.card.json
+++ b/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.2.0/goldens/reasoning.card.json
@@ -1,0 +1,525 @@
+{
+  "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+  "type": "AdaptiveCard",
+  "version": "1.5",
+  "body": [
+    {
+      "type": "Container",
+      "id": "octo-surface-accent-header-reasoning-active",
+      "style": "accent",
+      "bleed": true,
+      "spacing": "None",
+      "items": [
+        {
+          "type": "ColumnSet",
+          "spacing": "None",
+          "columns": [
+            {
+              "type": "Column",
+              "width": "stretch",
+              "verticalContentAlignment": "Center",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "text": "✦  已深度思考",
+                  "color": "Accent",
+                  "weight": "Bolder",
+                  "wrap": true,
+                  "spacing": "None"
+                },
+                {
+                  "type": "TextBlock",
+                  "text": "正在深度思考…",
+                  "size": "Small",
+                  "isSubtle": true,
+                  "wrap": true,
+                  "spacing": "Small"
+                }
+              ]
+            },
+            {
+              "type": "Column",
+              "width": "auto",
+              "verticalContentAlignment": "Center",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "id": "octo-badge-reasoning-active-status",
+                  "text": "思考中",
+                  "color": "Accent",
+                  "weight": "Bolder",
+                  "size": "Small",
+                  "wrap": true,
+                  "spacing": "None"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "id": "trace_panel",
+      "isVisible": true,
+      "spacing": "Large",
+      "items": [
+        {
+          "type": "Container",
+          "spacing": "None",
+          "separator": false,
+          "items": [
+            {
+              "type": "TextBlock",
+              "text": "先把渠道 B 转化下降的范围圈出来：拆成线索、试用激活、付费三段漏斗，取近 90 天数据。",
+              "size": "Small",
+              "wrap": true,
+              "spacing": "None"
+            },
+            {
+              "type": "Container",
+              "style": "emphasis",
+              "spacing": "Small",
+              "items": [
+                {
+                  "type": "ColumnSet",
+                  "spacing": "None",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "query_metrics",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "channel=B · range=90d · group=stage",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "read_file",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "~/analytics/funnel_definition.sql · ×2",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "run_sql",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "按漏斗阶段汇总数量与转化率",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "Container",
+          "spacing": "Large",
+          "separator": true,
+          "items": [
+            {
+              "type": "TextBlock",
+              "text": "口径正常，但激活率掉得比线索量快；继续拉行业标签、客服工单和 NPS 交叉验证。",
+              "size": "Small",
+              "wrap": true,
+              "spacing": "None"
+            },
+            {
+              "type": "Container",
+              "style": "emphasis",
+              "spacing": "Small",
+              "items": [
+                {
+                  "type": "ColumnSet",
+                  "spacing": "None",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "query_metrics",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "channel=B · dims=industry · metric=activation_rate",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "search_tickets",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "渠道 B · 试用 / 激活失败 · 近 60 天",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "read_file",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "~/nps/2026Q2_channelB.csv",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Accent",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "query_metrics",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "正在叠加季节性校正…",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "TextBlock",
+          "text": "◌  正在执行下一步…",
+          "color": "Accent",
+          "size": "Small",
+          "wrap": true,
+          "spacing": "Large"
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "id": "collapsed_panel",
+      "isVisible": false,
+      "spacing": "Medium",
+      "items": [
+        {
+          "type": "TextBlock",
+          "text": "✓  推理仍在进行 · 点击可查看当前过程",
+          "size": "Small",
+          "isSubtle": true,
+          "wrap": true,
+          "spacing": "None"
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "id": "octo-surface-default-footer-reasoning-active",
+      "style": "emphasis",
+      "bleed": true,
+      "separator": true,
+      "spacing": "Large",
+      "items": [
+        {
+          "type": "ActionSet",
+          "horizontalAlignment": "Right",
+          "actions": [
+            {
+              "type": "Action.Submit",
+              "id": "reasoning_stop",
+              "title": "停止",
+              "style": "destructive",
+              "associatedInputs": "none",
+              "data": {
+                "action": "reasoning_stop",
+                "effect": "stop_reasoning",
+                "reasoning_id": "reasoning-channel-b-001",
+                "owner": "ai",
+                "action_type": "reasoning.control"
+              }
+            },
+            {
+              "type": "Action.ToggleVisibility",
+              "id": "reasoning_toggle",
+              "title": "显示 / 隐藏推理",
+              "targetElements": [
+                "trace_panel",
+                "collapsed_panel"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.2.0/goldens/stopped.card.json
+++ b/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.2.0/goldens/stopped.card.json
@@ -1,0 +1,387 @@
+{
+  "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+  "type": "AdaptiveCard",
+  "version": "1.5",
+  "body": [
+    {
+      "type": "Container",
+      "id": "octo-surface-accent-header-reasoning-result",
+      "style": "accent",
+      "bleed": true,
+      "spacing": "None",
+      "items": [
+        {
+          "type": "ColumnSet",
+          "spacing": "None",
+          "columns": [
+            {
+              "type": "Column",
+              "width": "stretch",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "text": "✦  已深度思考",
+                  "color": "Accent",
+                  "weight": "Bolder",
+                  "wrap": true,
+                  "spacing": "None"
+                },
+                {
+                  "type": "TextBlock",
+                  "text": "已思考 6 秒 · 已停止于第 2 段",
+                  "size": "Small",
+                  "isSubtle": true,
+                  "wrap": true,
+                  "spacing": "Small"
+                }
+              ]
+            },
+            {
+              "type": "Column",
+              "width": "auto",
+              "verticalContentAlignment": "Center",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "id": "octo-badge-reasoning-result-status",
+                  "text": "已停止",
+                  "color": "Warning",
+                  "weight": "Bolder",
+                  "size": "Small",
+                  "wrap": true,
+                  "spacing": "None"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "id": "trace_panel",
+      "isVisible": false,
+      "spacing": "Large",
+      "items": [
+        {
+          "type": "Container",
+          "spacing": "None",
+          "separator": false,
+          "items": [
+            {
+              "type": "TextBlock",
+              "text": "先拆分线索、试用激活与付费三段漏斗，核对近 90 天数据。",
+              "size": "Small",
+              "wrap": true,
+              "spacing": "None"
+            },
+            {
+              "type": "Container",
+              "style": "emphasis",
+              "spacing": "Small",
+              "items": [
+                {
+                  "type": "ColumnSet",
+                  "spacing": "None",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "query_metrics",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "channel=B · range=90d · group=stage",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "read_file",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "~/analytics/funnel_definition.sql · ×2",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "run_sql",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "按漏斗阶段汇总数量与转化率",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "Container",
+          "spacing": "Large",
+          "separator": true,
+          "items": [
+            {
+              "type": "TextBlock",
+              "text": "激活率降幅高于线索量，开始按行业与试用权益触达交叉核验。",
+              "size": "Small",
+              "wrap": true,
+              "spacing": "None"
+            },
+            {
+              "type": "Container",
+              "style": "emphasis",
+              "spacing": "Small",
+              "items": [
+                {
+                  "type": "ColumnSet",
+                  "spacing": "None",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "query_metrics",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "按行业拆分激活率",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Accent",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "search_tickets",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "调用已由用户停止",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "id": "collapsed_panel",
+      "isVisible": true,
+      "spacing": "Medium",
+      "items": [
+        {
+          "type": "TextBlock",
+          "text": "✓  已保留停止前的 2 段推理过程",
+          "size": "Small",
+          "isSubtle": true,
+          "wrap": true,
+          "spacing": "None"
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "id": "octo-surface-default-footer-reasoning-result",
+      "style": "emphasis",
+      "bleed": true,
+      "separator": true,
+      "spacing": "Large",
+      "items": [
+        {
+          "type": "ActionSet",
+          "horizontalAlignment": "Right",
+          "actions": [
+            {
+              "type": "Action.ToggleVisibility",
+              "id": "reasoning_toggle",
+              "title": "显示 / 隐藏推理",
+              "targetElements": [
+                "trace_panel",
+                "collapsed_panel"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.2.0/manifest.json
+++ b/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.2.0/manifest.json
@@ -1,0 +1,51 @@
+{
+  "schemaVersion": 2,
+  "id": "ai.reasoning-process",
+  "name": "推理过程卡",
+  "version": "0.2.0",
+  "contractVersion": "1.1.0",
+  "protocol": "octo-card@1.0",
+  "adaptiveCardVersion": "1.5",
+  "renderProfile": "octo-chat@1.2.0-rc.1",
+  "renderProfileCompatibility": "octo-chat/v1",
+  "defaultLocale": "zh-CN",
+  "owner": "ai",
+  "actionType": "reasoning.control",
+  "dataSchema": "contract/data.schema.json",
+  "views": {
+    "active": {
+      "wireProfile": "octo/v2",
+      "states": [
+        "reasoning",
+        "answering"
+      ],
+      "template": "templates/active.template.json",
+      "samples": [
+        "samples/reasoning.json",
+        "samples/answering.json"
+      ]
+    },
+    "result": {
+      "wireProfile": "octo/v1",
+      "states": [
+        "completed",
+        "stopped"
+      ],
+      "template": "templates/result.template.json",
+      "samples": [
+        "samples/completed.json",
+        "samples/stopped.json"
+      ]
+    },
+    "error": {
+      "wireProfile": "octo/v2",
+      "states": [
+        "error"
+      ],
+      "template": "templates/error.template.json",
+      "samples": [
+        "samples/error.json"
+      ]
+    }
+  }
+}

--- a/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.2.0/reports/active.interaction.json
+++ b/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.2.0/reports/active.interaction.json
@@ -1,0 +1,22 @@
+{
+  "actions": [
+    {
+      "id": "reasoning_stop",
+      "type": "Action.Submit",
+      "associatedInputs": "none",
+      "dataKeys": [
+        "action",
+        "effect",
+        "reasoning_id",
+        "owner",
+        "action_type"
+      ],
+      "inputIds": []
+    },
+    {
+      "id": "reasoning_toggle",
+      "type": "Action.ToggleVisibility"
+    }
+  ],
+  "inputs": []
+}

--- a/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.2.0/reports/error.interaction.json
+++ b/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.2.0/reports/error.interaction.json
@@ -1,0 +1,22 @@
+{
+  "actions": [
+    {
+      "id": "reasoning_retry",
+      "type": "Action.Submit",
+      "associatedInputs": "none",
+      "dataKeys": [
+        "action",
+        "effect",
+        "reasoning_id",
+        "owner",
+        "action_type"
+      ],
+      "inputIds": []
+    },
+    {
+      "id": "reasoning_toggle",
+      "type": "Action.ToggleVisibility"
+    }
+  ],
+  "inputs": []
+}

--- a/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.2.0/samples/answering.json
+++ b/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.2.0/samples/answering.json
@@ -1,0 +1,89 @@
+{
+  "reasoningId": "reasoning-channel-b-001",
+  "state": "answering",
+  "title": "已深度思考",
+  "statusLabel": "回答中",
+  "statusTone": "Accent",
+  "timerText": "正在生成回答…",
+  "traceExpanded": true,
+  "traceCollapsed": false,
+  "collapsedSummary": "推理已完成 · 回答正在生成",
+  "progressText": "推理已完成，正在生成回答…",
+  "phases": [
+    {
+      "thought": "先拆分线索、试用激活与付费三段漏斗，核对近 90 天数据。",
+      "actions": [
+        {
+          "tool": "query_metrics",
+          "detail": "channel=B · range=90d · group=stage",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "read_file",
+          "detail": "~/analytics/funnel_definition.sql · ×2",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "run_sql",
+          "detail": "按漏斗阶段汇总数量与转化率",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        }
+      ]
+    },
+    {
+      "thought": "激活率的降幅高于线索量，交叉核验行业结构、客服工单、NPS 与季节性。",
+      "actions": [
+        {
+          "tool": "query_metrics",
+          "detail": "按行业拆分激活率",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "search_tickets",
+          "detail": "渠道 B · 试用 / 激活失败 · 近 60 天",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "read_file",
+          "detail": "~/nps/2026Q2_channelB.csv",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "query_metrics",
+          "detail": "叠加节假日与季节性校正",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        }
+      ]
+    },
+    {
+      "thought": "主因确认：教育与专业服务合计贡献 63% 降幅，激活断点集中在试用权益触达。",
+      "actions": [
+        {
+          "tool": "run_sql",
+          "detail": "按行业汇总转化降幅贡献",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "edit_file",
+          "detail": "~/reports/channelB_rootcause.md · 已编辑",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "think",
+          "detail": "正在组织结论、证据与下周建议…",
+          "statusGlyph": "●",
+          "statusTone": "Accent"
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.2.0/samples/completed.json
+++ b/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.2.0/samples/completed.json
@@ -1,0 +1,106 @@
+{
+  "reasoningId": "reasoning-channel-b-001",
+  "state": "completed",
+  "title": "已深度思考",
+  "statusLabel": "已完成",
+  "statusTone": "Good",
+  "timerText": "用时 12 秒 · 3 段推理 · 13 次工具调用",
+  "traceExpanded": false,
+  "traceCollapsed": true,
+  "collapsedSummary": "已思考 12 秒 · 推理过程已收起",
+  "phases": [
+    {
+      "thought": "先把渠道 B 转化下降的范围圈出来：拆成线索、试用激活、付费三段漏斗，取近 90 天数据。",
+      "actions": [
+        {
+          "tool": "query_metrics",
+          "detail": "channel=B · range=90d · group=stage",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "read_file",
+          "detail": "~/analytics/funnel_definition.sql · ×2",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "run_sql",
+          "detail": "按漏斗阶段汇总数量与转化率",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        }
+      ]
+    },
+    {
+      "thought": "激活率的降幅高于线索量，交叉核验行业结构、客服工单、NPS 与季节性。",
+      "actions": [
+        {
+          "tool": "query_metrics",
+          "detail": "按行业拆分激活率",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "run_sql",
+          "detail": "对比各行业激活与付费转化",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "search_tickets",
+          "detail": "渠道 B · 试用 / 激活失败 · 近 60 天",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "read_file",
+          "detail": "~/nps/2026Q2_channelB.csv",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "query_metrics",
+          "detail": "叠加节假日与季节性校正",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "run_sql",
+          "detail": "逐周复核线索与激活数量",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "web_search",
+          "detail": "SaaS 行业 2026 试用政策调整",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        }
+      ]
+    },
+    {
+      "thought": "主因确认：教育与专业服务合计贡献 63% 降幅，激活断点集中在试用权益触达。",
+      "actions": [
+        {
+          "tool": "run_sql",
+          "detail": "按行业汇总转化降幅贡献",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "edit_file",
+          "detail": "~/reports/channelB_rootcause.md · 已编辑",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "think",
+          "detail": "拆分行业漏斗深挖与权益触达复盘",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.2.0/samples/error.json
+++ b/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.2.0/samples/error.json
@@ -1,0 +1,55 @@
+{
+  "reasoningId": "reasoning-channel-b-003",
+  "state": "error",
+  "title": "已深度思考",
+  "statusLabel": "生成失败",
+  "statusTone": "Attention",
+  "timerText": "已中断",
+  "traceExpanded": true,
+  "traceCollapsed": false,
+  "collapsedSummary": "生成已中断 · 点击可查看停止前的过程",
+  "errorTitle": "生成失败",
+  "errorMessage": "推理服务连接超时，已停止本次生成。可以重试，已完成的过程会保留。",
+  "phases": [
+    {
+      "thought": "先拆分线索、试用激活与付费三段漏斗，核对近 90 天数据。",
+      "actions": [
+        {
+          "tool": "query_metrics",
+          "detail": "channel=B · range=90d · group=stage",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "read_file",
+          "detail": "~/analytics/funnel_definition.sql · ×2",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "run_sql",
+          "detail": "按漏斗阶段汇总数量与转化率",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        }
+      ]
+    },
+    {
+      "thought": "准备交叉核验行业结构、客服工单与 NPS 时，推理服务连接中断。",
+      "actions": [
+        {
+          "tool": "query_metrics",
+          "detail": "按行业拆分激活率",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "search_tickets",
+          "detail": "连接超时，调用未完成",
+          "statusGlyph": "●",
+          "statusTone": "Attention"
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.2.0/samples/reasoning.json
+++ b/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.2.0/samples/reasoning.json
@@ -1,0 +1,66 @@
+{
+  "reasoningId": "reasoning-channel-b-001",
+  "state": "reasoning",
+  "title": "已深度思考",
+  "statusLabel": "思考中",
+  "statusTone": "Accent",
+  "timerText": "正在深度思考…",
+  "traceExpanded": true,
+  "traceCollapsed": false,
+  "collapsedSummary": "推理仍在进行 · 点击可查看当前过程",
+  "progressText": "正在执行下一步…",
+  "phases": [
+    {
+      "thought": "先把渠道 B 转化下降的范围圈出来：拆成线索、试用激活、付费三段漏斗，取近 90 天数据。",
+      "actions": [
+        {
+          "tool": "query_metrics",
+          "detail": "channel=B · range=90d · group=stage",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "read_file",
+          "detail": "~/analytics/funnel_definition.sql · ×2",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "run_sql",
+          "detail": "按漏斗阶段汇总数量与转化率",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        }
+      ]
+    },
+    {
+      "thought": "口径正常，但激活率掉得比线索量快；继续拉行业标签、客服工单和 NPS 交叉验证。",
+      "actions": [
+        {
+          "tool": "query_metrics",
+          "detail": "channel=B · dims=industry · metric=activation_rate",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "search_tickets",
+          "detail": "渠道 B · 试用 / 激活失败 · 近 60 天",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "read_file",
+          "detail": "~/nps/2026Q2_channelB.csv",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "query_metrics",
+          "detail": "正在叠加季节性校正…",
+          "statusGlyph": "●",
+          "statusTone": "Accent"
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.2.0/samples/stopped.json
+++ b/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.2.0/samples/stopped.json
@@ -1,0 +1,53 @@
+{
+  "reasoningId": "reasoning-channel-b-002",
+  "state": "stopped",
+  "title": "已深度思考",
+  "statusLabel": "已停止",
+  "statusTone": "Warning",
+  "timerText": "已思考 6 秒 · 已停止于第 2 段",
+  "traceExpanded": false,
+  "traceCollapsed": true,
+  "collapsedSummary": "已保留停止前的 2 段推理过程",
+  "phases": [
+    {
+      "thought": "先拆分线索、试用激活与付费三段漏斗，核对近 90 天数据。",
+      "actions": [
+        {
+          "tool": "query_metrics",
+          "detail": "channel=B · range=90d · group=stage",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "read_file",
+          "detail": "~/analytics/funnel_definition.sql · ×2",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "run_sql",
+          "detail": "按漏斗阶段汇总数量与转化率",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        }
+      ]
+    },
+    {
+      "thought": "激活率降幅高于线索量，开始按行业与试用权益触达交叉核验。",
+      "actions": [
+        {
+          "tool": "query_metrics",
+          "detail": "按行业拆分激活率",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "search_tickets",
+          "detail": "调用已由用户停止",
+          "statusGlyph": "●",
+          "statusTone": "Accent"
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.2.0/templates/active.template.json
+++ b/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.2.0/templates/active.template.json
@@ -1,0 +1,206 @@
+{
+  "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+  "type": "AdaptiveCard",
+  "version": "1.5",
+  "body": [
+    {
+      "type": "Container",
+      "id": "octo-surface-accent-header-reasoning-active",
+      "style": "accent",
+      "bleed": true,
+      "spacing": "None",
+      "items": [
+        {
+          "type": "ColumnSet",
+          "spacing": "None",
+          "columns": [
+            {
+              "type": "Column",
+              "width": "stretch",
+              "verticalContentAlignment": "Center",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "text": "✦  ${title}",
+                  "color": "Accent",
+                  "weight": "Bolder",
+                  "wrap": true,
+                  "spacing": "None"
+                },
+                {
+                  "type": "TextBlock",
+                  "text": "${timerText}",
+                  "size": "Small",
+                  "isSubtle": true,
+                  "wrap": true,
+                  "spacing": "Small"
+                }
+              ]
+            },
+            {
+              "type": "Column",
+              "width": "auto",
+              "verticalContentAlignment": "Center",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "id": "octo-badge-reasoning-active-status",
+                  "text": "${statusLabel}",
+                  "color": "${statusTone}",
+                  "weight": "Bolder",
+                  "size": "Small",
+                  "wrap": true,
+                  "spacing": "None"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "id": "trace_panel",
+      "isVisible": "${traceExpanded}",
+      "spacing": "Large",
+      "items": [
+        {
+          "$data": "${phases}",
+          "type": "Container",
+          "spacing": "${if($index == 0, 'None', 'Large')}",
+          "separator": "${if($index == 0, false, true)}",
+          "items": [
+            {
+              "type": "TextBlock",
+              "text": "${thought}",
+              "size": "Small",
+              "wrap": true,
+              "spacing": "None"
+            },
+            {
+              "type": "Container",
+              "style": "emphasis",
+              "spacing": "Small",
+              "items": [
+                {
+                  "$data": "${actions}",
+                  "type": "ColumnSet",
+                  "spacing": "${if($index == 0, 'None', 'Small')}",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "${statusGlyph}",
+                          "color": "${statusTone}",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "${tool}",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "${detail}",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "TextBlock",
+          "text": "◌  ${progressText}",
+          "color": "Accent",
+          "size": "Small",
+          "wrap": true,
+          "spacing": "Large"
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "id": "collapsed_panel",
+      "isVisible": "${traceCollapsed}",
+      "spacing": "Medium",
+      "items": [
+        {
+          "type": "TextBlock",
+          "text": "✓  ${collapsedSummary}",
+          "size": "Small",
+          "isSubtle": true,
+          "wrap": true,
+          "spacing": "None"
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "id": "octo-surface-default-footer-reasoning-active",
+      "style": "emphasis",
+      "bleed": true,
+      "separator": true,
+      "spacing": "Large",
+      "items": [
+        {
+          "type": "ActionSet",
+          "horizontalAlignment": "Right",
+          "actions": [
+            {
+              "type": "Action.Submit",
+              "id": "reasoning_stop",
+              "title": "停止",
+              "style": "destructive",
+              "associatedInputs": "none",
+              "data": {
+                "action": "reasoning_stop",
+                "effect": "stop_reasoning",
+                "reasoning_id": "${reasoningId}",
+                "owner": "ai",
+                "action_type": "reasoning.control"
+              }
+            },
+            {
+              "type": "Action.ToggleVisibility",
+              "id": "reasoning_toggle",
+              "title": "显示 / 隐藏推理",
+              "targetElements": [
+                "trace_panel",
+                "collapsed_panel"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.2.0/templates/error.template.json
+++ b/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.2.0/templates/error.template.json
@@ -1,0 +1,215 @@
+{
+  "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+  "type": "AdaptiveCard",
+  "version": "1.5",
+  "body": [
+    {
+      "type": "Container",
+      "id": "octo-surface-accent-header-reasoning-error",
+      "style": "accent",
+      "bleed": true,
+      "spacing": "None",
+      "items": [
+        {
+          "type": "ColumnSet",
+          "spacing": "None",
+          "columns": [
+            {
+              "type": "Column",
+              "width": "stretch",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "text": "✦  ${title}",
+                  "color": "Accent",
+                  "weight": "Bolder",
+                  "wrap": true,
+                  "spacing": "None"
+                },
+                {
+                  "type": "TextBlock",
+                  "text": "${timerText}",
+                  "size": "Small",
+                  "isSubtle": true,
+                  "wrap": true,
+                  "spacing": "Small"
+                }
+              ]
+            },
+            {
+              "type": "Column",
+              "width": "auto",
+              "verticalContentAlignment": "Center",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "id": "octo-badge-reasoning-error-status",
+                  "text": "${statusLabel}",
+                  "color": "${statusTone}",
+                  "weight": "Bolder",
+                  "size": "Small",
+                  "wrap": true,
+                  "spacing": "None"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "id": "trace_panel",
+      "isVisible": "${traceExpanded}",
+      "spacing": "Large",
+      "items": [
+        {
+          "$data": "${phases}",
+          "type": "Container",
+          "spacing": "${if($index == 0, 'None', 'Large')}",
+          "separator": "${if($index == 0, false, true)}",
+          "items": [
+            {
+              "type": "TextBlock",
+              "text": "${thought}",
+              "size": "Small",
+              "wrap": true,
+              "spacing": "None"
+            },
+            {
+              "type": "Container",
+              "style": "emphasis",
+              "spacing": "Small",
+              "items": [
+                {
+                  "$data": "${actions}",
+                  "type": "ColumnSet",
+                  "spacing": "${if($index == 0, 'None', 'Small')}",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "${statusGlyph}",
+                          "color": "${statusTone}",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "${tool}",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "${detail}",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "id": "collapsed_panel",
+      "isVisible": "${traceCollapsed}",
+      "spacing": "Medium",
+      "items": [
+        {
+          "type": "TextBlock",
+          "text": "${collapsedSummary}",
+          "size": "Small",
+          "isSubtle": true,
+          "wrap": true,
+          "spacing": "None"
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "style": "attention",
+      "spacing": "Large",
+      "items": [
+        {
+          "type": "TextBlock",
+          "text": "${errorTitle}",
+          "color": "Attention",
+          "weight": "Bolder",
+          "wrap": true,
+          "spacing": "None"
+        },
+        {
+          "type": "TextBlock",
+          "text": "${errorMessage}",
+          "wrap": true,
+          "spacing": "Small"
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "id": "octo-surface-default-footer-reasoning-error",
+      "style": "emphasis",
+      "bleed": true,
+      "separator": true,
+      "spacing": "Large",
+      "items": [
+        {
+          "type": "ActionSet",
+          "horizontalAlignment": "Right",
+          "actions": [
+            {
+              "type": "Action.Submit",
+              "id": "reasoning_retry",
+              "title": "重试",
+              "style": "positive",
+              "associatedInputs": "none",
+              "data": {
+                "action": "reasoning_retry",
+                "effect": "retry_reasoning",
+                "reasoning_id": "${reasoningId}",
+                "owner": "ai",
+                "action_type": "reasoning.control"
+              }
+            },
+            {
+              "type": "Action.ToggleVisibility",
+              "id": "reasoning_toggle",
+              "title": "显示 / 隐藏推理",
+              "targetElements": [
+                "trace_panel",
+                "collapsed_panel"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.2.0/templates/result.template.json
+++ b/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.2.0/templates/result.template.json
@@ -1,0 +1,180 @@
+{
+  "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+  "type": "AdaptiveCard",
+  "version": "1.5",
+  "body": [
+    {
+      "type": "Container",
+      "id": "octo-surface-accent-header-reasoning-result",
+      "style": "accent",
+      "bleed": true,
+      "spacing": "None",
+      "items": [
+        {
+          "type": "ColumnSet",
+          "spacing": "None",
+          "columns": [
+            {
+              "type": "Column",
+              "width": "stretch",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "text": "✦  ${title}",
+                  "color": "Accent",
+                  "weight": "Bolder",
+                  "wrap": true,
+                  "spacing": "None"
+                },
+                {
+                  "type": "TextBlock",
+                  "text": "${timerText}",
+                  "size": "Small",
+                  "isSubtle": true,
+                  "wrap": true,
+                  "spacing": "Small"
+                }
+              ]
+            },
+            {
+              "type": "Column",
+              "width": "auto",
+              "verticalContentAlignment": "Center",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "id": "octo-badge-reasoning-result-status",
+                  "text": "${statusLabel}",
+                  "color": "${statusTone}",
+                  "weight": "Bolder",
+                  "size": "Small",
+                  "wrap": true,
+                  "spacing": "None"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "id": "trace_panel",
+      "isVisible": "${traceExpanded}",
+      "spacing": "Large",
+      "items": [
+        {
+          "$data": "${phases}",
+          "type": "Container",
+          "spacing": "${if($index == 0, 'None', 'Large')}",
+          "separator": "${if($index == 0, false, true)}",
+          "items": [
+            {
+              "type": "TextBlock",
+              "text": "${thought}",
+              "size": "Small",
+              "wrap": true,
+              "spacing": "None"
+            },
+            {
+              "type": "Container",
+              "style": "emphasis",
+              "spacing": "Small",
+              "items": [
+                {
+                  "$data": "${actions}",
+                  "type": "ColumnSet",
+                  "spacing": "${if($index == 0, 'None', 'Small')}",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "${statusGlyph}",
+                          "color": "${statusTone}",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "${tool}",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "${detail}",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "id": "collapsed_panel",
+      "isVisible": "${traceCollapsed}",
+      "spacing": "Medium",
+      "items": [
+        {
+          "type": "TextBlock",
+          "text": "✓  ${collapsedSummary}",
+          "size": "Small",
+          "isSubtle": true,
+          "wrap": true,
+          "spacing": "None"
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "id": "octo-surface-default-footer-reasoning-result",
+      "style": "emphasis",
+      "bleed": true,
+      "separator": true,
+      "spacing": "Large",
+      "items": [
+        {
+          "type": "ActionSet",
+          "horizontalAlignment": "Right",
+          "actions": [
+            {
+              "type": "Action.ToggleVisibility",
+              "id": "reasoning_toggle",
+              "title": "显示 / 隐藏推理",
+              "targetElements": [
+                "trace_panel",
+                "collapsed_panel"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/cardtmpl/json_template.go
+++ b/pkg/cardtmpl/json_template.go
@@ -1,6 +1,7 @@
 package cardtmpl
 
 import (
+	"bytes"
 	"context"
 	"embed"
 	"encoding/json"
@@ -19,8 +20,28 @@ import (
 // per-view template trees are parsed once at register time (viewAST) and only
 // re-bound per render — no per-frame JSON parse (progress cards re-render often).
 type jsonTemplate struct {
-	meta    TemplateMeta
-	viewAST map[ViewKey]any
+	meta                 TemplateMeta
+	viewAST              map[ViewKey]any
+	aggregateArrayLimits []jsonTemplateAggregateArrayLimit
+}
+
+type jsonTemplateFieldValidator interface {
+	validateFields(any) error
+}
+
+type jsonTemplateAggregateArrayLimit struct {
+	ParentArray   string `json:"parentArray"`
+	ChildArray    string `json:"childArray"`
+	MaxTotalItems int    `json:"maxTotalItems"`
+}
+
+type jsonTemplateConstraintSet struct {
+	AggregateArrayLimits []jsonTemplateAggregateArrayLimit `json:"aggregateArrayLimits"`
+}
+
+type jsonTemplateSchemaEnvelope struct {
+	Properties  map[string]json.RawMessage `json:"properties"`
+	Constraints json.RawMessage            `json:"x-octo-constraints"`
 }
 
 // SetMeta satisfies metaSetter; Registry injects the assembled meta at Register.
@@ -28,6 +49,64 @@ func (t *jsonTemplate) SetMeta(m TemplateMeta) { t.meta = m }
 
 // Meta returns a defensive deep copy, matching the Template contract.
 func (t *jsonTemplate) Meta() TemplateMeta { return t.meta.Clone() }
+
+func (t *jsonTemplate) validateFields(value any) error {
+	if len(t.aggregateArrayLimits) == 0 {
+		return nil
+	}
+	root, ok := value.(map[string]any)
+	if !ok {
+		return fmt.Errorf("JSON template fields are %T, want object", value)
+	}
+	for _, limit := range t.aggregateArrayLimits {
+		parentValue, exists := root[limit.ParentArray]
+		if !exists {
+			continue
+		}
+		parents, ok := parentValue.([]any)
+		if !ok {
+			return fmt.Errorf("aggregate parent %q is %T, want array", limit.ParentArray, parentValue)
+		}
+		total := 0
+		for index, parentValue := range parents {
+			parent, ok := parentValue.(map[string]any)
+			if !ok {
+				return fmt.Errorf("aggregate parent %q item %d is %T, want object", limit.ParentArray, index, parentValue)
+			}
+			childValue, exists := parent[limit.ChildArray]
+			if !exists {
+				continue
+			}
+			children, ok := childValue.([]any)
+			if !ok {
+				return fmt.Errorf("aggregate child %q[].%q is %T, want array", limit.ParentArray, limit.ChildArray, childValue)
+			}
+			total += len(children)
+			if total > limit.MaxTotalItems {
+				return fmt.Errorf("aggregate %s[].%s has %d items, max %d",
+					limit.ParentArray, limit.ChildArray, total, limit.MaxTotalItems)
+			}
+		}
+	}
+	return nil
+}
+
+func (t *jsonTemplate) validateRawFields(fields json.RawMessage) error {
+	if len(fields) == 0 {
+		return fmt.Errorf("%w: fields must not be empty", ErrFieldsInvalid)
+	}
+	var parsed any
+	if err := json.Unmarshal(fields, &parsed); err != nil {
+		return fmt.Errorf("%w: %v", ErrFieldsInvalid, err)
+	}
+	if err := t.meta.InputSchema.Validate(parsed); err != nil {
+		return fmt.Errorf("%w: %v", ErrFieldsInvalid, err)
+	}
+	if err := t.validateFields(parsed); err != nil {
+		return fmt.Errorf("%w: %v", ErrFieldsInvalid, err)
+	}
+	return nil
+}
 
 // jsonTemplateEscaper is the data-escaping policy for JSON templates (decision
 // D6): identity. Goldens bind caller data literally; the trust boundary is
@@ -79,13 +158,15 @@ func (t *jsonTemplate) Build(ctx context.Context, state State, fields json.RawMe
 // clients reduce the card to. Unlike Render this path does not run the full
 // cardmsg.Validate gate (the built card is a body/actions fragment, not a wire
 // payload). Its resource surface is bounded on the input side by jsontmpl.Expand's
-// maxExpandNodes ceiling (so an unbounded $data array can't balloon the fragment);
-// note BuildPlain itself imposes NO payload-size limit (only Finalize /
+// maxExpandNodes ceiling (so an unbounded $data array can't balloon the fragment).
+// It runs the same schema and JSON-template semantic constraints as Render before
+// expansion. BuildPlain itself imposes NO final payload-size limit (only Finalize /
 // RecheckPayloadSize do, neither runs here — PR #654 review yujiawei P2). Injection
 // is not a concern — BuildPlain reduces markdown links to their visible label.
-// When this path is first wired to a send path it should additionally run
-// InputSchema.Validate + a payload-size check (no production caller today).
 func (t *jsonTemplate) FallbackText(state State, fields json.RawMessage, lang string) (string, error) {
+	if err := t.validateRawFields(fields); err != nil {
+		return "", err
+	}
 	br, err := t.Build(context.Background(), state, fields, BuildEnv{Lang: lang})
 	if err != nil {
 		return "", err
@@ -110,6 +191,7 @@ func (t *jsonTemplate) FallbackText(state State, fields json.RawMessage, lang st
 // whitelist violation all panic at boot, never at first render).
 func (r *Registry) RegisterJSON(assets embed.FS, root string) {
 	mf := loadManifest(assets, root)
+	aggregateArrayLimits := loadJSONTemplateAggregateArrayLimits(assets, root)
 	viewAST := make(map[ViewKey]any, len(mf.Views))
 	for vk, vs := range mf.Views {
 		if strings.TrimSpace(vs.Template) == "" {
@@ -132,5 +214,96 @@ func (r *Registry) RegisterJSON(assets embed.FS, root string) {
 		}
 		viewAST[vk] = ast
 	}
-	r.Register(&jsonTemplate{viewAST: viewAST}, assets, root)
+	r.Register(&jsonTemplate{
+		viewAST:              viewAST,
+		aggregateArrayLimits: aggregateArrayLimits,
+	}, assets, root)
+}
+
+func loadJSONTemplateAggregateArrayLimits(assets embed.FS, root string) []jsonTemplateAggregateArrayLimit {
+	p := path.Join(root, "contract", "data.schema.json")
+	b, err := assets.ReadFile(p)
+	if err != nil {
+		panic(fmt.Errorf("cardtmpl: RegisterJSON: read schema constraints %s: %w", p, err))
+	}
+	var schema jsonTemplateSchemaEnvelope
+	if err := json.Unmarshal(b, &schema); err != nil {
+		panic(fmt.Errorf("cardtmpl: RegisterJSON: parse schema constraints %s: %w", p, err))
+	}
+	if len(schema.Constraints) == 0 {
+		return nil
+	}
+
+	decoder := json.NewDecoder(bytes.NewReader(schema.Constraints))
+	decoder.DisallowUnknownFields()
+	var constraints jsonTemplateConstraintSet
+	if err := decoder.Decode(&constraints); err != nil {
+		panic(fmt.Errorf("cardtmpl: RegisterJSON: parse x-octo-constraints in %s: %w", p, err))
+	}
+	if len(constraints.AggregateArrayLimits) == 0 {
+		panic(fmt.Errorf("cardtmpl: RegisterJSON: x-octo-constraints in %s has no aggregateArrayLimits", p))
+	}
+
+	seen := make(map[string]struct{}, len(constraints.AggregateArrayLimits))
+	for index, limit := range constraints.AggregateArrayLimits {
+		if limit.ParentArray == "" || limit.ParentArray != strings.TrimSpace(limit.ParentArray) {
+			panic(fmt.Errorf("cardtmpl: RegisterJSON: aggregateArrayLimits[%d].parentArray is required in %s", index, p))
+		}
+		if limit.ChildArray == "" || limit.ChildArray != strings.TrimSpace(limit.ChildArray) {
+			panic(fmt.Errorf("cardtmpl: RegisterJSON: aggregateArrayLimits[%d].childArray is required in %s", index, p))
+		}
+		if limit.MaxTotalItems <= 0 {
+			panic(fmt.Errorf("cardtmpl: RegisterJSON: aggregateArrayLimits[%d].maxTotalItems must be positive in %s", index, p))
+		}
+		key := limit.ParentArray + "\x00" + limit.ChildArray
+		if _, duplicate := seen[key]; duplicate {
+			panic(fmt.Errorf("cardtmpl: RegisterJSON: duplicate aggregateArrayLimits target %s[].%s in %s",
+				limit.ParentArray, limit.ChildArray, p))
+		}
+		seen[key] = struct{}{}
+		validateJSONTemplateAggregateTarget(schema.Properties, limit, p)
+	}
+	return constraints.AggregateArrayLimits
+}
+
+func validateJSONTemplateAggregateTarget(
+	properties map[string]json.RawMessage,
+	limit jsonTemplateAggregateArrayLimit,
+	schemaPath string,
+) {
+	parentRaw, exists := properties[limit.ParentArray]
+	if !exists {
+		panic(fmt.Errorf("cardtmpl: RegisterJSON: aggregate parentArray %q not found in %s", limit.ParentArray, schemaPath))
+	}
+	var parent struct {
+		Type  string `json:"type"`
+		Items struct {
+			Type       string                     `json:"type"`
+			Properties map[string]json.RawMessage `json:"properties"`
+		} `json:"items"`
+	}
+	if err := json.Unmarshal(parentRaw, &parent); err != nil {
+		panic(fmt.Errorf("cardtmpl: RegisterJSON: parse aggregate parentArray %q in %s: %w",
+			limit.ParentArray, schemaPath, err))
+	}
+	if parent.Type != "array" || parent.Items.Type != "object" {
+		panic(fmt.Errorf("cardtmpl: RegisterJSON: aggregate parentArray %q must be an array of objects in %s",
+			limit.ParentArray, schemaPath))
+	}
+	childRaw, exists := parent.Items.Properties[limit.ChildArray]
+	if !exists {
+		panic(fmt.Errorf("cardtmpl: RegisterJSON: aggregate childArray %q not found under %q in %s",
+			limit.ChildArray, limit.ParentArray, schemaPath))
+	}
+	var child struct {
+		Type string `json:"type"`
+	}
+	if err := json.Unmarshal(childRaw, &child); err != nil {
+		panic(fmt.Errorf("cardtmpl: RegisterJSON: parse aggregate childArray %q under %q in %s: %w",
+			limit.ChildArray, limit.ParentArray, schemaPath, err))
+	}
+	if child.Type != "array" {
+		panic(fmt.Errorf("cardtmpl: RegisterJSON: aggregate childArray %q under %q must be an array in %s",
+			limit.ChildArray, limit.ParentArray, schemaPath))
+	}
 }

--- a/pkg/cardtmpl/json_template_test.go
+++ b/pkg/cardtmpl/json_template_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"embed"
 	"encoding/json"
+	"errors"
 	"strings"
 	"testing"
 )
@@ -98,6 +99,68 @@ func TestRegisterJSON_C1_RejectsBadFields(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), ErrFieldsInvalid.Error()) {
 		t.Fatalf("want ErrFieldsInvalid, got %v", err)
+	}
+}
+
+func TestRegisterJSONAggregateArrayLimit(t *testing.T) {
+	reg := NewRegistry()
+	reg.RegisterJSON(jsonCardTestData, "testdata/test.jsoncard@0.1.0")
+	reg.SetDefault("test.jsoncard", "0.1.0")
+	reg.Freeze()
+
+	tests := []struct {
+		name    string
+		groups  string
+		wantErr bool
+	}{
+		{name: "exact aggregate limit", groups: `[{"items":["a"]},{"items":["b"]}]`},
+		{name: "aggregate overflow", groups: `[{"items":["a","b"]},{"items":["c"]}]`, wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fields := json.RawMessage(`{"title":"bounded","expanded":true,"rows":[],"groups":` + tt.groups + `}`)
+			_, err := reg.Render(context.Background(), "test.jsoncard", "0.1.0", "shown", fields,
+				BuildEnv{Lang: "zh-CN", SpaceID: "s1"})
+			if tt.wantErr {
+				if !errors.Is(err, ErrFieldsInvalid) {
+					t.Fatalf("Render error = %v, want ErrFieldsInvalid", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Render exact aggregate limit: %v", err)
+			}
+		})
+	}
+}
+
+func TestRegisterJSONAggregateArrayLimitMisconfigurationFailsRegistration(t *testing.T) {
+	tests := []struct {
+		name string
+		root string
+		want string
+	}{
+		{
+			name: "non-positive limit",
+			root: "testdata/test.aggregate-limit-zero@0.1.0",
+			want: "maxTotalItems",
+		},
+		{
+			name: "unknown parent array",
+			root: "testdata/test.aggregate-target-missing@0.1.0",
+			want: "parentArray",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rec := tryRegisterJSON(tt.root)
+			if rec == nil {
+				t.Fatal("expected register-time panic for invalid aggregate constraint")
+			}
+			if got := toStr(rec); !strings.Contains(got, tt.want) {
+				t.Fatalf("panic = %q, want %q", got, tt.want)
+			}
+		})
 	}
 }
 

--- a/pkg/cardtmpl/json_template_test.go
+++ b/pkg/cardtmpl/json_template_test.go
@@ -184,6 +184,21 @@ func TestRegisterJSON_FallbackText_DerivesPlain(t *testing.T) {
 	}
 }
 
+func TestRegisterJSON_FallbackTextEnforcesAggregateLimit(t *testing.T) {
+	reg := NewRegistry()
+	reg.RegisterJSON(jsonCardTestData, "testdata/test.jsoncard@0.1.0")
+	reg.Freeze()
+	tmpl, err := reg.Lookup("test.jsoncard", "0.1.0")
+	if err != nil {
+		t.Fatalf("lookup: %v", err)
+	}
+
+	fields := json.RawMessage(`{"title":"bounded","expanded":true,"rows":[],"groups":[{"items":["a","b"]},{"items":["c"]}]}`)
+	if _, err := tmpl.FallbackText("shown", fields, "zh-CN"); !errors.Is(err, ErrFieldsInvalid) {
+		t.Fatalf("FallbackText aggregate overflow error = %v, want ErrFieldsInvalid", err)
+	}
+}
+
 // TestRegisterJSON_MarkdownLinkInjection_RejectedByValidate proves decision D6's
 // security model: the engine binds data literally (no markdown escaping), and a
 // caller-injected dangerous markdown link in a text field is caught by the L0

--- a/pkg/cardtmpl/json_template_test.go
+++ b/pkg/cardtmpl/json_template_test.go
@@ -184,7 +184,7 @@ func TestRegisterJSON_FallbackText_DerivesPlain(t *testing.T) {
 	}
 }
 
-func TestRegisterJSON_FallbackTextEnforcesAggregateLimit(t *testing.T) {
+func TestRegisterJSON_FallbackTextEnforcesInputConstraints(t *testing.T) {
 	reg := NewRegistry()
 	reg.RegisterJSON(jsonCardTestData, "testdata/test.jsoncard@0.1.0")
 	reg.Freeze()
@@ -193,9 +193,26 @@ func TestRegisterJSON_FallbackTextEnforcesAggregateLimit(t *testing.T) {
 		t.Fatalf("lookup: %v", err)
 	}
 
-	fields := json.RawMessage(`{"title":"bounded","expanded":true,"rows":[],"groups":[{"items":["a","b"]},{"items":["c"]}]}`)
-	if _, err := tmpl.FallbackText("shown", fields, "zh-CN"); !errors.Is(err, ErrFieldsInvalid) {
-		t.Fatalf("FallbackText aggregate overflow error = %v, want ErrFieldsInvalid", err)
+	tests := []struct {
+		name   string
+		fields json.RawMessage
+	}{
+		{name: "empty", fields: nil},
+		{name: "malformed JSON", fields: json.RawMessage(`{`)},
+		{name: "schema invalid", fields: json.RawMessage(`{"title":"missing expanded"}`)},
+		{
+			name: "aggregate overflow",
+			fields: json.RawMessage(
+				`{"title":"bounded","expanded":true,"rows":[],"groups":[{"items":["a","b"]},{"items":["c"]}]}`,
+			),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := tmpl.FallbackText("shown", tt.fields, "zh-CN"); !errors.Is(err, ErrFieldsInvalid) {
+				t.Fatalf("FallbackText error = %v, want ErrFieldsInvalid", err)
+			}
+		})
 	}
 }
 

--- a/pkg/cardtmpl/render.go
+++ b/pkg/cardtmpl/render.go
@@ -23,7 +23,8 @@ const (
 //
 // 流水线 (与 docs/platform-card-base.md §5 对齐):
 //  1. Lookup(id, version) 命中 Template + Meta;
-//  2. Meta.InputSchema.Validate(fields) → 失败返 ErrFieldsInvalid;
+//  2. Meta.InputSchema.Validate(fields) + optional JSON-template semantic
+//     constraints → 失败返 ErrFieldsInvalid;
 //  3. Meta.ViewFor(state) 决定 view/profile → 未注册 state 返 ErrStateUnknown;
 //  4. Template.Build(ctx, state, fields, env) 拿 BuildResult;
 //  5. BuildResult.DeepLink 可选:非空则校验为绝对 https,空则跳过(无 metadata.webUrl);
@@ -73,6 +74,12 @@ func renderCore(
 	if err := meta.InputSchema.Validate(parsed); err != nil {
 		metricBuildResult(meta.ID, meta.Version, "", "fields_invalid")
 		return nil, fmt.Errorf("%w: %v", ErrFieldsInvalid, err)
+	}
+	if validator, ok := t.(jsonTemplateFieldValidator); ok {
+		if err := validator.validateFields(parsed); err != nil {
+			metricBuildResult(meta.ID, meta.Version, "", "fields_invalid")
+			return nil, fmt.Errorf("%w: %v", ErrFieldsInvalid, err)
+		}
 	}
 
 	// step 3: state → view

--- a/pkg/cardtmpl/testdata/test.aggregate-limit-zero@0.1.0/contract/data.schema.json
+++ b/pkg/cardtmpl/testdata/test.aggregate-limit-zero@0.1.0/contract/data.schema.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "x-octo-constraints": {
+    "aggregateArrayLimits": [
+      {
+        "parentArray": "groups",
+        "childArray": "items",
+        "maxTotalItems": 0
+      }
+    ]
+  },
+  "required": ["title", "groups"],
+  "properties": {
+    "title": { "type": "string" },
+    "groups": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["items"],
+        "properties": {
+          "items": { "type": "array", "items": { "type": "string" } }
+        }
+      }
+    }
+  }
+}

--- a/pkg/cardtmpl/testdata/test.aggregate-limit-zero@0.1.0/manifest.json
+++ b/pkg/cardtmpl/testdata/test.aggregate-limit-zero@0.1.0/manifest.json
@@ -1,0 +1,17 @@
+{
+  "schemaVersion": 2,
+  "id": "test.aggregate-limit-zero",
+  "name": "Invalid aggregate limit fixture",
+  "version": "0.1.0",
+  "adaptiveCardVersion": "1.5",
+  "defaultLocale": "zh-CN",
+  "dataSchema": "contract/data.schema.json",
+  "views": {
+    "main": {
+      "wireProfile": "octo/v1",
+      "states": ["shown"],
+      "template": "templates/main.template.json",
+      "samples": ["samples/basic.json"]
+    }
+  }
+}

--- a/pkg/cardtmpl/testdata/test.aggregate-limit-zero@0.1.0/samples/basic.json
+++ b/pkg/cardtmpl/testdata/test.aggregate-limit-zero@0.1.0/samples/basic.json
@@ -1,0 +1,4 @@
+{
+  "title": "invalid limit",
+  "groups": [{"items": ["a"]}]
+}

--- a/pkg/cardtmpl/testdata/test.aggregate-limit-zero@0.1.0/templates/main.template.json
+++ b/pkg/cardtmpl/testdata/test.aggregate-limit-zero@0.1.0/templates/main.template.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+  "type": "AdaptiveCard",
+  "version": "1.5",
+  "body": [
+    {"type": "TextBlock", "text": "${title}", "wrap": true}
+  ]
+}

--- a/pkg/cardtmpl/testdata/test.aggregate-target-missing@0.1.0/contract/data.schema.json
+++ b/pkg/cardtmpl/testdata/test.aggregate-target-missing@0.1.0/contract/data.schema.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "x-octo-constraints": {
+    "aggregateArrayLimits": [
+      {
+        "parentArray": "missing",
+        "childArray": "items",
+        "maxTotalItems": 2
+      }
+    ]
+  },
+  "required": ["title", "groups"],
+  "properties": {
+    "title": { "type": "string" },
+    "groups": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["items"],
+        "properties": {
+          "items": { "type": "array", "items": { "type": "string" } }
+        }
+      }
+    }
+  }
+}

--- a/pkg/cardtmpl/testdata/test.aggregate-target-missing@0.1.0/manifest.json
+++ b/pkg/cardtmpl/testdata/test.aggregate-target-missing@0.1.0/manifest.json
@@ -1,0 +1,17 @@
+{
+  "schemaVersion": 2,
+  "id": "test.aggregate-target-missing",
+  "name": "Missing aggregate target fixture",
+  "version": "0.1.0",
+  "adaptiveCardVersion": "1.5",
+  "defaultLocale": "zh-CN",
+  "dataSchema": "contract/data.schema.json",
+  "views": {
+    "main": {
+      "wireProfile": "octo/v1",
+      "states": ["shown"],
+      "template": "templates/main.template.json",
+      "samples": ["samples/basic.json"]
+    }
+  }
+}

--- a/pkg/cardtmpl/testdata/test.aggregate-target-missing@0.1.0/samples/basic.json
+++ b/pkg/cardtmpl/testdata/test.aggregate-target-missing@0.1.0/samples/basic.json
@@ -1,0 +1,4 @@
+{
+  "title": "missing target",
+  "groups": [{"items": ["a"]}]
+}

--- a/pkg/cardtmpl/testdata/test.aggregate-target-missing@0.1.0/templates/main.template.json
+++ b/pkg/cardtmpl/testdata/test.aggregate-target-missing@0.1.0/templates/main.template.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+  "type": "AdaptiveCard",
+  "version": "1.5",
+  "body": [
+    {"type": "TextBlock", "text": "${title}", "wrap": true}
+  ]
+}

--- a/pkg/cardtmpl/testdata/test.jsoncard@0.1.0/contract/data.schema.json
+++ b/pkg/cardtmpl/testdata/test.jsoncard@0.1.0/contract/data.schema.json
@@ -2,6 +2,15 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "additionalProperties": false,
+  "x-octo-constraints": {
+    "aggregateArrayLimits": [
+      {
+        "parentArray": "groups",
+        "childArray": "items",
+        "maxTotalItems": 2
+      }
+    ]
+  },
   "required": ["title", "expanded"],
   "properties": {
     "title": { "type": "string", "minLength": 1, "maxLength": 200 },
@@ -13,6 +22,20 @@
         "additionalProperties": false,
         "required": ["label"],
         "properties": { "label": { "type": "string", "minLength": 1 } }
+      }
+    },
+    "groups": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["items"],
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": { "type": "string" }
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary

Publish the bounded `ai.reasoning-process@0.2.0` successor, preserve the immutable `0.1.0` contract for in-flight edits, and cut Bot discovery/new send to the successor without changing `template-ref/v1`.

Production card delivery remains gated by `OCTO_BOT_CARD_ENABLED`; this PR does not enable Model A in production or implement stop/retry business semantics.

## Related Issue

Closes #668

## Linked Spec

`.octospec/tasks/cardtmpl-reasoning-schema-successor/brief.md`

## Changes

- Add `ai.reasoning-process@0.2.0` with bounded free strings and arrays while keeping the published `0.1.0` handoff byte-identical.
- Add schema-declared `x-octo-constraints.aggregateArrayLimits`, validate its target at registration, and enforce the aggregate limit before JSON template expansion in both Render and FallbackText paths.
- Use an aggregate action limit of 13 to preserve the frozen `completed` fixture (`3 + 7 + 3`); the OpenClaw producer remains stricter at 12.
- Register both versions, set `0.2.0` as the Registry default, advertise/allow only `0.2.0` for new Bot sends, and retain `0.1.0 + 0.2.0` for same-version edits.
- Add boundary, conformance, catalog, zero-dispatch/zero-mutation, legacy-edit, and race coverage.

## Testing

- [x] Unit tests added/updated
- [ ] Manually verified (not deployed; no live successor E2E in this PR)

Passed locally:

- `go test ./pkg/cardtmpl/... -count=1`
- E1c Bot catalog/send/edit tests under `./modules/bot_api`
- `go test ./pkg/cardmsg/... ./internal/carddispatch/... ./internal/cardactiondispatch/... -count=1`
- `go test -race ./pkg/cardtmpl/... -count=1`
- E1c Bot catalog/send/edit race tests under `./modules/bot_api`
- `go test -race ./internal/carddispatch/... ./internal/cardactiondispatch/... -count=1`
- `go build ./...`
- targeted `go vet` and `golangci-lint` for the changed packages
- `make i18n-extract-check`
- `make i18n-lint`
- `git diff --check`

The full local `go test ./modules/bot_api/... -count=1` run is blocked by the existing test database reporting unknown migration `20191106000001_event_legacy01.sql`; CI must complete that clean-environment lane.

## COMPREHENSION

1. **What does this change actually do** to the load-bearing path?

   It moves deterministic caller-size failures ahead of JSON expansion, changes the active reasoning template version for Registry/default and Bot new-send authorization, and preserves the old version only for stored same-version edits. The wire shape, state/view mapping, ownership, Space checks, CAS, and dispatch/mutation paths remain unchanged.

2. **What could break** because of it (dependents + failure mode)?

   Producers that hard-code `0.1.0` can no longer create new Registry messages and will receive the existing card-invalid response. Inputs beyond the new schema/aggregate limits also fail deterministically with card-invalid. Rolling back to a pre-E1c binary would make experimental `0.2.0` cards non-editable, so production delivery must remain disabled until rollout and cross-repository validation are complete.

3. **How do you know it works** (specific test/repro/trace)?

   Tests cover exact-limit and limit+1 values (including Unicode), aggregate 13/14, worst-case rendering in every view, five-state conformance for both versions, byte equality of frozen artifacts, successor-only capability/new send, zero dispatch for legacy/invalid sends, zero mutation for invalid edits, and successful same-version legacy edits. Race, build, vet, lint, and i18n checks also pass as listed above.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] PR description is in English
- [x] Added tests for my changes
- [x] Updated documentation
- [x] Followed commit message conventions (Conventional Commits)
