### PR TITLE
fix(card): add render profile to new platform cards

### DIFF
--- a/.octospec/tasks/platform-card-render-profile-completion/brief.md
+++ b/.octospec/tasks/platform-card-render-profile-completion/brief.md
@@ -1,0 +1,180 @@
+---
+type: Task
+title: "Task: platform-card-render-profile-completion"
+description: Make every newly sent server-authored platform card explicitly carry render_profile octo-chat/v1, without rewriting or changing already-sent messages.
+tags: ["card", "wire-contract", "testing"]
+timestamp: 2026-08-03T00:00:00+08:00
+slug: platform-card-render-profile-completion
+upstream: self
+source: self
+---
+
+# Task: platform-card-render-profile-completion
+
+## Goal
+
+Every newly sent **platform-owned** type-17 card must carry these two
+independent top-level wire fields:
+
+```json
+{
+  "profile": "<existing octo/v1 or octo/v2>",
+  "render_profile": "octo-chat/v1"
+}
+```
+
+`profile` remains the card capability/interaction profile (`octo/v1` or
+`octo/v2`). `render_profile` remains the client visual-compatibility selector.
+The server owns `render_profile`; platform producers do not choose it.
+
+The client already treats a missing historical `render_profile` as
+`octo-chat/v1`. This task makes the same decision explicit for all new platform
+messages so their rendering contract does not depend on the historical fallback.
+
+## Current state
+
+Current `main` has two different outcomes:
+
+- Registry-backed new cards already propagate
+  `manifest.renderProfileCompatibility = "octo-chat/v1"` through render,
+  and internal dispatch. This includes
+  `summary.completed`, `summary.failed`, `docs.commented`, `docs.shared`,
+  `docs.access-request@0.3.0`, and `ai.reasoning-process`.
+- Several platform-owned legacy builders still pass an empty
+  `carddispatch.Card.RenderProfile`. Their newly sent payload therefore omits
+  the field even though the client currently infers the same visual profile.
+
+The observed production `summary.completed` payload without `render_profile`
+does not match the current source path. Implementation verification must pin
+the final transport payload and deployed server SHA; do not “fix” the summary
+template blindly when the current manifest and dispatch chain are already
+correct.
+
+## In scope
+
+### Platform new-send paths
+
+The following newly sent cards must explicitly emit
+`render_profile: "octo-chat/v1"`:
+
+1. Docs legacy notification branches in `deliverDocsCardNotification`:
+   - `access_requested` when the approval-card Registry gate is off;
+   - `access_granted`;
+   - `access_denied`.
+2. The applicant outcome card sent by `DocsActionFinalizer`, including the
+   user-facing “文档访问已获批准/拒绝” cards.
+3. Generic approval request cards sent by `deliverApprovalCardNotification`.
+4. Generic approval applicant outcome cards sent by
+   `StandardActionFinalizer`.
+
+## Proposed design
+
+### 1. Author the default at the internal dispatch boundary
+
+`internal/carddispatch.producerSender.Send` owns the final type-17 envelope for
+all platform card new-sends. Resolve the outgoing render profile as follows:
+
+1. non-empty `Card.RenderProfile` -> validate and preserve it;
+2. empty `Card.RenderProfile` -> author `cardmsg.RenderProfileOctoChatV1`;
+3. unsupported non-empty value -> fail closed as today.
+
+Always write the resolved non-empty value into the final payload before
+`cardmsg.Validate`, `Finalize`, the final payload-size check, and transport
+serialization.
+
+This is intentionally scoped to the internal platform dispatch boundary. It
+avoids duplicating the same default across every notify caller and makes future
+platform-card senders safe by construction. It does not change the meaning of
+missing fields when reading historical messages.
+
+### 2. Lock the contract with transport-level tests
+
+Tests must cover the final envelope, not only manifest metadata or the
+intermediate Adaptive Card document:
+
+- internal dispatch authors `octo-chat/v1` when `Card.RenderProfile` is empty;
+- explicit `octo-chat/v1` remains unchanged;
+- an unsupported explicit value is rejected before transport;
+- `summary.completed` and `summary.failed` Registry renders expose the field,
+  and their internal-dispatch transport payload retains it;
+- docs and generic approval tests assert newly sent request/outcome cards have
+  the field;
+- non-card payload behavior is unchanged.
+
+## Load-bearing behavior
+
+- **Wire contract:** `render_profile` is a top-level sibling of `profile`, not
+  part of the Adaptive Card document or `metadata.octo`.
+- **Profile separation:** this task must not rename `profile`, introduce a
+  `card_profile` wire field, or change any `octo/v1`/`octo/v2` capability.
+- **Server authority:** callers cannot select arbitrary render profiles.
+  Unknown explicit values remain fail-closed through the accepted-profile
+  allowlist.
+- **Historical compatibility:** stored historical messages and their existing
+  `content_edit` frames are not rewritten or changed for this task. Missing
+  historical fields continue to use the client's existing `octo-chat/v1`
+  fallback.
+- **Frozen L1 contract:** do not modify
+  `docs.access-request@0.2.0`. Its field-less historical artifact remains
+  frozen; a later authoritative update may replace it with the existing
+  `0.3.0/result` frame.
+- **Mutation behavior:** existing-card updates, sender ownership,
+  message/channel/Space binding, lifecycle checks, `card_seq` CAS, revision
+  append, and CMD semantics are unchanged.
+- **Validation and size:** the final enriched payload still runs
+  `cardmsg.Validate`, `Finalize`, and the existing post-enrichment size check.
+- **Failure behavior:** adding the field must not turn a render or dispatch
+  error into a fabricated success or change text/card message types.
+
+## Out of scope
+
+- No historical message, `message_extra`, or revision backfill.
+- No change to `content_edit` or any already-sent card update path.
+- No database migration.
+- No client changes; the client fallback is already implemented.
+- No changes to card layout, copy, actions, inputs, template data schemas, or
+  template versions.
+- No change to the frozen `docs.access-request@0.2.0` assets.
+- No new render profile generation such as `octo-chat/v2`.
+- No runtime-catalog activation, producer-grant, or owner-policy change.
+- No Incoming Webhook or legacy Robot API change in this task. Those are raw
+  external ingress surfaces, not the platform-owned card paths requested here,
+  and require their own compatibility/trust-boundary review.
+- No change to the user message API, which continues to reject type-17 sends
+  and edits.
+
+## Acceptance
+
+- Every platform new-send listed in **In scope** reaches transport with an
+  explicit top-level `render_profile: "octo-chat/v1"`.
+- The applicant-facing “文档访问已获批准/拒绝” cards contain the field.
+- Current Registry-backed defaults continue to contain the field, including
+  `summary.completed` and `summary.failed`.
+- The canonical capability field remains `profile`; no `card_profile` field is
+  introduced.
+- Unsupported explicit render profiles remain rejected and never reach
+  transport.
+- Historical payload bytes and the frozen `docs.access-request@0.2.0` tree have
+  no diff.
+- Existing card authorization, action dispatch, mutation CAS, revision, CMD,
+  localization, and text-fallback tests remain green and unchanged.
+- Focused tests pass:
+
+  ```bash
+  go test ./internal/carddispatch/...
+  go test ./pkg/cardtmpl/summary_completed/... ./pkg/cardtmpl/summary_failed/...
+  go test ./modules/notify/... -run 'RenderProfile|Summary|DocsActionFinalizer|StandardActionFinalizer|Approval'
+  ```
+
+## Rollout and rollback
+
+- No new rollout flag is required: clients already resolve missing historical
+  fields to the same `octo-chat/v1` value, so this change makes an existing
+  rendering decision explicit rather than selecting a new renderer.
+- Before production rollout, capture at least one raw WuKongIM payload for
+  `summary.completed`, docs granted/denied outcome, and generic approval result;
+  record the deployed octo-server SHA with the evidence.
+- Monitor existing card dispatch failure metrics and client rendering errors.
+  The added bounded string must not create a new high-cardinality label.
+- Rollback is an image rollback. No data rollback is required: clients already
+  accept both explicit `octo-chat/v1` and missing historical fields.

--- a/docs/platform-card-base.md
+++ b/docs/platform-card-base.md
@@ -165,11 +165,12 @@
 - manifest 的 `renderProfile` 固定 Forge 验证制品的精确不可变版本，例如 `octo-chat@1.2.0-rc.1`；
 - manifest 的 `renderProfileCompatibility` 是客户端稳定兼容键，例如 `octo-chat/v1`；
 - type-17 信封只发送稳定键：`"render_profile": "octo-chat/v1"`，Web 不需要保存每个 Forge 历史包；
-- Registry 历史模板未声明 `renderProfileCompatibility` 时不写 `render_profile`，永久走 Legacy 渲染；
+- 已发送的历史卡片不回填；客户端遇到缺失的 `render_profile` 时按 `octo-chat/v1` fallback；
+- 新发内部平台卡由 `internal/carddispatch` 统一写入 `octo-chat/v1`；Registry 声明的合法兼容键原样透传，未声明时由发送边界补默认值；
 - raw Bot send/edit 的调用方不选择该字段，Bot API 在有效帧统一写入 `octo-chat/v1`；
 - 服务端只接受已注册的稳定键，未知值在发送/写入边界 fail-close。
 
-当前 `docs.access-request@0.3.0` 固定 `octo-chat@1.2.0-rc.1` 并发送 `octo-chat/v1`；冻结的 `0.2.0` 不发送视觉兼容键。
+当前 `docs.access-request@0.3.0` 固定 `octo-chat@1.2.0-rc.1` 并发送 `octo-chat/v1`。冻结的 `0.2.0` 制品仍不声明视觉兼容键且不修改；其历史消息继续由客户端 fallback，新发内部平台卡仍由 `carddispatch` 补齐稳定键。
 
 ---
 

--- a/internal/carddispatch/dispatch.go
+++ b/internal/carddispatch/dispatch.go
@@ -100,14 +100,16 @@ func (s *producerSender) Send(ctx context.Context, target Target, card Card) (re
 		}
 		return nil, categorized(terminal, decodeErr)
 	}
-	payload := map[string]interface{}{
-		"type":         cardmsg.InteractiveCard.Int(),
-		"card_version": cardmsg.CardVersion,
-		"profile":      card.Profile,
-		"card":         cardDocument,
+	renderProfile := card.RenderProfile
+	if renderProfile == "" {
+		renderProfile = cardmsg.RenderProfileOctoChatV1
 	}
-	if card.RenderProfile != "" {
-		payload["render_profile"] = card.RenderProfile
+	payload := map[string]interface{}{
+		"type":           cardmsg.InteractiveCard.Int(),
+		"card_version":   cardmsg.CardVersion,
+		"profile":        card.Profile,
+		"render_profile": renderProfile,
+		"card":           cardDocument,
 	}
 	if validateErr := cardmsg.Validate(payload); validateErr != nil {
 		terminal = cardErrorCategory(validateErr)

--- a/internal/carddispatch/dispatch_test.go
+++ b/internal/carddispatch/dispatch_test.go
@@ -325,6 +325,26 @@ func TestSendBuildsAuthoritativeEnvelopeAndReturnsTransportResult(t *testing.T) 
 	assert.LessOrEqual(t, len(req.Payload), cardmsg.MaxPayloadBytes)
 }
 
+func TestSendAuthorsDefaultRenderProfile(t *testing.T) {
+	reg, _, _, transport, _ := newHarness(t, validSpec())
+	sender, err := reg.Sender("summary-notify")
+	require.NoError(t, err)
+
+	_, err = sender.Send(context.Background(), validTarget(), Card{
+		Profile:  cardmsg.ProfileV1,
+		Document: validCardDocument(),
+	})
+	require.NoError(t, err)
+
+	calls, req := transport.snapshot()
+	require.Equal(t, 1, calls)
+	require.NotNil(t, req)
+
+	var payload map[string]interface{}
+	require.NoError(t, json.Unmarshal(req.Payload, &payload))
+	assert.Equal(t, cardmsg.RenderProfileOctoChatV1, payload["render_profile"])
+}
+
 func TestSendFailClosedStagesNeverReachTransport(t *testing.T) {
 	tests := []struct {
 		name          string

--- a/internal/carddispatch/types.go
+++ b/internal/carddispatch/types.go
@@ -35,7 +35,10 @@ type Target struct {
 }
 
 type Card struct {
-	Profile       string
+	Profile string
+	// RenderProfile selects the client visual compatibility profile. An empty
+	// value asks the trusted platform dispatch boundary to author its stable
+	// default; callers may only provide an explicitly accepted value.
 	RenderProfile string
 	Document      json.RawMessage
 }

--- a/modules/notify/platform_card_dispatch_test.go
+++ b/modules/notify/platform_card_dispatch_test.go
@@ -1,0 +1,211 @@
+package notify
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-server/internal/cardactiondispatch"
+	"github.com/Mininglamp-OSS/octo-server/internal/carddispatch"
+	"github.com/Mininglamp-OSS/octo-server/modules/botidentity"
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardmsg"
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl"
+	summarycompleted "github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl/summary_completed"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type platformDispatchIdentityResolver struct{}
+
+func (platformDispatchIdentityResolver) Resolve(uid string) (*botidentity.Identity, error) {
+	return &botidentity.Identity{UID: uid, Kind: botidentity.KindUserBot, CreatorUID: "owner-1"}, nil
+}
+
+type platformDispatchAuthorizer struct{}
+
+func (platformDispatchAuthorizer) Authorize(
+	context.Context, *botidentity.Identity, carddispatch.Target, carddispatch.AuthorizationPolicy,
+) error {
+	return nil
+}
+
+type platformDispatchTransport struct {
+	calls int
+	req   *config.MsgSendReq
+}
+
+func (t *platformDispatchTransport) SendMessageWithResult(req *config.MsgSendReq) (*config.MsgSendResp, error) {
+	t.calls++
+	copyReq := *req
+	copyReq.Payload = append([]byte(nil), req.Payload...)
+	t.req = &copyReq
+	return &config.MsgSendResp{MessageID: 101, MessageSeq: 7, ClientMsgNo: "platform-card-101"}, nil
+}
+
+func newPlatformDispatchSender(
+	t *testing.T, profile, actionOwner string,
+) (carddispatch.Sender, *platformDispatchTransport) {
+	t.Helper()
+	transport := &platformDispatchTransport{}
+	const producerID = carddispatch.ProducerID("platform-wire-test")
+	registry := carddispatch.NewRegistry(carddispatch.Dependencies{
+		IdentityResolver: platformDispatchIdentityResolver{},
+		Authorizer:       platformDispatchAuthorizer{},
+		Transport:        transport,
+		FeatureEnabled:   func() bool { return true },
+	}, []carddispatch.ProducerSpec{{
+		ID:                  producerID,
+		Enabled:             true,
+		SenderUID:           NotifyBotUIDValue,
+		AllowedChannelTypes: []uint8{common.ChannelTypePerson.Uint8()},
+		AllowedProfiles:     []string{profile},
+		SpacePolicy:         carddispatch.SpacePolicySystemNotification,
+		GroupPolicy:         carddispatch.GroupPolicyMemberRequired,
+		ActionEventOwner:    actionOwner,
+		MaxInFlight:         1,
+	}})
+	sender, err := registry.Sender(producerID)
+	require.NoError(t, err)
+	return sender, transport
+}
+
+func requirePlatformTransportPayload(
+	t *testing.T, transport *platformDispatchTransport, wantProfile string,
+) map[string]interface{} {
+	t.Helper()
+	require.Equal(t, 1, transport.calls)
+	require.NotNil(t, transport.req)
+	assert.Equal(t, NotifyBotUIDValue, transport.req.FromUID)
+	assert.Equal(t, "user-1", transport.req.ChannelID)
+	assert.Equal(t, common.ChannelTypePerson.Uint8(), transport.req.ChannelType)
+
+	var payload map[string]interface{}
+	require.NoError(t, json.Unmarshal(transport.req.Payload, &payload))
+	assert.Equal(t, float64(cardmsg.InteractiveCard.Int()), payload["type"])
+	assert.Equal(t, wantProfile, payload["profile"])
+	assert.Equal(t, cardmsg.RenderProfileOctoChatV1, payload["render_profile"])
+	assert.NotContains(t, payload, "card_profile")
+	require.NotNil(t, payload["card"])
+	return payload
+}
+
+func platformDispatchTarget() carddispatch.Target {
+	return carddispatch.Target{
+		SpaceID: "space-1", ChannelID: "user-1", ChannelType: common.ChannelTypePerson.Uint8(),
+	}
+}
+
+func TestSummaryCompletedRegistryCardReachesTransportWithRenderProfile(t *testing.T) {
+	wk := newWuKongServer()
+	defer wk.close()
+	ctx := newTestContext(t, wk)
+	ctx.GetConfig().External.WebLoginURL = "https://im.example.com/login"
+	n := newTestNotify(ctx, nil, nil, nil, "token")
+
+	document, renderProfile, err := n.buildSummaryCardViaRegistry(
+		context.Background(), "space-1", validCard(), "zh-CN",
+		summarycompleted.TemplateID, summarycompleted.StateShown,
+	)
+	require.NoError(t, err)
+	require.Equal(t, cardmsg.RenderProfileOctoChatV1, renderProfile)
+
+	sender, transport := newPlatformDispatchSender(t, cardmsg.ProfileV1, "")
+	_, err = sender.Send(context.Background(), platformDispatchTarget(), carddispatch.Card{
+		Profile: cardmsg.ProfileV1, RenderProfile: renderProfile, Document: document,
+	})
+	require.NoError(t, err)
+	payload := requirePlatformTransportPayload(t, transport, cardmsg.ProfileV1)
+	card := payload["card"].(map[string]interface{})
+	metadata := card["metadata"].(map[string]interface{})
+	octo := metadata["octo"].(map[string]interface{})
+	assert.Equal(t, "summary.completed", octo["variant"])
+}
+
+func TestDocsApplicantOutcomesReachTransportWithRenderProfile(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		state       cardactiondispatch.State
+		inputs      map[string]interface{}
+		wantVariant string
+	}{
+		{name: "approved", state: cardactiondispatch.StateApproved, wantVariant: "docs.access_granted"},
+		{
+			name: "denied", state: cardactiondispatch.StateDenied,
+			inputs:      map[string]interface{}{cardtmpl.DocsDenyReasonInputID: "scope mismatch"},
+			wantVariant: "docs.access_denied",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			wk := newWuKongServer()
+			defer wk.close()
+			ctx := newTestContext(t, wk)
+			ctx.GetConfig().External.WebLoginURL = "https://im.example.com/login"
+			sender, transport := newPlatformDispatchSender(t, cardmsg.ProfileV1, "")
+			finalizer, err := NewDocsActionFinalizer(ctx, &captureCardMutator{}, sender)
+			require.NoError(t, err)
+
+			err = finalizer.Finalize(context.Background(), cardactiondispatch.Event{
+				EventID: 42, SenderUID: NotifyBotUIDValue, Owner: "docs",
+				ActionType: "access_request.decision", MessageID: "message-1",
+				ChannelID: "reviewer-1", ChannelType: common.ChannelTypePerson.Uint8(),
+				SpaceID: "space-1", OperatorUID: "reviewer-1", Inputs: tc.inputs,
+				Data: map[string]interface{}{
+					"doc_id": "doc-1", "request_id": "request-1", "doc_title": "Roadmap",
+				},
+			}, cardactiondispatch.DecisionResult{
+				Disposition: cardactiondispatch.DispositionApplied, State: tc.state,
+				RequesterUID: "user-1", Display: map[string]string{"title": "Roadmap"},
+			})
+			require.NoError(t, err)
+
+			payload := requirePlatformTransportPayload(t, transport, cardmsg.ProfileV1)
+			card := payload["card"].(map[string]interface{})
+			metadata := card["metadata"].(map[string]interface{})
+			octo := metadata["octo"].(map[string]interface{})
+			assert.Equal(t, tc.wantVariant, octo["variant"])
+		})
+	}
+}
+
+func TestGenericApprovalCardsReachTransportWithRenderProfile(t *testing.T) {
+	t.Run("request", func(t *testing.T) {
+		capability := cardactiondispatch.NotifyCapability{SenderUID: NotifyBotUIDValue, Owner: "smart-summary"}
+		document, err := (&Notify{}).buildApprovalRequestCard(&ApprovalCardFields{
+			ActionType: "summary.publish.decision", Title: "Publish summary",
+			Description: "Review it first", Data: map[string]string{"task_no": "task-1"},
+		}, capability, "zh-CN")
+		require.NoError(t, err)
+
+		sender, transport := newPlatformDispatchSender(t, cardmsg.ProfileV2, capability.Owner)
+		_, err = sender.Send(context.Background(), platformDispatchTarget(), carddispatch.Card{
+			Profile: cardmsg.ProfileV2, Document: document,
+		})
+		require.NoError(t, err)
+		requirePlatformTransportPayload(t, transport, cardmsg.ProfileV2)
+	})
+
+	t.Run("applicant outcome", func(t *testing.T) {
+		sender, transport := newPlatformDispatchSender(t, cardmsg.ProfileV1, "")
+		finalizer, err := NewStandardActionFinalizer(&captureCardMutator{}, sender)
+		require.NoError(t, err)
+		err = finalizer.Finalize(context.Background(), cardactiondispatch.Event{
+			EventID: 84, SenderUID: NotifyBotUIDValue, Owner: "smart-summary",
+			ActionType: "summary.publish.decision", MessageID: "message-2",
+			ChannelID: "reviewer-1", ChannelType: common.ChannelTypePerson.Uint8(),
+			SpaceID: "space-1", OperatorUID: "reviewer-1",
+		}, cardactiondispatch.DecisionResult{
+			Disposition: cardactiondispatch.DispositionApplied,
+			State:       cardactiondispatch.StateApproved, RequesterUID: "user-1",
+			Display: map[string]string{"title": "Publish summary"},
+		})
+		require.NoError(t, err)
+
+		payload := requirePlatformTransportPayload(t, transport, cardmsg.ProfileV1)
+		card := payload["card"].(map[string]interface{})
+		metadata := card["metadata"].(map[string]interface{})
+		octo := metadata["octo"].(map[string]interface{})
+		assert.Equal(t, "approval.approved", octo["variant"])
+	})
+}

--- a/modules/notify/platform_card_dispatch_test.go
+++ b/modules/notify/platform_card_dispatch_test.go
@@ -3,6 +3,7 @@ package notify
 import (
 	"context"
 	"encoding/json"
+	"sync"
 	"testing"
 
 	"github.com/Mininglamp-OSS/octo-lib/common"
@@ -33,16 +34,29 @@ func (platformDispatchAuthorizer) Authorize(
 }
 
 type platformDispatchTransport struct {
-	calls int
-	req   *config.MsgSendReq
+	mu   sync.Mutex
+	reqs []*config.MsgSendReq
 }
 
 func (t *platformDispatchTransport) SendMessageWithResult(req *config.MsgSendReq) (*config.MsgSendResp, error) {
-	t.calls++
 	copyReq := *req
 	copyReq.Payload = append([]byte(nil), req.Payload...)
-	t.req = &copyReq
+	t.mu.Lock()
+	t.reqs = append(t.reqs, &copyReq)
+	t.mu.Unlock()
 	return &config.MsgSendResp{MessageID: 101, MessageSeq: 7, ClientMsgNo: "platform-card-101"}, nil
+}
+
+func (t *platformDispatchTransport) snapshot() []*config.MsgSendReq {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	requests := make([]*config.MsgSendReq, 0, len(t.reqs))
+	for _, req := range t.reqs {
+		copyReq := *req
+		copyReq.Payload = append([]byte(nil), req.Payload...)
+		requests = append(requests, &copyReq)
+	}
+	return requests
 }
 
 func newPlatformDispatchSender(
@@ -76,14 +90,21 @@ func requirePlatformTransportPayload(
 	t *testing.T, transport *platformDispatchTransport, wantProfile string,
 ) map[string]interface{} {
 	t.Helper()
-	require.Equal(t, 1, transport.calls)
-	require.NotNil(t, transport.req)
-	assert.Equal(t, NotifyBotUIDValue, transport.req.FromUID)
-	assert.Equal(t, "user-1", transport.req.ChannelID)
-	assert.Equal(t, common.ChannelTypePerson.Uint8(), transport.req.ChannelType)
+	requests := transport.snapshot()
+	require.Len(t, requests, 1)
+	assert.Equal(t, "user-1", requests[0].ChannelID)
+	return requirePlatformRequestPayload(t, requests[0], wantProfile)
+}
 
+func requirePlatformRequestPayload(
+	t *testing.T, req *config.MsgSendReq, wantProfile string,
+) map[string]interface{} {
+	t.Helper()
+	require.NotNil(t, req)
+	assert.Equal(t, NotifyBotUIDValue, req.FromUID)
+	assert.Equal(t, common.ChannelTypePerson.Uint8(), req.ChannelType)
 	var payload map[string]interface{}
-	require.NoError(t, json.Unmarshal(transport.req.Payload, &payload))
+	require.NoError(t, json.Unmarshal(req.Payload, &payload))
 	assert.Equal(t, float64(cardmsg.InteractiveCard.Int()), payload["type"])
 	assert.Equal(t, wantProfile, payload["profile"])
 	assert.Equal(t, cardmsg.RenderProfileOctoChatV1, payload["render_profile"])
@@ -180,14 +201,14 @@ func TestLegacyDocsNotificationsReachTransportWithRenderProfile(t *testing.T) {
 			})
 			require.NoError(t, err)
 			assert.ElementsMatch(t, []string{"user-1", "user-2"}, response.Delivered)
-			require.Equal(t, 2, transport.calls)
-			require.NotNil(t, transport.req)
-
-			var payload map[string]interface{}
-			require.NoError(t, json.Unmarshal(transport.req.Payload, &payload))
-			assert.Equal(t, cardmsg.ProfileV1, payload["profile"])
-			assert.Equal(t, cardmsg.RenderProfileOctoChatV1, payload["render_profile"])
-			assert.NotContains(t, payload, "card_profile")
+			requests := transport.snapshot()
+			require.Len(t, requests, 2)
+			channels := make([]string, 0, len(requests))
+			for _, req := range requests {
+				channels = append(channels, req.ChannelID)
+				requirePlatformRequestPayload(t, req, cardmsg.ProfileV1)
+			}
+			assert.ElementsMatch(t, []string{"user-1", "user-2"}, channels)
 		})
 	}
 }

--- a/modules/notify/platform_card_dispatch_test.go
+++ b/modules/notify/platform_card_dispatch_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-server/pkg/cardmsg"
 	"github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl"
 	summarycompleted "github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl/summary_completed"
+	summaryfailed "github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl/summary_failed"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -64,7 +65,7 @@ func newPlatformDispatchSender(
 		SpacePolicy:         carddispatch.SpacePolicySystemNotification,
 		GroupPolicy:         carddispatch.GroupPolicyMemberRequired,
 		ActionEventOwner:    actionOwner,
-		MaxInFlight:         1,
+		MaxInFlight:         20,
 	}})
 	sender, err := registry.Sender(producerID)
 	require.NoError(t, err)
@@ -97,30 +98,98 @@ func platformDispatchTarget() carddispatch.Target {
 	}
 }
 
-func TestSummaryCompletedRegistryCardReachesTransportWithRenderProfile(t *testing.T) {
+func TestSummaryRegistryCardsReachTransportWithRenderProfile(t *testing.T) {
 	wk := newWuKongServer()
 	defer wk.close()
 	ctx := newTestContext(t, wk)
 	ctx.GetConfig().External.WebLoginURL = "https://im.example.com/login"
 	n := newTestNotify(ctx, nil, nil, nil, "token")
 
-	document, renderProfile, err := n.buildSummaryCardViaRegistry(
-		context.Background(), "space-1", validCard(), "zh-CN",
-		summarycompleted.TemplateID, summarycompleted.StateShown,
-	)
-	require.NoError(t, err)
-	require.Equal(t, cardmsg.RenderProfileOctoChatV1, renderProfile)
+	for _, tc := range []struct {
+		name        string
+		card        *SummaryCardFields
+		templateID  cardtmpl.ID
+		state       cardtmpl.State
+		wantVariant string
+	}{
+		{
+			name: "completed", card: validCard(), templateID: summarycompleted.TemplateID,
+			state: summarycompleted.StateShown, wantVariant: summarycompleted.Variant,
+		},
+		{
+			name: "failed",
+			card: &SummaryCardFields{
+				TaskNo: "TN_abcd", Kind: SummaryCardKindFailed, Title: "产品周会纪要",
+				Reason: "upstream timeout", GeneratedAt: "2026-07-13 15:04",
+			},
+			templateID: summaryfailed.TemplateID, state: summaryfailed.StateShown,
+			wantVariant: summaryfailed.Variant,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			document, renderProfile, err := n.buildSummaryCardViaRegistry(
+				context.Background(), "space-1", tc.card, "zh-CN", tc.templateID, tc.state,
+			)
+			require.NoError(t, err)
+			require.Equal(t, cardmsg.RenderProfileOctoChatV1, renderProfile)
 
-	sender, transport := newPlatformDispatchSender(t, cardmsg.ProfileV1, "")
-	_, err = sender.Send(context.Background(), platformDispatchTarget(), carddispatch.Card{
-		Profile: cardmsg.ProfileV1, RenderProfile: renderProfile, Document: document,
-	})
-	require.NoError(t, err)
-	payload := requirePlatformTransportPayload(t, transport, cardmsg.ProfileV1)
-	card := payload["card"].(map[string]interface{})
-	metadata := card["metadata"].(map[string]interface{})
-	octo := metadata["octo"].(map[string]interface{})
-	assert.Equal(t, "summary.completed", octo["variant"])
+			sender, transport := newPlatformDispatchSender(t, cardmsg.ProfileV1, "")
+			_, err = sender.Send(context.Background(), platformDispatchTarget(), carddispatch.Card{
+				Profile: cardmsg.ProfileV1, RenderProfile: renderProfile, Document: document,
+			})
+			require.NoError(t, err)
+			payload := requirePlatformTransportPayload(t, transport, cardmsg.ProfileV1)
+			card := payload["card"].(map[string]interface{})
+			metadata := card["metadata"].(map[string]interface{})
+			octo := metadata["octo"].(map[string]interface{})
+			assert.Equal(t, tc.wantVariant, octo["variant"])
+		})
+	}
+}
+
+func TestLegacyDocsNotificationsReachTransportWithRenderProfile(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		kind string
+	}{
+		{name: "approval gate off request", kind: DocsCardKindAccessRequested},
+		{name: "access granted", kind: DocsCardKindAccessGranted},
+		{name: "access denied", kind: DocsCardKindAccessDenied},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("OCTO_CARD_MESSAGE_ENABLED", "true")
+			t.Setenv("OCTO_DOCS_APPROVAL_CARD_ENABLED", "false")
+			wk := newWuKongServer()
+			defer wk.close()
+			ctx := newTestContext(t, wk)
+			ctx.GetConfig().External.WebLoginURL = "https://im.example.com/login"
+			n := newTestNotify(ctx, nil, nil, nil, "token")
+			n.botOK.Store(true)
+			primeMemberCache(n, "space-1", "user-1", "user-2")
+			sender, transport := newPlatformDispatchSender(t, cardmsg.ProfileV1, "")
+			n.docsSender = sender
+
+			card := validDocsCard()
+			card.Kind = tc.kind
+			if tc.kind == DocsCardKindAccessRequested {
+				card.RequestID = "request-1"
+			}
+			response, err := n.deliverDocsCardNotification(context.Background(), &NotifyReq{
+				SpaceID: "space-1", Service: "docs", Targets: []string{"user-1", "user-2"},
+				ActorUID: "actor-1", DocsCard: card,
+			})
+			require.NoError(t, err)
+			assert.ElementsMatch(t, []string{"user-1", "user-2"}, response.Delivered)
+			require.Equal(t, 2, transport.calls)
+			require.NotNil(t, transport.req)
+
+			var payload map[string]interface{}
+			require.NoError(t, json.Unmarshal(transport.req.Payload, &payload))
+			assert.Equal(t, cardmsg.ProfileV1, payload["profile"])
+			assert.Equal(t, cardmsg.RenderProfileOctoChatV1, payload["render_profile"])
+			assert.NotContains(t, payload, "card_profile")
+		})
+	}
 }
 
 func TestDocsApplicantOutcomesReachTransportWithRenderProfile(t *testing.T) {

--- a/pkg/cardmsg/profiles.go
+++ b/pkg/cardmsg/profiles.go
@@ -6,8 +6,9 @@ package cardmsg
 // not need to retain every artifact version.
 const RenderProfileOctoChatV1 = "octo-chat/v1"
 
-// IsAcceptedRenderProfile validates an explicit runtime visual profile. An
-// empty value means the permanent legacy renderer and is intentionally valid.
+// IsAcceptedRenderProfile validates a candidate runtime visual profile. An
+// empty value means the owning authoring boundary has not selected its default
+// yet and is intentionally valid here; a present wire value must be non-empty.
 func IsAcceptedRenderProfile(value string) bool {
 	return value == "" || value == RenderProfileOctoChatV1
 }

--- a/pkg/cardtmpl/summary_completed/template_test.go
+++ b/pkg/cardtmpl/summary_completed/template_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardmsg"
 	"github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl"
 	summarycompleted "github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl/summary_completed"
 )
@@ -61,6 +62,9 @@ func TestRegisterAndRenderSample(t *testing.T) {
 	}
 	if payload["profile"] != "octo/v1" {
 		t.Errorf("wire profile = %v want octo/v1", payload["profile"])
+	}
+	if payload["render_profile"] != cardmsg.RenderProfileOctoChatV1 {
+		t.Errorf("render profile = %v want %s", payload["render_profile"], cardmsg.RenderProfileOctoChatV1)
 	}
 }
 

--- a/pkg/cardtmpl/summary_failed/template_test.go
+++ b/pkg/cardtmpl/summary_failed/template_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardmsg"
 	"github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl"
 	summaryfailed "github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl/summary_failed"
 )
@@ -59,6 +60,9 @@ func TestRegisterAndRenderSample(t *testing.T) {
 	}
 	if payload["profile"] != "octo/v1" {
 		t.Errorf("wire profile = %v want octo/v1", payload["profile"])
+	}
+	if payload["render_profile"] != cardmsg.RenderProfileOctoChatV1 {
+		t.Errorf("render profile = %v want %s", payload["render_profile"], cardmsg.RenderProfileOctoChatV1)
 	}
 }
 


### PR DESCRIPTION
## Summary

Ensure every newly sent server-authored platform card carries the stable visual compatibility field `render_profile: "octo-chat/v1"`, while leaving historical messages and existing `content_edit` frames unchanged.

## Related Issue

N/A — direct platform-card compatibility task.

## Linked Spec

`.octospec/tasks/platform-card-render-profile-completion/brief.md`

## Changes

- Author the stable render profile at the trusted `internal/carddispatch` new-send boundary when a platform producer leaves it empty.
- Preserve explicit accepted values and keep unsupported values fail-closed before transport.
- Add transport-level composition coverage for `summary.completed`, docs approved/denied applicant outcomes, and generic approval request/outcome cards.
- Document that historical cards are not backfilled and continue to use the client fallback; the frozen `docs.access-request@0.2.0` artifact remains unchanged.

## Testing

- [x] Unit tests added/updated
- [ ] Manually verified in a deployed environment
- `go test -race ./internal/carddispatch/... -count=1`
- `go test -race ./pkg/cardtmpl/summary_completed/... ./pkg/cardtmpl/summary_failed/... -count=1`
- `go test -race ./modules/notify -run 'Test(SummaryRegistryCardsReachTransportWithRenderProfile|LegacyDocsNotificationsReachTransportWithRenderProfile|DocsApplicantOutcomesReachTransportWithRenderProfile|GenericApprovalCardsReachTransportWithRenderProfile)$' -count=1`
- `go test ./modules/notify/... -run 'RenderProfile|Summary|DocsActionFinalizer|StandardActionFinalizer|Approval' -count=1`
- `go build ./...`
- `go vet ./internal/carddispatch/... ./pkg/cardtmpl/summary_completed/... ./pkg/cardtmpl/summary_failed/... ./modules/notify/...`
- `golangci-lint run ./internal/carddispatch/... ./pkg/cardtmpl/summary_completed/... ./pkg/cardtmpl/summary_failed/... ./modules/notify/... --timeout=5m` (`0 issues`)
- `git diff --check`
- `internal/carddispatch.producerSender.Send`: 92.4% statement coverage.

The full `go test ./...` suite was not claimed locally because the existing test database contains an unknown legacy migration (`20191106000001_event_legacy01.sql`). The focused tests above do not require that database and passed.

## COMPREHENSION

1. **What does this change actually do** to the load-bearing path?

   The trusted internal dispatch boundary resolves an empty platform-card render profile to `octo-chat/v1`, writes it as a top-level sibling of `profile`, then runs the existing validation, finalization, payload-size check, and transport serialization. Explicit accepted values are preserved.

2. **What could break** because of it (dependents + failure mode)?

   Every new internal platform-card sender now emits one additional bounded string when it previously omitted the field. A near-limit payload could exceed the size cap, but the existing post-enrichment size check fails it closed before transport. Historical messages, mutation frames, Incoming Webhooks, and legacy Robot ingress are outside this path and unchanged.

3. **How do you know it works** (specific test/repro/trace)?

   Transport-capture composition tests exercise real Registry/builders and finalizers through a real `carddispatch.Registry`, then assert the serialized `config.MsgSendReq.Payload` keeps the existing `profile`, contains `render_profile: "octo-chat/v1"`, and never introduces `card_profile`. Dispatch tests also verify explicit values and unsupported-value rejection.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] PR description is in English
- [x] Added tests for my changes
- [x] Updated documentation
- [x] Followed commit message conventions (Conventional Commits)
