### PR TITLE
feat(common): appconfig 新增 drive_on 展示开关

### DIFF
--- a/modules/common/api.go
+++ b/modules/common/api.go
@@ -394,6 +394,7 @@ func (cn *Common) appConfig(c *wkhttp.Context) {
 			StickerCustomEnabled:   cn.systemSettings.StickerCustomEnabled(),
 			StickerHandleRequired:  cn.systemSettings.StickerHandleRequired(),
 			DocsOn:                 cn.systemSettings.DocsEnabled(),
+			DriveOn:                cn.systemSettings.DriveEnabled(),
 			DmloopOn:               cn.systemSettings.DmloopEnabled(),
 			DmpersonalOn:           cn.systemSettings.DmpersonalEnabled(),
 			MessageReaction:        messageReaction,
@@ -443,6 +444,7 @@ func (cn *Common) appConfig(c *wkhttp.Context) {
 		StickerCustomEnabled:   cn.systemSettings.StickerCustomEnabled(),
 		StickerHandleRequired:  cn.systemSettings.StickerHandleRequired(),
 		DocsOn:                 cn.systemSettings.DocsEnabled(),
+		DriveOn:                cn.systemSettings.DriveEnabled(),
 		DmloopOn:               cn.systemSettings.DmloopEnabled(),
 		DmpersonalOn:           cn.systemSettings.DmpersonalEnabled(),
 		MessageReaction:        messageReaction,
@@ -822,6 +824,13 @@ type appConfigResp struct {
 	// 与 app_config.version 解耦的原因同 LocalLoginOff / SearchEnabled：运维切展示
 	// 策略后老客户端命中 version 短路分支也必须拿到最新值，故两个分支都下发。
 	DocsOn bool `json:"docs_on"`
+
+	// DriveOn 告知客户端是否展示网盘(drive)模块入口。值来源于 system_setting
+	// drive.enabled；默认 false —— 独立部署的 octo-drive 服务尚未上线，先隐藏入口，
+	// 上线后由管理台切 drive.enabled 灰度放开。只表达展示策略，服务端鉴权在 octo-drive
+	// 自身，本字段不承担任何鉴权。与 app_config.version 解耦的原因同 DocsOn：运维切展示
+	// 策略后老客户端命中 version 短路分支也必须拿到最新值，故两个分支都下发。
+	DriveOn bool `json:"drive_on"`
 
 	// dmloop.enabled / dmpersonal.enabled；默认 false —— loop(回路)与「我的/运行时」入口在
 	// 后端服务就绪前先隐藏,上线后由管理台切对应 system_setting 灰度放开。两者分开:

--- a/modules/common/api_test.go
+++ b/modules/common/api_test.go
@@ -958,6 +958,57 @@ func TestGetAppConfig_LoopFlags_OnVersionShortCircuit(t *testing.T) {
 	assert.Contains(t, w.Body.String(), `"dmpersonal_on":true`)
 }
 
+// appconfig 必须下发 drive_on：值来源于 system_setting drive.enabled。默认 false，
+// 客户端据此隐藏网盘(drive)模块入口（独立部署的 octo-drive 上线前）。
+func TestGetAppConfig_DriveOn_DefaultFalse(t *testing.T) {
+	s, ctx := testutil.NewTestServer()
+	f := New(ctx)
+	cleanAllTablesAndReloadSettings(t, ctx)
+	err := f.appConfigDB.insert(&appConfigModel{})
+	assert.NoError(t, err)
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/v1/common/appconfig", nil)
+	req.Header.Set("token", testutil.Token)
+	s.GetRoute().ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), `"drive_on":false`)
+}
+
+// system_setting drive.enabled=true → appconfig 下发 true，客户端展示网盘入口；
+// docs_on 保持默认关，证明两个模块开关互不派生。
+func TestGetAppConfig_DriveOn_TrueIndependentOfDocs(t *testing.T) {
+	s, ctx := testutil.NewTestServer()
+	f := New(ctx)
+	cleanAllTablesAndReloadSettings(t, ctx)
+	setModuleEnabledSetting(t, ctx, "drive", true)
+	err := f.appConfigDB.insert(&appConfigModel{})
+	assert.NoError(t, err)
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/v1/common/appconfig", nil)
+	req.Header.Set("token", testutil.Token)
+	s.GetRoute().ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), `"drive_on":true`)
+	assert.Contains(t, w.Body.String(), `"docs_on":false`)
+}
+
+// version 短路分支同样下发 drive_on：展示开关须与 app_config.version 解耦，避免 admin
+// 切换后老客户端命中版本短路而继续用旧值(同 docs_on)。
+func TestGetAppConfig_DriveOn_OnVersionShortCircuit(t *testing.T) {
+	s, ctx := testutil.NewTestServer()
+	f := New(ctx)
+	cleanAllTablesAndReloadSettings(t, ctx)
+	setModuleEnabledSetting(t, ctx, "drive", true)
+	err := f.appConfigDB.insert(&appConfigModel{})
+	assert.NoError(t, err)
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/v1/common/appconfig?version=99999999", nil)
+	req.Header.Set("token", testutil.Token)
+	s.GetRoute().ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), `"drive_on":true`)
+}
+
 // setStickerUploadLimitsSettings upserts the three sticker upload knobs
 // (size KB / max dim / allowed formats CSV) and reloads the shared snapshot.
 // Passing "" for any of them skips writing that row so tests can exercise the

--- a/modules/common/system_setting_schema.go
+++ b/modules/common/system_setting_schema.go
@@ -169,6 +169,12 @@ var systemSettingSchema = []settingDef{
 	{Category: "docs", Key: "enabled", Type: settingTypeBool, Description: "是否向客户端展示文档(docs)模块入口（octo-docs-backend 上线前默认关闭）",
 		Effective: func(s *SystemSettings) string { return boolToCanonical(s.DocsEnabled()) }},
 
+	// drive(网盘)模块展示开关。独立部署的 octo-drive 服务尚未上线，默认关闭；上线后由管理台
+	// 切 drive.enabled 灰度放量。仅表达展示策略，服务端鉴权在 octo-drive 自身。经 GET
+	// /v1/common/appconfig 的 drive_on 下发给客户端。
+	{Category: "drive", Key: "enabled", Type: settingTypeBool, Description: "是否向客户端展示网盘(drive)模块入口（octo-drive 上线前默认关闭）",
+		Effective: func(s *SystemSettings) string { return boolToCanonical(s.DriveEnabled()) }},
+
 	// Loop(回路)模块展示开关。loop 依赖后端服务 + fleet 代理 + daemon runtime 一整套,未就绪前
 	// 默认关闭;feature 分支合入 main 也不暴露,上线后由管理台切 dmloop.enabled 灰度放量。仅表达
 	// 展示策略,不承担服务端鉴权(/fleet 鉴权在后端)。经 GET /v1/common/appconfig 的 dmloop_on 下发给客户端。

--- a/modules/common/system_settings.go
+++ b/modules/common/system_settings.go
@@ -880,6 +880,16 @@ func (s *SystemSettings) DocsEnabled() bool {
 	return s.getBool("docs", "enabled", false)
 }
 
+// DriveEnabled reports whether clients should surface the drive (网盘) module
+// entry (backed by the standalone octo-drive service). Display policy only —
+// it neither grants nor enforces any server-side authorization, which lives in
+// octo-drive itself. Default false so the entry stays hidden until octo-drive
+// is deployed and the admin flips drive.enabled for a controlled rollout.
+// Value source: system_setting drive.enabled (DB, hot-reloaded).
+func (s *SystemSettings) DriveEnabled() bool {
+	return s.getBool("drive", "enabled", false)
+}
+
 // DmloopEnabled reports whether the Loop(回路)module entry should be shown to
 // clients. Default false — the loop feature (backend service + fleet proxy +
 // daemon runtimes) stays hidden until ops flips dmloop.enabled after those deps

--- a/modules/common/system_settings_test.go
+++ b/modules/common/system_settings_test.go
@@ -766,3 +766,17 @@ func TestSystemSettings_DocsEnabled_DBTrueWins(t *testing.T) {
 
 	assert.True(t, s.DocsEnabled(), "DB true -> docs module shown")
 }
+
+func TestSystemSettings_DriveEnabled_DefaultsFalse(t *testing.T) {
+	s := newTestSystemSettings(t, nil)
+
+	assert.False(t, s.DriveEnabled(), "DB empty -> drive module hidden by default")
+}
+
+func TestSystemSettings_DriveEnabled_DBTrueWins(t *testing.T) {
+	s := newTestSystemSettings(t, nil)
+	require.NoError(t, s.db.upsert("drive", "enabled", "1", settingTypeBool, ""))
+	require.NoError(t, s.Reload())
+
+	assert.True(t, s.DriveEnabled(), "DB true -> drive module shown")
+}


### PR DESCRIPTION
## 概述

在 appconfig 下发接口新增 `drive_on` 展示开关，控制客户端是否展示网盘（drive）模块入口。跟随现有 `docs_on` / `dmloop_on` 的模块展示门模式 1:1 实现。

## 背景

drive（网盘）是一个独立部署的模块，其反向代理路由 / 后端服务在部署就绪前不可用。因此入口默认隐藏（fail-safe），由管理台按 `system_setting` 的 `drive.enabled` 灰度放开。本字段只表达展示策略，不承担服务端鉴权（鉴权在 drive 服务自身）。

## 改动

全部在 `modules/common/`：

- `system_settings.go`：新增 `DriveEnabled()`，读 `system_setting` 的 `drive.enabled`，默认 `false`
- `system_setting_schema.go`：注册 `{Category: "drive", Key: "enabled", Type: bool}` schema 项（含 `Effective`），使管理台可见可切
- `api.go`：appconfig 响应体新增 `DriveOn bool json:"drive_on"` 字段，两处赋值点（version 短路分支 + 完整分支）均赋 `DriveEnabled()`，与 `app_config.version` 解耦

## 测试

- `api_test.go`：3 个 appconfig 用例（默认下发 `false` / `drive.enabled=true` 后下发 `true` 且 `docs_on` 仍 `false` 验证解耦 / version 短路分支同样下发），复用现有 helper
- `system_settings_test.go`：2 个 `DriveEnabled` 用例（默认 false / DB 值优先）
- `go build ./...` + `go vet ./modules/common/` 通过；i18n gate 通过；集成测试由 CI 完整环境执行

## 影响

纯新增字段，向后兼容。默认 `false` 不改变任何现有客户端行为，直到管理台开启 `drive.enabled`。
