### PR TITLE
feat(common): appconfig adds docs_search_on display flag

### DIFF
--- a/modules/common/api.go
+++ b/modules/common/api.go
@@ -396,6 +396,7 @@ func (cn *Common) appConfig(c *wkhttp.Context) {
 			StickerCustomEnabled:   cn.systemSettings.StickerCustomEnabled(),
 			StickerHandleRequired:  cn.systemSettings.StickerHandleRequired(),
 			DocsOn:                 cn.systemSettings.DocsEnabled(),
+			DocsSearchOn:           cn.systemSettings.DocsSearchEnabled(),
 			DriveOn:                cn.systemSettings.DriveEnabled(),
 			DmloopOn:               cn.systemSettings.DmloopEnabled(),
 			DmpersonalOn:           cn.systemSettings.DmpersonalEnabled(),
@@ -446,6 +447,7 @@ func (cn *Common) appConfig(c *wkhttp.Context) {
 		StickerCustomEnabled:   cn.systemSettings.StickerCustomEnabled(),
 		StickerHandleRequired:  cn.systemSettings.StickerHandleRequired(),
 		DocsOn:                 cn.systemSettings.DocsEnabled(),
+		DocsSearchOn:           cn.systemSettings.DocsSearchEnabled(),
 		DriveOn:                cn.systemSettings.DriveEnabled(),
 		DmloopOn:               cn.systemSettings.DmloopEnabled(),
 		DmpersonalOn:           cn.systemSettings.DmpersonalEnabled(),
@@ -826,6 +828,12 @@ type appConfigResp struct {
 	// 与 app_config.version 解耦的原因同 LocalLoginOff / SearchEnabled：运维切展示
 	// 策略后老客户端命中 version 短路分支也必须拿到最新值，故两个分支都下发。
 	DocsOn bool `json:"docs_on"`
+
+	// DocsSearchOn 告知客户端是否展示云文档全文搜索。值来源于 system_setting
+	// docs.search_enabled；默认 false —— 与 docs_on 解耦，搜索端点由 octo-docs-backend
+	// 独立提供，可晚于 docs 模块上线，上线+索引就绪后才放量。仅表达展示策略，鉴权
+	// 在 octo-docs-backend 自身，本字段不承担鉴权。与 app_config.version 解耦的原因同 DocsOn。
+	DocsSearchOn bool `json:"docs_search_on"`
 
 	// DriveOn 告知客户端是否展示网盘(drive)模块入口。值来源于 system_setting
 	// drive.enabled；默认 false —— 独立部署的 octo-drive 服务尚未上线，先隐藏入口，

--- a/modules/common/api_test.go
+++ b/modules/common/api_test.go
@@ -114,6 +114,22 @@ func setDocsEnabledSetting(t *testing.T, ctx *config.Context, enabled bool) {
 	require.NoError(t, EnsureSystemSettings(ctx).Reload())
 }
 
+// setDocsSearchEnabledSetting upserts system_setting docs.search_enabled and
+// reloads the shared snapshot. This is the appconfig-facing display toggle for
+// cloud-doc full-text search, decoupled from docs.enabled.
+func setDocsSearchEnabledSetting(t *testing.T, ctx *config.Context, enabled bool) {
+	t.Helper()
+	v := "0"
+	if enabled {
+		v = "1"
+	}
+	_, err := ctx.DB().InsertInto("system_setting").
+		Columns("category", "key_name", "value", "value_type").
+		Values("docs", "search_enabled", v, "bool").Exec()
+	require.NoError(t, err)
+	require.NoError(t, EnsureSystemSettings(ctx).Reload())
+}
+
 func TestAddVersion(t *testing.T) {
 	t.Skip("OCTO migration TODO: see https://github.com/Mininglamp-OSS/octo-server/issues/17")
 	s, ctx := testutil.NewTestServer()
@@ -872,7 +888,55 @@ func TestGetAppConfig_DocsOn_OnVersionShortCircuit(t *testing.T) {
 	assert.Contains(t, w.Body.String(), `"docs_on":true`)
 }
 
-// setModuleEnabledSetting upserts a `<category>.enabled` bool system_setting and
+// appconfig 必须下发 docs_search_on：值来源于 system_setting docs.search_enabled。
+// 默认 false，与 docs_on 解耦，客户端据此隐藏云文档搜索 tab（搜索端点就绪前）。
+func TestGetAppConfig_DocsSearchOn_DefaultFalse(t *testing.T) {
+	s, ctx := testutil.NewTestServer()
+	f := New(ctx)
+	cleanAllTablesAndReloadSettings(t, ctx)
+	err := f.appConfigDB.insert(&appConfigModel{})
+	assert.NoError(t, err)
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/v1/common/appconfig", nil)
+	req.Header.Set("token", testutil.Token)
+	s.GetRoute().ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), `"docs_search_on":false`)
+}
+
+// system_setting docs.search_enabled=true → appconfig 下发 true。与 docs.enabled 解耦：
+// 只开 docs.search_enabled 不开 docs.enabled 时，docs_search_on=true 而 docs_on=false。
+func TestGetAppConfig_DocsSearchOn_True_Independent(t *testing.T) {
+	s, ctx := testutil.NewTestServer()
+	f := New(ctx)
+	cleanAllTablesAndReloadSettings(t, ctx)
+	setDocsSearchEnabledSetting(t, ctx, true)
+	err := f.appConfigDB.insert(&appConfigModel{})
+	assert.NoError(t, err)
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/v1/common/appconfig", nil)
+	req.Header.Set("token", testutil.Token)
+	s.GetRoute().ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), `"docs_search_on":true`)
+	assert.Contains(t, w.Body.String(), `"docs_on":false`)
+}
+
+// version 短路分支同样要下发 docs_search_on（展示开关与 app_config.version 解耦）。
+func TestGetAppConfig_DocsSearchOn_OnVersionShortCircuit(t *testing.T) {
+	s, ctx := testutil.NewTestServer()
+	f := New(ctx)
+	cleanAllTablesAndReloadSettings(t, ctx)
+	setDocsSearchEnabledSetting(t, ctx, true)
+	err := f.appConfigDB.insert(&appConfigModel{})
+	assert.NoError(t, err)
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/v1/common/appconfig?version=99999999", nil)
+	req.Header.Set("token", testutil.Token)
+	s.GetRoute().ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), `"docs_search_on":true`)
+}
 // reloads the shared snapshot. Generic sibling of setDocsEnabledSetting for the
 // dmloop / dmpersonal launch flags. Call AFTER cleanAllTablesAndReloadSettings.
 func setModuleEnabledSetting(t *testing.T, ctx *config.Context, category string, enabled bool) {

--- a/modules/common/system_setting_schema.go
+++ b/modules/common/system_setting_schema.go
@@ -169,6 +169,13 @@ var systemSettingSchema = []settingDef{
 	{Category: "docs", Key: "enabled", Type: settingTypeBool, Description: "是否向客户端展示文档(docs)模块入口（octo-docs-backend 上线前默认关闭）",
 		Effective: func(s *SystemSettings) string { return boolToCanonical(s.DocsEnabled()) }},
 
+	// docs 全文搜索展示开关，与 docs.enabled 解耦：搜索端点由 octo-docs-backend #131
+	// 独立提供，可晚于 docs 模块本体上线。默认关闭；上线且索引灰度完成后由管理台
+	// 切 docs.search_enabled 放量。仅表达展示策略，不承担任何服务端鉴权（搜索鉴权在
+	// octo-docs-backend 自身）。经 GET /v1/common/appconfig 的 docs_search_on 下发给客户端。
+	{Category: "docs", Key: "search_enabled", Type: settingTypeBool, Description: "是否向客户端展示云文档全文搜索（与 docs.enabled 解耦；搜索端点上线+索引就绪前默认关闭）",
+		Effective: func(s *SystemSettings) string { return boolToCanonical(s.DocsSearchEnabled()) }},
+
 	// drive(网盘)模块展示开关。独立部署的 octo-drive 服务尚未上线，默认关闭；上线后由管理台
 	// 切 drive.enabled 灰度放量。仅表达展示策略，服务端鉴权在 octo-drive 自身。经 GET
 	// /v1/common/appconfig 的 drive_on 下发给客户端。

--- a/modules/common/system_settings.go
+++ b/modules/common/system_settings.go
@@ -880,6 +880,18 @@ func (s *SystemSettings) DocsEnabled() bool {
 	return s.getBool("docs", "enabled", false)
 }
 
+// DocsSearchEnabled reports whether clients should surface cloud-doc full-text
+// search. Decoupled from DocsEnabled: the search endpoint is provided
+// independently by octo-docs-backend and may land later than the docs module
+// itself. Display policy only — it neither grants nor enforces any server-side
+// authorization, which lives in octo-docs-backend. Default false so the tab
+// stays hidden until search is deployed and the index is populated and the
+// admin flips docs.search_enabled for a controlled rollout. Value source:
+// system_setting docs.search_enabled (DB, hot-reloaded).
+func (s *SystemSettings) DocsSearchEnabled() bool {
+	return s.getBool("docs", "search_enabled", false)
+}
+
 // DriveEnabled reports whether clients should surface the drive (网盘) module
 // entry (backed by the standalone octo-drive service). Display policy only —
 // it neither grants nor enforces any server-side authorization, which lives in


### PR DESCRIPTION
## Summary

Add a `docs.search_enabled` system setting and surface it as `docs_search_on` on `GET /v1/common/appconfig`, mirroring `drive_on` (#676). It lets the client gate the cloud-doc search tab on `docs_on && docs_search_on`, decoupled from the docs module so search can be rolled out independently.

## Related Issue

Closes #677

## Linked Spec

- octo-web #1087 (front-end cloud-docs search tab; gates on `docs_search_on`)
- octo-docs-backend #131 (search API + index producer)

## Changes

- `system_setting_schema.go`: add `{Category: "docs", Key: "search_enabled", Type: settingTypeBool}` with an `Effective` accessor, alongside the existing `docs.enabled`.
- `system_settings.go`: add `DocsSearchEnabled()` accessor (`getBool("docs", "search_enabled", false)`), documented as display-policy-only.
- `api.go`: add `DocsSearchOn bool json:"docs_search_on"` to `appConfigResp`; populate it from `DocsSearchEnabled()` on **both** the normal branch and the `app_config.version` short-circuit branch (same as `docs_on`, so an admin toggle reaches clients that hit the version cache).
- `api_test.go`: add `setDocsSearchEnabledSetting` helper + three tests (default false; enabled independently of `docs_on`; delivered on the version short-circuit branch).

## Testing

- `go build ./modules/common/` — pass.
- `go test ./modules/common/ -run 'DocsSearchOn|DocsOn'` — pass (against a MySQL + Redis fixture):
  - `TestGetAppConfig_DocsSearchOn_DefaultFalse`
  - `TestGetAppConfig_DocsSearchOn_True_Independent` (asserts `docs_search_on:true` while `docs_on:false`)
  - `TestGetAppConfig_DocsSearchOn_OnVersionShortCircuit`
  - existing `docs_on` tests still green.

## COMPREHENSION

**What is the blast radius if this flag is wrong?** Display-only: it can only show/hide the client's cloud-doc search tab. It grants no access — every search request is still authorized in octo-docs-backend (`listVisibleDocIdSet` in MySQL). A wrong `true` at worst shows a tab that 404s until the backend is live; a wrong `false` hides a working tab. No data exposure either way.

**Why decouple from `docs_on` instead of reusing it?** The search endpoint ships in a separate service (octo-docs-backend #131) on its own timeline. Reusing `docs_on` would surface the tab the moment the docs module is enabled, before search exists, producing permanent 404s. A dedicated flag lets search be dark-launched and enabled only once the index is populated.

**Why send it on both appconfig branches?** The `version` short-circuit path returns a cached snapshot; display flags are intentionally decoupled from `app_config.version` (same rationale as `docs_on`/`drive_on`) so an admin toggling the setting reaches old clients too. Sending on only one branch would make the flag silently stale for version-cached clients.

## Checklist

- [x] Conventional commit
- [x] Mirrors the established `drive_on`/#676 pattern
- [x] Default false (safe dark-launch)
- [x] Tests added and passing
- [x] No server-side authorization added or changed
- [x] No unrelated changes
