### PR TITLE
feat: add immutable runtime card template publishing foundation

### DIFF
--- a/.octospec/journal/shared/cardtmpl-runtime-catalog.md
+++ b/.octospec/journal/shared/cardtmpl-runtime-catalog.md
@@ -1,0 +1,103 @@
+---
+type: Journal
+title: "Journal: cardtmpl-runtime-catalog (roadmap E3 PR-A)"
+description: Add the dark, immutable publishing foundation for governed runtime JSON card templates without enabling activation, discovery, or dynamic sends.
+tags: ["cardtmpl", "runtime-catalog", "json-template", "control-plane", "database", "trust-boundary", "wire-contract", "testing", "e3"]
+timestamp: 2026-07-28T11:14:10+08:00
+# --- octospec extension fields ---
+task: cardtmpl-runtime-catalog
+upstream: "roadmap E3; Issue #669"
+pr: 670
+source: self
+---
+
+# Journal: cardtmpl-runtime-catalog (roadmap E3 PR-A)
+
+## What was done
+
+- Added a shared, error-returning JSON artifact compiler used by both runtime
+  control requests and static `Registry.RegisterJSON`. It strictly decodes every
+  document, rejects duplicate keys/trailing tokens/invalid Unicode and unsafe
+  references, applies document/depth/node/concurrency budgets, compiles schemas
+  and templates, renders state samples, checks interaction reports and goldens,
+  and derives a deterministic canonical SHA-256 identity.
+- Kept Go-authored templates fail-closed: a Go template that declares the
+  JSON-only `x-octo-constraints` extension now panics during registration instead
+  of silently ignoring the constraint. Legacy static JSON fixtures retain their
+  pre-E3 governance compatibility while still sharing the parser/compiler.
+- Added case-sensitive, immutable `card_template_version_claim`,
+  `card_template_artifact`, and append-only `card_template_audit` storage.
+  Publish atomically inserts claim + artifact + success audit; same-hash retry is
+  idempotent, different-hash or static-source reuse is a conflict, and audit
+  failure rolls the transaction back.
+- Reconciled the frozen built-in Registry into persistent static claims during
+  startup. A dynamic/static exact-key collision or incomplete catalog state
+  fails startup rather than allowing replicas to resolve different content.
+- Added `POST /v1/manager/card-templates/validate` and `/publish` behind Auth,
+  the shared UID rate limiter, and an explicit super-admin guard. Requests have
+  a 2 MiB pre-decode cap, strict envelopes, bounded reason/change-ticket/actor
+  fields, localized safe errors, and low-cardinality operation/compile/DB
+  metrics. Every response reports `active=false`; no production render path
+  reads the dynamic artifact table in PR-A.
+
+## Load-bearing decisions
+
+- Publish, activate, and authorize remain separate. PR-A only validates and
+  persists inactive immutable artifacts; activation/runtime overlay is PR-B,
+  while grants and B1/B2 discovery/export are PR-C.
+- MySQL is authoritative for version claims and artifacts. Static reconciliation
+  happens transactionally before the module serves routes; correctness never
+  relies on process-local registration order or eventual cache invalidation.
+- Canonical identity is server-computed from parsed content. Equivalent JSON
+  formatting produces the same bundle hash and the same canonical manifest
+  metadata; caller-supplied hashes are not accepted.
+- Runtime governance is stricter than frozen legacy registration: manifest
+  identity lengths match the persistence columns, SemVer is canonical, schemas
+  must be structurally bounded, and unsupported/ambiguous forms fail closed.
+
+## Verification
+
+- Final focused suites passed for `pkg/cardtmpl/...` and
+  `modules/card_template_catalog`; coverage is 80.8% and 82.5% respectively.
+- Final race suites passed for cardtmpl/catalog, `pkg/cardmsg`,
+  `internal/carddispatch`, `internal/cardactiondispatch`, and the database-free
+  Bot template catalog/policy lane.
+- `go build ./...`, focused `go vet`, `golangci-lint run ./...`,
+  `make i18n-extract-check`, `make i18n-lint`, and `git diff --check` passed.
+- The local Bot profile integration lane remains blocked before assertions by a
+  stale shared test-database migration record
+  (`20191106000001_event_legacy01.sql`). PR #670 received three approvals and a
+  successful automated code-review gate; Ready-state clean-database CI remains
+  required before merge.
+
+## Structural learnings / gotchas
+
+- A successful control-plane `validate` response is part of the publish
+  contract. Compiler limits must match persistence widths; otherwise a bundle
+  can validate successfully and then deterministically fail at the database.
+- Checking only `type == "string"` or `type == "array"` is not a complete schema
+  resource proof. `{}` permits every shape, and union types such as
+  `["string", "null"]` bypass a scalar type assertion. The analyzer now handles
+  finite unions, enum/const, local refs, and supported compositions
+  conservatively; unknown shapes fail closed.
+- Canonical hash equality is insufficient if metadata retains raw formatting.
+  Hash input and exposed compiled metadata must derive from the same parsed,
+  canonical representation so an idempotent same-hash publish cannot expose
+  replica-dependent metadata.
+
+## Review follow-ups / out of scope
+
+- Before PR-B enables dynamic resolution, bound object key cardinality and
+  explicitly reject or constrain open-keyspace schema constructs such as
+  `patternProperties`; `additionalProperties=false` alone is not a complete
+  object resource bound.
+- Before untrusted runtime fields can reach dynamic rendering, make their decode
+  path preserve the compiler's duplicate-key/trailing-token/depth/node rules;
+  the existing static render path still uses standard `json.Unmarshal` before
+  schema and final card validation.
+- Add a clean-MySQL concurrent same-identity publish integration test and decide
+  whether the 2 MiB canonical bundle invariant also needs a DB `CHECK` as
+  defense in depth.
+- Activate/rollback/block, runtime overlay/cache, grants, B1/B2, Bot capability
+  merge, multi-replica runtime recovery, and production go-live remain PR-B/PR-C
+  and separate rollout work.

--- a/.octospec/journal/shared/cardtmpl-runtime-catalog.md
+++ b/.octospec/journal/shared/cardtmpl-runtime-catalog.md
@@ -21,6 +21,11 @@ source: self
   references, applies document/depth/node/concurrency budgets, compiles schemas
   and templates, renders state samples, checks interaction reports and goldens,
   and derives a deterministic canonical SHA-256 identity.
+- Golden expansion now gives strict-decoder `json.Number` values the same
+  comparison and interpolation semantics as production `float64` rendering.
+  Positive integer schema/aggregate limits accept equivalent JSON exponent
+  notation, so canonical bundles containing `1e+6` round-trip through storage
+  and recompilation without being mislabeled as unbounded.
 - Bounded-schema analysis now resolves bundle-local JSON Pointers at every
   schema-bearing position, including array `items`; boolean/empty/unbounded
   targets and reference cycles fail closed. The validator performs one
@@ -37,8 +42,10 @@ source: self
 - Added case-sensitive, immutable `card_template_version_claim`,
   `card_template_artifact`, and append-only `card_template_audit` storage.
   Publish atomically inserts claim + artifact + success audit; same-hash retry is
-  idempotent, different-hash or static-source reuse is a conflict, and audit
-  failure rolls the transaction back.
+  idempotent, while different-hash or static-source reuse commits an audit-only
+  conflict row without changing claim/artifact state. Any success or rejected
+  audit failure rolls its transaction back; an audit commit failure is surfaced
+  as unavailable instead of claiming an unaudited conflict response.
 - Reconciled the frozen built-in Registry into persistent static claims during
   startup. A dynamic/static exact-key collision or incomplete catalog state
   fails startup rather than allowing replicas to resolve different content.
@@ -49,8 +56,10 @@ source: self
   the shared UID rate limiter, and an explicit super-admin guard. Requests have
   a 2 MiB pre-decode cap, strict envelopes, bounded reason/change-ticket/actor
   fields, localized safe errors, and low-cardinality operation/compile/DB
-  metrics. Every response reports `active=false`; no production render path
-  reads the dynamic artifact table in PR-A.
+  metrics. The envelope is strictly parsed once and its validated bundle value
+  is decoded directly, avoiding the earlier full-envelope canonicalize plus
+  nested-bundle reparse. Every response reports `active=false`; no production
+  render path reads the dynamic artifact table in PR-A.
 - Persistent catalog-integrity violations are logged and reported as the shared
   internal error with a dedicated `integrity_error` metric result; transient or
   unknown store failures retain the retryable unavailable response. Publish DB
@@ -85,7 +94,7 @@ source: self
 ## Verification
 
 - Final focused suites passed for `pkg/cardtmpl/...` and
-  `modules/card_template_catalog`; coverage is 80.4% and 81.6% respectively.
+  `modules/card_template_catalog`; coverage is 80.6% and 83.0% respectively.
 - Final race suites passed for cardtmpl/catalog, `pkg/cardmsg`,
   `internal/carddispatch`, `internal/cardactiondispatch`, and the database-free
   Bot template catalog/policy lane.
@@ -130,6 +139,14 @@ source: self
   Hash input and exposed compiled metadata must derive from the same parsed,
   canonical representation so an idempotent same-hash publish cannot expose
   replica-dependent metadata.
+- Validation and production rendering must normalize numeric values at the
+  evaluator boundary: strict compilation intentionally preserves `json.Number`
+  for canonical identity, while production field decoding yields `float64`.
+  Conditions and interpolation must therefore share one value-semantic format.
+- Sample assignment with both exact-name and positional fallback is a two-phase
+  allocation problem. Reserve every exact match first, then assign only the
+  remaining samples in manifest order; a one-pass fallback can steal a later
+  state's exact sample.
 
 ## Review follow-ups / out of scope
 
@@ -147,14 +164,14 @@ source: self
 - Freeze and document the exact canonical-number representation for
   `octo-json-template/v1`; add formal JCS conformance vectors before claiming
   cross-system RFC 8785 reproducibility or changing the identity algorithm.
-- Before activation, acquire compile admission before repeated strict-decode and
-  canonicalization work. Publish deadline, overload/context classification, and
-  transient 1205/1213 transaction retry are complete in PR-A.
-- Decide in PR-B governance work whether rejected publish conflicts need a
-  durable audit written outside the rolled-back state transaction, and whether
-  database triggers or restricted grants must enforce artifact/audit
-  immutability against direct SQL. Do not weaken the existing atomic success
-  audit while adding rejected-attempt evidence.
+- Before activation or wider control-plane delegation, decide whether the
+  remaining single strict envelope parse needs separate admission ahead of the
+  compiler semaphore. The redundant nested-bundle parse, canonical sort
+  allocations, publish deadline, overload/context classification, and transient
+  1205/1213 transaction retry are complete in PR-A.
+- Decide in PR-B governance work whether database triggers or restricted grants
+  must enforce artifact/audit immutability against direct SQL. Atomic success
+  audits and audit-only immutable/source-conflict records are complete in PR-A.
 - Split the compiler's owner-required policy from action-contract validation,
   and make the JSON node budget bundle-wide if document limits are ever raised.
   The existing byte/document caps keep the current per-document budget bounded.

--- a/.octospec/journal/shared/cardtmpl-runtime-catalog.md
+++ b/.octospec/journal/shared/cardtmpl-runtime-catalog.md
@@ -21,6 +21,11 @@ source: self
   references, applies document/depth/node/concurrency budgets, compiles schemas
   and templates, renders state samples, checks interaction reports and goldens,
   and derives a deterministic canonical SHA-256 identity.
+- Bounded-schema analysis now resolves bundle-local JSON Pointers at every
+  schema-bearing position, including array `items`; boolean/empty/unbounded
+  targets and reference cycles fail closed. Sample assignment is view-local,
+  and a parity fixture compares static and runtime compilation for identity,
+  metadata, interactions, samples, and rendered output.
 - Kept Go-authored templates fail-closed: a Go template that declares the
   JSON-only `x-octo-constraints` extension now panics during registration instead
   of silently ignoring the constraint. Legacy static JSON fixtures retain their
@@ -33,12 +38,18 @@ source: self
 - Reconciled the frozen built-in Registry into persistent static claims during
   startup. A dynamic/static exact-key collision or incomplete catalog state
   fails startup rather than allowing replicas to resolve different content.
+  Reconciliation uses a no-op upsert followed by source/artifact verification
+  and bounded retry for transient transaction failures, avoiding the duplicate
+  INSERT lock-upgrade pattern under concurrent replica startup.
 - Added `POST /v1/manager/card-templates/validate` and `/publish` behind Auth,
   the shared UID rate limiter, and an explicit super-admin guard. Requests have
   a 2 MiB pre-decode cap, strict envelopes, bounded reason/change-ticket/actor
   fields, localized safe errors, and low-cardinality operation/compile/DB
   metrics. Every response reports `active=false`; no production render path
   reads the dynamic artifact table in PR-A.
+- Persistent catalog-integrity violations are logged and reported as the shared
+  internal error with a dedicated `integrity_error` metric result; transient or
+  unknown store failures retain the retryable unavailable response.
 
 ## Load-bearing decisions
 
@@ -58,7 +69,7 @@ source: self
 ## Verification
 
 - Final focused suites passed for `pkg/cardtmpl/...` and
-  `modules/card_template_catalog`; coverage is 80.8% and 82.5% respectively.
+  `modules/card_template_catalog`; coverage is 80.4% and 81.9% respectively.
 - Final race suites passed for cardtmpl/catalog, `pkg/cardmsg`,
   `internal/carddispatch`, `internal/cardactiondispatch`, and the database-free
   Bot template catalog/policy lane.
@@ -66,9 +77,8 @@ source: self
   `make i18n-extract-check`, `make i18n-lint`, and `git diff --check` passed.
 - The local Bot profile integration lane remains blocked before assertions by a
   stale shared test-database migration record
-  (`20191106000001_event_legacy01.sql`). PR #670 received three approvals and a
-  successful automated code-review gate; Ready-state clean-database CI remains
-  required before merge.
+  (`20191106000001_event_legacy01.sql`). A clean test database remains required
+  for that integration lane and for the merge gate.
 
 ## Structural learnings / gotchas
 
@@ -80,6 +90,18 @@ source: self
   `["string", "null"]` bypass a scalar type assertion. The analyzer now handles
   finite unions, enum/const, local refs, and supported compositions
   conservatively; unknown shapes fail closed.
+- Allowing the syntax of a local `$ref` is not the same as proving its target is
+  bounded. Every reference must be resolved against the root schema with cycle
+  detection, and every nested schema position (notably array `items`) must apply
+  the same proof.
+- Bundle-wide lookup maps are unsafe for view-local sample/state binding: key
+  collisions across views combine with randomized Go map iteration to make the
+  compiled artifact nondeterministic. Bind only against the current view's
+  declared samples.
+- Concurrent startup reconciliation must avoid a plain duplicate INSERT followed
+  by verification, which can create an InnoDB S-to-X lock upgrade cycle. A no-op
+  upsert plus post-write verification removes that shape; bounded retry is still
+  required for transient deadlock/lock-timeout errors.
 - Canonical hash equality is insufficient if metadata retains raw formatting.
   Hash input and exposed compiled metadata must derive from the same parsed,
   canonical representation so an idempotent same-hash publish cannot expose
@@ -96,8 +118,15 @@ source: self
   the existing static render path still uses standard `json.Unmarshal` before
   schema and final card validation.
 - Add a clean-MySQL concurrent same-identity publish integration test and decide
-  whether the 2 MiB canonical bundle invariant also needs a DB `CHECK` as
-  defense in depth.
+  whether the 2 MiB canonical bundle and engine-contract invariants also need DB
+  `CHECK`s as defense in depth.
+- Freeze and document the exact canonical-number representation for
+  `octo-json-template/v1`; add formal JCS conformance vectors before claiming
+  cross-system RFC 8785 reproducibility or changing the identity algorithm.
+- Before activation, acquire compile admission before repeated strict-decode and
+  canonicalization work, and give publish DB work an explicit request-scoped
+  timeout so overload, timeout, transient DB failure, and integrity failure stay
+  independently observable.
 - Activate/rollback/block, runtime overlay/cache, grants, B1/B2, Bot capability
   merge, multi-replica runtime recovery, and production go-live remain PR-B/PR-C
   and separate rollout work.

--- a/.octospec/journal/shared/cardtmpl-runtime-catalog.md
+++ b/.octospec/journal/shared/cardtmpl-runtime-catalog.md
@@ -23,9 +23,13 @@ source: self
   and derives a deterministic canonical SHA-256 identity.
 - Bounded-schema analysis now resolves bundle-local JSON Pointers at every
   schema-bearing position, including array `items`; boolean/empty/unbounded
-  targets and reference cycles fail closed. Sample assignment is view-local,
-  and a parity fixture compares static and runtime compilation for identity,
-  metadata, interactions, samples, and rendered output.
+  targets and reference cycles fail closed. The validator performs one
+  deterministic traversal, checks cancellation throughout, enforces a total
+  visit budget, and caches successfully validated local refs; context failures
+  remain server failures rather than being relabeled as invalid artifacts.
+  Sample assignment is view-local, and a parity fixture compares static and
+  runtime compilation for identity, metadata, interactions, samples, and
+  rendered output.
 - Kept Go-authored templates fail-closed: a Go template that declares the
   JSON-only `x-octo-constraints` extension now panics during registration instead
   of silently ignoring the constraint. Legacy static JSON fixtures retain their
@@ -49,7 +53,15 @@ source: self
   reads the dynamic artifact table in PR-A.
 - Persistent catalog-integrity violations are logged and reported as the shared
   internal error with a dedicated `integrity_error` metric result; transient or
-  unknown store failures retain the retryable unavailable response.
+  unknown store failures retain the retryable unavailable response. Publish DB
+  work has its own 10-second deadline, retries the complete transaction up to
+  three times for MySQL 1205/1213, and exposes separate bounded timeout,
+  cancellation, busy, integrity, conflict, and generic-error outcomes.
+- Kept startup reconciliation fail-closed without an ignore-conflict switch.
+  The [startup recovery runbook](../../../docs/card-template-runtime-catalog-runbook.md)
+  defines rollback/corrective-image recovery for a future built-in exact-key
+  collision and reserves direct row repair for a separately audited integrity
+  incident.
 
 ## Load-bearing decisions
 
@@ -59,6 +71,10 @@ source: self
 - MySQL is authoritative for version claims and artifacts. Static reconciliation
   happens transactionally before the module serves routes; correctness never
   relies on process-local registration order or eventual cache invalidation.
+- Permanent exact-key claims are a safety boundary, not data to rewrite during
+  rollout recovery. A conflicting built-in must move to a new version; binary
+  rollback is the PR-A break-glass action because no dynamic runtime reader is
+  enabled yet.
 - Canonical identity is server-computed from parsed content. Equivalent JSON
   formatting produces the same bundle hash and the same canonical manifest
   metadata; caller-supplied hashes are not accepted.
@@ -69,7 +85,7 @@ source: self
 ## Verification
 
 - Final focused suites passed for `pkg/cardtmpl/...` and
-  `modules/card_template_catalog`; coverage is 80.4% and 81.9% respectively.
+  `modules/card_template_catalog`; coverage is 80.4% and 81.6% respectively.
 - Final race suites passed for cardtmpl/catalog, `pkg/cardmsg`,
   `internal/carddispatch`, `internal/cardactiondispatch`, and the database-free
   Bot template catalog/policy lane.
@@ -102,6 +118,14 @@ source: self
   by verification, which can create an InnoDB S-to-X lock upgrade cycle. A no-op
   upsert plus post-write verification removes that shape; bounded retry is still
   required for transient deadlock/lock-timeout errors.
+- Schema walkers must not combine a structural pass with an unrestricted
+  catch-all pass over the same keywords. That turns ordinary nesting into
+  exponential CPU work, and a deadline checked only after the walker cannot
+  bound it. Single traversal, in-walker context checks, and a total visit budget
+  are one invariant and must be tested together.
+- A duplicate-key fallback can still deadlock under concurrent idempotent
+  publishes. Retry the whole transaction, never a statement inside the failed
+  transaction, and restrict retries to known transient MySQL codes.
 - Canonical hash equality is insufficient if metadata retains raw formatting.
   Hash input and exposed compiled metadata must derive from the same parsed,
   canonical representation so an idempotent same-hash publish cannot expose
@@ -124,9 +148,19 @@ source: self
   `octo-json-template/v1`; add formal JCS conformance vectors before claiming
   cross-system RFC 8785 reproducibility or changing the identity algorithm.
 - Before activation, acquire compile admission before repeated strict-decode and
-  canonicalization work, and give publish DB work an explicit request-scoped
-  timeout so overload, timeout, transient DB failure, and integrity failure stay
-  independently observable.
+  canonicalization work. Publish deadline, overload/context classification, and
+  transient 1205/1213 transaction retry are complete in PR-A.
+- Decide in PR-B governance work whether rejected publish conflicts need a
+  durable audit written outside the rolled-back state transaction, and whether
+  database triggers or restricted grants must enforce artifact/audit
+  immutability against direct SQL. Do not weaken the existing atomic success
+  audit while adding rejected-attempt evidence.
+- Split the compiler's owner-required policy from action-contract validation,
+  and make the JSON node budget bundle-wide if document limits are ever raised.
+  The existing byte/document caps keep the current per-document budget bounded.
+- The `blocked` publish response remains an omitted `false` in PR-A and mirrors
+  the forward-compatible persistence column; PR-B owns the first state
+  transition and must add behavior tests before clients may rely on it.
 - Activate/rollback/block, runtime overlay/cache, grants, B1/B2, Bot capability
   merge, multi-replica runtime recovery, and production go-live remain PR-B/PR-C
   and separate rollout work.

--- a/.octospec/learnings/pending/cardtmpl-runtime-catalog.md
+++ b/.octospec/learnings/pending/cardtmpl-runtime-catalog.md
@@ -31,8 +31,8 @@ not only a convenient decoded representation:
 
 - `{}` allows strings, arrays, and objects and is therefore not bounded;
 - `type: ["string", "null"]` still requires a string bound;
-- finite `enum`/`const`, internal refs, and compositions need explicit,
-  conservative handling;
+- finite `enum`/`const`, internal refs, array items, and compositions need
+  explicit, conservative handling; refs must be resolved with cycle detection;
 - open-keyspace object constructs such as `patternProperties` need a key-count
   bound or rejection before runtime activation.
 

--- a/.octospec/learnings/pending/cardtmpl-runtime-catalog.md
+++ b/.octospec/learnings/pending/cardtmpl-runtime-catalog.md
@@ -41,7 +41,18 @@ supports them. Finally, canonical hash input and exposed compiled metadata must
 come from the same parsed representation; otherwise equivalent same-hash
 artifacts can still expose formatting-dependent metadata.
 
+The proof must also be computationally bounded. A walker that handles
+`properties` structurally and then revisits it through a generic map traversal
+does exponential work as object depth increases, even when the schema is only a
+few kilobytes. A request deadline is ineffective if the walker does not inspect
+the context. Treat these as one load-bearing invariant: each structural edge is
+visited once, traversal checks cancellation, successful local-ref proofs may be
+memoized only after cycle-safe validation, and a total visit budget stops future
+schema keywords from creating unbounded work. Keep a depth-cost regression and
+a context-classification regression, not only correctness fixtures.
+
 **Candidate rule:** an untrusted artifact validator must prove both downstream
-persistence compatibility and worst-case runtime resource bounds. Test every
-schema form that can widen the accepted value space, and reject unsupported
-forms rather than interpreting them as harmless.
+persistence compatibility and worst-case runtime resource bounds, including the
+cost of the proof itself. Test every schema form that can widen the accepted
+value space, and reject unsupported forms rather than interpreting them as
+harmless.

--- a/.octospec/learnings/pending/cardtmpl-runtime-catalog.md
+++ b/.octospec/learnings/pending/cardtmpl-runtime-catalog.md
@@ -1,0 +1,47 @@
+---
+type: Learning
+title: "Runtime artifact validation must prove persistence and resource invariants"
+description: A validate endpoint for untrusted authored artifacts must enforce the same storage widths and schema resource bounds as publish; unknown or union schema forms cannot be treated as bounded by omission.
+tags: ["runtime-catalog", "json-schema", "database", "validation", "trust-boundary", "testing"]
+timestamp: 2026-07-28T11:14:10+08:00
+# --- octospec extension fields ---
+source: self
+origin_task: cardtmpl-runtime-catalog
+origin_pr: 670
+status: pending
+candidate_rule: trust-boundary
+---
+
+# Runtime artifact validation must prove persistence and resource invariants
+
+For a control plane that exposes separate `validate` and `publish` operations,
+"valid" must mean that the artifact satisfies every deterministic invariant
+required by the immutable store. If validation accepts a 129-byte identity but
+the database column is `VARCHAR(128)`, the API has created a validate/publish
+contract drift even though persistence still fails closed.
+
+Mirror persistence invariants at the compiler boundary and lock them with
+tests: identity length/collation, canonical version syntax, canonical bundle
+size, engine/visibility values, and any metadata written into narrower columns.
+The store should still revalidate defensive invariants, but it must not be the
+first layer to discover a caller-correctable artifact error.
+
+Schema resource analysis must also reason about every shape the schema permits,
+not only a convenient decoded representation:
+
+- `{}` allows strings, arrays, and objects and is therefore not bounded;
+- `type: ["string", "null"]` still requires a string bound;
+- finite `enum`/`const`, internal refs, and compositions need explicit,
+  conservative handling;
+- open-keyspace object constructs such as `patternProperties` need a key-count
+  bound or rejection before runtime activation.
+
+Unknown schema forms should fail closed until the engine contract deliberately
+supports them. Finally, canonical hash input and exposed compiled metadata must
+come from the same parsed representation; otherwise equivalent same-hash
+artifacts can still expose formatting-dependent metadata.
+
+**Candidate rule:** an untrusted artifact validator must prove both downstream
+persistence compatibility and worst-case runtime resource bounds. Test every
+schema form that can widen the accepted value space, and reject unsupported
+forms rather than interpreting them as harmless.

--- a/.octospec/log.md
+++ b/.octospec/log.md
@@ -4,6 +4,29 @@ Change history for this repo's `.octospec/`, following the
 [OKF](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md)
 change-log convention (§7). Newest first.
 
+## 2026-07-28 (cardtmpl-runtime-catalog, roadmap E3 PR-A)
+
+- **Dark publishing foundation** — Added the shared strict JSON artifact
+  compiler, deterministic canonical identity, immutable static/dynamic version
+  claims and artifacts, transactional publish audit, and startup static
+  inventory reconciliation. See
+  [journal](journal/shared/cardtmpl-runtime-catalog.md),
+  [brief](tasks/cardtmpl-runtime-catalog/brief.md), and PR #670 / Issue #669.
+- **Control plane** — Added super-admin-only, authenticated and UID-rate-limited
+  validate/publish endpoints with a 2 MiB body cap, localized safe errors, and
+  bounded operation/compile/DB metrics. Published artifacts remain inactive and
+  are not read by production render/send/edit paths in PR-A.
+- **Fail-close hardening** — Runtime manifests now align identity lengths with
+  persistence columns, reject ambiguous SemVer/Unicode identities, conservatively
+  validate bounded schema shapes, and expose canonical manifest metadata.
+- **Learning (pending)** — Artifact validation must prove both persistence
+  compatibility and worst-case schema resource bounds; unknown or union schema
+  forms cannot be treated as bounded by omission. See
+  [learning](learnings/pending/cardtmpl-runtime-catalog.md).
+- **Boundary** — activation/rollback/block/runtime overlay remain PR-B; grants,
+  B1/B2, and Bot capability merge remain PR-C. Object keyspace bounds and strict
+  untrusted render-field decoding must close before dynamic activation.
+
 ## 2026-07-24 (bot-card-template-consumption, roadmap E1b)
 
 - **Protocol** — Added the explicit Bot Registry template catalog to

--- a/.octospec/log.md
+++ b/.octospec/log.md
@@ -17,8 +17,12 @@ change-log convention (§7). Newest first.
   bounded operation/compile/DB metrics. Published artifacts remain inactive and
   are not read by production render/send/edit paths in PR-A.
 - **Fail-close hardening** — Runtime manifests now align identity lengths with
-  persistence columns, reject ambiguous SemVer/Unicode identities, conservatively
-  validate bounded schema shapes, and expose canonical manifest metadata.
+  persistence columns, reject ambiguous SemVer/Unicode identities, resolve local
+  schema refs (including array items) with cycle detection, bind samples within
+  their declaring view, and expose canonical manifest metadata.
+- **Review hardening** — Added full static/runtime canonical parity coverage,
+  contention-safe static-claim upsert plus bounded retry, and a distinct internal
+  error/metric classification for persistent catalog-integrity failures.
 - **Learning (pending)** — Artifact validation must prove both persistence
   compatibility and worst-case schema resource bounds; unknown or union schema
   forms cannot be treated as bounded by omission. See

--- a/.octospec/log.md
+++ b/.octospec/log.md
@@ -22,7 +22,15 @@ change-log convention (§7). Newest first.
   their declaring view, and expose canonical manifest metadata.
 - **Review hardening** — Added full static/runtime canonical parity coverage,
   contention-safe static-claim upsert plus bounded retry, and a distinct internal
-  error/metric classification for persistent catalog-integrity failures.
+  error/metric classification for persistent catalog-integrity failures. The
+  bounded-schema proof is now a context-aware, visit-budgeted single traversal;
+  publish DB work has a 10-second deadline, bounded whole-transaction retry for
+  MySQL 1205/1213, and separate low-cardinality failure outcomes.
+- **Startup recovery** — Kept exact-key reconciliation fail-closed and documented
+  the safe PR-A break-glass path in the
+  [runbook](../docs/card-template-runtime-catalog-runbook.md): roll back or
+  correct the conflicting image and assign a new built-in version; never delete,
+  rewrite, or bypass permanent claim/artifact state.
 - **Learning (pending)** — Artifact validation must prove both persistence
   compatibility and worst-case schema resource bounds; unknown or union schema
   forms cannot be treated as bounded by omission. See

--- a/.octospec/log.md
+++ b/.octospec/log.md
@@ -26,6 +26,11 @@ change-log convention (§7). Newest first.
   bounded-schema proof is now a context-aware, visit-budgeted single traversal;
   publish DB work has a 10-second deadline, bounded whole-transaction retry for
   MySQL 1205/1213, and separate low-cardinality failure outcomes.
+- **Final review closure** — Unified golden/runtime number semantics, made
+  canonical integer limits recompile-safe, fixed mixed exact/positional sample
+  assignment, made validation-document selection deterministic, removed UTF-16
+  sort allocations and a redundant envelope/bundle decode pass, and durably
+  audited immutable/static-source publish conflicts without mutating artifacts.
 - **Startup recovery** — Kept exact-key reconciliation fail-closed and documented
   the safe PR-A break-glass path in the
   [runbook](../docs/card-template-runtime-catalog-runbook.md): roll back or

--- a/.octospec/tasks/cardtmpl-runtime-catalog/brief.md
+++ b/.octospec/tasks/cardtmpl-runtime-catalog/brief.md
@@ -30,8 +30,13 @@ source: self
   contention-safe, and distinguishes persistent catalog-integrity failures from timeout,
   cancellation, overload, and retryable database unavailability. Publish database work has an
   independent 10-second deadline and retries whole transactions for MySQL 1205/1213 only.
+- Final review hardening unifies strict-decoder `json.Number` behavior with production rendering,
+  preserves integer limits through canonical exponent notation and storage recompilation, reserves
+  exact sample/state matches before positional fallback, makes multi-document errors deterministic,
+  records immutable/source-conflict publish attempts in audit-only transactions, and removes one
+  redundant full-bundle decode/canonicalization pass from the control request path.
 - Focused unit, coverage, race, build, vet, lint, and i18n checks pass locally. `pkg/cardtmpl` coverage is
-  80.4% and `modules/card_template_catalog` coverage is 81.6%.
+  80.6% and `modules/card_template_catalog` coverage is 83.0%.
 - The database-independent Bot catalog race lane passes. The local Bot profile integration lane is blocked
   before assertions by a stale shared test-database migration record
   (`20191106000001_event_legacy01.sql`); Ready-state clean CI remains required before merge.
@@ -336,6 +341,8 @@ func CompileJSONArtifact(ctx context.Context, bundle Bundle, limits CompileLimit
 append-only 记录：validate（可只打日志/指标）、publish、activate、rollback、grant、revoke、block。
 至少包含 actor UID、operation、template ID/version、hash、old/new revision、reason/change ticket、
 result、timestamp；不保存 token、完整 bundle 或业务 sample 内容。
+已编译完成但因 immutable hash 或 static source claim 冲突而拒绝的 publish 也必须写 audit-only
+记录；该事务不得修改 claim/artifact，audit 写入或提交失败时不得伪装成已审计的 409。
 
 ## Authorization and visibility
 

--- a/.octospec/tasks/cardtmpl-runtime-catalog/brief.md
+++ b/.octospec/tasks/cardtmpl-runtime-catalog/brief.md
@@ -21,7 +21,7 @@ source: self
 
 ## Implementation status (2026-07-28)
 
-- **PR-A is implemented in Draft PR #670; CI and review are pending.** It includes the shared strict
+- **PR-A is implemented in PR #670 and code review is approved.** It includes the shared strict
   compiler, canonical artifact identity, immutable version claim/artifact/audit store, startup static
   inventory reconciliation, super-admin validate/publish APIs, localized errors, body/rate limits, and
   bounded control-plane metrics.
@@ -29,7 +29,7 @@ source: self
   80.8% and `modules/card_template_catalog` coverage is 82.5%.
 - The database-independent Bot catalog race lane passes. The local Bot profile integration lane is blocked
   before assertions by a stale shared test-database migration record
-  (`20191106000001_event_legacy01.sql`); clean CI remains the authoritative integration result.
+  (`20191106000001_event_legacy01.sql`); Ready-state clean CI remains required before merge.
 - PR-A artifacts are always inactive. Runtime overlay, activate/rollback/block, grants, B1/B2, and any
   production dynamic send remain PR-B/PR-C work and are not advertised as available.
 

--- a/.octospec/tasks/cardtmpl-runtime-catalog/brief.md
+++ b/.octospec/tasks/cardtmpl-runtime-catalog/brief.md
@@ -17,16 +17,18 @@ source: self
 > human confirms the decisions in the final section before implementation.
 > D1–D9 were accepted on 2026-07-28 when implementation was authorized; delivery
 > remains split into PR-A/PR-B/PR-C, and the current branch starts with PR-A only.
-> PR-A implementation is tracked by Issue #669 and Draft PR #670.
+> PR-A implementation is tracked by Issue #669 and PR #670.
 
 ## Implementation status (2026-07-28)
 
-- **PR-A is implemented in PR #670 and code review is approved.** It includes the shared strict
-  compiler, canonical artifact identity, immutable version claim/artifact/audit store, startup static
-  inventory reconciliation, super-admin validate/publish APIs, localized errors, body/rate limits, and
-  bounded control-plane metrics.
+- **PR-A is implemented in PR #670.** It includes the shared strict compiler, canonical artifact
+  identity, immutable version claim/artifact/audit store, startup static inventory reconciliation,
+  super-admin validate/publish APIs, localized errors, body/rate limits, and bounded control-plane
+  metrics. Review hardening resolves local refs at every schema-bearing position, binds samples within
+  their declaring view, verifies static/runtime parity, makes static reconciliation contention-safe,
+  and distinguishes persistent catalog-integrity failures from retryable unavailability.
 - Focused unit, coverage, race, build, vet, lint, and i18n checks pass locally. `pkg/cardtmpl` coverage is
-  80.8% and `modules/card_template_catalog` coverage is 82.5%.
+  80.4% and `modules/card_template_catalog` coverage is 81.9%.
 - The database-independent Bot catalog race lane passes. The local Bot profile integration lane is blocked
   before assertions by a stale shared test-database migration record
   (`20191106000001_event_legacy01.sql`); Ready-state clean CI remains required before merge.

--- a/.octospec/tasks/cardtmpl-runtime-catalog/brief.md
+++ b/.octospec/tasks/cardtmpl-runtime-catalog/brief.md
@@ -17,7 +17,21 @@ source: self
 > human confirms the decisions in the final section before implementation.
 > D1–D9 were accepted on 2026-07-28 when implementation was authorized; delivery
 > remains split into PR-A/PR-B/PR-C, and the current branch starts with PR-A only.
-> PR-A implementation is tracked by Issue #669.
+> PR-A implementation is tracked by Issue #669 and Draft PR #670.
+
+## Implementation status (2026-07-28)
+
+- **PR-A is implemented in Draft PR #670; CI and review are pending.** It includes the shared strict
+  compiler, canonical artifact identity, immutable version claim/artifact/audit store, startup static
+  inventory reconciliation, super-admin validate/publish APIs, localized errors, body/rate limits, and
+  bounded control-plane metrics.
+- Focused unit, coverage, race, build, vet, lint, and i18n checks pass locally. `pkg/cardtmpl` coverage is
+  80.8% and `modules/card_template_catalog` coverage is 82.5%.
+- The database-independent Bot catalog race lane passes. The local Bot profile integration lane is blocked
+  before assertions by a stale shared test-database migration record
+  (`20191106000001_event_legacy01.sql`); clean CI remains the authoritative integration result.
+- PR-A artifacts are always inactive. Runtime overlay, activate/rollback/block, grants, B1/B2, and any
+  production dynamic send remain PR-B/PR-C work and are not advertised as available.
 
 ## Goal
 

--- a/.octospec/tasks/cardtmpl-runtime-catalog/brief.md
+++ b/.octospec/tasks/cardtmpl-runtime-catalog/brief.md
@@ -25,15 +25,22 @@ source: self
   identity, immutable version claim/artifact/audit store, startup static inventory reconciliation,
   super-admin validate/publish APIs, localized errors, body/rate limits, and bounded control-plane
   metrics. Review hardening resolves local refs at every schema-bearing position, binds samples within
-  their declaring view, verifies static/runtime parity, makes static reconciliation contention-safe,
-  and distinguishes persistent catalog-integrity failures from retryable unavailability.
+  their declaring view, verifies static/runtime parity, makes bounded-schema validation a
+  context-aware single traversal with a total visit budget, makes static reconciliation
+  contention-safe, and distinguishes persistent catalog-integrity failures from timeout,
+  cancellation, overload, and retryable database unavailability. Publish database work has an
+  independent 10-second deadline and retries whole transactions for MySQL 1205/1213 only.
 - Focused unit, coverage, race, build, vet, lint, and i18n checks pass locally. `pkg/cardtmpl` coverage is
-  80.4% and `modules/card_template_catalog` coverage is 81.9%.
+  80.4% and `modules/card_template_catalog` coverage is 81.6%.
 - The database-independent Bot catalog race lane passes. The local Bot profile integration lane is blocked
   before assertions by a stale shared test-database migration record
   (`20191106000001_event_legacy01.sql`); Ready-state clean CI remains required before merge.
 - PR-A artifacts are always inactive. Runtime overlay, activate/rollback/block, grants, B1/B2, and any
   production dynamic send remain PR-B/PR-C work and are not advertised as available.
+- Startup exact-key conflicts keep the required fail-close behavior. The reviewed PR-A recovery path
+  is binary rollback/correction plus a never-before-claimed built-in version; deleting or rewriting
+  immutable catalog rows and adding an ignore-conflict switch are forbidden. See the
+  [startup recovery runbook](../../../docs/card-template-runtime-catalog-runbook.md).
 
 ## Goal
 
@@ -601,6 +608,13 @@ token、完整 bundle、完整 schema/sample、卡片 data 或业务敏感文本
   `go build ./...`、`go vet` 和 `git diff --check` 通过。
 
 ## Rollout / rollback
+
+PR-A startup reconciliation recovery is defined in the
+[runtime catalog startup runbook](../../../docs/card-template-runtime-catalog-runbook.md). A future
+image that introduces a built-in exact key already claimed by a dynamic artifact must fail startup.
+Break glass by rolling back that image (or deploying a corrective image with a new version), not by
+bypassing reconciliation or mutating/deleting the permanent claim/artifact rows. Genuine persisted
+integrity damage requires a separate, snapshotted, two-person-reviewed SRE/DBA repair plan.
 
 1. PR-A 部署时 runtime activation 完全不可用；只在测试环境 validate/publish inactive bundle。
 2. PR-B 以 `OCTO_CARD_RUNTIME_CATALOG_CONTROL_ENABLED=false` 和

--- a/.octospec/tasks/cardtmpl-runtime-catalog/brief.md
+++ b/.octospec/tasks/cardtmpl-runtime-catalog/brief.md
@@ -1,0 +1,641 @@
+---
+type: Task
+title: "Task: cardtmpl-runtime-catalog"
+description: Add an audited, immutable, database-backed runtime catalog for JSON card templates, with super-admin validate/publish/activate/rollback controls and visibility-aware discovery, without weakening the frozen built-in Registry or producer authorization boundaries.
+tags: [card, cardtmpl, json-template, catalog, control-plane, database, wire-contract, trust-boundary, auth, acl, space, rate-limit, observability, testing]
+timestamp: 2026-07-27T23:36:03+08:00
+# --- octospec extension fields ---
+slug: cardtmpl-runtime-catalog
+upstream: "roadmap E3; PR-A tracked by #669; follows E1 JSON engine (#654), E1b Bot consumption (#659), and E1c successor (#667)"
+source: self
+---
+
+# Task: cardtmpl-runtime-catalog
+
+> One task = one `.octospec/tasks/<slug>/` directory. This brief is the design
+> and acceptance contract for roadmap E3. AI may draft it from current code; a
+> human confirms the decisions in the final section before implementation.
+> D1–D9 were accepted on 2026-07-28 when implementation was authorized; delivery
+> remains split into PR-A/PR-B/PR-C, and the current branch starts with PR-A only.
+> PR-A implementation is tracked by Issue #669.
+
+## Goal
+
+让已经通过平台治理的 **纯 JSON 卡片模板**无需重新构建、发布和部署 octo-server，
+即可完成：
+
+1. dry-run 校验；
+2. 发布不可变的 `template_id@version` 制品；
+3. 为新消息原子切换 active version；
+4. 回滚到任一仍可用的历史版本；
+5. 通过 B1/B2 发现或导出调用方有权看到的模板契约。
+
+E3 交付的是生产级 **模板控制面 + 运行时 catalog**，不是“上传任意 JSON 并立即发卡”。
+必须保持现有 L0 不变量：server-authoritative、`Registry.Render`/`renderCore` 统一验证、
+L1 版本冻结、producer 授权、Space/owner 隔离、历史消息固定原 `id@version`。
+
+本任务不直接打开任何生产 Bot/卡片开关。动态模板首次生产激活是独立 go/no-go，
+必须在本任务全部验收完成后执行。
+
+## Success definition
+
+以下四件事必须同时成立，才算 E3 闭环：
+
+- **制品闭环**：不可信 bundle 经过同一编译/校验管线，失败不会入库为 published；
+- **运行闭环**：任意副本可按显式 `id@version` 载入并渲染，active 切换不会冻结历史消息；
+- **治理闭环**：publish、activate、rollback、grant、emergency block 都有权限、CAS 和审计；
+- **生产闭环**：多副本、重启、DB 故障、回滚、缓存冷启动和权限隔离均有自动化或演练证据。
+
+## Background / current gap
+
+- E1 已提供 `Registry.RegisterJSON` 和受控 `${}` 模板引擎；JSON 模板会经过 schema、
+  aggregate constraints、模板 AST、sample self-check、interaction conformance 和
+  `cardmsg.Validate`。
+- 当前所有模板仍由 `//go:embed` 在 composition root 注册，随后 `Registry.Freeze()`；
+  新模板或新版本仍要改 Go 仓库、发 server 镜像。
+- `Registry.List()` 已存在，但 B1/B2 HTTP route 尚未实现；它当前只能列出二进制内置模板。
+- L2b `ext.*` owner、private visibility、owner 授权和独立 callback route 仍未开放。
+- Bot Registry catalog 是显式授权边界，不能把“存在于 runtime catalog”误当成
+  “任意 Bot 可以 discover/send/edit”。
+
+## Core model: publish != activate != authorize
+
+三个动作必须分开，且任何一步都不能隐式完成下一步：
+
+| 动作 | 含义 | 不产生的副作用 |
+| --- | --- | --- |
+| **publish** | 校验并持久化一个不可变 `id@version` | 不改变 active version，不向 producer 授权，不发消息 |
+| **activate** | 修改某 template ID 的新消息默认版本 | 不覆盖旧制品，不迁移历史消息，不自动授权 producer |
+| **grant** | 允许一个受信 principal discover/send/edit 某 template ID | 不改变 active version，不放宽 owner/callback/Space 校验 |
+
+历史 edit 使用 stored、server-authored `id@version`；active pointer 只影响新消息/default
+resolution。rollback 只是再次修改 active pointer，不删除任何制品。
+
+## Architecture decision
+
+### 1. Keep the built-in Registry frozen
+
+禁止给现有 `Registry` 增加运行期 `Register`/`Unfreeze`：
+
+- `go:embed` 内置模板继续在启动期 fail-close，并在 `Freeze()` 后不可变；
+- 新增 `RuntimeCatalog`（名字可实现时微调）作为静态 Registry 的 overlay；
+- 精确 `id@version` 在 static + dynamic 联集中必须唯一；动态制品不得覆盖同名内置版本；
+- 该唯一性不能只检查“当前进程看见的 Registry”：MySQL 必须持久化 static/dynamic
+  version claim。启用 RuntimeCatalog 的进程在进入 readiness 前，原子登记/核对本镜像的 static
+  inventory；若某 exact key 已被 dynamic 占用则启动失败，禁止滚动发布后不同副本解析出不同内容；
+- exact resolution 若仍检测到双源冲突，必须报 catalog integrity error，绝不能以“static 优先”
+  静默选一个；
+- active pointer 可以指向内置或动态版本，便于随时回滚到镜像内置的已知良好版本；
+- overlay 对两种 source 统一暴露 server-authored `CatalogMeta`（source/engine/visibility/export hash）。
+  static metadata 由 composition root 明确注入，未配置 visibility 时按 private fail-close，不能因为
+  旧 manifest 没有该字段就默认公开；
+- 现有调用方可逐步从 `*Registry` 迁到窄接口，不能一次大改所有卡片链路。
+
+建议运行结构：
+
+```text
+                       +---------------- Built-in Registry (frozen)
+caller -> RuntimeCatalog.Resolve/Render
+                       +---------------- Dynamic Store (MySQL)
+                                           |
+                                           +-> bounded compiled-artifact cache
+```
+
+运行时消费者不能继续绑定具体 `*Registry`。应抽只读窄接口（名字可微调），至少覆盖 exact/default
+render、metadata、`ActionView` 和 list/export；built-in `Registry` 与 `RuntimeCatalog` 都实现它。
+`Register/RegisterJSON/SetDefault/Freeze` 仍只存在于 built-in Registry，不进入运行时接口。以下
+load-bearing 消费点必须迁移，不能只改 Bot send：
+
+- `modules/bot_api` template send/edit/capability；
+- `pkg/cardtmpl.CardUpdater` 及 notify finalizer/mutate path；
+- `modules/message.resolveRegistryCardContext` 的 `ActionView` + `ActionContract` 查询；
+- B1/B2 discovery/export。
+
+否则 dynamic interactive card 会出现“能发送，但 Action.Submit 或后续 edit 找不到模板”的半闭环。
+
+授权不能继续靠每个 handler 手工“先查 grant、再调无身份 `Render`”。运行时接口必须区分
+`new_send|historical_edit|action_context|discover|export` purpose，并接收由鉴权层构造的 typed principal
+（kind/id/authoritative Space）；不得从 caller JSON、query 或任意字符串 context 取 principal。
+底层无授权 exact resolver 仅供 package 内 compiler/control/readiness 使用，不对业务模块导出。
+static compatibility path 仍由现有显式 producer policy 授权，dynamic path 则在同一次 runtime
+resolution 中原子检查 grant/active/block，避免 TOCTOU 或漏查绕过。
+
+### 2. MySQL is authoritative; caches hold immutable compiled artifacts only
+
+- MySQL 是 version claim、artifact bytes、active pointer、grants、block 状态和 audit 的唯一真源；
+- local cache 只缓存按 `engine_contract + content_sha256` 编译完成的不可变 Template，不拥有
+  active/grant/block 真相；
+- v1 的 new-send/default resolution 和 capability/discovery 权限判断读权威 DB 状态，
+  不用仅靠 Redis pub/sub 或进程 TTL 猜 active pointer；
+- dynamic exact-version render/edit 每次也必须从权威 DB 读取最小 artifact/block 元数据，再复用
+  compiled cache；否则紧急 block 会被热 cache 绕过；
+- active/grant/block 等授权读必须走具备 read-after-write 的主库/强一致连接，不得走可能延迟的
+  MySQL replica；new-send 可用一次 join 查询合并 active + artifact + grant 检查；
+- cache miss 用 `singleflight` 合并同一 `id@version` 的并发编译；缓存必须有 entry/byte 双上限；
+- 任意副本在 publish commit 后都能从 MySQL lazy-load、验 hash、编译并服务显式版本，
+  不依赖“恰好收到一次缓存失效消息”；
+- Redis 事件可作为后续预热优化，但不得成为正确性或重启恢复的唯一机制。
+
+这个选择有意接受 dynamic new-send/edit 多一次小型 catalog DB 查询，换取 v1 多副本一致性和
+emergency block 可证明。
+若未来性能数据证明需要 active/grant cache，必须引入单调 catalog revision、最大陈旧窗口和
+跨副本回归，不能在本任务中提前做无法证明的最终一致缓存。
+
+### 3. JSON-only, frozen engine contract
+
+E3 v1 的发布 envelope 只接受 `engine = "octo-json-template/v1"`：
+
+- 不接受 Go、JavaScript、WASM、脚本表达式、远程 include 或任意代码；
+- 不从 URL、对象存储路径、Git ref 或本地绝对路径加载模板内容；
+- bundle 中的 JSON Schema `$ref` 只能指向 bundle 内明确允许的资源；禁止网络/file `$ref`；
+- 模板语法仍是 E1 已冻结的 ACT 子集；扩语法先发 server，再考虑发布依赖新 engine contract
+  的制品；
+- 混合 server 版本 rollout 期间，只允许激活所有副本都已支持的 engine contract。
+
+## Bundle contract
+
+控制面接收结构化 JSON bundle，不接收 zip/tar，避免 path traversal、zip bomb、重复 entry
+和解压后尺寸不确定性：
+
+```jsonc
+{
+  "catalog": {
+    "engine": "octo-json-template/v1",
+    "visibility": "private"
+  },
+  "manifest": { "...": "manifest.json content" },
+  "schema": { "...": "contract/data.schema.json content" },
+  "templates": {
+    "active": { "...": "templates/active.template.json content" }
+  },
+  "reports": {
+    "active": { "...": "reports/active.interaction.json content" }
+  },
+  "samples": {
+    "reasoning": { "...": "samples/reasoning.json content" }
+  },
+  "goldens": {
+    "reasoning": { "...": "goldens/reasoning.card.json content" }
+  }
+}
+```
+
+`catalog.engine` / `catalog.visibility` 是运行时发布治理元数据，不写回现有 handoff
+`manifest.json`。这样 `0.1.0` 等已冻结 manifest 无需原地改版，static fixture 也可套同一
+envelope 进入 compiler 做 parity test。owner、protocol、version、views 等模板契约仍以
+manifest 为唯一真源，禁止在 envelope 重复一份可漂移字段。
+
+static JSON template 使用 composition-root `CatalogMeta` 补齐同样的 engine/visibility，并对其可导出
+manifest/schema/reports/samples 计算 canonical export hash；不修改 embed bytes。B2 的 ETag 对 dynamic
+使用 `content_sha256`，对 static 使用该 export hash。
+
+v1 proposed hard limits（实现前由 D3 最终确认）：
+
+| 项目 | 上限 | 理由 |
+| --- | ---: | --- |
+| HTTP request body | 2 MiB | 当前最大 handoff 约 129 KiB，保留充足余量，同时限制解析前内存 |
+| canonical bundle bytes | 2 MiB | 入库、hash、审计和 cache 可控 |
+| logical documents | 128 | 防病理 map/file fan-out |
+| single document | 512 KiB | 与现有 card payload 量级一致 |
+| views / states | 16 / 64 | 平台卡状态机有界，避免 capability/validation 爆炸 |
+| samples / goldens | 64 / 64 | 每个 state 至少一份 sample，仍保持 CI/发布耗时可控 |
+
+规则：
+
+- server 对完整 catalog descriptor + documents 做版本化、确定性的 canonical JSON（建议固定
+  RFC 8785/JCS 兼容规则）再计算 SHA-256；hash 不信任调用方传值。canonicalization 规则属于
+  engine contract，不能在同一 contract 下随 server 版本变化；
+- decoder 必须拒绝 duplicate object key、trailing JSON token、非法 UTF-8 和非有限/越界数字，
+  不能沿用 `encoding/json` 的 last-key-wins 作为签名/hash 语义；
+- document key 只能使用有界安全 token；manifest 明示或按 view/key 约定推导的
+  schema/template/report/sample/golden 必须全部存在且只能指向 bundle 内文档，unknown/unreferenced
+  document fail-close；
+- 同一 `id@version + same hash` publish 是幂等成功；同一 `id@version + different hash`
+  永久冲突，不允许“管理员覆盖”；
+- catalog descriptor 必须显式包含 engine、visibility；manifest 必须显式包含 id、owner、
+  protocol、version、views；
+- `visibility` v1 仅允许 `public|private`；unknown value fail-close；public 仅代表可发现，
+  不自动产生 send/edit 权限；
+- root schema 必须 `type=object`、`additionalProperties=false`；自由 string/array 必须由
+  `maxLength`/`maxItems` 或枚举等价有界，不能只依赖最终 payload cap；
+- 每个 manifest state 至少一份 sample；每份 sample 必须 schema-valid、可展开、可通过
+  `cardmsg.Validate`；golden 若存在必须 canonical 相等；
+- v2 view 必须有 interaction report；实际 action/input/report、owner/action_type 全量一致；
+- aggregate constraints、node/depth/expanded-node/payload budgets 与 E1/E1c 共用实现；
+- samples/goldens 必须是可导出的合成数据，不得包含 token、真实用户数据或生产业务秘密；
+- 错误响应只暴露安全的 validation category/document key，不回显 bundle、sample、schema
+  内容或完整 caller data。
+
+## Validation/compiler refactor
+
+当前 loaders 绑定 `embed.FS` 且用 panic 表达启动失败。E3 不能通过 `recover` 把任意 panic
+当普通校验错误；应先抽一个共享、显式返回 error 的 compiler：
+
+```go
+type CompiledArtifact struct {
+    Template Template
+    Meta     TemplateMeta
+    Hash     string
+    Bundle   CanonicalBundle
+}
+
+func CompileJSONArtifact(ctx context.Context, bundle Bundle, limits CompileLimits) (*CompiledArtifact, error)
+```
+
+- static `RegisterJSON` 调 compiler，遇 error 继续 panic，保留 boot fail-close；
+- runtime validate/publish 调同一 compiler，返回 typed validation error；
+- compiler 不访问 DB、网络或进程环境；有 context deadline 和显式资源预算；
+- validate/publish/runtime lazy-load 的所有 compile 入口共享进程级 bounded semaphore；队列满或
+  deadline 到期时快速失败，避免 `SharedUIDRateLimiter` 的 burst 或冷 cache 同时展开大量 bundle；
+- static embed fixture 与同内容 runtime bundle 必须生成 canonical 相同的 Meta/render 结果；
+- `renderCore` 仍是 metadata 注入、profile、URL、白名单和最终 `cardmsg.Validate` 的唯一真源。
+
+## Persistence model
+
+建议新增独立 module `modules/card_template_catalog/`（最终目录名可按 maintainer 习惯微调），
+包含以下表：
+
+所有 identity 字段使用明确长度、大小写敏感 collation 和 canonical version 格式；不依赖数据库
+默认的大小写折叠。所有状态写与对应成功 audit 必须在同一事务提交，audit 写失败则状态不变。
+
+### `card_template_version_claim`
+
+跨 static/dynamic 的 exact-key 占位表：
+
+- `(template_id, version)` primary key，`source=static|dynamic`；
+- dynamic publish 必须先原子取得 dynamic claim；任一历史 static claim 永久禁止被 dynamic 复用；
+- RuntimeCatalog 启动时将 `Registry.List()` inventory 登记为 static claim；撞到 dynamic claim 时
+  readiness fail-close，并输出不含 bundle 的 integrity 告警；
+- claim 不提供 DELETE/改 source API。即使某旧镜像暂时不再注册该 static version，也不能把
+  exact key 回收给另一份内容。
+
+### `card_template_artifact`
+
+不可变内容与身份：
+
+- `(template_id, version)` primary/unique key，并 FK/等价事务约束到 dynamic version claim；
+- owner、visibility、engine_contract、protocol、contract_version；
+- canonical_bundle（MEDIUMBLOB/等价有界字段）和 `content_sha256 CHAR(64)`；
+- created_by、created_at；
+- operational block 是单向状态：首次 `blocked_at/by/reason` 写入后不可 unblock/改写；v1 如需恢复，
+  发布新 version。canonical bytes/hash 永不更新；
+- 对已 blocked artifact 重放 same-hash publish 只返回“已存在且 blocked”，不得借幂等 publish 清除状态；
+- 不提供 DELETE/UPDATE bundle API。
+
+### `card_template_activation`
+
+- `template_id` primary key；
+- nullable `active_version` + 显式 `status=active|disabled`；active source 通过 version claim join 派生，
+  不冗余存两份可漂移字段；active version 以 FK/等价事务约束指向同 template ID 的 claim；
+- 单调 `revision BIGINT`；
+- updated_by、updated_at、reason/change_ticket；
+- v1 只做 global active pointer，不做 per-Space 不同 active version；Space 只参与 grant/visibility；
+- activation row **不存在**时可沿用 built-in Registry 的 static default；row 显式 disabled 时必须
+  返回 unavailable，不能悄悄 fallback 到 static default；dynamic template 不存在 activation row
+  时不可 new-send；
+- activate/rollback 使用 `WHERE revision = expected_revision` CAS，冲突返回语义 409。
+
+### `card_template_grant`
+
+- `(template_id, principal_type, principal_id, scope_space_id)` unique；所有 key 列 non-null，global
+  scope 使用唯一 canonical sentinel，避免 MySQL nullable unique key 允许多条 `NULL`；
+- v1 principal type 至少支持 `bot`、`internal_producer`、`space`；
+- 权限只允许有界集合 `discover|send|edit`；不得存任意字符串权限。`send` 只允许当前 active
+  version，`edit` 只允许 target 中 server-authored provenance 指向的 same version；
+- `space` principal 只授予 discover；send/edit 只能授予具备可认证 producer identity 的
+  `bot|internal_producer`，不能把“Space 成员”偷换成发卡主体；
+- active 切换不得自动撤销旧版本 edit；但撤销 principal 的 `edit` 权限应立即阻止后续 edit。
+  此外 sender/owner/Space/lifecycle/CAS 仍需全部通过；
+- grant 写入/撤销必须审计，且不能替代既有 Bot ownership 或 callback RouteSpec。
+
+### `card_template_audit`
+
+append-only 记录：validate（可只打日志/指标）、publish、activate、rollback、grant、revoke、block。
+至少包含 actor UID、operation、template ID/version、hash、old/new revision、reason/change ticket、
+result、timestamp；不保存 token、完整 bundle 或业务 sample 内容。
+
+## Authorization and visibility
+
+### Control plane
+
+v1 控制面只开放给现有 `superAdmin`：
+
+- route group：`/v1/manager/card-templates`；
+- `AuthMiddleware` → `SharedUIDRateLimiter` → handler 内 `CheckLoginRoleIsSuperAdmin()`；
+- 这是显式的全局 superAdmin 控制面，不以请求当前 Space 作为授权范围，因此不套普通业务
+  Space middleware；涉及的 target Space 必须按 body/path scope 单独校验存在性并写审计；
+- body cap 必须在 `BindJSON` 前安装；
+- 不接受 Bot token、internal notify token、匿名请求或“manifest.owner 自声明即授权”；
+- actor UID 从服务端认证上下文取，不接受 body 中的 created_by/approved_by；
+- publish/activate 还要通过服务端 owner policy：v1 只允许已批准的 L2a owner；`ext.*` 和未知
+  owner 在 D1/D2 gate 打开前 fail-close，display-only template 也不例外；
+- 所有错误走 `httperr.ResponseErrorL` + `pkg/errcode` localized envelope；若要使用真实 HTTP
+  status，须另行获得 maintainer 对新端点偏离 D14 的明确确认。
+
+这一步实现“无需 server 发版”，但不是最终 L2b 自助发布。owner delegated publisher、双人审批、
+external owner 与独立 callback secret 必须在 D2/L2b gate 满足后再开放，不能为了 E3 降低门槛。
+
+### Read side (B1/B2)
+
+- `GET /v1/message/card/templates`：Auth + UID limiter + Space middleware；分页、有上限；
+- `GET /v1/message/card/templates/{id}@{version}`：同一鉴权链；
+- public：返回给有正常卡片能力的已认证调用方；
+- private：仅 superAdmin 或命中当前 Space/principal grant 的调用方可见；
+- B1 对普通调用方只列 visible + unblocked 的 exact versions，并明确 `active_for_new_send`；
+  “能发现”不等于“能发送”。blocked 制品和控制面状态只在 manager API 可见；
+- unauthorized 与 nonexistent 对普通调用方使用同一 not-found 语义，避免 template 枚举 oracle；
+- B2 返回 manifest/schema/reports/samples，不返回控制面 audit、grant、内部 DB id；
+- B2 response 带 source-specific canonical export hash ETag（dynamic 为 `content_sha256`）并实现
+  `If-None-Match`；private 响应使用
+  `Cache-Control: private`，不得进入 public shared cache；
+- Bot 模板发现仍以 `/v1/bot/card/profile` 的 bot-scoped catalog 为权威，不让 Bot 直接调用
+  B1/B2 绕过 grant。
+
+## Runtime resolution and producer authorization
+
+### Exact version
+
+`Resolve(id, version)` 通过 version claim 确定唯一 source；static/dynamic 任一路径都返回同一
+Template/Meta 抽象并走 `renderCore`。不得用 lookup 顺序掩盖双源冲突。dynamic 路径在命中 compiled
+cache 前仍要读取 DB block 元数据。static exact key 则使用已在 readiness 阶段核对过的 frozen
+in-memory inventory，运行中不为每次 render 查询 DB。历史消息必须始终显式使用 stored version，
+不重新解析 active。blocked 是唯一安全例外，会拒绝继续 render/edit，但已存储的最后成功卡片
+仍可正常展示。
+
+### Default/new send
+
+只有新消息/default resolution 才读取 `card_template_activation`。activation row 不存在与显式
+disabled 是两个不同状态，后者不可 fallback。新 send 必须同时满足：
+
+1. effective active resolution（activation row，或仅 static 的 legacy default）指向该版本；
+2. exact source 可解析；若为 dynamic，则 artifact 存在、hash 正确、未 blocked、engine 支持；
+3. static template 命中既有显式 producer policy，或 dynamic template 命中 principal 的 `send` grant；
+4. 既有 producer-specific ownership、Space、channel、feature gate 全部通过。
+
+catalog 存在本身绝不是发送授权。现有 Bot E1b 路径迁移时：
+
+- 当前代码内 `AdvertisedSend/EditCompatible` 继续约束 static templates；dynamic templates 使用
+  DB grant，最终 capability 是两者安全合并，不把 `Registry.List()` 全量授权给 Bot。对已有
+  activation row 的 template ID，new-send 只广告 effective active version：dynamic active 不得
+  同时残留 static `AdvertisedSend`，rollback 到 static 后再按 static policy 恢复；
+- `/v1/bot/card/profile` 仍走 bot-token auth，不套用户 Space middleware；runtime 必须从既有 Bot
+  identity/ownership 取 authoritative bot ID + Space，不能信 query/body 自报 principal。由于它从
+  部署常量变成 per-Bot DB read，route 应升级为 `authBot → botActorUID → SharedUIDRateLimiter`；
+- `templating.templates` 的 dynamic 部分只从该 Bot 的 `send` grant + active unblocked version 生成；
+  historical stored version 的 edit 还要求 `edit` grant，保持 same-version，不能用 active pointer
+  跨版本改写；
+- profile/capability 与 send 都读同一权威 revision。active 在二者之间变化时，旧显式 ref 安全失败，
+  producer 刷新 capability 后重试，不允许 server 偷换版本。
+- RuntimeCatalog 的 not-active/not-granted/blocked/internal typed errors 必须映射到既有 Bot API
+  card-invalid/catalog-unavailable error facade，不向 producer 暴露 grant、owner 或 artifact 存在性。
+
+### Interactive templates
+
+interactive artifact publish 可以通过静态契约校验，但 activate 前必须确认其
+`(owner, action_type)` 对应的 `cardactiondispatch.RouteSpec` 已存在且 owner 策略允许。
+E3 不动态创建 callback URL、secret 或 finalizer。route 缺失时 activation fail-close；catalog-enabled
+进程启动时也要复核所有 active artifacts 的 engine/owner policy，以及 interactive artifact 的
+RouteSpec，避免未来 binary 删除能力或 route 后仍 ready。
+Action ingress 必须从 effective stored frame 的 server-authored `id@version` 调 RuntimeCatalog
+`ActionView/Meta`，再执行现有 owner/route/Space 校验；不得信点击请求自报 template identity。
+
+## Control APIs
+
+建议 v1 API（字段可在实现 brief refinement 时机械微调，语义不得合并）：
+
+| Method/path | 语义 |
+| --- | --- |
+| `GET /v1/manager/card-templates` | 分页列出全部 source/visibility/active/block 摘要，含普通 B1 隐藏项 |
+| `GET /v1/manager/card-templates/{id}` | 返回 versions、source、block、active revision 和 grants，供 CAS 操作前读取 |
+| `GET /v1/manager/card-templates/{id}/audit` | 分页读取该 ID 的脱敏 append-only 操作记录 |
+| `POST /v1/manager/card-templates/validate` | dry-run compile/conformance，返回 server-computed hash 和安全摘要，不持久化 |
+| `POST /v1/manager/card-templates/publish` | 重跑完整校验并插入 immutable artifact；exact key + server hash 天然幂等 |
+| `PUT /v1/manager/card-templates/{id}/active` | CAS 激活指定 published/unblocked version |
+| `POST /v1/manager/card-templates/{id}/rollback` | CAS 切回明确 target version，单独 audit operation |
+| `POST /v1/manager/card-templates/{id}@{version}/block` | 单向阻断 dynamic artifact；若当前 active，同事务切到明确 fallback，或将该 ID 置 disabled |
+| `PUT /v1/manager/card-templates/{id}/grants/{principal_type}/{principal_id}` | 创建/收敛 discover/send/edit grant；可选 Space scope |
+| `DELETE /v1/manager/card-templates/{id}/grants/{principal_type}/{principal_id}` | 撤销 grant，不删除 artifact/历史消息 |
+
+写接口要求 `reason`；activate/rollback/block 额外要求 `expected_revision`，建议要求
+`change_ticket`。v1 不增加通用 Idempotency-Key store：publish 由 immutable exact key + hash 天然
+幂等，pointer 写由 revision CAS 防并发覆盖。以下重试/冲突语义必须测试：
+
+- same id@version + same server hash → publish success/idempotent；
+- same id@version + different hash → immutable conflict；
+- stale expected revision → conflict，不能 last-write-wins。
+
+block 是安全操作，不能因为“没有已知良好 rollback target”而被拒绝；此时必须原子 block +
+disable active，让新 send 明确不可用。v1 不提供 unblock；误封只能发布新 version 并重新激活。
+
+## Failure semantics
+
+- validation error：400，零 claim/artifact/active/grant 状态变化；允许追加不含 bundle/data 的
+  失败审计摘要；
+- immutable/CAS conflict：语义 409，经 D14 error envelope 返回；
+- unauthorized/not visible：generic forbidden/not-found，不暴露 owner、hash、version 是否存在；
+- DB/cache/compile internal failure：5xx internal code，服务端日志记录 cause；响应不回显 bundle；
+- dynamic DB unavailable：dynamic new send、activation、B1/B2 fail closed；不能静默换成另一个版本；
+- historical dynamic edit 失败时保留最后成功帧并返回可重试错误，不能 raw overwrite；
+- 显式 static exact-version render 不依赖 dynamic tables；需要判断 activation/disabled 的 default
+  resolution 在 DB 不可用时仍须 fail closed，不能把“查询失败”当成“activation row 不存在”；
+- blocked version 不允许 new send/render/edit；已存储的旧卡片 payload 仍可展示。所有后续 edit
+  拒绝并告警，这是安全 kill switch，不能被 local cache 绕过。
+
+## Multi-replica consistency
+
+必须用自动化测试证明以下序列：
+
+1. replica A/B 启动时登记相同 static inventory，并复核 active engine/owner/RouteSpec；claim 冲突或
+   active contract 不可服务的 replica 不 ready；
+2. replica A publish；replica B 无本地 cache；
+3. A activate revision N；
+4. B 从强一致 DB 读取 active/grant/block，lazy-load artifact、验 hash、compile 后成功 new send/render；
+5. 已有旧卡仍按旧 version + edit grant edit；
+6. A rollback 到旧 version revision N+1；
+7. B 的新 send 立即按 DB 权威指针选择旧版，动态新版 cache 即使仍在也不能被默认选择；
+8. A block 当前 active；有 fallback 时原子切换，无 fallback 时原子 disabled；B 的热 cache 不能继续 render；
+9. 进程重启、cache 全空后可从 DB 恢复同一行为。
+
+v1 不以“所有副本收到 pub/sub ACK”作为 correctness 条件。若后续引入 active cache，必须另起
+L0 brief，定义 revision fence、最大陈旧窗口和 capability→send 不错配证明。
+
+## Observability and audit
+
+新增低基数指标（确切名字实现时统一）：
+
+- `dmwork_card_catalog_operation_total{operation,result}`；
+- `dmwork_card_catalog_resolve_total{source=static|dynamic,result}`；
+- `dmwork_card_catalog_compile_seconds{result}`；
+- `dmwork_card_catalog_cache_total{result=hit|miss|evict}`；
+- `dmwork_card_catalog_db_total{operation,result}`。
+
+日志/审计可带 template id/version、hash、revision、actor UID、principal ID、Space ID；不得带
+token、完整 bundle、完整 schema/sample、卡片 data 或业务敏感文本。至少对以下情况告警：
+
+- active artifact 无法 compile/hash mismatch；
+- activation/rollback/block 失败；
+- dynamic DB 持续不可用；
+- CAS conflict 异常升高；
+- blocked version 仍收到 send/edit；
+- static/dynamic claim 冲突或启动 inventory reconciliation 失败；
+- cache 编译耗时或内存超过预算。
+
+## Implementation slices
+
+本任务不应以一个超大 PR 落地，建议三个可独立评审、在首次 dynamic send 前可回滚的切片；
+首次 dynamic send 后受下文 binary compatibility floor 约束：
+
+### PR-A — compiler + immutable store + validate/publish (no runtime activation)
+
+- 抽共享 error-returning compiler，static RegisterJSON 行为/输出零回归；
+- schema bytes 只经一个 loader/parse 结果进入 JSON Schema compile 与 `x-octo-constraints`
+  解析，禁止 `contract/data.schema.json` 路径和读取逻辑双写；
+- Go-authored `Registry.Register` 若发现仅 JSON compiler 能执行的 `x-octo-constraints`，必须
+  注册期 panic/fail-close，禁止 silent no-op；
+- 用 table-driven fixtures 覆盖全部约束误配置分支：unknown key、空白/未 trim parent/child、
+  non-positive limit、duplicate/empty list、parent/child missing 或类型错误、invalid sub-schema；
+- module/migrations、version claim + static inventory reconciliation、store/audit；
+- superAdmin validate/publish endpoints、body cap、rate limit、i18n errors；
+- artifact 只能 inactive，生产 render 路径不读动态表。
+
+### PR-B — runtime overlay + activate/rollback/block
+
+- RuntimeCatalog exact/default resolution；
+- 抽 runtime Catalog 窄接口并迁移 Bot send/edit、CardUpdater、message action-context 等 load-bearing
+  消费点；built-in registration API 保持隔离；
+- 双源 exact-key 冲突在 runtime resolution 继续 fail-close；
+- bounded compiled cache + singleflight；
+- CAS active pointer、rollback、emergency block；
+- static/dynamic parity、多副本、restart/DB failure tests；
+- control/new-send kill switches，历史 exact-version resolution 不随意关闭。
+
+### PR-C — grants + B1/B2 + one non-production pilot
+
+- principal/Space discover/send/edit grants；
+- visibility-aware B1/B2、pagination/ETag/anti-enumeration；
+- Bot static policy + dynamic grants 的安全合并；一个现有 producer 通过显式 grant 消费 dynamic
+  active version；
+- `AdvertisedSend` 必须按 template ID 强制最多一个 version，不能只按完整 `id@version` 去重；
+  duplicate ID 在 capability 构造期 fail-close 并有回归测试；
+- 非生产 publish→activate→send→Action.Submit(existing RouteSpec)→same-version edit→rollback E2E；
+- 生产首次激活仍由单独 rollout 工单批准。
+
+任何切片都不能把未实现的下一阶段伪装成已支持：PR-A 合并后仍不能动态发卡；PR-B 合并后
+未授权 principal 仍不能发现/发送；PR-C E2E 通过也不等于开放 L2b。
+
+## Acceptance
+
+### Compiler / trust boundary
+
+- static embed 与同内容 runtime bundle 的 Meta、interaction、sample、render canonical 相等；
+- malformed/duplicate-key/trailing-token JSON、schema/template/report/sample/golden 全部 typed error，
+  不 panic 服务进程；
+- static `RegisterJSON` 与 runtime compiler 共用一次 schema load/parse；Go-authored Register 遇到
+  `x-octo-constraints` 必须拒绝，不能静默忽略；
+- aggregate constraint 的 unknown/empty/untrimmed/non-positive/duplicate/missing/wrong-type/invalid
+  sub-schema 误配置分支全部由 table-driven RED→GREEN fixtures 锁定；
+- remote/file `$ref`、unknown engine/directive、unbounded schema、超 body/doc/count/node/depth/
+  expansion budgets 均 fail closed；
+- Action.Submit、Input、inlineAction/Table 等完整遍历面与现有 conformance 一致；
+- fuzz/property tests 覆盖深嵌套、重复 key、astral Unicode、巨大数字、恶意 URL/markdown。
+
+### Immutability / state transitions
+
+- same hash publish 幂等；different hash same id@version 永久冲突；
+- static/dynamic version claim 全局唯一；未来镜像若引入已被 dynamic 占用的 exact key，readiness
+  必须失败，不能产生按副本漂移的解析结果；
+- publish 不改变 active/grants；grant 不改变 active；activate 不创建 grant；
+- publish/activate/rollback/grant/revoke/block 的成功 audit 与状态在同一事务；revision CAS 并发写
+  只有一个成功；
+- 不存在 artifact/claim hard-delete 路径；未 blocked 历史版本可显式 lookup/render；
+- block 是单向的；active version 要么与 fallback 切换同事务成功，要么与 disabled 同事务成功，
+  不能因缺少 fallback 留下一个仍可发送的已知危险版本。
+
+### Authorization / isolation
+
+- control endpoints 非 superAdmin 全拒，且不信 body actor/owner；
+- B1/B2 public/private、Space/principal grant 矩阵有 table-driven tests；
+- unauthorized 与 nonexistent 不形成枚举 oracle；
+- Bot A 的 grant/cache/capability 不能被同 apiUrl 的 Bot B 复用；
+- revoke edit 立即阻断后续 edit；仅 active 切换不影响仍有 edit grant 的历史 same-version edit；
+- grant 不能绕过 Bot owner、Space、callback RouteSpec、card feature gate。
+
+### Runtime / resilience
+
+- 已完成启动期 claim reconciliation 的进程，其显式 static exact-version 路径在 dynamic DB outage
+  时仍成功；dynamic/default-resolution 路径 fail closed 且可观测；
+- 两副本冷/热 cache、publish/activate/rollback、restart recovery 测试通过；
+- dynamic exact render/edit 在热 cache 下仍读取权威 block 状态；强一致授权查询不可误接只读副本；
+- exact historical edit 不因 active 切换改变版本；raw/template mode XOR 继续成立；
+- dynamic interactive action 只能用 stored provenance 解析 ActionView/ActionContract 并进入已有
+  RouteSpec；伪造 template ref、缺 route、blocked version 全部在 enqueue/callback 前拒绝；
+- cache 有 entry/byte 双上限、singleflight、race tests，无无界 goroutine/keyspace；
+- activation 后 capability/discovery 与 new send 读取同一权威状态，不出现“广告新版、另一副本只认旧版”。
+
+### HTTP / operations
+
+- manager routes 为 Auth → SharedUIDRateLimiter → superAdmin guard；B1/B2 含 Auth/Space/UID limiter；
+- dynamic Bot profile 为 authBot → botActorUID → SharedUIDRateLimiter，测试重置持久 Redis UID bucket；
+- 所有错误使用 localized envelope；5xx `Internal=true` 且先 log cause；
+- body cap 在 JSON decode 前生效；分页和导出响应有硬上限；
+- compile 并发/队列有硬上限；多副本 publish 重试保持 same-hash success、different-hash conflict，
+  pointer 写保持 CAS；
+- metrics label 无 bundle hash、UID、Space 或任意高基数业务值；
+- `make i18n-extract-check`、`make i18n-lint`、source guards、focused/race/integration tests、
+  `go build ./...`、`go vet` 和 `git diff --check` 通过。
+
+## Rollout / rollback
+
+1. PR-A 部署时 runtime activation 完全不可用；只在测试环境 validate/publish inactive bundle。
+2. PR-B 以 `OCTO_CARD_RUNTIME_CATALOG_CONTROL_ENABLED=false` 和
+   `OCTO_CARD_RUNTIME_CATALOG_NEW_SEND_ENABLED=false` 部署；验证 static 路径零回归。
+3. 所有 serving replica 均升级到支持 RuntimeCatalog 且完成 static claim reconciliation 后，才允许
+   激活 dynamic version；混合新旧 binary 时 control/new-send 必须保持关闭。
+4. 在测试环境发布一个 bundle，分别从两个 server replica 冷 cache render，重启后重验。
+5. PR-C 建 grant 并执行 publish→activate→new send→Action.Submit(existing RouteSpec)→same-version
+   edit→rollback→旧版 new send；
+   同时验证 private B1/B2 隔离。
+6. 首次生产 rollout 只允许既有 L2a owner、已有 RouteSpec、已知 producer；先 publish inactive，
+   再 shadow/canonical diff，最后小流量 activate。
+7. 普通回滚：CAS 将 active pointer 切回上一已知良好版本；不要删新版 artifact/cache。
+8. 安全事件：同事务 block + fallback；无 fallback 时 block + disabled。告警所有仍引用 blocked
+   version 的请求，已有消息保留最后成功 payload。
+9. 禁止用“关闭 runtime catalog 读取”作为常规回滚，因为历史 dynamic 消息仍需要 exact-version
+   render/edit。kill switch 应先关闭 control/new send，保留安全的历史读取；只有安全事件才 block version。
+10. **兼容性底线：**首条 dynamic 卡片一旦成功发送，E3 exact-version reader 就成为 server binary
+    的最低兼容版本。不得直接回滚到 pre-E3 binary；如需回滚实现，只能部署仍保留 dynamic historical
+    read/edit 的修复版。首次生产激活前必须完成 catalog 表备份/恢复演练并确认 RPO/RTO。
+
+## Out of scope
+
+- 任意 Go/plugin/script/WASM 上传或运行；远程模板 URL/include；服务端主动 fetch；
+- 可视化模板编辑器、draft 协作 UI、Marketplace；
+- 匿名、普通用户、Bot 自助 publish/activate；
+- 动态创建 callback route、callback secret、finalizer 或 owner namespace；
+- 在 D1/D2 gate 未满足前开放 `ext.*` L2b producer；
+- 自动迁移历史消息到新版本、跨版本 edit、hard delete/GC 已发布版本；
+- v1 unblock 已 blocked version；误封后只能发布新 version；
+- per-Space 不同 active version（v1 只有 global active；Space 仅做 visibility/grant）；
+- 修改 `template-ref/v1` wire；修改 E1d/E1e stop/retry 业务语义；
+- E2 internal notify envelope（可在 E3 RuntimeCatalog 就绪后独立接入）；
+- active/grant 的最终一致本地缓存或 Redis-only source of truth。
+
+## Confirmed implementation decisions (2026-07-28)
+
+- **D1 — v1 publisher：**建议仅 `superAdmin`；owner delegated publishing 等 D2/L2b，不在 E3 v1。
+- **D2 — activation scope：**建议 v1 只有 global active pointer；Space 只用于 grant/visibility，
+  不做同一 ID 每 Space 不同 active version。
+- **D3 — bundle limits：**确认 2 MiB body/bundle、128 documents、512 KiB/document、
+  16 views、64 states/samples/goldens。
+- **D4 — consistency：**建议 v1 active/grant 读 MySQL 权威状态，local cache 只缓存 immutable
+  compiled artifact；接受每次 dynamic new send/edit 一次 catalog DB check，后续按指标优化。
+- **D5 — built-in overlap：**允许 active pointer 指向 static 版本，但 dynamic publish 禁止覆盖
+  任一 static exact `id@version`；用持久化 version claim + startup readiness reconciliation 防止
+  “dynamic 先发布、未来 binary 后引入同 key”的反向冲突。
+- **D6 — interactive activation：**必须已有 RouteSpec；E3 不动态创建 route/secret/finalizer。
+- **D7 — first pilot：**建议非生产使用一个现有 L2a owner + 已有 producer/route；生产首张动态卡
+  另起 rollout 工单，不直接拿 E3 merge 当 go-live。
+- **D8 — four-eyes：**v1 要求 reason/change ticket + append-only audit；生产 SOP 要求双人复核，
+  v1 暂不在应用内硬编码“发布人与激活人必须不同”，避免在缺少审批对象/应急旁路契约时造半套流程。
+- **D9 — emergency block：**建议 block 单向不可恢复；当前 active 无安全 fallback 时原子置
+  disabled，不因缺少 rollback target 拒绝安全操作。

--- a/.octospec/tasks/cardtmpl-runtime-catalog/context.yaml
+++ b/.octospec/tasks/cardtmpl-runtime-catalog/context.yaml
@@ -1,0 +1,20 @@
+injected:
+  - id: space-isolation
+    source: repo
+    why: 控制面是显式 global superAdmin 路由，不使用普通业务 Space middleware；actor 只取认证上下文，未来 Space grant 必须由 PR-C 以 authoritative scope 单独实现。
+  - id: trust-boundary
+    source: repo
+    why: bundle、schema、template、sample 和 golden 均是不可信控制面输入；严格 JSON、资源预算、bundle-local ref、共享 renderCore/cardmsg.Validate 与 inactive-only publish 构成不可绕过边界。
+  - id: error-handling
+    source: repo
+    why: validate/publish 的所有用户可见错误均使用 httperr.ResponseErrorL 和已注册 i18n code；只暴露 bounded category/document，内部 cause 与 bundle 内容不回显。
+  - id: rate-limit
+    source: repo
+    why: manager routes 按 AuthMiddleware → SharedUIDRateLimiter → superAdmin guard 安装；不手写 Redis 请求频率计数器。
+  - id: testing
+    source: repo
+    why: TDD checkpoint 覆盖 compiler trust boundary、canonical identity、immutable transaction、static reconciliation、HTTP auth/body/error、metrics、coverage 与 race；本地脏 DB 限制被显式记录。
+  - id: commit-style
+    source: repo
+    why: 提交使用英文 Conventional Commits 并带 Refs #669；PR #670 使用英文模板、Linked Spec 与实质性 COMPREHENSION。
+brief: .octospec/tasks/cardtmpl-runtime-catalog/brief.md

--- a/docs/card-template-runtime-catalog-runbook.md
+++ b/docs/card-template-runtime-catalog-runbook.md
@@ -1,0 +1,120 @@
+# Runtime card template catalog startup recovery
+
+This runbook covers startup failures from the runtime card template catalog,
+especially a static/dynamic collision on the same exact `template_id@version`.
+It applies to PR-A, where dynamic artifacts can be validated and published but
+cannot be activated, resolved, or sent in production.
+
+## Safety invariant
+
+Every exact `template_id@version` has one permanent source: `static` or
+`dynamic`. Startup reconciliation must fail closed when the built-in Registry
+and the database disagree. Do not add or use a switch that ignores the
+collision: doing so can make replicas resolve different content for the same
+identity.
+
+The PR-A break-glass action is a **binary rollback or corrective binary**, not a
+catalog bypass or database rewrite. A normal static/dynamic collision can be
+recovered without changing any catalog row.
+
+## Detection and classification
+
+The process exits with a panic containing:
+
+```text
+card template catalog: reconcile static inventory: ...
+```
+
+Classify the nested error before acting:
+
+| Signal | Meaning | First action |
+| --- | --- | --- |
+| `version claim conflicts with source` | The image contains a static exact key already reserved by a dynamic publish. | Stop the rollout and follow **Exact-key collision** below. |
+| `catalog integrity failure` | Static inventory or persisted claim/artifact state violates an invariant. | Freeze catalog changes and follow **Integrity incident** below. |
+| DB timeout/deadlock/connectivity error after bounded retry | Infrastructure is unavailable; no source conflict has been proven. | Restore DB connectivity/capacity, then restart. Do not edit catalog rows. |
+
+Use the identity from the panic log for read-only diagnosis. Do not select or
+export `canonical_bundle` during routine triage.
+
+```sql
+SELECT c.template_id, c.version, c.source, c.created_at,
+       (a.template_id IS NOT NULL) AS has_artifact,
+       a.content_sha256, a.created_at AS artifact_created_at
+FROM card_template_version_claim AS c
+LEFT JOIN card_template_artifact AS a
+  ON a.template_id = c.template_id AND a.version = c.version
+WHERE c.template_id = '<template_id>' AND c.version = '<version>';
+
+SELECT actor_uid, operation, result, reason, change_ticket, created_at
+FROM card_template_audit
+WHERE template_id = '<template_id>' AND version = '<version>'
+ORDER BY id DESC
+LIMIT 50;
+```
+
+## Exact-key collision
+
+This is the expected recovery path when a new image introduces a built-in
+`id@version` that was previously published dynamically.
+
+1. Stop or pause the rollout. Keep healthy replicas on the last known-good
+   image serving; do not scale them down while the replacement is crash-looping.
+2. Roll back to the last image that does not register the conflicting static
+   exact key. If that image cannot be deployed, build a corrective image that
+   removes the new registration or assigns it a new version. This is the
+   break-glass recovery path.
+3. Verify all serving replicas are ready and no longer emit reconciliation
+   panics. Confirm that the conflicting database claim and artifact are
+   unchanged.
+4. Assign the built-in content a new, canonical SemVer that has never been
+   claimed. Update the embedded manifest and every explicit producer/catalog
+   reference in the same reviewed change. Never reuse the dynamically claimed
+   version, even when the bytes happen to match.
+5. Run the card template, catalog, Bot template-policy, and dispatch regression
+   gates. Build and deploy the corrected image through the normal rollout.
+6. Restart at least two replicas and confirm the new exact key is recorded as
+   `source='static'` with no artifact row. Record the conflicting identity,
+   image digests, owner, ticket, and final replacement version in the incident
+   or rollout record.
+
+Do **not** delete the dynamic artifact or claim, change its `source`, or update
+its bytes/hash to make the image boot. Claims are permanent identity history;
+rewriting them defeats immutability and can break historical references once
+runtime activation exists.
+
+## Integrity incident
+
+`ErrCatalogIntegrity` is not a retryable rollout conflict. Examples include a
+static claim that unexpectedly has a dynamic artifact or a dynamic claim with
+no artifact during an idempotent publish.
+
+1. Stop the rollout and disable further catalog control-plane changes at the
+   operational boundary (traffic/authorization), while leaving existing static
+   messaging paths available where the last known-good image permits it.
+2. Capture the panic, image digest, exact identity, read-only query results, and
+   relevant audit rows. Take and verify a database snapshot before any repair.
+3. Escalate to the catalog owner plus SRE/DBA. Treat unexplained direct database
+   mutation as a security and audit event.
+4. Prepare a separate, two-person-reviewed repair plan with an explicit restore
+   point, exact affected rows, post-repair invariant queries, and rollback. This
+   generic runbook intentionally provides no `DELETE`, `UPDATE source`, or hash
+   rewrite commands.
+5. Rehearse the repair on a restored copy, execute it under a dedicated change
+   ticket, then restart multiple replicas and re-run invariant checks. Preserve
+   the incident record independently of the mutable database tables.
+
+## Exit criteria
+
+- All intended replicas run the same corrected image digest and pass startup.
+- Reconciliation completes without conflict/integrity errors on multiple fresh
+  starts.
+- Every built-in exact key has `source='static'` and no artifact row.
+- The original dynamic collision rows remain unchanged unless a separately
+  approved integrity repair was required.
+- PR-A remains dark: no activation, runtime overlay, dynamic discovery, or
+  dynamic send capability is inferred from successful publish/reconciliation.
+
+After PR-B/PR-C allow the first dynamic card to be sent, pre-E3 binary rollback
+is no longer safe for historical exact-version rendering. Their rollout
+runbooks must retain the runtime reader and use activate/rollback/block controls
+instead; this PR-A procedure must not be reused past that compatibility floor.

--- a/docs/card-template-runtime-catalog-runbook.md
+++ b/docs/card-template-runtime-catalog-runbook.md
@@ -52,6 +52,12 @@ ORDER BY id DESC
 LIMIT 50;
 ```
 
+Rejected overwrite attempts are retained with `result='immutable_conflict'`;
+attempts to reuse a static claim are retained with `result='source_conflict'`.
+These are audit-only commits: they do not change claim or artifact state. If the
+audit insert or commit fails, the API returns unavailable rather than an
+unaudited conflict response.
+
 ## Exact-key collision
 
 This is the expected recovery path when a new image introduces a built-in

--- a/internal/modules.go
+++ b/internal/modules.go
@@ -30,6 +30,7 @@ import (
 
 	_ "github.com/Mininglamp-OSS/octo-server/modules/botfather"
 
+	_ "github.com/Mininglamp-OSS/octo-server/modules/card_template_catalog"
 	_ "github.com/Mininglamp-OSS/octo-server/modules/category"
 	_ "github.com/Mininglamp-OSS/octo-server/modules/channel"
 	_ "github.com/Mininglamp-OSS/octo-server/modules/common"

--- a/modules/card_template_catalog/1module.go
+++ b/modules/card_template_catalog/1module.go
@@ -3,6 +3,7 @@ package card_template_catalog
 import (
 	"embed"
 
+	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/register"
 )
 
@@ -12,7 +13,10 @@ var sqlFS embed.FS
 func init() {
 	register.AddModule(func(ctx interface{}) register.Module {
 		return register.Module{
-			Name:   "card_template_catalog",
+			Name: "card_template_catalog",
+			SetupAPI: func() register.APIRouter {
+				return New(ctx.(*config.Context))
+			},
 			SQLDir: register.NewSQLFS(sqlFS),
 		}
 	})

--- a/modules/card_template_catalog/1module.go
+++ b/modules/card_template_catalog/1module.go
@@ -1,0 +1,19 @@
+package card_template_catalog
+
+import (
+	"embed"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/register"
+)
+
+//go:embed sql
+var sqlFS embed.FS
+
+func init() {
+	register.AddModule(func(ctx interface{}) register.Module {
+		return register.Module{
+			Name:   "card_template_catalog",
+			SQLDir: register.NewSQLFS(sqlFS),
+		}
+	})
+}

--- a/modules/card_template_catalog/api.go
+++ b/modules/card_template_catalog/api.go
@@ -21,6 +21,7 @@ import (
 const (
 	controlBodyMaxBytes = 2 << 20
 	compileTimeout      = 10 * time.Second
+	publishTimeout      = 10 * time.Second
 	reconcileTimeout    = 30 * time.Second
 	reconcileAttempts   = 3
 	reconcileRetryDelay = 250 * time.Millisecond
@@ -143,8 +144,9 @@ func (a *API) validate(c *wkhttp.Context) {
 	if !ok {
 		return
 	}
-	artifact, ok := a.compileRequest(c, bundle)
+	artifact, compileOutcome, ok := a.compileRequest(c, bundle)
 	if !ok {
+		operationResult = compileOutcome
 		return
 	}
 	operationResult = "ok"
@@ -171,11 +173,14 @@ func (a *API) publish(c *wkhttp.Context) {
 		respondCatalogForbidden(c)
 		return
 	}
-	artifact, ok := a.compileRequest(c, bundle)
+	artifact, compileOutcome, ok := a.compileRequest(c, bundle)
 	if !ok {
+		operationResult = compileOutcome
 		return
 	}
-	result, err := a.store.Publish(c.Request.Context(), PublishRequest{
+	publishCtx, cancel := context.WithTimeout(c.Request.Context(), publishTimeout)
+	defer cancel()
+	result, err := a.store.Publish(publishCtx, PublishRequest{
 		Artifact:     artifact,
 		ActorUID:     actorUID,
 		Reason:       request.Reason,
@@ -183,6 +188,15 @@ func (a *API) publish(c *wkhttp.Context) {
 	})
 	if err != nil {
 		switch {
+		case errors.Is(err, context.DeadlineExceeded):
+			operationResult = "timeout"
+			a.metrics.observeDB("publish", "timeout")
+			a.logError("publish card template timed out", err, artifact)
+			respondCatalogUnavailable(c)
+		case errors.Is(err, context.Canceled):
+			operationResult = "canceled"
+			a.metrics.observeDB("publish", "canceled")
+			respondCatalogUnavailable(c)
 		case errors.Is(err, ErrImmutableVersionConflict), errors.Is(err, ErrVersionClaimConflict):
 			operationResult = "conflict"
 			a.metrics.observeDB("publish", "conflict")
@@ -245,7 +259,7 @@ func readControlRequest(c *wkhttp.Context) (controlRequest, cardtmpl.Bundle, boo
 	return request, bundle, true
 }
 
-func (a *API) compileRequest(c *wkhttp.Context, bundle cardtmpl.Bundle) (*cardtmpl.CompiledArtifact, bool) {
+func (a *API) compileRequest(c *wkhttp.Context, bundle cardtmpl.Bundle) (*cardtmpl.CompiledArtifact, string, bool) {
 	started := time.Now()
 	compileResult := "error"
 	defer func() { a.metrics.observeCompile(compileResult, time.Since(started)) }()
@@ -254,17 +268,33 @@ func (a *API) compileRequest(c *wkhttp.Context, bundle cardtmpl.Bundle) (*cardtm
 	artifact, err := a.compile(ctx, bundle, cardtmpl.DefaultCompileLimits())
 	if err == nil {
 		compileResult = "ok"
-		return artifact, true
+		return artifact, "ok", true
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		compileResult = "timeout"
+		a.logError("compile card template timed out", err, nil)
+		respondCatalogUnavailable(c)
+		return nil, "timeout", false
+	}
+	if errors.Is(err, context.Canceled) {
+		compileResult = "canceled"
+		respondCatalogUnavailable(c)
+		return nil, "canceled", false
+	}
+	if errors.Is(err, cardtmpl.ErrArtifactCompileBusy) {
+		compileResult = "busy"
+		respondCatalogUnavailable(c)
+		return nil, "busy", false
 	}
 	var validationErr *cardtmpl.ArtifactValidationError
 	if errors.As(err, &validationErr) {
 		compileResult = "validation_error"
 		respondCatalogRequestInvalid(c, err)
-		return nil, false
+		return nil, "rejected", false
 	}
 	a.logError("compile card template failed", err, nil)
 	respondCatalogUnavailable(c)
-	return nil, false
+	return nil, "error", false
 }
 
 func responseForArtifact(artifact *cardtmpl.CompiledArtifact, published bool, result PublishResult) controlResponse {

--- a/modules/card_template_catalog/api.go
+++ b/modules/card_template_catalog/api.go
@@ -14,6 +14,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
 	"github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl"
 	appwkhttp "github.com/Mininglamp-OSS/octo-server/pkg/wkhttp"
+	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/zap"
 )
 
@@ -35,14 +36,17 @@ type API struct {
 	store   catalogStore
 	compile compileArtifactFunc
 	logger  log.Log
+	metrics *catalogMetrics
 }
 
 func New(ctx *config.Context) *API {
+	metrics := newCatalogMetrics(prometheus.DefaultRegisterer)
 	api := &API{
 		ctx:     ctx,
 		store:   newStore(ctx.DB().DB),
 		compile: cardtmpl.CompileJSONArtifact,
 		logger:  log.NewTLog("CardTemplateCatalog"),
+		metrics: metrics,
 	}
 	registry := cardtmpl.DefaultRegistry()
 	if registry == nil {
@@ -54,8 +58,10 @@ func New(ctx *config.Context) *API {
 	reconcileCtx, cancel := context.WithTimeout(context.Background(), reconcileTimeout)
 	defer cancel()
 	if err := reconcileStaticInventory(reconcileCtx, api.store, registry); err != nil {
+		api.metrics.observeDB("reconcile_static", "error")
 		panic(fmt.Sprintf("card template catalog: reconcile static inventory: %v", err))
 	}
+	api.metrics.observeDB("reconcile_static", "ok")
 	return api
 }
 
@@ -99,6 +105,8 @@ type controlResponse struct {
 }
 
 func (a *API) validate(c *wkhttp.Context) {
+	operationResult := "rejected"
+	defer func() { a.metrics.observeOperation("validate", operationResult) }()
 	if !a.requireSuperAdmin(c) {
 		return
 	}
@@ -110,10 +118,13 @@ func (a *API) validate(c *wkhttp.Context) {
 	if !ok {
 		return
 	}
+	operationResult = "ok"
 	c.Response(responseForArtifact(artifact, false, PublishResult{}))
 }
 
 func (a *API) publish(c *wkhttp.Context) {
+	operationResult := "rejected"
+	defer func() { a.metrics.observeOperation("publish", operationResult) }()
 	if !a.requireSuperAdmin(c) {
 		return
 	}
@@ -144,15 +155,22 @@ func (a *API) publish(c *wkhttp.Context) {
 	if err != nil {
 		switch {
 		case errors.Is(err, ErrImmutableVersionConflict), errors.Is(err, ErrVersionClaimConflict):
+			operationResult = "conflict"
+			a.metrics.observeDB("publish", "conflict")
 			respondCatalogConflict(c)
 		case errors.Is(err, ErrPublishRequestInvalid):
+			a.metrics.observeDB("publish", "rejected")
 			respondCatalogRequestInvalid(c, err)
 		default:
+			operationResult = "error"
+			a.metrics.observeDB("publish", "error")
 			a.logError("publish card template failed", err, artifact)
 			respondCatalogUnavailable(c)
 		}
 		return
 	}
+	a.metrics.observeDB("publish", "ok")
+	operationResult = "ok"
 	c.Response(responseForArtifact(artifact, true, result))
 }
 
@@ -194,14 +212,19 @@ func readControlRequest(c *wkhttp.Context) (controlRequest, cardtmpl.Bundle, boo
 }
 
 func (a *API) compileRequest(c *wkhttp.Context, bundle cardtmpl.Bundle) (*cardtmpl.CompiledArtifact, bool) {
+	started := time.Now()
+	compileResult := "error"
+	defer func() { a.metrics.observeCompile(compileResult, time.Since(started)) }()
 	ctx, cancel := context.WithTimeout(c.Request.Context(), compileTimeout)
 	defer cancel()
 	artifact, err := a.compile(ctx, bundle, cardtmpl.DefaultCompileLimits())
 	if err == nil {
+		compileResult = "ok"
 		return artifact, true
 	}
 	var validationErr *cardtmpl.ArtifactValidationError
 	if errors.As(err, &validationErr) {
+		compileResult = "validation_error"
 		respondCatalogRequestInvalid(c, err)
 		return nil, false
 	}

--- a/modules/card_template_catalog/api.go
+++ b/modules/card_template_catalog/api.go
@@ -1,0 +1,242 @@
+package card_template_catalog
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl"
+	appwkhttp "github.com/Mininglamp-OSS/octo-server/pkg/wkhttp"
+	"go.uber.org/zap"
+)
+
+const (
+	controlBodyMaxBytes = 2 << 20
+	compileTimeout      = 10 * time.Second
+	reconcileTimeout    = 30 * time.Second
+)
+
+type catalogStore interface {
+	Publish(context.Context, PublishRequest) (PublishResult, error)
+	ReconcileStatic(context.Context, []cardtmpl.TemplateMeta) error
+}
+
+type compileArtifactFunc func(context.Context, cardtmpl.Bundle, cardtmpl.CompileLimits) (*cardtmpl.CompiledArtifact, error)
+
+type API struct {
+	ctx     *config.Context
+	store   catalogStore
+	compile compileArtifactFunc
+	logger  log.Log
+}
+
+func New(ctx *config.Context) *API {
+	api := &API{
+		ctx:     ctx,
+		store:   newStore(ctx.DB().DB),
+		compile: cardtmpl.CompileJSONArtifact,
+		logger:  log.NewTLog("CardTemplateCatalog"),
+	}
+	registry := cardtmpl.DefaultRegistry()
+	if registry == nil {
+		if !ctx.GetConfig().Test {
+			panic("card template catalog: built-in Registry is not installed")
+		}
+		return api
+	}
+	reconcileCtx, cancel := context.WithTimeout(context.Background(), reconcileTimeout)
+	defer cancel()
+	if err := reconcileStaticInventory(reconcileCtx, api.store, registry); err != nil {
+		panic(fmt.Sprintf("card template catalog: reconcile static inventory: %v", err))
+	}
+	return api
+}
+
+func reconcileStaticInventory(ctx context.Context, store catalogStore, registry *cardtmpl.Registry) error {
+	if store == nil || registry == nil {
+		return fmt.Errorf("%w: store and Registry are required", ErrCatalogIntegrity)
+	}
+	return store.ReconcileStatic(ctx, registry.List())
+}
+
+// Route installs a global super-admin control plane. It intentionally does not
+// use Space middleware: target Space grants are a later, explicitly scoped PR.
+func (a *API) Route(r *wkhttp.WKHttp) {
+	manager := r.Group(
+		"/v1/manager/card-templates",
+		a.ctx.AuthMiddleware(r),
+		appwkhttp.SharedUIDRateLimiter(r, a.ctx),
+	)
+	manager.POST("/validate", a.validate)
+	manager.POST("/publish", a.publish)
+}
+
+type controlRequest struct {
+	Bundle       json.RawMessage `json:"bundle"`
+	Reason       string          `json:"reason,omitempty"`
+	ChangeTicket string          `json:"change_ticket,omitempty"`
+}
+
+type controlResponse struct {
+	Hash       string `json:"hash"`
+	TemplateID string `json:"template_id"`
+	Version    string `json:"version"`
+	Owner      string `json:"owner"`
+	Engine     string `json:"engine"`
+	Visibility string `json:"visibility"`
+	Active     bool   `json:"active"`
+	Published  bool   `json:"published"`
+	Created    bool   `json:"created,omitempty"`
+	Idempotent bool   `json:"idempotent,omitempty"`
+	Blocked    bool   `json:"blocked,omitempty"`
+}
+
+func (a *API) validate(c *wkhttp.Context) {
+	if !a.requireSuperAdmin(c) {
+		return
+	}
+	_, bundle, ok := readControlRequest(c)
+	if !ok {
+		return
+	}
+	artifact, ok := a.compileRequest(c, bundle)
+	if !ok {
+		return
+	}
+	c.Response(responseForArtifact(artifact, false, PublishResult{}))
+}
+
+func (a *API) publish(c *wkhttp.Context) {
+	if !a.requireSuperAdmin(c) {
+		return
+	}
+	request, bundle, ok := readControlRequest(c)
+	if !ok {
+		return
+	}
+	if !boundedRequiredText(request.Reason, maxReasonRunes) ||
+		!boundedRequiredText(request.ChangeTicket, maxChangeTicketRunes) {
+		respondCatalogRequestInvalid(c, ErrPublishRequestInvalid)
+		return
+	}
+	actorUID := c.GetLoginUID()
+	if !boundedRequiredText(actorUID, maxActorUIDRunes) {
+		respondCatalogForbidden(c)
+		return
+	}
+	artifact, ok := a.compileRequest(c, bundle)
+	if !ok {
+		return
+	}
+	result, err := a.store.Publish(c.Request.Context(), PublishRequest{
+		Artifact:     artifact,
+		ActorUID:     actorUID,
+		Reason:       request.Reason,
+		ChangeTicket: request.ChangeTicket,
+	})
+	if err != nil {
+		switch {
+		case errors.Is(err, ErrImmutableVersionConflict), errors.Is(err, ErrVersionClaimConflict):
+			respondCatalogConflict(c)
+		case errors.Is(err, ErrPublishRequestInvalid):
+			respondCatalogRequestInvalid(c, err)
+		default:
+			a.logError("publish card template failed", err, artifact)
+			respondCatalogUnavailable(c)
+		}
+		return
+	}
+	c.Response(responseForArtifact(artifact, true, result))
+}
+
+func (a *API) requireSuperAdmin(c *wkhttp.Context) bool {
+	if err := c.CheckLoginRoleIsSuperAdmin(); err != nil {
+		respondCatalogForbidden(c)
+		return false
+	}
+	return true
+}
+
+func readControlRequest(c *wkhttp.Context) (controlRequest, cardtmpl.Bundle, bool) {
+	c.Request.Body = http.MaxBytesReader(c.Writer, c.Request.Body, controlBodyMaxBytes)
+	raw, err := io.ReadAll(c.Request.Body)
+	if err != nil {
+		var maxBytesErr *http.MaxBytesError
+		if errors.As(err, &maxBytesErr) {
+			respondCatalogContentTooLarge(c)
+			return controlRequest{}, cardtmpl.Bundle{}, false
+		}
+		respondCatalogRequestInvalid(c, err)
+		return controlRequest{}, cardtmpl.Bundle{}, false
+	}
+	var request controlRequest
+	if err := cardtmpl.DecodeStrictJSON(raw, &request); err != nil {
+		respondCatalogRequestInvalid(c, err)
+		return controlRequest{}, cardtmpl.Bundle{}, false
+	}
+	if len(request.Bundle) == 0 || string(request.Bundle) == "null" {
+		respondCatalogRequestInvalid(c, errors.New("bundle is required"))
+		return controlRequest{}, cardtmpl.Bundle{}, false
+	}
+	bundle, err := cardtmpl.DecodeBundleJSON(request.Bundle)
+	if err != nil {
+		respondCatalogRequestInvalid(c, err)
+		return controlRequest{}, cardtmpl.Bundle{}, false
+	}
+	return request, bundle, true
+}
+
+func (a *API) compileRequest(c *wkhttp.Context, bundle cardtmpl.Bundle) (*cardtmpl.CompiledArtifact, bool) {
+	ctx, cancel := context.WithTimeout(c.Request.Context(), compileTimeout)
+	defer cancel()
+	artifact, err := a.compile(ctx, bundle, cardtmpl.DefaultCompileLimits())
+	if err == nil {
+		return artifact, true
+	}
+	var validationErr *cardtmpl.ArtifactValidationError
+	if errors.As(err, &validationErr) {
+		respondCatalogRequestInvalid(c, err)
+		return nil, false
+	}
+	a.logError("compile card template failed", err, nil)
+	respondCatalogUnavailable(c)
+	return nil, false
+}
+
+func responseForArtifact(artifact *cardtmpl.CompiledArtifact, published bool, result PublishResult) controlResponse {
+	return controlResponse{
+		Hash:       artifact.Hash,
+		TemplateID: string(artifact.Meta.ID),
+		Version:    artifact.Meta.Version,
+		Owner:      artifact.Owner,
+		Engine:     artifact.Engine,
+		Visibility: artifact.Visibility,
+		Active:     false,
+		Published:  published,
+		Created:    result.Created,
+		Idempotent: result.Idempotent,
+		Blocked:    result.Blocked,
+	}
+}
+
+func (a *API) logError(message string, err error, artifact *cardtmpl.CompiledArtifact) {
+	if a.logger == nil {
+		return
+	}
+	fields := []zap.Field{zap.Error(err)}
+	if artifact != nil {
+		fields = append(fields,
+			zap.String("template_id", string(artifact.Meta.ID)),
+			zap.String("version", artifact.Meta.Version),
+			zap.String("content_sha256", artifact.Hash),
+		)
+	}
+	a.logger.Error(message, fields...)
+}

--- a/modules/card_template_catalog/api.go
+++ b/modules/card_template_catalog/api.go
@@ -2,11 +2,11 @@ package card_template_catalog
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"net/http"
+	"sort"
 	"time"
 
 	"github.com/Mininglamp-OSS/octo-lib/config"
@@ -115,9 +115,8 @@ func (a *API) Route(r *wkhttp.WKHttp) {
 }
 
 type controlRequest struct {
-	Bundle       json.RawMessage `json:"bundle"`
-	Reason       string          `json:"reason,omitempty"`
-	ChangeTicket string          `json:"change_ticket,omitempty"`
+	Reason       string
+	ChangeTicket string
 }
 
 type controlResponse struct {
@@ -242,21 +241,65 @@ func readControlRequest(c *wkhttp.Context) (controlRequest, cardtmpl.Bundle, boo
 		respondCatalogRequestInvalid(c, err)
 		return controlRequest{}, cardtmpl.Bundle{}, false
 	}
-	var request controlRequest
-	if err := cardtmpl.DecodeStrictJSON(raw, &request); err != nil {
+	root, err := cardtmpl.DecodeStrictJSONObject(raw)
+	if err != nil {
 		respondCatalogRequestInvalid(c, err)
 		return controlRequest{}, cardtmpl.Bundle{}, false
 	}
-	if len(request.Bundle) == 0 || string(request.Bundle) == "null" {
-		respondCatalogRequestInvalid(c, errors.New("bundle is required"))
+	request, bundleValue, err := decodeControlRequest(root)
+	if err != nil {
+		respondCatalogRequestInvalid(c, err)
 		return controlRequest{}, cardtmpl.Bundle{}, false
 	}
-	bundle, err := cardtmpl.DecodeBundleJSON(request.Bundle)
+	bundle, err := cardtmpl.DecodeBundleValue(bundleValue)
 	if err != nil {
 		respondCatalogRequestInvalid(c, err)
 		return controlRequest{}, cardtmpl.Bundle{}, false
 	}
 	return request, bundle, true
+}
+
+func decodeControlRequest(root map[string]any) (controlRequest, any, error) {
+	allowed := map[string]struct{}{
+		"bundle":        {},
+		"reason":        {},
+		"change_ticket": {},
+	}
+	unknown := make([]string, 0)
+	for key := range root {
+		if _, ok := allowed[key]; !ok {
+			unknown = append(unknown, key)
+		}
+	}
+	if len(unknown) > 0 {
+		sort.Strings(unknown)
+		return controlRequest{}, nil, fmt.Errorf("unknown request field %q", unknown[0])
+	}
+	bundle, exists := root["bundle"]
+	if !exists || bundle == nil {
+		return controlRequest{}, nil, errors.New("bundle is required")
+	}
+	reason, err := optionalControlString(root, "reason")
+	if err != nil {
+		return controlRequest{}, nil, err
+	}
+	changeTicket, err := optionalControlString(root, "change_ticket")
+	if err != nil {
+		return controlRequest{}, nil, err
+	}
+	return controlRequest{Reason: reason, ChangeTicket: changeTicket}, bundle, nil
+}
+
+func optionalControlString(root map[string]any, key string) (string, error) {
+	value, exists := root[key]
+	if !exists || value == nil {
+		return "", nil
+	}
+	text, ok := value.(string)
+	if !ok {
+		return "", fmt.Errorf("request field %q must be a string", key)
+	}
+	return text, nil
 }
 
 func (a *API) compileRequest(c *wkhttp.Context, bundle cardtmpl.Bundle) (*cardtmpl.CompiledArtifact, string, bool) {

--- a/modules/card_template_catalog/api.go
+++ b/modules/card_template_catalog/api.go
@@ -22,6 +22,8 @@ const (
 	controlBodyMaxBytes = 2 << 20
 	compileTimeout      = 10 * time.Second
 	reconcileTimeout    = 30 * time.Second
+	reconcileAttempts   = 3
+	reconcileRetryDelay = 250 * time.Millisecond
 )
 
 type catalogStore interface {
@@ -69,7 +71,34 @@ func reconcileStaticInventory(ctx context.Context, store catalogStore, registry 
 	if store == nil || registry == nil {
 		return fmt.Errorf("%w: store and Registry are required", ErrCatalogIntegrity)
 	}
-	return store.ReconcileStatic(ctx, registry.List())
+	inventory := registry.List()
+	var lastErr error
+	for attempt := 1; attempt <= reconcileAttempts; attempt++ {
+		lastErr = store.ReconcileStatic(ctx, inventory)
+		if lastErr == nil {
+			return nil
+		}
+		if errors.Is(lastErr, ErrCatalogIntegrity) || errors.Is(lastErr, ErrVersionClaimConflict) {
+			return lastErr
+		}
+		if attempt == reconcileAttempts {
+			break
+		}
+		delay := reconcileRetryDelay * time.Duration(1<<(attempt-1))
+		timer := time.NewTimer(delay)
+		select {
+		case <-ctx.Done():
+			if !timer.Stop() {
+				select {
+				case <-timer.C:
+				default:
+				}
+			}
+			return ctx.Err()
+		case <-timer.C:
+		}
+	}
+	return fmt.Errorf("reconcile static inventory failed after %d attempts: %w", reconcileAttempts, lastErr)
 }
 
 // Route installs a global super-admin control plane. It intentionally does not

--- a/modules/card_template_catalog/api.go
+++ b/modules/card_template_catalog/api.go
@@ -190,6 +190,11 @@ func (a *API) publish(c *wkhttp.Context) {
 		case errors.Is(err, ErrPublishRequestInvalid):
 			a.metrics.observeDB("publish", "rejected")
 			respondCatalogRequestInvalid(c, err)
+		case errors.Is(err, ErrCatalogIntegrity):
+			operationResult = "integrity_error"
+			a.metrics.observeDB("publish", "integrity_error")
+			a.logError("card template catalog integrity failure", err, artifact)
+			respondCatalogIntegrityFailure(c)
 		default:
 			operationResult = "error"
 			a.metrics.observeDB("publish", "error")

--- a/modules/card_template_catalog/api_additional_test.go
+++ b/modules/card_template_catalog/api_additional_test.go
@@ -114,3 +114,27 @@ func TestReconcileStaticInventoryRejectsMissingDependencies(t *testing.T) {
 		t.Fatalf("error = %v, want ErrCatalogIntegrity", err)
 	}
 }
+
+func TestReconcileStaticInventoryRetriesTransientFailure(t *testing.T) {
+	registry := cardtmpl.NewRegistry()
+	registry.Freeze()
+	store := &fakeCatalogStore{reconcileErrs: []error{errors.New("deadlock"), nil}}
+	if err := reconcileStaticInventory(context.Background(), store, registry); err != nil {
+		t.Fatalf("reconcileStaticInventory: %v", err)
+	}
+	if store.reconcileCalls != 2 {
+		t.Fatalf("reconcile calls = %d, want 2", store.reconcileCalls)
+	}
+}
+
+func TestReconcileStaticInventoryDoesNotRetryIntegrityFailure(t *testing.T) {
+	registry := cardtmpl.NewRegistry()
+	registry.Freeze()
+	store := &fakeCatalogStore{reconcileErrs: []error{ErrCatalogIntegrity}}
+	if err := reconcileStaticInventory(context.Background(), store, registry); !errors.Is(err, ErrCatalogIntegrity) {
+		t.Fatalf("reconcileStaticInventory error = %v, want ErrCatalogIntegrity", err)
+	}
+	if store.reconcileCalls != 1 {
+		t.Fatalf("reconcile calls = %d, want 1", store.reconcileCalls)
+	}
+}

--- a/modules/card_template_catalog/api_additional_test.go
+++ b/modules/card_template_catalog/api_additional_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
 	"github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl"
 	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 )
 
 func TestNewInTestModeAllowsUninstalledStaticRegistry(t *testing.T) {
@@ -58,25 +60,42 @@ func TestRouteRequiresAuthenticationBeforeControlHandlers(t *testing.T) {
 
 func TestCompileRequestMapsValidationAndCapacityErrors(t *testing.T) {
 	tests := []struct {
-		name     string
-		err      error
-		wantCode string
+		name          string
+		err           error
+		wantCode      string
+		wantOperation string
 	}{
 		{
-			name:     "validation",
-			err:      &cardtmpl.ArtifactValidationError{Category: "schema", Document: "schema"},
-			wantCode: "err.server.card_template_catalog.request_invalid",
+			name:          "validation",
+			err:           &cardtmpl.ArtifactValidationError{Category: "schema", Document: "schema"},
+			wantCode:      "err.server.card_template_catalog.request_invalid",
+			wantOperation: "rejected",
 		},
 		{
-			name:     "capacity",
-			err:      cardtmpl.ErrArtifactCompileBusy,
-			wantCode: "err.server.card_template_catalog.unavailable",
+			name:          "capacity",
+			err:           cardtmpl.ErrArtifactCompileBusy,
+			wantCode:      "err.server.card_template_catalog.unavailable",
+			wantOperation: "busy",
+		},
+		{
+			name:          "timeout",
+			err:           context.DeadlineExceeded,
+			wantCode:      "err.server.card_template_catalog.unavailable",
+			wantOperation: "timeout",
+		},
+		{
+			name:          "internal",
+			err:           errors.New("compiler failed"),
+			wantCode:      "err.server.card_template_catalog.unavailable",
+			wantOperation: "error",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			registry := prometheus.NewRegistry()
 			api := &API{
-				store: &fakeCatalogStore{},
+				store:   &fakeCatalogStore{},
+				metrics: newCatalogMetrics(registry),
 				compile: func(context.Context, cardtmpl.Bundle, cardtmpl.CompileLimits) (*cardtmpl.CompiledArtifact, error) {
 					return nil, tt.err
 				},
@@ -88,6 +107,9 @@ func TestCompileRequestMapsValidationAndCapacityErrors(t *testing.T) {
 			}
 			if envelope.Error.Code != tt.wantCode {
 				t.Fatalf("code = %q, want %q", envelope.Error.Code, tt.wantCode)
+			}
+			if got := testutil.ToFloat64(api.metrics.operations.WithLabelValues("validate", tt.wantOperation)); got != 1 {
+				t.Fatalf("validate operation result %q = %v, want 1", tt.wantOperation, got)
 			}
 		})
 	}

--- a/modules/card_template_catalog/api_additional_test.go
+++ b/modules/card_template_catalog/api_additional_test.go
@@ -1,0 +1,116 @@
+package card_template_catalog
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl"
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
+)
+
+func TestNewInTestModeAllowsUninstalledStaticRegistry(t *testing.T) {
+	previous := cardtmpl.DefaultRegistry()
+	cardtmpl.SetDefaultRegistry(nil)
+	t.Cleanup(func() { cardtmpl.SetDefaultRegistry(previous) })
+
+	cfg := config.New()
+	cfg.Test = true
+	ctx := config.NewContext(cfg)
+	api := New(ctx)
+	if api.ctx != ctx || api.store == nil || api.compile == nil || api.logger == nil {
+		t.Fatalf("New returned incomplete API: %+v", api)
+	}
+}
+
+func TestRouteRequiresAuthenticationBeforeControlHandlers(t *testing.T) {
+	cfg := config.New()
+	cfg.Test = true
+	ctx := config.NewContext(cfg)
+	compilerCalls := 0
+	api := &API{
+		ctx:   ctx,
+		store: &fakeCatalogStore{},
+		compile: func(context.Context, cardtmpl.Bundle, cardtmpl.CompileLimits) (*cardtmpl.CompiledArtifact, error) {
+			compilerCalls++
+			return compiledArtifactFixture(), nil
+		},
+	}
+	route := wkhttp.New()
+	route.SetErrorRenderer(i18n.NewErrorRenderer(i18n.NewLocalizer(i18n.DefaultLanguage)))
+	api.Route(route)
+
+	request := httptest.NewRequest(http.MethodPost, "/v1/manager/card-templates/validate", nil)
+	response := httptest.NewRecorder()
+	route.ServeHTTP(response, request)
+	if response.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401; body=%s", response.Code, response.Body.String())
+	}
+	if compilerCalls != 0 {
+		t.Fatalf("compiler called %d times before auth", compilerCalls)
+	}
+}
+
+func TestCompileRequestMapsValidationAndCapacityErrors(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		wantCode string
+	}{
+		{
+			name:     "validation",
+			err:      &cardtmpl.ArtifactValidationError{Category: "schema", Document: "schema"},
+			wantCode: "err.server.card_template_catalog.request_invalid",
+		},
+		{
+			name:     "capacity",
+			err:      cardtmpl.ErrArtifactCompileBusy,
+			wantCode: "err.server.card_template_catalog.unavailable",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			api := &API{
+				store: &fakeCatalogStore{},
+				compile: func(context.Context, cardtmpl.Bundle, cardtmpl.CompileLimits) (*cardtmpl.CompiledArtifact, error) {
+					return nil, tt.err
+				},
+			}
+			response := doCatalogRequest(t, api, wkhttp.SuperAdmin, "/validate", validControlRequestJSON(t, false))
+			var envelope catalogErrorEnvelope
+			if err := json.Unmarshal(response.Body.Bytes(), &envelope); err != nil {
+				t.Fatal(err)
+			}
+			if envelope.Error.Code != tt.wantCode {
+				t.Fatalf("code = %q, want %q", envelope.Error.Code, tt.wantCode)
+			}
+		})
+	}
+}
+
+func TestPublishRejectsMissingAuditFieldsBeforeCompile(t *testing.T) {
+	compilerCalls := 0
+	api := &API{
+		store: &fakeCatalogStore{},
+		compile: func(context.Context, cardtmpl.Bundle, cardtmpl.CompileLimits) (*cardtmpl.CompiledArtifact, error) {
+			compilerCalls++
+			return compiledArtifactFixture(), nil
+		},
+	}
+	response := doCatalogRequest(t, api, wkhttp.SuperAdmin, "/publish", validControlRequestJSON(t, false))
+	assertCatalogError(t, response, "err.server.card_template_catalog.request_invalid", http.StatusBadRequest)
+	if compilerCalls != 0 {
+		t.Fatalf("compiler called %d times before audit-field validation", compilerCalls)
+	}
+}
+
+func TestReconcileStaticInventoryRejectsMissingDependencies(t *testing.T) {
+	if err := reconcileStaticInventory(context.Background(), nil, nil); !errors.Is(err, ErrCatalogIntegrity) {
+		t.Fatalf("error = %v, want ErrCatalogIntegrity", err)
+	}
+}

--- a/modules/card_template_catalog/api_i18n.go
+++ b/modules/card_template_catalog/api_i18n.go
@@ -42,3 +42,7 @@ func respondCatalogConflict(c *wkhttp.Context) {
 func respondCatalogUnavailable(c *wkhttp.Context) {
 	httperr.ResponseErrorL(c, errcode.ErrCardTemplateCatalogUnavailable, nil, nil)
 }
+
+func respondCatalogIntegrityFailure(c *wkhttp.Context) {
+	httperr.ResponseErrorL(c, errcode.ErrSharedInternal, nil, nil)
+}

--- a/modules/card_template_catalog/api_i18n.go
+++ b/modules/card_template_catalog/api_i18n.go
@@ -1,0 +1,44 @@
+package card_template_catalog
+
+import (
+	"errors"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
+	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
+)
+
+func respondCatalogForbidden(c *wkhttp.Context) {
+	httperr.ResponseErrorL(c, errcode.ErrCardTemplateCatalogForbidden, nil, nil)
+}
+
+func respondCatalogRequestInvalid(c *wkhttp.Context, err error) {
+	details := i18n.Details{}
+	var validationErr *cardtmpl.ArtifactValidationError
+	if errors.As(err, &validationErr) {
+		if validationErr.Category != "" {
+			details["category"] = validationErr.Category
+		}
+		if validationErr.Document != "" {
+			details["document"] = validationErr.Document
+		}
+	}
+	if len(details) == 0 {
+		details = nil
+	}
+	httperr.ResponseErrorL(c, errcode.ErrCardTemplateCatalogRequestInvalid, nil, details)
+}
+
+func respondCatalogContentTooLarge(c *wkhttp.Context) {
+	httperr.ResponseErrorL(c, errcode.ErrCardTemplateCatalogContentTooLarge, nil, nil)
+}
+
+func respondCatalogConflict(c *wkhttp.Context) {
+	httperr.ResponseErrorL(c, errcode.ErrCardTemplateCatalogConflict, nil, nil)
+}
+
+func respondCatalogUnavailable(c *wkhttp.Context) {
+	httperr.ResponseErrorL(c, errcode.ErrCardTemplateCatalogUnavailable, nil, nil)
+}

--- a/modules/card_template_catalog/api_test.go
+++ b/modules/card_template_catalog/api_test.go
@@ -15,6 +15,8 @@ import (
 	"github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl"
 	aireasoningprocess "github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl/ai_reasoning_process"
 	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 )
 
 func TestValidateCompilesWithoutPersisting(t *testing.T) {
@@ -145,20 +147,28 @@ func TestPublishMapsConflictAndInternalErrors(t *testing.T) {
 		err        error
 		wantCode   string
 		wantStatus int
+		wantDB     string
 	}{
-		{name: "immutable conflict", err: ErrImmutableVersionConflict, wantCode: "err.server.card_template_catalog.conflict", wantStatus: http.StatusConflict},
-		{name: "store unavailable", err: errors.New("db unavailable"), wantCode: "err.server.card_template_catalog.unavailable", wantStatus: http.StatusServiceUnavailable},
+		{name: "immutable conflict", err: ErrImmutableVersionConflict, wantCode: "err.server.card_template_catalog.conflict", wantStatus: http.StatusConflict, wantDB: "conflict"},
+		{name: "version claim conflict", err: ErrVersionClaimConflict, wantCode: "err.server.card_template_catalog.conflict", wantStatus: http.StatusConflict, wantDB: "conflict"},
+		{name: "catalog integrity failure", err: ErrCatalogIntegrity, wantCode: "err.shared.internal", wantStatus: http.StatusInternalServerError, wantDB: "integrity_error"},
+		{name: "store unavailable", err: errors.New("db unavailable"), wantCode: "err.server.card_template_catalog.unavailable", wantStatus: http.StatusServiceUnavailable, wantDB: "error"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			registry := prometheus.NewRegistry()
 			api := &API{
-				store: &fakeCatalogStore{publishErr: tt.err},
+				store:   &fakeCatalogStore{publishErr: tt.err},
+				metrics: newCatalogMetrics(registry),
 				compile: func(context.Context, cardtmpl.Bundle, cardtmpl.CompileLimits) (*cardtmpl.CompiledArtifact, error) {
 					return compiledArtifactFixture(), nil
 				},
 			}
 			response := doCatalogRequest(t, api, wkhttp.SuperAdmin, "/publish", validControlRequestJSON(t, true))
 			assertCatalogError(t, response, tt.wantCode, tt.wantStatus)
+			if got := testutil.ToFloat64(api.metrics.db.WithLabelValues("publish", tt.wantDB)); got != 1 {
+				t.Fatalf("publish DB metric result %q = %v, want 1", tt.wantDB, got)
+			}
 		})
 	}
 }

--- a/modules/card_template_catalog/api_test.go
+++ b/modules/card_template_catalog/api_test.go
@@ -173,6 +173,7 @@ func TestPublishMapsConflictAndInternalErrors(t *testing.T) {
 		{name: "immutable conflict", err: ErrImmutableVersionConflict, wantCode: "err.server.card_template_catalog.conflict", wantStatus: http.StatusConflict, wantDB: "conflict"},
 		{name: "version claim conflict", err: ErrVersionClaimConflict, wantCode: "err.server.card_template_catalog.conflict", wantStatus: http.StatusConflict, wantDB: "conflict"},
 		{name: "catalog integrity failure", err: ErrCatalogIntegrity, wantCode: "err.shared.internal", wantStatus: http.StatusInternalServerError, wantDB: "integrity_error"},
+		{name: "store timeout", err: context.DeadlineExceeded, wantCode: "err.server.card_template_catalog.unavailable", wantStatus: http.StatusServiceUnavailable, wantDB: "timeout"},
 		{name: "store unavailable", err: errors.New("db unavailable"), wantCode: "err.server.card_template_catalog.unavailable", wantStatus: http.StatusServiceUnavailable, wantDB: "error"},
 	}
 	for _, tt := range tests {

--- a/modules/card_template_catalog/api_test.go
+++ b/modules/card_template_catalog/api_test.go
@@ -216,7 +216,7 @@ func validControlRequestJSON(t *testing.T, publish bool) []byte {
 		Catalog: cardtmpl.CatalogDescriptor{Engine: cardtmpl.JSONTemplateEngineV1, Visibility: cardtmpl.CatalogVisibilityPrivate},
 		Manifest: json.RawMessage(`{
 			"schemaVersion":2,"id":"test.runtime-card","name":"Runtime card","version":"1.0.0",
-			"contractVersion":"1.0.0","protocol":"octo-card@1.0","owner":"ai",
+			"contractVersion":"1.0.0","protocol":"octo-card@1.0","adaptiveCardVersion":"1.5","owner":"ai",
 			"dataSchema":"contract/data.schema.json",
 			"views":{"main":{"wireProfile":"octo/v1","states":["shown"],"template":"templates/main.template.json","samples":["samples/shown.json"]}}
 		}`),

--- a/modules/card_template_catalog/api_test.go
+++ b/modules/card_template_catalog/api_test.go
@@ -254,12 +254,14 @@ func compiledArtifactFixture() *cardtmpl.CompiledArtifact {
 }
 
 type fakeCatalogStore struct {
-	publishResult PublishResult
-	publishErr    error
-	publishCalls  int
-	lastPublish   PublishRequest
-	reconciled    []cardtmpl.TemplateMeta
-	reconcileErr  error
+	publishResult  PublishResult
+	publishErr     error
+	publishCalls   int
+	lastPublish    PublishRequest
+	reconciled     []cardtmpl.TemplateMeta
+	reconcileErr   error
+	reconcileErrs  []error
+	reconcileCalls int
 }
 
 func (s *fakeCatalogStore) Publish(_ context.Context, request PublishRequest) (PublishResult, error) {
@@ -269,7 +271,13 @@ func (s *fakeCatalogStore) Publish(_ context.Context, request PublishRequest) (P
 }
 
 func (s *fakeCatalogStore) ReconcileStatic(_ context.Context, inventory []cardtmpl.TemplateMeta) error {
+	s.reconcileCalls++
 	s.reconciled = append([]cardtmpl.TemplateMeta(nil), inventory...)
+	if len(s.reconcileErrs) > 0 {
+		err := s.reconcileErrs[0]
+		s.reconcileErrs = s.reconcileErrs[1:]
+		return err
+	}
 	return s.reconcileErr
 }
 

--- a/modules/card_template_catalog/api_test.go
+++ b/modules/card_template_catalog/api_test.go
@@ -210,7 +210,7 @@ func TestReconcileStaticInventoryUsesFrozenRegistryList(t *testing.T) {
 
 func TestCatalogNoLegacyErrorResponses(t *testing.T) {
 	files := []string{"api.go", "api_i18n.go"}
-	banned := []string{".ResponseError(", ".ResponseErrorf(", ".ResponseErrorWithStatus(", ".AbortWithStatusJSON(", ".AbortWithStatus("}
+	banned := []string{".ResponseError(", ".ResponseErrorf(", ".ResponseErrorWithStatus(", ".AbortWithStatusJSON(", ".AbortWithStatus(", `.Response("`}
 	for _, file := range files {
 		data, err := os.ReadFile(file)
 		if err != nil {

--- a/modules/card_template_catalog/api_test.go
+++ b/modules/card_template_catalog/api_test.go
@@ -77,6 +77,27 @@ func TestPublishUsesAuthenticatedActorAndKeepsArtifactInactive(t *testing.T) {
 	}
 }
 
+func TestPublishBoundsStoreContext(t *testing.T) {
+	store := &fakeCatalogStore{publishResult: PublishResult{Created: true}}
+	api := &API{
+		store: store,
+		compile: func(context.Context, cardtmpl.Bundle, cardtmpl.CompileLimits) (*cardtmpl.CompiledArtifact, error) {
+			return compiledArtifactFixture(), nil
+		},
+	}
+
+	response := doCatalogRequest(t, api, wkhttp.SuperAdmin, "/publish", validControlRequestJSON(t, true))
+	if response.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", response.Code, response.Body.String())
+	}
+	if store.publishContext == nil {
+		t.Fatal("store did not receive a publish context")
+	}
+	if _, ok := store.publishContext.Deadline(); !ok {
+		t.Fatal("store publish context has no server-side deadline")
+	}
+}
+
 func TestControlEndpointsRejectNonSuperAdminBeforeCompile(t *testing.T) {
 	compilerCalls := 0
 	api := &API{
@@ -267,6 +288,7 @@ type fakeCatalogStore struct {
 	publishResult  PublishResult
 	publishErr     error
 	publishCalls   int
+	publishContext context.Context
 	lastPublish    PublishRequest
 	reconciled     []cardtmpl.TemplateMeta
 	reconcileErr   error
@@ -274,8 +296,9 @@ type fakeCatalogStore struct {
 	reconcileCalls int
 }
 
-func (s *fakeCatalogStore) Publish(_ context.Context, request PublishRequest) (PublishResult, error) {
+func (s *fakeCatalogStore) Publish(ctx context.Context, request PublishRequest) (PublishResult, error) {
 	s.publishCalls++
+	s.publishContext = ctx
 	s.lastPublish = request
 	return s.publishResult, s.publishErr
 }

--- a/modules/card_template_catalog/api_test.go
+++ b/modules/card_template_catalog/api_test.go
@@ -1,0 +1,307 @@
+package card_template_catalog
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl"
+	aireasoningprocess "github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl/ai_reasoning_process"
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
+)
+
+func TestValidateCompilesWithoutPersisting(t *testing.T) {
+	store := &fakeCatalogStore{}
+	compilerCalls := 0
+	api := &API{
+		store: store,
+		compile: func(_ context.Context, bundle cardtmpl.Bundle, _ cardtmpl.CompileLimits) (*cardtmpl.CompiledArtifact, error) {
+			compilerCalls++
+			if bundle.Catalog.Engine != cardtmpl.JSONTemplateEngineV1 {
+				t.Fatalf("compiler bundle engine = %q", bundle.Catalog.Engine)
+			}
+			return compiledArtifactFixture(), nil
+		},
+	}
+
+	response := doCatalogRequest(t, api, wkhttp.SuperAdmin, "/validate", validControlRequestJSON(t, false))
+	if response.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", response.Code, response.Body.String())
+	}
+	if compilerCalls != 1 || store.publishCalls != 0 {
+		t.Fatalf("compiler calls=%d publish calls=%d", compilerCalls, store.publishCalls)
+	}
+	var body map[string]any
+	if err := json.Unmarshal(response.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if body["hash"] != strings.Repeat("a", 64) || body["active"] != false || body["published"] != false {
+		t.Fatalf("validate response = %v", body)
+	}
+}
+
+func TestPublishUsesAuthenticatedActorAndKeepsArtifactInactive(t *testing.T) {
+	store := &fakeCatalogStore{publishResult: PublishResult{Created: true}}
+	api := &API{
+		store: store,
+		compile: func(context.Context, cardtmpl.Bundle, cardtmpl.CompileLimits) (*cardtmpl.CompiledArtifact, error) {
+			return compiledArtifactFixture(), nil
+		},
+	}
+
+	response := doCatalogRequest(t, api, wkhttp.SuperAdmin, "/publish", validControlRequestJSON(t, true))
+	if response.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", response.Code, response.Body.String())
+	}
+	if store.publishCalls != 1 {
+		t.Fatalf("publish calls = %d, want 1", store.publishCalls)
+	}
+	if store.lastPublish.ActorUID != "admin-1" || store.lastPublish.Reason != "reviewed" || store.lastPublish.ChangeTicket != "CHG-1" {
+		t.Fatalf("publish request = %+v", store.lastPublish)
+	}
+	var body map[string]any
+	if err := json.Unmarshal(response.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if body["active"] != false || body["created"] != true {
+		t.Fatalf("publish response = %v", body)
+	}
+}
+
+func TestControlEndpointsRejectNonSuperAdminBeforeCompile(t *testing.T) {
+	compilerCalls := 0
+	api := &API{
+		store: &fakeCatalogStore{},
+		compile: func(context.Context, cardtmpl.Bundle, cardtmpl.CompileLimits) (*cardtmpl.CompiledArtifact, error) {
+			compilerCalls++
+			return compiledArtifactFixture(), nil
+		},
+	}
+	for _, endpoint := range []string{"/validate", "/publish"} {
+		response := doCatalogRequest(t, api, wkhttp.Admin, endpoint, validControlRequestJSON(t, endpoint == "/publish"))
+		assertCatalogError(t, response, "err.server.card_template_catalog.forbidden", http.StatusForbidden)
+	}
+	if compilerCalls != 0 {
+		t.Fatalf("compiler called %d times for forbidden requests", compilerCalls)
+	}
+}
+
+func TestControlEndpointsRejectOversizeAndAmbiguousJSONBeforeCompile(t *testing.T) {
+	compilerCalls := 0
+	api := &API{
+		store: &fakeCatalogStore{},
+		compile: func(context.Context, cardtmpl.Bundle, cardtmpl.CompileLimits) (*cardtmpl.CompiledArtifact, error) {
+			compilerCalls++
+			return compiledArtifactFixture(), nil
+		},
+	}
+
+	t.Run("body limit", func(t *testing.T) {
+		response := doCatalogRequest(t, api, wkhttp.SuperAdmin, "/validate", []byte(strings.Repeat("x", controlBodyMaxBytes+1)))
+		assertCatalogError(t, response, "err.server.card_template_catalog.content_too_large", http.StatusRequestEntityTooLarge)
+	})
+	t.Run("duplicate wrapper key", func(t *testing.T) {
+		valid := validControlRequestJSON(t, false)
+		var request map[string]json.RawMessage
+		if err := json.Unmarshal(valid, &request); err != nil {
+			t.Fatal(err)
+		}
+		ambiguous := append([]byte(`{"bundle":`), request["bundle"]...)
+		ambiguous = append(ambiguous, []byte(`,"bundle":`)...)
+		ambiguous = append(ambiguous, request["bundle"]...)
+		ambiguous = append(ambiguous, '}')
+		response := doCatalogRequest(t, api, wkhttp.SuperAdmin, "/validate", ambiguous)
+		assertCatalogError(t, response, "err.server.card_template_catalog.request_invalid", http.StatusBadRequest)
+	})
+	if compilerCalls != 0 {
+		t.Fatalf("compiler called %d times for rejected bodies", compilerCalls)
+	}
+}
+
+func TestPublishRejectsCallerSuppliedActor(t *testing.T) {
+	api := &API{store: &fakeCatalogStore{}, compile: func(context.Context, cardtmpl.Bundle, cardtmpl.CompileLimits) (*cardtmpl.CompiledArtifact, error) {
+		return compiledArtifactFixture(), nil
+	}}
+	var request map[string]any
+	if err := json.Unmarshal(validControlRequestJSON(t, true), &request); err != nil {
+		t.Fatal(err)
+	}
+	request["actor_uid"] = "spoofed-admin"
+	body, _ := json.Marshal(request)
+	response := doCatalogRequest(t, api, wkhttp.SuperAdmin, "/publish", body)
+	assertCatalogError(t, response, "err.server.card_template_catalog.request_invalid", http.StatusBadRequest)
+}
+
+func TestPublishMapsConflictAndInternalErrors(t *testing.T) {
+	tests := []struct {
+		name       string
+		err        error
+		wantCode   string
+		wantStatus int
+	}{
+		{name: "immutable conflict", err: ErrImmutableVersionConflict, wantCode: "err.server.card_template_catalog.conflict", wantStatus: http.StatusConflict},
+		{name: "store unavailable", err: errors.New("db unavailable"), wantCode: "err.server.card_template_catalog.unavailable", wantStatus: http.StatusServiceUnavailable},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			api := &API{
+				store: &fakeCatalogStore{publishErr: tt.err},
+				compile: func(context.Context, cardtmpl.Bundle, cardtmpl.CompileLimits) (*cardtmpl.CompiledArtifact, error) {
+					return compiledArtifactFixture(), nil
+				},
+			}
+			response := doCatalogRequest(t, api, wkhttp.SuperAdmin, "/publish", validControlRequestJSON(t, true))
+			assertCatalogError(t, response, tt.wantCode, tt.wantStatus)
+		})
+	}
+}
+
+func TestReconcileStaticInventoryUsesFrozenRegistryList(t *testing.T) {
+	registry := cardtmpl.NewRegistry()
+	registry.RegisterJSON(aireasoningprocess.Assets, aireasoningprocess.HandoffRootV2)
+	registry.Freeze()
+	store := &fakeCatalogStore{}
+	if err := reconcileStaticInventory(context.Background(), store, registry); err != nil {
+		t.Fatalf("reconcileStaticInventory: %v", err)
+	}
+	if len(store.reconciled) != 1 || store.reconciled[0].ID != aireasoningprocess.TemplateID || store.reconciled[0].Version != aireasoningprocess.TemplateVersionV2 {
+		t.Fatalf("reconciled inventory = %+v", store.reconciled)
+	}
+}
+
+func TestCatalogNoLegacyErrorResponses(t *testing.T) {
+	files := []string{"api.go", "api_i18n.go"}
+	banned := []string{".ResponseError(", ".ResponseErrorf(", ".ResponseErrorWithStatus(", ".AbortWithStatusJSON(", ".AbortWithStatus("}
+	for _, file := range files {
+		data, err := os.ReadFile(file)
+		if err != nil {
+			t.Fatalf("read %s: %v", file, err)
+		}
+		cleaned := stripLineComments(string(data))
+		for _, token := range banned {
+			if strings.Contains(cleaned, token) {
+				t.Fatalf("%s contains legacy error response %s", file, token)
+			}
+		}
+	}
+}
+
+func doCatalogRequest(t *testing.T, api *API, role wkhttp.UserRole, endpoint string, body []byte) *httptest.ResponseRecorder {
+	t.Helper()
+	route := wkhttp.New()
+	route.SetErrorRenderer(i18n.NewErrorRenderer(i18n.NewLocalizer(i18n.DefaultLanguage)))
+	route.Use(func(c *wkhttp.Context) {
+		c.Set("uid", "admin-1")
+		c.Set("role", string(role))
+	})
+	route.POST("/validate", api.validate)
+	route.POST("/publish", api.publish)
+	request := httptest.NewRequest(http.MethodPost, endpoint, bytes.NewReader(body))
+	request.Header.Set("Content-Type", "application/json")
+	recorder := httptest.NewRecorder()
+	route.ServeHTTP(recorder, request)
+	return recorder
+}
+
+func validControlRequestJSON(t *testing.T, publish bool) []byte {
+	t.Helper()
+	bundle := cardtmpl.Bundle{
+		Catalog: cardtmpl.CatalogDescriptor{Engine: cardtmpl.JSONTemplateEngineV1, Visibility: cardtmpl.CatalogVisibilityPrivate},
+		Manifest: json.RawMessage(`{
+			"schemaVersion":2,"id":"test.runtime-card","name":"Runtime card","version":"1.0.0",
+			"contractVersion":"1.0.0","protocol":"octo-card@1.0","owner":"ai",
+			"dataSchema":"contract/data.schema.json",
+			"views":{"main":{"wireProfile":"octo/v1","states":["shown"],"template":"templates/main.template.json","samples":["samples/shown.json"]}}
+		}`),
+		Schema: json.RawMessage(`{
+			"$schema":"http://json-schema.org/draft-07/schema#","type":"object","additionalProperties":false,
+			"required":["title"],"properties":{"title":{"type":"string","maxLength":32}}
+		}`),
+		Templates: map[string]json.RawMessage{
+			"main": json.RawMessage(`{"type":"AdaptiveCard","version":"1.5","body":[{"type":"TextBlock","text":"${title}"}]}`),
+		},
+		Samples: map[string]json.RawMessage{"shown": json.RawMessage(`{"title":"hello"}`)},
+	}
+	request := map[string]any{"bundle": bundle}
+	if publish {
+		request["reason"] = "reviewed"
+		request["change_ticket"] = "CHG-1"
+	}
+	body, err := json.Marshal(request)
+	if err != nil {
+		t.Fatalf("marshal control request: %v", err)
+	}
+	return body
+}
+
+func compiledArtifactFixture() *cardtmpl.CompiledArtifact {
+	return &cardtmpl.CompiledArtifact{
+		Meta:            cardtmpl.TemplateMeta{ID: "test.runtime-card", Version: "1.0.0", Protocol: cardtmpl.Protocol},
+		Hash:            strings.Repeat("a", 64),
+		Bundle:          cardtmpl.CanonicalBundle(`{"canonical":true}`),
+		Engine:          cardtmpl.JSONTemplateEngineV1,
+		Visibility:      cardtmpl.CatalogVisibilityPrivate,
+		Owner:           "ai",
+		ContractVersion: "1.0.0",
+	}
+}
+
+type fakeCatalogStore struct {
+	publishResult PublishResult
+	publishErr    error
+	publishCalls  int
+	lastPublish   PublishRequest
+	reconciled    []cardtmpl.TemplateMeta
+	reconcileErr  error
+}
+
+func (s *fakeCatalogStore) Publish(_ context.Context, request PublishRequest) (PublishResult, error) {
+	s.publishCalls++
+	s.lastPublish = request
+	return s.publishResult, s.publishErr
+}
+
+func (s *fakeCatalogStore) ReconcileStatic(_ context.Context, inventory []cardtmpl.TemplateMeta) error {
+	s.reconciled = append([]cardtmpl.TemplateMeta(nil), inventory...)
+	return s.reconcileErr
+}
+
+type catalogErrorEnvelope struct {
+	Error struct {
+		Code       string `json:"code"`
+		HTTPStatus int    `json:"http_status"`
+	} `json:"error"`
+}
+
+func assertCatalogError(t *testing.T, response *httptest.ResponseRecorder, wantCode string, wantStatus int) {
+	t.Helper()
+	if response.Code != http.StatusBadRequest {
+		t.Fatalf("transport status = %d, want D14 400; body=%s", response.Code, response.Body.String())
+	}
+	var envelope catalogErrorEnvelope
+	if err := json.Unmarshal(response.Body.Bytes(), &envelope); err != nil {
+		t.Fatalf("decode error envelope: %v body=%s", err, response.Body.String())
+	}
+	if envelope.Error.Code != wantCode || envelope.Error.HTTPStatus != wantStatus {
+		t.Fatalf("error = %+v, want code=%s status=%d", envelope.Error, wantCode, wantStatus)
+	}
+}
+
+func stripLineComments(source string) string {
+	var cleaned strings.Builder
+	for _, line := range strings.Split(source, "\n") {
+		if index := strings.Index(line, "//"); index >= 0 {
+			line = line[:index]
+		}
+		cleaned.WriteString(line)
+		cleaned.WriteByte('\n')
+	}
+	return cleaned.String()
+}

--- a/modules/card_template_catalog/metrics.go
+++ b/modules/card_template_catalog/metrics.go
@@ -1,0 +1,79 @@
+package card_template_catalog
+
+import (
+	"errors"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type catalogMetrics struct {
+	operations *prometheus.CounterVec
+	compile    *prometheus.HistogramVec
+	db         *prometheus.CounterVec
+}
+
+func newCatalogMetrics(registerer prometheus.Registerer) *catalogMetrics {
+	if registerer == nil {
+		registerer = prometheus.DefaultRegisterer
+	}
+	return &catalogMetrics{
+		operations: registerCounterVec(registerer, prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "dmwork_card_catalog_operation_total",
+			Help: "Card template catalog control-plane operations by bounded outcome.",
+		}, []string{"operation", "result"})),
+		compile: registerHistogramVec(registerer, prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Name:    "dmwork_card_catalog_compile_seconds",
+			Help:    "Card template artifact compile duration by bounded outcome.",
+			Buckets: prometheus.DefBuckets,
+		}, []string{"result"})),
+		db: registerCounterVec(registerer, prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "dmwork_card_catalog_db_total",
+			Help: "Card template catalog authoritative database operations by bounded outcome.",
+		}, []string{"operation", "result"})),
+	}
+}
+
+func registerCounterVec(registerer prometheus.Registerer, collector *prometheus.CounterVec) *prometheus.CounterVec {
+	if err := registerer.Register(collector); err != nil {
+		var alreadyRegistered prometheus.AlreadyRegisteredError
+		if errors.As(err, &alreadyRegistered) {
+			if existing, ok := alreadyRegistered.ExistingCollector.(*prometheus.CounterVec); ok {
+				return existing
+			}
+		}
+		panic(err)
+	}
+	return collector
+}
+
+func registerHistogramVec(registerer prometheus.Registerer, collector *prometheus.HistogramVec) *prometheus.HistogramVec {
+	if err := registerer.Register(collector); err != nil {
+		var alreadyRegistered prometheus.AlreadyRegisteredError
+		if errors.As(err, &alreadyRegistered) {
+			if existing, ok := alreadyRegistered.ExistingCollector.(*prometheus.HistogramVec); ok {
+				return existing
+			}
+		}
+		panic(err)
+	}
+	return collector
+}
+
+func (m *catalogMetrics) observeOperation(operation, result string) {
+	if m != nil {
+		m.operations.WithLabelValues(operation, result).Inc()
+	}
+}
+
+func (m *catalogMetrics) observeCompile(result string, duration time.Duration) {
+	if m != nil {
+		m.compile.WithLabelValues(result).Observe(duration.Seconds())
+	}
+}
+
+func (m *catalogMetrics) observeDB(operation, result string) {
+	if m != nil {
+		m.db.WithLabelValues(operation, result).Inc()
+	}
+}

--- a/modules/card_template_catalog/metrics_test.go
+++ b/modules/card_template_catalog/metrics_test.go
@@ -11,6 +11,10 @@ import (
 func TestCatalogMetricsExposeOnlyBoundedLabels(t *testing.T) {
 	registry := prometheus.NewRegistry()
 	metrics := newCatalogMetrics(registry)
+	again := newCatalogMetrics(registry)
+	if again.operations != metrics.operations || again.compile != metrics.compile || again.db != metrics.db {
+		t.Fatal("duplicate registration must reuse the existing collectors")
+	}
 	metrics.observeOperation("validate", "ok")
 	metrics.observeCompile("validation_error", 25*time.Millisecond)
 	metrics.observeDB("publish", "conflict")

--- a/modules/card_template_catalog/metrics_test.go
+++ b/modules/card_template_catalog/metrics_test.go
@@ -1,0 +1,57 @@
+package card_template_catalog
+
+import (
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+)
+
+func TestCatalogMetricsExposeOnlyBoundedLabels(t *testing.T) {
+	registry := prometheus.NewRegistry()
+	metrics := newCatalogMetrics(registry)
+	metrics.observeOperation("validate", "ok")
+	metrics.observeCompile("validation_error", 25*time.Millisecond)
+	metrics.observeDB("publish", "conflict")
+
+	families, err := registry.Gather()
+	if err != nil {
+		t.Fatalf("Gather: %v", err)
+	}
+	want := map[string]bool{
+		"dmwork_card_catalog_operation_total": false,
+		"dmwork_card_catalog_compile_seconds": false,
+		"dmwork_card_catalog_db_total":        false,
+	}
+	for _, family := range families {
+		name := family.GetName()
+		if _, ok := want[name]; !ok {
+			continue
+		}
+		want[name] = true
+		for _, metric := range family.Metric {
+			for _, label := range metric.Label {
+				if !allowedCatalogMetricLabel(name, label) {
+					t.Errorf("metric %s has unexpected/high-cardinality label %s", name, label.GetName())
+				}
+			}
+		}
+	}
+	for name, found := range want {
+		if !found {
+			t.Errorf("metric %s not registered", name)
+		}
+	}
+}
+
+func allowedCatalogMetricLabel(metric string, label *dto.LabelPair) bool {
+	switch metric {
+	case "dmwork_card_catalog_compile_seconds":
+		return label.GetName() == "result"
+	case "dmwork_card_catalog_operation_total", "dmwork_card_catalog_db_total":
+		return label.GetName() == "operation" || label.GetName() == "result"
+	default:
+		return false
+	}
+}

--- a/modules/card_template_catalog/sql/20260728000001_card_template_catalog.sql
+++ b/modules/card_template_catalog/sql/20260728000001_card_template_catalog.sql
@@ -1,0 +1,55 @@
+-- +migrate Up
+
+CREATE TABLE card_template_version_claim (
+    template_id VARCHAR(128) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    version     VARCHAR(64)  CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    source      VARCHAR(8)   CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    created_at  DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    PRIMARY KEY (template_id, version),
+    CONSTRAINT chk_card_template_claim_source CHECK (source IN ('static', 'dynamic'))
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+
+CREATE TABLE card_template_artifact (
+    template_id      VARCHAR(128) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    version          VARCHAR(64)  CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    owner             VARCHAR(64)  CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    visibility        VARCHAR(16)  CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    engine_contract   VARCHAR(64)  CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    protocol          VARCHAR(64)  CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    contract_version  VARCHAR(64)  CHARACTER SET ascii COLLATE ascii_bin NOT NULL DEFAULT '',
+    canonical_bundle  MEDIUMBLOB NOT NULL,
+    content_sha256    CHAR(64) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    created_by        VARCHAR(128) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL,
+    created_at        DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    blocked_at        DATETIME(6) NULL,
+    blocked_by        VARCHAR(128) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NULL,
+    block_reason      VARCHAR(512) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NULL,
+    PRIMARY KEY (template_id, version),
+    KEY idx_card_template_artifact_hash (content_sha256),
+    CONSTRAINT chk_card_template_artifact_visibility CHECK (visibility IN ('public', 'private')),
+    CONSTRAINT fk_card_template_artifact_claim
+        FOREIGN KEY (template_id, version)
+        REFERENCES card_template_version_claim (template_id, version)
+        ON DELETE RESTRICT
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+
+CREATE TABLE card_template_audit (
+    id             BIGINT NOT NULL AUTO_INCREMENT,
+    actor_uid      VARCHAR(128) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL,
+    operation      VARCHAR(32) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    template_id    VARCHAR(128) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    version        VARCHAR(64) CHARACTER SET ascii COLLATE ascii_bin NOT NULL DEFAULT '',
+    content_sha256 CHAR(64) CHARACTER SET ascii COLLATE ascii_bin NOT NULL DEFAULT '',
+    result         VARCHAR(32) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    reason         VARCHAR(512) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL,
+    change_ticket  VARCHAR(128) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL,
+    created_at     DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    PRIMARY KEY (id),
+    KEY idx_card_template_audit_identity (template_id, version, created_at),
+    KEY idx_card_template_audit_actor (actor_uid, created_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+
+-- +migrate Down
+DROP TABLE IF EXISTS card_template_audit;
+DROP TABLE IF EXISTS card_template_artifact;
+DROP TABLE IF EXISTS card_template_version_claim;

--- a/modules/card_template_catalog/store.go
+++ b/modules/card_template_catalog/store.go
@@ -1,0 +1,246 @@
+package card_template_catalog
+
+import (
+	"context"
+	"database/sql"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl"
+	"github.com/go-sql-driver/mysql"
+)
+
+const (
+	claimSourceStatic  = "static"
+	claimSourceDynamic = "dynamic"
+
+	auditOperationPublish = "publish"
+
+	maxActorUIDRunes     = 128
+	maxReasonRunes       = 512
+	maxChangeTicketRunes = 128
+)
+
+var (
+	ErrImmutableVersionConflict = errors.New("card template version already exists with different content")
+	ErrVersionClaimConflict     = errors.New("card template version claim conflicts with source")
+	ErrCatalogIntegrity         = errors.New("card template catalog integrity failure")
+	ErrPublishRequestInvalid    = errors.New("card template publish request invalid")
+)
+
+const (
+	insertClaimSQL = `INSERT INTO card_template_version_claim
+        (template_id, version, source) VALUES (?, ?, ?)`
+	selectPublishedClaimSQL = `SELECT c.source, a.content_sha256, a.blocked_at IS NOT NULL
+        FROM card_template_version_claim c
+        LEFT JOIN card_template_artifact a
+          ON a.template_id = c.template_id AND a.version = c.version
+        WHERE c.template_id = ? AND c.version = ?
+        FOR UPDATE`
+	insertArtifactSQL = `INSERT INTO card_template_artifact
+        (template_id, version, owner, visibility, engine_contract, protocol,
+         contract_version, canonical_bundle, content_sha256, created_by)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+	insertAuditSQL = `INSERT INTO card_template_audit
+        (actor_uid, operation, template_id, version, content_sha256, result, reason, change_ticket)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+	selectStaticClaimSQL = `SELECT c.source,
+        EXISTS(SELECT 1 FROM card_template_artifact a
+               WHERE a.template_id = c.template_id AND a.version = c.version) AS has_artifact
+        FROM card_template_version_claim c
+        WHERE c.template_id = ? AND c.version = ?
+        FOR UPDATE`
+)
+
+type store struct {
+	db *sql.DB
+}
+
+func newStore(db *sql.DB) *store { return &store{db: db} }
+
+type PublishRequest struct {
+	Artifact     *cardtmpl.CompiledArtifact
+	ActorUID     string
+	Reason       string
+	ChangeTicket string
+}
+
+type PublishResult struct {
+	Created    bool
+	Idempotent bool
+	Blocked    bool
+}
+
+func (s *store) Publish(ctx context.Context, request PublishRequest) (PublishResult, error) {
+	if err := validatePublishRequest(request); err != nil {
+		return PublishResult{}, err
+	}
+	artifact := request.Artifact
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return PublishResult{}, fmt.Errorf("card template catalog: begin publish: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	_, err = tx.ExecContext(ctx, insertClaimSQL, string(artifact.Meta.ID), artifact.Meta.Version, claimSourceDynamic)
+	if err != nil {
+		if !isDuplicateKey(err) {
+			return PublishResult{}, fmt.Errorf("card template catalog: claim version: %w", err)
+		}
+		result, resolveErr := s.resolveExistingPublish(ctx, tx, request)
+		if resolveErr != nil {
+			return PublishResult{}, resolveErr
+		}
+		if err := tx.Commit(); err != nil {
+			return PublishResult{}, fmt.Errorf("card template catalog: commit idempotent publish: %w", err)
+		}
+		return result, nil
+	}
+
+	if _, err := tx.ExecContext(ctx, insertArtifactSQL,
+		string(artifact.Meta.ID), artifact.Meta.Version, artifact.Owner, artifact.Visibility,
+		artifact.Engine, artifact.Meta.Protocol, artifact.ContractVersion, []byte(artifact.Bundle),
+		artifact.Hash, request.ActorUID,
+	); err != nil {
+		return PublishResult{}, fmt.Errorf("card template catalog: insert artifact: %w", err)
+	}
+	if err := insertPublishAudit(ctx, tx, request, "created"); err != nil {
+		return PublishResult{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return PublishResult{}, fmt.Errorf("card template catalog: commit publish: %w", err)
+	}
+	return PublishResult{Created: true}, nil
+}
+
+func (s *store) resolveExistingPublish(
+	ctx context.Context,
+	tx *sql.Tx,
+	request PublishRequest,
+) (PublishResult, error) {
+	artifact := request.Artifact
+	var source string
+	var storedHash sql.NullString
+	var blocked bool
+	err := tx.QueryRowContext(ctx, selectPublishedClaimSQL, string(artifact.Meta.ID), artifact.Meta.Version).
+		Scan(&source, &storedHash, &blocked)
+	if err != nil {
+		return PublishResult{}, fmt.Errorf("%w: load existing claim: %v", ErrCatalogIntegrity, err)
+	}
+	if source != claimSourceDynamic {
+		return PublishResult{}, fmt.Errorf("%w: %s@%s is claimed by %s",
+			ErrVersionClaimConflict, artifact.Meta.ID, artifact.Meta.Version, source)
+	}
+	if !storedHash.Valid || storedHash.String == "" {
+		return PublishResult{}, fmt.Errorf("%w: dynamic claim %s@%s has no artifact",
+			ErrCatalogIntegrity, artifact.Meta.ID, artifact.Meta.Version)
+	}
+	if storedHash.String != artifact.Hash {
+		return PublishResult{}, fmt.Errorf("%w: %s@%s", ErrImmutableVersionConflict, artifact.Meta.ID, artifact.Meta.Version)
+	}
+	if err := insertPublishAudit(ctx, tx, request, "idempotent"); err != nil {
+		return PublishResult{}, err
+	}
+	return PublishResult{Idempotent: true, Blocked: blocked}, nil
+}
+
+func insertPublishAudit(ctx context.Context, tx *sql.Tx, request PublishRequest, result string) error {
+	artifact := request.Artifact
+	if _, err := tx.ExecContext(ctx, insertAuditSQL,
+		request.ActorUID, auditOperationPublish, string(artifact.Meta.ID), artifact.Meta.Version,
+		artifact.Hash, result, request.Reason, request.ChangeTicket,
+	); err != nil {
+		return fmt.Errorf("card template catalog: insert publish audit: %w", err)
+	}
+	return nil
+}
+
+func (s *store) ReconcileStatic(ctx context.Context, inventory []cardtmpl.TemplateMeta) error {
+	ordered := append([]cardtmpl.TemplateMeta(nil), inventory...)
+	sort.Slice(ordered, func(i, j int) bool {
+		if ordered[i].ID != ordered[j].ID {
+			return ordered[i].ID < ordered[j].ID
+		}
+		return ordered[i].Version < ordered[j].Version
+	})
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("card template catalog: begin static reconciliation: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	var previous string
+	for _, meta := range ordered {
+		identity := string(meta.ID) + "@" + meta.Version
+		if strings.TrimSpace(string(meta.ID)) == "" || strings.TrimSpace(meta.Version) == "" || identity == previous {
+			return fmt.Errorf("%w: invalid or duplicate static identity %q", ErrCatalogIntegrity, identity)
+		}
+		previous = identity
+		_, err := tx.ExecContext(ctx, insertClaimSQL, string(meta.ID), meta.Version, claimSourceStatic)
+		if err == nil {
+			continue
+		}
+		if !isDuplicateKey(err) {
+			return fmt.Errorf("card template catalog: claim static %s: %w", identity, err)
+		}
+		var source string
+		var hasArtifact bool
+		if err := tx.QueryRowContext(ctx, selectStaticClaimSQL, string(meta.ID), meta.Version).
+			Scan(&source, &hasArtifact); err != nil {
+			return fmt.Errorf("%w: load static claim %s: %v", ErrCatalogIntegrity, identity, err)
+		}
+		if source != claimSourceStatic {
+			return fmt.Errorf("%w: static %s is claimed by %s", ErrVersionClaimConflict, identity, source)
+		}
+		if hasArtifact {
+			return fmt.Errorf("%w: static claim %s unexpectedly has dynamic artifact", ErrCatalogIntegrity, identity)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("card template catalog: commit static reconciliation: %w", err)
+	}
+	return nil
+}
+
+func validatePublishRequest(request PublishRequest) error {
+	artifact := request.Artifact
+	if artifact == nil || strings.TrimSpace(string(artifact.Meta.ID)) == "" || strings.TrimSpace(artifact.Meta.Version) == "" {
+		return fmt.Errorf("%w: artifact identity is required", ErrPublishRequestInvalid)
+	}
+	if artifact.Engine != cardtmpl.JSONTemplateEngineV1 ||
+		(artifact.Visibility != cardtmpl.CatalogVisibilityPublic && artifact.Visibility != cardtmpl.CatalogVisibilityPrivate) ||
+		strings.TrimSpace(artifact.Owner) == "" || artifact.Meta.Protocol != cardtmpl.Protocol {
+		return fmt.Errorf("%w: artifact metadata is invalid", ErrPublishRequestInvalid)
+	}
+	decodedHash, err := hex.DecodeString(artifact.Hash)
+	if err != nil || len(decodedHash) != sha256Bytes || strings.ToLower(artifact.Hash) != artifact.Hash {
+		return fmt.Errorf("%w: artifact hash is invalid", ErrPublishRequestInvalid)
+	}
+	if len(artifact.Bundle) == 0 || len(artifact.Bundle) > maxCanonicalBundleBytes {
+		return fmt.Errorf("%w: canonical bundle size is invalid", ErrPublishRequestInvalid)
+	}
+	if !boundedRequiredText(request.ActorUID, maxActorUIDRunes) ||
+		!boundedRequiredText(request.Reason, maxReasonRunes) ||
+		!boundedRequiredText(request.ChangeTicket, maxChangeTicketRunes) {
+		return fmt.Errorf("%w: actor, reason, and change_ticket are required and bounded", ErrPublishRequestInvalid)
+	}
+	return nil
+}
+
+const (
+	sha256Bytes             = 32
+	maxCanonicalBundleBytes = 2 << 20
+)
+
+func boundedRequiredText(value string, maxRunes int) bool {
+	trimmed := strings.TrimSpace(value)
+	return trimmed != "" && trimmed == value && len([]rune(value)) <= maxRunes
+}
+
+func isDuplicateKey(err error) bool {
+	var mysqlErr *mysql.MySQLError
+	return errors.As(err, &mysqlErr) && mysqlErr.Number == 1062
+}

--- a/modules/card_template_catalog/store.go
+++ b/modules/card_template_catalog/store.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl"
 	"github.com/go-sql-driver/mysql"
@@ -22,6 +23,9 @@ const (
 	maxActorUIDRunes     = 128
 	maxReasonRunes       = 512
 	maxChangeTicketRunes = 128
+
+	publishAttempts   = 3
+	publishRetryDelay = 50 * time.Millisecond
 )
 
 var (
@@ -81,6 +85,24 @@ func (s *store) Publish(ctx context.Context, request PublishRequest) (PublishRes
 	if err := validatePublishRequest(request); err != nil {
 		return PublishResult{}, err
 	}
+	var lastErr error
+	for attempt := 1; attempt <= publishAttempts; attempt++ {
+		result, err := s.publishOnce(ctx, request)
+		if err == nil {
+			return result, nil
+		}
+		lastErr = err
+		if !isTransientPublishError(err) || attempt == publishAttempts {
+			return PublishResult{}, err
+		}
+		if err := waitForPublishRetry(ctx, publishRetryDelay*time.Duration(1<<(attempt-1))); err != nil {
+			return PublishResult{}, err
+		}
+	}
+	return PublishResult{}, lastErr
+}
+
+func (s *store) publishOnce(ctx context.Context, request PublishRequest) (PublishResult, error) {
 	artifact := request.Artifact
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
@@ -119,6 +141,25 @@ func (s *store) Publish(ctx context.Context, request PublishRequest) (PublishRes
 	return PublishResult{Created: true}, nil
 }
 
+func isTransientPublishError(err error) bool {
+	var mysqlErr *mysql.MySQLError
+	if !errors.As(err, &mysqlErr) {
+		return false
+	}
+	return mysqlErr.Number == 1205 || mysqlErr.Number == 1213
+}
+
+func waitForPublishRetry(ctx context.Context, delay time.Duration) error {
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
 func (s *store) resolveExistingPublish(
 	ctx context.Context,
 	tx *sql.Tx,
@@ -131,7 +172,10 @@ func (s *store) resolveExistingPublish(
 	err := tx.QueryRowContext(ctx, selectPublishedClaimSQL, string(artifact.Meta.ID), artifact.Meta.Version).
 		Scan(&source, &storedHash, &blocked)
 	if err != nil {
-		return PublishResult{}, fmt.Errorf("%w: load existing claim: %v", ErrCatalogIntegrity, err)
+		if errors.Is(err, sql.ErrNoRows) {
+			return PublishResult{}, fmt.Errorf("%w: load existing claim: %w", ErrCatalogIntegrity, err)
+		}
+		return PublishResult{}, fmt.Errorf("card template catalog: load existing claim: %w", err)
 	}
 	if source != claimSourceDynamic {
 		return PublishResult{}, fmt.Errorf("%w: %s@%s is claimed by %s",

--- a/modules/card_template_catalog/store.go
+++ b/modules/card_template_catalog/store.go
@@ -34,6 +34,9 @@ var (
 const (
 	insertClaimSQL = `INSERT INTO card_template_version_claim
         (template_id, version, source) VALUES (?, ?, ?)`
+	upsertStaticClaimSQL = `INSERT INTO card_template_version_claim
+        (template_id, version, source) VALUES (?, ?, ?)
+        ON DUPLICATE KEY UPDATE source = source`
 	selectPublishedClaimSQL = `SELECT c.source, a.content_sha256, a.blocked_at IS NOT NULL
         FROM card_template_version_claim c
         LEFT JOIN card_template_artifact a
@@ -179,18 +182,14 @@ func (s *store) ReconcileStatic(ctx context.Context, inventory []cardtmpl.Templa
 			return fmt.Errorf("%w: invalid or duplicate static identity %q", ErrCatalogIntegrity, identity)
 		}
 		previous = identity
-		_, err := tx.ExecContext(ctx, insertClaimSQL, string(meta.ID), meta.Version, claimSourceStatic)
-		if err == nil {
-			continue
-		}
-		if !isDuplicateKey(err) {
+		if _, err := tx.ExecContext(ctx, upsertStaticClaimSQL, string(meta.ID), meta.Version, claimSourceStatic); err != nil {
 			return fmt.Errorf("card template catalog: claim static %s: %w", identity, err)
 		}
 		var source string
 		var hasArtifact bool
 		if err := tx.QueryRowContext(ctx, selectStaticClaimSQL, string(meta.ID), meta.Version).
 			Scan(&source, &hasArtifact); err != nil {
-			return fmt.Errorf("%w: load static claim %s: %v", ErrCatalogIntegrity, identity, err)
+			return fmt.Errorf("card template catalog: load static claim %s: %w", identity, err)
 		}
 		if source != claimSourceStatic {
 			return fmt.Errorf("%w: static %s is claimed by %s", ErrVersionClaimConflict, identity, source)

--- a/modules/card_template_catalog/store.go
+++ b/modules/card_template_catalog/store.go
@@ -117,6 +117,16 @@ func (s *store) publishOnce(ctx context.Context, request PublishRequest) (Publis
 		}
 		result, resolveErr := s.resolveExistingPublish(ctx, tx, request)
 		if resolveErr != nil {
+			auditResult, auditable := rejectedPublishAuditResult(resolveErr)
+			if !auditable {
+				return PublishResult{}, resolveErr
+			}
+			if err := insertPublishAudit(ctx, tx, request, auditResult); err != nil {
+				return PublishResult{}, err
+			}
+			if err := tx.Commit(); err != nil {
+				return PublishResult{}, fmt.Errorf("card template catalog: commit rejected publish audit: %w", err)
+			}
 			return PublishResult{}, resolveErr
 		}
 		if err := tx.Commit(); err != nil {
@@ -139,6 +149,17 @@ func (s *store) publishOnce(ctx context.Context, request PublishRequest) (Publis
 		return PublishResult{}, fmt.Errorf("card template catalog: commit publish: %w", err)
 	}
 	return PublishResult{Created: true}, nil
+}
+
+func rejectedPublishAuditResult(err error) (string, bool) {
+	switch {
+	case errors.Is(err, ErrImmutableVersionConflict):
+		return "immutable_conflict", true
+	case errors.Is(err, ErrVersionClaimConflict):
+		return "source_conflict", true
+	default:
+		return "", false
+	}
 }
 
 func isTransientPublishError(err error) bool {

--- a/modules/card_template_catalog/store_test.go
+++ b/modules/card_template_catalog/store_test.go
@@ -1,0 +1,221 @@
+package card_template_catalog
+
+import (
+	"context"
+	"errors"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl"
+	"github.com/go-sql-driver/mysql"
+)
+
+func TestStorePublishCreatesClaimArtifactAndAuditAtomically(t *testing.T) {
+	store, mock, closeDB := newMockStore(t)
+	defer closeDB()
+
+	mock.ExpectBegin()
+	mock.ExpectExec(regexp.QuoteMeta("INSERT INTO card_template_version_claim")).
+		WithArgs("test.runtime-card", "1.0.0", claimSourceDynamic).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec(regexp.QuoteMeta("INSERT INTO card_template_artifact")).
+		WithArgs(
+			"test.runtime-card", "1.0.0", "ai", "private", "octo-json-template/v1",
+			"octo-card@1.0", "1.0.0", []byte(`{"canonical":true}`), strings.Repeat("a", 64), "admin-1",
+		).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec(regexp.QuoteMeta("INSERT INTO card_template_audit")).
+		WithArgs("admin-1", auditOperationPublish, "test.runtime-card", "1.0.0", strings.Repeat("a", 64), "created", "reviewed", "CHG-1").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectCommit()
+
+	result, err := store.Publish(context.Background(), publishRequestFixture())
+	if err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	if !result.Created || result.Idempotent {
+		t.Fatalf("result = %+v, want created", result)
+	}
+	assertMockExpectations(t, mock)
+}
+
+func TestStorePublishSameHashIsIdempotentAndAudited(t *testing.T) {
+	store, mock, closeDB := newMockStore(t)
+	defer closeDB()
+
+	mock.ExpectBegin()
+	mock.ExpectExec(regexp.QuoteMeta("INSERT INTO card_template_version_claim")).
+		WithArgs("test.runtime-card", "1.0.0", claimSourceDynamic).
+		WillReturnError(&mysql.MySQLError{Number: 1062, Message: "duplicate"})
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT c.source, a.content_sha256, a.blocked_at IS NOT NULL")).
+		WithArgs("test.runtime-card", "1.0.0").
+		WillReturnRows(sqlmock.NewRows([]string{"source", "content_sha256", "blocked"}).
+			AddRow(claimSourceDynamic, strings.Repeat("a", 64), false))
+	mock.ExpectExec(regexp.QuoteMeta("INSERT INTO card_template_audit")).
+		WithArgs("admin-1", auditOperationPublish, "test.runtime-card", "1.0.0", strings.Repeat("a", 64), "idempotent", "reviewed", "CHG-1").
+		WillReturnResult(sqlmock.NewResult(2, 1))
+	mock.ExpectCommit()
+
+	result, err := store.Publish(context.Background(), publishRequestFixture())
+	if err != nil {
+		t.Fatalf("Publish idempotent: %v", err)
+	}
+	if result.Created || !result.Idempotent || result.Blocked {
+		t.Fatalf("result = %+v, want unblocked idempotent", result)
+	}
+	assertMockExpectations(t, mock)
+}
+
+func TestStorePublishRejectsImmutableAndStaticConflicts(t *testing.T) {
+	tests := []struct {
+		name       string
+		source     string
+		storedHash any
+		want       error
+	}{
+		{name: "different dynamic hash", source: claimSourceDynamic, storedHash: strings.Repeat("b", 64), want: ErrImmutableVersionConflict},
+		{name: "static claim", source: claimSourceStatic, storedHash: nil, want: ErrVersionClaimConflict},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store, mock, closeDB := newMockStore(t)
+			defer closeDB()
+
+			mock.ExpectBegin()
+			mock.ExpectExec(regexp.QuoteMeta("INSERT INTO card_template_version_claim")).
+				WithArgs("test.runtime-card", "1.0.0", claimSourceDynamic).
+				WillReturnError(&mysql.MySQLError{Number: 1062, Message: "duplicate"})
+			mock.ExpectQuery(regexp.QuoteMeta("SELECT c.source, a.content_sha256, a.blocked_at IS NOT NULL")).
+				WithArgs("test.runtime-card", "1.0.0").
+				WillReturnRows(sqlmock.NewRows([]string{"source", "content_sha256", "blocked"}).
+					AddRow(tt.source, tt.storedHash, false))
+			mock.ExpectRollback()
+
+			_, err := store.Publish(context.Background(), publishRequestFixture())
+			if !errors.Is(err, tt.want) {
+				t.Fatalf("Publish error = %v, want %v", err, tt.want)
+			}
+			assertMockExpectations(t, mock)
+		})
+	}
+}
+
+func TestStorePublishRollsBackWhenAuditFails(t *testing.T) {
+	store, mock, closeDB := newMockStore(t)
+	defer closeDB()
+
+	mock.ExpectBegin()
+	mock.ExpectExec(regexp.QuoteMeta("INSERT INTO card_template_version_claim")).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec(regexp.QuoteMeta("INSERT INTO card_template_artifact")).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec(regexp.QuoteMeta("INSERT INTO card_template_audit")).
+		WillReturnError(errors.New("audit unavailable"))
+	mock.ExpectRollback()
+
+	if _, err := store.Publish(context.Background(), publishRequestFixture()); err == nil || !strings.Contains(err.Error(), "audit") {
+		t.Fatalf("Publish error = %v, want audit failure", err)
+	}
+	assertMockExpectations(t, mock)
+}
+
+func TestStoreReconcileStaticInventoryClaimsExactVersions(t *testing.T) {
+	store, mock, closeDB := newMockStore(t)
+	defer closeDB()
+
+	mock.ExpectBegin()
+	mock.ExpectExec(regexp.QuoteMeta("INSERT INTO card_template_version_claim")).
+		WithArgs("ai.reasoning-process", "0.2.0", claimSourceStatic).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectCommit()
+
+	err := store.ReconcileStatic(context.Background(), []cardtmpl.TemplateMeta{{
+		ID: "ai.reasoning-process", Version: "0.2.0",
+	}})
+	if err != nil {
+		t.Fatalf("ReconcileStatic: %v", err)
+	}
+	assertMockExpectations(t, mock)
+}
+
+func TestStoreReconcileStaticRejectsDynamicClaim(t *testing.T) {
+	store, mock, closeDB := newMockStore(t)
+	defer closeDB()
+
+	mock.ExpectBegin()
+	mock.ExpectExec(regexp.QuoteMeta("INSERT INTO card_template_version_claim")).
+		WithArgs("ai.reasoning-process", "0.2.0", claimSourceStatic).
+		WillReturnError(&mysql.MySQLError{Number: 1062, Message: "duplicate"})
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT c.source, EXISTS(SELECT 1 FROM card_template_artifact")).
+		WithArgs("ai.reasoning-process", "0.2.0").
+		WillReturnRows(sqlmock.NewRows([]string{"source", "has_artifact"}).AddRow(claimSourceDynamic, true))
+	mock.ExpectRollback()
+
+	err := store.ReconcileStatic(context.Background(), []cardtmpl.TemplateMeta{{
+		ID: "ai.reasoning-process", Version: "0.2.0",
+	}})
+	if !errors.Is(err, ErrVersionClaimConflict) {
+		t.Fatalf("ReconcileStatic error = %v, want ErrVersionClaimConflict", err)
+	}
+	assertMockExpectations(t, mock)
+}
+
+func TestCatalogMigrationDefinesImmutableCaseSensitiveTables(t *testing.T) {
+	raw, err := sqlFS.ReadFile("sql/20260728000001_card_template_catalog.sql")
+	if err != nil {
+		t.Fatalf("read migration: %v", err)
+	}
+	sqlText := string(raw)
+	for _, required := range []string{
+		"CREATE TABLE card_template_version_claim",
+		"CREATE TABLE card_template_artifact",
+		"CREATE TABLE card_template_audit",
+		"COLLATE ascii_bin",
+		"MEDIUMBLOB NOT NULL",
+		"FOREIGN KEY (template_id, version)",
+	} {
+		if !strings.Contains(sqlText, required) {
+			t.Errorf("migration missing %q", required)
+		}
+	}
+	if strings.Contains(strings.ToUpper(sqlText), "ON UPDATE CASCADE") {
+		t.Fatal("immutable identity must not have ON UPDATE CASCADE")
+	}
+}
+
+func newMockStore(t *testing.T) (*store, sqlmock.Sqlmock, func()) {
+	t.Helper()
+	rawDB, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherRegexp))
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	return newStore(rawDB), mock, func() { _ = rawDB.Close() }
+}
+
+func publishRequestFixture() PublishRequest {
+	return PublishRequest{
+		Artifact: &cardtmpl.CompiledArtifact{
+			Meta: cardtmpl.TemplateMeta{
+				ID: "test.runtime-card", Version: "1.0.0", Protocol: cardtmpl.Protocol,
+			},
+			Hash:            strings.Repeat("a", 64),
+			Bundle:          cardtmpl.CanonicalBundle(`{"canonical":true}`),
+			Engine:          cardtmpl.JSONTemplateEngineV1,
+			Visibility:      cardtmpl.CatalogVisibilityPrivate,
+			Owner:           "ai",
+			ContractVersion: "1.0.0",
+		},
+		ActorUID:     "admin-1",
+		Reason:       "reviewed",
+		ChangeTicket: "CHG-1",
+	}
+}
+
+func assertMockExpectations(t *testing.T, mock sqlmock.Sqlmock) {
+	t.Helper()
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/modules/card_template_catalog/store_test.go
+++ b/modules/card_template_catalog/store_test.go
@@ -162,6 +162,87 @@ func TestStoreReconcileStaticRejectsDynamicClaim(t *testing.T) {
 	assertMockExpectations(t, mock)
 }
 
+func TestStoreReconcileStaticAcceptsExistingStaticClaim(t *testing.T) {
+	store, mock, closeDB := newMockStore(t)
+	defer closeDB()
+
+	mock.ExpectBegin()
+	mock.ExpectExec(regexp.QuoteMeta("INSERT INTO card_template_version_claim")).
+		WithArgs("ai.reasoning-process", "0.2.0", claimSourceStatic).
+		WillReturnError(&mysql.MySQLError{Number: 1062, Message: "duplicate"})
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT c.source, EXISTS(SELECT 1 FROM card_template_artifact")).
+		WithArgs("ai.reasoning-process", "0.2.0").
+		WillReturnRows(sqlmock.NewRows([]string{"source", "has_artifact"}).AddRow(claimSourceStatic, false))
+	mock.ExpectCommit()
+
+	err := store.ReconcileStatic(context.Background(), []cardtmpl.TemplateMeta{{
+		ID: "ai.reasoning-process", Version: "0.2.0",
+	}})
+	if err != nil {
+		t.Fatalf("ReconcileStatic existing claim: %v", err)
+	}
+	assertMockExpectations(t, mock)
+}
+
+func TestValidatePublishRequestRejectsMalformedInputs(t *testing.T) {
+	valid := publishRequestFixture()
+	if err := validatePublishRequest(valid); err != nil {
+		t.Fatalf("valid request rejected: %v", err)
+	}
+	tests := []struct {
+		name   string
+		mutate func(*PublishRequest)
+	}{
+		{name: "nil artifact", mutate: func(request *PublishRequest) { request.Artifact = nil }},
+		{name: "unknown engine", mutate: func(request *PublishRequest) { request.Artifact.Engine = "unknown/v1" }},
+		{name: "bad hash", mutate: func(request *PublishRequest) { request.Artifact.Hash = "not-sha256" }},
+		{name: "uppercase hash", mutate: func(request *PublishRequest) { request.Artifact.Hash = strings.Repeat("A", 64) }},
+		{name: "empty bundle", mutate: func(request *PublishRequest) { request.Artifact.Bundle = nil }},
+		{name: "missing actor", mutate: func(request *PublishRequest) { request.ActorUID = "" }},
+		{name: "untrimmed reason", mutate: func(request *PublishRequest) { request.Reason = " reviewed " }},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			request := publishRequestFixture()
+			artifactCopy := *request.Artifact
+			request.Artifact = &artifactCopy
+			tt.mutate(&request)
+			if err := validatePublishRequest(request); !errors.Is(err, ErrPublishRequestInvalid) {
+				t.Fatalf("error = %v, want ErrPublishRequestInvalid", err)
+			}
+		})
+	}
+}
+
+func TestStorePublishReturnsTransactionErrors(t *testing.T) {
+	t.Run("begin", func(t *testing.T) {
+		store, mock, closeDB := newMockStore(t)
+		defer closeDB()
+		mock.ExpectBegin().WillReturnError(errors.New("begin unavailable"))
+		if _, err := store.Publish(context.Background(), publishRequestFixture()); err == nil || !strings.Contains(err.Error(), "begin") {
+			t.Fatalf("error = %v", err)
+		}
+		assertMockExpectations(t, mock)
+	})
+
+	t.Run("commit", func(t *testing.T) {
+		store, mock, closeDB := newMockStore(t)
+		defer closeDB()
+		mock.ExpectBegin()
+		mock.ExpectExec(regexp.QuoteMeta("INSERT INTO card_template_version_claim")).
+			WillReturnResult(sqlmock.NewResult(1, 1))
+		mock.ExpectExec(regexp.QuoteMeta("INSERT INTO card_template_artifact")).
+			WillReturnResult(sqlmock.NewResult(1, 1))
+		mock.ExpectExec(regexp.QuoteMeta("INSERT INTO card_template_audit")).
+			WillReturnResult(sqlmock.NewResult(1, 1))
+		mock.ExpectCommit().WillReturnError(errors.New("commit unavailable"))
+		if _, err := store.Publish(context.Background(), publishRequestFixture()); err == nil || !strings.Contains(err.Error(), "commit") {
+			t.Fatalf("error = %v", err)
+		}
+		assertMockExpectations(t, mock)
+	})
+}
+
 func TestCatalogMigrationDefinesImmutableCaseSensitiveTables(t *testing.T) {
 	raw, err := sqlFS.ReadFile("sql/20260728000001_card_template_catalog.sql")
 	if err != nil {

--- a/modules/card_template_catalog/store_test.go
+++ b/modules/card_template_catalog/store_test.go
@@ -126,9 +126,12 @@ func TestStoreReconcileStaticInventoryClaimsExactVersions(t *testing.T) {
 	defer closeDB()
 
 	mock.ExpectBegin()
-	mock.ExpectExec(regexp.QuoteMeta("INSERT INTO card_template_version_claim")).
+	mock.ExpectExec(staticClaimUpsertPattern).
 		WithArgs("ai.reasoning-process", "0.2.0", claimSourceStatic).
 		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT c.source, EXISTS(SELECT 1 FROM card_template_artifact")).
+		WithArgs("ai.reasoning-process", "0.2.0").
+		WillReturnRows(sqlmock.NewRows([]string{"source", "has_artifact"}).AddRow(claimSourceStatic, false))
 	mock.ExpectCommit()
 
 	err := store.ReconcileStatic(context.Background(), []cardtmpl.TemplateMeta{{
@@ -145,9 +148,9 @@ func TestStoreReconcileStaticRejectsDynamicClaim(t *testing.T) {
 	defer closeDB()
 
 	mock.ExpectBegin()
-	mock.ExpectExec(regexp.QuoteMeta("INSERT INTO card_template_version_claim")).
+	mock.ExpectExec(staticClaimUpsertPattern).
 		WithArgs("ai.reasoning-process", "0.2.0", claimSourceStatic).
-		WillReturnError(&mysql.MySQLError{Number: 1062, Message: "duplicate"})
+		WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT c.source, EXISTS(SELECT 1 FROM card_template_artifact")).
 		WithArgs("ai.reasoning-process", "0.2.0").
 		WillReturnRows(sqlmock.NewRows([]string{"source", "has_artifact"}).AddRow(claimSourceDynamic, true))
@@ -167,9 +170,9 @@ func TestStoreReconcileStaticAcceptsExistingStaticClaim(t *testing.T) {
 	defer closeDB()
 
 	mock.ExpectBegin()
-	mock.ExpectExec(regexp.QuoteMeta("INSERT INTO card_template_version_claim")).
+	mock.ExpectExec(staticClaimUpsertPattern).
 		WithArgs("ai.reasoning-process", "0.2.0", claimSourceStatic).
-		WillReturnError(&mysql.MySQLError{Number: 1062, Message: "duplicate"})
+		WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT c.source, EXISTS(SELECT 1 FROM card_template_artifact")).
 		WithArgs("ai.reasoning-process", "0.2.0").
 		WillReturnRows(sqlmock.NewRows([]string{"source", "has_artifact"}).AddRow(claimSourceStatic, false))
@@ -300,3 +303,5 @@ func assertMockExpectations(t *testing.T, mock sqlmock.Sqlmock) {
 		t.Fatal(err)
 	}
 }
+
+const staticClaimUpsertPattern = `INSERT INTO card_template_version_claim[\s\S]+ON DUPLICATE KEY UPDATE source = source`

--- a/modules/card_template_catalog/store_test.go
+++ b/modules/card_template_catalog/store_test.go
@@ -2,6 +2,7 @@ package card_template_catalog
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"regexp"
 	"strings"
@@ -64,6 +65,72 @@ func TestStorePublishSameHashIsIdempotentAndAudited(t *testing.T) {
 	}
 	if result.Created || !result.Idempotent || result.Blocked {
 		t.Fatalf("result = %+v, want unblocked idempotent", result)
+	}
+	assertMockExpectations(t, mock)
+}
+
+func TestStorePublishClassifiesExistingClaimLookupErrors(t *testing.T) {
+	tests := []struct {
+		name          string
+		lookupErr     error
+		wantIntegrity bool
+	}{
+		{name: "claim disappeared", lookupErr: sql.ErrNoRows, wantIntegrity: true},
+		{name: "request deadline", lookupErr: context.DeadlineExceeded, wantIntegrity: false},
+		{name: "connection dropped", lookupErr: errors.New("connection dropped"), wantIntegrity: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store, mock, closeDB := newMockStore(t)
+			defer closeDB()
+
+			mock.ExpectBegin()
+			mock.ExpectExec(regexp.QuoteMeta("INSERT INTO card_template_version_claim")).
+				WillReturnError(&mysql.MySQLError{Number: 1062, Message: "duplicate"})
+			mock.ExpectQuery(regexp.QuoteMeta("SELECT c.source, a.content_sha256, a.blocked_at IS NOT NULL")).
+				WillReturnError(tt.lookupErr)
+			mock.ExpectRollback()
+
+			_, err := store.Publish(context.Background(), publishRequestFixture())
+			if got := errors.Is(err, ErrCatalogIntegrity); got != tt.wantIntegrity {
+				t.Fatalf("errors.Is(ErrCatalogIntegrity) = %v, want %v; err=%v", got, tt.wantIntegrity, err)
+			}
+			if !tt.wantIntegrity && !errors.Is(err, tt.lookupErr) {
+				t.Fatalf("lookup cause was not preserved: %v", err)
+			}
+			assertMockExpectations(t, mock)
+		})
+	}
+}
+
+func TestStorePublishRetriesTransientDuplicateResolutionFailure(t *testing.T) {
+	store, mock, closeDB := newMockStore(t)
+	defer closeDB()
+	deadlock := &mysql.MySQLError{Number: 1213, Message: "deadlock"}
+
+	mock.ExpectBegin()
+	mock.ExpectExec(regexp.QuoteMeta("INSERT INTO card_template_version_claim")).
+		WillReturnError(&mysql.MySQLError{Number: 1062, Message: "duplicate"})
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT c.source, a.content_sha256, a.blocked_at IS NOT NULL")).
+		WillReturnError(deadlock)
+	mock.ExpectRollback()
+
+	mock.ExpectBegin()
+	mock.ExpectExec(regexp.QuoteMeta("INSERT INTO card_template_version_claim")).
+		WillReturnError(&mysql.MySQLError{Number: 1062, Message: "duplicate"})
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT c.source, a.content_sha256, a.blocked_at IS NOT NULL")).
+		WillReturnRows(sqlmock.NewRows([]string{"source", "content_sha256", "blocked"}).
+			AddRow(claimSourceDynamic, strings.Repeat("a", 64), false))
+	mock.ExpectExec(regexp.QuoteMeta("INSERT INTO card_template_audit")).
+		WillReturnResult(sqlmock.NewResult(2, 1))
+	mock.ExpectCommit()
+
+	result, err := store.Publish(context.Background(), publishRequestFixture())
+	if err != nil {
+		t.Fatalf("Publish after transient deadlock: %v", err)
+	}
+	if !result.Idempotent {
+		t.Fatalf("result = %+v, want idempotent", result)
 	}
 	assertMockExpectations(t, mock)
 }

--- a/modules/card_template_catalog/store_test.go
+++ b/modules/card_template_catalog/store_test.go
@@ -137,13 +137,14 @@ func TestStorePublishRetriesTransientDuplicateResolutionFailure(t *testing.T) {
 
 func TestStorePublishRejectsImmutableAndStaticConflicts(t *testing.T) {
 	tests := []struct {
-		name       string
-		source     string
-		storedHash any
-		want       error
+		name        string
+		source      string
+		storedHash  any
+		want        error
+		auditResult string
 	}{
-		{name: "different dynamic hash", source: claimSourceDynamic, storedHash: strings.Repeat("b", 64), want: ErrImmutableVersionConflict},
-		{name: "static claim", source: claimSourceStatic, storedHash: nil, want: ErrVersionClaimConflict},
+		{name: "different dynamic hash", source: claimSourceDynamic, storedHash: strings.Repeat("b", 64), want: ErrImmutableVersionConflict, auditResult: "immutable_conflict"},
+		{name: "static claim", source: claimSourceStatic, storedHash: nil, want: ErrVersionClaimConflict, auditResult: "source_conflict"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -158,7 +159,10 @@ func TestStorePublishRejectsImmutableAndStaticConflicts(t *testing.T) {
 				WithArgs("test.runtime-card", "1.0.0").
 				WillReturnRows(sqlmock.NewRows([]string{"source", "content_sha256", "blocked"}).
 					AddRow(tt.source, tt.storedHash, false))
-			mock.ExpectRollback()
+			mock.ExpectExec(regexp.QuoteMeta("INSERT INTO card_template_audit")).
+				WithArgs("admin-1", auditOperationPublish, "test.runtime-card", "1.0.0", strings.Repeat("a", 64), tt.auditResult, "reviewed", "CHG-1").
+				WillReturnResult(sqlmock.NewResult(1, 1))
+			mock.ExpectCommit()
 
 			_, err := store.Publish(context.Background(), publishRequestFixture())
 			if !errors.Is(err, tt.want) {
@@ -184,6 +188,51 @@ func TestStorePublishRollsBackWhenAuditFails(t *testing.T) {
 
 	if _, err := store.Publish(context.Background(), publishRequestFixture()); err == nil || !strings.Contains(err.Error(), "audit") {
 		t.Fatalf("Publish error = %v, want audit failure", err)
+	}
+	assertMockExpectations(t, mock)
+}
+
+func TestStorePublishRejectedConflictRollsBackWhenAuditFails(t *testing.T) {
+	store, mock, closeDB := newMockStore(t)
+	defer closeDB()
+
+	mock.ExpectBegin()
+	mock.ExpectExec(regexp.QuoteMeta("INSERT INTO card_template_version_claim")).
+		WillReturnError(&mysql.MySQLError{Number: 1062, Message: "duplicate"})
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT c.source, a.content_sha256, a.blocked_at IS NOT NULL")).
+		WillReturnRows(sqlmock.NewRows([]string{"source", "content_sha256", "blocked"}).
+			AddRow(claimSourceDynamic, strings.Repeat("b", 64), false))
+	mock.ExpectExec(regexp.QuoteMeta("INSERT INTO card_template_audit")).
+		WillReturnError(errors.New("audit unavailable"))
+	mock.ExpectRollback()
+
+	_, err := store.Publish(context.Background(), publishRequestFixture())
+	if err == nil || !strings.Contains(err.Error(), "audit") {
+		t.Fatalf("Publish error = %v, want audit failure", err)
+	}
+	if errors.Is(err, ErrImmutableVersionConflict) {
+		t.Fatalf("audit failure was hidden by immutable conflict: %v", err)
+	}
+	assertMockExpectations(t, mock)
+}
+
+func TestStorePublishRejectedConflictReportsAuditCommitFailure(t *testing.T) {
+	store, mock, closeDB := newMockStore(t)
+	defer closeDB()
+
+	mock.ExpectBegin()
+	mock.ExpectExec(regexp.QuoteMeta("INSERT INTO card_template_version_claim")).
+		WillReturnError(&mysql.MySQLError{Number: 1062, Message: "duplicate"})
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT c.source, a.content_sha256, a.blocked_at IS NOT NULL")).
+		WillReturnRows(sqlmock.NewRows([]string{"source", "content_sha256", "blocked"}).
+			AddRow(claimSourceDynamic, strings.Repeat("b", 64), false))
+	mock.ExpectExec(regexp.QuoteMeta("INSERT INTO card_template_audit")).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectCommit().WillReturnError(errors.New("commit unavailable"))
+
+	_, err := store.Publish(context.Background(), publishRequestFixture())
+	if err == nil || !strings.Contains(err.Error(), "commit rejected publish audit") {
+		t.Fatalf("Publish error = %v, want rejected-audit commit failure", err)
 	}
 	assertMockExpectations(t, mock)
 }

--- a/pkg/cardtmpl/json_artifact.go
+++ b/pkg/cardtmpl/json_artifact.go
@@ -1170,8 +1170,12 @@ func (v *boundedSchemaValidator) validateNode(value any, location string) error 
 				if _, err := positiveJSONInt(node["maxItems"]); err != nil {
 					return fmt.Errorf("%s array is unbounded", location)
 				}
-				if _, ok := node["items"].(map[string]any); !ok {
+				items, exists := node["items"]
+				if !exists {
 					return fmt.Errorf("%s array items schema missing", location)
+				}
+				if err := v.validatePropertySchema(items, location+".items"); err != nil {
+					return err
 				}
 			case "object":
 				if additional, ok := node["additionalProperties"].(bool); !ok || additional {

--- a/pkg/cardtmpl/json_artifact.go
+++ b/pkg/cardtmpl/json_artifact.go
@@ -46,6 +46,7 @@ var (
 	artifactDocumentKeyRE  = regexp.MustCompile(`^[a-z][a-z0-9_.-]{0,63}$`)
 	artifactTemplateIDRE   = regexp.MustCompile(`^[a-z][a-z0-9]*(?:[.-][a-z0-9][a-z0-9-]*)+$`)
 	artifactVersionRE      = regexp.MustCompile(`^[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$`)
+	artifactActionTypeRE   = regexp.MustCompile(`^[a-z][a-z0-9_.-]{0,127}$`)
 
 	artifactCompileQueue = make(chan struct{}, 16)
 	artifactCompileSlots = make(chan struct{}, max(2, runtime.GOMAXPROCS(0)/2))
@@ -425,6 +426,11 @@ func CompileJSONArtifact(ctx context.Context, bundle Bundle, limits CompileLimit
 	if err != nil {
 		return nil, err
 	}
+	if limits.RequireOwner {
+		if err := validateRuntimeActionContract(mf, interactions); err != nil {
+			return nil, artifactValidationError("manifest", "manifest", err)
+		}
+	}
 	parsedSamples, sampleAssignments, err := compileBundleSamples(mf, schema, bundle.Samples, budget, limits)
 	if err != nil {
 		return nil, err
@@ -605,6 +611,18 @@ func validateRuntimeManifest(mf manifestFile, limits CompileLimits) error {
 	if limits.RequireProtocol && strings.TrimSpace(mf.Protocol) == "" {
 		return errors.New("protocol is required")
 	}
+	if mf.DataSchema != "" && mf.DataSchema != "contract/data.schema.json" {
+		return fmt.Errorf("dataSchema %q must reference contract/data.schema.json", mf.DataSchema)
+	}
+	if limits.RequireProtocol && mf.DataSchema == "" {
+		return errors.New("dataSchema must reference contract/data.schema.json")
+	}
+	if mf.AdaptiveCardVersion != "" && mf.AdaptiveCardVersion != cardmsg.CardVersion {
+		return fmt.Errorf("adaptiveCardVersion %q must be %q", mf.AdaptiveCardVersion, cardmsg.CardVersion)
+	}
+	if limits.RequireProtocol && mf.AdaptiveCardVersion == "" {
+		return errors.New("adaptiveCardVersion is required")
+	}
 	if len(mf.Views) > limits.MaxViews {
 		return fmt.Errorf("views exceed %d", limits.MaxViews)
 	}
@@ -625,6 +643,25 @@ func validateRuntimeManifest(mf manifestFile, limits CompileLimits) error {
 				return fmt.Errorf("state %q is not a safe token", state)
 			}
 		}
+	}
+	return nil
+}
+
+func validateRuntimeActionContract(mf manifestFile, interactions map[ViewKey]InteractionReport) error {
+	hasSubmit := false
+	for _, report := range interactions {
+		for _, action := range report.Actions {
+			if action.Type == "Action.Submit" {
+				hasSubmit = true
+				break
+			}
+		}
+	}
+	if !hasSubmit {
+		return nil
+	}
+	if !artifactActionTypeRE.MatchString(mf.ActionType) {
+		return errors.New("actionType is required and must be canonical for an interactive template")
 	}
 	return nil
 }
@@ -712,14 +749,19 @@ func compileBundleSamples(
 			if err != nil {
 				return nil, nil, artifactValidationError("manifest", "samples", err)
 			}
+			expectedPath := path.Join("samples", key+".json")
+			if samplePath != expectedPath {
+				return nil, nil, artifactValidationError("manifest", "samples."+key,
+					fmt.Errorf("sample path %q, want %q", samplePath, expectedPath))
+			}
 			if _, duplicate := expected[key]; duplicate {
 				return nil, nil, artifactValidationError("manifest", "samples."+key, errors.New("sample is referenced more than once"))
 			}
 			expected[key] = struct{}{}
 			keys = append(keys, key)
 		}
-		if limits.RequireStateSamples && len(keys) < len(spec.States) {
-			return nil, nil, artifactValidationError("manifest", "samples", fmt.Errorf("view %q has %d states but %d samples", view, len(spec.States), len(keys)))
+		if limits.RequireStateSamples && len(keys) != len(spec.States) {
+			return nil, nil, artifactValidationError("manifest", "samples", fmt.Errorf("view %q has %d states but %d samples; each sample must have one state assignment", view, len(spec.States), len(keys)))
 		}
 		used := make(map[string]struct{}, len(spec.States))
 		for index, state := range spec.States {
@@ -1346,7 +1388,3 @@ func utf16Less(left, right string) bool {
 	}
 	return len(a) < len(b)
 }
-
-// Keep the package-level reference explicit: compile-time validation and final
-// render both terminate at cardmsg validation, never at a runtime uploader.
-var _ = cardmsg.CardVersion

--- a/pkg/cardtmpl/json_artifact.go
+++ b/pkg/cardtmpl/json_artifact.go
@@ -422,7 +422,10 @@ func CompileJSONArtifact(ctx context.Context, bundle Bundle, limits CompileLimit
 		return nil, artifactValidationError("constraint", "schema", err)
 	}
 	if limits.RequireBoundedSchema {
-		if err := validateBoundedInputSchema(schemaMap); err != nil {
+		if err := validateBoundedInputSchemaContext(ctx, schemaMap, limits.MaxJSONNodes); err != nil {
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				return nil, err
+			}
 			return nil, artifactValidationError("bounds", "schema", err)
 		}
 	}
@@ -1119,6 +1122,13 @@ func rejectExternalSchemaRefs(value any) error {
 }
 
 func validateBoundedInputSchema(root map[string]any) error {
+	return validateBoundedInputSchemaContext(context.Background(), root, maxArtifactJSONNodes)
+}
+
+func validateBoundedInputSchemaContext(ctx context.Context, root map[string]any, maxVisits int) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	if root["type"] != "object" {
 		return errors.New("root schema type must be object")
 	}
@@ -1126,18 +1136,39 @@ func validateBoundedInputSchema(root map[string]any) error {
 		return errors.New("root schema additionalProperties must be false")
 	}
 	validator := boundedSchemaValidator{
-		root:      root,
-		resolving: make(map[string]struct{}),
+		ctx:           ctx,
+		root:          root,
+		resolving:     make(map[string]struct{}),
+		validatedRefs: make(map[string]struct{}),
+		maxVisits:     maxVisits,
 	}
 	return validator.validateNode(root, "$")
 }
 
 type boundedSchemaValidator struct {
-	root      map[string]any
-	resolving map[string]struct{}
+	ctx           context.Context
+	root          map[string]any
+	resolving     map[string]struct{}
+	validatedRefs map[string]struct{}
+	maxVisits     int
+	visits        int
+}
+
+func (v *boundedSchemaValidator) enter() error {
+	if err := v.ctx.Err(); err != nil {
+		return err
+	}
+	v.visits++
+	if v.maxVisits > 0 && v.visits > v.maxVisits {
+		return fmt.Errorf("schema validation exceeds %d visits", v.maxVisits)
+	}
+	return nil
 }
 
 func (v *boundedSchemaValidator) validateNode(value any, location string) error {
+	if err := v.enter(); err != nil {
+		return err
+	}
 	switch node := value.(type) {
 	case []any:
 		for index, child := range node {
@@ -1184,16 +1215,18 @@ func (v *boundedSchemaValidator) validateNode(value any, location string) error 
 			}
 		}
 		if properties, ok := node["properties"].(map[string]any); ok {
-			for name, property := range properties {
+			for _, name := range sortedMapKeys(properties) {
+				property := properties[name]
 				if err := v.validatePropertySchema(property, location+".properties."+name); err != nil {
 					return err
 				}
 			}
 		}
-		for key, child := range node {
-			if key == "examples" || key == "default" || key == "enum" || key == "const" {
+		for _, key := range sortedMapKeys(node) {
+			if key == "properties" || key == "items" || key == "examples" || key == "default" || key == "enum" || key == "const" {
 				continue
 			}
+			child := node[key]
 			if err := v.validateNode(child, location+"."+key); err != nil {
 				return err
 			}
@@ -1232,6 +1265,9 @@ func schemaTypeNames(raw any, location string) ([]string, error) {
 }
 
 func (v *boundedSchemaValidator) validatePropertySchema(value any, location string) error {
+	if err := v.enter(); err != nil {
+		return err
+	}
 	if allowed, ok := value.(bool); ok {
 		if !allowed {
 			return nil
@@ -1281,13 +1317,20 @@ func (v *boundedSchemaValidator) validateReference(ref, location string) error {
 	if _, cycle := v.resolving[ref]; cycle {
 		return fmt.Errorf("%s local $ref %q is cyclic", location, ref)
 	}
+	if _, validated := v.validatedRefs[ref]; validated {
+		return nil
+	}
 	target, err := resolveLocalSchemaRef(v.root, ref)
 	if err != nil {
 		return fmt.Errorf("%s local $ref %q: %w", location, ref, err)
 	}
 	v.resolving[ref] = struct{}{}
 	defer delete(v.resolving, ref)
-	return v.validatePropertySchema(target, location+".$ref")
+	if err := v.validatePropertySchema(target, location+".$ref"); err != nil {
+		return err
+	}
+	v.validatedRefs[ref] = struct{}{}
+	return nil
 }
 
 func resolveLocalSchemaRef(root map[string]any, ref string) (any, error) {

--- a/pkg/cardtmpl/json_artifact.go
+++ b/pkg/cardtmpl/json_artifact.go
@@ -607,7 +607,7 @@ func decodeManifest(parsed any) (manifestFile, error) {
 }
 
 func validateRuntimeManifest(mf manifestFile, limits CompileLimits) error {
-	if mf.SchemaVersion != artifactSchemaVersion {
+	if limits.RequireProtocol && mf.SchemaVersion != artifactSchemaVersion {
 		return fmt.Errorf("schemaVersion %d is unsupported; want %d", mf.SchemaVersion, artifactSchemaVersion)
 	}
 	if len(mf.ID) > maxArtifactTemplateIDLen || !artifactTemplateIDRE.MatchString(string(mf.ID)) {

--- a/pkg/cardtmpl/json_artifact.go
+++ b/pkg/cardtmpl/json_artifact.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"io/fs"
 	"math"
+	"math/big"
 	"net/url"
 	"path"
 	"regexp"
@@ -18,7 +19,6 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"unicode/utf16"
 	"unicode/utf8"
 
 	"github.com/Mininglamp-OSS/octo-server/pkg/cardmsg"
@@ -140,7 +140,6 @@ type CompileLimits struct {
 	RequireBoundedSchema bool
 	RequireOwner         bool
 	RequireProtocol      bool
-	RequireStateSamples  bool
 }
 
 func DefaultCompileLimits() CompileLimits {
@@ -157,7 +156,6 @@ func DefaultCompileLimits() CompileLimits {
 		RequireBoundedSchema: true,
 		RequireOwner:         true,
 		RequireProtocol:      true,
-		RequireStateSamples:  true,
 	}
 }
 
@@ -203,6 +201,14 @@ func DecodeBundleJSON(raw []byte) (Bundle, error) {
 	if err != nil {
 		return Bundle{}, artifactValidationError("json", "bundle", err)
 	}
+	return DecodeBundleValue(parsed)
+}
+
+// DecodeBundleValue validates and decodes a bundle from an already strictly
+// parsed JSON value. Control-plane envelopes use it to avoid reparsing the
+// nested bundle after duplicate-key, Unicode, depth, and node checks have
+// already covered the complete request tree.
+func DecodeBundleValue(parsed any) (Bundle, error) {
 	root, ok := parsed.(map[string]any)
 	if !ok {
 		return Bundle{}, artifactValidationError("shape", "bundle", errors.New("root must be an object"))
@@ -224,6 +230,25 @@ func DecodeBundleJSON(raw []byte) (Bundle, error) {
 		return Bundle{}, artifactValidationError("shape", "bundle", err)
 	}
 	return bundle, nil
+}
+
+// DecodeStrictJSONObject parses one bounded request object while preserving its
+// already-validated value tree for downstream decoders. It is the single-parse
+// handoff used by the card-template control plane; callers must still reject
+// endpoint-specific unknown fields.
+func DecodeStrictJSONObject(raw []byte) (map[string]any, error) {
+	if len(raw) > maxArtifactBundleBytes {
+		return nil, artifactValidationError("limit", "request", fmt.Errorf("body exceeds %d bytes", maxArtifactBundleBytes))
+	}
+	parsed, err := decodeStrictJSON(raw, jsonBudget{maxDepth: maxArtifactJSONDepth, maxNodes: maxArtifactJSONNodes})
+	if err != nil {
+		return nil, artifactValidationError("json", "request", err)
+	}
+	root, ok := parsed.(map[string]any)
+	if !ok {
+		return nil, artifactValidationError("shape", "request", errors.New("root must be an object"))
+	}
+	return root, nil
 }
 
 // DecodeStrictJSON applies the artifact request JSON rules to an enclosing
@@ -287,7 +312,9 @@ func LoadJSONBundle(assets fs.FS, root string, catalog CatalogDescriptor) (Bundl
 		Samples:   make(map[string]json.RawMessage),
 		Goldens:   make(map[string]json.RawMessage),
 	}
-	for view, spec := range mf.Views {
+	for _, viewName := range sortedMapKeys(viewKeys(mf.Views)) {
+		view := ViewKey(viewName)
+		spec := mf.Views[view]
 		if strings.TrimSpace(spec.Template) == "" {
 			return Bundle{}, artifactValidationError("manifest", "templates."+string(view), fmt.Errorf("view %q declares no template path", view))
 		}
@@ -447,7 +474,7 @@ func CompileJSONArtifact(ctx context.Context, bundle Bundle, limits CompileLimit
 	if err != nil {
 		return nil, err
 	}
-	parsedGoldens, err := compileBundleGoldens(bundle.Goldens, parsedSamples, budget, limits)
+	parsedGoldens, err := compileBundleGoldens(bundle.Goldens, parsedSamples, budget)
 	if err != nil {
 		return nil, err
 	}
@@ -532,20 +559,25 @@ func validateBundleDocumentLimits(bundle Bundle, limits CompileLimits) error {
 		{name: "manifest", raw: bundle.Manifest},
 		{name: "schema", raw: bundle.Schema},
 	}
-	for prefix, docs := range map[string]map[string]json.RawMessage{
-		"templates": bundle.Templates,
-		"reports":   bundle.Reports,
-		"samples":   bundle.Samples,
-		"goldens":   bundle.Goldens,
-	} {
-		for key, raw := range docs {
+	groups := []struct {
+		prefix string
+		docs   map[string]json.RawMessage
+	}{
+		{prefix: "templates", docs: bundle.Templates},
+		{prefix: "reports", docs: bundle.Reports},
+		{prefix: "samples", docs: bundle.Samples},
+		{prefix: "goldens", docs: bundle.Goldens},
+	}
+	for _, group := range groups {
+		for _, key := range sortedMapKeys(group.docs) {
+			raw := group.docs[key]
 			if !artifactDocumentKeyRE.MatchString(key) {
-				return artifactValidationError("key", prefix, fmt.Errorf("invalid document key %q", key))
+				return artifactValidationError("key", group.prefix, fmt.Errorf("invalid document key %q", key))
 			}
 			documents = append(documents, struct {
 				name string
 				raw  json.RawMessage
-			}{name: prefix + "." + key, raw: raw})
+			}{name: group.prefix + "." + key, raw: raw})
 		}
 	}
 	total := 0
@@ -588,7 +620,8 @@ func decodeManifest(parsed any) (manifestFile, error) {
 	if !ok {
 		return manifestFile{}, errors.New("views must be an object")
 	}
-	for view, raw := range views {
+	for _, view := range sortedMapKeys(views) {
+		raw := views[view]
 		viewMap, ok := raw.(map[string]any)
 		if !ok {
 			return manifestFile{}, fmt.Errorf("view %q must be an object", view)
@@ -649,7 +682,9 @@ func validateRuntimeManifest(mf manifestFile, limits CompileLimits) error {
 		return fmt.Errorf("views exceed %d", limits.MaxViews)
 	}
 	stateCount := 0
-	for view, spec := range mf.Views {
+	for _, viewName := range sortedMapKeys(viewKeys(mf.Views)) {
+		view := ViewKey(viewName)
+		spec := mf.Views[view]
 		if !artifactDocumentKeyRE.MatchString(string(view)) {
 			return fmt.Errorf("view %q is not a safe token", view)
 		}
@@ -693,7 +728,9 @@ func compileBundleTemplates(ctx context.Context, mf manifestFile, documents map[
 		return nil, err
 	}
 	out := make(map[ViewKey]any, len(mf.Views))
-	for view, spec := range mf.Views {
+	for _, viewName := range sortedMapKeys(viewKeys(mf.Views)) {
+		view := ViewKey(viewName)
+		spec := mf.Views[view]
 		if err := ctx.Err(); err != nil {
 			return nil, err
 		}
@@ -718,7 +755,9 @@ func compileBundleTemplates(ctx context.Context, mf manifestFile, documents map[
 
 func compileBundleReports(mf manifestFile, documents map[string]json.RawMessage, budget jsonBudget) (map[ViewKey]InteractionReport, map[string]any, error) {
 	expected := make(map[string]struct{})
-	for view, spec := range mf.Views {
+	for _, viewName := range sortedMapKeys(viewKeys(mf.Views)) {
+		view := ViewKey(viewName)
+		spec := mf.Views[view]
 		if spec.WireProfile == profileV2 {
 			expected[string(view)] = struct{}{}
 		}
@@ -728,7 +767,7 @@ func compileBundleReports(mf manifestFile, documents map[string]json.RawMessage,
 	}
 	interactions := make(map[ViewKey]InteractionReport, len(expected))
 	parsedReports := make(map[string]any, len(expected))
-	for key := range expected {
+	for _, key := range sortedMapKeys(expected) {
 		parsed, err := decodeArtifactDocument("reports."+key, documents[key], budget)
 		if err != nil {
 			return nil, nil, err
@@ -764,7 +803,9 @@ func compileBundleSamples(
 ) (map[string]any, []sampleAssignment, error) {
 	expected := make(map[string]struct{})
 	assignments := make([]sampleAssignment, 0)
-	for view, spec := range mf.Views {
+	for _, viewName := range sortedMapKeys(viewKeys(mf.Views)) {
+		view := ViewKey(viewName)
+		spec := mf.Views[view]
 		keys := make([]string, 0, len(spec.Samples))
 		viewSamples := make(map[string]struct{}, len(spec.Samples))
 		for _, samplePath := range spec.Samples {
@@ -784,30 +825,49 @@ func compileBundleSamples(
 			viewSamples[key] = struct{}{}
 			keys = append(keys, key)
 		}
-		if limits.RequireStateSamples && len(keys) != len(spec.States) {
+		if len(keys) != len(spec.States) {
 			return nil, nil, artifactValidationError("manifest", "samples", fmt.Errorf("view %q has %d states but %d samples; each sample must have one state assignment", view, len(spec.States), len(keys)))
 		}
+		assignedKeys := make([]string, len(spec.States))
 		used := make(map[string]struct{}, len(spec.States))
 		for index, state := range spec.States {
 			key := string(state)
 			if _, exists := viewSamples[key]; !exists {
-				if index >= len(keys) {
-					continue
-				}
-				key = keys[index]
+				continue
 			}
 			if _, duplicate := used[key]; duplicate {
 				return nil, nil, artifactValidationError("manifest", "samples."+key, errors.New("sample cannot cover multiple states in one view"))
 			}
 			used[key] = struct{}{}
-			assignments = append(assignments, sampleAssignment{view: view, state: state, key: key})
+			assignedKeys[index] = key
+		}
+		remaining := make([]string, 0, len(keys)-len(used))
+		for _, key := range keys {
+			if _, exact := used[key]; !exact {
+				remaining = append(remaining, key)
+			}
+		}
+		next := 0
+		for index := range spec.States {
+			if assignedKeys[index] != "" {
+				continue
+			}
+			if next >= len(remaining) {
+				return nil, nil, artifactValidationError("manifest", "samples", fmt.Errorf("view %q has no sample for state %q", view, spec.States[index]))
+			}
+			assignedKeys[index] = remaining[next]
+			next++
+		}
+		for index, state := range spec.States {
+			assignments = append(assignments, sampleAssignment{view: view, state: state, key: assignedKeys[index]})
 		}
 	}
 	if err := requireExactDocumentKeys("samples", documents, expected); err != nil {
 		return nil, nil, err
 	}
 	parsedSamples := make(map[string]any, len(documents))
-	for key, raw := range documents {
+	for _, key := range sortedMapKeys(documents) {
+		raw := documents[key]
 		parsed, err := decodeArtifactDocument("samples."+key, raw, budget)
 		if err != nil {
 			return nil, nil, err
@@ -824,13 +884,10 @@ func compileBundleGoldens(
 	documents map[string]json.RawMessage,
 	parsedSamples map[string]any,
 	budget jsonBudget,
-	limits CompileLimits,
 ) (map[string]any, error) {
-	if len(documents) > limits.MaxGoldens {
-		return nil, artifactValidationError("limit", "goldens", fmt.Errorf("goldens exceed %d", limits.MaxGoldens))
-	}
 	out := make(map[string]any, len(documents))
-	for key, raw := range documents {
+	for _, key := range sortedMapKeys(documents) {
+		raw := documents[key]
 		if _, ok := parsedSamples[key]; !ok {
 			return nil, artifactValidationError("unreferenced", "goldens."+key, errors.New("golden has no matching sample"))
 		}
@@ -844,12 +901,12 @@ func compileBundleGoldens(
 }
 
 func requireExactDocumentKeys(prefix string, documents map[string]json.RawMessage, expected map[string]struct{}) error {
-	for key := range expected {
+	for _, key := range sortedMapKeys(expected) {
 		if _, ok := documents[key]; !ok {
 			return artifactValidationError("missing", prefix+"."+key, errors.New("required document missing"))
 		}
 	}
-	for key := range documents {
+	for _, key := range sortedMapKeys(documents) {
 		if _, ok := expected[key]; !ok {
 			return artifactValidationError("unreferenced", prefix+"."+key, errors.New("document is not referenced by manifest"))
 		}
@@ -921,7 +978,8 @@ func checkArtifactGoldens(
 	for _, assignment := range assignments {
 		assignmentByKey[assignment.key] = assignment
 	}
-	for key, golden := range goldens {
+	for _, key := range sortedMapKeys(goldens) {
+		golden := goldens[key]
 		if err := ctx.Err(); err != nil {
 			return err
 		}
@@ -1058,11 +1116,15 @@ func positiveJSONInt(value any) (int, error) {
 	if !ok {
 		return 0, errors.New("not a number")
 	}
-	parsed, err := strconv.ParseInt(number.String(), 10, 32)
-	if err != nil || parsed <= 0 {
+	parsed, ok := new(big.Rat).SetString(number.String())
+	if !ok || parsed.Sign() <= 0 || !parsed.IsInt() || !parsed.Num().IsInt64() {
 		return 0, errors.New("not a positive integer")
 	}
-	return int(parsed), nil
+	integer := parsed.Num().Int64()
+	if integer > 1<<31-1 {
+		return 0, errors.New("positive integer exceeds int32")
+	}
+	return int(integer), nil
 }
 
 func validateAggregateTarget(schema map[string]any, limit jsonTemplateAggregateArrayLimit) error {
@@ -1112,17 +1174,14 @@ func rejectExternalSchemaRefs(value any) error {
 				return fmt.Errorf("external $ref %q is forbidden", ref)
 			}
 		}
-		for _, child := range node {
+		for _, key := range sortedMapKeys(node) {
+			child := node[key]
 			if err := rejectExternalSchemaRefs(child); err != nil {
 				return err
 			}
 		}
 	}
 	return nil
-}
-
-func validateBoundedInputSchema(root map[string]any) error {
-	return validateBoundedInputSchemaContext(context.Background(), root, maxArtifactJSONNodes)
 }
 
 func validateBoundedInputSchemaContext(ctx context.Context, root map[string]any, maxVisits int) error {
@@ -1398,7 +1457,7 @@ func rejectUnknownKeys(object map[string]any, allowed ...string) error {
 	for _, key := range allowed {
 		set[key] = struct{}{}
 	}
-	for key := range object {
+	for _, key := range sortedMapKeys(object) {
 		if _, ok := set[key]; !ok {
 			return fmt.Errorf("unknown key %q", key)
 		}
@@ -1677,12 +1736,41 @@ func canonicalJSONNumber(number json.Number) (string, error) {
 }
 
 func utf16Less(left, right string) bool {
-	a := utf16.Encode([]rune(left))
-	b := utf16.Encode([]rune(right))
-	for index := 0; index < len(a) && index < len(b); index++ {
-		if a[index] != b[index] {
-			return a[index] < b[index]
+	a := utf16Iterator{remaining: left}
+	b := utf16Iterator{remaining: right}
+	for {
+		leftUnit, leftOK := a.next()
+		rightUnit, rightOK := b.next()
+		if !leftOK || !rightOK {
+			return !leftOK && rightOK
+		}
+		if leftUnit != rightUnit {
+			return leftUnit < rightUnit
 		}
 	}
-	return len(a) < len(b)
+}
+
+type utf16Iterator struct {
+	remaining  string
+	pending    uint16
+	hasPending bool
+}
+
+func (i *utf16Iterator) next() (uint16, bool) {
+	if i.hasPending {
+		i.hasPending = false
+		return i.pending, true
+	}
+	if i.remaining == "" {
+		return 0, false
+	}
+	r, size := utf8.DecodeRuneInString(i.remaining)
+	i.remaining = i.remaining[size:]
+	if r <= 0xffff {
+		return uint16(r), true
+	}
+	r -= 0x10000
+	i.pending = uint16(0xdc00 + (r & 0x3ff))
+	i.hasPending = true
+	return uint16(0xd800 + (r >> 10)), true
 }

--- a/pkg/cardtmpl/json_artifact.go
+++ b/pkg/cardtmpl/json_artifact.go
@@ -1147,6 +1147,13 @@ func (v *boundedSchemaValidator) validateNode(value any, location string) error 
 		}
 		return nil
 	case map[string]any:
+		if rawRef, exists := node["$ref"]; exists {
+			ref, ok := rawRef.(string)
+			if !ok {
+				return fmt.Errorf("%s $ref must be a string", location)
+			}
+			return v.validateReference(ref, location)
+		}
 		kinds, err := schemaTypeNames(node["type"], location)
 		if err != nil {
 			return err
@@ -1241,16 +1248,7 @@ func (v *boundedSchemaValidator) validatePropertySchema(value any, location stri
 		return nil
 	}
 	if ref, hasRef := node["$ref"].(string); hasRef && strings.HasPrefix(ref, "#") {
-		if _, cycle := v.resolving[ref]; cycle {
-			return fmt.Errorf("%s local $ref %q is cyclic", location, ref)
-		}
-		target, err := resolveLocalSchemaRef(v.root, ref)
-		if err != nil {
-			return fmt.Errorf("%s local $ref %q: %w", location, ref, err)
-		}
-		v.resolving[ref] = struct{}{}
-		defer delete(v.resolving, ref)
-		return v.validatePropertySchema(target, location+".$ref")
+		return v.validateReference(ref, location)
 	}
 	for _, keyword := range []string{"anyOf", "oneOf"} {
 		if alternatives, exists := node[keyword].([]any); exists && len(alternatives) > 0 {
@@ -1270,6 +1268,22 @@ func (v *boundedSchemaValidator) validatePropertySchema(value any, location stri
 		}
 	}
 	return fmt.Errorf("%s must declare a bounded type, enum, const, or local $ref", location)
+}
+
+func (v *boundedSchemaValidator) validateReference(ref, location string) error {
+	if !strings.HasPrefix(ref, "#") {
+		return fmt.Errorf("%s external $ref %q is forbidden", location, ref)
+	}
+	if _, cycle := v.resolving[ref]; cycle {
+		return fmt.Errorf("%s local $ref %q is cyclic", location, ref)
+	}
+	target, err := resolveLocalSchemaRef(v.root, ref)
+	if err != nil {
+		return fmt.Errorf("%s local $ref %q: %w", location, ref, err)
+	}
+	v.resolving[ref] = struct{}{}
+	defer delete(v.resolving, ref)
+	return v.validatePropertySchema(target, location+".$ref")
 }
 
 func resolveLocalSchemaRef(root map[string]any, ref string) (any, error) {

--- a/pkg/cardtmpl/json_artifact.go
+++ b/pkg/cardtmpl/json_artifact.go
@@ -216,6 +216,32 @@ func DecodeBundleJSON(raw []byte) (Bundle, error) {
 	return bundle, nil
 }
 
+// DecodeStrictJSON applies the artifact request JSON rules to an enclosing
+// control-plane object before decoding it into out. Unknown struct fields are
+// rejected in addition to duplicate keys and trailing tokens.
+func DecodeStrictJSON(raw []byte, out any) error {
+	if out == nil {
+		return artifactValidationError("shape", "request", errors.New("decode target is nil"))
+	}
+	if len(raw) > maxArtifactBundleBytes {
+		return artifactValidationError("limit", "request", fmt.Errorf("body exceeds %d bytes", maxArtifactBundleBytes))
+	}
+	parsed, err := decodeStrictJSON(raw, jsonBudget{maxDepth: maxArtifactJSONDepth, maxNodes: maxArtifactJSONNodes})
+	if err != nil {
+		return artifactValidationError("json", "request", err)
+	}
+	canonical, err := marshalCanonicalJSON(parsed)
+	if err != nil {
+		return artifactValidationError("canonical", "request", err)
+	}
+	decoder := json.NewDecoder(bytes.NewReader(canonical))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(out); err != nil {
+		return artifactValidationError("shape", "request", err)
+	}
+	return nil
+}
+
 // LoadJSONBundle converts a reviewed embedded handoff into the same structured
 // bundle accepted by the runtime compiler. The schema is read exactly once.
 func LoadJSONBundle(assets fs.FS, root string, catalog CatalogDescriptor) (Bundle, error) {

--- a/pkg/cardtmpl/json_artifact.go
+++ b/pkg/cardtmpl/json_artifact.go
@@ -39,6 +39,10 @@ const (
 	maxArtifactGoldens       = 64
 	maxArtifactJSONDepth     = 64
 	maxArtifactJSONNodes     = 50_000
+	artifactSchemaVersion    = 2
+	maxArtifactTemplateIDLen = 128
+	maxArtifactVersionLen    = 64
+	maxArtifactContractLen   = 64
 )
 
 var (
@@ -603,11 +607,17 @@ func decodeManifest(parsed any) (manifestFile, error) {
 }
 
 func validateRuntimeManifest(mf manifestFile, limits CompileLimits) error {
-	if !artifactTemplateIDRE.MatchString(string(mf.ID)) {
+	if mf.SchemaVersion != artifactSchemaVersion {
+		return fmt.Errorf("schemaVersion %d is unsupported; want %d", mf.SchemaVersion, artifactSchemaVersion)
+	}
+	if len(mf.ID) > maxArtifactTemplateIDLen || !artifactTemplateIDRE.MatchString(string(mf.ID)) {
 		return fmt.Errorf("id %q is not canonical", mf.ID)
 	}
-	if !artifactVersionRE.MatchString(mf.Version) {
+	if len(mf.Version) > maxArtifactVersionLen || !artifactVersionRE.MatchString(mf.Version) {
 		return fmt.Errorf("version %q is not canonical semver", mf.Version)
+	}
+	if mf.ContractVersion != "" && (len(mf.ContractVersion) > maxArtifactContractLen || !artifactVersionRE.MatchString(mf.ContractVersion)) {
+		return fmt.Errorf("contractVersion %q is not canonical semver", mf.ContractVersion)
 	}
 	if limits.RequireOwner && strings.TrimSpace(mf.Owner) == "" {
 		return errors.New("owner is required")
@@ -1121,24 +1131,36 @@ func validateBoundedSchemaNode(value any, location string) error {
 		}
 		return nil
 	case map[string]any:
-		kind, _ := node["type"].(string)
-		switch kind {
-		case "string":
-			_, hasConst := node["const"]
-			enum, hasEnum := node["enum"].([]any)
-			if _, err := positiveJSONInt(node["maxLength"]); err != nil && !hasConst && (!hasEnum || len(enum) == 0) {
-				return fmt.Errorf("%s string is unbounded", location)
+		kinds, err := schemaTypeNames(node["type"], location)
+		if err != nil {
+			return err
+		}
+		for _, kind := range kinds {
+			switch kind {
+			case "string":
+				_, hasConst := node["const"]
+				enum, hasEnum := node["enum"].([]any)
+				if _, err := positiveJSONInt(node["maxLength"]); err != nil && !hasConst && (!hasEnum || len(enum) == 0) {
+					return fmt.Errorf("%s string is unbounded", location)
+				}
+			case "array":
+				if _, err := positiveJSONInt(node["maxItems"]); err != nil {
+					return fmt.Errorf("%s array is unbounded", location)
+				}
+				if _, ok := node["items"].(map[string]any); !ok {
+					return fmt.Errorf("%s array items schema missing", location)
+				}
+			case "object":
+				if additional, ok := node["additionalProperties"].(bool); !ok || additional {
+					return fmt.Errorf("%s object additionalProperties must be false", location)
+				}
 			}
-		case "array":
-			if _, err := positiveJSONInt(node["maxItems"]); err != nil {
-				return fmt.Errorf("%s array is unbounded", location)
-			}
-			if _, ok := node["items"].(map[string]any); !ok {
-				return fmt.Errorf("%s array items schema missing", location)
-			}
-		case "object":
-			if additional, ok := node["additionalProperties"].(bool); !ok || additional {
-				return fmt.Errorf("%s object additionalProperties must be false", location)
+		}
+		if properties, ok := node["properties"].(map[string]any); ok {
+			for name, property := range properties {
+				if err := validateBoundedPropertySchema(property, location+".properties."+name); err != nil {
+					return err
+				}
 			}
 		}
 		for key, child := range node {
@@ -1151,6 +1173,78 @@ func validateBoundedSchemaNode(value any, location string) error {
 		}
 	}
 	return nil
+}
+
+func schemaTypeNames(raw any, location string) ([]string, error) {
+	switch value := raw.(type) {
+	case nil:
+		return nil, nil
+	case string:
+		return []string{value}, nil
+	case []any:
+		if len(value) == 0 {
+			return nil, fmt.Errorf("%s type list is empty", location)
+		}
+		out := make([]string, 0, len(value))
+		seen := make(map[string]struct{}, len(value))
+		for _, item := range value {
+			kind, ok := item.(string)
+			if !ok {
+				return nil, fmt.Errorf("%s type list contains a non-string value", location)
+			}
+			if _, duplicate := seen[kind]; duplicate {
+				return nil, fmt.Errorf("%s type list contains duplicate %q", location, kind)
+			}
+			seen[kind] = struct{}{}
+			out = append(out, kind)
+		}
+		return out, nil
+	default:
+		return nil, fmt.Errorf("%s type must be a string or string array", location)
+	}
+}
+
+func validateBoundedPropertySchema(value any, location string) error {
+	if allowed, ok := value.(bool); ok {
+		if !allowed {
+			return nil
+		}
+		return fmt.Errorf("%s must declare a bounded type", location)
+	}
+	node, ok := value.(map[string]any)
+	if !ok {
+		return fmt.Errorf("%s must be a schema object", location)
+	}
+	if _, hasType := node["type"]; hasType {
+		return nil
+	}
+	if _, hasConst := node["const"]; hasConst {
+		return nil
+	}
+	if enum, hasEnum := node["enum"].([]any); hasEnum && len(enum) > 0 {
+		return nil
+	}
+	if ref, hasRef := node["$ref"].(string); hasRef && strings.HasPrefix(ref, "#") {
+		return nil
+	}
+	for _, keyword := range []string{"anyOf", "oneOf"} {
+		if alternatives, exists := node[keyword].([]any); exists && len(alternatives) > 0 {
+			for index, alternative := range alternatives {
+				if err := validateBoundedPropertySchema(alternative, fmt.Sprintf("%s.%s[%d]", location, keyword, index)); err != nil {
+					return err
+				}
+			}
+			return nil
+		}
+	}
+	if constraints, exists := node["allOf"].([]any); exists && len(constraints) > 0 {
+		for index, constraint := range constraints {
+			if validateBoundedPropertySchema(constraint, fmt.Sprintf("%s.allOf[%d]", location, index)) == nil {
+				return nil
+			}
+		}
+	}
+	return fmt.Errorf("%s must declare a bounded type, enum, const, or local $ref", location)
 }
 
 func rejectUnknownKeys(object map[string]any, allowed ...string) error {

--- a/pkg/cardtmpl/json_artifact.go
+++ b/pkg/cardtmpl/json_artifact.go
@@ -1,0 +1,1326 @@
+package cardtmpl
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"math"
+	"path"
+	"regexp"
+	"runtime"
+	"sort"
+	"strconv"
+	"strings"
+	"unicode/utf16"
+	"unicode/utf8"
+
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardmsg"
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl/jsontmpl"
+	"github.com/santhosh-tekuri/jsonschema/v6"
+)
+
+const (
+	JSONTemplateEngineV1     = "octo-json-template/v1"
+	CatalogVisibilityPublic  = "public"
+	CatalogVisibilityPrivate = "private"
+
+	maxArtifactBundleBytes   = 2 << 20
+	maxArtifactDocuments     = 128
+	maxArtifactDocumentBytes = 512 << 10
+	maxArtifactViews         = 16
+	maxArtifactStates        = 64
+	maxArtifactSamples       = 64
+	maxArtifactGoldens       = 64
+	maxArtifactJSONDepth     = 64
+	maxArtifactJSONNodes     = 50_000
+)
+
+var (
+	ErrArtifactCompileBusy = errors.New("cardtmpl: artifact compiler busy")
+	artifactDocumentKeyRE  = regexp.MustCompile(`^[a-z][a-z0-9_.-]{0,63}$`)
+	artifactTemplateIDRE   = regexp.MustCompile(`^[a-z][a-z0-9]*(?:[.-][a-z0-9][a-z0-9-]*)+$`)
+	artifactVersionRE      = regexp.MustCompile(`^[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$`)
+
+	artifactCompileQueue = make(chan struct{}, 16)
+	artifactCompileSlots = make(chan struct{}, max(2, runtime.GOMAXPROCS(0)/2))
+)
+
+// CatalogDescriptor contains governance metadata outside the frozen template
+// manifest. It is part of the canonical artifact identity.
+type CatalogDescriptor struct {
+	Engine     string `json:"engine"`
+	Visibility string `json:"visibility"`
+}
+
+// Bundle is the structured, path-free upload contract for JSON templates.
+// Map keys are bounded logical document names, not caller-controlled paths.
+type Bundle struct {
+	Catalog   CatalogDescriptor          `json:"catalog"`
+	Manifest  json.RawMessage            `json:"manifest"`
+	Schema    json.RawMessage            `json:"schema"`
+	Templates map[string]json.RawMessage `json:"templates"`
+	Reports   map[string]json.RawMessage `json:"reports,omitempty"`
+	Samples   map[string]json.RawMessage `json:"samples"`
+	Goldens   map[string]json.RawMessage `json:"goldens,omitempty"`
+}
+
+// CanonicalBundle is deterministic JSON used for hashing and immutable
+// persistence. Callers must treat the bytes as read-only.
+type CanonicalBundle []byte
+
+// CompiledArtifact is the result shared by static registration and the runtime
+// validate/publish control plane. It contains no database or activation state.
+type CompiledArtifact struct {
+	Template        Template
+	Meta            TemplateMeta
+	Hash            string
+	Bundle          CanonicalBundle
+	Engine          string
+	Visibility      string
+	Owner           string
+	ContractVersion string
+
+	samples map[string]json.RawMessage
+}
+
+// ArtifactValidationError exposes only a bounded category and logical
+// document name to HTTP callers. Cause is retained for server logs.
+type ArtifactValidationError struct {
+	Category string
+	Document string
+	cause    error
+}
+
+func (e *ArtifactValidationError) Error() string {
+	if e == nil {
+		return "cardtmpl: invalid artifact"
+	}
+	if e.cause == nil {
+		return fmt.Sprintf("cardtmpl: invalid artifact %s (%s)", e.Document, e.Category)
+	}
+	return fmt.Sprintf("cardtmpl: invalid artifact %s (%s): %v", e.Document, e.Category, e.cause)
+}
+
+func (e *ArtifactValidationError) Unwrap() error { return e.cause }
+
+func artifactValidationError(category, document string, err error) error {
+	return &ArtifactValidationError{Category: category, Document: document, cause: err}
+}
+
+// CompileLimits is explicit so tests and future engine contracts can lower
+// budgets. Production callers use DefaultCompileLimits; values above the hard
+// defaults are clamped by normalizeCompileLimits.
+type CompileLimits struct {
+	MaxBundleBytes   int
+	MaxDocuments     int
+	MaxDocumentBytes int
+	MaxViews         int
+	MaxStates        int
+	MaxSamples       int
+	MaxGoldens       int
+	MaxJSONDepth     int
+	MaxJSONNodes     int
+
+	RequireBoundedSchema bool
+	RequireOwner         bool
+	RequireProtocol      bool
+	RequireStateSamples  bool
+}
+
+func DefaultCompileLimits() CompileLimits {
+	return CompileLimits{
+		MaxBundleBytes:       maxArtifactBundleBytes,
+		MaxDocuments:         maxArtifactDocuments,
+		MaxDocumentBytes:     maxArtifactDocumentBytes,
+		MaxViews:             maxArtifactViews,
+		MaxStates:            maxArtifactStates,
+		MaxSamples:           maxArtifactSamples,
+		MaxGoldens:           maxArtifactGoldens,
+		MaxJSONDepth:         maxArtifactJSONDepth,
+		MaxJSONNodes:         maxArtifactJSONNodes,
+		RequireBoundedSchema: true,
+		RequireOwner:         true,
+		RequireProtocol:      true,
+		RequireStateSamples:  true,
+	}
+}
+
+func staticCompileLimits() CompileLimits {
+	limits := DefaultCompileLimits()
+	// Frozen legacy built-ins predate the E3 publisher bounds. They still use
+	// the same parser/compiler; only the new-publish governance checks are off.
+	limits.RequireBoundedSchema = false
+	limits.RequireOwner = false
+	limits.RequireProtocol = false
+	return limits
+}
+
+func normalizeCompileLimits(limits CompileLimits) CompileLimits {
+	defaults := DefaultCompileLimits()
+	limits.MaxBundleBytes = boundedLimit(limits.MaxBundleBytes, defaults.MaxBundleBytes)
+	limits.MaxDocuments = boundedLimit(limits.MaxDocuments, defaults.MaxDocuments)
+	limits.MaxDocumentBytes = boundedLimit(limits.MaxDocumentBytes, defaults.MaxDocumentBytes)
+	limits.MaxViews = boundedLimit(limits.MaxViews, defaults.MaxViews)
+	limits.MaxStates = boundedLimit(limits.MaxStates, defaults.MaxStates)
+	limits.MaxSamples = boundedLimit(limits.MaxSamples, defaults.MaxSamples)
+	limits.MaxGoldens = boundedLimit(limits.MaxGoldens, defaults.MaxGoldens)
+	limits.MaxJSONDepth = boundedLimit(limits.MaxJSONDepth, defaults.MaxJSONDepth)
+	limits.MaxJSONNodes = boundedLimit(limits.MaxJSONNodes, defaults.MaxJSONNodes)
+	return limits
+}
+
+func boundedLimit(value, hardMax int) int {
+	if value <= 0 || value > hardMax {
+		return hardMax
+	}
+	return value
+}
+
+// DecodeBundleJSON rejects duplicate keys, trailing tokens, invalid UTF-8 and
+// out-of-range numbers before converting the request to the typed Bundle.
+func DecodeBundleJSON(raw []byte) (Bundle, error) {
+	limits := DefaultCompileLimits()
+	if len(raw) > limits.MaxBundleBytes {
+		return Bundle{}, artifactValidationError("limit", "bundle", fmt.Errorf("body exceeds %d bytes", limits.MaxBundleBytes))
+	}
+	parsed, err := decodeStrictJSON(raw, jsonBudget{maxDepth: limits.MaxJSONDepth, maxNodes: limits.MaxJSONNodes})
+	if err != nil {
+		return Bundle{}, artifactValidationError("json", "bundle", err)
+	}
+	root, ok := parsed.(map[string]any)
+	if !ok {
+		return Bundle{}, artifactValidationError("shape", "bundle", errors.New("root must be an object"))
+	}
+	if err := rejectUnknownKeys(root, "catalog", "manifest", "schema", "templates", "reports", "samples", "goldens"); err != nil {
+		return Bundle{}, artifactValidationError("shape", "bundle", err)
+	}
+	if catalog, ok := root["catalog"].(map[string]any); ok {
+		if err := rejectUnknownKeys(catalog, "engine", "visibility"); err != nil {
+			return Bundle{}, artifactValidationError("shape", "catalog", err)
+		}
+	}
+	canonical, err := marshalCanonicalJSON(parsed)
+	if err != nil {
+		return Bundle{}, artifactValidationError("canonical", "bundle", err)
+	}
+	var bundle Bundle
+	if err := json.Unmarshal(canonical, &bundle); err != nil {
+		return Bundle{}, artifactValidationError("shape", "bundle", err)
+	}
+	return bundle, nil
+}
+
+// LoadJSONBundle converts a reviewed embedded handoff into the same structured
+// bundle accepted by the runtime compiler. The schema is read exactly once.
+func LoadJSONBundle(assets fs.FS, root string, catalog CatalogDescriptor) (Bundle, error) {
+	manifestPath := path.Join(root, "manifest.json")
+	manifestRaw, err := fs.ReadFile(assets, manifestPath)
+	if err != nil {
+		return Bundle{}, artifactValidationError("read", "manifest", err)
+	}
+	parsed, err := decodeStrictJSON(manifestRaw, jsonBudget{maxDepth: maxArtifactJSONDepth, maxNodes: maxArtifactJSONNodes})
+	if err != nil {
+		return Bundle{}, artifactValidationError("json", "manifest", err)
+	}
+	mf, err := decodeManifest(parsed)
+	if err != nil {
+		return Bundle{}, artifactValidationError("manifest", "manifest", err)
+	}
+
+	schemaPath := strings.TrimSpace(mf.DataSchema)
+	if schemaPath == "" {
+		schemaPath = "contract/data.schema.json"
+	}
+	schemaRaw, err := readBundleAsset(assets, root, schemaPath)
+	if err != nil {
+		return Bundle{}, artifactValidationError("read", "schema", err)
+	}
+
+	bundle := Bundle{
+		Catalog:   catalog,
+		Manifest:  append(json.RawMessage(nil), manifestRaw...),
+		Schema:    schemaRaw,
+		Templates: make(map[string]json.RawMessage, len(mf.Views)),
+		Reports:   make(map[string]json.RawMessage),
+		Samples:   make(map[string]json.RawMessage),
+		Goldens:   make(map[string]json.RawMessage),
+	}
+	for view, spec := range mf.Views {
+		if strings.TrimSpace(spec.Template) == "" {
+			return Bundle{}, artifactValidationError("manifest", "templates."+string(view), fmt.Errorf("view %q declares no template path", view))
+		}
+		templateRaw, readErr := readBundleAsset(assets, root, spec.Template)
+		if readErr != nil {
+			return Bundle{}, artifactValidationError("read", "templates."+string(view), readErr)
+		}
+		bundle.Templates[string(view)] = templateRaw
+		if spec.WireProfile == profileV2 {
+			reportRaw, reportErr := readBundleAsset(assets, root, path.Join("reports", string(view)+".interaction.json"))
+			if reportErr != nil {
+				return Bundle{}, artifactValidationError("read", "reports."+string(view), reportErr)
+			}
+			bundle.Reports[string(view)] = reportRaw
+		}
+		for _, samplePath := range spec.Samples {
+			key, keyErr := logicalDocumentKey(samplePath, ".json")
+			if keyErr != nil {
+				return Bundle{}, artifactValidationError("path", "samples", keyErr)
+			}
+			sampleRaw, sampleErr := readBundleAsset(assets, root, samplePath)
+			if sampleErr != nil {
+				return Bundle{}, artifactValidationError("read", "samples."+key, sampleErr)
+			}
+			if _, duplicate := bundle.Samples[key]; duplicate {
+				return Bundle{}, artifactValidationError("manifest", "samples."+key, errors.New("duplicate sample key"))
+			}
+			bundle.Samples[key] = sampleRaw
+		}
+	}
+
+	goldenDir := path.Join(root, "goldens")
+	entries, err := fs.ReadDir(assets, goldenDir)
+	if err == nil {
+		for _, entry := range entries {
+			if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".card.json") {
+				continue
+			}
+			key := strings.TrimSuffix(entry.Name(), ".card.json")
+			if !artifactDocumentKeyRE.MatchString(key) {
+				return Bundle{}, artifactValidationError("path", "goldens", fmt.Errorf("invalid key %q", key))
+			}
+			raw, readErr := fs.ReadFile(assets, path.Join(goldenDir, entry.Name()))
+			if readErr != nil {
+				return Bundle{}, artifactValidationError("read", "goldens."+key, readErr)
+			}
+			bundle.Goldens[key] = append(json.RawMessage(nil), raw...)
+		}
+	} else if !errors.Is(err, fs.ErrNotExist) {
+		return Bundle{}, artifactValidationError("read", "goldens", err)
+	}
+	return bundle, nil
+}
+
+func readBundleAsset(assets fs.FS, root, relative string) (json.RawMessage, error) {
+	clean := path.Clean(strings.TrimSpace(relative))
+	if clean == "." || clean == "" || clean != relative || !fs.ValidPath(clean) || strings.HasPrefix(clean, "../") {
+		return nil, fmt.Errorf("unsafe bundle path %q", relative)
+	}
+	raw, err := fs.ReadFile(assets, path.Join(root, clean))
+	if err != nil {
+		return nil, err
+	}
+	return append(json.RawMessage(nil), raw...), nil
+}
+
+func logicalDocumentKey(relative, suffix string) (string, error) {
+	clean := path.Clean(strings.TrimSpace(relative))
+	if clean != relative || !fs.ValidPath(clean) || !strings.HasSuffix(clean, suffix) {
+		return "", fmt.Errorf("unsafe document path %q", relative)
+	}
+	key := strings.TrimSuffix(path.Base(clean), suffix)
+	if !artifactDocumentKeyRE.MatchString(key) {
+		return "", fmt.Errorf("invalid document key %q", key)
+	}
+	return key, nil
+}
+
+// CompileJSONArtifact validates and compiles an untrusted JSON bundle without
+// panicking or accessing databases, the network, or process configuration.
+func CompileJSONArtifact(ctx context.Context, bundle Bundle, limits CompileLimits) (*CompiledArtifact, error) {
+	limits = normalizeCompileLimits(limits)
+	release, err := acquireArtifactCompiler(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer release()
+
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if bundle.Catalog.Engine != JSONTemplateEngineV1 {
+		return nil, artifactValidationError("engine", "catalog", fmt.Errorf("unsupported engine %q", bundle.Catalog.Engine))
+	}
+	if bundle.Catalog.Visibility != CatalogVisibilityPublic && bundle.Catalog.Visibility != CatalogVisibilityPrivate {
+		return nil, artifactValidationError("visibility", "catalog", fmt.Errorf("unsupported visibility %q", bundle.Catalog.Visibility))
+	}
+	if err := validateBundleDocumentLimits(bundle, limits); err != nil {
+		return nil, err
+	}
+
+	budget := jsonBudget{maxDepth: limits.MaxJSONDepth, maxNodes: limits.MaxJSONNodes}
+	manifestDoc, err := decodeArtifactDocument("manifest", bundle.Manifest, budget)
+	if err != nil {
+		return nil, err
+	}
+	mf, err := decodeManifest(manifestDoc)
+	if err != nil {
+		return nil, artifactValidationError("manifest", "manifest", err)
+	}
+	if err := validateRuntimeManifest(mf, limits); err != nil {
+		return nil, artifactValidationError("manifest", "manifest", err)
+	}
+
+	schemaDoc, err := decodeArtifactDocument("schema", bundle.Schema, budget)
+	if err != nil {
+		return nil, err
+	}
+	schemaMap, ok := schemaDoc.(map[string]any)
+	if !ok {
+		return nil, artifactValidationError("schema", "schema", errors.New("root must be an object"))
+	}
+	if err := rejectExternalSchemaRefs(schemaDoc); err != nil {
+		return nil, artifactValidationError("schema", "schema", err)
+	}
+	schema, err := compileJSONSchema(schemaDoc)
+	if err != nil {
+		return nil, artifactValidationError("schema", "schema", err)
+	}
+	aggregateLimits, err := parseAggregateArrayLimits(schemaMap)
+	if err != nil {
+		return nil, artifactValidationError("constraint", "schema", err)
+	}
+	if limits.RequireBoundedSchema {
+		if err := validateBoundedInputSchema(schemaMap); err != nil {
+			return nil, artifactValidationError("bounds", "schema", err)
+		}
+	}
+
+	parsedTemplates, err := compileBundleTemplates(ctx, mf, bundle.Templates, budget)
+	if err != nil {
+		return nil, err
+	}
+	interactions, parsedReports, err := compileBundleReports(mf, bundle.Reports, budget)
+	if err != nil {
+		return nil, err
+	}
+	parsedSamples, sampleAssignments, err := compileBundleSamples(mf, schema, bundle.Samples, budget, limits)
+	if err != nil {
+		return nil, err
+	}
+	parsedGoldens, err := compileBundleGoldens(bundle.Goldens, parsedSamples, budget, limits)
+	if err != nil {
+		return nil, err
+	}
+
+	meta, err := assembleTemplateMeta(mf, schema, interactions, bundle.Manifest)
+	if err != nil {
+		return nil, artifactValidationError("manifest", "manifest", err)
+	}
+	template := &jsonTemplate{
+		meta:                 meta,
+		viewAST:              parsedTemplates,
+		aggregateArrayLimits: aggregateLimits,
+	}
+	if err := selfCheckCompiledJSON(ctx, template, meta, bundle.Samples, sampleAssignments); err != nil {
+		return nil, artifactValidationError("conformance", err.document, err.cause)
+	}
+	if err := checkArtifactGoldens(ctx, parsedTemplates, parsedSamples, parsedGoldens, sampleAssignments); err != nil {
+		return nil, err
+	}
+
+	canonical, err := canonicalizeBundle(bundle, manifestDoc, schemaDoc, parsedTemplates, parsedReports, parsedSamples, parsedGoldens)
+	if err != nil {
+		return nil, artifactValidationError("canonical", "bundle", err)
+	}
+	if len(canonical) > limits.MaxBundleBytes {
+		return nil, artifactValidationError("limit", "bundle", fmt.Errorf("canonical bundle exceeds %d bytes", limits.MaxBundleBytes))
+	}
+	digest := sha256.Sum256(canonical)
+	return &CompiledArtifact{
+		Template:        template,
+		Meta:            meta.Clone(),
+		Hash:            hex.EncodeToString(digest[:]),
+		Bundle:          append(CanonicalBundle(nil), canonical...),
+		Engine:          bundle.Catalog.Engine,
+		Visibility:      bundle.Catalog.Visibility,
+		Owner:           mf.Owner,
+		ContractVersion: mf.ContractVersion,
+		samples:         cloneRawMessageMap(bundle.Samples),
+	}, nil
+}
+
+func acquireArtifactCompiler(ctx context.Context) (func(), error) {
+	select {
+	case artifactCompileQueue <- struct{}{}:
+	default:
+		return nil, ErrArtifactCompileBusy
+	}
+	select {
+	case artifactCompileSlots <- struct{}{}:
+		return func() {
+			<-artifactCompileSlots
+			<-artifactCompileQueue
+		}, nil
+	case <-ctx.Done():
+		<-artifactCompileQueue
+		return nil, ctx.Err()
+	}
+}
+
+func validateBundleDocumentLimits(bundle Bundle, limits CompileLimits) error {
+	documentCount := 2 + len(bundle.Templates) + len(bundle.Reports) + len(bundle.Samples) + len(bundle.Goldens)
+	if documentCount > limits.MaxDocuments {
+		return artifactValidationError("limit", "bundle", fmt.Errorf("document count %d exceeds %d", documentCount, limits.MaxDocuments))
+	}
+	if len(bundle.Templates) > limits.MaxViews {
+		return artifactValidationError("limit", "templates", fmt.Errorf("view count %d exceeds %d", len(bundle.Templates), limits.MaxViews))
+	}
+	if len(bundle.Samples) > limits.MaxSamples {
+		return artifactValidationError("limit", "samples", fmt.Errorf("sample count %d exceeds %d", len(bundle.Samples), limits.MaxSamples))
+	}
+	if len(bundle.Goldens) > limits.MaxGoldens {
+		return artifactValidationError("limit", "goldens", fmt.Errorf("golden count %d exceeds %d", len(bundle.Goldens), limits.MaxGoldens))
+	}
+	documents := []struct {
+		name string
+		raw  json.RawMessage
+	}{
+		{name: "manifest", raw: bundle.Manifest},
+		{name: "schema", raw: bundle.Schema},
+	}
+	for prefix, docs := range map[string]map[string]json.RawMessage{
+		"templates": bundle.Templates,
+		"reports":   bundle.Reports,
+		"samples":   bundle.Samples,
+		"goldens":   bundle.Goldens,
+	} {
+		for key, raw := range docs {
+			if !artifactDocumentKeyRE.MatchString(key) {
+				return artifactValidationError("key", prefix, fmt.Errorf("invalid document key %q", key))
+			}
+			documents = append(documents, struct {
+				name string
+				raw  json.RawMessage
+			}{name: prefix + "." + key, raw: raw})
+		}
+	}
+	total := 0
+	for _, document := range documents {
+		if len(document.raw) == 0 {
+			return artifactValidationError("json", document.name, errors.New("document is empty"))
+		}
+		if len(document.raw) > limits.MaxDocumentBytes {
+			return artifactValidationError("limit", document.name, fmt.Errorf("document exceeds %d bytes", limits.MaxDocumentBytes))
+		}
+		total += len(document.raw)
+	}
+	if total > limits.MaxBundleBytes {
+		return artifactValidationError("limit", "bundle", fmt.Errorf("document bytes %d exceed %d", total, limits.MaxBundleBytes))
+	}
+	return nil
+}
+
+func decodeArtifactDocument(name string, raw json.RawMessage, budget jsonBudget) (any, error) {
+	parsed, err := decodeStrictJSON(raw, budget)
+	if err != nil {
+		return nil, artifactValidationError("json", name, err)
+	}
+	return parsed, nil
+}
+
+func decodeManifest(parsed any) (manifestFile, error) {
+	root, ok := parsed.(map[string]any)
+	if !ok {
+		return manifestFile{}, errors.New("root must be an object")
+	}
+	if err := rejectUnknownKeys(root,
+		"schemaVersion", "id", "name", "version", "contractVersion", "protocol",
+		"adaptiveCardVersion", "renderProfile", "renderProfileCompatibility", "defaultLocale",
+		"owner", "actionType", "dataSchema", "views", "sourceLabel", "sourceIconUrl",
+	); err != nil {
+		return manifestFile{}, err
+	}
+	views, ok := root["views"].(map[string]any)
+	if !ok {
+		return manifestFile{}, errors.New("views must be an object")
+	}
+	for view, raw := range views {
+		viewMap, ok := raw.(map[string]any)
+		if !ok {
+			return manifestFile{}, fmt.Errorf("view %q must be an object", view)
+		}
+		if err := rejectUnknownKeys(viewMap, "wireProfile", "states", "template", "samples"); err != nil {
+			return manifestFile{}, fmt.Errorf("view %q: %w", view, err)
+		}
+	}
+	canonical, err := marshalCanonicalJSON(parsed)
+	if err != nil {
+		return manifestFile{}, err
+	}
+	var mf manifestFile
+	if err := json.Unmarshal(canonical, &mf); err != nil {
+		return manifestFile{}, err
+	}
+	if strings.TrimSpace(string(mf.ID)) == "" || strings.TrimSpace(mf.Version) == "" {
+		return manifestFile{}, errors.New("missing id/version")
+	}
+	if len(mf.Views) == 0 {
+		return manifestFile{}, errors.New("no views")
+	}
+	return mf, nil
+}
+
+func validateRuntimeManifest(mf manifestFile, limits CompileLimits) error {
+	if !artifactTemplateIDRE.MatchString(string(mf.ID)) {
+		return fmt.Errorf("id %q is not canonical", mf.ID)
+	}
+	if !artifactVersionRE.MatchString(mf.Version) {
+		return fmt.Errorf("version %q is not canonical semver", mf.Version)
+	}
+	if limits.RequireOwner && strings.TrimSpace(mf.Owner) == "" {
+		return errors.New("owner is required")
+	}
+	if limits.RequireProtocol && strings.TrimSpace(mf.Protocol) == "" {
+		return errors.New("protocol is required")
+	}
+	if len(mf.Views) > limits.MaxViews {
+		return fmt.Errorf("views exceed %d", limits.MaxViews)
+	}
+	stateCount := 0
+	for view, spec := range mf.Views {
+		if !artifactDocumentKeyRE.MatchString(string(view)) {
+			return fmt.Errorf("view %q is not a safe token", view)
+		}
+		if len(spec.States) == 0 {
+			return fmt.Errorf("view %q has no states", view)
+		}
+		stateCount += len(spec.States)
+		if stateCount > limits.MaxStates {
+			return fmt.Errorf("states exceed %d", limits.MaxStates)
+		}
+		for _, state := range spec.States {
+			if !artifactDocumentKeyRE.MatchString(string(state)) {
+				return fmt.Errorf("state %q is not a safe token", state)
+			}
+		}
+	}
+	return nil
+}
+
+func compileBundleTemplates(ctx context.Context, mf manifestFile, documents map[string]json.RawMessage, budget jsonBudget) (map[ViewKey]any, error) {
+	if err := requireExactDocumentKeys("templates", documents, viewKeys(mf.Views)); err != nil {
+		return nil, err
+	}
+	out := make(map[ViewKey]any, len(mf.Views))
+	for view, spec := range mf.Views {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		expectedPath := path.Join("templates", string(view)+".template.json")
+		if strings.TrimSpace(spec.Template) != expectedPath {
+			return nil, artifactValidationError("manifest", "templates."+string(view), fmt.Errorf("template path %q, want %q", spec.Template, expectedPath))
+		}
+		parsed, err := decodeArtifactDocument("templates."+string(view), documents[string(view)], budget)
+		if err != nil {
+			return nil, err
+		}
+		if _, ok := parsed.(map[string]any); !ok {
+			return nil, artifactValidationError("shape", "templates."+string(view), errors.New("template root must be an object"))
+		}
+		if err := jsontmpl.ValidateToggleTargets(parsed); err != nil {
+			return nil, artifactValidationError("template", "templates."+string(view), err)
+		}
+		out[view] = parsed
+	}
+	return out, nil
+}
+
+func compileBundleReports(mf manifestFile, documents map[string]json.RawMessage, budget jsonBudget) (map[ViewKey]InteractionReport, map[string]any, error) {
+	expected := make(map[string]struct{})
+	for view, spec := range mf.Views {
+		if spec.WireProfile == profileV2 {
+			expected[string(view)] = struct{}{}
+		}
+	}
+	if err := requireExactDocumentKeys("reports", documents, expected); err != nil {
+		return nil, nil, err
+	}
+	interactions := make(map[ViewKey]InteractionReport, len(expected))
+	parsedReports := make(map[string]any, len(expected))
+	for key := range expected {
+		parsed, err := decodeArtifactDocument("reports."+key, documents[key], budget)
+		if err != nil {
+			return nil, nil, err
+		}
+		canonical, err := marshalCanonicalJSON(parsed)
+		if err != nil {
+			return nil, nil, artifactValidationError("canonical", "reports."+key, err)
+		}
+		var report InteractionReport
+		decoder := json.NewDecoder(bytes.NewReader(canonical))
+		decoder.DisallowUnknownFields()
+		if err := decoder.Decode(&report); err != nil {
+			return nil, nil, artifactValidationError("report", "reports."+key, err)
+		}
+		interactions[ViewKey(key)] = report
+		parsedReports[key] = parsed
+	}
+	return interactions, parsedReports, nil
+}
+
+type sampleAssignment struct {
+	view  ViewKey
+	state State
+	key   string
+}
+
+func compileBundleSamples(
+	mf manifestFile,
+	schema *jsonschema.Schema,
+	documents map[string]json.RawMessage,
+	budget jsonBudget,
+	limits CompileLimits,
+) (map[string]any, []sampleAssignment, error) {
+	expected := make(map[string]struct{})
+	assignments := make([]sampleAssignment, 0)
+	for view, spec := range mf.Views {
+		keys := make([]string, 0, len(spec.Samples))
+		for _, samplePath := range spec.Samples {
+			key, err := logicalDocumentKey(samplePath, ".json")
+			if err != nil {
+				return nil, nil, artifactValidationError("manifest", "samples", err)
+			}
+			if _, duplicate := expected[key]; duplicate {
+				return nil, nil, artifactValidationError("manifest", "samples."+key, errors.New("sample is referenced more than once"))
+			}
+			expected[key] = struct{}{}
+			keys = append(keys, key)
+		}
+		if limits.RequireStateSamples && len(keys) < len(spec.States) {
+			return nil, nil, artifactValidationError("manifest", "samples", fmt.Errorf("view %q has %d states but %d samples", view, len(spec.States), len(keys)))
+		}
+		used := make(map[string]struct{}, len(spec.States))
+		for index, state := range spec.States {
+			key := string(state)
+			if _, exists := expected[key]; !exists {
+				if index >= len(keys) {
+					continue
+				}
+				key = keys[index]
+			}
+			if _, duplicate := used[key]; duplicate {
+				return nil, nil, artifactValidationError("manifest", "samples."+key, errors.New("sample cannot cover multiple states in one view"))
+			}
+			used[key] = struct{}{}
+			assignments = append(assignments, sampleAssignment{view: view, state: state, key: key})
+		}
+	}
+	if err := requireExactDocumentKeys("samples", documents, expected); err != nil {
+		return nil, nil, err
+	}
+	parsedSamples := make(map[string]any, len(documents))
+	for key, raw := range documents {
+		parsed, err := decodeArtifactDocument("samples."+key, raw, budget)
+		if err != nil {
+			return nil, nil, err
+		}
+		if err := schema.Validate(parsed); err != nil {
+			return nil, nil, artifactValidationError("schema", "samples."+key, err)
+		}
+		parsedSamples[key] = parsed
+	}
+	return parsedSamples, assignments, nil
+}
+
+func compileBundleGoldens(
+	documents map[string]json.RawMessage,
+	parsedSamples map[string]any,
+	budget jsonBudget,
+	limits CompileLimits,
+) (map[string]any, error) {
+	if len(documents) > limits.MaxGoldens {
+		return nil, artifactValidationError("limit", "goldens", fmt.Errorf("goldens exceed %d", limits.MaxGoldens))
+	}
+	out := make(map[string]any, len(documents))
+	for key, raw := range documents {
+		if _, ok := parsedSamples[key]; !ok {
+			return nil, artifactValidationError("unreferenced", "goldens."+key, errors.New("golden has no matching sample"))
+		}
+		parsed, err := decodeArtifactDocument("goldens."+key, raw, budget)
+		if err != nil {
+			return nil, err
+		}
+		out[key] = parsed
+	}
+	return out, nil
+}
+
+func requireExactDocumentKeys(prefix string, documents map[string]json.RawMessage, expected map[string]struct{}) error {
+	for key := range expected {
+		if _, ok := documents[key]; !ok {
+			return artifactValidationError("missing", prefix+"."+key, errors.New("required document missing"))
+		}
+	}
+	for key := range documents {
+		if _, ok := expected[key]; !ok {
+			return artifactValidationError("unreferenced", prefix+"."+key, errors.New("document is not referenced by manifest"))
+		}
+	}
+	return nil
+}
+
+func viewKeys(views map[ViewKey]manifestView) map[string]struct{} {
+	out := make(map[string]struct{}, len(views))
+	for view := range views {
+		out[string(view)] = struct{}{}
+	}
+	return out
+}
+
+type compiledSelfCheckError struct {
+	document string
+	cause    error
+}
+
+func selfCheckCompiledJSON(
+	ctx context.Context,
+	template *jsonTemplate,
+	meta TemplateMeta,
+	samples map[string]json.RawMessage,
+	assignments []sampleAssignment,
+) *compiledSelfCheckError {
+	for _, assignment := range assignments {
+		if err := ctx.Err(); err != nil {
+			return &compiledSelfCheckError{document: "samples." + assignment.key, cause: err}
+		}
+		raw := samples[assignment.key]
+		payload, err := renderCore(ctx, template, meta, assignment.state, raw, BuildEnv{
+			WebLoginURL: "https://selfcheck.internal",
+			Lang:        "en-US",
+			SpaceID:     "__cardtmpl_compile__",
+		})
+		if err != nil {
+			return &compiledSelfCheckError{document: "samples." + assignment.key, cause: err}
+		}
+		viewSpec := meta.Views[assignment.view]
+		if viewSpec.WireProfile != profileV2 {
+			continue
+		}
+		if meta.ActionContract != nil {
+			if err := assertActionContract(payload, *meta.ActionContract); err != nil {
+				return &compiledSelfCheckError{document: "samples." + assignment.key, cause: err}
+			}
+		}
+		report, ok := meta.Interaction(assignment.view)
+		if !ok {
+			return &compiledSelfCheckError{document: "reports." + string(assignment.view), cause: errors.New("interaction report missing")}
+		}
+		if err := assertInteractionReport(payload, report); err != nil {
+			return &compiledSelfCheckError{document: "reports." + string(assignment.view), cause: err}
+		}
+	}
+	return nil
+}
+
+func checkArtifactGoldens(
+	ctx context.Context,
+	templates map[ViewKey]any,
+	samples map[string]any,
+	goldens map[string]any,
+	assignments []sampleAssignment,
+) error {
+	assignmentByKey := make(map[string]sampleAssignment, len(assignments))
+	for _, assignment := range assignments {
+		assignmentByKey[assignment.key] = assignment
+	}
+	for key, golden := range goldens {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		assignment, ok := assignmentByKey[key]
+		if !ok {
+			return artifactValidationError("golden", "goldens."+key, errors.New("no state assignment"))
+		}
+		data, ok := samples[key].(map[string]any)
+		if !ok {
+			return artifactValidationError("shape", "samples."+key, errors.New("sample root must be an object"))
+		}
+		expanded, err := jsontmpl.Expand(ctx, templates[assignment.view], jsontmpl.Scope{Data: data}, jsonTemplateEscaper)
+		if err != nil {
+			return artifactValidationError("template", "templates."+string(assignment.view), err)
+		}
+		got, err := marshalCanonicalJSON(expanded)
+		if err != nil {
+			return artifactValidationError("canonical", "templates."+string(assignment.view), err)
+		}
+		want, err := marshalCanonicalJSON(golden)
+		if err != nil {
+			return artifactValidationError("canonical", "goldens."+key, err)
+		}
+		if !bytes.Equal(got, want) {
+			return artifactValidationError("golden", "goldens."+key, errors.New("expanded template does not match golden"))
+		}
+	}
+	return nil
+}
+
+func canonicalizeBundle(
+	bundle Bundle,
+	manifest any,
+	schema any,
+	templates map[ViewKey]any,
+	reports map[string]any,
+	samples map[string]any,
+	goldens map[string]any,
+) ([]byte, error) {
+	templateDocuments := make(map[string]any, len(templates))
+	for key, document := range templates {
+		templateDocuments[string(key)] = document
+	}
+	root := map[string]any{
+		"catalog": map[string]any{
+			"engine":     bundle.Catalog.Engine,
+			"visibility": bundle.Catalog.Visibility,
+		},
+		"manifest":  manifest,
+		"schema":    schema,
+		"templates": templateDocuments,
+		"reports":   reports,
+		"samples":   samples,
+		"goldens":   goldens,
+	}
+	return marshalCanonicalJSON(root)
+}
+
+func cloneRawMessageMap(in map[string]json.RawMessage) map[string]json.RawMessage {
+	out := make(map[string]json.RawMessage, len(in))
+	for key, value := range in {
+		out[key] = append(json.RawMessage(nil), value...)
+	}
+	return out
+}
+
+func compileJSONSchema(document any) (*jsonschema.Schema, error) {
+	const schemaURL = "https://octo.internal/card-template/data.schema.json"
+	compiler := jsonschema.NewCompiler()
+	if err := compiler.AddResource(schemaURL, document); err != nil {
+		return nil, fmt.Errorf("add schema resource: %w", err)
+	}
+	schema, err := compiler.Compile(schemaURL)
+	if err != nil {
+		return nil, fmt.Errorf("compile schema: %w", err)
+	}
+	return schema, nil
+}
+
+func parseAggregateArrayLimits(schema map[string]any) ([]jsonTemplateAggregateArrayLimit, error) {
+	raw, exists := schema["x-octo-constraints"]
+	if !exists {
+		return nil, nil
+	}
+	constraints, ok := raw.(map[string]any)
+	if !ok {
+		return nil, errors.New("x-octo-constraints must be an object")
+	}
+	if err := rejectUnknownKeys(constraints, "aggregateArrayLimits"); err != nil {
+		return nil, err
+	}
+	rawLimits, ok := constraints["aggregateArrayLimits"].([]any)
+	if !ok || len(rawLimits) == 0 {
+		return nil, errors.New("x-octo-constraints.aggregateArrayLimits must be a non-empty array")
+	}
+	limits := make([]jsonTemplateAggregateArrayLimit, 0, len(rawLimits))
+	seen := make(map[string]struct{}, len(rawLimits))
+	for index, rawLimit := range rawLimits {
+		entry, ok := rawLimit.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("aggregateArrayLimits[%d] must be an object", index)
+		}
+		if err := rejectUnknownKeys(entry, "parentArray", "childArray", "maxTotalItems"); err != nil {
+			return nil, fmt.Errorf("aggregateArrayLimits[%d]: %w", index, err)
+		}
+		parent, _ := entry["parentArray"].(string)
+		child, _ := entry["childArray"].(string)
+		if parent == "" || parent != strings.TrimSpace(parent) {
+			return nil, fmt.Errorf("aggregateArrayLimits[%d].parentArray is required and must be trimmed", index)
+		}
+		if child == "" || child != strings.TrimSpace(child) {
+			return nil, fmt.Errorf("aggregateArrayLimits[%d].childArray is required and must be trimmed", index)
+		}
+		maxItems, err := positiveJSONInt(entry["maxTotalItems"])
+		if err != nil {
+			return nil, fmt.Errorf("aggregateArrayLimits[%d].maxTotalItems must be positive", index)
+		}
+		key := parent + "\x00" + child
+		if _, duplicate := seen[key]; duplicate {
+			return nil, fmt.Errorf("duplicate aggregateArrayLimits target %s[].%s", parent, child)
+		}
+		seen[key] = struct{}{}
+		limit := jsonTemplateAggregateArrayLimit{ParentArray: parent, ChildArray: child, MaxTotalItems: maxItems}
+		if err := validateAggregateTarget(schema, limit); err != nil {
+			return nil, err
+		}
+		limits = append(limits, limit)
+	}
+	return limits, nil
+}
+
+func positiveJSONInt(value any) (int, error) {
+	number, ok := value.(json.Number)
+	if !ok {
+		return 0, errors.New("not a number")
+	}
+	parsed, err := strconv.ParseInt(number.String(), 10, 32)
+	if err != nil || parsed <= 0 {
+		return 0, errors.New("not a positive integer")
+	}
+	return int(parsed), nil
+}
+
+func validateAggregateTarget(schema map[string]any, limit jsonTemplateAggregateArrayLimit) error {
+	properties, ok := schema["properties"].(map[string]any)
+	if !ok {
+		return errors.New("schema properties must be an object")
+	}
+	parent, exists := properties[limit.ParentArray]
+	if !exists {
+		return fmt.Errorf("aggregate parentArray %q not found", limit.ParentArray)
+	}
+	parentSchema, ok := parent.(map[string]any)
+	if !ok || parentSchema["type"] != "array" {
+		return fmt.Errorf("aggregate parentArray %q must be an array of objects", limit.ParentArray)
+	}
+	items, ok := parentSchema["items"].(map[string]any)
+	if !ok || items["type"] != "object" {
+		return fmt.Errorf("aggregate parentArray %q must be an array of objects", limit.ParentArray)
+	}
+	itemProperties, ok := items["properties"].(map[string]any)
+	if !ok {
+		return fmt.Errorf("aggregate parentArray %q item properties missing", limit.ParentArray)
+	}
+	child, exists := itemProperties[limit.ChildArray]
+	if !exists {
+		return fmt.Errorf("aggregate childArray %q not found under %q", limit.ChildArray, limit.ParentArray)
+	}
+	childSchema, ok := child.(map[string]any)
+	if !ok || childSchema["type"] != "array" {
+		return fmt.Errorf("aggregate childArray %q under %q must be an array", limit.ChildArray, limit.ParentArray)
+	}
+	return nil
+}
+
+func rejectExternalSchemaRefs(value any) error {
+	switch node := value.(type) {
+	case []any:
+		for _, child := range node {
+			if err := rejectExternalSchemaRefs(child); err != nil {
+				return err
+			}
+		}
+	case map[string]any:
+		if raw, exists := node["$ref"]; exists {
+			ref, ok := raw.(string)
+			if !ok || !strings.HasPrefix(ref, "#") {
+				return fmt.Errorf("external $ref %q is forbidden", ref)
+			}
+		}
+		for _, child := range node {
+			if err := rejectExternalSchemaRefs(child); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func validateBoundedInputSchema(root map[string]any) error {
+	if root["type"] != "object" {
+		return errors.New("root schema type must be object")
+	}
+	if additional, ok := root["additionalProperties"].(bool); !ok || additional {
+		return errors.New("root schema additionalProperties must be false")
+	}
+	return validateBoundedSchemaNode(root, "$", make(map[any]struct{}))
+}
+
+func validateBoundedSchemaNode(value any, location string, seen map[any]struct{}) error {
+	// Parsed JSON is acyclic; seen only prevents accidental future cyclic input
+	// when this helper is reused with a caller-constructed map.
+	switch node := value.(type) {
+	case []any:
+		for index, child := range node {
+			if err := validateBoundedSchemaNode(child, fmt.Sprintf("%s[%d]", location, index), seen); err != nil {
+				return err
+			}
+		}
+		return nil
+	case map[string]any:
+		kind, _ := node["type"].(string)
+		switch kind {
+		case "string":
+			_, hasConst := node["const"]
+			enum, hasEnum := node["enum"].([]any)
+			if _, err := positiveJSONInt(node["maxLength"]); err != nil && !hasConst && (!hasEnum || len(enum) == 0) {
+				return fmt.Errorf("%s string is unbounded", location)
+			}
+		case "array":
+			if _, err := positiveJSONInt(node["maxItems"]); err != nil {
+				return fmt.Errorf("%s array is unbounded", location)
+			}
+			if _, ok := node["items"].(map[string]any); !ok {
+				return fmt.Errorf("%s array items schema missing", location)
+			}
+		case "object":
+			if additional, ok := node["additionalProperties"].(bool); !ok || additional {
+				return fmt.Errorf("%s object additionalProperties must be false", location)
+			}
+		}
+		for key, child := range node {
+			if key == "examples" || key == "default" || key == "enum" || key == "const" {
+				continue
+			}
+			if err := validateBoundedSchemaNode(child, location+"."+key, seen); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func rejectUnknownKeys(object map[string]any, allowed ...string) error {
+	set := make(map[string]struct{}, len(allowed))
+	for _, key := range allowed {
+		set[key] = struct{}{}
+	}
+	for key := range object {
+		if _, ok := set[key]; !ok {
+			return fmt.Errorf("unknown key %q", key)
+		}
+	}
+	return nil
+}
+
+type jsonBudget struct {
+	maxDepth int
+	maxNodes int
+	nodes    int
+}
+
+func decodeStrictJSON(raw []byte, budget jsonBudget) (any, error) {
+	if !utf8.Valid(raw) {
+		return nil, errors.New("invalid UTF-8")
+	}
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
+	value, err := decodeStrictJSONValue(decoder, &budget, 1)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := decoder.Token(); !errors.Is(err, io.EOF) {
+		if err == nil {
+			return nil, errors.New("trailing JSON token")
+		}
+		return nil, fmt.Errorf("trailing JSON token: %w", err)
+	}
+	return value, nil
+}
+
+func decodeStrictJSONValue(decoder *json.Decoder, budget *jsonBudget, depth int) (any, error) {
+	if depth > budget.maxDepth {
+		return nil, fmt.Errorf("JSON depth exceeds %d", budget.maxDepth)
+	}
+	budget.nodes++
+	if budget.nodes > budget.maxNodes {
+		return nil, fmt.Errorf("JSON nodes exceed %d", budget.maxNodes)
+	}
+	token, err := decoder.Token()
+	if err != nil {
+		return nil, err
+	}
+	switch token := token.(type) {
+	case json.Delim:
+		switch token {
+		case '{':
+			object := make(map[string]any)
+			for decoder.More() {
+				keyToken, err := decoder.Token()
+				if err != nil {
+					return nil, err
+				}
+				key, ok := keyToken.(string)
+				if !ok {
+					return nil, errors.New("object key is not a string")
+				}
+				if _, duplicate := object[key]; duplicate {
+					return nil, fmt.Errorf("duplicate object key %q", key)
+				}
+				value, err := decodeStrictJSONValue(decoder, budget, depth+1)
+				if err != nil {
+					return nil, err
+				}
+				object[key] = value
+			}
+			closing, err := decoder.Token()
+			if err != nil || closing != json.Delim('}') {
+				return nil, errors.New("object is not closed")
+			}
+			return object, nil
+		case '[':
+			array := make([]any, 0)
+			for decoder.More() {
+				value, err := decodeStrictJSONValue(decoder, budget, depth+1)
+				if err != nil {
+					return nil, err
+				}
+				array = append(array, value)
+			}
+			closing, err := decoder.Token()
+			if err != nil || closing != json.Delim(']') {
+				return nil, errors.New("array is not closed")
+			}
+			return array, nil
+		default:
+			return nil, fmt.Errorf("unexpected delimiter %q", token)
+		}
+	case json.Number:
+		if _, err := canonicalJSONNumber(token); err != nil {
+			return nil, err
+		}
+		return token, nil
+	case string, bool, nil:
+		return token, nil
+	default:
+		return nil, fmt.Errorf("unsupported JSON token %T", token)
+	}
+}
+
+func marshalCanonicalJSON(value any) ([]byte, error) {
+	var buffer bytes.Buffer
+	if err := appendCanonicalJSON(&buffer, value); err != nil {
+		return nil, err
+	}
+	return buffer.Bytes(), nil
+}
+
+func appendCanonicalJSON(buffer *bytes.Buffer, value any) error {
+	switch value := value.(type) {
+	case nil:
+		buffer.WriteString("null")
+	case bool:
+		if value {
+			buffer.WriteString("true")
+		} else {
+			buffer.WriteString("false")
+		}
+	case string:
+		encoded, err := marshalJSONString(value)
+		if err != nil {
+			return err
+		}
+		buffer.Write(encoded)
+	case json.Number:
+		canonical, err := canonicalJSONNumber(value)
+		if err != nil {
+			return err
+		}
+		buffer.WriteString(canonical)
+	case float64:
+		canonical, err := canonicalJSONNumber(json.Number(strconv.FormatFloat(value, 'g', -1, 64)))
+		if err != nil {
+			return err
+		}
+		buffer.WriteString(canonical)
+	case []any:
+		buffer.WriteByte('[')
+		for index, child := range value {
+			if index > 0 {
+				buffer.WriteByte(',')
+			}
+			if err := appendCanonicalJSON(buffer, child); err != nil {
+				return err
+			}
+		}
+		buffer.WriteByte(']')
+	case map[string]any:
+		keys := make([]string, 0, len(value))
+		for key := range value {
+			keys = append(keys, key)
+		}
+		sort.Slice(keys, func(i, j int) bool { return utf16Less(keys[i], keys[j]) })
+		buffer.WriteByte('{')
+		for index, key := range keys {
+			if index > 0 {
+				buffer.WriteByte(',')
+			}
+			encoded, err := marshalJSONString(key)
+			if err != nil {
+				return err
+			}
+			buffer.Write(encoded)
+			buffer.WriteByte(':')
+			if err := appendCanonicalJSON(buffer, value[key]); err != nil {
+				return err
+			}
+		}
+		buffer.WriteByte('}')
+	default:
+		encoded, err := json.Marshal(value)
+		if err != nil {
+			return err
+		}
+		parsed, err := decodeStrictJSON(encoded, jsonBudget{maxDepth: maxArtifactJSONDepth, maxNodes: maxArtifactJSONNodes})
+		if err != nil {
+			return err
+		}
+		return appendCanonicalJSON(buffer, parsed)
+	}
+	return nil
+}
+
+func marshalJSONString(value string) ([]byte, error) {
+	var buffer bytes.Buffer
+	encoder := json.NewEncoder(&buffer)
+	encoder.SetEscapeHTML(false)
+	if err := encoder.Encode(value); err != nil {
+		return nil, err
+	}
+	return bytes.TrimSuffix(buffer.Bytes(), []byte{'\n'}), nil
+}
+
+func canonicalJSONNumber(number json.Number) (string, error) {
+	value, err := strconv.ParseFloat(number.String(), 64)
+	if err != nil || math.IsInf(value, 0) || math.IsNaN(value) {
+		return "", fmt.Errorf("number %q is outside finite float64 range", number)
+	}
+	if value == 0 {
+		return "0", nil
+	}
+	if !strings.ContainsAny(number.String(), ".eE") && math.Abs(value) > 1<<53-1 {
+		return "", fmt.Errorf("integer %q exceeds exact JSON range", number)
+	}
+	formatted := strconv.FormatFloat(value, 'g', -1, 64)
+	if index := strings.IndexByte(formatted, 'e'); index >= 0 {
+		mantissa, exponent := formatted[:index], formatted[index+1:]
+		sign := ""
+		if strings.HasPrefix(exponent, "+") || strings.HasPrefix(exponent, "-") {
+			sign, exponent = exponent[:1], exponent[1:]
+		}
+		exponent = strings.TrimLeft(exponent, "0")
+		if exponent == "" {
+			exponent = "0"
+		}
+		formatted = mantissa + "e" + sign + exponent
+	}
+	return formatted, nil
+}
+
+func utf16Less(left, right string) bool {
+	a := utf16.Encode([]rune(left))
+	b := utf16.Encode([]rune(right))
+	for index := 0; index < len(a) && index < len(b); index++ {
+		if a[index] != b[index] {
+			return a[index] < b[index]
+		}
+	}
+	return len(a) < len(b)
+}
+
+// Keep the package-level reference explicit: compile-time validation and final
+// render both terminate at cardmsg validation, never at a runtime uploader.
+var _ = cardmsg.CardVersion

--- a/pkg/cardtmpl/json_artifact.go
+++ b/pkg/cardtmpl/json_artifact.go
@@ -448,7 +448,11 @@ func CompileJSONArtifact(ctx context.Context, bundle Bundle, limits CompileLimit
 		return nil, err
 	}
 
-	meta, err := assembleTemplateMeta(mf, schema, interactions, bundle.Manifest)
+	canonicalManifest, err := marshalCanonicalJSON(manifestDoc)
+	if err != nil {
+		return nil, artifactValidationError("canonical", "manifest", err)
+	}
+	meta, err := assembleTemplateMeta(mf, schema, interactions, canonicalManifest)
 	if err != nil {
 		return nil, artifactValidationError("manifest", "manifest", err)
 	}

--- a/pkg/cardtmpl/json_artifact.go
+++ b/pkg/cardtmpl/json_artifact.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"io/fs"
 	"math"
+	"net/url"
 	"path"
 	"regexp"
 	"runtime"
@@ -762,6 +763,7 @@ func compileBundleSamples(
 	assignments := make([]sampleAssignment, 0)
 	for view, spec := range mf.Views {
 		keys := make([]string, 0, len(spec.Samples))
+		viewSamples := make(map[string]struct{}, len(spec.Samples))
 		for _, samplePath := range spec.Samples {
 			key, err := logicalDocumentKey(samplePath, ".json")
 			if err != nil {
@@ -776,6 +778,7 @@ func compileBundleSamples(
 				return nil, nil, artifactValidationError("manifest", "samples."+key, errors.New("sample is referenced more than once"))
 			}
 			expected[key] = struct{}{}
+			viewSamples[key] = struct{}{}
 			keys = append(keys, key)
 		}
 		if limits.RequireStateSamples && len(keys) != len(spec.States) {
@@ -784,7 +787,7 @@ func compileBundleSamples(
 		used := make(map[string]struct{}, len(spec.States))
 		for index, state := range spec.States {
 			key := string(state)
-			if _, exists := expected[key]; !exists {
+			if _, exists := viewSamples[key]; !exists {
 				if index >= len(keys) {
 					continue
 				}
@@ -1122,14 +1125,23 @@ func validateBoundedInputSchema(root map[string]any) error {
 	if additional, ok := root["additionalProperties"].(bool); !ok || additional {
 		return errors.New("root schema additionalProperties must be false")
 	}
-	return validateBoundedSchemaNode(root, "$")
+	validator := boundedSchemaValidator{
+		root:      root,
+		resolving: make(map[string]struct{}),
+	}
+	return validator.validateNode(root, "$")
 }
 
-func validateBoundedSchemaNode(value any, location string) error {
+type boundedSchemaValidator struct {
+	root      map[string]any
+	resolving map[string]struct{}
+}
+
+func (v *boundedSchemaValidator) validateNode(value any, location string) error {
 	switch node := value.(type) {
 	case []any:
 		for index, child := range node {
-			if err := validateBoundedSchemaNode(child, fmt.Sprintf("%s[%d]", location, index)); err != nil {
+			if err := v.validateNode(child, fmt.Sprintf("%s[%d]", location, index)); err != nil {
 				return err
 			}
 		}
@@ -1162,7 +1174,7 @@ func validateBoundedSchemaNode(value any, location string) error {
 		}
 		if properties, ok := node["properties"].(map[string]any); ok {
 			for name, property := range properties {
-				if err := validateBoundedPropertySchema(property, location+".properties."+name); err != nil {
+				if err := v.validatePropertySchema(property, location+".properties."+name); err != nil {
 					return err
 				}
 			}
@@ -1171,7 +1183,7 @@ func validateBoundedSchemaNode(value any, location string) error {
 			if key == "examples" || key == "default" || key == "enum" || key == "const" {
 				continue
 			}
-			if err := validateBoundedSchemaNode(child, location+"."+key); err != nil {
+			if err := v.validateNode(child, location+"."+key); err != nil {
 				return err
 			}
 		}
@@ -1208,7 +1220,7 @@ func schemaTypeNames(raw any, location string) ([]string, error) {
 	}
 }
 
-func validateBoundedPropertySchema(value any, location string) error {
+func (v *boundedSchemaValidator) validatePropertySchema(value any, location string) error {
 	if allowed, ok := value.(bool); ok {
 		if !allowed {
 			return nil
@@ -1220,7 +1232,7 @@ func validateBoundedPropertySchema(value any, location string) error {
 		return fmt.Errorf("%s must be a schema object", location)
 	}
 	if _, hasType := node["type"]; hasType {
-		return nil
+		return v.validateNode(node, location)
 	}
 	if _, hasConst := node["const"]; hasConst {
 		return nil
@@ -1229,12 +1241,21 @@ func validateBoundedPropertySchema(value any, location string) error {
 		return nil
 	}
 	if ref, hasRef := node["$ref"].(string); hasRef && strings.HasPrefix(ref, "#") {
-		return nil
+		if _, cycle := v.resolving[ref]; cycle {
+			return fmt.Errorf("%s local $ref %q is cyclic", location, ref)
+		}
+		target, err := resolveLocalSchemaRef(v.root, ref)
+		if err != nil {
+			return fmt.Errorf("%s local $ref %q: %w", location, ref, err)
+		}
+		v.resolving[ref] = struct{}{}
+		defer delete(v.resolving, ref)
+		return v.validatePropertySchema(target, location+".$ref")
 	}
 	for _, keyword := range []string{"anyOf", "oneOf"} {
 		if alternatives, exists := node[keyword].([]any); exists && len(alternatives) > 0 {
 			for index, alternative := range alternatives {
-				if err := validateBoundedPropertySchema(alternative, fmt.Sprintf("%s.%s[%d]", location, keyword, index)); err != nil {
+				if err := v.validatePropertySchema(alternative, fmt.Sprintf("%s.%s[%d]", location, keyword, index)); err != nil {
 					return err
 				}
 			}
@@ -1243,12 +1264,72 @@ func validateBoundedPropertySchema(value any, location string) error {
 	}
 	if constraints, exists := node["allOf"].([]any); exists && len(constraints) > 0 {
 		for index, constraint := range constraints {
-			if validateBoundedPropertySchema(constraint, fmt.Sprintf("%s.allOf[%d]", location, index)) == nil {
+			if v.validatePropertySchema(constraint, fmt.Sprintf("%s.allOf[%d]", location, index)) == nil {
 				return nil
 			}
 		}
 	}
 	return fmt.Errorf("%s must declare a bounded type, enum, const, or local $ref", location)
+}
+
+func resolveLocalSchemaRef(root map[string]any, ref string) (any, error) {
+	if ref == "#" {
+		return root, nil
+	}
+	if !strings.HasPrefix(ref, "#/") {
+		return nil, errors.New("only local JSON Pointer references are supported")
+	}
+	pointer, err := url.PathUnescape(strings.TrimPrefix(ref, "#"))
+	if err != nil {
+		return nil, fmt.Errorf("decode JSON Pointer: %w", err)
+	}
+	var current any = root
+	for _, encodedToken := range strings.Split(strings.TrimPrefix(pointer, "/"), "/") {
+		token, err := decodeJSONPointerToken(encodedToken)
+		if err != nil {
+			return nil, err
+		}
+		switch node := current.(type) {
+		case map[string]any:
+			child, exists := node[token]
+			if !exists {
+				return nil, fmt.Errorf("JSON Pointer token %q does not exist", token)
+			}
+			current = child
+		case []any:
+			index, err := strconv.Atoi(token)
+			if err != nil || index < 0 || index >= len(node) {
+				return nil, fmt.Errorf("JSON Pointer array index %q is invalid", token)
+			}
+			current = node[index]
+		default:
+			return nil, fmt.Errorf("JSON Pointer token %q traverses a non-container", token)
+		}
+	}
+	return current, nil
+}
+
+func decodeJSONPointerToken(token string) (string, error) {
+	var decoded strings.Builder
+	for index := 0; index < len(token); index++ {
+		if token[index] != '~' {
+			decoded.WriteByte(token[index])
+			continue
+		}
+		if index+1 >= len(token) {
+			return "", errors.New("invalid trailing '~' in JSON Pointer token")
+		}
+		index++
+		switch token[index] {
+		case '0':
+			decoded.WriteByte('~')
+		case '1':
+			decoded.WriteByte('/')
+		default:
+			return "", fmt.Errorf("invalid JSON Pointer escape ~%c", token[index])
+		}
+	}
+	return decoded.String(), nil
 }
 
 func rejectUnknownKeys(object map[string]any, allowed ...string) error {

--- a/pkg/cardtmpl/json_artifact.go
+++ b/pkg/cardtmpl/json_artifact.go
@@ -1104,16 +1104,14 @@ func validateBoundedInputSchema(root map[string]any) error {
 	if additional, ok := root["additionalProperties"].(bool); !ok || additional {
 		return errors.New("root schema additionalProperties must be false")
 	}
-	return validateBoundedSchemaNode(root, "$", make(map[any]struct{}))
+	return validateBoundedSchemaNode(root, "$")
 }
 
-func validateBoundedSchemaNode(value any, location string, seen map[any]struct{}) error {
-	// Parsed JSON is acyclic; seen only prevents accidental future cyclic input
-	// when this helper is reused with a caller-constructed map.
+func validateBoundedSchemaNode(value any, location string) error {
 	switch node := value.(type) {
 	case []any:
 		for index, child := range node {
-			if err := validateBoundedSchemaNode(child, fmt.Sprintf("%s[%d]", location, index), seen); err != nil {
+			if err := validateBoundedSchemaNode(child, fmt.Sprintf("%s[%d]", location, index)); err != nil {
 				return err
 			}
 		}
@@ -1143,7 +1141,7 @@ func validateBoundedSchemaNode(value any, location string, seen map[any]struct{}
 			if key == "examples" || key == "default" || key == "enum" || key == "const" {
 				continue
 			}
-			if err := validateBoundedSchemaNode(child, location+"."+key, seen); err != nil {
+			if err := validateBoundedSchemaNode(child, location+"."+key); err != nil {
 				return err
 			}
 		}

--- a/pkg/cardtmpl/json_artifact.go
+++ b/pkg/cardtmpl/json_artifact.go
@@ -45,8 +45,12 @@ var (
 	ErrArtifactCompileBusy = errors.New("cardtmpl: artifact compiler busy")
 	artifactDocumentKeyRE  = regexp.MustCompile(`^[a-z][a-z0-9_.-]{0,63}$`)
 	artifactTemplateIDRE   = regexp.MustCompile(`^[a-z][a-z0-9]*(?:[.-][a-z0-9][a-z0-9-]*)+$`)
-	artifactVersionRE      = regexp.MustCompile(`^[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$`)
-	artifactActionTypeRE   = regexp.MustCompile(`^[a-z][a-z0-9_.-]{0,127}$`)
+	artifactVersionRE      = regexp.MustCompile(
+		`^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)` +
+			`(?:-(?:0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*))*)?` +
+			`(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$`,
+	)
+	artifactActionTypeRE = regexp.MustCompile(`^[a-z][a-z0-9_.-]{0,127}$`)
 
 	artifactCompileQueue = make(chan struct{}, 16)
 	artifactCompileSlots = make(chan struct{}, max(2, runtime.GOMAXPROCS(0)/2))
@@ -1172,6 +1176,9 @@ func decodeStrictJSON(raw []byte, budget jsonBudget) (any, error) {
 	if !utf8.Valid(raw) {
 		return nil, errors.New("invalid UTF-8")
 	}
+	if err := validateJSONUnicodeEscapes(raw); err != nil {
+		return nil, err
+	}
 	decoder := json.NewDecoder(bytes.NewReader(raw))
 	decoder.UseNumber()
 	value, err := decodeStrictJSONValue(decoder, &budget, 1)
@@ -1183,6 +1190,59 @@ func decodeStrictJSON(raw []byte, budget jsonBudget) (any, error) {
 			return nil, errors.New("trailing JSON token")
 		}
 		return nil, fmt.Errorf("trailing JSON token: %w", err)
+	}
+	return value, nil
+}
+
+func validateJSONUnicodeEscapes(raw []byte) error {
+	inString := false
+	for index := 0; index < len(raw); index++ {
+		switch raw[index] {
+		case '"':
+			inString = !inString
+		case '\\':
+			if !inString || index+1 >= len(raw) {
+				continue
+			}
+			if raw[index+1] != 'u' {
+				index++
+				continue
+			}
+			codepoint, err := parseJSONUnicodeEscape(raw, index)
+			if err != nil {
+				return err
+			}
+			switch {
+			case codepoint >= 0xD800 && codepoint <= 0xDBFF:
+				next := index + 6
+				if next+5 >= len(raw) || raw[next] != '\\' || raw[next+1] != 'u' {
+					return fmt.Errorf("high surrogate \\u%04x is not followed by a low surrogate", codepoint)
+				}
+				low, err := parseJSONUnicodeEscape(raw, next)
+				if err != nil {
+					return err
+				}
+				if low < 0xDC00 || low > 0xDFFF {
+					return fmt.Errorf("high surrogate \\u%04x is followed by non-low surrogate \\u%04x", codepoint, low)
+				}
+				index = next + 5
+			case codepoint >= 0xDC00 && codepoint <= 0xDFFF:
+				return fmt.Errorf("unpaired low surrogate \\u%04x", codepoint)
+			default:
+				index += 5
+			}
+		}
+	}
+	return nil
+}
+
+func parseJSONUnicodeEscape(raw []byte, slashIndex int) (uint64, error) {
+	if slashIndex+5 >= len(raw) || raw[slashIndex] != '\\' || raw[slashIndex+1] != 'u' {
+		return 0, errors.New("truncated Unicode escape")
+	}
+	value, err := strconv.ParseUint(string(raw[slashIndex+2:slashIndex+6]), 16, 16)
+	if err != nil {
+		return 0, fmt.Errorf("invalid Unicode escape: %w", err)
 	}
 	return value, nil
 }

--- a/pkg/cardtmpl/json_artifact_compiler_test.go
+++ b/pkg/cardtmpl/json_artifact_compiler_test.go
@@ -1,6 +1,7 @@
 package cardtmpl
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -27,7 +28,11 @@ func TestCompileJSONArtifactProducesStableCanonicalArtifact(t *testing.T) {
 
 	// Formatting and map insertion order are not part of the immutable identity.
 	secondBundle := validJSONArtifactBundle()
-	secondBundle.Schema = json.RawMessage(strings.ReplaceAll(string(secondBundle.Schema), ":", " : "))
+	var formattedSchema bytes.Buffer
+	if err := json.Indent(&formattedSchema, secondBundle.Schema, "", "  "); err != nil {
+		t.Fatalf("format schema fixture: %v", err)
+	}
+	secondBundle.Schema = append(json.RawMessage(nil), formattedSchema.Bytes()...)
 	secondBundle.Templates = map[string]json.RawMessage{
 		"main": secondBundle.Templates["main"],
 	}

--- a/pkg/cardtmpl/json_artifact_compiler_test.go
+++ b/pkg/cardtmpl/json_artifact_compiler_test.go
@@ -229,6 +229,7 @@ func validJSONArtifactBundle() Bundle {
 			"version":"1.0.0",
 			"contractVersion":"1.0.0",
 			"protocol":"octo-card@1.0",
+			"adaptiveCardVersion":"1.5",
 			"owner":"ai",
 			"dataSchema":"contract/data.schema.json",
 			"views":{"main":{"wireProfile":"octo/v1","states":["shown"],"template":"templates/main.template.json","samples":["samples/shown.json"]}}

--- a/pkg/cardtmpl/json_artifact_compiler_test.go
+++ b/pkg/cardtmpl/json_artifact_compiler_test.go
@@ -28,6 +28,11 @@ func TestCompileJSONArtifactProducesStableCanonicalArtifact(t *testing.T) {
 
 	// Formatting and map insertion order are not part of the immutable identity.
 	secondBundle := validJSONArtifactBundle()
+	var compactManifest bytes.Buffer
+	if err := json.Compact(&compactManifest, secondBundle.Manifest); err != nil {
+		t.Fatalf("compact manifest fixture: %v", err)
+	}
+	secondBundle.Manifest = append(json.RawMessage(nil), compactManifest.Bytes()...)
 	var formattedSchema bytes.Buffer
 	if err := json.Indent(&formattedSchema, secondBundle.Schema, "", "  "); err != nil {
 		t.Fatalf("format schema fixture: %v", err)
@@ -42,6 +47,9 @@ func TestCompileJSONArtifactProducesStableCanonicalArtifact(t *testing.T) {
 	}
 	if first.Hash != second.Hash || string(first.Bundle) != string(second.Bundle) {
 		t.Fatalf("canonical artifact drifted: first=%s second=%s", first.Hash, second.Hash)
+	}
+	if !bytes.Equal(first.Meta.Manifest, second.Meta.Manifest) {
+		t.Fatal("canonical artifact produced formatting-dependent manifest metadata")
 	}
 
 	fields := json.RawMessage(`{"title":"hello","groups":[{"items":["a"]}]}`)

--- a/pkg/cardtmpl/json_artifact_compiler_test.go
+++ b/pkg/cardtmpl/json_artifact_compiler_test.go
@@ -1,0 +1,259 @@
+package cardtmpl
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestCompileJSONArtifactProducesStableCanonicalArtifact(t *testing.T) {
+	bundle := validJSONArtifactBundle()
+	first, err := CompileJSONArtifact(context.Background(), bundle, DefaultCompileLimits())
+	if err != nil {
+		t.Fatalf("CompileJSONArtifact: %v", err)
+	}
+	if first.Meta.ID != "test.runtime-card" || first.Meta.Version != "1.0.0" {
+		t.Fatalf("compiled identity = %s@%s", first.Meta.ID, first.Meta.Version)
+	}
+	if len(first.Hash) != 64 {
+		t.Fatalf("hash length = %d, want 64", len(first.Hash))
+	}
+	if len(first.Bundle) == 0 {
+		t.Fatal("canonical bundle is empty")
+	}
+
+	// Formatting and map insertion order are not part of the immutable identity.
+	secondBundle := validJSONArtifactBundle()
+	secondBundle.Schema = json.RawMessage(strings.ReplaceAll(string(secondBundle.Schema), ":", " : "))
+	secondBundle.Templates = map[string]json.RawMessage{
+		"main": secondBundle.Templates["main"],
+	}
+	second, err := CompileJSONArtifact(context.Background(), secondBundle, DefaultCompileLimits())
+	if err != nil {
+		t.Fatalf("CompileJSONArtifact reformatted: %v", err)
+	}
+	if first.Hash != second.Hash || string(first.Bundle) != string(second.Bundle) {
+		t.Fatalf("canonical artifact drifted: first=%s second=%s", first.Hash, second.Hash)
+	}
+
+	fields := json.RawMessage(`{"title":"hello","groups":[{"items":["a"]}]}`)
+	card, err := first.Template.Build(context.Background(), "shown", fields, BuildEnv{Lang: "en-US"})
+	if err != nil {
+		t.Fatalf("compiled template Build: %v", err)
+	}
+	if len(card.Body) != 1 {
+		t.Fatalf("compiled card body len = %d, want 1", len(card.Body))
+	}
+}
+
+func TestCompileJSONArtifactReturnsTypedErrorsWithoutPanicking(t *testing.T) {
+	tests := []struct {
+		name       string
+		constraint string
+		properties string
+		want       string
+	}{
+		{
+			name:       "unknown constraint key",
+			constraint: `{"aggregateArrayLimits":[{"parentArray":"groups","childArray":"items","maxTotalItems":2}],"unknown":true}`,
+			want:       "unknown",
+		},
+		{name: "empty constraint list", constraint: `{"aggregateArrayLimits":[]}`, want: "aggregateArrayLimits"},
+		{
+			name:       "blank parent",
+			constraint: `{"aggregateArrayLimits":[{"parentArray":" ","childArray":"items","maxTotalItems":2}]}`,
+			want:       "parentArray",
+		},
+		{
+			name:       "untrimmed child",
+			constraint: `{"aggregateArrayLimits":[{"parentArray":"groups","childArray":" items","maxTotalItems":2}]}`,
+			want:       "childArray",
+		},
+		{
+			name:       "non-positive limit",
+			constraint: `{"aggregateArrayLimits":[{"parentArray":"groups","childArray":"items","maxTotalItems":0}]}`,
+			want:       "maxTotalItems",
+		},
+		{
+			name: "duplicate target",
+			constraint: `{"aggregateArrayLimits":[` +
+				`{"parentArray":"groups","childArray":"items","maxTotalItems":2},` +
+				`{"parentArray":"groups","childArray":"items","maxTotalItems":3}]}`,
+			want: "duplicate",
+		},
+		{
+			name:       "missing parent",
+			constraint: validAggregateConstraint,
+			properties: `{"title":{"type":"string","maxLength":32}}`,
+			want:       "parentArray",
+		},
+		{
+			name:       "parent wrong type",
+			constraint: validAggregateConstraint,
+			properties: `{"title":{"type":"string","maxLength":32},"groups":{"type":"object","additionalProperties":false}}`,
+			want:       "array of objects",
+		},
+		{
+			name:       "missing child",
+			constraint: validAggregateConstraint,
+			properties: `{"title":{"type":"string","maxLength":32},"groups":{"type":"array","maxItems":2,"items":{"type":"object","additionalProperties":false,"properties":{}}}}`,
+			want:       "childArray",
+		},
+		{
+			name:       "child wrong type",
+			constraint: validAggregateConstraint,
+			properties: `{"title":{"type":"string","maxLength":32},"groups":{"type":"array","maxItems":2,"items":{"type":"object","additionalProperties":false,"properties":{"items":{"type":"string","maxLength":8}}}}}`,
+			want:       "must be an array",
+		},
+		{
+			name:       "invalid child sub-schema",
+			constraint: validAggregateConstraint,
+			properties: `{"title":{"type":"string","maxLength":32},"groups":{"type":"array","maxItems":2,"items":{"type":"object","additionalProperties":false,"properties":{"items":{"type":7}}}}}`,
+			want:       "schema",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bundle := validJSONArtifactBundle()
+			properties := tt.properties
+			if properties == "" {
+				properties = validArtifactProperties
+			}
+			bundle.Schema = json.RawMessage(fmt.Sprintf(
+				`{"$schema":"http://json-schema.org/draft-07/schema#","type":"object","additionalProperties":false,"required":["title"],"properties":%s,"x-octo-constraints":%s}`,
+				properties,
+				tt.constraint,
+			))
+
+			var panicValue any
+			var err error
+			func() {
+				defer func() { panicValue = recover() }()
+				_, err = CompileJSONArtifact(context.Background(), bundle, DefaultCompileLimits())
+			}()
+			if panicValue != nil {
+				t.Fatalf("runtime compiler panicked: %v", panicValue)
+			}
+			if err == nil {
+				t.Fatal("expected validation error")
+			}
+			var validationErr *ArtifactValidationError
+			if !errors.As(err, &validationErr) {
+				t.Fatalf("error %T = %v, want ArtifactValidationError", err, err)
+			}
+			if validationErr.Document != "schema" {
+				t.Fatalf("validation document = %q, want schema", validationErr.Document)
+			}
+			if !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("error = %q, want substring %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestCompileJSONArtifactRejectsAmbiguousJSON(t *testing.T) {
+	tests := []struct {
+		name string
+		doc  func(*Bundle) *json.RawMessage
+		bad  json.RawMessage
+	}{
+		{
+			name: "duplicate key",
+			doc:  func(bundle *Bundle) *json.RawMessage { return &bundle.Manifest },
+			bad:  json.RawMessage(`{"id":"test.runtime-card","id":"other","version":"1.0.0"}`),
+		},
+		{
+			name: "trailing token",
+			doc:  func(bundle *Bundle) *json.RawMessage { return &bundle.Schema },
+			bad:  json.RawMessage(`{} {}`),
+		},
+		{
+			name: "non-finite numeric range",
+			doc:  func(bundle *Bundle) *json.RawMessage { return &bundle.Schema },
+			bad:  json.RawMessage(`{"type":"object","additionalProperties":false,"maximum":1e10000}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bundle := validJSONArtifactBundle()
+			*tt.doc(&bundle) = tt.bad
+			_, err := CompileJSONArtifact(context.Background(), bundle, DefaultCompileLimits())
+			var validationErr *ArtifactValidationError
+			if !errors.As(err, &validationErr) {
+				t.Fatalf("error = %v, want typed validation error", err)
+			}
+		})
+	}
+}
+
+func TestRegisterGoTemplateRejectsJSONOnlyConstraints(t *testing.T) {
+	reg := NewRegistry()
+	var panicValue any
+	func() {
+		defer func() { panicValue = recover() }()
+		reg.Register(&goConstraintTemplate{}, jsonCardTestData, "testdata/test.jsoncard@0.1.0")
+	}()
+	if panicValue == nil {
+		t.Fatal("Go-authored template silently accepted x-octo-constraints")
+	}
+	if !strings.Contains(fmt.Sprint(panicValue), "x-octo-constraints") {
+		t.Fatalf("panic = %v, want x-octo-constraints", panicValue)
+	}
+}
+
+const (
+	validAggregateConstraint = `{"aggregateArrayLimits":[{"parentArray":"groups","childArray":"items","maxTotalItems":2}]}`
+	validArtifactProperties  = `{"title":{"type":"string","maxLength":32},"groups":{"type":"array","maxItems":2,"items":{"type":"object","additionalProperties":false,"properties":{"items":{"type":"array","maxItems":2,"items":{"type":"string","maxLength":8}}}}}}`
+)
+
+func validJSONArtifactBundle() Bundle {
+	return Bundle{
+		Catalog: CatalogDescriptor{
+			Engine:     JSONTemplateEngineV1,
+			Visibility: CatalogVisibilityPrivate,
+		},
+		Manifest: json.RawMessage(`{
+			"schemaVersion":2,
+			"id":"test.runtime-card",
+			"name":"Runtime compiler test",
+			"version":"1.0.0",
+			"contractVersion":"1.0.0",
+			"protocol":"octo-card@1.0",
+			"owner":"ai",
+			"dataSchema":"contract/data.schema.json",
+			"views":{"main":{"wireProfile":"octo/v1","states":["shown"],"template":"templates/main.template.json","samples":["samples/shown.json"]}}
+		}`),
+		Schema: json.RawMessage(fmt.Sprintf(
+			`{"$schema":"http://json-schema.org/draft-07/schema#","type":"object","additionalProperties":false,"required":["title"],"properties":%s,"x-octo-constraints":%s}`,
+			validArtifactProperties,
+			validAggregateConstraint,
+		)),
+		Templates: map[string]json.RawMessage{
+			"main": json.RawMessage(`{"type":"AdaptiveCard","version":"1.5","body":[{"type":"TextBlock","text":"${title}","wrap":true}]}`),
+		},
+		Samples: map[string]json.RawMessage{
+			"shown": json.RawMessage(`{"title":"hello","groups":[{"items":["a"]}]}`),
+		},
+		Goldens: map[string]json.RawMessage{
+			"shown": json.RawMessage(`{"type":"AdaptiveCard","version":"1.5","body":[{"type":"TextBlock","text":"hello","wrap":true}]}`),
+		},
+	}
+}
+
+type goConstraintTemplate struct {
+	meta TemplateMeta
+}
+
+func (t *goConstraintTemplate) SetMeta(meta TemplateMeta) { t.meta = meta }
+func (t *goConstraintTemplate) Meta() TemplateMeta        { return t.meta.Clone() }
+func (t *goConstraintTemplate) Build(context.Context, State, json.RawMessage, BuildEnv) (BuildResult, error) {
+	return BuildResult{Body: []any{map[string]any{"type": "TextBlock", "text": "test"}}}, nil
+}
+func (t *goConstraintTemplate) FallbackText(State, json.RawMessage, string) (string, error) {
+	return "test", nil
+}

--- a/pkg/cardtmpl/json_artifact_compiler_test.go
+++ b/pkg/cardtmpl/json_artifact_compiler_test.go
@@ -157,6 +157,103 @@ func TestCompileBundleSamplesScopesStateLookupToEachView(t *testing.T) {
 	}
 }
 
+func TestCompileBundleSamplesReservesExactMatchesBeforePositionalFallback(t *testing.T) {
+	schema, err := compileJSONSchema(map[string]any{
+		"type": "object", "additionalProperties": false,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifest := manifestFile{Views: map[ViewKey]manifestView{
+		"main": {
+			States:  []State{"foo", "bar"},
+			Samples: []string{"samples/bar.json", "samples/baz.json"},
+		},
+	}}
+	documents := map[string]json.RawMessage{
+		"bar": json.RawMessage(`{}`),
+		"baz": json.RawMessage(`{}`),
+	}
+
+	_, assignments, err := compileBundleSamples(
+		manifest,
+		schema,
+		documents,
+		jsonBudget{maxDepth: maxArtifactJSONDepth, maxNodes: maxArtifactJSONNodes},
+		DefaultCompileLimits(),
+	)
+	if err != nil {
+		t.Fatalf("compileBundleSamples: %v", err)
+	}
+	got := make(map[State]string, len(assignments))
+	for _, assignment := range assignments {
+		got[assignment.state] = assignment.key
+	}
+	if got["foo"] != "baz" || got["bar"] != "bar" {
+		t.Fatalf("assignments = %v, want foo=baz and bar=bar", got)
+	}
+}
+
+func TestCompileJSONArtifactUsesProductionNumberSemanticsForGoldens(t *testing.T) {
+	bundle := validJSONArtifactBundle()
+	bundle.Schema = json.RawMessage(`{
+		"$schema":"http://json-schema.org/draft-07/schema#",
+		"type":"object",
+		"additionalProperties":false,
+		"required":["count"],
+		"properties":{"count":{"type":"integer"}}
+	}`)
+	bundle.Templates["main"] = json.RawMessage(`{
+		"type":"AdaptiveCard",
+		"version":"1.5",
+		"body":[{"type":"TextBlock","text":"${if(count == 1000000, 'equal', 'different')} ${count}"}]
+	}`)
+	bundle.Samples["shown"] = json.RawMessage(`{"count":1000000}`)
+	bundle.Goldens["shown"] = json.RawMessage(`{
+		"type":"AdaptiveCard",
+		"version":"1.5",
+		"body":[{"type":"TextBlock","text":"equal 1e+06"}]
+	}`)
+
+	artifact, err := CompileJSONArtifact(context.Background(), bundle, DefaultCompileLimits())
+	if err != nil {
+		t.Fatalf("CompileJSONArtifact: %v", err)
+	}
+	built, err := artifact.Template.Build(context.Background(), "shown", bundle.Samples["shown"], BuildEnv{})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	text, _ := built.Body[0].(map[string]any)["text"].(string)
+	if text != "equal 1e+06" {
+		t.Fatalf("production text = %q, want golden text", text)
+	}
+}
+
+func TestCompileJSONArtifactCanonicalBundleRecompilesIntegerLimits(t *testing.T) {
+	for _, literal := range []string{"1000000", "1e6"} {
+		t.Run(literal, func(t *testing.T) {
+			bundle := validJSONArtifactBundle()
+			bundle.Schema = artifactSchemaWithIntegerLimits(literal)
+
+			first, err := CompileJSONArtifact(context.Background(), bundle, DefaultCompileLimits())
+			if err != nil {
+				t.Fatalf("first CompileJSONArtifact: %v", err)
+			}
+			stored, err := DecodeBundleJSON(first.Bundle)
+			if err != nil {
+				t.Fatalf("DecodeBundleJSON(canonical): %v", err)
+			}
+			second, err := CompileJSONArtifact(context.Background(), stored, DefaultCompileLimits())
+			if err != nil {
+				t.Fatalf("recompile canonical bundle: %v", err)
+			}
+			if first.Hash != second.Hash || !bytes.Equal(first.Bundle, second.Bundle) {
+				t.Fatalf("canonical round trip drift: first=%s second=%s", first.Hash, second.Hash)
+			}
+		})
+	}
+}
+
 func TestCompileJSONArtifactReturnsTypedErrorsWithoutPanicking(t *testing.T) {
 	tests := []struct {
 		name       string
@@ -352,6 +449,25 @@ func validJSONArtifactBundle() Bundle {
 			"shown": json.RawMessage(`{"type":"AdaptiveCard","version":"1.5","body":[{"type":"TextBlock","text":"hello","wrap":true}]}`),
 		},
 	}
+}
+
+func artifactSchemaWithIntegerLimits(literal string) json.RawMessage {
+	return json.RawMessage(fmt.Sprintf(`{
+		"$schema":"http://json-schema.org/draft-07/schema#",
+		"type":"object",
+		"additionalProperties":false,
+		"required":["title"],
+		"properties":{
+			"title":{"type":"string","maxLength":%[1]s},
+			"groups":{"type":"array","maxItems":%[1]s,"items":{
+				"type":"object","additionalProperties":false,
+				"properties":{"items":{"type":"array","maxItems":%[1]s,"items":{"type":"string","maxLength":8}}}
+			}}
+		},
+		"x-octo-constraints":{"aggregateArrayLimits":[{
+			"parentArray":"groups","childArray":"items","maxTotalItems":%[1]s
+		}]}
+	}`, literal))
 }
 
 type goConstraintTemplate struct {

--- a/pkg/cardtmpl/json_artifact_compiler_test.go
+++ b/pkg/cardtmpl/json_artifact_compiler_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -59,6 +60,100 @@ func TestCompileJSONArtifactProducesStableCanonicalArtifact(t *testing.T) {
 	}
 	if len(card.Body) != 1 {
 		t.Fatalf("compiled card body len = %d, want 1", len(card.Body))
+	}
+}
+
+func TestStaticRegistrationAndRuntimeCompilerHaveCanonicalParity(t *testing.T) {
+	const root = "testdata/test.runtime-parity@1.0.0"
+	bundle, err := LoadJSONBundle(jsonCardTestData, root, CatalogDescriptor{
+		Engine: JSONTemplateEngineV1, Visibility: CatalogVisibilityPrivate,
+	})
+	if err != nil {
+		t.Fatalf("LoadJSONBundle: %v", err)
+	}
+	runtimeArtifact, err := CompileJSONArtifact(context.Background(), bundle, DefaultCompileLimits())
+	if err != nil {
+		t.Fatalf("runtime CompileJSONArtifact: %v", err)
+	}
+	staticArtifact, err := CompileJSONArtifact(context.Background(), bundle, staticCompileLimits())
+	if err != nil {
+		t.Fatalf("static CompileJSONArtifact: %v", err)
+	}
+	if runtimeArtifact.Hash != staticArtifact.Hash || !bytes.Equal(runtimeArtifact.Bundle, staticArtifact.Bundle) {
+		t.Fatalf("static/runtime identity drift: runtime=%s static=%s", runtimeArtifact.Hash, staticArtifact.Hash)
+	}
+
+	registry := NewRegistry()
+	registry.RegisterJSON(jsonCardTestData, root)
+	registry.Freeze()
+	staticTemplate, err := registry.Lookup("test.runtime-parity", "1.0.0")
+	if err != nil {
+		t.Fatalf("Lookup static template: %v", err)
+	}
+	staticMeta := staticTemplate.Meta()
+	runtimeMeta := runtimeArtifact.Meta.Clone()
+	staticMeta.InputSchema = nil
+	runtimeMeta.InputSchema = nil
+	if !reflect.DeepEqual(staticMeta, runtimeMeta) {
+		t.Fatalf("static/runtime metadata drift:\nstatic=%+v\nruntime=%+v", staticMeta, runtimeMeta)
+	}
+
+	fields := bundle.Samples["shown"]
+	env := BuildEnv{Lang: "en-US", SpaceID: "parity", WebLoginURL: "https://selfcheck.internal"}
+	staticPayload, err := renderCore(context.Background(), staticTemplate, staticTemplate.Meta(), "shown", fields, env)
+	if err != nil {
+		t.Fatalf("render static template: %v", err)
+	}
+	runtimePayload, err := renderCore(context.Background(), runtimeArtifact.Template, runtimeArtifact.Meta, "shown", fields, env)
+	if err != nil {
+		t.Fatalf("render runtime template: %v", err)
+	}
+	staticCanonical, err := marshalCanonicalJSON(staticPayload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	runtimeCanonical, err := marshalCanonicalJSON(runtimePayload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(staticCanonical, runtimeCanonical) {
+		t.Fatalf("static/runtime render drift:\nstatic=%s\nruntime=%s", staticCanonical, runtimeCanonical)
+	}
+}
+
+func TestCompileBundleSamplesScopesStateLookupToEachView(t *testing.T) {
+	schema, err := compileJSONSchema(map[string]any{
+		"type": "object", "additionalProperties": false,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifest := manifestFile{Views: map[ViewKey]manifestView{
+		"one": {States: []State{"alpha"}, Samples: []string{"samples/beta.json"}},
+		"two": {States: []State{"gamma"}, Samples: []string{"samples/alpha.json"}},
+	}}
+	documents := map[string]json.RawMessage{
+		"alpha": json.RawMessage(`{}`),
+		"beta":  json.RawMessage(`{}`),
+	}
+	for iteration := 0; iteration < 1000; iteration++ {
+		_, assignments, err := compileBundleSamples(
+			manifest,
+			schema,
+			documents,
+			jsonBudget{maxDepth: maxArtifactJSONDepth, maxNodes: maxArtifactJSONNodes},
+			DefaultCompileLimits(),
+		)
+		if err != nil {
+			t.Fatalf("compileBundleSamples iteration %d: %v", iteration, err)
+		}
+		got := make(map[string]string, len(assignments))
+		for _, assignment := range assignments {
+			got[string(assignment.view)+"/"+string(assignment.state)] = assignment.key
+		}
+		if got["one/alpha"] != "beta" || got["two/gamma"] != "alpha" {
+			t.Fatalf("iteration %d assignments = %v, want view-local samples", iteration, got)
+		}
 	}
 }
 

--- a/pkg/cardtmpl/json_artifact_decode_test.go
+++ b/pkg/cardtmpl/json_artifact_decode_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"unicode/utf16"
 )
 
 func TestDecodeBundleJSONStrictRoundTrip(t *testing.T) {
@@ -327,6 +328,104 @@ func TestCanonicalJSONNumberRejectsUnstableRanges(t *testing.T) {
 	}
 }
 
+func TestCompileJSONArtifactReportsDeterministicInvalidDocument(t *testing.T) {
+	bundle := validJSONArtifactBundle()
+	bundle.Templates = map[string]json.RawMessage{
+		"a": json.RawMessage{},
+		"b": json.RawMessage{},
+	}
+	for iteration := 0; iteration < 100; iteration++ {
+		_, err := CompileJSONArtifact(context.Background(), bundle, DefaultCompileLimits())
+		var validationErr *ArtifactValidationError
+		if !errors.As(err, &validationErr) {
+			t.Fatalf("iteration %d error = %v, want ArtifactValidationError", iteration, err)
+		}
+		if validationErr.Document != "templates.a" {
+			t.Fatalf("iteration %d document = %q, want templates.a", iteration, validationErr.Document)
+		}
+	}
+}
+
+func TestUTF16LessMatchesUTF16OrderingWithoutAllocations(t *testing.T) {
+	tests := []struct {
+		left  string
+		right string
+	}{
+		{left: "a", right: "b"},
+		{left: "a", right: "aa"},
+		{left: "\U0001f600", right: "\ue000"},
+		{left: "\U0001f600a", right: "\U0001f600b"},
+	}
+	for _, tt := range tests {
+		want := referenceUTF16Less(tt.left, tt.right)
+		if got := utf16Less(tt.left, tt.right); got != want {
+			t.Fatalf("utf16Less(%q, %q) = %v, want %v", tt.left, tt.right, got, want)
+		}
+	}
+
+	var result bool
+	allocations := testing.AllocsPerRun(1000, func() {
+		result = utf16Less("\U0001f600a", "\U0001f600b")
+	})
+	if !result {
+		t.Fatal("utf16Less allocation probe returned the wrong result")
+	}
+	if allocations != 0 {
+		t.Fatalf("utf16Less allocations = %v, want 0", allocations)
+	}
+}
+
+func FuzzUTF16LessMatchesUTF16Ordering(f *testing.F) {
+	f.Add("ascii", "astral \U0001f600")
+	f.Add("\ue000", "\U0001f600")
+	f.Add("same", "same")
+	f.Fuzz(func(t *testing.T, left, right string) {
+		if got, want := utf16Less(left, right), referenceUTF16Less(left, right); got != want {
+			t.Fatalf("utf16Less(%q, %q) = %v, want %v", left, right, got, want)
+		}
+	})
+}
+
+func referenceUTF16Less(left, right string) bool {
+	a := utf16.Encode([]rune(left))
+	b := utf16.Encode([]rune(right))
+	for index := 0; index < len(a) && index < len(b); index++ {
+		if a[index] != b[index] {
+			return a[index] < b[index]
+		}
+	}
+	return len(a) < len(b)
+}
+
+func TestPositiveJSONIntAcceptsEquivalentIntegerSyntax(t *testing.T) {
+	tests := []struct {
+		input   json.Number
+		want    int
+		wantErr bool
+	}{
+		{input: "1", want: 1},
+		{input: "1.0", want: 1},
+		{input: "1e6", want: 1_000_000},
+		{input: "1000000", want: 1_000_000},
+		{input: "0", wantErr: true},
+		{input: "-1", wantErr: true},
+		{input: "1.5", wantErr: true},
+		{input: "2147483648", wantErr: true},
+	}
+	for _, tt := range tests {
+		got, err := positiveJSONInt(tt.input)
+		if tt.wantErr {
+			if err == nil {
+				t.Errorf("positiveJSONInt(%q) = %d, want error", tt.input, got)
+			}
+			continue
+		}
+		if err != nil || got != tt.want {
+			t.Errorf("positiveJSONInt(%q) = %d, %v; want %d", tt.input, got, err, tt.want)
+		}
+	}
+}
+
 func TestValidateBoundedInputSchemaRejectsUnboundedShapes(t *testing.T) {
 	tests := []map[string]any{
 		{"type": "array", "additionalProperties": false},
@@ -342,7 +441,7 @@ func TestValidateBoundedInputSchemaRejectsUnboundedShapes(t *testing.T) {
 		}},
 	}
 	for index, schema := range tests {
-		if err := validateBoundedInputSchema(schema); err == nil {
+		if err := validateBoundedInputSchemaContext(context.Background(), schema, maxArtifactJSONNodes); err == nil {
 			t.Errorf("schema %d unexpectedly accepted", index)
 		}
 	}
@@ -398,7 +497,7 @@ func TestValidateBoundedInputSchemaAcceptsFinitePropertyShapes(t *testing.T) {
 			if tt.decorate != nil {
 				tt.decorate(schema)
 			}
-			if err := validateBoundedInputSchema(schema); err != nil {
+			if err := validateBoundedInputSchemaContext(context.Background(), schema, maxArtifactJSONNodes); err != nil {
 				t.Fatalf("validateBoundedInputSchema: %v", err)
 			}
 		})
@@ -422,7 +521,7 @@ func TestValidateBoundedInputSchemaRejectsAmbiguousPropertyShapes(t *testing.T) 
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := validateBoundedInputSchema(boundedRootWithProperty(tt.property)); err == nil {
+			if err := validateBoundedInputSchemaContext(context.Background(), boundedRootWithProperty(tt.property), maxArtifactJSONNodes); err == nil {
 				t.Fatal("ambiguous property schema unexpectedly accepted")
 			}
 		})
@@ -443,7 +542,7 @@ func TestValidateBoundedInputSchemaRejectsUnboundedLocalRefs(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			schema := boundedRootWithProperty(map[string]any{"$ref": "#/$defs/value"})
 			schema["$defs"] = map[string]any{"value": tt.target}
-			if err := validateBoundedInputSchema(schema); err == nil {
+			if err := validateBoundedInputSchemaContext(context.Background(), schema, maxArtifactJSONNodes); err == nil {
 				t.Fatal("unbounded local reference unexpectedly accepted")
 			}
 		})
@@ -457,7 +556,7 @@ func TestValidateBoundedInputSchemaRejectsUnboundedArrayItemRef(t *testing.T) {
 		"items":    map[string]any{"$ref": "#/$defs/value"},
 	})
 	schema["$defs"] = map[string]any{"value": true}
-	if err := validateBoundedInputSchema(schema); err == nil {
+	if err := validateBoundedInputSchemaContext(context.Background(), schema, maxArtifactJSONNodes); err == nil {
 		t.Fatal("array item reference to an unbounded schema unexpectedly accepted")
 	}
 }
@@ -468,7 +567,7 @@ func TestValidateBoundedInputSchemaRejectsUnboundedArrayItems(t *testing.T) {
 		"maxItems": json.Number("1"),
 		"items":    map[string]any{},
 	})
-	if err := validateBoundedInputSchema(schema); err == nil {
+	if err := validateBoundedInputSchemaContext(context.Background(), schema, maxArtifactJSONNodes); err == nil {
 		t.Fatal("unbounded array item schema unexpectedly accepted")
 	}
 }
@@ -477,7 +576,7 @@ func TestValidateBoundedInputSchemaDoesNotRevisitNestedPropertiesExponentially(t
 	schema := boundedRootWithProperty(nestedBoundedObjectSchema(24))
 	done := make(chan error, 1)
 	go func() {
-		done <- validateBoundedInputSchema(schema)
+		done <- validateBoundedInputSchemaContext(context.Background(), schema, maxArtifactJSONNodes)
 	}()
 
 	select {

--- a/pkg/cardtmpl/json_artifact_decode_test.go
+++ b/pkg/cardtmpl/json_artifact_decode_test.go
@@ -428,6 +428,27 @@ func TestValidateBoundedInputSchemaRejectsAmbiguousPropertyShapes(t *testing.T) 
 	}
 }
 
+func TestValidateBoundedInputSchemaRejectsUnboundedLocalRefs(t *testing.T) {
+	tests := []struct {
+		name   string
+		target any
+	}{
+		{name: "true schema", target: true},
+		{name: "empty schema", target: map[string]any{}},
+		{name: "unbounded string", target: map[string]any{"type": "string"}},
+		{name: "reference cycle", target: map[string]any{"$ref": "#/$defs/value"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			schema := boundedRootWithProperty(map[string]any{"$ref": "#/$defs/value"})
+			schema["$defs"] = map[string]any{"value": tt.target}
+			if err := validateBoundedInputSchema(schema); err == nil {
+				t.Fatal("unbounded local reference unexpectedly accepted")
+			}
+		})
+	}
+}
+
 func boundedRootWithProperty(property any) map[string]any {
 	return map[string]any{
 		"type":                 "object",

--- a/pkg/cardtmpl/json_artifact_decode_test.go
+++ b/pkg/cardtmpl/json_artifact_decode_test.go
@@ -1,0 +1,303 @@
+package cardtmpl
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestDecodeBundleJSONStrictRoundTrip(t *testing.T) {
+	raw, err := json.Marshal(validJSONArtifactBundle())
+	if err != nil {
+		t.Fatalf("marshal bundle: %v", err)
+	}
+	bundle, err := DecodeBundleJSON(raw)
+	if err != nil {
+		t.Fatalf("DecodeBundleJSON: %v", err)
+	}
+	if bundle.Catalog.Engine != JSONTemplateEngineV1 || len(bundle.Templates) != 1 {
+		t.Fatalf("decoded bundle = %+v", bundle)
+	}
+
+	tests := []struct {
+		name string
+		raw  []byte
+	}{
+		{name: "duplicate root key", raw: []byte(`{"catalog":{},"catalog":{}}`)},
+		{name: "unknown root key", raw: []byte(`{"unknown":true}`)},
+		{name: "catalog unknown key", raw: []byte(`{"catalog":{"engine":"octo-json-template/v1","visibility":"private","extra":true}}`)},
+		{name: "non-object root", raw: []byte(`[]`)},
+		{name: "oversize", raw: []byte(strings.Repeat(" ", maxArtifactBundleBytes+1))},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := DecodeBundleJSON(tt.raw)
+			var validationErr *ArtifactValidationError
+			if !errors.As(err, &validationErr) {
+				t.Fatalf("error = %v, want ArtifactValidationError", err)
+			}
+		})
+	}
+}
+
+func TestDecodeStrictJSONRejectsAmbiguousEnvelope(t *testing.T) {
+	type envelope struct {
+		Bundle json.RawMessage `json:"bundle"`
+	}
+	tests := []struct {
+		name string
+		raw  []byte
+		out  any
+		ok   bool
+	}{
+		{name: "valid", raw: []byte(`{"bundle":{"catalog":{}}}`), out: &envelope{}, ok: true},
+		{name: "unknown field", raw: []byte(`{"bundle":{},"actor_uid":"spoof"}`), out: &envelope{}},
+		{name: "duplicate field", raw: []byte(`{"bundle":{},"bundle":{}}`), out: &envelope{}},
+		{name: "trailing token", raw: []byte(`{"bundle":{}} true`), out: &envelope{}},
+		{name: "nil target", raw: []byte(`{}`), out: nil},
+		{name: "oversize", raw: []byte(strings.Repeat(" ", maxArtifactBundleBytes+1)), out: &envelope{}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := DecodeStrictJSON(tt.raw, tt.out)
+			if tt.ok {
+				if err != nil {
+					t.Fatalf("DecodeStrictJSON: %v", err)
+				}
+				return
+			}
+			var validationErr *ArtifactValidationError
+			if !errors.As(err, &validationErr) {
+				t.Fatalf("error = %v, want ArtifactValidationError", err)
+			}
+		})
+	}
+}
+
+func TestCompileJSONArtifactRejectsGovernanceAndDocumentDrift(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*Bundle)
+		want   string
+	}{
+		{
+			name: "unknown engine",
+			mutate: func(bundle *Bundle) {
+				bundle.Catalog.Engine = "unknown/v1"
+			},
+			want: "engine",
+		},
+		{
+			name: "unknown visibility",
+			mutate: func(bundle *Bundle) {
+				bundle.Catalog.Visibility = "internal"
+			},
+			want: "visibility",
+		},
+		{
+			name: "external schema ref",
+			mutate: func(bundle *Bundle) {
+				bundle.Schema = json.RawMessage(`{"type":"object","additionalProperties":false,"$ref":"https://example.com/schema.json"}`)
+			},
+			want: "$ref",
+		},
+		{
+			name: "unbounded string",
+			mutate: func(bundle *Bundle) {
+				bundle.Schema = json.RawMessage(`{"type":"object","additionalProperties":false,"properties":{"title":{"type":"string"}}}`)
+			},
+			want: "unbounded",
+		},
+		{
+			name: "invalid semver",
+			mutate: func(bundle *Bundle) {
+				bundle.Manifest = replaceManifestField(t, bundle.Manifest, "version", "latest")
+			},
+			want: "semver",
+		},
+		{
+			name: "missing owner",
+			mutate: func(bundle *Bundle) {
+				bundle.Manifest = replaceManifestField(t, bundle.Manifest, "owner", "")
+			},
+			want: "owner",
+		},
+		{
+			name: "external data schema path",
+			mutate: func(bundle *Bundle) {
+				bundle.Manifest = replaceManifestField(t, bundle.Manifest, "dataSchema", "https://example.com/schema.json")
+			},
+			want: "dataSchema",
+		},
+		{
+			name: "missing template document",
+			mutate: func(bundle *Bundle) {
+				delete(bundle.Templates, "main")
+			},
+			want: "missing",
+		},
+		{
+			name: "unreferenced sample",
+			mutate: func(bundle *Bundle) {
+				bundle.Samples["extra"] = json.RawMessage(`{"title":"extra"}`)
+			},
+			want: "unreferenced",
+		},
+		{
+			name: "sample without state assignment",
+			mutate: func(bundle *Bundle) {
+				bundle.Manifest = mutateManifest(t, bundle.Manifest, func(manifest map[string]any) {
+					views := manifest["views"].(map[string]any)
+					main := views["main"].(map[string]any)
+					main["samples"] = append(main["samples"].([]any), "samples/alternate.json")
+				})
+				bundle.Samples["alternate"] = json.RawMessage(`{"title":"alternate","groups":[]}`)
+			},
+			want: "samples",
+		},
+		{
+			name: "interactive template missing action type",
+			mutate: func(bundle *Bundle) {
+				bundle.Manifest = mutateManifest(t, bundle.Manifest, func(manifest map[string]any) {
+					views := manifest["views"].(map[string]any)
+					views["main"].(map[string]any)["wireProfile"] = profileV2
+					delete(manifest, "actionType")
+				})
+				bundle.Templates["main"] = json.RawMessage(`{
+					"type":"AdaptiveCard","version":"1.5","body":[{"type":"TextBlock","text":"${title}"}],
+					"actions":[{"type":"Action.Submit","id":"submit","data":{"owner":"ai","action_type":"test.submit"}}]
+				}`)
+				bundle.Reports = map[string]json.RawMessage{"main": json.RawMessage(`{
+					"actions":[{"id":"submit","type":"Action.Submit","associatedInputs":"auto","dataKeys":["owner","action_type"],"inputIds":[]}],
+					"inputs":[]
+				}`)}
+				bundle.Goldens = nil
+			},
+			want: "actionType",
+		},
+		{
+			name: "golden mismatch",
+			mutate: func(bundle *Bundle) {
+				bundle.Goldens["shown"] = json.RawMessage(`{"type":"AdaptiveCard","version":"1.5","body":[]}`)
+			},
+			want: "golden",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bundle := validJSONArtifactBundle()
+			tt.mutate(&bundle)
+			_, err := CompileJSONArtifact(context.Background(), bundle, DefaultCompileLimits())
+			var validationErr *ArtifactValidationError
+			if !errors.As(err, &validationErr) {
+				t.Fatalf("error = %v, want ArtifactValidationError", err)
+			}
+			if !strings.Contains(err.Error(), tt.want) && !strings.Contains(validationErr.Category, tt.want) {
+				t.Fatalf("error = %v, want %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestCompileJSONArtifactHonorsCancelledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := CompileJSONArtifact(ctx, validJSONArtifactBundle(), DefaultCompileLimits())
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("error = %v, want context.Canceled", err)
+	}
+}
+
+func TestLoadJSONBundleReadsEmbeddedHandoff(t *testing.T) {
+	bundle, err := LoadJSONBundle(jsonCardTestData, "testdata/test.jsoncard@0.1.0", CatalogDescriptor{
+		Engine: JSONTemplateEngineV1, Visibility: CatalogVisibilityPrivate,
+	})
+	if err != nil {
+		t.Fatalf("LoadJSONBundle: %v", err)
+	}
+	if len(bundle.Schema) == 0 || len(bundle.Templates) != 1 || len(bundle.Samples) != 1 {
+		t.Fatalf("bundle documents: schema=%d templates=%d samples=%d", len(bundle.Schema), len(bundle.Templates), len(bundle.Samples))
+	}
+}
+
+func TestArtifactValidationErrorFormattingAndUnwrap(t *testing.T) {
+	cause := errors.New("cause")
+	err := &ArtifactValidationError{Category: "json", Document: "schema", cause: cause}
+	if !errors.Is(err, cause) || !strings.Contains(err.Error(), "schema") {
+		t.Fatalf("error = %v", err)
+	}
+	var nilErr *ArtifactValidationError
+	if nilErr.Error() == "" {
+		t.Fatal("nil validation error must have a safe message")
+	}
+}
+
+func TestCanonicalJSONNumberRejectsUnstableRanges(t *testing.T) {
+	tests := []struct {
+		input   json.Number
+		want    string
+		wantErr bool
+	}{
+		{input: "0", want: "0"},
+		{input: "-0", want: "0"},
+		{input: "1e+09", want: "1e+9"},
+		{input: "9007199254740992", wantErr: true},
+		{input: "1e10000", wantErr: true},
+	}
+	for _, tt := range tests {
+		got, err := canonicalJSONNumber(tt.input)
+		if tt.wantErr {
+			if err == nil {
+				t.Errorf("canonicalJSONNumber(%q) = %q, want error", tt.input, got)
+			}
+			continue
+		}
+		if err != nil || got != tt.want {
+			t.Errorf("canonicalJSONNumber(%q) = %q, %v; want %q", tt.input, got, err, tt.want)
+		}
+	}
+}
+
+func TestValidateBoundedInputSchemaRejectsUnboundedShapes(t *testing.T) {
+	tests := []map[string]any{
+		{"type": "array", "additionalProperties": false},
+		{"type": "object", "additionalProperties": true},
+		{"type": "object", "additionalProperties": false, "properties": map[string]any{
+			"items": map[string]any{"type": "array"},
+		}},
+		{"type": "object", "additionalProperties": false, "properties": map[string]any{
+			"items": map[string]any{"type": "array", "maxItems": json.Number("2")},
+		}},
+		{"type": "object", "additionalProperties": false, "properties": map[string]any{
+			"nested": map[string]any{"type": "object", "additionalProperties": true},
+		}},
+	}
+	for index, schema := range tests {
+		if err := validateBoundedInputSchema(schema); err == nil {
+			t.Errorf("schema %d unexpectedly accepted", index)
+		}
+	}
+}
+
+func replaceManifestField(t *testing.T, raw json.RawMessage, field string, value any) json.RawMessage {
+	t.Helper()
+	return mutateManifest(t, raw, func(manifest map[string]any) {
+		manifest[field] = value
+	})
+}
+
+func mutateManifest(t *testing.T, raw json.RawMessage, mutate func(map[string]any)) json.RawMessage {
+	t.Helper()
+	var manifest map[string]any
+	if err := json.Unmarshal(raw, &manifest); err != nil {
+		t.Fatal(err)
+	}
+	mutate(manifest)
+	out, err := json.Marshal(manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return out
+}

--- a/pkg/cardtmpl/json_artifact_decode_test.go
+++ b/pkg/cardtmpl/json_artifact_decode_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 )
@@ -109,6 +110,48 @@ func TestCompileJSONArtifactRejectsGovernanceAndDocumentDrift(t *testing.T) {
 				bundle.Schema = json.RawMessage(`{"type":"object","additionalProperties":false,"properties":{"title":{"type":"string"}}}`)
 			},
 			want: "unbounded",
+		},
+		{
+			name: "unbounded unconstrained property",
+			mutate: func(bundle *Bundle) {
+				bundle.Schema = artifactSchemaWithProperties(`{"title":{},"groups":{"type":"array","maxItems":2,"items":{"type":"object","additionalProperties":false,"properties":{"items":{"type":"array","maxItems":2,"items":{"type":"string","maxLength":8}}}}}}`)
+			},
+			want: "bounded type",
+		},
+		{
+			name: "unbounded nullable string",
+			mutate: func(bundle *Bundle) {
+				bundle.Schema = artifactSchemaWithProperties(`{"title":{"type":["string","null"]},"groups":{"type":"array","maxItems":2,"items":{"type":"object","additionalProperties":false,"properties":{"items":{"type":"array","maxItems":2,"items":{"type":"string","maxLength":8}}}}}}`)
+			},
+			want: "unbounded",
+		},
+		{
+			name: "unsupported manifest schema version",
+			mutate: func(bundle *Bundle) {
+				bundle.Manifest = replaceManifestField(t, bundle.Manifest, "schemaVersion", 3)
+			},
+			want: "schemaVersion",
+		},
+		{
+			name: "template id exceeds storage",
+			mutate: func(bundle *Bundle) {
+				bundle.Manifest = replaceManifestField(t, bundle.Manifest, "id", "a."+strings.Repeat("b", 127))
+			},
+			want: "id",
+		},
+		{
+			name: "version exceeds storage",
+			mutate: func(bundle *Bundle) {
+				bundle.Manifest = replaceManifestField(t, bundle.Manifest, "version", "1.0.0+"+strings.Repeat("a", 59))
+			},
+			want: "version",
+		},
+		{
+			name: "contract version exceeds storage",
+			mutate: func(bundle *Bundle) {
+				bundle.Manifest = replaceManifestField(t, bundle.Manifest, "contractVersion", "1.0.0+"+strings.Repeat("a", 59))
+			},
+			want: "contractVersion",
 		},
 		{
 			name: "invalid semver",
@@ -323,4 +366,12 @@ func mutateManifest(t *testing.T, raw json.RawMessage, mutate func(map[string]an
 		t.Fatal(err)
 	}
 	return out
+}
+
+func artifactSchemaWithProperties(properties string) json.RawMessage {
+	return json.RawMessage(fmt.Sprintf(
+		`{"$schema":"http://json-schema.org/draft-07/schema#","type":"object","additionalProperties":false,"required":["title"],"properties":%s,"x-octo-constraints":%s}`,
+		properties,
+		validAggregateConstraint,
+	))
 }

--- a/pkg/cardtmpl/json_artifact_decode_test.go
+++ b/pkg/cardtmpl/json_artifact_decode_test.go
@@ -118,6 +118,13 @@ func TestCompileJSONArtifactRejectsGovernanceAndDocumentDrift(t *testing.T) {
 			want: "semver",
 		},
 		{
+			name: "semver leading zero",
+			mutate: func(bundle *Bundle) {
+				bundle.Manifest = replaceManifestField(t, bundle.Manifest, "version", "01.0.0")
+			},
+			want: "semver",
+		},
+		{
 			name: "missing owner",
 			mutate: func(bundle *Bundle) {
 				bundle.Manifest = replaceManifestField(t, bundle.Manifest, "owner", "")
@@ -198,6 +205,22 @@ func TestCompileJSONArtifactRejectsGovernanceAndDocumentDrift(t *testing.T) {
 				t.Fatalf("error = %v, want %q", err, tt.want)
 			}
 		})
+	}
+}
+
+func TestCompileJSONArtifactRejectsUnpairedUnicodeSurrogate(t *testing.T) {
+	bundle := validJSONArtifactBundle()
+	bundle.Samples["shown"] = json.RawMessage(`{"title":"\ud800","groups":[]}`)
+	bundle.Goldens = nil
+	_, err := CompileJSONArtifact(context.Background(), bundle, DefaultCompileLimits())
+	var validationErr *ArtifactValidationError
+	if !errors.As(err, &validationErr) || validationErr.Document != "samples.shown" {
+		t.Fatalf("error = %v, want samples.shown validation error", err)
+	}
+
+	bundle.Samples["shown"] = json.RawMessage(`{"title":"\ud83d\ude80","groups":[]}`)
+	if _, err := CompileJSONArtifact(context.Background(), bundle, DefaultCompileLimits()); err != nil {
+		t.Fatalf("valid astral Unicode surrogate pair rejected: %v", err)
 	}
 }
 

--- a/pkg/cardtmpl/json_artifact_decode_test.go
+++ b/pkg/cardtmpl/json_artifact_decode_test.go
@@ -449,6 +449,18 @@ func TestValidateBoundedInputSchemaRejectsUnboundedLocalRefs(t *testing.T) {
 	}
 }
 
+func TestValidateBoundedInputSchemaRejectsUnboundedArrayItemRef(t *testing.T) {
+	schema := boundedRootWithProperty(map[string]any{
+		"type":     "array",
+		"maxItems": json.Number("1"),
+		"items":    map[string]any{"$ref": "#/$defs/value"},
+	})
+	schema["$defs"] = map[string]any{"value": true}
+	if err := validateBoundedInputSchema(schema); err == nil {
+		t.Fatal("array item reference to an unbounded schema unexpectedly accepted")
+	}
+}
+
 func boundedRootWithProperty(property any) map[string]any {
 	return map[string]any{
 		"type":                 "object",

--- a/pkg/cardtmpl/json_artifact_decode_test.go
+++ b/pkg/cardtmpl/json_artifact_decode_test.go
@@ -347,6 +347,97 @@ func TestValidateBoundedInputSchemaRejectsUnboundedShapes(t *testing.T) {
 	}
 }
 
+func TestValidateBoundedInputSchemaAcceptsFinitePropertyShapes(t *testing.T) {
+	tests := []struct {
+		name     string
+		property any
+		decorate func(map[string]any)
+	}{
+		{
+			name:     "bounded nullable string",
+			property: map[string]any{"type": []any{"string", "null"}, "maxLength": json.Number("8")},
+		},
+		{name: "enum", property: map[string]any{"enum": []any{"ready", "done"}}},
+		{name: "const", property: map[string]any{"const": "ready"}},
+		{
+			name:     "local ref",
+			property: map[string]any{"$ref": "#/$defs/title"},
+			decorate: func(schema map[string]any) {
+				schema["$defs"] = map[string]any{
+					"title": map[string]any{"type": "string", "maxLength": json.Number("8")},
+				}
+			},
+		},
+		{
+			name: "any of bounded alternatives",
+			property: map[string]any{"anyOf": []any{
+				map[string]any{"type": "string", "maxLength": json.Number("8")},
+				map[string]any{"type": "integer"},
+			}},
+		},
+		{
+			name: "one of bounded alternatives",
+			property: map[string]any{"oneOf": []any{
+				map[string]any{"type": "string", "maxLength": json.Number("8")},
+				map[string]any{"type": "boolean"},
+			}},
+		},
+		{
+			name: "all of includes bounded shape",
+			property: map[string]any{"allOf": []any{
+				map[string]any{"type": "string", "maxLength": json.Number("8")},
+				map[string]any{"minLength": json.Number("1")},
+			}},
+		},
+		{name: "false schema", property: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			schema := boundedRootWithProperty(tt.property)
+			if tt.decorate != nil {
+				tt.decorate(schema)
+			}
+			if err := validateBoundedInputSchema(schema); err != nil {
+				t.Fatalf("validateBoundedInputSchema: %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateBoundedInputSchemaRejectsAmbiguousPropertyShapes(t *testing.T) {
+	tests := []struct {
+		name     string
+		property any
+	}{
+		{name: "true schema", property: true},
+		{name: "non-schema value", property: "string"},
+		{name: "empty type list", property: map[string]any{"type": []any{}}},
+		{name: "non-string type", property: map[string]any{"type": json.Number("7")}},
+		{name: "non-string type list item", property: map[string]any{"type": []any{"string", json.Number("7")}}},
+		{name: "duplicate type", property: map[string]any{"type": []any{"string", "string"}, "maxLength": json.Number("8")}},
+		{name: "unbounded any of", property: map[string]any{"anyOf": []any{map[string]any{"type": "integer"}, map[string]any{}}}},
+		{name: "unbounded one of", property: map[string]any{"oneOf": []any{map[string]any{"type": "boolean"}, map[string]any{}}}},
+		{name: "unbounded all of", property: map[string]any{"allOf": []any{map[string]any{"minLength": json.Number("1")}}}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := validateBoundedInputSchema(boundedRootWithProperty(tt.property)); err == nil {
+				t.Fatal("ambiguous property schema unexpectedly accepted")
+			}
+		})
+	}
+}
+
+func boundedRootWithProperty(property any) map[string]any {
+	return map[string]any{
+		"type":                 "object",
+		"additionalProperties": false,
+		"properties": map[string]any{
+			"value": property,
+		},
+	}
+}
+
 func replaceManifestField(t *testing.T, raw json.RawMessage, field string, value any) json.RawMessage {
 	t.Helper()
 	return mutateManifest(t, raw, func(manifest map[string]any) {

--- a/pkg/cardtmpl/json_artifact_decode_test.go
+++ b/pkg/cardtmpl/json_artifact_decode_test.go
@@ -461,6 +461,17 @@ func TestValidateBoundedInputSchemaRejectsUnboundedArrayItemRef(t *testing.T) {
 	}
 }
 
+func TestValidateBoundedInputSchemaRejectsUnboundedArrayItems(t *testing.T) {
+	schema := boundedRootWithProperty(map[string]any{
+		"type":     "array",
+		"maxItems": json.Number("1"),
+		"items":    map[string]any{},
+	})
+	if err := validateBoundedInputSchema(schema); err == nil {
+		t.Fatal("unbounded array item schema unexpectedly accepted")
+	}
+}
+
 func boundedRootWithProperty(property any) map[string]any {
 	return map[string]any{
 		"type":                 "object",

--- a/pkg/cardtmpl/json_artifact_decode_test.go
+++ b/pkg/cardtmpl/json_artifact_decode_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestDecodeBundleJSONStrictRoundTrip(t *testing.T) {
@@ -470,6 +471,67 @@ func TestValidateBoundedInputSchemaRejectsUnboundedArrayItems(t *testing.T) {
 	if err := validateBoundedInputSchema(schema); err == nil {
 		t.Fatal("unbounded array item schema unexpectedly accepted")
 	}
+}
+
+func TestValidateBoundedInputSchemaDoesNotRevisitNestedPropertiesExponentially(t *testing.T) {
+	schema := boundedRootWithProperty(nestedBoundedObjectSchema(24))
+	done := make(chan error, 1)
+	go func() {
+		done <- validateBoundedInputSchema(schema)
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("validateBoundedInputSchema: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("bounded schema validation exceeded 1s; traversal must stay linear in nesting depth")
+	}
+}
+
+func TestCompileJSONArtifactHonorsContextDuringBoundsValidation(t *testing.T) {
+	bundle := validJSONArtifactBundle()
+	bundle.Schema = json.RawMessage(`{
+		"type":"object",
+		"additionalProperties":false,
+		"properties":{"title":{"type":"string"}}
+	}`)
+	ctx := &errorAfterFirstCheckContext{Context: context.Background()}
+
+	_, err := CompileJSONArtifact(ctx, bundle, DefaultCompileLimits())
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("CompileJSONArtifact error = %v, want context deadline", err)
+	}
+	var validationErr *ArtifactValidationError
+	if errors.As(err, &validationErr) {
+		t.Fatalf("context deadline was misclassified as validation error: %v", err)
+	}
+}
+
+type errorAfterFirstCheckContext struct {
+	context.Context
+	checks int
+}
+
+func (c *errorAfterFirstCheckContext) Err() error {
+	c.checks++
+	if c.checks == 1 {
+		return nil
+	}
+	return context.DeadlineExceeded
+}
+
+func nestedBoundedObjectSchema(depth int) map[string]any {
+	var property any = map[string]any{"type": "string", "maxLength": json.Number("8")}
+	for index := 0; index < depth; index++ {
+		property = map[string]any{
+			"type":                 "object",
+			"additionalProperties": false,
+			"properties":           map[string]any{"next": property},
+		}
+	}
+	return property.(map[string]any)
 }
 
 func boundedRootWithProperty(property any) map[string]any {

--- a/pkg/cardtmpl/json_template.go
+++ b/pkg/cardtmpl/json_template.go
@@ -1,13 +1,10 @@
 package cardtmpl
 
 import (
-	"bytes"
 	"context"
 	"embed"
 	"encoding/json"
 	"fmt"
-	"path"
-	"strings"
 
 	"github.com/Mininglamp-OSS/octo-server/pkg/cardmsg"
 	"github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl/jsontmpl"
@@ -33,15 +30,6 @@ type jsonTemplateAggregateArrayLimit struct {
 	ParentArray   string `json:"parentArray"`
 	ChildArray    string `json:"childArray"`
 	MaxTotalItems int    `json:"maxTotalItems"`
-}
-
-type jsonTemplateConstraintSet struct {
-	AggregateArrayLimits []jsonTemplateAggregateArrayLimit `json:"aggregateArrayLimits"`
-}
-
-type jsonTemplateSchemaEnvelope struct {
-	Properties  map[string]json.RawMessage `json:"properties"`
-	Constraints json.RawMessage            `json:"x-octo-constraints"`
 }
 
 // SetMeta satisfies metaSetter; Registry injects the assembled meta at Register.
@@ -190,120 +178,16 @@ func (t *jsonTemplate) FallbackText(state State, fields json.RawMessage, lang st
 // registration guarantees as Go cards (missing template / schema / bad sample /
 // whitelist violation all panic at boot, never at first render).
 func (r *Registry) RegisterJSON(assets embed.FS, root string) {
-	mf := loadManifest(assets, root)
-	aggregateArrayLimits := loadJSONTemplateAggregateArrayLimits(assets, root)
-	viewAST := make(map[ViewKey]any, len(mf.Views))
-	for vk, vs := range mf.Views {
-		if strings.TrimSpace(vs.Template) == "" {
-			panic(fmt.Errorf("cardtmpl: RegisterJSON: view %q in %s/manifest.json declares no template path", vk, root))
-		}
-		p := path.Join(root, vs.Template)
-		b, err := assets.ReadFile(p)
-		if err != nil {
-			panic(fmt.Errorf("cardtmpl: RegisterJSON: read template %s: %w", p, err))
-		}
-		var ast any
-		if err := json.Unmarshal(b, &ast); err != nil {
-			panic(fmt.Errorf("cardtmpl: RegisterJSON: parse template %s: %w", p, err))
-		}
-		// Fail-close: every Action.ToggleVisibility target must resolve to an
-		// element id in the same template (a dangling target is an authoring bug
-		// — a button that toggles nothing — caught here, not at first render).
-		if err := jsontmpl.ValidateToggleTargets(ast); err != nil {
-			panic(fmt.Errorf("cardtmpl: RegisterJSON: template %s: %w", p, err))
-		}
-		viewAST[vk] = ast
-	}
-	r.Register(&jsonTemplate{
-		viewAST:              viewAST,
-		aggregateArrayLimits: aggregateArrayLimits,
-	}, assets, root)
-}
-
-func loadJSONTemplateAggregateArrayLimits(assets embed.FS, root string) []jsonTemplateAggregateArrayLimit {
-	p := path.Join(root, "contract", "data.schema.json")
-	b, err := assets.ReadFile(p)
+	bundle, err := LoadJSONBundle(assets, root, CatalogDescriptor{
+		Engine:     JSONTemplateEngineV1,
+		Visibility: CatalogVisibilityPrivate,
+	})
 	if err != nil {
-		panic(fmt.Errorf("cardtmpl: RegisterJSON: read schema constraints %s: %w", p, err))
+		panic(fmt.Errorf("cardtmpl: RegisterJSON %s: %w", root, err))
 	}
-	var schema jsonTemplateSchemaEnvelope
-	if err := json.Unmarshal(b, &schema); err != nil {
-		panic(fmt.Errorf("cardtmpl: RegisterJSON: parse schema constraints %s: %w", p, err))
+	artifact, err := CompileJSONArtifact(context.Background(), bundle, staticCompileLimits())
+	if err != nil {
+		panic(fmt.Errorf("cardtmpl: RegisterJSON %s: %w", root, err))
 	}
-	if len(schema.Constraints) == 0 {
-		return nil
-	}
-
-	decoder := json.NewDecoder(bytes.NewReader(schema.Constraints))
-	decoder.DisallowUnknownFields()
-	var constraints jsonTemplateConstraintSet
-	if err := decoder.Decode(&constraints); err != nil {
-		panic(fmt.Errorf("cardtmpl: RegisterJSON: parse x-octo-constraints in %s: %w", p, err))
-	}
-	if len(constraints.AggregateArrayLimits) == 0 {
-		panic(fmt.Errorf("cardtmpl: RegisterJSON: x-octo-constraints in %s has no aggregateArrayLimits", p))
-	}
-
-	seen := make(map[string]struct{}, len(constraints.AggregateArrayLimits))
-	for index, limit := range constraints.AggregateArrayLimits {
-		if limit.ParentArray == "" || limit.ParentArray != strings.TrimSpace(limit.ParentArray) {
-			panic(fmt.Errorf("cardtmpl: RegisterJSON: aggregateArrayLimits[%d].parentArray is required in %s", index, p))
-		}
-		if limit.ChildArray == "" || limit.ChildArray != strings.TrimSpace(limit.ChildArray) {
-			panic(fmt.Errorf("cardtmpl: RegisterJSON: aggregateArrayLimits[%d].childArray is required in %s", index, p))
-		}
-		if limit.MaxTotalItems <= 0 {
-			panic(fmt.Errorf("cardtmpl: RegisterJSON: aggregateArrayLimits[%d].maxTotalItems must be positive in %s", index, p))
-		}
-		key := limit.ParentArray + "\x00" + limit.ChildArray
-		if _, duplicate := seen[key]; duplicate {
-			panic(fmt.Errorf("cardtmpl: RegisterJSON: duplicate aggregateArrayLimits target %s[].%s in %s",
-				limit.ParentArray, limit.ChildArray, p))
-		}
-		seen[key] = struct{}{}
-		validateJSONTemplateAggregateTarget(schema.Properties, limit, p)
-	}
-	return constraints.AggregateArrayLimits
-}
-
-func validateJSONTemplateAggregateTarget(
-	properties map[string]json.RawMessage,
-	limit jsonTemplateAggregateArrayLimit,
-	schemaPath string,
-) {
-	parentRaw, exists := properties[limit.ParentArray]
-	if !exists {
-		panic(fmt.Errorf("cardtmpl: RegisterJSON: aggregate parentArray %q not found in %s", limit.ParentArray, schemaPath))
-	}
-	var parent struct {
-		Type  string `json:"type"`
-		Items struct {
-			Type       string                     `json:"type"`
-			Properties map[string]json.RawMessage `json:"properties"`
-		} `json:"items"`
-	}
-	if err := json.Unmarshal(parentRaw, &parent); err != nil {
-		panic(fmt.Errorf("cardtmpl: RegisterJSON: parse aggregate parentArray %q in %s: %w",
-			limit.ParentArray, schemaPath, err))
-	}
-	if parent.Type != "array" || parent.Items.Type != "object" {
-		panic(fmt.Errorf("cardtmpl: RegisterJSON: aggregate parentArray %q must be an array of objects in %s",
-			limit.ParentArray, schemaPath))
-	}
-	childRaw, exists := parent.Items.Properties[limit.ChildArray]
-	if !exists {
-		panic(fmt.Errorf("cardtmpl: RegisterJSON: aggregate childArray %q not found under %q in %s",
-			limit.ChildArray, limit.ParentArray, schemaPath))
-	}
-	var child struct {
-		Type string `json:"type"`
-	}
-	if err := json.Unmarshal(childRaw, &child); err != nil {
-		panic(fmt.Errorf("cardtmpl: RegisterJSON: parse aggregate childArray %q under %q in %s: %w",
-			limit.ChildArray, limit.ParentArray, schemaPath, err))
-	}
-	if child.Type != "array" {
-		panic(fmt.Errorf("cardtmpl: RegisterJSON: aggregate childArray %q under %q must be an array in %s",
-			limit.ChildArray, limit.ParentArray, schemaPath))
-	}
+	r.registerCompiledJSON(artifact)
 }

--- a/pkg/cardtmpl/jsontmpl/expr.go
+++ b/pkg/cardtmpl/jsontmpl/expr.go
@@ -12,6 +12,7 @@
 package jsontmpl
 
 import (
+	"encoding/json"
 	"fmt"
 	"strconv"
 	"strings"
@@ -208,6 +209,9 @@ func toFloat(v any) (float64, bool) {
 		return float64(n), true
 	case float64:
 		return n, true
+	case json.Number:
+		parsed, err := strconv.ParseFloat(n.String(), 64)
+		return parsed, err == nil
 	default:
 		return 0, false
 	}
@@ -295,6 +299,12 @@ func stringify(v any) string {
 		return strconv.Itoa(t)
 	case float64:
 		return strconv.FormatFloat(t, 'g', -1, 64)
+	case json.Number:
+		parsed, err := strconv.ParseFloat(t.String(), 64)
+		if err == nil {
+			return strconv.FormatFloat(parsed, 'g', -1, 64)
+		}
+		return t.String()
 	default:
 		return fmt.Sprintf("%v", t)
 	}

--- a/pkg/cardtmpl/registry.go
+++ b/pkg/cardtmpl/registry.go
@@ -69,12 +69,20 @@ type manifestFile struct {
 // view's `.template.json`. Go-mode cards (hand-written Template.Build) omit both
 // — the fields are ignored there.
 //
-// Samples is currently informational only: the register-time self-check globs the
-// handoff's `samples/` directory (loadSamples), so a per-view `samples` list is
-// NOT a fail-close allowlist — a listed-but-missing sample is not caught here, and
-// an unlisted sample file is still loaded. It is parsed (not dropped) so a future
-// L0 PR can promote it to an allowlist without a manifest schema change; until
-// then, treat `samples/` on disk as the source of truth (PR #654 review P2).
+// Samples IS the fail-closed allowlist for JSON-mode: LoadJSONBundle reads exactly
+// the listed paths, a listed-but-missing sample is a hard registration error, and an
+// unlisted `samples/*.json` on disk is never read — so it gets neither schema
+// validation nor a render self-check. The manifest, not the directory, is the source
+// of truth here; a sample that is not listed silently contributes no coverage.
+//
+// `goldens/` is asymmetric on purpose: it is still directory-globbed
+// (`goldens/*.card.json`, LoadJSONBundle) and is not declared in the manifest, but
+// compileBundleGoldens requires every golden to have a same-key sample. Adding
+// `goldens/foo.card.json` without also listing the matching sample therefore fails
+// registration rather than being ignored.
+//
+// Go-mode cards keep the older behaviour: Register globs `samples/` via loadSamples
+// and ignores this field entirely (PR #654 review P2, PR #670 review).
 type manifestView struct {
 	WireProfile string   `json:"wireProfile"`
 	States      []State  `json:"states"`

--- a/pkg/cardtmpl/registry.go
+++ b/pkg/cardtmpl/registry.go
@@ -42,11 +42,15 @@ var (
 // manifestFile 是 Registry 从 assets FS 解析的 manifest.json 形状。
 // 与 docs/platform-card-base.md §4.1 对齐;未在 §4.1 声明的字段被忽略。
 type manifestFile struct {
-	ID              ID     `json:"id"`
-	Name            string `json:"name"`
-	Version         string `json:"version"`
-	ContractVersion string `json:"contractVersion"`
-	Protocol        string `json:"protocol"`
+	SchemaVersion       int    `json:"schemaVersion"`
+	ID                  ID     `json:"id"`
+	Name                string `json:"name"`
+	Version             string `json:"version"`
+	ContractVersion     string `json:"contractVersion"`
+	Protocol            string `json:"protocol"`
+	AdaptiveCardVersion string `json:"adaptiveCardVersion"`
+	DefaultLocale       string `json:"defaultLocale"`
+	DataSchema          string `json:"dataSchema"`
 	// RenderProfile is provenance-only metadata for the exact Forge artifact.
 	// RenderProfileCompatibility is the stable value written to the type-17
 	// envelope and is the only render-profile value retained at runtime.
@@ -155,68 +159,17 @@ func (r *Registry) Register(t Template, assets embed.FS, root string) {
 	}
 
 	mf := loadManifest(assets, root)
-	schema := loadSchema(assets, root)
+	loadedSchema := loadSchema(assets, root)
+	if _, hasJSONOnlyConstraints := loadedSchema.document["x-octo-constraints"]; hasJSONOnlyConstraints {
+		panic(fmt.Errorf("cardtmpl: Go-authored template %s@%s cannot declare x-octo-constraints; use RegisterJSON", mf.ID, mf.Version))
+	}
+	schema := loadedSchema.schema
 	interactions := loadInteractionReports(assets, root, mf.Views)
 	samples := loadSamples(assets, root, schema)
 
-	// state 索引 + 唯一性校验
-	stateIndex := make(map[State]ViewKey, 8)
-	views := make(map[ViewKey]ViewSpec, len(mf.Views))
-	for vk, vs := range mf.Views {
-		views[vk] = ViewSpec{WireProfile: vs.WireProfile, States: append([]State(nil), vs.States...)}
-		for _, st := range vs.States {
-			if prev, dup := stateIndex[st]; dup {
-				panic(fmt.Errorf("cardtmpl: state %q declared in multiple views (%q and %q) in %s/manifest.json", st, prev, vk, root))
-			}
-			stateIndex[st] = vk
-		}
-	}
-
-	// owner 校验 (§2.2-1)
-	if mf.Owner != "" {
-		if strings.HasPrefix(mf.Owner, l2bOwnerPrefix) {
-			// L2b 分支保留代码路径,生产阶段不开放
-			panic(fmt.Errorf("cardtmpl: L2b owner %q rejected: ext.* channel not enabled (see docs/platform-card-base.md §2.2-5)", mf.Owner))
-		}
-		if _, ok := l2aOwnerAllowlist[mf.Owner]; !ok {
-			panic(fmt.Errorf("cardtmpl: owner %q not in L2a allowlist", mf.Owner))
-		}
-	}
-
-	// Protocol 校验
-	protocol := mf.Protocol
-	if protocol == "" {
-		protocol = Protocol
-	}
-	if protocol != Protocol {
-		panic(fmt.Errorf("cardtmpl: manifest protocol %q != base protocol %q", protocol, Protocol))
-	}
-	renderProfileCompatibility := strings.TrimSpace(mf.RenderProfileCompatibility)
-	if !cardmsg.IsAcceptedRenderProfile(renderProfileCompatibility) {
-		panic(fmt.Errorf("cardtmpl: unsupported render profile compatibility %q", renderProfileCompatibility))
-	}
-	if renderProfileCompatibility != "" && strings.TrimSpace(mf.RenderProfile) == "" {
-		panic(errors.New("cardtmpl: renderProfile is required when renderProfileCompatibility is set"))
-	}
-
-	// ActionContract 派生
-	var contract *TemplateActionContract
-	if mf.Owner != "" && mf.ActionType != "" {
-		contract = &TemplateActionContract{Owner: mf.Owner, ActionType: mf.ActionType}
-	}
-
-	meta := TemplateMeta{
-		ID:                         mf.ID,
-		Version:                    mf.Version,
-		Protocol:                   protocol,
-		RenderProfileCompatibility: renderProfileCompatibility,
-		Views:                      views,
-		ActionContract:             contract,
-		Manifest:                   manifestBytes(assets, root),
-		InputSchema:                schema,
-		Source:                     Source{Label: mf.SourceLabel, IconURL: mf.SourceIconURL},
-		stateIndex:                 stateIndex,
-		interactions:               interactions,
+	meta, err := assembleTemplateMeta(mf, schema, interactions, manifestBytes(assets, root))
+	if err != nil {
+		panic(fmt.Errorf("cardtmpl: register %s: %w", root, err))
 	}
 
 	// 注入 Meta 到 Template
@@ -243,6 +196,88 @@ func (r *Registry) Register(t Template, assets embed.FS, root string) {
 	if err := r.selfCheckSamples(t, meta, samples); err != nil {
 		panic(fmt.Errorf("cardtmpl: register self-check %s@%s: %w", meta.ID, meta.Version, err))
 	}
+}
+
+func (r *Registry) registerCompiledJSON(artifact *CompiledArtifact) {
+	if artifact == nil || artifact.Template == nil {
+		panic(errors.New("cardtmpl: RegisterJSON received nil compiled artifact"))
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.frozen {
+		panic(fmt.Errorf("%w: cannot RegisterJSON after Freeze", ErrRegistryFrozen))
+	}
+	meta := artifact.Meta.Clone()
+	key := registryKey{id: meta.ID, version: meta.Version}
+	if _, duplicate := r.entries[key]; duplicate {
+		panic(fmt.Errorf("cardtmpl: duplicate registration %s@%s", meta.ID, meta.Version))
+	}
+	r.entries[key] = &entry{
+		tmpl:    artifact.Template,
+		meta:    meta,
+		samples: cloneRawMessageMap(artifact.samples),
+	}
+}
+
+func assembleTemplateMeta(
+	mf manifestFile,
+	schema *jsonschema.Schema,
+	interactions map[ViewKey]InteractionReport,
+	manifest json.RawMessage,
+) (TemplateMeta, error) {
+	stateIndex := make(map[State]ViewKey, 8)
+	views := make(map[ViewKey]ViewSpec, len(mf.Views))
+	for view, spec := range mf.Views {
+		views[view] = ViewSpec{WireProfile: spec.WireProfile, States: append([]State(nil), spec.States...)}
+		for _, state := range spec.States {
+			if previous, duplicate := stateIndex[state]; duplicate {
+				return TemplateMeta{}, fmt.Errorf("state %q declared in multiple views (%q and %q)", state, previous, view)
+			}
+			stateIndex[state] = view
+		}
+	}
+
+	if mf.Owner != "" {
+		if strings.HasPrefix(mf.Owner, l2bOwnerPrefix) {
+			return TemplateMeta{}, fmt.Errorf("L2b owner %q rejected: ext.* channel not enabled (see docs/platform-card-base.md §2.2-5)", mf.Owner)
+		}
+		if _, ok := l2aOwnerAllowlist[mf.Owner]; !ok {
+			return TemplateMeta{}, fmt.Errorf("owner %q not in L2a allowlist", mf.Owner)
+		}
+	}
+
+	protocol := mf.Protocol
+	if protocol == "" {
+		protocol = Protocol
+	}
+	if protocol != Protocol {
+		return TemplateMeta{}, fmt.Errorf("manifest protocol %q != base protocol %q", protocol, Protocol)
+	}
+	renderProfileCompatibility := strings.TrimSpace(mf.RenderProfileCompatibility)
+	if !cardmsg.IsAcceptedRenderProfile(renderProfileCompatibility) {
+		return TemplateMeta{}, fmt.Errorf("unsupported render profile compatibility %q", renderProfileCompatibility)
+	}
+	if renderProfileCompatibility != "" && strings.TrimSpace(mf.RenderProfile) == "" {
+		return TemplateMeta{}, errors.New("renderProfile is required when renderProfileCompatibility is set")
+	}
+
+	var contract *TemplateActionContract
+	if mf.Owner != "" && mf.ActionType != "" {
+		contract = &TemplateActionContract{Owner: mf.Owner, ActionType: mf.ActionType}
+	}
+	return TemplateMeta{
+		ID:                         mf.ID,
+		Version:                    mf.Version,
+		Protocol:                   protocol,
+		RenderProfileCompatibility: renderProfileCompatibility,
+		Views:                      views,
+		ActionContract:             contract,
+		Manifest:                   append(json.RawMessage(nil), manifest...),
+		InputSchema:                schema,
+		Source:                     Source{Label: mf.SourceLabel, IconURL: mf.SourceIconURL},
+		stateIndex:                 stateIndex,
+		interactions:               interactions,
+	}, nil
 }
 
 // SetDefault 显式设置某 id 的默认版本。Freeze 之后调用 → panic。
@@ -373,22 +408,30 @@ func manifestBytes(fs embed.FS, root string) json.RawMessage {
 	return append(json.RawMessage(nil), b...)
 }
 
-func loadSchema(fs embed.FS, root string) *jsonschema.Schema {
+type loadedSchema struct {
+	schema   *jsonschema.Schema
+	document map[string]any
+}
+
+func loadSchema(fs embed.FS, root string) loadedSchema {
 	p := path.Join(root, "contract", "data.schema.json")
 	b, err := fs.ReadFile(p)
 	if err != nil {
 		panic(fmt.Errorf("cardtmpl: read %s: %w", p, err))
 	}
-	c := jsonschema.NewCompiler()
-	// 用 URL 形式挂载 in-memory 资源,便于错误定位。
-	if err := c.AddResource(p, mustParseJSON(b)); err != nil {
-		panic(fmt.Errorf("cardtmpl: add schema resource %s: %w", p, err))
+	parsed, err := decodeStrictJSON(b, jsonBudget{maxDepth: maxArtifactJSONDepth, maxNodes: maxArtifactJSONNodes})
+	if err != nil {
+		panic(fmt.Errorf("cardtmpl: parse schema %s: %w", p, err))
 	}
-	sch, err := c.Compile(p)
+	document, ok := parsed.(map[string]any)
+	if !ok {
+		panic(fmt.Errorf("cardtmpl: schema %s root must be an object", p))
+	}
+	sch, err := compileJSONSchema(document)
 	if err != nil {
 		panic(fmt.Errorf("cardtmpl: compile schema %s: %w", p, err))
 	}
-	return sch
+	return loadedSchema{schema: sch, document: document}
 }
 
 func loadInteractionReports(fs embed.FS, root string, views map[ViewKey]manifestView) map[ViewKey]InteractionReport {

--- a/pkg/cardtmpl/testdata/test.runtime-parity@1.0.0/contract/data.schema.json
+++ b/pkg/cardtmpl/testdata/test.runtime-parity@1.0.0/contract/data.schema.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["title"],
+  "properties": {
+    "title": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 32
+    }
+  }
+}

--- a/pkg/cardtmpl/testdata/test.runtime-parity@1.0.0/manifest.json
+++ b/pkg/cardtmpl/testdata/test.runtime-parity@1.0.0/manifest.json
@@ -1,0 +1,20 @@
+{
+  "schemaVersion": 2,
+  "id": "test.runtime-parity",
+  "name": "Runtime parity fixture",
+  "version": "1.0.0",
+  "contractVersion": "1.0.0",
+  "protocol": "octo-card@1.0",
+  "adaptiveCardVersion": "1.5",
+  "defaultLocale": "en-US",
+  "owner": "ai",
+  "dataSchema": "contract/data.schema.json",
+  "views": {
+    "main": {
+      "wireProfile": "octo/v1",
+      "states": ["shown"],
+      "template": "templates/main.template.json",
+      "samples": ["samples/shown.json"]
+    }
+  }
+}

--- a/pkg/cardtmpl/testdata/test.runtime-parity@1.0.0/samples/shown.json
+++ b/pkg/cardtmpl/testdata/test.runtime-parity@1.0.0/samples/shown.json
@@ -1,0 +1,3 @@
+{
+  "title": "parity"
+}

--- a/pkg/cardtmpl/testdata/test.runtime-parity@1.0.0/templates/main.template.json
+++ b/pkg/cardtmpl/testdata/test.runtime-parity@1.0.0/templates/main.template.json
@@ -1,0 +1,11 @@
+{
+  "type": "AdaptiveCard",
+  "version": "1.5",
+  "body": [
+    {
+      "type": "TextBlock",
+      "text": "${title}",
+      "wrap": true
+    }
+  ]
+}

--- a/pkg/errcode/card_template_catalog.go
+++ b/pkg/errcode/card_template_catalog.go
@@ -1,0 +1,37 @@
+package errcode
+
+import (
+	"net/http"
+
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n/codes"
+)
+
+var (
+	ErrCardTemplateCatalogForbidden = register(codes.Code{
+		ID:             "err.server.card_template_catalog.forbidden",
+		HTTPStatus:     http.StatusForbidden,
+		DefaultMessage: "Only a super admin can manage card templates.",
+	})
+	ErrCardTemplateCatalogRequestInvalid = register(codes.Code{
+		ID:             "err.server.card_template_catalog.request_invalid",
+		HTTPStatus:     http.StatusBadRequest,
+		DefaultMessage: "The card template bundle is invalid.",
+		SafeDetailKeys: []string{"category", "document"},
+	})
+	ErrCardTemplateCatalogContentTooLarge = register(codes.Code{
+		ID:             "err.server.card_template_catalog.content_too_large",
+		HTTPStatus:     http.StatusRequestEntityTooLarge,
+		DefaultMessage: "The card template request is too large.",
+	})
+	ErrCardTemplateCatalogConflict = register(codes.Code{
+		ID:             "err.server.card_template_catalog.conflict",
+		HTTPStatus:     http.StatusConflict,
+		DefaultMessage: "The card template version conflicts with an immutable artifact.",
+	})
+	ErrCardTemplateCatalogUnavailable = register(codes.Code{
+		ID:             "err.server.card_template_catalog.unavailable",
+		HTTPStatus:     http.StatusServiceUnavailable,
+		DefaultMessage: "The card template catalog is temporarily unavailable.",
+		Internal:       true,
+	})
+)

--- a/pkg/i18n/locales/active.zh-CN.toml
+++ b/pkg/i18n/locales/active.zh-CN.toml
@@ -1291,3 +1291,18 @@ other = "只能清除自己发送的卡片的修订历史。"
 
 ["err.server.robot.card_edit_forbidden"]
 other = "卡片消息不支持编辑。"
+
+["err.server.card_template_catalog.forbidden"]
+other = "仅超级管理员可管理卡片模板。"
+
+["err.server.card_template_catalog.request_invalid"]
+other = "卡片模板制品无效。"
+
+["err.server.card_template_catalog.content_too_large"]
+other = "卡片模板请求超过大小上限。"
+
+["err.server.card_template_catalog.conflict"]
+other = "卡片模板版本与已发布的不可变制品冲突。"
+
+["err.server.card_template_catalog.unavailable"]
+other = "卡片模板目录暂时不可用。"

--- a/tools/i18nmarkers/server/active.en-US.toml
+++ b/tools/i18nmarkers/server/active.en-US.toml
@@ -249,6 +249,21 @@ other = "Failed to update data."
 ["err.server.botfather.username_taken"]
 other = "The username is already taken."
 
+["err.server.card_template_catalog.conflict"]
+other = "The card template version conflicts with an immutable artifact."
+
+["err.server.card_template_catalog.content_too_large"]
+other = "The card template request is too large."
+
+["err.server.card_template_catalog.forbidden"]
+other = "Only a super admin can manage card templates."
+
+["err.server.card_template_catalog.request_invalid"]
+other = "The card template bundle is invalid."
+
+["err.server.card_template_catalog.unavailable"]
+other = "The card template catalog is temporarily unavailable."
+
 ["err.server.category.default_immutable"]
 other = "The default category cannot be modified."
 


### PR DESCRIPTION
## Summary

Add the E3 PR-A foundation for runtime JSON card-template publishing: a shared fail-closed compiler, immutable audited persistence, and super-admin validate/publish APIs. Published artifacts remain inactive and are not read by production render paths.

## Related Issue

Fixes #669

## Linked Spec

[`.octospec/tasks/cardtmpl-runtime-catalog/brief.md`](.octospec/tasks/cardtmpl-runtime-catalog/brief.md)

## Changes

- Compile untrusted structured JSON bundles with strict decoding, bounded resources, canonical SHA-256 identity, schema/template/report/sample/golden conformance, and typed safe errors.
- Reuse the compiler from static `RegisterJSON`; reject JSON-only constraints on Go-authored templates and preserve legacy static registration compatibility.
- Resolve local schema refs at every schema-bearing position with cycle and bound checks; use a context-aware, deterministic single traversal with a total visit budget; keep sample binding view-local; and verify static/runtime canonical parity.
- Close final review gaps: normalize golden and production number semantics, make canonical integer limits recompile-safe, reserve exact sample matches before positional fallback, deterministically report invalid documents, audit rejected immutable/static-source publishes, and remove redundant control-envelope parsing plus UTF-16 sort allocations.
- Persist case-sensitive static/dynamic version claims, immutable canonical artifacts, and append-only publish audits transactionally; reconcile the frozen static inventory with a contention-safe upsert and bounded transient retry.
- Add authenticated, UID-rate-limited super-admin `validate` and `publish` endpoints with a 2 MiB body cap, localized errors, inactive-only responses, and distinct busy/timeout/cancellation/integrity/unavailability signaling. Publish DB work has an independent 10-second deadline and bounded whole-transaction retry for MySQL 1205/1213.
- Document fail-closed startup recovery: roll back or correct an image that introduces a static/dynamic exact-key collision, assign the built-in a new version, and never bypass reconciliation or rewrite immutable catalog rows.
- Add bounded operation/compile/database metrics and TDD coverage for immutability, trust boundaries, storage limits, canonical identity, and failure paths.

## Testing

- [x] Unit tests added/updated
- [ ] Manually verified
- `go test ./pkg/cardtmpl/... ./modules/card_template_catalog -count=1`
- `go test ./pkg/cardtmpl -coverprofile=.context/cardtmpl.cover.out -count=1` (`80.6%`)
- `go test ./modules/card_template_catalog -coverprofile=.context/card_template_catalog.cover.out -count=1` (`83.0%`)
- `go test -race ./pkg/cardtmpl/... ./modules/card_template_catalog ./pkg/cardmsg ./internal/carddispatch ./internal/cardactiondispatch -count=1`
- `go test -race ./modules/bot_api -run 'Test(BotCardTemplate|EffectiveCardTemplateIdentity)' -count=1`
- `go build ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `make i18n-extract-check && make i18n-lint`

`go test ./modules/bot_api/... -count=1` remains blocked before the relevant assertions by a stale shared test-database migration record (`20191106000001_event_legacy01.sql`); the database-independent Bot catalog race tests above pass.

## COMPREHENSION

1. **What does this change actually do** to the load-bearing path?

   Static JSON registration now goes through the same strict compiler used by the new control plane. Startup also transactionally claims every frozen static `id@version`. Super admins can validate and immutably publish reviewed JSON bundles, but the resulting artifact is always inactive and no send, edit, action, or discovery path reads it in PR-A.

2. **What could break** because of it (dependents + failure mode)?

   A compiler regression could reject a built-in JSON template during boot, and a static/dynamic exact-key conflict or catalog database failure now prevents startup readiness instead of allowing replicas to disagree. The safe PR-A break-glass path is binary rollback/correction; an ignore-conflict switch or direct claim rewrite would violate the identity invariant. Publish validation, audit, or database failures fail closed without creating a usable artifact. Existing Go templates, Bot authorization, card rendering, and dispatch remain unchanged beyond the shared static compiler path.

3. **How do you know it works** (specific test/repro/trace)?

   RED/GREEN checkpoints cover strict decoding, local-ref bounds and cycles, linear/context-bounded schema traversal, deterministic view-local sample binding, canonical identity, all aggregate-constraint misconfiguration branches, static/runtime parity, immutable same-hash retry versus different-hash conflict, whole-transaction 1205/1213 retry, publish deadline and failure classification, transactional audit rollback, contention-safe static-claim reconciliation, super-admin/auth/body-limit/error behavior, inactive responses, and bounded metric labels. Focused race tests, full build/vet, lint, and i18n checks pass locally.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] PR description is in English
- [x] Added tests for my changes
- [x] Updated documentation
- [x] Followed commit message conventions (Conventional Commits)