### PR TITLE
docs(federation): DRAFT design for cross-instance federation (single-homed external groups)

### DIFF
--- a/docs/federation-design.md
+++ b/docs/federation-design.md
@@ -1,0 +1,290 @@
+# octo 跨实例联邦设计：两家自部署企业互信通信 / 跨实例外部群
+
+**status: DRAFT — 待拍板**
+**方案：A 单边托管（single-homed）** — 外部群寄居在其中一方实例上（下称 **Host / A**；对端下称 **Peer / B**）
+**代码基线：** octo-server HEAD `a61b5411`（branch `feat/thread-peruser-visibility`）
+**证据说明：** 本草案的 file:line 结论来自一轮独立代码勘察，撰写时未逐条重开文件复核。凡标注「未验证 / 需实测」处，执行前必须先验证，并 drift check 对齐当时 HEAD。
+
+---
+
+## 0. 范围
+
+**要**：可评审的架构设计，说明两家独立部署的 octo 实例如何建立互信、让双方用户在一个共享外部群里协作。
+**不要**：实现代码。写码票在设计拍板 + 人工理解节点通过后再拆。
+**已定方向（不重新论证）**：方案 A 单边托管。放弃方案 B（双向复制）理由已验证。
+**架构硬约束**：联邦网关必须抽成独立模块 `modules/federation`，不把单边托管假设焊死进业务代码。
+
+---
+
+## 1. 核心设计立场
+
+**联邦 = 复用现有 `is_external` 外部群语义骨架 + 把身份来源从「同实例另一 Space」替换为「对端实例」。** 远端用户在 Host 落一行**普通形态、但被硬约束为「不可认证」的本地 32 位 uid 影子账号**；联邦来源记在旁路表 + 现有 `is_external` 标记里，**绝不把联邦身份编进 uid 字符串**（规避 `@` 毒性与被回滚的列宽放大）。WuKongIM 当哑消息总线（目标零改动，但**发送方伪装能力必须先实测**，见 §5.4）。跨实例信任、授权、消息中继、可靠投递成本全部搬到 octo-server 侧的 `modules/federation`。
+
+
+---
+
+## 2. 与现有 `is_external` 机制的复用边界
+
+| 现有能力 | 证据（file:line，来自前置勘察，未在本轮重核） | 联邦处置 |
+|---|---|---|
+| `is_external=1` 成员标记 + 外部角标渲染 | `docs/external-group-design.md`（v1.1，PR #1167） | **直接复用** |
+| `allow_external` 安全阀 | 同上 | **直接复用**（联邦总开关前置） |
+| 会话过滤放行 | `space_filter.go` | **直接复用** |
+| 搜索放行 | `shouldIncludeGroupForSpace` | **直接复用** |
+| 退群自动恢复 | `is_external_group` 逻辑 | **直接复用** |
+| `source_space_id` 来源标识 | external-group-design.md | **扩展**：新增平行维度 `source_peer_instance_id`（落哪张成员表 / 与 `source_space_id` 共存 / 唯一键，**需实测**，见 §6） |
+| 外部标记缓存 | `external_marker_cache.go:162-168` | **扩展 + 修 bug**（当前静默丢标记，见 §7） |
+| IM 成员名单反查 datasource | `modules/webhook/api.go:141`、`api_datasource.go:84-113`、`modules/group/1module.go:66-78` `GetSubscribableMemberUIDs()` | **直接复用** |
+| `IMAddSubscriber` | `octo-lib/config/msg.go:298`（只传 uid、无握手） | **直接复用** |
+| webhook HMAC-SHA256 签名 | `modules/webhook/hmac.go:30-58`（fail-closed） | **复用为互信起步原语**（仅认证，非授权，见 §4.2） |
+| `user_oidc_identity` 形状 | `modules/oidc/sql/20260427000002:5-24` | **复用形状**新建 `federation_identity` |
+| `modules/federation` 网关 / `federation_peer` 信任表 / 授权层 / 中继协议 / outbox 可靠投递 / 附件异步拉取 / 生命周期事件 | `federat` 全零命中 | **全部新建** |
+
+---
+
+## 3. Q1 · 身份
+
+### 3.1 影子 uid 形态
+远端用户在 Host 上映射到**一个正常生成的本地 32 位 hex uid**（`pkg/util/string.go:15` 同款），**无 namespace 限定符**。理由：`@` 是毒（`octo-lib/common/msg.go:172-174` `IsFakeChannel`、`:157-169` `from@to` 拼 DM，9 处非测试调用点）；列宽 `uid VARCHAR(40)` 焊死（约 40 migration + 索引，oidc 曾放大到 64 并 revert，**revert 原因未验证——执行前必查 git log/PR**）。影子 uid 为普通本地行 → 无声穿过 `QueryByUIDs`、DM 逻辑、全部索引。
+
+### 3.2 `federation_identity`（复用 `user_oidc_identity` 形状）
+```sql
+CREATE TABLE federation_identity (
+  id               BIGINT AUTO_INCREMENT PRIMARY KEY,
+  peer_instance_id VARCHAR(64)  NOT NULL,
+  remote_uid       VARCHAR(64)  NOT NULL,
+  local_shadow_uid VARCHAR(40)  NOT NULL,
+  status           TINYINT      NOT NULL DEFAULT 1,   -- 1=active 2=suspended 3=revoked
+  lease_expires_at DATETIME     NULL,
+  display_name     VARCHAR(128) NULL,                 -- 投影自对端，随 profile 事件更新（§8.3）
+  avatar_url       VARCHAR(255) NULL,
+  created_at       DATETIME     NOT NULL,
+  updated_at       DATETIME     NOT NULL,
+  UNIQUE KEY uk_peer_remote (peer_instance_id, remote_uid),
+  UNIQUE KEY uk_shadow (local_shadow_uid)
+) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+```
+🔴 **并发创建竞态（P0）**：入站消息可能瞬间并发触发同一 `(peer,remote_uid)` 的影子创建，撞 `uk_peer_remote` → 500 + 丢消息。**必须用 DB 级 upsert（`INSERT ... ON DUPLICATE KEY UPDATE` 取回既有行）或 per-key 分布式锁**收敛，禁止「先 SELECT 再 INSERT」裸竞态。
+
+### 3.3 🔴 不可认证影子（Unauthenticatable Federation Shadow）—— 一等约束
+设计评审指出：仅封「好友/推荐/搜索」远远不够。影子是普通本地行意味着**登录、token 铸发、密码/OIDC 绑定、设备注册、通知、@提及、DM 发起、审计、管理后台、导入导出、删除任务、权限缓存**都可能把它当真人。
+
+**约束（spec 级强制）**：影子账号带一个**统一可判定标志**（如 `user.federation_shadow=1`，落 user 表，**列位置/迁移兼容需实测**），并要求执行者**逐路径审计**下表，每条给出「拒绝 / 降级 / 放行」处置，缺一条即 STOP：
+
+| 路径 | 期望处置 |
+|---|---|
+| 登录 / 铸 IM/Web token | **拒绝**（影子永不登录，§5.1 依赖此） |
+| 密码 / OIDC 绑定 | **拒绝** |
+| 加好友 / 好友推荐 / 通讯录 | **排除** |
+| 全局搜索 / 用户目录 | **排除**（仅联邦群内可见） |
+| 发起 DM / 被 DM | **拒绝或仅群内**（待 Yu 定，§16） |
+| @提及 | 仅群内成员范围 |
+| 管理后台 / 导入导出 | 标注为联邦来源，不可当本地成员导出 |
+| 删除 / GDPR 任务 | 随联邦生命周期（§8），不进本地注销流程 |
+| 权限缓存 | 缓存键须含 shadow 判定，吊销时失效（§8.4） |
+
+---
+
+## 4. Q2 · 互信 + 授权
+
+### 4.1 认证选型：HMAC 共享密钥起步
+| 候选 | 结论 |
+|---|---|
+| HMAC 共享密钥（复用 `webhook/hmac.go`，fail-closed，零新基建） | **MVP 选它** |
+| JWT+JWKS（基建已删 `modules/bot_provision/jwt.go`） | 不作起步 |
+| mTLS（无 CA/轮换基建） | 后续 |
+理由：起步是**少量、带合同的点对点配对**，非开放联邦。抽象 `FederationTrust` 接口（`Sign/Verify`）留 JWT/mTLS 迁移位，不动业务代码。
+
+### 4.2 🔴 授权 ≠ 认证（P0）
+HMAC 只证明「请求来自持共享密钥的一方」，**不证明**：① `remote_uid` 当前确属该 peer 且 active；② 该 uid 仍是目标群成员；③ 该 peer 被授权向该 `channel_ref` 写入。**必须显式三段校验，缺任一 fail-closed**：
+1. **peer 认证**：HMAC 验签通过（含 §4.4 防重放）。
+2. **身份绑定**：`federation_identity` 中 `(peer, remote_uid)` 存在且 `status=active` 且租约未过期。
+3. **频道授权**：`channel_ref` 解析出的本地群 `allow_external=1`、且该群已与该 peer 建立联邦关系（新表 `federation_channel`，§4.5）、且该 remote 影子是该群成员。
+> 🔴 **禁止**依赖 `pkg/space/middleware.go:112-115`「无 space_id → 跳过校验」的口子；联邦入站必须显式携带并强校验频道/租户归属（[api] 测试：缺归属的入站请求被拒）。
+
+### 4.3 `federation_peer`
+```sql
+CREATE TABLE federation_peer (
+  peer_instance_id VARCHAR(64) PRIMARY KEY,
+  display_name     VARCHAR(128) NOT NULL,      -- 对端组织名（外部标记用，§7）
+  base_url         VARCHAR(255) NOT NULL,      -- 对端网关入口（见 §4.6 SSRF 约束）
+  hmac_key_id      VARCHAR(32)  NOT NULL,      -- 当前密钥 ID（envelope 回填，§4.4）
+  hmac_secret_enc  VARBINARY(512) NOT NULL,    -- 加密存储
+  hmac_key_id_prev VARCHAR(32)  NULL,          -- 轮换窗口旧密钥 ID
+  hmac_secret_prev VARBINARY(512) NULL,
+  status           TINYINT NOT NULL DEFAULT 1, -- 1=active 2=suspended 3=revoked
+  created_at DATETIME NOT NULL, updated_at DATETIME NOT NULL
+);
+```
+
+### 4.4 🔴 密钥管理 + 防重放（P0/P1）
+- **规范化签名输入**：签名覆盖 `key_id + method + path + sha256(body) + timestamp + nonce`（明确定义拼接顺序，避免歧义）。
+- **时间窗**：`timestamp` 超出 ±N 分钟拒绝；**nonce** 在窗口内去重（Redis SETNX，保留期 ≥ 时间窗），杜绝重放。区分「网络重试（同 idempotency_key，§5.5 幂等吸收）」与「重放攻击（nonce 撞）」。
+- **轮换**：envelope 带 `key_id`，接收方据此选 current/prev 密钥；双密钥窗口内两者都验，窗口结束废弃 prev。
+- **密钥托管**：`hmac_secret_enc` 依赖 KMS / 应用层加密密钥 + 版本管理；**带外人工配对交换，密钥永不回显/入日志/进文档**。删除 peer → 立即 fail-closed，同时失效积压重试队列、连接池、权限缓存。
+
+### 4.5 `federation_channel`（联邦群 ↔ peer 的权威映射）
+🔴 设计评审修正：`channel_ref` 不能是自由字符串。新表把**本地群**与 **peer + 对端频道 ID** 双向绑定，`channel_ref` 用**不可猜测的联邦频道 token**（非本地 group id 直出），Host 为解析权威方：
+```sql
+CREATE TABLE federation_channel (
+  federation_channel_token VARCHAR(64) PRIMARY KEY,  -- 不可猜测
+  local_group_id           VARCHAR(64) NOT NULL,
+  peer_instance_id         VARCHAR(64) NOT NULL,
+  peer_channel_id          VARCHAR(64) NOT NULL,
+  status                   TINYINT NOT NULL DEFAULT 1,
+  created_at DATETIME NOT NULL, updated_at DATETIME NOT NULL,
+  UNIQUE KEY uk_local_peer (local_group_id, peer_instance_id)
+);
+```
+
+### 4.6 🔴 `base_url` 的 SSRF / 路由劫持面（P1）
+管理员配置的 peer URL 未约束会让网关向内网/错主机推数据。**必须**：仅 https；解析 IP 后拒绝私网/环回/元数据段（RFC1918、169.254/16 等）；禁跟随重定向；建议证书 pin 或固定 CA。HMAC 不防错目的地。
+
+---
+
+## 5. Q3 · 消息流
+
+### 5.1 分岔口（2.3(b)）：服务端中继（选定）
+B 客户端只连 **B 自己的 IM**；跨实例由两侧 `modules/federation` 服务端中继。A 的 IM 把影子当**从不连接的订阅者**（2.2：`IMAddSubscriber` 无握手、token 只在真实登录铸）。**不选** Option 2（Host 给 B 用户铸 IM token）——那是给管不着的人铸凭证、把 IM 暴露给不受信客户端，攻击面巨大。
+
+### 5.2 流转（文本，单条，B→A 入站）
+```
+B 用户发消息 → B server 识别频道为联邦 → B 网关 POST A 网关（HMAC 签名 + nonce）
+ → A 网关：§4.2 三段授权 → 解析 remote_uid→shadow_uid（并发 upsert，§3.2）
+ → A 写 outbox（§5.5）→ 以影子 uid 服务端发送写入 A 的 IM 频道 → IM 广播群内订阅者
+```
+A→B 反向为对称链路（Phase 1b，见 §12）。
+
+### 5.3 中继 envelope
+```json
+{ "key_id":"<签名密钥ID>", "peer_instance_id":"<发送方>", "federation_channel_token":"<§4.5>",
+  "remote_uid":"<发送方本地 uid>", "msg_type":"text|image|file|edit|revoke|profile|lifecycle",
+  "payload":{...}, "idempotency_key":"<对端消息唯一键>", "nonce":"<防重放>", "sent_at":"<RFC3339>" }
+```
+🔴 `sent_at` 来自对端，**不可信作排序权威**；Host 以本地接收序 + 自身时钟为准，`sent_at` 仅供展示，避免时钟偏移乱序。
+
+### 5.4 🔴 Phase 0 spike（阻塞性前提）
+仅测「真实用户向含合成 uid 的频道发消息不报错」**不够**。**必须同时实测**「以合成 uid 作为 `from_uid` 走服务端 API 发送（伪装发送者）IM 是否接受」——这才是 Option 1 的真正前提。
+实测断言（全绿才进 Phase 1）：
+1. `IMAddSubscriber` 把从不登录的合成 uid 加入频道 **成功**；
+2. `getSubscribers` datasource 返回列表**含**该 uid；
+3. **以该 uid 为 from_uid 服务端发消息，IM 接受并广播、不校验发送者 token**；
+4. A 能**捕获**群内消息作为出站事件（§5.5 前提）。
+任一失败 → **STOP 上报**，Option 1 前提崩，回设计（评估 Option 2 或消息落库不进 IM 的降级）。
+
+### 5.5 🔴 出站捕获 + 可靠投递（outbox，P0/P1）
+- **出站捕获**：Host 需一个「消息写入联邦频道」的**事件钩子**（webhook / 消息持久化后回调）来触发向 peer 中继。**该钩子在 octo 消息管线中的确切落点未验证——需实测**（候选：现有 webhook 事件流 `modules/webhook`）。
+- **双写难题**：「写 IM」与「记幂等/outbox」非同一事务 → 崩溃窗口造成重复或永久丢消息。**采用 outbox 模式**：入站先落 `federation_inbox`（`(peer, idempotency_key)` 唯一，事务内），再由 worker 幂等地推 IM；出站先落 `federation_outbox`，worker 带 ACK/重试/死信地投递 peer。定义：保留期、最大重试、DLQ、崩溃恢复（重启后扫未 ACK）。
+- **IM 侧去重（P2）**：即便 DB 幂等，网络抖动重试写 IM 仍可能双气泡；需确认 IM 是否支持外置 client-msg-no 去重（**需实测**），否则 worker 必须保证「已确认写入 IM」的状态持久化后才不重发。
+
+---
+
+## 6. Q4 · 成员投影
+影子 uid 是真实本地成员行 → `GetSubscribableMemberUIDs()` 天然返回，datasource 无需改。加成员走 `IMAddSubscriber`，带 `is_external=1` + `source_peer_instance_id`。
+🔴 **成员存储模型（P1）**：`source_peer_instance_id` 落**哪张成员表**、能否与 `source_space_id` 共存、唯一键、迁移兼容——**均需实测现有 group member 表后确定**，不得假设。
+🔴 静默消失（2.4）：`service.go:1452 QueryByUIDs`→`:1497` 遍历 DB 结果丢弃未知 uid——因影子已是真实行而被规避；[api] 测试须断言投递含影子 uid 名单无静默丢弃。
+
+---
+
+## 7. Q5 · 外部标记绝不能丢
+现状 bug：`GetSpaceName` 对远端 space 返回空串 → `external_marker_cache.go:162-168` 丢标签 → 联邦成员渲染成无标记（最坏）。
+**不变量（spec 级强制）**：`source_peer_instance_id` 非空而 space name 不可解析时，**强制**用 `federation_peer.display_name` 渲染外部角标，**绝不渲染成无标记**；缺标记 = 硬 bug。
+🔴 验收精化（P2）：「每一处」需给**完整渲染面清单**（成员列表 / 消息气泡 / 会话列表 / 通知 / @提及 / 历史消息 / 各客户端版本）+ 缓存失效规则；单个 browser 测试不足以证明全覆盖——按渲染面拆多条 [api]/[browser] 断言。移动端渲染为 [manual]（无移动自动化 lane）。
+
+---
+
+## 8. Q6 · 撤销与生命周期（事件驱动为主）
+🔴 设计评审修正：轮询心跳在数百成员下 O(N) 无效轮询 + 生命周期竞态可绕过。修正：
+- **8.1 事件驱动为主**：B 主动推 `lifecycle`（`user_suspended`/`user_revoked`/入群/退群）事件，Host 即时处置。放弃周期性全量轮询。
+- **8.2 租约作 fail-closed 兜底**：`lease_expires_at` 仅作「长时间无任何事件」的保险；过期→`suspended`（禁发言、标记不活跃），非高频轮询。网关断线重连时做一次全量 sync 对账。
+- **8.3 profile 更新通道（P1）**：B 用户改昵称/头像 → 推 `profile` 事件 → 更新 `federation_identity.display_name/avatar_url`，避免影子信息永久停在首条消息快照。
+- **8.4 🔴 吊销的线性化（P1）**：revoke 必须**原子失效**在途请求 + 成员缓存 + 权限缓存，防止「已 revoke 用户借在途请求/陈旧缓存继续写入」。历史消息作者改标注须与现有作者缓存一致（定义失效顺序）。
+
+---
+
+## 9. Q7 · 附件跨域（异步拉取）
+🔴 设计评审修正：同步推送几十~上百 MB 文件经 HTTP 网关会堆积/内存暴涨/超时导致中继失败。**改为**：
+- B 中继消息只带**附件元数据 + B 侧签名下载 token**；A 落消息后由**异步 Worker 回 B 拉取**并转存 A 本地 MinIO，改写 URL 为 Host-local（保「内容落 Host」的数据主权属性）。
+- 必须定义：流式**大小/类型前置校验**、内容哈希完整性、（可选）恶意文件扫描、对象写入与消息引用的**原子提交/失败清理**、重复上传幂等、下载授权、**撤销后历史附件访问策略**。
+- 惰性签名 URL（读时回源）作为备选，但依赖对端长期在线，MVP 不选。
+
+---
+
+## 10. Q8 · E2E 加密
+`signal_identities` 表存在。**结论：Option 1 服务端中继下 E2E 不成立**（server 必须见明文以影子 uid 存/发；影子在 Host 无真实设备/密钥；附件在 Host 落明文）。
+**硬门（fail-closed，双向拦截）**：① 开 E2E 的群拒绝开联邦；② 🔴 **开联邦的群也必须拒绝 `EnableE2E` 接口**（P2——防只拦 CreateFederation 漏改 EnableE2E 造成损坏混合态）。判定须有**单一事实源 + 事务约束**，防群设置并发变更下短暂双开。向用户明示「跨企业协作，非端到端加密」。
+
+---
+
+## 11. Q9 · 安全边界（联邦版信息暴露表）
+**总开关**：群 `allow_external=1`（复用）**且** `federation_peer.status=active`（新增），双前置缺一不可，默认关。
+| 信息面 | 联邦影子能看到 | 不能看到 |
+|---|---|---|
+| 该联邦群消息/附件 | ✅ | — |
+| 群成员列表（影子投影，带角标） | ✅ | 成员跨群/组织内其它信息 |
+| Host 其它 Space/群 | ❌ | ✅ 隔离 |
+| Host 用户目录/全局搜索 | ❌（仅群内） | ✅ 隔离 |
+| Host 好友图/组织架构 | ❌ | ✅ 隔离 |
+复用 `space_filter.go`/`shouldIncludeGroupForSpace` 收敛可见性到该联邦群。
+🔴 复用 §4.2 授权 + 禁用 `middleware.go:112-115` 跳过口子。补：**per-peer 限流 / DoS 防护**（一个被攻陷 peer 洪泛）；**跨实例流量审计日志**（合规需要，记录谁经边界发了什么）。
+
+---
+
+## 12. Q10 · 分阶段落地
+为避免范围自相矛盾（声称单向却验反向），最小切面拆分如下：
+
+| 阶段 | 切面 | 可验证验收 |
+|---|---|---|
+| **Phase 0（spike）** | §5.4 扩展 spike（订阅 + **伪装发送** + 出站捕获） | 四断言全绿→过；任一失败 STOP |
+| **Phase 1a（MVP，真·单向）** | HMAC 配对 + 三段授权 + `federation_identity`(并发 upsert) + 不可认证影子约束 + `federation_channel` + inbox/outbox + **仅 B→A 文本入站** + 硬外部标记 | [api] B 文本经中继出现在 A 群、带正确角标、无静默丢弃；[api] 缺归属/未授权入站被拒；[api] 重放（nonce 撞）被拒、重试（同 idempotency）幂等；[browser] 群内每处见角标 |
+| **Phase 1b** | A→B 反向出站（对称链路） | [api] A 消息经出站 outbox 到达 B、ACK/重试可靠 |
+| **Phase 2** | 附件异步拉取 + 花名册事件同步 + profile 更新 + 吊销/租约生命周期 | [api] 附件落 Host 存储且原子;[api] revoke 后影子移出+发言被拒+缓存失效;[api] profile 事件更新影子;[api] 租约过期→suspended |
+| **Phase 3（加固）** | 密钥轮换（key_id 双窗口）+ SSRF 约束 + per-peer 限流 + 审计日志 + E2E 双向硬 gate | [api] 轮换期 old+new 均验、切换后 old 失效;[api] base_url 私网被拒;[api] E2E 群开联邦 & 联邦群 EnableE2E 均被拒 |
+优先级：[api] > [browser] > [manual]。移动端渲染面为 [manual]。
+
+---
+
+## 13. Out-of-scope
+双向复制（方案 B）；开放联邦 / 多于两家动态发现（起步只做带合同点对点）；联邦 E2E（§10 已知限制）；WuKongIM 源码改动；修改现有 go 业务文件行为（本轮只出设计）；`@` 域名限定 uid。
+
+---
+
+## 14. STOP conditions（执行者遇到即停并上报）
+1. Phase 0：IM 拒绝未知订阅者 **或** 拒绝伪装 from_uid 发送 **或** 无法捕获出站消息 → Option 1 崩，回设计。
+2. 无法建立出站事件捕获钩子 / 无法实现 inbox·outbox 幂等与崩溃恢复 → 停。
+3. 无法建立 `federation_channel` 双端映射 → 停。
+4. oidc 列宽 revert 存在数据/索引级根因影响影子方案 → 停。
+5. `source_peer_instance_id` 无既有成员表可安全承载 / 与 `source_space_id` 冲突 → 停。
+6. `short_no` / `federation_shadow` 列不可空且无安全落位 → 停。
+7. §3.3 影子路径审计发现无法统一拦截的认证入口 → 停。
+8. 发现 uid 上本 spec 未覆盖的强假设（除 `@`/DM 外）→ 停。
+9. 数据主权/合规决策点（§16）未获明确 confirm → 不得进 Phase 1 之后。
+
+---
+
+## 15. 未验证 / 需实测清单（诚实标注）
+1. **2.3(a) 扩展**：IM 接受未知订阅者 **且** 接受伪装 from_uid 服务端发送 **且** 可捕获出站——未验证，Phase 0 必做。
+2. **出站事件捕获钩子在消息管线的确切落点** — 未验证（候选 webhook 事件流）。
+3. **IM 是否支持外置 client-msg-no 去重** — 未验证。
+4. **oidc uid 列宽 64 放大被 revert 的原因** — 本轮未查（仓未配置），执行前必查。
+5. **`short_no` 可空性 / `federation_shadow` 及 `source_peer_instance_id` 列落位与迁移兼容** — 未验证。
+6. **本文档全部 file:line 证据** — 本轮未能重开 octo-server 复核（工作区未配置该仓），沿用前置勘察；执行者 drift check 后逐条对齐当前 HEAD。
+
+---
+
+## 16. 需 Yu confirm 的决策点
+1. 🔴 **数据主权（最重）**：单边托管下 B 的协作数据（消息/附件/成员 profile）物理落 A 服务器。两家法务/合规是否接受？谁是数据控制者？跨境？**联邦解除后 A 上 B 数据是否须清除（GDPR）？**
+2. **互信原语**：MVP 用 HMAC 共享密钥可否，抑或合规要求起步即 mTLS/JWT？
+3. **E2E**：联邦群非端到端加密（双向硬 gate）可否接受？
+4. **消息流分岔**：服务端中继（推荐）vs 给 B 用户铸 A 的 IM token？
+5. **附件**：异步拉取转存 Host（推荐）vs 惰性签名跨取？
+6. **影子 profile 投影范围**：B 用户真实姓名/头像在 A 侧展示到什么程度？影子能否被 DM？
+7. **`short_no` 分配策略**：影子是否占号 / 占哪段？
+8. **谁当 Host（A）**：每个外部群由哪方托管的治理规则 + per-peer 授权到「哪些群」。
+
+---
+
+## 17. 测试要点汇总
+Phase 0 扩展 spike（阻塞）；影子穿 `QueryByUIDs` 无丢弃；外部标记按渲染面多点 fail-safe；缺归属入站被拒 / 影子不可全局搜索·加好友·登录；防重放（nonce）与幂等（idempotency）区分；outbox 崩溃恢复 / ACK；附件原子转存；生命周期 revoke·租约·profile 事件；HMAC 双密钥轮换；base_url SSRF 拒私网；E2E 双向 gate。
+
+---

--- a/modules/message/api_reminders.go
+++ b/modules/message/api_reminders.go
@@ -13,6 +13,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
 	"github.com/Mininglamp-OSS/octo-server/modules/group"
+	"github.com/Mininglamp-OSS/octo-server/modules/thread"
 	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
 	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
 	"go.uber.org/zap"
@@ -60,6 +61,25 @@ func (m *Message) reminderDone(c *wkhttp.Context) {
 		if err != nil {
 			tx.Rollback()
 			m.Error("更新提醒项版本失败！", zap.Error(err))
+			httperr.ResponseErrorL(c, errcode.ErrMessageStoreFailed, nil, nil)
+			return
+		}
+	}
+	// plan T5：per-user 可见性 flag=on 时，reminder_done 掉的子区 @（P1 消失）在同一 tx 内
+	// bump 本人 follow_version，客户端据此重拉 sidebar 跑仲裁（子区从"P1 强制可见"回落 P2/P3）。
+	// 遵锁序 F3：本 bump 只碰 user_follow_version、不碰 conversation_ext，先 bump 安全。
+	// 解析范围严格限于 id→channel_id→groupNo→space_id（STOP-2 边界内），不改 done 契约。
+	if thread.PerUserVisibilityEnabled() {
+		threadChannels, qerr := m.remindersDB.queryThreadChannelsByIDsTx(tx, ids, loginUID)
+		if qerr != nil {
+			tx.Rollback()
+			m.Error("查询 reminder 子区频道失败（T5 bump）！", zap.Error(qerr))
+			httperr.ResponseErrorL(c, errcode.ErrMessageStoreFailed, nil, nil)
+			return
+		}
+		if berr := m.bumpFollowVersionForThreadChannelsTx(tx, loginUID, threadChannels); berr != nil {
+			tx.Rollback()
+			m.Error("bump follow_version 失败（T5 reminder_done）！", zap.Error(berr))
 			httperr.ResponseErrorL(c, errcode.ErrMessageStoreFailed, nil, nil)
 			return
 		}
@@ -385,6 +405,13 @@ func (m *Message) handleReminders(reminders []*remindersModel) {
 		err := m.remindersDB.inserts(reminders)
 		if err != nil {
 			m.Error("插入提醒项失败！", zap.Error(err))
+		} else if thread.PerUserVisibilityEnabled() {
+			// plan T6：per-uid @ 落 reminder 后，fire-and-forget bump 被@uid 的 follow_version，
+			// 客户端据此重拉 sidebar 让子区从归档状态被 P1 拉回可见。
+			// 绝不包进核心写 tx（R2）：各自独立短 tx、失败只 warn，不阻断消息投递 / CMDSyncReminders。
+			// 快照 reminders 切片供 goroutine 独立消费，不与下方 CMD 发送共享可变状态。
+			bumpReminders := reminders
+			go m.bumpFollowVersionForReminders(bumpReminders)
 		}
 		channels := make([]*config.ChannelReq, 0)
 		uids := make([]string, 0)

--- a/modules/message/api_sidebar.go
+++ b/modules/message/api_sidebar.go
@@ -70,6 +70,8 @@ type Sidebar struct {
 	convExtDB       *convext.DB
 	threadDB        *thread.DB
 	followVersionDB *convext.FollowVersionDB
+	// remindersDB 供 per-user 可见性仲裁（plan T3 P1：未处理 per-uid @）批量查询使用。
+	remindersDB *remindersDB
 	// PR #21 review (Jerry-Xin Critical)：Space 过滤需要群表查询。
 	groupService group.IService
 	// groupDB 仅用于 thread ext 行的 Space 过滤（PR #21 Round-6 P0-2）查
@@ -86,6 +88,7 @@ func NewSidebar(ctx *config.Context) *Sidebar {
 		convExtDB:       convext.NewDB(ctx),
 		threadDB:        thread.NewDB(ctx),
 		followVersionDB: convext.NewFollowVersionDB(ctx),
+		remindersDB:     newRemindersDB(ctx),
 		groupService:    group.NewService(ctx),
 		groupDB:         group.NewDB(ctx),
 		Log:             log.NewTLog("Sidebar"),
@@ -500,7 +503,14 @@ func (sb *Sidebar) Sync(c *wkhttp.Context) {
 		// TargetID 同口径。同时覆盖 buildFollowItems（IM-present）与 mergeThreadEntries
 		// （DB-only）两条路径；mergeThreadEntries 已把不在 statusMap 中的 thread
 		// （deleted/missing）skip，所以幸存的 thread 条目必有 status。
-		backfillThreadStatus(items, threadStatusMap)
+		//
+		// plan T3/T4：flag=on 时改跑 per-user 四级仲裁 + Unread 二次过滤
+		// （computeEffectiveStatus 内含 fail-open 回落全局 status）；flag=off 逐字等于现状。
+		if thread.PerUserVisibilityEnabled() {
+			sb.computeEffectiveStatus(loginUID, items, threadStatusMap)
+		} else {
+			backfillThreadStatus(items, threadStatusMap)
+		}
 
 		// Issue #151 symptom #2 — materialize ext rows for default-followed
 		// groups (categorized but never touched).  Without this, OnThreadCreated
@@ -566,8 +576,12 @@ func (sb *Sidebar) Sync(c *wkhttp.Context) {
 		// 查询所有 thread 条目的 status（无 N+1），再 backfill。
 		// FAIL-OPEN：查询失败只记 warn 并把 Status 留空（omitempty -> 字段缺省），
 		// 与 recent tab 既有的降级行为一致，绝不 fail-closed。
+		//
+		// plan T3/T4：flag=on 时改跑 per-user 四级仲裁 + Unread 二次过滤；flag=off 逐字等于现状。
 		if statusMap, qerr := sb.loadThreadStatuses(items); qerr != nil {
 			sb.Warn("sidebar sync: thread status query failed (recent tab non-fatal, status omitted)", zap.Error(qerr))
+		} else if thread.PerUserVisibilityEnabled() {
+			sb.computeEffectiveStatus(loginUID, items, statusMap)
 		} else {
 			backfillThreadStatus(items, statusMap)
 		}
@@ -730,6 +744,116 @@ func backfillThreadStatus(items []*SidebarItem, statusMap map[string]int) {
 			it.Status = st
 		}
 	}
+}
+
+// computeEffectiveStatus 对 sidebar 里的 thread 条目跑「按用户」四级仲裁
+// MUTE > P1 > P2 > P3，把 SidebarItem.Status 从「全局 thread.status」改写成
+// 「当前 uid 的有效可见性」；并在同一循环里做 T4 的 Unread 二次过滤
+// （对 per-user 归档隐藏的条目置 Unread=0）。仅在 feature flag DM_THREAD_PERUSER_VISIBILITY
+// = on 时由调用方调用；flag=off 时调用方沿用 backfillThreadStatus（全局 status），本函数不被触及。
+//
+// 四级仲裁（plan 决策2 / §3-T3）：
+//   - MUTE（thread_setting.mute，最高）：压制 P1 的强制可见 + 红点鼓包（badge），
+//     但「是否隐藏」仍交由 P2/P3 决定 → 静音条目走 P2/P3 的 status，且 Unread 清零（不鼓红点）。
+//   - P1（未处理 per-uid @）：强制可见（status=1 active）+ 保留红点。@所有人(uid='')不触发。
+//   - P2（thread_user_state.archive_intent 本人手工意图）：intent==1 → status=2 归档；否则 active。
+//   - P3（全局 thread.status / 时间兜底，即现有 backfill 值）：无 P1/P2 时回落。
+//
+// fail-open 铁律（plan §5-R1）：三份 per-uid 数据（mute / archive_intent / P1）任一查询失败，
+// 只记 warn 并让**该批**条目保持既有全局 status 回填（不 fail-closed 隐藏）；绝不因 per-uid
+// 查询失败把用户能看的子区藏掉。statusMap 为调用方已算好的全局 status（P3 兜底）。
+func (sb *Sidebar) computeEffectiveStatus(loginUID string, items []*SidebarItem, statusMap map[string]int) {
+	if loginUID == "" || len(items) == 0 {
+		// 先按 P3 回填全局 status，保持与现状一致（fail-open 兜底）。
+		backfillThreadStatus(items, statusMap)
+		return
+	}
+
+	// 收集 thread 条目 refs + channelIDs（复用现有 parse，与 TargetID 同口径）。
+	refs := make([]thread.ShortRef, 0)
+	channelIDs := make([]string, 0)
+	for _, it := range items {
+		if it.TargetType != int(common.ChannelTypeCommunityTopic) {
+			continue
+		}
+		gno, sid, err := parseThreadChannelIDSidebar(it.TargetID)
+		if err != nil {
+			continue
+		}
+		refs = append(refs, thread.ShortRef{GroupNo: gno, ShortID: sid})
+		channelIDs = append(channelIDs, it.TargetID)
+	}
+
+	// 先按 P3 全局 status 回填（无 P1/P2 时的兜底基线，也是 fail-open 的回落值）。
+	backfillThreadStatus(items, statusMap)
+	if len(refs) == 0 {
+		return
+	}
+
+	// 一次性批量取三份 per-uid 数据（无 N+1）。任一失败 → fail-open：记 warn 并直接返回，
+	// 条目保持已回填的全局 status（客户端按现状可见）。
+	muteMap, err := sb.threadDB.QueryMuteForUID(loginUID, refs)
+	if err != nil {
+		sb.Warn("sidebar per-user visibility: mute batch query failed (fail-open, fall back to global status)",
+			zap.Error(err), zap.String("loginUID", loginUID))
+		return
+	}
+	stateMap, err := sb.threadDB.QueryUserStates(loginUID, refs)
+	if err != nil {
+		sb.Warn("sidebar per-user visibility: user_state batch query failed (fail-open, fall back to global status)",
+			zap.Error(err), zap.String("loginUID", loginUID))
+		return
+	}
+	p1Set, err := sb.remindersDB.queryUnhandledMentionChannels(loginUID, channelIDs)
+	if err != nil {
+		sb.Warn("sidebar per-user visibility: unhandled-mention (P1) query failed (fail-open, fall back to global status)",
+			zap.Error(err), zap.String("loginUID", loginUID))
+		return
+	}
+
+	// 逐条仲裁 + T4 Unread 二次过滤（同一循环，避免二次遍历）。
+	for _, it := range items {
+		if it.TargetType != int(common.ChannelTypeCommunityTopic) {
+			continue
+		}
+		key := it.TargetID
+		muted := muteMap[key] == 1
+		_, hasP1 := p1Set[key]
+		state, hasState := stateMap[key]
+
+		switch {
+		case muted:
+			// MUTE 只压 P1 强制可见 + 红点：走 P2/P3 决定是否隐藏，并清零 Unread（不鼓红点）。
+			if hasState {
+				it.Status = intentToStatus(state.ArchiveIntent)
+			} // else 保持已回填的全局 status（P3）
+			it.Unread = 0
+			// 若静音后 effective 为归档隐藏，Unread 已是 0；若可见也不鼓红点。
+		case hasP1:
+			// P1 强制可见：拉回 active，保留 Unread（红点）。
+			it.Status = thread.ThreadStatusActive
+		case hasState:
+			// P2 本人手工意图。
+			it.Status = intentToStatus(state.ArchiveIntent)
+			if it.Status == thread.ThreadStatusArchived {
+				it.Unread = 0 // T4：归档隐藏条目 Unread 清零
+			}
+		default:
+			// P3：保持已回填的全局 status。若全局归档也清零 Unread，保持列表内一致。
+			if it.Status == thread.ThreadStatusArchived {
+				it.Unread = 0
+			}
+		}
+	}
+}
+
+// intentToStatus 把 thread_user_state.archive_intent 映射到契约 status 线值。
+// intent==1 → 2(archived)；否则 → 1(active)。钉死 1 基线值，不新增线值。
+func intentToStatus(intent int) int {
+	if intent == 1 {
+		return thread.ThreadStatusArchived
+	}
+	return thread.ThreadStatusActive
 }
 
 // ---------------------------------------------------------------------------

--- a/modules/message/api_sidebar_peruser_test.go
+++ b/modules/message/api_sidebar_peruser_test.go
@@ -1,0 +1,309 @@
+//go:build integration
+
+package message
+
+// =============================================================================
+// Sidebar per-user thread visibility — DB-backed tests (plan T3/T4)
+//
+// computeEffectiveStatus runs the four-level arbitration MUTE > P1 > P2 > P3 and
+// folds in the T4 Unread second filter. These tests seed real thread rows,
+// thread_setting (mute), thread_user_state (archive_intent) and reminders /
+// reminder_done (P1 unhandled per-uid @), then drive the same helper Sidebar.Sync
+// uses (flag=on path). flag=off equivalence is covered separately.
+//
+// Build-tagged `integration` like api_sidebar_status_test.go: these spin up
+// testutil.NewTestServer against the shared `test` DB.
+// =============================================================================
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	"github.com/Mininglamp-OSS/octo-server/modules/thread"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// setupPerUserEnv sets the env the message-package test server needs before
+// NewTestServer: OCTO_MASTER_KEY (common.Setup requires it) and DM_THREAD_ON
+// (thread API + migrations apply cleanly). Must be called first in each test.
+func setupPerUserEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv("OCTO_MASTER_KEY", "0123456789abcdef0123456789abcdef")
+	t.Setenv("DM_THREAD_ON", "true")
+}
+
+// seedUserArchiveIntent writes a per-user archive intent row via the thread DB.
+func seedUserArchiveIntent(t *testing.T, ctx *config.Context, uid, groupNo, shortID string, intent int) {
+	t.Helper()
+	tdb := thread.NewDB(ctx)
+	tx, err := ctx.DB().Begin()
+	require.NoError(t, err)
+	require.NoError(t, tdb.UpsertArchiveIntentTx(tx, uid, groupNo, shortID, intent, 1))
+	require.NoError(t, tx.Commit())
+}
+
+// seedMute writes a per-user mute setting via the thread DB.
+func seedMute(t *testing.T, ctx *config.Context, uid, groupNo, shortID string, mute int) {
+	t.Helper()
+	tdb := thread.NewDB(ctx)
+	require.NoError(t, tdb.UpsertSetting(&thread.SettingModel{
+		GroupNo: groupNo, ShortID: shortID, UID: uid, Mute: mute, Version: 1,
+	}))
+}
+
+// seedReminder inserts a reminders row for a thread channel (channel_type=5).
+// uid="" means an @所有人 broadcast (must NOT trigger P1 for individuals).
+func seedReminder(t *testing.T, ctx *config.Context, uid, groupNo, shortID string) int64 {
+	t.Helper()
+	channelID := groupNo + "____" + shortID
+	res, err := ctx.DB().InsertBySql(
+		"INSERT INTO reminders (channel_id, channel_type, reminder_type, uid, is_deleted, version) VALUES (?,?,?,?,0,1)",
+		channelID, uint8(common.ChannelTypeCommunityTopic), 1, uid,
+	).Exec()
+	require.NoError(t, err)
+	id, err := res.LastInsertId()
+	require.NoError(t, err)
+	return id
+}
+
+// markReminderDone inserts a reminder_done row for (reminderID, uid).
+func markReminderDone(t *testing.T, ctx *config.Context, reminderID int64, uid string) {
+	t.Helper()
+	_, err := ctx.DB().InsertBySql(
+		"INSERT INTO reminder_done (reminder_id, uid) VALUES (?,?)", reminderID, uid,
+	).Exec()
+	require.NoError(t, err)
+}
+
+func threadItem(groupNo, shortID string, unread int) *SidebarItem {
+	return &SidebarItem{
+		TargetType: int(common.ChannelTypeCommunityTopic),
+		TargetID:   groupNo + "____" + shortID,
+		Unread:     unread,
+	}
+}
+
+// itemByID finds a SidebarItem by TargetID.
+func itemByID(items []*SidebarItem, targetID string) *SidebarItem {
+	for _, it := range items {
+		if it.TargetID == targetID {
+			return it
+		}
+	}
+	return nil
+}
+
+// TestComputeEffectiveStatus_PerUserIsolation — gate 1: 子区内 @Alice 未处理 →
+// Alice effective status=1；同群未被@的 Bob effective status=2（手工归档）。
+// uid='' 广播不触发 P1。
+func TestComputeEffectiveStatus_PerUserIsolation(t *testing.T) {
+	setupPerUserEnv(t)
+	_, ctx := testutil.NewTestServer()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+
+	const g = "gp1"
+	now := time.Now().Add(-time.Hour)
+	seedThread(t, ctx, g, "t1", thread.ThreadStatusActive, &now)
+
+	// Alice 有未处理 per-uid @；Bob 手工归档了 t1。
+	seedReminder(t, ctx, "alice", g, "t1")
+	seedUserArchiveIntent(t, ctx, "bob", g, "t1", 1)
+	// @所有人 广播（uid=''）——不该把任何人拉成 P1。
+	seedReminder(t, ctx, "", g, "t1")
+
+	sb := NewSidebar(ctx)
+	statusMap := map[string]int{threadChannelID(g, "t1"): thread.ThreadStatusActive}
+
+	// Alice 视角：P1 命中 → active。
+	aliceItems := []*SidebarItem{threadItem(g, "t1", 3)}
+	sb.computeEffectiveStatus("alice", aliceItems, statusMap)
+	assert.Equal(t, thread.ThreadStatusActive, itemByID(aliceItems, threadChannelID(g, "t1")).Status)
+	assert.Equal(t, 3, itemByID(aliceItems, threadChannelID(g, "t1")).Unread, "P1 keeps unread")
+
+	// Bob 视角：无 P1、有 archive_intent → archived + Unread 清零。
+	bobItems := []*SidebarItem{threadItem(g, "t1", 5)}
+	sb.computeEffectiveStatus("bob", bobItems, statusMap)
+	assert.Equal(t, thread.ThreadStatusArchived, itemByID(bobItems, threadChannelID(g, "t1")).Status)
+	assert.Equal(t, 0, itemByID(bobItems, threadChannelID(g, "t1")).Unread, "archived-hidden -> unread 0")
+
+	// Carol 视角：无 P1/P2 → 回落全局 status (active)。
+	carolItems := []*SidebarItem{threadItem(g, "t1", 2)}
+	sb.computeEffectiveStatus("carol", carolItems, statusMap)
+	assert.Equal(t, thread.ThreadStatusActive, itemByID(carolItems, threadChannelID(g, "t1")).Status)
+}
+
+// TestComputeEffectiveStatus_NoFlapping — gate 1: 连续多轮 sync（模拟 worker 只改全局 P3）
+// 同一 uid 可见性不翻烧饼。
+func TestComputeEffectiveStatus_NoFlapping(t *testing.T) {
+	setupPerUserEnv(t)
+	_, ctx := testutil.NewTestServer()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+
+	const g = "gp2"
+	now := time.Now().Add(-time.Hour)
+	seedThread(t, ctx, g, "t1", thread.ThreadStatusActive, &now)
+	seedReminder(t, ctx, "alice", g, "t1") // Alice 有未处理@
+
+	sb := NewSidebar(ctx)
+	// worker 把全局 status 翻来覆去（P3），Alice 的 P1 应稳定压过它。
+	for _, globalStatus := range []int{1, 2, 1, 2, 2} {
+		items := []*SidebarItem{threadItem(g, "t1", 1)}
+		statusMap := map[string]int{threadChannelID(g, "t1"): globalStatus}
+		sb.computeEffectiveStatus("alice", items, statusMap)
+		assert.Equal(t, thread.ThreadStatusActive, itemByID(items, threadChannelID(g, "t1")).Status,
+			"P1 must stay active regardless of global status churn (global=%d)", globalStatus)
+	}
+}
+
+// TestComputeEffectiveStatus_MuteOverP1 — gate 2: Alice 静音且有未处理@ →
+// 不被 P1 强制拉成 active、Unread 清零（suppressBadge）。
+func TestComputeEffectiveStatus_MuteOverP1(t *testing.T) {
+	setupPerUserEnv(t)
+	_, ctx := testutil.NewTestServer()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+
+	const g = "gp3"
+	now := time.Now().Add(-time.Hour)
+	seedThread(t, ctx, g, "t1", thread.ThreadStatusArchived, &now) // 全局归档
+
+	seedReminder(t, ctx, "alice", g, "t1") // 有未处理@（P1）
+	seedMute(t, ctx, "alice", g, "t1", 1)  // 但静音
+
+	sb := NewSidebar(ctx)
+	statusMap := map[string]int{threadChannelID(g, "t1"): thread.ThreadStatusArchived}
+	items := []*SidebarItem{threadItem(g, "t1", 4)}
+	sb.computeEffectiveStatus("alice", items, statusMap)
+
+	got := itemByID(items, threadChannelID(g, "t1"))
+	// MUTE 压过 P1：不被强制拉成 active，走 P3（全局 archived），且 Unread 清零。
+	assert.Equal(t, thread.ThreadStatusArchived, got.Status, "mute suppresses P1 forced-visible")
+	assert.Equal(t, 0, got.Unread, "mute suppresses badge -> unread 0")
+}
+
+// TestComputeEffectiveStatus_MuteWithIntent — MUTE + 本人手工归档意图：静音走 P2。
+func TestComputeEffectiveStatus_MuteWithIntent(t *testing.T) {
+	setupPerUserEnv(t)
+	_, ctx := testutil.NewTestServer()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+
+	const g = "gp3b"
+	now := time.Now().Add(-time.Hour)
+	seedThread(t, ctx, g, "t1", thread.ThreadStatusActive, &now)
+	seedReminder(t, ctx, "alice", g, "t1")            // P1
+	seedMute(t, ctx, "alice", g, "t1", 1)             // 静音
+	seedUserArchiveIntent(t, ctx, "alice", g, "t1", 1) // 本人归档意图
+
+	sb := NewSidebar(ctx)
+	statusMap := map[string]int{threadChannelID(g, "t1"): thread.ThreadStatusActive}
+	items := []*SidebarItem{threadItem(g, "t1", 4)}
+	sb.computeEffectiveStatus("alice", items, statusMap)
+
+	got := itemByID(items, threadChannelID(g, "t1"))
+	assert.Equal(t, thread.ThreadStatusArchived, got.Status, "mute -> P2 intent archived")
+	assert.Equal(t, 0, got.Unread)
+}
+
+// TestComputeEffectiveStatus_P1AfterDone — reminder_done 后 P1 消失，回落 P2/P3。
+func TestComputeEffectiveStatus_P1AfterDone(t *testing.T) {
+	setupPerUserEnv(t)
+	_, ctx := testutil.NewTestServer()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+
+	const g = "gp4"
+	now := time.Now().Add(-time.Hour)
+	seedThread(t, ctx, g, "t1", thread.ThreadStatusActive, &now)
+	seedUserArchiveIntent(t, ctx, "alice", g, "t1", 1) // 本人已归档
+	rid := seedReminder(t, ctx, "alice", g, "t1")      // 但有未处理@ → P1 拉回
+
+	sb := NewSidebar(ctx)
+	statusMap := map[string]int{threadChannelID(g, "t1"): thread.ThreadStatusActive}
+
+	// done 前：P1 压过 intent → active。
+	items := []*SidebarItem{threadItem(g, "t1", 2)}
+	sb.computeEffectiveStatus("alice", items, statusMap)
+	assert.Equal(t, thread.ThreadStatusActive, itemByID(items, threadChannelID(g, "t1")).Status)
+
+	// done 后：P1 消失 → 回落 P2 (archived) + Unread 清零。
+	markReminderDone(t, ctx, rid, "alice")
+	items = []*SidebarItem{threadItem(g, "t1", 2)}
+	sb.computeEffectiveStatus("alice", items, statusMap)
+	got := itemByID(items, threadChannelID(g, "t1"))
+	assert.Equal(t, thread.ThreadStatusArchived, got.Status, "after done, fall back to intent archived")
+	assert.Equal(t, 0, got.Unread)
+}
+
+// TestComputeEffectiveStatus_FailOpen — gate 4: per-uid 查询失败 → 保持全局 status（不隐藏）。
+// 这里用 loginUID="" 触发的早退 + 空 refs 场景验证 fail-open 回落到 backfill。
+func TestComputeEffectiveStatus_FailOpenEmptyUID(t *testing.T) {
+	setupPerUserEnv(t)
+	_, ctx := testutil.NewTestServer()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+
+	const g = "gp5"
+	sb := NewSidebar(ctx)
+	statusMap := map[string]int{threadChannelID(g, "t1"): thread.ThreadStatusArchived}
+	items := []*SidebarItem{threadItem(g, "t1", 7)}
+	// loginUID 空 → fail-open：回落全局 status，Unread 不动（除非全局归档）。
+	sb.computeEffectiveStatus("", items, statusMap)
+	got := itemByID(items, threadChannelID(g, "t1"))
+	assert.Equal(t, thread.ThreadStatusArchived, got.Status, "empty uid falls back to global status")
+}
+
+// TestComputeEffectiveStatus_EmptyTableFallback — gate 4b: thread_user_state 空表 →
+// 所有 thread 回落全局 status（== 现状），零回填。
+func TestComputeEffectiveStatus_EmptyTableFallback(t *testing.T) {
+	setupPerUserEnv(t)
+	_, ctx := testutil.NewTestServer()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+
+	const g = "gp6"
+	now := time.Now().Add(-time.Hour)
+	seedThread(t, ctx, g, "t1", thread.ThreadStatusActive, &now)
+	seedThread(t, ctx, g, "t2", thread.ThreadStatusArchived, &now)
+
+	sb := NewSidebar(ctx)
+	statusMap := map[string]int{
+		threadChannelID(g, "t1"): thread.ThreadStatusActive,
+		threadChannelID(g, "t2"): thread.ThreadStatusArchived,
+	}
+	items := []*SidebarItem{threadItem(g, "t1", 1), threadItem(g, "t2", 2)}
+	sb.computeEffectiveStatus("nobody", items, statusMap)
+
+	assert.Equal(t, thread.ThreadStatusActive, itemByID(items, threadChannelID(g, "t1")).Status)
+	assert.Equal(t, thread.ThreadStatusArchived, itemByID(items, threadChannelID(g, "t2")).Status)
+	// 全局归档条目在列表内 Unread 清零（列表内一致）。
+	assert.Equal(t, 0, itemByID(items, threadChannelID(g, "t2")).Unread)
+}
+
+// TestComputeEffectiveStatus_UnreadSecondFilter — gate 3: per-user 归档隐藏条目 Unread=0；
+// P1 拉回可见条目 Unread 保留。
+func TestComputeEffectiveStatus_UnreadSecondFilter(t *testing.T) {
+	setupPerUserEnv(t)
+	_, ctx := testutil.NewTestServer()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+
+	const g = "gp7"
+	now := time.Now().Add(-time.Hour)
+	seedThread(t, ctx, g, "hidden", thread.ThreadStatusActive, &now)
+	seedThread(t, ctx, g, "pulled", thread.ThreadStatusActive, &now)
+
+	seedUserArchiveIntent(t, ctx, "alice", g, "hidden", 1) // 归档隐藏
+	seedReminder(t, ctx, "alice", g, "pulled")             // P1 拉回
+
+	sb := NewSidebar(ctx)
+	statusMap := map[string]int{
+		threadChannelID(g, "hidden"): thread.ThreadStatusActive,
+		threadChannelID(g, "pulled"): thread.ThreadStatusActive,
+	}
+	items := []*SidebarItem{threadItem(g, "hidden", 9), threadItem(g, "pulled", 6)}
+	sb.computeEffectiveStatus("alice", items, statusMap)
+
+	assert.Equal(t, 0, itemByID(items, threadChannelID(g, "hidden")).Unread, "archived-hidden unread zeroed")
+	assert.Equal(t, thread.ThreadStatusArchived, itemByID(items, threadChannelID(g, "hidden")).Status)
+	assert.Equal(t, 6, itemByID(items, threadChannelID(g, "pulled")).Unread, "P1 pulled item keeps unread")
+	assert.Equal(t, thread.ThreadStatusActive, itemByID(items, threadChannelID(g, "pulled")).Status)
+}

--- a/modules/message/db_reminders.go
+++ b/modules/message/db_reminders.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/Mininglamp-OSS/octo-lib/common"
 	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/db"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
@@ -67,10 +68,42 @@ func (r *remindersDB) queryWithUIDAndChannel(uid string, channelID string, chann
 	return list, err
 }
 
+// queryUnhandledMentionChannels 批量查询「本人有未处理 per-uid @」的子区 channel_id 集合（plan T3 P1）。
+//
+// P1 定义（四级仲裁的强制可见级）：reminders LEFT JOIN reminder_done，channel_type=5，
+// uid=本人（per-uid @；@所有人 uid='' 不触发），is_deleted=0，且 reminder_done 无对应行（未 done）。
+//
+// SQL uid 打头（WHERE r.uid=?）以命中现有索引 channel_uid_uidx (uid, channel_id, channel_type)
+// 的 (uid, channel_id) 前缀（plan F8/R4），不新增 reminders 索引。
+// channelIDs 形如 "{groupNo}____{shortID}"。空入参返回空 set、不发查询。
+//
+// 返回集合语义：key 存在 = 该子区对本 uid 有未处理 @（强制可见）。
+func (r *remindersDB) queryUnhandledMentionChannels(uid string, channelIDs []string) (map[string]struct{}, error) {
+	result := make(map[string]struct{}, len(channelIDs))
+	if uid == "" || len(channelIDs) == 0 {
+		return result, nil
+	}
+	var hits []string
+	_, err := r.session.
+		Select("r.channel_id").
+		From(dbr.I("reminders").As("r")).
+		LeftJoin(dbr.I("reminder_done").As("d"), dbr.Expr("d.reminder_id = r.id AND d.uid = ?", uid)).
+		Where("r.uid = ?", uid). // uid 打头命中 channel_uid_uidx；per-uid 排除 @所有人(uid='')
+		Where("r.channel_id IN ?", channelIDs).
+		Where("r.channel_type = ?", uint8(common.ChannelTypeCommunityTopic)).
+		Where("r.is_deleted = 0").
+		Where("d.id IS NULL"). // 未 done
+		Load(&hits)
+	if err != nil {
+		return nil, fmt.Errorf("query unhandled mention channels: %w", err)
+	}
+	for _, ch := range hits {
+		result[ch] = struct{}{}
+	}
+	return result, nil
+}
+
 /*
-*
-同步提醒项
-@param uid 当前登录用户的uid
 @param version 以uid为key的增量版本号
 @param limit 数据限制
 @param channelIDs 频道集合 查询以频道为目标的提醒项
@@ -162,6 +195,27 @@ func (r *remindersDB) batchInsertDonesTx(sortedIds []int64, uid string, tx *dbr.
 func (r *remindersDB) updateVersionTx(version int64, id int64, tx *dbr.Tx) error {
 	_, err := tx.Update("reminders").Set("version", version).Where("id=?", id).Exec()
 	return err
+}
+
+// queryThreadChannelsByIDsTx 在 tx 内按 reminder id 列表反查「本人 per-uid 且属于子区
+// (channel_type=5)」的 reminder 行的去重 channel_id 集合（plan T5）。
+// channel_id 形如 "{groupNo}____{shortID}"。用于 reminder_done 后按子区 bump follow_version。
+// 只取 uid=本人（per-uid @）、channel_type=5 的行；@所有人(uid='')与非子区 reminder 天然排除。
+func (r *remindersDB) queryThreadChannelsByIDsTx(tx *dbr.Tx, ids []int64, uid string) ([]string, error) {
+	if len(ids) == 0 || uid == "" {
+		return nil, nil
+	}
+	var channelIDs []string
+	_, err := tx.Select("DISTINCT channel_id").
+		From("reminders").
+		Where("id IN ?", ids).
+		Where("uid = ?", uid).
+		Where("channel_type = ?", uint8(common.ChannelTypeCommunityTopic)).
+		Load(&channelIDs)
+	if err != nil {
+		return nil, fmt.Errorf("query thread channels by reminder ids: %w", err)
+	}
+	return channelIDs, nil
 }
 
 type remindersDetailModel struct {

--- a/modules/message/thread_visibility_bump.go
+++ b/modules/message/thread_visibility_bump.go
@@ -1,0 +1,114 @@
+package message
+
+// Per-user thread visibility follow_version bump helpers (plan T5/T6).
+//
+// 背景：客户端只观察 follow_version 感知「自己的 follow 列表/可见性变了」。per-user
+// 归档相关写路径（写 reminder_done / 写 reminder / 写 archive_intent）都要在事务里
+// bump 被影响 uid 的 follow_version，客户端才会重新拉 sidebar 跑仲裁。
+//
+// 锁序铁律（plan F3/R3）：新写路径同 tx 若碰 conversation_ext，必须先对 user_follow_version
+// 加锁（即先调 BumpFollowVersionTx）再碰 user_conversation_ext。这里只 bump，不碰 ext 行，
+// 但仍统一走 BumpFollowVersionTx 以复用其 INSERT ... ON DUPLICATE KEY 幂等语义。
+
+import (
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	convext "github.com/Mininglamp-OSS/octo-server/modules/conversation_ext"
+	"github.com/Mininglamp-OSS/octo-server/modules/thread"
+	"github.com/gocraft/dbr/v2"
+	"go.uber.org/zap"
+)
+
+// resolveSpaceIDForGroup 把 groupNo 解析成 space_id（复用 groupService.GetGroupWithGroupNo）。
+// 群不存在 / 无 space_id 时返回空串（follow_version 表按 (uid, space_id) 建行，空 space 亦合法）。
+func (m *Message) resolveSpaceIDForGroup(groupNo string) string {
+	if groupNo == "" {
+		return ""
+	}
+	info, err := m.groupService.GetGroupWithGroupNo(groupNo)
+	if err != nil || info == nil {
+		return ""
+	}
+	return info.SpaceID
+}
+
+// bumpFollowVersionForThreadChannelsTx 对一批 thread channel_id（"{groupNo}____{shortID}"）
+// 解析出 space_id 后，在同一 tx 内 bump (uid, space_id) 的 follow_version（去重每个 space 只 bump 一次）。
+// 用于 reminder_done 侧（T5）。channel_id 解析失败的条目跳过（不阻断核心写）。
+func (m *Message) bumpFollowVersionForThreadChannelsTx(tx *dbr.Tx, uid string, channelIDs []string) error {
+	if uid == "" || len(channelIDs) == 0 {
+		return nil
+	}
+	bumped := make(map[string]struct{})
+	for _, ch := range channelIDs {
+		groupNo, _, err := thread.ParseChannelID(ch)
+		if err != nil {
+			continue
+		}
+		spaceID := m.resolveSpaceIDForGroup(groupNo)
+		if _, ok := bumped[spaceID]; ok {
+			continue
+		}
+		if _, err := convext.BumpFollowVersionTx(tx, uid, spaceID); err != nil {
+			return err
+		}
+		bumped[spaceID] = struct{}{}
+	}
+	return nil
+}
+
+// bumpFollowVersionForReminders 是 reminder 触发侧 bump（plan T6）的同步内核：
+// 对每条 per-uid（uid≠''）且属于子区（channel_type=5）的新 reminder，bump 被@uid 的
+// follow_version。@所有人(uid='')不 bump。
+//
+// 关键约束（plan T6/R2，顾问共识）：**绝不把本 bump 包进 handleReminders 的核心写 tx**。
+// 消息入库是高频核心链路，bump 是边缘 UI 链路。这里每个 (uid, space) 各自独立短 tx、
+// 失败只 warn，绝不影响消息投递。调用方（handleReminders）以 fire-and-forget goroutine 调用它。
+func (m *Message) bumpFollowVersionForReminders(reminders []*remindersModel) {
+	if !thread.PerUserVisibilityEnabled() || len(reminders) == 0 {
+		return
+	}
+	// fire-and-forget 在独立 goroutine 里跑：任何 panic 都必须就地 recover，否则会拖垮整个进程
+	// （与 remindersDB.inserts / reminderDone 的 recover 惯例一致）。
+	defer func() {
+		if r := recover(); r != nil {
+			m.Warn("T6 bump: recovered panic (non-fatal)", zap.Any("panic", r))
+		}
+	}()
+	// 去重 (uid, space)：同一被@人在同 space 多子区只 bump 一次。
+	type key struct{ uid, space string }
+	seen := make(map[key]struct{})
+	for _, r := range reminders {
+		if r == nil || r.UID == "" { // 广播 uid='' 不 bump
+			continue
+		}
+		if r.ChannelType != uint8(common.ChannelTypeCommunityTopic) {
+			continue // 只处理子区 reminder
+		}
+		groupNo, _, err := thread.ParseChannelID(r.ChannelID)
+		if err != nil {
+			continue
+		}
+		spaceID := m.resolveSpaceIDForGroup(groupNo)
+		k := key{uid: r.UID, space: spaceID}
+		if _, ok := seen[k]; ok {
+			continue
+		}
+		seen[k] = struct{}{}
+
+		// 各自独立短 tx，失败只 warn（fire-and-forget 语义，不阻断消息投递）。
+		tx, err := m.ctx.DB().Begin()
+		if err != nil {
+			m.Warn("T6 bump: begin tx failed (non-fatal)", zap.Error(err), zap.String("uid", r.UID))
+			continue
+		}
+		if _, err := convext.BumpFollowVersionTx(tx, r.UID, spaceID); err != nil {
+			tx.RollbackUnlessCommitted()
+			m.Warn("T6 bump: BumpFollowVersionTx failed (non-fatal)", zap.Error(err), zap.String("uid", r.UID))
+			continue
+		}
+		if err := tx.Commit(); err != nil {
+			tx.RollbackUnlessCommitted()
+			m.Warn("T6 bump: commit failed (non-fatal)", zap.Error(err), zap.String("uid", r.UID))
+		}
+	}
+}

--- a/modules/message/thread_visibility_bump_test.go
+++ b/modules/message/thread_visibility_bump_test.go
@@ -1,0 +1,138 @@
+//go:build integration
+
+package message
+
+// =============================================================================
+// Per-user thread visibility follow_version bump — DB-backed tests (plan T5/T6).
+//
+// gate 2 (partial): reminder_done (T5) 后 (uid, space) follow_version +1；
+// reminder 触发侧 (T6) 新 per-uid @ 后 (被@uid, space) follow_version +1，@所有人(uid='')不 bump。
+// =============================================================================
+
+import (
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	convext "github.com/Mininglamp-OSS/octo-server/modules/conversation_ext"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestReminderDoneBump_T5 verifies reminder_done 侧 bump（T5）：
+// done 掉一个子区 per-uid @ 后，(loginUID, space) follow_version +1（空 space 也算一次）。
+func TestReminderDoneBump_T5(t *testing.T) {
+	setupPerUserEnv(t)
+	_, ctx := testutil.NewTestServer()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+
+	m := New(ctx)
+	fvDB := convext.NewFollowVersionDB(ctx)
+
+	const g = "gt5"
+	uid := "alice"
+	// seed 一个子区 per-uid @ reminder（channel_type=5）。
+	rid := seedReminder(t, ctx, uid, g, "t1")
+
+	// group 不存在 → space 解析为空串；bump 落在 (uid, "").
+	before, err := fvDB.Get(uid, "")
+	require.NoError(t, err)
+
+	tx, err := ctx.DB().Begin()
+	require.NoError(t, err)
+	chs, err := m.remindersDB.queryThreadChannelsByIDsTx(tx, []int64{rid}, uid)
+	require.NoError(t, err)
+	require.Contains(t, chs, g+"____t1")
+	require.NoError(t, m.bumpFollowVersionForThreadChannelsTx(tx, uid, chs))
+	require.NoError(t, tx.Commit())
+
+	after, err := fvDB.Get(uid, "")
+	require.NoError(t, err)
+	assert.Equal(t, before+1, after, "reminder_done bumps (uid, space) follow_version by 1")
+}
+
+// TestReminderDoneBump_DedupPerSpace verifies 多个同 space 子区 done 只 bump 一次。
+func TestReminderDoneBump_DedupPerSpace(t *testing.T) {
+	setupPerUserEnv(t)
+	_, ctx := testutil.NewTestServer()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+
+	m := New(ctx)
+	fvDB := convext.NewFollowVersionDB(ctx)
+
+	const g = "gt5b"
+	uid := "bob"
+	r1 := seedReminder(t, ctx, uid, g, "t1")
+	r2 := seedReminder(t, ctx, uid, g, "t2") // 同群 → 同 space
+
+	before, err := fvDB.Get(uid, "")
+	require.NoError(t, err)
+
+	tx, err := ctx.DB().Begin()
+	require.NoError(t, err)
+	chs, err := m.remindersDB.queryThreadChannelsByIDsTx(tx, []int64{r1, r2}, uid)
+	require.NoError(t, err)
+	require.Len(t, chs, 2)
+	require.NoError(t, m.bumpFollowVersionForThreadChannelsTx(tx, uid, chs))
+	require.NoError(t, tx.Commit())
+
+	after, err := fvDB.Get(uid, "")
+	require.NoError(t, err)
+	assert.Equal(t, before+1, after, "two threads in same space bump follow_version only once")
+}
+
+// TestReminderDoneBump_BroadcastExcluded verifies @所有人(uid='')的 reminder
+// 不会被 queryThreadChannelsByIDsTx 当成本人 per-uid @（不 bump）。
+func TestReminderDoneBump_BroadcastExcluded(t *testing.T) {
+	setupPerUserEnv(t)
+	_, ctx := testutil.NewTestServer()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+
+	m := New(ctx)
+
+	const g = "gt5c"
+	// 广播 reminder（uid=''）。
+	rid := seedReminder(t, ctx, "", g, "t1")
+
+	tx, err := ctx.DB().Begin()
+	require.NoError(t, err)
+	// 以 alice 身份反查：广播行 uid='' ≠ alice，不返回。
+	chs, err := m.remindersDB.queryThreadChannelsByIDsTx(tx, []int64{rid}, "alice")
+	require.NoError(t, err)
+	require.NoError(t, tx.Commit())
+	assert.Empty(t, chs, "broadcast (uid='') must not be treated as alice's per-uid @")
+}
+
+// TestReminderTriggerBump_T6 verifies reminder 触发侧 bump（T6）：
+// handleRemindersVisibilityBump 对 per-uid @（uid≠''）落 reminder 后 bump 被@uid follow_version；
+// @所有人(uid='')不 bump。用 fire-and-forget 的同步内核 bumpFollowVersionForReminders 验证。
+func TestReminderTriggerBump_T6(t *testing.T) {
+	setupPerUserEnv(t)
+	t.Setenv("DM_THREAD_PERUSER_VISIBILITY", "true") // T6 内核自判 flag，需开启
+	_, ctx := testutil.NewTestServer()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+
+	m := New(ctx)
+	fvDB := convext.NewFollowVersionDB(ctx)
+
+	const g = "gt6"
+	reminders := []*remindersModel{
+		{ChannelID: g + "____t1", ChannelType: uint8(common.ChannelTypeCommunityTopic), UID: "carol", ReminderType: 1},
+		{ChannelID: g + "____t1", ChannelType: uint8(common.ChannelTypeCommunityTopic), UID: "", ReminderType: 1}, // 广播
+	}
+
+	beforeCarol, err := fvDB.Get("carol", "")
+	require.NoError(t, err)
+
+	// 直接调同步内核（生产是 fire-and-forget 包一层 goroutine）。
+	m.bumpFollowVersionForReminders(reminders)
+
+	afterCarol, err := fvDB.Get("carol", "")
+	require.NoError(t, err)
+	assert.Equal(t, beforeCarol+1, afterCarol, "per-uid @ bumps the mentioned user's follow_version")
+
+	// 广播 uid='' 不产生任何 (,'') 之外的 bump —— 断言空 uid 不写。
+	emptyUIDVer, err := fvDB.Get("", "")
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), emptyUIDVer, "broadcast (uid='') must not bump")
+}

--- a/modules/thread/archive_config.go
+++ b/modules/thread/archive_config.go
@@ -7,6 +7,19 @@ import (
 	"time"
 )
 
+// envPerUserVisibility 是「按用户子区可见性」总开关（plan feature flag）。
+// 默认 off：off 时读路径走全局 status、写路径不写 thread_user_state、不新增
+// follow_version bump（除既有 category bump），行为逐字等于现状。回退=翻 flag。
+const envPerUserVisibility = "DM_THREAD_PERUSER_VISIBILITY"
+
+// PerUserVisibilityEnabled 报告 per-user 子区可见性 feature flag 是否开启。
+// 读 env DM_THREAD_PERUSER_VISIBILITY（"true"/"1" 为开），默认 off。
+// 读路径（message.computeEffectiveStatus）与写路径（reminder_done / reminder 触发 /
+// Archive/Unarchive / detail）每步入口先判本 flag，off 分支必须等于现状。
+func PerUserVisibilityEnabled() bool {
+	return parseBool(os.Getenv(envPerUserVisibility))
+}
+
 // ArchiveConfig 子区自动归档 worker 的运行参数。
 type ArchiveConfig struct {
 	// Enabled 总开关。disabled 时 worker 不启动 ticker。

--- a/modules/thread/db_user_state.go
+++ b/modules/thread/db_user_state.go
@@ -1,0 +1,151 @@
+package thread
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/db"
+	"github.com/gocraft/dbr/v2"
+)
+
+// UserStateModel 映射 thread_user_state 表：子区「按用户」的可见性状态。
+// 承载四级仲裁里的 P2（本人手工归档意图）。read_intent_at 为未来 mute/read 并入预留。
+type UserStateModel struct {
+	UID             string     `db:"uid"`
+	GroupNo         string     `db:"group_no"`
+	ShortID         string     `db:"short_id"`
+	ArchiveIntent   int        `db:"archive_intent"`
+	ArchiveIntentAt *time.Time `db:"archive_intent_at"`
+	ReadIntentAt    *time.Time `db:"read_intent_at"`
+	Version         int64      `db:"version"`
+	db.BaseModel
+}
+
+// QueryUserStates 批量查询「一个 uid × 多 thread」的 per-user 状态。
+// 键为 "{groupNo}____{shortID}"（与 thread 条目 TargetID / QueryActiveByGroupShortIDs
+// 同口径）。无对应行的键不出现在 map 中，调用方按零值（未归档，回落全局）判定。
+// refs 为空时返回空 map、不发查询。
+func (d *DB) QueryUserStates(uid string, refs []ShortRef) (map[string]*UserStateModel, error) {
+	result := make(map[string]*UserStateModel, len(refs))
+	if uid == "" || len(refs) == 0 {
+		return result, nil
+	}
+	placeholders := make([]string, len(refs))
+	args := make([]interface{}, 0, 1+len(refs)*2)
+	args = append(args, uid)
+	for i, r := range refs {
+		placeholders[i] = "(?, ?)"
+		args = append(args, r.GroupNo, r.ShortID)
+	}
+	var rows []*UserStateModel
+	_, err := d.session.SelectBySql(
+		"SELECT uid, group_no, short_id, archive_intent, archive_intent_at, read_intent_at, version"+
+			" FROM thread_user_state"+
+			" WHERE uid = ? AND (group_no, short_id) IN ("+strings.Join(placeholders, ", ")+")",
+		args...,
+	).Load(&rows)
+	if err != nil {
+		return nil, fmt.Errorf("query thread_user_state by uid+refs: %w", err)
+	}
+	for _, r := range rows {
+		result[r.GroupNo+"____"+r.ShortID] = r
+	}
+	return result, nil
+}
+
+// UpsertArchiveIntentTx 在 tx 内按 (uid, group_no, short_id) 幂等写入归档意图。
+// intent: 0=未归档 1=已归档(本人)。version 由调用方传（复用 thread 版本号发号器）。
+// 照 UpsertSetting 惯例用 INSERT ... ON DUPLICATE KEY UPDATE，避免并发 read-then-write 竞态。
+func (d *DB) UpsertArchiveIntentTx(tx *dbr.Tx, uid, groupNo, shortID string, intent int, version int64) error {
+	_, err := tx.InsertBySql(
+		"INSERT INTO thread_user_state (uid, group_no, short_id, archive_intent, archive_intent_at, version)"+
+			" VALUES (?, ?, ?, ?, CURRENT_TIMESTAMP, ?)"+
+			" ON DUPLICATE KEY UPDATE archive_intent=VALUES(archive_intent),"+
+			" archive_intent_at=CURRENT_TIMESTAMP, version=VALUES(version)",
+		uid, groupNo, shortID, intent, version,
+	).Exec()
+	if err != nil {
+		return fmt.Errorf("upsert thread_user_state archive_intent: %w", err)
+	}
+	return nil
+}
+
+// DeleteUserStatesForThread 按 (group_no, short_id) 删除某子区所有用户的状态行，
+// 走 idx_thread。用于 DeleteThread / 退群清理，避免孤儿行膨胀（plan T-GC）。
+func (d *DB) DeleteUserStatesForThread(groupNo, shortID string) error {
+	_, err := d.session.DeleteFrom("thread_user_state").
+		Where("group_no=? AND short_id=?", groupNo, shortID).Exec()
+	if err != nil {
+		return fmt.Errorf("delete thread_user_state for thread: %w", err)
+	}
+	return nil
+}
+
+// QueryMuteForUID 批量查询「一个 uid × 多 thread」的 mute 设置。
+// 键为 "{groupNo}____{shortID}"，值为 mute（0/1）。
+//
+// 注意：现有 QuerySettingsWithUIDs 是「一个 thread × 多 uid」形状（db.go），与本批
+// 四级仲裁需要的「一个 uid × 多 thread」正交，故新增本 helper（plan F6/T2）。
+// refs 为空返回空 map、不发查询。
+func (d *DB) QueryMuteForUID(uid string, refs []ShortRef) (map[string]int, error) {
+	result := make(map[string]int, len(refs))
+	if uid == "" || len(refs) == 0 {
+		return result, nil
+	}
+	placeholders := make([]string, len(refs))
+	args := make([]interface{}, 0, 1+len(refs)*2)
+	args = append(args, uid)
+	for i, r := range refs {
+		placeholders[i] = "(?, ?)"
+		args = append(args, r.GroupNo, r.ShortID)
+	}
+	var rows []*SettingModel
+	_, err := d.session.SelectBySql(
+		"SELECT group_no, short_id, uid, mute, version FROM thread_setting"+
+			" WHERE uid = ? AND (group_no, short_id) IN ("+strings.Join(placeholders, ", ")+")",
+		args...,
+	).Load(&rows)
+	if err != nil {
+		return nil, fmt.Errorf("query thread_setting mute by uid+refs: %w", err)
+	}
+	for _, r := range rows {
+		result[r.GroupNo+"____"+r.ShortID] = r.Mute
+	}
+	return result, nil
+}
+
+// HasUnhandledMention 判断 uid 对某子区是否存在「未处理 per-uid @」（plan T8 P1，detail 端）。
+//
+// 与 message 侧 queryUnhandledMentionChannels 同口径：reminders LEFT JOIN reminder_done，
+// channel_type=5，uid=本人（@所有人 uid='' 不触发），is_deleted=0，reminder_done 无对应行。
+// SQL uid 打头命中现有索引 channel_uid_uidx（plan F8）。
+//
+// detail 端与 list 端同源仲裁（plan T8/R5），但 thread 包不能 import message（会成环），
+// 故在 thread DB 层对同一张 reminders 表做等价 EXISTS 查询。
+func (d *DB) HasUnhandledMention(uid, groupNo, shortID string) (bool, error) {
+	if uid == "" {
+		return false, nil
+	}
+	channelID := groupNo + "____" + shortID
+	var one int
+	err := d.session.SelectBySql(
+		"SELECT 1 FROM reminders r"+
+			" LEFT JOIN reminder_done dn ON dn.reminder_id = r.id AND dn.uid = ?"+
+			" WHERE r.uid = ?"+ // uid 打头命中 channel_uid_uidx；per-uid 排除 @所有人(uid='')
+			" AND r.channel_id = ?"+
+			" AND r.channel_type = ?"+
+			" AND r.is_deleted = 0"+
+			" AND dn.id IS NULL"+
+			" LIMIT 1",
+		uid, uid, channelID, int(common.ChannelTypeCommunityTopic),
+	).LoadOne(&one)
+	if err == dbr.ErrNotFound {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("query unhandled mention (detail): %w", err)
+	}
+	return one == 1, nil
+}

--- a/modules/thread/db_user_state_test.go
+++ b/modules/thread/db_user_state_test.go
@@ -1,0 +1,128 @@
+package thread
+
+import (
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// upsertIntent 是测试内的小工具：开 tx、调 UpsertArchiveIntentTx、提交。
+func upsertIntent(t *testing.T, db *DB, uid, groupNo, shortID string, intent int, version int64) {
+	t.Helper()
+	tx, err := db.session.Begin()
+	require.NoError(t, err)
+	require.NoError(t, db.UpsertArchiveIntentTx(tx, uid, groupNo, shortID, intent, version))
+	require.NoError(t, tx.Commit())
+}
+
+// TestUserStateUpsertAndQuery 覆盖 T2 验证：upsert 幂等 + query 命中/未命中(空 map)。
+func TestUserStateUpsertAndQuery(t *testing.T) {
+	_, ctx := testutil.NewTestServer()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+	db := NewDB(ctx)
+
+	uid := "u_alice"
+	refA := ShortRef{GroupNo: "g1", ShortID: "t1"}
+	refB := ShortRef{GroupNo: "g1", ShortID: "t2"}
+
+	// 未写入前：查询返回空 map（未命中）。
+	got, err := db.QueryUserStates(uid, []ShortRef{refA, refB})
+	require.NoError(t, err)
+	assert.Empty(t, got, "no rows yet")
+
+	// 写归档意图 intent=1。
+	upsertIntent(t, db, uid, refA.GroupNo, refA.ShortID, 1, 10)
+	got, err = db.QueryUserStates(uid, []ShortRef{refA, refB})
+	require.NoError(t, err)
+	require.Contains(t, got, "g1____t1")
+	assert.Equal(t, 1, got["g1____t1"].ArchiveIntent)
+	assert.Equal(t, int64(10), got["g1____t1"].Version)
+	assert.NotContains(t, got, "g1____t2", "t2 never written")
+
+	// 幂等：同键再 upsert 覆盖为 intent=0、version=20，不产生第二行。
+	upsertIntent(t, db, uid, refA.GroupNo, refA.ShortID, 0, 20)
+	got, err = db.QueryUserStates(uid, []ShortRef{refA})
+	require.NoError(t, err)
+	require.Contains(t, got, "g1____t1")
+	assert.Equal(t, 0, got["g1____t1"].ArchiveIntent)
+	assert.Equal(t, int64(20), got["g1____t1"].Version)
+
+	var cnt int
+	_, err = db.session.SelectBySql(
+		"SELECT COUNT(*) FROM thread_user_state WHERE uid=? AND group_no=? AND short_id=?",
+		uid, refA.GroupNo, refA.ShortID,
+	).Load(&cnt)
+	require.NoError(t, err)
+	assert.Equal(t, 1, cnt, "upsert must not create duplicate rows")
+
+	// per-user 隔离：另一个 uid 查同 refs 未命中。
+	got, err = db.QueryUserStates("u_bob", []ShortRef{refA})
+	require.NoError(t, err)
+	assert.Empty(t, got, "bob has no state")
+
+	// 空 refs / 空 uid 短路。
+	got, err = db.QueryUserStates(uid, nil)
+	require.NoError(t, err)
+	assert.Empty(t, got)
+	got, err = db.QueryUserStates("", []ShortRef{refA})
+	require.NoError(t, err)
+	assert.Empty(t, got)
+}
+
+// TestDeleteUserStatesForThread 覆盖 T-GC 的 DB 原语：按 thread 清所有用户状态行。
+func TestDeleteUserStatesForThread(t *testing.T) {
+	_, ctx := testutil.NewTestServer()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+	db := NewDB(ctx)
+
+	upsertIntent(t, db, "u1", "g1", "t1", 1, 1)
+	upsertIntent(t, db, "u2", "g1", "t1", 1, 1)
+	upsertIntent(t, db, "u1", "g1", "t2", 1, 1) // 不同 thread，不该被删
+
+	require.NoError(t, db.DeleteUserStatesForThread("g1", "t1"))
+
+	got, err := db.QueryUserStates("u1", []ShortRef{{GroupNo: "g1", ShortID: "t1"}})
+	require.NoError(t, err)
+	assert.Empty(t, got, "t1 rows gone")
+	got, err = db.QueryUserStates("u2", []ShortRef{{GroupNo: "g1", ShortID: "t1"}})
+	require.NoError(t, err)
+	assert.Empty(t, got, "t1 rows gone for u2 too")
+	got, err = db.QueryUserStates("u1", []ShortRef{{GroupNo: "g1", ShortID: "t2"}})
+	require.NoError(t, err)
+	assert.Contains(t, got, "g1____t2", "t2 survives")
+}
+
+// TestQueryMuteForUID 覆盖 T2 的 mute 批量 helper（一个 uid × 多 thread）。
+func TestQueryMuteForUID(t *testing.T) {
+	_, ctx := testutil.NewTestServer()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+	db := NewDB(ctx)
+
+	// 用现有 UpsertSetting 落 mute 数据。
+	require.NoError(t, db.UpsertSetting(&SettingModel{GroupNo: "g1", ShortID: "t1", UID: "u_alice", Mute: 1, Version: 1}))
+	require.NoError(t, db.UpsertSetting(&SettingModel{GroupNo: "g1", ShortID: "t2", UID: "u_alice", Mute: 0, Version: 1}))
+	require.NoError(t, db.UpsertSetting(&SettingModel{GroupNo: "g1", ShortID: "t1", UID: "u_bob", Mute: 1, Version: 1}))
+
+	refs := []ShortRef{{GroupNo: "g1", ShortID: "t1"}, {GroupNo: "g1", ShortID: "t2"}, {GroupNo: "g1", ShortID: "t3"}}
+	m, err := db.QueryMuteForUID("u_alice", refs)
+	require.NoError(t, err)
+	assert.Equal(t, 1, m["g1____t1"], "alice muted t1")
+	// t2 mute=0 命中但值 0；t3 无行不出现。
+	v, ok := m["g1____t2"]
+	assert.True(t, ok)
+	assert.Equal(t, 0, v)
+	assert.NotContains(t, m, "g1____t3")
+
+	// per-user 隔离：bob 的 mute 不混进 alice。
+	mb, err := db.QueryMuteForUID("u_bob", refs)
+	require.NoError(t, err)
+	assert.Equal(t, 1, mb["g1____t1"])
+	assert.NotContains(t, mb, "g1____t2", "bob has no t2 setting")
+
+	// 空短路。
+	empty, err := db.QueryMuteForUID("u_alice", nil)
+	require.NoError(t, err)
+	assert.Empty(t, empty)
+}

--- a/modules/thread/main_test.go
+++ b/modules/thread/main_test.go
@@ -31,6 +31,13 @@ func TestMain(m *testing.M) {
 		// 内的 UNIQUE KEY，避免单独跑 CREATE UNIQUE INDEX IF NOT EXISTS（部分 MySQL 版本不支持
 		// 该语法）。
 		_, _ = db.Exec("CREATE TABLE IF NOT EXISTS `robot` (`id` BIGINT AUTO_INCREMENT PRIMARY KEY, `robot_id` VARCHAR(40) NOT NULL DEFAULT '', `token` VARCHAR(100) NOT NULL DEFAULT '', `version` BIGINT NOT NULL DEFAULT 0, `status` SMALLINT NOT NULL DEFAULT 1, `creator_uid` VARCHAR(40) NOT NULL DEFAULT '', `created_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP, `updated_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP, UNIQUE KEY `robot_id_robot_index` (`robot_id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci")
+
+		// reminders / reminder_done 属 message 模块（其迁移在 thread-only 测试进程里不会跑），
+		// 但 T8 detail 端 P1 仲裁（HasUnhandledMention）要查它们。手工建表，schema 与
+		// modules/message/sql/20220418000001_message_legacy01.sql 对齐（含 channel_uid_uidx，
+		// P1 SQL uid 打头命中它）。IF NOT EXISTS 幂等，与 robot 表同款处理。
+		_, _ = db.Exec("CREATE TABLE IF NOT EXISTS `reminders` (`id` BIGINT NOT NULL PRIMARY KEY AUTO_INCREMENT, `channel_id` VARCHAR(100) NOT NULL DEFAULT '', `channel_type` SMALLINT NOT NULL DEFAULT 0, `reminder_type` INTEGER NOT NULL DEFAULT 0, `uid` VARCHAR(40) NOT NULL DEFAULT '', `text` VARCHAR(255) NOT NULL DEFAULT '', `data` VARCHAR(1000) NOT NULL DEFAULT '', `is_locate` SMALLINT NOT NULL DEFAULT 0, `message_seq` BIGINT NOT NULL DEFAULT 0, `message_id` VARCHAR(20) NOT NULL DEFAULT '', `version` BIGINT NOT NULL DEFAULT 0, `is_deleted` SMALLINT NOT NULL DEFAULT 0, `created_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP, `updated_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP, KEY `channel_uid_uidx` (`uid`, `channel_id`, `channel_type`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci")
+		_, _ = db.Exec("CREATE TABLE IF NOT EXISTS `reminder_done` (`id` BIGINT NOT NULL PRIMARY KEY AUTO_INCREMENT, `reminder_id` BIGINT NOT NULL DEFAULT 0, `uid` VARCHAR(40) NOT NULL DEFAULT '', `created_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP, `updated_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP, UNIQUE KEY `reminder_done_uid_reminder_id_uidx` (`uid`, `reminder_id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci")
 	}
 
 	os.Exit(m.Run())

--- a/modules/thread/service.go
+++ b/modules/thread/service.go
@@ -15,6 +15,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-server/modules/group"
 	"github.com/Mininglamp-OSS/octo-server/modules/user"
 	"github.com/Mininglamp-OSS/octo-server/pkg/pushcache"
+	"github.com/gocraft/dbr/v2"
 	"go.uber.org/zap"
 )
 
@@ -597,7 +598,74 @@ func (s *Service) GetThread(groupNo, shortID, loginUID string) (*ThreadResp, err
 			resp.Mute = &mute
 		}
 	}
+
+	// plan T8：flag=on 时对 detail 端 status 跑同一四级仲裁（MUTE>P1>P2>P3），
+	// 与 sidebar list 同源，避免详情/列表矛盾（R5）。flag=off 返全局 status（现状）。
+	// fail-open：仲裁内查询失败保留全局 status，不隐藏。
+	if loginUID != "" && PerUserVisibilityEnabled() {
+		resp.Status = s.effectiveStatusForUser(loginUID, groupNo, shortID, resp.Status)
+	}
 	return resp, nil
+}
+
+// effectiveStatusForUser 对单个 thread 跑「按用户」四级仲裁 MUTE>P1>P2>P3（plan T8，detail 端）。
+// globalStatus 是 P3 兜底（当前全局 thread.status）。与 message.computeEffectiveStatus 同口径：
+//   - MUTE（thread_setting.mute）：压 P1 强制可见，隐藏交 P2/P3；detail 无 Unread 概念，只影响 status。
+//   - P1（未处理 per-uid @）：强制可见 active。
+//   - P2（archive_intent 本人意图）：intent==1 归档，否则 active。
+//   - P3：回落 globalStatus。
+//
+// fail-open：任一 per-uid 查询失败 → 返回 globalStatus（不隐藏），记 warn。
+func (s *Service) effectiveStatusForUser(loginUID, groupNo, shortID string, globalStatus int) int {
+	muted := false
+	// QuerySetting 在无 mute 行时可能返回 dbr.ErrNotFound；那不是查询故障，按「未静音」处理，
+	// 不触发 fail-open 回落。只有真实查询错误才 fail-open 保留全局 status。
+	if setting, err := s.db.QuerySetting(groupNo, shortID, loginUID); err != nil {
+		if !errors.Is(err, dbr.ErrNotFound) {
+			s.Warn("detail 仲裁 mute 查询失败（fail-open）", zap.Error(err), zap.String("loginUID", loginUID))
+			return globalStatus
+		}
+	} else if setting != nil {
+		muted = setting.Mute == 1
+	}
+
+	ref := ShortRef{GroupNo: groupNo, ShortID: shortID}
+	states, err := s.db.QueryUserStates(loginUID, []ShortRef{ref})
+	if err != nil {
+		s.Warn("detail 仲裁 user_state 查询失败（fail-open）", zap.Error(err), zap.String("loginUID", loginUID))
+		return globalStatus
+	}
+	state, hasState := states[groupNo+"____"+shortID]
+
+	hasP1, err := s.db.HasUnhandledMention(loginUID, groupNo, shortID)
+	if err != nil {
+		s.Warn("detail 仲裁 P1 查询失败（fail-open）", zap.Error(err), zap.String("loginUID", loginUID))
+		return globalStatus
+	}
+
+	switch {
+	case muted:
+		// MUTE 只压 P1 强制可见：隐藏交 P2/P3。
+		if hasState {
+			return intentToStatus(state.ArchiveIntent)
+		}
+		return globalStatus
+	case hasP1:
+		return ThreadStatusActive
+	case hasState:
+		return intentToStatus(state.ArchiveIntent)
+	default:
+		return globalStatus
+	}
+}
+
+// intentToStatus 把 thread_user_state.archive_intent 映射到契约 status 线值。
+// intent==1 → 2(archived)；否则 → 1(active)。钉死 1 基线值。
+func intentToStatus(intent int) int {
+	if intent == 1 {
+		return ThreadStatusArchived
+	}
+	return ThreadStatusActive
 }
 
 // ArchiveThread 归档子区
@@ -612,6 +680,20 @@ func (s *Service) ArchiveThread(groupNo, shortID, operatorUID string) error {
 	if thread.Status == ThreadStatusDeleted {
 		return errors.New("thread has been deleted")
 	}
+
+	// plan T7：per-user 可见性 flag=on 时改走 per-uid 归档意图（不再改全局 thread.status）。
+	// 全局 status 的「已归档→直接返回」短路只在 flag=off 生效；flag=on 由 per-uid intent 幂等。
+	if PerUserVisibilityEnabled() {
+		canOperate, err := s.canOperate(groupNo, shortID, operatorUID)
+		if err != nil {
+			return fmt.Errorf("check permission: %w", err)
+		}
+		if !canOperate {
+			return errors.New("no permission to archive")
+		}
+		return s.setArchiveIntentPerUser(groupNo, shortID, operatorUID, 1)
+	}
+
 	if thread.Status == ThreadStatusArchived {
 		return nil // 已归档，无需操作
 	}
@@ -651,6 +733,19 @@ func (s *Service) UnarchiveThread(groupNo, shortID, operatorUID string) error {
 	if thread.Status == ThreadStatusDeleted {
 		return errors.New("thread has been deleted")
 	}
+
+	// plan T7：flag=on 时改走 per-uid 归档意图（intent=0 恢复可见），不改全局 thread.status。
+	if PerUserVisibilityEnabled() {
+		canOperate, err := s.canOperate(groupNo, shortID, operatorUID)
+		if err != nil {
+			return fmt.Errorf("check permission: %w", err)
+		}
+		if !canOperate {
+			return errors.New("no permission to unarchive")
+		}
+		return s.setArchiveIntentPerUser(groupNo, shortID, operatorUID, 0)
+	}
+
 	if thread.Status == ThreadStatusActive {
 		return nil // 已激活，无需操作
 	}
@@ -674,6 +769,41 @@ func (s *Service) UnarchiveThread(groupNo, shortID, operatorUID string) error {
 			return errors.New("thread status changed concurrently")
 		}
 		return fmt.Errorf("update thread status: %w", err)
+	}
+	return nil
+}
+
+// setArchiveIntentPerUser 在一个 tx 内写 operatorUID 对该子区的归档意图并 bump follow_version（plan T7）。
+// intent: 1=归档 0=取消归档。
+//
+// 锁序铁律（plan F3/R3）：必须**先** BumpFollowVersionTx（对 user_follow_version 行加 X 锁）
+// **再** UpsertArchiveIntentTx，避免与 UnfollowChannel/UpdateSort 反向交叉造成 InnoDB 死锁。
+// 事务惯例参照 service.go 的 s.db.session.Begin()（勿另造事务框架，遵 STOP-4）。
+func (s *Service) setArchiveIntentPerUser(groupNo, shortID, operatorUID string, intent int) error {
+	spaceID := ""
+	if groupInfo, gerr := s.groupService.GetGroupWithGroupNo(groupNo); gerr == nil && groupInfo != nil {
+		spaceID = groupInfo.SpaceID
+	}
+	version, err := s.threadVersionGen()()
+	if err != nil {
+		return fmt.Errorf("gen version for archive intent: %w", err)
+	}
+
+	tx, err := s.db.session.Begin()
+	if err != nil {
+		return fmt.Errorf("begin tx for archive intent: %w", err)
+	}
+	defer tx.RollbackUnlessCommitted()
+
+	// 先 bump（锁序：user_follow_version 先于 user_conversation_ext / 其它写）。
+	if _, err := conversation_ext.BumpFollowVersionTx(tx, operatorUID, spaceID); err != nil {
+		return fmt.Errorf("bump follow_version for archive intent: %w", err)
+	}
+	if err := s.db.UpsertArchiveIntentTx(tx, operatorUID, groupNo, shortID, intent, version); err != nil {
+		return fmt.Errorf("upsert archive intent: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit archive intent tx: %w", err)
 	}
 	return nil
 }
@@ -719,6 +849,12 @@ func (s *Service) DeleteThread(groupNo, shortID, operatorUID string) error {
 	// 清理所有用户对该子区的置顶
 	user.RemovePinnedForChannel(channelID, common.ChannelTypeCommunityTopic.Uint8())
 	conversation_ext.RemoveConvExtForChannel(channelID, common.ChannelTypeCommunityTopic.Uint8())
+
+	// plan T-GC：清理该子区所有用户的 per-user 归档状态行（走 idx_thread），避免孤儿膨胀。
+	// 非致命：删除失败只记 warn，不回滚已完成的删除（与上面清理块同等 fail-open 语义）。
+	if err := s.db.DeleteUserStatesForThread(groupNo, shortID); err != nil {
+		s.Warn("清理 thread_user_state 失败（非致命）", zap.String("groupNo", groupNo), zap.String("shortID", shortID), zap.Error(err))
+	}
 
 	return nil
 }

--- a/modules/thread/service_peruser_test.go
+++ b/modules/thread/service_peruser_test.go
@@ -1,0 +1,150 @@
+package thread
+
+import (
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	convext "github.com/Mininglamp-OSS/octo-server/modules/conversation_ext"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// seedThreadReminder inserts an unhandled per-uid @ (P1) reminder for a thread channel.
+func seedThreadReminder(t *testing.T, ctx *config.Context, uid, groupNo, shortID string) {
+	t.Helper()
+	channelID := groupNo + "____" + shortID
+	_, err := ctx.DB().InsertBySql(
+		"INSERT INTO reminders (channel_id, channel_type, reminder_type, uid, is_deleted, version) VALUES (?,?,?,?,0,1)",
+		channelID, uint8(common.ChannelTypeCommunityTopic), 1, uid,
+	).Exec()
+	require.NoError(t, err)
+}
+
+// seedActiveThread inserts an active thread row directly (avoids CreateThread's live-IM dep,
+// which is why the DB-heavy service tests are otherwise skipped). Uses a snowflake-shaped shortID.
+func seedActiveThread(t *testing.T, svc *Service, groupNo, shortID string) {
+	t.Helper()
+	require.NoError(t, svc.db.Insert(&Model{
+		ShortID:    shortID,
+		GroupNo:    groupNo,
+		Name:       "thr-" + shortID,
+		CreatorUID: testutil.UID,
+		Status:     ThreadStatusActive,
+		Version:    1,
+	}))
+}
+
+const testShortID = "170000000000001" // 15-digit snowflake-shaped shortID (creator can operate)
+
+// TestArchiveThread_PerUser_FlagOn 覆盖 plan T7 + T8 + gate 1/5：
+// flag=on 时 ArchiveThread 写 per-uid intent（不改全局 status），A 视角归档、他人不变，且 bump follow_version；
+// detail 同源。
+func TestArchiveThread_PerUser_FlagOn(t *testing.T) {
+	t.Setenv("DM_THREAD_PERUSER_VISIBILITY", "true")
+	svc, groupNo := setupServiceTestData(t)
+	shortID := testShortID
+	seedActiveThread(t, svc, groupNo, shortID)
+
+	fvDB := convext.NewFollowVersionDB(svc.ctx)
+	before, err := fvDB.Get(testutil.UID, "")
+	require.NoError(t, err)
+
+	// A（creator）归档：写 per-uid intent，全局 status 不变。
+	require.NoError(t, svc.ArchiveThread(groupNo, shortID, testutil.UID))
+
+	globalRow, err := svc.db.QueryByGroupNoAndShortID(groupNo, shortID)
+	require.NoError(t, err)
+	assert.Equal(t, ThreadStatusActive, globalRow.Status, "flag=on 不改全局 status")
+
+	states, err := svc.db.QueryUserStates(testutil.UID, []ShortRef{{GroupNo: groupNo, ShortID: shortID}})
+	require.NoError(t, err)
+	require.Contains(t, states, groupNo+"____"+shortID)
+	assert.Equal(t, 1, states[groupNo+"____"+shortID].ArchiveIntent)
+
+	otherStates, err := svc.db.QueryUserStates("user2", []ShortRef{{GroupNo: groupNo, ShortID: shortID}})
+	require.NoError(t, err)
+	assert.Empty(t, otherStates, "他人不受影响")
+
+	after, err := fvDB.Get(testutil.UID, "")
+	require.NoError(t, err)
+	assert.Equal(t, before+1, after, "archive per-uid bumps follow_version")
+
+	// detail 同源（T8）：A 视角 detail.status == 2；user2 仍 active。
+	resp, err := svc.GetThread(groupNo, shortID, testutil.UID)
+	require.NoError(t, err)
+	assert.Equal(t, ThreadStatusArchived, resp.Status, "detail per-uid archived for A")
+
+	respOther, err := svc.GetThread(groupNo, shortID, "user2")
+	require.NoError(t, err)
+	assert.Equal(t, ThreadStatusActive, respOther.Status, "detail active for others")
+
+	// Unarchive 恢复：intent=0。
+	require.NoError(t, svc.UnarchiveThread(groupNo, shortID, testutil.UID))
+	states, err = svc.db.QueryUserStates(testutil.UID, []ShortRef{{GroupNo: groupNo, ShortID: shortID}})
+	require.NoError(t, err)
+	assert.Equal(t, 0, states[groupNo+"____"+shortID].ArchiveIntent, "unarchive sets intent 0")
+	resp, err = svc.GetThread(groupNo, shortID, testutil.UID)
+	require.NoError(t, err)
+	assert.Equal(t, ThreadStatusActive, resp.Status)
+}
+
+// TestArchiveThread_Global_FlagOff 覆盖 gate 5：flag=off 时走原全局 CAS（现状），不写 per-uid 表。
+func TestArchiveThread_Global_FlagOff(t *testing.T) {
+	t.Setenv("DM_THREAD_PERUSER_VISIBILITY", "false")
+	svc, groupNo := setupServiceTestData(t)
+	shortID := testShortID
+	seedActiveThread(t, svc, groupNo, shortID)
+
+	require.NoError(t, svc.ArchiveThread(groupNo, shortID, testutil.UID))
+
+	globalRow, err := svc.db.QueryByGroupNoAndShortID(groupNo, shortID)
+	require.NoError(t, err)
+	assert.Equal(t, ThreadStatusArchived, globalRow.Status, "flag=off 改全局 status（现状）")
+
+	states, err := svc.db.QueryUserStates(testutil.UID, []ShortRef{{GroupNo: groupNo, ShortID: shortID}})
+	require.NoError(t, err)
+	assert.Empty(t, states, "flag=off 不写 thread_user_state")
+
+	resp, err := svc.GetThread(groupNo, shortID, testutil.UID)
+	require.NoError(t, err)
+	assert.Equal(t, ThreadStatusArchived, resp.Status)
+}
+
+// TestGetThread_P1OverIntent 覆盖 T8 + gate 1：detail 端 P1 压过 intent 重新可见。
+func TestGetThread_P1OverIntent(t *testing.T) {
+	t.Setenv("DM_THREAD_PERUSER_VISIBILITY", "true")
+	svc, groupNo := setupServiceTestData(t)
+	shortID := testShortID
+	seedActiveThread(t, svc, groupNo, shortID)
+
+	require.NoError(t, svc.ArchiveThread(groupNo, shortID, testutil.UID))
+	resp, err := svc.GetThread(groupNo, shortID, testutil.UID)
+	require.NoError(t, err)
+	require.Equal(t, ThreadStatusArchived, resp.Status)
+
+	// 给 A 一个未处理 per-uid @（P1）→ detail 拉回 active。
+	seedThreadReminder(t, svc.ctx, testutil.UID, groupNo, shortID)
+	resp, err = svc.GetThread(groupNo, shortID, testutil.UID)
+	require.NoError(t, err)
+	assert.Equal(t, ThreadStatusActive, resp.Status, "P1 pulls archived thread back to active in detail")
+}
+
+// TestDeleteThread_GC 覆盖 T-GC：DeleteThread 后 user_state 行被清（无孤儿）。
+func TestDeleteThread_GC(t *testing.T) {
+	t.Setenv("DM_THREAD_PERUSER_VISIBILITY", "true")
+	svc, groupNo := setupServiceTestData(t)
+	shortID := testShortID
+	seedActiveThread(t, svc, groupNo, shortID)
+
+	require.NoError(t, svc.ArchiveThread(groupNo, shortID, testutil.UID))
+	states, err := svc.db.QueryUserStates(testutil.UID, []ShortRef{{GroupNo: groupNo, ShortID: shortID}})
+	require.NoError(t, err)
+	require.NotEmpty(t, states)
+
+	require.NoError(t, svc.DeleteThread(groupNo, shortID, testutil.UID))
+	states, err = svc.db.QueryUserStates(testutil.UID, []ShortRef{{GroupNo: groupNo, ShortID: shortID}})
+	require.NoError(t, err)
+	assert.Empty(t, states, "DeleteThread cleans thread_user_state (no orphan)")
+}

--- a/modules/thread/sql/20260713000001_thread_user_state.sql
+++ b/modules/thread/sql/20260713000001_thread_user_state.sql
@@ -1,0 +1,36 @@
+-- +migrate Up
+
+-- thread_user_state：子区「按用户」的可见性状态（per-user thread visibility）。
+--
+-- 背景（bug）：子区自动归档是「全局」thread.status，一人手工归档 / worker 陈旧归档
+-- 会波及所有成员，且未处理的 per-uid @（P1）无法把子区强制拉回可见。本表承载
+-- 四级仲裁 MUTE > P1 > P2 > P3 中的 **P2（本人手工归档意图）**，与已 per-user 的
+-- thread_setting（mute，MUTE 级）语义对齐，让归档从「全局字段」升为「per-user 正源」。
+--
+-- 空表 = 现状：仲裁读路径查不到行即回落全局 thread.status（P3 兜底），迁移向后兼容、
+-- 无需回填（feature flag DM_THREAD_PERUSER_VISIBILITY 默认 off 时本表根本不写不读）。
+--
+-- 索引：
+--   uk_uid_thread (uid, group_no, short_id) —— 仲裁按「一个 uid × 多 thread」批量定位
+--     （P1 SQL / mute 批量 / 本表批量共用同一 refs），uid 打头。
+--   idx_thread (group_no, short_id) —— DeleteThread / GC 按 thread 反查清理孤儿行。
+--
+-- read_intent_at 为未来把 mute/read 并入本表预留列位（本批不写，见 plan out-of-scope）。
+CREATE TABLE `thread_user_state` (
+  `id` BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+  `uid` VARCHAR(40) NOT NULL,
+  `group_no` VARCHAR(40) NOT NULL,
+  `short_id` VARCHAR(32) NOT NULL,
+  `archive_intent` TINYINT NOT NULL DEFAULT 0,      -- 0=未归档 1=已归档(本人)
+  `archive_intent_at` TIMESTAMP NULL,
+  `read_intent_at` TIMESTAMP NULL,                  -- 预留(mute/read 未来并入)
+  `version` BIGINT NOT NULL DEFAULT 0,
+  `created_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_uid_thread` (`uid`, `group_no`, `short_id`),   -- 仲裁按 uid+thread 定位
+  KEY `idx_thread` (`group_no`, `short_id`)                     -- 删除/GC 按 thread 反查
+) ENGINE=InnoDB;
+
+-- +migrate Down
+DROP TABLE `thread_user_state`;


### PR DESCRIPTION
## Spec

**What:** DRAFT architecture design for **cross-instance federation** — letting two independently self-hosted octo instances establish mutual trust so users from two different organisations can collaborate in one shared external group (Slack-Connect-style).

**Why now:** The existing 外部群 work (`docs/external-group-design.md`, v1.1) solves *cross-Space within a single instance* — it assumes one DB, one WuKongIM, one `user` table. Cross-*instance* is a different problem and currently has **zero** support in the codebase (`federat` → no hits anywhere).

**Approach chosen: A — single-homed.** The external group is hosted on one instance (Host); the peer's users are projected onto the Host as **unauthenticatable local shadow uids**. Federation provenance lives in side tables plus the existing `is_external` marker — deliberately **never encoded into the uid string**.

Why not double-sided replication: tokens are opaque Redis keys and cannot be verified across instances (`pkg/auth/parser.go:130` — verification *is* a Redis GET); JWT/JWKS infrastructure was deliberately removed (`modules/bot_provision/jwt.go`); `@` is already the DM channel-pair separator (`octo-lib/common/msg.go:172-174`), so domain-qualified federated uids are poison; and replication would additionally require re-solving dedup, ordering, edit/revoke sync and state convergence.

**Reuse boundary:** ~70% of the *product* semantics of an external group already exist and are reused as-is (external badge, `allow_external` safety valve, conversation/search pass-through, auto-reset of `is_external_group`). What is genuinely new is the identity substrate and the trust/authorisation layer. Full per-capability table in §2.

**WuKongIM: intended to stay untouched.** Evidence that this is plausible: IM already pulls authoritative membership *from* octo via `POST /v1/datasource` + `cmd=getSubscribers` (`modules/webhook/api.go:141`, `api_datasource.go:84-113` → `modules/group/1module.go:66-78`), and `IMAddSubscriber` takes bare uid strings with no registration handshake. ⚠️ But see the blocking spike below — this is **not yet proven**.

**Scope:** design only. No implementation code in this PR. Implementation tickets are to be split *after* the decision points in §16 are settled.

## COMPREHENSION

- **This is a load-bearing architecture spec, not an incremental feature.** It should not be merged as "approved design" — it is explicitly `status: DRAFT`. It needs a human comprehension pass before any implementation work is split off.

- **Most fragile premise — §5.4, a blocking Phase 0 spike.** The whole single-homed approach rests on WuKongIM accepting a *spoofed* `from_uid` on server-side send (i.e. sending *as* a shadow uid that never logs in). WuKongIM's source is not in this repo, so this is currently **inference, not verified**. The spike asserts four things (subscriber add / datasource listing / spoofed-sender send / outbound capture); if any fails, the approach collapses and the design must be revisited. Do not start implementation before this is green.

- **Largest security surface — three things that must all hold:** §4.2 authorisation (HMAC authenticates the *peer*, it does **not** prove the `remote_uid` belongs to that peer, is still a member of that group, or that the peer may write to that channel — missing any of these degenerates into "any trusted peer's any user can write to any group"); §3.3 the unauthenticatable-shadow constraint (a shadow row is an ordinary local user row, so login / token minting / credential binding / DM / global search / admin export / GDPR deletion paths must each be audited and explicitly denied or downgraded); §4.6 SSRF on the operator-configured peer `base_url` (HMAC does not protect against the wrong destination).

- **Known limitation, stated rather than hidden:** federated groups **cannot** be end-to-end encrypted under server-side relay (§10). The design specifies a *bidirectional* fail-closed gate (an E2E group cannot enable federation, and a federated group cannot enable E2E) to prevent a damaged mixed state.

- **Honest gaps:** §15 lists everything not verified in this pass, including the outbound-event-capture hook location in the message pipeline, whether IM supports external client-msg-no dedup, and the reason a previous attempt to widen the uid column to 64 was reverted in the `oidc` module. The file:line evidence in this draft comes from one independent code survey and was **not** re-opened line-by-line while writing; a reviewer should drift-check against current HEAD.

- **Blocking on a non-technical decision — §16.1 data sovereignty.** Under single-homed hosting, the peer organisation's messages, attachments and member profiles physically reside on the Host's servers. Who is the data controller, is this cross-border, and must the Host purge peer data when the federation is dissolved? This is a legal/compliance call, not an engineering one, and the design states that work must not proceed past Phase 1 without an explicit answer.

**Baseline:** written against `a61b5411`.
