### PR TITLE
fix: close the ordering guard's write skew + carry over #679 review debt (Batch 2, part 1)

### DIFF
--- a/.octospec/tasks/inactive-hiding-user-control/brief.md
+++ b/.octospec/tasks/inactive-hiding-user-control/brief.md
@@ -209,8 +209,16 @@ source: self
 ## 已知边界（评审要求显式记录，非缺陷）
 
 - **P0 与 P2 冲突时 P0 赢。** 一个既 archived 又置顶/有未读的子区仍会被 recent tab
-  丢弃 —— 归档是话题生命周期的客观事实，压过每人视图的豁免。三端本就在客户端隐藏
-  archived，且任何新消息都会复活，故无回归。
+  丢弃 —— 归档是话题生命周期的客观事实，压过每人视图的豁免。
+  **无回归的准确理由是：web 的主最近列表根本不消费这个端点。** 它走
+  `/v1/conversation/sync?recent_filter=true`，而那条路径早在本任务之前就丢弃 archived
+  （`QueryActiveShortIDs`, `status=active`）。`tab=recent` 在 web 上只有两个弹窗选择器
+  在用（转发弹窗、智能纪要会话选择器），转发弹窗自己已经跑 `filterArchivedThreads`。
+  原先这里写的是「三端本就在客户端隐藏 archived」—— 结论相同但理由是错的：
+  `archivedThreads.ts` 的头注释把自己定义为 **follow** tab 的过滤器，调用点也都在
+  `ConversationListGrouped` / 角标 / 转发弹窗，没有一个作用在这个端点的 recent tab 上。
+  照原文写下去，Batch 2 会依赖一个并不存在的客户端过滤
+  （PR #679 review 第 6 轮, yujiawei）。此外任何新消息都会让子区复活。
 - **静音但有未读的群永远不淡出。** `keepDespiteRecentWindow` 没有 mute 入参，两个
   调用点也都拿不到（`config.SyncUserConversationResp` 无 mute 字段，`SidebarItem`
   不暴露；用 `/v1/conversation/sync` 的 `Mute` 会重新制造 per-endpoint 分叉）。后果：

--- a/.octospec/tasks/per-user-hiding-window/brief.md
+++ b/.octospec/tasks/per-user-hiding-window/brief.md
@@ -164,28 +164,45 @@ Batch 1 已把这条写进 brief 的已知边界，并注明「Batch 2 之前必
 
 ### P0 — 前置缺口 A：偏序守卫的写竞态
 
-- [ ] 守卫改为**事务内**校验：`SELECT ... FOR UPDATE` 锁住三行
-      （`thread.auto_archive_enabled` / `thread.auto_archive_days` /
-      `sidebar.recent_filter_thread_days`），在锁内用行的真实值重跑
+- [x] 守卫改为**事务内**校验，在锁内用行的真实值重跑
       `ApplyThreadArchiveOrderingOverlay` + `ViolatesThreadArchiveOrdering`。
-- [ ] 并发回归：两个 goroutine 从 `enabled=true, archive=6, recent=3` 出发分别写
+      **锁的对象与原文不同,已修正**：原文写「`SELECT ... FOR UPDATE` 锁住三行」，
+      照做**不成立**。那三行可能都不存在（迁移刻意不写行，这是 Batch 1 的上线保证），
+      对不存在的行 `FOR UPDATE` 只拿到 gap lock，而 gap-X 锁彼此兼容 —— 两个写入会
+      **全部通过**校验，随后各自 INSERT 抢 insert-intention lock 互等，退化成 InnoDB
+      死锁(1213)，把一次合法并发写变成不透明的 500。本仓库在
+      `incomingwebhook.insertWithQuota` 上踩过并记录过同一个坑
+      （`modules/incomingwebhook/db.go:65`），结论是**锁一个必然存在的单行**；
+      `card_template_catalog_capacity_guard` 是同一形状。
+      实现改为新增单行锚点表 `system_setting_guard_lock`（CHECK 钉死主键=1），
+      事务第一条语句即锁它，其后才读三个 key 的真实值。
+- [x] 并发回归：两个 goroutine 从 `enabled=true, archive=6, recent=3` 出发分别写
       `archive=4` 与 `recent=5`，断言**恰好一个**成功、DB 终态不违反偏序。
-      当前实现下该用例必须先失败（钉住缺陷存在），修复后转绿。
-- [ ] 行不存在时（回落 env/默认）的加锁语义有明确定义并有用例 —— `FOR UPDATE` 锁不住
-      不存在的行，不能因此绕过守卫。
+      已按要求先在旧实现下验证必失败（实测 `codes=[200 200]`、终态 `archive=4 recent=5`），
+      再确认修复后转绿。
+- [x] 行不存在时（回落 env/默认）的加锁语义有明确定义并有用例 ——
+      `TestManagerSystemSetting_OrderingSerialisesWhenNoRowsExist`：锚点行与三个 setting
+      行的存在与否无关，所以「FOR UPDATE 锁不住不存在的行」这条不再构成绕过路径。
 - [ ] 每用户窗口的写入走同一条校验，不得另开一条不加锁的旁路。
-- [ ] 既有 `TestManagerSystemSetting_Ordering*` 全部仍绿（含重置为默认那条）。
+      **随 P1 交付**（本 PR 不含 P1）。守卫与锚点已就位，P1 的写入路径直接复用即可。
+- [x] 既有 `TestManagerSystemSetting_Ordering*` 全部仍绿（含重置为默认那条）。
+- [x] 附带：守卫从「事务前 return」变为「事务内 return」，新增整批回滚回归
+      （`TestManagerSystemSetting_OrderingRejectionRollsBackWholeBatch`）——
+      同批中与偏序无关的合法 key 不得留下部分写入。
+- [x] 附带：锚点行自愈（事务外 `INSERT IGNORE`）。`CleanAllTables` 会清掉它，任何
+      基于 truncate 的恢复同理；没有自愈的话，锚点一丢就让每次配置写入硬失败、
+      看起来像数据库故障。锚点不存任何状态，恢复因此是安全的。
 
 ### P0 — 前置缺口 B：静音但有未读
 
-- [ ] `keepDespiteRecentWindow` 的未读豁免加入 mute 维度，**两个端点行为一致**，
+- [x] `keepDespiteRecentWindow` 的未读豁免加入 mute 维度，**两个端点行为一致**，
       `TestRecentWindow_BothEndpointsAgree` 保持绿。
-- [ ] `/v1/sidebar/sync` 侧补齐 mute 来源，且与 `/v1/conversation/sync` 的
+- [x] `/v1/sidebar/sync` 侧补齐 mute 来源，且与 `/v1/conversation/sync` 的
       `userDetail.Mute` / `group.Mute` 同源 —— 不同源就是新的 per-endpoint 分叉。
-- [ ] **静音 + 有未解决的 @我 仍然保留**，复用 `reminders` / `reminder_done` 的判定
+- [x] **静音 + 有未解决的 @我 仍然保留**，复用 `reminders` / `reminder_done` 的判定
       （与 `ArchiveStaleBatch` 同一机制，`modules/thread/db.go:446-453`）。
-- [ ] mute 查询失败 **fail-open**：按未静音处理（宁可多显示，绝不误藏），与本仓库既有降级方向一致。
-- [ ] 用例矩阵：`{静音, 未静音} × {有未读, 无未读} × {有@我, 无@我}` 在超窗输入上的可见性。
+- [x] mute 查询失败 **fail-open**：按未静音处理（宁可多显示，绝不误藏），与本仓库既有降级方向一致。
+- [x] 用例矩阵：`{静音, 未静音} × {有未读, 无未读} × {有@我, 无@我}` 在超窗输入上的可见性。
 
 ### P1 — 每人窗口存储与解析
 
@@ -223,19 +240,19 @@ Batch 1 已把这条写进 brief 的已知边界，并注明「Batch 2 之前必
 评审第 6/7 轮均判定「不值得为它们再开一个 head」，因为每个新 head 都会作废全部批准并触发一次
 完整重审。因此它们结转到这里，作为独立的、先于功能代码的一个 commit。
 
-- [ ] `modules/common/system_settings.go:681` —— `threadAutoArchiveDaysFromEnv` 的
+- [x] `modules/common/system_settings.go:681` —— `threadAutoArchiveDaysFromEnv` 的
       `strings.TrimSpace` 与 legacy `parseDays` 不一致：`" 9999 "` 在新实现下解析成 9999，
       在 legacy 下回落默认。**这是「上线逐字节相同」唯一不成立的输入。**
       要么去掉 `TrimSpace`，要么改注释别再宣称精确镜像，并把 brief / PR 里的措辞
       改成「除首尾空白外逐字节相同」。
-- [ ] `modules/thread/archive_config.go:13` —— `Enabled` 的注释描述的是 PR 之前的启动门。
+- [x] `modules/thread/archive_config.go:13` —— `Enabled` 的注释描述的是 PR 之前的启动门。
       标记为死字段或指向 `system_settings`。
-- [ ] `modules/thread/archive_config.go:63-70` —— `parseDays` 回落路径未设上界，
+- [x] `modules/thread/archive_config.go:63-70` —— `parseDays` 回落路径未设上界，
       按 `archiveThresholdFromDays` 同样的方式钳住，避免该路径仍能回绕。
-- [ ] Batch 1 `brief.md:211` —— web「无回归」的理由不准确：真正的理由是**主最近列表
+- [x] Batch 1 `brief.md:211` —— web「无回归」的理由不准确：真正的理由是**主最近列表
       从不消费 `/v1/sidebar/sync`**（它走 `/v1/conversation/sync`），而不是「客户端会自己过滤
       这个端点」。后者会让 Batch 2 依赖一个并不存在的客户端过滤。
-- [ ] **worker 启动时打一次生效的归档/隐藏偏序**（第 7 轮新提）。当前守卫只覆盖 DB→DB
+- [x] **worker 启动时打一次生效的归档/隐藏偏序**（第 7 轮新提）。当前守卫只覆盖 DB→DB
       写入，`ViolatesThreadArchiveOrdering` 在 `!ArchiveEnabled` 时短路，所以「纯 env 配出的
       违规状态」不写一次管理接口就永远不暴露。启动日志正好补上这个洞。
 

--- a/.octospec/tasks/per-user-hiding-window/brief.md
+++ b/.octospec/tasks/per-user-hiding-window/brief.md
@@ -195,14 +195,29 @@ Batch 1 已把这条写进 brief 的已知边界，并注明「Batch 2 之前必
 
 ### P0 — 前置缺口 B：静音但有未读
 
-- [x] `keepDespiteRecentWindow` 的未读豁免加入 mute 维度，**两个端点行为一致**，
+> **已从 PR #695 撤出，等 import cycle 修好后重做。** 代码曾三次落地
+> （`d3835bdc` → `6235cd51` → `dbfce0d3`），三轮评审在同样的 ~40 行里找到三个缺陷，
+> **而每一个都是 CI 看不见的** —— SQL 在 integration tag 的文件里，那个 tag 因既有
+> import cycle 不编译。第三轮那条是 P0：三分支 UNION 在生产形状的库上直接
+> `ERROR 1271 Illegal mix of collations`（`user_setting`/`group_setting` 无
+> CHARSET 子句 → 服务器默认 `0900_ai_ci`；`thread_setting` 显式 `general_ci`）。
+> 本机 MySQL 8.0.46 上复现确认，两分支的前一版在同一 schema 下通过 —— 是本批引入的回归。
+>
+> 关键教训：CI 与本地开发库都用 `COLLATE utf8mb4_general_ci` 建库，会把三张表归一，
+> 因此「integration 全绿」对生产环境不构成证据。
+>
+> 补丁与两个未修缺陷（UNION 排序规则、DM 的 @我 键不匹配）的完整说明存于
+> `scratchpad/p0b-parked/README.md`。**重做的前置条件是先修 import cycle**，
+> 否则第四轮只会重演。
+
+- [ ] `keepDespiteRecentWindow` 的未读豁免加入 mute 维度，**两个端点行为一致**，
       `TestRecentWindow_BothEndpointsAgree` 保持绿。
-- [x] `/v1/sidebar/sync` 侧补齐 mute 来源，且与 `/v1/conversation/sync` 的
+- [ ] `/v1/sidebar/sync` 侧补齐 mute 来源，且与 `/v1/conversation/sync` 的
       `userDetail.Mute` / `group.Mute` 同源 —— 不同源就是新的 per-endpoint 分叉。
-- [x] **静音 + 有未解决的 @我 仍然保留**，复用 `reminders` / `reminder_done` 的判定
+- [ ] **静音 + 有未解决的 @我 仍然保留**，复用 `reminders` / `reminder_done` 的判定
       （与 `ArchiveStaleBatch` 同一机制，`modules/thread/db.go:446-453`）。
-- [x] mute 查询失败 **fail-open**：按未静音处理（宁可多显示，绝不误藏），与本仓库既有降级方向一致。
-- [x] 用例矩阵：`{静音, 未静音} × {有未读, 无未读} × {有@我, 无@我}` 在超窗输入上的可见性。
+- [ ] mute 查询失败 **fail-open**：按未静音处理（宁可多显示，绝不误藏），与本仓库既有降级方向一致。
+- [ ] 用例矩阵：`{静音, 未静音} × {有未读, 无未读} × {有@我, 无@我}` 在超窗输入上的可见性。
 
 ### P1 — 每人窗口存储与解析
 

--- a/.octospec/tasks/per-user-hiding-window/brief.md
+++ b/.octospec/tasks/per-user-hiding-window/brief.md
@@ -1,0 +1,270 @@
+---
+type: Task
+title: "Task: per-user-hiding-window"
+description: 把"安静的会话何时从我的列表里淡出"这个决定交给用户 —— 先关掉两个前置缺口（偏序守卫的写竞态、静音但有未读永不淡出），再给 user_space_setting 加三态的每人隐藏窗口并从 /v1/user/space/setting 读写。
+tags: [message, user, common, thread, space, isolation, wire-contract, error-response, i18n, rate-limit, system-setting, testing]
+timestamp: 2026-08-03T13:43:37Z
+# --- octospec extension fields ---
+slug: per-user-hiding-window
+upstream: self
+source: self
+---
+
+# Task: per-user-hiding-window
+
+## Goal
+
+**把不活跃隐藏窗口的控制权交给用户。**
+
+Batch 1（PR #679）铺完了地基：两条会话列表读路径的可见性谓词统一了、归档策略可热改了、
+窗口有了「未读 / 置顶 / 系统 Bot 永不被吞」的安全垫。但**至今没有任何用户可见的开关** ——
+现在仍是运维在管理台上给全站定一个数字。
+
+本批交付真正的开关：每个用户可以在每个 Space 里自己决定「群 / 子区 / 单聊各自安静多久
+就从我的最近列表淡出」，全局配置降级为**默认值**。
+
+行为变化：
+
+| | 现在 | 本批之后 |
+|---|---|---|
+| 窗口取值 | 全站一个数字（`sidebar.recent_filter_*_days`） | 用户没设 → 继承全站默认；设了 → 用自己的 |
+| 用户能做什么 | 无 | 每 Space 独立设置三类窗口，可显式关掉过滤 |
+| 静音的吵闹群 | 未读常驻 → **永远不淡出** | 静音 + 无未解决 @我 → 可以淡出 |
+
+**但本批的前两项不是这个功能，是它的准入条件。** 两个已知缺口在「窗口是运维配的」时是
+可接受的边界，在「窗口是用户配的」时就不是了 —— 见 Background §2、§3。
+
+## Background
+
+### 1 · 三层衰减模型（Batch 1 journal 已确立的轴）
+
+| 旋钮 | 正确的轴 | 因为 |
+|---|---|---|
+| 归档时长 | **每子区**（+ 群级默认） | 是**话题**的属性 |
+| 隐藏窗口 | **每用户**（+ 全局默认） | 是**观看者**的属性 |
+| 全局配置 | **只作默认值** | 不是唯一真相 |
+
+本批做中间那一行。第三行（每子区归档时长，Discord 的 `auto_archive_duration` 模型）留给 Batch 3。
+
+推论，Batch 1 journal 已记录：**全局归档窗口是每个用户窗口的硬天花板** —— 每人窗口是
+读投影，归档是全局写；被全局归档掉的子区，任何用户的窗口都救不回来。偏序守卫
+（`archive_days >= recent_filter_thread_days`）编码的正是这条。
+
+### 2 · 前置缺口 A —— 偏序守卫的写竞态
+
+`modules/common/api_manager_system_setting.go:343-370`：守卫读的是
+`m.systemSettings.ThreadArchiveOrdering()`，一个**进程本地快照**（`defaultReloadTTL` 60s），
+校验完才在 `:375` 开事务，事务内既不重读也不加锁。
+
+从 `enabled=true, archive=6, recent=3` 出发，A 写 `archive=4`、B 写 `recent=5`，各自对着同一份
+快照都通过（A 见 `4>=3`，B 见 `6>=5`），双双提交，落到 `4 < 5` —— 正是守卫要禁止的状态。
+跨副本更糟：只有写入方立即 `Reload`，其他副本最多可能对着一分钟前的快照校验。
+
+PR #679 三个独立评审 pass 都标了这一条，最终定 **P2 并放行**，理由是「需要两个 SuperAdmin
+在窗口内写两个不同的 key」。**本批直接推翻这个理由**：窗口一旦变成每用户写入，写入面就从
+「少数几个管理调用」放大到「每个用户随时可写」。评审因此把它列为 Batch 2 的准入门。
+
+注意：本批新增的每人窗口**也**要受同一条天花板约束，所以守卫不只是要修，还要能覆盖一条
+全新的、高频的写入路径。
+
+### 3 · 前置缺口 B —— 静音但有未读永不淡出
+
+`keepDespiteRecentWindow` 无条件豁免 `unread > 0`。用户静音一个吵闹的群、从此不点开 →
+未读常驻 → **永久豁免**。窗口是运维配的时候这只是个瑕疵；窗口交到用户手里之后，它精确地
+违背用户的预期 ——「我静音它就是不想再看见它」。
+
+Batch 1 已把这条写进 brief 的已知边界，并注明「Batch 2 之前必须处理」。
+
+难点是**两个端点对 mute 的可见性不对称**，而消除这种不对称正是 Batch 1 存在的理由：
+
+- `/v1/conversation/sync`：`api_conversation.go:699-710` 已经从 `userDetail.Mute` /
+  `group.Mute` 解析出 mute，并写进 `SyncUserConversationResp.Mute`（`:1503`）。过滤器在其后运行，
+  **拿得到**。
+- `/v1/sidebar/sync`：`api_sidebar.go` 里 **mute 出现 0 次**。`buildRecentItems` 吃的是
+  `[]*config.SyncUserConversationResp`（IM 原始类型，无 Mute 字段）。**拿不到**，需要新增查询。
+
+只在能拿到的那一端接 mute，就会重新制造 Batch 1 刚消灭的 per-endpoint 分叉。
+
+### 4 · 现有 `/v1/user/space/setting` 的实际状态（已核查）
+
+端点已存在（`modules/user/api_space_setting.go`，路由 `modules/user/api.go:274-278`），但扩展它
+之前有三件事必须知道：
+
+1. **它没走 i18n 错误信封。** 全文用 `c.ResponseErrorWithStatus(errors.New(...))` 和
+   `c.JSON`，CLAUDE.md 明令禁止。它现在能过 CI 只是因为 D23 lint 只 AST 计数
+   `AbortWithStatusJSON` / `AbortWithStatus`（`tools/lint-direct-error-response/main.go:152`），
+   抓不到 `ResponseErrorWithStatus`。它也不在 `TestMigratedUserFilesNoLegacyResponseError`
+   的清单里（`api_i18n_test.go:81-84`）。
+2. **PUT 的取值校验写死了布尔。** `val != 0 && val != 1` 一律 400（`api_space_setting.go:65-68`），
+   `UpdateSpaceSetting` 的字段白名单也是硬编码 switch（`db_space_setting.go:47-52`）。
+   天数是任意整数，且需要一个「取消设置」的表达 —— 现有形状表达不了。
+3. **路由没挂限流。** `spaceSetting := r.Group("/v1/user/space", AuthMiddleware, SpaceMiddleware)`，
+   没有 `SharedUIDRateLimiter`。CLAUDE.md 规定已认证端点默认要挂。
+
+表结构 `user_space_setting`（`modules/user/sql/20260522000001_user_space_setting.sql`）：
+`uid` / `space_id` / 两个 `voice_*` 列 / `UNIQUE KEY uk_uid_space (uid, space_id)`。
+现有列都是 `NOT NULL DEFAULT`，**没有可空列的先例**。
+
+### 5 · 三态取值，以及 0 为什么不能复用
+
+| 存储 | 含义 |
+|---|---|
+| `NULL` | 未设置 → 继承全局默认 |
+| `0` | 用户**显式**要求不过滤 |
+| `N > 0` | 用户自定义 N 天 |
+
+`0` 不能兼作「未设置」：在全局层 `0` 已经是「该类型不过滤」的哨兵
+（`system_setting_schema.go:125-129` 三个 key 的描述都写着 `0=不过滤`）。若用 `0` 表示未设置，
+用户就永远无法表达「我不要过滤」——运维一旦把全局默认调成 7 天，这个用户会被迫跟着变。
+
+## Load-bearing list
+
+- **`space` / `isolation`** — 窗口是 per-(uid, space)。读路径必须只拿当前请求 Space 的设置；
+  写路径必须只能改**自己**的。`/v1/sidebar/sync` 存在无 Space key 的跨 Space 请求
+  （Batch 1 已确认并写进 swagger），那条路径上「当前 Space 的窗口」无定义，必须显式决定语义。
+- **`wire-contract`** — 三处：
+  (a) `GET/PUT /v1/user/space/setting` 的请求/响应体扩展。现有响应是扁平 `gin.H`，三个字段恒非空；
+      新字段需要能表达「未设置」，`omitempty` 会把合法的 `0` 一起吞掉。
+  (b) **cursor 推进不得被任何新过滤影响** —— sidebar `respVersion` 基于 `rawConversations`、
+      conversation/sync `lastVersion` 基于过滤前列表（PR #21 Round-4 B1 / PR-B #1377）。
+      违反会复现客户端反复拉同一批的死循环。
+  (c) **改了设置但 cursor 已推过去**：用户把窗口从 3 天调到 30 天，之前被过滤掉的会话
+      version 低于客户端游标，增量同步永远拉不到它们。需要一个让客户端知道「该全量重拉」的信号。
+- **`error-response` / `i18n`** — 新的校验错误必须走 `httperr.ResponseErrorL` + 注册的
+  `pkg/errcode` code。同时决定是否顺手迁移 `api_space_setting.go` 既有的 5 处 legacy 响应
+  （见 Out of scope）。
+- **`rate-limit`** — PUT 从「运维偶尔调一次」变成用户可写，必须挂 `SharedUIDRateLimiter`，
+  且要挂在 `AuthMiddleware` **之后**否则读不到 uid、静默 fail-open。
+- **`thread`** — 子区窗口与全局归档窗口的偏序天花板；`ArchiveStaleBatch` 的
+  `reminders` / `reminder_done` 未解决 @我 判定（`modules/thread/db.go:446-453`）是
+  「静音但保留」的现成机制，缺口 B 的修法应当复用它而不是另造一个。
+- **`system-setting`** — 偏序守卫（`api_manager_system_setting.go:343-370`）、
+  `ApplyThreadArchiveOrderingOverlay`、`ViolatesThreadArchiveOrdering`、
+  `SystemSettings` 的 60s TTL 快照。守卫要从「事务外读进程快照」改成「事务内加锁重读」，
+  且需同时覆盖管理台写入与新增的每用户写入。
+- **两个端点的可见集合必须逐条一致** —— Batch 1 的核心不变量，由
+  `TestRecentWindow_BothEndpointsAgree` 钉住。mute 与每人窗口都必须同时落到两条路径，
+  否则该测试立即变红（这是设计意图：它就是用来挡这种分叉的）。
+- **`SidebarItem` / `SyncUserConversationResp` 的 `mute` 可见性不对称** —— 见 Background §3。
+
+## Out of scope
+
+- **每子区归档时长（Batch 3）**。`thread.auto_archive_days` 本批仍是全局值。
+- **PR #679 遗留的五条 advisory 不是 out-of-scope，而是本批的第一个 commit** —— 评审第 6/7 轮
+  两次要求「转成 follow-up、不要回推那个已批准的分支」，所以它们落在这里。见下方 Acceptance §P2。
+- **`ArchiveConfig.Enabled` / `Threshold` 死字段的删除** —— 要重构约 15 个 worker 测试，
+  与本批目标无关，继续挂在 follow-up。
+- **`modules/message` 的 `-tags integration` import cycle** —— 既有缺陷，`origin/main` 同样复现。
+  本批不修，但它会继续挡住 handler 级验收（见 Acceptance 的诚实标注）。
+- **运维调优项** `INTERVAL` / `BATCH_SIZE` / `BATCH_SLEEP` 仍留 env。
+- **`api_space_setting.go` 中与本批无关的既有 legacy 响应的全量迁移** —— 待定，见 Open questions 2。
+- **客户端实现**。本批只出服务端契约；web/iOS/Android 的设置界面另行排期。
+
+## Acceptance
+
+### P0 — 前置缺口 A：偏序守卫的写竞态
+
+- [ ] 守卫改为**事务内**校验：`SELECT ... FOR UPDATE` 锁住三行
+      （`thread.auto_archive_enabled` / `thread.auto_archive_days` /
+      `sidebar.recent_filter_thread_days`），在锁内用行的真实值重跑
+      `ApplyThreadArchiveOrderingOverlay` + `ViolatesThreadArchiveOrdering`。
+- [ ] 并发回归：两个 goroutine 从 `enabled=true, archive=6, recent=3` 出发分别写
+      `archive=4` 与 `recent=5`，断言**恰好一个**成功、DB 终态不违反偏序。
+      当前实现下该用例必须先失败（钉住缺陷存在），修复后转绿。
+- [ ] 行不存在时（回落 env/默认）的加锁语义有明确定义并有用例 —— `FOR UPDATE` 锁不住
+      不存在的行，不能因此绕过守卫。
+- [ ] 每用户窗口的写入走同一条校验，不得另开一条不加锁的旁路。
+- [ ] 既有 `TestManagerSystemSetting_Ordering*` 全部仍绿（含重置为默认那条）。
+
+### P0 — 前置缺口 B：静音但有未读
+
+- [ ] `keepDespiteRecentWindow` 的未读豁免加入 mute 维度，**两个端点行为一致**，
+      `TestRecentWindow_BothEndpointsAgree` 保持绿。
+- [ ] `/v1/sidebar/sync` 侧补齐 mute 来源，且与 `/v1/conversation/sync` 的
+      `userDetail.Mute` / `group.Mute` 同源 —— 不同源就是新的 per-endpoint 分叉。
+- [ ] **静音 + 有未解决的 @我 仍然保留**，复用 `reminders` / `reminder_done` 的判定
+      （与 `ArchiveStaleBatch` 同一机制，`modules/thread/db.go:446-453`）。
+- [ ] mute 查询失败 **fail-open**：按未静音处理（宁可多显示，绝不误藏），与本仓库既有降级方向一致。
+- [ ] 用例矩阵：`{静音, 未静音} × {有未读, 无未读} × {有@我, 无@我}` 在超窗输入上的可见性。
+
+### P1 — 每人窗口存储与解析
+
+- [ ] `user_space_setting` 新增三个**可空** int 列，迁移不写任何行、不改现有行 →
+      上线瞬间行为与现网完全一致。
+- [ ] 三态解析：`NULL` 继承全局 / `0` 显式不过滤 / `N` 自定义。三条各有用例。
+- [ ] 解析顺序：per-user → 全局 `system_setting` → env → 代码默认。
+- [ ] **天花板**：用户的子区窗口不得超过生效的全局归档窗口。越界时的行为需明确
+      （拒绝写入 vs 写入后读时钳制），并与管理台守卫用同一个判定函数。
+- [ ] 读路径每请求最多一次设置查询，且失败时 **fail-open** 回落全局默认。
+
+### P1 — `GET/PUT /v1/user/space/setting` 扩展
+
+- [ ] GET 返回三个窗口的当前值，**能区分「未设置」与「设置为 0」**。
+      现有响应是扁平 `gin.H` 且字段恒非空，需要显式决定表达方式（`null` / 独立的
+      `*_source` 字段 / 嵌套对象），并写进 swagger。
+- [ ] PUT 接受天数并支持**取消设置**（回到继承）。现有 `val != 0 && val != 1` 的布尔校验
+      必须为新字段放开，且不得放松既有三个布尔字段的校验。
+- [ ] `UpdateSpaceSetting` 的字段白名单同步扩展（`db_space_setting.go:47-52` 的硬编码 switch）。
+- [ ] 越界/非法值走 `httperr.ResponseErrorL` + 注册的 `pkg/errcode` code，
+      `make i18n-extract-check` 与 `make i18n-lint` 通过，zh-CN 译文补齐。
+- [ ] 路由挂上 `SharedUIDRateLimiter`，且在 `AuthMiddleware` **之后**。
+      测试须在 setup 里清 `ratelimit:uid:*`（该 bucket 不被 `CleanAllTables` 清理）。
+- [ ] **Space 隔离**：A 用户改不了 B 的设置；Space X 的设置不影响 Space Y。各有用例。
+
+### P1 — cursor 与设置变更的交互
+
+- [ ] 改设置后，先前被过滤掉的会话能重新出现 —— 不能因为它们的 version 低于客户端游标就永久丢失。
+- [ ] cursor 推进仍基于**过滤前**的原始列表（sidebar `respVersion` / conversation `lastVersion`），
+      构造「本批最高 version 的会话恰被新窗口过滤掉」的用例断言游标仍前进。
+      *（注：handler 级用例受既有 import cycle 阻塞，见 Out of scope；本条须给出可运行的替代形式。）*
+
+### P2 — PR #679 结转的五条 advisory（本批第一个 commit）
+
+评审第 6/7 轮均判定「不值得为它们再开一个 head」，因为每个新 head 都会作废全部批准并触发一次
+完整重审。因此它们结转到这里，作为独立的、先于功能代码的一个 commit。
+
+- [ ] `modules/common/system_settings.go:681` —— `threadAutoArchiveDaysFromEnv` 的
+      `strings.TrimSpace` 与 legacy `parseDays` 不一致：`" 9999 "` 在新实现下解析成 9999，
+      在 legacy 下回落默认。**这是「上线逐字节相同」唯一不成立的输入。**
+      要么去掉 `TrimSpace`，要么改注释别再宣称精确镜像，并把 brief / PR 里的措辞
+      改成「除首尾空白外逐字节相同」。
+- [ ] `modules/thread/archive_config.go:13` —— `Enabled` 的注释描述的是 PR 之前的启动门。
+      标记为死字段或指向 `system_settings`。
+- [ ] `modules/thread/archive_config.go:63-70` —— `parseDays` 回落路径未设上界，
+      按 `archiveThresholdFromDays` 同样的方式钳住，避免该路径仍能回绕。
+- [ ] Batch 1 `brief.md:211` —— web「无回归」的理由不准确：真正的理由是**主最近列表
+      从不消费 `/v1/sidebar/sync`**（它走 `/v1/conversation/sync`），而不是「客户端会自己过滤
+      这个端点」。后者会让 Batch 2 依赖一个并不存在的客户端过滤。
+- [ ] **worker 启动时打一次生效的归档/隐藏偏序**（第 7 轮新提）。当前守卫只覆盖 DB→DB
+      写入，`ViolatesThreadArchiveOrdering` 在 `!ArchiveEnabled` 时短路，所以「纯 env 配出的
+      违规状态」不写一次管理接口就永远不暴露。启动日志正好补上这个洞。
+
+### 全局
+
+- [ ] `go build ./...`、gofmt、`golangci-lint run` 0 issues。
+- [ ] `make i18n-extract-check` + `make i18n-lint` 通过。
+- [ ] `modules/{user,message,common,thread}` 默认 tag 全量测试通过（**分包跑并重建 test 库** ——
+      各包注册的模块子集不同，同一次 `go test` 跑两个包会让 sql-migrate 报 unknown migration 并 panic）。
+
+## 已拍板
+
+- **静音 + 有未读 → 允许淡出，`@我` 兜底。**（2026-08-03 确认）
+  静音的语义是「我主动降低它的优先级」，与「窗口让安静的东西淡出」同向；`@我` 是别人点名，
+  优先级不由自己定，不该被自己的静音吞掉。判定复用 `ArchiveStaleBatch` 已有的
+  `reminders` / `reminder_done` 未解决 `@我` 机制，不另造。P0-B 的验收按此写。
+
+## Open questions
+
+1. **越界写入：拒绝还是钳制？** 用户把子区窗口设成 30 天、而全局归档是 14 天 ——
+   400 拒绝（诚实但需要客户端解释「为什么我不能设 30」），还是接受并在读时钳到 14
+   （宽容但用户看到的和他设的不一致）。倾向**接受 + 读时钳制 + GET 回一个 effective 值**，
+   理由是全局归档窗口可能事后调小，任何写时校验都会被时间打破。
+2. **顺手迁移 `api_space_setting.go` 的既有 legacy 响应吗？** 该文件 5 处
+   `ResponseErrorWithStatus` + 1 处 `c.JSON`，D23 lint 抓不到（只计 `Abort*`），
+   但违反 CLAUDE.md 明文。倾向**顺手迁完并加进
+   `TestMigratedUserFilesNoLegacyResponseError` 清单** —— 半迁移的文件会让下一个人无所适从，
+   而本批本来就要在同一个文件里加新的错误路径。代价是 diff 变大、混入与功能无关的改动。
+3. **无 Space key 的 `/v1/sidebar/sync` 请求用谁的窗口？** 该路径返回跨 Space 列表
+   （Batch 1 已确认并写进 swagger），「当前 Space 的每人窗口」无定义。
+   候选：退回全局默认（最简单、可预期）/ 取各 Space 设置的并集或最宽值（最贴近用户意图、但要 N 次查询）。
+   倾向**退回全局默认**，并写进 swagger。

--- a/.octospec/tasks/per-user-hiding-window/context.yaml
+++ b/.octospec/tasks/per-user-hiding-window/context.yaml
@@ -1,0 +1,26 @@
+injected:
+  - id: space-isolation
+    source: repo
+  - id: trust-boundary
+    source: repo
+  - id: error-handling
+    source: repo
+  - id: rate-limit
+    source: repo
+  - id: testing
+    source: repo
+  - id: commit-style
+    source: repo
+brief: .octospec/tasks/per-user-hiding-window/brief.md
+notes: |
+  Resolved from the brief's load-bearing tags (space, isolation, wire-contract,
+  error-response, i18n, rate-limit, thread, system-setting, testing) and from
+  the paths this batch will touch (modules/**/*.go, **/*_test.go, **).
+  .octospec/_global/ is not synced in this checkout, so every rule resolves at
+  repo tier.
+
+  Scope note for the first commit (the five #679 carry-overs): it touches no
+  HTTP handler, so error-handling / rate-limit / space-isolation / trust-boundary
+  impose no new constraint on it beyond running the i18n gates. They are recorded
+  here because they govern the rest of the batch — the /v1/user/space/setting
+  extension is squarely inside all four.

--- a/modules/common/api_manager_system_setting.go
+++ b/modules/common/api_manager_system_setting.go
@@ -357,22 +357,29 @@ func (m *Manager) updateSystemSettings(c *wkhttp.Context) {
 			orderingIncoming[p.def.Category+"."+p.def.Key] = p.value
 		}
 	}
+	// Atomic batch: open one transaction, queue every upsert, commit only
+	// if all rows succeed. A mid-batch DB failure rolls back everything
+	// rather than leaving callers to debug partial state.
+	//
+	// The ordering guard runs INSIDE this transaction (below), not before it.
+	// An earlier revision validated against m.systemSettings.ThreadArchiveOrdering()
+	// — a process-local snapshot with a 60s TTL that only the writing replica
+	// refreshes eagerly — and then opened the transaction, so the check and the
+	// write were merely adjacent rather than atomic: from {enabled, archive=6,
+	// recent=3}, one request setting archive=4 and another setting recent=5 each
+	// passed against the same stale view (4>=3, 6>=5) and both committed, landing
+	// 4 < 5 (task per-user-hiding-window / P0-A, from PR #679 review).
+	// Restore the anchor row before opening the transaction, never inside it —
+	// healing must not interact with the lock the transaction is about to take.
+	// No-op in a healthy deployment; see ensureGuardAnchor.
 	if len(orderingIncoming) > 0 {
-		prospective := ApplyThreadArchiveOrderingOverlay(
-			m.systemSettings.ThreadArchiveOrdering(), orderingIncoming,
-		)
-		if ViolatesThreadArchiveOrdering(prospective) {
-			httperr.ResponseErrorL(c, errcode.ErrThreadArchiveWindowOrdering, nil, i18n.Details{
-				"archive_days": strconv.Itoa(prospective.ArchiveDays),
-				"recent_days":  strconv.Itoa(prospective.RecentDays),
-			})
+		if err := m.systemSettingDB.ensureGuardAnchor(); err != nil {
+			m.Error("恢复配置守卫锚点行失败", zap.Error(err))
+			c.ResponseError(errors.New("写入系统设置失败"))
 			return
 		}
 	}
 
-	// Atomic batch: open one transaction, queue every upsert, commit only
-	// if all rows succeed. A mid-batch DB failure rolls back everything
-	// rather than leaving callers to debug partial state.
 	tx, err := m.systemSettingDB.beginTx()
 	if err != nil {
 		m.Error("开启事务失败", zap.Error(err))
@@ -385,6 +392,40 @@ func (m *Manager) updateSystemSettings(c *wkhttp.Context) {
 			_ = tx.Rollback()
 		}
 	}()
+
+	// Guard, under the lock, before any row is written. Skipped entirely when the
+	// batch touches none of the three keys, so unrelated settings writes pay
+	// neither the lock nor the extra reads.
+	if len(orderingIncoming) > 0 {
+		// The anchor row must be locked FIRST — see lockGuardAnchorWithTx. Locking
+		// the three setting rows instead cannot work: the migration deliberately
+		// writes none of them, and FOR UPDATE over absent rows yields only mutually
+		// compatible gap locks, so both writers would pass and then deadlock on
+		// insert intention.
+		if err := m.systemSettingDB.lockGuardAnchorWithTx(tx); err != nil {
+			m.Error("获取配置守卫锁失败", zap.Error(err))
+			c.ResponseError(errors.New("写入系统设置失败"))
+			return
+		}
+		rows, err := m.systemSettingDB.loadValuesWithTx(tx, ThreadArchiveOrderingKeys())
+		if err != nil {
+			m.Error("读取偏序守卫相关配置失败", zap.Error(err))
+			c.ResponseError(errors.New("写入系统设置失败"))
+			return
+		}
+		// Resolved from the rows just read under the lock, NOT from the snapshot.
+		prospective := ApplyThreadArchiveOrderingOverlay(
+			ResolveThreadArchiveOrderingFrom(rows), orderingIncoming,
+		)
+		if ViolatesThreadArchiveOrdering(prospective) {
+			httperr.ResponseErrorL(c, errcode.ErrThreadArchiveWindowOrdering, nil, i18n.Details{
+				"archive_days": strconv.Itoa(prospective.ArchiveDays),
+				"recent_days":  strconv.Itoa(prospective.RecentDays),
+			})
+			return
+		}
+	}
+
 	for _, p := range plans {
 		if p.skip {
 			continue

--- a/modules/common/api_manager_system_setting.go
+++ b/modules/common/api_manager_system_setting.go
@@ -375,7 +375,7 @@ func (m *Manager) updateSystemSettings(c *wkhttp.Context) {
 	if len(orderingIncoming) > 0 {
 		if err := m.systemSettingDB.ensureGuardAnchor(); err != nil {
 			m.Error("恢复配置守卫锚点行失败", zap.Error(err))
-			c.ResponseError(errors.New("写入系统设置失败"))
+			httperr.ResponseErrorL(c, errcode.ErrSharedInternal, nil, nil)
 			return
 		}
 	}
@@ -396,6 +396,14 @@ func (m *Manager) updateSystemSettings(c *wkhttp.Context) {
 	// Guard, under the lock, before any row is written. Skipped entirely when the
 	// batch touches none of the three keys, so unrelated settings writes pay
 	// neither the lock nor the extra reads.
+	//
+	// The three failure paths below respond through the i18n envelope
+	// (err.shared.internal — 500, Internal:true, so the renderer hides the cause
+	// and the reason stays in the log). The neighbouring DB failures in this
+	// handler still use the legacy c.ResponseError: modules/common has not been
+	// migrated (no baseline entry, no NoLegacyResponseError guard test), and
+	// migrating all 13 sites is out of this task's scope. New code follows the
+	// rule regardless — this file should not accumulate more of them.
 	if len(orderingIncoming) > 0 {
 		// The anchor row must be locked FIRST — see lockGuardAnchorWithTx. Locking
 		// the three setting rows instead cannot work: the migration deliberately
@@ -404,13 +412,13 @@ func (m *Manager) updateSystemSettings(c *wkhttp.Context) {
 		// insert intention.
 		if err := m.systemSettingDB.lockGuardAnchorWithTx(tx); err != nil {
 			m.Error("获取配置守卫锁失败", zap.Error(err))
-			c.ResponseError(errors.New("写入系统设置失败"))
+			httperr.ResponseErrorL(c, errcode.ErrSharedInternal, nil, nil)
 			return
 		}
 		rows, err := m.systemSettingDB.loadValuesWithTx(tx, ThreadArchiveOrderingKeys())
 		if err != nil {
 			m.Error("读取偏序守卫相关配置失败", zap.Error(err))
-			c.ResponseError(errors.New("写入系统设置失败"))
+			httperr.ResponseErrorL(c, errcode.ErrSharedInternal, nil, nil)
 			return
 		}
 		// Resolved from the rows just read under the lock, NOT from the snapshot.

--- a/modules/common/db_system_setting.go
+++ b/modules/common/db_system_setting.go
@@ -1,6 +1,8 @@
 package common
 
 import (
+	"errors"
+
 	"github.com/Mininglamp-OSS/octo-lib/config"
 	ldb "github.com/Mininglamp-OSS/octo-lib/pkg/db"
 	"github.com/gocraft/dbr/v2"
@@ -52,6 +54,85 @@ func (s *systemSettingDB) upsertWithTx(tx *dbr.Tx, category, key, value, valueTy
 // admin payload without producing partial writes on mid-batch error.
 func (s *systemSettingDB) beginTx() (*dbr.Tx, error) {
 	return s.session.Begin()
+}
+
+// errGuardAnchorMissing means the serialisation anchor row is gone even after
+// ensureGuardAnchor tried to restore it, so a cross-key guard cannot be
+// serialised. Fail closed: an admin config write is not a hot path, and
+// validating without the lock is exactly the race the anchor exists to close.
+var errGuardAnchorMissing = errors.New("system_setting_guard_lock anchor row is missing")
+
+// ensureGuardAnchor restores the anchor row if it is absent. Call it BEFORE
+// opening the guarded transaction — never inside it, so healing cannot interact
+// with the lock the transaction is about to take.
+//
+// The migration seeds the row, so this is a no-op in a healthy deployment. It
+// exists because the row is trivially destroyable — a truncate-based restore, a
+// test harness that clears every table (testutil.CleanAllTables does) — and
+// without it a lost row turns every guarded settings write into a hard failure
+// that reads like a database outage. Healing is safe precisely because the row
+// carries no state: its identity is the whole of its content.
+func (s *systemSettingDB) ensureGuardAnchor() error {
+	_, err := s.session.InsertBySql(
+		"INSERT IGNORE INTO system_setting_guard_lock (guard_key) VALUES (1)",
+	).Exec()
+	return err
+}
+
+// lockGuardAnchorWithTx takes an X lock on the single system_setting_guard_lock
+// row, serialising every cross-key guard evaluation that runs in a transaction.
+//
+// It must be the FIRST statement in the guarded transaction: everything after it
+// — the re-read of the current rows, the merge, the violation check, the upserts
+// — then happens with no other guarded writer in flight, on any replica, which is
+// what makes the check-then-write atomic rather than merely adjacent.
+//
+// Locking a necessarily-existing single row rather than the (possibly absent)
+// setting rows themselves is deliberate; see the migration comment for why gap
+// locks degrade into a deadlock here.
+func (s *systemSettingDB) lockGuardAnchorWithTx(tx *dbr.Tx) error {
+	var key int
+	found, err := tx.SelectBySql(
+		"SELECT guard_key FROM system_setting_guard_lock WHERE guard_key=1 FOR UPDATE",
+	).Load(&key)
+	if err != nil {
+		return err
+	}
+	if found == 0 {
+		return errGuardAnchorMissing
+	}
+	return nil
+}
+
+// loadValuesWithTx reads the given (category, key_name) pairs inside the
+// transaction and returns them keyed by schemaKey(category, key).
+//
+// This is the "re-read under the lock" half of the guard: validating against
+// SystemSettings' in-memory snapshot is what allowed the skew, because that
+// snapshot has a 60s TTL and only the writing replica refreshes it eagerly.
+//
+// Rows that do not exist are simply absent from the result, and an existing row
+// with an empty value is returned as-is — the caller resolves both through the
+// same env → code-default chain the snapshot getters use, where lookup() already
+// treats "" as not-configured.
+func (s *systemSettingDB) loadValuesWithTx(tx *dbr.Tx, pairs [][2]string) (map[string]string, error) {
+	out := make(map[string]string, len(pairs))
+	if len(pairs) == 0 {
+		return out, nil
+	}
+	for _, p := range pairs {
+		var value string
+		found, err := tx.SelectBySql(
+			"SELECT value FROM system_setting WHERE category=? AND key_name=?", p[0], p[1],
+		).Load(&value)
+		if err != nil {
+			return nil, err
+		}
+		if found > 0 {
+			out[schemaKey(p[0], p[1])] = value
+		}
+	}
+	return out, nil
 }
 
 // runner is the minimal surface common to *dbr.Session and *dbr.Tx that we

--- a/modules/common/sql/20260803000001_add_system_setting_guard_lock.sql
+++ b/modules/common/sql/20260803000001_add_system_setting_guard_lock.sql
@@ -1,0 +1,32 @@
+-- +migrate Up
+
+-- system_setting_guard_lock: 跨键系统配置守卫的**串行化锚点**。
+--
+-- 背景（task per-user-hiding-window / P0-A，结转自 PR #679 review）：
+-- 两阶段衰减偏序守卫（thread.auto_archive_days >= sidebar.recent_filter_thread_days）
+-- 原先对着进程本地快照校验、且在事务之外，于是两个并发的管理写入各自看到同一份旧快照、
+-- 双双通过校验、双双提交，落到守卫本要禁止的状态。
+--
+-- 为什么需要一张单独的表，而不是直接 `SELECT ... FOR UPDATE` 那三个 system_setting 行：
+-- 那三行**可能都不存在**（迁移刻意不写行，取值回落 env / 代码默认，这是 Batch 1 的
+-- 上线安全保证）。对不存在的行做 FOR UPDATE 只拿到 gap lock，而 gap-X 锁彼此兼容 ——
+-- 并发事务会全部通过校验，随后各自 INSERT 抢 insert-intention lock 互等，退化成
+-- InnoDB 死锁(1213)，把一次合法的并发写变成不透明的 500。本仓库在
+-- incomingwebhook.insertWithQuota 上已经踩过并记录过同一个坑，结论是「锁一个必然存在的
+-- 单行」；card_template_catalog_capacity_guard 用的也是这个形状。
+--
+-- 单行、无业务字段：它只承担串行化，不存任何状态。CHECK 把主键钉死在 1，杜绝出现第二行
+-- 导致两批写入锁到不同锚点。未来其它跨键守卫（如 onboarding.space_welcome_* 复合校验，
+-- 它有同一个洞）可以复用本表，届时把 guard_key 换成具名主键即可。
+CREATE TABLE `system_setting_guard_lock` (
+    `guard_key`  TINYINT UNSIGNED NOT NULL,
+    `created_at` TIMESTAMP        NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (`guard_key`),
+    CONSTRAINT `chk_system_setting_guard_lock` CHECK (`guard_key` = 1)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci COMMENT='跨键系统配置守卫的串行化锚点行';
+
+INSERT INTO `system_setting_guard_lock` (`guard_key`) VALUES (1);
+
+-- +migrate Down
+
+DROP TABLE `system_setting_guard_lock`;

--- a/modules/common/system_setting_schema.go
+++ b/modules/common/system_setting_schema.go
@@ -136,9 +136,14 @@ var systemSettingSchema = []settingDef{
 	//
 	// days 与 sidebar.recent_filter_thread_days 之间存在偏序约束
 	// （archive_days >= recent_filter_thread_days），在写路径强制：
-	// api_manager_system_setting.go 的 updateSystemSettings 里，per-item 校验之后、
-	// 开启事务之前的那段 orderingIncoming 收集 + ApplyThreadArchiveOrderingOverlay
-	// + ViolatesThreadArchiveOrdering。三个 key 的写入都会经过它。
+	// api_manager_system_setting.go 的 updateSystemSettings 里，**事务内**、
+	// 取得 system_setting_guard_lock 锚点行锁之后的那段 —— 锁内重读三行的真实值，
+	// 再跑 ApplyThreadArchiveOrderingOverlay + ViolatesThreadArchiveOrdering。
+	// 三个 key 的写入都会经过它。
+	//
+	// 位置是要点：先前它在开启事务**之前**对着进程本地快照校验，check 与 write 只是
+	// 相邻而非原子，两个并发写入会各自通过再双双提交出违规状态
+	// （task per-user-hiding-window / P0-A）。
 	{Category: "thread", Key: "auto_archive_enabled", Type: settingTypeBool, Description: "是否开启子区不活跃自动归档",
 		Effective: func(s *SystemSettings) string { return boolToCanonical(s.ThreadAutoArchiveEnabled()) }},
 	{Category: "thread", Key: "auto_archive_days", Type: settingTypeInt, Description: "子区自动归档的不活跃阈值(天)，0=禁用时间阈值",

--- a/modules/common/system_settings.go
+++ b/modules/common/system_settings.go
@@ -664,6 +664,20 @@ func threadAutoArchiveEnabledFromEnv() bool {
 // legitimate "disable the threshold" value, and any other non-negative integer
 // is honoured verbatim — including values above settingIntMax.
 //
+// "Exactly" includes NOT trimming whitespace. An earlier revision wrapped the
+// lookup in strings.TrimSpace, which reads like a harmless convenience but was
+// the one input where this migration was not behaviour-identical on rollout
+// (PR #679 review, yujiawei): legacy parseDays hands " 9999 " straight to
+// strconv.Atoi, which fails, so today such a deployment archives at the 3-day
+// default — while the trimming version resolves it to 9999 and effectively
+// stops archiving. Whichever reading matches the operator's intent, silently
+// switching between them on a rollout is not this shim's job.
+// TestThreadAutoArchiveDaysFromEnv_MatchesLegacyParseDays pins the equivalence.
+//
+// Note the sibling threadAutoArchiveEnabledFromEnv DOES trim — correctly, because
+// the legacy parseBool it mirrors trims too. The rule is "match the legacy parser",
+// not "trim" or "don't trim".
+//
 // The upper bound deliberately does NOT apply here (PR #679 review, Jerry-Xin).
 // An earlier revision clamped the env layer too, on a defence-in-depth
 // argument, but that silently reinterprets an existing deployment's config:
@@ -678,7 +692,9 @@ func threadAutoArchiveEnabledFromEnv() bool {
 // or a documented fallback (getIntClamped) rather than a silent
 // reinterpretation.
 func threadAutoArchiveDaysFromEnv() int {
-	raw := strings.TrimSpace(os.Getenv(envThreadAutoArchiveDays))
+	// NOT TrimSpace — see the doc comment above. Legacy parseDays reads the raw
+	// value, so this must too.
+	raw := os.Getenv(envThreadAutoArchiveDays)
 	if raw == "" {
 		return defaultThreadAutoArchiveDays
 	}

--- a/modules/common/system_settings.go
+++ b/modules/common/system_settings.go
@@ -244,11 +244,11 @@ func (s *SystemSettings) getInt(category, key string, fallback int) int {
 // direct DB edit could still introduce — falls back to the code default rather
 // than being served verbatim. Defence in depth for the int settings (D-289).
 func (s *SystemSettings) getIntClamped(category, key string, fallback int) int {
-	v := s.getInt(category, key, fallback)
-	if v < settingIntMin || v > settingIntMax {
+	v, ok := s.lookup(category, key)
+	if !ok {
 		return fallback
 	}
-	return v
+	return parseSettingIntClamped(v, fallback)
 }
 
 func (s *SystemSettings) getFloat(category, key string, fallback float64) float64 {
@@ -587,6 +587,65 @@ func (s *SystemSettings) ThreadArchiveOrdering() ThreadArchiveOrdering {
 		ArchiveDays:    s.ThreadAutoArchiveDays(),
 		RecentDays:     s.SidebarRecentFilterThreadDays(),
 	}
+}
+
+// ThreadArchiveOrderingKeys enumerates the (category, key) pairs the two-stage
+// decay guard reads. Exported-shaped as a function so the write path and the
+// tests cannot drift from the overlay's key strings.
+func ThreadArchiveOrderingKeys() [][2]string {
+	return [][2]string{
+		{"thread", "auto_archive_enabled"},
+		{"thread", "auto_archive_days"},
+		{"sidebar", "recent_filter_thread_days"},
+	}
+}
+
+// ResolveThreadArchiveOrderingFrom builds the ordering from raw system_setting
+// values — the ones read inside the guarded transaction — applying the same
+// DB → env → code-default chain the snapshot getters apply.
+//
+// It exists because SystemSettings.ThreadArchiveOrdering() reads the in-memory
+// snapshot, which has a 60s TTL and is refreshed eagerly only on the writing
+// replica. Validating against that snapshot is precisely what let two concurrent
+// admin writes each pass against a stale view and commit a state the guard
+// forbids (task per-user-hiding-window / P0-A).
+//
+// `rows` holds only the keys that have a row; a missing key falls back, and an
+// existing row with an empty value falls back too — mirroring lookup(), which
+// reports "" as not-configured. Ints mirror getIntClamped: unparseable or
+// outside [settingIntMin, settingIntMax] falls back rather than being honoured,
+// so a row written before the bound existed cannot smuggle a value past the
+// guard that the getters would never return.
+func ResolveThreadArchiveOrderingFrom(rows map[string]string) ThreadArchiveOrdering {
+	o := ThreadArchiveOrdering{
+		ArchiveEnabled: threadAutoArchiveEnabledFromEnv(),
+		ArchiveDays:    threadAutoArchiveDaysFromEnv(),
+		RecentDays:     defaultSidebarRecentFilterThreadDays,
+	}
+	if v, ok := rows[schemaKey("thread", "auto_archive_enabled")]; ok && v != "" {
+		o.ArchiveEnabled = parseSettingBool(v, o.ArchiveEnabled)
+	}
+	if v, ok := rows[schemaKey("thread", "auto_archive_days")]; ok && v != "" {
+		o.ArchiveDays = parseSettingIntClamped(v, o.ArchiveDays)
+	}
+	if v, ok := rows[schemaKey("sidebar", "recent_filter_thread_days")]; ok && v != "" {
+		o.RecentDays = parseSettingIntClamped(v, o.RecentDays)
+	}
+	return o
+}
+
+// parseSettingIntClamped is the string-level half of getIntClamped, factored out
+// so the in-transaction resolver and the snapshot getter cannot diverge on what
+// an out-of-range stored value means.
+func parseSettingIntClamped(v string, fallback int) int {
+	n, err := strconv.Atoi(v)
+	if err != nil {
+		return fallback
+	}
+	if n < settingIntMin || n > settingIntMax {
+		return fallback
+	}
+	return n
 }
 
 // ApplyThreadArchiveOrderingOverlay merges an incoming admin batch onto the

--- a/modules/common/thread_archive_env_parity_test.go
+++ b/modules/common/thread_archive_env_parity_test.go
@@ -1,0 +1,96 @@
+package common
+
+// =============================================================================
+// DM_THREAD_AUTO_ARCHIVE_DAYS 的两个解析器必须逐字节一致
+// （task per-user-hiding-window / P2，结转自 PR #679 review 第 6-7 轮）
+//
+// 迁移把归档天数的真源移到 system_settings，env 降级为兼容垫，兼容垫的全部价值就是
+// 「上线瞬间行为与现网逐字节相同」。但同一个 env 变量现在有两个解析器 ——
+// common.threadAutoArchiveDaysFromEnv 与 thread.parseDays —— 它们分歧就等于同一份
+// 配置有两种含义，而那个保证也就不成立了。
+//
+// 第一版在 common 侧加了 strings.TrimSpace，看着像无害的便利，实际是整个迁移中**唯一**
+// 一个行为不相同的输入：legacy parseDays 把 " 9999 " 直接喂给 Atoi（失败 → 回落 3 天，
+// 按 3 天归档），加了 TrimSpace 则解析成 9999 天（实质不归档）。评审把「grep 部署配置里
+// 有没有带空格的取值」列进了人工核查清单 —— 这个测试让那次 grep 不必再有第二回。
+//
+// 纯逻辑测试，无需 DB / IM。
+// =============================================================================
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// legacyParseDaysDays 是 modules/thread/archive_config.go 里 parseDays 解析部分的逐字
+// 复制（只保留「字符串 → 天数」，去掉 → time.Duration 的换算，便于直接比对天数）。
+//
+// 有意复制而不是 import：thread 依赖 common，反向 import 会成环；而
+// threadAutoArchiveDaysFromEnv 不导出，也无法从 thread 侧调用。复制的代价是它可能与
+// 本体漂移 —— 但下面的表覆盖了 parseDays 的每一条分支，漂移会在这里而不是在生产上暴露。
+// 等 ArchiveConfig.Enabled/Threshold 两个死字段被删除、parseDays 随之消失，这个副本
+// 和整个文件都应当一起删掉。
+func legacyParseDaysDays(raw string, defaultDays int) int {
+	if raw == "" {
+		return defaultDays
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil || n < 0 {
+		return defaultDays
+	}
+	return n
+}
+
+func TestThreadAutoArchiveDaysFromEnv_MatchesLegacyParseDays(t *testing.T) {
+	cases := []struct {
+		raw  string
+		want int
+		why  string
+	}{
+		{"", defaultThreadAutoArchiveDays, "未设置 → 代码默认"},
+		{"0", 0, "0 是合法的『禁用时间阈值』，不是未设置"},
+		{"3", 3, "常规取值"},
+		{"14", 14, "产品拍板的两阶段衰减归档侧取值"},
+		{"9999", 9999, "远超 settingIntMax，env 层有意不设上界（实质不归档）"},
+		{"-1", defaultThreadAutoArchiveDays, "负数非法 → 默认"},
+		{"abc", defaultThreadAutoArchiveDays, "非数字 → 默认"},
+		{"3.5", defaultThreadAutoArchiveDays, "Atoi 不接受小数 → 默认"},
+
+		// 回归核心：带空白的取值必须与 legacy 一致地**失败**，而不是被 trim 后解析成功。
+		{" 9999 ", defaultThreadAutoArchiveDays, "首尾空格：Atoi 失败 → 默认（不得 TrimSpace）"},
+		{" 3", defaultThreadAutoArchiveDays, "前导空格同理"},
+		{"3 ", defaultThreadAutoArchiveDays, "尾随空格同理"},
+		{"\t3", defaultThreadAutoArchiveDays, "制表符同理"},
+	}
+
+	for _, c := range cases {
+		t.Run(strconv.Quote(c.raw), func(t *testing.T) {
+			t.Setenv(envThreadAutoArchiveDays, c.raw)
+
+			got := threadAutoArchiveDaysFromEnv()
+			assert.Equal(t, c.want, got, c.why)
+			assert.Equal(t, legacyParseDaysDays(c.raw, defaultThreadAutoArchiveDays), got,
+				"两个解析器必须给出同一个天数——分歧会让『上线逐字节相同』的保证失效")
+		})
+	}
+}
+
+// enabled 侧的对照：它**应当** TrimSpace，因为它镜像的 legacy parseBool 也 TrimSpace。
+// 规则是「与 legacy 一致」，不是「一律 trim」或「一律不 trim」，这条钉住方向不被写反。
+func TestThreadAutoArchiveEnabledFromEnv_TrimsLikeLegacyParseBool(t *testing.T) {
+	for _, raw := range []string{"true", " true ", "TRUE", "1", " 1 "} {
+		t.Run(strconv.Quote(raw), func(t *testing.T) {
+			t.Setenv(envThreadAutoArchiveEnabled, raw)
+			assert.True(t, threadAutoArchiveEnabledFromEnv(),
+				"legacy parseBool 做 TrimSpace+ToLower，这一侧必须跟随")
+		})
+	}
+	for _, raw := range []string{"", "false", "0", "yes"} {
+		t.Run("false/"+strconv.Quote(raw), func(t *testing.T) {
+			t.Setenv(envThreadAutoArchiveEnabled, raw)
+			assert.False(t, threadAutoArchiveEnabledFromEnv())
+		})
+	}
+}

--- a/modules/common/thread_archive_ordering_race_test.go
+++ b/modules/common/thread_archive_ordering_race_test.go
@@ -1,0 +1,226 @@
+package common
+
+// =============================================================================
+// 偏序守卫的写竞态（task per-user-hiding-window / P0-A，结转自 PR #679 review）
+//
+// 守卫原先对着**进程本地快照**（60s TTL，只有写入方立即 Reload）校验，且校验发生在
+// 事务之外 —— check 与 write 只是相邻，不是原子。于是从 {enabled, archive=6, recent=3}
+// 出发，A 写 archive=4、B 写 recent=5，各自对着同一份旧视图都通过（4>=3、6>=5），
+// 双双提交，落到 4 < 5：正是守卫本要禁止的状态。
+//
+// PR #679 把它判为 P2 放行，理由是「需要两个 SuperAdmin 在窗口内写两个不同的 key」。
+// 本批把窗口交给用户，写入面从少数管理调用放大到每用户可写，那个理由随之失效 ——
+// 所以这是 Batch 2 的准入门，必须先关。
+//
+// 依赖 MySQL + Redis + WuKongIM（testutil.NewTestServer）。
+// =============================================================================
+
+import (
+	"net/http"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// seedOrdering 把三个 key 写成给定的起始状态（直接走 DB，绕开管理接口的守卫）。
+func seedOrdering(t *testing.T, s *SystemSettings, enabled, archiveDays, recentDays string) {
+	t.Helper()
+	require.NoError(t, s.db.upsert("thread", "auto_archive_enabled", enabled, settingTypeBool, ""))
+	require.NoError(t, s.db.upsert("thread", "auto_archive_days", archiveDays, settingTypeInt, ""))
+	require.NoError(t, s.db.upsert("sidebar", "recent_filter_thread_days", recentDays, settingTypeInt, ""))
+	require.NoError(t, s.Reload())
+}
+
+// finalOrdering 从 DB 重新解析终态，不信任进程快照。
+func finalOrdering(t *testing.T, s *SystemSettings) ThreadArchiveOrdering {
+	t.Helper()
+	require.NoError(t, s.Reload())
+	return s.ThreadArchiveOrdering()
+}
+
+// ---------------------------------------------------------------------------
+// 核心回归：并发的两个单键写入不得双双提交出违规终态
+//
+// 修复前这条必失败 —— 两个请求都会 200，终态 4 < 5。修复后守卫在锚点行锁内重读，
+// 后到的那个看到的是对方已提交的值，于是被拒。
+// ---------------------------------------------------------------------------
+
+func TestManagerSystemSetting_OrderingSurvivesConcurrentSingleKeyWrites(t *testing.T) {
+	route, ctx := newSuperAdminServer(t)
+	s := EnsureSystemSettings(ctx)
+
+	// 起点合法：归档 6 天 >= 隐藏 3 天。
+	seedOrdering(t, s, "1", "6", "3")
+
+	// A：把归档收紧到 4（对旧视图 4>=3 合法）
+	// B：把隐藏放宽到 5（对旧视图 6>=5 合法）
+	// 两者合并后 4 < 5 —— 必须恰好一个成功。
+	var wg sync.WaitGroup
+	codes := make([]int, 2)
+	bodies := make([]string, 2)
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		w := postSystemSetting(t, route,
+			`{"items":[{"category":"thread","key":"auto_archive_days","value":"4"}]}`)
+		codes[0], bodies[0] = w.Code, w.Body.String()
+	}()
+	go func() {
+		defer wg.Done()
+		w := postSystemSetting(t, route,
+			`{"items":[{"category":"sidebar","key":"recent_filter_thread_days","value":"5"}]}`)
+		codes[1], bodies[1] = w.Code, w.Body.String()
+	}()
+	wg.Wait()
+
+	okCount := 0
+	for _, c := range codes {
+		if c == http.StatusOK {
+			okCount++
+		}
+	}
+	assert.Equal(t, 1, okCount,
+		"恰好一个写入应当成功；两个都成功说明守卫仍在事务外对着旧快照校验。codes=%v bodies=%v",
+		codes, bodies)
+
+	got := finalOrdering(t, s)
+	assert.False(t, ViolatesThreadArchiveOrdering(got),
+		"DB 终态不得违反偏序，实际 archive=%d recent=%d", got.ArchiveDays, got.RecentDays)
+}
+
+// 同样的竞态，但起点是**没有任何 DB 行**（回落 env/默认）—— 这是全新部署的形状，
+// 也是「FOR UPDATE 锁不住不存在的行」那条验收针对的场景：守卫锁的是必然存在的锚点行，
+// 所以三个 setting 行是否存在与串行化无关。
+func TestManagerSystemSetting_OrderingSerialisesWhenNoRowsExist(t *testing.T) {
+	route, ctx := newSuperAdminServer(t)
+	s := EnsureSystemSettings(ctx)
+
+	t.Setenv(envThreadAutoArchiveEnabled, "true")
+	t.Setenv(envThreadAutoArchiveDays, "6")
+	require.NoError(t, s.Reload()) // 无任何 thread.* / sidebar.* 行
+
+	_, hasRow := s.lookup("thread", "auto_archive_days")
+	require.False(t, hasRow,
+		"前提：这条路径上不存在 DB 行，守卫无法靠锁 setting 行来串行化")
+
+	var wg sync.WaitGroup
+	codes := make([]int, 2)
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		codes[0] = postSystemSetting(t, route,
+			`{"items":[{"category":"thread","key":"auto_archive_days","value":"4"}]}`).Code
+	}()
+	go func() {
+		defer wg.Done()
+		codes[1] = postSystemSetting(t, route,
+			`{"items":[{"category":"sidebar","key":"recent_filter_thread_days","value":"5"}]}`).Code
+	}()
+	wg.Wait()
+
+	got := finalOrdering(t, s)
+	assert.False(t, ViolatesThreadArchiveOrdering(got),
+		"无 DB 行起步时终态同样不得违反偏序，实际 archive=%d recent=%d codes=%v",
+		got.ArchiveDays, got.RecentDays, codes)
+}
+
+// 守卫改为在事务内校验之后，被拒的那一批**不得留下任何部分写入** —— 同批里合法的
+// 其它 key 也要一起回滚。修复前守卫在 beginTx 之前 return，天然没有这个风险；
+// 现在它在事务里 return，回滚路径就必须被钉住。
+func TestManagerSystemSetting_OrderingRejectionRollsBackWholeBatch(t *testing.T) {
+	route, ctx := newSuperAdminServer(t)
+	s := EnsureSystemSettings(ctx)
+	seedOrdering(t, s, "1", "6", "3")
+
+	// register.off 与偏序无关且取值合法；但同批的 recent=30 违反 6>=30，整批必须回滚。
+	w := postSystemSetting(t, route, `{"items":[
+		{"category":"register","key":"off","value":"1"},
+		{"category":"sidebar","key":"recent_filter_thread_days","value":"30"}
+	]}`)
+	require.NotEqual(t, http.StatusOK, w.Code, "违反偏序必须拒绝：%s", w.Body.String())
+
+	require.NoError(t, s.Reload())
+	assert.False(t, s.RegisterOff(),
+		"同批中与偏序无关的 register.off 不得被写入——守卫在事务内拒绝时必须整批回滚")
+	assert.Equal(t, 3, s.SidebarRecentFilterThreadDays(), "隐藏窗口应保持原值")
+}
+
+// 不触及三个 key 的批次不该被守卫牵连：既不加锁也不多读，行为与从前一致。
+func TestManagerSystemSetting_UnrelatedBatchSkipsGuard(t *testing.T) {
+	route, ctx := newSuperAdminServer(t)
+	s := EnsureSystemSettings(ctx)
+	seedOrdering(t, s, "1", "6", "3")
+
+	w := postSystemSetting(t, route,
+		`{"items":[{"category":"register","key":"off","value":"1"}]}`)
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	require.NoError(t, s.Reload())
+	assert.True(t, s.RegisterOff())
+}
+
+// ---------------------------------------------------------------------------
+// 事务内解析器：必须与快照 getter 逐条同义
+//
+// 守卫现在读的是锁内的原始行，而不是快照。两条路径对「行缺失 / 空串 / 越界 / 非法」
+// 的理解一旦分叉，守卫校验的就不是写入后真正生效的状态。
+// ---------------------------------------------------------------------------
+
+func TestResolveThreadArchiveOrderingFrom_MirrorsSnapshotGetters(t *testing.T) {
+	t.Setenv(envThreadAutoArchiveEnabled, "true")
+	t.Setenv(envThreadAutoArchiveDays, "9999") // env 层无上界
+
+	cases := []struct {
+		name string
+		rows map[string]string
+	}{
+		{"no rows at all", map[string]string{}},
+		{"empty values are not-configured", map[string]string{
+			"thread.auto_archive_enabled":       "",
+			"thread.auto_archive_days":          "",
+			"sidebar.recent_filter_thread_days": "",
+		}},
+		{"configured values win", map[string]string{
+			"thread.auto_archive_enabled":       "0",
+			"thread.auto_archive_days":          "30",
+			"sidebar.recent_filter_thread_days": "7",
+		}},
+		{"out-of-range int falls back", map[string]string{
+			"thread.auto_archive_days":          "99999", // > settingIntMax
+			"sidebar.recent_filter_thread_days": "-5",
+		}},
+		{"unparseable int falls back", map[string]string{
+			"thread.auto_archive_days": "abc",
+		}},
+		{"unparseable bool falls back to env", map[string]string{
+			"thread.auto_archive_enabled": "maybe",
+		}},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			s := newTestSystemSettings(t, nil)
+			for k, v := range c.rows {
+				cat, key := splitSchemaKeyForTest(k)
+				require.NoError(t, s.db.upsert(cat, key, v, settingTypeString, ""))
+			}
+			require.NoError(t, s.Reload())
+
+			want := s.ThreadArchiveOrdering()
+			got := ResolveThreadArchiveOrderingFrom(c.rows)
+			assert.Equal(t, want, got,
+				"事务内解析必须与快照 getter 给出同一个结论，否则守卫校验的不是写入后生效的状态")
+		})
+	}
+}
+
+func splitSchemaKeyForTest(k string) (string, string) {
+	for i := 0; i < len(k); i++ {
+		if k[i] == '.' {
+			return k[:i], k[i+1:]
+		}
+	}
+	return k, ""
+}

--- a/modules/thread/archive_carryover_test.go
+++ b/modules/thread/archive_carryover_test.go
@@ -1,0 +1,119 @@
+package thread
+
+// =============================================================================
+// PR #679 结转项（task per-user-hiding-window / P2）
+//
+//   - parseDays 的溢出钳制：该函数只服务 policy 未注入的单测路径，但一个只在测试里
+//     才会回绕的换算同样会把测试变成谎言。
+//   - logOrderingAtStart 的判定：管理写路径的守卫只覆盖 DB→DB，且
+//     ViolatesThreadArchiveOrdering 在 !ArchiveEnabled 时短路，于是纯 env 配出来的
+//     违规状态不写一次管理接口就永远不暴露。启动日志补的正是这个洞。
+//
+// 纯逻辑测试，无需 DB / IM。
+// =============================================================================
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	commonapi "github.com/Mininglamp-OSS/octo-server/modules/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// parseDays —— 与生产路径共用同一个溢出上限
+// ---------------------------------------------------------------------------
+
+func TestParseDays_NormalValues(t *testing.T) {
+	assert.Equal(t, 3*24*time.Hour, parseDays("3", 7))
+	assert.Equal(t, 14*24*time.Hour, parseDays("14", 3))
+	assert.Equal(t, 3650*24*time.Hour, parseDays("3650", 3))
+}
+
+func TestParseDays_FallbackBranches(t *testing.T) {
+	assert.Equal(t, 3*24*time.Hour, parseDays("", 3), "空 → 默认")
+	assert.Equal(t, 3*24*time.Hour, parseDays("abc", 3), "非数字 → 默认")
+	assert.Equal(t, 3*24*time.Hour, parseDays("-1", 3), "负数 → 默认")
+	assert.Equal(t, time.Duration(0), parseDays("0", 3), "0 是合法的『禁用阈值』")
+}
+
+// 与 common.threadAutoArchiveDaysFromEnv 的空白符语义必须一致：都不 TrimSpace。
+// 对应侧的断言在 modules/common/thread_archive_env_parity_test.go。
+func TestParseDays_DoesNotTrimWhitespace(t *testing.T) {
+	assert.Equal(t, 3*24*time.Hour, parseDays(" 9999 ", 3),
+		"带空格必须解析失败回落默认——与 common 侧逐字节一致")
+	assert.Equal(t, 3*24*time.Hour, parseDays("9999 ", 3))
+}
+
+// 核心回归：会让 int64 回绕的取值必须被钳住，不论它来自 raw 还是来自 defaultDays。
+func TestParseDays_OverflowClamped(t *testing.T) {
+	want := time.Duration(maxArchiveDays) * 24 * time.Hour
+
+	for _, raw := range []string{"100000", "213504", "2147483647"} {
+		got := parseDays(raw, 3)
+		assert.Equal(t, want, got, "raw=%s 必须钳到上限", raw)
+		assert.Greater(t, got, 365*24*time.Hour,
+			"raw=%s 钳制后必须仍是远大于一年的阈值，绝不能回绕成小正数", raw)
+	}
+
+	// 默认值路径同样要走钳制——否则调用方传一个巨大的 defaultDays 就能绕过。
+	assert.Equal(t, want, parseDays("", math.MaxInt32))
+	assert.Equal(t, want, parseDays("abc", math.MaxInt32))
+}
+
+// ---------------------------------------------------------------------------
+// logOrderingAtStart 的判定谓词
+// ---------------------------------------------------------------------------
+
+func TestOrderingViolatesIfEnabled_DetectsLatentViolation(t *testing.T) {
+	// 归档 3 天 < 隐藏 7 天：子区在隐藏窗口走完前就被归档，运维调宽隐藏窗口看不到效果。
+	latent := commonapi.ThreadArchiveOrdering{
+		ArchiveEnabled: false, // 关着 —— 守卫本人会在这里短路
+		ArchiveDays:    3,
+		RecentDays:     7,
+	}
+	assert.False(t, commonapi.ViolatesThreadArchiveOrdering(latent),
+		"前提：守卫在 !ArchiveEnabled 时短路，这正是启动日志要绕开的洞")
+	assert.True(t, orderingViolatesIfEnabled(latent),
+		"关着也必须报——那是『打开开关的瞬间就生效』的潜伏状态")
+}
+
+func TestOrderingViolatesIfEnabled_LiveViolation(t *testing.T) {
+	live := commonapi.ThreadArchiveOrdering{ArchiveEnabled: true, ArchiveDays: 3, RecentDays: 7}
+	assert.True(t, commonapi.ViolatesThreadArchiveOrdering(live))
+	assert.True(t, orderingViolatesIfEnabled(live))
+}
+
+func TestOrderingViolatesIfEnabled_HealthyAndInert(t *testing.T) {
+	// 产品拍板的 14/7：归档 >= 隐藏，合法。
+	assert.False(t, orderingViolatesIfEnabled(
+		commonapi.ThreadArchiveOrdering{ArchiveEnabled: true, ArchiveDays: 14, RecentDays: 7}))
+	// 相等是允许的（现网 3/3）。
+	assert.False(t, orderingViolatesIfEnabled(
+		commonapi.ThreadArchiveOrdering{ArchiveEnabled: true, ArchiveDays: 3, RecentDays: 3}))
+	// 任一侧为 0 = 该级不生效，无从违反。
+	assert.False(t, orderingViolatesIfEnabled(
+		commonapi.ThreadArchiveOrdering{ArchiveEnabled: true, ArchiveDays: 0, RecentDays: 7}))
+	assert.False(t, orderingViolatesIfEnabled(
+		commonapi.ThreadArchiveOrdering{ArchiveEnabled: true, ArchiveDays: 3, RecentDays: 0}))
+}
+
+// 未注入 ordering（单测默认）时 Start 不得 panic —— 既有 worker 测试全部走这条路径。
+func TestLogOrderingAtStart_NilResolverIsNoop(t *testing.T) {
+	w := newTestWorker(defaultCfg(), &stubArchiveDB{}, &stubVersionGen{}, time.Now())
+	require.Nil(t, w.ordering)
+	assert.NotPanics(t, w.logOrderingAtStart)
+}
+
+func TestLogOrderingAtStart_ResolvesOnceWhenInjected(t *testing.T) {
+	w := newTestWorker(defaultCfg(), &stubArchiveDB{}, &stubVersionGen{}, time.Now())
+	calls := 0
+	w.ordering = func() commonapi.ThreadArchiveOrdering {
+		calls++
+		return commonapi.ThreadArchiveOrdering{ArchiveEnabled: true, ArchiveDays: 3, RecentDays: 7}
+	}
+	w.logOrderingAtStart()
+	assert.Equal(t, 1, calls, "启动时读一次即可，不该是每 tick 的开销")
+}

--- a/modules/thread/archive_config.go
+++ b/modules/thread/archive_config.go
@@ -8,10 +8,24 @@ import (
 )
 
 // ArchiveConfig 子区自动归档 worker 的运行参数。
+//
+// 只有 Interval / BatchSize / BatchSleep 是**运维调优**项，仍以 env 为唯一来源。
+// Enabled / Threshold 是**策略**项，已迁往 system_settings（task
+// inactive-hiding-user-control / P1），在生产路径上不再被读取 —— 见下方各自的注释。
 type ArchiveConfig struct {
-	// Enabled 总开关。disabled 时 worker 不启动 ticker。
+	// Enabled 在生产路径上是**死字段**。
+	//
+	// 它曾经是启动门（"disabled 时 worker 不启动 ticker"），该语义已被移除：策略要能
+	// 热开启，卡在启动期会让「管理台打开归档」必须重启进程才生效。现在 Start() 只卡
+	// Interval，开关每 tick 由 ArchiveWorker.policy 从 system_settings 重读。
+	//
+	// 真源：system_setting `thread.auto_archive_enabled`，回落
+	// DM_THREAD_AUTO_ARCHIVE_ENABLED，再回落代码默认（modules/common）。
+	// 本字段只在 policy 未注入时（即单测）被 resolvePolicy 读到。
 	Enabled bool
-	// Threshold 子区"陈旧"判定阈值（自 last_message_at 起算）。0 视为禁用。
+	// Threshold 同为生产路径的**死字段**，语义与 Enabled 相同：真源是 system_setting
+	// `thread.auto_archive_days`，经 archiveThresholdFromDays 换算。
+	// 只在 policy 未注入时（单测）生效。
 	Threshold time.Duration
 	// Interval 两次 cron tick 之间的间隔。<=0 视为禁用。
 	Interval time.Duration
@@ -57,15 +71,25 @@ func parseBool(raw string) bool {
 }
 
 // parseDays 把字符串当"天数"解析。负数视为非法，回默认；0 是合法的"禁用"。
+//
+// 天数 → Duration 的换算走 archiveThresholdFromDays，与生产路径共用同一个溢出钳制：
+// time.Duration 是 int64 纳秒，约 106,751 天即回绕成一个**小的正数**阈值
+// （~213,504 天 ≈ 25 分钟），把几乎所有子区归档掉。本函数只服务于 policy 未注入的
+// 单测路径，但一个只在测试里才会回绕的换算同样会把测试变成谎言
+// （PR #679 review, yujiawei）。
+//
+// 解析语义（空/非法/负 → 默认，0 合法，其余原样）必须与 common.threadAutoArchiveDaysFromEnv
+// 逐字节一致，包括**不做 TrimSpace** —— 同一个 env 变量现在有两个解析器，它们分歧
+// 就等于同一份配置有两种含义。等 Enabled/Threshold 死字段被删掉之后这个约束才会消失。
 func parseDays(raw string, defaultDays int) time.Duration {
 	if raw == "" {
-		return time.Duration(defaultDays) * 24 * time.Hour
+		return archiveThresholdFromDays(defaultDays)
 	}
 	n, err := strconv.Atoi(raw)
 	if err != nil || n < 0 {
-		return time.Duration(defaultDays) * 24 * time.Hour
+		return archiveThresholdFromDays(defaultDays)
 	}
-	return time.Duration(n) * 24 * time.Hour
+	return archiveThresholdFromDays(n)
 }
 
 func parseDuration(raw string, def time.Duration) time.Duration {

--- a/modules/thread/archive_worker.go
+++ b/modules/thread/archive_worker.go
@@ -37,6 +37,9 @@ type ArchiveWorker struct {
 	// inactive-hiding-user-control / P1）。生产路径注入 system_settings 读取器；
 	// 为 nil 时回落到 cfg.Enabled / cfg.Threshold，单测据此保持原有构造方式。
 	policy func() (bool, time.Duration)
+	// ordering 读取当前生效的「归档窗口 vs 最近列表隐藏窗口」偏序，仅在 Start() 调一次。
+	// 生产路径注入 system_settings 读取器；为 nil 时跳过（单测默认）。
+	ordering func() commonapi.ThreadArchiveOrdering
 	// lastPolicy 只用于「策略变更时打一条日志」的去抖，避免每小时重复刷同样的值。
 	// 仅在 ticker goroutine 内读写，无并发。
 	lastPolicy   string
@@ -70,7 +73,50 @@ func NewArchiveWorker(ctx *config.Context, cfg ArchiveConfig) *ArchiveWorker {
 		w.warnIfClamped(enabled, days)
 		return enabled, archiveThresholdFromDays(days)
 	}
+	w.ordering = func() commonapi.ThreadArchiveOrdering {
+		return commonapi.EnsureSystemSettings(ctx).ThreadArchiveOrdering()
+	}
 	return w
+}
+
+// orderingViolatesIfEnabled 回答「这组取值**一旦归档开启**是否违反偏序」。
+//
+// 直接调 ViolatesThreadArchiveOrdering 不够：它在 !ArchiveEnabled 时短路返回 false，
+// 这正是本函数要绕开的那个洞（见 logOrderingAtStart）。做法是把 ArchiveEnabled 置真后
+// 再交给守卫本人判定 —— 不等式因此仍然只有一份实现，不在这里复制一遍。
+func orderingViolatesIfEnabled(o commonapi.ThreadArchiveOrdering) bool {
+	o.ArchiveEnabled = true
+	return commonapi.ViolatesThreadArchiveOrdering(o)
+}
+
+// logOrderingAtStart 在 worker 启动时把生效的两级衰减取值打一条日志，违反偏序时升为 WARN。
+//
+// 为什么需要它：管理写路径的守卫只覆盖 DB→DB，且 ViolatesThreadArchiveOrdering 在
+// !ArchiveEnabled 时短路，于是「纯 env 配出来的违规状态」不去写一次管理接口就永远不暴露
+// （PR #679 review 第 7 轮，known boundaries 的「守卫只覆盖 DB→DB」那条）。
+// 进程启动是唯一一个必然发生、且能同时看到两个窗口的时刻。
+//
+// 违规意味着子区会在最近列表的隐藏窗口走完之前就被归档 —— 运维调宽隐藏窗口会看不到任何
+// 效果，因为归档先一步把子区拿走了。归档关着时同样告警（带 archive_enabled=false），
+// 因为那正是「打开开关的瞬间就会生效」的潜伏状态，也正是守卫看不见的那一类。
+func (w *ArchiveWorker) logOrderingAtStart() {
+	if w.ordering == nil {
+		return
+	}
+	o := w.ordering()
+	fields := []zap.Field{
+		zap.Bool("archive_enabled", o.ArchiveEnabled),
+		zap.Int("archive_days", o.ArchiveDays),
+		zap.Int("recent_filter_thread_days", o.RecentDays),
+	}
+	if orderingViolatesIfEnabled(o) {
+		w.Warn("thread archive window is shorter than the recent-tab hiding window; "+
+			"threads are archived before the hiding window elapses, so widening the "+
+			"hiding window has no visible effect",
+			fields...)
+		return
+	}
+	w.Info("thread archive / recent-hiding windows at start", fields...)
 }
 
 // warnIfClamped 在生效天数被 maxArchiveDays 钳住时打一条 WARN。
@@ -163,6 +209,7 @@ func (w *ArchiveWorker) Start(ctx context.Context) {
 			zap.Duration("interval", w.cfg.Interval))
 		return
 	}
+	w.logOrderingAtStart()
 	rctx, cancel := context.WithCancel(ctx)
 	w.cancel = cancel
 	w.wg.Add(1)

--- a/modules/thread/archive_worker.go
+++ b/modules/thread/archive_worker.go
@@ -204,12 +204,20 @@ func (w *ArchiveWorker) Start(ctx context.Context) {
 	// 启动门只卡 Interval —— enabled 与 threshold 都已是每 tick 重读的策略项，
 	// 卡在启动期会让「管理台开启归档」必须重启才生效，正是 P1 要消除的。
 	// ticker 空转的代价是每 Interval 一次 system_settings 快照读（无 DB 往返）。
+	// 放在 Interval 门**之前**：这条日志的全部意义是「进程启动是唯一必然发生、
+	// 且能同时看到两个窗口的时刻」，摆在提前返回之后就等于把同一个盲区下移一层。
+	//
+	// 注意这是防御性的，不是修一个当前可达的洞：LoadArchiveConfig 走 parseDuration，
+	// 它把 d <= 0 映射回默认值，所以 cfg.Interval <= 0 从 env 根本产生不出来，只有
+	// 手工构造的测试配置能命中。先前的注释断言 DM_THREAD_AUTO_ARCHIVE_INTERVAL=0
+	// 会 park worker，那是错的（PR #695 review 第 4 轮，yujiawei 自陈其前提有误）。
+	// 保留这个顺序是为了移除对该门的依赖，万一它日后变得可达。
+	w.logOrderingAtStart()
 	if w.cfg.Interval <= 0 {
 		w.Info("thread auto-archive worker not started: invalid interval",
 			zap.Duration("interval", w.cfg.Interval))
 		return
 	}
-	w.logOrderingAtStart()
 	rctx, cancel := context.WithCancel(ctx)
 	w.cancel = cancel
 	w.wg.Add(1)


### PR DESCRIPTION
## Summary

Batch 2 of the staged change that hands the "when does a quiet conversation leave my list" decision back to users.

> [!NOTE]
> **Scope narrowed at review round 4.** This PR originally carried both preconditions. The muted-unread one (P0-B) has been **withdrawn** — see below. What remains is P0-A plus the five advisories carried over from #679, which three reviewers signed off independently and which have nothing to do with the withdrawn work. `modules/message` is now untouched relative to `main`.

**No user-visible behaviour change.** The earlier `[!IMPORTANT]` warning about muted groups leaving the recent tab no longer applies — that was P0-B.

### What ships

**P0-A — the ordering guard's write skew.** The guard validated against `m.systemSettings.ThreadArchiveOrdering()` — a process-local snapshot with a 60s TTL that only the writing replica refreshes eagerly — and *then* opened the transaction, so check and write were adjacent rather than atomic. From `{enabled, archive=6, recent=3}`, one request setting `archive=4` and another setting `recent=5` each passed against the same stale view (`4>=3`, `6>=5`) and both committed, landing `4 < 5`: exactly the state the guard exists to reject.

#679 graded this P2 because it takes two SuperAdmin writes inside the window. Batch 2 turns that into per-user writes, which is why it closes first.

**P2 — five advisories from #679 review**, which review asked twice not to be pushed to that already-approved head.

## Why P0-B was withdrawn

It landed three times (`d3835bdc` → `6235cd51` → `dbfce0d3`), and three review rounds found three defects in the same ~40 lines. **Every one was invisible to CI.**

| Round | Defect | Why CI missed it |
|---|---|---|
| 1 | `@所有人` broadcasts did not back a muted channel | no runnable SQL test |
| 2 | thread mute was a silent no-op (wrong table, wrong channel type) | the test manufactured its premise and passed |
| 3 | UNION collation failure (P0); DM `@me` key mismatch (P1) | CI's database pins `general_ci`; no Person-type reminder test |

The round-3 P0 is the decisive one. `user_setting` / `group_setting` carry no `CHARSET`/`COLLATE` clause, so on MySQL 8 they take the server default `utf8mb4_0900_ai_ci`; `thread_setting` is explicitly `utf8mb4_general_ci`. The three-branch UNION cannot aggregate them:

```
ERROR 1271 (HY000): Illegal mix of collations for operation 'UNION'
```

Reproduced locally on 8.0.46 against the verbatim DDL. The two-branch predecessor passes in the same schema, so this batch introduced it.

What makes it worth stopping over is not the SQL — it is that **the green integration run in the previous PR body was not evidence about production**. Both CI (`.github/workflows/ci.yml`) and the local dev database are created `COLLATE utf8mb4_general_ci`, which normalises all three tables and hides the failure completely. Layered on top, `loadFadeableMutedSet`'s structural fail-open turns the hard error into permanent silence: on an affected deployment the whole feature ships as a no-op with a WARN per sync request.

So the loop is structural, not a run of bad luck: the SQL lives in an integration-tagged file that does not compile because of the pre-existing `modules/message` import cycle, so each fix ships with prose reasoning instead of executed evidence and the next reviewer finds the next thing by reading. Fixing the SQL a fourth time without runnable coverage would just queue up round 5.

Per review's escalation, the import-cycle fix is the prerequisite. The three commits are parked with a written account of both unfixed defects (the collation failure and its verified `COLLATE` pin, and the DM `@me` key mismatch), and the brief records the withdrawal.

Credit where due: yujiawei reproduced the collation failure in a MySQL container rather than reasoning about it, which is the only reason it was caught before deploy.

## Related Issue

None — task originated in-repo (`upstream: self`). Follows #679 (Batch 1).

## Linked Spec

`.octospec/tasks/per-user-hiding-window/brief.md`

## Changes

- `modules/common/api_manager_system_setting.go` — the ordering guard runs inside the transaction, behind a lock, re-reading the rows instead of trusting the snapshot. The three new failure paths use `errcode.ErrSharedInternal` (500, `Internal:true`); the neighbouring legacy `c.ResponseError` calls stay, since `modules/common` is not a migrated module and all 13 sites are out of scope here.
- `modules/common/sql/20260803000001_add_system_setting_guard_lock.sql` — single-row anchor table, `CHECK` pinning the PK, seeded by the migration. **This is the load-bearing detail and it deviates from what the brief originally specified.** Locking the three setting rows cannot work: the migration deliberately writes none of them (Batch 1's rollout guarantee), and `FOR UPDATE` over absent rows yields only gap locks, which are mutually compatible — both writers pass the check and then deadlock on insert intention, turning a legitimate concurrent write into an opaque 500. `modules/incomingwebhook/db.go:65` records this repo hitting the same trap and landing on "lock a row that necessarily exists"; `card_template_catalog_capacity_guard` is the same shape.
- `modules/common/db_system_setting.go` — `lockGuardAnchorWithTx`, `loadValuesWithTx`, and `ensureGuardAnchor`. The anchor self-heals via `INSERT IGNORE` before the transaction opens, never inside it: it carries no state, and without that a truncate-based restore turns every guarded settings write into a hard failure that reads like a database outage.
- `modules/common/system_settings.go` — `ResolveThreadArchiveOrderingFrom` resolves the locked rows through the same DB → env → code-default chain the snapshot getters use; `getIntClamped` now shares its string half so the two cannot drift.
- `modules/common/system_setting_schema.go`, `modules/thread/archive_config.go`, `modules/thread/archive_worker.go` — the five #679 carry-overs plus two stale comments corrected at round 4.

On the carry-overs, the one worth naming: `threadAutoArchiveDaysFromEnv` no longer trims whitespace. That was the single input where the Batch 1 migration was not behaviour-identical on rollout — legacy `parseDays` hands `" 9999 "` to `Atoi`, which fails, so such a deployment archives at the 3-day default, while the trimming version resolved it to 9999 and effectively stopped archiving. The sibling `...EnabledFromEnv` *does* trim, correctly, because the `parseBool` it mirrors does; the rule is "match the legacy parser", not "trim".

## Testing

Rebased onto `main` at `40627cc0`, run against MySQL 8.0 + Redis + WuKongIM:

```
go build ./...                                            ok
go vet (message, thread, common)                          ok
gofmt -l <every file this PR touches>                     clean
golangci-lint run (message, thread, common)               0 issues
make i18n-extract-check && make i18n-lint                 ok
go test ./modules/common/                                 ok
go test ./modules/thread/                                 ok
go test ./modules/message/                                ok
```

Recreate the `test` DB between packages — each registers a different module subset, so sql-migrate reads the previous package's rows as "unknown migration in database" and panics. `max_connections` also needs raising above the 151 default for `modules/common`.

- [x] Unit tests added/updated
- [x] Manually verified

**The concurrency regression was verified to fail before the fix**, which is the only thing that makes it evidence. Reverting the handler to the pre-fix guard and re-running gives `codes=[200 200]` with a final state of `archive=4 recent=5` — exactly the state the guard exists to reject — in both shapes (rows present, and no rows at all).

## COMPREHENSION

**1. What does this change actually do to the load-bearing path?**

On the admin settings write path, the cross-key invariant `archive_days >= recent_filter_thread_days` becomes atomic instead of merely adjacent to its write: lock the anchor row, re-read the three settings inside the transaction, merge the incoming batch onto *those* values, validate, then upsert — all in one transaction, so a concurrent writer either waits or sees the committed result.

Nothing else changes behaviour. The remaining commits are comments, a whitespace-parsing correction, an overflow bound on a test-only path, and two log lines.

**2. What could break because of it (dependents + failure mode)?**

Exposure is small and in the safe direction: writes that previously succeeded in a race now get one rejection carrying the existing localized error with both day counts. Two extra queries and one row lock are added, but only when a batch touches the three ordering keys — unrelated settings writes pay neither.

The anchor row is a new single point of failure, which is why it self-heals rather than failing closed forever; a still-missing anchor after the heal fails closed, which is right for an admin write path.

Rolling deploy: old replicas still validate against their process-local snapshot and never take the anchor lock, so the skew stays open between an old and a new replica until rollout completes. Inherent to this class of fix, and no worse than today, but worth knowing before an admin batch runs mid-deploy.

The `parseDays` change touches only the `policy == nil` fallback, which is the unit-test path — production resolves policy through `system_settings`.

**3. How do you know it works (specific test/repro/trace)?**

- `TestManagerSystemSetting_OrderingSurvivesConcurrentSingleKeyWrites` drives two real concurrent HTTP writes and asserts exactly one succeeds and the final DB state does not violate the ordering. Verified to fail against the pre-fix implementation, in both the rows-present and no-rows shapes.
- `TestManagerSystemSetting_OrderingRejectionRollsBackWholeBatch` covers a risk this PR *introduces*: the guard now returns from inside the transaction, so an unrelated legal key in the same batch must not be left written.
- `TestResolveThreadArchiveOrderingFrom_MirrorsSnapshotGetters` compares the in-transaction resolver against the snapshot getters across six input shapes. If those two disagree, the guard validates a state the getters will never return.
- `TestThreadAutoArchiveDaysFromEnv_MatchesLegacyParseDays` compares against a verbatim copy of the legacy parser across twelve inputs, including the whitespace cases that motivated it.
- `TestArchiveThresholdFromDays_UnclampedWouldWrapToMinutes` demonstrates the naive conversion wrapping below an hour at 213,504 days before asserting the guarded one stays above a year, so the test states the failure it prevents rather than just the fixed value.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] PR description is in English
- [x] Added tests for my changes
- [x] Updated documentation
- [x] Followed commit message conventions (Conventional Commits)