### PR TITLE
feat(cardtmpl): add runtime catalog overlay

### DIFF
--- a/.octospec/journal/shared/cardtmpl-runtime-catalog-overlay.md
+++ b/.octospec/journal/shared/cardtmpl-runtime-catalog-overlay.md
@@ -1,0 +1,143 @@
+---
+type: Journal
+title: "Journal: cardtmpl-runtime-catalog-overlay (roadmap E3 PR-B server)"
+description: Add the dark RuntimeCatalog overlay, audited activation state machine, bounded cache, startup recovery, and runtime consumer migration on top of PR-A.
+tags: [cardtmpl, runtime-catalog, activation, rollback, cache, database, trust-boundary, observability, testing, e3]
+timestamp: 2026-07-29T07:20:03+08:00
+# --- octospec extension fields ---
+task: cardtmpl-runtime-catalog-overlay
+issue: 672
+stacked_on_pr: 670
+source: self
+---
+
+# Journal: cardtmpl-runtime-catalog-overlay (roadmap E3 PR-B server)
+
+## What was done
+
+- Installed one process-wide `RuntimeCatalog` in the composition root before
+  module factories are constructed. It overlays the frozen built-in Registry
+  with the PR-A MySQL artifact store while retaining a narrow read-only
+  interface for render, exact/default metadata, fallback text, and action
+  context.
+- Added an authoritative activation table and append-only state audit fields.
+  Activate, explicit-target rollback, and one-way block use revision CAS and
+  commit the pointer/block change with the success audit in one transaction.
+  Rollback only accepts a target proved previously active; blocking the active
+  version atomically switches to a valid fallback or disables the template.
+- Added default resolution, dynamic exact loading, source/identity/hash
+  revalidation, and a compiled-artifact LRU bounded by entry count and retained
+  canonical bytes. Cold loads use bounded `singleflight`; each waiter may cancel
+  independently, while shared DB/compile work owns a 10-second deadline.
+- Added super-admin detail/audit/activate/rollback/block routes behind Auth and
+  the shared UID limiter. Forward activation and dynamic new-send gates default
+  false; production installs no downstream dynamic grant, so every business
+  dynamic purpose remains fail-closed.
+- Moved Bot template send/edit, notify template rendering/preflight/fallback,
+  `CardUpdater`, and message action-context onto the catalog interface with
+  server-authored principal, purpose, and Space context. Explicit stored
+  versions are preserved for historical edit/action behavior.
+- Moved static reconciliation and active-target validation into asynchronous
+  module startup. Transient MySQL failure leaves DB-backed paths unavailable
+  and retries without crashing the whole process; proven integrity failure is
+  sticky until restart. Explicit static exact reads remain available for a
+  transient outage.
+- Updated the production runbook for activate, rollback, emergency block,
+  startup diagnostics, exact-key collision recovery, and the post-first-dynamic
+  binary compatibility floor.
+
+## Self-review closures
+
+- Static built-in interactive targets are no longer forced through the dynamic
+  `RouteSpec` activation precondition. This restores valid static fallback and
+  prevents an active `ai.reasoning-process@0.2.0` pointer from poisoning startup;
+  dynamic interactive artifacts still require a matching route.
+- Manager detail and audit stay readable for a super-admin while readiness is
+  pending or integrity-poisoned. State-changing and runtime data paths remain
+  fail-closed, and the diagnostic DB calls retain their server deadline.
+- Notify default/preflight/fallback calls now carry a server-owned 10-second
+  deadline. Moving static defaults behind the overlay introduced a real DB read;
+  an unbounded `context.Background()` would otherwise strand request goroutines
+  during a MySQL stall.
+- Runtime schemas with non-empty `patternProperties` are rejected before
+  publication/activation. `additionalProperties=false` does not close that
+  keyspace in JSON Schema, so bounded value schemas under a regex were still
+  able to admit an unbounded number of object keys.
+- The real-MySQL integration database now uses a process-unique name and a
+  bounded connection pool, avoiding destructive cross-workspace collisions in
+  parallel Conductor runs.
+
+## Current-head review closure
+
+- Kept default/dynamic resolution fail-closed until startup validation succeeds
+  and wired the same state into `/v1/ready`. Pending or integrity-poisoned
+  replicas now return 503 while `/v1/health` remains dependency-free.
+- Bounded startup to 128 active targets (`LIMIT 129` overflow detection), gave
+  each target an independent 10-second validation deadline, removed the shared
+  30-second whole-list budget, and exposed the observed count through
+  `dmwork_card_catalog_active_targets` including the overflow case.
+- Preserved runtime catalog causes through notify preflight, classified catalog
+  safety failures separately, and made block/disable/auth/integrity/unavailable
+  fail closed between preflight and render instead of degrading to successful
+  text delivery. Notify catalog calls now inherit request cancellation while
+  retaining the server-owned 10-second ceiling.
+- Bounded Bot manifest construction lookups to five seconds and added audit
+  indexes for manager paging plus prior-active proof lookups.
+- Recorded trusted producer provenance as a PR-C prerequisite. Existing stored
+  messages do not carry enough server-authored information to infer `bot` versus
+  `internal_producer`, so the action-context principal must not be guessed from
+  sender, template ID, or owner.
+
+## Verification
+
+- `go test -count=1 ./pkg/cardtmpl/... ./modules/card_template_catalog/...`
+  passed, including real MySQL migration Up/Down and multi-replica
+  activate/rollback/block/restart coverage.
+- After recreating the known-polluted shared `test` database with its required
+  `utf8mb4_general_ci` collation, the Bot, notify, message, carddispatch, and
+  cardactiondispatch packages all passed when run serially with a clean database
+  per package.
+- Targeted `-race` passed for RuntimeCatalog/cache/CardUpdater, Bot template
+  send/edit, message action-context, catalog startup/CAS, and the multi-replica
+  DB integration flow.
+- `pkg/cardtmpl` and `modules/card_template_catalog` whole-package coverage were
+  rechecked at 80.5% and 81.4%. The legacy consumer packages remain below 80%
+  as whole packages (Bot 48.3%, notify 68.7%, message 21.6%); their changed
+  runtime paths have focused and race tests, but the brief's literal
+  whole-package 80% line remains open and is not represented as complete.
+- `go build ./...`, `go vet ./...`, `golangci-lint run ./...`,
+  `make i18n-extract-check`, `make i18n-lint`, source guards, and
+  `git diff --check` passed locally.
+
+## Structural learnings / gotchas
+
+- A fail-closed readiness switch must not also remove the authenticated,
+  bounded read path needed to diagnose why readiness failed.
+- A runtime dependency that deliberately closes a serving path must also mark
+  process readiness down. Keeping liveness green is useful for diagnostics, but
+  keeping readiness green leaves the poisoned replica in normal rotation.
+- Activation capability checks are source-sensitive. Trusted built-ins are
+  reviewed with their binary; applying a current runtime route configuration to
+  them can invalidate a legitimate rollback target. Untrusted dynamic artifacts
+  need the stronger precondition.
+- Adding an overlay can turn formerly in-memory static-default calls into DB
+  calls. Every migrated caller must be re-audited for cancellation and a
+  server-owned deadline, even if its functional result remains static.
+- `additionalProperties=false` is not a complete object-cardinality proof when
+  `patternProperties` is present. Reject unsupported open-keyspace constructs or
+  pair them with a deliberately bounded policy before runtime use.
+- This repository's integration packages do not share an identical migration
+  inventory. Reusing one database across independently built package test
+  binaries produces legitimate "unknown migration" failures; clean databases
+  must be isolated per package/lane.
+
+## Remaining boundary
+
+- PR-A squash-merged through PR #674 as `68e8134d`. This branch has been
+  rebased/retargeted to `main`; post-rebase CI and current-head approvals must
+  pass before PR #673 can merge.
+- This journal covers only Issue #672's octo-server work package. OpenClaw Model
+  A selection/release (E1d), real multi-instance stop/retry (E1e), PR-C grants
+  and discovery, the cross-repository version matrix, and production gate
+  enablement are not complete. PR-C also owns trusted producer-provenance
+  persistence before principal-kind-aware grants can be enabled.

--- a/.octospec/learnings/pending/cardtmpl-runtime-catalog-overlay.md
+++ b/.octospec/learnings/pending/cardtmpl-runtime-catalog-overlay.md
@@ -1,0 +1,47 @@
+---
+type: Learning
+title: "Fail-closed runtime systems must preserve a bounded diagnostic read path"
+description: Readiness may block unsafe data and state transitions, but authenticated detail and audit reads must remain available to explain and recover the failure.
+tags: [fail-close, readiness, diagnostics, observability, runtime-catalog, error-handling]
+timestamp: 2026-07-29T07:20:03+08:00
+# --- octospec extension fields ---
+source: self
+origin_task: cardtmpl-runtime-catalog-overlay
+origin_issue: 672
+status: pending
+candidate_rule: error-handling
+---
+
+# Fail-closed runtime systems must preserve a bounded diagnostic read path
+
+## Context
+
+The runtime catalog correctly poisons its own serving state when startup proves
+a persistent integrity violation. The first implementation neither propagated
+that state into `/v1/ready` nor separated it from manager diagnostics. As a
+result, a poisoned process stayed in normal traffic rotation while the only safe
+APIs that could explain the invalid active pointer or audit history were
+unavailable precisely during the incident they served.
+
+## Rule of thumb
+
+Separate endpoints into two classes when introducing readiness:
+
+1. Runtime data access and state mutation remain fail-closed until readiness is
+   established. Do not fall back to stale local state. Propagate that closure to
+   the process readiness probe so normal traffic is removed from the replica;
+   keep liveness dependency-free so the process remains observable.
+2. Authenticated, read-only diagnostics bypass the runtime readiness gate, but
+   keep authorization, pagination/size bounds, response redaction, and a
+   server-owned dependency deadline.
+3. A diagnostic DB failure is still unavailable; bypassing readiness is not a
+   bypass of database errors or integrity checks in the read itself.
+4. Test pending and integrity-poisoned states explicitly. A normal-ready test
+   cannot prove that incident diagnostics survive the failure transition.
+
+## Why worth a rule
+
+"Keep the process up" is not operational recovery by itself. Without a safe
+read path, operators are pushed toward direct SQL, guesswork, or blind rollback.
+Preserving bounded diagnostics improves recovery without weakening fail-closed
+runtime behavior.

--- a/.octospec/log.md
+++ b/.octospec/log.md
@@ -4,6 +4,43 @@ Change history for this repo's `.octospec/`, following the
 [OKF](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md)
 change-log convention (§7). Newest first.
 
+## 2026-07-29 (cardtmpl-runtime-catalog-overlay, roadmap E3 PR-B server)
+
+- **Runtime overlay** — Added one composition-root RuntimeCatalog over frozen
+  built-ins and the immutable MySQL artifact store, with authoritative
+  exact/default resolution, bounded compiled caching, and fail-closed dynamic
+  authorization. See [journal](journal/shared/cardtmpl-runtime-catalog-overlay.md),
+  [brief](tasks/cardtmpl-runtime-catalog-overlay/brief.md), and Issue #672.
+- **Audited state machine** — Added revision-CAS activate, explicit prior-active
+  rollback, one-way emergency block with fallback/disable, manager detail/audit,
+  and transactional state-plus-audit persistence.
+- **Runtime consumers** — Migrated Bot template send/edit, notify, CardUpdater,
+  and message action-context to the catalog interface with server-authored
+  purpose/principal/Space context. Control and dynamic new-send remain dark and
+  no production grants are installed.
+- **Recovery hardening** — Startup reconciliation is asynchronous and retryable;
+  integrity remains sticky while super-admin detail/audit diagnostics stay
+  readable. Static interactive rollback targets no longer inherit the dynamic
+  RouteSpec precondition, and notify catalog DB calls are deadline-bounded.
+- **Current-head review closure** — Catalog startup state now participates in
+  `/v1/ready`; active-target validation has a 128-target hard cap, independent
+  per-target deadlines, and a bounded gauge. Notify preserves and fail-closes
+  runtime catalog safety errors, Bot construction lookups are deadline-bounded,
+  and audit paging/prior-active lookups have supporting indexes. Trusted
+  producer provenance is explicitly deferred as a PR-C grant prerequisite.
+- **Trust-boundary closure** — Runtime schemas now reject non-empty
+  `patternProperties`; `additionalProperties=false` alone does not bound regex
+  keyspaces.
+- **Verification boundary** — Core cardtmpl/catalog coverage exceeds 80% and all
+  focused, race, clean-DB integration, build, vet, lint, i18n, and diff gates are
+  green locally. Legacy Bot/notify/message whole-package coverage remains below
+  80%, so that literal brief checkbox stays open. PR #674 merge and the PR-B
+  rebase are complete; post-rebase CI/current-head approval, E1d/E1e, PR-C
+  grants, joint E2E, and production enablement remain pending.
+- **Learning (pending)** — A fail-closed runtime must retain an authenticated,
+  bounded diagnostic read path. See
+  [learning](learnings/pending/cardtmpl-runtime-catalog-overlay.md).
+
 ## 2026-07-28 (cardtmpl-runtime-catalog, roadmap E3 PR-A)
 
 - **Dark publishing foundation** — Added the shared strict JSON artifact

--- a/.octospec/tasks/cardtmpl-runtime-catalog-overlay/brief.md
+++ b/.octospec/tasks/cardtmpl-runtime-catalog-overlay/brief.md
@@ -1,0 +1,646 @@
+---
+type: Task
+title: "Task: cardtmpl-runtime-catalog-overlay"
+description: Deliver the dark-launched RuntimeCatalog overlay together with the OpenClaw Model A and reasoning-control production closure under one E3 PR-B milestone.
+tags: [card, cardtmpl, runtime-catalog, database, cache, wire-contract, trust-boundary, auth, acl, bot-api, cross-repo, error-response, i18n, rate-limit, test, testing, observability, rollback]
+timestamp: 2026-07-28T21:57:37+08:00
+# --- octospec extension fields ---
+slug: cardtmpl-runtime-catalog-overlay
+upstream: "roadmap E3 PR-B; PR-A merged via PR #674@68e8134d; parent spec cardtmpl-runtime-catalog"
+issue: 672
+source: self
+---
+
+# Task: cardtmpl-runtime-catalog-overlay
+
+> One task = one `.octospec/tasks/<slug>/` directory. This brief is the PR-B
+> implementation contract extracted from the accepted E3 parent brief. AI may
+> draft it from the current code; a human confirms it before `/octospec-go`.
+>
+> This brief was created during the OctoSpec **Plan** phase. Implementation
+> status and acceptance evidence are updated below during Verify/Finish.
+
+## Goal
+
+在 PR-A 已提供的 strict compiler、immutable version claim/artifact/audit store 和
+super-admin validate/publish 基础上，增加一个默认暗置的 `RuntimeCatalog`：
+
+1. 对 frozen built-in `Registry` 与 MySQL dynamic artifact 提供统一的 exact/default
+   resolution 和 render/metadata/action-context 读取；
+2. 用 MySQL 权威 active pointer + revision CAS 实现 activate、显式 target rollback 和
+   单向 emergency block；
+3. 用 entry/byte 双上限 compiled cache + `singleflight` 支撑多副本 lazy load，同时保证
+   active/block 真相永不由本地 cache 决定；
+4. 把 Bot template send/edit、notify Registry render、`CardUpdater` 和 message action-context
+   从具体 `*cardtmpl.Registry` 迁到只读 runtime catalog 接口，保持现有 static 行为和 wire
+   字节兼容；
+5. 以默认关闭的 control/new-send gates 部署，证明多副本、重启、DB outage、rollback 和
+   hot-cache block 行为；
+6. 在同一个 E3 PR-B delivery milestone 下完成 OpenClaw E1d Model A consumer 产品化和 E1e
+   `reasoning_stop/reasoning_retry` 真实业务闭环，并用 successor 跑联合跨仓 E2E；之后再由 PR-C
+   接入 catalog grants、B1/B2 和首个非生产 dynamic producer。
+
+PR-B 完成后代表“server 已具备受控加载、切换、回滚和阻断 dynamic artifact 的运行底座”，
+且 OpenClaw 的 Model A/stop/retry 已具备真实业务闭环；它仍**不代表任意 Bot/业务方已获准发现
+或发送 dynamic catalog template，也不代表生产开关已自动打开**。
+
+“同一个 PR-B”在本 brief 中指同一 delivery milestone、同一 go/no-go 和联合验收。E1d/E1e 的
+代码位于 OpenClaw/plugin/runtime，不在本 octo-server worktree；必须按仓库形成 companion PR，
+不能伪装成一个 GitHub PR 能原子修改多个仓库。
+
+## Background
+
+### Verified baseline at plan time (2026-07-28)
+
+- Parent contract：
+  [`.octospec/tasks/cardtmpl-runtime-catalog/brief.md`](../cardtmpl-runtime-catalog/brief.md)。
+- PR-A：GitHub PR #674 / Issue #669，已于 2026-07-29 squash merge 到 `main`，
+  merge commit 为 `68e8134d`。其 required checks、`code-review` 与 current-head
+  approvals 在合并前均已通过。
+- PR-A 已有：
+  - `card_template_version_claim`：static/dynamic exact-key 永久占位；
+  - `card_template_artifact`：immutable canonical bundle/hash，并预留单向 block 字段；
+  - `card_template_audit`：append-only publish audit；
+  - startup static inventory reconciliation；
+  - super-admin validate/publish API；
+  - `cardtmpl.CompileJSONArtifact` 及进程级 bounded compile gate。
+- PR-A 尚无 `card_template_activation`、activate/rollback/block store/API、dynamic resolver、
+  compiled cache 或 runtime consumer wiring；published artifact 始终 inactive。
+- 现有 runtime consumers 直接绑定具体 `*cardtmpl.Registry`：
+  - `modules/bot_api/card_template_catalog.go` 的 static `AdvertisedSend/EditCompatible`、
+    `Lookup` 和 `Render`；
+  - `modules/notify/card_via_registry.go` 的所有生产 Registry render；
+  - `pkg/cardtmpl.NewCardUpdater` 及 notify finalizer/mutate；
+  - `modules/message.resolveRegistryCardContext` 的 `ActionView` + `Lookup().Meta()`；
+  - package-global `DefaultRegistry()`。
+- built-in `Registry` 在 `main.go:installCardTmplRegistry` 注册、设 default、`Freeze()` 后注入；
+  module factories 随 `register.GetModules` 构造。PR-B 不能依赖无契约的 blank-import/init 顺序
+  在 Bot/notify/message 已构造后再安装 overlay。
+- Bot `template-ref/v1` 仍要求 caller 显式传 `{id,version}`；raw/template XOR、Bot owner、
+  Space、channel、message lifecycle、CAS 和 `card_seq` 约束均已冻结，不因 RuntimeCatalog 改写。
+- OpenClaw handoff：
+  [`.context/handoff/openclaw-bot-template-consumption.md`](../../../.context/handoff/openclaw-bot-template-consumption.md)。
+  当前仅证明 `0.1.0` experimental send/edit lifecycle；尚未证明 selector/reasoning lane/config/package
+  已合并发布。stop/retry 当前只 warning + metric + queue ACK，明确没有取消或重试副作用。
+- E1d/E1e 的权威运行态在 OpenClaw/plugin/runtime：`reasoning_id → active run/AbortController`、原始
+  request/context、retry scheduling 和多实例恢复不在 octo-server 代码库。本 brief 将其纳入联合
+  交付，但不虚构本仓可直接实现这些对象。
+
+### Why this is a separate PR
+
+PR-A 的安全边界是“可校验、可持久化，但永远 inactive”。PR-B 首次引入运行期 DB 读取、
+active pointer、cache 和 emergency state transition，故障面从控制面扩展到消息 send/edit/action
+热路径，必须独立评审、独立回滚并默认暗置。PR-C 再引入 producer grants 与发现面，避免把
+“存在于 catalog”“成为 active”“被 producer 授权”三个动作合并成一个不可审计开关。
+
+## Success definition for PR-B
+
+> Server work-package status (2026-07-29): implementation and clean local
+> integration/race/build/vet/lint verification are complete and tracked by
+> Issue #672. PR-A merged through #674 and this branch has been rebased onto
+> `main`; post-rebase CI and current-head re-approval remain pending. The
+> OpenClaw E1d/E1e companions and joint release gate are not complete;
+> production gates remain off.
+
+- **Overlay 闭环**：static exact/default 零回归；dynamic exact 能从任意副本验 hash、编译并按
+  server-authored metadata 渲染；双源或持久化损坏 fail-close。
+- **状态闭环**：activate/rollback/block 使用 revision CAS，状态与成功 audit 同事务；block
+  当前 active 时同事务 fallback 或 disabled。
+- **消费闭环**：所有 production `DefaultRegistry()` 读取迁入统一 catalog 接口；static Bot、
+  notify、CardUpdater 和 action-context 的现有行为、鉴权顺序及 wire 不变。
+- **故障闭环**：cache 热/冷、两副本、重启、DB outage、compile failure、stale CAS 和 hot-cache
+  block 均有自动化证据；不存在 silent fallback、未限内存或 goroutine/keyspace 泄漏。
+- **暗置闭环**：默认配置不能 activate dynamic template，也不能让 dynamic template 进入业务
+  new-send；PR-B merge/deploy 本身不会产生首张 dynamic 卡。
+- **consumer 闭环**：OpenClaw 从实时 manifest 选择唯一兼容 successor、每消息固定 mode/version/
+  card_seq，reasoning lane 生成有界且脱敏的 data；配置、package 和 release 证据完整。
+- **control 闭环**：stop/retry 绑定 authoritative run/message/bot/Space，幂等、多实例和重启可恢复；
+  只有真实 cancel/retry 成功后才写 `stopped` 或启动/展示新 reasoning。
+- **联合闭环**：server + OpenClaw companion PRs 在同一版本矩阵完成 send→edit→completed/error→
+  stop/retry、故障、回滚 E2E；任一 work package 未完成均不能把 E3 PR-B milestone 标 DONE。
+
+## Load-bearing list
+
+- **`trust-boundary`, `wire-contract`**：DB 中 canonical bundle 仍是不可信输入；每次 cache miss
+  必须验 row identity、engine、SHA-256 并复用 PR-A strict compiler，最终仍走
+  `renderCore` + `cardmsg.Validate`。不得直接反序列化成可执行 Template 或绕过 compile gate。
+- **`auth`, `acl`, `bot-api`, `space`**：manager control 只认认证上下文中的 superAdmin；runtime
+  request 的 principal/purpose/Space 必须由 server auth layer 构造。现有 Bot ownership、Space、
+  sender、channel、feature gate 不得被 catalog existence/active pointer 替代。
+- **`error-response`, `i18n`**：新增 manager/runtime 错误必须走 localized envelope；内部 DB/hash/
+  compile cause 先记录脱敏日志，5xx code 设置 `Internal=true`。
+- **`rate-limit`**：新增 manager GET/write routes 继续使用
+  `AuthMiddleware → SharedUIDRateLimiter → superAdmin guard`；测试显式清 Redis UID bucket。
+- **Static Registry freeze**：`Register/RegisterJSON/SetDefault/Freeze` 仍只属于 built-in
+  composition phase；RuntimeCatalog 绝不 `Unfreeze` 或运行期修改其 entries/defaults。
+- **Immutable identity**：`id@version` static/dynamic claim 永久唯一；artifact bytes/hash 不更新、
+  不 hard-delete；same key 不以 source precedence 掩盖冲突。
+- **Active semantics**：activation row 不存在、显式 active、显式 disabled 是三个状态；DB 查询
+  失败不能被当作 row 不存在；历史 exact-version 永不重新解析 active。
+- **Emergency block**：dynamic block 单向且 cache 不拥有 block 真相；已存 payload 仍可展示，
+  后续 render/edit/action-context 必须拒绝并告警。
+- **Bot compatibility**：`template-ref/v1` 封闭 wire、raw/template total XOR、static
+  `AdvertisedSend/EditCompatible` allowlists、unlisted ref 在 target lookup 前拒绝、same-version edit
+  provenance 校验全部保持。
+- **Card update compatibility**：`CardUpdater.ReplaceView/Append` 的 authoritative Space、stored
+  template identity、sender/lifecycle/CAS/card_seq 纪律保持；catalog 只替换模板解析依赖。
+- **Action ingress compatibility**：template identity 只取 effective stored frame；ActionView、
+  ActionContract 和 owner cross-check 必须来自同一个 exact resolved artifact，不能信 click body。
+- **`test`, `testing`**：涉及 DB migration、cache concurrency、Bot/message/notify 热路径和多副本
+  一致性，必须先补 RED fixtures，使用 bounded DB pool/cleanup，并跑 focused integration + race。
+- **Observability/rollback**：指标 label 只能是有界 operation/source/result；日志与 audit 不写 token、
+  bundle/schema/sample、card data、UID/Space 等高基数 label。kill switch 关闭后仍保留安全 rollback/
+  block 与 historical reader。
+- **Cross-repo Model A lifecycle**：manifest 必须动态选择唯一兼容版本；一条消息固定 Model A/B、
+  `id@version` 与单调 card_seq；Model A 失败后不得 raw edit 覆盖 Registry-authored frame。
+- **Reasoning control authority**：card_action 只证明用户意图已通过 server 校验，不证明业务成功。
+  stop/retry 必须绑定 active run、message、bot、Space、operator 和原始请求，不能从展示文本重建 prompt。
+- **Sensitive reasoning data**：`thought/detail` 只能是可展示、脱敏摘要，不记录 hidden chain-of-thought、
+  system prompt、token、Cookie、Authorization、私有文档或完整工具输入输出。
+
+## Architecture decisions
+
+### D1 — Branch and dependency discipline
+
+- PR-B 使用独立 Conductor workspace/branch，最初基于 PR-A accepted head `fcb9c524` stacked 开始；
+  未向 PR-A 分支追加提交，避免使 current-head approvals 失效。
+- PR-A 已通过 #674 squash merge；PR-B 已 rebase/retarget 到 merge commit `68e8134d` 后的
+  `origin/main`，并必须重新跑完整门禁及取得 current-head approvals 后方可合并。
+- Issue #669 只覆盖 PR-A。PR-B 实施前新建独立 issue，并让 PR body 的 Linked Spec 指向本 brief。
+- 同一 E3 PR-B milestone 至少包含三个可独立回滚的 work package：
+  1. octo-server RuntimeCatalog PR；
+  2. OpenClaw/plugin E1d Model A companion PR；
+  3. OpenClaw/runtime E1e reasoning-control companion PR（可与 2 合并仅当确属同仓、同 owner、同回滚单元）。
+- 三个 PR 共享 milestone、版本矩阵、联合 E2E 和 go/no-go；禁止为了“一个 PR”复制/搬运跨仓源码或
+  让任一 PR 在依赖未合并时独自打开生产开关。
+
+### D2 — Composition-root installation, not module-order luck
+
+- `main.go` 先构造并 freeze built-in Registry，再显式构造唯一的 process-level RuntimeCatalog，
+  然后才允许 `register.GetModules` 构造 Bot/notify/message APIs。
+- catalog DB/store、metrics、built-in Registry 和 action-route validator 由 composition root 显式
+  注入；`modules/card_template_catalog.API` 与业务消费者复用同一实例，不得各建一份 cache/catalog。
+- 禁止依赖 blank-import 排列或 Go `init()` 顺序完成 RuntimeCatalog 安装。
+- 保留 `DefaultRegistry()` 仅供 registration、static reconciliation 和兼容测试；新增只读
+  `DefaultCatalog()`（名字可机械微调）。测试未安装 overlay 时，`DefaultCatalog()` 可安全退回当前
+  frozen Registry adapter；生产 overlay 缺失必须在构造阶段 fail-close，而非流量到达后 nil panic。
+
+### D3 — Narrow runtime interface and typed request context
+
+接口名可按 Go 风格微调，但行为至少覆盖：
+
+```go
+type ResolvePurpose string // new_send | historical_edit | action_context
+
+type Principal struct {
+    Kind    PrincipalKind // bot | internal_producer | system
+    ID      string
+    SpaceID string
+}
+
+type Catalog interface {
+    RenderExact(ctx context.Context, req ExactRenderRequest) (map[string]any, error)
+    RenderDefault(ctx context.Context, req DefaultRenderRequest) (map[string]any, error)
+    MetaExact(ctx context.Context, req ExactRequest) (ResolvedMeta, error)
+    ActionContext(ctx context.Context, req ActionContextRequest) (ResolvedActionContext, error)
+}
+```
+
+- runtime interface 不暴露 `Register/RegisterJSON/SetDefault/Freeze`。
+- `ActionContext` 一次返回 view + cloned metadata/action contract，禁止 caller 用两次独立 lookup
+  拼出可能跨状态的结果。
+- `Principal` 只从 Bot auth、internal capability 或 stored server state 构造；不得从 bundle、body、
+  query 或任意 string context 自报。
+- 未授权 raw exact resolver 仅作为 `pkg/cardtmpl`/catalog control/readiness 内部方法，不导出给业务模块。
+- PR-B 保留现有 static producer policy；dynamic business purposes 在 grant store 尚未由 PR-C 接入前
+  一律返回 typed not-authorized/unavailable，不能靠 handler 手写 allow 或 catalog existence 放行。
+
+### D4 — Exact and default resolution
+
+**Exact `id@version`**：
+
+1. built-in inventory 命中时只从 frozen memory 返回；启动 reconciliation 已证明该 exact key 的
+   persistent claim 为 static，正常热路径不为 static render 增加 DB query；
+2. 非 static key 从强一致 MySQL 读取 dynamic claim + artifact minimal metadata；source 不符、artifact
+   缺失、identity/engine/hash 异常均为 catalog integrity failure；
+3. 即使 compiled cache 命中，每次 dynamic exact 仍读取权威 `blocked_at` 与 current hash，避免
+   hot cache 绕过 emergency block；
+4. cache miss 才读取 canonical bundle、重新计算 SHA-256、strict decode/compile，并再次核对编译出的
+   ID/version/owner/protocol/engine/hash 与 row；
+5. historical edit/action-context 始终使用 stored explicit version，不读取 active pointer，也不跨版本
+   偷换；blocked 是唯一拒绝继续执行的安全例外。
+
+**Default/new send**：
+
+- startup reconciliation 尚未成功时，default/dynamic resolution 必须 fail-close，且
+  `/v1/ready` 返回 503；此时仅 explicit static exact 在未证明 integrity collision 的前提下继续可用。
+  这是 readiness 语义，不是 rollout gate。证明 integrity failure 后所有 catalog resolution 均关闭。
+- 查询 `card_template_activation`；row 不存在时，只有 built-in Registry 已声明 static default 才可
+  走 legacy static default；dynamic-only ID 返回 unavailable/unknown。
+- `status=disabled` 必须拒绝，不 fallback 到 built-in default。
+- `status=active` 按 row 的 explicit version 进入 exact resolution；DB error、timeout、malformed row
+  全部 fail-close，不能当作 no-row。
+- dynamic target 还受 new-send gate 和未来 PR-C grant 约束；PR-B 阶段业务 dynamic new-send 永远
+  不成功。
+
+### D5 — Persistence additions
+
+新增 migration：
+
+1. `card_template_activation`
+   - `template_id` primary key（ASCII、case-sensitive）；
+   - nullable `active_version` + bounded `status=active|disabled`；
+   - monotonic `revision BIGINT`；
+   - `updated_by/updated_at/reason/change_ticket`；
+   - active version 以 composite FK/等价事务约束指向同 template ID 的 permanent claim；
+   - `active` 必须有 version，`disabled` 必须无 version；不提供 DELETE。
+2. 扩充 `card_template_audit`
+   - 足以记录 previous/target version、previous/resulting revision；
+   - `activate|rollback|block` 成功状态与 audit 同事务；audit 失败则状态不变；
+   - 不保存 bundle/card data/token。
+
+`card_template_artifact` 已有 block columns，PR-B 只允许第一次从 NULL 写入；不得改写或清空 block，
+不得更新 canonical bytes/hash。
+
+### D6 — State transitions and CAS
+
+**Activate**：
+
+- request 明确 target version、`expected_revision`、reason、change ticket；首次无 activation row 时
+  只接受 `expected_revision=0`，成功创建 revision 1；并发首次写只有一个成功。
+- target claim 必须存在；dynamic target 必须 artifact 完整、unblocked、engine supported、hash/compile
+  valid；static target 必须存在于本镜像 frozen Registry。
+- compile/route validation 不在长事务内执行；进入事务后按固定 lock order 重新核对 immutable identity、
+  block 和 current revision，再 CAS + audit。
+
+**Rollback**：
+
+- caller 必须明确 target version，不由 server 猜“上一版”；target 必须能由 append-only audit 证明曾
+  成功处于 active，避免把 rollback endpoint 当成绕过 control gate 的第二个首次 activate 入口。
+  验证与 activate 相同，但 operation/audit 为 `rollback`。
+- rollback 可指向 static 或仍 unblocked 的 dynamic version，不删除/清 cache 新版。
+
+**Block**：
+
+- 只支持 dynamic artifact，单向不可恢复；static 风险通过 binary/config rollback 处理。
+- request 带 `expected_revision`，可选 explicit fallback version。若 target 是 current active：
+  - fallback 有效且为 built-in static 或曾成功 active 的版本时，同一事务 block target + active 切
+    fallback + revision+1 + audit；
+  - 无 fallback 时，同一事务 block target + `status=disabled` + revision+1 + audit；
+  - 不得因“没有已知良好 fallback”拒绝 block。
+- target 非 active 时只写 block + audit，active pointer/revision 不变，但仍校验 caller 看到的 current
+  revision，防止基于陈旧控制面快照操作。
+- stale revision、already-blocked、invalid fallback 使用确定性 typed conflict；任何失败不得留下
+  “artifact 已 block 但 active 仍指向它”的半提交。
+- deadlock/lock-wait 只按 PR-A 同类规则 bounded retry 整个 transaction；CAS conflict 不重试。
+
+### D7 — Control APIs
+
+PR-B 增加以下 super-admin routes（具体 Go handler 名可微调，wire 语义冻结）：
+
+| Method/path | Request / response |
+| --- | --- |
+| `GET /v1/manager/card-templates/{id}` | 返回 source-aware versions、block 状态、active status/version/revision；不返回 bundle |
+| `GET /v1/manager/card-templates/{id}/audit` | bounded cursor pagination，返回脱敏 activate/rollback/block/publish audit |
+| `PUT /v1/manager/card-templates/{id}/active` | `{version, expected_revision, reason, change_ticket}` |
+| `POST /v1/manager/card-templates/{id}/rollback` | `{target_version, expected_revision, reason, change_ticket}` |
+| `POST /v1/manager/card-templates/{id}@{version}/block` | `{expected_revision, fallback_version?, reason, change_ticket}` |
+
+- 路由链固定为 Auth → shared UID limiter → handler superAdmin guard；actor 只取 login context。
+- path/body ID/version 冲突或 unknown fields fail-close；reason/change ticket 沿用 PR-A bounded/trimmed
+  规则。
+- 继续使用 `httperr.ResponseErrorL`：wire status 保持 D14 固定 400，真实 409/503 放在
+  `error.http_status`；除非 maintainer 明确批准，不切 `ResponseErrorLWithStatus`。
+- 2 MiB 仍是**完整 HTTP control envelope**上限；不扩成“2 MiB bundle + wrapper”。PR-A compiler 的
+  2 MiB canonical bundle 是独立内部 ceiling，不承诺 HTTP 能提交恰好满 2 MiB 的 bundle。
+- manager read pagination 默认 50、hard max 100；响应不得含 canonical bundle、schema/sample、token
+  或 callback secret。
+
+### D8 — Kill-switch semantics
+
+- `OCTO_CARD_RUNTIME_CATALOG_CONTROL_ENABLED`：默认/缺失/非法均为 false 并 WARN。false 时禁止
+  forward `activate`；validate/publish 与 manager read 保持 PR-A/运维可用，rollback 和 block 作为
+  安全操作保持可用且继续审计。这里的“可用”指不受 control gate 阻断；publish 仍须通过 runtime
+  readiness，并只接受 reviewed runtime-owner allowlist。rollback target 必须是 audit 可证明的
+  prior-active version，不能借 rollback 首次启用从未 active 的 artifact。
+- `OCTO_CARD_RUNTIME_CATALOG_NEW_SEND_ENABLED`：默认/缺失/非法均为 false。false 时 dynamic
+  default/new-send 返回 typed unavailable；不得 fallback 到另一个 static version。
+- 两个 gate 都不能关闭 static exact/default compatibility path。
+- historical dynamic exact reader/edit/action-context 不得被常规 rollout gate 关闭；首张 dynamic card
+  一旦发送，它就是 binary compatibility floor。PR-B 尚无 grants，因此这一能力只由 internal tests
+  验证，不对业务开放。
+- 部署必须先让所有 serving replicas 升级并完成 static reconciliation，再允许 control gate；混合
+  binary rollout 时两个 gate 都保持 false。
+
+### D9 — Compiled artifact cache
+
+- cache key 为 `engine_contract + content_sha256`；不以 caller ID、active revision 或 grant 作为 key。
+- 默认最多 **64 entries / 32 MiB canonical bytes**；可配置但 hard max 为 **256 entries / 128 MiB**。
+  byte accounting 使用 retained canonical bytes；entry cap 同时限制无法精确计量的 schema/AST heap。
+- 使用 LRU/等价有界淘汰；immutable artifact 不需要 TTL。不得缓存 active、grant、block 或 DB error；
+  compile/hash/integrity failure 不写正 cache，也不做无限期 negative cache。
+- 同 key cache miss 使用 `singleflight`，闭包内双检 cache；共享 load/compile 使用 catalog-owned
+  10s deadline 和现有 process compile semaphore。每个 waiter 可按自己的 context 提前返回；后台共享
+  work 最迟在 catalog deadline 终止，不产生无界 goroutine。
+- 每次 dynamic request 先读 authoritative minimal metadata/block，再查 cache；命中热 cache 也不能
+  少这一步。
+
+### D10 — Runtime consumer migration
+
+- 新增 static Registry adapter，使 `*Registry` 与 RuntimeCatalog 均实现相同只读接口；registration API
+  不进入接口。
+- 将所有非测试 production `DefaultRegistry()` 读取迁到 `DefaultCatalog()`：
+  - Bot catalog construction/send/edit；
+  - `modules/notify/card_via_registry.go`；
+  - `CardUpdater`、notify action finalizer 和 sibling mutate；
+  - message action-context。
+- `modules/card_template_catalog` 的 static reconciliation 仍显式使用 built-in Registry inventory，
+  不通过 overlay 反向枚举自身。
+- Bot static `AdvertisedSend/EditCompatible` 继续在任何 target snapshot/DB lookup 前判定；catalog
+  render request 额外携带 server-authored bot ID、purpose 和 authoritative Space。PR-B 不合并 dynamic
+  capability，也不修改 `template-ref/v1`。
+- notify/internal producers 使用代码内固定 principal ID；PR-B 只允许它们继续消费既有 static policy，
+  dynamic 仍 fail-close，等待 PR-C grant。
+- `CardUpdater.ReplaceView` 使用调用链已证明的 explicit version；`Append` 从 stored effective frame
+  读取 provenance。不得把 update 重新解析为 current active。
+- action ingress 从 effective frame 的 `metadata.octo.template` 取 exact ref，并通过一次
+  `ActionContext` 获取 view/contract；route owner 仍与 stored Action.Submit.data 交叉校验。
+
+### D11 — Interactive activation precondition
+
+- dynamic interactive artifact 的 ActionContract 必须完整；activate 前确认至少存在一个 configured
+  `cardactiondispatch.RouteSpec` 匹配 `(owner, action_type)`，否则 fail-close。
+- RouteSpec 实际还以 sender UID 分区。PR-B 只做 catalog-level “至少有可配置路由”检查；PR-C 在给
+  具体 producer grant 时必须再次验证该 authoritative sender 的 exact route/owner/Space。PR-B 不把
+  BotPull fallback 当作 dynamic interactive activation 证明。
+- active artifacts 在进程安装/启动校验时复核 engine、owner policy 与 interactive route capability；
+  不可服务的 active contract 使 catalog-enabled process fail-close，不允许不同副本各自解释。
+- startup active target 查询使用 `LIMIT 129` 探测 **128** 的 hard cap；static reconciliation 与列表读取
+  各有 30s budget，每个 target 有独立 10s validation budget，不再共享一个会随 target 数量触发的
+  30s 总预算。重试时重新读取并验证全量 target，避免沿用已变化 activation state 的部分进度。
+
+### D12 — Failure semantics and observability
+
+Typed runtime errors至少区分：unknown/not-active、disabled、blocked、not-authorized、CAS conflict、
+compile busy/timeout、DB unavailable、catalog integrity。业务 facade 可合并外部表现以防枚举，但日志/
+metrics 必须能低基数区分内部类别。
+
+- DB unavailable：dynamic/default/control fail-close；static exact 继续成功。default 查询失败不能回退
+  static。
+- hash/identity mismatch、missing artifact、双源冲突：internal integrity error + alert；不 panic 单个
+  request，不返回 bundle/cause。
+- blocked：new send/render/edit/action-context 拒绝，保留 last successful payload 展示。
+- 新增/补齐：
+  - `dmwork_card_catalog_resolve_total{source,result}`；
+  - `dmwork_card_catalog_cache_total{result=hit|miss|shared|evict}`；
+  - 复用 operation/compile/db 指标；
+  - cache retained entries/bytes 使用 gauge。
+  - `dmwork_card_catalog_active_targets` gauge；catalog pending/integrity 必须让 `/v1/ready` 503，body
+    只暴露 bounded dependency status，不暴露内部 cause。
+- metric labels 不含 template ID/version/hash、actor UID、principal ID、Space ID；这些只可进入遵循现有
+  脱敏/采样纪律的结构化日志或 append-only audit。
+
+### D13 — E1d/E1e cross-repo companion delivery
+
+#### E1d — OpenClaw Model A consumer
+
+- 每次新消息前读取 `/v1/bot/card/profile`，同时校验 top-level enabled、templating supported、
+  `wire=template-ref/v1`、view/state/profile 和完整 `submit_actions`；版本从 manifest 动态选择，不硬编码
+  `0.1.0/0.2.0`，多个兼容版本无明确 semver policy 时 fail closed 回 Model B。
+- 一条消息创建时固定 `{mode, template_id, template_version, next_card_seq}`；Model A send 只发
+  `template_ref+state+data`，edit 只发同版本 ref/data/card_seq/transient。不得中途切版本或回退 raw
+  Model B edit。
+- 接入 reasoning lane，生成用户可展示、脱敏的 `thought/actions`；落实 successor 的 string、phase、
+  per-phase action、aggregate action cap。`reasoningId` 采用稳定且无碰撞的 bounded ID，不能直接截断。
+- 配置 schema 至少支持 `off|shadow|experimental`；PR-B 联合验收前 production default 仍 off，
+  `OCTO_BOT_CARD_ENABLED=false`。完成 unit/integration、package、version、release note 和可回滚制品。
+- send 超时不盲重发；edit 仅对完全相同 body+seq 做有界重放；D14 按 `error.code`/
+  `error.http_status` 识别 conflict，不能只看 transport 400。
+
+#### E1e — Real stop/retry semantics
+
+- 建立 `reasoning_id → active run` 权威注册表，至少绑定 run/AbortController handle、message ID、bot ID、
+  Space ID、origin request reference、owner instance、status、created/expiry；caller/card 展示数据不得成为
+  authority。
+- registry 必须支持多实例路由与 bounded TTL，定义进程重启后的恢复策略：可恢复 run 重新挂载；不可恢复
+  run 明确失败/过期，不能把“找不到内存 AbortController”当取消成功。
+- stop：校验 stored card event 的 message/bot/Space/reasoning ID 和 operator 权限，使用 event/reasoning
+  identity 幂等；只有底层 cancel 已确认后才 edit 为 `stopped`。already-completed/already-stopped/not-found
+  有确定且不泄漏的语义。
+- retry：只从 server/plugin 持久化的原始 user request/context 重建，不从卡片 `thought/detail` 反推 prompt；
+  有幂等 key、per-run/per-user 频率限制、并发 single-writer。明确 v1 创建**新 reasoning ID/new run**，
+  新 run 创建成功后才发送/更新 reasoning 卡；失败保持原 error frame并返回可观察结果。
+- queue ACK 只在业务动作进入确定终态（success、safe idempotent replay 或明确不可重试 rejection）后执行；
+  transient infra failure 不得 ACK 丢失。业务成功、event ACK 和 card edit 分别可观测，不能合并成一个
+  “handled”指标。
+- stop/retry 的最终用户反馈、重试次数、超时、DLQ/补偿和告警必须有界；日志不记录 prompt、隐藏推理或
+  tool secrets。
+
+#### Joint contract
+
+- octo-server 继续把 action identity/data 绑定到 effective stored frame，并按 event ID 提供 at-least-once；
+  OpenClaw 用 event ID + reasoning operation key 实现幂等，不把 `client_token` 当业务幂等键。
+- successor 跨仓 E2E 必须覆盖：reasoning→answering→completed、error→retry→new run、active→stop→
+  stopped、重复/迟到/跨 Space action、owner instance crash、DB/Redis/HTTP 短暂故障、server catalog
+  rollback 和 consumer package rollback。
+- E1d/E1e companion 未合并发布或联合 E2E 未通过时，server RuntimeCatalog PR 即使绿灯也不能把
+  E3 PR-B milestone 标 DONE，更不能打开 production Bot card gate。
+
+## TDD implementation checkpoints
+
+1. **RED — state/store**：先写 first-activation concurrent CAS、stale revision、rollback、active block
+   with fallback、active block without fallback、non-active block、audit failure rollback fixtures。
+2. **RED — resolver/cache**：写 static no-DB exact、dynamic cold/hot load、hash mismatch、hot-cache block、
+   singleflight、entry/byte eviction、caller cancellation 和 DB outage fixtures。
+3. **GREEN — narrow interface/static adapter**：先迁 static callers，证明现有 Bot/notify/update/action
+   tests字节与鉴权顺序零回归。
+4. **GREEN — dynamic overlay**：接 store + compiler + cache；无 grant 的所有 business dynamic purpose
+   必须仍失败。
+5. **GREEN — control state machine/API**：实现 manager detail/audit + activate/rollback/block、gates、i18n、
+   metrics。
+6. **RED→GREEN — multi-replica**：两个 RuntimeCatalog 实例共享 DB、各自独立 cache，覆盖 activate、
+   rollback、block、restart 和 DB failure。
+7. **RED→GREEN — E1d companion**：先锁 manifest selector、unknown action、random version、caps、
+   per-message mode/version/seq、reasoning mapping、retry discipline，再接真实 profile/send/edit。
+8. **RED→GREEN — E1e companion**：先锁跨 Space/owner mismatch、duplicate/late event、completed-vs-stop
+   race、retry single-writer、instance loss/restart，再实现 active-run registry 与 control handlers。
+9. **Joint E2E**：固定 server/plugin/runtime/client version matrix，跑正常、stop、retry、故障和回滚；
+   任何 companion 只能在联合证据完成后标 DONE。
+10. **Verify**：focused → race → integration → build/vet/i18n/diff；不得以 mock-only 单副本测试代替 DB
+   transaction/multi-replica 证据。
+
+## Out of scope
+
+- PR-C 的 `card_template_grant`、grant/revoke API、principal/Space permission matrix。
+- B1/B2 普通用户 discovery/export、visibility filtering、ETag 和 anti-enumeration。
+- Bot dynamic capability 合并、按 template ID 单版本广告 guard、dynamic producer grant。
+- PR-C grant 接入前必须先设计并持久化可信 producer provenance，使 action-context 能从 server-authored
+  state 区分 `bot` 与 `internal_producer`。现有消息只保存 sender/template identity，禁止按 sender UID、
+  template ID 或 owner 硬编码推断 principal kind。
+- 首个非生产 publish→activate→send→Action.Submit→edit→rollback pilot，以及任何生产 go-live。
+- `ext.*` L2b owner、自助/委托发布、动态 callback URL/secret/finalizer/RouteSpec 创建。
+- per-Space active version；v1 仍只有 global pointer。
+- hard delete/GC claim/artifact、修改 immutable bytes、unblock 已 blocked version。
+- Redis pub/sub correctness、active/grant TTL cache、read-replica eventual consistency。
+- JavaScript/WASM/Go dynamic artifact、新 engine contract 或修改 `${}` ACT 语法。
+- 修改 `template-ref/v1` 或放宽 raw/template XOR；E1d/E1e 必须在既有 wire/event contract 上闭环。
+- 用 PR-B merge 自动打开 `OCTO_BOT_CARD_ENABLED`、control 或 new-send 开关。
+
+## Acceptance
+
+### A. Composition and static compatibility
+
+- [x] RuntimeCatalog 在 module factories/handlers 构造前由 composition root 唯一安装；测试证明交换
+  blank-import/module 注册顺序不会让 Bot/notify 退回另一份 catalog。
+- [x] built-in Registry 仍在 registration 后 `Freeze()`；不存在 runtime Register/Unfreeze 路径。
+- [x] 所有非测试 production `DefaultRegistry()` runtime reads 已迁移；registration/reconciliation 除外。
+- [x] static Registry adapter 与 RuntimeCatalog 对所有 built-in `id@version` 的 Meta、ActionView、
+  render payload/profile/render_profile canonical 相等。
+- [x] 现有 Bot `0.2.0` advertise/new-send、`0.1.0/0.2.0` historical edit、notify cards、
+  CardUpdater 和 message action tests 零行为回归；unlisted Bot ref 仍早于 target lookup 拒绝。
+
+### B. Persistence and transitions
+
+- [x] migration 创建 activation table、FK/check/index，并扩充 audit；up/down migration 在 clean DB 通过。
+- [x] absent row + `expected_revision=0` 并发 activate 只有一个 revision 1 成功；其余 deterministic conflict。
+- [x] stale activate/rollback/block 不 last-write-wins；CAS conflict 不被 transient retry 吞掉。
+- [x] activate/rollback target 必须存在、可服务、unblocked；dynamic target hash/compile/owner/route 校验通过。
+- [x] rollback 只接受 audit 可证明的 prior-active target；从未 active 的 artifact 不能通过 rollback 绕过
+  `CONTROL_ENABLED=false`。
+- [x] active block + valid fallback 原子切换；无 fallback 原子 disabled；任何注入的 audit/commit failure
+  都保持原状态。
+- [x] non-active block 不改变 active revision；blocked columns 只写一次，无 unblock/update/hard delete。
+- [x] state transition 与成功 audit 同事务，audit 可还原 actor、operation、target、old/new revision、reason、
+  ticket，但不含敏感 payload。
+
+### C. Resolution, cache, and failure behavior
+
+- [x] exact static render 在 runtime DB outage 时成功且无 per-request catalog DB query。
+- [x] default resolution DB error fail-close；no-row 才可使用 built-in default；explicit disabled 不 fallback。
+- [x] startup pending/integrity 时 `/v1/ready` 返回 503；pending 时 static exact 可用但 default/dynamic
+  fail-close，避免 replica 在 active-pointer truth 未建立时继续接收卡片流量。
+- [x] dynamic cold load 从 DB 验 identity/engine/hash 后走 PR-A compiler；compile result 与同 bundle static
+  registration canonical 相等。
+- [x] dynamic hot cache 每次仍读取 block/hash metadata；block 后另一实例的 hot cache 首次请求即拒绝。
+- [x] cache 同时满足 entry/byte cap、LRU eviction、singleflight shared compile、race safety；error 不污染正
+  cache，无无界 goroutine/keyspace。
+- [x] hash mismatch、missing artifact、source conflict 返回 typed integrity error并记录低基数指标；响应不泄漏
+  bundle、owner/grant/existence 细节。
+- [x] PR-B 中任意 Bot/internal producer dynamic new-send/edit/action-context 均因无 grant fail-close；package
+  internal tests可验证 resolver，但不存在业务绕过入口。
+
+### D. Control API, auth, and gates
+
+- [x] manager routes 使用 Auth → SharedUIDRateLimiter → superAdmin；匿名、普通用户、Bot token 全拒，actor
+  只取 login context。
+- [x] strict JSON、unknown field、path/body identity mismatch、reason/ticket/revision bounds 均有 table tests。
+- [x] `CONTROL_ENABLED=false` 时 forward activate 拒绝，但 validate/publish/read/rollback/block 语义按 D8
+  保持；`NEW_SEND_ENABLED=false` 时 dynamic new-send 拒绝且不 fallback。
+- [x] env 缺失/非法默认 false 并有 bounded WARN；开关不影响 static exact/default。
+- [x] control-plane conflict/control-disabled/blocked/unavailable/error 均走 registered localized code；runtime
+  disabled 保持 typed `cardtmpl.ErrRuntimeCatalogDisabled`，由 consumer facade 映射；5xx Internal + server log
+  cause；source guard 无 legacy/raw error response。
+- [x] manager detail/audit pagination hard cap 生效，响应不返回 canonical bundle/schema/sample/token/secret。
+
+### E. Multi-replica and restart
+
+- [x] replica A/B 使用同一 DB、不同 RuntimeCatalog/cache：A activate 后 B cold-load 同 version；A rollback 后
+  B 下一次 default 立即读取旧 version，不被旧 hot cache 影响。
+- [x] A block current dynamic version：B 即使 cache 热也拒绝 target；fallback/disabled 与 DB revision 一致。
+- [x] process restart + empty cache 能恢复同一 active/disabled/block 行为；static claim/active integrity 不可服务
+  时 fail-close。
+- [x] mixed-version rollout 测试/运维断言证明两个 gates 默认 false；不以 Redis event/ACK 作为一致性条件。
+
+### F. Observability and verification
+
+- [x] operation/resolve/cache/compile/db metrics label 集合有界；无 ID/version/hash/UID/Space 高基数 label。
+- [x] active-target list hard cap 128、limit+1 检测、per-target 10s deadline 和 active-target gauge 生效；
+  startup catalog 未 ready 会进入 readiness dependency status。
+- [x] activation/rollback/block failure、DB outage、integrity、hot-cache blocked request 有脱敏日志/指标。
+- [ ] focused tests：`pkg/cardtmpl/...`、`modules/card_template_catalog/...`、`modules/bot_api/...`、
+  `modules/message/...`、`modules/notify/...` 通过；变更包覆盖率不低于 80%。
+  - 2026-07-29：上述 focused suites 全绿；核心 `pkg/cardtmpl`/catalog 覆盖率为
+    80.6%/80.8%。但三个历史 consumer 大包的 whole-package baseline 仅
+    Bot 48.3%、notify 68.7%、message 21.6%，因此该条按字面仍未勾选；不得用
+    targeted-path tests/race 冒充 whole-package 80%。
+- [x] targeted `-race` 覆盖 RuntimeCatalog/cache、Bot template send/edit、CardUpdater、message action-context。
+- [x] DB integration lane 在 clean MySQL/Redis/WuKongIM 环境通过；若本地共享 DB 有已知 migration 污染，
+  必须记录真实阻断并以 clean CI 证据补齐，不能伪称本地通过。
+- [x] `go build ./...`、定向/全仓 `go vet`、`make i18n-extract-check`、`make i18n-lint`、相关 source
+  guards 与 `git diff --check` 全绿。
+
+### G. E1d OpenClaw Model A companion
+
+- [ ] selector 对 enabled/templating/wire/views/states/profiles/submit_actions 全量校验；随机 manifest version
+  测试证明无 `0.1.0/0.2.0` 硬编码，多兼容版本无 policy 时 fail closed。
+- [ ] successor exact-limit/limit+1 fixtures 覆盖全部 string、phases、per-phase actions 和 aggregate actions；
+  producer action 总数保持不高于 12，`reasoningId` bounded 且不以截断制造碰撞。
+- [ ] reasoning lane 映射只输出可展示脱敏摘要；hidden chain-of-thought、prompt、credential、私有 tool
+  payload 不进入 card data/log。
+- [ ] 每消息固定 mode/id/version/card_seq；Model A/B send/edit total XOR；active transient、terminal
+  non-transient；Model A 失败不 raw overwrite。
+- [ ] off/shadow/experimental 配置 schema、package、release artifact、version 和 rollback note 完整；production
+  default仍 off，未在未授权环境打开 Bot gate。
+- [ ] 对真实 server profile 跑 reasoning→answering→completed 与 error；相同 edit 幂等重放、stale seq、能力
+  关闭和 server 5xx 行为符合 handoff。
+
+### H. E1e reasoning-control companion
+
+- [ ] active-run registry 绑定 reasoning/run/message/bot/Space/origin request/owner instance/status/TTL；多实例
+  定向、owner loss、restart/expiry 有自动化测试和可观测结果。
+- [ ] stop 拒绝 forged/cross-Space/cross-bot/mismatched message event；duplicate/late/completed race 幂等；底层
+  cancel 成功后才写 stopped，失败不伪造成功文案或状态。
+- [ ] retry 不从 card display data 重建 prompt；使用持久化 origin request、幂等 key、频率限制和 single-writer；
+  创建新 reasoning ID/new run 成功后才发送/更新新 reasoning，失败保留原 error frame。
+- [ ] transient infra failure 不 ACK 丢事件；success/safe replay/permanent rejection 才 ACK。event ACK、business
+  outcome、card edit 分开记录 bounded metrics/logs。
+- [ ] stop/retry 多副本、重启、timeout、重复事件、乱序事件、queue redelivery、server edit failure 和补偿路径
+  通过 race/integration tests。
+
+### I. Joint release gate
+
+- [ ] octo-server、OpenClaw plugin/runtime、client 的 commit/package/version matrix 固化在 E2E 记录中；不能用
+  “latest”代替可复现版本。
+- [ ] successor 完成 send→edit→completed、error→retry→new run、reasoning→stop→stopped；同时覆盖跨 Space
+  拒绝、实例 crash、DB/Redis/HTTP 抖动、catalog rollback 和 consumer rollback。
+- [ ] 三个 work packages 的 CI/review/release evidence 均完成后才将 E3 PR-B milestone 标 DONE；任何一个缺失
+  时 production `OCTO_BOT_CARD_ENABLED`、runtime control/new-send gates 保持关闭。
+
+## Rollout and rollback
+
+1. PR-B 首次部署两个 runtime gates 均为 false，只验证 static traffic、manager read、metrics 和 startup
+   reconciliation；不得 activate dynamic version。
+2. 所有 serving replicas 升级且 clean DB multi-replica/restart evidence 完整后，才可在非生产短期开
+   control gate执行 activate/rollback/block 演练；new-send 仍 false。无 grants 阶段只能使用无人消费的
+   template ID，不能把某个生产 notify/Bot 正在使用的 ID 切到 dynamic 后再解释为“演练无影响”。
+3. OpenClaw E1d package 先以 shadow/experimental 发布，使用 built-in successor 验证 Model A；E1e active-run
+   registry 和 stop/retry 未发布前不允许生产展示可操作按钮。
+4. E1d/E1e companion 完成后固定跨仓版本矩阵跑联合 E2E；只有联合 go/no-go 批准才可单独开启 Bot card
+   灰度。该动作不自动开启 dynamic catalog new-send。
+5. PR-C 接入 grants 与 catalog pilot 前，production dynamic new-send 保持不可达。
+6. 常规回滚先关闭 forward control/new-send，CAS rollback 到 known-good static/dynamic target；不得删
+   artifact/cache。
+7. OpenClaw rollback 按消息固定 mode/version：已有 Model A 消息保留最后成功帧并停止 edit，不得用旧
+   Model B raw edit 覆盖；active-run rollback 必须先 drain/转移或明确终止在途 run。
+8. 安全事件使用 block + fallback/disabled；block 不受 forward control gate 阻断。
+9. 首张 dynamic 卡真正发送后，不得回滚到缺少 dynamic historical exact reader 的 pre-PR-B binary；只能
+   部署仍保留该 reader 的修复版本。该兼容性底线在 PR-C pilot/生产工单再次确认。
+
+## Human confirmation before `/octospec-go`
+
+- [x] 接受 PR-B 先 stacked、待 PR-A merge 后 rebase main 的分支策略；#674 合并及本次 rebase 已完成。
+- [x] 接受 PR-B 无 grants 时所有 business dynamic purpose fail-close，首次 producer/pilot 留 PR-C。
+- [x] 接受 forward control gate 只禁 activate，rollback/block 始终保留为安全操作。
+- [x] 接受 cache 默认 64 entries / 32 MiB，hard max 256 / 128 MiB。
+- [x] 接受 dynamic interactive activation 的 PR-B coarse RouteSpec 检查，以及 PR-C grant 时按 exact sender
+  再校验。
+- [x] 接受“同一个 E3 PR-B”是一个联合 delivery milestone；octo-server、OpenClaw E1d、OpenClaw/runtime
+  E1e 按仓库与回滚边界形成 companion PR，三者共享联合 E2E/go-no-go，不能压成单一 GitHub diff。
+- [x] 接受 E1e retry v1 创建新 reasoning ID/new run，且只有真实 cancel/retry 成功才改变卡片业务状态。
+- [x] 接受 startup 未 ready 时 default/dynamic fail-close，并由 `/v1/ready` 503 将 replica 摘流；不以
+  未验证的 static default 绕过 active pointer truth。
+- [x] 接受 publish 的 runtime-readiness + reviewed owner allowlist 前置，以及 typed-object
+  `patternProperties` fail-close，作为 PR-B 明示安全收紧；untyped combinator 的结构性完整扫描留在
+  dynamic producer/grant 打开前收口。
+- [x] 接受 action-context principal kind 不能从现有 sender/template 猜测；可信 producer provenance
+  设计与持久化是 PR-C grant 上线前置。

--- a/.octospec/tasks/cardtmpl-runtime-catalog-overlay/context.yaml
+++ b/.octospec/tasks/cardtmpl-runtime-catalog-overlay/context.yaml
@@ -1,0 +1,20 @@
+injected:
+  - id: space-isolation
+    source: repo
+    why: Runtime catalog consumers include Bot, notify, message action-context, and manager control routes; authoritative principal, ownership, and Space boundaries must not be weakened.
+  - id: trust-boundary
+    source: repo
+    why: Dynamic canonical bundles remain untrusted stored content and must pass strict hash, compiler, structural-budget, URL, and cardmsg validation boundaries on cache miss.
+  - id: error-handling
+    source: repo
+    why: New activate, rollback, block, manager-read, and runtime errors are user-visible wire contracts and must use registered localized envelopes.
+  - id: rate-limit
+    source: repo
+    why: Manager catalog routes remain authenticated and use the shared UID limiter before the super-admin guard.
+  - id: testing
+    source: repo
+    why: The task changes migrations, CAS transactions, cache concurrency, multi-replica behavior, and Bot/message/notify hot paths and therefore requires focused, integration, race, and coverage evidence.
+  - id: commit-style
+    source: repo
+    why: The eventual commits and PR must use English Conventional Commits, an English PR body, Linked Spec, and the dedicated PR-B issue; the Implement phase itself makes no commit.
+brief: .octospec/tasks/cardtmpl-runtime-catalog-overlay/brief.md

--- a/docs/card-template-runtime-catalog-runbook.md
+++ b/docs/card-template-runtime-catalog-runbook.md
@@ -1,9 +1,18 @@
-# Runtime card template catalog startup recovery
+# Runtime card template catalog operations and recovery
 
-This runbook covers startup failures from the runtime card template catalog,
-especially a static/dynamic collision on the same exact `template_id@version`.
-It applies to PR-A, where dynamic artifacts can be validated and published but
-cannot be activated, resolved, or sent in production.
+This runbook covers the PR-A immutable artifact store and the PR-B runtime
+catalog overlay, including startup validation, activate/rollback/block, and a
+static/dynamic collision on the same exact `template_id@version`.
+
+PR-B deploys dark by default:
+
+- `OCTO_CARD_RUNTIME_CATALOG_CONTROL_ENABLED=false` blocks forward activate;
+- `OCTO_CARD_RUNTIME_CATALOG_NEW_SEND_ENABLED=false` blocks dynamic new-send;
+- rollback and emergency block remain available after startup validation so a
+  kill switch cannot remove the recovery path.
+
+PR-B does not add producer grants or discovery. A published or active artifact
+is not, by itself, permission for a Bot or internal producer to use it.
 
 ## Safety invariant
 
@@ -13,28 +22,56 @@ and the database disagree. Do not add or use a switch that ignores the
 collision: doing so can make replicas resolve different content for the same
 identity.
 
-The PR-A break-glass action is a **binary rollback or corrective binary**, not a
-catalog bypass or database rewrite. A normal static/dynamic collision can be
-recovered without changing any catalog row.
+Before the first dynamic card is sent, a static-key collision is recovered with
+a **binary rollback or corrective binary**, not a catalog bypass or database
+rewrite. After a dynamic card is sent, rollback binaries must retain the PR-B
+historical exact reader; a pre-PR-B binary is no longer safe.
 
 ## Detection and classification
 
-The process exits with a panic containing:
+Startup reconciliation and active-target validation run outside module
+construction. A transient MySQL failure no longer crashes the whole
+`octo-server`: DB-backed default/dynamic/control paths stay unavailable and the
+process retries. Explicit static exact-version reads remain available during
+that transient outage. Until the first validation succeeds, and after a proven
+integrity failure, `/v1/ready` returns `503` with
+`dependencies.card_template_catalog=down`; the load balancer must not route
+normal traffic to that replica. This deliberately keeps static default
+resolution fail-closed instead of serving a fallback whose active-pointer state
+has not been established. `/v1/health` remains dependency-free for liveness.
+
+Startup work is bounded by a 30-second static-reconciliation query budget, a
+30-second active-target-list query budget, at most 128 active targets, and an
+independent 10-second validation budget per target. More than 128 active rows is
+an integrity/capacity failure. Targets are re-read and revalidated on a retry;
+partial progress is not retained because activation state may have changed
+between attempts.
+
+Watch these bounded signals:
 
 ```text
-card template catalog: reconcile static inventory: ...
+card template catalog startup validation unavailable; retrying
+card template catalog startup integrity failure
+dmwork_card_catalog_db_total{operation="startup_validate",result="error|integrity_error|ok"}
+dmwork_card_catalog_active_targets
 ```
 
-Classify the nested error before acting:
+An integrity failure poisons catalog readiness and fails all catalog resolution
+closed, including explicit static reads, because a source collision has been
+proved. The rest of `octo-server` stays up so operators retain diagnostics and
+unrelated service capacity.
+
+Classify the logged cause before acting:
 
 | Signal | Meaning | First action |
 | --- | --- | --- |
 | `version claim conflicts with source` | The image contains a static exact key already reserved by a dynamic publish. | Stop the rollout and follow **Exact-key collision** below. |
 | `catalog integrity failure` | Static inventory or persisted claim/artifact state violates an invariant. | Freeze catalog changes and follow **Integrity incident** below. |
-| DB timeout/deadlock/connectivity error after bounded retry | Infrastructure is unavailable; no source conflict has been proven. | Restore DB connectivity/capacity, then restart. Do not edit catalog rows. |
+| DB timeout/deadlock/connectivity error after bounded retry | Infrastructure is unavailable; no source conflict has been proven. | Restore DB connectivity/capacity and wait for retry; restart only if required by the wider incident. Do not edit catalog rows. |
+| Active target missing, blocked, hash/metadata mismatch, unsupported engine/owner, or missing interactive route | The persisted active pointer cannot be served safely by this image/config. | Freeze forward activation, inspect detail/audit, and use the last compatible image/config or the separately reviewed integrity procedure. |
 
-Use the identity from the panic log for read-only diagnosis. Do not select or
-export `canonical_bundle` during routine triage.
+Use the identity from the startup integrity log for read-only diagnosis. Do not
+select or export `canonical_bundle` during routine triage.
 
 ```sql
 SELECT c.template_id, c.version, c.source, c.created_at,
@@ -58,20 +95,80 @@ These are audit-only commits: they do not change claim or artifact state. If the
 audit insert or commit fails, the API returns unavailable rather than an
 unaudited conflict response.
 
+## Safe control procedure
+
+Use the manager read endpoints to obtain the authoritative version and
+`revision`; never guess a revision or infer rollback history from deployment
+notes:
+
+```text
+GET /v1/manager/card-templates/{id}
+GET /v1/manager/card-templates/{id}/audit?limit=50
+PUT /v1/manager/card-templates/{id}/active
+POST /v1/manager/card-templates/{id}/rollback
+POST /v1/manager/card-templates/{id}@{version}/block
+```
+
+The endpoints intentionally omit canonical bundles, schemas, samples, tokens,
+and callback secrets.
+
+### Activate
+
+1. Keep dynamic new-send disabled. Enable the forward control gate only in the
+   approved environment and only after all serving replicas run the PR-B image.
+2. Validate/publish the immutable artifact and review its hash, owner, protocol,
+   interaction contract, and route configuration. Publish accepts only the
+   reviewed runtime-owner allowlist and requires startup catalog readiness;
+   validate remains available for offline diagnostics.
+3. Read the current revision, then send an explicit target version and
+   `expected_revision`. A stale revision returns a conflict and must be
+   refreshed; do not blindly retry the old body.
+4. Confirm the success audit and resulting revision. Exercise exact resolution,
+   rollback, and block while new-send remains disabled. PR-B has no producer
+   grants, so activation drills must use a template ID that no Bot, notify path,
+   or other producer currently consumes; activating a dynamic version for a
+   consumed ID will correctly make that producer fail closed.
+
+### Rollback
+
+- Always name the target version. The server accepts only a version that the
+  audit history proves was previously active and that still passes artifact,
+  owner, block, compiler, and route validation.
+- Rollback remains available when the forward control gate is off. It performs
+  a revision CAS and writes the state change plus success audit in one
+  transaction.
+- A stale CAS is not retryable without first reading the new revision.
+
+### Emergency block
+
+- Block is dynamic-only, one-way, and remains available when forward activate
+  is disabled. There is no unblock or artifact rewrite operation.
+- If the blocked version is current active, provide an explicit known-good
+  fallback that was previously active, or omit fallback to atomically set the
+  template to `disabled`. The block, pointer transition, revision, and audit
+  commit together.
+- If the blocked version is not active, its block audit commits without changing
+  the active revision. Every replica re-reads authoritative block metadata even
+  on a compiled-cache hit, so a post-commit request cannot use a hot cache to
+  bypass the block.
+- Preserve the last successfully stored card payload for display; subsequent
+  render/edit/action-context operations for the blocked exact version fail.
+
 ## Exact-key collision
 
 This is the expected recovery path when a new image introduces a built-in
 `id@version` that was previously published dynamically.
 
 1. Stop or pause the rollout. Keep healthy replicas on the last known-good
-   image serving; do not scale them down while the replacement is crash-looping.
+   image serving; do not enable dynamic control/new-send while the replacement
+   reports catalog integrity failure.
 2. Roll back to the last image that does not register the conflicting static
    exact key. If that image cannot be deployed, build a corrective image that
    removes the new registration or assigns it a new version. This is the
    break-glass recovery path.
-3. Verify all serving replicas are ready and no longer emit reconciliation
-   panics. Confirm that the conflicting database claim and artifact are
-   unchanged.
+3. Verify all serving replicas report `startup_validate=ok` and no longer emit
+   catalog integrity logs. Confirm that the conflicting database claim and
+   artifact are unchanged.
 4. Assign the built-in content a new, canonical SemVer that has never been
    claimed. Update the embedded manifest and every explicit producer/catalog
    reference in the same reviewed change. Never reuse the dynamically claimed
@@ -97,8 +194,9 @@ no artifact during an idempotent publish.
 1. Stop the rollout and disable further catalog control-plane changes at the
    operational boundary (traffic/authorization), while leaving existing static
    messaging paths available where the last known-good image permits it.
-2. Capture the panic, image digest, exact identity, read-only query results, and
-   relevant audit rows. Take and verify a database snapshot before any repair.
+2. Capture the integrity log, image digest, exact identity, read-only query
+   results, and relevant audit rows. Take and verify a database snapshot before
+   any repair.
 3. Escalate to the catalog owner plus SRE/DBA. Treat unexplained direct database
    mutation as a security and audit event.
 4. Prepare a separate, two-person-reviewed repair plan with an explicit restore
@@ -111,16 +209,20 @@ no artifact during an idempotent publish.
 
 ## Exit criteria
 
-- All intended replicas run the same corrected image digest and pass startup.
-- Reconciliation completes without conflict/integrity errors on multiple fresh
-  starts.
+- All intended replicas run the same corrected image digest and emit
+  `startup_validate=ok`; `/v1/ready` reports
+  `dependencies.card_template_catalog=up`.
+- Reconciliation and active-target validation complete without
+  conflict/integrity errors on multiple fresh starts.
 - Every built-in exact key has `source='static'` and no artifact row.
 - The original dynamic collision rows remain unchanged unless a separately
   approved integrity repair was required.
-- PR-A remains dark: no activation, runtime overlay, dynamic discovery, or
-  dynamic send capability is inferred from successful publish/reconciliation.
+- Forward control/new-send gates are in the approved posture; successful
+  publish, reconciliation, or activation is not treated as a producer grant.
+- Multi-replica default resolution, explicit rollback, hot-cache block, process
+  restart, and DB-outage behavior have been exercised in the target environment.
 
-After PR-B/PR-C allow the first dynamic card to be sent, pre-E3 binary rollback
-is no longer safe for historical exact-version rendering. Their rollout
-runbooks must retain the runtime reader and use activate/rollback/block controls
-instead; this PR-A procedure must not be reused past that compatibility floor.
+After PR-C allows the first dynamic card to be sent, pre-PR-B binary rollback is
+not safe for historical exact-version rendering. Keep the runtime reader and use
+activate/rollback/block controls; do not reuse the PR-A-only rollback procedure
+past that compatibility floor.

--- a/main.go
+++ b/main.go
@@ -26,6 +26,8 @@ import (
 	commonapi "github.com/Mininglamp-OSS/octo-server/modules/base/common"
 	"github.com/Mininglamp-OSS/octo-server/modules/base/event"
 	"github.com/Mininglamp-OSS/octo-server/modules/botidentity"
+	cardtemplatecatalog "github.com/Mininglamp-OSS/octo-server/modules/card_template_catalog"
+	commonmodule "github.com/Mininglamp-OSS/octo-server/modules/common"
 	"github.com/Mininglamp-OSS/octo-server/modules/notify"
 	"github.com/Mininglamp-OSS/octo-server/modules/user"
 	"github.com/Mininglamp-OSS/octo-server/pkg/accesslog"
@@ -241,7 +243,16 @@ func runAPI(ctx *config.Context) {
 	if err := installCardDispatch(ctx); err != nil {
 		panic(fmt.Errorf("install internal card dispatch registry: %w", err))
 	}
-	installCardTmplRegistry() // pkg/cardtmpl L0 registry: pilot Templates + Freeze (fail-close)
+	cardTmplRegistry := installCardTmplRegistry() // built-ins: registration + Freeze
+	runtimeCatalog, err := cardtemplatecatalog.InstallRuntimeCatalog(
+		ctx.DB().DB,
+		cardTmplRegistry,
+		cardtmpl.RuntimeCatalogConfig{},
+	)
+	if err != nil {
+		panic(fmt.Errorf("install card template runtime catalog: %w", err))
+	}
+	commonmodule.SetCardTemplateCatalogReadinessCheck(runtimeCatalog.CheckReady)
 	cardActionRuntime, err := installCardActionDispatch(ctx)
 	if err != nil {
 		panic(fmt.Errorf("install card action callback dispatch: %w", err))
@@ -712,7 +723,7 @@ func replaceWebConfig(cfg *config.Config) {
 // Fail-close 契约:任一 Register/SetDefault 失败 → panic(与 main.go:521 现有的
 // docs approval callback route 校验同源)。init 期 schema/manifest 语法错无
 // runtime env 可挽救,回滚 = 镜像 revert。
-func installCardTmplRegistry() {
+func installCardTmplRegistry() *cardtmpl.Registry {
 	registry := cardtmpl.NewRegistry()
 	registry.Register(docsaccessrequest.New(), docsaccessrequest.Assets, docsaccessrequest.HandoffRoot)
 	registry.Register(docsaccessrequest.NewV3(), docsaccessrequest.Assets, docsaccessrequest.HandoffRootV3)
@@ -738,4 +749,5 @@ func installCardTmplRegistry() {
 	registry.Freeze()
 	cardtmpl.SetGlobalMetrics(cardtmpl.NewMetrics(prometheus.DefaultRegisterer))
 	cardtmpl.SetDefaultRegistry(registry)
+	return registry
 }

--- a/modules/bot_api/bot_api.go
+++ b/modules/bot_api/bot_api.go
@@ -221,9 +221,9 @@ func NewBotAPI(ctx *config.Context) *BotAPI {
 	}
 
 	var cardTemplates *botCardTemplateCatalog
-	if registry := cardtmpl.DefaultRegistry(); registry != nil {
+	if runtimeCatalog := cardtmpl.DefaultCatalog(); runtimeCatalog != nil {
 		var err error
-		cardTemplates, err = newBotCardTemplateCatalogWithPolicy(registry, defaultBotTemplatePolicy())
+		cardTemplates, err = newBotCardTemplateCatalogWithPolicy(runtimeCatalog, defaultBotTemplatePolicy())
 		if err != nil {
 			panic(fmt.Errorf("install Bot card template catalog: %w", err))
 		}

--- a/modules/bot_api/card_template_catalog.go
+++ b/modules/bot_api/card_template_catalog.go
@@ -8,13 +8,17 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/Mininglamp-OSS/octo-server/pkg/cardmsg"
 	"github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl"
 	aireasoningprocess "github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl/ai_reasoning_process"
 )
 
-const botTemplateWireV1 = "template-ref/v1"
+const (
+	botTemplateWireV1        = "template-ref/v1"
+	botTemplateLookupTimeout = 5 * time.Second
+)
 
 var (
 	errBotTemplateRequestInvalid     = errors.New("bot template request invalid")
@@ -51,7 +55,7 @@ type botTemplatingCapability struct {
 }
 
 type botCardTemplateCatalog struct {
-	registry    *cardtmpl.Registry
+	catalog     cardtmpl.Catalog
 	sendAllowed map[botTemplateRef]struct{}
 	editAllowed map[botTemplateRef]struct{}
 	capability  botTemplatingCapability
@@ -74,19 +78,20 @@ func defaultBotTemplatePolicy() botTemplatePolicy {
 	}
 }
 
-func newBotCardTemplateCatalog(registry *cardtmpl.Registry, refs []botTemplateRef) (*botCardTemplateCatalog, error) {
-	return newBotCardTemplateCatalogWithPolicy(registry, botTemplatePolicy{
+func newBotCardTemplateCatalog(source any, refs []botTemplateRef) (*botCardTemplateCatalog, error) {
+	return newBotCardTemplateCatalogWithPolicy(source, botTemplatePolicy{
 		AdvertisedSend: refs,
 		EditCompatible: refs,
 	})
 }
 
 func newBotCardTemplateCatalogWithPolicy(
-	registry *cardtmpl.Registry,
+	source any,
 	policy botTemplatePolicy,
 ) (*botCardTemplateCatalog, error) {
-	if registry == nil {
-		return nil, errBotTemplateCatalogUnavailable
+	runtimeCatalog, err := botRuntimeCatalog(source)
+	if err != nil {
+		return nil, err
 	}
 	if len(policy.AdvertisedSend) == 0 {
 		return nil, fmt.Errorf("bot template catalog: empty advertised/send allowlist")
@@ -95,7 +100,7 @@ func newBotCardTemplateCatalogWithPolicy(
 		return nil, fmt.Errorf("bot template catalog: empty edit-compatible allowlist")
 	}
 	catalog := &botCardTemplateCatalog{
-		registry:    registry,
+		catalog:     runtimeCatalog,
 		sendAllowed: make(map[botTemplateRef]struct{}, len(policy.AdvertisedSend)),
 		editAllowed: make(map[botTemplateRef]struct{}, len(policy.EditCompatible)),
 		capability: botTemplatingCapability{
@@ -111,11 +116,13 @@ func newBotCardTemplateCatalogWithPolicy(
 		if _, duplicate := catalog.sendAllowed[ref]; duplicate {
 			return nil, fmt.Errorf("bot template catalog: duplicate advertised/send %s@%s", ref.ID, ref.Version)
 		}
-		tmpl, err := registry.Lookup(ref.ID, ref.Version)
+		meta, err := lookupBotTemplateMeta(runtimeCatalog, cardtmpl.CatalogExactRequest{
+			Access: botCatalogAccess(cardtmpl.CatalogPurposeNewSend, "bot-api-manifest", ""),
+			ID:     ref.ID, Version: ref.Version,
+		})
 		if err != nil {
 			return nil, fmt.Errorf("bot template catalog: lookup %s@%s: %w", ref.ID, ref.Version, err)
 		}
-		meta := tmpl.Meta()
 		if meta.ID != ref.ID || meta.Version != ref.Version || len(meta.Views) == 0 {
 			return nil, fmt.Errorf("bot template catalog: incomplete metadata for %s@%s", ref.ID, ref.Version)
 		}
@@ -178,11 +185,13 @@ func newBotCardTemplateCatalogWithPolicy(
 		if _, duplicate := catalog.editAllowed[ref]; duplicate {
 			return nil, fmt.Errorf("bot template catalog: duplicate edit-compatible %s@%s", ref.ID, ref.Version)
 		}
-		tmpl, err := registry.Lookup(ref.ID, ref.Version)
+		meta, err := lookupBotTemplateMeta(runtimeCatalog, cardtmpl.CatalogExactRequest{
+			Access: botCatalogAccess(cardtmpl.CatalogPurposeHistoricalEdit, "bot-api-manifest", ""),
+			ID:     ref.ID, Version: ref.Version,
+		})
 		if err != nil {
 			return nil, fmt.Errorf("bot template catalog: edit-compatible lookup %s@%s: %w", ref.ID, ref.Version, err)
 		}
-		meta := tmpl.Meta()
 		if meta.ID != ref.ID || meta.Version != ref.Version || len(meta.Views) == 0 {
 			return nil, fmt.Errorf("bot template catalog: incomplete edit-compatible metadata for %s@%s", ref.ID, ref.Version)
 		}
@@ -233,7 +242,21 @@ func (c *botCardTemplateCatalog) RenderPayload(
 	if c == nil {
 		return nil, errBotTemplateCatalogUnavailable
 	}
-	return c.renderPayload(ctx, inbound, env, c.sendAllowed, "not Bot-callable for new send")
+	return c.renderPayload(ctx, "bot-api-compat", cardtmpl.CatalogPurposeNewSend,
+		inbound, env, c.sendAllowed, "not Bot-callable for new send")
+}
+
+func (c *botCardTemplateCatalog) RenderPayloadForPrincipal(
+	ctx context.Context,
+	botID string,
+	inbound map[string]any,
+	env cardtmpl.BuildEnv,
+) (map[string]any, error) {
+	if c == nil || strings.TrimSpace(botID) == "" {
+		return nil, errBotTemplateCatalogUnavailable
+	}
+	return c.renderPayload(ctx, botID, cardtmpl.CatalogPurposeNewSend,
+		inbound, env, c.sendAllowed, "not Bot-callable for new send")
 }
 
 func (c *botCardTemplateCatalog) RenderEditPayload(
@@ -244,17 +267,33 @@ func (c *botCardTemplateCatalog) RenderEditPayload(
 	if c == nil {
 		return nil, errBotTemplateCatalogUnavailable
 	}
-	return c.renderPayload(ctx, inbound, env, c.editAllowed, "not edit-compatible")
+	return c.renderPayload(ctx, "bot-api-compat", cardtmpl.CatalogPurposeHistoricalEdit,
+		inbound, env, c.editAllowed, "not edit-compatible")
+}
+
+func (c *botCardTemplateCatalog) RenderEditPayloadForPrincipal(
+	ctx context.Context,
+	botID string,
+	inbound map[string]any,
+	env cardtmpl.BuildEnv,
+) (map[string]any, error) {
+	if c == nil || strings.TrimSpace(botID) == "" {
+		return nil, errBotTemplateCatalogUnavailable
+	}
+	return c.renderPayload(ctx, botID, cardtmpl.CatalogPurposeHistoricalEdit,
+		inbound, env, c.editAllowed, "not edit-compatible")
 }
 
 func (c *botCardTemplateCatalog) renderPayload(
 	ctx context.Context,
+	botID string,
+	purpose cardtmpl.CatalogPurpose,
 	inbound map[string]any,
 	env cardtmpl.BuildEnv,
 	allowed map[botTemplateRef]struct{},
 	denialReason string,
 ) (map[string]any, error) {
-	if c == nil || c.registry == nil {
+	if c == nil || c.catalog == nil {
 		return nil, errBotTemplateCatalogUnavailable
 	}
 	if !cardmsg.IsCardPayload(inbound) {
@@ -294,7 +333,10 @@ func (c *botCardTemplateCatalog) renderPayload(
 	if err != nil {
 		return nil, fmt.Errorf("%w: marshal data: %v", errBotTemplateRequestInvalid, err)
 	}
-	rendered, err := c.registry.Render(ctx, ref.ID, ref.Version, cardtmpl.State(state), rawData, env)
+	rendered, err := c.catalog.Render(ctx, cardtmpl.CatalogRenderRequest{
+		Access: botCatalogAccess(purpose, botID, env.SpaceID),
+		ID:     ref.ID, Version: ref.Version, State: cardtmpl.State(state), Fields: rawData, Env: env,
+	})
 	if err != nil {
 		if errors.Is(err, cardtmpl.ErrFieldsInvalid) || errors.Is(err, cardtmpl.ErrStateUnknown) || errors.Is(err, cardtmpl.ErrTemplateUnknown) {
 			return nil, fmt.Errorf("%w: %v", errBotTemplateRequestInvalid, err)
@@ -330,7 +372,7 @@ func (c *botCardTemplateCatalog) requireRef(
 	allowed map[botTemplateRef]struct{},
 	denialReason string,
 ) (botTemplateRef, error) {
-	if c == nil || c.registry == nil {
+	if c == nil || c.catalog == nil {
 		return botTemplateRef{}, errBotTemplateCatalogUnavailable
 	}
 	ref, err := parseBotTemplateRef(value)
@@ -341,6 +383,47 @@ func (c *botCardTemplateCatalog) requireRef(
 		return botTemplateRef{}, fmt.Errorf("%w: %s", errBotTemplateRequestInvalid, denialReason)
 	}
 	return ref, nil
+}
+
+func lookupBotTemplateMeta(
+	catalog cardtmpl.Catalog,
+	request cardtmpl.CatalogExactRequest,
+) (cardtmpl.TemplateMeta, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), botTemplateLookupTimeout)
+	defer cancel()
+	return catalog.MetaExact(ctx, request)
+}
+
+func botRuntimeCatalog(source any) (cardtmpl.Catalog, error) {
+	switch typed := source.(type) {
+	case nil:
+		return nil, errBotTemplateCatalogUnavailable
+	case *cardtmpl.Registry:
+		if typed == nil {
+			return nil, errBotTemplateCatalogUnavailable
+		}
+		catalog, err := cardtmpl.NewStaticCatalog(typed)
+		if err != nil {
+			return nil, fmt.Errorf("bot template catalog: static adapter: %w", err)
+		}
+		return catalog, nil
+	case cardtmpl.Catalog:
+		if typed == nil {
+			return nil, errBotTemplateCatalogUnavailable
+		}
+		return typed, nil
+	default:
+		return nil, errBotTemplateCatalogUnavailable
+	}
+}
+
+func botCatalogAccess(purpose cardtmpl.CatalogPurpose, botID, spaceID string) cardtmpl.CatalogAccess {
+	return cardtmpl.CatalogAccess{
+		Purpose: purpose,
+		Principal: cardtmpl.CatalogPrincipal{
+			Kind: cardtmpl.CatalogPrincipalBot, ID: botID, SpaceID: spaceID,
+		},
+	}
 }
 
 func parseBotTemplateRef(value any) (botTemplateRef, error) {

--- a/modules/bot_api/card_template_catalog_test.go
+++ b/modules/bot_api/card_template_catalog_test.go
@@ -75,6 +75,41 @@ func TestBotCardTemplateCatalogSeparatesNewSendFromLegacyEdit(t *testing.T) {
 	}
 }
 
+func TestBotCardTemplateCatalogPassesAuthoritativePrincipalAndPurpose(t *testing.T) {
+	static, err := cardtmpl.NewStaticCatalog(testBotTemplateRegistry(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	spy := &botCatalogSpy{Catalog: static}
+	catalog, err := newBotCardTemplateCatalogWithPolicy(spy, defaultBotTemplatePolicy())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if spy.metaExactCalls == 0 || !spy.metaExactAllBounded {
+		t.Fatalf("constructor MetaExact calls/bounded = %d/%v, want calls > 0 and all bounded",
+			spy.metaExactCalls, spy.metaExactAllBounded)
+	}
+	payload := map[string]any{
+		"type": float64(17),
+		"template_ref": map[string]any{
+			"id": string(aireasoningprocess.TemplateID), "version": aireasoningprocess.TemplateVersionV2,
+		},
+		"state": "reasoning",
+		"data":  rawJSONToMap(t, testReasoningData(t, "reasoning")),
+	}
+	if _, err := catalog.RenderPayloadForPrincipal(
+		context.Background(), "bot-42", payload, cardtmpl.BuildEnv{SpaceID: "space-7"},
+	); err != nil {
+		t.Fatalf("RenderPayloadForPrincipal: %v", err)
+	}
+	if spy.lastRender.Access.Purpose != cardtmpl.CatalogPurposeNewSend ||
+		spy.lastRender.Access.Principal.Kind != cardtmpl.CatalogPrincipalBot ||
+		spy.lastRender.Access.Principal.ID != "bot-42" ||
+		spy.lastRender.Access.Principal.SpaceID != "space-7" {
+		t.Fatalf("catalog access = %+v", spy.lastRender.Access)
+	}
+}
+
 func TestBotCardTemplatePolicyRequiresEverySendRefToRemainEditable(t *testing.T) {
 	_, err := newBotCardTemplateCatalogWithPolicy(testBotTemplateRegistry(t), botTemplatePolicy{
 		AdvertisedSend: []botTemplateRef{{
@@ -394,4 +429,30 @@ func rawJSONToMap(t *testing.T, raw json.RawMessage) map[string]any {
 		t.Fatalf("unmarshal fixture: %v", err)
 	}
 	return out
+}
+
+type botCatalogSpy struct {
+	cardtmpl.Catalog
+	lastRender          cardtmpl.CatalogRenderRequest
+	metaExactCalls      int
+	metaExactAllBounded bool
+}
+
+func (s *botCatalogSpy) MetaExact(
+	ctx context.Context,
+	request cardtmpl.CatalogExactRequest,
+) (cardtmpl.TemplateMeta, error) {
+	_, bounded := ctx.Deadline()
+	if s.metaExactCalls == 0 {
+		s.metaExactAllBounded = bounded
+	} else {
+		s.metaExactAllBounded = s.metaExactAllBounded && bounded
+	}
+	s.metaExactCalls++
+	return s.Catalog.MetaExact(ctx, request)
+}
+
+func (s *botCatalogSpy) Render(ctx context.Context, request cardtmpl.CatalogRenderRequest) (map[string]any, error) {
+	s.lastRender = request
+	return s.Catalog.Render(ctx, request)
 }

--- a/modules/bot_api/card_template_edit_test.go
+++ b/modules/bot_api/card_template_edit_test.go
@@ -458,8 +458,12 @@ func initialRegistryEnvelopeVersion(
 		root = aireasoningprocess.HandoffRootV1
 	}
 	data := testReasoningDataVersion(t, root, state)
-	payload, err := catalog.registry.Render(context.Background(), aireasoningprocess.TemplateID,
-		version, cardtmpl.State(state), data, cardtmplBuildEnvForTest())
+	env := cardtmplBuildEnvForTest()
+	payload, err := catalog.catalog.Render(context.Background(), cardtmpl.CatalogRenderRequest{
+		Access: botCatalogAccess(cardtmpl.CatalogPurposeHistoricalEdit, "test-bot", env.SpaceID),
+		ID:     aireasoningprocess.TemplateID, Version: version,
+		State: cardtmpl.State(state), Fields: data, Env: env,
+	})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/bot_api/send.go
+++ b/modules/bot_api/send.go
@@ -250,7 +250,7 @@ func (ba *BotAPI) sendMessage(c *wkhttp.Context) {
 		if ba.ctx != nil && ba.ctx.GetConfig() != nil {
 			webLoginURL = ba.ctx.GetConfig().External.WebLoginURL
 		}
-		rendered, renderErr := ba.cardTemplates.RenderPayload(c.Request.Context(), req.Payload, cardtmpl.BuildEnv{
+		rendered, renderErr := ba.cardTemplates.RenderPayloadForPrincipal(c.Request.Context(), robotID, req.Payload, cardtmpl.BuildEnv{
 			WebLoginURL: webLoginURL,
 			Lang:        i18n.OutboundLanguage(c.Request.Context()),
 			SpaceID:     spaceID,
@@ -1216,7 +1216,7 @@ func (ba *BotAPI) botMessageEditViaRegistry(c *wkhttp.Context, req *botMessageEd
 		webLoginURL = ba.ctx.GetConfig().External.WebLoginURL
 	}
 	spaceID := effectiveEnvelopeSpaceID(snapshot.Envelope)
-	rendered, err := ba.cardTemplates.RenderEditPayload(c.Request.Context(), map[string]any{
+	rendered, err := ba.cardTemplates.RenderEditPayloadForPrincipal(c.Request.Context(), robotID, map[string]any{
 		"type":         cardmsg.InteractiveCard.Int(),
 		"template_ref": req.TemplateRef,
 		"state":        req.State,

--- a/modules/card_template_catalog/1module.go
+++ b/modules/card_template_catalog/1module.go
@@ -12,10 +12,24 @@ var sqlFS embed.FS
 
 func init() {
 	register.AddModule(func(ctx interface{}) register.Module {
+		var api *API
 		return register.Module{
 			Name: "card_template_catalog",
 			SetupAPI: func() register.APIRouter {
-				return New(ctx.(*config.Context))
+				api = New(ctx.(*config.Context))
+				return api
+			},
+			Start: func() error {
+				if api == nil {
+					return nil
+				}
+				return api.Start()
+			},
+			Stop: func() error {
+				if api == nil {
+					return nil
+				}
+				return api.Stop()
 			},
 			SQLDir: register.NewSQLFS(sqlFS),
 		}

--- a/modules/card_template_catalog/api.go
+++ b/modules/card_template_catalog/api.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"sort"
+	"sync"
 	"time"
 
 	"github.com/Mininglamp-OSS/octo-lib/config"
@@ -35,22 +36,39 @@ type catalogStore interface {
 type compileArtifactFunc func(context.Context, cardtmpl.Bundle, cardtmpl.CompileLimits) (*cardtmpl.CompiledArtifact, error)
 
 type API struct {
-	ctx     *config.Context
-	store   catalogStore
-	compile compileArtifactFunc
-	logger  log.Log
-	metrics *catalogMetrics
+	ctx                 *config.Context
+	store               catalogStore
+	compile             compileArtifactFunc
+	validateStateTarget func(context.Context, cardtmpl.ID, string) (stateTargetReceipt, error)
+	controlEnabled      bool
+	registry            *cardtmpl.Registry
+	readiness           *runtimeCatalogReadiness
+	startupMu           sync.Mutex
+	startupCancel       context.CancelFunc
+	startupDone         chan struct{}
+	logger              log.Log
+	metrics             *catalogMetrics
 }
 
 func New(ctx *config.Context) *API {
 	metrics := newCatalogMetrics(prometheus.DefaultRegisterer)
-	api := &API{
-		ctx:     ctx,
-		store:   newStore(ctx.DB().DB),
-		compile: cardtmpl.CompileJSONArtifact,
-		logger:  log.NewTLog("CardTemplateCatalog"),
-		metrics: metrics,
+	runtimeStore := installedRuntimeStore()
+	if runtimeStore == nil {
+		if !ctx.GetConfig().Test {
+			panic("card template catalog: RuntimeCatalog is not installed by the composition root")
+		}
+		runtimeStore = newStore(ctx.DB().DB)
 	}
+	api := &API{
+		ctx:            ctx,
+		store:          runtimeStore,
+		compile:        cardtmpl.CompileJSONArtifact,
+		controlEnabled: installedRuntimeGates().controlEnabled,
+		readiness:      installedRuntimeReadiness(),
+		logger:         log.NewTLog("CardTemplateCatalog"),
+		metrics:        metrics,
+	}
+	api.validateStateTarget = api.validateTarget
 	registry := cardtmpl.DefaultRegistry()
 	if registry == nil {
 		if !ctx.GetConfig().Test {
@@ -58,13 +76,10 @@ func New(ctx *config.Context) *API {
 		}
 		return api
 	}
-	reconcileCtx, cancel := context.WithTimeout(context.Background(), reconcileTimeout)
-	defer cancel()
-	if err := reconcileStaticInventory(reconcileCtx, api.store, registry); err != nil {
-		api.metrics.observeDB("reconcile_static", "error")
-		panic(fmt.Sprintf("card template catalog: reconcile static inventory: %v", err))
+	api.registry = registry
+	if api.readiness == nil && !ctx.GetConfig().Test {
+		panic("card template catalog: RuntimeCatalog readiness is not installed by the composition root")
 	}
-	api.metrics.observeDB("reconcile_static", "ok")
 	return api
 }
 
@@ -112,6 +127,11 @@ func (a *API) Route(r *wkhttp.WKHttp) {
 	)
 	manager.POST("/validate", a.validate)
 	manager.POST("/publish", a.publish)
+	manager.GET("/:id/audit", a.audit)
+	manager.GET("/:id", a.detail)
+	manager.PUT("/:id/active", a.activate)
+	manager.POST("/:id/rollback", a.rollback)
+	manager.POST("/:id/block", a.block)
 }
 
 type controlRequest struct {
@@ -158,6 +178,10 @@ func (a *API) publish(c *wkhttp.Context) {
 	if !a.requireSuperAdmin(c) {
 		return
 	}
+	if ready, result := a.requireRuntimeReady(c); !ready {
+		operationResult = result
+		return
+	}
 	request, bundle, ok := readControlRequest(c)
 	if !ok {
 		return
@@ -175,6 +199,10 @@ func (a *API) publish(c *wkhttp.Context) {
 	artifact, compileOutcome, ok := a.compileRequest(c, bundle)
 	if !ok {
 		operationResult = compileOutcome
+		return
+	}
+	if !isApprovedRuntimeOwner(artifact.Owner) {
+		respondCatalogRequestInvalid(c, ErrPublishRequestInvalid)
 		return
 	}
 	publishCtx, cancel := context.WithTimeout(c.Request.Context(), publishTimeout)
@@ -227,6 +255,22 @@ func (a *API) requireSuperAdmin(c *wkhttp.Context) bool {
 		return false
 	}
 	return true
+}
+
+func (a *API) requireRuntimeReady(c *wkhttp.Context) (bool, string) {
+	if a == nil || a.readiness == nil {
+		return true, "ok"
+	}
+	err := a.readiness.Check()
+	if err == nil {
+		return true, "ok"
+	}
+	if errors.Is(err, cardtmpl.ErrRuntimeCatalogIntegrity) {
+		respondCatalogIntegrityFailure(c)
+		return false, "integrity_error"
+	}
+	respondCatalogUnavailable(c)
+	return false, "unavailable"
 }
 
 func readControlRequest(c *wkhttp.Context) (controlRequest, cardtmpl.Bundle, bool) {

--- a/modules/card_template_catalog/api_additional_test.go
+++ b/modules/card_template_catalog/api_additional_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
 	"github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl"
@@ -15,6 +16,36 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 )
+
+func TestNewDoesNotPerformStartupDatabaseWrites(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	registry := cardtmpl.NewRegistry()
+	registry.Freeze()
+	previousRegistry := cardtmpl.DefaultRegistry()
+	previousStore := installedRuntimeStore()
+	cardtmpl.SetDefaultRegistry(registry)
+	setInstalledRuntimeStore(newStore(db))
+	t.Cleanup(func() {
+		cardtmpl.SetDefaultRegistry(previousRegistry)
+		setInstalledRuntimeStore(previousStore)
+	})
+
+	cfg := config.New()
+	cfg.Test = true
+	ctx := config.NewContext(cfg)
+	api := New(ctx)
+	if api == nil {
+		t.Fatal("New returned nil API")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("New performed a startup DB operation: %v", err)
+	}
+}
 
 func TestNewInTestModeAllowsUninstalledStaticRegistry(t *testing.T) {
 	previous := cardtmpl.DefaultRegistry()
@@ -128,6 +159,23 @@ func TestPublishRejectsMissingAuditFieldsBeforeCompile(t *testing.T) {
 	assertCatalogError(t, response, "err.server.card_template_catalog.request_invalid", http.StatusBadRequest)
 	if compilerCalls != 0 {
 		t.Fatalf("compiler called %d times before audit-field validation", compilerCalls)
+	}
+}
+
+func TestPublishRejectsUnapprovedOwnerBeforeStore(t *testing.T) {
+	store := &fakeCatalogStore{}
+	artifact := compiledArtifactFixture()
+	artifact.Owner = "ext.vendor"
+	api := &API{
+		store: store,
+		compile: func(context.Context, cardtmpl.Bundle, cardtmpl.CompileLimits) (*cardtmpl.CompiledArtifact, error) {
+			return artifact, nil
+		},
+	}
+	response := doCatalogRequest(t, api, wkhttp.SuperAdmin, "/publish", validControlRequestJSON(t, true))
+	assertCatalogError(t, response, "err.server.card_template_catalog.request_invalid", http.StatusBadRequest)
+	if store.publishCalls != 0 {
+		t.Fatalf("publish store calls = %d, want 0", store.publishCalls)
 	}
 }
 

--- a/modules/card_template_catalog/api_i18n.go
+++ b/modules/card_template_catalog/api_i18n.go
@@ -43,6 +43,18 @@ func respondCatalogUnavailable(c *wkhttp.Context) {
 	httperr.ResponseErrorL(c, errcode.ErrCardTemplateCatalogUnavailable, nil, nil)
 }
 
+func respondCatalogControlDisabled(c *wkhttp.Context) {
+	httperr.ResponseErrorL(c, errcode.ErrCardTemplateCatalogControlDisabled, nil, nil)
+}
+
+func respondCatalogStateConflict(c *wkhttp.Context) {
+	httperr.ResponseErrorL(c, errcode.ErrCardTemplateCatalogStateConflict, nil, nil)
+}
+
+func respondCatalogBlocked(c *wkhttp.Context) {
+	httperr.ResponseErrorL(c, errcode.ErrCardTemplateCatalogBlocked, nil, nil)
+}
+
 func respondCatalogIntegrityFailure(c *wkhttp.Context) {
 	httperr.ResponseErrorL(c, errcode.ErrSharedInternal, nil, nil)
 }

--- a/modules/card_template_catalog/api_state.go
+++ b/modules/card_template_catalog/api_state.go
@@ -1,0 +1,497 @@
+package card_template_catalog
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl"
+	"go.uber.org/zap"
+)
+
+const stateControlTimeout = 10 * time.Second
+
+var (
+	managerTemplateIDPattern = regexp.MustCompile(`^[a-z][a-z0-9]*(?:[.-][a-z0-9][a-z0-9-]*)+$`)
+	managerVersionPattern    = regexp.MustCompile(
+		`^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)` +
+			`(?:-(?:0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*))*)?` +
+			`(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$`,
+	)
+)
+
+type catalogStateStore interface {
+	Activate(context.Context, ActivationRequest) (ActivationResult, error)
+	Rollback(context.Context, RollbackRequest) (ActivationResult, error)
+	Block(context.Context, BlockRequest) (BlockResult, error)
+	GetTemplateDetail(context.Context, cardtmpl.ID, int) (TemplateDetail, error)
+	ListAudit(context.Context, cardtmpl.ID, uint64, int) (TemplateAuditPage, error)
+}
+
+type activateControlRequest struct {
+	Version          string `json:"version"`
+	ExpectedRevision uint64 `json:"expected_revision"`
+	Reason           string `json:"reason"`
+	ChangeTicket     string `json:"change_ticket"`
+}
+
+type rollbackControlRequest struct {
+	TargetVersion    string `json:"target_version"`
+	ExpectedRevision uint64 `json:"expected_revision"`
+	Reason           string `json:"reason"`
+	ChangeTicket     string `json:"change_ticket"`
+}
+
+type blockControlRequest struct {
+	ExpectedRevision uint64 `json:"expected_revision"`
+	FallbackVersion  string `json:"fallback_version,omitempty"`
+	Reason           string `json:"reason"`
+	ChangeTicket     string `json:"change_ticket"`
+}
+
+type activationControlResponse struct {
+	TemplateID       string `json:"template_id"`
+	PreviousVersion  string `json:"previous_version,omitempty"`
+	ActiveVersion    string `json:"active_version,omitempty"`
+	Status           string `json:"status"`
+	PreviousRevision uint64 `json:"previous_revision"`
+	Revision         uint64 `json:"revision"`
+}
+
+type blockControlResponse struct {
+	TemplateID       string `json:"template_id"`
+	Version          string `json:"version"`
+	Blocked          bool   `json:"blocked"`
+	PreviousVersion  string `json:"previous_version,omitempty"`
+	ActiveVersion    string `json:"active_version,omitempty"`
+	Status           string `json:"status,omitempty"`
+	PreviousRevision uint64 `json:"previous_revision"`
+	Revision         uint64 `json:"revision"`
+}
+
+func (a *API) activate(c *wkhttp.Context) {
+	resultLabel := "rejected"
+	defer func() { a.metrics.observeOperation("activate", resultLabel) }()
+	if !a.requireSuperAdmin(c) {
+		return
+	}
+	if !a.controlEnabled {
+		resultLabel = "disabled"
+		respondCatalogControlDisabled(c)
+		return
+	}
+	if ready, result := a.requireRuntimeReady(c); !ready {
+		resultLabel = result
+		return
+	}
+	id, ok := parseManagerTemplateID(c.Param("id"))
+	if !ok {
+		respondCatalogRequestInvalid(c, ErrPublishRequestInvalid)
+		return
+	}
+	var request activateControlRequest
+	if !readStrictStateRequest(c, &request, "version", "expected_revision", "reason", "change_ticket") {
+		return
+	}
+	if !validManagerVersion(request.Version) || !validStateControlText(request.Reason, request.ChangeTicket) {
+		respondCatalogRequestInvalid(c, ErrPublishRequestInvalid)
+		return
+	}
+	if a.validateStateTarget == nil {
+		respondCatalogUnavailable(c)
+		return
+	}
+	ctx, cancel := context.WithTimeout(c.Request.Context(), stateControlTimeout)
+	defer cancel()
+	receipt, err := a.validateStateTarget(ctx, id, request.Version)
+	if err != nil {
+		resultLabel = a.respondStateError(c, "activate_validate", err)
+		return
+	}
+	store, ok := a.stateStore(c)
+	if !ok {
+		return
+	}
+	result, err := store.Activate(ctx, ActivationRequest{
+		TemplateID: id, TargetVersion: request.Version, ExpectedRevision: request.ExpectedRevision,
+		ActorUID: c.GetLoginUID(), Reason: request.Reason, ChangeTicket: request.ChangeTicket,
+		targetReceipt: receipt,
+	})
+	if err != nil {
+		resultLabel = a.respondStateError(c, "activate", err)
+		return
+	}
+	resultLabel = "ok"
+	a.metrics.observeDB("activate", "ok")
+	c.Response(activationResponse(result))
+}
+
+func (a *API) rollback(c *wkhttp.Context) {
+	resultLabel := "rejected"
+	defer func() { a.metrics.observeOperation("rollback", resultLabel) }()
+	if !a.requireSuperAdmin(c) {
+		return
+	}
+	if ready, result := a.requireRuntimeReady(c); !ready {
+		resultLabel = result
+		return
+	}
+	id, ok := parseManagerTemplateID(c.Param("id"))
+	if !ok {
+		respondCatalogRequestInvalid(c, ErrPublishRequestInvalid)
+		return
+	}
+	var request rollbackControlRequest
+	if !readStrictStateRequest(c, &request, "target_version", "expected_revision", "reason", "change_ticket") {
+		return
+	}
+	if !validManagerVersion(request.TargetVersion) || !validStateControlText(request.Reason, request.ChangeTicket) {
+		respondCatalogRequestInvalid(c, ErrPublishRequestInvalid)
+		return
+	}
+	if a.validateStateTarget == nil {
+		respondCatalogUnavailable(c)
+		return
+	}
+	ctx, cancel := context.WithTimeout(c.Request.Context(), stateControlTimeout)
+	defer cancel()
+	receipt, err := a.validateStateTarget(ctx, id, request.TargetVersion)
+	if err != nil {
+		resultLabel = a.respondStateError(c, "rollback_validate", err)
+		return
+	}
+	store, ok := a.stateStore(c)
+	if !ok {
+		return
+	}
+	result, err := store.Rollback(ctx, RollbackRequest{
+		TemplateID: id, TargetVersion: request.TargetVersion, ExpectedRevision: request.ExpectedRevision,
+		ActorUID: c.GetLoginUID(), Reason: request.Reason, ChangeTicket: request.ChangeTicket,
+		targetReceipt: receipt,
+	})
+	if err != nil {
+		resultLabel = a.respondStateError(c, "rollback", err)
+		return
+	}
+	resultLabel = "ok"
+	a.metrics.observeDB("rollback", "ok")
+	c.Response(activationResponse(result))
+}
+
+func (a *API) block(c *wkhttp.Context) {
+	resultLabel := "rejected"
+	defer func() { a.metrics.observeOperation("block", resultLabel) }()
+	if !a.requireSuperAdmin(c) {
+		return
+	}
+	if ready, result := a.requireRuntimeReady(c); !ready {
+		resultLabel = result
+		return
+	}
+	id, version, ok := parseManagerIdentity(c.Param("id"))
+	if !ok {
+		respondCatalogRequestInvalid(c, ErrPublishRequestInvalid)
+		return
+	}
+	var request blockControlRequest
+	if !readStrictStateRequest(c, &request, "expected_revision", "reason", "change_ticket") {
+		return
+	}
+	if (request.FallbackVersion != "" && !validManagerVersion(request.FallbackVersion)) ||
+		!validStateControlText(request.Reason, request.ChangeTicket) {
+		respondCatalogRequestInvalid(c, ErrPublishRequestInvalid)
+		return
+	}
+	ctx, cancel := context.WithTimeout(c.Request.Context(), stateControlTimeout)
+	defer cancel()
+	var fallbackReceipt stateTargetReceipt
+	if request.FallbackVersion != "" {
+		if a.validateStateTarget == nil {
+			respondCatalogUnavailable(c)
+			return
+		}
+		var err error
+		fallbackReceipt, err = a.validateStateTarget(ctx, id, request.FallbackVersion)
+		if err != nil {
+			resultLabel = a.respondStateError(c, "block_fallback_validate", err)
+			return
+		}
+	}
+	store, ok := a.stateStore(c)
+	if !ok {
+		return
+	}
+	result, err := store.Block(ctx, BlockRequest{
+		TemplateID: id, Version: version, ExpectedRevision: request.ExpectedRevision,
+		FallbackVersion: request.FallbackVersion, ActorUID: c.GetLoginUID(),
+		Reason: request.Reason, ChangeTicket: request.ChangeTicket,
+		fallbackReceipt: fallbackReceipt,
+	})
+	if err != nil {
+		resultLabel = a.respondStateError(c, "block", err)
+		return
+	}
+	resultLabel = "ok"
+	a.metrics.observeDB("block", "ok")
+	c.Response(blockControlResponse{
+		TemplateID: string(result.TemplateID), Version: result.Version, Blocked: result.Blocked,
+		PreviousVersion: result.PreviousVersion, ActiveVersion: result.ActiveVersion, Status: string(result.Status),
+		PreviousRevision: result.PreviousRevision, Revision: result.Revision,
+	})
+}
+
+func (a *API) detail(c *wkhttp.Context) {
+	if !a.requireSuperAdmin(c) {
+		return
+	}
+	id, ok := parseManagerTemplateID(c.Param("id"))
+	if !ok {
+		respondCatalogRequestInvalid(c, ErrPublishRequestInvalid)
+		return
+	}
+	store, ok := a.stateStore(c)
+	if !ok {
+		return
+	}
+	ctx, cancel := context.WithTimeout(c.Request.Context(), stateControlTimeout)
+	defer cancel()
+	detail, err := store.GetTemplateDetail(ctx, id, managerReadHardLimit)
+	if err != nil {
+		a.respondStateError(c, "detail", err)
+		return
+	}
+	c.Response(templateDetailResponse(detail))
+}
+
+func (a *API) audit(c *wkhttp.Context) {
+	if !a.requireSuperAdmin(c) {
+		return
+	}
+	id, ok := parseManagerTemplateID(c.Param("id"))
+	if !ok {
+		respondCatalogRequestInvalid(c, ErrPublishRequestInvalid)
+		return
+	}
+	limit, err := parseBoundedUintQuery(c.Query("limit"), managerReadDefaultLimit, managerReadHardLimit)
+	if err != nil {
+		respondCatalogRequestInvalid(c, err)
+		return
+	}
+	cursor, err := parseBoundedUintQuery(c.Query("cursor"), 0, int(^uint(0)>>1))
+	if err != nil {
+		respondCatalogRequestInvalid(c, err)
+		return
+	}
+	store, ok := a.stateStore(c)
+	if !ok {
+		return
+	}
+	ctx, cancel := context.WithTimeout(c.Request.Context(), stateControlTimeout)
+	defer cancel()
+	page, err := store.ListAudit(ctx, id, uint64(cursor), limit)
+	if err != nil {
+		a.respondStateError(c, "audit", err)
+		return
+	}
+	c.Response(templateAuditResponse(page))
+}
+
+func (a *API) stateStore(c *wkhttp.Context) (catalogStateStore, bool) {
+	store, ok := a.store.(catalogStateStore)
+	if !ok || store == nil {
+		respondCatalogUnavailable(c)
+		return nil, false
+	}
+	return store, true
+}
+
+func (a *API) respondStateError(c *wkhttp.Context, operation string, err error) string {
+	switch {
+	case errors.Is(err, ErrActivationConflict):
+		a.metrics.observeDB(operation, "conflict")
+		respondCatalogStateConflict(c)
+		return "conflict"
+	case errors.Is(err, ErrArtifactBlocked):
+		a.metrics.observeDB(operation, "blocked")
+		respondCatalogBlocked(c)
+		return "blocked"
+	case errors.Is(err, ErrActivationTargetInvalid), errors.Is(err, ErrBlockTargetInvalid),
+		errors.Is(err, ErrRollbackTargetInvalid), errors.Is(err, ErrPublishRequestInvalid),
+		errors.Is(err, cardtmpl.ErrTemplateUnknown):
+		a.metrics.observeDB(operation, "rejected")
+		respondCatalogRequestInvalid(c, err)
+		return "rejected"
+	case errors.Is(err, ErrCatalogIntegrity), errors.Is(err, cardtmpl.ErrRuntimeCatalogIntegrity):
+		a.metrics.observeDB(operation, "integrity_error")
+		a.logStateError("card template catalog integrity failure", operation, err)
+		respondCatalogIntegrityFailure(c)
+		return "integrity_error"
+	case errors.Is(err, context.Canceled):
+		a.metrics.observeDB(operation, "canceled")
+		respondCatalogUnavailable(c)
+		return "canceled"
+	case errors.Is(err, context.DeadlineExceeded), errors.Is(err, cardtmpl.ErrArtifactCompileBusy):
+		a.metrics.observeDB(operation, "timeout")
+		respondCatalogUnavailable(c)
+		return "timeout"
+	default:
+		a.metrics.observeDB(operation, "error")
+		a.logStateError("card template catalog state operation failed", operation, err)
+		respondCatalogUnavailable(c)
+		return "error"
+	}
+}
+
+func (a *API) logStateError(message, operation string, err error) {
+	if a.logger != nil {
+		a.logger.Error(message, zap.String("operation", operation), zap.Error(err))
+	}
+}
+
+func readStrictStateRequest(c *wkhttp.Context, out any, required ...string) bool {
+	c.Request.Body = http.MaxBytesReader(c.Writer, c.Request.Body, controlBodyMaxBytes)
+	raw, err := io.ReadAll(c.Request.Body)
+	if err != nil {
+		var maxBytesErr *http.MaxBytesError
+		if errors.As(err, &maxBytesErr) {
+			respondCatalogContentTooLarge(c)
+		} else {
+			respondCatalogRequestInvalid(c, err)
+		}
+		return false
+	}
+	root, err := cardtmpl.DecodeStrictJSONObject(raw)
+	if err != nil {
+		respondCatalogRequestInvalid(c, err)
+		return false
+	}
+	for key, value := range root {
+		if value == nil {
+			respondCatalogRequestInvalid(c, fmt.Errorf("request field %q must not be null", key))
+			return false
+		}
+	}
+	for _, key := range required {
+		value, exists := root[key]
+		if !exists || value == nil {
+			respondCatalogRequestInvalid(c, fmt.Errorf("request field %q is required", key))
+			return false
+		}
+	}
+	if err := cardtmpl.DecodeStrictJSON(raw, out); err != nil {
+		respondCatalogRequestInvalid(c, err)
+		return false
+	}
+	return true
+}
+
+func parseManagerTemplateID(raw string) (cardtmpl.ID, bool) {
+	return cardtmpl.ID(raw), len(raw) <= 128 && managerTemplateIDPattern.MatchString(raw)
+}
+
+func parseManagerIdentity(raw string) (cardtmpl.ID, string, bool) {
+	index := strings.LastIndexByte(raw, '@')
+	if index <= 0 || index == len(raw)-1 {
+		return "", "", false
+	}
+	id, ok := parseManagerTemplateID(raw[:index])
+	version := raw[index+1:]
+	return id, version, ok && validManagerVersion(version)
+}
+
+func validManagerVersion(version string) bool {
+	return len(version) <= 64 && managerVersionPattern.MatchString(version)
+}
+
+func validStateControlText(reason, ticket string) bool {
+	return boundedRequiredText(reason, maxReasonRunes) && boundedRequiredText(ticket, maxChangeTicketRunes)
+}
+
+func parseBoundedUintQuery(raw string, fallback, hardMax int) (int, error) {
+	if raw == "" {
+		return fallback, nil
+	}
+	value, err := strconv.ParseUint(raw, 10, 63)
+	if err != nil {
+		return 0, errors.New("invalid unsigned query value")
+	}
+	if value > uint64(hardMax) {
+		value = uint64(hardMax)
+	}
+	return int(value), nil
+}
+
+func activationResponse(result ActivationResult) activationControlResponse {
+	return activationControlResponse{
+		TemplateID: string(result.TemplateID), PreviousVersion: result.PreviousVersion,
+		ActiveVersion: result.ActiveVersion, Status: string(result.Status),
+		PreviousRevision: result.PreviousRevision, Revision: result.Revision,
+	}
+}
+
+type activationReadResponse struct {
+	Exists   bool   `json:"exists"`
+	Version  string `json:"version,omitempty"`
+	Status   string `json:"status,omitempty"`
+	Revision uint64 `json:"revision"`
+}
+
+type versionReadResponse struct {
+	Version         string                 `json:"version"`
+	Source          cardtmpl.RuntimeSource `json:"source"`
+	Owner           string                 `json:"owner,omitempty"`
+	Visibility      string                 `json:"visibility,omitempty"`
+	Engine          string                 `json:"engine,omitempty"`
+	Protocol        string                 `json:"protocol,omitempty"`
+	ContractVersion string                 `json:"contract_version,omitempty"`
+	Hash            string                 `json:"content_sha256,omitempty"`
+	Blocked         bool                   `json:"blocked"`
+	BlockedAt       *time.Time             `json:"blocked_at,omitempty"`
+	CreatedAt       time.Time              `json:"created_at"`
+}
+
+type detailReadResponse struct {
+	TemplateID string                 `json:"template_id"`
+	Activation activationReadResponse `json:"activation"`
+	Versions   []versionReadResponse  `json:"versions"`
+	Truncated  bool                   `json:"truncated"`
+}
+
+func templateDetailResponse(detail TemplateDetail) detailReadResponse {
+	response := detailReadResponse{
+		TemplateID: detail.TemplateID,
+		Activation: activationReadResponse{
+			Exists: detail.Activation.Exists, Version: detail.Activation.Version,
+			Status: string(detail.Activation.Status), Revision: detail.Activation.Revision,
+		},
+		Versions: make([]versionReadResponse, len(detail.Versions)), Truncated: detail.Truncated,
+	}
+	for i, version := range detail.Versions {
+		response.Versions[i] = versionReadResponse{
+			Version: version.Version, Source: version.Source, Owner: version.Owner,
+			Visibility: version.Visibility, Engine: version.Engine, Protocol: version.Protocol,
+			ContractVersion: version.ContractVersion, Hash: version.Hash, Blocked: version.Blocked,
+			BlockedAt: version.BlockedAt, CreatedAt: version.CreatedAt,
+		}
+	}
+	return response
+}
+
+type auditReadResponse struct {
+	Entries    []TemplateAuditEntry `json:"entries"`
+	NextCursor uint64               `json:"next_cursor,omitempty"`
+}
+
+func templateAuditResponse(page TemplateAuditPage) auditReadResponse {
+	if page.Entries == nil {
+		page.Entries = []TemplateAuditEntry{}
+	}
+	return auditReadResponse{Entries: page.Entries, NextCursor: page.NextCursor}
+}

--- a/modules/card_template_catalog/api_state_test.go
+++ b/modules/card_template_catalog/api_state_test.go
@@ -1,0 +1,363 @@
+package card_template_catalog
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl"
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+func TestActivateGateDefaultsClosedAndDoesNotTouchStore(t *testing.T) {
+	store := &fakeStateCatalogStore{}
+	api := &API{store: store, controlEnabled: false}
+	response := doStateRequest(t, api, wkhttp.SuperAdmin, http.MethodPut,
+		"/test.runtime-card/active", `{"version":"1.0.0","expected_revision":0,"reason":"rollout","change_ticket":"CHG-1"}`)
+	assertCatalogError(t, response, "err.server.card_template_catalog.control_disabled", http.StatusServiceUnavailable)
+	if store.activateCalls != 0 {
+		t.Fatalf("activate calls = %d, want 0", store.activateCalls)
+	}
+}
+
+func TestRuntimeReadinessRejectsStateWritesBeforeTargetValidation(t *testing.T) {
+	store := &fakeStateCatalogStore{}
+	validateCalls := 0
+	api := &API{
+		store: store, controlEnabled: true, readiness: newRuntimeCatalogReadiness(),
+		validateStateTarget: func(context.Context, cardtmpl.ID, string) (stateTargetReceipt, error) {
+			validateCalls++
+			return stateTargetReceipt{}, nil
+		},
+	}
+	response := doStateRequest(t, api, wkhttp.SuperAdmin, http.MethodPut,
+		"/test.runtime-card/active", `{"version":"1.0.0","expected_revision":0,"reason":"rollout","change_ticket":"CHG-1"}`)
+	assertCatalogError(t, response, "err.server.card_template_catalog.unavailable", http.StatusServiceUnavailable)
+	if validateCalls != 0 || store.activateCalls != 0 {
+		t.Fatalf("validation/store calls = %d/%d, want 0/0", validateCalls, store.activateCalls)
+	}
+}
+
+func TestActivateValidatesTargetAndUsesAuthenticatedActor(t *testing.T) {
+	store := &fakeStateCatalogStore{activateResult: ActivationResult{
+		TemplateID: "test.runtime-card", ActiveVersion: "1.0.0", Status: activationStatusActive, Revision: 1,
+	}}
+	validated := ""
+	api := &API{
+		store: store, controlEnabled: true,
+		validateStateTarget: func(_ context.Context, id cardtmpl.ID, version string) (stateTargetReceipt, error) {
+			validated = string(id) + "@" + version
+			return dynamicTargetReceiptFixture(id, version, strings.Repeat("a", 64)), nil
+		},
+	}
+	response := doStateRequest(t, api, wkhttp.SuperAdmin, http.MethodPut,
+		"/test.runtime-card/active", `{"version":"1.0.0","expected_revision":0,"reason":"rollout","change_ticket":"CHG-1"}`)
+	if response.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", response.Code, response.Body.String())
+	}
+	if validated != "test.runtime-card@1.0.0" || store.activateCalls != 1 || store.lastActivate.ActorUID != "admin-1" {
+		t.Fatalf("validated=%q calls=%d request=%+v", validated, store.activateCalls, store.lastActivate)
+	}
+}
+
+func TestRollbackAndBlockRemainAvailableWhenForwardControlDisabled(t *testing.T) {
+	store := &fakeStateCatalogStore{
+		rollbackResult: ActivationResult{
+			TemplateID: "test.runtime-card", ActiveVersion: "1.0.0", Status: activationStatusActive, Revision: 5,
+		},
+		blockResult: BlockResult{
+			TemplateID: "test.runtime-card", Version: "1.1.0", Blocked: true,
+			Status: activationStatusDisabled, Revision: 6,
+		},
+	}
+	api := &API{
+		store: store, controlEnabled: false,
+		validateStateTarget: func(_ context.Context, id cardtmpl.ID, version string) (stateTargetReceipt, error) {
+			return dynamicTargetReceiptFixture(id, version, strings.Repeat("a", 64)), nil
+		},
+	}
+	rollback := doStateRequest(t, api, wkhttp.SuperAdmin, http.MethodPost,
+		"/test.runtime-card/rollback", `{"target_version":"1.0.0","expected_revision":4,"reason":"incident","change_ticket":"INC-1"}`)
+	if rollback.Code != http.StatusOK || store.rollbackCalls != 1 {
+		t.Fatalf("rollback status=%d calls=%d body=%s", rollback.Code, store.rollbackCalls, rollback.Body.String())
+	}
+	block := doStateRequest(t, api, wkhttp.SuperAdmin, http.MethodPost,
+		"/test.runtime-card@1.1.0/block", `{"expected_revision":5,"reason":"security","change_ticket":"SEC-1"}`)
+	if block.Code != http.StatusOK || store.blockCalls != 1 {
+		t.Fatalf("block status=%d calls=%d body=%s", block.Code, store.blockCalls, block.Body.String())
+	}
+}
+
+func TestStateWritesRejectUnknownFieldsBeforeValidation(t *testing.T) {
+	store := &fakeStateCatalogStore{}
+	validateCalls := 0
+	api := &API{
+		store: store, controlEnabled: true,
+		validateStateTarget: func(context.Context, cardtmpl.ID, string) (stateTargetReceipt, error) {
+			validateCalls++
+			return stateTargetReceipt{}, nil
+		},
+	}
+	response := doStateRequest(t, api, wkhttp.SuperAdmin, http.MethodPut,
+		"/test.runtime-card/active", `{"version":"1.0.0","expected_revision":0,"reason":"rollout","change_ticket":"CHG-1","actor_uid":"spoof"}`)
+	assertCatalogError(t, response, "err.server.card_template_catalog.request_invalid", http.StatusBadRequest)
+	if validateCalls != 0 || store.activateCalls != 0 {
+		t.Fatalf("validation/store calls = %d/%d, want 0/0", validateCalls, store.activateCalls)
+	}
+}
+
+func TestStateWritesRejectNullExpectedRevisionBeforeValidation(t *testing.T) {
+	store := &fakeStateCatalogStore{}
+	validateCalls := 0
+	api := &API{
+		store: store, controlEnabled: true,
+		validateStateTarget: func(context.Context, cardtmpl.ID, string) (stateTargetReceipt, error) {
+			validateCalls++
+			return stateTargetReceipt{}, nil
+		},
+	}
+	response := doStateRequest(t, api, wkhttp.SuperAdmin, http.MethodPut,
+		"/test.runtime-card/active", `{"version":"1.0.0","expected_revision":null,"reason":"rollout","change_ticket":"CHG-1"}`)
+	assertCatalogError(t, response, "err.server.card_template_catalog.request_invalid", http.StatusBadRequest)
+	if validateCalls != 0 || store.activateCalls != 0 {
+		t.Fatalf("validation/store calls = %d/%d, want 0/0", validateCalls, store.activateCalls)
+	}
+}
+
+func TestBlockRejectsNullOptionalFallbackBeforeStore(t *testing.T) {
+	store := &fakeStateCatalogStore{}
+	api := &API{store: store}
+	response := doStateRequest(t, api, wkhttp.SuperAdmin, http.MethodPost,
+		"/test.runtime-card@1.0.0/block", `{"expected_revision":1,"fallback_version":null,"reason":"incident","change_ticket":"INC-1"}`)
+	assertCatalogError(t, response, "err.server.card_template_catalog.request_invalid", http.StatusBadRequest)
+	if store.blockCalls != 0 {
+		t.Fatalf("block store calls = %d, want 0", store.blockCalls)
+	}
+}
+
+func TestManagerDetailAndAuditAreBoundedAndOmitBundle(t *testing.T) {
+	now := time.Date(2026, 7, 28, 12, 0, 0, 0, time.UTC)
+	store := &fakeStateCatalogStore{
+		detail: TemplateDetail{
+			TemplateID: "test.runtime-card",
+			Activation: cardtmpl.RuntimeActivation{Exists: true, Version: "1.0.0", Status: cardtmpl.RuntimeActivationActive, Revision: 1},
+			Versions:   []TemplateVersionDetail{{Version: "1.0.0", Source: cardtmpl.RuntimeSourceDynamic, Hash: "abc", CreatedAt: now}},
+		},
+		auditPage: TemplateAuditPage{Entries: []TemplateAuditEntry{{
+			ID: 9, ActorUID: "admin-1", Operation: "activate", Version: "1.0.0", Result: "ok", CreatedAt: now,
+		}}},
+	}
+	api := &API{store: store}
+	detail := doStateRequest(t, api, wkhttp.SuperAdmin, http.MethodGet, "/test.runtime-card", "")
+	if detail.Code != http.StatusOK || bytes.Contains(detail.Body.Bytes(), []byte("canonical_bundle")) {
+		t.Fatalf("detail status=%d body=%s", detail.Code, detail.Body.String())
+	}
+	audit := doStateRequest(t, api, wkhttp.SuperAdmin, http.MethodGet, "/test.runtime-card/audit?limit=1000", "")
+	if audit.Code != http.StatusOK || store.lastAuditLimit != managerReadHardLimit {
+		t.Fatalf("audit status=%d limit=%d body=%s", audit.Code, store.lastAuditLimit, audit.Body.String())
+	}
+}
+
+func TestManagerDetailAndAuditRemainAvailableWhileRuntimeIsNotReady(t *testing.T) {
+	tests := []struct {
+		name      string
+		readiness *runtimeCatalogReadiness
+	}{
+		{name: "startup pending", readiness: newRuntimeCatalogReadiness()},
+		{name: "integrity failure", readiness: integrityReadinessFixture()},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			store := &fakeStateCatalogStore{
+				detail:    TemplateDetail{TemplateID: "test.runtime-card"},
+				auditPage: TemplateAuditPage{},
+			}
+			api := &API{store: store, readiness: test.readiness}
+			detail := doStateRequest(t, api, wkhttp.SuperAdmin, http.MethodGet, "/test.runtime-card", "")
+			if detail.Code != http.StatusOK {
+				t.Fatalf("detail status=%d body=%s", detail.Code, detail.Body.String())
+			}
+			audit := doStateRequest(t, api, wkhttp.SuperAdmin, http.MethodGet, "/test.runtime-card/audit", "")
+			if audit.Code != http.StatusOK {
+				t.Fatalf("audit status=%d body=%s", audit.Code, audit.Body.String())
+			}
+		})
+	}
+}
+
+func integrityReadinessFixture() *runtimeCatalogReadiness {
+	readiness := newRuntimeCatalogReadiness()
+	readiness.MarkIntegrity(errors.New("stored activation is invalid"))
+	return readiness
+}
+
+func TestStateErrorsUseStableLocalizedMappings(t *testing.T) {
+	tests := []struct {
+		name       string
+		err        error
+		wantCode   string
+		wantStatus int
+	}{
+		{name: "revision conflict", err: ErrActivationConflict, wantCode: "err.server.card_template_catalog.state_conflict", wantStatus: http.StatusConflict},
+		{name: "blocked", err: ErrArtifactBlocked, wantCode: "err.server.card_template_catalog.blocked", wantStatus: http.StatusConflict},
+		{name: "invalid target", err: ErrActivationTargetInvalid, wantCode: "err.server.card_template_catalog.request_invalid", wantStatus: http.StatusBadRequest},
+		{name: "integrity", err: ErrCatalogIntegrity, wantCode: "err.shared.internal", wantStatus: http.StatusInternalServerError},
+		{name: "canceled", err: context.Canceled, wantCode: "err.server.card_template_catalog.unavailable", wantStatus: http.StatusServiceUnavailable},
+		{name: "deadline", err: context.DeadlineExceeded, wantCode: "err.server.card_template_catalog.unavailable", wantStatus: http.StatusServiceUnavailable},
+		{name: "compile busy", err: cardtmpl.ErrArtifactCompileBusy, wantCode: "err.server.card_template_catalog.unavailable", wantStatus: http.StatusServiceUnavailable},
+		{name: "database", err: errors.New("db unavailable"), wantCode: "err.server.card_template_catalog.unavailable", wantStatus: http.StatusServiceUnavailable},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			store := &fakeStateCatalogStore{activateErr: test.err}
+			api := &API{
+				store: store, controlEnabled: true, metrics: newCatalogMetrics(prometheus.NewRegistry()),
+				validateStateTarget: func(_ context.Context, id cardtmpl.ID, version string) (stateTargetReceipt, error) {
+					return dynamicTargetReceiptFixture(id, version, strings.Repeat("a", 64)), nil
+				},
+			}
+			response := doStateRequest(t, api, wkhttp.SuperAdmin, http.MethodPut,
+				"/test.runtime-card/active", `{"version":"1.0.0","expected_revision":0,"reason":"rollout","change_ticket":"CHG-1"}`)
+			assertCatalogError(t, response, test.wantCode, test.wantStatus)
+		})
+	}
+}
+
+func TestStateStoreUnavailableFailsClosed(t *testing.T) {
+	api := &API{store: &fakeCatalogStore{}}
+	response := doStateRequest(t, api, wkhttp.SuperAdmin, http.MethodGet, "/test.runtime-card", "")
+	assertCatalogError(t, response, "err.server.card_template_catalog.unavailable", http.StatusServiceUnavailable)
+}
+
+func TestManagerReadErrorsAndPaginationValidationFailClosed(t *testing.T) {
+	store := &fakeStateCatalogStore{detailErr: errors.New("db unavailable"), auditErr: errors.New("db unavailable")}
+	api := &API{store: store, metrics: newCatalogMetrics(prometheus.NewRegistry())}
+	detail := doStateRequest(t, api, wkhttp.SuperAdmin, http.MethodGet, "/test.runtime-card", "")
+	assertCatalogError(t, detail, "err.server.card_template_catalog.unavailable", http.StatusServiceUnavailable)
+	audit := doStateRequest(t, api, wkhttp.SuperAdmin, http.MethodGet, "/test.runtime-card/audit", "")
+	assertCatalogError(t, audit, "err.server.card_template_catalog.unavailable", http.StatusServiceUnavailable)
+	invalidCursor := doStateRequest(t, api, wkhttp.SuperAdmin, http.MethodGet, "/test.runtime-card/audit?cursor=-1", "")
+	assertCatalogError(t, invalidCursor, "err.server.card_template_catalog.request_invalid", http.StatusBadRequest)
+	if got := normalizeManagerReadLimit(0); got != managerReadDefaultLimit {
+		t.Fatalf("default normalized limit=%d", got)
+	}
+	if got := normalizeManagerReadLimit(managerReadHardLimit + 1); got != managerReadHardLimit {
+		t.Fatalf("hard normalized limit=%d", got)
+	}
+}
+
+func TestStateHandlersRejectInvalidTargetsBeforeStore(t *testing.T) {
+	store := &fakeStateCatalogStore{}
+	api := &API{
+		store: store, controlEnabled: true,
+		validateStateTarget: func(context.Context, cardtmpl.ID, string) (stateTargetReceipt, error) {
+			return stateTargetReceipt{}, ErrActivationTargetInvalid
+		},
+	}
+	rollback := doStateRequest(t, api, wkhttp.SuperAdmin, http.MethodPost,
+		"/test.runtime-card/rollback", `{"target_version":"1.0.0","expected_revision":1,"reason":"incident","change_ticket":"INC-1"}`)
+	assertCatalogError(t, rollback, "err.server.card_template_catalog.request_invalid", http.StatusBadRequest)
+	block := doStateRequest(t, api, wkhttp.SuperAdmin, http.MethodPost,
+		"/test.runtime-card@1.1.0/block", `{"expected_revision":1,"fallback_version":"1.0.0","reason":"incident","change_ticket":"INC-1"}`)
+	assertCatalogError(t, block, "err.server.card_template_catalog.request_invalid", http.StatusBadRequest)
+	badIdentity := doStateRequest(t, api, wkhttp.SuperAdmin, http.MethodPost,
+		"/INVALID/block", `{"expected_revision":1,"reason":"incident","change_ticket":"INC-1"}`)
+	assertCatalogError(t, badIdentity, "err.server.card_template_catalog.request_invalid", http.StatusBadRequest)
+	badLimit := doStateRequest(t, api, wkhttp.SuperAdmin, http.MethodGet,
+		"/test.runtime-card/audit?limit=invalid", "")
+	assertCatalogError(t, badLimit, "err.server.card_template_catalog.request_invalid", http.StatusBadRequest)
+	if store.rollbackCalls != 0 || store.blockCalls != 0 {
+		t.Fatalf("rollback/block store calls = %d/%d, want 0/0", store.rollbackCalls, store.blockCalls)
+	}
+}
+
+func doStateRequest(
+	t *testing.T,
+	api *API,
+	role wkhttp.UserRole,
+	method, target, body string,
+) *httptest.ResponseRecorder {
+	t.Helper()
+	route := wkhttp.New()
+	route.SetErrorRenderer(i18n.NewErrorRenderer(i18n.NewLocalizer(i18n.DefaultLanguage)))
+	route.Use(func(c *wkhttp.Context) {
+		c.Set("uid", "admin-1")
+		c.Set("role", string(role))
+	})
+	group := route.Group("")
+	group.GET("/:id/audit", api.audit)
+	group.GET("/:id", api.detail)
+	group.PUT("/:id/active", api.activate)
+	group.POST("/:id/rollback", api.rollback)
+	group.POST("/:id/block", api.block)
+	request := httptest.NewRequest(method, target, bytes.NewBufferString(body))
+	request.Header.Set("Content-Type", "application/json")
+	recorder := httptest.NewRecorder()
+	route.ServeHTTP(recorder, request)
+	return recorder
+}
+
+type fakeStateCatalogStore struct {
+	fakeCatalogStore
+	activateResult ActivationResult
+	activateErr    error
+	activateCalls  int
+	lastActivate   ActivationRequest
+	rollbackResult ActivationResult
+	rollbackErr    error
+	rollbackCalls  int
+	lastRollback   RollbackRequest
+	blockResult    BlockResult
+	blockErr       error
+	blockCalls     int
+	lastBlock      BlockRequest
+	detail         TemplateDetail
+	detailErr      error
+	auditPage      TemplateAuditPage
+	auditErr       error
+	lastAuditLimit int
+}
+
+func (s *fakeStateCatalogStore) Activate(_ context.Context, request ActivationRequest) (ActivationResult, error) {
+	s.activateCalls++
+	s.lastActivate = request
+	return s.activateResult, s.activateErr
+}
+
+func (s *fakeStateCatalogStore) Rollback(_ context.Context, request RollbackRequest) (ActivationResult, error) {
+	s.rollbackCalls++
+	s.lastRollback = request
+	return s.rollbackResult, s.rollbackErr
+}
+
+func (s *fakeStateCatalogStore) Block(_ context.Context, request BlockRequest) (BlockResult, error) {
+	s.blockCalls++
+	s.lastBlock = request
+	return s.blockResult, s.blockErr
+}
+
+func (s *fakeStateCatalogStore) GetTemplateDetail(context.Context, cardtmpl.ID, int) (TemplateDetail, error) {
+	return s.detail, s.detailErr
+}
+
+func (s *fakeStateCatalogStore) ListAudit(_ context.Context, _ cardtmpl.ID, _ uint64, limit int) (TemplateAuditPage, error) {
+	s.lastAuditLimit = limit
+	return s.auditPage, s.auditErr
+}
+
+func decodeStateResponse(t *testing.T, response *httptest.ResponseRecorder) map[string]any {
+	t.Helper()
+	var result map[string]any
+	if err := json.Unmarshal(response.Body.Bytes(), &result); err != nil {
+		t.Fatal(err)
+	}
+	return result
+}

--- a/modules/card_template_catalog/api_test.go
+++ b/modules/card_template_catalog/api_test.go
@@ -209,7 +209,7 @@ func TestReconcileStaticInventoryUsesFrozenRegistryList(t *testing.T) {
 }
 
 func TestCatalogNoLegacyErrorResponses(t *testing.T) {
-	files := []string{"api.go", "api_i18n.go"}
+	files := []string{"api.go", "api_state.go", "api_i18n.go"}
 	banned := []string{".ResponseError(", ".ResponseErrorf(", ".ResponseErrorWithStatus(", ".AbortWithStatusJSON(", ".AbortWithStatus(", `.Response("`}
 	for _, file := range files {
 		data, err := os.ReadFile(file)

--- a/modules/card_template_catalog/metrics.go
+++ b/modules/card_template_catalog/metrics.go
@@ -8,9 +8,14 @@ import (
 )
 
 type catalogMetrics struct {
-	operations *prometheus.CounterVec
-	compile    *prometheus.HistogramVec
-	db         *prometheus.CounterVec
+	operations    *prometheus.CounterVec
+	compile       *prometheus.HistogramVec
+	db            *prometheus.CounterVec
+	resolve       *prometheus.CounterVec
+	cache         *prometheus.CounterVec
+	cacheEntries  prometheus.Gauge
+	cacheBytes    prometheus.Gauge
+	activeTargets prometheus.Gauge
 }
 
 func newCatalogMetrics(registerer prometheus.Registerer) *catalogMetrics {
@@ -31,6 +36,26 @@ func newCatalogMetrics(registerer prometheus.Registerer) *catalogMetrics {
 			Name: "dmwork_card_catalog_db_total",
 			Help: "Card template catalog authoritative database operations by bounded outcome.",
 		}, []string{"operation", "result"})),
+		resolve: registerCounterVec(registerer, prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "dmwork_card_catalog_resolve_total",
+			Help: "Card template runtime resolutions by bounded source and outcome.",
+		}, []string{"source", "result"})),
+		cache: registerCounterVec(registerer, prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "dmwork_card_catalog_cache_total",
+			Help: "Card template compiled-cache operations by bounded outcome.",
+		}, []string{"result"})),
+		cacheEntries: registerGauge(registerer, prometheus.NewGauge(prometheus.GaugeOpts{
+			Name: "dmwork_card_catalog_cache_entries",
+			Help: "Retained card template compiled-cache entries.",
+		})),
+		cacheBytes: registerGauge(registerer, prometheus.NewGauge(prometheus.GaugeOpts{
+			Name: "dmwork_card_catalog_cache_bytes",
+			Help: "Retained canonical bytes in the card template compiled cache.",
+		})),
+		activeTargets: registerGauge(registerer, prometheus.NewGauge(prometheus.GaugeOpts{
+			Name: "dmwork_card_catalog_active_targets",
+			Help: "Authoritative active card template targets observed during startup validation.",
+		})),
 	}
 }
 
@@ -60,6 +85,19 @@ func registerHistogramVec(registerer prometheus.Registerer, collector *prometheu
 	return collector
 }
 
+func registerGauge(registerer prometheus.Registerer, collector prometheus.Gauge) prometheus.Gauge {
+	if err := registerer.Register(collector); err != nil {
+		var alreadyRegistered prometheus.AlreadyRegisteredError
+		if errors.As(err, &alreadyRegistered) {
+			if existing, ok := alreadyRegistered.ExistingCollector.(prometheus.Gauge); ok {
+				return existing
+			}
+		}
+		panic(err)
+	}
+	return collector
+}
+
 func (m *catalogMetrics) observeOperation(operation, result string) {
 	if m != nil {
 		m.operations.WithLabelValues(operation, result).Inc()
@@ -75,5 +113,30 @@ func (m *catalogMetrics) observeCompile(result string, duration time.Duration) {
 func (m *catalogMetrics) observeDB(operation, result string) {
 	if m != nil {
 		m.db.WithLabelValues(operation, result).Inc()
+	}
+}
+
+func (m *catalogMetrics) observeResolve(source, result string) {
+	if m != nil {
+		m.resolve.WithLabelValues(source, result).Inc()
+	}
+}
+
+func (m *catalogMetrics) observeCache(result string) {
+	if m != nil {
+		m.cache.WithLabelValues(result).Inc()
+	}
+}
+
+func (m *catalogMetrics) setCacheSize(entries, bytes int) {
+	if m != nil {
+		m.cacheEntries.Set(float64(entries))
+		m.cacheBytes.Set(float64(bytes))
+	}
+}
+
+func (m *catalogMetrics) setActiveTargetCount(count int) {
+	if m != nil {
+		m.activeTargets.Set(float64(count))
 	}
 }

--- a/modules/card_template_catalog/owner_policy.go
+++ b/modules/card_template_catalog/owner_policy.go
@@ -1,0 +1,14 @@
+package card_template_catalog
+
+// approvedRuntimeOwners is the E3 v1 server-authored owner policy. Adding an
+// owner is a reviewed code/config capability change; a manifest cannot grant
+// itself authority by declaring an arbitrary owner or an ext.* namespace.
+var approvedRuntimeOwners = map[string]struct{}{
+	"ai":   {},
+	"docs": {},
+}
+
+func isApprovedRuntimeOwner(owner string) bool {
+	_, ok := approvedRuntimeOwners[owner]
+	return ok
+}

--- a/modules/card_template_catalog/runtime_db_integration_test.go
+++ b/modules/card_template_catalog/runtime_db_integration_test.go
@@ -1,0 +1,302 @@
+package card_template_catalog
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path"
+	"sort"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl"
+	mysqldriver "github.com/go-sql-driver/mysql"
+	migrate "github.com/rubenv/sql-migrate"
+)
+
+const runtimeCatalogIntegrationDBPrefix = "octo_card_catalog_runtime_test"
+
+var runtimeCatalogIntegrationDBSequence atomic.Uint64
+
+func TestRuntimeCatalogMultiReplicaActivationRollbackBlockAndRestart(t *testing.T) {
+	db := newRuntimeCatalogIntegrationDB(t)
+	storeA, storeB := newStore(db), newStore(db)
+	artifactV1 := integrationArtifactForVersion(t, "1.0.0")
+	artifactV2 := integrationArtifactForVersion(t, "1.1.0")
+	for _, artifact := range []*cardtmpl.CompiledArtifact{artifactV1, artifactV2} {
+		if _, err := storeA.Publish(context.Background(), PublishRequest{
+			Artifact: artifact, ActorUID: "admin-1", Reason: "integration publish", ChangeTicket: "TEST-1",
+		}); err != nil {
+			t.Fatalf("Publish %s: %v", artifact.Meta.Version, err)
+		}
+	}
+
+	registry := cardtmpl.NewRegistry()
+	registry.Freeze()
+	catalogA := integrationRuntimeCatalog(t, registry, storeA)
+	catalogB := integrationRuntimeCatalog(t, registry, storeB)
+	access := cardtmpl.CatalogAccess{
+		Purpose: cardtmpl.CatalogPurposeNewSend,
+		Principal: cardtmpl.CatalogPrincipal{
+			Kind: cardtmpl.CatalogPrincipalSystem, ID: "integration", SpaceID: "space-1",
+		},
+	}
+	defaultRequest := cardtmpl.CatalogDefaultRequest{Access: access, ID: artifactV1.Meta.ID}
+
+	firstRequest := ActivationRequest{
+		TemplateID: artifactV1.Meta.ID, TargetVersion: artifactV1.Meta.Version,
+		ExpectedRevision: 0, ActorUID: "admin-1", Reason: "activate v1", ChangeTicket: "TEST-2",
+		targetReceipt: receiptForIntegrationArtifact(artifactV1),
+	}
+	type activationOutcome struct {
+		result ActivationResult
+		err    error
+	}
+	begin := make(chan struct{})
+	outcomes := make(chan activationOutcome, 2)
+	var callers sync.WaitGroup
+	for _, stateStore := range []*store{storeA, storeB} {
+		callers.Add(1)
+		go func(stateStore *store) {
+			defer callers.Done()
+			<-begin
+			result, err := stateStore.Activate(context.Background(), firstRequest)
+			outcomes <- activationOutcome{result: result, err: err}
+		}(stateStore)
+	}
+	close(begin)
+	callers.Wait()
+	close(outcomes)
+	successes, conflicts := 0, 0
+	for outcome := range outcomes {
+		switch {
+		case outcome.err == nil && outcome.result.Revision == 1:
+			successes++
+		case errors.Is(outcome.err, ErrActivationConflict):
+			conflicts++
+		default:
+			t.Fatalf("unexpected concurrent activation outcome: result=%+v err=%v", outcome.result, outcome.err)
+		}
+	}
+	if successes != 1 || conflicts != 1 {
+		t.Fatalf("concurrent first activation successes/conflicts=%d/%d, want 1/1", successes, conflicts)
+	}
+	assertCatalogDefaultVersion(t, catalogA, defaultRequest, artifactV1.Meta.Version)
+	assertCatalogDefaultVersion(t, catalogB, defaultRequest, artifactV1.Meta.Version)
+
+	second, err := storeA.Activate(context.Background(), ActivationRequest{
+		TemplateID: artifactV2.Meta.ID, TargetVersion: artifactV2.Meta.Version,
+		ExpectedRevision: 1, ActorUID: "admin-1", Reason: "activate v2", ChangeTicket: "TEST-3",
+		targetReceipt: receiptForIntegrationArtifact(artifactV2),
+	})
+	if err != nil || second.Revision != 2 {
+		t.Fatalf("activate v2 result=%+v err=%v", second, err)
+	}
+	assertCatalogDefaultVersion(t, catalogB, defaultRequest, artifactV2.Meta.Version)
+
+	rolledBack, err := storeA.Rollback(context.Background(), RollbackRequest{
+		TemplateID: artifactV1.Meta.ID, TargetVersion: artifactV1.Meta.Version,
+		ExpectedRevision: 2, ActorUID: "admin-1", Reason: "rollback v1", ChangeTicket: "TEST-4",
+		targetReceipt: receiptForIntegrationArtifact(artifactV1),
+	})
+	if err != nil || rolledBack.Revision != 3 {
+		t.Fatalf("rollback v1 result=%+v err=%v", rolledBack, err)
+	}
+	assertCatalogDefaultVersion(t, catalogB, defaultRequest, artifactV1.Meta.Version)
+
+	blockedV1, err := storeA.Block(context.Background(), BlockRequest{
+		TemplateID: artifactV1.Meta.ID, Version: artifactV1.Meta.Version,
+		ExpectedRevision: 3, FallbackVersion: artifactV2.Meta.Version,
+		ActorUID: "admin-1", Reason: "block v1", ChangeTicket: "TEST-5",
+		fallbackReceipt: receiptForIntegrationArtifact(artifactV2),
+	})
+	if err != nil || blockedV1.Revision != 4 || blockedV1.ActiveVersion != artifactV2.Meta.Version {
+		t.Fatalf("block v1 result=%+v err=%v", blockedV1, err)
+	}
+	_, err = catalogB.MetaExact(context.Background(), cardtmpl.CatalogExactRequest{
+		Access: access, ID: artifactV1.Meta.ID, Version: artifactV1.Meta.Version,
+	})
+	if !errors.Is(err, cardtmpl.ErrRuntimeCatalogBlocked) {
+		t.Fatalf("hot-cache blocked v1 error=%v, want ErrRuntimeCatalogBlocked", err)
+	}
+	assertCatalogDefaultVersion(t, catalogB, defaultRequest, artifactV2.Meta.Version)
+
+	// A new process has an empty compiled cache but must recover the same DB truth.
+	catalogAfterRestart := integrationRuntimeCatalog(t, registry, newStore(db))
+	assertCatalogDefaultVersion(t, catalogAfterRestart, defaultRequest, artifactV2.Meta.Version)
+
+	blockedV2, err := storeA.Block(context.Background(), BlockRequest{
+		TemplateID: artifactV2.Meta.ID, Version: artifactV2.Meta.Version,
+		ExpectedRevision: 4, ActorUID: "admin-1", Reason: "disable catalog", ChangeTicket: "TEST-6",
+	})
+	if err != nil || blockedV2.Revision != 5 || blockedV2.Status != activationStatusDisabled {
+		t.Fatalf("block v2 result=%+v err=%v", blockedV2, err)
+	}
+	for name, catalog := range map[string]*cardtmpl.RuntimeCatalog{"replica-b": catalogB, "restart": catalogAfterRestart} {
+		if _, err := catalog.MetaDefault(context.Background(), defaultRequest); !errors.Is(err, cardtmpl.ErrRuntimeCatalogDisabled) {
+			t.Fatalf("%s disabled default error=%v, want ErrRuntimeCatalogDisabled", name, err)
+		}
+	}
+
+}
+
+func newRuntimeCatalogIntegrationDB(t *testing.T) *sql.DB {
+	t.Helper()
+	databaseName := fmt.Sprintf("%s_%d_%d", runtimeCatalogIntegrationDBPrefix,
+		os.Getpid(), runtimeCatalogIntegrationDBSequence.Add(1))
+	baseDSN := os.Getenv("OCTO_TEST_MYSQL_ADDR")
+	if baseDSN == "" {
+		baseDSN = "root:demo@tcp(127.0.0.1:3306)/test?charset=utf8mb4&parseTime=true"
+	}
+	parsed, err := mysqldriver.ParseDSN(baseDSN)
+	if err != nil {
+		t.Fatalf("parse MySQL DSN: %v", err)
+	}
+	parsed.DBName = ""
+	bootstrap, err := sql.Open("mysql", parsed.FormatDSN())
+	if err != nil {
+		t.Fatalf("open MySQL bootstrap connection: %v", err)
+	}
+	bootstrap.SetMaxOpenConns(2)
+	bootstrap.SetMaxIdleConns(1)
+	if _, err := bootstrap.Exec("DROP DATABASE IF EXISTS `" + databaseName + "`"); err != nil {
+		_ = bootstrap.Close()
+		t.Fatalf("drop stale integration database: %v", err)
+	}
+	if _, err := bootstrap.Exec("CREATE DATABASE `" + databaseName + "` CHARACTER SET utf8mb4 COLLATE utf8mb4_bin"); err != nil {
+		_ = bootstrap.Close()
+		t.Fatalf("create integration database: %v", err)
+	}
+	parsed.DBName = databaseName
+	db, err := sql.Open("mysql", parsed.FormatDSN())
+	if err != nil {
+		_ = bootstrap.Close()
+		t.Fatalf("open integration database: %v", err)
+	}
+	db.SetMaxOpenConns(8)
+	db.SetMaxIdleConns(4)
+	if err := db.PingContext(context.Background()); err != nil {
+		_ = db.Close()
+		_ = bootstrap.Close()
+		t.Fatalf("ping integration database: %v", err)
+	}
+	source := runtimeCatalogMigrationSource{}
+	if applied, err := migrate.Exec(db, "mysql", source, migrate.Up); err != nil || applied != 2 {
+		_ = db.Close()
+		_ = bootstrap.Close()
+		t.Fatalf("apply catalog migrations: applied=%d err=%v", applied, err)
+	}
+	t.Cleanup(func() {
+		if reverted, err := migrate.Exec(db, "mysql", source, migrate.Down); err != nil || reverted != 2 {
+			t.Errorf("revert catalog migrations: reverted=%d err=%v", reverted, err)
+		}
+		if err := db.Close(); err != nil {
+			t.Errorf("close integration database: %v", err)
+		}
+		if _, err := bootstrap.Exec("DROP DATABASE IF EXISTS `" + databaseName + "`"); err != nil {
+			t.Errorf("drop integration database: %v", err)
+		}
+		if err := bootstrap.Close(); err != nil {
+			t.Errorf("close bootstrap database: %v", err)
+		}
+	})
+	return db
+}
+
+type runtimeCatalogMigrationSource struct{}
+
+func (runtimeCatalogMigrationSource) FindMigrations() ([]*migrate.Migration, error) {
+	entries, err := sqlFS.ReadDir("sql")
+	if err != nil {
+		return nil, err
+	}
+	migrations := make([]*migrate.Migration, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".sql") {
+			continue
+		}
+		raw, err := sqlFS.ReadFile(path.Join("sql", entry.Name()))
+		if err != nil {
+			return nil, err
+		}
+		migration, err := migrate.ParseMigration(entry.Name(), bytes.NewReader(raw))
+		if err != nil {
+			return nil, fmt.Errorf("parse migration %s: %w", entry.Name(), err)
+		}
+		migrations = append(migrations, migration)
+	}
+	sort.Slice(migrations, func(i, j int) bool { return migrations[i].Less(migrations[j]) })
+	return migrations, nil
+}
+
+func integrationRuntimeCatalog(t *testing.T, registry *cardtmpl.Registry, store *store) *cardtmpl.RuntimeCatalog {
+	t.Helper()
+	catalog, err := cardtmpl.NewRuntimeCatalog(registry, store, cardtmpl.RuntimeCatalogConfig{
+		MaxCacheEntries: 8, MaxCacheBytes: 8 << 20, CompileTimeout: 5 * time.Second,
+		AuthorizeDynamic: func(context.Context, cardtmpl.CatalogAccess, cardtmpl.RuntimeArtifactMeta) error {
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewRuntimeCatalog: %v", err)
+	}
+	return catalog
+}
+
+func integrationArtifactForVersion(t *testing.T, version string) *cardtmpl.CompiledArtifact {
+	t.Helper()
+	root, err := cardtmpl.DecodeStrictJSONObject(validControlRequestJSON(t, false))
+	if err != nil {
+		t.Fatal(err)
+	}
+	bundle, err := cardtmpl.DecodeBundleValue(root["bundle"])
+	if err != nil {
+		t.Fatal(err)
+	}
+	var manifest map[string]any
+	if err := json.Unmarshal(bundle.Manifest, &manifest); err != nil {
+		t.Fatal(err)
+	}
+	manifest["version"] = version
+	bundle.Manifest, err = json.Marshal(manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	artifact, err := cardtmpl.CompileJSONArtifact(context.Background(), bundle, cardtmpl.DefaultCompileLimits())
+	if err != nil {
+		t.Fatalf("CompileJSONArtifact %s: %v", version, err)
+	}
+	return artifact
+}
+
+func receiptForIntegrationArtifact(artifact *cardtmpl.CompiledArtifact) stateTargetReceipt {
+	return stateTargetReceipt{meta: cardtmpl.RuntimeArtifactMeta{
+		ID: artifact.Meta.ID, Version: artifact.Meta.Version, Source: cardtmpl.RuntimeSourceDynamic,
+		Engine: artifact.Engine, Hash: artifact.Hash, Owner: artifact.Owner,
+		Visibility: artifact.Visibility, Protocol: artifact.Meta.Protocol,
+		ContractVersion: artifact.ContractVersion,
+	}}
+}
+
+func assertCatalogDefaultVersion(
+	t *testing.T,
+	catalog *cardtmpl.RuntimeCatalog,
+	request cardtmpl.CatalogDefaultRequest,
+	want string,
+) {
+	t.Helper()
+	meta, err := catalog.MetaDefault(context.Background(), request)
+	if err != nil {
+		t.Fatalf("MetaDefault want %s: %v", want, err)
+	}
+	if meta.Version != want {
+		t.Fatalf("MetaDefault version=%s, want %s", meta.Version, want)
+	}
+}

--- a/modules/card_template_catalog/runtime_gates_test.go
+++ b/modules/card_template_catalog/runtime_gates_test.go
@@ -1,0 +1,71 @@
+package card_template_catalog
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl"
+)
+
+func TestRuntimeCatalogGatesFailClosedOnMissingAndInvalidValues(t *testing.T) {
+	tests := []struct {
+		name   string
+		values map[string]string
+		want   runtimeCatalogGates
+		warns  int
+	}{
+		{name: "missing", values: map[string]string{}, want: runtimeCatalogGates{}, warns: 2},
+		{name: "invalid", values: map[string]string{
+			runtimeCatalogControlEnv: "yes", runtimeCatalogNewSendEnv: "1",
+		}, want: runtimeCatalogGates{}, warns: 2},
+		{name: "explicit", values: map[string]string{
+			runtimeCatalogControlEnv: "true", runtimeCatalogNewSendEnv: "true",
+		}, want: runtimeCatalogGates{controlEnabled: true, newSendEnabled: true}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, warnings := resolveRuntimeCatalogGates(func(key string) string { return test.values[key] })
+			if got != test.want || len(warnings) != test.warns {
+				t.Fatalf("gates/warnings = (%+v, %v), want (%+v, %d)", got, warnings, test.want, test.warns)
+			}
+		})
+	}
+}
+
+func TestRuntimeCatalogCacheConfigFromEnvIsBounded(t *testing.T) {
+	values := map[string]string{
+		runtimeCatalogCacheEntriesEnv: "32",
+		runtimeCatalogCacheBytesEnv:   "16777216",
+		runtimeCatalogCompileMSEnv:    "2500",
+	}
+	config, err := runtimeCatalogConfigFromEnv(cardtmpl.RuntimeCatalogConfig{}, func(key string) string { return values[key] })
+	if err != nil {
+		t.Fatal(err)
+	}
+	if config.MaxCacheEntries != 32 || config.MaxCacheBytes != 16<<20 || config.CompileTimeout != 2500*time.Millisecond {
+		t.Fatalf("config = %+v", config)
+	}
+	values[runtimeCatalogCacheEntriesEnv] = "257"
+	if _, err := runtimeCatalogConfigFromEnv(cardtmpl.RuntimeCatalogConfig{}, func(key string) string { return values[key] }); err == nil {
+		t.Fatal("over-hard-max cache entries accepted")
+	}
+}
+
+func TestRuntimeDynamicAuthorizerKeepsNewSendDarkAndRequiresGrant(t *testing.T) {
+	access := cardtmpl.CatalogAccess{Purpose: cardtmpl.CatalogPurposeNewSend}
+	authorize := runtimeDynamicAuthorizer(runtimeCatalogGates{}, nil)
+	if err := authorize(context.Background(), access, cardtmpl.RuntimeArtifactMeta{}); !errors.Is(err, cardtmpl.ErrRuntimeCatalogNewSendDisabled) {
+		t.Fatalf("dark new-send error = %v, want ErrRuntimeCatalogNewSendDisabled", err)
+	}
+	authorize = runtimeDynamicAuthorizer(runtimeCatalogGates{newSendEnabled: true}, nil)
+	if err := authorize(context.Background(), access, cardtmpl.RuntimeArtifactMeta{}); !errors.Is(err, cardtmpl.ErrRuntimeCatalogNotAuthorized) {
+		t.Fatalf("ungranted new-send error = %v, want ErrRuntimeCatalogNotAuthorized", err)
+	}
+	authorize = runtimeDynamicAuthorizer(runtimeCatalogGates{newSendEnabled: true},
+		func(context.Context, cardtmpl.CatalogAccess, cardtmpl.RuntimeArtifactMeta) error { return nil })
+	if err := authorize(context.Background(), access, cardtmpl.RuntimeArtifactMeta{Owner: "ext.vendor"}); !errors.Is(err, cardtmpl.ErrRuntimeCatalogNotAuthorized) {
+		t.Fatalf("unapproved owner error = %v, want ErrRuntimeCatalogNotAuthorized", err)
+	}
+}

--- a/modules/card_template_catalog/runtime_install.go
+++ b/modules/card_template_catalog/runtime_install.go
@@ -1,0 +1,216 @@
+package card_template_catalog
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	runtimeCatalogControlEnv      = "OCTO_CARD_RUNTIME_CATALOG_CONTROL_ENABLED"
+	runtimeCatalogNewSendEnv      = "OCTO_CARD_RUNTIME_CATALOG_NEW_SEND_ENABLED"
+	runtimeCatalogCacheEntriesEnv = "OCTO_CARD_RUNTIME_CATALOG_CACHE_ENTRIES"
+	runtimeCatalogCacheBytesEnv   = "OCTO_CARD_RUNTIME_CATALOG_CACHE_BYTES"
+	runtimeCatalogCompileMSEnv    = "OCTO_CARD_RUNTIME_CATALOG_COMPILE_TIMEOUT_MS"
+)
+
+type runtimeCatalogGates struct {
+	controlEnabled bool
+	newSendEnabled bool
+}
+
+var (
+	installedStoreMu sync.RWMutex
+	installedStore   *store
+	installedGates   runtimeCatalogGates
+	installedReady   *runtimeCatalogReadiness
+)
+
+// InstallRuntimeCatalog is the composition-root entry point. It constructs the
+// process's only runtime store/cache pair before module factories are created;
+// the manager control plane later reuses the same store instance.
+func InstallRuntimeCatalog(
+	db *sql.DB,
+	registry *cardtmpl.Registry,
+	config cardtmpl.RuntimeCatalogConfig,
+) (*cardtmpl.RuntimeCatalog, error) {
+	if db == nil || registry == nil {
+		return nil, errors.New("card template catalog: runtime dependencies are required")
+	}
+	gates, warnings := resolveRuntimeCatalogGates(os.Getenv)
+	for _, warning := range warnings {
+		log.Warn(warning)
+	}
+	config, err := runtimeCatalogConfigFromEnv(config, os.Getenv)
+	if err != nil {
+		return nil, err
+	}
+	readiness := newRuntimeCatalogReadiness()
+	downstreamReady := config.CheckReady
+	config.CheckReady = func() error {
+		if err := readiness.Check(); err != nil {
+			return err
+		}
+		if downstreamReady != nil {
+			return downstreamReady()
+		}
+		return nil
+	}
+	config.AuthorizeDynamic = runtimeDynamicAuthorizer(gates, config.AuthorizeDynamic)
+	config.Hooks = runtimeMetricHooks(config.Hooks, newCatalogMetrics(prometheus.DefaultRegisterer))
+	runtimeStore := newStore(db)
+	catalog, err := cardtmpl.NewRuntimeCatalog(registry, runtimeStore, config)
+	if err != nil {
+		return nil, err
+	}
+	setInstalledRuntimeStore(runtimeStore)
+	setInstalledRuntimeGates(gates)
+	setInstalledRuntimeReadiness(readiness)
+	cardtmpl.SetDefaultCatalog(catalog)
+	return catalog, nil
+}
+
+func runtimeCatalogConfigFromEnv(
+	config cardtmpl.RuntimeCatalogConfig,
+	getenv func(string) string,
+) (cardtmpl.RuntimeCatalogConfig, error) {
+	if getenv == nil {
+		return config, nil
+	}
+	if raw := strings.TrimSpace(getenv(runtimeCatalogCacheEntriesEnv)); raw != "" {
+		value, err := strconv.Atoi(raw)
+		if err != nil || value < 1 || value > 256 {
+			return config, fmt.Errorf("%s must be between 1 and 256", runtimeCatalogCacheEntriesEnv)
+		}
+		config.MaxCacheEntries = value
+	}
+	if raw := strings.TrimSpace(getenv(runtimeCatalogCacheBytesEnv)); raw != "" {
+		value, err := strconv.Atoi(raw)
+		if err != nil || value < 1 || value > 128<<20 {
+			return config, fmt.Errorf("%s must be between 1 and %d", runtimeCatalogCacheBytesEnv, 128<<20)
+		}
+		config.MaxCacheBytes = value
+	}
+	if raw := strings.TrimSpace(getenv(runtimeCatalogCompileMSEnv)); raw != "" {
+		value, err := strconv.Atoi(raw)
+		if err != nil || value < 1 || value > 10_000 {
+			return config, fmt.Errorf("%s must be between 1 and 10000", runtimeCatalogCompileMSEnv)
+		}
+		config.CompileTimeout = time.Duration(value) * time.Millisecond
+	}
+	return config, nil
+}
+
+func runtimeMetricHooks(existing cardtmpl.RuntimeCatalogHooks, metrics *catalogMetrics) cardtmpl.RuntimeCatalogHooks {
+	return cardtmpl.RuntimeCatalogHooks{
+		OnResolve: func(source cardtmpl.RuntimeSource, result string) {
+			if existing.OnResolve != nil {
+				existing.OnResolve(source, result)
+			}
+			metrics.observeResolve(string(source), result)
+		},
+		OnCache: func(result string) {
+			if existing.OnCache != nil {
+				existing.OnCache(result)
+			}
+			metrics.observeCache(result)
+		},
+		OnCacheSize: func(entries, bytes int) {
+			if existing.OnCacheSize != nil {
+				existing.OnCacheSize(entries, bytes)
+			}
+			metrics.setCacheSize(entries, bytes)
+		},
+	}
+}
+
+func installedRuntimeStore() *store {
+	installedStoreMu.RLock()
+	defer installedStoreMu.RUnlock()
+	return installedStore
+}
+
+func setInstalledRuntimeStore(store *store) {
+	installedStoreMu.Lock()
+	defer installedStoreMu.Unlock()
+	installedStore = store
+}
+
+func installedRuntimeGates() runtimeCatalogGates {
+	installedStoreMu.RLock()
+	defer installedStoreMu.RUnlock()
+	return installedGates
+}
+
+func setInstalledRuntimeGates(gates runtimeCatalogGates) {
+	installedStoreMu.Lock()
+	defer installedStoreMu.Unlock()
+	installedGates = gates
+}
+
+func installedRuntimeReadiness() *runtimeCatalogReadiness {
+	installedStoreMu.RLock()
+	defer installedStoreMu.RUnlock()
+	return installedReady
+}
+
+func setInstalledRuntimeReadiness(readiness *runtimeCatalogReadiness) {
+	installedStoreMu.Lock()
+	defer installedStoreMu.Unlock()
+	installedReady = readiness
+}
+
+func resolveRuntimeCatalogGates(getenv func(string) string) (runtimeCatalogGates, []string) {
+	if getenv == nil {
+		getenv = func(string) string { return "" }
+	}
+	control, controlOK := strictRuntimeBool(getenv(runtimeCatalogControlEnv))
+	newSend, newSendOK := strictRuntimeBool(getenv(runtimeCatalogNewSendEnv))
+	warnings := make([]string, 0, 2)
+	if !controlOK {
+		warnings = append(warnings, runtimeCatalogControlEnv+" is missing or invalid; dynamic activation remains disabled")
+	}
+	if !newSendOK {
+		warnings = append(warnings, runtimeCatalogNewSendEnv+" is missing or invalid; dynamic new-send remains disabled")
+	}
+	return runtimeCatalogGates{controlEnabled: control, newSendEnabled: newSend}, warnings
+}
+
+func strictRuntimeBool(raw string) (bool, bool) {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "true":
+		return true, true
+	case "false":
+		return false, true
+	default:
+		return false, false
+	}
+}
+
+func runtimeDynamicAuthorizer(
+	gates runtimeCatalogGates,
+	downstream cardtmpl.RuntimeDynamicAuthorizeFunc,
+) cardtmpl.RuntimeDynamicAuthorizeFunc {
+	return func(ctx context.Context, access cardtmpl.CatalogAccess, meta cardtmpl.RuntimeArtifactMeta) error {
+		if access.Purpose == cardtmpl.CatalogPurposeNewSend && !gates.newSendEnabled {
+			return cardtmpl.ErrRuntimeCatalogNewSendDisabled
+		}
+		if !isApprovedRuntimeOwner(meta.Owner) {
+			return cardtmpl.ErrRuntimeCatalogNotAuthorized
+		}
+		if downstream == nil {
+			return cardtmpl.ErrRuntimeCatalogNotAuthorized
+		}
+		return downstream(ctx, access, meta)
+	}
+}

--- a/modules/card_template_catalog/runtime_install_test.go
+++ b/modules/card_template_catalog/runtime_install_test.go
@@ -1,0 +1,102 @@
+package card_template_catalog
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+func TestInstallRuntimeCatalogPublishesOneCatalogAndStore(t *testing.T) {
+	db, _, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	registry := cardtmpl.NewRegistry()
+	registry.Freeze()
+
+	previousStore := installedRuntimeStore()
+	previousGates := installedRuntimeGates()
+	previousReadiness := installedRuntimeReadiness()
+	t.Cleanup(func() {
+		cardtmpl.SetDefaultCatalog(nil)
+		setInstalledRuntimeStore(previousStore)
+		setInstalledRuntimeGates(previousGates)
+		setInstalledRuntimeReadiness(previousReadiness)
+	})
+
+	catalog, err := InstallRuntimeCatalog(db, registry, cardtmpl.RuntimeCatalogConfig{})
+	if err != nil {
+		t.Fatalf("InstallRuntimeCatalog: %v", err)
+	}
+	if catalog == nil || cardtmpl.DefaultCatalog() != catalog {
+		t.Fatal("installed catalog is not the process default")
+	}
+	if installedRuntimeStore() == nil {
+		t.Fatal("runtime store was not shared with the module control plane")
+	}
+	readiness := installedRuntimeReadiness()
+	if readiness == nil {
+		t.Fatal("runtime readiness was not shared with the module control plane")
+	}
+	if err := readiness.Check(); err == nil {
+		t.Fatal("runtime readiness must remain pending before startup reconciliation")
+	}
+	if err := catalog.CheckReady(); !errors.Is(err, cardtmpl.ErrRuntimeCatalogUnavailable) {
+		t.Fatalf("default catalog pending readiness = %v, want ErrRuntimeCatalogUnavailable", err)
+	}
+	readiness.MarkReady()
+	if err := readiness.Check(); err != nil {
+		t.Fatalf("ready check: %v", err)
+	}
+	if err := catalog.CheckReady(); err != nil {
+		t.Fatalf("default catalog ready check: %v", err)
+	}
+}
+
+func TestInstallRuntimeCatalogRejectsMissingDependencies(t *testing.T) {
+	registry := cardtmpl.NewRegistry()
+	registry.Freeze()
+	if _, err := InstallRuntimeCatalog(nil, registry, cardtmpl.RuntimeCatalogConfig{}); err == nil {
+		t.Fatal("InstallRuntimeCatalog(nil DB) error = nil")
+	}
+}
+
+func TestRuntimeMetricHooksFanOutAndUpdateBoundedMetrics(t *testing.T) {
+	registry := prometheus.NewRegistry()
+	metrics := newCatalogMetrics(registry)
+	resolveCalls, cacheCalls, sizeCalls := 0, 0, 0
+	hooks := runtimeMetricHooks(cardtmpl.RuntimeCatalogHooks{
+		OnResolve: func(cardtmpl.RuntimeSource, string) { resolveCalls++ },
+		OnCache:   func(string) { cacheCalls++ },
+		OnCacheSize: func(int, int) {
+			sizeCalls++
+		},
+	}, metrics)
+	hooks.OnResolve(cardtmpl.RuntimeSourceDynamic, "ok")
+	hooks.OnCache("hit")
+	hooks.OnCacheSize(2, 1024)
+	metrics.setActiveTargetCount(3)
+	if resolveCalls != 1 || cacheCalls != 1 || sizeCalls != 1 {
+		t.Fatalf("existing hook calls = %d/%d/%d", resolveCalls, cacheCalls, sizeCalls)
+	}
+	if got := testutil.ToFloat64(metrics.resolve.WithLabelValues("dynamic", "ok")); got != 1 {
+		t.Fatalf("resolve metric = %v", got)
+	}
+	if got := testutil.ToFloat64(metrics.cache.WithLabelValues("hit")); got != 1 {
+		t.Fatalf("cache metric = %v", got)
+	}
+	if got := testutil.ToFloat64(metrics.cacheEntries); got != 2 {
+		t.Fatalf("cache entries gauge = %v", got)
+	}
+	if got := testutil.ToFloat64(metrics.cacheBytes); got != 1024 {
+		t.Fatalf("cache bytes gauge = %v", got)
+	}
+	if got := testutil.ToFloat64(metrics.activeTargets); got != 3 {
+		t.Fatalf("active target gauge = %v", got)
+	}
+}

--- a/modules/card_template_catalog/runtime_startup.go
+++ b/modules/card_template_catalog/runtime_startup.go
@@ -1,0 +1,207 @@
+package card_template_catalog
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl"
+	"go.uber.org/zap"
+)
+
+const (
+	runtimeInitializationRetryDelay = 30 * time.Second
+	startupActiveTargetLimit        = 128
+	startupTargetValidationTimeout  = 10 * time.Second
+)
+
+type runtimeCatalogReadiness struct {
+	mu        sync.RWMutex
+	ready     bool
+	integrity error
+}
+
+func newRuntimeCatalogReadiness() *runtimeCatalogReadiness {
+	return &runtimeCatalogReadiness{}
+}
+
+func (r *runtimeCatalogReadiness) Check() error {
+	if r == nil {
+		return nil
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	if r.integrity != nil {
+		return fmt.Errorf("%w: startup validation: %v", cardtmpl.ErrRuntimeCatalogIntegrity, r.integrity)
+	}
+	if !r.ready {
+		return cardtmpl.ErrRuntimeCatalogUnavailable
+	}
+	return nil
+}
+
+func (r *runtimeCatalogReadiness) MarkReady() {
+	if r == nil {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.integrity == nil {
+		r.ready = true
+	}
+}
+
+func (r *runtimeCatalogReadiness) MarkIntegrity(err error) {
+	if r == nil || err == nil {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.integrity == nil {
+		r.integrity = err
+		r.ready = false
+	}
+}
+
+type startupActivationTarget struct {
+	ID      cardtmpl.ID
+	Version string
+}
+
+type runtimeStartupStore interface {
+	catalogStore
+	ListActiveTargets(context.Context) ([]startupActivationTarget, error)
+}
+
+func (a *API) initializeRuntimeCatalog(ctx context.Context) error {
+	if a == nil || a.registry == nil {
+		return fmt.Errorf("%w: built-in Registry is unavailable", ErrCatalogIntegrity)
+	}
+	store, ok := a.store.(runtimeStartupStore)
+	if !ok || store == nil {
+		return fmt.Errorf("%w: runtime startup store is unavailable", ErrCatalogIntegrity)
+	}
+	reconcileCtx, cancel := context.WithTimeout(ctx, reconcileTimeout)
+	err := reconcileStaticInventory(reconcileCtx, store, a.registry)
+	cancel()
+	if err != nil {
+		return err
+	}
+	listCtx, cancel := context.WithTimeout(ctx, reconcileTimeout)
+	targets, err := store.ListActiveTargets(listCtx)
+	cancel()
+	if a.metrics != nil {
+		a.metrics.setActiveTargetCount(len(targets))
+	}
+	if err != nil {
+		return err
+	}
+	if a.validateStateTarget == nil {
+		return fmt.Errorf("%w: active target validator is unavailable", ErrCatalogIntegrity)
+	}
+	for _, target := range targets {
+		targetCtx, targetCancel := context.WithTimeout(ctx, startupTargetValidationTimeout)
+		_, err := a.validateStateTarget(targetCtx, target.ID, target.Version)
+		targetCancel()
+		if err != nil {
+			if isRuntimeStartupIntegrityError(err) {
+				return fmt.Errorf("%w: active target %s@%s: %v", ErrCatalogIntegrity, target.ID, target.Version, err)
+			}
+			return fmt.Errorf("validate active target %s@%s: %w", target.ID, target.Version, err)
+		}
+	}
+	return nil
+}
+
+func isRuntimeStartupIntegrityError(err error) bool {
+	return errors.Is(err, ErrCatalogIntegrity) ||
+		errors.Is(err, ErrVersionClaimConflict) ||
+		errors.Is(err, ErrActivationTargetInvalid) ||
+		errors.Is(err, ErrRollbackTargetInvalid) ||
+		errors.Is(err, ErrBlockTargetInvalid) ||
+		errors.Is(err, ErrArtifactBlocked) ||
+		errors.Is(err, cardtmpl.ErrRuntimeCatalogIntegrity) ||
+		errors.Is(err, cardtmpl.ErrTemplateUnknown)
+}
+
+// Start begins catalog startup reconciliation without blocking module setup.
+// Static exact-version reads remain available while DB-backed catalog paths
+// fail closed through runtimeCatalogReadiness.
+func (a *API) Start() error {
+	if a == nil || a.readiness == nil {
+		return nil
+	}
+	a.startupMu.Lock()
+	defer a.startupMu.Unlock()
+	if a.startupDone != nil {
+		return nil
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	a.startupCancel = cancel
+	a.startupDone = make(chan struct{})
+	go a.runRuntimeInitialization(ctx, a.startupDone)
+	return nil
+}
+
+func (a *API) runRuntimeInitialization(ctx context.Context, done chan<- struct{}) {
+	defer close(done)
+	for {
+		err := a.initializeRuntimeCatalog(ctx)
+		if err == nil {
+			a.readiness.MarkReady()
+			if a.metrics != nil {
+				a.metrics.observeDB("startup_validate", "ok")
+			}
+			return
+		}
+		if ctx.Err() != nil {
+			return
+		}
+		if isRuntimeStartupIntegrityError(err) {
+			a.readiness.MarkIntegrity(err)
+			if a.metrics != nil {
+				a.metrics.observeDB("startup_validate", "integrity_error")
+			}
+			if a.logger != nil {
+				a.logger.Error("card template catalog startup integrity failure", zap.Error(err))
+			}
+			return
+		}
+		if a.metrics != nil {
+			a.metrics.observeDB("startup_validate", "error")
+		}
+		if a.logger != nil {
+			a.logger.Error("card template catalog startup validation unavailable; retrying", zap.Error(err))
+		}
+		timer := time.NewTimer(runtimeInitializationRetryDelay)
+		select {
+		case <-ctx.Done():
+			if !timer.Stop() {
+				select {
+				case <-timer.C:
+				default:
+				}
+			}
+			return
+		case <-timer.C:
+		}
+	}
+}
+
+func (a *API) Stop() error {
+	if a == nil {
+		return nil
+	}
+	a.startupMu.Lock()
+	cancel, done := a.startupCancel, a.startupDone
+	a.startupMu.Unlock()
+	if cancel != nil {
+		cancel()
+	}
+	if done != nil {
+		<-done
+	}
+	return nil
+}

--- a/modules/card_template_catalog/runtime_startup_test.go
+++ b/modules/card_template_catalog/runtime_startup_test.go
@@ -1,0 +1,265 @@
+package card_template_catalog
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl"
+	aireasoningprocess "github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl/ai_reasoning_process"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+func TestRuntimeCatalogReadinessDistinguishesPendingReadyAndIntegrity(t *testing.T) {
+	readiness := newRuntimeCatalogReadiness()
+	if err := readiness.Check(); !errors.Is(err, cardtmpl.ErrRuntimeCatalogUnavailable) {
+		t.Fatalf("pending readiness error = %v, want ErrRuntimeCatalogUnavailable", err)
+	}
+	readiness.MarkReady()
+	if err := readiness.Check(); err != nil {
+		t.Fatalf("ready check: %v", err)
+	}
+
+	poisoned := newRuntimeCatalogReadiness()
+	poisoned.MarkIntegrity(errors.New("source conflict"))
+	if err := poisoned.Check(); !errors.Is(err, cardtmpl.ErrRuntimeCatalogIntegrity) {
+		t.Fatalf("poisoned readiness error = %v, want ErrRuntimeCatalogIntegrity", err)
+	}
+	poisoned.MarkReady()
+	if err := poisoned.Check(); !errors.Is(err, cardtmpl.ErrRuntimeCatalogIntegrity) {
+		t.Fatalf("integrity readiness was reopened: %v", err)
+	}
+}
+
+func TestInitializeRuntimeCatalogReconcilesBeforeValidatingActiveTargets(t *testing.T) {
+	store := &startupStoreStub{targets: []startupActivationTarget{
+		{ID: "test.runtime-a", Version: "1.0.0"},
+		{ID: "test.runtime-b", Version: "2.0.0"},
+	}}
+	registry := cardtmpl.NewRegistry()
+	registry.Freeze()
+	api := &API{
+		store: store, registry: registry,
+		validateStateTarget: func(_ context.Context, id cardtmpl.ID, version string) (stateTargetReceipt, error) {
+			store.calls = append(store.calls, "validate:"+string(id)+"@"+version)
+			return stateTargetReceipt{}, nil
+		},
+	}
+	if err := api.initializeRuntimeCatalog(context.Background()); err != nil {
+		t.Fatalf("initializeRuntimeCatalog: %v", err)
+	}
+	want := []string{"reconcile", "list", "validate:test.runtime-a@1.0.0", "validate:test.runtime-b@2.0.0"}
+	if !reflect.DeepEqual(store.calls, want) {
+		t.Fatalf("startup order = %v, want %v", store.calls, want)
+	}
+}
+
+func TestInitializeRuntimeCatalogFailsClosedOnInvalidActiveTarget(t *testing.T) {
+	store := &startupStoreStub{targets: []startupActivationTarget{{ID: "test.runtime-a", Version: "1.0.0"}}}
+	registry := cardtmpl.NewRegistry()
+	registry.Freeze()
+	api := &API{
+		store: store, registry: registry,
+		validateStateTarget: func(context.Context, cardtmpl.ID, string) (stateTargetReceipt, error) {
+			return stateTargetReceipt{}, ErrActivationTargetInvalid
+		},
+	}
+	err := api.initializeRuntimeCatalog(context.Background())
+	if !errors.Is(err, ErrCatalogIntegrity) {
+		t.Fatalf("startup validation error = %v, want ErrCatalogIntegrity", err)
+	}
+}
+
+func TestInitializeRuntimeCatalogBoundsEachActiveTargetValidation(t *testing.T) {
+	store := &startupStoreStub{targets: []startupActivationTarget{
+		{ID: "test.runtime-a", Version: "1.0.0"},
+		{ID: "test.runtime-b", Version: "2.0.0"},
+	}}
+	registry := cardtmpl.NewRegistry()
+	registry.Freeze()
+	validated := 0
+	api := &API{
+		store: store, registry: registry,
+		validateStateTarget: func(ctx context.Context, _ cardtmpl.ID, _ string) (stateTargetReceipt, error) {
+			deadline, ok := ctx.Deadline()
+			if !ok || time.Until(deadline) <= 0 || time.Until(deadline) > 15*time.Second {
+				return stateTargetReceipt{}, errors.New("active target validation context is not independently bounded")
+			}
+			validated++
+			return stateTargetReceipt{}, nil
+		},
+	}
+	if err := api.initializeRuntimeCatalog(context.Background()); err != nil {
+		t.Fatalf("initializeRuntimeCatalog: %v", err)
+	}
+	if validated != 2 {
+		t.Fatalf("validated targets = %d, want 2", validated)
+	}
+}
+
+func TestInitializeRuntimeCatalogReportsActiveTargetCountOnOverflow(t *testing.T) {
+	targets := make([]startupActivationTarget, startupActiveTargetLimit+1)
+	store := &startupStoreStub{
+		targets: targets,
+		listErr: ErrCatalogIntegrity,
+	}
+	registry := cardtmpl.NewRegistry()
+	registry.Freeze()
+	metrics := newCatalogMetrics(prometheus.NewRegistry())
+	api := &API{store: store, registry: registry, metrics: metrics}
+
+	if err := api.initializeRuntimeCatalog(context.Background()); !errors.Is(err, ErrCatalogIntegrity) {
+		t.Fatalf("initializeRuntimeCatalog overflow error = %v, want ErrCatalogIntegrity", err)
+	}
+	if got := testutil.ToFloat64(metrics.activeTargets); got != startupActiveTargetLimit+1 {
+		t.Fatalf("active target gauge = %v, want %d", got, startupActiveTargetLimit+1)
+	}
+}
+
+func TestInitializeRuntimeCatalogAcceptsStaticInteractiveActiveTargetWithoutRouteSpec(t *testing.T) {
+	t.Setenv("OCTO_CARD_ACTION_ROUTES", "")
+	registry := cardtmpl.NewRegistry()
+	registry.RegisterJSON(aireasoningprocess.Assets, aireasoningprocess.HandoffRootV2)
+	registry.Freeze()
+	store := &startupStoreStub{targets: []startupActivationTarget{{
+		ID: aireasoningprocess.TemplateID, Version: aireasoningprocess.TemplateVersionV2,
+	}}}
+	api := &API{store: store, registry: registry}
+	api.validateStateTarget = api.validateTarget
+
+	if err := api.initializeRuntimeCatalog(context.Background()); err != nil {
+		t.Fatalf("initialize static interactive active target: %v", err)
+	}
+}
+
+func TestAPIStartDoesNotBlockOnDatabaseReconciliation(t *testing.T) {
+	store := &blockingStartupStore{started: make(chan struct{})}
+	registry := cardtmpl.NewRegistry()
+	registry.Freeze()
+	api := &API{
+		store: store, registry: registry, readiness: newRuntimeCatalogReadiness(),
+		validateStateTarget: func(context.Context, cardtmpl.ID, string) (stateTargetReceipt, error) {
+			return stateTargetReceipt{}, nil
+		},
+	}
+	startResult := make(chan error, 1)
+	go func() { startResult <- api.Start() }()
+	select {
+	case err := <-startResult:
+		if err != nil {
+			t.Fatalf("Start: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Start blocked on database reconciliation")
+	}
+	select {
+	case <-store.started:
+	case <-time.After(time.Second):
+		t.Fatal("background reconciliation did not start")
+	}
+	stopResult := make(chan error, 1)
+	go func() { stopResult <- api.Stop() }()
+	select {
+	case err := <-stopResult:
+		if err != nil {
+			t.Fatalf("Stop: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Stop did not cancel background reconciliation")
+	}
+}
+
+func TestAPIStartMarksReadyOnlyAfterSuccessfulInitialization(t *testing.T) {
+	store := &lifecycleStartupStore{}
+	registry := cardtmpl.NewRegistry()
+	registry.Freeze()
+	readiness := newRuntimeCatalogReadiness()
+	api := &API{
+		store: store, registry: registry, readiness: readiness,
+		validateStateTarget: func(context.Context, cardtmpl.ID, string) (stateTargetReceipt, error) {
+			return stateTargetReceipt{}, nil
+		},
+	}
+	if err := api.Start(); err != nil {
+		t.Fatal(err)
+	}
+	waitForStartupDone(t, api)
+	if err := readiness.Check(); err != nil {
+		t.Fatalf("readiness after successful initialization: %v", err)
+	}
+	if err := api.Stop(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestAPIStartPoisonsReadinessOnPersistentIntegrityFailure(t *testing.T) {
+	store := &lifecycleStartupStore{fakeCatalogStore: fakeCatalogStore{reconcileErr: ErrCatalogIntegrity}}
+	registry := cardtmpl.NewRegistry()
+	registry.Freeze()
+	readiness := newRuntimeCatalogReadiness()
+	api := &API{store: store, registry: registry, readiness: readiness}
+	if err := api.Start(); err != nil {
+		t.Fatal(err)
+	}
+	waitForStartupDone(t, api)
+	if err := readiness.Check(); !errors.Is(err, cardtmpl.ErrRuntimeCatalogIntegrity) {
+		t.Fatalf("integrity readiness error = %v", err)
+	}
+}
+
+func waitForStartupDone(t *testing.T, api *API) {
+	t.Helper()
+	api.startupMu.Lock()
+	done := api.startupDone
+	api.startupMu.Unlock()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("runtime catalog startup did not finish")
+	}
+}
+
+type startupStoreStub struct {
+	fakeCatalogStore
+	targets []startupActivationTarget
+	listErr error
+	calls   []string
+}
+
+type blockingStartupStore struct {
+	fakeCatalogStore
+	started chan struct{}
+	once    sync.Once
+}
+
+type lifecycleStartupStore struct {
+	fakeCatalogStore
+}
+
+func (s *lifecycleStartupStore) ListActiveTargets(context.Context) ([]startupActivationTarget, error) {
+	return nil, nil
+}
+
+func (s *blockingStartupStore) ReconcileStatic(ctx context.Context, _ []cardtmpl.TemplateMeta) error {
+	s.once.Do(func() { close(s.started) })
+	<-ctx.Done()
+	return ctx.Err()
+}
+
+func (s *blockingStartupStore) ListActiveTargets(context.Context) ([]startupActivationTarget, error) {
+	return nil, nil
+}
+
+func (s *startupStoreStub) ReconcileStatic(context.Context, []cardtmpl.TemplateMeta) error {
+	s.calls = append(s.calls, "reconcile")
+	return nil
+}
+
+func (s *startupStoreStub) ListActiveTargets(context.Context) ([]startupActivationTarget, error) {
+	s.calls = append(s.calls, "list")
+	return append([]startupActivationTarget(nil), s.targets...), s.listErr
+}

--- a/modules/card_template_catalog/sql/20260728000002_card_template_catalog_activation.sql
+++ b/modules/card_template_catalog/sql/20260728000002_card_template_catalog_activation.sql
@@ -1,0 +1,44 @@
+-- +migrate Up
+
+CREATE TABLE card_template_activation (
+    template_id     VARCHAR(128) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    active_version  VARCHAR(64) CHARACTER SET ascii COLLATE ascii_bin NULL,
+    status          VARCHAR(16) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    revision BIGINT UNSIGNED NOT NULL,
+    updated_by      VARCHAR(128) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL,
+    reason          VARCHAR(512) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL,
+    change_ticket   VARCHAR(128) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL,
+    updated_at      DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+    PRIMARY KEY (template_id),
+    KEY idx_card_template_activation_status (status, template_id),
+    CONSTRAINT chk_card_template_activation_status
+        CHECK (status IN ('active', 'disabled')),
+    CONSTRAINT chk_card_template_activation_shape
+        CHECK ((status = 'active' AND active_version IS NOT NULL) OR
+               (status = 'disabled' AND active_version IS NULL)),
+    CONSTRAINT fk_card_template_activation_claim
+        FOREIGN KEY (template_id, active_version)
+        REFERENCES card_template_version_claim (template_id, version)
+        ON DELETE RESTRICT
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+
+ALTER TABLE card_template_audit
+    ADD COLUMN previous_version VARCHAR(64) CHARACTER SET ascii COLLATE ascii_bin NOT NULL DEFAULT '' AFTER version,
+    ADD COLUMN resulting_version VARCHAR(64) CHARACTER SET ascii COLLATE ascii_bin NOT NULL DEFAULT '' AFTER previous_version,
+    ADD COLUMN previous_revision BIGINT UNSIGNED NULL AFTER resulting_version,
+    ADD COLUMN resulting_revision BIGINT UNSIGNED NULL AFTER previous_revision,
+    ADD KEY idx_card_template_audit_page (template_id, id),
+    ADD KEY idx_card_template_audit_previous (template_id, result, operation, previous_version),
+    ADD KEY idx_card_template_audit_resulting (template_id, result, operation, resulting_version);
+
+-- +migrate Down
+DROP TABLE IF EXISTS card_template_activation;
+
+ALTER TABLE card_template_audit
+    DROP INDEX idx_card_template_audit_resulting,
+    DROP INDEX idx_card_template_audit_previous,
+    DROP INDEX idx_card_template_audit_page,
+    DROP COLUMN resulting_revision,
+    DROP COLUMN previous_revision,
+    DROP COLUMN resulting_version,
+    DROP COLUMN previous_version;

--- a/modules/card_template_catalog/state_validation.go
+++ b/modules/card_template_catalog/state_validation.go
@@ -1,0 +1,99 @@
+package card_template_catalog
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/Mininglamp-OSS/octo-server/internal/cardactiondispatch"
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl"
+)
+
+type catalogArtifactReader interface {
+	LoadArtifactMeta(context.Context, cardtmpl.ID, string) (cardtmpl.RuntimeArtifactMeta, error)
+	LoadArtifactBundle(context.Context, cardtmpl.ID, string, string) (cardtmpl.CanonicalBundle, error)
+}
+
+func (a *API) validateTarget(ctx context.Context, id cardtmpl.ID, version string) (stateTargetReceipt, error) {
+	registry := a.registry
+	if registry == nil {
+		registry = cardtmpl.DefaultRegistry()
+	}
+	if registry != nil {
+		if _, err := registry.Lookup(id, version); err == nil {
+			return stateTargetReceipt{meta: cardtmpl.RuntimeArtifactMeta{
+				ID: id, Version: version, Source: cardtmpl.RuntimeSourceStatic,
+			}}, nil
+		} else if !errors.Is(err, cardtmpl.ErrTemplateUnknown) {
+			return stateTargetReceipt{}, err
+		}
+	}
+	reader, ok := a.store.(catalogArtifactReader)
+	if !ok || reader == nil {
+		return stateTargetReceipt{}, errors.New("card template catalog: artifact reader unavailable")
+	}
+	meta, err := reader.LoadArtifactMeta(ctx, id, version)
+	if err != nil {
+		if errors.Is(err, cardtmpl.ErrTemplateUnknown) {
+			return stateTargetReceipt{}, fmt.Errorf("%w: %s@%s", ErrActivationTargetInvalid, id, version)
+		}
+		return stateTargetReceipt{}, err
+	}
+	if meta.Source != cardtmpl.RuntimeSourceDynamic {
+		return stateTargetReceipt{}, fmt.Errorf("%w: non-built-in static target %s@%s", ErrCatalogIntegrity, id, version)
+	}
+	if meta.Blocked {
+		return stateTargetReceipt{}, fmt.Errorf("%w: %s@%s", ErrArtifactBlocked, id, version)
+	}
+	canonical, err := reader.LoadArtifactBundle(ctx, id, version, meta.Hash)
+	if err != nil {
+		return stateTargetReceipt{}, err
+	}
+	bundle, err := cardtmpl.DecodeBundleJSON(canonical)
+	if err != nil {
+		return stateTargetReceipt{}, fmt.Errorf("%w: decode persisted target", cardtmpl.ErrRuntimeCatalogIntegrity)
+	}
+	compiler := a.compile
+	if compiler == nil {
+		compiler = cardtmpl.CompileJSONArtifact
+	}
+	artifact, err := compiler(ctx, bundle, cardtmpl.DefaultCompileLimits())
+	if err != nil {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) ||
+			errors.Is(err, cardtmpl.ErrArtifactCompileBusy) {
+			return stateTargetReceipt{}, err
+		}
+		return stateTargetReceipt{}, fmt.Errorf("%w: compile persisted target", cardtmpl.ErrRuntimeCatalogIntegrity)
+	}
+	if artifact.Meta.ID != meta.ID || artifact.Meta.Version != meta.Version ||
+		artifact.Engine != meta.Engine || artifact.Hash != meta.Hash || artifact.Owner != meta.Owner ||
+		artifact.Visibility != meta.Visibility || artifact.Meta.Protocol != meta.Protocol ||
+		artifact.ContractVersion != meta.ContractVersion {
+		return stateTargetReceipt{}, fmt.Errorf("%w: compiled target metadata mismatch", cardtmpl.ErrRuntimeCatalogIntegrity)
+	}
+	if !isApprovedRuntimeOwner(artifact.Owner) {
+		return stateTargetReceipt{}, fmt.Errorf("%w: target owner is not approved", ErrActivationTargetInvalid)
+	}
+	if err := validateInteractiveTarget(artifact.Meta); err != nil {
+		return stateTargetReceipt{}, err
+	}
+	return stateTargetReceipt{meta: meta}, nil
+}
+
+func validateInteractiveTarget(meta cardtmpl.TemplateMeta) error {
+	contract := meta.ActionContract
+	if contract == nil {
+		return nil
+	}
+	specs, err := cardactiondispatch.LoadRouteSpecs(os.Getenv("OCTO_CARD_ACTION_ROUTES"))
+	if err != nil {
+		return fmt.Errorf("%w: invalid card action route configuration", ErrCatalogIntegrity)
+	}
+	for _, spec := range specs {
+		if spec.Owner == contract.Owner && spec.ActionType == contract.ActionType {
+			return nil
+		}
+	}
+	return fmt.Errorf("%w: no callback route for interactive target", ErrActivationTargetInvalid)
+}

--- a/modules/card_template_catalog/state_validation_test.go
+++ b/modules/card_template_catalog/state_validation_test.go
@@ -1,0 +1,190 @@
+package card_template_catalog
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl"
+	aireasoningprocess "github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl/ai_reasoning_process"
+	docscommented "github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl/docs_commented"
+)
+
+func TestValidateTargetRecompilesDynamicArtifactAndChecksStoredMetadata(t *testing.T) {
+	root, err := cardtmpl.DecodeStrictJSONObject(validControlRequestJSON(t, false))
+	if err != nil {
+		t.Fatal(err)
+	}
+	bundle, err := cardtmpl.DecodeBundleValue(root["bundle"])
+	if err != nil {
+		t.Fatal(err)
+	}
+	artifact, err := cardtmpl.CompileJSONArtifact(context.Background(), bundle, cardtmpl.DefaultCompileLimits())
+	if err != nil {
+		t.Fatal(err)
+	}
+	store := &fakeTargetValidationStore{
+		meta: cardtmpl.RuntimeArtifactMeta{
+			ID: artifact.Meta.ID, Version: artifact.Meta.Version, Source: cardtmpl.RuntimeSourceDynamic,
+			Engine: artifact.Engine, Hash: artifact.Hash, Owner: artifact.Owner,
+			Visibility: artifact.Visibility, Protocol: artifact.Meta.Protocol,
+			ContractVersion: artifact.ContractVersion,
+		},
+		bundle: artifact.Bundle,
+	}
+	previous := cardtmpl.DefaultRegistry()
+	cardtmpl.SetDefaultRegistry(nil)
+	t.Cleanup(func() { cardtmpl.SetDefaultRegistry(previous) })
+	compileCalls := 0
+	api := &API{store: store, compile: func(ctx context.Context, input cardtmpl.Bundle, limits cardtmpl.CompileLimits) (*cardtmpl.CompiledArtifact, error) {
+		compileCalls++
+		return cardtmpl.CompileJSONArtifact(ctx, input, limits)
+	}}
+	receipt, err := api.validateTarget(context.Background(), artifact.Meta.ID, artifact.Meta.Version)
+	if err != nil {
+		t.Fatalf("validateTarget: %v", err)
+	}
+	if receipt.meta.Hash != artifact.Hash || receipt.meta.Source != cardtmpl.RuntimeSourceDynamic {
+		t.Fatalf("validation receipt = %+v", receipt.meta)
+	}
+	if compileCalls != 1 || store.bundleCalls != 1 {
+		t.Fatalf("compile/bundle calls = %d/%d, want 1/1", compileCalls, store.bundleCalls)
+	}
+
+	store.meta.Owner = "other"
+	if _, err := api.validateTarget(context.Background(), artifact.Meta.ID, artifact.Meta.Version); !errors.Is(err, cardtmpl.ErrRuntimeCatalogIntegrity) {
+		t.Fatalf("metadata mismatch error = %v, want ErrRuntimeCatalogIntegrity", err)
+	}
+}
+
+func TestValidateTargetAllowsStaticInteractiveTemplateWithoutRouteSpec(t *testing.T) {
+	t.Setenv("OCTO_CARD_ACTION_ROUTES", "")
+	registry := cardtmpl.NewRegistry()
+	registry.RegisterJSON(aireasoningprocess.Assets, aireasoningprocess.HandoffRootV2)
+	registry.Freeze()
+
+	api := &API{registry: registry, store: &fakeCatalogStore{}}
+	receipt, err := api.validateTarget(context.Background(), aireasoningprocess.TemplateID, aireasoningprocess.TemplateVersionV2)
+	if err != nil {
+		t.Fatalf("validate static interactive target: %v", err)
+	}
+	if receipt.meta.Source != cardtmpl.RuntimeSourceStatic {
+		t.Fatalf("static interactive source = %q, want static", receipt.meta.Source)
+	}
+}
+
+func TestValidateTargetRequiresConfiguredRouteForDynamicInteractiveTemplate(t *testing.T) {
+	t.Setenv("OCTO_CARD_ACTION_ROUTES", "")
+	artifact := integrationArtifactForVersion(t, "1.0.0")
+	artifact.Meta.ActionContract = &cardtmpl.TemplateActionContract{Owner: "ai", ActionType: "reasoning.control"}
+	meta := receiptForIntegrationArtifact(artifact).meta
+	api := &API{
+		registry: cardtmpl.NewRegistry(),
+		store:    &fakeTargetValidationStore{meta: meta, bundle: artifact.Bundle},
+		compile: func(context.Context, cardtmpl.Bundle, cardtmpl.CompileLimits) (*cardtmpl.CompiledArtifact, error) {
+			return artifact, nil
+		},
+	}
+	_, err := api.validateTarget(context.Background(), artifact.Meta.ID, artifact.Meta.Version)
+	if !errors.Is(err, ErrActivationTargetInvalid) {
+		t.Fatalf("validateTarget error = %v, want ErrActivationTargetInvalid", err)
+	}
+}
+
+func TestValidateTargetRejectsUnapprovedDynamicOwner(t *testing.T) {
+	root, err := cardtmpl.DecodeStrictJSONObject(validControlRequestJSON(t, false))
+	if err != nil {
+		t.Fatal(err)
+	}
+	bundle, err := cardtmpl.DecodeBundleValue(root["bundle"])
+	if err != nil {
+		t.Fatal(err)
+	}
+	artifact, err := cardtmpl.CompileJSONArtifact(context.Background(), bundle, cardtmpl.DefaultCompileLimits())
+	if err != nil {
+		t.Fatal(err)
+	}
+	unapproved := *artifact
+	unapproved.Owner = "ext.vendor"
+	meta := cardtmpl.RuntimeArtifactMeta{
+		ID: unapproved.Meta.ID, Version: unapproved.Meta.Version, Source: cardtmpl.RuntimeSourceDynamic,
+		Engine: unapproved.Engine, Hash: unapproved.Hash, Owner: unapproved.Owner,
+		Visibility: unapproved.Visibility, Protocol: unapproved.Meta.Protocol,
+		ContractVersion: unapproved.ContractVersion,
+	}
+	api := &API{
+		store: &fakeTargetValidationStore{meta: meta, bundle: unapproved.Bundle},
+		compile: func(context.Context, cardtmpl.Bundle, cardtmpl.CompileLimits) (*cardtmpl.CompiledArtifact, error) {
+			return &unapproved, nil
+		},
+	}
+	_, err = api.validateTarget(context.Background(), unapproved.Meta.ID, unapproved.Meta.Version)
+	if !errors.Is(err, ErrActivationTargetInvalid) {
+		t.Fatalf("unapproved owner error = %v, want ErrActivationTargetInvalid", err)
+	}
+}
+
+func TestValidateTargetStaticDisplayAndDynamicFailurePaths(t *testing.T) {
+	displayRegistry := cardtmpl.NewRegistry()
+	displayRegistry.Register(docscommented.New(), docscommented.Assets, docscommented.HandoffRoot)
+	displayRegistry.Freeze()
+	api := &API{registry: displayRegistry, store: &fakeCatalogStore{}}
+	receipt, err := api.validateTarget(context.Background(), docscommented.TemplateID, docscommented.TemplateVersion)
+	if err != nil || receipt.meta.Source != cardtmpl.RuntimeSourceStatic {
+		t.Fatalf("static display receipt=%+v err=%v", receipt.meta, err)
+	}
+
+	artifact := integrationArtifactForVersion(t, "1.0.0")
+	meta := receiptForIntegrationArtifact(artifact).meta
+	meta.Blocked = true
+	blockedStore := &fakeTargetValidationStore{meta: meta, bundle: artifact.Bundle}
+	api = &API{store: blockedStore}
+	if _, err := api.validateTarget(context.Background(), artifact.Meta.ID, artifact.Meta.Version); !errors.Is(err, ErrArtifactBlocked) {
+		t.Fatalf("blocked target error=%v, want ErrArtifactBlocked", err)
+	}
+	if blockedStore.bundleCalls != 0 {
+		t.Fatalf("blocked target bundle calls=%d, want 0", blockedStore.bundleCalls)
+	}
+
+	api = &API{store: &fakeCatalogStore{}}
+	if _, err := api.validateTarget(context.Background(), artifact.Meta.ID, artifact.Meta.Version); err == nil {
+		t.Fatal("validateTarget accepted store without artifact reader")
+	}
+
+	meta.Blocked = false
+	api = &API{
+		store: &fakeTargetValidationStore{meta: meta, bundle: artifact.Bundle},
+		compile: func(context.Context, cardtmpl.Bundle, cardtmpl.CompileLimits) (*cardtmpl.CompiledArtifact, error) {
+			return nil, cardtmpl.ErrArtifactCompileBusy
+		},
+	}
+	if _, err := api.validateTarget(context.Background(), artifact.Meta.ID, artifact.Meta.Version); !errors.Is(err, cardtmpl.ErrArtifactCompileBusy) {
+		t.Fatalf("compile busy error=%v, want ErrArtifactCompileBusy", err)
+	}
+}
+
+func TestValidateInteractiveTargetRejectsInvalidRouteConfiguration(t *testing.T) {
+	t.Setenv("OCTO_CARD_ACTION_ROUTES", "not-json")
+	meta := cardtmpl.TemplateMeta{ActionContract: &cardtmpl.TemplateActionContract{Owner: "docs", ActionType: "docs.access.decision"}}
+	if err := validateInteractiveTarget(meta); !errors.Is(err, ErrCatalogIntegrity) {
+		t.Fatalf("invalid route config error=%v, want ErrCatalogIntegrity", err)
+	}
+}
+
+type fakeTargetValidationStore struct {
+	fakeCatalogStore
+	meta        cardtmpl.RuntimeArtifactMeta
+	metaErr     error
+	bundle      cardtmpl.CanonicalBundle
+	bundleErr   error
+	bundleCalls int
+}
+
+func (s *fakeTargetValidationStore) LoadArtifactMeta(context.Context, cardtmpl.ID, string) (cardtmpl.RuntimeArtifactMeta, error) {
+	return s.meta, s.metaErr
+}
+
+func (s *fakeTargetValidationStore) LoadArtifactBundle(context.Context, cardtmpl.ID, string, string) (cardtmpl.CanonicalBundle, error) {
+	s.bundleCalls++
+	return append(cardtmpl.CanonicalBundle(nil), s.bundle...), s.bundleErr
+}

--- a/modules/card_template_catalog/store_read.go
+++ b/modules/card_template_catalog/store_read.go
@@ -1,0 +1,190 @@
+package card_template_catalog
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl"
+)
+
+const (
+	managerReadDefaultLimit = 50
+	managerReadHardLimit    = 100
+
+	selectTemplateVersionsSQL = `SELECT c.version, c.source, a.owner, a.visibility, a.engine_contract,
+        a.protocol, a.contract_version, a.content_sha256, a.blocked_at, c.created_at
+        FROM card_template_version_claim c
+        LEFT JOIN card_template_artifact a
+          ON a.template_id = c.template_id AND a.version = c.version
+        WHERE c.template_id = ?
+        ORDER BY c.version ASC
+        LIMIT ?`
+	selectTemplateAuditSQL = `SELECT id, actor_uid, operation, version, previous_version, resulting_version,
+        previous_revision, resulting_revision, result, reason, change_ticket, created_at
+        FROM card_template_audit
+        WHERE template_id = ? AND (? = 0 OR id < ?)
+        ORDER BY id DESC
+        LIMIT ?`
+)
+
+type TemplateVersionDetail struct {
+	Version         string
+	Source          cardtmpl.RuntimeSource
+	Owner           string
+	Visibility      string
+	Engine          string
+	Protocol        string
+	ContractVersion string
+	Hash            string
+	Blocked         bool
+	BlockedAt       *time.Time
+	CreatedAt       time.Time
+}
+
+type TemplateDetail struct {
+	TemplateID string
+	Activation cardtmpl.RuntimeActivation
+	Versions   []TemplateVersionDetail
+	Truncated  bool
+}
+
+type TemplateAuditEntry struct {
+	ID                uint64    `json:"id"`
+	ActorUID          string    `json:"actor_uid"`
+	Operation         string    `json:"operation"`
+	Version           string    `json:"version,omitempty"`
+	PreviousVersion   string    `json:"previous_version,omitempty"`
+	ResultingVersion  string    `json:"resulting_version,omitempty"`
+	PreviousRevision  *uint64   `json:"previous_revision,omitempty"`
+	ResultingRevision *uint64   `json:"resulting_revision,omitempty"`
+	Result            string    `json:"result"`
+	Reason            string    `json:"reason"`
+	ChangeTicket      string    `json:"change_ticket"`
+	CreatedAt         time.Time `json:"created_at"`
+}
+
+type TemplateAuditPage struct {
+	Entries    []TemplateAuditEntry
+	NextCursor uint64
+}
+
+func (s *store) GetTemplateDetail(ctx context.Context, id cardtmpl.ID, limit int) (TemplateDetail, error) {
+	limit = normalizeManagerReadLimit(limit)
+	activation, err := s.LoadActivation(ctx, id)
+	if err != nil {
+		return TemplateDetail{}, err
+	}
+	rows, err := s.db.QueryContext(ctx, selectTemplateVersionsSQL, string(id), limit+1)
+	if err != nil {
+		return TemplateDetail{}, fmt.Errorf("card template catalog: list template versions: %w", err)
+	}
+	defer rows.Close()
+
+	versions := make([]TemplateVersionDetail, 0, limit)
+	for rows.Next() {
+		var version, source string
+		var owner, visibility, engine, protocol, contractVersion, hash sql.NullString
+		var blockedAt sql.NullTime
+		var createdAt time.Time
+		if err := rows.Scan(&version, &source, &owner, &visibility, &engine, &protocol,
+			&contractVersion, &hash, &blockedAt, &createdAt); err != nil {
+			return TemplateDetail{}, fmt.Errorf("card template catalog: scan template version: %w", err)
+		}
+		detail := TemplateVersionDetail{Version: version, CreatedAt: createdAt}
+		switch source {
+		case claimSourceStatic:
+			detail.Source = cardtmpl.RuntimeSourceStatic
+			if owner.Valid || visibility.Valid || engine.Valid || protocol.Valid || contractVersion.Valid || hash.Valid || blockedAt.Valid {
+				return TemplateDetail{}, fmt.Errorf("%w: static claim has artifact metadata", ErrCatalogIntegrity)
+			}
+		case claimSourceDynamic:
+			if !owner.Valid || !visibility.Valid || !engine.Valid || !protocol.Valid || !contractVersion.Valid || !hash.Valid {
+				return TemplateDetail{}, fmt.Errorf("%w: dynamic claim has incomplete artifact metadata", ErrCatalogIntegrity)
+			}
+			detail.Source = cardtmpl.RuntimeSourceDynamic
+			detail.Owner, detail.Visibility, detail.Engine = owner.String, visibility.String, engine.String
+			detail.Protocol, detail.ContractVersion, detail.Hash = protocol.String, contractVersion.String, hash.String
+			detail.Blocked = blockedAt.Valid
+			if blockedAt.Valid {
+				value := blockedAt.Time
+				detail.BlockedAt = &value
+			}
+		default:
+			return TemplateDetail{}, fmt.Errorf("%w: unknown claim source", ErrCatalogIntegrity)
+		}
+		versions = append(versions, detail)
+	}
+	if err := rows.Err(); err != nil {
+		return TemplateDetail{}, fmt.Errorf("card template catalog: iterate template versions: %w", err)
+	}
+	truncated := len(versions) > limit
+	if truncated {
+		versions = versions[:limit]
+	}
+	return TemplateDetail{
+		TemplateID: string(id), Activation: activation, Versions: versions, Truncated: truncated,
+	}, nil
+}
+
+func (s *store) ListAudit(
+	ctx context.Context,
+	id cardtmpl.ID,
+	cursor uint64,
+	limit int,
+) (TemplateAuditPage, error) {
+	limit = normalizeManagerReadLimit(limit)
+	rows, err := s.db.QueryContext(ctx, selectTemplateAuditSQL, string(id), cursor, cursor, limit+1)
+	if err != nil {
+		return TemplateAuditPage{}, fmt.Errorf("card template catalog: list audit: %w", err)
+	}
+	defer rows.Close()
+	entries := make([]TemplateAuditEntry, 0, limit)
+	for rows.Next() {
+		var entry TemplateAuditEntry
+		var previousRevision, resultingRevision sql.NullInt64
+		if err := rows.Scan(
+			&entry.ID, &entry.ActorUID, &entry.Operation, &entry.Version,
+			&entry.PreviousVersion, &entry.ResultingVersion,
+			&previousRevision, &resultingRevision, &entry.Result, &entry.Reason,
+			&entry.ChangeTicket, &entry.CreatedAt,
+		); err != nil {
+			return TemplateAuditPage{}, fmt.Errorf("card template catalog: scan audit: %w", err)
+		}
+		if previousRevision.Valid {
+			if previousRevision.Int64 < 0 {
+				return TemplateAuditPage{}, fmt.Errorf("%w: negative previous revision", ErrCatalogIntegrity)
+			}
+			value := uint64(previousRevision.Int64)
+			entry.PreviousRevision = &value
+		}
+		if resultingRevision.Valid {
+			if resultingRevision.Int64 < 0 {
+				return TemplateAuditPage{}, fmt.Errorf("%w: negative resulting revision", ErrCatalogIntegrity)
+			}
+			value := uint64(resultingRevision.Int64)
+			entry.ResultingRevision = &value
+		}
+		entries = append(entries, entry)
+	}
+	if err := rows.Err(); err != nil {
+		return TemplateAuditPage{}, fmt.Errorf("card template catalog: iterate audit: %w", err)
+	}
+	page := TemplateAuditPage{Entries: entries}
+	if len(entries) > limit {
+		page.Entries = entries[:limit]
+		page.NextCursor = page.Entries[len(page.Entries)-1].ID
+	}
+	return page, nil
+}
+
+func normalizeManagerReadLimit(limit int) int {
+	if limit <= 0 {
+		return managerReadDefaultLimit
+	}
+	if limit > managerReadHardLimit {
+		return managerReadHardLimit
+	}
+	return limit
+}

--- a/modules/card_template_catalog/store_read_test.go
+++ b/modules/card_template_catalog/store_read_test.go
@@ -1,0 +1,67 @@
+package card_template_catalog
+
+import (
+	"context"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl"
+)
+
+func TestStoreGetTemplateDetailReturnsSourceAndActivationWithoutBundle(t *testing.T) {
+	store, mock, closeDB := newMockStore(t)
+	defer closeDB()
+	now := time.Date(2026, 7, 28, 12, 0, 0, 0, time.UTC)
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT active_version, status, revision")).
+		WithArgs("test.runtime-card").
+		WillReturnRows(sqlmock.NewRows([]string{"active_version", "status", "revision"}).
+			AddRow("1.1.0", "active", 4))
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT c.version, c.source, a.owner, a.visibility, a.engine_contract")).
+		WithArgs("test.runtime-card", 101).
+		WillReturnRows(sqlmock.NewRows([]string{
+			"version", "source", "owner", "visibility", "engine_contract", "protocol",
+			"contract_version", "content_sha256", "blocked_at", "created_at",
+		}).
+			AddRow("1.0.0", "static", nil, nil, nil, nil, nil, nil, nil, now).
+			AddRow("1.1.0", "dynamic", "ai", "private", cardtmpl.JSONTemplateEngineV1,
+				cardtmpl.Protocol, "1.0.0", "abc", now, now))
+
+	detail, err := store.GetTemplateDetail(context.Background(), "test.runtime-card", 100)
+	if err != nil {
+		t.Fatalf("GetTemplateDetail: %v", err)
+	}
+	if detail.Activation.Version != "1.1.0" || detail.Activation.Revision != 4 || len(detail.Versions) != 2 {
+		t.Fatalf("detail = %+v", detail)
+	}
+	if detail.Versions[0].Source != cardtmpl.RuntimeSourceStatic || detail.Versions[1].Source != cardtmpl.RuntimeSourceDynamic ||
+		!detail.Versions[1].Blocked {
+		t.Fatalf("versions = %+v", detail.Versions)
+	}
+	assertMockExpectations(t, mock)
+}
+
+func TestStoreListAuditUsesDescendingCursorAndHardLimit(t *testing.T) {
+	store, mock, closeDB := newMockStore(t)
+	defer closeDB()
+	now := time.Date(2026, 7, 28, 12, 0, 0, 0, time.UTC)
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, actor_uid, operation, version, previous_version, resulting_version")).
+		WithArgs("test.runtime-card", uint64(50), uint64(50), 3).
+		WillReturnRows(sqlmock.NewRows([]string{
+			"id", "actor_uid", "operation", "version", "previous_version", "resulting_version",
+			"previous_revision", "resulting_revision", "result", "reason", "change_ticket", "created_at",
+		}).
+			AddRow(49, "admin-1", "rollback", "1.0.0", "1.1.0", "1.0.0", 3, 4, "ok", "incident", "INC-1", now).
+			AddRow(48, "admin-1", "activate", "1.1.0", "1.0.0", "1.1.0", 2, 3, "ok", "rollout", "CHG-2", now).
+			AddRow(47, "admin-1", "publish", "1.1.0", "", "", nil, nil, "created", "reviewed", "CHG-1", now))
+
+	page, err := store.ListAudit(context.Background(), "test.runtime-card", 50, 2)
+	if err != nil {
+		t.Fatalf("ListAudit: %v", err)
+	}
+	if len(page.Entries) != 2 || page.NextCursor != 48 {
+		t.Fatalf("page = %+v", page)
+	}
+	assertMockExpectations(t, mock)
+}

--- a/modules/card_template_catalog/store_runtime.go
+++ b/modules/card_template_catalog/store_runtime.go
@@ -1,0 +1,118 @@
+package card_template_catalog
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl"
+)
+
+const (
+	selectRuntimeActivationSQL = `SELECT active_version, status, revision
+        FROM card_template_activation
+        WHERE template_id = ?`
+	selectRuntimeArtifactMetaSQL = `SELECT c.source, a.owner, a.visibility, a.engine_contract,
+        a.protocol, a.contract_version, a.content_sha256, a.blocked_at IS NOT NULL
+        FROM card_template_version_claim c
+        LEFT JOIN card_template_artifact a
+          ON a.template_id = c.template_id AND a.version = c.version
+        WHERE c.template_id = ? AND c.version = ?`
+	selectRuntimeArtifactBundleSQL = `SELECT canonical_bundle FROM card_template_artifact
+        WHERE template_id = ? AND version = ? AND content_sha256 = ?`
+)
+
+func (s *store) LoadActivation(ctx context.Context, id cardtmpl.ID) (cardtmpl.RuntimeActivation, error) {
+	var version sql.NullString
+	var status string
+	var revision uint64
+	err := s.db.QueryRowContext(ctx, selectRuntimeActivationSQL, string(id)).
+		Scan(&version, &status, &revision)
+	if errors.Is(err, sql.ErrNoRows) {
+		return cardtmpl.RuntimeActivation{}, nil
+	}
+	if err != nil {
+		return cardtmpl.RuntimeActivation{}, fmt.Errorf("card template catalog: load runtime activation: %w", err)
+	}
+
+	result := cardtmpl.RuntimeActivation{Exists: true, Version: version.String, Revision: revision}
+	switch status {
+	case string(activationStatusActive):
+		if !version.Valid || version.String == "" {
+			return cardtmpl.RuntimeActivation{}, fmt.Errorf("%w: active row has no version", cardtmpl.ErrRuntimeCatalogIntegrity)
+		}
+		result.Status = cardtmpl.RuntimeActivationActive
+	case string(activationStatusDisabled):
+		if version.Valid {
+			return cardtmpl.RuntimeActivation{}, fmt.Errorf("%w: disabled row has a version", cardtmpl.ErrRuntimeCatalogIntegrity)
+		}
+		result.Status = cardtmpl.RuntimeActivationDisabled
+	default:
+		return cardtmpl.RuntimeActivation{}, fmt.Errorf("%w: invalid activation status", cardtmpl.ErrRuntimeCatalogIntegrity)
+	}
+	return result, nil
+}
+
+func (s *store) LoadArtifactMeta(
+	ctx context.Context,
+	id cardtmpl.ID,
+	version string,
+) (cardtmpl.RuntimeArtifactMeta, error) {
+	var source string
+	var owner, visibility, engine, protocol, contractVersion, hash sql.NullString
+	var blocked bool
+	err := s.db.QueryRowContext(ctx, selectRuntimeArtifactMetaSQL, string(id), version).Scan(
+		&source, &owner, &visibility, &engine, &protocol, &contractVersion, &hash, &blocked,
+	)
+	if errors.Is(err, sql.ErrNoRows) {
+		return cardtmpl.RuntimeArtifactMeta{}, fmt.Errorf("%w: %s@%s", cardtmpl.ErrTemplateUnknown, id, version)
+	}
+	if err != nil {
+		return cardtmpl.RuntimeArtifactMeta{}, fmt.Errorf("card template catalog: load runtime artifact metadata: %w", err)
+	}
+
+	result := cardtmpl.RuntimeArtifactMeta{ID: id, Version: version, Blocked: blocked}
+	switch source {
+	case claimSourceStatic:
+		result.Source = cardtmpl.RuntimeSourceStatic
+		if owner.Valid || visibility.Valid || engine.Valid || protocol.Valid || contractVersion.Valid || hash.Valid {
+			return cardtmpl.RuntimeArtifactMeta{}, fmt.Errorf("%w: static claim has dynamic artifact", cardtmpl.ErrRuntimeCatalogIntegrity)
+		}
+		return result, nil
+	case claimSourceDynamic:
+		if !owner.Valid || !visibility.Valid || !engine.Valid || !protocol.Valid || !contractVersion.Valid || !hash.Valid {
+			return cardtmpl.RuntimeArtifactMeta{}, fmt.Errorf("%w: dynamic claim has no complete artifact", cardtmpl.ErrRuntimeCatalogIntegrity)
+		}
+		result.Source = cardtmpl.RuntimeSourceDynamic
+	default:
+		return cardtmpl.RuntimeArtifactMeta{}, fmt.Errorf("%w: unknown claim source", cardtmpl.ErrRuntimeCatalogIntegrity)
+	}
+	result.Owner = owner.String
+	result.Visibility = visibility.String
+	result.Engine = engine.String
+	result.Protocol = protocol.String
+	result.ContractVersion = contractVersion.String
+	result.Hash = hash.String
+	return result, nil
+}
+
+func (s *store) LoadArtifactBundle(
+	ctx context.Context,
+	id cardtmpl.ID,
+	version string,
+	hash string,
+) (cardtmpl.CanonicalBundle, error) {
+	var raw []byte
+	err := s.db.QueryRowContext(ctx, selectRuntimeArtifactBundleSQL, string(id), version, hash).Scan(&raw)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, fmt.Errorf("%w: artifact bundle identity/hash mismatch", cardtmpl.ErrRuntimeCatalogIntegrity)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("card template catalog: load runtime artifact bundle: %w", err)
+	}
+	if len(raw) == 0 || len(raw) > maxCanonicalBundleBytes {
+		return nil, fmt.Errorf("%w: artifact bundle size is invalid", cardtmpl.ErrRuntimeCatalogIntegrity)
+	}
+	return append(cardtmpl.CanonicalBundle(nil), raw...), nil
+}

--- a/modules/card_template_catalog/store_runtime_test.go
+++ b/modules/card_template_catalog/store_runtime_test.go
@@ -1,0 +1,146 @@
+package card_template_catalog
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl"
+)
+
+func TestStoreLoadActivationDistinguishesAbsentActiveAndDisabled(t *testing.T) {
+	tests := []struct {
+		name string
+		rows *sqlmock.Rows
+		want cardtmpl.RuntimeActivation
+	}{
+		{name: "absent", rows: sqlmock.NewRows([]string{"active_version", "status", "revision"}), want: cardtmpl.RuntimeActivation{}},
+		{name: "active", rows: sqlmock.NewRows([]string{"active_version", "status", "revision"}).
+			AddRow("1.1.0", "active", 7), want: cardtmpl.RuntimeActivation{
+			Exists: true, Version: "1.1.0", Status: cardtmpl.RuntimeActivationActive, Revision: 7,
+		}},
+		{name: "disabled", rows: sqlmock.NewRows([]string{"active_version", "status", "revision"}).
+			AddRow(nil, "disabled", 8), want: cardtmpl.RuntimeActivation{
+			Exists: true, Status: cardtmpl.RuntimeActivationDisabled, Revision: 8,
+		}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			store, mock, closeDB := newMockStore(t)
+			defer closeDB()
+			mock.ExpectQuery(regexp.QuoteMeta("SELECT active_version, status, revision")).
+				WithArgs("test.runtime-card").WillReturnRows(test.rows)
+
+			got, err := store.LoadActivation(context.Background(), "test.runtime-card")
+			if err != nil {
+				t.Fatalf("LoadActivation: %v", err)
+			}
+			if got != test.want {
+				t.Fatalf("LoadActivation = %+v, want %+v", got, test.want)
+			}
+			assertMockExpectations(t, mock)
+		})
+	}
+}
+
+func TestStoreLoadActivationRejectsMalformedShape(t *testing.T) {
+	store, mock, closeDB := newMockStore(t)
+	defer closeDB()
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT active_version, status, revision")).
+		WillReturnRows(sqlmock.NewRows([]string{"active_version", "status", "revision"}).
+			AddRow(nil, "active", 1))
+
+	_, err := store.LoadActivation(context.Background(), "test.runtime-card")
+	if !errors.Is(err, cardtmpl.ErrRuntimeCatalogIntegrity) {
+		t.Fatalf("LoadActivation error = %v, want ErrRuntimeCatalogIntegrity", err)
+	}
+	assertMockExpectations(t, mock)
+}
+
+func TestStoreLoadArtifactMetaReturnsAuthoritativeDynamicFields(t *testing.T) {
+	store, mock, closeDB := newMockStore(t)
+	defer closeDB()
+	hash := strings.Repeat("a", 64)
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT c.source, a.owner, a.visibility, a.engine_contract")).
+		WithArgs("test.runtime-card", "1.1.0").
+		WillReturnRows(sqlmock.NewRows([]string{
+			"source", "owner", "visibility", "engine_contract", "protocol", "contract_version", "content_sha256", "blocked",
+		}).AddRow("dynamic", "ai", "private", cardtmpl.JSONTemplateEngineV1, cardtmpl.Protocol, "1.0.0", hash, true))
+
+	got, err := store.LoadArtifactMeta(context.Background(), "test.runtime-card", "1.1.0")
+	if err != nil {
+		t.Fatalf("LoadArtifactMeta: %v", err)
+	}
+	want := cardtmpl.RuntimeArtifactMeta{
+		ID: "test.runtime-card", Version: "1.1.0", Source: cardtmpl.RuntimeSourceDynamic,
+		Owner: "ai", Visibility: "private", Engine: cardtmpl.JSONTemplateEngineV1,
+		Protocol: cardtmpl.Protocol, ContractVersion: "1.0.0", Hash: hash, Blocked: true,
+	}
+	if got != want {
+		t.Fatalf("LoadArtifactMeta = %+v, want %+v", got, want)
+	}
+	assertMockExpectations(t, mock)
+}
+
+func TestStoreLoadArtifactMetaClassifiesMissingAndCorruptRows(t *testing.T) {
+	t.Run("unknown claim", func(t *testing.T) {
+		store, mock, closeDB := newMockStore(t)
+		defer closeDB()
+		mock.ExpectQuery(regexp.QuoteMeta("SELECT c.source, a.owner, a.visibility, a.engine_contract")).
+			WillReturnError(sql.ErrNoRows)
+		_, err := store.LoadArtifactMeta(context.Background(), "test.unknown", "1.0.0")
+		if !errors.Is(err, cardtmpl.ErrTemplateUnknown) {
+			t.Fatalf("error = %v, want ErrTemplateUnknown", err)
+		}
+		assertMockExpectations(t, mock)
+	})
+
+	t.Run("dynamic claim without artifact", func(t *testing.T) {
+		store, mock, closeDB := newMockStore(t)
+		defer closeDB()
+		mock.ExpectQuery(regexp.QuoteMeta("SELECT c.source, a.owner, a.visibility, a.engine_contract")).
+			WillReturnRows(sqlmock.NewRows([]string{
+				"source", "owner", "visibility", "engine_contract", "protocol", "contract_version", "content_sha256", "blocked",
+			}).AddRow("dynamic", nil, nil, nil, nil, nil, nil, false))
+		_, err := store.LoadArtifactMeta(context.Background(), "test.runtime-card", "1.0.0")
+		if !errors.Is(err, cardtmpl.ErrRuntimeCatalogIntegrity) {
+			t.Fatalf("error = %v, want ErrRuntimeCatalogIntegrity", err)
+		}
+		assertMockExpectations(t, mock)
+	})
+}
+
+func TestStoreLoadArtifactBundleRequiresExactIdentityAndHash(t *testing.T) {
+	store, mock, closeDB := newMockStore(t)
+	defer closeDB()
+	hash := strings.Repeat("b", 64)
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT canonical_bundle FROM card_template_artifact")).
+		WithArgs("test.runtime-card", "1.1.0", hash).
+		WillReturnRows(sqlmock.NewRows([]string{"canonical_bundle"}).AddRow([]byte(`{"catalog":{}}`)))
+
+	got, err := store.LoadArtifactBundle(context.Background(), "test.runtime-card", "1.1.0", hash)
+	if err != nil {
+		t.Fatalf("LoadArtifactBundle: %v", err)
+	}
+	if string(got) != `{"catalog":{}}` {
+		t.Fatalf("bundle = %q", got)
+	}
+	assertMockExpectations(t, mock)
+}
+
+func TestStoreLoadArtifactBundleMissingRowIsIntegrityFailure(t *testing.T) {
+	store, mock, closeDB := newMockStore(t)
+	defer closeDB()
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT canonical_bundle FROM card_template_artifact")).
+		WillReturnError(sql.ErrNoRows)
+
+	_, err := store.LoadArtifactBundle(context.Background(), "test.runtime-card", "1.1.0", strings.Repeat("c", 64))
+	if !errors.Is(err, cardtmpl.ErrRuntimeCatalogIntegrity) {
+		t.Fatalf("error = %v, want ErrRuntimeCatalogIntegrity", err)
+	}
+	assertMockExpectations(t, mock)
+}

--- a/modules/card_template_catalog/store_startup.go
+++ b/modules/card_template_catalog/store_startup.go
@@ -1,0 +1,42 @@
+package card_template_catalog
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl"
+)
+
+const selectActiveTargetsSQL = `SELECT template_id, active_version
+        FROM card_template_activation
+        WHERE status = 'active'
+        ORDER BY template_id ASC
+        LIMIT 129`
+
+func (s *store) ListActiveTargets(ctx context.Context) ([]startupActivationTarget, error) {
+	rows, err := s.db.QueryContext(ctx, selectActiveTargetsSQL)
+	if err != nil {
+		return nil, fmt.Errorf("card template catalog: list active startup targets: %w", err)
+	}
+	defer rows.Close()
+	targets := make([]startupActivationTarget, 0)
+	for rows.Next() {
+		var rawID, version string
+		if err := rows.Scan(&rawID, &version); err != nil {
+			return nil, fmt.Errorf("card template catalog: scan active startup target: %w", err)
+		}
+		id, validID := parseManagerTemplateID(rawID)
+		if !validID || !validManagerVersion(version) {
+			return nil, fmt.Errorf("%w: malformed active target identity", ErrCatalogIntegrity)
+		}
+		targets = append(targets, startupActivationTarget{ID: cardtmpl.ID(id), Version: version})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("card template catalog: iterate active startup targets: %w", err)
+	}
+	if len(targets) > startupActiveTargetLimit {
+		return targets, fmt.Errorf("%w: active target count exceeds hard limit %d",
+			ErrCatalogIntegrity, startupActiveTargetLimit)
+	}
+	return targets, nil
+}

--- a/modules/card_template_catalog/store_startup_test.go
+++ b/modules/card_template_catalog/store_startup_test.go
@@ -1,0 +1,62 @@
+package card_template_catalog
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+)
+
+func TestStoreListActiveTargetsReturnsOnlyValidatedIdentities(t *testing.T) {
+	store, mock, closeDB := newMockStore(t)
+	defer closeDB()
+	mock.ExpectQuery("SELECT template_id, active_version").
+		WillReturnRows(sqlmock.NewRows([]string{"template_id", "active_version"}).
+			AddRow("test.runtime-a", "1.0.0").
+			AddRow("test.runtime-b", "2.1.0"))
+	targets, err := store.ListActiveTargets(context.Background())
+	if err != nil {
+		t.Fatalf("ListActiveTargets: %v", err)
+	}
+	if len(targets) != 2 || targets[0].ID != "test.runtime-a" || targets[1].Version != "2.1.0" {
+		t.Fatalf("targets = %+v", targets)
+	}
+	assertMockExpectations(t, mock)
+}
+
+func TestStoreListActiveTargetsRejectsMalformedPersistentIdentity(t *testing.T) {
+	store, mock, closeDB := newMockStore(t)
+	defer closeDB()
+	mock.ExpectQuery("SELECT template_id, active_version").
+		WillReturnRows(sqlmock.NewRows([]string{"template_id", "active_version"}).
+			AddRow("INVALID", "1.0.0"))
+	_, err := store.ListActiveTargets(context.Background())
+	if !errors.Is(err, ErrCatalogIntegrity) {
+		t.Fatalf("ListActiveTargets error = %v, want ErrCatalogIntegrity", err)
+	}
+	assertMockExpectations(t, mock)
+}
+
+func TestStoreListActiveTargetsRejectsCapacityOverflow(t *testing.T) {
+	const activeTargetLimit = 128
+	if !strings.Contains(selectActiveTargetsSQL, "LIMIT 129") {
+		t.Fatalf("active target query is not bounded to limit+1: %s", selectActiveTargetsSQL)
+	}
+	store, mock, closeDB := newMockStore(t)
+	defer closeDB()
+	rows := sqlmock.NewRows([]string{"template_id", "active_version"})
+	for i := 0; i <= activeTargetLimit; i++ {
+		rows.AddRow("test.runtime-a", "1.0.0")
+	}
+	mock.ExpectQuery("SELECT template_id, active_version").WillReturnRows(rows)
+	targets, err := store.ListActiveTargets(context.Background())
+	if !errors.Is(err, ErrCatalogIntegrity) {
+		t.Fatalf("ListActiveTargets overflow error = %v, want ErrCatalogIntegrity", err)
+	}
+	if len(targets) != activeTargetLimit+1 {
+		t.Fatalf("ListActiveTargets overflow count = %d, want %d", len(targets), activeTargetLimit+1)
+	}
+	assertMockExpectations(t, mock)
+}

--- a/modules/card_template_catalog/store_state.go
+++ b/modules/card_template_catalog/store_state.go
@@ -1,0 +1,582 @@
+package card_template_catalog
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl"
+)
+
+type activationStatus string
+
+const (
+	activationStatusActive   activationStatus = "active"
+	activationStatusDisabled activationStatus = "disabled"
+
+	auditOperationActivate = "activate"
+	auditOperationRollback = "rollback"
+	auditOperationBlock    = "block"
+
+	stateTransitionAttempts = 3
+)
+
+var (
+	ErrActivationConflict      = errors.New("card template activation revision conflict")
+	ErrActivationTargetInvalid = errors.New("card template activation target invalid")
+	ErrArtifactBlocked         = errors.New("card template artifact is blocked")
+	ErrBlockTargetInvalid      = errors.New("card template block target invalid")
+	ErrRollbackTargetInvalid   = errors.New("card template rollback target was never active")
+)
+
+const (
+	selectActivationForUpdateSQL = `SELECT active_version, status, revision
+        FROM card_template_activation
+        WHERE template_id = ?
+        FOR UPDATE`
+	selectStateTargetForUpdateSQL = `SELECT c.source, a.template_id IS NOT NULL, a.blocked_at IS NOT NULL,
+		a.owner, a.visibility, a.engine_contract, a.protocol, a.contract_version, a.content_sha256
+        FROM card_template_version_claim c
+        LEFT JOIN card_template_artifact a
+          ON a.template_id = c.template_id AND a.version = c.version
+        WHERE c.template_id = ? AND c.version = ?
+        FOR UPDATE`
+	insertActivationSQL = `INSERT INTO card_template_activation
+        (template_id, active_version, status, revision, updated_by, reason, change_ticket)
+        VALUES (?, ?, ?, 1, ?, ?, ?)`
+	updateActivationSQL = `UPDATE card_template_activation
+        SET active_version = ?, status = ?, revision = revision + 1,
+            updated_by = ?, reason = ?, change_ticket = ?, updated_at = CURRENT_TIMESTAMP(6)
+        WHERE template_id = ? AND revision = ?`
+	blockArtifactSQL = `UPDATE card_template_artifact
+        SET blocked_at = CURRENT_TIMESTAMP(6), blocked_by = ?, block_reason = ?
+        WHERE template_id = ? AND version = ? AND blocked_at IS NULL`
+	selectPriorActiveSQL = `SELECT EXISTS(SELECT 1 FROM card_template_audit
+        WHERE template_id = ? AND result = 'ok'
+          AND operation IN ('activate', 'rollback', 'block')
+          AND (previous_version = ? OR resulting_version = ?))`
+	insertStateAuditSQL = `INSERT INTO card_template_audit
+        (actor_uid, operation, template_id, version, previous_version, resulting_version,
+         previous_revision, resulting_revision, content_sha256, result, reason, change_ticket)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, '', 'ok', ?, ?)`
+)
+
+type ActivationRequest struct {
+	TemplateID       cardtmpl.ID
+	TargetVersion    string
+	ExpectedRevision uint64
+	ActorUID         string
+	Reason           string
+	ChangeTicket     string
+	targetReceipt    stateTargetReceipt
+}
+
+type ActivationResult struct {
+	TemplateID       cardtmpl.ID
+	PreviousVersion  string
+	ActiveVersion    string
+	Status           activationStatus
+	PreviousRevision uint64
+	Revision         uint64
+}
+
+type RollbackRequest struct {
+	TemplateID       cardtmpl.ID
+	TargetVersion    string
+	ExpectedRevision uint64
+	ActorUID         string
+	Reason           string
+	ChangeTicket     string
+	targetReceipt    stateTargetReceipt
+}
+
+type BlockRequest struct {
+	TemplateID       cardtmpl.ID
+	Version          string
+	ExpectedRevision uint64
+	FallbackVersion  string
+	ActorUID         string
+	Reason           string
+	ChangeTicket     string
+	fallbackReceipt  stateTargetReceipt
+}
+
+type BlockResult struct {
+	TemplateID       cardtmpl.ID
+	Version          string
+	Blocked          bool
+	PreviousVersion  string
+	ActiveVersion    string
+	Status           activationStatus
+	PreviousRevision uint64
+	Revision         uint64
+}
+
+type activationRow struct {
+	exists   bool
+	version  string
+	status   activationStatus
+	revision uint64
+}
+
+type stateTarget struct {
+	source      string
+	hasArtifact bool
+	blocked     bool
+	meta        cardtmpl.RuntimeArtifactMeta
+}
+
+type stateTargetReceipt struct {
+	meta cardtmpl.RuntimeArtifactMeta
+}
+
+func (s *store) Activate(ctx context.Context, request ActivationRequest) (ActivationResult, error) {
+	if err := validateActivationRequest(request); err != nil {
+		return ActivationResult{}, err
+	}
+	return executeStateWithRetry(ctx, func() (ActivationResult, error) {
+		return s.activateOnce(ctx, request)
+	})
+}
+
+func (s *store) activateOnce(ctx context.Context, request ActivationRequest) (ActivationResult, error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return ActivationResult{}, fmt.Errorf("card template catalog: begin activate: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	current, err := loadActivationForUpdate(ctx, tx, request.TemplateID)
+	if err != nil {
+		return ActivationResult{}, err
+	}
+	if current.revision != request.ExpectedRevision {
+		return ActivationResult{}, fmt.Errorf("%w: expected %d, current %d",
+			ErrActivationConflict, request.ExpectedRevision, current.revision)
+	}
+	target, err := loadStateTargetForUpdate(ctx, tx, request.TemplateID, request.TargetVersion)
+	if err != nil {
+		return ActivationResult{}, err
+	}
+	if err := requireStateTargetReceipt(target, request.targetReceipt); err != nil {
+		return ActivationResult{}, err
+	}
+
+	nextRevision := current.revision + 1
+	if !current.exists {
+		if _, err := tx.ExecContext(ctx, insertActivationSQL,
+			string(request.TemplateID), request.TargetVersion, activationStatusActive,
+			request.ActorUID, request.Reason, request.ChangeTicket,
+		); err != nil {
+			if isDuplicateKey(err) {
+				return ActivationResult{}, fmt.Errorf("%w: concurrent first activation", ErrActivationConflict)
+			}
+			return ActivationResult{}, fmt.Errorf("card template catalog: insert activation: %w", err)
+		}
+	} else {
+		result, err := tx.ExecContext(ctx, updateActivationSQL,
+			request.TargetVersion, activationStatusActive, request.ActorUID, request.Reason,
+			request.ChangeTicket, string(request.TemplateID), request.ExpectedRevision,
+		)
+		if err != nil {
+			return ActivationResult{}, fmt.Errorf("card template catalog: update activation: %w", err)
+		}
+		if err := requireOneStateRow(result); err != nil {
+			return ActivationResult{}, err
+		}
+	}
+	if err := insertStateAudit(ctx, tx, stateAudit{
+		actorUID: request.ActorUID, operation: auditOperationActivate,
+		templateID: request.TemplateID, version: request.TargetVersion,
+		previousVersion: current.version, resultingVersion: request.TargetVersion,
+		previousRevision: current.revision, resultingRevision: nextRevision,
+		reason: request.Reason, changeTicket: request.ChangeTicket,
+	}); err != nil {
+		return ActivationResult{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return ActivationResult{}, fmt.Errorf("card template catalog: commit activate: %w", err)
+	}
+	return ActivationResult{
+		TemplateID: request.TemplateID, PreviousVersion: current.version,
+		ActiveVersion: request.TargetVersion, Status: activationStatusActive,
+		PreviousRevision: current.revision, Revision: nextRevision,
+	}, nil
+}
+
+func (s *store) Block(ctx context.Context, request BlockRequest) (BlockResult, error) {
+	if err := validateBlockRequest(request); err != nil {
+		return BlockResult{}, err
+	}
+	return executeStateWithRetry(ctx, func() (BlockResult, error) {
+		return s.blockOnce(ctx, request)
+	})
+}
+
+func (s *store) blockOnce(ctx context.Context, request BlockRequest) (BlockResult, error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return BlockResult{}, fmt.Errorf("card template catalog: begin block: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	current, err := loadActivationForUpdate(ctx, tx, request.TemplateID)
+	if err != nil {
+		return BlockResult{}, err
+	}
+	if current.revision != request.ExpectedRevision {
+		return BlockResult{}, fmt.Errorf("%w: expected %d, current %d",
+			ErrActivationConflict, request.ExpectedRevision, current.revision)
+	}
+	target, err := loadStateTargetForUpdate(ctx, tx, request.TemplateID, request.Version)
+	if err != nil {
+		return BlockResult{}, err
+	}
+	if target.source != claimSourceDynamic || !target.hasArtifact {
+		return BlockResult{}, fmt.Errorf("%w: %s@%s is not a dynamic artifact",
+			ErrBlockTargetInvalid, request.TemplateID, request.Version)
+	}
+	if target.blocked {
+		return BlockResult{}, fmt.Errorf("%w: %s@%s", ErrArtifactBlocked, request.TemplateID, request.Version)
+	}
+	blockResult, err := tx.ExecContext(ctx, blockArtifactSQL,
+		request.ActorUID, request.Reason, string(request.TemplateID), request.Version)
+	if err != nil {
+		return BlockResult{}, fmt.Errorf("card template catalog: block artifact: %w", err)
+	}
+	if err := requireOneBlockedRow(blockResult); err != nil {
+		return BlockResult{}, err
+	}
+
+	next := current
+	if current.exists && current.status == activationStatusActive && current.version == request.Version {
+		nextVersion := request.FallbackVersion
+		nextStatus := activationStatusActive
+		var persistedVersion any = nextVersion
+		if nextVersion == "" {
+			nextStatus = activationStatusDisabled
+			persistedVersion = nil
+		} else {
+			fallback, err := loadStateTargetForUpdate(ctx, tx, request.TemplateID, nextVersion)
+			if err != nil {
+				return BlockResult{}, fmt.Errorf("card template catalog: validate block fallback: %w", err)
+			}
+			if err := requireStateTargetReceipt(fallback, request.fallbackReceipt); err != nil {
+				return BlockResult{}, err
+			}
+			if fallback.source == claimSourceDynamic {
+				previouslyActive, err := targetWasPreviouslyActive(ctx, tx, request.TemplateID, nextVersion)
+				if err != nil {
+					return BlockResult{}, err
+				}
+				if !previouslyActive {
+					return BlockResult{}, fmt.Errorf("%w: dynamic fallback %s@%s was never active",
+						ErrBlockTargetInvalid, request.TemplateID, nextVersion)
+				}
+			}
+		}
+		stateResult, err := tx.ExecContext(ctx, updateActivationSQL,
+			persistedVersion, nextStatus, request.ActorUID, request.Reason, request.ChangeTicket,
+			string(request.TemplateID), request.ExpectedRevision,
+		)
+		if err != nil {
+			return BlockResult{}, fmt.Errorf("card template catalog: update blocked activation: %w", err)
+		}
+		if err := requireOneStateRow(stateResult); err != nil {
+			return BlockResult{}, err
+		}
+		next.version = nextVersion
+		next.status = nextStatus
+		next.revision++
+	}
+	if err := insertStateAudit(ctx, tx, stateAudit{
+		actorUID: request.ActorUID, operation: auditOperationBlock,
+		templateID: request.TemplateID, version: request.Version,
+		previousVersion: current.version, resultingVersion: next.version,
+		previousRevision: current.revision, resultingRevision: next.revision,
+		reason: request.Reason, changeTicket: request.ChangeTicket,
+	}); err != nil {
+		return BlockResult{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return BlockResult{}, fmt.Errorf("card template catalog: commit block: %w", err)
+	}
+	return BlockResult{
+		TemplateID: request.TemplateID, Version: request.Version, Blocked: true,
+		PreviousVersion: current.version, ActiveVersion: next.version, Status: next.status,
+		PreviousRevision: current.revision, Revision: next.revision,
+	}, nil
+}
+
+func (s *store) Rollback(ctx context.Context, request RollbackRequest) (ActivationResult, error) {
+	activation := ActivationRequest{
+		TemplateID: request.TemplateID, TargetVersion: request.TargetVersion,
+		ExpectedRevision: request.ExpectedRevision, ActorUID: request.ActorUID,
+		Reason: request.Reason, ChangeTicket: request.ChangeTicket,
+		targetReceipt: request.targetReceipt,
+	}
+	if err := validateActivationRequest(activation); err != nil {
+		return ActivationResult{}, err
+	}
+	return executeStateWithRetry(ctx, func() (ActivationResult, error) {
+		return s.rollbackOnce(ctx, request)
+	})
+}
+
+func (s *store) rollbackOnce(ctx context.Context, request RollbackRequest) (ActivationResult, error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return ActivationResult{}, fmt.Errorf("card template catalog: begin rollback: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	current, err := loadActivationForUpdate(ctx, tx, request.TemplateID)
+	if err != nil {
+		return ActivationResult{}, err
+	}
+	if !current.exists || current.revision != request.ExpectedRevision {
+		return ActivationResult{}, fmt.Errorf("%w: expected %d, current %d",
+			ErrActivationConflict, request.ExpectedRevision, current.revision)
+	}
+	target, err := loadStateTargetForUpdate(ctx, tx, request.TemplateID, request.TargetVersion)
+	if err != nil {
+		return ActivationResult{}, err
+	}
+	if err := requireStateTargetReceipt(target, request.targetReceipt); err != nil {
+		return ActivationResult{}, err
+	}
+	previouslyActive, err := targetWasPreviouslyActive(ctx, tx, request.TemplateID, request.TargetVersion)
+	if err != nil {
+		return ActivationResult{}, err
+	}
+	if !previouslyActive {
+		return ActivationResult{}, fmt.Errorf("%w: %s@%s", ErrRollbackTargetInvalid, request.TemplateID, request.TargetVersion)
+	}
+	nextRevision := current.revision + 1
+	result, err := tx.ExecContext(ctx, updateActivationSQL,
+		request.TargetVersion, activationStatusActive, request.ActorUID, request.Reason,
+		request.ChangeTicket, string(request.TemplateID), request.ExpectedRevision,
+	)
+	if err != nil {
+		return ActivationResult{}, fmt.Errorf("card template catalog: update rollback: %w", err)
+	}
+	if err := requireOneStateRow(result); err != nil {
+		return ActivationResult{}, err
+	}
+	if err := insertStateAudit(ctx, tx, stateAudit{
+		actorUID: request.ActorUID, operation: auditOperationRollback,
+		templateID: request.TemplateID, version: request.TargetVersion,
+		previousVersion: current.version, resultingVersion: request.TargetVersion,
+		previousRevision: current.revision, resultingRevision: nextRevision,
+		reason: request.Reason, changeTicket: request.ChangeTicket,
+	}); err != nil {
+		return ActivationResult{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return ActivationResult{}, fmt.Errorf("card template catalog: commit rollback: %w", err)
+	}
+	return ActivationResult{
+		TemplateID: request.TemplateID, PreviousVersion: current.version,
+		ActiveVersion: request.TargetVersion, Status: activationStatusActive,
+		PreviousRevision: current.revision, Revision: nextRevision,
+	}, nil
+}
+
+func executeStateWithRetry[T any](ctx context.Context, operation func() (T, error)) (T, error) {
+	var zero T
+	var lastErr error
+	for attempt := 1; attempt <= stateTransitionAttempts; attempt++ {
+		result, err := operation()
+		if err == nil {
+			return result, nil
+		}
+		lastErr = err
+		if !isTransientPublishError(err) || attempt == stateTransitionAttempts {
+			return zero, err
+		}
+		if err := waitForPublishRetry(ctx, publishRetryDelay*time.Duration(1<<(attempt-1))); err != nil {
+			return zero, err
+		}
+	}
+	return zero, lastErr
+}
+
+func targetWasPreviouslyActive(
+	ctx context.Context,
+	tx *sql.Tx,
+	id cardtmpl.ID,
+	version string,
+) (bool, error) {
+	var previouslyActive bool
+	if err := tx.QueryRowContext(ctx, selectPriorActiveSQL, string(id), version, version).
+		Scan(&previouslyActive); err != nil {
+		return false, fmt.Errorf("card template catalog: verify active history: %w", err)
+	}
+	return previouslyActive, nil
+}
+
+func loadActivationForUpdate(ctx context.Context, tx *sql.Tx, id cardtmpl.ID) (activationRow, error) {
+	var version sql.NullString
+	var status activationStatus
+	var revision uint64
+	err := tx.QueryRowContext(ctx, selectActivationForUpdateSQL, string(id)).Scan(&version, &status, &revision)
+	if errors.Is(err, sql.ErrNoRows) {
+		return activationRow{}, nil
+	}
+	if err != nil {
+		return activationRow{}, fmt.Errorf("card template catalog: load activation: %w", err)
+	}
+	if status != activationStatusActive && status != activationStatusDisabled {
+		return activationRow{}, fmt.Errorf("%w: invalid activation status %q", ErrCatalogIntegrity, status)
+	}
+	if (status == activationStatusActive) != version.Valid {
+		return activationRow{}, fmt.Errorf("%w: invalid activation shape", ErrCatalogIntegrity)
+	}
+	return activationRow{exists: true, version: version.String, status: status, revision: revision}, nil
+}
+
+func loadStateTargetForUpdate(
+	ctx context.Context,
+	tx *sql.Tx,
+	id cardtmpl.ID,
+	version string,
+) (stateTarget, error) {
+	var target stateTarget
+	var owner, visibility, engine, protocol, contractVersion, hash sql.NullString
+	err := tx.QueryRowContext(ctx, selectStateTargetForUpdateSQL, string(id), version).
+		Scan(&target.source, &target.hasArtifact, &target.blocked,
+			&owner, &visibility, &engine, &protocol, &contractVersion, &hash)
+	if errors.Is(err, sql.ErrNoRows) {
+		return stateTarget{}, fmt.Errorf("%w: %s@%s not claimed", ErrActivationTargetInvalid, id, version)
+	}
+	if err != nil {
+		return stateTarget{}, fmt.Errorf("card template catalog: load state target: %w", err)
+	}
+	switch target.source {
+	case claimSourceStatic:
+		if target.hasArtifact || owner.Valid || visibility.Valid || engine.Valid || protocol.Valid || contractVersion.Valid || hash.Valid {
+			return stateTarget{}, fmt.Errorf("%w: static target has dynamic artifact", ErrCatalogIntegrity)
+		}
+	case claimSourceDynamic:
+		if !target.hasArtifact || !owner.Valid || !visibility.Valid || !engine.Valid || !protocol.Valid || !contractVersion.Valid || !hash.Valid {
+			return stateTarget{}, fmt.Errorf("%w: dynamic target has incomplete artifact", ErrCatalogIntegrity)
+		}
+		target.meta = cardtmpl.RuntimeArtifactMeta{
+			ID: id, Version: version, Source: cardtmpl.RuntimeSourceDynamic,
+			Owner: owner.String, Visibility: visibility.String, Engine: engine.String,
+			Protocol: protocol.String, ContractVersion: contractVersion.String, Hash: hash.String,
+		}
+	default:
+		return stateTarget{}, fmt.Errorf("%w: unknown source %q", ErrCatalogIntegrity, target.source)
+	}
+	if target.blocked {
+		return stateTarget{}, fmt.Errorf("%w: %s@%s", ErrArtifactBlocked, id, version)
+	}
+	return target, nil
+}
+
+func requireStateTargetReceipt(target stateTarget, receipt stateTargetReceipt) error {
+	meta := receipt.meta
+	if meta.ID == "" || meta.Version == "" {
+		return fmt.Errorf("%w: target validation receipt is missing", ErrCatalogIntegrity)
+	}
+	switch target.source {
+	case claimSourceStatic:
+		if meta.Source != cardtmpl.RuntimeSourceStatic {
+			return fmt.Errorf("%w: static target receipt source mismatch", ErrCatalogIntegrity)
+		}
+		if target.meta.ID != "" || target.meta.Version != "" {
+			return fmt.Errorf("%w: static target contains dynamic metadata", ErrCatalogIntegrity)
+		}
+	case claimSourceDynamic:
+		if meta.Source != cardtmpl.RuntimeSourceDynamic || meta.ID != target.meta.ID || meta.Version != target.meta.Version ||
+			meta.Engine != target.meta.Engine || meta.Hash != target.meta.Hash || meta.Owner != target.meta.Owner ||
+			meta.Visibility != target.meta.Visibility || meta.Protocol != target.meta.Protocol ||
+			meta.ContractVersion != target.meta.ContractVersion || meta.Blocked {
+			return fmt.Errorf("%w: target changed after validation", ErrCatalogIntegrity)
+		}
+	default:
+		return fmt.Errorf("%w: unknown target source", ErrCatalogIntegrity)
+	}
+	return nil
+}
+
+type stateAudit struct {
+	actorUID          string
+	operation         string
+	templateID        cardtmpl.ID
+	version           string
+	previousVersion   string
+	resultingVersion  string
+	previousRevision  uint64
+	resultingRevision uint64
+	reason            string
+	changeTicket      string
+}
+
+func insertStateAudit(ctx context.Context, tx *sql.Tx, audit stateAudit) error {
+	if _, err := tx.ExecContext(ctx, insertStateAuditSQL,
+		audit.actorUID, audit.operation, string(audit.templateID), audit.version,
+		audit.previousVersion, audit.resultingVersion, audit.previousRevision,
+		audit.resultingRevision, audit.reason, audit.changeTicket,
+	); err != nil {
+		return fmt.Errorf("card template catalog: insert %s audit: %w", audit.operation, err)
+	}
+	return nil
+}
+
+func validateActivationRequest(request ActivationRequest) error {
+	if strings.TrimSpace(string(request.TemplateID)) == "" ||
+		strings.TrimSpace(request.TargetVersion) == "" || request.TargetVersion != strings.TrimSpace(request.TargetVersion) ||
+		!boundedRequiredText(request.ActorUID, maxActorUIDRunes) ||
+		!boundedRequiredText(request.Reason, maxReasonRunes) ||
+		!boundedRequiredText(request.ChangeTicket, maxChangeTicketRunes) {
+		return fmt.Errorf("%w: activation fields are required and bounded", ErrPublishRequestInvalid)
+	}
+	if request.targetReceipt.meta.ID != request.TemplateID || request.targetReceipt.meta.Version != request.TargetVersion {
+		return fmt.Errorf("%w: activation target validation receipt is missing", ErrCatalogIntegrity)
+	}
+	return nil
+}
+
+func validateBlockRequest(request BlockRequest) error {
+	if strings.TrimSpace(string(request.TemplateID)) == "" ||
+		strings.TrimSpace(request.Version) == "" || request.Version != strings.TrimSpace(request.Version) ||
+		(request.FallbackVersion != "" && request.FallbackVersion != strings.TrimSpace(request.FallbackVersion)) ||
+		request.FallbackVersion == request.Version ||
+		!boundedRequiredText(request.ActorUID, maxActorUIDRunes) ||
+		!boundedRequiredText(request.Reason, maxReasonRunes) ||
+		!boundedRequiredText(request.ChangeTicket, maxChangeTicketRunes) {
+		return fmt.Errorf("%w: block fields are required and bounded", ErrPublishRequestInvalid)
+	}
+	if request.FallbackVersion != "" &&
+		(request.fallbackReceipt.meta.ID != request.TemplateID || request.fallbackReceipt.meta.Version != request.FallbackVersion) {
+		return fmt.Errorf("%w: block fallback validation receipt is missing", ErrCatalogIntegrity)
+	}
+	return nil
+}
+
+func requireOneStateRow(result sql.Result) error {
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("card template catalog: read activation CAS result: %w", err)
+	}
+	if affected != 1 {
+		return fmt.Errorf("%w: activation CAS affected %d rows", ErrActivationConflict, affected)
+	}
+	return nil
+}
+
+func requireOneBlockedRow(result sql.Result) error {
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("card template catalog: read block result: %w", err)
+	}
+	if affected != 1 {
+		return fmt.Errorf("%w: block affected %d rows", ErrArtifactBlocked, affected)
+	}
+	return nil
+}

--- a/modules/card_template_catalog/store_state_additional_test.go
+++ b/modules/card_template_catalog/store_state_additional_test.go
@@ -1,0 +1,138 @@
+package card_template_catalog
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl"
+)
+
+func TestStateTargetReceiptCoversStaticAndCorruptSourceCases(t *testing.T) {
+	staticReceipt := stateTargetReceipt{meta: cardtmpl.RuntimeArtifactMeta{
+		ID: "test.static", Version: "1.0.0", Source: cardtmpl.RuntimeSourceStatic,
+	}}
+	if err := requireStateTargetReceipt(stateTarget{source: claimSourceStatic}, staticReceipt); err != nil {
+		t.Fatalf("valid static receipt: %v", err)
+	}
+	if err := requireStateTargetReceipt(stateTarget{source: claimSourceStatic}, stateTargetReceipt{}); !errors.Is(err, ErrCatalogIntegrity) {
+		t.Fatalf("missing receipt error=%v, want ErrCatalogIntegrity", err)
+	}
+	wrongSource := staticReceipt
+	wrongSource.meta.Source = cardtmpl.RuntimeSourceDynamic
+	if err := requireStateTargetReceipt(stateTarget{source: claimSourceStatic}, wrongSource); !errors.Is(err, ErrCatalogIntegrity) {
+		t.Fatalf("wrong static source error=%v, want ErrCatalogIntegrity", err)
+	}
+	if err := requireStateTargetReceipt(stateTarget{
+		source: claimSourceStatic, meta: cardtmpl.RuntimeArtifactMeta{ID: "corrupt", Version: "1.0.0"},
+	}, staticReceipt); !errors.Is(err, ErrCatalogIntegrity) {
+		t.Fatalf("static metadata error=%v, want ErrCatalogIntegrity", err)
+	}
+	if err := requireStateTargetReceipt(stateTarget{source: "unknown"}, staticReceipt); !errors.Is(err, ErrCatalogIntegrity) {
+		t.Fatalf("unknown source error=%v, want ErrCatalogIntegrity", err)
+	}
+}
+
+func TestStateRequestValidationRequiresBoundedReceipts(t *testing.T) {
+	valid := activationRequestFixture()
+	if err := validateActivationRequest(valid); err != nil {
+		t.Fatalf("valid activation request: %v", err)
+	}
+	missingReceipt := valid
+	missingReceipt.targetReceipt = stateTargetReceipt{}
+	if err := validateActivationRequest(missingReceipt); !errors.Is(err, ErrCatalogIntegrity) {
+		t.Fatalf("missing activation receipt error=%v, want ErrCatalogIntegrity", err)
+	}
+	invalidText := valid
+	invalidText.Reason = " padded "
+	if err := validateActivationRequest(invalidText); !errors.Is(err, ErrPublishRequestInvalid) {
+		t.Fatalf("invalid activation text error=%v, want ErrPublishRequestInvalid", err)
+	}
+
+	block := BlockRequest{
+		TemplateID: "test.runtime-card", Version: "1.1.0", FallbackVersion: "1.0.0",
+		ExpectedRevision: 2, ActorUID: "admin-1", Reason: "incident", ChangeTicket: "INC-1",
+		fallbackReceipt: dynamicTargetReceiptFixture("test.runtime-card", "1.0.0", strings.Repeat("a", 64)),
+	}
+	if err := validateBlockRequest(block); err != nil {
+		t.Fatalf("valid block request: %v", err)
+	}
+	block.fallbackReceipt = stateTargetReceipt{}
+	if err := validateBlockRequest(block); !errors.Is(err, ErrCatalogIntegrity) {
+		t.Fatalf("missing fallback receipt error=%v, want ErrCatalogIntegrity", err)
+	}
+	block.FallbackVersion = block.Version
+	if err := validateBlockRequest(block); !errors.Is(err, ErrPublishRequestInvalid) {
+		t.Fatalf("self fallback error=%v, want ErrPublishRequestInvalid", err)
+	}
+}
+
+func TestLoadStateTargetForUpdateRejectsPersistentCorruption(t *testing.T) {
+	tests := []struct {
+		name string
+		rows *sqlmock.Rows
+		err  error
+	}{
+		{name: "missing", err: sql.ErrNoRows},
+		{name: "valid static", rows: stateTargetRows(claimSourceStatic, false, false, nil, nil, nil, nil, nil, nil)},
+		{name: "static with artifact", rows: stateTargetRows(claimSourceStatic, true, false, "ai", "private", "engine", "protocol", "1.0.0", strings.Repeat("a", 64)), err: ErrCatalogIntegrity},
+		{name: "dynamic incomplete", rows: stateTargetRows(claimSourceDynamic, true, false, nil, nil, nil, nil, nil, nil), err: ErrCatalogIntegrity},
+		{name: "dynamic blocked", rows: dynamicStateTargetRowsWithBlocked(true), err: ErrArtifactBlocked},
+		{name: "unknown source", rows: stateTargetRows("other", false, false, nil, nil, nil, nil, nil, nil), err: ErrCatalogIntegrity},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			store, mock, closeDB := newMockStore(t)
+			defer closeDB()
+			mock.ExpectBegin()
+			expect := mock.ExpectQuery(regexp.QuoteMeta("SELECT c.source, a.template_id IS NOT NULL, a.blocked_at IS NOT NULL")).
+				WithArgs("test.runtime-card", "1.0.0")
+			if test.rows != nil {
+				expect.WillReturnRows(test.rows)
+			} else {
+				expect.WillReturnError(test.err)
+			}
+			mock.ExpectRollback()
+			tx, err := store.db.BeginTx(context.Background(), nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			target, gotErr := loadStateTargetForUpdate(context.Background(), tx, "test.runtime-card", "1.0.0")
+			if test.name == "valid static" {
+				if gotErr != nil || target.source != claimSourceStatic {
+					t.Fatalf("target=%+v err=%v", target, gotErr)
+				}
+			} else {
+				want := test.err
+				if test.name == "missing" {
+					want = ErrActivationTargetInvalid
+				}
+				if !errors.Is(gotErr, want) {
+					t.Fatalf("error=%v, want %v", gotErr, want)
+				}
+			}
+			if err := tx.Rollback(); err != nil {
+				t.Fatal(err)
+			}
+			assertMockExpectations(t, mock)
+		})
+	}
+}
+
+func stateTargetRows(source string, hasArtifact, blocked bool, owner, visibility, engine, protocol, contractVersion, hash any) *sqlmock.Rows {
+	return sqlmock.NewRows([]string{
+		"source", "has_artifact", "blocked", "owner", "visibility", "engine_contract",
+		"protocol", "contract_version", "content_sha256",
+	}).AddRow(source, hasArtifact, blocked, owner, visibility, engine, protocol, contractVersion, hash)
+}
+
+func dynamicStateTargetRowsWithBlocked(blocked bool) *sqlmock.Rows {
+	return stateTargetRows(
+		claimSourceDynamic, true, blocked, "ai", cardtmpl.CatalogVisibilityPrivate,
+		cardtmpl.JSONTemplateEngineV1, cardtmpl.Protocol, "1.0.0", strings.Repeat("a", 64),
+	)
+}

--- a/modules/card_template_catalog/store_state_test.go
+++ b/modules/card_template_catalog/store_state_test.go
@@ -1,0 +1,457 @@
+package card_template_catalog
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl"
+	"github.com/go-sql-driver/mysql"
+)
+
+func TestStoreActivateCreatesFirstRevisionAndAuditAtomically(t *testing.T) {
+	store, mock, closeDB := newMockStore(t)
+	defer closeDB()
+
+	mock.ExpectBegin()
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT active_version, status, revision")).
+		WithArgs("test.runtime-card").
+		WillReturnError(sql.ErrNoRows)
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT c.source, a.template_id IS NOT NULL, a.blocked_at IS NOT NULL")).
+		WithArgs("test.runtime-card", "1.0.0").
+		WillReturnRows(dynamicStateTargetRows(strings.Repeat("a", 64)))
+	mock.ExpectExec(regexp.QuoteMeta("INSERT INTO card_template_activation")).
+		WithArgs("test.runtime-card", "1.0.0", activationStatusActive, "admin-1", "activate reviewed artifact", "CHG-2").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec(regexp.QuoteMeta("INSERT INTO card_template_audit")).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectCommit()
+
+	result, err := store.Activate(context.Background(), ActivationRequest{
+		TemplateID:       "test.runtime-card",
+		TargetVersion:    "1.0.0",
+		ExpectedRevision: 0,
+		ActorUID:         "admin-1",
+		Reason:           "activate reviewed artifact",
+		ChangeTicket:     "CHG-2",
+		targetReceipt:    dynamicTargetReceiptFixture("test.runtime-card", "1.0.0", strings.Repeat("a", 64)),
+	})
+	if err != nil {
+		t.Fatalf("Activate: %v", err)
+	}
+	if result.Status != activationStatusActive || result.ActiveVersion != "1.0.0" || result.Revision != 1 {
+		t.Fatalf("Activate result = %+v, want active 1.0.0 revision 1", result)
+	}
+	assertMockExpectations(t, mock)
+}
+
+func TestStoreActivateRejectsStaleRevisionBeforeTargetMutation(t *testing.T) {
+	store, mock, closeDB := newMockStore(t)
+	defer closeDB()
+
+	mock.ExpectBegin()
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT active_version, status, revision")).
+		WithArgs("test.runtime-card").
+		WillReturnRows(sqlmock.NewRows([]string{"active_version", "status", "revision"}).
+			AddRow("1.0.0", activationStatusActive, 2))
+	mock.ExpectRollback()
+
+	_, err := store.Activate(context.Background(), ActivationRequest{
+		TemplateID:       "test.runtime-card",
+		TargetVersion:    "1.1.0",
+		ExpectedRevision: 1,
+		ActorUID:         "admin-1",
+		Reason:           "stale request",
+		ChangeTicket:     "CHG-3",
+		targetReceipt:    dynamicTargetReceiptFixture("test.runtime-card", "1.1.0", strings.Repeat("a", 64)),
+	})
+	if !errors.Is(err, ErrActivationConflict) {
+		t.Fatalf("Activate error = %v, want ErrActivationConflict", err)
+	}
+	assertMockExpectations(t, mock)
+}
+
+func TestStoreActivateRollsBackStateWhenAuditFails(t *testing.T) {
+	store, mock, closeDB := newMockStore(t)
+	defer closeDB()
+
+	mock.ExpectBegin()
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT active_version, status, revision")).
+		WithArgs("test.runtime-card").
+		WillReturnRows(sqlmock.NewRows([]string{"active_version", "status", "revision"}).
+			AddRow("1.0.0", activationStatusActive, 1))
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT c.source, a.template_id IS NOT NULL, a.blocked_at IS NOT NULL")).
+		WithArgs("test.runtime-card", "1.1.0").
+		WillReturnRows(dynamicStateTargetRows(strings.Repeat("a", 64)))
+	mock.ExpectExec(regexp.QuoteMeta("UPDATE card_template_activation")).
+		WithArgs("1.1.0", activationStatusActive, "admin-1", "activate next version", "CHG-4", "test.runtime-card", 1).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec(regexp.QuoteMeta("INSERT INTO card_template_audit")).
+		WillReturnError(errors.New("audit unavailable"))
+	mock.ExpectRollback()
+
+	_, err := store.Activate(context.Background(), ActivationRequest{
+		TemplateID:       "test.runtime-card",
+		TargetVersion:    "1.1.0",
+		ExpectedRevision: 1,
+		ActorUID:         "admin-1",
+		Reason:           "activate next version",
+		ChangeTicket:     "CHG-4",
+		targetReceipt:    dynamicTargetReceiptFixture("test.runtime-card", "1.1.0", strings.Repeat("a", 64)),
+	})
+	if err == nil || !strings.Contains(err.Error(), "audit") {
+		t.Fatalf("Activate error = %v, want audit failure", err)
+	}
+	assertMockExpectations(t, mock)
+}
+
+func TestStoreActivateRejectsArtifactMetadataChangedAfterPrevalidation(t *testing.T) {
+	store, mock, closeDB := newMockStore(t)
+	defer closeDB()
+
+	mock.ExpectBegin()
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT active_version, status, revision")).
+		WithArgs("test.runtime-card").
+		WillReturnError(sql.ErrNoRows)
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT c.source, a.template_id IS NOT NULL, a.blocked_at IS NOT NULL")).
+		WithArgs("test.runtime-card", "1.0.0").
+		WillReturnRows(dynamicStateTargetRows(strings.Repeat("b", 64)))
+	mock.ExpectRollback()
+
+	request := activationRequestFixture()
+	request.targetReceipt = dynamicTargetReceiptFixture("test.runtime-card", "1.0.0", strings.Repeat("a", 64))
+	_, err := store.Activate(context.Background(), request)
+	if !errors.Is(err, ErrCatalogIntegrity) {
+		t.Fatalf("Activate error = %v, want ErrCatalogIntegrity", err)
+	}
+	assertMockExpectations(t, mock)
+}
+
+func TestStoreBlockCurrentVersionWithoutFallbackDisablesAtomically(t *testing.T) {
+	store, mock, closeDB := newMockStore(t)
+	defer closeDB()
+
+	mock.ExpectBegin()
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT active_version, status, revision")).
+		WithArgs("test.runtime-card").
+		WillReturnRows(sqlmock.NewRows([]string{"active_version", "status", "revision"}).
+			AddRow("1.1.0", activationStatusActive, 3))
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT c.source, a.template_id IS NOT NULL, a.blocked_at IS NOT NULL")).
+		WithArgs("test.runtime-card", "1.1.0").
+		WillReturnRows(dynamicStateTargetRows(strings.Repeat("a", 64)))
+	mock.ExpectExec(regexp.QuoteMeta("UPDATE card_template_artifact")).
+		WithArgs("admin-1", "security incident", "test.runtime-card", "1.1.0").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec(regexp.QuoteMeta("UPDATE card_template_activation")).
+		WithArgs(nil, activationStatusDisabled, "admin-1", "security incident", "SEC-1", "test.runtime-card", 3).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec(regexp.QuoteMeta("INSERT INTO card_template_audit")).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectCommit()
+
+	result, err := store.Block(context.Background(), BlockRequest{
+		TemplateID:       "test.runtime-card",
+		Version:          "1.1.0",
+		ExpectedRevision: 3,
+		ActorUID:         "admin-1",
+		Reason:           "security incident",
+		ChangeTicket:     "SEC-1",
+	})
+	if err != nil {
+		t.Fatalf("Block: %v", err)
+	}
+	if !result.Blocked || result.Status != activationStatusDisabled || result.Revision != 4 || result.ActiveVersion != "" {
+		t.Fatalf("Block result = %+v, want blocked disabled revision 4", result)
+	}
+	assertMockExpectations(t, mock)
+}
+
+func TestStoreRollbackRequiresPriorActiveTargetAndAuditsTransition(t *testing.T) {
+	store, mock, closeDB := newMockStore(t)
+	defer closeDB()
+
+	mock.ExpectBegin()
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT active_version, status, revision")).
+		WithArgs("test.runtime-card").
+		WillReturnRows(sqlmock.NewRows([]string{"active_version", "status", "revision"}).
+			AddRow("1.1.0", activationStatusActive, 4))
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT c.source, a.template_id IS NOT NULL, a.blocked_at IS NOT NULL")).
+		WithArgs("test.runtime-card", "1.0.0").
+		WillReturnRows(dynamicStateTargetRows(strings.Repeat("a", 64)))
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT EXISTS(SELECT 1 FROM card_template_audit")).
+		WithArgs("test.runtime-card", "1.0.0", "1.0.0").
+		WillReturnRows(sqlmock.NewRows([]string{"previously_active"}).AddRow(true))
+	mock.ExpectExec(regexp.QuoteMeta("UPDATE card_template_activation")).
+		WithArgs("1.0.0", activationStatusActive, "admin-1", "rollback incident", "INC-1", "test.runtime-card", 4).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec(regexp.QuoteMeta("INSERT INTO card_template_audit")).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectCommit()
+
+	result, err := store.Rollback(context.Background(), RollbackRequest{
+		TemplateID:       "test.runtime-card",
+		TargetVersion:    "1.0.0",
+		ExpectedRevision: 4,
+		ActorUID:         "admin-1",
+		Reason:           "rollback incident",
+		ChangeTicket:     "INC-1",
+		targetReceipt:    dynamicTargetReceiptFixture("test.runtime-card", "1.0.0", strings.Repeat("a", 64)),
+	})
+	if err != nil {
+		t.Fatalf("Rollback: %v", err)
+	}
+	if result.ActiveVersion != "1.0.0" || result.Revision != 5 || result.Status != activationStatusActive {
+		t.Fatalf("Rollback result = %+v, want active 1.0.0 revision 5", result)
+	}
+	assertMockExpectations(t, mock)
+}
+
+func TestStoreRollbackRejectsNeverActiveTarget(t *testing.T) {
+	store, mock, closeDB := newMockStore(t)
+	defer closeDB()
+
+	mock.ExpectBegin()
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT active_version, status, revision")).
+		WillReturnRows(sqlmock.NewRows([]string{"active_version", "status", "revision"}).
+			AddRow("1.1.0", activationStatusActive, 4))
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT c.source, a.template_id IS NOT NULL, a.blocked_at IS NOT NULL")).
+		WillReturnRows(dynamicStateTargetRows(strings.Repeat("a", 64)))
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT EXISTS(SELECT 1 FROM card_template_audit")).
+		WillReturnRows(sqlmock.NewRows([]string{"previously_active"}).AddRow(false))
+	mock.ExpectRollback()
+
+	_, err := store.Rollback(context.Background(), RollbackRequest{
+		TemplateID:       "test.runtime-card",
+		TargetVersion:    "0.9.0",
+		ExpectedRevision: 4,
+		ActorUID:         "admin-1",
+		Reason:           "invalid rollback",
+		ChangeTicket:     "INC-2",
+		targetReceipt:    dynamicTargetReceiptFixture("test.runtime-card", "0.9.0", strings.Repeat("a", 64)),
+	})
+	if !errors.Is(err, ErrRollbackTargetInvalid) {
+		t.Fatalf("Rollback error = %v, want ErrRollbackTargetInvalid", err)
+	}
+	assertMockExpectations(t, mock)
+}
+
+func TestStoreBlockCurrentVersionSwitchesToFallbackAtomically(t *testing.T) {
+	store, mock, closeDB := newMockStore(t)
+	defer closeDB()
+
+	mock.ExpectBegin()
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT active_version, status, revision")).
+		WillReturnRows(sqlmock.NewRows([]string{"active_version", "status", "revision"}).
+			AddRow("1.1.0", activationStatusActive, 3))
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT c.source, a.template_id IS NOT NULL, a.blocked_at IS NOT NULL")).
+		WithArgs("test.runtime-card", "1.1.0").
+		WillReturnRows(dynamicStateTargetRows(strings.Repeat("a", 64)))
+	mock.ExpectExec(regexp.QuoteMeta("UPDATE card_template_artifact")).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT c.source, a.template_id IS NOT NULL, a.blocked_at IS NOT NULL")).
+		WithArgs("test.runtime-card", "1.0.0").
+		WillReturnRows(dynamicStateTargetRows(strings.Repeat("a", 64)))
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT EXISTS(SELECT 1 FROM card_template_audit")).
+		WithArgs("test.runtime-card", "1.0.0", "1.0.0").
+		WillReturnRows(sqlmock.NewRows([]string{"previously_active"}).AddRow(true))
+	mock.ExpectExec(regexp.QuoteMeta("UPDATE card_template_activation")).
+		WithArgs("1.0.0", activationStatusActive, "admin-1", "block with fallback", "SEC-2", "test.runtime-card", 3).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec(regexp.QuoteMeta("INSERT INTO card_template_audit")).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectCommit()
+
+	result, err := store.Block(context.Background(), BlockRequest{
+		TemplateID:       "test.runtime-card",
+		Version:          "1.1.0",
+		FallbackVersion:  "1.0.0",
+		ExpectedRevision: 3,
+		ActorUID:         "admin-1",
+		Reason:           "block with fallback",
+		ChangeTicket:     "SEC-2",
+		fallbackReceipt:  dynamicTargetReceiptFixture("test.runtime-card", "1.0.0", strings.Repeat("a", 64)),
+	})
+	if err != nil {
+		t.Fatalf("Block with fallback: %v", err)
+	}
+	if result.ActiveVersion != "1.0.0" || result.Status != activationStatusActive || result.Revision != 4 {
+		t.Fatalf("Block result = %+v, want fallback 1.0.0 revision 4", result)
+	}
+	assertMockExpectations(t, mock)
+}
+
+func TestStoreBlockRejectsNeverActiveDynamicFallbackAtomically(t *testing.T) {
+	store, mock, closeDB := newMockStore(t)
+	defer closeDB()
+
+	mock.ExpectBegin()
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT active_version, status, revision")).
+		WillReturnRows(sqlmock.NewRows([]string{"active_version", "status", "revision"}).
+			AddRow("1.1.0", activationStatusActive, 3))
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT c.source, a.template_id IS NOT NULL, a.blocked_at IS NOT NULL")).
+		WithArgs("test.runtime-card", "1.1.0").
+		WillReturnRows(dynamicStateTargetRows(strings.Repeat("a", 64)))
+	mock.ExpectExec(regexp.QuoteMeta("UPDATE card_template_artifact")).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT c.source, a.template_id IS NOT NULL, a.blocked_at IS NOT NULL")).
+		WithArgs("test.runtime-card", "1.0.0").
+		WillReturnRows(dynamicStateTargetRows(strings.Repeat("a", 64)))
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT EXISTS(SELECT 1 FROM card_template_audit")).
+		WithArgs("test.runtime-card", "1.0.0", "1.0.0").
+		WillReturnRows(sqlmock.NewRows([]string{"previously_active"}).AddRow(false))
+	mock.ExpectRollback()
+
+	_, err := store.Block(context.Background(), BlockRequest{
+		TemplateID: "test.runtime-card", Version: "1.1.0", FallbackVersion: "1.0.0",
+		ExpectedRevision: 3, ActorUID: "admin-1", Reason: "block with bad fallback", ChangeTicket: "SEC-4",
+		fallbackReceipt: dynamicTargetReceiptFixture("test.runtime-card", "1.0.0", strings.Repeat("a", 64)),
+	})
+	if !errors.Is(err, ErrBlockTargetInvalid) {
+		t.Fatalf("Block error = %v, want ErrBlockTargetInvalid", err)
+	}
+	assertMockExpectations(t, mock)
+}
+
+func TestStoreBlockNonActiveVersionPreservesActivationRevision(t *testing.T) {
+	store, mock, closeDB := newMockStore(t)
+	defer closeDB()
+
+	mock.ExpectBegin()
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT active_version, status, revision")).
+		WillReturnRows(sqlmock.NewRows([]string{"active_version", "status", "revision"}).
+			AddRow("1.1.0", activationStatusActive, 3))
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT c.source, a.template_id IS NOT NULL, a.blocked_at IS NOT NULL")).
+		WillReturnRows(dynamicStateTargetRows(strings.Repeat("a", 64)))
+	mock.ExpectExec(regexp.QuoteMeta("UPDATE card_template_artifact")).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec(regexp.QuoteMeta("INSERT INTO card_template_audit")).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectCommit()
+
+	result, err := store.Block(context.Background(), BlockRequest{
+		TemplateID:       "test.runtime-card",
+		Version:          "1.0.0",
+		ExpectedRevision: 3,
+		ActorUID:         "admin-1",
+		Reason:           "block old version",
+		ChangeTicket:     "SEC-3",
+	})
+	if err != nil {
+		t.Fatalf("Block non-active: %v", err)
+	}
+	if result.ActiveVersion != "1.1.0" || result.Revision != 3 {
+		t.Fatalf("Block result = %+v, want unchanged active revision", result)
+	}
+	assertMockExpectations(t, mock)
+}
+
+func TestStoreActivateMapsConcurrentFirstInsertToConflict(t *testing.T) {
+	store, mock, closeDB := newMockStore(t)
+	defer closeDB()
+
+	mock.ExpectBegin()
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT active_version, status, revision")).
+		WillReturnError(sql.ErrNoRows)
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT c.source, a.template_id IS NOT NULL, a.blocked_at IS NOT NULL")).
+		WillReturnRows(dynamicStateTargetRows(strings.Repeat("a", 64)))
+	mock.ExpectExec(regexp.QuoteMeta("INSERT INTO card_template_activation")).
+		WillReturnError(&mysql.MySQLError{Number: 1062, Message: "duplicate"})
+	mock.ExpectRollback()
+
+	_, err := store.Activate(context.Background(), activationRequestFixture())
+	if !errors.Is(err, ErrActivationConflict) {
+		t.Fatalf("Activate error = %v, want ErrActivationConflict", err)
+	}
+	assertMockExpectations(t, mock)
+}
+
+func TestStoreActivateRetriesTransientTransactionFailure(t *testing.T) {
+	store, mock, closeDB := newMockStore(t)
+	defer closeDB()
+
+	mock.ExpectBegin().WillReturnError(&mysql.MySQLError{Number: 1213, Message: "deadlock"})
+	mock.ExpectBegin()
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT active_version, status, revision")).
+		WillReturnError(sql.ErrNoRows)
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT c.source, a.template_id IS NOT NULL, a.blocked_at IS NOT NULL")).
+		WillReturnRows(dynamicStateTargetRows(strings.Repeat("a", 64)))
+	mock.ExpectExec(regexp.QuoteMeta("INSERT INTO card_template_activation")).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec(regexp.QuoteMeta("INSERT INTO card_template_audit")).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectCommit()
+
+	result, err := store.Activate(context.Background(), activationRequestFixture())
+	if err != nil {
+		t.Fatalf("Activate after deadlock: %v", err)
+	}
+	if result.Revision != 1 {
+		t.Fatalf("result = %+v", result)
+	}
+	assertMockExpectations(t, mock)
+}
+
+func TestActivationMigrationDefinesCASStateAndAuditColumns(t *testing.T) {
+	raw, err := sqlFS.ReadFile("sql/20260728000002_card_template_catalog_activation.sql")
+	if err != nil {
+		t.Fatalf("read activation migration: %v", err)
+	}
+	sqlText := string(raw)
+	for _, required := range []string{
+		"CREATE TABLE card_template_activation",
+		"active_version",
+		"status",
+		"revision BIGINT UNSIGNED NOT NULL",
+		"KEY idx_card_template_activation_status (status, template_id)",
+		"FOREIGN KEY (template_id, active_version)",
+		"ADD COLUMN previous_version",
+		"ADD COLUMN resulting_version",
+		"ADD COLUMN previous_revision",
+		"ADD COLUMN resulting_revision",
+		"ADD KEY idx_card_template_audit_page (template_id, id)",
+		"ADD KEY idx_card_template_audit_previous (template_id, result, operation, previous_version)",
+		"ADD KEY idx_card_template_audit_resulting (template_id, result, operation, resulting_version)",
+	} {
+		if !strings.Contains(sqlText, required) {
+			t.Errorf("activation migration missing %q", required)
+		}
+	}
+	if strings.Contains(strings.ToUpper(sqlText), "ON DELETE CASCADE") {
+		t.Fatal("activation must not cascade-delete immutable claims")
+	}
+}
+
+func activationRequestFixture() ActivationRequest {
+	return ActivationRequest{
+		TemplateID:       cardtmpl.ID("test.runtime-card"),
+		TargetVersion:    "1.0.0",
+		ExpectedRevision: 0,
+		ActorUID:         "admin-1",
+		Reason:           "activate reviewed artifact",
+		ChangeTicket:     "CHG-2",
+		targetReceipt:    dynamicTargetReceiptFixture("test.runtime-card", "1.0.0", strings.Repeat("a", 64)),
+	}
+}
+
+func dynamicStateTargetRows(hash string) *sqlmock.Rows {
+	return sqlmock.NewRows([]string{
+		"source", "has_artifact", "blocked", "owner", "visibility", "engine_contract",
+		"protocol", "contract_version", "content_sha256",
+	}).AddRow(
+		claimSourceDynamic, true, false, "ai", cardtmpl.CatalogVisibilityPrivate,
+		cardtmpl.JSONTemplateEngineV1, cardtmpl.Protocol, "1.0.0", hash,
+	)
+}
+
+func dynamicTargetReceiptFixture(id cardtmpl.ID, version, hash string) stateTargetReceipt {
+	return stateTargetReceipt{meta: cardtmpl.RuntimeArtifactMeta{
+		ID: id, Version: version, Source: cardtmpl.RuntimeSourceDynamic,
+		Owner: "ai", Visibility: cardtmpl.CatalogVisibilityPrivate,
+		Engine: cardtmpl.JSONTemplateEngineV1, Protocol: cardtmpl.Protocol,
+		ContractVersion: "1.0.0", Hash: hash,
+	}}
+}

--- a/modules/common/api.go
+++ b/modules/common/api.go
@@ -36,6 +36,7 @@ type Common struct {
 	appConfigDB      *appConfigDB
 	systemSettings   *SystemSettings
 	readinessChecker readinessChecker
+	catalogReadiness func() error
 	threadOn         int // 缓存 DM_THREAD_ON 环境变量
 }
 
@@ -56,6 +57,7 @@ func New(ctx *config.Context) *Common {
 		appConfigDB:      newAppConfigDB(ctx),
 		systemSettings:   EnsureSystemSettings(ctx),
 		readinessChecker: newDependencyReadinessChecker(ctx, database),
+		catalogReadiness: currentCardTemplateCatalogReadinessCheck(),
 		Log:              log.NewTLog("common"),
 		threadOn:         threadOn,
 	}

--- a/modules/common/health.go
+++ b/modules/common/health.go
@@ -37,6 +37,26 @@ type dependencyReadinessChecker struct {
 	redisClient *rd.Client
 }
 
+var cardTemplateCatalogReadinessCheck struct {
+	sync.RWMutex
+	check func() error
+}
+
+// SetCardTemplateCatalogReadinessCheck installs the process-local, IO-free
+// catalog readiness callback. The composition root calls it before module
+// construction; nil is reserved for test cleanup and pre-catalog binaries.
+func SetCardTemplateCatalogReadinessCheck(check func() error) {
+	cardTemplateCatalogReadinessCheck.Lock()
+	defer cardTemplateCatalogReadinessCheck.Unlock()
+	cardTemplateCatalogReadinessCheck.check = check
+}
+
+func currentCardTemplateCatalogReadinessCheck() func() error {
+	cardTemplateCatalogReadinessCheck.RLock()
+	defer cardTemplateCatalogReadinessCheck.RUnlock()
+	return cardTemplateCatalogReadinessCheck.check
+}
+
 func newDependencyReadinessChecker(ctx *config.Context, db *db) readinessChecker {
 	return &dependencyReadinessChecker{
 		db:          db,
@@ -75,6 +95,7 @@ func (cn *Common) ready(c *wkhttp.Context) {
 			Dependencies: map[string]string{"db": healthStatusDown, "redis": healthStatusDown},
 			Errors:       map[string]error{"readiness": errors.New("readiness checker unavailable")},
 		}
+		cn.applyCatalogReadiness(&result)
 		cn.logReadinessErrors(result.Errors)
 		// Readiness is an infra probe contract, not a user-facing business error.
 		// Keep the wire body small and safe instead of returning the i18n envelope.
@@ -100,6 +121,7 @@ func (cn *Common) ready(c *wkhttp.Context) {
 			Errors: map[string]error{"readiness": ctx.Err()},
 		}
 	}
+	cn.applyCatalogReadiness(&result)
 	cn.logReadinessErrors(result.Errors)
 	statusCode := http.StatusOK
 	if result.Status != healthStatusUp {
@@ -108,6 +130,26 @@ func (cn *Common) ready(c *wkhttp.Context) {
 	// Readiness is an infra probe contract, not a user-facing business error.
 	// Keep the wire body small and safe instead of returning the i18n envelope.
 	c.JSON(statusCode, result)
+}
+
+func (cn *Common) applyCatalogReadiness(result *readinessResult) {
+	if cn == nil || result == nil || cn.catalogReadiness == nil {
+		return
+	}
+	if result.Dependencies == nil {
+		result.Dependencies = make(map[string]string, 1)
+	}
+	if result.Errors == nil {
+		result.Errors = make(map[string]error, 1)
+	}
+	const dependency = "card_template_catalog"
+	if err := cn.catalogReadiness(); err != nil {
+		result.Dependencies[dependency] = healthStatusDown
+		result.Errors[dependency] = err
+		result.Status = healthStatusDown
+		return
+	}
+	result.Dependencies[dependency] = healthStatusUp
 }
 
 func (cn *Common) logReadinessErrors(errs map[string]error) {

--- a/modules/common/health_test.go
+++ b/modules/common/health_test.go
@@ -73,6 +73,33 @@ func TestReadyReturnsSafeDependencyStatus(t *testing.T) {
 	require.Equal(t, int32(1), atomic.LoadInt32(&checker.calls))
 }
 
+func TestReadyIncludesRuntimeCatalogReadiness(t *testing.T) {
+	checker := &fakeReadinessChecker{result: readinessResult{
+		Status: healthStatusUp,
+		Dependencies: map[string]string{
+			"db": healthStatusUp, "redis": healthStatusUp,
+		},
+		Errors: map[string]error{},
+	}}
+	cn := &Common{
+		readinessChecker: checker,
+		catalogReadiness: func() error {
+			return errors.New("catalog startup pending")
+		},
+	}
+	r := wkhttp.New()
+	r.GET("/v1/ready", cn.ready)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/v1/ready", nil)
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusServiceUnavailable, w.Code)
+	require.JSONEq(t,
+		`{"status":"down","dependencies":{"db":"up","redis":"up","card_template_catalog":"down"}}`,
+		w.Body.String())
+}
+
 func TestReadyBoundsCheckerWithTimeout(t *testing.T) {
 	checker := &fakeReadinessChecker{
 		check: func(ctx context.Context) readinessResult {

--- a/modules/message/api_card_action.go
+++ b/modules/message/api_card_action.go
@@ -23,6 +23,7 @@ package message
 // 可重试）。防枚举：除成员资格（403 语义）外全部归并到单一 400 invalid，具体原因只进日志。
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -219,7 +220,13 @@ func (m *Message) cardAction(c *wkhttp.Context) {
 		httperr.ResponseErrorL(c, errcode.ErrMessageCardActionInvalid, nil, nil)
 		return
 	}
-	cardContext, err := resolveRegistryCardContext(effective, req.ActionID, actionData)
+	cardSpaceID := m.resolveCardOriginSpaceID(msgM)
+	cardContext, err := resolveRegistryCardContext(c.Request.Context(), cardtmpl.CatalogAccess{
+		Purpose: cardtmpl.CatalogPurposeActionContext,
+		Principal: cardtmpl.CatalogPrincipal{
+			Kind: cardtmpl.CatalogPrincipalBot, ID: msgM.FromUID, SpaceID: cardSpaceID,
+		},
+	}, effective, req.ActionID, actionData)
 	if err != nil {
 		m.releaseCardClaim(idemKey)
 		m.Warn("registry 卡片 action 与已发布交互契约不一致,拒绝",
@@ -250,7 +257,7 @@ func (m *Message) cardAction(c *wkhttp.Context) {
 	// (操作者同属 A、B 两 Space 时可用 X-Space-ID: B 点 A 的卡)。与 send 出口
 	// "服务端权威、无权威值即 strip"同口径:取不到则省略键(fail-closed),绝不回退到
 	// 客户端可影响的上下文 Space。
-	if cardSpaceID := m.resolveCardOriginSpaceID(msgM); cardSpaceID != "" {
+	if cardSpaceID != "" {
 		eventData["space_id"] = cardSpaceID
 	}
 	if actionData != nil {
@@ -296,7 +303,13 @@ func (m *Message) cardAction(c *wkhttp.Context) {
 // resolveRegistryCardContext binds callback context to metadata and interaction
 // reports from the effective server-authored frame. Cards without octo-card
 // template metadata retain the legacy zero context.
-func resolveRegistryCardContext(effective []byte, actionID string, actionData map[string]interface{}) (cardactiondispatch.CardContext, error) {
+func resolveRegistryCardContext(
+	ctx context.Context,
+	access cardtmpl.CatalogAccess,
+	effective []byte,
+	actionID string,
+	actionData map[string]interface{},
+) (cardactiondispatch.CardContext, error) {
 	ref, ok := cardmsg.CardTemplateContext(effective)
 	if !ok {
 		if cardmsg.HasCardTemplateMetadata(effective) {
@@ -304,11 +317,16 @@ func resolveRegistryCardContext(effective []byte, actionID string, actionData ma
 		}
 		return cardactiondispatch.CardContext{}, nil
 	}
-	registry := cardtmpl.DefaultRegistry()
-	if registry == nil {
-		return cardactiondispatch.CardContext{}, errors.New("message: cardtmpl registry unavailable")
+	catalog := cardtmpl.DefaultCatalog()
+	if catalog == nil {
+		return cardactiondispatch.CardContext{}, errors.New("message: cardtmpl catalog unavailable")
 	}
-	view, err := registry.ActionView(cardtmpl.ID(ref.ID), ref.Version, actionID)
+	resolved, err := catalog.ActionContext(ctx, cardtmpl.CatalogActionRequest{
+		CatalogExactRequest: cardtmpl.CatalogExactRequest{
+			Access: access, ID: cardtmpl.ID(ref.ID), Version: ref.Version,
+		},
+		ActionID: actionID,
+	})
 	if err != nil {
 		return cardactiondispatch.CardContext{}, err
 	}
@@ -318,18 +336,14 @@ func resolveRegistryCardContext(effective []byte, actionID string, actionData ma
 	// assertActionContract 已强制 data.owner==template owner,故此断言只挡手工构造的
 	// 错配卡:防止一张 metadata 声明 docs 模板、data.owner 却指向别的已注册路由的卡,
 	// 把带 docs 身份的 octo-card-v1 信封投递到错误路由。
-	tmpl, err := registry.Lookup(cardtmpl.ID(ref.ID), ref.Version)
-	if err != nil {
-		return cardactiondispatch.CardContext{}, err
-	}
-	if contract := tmpl.Meta().ActionContract; contract != nil {
+	if contract := resolved.Meta.ActionContract; contract != nil {
 		routeOwner, _ := actionData["owner"].(string)
 		if strings.TrimSpace(routeOwner) != contract.Owner {
 			return cardactiondispatch.CardContext{}, errors.New("message: card template owner does not match action route owner")
 		}
 	}
 	return cardactiondispatch.CardContext{
-		TemplateID: ref.ID, TemplateVersion: ref.Version, View: string(view),
+		TemplateID: ref.ID, TemplateVersion: ref.Version, View: string(resolved.View),
 	}, nil
 }
 

--- a/modules/message/card_action_template_context_test.go
+++ b/modules/message/card_action_template_context_test.go
@@ -18,6 +18,13 @@ func TestResolveRegistryCardContextUsesEffectiveMetadataAndReport(t *testing.T) 
 	registry.Freeze()
 	cardtmpl.SetDefaultRegistry(registry)
 	t.Cleanup(func() { cardtmpl.SetDefaultRegistry(nil) })
+	static, err := cardtmpl.NewStaticCatalog(registry)
+	if err != nil {
+		t.Fatal(err)
+	}
+	spy := &actionContextCatalogSpy{Catalog: static}
+	cardtmpl.SetDefaultCatalog(spy)
+	t.Cleanup(func() { cardtmpl.SetDefaultCatalog(nil) })
 	sample, err := docsaccessrequest.Assets.ReadFile(docsaccessrequest.HandoffRoot + "/samples/pending.json")
 	if err != nil {
 		t.Fatal(err)
@@ -33,7 +40,13 @@ func TestResolveRegistryCardContextUsesEffectiveMetadataAndReport(t *testing.T) 
 	if !ok {
 		t.Fatal("approve action not found in rendered card")
 	}
-	got, err := resolveRegistryCardContext(raw, cardtmpl.DocsApproveActionID, actionData)
+	access := cardtmpl.CatalogAccess{
+		Purpose: cardtmpl.CatalogPurposeActionContext,
+		Principal: cardtmpl.CatalogPrincipal{
+			Kind: cardtmpl.CatalogPrincipalBot, ID: "notification", SpaceID: "space-1",
+		},
+	}
+	got, err := resolveRegistryCardContext(context.Background(), access, raw, cardtmpl.DocsApproveActionID, actionData)
 	if err != nil {
 		t.Fatalf("resolveRegistryCardContext: %v", err)
 	}
@@ -41,13 +54,16 @@ func TestResolveRegistryCardContextUsesEffectiveMetadataAndReport(t *testing.T) 
 	if got != want {
 		t.Fatalf("card context = %+v, want %+v", got, want)
 	}
-	if _, err := resolveRegistryCardContext(raw, "missing", nil); err == nil {
+	if spy.lastRequest.Access != access {
+		t.Fatalf("action catalog access = %+v, want %+v", spy.lastRequest.Access, access)
+	}
+	if _, err := resolveRegistryCardContext(context.Background(), access, raw, "missing", nil); err == nil {
 		t.Fatal("undeclared action resolved without error")
 	}
 
 	// P2-b(PR#641 review):route owner(Action.data.owner)与 template owner 不一致
 	// 必须拒绝 —— 防止带 docs 身份的信封投递到别的路由。
-	if _, err := resolveRegistryCardContext(raw, cardtmpl.DocsApproveActionID,
+	if _, err := resolveRegistryCardContext(context.Background(), access, raw, cardtmpl.DocsApproveActionID,
 		map[string]interface{}{"owner": "summary", "action_type": "access_request.decision"}); err == nil {
 		t.Fatal("owner mismatch resolved without error")
 	}
@@ -59,7 +75,7 @@ func TestResolveRegistryCardContextUsesEffectiveMetadataAndReport(t *testing.T) 
 	template := octo["template"].(map[string]any)
 	delete(template, "version")
 	partialRaw, _ := json.Marshal(payload)
-	if _, err := resolveRegistryCardContext(partialRaw, cardtmpl.DocsApproveActionID, actionData); err == nil {
+	if _, err := resolveRegistryCardContext(context.Background(), access, partialRaw, cardtmpl.DocsApproveActionID, actionData); err == nil {
 		t.Fatal("partial registry metadata resolved as a legacy card")
 	}
 
@@ -69,12 +85,25 @@ func TestResolveRegistryCardContextUsesEffectiveMetadataAndReport(t *testing.T) 
 		"metadata": map[string]any{"octo": "corrupt"},
 	}}
 	corruptRaw, _ := json.Marshal(corrupt)
-	if _, err := resolveRegistryCardContext(corruptRaw, "any", nil); err == nil {
+	if _, err := resolveRegistryCardContext(context.Background(), access, corruptRaw, "any", nil); err == nil {
 		t.Fatal("corrupt octo metadata resolved as a legacy card")
 	}
 
-	legacy, err := resolveRegistryCardContext([]byte(`{"type":17,"card":{"body":[]}}`), "legacy", nil)
+	legacy, err := resolveRegistryCardContext(context.Background(), access, []byte(`{"type":17,"card":{"body":[]}}`), "legacy", nil)
 	if err != nil || legacy != (cardactiondispatch.CardContext{}) {
 		t.Fatalf("legacy context = (%+v, %v)", legacy, err)
 	}
+}
+
+type actionContextCatalogSpy struct {
+	cardtmpl.Catalog
+	lastRequest cardtmpl.CatalogActionRequest
+}
+
+func (s *actionContextCatalogSpy) ActionContext(
+	ctx context.Context,
+	request cardtmpl.CatalogActionRequest,
+) (cardtmpl.CatalogActionContext, error) {
+	s.lastRequest = request
+	return s.Catalog.ActionContext(ctx, request)
 }

--- a/modules/notify/action_finalizer.go
+++ b/modules/notify/action_finalizer.go
@@ -57,7 +57,7 @@ func NewDocsActionFinalizerFromContext(ctx *config.Context) (*DocsActionFinalize
 		return nil, err
 	}
 	mutator := carddispatch.NewCardMutator(ctx)
-	updater, err := cardtmpl.NewCardUpdater(cardtmpl.DefaultRegistry(), mutator)
+	updater, err := cardtmpl.NewCardUpdater(cardtmpl.DefaultCatalog(), mutator)
 	if err != nil {
 		return nil, err
 	}

--- a/modules/notify/action_finalizer_v3_test.go
+++ b/modules/notify/action_finalizer_v3_test.go
@@ -164,7 +164,11 @@ func TestDocsActionFinalizerV3TruncatesOversizedDisplayFields(t *testing.T) {
 	registry.SetDefault(docsaccessrequest.TemplateID, docsaccessrequest.TemplateVersionV3)
 	registry.Freeze()
 	mut := &okMutator{}
-	realUpdater, err := cardtmpl.NewCardUpdater(registry, mut)
+	catalog, err := cardtmpl.NewStaticCatalog(registry)
+	if err != nil {
+		t.Fatalf("NewStaticCatalog: %v", err)
+	}
+	realUpdater, err := cardtmpl.NewCardUpdater(catalog, mut)
 	if err != nil {
 		t.Fatalf("NewCardUpdater: %v", err)
 	}

--- a/modules/notify/api.go
+++ b/modules/notify/api.go
@@ -1,6 +1,7 @@
 package notify
 
 import (
+	"context"
 	"crypto/sha256"
 	"crypto/subtle"
 	"encoding/hex"
@@ -363,7 +364,7 @@ func (n *Notify) sendNotify(c *wkhttp.Context) {
 		return
 	}
 
-	resp, err := n.dispatchNotify(&req, typedCapability)
+	resp, err := n.dispatchNotify(c.Request.Context(), &req, typedCapability)
 	if err != nil {
 		if errors.Is(err, errNotifyCardNotAllowed) {
 			httperr.ResponseErrorL(c, errcode.ErrNotifyCardNotAllowed, nil, nil)
@@ -382,12 +383,16 @@ func (n *Notify) sendNotify(c *wkhttp.Context) {
 
 // dispatchNotify routes a single request to the correct producer path (when a
 // structured Card / DocsCard is present) or the legacy text path.
-func (n *Notify) dispatchNotify(req *NotifyReq, capability notifyCapability) (*NotifyResp, error) {
+func (n *Notify) dispatchNotify(
+	ctx context.Context,
+	req *NotifyReq,
+	capability notifyCapability,
+) (*NotifyResp, error) {
 	if req != nil && req.Card != nil {
-		return n.deliverCardNotification(req)
+		return n.deliverCardNotification(ctx, req)
 	}
 	if req != nil && req.DocsCard != nil {
-		return n.deliverDocsCardNotification(req)
+		return n.deliverDocsCardNotification(ctx, req)
 	}
 	if req != nil && req.ApprovalCard != nil {
 		return n.deliverApprovalCardNotification(req, capability.Action)

--- a/modules/notify/card.go
+++ b/modules/notify/card.go
@@ -31,7 +31,12 @@ import (
 // notification is never silently lost. Per-recipient dispatch errors
 // (busy/dispatch_failed/target_denied) surface in Filtered so the caller's
 // existing retry/dedup state machine handles them, exactly as the text path.
-func (n *Notify) deliverCardNotification(req *NotifyReq) (*NotifyResp, error) {
+// Ordinary card-build failures retain the legacy text fallback; runtime-catalog
+// safety rejections (blocked/disabled/auth/integrity/unavailable) fail closed.
+func (n *Notify) deliverCardNotification(ctx context.Context, req *NotifyReq) (*NotifyResp, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	if req == nil || req.Card == nil {
 		return nil, errNotifyCardInvalid
 	}
@@ -61,7 +66,14 @@ func (n *Notify) deliverCardNotification(req *NotifyReq) (*NotifyResp, error) {
 	} else {
 		summaryTid = summaryfailed.TemplateID
 	}
-	if err := preflightSummarySchema(card, summaryTid); err != nil {
+	if err := preflightSummarySchema(ctx, card, summaryTid); err != nil {
+		if failure, ok := classifyNotifyCatalogRuntimeFailure(err); ok {
+			n.Error("summary card preflight rejected by runtime catalog",
+				zap.String("catalog_result", failure.result), zap.Error(err),
+				zap.String("space_id", req.SpaceID), zap.String("task_no", card.TaskNo),
+				zap.String("kind", card.Kind))
+			return nil, err
+		}
 		if errors.Is(err, errCardTmplUnavailable) {
 			n.Error("summary card preflight: cardtmpl unavailable (composition bug, 500)",
 				zap.Error(err), zap.String("space_id", req.SpaceID), zap.String("task_no", card.TaskNo),
@@ -124,14 +136,21 @@ func (n *Notify) deliverCardNotification(req *NotifyReq) (*NotifyResp, error) {
 		)
 		if card.Kind == SummaryCardKindCompleted {
 			doc, renderProfile, buildErr = n.buildSummaryCardViaRegistry(
-				context.Background(), req.SpaceID, card, lang,
+				ctx, req.SpaceID, card, lang,
 				summarycompleted.TemplateID, summarycompleted.StateShown)
 		} else {
 			doc, renderProfile, buildErr = n.buildSummaryCardViaRegistry(
-				context.Background(), req.SpaceID, card, lang,
+				ctx, req.SpaceID, card, lang,
 				summaryfailed.TemplateID, summaryfailed.StateShown)
 		}
 		if buildErr != nil {
+			if failure, ok := classifyNotifyCatalogRuntimeFailure(buildErr); ok {
+				n.Error("summary card rejected by runtime catalog",
+					zap.String("catalog_result", failure.result), zap.Error(buildErr),
+					zap.String("space_id", req.SpaceID), zap.String("task_no", card.TaskNo),
+					zap.String("kind", card.Kind))
+				return nil, buildErr
+			}
 			// C1: schema 违规理论上已被 preflight 拦掉,这里再 typed 断言一次
 			// 兜底(避免 Build 内部新增校验后绕过 preflight)。
 			if errors.Is(buildErr, cardtmpl.ErrFieldsInvalid) {
@@ -332,8 +351,13 @@ type summaryLabels struct {
 // verification -> bounded fan-out) but binds to the docs-notify producer and
 // uses BuildDocsResourceCard for the /d/{doc_id}?sp={space_id} deep link. A
 // build failure degrades the whole request to a plain-text DM so a docs
-// notification is never silently lost.
-func (n *Notify) deliverDocsCardNotification(req *NotifyReq) (*NotifyResp, error) {
+// notification is never silently lost. Runtime-catalog safety rejections are
+// excluded from that fallback and fail closed so an emergency block cannot be
+// converted into a successful text delivery.
+func (n *Notify) deliverDocsCardNotification(ctx context.Context, req *NotifyReq) (*NotifyResp, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	if req == nil || req.DocsCard == nil {
 		return nil, errNotifyCardInvalid
 	}
@@ -363,7 +387,13 @@ func (n *Notify) deliverDocsCardNotification(req *NotifyReq) (*NotifyResp, error
 	// Only the access_requested + gate-on branch flows through Registry.Render;
 	// other kinds keep the historical validate-in-builder behavior.
 	if card.Kind == DocsCardKindAccessRequested && docsApprovalCardsEnabled() {
-		if err := preflightDocsAccessRequestSchema(card); err != nil {
+		if err := preflightDocsAccessRequestSchema(ctx, card); err != nil {
+			if failure, ok := classifyNotifyCatalogRuntimeFailure(err); ok {
+				n.Error("docs access-request card preflight rejected by runtime catalog",
+					zap.String("catalog_result", failure.result), zap.Error(err),
+					zap.String("space_id", req.SpaceID), zap.String("doc_id", card.DocID))
+				return nil, err
+			}
 			// R2-2: preflight 现在能返 typed errCardTmplUnavailable (Registry/Template
 			// 未注入,composition bug) —— 与 schema 400 分开处理,让 500 不降级。
 			if errors.Is(err, errCardTmplUnavailable) {
@@ -385,7 +415,14 @@ func (n *Notify) deliverDocsCardNotification(req *NotifyReq) (*NotifyResp, error
 		} else {
 			tid = docsshared.TemplateID
 		}
-		if err := preflightDocsDisplaySchema(card, tid); err != nil {
+		if err := preflightDocsDisplaySchema(ctx, card, tid); err != nil {
+			if failure, ok := classifyNotifyCatalogRuntimeFailure(err); ok {
+				n.Error("docs display card preflight rejected by runtime catalog",
+					zap.String("catalog_result", failure.result), zap.Error(err),
+					zap.String("space_id", req.SpaceID), zap.String("doc_id", card.DocID),
+					zap.String("kind", card.Kind))
+				return nil, err
+			}
 			if errors.Is(err, errCardTmplUnavailable) {
 				n.Error("docs display card preflight: cardtmpl unavailable (composition bug, 500)",
 					zap.Error(err), zap.String("space_id", req.SpaceID), zap.String("doc_id", card.DocID),
@@ -441,25 +478,33 @@ func (n *Notify) deliverDocsCardNotification(req *NotifyReq) (*NotifyResp, error
 		if card.Kind == DocsCardKindAccessRequested && docsApprovalCardsEnabled() {
 			profile = cardmsg.ProfileV2
 			// F7: 唯一入口。Registry 未注入 = composition bug,不再 fallback 到 legacy
-			// (那样会遮蔽 wiring 漏洞);buildErr non-nil 分类走 render_error 降级文本。
-			doc, renderProfile, buildErr = n.buildDocsAccessRequestCardViaRegistry(context.Background(), req.SpaceID, card, lang)
+			// (那样会遮蔽 wiring 漏洞);普通 render_error 才降级文本,catalog safety
+			// rejection 由下方分类器直接拒绝。
+			doc, renderProfile, buildErr = n.buildDocsAccessRequestCardViaRegistry(ctx, req.SpaceID, card, lang)
 		} else if card.Kind == DocsCardKindCommented {
 			// roadmap C:docs.commented@0.1.0 走 Registry.Render(v1 展示卡)。
 			// 与 access_requested 同 policy —— preflight 早跑 C1、Registry 未注入
 			// 直接 500 不降级(F7)。字节等价 legacy buildDocsCard 由 body 共享
 			// assembleResourceCardBody 保证。
 			doc, renderProfile, buildErr = n.buildDocsDisplayCardViaRegistry(
-				context.Background(), req.SpaceID, card, lang,
+				ctx, req.SpaceID, card, lang,
 				docscommented.TemplateID, docscommented.StateShown)
 		} else if card.Kind == DocsCardKindShared {
 			// roadmap C:docs.shared@0.1.0 走 Registry.Render(与 commented 对称)。
 			doc, renderProfile, buildErr = n.buildDocsDisplayCardViaRegistry(
-				context.Background(), req.SpaceID, card, lang,
+				ctx, req.SpaceID, card, lang,
 				docsshared.TemplateID, docsshared.StateShown)
 		} else {
 			doc, buildErr = n.buildDocsCard(context.Background(), req.SpaceID, card, lang)
 		}
 		if buildErr != nil {
+			if failure, ok := classifyNotifyCatalogRuntimeFailure(buildErr); ok {
+				n.Error("docs card rejected by runtime catalog",
+					zap.String("catalog_result", failure.result), zap.Error(buildErr),
+					zap.String("space_id", req.SpaceID), zap.String("doc_id", card.DocID),
+					zap.String("kind", card.Kind))
+				return nil, buildErr
+			}
 			// C1 policy (docs/platform-card-base.md §10):
 			// - schema-level field errors (typed cardtmpl.ErrFieldsInvalid) → 400,
 			//   zero delivery. Reject the whole request instead of silently

--- a/modules/notify/card_action_test.go
+++ b/modules/notify/card_action_test.go
@@ -108,7 +108,7 @@ func TestDeliverDocsAccessRequestHonorsApprovalFlag(t *testing.T) {
 			capture := &capturingCardSender{}
 			n.docsSender = capture
 
-			response, err := n.deliverDocsCardNotification(&NotifyReq{
+			response, err := n.deliverDocsCardNotification(context.Background(), &NotifyReq{
 				SpaceID: "space-1", Service: "docs", Targets: []string{"user-b"}, ActorUID: "user-a",
 				DocsCard: validAccessRequestDocsCard(),
 			})

--- a/modules/notify/card_c1_regression_test.go
+++ b/modules/notify/card_c1_regression_test.go
@@ -1,12 +1,49 @@
 package notify
 
 import (
+	"context"
 	"errors"
+	"sync/atomic"
 	"testing"
 
 	"github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl"
 	"github.com/prometheus/client_golang/prometheus"
 )
+
+func TestDeliverDocsAccessRequest_BlockBetweenPreflightAndRenderFailsClosed(t *testing.T) {
+	t.Setenv("OCTO_DOCS_APPROVAL_CARD_ENABLED", "true")
+	t.Setenv("OCTO_CARD_MESSAGE_ENABLED", "true")
+	static, err := cardtmpl.NewStaticCatalog(freshPilotRegistry(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	cardtmpl.SetDefaultCatalog(&notifyFailureCatalog{
+		Catalog: static, renderErr: cardtmpl.ErrRuntimeCatalogBlocked,
+	})
+	t.Cleanup(func() { cardtmpl.SetDefaultCatalog(nil) })
+
+	wk := newWuKongServer()
+	defer wk.close()
+	ctx := newTestContext(t, wk)
+	ctx.GetConfig().External.WebLoginURL = "https://im.example.com/login"
+	n := newTestNotify(ctx, nil, nil, nil, "tk")
+	n.botOK.Store(true)
+	primeMemberCache(n, "space-1", "user-b")
+	capture := &capturingCardSender{}
+	n.docsSender = capture
+
+	resp, err := n.deliverDocsCardNotification(context.Background(), &NotifyReq{
+		SpaceID: "space-1", Service: "docs", Targets: []string{"user-b"}, ActorUID: "user-a",
+		DocsCard: validAccessRequestDocsCard(),
+	})
+	if !errors.Is(err, cardtmpl.ErrRuntimeCatalogBlocked) {
+		t.Fatalf("delivery error = %v, want ErrRuntimeCatalogBlocked (resp=%v)", err, resp)
+	}
+	if resp != nil || len(capture.cards) != 0 || atomic.LoadInt32(&wk.messageCount) != 0 {
+		t.Fatalf("blocked runtime delivered content: resp=%v cards=%d text=%d",
+			resp, len(capture.cards), atomic.LoadInt32(&wk.messageCount))
+	}
+}
 
 // TestDeliverDocsAccessRequest_UnwiredRegistryFailsClosed 是 R2-2 的 caller 级锁:
 // gate 开 + DefaultRegistry 未注入 (composition bug) → deliverDocsCardNotification
@@ -30,7 +67,7 @@ func TestDeliverDocsAccessRequest_UnwiredRegistryFailsClosed(t *testing.T) {
 	capture := &capturingCardSender{}
 	n.docsSender = capture
 
-	resp, err := n.deliverDocsCardNotification(&NotifyReq{
+	resp, err := n.deliverDocsCardNotification(context.Background(), &NotifyReq{
 		SpaceID: "space-1", Service: "docs", Targets: []string{"user-b"}, ActorUID: "user-a",
 		DocsCard: validAccessRequestDocsCard(),
 	})
@@ -70,7 +107,7 @@ func TestDeliverDocsAccessRequest_MalformedAvatarRejected400(t *testing.T) {
 	card := validAccessRequestDocsCard()
 	card.ActorAvatarURL = "https://?x=1" // 空 host,滑过 schema 正则,必须被 preflight parser 拦截
 
-	resp, err := n.deliverDocsCardNotification(&NotifyReq{
+	resp, err := n.deliverDocsCardNotification(context.Background(), &NotifyReq{
 		SpaceID: "space-1", Service: "docs", Targets: []string{"user-b"}, ActorUID: "user-a",
 		DocsCard: card,
 	})
@@ -100,7 +137,7 @@ func TestPreflightDocsAccessRequestSchema_AvatarSemantics(t *testing.T) {
 	for _, u := range bad {
 		card := validAccessRequestDocsCard()
 		card.ActorAvatarURL = u
-		if err := preflightDocsAccessRequestSchema(card); !errors.Is(err, cardtmpl.ErrFieldsInvalid) {
+		if err := preflightDocsAccessRequestSchema(context.Background(), card); !errors.Is(err, cardtmpl.ErrFieldsInvalid) {
 			t.Errorf("avatar %q: want ErrFieldsInvalid, got %v", u, err)
 		}
 	}
@@ -109,7 +146,7 @@ func TestPreflightDocsAccessRequestSchema_AvatarSemantics(t *testing.T) {
 	for _, u := range ok {
 		card := validAccessRequestDocsCard()
 		card.ActorAvatarURL = u
-		if err := preflightDocsAccessRequestSchema(card); err != nil {
+		if err := preflightDocsAccessRequestSchema(context.Background(), card); err != nil {
 			t.Errorf("avatar %q: want pass, got %v", u, err)
 		}
 	}
@@ -126,7 +163,7 @@ func TestPreflight_EmitsFieldsInvalidMetric(t *testing.T) {
 
 	card := validAccessRequestDocsCard()
 	card.Title = "" // schema violation: document.title minLength=1
-	if err := preflightDocsAccessRequestSchema(card); !errors.Is(err, cardtmpl.ErrFieldsInvalid) {
+	if err := preflightDocsAccessRequestSchema(context.Background(), card); !errors.Is(err, cardtmpl.ErrFieldsInvalid) {
 		t.Fatalf("want ErrFieldsInvalid, got %v", err)
 	}
 

--- a/modules/notify/card_mutate_api.go
+++ b/modules/notify/card_mutate_api.go
@@ -178,7 +178,7 @@ func (n *Notify) mutateCard(c *wkhttp.Context) {
 		httperr.ResponseErrorL(c, errcode.ErrNotifyCardMutateFailed, nil, nil)
 		return
 	}
-	updater, err := cardtmpl.NewCardUpdater(cardtmpl.DefaultRegistry(), mutator)
+	updater, err := cardtmpl.NewCardUpdater(cardtmpl.DefaultCatalog(), mutator)
 	if err != nil {
 		n.Error("create card updater for mutate failed", zap.Error(err))
 		httperr.ResponseErrorL(c, errcode.ErrNotifyCardMutateFailed, nil, nil)

--- a/modules/notify/card_test.go
+++ b/modules/notify/card_test.go
@@ -65,7 +65,7 @@ func TestDeliverCardNotification_ValidationRejectsBadFields(t *testing.T) {
 	for name, req := range cases {
 		t.Run(name, func(t *testing.T) {
 			r := req
-			_, err := n.deliverCardNotification(&r)
+			_, err := n.deliverCardNotification(context.Background(), &r)
 			require.ErrorIs(t, err, errNotifyCardInvalid)
 		})
 	}
@@ -153,7 +153,7 @@ func TestDeliverCardNotification_DegradesToTextWhenSenderUnavailable(t *testing.
 	n.botOK.Store(true) // notification bot already provisioned
 	primeMemberCache(n, "spc_1", "uid_a")
 
-	resp, err := n.deliverCardNotification(&NotifyReq{
+	resp, err := n.deliverCardNotification(context.Background(), &NotifyReq{
 		SpaceID: "spc_1", Service: "summary-service", Targets: []string{"uid_a"}, Card: validCard(),
 	})
 	require.NoError(t, err)
@@ -178,7 +178,7 @@ func TestDeliverCardNotification_NonMemberExcluded(t *testing.T) {
 	n.botOK.Store(true)
 	primeMemberCache(n, "spc_1", "uid_member") // uid_stranger is NOT a member
 
-	resp, err := n.deliverCardNotification(&NotifyReq{
+	resp, err := n.deliverCardNotification(context.Background(), &NotifyReq{
 		SpaceID: "spc_1", Service: "summary-service",
 		Targets: []string{"uid_member", "uid_stranger"}, Card: validCard(),
 	})
@@ -245,7 +245,7 @@ func TestDeliverDocsCardNotification_ValidationRejectsBadFields(t *testing.T) {
 	for name, req := range cases {
 		t.Run(name, func(t *testing.T) {
 			r := req
-			_, err := n.deliverDocsCardNotification(&r)
+			_, err := n.deliverDocsCardNotification(context.Background(), &r)
 			require.ErrorIs(t, err, errNotifyCardInvalid)
 		})
 	}
@@ -349,7 +349,7 @@ func TestDeliverDocsCardNotification_DegradesToTextWhenSenderUnavailable(t *test
 	n.botOK.Store(true)
 	primeMemberCache(n, "spc_1", "uid_a")
 
-	resp, err := n.deliverDocsCardNotification(&NotifyReq{
+	resp, err := n.deliverDocsCardNotification(context.Background(), &NotifyReq{
 		SpaceID: "spc_1", Service: "docs-service", Targets: []string{"uid_a"}, DocsCard: validDocsCard(),
 	})
 	require.NoError(t, err)
@@ -368,7 +368,7 @@ func TestDeliverDocsCardNotification_NonMemberExcluded(t *testing.T) {
 	n.botOK.Store(true)
 	primeMemberCache(n, "spc_1", "uid_member") // uid_stranger is NOT a member
 
-	resp, err := n.deliverDocsCardNotification(&NotifyReq{
+	resp, err := n.deliverDocsCardNotification(context.Background(), &NotifyReq{
 		SpaceID: "spc_1", Service: "docs-service",
 		Targets: []string{"uid_member", "uid_stranger"}, DocsCard: validDocsCard(),
 	})

--- a/modules/notify/card_via_registry.go
+++ b/modules/notify/card_via_registry.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl"
 	docsaccessrequest "github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl/docs_access_request"
@@ -18,24 +19,86 @@ import (
 // 与 cardtmpl.ErrFieldsInvalid 对齐 typed:前者是 500,后者是 400。
 var errCardTmplUnavailable = errors.New("notify: cardtmpl registry/template unavailable (composition bug)")
 
+type notifyCatalogRuntimeFailure struct {
+	result string
+	cause  error
+}
+
+func (e *notifyCatalogRuntimeFailure) Error() string {
+	if e == nil {
+		return "notify: runtime card template catalog rejected the operation"
+	}
+	return fmt.Sprintf("notify: runtime card template catalog rejected the operation (%s): %v", e.result, e.cause)
+}
+
+func (e *notifyCatalogRuntimeFailure) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.cause
+}
+
+func classifyNotifyCatalogRuntimeFailure(err error) (*notifyCatalogRuntimeFailure, bool) {
+	if err == nil {
+		return nil, false
+	}
+	var existing *notifyCatalogRuntimeFailure
+	if errors.As(err, &existing) {
+		return existing, true
+	}
+	result := ""
+	switch {
+	case errors.Is(err, cardtmpl.ErrRuntimeCatalogBlocked):
+		result = "blocked"
+	case errors.Is(err, cardtmpl.ErrRuntimeCatalogDisabled):
+		result = "disabled"
+	case errors.Is(err, cardtmpl.ErrRuntimeCatalogNewSendDisabled):
+		result = "new_send_disabled"
+	case errors.Is(err, cardtmpl.ErrRuntimeCatalogNotAuthorized):
+		result = "not_authorized"
+	case errors.Is(err, cardtmpl.ErrRuntimeCatalogIntegrity):
+		result = "integrity"
+	case errors.Is(err, cardtmpl.ErrRuntimeCatalogUnavailable):
+		result = "unavailable"
+	case errors.Is(err, context.Canceled):
+		result = "canceled"
+	case errors.Is(err, context.DeadlineExceeded):
+		result = "timeout"
+	default:
+		return nil, false
+	}
+	return &notifyCatalogRuntimeFailure{result: result, cause: err}, true
+}
+
+func notifyCatalogLookupError(id cardtmpl.ID, err error) error {
+	if failure, ok := classifyNotifyCatalogRuntimeFailure(err); ok {
+		return fmt.Errorf("notify: lookup %s: %w", id, failure)
+	}
+	return fmt.Errorf("%w: lookup %s: %v", errCardTmplUnavailable, id, err)
+}
+
+const notifyCatalogCallTimeout = 10 * time.Second
+
 // templateFallbackText 是 F6 分工:access_requested + gate + Registry-ready 时,
 // buildDocsFallbackText 会先调本函数,让 fallback 文本走 pilot Template 的 L0
 // 定义。Registry 未注入 / Template 未注册 / mapping/unmarshal 失败 → 返 ok=false,
 // caller 兜回 legacy 多行组装。
 func templateFallbackText(card *DocsCardFields, lang string) (string, bool) {
-	registry := cardtmpl.DefaultRegistry()
-	if registry == nil {
-		return "", false
-	}
-	tmpl, err := registry.Lookup(docsaccessrequest.TemplateID, "")
-	if err != nil {
+	catalog := cardtmpl.DefaultCatalog()
+	if catalog == nil {
 		return "", false
 	}
 	fields, err := mapDocsCardFieldsToJSON(card, lang)
 	if err != nil {
 		return "", false
 	}
-	text, err := tmpl.FallbackText(docsaccessrequest.StatePending, fields, lang)
+	ctx, cancel := boundedNotifyCatalogContext(context.Background())
+	defer cancel()
+	text, err := catalog.FallbackText(ctx, cardtmpl.CatalogFallbackRequest{
+		Access: notifyCatalogAccess(docsNotifyProducerID, ""),
+		ID:     docsaccessrequest.TemplateID, State: docsaccessrequest.StatePending,
+		Fields: fields, Lang: lang,
+	})
 	if err != nil || strings.TrimSpace(text) == "" {
 		return "", false
 	}
@@ -52,14 +115,18 @@ func templateFallbackText(card *DocsCardFields, lang string) (string, bool) {
 // R2-2 修正:前版当 registry nil 时返 nil 让 caller 继续走 v2 分支,后者最终降级
 // 文本 —— 那样"错请求"仍然会成功送达一条文本,与 §10 / A14 冲突。现在 preflight
 // 阶段就报 500,让 wiring bug 立刻可见。
-func preflightDocsAccessRequestSchema(card *DocsCardFields) error {
-	registry := cardtmpl.DefaultRegistry()
-	if registry == nil {
-		return fmt.Errorf("%w: default registry not wired", errCardTmplUnavailable)
+func preflightDocsAccessRequestSchema(parent context.Context, card *DocsCardFields) error {
+	catalog := cardtmpl.DefaultCatalog()
+	if catalog == nil {
+		return fmt.Errorf("%w: default catalog not wired", errCardTmplUnavailable)
 	}
-	tmpl, err := registry.Lookup(docsaccessrequest.TemplateID, "")
+	ctx, cancel := boundedNotifyCatalogContext(parent)
+	defer cancel()
+	meta, err := catalog.MetaDefault(ctx, cardtmpl.CatalogDefaultRequest{
+		Access: notifyCatalogAccess(docsNotifyProducerID, ""), ID: docsaccessrequest.TemplateID,
+	})
 	if err != nil {
-		return fmt.Errorf("%w: lookup %s: %v", errCardTmplUnavailable, docsaccessrequest.TemplateID, err)
+		return notifyCatalogLookupError(docsaccessrequest.TemplateID, err)
 	}
 	fields, err := mapDocsCardFieldsToJSON(card, "zh-CN") // preflight 只关心 schema shape,lang 无差异
 	if err != nil {
@@ -69,10 +136,13 @@ func preflightDocsAccessRequestSchema(card *DocsCardFields) error {
 	if err := json.Unmarshal(fields, &parsed); err != nil {
 		return fmt.Errorf("%w: %v", cardtmpl.ErrFieldsInvalid, err)
 	}
-	if err := tmpl.Meta().InputSchema.Validate(parsed); err != nil {
+	if meta.InputSchema == nil {
+		return fmt.Errorf("%w: %s has no input schema", errCardTmplUnavailable, docsaccessrequest.TemplateID)
+	}
+	if err := meta.InputSchema.Validate(parsed); err != nil {
 		// R2-8: preflight schema 失败也打 fields_invalid metric (Render 未被触发,
 		// 否则 metric 永远漏这条最"合法"的 400 路径)。
-		cardtmpl.RecordFieldsInvalid(docsaccessrequest.TemplateID, tmpl.Meta().Version)
+		cardtmpl.RecordFieldsInvalid(docsaccessrequest.TemplateID, meta.Version)
 		return fmt.Errorf("%w: %v", cardtmpl.ErrFieldsInvalid, err)
 	}
 	// R3-1: schema 的 avatarUrl pattern 只做粗粒度前缀防护,正则无法可靠判定 host
@@ -88,7 +158,7 @@ func preflightDocsAccessRequestSchema(card *DocsCardFields) error {
 	// 让基座统一前置校验,消除这条硬编码耦合。
 	if avatar := strings.TrimSpace(card.ActorAvatarURL); avatar != "" {
 		if err := cardtmpl.AbsoluteHTTPSURL(avatar); err != nil {
-			cardtmpl.RecordFieldsInvalid(docsaccessrequest.TemplateID, tmpl.Meta().Version)
+			cardtmpl.RecordFieldsInvalid(docsaccessrequest.TemplateID, meta.Version)
 			return fmt.Errorf("%w: actor_avatar_url: %v", cardtmpl.ErrFieldsInvalid, err)
 		}
 	}
@@ -107,11 +177,11 @@ func preflightDocsAccessRequestSchema(card *DocsCardFields) error {
 func (n *Notify) buildDocsAccessRequestCardViaRegistry(
 	ctx context.Context, spaceID string, card *DocsCardFields, lang string,
 ) (json.RawMessage, string, error) {
-	registry := cardtmpl.DefaultRegistry()
-	if registry == nil {
-		n.Error("cardtmpl DefaultRegistry unwired — composition bug",
+	catalog := cardtmpl.DefaultCatalog()
+	if catalog == nil {
+		n.Error("cardtmpl DefaultCatalog unwired — composition bug",
 			zap.String("space_id", spaceID), zap.String("doc_id", card.DocID))
-		return nil, "", fmt.Errorf("%w: default registry not wired", errCardTmplUnavailable)
+		return nil, "", fmt.Errorf("%w: default catalog not wired", errCardTmplUnavailable)
 	}
 
 	fields, err := mapDocsCardFieldsToJSON(card, lang)
@@ -124,9 +194,12 @@ func (n *Notify) buildDocsAccessRequestCardViaRegistry(
 		Lang:        lang,
 		SpaceID:     spaceID,
 	}
-	cardDoc, _, renderProfile, err := registry.RenderCardWithProfiles(ctx,
-		docsaccessrequest.TemplateID, "",
-		docsaccessrequest.StatePending, fields, env)
+	catalogCtx, cancel := boundedNotifyCatalogContext(ctx)
+	defer cancel()
+	cardDoc, _, renderProfile, err := cardtmpl.RenderCatalogCardWithProfiles(catalogCtx, catalog, cardtmpl.CatalogRenderRequest{
+		Access: notifyCatalogAccess(docsNotifyProducerID, spaceID),
+		ID:     docsaccessrequest.TemplateID, State: docsaccessrequest.StatePending, Fields: fields, Env: env,
+	})
 	if err != nil {
 		return nil, "", err
 	}
@@ -183,9 +256,9 @@ func (n *Notify) buildDocsDisplayCardViaRegistry(
 	ctx context.Context, spaceID string, card *DocsCardFields, lang string,
 	templateID cardtmpl.ID, state cardtmpl.State,
 ) (json.RawMessage, string, error) {
-	registry := cardtmpl.DefaultRegistry()
-	if registry == nil {
-		return nil, "", fmt.Errorf("%w: default registry not wired", errCardTmplUnavailable)
+	catalog := cardtmpl.DefaultCatalog()
+	if catalog == nil {
+		return nil, "", fmt.Errorf("%w: default catalog not wired", errCardTmplUnavailable)
 	}
 	fields, err := mapDocsCardFieldsToDisplayJSON(card)
 	if err != nil {
@@ -196,7 +269,12 @@ func (n *Notify) buildDocsDisplayCardViaRegistry(
 		Lang:        lang,
 		SpaceID:     spaceID,
 	}
-	cardDoc, _, renderProfile, err := registry.RenderCardWithProfiles(ctx, templateID, "", state, fields, env)
+	catalogCtx, cancel := boundedNotifyCatalogContext(ctx)
+	defer cancel()
+	cardDoc, _, renderProfile, err := cardtmpl.RenderCatalogCardWithProfiles(catalogCtx, catalog, cardtmpl.CatalogRenderRequest{
+		Access: notifyCatalogAccess(docsNotifyProducerID, spaceID),
+		ID:     templateID, State: state, Fields: fields, Env: env,
+	})
 	if err != nil {
 		return nil, "", err
 	}
@@ -206,14 +284,18 @@ func (n *Notify) buildDocsDisplayCardViaRegistry(
 // preflightDocsDisplaySchema 与 preflightDocsAccessRequestSchema 同思路:在
 // memberCache/docsSender/gate 之前独立跑一次 InputSchema 校验(C1 不被绕过)。
 // docs.commented / docs.shared 无用户可控 URL 字段,不需要 avatar https 前置校验。
-func preflightDocsDisplaySchema(card *DocsCardFields, templateID cardtmpl.ID) error {
-	registry := cardtmpl.DefaultRegistry()
-	if registry == nil {
-		return fmt.Errorf("%w: default registry not wired", errCardTmplUnavailable)
+func preflightDocsDisplaySchema(parent context.Context, card *DocsCardFields, templateID cardtmpl.ID) error {
+	catalog := cardtmpl.DefaultCatalog()
+	if catalog == nil {
+		return fmt.Errorf("%w: default catalog not wired", errCardTmplUnavailable)
 	}
-	tmpl, err := registry.Lookup(templateID, "")
+	ctx, cancel := boundedNotifyCatalogContext(parent)
+	defer cancel()
+	meta, err := catalog.MetaDefault(ctx, cardtmpl.CatalogDefaultRequest{
+		Access: notifyCatalogAccess(docsNotifyProducerID, ""), ID: templateID,
+	})
 	if err != nil {
-		return fmt.Errorf("%w: lookup %s: %v", errCardTmplUnavailable, templateID, err)
+		return notifyCatalogLookupError(templateID, err)
 	}
 	fields, err := mapDocsCardFieldsToDisplayJSON(card)
 	if err != nil {
@@ -223,8 +305,11 @@ func preflightDocsDisplaySchema(card *DocsCardFields, templateID cardtmpl.ID) er
 	if err := json.Unmarshal(fields, &parsed); err != nil {
 		return fmt.Errorf("%w: %v", cardtmpl.ErrFieldsInvalid, err)
 	}
-	if err := tmpl.Meta().InputSchema.Validate(parsed); err != nil {
-		cardtmpl.RecordFieldsInvalid(templateID, tmpl.Meta().Version)
+	if meta.InputSchema == nil {
+		return fmt.Errorf("%w: %s has no input schema", errCardTmplUnavailable, templateID)
+	}
+	if err := meta.InputSchema.Validate(parsed); err != nil {
+		cardtmpl.RecordFieldsInvalid(templateID, meta.Version)
 		return fmt.Errorf("%w: %v", cardtmpl.ErrFieldsInvalid, err)
 	}
 	return nil
@@ -360,9 +445,9 @@ func (n *Notify) buildSummaryCardViaRegistry(
 	ctx context.Context, spaceID string, card *SummaryCardFields, lang string,
 	templateID cardtmpl.ID, state cardtmpl.State,
 ) (json.RawMessage, string, error) {
-	registry := cardtmpl.DefaultRegistry()
-	if registry == nil {
-		return nil, "", fmt.Errorf("%w: default registry not wired", errCardTmplUnavailable)
+	catalog := cardtmpl.DefaultCatalog()
+	if catalog == nil {
+		return nil, "", fmt.Errorf("%w: default catalog not wired", errCardTmplUnavailable)
 	}
 	fields, err := mapSummaryCardFieldsToJSON(card)
 	if err != nil {
@@ -373,7 +458,12 @@ func (n *Notify) buildSummaryCardViaRegistry(
 		Lang:        lang,
 		SpaceID:     spaceID,
 	}
-	cardDoc, _, renderProfile, err := registry.RenderCardWithProfiles(ctx, templateID, "", state, fields, env)
+	catalogCtx, cancel := boundedNotifyCatalogContext(ctx)
+	defer cancel()
+	cardDoc, _, renderProfile, err := cardtmpl.RenderCatalogCardWithProfiles(catalogCtx, catalog, cardtmpl.CatalogRenderRequest{
+		Access: notifyCatalogAccess(summaryNotifyProducerID, spaceID),
+		ID:     templateID, State: state, Fields: fields, Env: env,
+	})
 	if err != nil {
 		return nil, "", err
 	}
@@ -383,14 +473,18 @@ func (n *Notify) buildSummaryCardViaRegistry(
 // preflightSummarySchema 与 preflightDocsDisplaySchema 同思路:在 memberCache /
 // docsSender / gate 之前独立跑一次 InputSchema 校验(C1 不被绕过)。summary 卡
 // 无用户可控 URL 字段,不需要 https 前置校验。
-func preflightSummarySchema(card *SummaryCardFields, templateID cardtmpl.ID) error {
-	registry := cardtmpl.DefaultRegistry()
-	if registry == nil {
-		return fmt.Errorf("%w: default registry not wired", errCardTmplUnavailable)
+func preflightSummarySchema(parent context.Context, card *SummaryCardFields, templateID cardtmpl.ID) error {
+	catalog := cardtmpl.DefaultCatalog()
+	if catalog == nil {
+		return fmt.Errorf("%w: default catalog not wired", errCardTmplUnavailable)
 	}
-	tmpl, err := registry.Lookup(templateID, "")
+	ctx, cancel := boundedNotifyCatalogContext(parent)
+	defer cancel()
+	meta, err := catalog.MetaDefault(ctx, cardtmpl.CatalogDefaultRequest{
+		Access: notifyCatalogAccess(summaryNotifyProducerID, ""), ID: templateID,
+	})
 	if err != nil {
-		return fmt.Errorf("%w: lookup %s: %v", errCardTmplUnavailable, templateID, err)
+		return notifyCatalogLookupError(templateID, err)
 	}
 	fields, err := mapSummaryCardFieldsToJSON(card)
 	if err != nil {
@@ -400,9 +494,28 @@ func preflightSummarySchema(card *SummaryCardFields, templateID cardtmpl.ID) err
 	if err := json.Unmarshal(fields, &parsed); err != nil {
 		return fmt.Errorf("%w: %v", cardtmpl.ErrFieldsInvalid, err)
 	}
-	if err := tmpl.Meta().InputSchema.Validate(parsed); err != nil {
-		cardtmpl.RecordFieldsInvalid(templateID, tmpl.Meta().Version)
+	if meta.InputSchema == nil {
+		return fmt.Errorf("%w: %s has no input schema", errCardTmplUnavailable, templateID)
+	}
+	if err := meta.InputSchema.Validate(parsed); err != nil {
+		cardtmpl.RecordFieldsInvalid(templateID, meta.Version)
 		return fmt.Errorf("%w: %v", cardtmpl.ErrFieldsInvalid, err)
 	}
 	return nil
+}
+
+func notifyCatalogAccess(producerID, spaceID string) cardtmpl.CatalogAccess {
+	return cardtmpl.CatalogAccess{
+		Purpose: cardtmpl.CatalogPurposeNewSend,
+		Principal: cardtmpl.CatalogPrincipal{
+			Kind: cardtmpl.CatalogPrincipalInternalProducer, ID: producerID, SpaceID: spaceID,
+		},
+	}
+}
+
+func boundedNotifyCatalogContext(parent context.Context) (context.Context, context.CancelFunc) {
+	if parent == nil {
+		parent = context.Background()
+	}
+	return context.WithTimeout(parent, notifyCatalogCallTimeout)
 }

--- a/modules/notify/card_via_registry_display_baseline_test.go
+++ b/modules/notify/card_via_registry_display_baseline_test.go
@@ -44,7 +44,7 @@ func TestMapDocsDisplayFields_TruncatesDisplayFields(t *testing.T) {
 		Excerpt:   strings.Repeat("评", 1000), // cap 300
 		UpdatedAt: strings.Repeat("时", 300),  // cap 80
 	}
-	if err := preflightDocsDisplaySchema(huge, docscommented.TemplateID); err != nil {
+	if err := preflightDocsDisplaySchema(context.Background(), huge, docscommented.TemplateID); err != nil {
 		t.Fatalf("preflight should PASS after truncation, got %v", err)
 	}
 	if _, _, err := n.buildDocsDisplayCardViaRegistry(context.Background(),
@@ -56,7 +56,7 @@ func TestMapDocsDisplayFields_TruncatesDisplayFields(t *testing.T) {
 	badDoc := &DocsCardFields{
 		DocID: strings.Repeat("x", 300), Title: "OK", Kind: DocsCardKindShared,
 	}
-	err := preflightDocsDisplaySchema(badDoc, docsshared.TemplateID)
+	err := preflightDocsDisplaySchema(context.Background(), badDoc, docsshared.TemplateID)
 	if err == nil || !errorsIsFieldsInvalid(err) {
 		t.Fatalf("over-length docId must stay C1 400, got %v", err)
 	}
@@ -231,7 +231,7 @@ func TestPreflightDocsDisplaySchema_C1RejectsEmptyDocID(t *testing.T) {
 
 	// docId 空 → schema minLength=1 违规
 	card := &DocsCardFields{DocID: "", Title: "T", Kind: DocsCardKindCommented}
-	err := preflightDocsDisplaySchema(card, docscommented.TemplateID)
+	err := preflightDocsDisplaySchema(context.Background(), card, docscommented.TemplateID)
 	if err == nil {
 		t.Fatal("expected ErrFieldsInvalid, got nil")
 	}

--- a/modules/notify/card_via_registry_summary_baseline_test.go
+++ b/modules/notify/card_via_registry_summary_baseline_test.go
@@ -47,7 +47,7 @@ func TestMapSummaryFields_TruncatesDisplayFields(t *testing.T) {
 		Members:     -5,
 		MsgCount:    -1,
 	}
-	if err := preflightSummarySchema(huge, summaryfailed.TemplateID); err != nil {
+	if err := preflightSummarySchema(context.Background(), huge, summaryfailed.TemplateID); err != nil {
 		t.Fatalf("preflight should PASS after truncation, got %v", err)
 	}
 	if _, _, err := n.buildSummaryCardViaRegistry(context.Background(),
@@ -59,7 +59,7 @@ func TestMapSummaryFields_TruncatesDisplayFields(t *testing.T) {
 	badTask := &SummaryCardFields{
 		TaskNo: strings.Repeat("x", 300), Title: "OK", Kind: SummaryCardKindCompleted,
 	}
-	err := preflightSummarySchema(badTask, summarycompleted.TemplateID)
+	err := preflightSummarySchema(context.Background(), badTask, summarycompleted.TemplateID)
 	if err == nil || !errorsIsFieldsInvalid(err) {
 		t.Fatalf("over-length taskNo must stay C1 400, got %v", err)
 	}
@@ -130,7 +130,7 @@ func TestMapSummaryFields_ClampsOverMaxCounts(t *testing.T) {
 			if s.kind == SummaryCardKindFailed {
 				card.Reason = "boom"
 			}
-			if err := preflightSummarySchema(card, s.templateID); err != nil {
+			if err := preflightSummarySchema(context.Background(), card, s.templateID); err != nil {
 				t.Fatalf("preflight should PASS after count clamp, got %v", err)
 			}
 			if _, _, err := n.buildSummaryCardViaRegistry(context.Background(),
@@ -350,7 +350,7 @@ func TestPreflightSummarySchema_C1RejectsEmptyTaskNo(t *testing.T) {
 
 	// taskNo 空 → schema minLength=1 违规(completed 分支)
 	badCompleted := &SummaryCardFields{TaskNo: "", Title: "T", Kind: SummaryCardKindCompleted}
-	err := preflightSummarySchema(badCompleted, summarycompleted.TemplateID)
+	err := preflightSummarySchema(context.Background(), badCompleted, summarycompleted.TemplateID)
 	if err == nil {
 		t.Fatal("expected ErrFieldsInvalid (completed), got nil")
 	}
@@ -360,7 +360,7 @@ func TestPreflightSummarySchema_C1RejectsEmptyTaskNo(t *testing.T) {
 
 	// 同样 taskNo 空 → schema minLength=1 违规(failed 分支)
 	badFailed := &SummaryCardFields{TaskNo: "", Title: "T", Kind: SummaryCardKindFailed, Reason: "r"}
-	err = preflightSummarySchema(badFailed, summaryfailed.TemplateID)
+	err = preflightSummarySchema(context.Background(), badFailed, summaryfailed.TemplateID)
 	if err == nil {
 		t.Fatal("expected ErrFieldsInvalid (failed), got nil")
 	}
@@ -377,7 +377,7 @@ func TestPreflightSummarySchema_F7RegistryUnwired(t *testing.T) {
 	defer cardtmpl.SetDefaultRegistry(prev)
 
 	card := &SummaryCardFields{TaskNo: "t", Title: "T", Kind: SummaryCardKindCompleted}
-	err := preflightSummarySchema(card, summarycompleted.TemplateID)
+	err := preflightSummarySchema(context.Background(), card, summarycompleted.TemplateID)
 	if err == nil {
 		t.Fatal("expected errCardTmplUnavailable, got nil")
 	}

--- a/modules/notify/card_via_registry_test.go
+++ b/modules/notify/card_via_registry_test.go
@@ -118,6 +118,95 @@ func TestBuildDocsAccessRequestCardViaRegistry_HappyPath(t *testing.T) {
 	}
 }
 
+func TestBuildDocsAccessRequestUsesRuntimeCatalogPrincipal(t *testing.T) {
+	wk := newWuKongServer()
+	defer wk.close()
+	ctx := newTestContext(t, wk)
+	ctx.GetConfig().External.WebLoginURL = "https://im.example.com/login"
+	registry := freshPilotRegistry(t)
+	static, err := cardtmpl.NewStaticCatalog(registry)
+	if err != nil {
+		t.Fatal(err)
+	}
+	spy := &notifyCatalogSpy{Catalog: static}
+	cardtmpl.SetDefaultCatalog(spy)
+	t.Cleanup(func() { cardtmpl.SetDefaultCatalog(nil) })
+
+	n := newTestNotify(ctx, nil, nil, nil, "tk")
+	if _, _, err := n.buildDocsAccessRequestCardViaRegistry(
+		context.Background(), "space-1", validAccessRequestDocsCard(), "zh-CN",
+	); err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	if spy.lastRender.Access.Purpose != cardtmpl.CatalogPurposeNewSend ||
+		spy.lastRender.Access.Principal.Kind != cardtmpl.CatalogPrincipalInternalProducer ||
+		spy.lastRender.Access.Principal.ID != docsNotifyProducerID ||
+		spy.lastRender.Access.Principal.SpaceID != "space-1" {
+		t.Fatalf("catalog access = %+v", spy.lastRender.Access)
+	}
+}
+
+func TestNotifyCatalogOperationsUseBoundedContexts(t *testing.T) {
+	wk := newWuKongServer()
+	defer wk.close()
+	ctx := newTestContext(t, wk)
+	ctx.GetConfig().External.WebLoginURL = "https://im.example.com/login"
+	static, err := cardtmpl.NewStaticCatalog(freshPilotRegistry(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	spy := &notifyDeadlineCatalog{Catalog: static}
+	cardtmpl.SetDefaultCatalog(spy)
+	t.Cleanup(func() { cardtmpl.SetDefaultCatalog(nil) })
+	card := validAccessRequestDocsCard()
+
+	parent, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := preflightDocsAccessRequestSchema(parent, card); err != nil {
+		t.Fatalf("preflight: %v", err)
+	}
+	if _, ok := templateFallbackText(card, "zh-CN"); !ok {
+		t.Fatal("template fallback was unavailable")
+	}
+	n := newTestNotify(ctx, nil, nil, nil, "tk")
+	if _, _, err := n.buildDocsAccessRequestCardViaRegistry(
+		context.Background(), "space-1", card, "zh-CN",
+	); err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	if !spy.metaDefaultDeadline || !spy.metaDefaultCanceled || !spy.fallbackDeadline || !spy.renderDeadline {
+		t.Fatalf("catalog deadline/cancel meta=%v/%v fallback=%v render=%v, want all true",
+			spy.metaDefaultDeadline, spy.metaDefaultCanceled, spy.fallbackDeadline, spy.renderDeadline)
+	}
+}
+
+func TestPreflightDocsAccessRequestPreservesRuntimeCatalogFailures(t *testing.T) {
+	static, err := cardtmpl.NewStaticCatalog(freshPilotRegistry(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, cause := range []error{
+		cardtmpl.ErrRuntimeCatalogBlocked,
+		cardtmpl.ErrRuntimeCatalogDisabled,
+		cardtmpl.ErrRuntimeCatalogNotAuthorized,
+		cardtmpl.ErrRuntimeCatalogIntegrity,
+		cardtmpl.ErrRuntimeCatalogUnavailable,
+	} {
+		t.Run(cause.Error(), func(t *testing.T) {
+			cardtmpl.SetDefaultCatalog(&notifyFailureCatalog{Catalog: static, metaErr: cause})
+			t.Cleanup(func() { cardtmpl.SetDefaultCatalog(nil) })
+
+			err := preflightDocsAccessRequestSchema(context.Background(), validAccessRequestDocsCard())
+			if !errors.Is(err, cause) {
+				t.Fatalf("preflight error = %v, want cause %v", err, cause)
+			}
+			if errors.Is(err, errCardTmplUnavailable) {
+				t.Fatalf("runtime rejection was flattened to composition error: %v", err)
+			}
+		})
+	}
+}
+
 // TestBuildDocsAccessRequestCardViaRegistry_FieldsInvalid 验证 C1 policy:
 // 传入 schema 违规字段 → 返回 typed cardtmpl.ErrFieldsInvalid,
 // caller (card.go 分支) 会翻成 errNotifyCardInvalid → 400 零投递。
@@ -165,4 +254,73 @@ func installTestCardTmplRegistry(t *testing.T) {
 	prev := cardtmpl.DefaultRegistry()
 	cardtmpl.SetDefaultRegistry(freshPilotRegistry(t))
 	t.Cleanup(func() { cardtmpl.SetDefaultRegistry(prev) })
+}
+
+type notifyCatalogSpy struct {
+	cardtmpl.Catalog
+	lastRender cardtmpl.CatalogRenderRequest
+}
+
+func (s *notifyCatalogSpy) Render(ctx context.Context, request cardtmpl.CatalogRenderRequest) (map[string]any, error) {
+	s.lastRender = request
+	return s.Catalog.Render(ctx, request)
+}
+
+type notifyDeadlineCatalog struct {
+	cardtmpl.Catalog
+	metaDefaultDeadline bool
+	metaDefaultCanceled bool
+	fallbackDeadline    bool
+	renderDeadline      bool
+}
+
+type notifyFailureCatalog struct {
+	cardtmpl.Catalog
+	metaErr   error
+	renderErr error
+}
+
+func (c *notifyFailureCatalog) MetaDefault(
+	ctx context.Context,
+	request cardtmpl.CatalogDefaultRequest,
+) (cardtmpl.TemplateMeta, error) {
+	if c.metaErr != nil {
+		return cardtmpl.TemplateMeta{}, c.metaErr
+	}
+	return c.Catalog.MetaDefault(ctx, request)
+}
+
+func (c *notifyFailureCatalog) Render(
+	ctx context.Context,
+	request cardtmpl.CatalogRenderRequest,
+) (map[string]any, error) {
+	if c.renderErr != nil {
+		return nil, c.renderErr
+	}
+	return c.Catalog.Render(ctx, request)
+}
+
+func (s *notifyDeadlineCatalog) MetaDefault(
+	ctx context.Context,
+	request cardtmpl.CatalogDefaultRequest,
+) (cardtmpl.TemplateMeta, error) {
+	_, s.metaDefaultDeadline = ctx.Deadline()
+	s.metaDefaultCanceled = errors.Is(ctx.Err(), context.Canceled)
+	return s.Catalog.MetaDefault(ctx, request)
+}
+
+func (s *notifyDeadlineCatalog) FallbackText(
+	ctx context.Context,
+	request cardtmpl.CatalogFallbackRequest,
+) (string, error) {
+	_, s.fallbackDeadline = ctx.Deadline()
+	return s.Catalog.FallbackText(ctx, request)
+}
+
+func (s *notifyDeadlineCatalog) Render(
+	ctx context.Context,
+	request cardtmpl.CatalogRenderRequest,
+) (map[string]any, error) {
+	_, s.renderDeadline = ctx.Deadline()
+	return s.Catalog.Render(ctx, request)
 }

--- a/pkg/cardtmpl/catalog.go
+++ b/pkg/cardtmpl/catalog.go
@@ -1,0 +1,232 @@
+package cardtmpl
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+)
+
+type CatalogPurpose string
+
+const (
+	CatalogPurposeNewSend        CatalogPurpose = "new_send"
+	CatalogPurposeHistoricalEdit CatalogPurpose = "historical_edit"
+	CatalogPurposeActionContext  CatalogPurpose = "action_context"
+)
+
+type CatalogPrincipalKind string
+
+const (
+	CatalogPrincipalBot              CatalogPrincipalKind = "bot"
+	CatalogPrincipalInternalProducer CatalogPrincipalKind = "internal_producer"
+	CatalogPrincipalSystem           CatalogPrincipalKind = "system"
+)
+
+type CatalogPrincipal struct {
+	Kind    CatalogPrincipalKind
+	ID      string
+	SpaceID string
+}
+
+type CatalogAccess struct {
+	Purpose   CatalogPurpose
+	Principal CatalogPrincipal
+}
+
+type CatalogRenderRequest struct {
+	Access  CatalogAccess
+	ID      ID
+	Version string
+	State   State
+	Fields  json.RawMessage
+	Env     BuildEnv
+}
+
+type CatalogExactRequest struct {
+	Access  CatalogAccess
+	ID      ID
+	Version string
+}
+
+type CatalogDefaultRequest struct {
+	Access CatalogAccess
+	ID     ID
+}
+
+type CatalogFallbackRequest struct {
+	Access  CatalogAccess
+	ID      ID
+	Version string
+	State   State
+	Fields  json.RawMessage
+	Lang    string
+}
+
+type CatalogActionRequest struct {
+	CatalogExactRequest
+	ActionID string
+}
+
+type CatalogActionContext struct {
+	View ViewKey
+	Meta TemplateMeta
+}
+
+// Catalog is the runtime-only template surface. Registration and default
+// mutation intentionally remain methods on the boot-time Registry only.
+type Catalog interface {
+	Render(context.Context, CatalogRenderRequest) (map[string]any, error)
+	MetaExact(context.Context, CatalogExactRequest) (TemplateMeta, error)
+	MetaDefault(context.Context, CatalogDefaultRequest) (TemplateMeta, error)
+	FallbackText(context.Context, CatalogFallbackRequest) (string, error)
+	ActionContext(context.Context, CatalogActionRequest) (CatalogActionContext, error)
+}
+
+type StaticCatalog struct {
+	registry *Registry
+}
+
+func NewStaticCatalog(registry *Registry) (*StaticCatalog, error) {
+	if registry == nil {
+		return nil, errors.New("cardtmpl: static catalog registry is required")
+	}
+	return &StaticCatalog{registry: registry}, nil
+}
+
+func (c *StaticCatalog) Render(ctx context.Context, request CatalogRenderRequest) (map[string]any, error) {
+	if c == nil || c.registry == nil {
+		return nil, errors.New("cardtmpl: static catalog unavailable")
+	}
+	return c.registry.Render(ctx, request.ID, request.Version, request.State, request.Fields, request.Env)
+}
+
+func (c *StaticCatalog) MetaExact(_ context.Context, request CatalogExactRequest) (TemplateMeta, error) {
+	if c == nil || c.registry == nil {
+		return TemplateMeta{}, errors.New("cardtmpl: static catalog unavailable")
+	}
+	template, err := c.registry.Lookup(request.ID, request.Version)
+	if err != nil {
+		return TemplateMeta{}, err
+	}
+	return template.Meta(), nil
+}
+
+func (c *StaticCatalog) MetaDefault(_ context.Context, request CatalogDefaultRequest) (TemplateMeta, error) {
+	if c == nil || c.registry == nil {
+		return TemplateMeta{}, errors.New("cardtmpl: static catalog unavailable")
+	}
+	template, err := c.registry.Lookup(request.ID, "")
+	if err != nil {
+		return TemplateMeta{}, err
+	}
+	return template.Meta(), nil
+}
+
+func (c *StaticCatalog) FallbackText(ctx context.Context, request CatalogFallbackRequest) (string, error) {
+	if c == nil || c.registry == nil {
+		return "", errors.New("cardtmpl: static catalog unavailable")
+	}
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+	template, err := c.registry.Lookup(request.ID, request.Version)
+	if err != nil {
+		return "", err
+	}
+	return template.FallbackText(request.State, request.Fields, request.Lang)
+}
+
+func (c *StaticCatalog) ActionContext(_ context.Context, request CatalogActionRequest) (CatalogActionContext, error) {
+	if c == nil || c.registry == nil {
+		return CatalogActionContext{}, errors.New("cardtmpl: static catalog unavailable")
+	}
+	view, err := c.registry.ActionView(request.ID, request.Version, request.ActionID)
+	if err != nil {
+		return CatalogActionContext{}, err
+	}
+	template, err := c.registry.Lookup(request.ID, request.Version)
+	if err != nil {
+		return CatalogActionContext{}, err
+	}
+	return CatalogActionContext{View: view, Meta: template.Meta()}, nil
+}
+
+func actionViewFromMeta(meta TemplateMeta, actionID string) (ViewKey, error) {
+	if strings.TrimSpace(actionID) == "" {
+		return "", ErrActionUnknown
+	}
+	var matched ViewKey
+	for view, report := range meta.interactions {
+		for _, action := range report.Actions {
+			if action.Type != "Action.Submit" || action.ID != actionID {
+				continue
+			}
+			if matched != "" && matched != view {
+				return "", fmt.Errorf("%w: %s@%s action %q is ambiguous",
+					ErrActionUnknown, meta.ID, meta.Version, actionID)
+			}
+			matched = view
+		}
+	}
+	if matched == "" {
+		return "", fmt.Errorf("%w: %s@%s action %q", ErrActionUnknown, meta.ID, meta.Version, actionID)
+	}
+	return matched, nil
+}
+
+func RenderCatalogCardWithProfiles(
+	ctx context.Context,
+	catalog Catalog,
+	request CatalogRenderRequest,
+) (cardDoc json.RawMessage, profile, renderProfile string, err error) {
+	if catalog == nil {
+		return nil, "", "", errors.New("cardtmpl: catalog unavailable")
+	}
+	payload, err := catalog.Render(ctx, request)
+	if err != nil {
+		return nil, "", "", err
+	}
+	raw, err := json.Marshal(payload["card"])
+	if err != nil {
+		return nil, "", "", fmt.Errorf("%w: marshal card: %v", ErrRenderFailed, err)
+	}
+	profile, _ = payload["profile"].(string)
+	renderProfile, _ = payload["render_profile"].(string)
+	return raw, profile, renderProfile, nil
+}
+
+var (
+	defaultCatalogMu sync.RWMutex
+	defaultCatalog   Catalog
+)
+
+// SetDefaultCatalog installs the process runtime reader. Production installs
+// it once in the composition root before module factories are constructed.
+func SetDefaultCatalog(c Catalog) {
+	defaultCatalogMu.Lock()
+	defer defaultCatalogMu.Unlock()
+	defaultCatalog = c
+}
+
+// DefaultCatalog returns the installed runtime reader. Tests and pre-overlay
+// binaries safely fall back to an adapter over the current frozen Registry.
+func DefaultCatalog() Catalog {
+	defaultCatalogMu.RLock()
+	catalog := defaultCatalog
+	defaultCatalogMu.RUnlock()
+	if catalog != nil {
+		return catalog
+	}
+	registry := DefaultRegistry()
+	if registry == nil {
+		return nil
+	}
+	static, err := NewStaticCatalog(registry)
+	if err != nil {
+		return nil
+	}
+	return static
+}

--- a/pkg/cardtmpl/default_registry.go
+++ b/pkg/cardtmpl/default_registry.go
@@ -6,7 +6,8 @@ import (
 
 // defaultRegistry 是进程内单一 Registry。main.go composition root 通过
 // SetDefaultRegistry 注入构造好的 Registry(注册所有 L2a Template + Freeze)。
-// 业务代码通过 DefaultRegistry() 拿到只读引用后调 Render。
+// 它只供启动期 registration/static reconciliation 和兼容测试使用；生产运行期
+// consumer 统一通过 DefaultCatalog() 读取，避免绕过 dynamic block/active 真相。
 //
 // 采用 pkg-scoped default 而非全局单例是权衡:
 //   - test 环境可以 SetDefaultRegistry(nil) 后自己构造独立 Registry;
@@ -24,7 +25,7 @@ func SetDefaultRegistry(r *Registry) {
 	defaultRegistry = r
 }
 
-// DefaultRegistry 返回当前默认 Registry。未注入 → nil,调用方须自行判空并降级。
+// DefaultRegistry 返回启动期 built-in Registry。未注入 → nil。
 func DefaultRegistry() *Registry {
 	defaultRegistryMu.RLock()
 	defer defaultRegistryMu.RUnlock()

--- a/pkg/cardtmpl/metrics_a_test.go
+++ b/pkg/cardtmpl/metrics_a_test.go
@@ -57,7 +57,11 @@ func TestUpdateMetricsOnlyUseRegisteredTemplateLabels(t *testing.T) {
 		SetGlobalMetrics(metrics)
 		t.Cleanup(func() { SetGlobalMetrics(nil) })
 
-		updater, err := NewCardUpdater(NewRegistry(), &metricMutationGateway{})
+		catalog, catalogErr := NewStaticCatalog(NewRegistry())
+		if catalogErr != nil {
+			t.Fatal(catalogErr)
+		}
+		updater, err := NewCardUpdater(catalog, &metricMutationGateway{})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -73,7 +77,7 @@ func TestUpdateMetricsOnlyUseRegisteredTemplateLabels(t *testing.T) {
 		}
 	})
 
-	t.Run("append unregistered metadata", func(t *testing.T) {
+	t.Run("append unregistered metadata preserves compatibility", func(t *testing.T) {
 		promRegistry := prometheus.NewRegistry()
 		metrics := NewMetrics(promRegistry)
 		SetGlobalMetrics(metrics)
@@ -94,7 +98,11 @@ func TestUpdateMetricsOnlyUseRegisteredTemplateLabels(t *testing.T) {
 			t.Fatal(err)
 		}
 		gateway := &metricMutationGateway{snapshot: carddispatch.CardMutationSnapshot{Envelope: envelope}}
-		updater, err := NewCardUpdater(NewRegistry(), gateway)
+		catalog, catalogErr := NewStaticCatalog(NewRegistry())
+		if catalogErr != nil {
+			t.Fatal(catalogErr)
+		}
+		updater, err := NewCardUpdater(catalog, gateway)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -103,7 +111,7 @@ func TestUpdateMetricsOnlyUseRegisteredTemplateLabels(t *testing.T) {
 			SenderUID: "notification", MessageID: "1001", CardSeq: 1,
 		}, json.RawMessage(`{"type":"TextBlock","text":"after"}`))
 		if err != nil {
-			t.Fatalf("Append(unregistered metadata): %v", err)
+			t.Fatalf("Append(unregistered metadata) error = %v, want nil", err)
 		}
 		if got := testutil.CollectAndCount(metrics.update); got != 0 {
 			t.Fatalf("unregistered metadata created %d update metric series, want 0", got)

--- a/pkg/cardtmpl/runtime_cache.go
+++ b/pkg/cardtmpl/runtime_cache.go
@@ -1,0 +1,91 @@
+package cardtmpl
+
+import (
+	"container/list"
+	"sync"
+)
+
+type compiledCacheEntry struct {
+	key      string
+	artifact *CompiledArtifact
+	bytes    int
+}
+
+type compiledArtifactCache struct {
+	mu         sync.Mutex
+	maxEntries int
+	maxBytes   int
+	bytes      int
+	lru        *list.List
+	entries    map[string]*list.Element
+}
+
+func newCompiledArtifactCache(maxEntries, maxBytes int) *compiledArtifactCache {
+	return &compiledArtifactCache{
+		maxEntries: maxEntries,
+		maxBytes:   maxBytes,
+		lru:        list.New(),
+		entries:    make(map[string]*list.Element, maxEntries),
+	}
+}
+
+func (c *compiledArtifactCache) get(key string) (*CompiledArtifact, bool) {
+	if c == nil {
+		return nil, false
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	element, ok := c.entries[key]
+	if !ok {
+		return nil, false
+	}
+	c.lru.MoveToFront(element)
+	return element.Value.(*compiledCacheEntry).artifact, true
+}
+
+func (c *compiledArtifactCache) add(key string, artifact *CompiledArtifact) int {
+	if c == nil || artifact == nil {
+		return 0
+	}
+	weight := len(artifact.Bundle)
+	if weight <= 0 || weight > c.maxBytes {
+		return 0
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if existing, ok := c.entries[key]; ok {
+		entry := existing.Value.(*compiledCacheEntry)
+		c.bytes -= entry.bytes
+		entry.artifact = artifact
+		entry.bytes = weight
+		c.bytes += weight
+		c.lru.MoveToFront(existing)
+	} else {
+		entry := &compiledCacheEntry{key: key, artifact: artifact, bytes: weight}
+		element := c.lru.PushFront(entry)
+		c.entries[key] = element
+		c.bytes += weight
+	}
+	evicted := 0
+	for len(c.entries) > c.maxEntries || c.bytes > c.maxBytes {
+		oldest := c.lru.Back()
+		if oldest == nil {
+			break
+		}
+		entry := oldest.Value.(*compiledCacheEntry)
+		delete(c.entries, entry.key)
+		c.bytes -= entry.bytes
+		c.lru.Remove(oldest)
+		evicted++
+	}
+	return evicted
+}
+
+func (c *compiledArtifactCache) size() (entries, bytes int) {
+	if c == nil {
+		return 0, 0
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.entries), c.bytes
+}

--- a/pkg/cardtmpl/runtime_catalog.go
+++ b/pkg/cardtmpl/runtime_catalog.go
@@ -1,0 +1,521 @@
+package cardtmpl
+
+import (
+	"context"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"golang.org/x/sync/singleflight"
+)
+
+const (
+	defaultRuntimeCacheEntries = 64
+	defaultRuntimeCacheBytes   = 32 << 20
+	hardRuntimeCacheEntries    = 256
+	hardRuntimeCacheBytes      = 128 << 20
+	defaultRuntimeCompileTime  = 10 * time.Second
+)
+
+var (
+	ErrRuntimeCatalogUnavailable     = errors.New("cardtmpl: runtime catalog unavailable")
+	ErrRuntimeCatalogDisabled        = errors.New("cardtmpl: runtime catalog template disabled")
+	ErrRuntimeCatalogBlocked         = errors.New("cardtmpl: runtime catalog artifact blocked")
+	ErrRuntimeCatalogNewSendDisabled = errors.New("cardtmpl: runtime catalog dynamic new-send disabled")
+	ErrRuntimeCatalogNotAuthorized   = errors.New("cardtmpl: runtime catalog principal not authorized")
+	ErrRuntimeCatalogIntegrity       = errors.New("cardtmpl: runtime catalog integrity failure")
+)
+
+type RuntimeActivationStatus string
+
+const (
+	RuntimeActivationActive   RuntimeActivationStatus = "active"
+	RuntimeActivationDisabled RuntimeActivationStatus = "disabled"
+)
+
+type RuntimeActivation struct {
+	Exists   bool
+	Version  string
+	Status   RuntimeActivationStatus
+	Revision uint64
+}
+
+type RuntimeSource string
+
+const (
+	RuntimeSourceStatic  RuntimeSource = "static"
+	RuntimeSourceDynamic RuntimeSource = "dynamic"
+)
+
+type RuntimeArtifactMeta struct {
+	ID              ID
+	Version         string
+	Source          RuntimeSource
+	Engine          string
+	Hash            string
+	Owner           string
+	Visibility      string
+	Protocol        string
+	ContractVersion string
+	Blocked         bool
+}
+
+type RuntimeArtifactStore interface {
+	LoadActivation(context.Context, ID) (RuntimeActivation, error)
+	LoadArtifactMeta(context.Context, ID, string) (RuntimeArtifactMeta, error)
+	LoadArtifactBundle(context.Context, ID, string, string) (CanonicalBundle, error)
+}
+
+type RuntimeDynamicAuthorizeFunc func(context.Context, CatalogAccess, RuntimeArtifactMeta) error
+
+type RuntimeCatalogHooks struct {
+	OnResolve   func(RuntimeSource, string)
+	OnCache     func(string)
+	OnCacheSize func(entries, bytes int)
+}
+
+type RuntimeCatalogConfig struct {
+	MaxCacheEntries  int
+	MaxCacheBytes    int
+	CompileTimeout   time.Duration
+	CheckReady       func() error
+	AuthorizeDynamic RuntimeDynamicAuthorizeFunc
+	Hooks            RuntimeCatalogHooks
+}
+
+type RuntimeCatalog struct {
+	static           *StaticCatalog
+	store            RuntimeArtifactStore
+	cache            *compiledArtifactCache
+	compileTimeout   time.Duration
+	compile          func(context.Context, Bundle, CompileLimits) (*CompiledArtifact, error)
+	checkReady       func() error
+	authorizeDynamic RuntimeDynamicAuthorizeFunc
+	hooks            RuntimeCatalogHooks
+	flights          singleflight.Group
+}
+
+func NewRuntimeCatalog(
+	registry *Registry,
+	store RuntimeArtifactStore,
+	config RuntimeCatalogConfig,
+) (*RuntimeCatalog, error) {
+	if registry == nil || store == nil {
+		return nil, errors.New("cardtmpl: runtime catalog dependencies are required")
+	}
+	registry.mu.RLock()
+	frozen := registry.frozen
+	registry.mu.RUnlock()
+	if !frozen {
+		return nil, errors.New("cardtmpl: runtime catalog requires a frozen built-in Registry")
+	}
+	static, err := NewStaticCatalog(registry)
+	if err != nil {
+		return nil, err
+	}
+	entries, bytes, timeout, err := normalizeRuntimeCatalogConfig(config)
+	if err != nil {
+		return nil, err
+	}
+	return &RuntimeCatalog{
+		static: static, store: store,
+		cache: newCompiledArtifactCache(entries, bytes), compileTimeout: timeout,
+		compile:          CompileJSONArtifact,
+		checkReady:       config.CheckReady,
+		authorizeDynamic: config.AuthorizeDynamic,
+		hooks:            config.Hooks,
+	}, nil
+}
+
+func normalizeRuntimeCatalogConfig(config RuntimeCatalogConfig) (int, int, time.Duration, error) {
+	entries := config.MaxCacheEntries
+	if entries == 0 {
+		entries = defaultRuntimeCacheEntries
+	}
+	bytes := config.MaxCacheBytes
+	if bytes == 0 {
+		bytes = defaultRuntimeCacheBytes
+	}
+	timeout := config.CompileTimeout
+	if timeout == 0 {
+		timeout = defaultRuntimeCompileTime
+	}
+	if entries < 1 || entries > hardRuntimeCacheEntries || bytes < 1 || bytes > hardRuntimeCacheBytes ||
+		timeout < 1 || timeout > defaultRuntimeCompileTime {
+		return 0, 0, 0, errors.New("cardtmpl: runtime catalog cache/compile limits are invalid")
+	}
+	return entries, bytes, timeout, nil
+}
+
+func (c *RuntimeCatalog) Render(ctx context.Context, request CatalogRenderRequest) (map[string]any, error) {
+	if c == nil || c.static == nil || c.store == nil {
+		return nil, ErrRuntimeCatalogUnavailable
+	}
+	explicit := request.Version != ""
+	version, err := c.resolveVersion(ctx, request.ID, request.Version)
+	if err != nil {
+		return nil, err
+	}
+	if version == "" {
+		payload, err := c.static.Render(ctx, request)
+		c.observeResolve(RuntimeSourceStatic, err)
+		return payload, err
+	}
+	if _, err := c.static.registry.Lookup(request.ID, version); err == nil {
+		if explicit {
+			if err := c.rejectIntegrity(); err != nil {
+				c.observeResolve(RuntimeSourceStatic, err)
+				return nil, err
+			}
+		}
+		request.Version = version
+		payload, renderErr := c.static.Render(ctx, request)
+		c.observeResolve(RuntimeSourceStatic, renderErr)
+		return payload, renderErr
+	} else if !errors.Is(err, ErrTemplateUnknown) {
+		return nil, err
+	}
+	request.Version = version
+	artifact, err := c.resolveDynamic(ctx, request.Access, request.ID, version)
+	if err != nil {
+		return nil, err
+	}
+	return renderCore(ctx, artifact.Template, artifact.Meta, request.State, request.Fields, request.Env)
+}
+
+func (c *RuntimeCatalog) MetaExact(ctx context.Context, request CatalogExactRequest) (TemplateMeta, error) {
+	if c == nil || c.static == nil || c.store == nil {
+		return TemplateMeta{}, ErrRuntimeCatalogUnavailable
+	}
+	if strings.TrimSpace(request.Version) == "" {
+		return TemplateMeta{}, fmt.Errorf("%w: explicit version is required", ErrTemplateUnknown)
+	}
+	if meta, err := c.static.MetaExact(ctx, request); err == nil {
+		if err := c.rejectIntegrity(); err != nil {
+			c.observeResolve(RuntimeSourceStatic, err)
+			return TemplateMeta{}, err
+		}
+		c.observeResolve(RuntimeSourceStatic, nil)
+		return meta, nil
+	} else if !errors.Is(err, ErrTemplateUnknown) {
+		return TemplateMeta{}, err
+	}
+	artifact, err := c.resolveDynamic(ctx, request.Access, request.ID, request.Version)
+	if err != nil {
+		return TemplateMeta{}, err
+	}
+	return artifact.Meta.Clone(), nil
+}
+
+func (c *RuntimeCatalog) MetaDefault(ctx context.Context, request CatalogDefaultRequest) (TemplateMeta, error) {
+	if c == nil || c.static == nil || c.store == nil {
+		return TemplateMeta{}, ErrRuntimeCatalogUnavailable
+	}
+	version, err := c.resolveVersion(ctx, request.ID, "")
+	if err != nil {
+		return TemplateMeta{}, err
+	}
+	if version == "" {
+		meta, metaErr := c.static.MetaDefault(ctx, request)
+		c.observeResolve(RuntimeSourceStatic, metaErr)
+		return meta, metaErr
+	}
+	return c.MetaExact(ctx, CatalogExactRequest{Access: request.Access, ID: request.ID, Version: version})
+}
+
+func (c *RuntimeCatalog) FallbackText(ctx context.Context, request CatalogFallbackRequest) (string, error) {
+	if c == nil || c.static == nil || c.store == nil {
+		return "", ErrRuntimeCatalogUnavailable
+	}
+	explicit := request.Version != ""
+	version, err := c.resolveVersion(ctx, request.ID, request.Version)
+	if err != nil {
+		return "", err
+	}
+	if template, lookupErr := c.static.registry.Lookup(request.ID, version); lookupErr == nil {
+		if explicit {
+			if err := c.rejectIntegrity(); err != nil {
+				c.observeResolve(RuntimeSourceStatic, err)
+				return "", err
+			}
+		}
+		text, fallbackErr := template.FallbackText(request.State, request.Fields, request.Lang)
+		c.observeResolve(RuntimeSourceStatic, fallbackErr)
+		return text, fallbackErr
+	} else if !errors.Is(lookupErr, ErrTemplateUnknown) {
+		return "", lookupErr
+	}
+	if version == "" {
+		return "", fmt.Errorf("%w: %s has no default", ErrTemplateUnknown, request.ID)
+	}
+	artifact, err := c.resolveDynamic(ctx, request.Access, request.ID, version)
+	if err != nil {
+		return "", err
+	}
+	return artifact.Template.FallbackText(request.State, request.Fields, request.Lang)
+}
+
+func (c *RuntimeCatalog) ActionContext(ctx context.Context, request CatalogActionRequest) (CatalogActionContext, error) {
+	if c == nil || c.static == nil || c.store == nil {
+		return CatalogActionContext{}, ErrRuntimeCatalogUnavailable
+	}
+	if _, err := c.static.registry.Lookup(request.ID, request.Version); err == nil {
+		if err := c.rejectIntegrity(); err != nil {
+			c.observeResolve(RuntimeSourceStatic, err)
+			return CatalogActionContext{}, err
+		}
+		result, actionErr := c.static.ActionContext(ctx, request)
+		c.observeResolve(RuntimeSourceStatic, actionErr)
+		return result, actionErr
+	} else if !errors.Is(err, ErrTemplateUnknown) {
+		return CatalogActionContext{}, err
+	}
+	artifact, err := c.resolveDynamic(ctx, request.Access, request.ID, request.Version)
+	if err != nil {
+		return CatalogActionContext{}, err
+	}
+	view, err := actionViewFromMeta(artifact.Meta, request.ActionID)
+	if err != nil {
+		return CatalogActionContext{}, err
+	}
+	return CatalogActionContext{View: view, Meta: artifact.Meta.Clone()}, nil
+}
+
+func (c *RuntimeCatalog) resolveDynamic(
+	ctx context.Context,
+	access CatalogAccess,
+	id ID,
+	version string,
+) (artifact *CompiledArtifact, err error) {
+	defer func() { c.observeResolve(RuntimeSourceDynamic, err) }()
+	if err := c.requireReady(); err != nil {
+		return nil, err
+	}
+	if c.authorizeDynamic == nil {
+		return nil, ErrRuntimeCatalogNotAuthorized
+	}
+	meta, err := c.store.LoadArtifactMeta(ctx, id, version)
+	if err != nil {
+		return nil, classifyRuntimeStoreError("load artifact metadata", err)
+	}
+	if err := validateRuntimeArtifactMeta(id, version, meta); err != nil {
+		return nil, err
+	}
+	if meta.Blocked {
+		return nil, fmt.Errorf("%w: %s@%s", ErrRuntimeCatalogBlocked, id, version)
+	}
+	if err := c.authorizeDynamic(ctx, access, meta); err != nil {
+		if errors.Is(err, ErrRuntimeCatalogNotAuthorized) || errors.Is(err, ErrRuntimeCatalogNewSendDisabled) {
+			return nil, err
+		}
+		return nil, fmt.Errorf("%w: authorize dynamic artifact: %w", ErrRuntimeCatalogUnavailable, err)
+	}
+	return c.loadCompiled(ctx, meta)
+}
+
+func (c *RuntimeCatalog) resolveVersion(ctx context.Context, id ID, explicit string) (string, error) {
+	if explicit != "" {
+		return explicit, nil
+	}
+	if err := c.requireReady(); err != nil {
+		return "", err
+	}
+	activation, err := c.store.LoadActivation(ctx, id)
+	if err != nil {
+		return "", classifyRuntimeStoreError("load activation", err)
+	}
+	if !activation.Exists {
+		return "", nil
+	}
+	switch activation.Status {
+	case RuntimeActivationDisabled:
+		return "", fmt.Errorf("%w: %s revision %d", ErrRuntimeCatalogDisabled, id, activation.Revision)
+	case RuntimeActivationActive:
+		if strings.TrimSpace(activation.Version) == "" {
+			return "", fmt.Errorf("%w: active row has no version", ErrRuntimeCatalogIntegrity)
+		}
+		return activation.Version, nil
+	default:
+		return "", fmt.Errorf("%w: unknown activation status %q", ErrRuntimeCatalogIntegrity, activation.Status)
+	}
+}
+
+func (c *RuntimeCatalog) loadCompiled(ctx context.Context, meta RuntimeArtifactMeta) (*CompiledArtifact, error) {
+	key := meta.Engine + ":" + meta.Hash
+	if artifact, ok := c.cache.get(key); ok {
+		c.observeCache("hit")
+		if err := validateCompiledArtifact(meta, artifact); err != nil {
+			return nil, err
+		}
+		return artifact, nil
+	}
+	c.observeCache("miss")
+	resultCh := c.flights.DoChan(key, func() (any, error) {
+		if artifact, ok := c.cache.get(key); ok {
+			if err := validateCompiledArtifact(meta, artifact); err != nil {
+				return nil, err
+			}
+			return artifact, nil
+		}
+		compileCtx, cancel := context.WithTimeout(context.Background(), c.compileTimeout)
+		defer cancel()
+		canonical, err := c.store.LoadArtifactBundle(compileCtx, meta.ID, meta.Version, meta.Hash)
+		if err != nil {
+			return nil, classifyRuntimeStoreError("load artifact bundle", err)
+		}
+		bundle, err := DecodeBundleJSON(canonical)
+		if err != nil {
+			return nil, fmt.Errorf("%w: decode stored bundle: %w", ErrRuntimeCatalogIntegrity, err)
+		}
+		compiler := c.compile
+		if compiler == nil {
+			compiler = CompileJSONArtifact
+		}
+		artifact, err := compiler(compileCtx, bundle, DefaultCompileLimits())
+		if err != nil {
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) ||
+				errors.Is(err, ErrArtifactCompileBusy) {
+				return nil, fmt.Errorf("%w: compile stored bundle: %w", ErrRuntimeCatalogUnavailable, err)
+			}
+			return nil, fmt.Errorf("%w: compile stored bundle: %w", ErrRuntimeCatalogIntegrity, err)
+		}
+		if err := validateCompiledArtifact(meta, artifact); err != nil {
+			return nil, err
+		}
+		evicted := c.cache.add(key, artifact)
+		for i := 0; i < evicted; i++ {
+			c.observeCache("evict")
+		}
+		if c.hooks.OnCacheSize != nil {
+			entries, bytes := c.cache.size()
+			c.hooks.OnCacheSize(entries, bytes)
+		}
+		return artifact, nil
+	})
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case result := <-resultCh:
+		if result.Shared {
+			c.observeCache("shared")
+		}
+		if result.Err != nil {
+			return nil, result.Err
+		}
+		artifact, ok := result.Val.(*CompiledArtifact)
+		if !ok || artifact == nil {
+			return nil, fmt.Errorf("%w: invalid compiled cache value", ErrRuntimeCatalogIntegrity)
+		}
+		if err := validateCompiledArtifact(meta, artifact); err != nil {
+			return nil, err
+		}
+		return artifact, nil
+	}
+}
+
+func (c *RuntimeCatalog) requireReady() error {
+	if c == nil || c.checkReady == nil {
+		return nil
+	}
+	err := c.checkReady()
+	switch {
+	case err == nil:
+		return nil
+	case errors.Is(err, ErrRuntimeCatalogIntegrity), errors.Is(err, ErrRuntimeCatalogUnavailable),
+		errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
+		return err
+	default:
+		return fmt.Errorf("%w: readiness check: %v", ErrRuntimeCatalogUnavailable, err)
+	}
+}
+
+// CheckReady reports whether startup reconciliation has established a safe
+// authoritative view for default and dynamic catalog paths. It performs no IO
+// and is intended for the process readiness probe composed by main.
+func (c *RuntimeCatalog) CheckReady() error {
+	return c.requireReady()
+}
+
+// rejectIntegrity keeps explicit static reads available during a transient DB
+// outage while still failing closed after startup proves a static/dynamic
+// source collision or another persistent catalog invariant violation.
+func (c *RuntimeCatalog) rejectIntegrity() error {
+	if c == nil || c.checkReady == nil {
+		return nil
+	}
+	err := c.checkReady()
+	if errors.Is(err, ErrRuntimeCatalogIntegrity) {
+		return err
+	}
+	return nil
+}
+
+func (c *RuntimeCatalog) observeResolve(source RuntimeSource, err error) {
+	if c != nil && c.hooks.OnResolve != nil {
+		c.hooks.OnResolve(source, runtimeCatalogResult(err))
+	}
+}
+
+func (c *RuntimeCatalog) observeCache(result string) {
+	if c != nil && c.hooks.OnCache != nil {
+		c.hooks.OnCache(result)
+	}
+}
+
+func runtimeCatalogResult(err error) string {
+	switch {
+	case err == nil:
+		return "ok"
+	case errors.Is(err, ErrTemplateUnknown):
+		return "unknown"
+	case errors.Is(err, ErrRuntimeCatalogDisabled), errors.Is(err, ErrRuntimeCatalogNewSendDisabled):
+		return "disabled"
+	case errors.Is(err, ErrRuntimeCatalogBlocked):
+		return "blocked"
+	case errors.Is(err, ErrRuntimeCatalogNotAuthorized):
+		return "unauthorized"
+	case errors.Is(err, ErrRuntimeCatalogIntegrity):
+		return "integrity"
+	case errors.Is(err, ErrRuntimeCatalogUnavailable), errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
+		return "unavailable"
+	default:
+		return "error"
+	}
+}
+
+func validateRuntimeArtifactMeta(id ID, version string, meta RuntimeArtifactMeta) error {
+	decodedHash, hashErr := hex.DecodeString(meta.Hash)
+	validHash := hashErr == nil && len(decodedHash) == 32 && strings.ToLower(meta.Hash) == meta.Hash
+	validVisibility := meta.Visibility == CatalogVisibilityPublic || meta.Visibility == CatalogVisibilityPrivate
+	if meta.ID != id || meta.Version != version || meta.Source != RuntimeSourceDynamic ||
+		meta.Engine != JSONTemplateEngineV1 || !validHash || strings.TrimSpace(meta.Owner) == "" ||
+		!validVisibility || meta.Protocol != Protocol {
+		return fmt.Errorf("%w: invalid metadata for %s@%s", ErrRuntimeCatalogIntegrity, id, version)
+	}
+	return nil
+}
+
+func validateCompiledArtifact(meta RuntimeArtifactMeta, artifact *CompiledArtifact) error {
+	if artifact == nil || artifact.Meta.ID != meta.ID || artifact.Meta.Version != meta.Version ||
+		artifact.Engine != meta.Engine || artifact.Hash != meta.Hash || artifact.Owner != meta.Owner ||
+		artifact.Visibility != meta.Visibility || artifact.Meta.Protocol != meta.Protocol ||
+		artifact.ContractVersion != meta.ContractVersion {
+		return fmt.Errorf("%w: compiled metadata mismatch for %s@%s",
+			ErrRuntimeCatalogIntegrity, meta.ID, meta.Version)
+	}
+	return nil
+}
+
+func classifyRuntimeStoreError(operation string, err error) error {
+	switch {
+	case err == nil:
+		return nil
+	case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded),
+		errors.Is(err, ErrTemplateUnknown), errors.Is(err, ErrRuntimeCatalogIntegrity):
+		return fmt.Errorf("cardtmpl: %s: %w", operation, err)
+	default:
+		return fmt.Errorf("%w: %s: %v", ErrRuntimeCatalogUnavailable, operation, err)
+	}
+}

--- a/pkg/cardtmpl/runtime_catalog_test.go
+++ b/pkg/cardtmpl/runtime_catalog_test.go
@@ -1,0 +1,802 @@
+package cardtmpl
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"reflect"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestStaticCatalogRenderMatchesFrozenRegistry(t *testing.T) {
+	registry := runtimeStaticRegistry(t)
+	catalog, err := NewStaticCatalog(registry)
+	if err != nil {
+		t.Fatalf("NewStaticCatalog: %v", err)
+	}
+	request := CatalogRenderRequest{
+		Access: CatalogAccess{Purpose: CatalogPurposeNewSend, Principal: CatalogPrincipal{
+			Kind: CatalogPrincipalSystem, ID: "test-producer", SpaceID: "space-1",
+		}},
+		ID: "test.runtime-parity", Version: "1.0.0", State: "shown",
+		Fields: json.RawMessage(`{"title":"parity"}`),
+		Env:    BuildEnv{Lang: "en-US", SpaceID: "space-1"},
+	}
+	got, err := catalog.Render(context.Background(), request)
+	if err != nil {
+		t.Fatalf("Catalog.Render: %v", err)
+	}
+	want, err := registry.Render(context.Background(), request.ID, request.Version, request.State, request.Fields, request.Env)
+	if err != nil {
+		t.Fatalf("Registry.Render: %v", err)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("static catalog payload drifted\ngot=%#v\nwant=%#v", got, want)
+	}
+}
+
+func TestStaticCatalogDefaultMetaFallbackAndCardMatchFrozenRegistry(t *testing.T) {
+	registry := runtimeStaticRegistry(t)
+	catalog, err := NewStaticCatalog(registry)
+	if err != nil {
+		t.Fatalf("NewStaticCatalog: %v", err)
+	}
+	access := staticDefaultRequest().Access
+	meta, err := catalog.MetaDefault(context.Background(), CatalogDefaultRequest{
+		Access: access, ID: "test.runtime-parity",
+	})
+	if err != nil {
+		t.Fatalf("MetaDefault: %v", err)
+	}
+	if meta.ID != "test.runtime-parity" || meta.Version != "1.0.0" {
+		t.Fatalf("default meta = %s@%s", meta.ID, meta.Version)
+	}
+	fields := json.RawMessage(`{"title":"parity"}`)
+	gotFallback, err := catalog.FallbackText(context.Background(), CatalogFallbackRequest{
+		Access: access, ID: "test.runtime-parity", State: "shown", Fields: fields, Lang: "en-US",
+	})
+	if err != nil {
+		t.Fatalf("FallbackText: %v", err)
+	}
+	template, err := registry.Lookup("test.runtime-parity", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantFallback, err := template.FallbackText("shown", fields, "en-US")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotFallback != wantFallback {
+		t.Fatalf("fallback = %q, want %q", gotFallback, wantFallback)
+	}
+	request := staticDefaultRequest()
+	gotCard, gotProfile, gotRenderProfile, err := RenderCatalogCardWithProfiles(context.Background(), catalog, request)
+	if err != nil {
+		t.Fatalf("RenderCatalogCardWithProfiles: %v", err)
+	}
+	wantCard, wantProfile, wantRenderProfile, err := registry.RenderCardWithProfiles(
+		context.Background(), request.ID, request.Version, request.State, request.Fields, request.Env,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(gotCard, wantCard) || gotProfile != wantProfile || gotRenderProfile != wantRenderProfile {
+		t.Fatalf("catalog card/profile drifted: card=%s profile=%q render=%q", gotCard, gotProfile, gotRenderProfile)
+	}
+}
+
+func TestRuntimeCatalogDefaultWithoutActivationUsesStaticDefault(t *testing.T) {
+	registry := runtimeStaticRegistry(t)
+	store := &runtimeStoreStub{activation: RuntimeActivation{Exists: false}}
+	catalog := newRuntimeCatalogForTest(t, registry, store, nil)
+
+	payload, err := catalog.Render(context.Background(), staticDefaultRequest())
+	if err != nil {
+		t.Fatalf("Render static default: %v", err)
+	}
+	if payload["profile"] != profileV1 {
+		t.Fatalf("profile = %v, want %s", payload["profile"], profileV1)
+	}
+	if store.activationCalls != 1 || store.metaCalls != 0 || store.bundleCalls != 0 {
+		t.Fatalf("store calls activation/meta/bundle = %d/%d/%d, want 1/0/0",
+			store.activationCalls, store.metaCalls, store.bundleCalls)
+	}
+}
+
+func TestNewRuntimeCatalogRejectsMutableRegistry(t *testing.T) {
+	registry := NewRegistry()
+	store := &runtimeStoreStub{}
+	if _, err := NewRuntimeCatalog(registry, store, RuntimeCatalogConfig{}); err == nil {
+		t.Fatal("NewRuntimeCatalog accepted a mutable built-in Registry")
+	}
+}
+
+func TestNewRuntimeCatalogRejectsCompileDeadlineAboveHardLimit(t *testing.T) {
+	registry := NewRegistry()
+	registry.Freeze()
+	if _, err := NewRuntimeCatalog(registry, &runtimeStoreStub{}, RuntimeCatalogConfig{
+		CompileTimeout: defaultRuntimeCompileTime + time.Nanosecond,
+	}); err == nil {
+		t.Fatal("NewRuntimeCatalog accepted compile timeout above hard limit")
+	}
+}
+
+func TestRuntimeCatalogDefaultDBFailureDoesNotFallbackStatic(t *testing.T) {
+	registry := runtimeStaticRegistry(t)
+	store := &runtimeStoreStub{activationErr: errors.New("db unavailable")}
+	catalog := newRuntimeCatalogForTest(t, registry, store, nil)
+
+	_, err := catalog.Render(context.Background(), staticDefaultRequest())
+	if !errors.Is(err, ErrRuntimeCatalogUnavailable) {
+		t.Fatalf("Render error = %v, want ErrRuntimeCatalogUnavailable", err)
+	}
+}
+
+func TestRuntimeCatalogExplicitDisabledDoesNotFallbackStatic(t *testing.T) {
+	registry := runtimeStaticRegistry(t)
+	store := &runtimeStoreStub{activation: RuntimeActivation{
+		Exists: true, Status: RuntimeActivationDisabled, Revision: 3,
+	}}
+	catalog := newRuntimeCatalogForTest(t, registry, store, nil)
+
+	_, err := catalog.Render(context.Background(), staticDefaultRequest())
+	if !errors.Is(err, ErrRuntimeCatalogDisabled) {
+		t.Fatalf("Render error = %v, want ErrRuntimeCatalogDisabled", err)
+	}
+}
+
+func TestRuntimeCatalogReadinessGatesDBBackedPathsButNotStaticExact(t *testing.T) {
+	registry := runtimeStaticRegistry(t)
+	store := &runtimeStoreStub{activation: RuntimeActivation{Exists: false}}
+	readyErr := ErrRuntimeCatalogUnavailable
+	readyCalls := 0
+	catalog, err := NewRuntimeCatalog(registry, store, RuntimeCatalogConfig{
+		MaxCacheEntries: 4,
+		MaxCacheBytes:   4 << 20,
+		CompileTimeout:  time.Second,
+		CheckReady: func() error {
+			readyCalls++
+			return readyErr
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewRuntimeCatalog: %v", err)
+	}
+
+	exact := staticDefaultRequest()
+	exact.Version = "1.0.0"
+	if _, err := catalog.Render(context.Background(), exact); err != nil {
+		t.Fatalf("explicit static render while runtime is unready: %v", err)
+	}
+	if readyCalls != 1 || store.activationCalls != 0 {
+		t.Fatalf("explicit static readiness/activation calls = %d/%d, want 1/0", readyCalls, store.activationCalls)
+	}
+
+	if _, err := catalog.Render(context.Background(), staticDefaultRequest()); !errors.Is(err, ErrRuntimeCatalogUnavailable) {
+		t.Fatalf("default render error = %v, want ErrRuntimeCatalogUnavailable", err)
+	}
+	if readyCalls != 2 || store.activationCalls != 0 {
+		t.Fatalf("unready default readiness/activation calls = %d/%d, want 2/0", readyCalls, store.activationCalls)
+	}
+
+	readyErr = nil
+	if _, err := catalog.Render(context.Background(), staticDefaultRequest()); err != nil {
+		t.Fatalf("ready default render: %v", err)
+	}
+	if readyCalls != 3 || store.activationCalls != 1 {
+		t.Fatalf("ready default readiness/activation calls = %d/%d, want 3/1", readyCalls, store.activationCalls)
+	}
+
+	readyErr = ErrRuntimeCatalogIntegrity
+	if _, err := catalog.Render(context.Background(), exact); !errors.Is(err, ErrRuntimeCatalogIntegrity) {
+		t.Fatalf("explicit static render under catalog integrity failure = %v, want ErrRuntimeCatalogIntegrity", err)
+	}
+	if readyCalls != 4 || store.activationCalls != 1 {
+		t.Fatalf("integrity static readiness/activation calls = %d/%d, want 4/1", readyCalls, store.activationCalls)
+	}
+}
+
+func TestRuntimeCatalogDynamicColdThenHotStillReadsAuthoritativeMetadata(t *testing.T) {
+	artifact := compileRuntimeFixture(t)
+	store := &runtimeStoreStub{
+		activation: RuntimeActivation{
+			Exists: true, Status: RuntimeActivationActive, Version: artifact.Meta.Version, Revision: 1,
+		},
+		meta:   runtimeArtifactMeta(artifact),
+		bundle: artifact.Bundle,
+	}
+	catalog := newRuntimeCatalogForTest(t, runtimeStaticRegistry(t), store, allowDynamicForTest)
+	request := dynamicDefaultRequest()
+
+	for i := 0; i < 2; i++ {
+		payload, err := catalog.Render(context.Background(), request)
+		if err != nil {
+			t.Fatalf("Render dynamic attempt %d: %v", i+1, err)
+		}
+		card, _ := payload["card"].(map[string]any)
+		if card == nil {
+			t.Fatalf("attempt %d returned no card", i+1)
+		}
+	}
+	if store.activationCalls != 2 || store.metaCalls != 2 || store.bundleCalls != 1 {
+		t.Fatalf("store calls activation/meta/bundle = %d/%d/%d, want 2/2/1",
+			store.activationCalls, store.metaCalls, store.bundleCalls)
+	}
+}
+
+func TestRuntimeCatalogHotCacheCannotBypassBlock(t *testing.T) {
+	artifact := compileRuntimeFixture(t)
+	store := &runtimeStoreStub{
+		activation: RuntimeActivation{
+			Exists: true, Status: RuntimeActivationActive, Version: artifact.Meta.Version, Revision: 1,
+		},
+		meta:   runtimeArtifactMeta(artifact),
+		bundle: artifact.Bundle,
+	}
+	catalog := newRuntimeCatalogForTest(t, runtimeStaticRegistry(t), store, allowDynamicForTest)
+	request := dynamicDefaultRequest()
+	if _, err := catalog.Render(context.Background(), request); err != nil {
+		t.Fatalf("warm cache: %v", err)
+	}
+	store.mu.Lock()
+	store.meta.Blocked = true
+	store.mu.Unlock()
+
+	_, err := catalog.Render(context.Background(), request)
+	if !errors.Is(err, ErrRuntimeCatalogBlocked) {
+		t.Fatalf("blocked hot-cache render error = %v, want ErrRuntimeCatalogBlocked", err)
+	}
+	if store.bundleCalls != 1 {
+		t.Fatalf("bundle calls = %d, want warm load only", store.bundleCalls)
+	}
+}
+
+func TestRuntimeCatalogHotCacheRejectsMetadataIdentityMismatch(t *testing.T) {
+	artifact := compileRuntimeFixture(t)
+	store := &runtimeStoreStub{
+		meta:   runtimeArtifactMeta(artifact),
+		bundle: artifact.Bundle,
+	}
+	catalog := newRuntimeCatalogForTest(t, runtimeStaticRegistry(t), store, allowDynamicForTest)
+	if _, err := catalog.MetaExact(context.Background(), CatalogExactRequest{
+		Access: dynamicDefaultRequest().Access, ID: artifact.Meta.ID, Version: artifact.Meta.Version,
+	}); err != nil {
+		t.Fatalf("warm cache: %v", err)
+	}
+
+	const aliasID ID = "test.runtime-card-alias"
+	store.mu.Lock()
+	store.meta.ID = aliasID
+	store.meta.Version = "9.9.9"
+	store.mu.Unlock()
+
+	_, err := catalog.MetaExact(context.Background(), CatalogExactRequest{
+		Access: dynamicDefaultRequest().Access, ID: aliasID, Version: "9.9.9",
+	})
+	if !errors.Is(err, ErrRuntimeCatalogIntegrity) {
+		t.Fatalf("aliased hot-cache error = %v, want ErrRuntimeCatalogIntegrity", err)
+	}
+	if store.bundleCalls != 1 {
+		t.Fatalf("bundle calls = %d, want no second load for same hash", store.bundleCalls)
+	}
+}
+
+func TestRuntimeCatalogColdLoadRejectsStoredMetadataDrift(t *testing.T) {
+	artifact := compileRuntimeFixture(t)
+	tests := []struct {
+		name   string
+		mutate func(*RuntimeArtifactMeta)
+	}{
+		{name: "owner", mutate: func(meta *RuntimeArtifactMeta) { meta.Owner += ".other" }},
+		{name: "visibility", mutate: func(meta *RuntimeArtifactMeta) { meta.Visibility = CatalogVisibilityPublic }},
+		{name: "protocol", mutate: func(meta *RuntimeArtifactMeta) { meta.Protocol = "octo-card@9.9" }},
+		{name: "contract version", mutate: func(meta *RuntimeArtifactMeta) { meta.ContractVersion = "9.9.9" }},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			meta := runtimeArtifactMeta(artifact)
+			test.mutate(&meta)
+			store := &runtimeStoreStub{meta: meta, bundle: artifact.Bundle}
+			catalog := newRuntimeCatalogForTest(t, runtimeStaticRegistry(t), store, allowDynamicForTest)
+
+			_, err := catalog.MetaExact(context.Background(), CatalogExactRequest{
+				Access: dynamicDefaultRequest().Access, ID: artifact.Meta.ID, Version: artifact.Meta.Version,
+			})
+			if !errors.Is(err, ErrRuntimeCatalogIntegrity) {
+				t.Fatalf("metadata drift error = %v, want ErrRuntimeCatalogIntegrity", err)
+			}
+		})
+	}
+}
+
+func TestRuntimeCatalogRejectsMalformedStoredHashBeforeBundleLoad(t *testing.T) {
+	artifact := compileRuntimeFixture(t)
+	meta := runtimeArtifactMeta(artifact)
+	meta.Hash = "not-a-sha256"
+	store := &runtimeStoreStub{meta: meta, bundle: artifact.Bundle}
+	catalog := newRuntimeCatalogForTest(t, runtimeStaticRegistry(t), store, allowDynamicForTest)
+
+	_, err := catalog.MetaExact(context.Background(), CatalogExactRequest{
+		Access: dynamicDefaultRequest().Access, ID: artifact.Meta.ID, Version: artifact.Meta.Version,
+	})
+	if !errors.Is(err, ErrRuntimeCatalogIntegrity) {
+		t.Fatalf("malformed hash error = %v, want ErrRuntimeCatalogIntegrity", err)
+	}
+	if store.bundleCalls != 0 {
+		t.Fatalf("bundle calls = %d, want 0 for malformed metadata", store.bundleCalls)
+	}
+}
+
+func TestRuntimeCatalogPreservesAuthoritativeStoreErrorClass(t *testing.T) {
+	artifact := compileRuntimeFixture(t)
+	request := CatalogExactRequest{
+		Access: dynamicDefaultRequest().Access, ID: artifact.Meta.ID, Version: artifact.Meta.Version,
+	}
+	tests := []struct {
+		name      string
+		metaErr   error
+		bundleErr error
+		want      error
+		unavail   bool
+	}{
+		{name: "unknown", metaErr: ErrTemplateUnknown, want: ErrTemplateUnknown},
+		{name: "metadata integrity", metaErr: ErrRuntimeCatalogIntegrity, want: ErrRuntimeCatalogIntegrity},
+		{name: "bundle integrity", bundleErr: ErrRuntimeCatalogIntegrity, want: ErrRuntimeCatalogIntegrity},
+		{name: "database unavailable", metaErr: errors.New("db unavailable"), want: ErrRuntimeCatalogUnavailable, unavail: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			store := &runtimeStoreStub{
+				meta: runtimeArtifactMeta(artifact), metaErr: test.metaErr,
+				bundle: artifact.Bundle, bundleErr: test.bundleErr,
+			}
+			catalog := newRuntimeCatalogForTest(t, runtimeStaticRegistry(t), store, allowDynamicForTest)
+			_, err := catalog.MetaExact(context.Background(), request)
+			if !errors.Is(err, test.want) {
+				t.Fatalf("error = %v, want %v", err, test.want)
+			}
+			if errors.Is(err, ErrRuntimeCatalogUnavailable) != test.unavail {
+				t.Fatalf("unavailable classification = %v, want %v (error=%v)",
+					errors.Is(err, ErrRuntimeCatalogUnavailable), test.unavail, err)
+			}
+		})
+	}
+}
+
+func TestRuntimeCatalogClassifiesCompileCapacitySeparatelyFromStoredCorruption(t *testing.T) {
+	artifact := compileRuntimeFixture(t)
+	request := CatalogExactRequest{
+		Access: dynamicDefaultRequest().Access, ID: artifact.Meta.ID, Version: artifact.Meta.Version,
+	}
+	tests := []struct {
+		name          string
+		compileErr    error
+		want          error
+		wantIntegrity bool
+	}{
+		{name: "deadline", compileErr: context.DeadlineExceeded, want: ErrRuntimeCatalogUnavailable},
+		{name: "busy", compileErr: ErrArtifactCompileBusy, want: ErrRuntimeCatalogUnavailable},
+		{name: "invalid stored bundle", compileErr: &ArtifactValidationError{Category: "schema", Document: "schema"}, want: ErrRuntimeCatalogIntegrity, wantIntegrity: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			store := &runtimeStoreStub{meta: runtimeArtifactMeta(artifact), bundle: artifact.Bundle}
+			catalog := newRuntimeCatalogForTest(t, runtimeStaticRegistry(t), store, allowDynamicForTest)
+			catalog.compile = func(context.Context, Bundle, CompileLimits) (*CompiledArtifact, error) {
+				return nil, test.compileErr
+			}
+			_, err := catalog.MetaExact(context.Background(), request)
+			if !errors.Is(err, test.want) {
+				t.Fatalf("error = %v, want %v", err, test.want)
+			}
+			if errors.Is(err, ErrRuntimeCatalogIntegrity) != test.wantIntegrity {
+				t.Fatalf("integrity classification = %v, want %v (error=%v)",
+					errors.Is(err, ErrRuntimeCatalogIntegrity), test.wantIntegrity, err)
+			}
+		})
+	}
+}
+
+func TestCompiledArtifactCacheEnforcesEntryLRU(t *testing.T) {
+	cache := newCompiledArtifactCache(2, 32)
+	a := &CompiledArtifact{Bundle: CanonicalBundle("aaa")}
+	b := &CompiledArtifact{Bundle: CanonicalBundle("bbb")}
+	c := &CompiledArtifact{Bundle: CanonicalBundle("ccc")}
+	cache.add("a", a)
+	cache.add("b", b)
+	if _, ok := cache.get("a"); !ok {
+		t.Fatal("expected a to be cached")
+	}
+	cache.add("c", c)
+
+	if _, ok := cache.get("b"); ok {
+		t.Fatal("least-recently-used b was not evicted")
+	}
+	if entries, bytes := cache.size(); entries != 2 || bytes != 6 {
+		t.Fatalf("cache size = %d entries/%d bytes, want 2/6", entries, bytes)
+	}
+}
+
+func TestCompiledArtifactCacheEnforcesByteLimit(t *testing.T) {
+	cache := newCompiledArtifactCache(4, 5)
+	cache.add("a", &CompiledArtifact{Bundle: CanonicalBundle("aaa")})
+	cache.add("b", &CompiledArtifact{Bundle: CanonicalBundle("bbb")})
+
+	if _, ok := cache.get("a"); ok {
+		t.Fatal("old entry a was not evicted to honor byte limit")
+	}
+	if entries, bytes := cache.size(); entries != 1 || bytes != 3 {
+		t.Fatalf("cache size = %d entries/%d bytes, want 1/3", entries, bytes)
+	}
+	cache.add("too-large", &CompiledArtifact{Bundle: CanonicalBundle("123456")})
+	if _, ok := cache.get("too-large"); ok {
+		t.Fatal("entry larger than the byte budget must not be cached")
+	}
+}
+
+func TestRuntimeCatalogSingleflightSharesConcurrentCompile(t *testing.T) {
+	artifact := compileRuntimeFixture(t)
+	started := make(chan struct{})
+	release := make(chan struct{})
+	store := &runtimeStoreStub{
+		meta: runtimeArtifactMeta(artifact), bundle: artifact.Bundle,
+		bundleStarted: started, bundleRelease: release,
+	}
+	catalog := newRuntimeCatalogForTest(t, runtimeStaticRegistry(t), store, allowDynamicForTest)
+
+	const callers = 16
+	begin := make(chan struct{})
+	errs := make(chan error, callers)
+	for i := 0; i < callers; i++ {
+		go func() {
+			<-begin
+			_, err := catalog.loadCompiled(context.Background(), runtimeArtifactMeta(artifact))
+			errs <- err
+		}()
+	}
+	close(begin)
+	<-started
+	close(release)
+	for i := 0; i < callers; i++ {
+		if err := <-errs; err != nil {
+			t.Fatalf("concurrent load %d: %v", i+1, err)
+		}
+	}
+	store.mu.Lock()
+	bundleCalls := store.bundleCalls
+	store.mu.Unlock()
+	if bundleCalls != 1 {
+		t.Fatalf("bundle calls = %d, want one shared load", bundleCalls)
+	}
+}
+
+func TestRuntimeCatalogSingleflightRevalidatesResultForEveryWaiter(t *testing.T) {
+	artifact := compileRuntimeFixture(t)
+	started := make(chan struct{})
+	release := make(chan struct{})
+	store := &runtimeStoreStub{
+		meta: runtimeArtifactMeta(artifact), bundle: artifact.Bundle,
+		bundleStarted: started, bundleRelease: release,
+	}
+	catalog := newRuntimeCatalogForTest(t, runtimeStaticRegistry(t), store, allowDynamicForTest)
+
+	firstResult := make(chan error, 1)
+	go func() {
+		_, err := catalog.loadCompiled(context.Background(), runtimeArtifactMeta(artifact))
+		firstResult <- err
+	}()
+	<-started
+
+	aliasMeta := runtimeArtifactMeta(artifact)
+	aliasMeta.ID = "test.runtime-card-alias"
+	aliasMeta.Version = "9.9.9"
+	secondResult := make(chan error, 1)
+	go func() {
+		_, err := catalog.loadCompiled(context.Background(), aliasMeta)
+		secondResult <- err
+	}()
+	close(release)
+
+	if err := <-firstResult; err != nil {
+		t.Fatalf("first waiter: %v", err)
+	}
+	if err := <-secondResult; !errors.Is(err, ErrRuntimeCatalogIntegrity) {
+		t.Fatalf("aliased shared waiter error = %v, want ErrRuntimeCatalogIntegrity", err)
+	}
+}
+
+func TestRuntimeCatalogCallerCancellationDoesNotCancelSharedCompile(t *testing.T) {
+	artifact := compileRuntimeFixture(t)
+	meta := runtimeArtifactMeta(artifact)
+	started := make(chan struct{})
+	release := make(chan struct{})
+	store := &runtimeStoreStub{
+		meta: meta, bundle: artifact.Bundle,
+		bundleStarted: started, bundleRelease: release,
+	}
+	catalog := newRuntimeCatalogForTest(t, runtimeStaticRegistry(t), store, allowDynamicForTest)
+
+	firstResult := make(chan error, 1)
+	go func() {
+		_, err := catalog.loadCompiled(context.Background(), meta)
+		firstResult <- err
+	}()
+	<-started
+
+	canceled, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := catalog.loadCompiled(canceled, meta); !errors.Is(err, context.Canceled) {
+		t.Fatalf("canceled waiter error = %v, want context.Canceled", err)
+	}
+	close(release)
+	if err := <-firstResult; err != nil {
+		t.Fatalf("shared compile was canceled by waiter: %v", err)
+	}
+	store.mu.Lock()
+	bundleCalls := store.bundleCalls
+	store.mu.Unlock()
+	if bundleCalls != 1 {
+		t.Fatalf("bundle calls = %d, want shared work to continue once", bundleCalls)
+	}
+}
+
+func TestRuntimeCatalogHooksUseBoundedResolveAndCacheOutcomes(t *testing.T) {
+	artifact := compileRuntimeFixture(t)
+	store := &runtimeStoreStub{
+		activation: RuntimeActivation{
+			Exists: true, Status: RuntimeActivationActive, Version: artifact.Meta.Version, Revision: 1,
+		},
+		meta: runtimeArtifactMeta(artifact), bundle: artifact.Bundle,
+	}
+	var resolveLabels, cacheLabels []string
+	var gaugeEntries, gaugeBytes int
+	catalog, err := NewRuntimeCatalog(runtimeStaticRegistry(t), store, RuntimeCatalogConfig{
+		MaxCacheEntries: 4, MaxCacheBytes: 4 << 20, CompileTimeout: time.Second,
+		AuthorizeDynamic: allowDynamicForTest,
+		Hooks: RuntimeCatalogHooks{
+			OnResolve: func(source RuntimeSource, result string) {
+				resolveLabels = append(resolveLabels, string(source)+":"+result)
+			},
+			OnCache:     func(result string) { cacheLabels = append(cacheLabels, result) },
+			OnCacheSize: func(entries, bytes int) { gaugeEntries, gaugeBytes = entries, bytes },
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 2; i++ {
+		if _, err := catalog.Render(context.Background(), dynamicDefaultRequest()); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if !reflect.DeepEqual(resolveLabels, []string{"dynamic:ok", "dynamic:ok"}) {
+		t.Fatalf("resolve labels = %v", resolveLabels)
+	}
+	if !reflect.DeepEqual(cacheLabels, []string{"miss", "hit"}) {
+		t.Fatalf("cache labels = %v", cacheLabels)
+	}
+	if gaugeEntries != 1 || gaugeBytes != len(artifact.Bundle) {
+		t.Fatalf("cache gauges = %d/%d, want 1/%d", gaugeEntries, gaugeBytes, len(artifact.Bundle))
+	}
+}
+
+func TestRuntimeCatalogDynamicMetadataFallbackAndActionContext(t *testing.T) {
+	artifact := compileRuntimeFixture(t)
+	artifact.Meta.interactions = map[ViewKey]InteractionReport{
+		"main": {Actions: []DeclaredAction{{Type: "Action.Submit", ID: "submit"}}},
+	}
+	store := &runtimeStoreStub{
+		activation: RuntimeActivation{
+			Exists: true, Status: RuntimeActivationActive, Version: artifact.Meta.Version, Revision: 1,
+		},
+		meta: runtimeArtifactMeta(artifact), bundle: artifact.Bundle,
+	}
+	catalog := newRuntimeCatalogForTest(t, runtimeStaticRegistry(t), store, allowDynamicForTest)
+	catalog.compile = func(context.Context, Bundle, CompileLimits) (*CompiledArtifact, error) {
+		return artifact, nil
+	}
+	access := dynamicDefaultRequest().Access
+	meta, err := catalog.MetaDefault(context.Background(), CatalogDefaultRequest{Access: access, ID: artifact.Meta.ID})
+	if err != nil || meta.Version != artifact.Meta.Version {
+		t.Fatalf("MetaDefault meta=%+v err=%v", meta, err)
+	}
+	fallback, err := catalog.FallbackText(context.Background(), CatalogFallbackRequest{
+		Access: access, ID: artifact.Meta.ID, Version: artifact.Meta.Version,
+		State: "shown", Fields: json.RawMessage(`{"title":"hello","groups":[{"items":["a"]}]}`), Lang: "en-US",
+	})
+	if err != nil || fallback == "" {
+		t.Fatalf("FallbackText fallback=%q err=%v", fallback, err)
+	}
+	action, err := catalog.ActionContext(context.Background(), CatalogActionRequest{
+		CatalogExactRequest: CatalogExactRequest{Access: access, ID: artifact.Meta.ID, Version: artifact.Meta.Version},
+		ActionID:            "submit",
+	})
+	if err != nil || action.View != "main" || action.Meta.Version != artifact.Meta.Version {
+		t.Fatalf("ActionContext action=%+v err=%v", action, err)
+	}
+}
+
+func TestRuntimeCatalogResultLabelsAreBounded(t *testing.T) {
+	tests := []struct {
+		err  error
+		want string
+	}{
+		{nil, "ok"},
+		{ErrTemplateUnknown, "unknown"},
+		{ErrRuntimeCatalogDisabled, "disabled"},
+		{ErrRuntimeCatalogNewSendDisabled, "disabled"},
+		{ErrRuntimeCatalogBlocked, "blocked"},
+		{ErrRuntimeCatalogNotAuthorized, "unauthorized"},
+		{ErrRuntimeCatalogIntegrity, "integrity"},
+		{ErrRuntimeCatalogUnavailable, "unavailable"},
+		{context.DeadlineExceeded, "unavailable"},
+		{errors.New("other"), "error"},
+	}
+	for _, test := range tests {
+		if got := runtimeCatalogResult(test.err); got != test.want {
+			t.Errorf("runtimeCatalogResult(%v)=%q, want %q", test.err, got, test.want)
+		}
+	}
+}
+
+func TestDefaultCatalogFallsBackToCurrentRegistryAndHonorsExplicitInstall(t *testing.T) {
+	previousRegistry := DefaultRegistry()
+	SetDefaultCatalog(nil)
+	registry := runtimeStaticRegistry(t)
+	SetDefaultRegistry(registry)
+	t.Cleanup(func() {
+		SetDefaultCatalog(nil)
+		SetDefaultRegistry(previousRegistry)
+	})
+
+	fallback := DefaultCatalog()
+	if fallback == nil {
+		t.Fatal("DefaultCatalog did not adapt the current Registry")
+	}
+	explicit, err := NewStaticCatalog(registry)
+	if err != nil {
+		t.Fatal(err)
+	}
+	SetDefaultCatalog(explicit)
+	if DefaultCatalog() != explicit {
+		t.Fatal("DefaultCatalog did not return the explicit process catalog")
+	}
+}
+
+func TestActionViewFromMetaRejectsUnknownAndAmbiguousActions(t *testing.T) {
+	meta := TemplateMeta{ID: "test.actions", Version: "1.0.0", interactions: map[ViewKey]InteractionReport{
+		"a": {Actions: []DeclaredAction{{Type: "Action.Submit", ID: "submit"}}},
+		"b": {Actions: []DeclaredAction{{Type: "Action.Submit", ID: "submit"}}},
+	}}
+	if _, err := actionViewFromMeta(meta, "missing"); !errors.Is(err, ErrActionUnknown) {
+		t.Fatalf("missing action error=%v, want ErrActionUnknown", err)
+	}
+	if _, err := actionViewFromMeta(meta, "submit"); !errors.Is(err, ErrActionUnknown) {
+		t.Fatalf("ambiguous action error=%v, want ErrActionUnknown", err)
+	}
+}
+
+func runtimeStaticRegistry(t *testing.T) *Registry {
+	t.Helper()
+	registry := NewRegistry()
+	registry.RegisterJSON(jsonCardTestData, "testdata/test.runtime-parity@1.0.0")
+	registry.SetDefault("test.runtime-parity", "1.0.0")
+	registry.Freeze()
+	return registry
+}
+
+func compileRuntimeFixture(t *testing.T) *CompiledArtifact {
+	t.Helper()
+	artifact, err := CompileJSONArtifact(context.Background(), validJSONArtifactBundle(), DefaultCompileLimits())
+	if err != nil {
+		t.Fatalf("CompileJSONArtifact fixture: %v", err)
+	}
+	return artifact
+}
+
+func runtimeArtifactMeta(artifact *CompiledArtifact) RuntimeArtifactMeta {
+	return RuntimeArtifactMeta{
+		ID: artifact.Meta.ID, Version: artifact.Meta.Version, Source: RuntimeSourceDynamic,
+		Engine: artifact.Engine, Hash: artifact.Hash, Owner: artifact.Owner,
+		Visibility: artifact.Visibility, Protocol: artifact.Meta.Protocol,
+		ContractVersion: artifact.ContractVersion,
+	}
+}
+
+func newRuntimeCatalogForTest(
+	t *testing.T,
+	registry *Registry,
+	store RuntimeArtifactStore,
+	authorize RuntimeDynamicAuthorizeFunc,
+) *RuntimeCatalog {
+	t.Helper()
+	catalog, err := NewRuntimeCatalog(registry, store, RuntimeCatalogConfig{
+		MaxCacheEntries:  4,
+		MaxCacheBytes:    4 << 20,
+		CompileTimeout:   time.Second,
+		AuthorizeDynamic: authorize,
+	})
+	if err != nil {
+		t.Fatalf("NewRuntimeCatalog: %v", err)
+	}
+	return catalog
+}
+
+func staticDefaultRequest() CatalogRenderRequest {
+	return CatalogRenderRequest{
+		Access: CatalogAccess{Purpose: CatalogPurposeNewSend, Principal: CatalogPrincipal{
+			Kind: CatalogPrincipalSystem, ID: "test-producer", SpaceID: "space-1",
+		}},
+		ID: "test.runtime-parity", State: "shown",
+		Fields: json.RawMessage(`{"title":"parity"}`),
+		Env:    BuildEnv{Lang: "en-US", SpaceID: "space-1"},
+	}
+}
+
+func dynamicDefaultRequest() CatalogRenderRequest {
+	return CatalogRenderRequest{
+		Access: CatalogAccess{Purpose: CatalogPurposeNewSend, Principal: CatalogPrincipal{
+			Kind: CatalogPrincipalSystem, ID: "test-producer", SpaceID: "space-1",
+		}},
+		ID: "test.runtime-card", State: "shown",
+		Fields: json.RawMessage(`{"title":"hello","groups":[{"items":["a"]}]}`),
+		Env:    BuildEnv{Lang: "en-US", SpaceID: "space-1"},
+	}
+}
+
+func allowDynamicForTest(context.Context, CatalogAccess, RuntimeArtifactMeta) error { return nil }
+
+type runtimeStoreStub struct {
+	mu              sync.Mutex
+	bundleStartOnce sync.Once
+
+	activation    RuntimeActivation
+	activationErr error
+	meta          RuntimeArtifactMeta
+	metaErr       error
+	bundle        CanonicalBundle
+	bundleErr     error
+	bundleStarted chan struct{}
+	bundleRelease <-chan struct{}
+
+	activationCalls int
+	metaCalls       int
+	bundleCalls     int
+}
+
+func (s *runtimeStoreStub) LoadActivation(context.Context, ID) (RuntimeActivation, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.activationCalls++
+	return s.activation, s.activationErr
+}
+
+func (s *runtimeStoreStub) LoadArtifactMeta(context.Context, ID, string) (RuntimeArtifactMeta, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.metaCalls++
+	return s.meta, s.metaErr
+}
+
+func (s *runtimeStoreStub) LoadArtifactBundle(ctx context.Context, _ ID, _, _ string) (CanonicalBundle, error) {
+	s.mu.Lock()
+	s.bundleCalls++
+	bundle := append(CanonicalBundle(nil), s.bundle...)
+	err := s.bundleErr
+	started := s.bundleStarted
+	release := s.bundleRelease
+	s.mu.Unlock()
+	if started != nil {
+		s.bundleStartOnce.Do(func() { close(started) })
+	}
+	if release != nil {
+		select {
+		case <-release:
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+	return bundle, err
+}

--- a/pkg/cardtmpl/updater.go
+++ b/pkg/cardtmpl/updater.go
@@ -38,15 +38,15 @@ type CardUpdater interface {
 }
 
 type updater struct {
-	registry *Registry
-	mutator  mutationGateway
+	catalog Catalog
+	mutator mutationGateway
 }
 
-func NewCardUpdater(registry *Registry, mutator mutationGateway) (CardUpdater, error) {
-	if registry == nil || mutator == nil {
+func NewCardUpdater(catalog Catalog, mutator mutationGateway) (CardUpdater, error) {
+	if catalog == nil || mutator == nil {
 		return nil, errors.New("cardtmpl: updater dependencies are required")
 	}
-	return &updater{registry: registry, mutator: mutator}, nil
+	return &updater{catalog: catalog, mutator: mutator}, nil
 }
 
 func (u *updater) ReplaceView(ctx context.Context, target UpdateTarget, id ID, version string,
@@ -57,7 +57,10 @@ func (u *updater) ReplaceView(ctx context.Context, target UpdateTarget, id ID, v
 	if id == "" || version == "" || env.SpaceID != target.Target.SpaceID {
 		return ErrUpdateInvalid
 	}
-	if _, err := u.registry.Lookup(id, version); err != nil {
+	meta, err := u.catalog.MetaExact(ctx, CatalogExactRequest{
+		Access: updaterCatalogAccess(target), ID: id, Version: version,
+	})
+	if err != nil {
 		return err
 	}
 	defer func() {
@@ -65,9 +68,12 @@ func (u *updater) ReplaceView(ctx context.Context, target UpdateTarget, id ID, v
 		if err != nil {
 			result = "error"
 		}
-		recordUpdate(id, version, result)
+		recordUpdate(meta.ID, meta.Version, result)
 	}()
-	document, profile, renderProfile, err := u.registry.RenderCardWithProfiles(ctx, id, version, state, fields, env)
+	document, profile, renderProfile, err := RenderCatalogCardWithProfiles(ctx, u.catalog, CatalogRenderRequest{
+		Access: updaterCatalogAccess(target), ID: id, Version: version,
+		State: state, Fields: fields, Env: env,
+	})
 	if err != nil {
 		return err
 	}
@@ -107,8 +113,14 @@ func (u *updater) Append(ctx context.Context, target UpdateTarget, element json.
 		return carddispatch.ErrCardMutationConflict
 	}
 	if template, ok := cardmsg.CardTemplateContext(snapshot.Envelope); ok {
-		if _, lookupErr := u.registry.Lookup(ID(template.ID), template.Version); lookupErr == nil {
-			metricID, metricVersion = ID(template.ID), template.Version
+		meta, lookupErr := u.catalog.MetaExact(ctx, CatalogExactRequest{
+			Access: updaterCatalogAccess(target), ID: ID(template.ID), Version: template.Version,
+		})
+		if lookupErr != nil && !errors.Is(lookupErr, ErrTemplateUnknown) {
+			return lookupErr
+		}
+		if lookupErr == nil {
+			metricID, metricVersion = meta.ID, meta.Version
 		}
 	}
 	decoder := json.NewDecoder(bytes.NewReader(snapshot.Envelope))
@@ -138,6 +150,15 @@ func (u *updater) Append(ctx context.Context, target UpdateTarget, element json.
 	}
 	_, err = u.mutator.Mutate(ctx, mutationRequest(target, normalized))
 	return err
+}
+
+func updaterCatalogAccess(target UpdateTarget) CatalogAccess {
+	return CatalogAccess{
+		Purpose: CatalogPurposeHistoricalEdit,
+		Principal: CatalogPrincipal{
+			Kind: CatalogPrincipalInternalProducer, ID: target.SenderUID, SpaceID: target.Target.SpaceID,
+		},
+	}
 }
 
 func validateUpdateTarget(ctx context.Context, target UpdateTarget) error {

--- a/pkg/cardtmpl/updater_test.go
+++ b/pkg/cardtmpl/updater_test.go
@@ -34,7 +34,7 @@ func TestCardUpdaterReplaceViewRendersV3AndPreservesMessageIdentity(t *testing.T
 	r.SetDefault(docsaccessrequest.TemplateID, docsaccessrequest.TemplateVersionV3)
 	r.Freeze()
 	gateway := &captureMutationGateway{result: carddispatch.CardMutationResult{Applied: true}}
-	updater, err := cardtmpl.NewCardUpdater(r, gateway)
+	updater, err := cardtmpl.NewCardUpdater(staticCatalog(t, r), gateway)
 	if err != nil {
 		t.Fatalf("NewCardUpdater: %v", err)
 	}
@@ -80,7 +80,11 @@ func TestCardUpdaterAppendUsesEffectiveFrameAndValidatesWholeCard(t *testing.T) 
 		snapshot: carddispatch.CardMutationSnapshot{Envelope: raw, CardSeq: 4},
 		result:   carddispatch.CardMutationResult{Applied: true},
 	}
-	updater, err := cardtmpl.NewCardUpdater(cardtmpl.NewRegistry(), gateway)
+	r := cardtmpl.NewRegistry()
+	r.Register(docsaccessrequest.NewV3(), docsaccessrequest.Assets, docsaccessrequest.HandoffRootV3)
+	r.SetDefault(docsaccessrequest.TemplateID, docsaccessrequest.TemplateVersionV3)
+	r.Freeze()
+	updater, err := cardtmpl.NewCardUpdater(staticCatalog(t, r), gateway)
 	if err != nil {
 		t.Fatalf("NewCardUpdater: %v", err)
 	}
@@ -121,7 +125,7 @@ func TestCardUpdaterAppendRejectsNonContiguousCardSequence(t *testing.T) {
 		snapshot: carddispatch.CardMutationSnapshot{Envelope: raw, CardSeq: 4},
 		result:   carddispatch.CardMutationResult{Applied: true},
 	}
-	updater, err := cardtmpl.NewCardUpdater(cardtmpl.NewRegistry(), gateway)
+	updater, err := cardtmpl.NewCardUpdater(staticCatalog(t, cardtmpl.NewRegistry()), gateway)
 	if err != nil {
 		t.Fatalf("NewCardUpdater: %v", err)
 	}
@@ -141,9 +145,9 @@ func TestCardUpdaterAppendRejectsNonContiguousCardSequence(t *testing.T) {
 func TestCardUpdaterFailsClosedOnInvalidInputsAndDependencies(t *testing.T) {
 	gateway := &captureMutationGateway{}
 	if _, err := cardtmpl.NewCardUpdater(nil, gateway); err == nil {
-		t.Fatal("NewCardUpdater(nil registry) error = nil")
+		t.Fatal("NewCardUpdater(nil catalog) error = nil")
 	}
-	if _, err := cardtmpl.NewCardUpdater(cardtmpl.NewRegistry(), nil); err == nil {
+	if _, err := cardtmpl.NewCardUpdater(staticCatalog(t, cardtmpl.NewRegistry()), nil); err == nil {
 		t.Fatal("NewCardUpdater(nil mutator) error = nil")
 	}
 
@@ -151,7 +155,7 @@ func TestCardUpdaterFailsClosedOnInvalidInputsAndDependencies(t *testing.T) {
 	r.Register(docsaccessrequest.NewV3(), docsaccessrequest.Assets, docsaccessrequest.HandoffRootV3)
 	r.SetDefault(docsaccessrequest.TemplateID, docsaccessrequest.TemplateVersionV3)
 	r.Freeze()
-	updater, err := cardtmpl.NewCardUpdater(r, gateway)
+	updater, err := cardtmpl.NewCardUpdater(staticCatalog(t, r), gateway)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -189,6 +193,67 @@ func TestCardUpdaterFailsClosedOnInvalidInputsAndDependencies(t *testing.T) {
 	if err := updater.Append(context.Background(), target, json.RawMessage(`{"type":"TextBlock","text":"after"}`)); !errors.Is(err, cardtmpl.ErrUpdateInvalid) {
 		t.Fatalf("Append(invalid effective frame) = %v, want %v", err, cardtmpl.ErrUpdateInvalid)
 	}
+}
+
+func TestCardUpdaterAppendRejectsBlockedStoredTemplate(t *testing.T) {
+	original := map[string]any{
+		"type": 17, "card_version": cardmsg.CardVersion, "profile": cardmsg.ProfileV1,
+		"space_id": "space-1", "card_seq": 4,
+		"card": map[string]any{
+			"type": "AdaptiveCard", "version": cardmsg.CardVersion,
+			"body": []any{map[string]any{"type": "TextBlock", "text": "before"}},
+			"metadata": map[string]any{"octo": map[string]any{
+				"protocol": cardtmpl.Protocol, "template": map[string]any{"id": "test.dynamic", "version": "1.0.0"},
+			}},
+		},
+	}
+	raw, _ := json.Marshal(original)
+	gateway := &captureMutationGateway{
+		snapshot: carddispatch.CardMutationSnapshot{Envelope: raw, CardSeq: 4},
+		result:   carddispatch.CardMutationResult{Applied: true},
+	}
+	updater, err := cardtmpl.NewCardUpdater(blockedCatalog{}, gateway)
+	if err != nil {
+		t.Fatal(err)
+	}
+	target := cardtmpl.UpdateTarget{
+		Target:    carddispatch.Target{SpaceID: "space-1", ChannelID: "user-b", ChannelType: 1},
+		SenderUID: "notification", MessageID: "1001", CardSeq: 5,
+	}
+	err = updater.Append(context.Background(), target, json.RawMessage(`{"type":"TextBlock","text":"after"}`))
+	if !errors.Is(err, cardtmpl.ErrRuntimeCatalogBlocked) {
+		t.Fatalf("Append(blocked template) error = %v, want ErrRuntimeCatalogBlocked", err)
+	}
+	if len(gateway.requests) != 0 {
+		t.Fatalf("blocked append wrote mutations: %+v", gateway.requests)
+	}
+}
+
+func staticCatalog(t *testing.T, registry *cardtmpl.Registry) cardtmpl.Catalog {
+	t.Helper()
+	catalog, err := cardtmpl.NewStaticCatalog(registry)
+	if err != nil {
+		t.Fatalf("NewStaticCatalog: %v", err)
+	}
+	return catalog
+}
+
+type blockedCatalog struct{}
+
+func (blockedCatalog) Render(context.Context, cardtmpl.CatalogRenderRequest) (map[string]any, error) {
+	return nil, cardtmpl.ErrRuntimeCatalogBlocked
+}
+func (blockedCatalog) MetaExact(context.Context, cardtmpl.CatalogExactRequest) (cardtmpl.TemplateMeta, error) {
+	return cardtmpl.TemplateMeta{}, cardtmpl.ErrRuntimeCatalogBlocked
+}
+func (blockedCatalog) MetaDefault(context.Context, cardtmpl.CatalogDefaultRequest) (cardtmpl.TemplateMeta, error) {
+	return cardtmpl.TemplateMeta{}, cardtmpl.ErrRuntimeCatalogBlocked
+}
+func (blockedCatalog) FallbackText(context.Context, cardtmpl.CatalogFallbackRequest) (string, error) {
+	return "", cardtmpl.ErrRuntimeCatalogBlocked
+}
+func (blockedCatalog) ActionContext(context.Context, cardtmpl.CatalogActionRequest) (cardtmpl.CatalogActionContext, error) {
+	return cardtmpl.CatalogActionContext{}, cardtmpl.ErrRuntimeCatalogBlocked
 }
 
 func assertUpdateEnvelope(t *testing.T, raw string, seq int64, profile, renderProfile, version string) {

--- a/pkg/errcode/card_template_catalog.go
+++ b/pkg/errcode/card_template_catalog.go
@@ -34,4 +34,20 @@ var (
 		DefaultMessage: "The card template catalog is temporarily unavailable.",
 		Internal:       true,
 	})
+	ErrCardTemplateCatalogControlDisabled = register(codes.Code{
+		ID:             "err.server.card_template_catalog.control_disabled",
+		HTTPStatus:     http.StatusServiceUnavailable,
+		DefaultMessage: "Card template activation is disabled.",
+		Internal:       true,
+	})
+	ErrCardTemplateCatalogStateConflict = register(codes.Code{
+		ID:             "err.server.card_template_catalog.state_conflict",
+		HTTPStatus:     http.StatusConflict,
+		DefaultMessage: "The card template state changed; refresh and retry.",
+	})
+	ErrCardTemplateCatalogBlocked = register(codes.Code{
+		ID:             "err.server.card_template_catalog.blocked",
+		HTTPStatus:     http.StatusConflict,
+		DefaultMessage: "The card template version is blocked.",
+	})
 )

--- a/pkg/i18n/locales/active.zh-CN.toml
+++ b/pkg/i18n/locales/active.zh-CN.toml
@@ -1306,3 +1306,12 @@ other = "卡片模板版本与已发布的不可变制品冲突。"
 
 ["err.server.card_template_catalog.unavailable"]
 other = "卡片模板目录暂时不可用。"
+
+["err.server.card_template_catalog.control_disabled"]
+other = "卡片模板激活功能当前未启用。"
+
+["err.server.card_template_catalog.state_conflict"]
+other = "卡片模板状态已变化，请刷新后重试。"
+
+["err.server.card_template_catalog.blocked"]
+other = "该卡片模板版本已被阻断。"

--- a/tools/i18nmarkers/server/active.en-US.toml
+++ b/tools/i18nmarkers/server/active.en-US.toml
@@ -249,17 +249,26 @@ other = "Failed to update data."
 ["err.server.botfather.username_taken"]
 other = "The username is already taken."
 
+["err.server.card_template_catalog.blocked"]
+other = "The card template version is blocked."
+
 ["err.server.card_template_catalog.conflict"]
 other = "The card template version conflicts with an immutable artifact."
 
 ["err.server.card_template_catalog.content_too_large"]
 other = "The card template request is too large."
 
+["err.server.card_template_catalog.control_disabled"]
+other = "Card template activation is disabled."
+
 ["err.server.card_template_catalog.forbidden"]
 other = "Only a super admin can manage card templates."
 
 ["err.server.card_template_catalog.request_invalid"]
 other = "The card template bundle is invalid."
+
+["err.server.card_template_catalog.state_conflict"]
+other = "The card template state changed; refresh and retry."
 
 ["err.server.card_template_catalog.unavailable"]
 other = "The card template catalog is temporarily unavailable."


### PR DESCRIPTION
## Summary

Add the dark-launched runtime card-template catalog overlay on top of the
immutable publishing foundation merged through PR #674.
The server can now resolve frozen built-ins and persisted dynamic artifacts
through one read-only interface, manage audited activation state, and preserve
fail-closed behavior across replicas and restarts.

PR #674 squash-merged as `68e8134d`. This branch is now rebased onto that
`main` commit; the post-rebase head is `55f9bd32`. Full GitHub CI and
current-head re-review are required before merge.

The runtime control and dynamic new-send gates remain disabled by default, and
no production dynamic producer grant is installed. OpenClaw E1d/E1e companion
work and the joint cross-repository release gate remain separate and pending.

## Related Issue

Fixes #672

## Linked Spec

`.octospec/tasks/cardtmpl-runtime-catalog-overlay/brief.md`

## Changes

- Install one process-wide `RuntimeCatalog` before module construction, with
  exact/default resolution, authoritative block checks, and a bounded
  entry/byte LRU plus `singleflight` compilation.
- Add revision-CAS activate, explicit prior-active rollback, and one-way block
  with atomic fallback/disable and append-only audit state.
- Add authenticated, UID-rate-limited super-admin detail, audit, activate,
  rollback, and block endpoints with localized fail-closed errors.
- Move Bot template send/edit, notify rendering, `CardUpdater`, and message
  action-context reads onto the catalog interface while preserving static wire
  behavior and server-authored principal/Space context.
- Make startup reconciliation retry asynchronously on transient database
  failure, return `/v1/ready` 503 until catalog readiness is established, cap
  active targets at 128 with independent per-target deadlines, and preserve
  bounded read-only diagnostics.
- Preserve runtime-catalog error causes through notify preflight/render and
  fail closed on block/disable/auth/integrity/unavailable instead of converting
  a rejected card into a successful text fallback.
- Bound Bot manifest lookups, expose an active-target gauge, and add audit
  indexes for manager paging and prior-active proof queries.
- Reject open schema keyspaces through non-empty `patternProperties`, and add
  migration, multi-replica, restart, DB-outage, hot-cache block, and race tests.

## Testing

Post-rebase local verification at `55f9bd32`:

- [x] Unit and integration tests added/updated
- [x] Verified against local MySQL, Redis, and WuKongIM containers
- [x] `go test -count=1 ./pkg/cardtmpl/...`
- [x] `go test -count=1 ./modules/card_template_catalog/...`
- [x] Core coverage: `pkg/cardtmpl` 80.7%; `card_template_catalog` 81.2%
- [x] Full `modules/notify` and `modules/message` suites passed serially on a
      clean test database
- [x] Focused Bot catalog/send/edit suites passed; the full Bot package retains
      the unrelated mainline failure
      `TestBotGroupMemberRemove_ManagerTargetCaseVariantForbidden`
- [x] Targeted `-race` for cardtmpl/catalog, Bot template send/edit, notify,
      message action-context, carddispatch, and cardactiondispatch
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `golangci-lint run ./...` (`0 issues`)
- [x] `make i18n-extract-check`
- [x] `make i18n-lint`
- [x] `git diff --check origin/main...HEAD`

Coverage caveat: the core changed packages exceed 80%, but the three historical
consumer packages remain below 80% as whole packages. Their changed runtime
paths have focused and race coverage; the brief's literal all-changed-package
80% checkbox intentionally remains open.

## COMPREHENSION

1. **What does this change actually do to the load-bearing path?**

   It replaces direct runtime reads from the frozen Registry with a narrow
   catalog interface. Static exact reads remain in memory; default and dynamic
   reads consult authoritative MySQL state. Dynamic cache misses revalidate
   identity/hash and compile through the existing strict compiler. State
   changes use revision CAS and commit the pointer/block transition together
   with its audit row.

2. **What could break because of it (dependents + failure mode)?**

   Bot template send/edit, notify rendering, card mutation, and card-action
   context now depend on catalog wiring. A composition error, DB outage on a
   default/dynamic lookup, invalid active artifact, stale CAS, or blocked
   artifact must fail closed. The main operational risk is catalog
   unavailability rather than silent fallback or rendering unvalidated content.
   `/v1/ready` returns 503 while startup validation is pending or
   integrity-poisoned, so the replica is removed from normal traffic. Explicit
   static exact reads remain available during transient startup DB failure;
   proven integrity failure deliberately poisons all catalog resolution.

3. **How do you know it works (specific test/repro/trace)?**

   Real-MySQL tests exercise migration Up/Down, concurrent first activation,
   replica-local caches sharing DB truth, rollback, active block with fallback,
   disable, restart, and hot-cache rejection. Focused consumer tests prove
   unchanged static payload/provenance and server-authored access context.
   Targeted race tests plus build, vet, lint, i18n, and source guards are green.

Trusted producer provenance for distinguishing Bot from internal-producer
action context is explicitly a PR-C prerequisite; it is not inferred from the
current sender/template fields. Runtime control/new-send and production Bot
card gates remain off.

## Checklist

- [x] I have read `CONTRIBUTING.md`
- [x] PR description is in English
- [x] Added tests for my changes
- [x] Updated documentation and the runtime recovery runbook
- [x] Followed Conventional Commits
