### PR TITLE
fix(message): allow same-Space colleagues to react to DM messages

### DIFF
--- a/.octospec/journal/shared/dm-reaction-space-access.md
+++ b/.octospec/journal/shared/dm-reaction-space-access.md
@@ -51,10 +51,21 @@ reachability signal and said so in comments
   middleware-verified `space_id`; a request without `space_id` / `X-Space-ID`
   degrades to friend-only (unchanged behavior, and one less query on that path).
   Keeps the predicate byte-identical to `validateChannelAccess`.
-- **Bot classification runs before the Space branch.** A bot has no
-  `space_member` row, so a Space-first ordering would deny a user reacting in
-  their own bot's DM. Disabled bots (`user.robot=1`, `robot.status!=1`) surface
-  `creatorUID=""` and therefore stay friendship-gated.
+- **Bot classification runs before the Space branch**, for two independent
+  reasons — the security-relevant one is the reverse of the intuitive one:
+  robot-module bots **do** have a `space_member` row (that row is what makes a
+  bot visible in a Space, `modules/robot/api.go:1497`), so a Space-first gate
+  would admit *someone else's* bot on Space membership alone and drop the
+  friendship requirement `modules/robot/event.go` enforces; App Bots **do not**
+  have one (`app_bot.go createBot` skips it), so a Space-first gate would deny a
+  user their *own* bot's DM. Disabled bots (`user.robot=1`, `robot.status!=1`)
+  surface `creatorUID=""` and therefore stay friendship-gated.
+
+- **`syncReaction` rejects composite (`a@b`) `channel_id` at the boundary, and
+  the storage channel id is now always derived from `loginUID`.** This is the
+  security fix that came out of review (see below); it turns "the physical
+  channel id always contains the caller" from an assumption about uid charsets
+  into a structural invariant.
 - **Prefixed DM channel ids (`s{spaceID}_{uid}`) deliberately not handled.**
   Investigated: the current system does not produce them for DMs — this repo's
   own record states conversation-level `SpaceID` for a DM is intentionally
@@ -77,6 +88,38 @@ reachability signal and said so in comments
 - 13-case unit decision table + 3 query-count assertions, all DB-free.
 - `go build ./...`, `go vet`, `golangci-lint` (0 issues),
   `make i18n-extract-check`, `make i18n-lint` green.
+
+## The defect review caught (and the general lesson)
+
+The first version of this change made a genuinely exploitable path reachable.
+`syncReaction` historically accepted an already-composed physical channel id
+(`strings.Contains(req.ChannelID, "@")`) and passed it to storage verbatim — the
+only path where the storage channel id was not derived from `loginUID`. The
+friend gate had kept that branch dead by accident: every `friend` insert path
+resolves the peer through a `user` existence check first, so `IsFriend(u, "a@b")`
+could never be true. The Space gate has no such discipline —
+`AreSpaceMembers` → `CheckBothMembers` joins `space` and `space_member` but
+**never `user`**, and `space_member.uid` is an attacker-writable arbitrary
+string (`space/api.go addMembers` inserts `req.UIDs` verbatim with no existence
+or charset check, and creating a Space is open to any authenticated user by
+default). So: create a Space, add the string `"<victimA>@<victimB>"` as a
+"member", then `POST /v1/reaction/sync` with that as `channel_id` — the gate
+passes and the victim DM's reaction metadata (message_id, reactor uid + display
+name, emoji, seq, timestamps) comes back.
+
+Confirmed empirically, not just by reading: `TestSyncReactionRejectsCompositeChannelIDLeak`
+returned `200` with the victim's row before the fix and is denied after.
+
+**Lesson:** when you swap the predicate behind a gate, the question is not "what
+values does the *identity* table allow" but "what does each *newly consulted*
+table allow, and who can write it". A predicate whose backing table has no
+referential discipline can revive input shapes that a stricter predicate had
+been keeping dead.
+
+Two follow-ups this exposes, both worth their own task and both wider than this
+endpoint: `space/api.go addMembers` should validate that each uid resolves to a
+real user, and `CheckBothMembers` should join `user` so "is a Space member"
+implies "is a user" for every caller at once.
 
 ## Gotcha worth remembering (test infrastructure)
 

--- a/.octospec/journal/shared/dm-reaction-space-access.md
+++ b/.octospec/journal/shared/dm-reaction-space-access.md
@@ -1,0 +1,123 @@
+---
+type: Journal
+title: "Journal: dm-reaction-space-access"
+description: DM reaction endpoints were gated on the friend table alone, so every colleague DM reaction 403'd in Space deployments; aligned both the write and the sync path with the canonical friend ∪ own-bot ∪ same-Space predicate.
+tags: ["space", "isolation", "auth", "acl", "error-response", "testing", "dm", "reaction"]
+timestamp: 2026-07-28T09:40:00Z
+# --- octospec extension fields ---
+task: dm-reaction-space-access
+upstream: "production report — POST /v1/reactions on a human-to-human DM returned err.server.message.channel_access_denied (403)"
+source: self
+---
+
+# Journal: dm-reaction-space-access
+
+## What was done
+
+- Replaced the friend-only DM gate on `POST /v1/reactions`
+  (`addOrCancelReaction`) and `POST /v1/reaction/sync` (`syncReaction`) with the
+  predicate `modules/user/api_pinned.go::validateChannelAccess` already used:
+  self → friend → bot (own bot allowed; someone else's bot still needs
+  friendship) → real user in the same active Space.
+- Extracted the predicate into `modules/message/api_person_access.go` as a pure
+  function over a three-method dependency interface (`IsFriend`,
+  `QueryPeerRobotInfo`, `AreSpaceMembers`), which `user.IService` satisfies
+  structurally. Read and write call the same helper, so the read/write parity
+  invariant already documented in `syncReaction` cannot drift.
+- No new error code and no wire change: denials stay
+  `ErrMessageChannelAccessDenied`, lookup failures stay
+  `ErrMessageQueryFailed` (logged with `zap.Error` first, fail-closed).
+
+## Why it was broken
+
+The Person branch of `addOrCancelReaction` has exactly one path to
+`channel_access_denied` — the `!isFriend` check — so the production 403 was
+unambiguous. `IsFriend` is a plain `friend` table lookup, and **nothing writes
+`friend` rows on Space join**: the only writers are the system-bot / fileHelper /
+botfather seeds and the explicit add-friend flow. In the enterprise
+contact-book (Space) deployment the table is therefore near-empty, so *every*
+colleague DM reaction failed, for every user, on both the write and the read
+side — the reaction UI could not even load its state.
+
+The rest of the codebase had already moved to Space membership as the DM
+reachability signal and said so in comments
+(`api_pinned.go::validateChannelAccess`, `messages_search/authz.go::checkP2PAccess`
+"in Space mode the friend table is near-empty", `sendMsg`'s Space branch using
+`CheckBothMembers`). The reaction endpoints were the outlier.
+
+## Load-bearing decisions
+
+- **No default-Space fallback.** The Space used is only the
+  middleware-verified `space_id`; a request without `space_id` / `X-Space-ID`
+  degrades to friend-only (unchanged behavior, and one less query on that path).
+  Keeps the predicate byte-identical to `validateChannelAccess`.
+- **Bot classification runs before the Space branch.** A bot has no
+  `space_member` row, so a Space-first ordering would deny a user reacting in
+  their own bot's DM. Disabled bots (`user.robot=1`, `robot.status!=1`) surface
+  `creatorUID=""` and therefore stay friendship-gated.
+- **Prefixed DM channel ids (`s{spaceID}_{uid}`) deliberately not handled.**
+  Investigated: the current system does not produce them for DMs — this repo's
+  own record states conversation-level `SpaceID` for a DM is intentionally
+  empty (`dm-space-isolation-484`, `api_conversation.go:1584`), which is why the
+  `payload.space_id` soft tag exists at all. The only non-test constructor
+  (`webhook/common.go resolvePushChannelID`) merely preserves a prefix that
+  arrived from WuKongIM; everything else is read-side legacy tolerance.
+- **Scope held to the two reaction endpoints** even though the identical
+  friend-only gate exists on three other endpoints (see Follow-ups).
+
+## Verification
+
+- Red-before-green proved on real infra: with the pre-fix `api.go`,
+  `TestReactionAllowsSameSpaceDMWithoutFriendship` fails and
+  `TestReactionRejectsDMWithoutFriendshipOrSpace` passes — i.e. the new test
+  pins the production bug and the negative test shows the gate was not merely
+  opened.
+- `-tags integration -run Reaction`: 20/20 pass. Default build (the lane CI
+  actually runs) `-race -shuffle=on ./modules/message/`: 380 pass, 0 fail.
+- 13-case unit decision table + 3 query-count assertions, all DB-free.
+- `go build ./...`, `go vet`, `golangci-lint` (0 issues),
+  `make i18n-extract-check`, `make i18n-lint` green.
+
+## Gotcha worth remembering (test infrastructure)
+
+`modules/message` integration tests do **not** run in CI, and there are two
+independent walls:
+
+1. `ci.yml` deliberately runs the **default** build with no `-tags integration`,
+   because `modules/conversation_ext/*` integration tests connect to a separate
+   `conv_ext_test` database with `Migration=false` and assume a pre-baked
+   schema; the CI job only provisions `test`. The comment there explicitly flags
+   flipping the flag as a maintainer decision.
+2. Even with the flag flipped, this package's integration build does not
+   compile: `api_card_action_test.go` imports `modules/app_bot` →
+   `modules/bot_api` → `modules/messages_search` → `modules/message`, an import
+   cycle in test. Reproduced on clean `origin/main`.
+
+Running the suite locally required temporarily setting
+`api_card_action_test.go` + `api_card_revisions_test.go` aside (the latter
+depends on a symbol in the former).
+
+## Follow-ups / notes
+
+- **Blacklist is not consulted on the DM reaction path.** `addBlacklist`
+  (`user/api.go:2396`) writes `user_setting.blacklist=1` and bumps the friend
+  version but does not delete the `friend` row, so a blacklisted *friend* could
+  already react before this change; the gap now extends to blacklisted
+  same-Space colleagues. `messages_search/authz.go` is the only DM gate that
+  checks the bidirectional blacklist; `validateChannelAccess` does not either.
+  Whether to tighten all three is a product call.
+- **Same friend-only gate remains on**: `message/api_pinned.go:59,357,551`
+  (pin/unpin/clear, `ErrMessageConversationForbidden`),
+  `message/api_channel_files.go:197` (`ErrMessageNotFriend`), and
+  `channel/api.go:99` (channel setting, still on legacy `c.ResponseError` so it
+  also needs an i18n migration). All three will 403/deny colleagues in Space
+  deployments exactly as reactions did.
+- **Dead branch**: `syncReaction` accepts a pre-built fake channel id
+  (`strings.Contains(req.ChannelID, "@")`, `api.go:1799`), but no such string
+  can pass the DM gate (before or after this change), so the branch is
+  unreachable and the write path never supported that shape. Worth cleaning up
+  separately.
+- octo-web: no change needed. Its reaction call passes
+  `requestChannel.channelID` unstripped
+  (`features/messageReaction/controller.ts:179`), which is inert with bare-UID
+  DM channels.

--- a/.octospec/learnings/pending/relationship-gate-deployment-mode.md
+++ b/.octospec/learnings/pending/relationship-gate-deployment-mode.md
@@ -44,10 +44,21 @@ Use the same four steps as `modules/user/api_pinned.go::validateChannelAccess`
 4. `AreSpaceMembers(spaceID, caller, peer)` — the Space signal, using only the
    `space_id` the Space middleware already verified.
 
-**Ordering is load-bearing, not stylistic: step 3 must precede step 4.** A bot
-has no `space_member` row, so a Space-first gate returns false for every bot and
-denies a user access to their *own* bot's DM. This is the one ordering mistake
-that reads as correct and fails in production.
+**Ordering is load-bearing, not stylistic: step 3 must precede step 4.** The two
+bot flavours each supply an independent reason, and the security-relevant one is
+easy to get backwards:
+
+- robot-module bots **do** carry a `space_member` row — that row is the mechanism
+  that makes a bot visible in a Space (`modules/robot/api.go:1497` lists them via
+  `space_member INNER JOIN user … u.robot = 1`). A Space-first gate would let
+  *someone else's* bot through on Space membership alone, silently dropping the
+  friendship requirement that `modules/robot/event.go` enforces.
+- App Bots **do not** (`modules/app_bot/app_bot.go createBot` deliberately skips
+  it), so a Space-first gate would deny a user their *own* bot's DM.
+
+Do not simplify this to "bots have no `space_member` row" — that half is only
+true for App Bots, and a future author who discovers the other half may drop the
+ordering constraint as obsolete.
 
 Two more details that keep the gate honest:
 

--- a/.octospec/learnings/pending/relationship-gate-deployment-mode.md
+++ b/.octospec/learnings/pending/relationship-gate-deployment-mode.md
@@ -1,0 +1,72 @@
+---
+type: Learning
+title: "Relationship gates: the friend table is not the deployment-portable signal"
+description: A DM/peer access check written as \"is friend?\" silently becomes a blanket 403 in the enterprise contact-book (Space) deployment, where nothing writes friend rows. Any new peer gate must use the friend ∪ own-bot ∪ same-Space predicate, and bot classification must precede the Space branch because bots have no space_member row.
+tags: ["space", "isolation", "auth", "acl", "dm", "review"]
+timestamp: 2026-07-28T09:40:00Z
+# --- octospec extension fields ---
+source: self
+origin_task: dm-reaction-space-access
+origin_pr: "Mininglamp-OSS/octo-server (DM reaction Space access)"
+status: pending
+candidate_rule: space-isolation
+---
+# Relationship gates: the friend table is not the deployment-portable signal
+
+`IsFriend(a, b)` reads one row from `friend`. In the personal-space deployment
+that table is authoritative. In the enterprise contact-book (**Space**)
+deployment **nothing writes it** on Space join — the only writers are the
+system-bot / fileHelper / botfather seeds and the explicit add-friend flow — so
+a gate written as
+
+```go
+isFriend, err := m.userService.IsFriend(loginUID, req.ChannelID)
+if !isFriend { /* deny */ }
+```
+
+is not "a stricter check". It is a **blanket deny for every colleague pair**,
+for every user, in that deployment. The failure is invisible in unit tests
+(which seed a friend row), invisible in the personal-space deployment, and
+looks like a permission bug rather than a missing-relationship bug in
+production — the caller sees a plain 403.
+
+## The portable predicate
+
+Use the same four steps as `modules/user/api_pinned.go::validateChannelAccess`
+(also `modules/messages_search/authz.go::checkP2PAccess`), in this order:
+
+1. `peer == caller` — notes-to-self; no relationship judgement is meaningful.
+2. `IsFriend(caller, peer)` — authoritative in personal-space deployments;
+   cheapest, so it short-circuits the common legacy case.
+3. `QueryPeerRobotInfo(peer)` — own bot passes; someone else's bot must be a
+   friend (matches `modules/robot/event.go`). A disabled bot yields
+   `creatorUID == ""`, so it correctly stays friendship-gated.
+4. `AreSpaceMembers(spaceID, caller, peer)` — the Space signal, using only the
+   `space_id` the Space middleware already verified.
+
+**Ordering is load-bearing, not stylistic: step 3 must precede step 4.** A bot
+has no `space_member` row, so a Space-first gate returns false for every bot and
+denies a user access to their *own* bot's DM. This is the one ordering mistake
+that reads as correct and fails in production.
+
+Two more details that keep the gate honest:
+
+- **Fail closed on every lookup.** Return `(false, err)` and let the caller map
+  it to the module's internal/query-failed code after logging the cause. A gate
+  that treats a DB error as "not a friend" is fine; one that treats it as
+  "allow" is a hole.
+- **A missing Space on the request is not a reason to invent one.** Resolving
+  the caller's default Space as a fallback widens the gate for clients that
+  simply omit the header. Degrade to friend-only instead — that keeps the
+  predicate identical to the canonical one and costs one query less.
+
+## How to catch it in review
+
+When a diff adds or moves a peer/DM access check, ask: *which deployment mode
+does this signal exist in?* Grep for the writers of the table being read
+(`friend` here). If the only writers are seeds and an explicit user action, the
+gate cannot carry the enterprise deployment on its own.
+
+Origin: `modules/message/api.go` reaction endpoints (write + sync) were the last
+two peer gates still on friend-only; the same pattern still exists in
+`message/api_pinned.go`, `message/api_channel_files.go`, and `channel/api.go`.

--- a/.octospec/log.md
+++ b/.octospec/log.md
@@ -4,6 +4,29 @@ Change history for this repo's `.octospec/`, following the
 [OKF](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md)
 change-log convention (§7). Newest first.
 
+## 2026-07-28 (dm-reaction-space-access)
+
+- **Access control** — DM (`channel_type=1`) authorization on `POST /v1/reactions`
+  and `POST /v1/reaction/sync` moved off friend-only to the canonical peer
+  predicate (self → friend → own bot → same active Space), extracted into one
+  helper shared by the write and sync paths. In the Space deployment the
+  `friend` table is near-empty, so the previous gate 403'd every colleague DM
+  reaction on both sides. No new error code, no wire change. See
+  [journal](journal/shared/dm-reaction-space-access.md) and
+  [brief](tasks/dm-reaction-space-access/brief.md).
+- **Decisions** — Space comes only from the middleware-verified `space_id` (no
+  default-Space fallback); bot classification must precede the Space branch
+  (bots have no `space_member` row); legacy `s{spaceID}_{uid}` DM channel ids
+  deliberately not handled after confirming the system no longer produces them.
+- **Learning (pending)** — a "is friend?" peer gate is not deployment-portable;
+  ordering bot-before-Space is load-bearing. See
+  [learning](learnings/pending/relationship-gate-deployment-mode.md).
+- **Known gaps recorded, not fixed** — the same friend-only gate remains on
+  `message/api_pinned.go`, `message/api_channel_files.go`, `channel/api.go`;
+  the bidirectional blacklist is still not consulted on the DM reaction path;
+  `modules/message` integration tests run in neither CI lane (deliberate
+  no-`-tags integration` policy plus a test-only import cycle).
+
 ## 2026-07-24 (bot-card-template-consumption, roadmap E1b)
 
 - **Protocol** — Added the explicit Bot Registry template catalog to

--- a/.octospec/tasks/dm-reaction-space-access/brief.md
+++ b/.octospec/tasks/dm-reaction-space-access/brief.md
@@ -158,10 +158,19 @@ that is inert.
   it — worth its own task.)
 - `fakeChannelID` computation (`common.GetFakeChannelIDWith`) and the
   `reaction_users` storage layout.
-- The pre-existing `-tags integration` import cycle in `modules/message`
-  (`api_card_action_test.go` → `app_bot` → `bot_api` → `messages_search` →
-  `message`), which currently prevents this package's integration tests from
-  compiling at all. Reproduced on clean `origin/main`; needs its own task.
+- The two reasons `modules/message` integration tests run in no CI lane, both
+  pre-existing and each needing its own task: (a) `ci.yml:236-253` deliberately
+  runs the **default** build with no `-tags integration`, because
+  `modules/conversation_ext/*` expects a separate pre-baked `conv_ext_test`
+  database that the job never provisions — the comment flags flipping the flag
+  as a maintainer decision; (b) even with the flag flipped this package's
+  integration build does not compile — `api_card_action_test.go` → `app_bot` →
+  `bot_api` → `messages_search` → `message` is an import cycle in test
+  (reproduced on clean `origin/main`).
+- The unreachable pre-built-fake-channel branch in `syncReaction`
+  (`api.go:1799`, `strings.Contains(req.ChannelID, "@")`): no such string can
+  pass the DM gate before or after this change, and the write path never
+  supported that shape. Cleanup belongs in its own task.
 - Any octo-web change (none required).
 
 ## Acceptance

--- a/.octospec/tasks/dm-reaction-space-access/brief.md
+++ b/.octospec/tasks/dm-reaction-space-access/brief.md
@@ -1,0 +1,194 @@
+---
+type: Task
+title: "Task: dm-reaction-space-access"
+description: DM (Person) reaction endpoints deny same-Space colleagues because the access gate only consults the friend table; align them with the canonical DM predicate.
+tags: ["space", "isolation", "auth", "acl", "error-response", "testing"]
+timestamp: 2026-07-28T00:00:00Z
+# --- octospec extension fields ---
+slug: dm-reaction-space-access
+upstream: production report — POST /v1/reactions on a human-to-human DM returns err.server.message.channel_access_denied (403)
+source: self
+---
+
+# Task: dm-reaction-space-access
+
+## Goal
+
+Reacting to a message in a **human-to-human DM** fails in production:
+
+```
+POST /api/v1/reactions
+{"message_id":"2081994021533552640","channel_id":"17630a8d72b24adc96db007d73380696","channel_type":1,"emoji":"[尚方宝剑]"}
+→ {"error":{"code":"err.server.message.channel_access_denied","http_status":403}, "status":400}
+```
+
+Replace the friend-only DM gate on the two reaction endpoints with the exact
+predicate `modules/user/api_pinned.go::validateChannelAccess` already uses
+(evaluated in order, first hit wins):
+
+1. peer == caller (notes-to-self);
+2. friend (authoritative in personal-space deployments);
+3. peer is a bot — own bot allowed; someone else's bot still requires friendship;
+4. peer is a real user and `AreSpaceMembers(requestSpaceID, caller, peer)`.
+
+The Space used in step 4 is **only** the request's middleware-verified
+`space_id` (`spacepkg.GetSpaceID(c)`). With no Space on the request the gate
+degrades to friend-only — i.e. today's behavior, 403 for a non-friend — by
+decision (D1 below).
+
+Denials keep the existing code and envelope; every lookup stays fail-closed.
+
+## Background
+
+**Localisation of the fault (evidence chain).**
+
+- Route: `modules/message/api.go:384` `POST /v1/reactions` → `addOrCancelReaction`
+  (`api.go:1978`); `modules/message/api.go:388` `POST /v1/reaction/sync` →
+  `syncReaction` (`api.go:1726`). Both mount `AuthMiddleware` + `uidLimit` +
+  `spacepkg.SpaceMiddleware`.
+- For `channel_type=1` (Person), `addOrCancelReaction` has **exactly one** path to
+  `errcode.ErrMessageChannelAccessDenied`: the `!isFriend` branch at
+  `api.go:2036-2044`. `syncReaction` mirrors it at `api.go:1755-1763`. So the
+  reported 403 is unambiguously the friend lookup returning false.
+- `channel_id` in the report is a bare 32-hex UID, `channel_type=1`, peer is a
+  human — the bot branches never ran; the friend check is the only gate involved.
+- `IsFriend` (`modules/user/db_friend.go:71`) is a plain `friend` table lookup.
+  Nothing populates `friend` on Space join: the only writers are the
+  system-bot / fileHelper / botfather seeds (`modules/user/api.go:3100,3150,3168,3251`,
+  `api_manager.go:1224,1266`) and the explicit add-friend flow.
+- The rest of the codebase already treats Space membership as the DM
+  reachability signal, and says so:
+  - `modules/user/api_pinned.go:264 validateChannelAccess` — friend ∪ own bot ∪
+    `AreSpaceMembers`, "允许同 Space 成员（即便未互加好友）之间互相置顶";
+  - `modules/messages_search/authz.go:92 checkP2PAccess` — same predicate, with
+    the reason spelled out: "in Space (enterprise contact-book) mode the friend
+    table is near-empty (mostly system bots); in non-Space deployments friend is
+    authoritative. Either-or covers both";
+  - `modules/message/api.go:471 sendMsg` — Space channel → `CheckBothMembers`,
+    friend only as the personal-space fallback.
+- Conclusion: the reaction endpoints are the outlier. In the enterprise
+  contact-book deployment every colleague DM reaction is a guaranteed 403, for
+  every user, on both the write and the read/sync side (so the reaction UI cannot
+  even load its state).
+
+**Why read and write must move together.** `syncReaction`'s existing comment
+(`api.go:1739-1741`) pins read/write parity as an invariant — "同步鉴权必须与写路径
+（addOrCancelReaction）对齐 … 否则读/同步路径会成为绕过写路径加固的短板". Fixing one
+side only would both leave the feature broken and break that invariant.
+
+**Space context available to the gate.** `spacepkg.GetSpaceID(c)`
+(`pkg/space/middleware.go:158`) is populated from the `space_id` query param or
+the `X-Space-ID` header; octo-web injects it on every request
+(`packages/dmworkbase/src/Service/APIClient.ts`, `X-Space-Id`). `AreSpaceMembers`
+→ `spacepkg.CheckBothMembers` (`pkg/space/membership.go`) requires both
+`space_member.status=1` rows plus `space.status=1`.
+
+**Prefixed DM channel ids are not a live case** (investigated for D2). The
+current system does not produce `s{spaceID}_{uid}` Person channel ids: this
+repo's own design record states "DM is a single physical WuKongIM Person channel;
+conversation-level `SpaceID` is intentionally empty"
+(`.octospec/tasks/dm-space-isolation-484/brief.md`, `api_conversation.go:1584`) —
+which is precisely why the `payload.space_id` soft tag + `dm_space_presence`
+mechanism exists. The only non-test constructor of a prefixed id is
+`modules/webhook/common.go:29 resolvePushChannelID`, and it merely preserves a
+prefix that arrived from WuKongIM. Everything else is read-side tolerance for
+legacy data (`webhook/api.go:926` "legacy fallback for prefixed channel_ids",
+`channel/api.go:166`, and octo-web's `stripSpacePrefix` in
+`ChannelSettingService.ts:22` / `datasource.ts:202`). Note octo-web's reaction
+call passes `requestChannel.channelID` unstripped
+(`features/messageReaction/controller.ts:179`), but with bare-UID DM channels
+that is inert.
+
+## Load-bearing list
+
+- **DM authorization on `POST /v1/reactions`** (`api.go:2033-2046`) — widened
+  from friend-only to friend ∪ own-bot ∪ same-Space. `touches: space, isolation, auth, acl`
+- **DM authorization on `POST /v1/reaction/sync`** (`api.go:1753-1765`) — same
+  widening; read/write parity invariant (`api.go:1739-1741`) must still hold.
+- **Bot DM semantics** — own bot exempt from friendship *and* Space (a bot has no
+  `space_member` row, so a Space-first ordering would deny own-bot DMs — see
+  `messages_search/authz.go:99-115`); someone else's bot still needs friendship
+  (`modules/robot/event.go` "用户与Bot非好友关系，拒绝转发消息"). Disabled bots
+  (`user.robot=1`, `robot.status!=1`) yield `creatorUID=""` and therefore stay
+  friendship-gated (`modules/user/db_pinned.go:61`).
+- **Per-message DM Space isolation** — `personSpaceAllows`
+  (`modules/message/space_filter.go:582`) + `payloadSpaceIDFromRaw`, used by both
+  `addOrCancelReaction` (`api.go:2134-2147`) and `filterReactionsByMessageVisibility`.
+  Runs *after* the access gate and must keep running unchanged, including the
+  untagged-message compat branch (`msgSpaceID=="" && spaceID==defaultSpaceID`).
+- **Anti-enumeration collapse** — target-not-visible / cross-Space / deleted-thread
+  all collapse to `ErrMessageNotFound`; access denial stays
+  `ErrMessageChannelAccessDenied`; lookup failures collapse to
+  `ErrMessageQueryFailed`. No new error code, no new wire status (`ResponseErrorL`
+  stays pinned 400 with `error.http_status=403`). `touches: error-response`
+- **Fail-closed on DB error** — every relationship lookup must deny on error and
+  log the cause via `zap.Error`; a Redis/MySQL blip must never open the gate.
+- **Group / CommunityTopic gates** — `ExistMemberActive`, thread-not-deleted,
+  group-disbanded guards: untouched.
+- **Guard test** `TestMessageNoLegacyResponseError` (`api_i18n_test.go:24`) — its
+  file list must cover any new handler-side file. `touches: error-response`
+- **Reaction integration suite** (`api_reaction_integration_test.go`) — the
+  friend-seeded DM cases and the cross-Space DM isolation cases must keep
+  passing unchanged. `touches: testing`
+
+## Decisions (confirmed)
+
+- **D1 — no default-Space fallback.** When the request carries no `space_id` /
+  `X-Space-ID`, the gate does **not** resolve the caller's default Space
+  (`space.GetUserDefaultSpaceIDE`); it falls through to friend-only and a
+  non-friend gets 403. Keeps the predicate byte-identical to
+  `validateChannelAccess` and adds no query on the no-Space path.
+- **D2 — prefixed DM channel ids not handled.** `req.ChannelID` is used as the
+  peer UID as-is; a legacy `s{spaceID}_{uid}` id keeps failing the gate exactly
+  as it does today (see Background for why this is not a live case).
+- **D3 — scope is the two reaction endpoints only.**
+
+## Out of scope
+
+- Everything ruled out by D1 / D2 / D3 above.
+- The identical friend-only DM gate on other endpoints — same latent production
+  bug, deliberately left for a separate task:
+  `modules/message/api_pinned.go:59,357,551` (pin/unpin/clear pinned,
+  `ErrMessageConversationForbidden`), `modules/message/api_channel_files.go:197`
+  (`ErrMessageNotFriend`), `modules/channel/api.go:99` (channel setting, still on
+  legacy `c.ResponseError`).
+- Bidirectional blacklist on the reaction DM path. `modules/message` consults
+  blacklist nowhere today and the canonical `validateChannelAccess` does not
+  either; adding it is a tightening, not this fix. (`messages_search` does check
+  it — worth its own task.)
+- `fakeChannelID` computation (`common.GetFakeChannelIDWith`) and the
+  `reaction_users` storage layout.
+- The pre-existing `-tags integration` import cycle in `modules/message`
+  (`api_card_action_test.go` → `app_bot` → `bot_api` → `messages_search` →
+  `message`), which currently prevents this package's integration tests from
+  compiling at all. Reproduced on clean `origin/main`; needs its own task.
+- Any octo-web change (none required).
+
+## Acceptance
+
+Unit (no DB — must run in the default, untagged build):
+
+- Decision table over the DM predicate covering: self; friend; own bot (allowed
+  without friendship *and* without Space); other's bot without friendship
+  (denied even when same-Space); other's bot with friendship; real user
+  same-Space; real user different-Space; real user with **no** Space on the
+  request → denied (D1); and fail-closed on each individual lookup error.
+- Friend hit short-circuits: no bot / Space lookup afterwards.
+
+Integration (`-tags integration`, MySQL + Redis):
+
+- Space colleague, **no** `friend` row, request carries `space_id` →
+  `POST /v1/reactions` returns 200 and persists exactly one `reaction_users`
+  row; `POST /v1/reaction/sync` returns 200 and includes that reaction.
+  (This is the production repro — red before, green after.)
+- Neither friend nor Space colleague → both endpoints denied with 4xx (not 5xx,
+  so a DB error cannot masquerade as a pass) and zero `reaction_users` rows.
+- `TestReactionRejectsCrossSpaceDMWrite` / `TestSyncReactionHidesCrossSpaceDMReaction`
+  and the group/thread gate cases pass unchanged.
+
+Gates:
+
+- `go build ./...`; `go vet ./modules/message/`;
+  `golangci-lint run ./modules/message/...` → 0 issues.
+- `make i18n-extract-check` and `make i18n-lint` pass (expected no-op: no new codes).
+- `TestMessageNoLegacyResponseError` passes with any new file registered in its list.

--- a/.octospec/tasks/dm-reaction-space-access/context.yaml
+++ b/.octospec/tasks/dm-reaction-space-access/context.yaml
@@ -1,0 +1,15 @@
+injected:
+  - id: space-isolation
+    source: repo
+    why: load-bearing; brief touches space/isolation/auth/acl and the change is a DM access gate
+  - id: error-handling
+    source: repo
+    why: load-bearing; paths modules/**/*.go + brief touches error-response (denials keep httperr.ResponseErrorL + registered errcode)
+  - id: rate-limit
+    source: repo
+    why: paths modules/**/*.go; no change (routes already mount uidLimit) — its testing note applies to the integration cases
+  - id: testing
+    source: repo
+    why: paths **/*_test.go; unit + integration coverage proportional to an auth-gate change
+brief: .octospec/tasks/dm-reaction-space-access/brief.md
+notes: .octospec/_global/ is not synced in this checkout, so only repo-tier rules were resolvable.

--- a/modules/message/api.go
+++ b/modules/message/api.go
@@ -1736,6 +1736,8 @@ func (m *Message) syncReaction(c *wkhttp.Context) {
 		respondMessageRequestInvalid(c, "")
 		return
 	}
+	// 与写路径对齐：channel_id 先 TrimSpace，避免 padding 造成的口径差异。
+	req.ChannelID = strings.TrimSpace(req.ChannelID)
 	// 同步鉴权必须与写路径（addOrCancelReaction）对齐：Group/子区用 ExistMemberActive
 	// 排除黑名单，子区解析父群并校验未删除，未知类型一律拒绝。否则读/同步路径会成为
 	// 绕过写路径加固的短板（任意登录用户凭 channel_id 拉取 reaction 元数据）。
@@ -1751,12 +1753,28 @@ func (m *Message) syncReaction(c *wkhttp.Context) {
 			return
 		}
 	} else if req.ChannelType == common.ChannelTypePerson.Uint8() {
+		// 复合（已拼好的物理频道）channel_id 一律在入口拒绝。DM 的 channel_id 契约是
+		// 「对端 UID」，"a@b" 这种形态历史上被下面的 fakeChannelID 分支原样透传，是唯一
+		// 一条 storage channel id 不由 loginUID 推导的路径。
+		//
+		// 旧的好友门恰好挡住了它（friend 行的写入方都先校验 user 存在，IsFriend("a@b")
+		// 永假），但同 Space 门查的是 space_member —— 那张表的 uid 是任意字符串：
+		// space/api.go addMembers 原样插入 req.UIDs、不校验 user 是否存在，而建 Space
+		// 默认对所有登录用户开放。于是攻击者可自建 Space、把受害者 DM 的物理频道串当
+		// 「成员」插进去，再用它 sync，越权读到别人私聊的 reaction 元数据（PR#671 review）。
+		// 拒绝这一形态后，下面的 fakeChannelID 必然由 loginUID 推导，
+		// 「物理频道 id 必然含调用者」成为结构性不变量，而不是对 uid 字符集的假设。
+		if strings.Contains(req.ChannelID, "@") {
+			respondMessageRequestInvalid(c, "channel_id")
+			return
+		}
 		// 与写路径（addOrCancelReaction）共用同一个 DM 门：好友 ∪ 本人创建的 bot
 		// ∪ 同 Space 同事。读/同步路径必须与写路径同口径，否则任一侧成为短板。
-		allowed, err := personChannelAccessAllowed(m.userService, loginUID, req.ChannelID, spacepkg.GetSpaceID(c))
+		reqSpaceID := spacepkg.GetSpaceID(c)
+		allowed, err := personChannelAccessAllowed(m.userService, loginUID, req.ChannelID, reqSpaceID)
 		if err != nil {
 			m.Error("校验私聊频道权限失败（reaction sync）", zap.Error(err),
-				zap.String("peer", req.ChannelID), zap.String("space_id", spacepkg.GetSpaceID(c)))
+				zap.String("peer", req.ChannelID), zap.String("space_id", reqSpaceID))
 			httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 			return
 		}
@@ -1798,9 +1816,9 @@ func (m *Message) syncReaction(c *wkhttp.Context) {
 
 	fakeChannelID := req.ChannelID
 	if req.ChannelType == common.ChannelTypePerson.Uint8() {
-		if !strings.Contains(req.ChannelID, "@") {
-			fakeChannelID = common.GetFakeChannelIDWith(loginUID, req.ChannelID)
-		}
+		// 一律由 loginUID 推导：复合形态已在鉴权前拒掉，这里不再有「原样透传」分支，
+		// 调用者不可能把物理频道 id 指向一条自己不在其中的 DM。
+		fakeChannelID = common.GetFakeChannelIDWith(loginUID, req.ChannelID)
 	}
 	limit := req.Limit
 	if limit <= 0 {

--- a/modules/message/api.go
+++ b/modules/message/api.go
@@ -1755,7 +1755,8 @@ func (m *Message) syncReaction(c *wkhttp.Context) {
 		// ∪ 同 Space 同事。读/同步路径必须与写路径同口径，否则任一侧成为短板。
 		allowed, err := personChannelAccessAllowed(m.userService, loginUID, req.ChannelID, spacepkg.GetSpaceID(c))
 		if err != nil {
-			m.Error("校验私聊频道权限失败（reaction sync）", zap.Error(err), zap.String("peer", req.ChannelID))
+			m.Error("校验私聊频道权限失败（reaction sync）", zap.Error(err),
+				zap.String("peer", req.ChannelID), zap.String("space_id", spacepkg.GetSpaceID(c)))
 			httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 			return
 		}
@@ -2037,7 +2038,8 @@ func (m *Message) addOrCancelReaction(c *wkhttp.Context) {
 		// 同事之间的 DM 一律 403 —— friend 表在该模式下近乎为空。
 		allowed, err := personChannelAccessAllowed(m.userService, loginUID, req.ChannelID, spacepkg.GetSpaceID(c))
 		if err != nil {
-			m.Error("校验私聊频道权限失败（reaction）", zap.Error(err), zap.String("peer", req.ChannelID))
+			m.Error("校验私聊频道权限失败（reaction）", zap.Error(err),
+				zap.String("peer", req.ChannelID), zap.String("space_id", spacepkg.GetSpaceID(c)))
 			httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 			return
 		}

--- a/modules/message/api.go
+++ b/modules/message/api.go
@@ -1751,17 +1751,17 @@ func (m *Message) syncReaction(c *wkhttp.Context) {
 			return
 		}
 	} else if req.ChannelType == common.ChannelTypePerson.Uint8() {
-		if req.ChannelID != loginUID {
-			isFriend, err := m.userService.IsFriend(loginUID, req.ChannelID)
-			if err != nil {
-				m.Error("查询好友关系错误", zap.Error(err))
-				httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
-				return
-			}
-			if !isFriend {
-				httperr.ResponseErrorL(c, errcode.ErrMessageChannelAccessDenied, nil, nil)
-				return
-			}
+		// 与写路径（addOrCancelReaction）共用同一个 DM 门：好友 ∪ 本人创建的 bot
+		// ∪ 同 Space 同事。读/同步路径必须与写路径同口径，否则任一侧成为短板。
+		allowed, err := personChannelAccessAllowed(m.userService, loginUID, req.ChannelID, spacepkg.GetSpaceID(c))
+		if err != nil {
+			m.Error("校验私聊频道权限失败（reaction sync）", zap.Error(err), zap.String("peer", req.ChannelID))
+			httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
+			return
+		}
+		if !allowed {
+			httperr.ResponseErrorL(c, errcode.ErrMessageChannelAccessDenied, nil, nil)
+			return
 		}
 	} else if req.ChannelType == common.ChannelTypeCommunityTopic.Uint8() {
 		parentGroupNo, shortID, perr := thread.ParseChannelID(req.ChannelID)
@@ -2032,17 +2032,18 @@ func (m *Message) addOrCancelReaction(c *wkhttp.Context) {
 		}
 	} else if req.ChannelType == common.ChannelTypePerson.Uint8() {
 		fakeChannelID = common.GetFakeChannelIDWith(req.ChannelID, loginUID)
-		if req.ChannelID != loginUID {
-			isFriend, err := m.userService.IsFriend(loginUID, req.ChannelID)
-			if err != nil {
-				m.Error("查询好友关系错误", zap.Error(err))
-				httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
-				return
-			}
-			if !isFriend {
-				httperr.ResponseErrorL(c, errcode.ErrMessageChannelAccessDenied, nil, nil)
-				return
-			}
+		// DM 鉴权：好友 ∪ 本人创建的 bot ∪ 同 Space 同事（详见
+		// personChannelAccessAllowed）。只查 friend 表会让企业通讯录部署下
+		// 同事之间的 DM 一律 403 —— friend 表在该模式下近乎为空。
+		allowed, err := personChannelAccessAllowed(m.userService, loginUID, req.ChannelID, spacepkg.GetSpaceID(c))
+		if err != nil {
+			m.Error("校验私聊频道权限失败（reaction）", zap.Error(err), zap.String("peer", req.ChannelID))
+			httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
+			return
+		}
+		if !allowed {
+			httperr.ResponseErrorL(c, errcode.ErrMessageChannelAccessDenied, nil, nil)
+			return
 		}
 	} else if req.ChannelType == common.ChannelTypeCommunityTopic.Uint8() {
 		parentGroupNo, shortID, perr := thread.ParseChannelID(req.ChannelID)

--- a/modules/message/api_i18n_test.go
+++ b/modules/message/api_i18n_test.go
@@ -27,6 +27,7 @@ func TestMessageNoLegacyResponseError(t *testing.T) {
 		"api_message_get.go", "api_reminders.go", "api_channel_files.go", "api_sidebar.go",
 		"api_card_action.go",
 		"api_card_revisions.go",
+		"api_person_access.go",
 	}
 	banned := []string{".ResponseError(", ".ResponseErrorf(", ".ResponseErrorWithStatus(", "c.Response(\""}
 	for _, f := range files {

--- a/modules/message/api_person_access.go
+++ b/modules/message/api_person_access.go
@@ -20,8 +20,11 @@ type personAccessDeps interface {
 //  2. 双方是好友 —— 个人空间（非 Space）部署下 friend 表是权威口径；
 //  3. 对方是 bot —— 本人创建的 bot 放行；他人创建的 bot 必须先加好友，与 robot
 //     模块的转发规则一致（modules/robot/event.go："用户与Bot非好友关系，拒绝转发消息"）。
-//     bot 判定必须在 Space 判定之前收口：bot 没有 space_member 行，落到第 4 步恒为 false，
-//     会把「自己的 bot」误拒；
+//     bot 判定必须在 Space 判定之前收口，两类 bot 各有一个理由，缺一不可：
+//     robot 模块的 bot **有** space_member 行（modules/robot/api.go:1497 的 Space bot
+//     列表正是靠它 INNER JOIN 出来的），Space 优先会让「他人的 bot」凭同 Space 直接
+//     放行，绕过上面那条好友要求；App Bot 则**没有** space_member 行
+//     （modules/app_bot/app_bot.go createBot 明确不写），Space 优先会把「自己的 bot」误拒；
 //  4. 对方是真人且与调用者同属 spaceID 这个在籍 Space —— 企业通讯录部署下 friend 表
 //     近乎为空（只有系统 bot），私聊可达性由 Space 在籍关系决定，与写消息路径
 //     （api.go sendMsg 的 Person/Space 分支 CheckBothMembers）同语义。

--- a/modules/message/api_person_access.go
+++ b/modules/message/api_person_access.go
@@ -13,7 +13,7 @@ type personAccessDeps interface {
 
 // personChannelAccessAllowed 判定 loginUID 是否有权操作与 peerUID 的私聊(DM)频道。
 //
-// 口径与 modules/user/api_pinned.go::validateChannelAccess 逐字对齐（另见
+// 与 modules/user/api_pinned.go::validateChannelAccess 同一 predicate（另见
 // modules/messages_search/authz.go::checkP2PAccess），按序判定，满足其一即放行：
 //
 //  1. peerUID == loginUID —— 给自己的「备忘」频道，好友/bot/Space 判定都无意义；
@@ -28,6 +28,13 @@ type personAccessDeps interface {
 //
 // 只有好友口径会让企业部署下同事之间的 DM 一律 403（channel_access_denied）——
 // 这正是本函数存在的原因。
+//
+// 有意与 validateChannelAccess 不同的两处，都是收紧或等价，不要为了「对齐两处实现」
+// 把它们删掉：第 1 步的 self 短路是 validateChannelAccess 没有的，缺了它，给自己的
+// 备忘频道会一路落到 AreSpaceMembers(spaceID, u, u)，而其 COUNT(DISTINCT sm.uid)
+// … uid IN (u,u) 只会等于 1、永不等于 2（那是 api_pinned 自己的既有缺陷，
+// messages_search/authz.go:93 有这个分支所以没踩到）；spaceID 为空时直接返回、不查
+// Space，是决策 D1，见下。
 //
 // spaceID 只取请求上 SpaceMiddleware 已校验的 space_id（spacepkg.GetSpaceID）。
 // 请求没带 space_id 时不去解析调用者的默认 Space（决策 D1），判定退回好友口径 ——

--- a/modules/message/api_person_access.go
+++ b/modules/message/api_person_access.go
@@ -1,0 +1,63 @@
+package message
+
+// personAccessDeps 是 personChannelAccessAllowed 需要的最小依赖面。
+// user.IService 天然满足它，单测可用三方法 fake 替换，无需起 DB。
+type personAccessDeps interface {
+	// IsFriend 查询 uid → toUID 的好友关系（friend 表口径）。
+	IsFriend(uid string, toUID string) (bool, error)
+	// QueryPeerRobotInfo 返回目标用户是否为 bot 及其创建者 UID。
+	QueryPeerRobotInfo(peerUID string) (isRobot bool, creatorUID string, err error)
+	// AreSpaceMembers 校验两个 uid 是否同属一个在籍 Space。
+	AreSpaceMembers(spaceID, uid1, uid2 string) (bool, error)
+}
+
+// personChannelAccessAllowed 判定 loginUID 是否有权操作与 peerUID 的私聊(DM)频道。
+//
+// 口径与 modules/user/api_pinned.go::validateChannelAccess 逐字对齐（另见
+// modules/messages_search/authz.go::checkP2PAccess），按序判定，满足其一即放行：
+//
+//  1. peerUID == loginUID —— 给自己的「备忘」频道，好友/bot/Space 判定都无意义；
+//  2. 双方是好友 —— 个人空间（非 Space）部署下 friend 表是权威口径；
+//  3. 对方是 bot —— 本人创建的 bot 放行；他人创建的 bot 必须先加好友，与 robot
+//     模块的转发规则一致（modules/robot/event.go："用户与Bot非好友关系，拒绝转发消息"）。
+//     bot 判定必须在 Space 判定之前收口：bot 没有 space_member 行，落到第 4 步恒为 false，
+//     会把「自己的 bot」误拒；
+//  4. 对方是真人且与调用者同属 spaceID 这个在籍 Space —— 企业通讯录部署下 friend 表
+//     近乎为空（只有系统 bot），私聊可达性由 Space 在籍关系决定，与写消息路径
+//     （api.go sendMsg 的 Person/Space 分支 CheckBothMembers）同语义。
+//
+// 只有好友口径会让企业部署下同事之间的 DM 一律 403（channel_access_denied）——
+// 这正是本函数存在的原因。
+//
+// spaceID 只取请求上 SpaceMiddleware 已校验的 space_id（spacepkg.GetSpaceID）。
+// 请求没带 space_id 时不去解析调用者的默认 Space（决策 D1），判定退回好友口径 ——
+// 与本次改动前的行为一致，且无 Space 的请求不会多一次查询。
+//
+// 任何一次查询出错都 fail-closed（返回 false + error），由调用方按
+// ErrMessageQueryFailed 归并，绝不因 DB 抖动放行。
+func personChannelAccessAllowed(deps personAccessDeps, loginUID, peerUID, spaceID string) (bool, error) {
+	if peerUID == "" {
+		return false, nil
+	}
+	if peerUID == loginUID {
+		return true, nil
+	}
+	isFriend, err := deps.IsFriend(loginUID, peerUID)
+	if err != nil {
+		return false, err
+	}
+	if isFriend {
+		return true, nil
+	}
+	isRobot, creatorUID, err := deps.QueryPeerRobotInfo(peerUID)
+	if err != nil {
+		return false, err
+	}
+	if isRobot {
+		return creatorUID == loginUID, nil
+	}
+	if spaceID == "" {
+		return false, nil
+	}
+	return deps.AreSpaceMembers(spaceID, loginUID, peerUID)
+}

--- a/modules/message/api_person_access_test.go
+++ b/modules/message/api_person_access_test.go
@@ -1,0 +1,221 @@
+package message
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakePersonAccessDeps 只实现 personAccessDeps 的三个方法，让 DM 门的判定顺序
+// 可以脱库断言（真实依赖是 user.IService，起它要 MySQL + Redis）。
+type fakePersonAccessDeps struct {
+	friends      map[string]bool // "uid→toUID" 有向好友边
+	robots       map[string]string
+	spaceMembers map[string]bool // "spaceID|uid1|uid2"
+
+	friendErr error
+	robotErr  error
+	spaceErr  error
+
+	friendCalls int
+	robotCalls  int
+	spaceCalls  int
+}
+
+func (f *fakePersonAccessDeps) IsFriend(uid string, toUID string) (bool, error) {
+	f.friendCalls++
+	if f.friendErr != nil {
+		return false, f.friendErr
+	}
+	return f.friends[uid+"→"+toUID], nil
+}
+
+func (f *fakePersonAccessDeps) QueryPeerRobotInfo(peerUID string) (bool, string, error) {
+	f.robotCalls++
+	if f.robotErr != nil {
+		return false, "", f.robotErr
+	}
+	creator, isRobot := f.robots[peerUID]
+	return isRobot, creator, nil
+}
+
+func (f *fakePersonAccessDeps) AreSpaceMembers(spaceID, uid1, uid2 string) (bool, error) {
+	f.spaceCalls++
+	if f.spaceErr != nil {
+		return false, f.spaceErr
+	}
+	return f.spaceMembers[spaceID+"|"+uid1+"|"+uid2], nil
+}
+
+// TestPersonChannelAccessAllowed 锁定 DM 门的判定口径（与
+// modules/user/api_pinned.go::validateChannelAccess 对齐）：
+// self → 好友 → bot（本人的放行/他人的仍需好友）→ 同 Space 真人，都不命中则拒绝。
+func TestPersonChannelAccessAllowed(t *testing.T) {
+	const me = "u_me"
+	const peer = "u_peer"
+
+	tests := []struct {
+		name        string
+		deps        *fakePersonAccessDeps
+		peer        string
+		spaceID     string
+		wantAllowed bool
+		wantErr     bool
+	}{
+		{
+			name:        "自己和自己的备忘频道直接放行",
+			deps:        &fakePersonAccessDeps{},
+			peer:        me,
+			wantAllowed: true,
+		},
+		{
+			name:        "空 peer 拒绝",
+			deps:        &fakePersonAccessDeps{},
+			peer:        "",
+			wantAllowed: false,
+		},
+		{
+			name:        "好友放行（个人空间部署口径）",
+			deps:        &fakePersonAccessDeps{friends: map[string]bool{me + "→" + peer: true}},
+			peer:        peer,
+			wantAllowed: true,
+		},
+		{
+			name: "非好友但同 Space 同事放行（企业通讯录部署，friend 表为空）",
+			deps: &fakePersonAccessDeps{
+				spaceMembers: map[string]bool{"spc1|" + me + "|" + peer: true},
+			},
+			peer:        peer,
+			spaceID:     "spc1",
+			wantAllowed: true,
+		},
+		{
+			name: "非好友且不同 Space 拒绝",
+			deps: &fakePersonAccessDeps{
+				spaceMembers: map[string]bool{"spc2|" + me + "|" + peer: true},
+			},
+			peer:        peer,
+			spaceID:     "spc1",
+			wantAllowed: false,
+		},
+		{
+			// D1：请求没带 space_id 时不解析默认 Space，退回好友口径。
+			name: "请求无 space_id → 不放行（不做默认 Space 兜底）",
+			deps: &fakePersonAccessDeps{
+				spaceMembers: map[string]bool{"spc1|" + me + "|" + peer: true},
+			},
+			peer:        peer,
+			spaceID:     "",
+			wantAllowed: false,
+		},
+		{
+			name: "本人创建的 bot 放行，且不需要好友/Space",
+			deps: &fakePersonAccessDeps{robots: map[string]string{"bot1": me}},
+			peer: "bot1",
+			// 故意不给 Space 成员关系：bot 没有 space_member 行。
+			spaceID:     "spc1",
+			wantAllowed: true,
+		},
+		{
+			name: "他人创建的 bot 非好友 → 拒绝（即使同 Space 也不放行）",
+			deps: &fakePersonAccessDeps{
+				robots:       map[string]string{"bot1": "u_other"},
+				spaceMembers: map[string]bool{"spc1|" + me + "|bot1": true},
+			},
+			peer:        "bot1",
+			spaceID:     "spc1",
+			wantAllowed: false,
+		},
+		{
+			name: "他人创建的 bot 是好友 → 放行",
+			deps: &fakePersonAccessDeps{
+				friends: map[string]bool{me + "→bot1": true},
+				robots:  map[string]string{"bot1": "u_other"},
+			},
+			peer:        "bot1",
+			wantAllowed: true,
+		},
+		{
+			// 已停用 bot：user.robot=1 但 robot.status!=1 → creatorUID 为空，
+			// 即便是自己创建的也落回好友口径（db_pinned.go QueryPeerRobotInfo 注释）。
+			name:        "已停用的 bot（creator 为空）→ 拒绝",
+			deps:        &fakePersonAccessDeps{robots: map[string]string{"bot1": ""}},
+			peer:        "bot1",
+			spaceID:     "spc1",
+			wantAllowed: false,
+		},
+		{
+			name:        "好友查询报错 fail-closed",
+			deps:        &fakePersonAccessDeps{friendErr: errors.New("db down")},
+			peer:        peer,
+			spaceID:     "spc1",
+			wantAllowed: false,
+			wantErr:     true,
+		},
+		{
+			name:        "bot 查询报错 fail-closed",
+			deps:        &fakePersonAccessDeps{robotErr: errors.New("db down")},
+			peer:        peer,
+			spaceID:     "spc1",
+			wantAllowed: false,
+			wantErr:     true,
+		},
+		{
+			name:        "Space 查询报错 fail-closed",
+			deps:        &fakePersonAccessDeps{spaceErr: errors.New("db down")},
+			peer:        peer,
+			spaceID:     "spc1",
+			wantAllowed: false,
+			wantErr:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			allowed, err := personChannelAccessAllowed(tt.deps, me, tt.peer, tt.spaceID)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, tt.wantAllowed, allowed)
+		})
+	}
+}
+
+// TestPersonChannelAccessAllowedSelfSkipsLookups 备忘频道不触发任何查询。
+func TestPersonChannelAccessAllowedSelfSkipsLookups(t *testing.T) {
+	deps := &fakePersonAccessDeps{}
+	allowed, err := personChannelAccessAllowed(deps, "u_me", "u_me", "spc1")
+	require.NoError(t, err)
+	assert.True(t, allowed)
+	assert.Zero(t, deps.friendCalls)
+	assert.Zero(t, deps.robotCalls)
+	assert.Zero(t, deps.spaceCalls)
+}
+
+// TestPersonChannelAccessAllowedFriendShortCircuits 好友命中后不再查 bot/Space，
+// 保证个人空间部署下仍然只有一次查询（与改动前的开销一致）。
+func TestPersonChannelAccessAllowedFriendShortCircuits(t *testing.T) {
+	deps := &fakePersonAccessDeps{friends: map[string]bool{"u_me→u_peer": true}}
+	allowed, err := personChannelAccessAllowed(deps, "u_me", "u_peer", "spc1")
+	require.NoError(t, err)
+	assert.True(t, allowed)
+	assert.Equal(t, 1, deps.friendCalls)
+	assert.Zero(t, deps.robotCalls)
+	assert.Zero(t, deps.spaceCalls)
+}
+
+// TestPersonChannelAccessAllowedNoSpaceSkipsSpaceLookup D1 的开销侧断言：
+// 请求没带 space_id 时不应发生 Space 查询。
+func TestPersonChannelAccessAllowedNoSpaceSkipsSpaceLookup(t *testing.T) {
+	deps := &fakePersonAccessDeps{}
+	allowed, err := personChannelAccessAllowed(deps, "u_me", "u_peer", "")
+	require.NoError(t, err)
+	assert.False(t, allowed)
+	assert.Equal(t, 1, deps.friendCalls)
+	assert.Equal(t, 1, deps.robotCalls)
+	assert.Zero(t, deps.spaceCalls)
+}

--- a/modules/message/api_reaction_integration_test.go
+++ b/modules/message/api_reaction_integration_test.go
@@ -346,6 +346,17 @@ func seedReactionSpaceMember(t *testing.T, ctx *config.Context, spaceID, uid, cr
 	_ = ctx.GetRedisConn().Del("space:member:" + spaceID + ":" + uid)
 }
 
+// seedReactionSpaceMemberRow 只加成员行（Space 已由 seedReactionSpaceMember 建好），
+// 用于让两个 uid 同属一个 Space。
+func seedReactionSpaceMemberRow(t *testing.T, ctx *config.Context, spaceID, uid, createdAt string) {
+	t.Helper()
+	_, err := ctx.DB().InsertBySql(
+		"INSERT INTO `space_member` (space_id, uid, role, status, created_at, updated_at) VALUES (?,?,0,1,?,?)",
+		spaceID, uid, createdAt, createdAt).Exec()
+	require.NoError(t, err)
+	_ = ctx.GetRedisConn().Del("space:member:" + spaceID + ":" + uid)
+}
+
 // insertPersonMessageWithSpace 在 DM 物理频道(fakeChannelID)插入一条带 space_id 的纯文本消息。
 func insertPersonMessageWithSpace(t *testing.T, ctx *config.Context, fakeChannelID string, mid int64, spaceID string) {
 	t.Helper()
@@ -608,4 +619,81 @@ func TestReactionRejectsRevokedMessageWrite(t *testing.T) {
 
 	assert.NotEqual(t, http.StatusOK, w.Code, "revoked messages must not accept reactions")
 	assert.Equal(t, 0, countReactionRows(t, ctx, mid), "revoked-message reaction must not be persisted")
+}
+
+// ---------- 企业通讯录（Space）部署：同事之间的 DM reaction ----------
+
+// setupSpaceDM 建一个 Space（testutil.UID 是成员），按需把 peer 也加进来，并在 DM
+// 物理频道里放一条归属该 Space 的纯文本消息。**不建 friend 行** —— 企业通讯录部署下
+// friend 表近乎为空，这正是线上 403 的现场。
+func setupSpaceDM(t *testing.T, peerInSpace bool) (*server.Server, *config.Context, int64, string) {
+	t.Helper()
+	s, ctx := testutil.NewTestServer()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+	resetReactionUIDRateLimit(t, ctx)
+
+	spaceID := "spcDM" + strconv.FormatInt(nextShortID.Add(1), 10)
+	seedReactionSpaceMember(t, ctx, spaceID, testutil.UID, "2020-01-01 00:00:00")
+	if peerInSpace {
+		seedReactionSpaceMemberRow(t, ctx, spaceID, reactionPeerUID, "2020-01-02 00:00:00")
+	}
+
+	const mid int64 = 930001
+	insertPersonMessageWithSpace(t, ctx, common.GetFakeChannelIDWith(testutil.UID, reactionPeerUID), mid, spaceID)
+	return s, ctx, mid, spaceID
+}
+
+// 线上回归：同 Space 同事（非好友）必须能对 DM 消息点回应，读侧同口径。
+// 修复前两个端点都只查 friend 表，这里必然 403 channel_access_denied。
+func TestReactionAllowsSameSpaceDMWithoutFriendship(t *testing.T) {
+	s, ctx, mid, spaceID := setupSpaceDM(t, true)
+
+	w := postReactionWithSpace(t, s, "/v1/reactions", spaceID, map[string]interface{}{
+		"message_id":   strconv.FormatInt(mid, 10),
+		"channel_id":   reactionPeerUID,
+		"channel_type": common.ChannelTypePerson.Uint8(),
+		"emoji":        "[尚方宝剑]",
+	})
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	assert.Equal(t, 1, countReactionRows(t, ctx, mid), "same-Space DM reaction must persist")
+
+	w = postReactionWithSpace(t, s, "/v1/reaction/sync", spaceID, map[string]interface{}{
+		"channel_id":   reactionPeerUID,
+		"channel_type": common.ChannelTypePerson.Uint8(),
+		"seq":          0,
+	})
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	var got []reactionResp
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &got), w.Body.String())
+	found := false
+	for _, r := range got {
+		if r.MessageID == strconv.FormatInt(mid, 10) {
+			found = true
+		}
+	}
+	assert.True(t, found, "same-Space DM reaction must be visible to sync")
+}
+
+// 既非好友也非同 Space 同事 → 读写都拒，且不落库（放宽好友口径不等于不设门）。
+// 断言 4xx 而非 !=200：若鉴权因 DB 抖动 500，NotEqual(200) 会静默通过。
+func TestReactionRejectsDMWithoutFriendshipOrSpace(t *testing.T) {
+	s, ctx, mid, spaceID := setupSpaceDM(t, false)
+
+	w := postReactionWithSpace(t, s, "/v1/reactions", spaceID, map[string]interface{}{
+		"message_id":   strconv.FormatInt(mid, 10),
+		"channel_id":   reactionPeerUID,
+		"channel_type": common.ChannelTypePerson.Uint8(),
+		"emoji":        "👍",
+	})
+	assert.GreaterOrEqual(t, w.Code, 400, "陌生人 DM reaction 必须被拒绝: %d %s", w.Code, w.Body.String())
+	assert.Less(t, w.Code, 500, "拒绝不能是 5xx（否则可能是 DB 错误伪通过）: %d %s", w.Code, w.Body.String())
+	assert.Equal(t, 0, countReactionRows(t, ctx, mid), "rejected DM reaction must not persist")
+
+	w = postReactionWithSpace(t, s, "/v1/reaction/sync", spaceID, map[string]interface{}{
+		"channel_id":   reactionPeerUID,
+		"channel_type": common.ChannelTypePerson.Uint8(),
+		"seq":          0,
+	})
+	assert.GreaterOrEqual(t, w.Code, 400, "陌生人 DM reaction sync 必须被拒绝: %d %s", w.Code, w.Body.String())
+	assert.Less(t, w.Code, 500, "拒绝不能是 5xx: %d %s", w.Code, w.Body.String())
 }

--- a/modules/message/api_reaction_integration_test.go
+++ b/modules/message/api_reaction_integration_test.go
@@ -704,3 +704,76 @@ func TestReactionRejectsDMWithoutFriendshipOrSpace(t *testing.T) {
 	assert.GreaterOrEqual(t, w.Code, 400, "陌生人 DM reaction sync 必须被拒绝: %d %s", w.Code, w.Body.String())
 	assert.Less(t, w.Code, 500, "拒绝不能是 5xx: %d %s", w.Code, w.Body.String())
 }
+
+// ---------- P1 复现（review #671）：syncReaction 的 @ 形态 channel_id ----------
+
+// TestSyncReactionRejectsCompositeChannelIDLeak 复现 review 指出的越权读：
+//
+// syncReaction 对 Person 允许把「已拼好的物理频道 id」(a@b) 原样当 channel_id 用
+// （api.go 的 strings.Contains(req.ChannelID,"@") 分支）——这是唯一一条 storage
+// channel id 不由 loginUID 推导的路径。原来的好友门挡得住它（friend 行的写入方
+// 都先校验 user 存在，IsFriend("a@b") 永假），但同 Space 门查的是 space_member，
+// 而 space_member.uid 是攻击者可写的任意字符串（addMembers 原样插入、不校验 user
+// 是否存在；建 Space 默认对所有登录用户开放）。于是：
+//
+//	攻击者建一个 Space S（自己是 owner，且 S 是其最早加入的 Space → 默认 Space）
+//	→ 把受害者 DM 的物理频道串 "V@W" 作为「成员」加进 S
+//	→ POST /v1/reaction/sync {space_id:S, channel_id:"V@W", channel_type:1}
+//	→ 同 Space 门放行 → 拉到 V 与 W 私聊里的 reaction 元数据
+//	  （message_id / uid / name / emoji / seq / created_at）。
+//
+// 受害者消息不带 space_id 标签时，personSpaceAllows 的兼容分支（无标签 +
+// spaceID==默认 Space）也拦不住，因为 IsSystemBot("V@W") 对复合串恒为 false。
+func TestSyncReactionRejectsCompositeChannelIDLeak(t *testing.T) {
+	s, ctx := testutil.NewTestServer()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+	resetReactionUIDRateLimit(t, ctx)
+
+	// 受害者双方与他们的 DM 物理频道，攻击者(testutil.UID)与他们毫无关系。
+	const victimA, victimB = "victim_a_uid", "victim_b_uid"
+	victimChannel := common.GetFakeChannelIDWith(victimA, victimB)
+
+	// 受害者 DM 里一条无 space 标签的文本消息 + 一条 reaction。
+	const mid int64 = 940001
+	payload, err := json.Marshal(map[string]interface{}{"type": 1, "content": "secret dm"})
+	require.NoError(t, err)
+	require.NoError(t, NewDB(ctx).insertMessage(&messageModel{
+		MessageID: mid, MessageSeq: uint32(mid), ClientMsgNo: "cli-victim-940001",
+		FromUID: victimA, ChannelID: victimChannel,
+		ChannelType: common.ChannelTypePerson.Uint8(), Payload: payload,
+	}))
+	seq, err := ctx.GenSeq("messageReactionSeq:" + victimChannel)
+	require.NoError(t, err)
+	_, err = New(ctx).messageReactionDB.toggleReaction(&reactionModel{
+		ChannelID: victimChannel, ChannelType: common.ChannelTypePerson.Uint8(),
+		UID: victimA, Name: "victim-a", MessageID: strconv.FormatInt(mid, 10),
+		Emoji: "🤫", Seq: seq,
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, countReactionRows(t, ctx, mid), "sanity: 受害者 reaction 已落库")
+
+	// 攻击者自建 Space（其唯一 Space，故也是默认 Space），并把受害者的物理频道串
+	// 当成「成员 uid」塞进 space_member —— addMembers 就是这么原样插入的。
+	attackerSpace := "spcATK" + strconv.FormatInt(nextShortID.Add(1), 10)
+	seedReactionSpaceMember(t, ctx, attackerSpace, testutil.UID, "2020-01-01 00:00:00")
+	seedReactionSpaceMemberRow(t, ctx, attackerSpace, victimChannel, "2020-01-02 00:00:00")
+
+	w := postReactionWithSpace(t, s, "/v1/reaction/sync", attackerSpace, map[string]interface{}{
+		"channel_id":   victimChannel,
+		"channel_type": common.ChannelTypePerson.Uint8(),
+		"seq":          0,
+	})
+
+	// 必须拒（4xx，且不能是 5xx 伪通过）；即便将来改成 200 空集，也绝不能出现
+	// 受害者的 reaction 行。
+	assert.Less(t, w.Code, 500, "拒绝不能是 5xx: %d %s", w.Code, w.Body.String())
+	if w.Code == http.StatusOK {
+		var got []reactionResp
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &got), w.Body.String())
+		for _, r := range got {
+			assert.NotEqual(t, strconv.FormatInt(mid, 10), r.MessageID,
+				"越权读：攻击者不得拿到受害者 DM 的 reaction 元数据")
+		}
+	}
+	assert.GreaterOrEqual(t, w.Code, 400, "复合 channel_id 必须在入口被拒: %d %s", w.Code, w.Body.String())
+}

--- a/modules/message/api_reaction_integration_test.go
+++ b/modules/message/api_reaction_integration_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/testutil"
 	"github.com/Mininglamp-OSS/octo-server/modules/group"
 	"github.com/Mininglamp-OSS/octo-server/modules/thread"
+	"github.com/Mininglamp-OSS/octo-server/modules/user"
 	"github.com/go-redis/redis"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -631,6 +632,12 @@ func setupSpaceDM(t *testing.T, peerInSpace bool) (*server.Server, *config.Conte
 	s, ctx := testutil.NewTestServer()
 	require.NoError(t, testutil.CleanAllTables(ctx))
 	resetReactionUIDRateLimit(t, ctx)
+
+	// peer 落一行真实 user：让 QueryPeerRobotInfo 打到真人行（robot=0）而不是空结果，
+	// 与生产一致 —— 空行与真人行都走「非 bot」分支，但只有前者才是测试假象。
+	require.NoError(t, user.NewDB(ctx).Insert(&user.Model{
+		UID: reactionPeerUID, Name: "dm-peer", ShortNo: "2" + strconv.FormatInt(nextShortID.Add(1), 10),
+	}))
 
 	spaceID := "spcDM" + strconv.FormatInt(nextShortID.Add(1), 10)
 	seedReactionSpaceMember(t, ctx, spaceID, testutil.UID, "2020-01-01 00:00:00")


### PR DESCRIPTION
## Summary

DM reactions were gated on the `friend` table alone. In the enterprise contact-book (**Space**) deployment nothing writes `friend` rows on Space join, so reacting to a colleague's DM message failed for every user with

```json
{"error":{"code":"err.server.message.channel_access_denied","http_status":403},"status":400}
```

The Person branch of `addOrCancelReaction` has exactly one path to that code — the `!isFriend` check — and `syncReaction` mirrors it, so the read side was broken too and the reaction UI could not even load its state.

Both endpoints now use the peer predicate that `modules/user/api_pinned.go::validateChannelAccess` already uses (see also `modules/messages_search/authz.go::checkP2PAccess`), evaluated in order: self → friend → bot (own bot allowed, someone else's bot still requires friendship) → real user in the same active Space.

## Related Issue

No tracking issue — reported directly from production (`POST /api/v1/reactions`, `channel_type=1`, human-to-human DM). Known adjacent gaps are recorded in the journal's Follow-ups rather than as issues.

## Linked Spec

`.octospec/tasks/dm-reaction-space-access/brief.md` (journal: `.octospec/journal/shared/dm-reaction-space-access.md`)

## Changes

- Add `modules/message/api_person_access.go`: `personChannelAccessAllowed` as a pure function over a three-method dependency interface (`IsFriend`, `QueryPeerRobotInfo`, `AreSpaceMembers`) that `user.IService` satisfies structurally, so the gate is unit-testable without MySQL/Redis.
- Point both `addOrCancelReaction` (`POST /v1/reactions`) and `syncReaction` (`POST /v1/reaction/sync`) at that single helper, so the read/write parity invariant already documented in `syncReaction` cannot drift.
- Space comes only from the middleware-verified `space_id` (`spacepkg.GetSpaceID`). With no Space on the request the gate degrades to friend-only — unchanged behavior, and one less query on that path. No default-Space fallback.
- Keep the existing envelope: denials stay `ErrMessageChannelAccessDenied`, lookup failures stay `ErrMessageQueryFailed` after logging the cause with `zap.Error`. No new error code, no wire-status change.
- Register the new file in the `TestMessageNoLegacyResponseError` source guard.
- Untouched: `fakeChannelID` computation, the per-message DM Space isolation check (`personSpaceAllows`), the text-only type gate, and the group / CommunityTopic gates.
- Spec records: task brief, injected-rule context, journal, `log.md` entry, and a pending learning candidate for the `space-isolation` rule.

## Testing

- [x] Unit tests added/updated
- [ ] Manually verified — no deployment available from this environment; verified instead against real MySQL 8.0 + Redis + WuKongIM v2.2.4 as described below.

**Red before green.** With the pre-fix `api.go` restored, `TestReactionAllowsSameSpaceDMWithoutFriendship` fails (expects 200, gets the 403) while `TestReactionRejectsDMWithoutFriendshipOrSpace` still passes — the new test pins the production bug, and the negative test shows the gate was not merely opened.

```
go test -tags integration -run Reaction ./modules/message/     → 20/20 PASS
go test -race -shuffle=on -count=1 ./modules/message/          → 380 PASS, 0 FAIL   (the lane CI runs)
go build ./... ; go vet ./modules/message/                     → clean
golangci-lint run ./modules/message/...                        → 0 issues
make i18n-extract-check ; make i18n-lint                       → green (no code changes expected)
```

Unit coverage is a 13-case decision table plus 3 query-count assertions, all DB-free: self; friend; own bot (allowed without friendship *and* without Space); someone else's bot without friendship (denied even when same-Space); someone else's bot with friendship; disabled bot (empty `creator_uid` → stays friendship-gated); real user same-Space; different Space; no Space on the request; fail-closed on each of the three lookups; friend-hit short-circuit; no Space lookup when the request carries no `space_id`.

Note for reviewers: `modules/message` integration tests run in **no** CI lane today. `ci.yml:236-253` deliberately omits `-tags integration` (`modules/conversation_ext/*` needs a pre-baked `conv_ext_test` database the job never provisions), and even with the flag flipped this package's integration build does not compile — `api_card_action_test.go` → `app_bot` → `bot_api` → `messages_search` → `message` is an import cycle in test, reproducible on clean `main`. Running the suite locally required setting `api_card_action_test.go` and `api_card_revisions_test.go` aside. Both are pre-existing and out of scope here; they are recorded in the brief.

## COMPREHENSION

1. **What does this change actually do** to the load-bearing path?

   It widens DM authorization on the two reaction endpoints from `friend` to `friend ∪ own-bot ∪ same-active-Space`, and only that. The ordering is load-bearing: bot classification must precede the Space branch, because a bot has no `space_member` row and a Space-first gate would deny a user reacting in their *own* bot's DM. Everything downstream of the gate is unchanged — the message lookup, `reactionTargetVisibleToViewer`, the per-message DM Space isolation (`personSpaceAllows`, which still compares the message payload's `space_id` against the request Space), the text-only type gate, and the group/thread branches. Denials keep the same code and the same pinned-400 envelope, so no client contract moves.

2. **What could break** because of it (dependents + failure mode)?

   The change is a widening, so the risk is over-widening. Three bounds: (a) a request with no verified `space_id` gets no Space consideration at all, so unauthenticated-Space clients see exactly today's behavior; (b) someone else's bot still requires friendship, matching `modules/robot/event.go`, and a disabled bot yields `creator_uid=""` so it also stays friendship-gated; (c) every lookup fails closed — a MySQL/Redis blip returns `(false, err)` and maps to `ErrMessageQueryFailed`, never to "allow". Cross-Space DM isolation is unaffected because it is enforced after the gate by payload tag, covered by the pre-existing `TestReactionRejectsCrossSpaceDMWrite` / `TestSyncReactionHidesCrossSpaceDMReaction`. Cost: a non-friend colleague now does up to 3 lookups per toggle; `CheckBothMembers` filters on `space_id` + `uid IN (...)` and rides the `UNIQUE INDEX (space_id, uid)` on `space_member`, and the endpoint is already behind the 2 rps/uid limiter. One gap is knowingly **not** closed: the bidirectional blacklist is still not consulted on this path — `addBlacklist` never deletes the `friend` row, so a blacklisted friend could already react before this change; the gap now extends to blacklisted same-Space colleagues. `messages_search` is the only DM gate that checks it; tightening all three is a product call, recorded in the journal.

3. **How do you know it works** (specific test/repro/trace)?

   The production payload was replayed as `TestReactionAllowsSameSpaceDMWithoutFriendship` (Space colleague, no `friend` row, request carries `space_id`): it fails on the pre-fix `api.go` and passes on this branch, for both the write and the sync side, and the reaction row is asserted to persist exactly once. `TestReactionRejectsDMWithoutFriendshipOrSpace` asserts a stranger is still denied with `4xx` — bounded `>= 400 && < 500` on purpose, so a 5xx from a DB error cannot masquerade as a pass — and that no row is written. The full 20-test reaction integration suite and the 380-test default build both pass against real MySQL/Redis/WuKongIM.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] PR description is in English
- [x] Added tests for my changes
- [x] Updated documentation — `.octospec/` brief, context, journal, `log.md`, pending learning (no user-facing docs affected)
- [x] Followed commit message conventions (Conventional Commits)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MGGfY4fbtEBTso5nw6n8c7

---
_Generated by [Claude Code](https://claude.ai/code/session_01MGGfY4fbtEBTso5nw6n8c7)_