### PR TITLE
feat: add document comment User Bot mention ingress

### DIFF
--- a/.octospec/tasks/doc-comment-bot-mention-mvp/brief.md
+++ b/.octospec/tasks/doc-comment-bot-mention-mvp/brief.md
@@ -1,0 +1,293 @@
+---
+type: Task
+title: "Task: doc-comment-bot-mention-mvp"
+description: MVP — @User Bot in a doc comment wakes an OpenClaw bot that edits the doc via octo-cli and replies in the comment thread
+tags: [bot-api, robot, internal-api, event-queue, openclaw-plugin]
+timestamp: 2026-07-30T00:00:00Z
+# --- octospec extension fields ---
+slug: doc-comment-bot-mention-mvp
+upstream: 可执行评论产品原型（Octo Docs · 可执行评论 v2）；技术方案 bot-task-platform-solution v2.6（slim 化执行）
+source: self
+---
+
+# Task: doc-comment-bot-mention-mvp
+
+> One task = one `.octospec/tasks/<slug>/` directory. This brief is the spec for
+> the work. AI may draft it from existing code; a human confirms it.
+
+## Goal
+
+用户在 octo-web 文档页评论区 @ 一个**已具有该文档权限的 User Bot**（`robot`
+表中 `status=1`、通过 Bot Token 接入 OpenClaw），bot 被唤醒后通过 octo-cli
+（docs API，bot 自身 token）编辑文档正文；完成后在该评论串下回复一条 bot 消息，
+文档版本记录中出现该次 bot 修改的 diff。
+
+本 MVP **只支持 User Bot，不支持 `app_bot`**。
+
+octo-server 在链路中只做「业务 ↔ Bot」的桥梁：接收 docs-backend 上报的 @bot 事件，
+校验内部调用、灰度范围、User Bot 状态和幂等性后，投进目标 bot 的既有事件队列。
+**不做**临时授权票据、平台任务状态机、终态对账或通知卡片；文档访问权限始终由
+docs-backend 在评论写入和实际编辑/回复时判定，`from_uid` 等上报字段不得成为授权依据。
+
+链路（六步，★ 为本 brief 范围）：
+
+```
+1. octo-web 评论 @User Bot                  [octo-web]
+2. docs-backend 存评论 → 上报 octo-server     [docs-backend]
+3. ★octo-server 校验、幂等 claim、入队 bot 事件 [本仓库]
+4. ★openclaw 插件收事件 → 隔离会话 → 派发 agent [openclaw-channel-octo]
+5. agent 经 octo-cli 改文档、回复评论          [bot 运行时 + docs-backend]
+6. 页面展示 bot 回复 + 版本 diff              [docs 侧既有能力]
+```
+
+## Background
+
+- 原始诉求：文档评论 @bot 的操作流量不能复用 DM 私聊（会话与串行队列同键，
+  混入私聊历史；`openclaw-channel-octo/src/inbound.ts` sessionId 派生已证实）。
+- 经五仓库分析与业界对标（Linear/GitHub/飞书/Slack），不新增 IM channel 类型；
+  完整平台化设计见 bot-task-platform-solution.md v2.6，本 MVP 是其 slim 子集。
+  开工前须把产品原型、技术方案及外仓证据补成可访问的 `repo@commit:path`，避免实现期
+  依赖漂移。
+- 关键存量（octo-server 当前实现已复核，直接复用）：
+  - 类型化 bot 事件是队列一等公民：`robotEvent{EventType, EventData}`
+    （`modules/robot/model.go:9-16`），`EnqueueBotTypedEvent` 已存在
+    （`modules/robot/api.go:188`，card_action 也走此路径）。
+  - 内部服务鉴权可复用 `X-Internal-Token` header、常量时间比较和未配置 fail-closed
+    模式；本能力使用独立 token，不复用 notify token。
+  - `ExistRobot` 只查询 `robot` 表中 `status=1` 的 User Bot，正好匹配本 MVP；
+    `app_bot` 明确拒绝。
+  - `/v1/bot/events` 会原样透传类型化事件；App Bot 的非 Person 过滤只针对
+    message-shaped 事件，但本 MVP 不以 App Bot 为目标。
+  - 插件缝合点：`synthesizeCardActionMessage` + `routeOverride`
+    （`src/card-action.ts:110-129`、`src/channel.ts:1516-1536`；开工前固定 commit）。
+
+## Delivery semantics
+
+- docs-backend 为每一次“评论中的某个 bot mention”生成稳定且唯一的
+  `idempotency_key`；HTTP 重试必须复用该 key，不得按请求次数生成新 key。
+- octo-server 在正常请求和并发重放下保证同一 `(bot_uid, idempotency_key)` 只入队一次。
+  幂等流程沿用 card_action 的 `claim(pending) → enqueue → confirm(event_id)` 模式：
+  - pending TTL 使用 60 秒；入队失败以 CAS 方式只释放仍为 pending 的 claim；
+  - confirm TTL 与 `Robot.MessageExpire` 使用同一配置；
+  - 同 key、同规范化请求体回放原 `event_id`；同 key、不同请求体返回冲突；
+  - 进程在 enqueue 后、confirm 前崩溃可能产生新的 `event_id` 重投；这是无事务 outbox
+    下保留的 at-least-once 窗口，插件必须按 `idempotency_key` 去重最终副作用。
+- bot 事件队列的保留窗口是 `Robot.MessageExpire`。离线恢复承诺只覆盖该窗口内的事件；
+  不承诺无限期保存。
+- 插件不得在事件仅被解析时立即 ACK：只有事件已进入可恢复的执行/幂等记录，或任务已经
+  到达明确终态后才能 ACK。游标只有在 ACK 成功或事件已被持久 claim 后才能越过该事件。
+- 跨 docs-backend、octo-server、OpenClaw 的分布式 exactly-once 事务不在 MVP 范围；
+  用户可见效果通过稳定 `idempotency_key`、插件持久去重，以及 docs 编辑/回复 API 的
+  幂等能力实现 effect-once。若 docs API/现有 octo-cli 不支持幂等 key，必须在开工前确认
+  插件侧持久去重足以覆盖进程重启，否则不得声称“一次编辑、一次回复”。
+
+## Load-bearing list
+
+### octo-server
+
+- 新增独立模块 `modules/bot_mention`，并在 `internal/modules.go` 加 blank import；模块通过
+  `robot.IService` 复用 `ExistRobot` 和 `EnqueueBotTypedEvent`。
+- `modules/robot` 事件队列 wire format（`robotEvent` 结构、score/expiry 语义）只新增
+  `event_type` 值，不改结构；`robot/model.go` 与 `bot_api/events.go` 的两处定义保持
+  lockstep。
+- 内部入口使用独立环境变量 `OCTO_DOCS_BOT_MENTION_TOKEN`：
+  - header 为 `X-Internal-Token`，常量时间比较；
+  - 未配置时入口 fail-closed 并记录启动错误日志；
+  - 不复用 `NOTIFY_INTERNAL_TOKEN` 或 `OCTO_DOCS_NOTIFY_TOKEN`；
+  - 这是 service-to-service 鉴权，明确不挂用户 `AuthMiddleware`、Space middleware 或
+    UID limiter；全局 IP 防护仍由现有全局 middleware 承担。
+- 新端点无固定 400 的历史客户端，错误使用 `ResponseErrorLWithStatus` 返回真实 HTTP
+  status；合并前取得 maintainer 对偏离 D14 的确认。所有错误仍注册 errcode/i18n，并加入
+  `TestBotMentionNoLegacyResponseError` guard。
+- 幂等 key 必须包含 bot 维度并保存规范化请求指纹；Redis 故障 fail-closed，不允许绕过去重
+  直接入队。
+- 灰度配置采用环境变量，启动时读取：
+  - `OCTO_DOCS_BOT_MENTION_ENABLED`，默认 `false`；
+  - `OCTO_DOCS_BOT_MENTION_SPACE_ALLOWLIST`；
+  - `OCTO_DOCS_BOT_MENTION_DOC_ALLOWLIST`。
+  开关为 true 后，doc 或非空 space 命中任一 allowlist 才放行；两份 allowlist 都为空时
+  仍 fail-closed。显式值 `*` 表示全量。配置变更通过重启生效。
+
+### openclaw-channel-octo
+
+- `events-poll.ts` 轮询器改为配置开启后常驻，不依赖先发卡片；
+  `doc_comment_mention` 必须显式解析、派发和 ACK，未知事件仍按既有兼容策略处理。
+- `inbound-queue.ts` 的队列键必须随会话键覆写，禁止合成 DM 形状后落入用户 DM 队列。
+- 服务端下发规范化 `thread_id = parent_id != "" ? parent_id : comment_id`；插件不得自行
+  产生另一套规则。
+- session/queue key 使用同一个 canonical key：
+  `octo:doctask:{account_id}:{bot_uid}:{space_or_global}:{doc_id}:{thread_id}`。
+  每段须做无歧义编码或哈希，避免分隔符注入；同评论串串行、跨评论串可并行，但仍受
+  插件既有的 per-account 总并发上限约束，不得按 thread 无界创建执行 goroutine。
+- 插件持久去重使用 `idempotency_key`，而不是仅用可能因崩溃重投而变化的 `event_id`；
+  去重状态必须覆盖进程重启，TTL 不短于 `Robot.MessageExpire`。
+- ClawHub 发版与存量 bot 升级必须纳入发布计划；旧插件不识别新事件时不能开启服务端灰度。
+
+## Ingress contract
+
+`POST /v1/internal/bot-mentions`
+
+```json
+{
+  "idempotency_key": "stable-id-for-this-comment-mention",
+  "doc_id": "doc-id",
+  "comment_id": "comment-id",
+  "parent_id": "optional-root-comment-id",
+  "from_uid": "human-user-id",
+  "bot_uid": "active-user-bot-id",
+  "text": "comment text",
+  "url": "optional https://docs/...",
+  "space_id": "optional-space-id"
+}
+```
+
+字段规则：
+
+- 整个 request body 最大 32 KiB。
+- `idempotency_key`、`doc_id`、`comment_id`、`from_uid`、`bot_uid` 必填，trim 后
+  1–256 bytes；`parent_id`、`space_id` 非空时不超过 256 bytes。
+- `text` 必填且不能全为空白，保留原文，最大 10 KiB；它是用户指令内容，不是可信代码或
+  授权信息。
+- `url` 可选，最大 2048 bytes，只接受绝对 `http/https` URL；仅作展示/定位元数据，
+  agent 工具调用以 `doc_id/comment_id/thread_id` 为准，不得把 URL 拼进 shell 命令。
+- `thread_id` 由 octo-server 按 `parent_id`/`comment_id` 派生，不接受调用方直接指定。
+- `from_uid`、`space_id` 和 `url` 均来自受信 docs-backend，但只能作为事件元数据、灰度输入
+  或审计线索，不能替代 docs 权限校验。
+
+成功与灰度响应：
+
+```json
+{"accepted": true, "replay": false, "event_id": 1000001}
+{"accepted": true, "replay": true,  "event_id": 1000001}
+{"accepted": false, "replay": false, "reason": "disabled"}
+```
+
+- 首次有效请求：200，`accepted=true, replay=false`。
+- 同 key、同请求体且已 confirm：200，`accepted=true, replay=true`，返回原 `event_id`；
+  replay 检查先于可变的灰度和 bot 状态检查，已受理事件不会因后来关灰度或停用 bot 而
+  改写历史结果。
+- 同 key 尚在 pending：409，返回幂等处理中错误并带 `Retry-After`。
+- 同 key、不同规范化请求体：409，绝不复用或覆盖旧事件。
+- 灰度未命中：200，`accepted=false, reason=disabled`，不写幂等终值、不入队，避免
+  docs-backend 把有意关闭当瞬时故障无限重试。
+- 无/错 token：401；坏 JSON、缺字段、越界字段：400；目标不是 active User Bot（包括
+  `app_bot`）：统一 404，防止区分不存在与停用；存储或依赖失败：500。
+
+入队事件：
+
+```json
+{
+  "event_type": "doc_comment_mention",
+  "event_data": {
+    "idempotency_key": "stable-id-for-this-comment-mention",
+    "doc_id": "doc-id",
+    "comment_id": "comment-id",
+    "thread_id": "root-comment-id",
+    "parent_id": "optional-root-comment-id",
+    "from_uid": "human-user-id",
+    "bot_uid": "active-user-bot-id",
+    "text": "comment text",
+    "url": "optional https://docs/...",
+    "space_id": "optional-space-id",
+    "enqueued_at": 1785460000
+  }
+}
+```
+
+可选字段为空时省略；`enqueued_at` 由 octo-server 生成。上述字段只许向后兼容地增补，
+不得改名或改变语义。
+
+## Failure handling
+
+- docs 编辑/回复返回网络错误、429 或 5xx：按带 jitter 的指数退避重试，不 ACK，不得热循环；
+  重试不得超过事件保留窗口。
+- docs 返回 401/403/404 等永久错误：禁止继续编辑；若评论回复权限仍可用，向原线程写一条
+  安全、非敏感的失败说明，然后作为 terminal failure ACK。
+- agent/tool 返回确定的参数或业务错误：回复安全失败说明并 ACK；无法分类的错误按可重试
+  处理，但必须有次数/时间上界。
+- terminal failure 的评论回复本身也永久失败时，记录结构化日志和指标后 ACK，避免 poison
+  event 永久占队；平台级终态对账仍属 out of scope。
+- 日志和 prompt 不得包含 bot token、内部 token 或其他凭证；生产日志不得记录完整评论正文
+  或 URL。
+
+## Observability
+
+- octo-server 至少提供低基数指标：
+  - `dmwork_doc_bot_mention_ingress_total{result}`，result 包含 accepted/replay/disabled/
+    invalid/unauthorized/conflict/error；
+  - `dmwork_doc_bot_mention_enqueue_total{result}`；
+  - ingress/enqueue latency。
+- 插件至少提供 poll、claim、dispatch、retry、terminal、ack 指标，并能从
+  `event_id + idempotency_key hash + bot_uid` 关联一次执行；不得把 doc/comment/user ID 放进
+  metrics label。
+- 结构化日志记录 `event_id`、bot uid、结果和 idempotency key 的不可逆短 hash；不记录
+  token、完整 text 或 URL。
+
+## Out of scope
+
+- `app_bot` 支持。
+- 临时授权票据（task_grant）、平台任务状态机/SLA/终态对账、任务流 UI、通知卡片、
+  出站事件订阅——完整版方案内容，按需另立任务。
+- 跨系统 exactly-once 事务；MVP 采用 at-least-once delivery + effect idempotency。
+- octo-im、octo-cli 的代码改动；若现有 octo-cli 能力不能满足前置条件，必须回到 brief
+  重新定范围，不能在实现时静默扩项。
+- docs-backend / octo-web 内部实现（上报调用、@ 选择器、版本/diff/权限模型均自理；
+  octo-server 只冻结上报和事件契约）。
+- bot 对文档的权限授予流程（docs 侧产品能力）。
+
+## Acceptance
+
+### octo-server
+
+- `POST /v1/internal/bot-mentions` 按 Ingress contract 返回固定响应；有效首请求只生成一条
+  `doc_comment_mention` 事件，event_data 字段完整。
+- 集成测试覆盖：
+  - token 未配置、无 token、错 token、正确 token；
+  - 坏 JSON、缺字段、越界 body/text/URL、非法 URL scheme；
+  - active User Bot 成功；不存在、inactive User Bot 和 `app_bot` 统一拒绝且不入队；
+  - 同 key 顺序重放与并发重放只有一个正常入队；replay 返回原 event_id；
+  - 同 key 不同 body 409；pending 409 + Retry-After；
+  - enqueue 失败释放 pending 后可重试；confirm 失败不回滚已入队事件；
+  - 灰度全关、doc 命中、space 命中、空 allowlist、`*` 全量；
+  - Redis/DB 故障 fail-closed；日志不包含 token 或完整正文。
+- 事件可被 `POST /v1/bot/events` 拉到并 ACK；队列 TTL 和幂等 confirm TTL 均来自
+  `Robot.MessageExpire`。
+- 指标按 accepted/replay/disabled/conflict/error 等结果递增，无高基数 label。
+- `make i18n-extract`、`make i18n-extract-check`、`make i18n-lint`、
+  `TestBotMentionNoLegacyResponseError` 和目标模块测试全部通过。
+
+### openclaw-channel-octo
+
+- 配置开启后轮询常驻；`doc_comment_mention` 被解析、持久 claim、派发并按 ACK 规则确认。
+- vitest 断言：
+  1. 同评论串两事件串行且同 session；
+  2. 不同评论串可并行且 session 互不可见，同时受总并发上限约束；
+  3. bot 的 DM session、DM history 和 DM queue 零污染；
+  4. 同 `idempotency_key` 即使以不同 event_id 双到，也只产生一次文档副作用；
+  5. 插件重启后仍能识别已 claim/完成事件；
+  6. retryable failure 不 ACK，terminal failure 按规则回复并 ACK。
+- agent prompt 含评论文本与 doc/comment/thread 定位，明确文本为不可信用户指令；prompt 中
+  不出现票据或 credential，bot token 只走既有 credential 链。
+
+### 端到端（灰度环境，人工/脚本各跑一次）
+
+- 评论 @User Bot → 评论串出现 bot 回复、版本记录出现 bot diff。
+- bot 进程离线期间触发 @，在 `Robot.MessageExpire` 窗口内恢复后事件送达并完成。
+- 同一 mention 顺序/并发重复上报，仅一次编辑、一次回复。
+- 灰度未命中时不入队，docs-backend 能识别 `accepted=false/reason=disabled` 且不重试。
+- 执行前撤销 bot 文档权限时不发生编辑，评论串出现安全失败说明；若回复也不可用，日志和
+  指标可定位 terminal failure。
+- 注入一次 docs 429/5xx，验证退避重试、无热循环、成功前不 ACK，恢复后只产生一次最终效果。
+
+## 前置确认（开工前拿到答复）
+
+1. docs-backend：User Bot 作为“有文档权限的协作者”的授权模型；评论落库时验证触发用户
+   可评论，编辑/回复执行时再次验证 bot 当前权限。
+2. docs-backend：为每个 `(comment mention, bot_uid)` 生成稳定唯一 idempotency key，明确
+   上报超时、409 pending、4xx 和 5xx 的重试口径。
+3. docs-backend / octo-cli：现有 bot token credential 链已支持文档编辑、指定评论串回复，
+   并确认写操作的幂等 key 能力；不满足时回到 brief 决定插件持久 ledger 或扩展 API。
+4. openclaw-channel-octo：可复用的持久状态/去重存储、per-account 总并发上限，以及 ACK/
+   游标的现有语义已经核实。
+5. 产品原型、bot-task-platform-solution v2.6、插件缝合点均补充 `repo@commit:path`。
+6. 插件 ClawHub 发版窗口、最低兼容版本和存量 User Bot 升级计划。

--- a/.octospec/tasks/doc-comment-bot-mention-mvp/brief.md
+++ b/.octospec/tasks/doc-comment-bot-mention-mvp/brief.md
@@ -68,12 +68,17 @@ docs-backend 在评论写入和实际编辑/回复时判定，`from_uid` 等上�
 - octo-server 在正常请求和并发重放下保证同一 `(bot_uid, idempotency_key)` 只入队一次。
   幂等流程沿用 card_action 的 `claim(pending) → enqueue → confirm(event_id)` 模式：
   - pending TTL 使用 60 秒；入队失败以 CAS 方式只释放仍为 pending 的 claim；
+  - 入队前必须以 CAS 续租，慢入队期间持续续租；进程退出后续租停止，pending 才按 TTL
+    自然释放，避免正常慢请求跨过 TTL 后被另一请求重新 claim；
   - confirm TTL 与 `Robot.MessageExpire` 使用同一配置；
-  - 同 key、同规范化请求体回放原 `event_id`；同 key、不同请求体返回冲突；
+  - claim 仍存在时，同 key、同规范化请求体回放原 `event_id`，同 key、不同请求体返回冲突；
+    docs-backend 对同一 key 的所有重试必须保持规范化请求体稳定，不能把 key 当作可复用业务 ID；
   - 进程在 enqueue 后、confirm 前崩溃可能产生新的 `event_id` 重投；这是无事务 outbox
     下保留的 at-least-once 窗口，插件必须按 `idempotency_key` 去重最终副作用。
-- bot 事件队列的保留窗口是 `Robot.MessageExpire`。离线恢复承诺只覆盖该窗口内的事件；
-  不承诺无限期保存。
+- bot 事件记录的 `expire` 和队列 key TTL 均由 `Robot.MessageExpire` 生成。现有队列在新事件
+  入队时会刷新整个 key 的 TTL，因此繁忙 bot 的旧成员可能存活更久；离线恢复承诺至少覆盖
+  `Robot.MessageExpire`，但插件的持久去重不能只依赖该 TTL，应保存到明确终态/ACK，避免旧事件
+  与已过期 claim 重叠时重复产生文档副作用。
 - 插件不得在事件仅被解析时立即 ACK：只有事件已进入可恢复的执行/幂等记录，或任务已经
   到达明确终态后才能 ACK。游标只有在 ACK 成功或事件已被持久 claim 后才能越过该事件。
 - 跨 docs-backend、octo-server、OpenClaw 的分布式 exactly-once 事务不在 MVP 范围；
@@ -106,7 +111,8 @@ docs-backend 在评论写入和实际编辑/回复时判定，`from_uid` 等上�
   - `OCTO_DOCS_BOT_MENTION_SPACE_ALLOWLIST`；
   - `OCTO_DOCS_BOT_MENTION_DOC_ALLOWLIST`。
   开关为 true 后，doc 或非空 space 命中任一 allowlist 才放行；两份 allowlist 都为空时
-  仍 fail-closed。显式值 `*` 表示全量。配置变更通过重启生效。
+  仍 fail-closed。doc allowlist 的 `*` 表示所有文档；space allowlist 的 `*` 表示任意**非空**
+  space，不能让空 `space_id` 命中。配置变更通过重启生效。
 
 ### openclaw-channel-octo
 
@@ -214,7 +220,7 @@ docs-backend 在评论写入和实际编辑/回复时判定，`from_uid` 等上�
 
 - octo-server 至少提供低基数指标：
   - `dmwork_doc_bot_mention_ingress_total{result}`，result 包含 accepted/replay/disabled/
-    invalid/unauthorized/conflict/error；
+    invalid/not_found/unauthorized/conflict/error；
   - `dmwork_doc_bot_mention_enqueue_total{result}`；
   - ingress/enqueue latency。
 - 插件至少提供 poll、claim、dispatch、retry、terminal、ack 指标，并能从

--- a/.octospec/tasks/doc-comment-bot-mention-mvp/brief.md
+++ b/.octospec/tasks/doc-comment-bot-mention-mvp/brief.md
@@ -50,8 +50,8 @@ docs-backend 在评论写入和实际编辑/回复时判定，`from_uid` 等上�
   依赖漂移。
 - 关键存量（octo-server 当前实现已复核，直接复用）：
   - 类型化 bot 事件是队列一等公民：`robotEvent{EventType, EventData}`
-    （`modules/robot/model.go:9-16`），`EnqueueBotTypedEvent` 已存在
-    （`modules/robot/api.go:188`，card_action 也走此路径）。
+    （`modules/robot/model.go:9-16`）；普通调用使用 `EnqueueBotTypedEvent`，本 ingress 使用
+    同一序列化路径的 `PrepareBotTypedEvent` 后原子提交（card_action 仍走普通路径）。
   - 内部服务鉴权可复用 `X-Internal-Token` header、常量时间比较和未配置 fail-closed
     模式；本能力使用独立 token，不复用 notify token。
   - `ExistRobot` 只查询 `robot` 表中 `status=1` 的 User Bot，正好匹配本 MVP；
@@ -66,23 +66,25 @@ docs-backend 在评论写入和实际编辑/回复时判定，`from_uid` 等上�
 - docs-backend 为每一次“评论中的某个 bot mention”生成稳定且唯一的
   `idempotency_key`；HTTP 重试必须复用该 key，不得按请求次数生成新 key。
 - octo-server 在正常请求和并发重放下保证同一 `(bot_uid, idempotency_key)` 只入队一次。
-  幂等流程沿用 card_action 的 `claim(pending) → enqueue → confirm(event_id)` 模式：
-  - pending TTL 使用 60 秒；入队失败以 CAS 方式只释放仍为 pending 的 claim；
-  - 入队前必须以 CAS 续租，慢入队期间持续续租；进程退出后续租停止，pending 才按 TTL
-    自然释放，避免正常慢请求跨过 TTL 后被另一请求重新 claim；
-  - confirm TTL 与 `Robot.MessageExpire` 使用同一配置；
+  幂等流程为 `claim(pending) → prepare event → atomic enqueue+confirm(event_id)`：
+  - pending TTL 使用 60 秒；事件序列号分配或序列化失败时，以 CAS 方式只释放仍为 pending
+    的 claim；因此这类失败可安全重试；
+  - 事件准备阶段不写可见队列；最终通过同一 Redis Lua 原子校验 lease、`ZADD` bot 队列、
+    刷新队列 TTL，并把 claim 更新为 done。旧 lease 即使在慢请求后恢复也不能写入队列；
+  - atomic enqueue+confirm 的 claim TTL 与队列 TTL 均使用 `Robot.MessageExpire`；序列号可因
+    lease 失效而出现空洞，bot 消费游标不得假设 event_id 连续；
   - claim 仍存在时，同 key、同规范化请求体回放原 `event_id`，同 key、不同请求体返回冲突；
     docs-backend 对同一 key 的所有重试必须保持规范化请求体稳定，不能把 key 当作可复用业务 ID；
-  - 进程在 enqueue 后、confirm 前崩溃可能产生新的 `event_id` 重投；这是无事务 outbox
-    下保留的 at-least-once 窗口，插件必须按 `idempotency_key` 去重最终副作用。
+  - Redis 提交结果不明确时先读取 claim：done 则按 replay 返回；无法确认则 fail-closed，
+    不释放 pending claim，避免已提交事件被另一请求重复入队。
 - bot 事件记录的 `expire` 和队列 key TTL 均由 `Robot.MessageExpire` 生成。现有队列在新事件
   入队时会刷新整个 key 的 TTL，因此繁忙 bot 的旧成员可能存活更久；离线恢复承诺至少覆盖
   `Robot.MessageExpire`，但插件的持久去重不能只依赖该 TTL，应保存到明确终态/ACK，避免旧事件
   与已过期 claim 重叠时重复产生文档副作用。
 - 插件不得在事件仅被解析时立即 ACK：只有事件已进入可恢复的执行/幂等记录，或任务已经
   到达明确终态后才能 ACK。游标只有在 ACK 成功或事件已被持久 claim 后才能越过该事件。
-- 跨 docs-backend、octo-server、OpenClaw 的分布式 exactly-once 事务不在 MVP 范围；
-  用户可见效果通过稳定 `idempotency_key`、插件持久去重，以及 docs 编辑/回复 API 的
+- 跨 docs-backend、octo-server、OpenClaw 的分布式 exactly-once 事务不在 MVP 范围；bot
+  拉取/执行仍采用 at-least-once delivery。用户可见效果通过稳定 `idempotency_key`、插件持久去重，以及 docs 编辑/回复 API 的
   幂等能力实现 effect-once。若 docs API/现有 octo-cli 不支持幂等 key，必须在开工前确认
   插件侧持久去重足以覆盖进程重启，否则不得声称“一次编辑、一次回复”。
 
@@ -91,7 +93,7 @@ docs-backend 在评论写入和实际编辑/回复时判定，`from_uid` 等上�
 ### octo-server
 
 - 新增独立模块 `modules/bot_mention`，并在 `internal/modules.go` 加 blank import；模块通过
-  `robot.IService` 复用 `ExistRobot` 和 `EnqueueBotTypedEvent`。
+  `robot.IService` 复用 `ExistRobot` 和 `PrepareBotTypedEvent`。
 - `modules/robot` 事件队列 wire format（`robotEvent` 结构、score/expiry 语义）只新增
   `event_type` 值，不改结构；`robot/model.go` 与 `bot_api/events.go` 的两处定义保持
   lockstep。
@@ -169,7 +171,7 @@ docs-backend 在评论写入和实际编辑/回复时判定，`from_uid` 等上�
 ```
 
 - 首次有效请求：200，`accepted=true, replay=false`。
-- 同 key、同请求体且已 confirm：200，`accepted=true, replay=true`，返回原 `event_id`；
+- 同 key、同请求体且 claim 已为 done：200，`accepted=true, replay=true`，返回原 `event_id`；
   replay 检查先于可变的灰度和 bot 状态检查，已受理事件不会因后来关灰度或停用 bot 而
   改写历史结果。
 - 同 key 尚在 pending：409，返回幂等处理中错误并带 `Retry-After`。
@@ -234,7 +236,8 @@ docs-backend 在评论写入和实际编辑/回复时判定，`from_uid` 等上�
 - `app_bot` 支持。
 - 临时授权票据（task_grant）、平台任务状态机/SLA/终态对账、任务流 UI、通知卡片、
   出站事件订阅——完整版方案内容，按需另立任务。
-- 跨系统 exactly-once 事务；MVP 采用 at-least-once delivery + effect idempotency。
+- 跨系统 exactly-once 事务；MVP 的 bot 拉取/执行采用 at-least-once delivery + effect
+  idempotency，但 octo-server ingress 的 claim 与队列写入保持原子。
 - octo-im、octo-cli 的代码改动；若现有 octo-cli 能力不能满足前置条件，必须回到 brief
   重新定范围，不能在实现时静默扩项。
 - docs-backend / octo-web 内部实现（上报调用、@ 选择器、版本/diff/权限模型均自理；
@@ -253,10 +256,11 @@ docs-backend 在评论写入和实际编辑/回复时判定，`from_uid` 等上�
   - active User Bot 成功；不存在、inactive User Bot 和 `app_bot` 统一拒绝且不入队；
   - 同 key 顺序重放与并发重放只有一个正常入队；replay 返回原 event_id；
   - 同 key 不同 body 409；pending 409 + Retry-After；
-  - enqueue 失败释放 pending 后可重试；confirm 失败不回滚已入队事件；
+  - event 准备失败释放 pending 后可重试；旧 lease 在另一请求接管后恢复时不能入队；
+  - atomic enqueue+confirm 结果不明确时，done 可恢复为 replay，其余情况 fail-closed；
   - 灰度全关、doc 命中、space 命中、空 allowlist、`*` 全量；
   - Redis/DB 故障 fail-closed；日志不包含 token 或完整正文。
-- 事件可被 `POST /v1/bot/events` 拉到并 ACK；队列 TTL 和幂等 confirm TTL 均来自
+- 事件可被 `POST /v1/bot/events` 拉到并 ACK；队列 TTL 和幂等 done TTL 均来自
   `Robot.MessageExpire`。
 - 指标按 accepted/replay/disabled/conflict/error 等结果递增，无高基数 label。
 - `make i18n-extract`、`make i18n-extract-check`、`make i18n-lint`、

--- a/internal/cardactiondispatch/contract_test.go
+++ b/internal/cardactiondispatch/contract_test.go
@@ -350,6 +350,17 @@ func TestRegistryRejectsNotifyTokenThatConflictsWithBroaderIngress(t *testing.T)
 	}
 }
 
+func TestRegistryRejectsDuplicateBroaderIngressTokens(t *testing.T) {
+	registry, err := NewRegistry([]RouteSpec{validRouteSpec()}, testGetenv)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	shared := "shared-broader-ingress-token"
+	if err := registry.ValidateNotifyTokenExclusions(shared, shared); err == nil {
+		t.Fatal("ValidateNotifyTokenExclusions() error = nil for duplicate broader ingress tokens")
+	}
+}
+
 func TestHMACSignatureUsesVersionedCanonicalRequest(t *testing.T) {
 	body := []byte(`{"event_id":"42","decision":"approve"}`)
 	timestamp := "1784073600"

--- a/internal/cardactiondispatch/contract_test.go
+++ b/internal/cardactiondispatch/contract_test.go
@@ -350,14 +350,14 @@ func TestRegistryRejectsNotifyTokenThatConflictsWithBroaderIngress(t *testing.T)
 	}
 }
 
-func TestRegistryRejectsDuplicateBroaderIngressTokens(t *testing.T) {
+func TestRegistryAllowsDuplicateBroaderIngressTokens(t *testing.T) {
 	registry, err := NewRegistry([]RouteSpec{validRouteSpec()}, testGetenv)
 	if err != nil {
 		t.Fatalf("NewRegistry() error = %v", err)
 	}
 	shared := "shared-broader-ingress-token"
-	if err := registry.ValidateNotifyTokenExclusions(shared, shared); err == nil {
-		t.Fatal("ValidateNotifyTokenExclusions() error = nil for duplicate broader ingress tokens")
+	if err := registry.ValidateNotifyTokenExclusions(shared, shared); err != nil {
+		t.Fatalf("ValidateNotifyTokenExclusions() error = %v; broader ingress equality is enforced by each capability", err)
 	}
 }
 

--- a/internal/cardactiondispatch/registry.go
+++ b/internal/cardactiondispatch/registry.go
@@ -243,15 +243,10 @@ func (r *Registry) ValidateNotifyTokenExclusions(tokens ...string) error {
 	if r == nil {
 		return errors.New("cardactiondispatch: registry unavailable")
 	}
-	seen := make(map[string]struct{}, len(tokens))
 	for _, token := range tokens {
 		if token == "" {
 			continue
 		}
-		if _, ok := seen[token]; ok {
-			return errors.New("cardactiondispatch: broader ingress tokens must be distinct")
-		}
-		seen[token] = struct{}{}
 		if _, ok := r.ResolveNotifyToken(token); ok {
 			return errors.New("cardactiondispatch: action notify token conflicts with an existing notify token")
 		}

--- a/internal/cardactiondispatch/registry.go
+++ b/internal/cardactiondispatch/registry.go
@@ -243,10 +243,15 @@ func (r *Registry) ValidateNotifyTokenExclusions(tokens ...string) error {
 	if r == nil {
 		return errors.New("cardactiondispatch: registry unavailable")
 	}
+	seen := make(map[string]struct{}, len(tokens))
 	for _, token := range tokens {
 		if token == "" {
 			continue
 		}
+		if _, ok := seen[token]; ok {
+			return errors.New("cardactiondispatch: broader ingress tokens must be distinct")
+		}
+		seen[token] = struct{}{}
 		if _, ok := r.ResolveNotifyToken(token); ok {
 			return errors.New("cardactiondispatch: action notify token conflicts with an existing notify token")
 		}

--- a/internal/modules.go
+++ b/internal/modules.go
@@ -28,6 +28,7 @@ import (
 	// (历史顺序，非 load-bearing —— 真正排序由 SQL 文件时间戳决定)。
 	_ "github.com/Mininglamp-OSS/octo-server/modules/robot"
 
+	_ "github.com/Mininglamp-OSS/octo-server/modules/bot_mention"
 	_ "github.com/Mininglamp-OSS/octo-server/modules/botfather"
 
 	_ "github.com/Mininglamp-OSS/octo-server/modules/card_template_catalog"

--- a/main.go
+++ b/main.go
@@ -509,7 +509,11 @@ func installCardActionDispatch(ctx *config.Context) (*cardActionDispatchRuntime,
 	if err != nil {
 		return nil, err
 	}
-	if err := registry.ValidateNotifyTokenExclusions(os.Getenv("NOTIFY_INTERNAL_TOKEN"), os.Getenv("OCTO_DOCS_NOTIFY_TOKEN")); err != nil {
+	if err := registry.ValidateNotifyTokenExclusions(
+		os.Getenv("NOTIFY_INTERNAL_TOKEN"),
+		os.Getenv("OCTO_DOCS_NOTIFY_TOKEN"),
+		os.Getenv("OCTO_DOCS_BOT_MENTION_TOKEN"),
+	); err != nil {
 		return nil, err
 	}
 	// OCTO_CARD_MESSAGE_ENABLED is the deployment-level master gate (rollout /

--- a/main_carddispatch_test.go
+++ b/main_carddispatch_test.go
@@ -233,7 +233,7 @@ func TestCardActionDispatchValidatesRoutesWhenGateOff(t *testing.T) {
 	}
 }
 
-func TestCardActionDispatchRejectsBotMentionTokenCapabilityCollisions(t *testing.T) {
+func TestCardActionDispatchScopesBotMentionTokenCollisionFailures(t *testing.T) {
 	const (
 		callbackSecret = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 		routeToken     = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
@@ -250,8 +250,8 @@ func TestCardActionDispatchRejectsBotMentionTokenCapabilityCollisions(t *testing
 		{name: "independent capability", mentionToken: mentionToken},
 		{name: "route notify token collision", mentionToken: routeToken, wantErr: true},
 		{name: "callback secret collision", mentionToken: callbackSecret, wantErr: true},
-		{name: "legacy notify token collision", mentionToken: notifyToken, wantErr: true},
-		{name: "docs notify token collision", mentionToken: docsToken, wantErr: true},
+		{name: "legacy notify token collision stays module local", mentionToken: notifyToken},
+		{name: "docs notify token collision stays module local", mentionToken: docsToken},
 	}
 
 	for _, tt := range tests {

--- a/main_carddispatch_test.go
+++ b/main_carddispatch_test.go
@@ -233,6 +233,58 @@ func TestCardActionDispatchValidatesRoutesWhenGateOff(t *testing.T) {
 	}
 }
 
+func TestCardActionDispatchRejectsBotMentionTokenCapabilityCollisions(t *testing.T) {
+	const (
+		callbackSecret = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+		routeToken     = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+		notifyToken    = "cccccccccccccccccccccccccccccccc"
+		docsToken      = "dddddddddddddddddddddddddddddddd"
+		mentionToken   = "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+	)
+
+	tests := []struct {
+		name         string
+		mentionToken string
+		wantErr      bool
+	}{
+		{name: "independent capability", mentionToken: mentionToken},
+		{name: "route notify token collision", mentionToken: routeToken, wantErr: true},
+		{name: "callback secret collision", mentionToken: callbackSecret, wantErr: true},
+		{name: "legacy notify token collision", mentionToken: notifyToken, wantErr: true},
+		{name: "docs notify token collision", mentionToken: docsToken, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("OCTO_CARD_MESSAGE_ENABLED", "false")
+			t.Setenv("OCTO_DOCS_APPROVAL_CARD_ENABLED", "false")
+			t.Setenv("OCTO_TASKS_CARD_ACTION_SECRET", callbackSecret)
+			t.Setenv("OCTO_TASKS_NOTIFY_TOKEN", routeToken)
+			t.Setenv("NOTIFY_INTERNAL_TOKEN", notifyToken)
+			t.Setenv("OCTO_DOCS_NOTIFY_TOKEN", docsToken)
+			t.Setenv("OCTO_DOCS_BOT_MENTION_TOKEN", tt.mentionToken)
+			t.Setenv("OCTO_CARD_ACTION_ROUTES", `[{"sender_uid":"notification","owner":"tasks","action_type":"task.execute.decision","url":"https://tasks.internal/v1/card-actions/decide","secret_env":"OCTO_TASKS_CARD_ACTION_SECRET","notify_token_env":"OCTO_TASKS_NOTIFY_TOKEN"}]`)
+
+			runtime, err := installCardActionDispatch(nil)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("installCardActionDispatch() error = nil; capability collision must fail startup")
+				}
+				if runtime != nil {
+					t.Fatalf("runtime = %+v, want nil on capability collision", runtime)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("installCardActionDispatch() error = %v", err)
+			}
+			if runtime == nil {
+				t.Fatal("installCardActionDispatch() runtime = nil")
+			}
+		})
+	}
+}
+
 func TestConfiguredApprovalRouteRejectsNonNotificationSender(t *testing.T) {
 	_, err := cardActionApprovalProducerSpecs([]cardactiondispatch.RouteSpec{
 		{

--- a/modules/bot_mention/1module.go
+++ b/modules/bot_mention/1module.go
@@ -1,0 +1,17 @@
+package bot_mention
+
+import (
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/register"
+)
+
+func init() {
+	register.AddModule(func(ctx interface{}) register.Module {
+		return register.Module{
+			Name: "bot_mention",
+			SetupAPI: func() register.APIRouter {
+				return New(ctx.(*config.Context))
+			},
+		}
+	})
+}

--- a/modules/bot_mention/api.go
+++ b/modules/bot_mention/api.go
@@ -1,0 +1,224 @@
+package bot_mention
+
+import (
+	"crypto/subtle"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/modules/robot"
+	"go.uber.org/zap"
+)
+
+type botMentionRobotService interface {
+	ExistRobot(uid string) (bool, error)
+	EnqueueBotTypedEvent(robotID, eventType string, eventData map[string]interface{}) (int64, error)
+}
+
+type botMentionClaimStore interface {
+	Lookup(key, sha string) (claimOutcome, error)
+	Begin(key, sha string) (claimOutcome, *claimLease, error)
+	Confirm(lease *claimLease, eventID int64) (bool, error)
+	Release(lease *claimLease) (bool, error)
+}
+
+type BotMention struct {
+	robots        botMentionRobotService
+	claims        botMentionClaimStore
+	gate          featureGate
+	internalToken string
+	metrics       botMentionMetricRecorder
+	now           func() time.Time
+	log.Log
+}
+
+type mentionIngressResponse struct {
+	Accepted bool   `json:"accepted"`
+	Replay   bool   `json:"replay"`
+	EventID  int64  `json:"event_id,omitempty"`
+	Reason   string `json:"reason,omitempty"`
+}
+
+func New(ctx *config.Context) *BotMention {
+	logger := log.NewTLog("BotMention")
+	token := os.Getenv(internalTokenEnv)
+	if token == "" {
+		logger.Error("OCTO_DOCS_BOT_MENTION_TOKEN not set; internal bot mention API will reject all requests")
+	}
+	return &BotMention{
+		robots:        robot.NewService(ctx),
+		claims:        newRedisClaimStore(ctx),
+		gate:          featureGateFromEnv(),
+		internalToken: token,
+		metrics:       defaultBotMentionMetrics,
+		now:           time.Now,
+		Log:           logger,
+	}
+}
+
+func (m *BotMention) Route(r *wkhttp.WKHttp) {
+	internal := r.Group("/v1/internal", m.internalAuthMiddleware())
+	internal.POST("/bot-mentions", m.create)
+}
+
+func (m *BotMention) internalAuthMiddleware() wkhttp.HandlerFunc {
+	return func(c *wkhttp.Context) {
+		started := time.Now()
+		token := c.GetHeader(internalTokenHeader)
+		if m.internalToken == "" || subtle.ConstantTimeCompare([]byte(token), []byte(m.internalToken)) != 1 {
+			respondBotMentionUnauthorized(c)
+			c.Abort()
+			if m.metrics != nil {
+				m.metrics.ObserveIngress("unauthorized", time.Since(started))
+			}
+			return
+		}
+		c.Next()
+	}
+}
+
+func (m *BotMention) create(c *wkhttp.Context) {
+	started := time.Now()
+	result := "error"
+	defer func() {
+		if m.metrics != nil {
+			m.metrics.ObserveIngress(result, time.Since(started))
+		}
+	}()
+
+	c.Request.Body = http.MaxBytesReader(c.Writer, c.Request.Body, maxRequestBodyBytes)
+	var request mentionRequest
+	if err := c.ShouldBindJSON(&request); err != nil {
+		result = "invalid"
+		respondBotMentionInvalid(c, "body")
+		return
+	}
+	mention, err := normalizeMentionRequest(request)
+	if err != nil {
+		result = "invalid"
+		respondBotMentionInvalid(c, invalidField(err))
+		return
+	}
+
+	claimKey := mentionClaimKey(mention.BotUID, mention.IdempotencyKey)
+	fingerprint := mentionFingerprint(mention)
+	existing, err := m.claims.Lookup(claimKey, fingerprint)
+	if err != nil {
+		m.Error("bot mention idempotency lookup failed", zap.Error(err), zap.String("claim_key", claimKey))
+		respondBotMentionStoreFailed(c)
+		return
+	}
+	if handled, claimResult := respondBotMentionClaimOutcome(c, existing); handled {
+		result = claimResult
+		return
+	}
+
+	if !m.gate.Allows(mention.DocID, mention.SpaceID) {
+		result = "disabled"
+		c.Response(mentionIngressResponse{Accepted: false, Replay: false, Reason: "disabled"})
+		return
+	}
+
+	exists, err := m.robots.ExistRobot(mention.BotUID)
+	if err != nil {
+		m.Error("bot mention user bot lookup failed", zap.Error(err), zap.String("bot_uid", mention.BotUID))
+		respondBotMentionStoreFailed(c)
+		return
+	}
+	if !exists {
+		result = "invalid"
+		respondBotMentionNotFound(c)
+		return
+	}
+
+	outcome, lease, err := m.claims.Begin(claimKey, fingerprint)
+	if err != nil {
+		m.Error("bot mention idempotency claim failed", zap.Error(err), zap.String("claim_key", claimKey))
+		respondBotMentionStoreFailed(c)
+		return
+	}
+	if handled, claimResult := respondBotMentionClaimOutcome(c, outcome); handled {
+		result = claimResult
+		return
+	}
+	if outcome.State != claimAcquired || lease == nil {
+		m.Error("bot mention idempotency claim returned invalid state", zap.Int("state", int(outcome.State)), zap.String("claim_key", claimKey))
+		respondBotMentionStoreFailed(c)
+		return
+	}
+
+	eventData := mentionEventData(mention, m.now().Unix())
+	enqueueStarted := time.Now()
+	eventID, err := m.robots.EnqueueBotTypedEvent(mention.BotUID, docCommentMentionEventType, eventData)
+	if err != nil {
+		if m.metrics != nil {
+			m.metrics.ObserveEnqueue("error", time.Since(enqueueStarted))
+		}
+		if released, releaseErr := m.claims.Release(lease); releaseErr != nil || !released {
+			m.Warn("bot mention claim release did not apply",
+				zap.Bool("released", released), zap.Error(releaseErr), zap.String("claim_key", claimKey))
+		}
+		m.Error("bot mention event enqueue failed", zap.Error(err), zap.String("bot_uid", mention.BotUID), zap.String("claim_key", claimKey))
+		respondBotMentionStoreFailed(c)
+		return
+	}
+	if m.metrics != nil {
+		m.metrics.ObserveEnqueue("accepted", time.Since(enqueueStarted))
+	}
+
+	if confirmed, confirmErr := m.claims.Confirm(lease, eventID); confirmErr != nil || !confirmed {
+		// The event is already in the bot queue. Do not report a false failure or
+		// attempt to roll it back; the consumer deduplicates on idempotency_key.
+		m.Warn("bot mention idempotency confirm did not apply",
+			zap.Bool("confirmed", confirmed), zap.Error(confirmErr),
+			zap.Int64("event_id", eventID), zap.String("claim_key", claimKey))
+	}
+
+	result = "accepted"
+	c.Response(mentionIngressResponse{Accepted: true, Replay: false, EventID: eventID})
+}
+
+func respondBotMentionClaimOutcome(c *wkhttp.Context, outcome claimOutcome) (bool, string) {
+	switch outcome.State {
+	case claimMissing, claimAcquired:
+		return false, ""
+	case claimPending:
+		respondBotMentionInProgress(c)
+		return true, "conflict"
+	case claimReplay:
+		c.Response(mentionIngressResponse{Accepted: true, Replay: true, EventID: outcome.EventID})
+		return true, "replay"
+	case claimConflict:
+		respondBotMentionConflict(c)
+		return true, "conflict"
+	default:
+		respondBotMentionStoreFailed(c)
+		return true, "error"
+	}
+}
+
+func mentionEventData(mention normalizedMention, enqueuedAt int64) map[string]interface{} {
+	data := map[string]interface{}{
+		"idempotency_key": mention.IdempotencyKey,
+		"doc_id":          mention.DocID,
+		"comment_id":      mention.CommentID,
+		"thread_id":       mention.ThreadID,
+		"from_uid":        mention.FromUID,
+		"bot_uid":         mention.BotUID,
+		"text":            mention.Text,
+		"enqueued_at":     enqueuedAt,
+	}
+	if mention.ParentID != "" {
+		data["parent_id"] = mention.ParentID
+	}
+	if mention.URL != "" {
+		data["url"] = mention.URL
+	}
+	if mention.SpaceID != "" {
+		data["space_id"] = mention.SpaceID
+	}
+	return data
+}

--- a/modules/bot_mention/api.go
+++ b/modules/bot_mention/api.go
@@ -2,8 +2,12 @@ package bot_mention
 
 import (
 	"crypto/subtle"
+	"encoding/json"
+	"errors"
+	"io"
 	"net/http"
 	"os"
+	"sync"
 	"time"
 
 	"github.com/Mininglamp-OSS/octo-lib/config"
@@ -21,6 +25,7 @@ type botMentionRobotService interface {
 type botMentionClaimStore interface {
 	Lookup(key, sha string) (claimOutcome, error)
 	Begin(key, sha string) (claimOutcome, *claimLease, error)
+	Renew(lease *claimLease) (bool, error)
 	Confirm(lease *claimLease, eventID int64) (bool, error)
 	Release(lease *claimLease) (bool, error)
 }
@@ -32,6 +37,7 @@ type BotMention struct {
 	internalToken string
 	metrics       botMentionMetricRecorder
 	now           func() time.Time
+	claimRenewal  time.Duration
 	log.Log
 }
 
@@ -44,16 +50,9 @@ type mentionIngressResponse struct {
 
 func New(ctx *config.Context) *BotMention {
 	logger := log.NewTLog("BotMention")
-	token := os.Getenv(internalTokenEnv)
-	switch {
-	case token == "":
-		logger.Error("OCTO_DOCS_BOT_MENTION_TOKEN not set; internal bot mention API will reject all requests")
-	case token == os.Getenv("NOTIFY_INTERNAL_TOKEN"):
-		logger.Error("OCTO_DOCS_BOT_MENTION_TOKEN must differ from NOTIFY_INTERNAL_TOKEN; bot mention capability disabled")
-		token = ""
-	case token == os.Getenv("OCTO_DOCS_NOTIFY_TOKEN"):
-		logger.Error("OCTO_DOCS_BOT_MENTION_TOKEN must differ from OCTO_DOCS_NOTIFY_TOKEN; bot mention capability disabled")
-		token = ""
+	token, tokenErr := resolveBotMentionInternalToken(os.Getenv)
+	if tokenErr != nil {
+		logger.Error(tokenErr.Error())
 	}
 	return &BotMention{
 		robots:        robot.NewService(ctx),
@@ -62,6 +61,7 @@ func New(ctx *config.Context) *BotMention {
 		internalToken: token,
 		metrics:       defaultBotMentionMetrics,
 		now:           time.Now,
+		claimRenewal:  claimPendingTTL / 3,
 		Log:           logger,
 	}
 }
@@ -96,9 +96,8 @@ func (m *BotMention) create(c *wkhttp.Context) {
 		}
 	}()
 
-	c.Request.Body = http.MaxBytesReader(c.Writer, c.Request.Body, maxRequestBodyBytes)
-	var request mentionRequest
-	if err := c.ShouldBindJSON(&request); err != nil {
+	request, err := decodeMentionRequest(c)
+	if err != nil {
 		result = "invalid"
 		respondBotMentionInvalid(c, "body")
 		return
@@ -114,17 +113,21 @@ func (m *BotMention) create(c *wkhttp.Context) {
 	fingerprint := mentionFingerprint(mention)
 	existing, err := m.claims.Lookup(claimKey, fingerprint)
 	if err != nil {
-		m.Error("bot mention idempotency lookup failed", zap.Error(err), zap.String("claim_key", claimKey))
+		m.Error("bot mention idempotency lookup failed", zap.Error(err), zap.String("idempotency_hash", mentionClaimLogHash(claimKey)))
 		respondBotMentionStoreFailed(c)
 		return
 	}
 	if handled, claimResult := respondBotMentionClaimOutcome(c, existing); handled {
 		result = claimResult
+		if claimResult == "replay" {
+			m.logOutcome(mention, claimResult, existing.EventID, claimKey)
+		}
 		return
 	}
 
 	if !m.gate.Allows(mention.DocID, mention.SpaceID) {
 		result = "disabled"
+		m.logOutcome(mention, result, 0, claimKey)
 		c.Response(mentionIngressResponse{Accepted: false, Replay: false, Reason: "disabled"})
 		return
 	}
@@ -136,39 +139,55 @@ func (m *BotMention) create(c *wkhttp.Context) {
 		return
 	}
 	if !exists {
-		result = "invalid"
+		result = "not_found"
 		respondBotMentionNotFound(c)
 		return
 	}
 
 	outcome, lease, err := m.claims.Begin(claimKey, fingerprint)
 	if err != nil {
-		m.Error("bot mention idempotency claim failed", zap.Error(err), zap.String("claim_key", claimKey))
+		m.Error("bot mention idempotency claim failed", zap.Error(err), zap.String("idempotency_hash", mentionClaimLogHash(claimKey)))
 		respondBotMentionStoreFailed(c)
 		return
 	}
 	if handled, claimResult := respondBotMentionClaimOutcome(c, outcome); handled {
 		result = claimResult
+		if claimResult == "replay" {
+			m.logOutcome(mention, claimResult, outcome.EventID, claimKey)
+		}
 		return
 	}
 	if outcome.State != claimAcquired || lease == nil {
-		m.Error("bot mention idempotency claim returned invalid state", zap.Int("state", int(outcome.State)), zap.String("claim_key", claimKey))
+		m.Error("bot mention idempotency claim returned invalid state", zap.Int("state", int(outcome.State)), zap.String("idempotency_hash", mentionClaimLogHash(claimKey)))
 		respondBotMentionStoreFailed(c)
+		return
+	}
+	renewed, renewErr := m.claims.Renew(lease)
+	if renewErr != nil {
+		m.Error("bot mention idempotency lease renewal failed", zap.Error(renewErr), zap.String("idempotency_hash", mentionClaimLogHash(claimKey)))
+		respondBotMentionStoreFailed(c)
+		return
+	}
+	if !renewed {
+		result = "conflict"
+		respondBotMentionInProgress(c)
 		return
 	}
 
 	eventData := mentionEventData(mention, m.now().Unix())
 	enqueueStarted := time.Now()
+	stopKeepalive := m.startClaimLeaseKeepalive(lease, claimKey)
 	eventID, err := m.robots.EnqueueBotTypedEvent(mention.BotUID, docCommentMentionEventType, eventData)
+	stopKeepalive()
 	if err != nil {
 		if m.metrics != nil {
 			m.metrics.ObserveEnqueue("error", time.Since(enqueueStarted))
 		}
 		if released, releaseErr := m.claims.Release(lease); releaseErr != nil || !released {
 			m.Warn("bot mention claim release did not apply",
-				zap.Bool("released", released), zap.Error(releaseErr), zap.String("claim_key", claimKey))
+				zap.Bool("released", released), zap.Error(releaseErr), zap.String("idempotency_hash", mentionClaimLogHash(claimKey)))
 		}
-		m.Error("bot mention event enqueue failed", zap.Error(err), zap.String("bot_uid", mention.BotUID), zap.String("claim_key", claimKey))
+		m.Error("bot mention event enqueue failed", zap.Error(err), zap.String("bot_uid", mention.BotUID), zap.String("idempotency_hash", mentionClaimLogHash(claimKey)))
 		respondBotMentionStoreFailed(c)
 		return
 	}
@@ -181,11 +200,78 @@ func (m *BotMention) create(c *wkhttp.Context) {
 		// attempt to roll it back; the consumer deduplicates on idempotency_key.
 		m.Warn("bot mention idempotency confirm did not apply",
 			zap.Bool("confirmed", confirmed), zap.Error(confirmErr),
-			zap.Int64("event_id", eventID), zap.String("claim_key", claimKey))
+			zap.Int64("event_id", eventID), zap.String("idempotency_hash", mentionClaimLogHash(claimKey)))
 	}
 
 	result = "accepted"
+	m.logOutcome(mention, result, eventID, claimKey)
 	c.Response(mentionIngressResponse{Accepted: true, Replay: false, EventID: eventID})
+}
+
+func decodeMentionRequest(c *wkhttp.Context) (mentionRequest, error) {
+	c.Request.Body = http.MaxBytesReader(c.Writer, c.Request.Body, maxRequestBodyBytes)
+	decoder := json.NewDecoder(c.Request.Body)
+	decoder.DisallowUnknownFields()
+	var request mentionRequest
+	if err := decoder.Decode(&request); err != nil {
+		return mentionRequest{}, err
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		if err == nil {
+			return mentionRequest{}, errors.New("bot mention request contains multiple JSON values")
+		}
+		return mentionRequest{}, err
+	}
+	return request, nil
+}
+
+func (m *BotMention) logOutcome(mention normalizedMention, result string, eventID int64, claimKey string) {
+	m.Info("bot mention ingress completed",
+		zap.String("result", result),
+		zap.Int64("event_id", eventID),
+		zap.String("bot_uid", mention.BotUID),
+		zap.String("idempotency_hash", mentionClaimLogHash(claimKey)),
+	)
+}
+
+func (m *BotMention) startClaimLeaseKeepalive(lease *claimLease, claimKey string) func() {
+	done := make(chan struct{})
+	stopped := make(chan struct{})
+	go func() {
+		defer close(stopped)
+		interval := m.claimRenewal
+		if interval <= 0 {
+			interval = claimPendingTTL / 3
+		}
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-done:
+				return
+			case <-ticker.C:
+				renewed, err := m.claims.Renew(lease)
+				if err != nil {
+					m.Warn("bot mention idempotency lease keepalive failed",
+						zap.Error(err), zap.String("idempotency_hash", mentionClaimLogHash(claimKey)))
+					continue
+				}
+				if !renewed {
+					m.Warn("bot mention idempotency lease keepalive lost ownership",
+						zap.String("idempotency_hash", mentionClaimLogHash(claimKey)))
+					return
+				}
+			}
+		}
+	}()
+
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			close(done)
+			<-stopped
+		})
+	}
 }
 
 func respondBotMentionClaimOutcome(c *wkhttp.Context, outcome claimOutcome) (bool, string) {

--- a/modules/bot_mention/api.go
+++ b/modules/bot_mention/api.go
@@ -45,8 +45,15 @@ type mentionIngressResponse struct {
 func New(ctx *config.Context) *BotMention {
 	logger := log.NewTLog("BotMention")
 	token := os.Getenv(internalTokenEnv)
-	if token == "" {
+	switch {
+	case token == "":
 		logger.Error("OCTO_DOCS_BOT_MENTION_TOKEN not set; internal bot mention API will reject all requests")
+	case token == os.Getenv("NOTIFY_INTERNAL_TOKEN"):
+		logger.Error("OCTO_DOCS_BOT_MENTION_TOKEN must differ from NOTIFY_INTERNAL_TOKEN; bot mention capability disabled")
+		token = ""
+	case token == os.Getenv("OCTO_DOCS_NOTIFY_TOKEN"):
+		logger.Error("OCTO_DOCS_BOT_MENTION_TOKEN must differ from OCTO_DOCS_NOTIFY_TOKEN; bot mention capability disabled")
+		token = ""
 	}
 	return &BotMention{
 		robots:        robot.NewService(ctx),

--- a/modules/bot_mention/api.go
+++ b/modules/bot_mention/api.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"net/http"
 	"os"
-	"sync"
 	"time"
 
 	"github.com/Mininglamp-OSS/octo-lib/config"
@@ -19,14 +18,13 @@ import (
 
 type botMentionRobotService interface {
 	ExistRobot(uid string) (bool, error)
-	EnqueueBotTypedEvent(robotID, eventType string, eventData map[string]interface{}) (int64, error)
+	PrepareBotTypedEvent(robotID, eventType string, eventData map[string]interface{}) (robot.PreparedBotTypedEvent, error)
 }
 
 type botMentionClaimStore interface {
 	Lookup(key, sha string) (claimOutcome, error)
 	Begin(key, sha string) (claimOutcome, *claimLease, error)
-	Renew(lease *claimLease) (bool, error)
-	Confirm(lease *claimLease, eventID int64) (bool, error)
+	Commit(lease *claimLease, event robot.PreparedBotTypedEvent) (bool, error)
 	Release(lease *claimLease) (bool, error)
 }
 
@@ -37,7 +35,6 @@ type BotMention struct {
 	internalToken string
 	metrics       botMentionMetricRecorder
 	now           func() time.Time
-	claimRenewal  time.Duration
 	log.Log
 }
 
@@ -61,7 +58,6 @@ func New(ctx *config.Context) *BotMention {
 		internalToken: token,
 		metrics:       defaultBotMentionMetrics,
 		now:           time.Now,
-		claimRenewal:  claimPendingTTL / 3,
 		Log:           logger,
 	}
 }
@@ -162,23 +158,9 @@ func (m *BotMention) create(c *wkhttp.Context) {
 		respondBotMentionStoreFailed(c)
 		return
 	}
-	renewed, renewErr := m.claims.Renew(lease)
-	if renewErr != nil {
-		m.Error("bot mention idempotency lease renewal failed", zap.Error(renewErr), zap.String("idempotency_hash", mentionClaimLogHash(claimKey)))
-		respondBotMentionStoreFailed(c)
-		return
-	}
-	if !renewed {
-		result = "conflict"
-		respondBotMentionInProgress(c)
-		return
-	}
-
 	eventData := mentionEventData(mention, m.now().Unix())
 	enqueueStarted := time.Now()
-	stopKeepalive := m.startClaimLeaseKeepalive(lease, claimKey)
-	eventID, err := m.robots.EnqueueBotTypedEvent(mention.BotUID, docCommentMentionEventType, eventData)
-	stopKeepalive()
+	prepared, err := m.robots.PrepareBotTypedEvent(mention.BotUID, docCommentMentionEventType, eventData)
 	if err != nil {
 		if m.metrics != nil {
 			m.metrics.ObserveEnqueue("error", time.Since(enqueueStarted))
@@ -187,25 +169,57 @@ func (m *BotMention) create(c *wkhttp.Context) {
 			m.Warn("bot mention claim release did not apply",
 				zap.Bool("released", released), zap.Error(releaseErr), zap.String("idempotency_hash", mentionClaimLogHash(claimKey)))
 		}
-		m.Error("bot mention event enqueue failed", zap.Error(err), zap.String("bot_uid", mention.BotUID), zap.String("idempotency_hash", mentionClaimLogHash(claimKey)))
+		m.Error("bot mention event preparation failed", zap.Error(err), zap.String("bot_uid", mention.BotUID), zap.String("idempotency_hash", mentionClaimLogHash(claimKey)))
 		respondBotMentionStoreFailed(c)
+		return
+	}
+
+	committed, commitErr := m.claims.Commit(lease, prepared)
+	if commitErr != nil {
+		current, lookupErr := m.claims.Lookup(claimKey, fingerprint)
+		if lookupErr == nil && current.State == claimReplay {
+			if m.metrics != nil {
+				m.metrics.ObserveEnqueue("accepted", time.Since(enqueueStarted))
+			}
+			result = "replay"
+			m.logOutcome(mention, result, current.EventID, claimKey)
+			c.Response(mentionIngressResponse{Accepted: true, Replay: true, EventID: current.EventID})
+			return
+		}
+		if m.metrics != nil {
+			m.metrics.ObserveEnqueue("error", time.Since(enqueueStarted))
+		}
+		m.Error("bot mention atomic enqueue failed",
+			zap.NamedError("commit_error", commitErr), zap.NamedError("lookup_error", lookupErr),
+			zap.Int64("event_id", prepared.EventID), zap.String("idempotency_hash", mentionClaimLogHash(claimKey)))
+		respondBotMentionStoreFailed(c)
+		return
+	}
+	if !committed {
+		current, lookupErr := m.claims.Lookup(claimKey, fingerprint)
+		if lookupErr != nil {
+			m.Error("bot mention stale enqueue outcome lookup failed", zap.Error(lookupErr), zap.String("idempotency_hash", mentionClaimLogHash(claimKey)))
+			respondBotMentionStoreFailed(c)
+			return
+		}
+		if handled, claimResult := respondBotMentionClaimOutcome(c, current); handled {
+			result = claimResult
+			if claimResult == "replay" {
+				m.logOutcome(mention, claimResult, current.EventID, claimKey)
+			}
+			return
+		}
+		result = "conflict"
+		respondBotMentionInProgress(c)
 		return
 	}
 	if m.metrics != nil {
 		m.metrics.ObserveEnqueue("accepted", time.Since(enqueueStarted))
 	}
 
-	if confirmed, confirmErr := m.claims.Confirm(lease, eventID); confirmErr != nil || !confirmed {
-		// The event is already in the bot queue. Do not report a false failure or
-		// attempt to roll it back; the consumer deduplicates on idempotency_key.
-		m.Warn("bot mention idempotency confirm did not apply",
-			zap.Bool("confirmed", confirmed), zap.Error(confirmErr),
-			zap.Int64("event_id", eventID), zap.String("idempotency_hash", mentionClaimLogHash(claimKey)))
-	}
-
 	result = "accepted"
-	m.logOutcome(mention, result, eventID, claimKey)
-	c.Response(mentionIngressResponse{Accepted: true, Replay: false, EventID: eventID})
+	m.logOutcome(mention, result, prepared.EventID, claimKey)
+	c.Response(mentionIngressResponse{Accepted: true, Replay: false, EventID: prepared.EventID})
 }
 
 func decodeMentionRequest(c *wkhttp.Context) (mentionRequest, error) {
@@ -232,46 +246,6 @@ func (m *BotMention) logOutcome(mention normalizedMention, result string, eventI
 		zap.String("bot_uid", mention.BotUID),
 		zap.String("idempotency_hash", mentionClaimLogHash(claimKey)),
 	)
-}
-
-func (m *BotMention) startClaimLeaseKeepalive(lease *claimLease, claimKey string) func() {
-	done := make(chan struct{})
-	stopped := make(chan struct{})
-	go func() {
-		defer close(stopped)
-		interval := m.claimRenewal
-		if interval <= 0 {
-			interval = claimPendingTTL / 3
-		}
-		ticker := time.NewTicker(interval)
-		defer ticker.Stop()
-		for {
-			select {
-			case <-done:
-				return
-			case <-ticker.C:
-				renewed, err := m.claims.Renew(lease)
-				if err != nil {
-					m.Warn("bot mention idempotency lease keepalive failed",
-						zap.Error(err), zap.String("idempotency_hash", mentionClaimLogHash(claimKey)))
-					continue
-				}
-				if !renewed {
-					m.Warn("bot mention idempotency lease keepalive lost ownership",
-						zap.String("idempotency_hash", mentionClaimLogHash(claimKey)))
-					return
-				}
-			}
-		}
-	}()
-
-	var once sync.Once
-	return func() {
-		once.Do(func() {
-			close(done)
-			<-stopped
-		})
-	}
 }
 
 func respondBotMentionClaimOutcome(c *wkhttp.Context, outcome claimOutcome) (bool, string) {

--- a/modules/bot_mention/api_i18n.go
+++ b/modules/bot_mention/api_i18n.go
@@ -27,7 +27,7 @@ func respondBotMentionNotFound(c *wkhttp.Context) {
 }
 
 func respondBotMentionInProgress(c *wkhttp.Context) {
-	c.Header("Retry-After", strconv.Itoa(int(claimPendingTTL/time.Second)))
+	c.Header("Retry-After", strconv.Itoa(int(claimRetryAfter/time.Second)))
 	httperr.ResponseErrorLWithStatus(c, errcode.ErrBotMentionInProgress, nil, nil)
 }
 

--- a/modules/bot_mention/api_i18n.go
+++ b/modules/bot_mention/api_i18n.go
@@ -1,0 +1,40 @@
+package bot_mention
+
+import (
+	"strconv"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
+	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
+)
+
+func respondBotMentionUnauthorized(c *wkhttp.Context) {
+	httperr.ResponseErrorLWithStatus(c, errcode.ErrSharedTokenInvalid, nil, nil)
+}
+
+func respondBotMentionInvalid(c *wkhttp.Context, field string) {
+	var details i18n.Details
+	if field != "" {
+		details = i18n.Details{"field": field}
+	}
+	httperr.ResponseErrorLWithStatus(c, errcode.ErrSharedParamInvalid, nil, details)
+}
+
+func respondBotMentionNotFound(c *wkhttp.Context) {
+	httperr.ResponseErrorLWithStatus(c, errcode.ErrSharedNotFound, nil, nil)
+}
+
+func respondBotMentionInProgress(c *wkhttp.Context) {
+	c.Header("Retry-After", strconv.Itoa(int(claimPendingTTL/time.Second)))
+	httperr.ResponseErrorLWithStatus(c, errcode.ErrBotMentionInProgress, nil, nil)
+}
+
+func respondBotMentionConflict(c *wkhttp.Context) {
+	httperr.ResponseErrorLWithStatus(c, errcode.ErrBotMentionIdempotencyConflict, nil, nil)
+}
+
+func respondBotMentionStoreFailed(c *wkhttp.Context) {
+	httperr.ResponseErrorLWithStatus(c, errcode.ErrBotMentionStoreFailed, nil, nil)
+}

--- a/modules/bot_mention/api_i18n_test.go
+++ b/modules/bot_mention/api_i18n_test.go
@@ -2,15 +2,19 @@ package bot_mention
 
 import (
 	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"testing"
 )
 
-// TestBotMentionNoLegacyResponseError pins the new internal endpoint to the
-// localized error envelope. Add future handler files to this list.
+// TestBotMentionNoLegacyResponseError pins the module to the localized error
+// envelope and automatically covers future production Go files.
 func TestBotMentionNoLegacyResponseError(t *testing.T) {
-	files := []string{"api.go", "api_i18n.go"}
+	files, err := filepath.Glob("*.go")
+	if err != nil {
+		t.Fatalf("glob module files: %v", err)
+	}
 	banned := []string{
 		".ResponseError(",
 		".ResponseErrorf(",
@@ -21,6 +25,9 @@ func TestBotMentionNoLegacyResponseError(t *testing.T) {
 		regexp.MustCompile(`c\.AbortWithStatus(?:JSON)?\(`),
 	}
 	for _, file := range files {
+		if strings.HasSuffix(file, "_test.go") {
+			continue
+		}
 		t.Run(file, func(t *testing.T) {
 			data, err := os.ReadFile(file)
 			if err != nil {

--- a/modules/bot_mention/api_i18n_test.go
+++ b/modules/bot_mention/api_i18n_test.go
@@ -1,0 +1,50 @@
+package bot_mention
+
+import (
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// TestBotMentionNoLegacyResponseError pins the new internal endpoint to the
+// localized error envelope. Add future handler files to this list.
+func TestBotMentionNoLegacyResponseError(t *testing.T) {
+	files := []string{"api.go", "api_i18n.go"}
+	banned := []string{
+		".ResponseError(",
+		".ResponseErrorf(",
+		".ResponseErrorWithStatus(",
+	}
+	patterns := []*regexp.Regexp{
+		regexp.MustCompile(`c\.JSON\(\s*(?:http\.Status[A-Z]|[1-5]\d{2}\b)`),
+		regexp.MustCompile(`c\.AbortWithStatus(?:JSON)?\(`),
+	}
+	for _, file := range files {
+		t.Run(file, func(t *testing.T) {
+			data, err := os.ReadFile(file)
+			if err != nil {
+				t.Fatalf("read %s: %v", file, err)
+			}
+			var clean strings.Builder
+			for _, line := range strings.Split(string(data), "\n") {
+				if idx := strings.Index(line, "//"); idx >= 0 {
+					line = line[:idx]
+				}
+				clean.WriteString(line)
+				clean.WriteByte('\n')
+			}
+			cleaned := clean.String()
+			for _, token := range banned {
+				if strings.Contains(cleaned, token) {
+					t.Fatalf("modules/bot_mention/%s must use httperr.ResponseErrorLWithStatus, found %s", file, token)
+				}
+			}
+			for _, pattern := range patterns {
+				if match := pattern.FindString(cleaned); match != "" {
+					t.Fatalf("modules/bot_mention/%s contains banned raw error response %q", file, match)
+				}
+			}
+		})
+	}
+}

--- a/modules/bot_mention/api_test.go
+++ b/modules/bot_mention/api_test.go
@@ -15,6 +15,8 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
 	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 )
 
 type stubRobotService struct {
@@ -75,6 +77,49 @@ type fakeMetricRecorder struct {
 	mu       sync.Mutex
 	ingress  []string
 	enqueues []string
+}
+
+type capturedLogEntry struct {
+	level  string
+	msg    string
+	fields map[string]interface{}
+}
+
+type capturedLog struct {
+	mu      sync.Mutex
+	entries []capturedLogEntry
+}
+
+func (l *capturedLog) append(level, msg string, fields ...zap.Field) {
+	encoder := zapcore.NewMapObjectEncoder()
+	for _, field := range fields {
+		field.AddTo(encoder)
+	}
+	l.mu.Lock()
+	l.entries = append(l.entries, capturedLogEntry{level: level, msg: msg, fields: encoder.Fields})
+	l.mu.Unlock()
+}
+
+func (l *capturedLog) Info(msg string, fields ...zap.Field) {
+	l.append("info", msg, fields...)
+}
+
+func (l *capturedLog) Debug(msg string, fields ...zap.Field) {
+	l.append("debug", msg, fields...)
+}
+
+func (l *capturedLog) Error(msg string, fields ...zap.Field) {
+	l.append("error", msg, fields...)
+}
+
+func (l *capturedLog) Warn(msg string, fields ...zap.Field) {
+	l.append("warn", msg, fields...)
+}
+
+func (l *capturedLog) snapshot() []capturedLogEntry {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return append([]capturedLogEntry(nil), l.entries...)
 }
 
 func (m *fakeMetricRecorder) ObserveIngress(result string, _ time.Duration) {
@@ -299,8 +344,8 @@ func TestBotMentionConcurrentDuplicateHasSingleEnqueue(t *testing.T) {
 		if w.Code != http.StatusConflict {
 			t.Fatalf("in-flight duplicate status = %d, body=%s", w.Code, w.Body.String())
 		}
-		if got := w.Header().Get("Retry-After"); got != "60" {
-			t.Fatalf("Retry-After = %q, want 60", got)
+		if got := w.Header().Get("Retry-After"); got != "2" {
+			t.Fatalf("Retry-After = %q, want 2", got)
 		}
 	}
 	close(robots.enqueueContinue)
@@ -349,6 +394,20 @@ func TestBotMentionRejectsInvalidRequests(t *testing.T) {
 	badURL.URL = "file:///etc/passwd"
 	missingBot := validMentionRequest()
 	missingBot.BotUID = ""
+	unknownField := map[string]interface{}{
+		"idempotency_key": "idem-1",
+		"doc_id":          "doc-1",
+		"comment_id":      "comment-1",
+		"from_uid":        "human-1",
+		"bot_uid":         "bot-1",
+		"text":            "update it",
+		"thread_id":       "caller-controlled-thread",
+	}
+	validRaw, err := json.Marshal(validMentionRequest())
+	if err != nil {
+		t.Fatal(err)
+	}
+	trailingJSON := append(append([]byte(nil), validRaw...), []byte(`{"extra":true}`)...)
 
 	tests := []struct {
 		name string
@@ -358,6 +417,8 @@ func TestBotMentionRejectsInvalidRequests(t *testing.T) {
 		{name: "oversized body", body: oversized},
 		{name: "unsafe url", body: badURL},
 		{name: "missing required field", body: missingBot},
+		{name: "unknown field", body: unknownField},
+		{name: "trailing json value", body: trailingJSON},
 		{name: "empty body", body: []byte{}},
 	}
 	for _, tc := range tests {
@@ -403,10 +464,15 @@ func TestBotMentionDisabledIsDistinguishableAndDoesNotClaim(t *testing.T) {
 func TestBotMentionRejectsUnavailableUserBotAndDependencyFailure(t *testing.T) {
 	t.Run("non active user bot is opaque not found", func(t *testing.T) {
 		robots := &stubRobotService{exists: false}
-		module := newTestBotMention(robots, &scriptedClaimStore{}, newFeatureGate(true, "", "*"), &fakeMetricRecorder{})
+		metrics := &fakeMetricRecorder{}
+		module := newTestBotMention(robots, &scriptedClaimStore{}, newFeatureGate(true, "", "*"), metrics)
 		w := doMentionRequest(t, newMentionRouter(module), "internal-secret", validMentionRequest())
 		if w.Code != http.StatusNotFound || decodeMentionError(t, w).Error.Code != "err.shared.not_found" {
 			t.Fatalf("status=%d body=%s", w.Code, w.Body.String())
+		}
+		ingress, _ := metrics.snapshot()
+		if fmt.Sprint(ingress) != "[not_found]" {
+			t.Fatalf("ingress metrics = %v, want [not_found]", ingress)
 		}
 	})
 
@@ -418,6 +484,89 @@ func TestBotMentionRejectsUnavailableUserBotAndDependencyFailure(t *testing.T) {
 			t.Fatalf("status=%d body=%s", w.Code, w.Body.String())
 		}
 	})
+}
+
+func TestBotMentionStructuredOutcomeLogsDoNotLeakSensitivePayload(t *testing.T) {
+	request := validMentionRequest()
+	request.IdempotencyKey = "secret-idempotency-key"
+	request.Text = "sensitive full comment body"
+	request.URL = "https://docs.example.test/sensitive-location"
+
+	logger := &capturedLog{}
+	backend := newMemoryClaimBackend()
+	claims := newClaimStore(backend, time.Hour, deterministicTokens("lease-1"))
+	module := newTestBotMention(
+		&stubRobotService{exists: true, eventID: 4242},
+		claims,
+		newFeatureGate(true, "", "*"),
+		&fakeMetricRecorder{},
+	)
+	module.Log = logger
+	router := newMentionRouter(module)
+
+	for _, wantReplay := range []bool{false, true} {
+		response := doMentionRequest(t, router, "internal-secret", request)
+		if response.Code != http.StatusOK {
+			t.Fatalf("ingress status = %d, body=%s", response.Code, response.Body.String())
+		}
+		if got := decodeMentionResponse(t, response).Replay; got != wantReplay {
+			t.Fatalf("replay = %v, want %v", got, wantReplay)
+		}
+	}
+
+	disabled := newTestBotMention(
+		&stubRobotService{exists: true, eventID: 1},
+		newClaimStore(newMemoryClaimBackend(), time.Hour, deterministicTokens("unused")),
+		newFeatureGate(false, "", "*"),
+		&fakeMetricRecorder{},
+	)
+	disabled.Log = logger
+	if response := doMentionRequest(t, newMentionRouter(disabled), "internal-secret", request); response.Code != http.StatusOK {
+		t.Fatalf("disabled status = %d, body=%s", response.Code, response.Body.String())
+	}
+
+	failed := newTestBotMention(
+		&stubRobotService{existErr: errors.New("mysql unavailable")},
+		&scriptedClaimStore{},
+		newFeatureGate(true, "", "*"),
+		&fakeMetricRecorder{},
+	)
+	failed.Log = logger
+	if response := doMentionRequest(t, newMentionRouter(failed), "internal-secret", request); response.Code != http.StatusInternalServerError {
+		t.Fatalf("failed status = %d, body=%s", response.Code, response.Body.String())
+	}
+
+	entries := logger.snapshot()
+	wantResults := map[string]bool{"accepted": false, "replay": false, "disabled": false}
+	for _, entry := range entries {
+		result, _ := entry.fields["result"].(string)
+		if _, ok := wantResults[result]; !ok || entry.level != "info" {
+			continue
+		}
+		wantResults[result] = true
+		if entry.fields["bot_uid"] != request.BotUID {
+			t.Fatalf("%s bot_uid = %#v", result, entry.fields["bot_uid"])
+		}
+		if _, ok := entry.fields["event_id"]; !ok {
+			t.Fatalf("%s log missing event_id: %#v", result, entry.fields)
+		}
+		hash, _ := entry.fields["idempotency_hash"].(string)
+		if len(hash) != 12 || strings.Contains(hash, request.IdempotencyKey) {
+			t.Fatalf("%s idempotency_hash = %q", result, hash)
+		}
+	}
+	for result, seen := range wantResults {
+		if !seen {
+			t.Fatalf("missing structured %s outcome log: %#v", result, entries)
+		}
+	}
+
+	serialized := fmt.Sprint(entries)
+	for _, sensitive := range []string{"internal-secret", request.IdempotencyKey, request.Text, request.URL} {
+		if strings.Contains(serialized, sensitive) {
+			t.Fatalf("logs leaked sensitive value %q: %s", sensitive, serialized)
+		}
+	}
 }
 
 func TestBotMentionClaimOutcomes(t *testing.T) {

--- a/modules/bot_mention/api_test.go
+++ b/modules/bot_mention/api_test.go
@@ -35,6 +35,7 @@ type stubRobotService struct {
 
 	enqueueStarted  chan struct{}
 	enqueueContinue chan struct{}
+	beforeEnqueue   func()
 	startOnce       sync.Once
 }
 
@@ -53,8 +54,12 @@ func (s *stubRobotService) EnqueueBotTypedEvent(robotID, eventType string, event
 	s.eventData = eventData
 	started := s.enqueueStarted
 	continuation := s.enqueueContinue
+	beforeEnqueue := s.beforeEnqueue
 	s.mu.Unlock()
 
+	if beforeEnqueue != nil {
+		beforeEnqueue()
+	}
 	if started != nil {
 		s.startOnce.Do(func() { close(started) })
 	}
@@ -149,10 +154,13 @@ type scriptedClaimStore struct {
 	confirmErr    error
 	releaseOK     bool
 	releaseErr    error
+	renewDenied   bool
+	renewErr      error
 
 	lease        *claimLease
 	confirmCalls int
 	releaseCalls int
+	renewCalls   int
 }
 
 func (s *scriptedClaimStore) Lookup(_, _ string) (claimOutcome, error) {
@@ -179,6 +187,11 @@ func (s *scriptedClaimStore) Confirm(_ *claimLease, _ int64) (bool, error) {
 func (s *scriptedClaimStore) Release(_ *claimLease) (bool, error) {
 	s.releaseCalls++
 	return s.releaseOK, s.releaseErr
+}
+
+func (s *scriptedClaimStore) Renew(_ *claimLease) (bool, error) {
+	s.renewCalls++
+	return !s.renewDenied, s.renewErr
 }
 
 type mentionResponse struct {
@@ -618,6 +631,40 @@ func TestBotMentionEnqueueFailureReleasesClaim(t *testing.T) {
 	}
 	if store.releaseCalls != 1 {
 		t.Fatalf("release calls = %d, want 1", store.releaseCalls)
+	}
+}
+
+func TestBotMentionRenewsClaimBeforeEnqueue(t *testing.T) {
+	store := &scriptedClaimStore{confirmOK: true}
+	robots := &stubRobotService{
+		exists:  true,
+		eventID: 4242,
+		beforeEnqueue: func() {
+			if store.renewCalls == 0 {
+				t.Error("claim lease was not renewed before enqueue")
+			}
+		},
+	}
+	module := newTestBotMention(robots, store, newFeatureGate(true, "", "*"), &fakeMetricRecorder{})
+	response := doMentionRequest(t, newMentionRouter(module), "internal-secret", validMentionRequest())
+	if response.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", response.Code, response.Body.String())
+	}
+	if store.renewCalls == 0 {
+		t.Fatal("renew calls = 0, want at least one")
+	}
+}
+
+func TestBotMentionLostLeaseBeforeEnqueueReturnsInProgress(t *testing.T) {
+	store := &scriptedClaimStore{renewDenied: true}
+	robots := &stubRobotService{exists: true, eventID: 4242}
+	module := newTestBotMention(robots, store, newFeatureGate(true, "", "*"), &fakeMetricRecorder{})
+	response := doMentionRequest(t, newMentionRouter(module), "internal-secret", validMentionRequest())
+	if response.Code != http.StatusConflict || decodeMentionError(t, response).Error.Code != "err.server.bot_mention.in_progress" {
+		t.Fatalf("status=%d body=%s", response.Code, response.Body.String())
+	}
+	if _, enqueues := robots.counts(); enqueues != 0 {
+		t.Fatalf("enqueue calls = %d, want 0", enqueues)
 	}
 }
 

--- a/modules/bot_mention/api_test.go
+++ b/modules/bot_mention/api_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/modules/robot"
 	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -45,14 +46,13 @@ type leaseRaceRobotService struct {
 	firstStarted chan struct{}
 	releaseFirst chan struct{}
 	enqueueCalls int
-	eventIDs     []int64
 }
 
 func (s *leaseRaceRobotService) ExistRobot(string) (bool, error) {
 	return true, nil
 }
 
-func (s *leaseRaceRobotService) EnqueueBotTypedEvent(_ string, _ string, _ map[string]interface{}) (int64, error) {
+func (s *leaseRaceRobotService) PrepareBotTypedEvent(robotID string, _ string, _ map[string]interface{}) (robot.PreparedBotTypedEvent, error) {
 	s.mu.Lock()
 	s.enqueueCalls++
 	call := s.enqueueCalls
@@ -64,16 +64,11 @@ func (s *leaseRaceRobotService) EnqueueBotTypedEvent(_ string, _ string, _ map[s
 	}
 
 	eventID := int64(1000 + call)
-	s.mu.Lock()
-	s.eventIDs = append(s.eventIDs, eventID)
-	s.mu.Unlock()
-	return eventID, nil
-}
-
-func (s *leaseRaceRobotService) visibleEventIDs() []int64 {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	return append([]int64(nil), s.eventIDs...)
+	return robot.PreparedBotTypedEvent{
+		EventID:  eventID,
+		QueueKey: "robotEvent:" + robotID,
+		Member:   fmt.Sprintf("event-%d", eventID),
+	}, nil
 }
 
 type observingClaimBackend struct {
@@ -82,8 +77,52 @@ type observingClaimBackend struct {
 	once     sync.Once
 }
 
-func (b *observingClaimBackend) CompareAndSet(key, oldValue, newValue string, ttl time.Duration) (bool, error) {
-	ok, err := b.memoryClaimBackend.CompareAndSet(key, oldValue, newValue, ttl)
+type ambiguousCommitClaimStore struct {
+	mu sync.Mutex
+
+	committed    bool
+	eventID      int64
+	commitCalls  int
+	releaseCalls int
+}
+
+func (s *ambiguousCommitClaimStore) Lookup(string, string) (claimOutcome, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.committed {
+		return claimOutcome{State: claimReplay, EventID: s.eventID}, nil
+	}
+	return claimOutcome{State: claimMissing}, nil
+}
+
+func (s *ambiguousCommitClaimStore) Begin(string, string) (claimOutcome, *claimLease, error) {
+	return claimOutcome{State: claimAcquired}, &claimLease{}, nil
+}
+
+func (s *ambiguousCommitClaimStore) Commit(_ *claimLease, event robot.PreparedBotTypedEvent) (bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.committed = true
+	s.eventID = event.EventID
+	s.commitCalls++
+	return false, errors.New("redis response lost after atomic commit")
+}
+
+func (s *ambiguousCommitClaimStore) Release(*claimLease) (bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.releaseCalls++
+	return true, nil
+}
+
+func (s *ambiguousCommitClaimStore) counts() (commits, releases int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.commitCalls, s.releaseCalls
+}
+
+func (b *observingClaimBackend) CompareAndEnqueue(key, oldValue, newValue string, ttl time.Duration, event robot.PreparedBotTypedEvent) (bool, error) {
+	ok, err := b.memoryClaimBackend.CompareAndEnqueue(key, oldValue, newValue, ttl, event)
 	if err == nil && !ok {
 		b.once.Do(func() { close(b.staleCAS) })
 	}
@@ -97,7 +136,7 @@ func (s *stubRobotService) ExistRobot(uid string) (bool, error) {
 	return s.exists, s.existErr
 }
 
-func (s *stubRobotService) EnqueueBotTypedEvent(robotID, eventType string, eventData map[string]interface{}) (int64, error) {
+func (s *stubRobotService) PrepareBotTypedEvent(robotID, eventType string, eventData map[string]interface{}) (robot.PreparedBotTypedEvent, error) {
 	s.mu.Lock()
 	s.enqueueCalls++
 	s.robotID = robotID
@@ -118,9 +157,13 @@ func (s *stubRobotService) EnqueueBotTypedEvent(robotID, eventType string, event
 		<-continuation
 	}
 	if s.enqueueErr != nil {
-		return 0, s.enqueueErr
+		return robot.PreparedBotTypedEvent{}, s.enqueueErr
 	}
-	return s.eventID, nil
+	return robot.PreparedBotTypedEvent{
+		EventID:  s.eventID,
+		QueueKey: "robotEvent:" + robotID,
+		Member:   fmt.Sprintf("event-%d", s.eventID),
+	}, nil
 }
 
 func (s *stubRobotService) counts() (exists, enqueues int) {
@@ -201,18 +244,14 @@ type scriptedClaimStore struct {
 	lookupErr     error
 	beginOutcome  claimOutcome
 	beginErr      error
-	confirmOK     bool
-	confirmErr    error
+	commitDenied  bool
+	commitErr     error
 	releaseOK     bool
 	releaseErr    error
-	renewDenied   bool
-	renewErr      error
-	renewSignal   chan struct{}
 
 	lease        *claimLease
-	confirmCalls int
+	commitCalls  int
 	releaseCalls int
-	renewCalls   int
 }
 
 func (s *scriptedClaimStore) Lookup(_, _ string) (claimOutcome, error) {
@@ -231,22 +270,14 @@ func (s *scriptedClaimStore) Begin(_, _ string) (claimOutcome, *claimLease, erro
 	return outcome, lease, s.beginErr
 }
 
-func (s *scriptedClaimStore) Confirm(_ *claimLease, _ int64) (bool, error) {
-	s.confirmCalls++
-	return s.confirmOK, s.confirmErr
+func (s *scriptedClaimStore) Commit(_ *claimLease, _ robot.PreparedBotTypedEvent) (bool, error) {
+	s.commitCalls++
+	return !s.commitDenied, s.commitErr
 }
 
 func (s *scriptedClaimStore) Release(_ *claimLease) (bool, error) {
 	s.releaseCalls++
 	return s.releaseOK, s.releaseErr
-}
-
-func (s *scriptedClaimStore) Renew(_ *claimLease) (bool, error) {
-	s.renewCalls++
-	if s.renewSignal != nil {
-		s.renewSignal <- struct{}{}
-	}
-	return !s.renewDenied, s.renewErr
 }
 
 type mentionResponse struct {
@@ -271,7 +302,6 @@ func newTestBotMention(robots botMentionRobotService, claims botMentionClaimStor
 		internalToken: "internal-secret",
 		metrics:       metrics,
 		now:           func() time.Time { return time.Unix(1_785_460_000, 0) },
-		claimRenewal:  claimPendingTTL / 3,
 		Log:           log.NewTLog("BotMentionTest"),
 	}
 }
@@ -677,9 +707,9 @@ func TestBotMentionClaimOutcomes(t *testing.T) {
 	}
 }
 
-func TestBotMentionEnqueueFailureReleasesClaim(t *testing.T) {
-	store := &scriptedClaimStore{confirmOK: true, releaseOK: true}
-	robots := &stubRobotService{exists: true, enqueueErr: errors.New("redis zadd failed")}
+func TestBotMentionPrepareFailureReleasesClaim(t *testing.T) {
+	store := &scriptedClaimStore{releaseOK: true}
+	robots := &stubRobotService{exists: true, enqueueErr: errors.New("allocate event ID failed")}
 	module := newTestBotMention(robots, store, newFeatureGate(true, "", "*"), &fakeMetricRecorder{})
 	w := doMentionRequest(t, newMentionRouter(module), "internal-secret", validMentionRequest())
 	if w.Code != http.StatusInternalServerError || decodeMentionError(t, w).Error.Code != "err.server.bot_mention.store_failed" {
@@ -690,69 +720,16 @@ func TestBotMentionEnqueueFailureReleasesClaim(t *testing.T) {
 	}
 }
 
-func TestBotMentionRenewsClaimBeforeEnqueue(t *testing.T) {
-	store := &scriptedClaimStore{confirmOK: true}
-	robots := &stubRobotService{
-		exists:  true,
-		eventID: 4242,
-		beforeEnqueue: func() {
-			if store.renewCalls == 0 {
-				t.Error("claim lease was not renewed before enqueue")
-			}
-		},
-	}
-	module := newTestBotMention(robots, store, newFeatureGate(true, "", "*"), &fakeMetricRecorder{})
-	response := doMentionRequest(t, newMentionRouter(module), "internal-secret", validMentionRequest())
-	if response.Code != http.StatusOK {
-		t.Fatalf("status=%d body=%s", response.Code, response.Body.String())
-	}
-	if store.renewCalls == 0 {
-		t.Fatal("renew calls = 0, want at least one")
-	}
-}
-
-func TestBotMentionLostLeaseBeforeEnqueueReturnsInProgress(t *testing.T) {
-	store := &scriptedClaimStore{renewDenied: true}
+func TestBotMentionStaleCommitReturnsInProgress(t *testing.T) {
+	store := &scriptedClaimStore{commitDenied: true}
 	robots := &stubRobotService{exists: true, eventID: 4242}
 	module := newTestBotMention(robots, store, newFeatureGate(true, "", "*"), &fakeMetricRecorder{})
 	response := doMentionRequest(t, newMentionRouter(module), "internal-secret", validMentionRequest())
 	if response.Code != http.StatusConflict || decodeMentionError(t, response).Error.Code != "err.server.bot_mention.in_progress" {
 		t.Fatalf("status=%d body=%s", response.Code, response.Body.String())
 	}
-	if _, enqueues := robots.counts(); enqueues != 0 {
-		t.Fatalf("enqueue calls = %d, want 0", enqueues)
-	}
-}
-
-func TestBotMentionRenewsClaimWhileEnqueueIsBlocked(t *testing.T) {
-	renewSignal := make(chan struct{}, 4)
-	store := &scriptedClaimStore{confirmOK: true, renewSignal: renewSignal}
-	robots := &stubRobotService{
-		exists:          true,
-		eventID:         4242,
-		enqueueStarted:  make(chan struct{}),
-		enqueueContinue: make(chan struct{}),
-	}
-	module := newTestBotMention(robots, store, newFeatureGate(true, "", "*"), &fakeMetricRecorder{})
-	module.claimRenewal = time.Millisecond
-	router := newMentionRouter(module)
-
-	result := make(chan *httptest.ResponseRecorder, 1)
-	go func() {
-		result <- doMentionRequest(t, router, "internal-secret", validMentionRequest())
-	}()
-
-	<-renewSignal // synchronous pre-enqueue renewal
-	<-robots.enqueueStarted
-	select {
-	case <-renewSignal: // periodic renewal while enqueue is still blocked
-	case <-time.After(time.Second):
-		t.Fatal("claim lease was not renewed while enqueue was blocked")
-	}
-	close(robots.enqueueContinue)
-	response := <-result
-	if response.Code != http.StatusOK {
-		t.Fatalf("status=%d body=%s", response.Code, response.Body.String())
+	if store.commitCalls != 1 || store.releaseCalls != 0 {
+		t.Fatalf("commit=%d release=%d, want 1 and 0", store.commitCalls, store.releaseCalls)
 	}
 }
 
@@ -767,7 +744,6 @@ func TestBotMentionLostLeaseDuringBlockedEnqueueReplaysSingleVisibleEvent(t *tes
 		releaseFirst: make(chan struct{}),
 	}
 	module := newTestBotMention(robots, store, newFeatureGate(true, "", "*"), &fakeMetricRecorder{})
-	module.claimRenewal = time.Millisecond
 	router := newMentionRouter(module)
 	request := validMentionRequest()
 	claimKey := mentionClaimKey(request.BotUID, request.IdempotencyKey)
@@ -791,13 +767,13 @@ func TestBotMentionLostLeaseDuringBlockedEnqueueReplaysSingleVisibleEvent(t *tes
 	if !secondResponse.Accepted || secondResponse.Replay {
 		t.Fatalf("retry response=%+v, want newly accepted event", secondResponse)
 	}
+	close(robots.releaseFirst)
 	select {
 	case <-backend.staleCAS:
 	case <-time.After(time.Second):
 		t.Fatal("blocked attempt did not observe lease loss")
 	}
 
-	close(robots.releaseFirst)
 	var first *httptest.ResponseRecorder
 	select {
 	case first = <-firstResult:
@@ -811,13 +787,26 @@ func TestBotMentionLostLeaseDuringBlockedEnqueueReplaysSingleVisibleEvent(t *tes
 	if !firstResponse.Accepted || !firstResponse.Replay || firstResponse.EventID != secondResponse.EventID {
 		t.Fatalf("first response=%+v, want replay of event_id %d", firstResponse, secondResponse.EventID)
 	}
-	if visible := robots.visibleEventIDs(); len(visible) != 1 || visible[0] != secondResponse.EventID {
+	if visible := backend.queuedEventIDs("robotEvent:" + request.BotUID); len(visible) != 1 || visible[0] != secondResponse.EventID {
 		t.Fatalf("visible event IDs=%v, want only %d", visible, secondResponse.EventID)
 	}
 }
 
-func TestBotMentionConfirmFailureDoesNotRollBackEnqueuedEvent(t *testing.T) {
-	store := &scriptedClaimStore{confirmErr: errors.New("redis cas failed")}
+func TestBotMentionAtomicCommitFailureFailsClosedWithoutRelease(t *testing.T) {
+	store := &scriptedClaimStore{commitErr: errors.New("redis eval failed")}
+	robots := &stubRobotService{exists: true, eventID: 777}
+	module := newTestBotMention(robots, store, newFeatureGate(true, "", "*"), &fakeMetricRecorder{})
+	w := doMentionRequest(t, newMentionRouter(module), "internal-secret", validMentionRequest())
+	if w.Code != http.StatusInternalServerError || decodeMentionError(t, w).Error.Code != "err.server.bot_mention.store_failed" {
+		t.Fatalf("status=%d body=%s", w.Code, w.Body.String())
+	}
+	if store.commitCalls != 1 || store.releaseCalls != 0 {
+		t.Fatalf("commit=%d release=%d, want 1 and 0", store.commitCalls, store.releaseCalls)
+	}
+}
+
+func TestBotMentionRecoversAmbiguousAtomicCommitAsReplay(t *testing.T) {
+	store := &ambiguousCommitClaimStore{}
 	robots := &stubRobotService{exists: true, eventID: 777}
 	module := newTestBotMention(robots, store, newFeatureGate(true, "", "*"), &fakeMetricRecorder{})
 	w := doMentionRequest(t, newMentionRouter(module), "internal-secret", validMentionRequest())
@@ -825,10 +814,11 @@ func TestBotMentionConfirmFailureDoesNotRollBackEnqueuedEvent(t *testing.T) {
 		t.Fatalf("status=%d body=%s", w.Code, w.Body.String())
 	}
 	response := decodeMentionResponse(t, w)
-	if !response.Accepted || response.Replay || response.EventID != 777 {
-		t.Fatalf("response=%+v", response)
+	if !response.Accepted || !response.Replay || response.EventID != 777 {
+		t.Fatalf("response=%+v, want replay of event 777", response)
 	}
-	if store.confirmCalls != 1 || store.releaseCalls != 0 {
-		t.Fatalf("confirm=%d release=%d", store.confirmCalls, store.releaseCalls)
+	commits, releases := store.counts()
+	if commits != 1 || releases != 0 {
+		t.Fatalf("commit=%d release=%d, want 1 and 0", commits, releases)
 	}
 }

--- a/modules/bot_mention/api_test.go
+++ b/modules/bot_mention/api_test.go
@@ -156,6 +156,7 @@ type scriptedClaimStore struct {
 	releaseErr    error
 	renewDenied   bool
 	renewErr      error
+	renewSignal   chan struct{}
 
 	lease        *claimLease
 	confirmCalls int
@@ -191,6 +192,9 @@ func (s *scriptedClaimStore) Release(_ *claimLease) (bool, error) {
 
 func (s *scriptedClaimStore) Renew(_ *claimLease) (bool, error) {
 	s.renewCalls++
+	if s.renewSignal != nil {
+		s.renewSignal <- struct{}{}
+	}
 	return !s.renewDenied, s.renewErr
 }
 
@@ -216,6 +220,7 @@ func newTestBotMention(robots botMentionRobotService, claims botMentionClaimStor
 		internalToken: "internal-secret",
 		metrics:       metrics,
 		now:           func() time.Time { return time.Unix(1_785_460_000, 0) },
+		claimRenewal:  claimPendingTTL / 3,
 		Log:           log.NewTLog("BotMentionTest"),
 	}
 }
@@ -665,6 +670,38 @@ func TestBotMentionLostLeaseBeforeEnqueueReturnsInProgress(t *testing.T) {
 	}
 	if _, enqueues := robots.counts(); enqueues != 0 {
 		t.Fatalf("enqueue calls = %d, want 0", enqueues)
+	}
+}
+
+func TestBotMentionRenewsClaimWhileEnqueueIsBlocked(t *testing.T) {
+	renewSignal := make(chan struct{}, 4)
+	store := &scriptedClaimStore{confirmOK: true, renewSignal: renewSignal}
+	robots := &stubRobotService{
+		exists:          true,
+		eventID:         4242,
+		enqueueStarted:  make(chan struct{}),
+		enqueueContinue: make(chan struct{}),
+	}
+	module := newTestBotMention(robots, store, newFeatureGate(true, "", "*"), &fakeMetricRecorder{})
+	module.claimRenewal = time.Millisecond
+	router := newMentionRouter(module)
+
+	result := make(chan *httptest.ResponseRecorder, 1)
+	go func() {
+		result <- doMentionRequest(t, router, "internal-secret", validMentionRequest())
+	}()
+
+	<-renewSignal // synchronous pre-enqueue renewal
+	<-robots.enqueueStarted
+	select {
+	case <-renewSignal: // periodic renewal while enqueue is still blocked
+	case <-time.After(time.Second):
+		t.Fatal("claim lease was not renewed while enqueue was blocked")
+	}
+	close(robots.enqueueContinue)
+	response := <-result
+	if response.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", response.Code, response.Body.String())
 	}
 }
 

--- a/modules/bot_mention/api_test.go
+++ b/modules/bot_mention/api_test.go
@@ -1,0 +1,490 @@
+package bot_mention
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
+)
+
+type stubRobotService struct {
+	mu sync.Mutex
+
+	exists     bool
+	existErr   error
+	enqueueErr error
+	eventID    int64
+
+	existCalls   int
+	enqueueCalls int
+	robotID      string
+	eventType    string
+	eventData    map[string]interface{}
+
+	enqueueStarted  chan struct{}
+	enqueueContinue chan struct{}
+	startOnce       sync.Once
+}
+
+func (s *stubRobotService) ExistRobot(uid string) (bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.existCalls++
+	return s.exists, s.existErr
+}
+
+func (s *stubRobotService) EnqueueBotTypedEvent(robotID, eventType string, eventData map[string]interface{}) (int64, error) {
+	s.mu.Lock()
+	s.enqueueCalls++
+	s.robotID = robotID
+	s.eventType = eventType
+	s.eventData = eventData
+	started := s.enqueueStarted
+	continuation := s.enqueueContinue
+	s.mu.Unlock()
+
+	if started != nil {
+		s.startOnce.Do(func() { close(started) })
+	}
+	if continuation != nil {
+		<-continuation
+	}
+	if s.enqueueErr != nil {
+		return 0, s.enqueueErr
+	}
+	return s.eventID, nil
+}
+
+func (s *stubRobotService) counts() (exists, enqueues int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.existCalls, s.enqueueCalls
+}
+
+type fakeMetricRecorder struct {
+	mu       sync.Mutex
+	ingress  []string
+	enqueues []string
+}
+
+func (m *fakeMetricRecorder) ObserveIngress(result string, _ time.Duration) {
+	m.mu.Lock()
+	m.ingress = append(m.ingress, result)
+	m.mu.Unlock()
+}
+
+func (m *fakeMetricRecorder) ObserveEnqueue(result string) {
+	m.mu.Lock()
+	m.enqueues = append(m.enqueues, result)
+	m.mu.Unlock()
+}
+
+func (m *fakeMetricRecorder) snapshot() ([]string, []string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]string(nil), m.ingress...), append([]string(nil), m.enqueues...)
+}
+
+type scriptedClaimStore struct {
+	lookupOutcome claimOutcome
+	lookupErr     error
+	beginOutcome  claimOutcome
+	beginErr      error
+	confirmOK     bool
+	confirmErr    error
+	releaseOK     bool
+	releaseErr    error
+
+	lease        *claimLease
+	confirmCalls int
+	releaseCalls int
+}
+
+func (s *scriptedClaimStore) Lookup(_, _ string) (claimOutcome, error) {
+	return s.lookupOutcome, s.lookupErr
+}
+
+func (s *scriptedClaimStore) Begin(_, _ string) (claimOutcome, *claimLease, error) {
+	outcome := s.beginOutcome
+	if outcome.State == claimMissing {
+		outcome.State = claimAcquired
+	}
+	lease := s.lease
+	if lease == nil {
+		lease = &claimLease{}
+	}
+	return outcome, lease, s.beginErr
+}
+
+func (s *scriptedClaimStore) Confirm(_ *claimLease, _ int64) (bool, error) {
+	s.confirmCalls++
+	return s.confirmOK, s.confirmErr
+}
+
+func (s *scriptedClaimStore) Release(_ *claimLease) (bool, error) {
+	s.releaseCalls++
+	return s.releaseOK, s.releaseErr
+}
+
+type mentionResponse struct {
+	Accepted bool   `json:"accepted"`
+	Replay   bool   `json:"replay"`
+	EventID  int64  `json:"event_id"`
+	Reason   string `json:"reason"`
+}
+
+type mentionErrorEnvelope struct {
+	Error struct {
+		Code       string `json:"code"`
+		HTTPStatus int    `json:"http_status"`
+	} `json:"error"`
+}
+
+func newTestBotMention(robots botMentionRobotService, claims botMentionClaimStore, gate featureGate, metrics botMentionMetricRecorder) *BotMention {
+	return &BotMention{
+		robots:        robots,
+		claims:        claims,
+		gate:          gate,
+		internalToken: "internal-secret",
+		metrics:       metrics,
+		now:           func() time.Time { return time.Unix(1_785_460_000, 0) },
+		Log:           log.NewTLog("BotMentionTest"),
+	}
+}
+
+func newMentionRouter(module *BotMention) *wkhttp.WKHttp {
+	r := wkhttp.New()
+	r.SetErrorRenderer(i18n.NewErrorRenderer(i18n.NewLocalizer(i18n.DefaultLanguage)))
+	module.Route(r)
+	return r
+}
+
+func validMentionRequest() mentionRequest {
+	return mentionRequest{
+		IdempotencyKey: "idem-1",
+		DocID:          "doc-1",
+		CommentID:      "comment-2",
+		ParentID:       "comment-root",
+		FromUID:        "human-1",
+		BotUID:         "bot-1",
+		Text:           "@bot please update the introduction",
+		URL:            "https://docs.example.test/doc-1?comment=comment-2",
+		SpaceID:        "space-1",
+	}
+}
+
+func doMentionRequest(t *testing.T, r *wkhttp.WKHttp, token string, body interface{}) *httptest.ResponseRecorder {
+	t.Helper()
+	var raw []byte
+	switch v := body.(type) {
+	case []byte:
+		raw = v
+	default:
+		var err error
+		raw, err = json.Marshal(v)
+		if err != nil {
+			t.Fatalf("marshal body: %v", err)
+		}
+	}
+	req := httptest.NewRequest(http.MethodPost, "/v1/internal/bot-mentions", bytes.NewReader(raw))
+	req.Header.Set("Content-Type", "application/json")
+	if token != "" {
+		req.Header.Set(internalTokenHeader, token)
+	}
+	w := httptest.NewRecorder()
+	r.GetRoute().ServeHTTP(w, req)
+	return w
+}
+
+func decodeMentionResponse(t *testing.T, w *httptest.ResponseRecorder) mentionResponse {
+	t.Helper()
+	var response mentionResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode response %s: %v", w.Body.String(), err)
+	}
+	return response
+}
+
+func decodeMentionError(t *testing.T, w *httptest.ResponseRecorder) mentionErrorEnvelope {
+	t.Helper()
+	var response mentionErrorEnvelope
+	if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode error %s: %v", w.Body.String(), err)
+	}
+	return response
+}
+
+func TestBotMentionAcceptedAndReplay(t *testing.T) {
+	backend := newMemoryClaimBackend()
+	claims := newClaimStore(backend, 7*24*time.Hour, deterministicTokens("lease-1"))
+	robots := &stubRobotService{exists: true, eventID: 4242}
+	metrics := &fakeMetricRecorder{}
+	module := newTestBotMention(robots, claims, newFeatureGate(true, "space-1", ""), metrics)
+	router := newMentionRouter(module)
+
+	first := doMentionRequest(t, router, "internal-secret", validMentionRequest())
+	if first.Code != http.StatusOK {
+		t.Fatalf("first status = %d, body=%s", first.Code, first.Body.String())
+	}
+	firstResp := decodeMentionResponse(t, first)
+	if !firstResp.Accepted || firstResp.Replay || firstResp.EventID != 4242 {
+		t.Fatalf("first response = %+v", firstResp)
+	}
+
+	second := doMentionRequest(t, router, "internal-secret", validMentionRequest())
+	if second.Code != http.StatusOK {
+		t.Fatalf("replay status = %d, body=%s", second.Code, second.Body.String())
+	}
+	replay := decodeMentionResponse(t, second)
+	if !replay.Accepted || !replay.Replay || replay.EventID != 4242 {
+		t.Fatalf("replay response = %+v", replay)
+	}
+
+	existCalls, enqueueCalls := robots.counts()
+	if existCalls != 1 || enqueueCalls != 1 {
+		t.Fatalf("robot calls exist=%d enqueue=%d, want 1/1", existCalls, enqueueCalls)
+	}
+	if robots.robotID != "bot-1" || robots.eventType != docCommentMentionEventType {
+		t.Fatalf("enqueued target/type = %q/%q", robots.robotID, robots.eventType)
+	}
+	if robots.eventData["thread_id"] != "comment-root" || robots.eventData["idempotency_key"] != "idem-1" {
+		t.Fatalf("event data missing canonical identity: %#v", robots.eventData)
+	}
+	if robots.eventData["enqueued_at"] != int64(1_785_460_000) {
+		t.Fatalf("enqueued_at = %#v", robots.eventData["enqueued_at"])
+	}
+	ingress, enqueues := metrics.snapshot()
+	if fmt.Sprint(ingress) != "[accepted replay]" || fmt.Sprint(enqueues) != "[accepted]" {
+		t.Fatalf("metrics ingress=%v enqueue=%v", ingress, enqueues)
+	}
+}
+
+func TestBotMentionConcurrentDuplicateHasSingleEnqueue(t *testing.T) {
+	backend := newMemoryClaimBackend()
+	claims := newClaimStore(backend, time.Hour, deterministicTokens("lease-1"))
+	robots := &stubRobotService{
+		exists:          true,
+		eventID:         4242,
+		enqueueStarted:  make(chan struct{}),
+		enqueueContinue: make(chan struct{}),
+	}
+	module := newTestBotMention(robots, claims, newFeatureGate(true, "", "doc-1"), &fakeMetricRecorder{})
+	router := newMentionRouter(module)
+
+	firstDone := make(chan *httptest.ResponseRecorder, 1)
+	go func() {
+		firstDone <- doMentionRequest(t, router, "internal-secret", validMentionRequest())
+	}()
+	<-robots.enqueueStarted
+
+	const duplicates = 8
+	results := make(chan *httptest.ResponseRecorder, duplicates)
+	for i := 0; i < duplicates; i++ {
+		go func() {
+			results <- doMentionRequest(t, router, "internal-secret", validMentionRequest())
+		}()
+	}
+	for i := 0; i < duplicates; i++ {
+		w := <-results
+		if w.Code != http.StatusConflict {
+			t.Fatalf("in-flight duplicate status = %d, body=%s", w.Code, w.Body.String())
+		}
+		if got := w.Header().Get("Retry-After"); got != "60" {
+			t.Fatalf("Retry-After = %q, want 60", got)
+		}
+	}
+	close(robots.enqueueContinue)
+	if w := <-firstDone; w.Code != http.StatusOK {
+		t.Fatalf("first status = %d, body=%s", w.Code, w.Body.String())
+	}
+	_, enqueueCalls := robots.counts()
+	if enqueueCalls != 1 {
+		t.Fatalf("enqueue calls = %d, want 1", enqueueCalls)
+	}
+}
+
+func TestBotMentionAuthFailsClosed(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		serverToken  string
+		requestToken string
+	}{
+		{name: "token not configured", serverToken: "", requestToken: "internal-secret"},
+		{name: "token missing", serverToken: "internal-secret"},
+		{name: "token wrong", serverToken: "internal-secret", requestToken: "wrong"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			robots := &stubRobotService{exists: true, eventID: 1}
+			module := newTestBotMention(robots, &scriptedClaimStore{}, newFeatureGate(true, "", "*"), &fakeMetricRecorder{})
+			module.internalToken = tc.serverToken
+			w := doMentionRequest(t, newMentionRouter(module), tc.requestToken, validMentionRequest())
+			if w.Code != http.StatusUnauthorized {
+				t.Fatalf("status = %d, body=%s", w.Code, w.Body.String())
+			}
+			if got := decodeMentionError(t, w).Error.Code; got != "err.shared.auth.token_invalid" {
+				t.Fatalf("code = %q", got)
+			}
+			if _, enqueues := robots.counts(); enqueues != 0 {
+				t.Fatalf("enqueue calls = %d", enqueues)
+			}
+		})
+	}
+}
+
+func TestBotMentionRejectsInvalidRequests(t *testing.T) {
+	base := validMentionRequest()
+	oversized := validMentionRequest()
+	oversized.Text = strings.Repeat("x", maxRequestBodyBytes)
+	badURL := validMentionRequest()
+	badURL.URL = "file:///etc/passwd"
+	missingBot := validMentionRequest()
+	missingBot.BotUID = ""
+
+	tests := []struct {
+		name string
+		body interface{}
+	}{
+		{name: "malformed json", body: []byte("{not-json")},
+		{name: "oversized body", body: oversized},
+		{name: "unsafe url", body: badURL},
+		{name: "missing required field", body: missingBot},
+		{name: "empty body", body: []byte{}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			robots := &stubRobotService{exists: true, eventID: 1}
+			module := newTestBotMention(robots, &scriptedClaimStore{}, newFeatureGate(true, "", "*"), &fakeMetricRecorder{})
+			w := doMentionRequest(t, newMentionRouter(module), "internal-secret", tc.body)
+			if w.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, body=%s", w.Code, w.Body.String())
+			}
+			if got := decodeMentionError(t, w).Error.Code; got != "err.shared.param.invalid" {
+				t.Fatalf("code = %q", got)
+			}
+			if _, enqueues := robots.counts(); enqueues != 0 {
+				t.Fatalf("enqueue calls = %d", enqueues)
+			}
+		})
+	}
+	_ = base
+}
+
+func TestBotMentionDisabledIsDistinguishableAndDoesNotClaim(t *testing.T) {
+	backend := newMemoryClaimBackend()
+	claims := newClaimStore(backend, time.Hour, deterministicTokens("unused"))
+	robots := &stubRobotService{exists: true, eventID: 1}
+	module := newTestBotMention(robots, claims, newFeatureGate(false, "", "*"), &fakeMetricRecorder{})
+	w := doMentionRequest(t, newMentionRouter(module), "internal-secret", validMentionRequest())
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", w.Code, w.Body.String())
+	}
+	response := decodeMentionResponse(t, w)
+	if response.Accepted || response.Replay || response.Reason != "disabled" {
+		t.Fatalf("response = %+v", response)
+	}
+	if len(backend.values) != 0 {
+		t.Fatalf("disabled request wrote claims: %#v", backend.values)
+	}
+	if exists, enqueues := robots.counts(); exists != 0 || enqueues != 0 {
+		t.Fatalf("robot calls exist=%d enqueue=%d", exists, enqueues)
+	}
+}
+
+func TestBotMentionRejectsUnavailableUserBotAndDependencyFailure(t *testing.T) {
+	t.Run("non active user bot is opaque not found", func(t *testing.T) {
+		robots := &stubRobotService{exists: false}
+		module := newTestBotMention(robots, &scriptedClaimStore{}, newFeatureGate(true, "", "*"), &fakeMetricRecorder{})
+		w := doMentionRequest(t, newMentionRouter(module), "internal-secret", validMentionRequest())
+		if w.Code != http.StatusNotFound || decodeMentionError(t, w).Error.Code != "err.shared.not_found" {
+			t.Fatalf("status=%d body=%s", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("robot lookup failure is internal", func(t *testing.T) {
+		robots := &stubRobotService{existErr: errors.New("mysql unavailable")}
+		module := newTestBotMention(robots, &scriptedClaimStore{}, newFeatureGate(true, "", "*"), &fakeMetricRecorder{})
+		w := doMentionRequest(t, newMentionRouter(module), "internal-secret", validMentionRequest())
+		if w.Code != http.StatusInternalServerError || decodeMentionError(t, w).Error.Code != "err.server.bot_mention.store_failed" {
+			t.Fatalf("status=%d body=%s", w.Code, w.Body.String())
+		}
+	})
+}
+
+func TestBotMentionClaimOutcomes(t *testing.T) {
+	tests := []struct {
+		name       string
+		store      *scriptedClaimStore
+		wantStatus int
+		wantCode   string
+		wantReplay bool
+	}{
+		{name: "lookup pending", store: &scriptedClaimStore{lookupOutcome: claimOutcome{State: claimPending}}, wantStatus: http.StatusConflict, wantCode: "err.server.bot_mention.in_progress"},
+		{name: "lookup conflict", store: &scriptedClaimStore{lookupOutcome: claimOutcome{State: claimConflict}}, wantStatus: http.StatusConflict, wantCode: "err.server.bot_mention.idempotency_conflict"},
+		{name: "lookup failure", store: &scriptedClaimStore{lookupErr: errors.New("redis unavailable")}, wantStatus: http.StatusInternalServerError, wantCode: "err.server.bot_mention.store_failed"},
+		{name: "lookup replay", store: &scriptedClaimStore{lookupOutcome: claimOutcome{State: claimReplay, EventID: 99}}, wantStatus: http.StatusOK, wantReplay: true},
+		{name: "begin pending race", store: &scriptedClaimStore{beginOutcome: claimOutcome{State: claimPending}}, wantStatus: http.StatusConflict, wantCode: "err.server.bot_mention.in_progress"},
+		{name: "begin conflict race", store: &scriptedClaimStore{beginOutcome: claimOutcome{State: claimConflict}}, wantStatus: http.StatusConflict, wantCode: "err.server.bot_mention.idempotency_conflict"},
+		{name: "begin failure", store: &scriptedClaimStore{beginErr: errors.New("redis unavailable")}, wantStatus: http.StatusInternalServerError, wantCode: "err.server.bot_mention.store_failed"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			robots := &stubRobotService{exists: true, eventID: 1}
+			module := newTestBotMention(robots, tc.store, newFeatureGate(true, "", "*"), &fakeMetricRecorder{})
+			w := doMentionRequest(t, newMentionRouter(module), "internal-secret", validMentionRequest())
+			if w.Code != tc.wantStatus {
+				t.Fatalf("status=%d want=%d body=%s", w.Code, tc.wantStatus, w.Body.String())
+			}
+			if tc.wantReplay {
+				response := decodeMentionResponse(t, w)
+				if !response.Accepted || !response.Replay || response.EventID != 99 {
+					t.Fatalf("response = %+v", response)
+				}
+				return
+			}
+			if got := decodeMentionError(t, w).Error.Code; got != tc.wantCode {
+				t.Fatalf("code=%q want=%q", got, tc.wantCode)
+			}
+		})
+	}
+}
+
+func TestBotMentionEnqueueFailureReleasesClaim(t *testing.T) {
+	store := &scriptedClaimStore{confirmOK: true, releaseOK: true}
+	robots := &stubRobotService{exists: true, enqueueErr: errors.New("redis zadd failed")}
+	module := newTestBotMention(robots, store, newFeatureGate(true, "", "*"), &fakeMetricRecorder{})
+	w := doMentionRequest(t, newMentionRouter(module), "internal-secret", validMentionRequest())
+	if w.Code != http.StatusInternalServerError || decodeMentionError(t, w).Error.Code != "err.server.bot_mention.store_failed" {
+		t.Fatalf("status=%d body=%s", w.Code, w.Body.String())
+	}
+	if store.releaseCalls != 1 {
+		t.Fatalf("release calls = %d, want 1", store.releaseCalls)
+	}
+}
+
+func TestBotMentionConfirmFailureDoesNotRollBackEnqueuedEvent(t *testing.T) {
+	store := &scriptedClaimStore{confirmErr: errors.New("redis cas failed")}
+	robots := &stubRobotService{exists: true, eventID: 777}
+	module := newTestBotMention(robots, store, newFeatureGate(true, "", "*"), &fakeMetricRecorder{})
+	w := doMentionRequest(t, newMentionRouter(module), "internal-secret", validMentionRequest())
+	if w.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", w.Code, w.Body.String())
+	}
+	response := decodeMentionResponse(t, w)
+	if !response.Accepted || response.Replay || response.EventID != 777 {
+		t.Fatalf("response=%+v", response)
+	}
+	if store.confirmCalls != 1 || store.releaseCalls != 0 {
+		t.Fatalf("confirm=%d release=%d", store.confirmCalls, store.releaseCalls)
+	}
+}

--- a/modules/bot_mention/api_test.go
+++ b/modules/bot_mention/api_test.go
@@ -83,7 +83,7 @@ func (m *fakeMetricRecorder) ObserveIngress(result string, _ time.Duration) {
 	m.mu.Unlock()
 }
 
-func (m *fakeMetricRecorder) ObserveEnqueue(result string) {
+func (m *fakeMetricRecorder) ObserveEnqueue(result string, _ time.Duration) {
 	m.mu.Lock()
 	m.enqueues = append(m.enqueues, result)
 	m.mu.Unlock()
@@ -202,7 +202,7 @@ func doMentionRequest(t *testing.T, r *wkhttp.WKHttp, token string, body interfa
 		req.Header.Set(internalTokenHeader, token)
 	}
 	w := httptest.NewRecorder()
-	r.GetRoute().ServeHTTP(w, req)
+	r.ServeHTTP(w, req)
 	return w
 }
 

--- a/modules/bot_mention/api_test.go
+++ b/modules/bot_mention/api_test.go
@@ -39,6 +39,57 @@ type stubRobotService struct {
 	startOnce       sync.Once
 }
 
+type leaseRaceRobotService struct {
+	mu sync.Mutex
+
+	firstStarted chan struct{}
+	releaseFirst chan struct{}
+	enqueueCalls int
+	eventIDs     []int64
+}
+
+func (s *leaseRaceRobotService) ExistRobot(string) (bool, error) {
+	return true, nil
+}
+
+func (s *leaseRaceRobotService) EnqueueBotTypedEvent(_ string, _ string, _ map[string]interface{}) (int64, error) {
+	s.mu.Lock()
+	s.enqueueCalls++
+	call := s.enqueueCalls
+	s.mu.Unlock()
+
+	if call == 1 {
+		close(s.firstStarted)
+		<-s.releaseFirst
+	}
+
+	eventID := int64(1000 + call)
+	s.mu.Lock()
+	s.eventIDs = append(s.eventIDs, eventID)
+	s.mu.Unlock()
+	return eventID, nil
+}
+
+func (s *leaseRaceRobotService) visibleEventIDs() []int64 {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]int64(nil), s.eventIDs...)
+}
+
+type observingClaimBackend struct {
+	*memoryClaimBackend
+	staleCAS chan struct{}
+	once     sync.Once
+}
+
+func (b *observingClaimBackend) CompareAndSet(key, oldValue, newValue string, ttl time.Duration) (bool, error) {
+	ok, err := b.memoryClaimBackend.CompareAndSet(key, oldValue, newValue, ttl)
+	if err == nil && !ok {
+		b.once.Do(func() { close(b.staleCAS) })
+	}
+	return ok, err
+}
+
 func (s *stubRobotService) ExistRobot(uid string) (bool, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -702,6 +753,66 @@ func TestBotMentionRenewsClaimWhileEnqueueIsBlocked(t *testing.T) {
 	response := <-result
 	if response.Code != http.StatusOK {
 		t.Fatalf("status=%d body=%s", response.Code, response.Body.String())
+	}
+}
+
+func TestBotMentionLostLeaseDuringBlockedEnqueueReplaysSingleVisibleEvent(t *testing.T) {
+	backend := &observingClaimBackend{
+		memoryClaimBackend: newMemoryClaimBackend(),
+		staleCAS:           make(chan struct{}),
+	}
+	store := newClaimStore(backend, time.Hour, deterministicTokens("lease-old", "lease-new"))
+	robots := &leaseRaceRobotService{
+		firstStarted: make(chan struct{}),
+		releaseFirst: make(chan struct{}),
+	}
+	module := newTestBotMention(robots, store, newFeatureGate(true, "", "*"), &fakeMetricRecorder{})
+	module.claimRenewal = time.Millisecond
+	router := newMentionRouter(module)
+	request := validMentionRequest()
+	claimKey := mentionClaimKey(request.BotUID, request.IdempotencyKey)
+
+	firstResult := make(chan *httptest.ResponseRecorder, 1)
+	go func() {
+		firstResult <- doMentionRequest(t, router, "internal-secret", request)
+	}()
+	select {
+	case <-robots.firstStarted:
+	case <-time.After(time.Second):
+		t.Fatal("first enqueue did not block")
+	}
+
+	backend.forceDelete(claimKey)
+	second := doMentionRequest(t, router, "internal-secret", request)
+	if second.Code != http.StatusOK {
+		t.Fatalf("retry status=%d body=%s", second.Code, second.Body.String())
+	}
+	secondResponse := decodeMentionResponse(t, second)
+	if !secondResponse.Accepted || secondResponse.Replay {
+		t.Fatalf("retry response=%+v, want newly accepted event", secondResponse)
+	}
+	select {
+	case <-backend.staleCAS:
+	case <-time.After(time.Second):
+		t.Fatal("blocked attempt did not observe lease loss")
+	}
+
+	close(robots.releaseFirst)
+	var first *httptest.ResponseRecorder
+	select {
+	case first = <-firstResult:
+	case <-time.After(time.Second):
+		t.Fatal("first request did not finish")
+	}
+	if first.Code != http.StatusOK {
+		t.Fatalf("first status=%d body=%s", first.Code, first.Body.String())
+	}
+	firstResponse := decodeMentionResponse(t, first)
+	if !firstResponse.Accepted || !firstResponse.Replay || firstResponse.EventID != secondResponse.EventID {
+		t.Fatalf("first response=%+v, want replay of event_id %d", firstResponse, secondResponse.EventID)
+	}
+	if visible := robots.visibleEventIDs(); len(visible) != 1 || visible[0] != secondResponse.EventID {
+		t.Fatalf("visible event IDs=%v, want only %d", visible, secondResponse.EventID)
 	}
 }
 

--- a/modules/bot_mention/config.go
+++ b/modules/bot_mention/config.go
@@ -126,6 +126,28 @@ func mentionFingerprint(req normalizedMention) string {
 	return hex.EncodeToString(sum[:])
 }
 
+func mentionClaimLogHash(claimKey string) string {
+	sum := sha256.Sum256([]byte(claimKey))
+	return hex.EncodeToString(sum[:6])
+}
+
+func resolveBotMentionInternalToken(getenv func(string) string) (string, error) {
+	if getenv == nil {
+		return "", errors.New("OCTO_DOCS_BOT_MENTION_TOKEN lookup unavailable; bot mention capability disabled")
+	}
+	token := getenv(internalTokenEnv)
+	switch {
+	case token == "":
+		return "", errors.New("OCTO_DOCS_BOT_MENTION_TOKEN not set; internal bot mention API will reject all requests")
+	case token == getenv("NOTIFY_INTERNAL_TOKEN"):
+		return "", errors.New("OCTO_DOCS_BOT_MENTION_TOKEN must differ from NOTIFY_INTERNAL_TOKEN; bot mention capability disabled")
+	case token == getenv("OCTO_DOCS_NOTIFY_TOKEN"):
+		return "", errors.New("OCTO_DOCS_BOT_MENTION_TOKEN must differ from OCTO_DOCS_NOTIFY_TOKEN; bot mention capability disabled")
+	default:
+		return token, nil
+	}
+}
+
 type featureGate struct {
 	enabled bool
 	spaces  map[string]struct{}
@@ -165,15 +187,15 @@ func (g featureGate) Allows(docID, spaceID string) bool {
 	if _, ok := g.docs["*"]; ok {
 		return true
 	}
-	if _, ok := g.spaces["*"]; ok {
-		return true
-	}
 	if _, ok := g.docs[docID]; ok {
 		return true
 	}
-	if spaceID != "" {
-		_, ok := g.spaces[spaceID]
-		return ok
+	if spaceID == "" {
+		return false
 	}
-	return false
+	if _, ok := g.spaces["*"]; ok {
+		return true
+	}
+	_, ok := g.spaces[spaceID]
+	return ok
 }

--- a/modules/bot_mention/config.go
+++ b/modules/bot_mention/config.go
@@ -1,0 +1,179 @@
+package bot_mention
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+)
+
+const (
+	maxRequestBodyBytes = 32 * 1024
+	maxIdentifierBytes  = 256
+	maxTextBytes        = 10 * 1024
+	maxURLBytes         = 2048
+
+	featureEnabledEnv          = "OCTO_DOCS_BOT_MENTION_ENABLED"
+	spaceAllowlistEnv          = "OCTO_DOCS_BOT_MENTION_SPACE_ALLOWLIST"
+	documentAllowlistEnv       = "OCTO_DOCS_BOT_MENTION_DOC_ALLOWLIST"
+	internalTokenEnv           = "OCTO_DOCS_BOT_MENTION_TOKEN"
+	internalTokenHeader        = "X-Internal-Token"
+	docCommentMentionEventType = "doc_comment_mention"
+)
+
+type mentionRequest struct {
+	IdempotencyKey string `json:"idempotency_key"`
+	DocID          string `json:"doc_id"`
+	CommentID      string `json:"comment_id"`
+	ParentID       string `json:"parent_id,omitempty"`
+	FromUID        string `json:"from_uid"`
+	BotUID         string `json:"bot_uid"`
+	Text           string `json:"text"`
+	URL            string `json:"url,omitempty"`
+	SpaceID        string `json:"space_id,omitempty"`
+}
+
+type normalizedMention struct {
+	IdempotencyKey string `json:"idempotency_key"`
+	DocID          string `json:"doc_id"`
+	CommentID      string `json:"comment_id"`
+	ThreadID       string `json:"thread_id"`
+	ParentID       string `json:"parent_id,omitempty"`
+	FromUID        string `json:"from_uid"`
+	BotUID         string `json:"bot_uid"`
+	Text           string `json:"text"`
+	URL            string `json:"url,omitempty"`
+	SpaceID        string `json:"space_id,omitempty"`
+}
+
+type requestValidationError struct {
+	field string
+}
+
+func (e *requestValidationError) Error() string {
+	return fmt.Sprintf("invalid bot mention field %q", e.field)
+}
+
+func invalidField(err error) string {
+	var validationErr *requestValidationError
+	if errors.As(err, &validationErr) {
+		return validationErr.field
+	}
+	return ""
+}
+
+func normalizeMentionRequest(req mentionRequest) (normalizedMention, error) {
+	normalized := normalizedMention{
+		IdempotencyKey: strings.TrimSpace(req.IdempotencyKey),
+		DocID:          strings.TrimSpace(req.DocID),
+		CommentID:      strings.TrimSpace(req.CommentID),
+		ParentID:       strings.TrimSpace(req.ParentID),
+		FromUID:        strings.TrimSpace(req.FromUID),
+		BotUID:         strings.TrimSpace(req.BotUID),
+		Text:           req.Text,
+		URL:            strings.TrimSpace(req.URL),
+		SpaceID:        strings.TrimSpace(req.SpaceID),
+	}
+
+	for _, field := range []struct {
+		name     string
+		value    string
+		required bool
+	}{
+		{name: "idempotency_key", value: normalized.IdempotencyKey, required: true},
+		{name: "doc_id", value: normalized.DocID, required: true},
+		{name: "comment_id", value: normalized.CommentID, required: true},
+		{name: "parent_id", value: normalized.ParentID},
+		{name: "from_uid", value: normalized.FromUID, required: true},
+		{name: "bot_uid", value: normalized.BotUID, required: true},
+		{name: "space_id", value: normalized.SpaceID},
+	} {
+		if (field.required && field.value == "") || len(field.value) > maxIdentifierBytes {
+			return normalizedMention{}, &requestValidationError{field: field.name}
+		}
+	}
+	if strings.TrimSpace(normalized.Text) == "" || len(normalized.Text) > maxTextBytes {
+		return normalizedMention{}, &requestValidationError{field: "text"}
+	}
+	if normalized.URL != "" {
+		if len(normalized.URL) > maxURLBytes {
+			return normalizedMention{}, &requestValidationError{field: "url"}
+		}
+		parsed, err := url.Parse(normalized.URL)
+		if err != nil || parsed.Host == "" || (parsed.Scheme != "http" && parsed.Scheme != "https") {
+			return normalizedMention{}, &requestValidationError{field: "url"}
+		}
+	}
+	normalized.ThreadID = normalized.ParentID
+	if normalized.ThreadID == "" {
+		normalized.ThreadID = normalized.CommentID
+	}
+	return normalized, nil
+}
+
+func mentionFingerprint(req normalizedMention) string {
+	raw, err := json.Marshal(req)
+	if err != nil {
+		// normalizedMention contains only strings, so marshaling cannot fail.
+		panic(fmt.Sprintf("marshal normalized bot mention: %v", err))
+	}
+	sum := sha256.Sum256(raw)
+	return hex.EncodeToString(sum[:])
+}
+
+type featureGate struct {
+	enabled bool
+	spaces  map[string]struct{}
+	docs    map[string]struct{}
+}
+
+func newFeatureGate(enabled bool, spaceAllowlist, documentAllowlist string) featureGate {
+	return featureGate{
+		enabled: enabled,
+		spaces:  parseAllowlist(spaceAllowlist),
+		docs:    parseAllowlist(documentAllowlist),
+	}
+}
+
+func featureGateFromEnv() featureGate {
+	enabled, err := strconv.ParseBool(strings.TrimSpace(os.Getenv(featureEnabledEnv)))
+	if err != nil {
+		enabled = false
+	}
+	return newFeatureGate(enabled, os.Getenv(spaceAllowlistEnv), os.Getenv(documentAllowlistEnv))
+}
+
+func parseAllowlist(raw string) map[string]struct{} {
+	result := make(map[string]struct{})
+	for _, item := range strings.Split(raw, ",") {
+		if item = strings.TrimSpace(item); item != "" {
+			result[item] = struct{}{}
+		}
+	}
+	return result
+}
+
+func (g featureGate) Allows(docID, spaceID string) bool {
+	if !g.enabled {
+		return false
+	}
+	if _, ok := g.docs["*"]; ok {
+		return true
+	}
+	if _, ok := g.spaces["*"]; ok {
+		return true
+	}
+	if _, ok := g.docs[docID]; ok {
+		return true
+	}
+	if spaceID != "" {
+		_, ok := g.spaces[spaceID]
+		return ok
+	}
+	return false
+}

--- a/modules/bot_mention/config_test.go
+++ b/modules/bot_mention/config_test.go
@@ -1,0 +1,134 @@
+package bot_mention
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestFeatureGate(t *testing.T) {
+	tests := []struct {
+		name      string
+		gate      featureGate
+		docID     string
+		spaceID   string
+		wantAllow bool
+	}{
+		{name: "global switch off", gate: newFeatureGate(false, "space-a", "doc-a"), docID: "doc-a", spaceID: "space-a"},
+		{name: "empty allowlists fail closed", gate: newFeatureGate(true, "", ""), docID: "doc-a", spaceID: "space-a"},
+		{name: "doc allowlist hit", gate: newFeatureGate(true, "", "doc-a, doc-b"), docID: "doc-b", wantAllow: true},
+		{name: "space allowlist hit", gate: newFeatureGate(true, "space-a", ""), docID: "doc-z", spaceID: "space-a", wantAllow: true},
+		{name: "missing space cannot hit space allowlist", gate: newFeatureGate(true, "space-a", ""), docID: "doc-z"},
+		{name: "explicit wildcard enables all", gate: newFeatureGate(true, "", "*"), docID: "doc-z", wantAllow: true},
+		{name: "whitespace is normalized", gate: newFeatureGate(true, " space-a , space-b ", ""), spaceID: "space-b", wantAllow: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.gate.Allows(tt.docID, tt.spaceID); got != tt.wantAllow {
+				t.Fatalf("Allows(%q, %q) = %v, want %v", tt.docID, tt.spaceID, got, tt.wantAllow)
+			}
+		})
+	}
+}
+
+func TestNormalizeMentionRequest(t *testing.T) {
+	valid := mentionRequest{
+		IdempotencyKey: " idem-1 ",
+		DocID:          " doc-1 ",
+		CommentID:      " comment-1 ",
+		ParentID:       " root-1 ",
+		FromUID:        " user-1 ",
+		BotUID:         " bot-1 ",
+		Text:           "  please update the document  ",
+		URL:            " https://docs.example.test/doc-1 ",
+		SpaceID:        " space-1 ",
+	}
+
+	got, err := normalizeMentionRequest(valid)
+	if err != nil {
+		t.Fatalf("normalize valid request: %v", err)
+	}
+	if got.IdempotencyKey != "idem-1" || got.DocID != "doc-1" || got.CommentID != "comment-1" {
+		t.Fatalf("identifiers were not normalized: %+v", got)
+	}
+	if got.ThreadID != "root-1" {
+		t.Fatalf("ThreadID = %q, want root-1", got.ThreadID)
+	}
+	if got.Text != valid.Text {
+		t.Fatalf("Text = %q, want original %q", got.Text, valid.Text)
+	}
+	if got.URL != "https://docs.example.test/doc-1" {
+		t.Fatalf("URL = %q", got.URL)
+	}
+
+	valid.ParentID = ""
+	got, err = normalizeMentionRequest(valid)
+	if err != nil {
+		t.Fatalf("normalize root comment: %v", err)
+	}
+	if got.ThreadID != "comment-1" {
+		t.Fatalf("root ThreadID = %q, want comment-1", got.ThreadID)
+	}
+}
+
+func TestNormalizeMentionRequestRejectsInvalidFields(t *testing.T) {
+	base := mentionRequest{
+		IdempotencyKey: "idem-1",
+		DocID:          "doc-1",
+		CommentID:      "comment-1",
+		FromUID:        "user-1",
+		BotUID:         "bot-1",
+		Text:           "update it",
+	}
+
+	tests := []struct {
+		name   string
+		mutate func(*mentionRequest)
+		field  string
+	}{
+		{name: "missing idempotency key", mutate: func(r *mentionRequest) { r.IdempotencyKey = " " }, field: "idempotency_key"},
+		{name: "oversized doc id", mutate: func(r *mentionRequest) { r.DocID = strings.Repeat("d", maxIdentifierBytes+1) }, field: "doc_id"},
+		{name: "missing comment id", mutate: func(r *mentionRequest) { r.CommentID = "" }, field: "comment_id"},
+		{name: "oversized parent id", mutate: func(r *mentionRequest) { r.ParentID = strings.Repeat("p", maxIdentifierBytes+1) }, field: "parent_id"},
+		{name: "missing actor", mutate: func(r *mentionRequest) { r.FromUID = "" }, field: "from_uid"},
+		{name: "missing bot", mutate: func(r *mentionRequest) { r.BotUID = "" }, field: "bot_uid"},
+		{name: "blank text", mutate: func(r *mentionRequest) { r.Text = " \n\t " }, field: "text"},
+		{name: "oversized text", mutate: func(r *mentionRequest) { r.Text = strings.Repeat("x", maxTextBytes+1) }, field: "text"},
+		{name: "relative url", mutate: func(r *mentionRequest) { r.URL = "/doc/1" }, field: "url"},
+		{name: "unsafe url scheme", mutate: func(r *mentionRequest) { r.URL = "javascript:alert(1)" }, field: "url"},
+		{name: "url without host", mutate: func(r *mentionRequest) { r.URL = "https:///doc/1" }, field: "url"},
+		{name: "oversized url", mutate: func(r *mentionRequest) { r.URL = "https://example.test/" + strings.Repeat("u", maxURLBytes) }, field: "url"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := base
+			tt.mutate(&req)
+			_, err := normalizeMentionRequest(req)
+			if err == nil {
+				t.Fatal("expected validation error")
+			}
+			if got := invalidField(err); got != tt.field {
+				t.Fatalf("invalidField = %q, want %q (err=%v)", got, tt.field, err)
+			}
+		})
+	}
+}
+
+func TestMentionFingerprintIsStableAndCoversExecutionFields(t *testing.T) {
+	req, err := normalizeMentionRequest(mentionRequest{
+		IdempotencyKey: "idem-1", DocID: "doc-1", CommentID: "comment-1",
+		FromUID: "user-1", BotUID: "bot-1", Text: "update it",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	first := mentionFingerprint(req)
+	if first == "" || first != mentionFingerprint(req) {
+		t.Fatalf("fingerprint must be non-empty and stable: %q", first)
+	}
+	req.Text = "different instruction"
+	if first == mentionFingerprint(req) {
+		t.Fatal("fingerprint must change when execution-relevant content changes")
+	}
+}

--- a/modules/bot_mention/config_test.go
+++ b/modules/bot_mention/config_test.go
@@ -1,6 +1,7 @@
 package bot_mention
 
 import (
+	"errors"
 	"strings"
 	"testing"
 )
@@ -28,6 +29,21 @@ func TestFeatureGate(t *testing.T) {
 				t.Fatalf("Allows(%q, %q) = %v, want %v", tt.docID, tt.spaceID, got, tt.wantAllow)
 			}
 		})
+	}
+}
+
+func TestFeatureGateFromEnv(t *testing.T) {
+	t.Setenv(featureEnabledEnv, "true")
+	t.Setenv(spaceAllowlistEnv, "space-env")
+	t.Setenv(documentAllowlistEnv, "doc-env")
+	gate := featureGateFromEnv()
+	if !gate.Allows("doc-env", "") || !gate.Allows("other", "space-env") {
+		t.Fatal("environment allowlists were not loaded")
+	}
+
+	t.Setenv(featureEnabledEnv, "not-a-bool")
+	if featureGateFromEnv().Allows("doc-env", "space-env") {
+		t.Fatal("invalid enabled value must fail closed")
 	}
 }
 
@@ -130,5 +146,15 @@ func TestMentionFingerprintIsStableAndCoversExecutionFields(t *testing.T) {
 	req.Text = "different instruction"
 	if first == mentionFingerprint(req) {
 		t.Fatal("fingerprint must change when execution-relevant content changes")
+	}
+}
+
+func TestRequestValidationError(t *testing.T) {
+	err := &requestValidationError{field: "doc_id"}
+	if got := err.Error(); !strings.Contains(got, "doc_id") {
+		t.Fatalf("Error() = %q", got)
+	}
+	if got := invalidField(errors.New("different error")); got != "" {
+		t.Fatalf("invalidField(non-validation) = %q", got)
 	}
 }

--- a/modules/bot_mention/config_test.go
+++ b/modules/bot_mention/config_test.go
@@ -49,6 +49,50 @@ func TestFeatureGateFromEnv(t *testing.T) {
 	}
 }
 
+func TestResolveBotMentionInternalToken(t *testing.T) {
+	tests := []struct {
+		name         string
+		mentionToken string
+		notifyToken  string
+		docsToken    string
+		want         string
+		wantErr      bool
+	}{
+		{name: "independent token enabled", mentionToken: "mention-secret", notifyToken: "notify-secret", docsToken: "docs-notify-secret", want: "mention-secret"},
+		{name: "empty token disabled", notifyToken: "notify-secret", docsToken: "docs-notify-secret", wantErr: true},
+		{name: "legacy notify collision disabled", mentionToken: "shared-secret", notifyToken: "shared-secret", docsToken: "docs-notify-secret", wantErr: true},
+		{name: "docs notify collision disabled", mentionToken: "shared-secret", notifyToken: "notify-secret", docsToken: "shared-secret", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			getenv := func(key string) string {
+				switch key {
+				case internalTokenEnv:
+					return tt.mentionToken
+				case "NOTIFY_INTERNAL_TOKEN":
+					return tt.notifyToken
+				case "OCTO_DOCS_NOTIFY_TOKEN":
+					return tt.docsToken
+				default:
+					return ""
+				}
+			}
+			got, err := resolveBotMentionInternalToken(getenv)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("resolveBotMentionInternalToken() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if got != tt.want {
+				t.Fatalf("token = %q, want %q", got, tt.want)
+			}
+		})
+	}
+
+	if token, err := resolveBotMentionInternalToken(nil); err == nil || token != "" {
+		t.Fatalf("nil getenv = %q, %v; want disabled error", token, err)
+	}
+}
+
 func TestNormalizeMentionRequest(t *testing.T) {
 	valid := mentionRequest{
 		IdempotencyKey: " idem-1 ",

--- a/modules/bot_mention/config_test.go
+++ b/modules/bot_mention/config_test.go
@@ -19,6 +19,8 @@ func TestFeatureGate(t *testing.T) {
 		{name: "doc allowlist hit", gate: newFeatureGate(true, "", "doc-a, doc-b"), docID: "doc-b", wantAllow: true},
 		{name: "space allowlist hit", gate: newFeatureGate(true, "space-a", ""), docID: "doc-z", spaceID: "space-a", wantAllow: true},
 		{name: "missing space cannot hit space allowlist", gate: newFeatureGate(true, "space-a", ""), docID: "doc-z"},
+		{name: "space wildcard requires non-empty space", gate: newFeatureGate(true, "*", ""), docID: "doc-z"},
+		{name: "space wildcard allows any non-empty space", gate: newFeatureGate(true, "*", ""), docID: "doc-z", spaceID: "space-z", wantAllow: true},
 		{name: "explicit wildcard enables all", gate: newFeatureGate(true, "", "*"), docID: "doc-z", wantAllow: true},
 		{name: "whitespace is normalized", gate: newFeatureGate(true, " space-a , space-b ", ""), spaceID: "space-b", wantAllow: true},
 	}

--- a/modules/bot_mention/idempotency.go
+++ b/modules/bot_mention/idempotency.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-server/modules/robot"
 	octoredis "github.com/Mininglamp-OSS/octo-server/pkg/redis"
 	rd "github.com/go-redis/redis"
 )
@@ -57,7 +58,7 @@ type claimLease struct {
 type claimBackend interface {
 	Get(key string) (string, error)
 	SetNX(key, value string, ttl time.Duration) (bool, error)
-	CompareAndSet(key, oldValue, newValue string, ttl time.Duration) (bool, error)
+	CompareAndEnqueue(key, oldValue, newValue string, ttl time.Duration, event robot.PreparedBotTypedEvent) (bool, error)
 	CompareAndDelete(key, oldValue string) (bool, error)
 }
 
@@ -167,28 +168,17 @@ func (s *claimStore) Begin(key, sha string) (claimOutcome, *claimLease, error) {
 	}, nil
 }
 
-func (s *claimStore) Renew(lease *claimLease) (bool, error) {
-	if lease == nil {
-		return false, errors.New("renew bot mention claim: nil lease")
+func (s *claimStore) Commit(lease *claimLease, event robot.PreparedBotTypedEvent) (bool, error) {
+	if lease == nil || event.EventID <= 0 || event.QueueKey == "" || event.Member == "" {
+		return false, errors.New("commit bot mention event: invalid lease or prepared event")
 	}
-	ok, err := s.backend.CompareAndSet(lease.key, lease.pendingValue, lease.pendingValue, claimPendingTTL)
+	done, err := json.Marshal(claimRecord{State: claimRecordDone, SHA: lease.sha, EventID: event.EventID})
 	if err != nil {
-		return false, fmt.Errorf("renew bot mention claim: %w", err)
+		return false, fmt.Errorf("encode committed bot mention claim: %w", err)
 	}
-	return ok, nil
-}
-
-func (s *claimStore) Confirm(lease *claimLease, eventID int64) (bool, error) {
-	if lease == nil || eventID <= 0 {
-		return false, errors.New("confirm bot mention claim: invalid lease or event_id")
-	}
-	done, err := json.Marshal(claimRecord{State: claimRecordDone, SHA: lease.sha, EventID: eventID})
+	ok, err := s.backend.CompareAndEnqueue(lease.key, lease.pendingValue, string(done), s.doneTTL, event)
 	if err != nil {
-		return false, fmt.Errorf("encode confirmed bot mention claim: %w", err)
-	}
-	ok, err := s.backend.CompareAndSet(lease.key, lease.pendingValue, string(done), s.doneTTL)
-	if err != nil {
-		return false, fmt.Errorf("confirm bot mention claim: %w", err)
+		return false, fmt.Errorf("commit bot mention event: %w", err)
 	}
 	return ok, nil
 }
@@ -220,21 +210,25 @@ func (b *redisClaimBackend) SetNX(key, value string, ttl time.Duration) (bool, e
 	return b.client.SetNX(key, value, ttl).Result()
 }
 
-var compareAndSetClaimScript = rd.NewScript(`
+var compareAndEnqueueClaimScript = rd.NewScript(`
 if redis.call("get", KEYS[1]) == ARGV[1] then
+	redis.call("zadd", KEYS[2], ARGV[4], ARGV[5])
+	redis.call("pexpire", KEYS[2], ARGV[3])
 	redis.call("psetex", KEYS[1], ARGV[3], ARGV[2])
 	return 1
 end
 return 0
 `)
 
-func (b *redisClaimBackend) CompareAndSet(key, oldValue, newValue string, ttl time.Duration) (bool, error) {
-	result, err := compareAndSetClaimScript.Run(
+func (b *redisClaimBackend) CompareAndEnqueue(key, oldValue, newValue string, ttl time.Duration, event robot.PreparedBotTypedEvent) (bool, error) {
+	result, err := compareAndEnqueueClaimScript.Run(
 		b.client,
-		[]string{key},
+		[]string{key, event.QueueKey},
 		oldValue,
 		newValue,
 		ttl.Milliseconds(),
+		event.EventID,
+		event.Member,
 	).Int64()
 	return result == 1, err
 }

--- a/modules/bot_mention/idempotency.go
+++ b/modules/bot_mention/idempotency.go
@@ -1,0 +1,234 @@
+package bot_mention
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	octoredis "github.com/Mininglamp-OSS/octo-server/pkg/redis"
+	rd "github.com/go-redis/redis"
+)
+
+const (
+	mentionClaimPrefix  = "docbotmention:"
+	claimPendingTTL     = 60 * time.Second
+	defaultClaimDoneTTL = 7 * 24 * time.Hour
+
+	claimRecordPending = "pending"
+	claimRecordDone    = "done"
+)
+
+var errClaimNotFound = errors.New("bot mention claim not found")
+
+type claimState uint8
+
+const (
+	claimMissing claimState = iota
+	claimAcquired
+	claimPending
+	claimReplay
+	claimConflict
+)
+
+type claimOutcome struct {
+	State   claimState
+	EventID int64
+}
+
+type claimRecord struct {
+	State   string `json:"state"`
+	SHA     string `json:"sha"`
+	Token   string `json:"token,omitempty"`
+	EventID int64  `json:"event_id,omitempty"`
+}
+
+type claimLease struct {
+	key          string
+	sha          string
+	pendingValue string
+}
+
+type claimBackend interface {
+	Get(key string) (string, error)
+	SetNX(key, value string, ttl time.Duration) (bool, error)
+	CompareAndSet(key, oldValue, newValue string, ttl time.Duration) (bool, error)
+	CompareAndDelete(key, oldValue string) (bool, error)
+}
+
+type claimStore struct {
+	backend  claimBackend
+	doneTTL  time.Duration
+	newToken func() (string, error)
+}
+
+func newClaimStore(backend claimBackend, doneTTL time.Duration, newToken func() (string, error)) *claimStore {
+	if doneTTL <= 0 {
+		doneTTL = defaultClaimDoneTTL
+	}
+	if newToken == nil {
+		newToken = newClaimToken
+	}
+	return &claimStore{backend: backend, doneTTL: doneTTL, newToken: newToken}
+}
+
+func newRedisClaimStore(ctx *config.Context) *claimStore {
+	doneTTL := ctx.GetConfig().Robot.MessageExpire
+	client := octoredis.NewInstrumentedClient(ctx.GetConfig(), func(options *rd.Options) {
+		options.MaxRetries = 3
+		options.ReadTimeout = 3 * time.Second
+		options.WriteTimeout = 3 * time.Second
+		options.DialTimeout = 3 * time.Second
+	})
+	return newClaimStore(&redisClaimBackend{client: client}, doneTTL, newClaimToken)
+}
+
+func mentionClaimKey(botUID, idempotencyKey string) string {
+	sum := sha256.Sum256([]byte(botUID + "\x00" + idempotencyKey))
+	return mentionClaimPrefix + hex.EncodeToString(sum[:])
+}
+
+func newClaimToken() (string, error) {
+	var raw [16]byte
+	if _, err := rand.Read(raw[:]); err != nil {
+		return "", fmt.Errorf("generate bot mention claim token: %w", err)
+	}
+	return hex.EncodeToString(raw[:]), nil
+}
+
+func (s *claimStore) Lookup(key, sha string) (claimOutcome, error) {
+	raw, err := s.backend.Get(key)
+	if errors.Is(err, errClaimNotFound) {
+		return claimOutcome{State: claimMissing}, nil
+	}
+	if err != nil {
+		return claimOutcome{}, fmt.Errorf("lookup bot mention claim: %w", err)
+	}
+	var record claimRecord
+	if err := json.Unmarshal([]byte(raw), &record); err != nil {
+		return claimOutcome{}, fmt.Errorf("decode bot mention claim: %w", err)
+	}
+	if record.SHA != sha {
+		return claimOutcome{State: claimConflict}, nil
+	}
+	switch record.State {
+	case claimRecordPending:
+		return claimOutcome{State: claimPending}, nil
+	case claimRecordDone:
+		if record.EventID <= 0 {
+			return claimOutcome{}, errors.New("decode bot mention claim: done record has no event_id")
+		}
+		return claimOutcome{State: claimReplay, EventID: record.EventID}, nil
+	default:
+		return claimOutcome{}, fmt.Errorf("decode bot mention claim: unknown state %q", record.State)
+	}
+}
+
+func (s *claimStore) Begin(key, sha string) (claimOutcome, *claimLease, error) {
+	existing, err := s.Lookup(key, sha)
+	if err != nil {
+		return claimOutcome{}, nil, err
+	}
+	if existing.State != claimMissing {
+		return existing, nil, nil
+	}
+
+	token, err := s.newToken()
+	if err != nil {
+		return claimOutcome{}, nil, err
+	}
+	pending, err := json.Marshal(claimRecord{State: claimRecordPending, SHA: sha, Token: token})
+	if err != nil {
+		return claimOutcome{}, nil, fmt.Errorf("encode bot mention claim: %w", err)
+	}
+	created, err := s.backend.SetNX(key, string(pending), claimPendingTTL)
+	if err != nil {
+		return claimOutcome{}, nil, fmt.Errorf("reserve bot mention claim: %w", err)
+	}
+	if !created {
+		outcome, lookupErr := s.Lookup(key, sha)
+		return outcome, nil, lookupErr
+	}
+	return claimOutcome{State: claimAcquired}, &claimLease{
+		key:          key,
+		sha:          sha,
+		pendingValue: string(pending),
+	}, nil
+}
+
+func (s *claimStore) Confirm(lease *claimLease, eventID int64) (bool, error) {
+	if lease == nil || eventID <= 0 {
+		return false, errors.New("confirm bot mention claim: invalid lease or event_id")
+	}
+	done, err := json.Marshal(claimRecord{State: claimRecordDone, SHA: lease.sha, EventID: eventID})
+	if err != nil {
+		return false, fmt.Errorf("encode confirmed bot mention claim: %w", err)
+	}
+	ok, err := s.backend.CompareAndSet(lease.key, lease.pendingValue, string(done), s.doneTTL)
+	if err != nil {
+		return false, fmt.Errorf("confirm bot mention claim: %w", err)
+	}
+	return ok, nil
+}
+
+func (s *claimStore) Release(lease *claimLease) (bool, error) {
+	if lease == nil {
+		return false, errors.New("release bot mention claim: nil lease")
+	}
+	ok, err := s.backend.CompareAndDelete(lease.key, lease.pendingValue)
+	if err != nil {
+		return false, fmt.Errorf("release bot mention claim: %w", err)
+	}
+	return ok, nil
+}
+
+type redisClaimBackend struct {
+	client *rd.Client
+}
+
+func (b *redisClaimBackend) Get(key string) (string, error) {
+	value, err := b.client.Get(key).Result()
+	if err == rd.Nil {
+		return "", errClaimNotFound
+	}
+	return value, err
+}
+
+func (b *redisClaimBackend) SetNX(key, value string, ttl time.Duration) (bool, error) {
+	return b.client.SetNX(key, value, ttl).Result()
+}
+
+var compareAndSetClaimScript = rd.NewScript(`
+if redis.call("get", KEYS[1]) == ARGV[1] then
+	redis.call("psetex", KEYS[1], ARGV[3], ARGV[2])
+	return 1
+end
+return 0
+`)
+
+func (b *redisClaimBackend) CompareAndSet(key, oldValue, newValue string, ttl time.Duration) (bool, error) {
+	result, err := compareAndSetClaimScript.Run(
+		b.client,
+		[]string{key},
+		oldValue,
+		newValue,
+		ttl.Milliseconds(),
+	).Int64()
+	return result == 1, err
+}
+
+var compareAndDeleteClaimScript = rd.NewScript(`
+if redis.call("get", KEYS[1]) == ARGV[1] then
+	return redis.call("del", KEYS[1])
+end
+return 0
+`)
+
+func (b *redisClaimBackend) CompareAndDelete(key, oldValue string) (bool, error) {
+	result, err := compareAndDeleteClaimScript.Run(b.client, []string{key}, oldValue).Int64()
+	return result == 1, err
+}

--- a/modules/bot_mention/idempotency.go
+++ b/modules/bot_mention/idempotency.go
@@ -17,6 +17,7 @@ import (
 const (
 	mentionClaimPrefix  = "docbotmention:"
 	claimPendingTTL     = 60 * time.Second
+	claimRetryAfter     = 2 * time.Second
 	defaultClaimDoneTTL = 7 * 24 * time.Hour
 
 	claimRecordPending = "pending"
@@ -151,6 +152,12 @@ func (s *claimStore) Begin(key, sha string) (claimOutcome, *claimLease, error) {
 	}
 	if !created {
 		outcome, lookupErr := s.Lookup(key, sha)
+		if lookupErr == nil && outcome.State == claimMissing {
+			// The SetNX loser observed the winner's pending claim disappear
+			// before the fallback lookup. Treat this benign race as retryable
+			// in-progress instead of surfacing an internal error.
+			outcome.State = claimPending
+		}
 		return outcome, nil, lookupErr
 	}
 	return claimOutcome{State: claimAcquired}, &claimLease{
@@ -158,6 +165,17 @@ func (s *claimStore) Begin(key, sha string) (claimOutcome, *claimLease, error) {
 		sha:          sha,
 		pendingValue: string(pending),
 	}, nil
+}
+
+func (s *claimStore) Renew(lease *claimLease) (bool, error) {
+	if lease == nil {
+		return false, errors.New("renew bot mention claim: nil lease")
+	}
+	ok, err := s.backend.CompareAndSet(lease.key, lease.pendingValue, lease.pendingValue, claimPendingTTL)
+	if err != nil {
+		return false, fmt.Errorf("renew bot mention claim: %w", err)
+	}
+	return ok, nil
 }
 
 func (s *claimStore) Confirm(lease *claimLease, eventID int64) (bool, error) {

--- a/modules/bot_mention/idempotency_test.go
+++ b/modules/bot_mention/idempotency_test.go
@@ -2,10 +2,13 @@ package bot_mention
 
 import (
 	"errors"
+	"sort"
 	"strings"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/Mininglamp-OSS/octo-server/modules/robot"
 )
 
 type memoryClaimBackend struct {
@@ -13,10 +16,11 @@ type memoryClaimBackend struct {
 
 	values map[string]string
 	ttls   map[string]time.Duration
+	queues map[string]map[int64]string
 
 	getErr    error
 	setNXErr  error
-	setCASErr error
+	commitErr error
 	delCASErr error
 }
 
@@ -30,7 +34,7 @@ func (disappearingSetNXBackend) SetNX(string, string, time.Duration) (bool, erro
 	return false, nil
 }
 
-func (disappearingSetNXBackend) CompareAndSet(string, string, string, time.Duration) (bool, error) {
+func (disappearingSetNXBackend) CompareAndEnqueue(string, string, string, time.Duration, robot.PreparedBotTypedEvent) (bool, error) {
 	return false, nil
 }
 
@@ -39,7 +43,11 @@ func (disappearingSetNXBackend) CompareAndDelete(string, string) (bool, error) {
 }
 
 func newMemoryClaimBackend() *memoryClaimBackend {
-	return &memoryClaimBackend{values: make(map[string]string), ttls: make(map[string]time.Duration)}
+	return &memoryClaimBackend{
+		values: make(map[string]string),
+		ttls:   make(map[string]time.Duration),
+		queues: make(map[string]map[int64]string),
+	}
 }
 
 func (b *memoryClaimBackend) Get(key string) (string, error) {
@@ -69,15 +77,22 @@ func (b *memoryClaimBackend) SetNX(key, value string, ttl time.Duration) (bool, 
 	return true, nil
 }
 
-func (b *memoryClaimBackend) CompareAndSet(key, oldValue, newValue string, ttl time.Duration) (bool, error) {
+func (b *memoryClaimBackend) CompareAndEnqueue(key, oldValue, newValue string, ttl time.Duration, event robot.PreparedBotTypedEvent) (bool, error) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
-	if b.setCASErr != nil {
-		return false, b.setCASErr
+	if b.commitErr != nil {
+		return false, b.commitErr
 	}
 	if b.values[key] != oldValue {
 		return false, nil
 	}
+	queue := b.queues[event.QueueKey]
+	if queue == nil {
+		queue = make(map[int64]string)
+		b.queues[event.QueueKey] = queue
+	}
+	queue[event.EventID] = event.Member
+	b.ttls[event.QueueKey] = ttl
 	b.values[key] = newValue
 	b.ttls[key] = ttl
 	return true, nil
@@ -102,6 +117,26 @@ func (b *memoryClaimBackend) forceDelete(key string) {
 	delete(b.values, key)
 	delete(b.ttls, key)
 	b.mu.Unlock()
+}
+
+func (b *memoryClaimBackend) queuedEventIDs(key string) []int64 {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	queue := b.queues[key]
+	ids := make([]int64, 0, len(queue))
+	for eventID := range queue {
+		ids = append(ids, eventID)
+	}
+	sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
+	return ids
+}
+
+func preparedTestEvent(eventID int64) robot.PreparedBotTypedEvent {
+	return robot.PreparedBotTypedEvent{
+		EventID:  eventID,
+		QueueKey: "robotEvent:bot-a",
+		Member:   "event-payload",
+	}
 }
 
 func deterministicTokens(tokens ...string) func() (string, error) {
@@ -136,13 +171,6 @@ func TestClaimStoreLifecycleAndConflict(t *testing.T) {
 	if backend.ttls[key] != claimPendingTTL {
 		t.Fatalf("pending TTL = %v, want %v", backend.ttls[key], claimPendingTTL)
 	}
-	backend.ttls[key] = time.Second
-	if renewed, err := store.Renew(lease); err != nil || !renewed {
-		t.Fatalf("renew = %v, %v", renewed, err)
-	}
-	if backend.ttls[key] != claimPendingTTL {
-		t.Fatalf("renewed TTL = %v, want %v", backend.ttls[key], claimPendingTTL)
-	}
 
 	pending, _, err := store.Begin(key, "sha-a")
 	if err != nil || pending.State != claimPending {
@@ -153,12 +181,19 @@ func TestClaimStoreLifecycleAndConflict(t *testing.T) {
 		t.Fatalf("conflicting begin = %+v, %v", conflict, err)
 	}
 
-	ok, err := store.Confirm(lease, 4242)
+	event := preparedTestEvent(4242)
+	ok, err := store.Commit(lease, event)
 	if err != nil || !ok {
-		t.Fatalf("confirm = %v, %v", ok, err)
+		t.Fatalf("commit = %v, %v", ok, err)
 	}
 	if backend.ttls[key] != 2*time.Hour {
 		t.Fatalf("done TTL = %v, want 2h", backend.ttls[key])
+	}
+	if backend.ttls[event.QueueKey] != 2*time.Hour {
+		t.Fatalf("queue TTL = %v, want 2h", backend.ttls[event.QueueKey])
+	}
+	if ids := backend.queuedEventIDs(event.QueueKey); len(ids) != 1 || ids[0] != event.EventID {
+		t.Fatalf("queued event IDs = %v, want [%d]", ids, event.EventID)
 	}
 	replay, err := store.Lookup(key, "sha-a")
 	if err != nil || replay.State != claimReplay || replay.EventID != 4242 {
@@ -196,16 +231,16 @@ func TestClaimStoreStaleLeaseCannotMutateReplacement(t *testing.T) {
 	if err != nil || deleted {
 		t.Fatalf("stale release = %v, %v; must not delete replacement", deleted, err)
 	}
-	if renewed, err := store.Renew(oldLease); err != nil || renewed {
-		t.Fatalf("stale renew = %v, %v; must not extend replacement", renewed, err)
-	}
-	ok, err := store.Confirm(newLease, 200)
+	ok, err := store.Commit(newLease, preparedTestEvent(200))
 	if err != nil || !ok {
-		t.Fatalf("new confirm = %v, %v", ok, err)
+		t.Fatalf("new commit = %v, %v", ok, err)
 	}
-	ok, err = store.Confirm(oldLease, 100)
+	ok, err = store.Commit(oldLease, preparedTestEvent(100))
 	if err != nil || ok {
-		t.Fatalf("stale confirm = %v, %v; must not overwrite replacement", ok, err)
+		t.Fatalf("stale commit = %v, %v; must not enqueue or overwrite replacement", ok, err)
+	}
+	if ids := backend.queuedEventIDs("robotEvent:bot-a"); len(ids) != 1 || ids[0] != 200 {
+		t.Fatalf("queued event IDs = %v, want [200]", ids)
 	}
 	replay, err := store.Lookup(key, "sha-a")
 	if err != nil || replay.EventID != 200 {
@@ -257,11 +292,8 @@ func TestClaimStoreDefaultsAndErrorBranches(t *testing.T) {
 	if token, err := newClaimToken(); err != nil || len(token) != 32 {
 		t.Fatalf("newClaimToken() = %q, %v", token, err)
 	}
-	if ok, err := store.Confirm(nil, 0); err == nil || ok {
-		t.Fatalf("Confirm(nil) = %v, %v", ok, err)
-	}
-	if ok, err := store.Renew(nil); err == nil || ok {
-		t.Fatalf("Renew(nil) = %v, %v", ok, err)
+	if ok, err := store.Commit(nil, robot.PreparedBotTypedEvent{}); err == nil || ok {
+		t.Fatalf("Commit(nil) = %v, %v", ok, err)
 	}
 	if ok, err := store.Release(nil); err == nil || ok {
 		t.Fatalf("Release(nil) = %v, %v", ok, err)
@@ -284,21 +316,18 @@ func TestClaimStoreDefaultsAndErrorBranches(t *testing.T) {
 	}
 }
 
-func TestClaimStorePropagatesCASErrors(t *testing.T) {
+func TestClaimStorePropagatesCommitAndReleaseErrors(t *testing.T) {
 	backend := newMemoryClaimBackend()
 	store := newClaimStore(backend, time.Hour, deterministicTokens("lease-a", "lease-b"))
 	_, lease, err := store.Begin("confirm-key", "sha")
 	if err != nil {
 		t.Fatal(err)
 	}
-	backend.setCASErr = errors.New("cas failed")
-	if ok, err := store.Renew(lease); err == nil || ok {
-		t.Fatalf("Renew CAS error = %v, %v", ok, err)
+	backend.commitErr = errors.New("atomic commit failed")
+	if ok, err := store.Commit(lease, preparedTestEvent(1)); err == nil || ok {
+		t.Fatalf("Commit error = %v, %v", ok, err)
 	}
-	if ok, err := store.Confirm(lease, 1); err == nil || ok {
-		t.Fatalf("Confirm CAS error = %v, %v", ok, err)
-	}
-	backend.setCASErr = nil
+	backend.commitErr = nil
 
 	_, releaseLease, err := store.Begin("release-key", "sha")
 	if err != nil {

--- a/modules/bot_mention/idempotency_test.go
+++ b/modules/bot_mention/idempotency_test.go
@@ -136,6 +136,13 @@ func TestClaimStoreLifecycleAndConflict(t *testing.T) {
 	if backend.ttls[key] != claimPendingTTL {
 		t.Fatalf("pending TTL = %v, want %v", backend.ttls[key], claimPendingTTL)
 	}
+	backend.ttls[key] = time.Second
+	if renewed, err := store.Renew(lease); err != nil || !renewed {
+		t.Fatalf("renew = %v, %v", renewed, err)
+	}
+	if backend.ttls[key] != claimPendingTTL {
+		t.Fatalf("renewed TTL = %v, want %v", backend.ttls[key], claimPendingTTL)
+	}
 
 	pending, _, err := store.Begin(key, "sha-a")
 	if err != nil || pending.State != claimPending {
@@ -188,6 +195,9 @@ func TestClaimStoreStaleLeaseCannotMutateReplacement(t *testing.T) {
 	deleted, err := store.Release(oldLease)
 	if err != nil || deleted {
 		t.Fatalf("stale release = %v, %v; must not delete replacement", deleted, err)
+	}
+	if renewed, err := store.Renew(oldLease); err != nil || renewed {
+		t.Fatalf("stale renew = %v, %v; must not extend replacement", renewed, err)
 	}
 	ok, err := store.Confirm(newLease, 200)
 	if err != nil || !ok {
@@ -250,6 +260,9 @@ func TestClaimStoreDefaultsAndErrorBranches(t *testing.T) {
 	if ok, err := store.Confirm(nil, 0); err == nil || ok {
 		t.Fatalf("Confirm(nil) = %v, %v", ok, err)
 	}
+	if ok, err := store.Renew(nil); err == nil || ok {
+		t.Fatalf("Renew(nil) = %v, %v", ok, err)
+	}
 	if ok, err := store.Release(nil); err == nil || ok {
 		t.Fatalf("Release(nil) = %v, %v", ok, err)
 	}
@@ -279,6 +292,9 @@ func TestClaimStorePropagatesCASErrors(t *testing.T) {
 		t.Fatal(err)
 	}
 	backend.setCASErr = errors.New("cas failed")
+	if ok, err := store.Renew(lease); err == nil || ok {
+		t.Fatalf("Renew CAS error = %v, %v", ok, err)
+	}
 	if ok, err := store.Confirm(lease, 1); err == nil || ok {
 		t.Fatalf("Confirm CAS error = %v, %v", ok, err)
 	}

--- a/modules/bot_mention/idempotency_test.go
+++ b/modules/bot_mention/idempotency_test.go
@@ -20,6 +20,24 @@ type memoryClaimBackend struct {
 	delCASErr error
 }
 
+type disappearingSetNXBackend struct{}
+
+func (disappearingSetNXBackend) Get(string) (string, error) {
+	return "", errClaimNotFound
+}
+
+func (disappearingSetNXBackend) SetNX(string, string, time.Duration) (bool, error) {
+	return false, nil
+}
+
+func (disappearingSetNXBackend) CompareAndSet(string, string, string, time.Duration) (bool, error) {
+	return false, nil
+}
+
+func (disappearingSetNXBackend) CompareAndDelete(string, string) (bool, error) {
+	return false, nil
+}
+
 func newMemoryClaimBackend() *memoryClaimBackend {
 	return &memoryClaimBackend{values: make(map[string]string), ttls: make(map[string]time.Duration)}
 }
@@ -138,6 +156,17 @@ func TestClaimStoreLifecycleAndConflict(t *testing.T) {
 	replay, err := store.Lookup(key, "sha-a")
 	if err != nil || replay.State != claimReplay || replay.EventID != 4242 {
 		t.Fatalf("replay = %+v, %v", replay, err)
+	}
+}
+
+func TestClaimStoreTreatsDisappearingSetNXLoserAsInProgress(t *testing.T) {
+	store := newClaimStore(disappearingSetNXBackend{}, time.Hour, deterministicTokens("lease-a"))
+	outcome, lease, err := store.Begin("claim-key", "sha-a")
+	if err != nil {
+		t.Fatalf("Begin() error = %v", err)
+	}
+	if outcome.State != claimPending || lease != nil {
+		t.Fatalf("Begin() = %+v, lease=%+v; want pending with no lease", outcome, lease)
 	}
 }
 

--- a/modules/bot_mention/idempotency_test.go
+++ b/modules/bot_mention/idempotency_test.go
@@ -208,3 +208,59 @@ func TestMentionClaimKeyDoesNotExposeIdentifiers(t *testing.T) {
 		t.Fatal("claim key must be stable")
 	}
 }
+
+func TestClaimStoreDefaultsAndErrorBranches(t *testing.T) {
+	backend := newMemoryClaimBackend()
+	store := newClaimStore(backend, 0, nil)
+	if store.doneTTL != defaultClaimDoneTTL || store.newToken == nil {
+		t.Fatalf("defaults doneTTL=%v tokenConfigured=%v", store.doneTTL, store.newToken != nil)
+	}
+	if token, err := newClaimToken(); err != nil || len(token) != 32 {
+		t.Fatalf("newClaimToken() = %q, %v", token, err)
+	}
+	if ok, err := store.Confirm(nil, 0); err == nil || ok {
+		t.Fatalf("Confirm(nil) = %v, %v", ok, err)
+	}
+	if ok, err := store.Release(nil); err == nil || ok {
+		t.Fatalf("Release(nil) = %v, %v", ok, err)
+	}
+
+	tokenErrStore := newClaimStore(backend, time.Hour, func() (string, error) {
+		return "", errors.New("entropy unavailable")
+	})
+	if _, _, err := tokenErrStore.Begin("new-key", "sha"); err == nil {
+		t.Fatal("expected token generation error")
+	}
+
+	backend.values["unknown"] = `{"state":"future","sha":"sha"}`
+	if _, err := store.Lookup("unknown", "sha"); err == nil {
+		t.Fatal("expected unknown state error")
+	}
+	backend.values["done-without-event"] = `{"state":"done","sha":"sha"}`
+	if _, err := store.Lookup("done-without-event", "sha"); err == nil {
+		t.Fatal("expected missing event id error")
+	}
+}
+
+func TestClaimStorePropagatesCASErrors(t *testing.T) {
+	backend := newMemoryClaimBackend()
+	store := newClaimStore(backend, time.Hour, deterministicTokens("lease-a", "lease-b"))
+	_, lease, err := store.Begin("confirm-key", "sha")
+	if err != nil {
+		t.Fatal(err)
+	}
+	backend.setCASErr = errors.New("cas failed")
+	if ok, err := store.Confirm(lease, 1); err == nil || ok {
+		t.Fatalf("Confirm CAS error = %v, %v", ok, err)
+	}
+	backend.setCASErr = nil
+
+	_, releaseLease, err := store.Begin("release-key", "sha")
+	if err != nil {
+		t.Fatal(err)
+	}
+	backend.delCASErr = errors.New("cas delete failed")
+	if ok, err := store.Release(releaseLease); err == nil || ok {
+		t.Fatalf("Release CAS error = %v, %v", ok, err)
+	}
+}

--- a/modules/bot_mention/idempotency_test.go
+++ b/modules/bot_mention/idempotency_test.go
@@ -1,0 +1,210 @@
+package bot_mention
+
+import (
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+type memoryClaimBackend struct {
+	mu sync.Mutex
+
+	values map[string]string
+	ttls   map[string]time.Duration
+
+	getErr    error
+	setNXErr  error
+	setCASErr error
+	delCASErr error
+}
+
+func newMemoryClaimBackend() *memoryClaimBackend {
+	return &memoryClaimBackend{values: make(map[string]string), ttls: make(map[string]time.Duration)}
+}
+
+func (b *memoryClaimBackend) Get(key string) (string, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.getErr != nil {
+		return "", b.getErr
+	}
+	v, ok := b.values[key]
+	if !ok {
+		return "", errClaimNotFound
+	}
+	return v, nil
+}
+
+func (b *memoryClaimBackend) SetNX(key, value string, ttl time.Duration) (bool, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.setNXErr != nil {
+		return false, b.setNXErr
+	}
+	if _, ok := b.values[key]; ok {
+		return false, nil
+	}
+	b.values[key] = value
+	b.ttls[key] = ttl
+	return true, nil
+}
+
+func (b *memoryClaimBackend) CompareAndSet(key, oldValue, newValue string, ttl time.Duration) (bool, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.setCASErr != nil {
+		return false, b.setCASErr
+	}
+	if b.values[key] != oldValue {
+		return false, nil
+	}
+	b.values[key] = newValue
+	b.ttls[key] = ttl
+	return true, nil
+}
+
+func (b *memoryClaimBackend) CompareAndDelete(key, oldValue string) (bool, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.delCASErr != nil {
+		return false, b.delCASErr
+	}
+	if b.values[key] != oldValue {
+		return false, nil
+	}
+	delete(b.values, key)
+	delete(b.ttls, key)
+	return true, nil
+}
+
+func (b *memoryClaimBackend) forceDelete(key string) {
+	b.mu.Lock()
+	delete(b.values, key)
+	delete(b.ttls, key)
+	b.mu.Unlock()
+}
+
+func deterministicTokens(tokens ...string) func() (string, error) {
+	var mu sync.Mutex
+	next := 0
+	return func() (string, error) {
+		mu.Lock()
+		defer mu.Unlock()
+		if next >= len(tokens) {
+			return "", errors.New("no token available")
+		}
+		v := tokens[next]
+		next++
+		return v, nil
+	}
+}
+
+func TestClaimStoreLifecycleAndConflict(t *testing.T) {
+	backend := newMemoryClaimBackend()
+	store := newClaimStore(backend, 2*time.Hour, deterministicTokens("lease-a", "lease-b"))
+	key := mentionClaimKey("bot-a", "idem-a")
+
+	outcome, err := store.Lookup(key, "sha-a")
+	if err != nil || outcome.State != claimMissing {
+		t.Fatalf("initial lookup = %+v, %v", outcome, err)
+	}
+
+	outcome, lease, err := store.Begin(key, "sha-a")
+	if err != nil || outcome.State != claimAcquired || lease == nil {
+		t.Fatalf("begin = %+v, lease=%+v, err=%v", outcome, lease, err)
+	}
+	if backend.ttls[key] != claimPendingTTL {
+		t.Fatalf("pending TTL = %v, want %v", backend.ttls[key], claimPendingTTL)
+	}
+
+	pending, _, err := store.Begin(key, "sha-a")
+	if err != nil || pending.State != claimPending {
+		t.Fatalf("duplicate begin = %+v, %v", pending, err)
+	}
+	conflict, _, err := store.Begin(key, "sha-b")
+	if err != nil || conflict.State != claimConflict {
+		t.Fatalf("conflicting begin = %+v, %v", conflict, err)
+	}
+
+	ok, err := store.Confirm(lease, 4242)
+	if err != nil || !ok {
+		t.Fatalf("confirm = %v, %v", ok, err)
+	}
+	if backend.ttls[key] != 2*time.Hour {
+		t.Fatalf("done TTL = %v, want 2h", backend.ttls[key])
+	}
+	replay, err := store.Lookup(key, "sha-a")
+	if err != nil || replay.State != claimReplay || replay.EventID != 4242 {
+		t.Fatalf("replay = %+v, %v", replay, err)
+	}
+}
+
+func TestClaimStoreStaleLeaseCannotMutateReplacement(t *testing.T) {
+	backend := newMemoryClaimBackend()
+	store := newClaimStore(backend, time.Hour, deterministicTokens("old", "new"))
+	key := mentionClaimKey("bot-a", "idem-a")
+
+	_, oldLease, err := store.Begin(key, "sha-a")
+	if err != nil {
+		t.Fatal(err)
+	}
+	backend.forceDelete(key) // model pending expiry before the old worker resumes
+	_, newLease, err := store.Begin(key, "sha-a")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	deleted, err := store.Release(oldLease)
+	if err != nil || deleted {
+		t.Fatalf("stale release = %v, %v; must not delete replacement", deleted, err)
+	}
+	ok, err := store.Confirm(newLease, 200)
+	if err != nil || !ok {
+		t.Fatalf("new confirm = %v, %v", ok, err)
+	}
+	ok, err = store.Confirm(oldLease, 100)
+	if err != nil || ok {
+		t.Fatalf("stale confirm = %v, %v; must not overwrite replacement", ok, err)
+	}
+	replay, err := store.Lookup(key, "sha-a")
+	if err != nil || replay.EventID != 200 {
+		t.Fatalf("replacement replay = %+v, %v", replay, err)
+	}
+}
+
+func TestClaimStorePropagatesBackendAndEncodingErrors(t *testing.T) {
+	backend := newMemoryClaimBackend()
+	store := newClaimStore(backend, time.Hour, deterministicTokens("lease-a"))
+	key := mentionClaimKey("bot-a", "idem-a")
+
+	backend.getErr = errors.New("redis get failed")
+	if _, err := store.Lookup(key, "sha-a"); err == nil {
+		t.Fatal("expected lookup error")
+	}
+	backend.getErr = nil
+	backend.setNXErr = errors.New("redis setnx failed")
+	if _, _, err := store.Begin(key, "sha-a"); err == nil {
+		t.Fatal("expected begin error")
+	}
+
+	backend.setNXErr = nil
+	backend.values[key] = "not-json"
+	if _, err := store.Lookup(key, "sha-a"); err == nil {
+		t.Fatal("expected corrupt record error")
+	}
+}
+
+func TestMentionClaimKeyDoesNotExposeIdentifiers(t *testing.T) {
+	key := mentionClaimKey("sensitive-bot", "sensitive-idempotency-key")
+	if !strings.HasPrefix(key, mentionClaimPrefix) {
+		t.Fatalf("key %q missing prefix %q", key, mentionClaimPrefix)
+	}
+	if strings.Contains(key, "sensitive") {
+		t.Fatalf("claim key leaks raw identifiers: %q", key)
+	}
+	if key != mentionClaimKey("sensitive-bot", "sensitive-idempotency-key") {
+		t.Fatal("claim key must be stable")
+	}
+}

--- a/modules/bot_mention/metrics.go
+++ b/modules/bot_mention/metrics.go
@@ -73,7 +73,7 @@ func (m *botMentionMetrics) ObserveEnqueue(result string, duration time.Duration
 
 func normalizeIngressMetricResult(result string) string {
 	switch result {
-	case "accepted", "replay", "disabled", "invalid", "unauthorized", "conflict", "error":
+	case "accepted", "replay", "disabled", "invalid", "not_found", "unauthorized", "conflict", "error":
 		return result
 	default:
 		return "error"

--- a/modules/bot_mention/metrics.go
+++ b/modules/bot_mention/metrics.go
@@ -1,0 +1,90 @@
+package bot_mention
+
+import (
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type botMentionMetricRecorder interface {
+	ObserveIngress(result string, duration time.Duration)
+	ObserveEnqueue(result string, duration time.Duration)
+}
+
+type botMentionMetrics struct {
+	ingressTotal    *prometheus.CounterVec
+	enqueueTotal    *prometheus.CounterVec
+	ingressDuration *prometheus.HistogramVec
+	enqueueDuration *prometheus.HistogramVec
+}
+
+var defaultBotMentionMetrics = newBotMentionMetrics(prometheus.DefaultRegisterer)
+
+func newBotMentionMetrics(registerer prometheus.Registerer) *botMentionMetrics {
+	if registerer == nil {
+		return nil
+	}
+	metrics := &botMentionMetrics{
+		ingressTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "dmwork_doc_bot_mention_ingress_total",
+			Help: "Document comment bot mention ingress outcomes.",
+		}, []string{"result"}),
+		enqueueTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "dmwork_doc_bot_mention_enqueue_total",
+			Help: "Document comment bot mention event enqueue outcomes.",
+		}, []string{"result"}),
+		ingressDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Name:    "dmwork_doc_bot_mention_ingress_duration_seconds",
+			Help:    "Document comment bot mention ingress latency.",
+			Buckets: prometheus.DefBuckets,
+		}, []string{"result"}),
+		enqueueDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Name:    "dmwork_doc_bot_mention_enqueue_duration_seconds",
+			Help:    "Document comment bot mention event enqueue latency.",
+			Buckets: prometheus.DefBuckets,
+		}, []string{"result"}),
+	}
+	registerer.MustRegister(
+		metrics.ingressTotal,
+		metrics.enqueueTotal,
+		metrics.ingressDuration,
+		metrics.enqueueDuration,
+	)
+	return metrics
+}
+
+func (m *botMentionMetrics) ObserveIngress(result string, duration time.Duration) {
+	if m == nil {
+		return
+	}
+	result = normalizeIngressMetricResult(result)
+	m.ingressTotal.WithLabelValues(result).Inc()
+	m.ingressDuration.WithLabelValues(result).Observe(duration.Seconds())
+}
+
+func (m *botMentionMetrics) ObserveEnqueue(result string, duration time.Duration) {
+	if m == nil {
+		return
+	}
+	result = normalizeEnqueueMetricResult(result)
+	m.enqueueTotal.WithLabelValues(result).Inc()
+	m.enqueueDuration.WithLabelValues(result).Observe(duration.Seconds())
+}
+
+func normalizeIngressMetricResult(result string) string {
+	switch result {
+	case "accepted", "replay", "disabled", "invalid", "unauthorized", "conflict", "error":
+		return result
+	default:
+		return "error"
+	}
+}
+
+func normalizeEnqueueMetricResult(result string) string {
+	switch result {
+	case "accepted", "error":
+		return result
+	default:
+		return "error"
+	}
+}

--- a/modules/bot_mention/metrics_test.go
+++ b/modules/bot_mention/metrics_test.go
@@ -12,6 +12,7 @@ func TestBotMentionMetricsRegisterLowCardinalityResults(t *testing.T) {
 	metrics := newBotMentionMetrics(registry)
 
 	metrics.ObserveIngress("accepted", 25*time.Millisecond)
+	metrics.ObserveIngress("not_found", 20*time.Millisecond)
 	metrics.ObserveIngress("unexpected-result", 10*time.Millisecond)
 	metrics.ObserveEnqueue("accepted", 15*time.Millisecond)
 	metrics.ObserveEnqueue("unexpected-result", 5*time.Millisecond)
@@ -44,6 +45,14 @@ func TestBotMentionMetricsRegisterLowCardinalityResults(t *testing.T) {
 		}
 		if !got[name]["accepted"] || !got[name]["error"] {
 			t.Fatalf("metric %q results=%v, want accepted and sanitized error", name, got[name])
+		}
+	}
+	for _, name := range []string{
+		"dmwork_doc_bot_mention_ingress_total",
+		"dmwork_doc_bot_mention_ingress_duration_seconds",
+	} {
+		if !got[name]["not_found"] {
+			t.Fatalf("metric %q results=%v, want distinct not_found outcome", name, got[name])
 		}
 	}
 }

--- a/modules/bot_mention/metrics_test.go
+++ b/modules/bot_mention/metrics_test.go
@@ -13,8 +13,8 @@ func TestBotMentionMetricsRegisterLowCardinalityResults(t *testing.T) {
 
 	metrics.ObserveIngress("accepted", 25*time.Millisecond)
 	metrics.ObserveIngress("unexpected-result", 10*time.Millisecond)
-	metrics.ObserveEnqueue("accepted")
-	metrics.ObserveEnqueue("unexpected-result")
+	metrics.ObserveEnqueue("accepted", 15*time.Millisecond)
+	metrics.ObserveEnqueue("unexpected-result", 5*time.Millisecond)
 
 	families, err := registry.Gather()
 	if err != nil {
@@ -37,6 +37,7 @@ func TestBotMentionMetricsRegisterLowCardinalityResults(t *testing.T) {
 		"dmwork_doc_bot_mention_ingress_total",
 		"dmwork_doc_bot_mention_enqueue_total",
 		"dmwork_doc_bot_mention_ingress_duration_seconds",
+		"dmwork_doc_bot_mention_enqueue_duration_seconds",
 	} {
 		if _, ok := got[name]; !ok {
 			t.Fatalf("metric family %q not registered; got=%v", name, got)

--- a/modules/bot_mention/metrics_test.go
+++ b/modules/bot_mention/metrics_test.go
@@ -1,0 +1,48 @@
+package bot_mention
+
+import (
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+func TestBotMentionMetricsRegisterLowCardinalityResults(t *testing.T) {
+	registry := prometheus.NewRegistry()
+	metrics := newBotMentionMetrics(registry)
+
+	metrics.ObserveIngress("accepted", 25*time.Millisecond)
+	metrics.ObserveIngress("unexpected-result", 10*time.Millisecond)
+	metrics.ObserveEnqueue("accepted")
+	metrics.ObserveEnqueue("unexpected-result")
+
+	families, err := registry.Gather()
+	if err != nil {
+		t.Fatalf("gather metrics: %v", err)
+	}
+	got := make(map[string]map[string]bool)
+	for _, family := range families {
+		results := make(map[string]bool)
+		for _, metric := range family.Metric {
+			for _, label := range metric.Label {
+				if label.GetName() == "result" {
+					results[label.GetValue()] = true
+				}
+			}
+		}
+		got[family.GetName()] = results
+	}
+
+	for _, name := range []string{
+		"dmwork_doc_bot_mention_ingress_total",
+		"dmwork_doc_bot_mention_enqueue_total",
+		"dmwork_doc_bot_mention_ingress_duration_seconds",
+	} {
+		if _, ok := got[name]; !ok {
+			t.Fatalf("metric family %q not registered; got=%v", name, got)
+		}
+		if !got[name]["accepted"] || !got[name]["error"] {
+			t.Fatalf("metric %q results=%v, want accepted and sanitized error", name, got[name])
+		}
+	}
+}

--- a/modules/bot_mention/redis_integration_test.go
+++ b/modules/bot_mention/redis_integration_test.go
@@ -58,12 +58,15 @@ func TestBotMentionMySQLRedisRobotQueueIntegration(t *testing.T) {
 	ctx, cfg := newBotMentionIntegrationContext(t, botMentionIntegrationExpire)
 	nonce := time.Now().UnixNano()
 	botID := fmt.Sprintf("bm-%d", nonce)
+	inactiveBotID := fmt.Sprintf("bm-inactive-%d", nonce)
+	appBotID := fmt.Sprintf("bm-app-%d", nonce)
 	botToken := fmt.Sprintf("bf_bm_%d", nonce)
 	request := validMentionRequest()
 	request.BotUID = botID
 	request.IdempotencyKey = fmt.Sprintf("idem-%d", nonce)
 	ensureBotMentionIntegrationSchema(t, ctx)
 	prepareActiveUserBot(t, ctx, botID, botToken)
+	prepareIneligibleBots(t, ctx, inactiveBotID, appBotID, nonce)
 
 	claims := newRedisClaimStore(ctx)
 	redisClient := claims.backend.(*redisClaimBackend).client
@@ -89,6 +92,30 @@ func TestBotMentionMySQLRedisRobotQueueIntegration(t *testing.T) {
 	router.SetErrorRenderer(i18n.NewErrorRenderer(i18n.NewLocalizer(i18n.DefaultLanguage)))
 	module.Route(router)
 	bot_api.NewBotAPI(ctx).Route(router)
+
+	for _, tt := range []struct {
+		name  string
+		botID string
+	}{
+		{name: "inactive User Bot", botID: inactiveBotID},
+		{name: "App Bot", botID: appBotID},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			ineligible := request
+			ineligible.BotUID = tt.botID
+			ineligible.IdempotencyKey = fmt.Sprintf("idem-%s-%d", tt.botID, nonce)
+			response := doMentionRequest(t, router, module.internalToken, ineligible)
+			if response.Code != http.StatusNotFound || decodeMentionError(t, response).Error.Code != "err.shared.not_found" {
+				t.Fatalf("status=%d body=%s", response.Code, response.Body.String())
+			}
+			if got := redisClient.ZCard("robotEvent:" + tt.botID).Val(); got != 0 {
+				t.Fatalf("queue size = %d, want 0", got)
+			}
+			if got := redisClient.Exists(mentionClaimKey(tt.botID, ineligible.IdempotencyKey)).Val(); got != 0 {
+				t.Fatalf("claim count = %d, want 0", got)
+			}
+		})
+	}
 
 	first := doMentionRequest(t, router, module.internalToken, request)
 	if first.Code != http.StatusOK {
@@ -217,6 +244,27 @@ func ensureBotMentionIntegrationSchema(t *testing.T, ctx *config.Context) {
 			) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci`,
 		},
 		{
+			name: "app_bot",
+			sql: `CREATE TABLE IF NOT EXISTS app_bot (
+				id VARCHAR(40) NOT NULL,
+				uid VARCHAR(40) NOT NULL,
+				display_name VARCHAR(100) NOT NULL,
+				description VARCHAR(500) NOT NULL DEFAULT '',
+				avatar VARCHAR(200) NOT NULL DEFAULT '',
+				scope VARCHAR(20) NOT NULL DEFAULT 'platform',
+				space_id VARCHAR(40) DEFAULT NULL,
+				status TINYINT NOT NULL DEFAULT 0,
+				token VARCHAR(100) NOT NULL,
+				welcome_msg VARCHAR(500) NOT NULL DEFAULT '',
+				created_by VARCHAR(40) NOT NULL,
+				created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+				updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+				PRIMARY KEY (id),
+				UNIQUE KEY uk_app_bot_uid (uid),
+				UNIQUE KEY uk_app_bot_token (token)
+			) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci`,
+		},
+		{
 			name: "seq",
 			sql: `CREATE TABLE IF NOT EXISTS seq (
 				id INT NOT NULL AUTO_INCREMENT,
@@ -250,6 +298,30 @@ func ensureBotMentionIntegrationSchema(t *testing.T, ctx *config.Context) {
 			t.Fatalf("create integration %s table: %v", statement.name, err)
 		}
 	}
+}
+
+func prepareIneligibleBots(t *testing.T, ctx *config.Context, inactiveBotID, appBotID string, nonce int64) {
+	t.Helper()
+	if _, err := ctx.DB().InsertBySql(
+		"INSERT INTO robot (robot_id, status, creator_uid, bot_token) VALUES (?, 0, ?, ?)",
+		inactiveBotID, "bot-mention-integration-owner", fmt.Sprintf("bf_inactive_%d", nonce),
+	).Exec(); err != nil {
+		t.Fatalf("insert inactive integration User Bot: %v", err)
+	}
+	if _, err := ctx.DB().InsertBySql(
+		"INSERT INTO app_bot (id, uid, display_name, status, token, created_by) VALUES (?, ?, ?, 1, ?, ?)",
+		fmt.Sprintf("app-%d", nonce), appBotID, "Bot Mention App Bot", fmt.Sprintf("app_token_%d", nonce), "bot-mention-integration-owner",
+	).Exec(); err != nil {
+		t.Fatalf("insert integration App Bot: %v", err)
+	}
+	t.Cleanup(func() {
+		if _, err := ctx.DB().DeleteFrom("app_bot").Where("uid=?", appBotID).Exec(); err != nil {
+			t.Errorf("cleanup integration App Bot: %v", err)
+		}
+		if _, err := ctx.DB().DeleteFrom("robot").Where("robot_id=?", inactiveBotID).Exec(); err != nil {
+			t.Errorf("cleanup inactive integration User Bot: %v", err)
+		}
+	})
 }
 
 func prepareActiveUserBot(t *testing.T, ctx *config.Context, botID, botToken string) {

--- a/modules/bot_mention/redis_integration_test.go
+++ b/modules/bot_mention/redis_integration_test.go
@@ -1,0 +1,308 @@
+package bot_mention
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"reflect"
+	"regexp"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+	"unsafe"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/modules/bot_api"
+	"github.com/Mininglamp-OSS/octo-server/modules/robot"
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
+	"github.com/go-redis/redis"
+	"github.com/gocraft/dbr/v2"
+	"github.com/gocraft/dbr/v2/dialect"
+)
+
+const botMentionIntegrationExpire = 2 * time.Minute
+
+func TestNewRejectsInternalTokenCapabilityCollisions(t *testing.T) {
+	tests := []struct {
+		name         string
+		mentionToken string
+		notifyToken  string
+		docsToken    string
+		want         string
+	}{
+		{name: "independent token enabled", mentionToken: "mention-secret", notifyToken: "notify-secret", docsToken: "docs-notify-secret", want: "mention-secret"},
+		{name: "empty token disabled", notifyToken: "notify-secret", docsToken: "docs-notify-secret"},
+		{name: "legacy notify collision disabled", mentionToken: "shared-secret", notifyToken: "shared-secret", docsToken: "docs-notify-secret"},
+		{name: "docs notify collision disabled", mentionToken: "shared-secret", notifyToken: "notify-secret", docsToken: "shared-secret"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv(internalTokenEnv, tt.mentionToken)
+			t.Setenv("NOTIFY_INTERNAL_TOKEN", tt.notifyToken)
+			t.Setenv("OCTO_DOCS_NOTIFY_TOKEN", tt.docsToken)
+
+			ctx, _, _ := newBotMentionRedisTestContext(t, botMentionIntegrationExpire)
+			module := New(ctx)
+			closeBotMentionClaimClient(t, module.claims)
+
+			if module.internalToken != tt.want {
+				t.Fatalf("internal token = %q, want %q", module.internalToken, tt.want)
+			}
+		})
+	}
+}
+
+func TestBotMentionRedisRobotQueueIntegration(t *testing.T) {
+	ctx, dbMock, cfg := newBotMentionRedisTestContext(t, botMentionIntegrationExpire)
+	botID := fmt.Sprintf("bot-mention-integration-%d", time.Now().UnixNano())
+	botToken := "bf_bot_mention_integration"
+	request := validMentionRequest()
+	request.BotUID = botID
+	request.IdempotencyKey = fmt.Sprintf("idem-%d", time.Now().UnixNano())
+
+	claims := newRedisClaimStore(ctx)
+	redisClient := claims.backend.(*redisClaimBackend).client
+	t.Cleanup(func() { _ = redisClient.Close() })
+	if err := redisClient.Ping().Err(); err != nil {
+		t.Fatalf("real Redis is required for bot mention integration test at %s: %v", cfg.DB.RedisAddr, err)
+	}
+
+	queueKey := "robotEvent:" + botID
+	claimKey := mentionClaimKey(botID, request.IdempotencyKey)
+	t.Cleanup(func() { _ = redisClient.Del(queueKey, claimKey).Err() })
+
+	expectActiveUserBot(dbMock, botID)
+	expectNewRobotEventSequence(dbMock)
+	expectSystemSettingsLoad(dbMock)
+
+	module := &BotMention{
+		robots:        robot.NewService(ctx),
+		claims:        claims,
+		gate:          newFeatureGate(true, "", "*"),
+		internalToken: "mention-internal-secret",
+		metrics:       &fakeMetricRecorder{},
+		now:           time.Now,
+		Log:           log.NewTLog("BotMentionRedisIntegrationTest"),
+	}
+	router := wkhttp.New()
+	router.SetErrorRenderer(i18n.NewErrorRenderer(i18n.NewLocalizer(i18n.DefaultLanguage)))
+	module.Route(router)
+	bot_api.NewBotAPI(ctx).Route(router)
+
+	first := doMentionRequest(t, router, module.internalToken, request)
+	if first.Code != http.StatusOK {
+		t.Fatalf("first ingress status = %d, body=%s", first.Code, first.Body.String())
+	}
+	accepted := decodeMentionResponse(t, first)
+	if !accepted.Accepted || accepted.Replay || accepted.EventID <= 0 {
+		t.Fatalf("first ingress response = %+v", accepted)
+	}
+
+	if got := redisClient.ZCard(queueKey).Val(); got != 1 {
+		t.Fatalf("queue size after first ingress = %d, want 1", got)
+	}
+	assertRedisTTLTracksMessageExpire(t, redisClient.TTL(queueKey).Val(), cfg.Robot.MessageExpire, "queue")
+	assertRedisTTLTracksMessageExpire(t, redisClient.TTL(claimKey).Val(), cfg.Robot.MessageExpire, "confirmed claim")
+	assertQueuedEventExpireTracksMessageExpire(t, redisClient, queueKey, cfg.Robot.MessageExpire)
+
+	replay := doMentionRequest(t, router, module.internalToken, request)
+	if replay.Code != http.StatusOK {
+		t.Fatalf("replay status = %d, body=%s", replay.Code, replay.Body.String())
+	}
+	replayed := decodeMentionResponse(t, replay)
+	if !replayed.Accepted || !replayed.Replay || replayed.EventID != accepted.EventID {
+		t.Fatalf("replay response = %+v, want event_id %d", replayed, accepted.EventID)
+	}
+	if got := redisClient.ZCard(queueKey).Val(); got != 1 {
+		t.Fatalf("queue size after replay = %d, want 1", got)
+	}
+
+	expectBotTokenAuth(dbMock, botID, botToken)
+	pulled := doBotAPIRequest(t, router, http.MethodPost, "/v1/bot/events", botToken, []byte("{\"event_id\":0,\"limit\":10}"))
+	if pulled.Code != http.StatusOK {
+		t.Fatalf("pull status = %d, body=%s", pulled.Code, pulled.Body.String())
+	}
+	var events struct {
+		Status  int `json:"status"`
+		Results []struct {
+			EventID   int64                  `json:"event_id"`
+			EventType string                 `json:"event_type"`
+			EventData map[string]interface{} `json:"event_data"`
+		} `json:"results"`
+	}
+	if err := json.Unmarshal(pulled.Body.Bytes(), &events); err != nil {
+		t.Fatalf("decode pulled events: %v, body=%s", err, pulled.Body.String())
+	}
+	if events.Status != 1 || len(events.Results) != 1 {
+		t.Fatalf("pulled events = %+v", events)
+	}
+	event := events.Results[0]
+	if event.EventID != accepted.EventID || event.EventType != docCommentMentionEventType {
+		t.Fatalf("pulled event id/type = %d/%q", event.EventID, event.EventType)
+	}
+	if event.EventData["idempotency_key"] != request.IdempotencyKey || event.EventData["bot_uid"] != botID {
+		t.Fatalf("pulled event data = %#v", event.EventData)
+	}
+
+	expectBotTokenAuth(dbMock, botID, botToken)
+	ackPath := fmt.Sprintf("/v1/bot/events/%d/ack", accepted.EventID)
+	acked := doBotAPIRequest(t, router, http.MethodPost, ackPath, botToken, nil)
+	if acked.Code != http.StatusOK {
+		t.Fatalf("ack status = %d, body=%s", acked.Code, acked.Body.String())
+	}
+	if got := redisClient.ZCard(queueKey).Val(); got != 0 {
+		t.Fatalf("queue size after ACK = %d, want 0", got)
+	}
+
+	afterACKReplay := doMentionRequest(t, router, module.internalToken, request)
+	if afterACKReplay.Code != http.StatusOK {
+		t.Fatalf("post-ACK replay status = %d, body=%s", afterACKReplay.Code, afterACKReplay.Body.String())
+	}
+	if response := decodeMentionResponse(t, afterACKReplay); !response.Replay || response.EventID != accepted.EventID {
+		t.Fatalf("post-ACK replay response = %+v", response)
+	}
+	if got := redisClient.ZCard(queueKey).Val(); got != 0 {
+		t.Fatalf("queue size after post-ACK replay = %d, want 0", got)
+	}
+
+	assertRealRedisClaimCAS(t, claims, redisClient)
+	if err := dbMock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("database expectations: %v", err)
+	}
+}
+
+func newBotMentionRedisTestContext(t *testing.T, messageExpire time.Duration) (*config.Context, sqlmock.Sqlmock, *config.Config) {
+	t.Helper()
+	cfg := config.New()
+	cfg.Test = true
+	cfg.Robot.MessageExpire = messageExpire
+	if addr := os.Getenv("OCTO_TEST_REDIS_ADDR"); addr != "" {
+		cfg.DB.RedisAddr = addr
+	}
+
+	ctx := config.NewContext(cfg)
+	rawDB, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherRegexp))
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	mock.MatchExpectationsInOrder(false)
+	conn := &dbr.Connection{DB: rawDB, EventReceiver: &dbr.NullEventReceiver{}, Dialect: dialect.MySQL}
+	injectBotMentionMockDB(t, ctx, conn.NewSession(nil))
+	t.Cleanup(func() { _ = rawDB.Close() })
+	return ctx, mock, cfg
+}
+
+func injectBotMentionMockDB(t *testing.T, ctx *config.Context, session *dbr.Session) {
+	t.Helper()
+	ctxValue := reflect.ValueOf(ctx).Elem()
+	onceField := ctxValue.FieldByName("mysqlOnce")
+	once := (*sync.Once)(unsafe.Pointer(onceField.UnsafeAddr()))
+	once.Do(func() {})
+	sessionField := ctxValue.FieldByName("mySQLSession")
+	reflect.NewAt(sessionField.Type(), unsafe.Pointer(sessionField.UnsafeAddr())).Elem().Set(reflect.ValueOf(session))
+}
+
+func closeBotMentionClaimClient(t *testing.T, store botMentionClaimStore) {
+	t.Helper()
+	claims, ok := store.(*claimStore)
+	if !ok {
+		return
+	}
+	backend, ok := claims.backend.(*redisClaimBackend)
+	if ok {
+		t.Cleanup(func() { _ = backend.client.Close() })
+	}
+}
+
+func expectActiveUserBot(mock sqlmock.Sqlmock, botID string) {
+	mock.ExpectQuery("(?i)SELECT count\\(\\*\\) FROM robot WHERE .*" +
+		regexp.QuoteMeta("robot_id='"+botID+"'") + ".*status=1").
+		WillReturnRows(sqlmock.NewRows([]string{"count(*)"}).AddRow(1))
+}
+
+func expectNewRobotEventSequence(mock sqlmock.Sqlmock) {
+	mock.ExpectQuery("(?i)SELECT \\* FROM seq WHERE").
+		WillReturnRows(sqlmock.NewRows([]string{"key", "min_seq", "step"}))
+	mock.ExpectExec("(?i)insert into `seq`").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+}
+
+func expectBotTokenAuth(mock sqlmock.Sqlmock, botID, token string) {
+	mock.ExpectQuery("(?i)SELECT \\* FROM robot WHERE .*" +
+		regexp.QuoteMeta("bot_token='"+token+"'") + ".*status=1").
+		WillReturnRows(sqlmock.NewRows([]string{"robot_id", "status", "bot_token"}).AddRow(botID, 1, token))
+}
+
+func expectSystemSettingsLoad(mock sqlmock.Sqlmock) {
+	mock.ExpectQuery("(?i)SELECT \\* FROM system_setting").
+		WillReturnRows(sqlmock.NewRows([]string{"category", "key_name", "value", "value_type", "description"}))
+}
+
+func doBotAPIRequest(t *testing.T, router *wkhttp.WKHttp, method, path, token string, body []byte) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(method, path, bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+token)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	return w
+}
+
+func assertRedisTTLTracksMessageExpire(t *testing.T, got, want time.Duration, kind string) {
+	t.Helper()
+	if got <= want-3*time.Second || got > want {
+		t.Fatalf("%s TTL = %v, want within (%v, %v]", kind, got, want-3*time.Second, want)
+	}
+}
+
+func assertQueuedEventExpireTracksMessageExpire(t *testing.T, client *redis.Client, queueKey string, expire time.Duration) {
+	t.Helper()
+	values, err := client.ZRange(queueKey, 0, -1).Result()
+	if err != nil || len(values) != 1 {
+		t.Fatalf("read queued event = %v, %v", values, err)
+	}
+	var record struct {
+		Expire int64 `json:"expire"`
+	}
+	if err := json.Unmarshal([]byte(values[0]), &record); err != nil {
+		t.Fatalf("decode queued event: %v", err)
+	}
+	want := time.Now().Add(expire).Unix()
+	if record.Expire < want-3 || record.Expire > want+1 {
+		t.Fatalf("queued event expire = %d, want around %d", record.Expire, want)
+	}
+}
+
+func assertRealRedisClaimCAS(t *testing.T, claims *claimStore, client *redis.Client) {
+	t.Helper()
+	key := mentionClaimPrefix + fmt.Sprintf("cas-%d", time.Now().UnixNano())
+	t.Cleanup(func() { _ = client.Del(key).Err() })
+
+	outcome, lease, err := claims.Begin(key, "sha-original")
+	if err != nil || outcome.State != claimAcquired || lease == nil {
+		t.Fatalf("real Redis begin = %+v, lease=%+v, err=%v", outcome, lease, err)
+	}
+	assertRedisTTLTracksMessageExpire(t, client.TTL(key).Val(), claimPendingTTL, "pending claim")
+
+	replacement := "{\"state\":\"pending\",\"sha\":\"sha-replacement\",\"token\":\"replacement\"}"
+	if err := client.Set(key, replacement, claimPendingTTL).Err(); err != nil {
+		t.Fatalf("replace pending claim: %v", err)
+	}
+	if released, err := claims.Release(lease); err != nil || released {
+		t.Fatalf("stale real Redis release = %v, %v; want false, nil", released, err)
+	}
+	if confirmed, err := claims.Confirm(lease, 99); err != nil || confirmed {
+		t.Fatalf("stale real Redis confirm = %v, %v; want false, nil", confirmed, err)
+	}
+	if got, err := client.Get(key).Result(); err != nil || !strings.Contains(got, "sha-replacement") {
+		t.Fatalf("replacement claim after stale CAS = %q, %v", got, err)
+	}
+}

--- a/modules/bot_mention/redis_integration_test.go
+++ b/modules/bot_mention/redis_integration_test.go
@@ -351,7 +351,8 @@ func assertQueuedEventExpireTracksMessageExpire(t *testing.T, client *redis.Clie
 func assertRealRedisClaimCAS(t *testing.T, claims *claimStore, client *redis.Client) {
 	t.Helper()
 	key := mentionClaimPrefix + fmt.Sprintf("cas-%d", time.Now().UnixNano())
-	t.Cleanup(func() { _ = client.Del(key).Err() })
+	queueKey := "robotEvent:" + key
+	t.Cleanup(func() { _ = client.Del(key, queueKey).Err() })
 
 	outcome, lease, err := claims.Begin(key, "sha-original")
 	if err != nil || outcome.State != claimAcquired || lease == nil {
@@ -366,8 +367,12 @@ func assertRealRedisClaimCAS(t *testing.T, claims *claimStore, client *redis.Cli
 	if released, err := claims.Release(lease); err != nil || released {
 		t.Fatalf("stale real Redis release = %v, %v; want false, nil", released, err)
 	}
-	if confirmed, err := claims.Confirm(lease, 99); err != nil || confirmed {
-		t.Fatalf("stale real Redis confirm = %v, %v; want false, nil", confirmed, err)
+	prepared := robot.PreparedBotTypedEvent{EventID: 99, QueueKey: queueKey, Member: `{"event_id":99}`}
+	if committed, err := claims.Commit(lease, prepared); err != nil || committed {
+		t.Fatalf("stale real Redis commit = %v, %v; want false, nil", committed, err)
+	}
+	if got := client.ZCard(queueKey).Val(); got != 0 {
+		t.Fatalf("stale real Redis commit queued %d events, want 0", got)
 	}
 	if got, err := client.Get(key).Result(); err != nil || !strings.Contains(got, "sha-replacement") {
 		t.Fatalf("replacement claim after stale CAS = %q, %v", got, err)

--- a/modules/bot_mention/redis_integration_test.go
+++ b/modules/bot_mention/redis_integration_test.go
@@ -29,6 +29,8 @@ import (
 
 const botMentionIntegrationExpire = 2 * time.Minute
 
+var expectSystemSettingsLoadOnce sync.Once
+
 func TestNewRejectsInternalTokenCapabilityCollisions(t *testing.T) {
 	tests := []struct {
 		name         string
@@ -81,7 +83,7 @@ func TestBotMentionRedisRobotQueueIntegration(t *testing.T) {
 
 	expectActiveUserBot(dbMock, botID)
 	expectNewRobotEventSequence(dbMock)
-	expectSystemSettingsLoad(dbMock)
+	expectSystemSettingsLoadOnce.Do(func() { expectSystemSettingsLoad(dbMock) })
 
 	module := &BotMention{
 		robots:        robot.NewService(ctx),

--- a/modules/bot_mention/redis_integration_test.go
+++ b/modules/bot_mention/redis_integration_test.go
@@ -62,6 +62,7 @@ func TestBotMentionMySQLRedisRobotQueueIntegration(t *testing.T) {
 	request := validMentionRequest()
 	request.BotUID = botID
 	request.IdempotencyKey = fmt.Sprintf("idem-%d", nonce)
+	ensureBotMentionIntegrationSchema(t, ctx)
 	prepareActiveUserBot(t, ctx, botID, botToken)
 
 	claims := newRedisClaimStore(ctx)
@@ -186,6 +187,69 @@ func newBotMentionIntegrationContext(t *testing.T, messageExpire time.Duration) 
 	}
 	t.Cleanup(func() { _ = ctx.DB().Close() })
 	return ctx, cfg
+}
+
+// ensureBotMentionIntegrationSchema keeps this package test self-contained.
+// CI drops and recreates the shared test database before every Go package, so
+// the bot_mention package cannot rely on robot/common migrations run elsewhere.
+// IF NOT EXISTS preserves the production-like local schema when it is present.
+func ensureBotMentionIntegrationSchema(t *testing.T, ctx *config.Context) {
+	t.Helper()
+	statements := []struct {
+		name string
+		sql  string
+	}{
+		{
+			name: "robot",
+			sql: `CREATE TABLE IF NOT EXISTS robot (
+				id BIGINT NOT NULL AUTO_INCREMENT,
+				robot_id VARCHAR(40) NOT NULL DEFAULT '',
+				token VARCHAR(100) NOT NULL DEFAULT '',
+				version BIGINT NOT NULL DEFAULT 0,
+				status SMALLINT NOT NULL DEFAULT 1,
+				creator_uid VARCHAR(40) NOT NULL DEFAULT '',
+				bot_token VARCHAR(100) NOT NULL DEFAULT '',
+				created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+				updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+				PRIMARY KEY (id),
+				UNIQUE KEY robot_id_robot_index (robot_id),
+				UNIQUE KEY idx_robot_bot_token (bot_token)
+			) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci`,
+		},
+		{
+			name: "seq",
+			sql: `CREATE TABLE IF NOT EXISTS seq (
+				id INT NOT NULL AUTO_INCREMENT,
+				` + "`key`" + ` VARCHAR(100) NOT NULL DEFAULT '',
+				min_seq BIGINT NOT NULL DEFAULT 1000000,
+				step INT NOT NULL DEFAULT 1000,
+				created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+				updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+				PRIMARY KEY (id),
+				UNIQUE KEY seq_uidx (` + "`key`" + `)
+			) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci`,
+		},
+		{
+			name: "system_setting",
+			sql: `CREATE TABLE IF NOT EXISTS system_setting (
+				id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+				category VARCHAR(64) NOT NULL,
+				key_name VARCHAR(128) NOT NULL,
+				value TEXT NOT NULL,
+				value_type VARCHAR(16) NOT NULL DEFAULT 'string',
+				description VARCHAR(255) NOT NULL DEFAULT '',
+				created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+				updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+				PRIMARY KEY (id),
+				UNIQUE KEY uk_category_key (category, key_name)
+			) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci`,
+		},
+	}
+	for _, statement := range statements {
+		if _, err := ctx.DB().DB.Exec(statement.sql); err != nil {
+			t.Fatalf("create integration %s table: %v", statement.name, err)
+		}
+	}
 }
 
 func prepareActiveUserBot(t *testing.T, ctx *config.Context, botID, botToken string) {

--- a/modules/bot_mention/redis_integration_test.go
+++ b/modules/bot_mention/redis_integration_test.go
@@ -23,37 +23,6 @@ import (
 
 const botMentionIntegrationExpire = 2 * time.Minute
 
-func TestNewRejectsInternalTokenCapabilityCollisions(t *testing.T) {
-	tests := []struct {
-		name         string
-		mentionToken string
-		notifyToken  string
-		docsToken    string
-		want         string
-	}{
-		{name: "independent token enabled", mentionToken: "mention-secret", notifyToken: "notify-secret", docsToken: "docs-notify-secret", want: "mention-secret"},
-		{name: "empty token disabled", notifyToken: "notify-secret", docsToken: "docs-notify-secret"},
-		{name: "legacy notify collision disabled", mentionToken: "shared-secret", notifyToken: "shared-secret", docsToken: "docs-notify-secret"},
-		{name: "docs notify collision disabled", mentionToken: "shared-secret", notifyToken: "notify-secret", docsToken: "shared-secret"},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Setenv(internalTokenEnv, tt.mentionToken)
-			t.Setenv("NOTIFY_INTERNAL_TOKEN", tt.notifyToken)
-			t.Setenv("OCTO_DOCS_NOTIFY_TOKEN", tt.docsToken)
-
-			ctx, _ := newBotMentionIntegrationContext(t, botMentionIntegrationExpire)
-			module := New(ctx)
-			closeBotMentionClaimClient(t, module.claims)
-
-			if module.internalToken != tt.want {
-				t.Fatalf("internal token = %q, want %q", module.internalToken, tt.want)
-			}
-		})
-	}
-}
-
 func TestBotMentionMySQLRedisRobotQueueIntegration(t *testing.T) {
 	ctx, cfg := newBotMentionIntegrationContext(t, botMentionIntegrationExpire)
 	nonce := time.Now().UnixNano()
@@ -342,18 +311,6 @@ func prepareActiveUserBot(t *testing.T, ctx *config.Context, botID, botToken str
 			t.Errorf("cleanup integration User Bot: %v", err)
 		}
 	})
-}
-
-func closeBotMentionClaimClient(t *testing.T, store botMentionClaimStore) {
-	t.Helper()
-	claims, ok := store.(*claimStore)
-	if !ok {
-		return
-	}
-	backend, ok := claims.backend.(*redisClaimBackend)
-	if ok {
-		t.Cleanup(func() { _ = backend.client.Close() })
-	}
 }
 
 func doBotAPIRequest(t *testing.T, router *wkhttp.WKHttp, method, path, token string, body []byte) *httptest.ResponseRecorder {

--- a/modules/bot_mention/redis_integration_test.go
+++ b/modules/bot_mention/redis_integration_test.go
@@ -7,15 +7,11 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
-	"reflect"
-	"regexp"
 	"strings"
-	"sync"
 	"testing"
 	"time"
-	"unsafe"
 
-	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/Mininglamp-OSS/octo-lib/common"
 	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
@@ -23,13 +19,9 @@ import (
 	"github.com/Mininglamp-OSS/octo-server/modules/robot"
 	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
 	"github.com/go-redis/redis"
-	"github.com/gocraft/dbr/v2"
-	"github.com/gocraft/dbr/v2/dialect"
 )
 
 const botMentionIntegrationExpire = 2 * time.Minute
-
-var expectSystemSettingsLoadOnce sync.Once
 
 func TestNewRejectsInternalTokenCapabilityCollisions(t *testing.T) {
 	tests := []struct {
@@ -51,7 +43,7 @@ func TestNewRejectsInternalTokenCapabilityCollisions(t *testing.T) {
 			t.Setenv("NOTIFY_INTERNAL_TOKEN", tt.notifyToken)
 			t.Setenv("OCTO_DOCS_NOTIFY_TOKEN", tt.docsToken)
 
-			ctx, _, _ := newBotMentionRedisTestContext(t, botMentionIntegrationExpire)
+			ctx, _ := newBotMentionIntegrationContext(t, botMentionIntegrationExpire)
 			module := New(ctx)
 			closeBotMentionClaimClient(t, module.claims)
 
@@ -62,13 +54,15 @@ func TestNewRejectsInternalTokenCapabilityCollisions(t *testing.T) {
 	}
 }
 
-func TestBotMentionRedisRobotQueueIntegration(t *testing.T) {
-	ctx, dbMock, cfg := newBotMentionRedisTestContext(t, botMentionIntegrationExpire)
-	botID := fmt.Sprintf("bot-mention-integration-%d", time.Now().UnixNano())
-	botToken := "bf_bot_mention_integration"
+func TestBotMentionMySQLRedisRobotQueueIntegration(t *testing.T) {
+	ctx, cfg := newBotMentionIntegrationContext(t, botMentionIntegrationExpire)
+	nonce := time.Now().UnixNano()
+	botID := fmt.Sprintf("bm-%d", nonce)
+	botToken := fmt.Sprintf("bf_bm_%d", nonce)
 	request := validMentionRequest()
 	request.BotUID = botID
-	request.IdempotencyKey = fmt.Sprintf("idem-%d", time.Now().UnixNano())
+	request.IdempotencyKey = fmt.Sprintf("idem-%d", nonce)
+	prepareActiveUserBot(t, ctx, botID, botToken)
 
 	claims := newRedisClaimStore(ctx)
 	redisClient := claims.backend.(*redisClaimBackend).client
@@ -80,10 +74,6 @@ func TestBotMentionRedisRobotQueueIntegration(t *testing.T) {
 	queueKey := "robotEvent:" + botID
 	claimKey := mentionClaimKey(botID, request.IdempotencyKey)
 	t.Cleanup(func() { _ = redisClient.Del(queueKey, claimKey).Err() })
-
-	expectActiveUserBot(dbMock, botID)
-	expectNewRobotEventSequence(dbMock)
-	expectSystemSettingsLoadOnce.Do(func() { expectSystemSettingsLoad(dbMock) })
 
 	module := &BotMention{
 		robots:        robot.NewService(ctx),
@@ -127,7 +117,6 @@ func TestBotMentionRedisRobotQueueIntegration(t *testing.T) {
 		t.Fatalf("queue size after replay = %d, want 1", got)
 	}
 
-	expectBotTokenAuth(dbMock, botID, botToken)
 	pulled := doBotAPIRequest(t, router, http.MethodPost, "/v1/bot/events", botToken, []byte("{\"event_id\":0,\"limit\":10}"))
 	if pulled.Code != http.StatusOK {
 		t.Fatalf("pull status = %d, body=%s", pulled.Code, pulled.Body.String())
@@ -154,7 +143,6 @@ func TestBotMentionRedisRobotQueueIntegration(t *testing.T) {
 		t.Fatalf("pulled event data = %#v", event.EventData)
 	}
 
-	expectBotTokenAuth(dbMock, botID, botToken)
 	ackPath := fmt.Sprintf("/v1/bot/events/%d/ack", accepted.EventID)
 	acked := doBotAPIRequest(t, router, http.MethodPost, ackPath, botToken, nil)
 	if acked.Code != http.StatusOK {
@@ -176,40 +164,48 @@ func TestBotMentionRedisRobotQueueIntegration(t *testing.T) {
 	}
 
 	assertRealRedisClaimCAS(t, claims, redisClient)
-	if err := dbMock.ExpectationsWereMet(); err != nil {
-		t.Fatalf("database expectations: %v", err)
-	}
 }
 
-func newBotMentionRedisTestContext(t *testing.T, messageExpire time.Duration) (*config.Context, sqlmock.Sqlmock, *config.Config) {
+func newBotMentionIntegrationContext(t *testing.T, messageExpire time.Duration) (*config.Context, *config.Config) {
 	t.Helper()
 	cfg := config.New()
 	cfg.Test = true
 	cfg.Robot.MessageExpire = messageExpire
+	cfg.DB.MySQLAddr = "root:demo@tcp(127.0.0.1:3306)/test?charset=utf8mb4&parseTime=true"
+	if dsn := os.Getenv("OCTO_TEST_MYSQL_DSN"); dsn != "" {
+		cfg.DB.MySQLAddr = dsn
+	}
 	if addr := os.Getenv("OCTO_TEST_REDIS_ADDR"); addr != "" {
 		cfg.DB.RedisAddr = addr
 	}
 
 	ctx := config.NewContext(cfg)
-	rawDB, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherRegexp))
-	if err != nil {
-		t.Fatalf("sqlmock.New: %v", err)
+	var one int
+	if err := ctx.DB().SelectBySql("SELECT 1").LoadOne(&one); err != nil || one != 1 {
+		t.Fatalf("real MySQL is required for bot mention integration test: SELECT 1 = %d, %v", one, err)
 	}
-	mock.MatchExpectationsInOrder(false)
-	conn := &dbr.Connection{DB: rawDB, EventReceiver: &dbr.NullEventReceiver{}, Dialect: dialect.MySQL}
-	injectBotMentionMockDB(t, ctx, conn.NewSession(nil))
-	t.Cleanup(func() { _ = rawDB.Close() })
-	return ctx, mock, cfg
+	t.Cleanup(func() { _ = ctx.DB().Close() })
+	return ctx, cfg
 }
 
-func injectBotMentionMockDB(t *testing.T, ctx *config.Context, session *dbr.Session) {
+func prepareActiveUserBot(t *testing.T, ctx *config.Context, botID, botToken string) {
 	t.Helper()
-	ctxValue := reflect.ValueOf(ctx).Elem()
-	onceField := ctxValue.FieldByName("mysqlOnce")
-	once := (*sync.Once)(unsafe.Pointer(onceField.UnsafeAddr()))
-	once.Do(func() {})
-	sessionField := ctxValue.FieldByName("mySQLSession")
-	reflect.NewAt(sessionField.Type(), unsafe.Pointer(sessionField.UnsafeAddr())).Elem().Set(reflect.ValueOf(session))
+	if _, err := ctx.DB().InsertBySql(
+		"INSERT INTO robot (robot_id, status, creator_uid, bot_token) VALUES (?, 1, ?, ?)",
+		botID, "bot-mention-integration-owner", botToken,
+	).Exec(); err != nil {
+		t.Fatalf("insert integration User Bot: %v", err)
+	}
+
+	seqKey := "seq:" + common.RobotEventSeqKey + botID
+	t.Cleanup(func() {
+		if _, err := ctx.DB().DeleteFrom("seq").Where("`key`=?", seqKey).Exec(); err != nil {
+			t.Errorf("cleanup integration sequence: %v", err)
+		}
+		if _, err := ctx.DB().DeleteFrom("robot").Where("robot_id=?", botID).Exec(); err != nil {
+			t.Errorf("cleanup integration User Bot: %v", err)
+		}
+	})
 }
 
 func closeBotMentionClaimClient(t *testing.T, store botMentionClaimStore) {
@@ -222,30 +218,6 @@ func closeBotMentionClaimClient(t *testing.T, store botMentionClaimStore) {
 	if ok {
 		t.Cleanup(func() { _ = backend.client.Close() })
 	}
-}
-
-func expectActiveUserBot(mock sqlmock.Sqlmock, botID string) {
-	mock.ExpectQuery("(?i)SELECT count\\(\\*\\) FROM robot WHERE .*" +
-		regexp.QuoteMeta("robot_id='"+botID+"'") + ".*status=1").
-		WillReturnRows(sqlmock.NewRows([]string{"count(*)"}).AddRow(1))
-}
-
-func expectNewRobotEventSequence(mock sqlmock.Sqlmock) {
-	mock.ExpectQuery("(?i)SELECT \\* FROM seq WHERE").
-		WillReturnRows(sqlmock.NewRows([]string{"key", "min_seq", "step"}))
-	mock.ExpectExec("(?i)insert into `seq`").
-		WillReturnResult(sqlmock.NewResult(1, 1))
-}
-
-func expectBotTokenAuth(mock sqlmock.Sqlmock, botID, token string) {
-	mock.ExpectQuery("(?i)SELECT \\* FROM robot WHERE .*" +
-		regexp.QuoteMeta("bot_token='"+token+"'") + ".*status=1").
-		WillReturnRows(sqlmock.NewRows([]string{"robot_id", "status", "bot_token"}).AddRow(botID, 1, token))
-}
-
-func expectSystemSettingsLoad(mock sqlmock.Sqlmock) {
-	mock.ExpectQuery("(?i)SELECT \\* FROM system_setting").
-		WillReturnRows(sqlmock.NewRows([]string{"category", "key_name", "value", "value_type", "description"}))
 }
 
 func doBotAPIRequest(t *testing.T, router *wkhttp.WKHttp, method, path, token string, body []byte) *httptest.ResponseRecorder {

--- a/modules/robot/api.go
+++ b/modules/robot/api.go
@@ -48,6 +48,16 @@ import (
 	"go.uber.org/zap"
 )
 
+// PreparedBotTypedEvent is a typed bot event with its sequence and wire payload
+// allocated, but not yet visible in the Redis queue. Callers that need to
+// combine the queue write with another Redis state transition can commit these
+// fields atomically; ordinary callers should keep using EnqueueBotTypedEvent.
+type PreparedBotTypedEvent struct {
+	EventID  int64
+	QueueKey string
+	Member   string
+}
+
 // IService 为其他模块提供的窄接口，避免持有完整 *Robot 以及由此产生的循环依赖。
 // YUJ-60: 允许 bot 创建者撤回自己 bot 发的消息时，由 message 模块注入并调用。
 //
@@ -95,6 +105,10 @@ type IService interface {
 	// bots key at-least-once idempotency on it per D8). Error only on
 	// GenSeq / ZADD failure.
 	EnqueueBotTypedEvent(robotID, eventType string, eventData map[string]interface{}) (int64, error)
+	// PrepareBotTypedEvent allocates and serializes the same queue record as
+	// EnqueueBotTypedEvent without making it visible. The returned event is
+	// intended for an atomic fenced commit by another module.
+	PrepareBotTypedEvent(robotID, eventType string, eventData map[string]interface{}) (PreparedBotTypedEvent, error)
 }
 
 // Service robot 模块对外暴露的只读服务实现，供其它模块注入使用。
@@ -195,6 +209,16 @@ func (rb *Robot) EnqueueBotTypedEvent(robotID, eventType string, eventData map[s
 	return enqueueBotTypedEventGeneric(rb.ctx, robotID, eventType, eventData)
 }
 
+// PrepareBotTypedEvent — IService — Service variant.
+func (s *Service) PrepareBotTypedEvent(robotID, eventType string, eventData map[string]interface{}) (PreparedBotTypedEvent, error) {
+	return prepareBotTypedEvent(s.ctx, robotID, eventType, eventData)
+}
+
+// PrepareBotTypedEvent — IService — *Robot variant.
+func (rb *Robot) PrepareBotTypedEvent(robotID, eventType string, eventData map[string]interface{}) (PreparedBotTypedEvent, error) {
+	return prepareBotTypedEvent(rb.ctx, robotID, eventType, eventData)
+}
+
 // enqueueBotEventGeneric is the shared write-to-bot-event-queue helper
 // used by saveRobotMessage (listener path) and EnqueueBotEvent (cross-
 // module synthetic path). Centralizing the GenSeq / ZAdd / Expire shape
@@ -245,18 +269,34 @@ func enqueueBotEventGeneric(ctx *config.Context, robotID string, message *config
 // GenSeq / ZAdd / Expire chokepoint，只是承载 EventType/EventData 而非 Message，
 // 并把分配到的 event_id（= seq）返回给调用方（D4 用作 confirm 值 / D8 bot 幂等键）。
 func enqueueBotTypedEventGeneric(ctx *config.Context, robotID, eventType string, eventData map[string]interface{}) (int64, error) {
+	prepared, err := prepareBotTypedEvent(ctx, robotID, eventType, eventData)
+	if err != nil {
+		return 0, err
+	}
+	if err := ctx.GetRedisConn().ZAdd(prepared.QueueKey, float64(prepared.EventID), prepared.Member); err != nil {
+		return 0, err
+	}
+	if err := ctx.GetRedisConn().Expire(prepared.QueueKey, ctx.GetConfig().Robot.MessageExpire); err != nil {
+		// Best-effort TTL refresh — 与 enqueueBotEventGeneric 一致，不因 TTL
+		// 刷新失败而回滚已成功的 ZAdd（event 已入队，event_id 有效）。
+		return prepared.EventID, nil
+	}
+	return prepared.EventID, nil
+}
+
+func prepareBotTypedEvent(ctx *config.Context, robotID, eventType string, eventData map[string]interface{}) (PreparedBotTypedEvent, error) {
 	if ctx == nil {
-		return 0, errors.New("robot: nil ctx, cannot enqueue typed bot event")
+		return PreparedBotTypedEvent{}, errors.New("robot: nil ctx, cannot prepare typed bot event")
 	}
 	if strings.TrimSpace(robotID) == "" {
-		return 0, errors.New("robot: empty robotID, cannot enqueue typed bot event")
+		return PreparedBotTypedEvent{}, errors.New("robot: empty robotID, cannot prepare typed bot event")
 	}
 	if strings.TrimSpace(eventType) == "" {
-		return 0, errors.New("robot: empty eventType, cannot enqueue typed bot event")
+		return PreparedBotTypedEvent{}, errors.New("robot: empty eventType, cannot prepare typed bot event")
 	}
 	seq, err := ctx.GenSeq(fmt.Sprintf("%s%s", common.RobotEventSeqKey, robotID))
 	if err != nil {
-		return 0, err
+		return PreparedBotTypedEvent{}, err
 	}
 	messageUpdateJson := util.ToJson(&robotEvent{
 		EventID:   seq,
@@ -264,16 +304,11 @@ func enqueueBotTypedEventGeneric(ctx *config.Context, robotID, eventType string,
 		EventData: eventData,
 		Expire:    time.Now().Add(ctx.GetConfig().Robot.MessageExpire).Unix(),
 	})
-	key := fmt.Sprintf("robotEvent:%s", robotID)
-	if err := ctx.GetRedisConn().ZAdd(key, float64(seq), messageUpdateJson); err != nil {
-		return 0, err
-	}
-	if err := ctx.GetRedisConn().Expire(key, ctx.GetConfig().Robot.MessageExpire); err != nil {
-		// Best-effort TTL refresh — 与 enqueueBotEventGeneric 一致，不因 TTL
-		// 刷新失败而回滚已成功的 ZAdd（event 已入队，event_id 有效）。
-		return seq, nil
-	}
-	return seq, nil
+	return PreparedBotTypedEvent{
+		EventID:  seq,
+		QueueKey: fmt.Sprintf("robotEvent:%s", robotID),
+		Member:   messageUpdateJson,
+	}, nil
 }
 
 type Robot struct {

--- a/pkg/errcode/bot_mention.go
+++ b/pkg/errcode/bot_mention.go
@@ -1,0 +1,26 @@
+package errcode
+
+import (
+	"net/http"
+
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n/codes"
+)
+
+var (
+	ErrBotMentionInProgress = register(codes.Code{
+		ID:             "err.server.bot_mention.in_progress",
+		HTTPStatus:     http.StatusConflict,
+		DefaultMessage: "A request with this idempotency key is still in progress.",
+	})
+	ErrBotMentionIdempotencyConflict = register(codes.Code{
+		ID:             "err.server.bot_mention.idempotency_conflict",
+		HTTPStatus:     http.StatusConflict,
+		DefaultMessage: "This idempotency key was already used with a different request.",
+	})
+	ErrBotMentionStoreFailed = register(codes.Code{
+		ID:             "err.server.bot_mention.store_failed",
+		HTTPStatus:     http.StatusInternalServerError,
+		DefaultMessage: "Failed to process the bot mention event.",
+		Internal:       true,
+	})
+)

--- a/pkg/httperr/respond.go
+++ b/pkg/httperr/respond.go
@@ -34,6 +34,9 @@ func ResponseErrorL(c *wkhttp.Context, code codes.Code, params i18n.Params, deta
 //   - the Octo-link Bot bind/unbind endpoints (modules/botfather/api_user.go,
 //     POST/DELETE /v1/user/bots/:bot_id/bind) — new endpoints that must return
 //     real REST status (404/409/…) so external Agents branch on the wire code.
+//   - the document-comment Bot mention ingress (modules/bot_mention/api.go,
+//     POST /v1/internal/bot-mentions) — a new service-to-service endpoint whose
+//     docs-backend caller branches on 401/404/409/500 retry semantics.
 //
 // The body envelope is byte-for-byte identical to ResponseErrorL; only the
 // transport status differs — here it equals the code's canonical HTTPStatus, so

--- a/pkg/i18n/locales/active.zh-CN.toml
+++ b/pkg/i18n/locales/active.zh-CN.toml
@@ -1315,3 +1315,12 @@ other = "卡片模板状态已变化，请刷新后重试。"
 
 ["err.server.card_template_catalog.blocked"]
 other = "该卡片模板版本已被阻断。"
+
+["err.server.bot_mention.in_progress"]
+other = "相同幂等键的请求仍在处理中，请稍后重试。"
+
+["err.server.bot_mention.idempotency_conflict"]
+other = "该幂等键已用于不同的请求。"
+
+["err.server.bot_mention.store_failed"]
+other = "文档评论机器人事件处理失败。"

--- a/tools/i18nmarkers/server/active.en-US.toml
+++ b/tools/i18nmarkers/server/active.en-US.toml
@@ -180,6 +180,15 @@ other = "The upstream service is unavailable."
 ["err.server.bot_api.user_not_found"]
 other = "User not found."
 
+["err.server.bot_mention.idempotency_conflict"]
+other = "This idempotency key was already used with a different request."
+
+["err.server.bot_mention.in_progress"]
+other = "A request with this idempotency key is still in progress."
+
+["err.server.bot_mention.store_failed"]
+other = "Failed to process the bot mention event."
+
 ["err.server.bot_provision.auth_failed"]
 other = "Authentication failed."
 


### PR DESCRIPTION
## Summary

Add the octo-server ingress that converts a document comment mention of an active User Bot into the existing typed bot event queue. The endpoint is disabled by default and is guarded by an independent internal token, rollout allowlists, active User Bot validation, and Redis-backed idempotency.

This PR implements the octo-server portion of the linked cross-service brief. Enabling the rollout still depends on a compatible OpenClaw plugin and docs-backend integration.

## Related Issue

N/A — spec-driven change; no matching GitHub issue was found.

## Linked Spec

`.octospec/tasks/doc-comment-bot-mention-mvp/brief.md`

## Changes

- Add `POST /v1/internal/bot-mentions` with localized real HTTP status responses, a 32 KiB body limit, request normalization, and the `doc_comment_mention` event contract.
- Require `OCTO_DOCS_BOT_MENTION_TOKEN`, reject token reuse with either notify capability, and keep the endpoint fail-closed when the token is absent or conflicting.
- Add startup-read rollout controls for the global switch and document/Space allowlists; empty allowlists remain fail-closed and `*` is explicit full rollout.
- Restrict targets to active User Bots through `robot.IService.ExistRobot`; App Bots, inactive bots, and unknown bots share the same opaque not-found response.
- Add Redis claim/begin/confirm/release idempotency with request fingerprints, bot-scoped keys, a 60-second pending TTL, and `Robot.MessageExpire` for confirmed claims.
- Reuse `robot.IService.EnqueueBotTypedEvent`, preserving the existing bot queue wire format and `/v1/bot/events` consumption path.
- Add low-cardinality ingress/enqueue metrics, registered error codes, zh-CN translations, and a direct-error-response source guard.
- Add unit tests plus a real MySQL + Redis integration test covering enqueue, replay, bot event polling, ACK deletion, Lua CAS, and queue/claim expiry.

## Testing

- [x] `go test -race ./modules/bot_mention -count=1`
- [x] `go test ./modules/bot_mention -coverprofile=.context/bot_mention.cover.out -count=1` — 92.8% statement coverage
- [x] `go test ./modules/bot_mention -run '^TestBotMentionMySQLRedisRobotQueueIntegration$' -count=3`
- [x] `make i18n-extract-check`
- [x] `make i18n-lint`
- [x] `go vet ./modules/bot_mention`
- [x] `golangci-lint run ./modules/bot_mention/...` — 0 issues
- [ ] `go test ./...` — attempted, but unrelated existing test-database migration state fails in packages such as `app_bot`, `sticker`, `thread`, and `user` (`welcome_msg` duplicate column and unknown legacy migration errors). The target package passes again after the full-suite attempt.

## Rollout dependencies

- Keep `OCTO_DOCS_BOT_MENTION_ENABLED=false` until the OpenClaw plugin version that persistently claims and dispatches `doc_comment_mention` is deployed to target User Bots.
- docs-backend must provide a stable idempotency key per `(comment mention, bot_uid)` and enforce document/comment permissions on both the original comment and the Bot's edit/reply operations.
- The real-status error envelope on this new endpoint requires maintainer confirmation as documented in the linked spec.

## COMPREHENSION

1. **What does this change actually do to the load-bearing path?**

   It adds a service-to-service ingress before the existing Bot event queue. A request is authenticated, normalized, checked against rollout policy, resolved to an active User Bot, claimed in Redis, and appended as a typed event. Confirmed replays return the original `event_id`; conflicting or pending claims do not enqueue again.

2. **What could break because of it (dependents + failure mode)?**

   docs-backend depends on the request/response and retry contract, while OpenClaw depends on the typed event payload and ACK discipline. Redis or MySQL failures intentionally fail closed. An old plugin may not process the new event, so rollout must remain disabled until plugin compatibility is confirmed. A reused internal token would widen capability access, so token collisions disable this endpoint at startup.

3. **How do you know it works (specific test/repro/trace)?**

   Unit tests cover validation, rollout gates, authentication, sequential/concurrent replay, conflicts, dependency failures, claim release/confirm behavior, metrics, and localized errors. The integration test uses the real local MySQL and Redis services with the real robot service and Bot API routes, then verifies one queue entry, replay without duplication, `/v1/bot/events` delivery, ACK removal, Lua stale-lease protection, and both expiry sources.

## Checklist

- [x] I have read `CONTRIBUTING.md`
- [x] PR description is in English
- [x] Added tests for my changes
- [x] Updated documentation
- [x] Followed commit message conventions (Conventional Commits)
