### PR TITLE
feat(cardtmpl): publish reasoning template v3 without inactive controls

### DIFF
--- a/.octospec/journal/shared/cardtmpl-reasoning-controls-hidden-successor.md
+++ b/.octospec/journal/shared/cardtmpl-reasoning-controls-hidden-successor.md
@@ -1,0 +1,112 @@
+---
+type: Journal
+title: "Journal: cardtmpl-reasoning-controls-hidden-successor"
+description: Publish ai.reasoning-process@0.3.0 without unsupported stop/retry controls, cut new Bot sends to V3, and preserve exact-version historical edits.
+tags: [cardtmpl, ai-reasoning-process, json-template, bot-api, wire-contract, trust-boundary, testing, rollback]
+timestamp: 2026-07-30T13:02:11+08:00
+# --- octospec extension fields ---
+task: cardtmpl-reasoning-controls-hidden-successor
+source: user
+---
+
+# Journal: cardtmpl-reasoning-controls-hidden-successor
+
+## What was done
+
+- Added immutable built-in `ai.reasoning-process@0.3.0` from the bounded server
+  `0.2.0` baseline. The V2 schema and four unchanged samples remain
+  byte-identical; the only product deltas are removal of `reasoning_stop` and
+  `reasoning_retry` Submit controls plus the obsolete retry invitation.
+- Preserved all five states and the existing wire mapping: reasoning,
+  answering, and error use `octo/v2`; completed and stopped use `octo/v1`.
+  Every state keeps the client-local `reasoning_toggle`; V3 has no server
+  action contract, inputs, or Submit actions.
+- Registered V1, V2, and V3 together, moved the Registry default and Bot
+  new-send advertisement to V3, and retained same-exact-version historical
+  edits for all three versions. V1/V2 new sends and cross-version edits remain
+  fail-closed.
+- Covered RuntimeCatalog static reconciliation for the new exact V3 identity,
+  including a real-MySQL dynamic-claim collision. Because V3 has no Submit,
+  it needs no `reasoning.control` RouteSpec; dynamic interactive artifacts
+  retain their existing route requirement.
+- Made Bot visual-profile ownership server-authoritative. Raw type-17 send and
+  edit callers omit `render_profile`; the Bot API writes `octo-chat/v1` after
+  validating the caller frame and before final dispatch/persistence. Registry
+  `template_ref` callers still omit the field because the server authors it
+  from the immutable manifest.
+
+## Review closure
+
+- Documented the inherited RuntimeCatalog rollback trap: persisting a built-in
+  V3 activation pointer makes a rollback image without V3 classify the active
+  static claim as sticky catalog integrity failure. The production runbook now
+  forbids routine static-to-static Activate/Rollback, requires active-pointer
+  compatibility proof before binary rollback, and reserves static fallback for
+  a separately reviewed future dynamic pilot.
+- Restored the composition-root comment for the unrelated
+  `docs.access-request` V2→V3 finalizer path at the correct registration site.
+- Added explicit regressions proving legacy reasoning stop/retry IDs do not
+  resolve from V3 at either stored-frame Submit lookup or catalog/message
+  `ActionContext` (`ErrActionUnknown` before enqueue), and Registry-mode callers
+  cannot inject the server-owned `render_profile` field.
+- Retargeted the V3 RouteSpec unit test to call `validateInteractiveTarget`
+  directly; the separate startup test is now accurately named as a static
+  registry compatibility test instead of claiming to cover a branch bypassed
+  by static resolution.
+- Mutation-tested the reported `octo/v1` registration gap. It is already
+  closed by `renderCore -> cardmsg.Validate` before the report-only branch:
+  even with a matching golden, an `Action.Submit` in the V1 result profile
+  fails compilation. A dedicated regression now preserves that guarantee;
+  no duplicate production walker was added.
+- Expanded the tracked card protocol with the Bot `templating` capability and
+  empty V3 `submit_actions`. The gitignored OpenClaw execution handoff was
+  separately re-signed to V3 and now explicitly forbids falling back to a local
+  raw-card/template version; it is operational context, not part of the PR.
+- Corrected the raw Bot render-profile interpretation after product review:
+  handler and real-service tests now prove omitted send/edit inputs produce a
+  server-authored `octo-chat/v1` effective frame rather than requiring producer
+  passthrough.
+
+## Verification
+
+- Focused suites passed serially for `pkg/cardtmpl/...`, `modules/bot_api/...`,
+  `modules/card_template_catalog/...`, and the composition-root V3 default.
+- The real-MySQL V3 static-claim/collision test executed and passed (not
+  skipped) against the local container environment.
+- Race suites passed for cardtmpl, catalog, cardmsg, card dispatch/action
+  dispatch, the focused Bot capability/send/edit/raw-render-profile paths, and
+  the V3 legacy-action message context rejection. The raw Bot edit lane also
+  passed under `-race` against real MySQL/Redis/WuKongIM without skipping.
+- `go build ./...`, `go vet ./...`, and `golangci-lint run ./...` passed with
+  zero lint issues. `git diff --check`, all V3 JSON parsing, V1/V2 zero-diff,
+  V2/V3 schema byte equality, and the forbidden-control scan passed.
+- Rechecked statement coverage: `pkg/cardtmpl` 80.8% and
+  `modules/card_template_catalog` 81.3%.
+
+## Structural learnings / gotchas
+
+- `profile` and `render_profile` are orthogonal. The former is the message
+  capability tier; the latter selects a client visual compatibility tier. A
+  card may legitimately remain `octo/v2` after removing every Submit action.
+- Exact Forge provenance (`renderProfile=octo-chat@1.2.0-rc.1`) belongs in the
+  immutable manifest; the message envelope carries only the stable
+  `render_profile=octo-chat/v1` compatibility key.
+- Bot callers never own the visual key. Raw-card frames receive the deployment
+  default in the Bot API; Registry frames receive the manifest compatibility
+  key. Adding an outer request field would create a competing authority.
+
+## Remaining rollout boundary
+
+- This is server-only. It does not implement OpenClaw selection/release,
+  active-run authority, stop/retry semantics, dynamic catalog grants, or joint
+  E2E.
+- Production Bot and dynamic new-send gates remain closed for the first
+  deployment. Operators must verify every replica reconciles V3, confirm no
+  activation row pins static V3, and audit any still-active V1/V2 messages
+  before enablement.
+- The server-owned raw Bot visual key affects every raw type-17 Bot send/edit,
+  not only reasoning cards. Rollout must verify target clients have the
+  `octo-chat/v1` host generation before enabling Bot card traffic.
+- A previous binary cannot resolve/edit V3. After the first V3 message exists,
+  rollback must retain a V3-capable binary or explicitly accept freezing its
+  last successful frame; immutable V3 must never be rewritten in place.

--- a/.octospec/log.md
+++ b/.octospec/log.md
@@ -4,6 +4,35 @@ Change history for this repo's `.octospec/`, following the
 [OKF](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md)
 change-log convention (§7). Newest first.
 
+## 2026-07-30 (cardtmpl-reasoning-controls-hidden-successor)
+
+- **Safe reasoning successor** — Added immutable
+  `ai.reasoning-process@0.3.0` from the bounded V2 contract, removing unsupported
+  stop/retry Submit controls while preserving five states, the local reasoning
+  toggle, and active/error=`octo/v2`, result=`octo/v1`.
+- **Version cutover** — Registry default and Bot new sends now select V3;
+  V1/V2/V3 remain available only for same-exact-version historical edits.
+  Runtime static reconciliation claims V3 and dynamic same-key collision stays
+  fail-closed.
+- **Visual-profile contract** — Raw Bot send/edit callers no longer need to
+  provide `render_profile`; the Bot API authors `octo-chat/v1` on effective
+  frames. Registry callers still cannot override the server-authored manifest
+  value. See
+  [journal](journal/shared/cardtmpl-reasoning-controls-hidden-successor.md) and
+  [brief](tasks/cardtmpl-reasoning-controls-hidden-successor/brief.md).
+- **Boundary** — No OpenClaw release, active-run stop/retry, dynamic grant, or
+  production gate enablement is included. V3-capable server rollback support is
+  required after the first V3 message is sent.
+- **Review closure** — The runtime-catalog runbook now forbids routine
+  static-to-static Activate/Rollback and requires active-pointer compatibility
+  before binary rollback, preventing an older image from treating a persisted
+  static V3 target as sticky global integrity failure. Protocol docs now include
+  the Bot templating/empty-submit capability; focused tests reject legacy V3
+  stop/retry IDs through the Submit and ActionContext gates and caller-owned
+  Registry `render_profile`. The reported V1 self-check gap was mutation-tested
+  and is already closed by registration-time `cardmsg.Validate`; a regression
+  now locks it, and the V3 RouteSpec test directly covers its intended branch.
+
 ## 2026-07-29 (cardtmpl-runtime-catalog-overlay, roadmap E3 PR-B server)
 
 - **Runtime overlay** — Added one composition-root RuntimeCatalog over frozen

--- a/.octospec/tasks/cardtmpl-reasoning-controls-hidden-successor/brief.md
+++ b/.octospec/tasks/cardtmpl-reasoning-controls-hidden-successor/brief.md
@@ -1,0 +1,338 @@
+---
+type: Task
+title: "Task: cardtmpl-reasoning-controls-hidden-successor"
+description: Publish ai.reasoning-process@0.3.0 without unsupported stop/retry controls while preserving the bounded server contract and historical exact-version edits.
+tags: [card, cardtmpl, ai-reasoning-process, json-template, bot-api, wire-contract, trust-boundary, test, testing, observability, rollback]
+timestamp: 2026-07-30T12:09:35+08:00
+# --- octospec extension fields ---
+slug: cardtmpl-reasoning-controls-hidden-successor
+upstream: "roadmap E1d/E3 safety follow-up; server PRs #667/#675; source attachment sha256 db694427d79f5eb4b760993dca46eccb8b0f48620d4e82c00136e2c02c69ebe4"
+source: user
+---
+
+# Task: cardtmpl-reasoning-controls-hidden-successor
+
+> One task = one `.octospec/tasks/<slug>/` directory. This brief is the spec for
+> the work. AI may draft it from existing code; a human confirms it.
+>
+> Finish status (2026-07-30): `/octospec-go`, `/octospec-check`, and local
+> `/octospec-finish` gates are complete. Focused, race, real-service integration,
+> build, vet, lint, immutability, and diff-hygiene gates passed locally; Draft PR
+> #681 records the evidence and rollout boundary. Deployment checks remain for
+> the later operational go/no-go and are not claimed by this PR.
+
+## Goal
+
+Publish a new immutable built-in JSON artifact, `ai.reasoning-process@0.3.0`, whose rendered cards no
+longer display the unsupported `reasoning_stop` or `reasoning_retry` `Action.Submit` controls. Preserve
+the client-side `reasoning_toggle` action, all five states, the bounded `0.2.0` data contract, and the
+existing state-to-view/wire mapping:
+
+| View | States | Wire profile | `0.3.0` actions |
+| --- | --- | --- | --- |
+| `active` | `reasoning`, `answering` | `octo/v2` | `reasoning_toggle` only |
+| `result` | `completed`, `stopped` | `octo/v1` | `reasoning_toggle` only |
+| `error` | `error` | `octo/v2` | `reasoning_toggle` only |
+
+Register `0.1.0`, `0.2.0`, and `0.3.0` together; make `0.3.0` the Registry default and the only Bot
+version advertised/accepted for new `template_ref` sends; retain exact-version edit compatibility for
+all three versions. `0.1.0` and `0.2.0` remain byte-for-byte frozen.
+
+This is a server-only safety successor. It does not implement OpenClaw run control, change OpenClaw
+fallback behavior, or open any production gate.
+
+## Background
+
+### Verified server baseline
+
+- PR #657 introduced frozen `ai.reasoning-process@0.1.0` with active/error Submit controls.
+- PR #667 introduced bounded `0.2.0`, registered both versions, moved Registry default and Bot new-send
+  advertisement to `0.2.0`, and retained `0.1.0` for historical edits. Its acceptance deliberately kept
+  templates/reports/samples/goldens visually identical to `0.1.0`, so the unsupported controls remained.
+- PR #675 installed the RuntimeCatalog overlay and static reconciliation, but PR-C grants and Bot dynamic
+  capability merging are not implemented. A dynamic publish cannot currently become an authorized Bot
+  new-send path. This task therefore adds a new built-in static version and requires a server release.
+- PR #675 also permits a validated static version to be persisted as an activation target. That pointer
+  outlives the image and overrides `SetDefault`; if it names V3, a rollback binary without V3 classifies
+  the orphan static active target as sticky catalog integrity failure. The V3 rollout therefore forbids
+  using Activate/Rollback for routine built-in version selection and requires an activation-pointer check
+  before binary rollback.
+- Current package registration is in `main.go:installCardTmplRegistry`; Bot new-send and historical-edit
+  policy is in `modules/bot_api/card_template_catalog.go`.
+- Current `0.1.0/0.2.0` mapping is active=`octo/v2`, result=`octo/v1`, error=`octo/v2`. The result profile
+  is load-bearing and remains unchanged.
+- The shared validator accepts an explicit `payload.render_profile`, but raw Bot send/edit previously did
+  not author one when the caller omitted it. That left the visual generation under producer control and
+  made omitted raw frames use Legacy rendering. Registry `template_ref` sends already author the field
+  from `renderProfileCompatibility`.
+- Production `OCTO_BOT_CARD_ENABLED` and runtime dynamic new-send remain closed until their separate
+  rollout/go-no-go. Merge is not authorization to enable either gate.
+
+### Source attachment audit
+
+The user supplied local artifact:
+
+```text
+.context/attachments/DaYAA4/ai.reasoning-process@0.2.0.handoff.zip
+sha256 db694427d79f5eb4b760993dca46eccb8b0f48620d4e82c00136e2c02c69ebe4
+```
+
+All 22 JSON documents parse successfully. Its templates, interaction reports, and goldens contain only
+`Action.ToggleVisibility`; there is no `reasoning_stop`, `reasoning_retry`, or template-level
+`Action.Submit`. The generic render-profile capability still lists `Action.Submit` as an allowed platform
+action; that is not evidence that this template uses it.
+
+The ZIP is a UX input, not a directly registrable server bundle:
+
+- it reuses the already published identity `0.2.0`, which cannot be overwritten;
+- its schema is the old unbounded contract and lacks the #667 string/array/aggregate limits;
+- its manifest lacks server-required `protocol`, `owner`, render-profile compatibility, and explicit
+  state declarations;
+- it changes result from the server contract’s `octo/v1` to `octo/v2`;
+- it emits one interaction report per state, while the server artifact format requires one report per
+  `octo/v2` view;
+- it also renames render component IDs/badge IDs, which is unrelated to hiding stop/retry;
+- its error sample removes “可以重试”, which is consistent with hiding the retry control.
+
+The server adaptation therefore uses repository `0.2.0` as the security/wire baseline and imports only
+the approved product deltas: remove stop/retry Submit controls and remove the retry invitation from the
+error sample/golden. The source ZIP is gitignored; all accepted deltas must be represented by reviewed,
+tracked `0.3.0` assets and tests.
+
+## Contract decisions
+
+### D1 — New immutable identity
+
+- Add `pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.3.0/`.
+- `id` remains `ai.reasoning-process`; `version` becomes `0.3.0`.
+- Keep `contractVersion=1.1.0`, because the producer data/schema contract remains the bounded #667
+  contract. The template version, not the data-contract version, carries the presentation/action change.
+- Keep `protocol=octo-card@1.0`, `adaptiveCardVersion=1.5`, pinned
+  `renderProfile=octo-chat@1.2.0-rc.1`, `renderProfileCompatibility=octo-chat/v1`, and `owner=ai`.
+- Omit `actionType` from `0.3.0`. With no `Action.Submit`, `TemplateMeta.ActionContract` must be nil rather
+  than advertising a callback contract that cannot be invoked.
+
+### D2 — Minimal UX delta
+
+- `active.template.json`: remove only `reasoning_stop`; retain `reasoning_toggle` and existing server
+  component IDs/layout.
+- `error.template.json`: remove only `reasoning_retry`; retain `reasoning_toggle` and existing server
+  component IDs/layout.
+- `result.template.json`: preserve the existing server template and `octo/v1` wire profile.
+- `samples/error.json`: remove the “可以重试” invitation; preserve the rest of the safe error copy.
+- Other samples remain byte-identical to server `0.2.0`.
+- Do not import the attachment’s component-ID renames, `renderProfile=latest`, result=`octo/v2`, per-state
+  report layout, or unbounded schema.
+
+### D3 — Reports, schema, and goldens
+
+- Copy the bounded `0.2.0` schema byte-for-byte, including `x-octo-constraints` aggregate limits.
+- Keep server report layout: `active.interaction.json` and `error.interaction.json` only. Each report lists
+  exactly one `Action.ToggleVisibility` (`reasoning_toggle`), zero inputs, and the existing two toggle
+  targets. Result stays `octo/v1` and has no report document; the shared `cardmsg.Validate` profile gate
+  rejects any `Action.Submit` in that view during registration before report-specific checks.
+- Regenerate/review all five goldens from the selected templates and samples. Reasoning/answering/error
+  goldens lose their Submit control; error also loses the retry invitation. Completed/stopped stay
+  canonical-equal to the server `0.2.0` output.
+- Full report-drift and golden self-check remain registration-time fail-close gates; no test-only bypass or
+  hand-maintained manifest `submit_actions` list is introduced.
+
+### D4 — Registry and Bot cutover
+
+- Add explicit `HandoffRootV3` / `TemplateVersionV3`; current-version aliases point to V3.
+- Register V1, V2, then V3 before `Registry.Freeze()`; set the default to V3.
+- Bot `AdvertisedSend` contains only `ai.reasoning-process@0.3.0`.
+- Bot `EditCompatible` contains V1, V2, and V3. Existing messages remain pinned to their stored exact
+  version; there is no cross-version edit or migration.
+- Capability for V3 reports empty `submit_actions` for active, result, and error. New sends using V1/V2
+  fail before dispatch; historical V1/V2 edits keep their current authorization and validation order.
+- RuntimeCatalog static reconciliation learns V3 from the frozen Registry; no dynamic artifact, grant,
+  activation row, or migration is added by this task.
+
+### D5 — Bot send render-profile contract
+
+- Keep `render_profile` inside the final/effective raw type-17 `payload`; do not add a conflicting outer
+  `/v1/bot/sendMessage` request field.
+- Raw Bot send and raw Bot edit callers omit the field. After validating the caller-authored frame, the
+  Bot API writes `render_profile="octo-chat/v1"` before final size validation and dispatch/persistence.
+  A caller that already sends the accepted same value remains compatible, but it is not the authority;
+  invalid explicit values still fail at the existing validation gate.
+- Keep Registry mode server-authoritative: a `template_ref` caller still cannot supply `render_profile`,
+  while rendered V3 messages receive `octo-chat/v1` from the manifest.
+- This adds no outer request field, new profile value, or capability-manifest field.
+
+## Load-bearing list
+
+- **L1 immutable artifact identity (`cardtmpl`, `wire-contract`)** — published `0.1.0/0.2.0` bytes, manifests,
+  samples, reports, templates, and goldens cannot change. Hiding controls requires a new exact version.
+- **Bounded JSON producer contract (`cardtmpl`, `trust-boundary`)** — all #667 max lengths, phase/action
+  bounds, aggregate action cap, template budgets, URL/cardmsg validation, and fail-close classification
+  remain intact; the attachment’s unbounded schema cannot replace them.
+- **Interaction truth (`cardtmpl`, `wire-contract`)** — rendered templates, reports, goldens,
+  `TemplateMeta.ActionContract`, and Bot `submit_actions` must agree that V3 has no Submit controls.
+- **View/state/profile compatibility (`wire-contract`)** — five states and active/error=`octo/v2`,
+  result=`octo/v1` remain stable. Hiding actions must not silently change view selection or wire profile.
+- **Registry multi-version/default (`cardtmpl`)** — three exact versions coexist; only V3 is the default;
+  `Freeze()` and global exact-key uniqueness remain unchanged.
+- **Bot capability/new-send/edit boundary (`bot-api`, `wire-contract`)** — only V3 is discoverable/sendable,
+  while historical V1/V2 exact edits remain possible without allowing cross-version overwrite or existence
+  probing.
+- **Visual-profile ownership (`bot-api`, `wire-contract`)** — callers do not choose `render_profile`.
+  Raw Bot send/edit use the deployment-owned stable key; Registry frames use the selected immutable
+  manifest. Both paths continue through final `cardmsg` validation and size gates.
+- **Runtime catalog reconciliation (`cardtmpl`, `testing`)** — V3 becomes a new static claim on startup;
+  a pre-existing dynamic claim for the same exact key must fail readiness rather than select by replica.
+- **Rollout/rollback (`rollback`)** — old binaries cannot edit a V3 card. Production gates stay closed until
+  all replicas and the compatible consumer are verified; rollback cannot rewrite V3 messages to V2/raw.
+  V3 is selected only by the image Registry default: normal operations must not persist a static V3
+  activation pointer that an older rollback image cannot validate.
+- **Regression evidence (`test`, `testing`)** — conformance, report drift, golden rendering, Bot policy,
+  historical edits, runtime startup/reconciliation, focused race, build, vet, and diff hygiene are required.
+
+## TDD implementation checkpoints
+
+1. **RED — immutable/version contract**: add tests expecting V1/V2/V3 registration, V3 default, old exact
+   versions still renderable, and frozen V1/V2 directories unchanged.
+2. **RED — control removal**: assert V3 active/error rendered output and reports contain no
+   `Action.Submit`, `reasoning_stop`, `reasoning_retry`, or retry invitation; toggle remains valid in all
+   five states; V3 `ActionContract` is nil.
+3. **GREEN — V3 artifact**: adapt the approved attachment delta onto the bounded V2 server baseline and
+   make all five self-check/golden fixtures pass.
+4. **RED→GREEN — Registry/composition**: add V3 constants, registration, and default without changing
+   freeze/order guarantees.
+5. **RED→GREEN — Bot policy**: advertise/send V3 only, retain V1/V2/V3 historical edits, assert empty
+   Submit capability and zero dispatch/side effects for old-version new sends or cross-version edits.
+6. **RED→GREEN — RuntimeCatalog**: cover V3 static reconciliation/exact lookup and prove no interactive
+   RouteSpec is required for a no-Submit V3 artifact; retain source-sensitive V2 static acceptance and
+   the dynamic interactive RouteSpec guard.
+7. **Verify**: focused tests first, then cardtmpl/Bot/catalog race and integration lanes, build/vet, and
+   `git diff --check`. No error-code/i18n change is expected.
+
+## Out of scope
+
+- Modifying any file under frozen `ai.reasoning-process@0.1.0` or `@0.2.0`.
+- OpenClaw source, selector, package/release, local Model B behavior, or deployment configuration.
+- Implementing `reasoning_stop`/`reasoning_retry`, active-run authority, event polling, queue ACK, or E1e.
+- PR-C grants, trusted producer provenance, B1/B2 discovery/export, dynamic Bot capability, or a dynamic
+  producer pilot.
+- Publishing this version through the dynamic catalog; without PR-C grants it would remain unusable for
+  Bot new-send.
+- Importing attachment-only component-ID/badge-ID renames, result=`octo/v2`, `renderProfile=latest`,
+  render-profile package files, or the unbounded source schema.
+- Removing `stopped` state. It remains part of the producer contract for cancellation initiated outside
+  these hidden card controls and for historical compatibility.
+- Adding routes, DB migrations, error codes, localized error responses, callback RouteSpecs, or client
+  rendering changes.
+- Adding `render_profile` as an outer Bot request field, introducing a new render-profile value, or changing
+  the `/v1/bot/card/profile` capability response.
+- Enabling production Bot/runtime gates or claiming OpenClaw E2E/release completion.
+- Redesigning PR #675's global startup integrity classification or removing its future dynamic-to-static
+  recovery mechanism. This PR documents and gates the safe V3 operational path; broader isolation of an
+  incompatible active target belongs in a separate reviewed RuntimeCatalog hardening change.
+- Retrofactively rewriting already delivered V1/V2 payloads; those cards remain immutable historical
+  messages and may still display their original controls.
+
+## Acceptance
+
+### A. Artifact identity and immutability
+
+- [x] A tracked `ai.reasoning-process@0.3.0` server handoff exists with exact `id/version`, explicit states,
+  pinned protocol/render-profile metadata, `owner=ai`, no `actionType`, and `contractVersion=1.1.0`.
+- [x] `git diff origin/main --` for both V1 and V2 handoff directories is empty; no formatting or generated
+  byte drift is accepted.
+- [x] V3 schema is byte-identical to bounded V2 schema and still rejects every string/array/aggregate
+  limit+1 case before template expansion while accepting exact-limit and worst-case valid fixtures.
+- [x] Reasoning/answering/completed/stopped samples remain byte-identical to V2; error differs only by
+  removing “可以重试”.
+
+### B. No unsupported controls
+
+- [x] V3 templates, reports, and goldens contain no `Action.Submit`, `reasoning_stop`, `reasoning_retry`,
+  `stop_reasoning`, `retry_reasoning`, or “可以重试”.
+- [x] Every V3 state renders exactly one `reasoning_toggle`; its targets resolve to `trace_panel` and
+  `collapsed_panel`, with no input or server callback payload.
+- [x] V3 active/error per-view reports exactly match rendered actions; result remains `octo/v1` with no
+  report document; registration-time report/golden drift checks pass, and a mutation test proves an
+  `octo/v1` Submit is rejected by `cardmsg.Validate` even when its golden matches.
+- [x] V3 `TemplateMeta.ActionContract == nil`; V1/V2 action contracts and exact rendered Submit payloads
+  remain unchanged for historical messages.
+
+### C. Registry and runtime catalog
+
+- [x] Registry lists V1, V2, V3, resolves empty-version/default lookup to V3, and continues exact lookup
+  and rendering for V1/V2 after `Freeze()`.
+- [x] Composition root registers all three before installing the RuntimeCatalog; no duplicate registry,
+  post-freeze mutation, or initialization-order fallback is introduced.
+- [x] Startup static reconciliation records V3’s exact identity with `source=static` (the existing static
+  claim model does not persist built-in hashes). Static/dynamic V3 source conflict and malformed artifact
+  still fail readiness; explicit historical static exact lookup remains available during dynamic DB outage
+  under the existing catalog contract.
+- [x] V3 activation/validation does not require a `reasoning.control` RouteSpec because there is no Submit;
+  existing V2 static-interactive tests retain the source-sensitive built-in bypass, while dynamic
+  interactive artifacts continue requiring a matching route.
+
+### D. Bot capability, send, and edit
+
+- [x] `/v1/bot/card/profile` advertises exactly one `ai.reasoning-process` entry, V3, and all three views
+  expose `submit_actions: []` even when top-level card delivery is disabled.
+- [x] A V3 new send renders through server `template_ref + state + data`, writes server-authored V3
+  provenance, and emits no Submit action. V1/V2 new sends fail with zero message/dispatch side effects.
+- [x] V1, V2, and V3 historical same-version edits remain allowed with the existing owner/Space/lifecycle/
+  CAS checks. Cross-version edits and raw overwrite remain rejected before mutation.
+- [x] Disabled gate, malformed data, stale/out-of-order `card_seq`, and identical replay behavior are
+  unchanged; errors do not disclose catalog membership or historical message existence.
+- [x] Raw Bot type-17 send and edit requests may omit `render_profile`; their dispatched/persisted frames
+  contain server-authored `octo-chat/v1`. A valid explicit same value remains compatible, invalid values
+  fail validation, and Registry manifest ownership remains unchanged.
+
+### E. Verification evidence
+
+- [x] Focused package tests pass for `pkg/cardtmpl/ai_reasoning_process`, `pkg/cardtmpl`,
+  `modules/bot_api`, and `modules/card_template_catalog`.
+- [x] Targeted race tests pass for reasoning registration/render, Bot template capability/send/edit, and
+  RuntimeCatalog/static reconciliation paths.
+- [x] Clean MySQL/Redis/WuKongIM integration lane passes for affected Bot/catalog behavior before finish;
+  no shared-DB migration pollution is reported as success.
+- [x] `go build ./...`, affected-package `go vet`, relevant source guards, and `git diff --check` pass.
+- [x] V3 legacy `reasoning_stop`/`reasoning_retry` IDs do not resolve through `cardmsg.SubmitAction` or
+  catalog/message `ActionContext` (`ErrActionUnknown` before enqueue), and Registry callers supplying
+  server-owned `render_profile` fail before dispatch.
+- [x] Handler-level raw send and real MySQL/Redis/WuKongIM raw-edit tests prove the Bot API authors
+  `render_profile` when callers omit it; edit normalization preserves `card_seq` integer precision.
+- [x] PR evidence records the source attachment SHA, exact server adaptation decisions, focused/race/
+  integration results, and confirms that no i18n extraction was required because no error code or
+  user-facing server error changed.
+
+### F. Rollout and rollback
+
+- [x] The production RuntimeCatalog runbook forbids routine static-to-static Activate/Rollback, explains
+  the sticky-readiness failure mode, and requires checking active-pointer compatibility before binary
+  rollback. `ai.reasoning-process@0.3.0` is selected by image `SetDefault`, not a MySQL activation row.
+- [ ] First deployment keeps `OCTO_BOT_CARD_ENABLED=false` and dynamic new-send closed; all replicas reach
+  ready after V3 static reconciliation before any experimental enablement.
+- [ ] With the Bot gate closed, live profile inspection shows V3 only and empty Submit actions. A
+  compatible consumer/release and server-rendered send/edit E2E are separate go/no-go evidence; this PR
+  does not assert them without execution.
+- [ ] Before enabling new sends, operators verify whether any V1/V2 experimental/production messages are
+  still active. They are not migrated: old payloads can retain their original controls until naturally
+  terminal/frozen.
+- [ ] Target clients have the `octo-chat/v1` host generation before Bot card traffic is enabled; the
+  server-authored raw Bot key applies to every raw type-17 Bot send/edit, not only reasoning cards.
+- [ ] Before binary rollback, operators prove the activation target is absent or resolvable by the rollback
+  image; no row may point to static V3. Before any V3 send, the previous binary is then safe. After a V3
+  message exists, rollback must retain a binary that can resolve/edit V3 or accept freezing the last
+  successful frame; it must not raw overwrite or mutate the immutable version.
+- [ ] Reintroducing stop/retry in the future requires another immutable template version plus real E1e
+  semantics and joint E2E; it cannot modify V3 in place.
+
+## Human confirmation before `/octospec-go`
+
+- [x] Accept `ai.reasoning-process@0.3.0` with `contractVersion=1.1.0`; V1/V2 remain byte-frozen.
+- [x] Accept the minimal attachment delta only: hide stop/retry and remove retry invitation; preserve
+  existing server component IDs, bounded schema, pinned render profile, and result=`octo/v1`.
+- [x] Accept `owner=ai` with no `actionType`, making V3 `ActionContract=nil` while toggle remains a
+  client-local action.
+- [x] Accept V3-only Bot advertisement/new-send and V1/V2/V3 same-version historical edit compatibility.
+- [x] Accept that already delivered V1/V2 cards are not migrated and can retain their old rendered
+  controls; production gates remain closed while this is audited.
+- [x] Accept server-only scope: no OpenClaw, E1e, PR-C grants/discovery, DB migration, or production enable.

--- a/.octospec/tasks/cardtmpl-reasoning-controls-hidden-successor/context.yaml
+++ b/.octospec/tasks/cardtmpl-reasoning-controls-hidden-successor/context.yaml
@@ -1,0 +1,20 @@
+injected:
+  - id: space-isolation
+    source: repo
+    why: Bot catalog and send/edit tests must preserve bot ownership and authoritative Space boundaries.
+  - id: trust-boundary
+    source: repo
+    why: The new JSON artifact must retain bounded schema, report/golden self-check, and final card validation.
+  - id: error-handling
+    source: repo
+    why: Bot wire paths are touched; existing localized error behavior must remain unchanged.
+  - id: rate-limit
+    source: repo
+    why: Bot module files are touched; no route or shared UID limiter behavior may regress.
+  - id: testing
+    source: repo
+    why: The version cutover requires unit, race, catalog integration, and historical-edit regression evidence.
+  - id: commit-style
+    source: repo
+    why: Eventual commits and PR must follow English Conventional Commit and PR conventions; Implement makes no commit.
+brief: .octospec/tasks/cardtmpl-reasoning-controls-hidden-successor/brief.md

--- a/docs/card-protocol.md
+++ b/docs/card-protocol.md
@@ -113,7 +113,7 @@ allowlist —— 服务端用**完整 CommonMark 解析器**（非模式匹配�
   2. 不认识 `profile`（更新的服务端/更旧的客户端）→ 渲染 `plain`；
   3. 连 `type:17` 都不认识（存量客户端）→ octo-lib 未知类型兜底文案。
 - P2 产者能力发现：`GET /v1/bot/card/profile`（D12，随 P2 落地）返回部署的
-  `enabled` / `card_version` / `profiles` / `elements` / `inputs` / `actions` / `limits`
+  `enabled` / `card_version` / `profiles` / `elements` / `inputs` / `actions` / `templating` / `limits`
   清单（只增不改）；`elements`/`inputs`/`actions` 是本部署接受的展示元素 / 交互输入 /
   **本地动作**白名单（源自 `pkg/cardmsg` 权威列表；`elements` 只列**顶层可放置**元素——
   `Column` 是 `ColumnSet` 的子列、由 `ColumnSet` 涵盖，不单列；`actions` 只列 octo/v1
@@ -122,6 +122,32 @@ allowlist —— 服务端用**完整 CommonMark 解析器**（非模式匹配�
   前向兼容协商——即便 `card_version` 停在 `"1.5"`、`profiles` 不变，也能探测是否接受
   `Input.Number/Date/Time`、`ToggleVisibility`/`CopyToClipboard` 等 additive 新增能力。
   P1 期间生产者以发送被 400/`card_disabled` 拒绝为「未启用」信号。
+
+`templating` 是 Bot Registry 模式的服务端新发 allowlist，不是整个
+`Registry.List()`。消费者必须同时校验 `supported`、wire 版本、模板精确版本、
+view/state/wire profile 以及每个 view 的 `submit_actions`；不能从
+`profile="octo/v2"` 推断某张模板一定带 Submit。当前 V3 形状如下，实际选择仍以
+目标环境实时响应为准：
+
+```json
+{
+  "templating": {
+    "supported": true,
+    "wire": "template-ref/v1",
+    "templates": [
+      {
+        "id": "ai.reasoning-process",
+        "version": "0.3.0",
+        "views": [
+          {"name":"active","states":["answering","reasoning"],"wire_profile":"octo/v2","submit_actions":[]},
+          {"name":"error","states":["error"],"wire_profile":"octo/v2","submit_actions":[]},
+          {"name":"result","states":["completed","stopped"],"wire_profile":"octo/v1","submit_actions":[]}
+        ]
+      }
+    ]
+  }
+}
+```
 
 ## 4. 信任模型（谁能发卡、谁能信卡）
 
@@ -181,8 +207,16 @@ allowlist —— 服务端用**完整 CommonMark 解析器**（非模式匹配�
 { "msg_type": "card", "card": { "…": "AC JSON" }, "text": "optional plain seed" }
 ```
 
-robot API（legacy）`/robot/sendMessage` 同样接受 type-17（校验与 bot ingress
-对称；错误形状是该 API 的单一 content-invalid 400）。
+`render_profile` 是服务端写入最终 type-17 信封的视觉兼容键，不是
+`/v1/bot/sendMessage` 的外层字段，也不需要 Bot 放进 raw `payload`。raw Bot send/edit
+在校验调用方卡片后统一写入 `octo-chat/v1`，再执行最终大小校验和派发/落库；为兼容
+已有调用方，显式传入同一合法值仍可通过，但不是权威来源，未知值仍在写入前
+fail-close。Registry `template_ref` 模式继续禁止调用方携带该字段，由服务端按 manifest
+的 `renderProfileCompatibility` 权威生成。其他 ingress 未选择兼容档时仍按各自既有
+契约走 Legacy 渲染。
+
+robot API（legacy）`/robot/sendMessage` 同样接受 type-17 的共享结构校验，但不继承
+Bot API 的服务端视觉默认值；错误形状仍是该 API 的单一 content-invalid 400。
 
 **P1 卡片不可变**：所有编辑入口（用户 `/v1/message/edit`、bot
 `/v1/bot/message/edit`、robot 编辑）对 type-17（目标消息或编辑体）一律 400。

--- a/docs/card-template-runtime-catalog-runbook.md
+++ b/docs/card-template-runtime-catalog-runbook.md
@@ -22,6 +22,37 @@ and the database disagree. Do not add or use a switch that ignores the
 collision: doing so can make replicas resolve different content for the same
 identity.
 
+### Built-in static versions and binary rollback
+
+During the pre-PR-C dark phase, **do not use Activate or Rollback to switch a
+built-in-only template between static versions**. A built-in default is selected
+by the image's frozen Registry `SetDefault`; change it by deploying a reviewed
+image, not by persisting a catalog pointer. In particular, do not Activate or
+Rollback `ai.reasoning-process` to `0.3.0` as a shortcut for the image cutover.
+
+An activation row outlives the image that created it and overrides the
+built-in default. If it points to a static version that a rollback image does
+not contain, that image sees a permanent `source=static` claim outside its
+frozen Registry, classifies the active target as catalog integrity failure,
+marks readiness sticky-down, and rejects all catalog resolution. This can take
+every replica out of readiness even though the artifact bytes themselves are
+valid.
+
+Before any binary rollback, inspect the authoritative activation target and
+prove that it is absent or resolvable by the rollback image. If an operator has
+already persisted an incompatible static target, stop the rollout and use the
+current compatible image under an approved change ticket to Activate, with the
+current revision CAS, a target present in both images. Verify the audit and
+readiness, and only then roll back the binary. Do not repair this condition by
+editing the activation/claim tables directly; Block is irreversible and is not
+a shortcut for clearing an accidental static activation pointer.
+
+A future dynamic-catalog pilot may need a reviewed rollback from a dynamic
+artifact to a known built-in fallback. That exception must name a static
+version present in every allowed rollback image and establishes the same binary
+compatibility floor; it is not permission to use the control plane for routine
+static-to-static version selection.
+
 Before the first dynamic card is sent, a static-key collision is recovered with
 a **binary rollback or corrective binary**, not a catalog bypass or database
 rewrite. After a dynamic card is sent, rollback binaries must retain the PR-B
@@ -101,6 +132,12 @@ unaudited conflict response.
 
 ## Safe control procedure
 
+The procedures below operate the **dynamic** catalog state machine. In the
+current dark phase, a built-in-only template ID is not a control-plane drill
+target. The fact that the API can validate a static target is a recovery
+mechanism for a future dynamic pilot, not an operational recommendation to pin
+ordinary static defaults in MySQL.
+
 Use the manager read endpoints to obtain the authoritative version and
 `revision`; never guess a revision or infer rollback history from deployment
 notes:
@@ -120,6 +157,10 @@ and callback secrets.
 
 1. Keep dynamic new-send disabled. Enable the forward control gate only in the
    approved environment and only after all serving replicas run the PR-B image.
+   For routine forward control, Activate only a reviewed dynamic artifact;
+   never use this endpoint to select a built-in static version already
+   controlled by the image Registry. The approved compatibility repair in
+   "Built-in static versions and binary rollback" is the narrow exception.
 2. Validate/publish the immutable artifact and review its hash, owner, protocol,
    interaction contract, and route configuration. Publish accepts only the
    reviewed runtime-owner allowlist and requires startup catalog readiness;
@@ -138,6 +179,10 @@ and callback secrets.
 - Always name the target version. The server accepts only a version that the
   audit history proves was previously active and that still passes artifact,
   owner, block, compiler, and route validation.
+- Do not use rollback for routine static-to-static version selection. A static
+  target is allowed operationally only as an explicitly reviewed fallback from
+  a dynamic pilot, and only when that exact version exists in every image still
+  eligible for binary rollback.
 - Rollback remains available when the forward control gate is off. It performs
   a revision CAS and writes the state change plus success audit in one
   transaction.
@@ -223,6 +268,9 @@ no artifact during an idempotent publish.
   approved integrity repair was required.
 - Forward control/new-send gates are in the approved posture; successful
   publish, reconciliation, or activation is not treated as a producer grant.
+- No activation row points to a built-in static version absent from any image
+  still eligible for rollback. Built-in-only version changes use image
+  `SetDefault`, not a persistent Activate/Rollback pointer.
 - Multi-replica default resolution, explicit rollback, hot-cache block, process
   restart, and DB-outage behavior have been exercised in the target environment.
 

--- a/docs/platform-card-base.md
+++ b/docs/platform-card-base.md
@@ -165,7 +165,8 @@
 - manifest 的 `renderProfile` 固定 Forge 验证制品的精确不可变版本，例如 `octo-chat@1.2.0-rc.1`；
 - manifest 的 `renderProfileCompatibility` 是客户端稳定兼容键，例如 `octo-chat/v1`；
 - type-17 信封只发送稳定键：`"render_profile": "octo-chat/v1"`，Web 不需要保存每个 Forge 历史包；
-- 未声明 `renderProfileCompatibility` 的历史卡不写 `render_profile`，永久走 Legacy 渲染；
+- Registry 历史模板未声明 `renderProfileCompatibility` 时不写 `render_profile`，永久走 Legacy 渲染；
+- raw Bot send/edit 的调用方不选择该字段，Bot API 在有效帧统一写入 `octo-chat/v1`；
 - 服务端只接受已注册的稳定键，未知值在发送/写入边界 fail-close。
 
 当前 `docs.access-request@0.3.0` 固定 `octo-chat@1.2.0-rc.1` 并发送 `octo-chat/v1`；冻结的 `0.2.0` 不发送视觉兼容键。

--- a/main.go
+++ b/main.go
@@ -717,14 +717,15 @@ func replaceWebConfig(cfg *config.Config) {
 }
 
 // installCardTmplRegistry 装配 L0 cardtmpl.Registry 并注入到 pkg-scoped default。
-// 同时保留已发布冻结的 0.2.0 与带 result 视图的 0.3.0;新消息默认 0.3.0,
-// 旧 0.2.0 pending 消息仍可由 finalizer 升级成 0.3.0/result。
 //
 // Fail-close 契约:任一 Register/SetDefault 失败 → panic(与 main.go:521 现有的
 // docs approval callback route 校验同源)。init 期 schema/manifest 语法错无
 // runtime env 可挽救,回滚 = 镜像 revert。
 func installCardTmplRegistry() *cardtmpl.Registry {
 	registry := cardtmpl.NewRegistry()
+	// docs.access-request:同时保留已发布冻结的 0.2.0 与带 result 视图的
+	// 0.3.0;新消息默认 0.3.0,旧 0.2.0 pending 消息仍可由 finalizer
+	// 升级成 0.3.0/result。
 	registry.Register(docsaccessrequest.New(), docsaccessrequest.Assets, docsaccessrequest.HandoffRoot)
 	registry.Register(docsaccessrequest.NewV3(), docsaccessrequest.Assets, docsaccessrequest.HandoffRootV3)
 	registry.SetDefault(docsaccessrequest.TemplateID, docsaccessrequest.TemplateVersionV3)
@@ -740,12 +741,15 @@ func installCardTmplRegistry() *cardtmpl.Registry {
 	registry.SetDefault(summarycompleted.TemplateID, summarycompleted.TemplateVersion)
 	registry.Register(summaryfailed.New(), summaryfailed.Assets, summaryfailed.HandoffRoot)
 	registry.SetDefault(summaryfailed.TemplateID, summaryfailed.TemplateVersion)
-	// roadmap E1/E1c:保留冻结的 0.1.0 供历史消息按原契约编辑，同时注册有界的
-	// 0.2.0 successor 并设为新默认。Bot 新发/legacy edit 的授权集合由 bot_api
-	// catalog 独立收口；Registry 多版本只提供渲染能力，不隐式开放 Bot 权限。
+	// roadmap E1/E1c safety successor:保留冻结的 0.1.0/0.2.0 供历史消息按原
+	// 契约编辑且不跨版本迁移，同时注册隐藏未实现 stop/retry 控件的 0.3.0
+	// 并设为新默认。
+	// Bot 新发/历史 edit 的授权集合由 bot_api catalog 独立收口；Registry 多版本
+	// 只提供精确版本渲染能力，不隐式开放 Bot 权限。
 	registry.RegisterJSON(aireasoningprocess.Assets, aireasoningprocess.HandoffRootV1)
 	registry.RegisterJSON(aireasoningprocess.Assets, aireasoningprocess.HandoffRootV2)
-	registry.SetDefault(aireasoningprocess.TemplateID, aireasoningprocess.TemplateVersionV2)
+	registry.RegisterJSON(aireasoningprocess.Assets, aireasoningprocess.HandoffRootV3)
+	registry.SetDefault(aireasoningprocess.TemplateID, aireasoningprocess.TemplateVersionV3)
 	registry.Freeze()
 	cardtmpl.SetGlobalMetrics(cardtmpl.NewMetrics(prometheus.DefaultRegisterer))
 	cardtmpl.SetDefaultRegistry(registry)

--- a/main_test.go
+++ b/main_test.go
@@ -1,8 +1,12 @@
 package main
 
 import (
+	"sort"
 	"testing"
 
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl"
+	aireasoningprocess "github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl/ai_reasoning_process"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 )
 
@@ -20,4 +24,41 @@ func TestAccessLogIgnorePathsIncludesProbeEndpoints(t *testing.T) {
 	require.Contains(t, paths, "/v1/ping")
 	require.Contains(t, paths, "/v1/health")
 	require.Contains(t, paths, "/v1/ready")
+}
+
+func TestInstallCardTmplRegistryRegistersReasoningHistoryAndV3Default(t *testing.T) {
+	previousRegistry := cardtmpl.DefaultRegistry()
+	previousRegisterer := prometheus.DefaultRegisterer
+	previousGatherer := prometheus.DefaultGatherer
+	metricsRegistry := prometheus.NewRegistry()
+	prometheus.DefaultRegisterer = metricsRegistry
+	prometheus.DefaultGatherer = metricsRegistry
+	t.Cleanup(func() {
+		cardtmpl.SetDefaultRegistry(previousRegistry)
+		cardtmpl.SetGlobalMetrics(nil)
+		prometheus.DefaultRegisterer = previousRegisterer
+		prometheus.DefaultGatherer = previousGatherer
+	})
+
+	registry := installCardTmplRegistry()
+	var versions []string
+	for _, meta := range registry.List() {
+		if meta.ID == aireasoningprocess.TemplateID {
+			versions = append(versions, meta.Version)
+		}
+	}
+	sort.Strings(versions)
+	require.Equal(t, []string{
+		aireasoningprocess.TemplateVersionV1,
+		aireasoningprocess.TemplateVersionV2,
+		aireasoningprocess.TemplateVersionV3,
+	}, versions)
+
+	current, err := registry.Lookup(aireasoningprocess.TemplateID, "")
+	require.NoError(t, err)
+	require.Equal(t, aireasoningprocess.TemplateVersionV3, current.Meta().Version)
+	for _, version := range versions {
+		_, err := registry.Lookup(aireasoningprocess.TemplateID, version)
+		require.NoError(t, err)
+	}
 }

--- a/modules/bot_api/card_p2_edit_im_test.go
+++ b/modules/bot_api/card_p2_edit_im_test.go
@@ -126,6 +126,10 @@ func TestBotCardEditCASIM(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Contains(t, stored, "done_btn", "message_extra 应存最新帧")
 	assert.NotContains(t, stored, "forged-by-client", "plain 必须被服务端重算覆盖")
+	var storedEnvelope map[string]interface{}
+	assert.NoError(t, json.Unmarshal([]byte(stored), &storedEnvelope))
+	assert.Equal(t, cardmsg.RenderProfileOctoChatV1, storedEnvelope["render_profile"],
+		"raw card edit 必须由服务端写入 render_profile")
 	// P1-2：捕获 advancing 写后的 version,用于验证下方冲突帧不改动它。
 	var vAfterDone int64
 	err = ctx.DB().Select("version").From("message_extra").Where("message_id=?", msgID).LoadOne(&vAfterDone)

--- a/modules/bot_api/card_profile.go
+++ b/modules/bot_api/card_profile.go
@@ -53,7 +53,7 @@ func (ba *BotAPI) botCardProfile(c *wkhttp.Context) {
 		// ToggleVisibility / CopyToClipboard 等 additive 新增本地动作。Action.Submit 属
 		// octo/v2 交互档，经 profiles 隐式发现、不在此列。
 		"actions": cardmsg.DisplayActions(),
-		// templating is additive to the raw-card Model B manifest. It advertises
+		// templating is additive to the raw-card capability manifest. It advertises
 		// only the explicit Bot catalog, never the broader Registry.List(). A nil
 		// catalog occurs only in focused tests that do not install the production
 		// composition root and reports supported:false rather than inventing refs.

--- a/modules/bot_api/card_profile_test.go
+++ b/modules/bot_api/card_profile_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/testutil"
 	"github.com/Mininglamp-OSS/octo-server/pkg/cardmsg"
 	"github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl"
+	aireasoningprocess "github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl/ai_reasoning_process"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -90,6 +91,7 @@ func TestBotCardProfile_ElementsInputsFromConstants(t *testing.T) {
 	assert.True(t, m.Templating.Supported)
 	assert.Equal(t, botTemplateWireV1, m.Templating.Wire)
 	assert.Len(t, m.Templating.Templates, 1)
+	assertReasoningV3Capability(t, m.Templating)
 }
 
 // TestBotCardProfile_ValuesFromConstants：清单每个值必须等于 pkg/cardmsg 常量
@@ -134,6 +136,7 @@ func TestBotCardProfile_DisabledStillReturnsManifestAndSendRejects(t *testing.T)
 	assert.Equal(t, cardmsg.MaxPayloadBytes, m.Limits.MaxPayloadBytes)
 	assert.True(t, m.Templating.Supported, "关闭时仍返完整模板清单")
 	assert.Len(t, m.Templating.Templates, 1)
+	assertReasoningV3Capability(t, m.Templating)
 
 	// 半 2：send 路径对卡片仍拒绝（同源 bot 门禁 BotEnabled，此处经部署级总开关关闭
 	// 而生效，send.go —— 在 IM 派发前拒绝，无需 WuKongIM）。
@@ -174,6 +177,7 @@ func TestBotCardProfile_BotSubSwitchDisablesProfileAndSend(t *testing.T) {
 	assert.Equal(t, cardmsg.AcceptedProfiles(), m.Profiles)
 	assert.True(t, m.Templating.Supported, "bot 子开关关闭时仍返完整模板清单")
 	assert.Len(t, m.Templating.Templates, 1)
+	assertReasoningV3Capability(t, m.Templating)
 
 	// 半 2：send 路径同源门禁（BotEnabled）→ 拒绝，与 profile 一致。
 	body := map[string]interface{}{
@@ -242,4 +246,18 @@ func newMustTestCatalog(t *testing.T) *botCardTemplateCatalog {
 	catalog, err := newBotCardTemplateCatalog(testBotTemplateRegistry(t), defaultBotTemplateRefs())
 	assert.NoError(t, err)
 	return catalog
+}
+
+func assertReasoningV3Capability(t *testing.T, capability botTemplatingCapability) {
+	t.Helper()
+	if !assert.Len(t, capability.Templates, 1) {
+		return
+	}
+	template := capability.Templates[0]
+	assert.Equal(t, string(aireasoningprocess.TemplateID), template.ID)
+	assert.Equal(t, aireasoningprocess.TemplateVersionV3, template.Version)
+	assert.Len(t, template.Views, 3)
+	for _, view := range template.Views {
+		assert.Empty(t, view.SubmitActions, "view %s must not advertise server callbacks", view.Name)
+	}
 }

--- a/modules/bot_api/card_template_catalog.go
+++ b/modules/bot_api/card_template_catalog.go
@@ -64,7 +64,7 @@ type botCardTemplateCatalog struct {
 func defaultBotTemplateRefs() []botTemplateRef {
 	return []botTemplateRef{{
 		ID:      aireasoningprocess.TemplateID,
-		Version: aireasoningprocess.TemplateVersionV2,
+		Version: aireasoningprocess.TemplateVersionV3,
 	}}
 }
 
@@ -74,6 +74,7 @@ func defaultBotTemplatePolicy() botTemplatePolicy {
 		EditCompatible: []botTemplateRef{
 			{ID: aireasoningprocess.TemplateID, Version: aireasoningprocess.TemplateVersionV1},
 			{ID: aireasoningprocess.TemplateID, Version: aireasoningprocess.TemplateVersionV2},
+			{ID: aireasoningprocess.TemplateID, Version: aireasoningprocess.TemplateVersionV3},
 		},
 	}
 }

--- a/modules/bot_api/card_template_catalog_test.go
+++ b/modules/bot_api/card_template_catalog_test.go
@@ -12,12 +12,18 @@ import (
 	docsaccessrequest "github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl/docs_access_request"
 )
 
+const (
+	testReasoningVersionV3 = aireasoningprocess.TemplateVersionV3
+	testReasoningRootV3    = aireasoningprocess.HandoffRootV3
+)
+
 func testBotTemplateRegistry(t *testing.T) *cardtmpl.Registry {
 	t.Helper()
 	r := cardtmpl.NewRegistry()
 	r.RegisterJSON(aireasoningprocess.Assets, aireasoningprocess.HandoffRootV1)
 	r.RegisterJSON(aireasoningprocess.Assets, aireasoningprocess.HandoffRootV2)
-	r.SetDefault(aireasoningprocess.TemplateID, aireasoningprocess.TemplateVersionV2)
+	r.RegisterJSON(aireasoningprocess.Assets, testReasoningRootV3)
+	r.SetDefault(aireasoningprocess.TemplateID, testReasoningVersionV3)
 	r.Register(docsaccessrequest.NewV3(), docsaccessrequest.Assets, docsaccessrequest.HandoffRootV3)
 	r.SetDefault(docsaccessrequest.TemplateID, docsaccessrequest.TemplateVersionV3)
 	r.Freeze()
@@ -25,7 +31,7 @@ func testBotTemplateRegistry(t *testing.T) *cardtmpl.Registry {
 }
 
 func testReasoningData(t *testing.T, state string) json.RawMessage {
-	return testReasoningDataVersion(t, aireasoningprocess.HandoffRootV2, state)
+	return testReasoningDataVersion(t, testReasoningRootV3, state)
 }
 
 func testReasoningDataVersion(t *testing.T, root, state string) json.RawMessage {
@@ -46,32 +52,42 @@ func TestBotCardTemplateCatalogSeparatesNewSendFromLegacyEdit(t *testing.T) {
 	}
 
 	capability := catalog.Capability()
-	if len(capability.Templates) != 1 || capability.Templates[0].Version != aireasoningprocess.TemplateVersionV2 {
+	if len(capability.Templates) != 1 || capability.Templates[0].Version != testReasoningVersionV3 {
 		t.Fatalf("advertised templates = %+v, want successor only", capability.Templates)
 	}
 
-	legacyRef := map[string]any{
-		"id": string(aireasoningprocess.TemplateID), "version": aireasoningprocess.TemplateVersionV1,
-	}
-	legacyPayload := map[string]any{
-		"type":         17,
-		"template_ref": legacyRef,
-		"state":        "reasoning",
-		"data": rawJSONToMap(t, testReasoningDataVersion(t,
-			aireasoningprocess.HandoffRootV1, "reasoning")),
-	}
-	if _, err := catalog.RenderPayload(context.Background(), legacyPayload, cardtmpl.BuildEnv{}); !errors.Is(err, errBotTemplateRequestInvalid) {
-		t.Fatalf("legacy send error = %v, want request invalid", err)
-	}
-	if ref, err := catalog.requireEditableRef(legacyRef); err != nil || ref.Version != aireasoningprocess.TemplateVersionV1 {
-		t.Fatalf("legacy edit ref = %+v, error = %v", ref, err)
-	}
-	rendered, err := catalog.RenderEditPayload(context.Background(), legacyPayload, cardtmpl.BuildEnv{})
-	if err != nil {
-		t.Fatalf("RenderEditPayload(legacy): %v", err)
-	}
-	if got := rendered["template_ref"].(map[string]any)["version"]; got != aireasoningprocess.TemplateVersionV1 {
-		t.Fatalf("legacy edit rendered version = %v", got)
+	for _, historical := range []struct {
+		version string
+		root    string
+	}{
+		{aireasoningprocess.TemplateVersionV1, aireasoningprocess.HandoffRootV1},
+		{aireasoningprocess.TemplateVersionV2, aireasoningprocess.HandoffRootV2},
+	} {
+		t.Run(historical.version, func(t *testing.T) {
+			legacyRef := map[string]any{
+				"id": string(aireasoningprocess.TemplateID), "version": historical.version,
+			}
+			legacyPayload := map[string]any{
+				"type":         17,
+				"template_ref": legacyRef,
+				"state":        "reasoning",
+				"data": rawJSONToMap(t, testReasoningDataVersion(t,
+					historical.root, "reasoning")),
+			}
+			if _, err := catalog.RenderPayload(context.Background(), legacyPayload, cardtmpl.BuildEnv{}); !errors.Is(err, errBotTemplateRequestInvalid) {
+				t.Fatalf("historical send error = %v, want request invalid", err)
+			}
+			if ref, err := catalog.requireEditableRef(legacyRef); err != nil || ref.Version != historical.version {
+				t.Fatalf("historical edit ref = %+v, error = %v", ref, err)
+			}
+			rendered, err := catalog.RenderEditPayload(context.Background(), legacyPayload, cardtmpl.BuildEnv{})
+			if err != nil {
+				t.Fatalf("RenderEditPayload(historical): %v", err)
+			}
+			if got := rendered["template_ref"].(map[string]any)["version"]; got != historical.version {
+				t.Fatalf("historical edit rendered version = %v", got)
+			}
+		})
 	}
 }
 
@@ -92,7 +108,7 @@ func TestBotCardTemplateCatalogPassesAuthoritativePrincipalAndPurpose(t *testing
 	payload := map[string]any{
 		"type": float64(17),
 		"template_ref": map[string]any{
-			"id": string(aireasoningprocess.TemplateID), "version": aireasoningprocess.TemplateVersionV2,
+			"id": string(aireasoningprocess.TemplateID), "version": testReasoningVersionV3,
 		},
 		"state": "reasoning",
 		"data":  rawJSONToMap(t, testReasoningData(t, "reasoning")),
@@ -113,7 +129,7 @@ func TestBotCardTemplateCatalogPassesAuthoritativePrincipalAndPurpose(t *testing
 func TestBotCardTemplatePolicyRequiresEverySendRefToRemainEditable(t *testing.T) {
 	_, err := newBotCardTemplateCatalogWithPolicy(testBotTemplateRegistry(t), botTemplatePolicy{
 		AdvertisedSend: []botTemplateRef{{
-			ID: aireasoningprocess.TemplateID, Version: aireasoningprocess.TemplateVersionV2,
+			ID: aireasoningprocess.TemplateID, Version: testReasoningVersionV3,
 		}},
 		EditCompatible: []botTemplateRef{{
 			ID: aireasoningprocess.TemplateID, Version: aireasoningprocess.TemplateVersionV1,
@@ -127,7 +143,7 @@ func TestBotCardTemplatePolicyRequiresEverySendRefToRemainEditable(t *testing.T)
 func TestBotCardTemplatePolicyFailsClosed(t *testing.T) {
 	registry := testBotTemplateRegistry(t)
 	successor := botTemplateRef{
-		ID: aireasoningprocess.TemplateID, Version: aireasoningprocess.TemplateVersionV2,
+		ID: aireasoningprocess.TemplateID, Version: testReasoningVersionV3,
 	}
 	missing := botTemplateRef{ID: "ai.missing", Version: "1.0.0"}
 	tests := []struct {
@@ -191,8 +207,8 @@ func TestBotCardTemplateCatalogCapability(t *testing.T) {
 		t.Fatalf("template = %+v", tpl)
 	}
 	wantViews := []botTemplateViewCapability{
-		{Name: "active", States: []string{"answering", "reasoning"}, WireProfile: "octo/v2", SubmitActions: []string{"reasoning_stop"}},
-		{Name: "error", States: []string{"error"}, WireProfile: "octo/v2", SubmitActions: []string{"reasoning_retry"}},
+		{Name: "active", States: []string{"answering", "reasoning"}, WireProfile: "octo/v2", SubmitActions: []string{}},
+		{Name: "error", States: []string{"error"}, WireProfile: "octo/v2", SubmitActions: []string{}},
 		{Name: "result", States: []string{"completed", "stopped"}, WireProfile: "octo/v1", SubmitActions: []string{}},
 	}
 	if !reflect.DeepEqual(tpl.Views, wantViews) {
@@ -370,6 +386,7 @@ func TestBotCardTemplateCatalogRejectsCallerControlledInvalidModes(t *testing.T)
 		{name: "state mismatch", mutate: func(p map[string]any) { p["state"] = "completed" }},
 		{name: "render owned plain", mutate: func(p map[string]any) { p["plain"] = "forged" }},
 		{name: "render owned profile", mutate: func(p map[string]any) { p["profile"] = "octo/v1" }},
+		{name: "render owned render profile", mutate: func(p map[string]any) { p["render_profile"] = "octo-chat/v1" }},
 		{name: "render owned space", mutate: func(p map[string]any) { p["space_id"] = "forged" }},
 		{name: "unknown envelope field", mutate: func(p map[string]any) { p["content"] = "smuggled" }},
 		{name: "data must be object", mutate: func(p map[string]any) { p["data"] = []any{} }},

--- a/modules/bot_api/card_template_edit_test.go
+++ b/modules/bot_api/card_template_edit_test.go
@@ -85,38 +85,48 @@ func TestBotMessageEditRegistryTemplateRendersSameIdentity(t *testing.T) {
 	}
 }
 
-func TestBotMessageEditRegistryTemplateKeepsLegacyVersionEditable(t *testing.T) {
+func TestBotMessageEditRegistryTemplateKeepsHistoricalVersionsEditable(t *testing.T) {
 	t.Setenv(cardmsg.EnvEnabled, "true")
 	catalog, err := newBotCardTemplateCatalogWithPolicy(testBotTemplateRegistry(t), defaultBotTemplatePolicy())
 	if err != nil {
 		t.Fatal(err)
 	}
-	mutator := &fakeBotCardMutator{
-		snapshot: carddispatch.CardMutationSnapshot{
-			Envelope: initialRegistryEnvelopeVersion(t, catalog, aireasoningprocess.TemplateVersionV1, "reasoning"),
-			CardSeq:  1,
-		},
-		mutateResult: carddispatch.CardMutationResult{Applied: true},
-	}
-	ba := &BotAPI{
-		Log:           log.NewTLog("BotAPI-template-edit-legacy"),
-		cardTemplates: catalog,
-		cardMutator:   mutator,
-	}
-	body := registryEditBodyVersion(t, aireasoningprocess.TemplateVersionV1, "completed",
-		testReasoningDataVersion(t, aireasoningprocess.HandoffRootV1, "completed"), 2, false)
+	for _, historical := range []struct {
+		version string
+		root    string
+	}{
+		{aireasoningprocess.TemplateVersionV1, aireasoningprocess.HandoffRootV1},
+		{aireasoningprocess.TemplateVersionV2, aireasoningprocess.HandoffRootV2},
+	} {
+		t.Run(historical.version, func(t *testing.T) {
+			mutator := &fakeBotCardMutator{
+				snapshot: carddispatch.CardMutationSnapshot{
+					Envelope: initialRegistryEnvelopeVersion(t, catalog, historical.version, "reasoning"),
+					CardSeq:  1,
+				},
+				mutateResult: carddispatch.CardMutationResult{Applied: true},
+			}
+			ba := &BotAPI{
+				Log:           log.NewTLog("BotAPI-template-edit-historical"),
+				cardTemplates: catalog,
+				cardMutator:   mutator,
+			}
+			body := registryEditBodyVersion(t, historical.version, "completed",
+				testReasoningDataVersion(t, historical.root, "completed"), 2, false)
 
-	recorder := invokeTemplateEdit(t, ba, body)
-	if recorder.Code != http.StatusOK {
-		t.Fatalf("status=%d body=%s", recorder.Code, recorder.Body.String())
-	}
-	if mutator.snapshotCalls != 1 || len(mutator.mutateRequests) != 1 {
-		t.Fatalf("snapshot/mutate calls = %d/%d", mutator.snapshotCalls, len(mutator.mutateRequests))
-	}
-	if err := requireEffectiveCardTemplate([]byte(mutator.mutateRequests[0].ContentEdit), botTemplateRef{
-		ID: aireasoningprocess.TemplateID, Version: aireasoningprocess.TemplateVersionV1,
-	}); err != nil {
-		t.Fatalf("legacy replacement identity: %v", err)
+			recorder := invokeTemplateEdit(t, ba, body)
+			if recorder.Code != http.StatusOK {
+				t.Fatalf("status=%d body=%s", recorder.Code, recorder.Body.String())
+			}
+			if mutator.snapshotCalls != 1 || len(mutator.mutateRequests) != 1 {
+				t.Fatalf("snapshot/mutate calls = %d/%d", mutator.snapshotCalls, len(mutator.mutateRequests))
+			}
+			if err := requireEffectiveCardTemplate([]byte(mutator.mutateRequests[0].ContentEdit), botTemplateRef{
+				ID: aireasoningprocess.TemplateID, Version: historical.version,
+			}); err != nil {
+				t.Fatalf("historical replacement identity: %v", err)
+			}
+		})
 	}
 }
 
@@ -453,9 +463,12 @@ func initialRegistryEnvelopeVersion(
 	state string,
 ) []byte {
 	t.Helper()
-	root := aireasoningprocess.HandoffRootV2
-	if version == aireasoningprocess.TemplateVersionV1 {
+	root := testReasoningRootV3
+	switch version {
+	case aireasoningprocess.TemplateVersionV1:
 		root = aireasoningprocess.HandoffRootV1
+	case aireasoningprocess.TemplateVersionV2:
+		root = aireasoningprocess.HandoffRootV2
 	}
 	data := testReasoningDataVersion(t, root, state)
 	env := cardtmplBuildEnvForTest()

--- a/modules/bot_api/card_template_send_test.go
+++ b/modules/bot_api/card_template_send_test.go
@@ -70,34 +70,142 @@ func TestSendMessageRegistryTemplateRendersAndDispatches(t *testing.T) {
 	if _, ok := wire["reply"].(map[string]any); !ok {
 		t.Fatalf("reply not preserved: %#v", wire["reply"])
 	}
+	for _, forbidden := range [][]byte{
+		[]byte("Action.Submit"), []byte("reasoning_stop"), []byte("reasoning_retry"),
+		[]byte("stop_reasoning"), []byte("retry_reasoning"), []byte("可以重试"),
+	} {
+		if bytes.Contains(captured.Payload, forbidden) {
+			t.Fatalf("new-send payload contains unsupported control %q", forbidden)
+		}
+	}
 }
 
-func TestSendMessageRegistryTemplateRejectsLegacyVersionWithoutDispatch(t *testing.T) {
+func TestSendMessageRawCardAuthorsRenderProfile(t *testing.T) {
 	t.Setenv(cardmsg.EnvEnabled, "true")
 	gin.SetMode(gin.TestMode)
 
-	dispatch := &dispatchCapture{}
-	catalog, err := newBotCardTemplateCatalogWithPolicy(testBotTemplateRegistry(t), defaultBotTemplatePolicy())
+	for _, tc := range []struct {
+		name          string
+		renderProfile any
+		wantStatus    int
+	}{
+		{name: "omitted by caller", wantStatus: http.StatusOK},
+		{name: "matching legacy input remains compatible", renderProfile: cardmsg.RenderProfileOctoChatV1, wantStatus: http.StatusOK},
+		{name: "invalid legacy input still fails closed", renderProfile: "octo-chat/v2", wantStatus: http.StatusBadRequest},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dispatch := &dispatchCapture{}
+			ba := &BotAPI{
+				Log:              log.NewTLog("BotAPI-raw-card-render-profile"),
+				spaceQuerier:     &fakeSpaceQuerier{defaultSpace: "space-authoritative"},
+				dispatchOverride: dispatch.hook,
+			}
+			payload := map[string]any{
+				"type":         cardmsg.InteractiveCard.Int(),
+				"profile":      cardmsg.ProfileV1,
+				"card_version": cardmsg.CardVersion,
+				"card": map[string]any{
+					"type":    "AdaptiveCard",
+					"version": cardmsg.CardVersion,
+					"body": []any{
+						map[string]any{"type": "TextBlock", "text": "server authored render profile"},
+					},
+				},
+			}
+			if tc.renderProfile != nil {
+				payload["render_profile"] = tc.renderProfile
+			}
+			body := map[string]any{
+				"channel_id":   "user_creator",
+				"channel_type": common.ChannelTypePerson.Uint8(),
+				"payload":      payload,
+			}
+
+			recorder := invokeTemplateSend(t, ba, body, "")
+			if recorder.Code != tc.wantStatus {
+				t.Fatalf("status=%d, want=%d body=%s", recorder.Code, tc.wantStatus, recorder.Body.String())
+			}
+			dispatch.mu.Lock()
+			captured := dispatch.captured
+			dispatch.mu.Unlock()
+			if tc.wantStatus != http.StatusOK {
+				if captured != nil {
+					t.Fatal("invalid render_profile dispatched a message")
+				}
+				return
+			}
+			if captured == nil {
+				t.Fatal("expected exactly one dispatch")
+			}
+			var wire map[string]any
+			if err := json.Unmarshal(captured.Payload, &wire); err != nil {
+				t.Fatal(err)
+			}
+			if got := wire["render_profile"]; got != cardmsg.RenderProfileOctoChatV1 {
+				t.Fatalf("render_profile = %v, want %q", got, cardmsg.RenderProfileOctoChatV1)
+			}
+		})
+	}
+}
+
+func TestBotRawCardEditRenderProfilePreservesLargeCardSeq(t *testing.T) {
+	const contentEdit = `{"type":17,"profile":"octo/v2","card_version":"1.5","card_seq":9007199254740993,"card":{"type":"AdaptiveCard","version":"1.5","body":[{"type":"TextBlock","text":"progress"}]}}`
+	normalized, err := cardmsg.NormalizeContentEdit(contentEdit)
 	if err != nil {
 		t.Fatal(err)
 	}
-	ba := &BotAPI{
-		Log:              log.NewTLog("BotAPI-template-send-legacy"),
-		cardTemplates:    catalog,
-		spaceQuerier:     &fakeSpaceQuerier{defaultSpace: "space-authoritative"},
-		dispatchOverride: dispatch.hook,
+	authored, err := authorBotRawCardRenderProfile(normalized)
+	if err != nil {
+		t.Fatal(err)
 	}
-	body := registrySendBodyVersion(t, aireasoningprocess.TemplateVersionV1,
-		"reasoning", testReasoningDataVersion(t, aireasoningprocess.HandoffRootV1, "reasoning"))
+	if got, ok := cardmsg.CardSeqFromContentEdit(authored); !ok || got != 9007199254740993 {
+		t.Fatalf("card_seq = %d, ok=%v; want 9007199254740993", got, ok)
+	}
+	var wire map[string]any
+	if err := json.Unmarshal([]byte(authored), &wire); err != nil {
+		t.Fatal(err)
+	}
+	if got := wire["render_profile"]; got != cardmsg.RenderProfileOctoChatV1 {
+		t.Fatalf("render_profile = %v, want %q", got, cardmsg.RenderProfileOctoChatV1)
+	}
+}
 
-	recorder := invokeTemplateSend(t, ba, body, "")
-	if recorder.Code != http.StatusBadRequest {
-		t.Fatalf("status=%d body=%s", recorder.Code, recorder.Body.String())
-	}
-	dispatch.mu.Lock()
-	defer dispatch.mu.Unlock()
-	if dispatch.captured != nil {
-		t.Fatal("legacy template ref dispatched a new message")
+func TestSendMessageRegistryTemplateRejectsHistoricalVersionsWithoutDispatch(t *testing.T) {
+	t.Setenv(cardmsg.EnvEnabled, "true")
+	gin.SetMode(gin.TestMode)
+
+	for _, historical := range []struct {
+		version string
+		root    string
+	}{
+		{aireasoningprocess.TemplateVersionV1, aireasoningprocess.HandoffRootV1},
+		{aireasoningprocess.TemplateVersionV2, aireasoningprocess.HandoffRootV2},
+	} {
+		t.Run(historical.version, func(t *testing.T) {
+			dispatch := &dispatchCapture{}
+			catalog, err := newBotCardTemplateCatalogWithPolicy(testBotTemplateRegistry(t), defaultBotTemplatePolicy())
+			if err != nil {
+				t.Fatal(err)
+			}
+			ba := &BotAPI{
+				Log:              log.NewTLog("BotAPI-template-send-historical"),
+				cardTemplates:    catalog,
+				spaceQuerier:     &fakeSpaceQuerier{defaultSpace: "space-authoritative"},
+				dispatchOverride: dispatch.hook,
+			}
+			body := registrySendBodyVersion(t, historical.version,
+				"reasoning", testReasoningDataVersion(t, historical.root, "reasoning"))
+
+			recorder := invokeTemplateSend(t, ba, body, "")
+			if recorder.Code != http.StatusBadRequest {
+				t.Fatalf("status=%d body=%s", recorder.Code, recorder.Body.String())
+			}
+			dispatch.mu.Lock()
+			defer dispatch.mu.Unlock()
+			if dispatch.captured != nil {
+				t.Fatal("historical template ref dispatched a new message")
+			}
+		})
 	}
 }
 
@@ -147,6 +255,7 @@ func TestSendMessageRegistryTemplateRejectsInvalidWithoutDispatch(t *testing.T) 
 		}},
 		{name: "raw and registry both present", mutate: func(payload map[string]any) { payload["card"] = map[string]any{} }},
 		{name: "render owned field", mutate: func(payload map[string]any) { payload["plain"] = "forged" }},
+		{name: "render owned render profile", mutate: func(payload map[string]any) { payload["render_profile"] = "octo-chat/v1" }},
 		{name: "aggregate action overflow", mutate: func(payload map[string]any) {
 			payload["data"].(map[string]any)["phases"] = reasoningPhasesForBotTest(4, 2, 2, 2, 2, 2)
 		}},

--- a/modules/bot_api/send.go
+++ b/modules/bot_api/send.go
@@ -131,6 +131,11 @@ func (ba *BotAPI) sendMessage(c *wkhttp.Context) {
 				httperr.ResponseErrorL(c, errcode.ErrBotAPICardInvalid, nil, nil)
 				return
 			}
+			// Raw Bot callers own the card/profile capability payload, but the
+			// deployment owns the visual host compatibility generation. Validate
+			// any explicit inbound value first for backward-compatible fail-close,
+			// then author the stable outbound key so callers do not need to send it.
+			req.Payload["render_profile"] = cardmsg.RenderProfileOctoChatV1
 		}
 	}
 
@@ -1039,6 +1044,12 @@ func (ba *BotAPI) botMessageEdit(c *wkhttp.Context) {
 			httperr.ResponseErrorL(c, errcode.ErrBotAPICardInvalid, nil, nil)
 			return
 		}
+		normalized, cErr = authorBotRawCardRenderProfile(normalized)
+		if cErr != nil {
+			ba.Warn("InteractiveCard content_edit render_profile 写入失败", zap.Error(cErr), zap.String("messageID", req.MessageID))
+			httperr.ResponseErrorL(c, errcode.ErrBotAPICardInvalid, nil, nil)
+			return
+		}
 		req.ContentEdit = normalized
 		cardSeq, hasCardSeq = cardmsg.CardSeqFromContentEdit(normalized)
 	} else {
@@ -1320,6 +1331,36 @@ func cardEnvelopeHasTemplateRef(raw []byte) bool {
 	}
 	_, exists := payload["template_ref"]
 	return exists
+}
+
+// authorBotRawCardRenderProfile adds the deployment-owned visual compatibility
+// key after the caller-authored raw frame has passed cardmsg validation. UseNumber
+// preserves card_seq and any other 64-bit JSON integers across the rewrite.
+func authorBotRawCardRenderProfile(contentEdit string) (string, error) {
+	decoder := json.NewDecoder(strings.NewReader(contentEdit))
+	decoder.UseNumber()
+	var payload map[string]interface{}
+	if err := decoder.Decode(&payload); err != nil {
+		return "", err
+	}
+	if decoder.More() {
+		return "", errors.New("bot_api: card content_edit has trailing JSON data")
+	}
+	if !cardmsg.IsCardPayload(payload) {
+		return contentEdit, nil
+	}
+	payload["render_profile"] = cardmsg.RenderProfileOctoChatV1
+	if err := cardmsg.Validate(payload); err != nil {
+		return "", err
+	}
+	if err := cardmsg.Finalize(payload); err != nil {
+		return "", err
+	}
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return "", err
+	}
+	return string(raw), nil
 }
 
 // cardSeqCASMaxAttempts 是 D9 CAS 遇 InnoDB 死锁/锁等待超时的有界重试次数。

--- a/modules/card_template_catalog/api_test.go
+++ b/modules/card_template_catalog/api_test.go
@@ -197,14 +197,26 @@ func TestPublishMapsConflictAndInternalErrors(t *testing.T) {
 
 func TestReconcileStaticInventoryUsesFrozenRegistryList(t *testing.T) {
 	registry := cardtmpl.NewRegistry()
+	registry.RegisterJSON(aireasoningprocess.Assets, aireasoningprocess.HandoffRootV1)
 	registry.RegisterJSON(aireasoningprocess.Assets, aireasoningprocess.HandoffRootV2)
+	registry.RegisterJSON(aireasoningprocess.Assets, aireasoningprocess.HandoffRootV3)
 	registry.Freeze()
 	store := &fakeCatalogStore{}
 	if err := reconcileStaticInventory(context.Background(), store, registry); err != nil {
 		t.Fatalf("reconcileStaticInventory: %v", err)
 	}
-	if len(store.reconciled) != 1 || store.reconciled[0].ID != aireasoningprocess.TemplateID || store.reconciled[0].Version != aireasoningprocess.TemplateVersionV2 {
+	if len(store.reconciled) != 3 {
 		t.Fatalf("reconciled inventory = %+v", store.reconciled)
+	}
+	for index, version := range []string{
+		aireasoningprocess.TemplateVersionV1,
+		aireasoningprocess.TemplateVersionV2,
+		aireasoningprocess.TemplateVersionV3,
+	} {
+		if store.reconciled[index].ID != aireasoningprocess.TemplateID || store.reconciled[index].Version != version {
+			t.Fatalf("reconciled inventory[%d] = %+v, want %s@%s",
+				index, store.reconciled[index], aireasoningprocess.TemplateID, version)
+		}
 	}
 }
 

--- a/modules/card_template_catalog/runtime_startup_test.go
+++ b/modules/card_template_catalog/runtime_startup_test.go
@@ -120,19 +120,21 @@ func TestInitializeRuntimeCatalogReportsActiveTargetCountOnOverflow(t *testing.T
 	}
 }
 
-func TestInitializeRuntimeCatalogAcceptsStaticInteractiveActiveTargetWithoutRouteSpec(t *testing.T) {
+func TestInitializeRuntimeCatalogAcceptsRegisteredStaticReasoningTargets(t *testing.T) {
 	t.Setenv("OCTO_CARD_ACTION_ROUTES", "")
 	registry := cardtmpl.NewRegistry()
 	registry.RegisterJSON(aireasoningprocess.Assets, aireasoningprocess.HandoffRootV2)
+	registry.RegisterJSON(aireasoningprocess.Assets, aireasoningprocess.HandoffRootV3)
 	registry.Freeze()
-	store := &startupStoreStub{targets: []startupActivationTarget{{
-		ID: aireasoningprocess.TemplateID, Version: aireasoningprocess.TemplateVersionV2,
-	}}}
+	store := &startupStoreStub{targets: []startupActivationTarget{
+		{ID: aireasoningprocess.TemplateID, Version: aireasoningprocess.TemplateVersionV2},
+		{ID: aireasoningprocess.TemplateID, Version: aireasoningprocess.TemplateVersionV3},
+	}}
 	api := &API{store: store, registry: registry}
 	api.validateStateTarget = api.validateTarget
 
 	if err := api.initializeRuntimeCatalog(context.Background()); err != nil {
-		t.Fatalf("initialize static interactive active target: %v", err)
+		t.Fatalf("initialize registered static reasoning targets: %v", err)
 	}
 }
 

--- a/modules/card_template_catalog/state_validation_test.go
+++ b/modules/card_template_catalog/state_validation_test.go
@@ -73,6 +73,24 @@ func TestValidateTargetAllowsStaticInteractiveTemplateWithoutRouteSpec(t *testin
 	}
 }
 
+func TestValidateInteractiveTargetAllowsHiddenControlsSuccessorWithoutRouteSpec(t *testing.T) {
+	t.Setenv("OCTO_CARD_ACTION_ROUTES", "")
+	registry := cardtmpl.NewRegistry()
+	registry.RegisterJSON(aireasoningprocess.Assets, aireasoningprocess.HandoffRootV3)
+	registry.Freeze()
+
+	template, err := registry.Lookup(aireasoningprocess.TemplateID, aireasoningprocess.TemplateVersionV3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if contract := template.Meta().ActionContract; contract != nil {
+		t.Fatalf("0.3.0 ActionContract = %+v, want nil", contract)
+	}
+	if err := validateInteractiveTarget(template.Meta()); err != nil {
+		t.Fatalf("validate hidden-controls successor interaction contract: %v", err)
+	}
+}
+
 func TestValidateTargetRequiresConfiguredRouteForDynamicInteractiveTemplate(t *testing.T) {
 	t.Setenv("OCTO_CARD_ACTION_ROUTES", "")
 	artifact := integrationArtifactForVersion(t, "1.0.0")

--- a/modules/card_template_catalog/store_mysql_integration_test.go
+++ b/modules/card_template_catalog/store_mysql_integration_test.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl"
+	aireasoningprocess "github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl/ai_reasoning_process"
 	mysqldriver "github.com/go-sql-driver/mysql"
 	migrate "github.com/rubenv/sql-migrate"
 )
@@ -24,6 +25,50 @@ import (
 const catalogStoreIntegrationDBPrefix = "octo_card_catalog_store_test"
 
 var catalogStoreIntegrationDBSequence atomic.Uint64
+
+func TestStoreReconcileStaticV3ClaimsExactVersionAndRejectsDynamicCollisionRealMySQL(t *testing.T) {
+	db := newCatalogStoreIntegrationDB(t)
+	registry := cardtmpl.NewRegistry()
+	registry.RegisterJSON(aireasoningprocess.Assets, aireasoningprocess.HandoffRootV3)
+	registry.Freeze()
+	catalogStore := newStore(db)
+
+	if err := catalogStore.ReconcileStatic(context.Background(), registry.List()); err != nil {
+		t.Fatalf("ReconcileStatic V3: %v", err)
+	}
+	var source string
+	if err := db.QueryRow(`SELECT source FROM card_template_version_claim
+        WHERE template_id = ? AND version = ?`,
+		aireasoningprocess.TemplateID, aireasoningprocess.TemplateVersionV3).Scan(&source); err != nil {
+		t.Fatalf("query V3 static claim: %v", err)
+	}
+	if source != claimSourceStatic {
+		t.Fatalf("V3 claim source = %q, want %q", source, claimSourceStatic)
+	}
+	var artifactCount int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM card_template_artifact
+        WHERE template_id = ? AND version = ?`,
+		aireasoningprocess.TemplateID, aireasoningprocess.TemplateVersionV3).Scan(&artifactCount); err != nil {
+		t.Fatalf("count V3 dynamic artifacts: %v", err)
+	}
+	if artifactCount != 0 {
+		t.Fatalf("V3 dynamic artifact count = %d, want 0", artifactCount)
+	}
+
+	if _, err := db.Exec(`DELETE FROM card_template_version_claim
+        WHERE template_id = ? AND version = ?`,
+		aireasoningprocess.TemplateID, aireasoningprocess.TemplateVersionV3); err != nil {
+		t.Fatalf("remove V3 static claim fixture: %v", err)
+	}
+	if _, err := db.Exec(`INSERT INTO card_template_version_claim
+        (template_id, version, source) VALUES (?, ?, 'dynamic')`,
+		aireasoningprocess.TemplateID, aireasoningprocess.TemplateVersionV3); err != nil {
+		t.Fatalf("seed V3 dynamic collision: %v", err)
+	}
+	if err := catalogStore.ReconcileStatic(context.Background(), registry.List()); !errors.Is(err, ErrVersionClaimConflict) {
+		t.Fatalf("ReconcileStatic V3 collision error = %v, want ErrVersionClaimConflict", err)
+	}
+}
 
 func TestStorePublishRealMySQLImmutableConcurrency(t *testing.T) {
 	db := newCatalogStoreIntegrationDB(t)

--- a/modules/message/card_action_template_context_test.go
+++ b/modules/message/card_action_template_context_test.go
@@ -3,11 +3,13 @@ package message
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"testing"
 
 	"github.com/Mininglamp-OSS/octo-server/internal/cardactiondispatch"
 	"github.com/Mininglamp-OSS/octo-server/pkg/cardmsg"
 	"github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl"
+	aireasoningprocess "github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl/ai_reasoning_process"
 	docsaccessrequest "github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl/docs_access_request"
 )
 
@@ -92,6 +94,56 @@ func TestResolveRegistryCardContextUsesEffectiveMetadataAndReport(t *testing.T) 
 	legacy, err := resolveRegistryCardContext(context.Background(), access, []byte(`{"type":17,"card":{"body":[]}}`), "legacy", nil)
 	if err != nil || legacy != (cardactiondispatch.CardContext{}) {
 		t.Fatalf("legacy context = (%+v, %v)", legacy, err)
+	}
+}
+
+func TestResolveRegistryCardContextRejectsV3LegacyControlIDs(t *testing.T) {
+	registry := cardtmpl.NewRegistry()
+	registry.RegisterJSON(aireasoningprocess.Assets, aireasoningprocess.HandoffRootV3)
+	registry.Freeze()
+	static, err := cardtmpl.NewStaticCatalog(registry)
+	if err != nil {
+		t.Fatal(err)
+	}
+	previousCatalog := cardtmpl.DefaultCatalog()
+	cardtmpl.SetDefaultCatalog(static)
+	t.Cleanup(func() { cardtmpl.SetDefaultCatalog(previousCatalog) })
+
+	access := cardtmpl.CatalogAccess{
+		Purpose: cardtmpl.CatalogPurposeActionContext,
+		Principal: cardtmpl.CatalogPrincipal{
+			Kind: cardtmpl.CatalogPrincipalBot, ID: "bot-reasoning", SpaceID: "space-1",
+		},
+	}
+	for _, tc := range []struct {
+		state    cardtmpl.State
+		actionID string
+	}{
+		{state: "reasoning", actionID: "reasoning_stop"},
+		{state: "error", actionID: "reasoning_retry"},
+	} {
+		t.Run(string(tc.state)+"/"+tc.actionID, func(t *testing.T) {
+			sample, err := aireasoningprocess.Assets.ReadFile(
+				aireasoningprocess.HandoffRootV3 + "/samples/" + string(tc.state) + ".json")
+			if err != nil {
+				t.Fatal(err)
+			}
+			payload, err := registry.Render(context.Background(), aireasoningprocess.TemplateID,
+				aireasoningprocess.TemplateVersionV3, tc.state, sample,
+				cardtmpl.BuildEnv{Lang: "zh-CN", SpaceID: "space-1"})
+			if err != nil {
+				t.Fatal(err)
+			}
+			raw, err := json.Marshal(payload)
+			if err != nil {
+				t.Fatal(err)
+			}
+			_, err = resolveRegistryCardContext(context.Background(), access, raw, tc.actionID,
+				map[string]interface{}{"owner": "ai", "action_type": "reasoning.control"})
+			if !errors.Is(err, cardtmpl.ErrActionUnknown) {
+				t.Fatalf("resolve legacy action error = %v, want ErrActionUnknown", err)
+			}
+		})
 	}
 }
 

--- a/pkg/cardtmpl/ai_reasoning_process/card.go
+++ b/pkg/cardtmpl/ai_reasoning_process/card.go
@@ -1,7 +1,6 @@
-// Package aireasoningprocess wires the AI reasoning-process progress card
-// (ai.reasoning-process@0.1.0 and its bounded 0.2.0 successor) into the cardtmpl
-// base. Unlike the Go-authored L2a cards, this card ships as a pure JSON handoff
-// (roadmap E1): it has no
+// Package aireasoningprocess wires the AI reasoning-process progress card and
+// its immutable successors into the cardtmpl base. Unlike the Go-authored L2a
+// cards, this card ships as a pure JSON handoff (roadmap E1): it has no
 // hand-written Template — the base compiles its `.template.json` views via
 // Registry.RegisterJSON. This package only embeds the handoff assets and
 // exposes their identity for the composition root.
@@ -10,15 +9,13 @@
 //
 //	registry.RegisterJSON(aireasoningprocess.Assets, aireasoningprocess.HandoffRootV1)
 //	registry.RegisterJSON(aireasoningprocess.Assets, aireasoningprocess.HandoffRootV2)
-//	registry.SetDefault(aireasoningprocess.TemplateID, aireasoningprocess.TemplateVersionV2)
+//	registry.RegisterJSON(aireasoningprocess.Assets, aireasoningprocess.HandoffRootV3)
+//	registry.SetDefault(aireasoningprocess.TemplateID, aireasoningprocess.TemplateVersionV3)
 //
-// Layering: L1 JSON artifacts live under handoff/. The card carries the
-// producer's own action buttons (reasoning_stop / reasoning_retry Submit +
-// reasoning_toggle) under a fixed platform owner "ai" / action_type
-// "reasoning.control"; the active/error views are octo/v2, the display-only
-// result view is octo/v1. The server-side handler + RouteSpec that make the
-// buttons act (stop / retry a reasoning run) and the bot streaming delivery are
-// deliberately downstream — see the task brief cardtmpl-reasoning-progress-card.
+// Layering: L1 JSON artifacts live under handoff/. Frozen V1/V2 retain their
+// historical reasoning_stop/reasoning_retry Submit contracts. V3 removes those
+// unsupported server callbacks and keeps only the client-local reasoning_toggle;
+// active/error remain octo/v2 and result remains octo/v1.
 package aireasoningprocess
 
 import (
@@ -42,9 +39,13 @@ const (
 	// HandoffRootV2 and TemplateVersionV2 identify the bounded successor.
 	HandoffRootV2     = "handoff/ai.reasoning-process@0.2.0"
 	TemplateVersionV2 = "0.2.0"
+	// HandoffRootV3 and TemplateVersionV3 identify the successor that hides
+	// unsupported stop/retry controls while retaining the bounded V2 schema.
+	HandoffRootV3     = "handoff/ai.reasoning-process@0.3.0"
+	TemplateVersionV3 = "0.3.0"
 
 	// HandoffRoot and TemplateVersion retain the package's current-version
 	// aliases for callers that do not need an explicit historical version.
-	HandoffRoot     = HandoffRootV2
-	TemplateVersion = TemplateVersionV2
+	HandoffRoot     = HandoffRootV3
+	TemplateVersion = TemplateVersionV3
 )

--- a/pkg/cardtmpl/ai_reasoning_process/card_test.go
+++ b/pkg/cardtmpl/ai_reasoning_process/card_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardmsg"
 	"github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl"
 	aireasoningprocess "github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl/ai_reasoning_process"
 )
@@ -24,25 +25,34 @@ var reasoningStates = []struct {
 	{"error", "octo/v2"},
 }
 
+const (
+	reasoningVersionV3 = aireasoningprocess.TemplateVersionV3
+	reasoningRootV3    = aireasoningprocess.HandoffRootV3
+)
+
 var reasoningVersions = []struct {
 	version string
 	root    string
 }{
 	{aireasoningprocess.TemplateVersionV1, aireasoningprocess.HandoffRootV1},
 	{aireasoningprocess.TemplateVersionV2, aireasoningprocess.HandoffRootV2},
+	{reasoningVersionV3, reasoningRootV3},
 }
+
+var boundedReasoningVersions = reasoningVersions[1:]
 
 func newRegistry(t *testing.T) *cardtmpl.Registry {
 	t.Helper()
 	reg := cardtmpl.NewRegistry()
 	reg.RegisterJSON(aireasoningprocess.Assets, aireasoningprocess.HandoffRootV1)
 	reg.RegisterJSON(aireasoningprocess.Assets, aireasoningprocess.HandoffRootV2)
-	reg.SetDefault(aireasoningprocess.TemplateID, aireasoningprocess.TemplateVersionV2)
+	reg.RegisterJSON(aireasoningprocess.Assets, reasoningRootV3)
+	reg.SetDefault(aireasoningprocess.TemplateID, reasoningVersionV3)
 	reg.Freeze()
 	return reg
 }
 
-func TestRegistersBothVersionsAndDefaultsToSuccessor(t *testing.T) {
+func TestRegistersAllVersionsAndDefaultsToHiddenControlsSuccessor(t *testing.T) {
 	reg := newRegistry(t)
 	var versions []string
 	for _, meta := range reg.List() {
@@ -50,27 +60,41 @@ func TestRegistersBothVersionsAndDefaultsToSuccessor(t *testing.T) {
 			continue
 		}
 		versions = append(versions, meta.Version)
+		if meta.Version == reasoningVersionV3 {
+			if meta.ActionContract != nil {
+				t.Fatalf("%s ActionContract = %+v, want nil", meta.Version, meta.ActionContract)
+			}
+			continue
+		}
 		if meta.ActionContract == nil || meta.ActionContract.Owner != "ai" ||
 			meta.ActionContract.ActionType != "reasoning.control" {
-			t.Fatalf("%s ActionContract = %+v, want {ai, reasoning.control}", meta.Version, meta.ActionContract)
+			t.Fatalf("historical %s ActionContract = %+v, want {ai, reasoning.control}", meta.Version, meta.ActionContract)
 		}
 	}
 	sort.Strings(versions)
-	wantVersions := []string{aireasoningprocess.TemplateVersionV1, aireasoningprocess.TemplateVersionV2}
+	wantVersions := []string{
+		aireasoningprocess.TemplateVersionV1,
+		aireasoningprocess.TemplateVersionV2,
+		reasoningVersionV3,
+	}
 	if !equalStrings(versions, wantVersions) {
 		t.Fatalf("registered versions = %v, want %v", versions, wantVersions)
+	}
+	if aireasoningprocess.TemplateVersion != reasoningVersionV3 || aireasoningprocess.HandoffRoot != reasoningRootV3 {
+		t.Fatalf("current aliases = %s / %s, want %s / %s",
+			aireasoningprocess.TemplateVersion, aireasoningprocess.HandoffRoot, reasoningVersionV3, reasoningRootV3)
 	}
 
 	tmpl, err := reg.Lookup(aireasoningprocess.TemplateID, "")
 	if err != nil {
 		t.Fatalf("Lookup(default): %v", err)
 	}
-	if got := tmpl.Meta().Version; got != aireasoningprocess.TemplateVersionV2 {
-		t.Fatalf("default version = %q, want %q", got, aireasoningprocess.TemplateVersionV2)
+	if got := tmpl.Meta().Version; got != reasoningVersionV3 {
+		t.Fatalf("default version = %q, want %q", got, reasoningVersionV3)
 	}
 }
 
-func TestRenderAllStatesForBothVersions(t *testing.T) {
+func TestRenderAllStatesForAllVersions(t *testing.T) {
 	reg := newRegistry(t)
 	for _, version := range reasoningVersions {
 		for _, tc := range reasoningStates {
@@ -90,7 +114,7 @@ func TestRenderAllStatesForBothVersions(t *testing.T) {
 	}
 }
 
-func TestConformanceForBothVersions(t *testing.T) {
+func TestConformanceForAllVersions(t *testing.T) {
 	reg := newRegistry(t)
 	for _, version := range reasoningVersions {
 		for _, tc := range reasoningStates {
@@ -122,6 +146,193 @@ func TestConformanceForBothVersions(t *testing.T) {
 	}
 }
 
+func TestHiddenControlsSuccessorArtifactContract(t *testing.T) {
+	manifest := readAssetMap(t, reasoningRootV3+"/manifest.json")
+	for key, want := range map[string]string{
+		"id":                         string(aireasoningprocess.TemplateID),
+		"version":                    reasoningVersionV3,
+		"contractVersion":            "1.1.0",
+		"protocol":                   "octo-card@1.0",
+		"adaptiveCardVersion":        "1.5",
+		"renderProfile":              "octo-chat@1.2.0-rc.1",
+		"renderProfileCompatibility": "octo-chat/v1",
+		"owner":                      "ai",
+	} {
+		if got, _ := manifest[key].(string); got != want {
+			t.Fatalf("manifest.%s = %q, want %q", key, got, want)
+		}
+	}
+	if _, exists := manifest["actionType"]; exists {
+		t.Fatal("0.3.0 manifest must not advertise actionType")
+	}
+
+	if got, want := readAsset(t, reasoningRootV3+"/contract/data.schema.json"),
+		readAsset(t, aireasoningprocess.HandoffRootV2+"/contract/data.schema.json"); !bytes.Equal(got, want) {
+		t.Fatal("0.3.0 schema drifted from bounded 0.2.0 schema")
+	}
+	for _, relative := range []string{
+		"templates/result.template.json",
+		"samples/reasoning.json",
+		"samples/answering.json",
+		"samples/completed.json",
+		"samples/stopped.json",
+		"goldens/completed.card.json",
+		"goldens/stopped.card.json",
+	} {
+		if got, want := readAsset(t, reasoningRootV3+"/"+relative),
+			readAsset(t, aireasoningprocess.HandoffRootV2+"/"+relative); !bytes.Equal(got, want) {
+			t.Fatalf("0.3.0 artifact %s drifted from 0.2.0", relative)
+		}
+	}
+
+	legacyError := readAssetMap(t, aireasoningprocess.HandoffRootV2+"/samples/error.json")
+	successorError := readAssetMap(t, reasoningRootV3+"/samples/error.json")
+	if got, _ := successorError["errorMessage"].(string); got != "推理服务连接超时，已停止本次生成。已完成的过程会保留。" {
+		t.Fatalf("0.3.0 errorMessage = %q", got)
+	}
+	successorError["errorMessage"] = legacyError["errorMessage"]
+	if got, want := canon(t, successorError), canon(t, legacyError); got != want {
+		t.Fatalf("0.3.0 error sample has changes beyond retry invitation\ngot=%s\nwant=%s", got, want)
+	}
+}
+
+func TestHiddenControlsSuccessorHasOnlyLocalToggle(t *testing.T) {
+	reg := newRegistry(t)
+	tmpl, err := reg.Lookup(aireasoningprocess.TemplateID, reasoningVersionV3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	meta := tmpl.Meta()
+	if meta.ActionContract != nil {
+		t.Fatalf("ActionContract = %+v, want nil", meta.ActionContract)
+	}
+	for _, view := range []cardtmpl.ViewKey{"active", "error"} {
+		report, ok := meta.Interaction(view)
+		if !ok {
+			t.Fatalf("interaction report missing for %s", view)
+		}
+		if len(report.Actions) != 1 || report.Actions[0].ID != "reasoning_toggle" ||
+			report.Actions[0].Type != "Action.ToggleVisibility" || len(report.Inputs) != 0 {
+			t.Fatalf("%s interaction report = %+v", view, report)
+		}
+	}
+	if _, ok := meta.Interaction("result"); ok {
+		t.Fatal("octo/v1 result view must not have an interaction report")
+	}
+
+	for _, tc := range reasoningStates {
+		t.Run(string(tc.state), func(t *testing.T) {
+			payload, err := reg.Render(context.Background(), aireasoningprocess.TemplateID,
+				reasoningVersionV3, tc.state, readSample(t, reasoningRootV3, string(tc.state)),
+				cardtmpl.BuildEnv{Lang: "zh-CN", SpaceID: "space-x"})
+			if err != nil {
+				t.Fatal(err)
+			}
+			encoded, err := json.Marshal(payload)
+			if err != nil {
+				t.Fatal(err)
+			}
+			for _, forbidden := range []string{
+				"Action.Submit", "reasoning_stop", "reasoning_retry",
+				"stop_reasoning", "retry_reasoning", "可以重试",
+			} {
+				if bytes.Contains(encoded, []byte(forbidden)) {
+					t.Fatalf("rendered payload contains unsupported control %q", forbidden)
+				}
+			}
+			var actions []map[string]any
+			collectActions(payload, &actions)
+			if len(actions) != 1 {
+				t.Fatalf("rendered actions = %+v, want one local toggle", actions)
+			}
+			action := actions[0]
+			if action["type"] != "Action.ToggleVisibility" || action["id"] != "reasoning_toggle" {
+				t.Fatalf("rendered action = %+v", action)
+			}
+			if got := canon(t, action["targetElements"]); got != canon(t, []any{"trace_panel", "collapsed_panel"}) {
+				t.Fatalf("toggle targets = %s", got)
+			}
+		})
+	}
+}
+
+func TestHiddenControlsSuccessorRejectsLegacySubmitIDs(t *testing.T) {
+	reg := newRegistry(t)
+	catalog, err := cardtmpl.NewStaticCatalog(reg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, tc := range []struct {
+		state    cardtmpl.State
+		actionID string
+	}{
+		{state: "reasoning", actionID: "reasoning_stop"},
+		{state: "answering", actionID: "reasoning_stop"},
+		{state: "error", actionID: "reasoning_retry"},
+	} {
+		t.Run(string(tc.state)+"/"+tc.actionID, func(t *testing.T) {
+			payload, err := reg.Render(context.Background(), aireasoningprocess.TemplateID,
+				reasoningVersionV3, tc.state, readSample(t, reasoningRootV3, string(tc.state)),
+				cardtmpl.BuildEnv{Lang: "zh-CN", SpaceID: "space-x"})
+			if err != nil {
+				t.Fatal(err)
+			}
+			encoded, err := json.Marshal(payload)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, found := cardmsg.SubmitAction(encoded, tc.actionID); found {
+				t.Fatalf("legacy action %q resolved from V3 %s frame", tc.actionID, tc.state)
+			}
+			_, err = catalog.ActionContext(context.Background(), cardtmpl.CatalogActionRequest{
+				CatalogExactRequest: cardtmpl.CatalogExactRequest{
+					Access: cardtmpl.CatalogAccess{Purpose: cardtmpl.CatalogPurposeActionContext},
+					ID:     aireasoningprocess.TemplateID, Version: reasoningVersionV3,
+				},
+				ActionID: tc.actionID,
+			})
+			if !errors.Is(err, cardtmpl.ErrActionUnknown) {
+				t.Fatalf("legacy action %q ActionContext error = %v, want ErrActionUnknown", tc.actionID, err)
+			}
+		})
+	}
+}
+
+func TestHiddenControlsSuccessorStaticExactRenderSurvivesRuntimeStoreOutage(t *testing.T) {
+	reg := newRegistry(t)
+	store := &unavailableRuntimeStore{}
+	catalog, err := cardtmpl.NewRuntimeCatalog(reg, store, cardtmpl.RuntimeCatalogConfig{
+		CheckReady: func() error { return cardtmpl.ErrRuntimeCatalogUnavailable },
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload, err := catalog.Render(context.Background(), cardtmpl.CatalogRenderRequest{
+		Access: cardtmpl.CatalogAccess{
+			Purpose: cardtmpl.CatalogPurposeHistoricalEdit,
+			Principal: cardtmpl.CatalogPrincipal{
+				Kind: cardtmpl.CatalogPrincipalBot, ID: "bot-test", SpaceID: "space-x",
+			},
+		},
+		ID: aireasoningprocess.TemplateID, Version: reasoningVersionV3,
+		State: "completed", Fields: readSample(t, reasoningRootV3, "completed"),
+		Env: cardtmpl.BuildEnv{Lang: "zh-CN", SpaceID: "space-x"},
+	})
+	if err != nil {
+		t.Fatalf("explicit static render during runtime store outage: %v", err)
+	}
+	if store.calls != 0 {
+		t.Fatalf("explicit static render made %d runtime store calls", store.calls)
+	}
+	card := payload["card"].(map[string]any)
+	metadata := card["metadata"].(map[string]any)
+	octo := metadata["octo"].(map[string]any)
+	template := octo["template"].(map[string]any)
+	if got := template["version"]; got != reasoningVersionV3 {
+		t.Fatalf("rendered template version = %v", got)
+	}
+}
+
 func TestSuccessorFreeStringBounds(t *testing.T) {
 	reg := newRegistry(t)
 	setTop := func(key string) func(map[string]any, string) {
@@ -145,21 +356,23 @@ func TestSuccessorFreeStringBounds(t *testing.T) {
 		{name: "errorMessage", limit: 121, set: setTop("errorMessage")},
 	}
 	units := []string{"x", "界", "😀"}
-	for i, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			unit := units[i%len(units)]
-			exact := readSampleMap(t, aireasoningprocess.HandoffRootV2, "reasoning")
-			tc.set(exact, strings.Repeat(unit, tc.limit))
-			if err := renderData(reg, "reasoning", exact); err != nil {
-				t.Fatalf("exact %d-rune value rejected: %v", tc.limit, err)
-			}
+	for _, version := range boundedReasoningVersions {
+		for i, tc := range tests {
+			t.Run(version.version+"/"+tc.name, func(t *testing.T) {
+				unit := units[i%len(units)]
+				exact := readSampleMap(t, version.root, "reasoning")
+				tc.set(exact, strings.Repeat(unit, tc.limit))
+				if err := renderData(reg, version.version, "reasoning", exact); err != nil {
+					t.Fatalf("exact %d-rune value rejected: %v", tc.limit, err)
+				}
 
-			over := readSampleMap(t, aireasoningprocess.HandoffRootV2, "reasoning")
-			tc.set(over, strings.Repeat(unit, tc.limit+1))
-			if err := renderData(reg, "reasoning", over); !errors.Is(err, cardtmpl.ErrFieldsInvalid) {
-				t.Fatalf("%d-rune value error = %v, want ErrFieldsInvalid", tc.limit+1, err)
-			}
-		})
+				over := readSampleMap(t, version.root, "reasoning")
+				tc.set(over, strings.Repeat(unit, tc.limit+1))
+				if err := renderData(reg, version.version, "reasoning", over); !errors.Is(err, cardtmpl.ErrFieldsInvalid) {
+					t.Fatalf("%d-rune value error = %v, want ErrFieldsInvalid", tc.limit+1, err)
+				}
+			})
+		}
 	}
 }
 
@@ -178,44 +391,48 @@ func TestSuccessorArrayAndAggregateBounds(t *testing.T) {
 		{name: "aggregate thirteen with each phase under per-phase max", actionCounts: []int{3, 2, 2, 2, 2, 2}},
 		{name: "aggregate fourteen with each phase under per-phase max", actionCounts: []int{4, 2, 2, 2, 2, 2}, wantErr: true},
 	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			data := readSampleMap(t, aireasoningprocess.HandoffRootV2, "reasoning")
-			data["phases"] = phasesWithActionCounts(tc.actionCounts...)
-			err := renderData(reg, "reasoning", data)
-			if tc.wantErr {
-				if !errors.Is(err, cardtmpl.ErrFieldsInvalid) {
-					t.Fatalf("Render error = %v, want ErrFieldsInvalid", err)
+	for _, version := range boundedReasoningVersions {
+		for _, tc := range tests {
+			t.Run(version.version+"/"+tc.name, func(t *testing.T) {
+				data := readSampleMap(t, version.root, "reasoning")
+				data["phases"] = phasesWithActionCounts(tc.actionCounts...)
+				err := renderData(reg, version.version, "reasoning", data)
+				if tc.wantErr {
+					if !errors.Is(err, cardtmpl.ErrFieldsInvalid) {
+						t.Fatalf("Render error = %v, want ErrFieldsInvalid", err)
+					}
+					return
 				}
-				return
-			}
-			if err != nil {
-				t.Fatalf("Render: %v", err)
-			}
-		})
+				if err != nil {
+					t.Fatalf("Render: %v", err)
+				}
+			})
+		}
 	}
 }
 
 func TestSuccessorWorstCaseRendersEveryView(t *testing.T) {
 	reg := newRegistry(t)
-	for _, tc := range reasoningStates {
-		t.Run(string(tc.state), func(t *testing.T) {
-			data := readSampleMap(t, aireasoningprocess.HandoffRootV2, "reasoning")
-			data["state"] = string(tc.state)
-			data["reasoningId"] = strings.Repeat("r", 512)
-			data["title"] = strings.Repeat("题", 64)
-			data["statusLabel"] = strings.Repeat("状", 32)
-			data["timerText"] = strings.Repeat("时", 128)
-			data["collapsedSummary"] = strings.Repeat("摘", 160)
-			data["progressText"] = strings.Repeat("进", 160)
-			data["errorTitle"] = strings.Repeat("错", 64)
-			data["errorMessage"] = strings.Repeat("误", 121)
-			data["phases"] = worstCasePhases()
+	for _, version := range boundedReasoningVersions {
+		for _, tc := range reasoningStates {
+			t.Run(version.version+"/"+string(tc.state), func(t *testing.T) {
+				data := readSampleMap(t, version.root, "reasoning")
+				data["state"] = string(tc.state)
+				data["reasoningId"] = strings.Repeat("r", 512)
+				data["title"] = strings.Repeat("题", 64)
+				data["statusLabel"] = strings.Repeat("状", 32)
+				data["timerText"] = strings.Repeat("时", 128)
+				data["collapsedSummary"] = strings.Repeat("摘", 160)
+				data["progressText"] = strings.Repeat("进", 160)
+				data["errorTitle"] = strings.Repeat("错", 64)
+				data["errorMessage"] = strings.Repeat("误", 121)
+				data["phases"] = worstCasePhases()
 
-			if err := renderData(reg, tc.state, data); err != nil {
-				t.Fatalf("worst-case %s render: %v", tc.state, err)
-			}
-		})
+				if err := renderData(reg, version.version, tc.state, data); err != nil {
+					t.Fatalf("worst-case %s render: %v", tc.state, err)
+				}
+			})
+		}
 	}
 }
 
@@ -288,13 +505,13 @@ func worstCasePhases() []any {
 	return phases
 }
 
-func renderData(reg *cardtmpl.Registry, state cardtmpl.State, data map[string]any) error {
+func renderData(reg *cardtmpl.Registry, version string, state cardtmpl.State, data map[string]any) error {
 	raw, err := json.Marshal(data)
 	if err != nil {
 		return err
 	}
 	_, err = reg.Render(context.Background(), aireasoningprocess.TemplateID,
-		aireasoningprocess.TemplateVersionV2, state, raw,
+		version, state, raw,
 		cardtmpl.BuildEnv{Lang: "zh-CN", SpaceID: "space-x"})
 	return err
 }
@@ -322,6 +539,15 @@ func readGolden(t *testing.T, root, name string) map[string]any {
 	return golden
 }
 
+func readAssetMap(t *testing.T, name string) map[string]any {
+	t.Helper()
+	var value map[string]any
+	if err := json.Unmarshal(readAsset(t, name), &value); err != nil {
+		t.Fatalf("unmarshal asset %s: %v", name, err)
+	}
+	return value
+}
+
 func readAsset(t *testing.T, name string) []byte {
 	t.Helper()
 	b, err := aireasoningprocess.Assets.ReadFile(name)
@@ -329,6 +555,41 @@ func readAsset(t *testing.T, name string) []byte {
 		t.Fatalf("read asset %s: %v", name, err)
 	}
 	return b
+}
+
+func collectActions(value any, actions *[]map[string]any) {
+	switch typed := value.(type) {
+	case map[string]any:
+		if kind, _ := typed["type"].(string); strings.HasPrefix(kind, "Action.") {
+			*actions = append(*actions, typed)
+		}
+		for _, child := range typed {
+			collectActions(child, actions)
+		}
+	case []any:
+		for _, child := range typed {
+			collectActions(child, actions)
+		}
+	}
+}
+
+type unavailableRuntimeStore struct {
+	calls int
+}
+
+func (s *unavailableRuntimeStore) LoadActivation(context.Context, cardtmpl.ID) (cardtmpl.RuntimeActivation, error) {
+	s.calls++
+	return cardtmpl.RuntimeActivation{}, errors.New("runtime store unavailable")
+}
+
+func (s *unavailableRuntimeStore) LoadArtifactMeta(context.Context, cardtmpl.ID, string) (cardtmpl.RuntimeArtifactMeta, error) {
+	s.calls++
+	return cardtmpl.RuntimeArtifactMeta{}, errors.New("runtime store unavailable")
+}
+
+func (s *unavailableRuntimeStore) LoadArtifactBundle(context.Context, cardtmpl.ID, string, string) (cardtmpl.CanonicalBundle, error) {
+	s.calls++
+	return nil, errors.New("runtime store unavailable")
 }
 
 func mustState(t *testing.T, fields json.RawMessage) string {

--- a/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.3.0/contract/data.schema.json
+++ b/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.3.0/contract/data.schema.json
@@ -1,0 +1,263 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "推理过程卡数据契约",
+  "description": "AI 推理过程附件的展示型 ViewModel。消息作者、头像、时间与最终 Markdown 回答由消息容器负责，不进入卡片契约。",
+  "type": "object",
+  "additionalProperties": false,
+  "x-octo-constraints": {
+    "aggregateArrayLimits": [
+      {
+        "parentArray": "phases",
+        "childArray": "actions",
+        "maxTotalItems": 13
+      }
+    ]
+  },
+  "required": [
+    "reasoningId",
+    "state",
+    "title",
+    "statusLabel",
+    "statusTone",
+    "timerText",
+    "traceExpanded",
+    "traceCollapsed",
+    "collapsedSummary",
+    "phases"
+  ],
+  "properties": {
+    "reasoningId": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 512,
+      "description": "本轮推理的稳定标识，会随停止或重试动作回传。",
+      "examples": [
+        "reasoning-channel-b-001"
+      ]
+    },
+    "state": {
+      "type": "string",
+      "enum": [
+        "reasoning",
+        "answering",
+        "completed",
+        "stopped",
+        "error"
+      ],
+      "description": "卡片当前状态；宿主据此选择 active、result 或 error View。"
+    },
+    "title": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 64,
+      "description": "推理卡标题。",
+      "examples": [
+        "已深度思考"
+      ]
+    },
+    "statusLabel": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 32,
+      "description": "面向用户的状态文案。"
+    },
+    "statusTone": {
+      "type": "string",
+      "enum": [
+        "Accent",
+        "Good",
+        "Warning",
+        "Attention"
+      ],
+      "description": "Adaptive Cards 标准语义色。"
+    },
+    "timerText": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 128,
+      "description": "耗时、阶段数和工具调用数的展示文案。"
+    },
+    "traceExpanded": {
+      "type": "boolean",
+      "description": "初始是否展示推理明细。"
+    },
+    "traceCollapsed": {
+      "type": "boolean",
+      "description": "初始是否展示收起摘要；应与 traceExpanded 互斥。"
+    },
+    "collapsedSummary": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 160,
+      "description": "推理明细收起时的摘要。"
+    },
+    "progressText": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 160,
+      "description": "活动态底部的实时进度提示。"
+    },
+    "phases": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 6,
+      "description": "按发生顺序排列的推理阶段。仅包含可向用户展示的过程摘要，不承载隐藏的模型内部思维。",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "thought",
+          "actions"
+        ],
+        "properties": {
+          "thought": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 281,
+            "description": "该阶段面向用户的推理摘要。"
+          },
+          "actions": {
+            "type": "array",
+            "minItems": 1,
+            "maxItems": 12,
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "tool",
+                "detail",
+                "statusGlyph",
+                "statusTone"
+              ],
+              "properties": {
+                "tool": {
+                  "type": "string",
+                  "minLength": 1,
+                  "maxLength": 81,
+                  "description": "工具或步骤名称。"
+                },
+                "detail": {
+                  "type": "string",
+                  "minLength": 1,
+                  "maxLength": 192,
+                  "description": "已脱敏的调用摘要。"
+                },
+                "statusGlyph": {
+                  "type": "string",
+                  "minLength": 1,
+                  "maxLength": 2,
+                  "description": "调用状态符号，例如 ●。"
+                },
+                "statusTone": {
+                  "type": "string",
+                  "enum": [
+                    "Accent",
+                    "Good",
+                    "Attention"
+                  ],
+                  "description": "工具调用状态的标准语义色。"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "errorTitle": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 64,
+      "description": "失败态标题。"
+    },
+    "errorMessage": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 121,
+      "description": "失败原因与用户可采取动作。"
+    }
+  },
+  "allOf": [
+    {
+      "oneOf": [
+        {
+          "properties": {
+            "traceExpanded": {
+              "const": true
+            },
+            "traceCollapsed": {
+              "const": false
+            }
+          }
+        },
+        {
+          "properties": {
+            "traceExpanded": {
+              "const": false
+            },
+            "traceCollapsed": {
+              "const": true
+            }
+          }
+        }
+      ]
+    },
+    {
+      "if": {
+        "properties": {
+          "state": {
+            "enum": [
+              "reasoning",
+              "answering"
+            ]
+          }
+        }
+      },
+      "then": {
+        "required": [
+          "progressText"
+        ]
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "state": {
+            "const": "error"
+          }
+        }
+      },
+      "then": {
+        "required": [
+          "errorTitle",
+          "errorMessage"
+        ]
+      }
+    }
+  ],
+  "examples": [
+    {
+      "reasoningId": "reasoning-channel-b-001",
+      "state": "completed",
+      "title": "已深度思考",
+      "statusLabel": "已完成",
+      "statusTone": "Good",
+      "timerText": "用时 12 秒 · 3 段推理 · 13 次工具调用",
+      "traceExpanded": false,
+      "traceCollapsed": true,
+      "collapsedSummary": "已思考 12 秒 · 推理过程已收起",
+      "phases": [
+        {
+          "thought": "先拆解漏斗并核对近 90 天数据。",
+          "actions": [
+            {
+              "tool": "query_metrics",
+              "detail": "channel=B · range=90d",
+              "statusGlyph": "●",
+              "statusTone": "Good"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.3.0/goldens/answering.card.json
+++ b/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.3.0/goldens/answering.card.json
@@ -1,0 +1,682 @@
+{
+  "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+  "type": "AdaptiveCard",
+  "version": "1.5",
+  "body": [
+    {
+      "type": "Container",
+      "id": "octo-surface-accent-header-reasoning-active",
+      "style": "accent",
+      "bleed": true,
+      "spacing": "None",
+      "items": [
+        {
+          "type": "ColumnSet",
+          "spacing": "None",
+          "columns": [
+            {
+              "type": "Column",
+              "width": "stretch",
+              "verticalContentAlignment": "Center",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "text": "✦  已深度思考",
+                  "color": "Accent",
+                  "weight": "Bolder",
+                  "wrap": true,
+                  "spacing": "None"
+                },
+                {
+                  "type": "TextBlock",
+                  "text": "正在生成回答…",
+                  "size": "Small",
+                  "isSubtle": true,
+                  "wrap": true,
+                  "spacing": "Small"
+                }
+              ]
+            },
+            {
+              "type": "Column",
+              "width": "auto",
+              "verticalContentAlignment": "Center",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "id": "octo-badge-reasoning-active-status",
+                  "text": "回答中",
+                  "color": "Accent",
+                  "weight": "Bolder",
+                  "size": "Small",
+                  "wrap": true,
+                  "spacing": "None"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "id": "trace_panel",
+      "isVisible": true,
+      "spacing": "Large",
+      "items": [
+        {
+          "type": "Container",
+          "spacing": "None",
+          "separator": false,
+          "items": [
+            {
+              "type": "TextBlock",
+              "text": "先拆分线索、试用激活与付费三段漏斗，核对近 90 天数据。",
+              "size": "Small",
+              "wrap": true,
+              "spacing": "None"
+            },
+            {
+              "type": "Container",
+              "style": "emphasis",
+              "spacing": "Small",
+              "items": [
+                {
+                  "type": "ColumnSet",
+                  "spacing": "None",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "query_metrics",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "channel=B · range=90d · group=stage",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "read_file",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "~/analytics/funnel_definition.sql · ×2",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "run_sql",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "按漏斗阶段汇总数量与转化率",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "Container",
+          "spacing": "Large",
+          "separator": true,
+          "items": [
+            {
+              "type": "TextBlock",
+              "text": "激活率的降幅高于线索量，交叉核验行业结构、客服工单、NPS 与季节性。",
+              "size": "Small",
+              "wrap": true,
+              "spacing": "None"
+            },
+            {
+              "type": "Container",
+              "style": "emphasis",
+              "spacing": "Small",
+              "items": [
+                {
+                  "type": "ColumnSet",
+                  "spacing": "None",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "query_metrics",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "按行业拆分激活率",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "search_tickets",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "渠道 B · 试用 / 激活失败 · 近 60 天",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "read_file",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "~/nps/2026Q2_channelB.csv",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "query_metrics",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "叠加节假日与季节性校正",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "Container",
+          "spacing": "Large",
+          "separator": true,
+          "items": [
+            {
+              "type": "TextBlock",
+              "text": "主因确认：教育与专业服务合计贡献 63% 降幅，激活断点集中在试用权益触达。",
+              "size": "Small",
+              "wrap": true,
+              "spacing": "None"
+            },
+            {
+              "type": "Container",
+              "style": "emphasis",
+              "spacing": "Small",
+              "items": [
+                {
+                  "type": "ColumnSet",
+                  "spacing": "None",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "run_sql",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "按行业汇总转化降幅贡献",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "edit_file",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "~/reports/channelB_rootcause.md · 已编辑",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Accent",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "think",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "正在组织结论、证据与下周建议…",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "TextBlock",
+          "text": "◌  推理已完成，正在生成回答…",
+          "color": "Accent",
+          "size": "Small",
+          "wrap": true,
+          "spacing": "Large"
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "id": "collapsed_panel",
+      "isVisible": false,
+      "spacing": "Medium",
+      "items": [
+        {
+          "type": "TextBlock",
+          "text": "✓  推理已完成 · 回答正在生成",
+          "size": "Small",
+          "isSubtle": true,
+          "wrap": true,
+          "spacing": "None"
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "id": "octo-surface-default-footer-reasoning-active",
+      "style": "emphasis",
+      "bleed": true,
+      "separator": true,
+      "spacing": "Large",
+      "items": [
+        {
+          "type": "ActionSet",
+          "horizontalAlignment": "Right",
+          "actions": [
+            {
+              "type": "Action.ToggleVisibility",
+              "id": "reasoning_toggle",
+              "title": "显示 / 隐藏推理",
+              "targetElements": [
+                "trace_panel",
+                "collapsed_panel"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.3.0/goldens/completed.card.json
+++ b/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.3.0/goldens/completed.card.json
@@ -1,0 +1,784 @@
+{
+  "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+  "type": "AdaptiveCard",
+  "version": "1.5",
+  "body": [
+    {
+      "type": "Container",
+      "id": "octo-surface-accent-header-reasoning-result",
+      "style": "accent",
+      "bleed": true,
+      "spacing": "None",
+      "items": [
+        {
+          "type": "ColumnSet",
+          "spacing": "None",
+          "columns": [
+            {
+              "type": "Column",
+              "width": "stretch",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "text": "✦  已深度思考",
+                  "color": "Accent",
+                  "weight": "Bolder",
+                  "wrap": true,
+                  "spacing": "None"
+                },
+                {
+                  "type": "TextBlock",
+                  "text": "用时 12 秒 · 3 段推理 · 13 次工具调用",
+                  "size": "Small",
+                  "isSubtle": true,
+                  "wrap": true,
+                  "spacing": "Small"
+                }
+              ]
+            },
+            {
+              "type": "Column",
+              "width": "auto",
+              "verticalContentAlignment": "Center",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "id": "octo-badge-reasoning-result-status",
+                  "text": "已完成",
+                  "color": "Good",
+                  "weight": "Bolder",
+                  "size": "Small",
+                  "wrap": true,
+                  "spacing": "None"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "id": "trace_panel",
+      "isVisible": false,
+      "spacing": "Large",
+      "items": [
+        {
+          "type": "Container",
+          "spacing": "None",
+          "separator": false,
+          "items": [
+            {
+              "type": "TextBlock",
+              "text": "先把渠道 B 转化下降的范围圈出来：拆成线索、试用激活、付费三段漏斗，取近 90 天数据。",
+              "size": "Small",
+              "wrap": true,
+              "spacing": "None"
+            },
+            {
+              "type": "Container",
+              "style": "emphasis",
+              "spacing": "Small",
+              "items": [
+                {
+                  "type": "ColumnSet",
+                  "spacing": "None",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "query_metrics",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "channel=B · range=90d · group=stage",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "read_file",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "~/analytics/funnel_definition.sql · ×2",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "run_sql",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "按漏斗阶段汇总数量与转化率",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "Container",
+          "spacing": "Large",
+          "separator": true,
+          "items": [
+            {
+              "type": "TextBlock",
+              "text": "激活率的降幅高于线索量，交叉核验行业结构、客服工单、NPS 与季节性。",
+              "size": "Small",
+              "wrap": true,
+              "spacing": "None"
+            },
+            {
+              "type": "Container",
+              "style": "emphasis",
+              "spacing": "Small",
+              "items": [
+                {
+                  "type": "ColumnSet",
+                  "spacing": "None",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "query_metrics",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "按行业拆分激活率",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "run_sql",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "对比各行业激活与付费转化",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "search_tickets",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "渠道 B · 试用 / 激活失败 · 近 60 天",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "read_file",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "~/nps/2026Q2_channelB.csv",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "query_metrics",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "叠加节假日与季节性校正",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "run_sql",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "逐周复核线索与激活数量",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "web_search",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "SaaS 行业 2026 试用政策调整",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "Container",
+          "spacing": "Large",
+          "separator": true,
+          "items": [
+            {
+              "type": "TextBlock",
+              "text": "主因确认：教育与专业服务合计贡献 63% 降幅，激活断点集中在试用权益触达。",
+              "size": "Small",
+              "wrap": true,
+              "spacing": "None"
+            },
+            {
+              "type": "Container",
+              "style": "emphasis",
+              "spacing": "Small",
+              "items": [
+                {
+                  "type": "ColumnSet",
+                  "spacing": "None",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "run_sql",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "按行业汇总转化降幅贡献",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "edit_file",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "~/reports/channelB_rootcause.md · 已编辑",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "think",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "拆分行业漏斗深挖与权益触达复盘",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "id": "collapsed_panel",
+      "isVisible": true,
+      "spacing": "Medium",
+      "items": [
+        {
+          "type": "TextBlock",
+          "text": "✓  已思考 12 秒 · 推理过程已收起",
+          "size": "Small",
+          "isSubtle": true,
+          "wrap": true,
+          "spacing": "None"
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "id": "octo-surface-default-footer-reasoning-result",
+      "style": "emphasis",
+      "bleed": true,
+      "separator": true,
+      "spacing": "Large",
+      "items": [
+        {
+          "type": "ActionSet",
+          "horizontalAlignment": "Right",
+          "actions": [
+            {
+              "type": "Action.ToggleVisibility",
+              "id": "reasoning_toggle",
+              "title": "显示 / 隐藏推理",
+              "targetElements": [
+                "trace_panel",
+                "collapsed_panel"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.3.0/goldens/error.card.json
+++ b/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.3.0/goldens/error.card.json
@@ -1,0 +1,408 @@
+{
+  "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+  "type": "AdaptiveCard",
+  "version": "1.5",
+  "body": [
+    {
+      "type": "Container",
+      "id": "octo-surface-accent-header-reasoning-error",
+      "style": "accent",
+      "bleed": true,
+      "spacing": "None",
+      "items": [
+        {
+          "type": "ColumnSet",
+          "spacing": "None",
+          "columns": [
+            {
+              "type": "Column",
+              "width": "stretch",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "text": "✦  已深度思考",
+                  "color": "Accent",
+                  "weight": "Bolder",
+                  "wrap": true,
+                  "spacing": "None"
+                },
+                {
+                  "type": "TextBlock",
+                  "text": "已中断",
+                  "size": "Small",
+                  "isSubtle": true,
+                  "wrap": true,
+                  "spacing": "Small"
+                }
+              ]
+            },
+            {
+              "type": "Column",
+              "width": "auto",
+              "verticalContentAlignment": "Center",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "id": "octo-badge-reasoning-error-status",
+                  "text": "生成失败",
+                  "color": "Attention",
+                  "weight": "Bolder",
+                  "size": "Small",
+                  "wrap": true,
+                  "spacing": "None"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "id": "trace_panel",
+      "isVisible": true,
+      "spacing": "Large",
+      "items": [
+        {
+          "type": "Container",
+          "spacing": "None",
+          "separator": false,
+          "items": [
+            {
+              "type": "TextBlock",
+              "text": "先拆分线索、试用激活与付费三段漏斗，核对近 90 天数据。",
+              "size": "Small",
+              "wrap": true,
+              "spacing": "None"
+            },
+            {
+              "type": "Container",
+              "style": "emphasis",
+              "spacing": "Small",
+              "items": [
+                {
+                  "type": "ColumnSet",
+                  "spacing": "None",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "query_metrics",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "channel=B · range=90d · group=stage",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "read_file",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "~/analytics/funnel_definition.sql · ×2",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "run_sql",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "按漏斗阶段汇总数量与转化率",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "Container",
+          "spacing": "Large",
+          "separator": true,
+          "items": [
+            {
+              "type": "TextBlock",
+              "text": "准备交叉核验行业结构、客服工单与 NPS 时，推理服务连接中断。",
+              "size": "Small",
+              "wrap": true,
+              "spacing": "None"
+            },
+            {
+              "type": "Container",
+              "style": "emphasis",
+              "spacing": "Small",
+              "items": [
+                {
+                  "type": "ColumnSet",
+                  "spacing": "None",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "query_metrics",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "按行业拆分激活率",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Attention",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "search_tickets",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "连接超时，调用未完成",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "id": "collapsed_panel",
+      "isVisible": false,
+      "spacing": "Medium",
+      "items": [
+        {
+          "type": "TextBlock",
+          "text": "生成已中断 · 点击可查看停止前的过程",
+          "size": "Small",
+          "isSubtle": true,
+          "wrap": true,
+          "spacing": "None"
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "style": "attention",
+      "spacing": "Large",
+      "items": [
+        {
+          "type": "TextBlock",
+          "text": "生成失败",
+          "color": "Attention",
+          "weight": "Bolder",
+          "wrap": true,
+          "spacing": "None"
+        },
+        {
+          "type": "TextBlock",
+          "text": "推理服务连接超时，已停止本次生成。已完成的过程会保留。",
+          "wrap": true,
+          "spacing": "Small"
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "id": "octo-surface-default-footer-reasoning-error",
+      "style": "emphasis",
+      "bleed": true,
+      "separator": true,
+      "spacing": "Large",
+      "items": [
+        {
+          "type": "ActionSet",
+          "horizontalAlignment": "Right",
+          "actions": [
+            {
+              "type": "Action.ToggleVisibility",
+              "id": "reasoning_toggle",
+              "title": "显示 / 隐藏推理",
+              "targetElements": [
+                "trace_panel",
+                "collapsed_panel"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.3.0/goldens/reasoning.card.json
+++ b/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.3.0/goldens/reasoning.card.json
@@ -1,0 +1,511 @@
+{
+  "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+  "type": "AdaptiveCard",
+  "version": "1.5",
+  "body": [
+    {
+      "type": "Container",
+      "id": "octo-surface-accent-header-reasoning-active",
+      "style": "accent",
+      "bleed": true,
+      "spacing": "None",
+      "items": [
+        {
+          "type": "ColumnSet",
+          "spacing": "None",
+          "columns": [
+            {
+              "type": "Column",
+              "width": "stretch",
+              "verticalContentAlignment": "Center",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "text": "✦  已深度思考",
+                  "color": "Accent",
+                  "weight": "Bolder",
+                  "wrap": true,
+                  "spacing": "None"
+                },
+                {
+                  "type": "TextBlock",
+                  "text": "正在深度思考…",
+                  "size": "Small",
+                  "isSubtle": true,
+                  "wrap": true,
+                  "spacing": "Small"
+                }
+              ]
+            },
+            {
+              "type": "Column",
+              "width": "auto",
+              "verticalContentAlignment": "Center",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "id": "octo-badge-reasoning-active-status",
+                  "text": "思考中",
+                  "color": "Accent",
+                  "weight": "Bolder",
+                  "size": "Small",
+                  "wrap": true,
+                  "spacing": "None"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "id": "trace_panel",
+      "isVisible": true,
+      "spacing": "Large",
+      "items": [
+        {
+          "type": "Container",
+          "spacing": "None",
+          "separator": false,
+          "items": [
+            {
+              "type": "TextBlock",
+              "text": "先把渠道 B 转化下降的范围圈出来：拆成线索、试用激活、付费三段漏斗，取近 90 天数据。",
+              "size": "Small",
+              "wrap": true,
+              "spacing": "None"
+            },
+            {
+              "type": "Container",
+              "style": "emphasis",
+              "spacing": "Small",
+              "items": [
+                {
+                  "type": "ColumnSet",
+                  "spacing": "None",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "query_metrics",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "channel=B · range=90d · group=stage",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "read_file",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "~/analytics/funnel_definition.sql · ×2",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "run_sql",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "按漏斗阶段汇总数量与转化率",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "Container",
+          "spacing": "Large",
+          "separator": true,
+          "items": [
+            {
+              "type": "TextBlock",
+              "text": "口径正常，但激活率掉得比线索量快；继续拉行业标签、客服工单和 NPS 交叉验证。",
+              "size": "Small",
+              "wrap": true,
+              "spacing": "None"
+            },
+            {
+              "type": "Container",
+              "style": "emphasis",
+              "spacing": "Small",
+              "items": [
+                {
+                  "type": "ColumnSet",
+                  "spacing": "None",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "query_metrics",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "channel=B · dims=industry · metric=activation_rate",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "search_tickets",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "渠道 B · 试用 / 激活失败 · 近 60 天",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "read_file",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "~/nps/2026Q2_channelB.csv",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Accent",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "query_metrics",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "正在叠加季节性校正…",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "TextBlock",
+          "text": "◌  正在执行下一步…",
+          "color": "Accent",
+          "size": "Small",
+          "wrap": true,
+          "spacing": "Large"
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "id": "collapsed_panel",
+      "isVisible": false,
+      "spacing": "Medium",
+      "items": [
+        {
+          "type": "TextBlock",
+          "text": "✓  推理仍在进行 · 点击可查看当前过程",
+          "size": "Small",
+          "isSubtle": true,
+          "wrap": true,
+          "spacing": "None"
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "id": "octo-surface-default-footer-reasoning-active",
+      "style": "emphasis",
+      "bleed": true,
+      "separator": true,
+      "spacing": "Large",
+      "items": [
+        {
+          "type": "ActionSet",
+          "horizontalAlignment": "Right",
+          "actions": [
+            {
+              "type": "Action.ToggleVisibility",
+              "id": "reasoning_toggle",
+              "title": "显示 / 隐藏推理",
+              "targetElements": [
+                "trace_panel",
+                "collapsed_panel"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.3.0/goldens/stopped.card.json
+++ b/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.3.0/goldens/stopped.card.json
@@ -1,0 +1,387 @@
+{
+  "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+  "type": "AdaptiveCard",
+  "version": "1.5",
+  "body": [
+    {
+      "type": "Container",
+      "id": "octo-surface-accent-header-reasoning-result",
+      "style": "accent",
+      "bleed": true,
+      "spacing": "None",
+      "items": [
+        {
+          "type": "ColumnSet",
+          "spacing": "None",
+          "columns": [
+            {
+              "type": "Column",
+              "width": "stretch",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "text": "✦  已深度思考",
+                  "color": "Accent",
+                  "weight": "Bolder",
+                  "wrap": true,
+                  "spacing": "None"
+                },
+                {
+                  "type": "TextBlock",
+                  "text": "已思考 6 秒 · 已停止于第 2 段",
+                  "size": "Small",
+                  "isSubtle": true,
+                  "wrap": true,
+                  "spacing": "Small"
+                }
+              ]
+            },
+            {
+              "type": "Column",
+              "width": "auto",
+              "verticalContentAlignment": "Center",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "id": "octo-badge-reasoning-result-status",
+                  "text": "已停止",
+                  "color": "Warning",
+                  "weight": "Bolder",
+                  "size": "Small",
+                  "wrap": true,
+                  "spacing": "None"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "id": "trace_panel",
+      "isVisible": false,
+      "spacing": "Large",
+      "items": [
+        {
+          "type": "Container",
+          "spacing": "None",
+          "separator": false,
+          "items": [
+            {
+              "type": "TextBlock",
+              "text": "先拆分线索、试用激活与付费三段漏斗，核对近 90 天数据。",
+              "size": "Small",
+              "wrap": true,
+              "spacing": "None"
+            },
+            {
+              "type": "Container",
+              "style": "emphasis",
+              "spacing": "Small",
+              "items": [
+                {
+                  "type": "ColumnSet",
+                  "spacing": "None",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "query_metrics",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "channel=B · range=90d · group=stage",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "read_file",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "~/analytics/funnel_definition.sql · ×2",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "run_sql",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "按漏斗阶段汇总数量与转化率",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "Container",
+          "spacing": "Large",
+          "separator": true,
+          "items": [
+            {
+              "type": "TextBlock",
+              "text": "激活率降幅高于线索量，开始按行业与试用权益触达交叉核验。",
+              "size": "Small",
+              "wrap": true,
+              "spacing": "None"
+            },
+            {
+              "type": "Container",
+              "style": "emphasis",
+              "spacing": "Small",
+              "items": [
+                {
+                  "type": "ColumnSet",
+                  "spacing": "None",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Good",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "query_metrics",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "按行业拆分激活率",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "ColumnSet",
+                  "spacing": "Small",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "●",
+                          "color": "Accent",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "search_tickets",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "调用已由用户停止",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "id": "collapsed_panel",
+      "isVisible": true,
+      "spacing": "Medium",
+      "items": [
+        {
+          "type": "TextBlock",
+          "text": "✓  已保留停止前的 2 段推理过程",
+          "size": "Small",
+          "isSubtle": true,
+          "wrap": true,
+          "spacing": "None"
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "id": "octo-surface-default-footer-reasoning-result",
+      "style": "emphasis",
+      "bleed": true,
+      "separator": true,
+      "spacing": "Large",
+      "items": [
+        {
+          "type": "ActionSet",
+          "horizontalAlignment": "Right",
+          "actions": [
+            {
+              "type": "Action.ToggleVisibility",
+              "id": "reasoning_toggle",
+              "title": "显示 / 隐藏推理",
+              "targetElements": [
+                "trace_panel",
+                "collapsed_panel"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.3.0/manifest.json
+++ b/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.3.0/manifest.json
@@ -1,0 +1,50 @@
+{
+  "schemaVersion": 2,
+  "id": "ai.reasoning-process",
+  "name": "推理过程卡",
+  "version": "0.3.0",
+  "contractVersion": "1.1.0",
+  "protocol": "octo-card@1.0",
+  "adaptiveCardVersion": "1.5",
+  "renderProfile": "octo-chat@1.2.0-rc.1",
+  "renderProfileCompatibility": "octo-chat/v1",
+  "defaultLocale": "zh-CN",
+  "owner": "ai",
+  "dataSchema": "contract/data.schema.json",
+  "views": {
+    "active": {
+      "wireProfile": "octo/v2",
+      "states": [
+        "reasoning",
+        "answering"
+      ],
+      "template": "templates/active.template.json",
+      "samples": [
+        "samples/reasoning.json",
+        "samples/answering.json"
+      ]
+    },
+    "result": {
+      "wireProfile": "octo/v1",
+      "states": [
+        "completed",
+        "stopped"
+      ],
+      "template": "templates/result.template.json",
+      "samples": [
+        "samples/completed.json",
+        "samples/stopped.json"
+      ]
+    },
+    "error": {
+      "wireProfile": "octo/v2",
+      "states": [
+        "error"
+      ],
+      "template": "templates/error.template.json",
+      "samples": [
+        "samples/error.json"
+      ]
+    }
+  }
+}

--- a/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.3.0/reports/active.interaction.json
+++ b/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.3.0/reports/active.interaction.json
@@ -1,0 +1,9 @@
+{
+  "actions": [
+    {
+      "id": "reasoning_toggle",
+      "type": "Action.ToggleVisibility"
+    }
+  ],
+  "inputs": []
+}

--- a/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.3.0/reports/error.interaction.json
+++ b/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.3.0/reports/error.interaction.json
@@ -1,0 +1,9 @@
+{
+  "actions": [
+    {
+      "id": "reasoning_toggle",
+      "type": "Action.ToggleVisibility"
+    }
+  ],
+  "inputs": []
+}

--- a/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.3.0/samples/answering.json
+++ b/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.3.0/samples/answering.json
@@ -1,0 +1,89 @@
+{
+  "reasoningId": "reasoning-channel-b-001",
+  "state": "answering",
+  "title": "已深度思考",
+  "statusLabel": "回答中",
+  "statusTone": "Accent",
+  "timerText": "正在生成回答…",
+  "traceExpanded": true,
+  "traceCollapsed": false,
+  "collapsedSummary": "推理已完成 · 回答正在生成",
+  "progressText": "推理已完成，正在生成回答…",
+  "phases": [
+    {
+      "thought": "先拆分线索、试用激活与付费三段漏斗，核对近 90 天数据。",
+      "actions": [
+        {
+          "tool": "query_metrics",
+          "detail": "channel=B · range=90d · group=stage",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "read_file",
+          "detail": "~/analytics/funnel_definition.sql · ×2",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "run_sql",
+          "detail": "按漏斗阶段汇总数量与转化率",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        }
+      ]
+    },
+    {
+      "thought": "激活率的降幅高于线索量，交叉核验行业结构、客服工单、NPS 与季节性。",
+      "actions": [
+        {
+          "tool": "query_metrics",
+          "detail": "按行业拆分激活率",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "search_tickets",
+          "detail": "渠道 B · 试用 / 激活失败 · 近 60 天",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "read_file",
+          "detail": "~/nps/2026Q2_channelB.csv",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "query_metrics",
+          "detail": "叠加节假日与季节性校正",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        }
+      ]
+    },
+    {
+      "thought": "主因确认：教育与专业服务合计贡献 63% 降幅，激活断点集中在试用权益触达。",
+      "actions": [
+        {
+          "tool": "run_sql",
+          "detail": "按行业汇总转化降幅贡献",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "edit_file",
+          "detail": "~/reports/channelB_rootcause.md · 已编辑",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "think",
+          "detail": "正在组织结论、证据与下周建议…",
+          "statusGlyph": "●",
+          "statusTone": "Accent"
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.3.0/samples/completed.json
+++ b/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.3.0/samples/completed.json
@@ -1,0 +1,106 @@
+{
+  "reasoningId": "reasoning-channel-b-001",
+  "state": "completed",
+  "title": "已深度思考",
+  "statusLabel": "已完成",
+  "statusTone": "Good",
+  "timerText": "用时 12 秒 · 3 段推理 · 13 次工具调用",
+  "traceExpanded": false,
+  "traceCollapsed": true,
+  "collapsedSummary": "已思考 12 秒 · 推理过程已收起",
+  "phases": [
+    {
+      "thought": "先把渠道 B 转化下降的范围圈出来：拆成线索、试用激活、付费三段漏斗，取近 90 天数据。",
+      "actions": [
+        {
+          "tool": "query_metrics",
+          "detail": "channel=B · range=90d · group=stage",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "read_file",
+          "detail": "~/analytics/funnel_definition.sql · ×2",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "run_sql",
+          "detail": "按漏斗阶段汇总数量与转化率",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        }
+      ]
+    },
+    {
+      "thought": "激活率的降幅高于线索量，交叉核验行业结构、客服工单、NPS 与季节性。",
+      "actions": [
+        {
+          "tool": "query_metrics",
+          "detail": "按行业拆分激活率",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "run_sql",
+          "detail": "对比各行业激活与付费转化",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "search_tickets",
+          "detail": "渠道 B · 试用 / 激活失败 · 近 60 天",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "read_file",
+          "detail": "~/nps/2026Q2_channelB.csv",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "query_metrics",
+          "detail": "叠加节假日与季节性校正",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "run_sql",
+          "detail": "逐周复核线索与激活数量",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "web_search",
+          "detail": "SaaS 行业 2026 试用政策调整",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        }
+      ]
+    },
+    {
+      "thought": "主因确认：教育与专业服务合计贡献 63% 降幅，激活断点集中在试用权益触达。",
+      "actions": [
+        {
+          "tool": "run_sql",
+          "detail": "按行业汇总转化降幅贡献",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "edit_file",
+          "detail": "~/reports/channelB_rootcause.md · 已编辑",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "think",
+          "detail": "拆分行业漏斗深挖与权益触达复盘",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.3.0/samples/error.json
+++ b/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.3.0/samples/error.json
@@ -1,0 +1,55 @@
+{
+  "reasoningId": "reasoning-channel-b-003",
+  "state": "error",
+  "title": "已深度思考",
+  "statusLabel": "生成失败",
+  "statusTone": "Attention",
+  "timerText": "已中断",
+  "traceExpanded": true,
+  "traceCollapsed": false,
+  "collapsedSummary": "生成已中断 · 点击可查看停止前的过程",
+  "errorTitle": "生成失败",
+  "errorMessage": "推理服务连接超时，已停止本次生成。已完成的过程会保留。",
+  "phases": [
+    {
+      "thought": "先拆分线索、试用激活与付费三段漏斗，核对近 90 天数据。",
+      "actions": [
+        {
+          "tool": "query_metrics",
+          "detail": "channel=B · range=90d · group=stage",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "read_file",
+          "detail": "~/analytics/funnel_definition.sql · ×2",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "run_sql",
+          "detail": "按漏斗阶段汇总数量与转化率",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        }
+      ]
+    },
+    {
+      "thought": "准备交叉核验行业结构、客服工单与 NPS 时，推理服务连接中断。",
+      "actions": [
+        {
+          "tool": "query_metrics",
+          "detail": "按行业拆分激活率",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "search_tickets",
+          "detail": "连接超时，调用未完成",
+          "statusGlyph": "●",
+          "statusTone": "Attention"
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.3.0/samples/reasoning.json
+++ b/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.3.0/samples/reasoning.json
@@ -1,0 +1,66 @@
+{
+  "reasoningId": "reasoning-channel-b-001",
+  "state": "reasoning",
+  "title": "已深度思考",
+  "statusLabel": "思考中",
+  "statusTone": "Accent",
+  "timerText": "正在深度思考…",
+  "traceExpanded": true,
+  "traceCollapsed": false,
+  "collapsedSummary": "推理仍在进行 · 点击可查看当前过程",
+  "progressText": "正在执行下一步…",
+  "phases": [
+    {
+      "thought": "先把渠道 B 转化下降的范围圈出来：拆成线索、试用激活、付费三段漏斗，取近 90 天数据。",
+      "actions": [
+        {
+          "tool": "query_metrics",
+          "detail": "channel=B · range=90d · group=stage",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "read_file",
+          "detail": "~/analytics/funnel_definition.sql · ×2",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "run_sql",
+          "detail": "按漏斗阶段汇总数量与转化率",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        }
+      ]
+    },
+    {
+      "thought": "口径正常，但激活率掉得比线索量快；继续拉行业标签、客服工单和 NPS 交叉验证。",
+      "actions": [
+        {
+          "tool": "query_metrics",
+          "detail": "channel=B · dims=industry · metric=activation_rate",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "search_tickets",
+          "detail": "渠道 B · 试用 / 激活失败 · 近 60 天",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "read_file",
+          "detail": "~/nps/2026Q2_channelB.csv",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "query_metrics",
+          "detail": "正在叠加季节性校正…",
+          "statusGlyph": "●",
+          "statusTone": "Accent"
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.3.0/samples/stopped.json
+++ b/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.3.0/samples/stopped.json
@@ -1,0 +1,53 @@
+{
+  "reasoningId": "reasoning-channel-b-002",
+  "state": "stopped",
+  "title": "已深度思考",
+  "statusLabel": "已停止",
+  "statusTone": "Warning",
+  "timerText": "已思考 6 秒 · 已停止于第 2 段",
+  "traceExpanded": false,
+  "traceCollapsed": true,
+  "collapsedSummary": "已保留停止前的 2 段推理过程",
+  "phases": [
+    {
+      "thought": "先拆分线索、试用激活与付费三段漏斗，核对近 90 天数据。",
+      "actions": [
+        {
+          "tool": "query_metrics",
+          "detail": "channel=B · range=90d · group=stage",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "read_file",
+          "detail": "~/analytics/funnel_definition.sql · ×2",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "run_sql",
+          "detail": "按漏斗阶段汇总数量与转化率",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        }
+      ]
+    },
+    {
+      "thought": "激活率降幅高于线索量，开始按行业与试用权益触达交叉核验。",
+      "actions": [
+        {
+          "tool": "query_metrics",
+          "detail": "按行业拆分激活率",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "search_tickets",
+          "detail": "调用已由用户停止",
+          "statusGlyph": "●",
+          "statusTone": "Accent"
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.3.0/templates/active.template.json
+++ b/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.3.0/templates/active.template.json
@@ -1,0 +1,192 @@
+{
+  "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+  "type": "AdaptiveCard",
+  "version": "1.5",
+  "body": [
+    {
+      "type": "Container",
+      "id": "octo-surface-accent-header-reasoning-active",
+      "style": "accent",
+      "bleed": true,
+      "spacing": "None",
+      "items": [
+        {
+          "type": "ColumnSet",
+          "spacing": "None",
+          "columns": [
+            {
+              "type": "Column",
+              "width": "stretch",
+              "verticalContentAlignment": "Center",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "text": "✦  ${title}",
+                  "color": "Accent",
+                  "weight": "Bolder",
+                  "wrap": true,
+                  "spacing": "None"
+                },
+                {
+                  "type": "TextBlock",
+                  "text": "${timerText}",
+                  "size": "Small",
+                  "isSubtle": true,
+                  "wrap": true,
+                  "spacing": "Small"
+                }
+              ]
+            },
+            {
+              "type": "Column",
+              "width": "auto",
+              "verticalContentAlignment": "Center",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "id": "octo-badge-reasoning-active-status",
+                  "text": "${statusLabel}",
+                  "color": "${statusTone}",
+                  "weight": "Bolder",
+                  "size": "Small",
+                  "wrap": true,
+                  "spacing": "None"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "id": "trace_panel",
+      "isVisible": "${traceExpanded}",
+      "spacing": "Large",
+      "items": [
+        {
+          "$data": "${phases}",
+          "type": "Container",
+          "spacing": "${if($index == 0, 'None', 'Large')}",
+          "separator": "${if($index == 0, false, true)}",
+          "items": [
+            {
+              "type": "TextBlock",
+              "text": "${thought}",
+              "size": "Small",
+              "wrap": true,
+              "spacing": "None"
+            },
+            {
+              "type": "Container",
+              "style": "emphasis",
+              "spacing": "Small",
+              "items": [
+                {
+                  "$data": "${actions}",
+                  "type": "ColumnSet",
+                  "spacing": "${if($index == 0, 'None', 'Small')}",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "${statusGlyph}",
+                          "color": "${statusTone}",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "${tool}",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "${detail}",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "TextBlock",
+          "text": "◌  ${progressText}",
+          "color": "Accent",
+          "size": "Small",
+          "wrap": true,
+          "spacing": "Large"
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "id": "collapsed_panel",
+      "isVisible": "${traceCollapsed}",
+      "spacing": "Medium",
+      "items": [
+        {
+          "type": "TextBlock",
+          "text": "✓  ${collapsedSummary}",
+          "size": "Small",
+          "isSubtle": true,
+          "wrap": true,
+          "spacing": "None"
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "id": "octo-surface-default-footer-reasoning-active",
+      "style": "emphasis",
+      "bleed": true,
+      "separator": true,
+      "spacing": "Large",
+      "items": [
+        {
+          "type": "ActionSet",
+          "horizontalAlignment": "Right",
+          "actions": [
+            {
+              "type": "Action.ToggleVisibility",
+              "id": "reasoning_toggle",
+              "title": "显示 / 隐藏推理",
+              "targetElements": [
+                "trace_panel",
+                "collapsed_panel"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.3.0/templates/error.template.json
+++ b/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.3.0/templates/error.template.json
@@ -1,0 +1,201 @@
+{
+  "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+  "type": "AdaptiveCard",
+  "version": "1.5",
+  "body": [
+    {
+      "type": "Container",
+      "id": "octo-surface-accent-header-reasoning-error",
+      "style": "accent",
+      "bleed": true,
+      "spacing": "None",
+      "items": [
+        {
+          "type": "ColumnSet",
+          "spacing": "None",
+          "columns": [
+            {
+              "type": "Column",
+              "width": "stretch",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "text": "✦  ${title}",
+                  "color": "Accent",
+                  "weight": "Bolder",
+                  "wrap": true,
+                  "spacing": "None"
+                },
+                {
+                  "type": "TextBlock",
+                  "text": "${timerText}",
+                  "size": "Small",
+                  "isSubtle": true,
+                  "wrap": true,
+                  "spacing": "Small"
+                }
+              ]
+            },
+            {
+              "type": "Column",
+              "width": "auto",
+              "verticalContentAlignment": "Center",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "id": "octo-badge-reasoning-error-status",
+                  "text": "${statusLabel}",
+                  "color": "${statusTone}",
+                  "weight": "Bolder",
+                  "size": "Small",
+                  "wrap": true,
+                  "spacing": "None"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "id": "trace_panel",
+      "isVisible": "${traceExpanded}",
+      "spacing": "Large",
+      "items": [
+        {
+          "$data": "${phases}",
+          "type": "Container",
+          "spacing": "${if($index == 0, 'None', 'Large')}",
+          "separator": "${if($index == 0, false, true)}",
+          "items": [
+            {
+              "type": "TextBlock",
+              "text": "${thought}",
+              "size": "Small",
+              "wrap": true,
+              "spacing": "None"
+            },
+            {
+              "type": "Container",
+              "style": "emphasis",
+              "spacing": "Small",
+              "items": [
+                {
+                  "$data": "${actions}",
+                  "type": "ColumnSet",
+                  "spacing": "${if($index == 0, 'None', 'Small')}",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "${statusGlyph}",
+                          "color": "${statusTone}",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "${tool}",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "${detail}",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "id": "collapsed_panel",
+      "isVisible": "${traceCollapsed}",
+      "spacing": "Medium",
+      "items": [
+        {
+          "type": "TextBlock",
+          "text": "${collapsedSummary}",
+          "size": "Small",
+          "isSubtle": true,
+          "wrap": true,
+          "spacing": "None"
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "style": "attention",
+      "spacing": "Large",
+      "items": [
+        {
+          "type": "TextBlock",
+          "text": "${errorTitle}",
+          "color": "Attention",
+          "weight": "Bolder",
+          "wrap": true,
+          "spacing": "None"
+        },
+        {
+          "type": "TextBlock",
+          "text": "${errorMessage}",
+          "wrap": true,
+          "spacing": "Small"
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "id": "octo-surface-default-footer-reasoning-error",
+      "style": "emphasis",
+      "bleed": true,
+      "separator": true,
+      "spacing": "Large",
+      "items": [
+        {
+          "type": "ActionSet",
+          "horizontalAlignment": "Right",
+          "actions": [
+            {
+              "type": "Action.ToggleVisibility",
+              "id": "reasoning_toggle",
+              "title": "显示 / 隐藏推理",
+              "targetElements": [
+                "trace_panel",
+                "collapsed_panel"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.3.0/templates/result.template.json
+++ b/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.3.0/templates/result.template.json
@@ -1,0 +1,180 @@
+{
+  "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+  "type": "AdaptiveCard",
+  "version": "1.5",
+  "body": [
+    {
+      "type": "Container",
+      "id": "octo-surface-accent-header-reasoning-result",
+      "style": "accent",
+      "bleed": true,
+      "spacing": "None",
+      "items": [
+        {
+          "type": "ColumnSet",
+          "spacing": "None",
+          "columns": [
+            {
+              "type": "Column",
+              "width": "stretch",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "text": "✦  ${title}",
+                  "color": "Accent",
+                  "weight": "Bolder",
+                  "wrap": true,
+                  "spacing": "None"
+                },
+                {
+                  "type": "TextBlock",
+                  "text": "${timerText}",
+                  "size": "Small",
+                  "isSubtle": true,
+                  "wrap": true,
+                  "spacing": "Small"
+                }
+              ]
+            },
+            {
+              "type": "Column",
+              "width": "auto",
+              "verticalContentAlignment": "Center",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "id": "octo-badge-reasoning-result-status",
+                  "text": "${statusLabel}",
+                  "color": "${statusTone}",
+                  "weight": "Bolder",
+                  "size": "Small",
+                  "wrap": true,
+                  "spacing": "None"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "id": "trace_panel",
+      "isVisible": "${traceExpanded}",
+      "spacing": "Large",
+      "items": [
+        {
+          "$data": "${phases}",
+          "type": "Container",
+          "spacing": "${if($index == 0, 'None', 'Large')}",
+          "separator": "${if($index == 0, false, true)}",
+          "items": [
+            {
+              "type": "TextBlock",
+              "text": "${thought}",
+              "size": "Small",
+              "wrap": true,
+              "spacing": "None"
+            },
+            {
+              "type": "Container",
+              "style": "emphasis",
+              "spacing": "Small",
+              "items": [
+                {
+                  "$data": "${actions}",
+                  "type": "ColumnSet",
+                  "spacing": "${if($index == 0, 'None', 'Small')}",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "${statusGlyph}",
+                          "color": "${statusTone}",
+                          "size": "Small",
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "${tool}",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "${detail}",
+                          "isSubtle": true,
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "id": "collapsed_panel",
+      "isVisible": "${traceCollapsed}",
+      "spacing": "Medium",
+      "items": [
+        {
+          "type": "TextBlock",
+          "text": "✓  ${collapsedSummary}",
+          "size": "Small",
+          "isSubtle": true,
+          "wrap": true,
+          "spacing": "None"
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "id": "octo-surface-default-footer-reasoning-result",
+      "style": "emphasis",
+      "bleed": true,
+      "separator": true,
+      "spacing": "Large",
+      "items": [
+        {
+          "type": "ActionSet",
+          "horizontalAlignment": "Right",
+          "actions": [
+            {
+              "type": "Action.ToggleVisibility",
+              "id": "reasoning_toggle",
+              "title": "显示 / 隐藏推理",
+              "targetElements": [
+                "trace_panel",
+                "collapsed_panel"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/cardtmpl/json_artifact_compiler_test.go
+++ b/pkg/cardtmpl/json_artifact_compiler_test.go
@@ -63,6 +63,30 @@ func TestCompileJSONArtifactProducesStableCanonicalArtifact(t *testing.T) {
 	}
 }
 
+func TestCompileJSONArtifactRejectsSubmitInV1WithoutActionContract(t *testing.T) {
+	bundle := validJSONArtifactBundle()
+	card := json.RawMessage(`{
+		"type":"AdaptiveCard","version":"1.5",
+		"body":[{"type":"TextBlock","text":"${title}","wrap":true}],
+		"actions":[{"type":"Action.Submit","id":"forged-submit","title":"Submit"}]
+	}`)
+	bundle.Templates["main"] = card
+	bundle.Goldens["shown"] = json.RawMessage(`{
+		"type":"AdaptiveCard","version":"1.5",
+		"body":[{"type":"TextBlock","text":"hello","wrap":true}],
+		"actions":[{"type":"Action.Submit","id":"forged-submit","title":"Submit"}]
+	}`)
+
+	_, err := CompileJSONArtifact(context.Background(), bundle, DefaultCompileLimits())
+	if err == nil {
+		t.Fatal("octo/v1 artifact without ActionContract accepted Action.Submit")
+	}
+	if got := err.Error(); !strings.Contains(got, "cardmsg.Validate") ||
+		!strings.Contains(got, "Action.Submit") || !strings.Contains(got, "octo/v1") {
+		t.Fatalf("error = %q, want octo/v1 cardmsg profile rejection", got)
+	}
+}
+
 func TestStaticRegistrationAndRuntimeCompilerHaveCanonicalParity(t *testing.T) {
 	const root = "testdata/test.runtime-parity@1.0.0"
 	bundle, err := LoadJSONBundle(jsonCardTestData, root, CatalogDescriptor{

--- a/pkg/cardtmpl/registry.go
+++ b/pkg/cardtmpl/registry.go
@@ -22,7 +22,7 @@ var l2aOwnerAllowlist = map[string]struct{}{
 	"summary": {},
 	"notify":  {},
 	"action":  {},
-	"ai":      {}, // AI reasoning-process progress card family (roadmap E1 downstream)
+	"ai":      {}, // AI reasoning-process JSON card family (roadmap E1)
 }
 
 // L2b owner 前缀。前缀合规但清单不在 docs/l2b-owners.md 里 → Register 拒绝。


### PR DESCRIPTION
## Summary

Publish `ai.reasoning-process@0.3.0` as the immutable server successor that hides the unsupported stop/retry controls while retaining the bounded producer contract and exact-version historical edits.

## Related Issue

Closes #682.

Follow-up to #668. This PR does not reopen or modify the already-published `0.2.0` artifact.

## Linked Spec

[`.octospec/tasks/cardtmpl-reasoning-controls-hidden-successor/brief.md`](.octospec/tasks/cardtmpl-reasoning-controls-hidden-successor/brief.md)

## Changes

- Add `ai.reasoning-process@0.3.0` from the bounded server `0.2.0` baseline. Remove only `reasoning_stop`, `reasoning_retry`, their Submit reports/goldens, and the obsolete retry invitation; keep all five states, the local toggle, and the existing active/error=`octo/v2`, result=`octo/v1` mapping.
- Register V1/V2/V3 together, move the Registry default and Bot new-send advertisement to V3, and keep V1/V2/V3 available for same-exact-version historical edits only.
- Cover RuntimeCatalog static reconciliation and dynamic same-key collision for V3, including a real MySQL test. V3 has no `ActionContract` and does not require a callback RouteSpec.
- Make visual-profile ownership server-authoritative: raw Bot send/edit callers omit `render_profile`, the Bot API writes `octo-chat/v1` on effective frames, and Registry requests continue receiving the manifest-owned value.
- Document the Bot `templating` capability, including V3 view/state/wire-profile mapping and empty `submit_actions` for every view.
- Harden review boundaries: reject legacy stop/retry IDs through stored-frame and `ActionContext` gates, reject caller-owned Registry `render_profile`, directly cover the nil-action-contract RouteSpec branch, and lock the existing `octo/v1` registration-time Submit rejection.
- Update the production runbook to forbid routine static-to-static Activate/Rollback and require active-pointer compatibility before binary rollback; a persisted static V3 pointer would otherwise make an older image mark catalog integrity sticky-down.
- Preserve V1 and V2 byte-for-byte. No route, migration, error code, i18n error message, dynamic grant, or production gate changes are included.

Source UX artifact audited during adaptation:

- SHA-256: `db694427d79f5eb4b760993dca46eccb8b0f48620d4e82c00136e2c02c69ebe4`
- The local UX source was not imported verbatim: it reused immutable version `0.2.0`, had an unbounded schema, changed result to `octo/v2`, and renamed unrelated component IDs. The tracked V3 artifact applies only the approved control/copy delta to the bounded repository V2 baseline; reviewers need only the tracked artifact plus this digest/audit conclusion.

## Testing

- [x] `go test -p 1 -count=1 ./pkg/cardtmpl/... ./modules/bot_api/... ./modules/card_template_catalog/...`
- [x] `go test -count=1 -v ./modules/card_template_catalog -run '^TestStoreReconcileStaticV3ClaimsExactVersionAndRejectsDynamicCollisionRealMySQL$'` (executed against local MySQL; not skipped)
- [x] `go test -race -p 1 -count=1 ./pkg/cardtmpl/... ./modules/card_template_catalog/... ./pkg/cardmsg ./internal/carddispatch/... ./internal/cardactiondispatch/...`
- [x] `go test -race -count=1 ./modules/bot_api -run 'Test(BotCardTemplate|EffectiveCardTemplateIdentity|SendMessageRegistryTemplate|SendMessageRawCard|BotRawCardEditRenderProfile|BotMessageEditRegistryTemplate|BotCardProfile_)'`
- [x] `go test -race -count=1 ./modules/message -run '^TestResolveRegistryCardContextRejectsV3LegacyControlIDs$'`
- [x] `GIN_MODE=release go test -race -count=1 -v ./modules/bot_api -run '^TestBotCardEditCASIM$'` (real MySQL/Redis/WuKongIM; not skipped)
- [x] Focused review regressions: V3 legacy action IDs return `ErrActionUnknown` before enqueue, Registry-mode `render_profile` has zero dispatch, the nil-contract RouteSpec branch is called directly, and an `octo/v1` Submit with a matching golden still fails registration through `cardmsg.Validate`.
- [x] `go test -count=1 -cover ./pkg/cardtmpl ./modules/card_template_catalog` (`80.8%` / `81.3%` statement coverage)
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `golangci-lint run ./...` (`0 issues`)
- [x] All V3 JSON parses; V1/V2 have zero diff; V2/V3 schemas are byte-identical; forbidden control/copy scan and `git diff --check` pass.

No i18n extraction was required: this change adds no registered error code and changes no localized server error behavior. The only copy delta is inside the new immutable V3 card sample/golden.

## COMPREHENSION

1. **What does this change actually do to the load-bearing path?**

   New Bot reasoning-card sends resolve only to V3, whose server-rendered frames contain the client-local toggle but no stop/retry Submit action. Registry startup compiles and freezes all three exact versions, RuntimeCatalog reconciles V3 as a static claim, and historical edits continue resolving the version stored on the message instead of upgrading it. Raw Bot send/edit effective frames now receive `render_profile="octo-chat/v1"` from the server even when callers omit it.

2. **What could break because of it (dependents + failure mode)?**

   A malformed V3 artifact would fail registration/readiness; a pre-existing dynamic claim for the V3 key would fail static reconciliation; a consumer hardcoded to V2 would not select the newly advertised version; and an old server binary cannot edit a V3 message after rollback. A persisted static V3 activation pointer would also make that old image fail startup validation globally, so the runbook prohibits using Activate/Rollback for this built-in cutover. Existing V1/V2 payloads are intentionally not rewritten and may still display their historical controls. Raw Bot cards switch to the Forge-compatible host generation on their next send/edit; payloads already at the size ceiling can be rejected after the server-owned key is added.

3. **How do you know it works (specific test/repro/trace)?**

   Registration/render/conformance tests cover all five states across V1/V2/V3 and prove V3 has one toggle, no Submit/input/action contract, bounded schema parity, and exact wire profiles. Bot tests prove V3-only capability/new-send, zero-dispatch rejection of V1/V2 new sends, same-version V1/V2/V3 edits, server-authored raw send/edit render profiles, and preserved 64-bit `card_seq`; the raw edit path ran against real MySQL/Redis/WuKongIM. Runtime tests and a real-MySQL test prove static reconciliation, exact lookup during store outage, and collision fail-close. Focused, race, build, vet, lint, immutability, and JSON gates are all green locally.

## Rollout / rollback

- Keep `OCTO_BOT_CARD_ENABLED=false` and dynamic new-send closed on the first deployment.
- Require every replica to reach ready after V3 static reconciliation, then inspect the live Bot card profile before any experimental enablement.
- Verify target clients have the `octo-chat/v1` host generation before enabling Bot card traffic; the server-authored raw key applies to every raw type-17 Bot send/edit, not only reasoning cards.
- Select V3 only through the image Registry default. Do not Activate/Rollback `ai.reasoning-process` between built-in versions; before binary rollback, prove the activation target is absent or resolvable by the rollback image.
- Audit active V1/V2 messages; they are not migrated and can retain their original controls.
- Before the first V3 send, rollback to the previous image is safe. After a V3 message exists, retain a V3-capable binary or explicitly accept freezing its last frame; never rewrite V3 in place.
- OpenClaw selection/release, active-run stop/retry semantics, dynamic producer grants, and joint E2E remain separate go/no-go work.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] PR description is in English
- [x] Added tests for my changes
- [x] Updated documentation
- [x] Followed commit message conventions (Conventional Commits)
