### PR TITLE
fix(botevent): monotonic bot event id allocator behind an activation gate (#697)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,11 @@ octo-server
 octo-server-old*
 octo-server-pre-*
 octo-server-prev*
+
+# Operator tools compiled into the repo root by `go build ./tools/<name>`.
+# Build them to /tmp instead; a committed 40MB+ binary is not a source artifact.
+/botevent-seq
+/msgextra-version
+/card-action-dlq
+/genseq-repro
+/i18nmarkers

--- a/.octospec/tasks/bot-event-score-monotonic/brief.md
+++ b/.octospec/tasks/bot-event-score-monotonic/brief.md
@@ -210,14 +210,23 @@ T0 后发号至 `C1`、入队至 `S1`。崩溃恢复到 T0 → 计数器回到 `
 选 per-bot 而非全局 key：单调性只需队列内成立；全局 key 的 floor 必须 ≥ **所有**队列的
 max score（否则某个高 score 队列的客户端游标会把新号段整体挡在门外），且是热点。
 
-**D2. 单阶段部署，不需要 #627 那样的 flip。** 号段单向性（新号恒高于旧号）+ D1 的同域
-自洽性使新旧副本共存是安全的。前提是 floor 引导**幂等**：任何副本任意次引导结果相同，
-不要求「引导必须在第一个新副本启动前完成」。
+**D2.（已更正 —— 原判断是错的）需要显式 activation gate，两阶段，不是单阶段部署。**
 
-> **更正**：本 brief 早先写「用 `SET key <floor> GT`」是错的 —— Redis 的 `SET` 没有
-> `GT` 选项（`GT`/`LT` 属于 `EXPIRE` 和 `ZADD`）。幂等取 max 必须用 Lua
-> （`GET` → 比较 → 条件 `SET`，单脚本内原子），与本仓其他 Lua 站点同模式
-> （`pkg/botevent/bell.go` 的 `EVALSHA` + `NOSCRIPT` 回退）。
+原文写「号段单向性使新旧副本共存安全」，**方向搞反了，review 抓到**。legacy 副本是从它那个块的**底部往上**发号的：新分配器在 7001 发号时，legacy 副本还在发 5001、5002…… 一旦消费者游标到了 7001，legacy 后续发的每一个 id 都永久不可见 —— 正是本任务要消除的丢失，由本任务自己造成。而且 `seedSafetyMargin` 越大越糟：**margin 本身就是吞掉 legacy id 的那个 gap**。
+
+改为：
+- Redis key `botEventSeq:mode`，缺省 / 非 `incr` 即 legacy。**未激活时 `NextEventID` 委托给
+  `GenSeq`**（与 `internal/msgextraseq` 的 `mode=legacy` 同构），所以部署本身行为中立。
+- mode 与分配在**同一个 Lua 脚本内**读取（`gateSource`）—— 刻意不做进程内缓存：缓存哪怕
+  1 秒，也意味着那 1 秒里部分副本用计数器、部分用 GenSeq，即两个活跃号源，正是缺陷本身。
+  flip 后**下一次分配**即生效，无副本间分歧窗口。
+- 残余窗口只剩「已读到 legacy、尚未 ZAdd」的在途请求（微秒级）；flip 前后短暂停写即可关闭。
+- operator 工具 `tools/botevent-seq`（`-action preflight|activate`）。**它无法自动验证
+  「所有旧副本已下线」**，这必须是人工前置步骤，工具用 `-yes` + 显式告警要求确认。
+- 无 online deactivate：回退意味着 legacy id 落在消费者游标下方，是同一种丢失的镜像。
+
+**D1 的「no fallback」与此不冲突，但必须分清**：未激活 → 走 legacy，这是**设计的模式**；
+已激活但 Redis 失败 → 返回错误、拒绝入队，**不**偷偷回退 GenSeq。
 
 **D3. 现存碰撞 member 不重编号**（详见 Open questions 1 —— 这是唯一需要人类签字的一条，
 因为它是唯一涉及写生产数据的选项）。
@@ -233,14 +242,22 @@ max score（否则某个高 score 队列的客户端游标会把新号段整体�
 
 实现过程中三处偏离 / 补充了本 brief 的原始判断，记在此处而非默默改掉：
 
-**① 站点是 6 个，不是 5 个。** 新增的 `TestNoGenSeqForBotEventIDs` 守卫立刻抓到
-`modules/robot/api.go` 的 `addInlineQuery` —— 它也从 `RobotEventSeqKey+robotID` 取号。
-本 brief 和 `modules/robot/api.go:232` 的注释都说「five ZADD sites in total」，都漏了它，
-因为它**不写 ZSET**（只 append 到进程内 `inlineQueryEventsMap`）。而 `inlineQueryEventsMap`
-**没有任何读取/投递路径**（只有 add / remove），所以那些 event 从不发给任何人 —— 它唯一的
-实际作用是消耗号码并推进 `min_seq`，即污染队列号源却不产出任何可投递事件。处置：隔离到
-独立 key `inlineQuerySeq:`，仍用 GenSeq（无人消费的 id 没有单调性要求，不值得引入 Redis
-依赖）。**这正是「守卫而非注释」的价值：注释错过一次，守卫一次就抓到。**
+**①（已更正）站点是 6 个，第 6 个是 `addInlineQuery`，而它的事件**有**消费路径。**
+新增守卫立刻抓到 `modules/robot/api.go` 的 `addInlineQuery` 也从 `RobotEventSeqKey+robotID`
+取号 —— 本 brief 与 `modules/robot/api.go:232` 的注释都只说「five ZADD sites」，都漏了它。
+
+第一版处置是「隔离到独立 `inlineQuerySeq:` key，因为 `inlineQueryEventsMap` 无人读取」。
+**这个前提是错的，review 抓到**：`getEventsResult`（`modules/robot/api.go:1089`）会读该 map，
+把 inline query 事件与 ZSET 事件**合并、按 `EventID` 排序、按同一个 cursor 过滤**。两个
+id 空间共享一个游标。隔离后果比原缺陷更糟：新 GenSeq key 首号约 1000001，而计数器从低位
+起，一条 inline event 就把客户端游标顶到百万，之后的普通事件全部被永久过滤。
+
+**调查失误的具体原因值得记下来**：当时那次 `grep inlineQueryEventsMap` 加了 `| head`，
+输出恰好 10 行被截断，漏掉了 1089 行的读取，然后据此断言「没有任何读取路径」。**截断过的
+搜索结果不能用来证明「不存在」。**
+
+最终处置：`addInlineQuery` 改用 `botevent.NextEventID` —— 与队列事件同一号源，未激活时
+同为一条 GenSeq 序列，激活后同为一个计数器，任何时刻单源。
 
 **② 队列 key 统一到 `botevent.QueueKey`。** 原先 5 处各自 `fmt.Sprintf("robotEvent:%s", ...)`。
 seed 必须读 producer 写的同一个 key，硬编码分散是真实风险。统一后必须同步更新

--- a/.octospec/tasks/bot-event-score-monotonic/brief.md
+++ b/.octospec/tasks/bot-event-score-monotonic/brief.md
@@ -670,3 +670,37 @@ counter 被同一次 Redis 恢复一起丢失」。因此激活验证完成后�
 `modules/robot`、`modules/bot_api`、`modules/group`、`modules/message` 均以
 `-race -shuffle=on` 通过（模块包按 CI 方式逐包重建 MySQL test 库并清 Redis）；另通过
 `go build ./...`、`go vet ./...`、i18n extract/lint 与 `git diff --check`。
+
+## 第九轮实现记录（head `d96efa38` 后续复核，2026-08-09）
+
+本轮先为七个可复现缺口提交 RED checkpoint（`795675f0`），逐项确认失败来自目标逻辑，
+再提交生产修复（`2c3a0d18`）：
+
+1. **已验证的正向 belief 丢失 cutover floor。** floor 现在与 `activated` / `epoch` 一起保存在
+   不可变 belief 中，后续 per-bot seed 直接使用同一次权威读取验证过的值；不会再单独重读状态行
+   并把读取失败折成 0。`TestValidatedBeliefRetainsTheCutoverFloor` 覆盖权威行随后不可读的形状。
+2. **一次 seed 做两次同表 MySQL 查询。** legacy ceiling 与 durable high-water 合并成一条带
+   deadline 的条件聚合查询；mirror 丢失导致全进程 seed 失效时，每个活跃 bot 只产生一次 DB
+   往返。既有 I/O-shape guard 与真实行值集成测试同时覆盖。
+3. **preflight 对单队列做 `ZRANGE 0 -1` 并保留 score-sized map。** 改为每页 500 条的 rank
+   分页；利用 ZRANGE 按 score/member 排序的性质，仅保留上一条 score，就能跨分页统计重复且
+   内存为 O(1)。激活仍要求写暂停，因此 rank 视图不会在证据采集中漂移。
+4. **两个 recovery retry 对 gate sentinel 解释不一致。** `gateNotActivated(-1)` 统一重新进入
+   权威恢复；`gateCounterMissing(-2)` 统一按 counter 再次丢失 fail closed，不再把 -2 误报为
+   数字 floor。两个 race fixture 分别在 retry 前删除 mirror / counter。
+5. **正向 belief 会覆盖更高 mirror epoch。** 观察到高于本地 belief 的 `incr:N` 时强制刷新
+   MySQL 权威；权威不能确认该代次就拒绝，确认后才允许继续，旧进程不能把新 mirror 写回旧代次。
+6. **运行时 counter 没有 float64 score 精度上界。** `runGate` 在 Redis `INCR` 后拒绝
+   `>= 2^53` 的 id；否则相邻 int64 会映射为同一 ZSET score，重新制造 #697 的碰撞、游标跳过
+   与按 score ack 连带删除。operator floor 的 2^50 上界仍保留更大的提前余量。
+7. **未知 `payload.robot_id` 既重复查 MySQL，又吞掉 sibling mention 路由。** 可证不存在的 bot
+   以 `robot:exist:{id}=0` 负缓存 30 秒；仅当 payload id 正向验证成功才停止后续路由，否则继续
+   解析 `mention` / 文本 @。短 TTL 明确承担“刚创建 bot 最多延迟 30 秒被该缓存看见”的取舍，
+   避免客户端控制的重复未知 id 把 listener 变成逐消息 DB 查询。
+
+**完整验证**：按 CI 脚本逐个 `go list ./...` 包执行 `-race -shuffle=on -count=1 -timeout=5m`，
+每包前重建 `test` 库并 `FLUSHALL`；本地漏设 CI 的 `max_connections=1000` 时
+`modules/common` 首次以 `Error 1040` 失败，对齐 CI 后单独重跑通过，其余包一次通过。
+另通过 `CGO_ENABLED=0 go build ./...`、`go vet ./...`、`golangci-lint run ./...`、
+`make i18n-extract-check`、`make i18n-lint` 与 `git diff --check`。#704 的 activation-only
+Gap 1–7 仍是独立门禁；本轮没有把“合并/部署”描述成“已激活”。

--- a/.octospec/tasks/bot-event-score-monotonic/brief.md
+++ b/.octospec/tasks/bot-event-score-monotonic/brief.md
@@ -704,3 +704,15 @@ counter 被同一次 Redis 恢复一起丢失」。因此激活验证完成后�
 另通过 `CGO_ENABLED=0 go build ./...`、`go vet ./...`、`golangci-lint run ./...`、
 `make i18n-extract-check`、`make i18n-lint` 与 `git diff --check`。#704 的 activation-only
 Gap 1–7 仍是独立门禁；本轮没有把“合并/部署”描述成“已激活”。
+
+## 第十轮实现记录（head `60c2dd0e` 重审之后，2026-08-09）
+
+重审确认第九轮 preflight 的内存修复引入了一条 cutover 证据回退：停写不等于停 ACK，
+低端 `ZREM` 会在两次 rank 分页之间把后续成员左移，使分页提前结束并静默低估队列最大 score。
+该值直接参与不可逆激活的 floor 校验，因此属于 blocker。
+
+本轮先提交编译期 RED（`ad187e12`），用 2000 个 score 模拟第一页后 ACK 掉前 1600 条；旧实现
+只观察到最大值 500，而真实最大值 2000 仍在队列。修复将两类证据拆开：重复 score 数量继续用
+500 条 rank 分页与 O(1) 状态做诊断；激活所依赖的最大 score 单独用一次原子的
+`ZREVRANGE 0 0 WITHSCORES` 获取。ACK 只会缩小队列，所以预先捕获的最大值可能保守偏高，
+不会低估 cutover floor；新写入仍由激活前停写前置条件排除。

--- a/.octospec/tasks/bot-event-score-monotonic/brief.md
+++ b/.octospec/tasks/bot-event-score-monotonic/brief.md
@@ -562,3 +562,62 @@ sql-migrate 应用（`gorp_migrations` 有记录、状态表已建）。
 
 **验证**：`pkg/botevent` 45 测试全绿（`-race -shuffle=on`，`CI=true`，**零 skip**）；
 `modules/robot` 新增 `plausible_robot_id_test.go`。
+
+## 第六轮实现记录（第七轮 review 之后，2026-08-06）
+
+上一轮我把 durable-mark 边界移交 #704 是对的（reviewer 明确认可），但**同一种复发转移到了
+mirror repair** —— 它已被重写两次（缓存否定 → 删除键），第二次有了新的失效模式。这一轮
+先复现、再修，且第三种做法是「不再自动修 mirror」。
+
+1. **删除与权威矛盾的 mirror，在「权威才是回滚方」时是全 fleet 中断（review P1-1）。**
+   `allocate` 在 `:596` 就拿到 `counterExists`，`:604` 删 mirror，`:611` 才用同一个
+   `counterExists` 断定「权威曾激活过、现在回滚了」并拒绝 —— **代码在确认权威不可靠之前，
+   已经按权威的说法销毁了 mirror**。一个新起的副本就能删掉每个健康已激活副本 gate 比对的
+   那个 artifact，于是它们 gate 返回 -1 → 强制读权威 → legacy vs 已激活 belief → 拒绝
+   每一次入队，直到有人恢复状态行。**一次滚动重启把零投递影响的簿记回滚放大成全面中断。**
+   与第四轮被接受的 P1-3 同族：推翻操作前提的证据在操作之前算出、在操作之后才被使用。
+
+   **我先写了复现测试并看它失败**（`TestRegressedAuthorityDoesNotDestroyTheLegitimateMirror`），
+   报错正是「the legitimate mirror "incr:0" was destroyed」。上一轮随修复发的测试第三次
+   断言在旁边的性质上 —— 它 `Del` 掉了 counter，所以 `counterExists` 全程为 false。
+
+2. **修法不是加 `!counterExists`，是不再删。** reviewer 给的最小修法能收窄窗口但不闭合：
+   mirror 是全局的、counter 是 per-bot 的，一个从未收过事件的 bot 的分配仍然没有 counter
+   可以反对。而删除的**唯一收益**是压住读风暴，而冷却也能压住 —— 所以删除整体去掉，不是
+   加条件。现在**分配器在 legacy 路径上永不写 mirror**，只有 operator 工具写它，那是唯一
+   有人能看见自己在覆盖什么的地方。
+   代价如实写出：按值缓存的否定结论有 ≤1s 的窗口，期间「与被拒值字节相同的真激活」不被
+   察觉。这个窗口不可能为 0（区分二者只能读权威），且只在「已有 mirror 声称激活而权威说
+   legacy」时进入 —— 而工具现在拒绝在这个前置条件下激活。冷却**只在无 counter 时武装**：
+   有 counter 时分配一律拒绝，读风暴伤不到正常流量，且权威一恢复立刻生效。
+
+3. **工具不幂等，且它的拒绝断言了一个它没检查过的事实（P2-1，两位 reviewer 独立发现）。**
+   `refuseUnauthorizedMirror` 跑在 `Activate` 之前且**从不读状态行**，于是在「已成功激活 +
+   mirror 正确」这个正常状态下重跑 `activate -yes` 会死掉，并告诉运维「…while the authority
+   says legacy…then DEL the key」—— 每一句在常见情形下都是假的，还指示删掉活的 mirror。
+   已改为**先读权威**。并且把判定抽成纯函数 `judgeMirror`，给这个工具补了**第一个测试文件**
+   —— 它承载整个激活流程、是切换时唯一由人手跑的组件，两轮出两个问题而零测试。
+
+4. `belief.confirmed` 只写不读（docstring 承诺了一个没人 surface 的区分）→ **删掉字段**，
+   两个 warn 调用点本身就是那个区分的记录。`install` 永不返回错误而三处都在检查 → 去掉。
+   `plausibleRobotID` 卡字节而理由说的是字符（`VARCHAR(40)` 在 utf8mb4 下按字符）→ 写清它
+   **故意是更严的那个**，并说明为何今天不可达（两条产 id 的路径都是纯 ASCII）。
+   `invalidateSeeded` 的 docstring 夸大了顺序的重要性（span 边界移走后 `lastPersisted` 只是
+   节流标记）→ 改成真实的赌注。
+   botfather 保留 per-bot counter 的注释补上「为什么 bot-count 尺度可接受、payload 尺度不行」
+   —— 滥用单位不同：payload 字段每条消息免费且无界，bot 是限流、审计、有配额的对象。
+
+5. **「behaviour-neutral … exactly as before」第三轮被提，这次改在声明本身**：未激活时每次
+   分配确实多一次 Redis EVALSHA（`probeAllocatorState`），而 GenSeq 999/1000 次零 I/O。
+   披露从 Rollout 第 3 步（写成激活的后果）移到 Summary 里那句声明旁边，并点名
+   `addInlineQuery` 是唯一真正新增 Redis 依赖的地方。
+
+6. **#704 加 Gap 5**：mirror repair 没有安全的自动形式（两次尝试及各自失效原因），加上它依赖
+   却无人审计的两件事（`counterExists` 只是 EXISTS、无 provenance 无 TTL；每进程重启把每个
+   活跃 bot 的 counter 抬 ~2000 的 id 空间消耗），以及保留状态的回收 sweep。
+
+**验证**：`pkg/botevent` 46 测试、`tools/botevent-seq` 首个测试文件、`pkg/redis`、
+`modules/robot`、`modules/bot_api`、`modules/message` 全绿（`-race -shuffle=on`，`CI=true`，
+零 skip）。`modules/message` 的 `TestE2E_Issue557_*` 一度连续红，查明是**本地 WuKongIM 的
+raft 超时**（`propose batch until applied timeout` / `store message failed: context deadline
+exceeded`）—— 在 HEAD 上同样红，重启 IM 容器后即绿。

--- a/.octospec/tasks/bot-event-score-monotonic/brief.md
+++ b/.octospec/tasks/bot-event-score-monotonic/brief.md
@@ -160,9 +160,12 @@ PR #644·#648 把 `message_extra.version` 换成了事务性 per-channel 序列
 
 ## Acceptance
 
-- **源码守卫**：新增测试断言 `robotEvent:` 的**每一个** `ZADD` 站点都经由新分配器，
-  且 `GenSeq(RobotEventSeqKey…)` 在 `modules/` 下不再有调用点（参照
-  `TestEveryBotEventQueueWriterRingsTheDoorbell` 与 `msgextraseq` 的 PR-2c 守卫形状）。
+- **源码守卫**：`GenSeq(RobotEventSeqKey…)` 在 `modules/` 下不再有调用点（守卫改为断言
+  **key 符号本身**不得出现在 allowlist 之外，见第四轮记录），且每个 `robotEvent:` 的
+  `ZADD` 都摇门铃。
+  > **DEFERRED（第六轮 review 达成一致）**：本条原文还要求断言每个 `ZADD` 的 **score 来源**
+  > 是新分配器。已发的两个守卫都不约束 score —— 一个用 `time.Now().UnixNano()` 打分的
+  > writer 能同时通过。已记入 `Mininglamp-OSS/octo-server#704` Gap 4，不在本任务交付。
 - **并发单调性（新分配器）**：并发 goroutine × 两个独立分配器实例发 N 号，断言结果
   **严格递增且无重复**。
 - **对照必须失败（已本地验证可行，方法见下）**：同一条无损性断言用今天的 `GenSeq` 跑
@@ -499,3 +502,63 @@ sql-migrate 应用（`gorp_migrations` 有记录、状态表已建）。
 `pkg/redis`、`modules/robot`、`modules/bot_api`、`modules/message` 整包绿。
 `modules/message` 的 `TestE2E_Issue557_*` 一度红过一次并被我误判成迁移文件所致 —— 重跑两次
 均绿，是依赖 IM 的 flaky，**「revert 之后就好了」那一次是巧合**，记在这里以免下次又当因果。
+
+## 第五轮实现记录（第六轮 review 之后，2026-08-06）
+
+上一轮的两条修复又各自以新的方式出错，其中一条是我记为「已修」的。这一轮最重要的决定是
+**停止在本 PR 里迭代 durable-mark 边界**。
+
+1. **改主意：durable-mark 边界整块移交 `#704`，不再本地打第三次补丁。**
+   review 指出上一轮的 span 边界在**每次 seed 后的第一次分配**就已过界，且是确定性的：
+   `seedCounter` 存 `lastDurable = durableMax`，却把计数器 seed 到 `max(sources) + margin`，
+   两者天生差一个 margin。后果是第一次 durable 写失败就拒绝并**丢事件**，探针变成风暴
+   （每 bot 每 200ms 一次 300ms deadline 的 INSERT，都在 msgSem 槽内，约 67 个活跃 bot
+   打满 100 槽），错误文案的算术也是错的。**我的测试第三次断言在旁边那个机制上** —— 它先做
+   一次健康分配才打断写入，于是从没覆盖「seed 时写入就已经坏了」这个边界存在的状态。
+
+   我先按计划试算「让 seed 持久化自己的 floor」，算完发现修不好：
+
+       seed 把计数器设到 S = max(sources) + seedSafetyMargin
+       恢复时的 seed **重放同一个计算**，落在同一个 S。seed 后发出的号是 S+1, S+2, …，全在 S 之上。
+
+   也就是说 seed 后的**第一个 id** 就已经在「从未变的 mark 恢复」够不到的地方 —— 暴露不是
+   在某段宽限之后开始，是立刻开始。要关掉它必须在 seed 时推进 mark，而记录了 seed 值的 mark
+   会回灌进下一次 seed 的 floor，于是**每次 re-seed 复利一个 block**，并推翻
+   `TestSeedIsIdempotentAndNeverLowers` 守的「再 seed 是 no-op」。这不是改一个比较式，是
+   **改变 recovery floor 的定义** —— 正是 `#704` 那张表要做的事，两位 reviewer 也都建议移过去。
+
+   所以现在：保留 mark、节流（失败也重新武装，这是 P1-7 真正修好的那半）、metric，**如实写出
+   「写失败期间 mark 无界滞后」**，并用 `TestFailedDurableWriteIsThrottledAndDoesNotFailTheEnqueue`
+   把这个 gap 钉成测试事实（断言它**仍在**，将来修好会失败并提醒改成回归测试）。
+   算术与两次失败的原因都写进了 `#704` Gap 3，以免第三次重试同一条路。
+
+2. **上一轮的「按被拒 mirror 值缓存否定结论」能吞掉真正的激活。** `Activate` 把 epoch 0→1，
+   工具随后写的 mirror 就是 `incr:1` —— 与一个可能早已躺在 Redis 里的伪造 `incr:1`
+   **字节相同**，缓存命中，那些副本在 TTL 内继续 legacy 而别的副本已用 counter。激活瞬间
+   两个活跃号源。我 docstring 里写的「换一个值、包括真正的激活，仍算冲突」是错的。
+   **改为删除**与权威矛盾的 mirror（按值 CAS 删）：权威说 legacy 时正确的 mirror 状态就是
+   「不存在」，这与「权威说激活就重建 mirror」是对称的修复，于是没有缓存可过期，读风暴也
+   不需要缓存来挡。只剩「删不掉时」的短冷却（1s，而那种状态下 counter 的 INCR 也在失败）。
+   工具另加一道：检测到未授权 mirror 时**拒绝激活**，把前置条件在有人值守的那一步消掉。
+
+3. **`invalidateSeeded` 的删除顺序**能让并发 reseed 留下「已 seeded 但配套状态被清」的 bot。
+   改成 `seeded` 最后删 —— 最坏交错变成「未 seeded 但有残留簿记」，下次分配重 seed 即修。
+
+4. **staleness 快捷路径**会用「针对另一次 mirror 观测解析出的 belief」作答：加 mirror 复核。
+
+5. **那句运维在事故里唯一会读的文案是错的。** `counterExists` 拒绝里我写「restore the state
+   row (or set `OCTO_BOTEVENT_EXPECTED_MODE=incr`)」，但设了这个 env 会走到
+   `assertExpectedMode(false)` 报错，分配照样失败 —— 它是 fail-closed 断言，不是手动 override。
+   已改成说清它到底买到什么。Rollout 第 6 步同样错（三种形态里两种已不再自愈），已拆成三个
+   metric 并写明哪个不自愈。
+
+6. **`payload.robot_id` 的 fail-open 路径加语法界**：长度 ≤ `robot.robot_id` 的列宽（40）+
+   拒空白/控制字符。长度这条不需要判断力 —— 超过列宽的值不可能匹配任何行，所以采用它只可能
+   为一个可证不存在的 bot 创建永久状态。**刻意不做字符集白名单**：生产 id 是 UUID-hex，但列里
+   存什么都行，猜窄了会静默掉一个真 bot 的事件。另加一条测试把常量与列宽绑在一起。
+
+7. **score-source 守卫标为 DEFERRED** 并记入 `#704` Gap 4 —— 上一轮说了「建或移」，结果两样
+   都没做，于是 brief 挂着一条无人跟踪的验收项。
+
+**验证**：`pkg/botevent` 45 测试全绿（`-race -shuffle=on`，`CI=true`，**零 skip**）；
+`modules/robot` 新增 `plausible_robot_id_test.go`。

--- a/.octospec/tasks/bot-event-score-monotonic/brief.md
+++ b/.octospec/tasks/bot-event-score-monotonic/brief.md
@@ -621,3 +621,24 @@ mirror repair** —— 它已被重写两次（缓存否定 → 删除键），�
 零 skip）。`modules/message` 的 `TestE2E_Issue557_*` 一度连续红，查明是**本地 WuKongIM 的
 raft 超时**（`propose batch until applied timeout` / `store message failed: context deadline
 exceeded`）—— 在 HEAD 上同样红，重启 IM 容器后即绿。
+
+## 第七轮实现记录（head `6a5cd9a6` 重审之后，2026-08-09）
+
+最新重审确认两处合并即暴露的边界，均先加失败测试再修复：
+
+1. **expected-mode 拒绝没有保存已解析的权威结果。** 当权威为 legacy 而
+   `OCTO_BOTEVENT_EXPECTED_MODE=incr` 时，原实现先返回 mismatch error、后 `install`，所以每条
+   被拒消息都在 `msgSem` 槽内重新读取 MySQL；拼错值（如 `inrc`）也先 probe Redis、再读 MySQL
+   才失败。现在 malformed guard 在任何依赖 I/O 前拒绝；已成功解析的权威 belief 先保存、再执行
+   assertion，缓存 belief 每次使用仍重新 assertion。结果是 mismatch 首次最多一次权威读、之后
+   快速拒绝，不会因缓存 negative belief 而放行 legacy；mirror 真正翻到新 epoch 时仍会触发刷新。
+2. **`payload.robot_id` 的 40 字节形状界只限制单键大小，不限制键数量。** 原来的 lookup-error
+   fail-open 允许客户端在 DB/Redis 故障窗口提交无限多个不同但合法形状的 id，并为每个值留下无
+   TTL counter 与永久 `seq` 行。现在只有 `err == nil && exists == true` 才采用客户端 id；查询失败
+   会记录错误并忽略这条仅靠 `payload.robot_id` 路由的事件。这个可用性取舍在**合并部署后立即
+   生效**，与 allocator activation 无关；它避免把一次依赖故障放大成永久、无界状态增长。
+
+同时更正 rollout 残余的描述：需要 fail-closed assertion 覆盖的真实证据空洞是 **mirror 缺失或
+非法 + authority 不可读 + 当前 bot 尚无 counter（新建或空闲 bot）**，不只限于「mirror 和
+counter 被同一次 Redis 恢复一起丢失」。因此激活验证完成后仍必须最后滚动设置
+`OCTO_BOTEVENT_EXPECTED_MODE=incr`；它是断言，不是激活开关。

--- a/.octospec/tasks/bot-event-score-monotonic/brief.md
+++ b/.octospec/tasks/bot-event-score-monotonic/brief.md
@@ -229,6 +229,33 @@ max score（否则某个高 score 队列的客户端游标会把新号段整体�
 同性质（排障/验证工具）。实现阶段把核心断言抽成 `pkg/botevent` 下的正式测试，工具保留
 供运维复核。
 
+## 实现记录（2026-08-05，commit b4fca040）
+
+实现过程中三处偏离 / 补充了本 brief 的原始判断，记在此处而非默默改掉：
+
+**① 站点是 6 个，不是 5 个。** 新增的 `TestNoGenSeqForBotEventIDs` 守卫立刻抓到
+`modules/robot/api.go` 的 `addInlineQuery` —— 它也从 `RobotEventSeqKey+robotID` 取号。
+本 brief 和 `modules/robot/api.go:232` 的注释都说「five ZADD sites in total」，都漏了它，
+因为它**不写 ZSET**（只 append 到进程内 `inlineQueryEventsMap`）。而 `inlineQueryEventsMap`
+**没有任何读取/投递路径**（只有 add / remove），所以那些 event 从不发给任何人 —— 它唯一的
+实际作用是消耗号码并推进 `min_seq`，即污染队列号源却不产出任何可投递事件。处置：隔离到
+独立 key `inlineQuerySeq:`，仍用 GenSeq（无人消费的 id 没有单调性要求，不值得引入 Redis
+依赖）。**这正是「守卫而非注释」的价值：注释错过一次，守卫一次就抓到。**
+
+**② 队列 key 统一到 `botevent.QueueKey`。** 原先 5 处各自 `fmt.Sprintf("robotEvent:%s", ...)`。
+seed 必须读 producer 写的同一个 key，硬编码分散是真实风险。统一后必须同步更新
+`TestEveryBotEventQueueWriterRingsTheDoorbell` 的 `queueKey` regex —— 否则它 `matched=4 < 5`
+直接 fatal（那个守卫的防盲下限按设计生效了，值得记一笔）。
+
+**③ 测试用独立库 `botevent_test`，不用共享 `test` 库。** `seq` 表由
+`modules/common/sql/20211108000001_common_legacy01.sql` 管理；在 `test` 库裸建它会留下
+`gorp_migrations` 无记录的表，下个包的 `NewTestServer` 就 `Table 'seq' already exists` ——
+与 message 包大量 DB 测试被 skip 的根因同一个。已在实现中踩到并修正。
+
+验证：`pkg/botevent` 全包 19 测试绿（`-race`）；`modules/robot`、`modules/group`、
+`modules/bot_api` 整包绿；`go build ./...`、`go vet`、`gofmt`、`make i18n-extract-check`、
+`make i18n-lint` 全过。
+
 ## Open questions（需人类确认）
 
 1. **现存 3 个碰撞队列（2624 个碰撞 member）要不要一次性重编号？**

--- a/.octospec/tasks/bot-event-score-monotonic/brief.md
+++ b/.octospec/tasks/bot-event-score-monotonic/brief.md
@@ -445,3 +445,57 @@ sql-migrate 应用（`gorp_migrations` 有记录、状态表已建）。
     测试建表也补齐 migration 的 `CHECK` 与 `ON UPDATE`。
 
 **验证**：`pkg/botevent` 42 测试全绿（`-race -shuffle=on`，`CI=true`，**零 skip**）。
+
+## 第四轮实现记录（第五轮 review 之后，2026-08-06）
+
+两位 reviewer 独立抓到同一处：**上一轮记为「已修」的 P1-7 其实没修**。加上另一位的三条，
+六项在本轮修完，回退检测两条仍在 `#704`。逐条记下被推翻的判断：
+
+1. **fail-closed 没生效，而且我的测试给了假信心。** 边界是「连续失败的 interval 数」，但
+   `persistHighWater` 的节流早退发生在**查这个边界之前**，且 `noteHighWaterFailure` 顶上
+   无条件重新武装了节流标记。于是过界后每 1000 次分配只有 1 次真的走到检查，其余 999 次
+   `return nil` 成功 —— 正是「对着冻结的 mark 无界发号」本身。算术上还不只是声明没兑现：
+   limit=3 时 id 跑到 `M+2999`，而 `seedSafetyMargin` 是 2000，从 `M` 重算的 seed 落在
+   `M+2000`；发号进程会 `retried <= prev` 响亮拒绝，但**重启后的进程 `lastIssued` 为空，
+   会静默从 `M+2001` 接着发**，落在已到 `M+2999` 的游标下方。
+   我的测试直接调 helper、参数恰好按 interval 间隔，所以从没经过那个吞掉 999 的早退，
+   断言的是 helper 的返回值而不是分配器的行为。**这条批评完全成立。**
+2. **边界改成「距上次真正落盘的 mark 有多远」**，即安全论证真正依赖的那个量。`lastDurable`
+   与节流标记分开，失败时绝不前进；在 `seedSafetyMargin` 处拒绝，使最大已发号恰好比恢复
+   首号低 1。一条不等式取代了需要手工与 margin 对账的计数，顺带删掉那个非原子的计数器。
+3. **测试逼出两件事**：①过界后按 id 距离节流会让恢复取决于流量（低流量 bot 无界等待），
+   改成时间预算（200ms）；但**不能不节流** —— 300ms deadline 的失败 INSERT 占着 msgSem 槽，
+   对全进程所有 bot 是吞吐悬崖，不因为这次入队注定失败而改变。②未节流路径上不能先查 span：
+   durable 行还不存在的 bot base 为 0，先查会在还没尝试记录之前就拒掉它的第一次分配。
+4. **`mode.go` 里那句核心不变量陈述是假的，而 follow-up 的拆分理由正引用它。** 我写
+   「every replica reads the same authority row and reaches the same conclusion」，但正向
+   belief 直接返回、不再读权威，mirror 完好时 gate 也永不关闭。于是激活后权威回滚会让
+   在跑的副本继续用 counter、新起的副本走 GenSeq —— 两个活跃号源。
+   **修法不需要 DB 读也不依赖 env**：读 mirror 的那次往返顺带返回该 bot 的 counter 是否存在，
+   而 counter 存在只可能因为某个副本从它发过号，也就只可能发生在权威说 incr 之后。冷启动
+   看到 legacy + 活的 counter 就拒绝而非降级。**折进同一次往返**，另开一次就是 P1-1 的缩小版。
+   残余（counter 也一起丢）明确写成 accepted residual 并用测试钉住。
+5. **被拒绝的 mirror 会让每次分配串行读一次权威且没有出口。** mirror 声称 incr 时刻意跳过
+   负向 TTL（这才让 flip 不等 TTL），但没有任何代码会改写或清掉一个伪造的键，于是每次分配
+   在 `beliefMu` 后各读一次、都在 msgSem 槽内 —— 与上一轮修掉的每次分配读权威同一类。改为
+   按**被拒的那个 mirror 值**缓存否定结论，换一个值（包括真正的激活）仍算冲突仍强制重读；
+   forced refresh 也加了指针检查，一次 mode 键丢失只花一次读而不是每个在飞分配各一次。
+6. **队列 key 第三次才真正统一。** 还剩 4 个生产点自己拼（`api_manager.go` 撤 token、
+   `botfather/command.go` 三处 teardown）加一个死字段，全是 `Del`、不影响分配 chokepoint，
+   但「一种拼法」这句话就是假的。现在 `grep -rn '"robotEvent:' modules/` 在非测试代码里为空。
+7. **`payload.robot_id` 的存在性校验改成查询出错时 fail-open。** review 指出照原样发布会把
+   一次 DB/Redis 抖动变成静默丢事件，而它要挡的增长面是「攻击者给的、可证明不存在的 id」，
+   且没有调用方能让这次查询报错。所以保留校验、去掉 fail-closed，改动收敛成「已知不存在才拒」。
+8. **守卫的盲拼法**：`"robotEvent:%s"` 匹配得到，`"robotEvent:" + robotID` 匹配不到 —— 而后者
+   正是 `modules/message`、`modules/bot_mention` 测试里通用的写法，第六个 writer 用它会同时
+   躲过匹配和防盲下限。已补全并在 vacuity 测试里逐个断言。
+9. **`TestMain` 的探针不够**：只探 `SELECT 1` 与 `PING`，而真正卡住测试的是两条 `CREATE TABLE`。
+   CI 上一个权限/collation 问题仍会让整包静默 skip 而 `go test` 退 0 —— 正是这个 TestMain
+   要关掉的盲点。DDL 已与 `seqTestCtx` 共用。
+10. **expected-mode 改 atomic 指针**：测试钩子改写的是生产代码读的包级变量，当前调用点都是
+    单 goroutine 所以 `-race` 干净，但「今天干净」不值得依赖。
+
+**验证**：`pkg/botevent` 46 测试全绿（`-race -shuffle=on`，`CI=true`，**零 skip**）；
+`pkg/redis`、`modules/robot`、`modules/bot_api`、`modules/message` 整包绿。
+`modules/message` 的 `TestE2E_Issue557_*` 一度红过一次并被我误判成迁移文件所致 —— 重跑两次
+均绿，是依赖 IM 的 flaky，**「revert 之后就好了」那一次是巧合**，记在这里以免下次又当因果。

--- a/.octospec/tasks/bot-event-score-monotonic/brief.md
+++ b/.octospec/tasks/bot-event-score-monotonic/brief.md
@@ -1,7 +1,7 @@
 ---
 type: Task
 title: "Task: bot-event-score-monotonic"
-description: 把 robotEvent:{robotID} 的 score 从 octo-lib GenSeq（进程内 HiLo 块）换成严格单调分配器，使 POST /v1/bot/events 的排他游标分页无损；生产上乱序与碰撞均已实测发生，碰撞还会让 ack 误删未投递事件。核心迁移风险是新号段必须整体高于所有客户端已持有的旧游标。
+description: 把 robotEvent:{robotID} 的 score 从 octo-lib GenSeq（进程内 HiLo 块）换成严格单调分配器，消除排他游标下的碰撞与跨重启倒挂两类永久丢失；生产上两者均已实测发生，碰撞还会让 ack 误删未投递事件。不含 ZADD 重排窗口（见 Out of scope，独立 issue），故不得称为「使排他游标无损」。核心迁移风险是新号段必须整体高于所有客户端已持有的旧游标。
 tags: ["bot-api", "wire-contract", "observability", "testing", "commit"]
 timestamp: 2026-08-05T17:03:42+08:00
 # --- octospec extension fields ---
@@ -17,9 +17,14 @@ source: self
 
 ## Goal
 
-让 `robotEvent:{robotID}` 的 sorted-set score **严格单调、全局唯一**，从而使
-`POST /v1/bot/events` 的排他游标分页（`ZRANGEBYSCORE key (cursor +inf`，
-`modules/bot_api/events.go:251`）成为无损投递。
+让 `robotEvent:{robotID}` 的 sorted-set score **严格单调、全局唯一**，消除
+`POST /v1/bot/events` 排他游标分页（`ZRANGEBYSCORE key (cursor +inf`，
+`modules/bot_api/events.go:251`）下的两类永久丢失：**score 碰撞**与**跨重启的号序倒挂**。
+
+> **范围声明（review 2.3/2.4 要求）**：这**不等于**「排他游标从此无损」。分配与发布是两次
+> 操作，A 分配 `N` 后 stall、B 分配 `N+1` 并 ZADD 摇铃时，消费者的游标会越过 `N`。那个窗口
+> 本任务不修，见 Out of scope，并已被 `TestKnownResidualZaddReorderingCanStillSkip` 钉成
+> 测试事实。原文写「成为无损投递」是过度声称。
 
 **当前的缺陷**：score 来自 octo-lib `GenSeq`（`config/seq.go`），这是**进程内**
 HiLo 块分配器 —— `seqStep = 1000`，块缓存在包级 `seqMap`，只由进程内 mutex 保护，
@@ -79,7 +84,7 @@ PR #644·#648 把 `message_extra.version` 换成了事务性 per-channel 序列
 从来不在那个范围内，**激活 #627 的 cutover 对本路径零影响**。本任务不依赖 #627 的
 激活状态，也不改变它。
 
-**分配器选型（待人类确认）**：
+**分配器选型（已定，见 D1）**：
 
 | 方案 | 单调唯一 | 成本 | 备注 |
 |---|---|---|---|
@@ -127,6 +132,15 @@ PR #644·#648 把 `message_extra.version` 换成了事务性 per-channel 序列
   member 永不清理是另一个 bug，单独处置。
 - **bot 侧游标策略**。正确用法（`event_id=0` + 严格 ack，让 `ZREM` 而非游标定义进度）
   应写进文档并通知 bot 作者，但**不在本任务改任何 bot**。
+- **ZADD 重排窗口（review 2.3，已知 residual，需独立 issue）**。分配与发布是两次操作：
+  A 分配 `N` 后 stall（marshal / GC / 慢往返），B 分配 `N+1` 并 ZADD **且摇铃** → 消费者被
+  唤醒读到 `N+1`、游标推到 `N+1` → A 的 ZADD 才落在 `N`，永久不可达。**doorbell 让它更易
+  发生，不是更难** —— 唤醒正由造成倒挂的那次 ZADD 触发。单调 id 消掉的是碰撞与跨重启倒挂，
+  **不含这个窗口**；它需要游标下方的 re-delivery 窗口（`modules/bot_api/events.go:186-199`
+  自己就写了 "a Redis-side allocator **or** a re-delivery window"，本任务只交付了前者），
+  要改消费侧契约，属独立提案。已用 `TestKnownResidualZaddReorderingCanStillSkip` 把它钉成
+  测试事实而不是 PR 描述里的一句话 —— 那个测试断言「今天仍会丢」，将来修好了它会失败并提醒
+  改成回归测试。**因此本任务不得被描述为「使排他游标无损」。**
 - **重新设计 ack 协议 / 改成 stream（`XADD`）**。`XADD` 天然单调且有 consumer group，
   是更彻底的方向，但会改 wire 契约与所有 bot，属独立提案。
 - **octo-lib `GenSeq` 本身的修复**，以及**已确认的两个同类实例**（不是"待审计"，是
@@ -186,7 +200,13 @@ PR #644·#648 把 `message_extra.version` 换成了事务性 per-channel 序列
 
 ## Decisions（已定，附依据；无需再讨论除非依据被推翻）
 
-**D1. 分配器用 Redis `INCR`，per-bot key（`botevent:seq:{robotID}`）。**
+**D1. 分配器用 Redis `INCR`，per-bot key `botEventSeq:counter:{robotID}`。**
+
+> **更正**：本 brief 原写 `botevent:seq:{robotID}`，实现最初写成 `botEventSeq:{robotID}` ——
+> 而 `ModeKey` 是 `botEventSeq:mode`，于是 `SeqKey("mode")` **就等于** `ModeKey`：robotID 为
+> `mode` 的 bot 会把全局激活开关当自己的计数器 seed + INCR。UUID-hex 的 robotID 让它不可达，
+> 但「一个合法输入能撞上全局键」的命名空间不该留着。已加 `counter:` 段并加回归测试
+> （`TestCounterKeyCannotCollideWithModeKey`）。讽刺的是 brief 原来的拼写本来不会撞。
 
 原先把它列为待决，是因为「Redis 持久化丢失导致计数器回退」这个风险的强度取决于生产
 配置 —— 那是事实问题，不是偏好问题，已查清（生产 Redis，只读 `CONFIG GET` / `INFO`）：
@@ -227,6 +247,25 @@ max score（否则某个高 score 队列的客户端游标会把新号段整体�
 
 **D1 的「no fallback」与此不冲突，但必须分清**：未激活 → 走 legacy，这是**设计的模式**；
 已激活但 Redis 失败 → 返回错误、拒绝入队，**不**偷偷回退 GenSeq。
+
+**D6.（review 后新增）激活状态的权威在 MySQL，Redis 只是镜像 —— 对齐 #627，但不照搬。**
+
+只把 mode 放 Redis 是错的：生产 `appendonly no`，RDB 回滚会让它退回，而**丢失后降级回
+legacy 会发出低于计数器已发出号的 id**，落在活跃游标下方，正是 #697 的镜像。
+
+- 权威：`octo_bot_event_seq_state`（singleton：`mode`/`epoch`/`cutover_floor`），
+  `FOR UPDATE` 的 CAS flip + `ErrFloorTooLow` 的 floor 校验，形状与
+  `octo_message_extra_version_state` 一致
+- 镜像：Redis `botEventSeq:mode`，**唯一目的**是让 mode 能与 `INCR` 在同一个 Lua 里原子读取
+  （热路径不能加 DB 往返）
+- 镜像丢失 → 分配器读权威行；权威说已激活就**重建镜像 + 重新 seed 并继续**（自愈），说
+  legacy 才走 legacy，读不到则按 expected-mode 决定 fail-closed 还是当作未迁移
+
+**刻意不复用 #627 的 `FOR SHARE` drain barrier**：那个 barrier 要求每个写入方在业务事务内
+持状态行锁到 commit，而 `robotEvent` 的写入是 `INCR` + `ZADD` 纯 Redis，**没有 commit 可持**；
+为借用它而给每次分配包一个事务，等于把分配器要避免的「每条消息一次 DB 往返」原样请回来。
+**代价必须写在纸上**：本方案在 flip 瞬间无法 drain 在途写入方，只能靠「运维先确认无旧副本」
++ flip 前后短暂停写。
 
 **D3. 现存碰撞 member 不重编号**（详见 Open questions 1 —— 这是唯一需要人类签字的一条，
 因为它是唯一涉及写生产数据的选项）。
@@ -293,3 +332,42 @@ seed 必须读 producer 写的同一个 key，硬编码分散是真实风险。�
    所以基线要在修复上线前后各取一次。
 
    如果你倾向重编号，我需要额外的授权范围（写哪个队列、是否停写窗口）和一个回滚快照方案。
+
+
+## 第二轮实现记录（review 之后，2026-08-05）
+
+两位 reviewer 独立指出 co-recovery 论证「只证唯一性、不证相对游标的单调性」，据此加了 D6
+与 durable high-water。实现过程中被测试推翻的、以及 review 抓到的，逐条记下：
+
+1. **回退检测在并发下误判**。`INCR` 原子，但并发调用者**不按发号顺序观察结果** —— 拿到 100
+   的可能比拿到 140 的更晚到达检查点。无容差比较把普通并发判成回退，并发测试暴露为「200 次
+   分配跨度 6000」。加 `rollbackTolerance`（一个 legacy block：远高于真实在飞数，远低于真实
+   回退幅度）+ CAS 维护最大值。**代价写明**：小于该容差的回退检测不到，靠下次 seed 修。
+2. **并发首次分配各自 seed**。后到者在赢家已发号并推进高水位之后才算 floor，于是 floor 落在
+   活跃 counter 之上，每个竞争者烧掉一个号段。改为 per-bot 单飞 + 双检。
+3. **高水位写的是 `v + interval` 而非 `v`**，与 seed margin 叠加放大跳变。
+4. **gate 哨兵用 `v < 0` 判断**，于是变负的 counter 会被读成「未激活」而静默降级。改为精确
+   匹配；加第二个哨兵后又漏改这处校验，被测试再抓一次。
+5. **缺 `EXISTS` 守卫**（review 2.2）。`INCR` 在缺失键上返回 **1**，而唯一的阻挡是 `seeded`
+   —— **进程内状态守着 Redis 状态**。mirror 存活、counter 被删、进程不重启，该 bot 的事件会
+   从 1 重新编号，比快照回滚更糟（回滚一个窗口后自愈，这个要重发完整个历史号段才有一个事件
+   可见）。加 `-2` 哨兵，**发号前**失败而不是发完再检测。
+6. **`ModeKey` 与合法 counter key 碰撞**（见 D1 更正）。
+7. **写侧计数器接了 Prometheus，不留 follow-up**。原打算沿用 `bell.go` 把 metric 归给 G1
+   的先例，但那条先例适用的是**门铃丢失**（代价有界：一个 chunk 的延迟）。这四个计数器
+   （回退 / counter 丢失 / 镜像重建 / 高水位写失败）是四个**自愈**机制的唯一可见性 ——
+   自愈意味着没有 error、没有失败入队、没有可告警的日志，不接就等于 RDB 安全边界静默退化。
+   用 `promauto` 注册到 default registry（同 `pkg/i18n/details.go`、`modules/oidc/metrics.go`），
+   无 label（brief 要求低基数），`healCounter` 同时保留一个 atomic 供测试断言，避免生产
+   代码依赖 `prometheus/testutil`。
+8. **`afterIssue` 与 `mirrorMissing` 互相递归无界**（自审发现，非 reviewer）。Redis 反复丢
+   状态时会栈溢出 —— **进程崩溃**，比丢一个事件严重。加 `maxAllocAttempts = 3` 并把尝试
+   计数穿过所有自愈路径。
+9. **测试库判断反复了一次**：为避开污染改用独立库 `botevent_test`，**错得更隐蔽** —— CI 从不
+   创建它，于是所有集成测试在 CI 里静默 `Skip`，与通过无法区分。已改回 `test` 库；CI 每包前
+   `DROP/CREATE test` 才是让这里裸建 migration 表安全的前提。
+
+**验证**（按 `.github/workflows/ci.yml` 的方式：`-race -shuffle=on` + 每包前重置库）：
+`pkg/botevent`（28 测试）、`pkg/redis`、`modules/robot`、`modules/group`、`modules/bot_api`、
+**`modules/message`**（brief 点名、上一轮漏跑，review 抓到）全绿；migration 经真实
+sql-migrate 应用（`gorp_migrations` 有记录、状态表已建）。

--- a/.octospec/tasks/bot-event-score-monotonic/brief.md
+++ b/.octospec/tasks/bot-event-score-monotonic/brief.md
@@ -642,3 +642,31 @@ exceeded`）—— 在 HEAD 上同样红，重启 IM 容器后即绿。
 非法 + authority 不可读 + 当前 bot 尚无 counter（新建或空闲 bot）**，不只限于「mirror 和
 counter 被同一次 Redis 恢复一起丢失」。因此激活验证完成后仍必须最后滚动设置
 `OCTO_BOTEVENT_EXPECTED_MODE=incr`；它是断言，不是激活开关。
+
+## 第八轮实现记录（head `c175ca6e` 重审之后，2026-08-09）
+
+最新重审确认上一轮两条 blocker 已修，但又找出四处会误导激活操作或评审边界的声明，以及
+一处激活 floor 风险。本轮继续先写失败测试，再做最小修复：
+
+1. **MySQL 已翻转、Redis mirror 写失败不能算成功。** 原工具只打印 warning 并退出 0，还说
+   下一次 allocation 会立即修复；实际已有 negative belief 的副本最长 5 秒仍可走 GenSeq。
+   `writeMirror` 现在返回 error，两条 activate 路径都 fatal 非零，并明确要求保持 bot-event
+   停写，直到 `botEventSeq:mode` 出现期望的 `incr:{epoch}`。测试
+   `TestMirrorWriteFailureStopsActivationAndExplainsPause` 覆盖退出契约依赖的错误内容。
+2. **`-yes` 不再隐藏前置条件。** 三项前置条件每次 activate 都输出；`-yes` 只表示 operator
+   已核实。清单补上 cutover floor 不能继承已回退的 legacy `min_seq` 并落到现存 consumer
+   cursor 下方；完整算术交由 #704。
+3. **unauthorized mirror 不会被删除，也不会自动自愈。** allocator 无法判断回退的是 mirror
+   还是 authority，因此保留冲突键；日志、metric 注释和 operator 文案全部改成要求人工诊断，
+   只有确认 mirror 非法后才可删除。allocator 仅在已验证激活且当前 bot 完成 re-seed 后重建
+   丢失的 mirror；不是 legacy 路径上的自愈。
+4. **证据空洞比上一轮写得更宽。** 精确条件是「任意 negative belief + 当前 bot 无 counter」：
+   包括 authority 可读但已回退为 legacy/missing，也包括 authority 不可读且 mirror 不声称激活。
+   `OCTO_BOTEVENT_EXPECTED_MODE=incr` 仍是激活验证后的最终 fail-closed assertion。
+5. **守卫边界保持 DEFERRED。** 已有 guard 证明每个 queue ZADD 会响 doorbell；它不证明 score
+   一定来自 allocator。score-source guard 仍由 #704 Gap 4 承接，PR 描述不得再把两者等同。
+
+**验证**：新增两条工具测试转绿；`pkg/botevent`、`tools/botevent-seq`、`pkg/redis`、
+`modules/robot`、`modules/bot_api`、`modules/group`、`modules/message` 均以
+`-race -shuffle=on` 通过（模块包按 CI 方式逐包重建 MySQL test 库并清 Redis）；另通过
+`go build ./...`、`go vet ./...`、i18n extract/lint 与 `git diff --check`。

--- a/.octospec/tasks/bot-event-score-monotonic/brief.md
+++ b/.octospec/tasks/bot-event-score-monotonic/brief.md
@@ -1,0 +1,251 @@
+---
+type: Task
+title: "Task: bot-event-score-monotonic"
+description: 把 robotEvent:{robotID} 的 score 从 octo-lib GenSeq（进程内 HiLo 块）换成严格单调分配器，使 POST /v1/bot/events 的排他游标分页无损；生产上乱序与碰撞均已实测发生，碰撞还会让 ack 误删未投递事件。核心迁移风险是新号段必须整体高于所有客户端已持有的旧游标。
+tags: ["bot-api", "wire-contract", "observability", "testing", "commit"]
+timestamp: 2026-08-05T17:03:42+08:00
+# --- octospec extension fields ---
+slug: bot-event-score-monotonic
+upstream: Mininglamp-OSS/octo-server#697
+source: self
+---
+
+# Task: bot-event-score-monotonic
+
+> One task = one `.octospec/tasks/<slug>/` directory. This brief is the spec for
+> the work. AI may draft it from existing code; a human confirms it.
+
+## Goal
+
+让 `robotEvent:{robotID}` 的 sorted-set score **严格单调、全局唯一**，从而使
+`POST /v1/bot/events` 的排他游标分页（`ZRANGEBYSCORE key (cursor +inf`，
+`modules/bot_api/events.go:251`）成为无损投递。
+
+**当前的缺陷**：score 来自 octo-lib `GenSeq`（`config/seq.go`），这是**进程内**
+HiLo 块分配器 —— `seqStep = 1000`，块缓存在包级 `seqMap`，只由进程内 mutex 保护，
+`min_seq` 用无条件 `ON DUPLICATE KEY UPDATE` 写回。3 副本部署下同时存在多个 1000
+宽的活跃块，`event_id` 顺序与真实入队顺序脱钩。**游标一旦推进到高块，之后从低块
+发出的事件永久不可达** —— 排他 `Min` 把它排除，而游标下方没有任何重投机制。
+
+`events.go:182-213` 已经记下了相邻的那条假设（"uniqueness is assumed and
+unverified"，PR #685 review P2-3），但把后果限定在 score **碰撞**上。实测表明
+**仅顺序倒挂就足够**，不需要碰撞。
+
+**生产实测（只读）**：单个 bot 队列 644 条事件里 **19 处相邻顺序倒挂，全部精确落在
+1000 块边界**（`…X007 → …(X+1)001`），**最大时间回退 6.7 天**。在 `card_action` 事件上
+（`acted_at` 是服务端 `time.Now()`，`modules/message/api_card_action.go:253`，可直接
+比较）测到 `…5009` 的 `acted_at` 比 `…4007/…4012/…4013` 都早 —— 两个块并发发号的
+直接证据。
+
+**碰撞也已发生，不只是乱序。** 全量只读扫描 **1948 个非平凡队列，3 个存在重复
+score**：`70565/70395`（170 重复）、`25136/23932`（1204）、`16588/15526`（1062）。
+重复数聚集在 `seqStep` 倍数附近 —— 整块被重复发放的指纹。机制在 `addOrUpdateSeq`：
+写回的 `min_seq` 由**进程本地** `CurSeq + seqStep` 算出，且 `ON DUPLICATE KEY UPDATE
+min_seq=VALUES(min_seq)` 是**无条件覆盖**，所以落后的副本能把 `min_seq` **改小**，
+之后冷启动的副本读到已发放区间并重发一遍。
+
+碰撞叠加出**第二条、更坏的丢失路径**：`ackEvent` / `eventAck` 按
+`ZRemRangeByScore(key, id, id)` 删除（`events.go:160`、`:324`），会删掉**所有**共享该
+score 的 member —— 于是 ack 一条已投递的事件会静默销毁一条从未投递给任何人的事件。
+`events.go:182-213` 预言了这一点并记为「假设不会发生」；它已经发生了。
+
+**本地已复现（`tools/genseq-repro/`）**：用真实 `config.Context.GenSeq` + 真实
+`events.go` 的读/删形状，在容器 MySQL 8.0 + Redis 7 上复现出全部三条丢失路径 —— 碰撞
+（确定性、全量重叠）、分页边界跳过、低块晚到跳过、ack 连带删除。详见 #697 的复现评论。
+
+**用户可见症状**：点交互卡片没反应，且**同一张卡上部分人可用、部分人永久失效**，
+取决于其点击落在哪个块。叠加 D4 幂等（键为 `(message_id, action_id, operator_uid)`，
+TTL = `Robot.MessageExpire` 默认 7 天，刻意不含 `inputs`），被跳过的用户重试只会拿到
+`{"accepted":true,"replay":true}` —— **D8「超时 re-tap 自愈」的假设在这里不成立**，
+丢失不可自愈。
+
+## Background
+
+**这不是 bot 侧误用 API。** 服务端在自己的 long-poll hold 内部就是按「已观测到的
+最大 `event_id`」推进游标的：
+
+```go
+for _, r := range raw {
+    if r.EventID > page.cursor { page.cursor = r.EventID }   // events.go:235
+}
+```
+
+一次 hold 里先读到高块事件、随后收到低块入队，服务端自己就会跳过它，与 bot 怎么管
+游标无关。所以修复责任在服务端。
+
+**与 #627 的关系**：同一根因家族（`GenSeq` 跨副本 HiLo），但**不同作用面**。#627 /
+PR #644·#648 把 `message_extra.version` 换成了事务性 per-channel 序列
+（`internal/msgextraseq`），只覆盖 `message_extra` 的写入方；`robotEvent` 的 score
+从来不在那个范围内，**激活 #627 的 cutover 对本路径零影响**。本任务不依赖 #627 的
+激活状态，也不改变它。
+
+**分配器选型（待人类确认）**：
+
+| 方案 | 单调唯一 | 成本 | 备注 |
+|---|---|---|---|
+| Redis `INCR`（per-bot key） | ✅ | 一次 Redis 往返，与 `ZAdd` 同一 pipeline/Lua 可合并 | **倾向选它**：队列本身就在 Redis，无新依赖；`saveRobotMessage` 是最热路径，不宜再加 DB 往返 |
+| `internal/msgextraseq` 式 DB 事务序列 | ✅ | 每条事件一次 DB 写 + 行锁 | 语义最强，但对 bot 消息扇出这种量级的热路径过重 |
+| 保留 `GenSeq` + 游标下方重投窗口 | ❌ | 低 | 只缩小窗口不封闭，仅作为过渡缓解；且要求消费方按 `event_id` 去重（改 bot 契约） |
+
+若选 Redis `INCR`，必须处理 **Redis 持久化丢失导致计数器回退**：启动/首次使用时以
+`max(该队列现存 max score, 旧 `GenSeq` `min_seq`)` 作为 floor 引导（与
+`msgextraseq` 的 bootstrap 同思路），并在写入侧对「新 score ≤ 队列当前 max」计数告警。
+
+## Load-bearing list
+
+- **`POST /v1/bot/events` 的 wire 契约**：`event_id` 的语义、游标的排他语义、返回
+  形状（`status`/`results`）。已有 bot 客户端持有旧号段的游标值。
+- **切换时的号段单向性（本任务最大风险）**：新分配器的首发值必须 **> 所有客户端已
+  持有的游标**，否则新事件被旧游标挡在 `Min` 之外 —— 症状与本 bug 完全相同，只是
+  影响所有 bot。这是硬前置条件，不是 nice-to-have。
+- **score == payload `event_id` 的等值不变量**：`ackEvent` /
+  `eventAck` 用 `ZRemRangeByScore(key, id, id)` 定位 member（`events.go:160`、
+  `:324`），`events.go:182-213` 明确记录了这个耦合。新分配器不得破坏它。
+- **碰撞下的 ack 误删**：同一 score 的多个 member 会被一次 ack 全部删掉。修好分配器
+  能阻止**新增**碰撞，但**现存队列里已有的重复 score 不会自愈** —— 处置方式见
+  Open questions 3。
+- **5 个 `ZADD` 生产点必须整体切换**（`modules/robot/api.go:224-235` 列举）：
+  `enqueueBotEventGeneric`、`enqueueBotTypedEventGeneric`（`card_action`）、
+  `saveRobotMessage`、以及 `modules/group` 的两个 `notifyBotJoinedGroup`。**部分
+  切换会重新造出「两个活跃号源」这一正是本 issue 的条件。** 需要源码守卫，参照
+  `pkg/botevent` 的 `TestEveryBotEventQueueWriterRingsTheDoorbell`。
+- **long-poll 的前进保证**（PR #685）：`readEventPage` 的 `page.cursor`/`advanced`
+  推进逻辑，及其「Redis 读成功而写失败时仍能前进」的设计（`ackEvent` 的注入缝）。
+- **App Bot 的 DM-only 过滤 + auto-ack**（`filterAppBotEvents`）：依赖同一等值不变量。
+- **doorbell**（`pkg/botevent`）：门铃只是提示，ZSet 是唯一权威 —— 本任务不得把
+  分配器塞进门铃路径，也不得让分配失败阻塞生产者（`msgSem` 停摆风险，见
+  `bot-events-longpoll` brief）。
+- **`card_action` 的 D4 幂等 claim**：`modules/message/card_action_claims.go`。事件
+  丢失不可自愈的那一半来自这里；本任务修上游丢失，**不改幂等语义**。
+- **既有队列中的历史 member**：迁移期读路径必须同时能读旧号段和新号段的 member。
+
+## Out of scope
+
+- **#627 / PR #644·#648 的 `message_extra.version` 激活**（`tools/msgextra-version`
+  的 cutover runbook）。独立事项，与本路径无因果关系。
+- **过期事件回收**（`Mininglamp-OSS/octo-server#698`）：`robotEvent` 队列里过期
+  member 永不清理是另一个 bug，单独处置。
+- **bot 侧游标策略**。正确用法（`event_id=0` + 严格 ack，让 `ZREM` 而非游标定义进度）
+  应写进文档并通知 bot 作者，但**不在本任务改任何 bot**。
+- **重新设计 ack 协议 / 改成 stream（`XADD`）**。`XADD` 天然单调且有 consumer group，
+  是更彻底的方向，但会改 wire 契约与所有 bot，属独立提案。
+- **octo-lib `GenSeq` 本身的修复**，以及**已确认的两个同类实例**（不是"待审计"，是
+  review 中查实的）：
+  - `conversation_extra.version` — `GenSeq(common.SyncConversationExtraKey)`
+    （`api_conversation.go:195`），读回 `Where("uid=? and version>?")`
+    （`db_conversation_extra.go:29`）
+  - `reminders.version` — `GenSeq(common.RemindersKey)`（`api_reminders.go:172`），
+    读回 `reminders.version>?`（`db_reminders.go:93-102`）
+
+  两者都是「排他游标 + `GenSeq` 号源」，且用**全局单一 seq key**（不带 uid/channel
+  后缀），所以一次非单调分配由该功能的**所有用户**共担 —— 爆炸半径比 per-bot 队列更大，
+  症状是静默丢提醒 / 丢会话扩展状态。**需单独立项**，已在 #697 的 Related 段记录。
+  `pinned_message.version` 已走 `seqStore.ReserveTx`，属 #627 范围，不在此列。
+  其余 `GenSeq` 调用点（`MessageReactionSeqKey`、`ProhibitWordKey`）尚未核对读回是否
+  为排他游标。
+
+## Acceptance
+
+- **源码守卫**：新增测试断言 `robotEvent:` 的**每一个** `ZADD` 站点都经由新分配器，
+  且 `GenSeq(RobotEventSeqKey…)` 在 `modules/` 下不再有调用点（参照
+  `TestEveryBotEventQueueWriterRingsTheDoorbell` 与 `msgextraseq` 的 PR-2c 守卫形状）。
+- **并发单调性（新分配器）**：并发 goroutine × 两个独立分配器实例发 N 号，断言结果
+  **严格递增且无重复**。
+- **对照必须失败（已本地验证可行，方法见下）**：同一条无损性断言用今天的 `GenSeq` 跑
+  必须**失败**。**不能靠「实例化两个 `GenSeq`」** —— `seqMap` / `seqLock` 是 octo-lib 的
+  **包级**变量，同一进程内拿不到两份独立块状态，那样写出来的测试会假绿。
+  **可行方法（已跑通，见 `tools/genseq-repro/`）**：起两个子进程，各自冷启动真实
+  `config.Context.GenSeq`，用一个共同的 wall-clock barrier 让两边的 `min_seq` 读都发生在
+  任一写回之前 —— 这正是 N 副本滚动重启产生的条件。**不需要**手工操纵 `seq` 表。
+  实测结果：两副本发出**完全相同**的 12 个 id（重叠是全量而非部分），`min_seq`
+  5000 → 6000（两次无条件写回同值）。**碰撞是确定性的，不是要靠运气撞上的竞态。**
+- **三条丢失路径都要各有一条测试**（本地已全部复现，`tools/genseq-repro/`）：
+  - **分页边界落在共享 score 上** → 排他 `(cursor` 永久排除第二个 member。**不需要
+    时间倒挂**；`getEvents` 的 limit 是 20..100，在有 1000+ 重复 score 的队列上是常态。
+  - **低块晚到入队** → 事件出生即在游标下方，永不可投递（生产实测到的形状）。
+  - **ack 连带删除** → `ZRemRangeByScore(id,id)` 删掉所有共享该 score 的 member，
+    ack 一条已投递事件会销毁一条从未投递的事件。
+- **潜伏性也要记进测试注释**：把整个碰撞队列**一次读完**是**不丢**的。丢失需要「分页
+  边界命中」或「低块晚到」二者之一 —— 这解释了为什么症状是间歇的、同一张卡上因人而异，
+  而不是一眼可见的整体故障。删掉这条注释的人会以为一次读完的绿测就证明了无损。
+- **碰撞检测**：新增一个可只读运行于预发/生产的校验（及其测试形态等价物），断言任一
+  `robotEvent:*` 队列的 member 数 == distinct score 数。当前生产该断言在 **3 个队列上
+  失败**（见 Goal），修复后**新增**碰撞应恒为 0。
+- **排他游标无损**：并发入队 + 按「最大 event_id」推进游标消费，断言零丢失。用今天
+  的分配器跑必须复现丢失。
+- **floor 引导**：分配器首发值 > `max(该队列现存 max score, 旧 GenSeq min_seq)`；构造
+  「Redis 计数器被清空但队列仍有高 score member」的场景，断言不回退、不重号。
+- **等值不变量**：`ZAdd` 的 score 与 payload `event_id` 相等；`ackEvent` 能按
+  `event_id` 精确删到目标 member。
+- **回归**：`go test -race ./modules/bot_api ./modules/robot ./pkg/botevent ./modules/message -count=1`
+  全绿；`modules/group` 的 `notifyBotJoinedGroup` 相关测试全绿。
+- **观测**：新增「score 非单调」计数器（写入时新 score ≤ 队列当前 max 即计数），
+  低基数 label；上线后该计数应恒为 0。
+- **迁移验证步骤**（写进 PR 描述，运维可执行）：切换前记录各队列 max score 与
+  `seq` 表 `min_seq`，切换后断言新号段整体高于两者。
+
+## Decisions（已定，附依据；无需再讨论除非依据被推翻）
+
+**D1. 分配器用 Redis `INCR`，per-bot key（`botevent:seq:{robotID}`）。**
+
+原先把它列为待决，是因为「Redis 持久化丢失导致计数器回退」这个风险的强度取决于生产
+配置 —— 那是事实问题，不是偏好问题，已查清（生产 Redis，只读 `CONFIG GET` / `INFO`）：
+
+| 配置 | 值 | 对本方案的影响 |
+|---|---|---|
+| `appendonly` | `no` | 无 AOF，只有 RDB |
+| `save` | `3600 1 300 100 60 10000` | 崩溃最坏丢 60–300 秒 |
+| `maxmemory` / `maxmemory-policy` | `0` / `noeviction` | **计数器不会被 LRU 淘汰** —— 这是 `INCR` 方案最大的隐性杀手，已排除 |
+| `role` / `connected_slaves` | `master` / `0` | 单实例，无 failover 异步复制回退 |
+
+**回退是自洽的，这是选 `INCR` 的核心理由**：计数器与 `robotEvent` ZSET 在**同一个 Redis
+实例、同一个 RDB 持久化域**。设 RDB 落盘于 T0，计数器值 `C0`，队列 max score `S0 ≤ C0`；
+T0 后发号至 `C1`、入队至 `S1`。崩溃恢复到 T0 → 计数器回到 `C0`，而 T0 之后入队的 member
+**也一起没了**，队列 max 回到 `S0`。于是从 `C0+1` 继续发号，**不可能与存活 member 碰撞**。
+
+> **硬约束（必须写进代码注释）**：计数器**必须**与队列同实例、同 db、同持久化域。任何
+> 「为了性能把计数器挪到另一个 Redis / 另一个 db / 加独立 AOF」的优化都会立刻摧毁上面
+> 这个自洽性论证。未来若引入主从，论证仍成立（计数器与队列一起滞后），但**跨实例不成立**。
+
+选 per-bot 而非全局 key：单调性只需队列内成立；全局 key 的 floor 必须 ≥ **所有**队列的
+max score（否则某个高 score 队列的客户端游标会把新号段整体挡在门外），且是热点。
+
+**D2. 单阶段部署，不需要 #627 那样的 flip。** 号段单向性（新号恒高于旧号）+ D1 的同域
+自洽性使新旧副本共存是安全的。前提是 floor 引导**幂等**：任何副本任意次引导结果相同，
+不要求「引导必须在第一个新副本启动前完成」。
+
+> **更正**：本 brief 早先写「用 `SET key <floor> GT`」是错的 —— Redis 的 `SET` 没有
+> `GT` 选项（`GT`/`LT` 属于 `EXPIRE` 和 `ZADD`）。幂等取 max 必须用 Lua
+> （`GET` → 比较 → 条件 `SET`，单脚本内原子），与本仓其他 Lua 站点同模式
+> （`pkg/botevent/bell.go` 的 `EVALSHA` + `NOSCRIPT` 回退）。
+
+**D3. 现存碰撞 member 不重编号**（详见 Open questions 1 —— 这是唯一需要人类签字的一条，
+因为它是唯一涉及写生产数据的选项）。
+
+**D4. `reminders` / `conversation_extra` 已单独立项**
+（`Mininglamp-OSS/octo-server#700`，P1），不在本任务范围。
+
+**D5. `tools/genseq-repro/` 保留在 `tools/`**，与 `msgextra-version`、`card-action-dlq`
+同性质（排障/验证工具）。实现阶段把核心断言抽成 `pkg/botevent` 下的正式测试，工具保留
+供运维复核。
+
+## Open questions（需人类确认）
+
+1. **现存 3 个碰撞队列（2624 个碰撞 member）要不要一次性重编号？**
+   这是**唯一**涉及写生产数据的选项，所以只有你能签字。
+
+   **我的建议：不动，只记基线。** 理由：
+   - **无法区分哪一个未被投递** —— 游标在 bot 客户端手里，服务端没有投递记录。所以
+     重编号只能对每对里的**两个**都重发，等于给已处理过的事件制造重复投递（bot 侧按
+     `event_id` 幂等，而重编号恰恰换掉了 `event_id`，幂等失效）。
+   - **多数已无消费价值** —— 同一队列里 470/647 的 member 级 `expire` 已过期数周
+     （见 #698）。
+   - **真正的损失已经发生且不可挽回**，重编号挽回的是「可能从未投递、且仍在有效期内」
+     的一小部分，收益远低于写生产 ZSET 的风险。
+   - 修好分配器即可**止血**（新增碰撞归零），这是主要收益。
+
+   配套动作（只读，无需签字，我可以直接做）：把当前 3 个队列的碰撞计数与 score 区间记为
+   基线，上线后验证增量归零。**当前碰撞正在增长**（`botfather` 一小时内 170 → 358），
+   所以基线要在修复上线前后各取一次。
+
+   如果你倾向重编号，我需要额外的授权范围（写哪个队列、是否停写窗口）和一个回滚快照方案。

--- a/.octospec/tasks/bot-event-score-monotonic/brief.md
+++ b/.octospec/tasks/bot-event-score-monotonic/brief.md
@@ -193,8 +193,10 @@ PR #644·#648 把 `message_extra.version` 换成了事务性 per-channel 序列
   `event_id` 精确删到目标 member。
 - **回归**：`go test -race ./modules/bot_api ./modules/robot ./pkg/botevent ./modules/message -count=1`
   全绿；`modules/group` 的 `notifyBotJoinedGroup` 相关测试全绿。
-- **观测**：新增「score 非单调」计数器（写入时新 score ≤ 队列当前 max 即计数），
-  低基数 label；上线后该计数应恒为 0。
+- **观测**：见下方第三轮记录第 6 条 —— 原文要求的「写入时新 score ≤ 队列当前 max 即计数」
+  **已修订**：那个比较做对了就等于原子 allocate-and-publish（属 Out of scope 的独立
+  follow-up），这里改为交付 6 个自愈计数器 + `AuthorityReads()`，并把跨副本回退检测
+  单独立项（P1-5/P1-6）。低基数、无 label 的要求保留。
 - **迁移验证步骤**（写进 PR 描述，运维可执行）：切换前记录各队列 max score 与
   `seq` 表 `min_seq`，切换后断言新号段整体高于两者。
 
@@ -303,6 +305,13 @@ seed 必须读 producer 写的同一个 key，硬编码分散是真实风险。�
 `TestEveryBotEventQueueWriterRingsTheDoorbell` 的 `queueKey` regex —— 否则它 `matched=4 < 5`
 直接 fatal（那个守卫的防盲下限按设计生效了，值得记一笔）。
 
+> **更正（第三轮）**：这条当时写成已完成，实际只做了 4/5 —— `modules/robot/event.go:367`
+> 仍从 `rb.robotEventPrefix` 拼 key，`api.go` 的读/删两处同样，消费侧
+> `modules/bot_api/bot_api.go:32` 另有一份字面量。PR 描述当时是诚实的（"four of the five
+> writers"），**brief 不是，而 brief 才是下一个人当记录看的东西**（review 抓到）。第三轮
+> 已真正做完：`robotEventPrefix` 字段和 `bot_api` 的常量都删除，六个生产点与消费侧全部
+> 走 `botevent.QueueKey`。
+
 **③ 测试用独立库 `botevent_test`，不用共享 `test` 库。** `seq` 表由
 `modules/common/sql/20211108000001_common_legacy01.sql` 管理；在 `test` 库裸建它会留下
 `gorp_migrations` 无记录的表，下个包的 `NewTestServer` 就 `Table 'seq' already exists` ——
@@ -371,3 +380,68 @@ seed 必须读 producer 写的同一个 key，硬编码分散是真实风险。�
 `pkg/botevent`（28 测试）、`pkg/redis`、`modules/robot`、`modules/group`、`modules/bot_api`、
 **`modules/message`**（brief 点名、上一轮漏跑，review 抓到）全绿；migration 经真实
 sql-migrate 应用（`gorp_migrations` 有记录、状态表已建）。
+
+## 第三轮实现记录（第四轮 review 之后，2026-08-06）
+
+两位 reviewer 独立抓到同一条：**热路径信任正向 mirror，从不校验 MySQL 权威**。另一位还抓到
+上一轮我自己引入的回归。八条 P1 里六条在本轮修，两条（回退检测的设计问题）单独立项 ——
+理由见下第 7 条。
+
+1. **mode 解析没有统一入口，于是三处给出三个不同答案**（P1-1/P1-2/P1-4 是同一个缺失）。
+   新增 `pkg/botevent/mode.go`，不变量收敛成一句：**权威决定，mirror 只能加速、不能翻案**。
+   - 正向信念（activated）对 legacy **终态**：本进程一旦解析出 incr，可以向上刷新 epoch，
+     但永不再回 legacy —— 不因 DB 报错、不因行被回滚、不因表被 drop。这让 P1-4 从「不太可能」
+     变成**结构上不可达**。
+   - 负向信念只在 **mirror 也不声称 incr** 时可信。`mirror=incr` + 缓存 legacy 是**冲突**，
+     强制现场重读。这一条是保住 D2 的关键：flip 的传播**不等 TTL**，因为第一次看到新 mirror
+     的分配就会重读权威。TTL 只兜「operator 的 mirror 写失败」这一种情况。
+   - 确认过的冲突（mirror 说 incr、权威说 legacy）= mirror 被伪造 → 走 legacy + 响亮计数。
+     **这不会撕裂集群**：所有副本读同一行、得同一结论，一致性来自权威而非 mirror。这句话
+     正是上一轮缺的那句。
+2. **D2 需要修订而不是推翻**。D2 禁的是「用缓存判决 gate」，gate 仍每次在 Lua 里读未缓存的
+   mirror；这里缓存的是「mirror 背后的权威」。分歧只可能来自两个副本对同一时刻的权威给出
+   不同答案，而冲突强制重读移除了这种可能。
+3. **mirror 值带 epoch（`incr:{epoch}`）**。gate 比对的是本进程向权威确认过的那个确切字符串，
+   于是手写 `SET botEventSeq:mode incr` 连一次分配都开不了门 —— 它没有代次，只能触发一次
+   权威读。这正是 migration 里 `epoch` 列注释**声称已有而实际没有**的机制（review 记为
+   spec 偏离），现在注释成真。
+4. **顺序倒了：先开全局门，再做 per-bot seed**（P1-3）。改成先 seed 后发布 mirror。并且
+   **mirror 丢失会失效所有 bot 的 seeded 标记**，不只是当前这个 —— mode 键丢失就是 Redis
+   丢数据的证据，本进程认为已 seed 过的每个 counter 都可疑。docstring 写明「mirror 是全局的、
+   seed 是 per-bot」。
+5. **`gateClosed` 与快路径互相打转，是测试抓出来的**：强制重读权威后 `seeded` 仍在，
+   `allocate` 的快路径又撞同一个关闭的门，一直转到 `maxAllocAttempts` 才报错 —— 表现为
+   「mirror 被反复丢失」，而实际上只丢了一次。修法是重读后丢掉该 bot 的 `seeded` 让重试走
+   慢路径。`refreshAuthority` 因此需要一个 `force` 参数：正向信念的短路正是这条路径要绕开的。
+6. **写侧「新 score ≤ 队列 max」检测器：修订 acceptance，不硬加**（原 Acceptance 观测项）。
+   理由不是推脱：那个比较做**对**了就会收敛到我已经原型过又回滚的原子 allocate-and-publish。
+   并发下 A 分配 100、B 分配 101 且先 ZADD，A 再比「100 ≤ 队列 max 101」就是假阳性，除非
+   比较发生在 ZADD 那一刻的同一个 Lua 里 —— 而那与 `modules/bot_mention` 的原子性边界冲突，
+   已在 Out of scope 立项。两位 reviewer 在这条上判断相反（一位判「实质满足」、一位判
+   「未实现」），这个论证解释了两边各对一半：现有计数器覆盖了写侧非单调的**一个**来源，
+   而规格要的那个比较**在当前架构里做不成无假阳性的**。
+7. **P1-5/P1-6 单独立项，门禁定在「激活前」而不是「合并前」。**
+   - P1-5：`rollbackTolerance = 1000` 以下的回退检测不到，而上一轮我写的「靠下次 seed 修」
+     被代码否证 —— `seeded.Delete` 只有三处且**全在已检测分支**，未检测与自愈按构造互斥。
+     那句错的理由同时写在 `seq.go` 和本 brief 第二轮记录第 1 条里，是**重申**而不是承认的
+     取舍。而且生产 `save … 60 10000`，任何每分钟少于 ~1000 事件的 bot（1948 个队列里几乎
+     全部）回退幅度**永远**在容差内 —— 这个机制在常见情形下从不触发。
+   - P1-6：回退检测只比本进程 `lastIssued`，长寿进程冷 per-bot 状态会把跨副本回退当前进。
+   - 两条是同一个设计问题（什么状态会回退 / 谁检测 / 什么重建 floor），需要一张表；而它们
+     **只在 `mode=incr` 之后可达**，本轮把 merge 修成真正惰性（P1-1 去掉每次分配的 DB 往返，
+     P1-2 让野键无法激活）之后，延后才站得住。已立项
+     `Mininglamp-OSS/octo-server#704`，**门禁是「激活前」而不是「合并前」** ——
+     `tools/botevent-seq` 的 `-yes` 拒绝文案也引用了它。
+8. **激活证据结构性漏掉它要保护的 bot**（P1-8）。工具只从 `SCAN robotEvent:*` 发现 bot，
+   队列已 drain 的 bot 一行 `seq` 都不读；`scalarSeq` 还把任何 DB error 变成 0。改为按前缀
+   `SELECT MAX(min_seq)` 全表扫两个命名空间，并像拒绝 sampled 证据一样**拒绝部分失败的证据**。
+9. **`payload.robot_id` 分支从来没做存在性校验**（review 要求人工确认 robotID 来源，查得出来
+   就不该挂在那里）。另外三个分支（mention.uids / @username / ais）都查了 `existRobot`，只有
+   这个把客户端 payload 里的值原样当 bot id。以前的代价只是一个带 TTL 的队列键加一行 `seq`；
+   新分配器会为它建一个**无 TTL** 的 counter 键（Redis `noeviction`）加一行永不回收的
+   `seq`。补上校验。
+10. **测试能静默退化成只跑守卫**（P2-11，与上一轮 `botevent_test` 库同一个失效模式，我在这上面
+    已经栽过一次）。加 `TestMain`：`CI=true` 下依赖缺失直接失败并说明缺什么，本地仍 skip。
+    测试建表也补齐 migration 的 `CHECK` 与 `ON UPDATE`。
+
+**验证**：`pkg/botevent` 42 测试全绿（`-race -shuffle=on`，`CI=true`，**零 skip**）。

--- a/modules/bot_api/bot_api.go
+++ b/modules/bot_api/bot_api.go
@@ -29,9 +29,6 @@ const (
 	// heartbeat Redis key prefix and TTL
 	heartbeatKeyPrefix = "bot:heartbeat:"
 	heartbeatTTL       = 60
-
-	// robotEventPrefix for events queue
-	robotEventPrefix = "robotEvent:"
 )
 
 // BotAPI is the public Bot API gateway module.

--- a/modules/bot_api/events.go
+++ b/modules/bot_api/events.go
@@ -8,6 +8,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/pkg/botevent"
 	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
 	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
 	"github.com/gin-gonic/gin"
@@ -128,7 +129,7 @@ func (ba *BotAPI) filterAppBotEvents(botKind string, robotID string, results []*
 		filtered = append(filtered, r)
 	}
 	if len(filteredIDs) > 0 {
-		key := fmt.Sprintf("%s%s", robotEventPrefix, robotID)
+		key := botevent.QueueKey(robotID)
 		for _, id := range filteredIDs {
 			if err := ba.ackEvent(key, id); err != nil {
 				ba.Warn("auto-ACK filtered event failed", zap.String("eventID", id), zap.Error(err))
@@ -181,23 +182,38 @@ func (ba *BotAPI) ackEvent(key string, eventID string) error {
 // received. The same equality is what makes the auto-ACK's
 // `ZRemRangeByScore(key, id, id)` address the member it means to.
 //
-// **Uniqueness, which is the stronger one and is NOT currently guaranteed.**
-// Exclusive `Min: "(cursor"` pagination is lossless only if scores are strictly
-// unique. `GenSeq` (octo-lib `config/seq.go`) is a DB-backed *block* allocator:
-// it reads `min_seq` and writes back an absolute value computed from
+// **Uniqueness, which is the stronger one.** Exclusive `Min: "(cursor"`
+// pagination is lossless only if scores are strictly unique, and until #697 they
+// were not. Ids came from `GenSeq` (octo-lib `config/seq.go`), a DB-backed *block*
+// allocator: it reads `min_seq` and writes back an absolute value computed from
 // process-local state, guarded only by a process-local mutex. Two replicas whose
-// blocks race — a concurrent cold start, or a concurrent extend — can hand out
-// the same id. Two members sharing score 42 means a page ending on the first
-// advances the cursor to 42 and the second is **never delivered**; the auto-ACK
-// and `eventAck` likewise remove both.
+// blocks race — a concurrent cold start, or a concurrent extend — hand out the same
+// id. Two members sharing score 42 means a page ending on the first advances the
+// cursor to 42 and the second is **never delivered**; the auto-ACK and `eventAck`
+// likewise remove both. Measured in production: 2624 colliding scores across three
+// queues, still accumulating, plus 19 time-inverted ids on block boundaries.
 //
-// That risk is pre-existing and unchanged here — the exclusive cursor, the
-// auto-ACK and `eventAck` all predate the long poll — but this is the code that
-// promotes the cursor to a stated safety property, so the property is stated
-// honestly: **uniqueness is assumed and unverified**. Reading with
-// `ZRangeByScoreWithScores` would remove the equality assumption but not this
-// one; closing it needs a Redis-side allocator or a re-delivery window below the
-// cursor, which is its own change (PR#685 review, yujiawei P2-3).
+// `pkg/botevent`'s allocator replaces that source with a per-bot monotonic counter,
+// so **once activated** the uniqueness this cursor depends on holds by construction
+// rather than by assumption. Two things about that are worth knowing here:
+//
+//   - Before activation the allocator delegates to GenSeq, so on a merged-but-not-
+//     activated deployment everything in the paragraph above is still live.
+//   - Activation does not make the exclusive cursor lossless, and the sentence this
+//     paragraph replaced named the reason: closing it needs "a Redis-side allocator
+//     **or** a re-delivery window below the cursor". #697 delivered the allocator,
+//     which removes the collision and cross-restart-inversion classes. It does not
+//     remove the reordering window — allocation and publication are two operations,
+//     so a producer that allocates `N` and stalls while another publishes `N+1`
+//     still loses `N` once this cursor passes it, and the doorbell makes that *more*
+//     likely because the wake is triggered by the very ZADD that creates the
+//     inversion. That residual is pinned by
+//     `TestKnownResidualZaddReorderingCanStillSkip` in `pkg/botevent` and needs the
+//     re-delivery window, i.e. a change to this file, not that one.
+//
+// Existing duplicate members are also deliberately left in place: an ack deletes
+// every member sharing a score, and there is no record of which of a pair was ever
+// delivered, so re-scoring them would mean re-delivering both.
 type eventPage struct {
 	// visible is what may be returned to the caller.
 	visible []*eventResp
@@ -247,7 +263,7 @@ func (ba *BotAPI) readEventPage(robotID string, botKind string, cursor int64, li
 // member fails to decode, and callers need the raw count to tell a full page
 // from a short one.
 func (ba *BotAPI) getEventsResult(robotID string, eventID int64, limit int64) ([]*eventResp, int, error) {
-	key := fmt.Sprintf("%s%s", robotEventPrefix, robotID)
+	key := botevent.QueueKey(robotID)
 	robotEventJsons, err := ba.ctx.GetRedisConn().ZRangeByScore(key, redis.ZRangeBy{
 		Max:   "+inf",
 		Min:   fmt.Sprintf("(%d", eventID),
@@ -320,7 +336,7 @@ func (ba *BotAPI) eventAck(c *wkhttp.Context) {
 		return
 	}
 
-	key := fmt.Sprintf("%s%s", robotEventPrefix, robotID)
+	key := botevent.QueueKey(robotID)
 	err = ba.ctx.GetRedisConn().ZRemRangeByScore(key, fmt.Sprintf("%d", eventID), fmt.Sprintf("%d", eventID))
 	if err != nil {
 		ba.Error("ack event failed", zap.Error(err), zap.String("robotID", robotID), zap.Int64("eventID", eventID))

--- a/modules/bot_api/events.go
+++ b/modules/bot_api/events.go
@@ -174,9 +174,12 @@ func (ba *BotAPI) ackEvent(key string, eventID string) error {
 //
 // **Equality.** The cursor is a payload `event_id` (`getEventsResult` decodes
 // it), while the read that consumes it is bounded by the sorted-set **score**
-// (`Min: "(cursor"`). The two are the same number by construction at all five
-// producers — each does `ZAdd(key, float64(seq), payload{EventID: seq})` — and
-// `GenSeq` returns small integers well inside float64's exact range. A future
+// (`Min: "(cursor"`). The two are the same number by construction at every
+// producer — each does `ZAdd(key, float64(seq), payload{EventID: seq})` — and
+// both id sources return integers well inside float64's exact range, which
+// `tools/botevent-seq` keeps true by refusing a cutover floor near 2^53. (The
+// count was "five" until `addInlineQuery` was found to be a sixth; naming a
+// number here just invites the next one to be missed.) A future
 // writer that scored by, say, timestamp while keeping a separate `event_id`
 // would break this silently: the cursor would jump past members the caller never
 // received. The same equality is what makes the auto-ACK's

--- a/modules/bot_api/events_longpoll_integration_test.go
+++ b/modules/bot_api/events_longpoll_integration_test.go
@@ -48,7 +48,7 @@ func seedLongPollBot(t *testing.T, ctx *config.Context) {
 // touches MySQL, so Redis state leaks between tests unless cleared explicitly.
 func clearLongPollKeys(t *testing.T, ctx *config.Context) {
 	t.Helper()
-	_ = ctx.GetRedisConn().Del(robotEventPrefix + lpBotID)
+	_ = ctx.GetRedisConn().Del(botevent.QueueKey(lpBotID))
 	_ = ctx.GetRedisConn().Del(botevent.BellKey(lpBotID))
 }
 
@@ -58,7 +58,7 @@ func clearLongPollKeys(t *testing.T, ctx *config.Context) {
 func enqueueRaw(t *testing.T, ctx *config.Context, eventID int64) {
 	t.Helper()
 	payload := fmt.Sprintf(`{"event_id":%d,"event_type":"card_action","event_data":{"action_id":"approve"}}`, eventID)
-	assert.NoError(t, ctx.GetRedisConn().ZAdd(robotEventPrefix+lpBotID, float64(eventID), payload))
+	assert.NoError(t, ctx.GetRedisConn().ZAdd(botevent.QueueKey(lpBotID), float64(eventID), payload))
 }
 
 type lpResponse struct {
@@ -352,7 +352,7 @@ func enqueueMessageEvent(t *testing.T, ctx *config.Context, eventID int64, chann
 	payload := fmt.Sprintf(
 		`{"event_id":%d,"message":{"message_id":%d,"message_seq":%d,"from_uid":"u1","channel_id":"c1","channel_type":%d,"timestamp":1}}`,
 		eventID, eventID, eventID, channelType)
-	assert.NoError(t, ctx.GetRedisConn().ZAdd(robotEventPrefix+lpBotID, float64(eventID), payload))
+	assert.NoError(t, ctx.GetRedisConn().ZAdd(botevent.QueueKey(lpBotID), float64(eventID), payload))
 }
 
 // enqueueUndecodable writes a member that survives in the sorted set but cannot
@@ -363,7 +363,7 @@ func enqueueMessageEvent(t *testing.T, ctx *config.Context, eventID int64, chann
 func enqueueUndecodable(t *testing.T, ctx *config.Context, eventID int64) {
 	t.Helper()
 	assert.NoError(t, ctx.GetRedisConn().ZAdd(
-		robotEventPrefix+lpBotID, float64(eventID), fmt.Sprintf("not json at all #%d", eventID)))
+		botevent.QueueKey(lpBotID), float64(eventID), fmt.Sprintf("not json at all #%d", eventID)))
 }
 
 // TestReadEventPageCursorIsAPureFunctionOfTheRead asserts what it says and no
@@ -575,7 +575,7 @@ func TestWaitForEventsMakesProgressWhenTheAutoACKFails(t *testing.T) {
 
 	// The injected failure must have been real: the filtered events are still in
 	// the queue. Without this the test could pass against a working ZREM.
-	remaining, err := ctx.GetRedisConn().ZRangeByScore(robotEventPrefix+lpBotID, rd.ZRangeBy{
+	remaining, err := ctx.GetRedisConn().ZRangeByScore(botevent.QueueKey(lpBotID), rd.ZRangeBy{
 		Min: "-inf", Max: "+inf",
 	})
 	assert.NoError(t, err)

--- a/modules/botfather/api.go
+++ b/modules/botfather/api.go
@@ -27,19 +27,18 @@ import (
 
 // BotFather BotFather模块
 type BotFather struct {
-	ctx              *config.Context
-	db               *botfatherDB
-	cmdHandler       *commandHandler
-	userService      user.IService
-	appService       app.IService
-	fileService      file.IService
-	groupService     group.IService
-	apiKeyService    UserAPIKeyService
-	userDB           *user.DB
-	threadService    thread.IService
-	robotEventPrefix string
-	initOnce         sync.Once
-	msgSem           chan struct{} // 限制并发消息处理的信号量
+	ctx           *config.Context
+	db            *botfatherDB
+	cmdHandler    *commandHandler
+	userService   user.IService
+	appService    app.IService
+	fileService   file.IService
+	groupService  group.IService
+	apiKeyService UserAPIKeyService
+	userDB        *user.DB
+	threadService thread.IService
+	initOnce      sync.Once
+	msgSem        chan struct{} // 限制并发消息处理的信号量
 	// searchHandler 是共享的消息搜索 Handler（messages_search.Shared）。uk 搜索路由
 	// /v1/user/messages/_search* 复用它（YUJ-49 / #B，决策十正式接线）：authUserAPIKey
 	// 鉴权、principal=uk（subjectUID=keyModel.UID，spaceID=api_key_space_id）。与 web、
@@ -51,20 +50,19 @@ type BotFather struct {
 // New 创建BotFather实例
 func New(ctx *config.Context) *BotFather {
 	bf := &BotFather{
-		ctx:              ctx,
-		db:               newBotfatherDB(ctx),
-		cmdHandler:       newCommandHandler(ctx),
-		userService:      user.NewService(ctx),
-		appService:       app.NewService(ctx),
-		fileService:      file.NewService(ctx),
-		groupService:     group.NewService(ctx),
-		apiKeyService:    NewUserAPIKeyService(ctx),
-		userDB:           user.NewDB(ctx),
-		threadService:    thread.NewService(ctx),
-		robotEventPrefix: "robotEvent:",
-		msgSem:           make(chan struct{}, 100),
-		searchHandler:    messages_search.Shared(ctx),
-		Log:              log.NewTLog("BotFather"),
+		ctx:           ctx,
+		db:            newBotfatherDB(ctx),
+		cmdHandler:    newCommandHandler(ctx),
+		userService:   user.NewService(ctx),
+		appService:    app.NewService(ctx),
+		fileService:   file.NewService(ctx),
+		groupService:  group.NewService(ctx),
+		apiKeyService: NewUserAPIKeyService(ctx),
+		userDB:        user.NewDB(ctx),
+		threadService: thread.NewService(ctx),
+		msgSem:        make(chan struct{}, 100),
+		searchHandler: messages_search.Shared(ctx),
+		Log:           log.NewTLog("BotFather"),
 	}
 
 	// 注册消息监听器

--- a/modules/botfather/api_user.go
+++ b/modules/botfather/api_user.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-server/modules/space"
 	"github.com/Mininglamp-OSS/octo-server/modules/user"
 	"github.com/Mininglamp-OSS/octo-server/pkg/authtree"
+	"github.com/Mininglamp-OSS/octo-server/pkg/botevent"
 	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
 	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
 	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
@@ -469,7 +470,17 @@ func (bf *BotFather) deleteUserBot(c *wkhttp.Context) {
 
 	// Clear heartbeat and event queue
 	bf.ctx.GetRedisConn().Del(fmt.Sprintf("%s%s", heartbeatKeyPrefix, botID))
-	bf.ctx.GetRedisConn().Del(fmt.Sprintf("robotEvent:%s", botID))
+	bf.ctx.GetRedisConn().Del(botevent.QueueKey(botID))
+	// #697 (review P2-4): the per-bot event id counter (botEventSeq:counter:{botID})
+	// and its durable high-water row (seq:botEventHigh:{botID}) are deliberately NOT
+	// deleted here. A bot id is a UUID and is never reissued, but "never" is a claim
+	// about a different module — and if one ever were reissued, a counter restarting
+	// from 1 would renumber the new bot's events underneath any cursor a client had
+	// kept from the old one, which is #697 exactly. Keeping them costs one small Redis
+	// key plus one `seq` row per bot ever deleted, in a Redis running `noeviction`.
+	// That is a leak, and it is the cheaper side of the trade; if it ever needs
+	// reclaiming, do it as a dated sweep that also proves the id is not in use, not as
+	// a delete alongside the queue.
 
 	// Remove friend records (both directions) with version for client sync
 	friendVersion, verErr := bf.ctx.GenSeq(common.FriendSeqKey)

--- a/modules/botfather/api_user.go
+++ b/modules/botfather/api_user.go
@@ -480,7 +480,18 @@ func (bf *BotFather) deleteUserBot(c *wkhttp.Context) {
 	// key plus one `seq` row per bot ever deleted, in a Redis running `noeviction`.
 	// That is a leak, and it is the cheaper side of the trade; if it ever needs
 	// reclaiming, do it as a dated sweep that also proves the id is not in use, not as
-	// a delete alongside the queue.
+	// a delete alongside the queue. Tracked on Mininglamp-OSS/octo-server#704.
+	//
+	// Worth being explicit about the scale, because two files away #697 rejects an
+	// arbitrary `payload.robot_id` on very similar reasoning (modules/robot/event.go):
+	// `create bot → have it receive one message → delete bot` is available to any
+	// authenticated user, so this leak grows with the **bot-creation rate**, not with the
+	// live bot count. The difference that makes it acceptable here and not there is the
+	// unit of abuse: a payload field is free and unbounded per message, while a bot is a
+	// rate-limited, audited, per-user-quota object — and the legacy seq:robotEventSeq:
+	// row already leaked identically before #697, so only the small Redis key is new. A
+	// bot that never receives an event leaves nothing behind at all, since both artifacts
+	// are created on first allocation.
 
 	// Remove friend records (both directions) with version for client sync
 	friendVersion, verErr := bf.ctx.GenSeq(common.FriendSeqKey)

--- a/modules/botfather/command.go
+++ b/modules/botfather/command.go
@@ -15,6 +15,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-server/modules/base/app"
 	"github.com/Mininglamp-OSS/octo-server/modules/group"
 	"github.com/Mininglamp-OSS/octo-server/modules/user"
+	"github.com/Mininglamp-OSS/octo-server/pkg/botevent"
 	"github.com/Mininglamp-OSS/octo-server/pkg/botutil"
 	"go.uber.org/zap"
 )
@@ -621,7 +622,7 @@ func (h *commandHandler) onDeleteConfirm(fromUID string, input string) {
 	h.ctx.GetRedisConn().Del(heartbeatKey)
 
 	// 清除事件队列
-	eventKey := fmt.Sprintf("robotEvent:%s", botID)
+	eventKey := botevent.QueueKey(botID)
 	h.ctx.GetRedisConn().Del(eventKey)
 
 	// Remove bot from all groups
@@ -758,7 +759,7 @@ func (h *commandHandler) onRevokeConfirm(fromUID string, input string) {
 	h.ctx.GetRedisConn().Del(heartbeatKey)
 
 	// 清除事件队列
-	eventKey := fmt.Sprintf("robotEvent:%s", botID)
+	eventKey := botevent.QueueKey(botID)
 	h.ctx.GetRedisConn().Del(eventKey)
 
 	h.sm.Clear(fromUID, h.spaceID(fromUID))
@@ -789,7 +790,7 @@ func (h *commandHandler) disconnectBot(fromUID string, bot *robotModel) {
 	h.ctx.GetRedisConn().Del(heartbeatKey)
 
 	// 4. 清除待处理事件队列
-	eventKey := fmt.Sprintf("robotEvent:%s", bot.RobotID)
+	eventKey := botevent.QueueKey(bot.RobotID)
 	h.ctx.GetRedisConn().Del(eventKey)
 
 	h.replyL(fromUID, MsgBotDisconnected, map[string]any{"BotDisplay": h.formatBotDisplay(bot.RobotID)})

--- a/modules/group/api.go
+++ b/modules/group/api.go
@@ -1968,9 +1968,10 @@ func (g *Group) addMembers(members []string, groupNo string, operator, operatorN
 func (g *Group) notifyBotJoinedGroup(botMembers []*user.Model, groupNo, operator, operatorName string) {
 	for _, botMember := range botMembers {
 		robotID := botMember.UID
-		seq, err := g.ctx.GenSeq(fmt.Sprintf("%s%s", common.RobotEventSeqKey, robotID))
+		// #697: monotonic per-bot allocator instead of GenSeq.
+		seq, err := botevent.NextEventID(g.ctx, robotID)
 		if err != nil {
-			g.Warn("GenSeq failed for bot", zap.String("robotID", robotID), zap.Error(err))
+			g.Warn("allocate bot event id failed", zap.String("robotID", robotID), zap.Error(err))
 			continue
 		}
 		eventData := map[string]interface{}{
@@ -1983,7 +1984,7 @@ func (g *Group) notifyBotJoinedGroup(botMembers []*user.Model, groupNo, operator
 			},
 			"expire": time.Now().Add(time.Hour * 24).Unix(),
 		}
-		key := fmt.Sprintf("robotEvent:%s", robotID)
+		key := botevent.QueueKey(robotID)
 		err = g.ctx.GetRedisConn().ZAdd(key, float64(seq), util.ToJson(eventData))
 		if err != nil {
 			g.Error("推送bot_joined_group事件失败！", zap.Error(err), zap.String("robotID", robotID), zap.String("groupNo", groupNo))

--- a/modules/group/service.go
+++ b/modules/group/service.go
@@ -2076,9 +2076,10 @@ func (s *Service) notifyBotJoinedGroup(memberUsers []*user.Model, addedUIDSet ma
 			continue
 		}
 		robotID := memberUser.UID
-		seq, err := s.ctx.GenSeq(fmt.Sprintf("%s%s", common.RobotEventSeqKey, robotID))
+		// #697: monotonic per-bot allocator instead of GenSeq.
+		seq, err := botevent.NextEventID(s.ctx, robotID)
 		if err != nil {
-			s.Error("generate bot event seq failed", zap.Error(err), zap.String("robotID", robotID))
+			s.Error("allocate bot event id failed", zap.Error(err), zap.String("robotID", robotID))
 			continue
 		}
 		eventData := map[string]interface{}{
@@ -2090,7 +2091,7 @@ func (s *Service) notifyBotJoinedGroup(memberUsers []*user.Model, addedUIDSet ma
 				"operator_name": operatorName,
 			},
 		}
-		key := fmt.Sprintf("robotEvent:%s", robotID)
+		key := botevent.QueueKey(robotID)
 		err = s.ctx.GetRedisConn().ZAdd(key, float64(seq), util.ToJson(eventData))
 		if err != nil {
 			s.Error("push bot_joined_group event failed", zap.Error(err), zap.String("robotID", robotID))

--- a/modules/robot/api.go
+++ b/modules/robot/api.go
@@ -1181,22 +1181,25 @@ func (rb *Robot) inlineQuery(c *wkhttp.Context) {
 
 }
 
-// inlineQuerySeqKeyPrefix is the sequence for inline-query event ids.
+// #697 (reviewer P1): inline-query event ids MUST come from the same monotonic
+// source as the queue's, because both streams are merged into one response.
 //
-// #697: these used to be allocated from `RobotEventSeqKey+robotID` — the *same*
-// sequence robotEvent:{robotID} scores came from. Inline-query events are only
-// ever appended to this process's inlineQueryEventsMap and nothing reads that map,
-// so those allocations produced no deliverable event while still consuming ids
-// from, and advancing min_seq of, the sequence the bot event queue depended on:
-// a third party to the block churn behind #697, for nothing. They get their own
-// key. Still GenSeq, deliberately — an id nobody consumes has no monotonicity
-// requirement and does not justify a Redis dependency.
-const inlineQuerySeqKeyPrefix = "inlineQuerySeq:"
-
+// getEventsResult below reads inlineQueryEventsMap, appends it to the events read
+// from robotEvent:{robotID}, sorts the union by EventID, and filters it by the
+// caller's cursor. So the two id spaces are not independent — they share a cursor.
+//
+// An earlier revision of this change gave inline queries their own GenSeq key on
+// the belief that nothing consumed them. That was wrong, and the consequence was
+// worse than the bug being fixed: a fresh GenSeq key starts near 1000001 while the
+// new counter starts low, so one inline event would push the client's cursor into
+// the millions and permanently filter out every ordinary event behind it.
+//
+// Sharing NextEventID keeps them on one source in both modes — one GenSeq
+// sequence before activation, one counter after.
 func (rb *Robot) addInlineQuery(robotID string, inlineQuery *InlineQuery) {
-	seq, err := rb.ctx.GenSeq(inlineQuerySeqKeyPrefix + robotID)
+	seq, err := botevent.NextEventID(rb.ctx, robotID)
 	if err != nil {
-		rb.Error("GenSeq failed", zap.Error(err))
+		rb.Error("allocate inline query event id failed", zap.Error(err), zap.String("robotID", robotID))
 		return
 	}
 	rb.inlineQueryEventsMapLock.Lock()

--- a/modules/robot/api.go
+++ b/modules/robot/api.go
@@ -360,7 +360,6 @@ type Robot struct {
 	ctx *config.Context
 	log.Log
 	db                                robotDB
-	robotEventPrefix                  string
 	userService                       user.IService
 	appService                        app.IService
 	groupService                      group.IService
@@ -393,7 +392,6 @@ func New(ctx *config.Context) *Robot {
 		ctx:                           ctx,
 		Log:                           log.NewTLog("Robot"),
 		db:                            *newBotDB(ctx),
-		robotEventPrefix:              "robotEvent:",
 		userService:                   user.NewService(ctx),
 		appService:                    app.NewService(ctx),
 		groupService:                  group.NewService(ctx),
@@ -1261,7 +1259,7 @@ func (rb *Robot) getEventsResult(robotID string, eventID int64, limit int64) ([]
 		limit = 100
 	}
 
-	robotEventJsons, err := rb.ctx.GetRedisConn().ZRangeByScore(fmt.Sprintf("%s%s", rb.robotEventPrefix, robotID), redis.ZRangeBy{
+	robotEventJsons, err := rb.ctx.GetRedisConn().ZRangeByScore(botevent.QueueKey(robotID), redis.ZRangeBy{
 		Max:   "+inf",
 		Min:   fmt.Sprintf("%d", eventID),
 		Count: limit,
@@ -1312,7 +1310,7 @@ func (rb *Robot) getEventsResult(robotID string, eventID int64, limit int64) ([]
 
 // 移除指定事件
 func (rb *Robot) removeEvent(robotID string, eventID int64) error {
-	err := rb.ctx.GetRedisConn().ZRemRangeByScore(fmt.Sprintf("%s%s", rb.robotEventPrefix, robotID), fmt.Sprintf("%d", eventID), fmt.Sprintf("%d", eventID))
+	err := rb.ctx.GetRedisConn().ZRemRangeByScore(botevent.QueueKey(robotID), fmt.Sprintf("%d", eventID), fmt.Sprintf("%d", eventID))
 	return err
 }
 

--- a/modules/robot/api.go
+++ b/modules/robot/api.go
@@ -274,7 +274,11 @@ func enqueueBotEventGeneric(ctx *config.Context, robotID string, message *config
 		cp.Payload = normalized
 		message = &cp
 	}
-	seq, err := ctx.GenSeq(fmt.Sprintf("%s%s", common.RobotEventSeqKey, robotID))
+	// #697: event ids come from the monotonic per-bot allocator, not GenSeq. A
+	// failure here fails the enqueue exactly as a GenSeq error did — there is
+	// deliberately no fallback, because two live id sources on one queue is the
+	// defect being removed. See pkg/botevent/seq.go.
+	seq, err := botevent.NextEventID(ctx, robotID)
 	if err != nil {
 		return err
 	}
@@ -283,7 +287,7 @@ func enqueueBotEventGeneric(ctx *config.Context, robotID string, message *config
 		Message: message,
 		Expire:  time.Now().Add(ctx.GetConfig().Robot.MessageExpire).Unix(),
 	})
-	key := fmt.Sprintf("robotEvent:%s", robotID)
+	key := botevent.QueueKey(robotID)
 	if err := ctx.GetRedisConn().ZAdd(key, float64(seq), messageUpdateJson); err != nil {
 		return err
 	}
@@ -334,7 +338,8 @@ func prepareBotTypedEvent(ctx *config.Context, robotID, eventType string, eventD
 	if strings.TrimSpace(eventType) == "" {
 		return PreparedBotTypedEvent{}, errors.New("robot: empty eventType, cannot prepare typed bot event")
 	}
-	seq, err := ctx.GenSeq(fmt.Sprintf("%s%s", common.RobotEventSeqKey, robotID))
+	// #697: see enqueueBotEventGeneric — monotonic allocator, no GenSeq fallback.
+	seq, err := botevent.NextEventID(ctx, robotID)
 	if err != nil {
 		return PreparedBotTypedEvent{}, err
 	}
@@ -346,7 +351,7 @@ func prepareBotTypedEvent(ctx *config.Context, robotID, eventType string, eventD
 	})
 	return PreparedBotTypedEvent{
 		EventID:  seq,
-		QueueKey: fmt.Sprintf("robotEvent:%s", robotID),
+		QueueKey: botevent.QueueKey(robotID),
 		Member:   messageUpdateJson,
 	}, nil
 }
@@ -1176,8 +1181,20 @@ func (rb *Robot) inlineQuery(c *wkhttp.Context) {
 
 }
 
+// inlineQuerySeqKeyPrefix is the sequence for inline-query event ids.
+//
+// #697: these used to be allocated from `RobotEventSeqKey+robotID` — the *same*
+// sequence robotEvent:{robotID} scores came from. Inline-query events are only
+// ever appended to this process's inlineQueryEventsMap and nothing reads that map,
+// so those allocations produced no deliverable event while still consuming ids
+// from, and advancing min_seq of, the sequence the bot event queue depended on:
+// a third party to the block churn behind #697, for nothing. They get their own
+// key. Still GenSeq, deliberately — an id nobody consumes has no monotonicity
+// requirement and does not justify a Redis dependency.
+const inlineQuerySeqKeyPrefix = "inlineQuerySeq:"
+
 func (rb *Robot) addInlineQuery(robotID string, inlineQuery *InlineQuery) {
-	seq, err := rb.ctx.GenSeq(fmt.Sprintf("%s%s", common.RobotEventSeqKey, robotID))
+	seq, err := rb.ctx.GenSeq(inlineQuerySeqKeyPrefix + robotID)
 	if err != nil {
 		rb.Error("GenSeq failed", zap.Error(err))
 		return

--- a/modules/robot/api.go
+++ b/modules/robot/api.go
@@ -246,11 +246,13 @@ func (rb *Robot) PrepareBotTypedEvent(robotID, eventType string, eventData map[s
 //
 // It is NOT the only writer, and this comment used to claim otherwise.
 // `saveRobotMessage` (modules/robot/event.go) carries its own inline
-// GenSeq / ZAdd / Expire copy for the listener fast-path, and both
-// `notifyBotJoinedGroup` variants in modules/group write the queue directly
-// as well — five ZADD sites in total. PR#685's review caught the doorbell
-// being wired to only two of them because the brief trusted this docstring
-// instead of the call graph.
+// allocator / ZAdd / Expire copy for the listener fast-path, `addInlineQuery`
+// below writes the merged inline-query stream, and both `notifyBotJoinedGroup`
+// variants in modules/group write the queue directly as well. PR#685's review
+// caught the doorbell being wired to only two of them because the brief trusted
+// this docstring instead of the call graph, and #697's review then found the
+// count itself was wrong. Both guards in pkg/botevent are the record now;
+// this paragraph is orientation, not inventory.
 //
 // If you add a queue writer, it must also ring the doorbell
 // (pkg/botevent.Ring) after a successful ZADD, or /v1/bot/events long-poll

--- a/modules/robot/api_manager.go
+++ b/modules/robot/api_manager.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/pkg/botevent"
 	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
 	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
 	pkgutil "github.com/Mininglamp-OSS/octo-server/pkg/util"
@@ -371,7 +372,7 @@ func (m *Manager) cleanupBotConnection(robotID string) error {
 	m.ctx.GetRedisConn().Del(heartbeatKey)
 
 	// 4. 清除事件队列 Redis key
-	eventKey := fmt.Sprintf("robotEvent:%s", robotID)
+	eventKey := botevent.QueueKey(robotID)
 	m.ctx.GetRedisConn().Del(eventKey)
 
 	return nil

--- a/modules/robot/event.go
+++ b/modules/robot/event.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 	"time"
+	"unicode"
 
 	"github.com/Mininglamp-OSS/octo-lib/common"
 	"github.com/Mininglamp-OSS/octo-lib/config"
@@ -26,6 +27,42 @@ func (rb *Robot) getCreatorUID(robotID string) (string, error) {
 	}
 	rb.creatorCache.Store(robotID, uid)
 	return uid, nil
+}
+
+// robotIDMaxLen is the width of `robot.robot_id` (VARCHAR(40),
+// modules/robot/sql/20210926000001_robot_legacy01.sql). A longer string cannot be a row in
+// that table, so it cannot name a bot.
+const robotIDMaxLen = 40
+
+// plausibleRobotID reports whether a client-supplied `payload.robot_id` is shaped like
+// something that could name a bot at all.
+//
+// This is a *syntactic* gate in front of the existRobot lookup, and it exists because that
+// lookup fails open (#697 review, sixth round): a DB blip must not drop a bot event, but it
+// must also not let an arbitrary-length client string through, because the monotonic
+// allocator turns every distinct value into a permanent `botEventSeq:counter:{id}` key — no
+// TTL, in a Redis running `noeviction` — plus a `seq` row that is never reclaimed.
+//
+// The length bound is the decisive one and it needs no judgement call: a value longer than
+// the column cannot match any row, so adopting it could only ever create permanent state for
+// a bot that provably does not exist. Whitespace and control characters are rejected for the
+// same reason botevent.NextEventID rejects a padded id — the allocator, the queue key and
+// the doorbell must all key off the identical string, and an id that cannot round-trip
+// through a log line or a `KEYS` listing is not one anybody meant to send.
+//
+// Deliberately no charset allowlist beyond that: bot ids are UUID-hex in production, but the
+// column stores whatever it is given, and guessing narrower here would silently stop a real
+// bot's events for the sake of a surface the length bound already closes.
+func plausibleRobotID(candidate string) bool {
+	if candidate == "" || len(candidate) > robotIDMaxLen {
+		return false
+	}
+	for _, r := range candidate {
+		if unicode.IsSpace(r) || unicode.IsControl(r) {
+			return false
+		}
+	}
+	return true
 }
 
 func (rb *Robot) existRobot(robotID string) (bool, error) {
@@ -182,24 +219,35 @@ func (rb *Robot) robotMessageListen(messages []*config.MessageResp) {
 				// is not a delivery.
 				//
 				// A *lookup error* deliberately falls through to the old behaviour
-				// rather than dropping the event. The growth surface this closes is
-				// attacker-shaped — an id that provably does not exist — and no caller
-				// can force this query to error, so failing closed here would only
-				// convert a DB blip into silently lost bot events that used to be
-				// delivered (review, fifth round). The change is therefore strictly
-				// "reject when the bot is known not to exist".
+				// rather than dropping the event. No caller can force this query to
+				// error, so failing closed here would only convert a DB blip into
+				// silently lost bot events that used to be delivered (review, fifth
+				// round). The change is therefore strictly "reject when the bot is
+				// known not to exist".
+				//
+				// Which leaves the fail-open path able to adopt an arbitrary
+				// client-supplied string, so it gets a *syntactic* bound first (review,
+				// sixth round). That bound needs no database and cannot blip: it is the
+				// difference between "an id shaped like every real bot id" and "any
+				// length of anything", which is what decides whether the permanent
+				// per-value state above is bounded.
 				candidate := robotIDValue.String()
-				exist, err := rb.existRobot(candidate)
-				switch {
-				case err != nil:
-					rb.Error("查询有效robotID失败，按原行为放行",
-						zap.Error(err), zap.String("robotID", candidate))
-					robotID = candidate
-				case exist:
-					robotID = candidate
-				default:
-					rb.Debug("payload.robot_id 不是已知机器人，忽略",
+				if !plausibleRobotID(candidate) {
+					rb.Debug("payload.robot_id 形状不合法，忽略",
 						zap.String("robotID", candidate), zap.Int64("messageID", message.MessageID))
+				} else {
+					exist, err := rb.existRobot(candidate)
+					switch {
+					case err != nil:
+						rb.Error("查询有效robotID失败，按原行为放行",
+							zap.Error(err), zap.String("robotID", candidate))
+						robotID = candidate
+					case exist:
+						robotID = candidate
+					default:
+						rb.Debug("payload.robot_id 不是已知机器人，忽略",
+							zap.String("robotID", candidate), zap.Int64("messageID", message.MessageID))
+					}
 				}
 			} else if payloadValue.Get("mention").Exists() {
 				rb.Debug("检测到@提及", zap.String("mention", payloadValue.Get("mention").String()))

--- a/modules/robot/event.go
+++ b/modules/robot/event.go
@@ -168,7 +168,28 @@ func (rb *Robot) robotMessageListen(messages []*config.MessageResp) {
 		if len(robotID) == 0 {
 			robotIDValue := payloadValue.Get("robot_id")
 			if robotIDValue.Exists() {
-				robotID = robotIDValue.String()
+				// #697: validate before adopting it, as the three sibling branches below
+				// already do (mention.uids, @username text, ais broadcast). This one did
+				// not, and it is the only branch whose value comes verbatim out of a
+				// client's message payload.
+				//
+				// It used to cost an unknown value only a queue key with a TTL plus a
+				// `seq` row. The monotonic allocator adds a per-bot counter key with
+				// **no** TTL in a Redis running `noeviction`, plus a durable `seq` row
+				// that is never reclaimed — so an arbitrary payload value would become
+				// permanent per-value state. Rejecting an unknown bot is also just
+				// correct on its own terms: enqueueing onto a queue no bot will ever poll
+				// is not a delivery.
+				candidate := robotIDValue.String()
+				exist, err := rb.existRobot(candidate)
+				if err != nil {
+					rb.Error("查询有效robotID失败！", zap.Error(err), zap.String("robotID", candidate))
+				} else if exist {
+					robotID = candidate
+				} else {
+					rb.Debug("payload.robot_id 不是已知机器人，忽略",
+						zap.String("robotID", candidate), zap.Int64("messageID", message.MessageID))
+				}
 			} else if payloadValue.Get("mention").Exists() {
 				rb.Debug("检测到@提及", zap.String("mention", payloadValue.Get("mention").String()))
 				mentionValue := payloadValue.Get("mention")
@@ -364,7 +385,7 @@ func (rb *Robot) saveRobotMessage(message *config.MessageResp, robotID string) {
 		Message: message,
 		Expire:  time.Now().Add(rb.ctx.GetConfig().Robot.MessageExpire).Unix(),
 	})
-	key := fmt.Sprintf("%s%s", rb.robotEventPrefix, robotID)
+	key := botevent.QueueKey(robotID)
 	err = rb.ctx.GetRedisConn().ZAdd(key, float64(seq), messageUpdateJson)
 	if err != nil {
 		rb.Error("投递消息给机器人失败！", zap.Error(err), zap.String("robotID", robotID), zap.String("message", messageUpdateJson))

--- a/modules/robot/event.go
+++ b/modules/robot/event.go
@@ -29,9 +29,17 @@ func (rb *Robot) getCreatorUID(robotID string) (string, error) {
 	return uid, nil
 }
 
-// robotIDMaxLen is the width of `robot.robot_id` (VARCHAR(40),
-// modules/robot/sql/20210926000001_robot_legacy01.sql). A longer string cannot be a row in
-// that table, so it cannot name a bot.
+// robotIDMaxLen bounds a candidate bot id in **bytes**.
+//
+// It is the width of `robot.robot_id` (VARCHAR(40),
+// modules/robot/sql/20210926000001_robot_legacy01.sql), which MySQL counts in *characters*
+// under utf8mb4 — so this is deliberately the stricter of the two, and the difference is
+// stated rather than glossed (review round 7). A multibyte id would be rejected here while
+// the column would accept it; that is unreachable today because both id-producing paths are
+// ASCII-only (a client-chosen username is `[a-z0-9_]{1,20}` plus `_bot`, and the generated
+// form is lowercase hex plus `_bot` — modules/botfather), and bytes are what the Redis key
+// and the log line are actually made of. If a multibyte id ever becomes producible, widen
+// this to utf8.RuneCountInString rather than raising the number.
 const robotIDMaxLen = 40
 
 // plausibleRobotID reports whether a client-supplied `payload.robot_id` is shaped like
@@ -44,11 +52,11 @@ const robotIDMaxLen = 40
 // TTL, in a Redis running `noeviction` — plus a `seq` row that is never reclaimed.
 //
 // The length bound is the decisive one and it needs no judgement call: a value longer than
-// the column cannot match any row, so adopting it could only ever create permanent state for
-// a bot that provably does not exist. Whitespace and control characters are rejected for the
-// same reason botevent.NextEventID rejects a padded id — the allocator, the queue key and
-// the doorbell must all key off the identical string, and an id that cannot round-trip
-// through a log line or a `KEYS` listing is not one anybody meant to send.
+// the column can hold cannot match any row, so adopting it could only ever create permanent
+// state for a bot that provably does not exist. Whitespace and control characters are
+// rejected for the same reason botevent.NextEventID rejects a padded id — the allocator, the
+// queue key and the doorbell must all key off the identical string, and an id that cannot
+// round-trip through a log line or a `KEYS` listing is not one anybody meant to send.
 //
 // Deliberately no charset allowlist beyond that: bot ids are UUID-hex in production, but the
 // column stores whatever it is given, and guessing narrower here would silently stop a real

--- a/modules/robot/event.go
+++ b/modules/robot/event.go
@@ -180,13 +180,24 @@ func (rb *Robot) robotMessageListen(messages []*config.MessageResp) {
 				// permanent per-value state. Rejecting an unknown bot is also just
 				// correct on its own terms: enqueueing onto a queue no bot will ever poll
 				// is not a delivery.
+				//
+				// A *lookup error* deliberately falls through to the old behaviour
+				// rather than dropping the event. The growth surface this closes is
+				// attacker-shaped — an id that provably does not exist — and no caller
+				// can force this query to error, so failing closed here would only
+				// convert a DB blip into silently lost bot events that used to be
+				// delivered (review, fifth round). The change is therefore strictly
+				// "reject when the bot is known not to exist".
 				candidate := robotIDValue.String()
 				exist, err := rb.existRobot(candidate)
-				if err != nil {
-					rb.Error("查询有效robotID失败！", zap.Error(err), zap.String("robotID", candidate))
-				} else if exist {
+				switch {
+				case err != nil:
+					rb.Error("查询有效robotID失败，按原行为放行",
+						zap.Error(err), zap.String("robotID", candidate))
 					robotID = candidate
-				} else {
+				case exist:
+					robotID = candidate
+				default:
 					rb.Debug("payload.robot_id 不是已知机器人，忽略",
 						zap.String("robotID", candidate), zap.Int64("messageID", message.MessageID))
 				}

--- a/modules/robot/event.go
+++ b/modules/robot/event.go
@@ -42,6 +42,8 @@ func (rb *Robot) getCreatorUID(robotID string) (string, error) {
 // this to utf8.RuneCountInString rather than raising the number.
 const robotIDMaxLen = 40
 
+const robotMissingCacheTTL = 30 * time.Second
+
 // plausibleRobotID reports whether a client-supplied `payload.robot_id` is shaped like
 // something that could name a bot at all.
 //
@@ -102,6 +104,9 @@ func (rb *Robot) existRobot(robotID string) (bool, error) {
 	if exist == "1" {
 		return true, nil
 	}
+	if exist == "0" {
+		return false, nil
+	}
 	existB, err := rb.db.exist(robotID)
 	if err != nil {
 		return false, err
@@ -112,6 +117,13 @@ func (rb *Robot) existRobot(robotID string) (bool, error) {
 			return false, err
 		}
 		return true, nil
+	}
+	// Unknown client-supplied ids are common on this listener path. Cache a proven miss
+	// briefly so one repeated payload cannot turn into one MySQL query per message. Keep
+	// the TTL short: bot creation is allowed to make a previously missing id valid, and
+	// no creation hook can invalidate every replica's local observation atomically.
+	if err := rb.ctx.GetRedisConn().SetAndExpire(key, "0", robotMissingCacheTTL); err != nil {
+		rb.Warn("缓存不存在的robotID失败", zap.Error(err), zap.String("robotID", robotID))
 	}
 	return false, nil
 
@@ -272,7 +284,8 @@ func (rb *Robot) robotMessageListen(messages []*config.MessageResp) {
 							zap.String("robotID", candidate), zap.Int64("messageID", message.MessageID))
 					}
 				}
-			} else if payloadValue.Get("mention").Exists() {
+			}
+			if len(robotID) == 0 && payloadValue.Get("mention").Exists() {
 				rb.Debug("检测到@提及", zap.String("mention", payloadValue.Get("mention").String()))
 				mentionValue := payloadValue.Get("mention")
 				mentionUIDsValue := mentionValue.Get("uids")
@@ -355,7 +368,7 @@ func (rb *Robot) robotMessageListen(messages []*config.MessageResp) {
 						}
 					}
 				}
-			} else {
+			} else if len(robotID) == 0 {
 				if common.ContentType(payloadValue.Get("type").Int()) == common.Text {
 					content := payloadValue.Get("content").String()
 					if strings.Contains(content, "@") {

--- a/modules/robot/event.go
+++ b/modules/robot/event.go
@@ -46,10 +46,12 @@ const robotIDMaxLen = 40
 // something that could name a bot at all.
 //
 // This is a *syntactic* gate in front of the existRobot lookup, and it exists because that
-// lookup fails open (#697 review, sixth round): a DB blip must not drop a bot event, but it
-// must also not let an arbitrary-length client string through, because the monotonic
-// allocator turns every distinct value into a permanent `botEventSeq:counter:{id}` key — no
-// TTL, in a Redis running `noeviction` — plus a `seq` row that is never reclaimed.
+// lookup is on a client-controlled path. The monotonic allocator turns every adopted value
+// into a permanent `botEventSeq:counter:{id}` key — no TTL, in a Redis running `noeviction`
+// — plus a `seq` row that is never reclaimed. This check bounds one key's size and rejects
+// spellings no real bot can use; it does **not** bound cardinality, because a client can send
+// arbitrarily many distinct well-shaped values. Positive existence verification below is
+// what closes that dimension.
 //
 // The length bound is the decisive one and it needs no judgement call: a value longer than
 // the column can hold cannot match any row, so adopting it could only ever create permanent
@@ -71,6 +73,24 @@ func plausibleRobotID(candidate string) bool {
 		}
 	}
 	return true
+}
+
+// verifiedPayloadRobotID applies the trust boundary for client-controlled
+// payload.robot_id values.
+//
+// Only a successful, positive lookup is authority to adopt the candidate. Treating a lookup
+// error as existence lets a client create a fresh permanent counter key for every distinct
+// value throughout a dependency outage; the syntactic bound above limits key size, not key
+// count. Returning the lookup error lets the caller surface the availability failure while
+// keeping the unverified id out of the allocator.
+func verifiedPayloadRobotID(candidate string, exists bool, lookupErr error) (string, error) {
+	if lookupErr != nil {
+		return "", lookupErr
+	}
+	if !exists {
+		return "", nil
+	}
+	return candidate, nil
 }
 
 func (rb *Robot) existRobot(robotID string) (bool, error) {
@@ -226,32 +246,27 @@ func (rb *Robot) robotMessageListen(messages []*config.MessageResp) {
 				// correct on its own terms: enqueueing onto a queue no bot will ever poll
 				// is not a delivery.
 				//
-				// A *lookup error* deliberately falls through to the old behaviour
-				// rather than dropping the event. No caller can force this query to
-				// error, so failing closed here would only convert a DB blip into
-				// silently lost bot events that used to be delivered (review, fifth
-				// round). The change is therefore strictly "reject when the bot is
-				// known not to exist".
-				//
-				// Which leaves the fail-open path able to adopt an arbitrary
-				// client-supplied string, so it gets a *syntactic* bound first (review,
-				// sixth round). That bound needs no database and cannot blip: it is the
-				// difference between "an id shaped like every real bot id" and "any
-				// length of anything", which is what decides whether the permanent
-				// per-value state above is bounded.
+				// A lookup error must not turn into authority to adopt the value. During
+				// a dependency outage a client can submit arbitrarily many distinct,
+				// well-shaped ids; adopting them would leave one permanent counter per
+				// value. The syntactic gate limits each key's size, not their count, so
+				// this branch accepts only a positively verified bot. The availability
+				// trade-off is explicit: an event routed solely by payload.robot_id is
+				// ignored while its identity cannot be verified.
 				candidate := robotIDValue.String()
 				if !plausibleRobotID(candidate) {
 					rb.Debug("payload.robot_id 形状不合法，忽略",
 						zap.String("robotID", candidate), zap.Int64("messageID", message.MessageID))
 				} else {
 					exist, err := rb.existRobot(candidate)
+					verified, verifyErr := verifiedPayloadRobotID(candidate, exist, err)
 					switch {
-					case err != nil:
-						rb.Error("查询有效robotID失败，按原行为放行",
-							zap.Error(err), zap.String("robotID", candidate))
-						robotID = candidate
-					case exist:
-						robotID = candidate
+					case verifyErr != nil:
+						rb.Error("查询有效robotID失败，无法正向验证，忽略payload.robot_id",
+							zap.Error(verifyErr), zap.String("robotID", candidate),
+							zap.Int64("messageID", message.MessageID))
+					case verified != "":
+						robotID = verified
 					default:
 						rb.Debug("payload.robot_id 不是已知机器人，忽略",
 							zap.String("robotID", candidate), zap.Int64("messageID", message.MessageID))

--- a/modules/robot/event.go
+++ b/modules/robot/event.go
@@ -351,9 +351,12 @@ func (rb *Robot) saveRobotMessage(message *config.MessageResp, robotID string) {
 		message = &cp
 	}
 
-	seq, err := rb.ctx.GenSeq(fmt.Sprintf("%s%s", common.RobotEventSeqKey, robotID))
+	// #697: monotonic per-bot allocator instead of GenSeq. This is the
+	// highest-volume producer and it runs inside a msgSem slot, which is why the
+	// allocator's timeouts are bounded — see pkg/botevent/seq.go.
+	seq, err := botevent.NextEventID(rb.ctx, robotID)
 	if err != nil {
-		rb.Warn("GenSeq failed", zap.Error(err))
+		rb.Warn("allocate bot event id failed", zap.Error(err), zap.String("robotID", robotID))
 		return
 	}
 	messageUpdateJson := util.ToJson(&robotEvent{

--- a/modules/robot/event_test.go
+++ b/modules/robot/event_test.go
@@ -2,9 +2,17 @@ package robot
 
 import (
 	"encoding/json"
+	"fmt"
 	"testing"
+	"time"
 
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	"github.com/Mininglamp-OSS/octo-server/pkg/botevent"
+	rd "github.com/go-redis/redis"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/tidwall/gjson"
 )
 
@@ -222,10 +230,10 @@ func TestShouldSkipFriendCheck(t *testing.T) {
 // the new mention.entities field. This mirrors the parsing logic at event.go:135-153.
 func TestRobotMentionParsingWithEntities(t *testing.T) {
 	tests := []struct {
-		name         string
-		payload      string
-		expectUIDs   []string
-		expectPanic  bool
+		name        string
+		payload     string
+		expectUIDs  []string
+		expectPanic bool
 	}{
 		{
 			name: "v2 payload with uids and entities",
@@ -403,6 +411,57 @@ func TestGjsonIgnoresUnknownFields(t *testing.T) {
 		parsed.Get("mention.uids").String(),
 		parsedWithout.Get("mention.uids").String(),
 		"uids should be identical with or without entities")
+}
+
+// TestUnknownPayloadRobotIDIsNegativelyCachedAndFallsThroughToMention covers two
+// properties of the client-controlled payload.robot_id branch:
+//  1. repeated well-shaped unknown ids must not cause one MySQL query per message;
+//  2. a declined payload id must not swallow a valid sibling mention route.
+func TestUnknownPayloadRobotIDIsNegativelyCachedAndFallsThroughToMention(t *testing.T) {
+	_, ctx := testutil.NewTestServer()
+	defer testutil.CleanAllTables(ctx)
+
+	rb := New(ctx)
+	validBot := fmt.Sprintf("mention_fallback_%d_bot", time.Now().UnixNano())
+	unknownBot := fmt.Sprintf("missing_payload_%d_bot", time.Now().UnixNano())
+	if _, err := ctx.DB().InsertInto("robot").
+		Columns("robot_id", "status", "creator_uid", "description").
+		Values(validBot, 1, "owner", "fallback fixture").Exec(); err != nil {
+		t.Fatalf("insert mentioned bot: %v", err)
+	}
+
+	unknownCacheKey := "robot:exist:" + unknownBot
+	queueKey := botevent.QueueKey(validBot)
+	_ = ctx.GetRedisConn().Del(unknownCacheKey)
+	_ = ctx.GetRedisConn().Del("robot:exist:" + validBot)
+	_ = ctx.GetRedisConn().Del(queueKey)
+	t.Cleanup(func() {
+		_ = ctx.GetRedisConn().Del(unknownCacheKey)
+		_ = ctx.GetRedisConn().Del("robot:exist:" + validBot)
+		_ = ctx.GetRedisConn().Del(queueKey)
+	})
+
+	payload := []byte(fmt.Sprintf(`{"type":1,"content":"hello","robot_id":%q,"mention":{"uids":[%q]}}`,
+		unknownBot, validBot))
+	rb.robotMessageListen([]*config.MessageResp{{
+		MessageID:   time.Now().UnixNano(),
+		FromUID:     "sender",
+		ChannelID:   "group",
+		ChannelType: common.ChannelTypeGroup.Uint8(),
+		Payload:     payload,
+	}})
+
+	require.Eventually(t, func() bool {
+		members, err := ctx.GetRedisConn().ZRangeByScore(queueKey, rd.ZRangeBy{Min: "-inf", Max: "+inf"})
+		return err == nil && len(members) == 1
+	}, 3*time.Second, 20*time.Millisecond, "valid mention route was swallowed by an unknown payload.robot_id")
+
+	if cached, err := ctx.GetRedisConn().GetString(unknownCacheKey); err != nil || cached != "0" {
+		t.Fatalf("unknown bot was not negatively cached (value=%q err=%v); repeated messages would query MySQL", cached, err)
+	}
+	if exists, err := rb.existRobot(unknownBot); err != nil || exists {
+		t.Fatalf("negative cache did not answer the repeated lookup (exists=%v err=%v)", exists, err)
+	}
 }
 
 // extractBotCommandKey extracts the bot command from content using entities.

--- a/modules/robot/payload_robot_id_test.go
+++ b/modules/robot/payload_robot_id_test.go
@@ -1,0 +1,40 @@
+package robot
+
+import (
+	"errors"
+	"testing"
+)
+
+// TestVerifiedPayloadRobotIDRequiresPositiveVerification pins the trust boundary
+// for client-controlled payload.robot_id values.
+//
+// The allocator creates a no-TTL counter for every adopted id. A lookup error is
+// not positive evidence that the id names a bot, so returning the candidate in
+// that case turns a transient dependency failure into unbounded permanent Redis
+// state. The candidate may be adopted only after a successful existence check.
+func TestVerifiedPayloadRobotIDRequiresPositiveVerification(t *testing.T) {
+	lookupErr := errors.New("lookup failed")
+	cases := []struct {
+		name    string
+		exists  bool
+		err     error
+		want    string
+		wantErr error
+	}{
+		{name: "verified bot", exists: true, want: "known_bot"},
+		{name: "known missing", exists: false},
+		{name: "lookup failure", err: lookupErr, wantErr: lookupErr},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := verifiedPayloadRobotID("known_bot", tc.exists, tc.err)
+			if !errors.Is(err, tc.wantErr) {
+				t.Fatalf("error = %v, want %v", err, tc.wantErr)
+			}
+			if got != tc.want {
+				t.Fatalf("robot id = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/modules/robot/plausible_robot_id_test.go
+++ b/modules/robot/plausible_robot_id_test.go
@@ -1,0 +1,74 @@
+package robot
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestPlausibleRobotID pins the syntactic gate in front of the payload.robot_id lookup.
+//
+// #697 review, sixth round: the lookup fails open on a query error so a DB blip cannot drop
+// a bot event, which leaves the fail-open path able to adopt an arbitrary client-supplied
+// string. The monotonic allocator turns every distinct value into a permanent
+// `botEventSeq:counter:{id}` key (no TTL, `noeviction`) plus a `seq` row that is never
+// reclaimed, so the bound is what keeps that state finite.
+func TestPlausibleRobotID(t *testing.T) {
+	cases := []struct {
+		name      string
+		candidate string
+		want      bool
+	}{
+		// Shapes that really occur: UUID-hex in production, underscored ids in fixtures
+		// and for well-known bots. Rejecting any of these would silently stop a real
+		// bot's events, which is why there is no charset allowlist.
+		{"uuid hex", "0f8fad5bd9cb469fa16570867728950e", true},
+		{"botfather", "botfather", true},
+		{"underscored fixture id", "test_robot_001", true},
+		{"dashed id", "lp-bot-1", true},
+		{"exactly the column width", strings.Repeat("a", robotIDMaxLen), true},
+
+		// The decisive bound: longer than `robot.robot_id` (VARCHAR(40)) cannot be a row
+		// in that table, so adopting it could only ever create permanent state for a bot
+		// that provably does not exist.
+		{"one over the column width", strings.Repeat("a", robotIDMaxLen+1), false},
+		{"absurdly long", strings.Repeat("x", 4096), false},
+
+		// An id that cannot round-trip identically through a log line or a key listing is
+		// not one anybody meant to send, and botevent.NextEventID rejects padding for the
+		// same reason: the allocator, the queue key and the doorbell must key off the
+		// identical string.
+		{"empty", "", false},
+		{"leading space", " bot", false},
+		{"trailing space", "bot ", false},
+		{"inner space", "bot id", false},
+		{"newline", "bot\nid", false},
+		{"tab", "bot\tid", false},
+		{"nul", "bot\x00id", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := plausibleRobotID(tc.candidate); got != tc.want {
+				t.Errorf("plausibleRobotID(%q) = %v, want %v", tc.candidate, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestRobotIDMaxLenMatchesTheColumn keeps the constant honest.
+//
+// The bound's whole justification is "longer than the column cannot name a bot", so if the
+// column ever widens and this does not, the gate starts rejecting real ids.
+func TestRobotIDMaxLenMatchesTheColumn(t *testing.T) {
+	const declared = "robot_id   VARCHAR(40)"
+	const schemaFile = "sql/20210926000001_robot_legacy01.sql"
+	schema, err := os.ReadFile(schemaFile)
+	if err != nil {
+		t.Fatalf("read %s: %v", schemaFile, err)
+	}
+	if !strings.Contains(string(schema), declared) {
+		t.Fatalf("robot.robot_id is no longer declared as %q in %s, so robotIDMaxLen = %d may "+
+			"be wrong; plausibleRobotID rejects anything longer, which would silently stop a "+
+			"real bot's events", declared, schemaFile, robotIDMaxLen)
+	}
+}

--- a/modules/robot/plausible_robot_id_test.go
+++ b/modules/robot/plausible_robot_id_test.go
@@ -8,11 +8,13 @@ import (
 
 // TestPlausibleRobotID pins the syntactic gate in front of the payload.robot_id lookup.
 //
-// #697 review, sixth round: the lookup fails open on a query error so a DB blip cannot drop
-// a bot event, which leaves the fail-open path able to adopt an arbitrary client-supplied
-// string. The monotonic allocator turns every distinct value into a permanent
-// `botEventSeq:counter:{id}` key (no TTL, `noeviction`) plus a `seq` row that is never
-// reclaimed, so the bound is what keeps that state finite.
+// #697 review, sixth round added this syntactic bound before the lookup. The latest re-review
+// corrected what the bound proves: it limits one Redis key's size and rejects spellings no
+// real bot can use, but it does not limit how many distinct well-shaped values a client can
+// send. Positive existence verification closes that cardinality dimension separately in
+// TestVerifiedPayloadRobotIDRequiresPositiveVerification. The monotonic allocator turns
+// every adopted value into a permanent `botEventSeq:counter:{id}` key (no TTL, `noeviction`)
+// plus a `seq` row that is never reclaimed.
 func TestPlausibleRobotID(t *testing.T) {
 	cases := []struct {
 		name      string

--- a/modules/robot/sql/20260805000001_bot_event_seq_state.sql
+++ b/modules/robot/sql/20260805000001_bot_event_seq_state.sql
@@ -19,7 +19,7 @@
 CREATE TABLE IF NOT EXISTS `octo_bot_event_seq_state` (
   `singleton_id`  TINYINT UNSIGNED NOT NULL COMMENT '恒为1的单例键',
   `mode`          TINYINT          NOT NULL DEFAULT 0 COMMENT '0=legacy(GenSeq) 1=incr(Redis计数器)',
-  `epoch`         BIGINT UNSIGNED  NOT NULL DEFAULT 0 COMMENT '换代计数,operator CAS 递增;镜像据此判过期',
+  `epoch`         BIGINT UNSIGNED  NOT NULL DEFAULT 0 COMMENT '换代计数,operator CAS 递增;Redis 镜像值为 incr:{epoch},分配器据此拒绝陈旧/伪造镜像',
   `cutover_floor` BIGINT           NOT NULL DEFAULT 0 COMMENT '激活时校验过的号段下界',
   `updated_at`    TIMESTAMP        NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   PRIMARY KEY (`singleton_id`),
@@ -33,5 +33,20 @@ VALUES (1, 0, 0, 0)
 ON DUPLICATE KEY UPDATE `singleton_id` = `singleton_id`;
 
 -- +migrate Down
+
+-- 拒绝在**已激活**状态下 drop 权威行(review P2-2)。
+--
+-- 一旦 mode=1，这张表就是唯一不随 Redis RDB 回滚的激活凭据：drop 掉它之后，
+-- ReadState 返回 ErrStateMissing、按设计被读方当作 legacy，于是任何一次镜像丢失都会让
+-- 分配器发出低于计数器已发号的 GenSeq id，落在活跃游标下方 —— #697 的镜像，由回滚本身
+-- 造成。这个 flip 在别处（tools/botevent-seq、pkg/botevent/seq.go）都写明不可逆，Down
+-- 也必须一致。
+--
+-- 手法：向单例表插入 singleton_id=2，只在 mode=1 时选出行。CHECK (singleton_id = 1)
+-- 于是报 3819 并中止整个 Down；mode=0 时 SELECT 无行，INSERT 是 no-op。用已有约束报错，
+-- 免得为一条条件判断建存储过程。
+-- 若确实要在激活后拆除，先人工把 mode 改回 0 并明白这意味着什么。
+INSERT INTO `octo_bot_event_seq_state` (`singleton_id`, `mode`, `epoch`, `cutover_floor`)
+SELECT 2, 0, 0, 0 FROM `octo_bot_event_seq_state` WHERE `singleton_id` = 1 AND `mode` = 1;
 
 DROP TABLE IF EXISTS `octo_bot_event_seq_state`;

--- a/modules/robot/sql/20260805000001_bot_event_seq_state.sql
+++ b/modules/robot/sql/20260805000001_bot_event_seq_state.sql
@@ -45,6 +45,8 @@ ON DUPLICATE KEY UPDATE `singleton_id` = `singleton_id`;
 -- 手法：向单例表插入 singleton_id=2，只在 mode=1 时选出行。CHECK (singleton_id = 1)
 -- 于是报 3819 并中止整个 Down；mode=0 时 SELECT 无行，INSERT 是 no-op。用已有约束报错，
 -- 免得为一条条件判断建存储过程。
+-- 前提：MySQL >= 8.0.16 才真正强制 CHECK（更早的版本解析后忽略，这条 Down 会静默放过）。
+-- 本项目锁定 MySQL 8.0，所以这个前提成立。
 -- 若确实要在激活后拆除，先人工把 mode 改回 0 并明白这意味着什么。
 INSERT INTO `octo_bot_event_seq_state` (`singleton_id`, `mode`, `epoch`, `cutover_floor`)
 SELECT 2, 0, 0, 0 FROM `octo_bot_event_seq_state` WHERE `singleton_id` = 1 AND `mode` = 1;

--- a/modules/robot/sql/20260805000001_bot_event_seq_state.sql
+++ b/modules/robot/sql/20260805000001_bot_event_seq_state.sql
@@ -1,0 +1,37 @@
+-- +migrate Up
+
+-- octo_bot_event_seq_state (#697): bot 事件 id 分配器的**权威**状态，恒 1 行。
+--
+-- 为什么状态必须在 MySQL 而不是只在 Redis：分配器本身是 Redis INCR（热路径，
+-- saveRobotMessage 跑在 msgSem 槽内，承受不起每次一次 DB 往返），但激活状态若也只在
+-- Redis，就会随 RDB 回滚一起丢——生产 appendonly no，只有 RDB 快照。状态丢失后分配器
+-- 降级回 legacy GenSeq，而 GenSeq 的号低于计数器已发出的号，于是新事件落在消费者游标
+-- 下方、永久不可见，正是 #697 本身的镜像。
+--
+-- 所以：本表是权威 + 恢复源，Redis 键 botEventSeq:mode 只是镜像。镜像丢失时分配器读
+-- 本表自愈（重建镜像 + 重新 seed），不降级。
+--
+-- 与 octo_message_extra_version_state (#627) 刻意同形（mode/epoch/cutover_floor +
+-- FOR UPDATE 的 CAS flip + floor 校验），但**不复用它的 FOR SHARE drain barrier**：
+-- 那个 barrier 要求每个写入方在业务事务内持锁到 commit，而 robotEvent 的写入是
+-- INCR + ZADD 纯 Redis，没有 commit 可持。本方案的 flip 前提是运维先确认无旧副本，
+-- 详见 tools/botevent-seq。
+CREATE TABLE IF NOT EXISTS `octo_bot_event_seq_state` (
+  `singleton_id`  TINYINT UNSIGNED NOT NULL COMMENT '恒为1的单例键',
+  `mode`          TINYINT          NOT NULL DEFAULT 0 COMMENT '0=legacy(GenSeq) 1=incr(Redis计数器)',
+  `epoch`         BIGINT UNSIGNED  NOT NULL DEFAULT 0 COMMENT '换代计数,operator CAS 递增;镜像据此判过期',
+  `cutover_floor` BIGINT           NOT NULL DEFAULT 0 COMMENT '激活时校验过的号段下界',
+  `updated_at`    TIMESTAMP        NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`singleton_id`),
+  CONSTRAINT `chk_bot_event_seq_singleton` CHECK (`singleton_id` = 1)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci COMMENT='bot 事件 id 分配器状态单例(#697)';
+
+-- seed 为 legacy：部署本身行为中立,切换是独立的运维动作。
+INSERT INTO `octo_bot_event_seq_state`
+  (`singleton_id`, `mode`, `epoch`, `cutover_floor`)
+VALUES (1, 0, 0, 0)
+ON DUPLICATE KEY UPDATE `singleton_id` = `singleton_id`;
+
+-- +migrate Down
+
+DROP TABLE IF EXISTS `octo_bot_event_seq_state`;

--- a/pkg/botevent/chokepoint_guard_test.go
+++ b/pkg/botevent/chokepoint_guard_test.go
@@ -29,10 +29,17 @@ func TestEveryBotEventQueueWriterRingsTheDoorbell(t *testing.T) {
 	root := repoRootForGuard(t)
 
 	// A queue writer is a ZAdd whose key is the bot event queue. Cover the shared
-	// QueueKey helper (#697 consolidated the producers onto it, so the seed reads
-	// the exact key they write), the legacy prefix field, the literal spelling,
-	// and the prepared typed-event key produced by PrepareBotTypedEvent.
-	queueKey := regexp.MustCompile(`(robotEventPrefix|"robotEvent:%s"|botevent\.QueueKey|prepared\.QueueKey)`)
+	// QueueKey helper (#697 consolidated every producer *and* every Del site onto it,
+	// so the seed reads the exact key they write) and the prepared typed-event key
+	// produced by PrepareBotTypedEvent — plus every hand-rolled spelling of the
+	// literal, so a writer that reintroduces one is still recognised rather than
+	// silently skipped.
+	//
+	// `"robotEvent:"` on its own matters: review found the previous pattern matched
+	// `"robotEvent:%s"` but not `"robotEvent:" + robotID`, which is the spelling used
+	// throughout modules/message and modules/bot_mention tests. A sixth writer using it
+	// would have cleared both the match and the vacuity floor below.
+	queueKey := regexp.MustCompile(`(robotEventPrefix|"robotEvent:|botevent\.QueueKey|prepared\.QueueKey)`)
 	zaddCall := regexp.MustCompile(`\.ZAdd\(`)
 	// Notify is the producer-facing entry point; Ring is the synchronous
 	// primitive it wraps. Both count: a writer that calls Ring directly is
@@ -130,6 +137,23 @@ func TestEveryBotEventQueueWriterRingsTheDoorbell(t *testing.T) {
 func TestGuardWouldCatchAnUnrungWriter(t *testing.T) {
 	zaddCall := regexp.MustCompile(`\.ZAdd\(`)
 	ringCall := regexp.MustCompile(`botevent\.(Notify|Ring)\(`)
+	queueKey := regexp.MustCompile(`(robotEventPrefix|"robotEvent:|botevent\.QueueKey|prepared\.QueueKey)`)
+
+	// Every spelling a writer could reach for has to be recognised as a queue key, or
+	// that writer is skipped rather than checked. The concatenation form is the one the
+	// previous pattern missed (review, fifth round).
+	for _, spelling := range []string{
+		`key := botevent.QueueKey(robotID)`,
+		`key := fmt.Sprintf("%s%s", rb.robotEventPrefix, robotID)`,
+		`key := fmt.Sprintf("robotEvent:%s", robotID)`,
+		`key := "robotEvent:" + robotID`,
+		`err := c.ZAdd(prepared.QueueKey, score, member)`,
+	} {
+		if !queueKey.MatchString(spelling) {
+			t.Errorf("queue-key pattern does not recognise %q, so a writer spelled that way "+
+				"would be skipped by the guard instead of checked", spelling)
+		}
+	}
 
 	unrung := []string{
 		`key := fmt.Sprintf("%s%s", rb.robotEventPrefix, robotID)`,

--- a/pkg/botevent/chokepoint_guard_test.go
+++ b/pkg/botevent/chokepoint_guard_test.go
@@ -28,10 +28,11 @@ import (
 func TestEveryBotEventQueueWriterRingsTheDoorbell(t *testing.T) {
 	root := repoRootForGuard(t)
 
-	// A queue writer is a ZAdd whose key is the bot event queue. Cover the two
-	// direct spellings plus the prepared typed-event key produced by
-	// PrepareBotTypedEvent.
-	queueKey := regexp.MustCompile(`(robotEventPrefix|"robotEvent:%s"|prepared\.QueueKey)`)
+	// A queue writer is a ZAdd whose key is the bot event queue. Cover the shared
+	// QueueKey helper (#697 consolidated the producers onto it, so the seed reads
+	// the exact key they write), the legacy prefix field, the literal spelling,
+	// and the prepared typed-event key produced by PrepareBotTypedEvent.
+	queueKey := regexp.MustCompile(`(robotEventPrefix|"robotEvent:%s"|botevent\.QueueKey|prepared\.QueueKey)`)
 	zaddCall := regexp.MustCompile(`\.ZAdd\(`)
 	// Notify is the producer-facing entry point; Ring is the synchronous
 	// primitive it wraps. Both count: a writer that calls Ring directly is

--- a/pkg/botevent/genseq_guard_test.go
+++ b/pkg/botevent/genseq_guard_test.go
@@ -1,0 +1,106 @@
+package botevent
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// TestNoGenSeqForBotEventIDs pins the other half of the #697 fix.
+//
+// Replacing the allocator only helps if it replaces it *everywhere*. GenSeq hands
+// out HiLo blocks from process-local state, so one remaining caller means one
+// remaining live id source on the same queue — which is not "most of the fix",
+// it is the original defect: two sources issuing into one exclusive-cursor
+// sorted set is exactly what produced the 2624 colliding scores measured in
+// production.
+//
+// The sibling guard (TestEveryBotEventQueueWriterRingsTheDoorbell) exists because
+// a docstring claimed there was a single chokepoint when there were five writers.
+// This one exists for the same reason in the other direction: nothing structural
+// stops a sixth writer from reaching for GenSeq, and a code comment would not
+// notice.
+func TestNoGenSeqForBotEventIDs(t *testing.T) {
+	root := repoRootForGuard(t)
+
+	// Both spellings of the legacy allocation: the constant and the literal key
+	// prefix it holds. A caller that inlined the string still counts.
+	legacyAlloc := regexp.MustCompile(`GenSeq\([^)]*(RobotEventSeqKey|"robotEventSeq:)`)
+
+	var violations []string
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() {
+			switch d.Name() {
+			case ".git", "vendor", "node_modules", ".octospec", "tools":
+				// tools/ is exempt: tools/genseq-repro exists precisely to call the
+				// legacy allocator and demonstrate that it collides.
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		content, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return readErr
+		}
+		for i, line := range strings.Split(string(content), "\n") {
+			if legacyAlloc.MatchString(line) {
+				rel, _ := filepath.Rel(root, path)
+				violations = append(violations, rel+":"+itoaGuard(i+1))
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk: %v", err)
+	}
+
+	if len(violations) > 0 {
+		t.Fatalf("bot event ids allocated through octo-lib GenSeq:\n  %s\n\n"+
+			"GenSeq is a per-process HiLo block allocator, so two replicas can issue the same "+
+			"id and can issue ids out of time order. robotEvent:{robotID} is read with an "+
+			"exclusive cursor and acked by score, both of which require strict monotonicity. "+
+			"Use botevent.NextEventID instead (pkg/botevent/seq.go), and do not add a GenSeq "+
+			"fallback — two live id sources on one queue is the defect this replaced (#697).",
+			strings.Join(violations, "\n  "))
+	}
+}
+
+// TestGenSeqGuardWouldCatchAReintroduction proves the guard above can fail. A
+// pattern that matches nothing would pass forever while protecting nothing —
+// the same vacuity the sibling guard's minKnownQueueWriters floor defends.
+func TestGenSeqGuardWouldCatchAReintroduction(t *testing.T) {
+	legacyAlloc := regexp.MustCompile(`GenSeq\([^)]*(RobotEventSeqKey|"robotEventSeq:)`)
+
+	shouldMatch := []string{
+		`seq, err := ctx.GenSeq(fmt.Sprintf("%s%s", common.RobotEventSeqKey, robotID))`,
+		`seq, err := rb.ctx.GenSeq(fmt.Sprintf("%s%s", common.RobotEventSeqKey, robotID))`,
+		`v, _ := c.GenSeq("robotEventSeq:" + id)`,
+	}
+	for _, s := range shouldMatch {
+		if !legacyAlloc.MatchString(s) {
+			t.Fatalf("guard would not catch a reintroduction: %s", s)
+		}
+	}
+
+	// Other GenSeq users are none of this guard's business — #700 tracks the
+	// reminders and conversation_extra cursors, which are a different fix.
+	shouldNotMatch := []string{
+		`version, err := m.ctx.GenSeq(common.RemindersKey)`,
+		`version, err := co.ctx.GenSeq(common.SyncConversationExtraKey)`,
+		`seq, err := botevent.NextEventID(ctx, robotID)`,
+	}
+	for _, s := range shouldNotMatch {
+		if legacyAlloc.MatchString(s) {
+			t.Fatalf("guard is too broad, it matched: %s", s)
+		}
+	}
+}

--- a/pkg/botevent/genseq_guard_test.go
+++ b/pkg/botevent/genseq_guard_test.go
@@ -26,8 +26,23 @@ import (
 func TestNoGenSeqForBotEventIDs(t *testing.T) {
 	root := repoRootForGuard(t)
 
-	// Both spellings of the legacy allocation: the constant and the literal key
-	// prefix it holds. A caller that inlined the string still counts.
+	// Assert on the *key*, not on `GenSeq(...key)`.
+	//
+	// An earlier revision matched `GenSeq\([^)]*(RobotEventSeqKey|"robotEventSeq:)` one
+	// line at a time, which a routine refactor walks straight past (review P2-5):
+	//
+	//	key := common.RobotEventSeqKey + robotID
+	//	seq, err := ctx.GenSeq(key)
+	//
+	// or the same call wrapped across two lines. Nothing outside the allowlisted file
+	// has any business naming this key at all — reading the row, formatting it, logging
+	// it — because every use of it is either an allocation from the retired source or a
+	// reimplementation of the seed's ceiling read. So the key itself is the thing to
+	// forbid, and every spelling of the call becomes unreachable rather than
+	// individually pattern-matched.
+	legacyKey := regexp.MustCompile(`RobotEventSeqKey|"robotEventSeq:|robotEventSeq:%s`)
+
+	// The delegation itself still has to exist; see the assertion below.
 	legacyAlloc := regexp.MustCompile(`GenSeq\([^)]*(RobotEventSeqKey|"robotEventSeq:)`)
 
 	// pkg/botevent/seq.go is the single allowlisted GenSeq call site, the same
@@ -45,7 +60,8 @@ func TestNoGenSeqForBotEventIDs(t *testing.T) {
 			switch d.Name() {
 			case ".git", "vendor", "node_modules", ".octospec", "tools":
 				// tools/ is exempt: tools/genseq-repro exists precisely to call the
-				// legacy allocator and demonstrate that it collides.
+				// legacy allocator and demonstrate that it collides, and
+				// tools/botevent-seq reads the legacy rows to compute the cutover floor.
 				return filepath.SkipDir
 			}
 			return nil
@@ -62,7 +78,7 @@ func TestNoGenSeqForBotEventIDs(t *testing.T) {
 			return readErr
 		}
 		for i, line := range strings.Split(string(content), "\n") {
-			if legacyAlloc.MatchString(line) {
+			if legacyKey.MatchString(line) {
 				violations = append(violations, rel+":"+itoaGuard(i+1))
 			}
 		}
@@ -88,13 +104,15 @@ func TestNoGenSeqForBotEventIDs(t *testing.T) {
 	}
 
 	if len(violations) > 0 {
-		t.Fatalf("bot event ids allocated through octo-lib GenSeq:\n  %s\n\n"+
+		t.Fatalf("the legacy bot-event seq key is named outside %s:\n  %s\n\n"+
 			"GenSeq is a per-process HiLo block allocator, so two replicas can issue the same "+
 			"id and can issue ids out of time order. robotEvent:{robotID} is read with an "+
 			"exclusive cursor and acked by score, both of which require strict monotonicity. "+
 			"Use botevent.NextEventID instead (pkg/botevent/seq.go), and do not add a GenSeq "+
-			"fallback — two live id sources on one queue is the defect this replaced (#697).",
-			strings.Join(violations, "\n  "))
+			"fallback — two live id sources on one queue is the defect this replaced (#697). "+
+			"If you only need to *read* the legacy ceiling, that already exists as "+
+			"legacyCeiling in the allowlisted file.",
+			allowlisted, strings.Join(violations, "\n  "))
 	}
 }
 
@@ -102,15 +120,18 @@ func TestNoGenSeqForBotEventIDs(t *testing.T) {
 // pattern that matches nothing would pass forever while protecting nothing —
 // the same vacuity the sibling guard's minKnownQueueWriters floor defends.
 func TestGenSeqGuardWouldCatchAReintroduction(t *testing.T) {
-	legacyAlloc := regexp.MustCompile(`GenSeq\([^)]*(RobotEventSeqKey|"robotEventSeq:)`)
+	legacyKey := regexp.MustCompile(`RobotEventSeqKey|"robotEventSeq:|robotEventSeq:%s`)
 
 	shouldMatch := []string{
 		`seq, err := ctx.GenSeq(fmt.Sprintf("%s%s", common.RobotEventSeqKey, robotID))`,
 		`seq, err := rb.ctx.GenSeq(fmt.Sprintf("%s%s", common.RobotEventSeqKey, robotID))`,
 		`v, _ := c.GenSeq("robotEventSeq:" + id)`,
+		// The two shapes the previous line-anchored pattern walked past (P2-5).
+		`	key := common.RobotEventSeqKey + robotID`,
+		`		common.RobotEventSeqKey + robotID,`,
 	}
 	for _, s := range shouldMatch {
-		if !legacyAlloc.MatchString(s) {
+		if !legacyKey.MatchString(s) {
 			t.Fatalf("guard would not catch a reintroduction: %s", s)
 		}
 	}
@@ -121,9 +142,10 @@ func TestGenSeqGuardWouldCatchAReintroduction(t *testing.T) {
 		`version, err := m.ctx.GenSeq(common.RemindersKey)`,
 		`version, err := co.ctx.GenSeq(common.SyncConversationExtraKey)`,
 		`seq, err := botevent.NextEventID(ctx, robotID)`,
+		`key := botevent.QueueKey(robotID)`,
 	}
 	for _, s := range shouldNotMatch {
-		if legacyAlloc.MatchString(s) {
+		if legacyKey.MatchString(s) {
 			t.Fatalf("guard is too broad, it matched: %s", s)
 		}
 	}

--- a/pkg/botevent/genseq_guard_test.go
+++ b/pkg/botevent/genseq_guard_test.go
@@ -30,6 +30,12 @@ func TestNoGenSeqForBotEventIDs(t *testing.T) {
 	// prefix it holds. A caller that inlined the string still counts.
 	legacyAlloc := regexp.MustCompile(`GenSeq\([^)]*(RobotEventSeqKey|"robotEventSeq:)`)
 
+	// pkg/botevent/seq.go is the single allowlisted GenSeq call site, the same
+	// shape internal/msgextraseq uses: the allocator delegates to GenSeq while it
+	// is not activated, so a deployment behaves exactly like the old binary until
+	// an operator flips the mode. Every OTHER caller is a second live id source.
+	const allowlisted = "pkg/botevent/seq.go"
+
 	var violations []string
 	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, walkErr error) error {
 		if walkErr != nil {
@@ -47,13 +53,16 @@ func TestNoGenSeqForBotEventIDs(t *testing.T) {
 		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
 			return nil
 		}
+		rel, _ := filepath.Rel(root, path)
+		if filepath.ToSlash(rel) == allowlisted {
+			return nil
+		}
 		content, readErr := os.ReadFile(path)
 		if readErr != nil {
 			return readErr
 		}
 		for i, line := range strings.Split(string(content), "\n") {
 			if legacyAlloc.MatchString(line) {
-				rel, _ := filepath.Rel(root, path)
 				violations = append(violations, rel+":"+itoaGuard(i+1))
 			}
 		}
@@ -61,6 +70,21 @@ func TestNoGenSeqForBotEventIDs(t *testing.T) {
 	})
 	if err != nil {
 		t.Fatalf("walk: %v", err)
+	}
+
+	// The allowlisted file must actually still contain the delegation. If it stops
+	// (say the legacy branch is deleted as "dead code"), pre-activation deployments
+	// silently lose the behaviour that makes them safe, and this guard would go
+	// green while protecting nothing.
+	allowed, readErr := os.ReadFile(filepath.Join(root, allowlisted))
+	if readErr != nil {
+		t.Fatalf("read allowlisted file: %v", readErr)
+	}
+	if !legacyAlloc.Match(allowed) {
+		t.Fatalf("%s no longer delegates to GenSeq. The pre-activation path is what makes "+
+			"deploying this change a no-op until an operator activates it; without it a "+
+			"deploy switches allocators while legacy replicas are still running, which is "+
+			"the mixed-source loss described in #697.", allowlisted)
 	}
 
 	if len(violations) > 0 {

--- a/pkg/botevent/main_test.go
+++ b/pkg/botevent/main_test.go
@@ -43,6 +43,12 @@ func TestMain(m *testing.M) {
 }
 
 // probeTestDependencies reports the first missing dependency, if any.
+//
+// It performs the same two CREATE TABLEs seqTestCtx does, because those are what actually
+// gate the tests: probing only `SELECT 1` and `PING` left the interesting failure — a
+// privilege or collation problem on the writes — skipping every integration test while
+// `go test` exited 0, which is the exact blind spot this TestMain was added to close
+// (review, fifth round).
 func probeTestDependencies() error {
 	mysqlAddr, redisAddr := testAddrs()
 
@@ -51,6 +57,12 @@ func probeTestDependencies() error {
 	ctx := config.NewContext(cfg)
 	if _, err := ctx.DB().Exec("SELECT 1"); err != nil {
 		return fmt.Errorf("no usable MySQL at %s: %w", mysqlAddr, err)
+	}
+	if _, err := ctx.DB().Exec(seqTableDDL); err != nil {
+		return fmt.Errorf("cannot create the `seq` table at %s: %w", mysqlAddr, err)
+	}
+	if _, err := ctx.DB().Exec(stateTableDDL); err != nil {
+		return fmt.Errorf("cannot create %s at %s: %w", stateTable, mysqlAddr, err)
 	}
 
 	client := rd.NewClient(&rd.Options{Addr: redisAddr})

--- a/pkg/botevent/main_test.go
+++ b/pkg/botevent/main_test.go
@@ -1,0 +1,62 @@
+package botevent
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	rd "github.com/go-redis/redis"
+)
+
+// This package's tests are almost all integration tests: the contract is about what
+// two concurrent processes and one exclusive cursor do to each other, and a fake would
+// only restate the code. So a missing MySQL or Redis has to be handled, and there are
+// exactly two right answers depending on where the tests run.
+//
+// Locally, skipping is the ergonomic answer — not everybody has both containers up to
+// change a comment.
+//
+// In CI it is the *wrong* answer, and quietly so (review P2-11). Every seqTestCtx call
+// site used to t.Skipf on an unusable dependency, so a credential change, a renamed
+// service or a dropped database would leave only the source guards running while
+// `go test` still exited 0. That is the same failure mode as the `botevent_test`
+// database an earlier revision of this package used: indistinguishable from passing,
+// on the tests that carry the whole safety argument.
+//
+// So the dependencies are probed once here, and CI (which sets CI=true, as GitHub
+// Actions does for every job) gets a hard failure naming what is missing.
+func TestMain(m *testing.M) {
+	if err := probeTestDependencies(); err != nil {
+		if os.Getenv("CI") != "" {
+			fmt.Fprintf(os.Stderr, "pkg/botevent: %v\n\n"+
+				"This package's integration tests carry the #697 safety argument (seeding above "+
+				"every ceiling, rollback detection, activation gating). Skipping them in CI would "+
+				"look exactly like passing, so this is a failure instead. Set OCTO_TEST_MYSQL_ADDR "+
+				"/ OCTO_TEST_REDIS_ADDR if the services are not on their default addresses.\n", err)
+			os.Exit(1)
+		}
+		fmt.Fprintf(os.Stderr, "pkg/botevent: %v — integration tests will skip (set CI=true to "+
+			"make this a failure)\n", err)
+	}
+	os.Exit(m.Run())
+}
+
+// probeTestDependencies reports the first missing dependency, if any.
+func probeTestDependencies() error {
+	mysqlAddr, redisAddr := testAddrs()
+
+	cfg := config.New()
+	cfg.DB.MySQLAddr = mysqlAddr
+	ctx := config.NewContext(cfg)
+	if _, err := ctx.DB().Exec("SELECT 1"); err != nil {
+		return fmt.Errorf("no usable MySQL at %s: %w", mysqlAddr, err)
+	}
+
+	client := rd.NewClient(&rd.Options{Addr: redisAddr})
+	defer func() { _ = client.Close() }()
+	if err := client.Ping().Err(); err != nil {
+		return fmt.Errorf("no usable Redis at %s: %w", redisAddr, err)
+	}
+	return nil
+}

--- a/pkg/botevent/mode.go
+++ b/pkg/botevent/mode.go
@@ -71,14 +71,13 @@ package botevent
 // only have happened after the authority said `incr`. So a cold process that sees
 // `legacy` alongside a live counter refuses instead of degrading — see legacyDelegate.
 //
-// One residual is accepted rather than claimed away: when the mirror is absent or invalid,
-// the authority is unreadable, and this bot has no counter yet (a new or idle bot), a cold
-// process has no evidence that the counter era began and delegates to GenSeq. Only
-// `OCTO_BOTEVENT_EXPECTED_MODE=incr` closes that, and the rollout arms it only after activation
-// is verified, so the window is open by design during the flip itself. This is broader than
-// "the mirror and counter were restored away": an authority outage plus a bot that has never
-// created its counter has the same evidence shape. The operator assertion closes it after the
-// flip and is documented as a required last step.
+// One residual is accepted rather than claimed away: any negative belief may delegate to
+// GenSeq when this bot has no counter yet. That includes an authority that is readable but has
+// regressed to legacy or missing, and an unreadable authority when the mirror does not claim
+// activation. In both cases a new or idle bot has no per-bot evidence that the counter era
+// began. Only `OCTO_BOTEVENT_EXPECTED_MODE=incr` closes that evidence gap, and the rollout arms
+// it only after activation is verified, so the window is open by design during the flip itself.
+// The operator assertion closes it after the flip and is documented as a required last step.
 //
 // # Why the mirror carries the epoch
 //
@@ -176,8 +175,9 @@ type modeResolution struct {
 	// per-bot, so an allocation for a bot that has never received an event still has no
 	// counter to object with. Since the delete's only benefit was suppressing the read
 	// storm, and the cooldown suppresses that too, the delete is gone entirely rather than
-	// conditioned. Nothing in the allocator writes this key now; only the operator tool
-	// does, which is the one place a human can see what they are overwriting.
+	// conditioned. Nothing on the allocator's legacy path writes this key now. The activated
+	// recovery path can rebuild it only after validating the authority and re-seeding the
+	// current bot; the operator tool is the only writer during the supervised cutover.
 	unauthorizedMirror string
 }
 
@@ -218,6 +218,13 @@ const (
 	authorityTimeout = 300 * time.Millisecond
 )
 
+// NegativeBeliefTTL is the longest interval for which an allocator may reuse a
+// pre-activation belief while the mode mirror is absent.
+//
+// The operator tool uses this bound in its cutover failure instructions: once the
+// authority has been flipped, a failed mirror write is not a successful activation.
+func NegativeBeliefTTL() time.Duration { return negativeBeliefTTL }
+
 var (
 	// activeBelief is read on the hottest producer path and written only by a
 	// resolution, so it is an atomic pointer rather than a mutex-guarded var. nil
@@ -232,8 +239,10 @@ var (
 	beliefNow = time.Now
 
 	// mirrorUnauthorized counts mirrors claiming an activation the authority denied.
-	// It self-heals to legacy, so without this metric a forged or stale mirror is
-	// invisible — no error, no failed enqueue, nothing to alert on.
+	// The allocator deliberately leaves the mirror intact: it cannot know whether the
+	// mirror or the authority regressed. Without this metric the conflict is invisible,
+	// and activation remains blocked until an operator diagnoses it and removes only a
+	// mirror proven to be unauthorized.
 	mirrorUnauthorized = newHealCounter("dmwork_bot_event_seq_mirror_unauthorized_total",
 		"Mode mirrors claiming an activation the DB authority did not confirm.")
 
@@ -498,7 +507,8 @@ func refreshAuthority(ctx *config.Context, mirrorClaimsIncr bool, mirror string,
 			// header for what does and what remains residual.
 			mirrorUnauthorized.inc()
 			unauthorizedWarn.warn("botevent: mode mirror claims activation but the authority does not; "+
-				"removing the stale mirror and allocating from the legacy allocator",
+				"leaving the conflicting mirror intact and allocating from the legacy allocator "+
+				"only when this bot has no counter evidence; operator diagnosis is required before activation",
 				zap.String("mirrorKey", ModeKey), zap.String("mirrorValue", mirror), zap.Error(err))
 			unauthorized = mirror
 		}

--- a/pkg/botevent/mode.go
+++ b/pkg/botevent/mode.go
@@ -132,19 +132,51 @@ type belief struct {
 	// both expire; the flag exists so the log says which one happened.
 	confirmed bool
 
-	// deniedMirror is the mirror value this belief was resolved against when that
-	// mirror claimed activation the authority did not confirm.
+	// repairFailedFor / repairFailedAt record a mirror value this process denied and then
+	// could not remove.
 	//
-	// Without it, a forged mirror sitting in Redis costs an authority read on **every**
-	// allocation, serialized behind beliefMu, inside a held msgSem slot — the same
-	// hazard class as the per-allocation read review P1-1 removed, and with no exit,
-	// because nothing rewrites or clears that key (review P1-C). Caching the denial
-	// keyed on the exact value denied keeps the guarantee that matters: a *different*
-	// mirror value, including a genuine activation, is still a conflict and still
-	// forces a read.
-	deniedMirror string
+	// The normal answer to a mirror claiming an unconfirmed activation is to delete it —
+	// see modeResolution.unauthorizedMirror. When that delete fails the key stays, so
+	// without a cooldown every subsequent allocation would read the authority again,
+	// serialized behind beliefMu inside a held msgSem slot: the storm review P1-C named.
+	//
+	// This is deliberately NOT the general "cache the denial" the previous revision had.
+	// That one keyed on the denied value with the full negativeBeliefTTL and could swallow
+	// the genuine activation, because `Activate` bumps epoch 0 → 1 and the tool then writes
+	// exactly the `incr:1` that may already have been sitting there forged (Jerry-Xin 🔴).
+	// Here the window is short, and it only applies while Redis is rejecting our writes —
+	// a state in which the counter's own INCR would be failing too.
+	repairFailedFor string
+	repairFailedAt  time.Time
 
 	resolvedAt time.Time
+}
+
+// modeResolution is what resolveMode answers with.
+type modeResolution struct {
+	decision modeDecision
+
+	// belief is what the caller must use for the gate: its mirrorValue() is the exact
+	// string the gate compares against, so a mirror that has drifted from the validated
+	// generation closes the gate rather than allocating.
+	belief *belief
+
+	// unauthorizedMirror is a mirror value the authority denied, for the caller to remove.
+	//
+	// Deleting it rather than caching the denial is the fix for the swallow described on
+	// belief.repairFailedFor, and it is the symmetric repair to the one the allocator
+	// already performs in the other direction: when the authority says activated and the
+	// mirror disagrees, the mirror is rebuilt. When the authority says legacy, the correct
+	// mirror state is *absent* — "absent" is defined to mean "consult the authority" — so
+	// removing a mirror the authority contradicts restores consistency rather than
+	// destroying information.
+	//
+	// The race is benign: if an operator activates between the authority read and this
+	// delete, a legitimate mirror is removed, every replica's next allocation consults the
+	// authority, finds it activated, and rebuilds it. One extra read each, no mixed source.
+	// `botevent-seq` also refuses to activate while an unauthorized mirror is present, so
+	// that interleaving needs the key to appear during the flip itself.
+	unauthorizedMirror string
 }
 
 // mirrorValue is the exact ModeKey value the gate must find for this belief.
@@ -161,6 +193,12 @@ const (
 	// pre-activation steady state costs well under one authority read per second per
 	// replica instead of one per allocation.
 	negativeBeliefTTL = 5 * time.Second
+
+	// repairCooldown bounds how long a mirror this process failed to remove is answered
+	// from the cached denial instead of re-reading the authority. See
+	// belief.repairFailedFor for why it exists and why it is much shorter than
+	// negativeBeliefTTL.
+	repairCooldown = time.Second
 
 	// authorityTimeout bounds every authority read.
 	//
@@ -290,8 +328,18 @@ func formatMirror(epoch uint64) string {
 //
 // Exported for the operator tool, which must write the same spelling the allocator
 // validates. A bare `incr` would be accepted as a *claim* and then force every replica
-// into an authority read on every allocation until one of them rewrote the key.
+// into an authority read on every allocation until one of them removed the key.
 func MirrorValue(epoch uint64) string { return formatMirror(epoch) }
+
+// ParseMirrorEpoch reports whether a raw ModeKey value claims activation, and for which
+// generation.
+//
+// Exported so the operator tool can recognise a mirror that claims activation the authority
+// has not granted, and refuse to flip while one is present.
+func ParseMirrorEpoch(v string) (uint64, bool) {
+	claims, epoch, _ := parseMirror(v)
+	return epoch, claims
+}
 
 // parseMirror reports whether a mirror value claims activation.
 //
@@ -331,22 +379,23 @@ func cutPrefix(s, prefix string) (string, bool) {
 // caller must use for the gate: its mirrorValue() is the exact string the gate
 // compares against, so a mirror that has drifted from the validated generation
 // closes the gate rather than allocating.
-func resolveMode(ctx *config.Context, mirror string) (modeDecision, *belief, error) {
+func resolveMode(ctx *config.Context, mirror string) (modeResolution, error) {
 	claims, _, _ := parseMirror(mirror)
 
 	if b := activeBelief.Load(); b != nil {
 		// Positive is terminal with respect to legacy.
 		if b.activated {
-			return decideCounter, b, nil
+			return modeResolution{decision: decideCounter, belief: b}, nil
 		}
-		if beliefNow().Sub(b.resolvedAt) < negativeBeliefTTL {
-			// Negative is trusted while the mirror agrees with it, and also when the
-			// mirror is the *same* value this belief already denied — otherwise a forged
-			// key sitting in Redis costs an authority read per allocation with no exit
-			// (review P1-C).
-			if !claims || (b.confirmed && b.deniedMirror == mirror) {
-				return decideLegacy, b, nil
-			}
+		if !claims && beliefNow().Sub(b.resolvedAt) < negativeBeliefTTL {
+			return modeResolution{decision: decideLegacy, belief: b}, nil
+		}
+		// A mirror claiming activation normally forces a read — that is what makes a flip
+		// propagate without waiting for the TTL. The one exception is a value this process
+		// already tried and failed to remove: re-reading per allocation then would be the
+		// serialized-read storm review P1-C named, with no exit. See repairCooldown.
+		if claims && mirror == b.repairFailedFor && beliefNow().Sub(b.repairFailedAt) < repairCooldown {
+			return modeResolution{decision: decideLegacy, belief: b}, nil
 		}
 	}
 	return refreshAuthority(ctx, claims, mirror, false)
@@ -366,7 +415,7 @@ func resolveMode(ctx *config.Context, mirror string) (modeDecision, *belief, err
 // caller that arrives after somebody else already did the read it wanted is served from
 // that result, so one lost mode key costs one authority read rather than one per in-flight
 // allocation (review P1-C).
-func refreshAuthority(ctx *config.Context, mirrorClaimsIncr bool, mirror string, force bool) (modeDecision, *belief, error) {
+func refreshAuthority(ctx *config.Context, mirrorClaimsIncr bool, mirror string, force bool) (modeResolution, error) {
 	seen := activeBelief.Load()
 	beliefMu.Lock()
 	defer beliefMu.Unlock()
@@ -375,21 +424,29 @@ func refreshAuthority(ctx *config.Context, mirrorClaimsIncr bool, mirror string,
 	// Double-check under the lock: a concurrent caller may already have paid for the
 	// answer this one was about to ask for.
 	if prior != nil && prior != seen {
-		// Somebody refreshed while this caller waited for the lock. That is the answer it
-		// came for, forced or not.
+		// Somebody refreshed while this caller waited for the lock. That is usually the
+		// answer this caller came for — but not when it observed a mirror claiming
+		// activation and the fresh belief is negative: that belief was resolved against a
+		// *different* mirror observation, so serving it here would delegate to GenSeq on
+		// evidence this caller has already contradicted (review P2-3). Fall through and
+		// read.
 		if prior.activated {
-			return decideCounter, prior, nil
+			return modeResolution{decision: decideCounter, belief: prior}, nil
 		}
-		return decideLegacy, prior, nil
+		if !mirrorClaimsIncr {
+			return modeResolution{decision: decideLegacy, belief: prior}, nil
+		}
 	}
 	if prior != nil && !force {
 		if prior.activated {
-			return decideCounter, prior, nil
+			return modeResolution{decision: decideCounter, belief: prior}, nil
 		}
-		if beliefNow().Sub(prior.resolvedAt) < negativeBeliefTTL {
-			if !mirrorClaimsIncr || (prior.confirmed && prior.deniedMirror == mirror) {
-				return decideLegacy, prior, nil
-			}
+		if !mirrorClaimsIncr && beliefNow().Sub(prior.resolvedAt) < negativeBeliefTTL {
+			return modeResolution{decision: decideLegacy, belief: prior}, nil
+		}
+		if mirrorClaimsIncr && mirror == prior.repairFailedFor &&
+			beliefNow().Sub(prior.repairFailedAt) < repairCooldown {
+			return modeResolution{decision: decideLegacy, belief: prior}, nil
 		}
 	}
 
@@ -397,9 +454,9 @@ func refreshAuthority(ctx *config.Context, mirrorClaimsIncr bool, mirror string,
 	switch {
 	case err == nil && st.Activated():
 		if err := assertExpectedMode(true); err != nil {
-			return decideLegacy, nil, err
+			return modeResolution{}, err
 		}
-		return install(&belief{activated: true, epoch: st.Epoch, confirmed: true, resolvedAt: beliefNow()})
+		return install(&belief{activated: true, epoch: st.Epoch, confirmed: true, resolvedAt: beliefNow()}, "")
 
 	case err == nil, errors.Is(err, ErrStateMissing):
 		// The authority says legacy, or says nothing because the migration has not
@@ -410,11 +467,12 @@ func refreshAuthority(ctx *config.Context, mirrorClaimsIncr bool, mirror string,
 			// Asserted rather than assumed: the consequence of getting it wrong is a
 			// permanently invisible event, and this is the exact shape a migration
 			// rollback produces (review P1-4).
-			return decideLegacy, nil, fmt.Errorf("botevent: the authority now says the allocator "+
+			return modeResolution{}, fmt.Errorf("botevent: the authority now says the allocator "+
 				"is not activated (epoch %d, %v), but this process has already issued counter ids; "+
 				"refusing to downgrade to the legacy allocator, whose ids would land below live "+
 				"consumer cursors", prior.epoch, err)
 		}
+		unauthorized := ""
 		if mirrorClaimsIncr {
 			// A mirror claiming an activation the authority denies. Legacy is what the
 			// authority says, so that is the answer — but somebody wrote that key, and
@@ -423,51 +481,74 @@ func refreshAuthority(ctx *config.Context, mirrorClaimsIncr bool, mirror string,
 			// header for what does and what remains residual.
 			mirrorUnauthorized.inc()
 			unauthorizedWarn.warn("botevent: mode mirror claims activation but the authority does not; "+
-				"ignoring the mirror and allocating from the legacy allocator",
-				zap.String("mirrorKey", ModeKey), zap.Error(err))
+				"removing the stale mirror and allocating from the legacy allocator",
+				zap.String("mirrorKey", ModeKey), zap.String("mirrorValue", mirror), zap.Error(err))
+			unauthorized = mirror
 		}
 		if err := assertExpectedMode(false); err != nil {
-			return decideLegacy, nil, err
+			return modeResolution{}, err
 		}
-		// deniedMirror records which value was denied, so the next allocation seeing the
-		// same forged key is served from this belief instead of paying for another read.
-		denied := ""
-		if mirrorClaimsIncr {
-			denied = mirror
-		}
-		return install(&belief{confirmed: true, deniedMirror: denied, resolvedAt: beliefNow()})
+		return install(&belief{confirmed: true, resolvedAt: beliefNow()}, unauthorized)
 
 	default:
 		// Inconclusive.
 		authorityUnreadable.inc()
 		if prior != nil && prior.activated {
-			return decideLegacy, nil, fmt.Errorf("botevent: the authority is unreadable (%w) and this "+
+			return modeResolution{}, fmt.Errorf("botevent: the authority is unreadable (%w) and this "+
 				"process has already issued counter ids; refusing to downgrade to the legacy allocator", err)
 		}
 		if mirrorClaimsIncr {
-			return decideLegacy, nil, fmt.Errorf("botevent: the mode mirror claims activation but the "+
+			return modeResolution{}, fmt.Errorf("botevent: the mode mirror claims activation but the "+
 				"authority is unreadable (%w); refusing to allocate — the counter cannot be trusted "+
 				"unconfirmed, and legacy would issue ids below live cursors if the claim is true", err)
 		}
 		if guardErr := assertExpectedMode(false); guardErr != nil {
-			return decideLegacy, nil, guardErr
+			return modeResolution{}, guardErr
 		}
 		unreadableWarn.warn("botevent: allocator authority unreadable; treating as not activated",
 			zap.Error(err))
 		// Cache the inconclusive answer too. During a DB outage the alternative is one
 		// failed read per allocation on the fan-out path, which is the cost this cache
 		// exists to remove.
-		return install(&belief{resolvedAt: beliefNow()})
+		return install(&belief{resolvedAt: beliefNow()}, "")
 	}
 }
 
-// install stores a belief and returns the matching decision.
-func install(b *belief) (modeDecision, *belief, error) {
+// install stores a belief and returns the matching resolution.
+//
+// unauthorizedMirror is passed through to the caller rather than acted on here: repairing
+// it is a Redis write and this file deliberately does no Redis I/O — the allocator holds
+// the client.
+func install(b *belief, unauthorizedMirror string) (modeResolution, error) {
 	activeBelief.Store(b)
+	res := modeResolution{belief: b, unauthorizedMirror: unauthorizedMirror}
 	if b.activated {
-		return decideCounter, b, nil
+		res.decision = decideCounter
+		return res, nil
 	}
-	return decideLegacy, b, nil
+	res.decision = decideLegacy
+	return res, nil
+}
+
+// noteMirrorRepairFailed records that an unauthorized mirror could not be removed, so the
+// next allocations are answered from the cached denial for repairCooldown rather than
+// re-reading the authority each time. See belief.repairFailedFor.
+//
+// Copy-on-write like every other belief update: the pointer is swapped, never mutated, so
+// a reader on the hot path cannot see a half-updated belief.
+func noteMirrorRepairFailed(denied string) {
+	beliefMu.Lock()
+	defer beliefMu.Unlock()
+	cur := activeBelief.Load()
+	if cur == nil || cur.activated {
+		// Nothing to cool down: an activated belief does not consult the mirror claim at
+		// all, and with no belief the next allocation reads the authority anyway.
+		return
+	}
+	updated := *cur
+	updated.repairFailedFor = denied
+	updated.repairFailedAt = beliefNow()
+	activeBelief.Store(&updated)
 }
 
 // readStateDeadlined reads the authority under authorityTimeout.

--- a/pkg/botevent/mode.go
+++ b/pkg/botevent/mode.go
@@ -1,0 +1,437 @@
+package botevent
+
+// #697: which allocator this process may use, and how it decides.
+//
+// # The invariant, in one line
+//
+//	The authority decides. The mirror can only shortcut, never override.
+//
+// # Why this file exists (review P1-1, P1-2, P1-4)
+//
+// An earlier revision spread that decision across three call sites and got three
+// different answers out of it:
+//
+//   - The hot path trusted a positive mirror outright and never read the authority,
+//     so a stray `SET botEventSeq:mode incr` performed the activation the operator
+//     tool exists to gate: floor validation, "no pre-fix replica remains" and the
+//     `-yes` confirmation all bypassed, on every replica at once. (P1-2)
+//   - The pre-activation path read the authority on *every* allocation, inside a
+//     held msgSem slot, so "merging is behaviour-neutral" was false — it delegated
+//     to GenSeq after a synchronous DB round trip. (P1-1)
+//   - The mirror-missing path would return a GenSeq id even for a bot this process
+//     had already issued counter ids for, i.e. an event deliberately placed below a
+//     cursor a client demonstrably holds. (P1-4)
+//
+// All three are one missing thing: no single stateful entry point for "is the
+// counter activated". This is it.
+//
+// # The cache is asymmetric, and the asymmetry is the design
+//
+// D2 in the task brief says the mode must not be cached per process, because one
+// replica running on a stale `legacy` while another runs on `incr` is two live id
+// sources — the defect itself. That reasoning stands, and what it forbids is
+// *deciding the gate from a cache*: the gate still reads the uncached mirror inside
+// the same Lua script as the INCR, so a flip still takes effect on the next
+// allocation everywhere. What is cached here is the *authority behind* the mirror,
+// under two deliberately different rules:
+//
+//   - A **positive** belief (activated) is terminal with respect to legacy. Once
+//     this process has resolved `incr` it may refresh the epoch upward, but it can
+//     never decide `legacy` again — not on a DB error, not on a rolled-back row, not
+//     on a dropped table. That is what makes P1-4 unreachable rather than merely
+//     unlikely: the branch that returned a low GenSeq id after the counter era began
+//     is gone, not guarded.
+//   - A **negative** belief (not activated) is trusted only while the mirror agrees
+//     with it. A mirror claiming `incr` against a cached `legacy` is a **conflict**,
+//     and a conflict forces a fresh authority read. This is what preserves D2's
+//     property: propagation of the flip never waits for a TTL, because the first
+//     allocation that sees the new mirror re-reads the authority. The TTL only bounds
+//     the case where the operator's mirror write failed — the tool warns when it
+//     does — and even then every replica converges within one interval.
+//
+// A *confirmed* conflict (mirror says `incr`, authority says `legacy`) is a forged
+// mirror. The answer is `legacy`, loudly, and it does not split the fleet: every
+// replica reads the same authority row and reaches the same conclusion, so
+// consistency comes from the authority rather than from the mirror. That sentence is
+// what the previous revision was missing, and it is why trusting the authority over
+// the mirror is safe where trusting a cache would not be.
+//
+// # Why the mirror carries the epoch
+//
+// The mirror value is `incr:{epoch}`, not a bare `incr`, and the gate compares it
+// against the exact string this process validated against the authority. So a
+// hand-written `SET botEventSeq:mode incr` cannot open the gate even for a single
+// allocation: carrying no generation, all it can do is force an authority read. This
+// is the mechanism `octo_bot_event_seq_state.epoch` was documented as having and did
+// not have. A bare `incr` is still accepted as a *claim* ("something says activated,
+// go confirm it"), which is what lets a mirror written by an older build heal rather
+// than wedge.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"go.uber.org/zap"
+)
+
+// modeDecision is what an allocation may do about the mode.
+type modeDecision int
+
+const (
+	// decideLegacy delegates to GenSeq — the pre-activation state, not a fallback.
+	decideLegacy modeDecision = iota
+
+	// decideCounter allocates from the monotonic Redis counter.
+	decideCounter
+)
+
+// belief is this process's resolved view of the authority.
+//
+// Immutable once stored: refreshing replaces the pointer rather than mutating in
+// place, so a reader on the hot path never sees a half-updated belief and needs no
+// lock.
+type belief struct {
+	activated bool
+
+	// epoch is the authority's generation. Meaningful only when activated.
+	epoch uint64
+
+	// confirmed distinguishes "the authority said legacy" from "the authority could
+	// not be read and legacy is what we do about it". Both behave identically and
+	// both expire; the flag exists so the log says which one happened.
+	confirmed bool
+
+	resolvedAt time.Time
+}
+
+// mirrorValue is the exact ModeKey value the gate must find for this belief.
+func (b *belief) mirrorValue() string { return formatMirror(b.epoch) }
+
+const (
+	// negativeBeliefTTL bounds how long a "not activated" answer is reused.
+	//
+	// This is NOT how long a flip takes to propagate — a mirror claiming activation
+	// forces a fresh read regardless of this TTL (see the conflict rule above). It
+	// bounds only the case where the authority is already flipped and the mirror is
+	// not: the operator tool's mirror write failed, or the key was lost afterwards.
+	// Short enough that such a window closes on its own, long enough that the
+	// pre-activation steady state costs well under one authority read per second per
+	// replica instead of one per allocation.
+	negativeBeliefTTL = 5 * time.Second
+
+	// authorityTimeout bounds every authority read.
+	//
+	// Explicit rather than inherited: the default MySQL DSN sets no
+	// readTimeout/writeTimeout (octo-lib config), and this read happens inside a held
+	// msgSem slot, where an unbounded wait stalls message fan-out for every bot in the
+	// process. Failing the read is recoverable — a stale negative belief costs one
+	// interval, and a positive belief cannot be downgraded by a failed read at all.
+	authorityTimeout = 300 * time.Millisecond
+)
+
+var (
+	// activeBelief is read on the hottest producer path and written only by a
+	// resolution, so it is an atomic pointer rather than a mutex-guarded var. nil
+	// means "never resolved".
+	activeBelief atomic.Pointer[belief]
+
+	// beliefMu single-flights authority reads: without it, a cold start under load
+	// sends one SELECT per concurrent allocation for an answer they all share.
+	beliefMu sync.Mutex
+
+	// beliefNow is time.Now, indirected so a test can age a belief without sleeping.
+	beliefNow = time.Now
+
+	// mirrorUnauthorized counts mirrors claiming an activation the authority denied.
+	// It self-heals to legacy, so without this metric a forged or stale mirror is
+	// invisible — no error, no failed enqueue, nothing to alert on.
+	mirrorUnauthorized = newHealCounter("dmwork_bot_event_seq_mirror_unauthorized_total",
+		"Mode mirrors claiming an activation the DB authority did not confirm.")
+
+	// authorityUnreadable counts authority reads that failed. Pre-activation this is
+	// benign (legacy is what a pre-migration deploy does anyway); post-activation a
+	// positive belief means it changes nothing. Either way a rising count means the
+	// allocator is deciding on stale information.
+	authorityUnreadable = newHealCounter("dmwork_bot_event_seq_authority_unreadable_total",
+		"Authority reads that failed, leaving the allocator mode unconfirmed.")
+
+	unauthorizedWarn = &throttledWarn{every: time.Minute}
+	unreadableWarn   = &throttledWarn{every: time.Minute}
+
+	// authorityReads counts authority reads, successful or not.
+	//
+	// Not a Prometheus counter: its value is in the *shape* of the I/O, which is a
+	// property tests assert and an incident responder reads once ("is this fleet
+	// querying the state table per allocation?"), not a time series worth a metric
+	// name. The pre-activation path is supposed to issue one of these per process per
+	// negativeBeliefTTL — one per allocation was the regression at review P1-1, and
+	// nothing in the suite could see it, because the other pre-activation test asserts
+	// the id's shape rather than the I/O's.
+	authorityReads atomic.Int64
+)
+
+// AuthorityReads reports how many times the authoritative state row has been read.
+func AuthorityReads() int64 { return authorityReads.Load() }
+
+// MirrorUnauthorized reports mirrors that claimed an unconfirmed activation.
+func MirrorUnauthorized() int64 { return mirrorUnauthorized.load() }
+
+// AuthorityUnreadable reports authority reads that failed.
+func AuthorityUnreadable() int64 { return authorityUnreadable.load() }
+
+// The expected-mode deployment guard, parsed once.
+//
+// Same shape as #627's internal/msgextraseq: unset means no assertion, and a
+// *malformed* value fails closed instead of silently disabling the guard. The
+// previous revision compared a free-form env string against ModeIncr, so
+// `OCTO_BOTEVENT_EXPECTED_MODE=inrc` was indistinguishable from unset — a typo
+// disarming the one guard that exists to stop a silent downgrade (review P1-4).
+var (
+	expectedModeSet       bool
+	expectedModeIncr      bool
+	expectedModeMalformed bool
+)
+
+func init() { loadExpectedMode(os.Getenv(ExpectedModeEnv)) }
+
+func loadExpectedMode(raw string) {
+	expectedModeSet, expectedModeIncr, expectedModeMalformed = false, false, false
+	switch strings.TrimSpace(raw) {
+	case "":
+	case ModeLegacy:
+		expectedModeSet = true
+	case ModeIncr:
+		expectedModeSet, expectedModeIncr = true, true
+	default:
+		expectedModeSet, expectedModeMalformed = true, true
+	}
+}
+
+// assertExpectedMode enforces the optional deployment guard against a resolved mode.
+func assertExpectedMode(activated bool) error {
+	if !expectedModeSet {
+		return nil
+	}
+	if expectedModeMalformed {
+		return fmt.Errorf("botevent: %s is set to an unrecognised value; refusing to allocate "+
+			"rather than run with a guard that silently does nothing (want %q or %q)",
+			ExpectedModeEnv, ModeLegacy, ModeIncr)
+	}
+	if expectedModeIncr && !activated {
+		return fmt.Errorf("botevent: %s=%s but the authority says the allocator is not activated; "+
+			"refusing to fall back to the legacy allocator, whose lower ids would land below "+
+			"live consumer cursors", ExpectedModeEnv, ModeIncr)
+	}
+	if !expectedModeIncr && activated {
+		return fmt.Errorf("botevent: %s=%s but the authority says the allocator is activated; "+
+			"refusing to allocate from a mode this replica was not deployed for",
+			ExpectedModeEnv, ModeLegacy)
+	}
+	return nil
+}
+
+// formatMirror renders the mirror value for an epoch.
+func formatMirror(epoch uint64) string {
+	return ModeIncr + ":" + strconv.FormatUint(epoch, 10)
+}
+
+// MirrorValue is the exact ModeKey value that activates the given generation.
+//
+// Exported for the operator tool, which must write the same spelling the allocator
+// validates. A bare `incr` would be accepted as a *claim* and then force every replica
+// into an authority read on every allocation until one of them rewrote the key.
+func MirrorValue(epoch uint64) string { return formatMirror(epoch) }
+
+// parseMirror reports whether a mirror value claims activation.
+//
+// A bare `incr` claims activation without naming a generation, so it can never match
+// a validated mirror value and can only ever force an authority read. A malformed
+// suffix is not a claim at all: there is nothing to confirm, and treating it as one
+// would turn a corrupt key into an authority read per allocation.
+func parseMirror(v string) (claimsIncr bool, epoch uint64, hasEpoch bool) {
+	v = strings.TrimSpace(v)
+	if v == ModeIncr {
+		return true, 0, false
+	}
+	rest, ok := cutPrefix(v, ModeIncr+":")
+	if !ok {
+		return false, 0, false
+	}
+	parsed, err := strconv.ParseUint(rest, 10, 64)
+	if err != nil {
+		return false, 0, false
+	}
+	return true, parsed, true
+}
+
+// cutPrefix is strings.CutPrefix, spelled out to keep this file's Go version
+// requirement the same as the rest of the package.
+func cutPrefix(s, prefix string) (string, bool) {
+	if !strings.HasPrefix(s, prefix) {
+		return "", false
+	}
+	return s[len(prefix):], true
+}
+
+// resolveMode decides which allocator this allocation may use, given what the
+// uncached mirror says right now.
+//
+// mirror is the raw ModeKey value ("" when absent). The returned belief is what the
+// caller must use for the gate: its mirrorValue() is the exact string the gate
+// compares against, so a mirror that has drifted from the validated generation
+// closes the gate rather than allocating.
+func resolveMode(ctx *config.Context, mirror string) (modeDecision, *belief, error) {
+	claims, _, _ := parseMirror(mirror)
+
+	if b := activeBelief.Load(); b != nil {
+		// Positive is terminal with respect to legacy.
+		if b.activated {
+			return decideCounter, b, nil
+		}
+		// Negative is trusted only while the mirror agrees.
+		if !claims && beliefNow().Sub(b.resolvedAt) < negativeBeliefTTL {
+			return decideLegacy, b, nil
+		}
+	}
+	return refreshAuthority(ctx, claims, false)
+}
+
+// refreshAuthority reads the authority and installs the resulting belief.
+//
+// mirrorClaimsIncr changes only how an *inconclusive* read is handled: with a mirror
+// claiming activation, "unreadable" must not become "legacy", because legacy after
+// activation issues ids below live cursors. Without one, unreadable means the same
+// thing a pre-migration deploy means, and legacy is the honest answer.
+//
+// force skips the cached-answer short circuits, including the positive one. It is for
+// the gate-closed path, where the whole point is that something changed the mirror
+// underneath a belief this process was already acting on: serving that caller from the
+// belief it is trying to re-verify would spin.
+func refreshAuthority(ctx *config.Context, mirrorClaimsIncr, force bool) (modeDecision, *belief, error) {
+	beliefMu.Lock()
+	defer beliefMu.Unlock()
+
+	prior := activeBelief.Load()
+	// Double-check under the lock: a concurrent caller may already have paid for the
+	// answer this one was about to ask for.
+	if prior != nil && !force {
+		if prior.activated {
+			return decideCounter, prior, nil
+		}
+		if !mirrorClaimsIncr && beliefNow().Sub(prior.resolvedAt) < negativeBeliefTTL {
+			return decideLegacy, prior, nil
+		}
+	}
+
+	st, err := readStateDeadlined(ctx)
+	switch {
+	case err == nil && st.Activated():
+		if err := assertExpectedMode(true); err != nil {
+			return decideLegacy, nil, err
+		}
+		return install(&belief{activated: true, epoch: st.Epoch, confirmed: true, resolvedAt: beliefNow()})
+
+	case err == nil, errors.Is(err, ErrStateMissing):
+		// The authority says legacy, or says nothing because the migration has not
+		// run — which is what legacy looks like before the migration.
+		if prior != nil && prior.activated {
+			// Unreachable through resolveMode, which returns early on a positive
+			// belief; reachable from the gate-closed path, which forces a read.
+			// Asserted rather than assumed: the consequence of getting it wrong is a
+			// permanently invisible event, and this is the exact shape a migration
+			// rollback produces (review P1-4).
+			return decideLegacy, nil, fmt.Errorf("botevent: the authority now says the allocator "+
+				"is not activated (epoch %d, %v), but this process has already issued counter ids; "+
+				"refusing to downgrade to the legacy allocator, whose ids would land below live "+
+				"consumer cursors", prior.epoch, err)
+		}
+		if mirrorClaimsIncr {
+			// A mirror claiming an activation the authority denies. Legacy is correct
+			// and is what every replica concludes from the same row, so this does not
+			// split the fleet — but somebody wrote that key, and nothing else about
+			// this is visible from outside.
+			mirrorUnauthorized.inc()
+			unauthorizedWarn.warn("botevent: mode mirror claims activation but the authority does not; "+
+				"ignoring the mirror and allocating from the legacy allocator",
+				zap.String("mirrorKey", ModeKey), zap.Error(err))
+		}
+		if err := assertExpectedMode(false); err != nil {
+			return decideLegacy, nil, err
+		}
+		return install(&belief{confirmed: true, resolvedAt: beliefNow()})
+
+	default:
+		// Inconclusive.
+		authorityUnreadable.inc()
+		if prior != nil && prior.activated {
+			return decideLegacy, nil, fmt.Errorf("botevent: the authority is unreadable (%w) and this "+
+				"process has already issued counter ids; refusing to downgrade to the legacy allocator", err)
+		}
+		if mirrorClaimsIncr {
+			return decideLegacy, nil, fmt.Errorf("botevent: the mode mirror claims activation but the "+
+				"authority is unreadable (%w); refusing to allocate — the counter cannot be trusted "+
+				"unconfirmed, and legacy would issue ids below live cursors if the claim is true", err)
+		}
+		if guardErr := assertExpectedMode(false); guardErr != nil {
+			return decideLegacy, nil, guardErr
+		}
+		unreadableWarn.warn("botevent: allocator authority unreadable; treating as not activated",
+			zap.Error(err))
+		// Cache the inconclusive answer too. During a DB outage the alternative is one
+		// failed read per allocation on the fan-out path, which is the cost this cache
+		// exists to remove.
+		return install(&belief{resolvedAt: beliefNow()})
+	}
+}
+
+// install stores a belief and returns the matching decision.
+func install(b *belief) (modeDecision, *belief, error) {
+	activeBelief.Store(b)
+	if b.activated {
+		return decideCounter, b, nil
+	}
+	return decideLegacy, b, nil
+}
+
+// readStateDeadlined reads the authority under authorityTimeout.
+func readStateDeadlined(ctx *config.Context) (State, error) {
+	authorityReads.Add(1)
+	dl, cancel := context.WithTimeout(context.Background(), authorityTimeout)
+	defer cancel()
+	return ReadStateContext(dl, ctx)
+}
+
+// ResetModeBeliefForTest clears the cached authority belief.
+func ResetModeBeliefForTest() {
+	activeBelief.Store(nil)
+	mirrorUnauthorized.resetForTest()
+	authorityUnreadable.resetForTest()
+}
+
+// AgeModeBeliefForTest ages the cached belief past negativeBeliefTTL without
+// sleeping, so a test can prove the negative cache expires rather than persists.
+func AgeModeBeliefForTest() {
+	if b := activeBelief.Load(); b != nil {
+		aged := *b
+		aged.resolvedAt = b.resolvedAt.Add(-2 * negativeBeliefTTL)
+		activeBelief.Store(&aged)
+	}
+}
+
+// SetExpectedModeForTest overrides the env-derived expectation and returns a restore
+// function. Takes the raw env spelling so a test can exercise a malformed value.
+func SetExpectedModeForTest(raw string) func() {
+	prevSet, prevIncr, prevMalformed := expectedModeSet, expectedModeIncr, expectedModeMalformed
+	loadExpectedMode(raw)
+	return func() {
+		expectedModeSet, expectedModeIncr, expectedModeMalformed = prevSet, prevIncr, prevMalformed
+	}
+}

--- a/pkg/botevent/mode.go
+++ b/pkg/botevent/mode.go
@@ -127,6 +127,12 @@ type belief struct {
 	// epoch is the authority's generation. Meaningful only when activated.
 	epoch uint64
 
+	// cutoverFloor is the global floor validated in the same authoritative read as
+	// activated/epoch. It must travel with the positive belief: re-reading the state row
+	// during a later per-bot seed and treating an error as zero discards the activation
+	// proof and can restart a new counter below live cursors.
+	cutoverFloor int64
+
 	// deniedMirror / deniedAt record a mirror value the authority explicitly denied, so
 	// the next allocations that see the same value are answered from this belief for a
 	// short cooldown instead of re-reading the authority each time.
@@ -409,11 +415,30 @@ func cutPrefix(s, prefix string) (string, bool) {
 // compares against, so a mirror that has drifted from the validated generation
 // closes the gate rather than allocating.
 func resolveMode(ctx *config.Context, mirror string) (modeResolution, error) {
-	claims, _, _ := parseMirror(mirror)
+	claims, mirrorEpoch, hasEpoch := parseMirror(mirror)
 
 	if b := activeBelief.Load(); b != nil {
 		// Positive is terminal with respect to legacy.
 		if b.activated {
+			// Positive is not terminal with respect to a newer generation. An old
+			// process must refresh before it considers rebuilding the mirror, otherwise
+			// it can overwrite a legitimate incr:N+1 with its cached incr:N.
+			if claims && hasEpoch && mirrorEpoch > b.epoch {
+				res, err := refreshAuthority(ctx, true, mirror, true)
+				if err != nil {
+					return modeResolution{}, err
+				}
+				confirmedEpoch := uint64(0)
+				if res.belief != nil {
+					confirmedEpoch = res.belief.epoch
+				}
+				if res.belief == nil || !res.belief.activated || confirmedEpoch < mirrorEpoch {
+					return modeResolution{}, fmt.Errorf("botevent: mode mirror claims newer epoch %d but "+
+						"the authority only confirmed epoch %d; refusing to overwrite the newer mirror",
+						mirrorEpoch, confirmedEpoch)
+				}
+				return res, nil
+			}
 			return resolutionFromBelief(b, "")
 		}
 		if !claims && beliefNow().Sub(b.resolvedAt) < negativeBeliefTTL {
@@ -482,7 +507,12 @@ func refreshAuthority(ctx *config.Context, mirrorClaimsIncr bool, mirror string,
 	st, err := readStateDeadlined(ctx)
 	switch {
 	case err == nil && st.Activated():
-		return install(&belief{activated: true, epoch: st.Epoch, resolvedAt: beliefNow()}, "")
+		return install(&belief{
+			activated:    true,
+			epoch:        st.Epoch,
+			cutoverFloor: st.CutoverFloor,
+			resolvedAt:   beliefNow(),
+		}, "")
 
 	case err == nil, errors.Is(err, ErrStateMissing):
 		// The authority says legacy, or says nothing because the migration has not

--- a/pkg/botevent/mode.go
+++ b/pkg/botevent/mode.go
@@ -50,11 +50,34 @@ package botevent
 //     does — and even then every replica converges within one interval.
 //
 // A *confirmed* conflict (mirror says `incr`, authority says `legacy`) is a forged
-// mirror. The answer is `legacy`, loudly, and it does not split the fleet: every
-// replica reads the same authority row and reaches the same conclusion, so
-// consistency comes from the authority rather than from the mirror. That sentence is
-// what the previous revision was missing, and it is why trusting the authority over
-// the mirror is safe where trusting a cache would not be.
+// mirror, and the answer is `legacy`, loudly.
+//
+// # What that does NOT mean (review P1-A)
+//
+// An earlier revision of this comment said it "does not split the fleet: every replica
+// reads the same authority row and reaches the same conclusion". That is not what the
+// code does, and the difference mattered because the claim was load-bearing. A replica
+// with a positive belief returns from resolveMode without reading the authority again,
+// and with an intact mirror the gate never closes, so nothing forces it to. So if the
+// authority itself regresses *after* activation — a restore from before the migration, a
+// manual `UPDATE … SET mode=0`, the table dropped outside sql-migrate — the fleet does
+// split: replicas already running keep allocating from the counter, while a replica that
+// starts afterwards reads `legacy` and would delegate to GenSeq. Two live id sources on
+// one queue, which is #697.
+//
+// That path is now closed, with no DB read and without depending on the env guard: the
+// same round trip that reads the mirror also reports whether this bot's counter key
+// exists, and a counter exists only because some replica allocated from it, which can
+// only have happened after the authority said `incr`. So a cold process that sees
+// `legacy` alongside a live counter refuses instead of degrading — see legacyDelegate.
+//
+// One residual is accepted rather than claimed away: if the counter key is gone **as
+// well** — a Redis flush or restore correlated with a regressed authority — a cold
+// process has no evidence at all and delegates to GenSeq. Only
+// `OCTO_BOTEVENT_EXPECTED_MODE=incr` closes that, and the rollout arms it only after
+// activation is verified, so the window is open by design during the flip itself. It is a
+// residual rather than a defect because both halves of the evidence have to be lost at
+// once, and the operator step that closes it exists and is documented.
 //
 // # Why the mirror carries the epoch
 //
@@ -108,6 +131,18 @@ type belief struct {
 	// not be read and legacy is what we do about it". Both behave identically and
 	// both expire; the flag exists so the log says which one happened.
 	confirmed bool
+
+	// deniedMirror is the mirror value this belief was resolved against when that
+	// mirror claimed activation the authority did not confirm.
+	//
+	// Without it, a forged mirror sitting in Redis costs an authority read on **every**
+	// allocation, serialized behind beliefMu, inside a held msgSem slot — the same
+	// hazard class as the per-allocation read review P1-1 removed, and with no exit,
+	// because nothing rewrites or clears that key (review P1-C). Caching the denial
+	// keyed on the exact value denied keeps the guarantee that matters: a *different*
+	// mirror value, including a genuine activation, is still a conflict and still
+	// forces a read.
+	deniedMirror string
 
 	resolvedAt time.Time
 }
@@ -194,43 +229,51 @@ func AuthorityUnreadable() int64 { return authorityUnreadable.load() }
 // previous revision compared a free-form env string against ModeIncr, so
 // `OCTO_BOTEVENT_EXPECTED_MODE=inrc` was indistinguishable from unset — a typo
 // disarming the one guard that exists to stop a silent downgrade (review P1-4).
-var (
-	expectedModeSet       bool
-	expectedModeIncr      bool
-	expectedModeMalformed bool
-)
+//
+// Held behind an atomic pointer rather than three package vars because the test hook
+// rewrites it while production code reads it. Both current call sites are
+// single-goroutine so `-race` was clean, but combining the hook with the concurrency
+// test would not be, and "clean today" is not a property worth relying on (review P2-3).
+type expectedModeGuard struct {
+	set       bool
+	incr      bool
+	malformed bool
+}
 
-func init() { loadExpectedMode(os.Getenv(ExpectedModeEnv)) }
+var expectedMode atomic.Pointer[expectedModeGuard]
 
-func loadExpectedMode(raw string) {
-	expectedModeSet, expectedModeIncr, expectedModeMalformed = false, false, false
+func init() { expectedMode.Store(parseExpectedMode(os.Getenv(ExpectedModeEnv))) }
+
+func parseExpectedMode(raw string) *expectedModeGuard {
 	switch strings.TrimSpace(raw) {
 	case "":
+		return &expectedModeGuard{}
 	case ModeLegacy:
-		expectedModeSet = true
+		return &expectedModeGuard{set: true}
 	case ModeIncr:
-		expectedModeSet, expectedModeIncr = true, true
+		return &expectedModeGuard{set: true, incr: true}
 	default:
-		expectedModeSet, expectedModeMalformed = true, true
+		return &expectedModeGuard{set: true, malformed: true}
 	}
 }
 
 // assertExpectedMode enforces the optional deployment guard against a resolved mode.
 func assertExpectedMode(activated bool) error {
-	if !expectedModeSet {
+	g := expectedMode.Load()
+	if g == nil || !g.set {
 		return nil
 	}
-	if expectedModeMalformed {
+	if g.malformed {
 		return fmt.Errorf("botevent: %s is set to an unrecognised value; refusing to allocate "+
 			"rather than run with a guard that silently does nothing (want %q or %q)",
 			ExpectedModeEnv, ModeLegacy, ModeIncr)
 	}
-	if expectedModeIncr && !activated {
+	if g.incr && !activated {
 		return fmt.Errorf("botevent: %s=%s but the authority says the allocator is not activated; "+
 			"refusing to fall back to the legacy allocator, whose lower ids would land below "+
 			"live consumer cursors", ExpectedModeEnv, ModeIncr)
 	}
-	if !expectedModeIncr && activated {
+	if !g.incr && activated {
 		return fmt.Errorf("botevent: %s=%s but the authority says the allocator is activated; "+
 			"refusing to allocate from a mode this replica was not deployed for",
 			ExpectedModeEnv, ModeLegacy)
@@ -296,12 +339,17 @@ func resolveMode(ctx *config.Context, mirror string) (modeDecision, *belief, err
 		if b.activated {
 			return decideCounter, b, nil
 		}
-		// Negative is trusted only while the mirror agrees.
-		if !claims && beliefNow().Sub(b.resolvedAt) < negativeBeliefTTL {
-			return decideLegacy, b, nil
+		if beliefNow().Sub(b.resolvedAt) < negativeBeliefTTL {
+			// Negative is trusted while the mirror agrees with it, and also when the
+			// mirror is the *same* value this belief already denied — otherwise a forged
+			// key sitting in Redis costs an authority read per allocation with no exit
+			// (review P1-C).
+			if !claims || (b.confirmed && b.deniedMirror == mirror) {
+				return decideLegacy, b, nil
+			}
 		}
 	}
-	return refreshAuthority(ctx, claims, false)
+	return refreshAuthority(ctx, claims, mirror, false)
 }
 
 // refreshAuthority reads the authority and installs the resulting belief.
@@ -311,23 +359,37 @@ func resolveMode(ctx *config.Context, mirror string) (modeDecision, *belief, err
 // activation issues ids below live cursors. Without one, unreadable means the same
 // thing a pre-migration deploy means, and legacy is the honest answer.
 //
-// force skips the cached-answer short circuits, including the positive one. It is for
-// the gate-closed path, where the whole point is that something changed the mirror
-// underneath a belief this process was already acting on: serving that caller from the
-// belief it is trying to re-verify would spin.
-func refreshAuthority(ctx *config.Context, mirrorClaimsIncr, force bool) (modeDecision, *belief, error) {
+// force skips the TTL short circuits, including the positive one. It is for the
+// gate-closed path, where the whole point is that something changed the mirror underneath
+// a belief this process was already acting on: serving that caller from the belief it is
+// trying to re-verify would spin. It does NOT skip the *staleness* check below — a forced
+// caller that arrives after somebody else already did the read it wanted is served from
+// that result, so one lost mode key costs one authority read rather than one per in-flight
+// allocation (review P1-C).
+func refreshAuthority(ctx *config.Context, mirrorClaimsIncr bool, mirror string, force bool) (modeDecision, *belief, error) {
+	seen := activeBelief.Load()
 	beliefMu.Lock()
 	defer beliefMu.Unlock()
 
 	prior := activeBelief.Load()
 	// Double-check under the lock: a concurrent caller may already have paid for the
 	// answer this one was about to ask for.
+	if prior != nil && prior != seen {
+		// Somebody refreshed while this caller waited for the lock. That is the answer it
+		// came for, forced or not.
+		if prior.activated {
+			return decideCounter, prior, nil
+		}
+		return decideLegacy, prior, nil
+	}
 	if prior != nil && !force {
 		if prior.activated {
 			return decideCounter, prior, nil
 		}
-		if !mirrorClaimsIncr && beliefNow().Sub(prior.resolvedAt) < negativeBeliefTTL {
-			return decideLegacy, prior, nil
+		if beliefNow().Sub(prior.resolvedAt) < negativeBeliefTTL {
+			if !mirrorClaimsIncr || (prior.confirmed && prior.deniedMirror == mirror) {
+				return decideLegacy, prior, nil
+			}
 		}
 	}
 
@@ -354,10 +416,11 @@ func refreshAuthority(ctx *config.Context, mirrorClaimsIncr, force bool) (modeDe
 				"consumer cursors", prior.epoch, err)
 		}
 		if mirrorClaimsIncr {
-			// A mirror claiming an activation the authority denies. Legacy is correct
-			// and is what every replica concludes from the same row, so this does not
-			// split the fleet — but somebody wrote that key, and nothing else about
-			// this is visible from outside.
+			// A mirror claiming an activation the authority denies. Legacy is what the
+			// authority says, so that is the answer — but somebody wrote that key, and
+			// nothing else about this is visible from outside. Note this does NOT by
+			// itself keep the fleet on one id source; see the P1-A section in the file
+			// header for what does and what remains residual.
 			mirrorUnauthorized.inc()
 			unauthorizedWarn.warn("botevent: mode mirror claims activation but the authority does not; "+
 				"ignoring the mirror and allocating from the legacy allocator",
@@ -366,7 +429,13 @@ func refreshAuthority(ctx *config.Context, mirrorClaimsIncr, force bool) (modeDe
 		if err := assertExpectedMode(false); err != nil {
 			return decideLegacy, nil, err
 		}
-		return install(&belief{confirmed: true, resolvedAt: beliefNow()})
+		// deniedMirror records which value was denied, so the next allocation seeing the
+		// same forged key is served from this belief instead of paying for another read.
+		denied := ""
+		if mirrorClaimsIncr {
+			denied = mirror
+		}
+		return install(&belief{confirmed: true, deniedMirror: denied, resolvedAt: beliefNow()})
 
 	default:
 		// Inconclusive.
@@ -429,9 +498,7 @@ func AgeModeBeliefForTest() {
 // SetExpectedModeForTest overrides the env-derived expectation and returns a restore
 // function. Takes the raw env spelling so a test can exercise a malformed value.
 func SetExpectedModeForTest(raw string) func() {
-	prevSet, prevIncr, prevMalformed := expectedModeSet, expectedModeIncr, expectedModeMalformed
-	loadExpectedMode(raw)
-	return func() {
-		expectedModeSet, expectedModeIncr, expectedModeMalformed = prevSet, prevIncr, prevMalformed
-	}
+	prev := expectedMode.Load()
+	expectedMode.Store(parseExpectedMode(raw))
+	return func() { expectedMode.Store(prev) }
 }

--- a/pkg/botevent/mode.go
+++ b/pkg/botevent/mode.go
@@ -127,27 +127,23 @@ type belief struct {
 	// epoch is the authority's generation. Meaningful only when activated.
 	epoch uint64
 
-	// confirmed distinguishes "the authority said legacy" from "the authority could
-	// not be read and legacy is what we do about it". Both behave identically and
-	// both expire; the flag exists so the log says which one happened.
-	confirmed bool
-
-	// repairFailedFor / repairFailedAt record a mirror value this process denied and then
-	// could not remove.
+	// deniedMirror / deniedAt record a mirror value the authority explicitly denied, so
+	// the next allocations that see the same value are answered from this belief for a
+	// short cooldown instead of re-reading the authority each time.
 	//
-	// The normal answer to a mirror claiming an unconfirmed activation is to delete it —
-	// see modeResolution.unauthorizedMirror. When that delete fails the key stays, so
-	// without a cooldown every subsequent allocation would read the authority again,
+	// Without it, a mirror nobody clears costs an authority read on **every** allocation,
 	// serialized behind beliefMu inside a held msgSem slot: the storm review P1-C named.
 	//
-	// This is deliberately NOT the general "cache the denial" the previous revision had.
-	// That one keyed on the denied value with the full negativeBeliefTTL and could swallow
-	// the genuine activation, because `Activate` bumps epoch 0 → 1 and the tool then writes
-	// exactly the `incr:1` that may already have been sitting there forged (Jerry-Xin 🔴).
-	// Here the window is short, and it only applies while Redis is rejecting our writes —
-	// a state in which the counter's own INCR would be failing too.
-	repairFailedFor string
-	repairFailedAt  time.Time
+	// The cooldown is deliberately much shorter than negativeBeliefTTL, and it is
+	// deliberately keyed on the exact value, because a cached denial is what swallowed a
+	// genuine activation once already (Jerry-Xin 🔴, round 6): `Activate` bumps epoch 0 → 1
+	// and the tool then writes exactly the `incr:1` that may already have been sitting
+	// there forged, so the denied value and the real one are the same bytes. Nothing
+	// visible from Redis distinguishes them — only a fresh authority read does — so a
+	// window is unavoidable and the choice is how long. See repairCooldown, and note the
+	// caller only arms this when there is no counter to contradict the authority.
+	deniedMirror string
+	deniedAt     time.Time
 
 	resolvedAt time.Time
 }
@@ -161,21 +157,26 @@ type modeResolution struct {
 	// generation closes the gate rather than allocating.
 	belief *belief
 
-	// unauthorizedMirror is a mirror value the authority denied, for the caller to remove.
+	// unauthorizedMirror is a mirror value the authority explicitly denied.
 	//
-	// Deleting it rather than caching the denial is the fix for the swallow described on
-	// belief.repairFailedFor, and it is the symmetric repair to the one the allocator
-	// already performs in the other direction: when the authority says activated and the
-	// mirror disagrees, the mirror is rebuilt. When the authority says legacy, the correct
-	// mirror state is *absent* — "absent" is defined to mean "consult the authority" — so
-	// removing a mirror the authority contradicts restores consistency rather than
-	// destroying information.
+	// The caller uses it to arm the denial cooldown — and **only** that. An earlier
+	// revision had the caller *delete* the key, on the reasoning that the correct mirror
+	// for a legacy authority is absent. That was a fleet-wide-outage regression (review
+	// round 7, P1-1): when the party that regressed is the **authority** rather than the
+	// mirror, one freshly started replica would delete the very artifact every healthy
+	// activated replica's gate compares against. Their gate then returns
+	// gateNotActivated, they force an authority read, find legacy against an activated
+	// belief, and refuse every enqueue for every bot until the state row is restored — a
+	// bookkeeping regression with zero delivery impact turned into total delivery loss by
+	// a rolling restart.
 	//
-	// The race is benign: if an operator activates between the authority read and this
-	// delete, a legitimate mirror is removed, every replica's next allocation consults the
-	// authority, finds it activated, and rebuilds it. One extra read each, no mixed source.
-	// `botevent-seq` also refuses to activate while an unauthorized mirror is present, so
-	// that interleaving needs the key to appear during the flip itself.
+	// Guarding the delete on `!counterExists` was the suggested minimum fix and it does
+	// narrow the window, but it does not close it: the mirror is global while a counter is
+	// per-bot, so an allocation for a bot that has never received an event still has no
+	// counter to object with. Since the delete's only benefit was suppressing the read
+	// storm, and the cooldown suppresses that too, the delete is gone entirely rather than
+	// conditioned. Nothing in the allocator writes this key now; only the operator tool
+	// does, which is the one place a human can see what they are overwriting.
 	unauthorizedMirror string
 }
 
@@ -194,10 +195,16 @@ const (
 	// replica instead of one per allocation.
 	negativeBeliefTTL = 5 * time.Second
 
-	// repairCooldown bounds how long a mirror this process failed to remove is answered
-	// from the cached denial instead of re-reading the authority. See
-	// belief.repairFailedFor for why it exists and why it is much shorter than
-	// negativeBeliefTTL.
+	// repairCooldown bounds how long a mirror the authority denied is answered from the
+	// cached denial instead of re-reading the authority. See belief.deniedMirror for why it
+	// exists and why it is much shorter than negativeBeliefTTL.
+	//
+	// One second, and the tradeoff is explicit: it is the window in which a genuine
+	// activation writing the same bytes as a previously denied mirror is not noticed. That
+	// window cannot be zero without re-reading the authority per allocation, and it is only
+	// entered at all when a mirror claiming activation was already sitting in Redis against
+	// a legacy authority — which `botevent-seq -action activate` now refuses to flip on top
+	// of, so the precondition is checked at the one supervised step.
 	repairCooldown = time.Second
 
 	// authorityTimeout bounds every authority read.
@@ -391,10 +398,10 @@ func resolveMode(ctx *config.Context, mirror string) (modeResolution, error) {
 			return modeResolution{decision: decideLegacy, belief: b}, nil
 		}
 		// A mirror claiming activation normally forces a read — that is what makes a flip
-		// propagate without waiting for the TTL. The one exception is a value this process
-		// already tried and failed to remove: re-reading per allocation then would be the
+		// propagate without waiting for the TTL. The one exception is a value the authority
+		// already denied to this process: re-reading per allocation then would be the
 		// serialized-read storm review P1-C named, with no exit. See repairCooldown.
-		if claims && mirror == b.repairFailedFor && beliefNow().Sub(b.repairFailedAt) < repairCooldown {
+		if claims && mirror == b.deniedMirror && beliefNow().Sub(b.deniedAt) < repairCooldown {
 			return modeResolution{decision: decideLegacy, belief: b}, nil
 		}
 	}
@@ -444,8 +451,8 @@ func refreshAuthority(ctx *config.Context, mirrorClaimsIncr bool, mirror string,
 		if !mirrorClaimsIncr && beliefNow().Sub(prior.resolvedAt) < negativeBeliefTTL {
 			return modeResolution{decision: decideLegacy, belief: prior}, nil
 		}
-		if mirrorClaimsIncr && mirror == prior.repairFailedFor &&
-			beliefNow().Sub(prior.repairFailedAt) < repairCooldown {
+		if mirrorClaimsIncr && mirror == prior.deniedMirror &&
+			beliefNow().Sub(prior.deniedAt) < repairCooldown {
 			return modeResolution{decision: decideLegacy, belief: prior}, nil
 		}
 	}
@@ -456,7 +463,7 @@ func refreshAuthority(ctx *config.Context, mirrorClaimsIncr bool, mirror string,
 		if err := assertExpectedMode(true); err != nil {
 			return modeResolution{}, err
 		}
-		return install(&belief{activated: true, epoch: st.Epoch, confirmed: true, resolvedAt: beliefNow()}, "")
+		return install(&belief{activated: true, epoch: st.Epoch, resolvedAt: beliefNow()}, ""), nil
 
 	case err == nil, errors.Is(err, ErrStateMissing):
 		// The authority says legacy, or says nothing because the migration has not
@@ -488,7 +495,7 @@ func refreshAuthority(ctx *config.Context, mirrorClaimsIncr bool, mirror string,
 		if err := assertExpectedMode(false); err != nil {
 			return modeResolution{}, err
 		}
-		return install(&belief{confirmed: true, resolvedAt: beliefNow()}, unauthorized)
+		return install(&belief{resolvedAt: beliefNow()}, unauthorized), nil
 
 	default:
 		// Inconclusive.
@@ -505,38 +512,46 @@ func refreshAuthority(ctx *config.Context, mirrorClaimsIncr bool, mirror string,
 		if guardErr := assertExpectedMode(false); guardErr != nil {
 			return modeResolution{}, guardErr
 		}
+		// Which of the two "legacy" reasons this was — the authority said so, or it could
+		// not be read — is distinguished by *which warning fires*, here versus the branch
+		// above. An earlier revision kept a `confirmed` flag on the belief for that and
+		// nothing ever read it (review round 7), so the flag is gone and these two call
+		// sites are the record.
 		unreadableWarn.warn("botevent: allocator authority unreadable; treating as not activated",
 			zap.Error(err))
 		// Cache the inconclusive answer too. During a DB outage the alternative is one
 		// failed read per allocation on the fan-out path, which is the cost this cache
 		// exists to remove.
-		return install(&belief{resolvedAt: beliefNow()}, "")
+		return install(&belief{resolvedAt: beliefNow()}, ""), nil
 	}
 }
 
 // install stores a belief and returns the matching resolution.
 //
+// No error return: it never had a failure mode, and all three call sites used to check one —
+// dead API surface implying a path that does not exist (review round 7).
+//
 // unauthorizedMirror is passed through to the caller rather than acted on here: repairing
 // it is a Redis write and this file deliberately does no Redis I/O — the allocator holds
 // the client.
-func install(b *belief, unauthorizedMirror string) (modeResolution, error) {
+func install(b *belief, unauthorizedMirror string) modeResolution {
 	activeBelief.Store(b)
 	res := modeResolution{belief: b, unauthorizedMirror: unauthorizedMirror}
 	if b.activated {
 		res.decision = decideCounter
-		return res, nil
+		return res
 	}
 	res.decision = decideLegacy
-	return res, nil
+	return res
 }
 
-// noteMirrorRepairFailed records that an unauthorized mirror could not be removed, so the
-// next allocations are answered from the cached denial for repairCooldown rather than
-// re-reading the authority each time. See belief.repairFailedFor.
+// noteMirrorUnauthorized records a mirror value the authority denied, so the next
+// allocations that see the same value are answered from this belief for a short cooldown
+// rather than re-reading the authority each time. See belief.deniedMirror.
 //
 // Copy-on-write like every other belief update: the pointer is swapped, never mutated, so
 // a reader on the hot path cannot see a half-updated belief.
-func noteMirrorRepairFailed(denied string) {
+func noteMirrorUnauthorized(denied string) {
 	beliefMu.Lock()
 	defer beliefMu.Unlock()
 	cur := activeBelief.Load()
@@ -546,8 +561,8 @@ func noteMirrorRepairFailed(denied string) {
 		return
 	}
 	updated := *cur
-	updated.repairFailedFor = denied
-	updated.repairFailedAt = beliefNow()
+	updated.deniedMirror = denied
+	updated.deniedAt = beliefNow()
 	activeBelief.Store(&updated)
 }
 
@@ -566,12 +581,17 @@ func ResetModeBeliefForTest() {
 	authorityUnreadable.resetForTest()
 }
 
-// AgeModeBeliefForTest ages the cached belief past negativeBeliefTTL without
-// sleeping, so a test can prove the negative cache expires rather than persists.
+// AgeModeBeliefForTest ages the cached belief past negativeBeliefTTL and past
+// repairCooldown without sleeping, so a test can prove the caches expire rather than
+// persist. Both timestamps move together: a test that needs one of them stale almost always
+// means "make this belief old".
 func AgeModeBeliefForTest() {
 	if b := activeBelief.Load(); b != nil {
 		aged := *b
 		aged.resolvedAt = b.resolvedAt.Add(-2 * negativeBeliefTTL)
+		if !b.deniedAt.IsZero() {
+			aged.deniedAt = b.deniedAt.Add(-2 * negativeBeliefTTL)
+		}
 		activeBelief.Store(&aged)
 	}
 }

--- a/pkg/botevent/mode.go
+++ b/pkg/botevent/mode.go
@@ -71,13 +71,14 @@ package botevent
 // only have happened after the authority said `incr`. So a cold process that sees
 // `legacy` alongside a live counter refuses instead of degrading — see legacyDelegate.
 //
-// One residual is accepted rather than claimed away: if the counter key is gone **as
-// well** — a Redis flush or restore correlated with a regressed authority — a cold
-// process has no evidence at all and delegates to GenSeq. Only
-// `OCTO_BOTEVENT_EXPECTED_MODE=incr` closes that, and the rollout arms it only after
-// activation is verified, so the window is open by design during the flip itself. It is a
-// residual rather than a defect because both halves of the evidence have to be lost at
-// once, and the operator step that closes it exists and is documented.
+// One residual is accepted rather than claimed away: when the mirror is absent or invalid,
+// the authority is unreadable, and this bot has no counter yet (a new or idle bot), a cold
+// process has no evidence that the counter era began and delegates to GenSeq. Only
+// `OCTO_BOTEVENT_EXPECTED_MODE=incr` closes that, and the rollout arms it only after activation
+// is verified, so the window is open by design during the flip itself. This is broader than
+// "the mirror and counter were restored away": an authority outage plus a bot that has never
+// created its counter has the same evidence shape. The operator assertion closes it after the
+// flip and is documented as a required last step.
 //
 // # Why the mirror carries the epoch
 //
@@ -302,6 +303,20 @@ func parseExpectedMode(raw string) *expectedModeGuard {
 	}
 }
 
+// validateExpectedMode rejects a malformed deployment guard without needing to know
+// which allocator the authority selected. allocate calls this before any Redis or DB I/O:
+// a typo is process-local, stable configuration, so discovering it once per allocation
+// must be both immediate and cheap.
+func validateExpectedMode() error {
+	g := expectedMode.Load()
+	if g == nil || !g.set || !g.malformed {
+		return nil
+	}
+	return fmt.Errorf("botevent: %s is set to an unrecognised value; refusing to allocate "+
+		"rather than run with a guard that silently does nothing (want %q or %q)",
+		ExpectedModeEnv, ModeLegacy, ModeIncr)
+}
+
 // assertExpectedMode enforces the optional deployment guard against a resolved mode.
 func assertExpectedMode(activated bool) error {
 	g := expectedMode.Load()
@@ -309,9 +324,7 @@ func assertExpectedMode(activated bool) error {
 		return nil
 	}
 	if g.malformed {
-		return fmt.Errorf("botevent: %s is set to an unrecognised value; refusing to allocate "+
-			"rather than run with a guard that silently does nothing (want %q or %q)",
-			ExpectedModeEnv, ModeLegacy, ModeIncr)
+		return validateExpectedMode()
 	}
 	if g.incr && !activated {
 		return fmt.Errorf("botevent: %s=%s but the authority says the allocator is not activated; "+
@@ -392,17 +405,17 @@ func resolveMode(ctx *config.Context, mirror string) (modeResolution, error) {
 	if b := activeBelief.Load(); b != nil {
 		// Positive is terminal with respect to legacy.
 		if b.activated {
-			return modeResolution{decision: decideCounter, belief: b}, nil
+			return resolutionFromBelief(b, "")
 		}
 		if !claims && beliefNow().Sub(b.resolvedAt) < negativeBeliefTTL {
-			return modeResolution{decision: decideLegacy, belief: b}, nil
+			return resolutionFromBelief(b, "")
 		}
 		// A mirror claiming activation normally forces a read — that is what makes a flip
 		// propagate without waiting for the TTL. The one exception is a value the authority
 		// already denied to this process: re-reading per allocation then would be the
 		// serialized-read storm review P1-C named, with no exit. See repairCooldown.
 		if claims && mirror == b.deniedMirror && beliefNow().Sub(b.deniedAt) < repairCooldown {
-			return modeResolution{decision: decideLegacy, belief: b}, nil
+			return resolutionFromBelief(b, "")
 		}
 	}
 	return refreshAuthority(ctx, claims, mirror, false)
@@ -438,32 +451,29 @@ func refreshAuthority(ctx *config.Context, mirrorClaimsIncr bool, mirror string,
 		// evidence this caller has already contradicted (review P2-3). Fall through and
 		// read.
 		if prior.activated {
-			return modeResolution{decision: decideCounter, belief: prior}, nil
+			return resolutionFromBelief(prior, "")
 		}
 		if !mirrorClaimsIncr {
-			return modeResolution{decision: decideLegacy, belief: prior}, nil
+			return resolutionFromBelief(prior, "")
 		}
 	}
 	if prior != nil && !force {
 		if prior.activated {
-			return modeResolution{decision: decideCounter, belief: prior}, nil
+			return resolutionFromBelief(prior, "")
 		}
 		if !mirrorClaimsIncr && beliefNow().Sub(prior.resolvedAt) < negativeBeliefTTL {
-			return modeResolution{decision: decideLegacy, belief: prior}, nil
+			return resolutionFromBelief(prior, "")
 		}
 		if mirrorClaimsIncr && mirror == prior.deniedMirror &&
 			beliefNow().Sub(prior.deniedAt) < repairCooldown {
-			return modeResolution{decision: decideLegacy, belief: prior}, nil
+			return resolutionFromBelief(prior, "")
 		}
 	}
 
 	st, err := readStateDeadlined(ctx)
 	switch {
 	case err == nil && st.Activated():
-		if err := assertExpectedMode(true); err != nil {
-			return modeResolution{}, err
-		}
-		return install(&belief{activated: true, epoch: st.Epoch, resolvedAt: beliefNow()}, ""), nil
+		return install(&belief{activated: true, epoch: st.Epoch, resolvedAt: beliefNow()}, "")
 
 	case err == nil, errors.Is(err, ErrStateMissing):
 		// The authority says legacy, or says nothing because the migration has not
@@ -492,10 +502,7 @@ func refreshAuthority(ctx *config.Context, mirrorClaimsIncr bool, mirror string,
 				zap.String("mirrorKey", ModeKey), zap.String("mirrorValue", mirror), zap.Error(err))
 			unauthorized = mirror
 		}
-		if err := assertExpectedMode(false); err != nil {
-			return modeResolution{}, err
-		}
-		return install(&belief{resolvedAt: beliefNow()}, unauthorized), nil
+		return install(&belief{resolvedAt: beliefNow()}, unauthorized)
 
 	default:
 		// Inconclusive.
@@ -509,9 +516,6 @@ func refreshAuthority(ctx *config.Context, mirrorClaimsIncr bool, mirror string,
 				"authority is unreadable (%w); refusing to allocate — the counter cannot be trusted "+
 				"unconfirmed, and legacy would issue ids below live cursors if the claim is true", err)
 		}
-		if guardErr := assertExpectedMode(false); guardErr != nil {
-			return modeResolution{}, guardErr
-		}
 		// Which of the two "legacy" reasons this was — the authority said so, or it could
 		// not be read — is distinguished by *which warning fires*, here versus the branch
 		// above. An earlier revision kept a `confirmed` flag on the belief for that and
@@ -522,27 +526,41 @@ func refreshAuthority(ctx *config.Context, mirrorClaimsIncr bool, mirror string,
 		// Cache the inconclusive answer too. During a DB outage the alternative is one
 		// failed read per allocation on the fan-out path, which is the cost this cache
 		// exists to remove.
-		return install(&belief{resolvedAt: beliefNow()}, ""), nil
+		return install(&belief{resolvedAt: beliefNow()}, "")
 	}
 }
 
-// install stores a belief and returns the matching resolution.
+// install stores a belief before enforcing the deployment guard and returning the
+// matching resolution.
 //
-// No error return: it never had a failure mode, and all three call sites used to check one —
-// dead API surface implying a path that does not exist (review round 7).
+// The ordering is load-bearing: a guard mismatch is stable process configuration, not a
+// reason to throw away a successfully parsed authority result. Keeping the belief means
+// later refusals reuse it instead of serializing every message on another MySQL read. Cached
+// resolutions still re-run assertExpectedMode, so retaining a negative belief cannot make an
+// `EXPECTED_MODE=incr` replica fall through to GenSeq.
 //
 // unauthorizedMirror is passed through to the caller rather than acted on here: repairing
 // it is a Redis write and this file deliberately does no Redis I/O — the allocator holds
 // the client.
-func install(b *belief, unauthorizedMirror string) modeResolution {
+func install(b *belief, unauthorizedMirror string) (modeResolution, error) {
 	activeBelief.Store(b)
+	return resolutionFromBelief(b, unauthorizedMirror)
+}
+
+// resolutionFromBelief applies the deployment assertion every time a cached or freshly
+// installed belief is used. The belief decides the candidate mode; the assertion decides
+// whether this replica is permitted to act on it.
+func resolutionFromBelief(b *belief, unauthorizedMirror string) (modeResolution, error) {
+	if err := assertExpectedMode(b.activated); err != nil {
+		return modeResolution{}, err
+	}
 	res := modeResolution{belief: b, unauthorizedMirror: unauthorizedMirror}
 	if b.activated {
 		res.decision = decideCounter
-		return res
+		return res, nil
 	}
 	res.decision = decideLegacy
-	return res
+	return res, nil
 }
 
 // noteMirrorUnauthorized records a mirror value the authority denied, so the next

--- a/pkg/botevent/seq.go
+++ b/pkg/botevent/seq.go
@@ -1,0 +1,303 @@
+package botevent
+
+// #697: the score allocator for `robotEvent:{robotID}`.
+//
+// # Why this package owns it
+//
+// Bot event delivery (`POST /v1/bot/events`) paginates the queue with an
+// **exclusive** lower bound — `ZRANGEBYSCORE key (cursor +inf` — and acks by
+// score — `ZRemRangeByScore(id, id)`. Both are only correct if scores are
+// strictly monotonic and unique per queue.
+//
+// They were neither. Scores came from octo-lib `GenSeq`, a **per-process** HiLo
+// block allocator (`config/seq.go`: `seqStep = 1000`, blocks cached in a
+// package-level `seqMap` behind a process-local mutex, `min_seq` written back
+// from process-local state with an unconditional
+// `ON DUPLICATE KEY UPDATE min_seq=VALUES(min_seq)`). Two replicas whose
+// cold-start reads both precede either write-back issue the *same* ids, and two
+// replicas holding different live blocks issue ids whose order has nothing to do
+// with time. Measured in production: 19 ordering inversions on block boundaries
+// with a 6.7 day maximum regression, and 2624 colliding scores across three
+// queues that were still accumulating. Reproduced end to end in
+// `tools/genseq-repro`.
+//
+// The allocator lives here, next to the doorbell, because `pkg/botevent` is
+// already the leaf package shared by every producer (`modules/robot`,
+// `modules/group`) and the consumer (`modules/bot_api`). A copy in either side
+// would drift, and a new package would need the same import-cycle escape.
+//
+// # Why Redis INCR, and the constraint that comes with it
+//
+// `INCR` on a single instance is strictly monotonic and never reuses a value, so
+// both invariants hold by construction rather than by assumption.
+//
+// The obvious objection is durability: production runs `appendonly no` with only
+// RDB snapshots (`save 3600 1 300 100 60 10000`), so a crash loses the last
+// 60–300 seconds and the counter moves backwards. That is safe **here** for a
+// specific reason: the counter and the queue it guards live in the same Redis
+// instance and therefore the same RDB domain. If the snapshot is at T0 with
+// counter `C0` and queue max score `S0 <= C0`, a crash restores both — the
+// members enqueued after T0 are gone along with the counter's advance, so
+// resuming from `C0+1` cannot collide with anything that survived.
+//
+// **That argument is why the counter must stay in the same Redis instance and db
+// as the queue.** Moving it to a separate Redis, a separate db, or giving it its
+// own AOF for "durability" breaks the co-recovery property and reintroduces
+// exactly the collision class this package exists to remove. Adding replicas is
+// fine (counter and queue lag together); splitting them is not.
+//
+// Production also runs `maxmemory 0` / `noeviction`, so the counter cannot be
+// evicted under pressure — the failure mode that would otherwise make an `INCR`
+// counter quietly unusable.
+//
+// # No fallback to GenSeq, deliberately
+//
+// When allocation fails, callers must fail the enqueue the same way they failed
+// a `GenSeq` error before. Falling back to `GenSeq` would put two live id
+// sources on one queue, which is precisely the condition that produced #697.
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	octoredis "github.com/Mininglamp-OSS/octo-server/pkg/redis"
+	rd "github.com/go-redis/redis"
+)
+
+const (
+	// SeqKeyPrefix namespaces the per-bot event id counter. Distinct from both
+	// `robotEvent:` and `robotEventBell:` so the counter, the authoritative queue
+	// and the hint can never collide.
+	SeqKeyPrefix = "botEventSeq:"
+
+	// QueueKeyPrefix is the authoritative per-bot event queue. Defined here so the
+	// five producers and the consumer stop each spelling it with their own
+	// fmt.Sprintf — the seed below has to read the very key the producers write.
+	QueueKeyPrefix = "robotEvent:"
+
+	// legacyGenSeqStep mirrors octo-lib `config.seqStep`. It is duplicated rather
+	// than imported because octo-lib does not export it, and the seed's safety
+	// margin is meaningless without it.
+	legacyGenSeqStep = 1000
+
+	// seedSafetyMargin is how far above the observed ceiling a first-time seed
+	// starts.
+	//
+	// Two legacy blocks matter, not one. A replica still running the old binary
+	// during a rolling deploy holds a block whose top is up to `seqStep` above the
+	// ids it has enqueued so far, and `min_seq` in the DB may itself have been
+	// moved *backwards* by another replica's unconditional write-back — so the DB
+	// value is a lower bound on what legacy can still hand out, not an upper one.
+	// Two steps covers a block in flight plus one such regression.
+	seedSafetyMargin = 2 * legacyGenSeqStep
+)
+
+// SeqKey returns the event-id counter key for robotID. As with BellKey, robotID
+// must be the identity resolved from the authenticated context, never a
+// request-body value: the counter shares the queue's bot-ownership boundary.
+func SeqKey(robotID string) string { return SeqKeyPrefix + robotID }
+
+// QueueKey returns the authoritative event queue key for robotID.
+func QueueKey(robotID string) string { return QueueKeyPrefix + robotID }
+
+// seedSource raises the counter to floor if it is currently lower or unset, and
+// returns the resulting value.
+//
+// Idempotent by construction, which is what lets the fix ship as a single-stage
+// deploy: every replica seeds on its own first use for a given bot, in any order,
+// any number of times, and they all converge. `SET` has no `GT` option in Redis
+// (`GT`/`LT` belong to `EXPIRE` and `ZADD`), so the compare and the write have to
+// share one script to be atomic against a concurrent seeder.
+const seedSource = `
+local cur = redis.call('GET', KEYS[1])
+local floor = tonumber(ARGV[1])
+if cur == false or tonumber(cur) < floor then
+  redis.call('SET', KEYS[1], floor)
+  return floor
+end
+return tonumber(cur)`
+
+// seedScript sends EVALSHA and falls back to EVAL only on NOSCRIPT, matching
+// bell.go and every other Lua site in this repo.
+var seedScript = rd.NewScript(seedSource)
+
+// Scripter is the go-redis surface the allocator needs: INCR, the sorted-set read
+// used to observe the current ceiling, and the scripting set *rd.Script.Run
+// requires. octo-lib's *redis.Conn exposes none of the scripting calls, so the
+// allocator uses the instrumented raw client like the ring does.
+//
+// Declared as an interface so tests can substitute a fake — in particular one
+// whose INCR succeeds while its seed fails, since the two have different
+// consequences.
+type Scripter interface {
+	Incr(key string) *rd.IntCmd
+	ZRevRangeWithScores(key string, start, stop int64) *rd.ZSliceCmd
+	Eval(script string, keys []string, args ...interface{}) *rd.Cmd
+	EvalSha(sha1 string, keys []string, args ...interface{}) *rd.Cmd
+	ScriptExists(hashes ...string) *rd.BoolSliceCmd
+	ScriptLoad(script string) *rd.StringCmd
+}
+
+// Unlike the doorbell, this is not best-effort: a failed allocation must fail the
+// enqueue, so the timeouts trade a little more patience for not dropping events.
+// They stay bounded because `saveRobotMessage` allocates inside a `msgSem` slot,
+// where a slow call stalls fan-out for every bot in the process — the same reason
+// the ring is asynchronous. Worst case here is ~3s (1s × 1 try + 2 retries),
+// which is the same order as the DB round trip GenSeq used to make.
+const (
+	seqDialTimeout = time.Second
+	seqReadTimeout = time.Second
+	seqPoolTimeout = 500 * time.Millisecond
+	seqMaxRetries  = 2
+)
+
+var (
+	seqClientOnce sync.Once
+	seqClient     *rd.Client
+
+	// seeded records which bots this process has already seeded. Purely an
+	// optimisation: the seed is idempotent, so a cold cache costs one extra
+	// round trip, never correctness.
+	seeded sync.Map
+
+	// seedFailures counts seeds that could not be established. Exposed for tests
+	// and for the operator check; wiring it to Prometheus belongs to the card
+	// observability work that owns that namespace, as bell.go notes for its own
+	// counter.
+	seedFailures atomic.Int64
+)
+
+// SeqClient returns the shared allocator client, built through octoredis so TLS
+// options are honoured and pkg/redis's raw-client chokepoint guard stays
+// satisfied.
+//
+// It is built from the same *config.Config as every other Redis user in the
+// process, which is what keeps the counter in the queue's instance and db. See
+// the co-recovery argument at the top of this file before changing that.
+func SeqClient(cfg *config.Config) Scripter {
+	seqClientOnce.Do(func() {
+		seqClient = octoredis.NewInstrumentedClient(cfg, func(o *rd.Options) {
+			o.MaxRetries = seqMaxRetries
+			o.DialTimeout = seqDialTimeout
+			o.ReadTimeout = seqReadTimeout
+			o.WriteTimeout = seqReadTimeout
+			o.PoolTimeout = seqPoolTimeout
+		})
+	})
+	return seqClient
+}
+
+// SeedFailures reports how many allocations failed at the seed step.
+func SeedFailures() int64 { return seedFailures.Load() }
+
+// NextEventID allocates the next event id for robotID's queue.
+//
+// The returned value is used both as the sorted-set score and as the payload's
+// `event_id`. Those two must stay equal: the consumer's cursor is a payload
+// `event_id` while its reads and acks are bounded by score
+// (`modules/bot_api/events.go`).
+func NextEventID(ctx *config.Context, robotID string) (int64, error) {
+	if ctx == nil {
+		return 0, errors.New("botevent: nil ctx, cannot allocate event id")
+	}
+	robotID = strings.TrimSpace(robotID)
+	if robotID == "" {
+		return 0, errors.New("botevent: empty robotID, cannot allocate event id")
+	}
+	return nextEventID(ctx, SeqClient(ctx.GetConfig()), robotID)
+}
+
+// nextEventID is the testable core: it takes the client explicitly so a test can
+// inject one whose seed or INCR fails.
+func nextEventID(ctx *config.Context, client Scripter, robotID string) (int64, error) {
+	if client == nil {
+		return 0, errors.New("botevent: nil redis client, cannot allocate event id")
+	}
+	if _, ok := seeded.Load(robotID); !ok {
+		if err := seedCounter(ctx, client, robotID); err != nil {
+			seedFailures.Add(1)
+			return 0, fmt.Errorf("botevent: seed event id counter for %q: %w", robotID, err)
+		}
+		seeded.Store(robotID, struct{}{})
+	}
+	v, err := client.Incr(SeqKey(robotID)).Result()
+	if err != nil {
+		return 0, fmt.Errorf("botevent: allocate event id for %q: %w", robotID, err)
+	}
+	return v, nil
+}
+
+// seedCounter raises the counter above everything legacy could have handed out
+// for this bot.
+//
+// Both sources are needed. The queue's max score covers ids already enqueued —
+// including by an old replica whose block sits above a regressed `min_seq`. The
+// `seq` row covers the opposite case: a bot whose queue has been fully acked (or
+// has expired) still has clients holding a cursor near the last id it was ever
+// issued, and seeding below that cursor would make every new event unreachable —
+// the very failure this change exists to remove, self-inflicted at deploy time.
+func seedCounter(ctx *config.Context, client Scripter, robotID string) error {
+	queueMax, err := queueCeiling(client, robotID)
+	if err != nil {
+		return err
+	}
+	legacyMax, err := legacyCeiling(ctx, robotID)
+	if err != nil {
+		return err
+	}
+	floor := queueMax
+	if legacyMax > floor {
+		floor = legacyMax
+	}
+	if floor > 0 {
+		// A bot with no queue and no seq row has never been issued an id, so it
+		// has no cursor to clear and starts from 1. Adding the margin there would
+		// only make the numbers less legible.
+		floor += seedSafetyMargin
+	}
+	return seedScript.Run(client, []string{SeqKey(robotID)}, floor).Err()
+}
+
+// queueCeiling returns the highest score currently in the bot's queue, or 0.
+func queueCeiling(client Scripter, robotID string) (int64, error) {
+	top, err := client.ZRevRangeWithScores(QueueKey(robotID), 0, 0).Result()
+	if err != nil {
+		return 0, fmt.Errorf("read queue ceiling: %w", err)
+	}
+	if len(top) == 0 {
+		return 0, nil
+	}
+	return int64(top[0].Score), nil
+}
+
+// legacyCeiling returns the legacy `GenSeq` block boundary for this bot's event
+// sequence, or 0 when it never used one.
+//
+// This reads the `seq` row directly rather than calling GenSeq, which would
+// allocate — and allocating from the very source being retired is how a "read"
+// turns into a third live id source.
+func legacyCeiling(ctx *config.Context, robotID string) (int64, error) {
+	var minSeq int64
+	key := fmt.Sprintf("seq:%s%s", common.RobotEventSeqKey, robotID)
+	if _, err := ctx.DB().Select("min_seq").From("`seq`").
+		Where("`key`=?", key).Load(&minSeq); err != nil {
+		return 0, fmt.Errorf("read legacy seq row: %w", err)
+	}
+	return minSeq, nil
+}
+
+// ResetSeededForTest clears the process-local seed cache. Tests that seed against
+// different fixtures need it; production never does.
+func ResetSeededForTest() {
+	seeded.Range(func(k, _ interface{}) bool {
+		seeded.Delete(k)
+		return true
+	})
+	seedFailures.Store(0)
+}

--- a/pkg/botevent/seq.go
+++ b/pkg/botevent/seq.go
@@ -31,20 +31,47 @@ package botevent
 // `INCR` on a single instance is strictly monotonic and never reuses a value, so
 // both invariants hold by construction rather than by assumption.
 //
-// The obvious objection is durability: production runs `appendonly no` with only
-// RDB snapshots (`save 3600 1 300 100 60 10000`), so a crash loses the last
-// 60–300 seconds and the counter moves backwards. That is safe **here** for a
-// specific reason: the counter and the queue it guards live in the same Redis
-// instance and therefore the same RDB domain. If the snapshot is at T0 with
-// counter `C0` and queue max score `S0 <= C0`, a crash restores both — the
-// members enqueued after T0 are gone along with the counter's advance, so
-// resuming from `C0+1` cannot collide with anything that survived.
+// The objection is durability: production runs `appendonly no` with only RDB
+// snapshots (`save 3600 1 300 100 60 10000`), so a crash loses the last 60–300
+// seconds and the counter moves backwards.
 //
-// **That argument is why the counter must stay in the same Redis instance and db
-// as the queue.** Moving it to a separate Redis, a separate db, or giving it its
-// own AOF for "durability" breaks the co-recovery property and reintroduces
-// exactly the collision class this package exists to remove. Adding replicas is
-// fine (counter and queue lag together); splitting them is not.
+// # Co-recovery guarantees uniqueness, NOT monotonicity (review finding)
+//
+// Being in the same Redis instance as the queue does buy something real: if the
+// snapshot is at T0 with counter `C0` and queue max `S0 <= C0`, a crash restores
+// both, so the members that could have collided are gone along with the counter's
+// advance. Resuming from `C0+1` therefore cannot produce a **duplicate**.
+//
+// It does NOT buy the other invariant, and an earlier revision of this comment
+// wrongly treated the two as one. **Consumer cursors are external state and do not
+// roll back with Redis.** A bot that read up to 49900 still holds 49900 after the
+// counter regresses to 49000, so ids 49001..49900 are re-issued *below* a live
+// cursor and are permanently invisible — #697 re-inflicted by a crash. On this
+// axis a bare INCR counter is strictly worse than GenSeq, whose `min_seq` lives in
+// MySQL and does not regress when Redis does.
+//
+// Two mechanisms close it, because neither suffices alone:
+//
+//   - **A durable high-water mark in MySQL** (`seq` row `botEventHigh:{robotID}`),
+//     advanced roughly every `highWaterInterval` ids and folded into every seed's
+//     floor. It does not share Redis's recovery domain, so it survives an RDB
+//     rollback. Persisting every id would be a DB write per allocation; persisting
+//     every ~1000 means the mark can trail the true maximum by at most that much,
+//     which `seedSafetyMargin` (2 × step) already covers.
+//   - **Rollback detection in the issuing process.** The durable mark only helps if
+//     something re-seeds, and a long-running replica would otherwise keep INCRing
+//     the regressed counter forever — its `seeded` entry is already set. So every
+//     allocation is compared against the last id this process issued for that bot;
+//     a value that did not advance means the counter regressed, and the allocation
+//     re-seeds and retries. That makes recovery automatic rather than a runbook.
+//
+// The high-water write uses `GREATEST(min_seq, VALUES(min_seq))`. It must: an
+// unconditional `ON DUPLICATE KEY UPDATE` is exactly how `GenSeq` lets a lagging
+// replica move a floor backwards, which is the root cause of #697. Repeating that
+// mistake in the mechanism meant to fix it would be quite something.
+//
+// The counter must still stay in the same Redis instance and db as the queue —
+// splitting them costs the uniqueness half of the argument above.
 //
 // Production also runs `maxmemory 0` / `noeviction`, so the counter cannot be
 // evicted under pressure — the failure mode that would otherwise make an `INCR`
@@ -85,6 +112,7 @@ package botevent
 import (
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -113,6 +141,47 @@ const (
 	// ModeLegacy is the pre-activation state, written explicitly by the operator
 	// tool so preflight can tell "not yet activated" from "never configured".
 	ModeLegacy = "legacy"
+
+	// HighWaterKeyPrefix names the durable high-water row in the `seq` table.
+	//
+	// It reuses that table rather than adding one: the schema (`key`, `min_seq`) is
+	// exactly right, the seed already reads that table for the legacy ceiling, and
+	// it needs no migration. The key namespace is disjoint from GenSeq's
+	// (`seq:robotEventSeq:…`), so neither reads the other's rows.
+	HighWaterKeyPrefix = "botEventHigh:"
+
+	// ExpectedModeEnv makes a lost or rolled-back mode key fail closed instead of
+	// silently degrading to legacy.
+	//
+	// `ModeKey` lives in Redis, so it regresses under exactly the RDB rollback
+	// described above — and dropping to legacy then issues *lower* ids beneath live
+	// cursors, the same loss mirrored. Once activation is verified, roll this out as
+	// `incr` and a missing mode refuses the enqueue instead. Same shape as #627's
+	// OCTO_MESSAGE_EXTRA_VERSION_EXPECTED_MODE. Leave it unset until then: a replica
+	// expecting `incr` before the flip fails every enqueue closed.
+	ExpectedModeEnv = "OCTO_BOTEVENT_EXPECTED_MODE"
+
+	// highWaterInterval is how many ids may be issued between durable writes. One
+	// legacy block, so the mark trails the truth by less than seedSafetyMargin.
+	highWaterInterval = legacyGenSeqStep
+
+	// rollbackTolerance is how far below this process's high-water an allocation may
+	// land before it is treated as a counter regression rather than ordinary
+	// concurrency.
+	//
+	// A tolerance is unavoidable. `INCR` is atomic, but concurrent callers do not
+	// *observe* their results in issue order: with N allocations in flight, the
+	// caller holding 100 can reach the check after the caller holding 140. Comparing
+	// against the running maximum with no slack would flag that as a regression,
+	// re-seed, and jump the counter — which is what an earlier revision did, and the
+	// concurrency test caught it as a 6000-wide gap across 200 allocations.
+	//
+	// One legacy block of slack is far above any real in-flight count (bounded in
+	// practice by msgSem's 100 slots and the client pool) and far below a real
+	// rollback, which loses 60–300 seconds of a live queue's ids. The gap it leaves
+	// is a regression smaller than this bound: those go undetected here, and are
+	// corrected by the next seed, since every seed's floor includes the durable mark.
+	rollbackTolerance = legacyGenSeqStep
 
 	// QueueKeyPrefix is the authoritative per-bot event queue. Defined here so the
 	// producers and the consumer stop each spelling it with their own
@@ -144,6 +213,10 @@ func SeqKey(robotID string) string { return SeqKeyPrefix + robotID }
 // QueueKey returns the authoritative event queue key for robotID.
 func QueueKey(robotID string) string { return QueueKeyPrefix + robotID }
 
+// HighWaterSeqKey returns the `seq` table key holding robotID's durable
+// high-water mark. The `seq:` prefix matches how GenSeq namespaces its own rows.
+func HighWaterSeqKey(robotID string) string { return "seq:" + HighWaterKeyPrefix + robotID }
+
 // seedSource raises the counter to floor if it is currently lower or unset, and
 // returns the resulting value.
 //
@@ -174,6 +247,15 @@ var seedScript = rd.NewScript(seedSource)
 // while others still allocate from GenSeq: two live id sources, which is the
 // defect. Reading it inside the same script as the INCR makes a flip take effect
 // on the very next allocation, everywhere, with no window of divergence.
+// gateNotActivated is the sentinel gateSource returns when the mode does not match.
+//
+// It is distinguishable from any legitimate id because a seeded counter is never
+// negative: every floor is >= 0 and INCR only rises. Callers match it **exactly**
+// rather than testing `v < 0`, so a counter that somehow went negative (a manual
+// SET, a corrupted restore) surfaces as an error instead of being mistaken for
+// "not activated" and silently degrading to the legacy allocator.
+const gateNotActivated = -1
+
 const gateSource = `
 if redis.call('GET', KEYS[1]) ~= ARGV[1] then return -1 end
 return redis.call('INCR', KEYS[2])`
@@ -241,7 +323,35 @@ var (
 	// observability work that owns that namespace, as bell.go notes for its own
 	// counter.
 	seedFailures atomic.Int64
+
+	// lastIssued is the highest id this process has handed out per bot. It is the
+	// rollback detector: Redis INCR cannot go backwards on its own, so an
+	// allocation that fails to advance past this means the counter regressed
+	// underneath us (an RDB-loss restart, or a flushed key).
+	lastIssued sync.Map
+
+	// seedLocks single-flights the seed per bot; see reseed.
+	seedLocks sync.Map
+
+	// lastPersisted tracks how far the durable high-water mark has been advanced,
+	// so the DB write happens once per highWaterInterval rather than per id.
+	lastPersisted sync.Map
+
+	// rollbacksDetected counts regressions caught and self-healed. Non-zero means
+	// Redis lost data; the events issued in the lost window are gone regardless,
+	// but delivery recovers without a runbook.
+	rollbacksDetected atomic.Int64
+
+	// expectedMode is read once. Re-reading os.Getenv per allocation would put a
+	// syscall on the hottest producer path for a value that cannot change.
+	expectedMode = strings.TrimSpace(os.Getenv(ExpectedModeEnv))
 )
+
+// SeedFailures reports how many allocations failed at the seed step.
+func SeedFailures() int64 { return seedFailures.Load() }
+
+// RollbacksDetected reports how many counter regressions were caught and healed.
+func RollbacksDetected() int64 { return rollbacksDetected.Load() }
 
 // SeqClient returns the shared allocator client, built through octoredis so TLS
 // options are honoured and pkg/redis's raw-client chokepoint guard stays
@@ -262,9 +372,6 @@ func SeqClient(cfg *config.Config) Scripter {
 	})
 	return seqClient
 }
-
-// SeedFailures reports how many allocations failed at the seed step.
-func SeedFailures() int64 { return seedFailures.Load() }
 
 // NextEventID allocates the next event id for robotID's queue.
 //
@@ -297,13 +404,10 @@ func nextEventID(ctx *config.Context, client Scripter, robotID string) (int64, e
 		if err != nil {
 			return 0, err
 		}
-		if v >= 0 {
-			return v, nil
+		if v == gateNotActivated {
+			return modeLost(ctx, robotID)
 		}
-		// Activated, then not: there is no supported deactivation, so this means
-		// the mode key was cleared out from under us. Legacy is the safe answer —
-		// it is what every other writer would now be doing too.
-		return legacyEventID(ctx, robotID)
+		return afterIssue(ctx, client, robotID, v)
 	}
 
 	mode, err := client.Get(ModeKey).Result()
@@ -311,26 +415,177 @@ func nextEventID(ctx *config.Context, client Scripter, robotID string) (int64, e
 		return 0, fmt.Errorf("botevent: read allocator mode: %w", err)
 	}
 	if mode != ModeIncr {
-		return legacyEventID(ctx, robotID)
+		return modeLost(ctx, robotID)
 	}
 
 	// Activated and this process has not seeded this bot yet. Seed before the
 	// first INCR, never after: an id handed out below the floor is exactly the
 	// unreachable-event bug.
-	if err := seedCounter(ctx, client, robotID); err != nil {
-		seedFailures.Add(1)
-		return 0, fmt.Errorf("botevent: seed event id counter for %q: %w", robotID, err)
+	if err := reseed(ctx, client, robotID); err != nil {
+		return 0, err
 	}
-	seeded.Store(robotID, struct{}{})
 
 	v, err := runGate(client, robotID)
 	if err != nil {
 		return 0, err
 	}
-	if v < 0 {
-		return legacyEventID(ctx, robotID)
+	if v == gateNotActivated {
+		return modeLost(ctx, robotID)
 	}
+	return afterIssue(ctx, client, robotID, v)
+}
+
+// afterIssue validates the freshly allocated id against what this process has
+// already issued, then advances the durable high-water mark.
+//
+// The check is the rollback detector. INCR is monotonic while the key survives, so
+// an id that does not advance can only mean the counter regressed beneath us — an
+// RDB-loss restart, a FLUSHDB, a manual DEL. Without this, a long-running replica
+// would keep INCRing the regressed counter and every id it issues would sit below
+// live consumer cursors, invisible, until the counter climbed back on its own.
+func afterIssue(ctx *config.Context, client Scripter, robotID string, v int64) (int64, error) {
+	if prev, regressed := checkRegression(robotID, v); regressed {
+		rollbacksDetected.Add(1)
+		// Re-seed from the durable floor and retry once. One retry is enough: the
+		// seed raises the counter above the high-water mark, so the next INCR
+		// cannot land beneath it again unless Redis regresses a second time in
+		// between, which the next allocation would catch in turn.
+		seeded.Delete(robotID)
+		lastPersisted.Delete(robotID)
+		if err := reseed(ctx, client, robotID); err != nil {
+			return 0, err
+		}
+		retried, err := runGate(client, robotID)
+		if err != nil {
+			return 0, err
+		}
+		if retried == gateNotActivated {
+			return modeLost(ctx, robotID)
+		}
+		if retried <= prev {
+			// The floor did not clear the ids this process already handed out, so
+			// issuing would put an event below a cursor we know a client can hold.
+			// Refuse rather than lose it silently.
+			return 0, fmt.Errorf("botevent: counter for %q regressed to %d and re-seeding "+
+				"only reached %d, which is still at or below the %d already issued by this "+
+				"process; refusing to issue an id below a live consumer cursor",
+				robotID, v, retried, prev)
+		}
+		v = retried
+	}
+	recordIssued(robotID, v)
+	persistHighWater(ctx, robotID, v)
 	return v, nil
+}
+
+// checkRegression reports this process's high-water for robotID and whether v is
+// far enough below it to mean the counter regressed. See rollbackTolerance for why
+// "far enough" rather than "at all".
+func checkRegression(robotID string, v int64) (int64, bool) {
+	prev, ok := lastIssued.Load(robotID)
+	if !ok {
+		return 0, false
+	}
+	high := prev.(int64)
+	return high, v+rollbackTolerance <= high
+}
+
+// recordIssued advances this process's high-water monotonically.
+//
+// Compare-and-swap rather than a plain Store: concurrent callers arrive out of
+// order, and a Store would let a later-arriving lower id overwrite the maximum,
+// which would then make the *next* allocation look like a regression.
+func recordIssued(robotID string, v int64) {
+	for {
+		prev, loaded := lastIssued.Load(robotID)
+		if !loaded {
+			if _, already := lastIssued.LoadOrStore(robotID, v); !already {
+				return
+			}
+			continue
+		}
+		high := prev.(int64)
+		if v <= high {
+			return
+		}
+		if lastIssued.CompareAndSwap(robotID, high, v) {
+			return
+		}
+	}
+}
+
+// reseed seeds the counter and marks the bot seeded, counting failures.
+//
+// Single-flighted per bot, with a double check inside the lock. Concurrent first
+// allocations would otherwise each seed: the ones that lose the race run *after*
+// the winner has already issued ids and advanced the durable mark, so their floor
+// is computed from that mark and lands seedSafetyMargin above the live counter —
+// jumping it forward and burning a block of ids per racing caller. The seed is
+// still idempotent (the Lua only raises), so this is about not moving the counter
+// needlessly, not about correctness of a single seed.
+func reseed(ctx *config.Context, client Scripter, robotID string) error {
+	mu := seedMutex(robotID)
+	mu.Lock()
+	defer mu.Unlock()
+	if _, done := seeded.Load(robotID); done {
+		return nil
+	}
+	if err := seedCounter(ctx, client, robotID); err != nil {
+		seedFailures.Add(1)
+		return fmt.Errorf("botevent: seed event id counter for %q: %w", robotID, err)
+	}
+	seeded.Store(robotID, struct{}{})
+	return nil
+}
+
+// seedMutex returns the per-bot seed lock, creating it once.
+func seedMutex(robotID string) *sync.Mutex {
+	if mu, ok := seedLocks.Load(robotID); ok {
+		return mu.(*sync.Mutex)
+	}
+	actual, _ := seedLocks.LoadOrStore(robotID, &sync.Mutex{})
+	return actual.(*sync.Mutex)
+}
+
+// modeLost handles a mode key that is absent when the caller may have expected it.
+//
+// Unset expectation means pre-activation, and legacy is correct. An explicit
+// `incr` expectation means the mode was lost or rolled back after activation, and
+// legacy would then issue ids from a lower GenSeq block — beneath live cursors, the
+// same loss mirrored. Fail closed instead.
+func modeLost(ctx *config.Context, robotID string) (int64, error) {
+	if expectedMode == ModeIncr {
+		return 0, fmt.Errorf("botevent: %s=%s but %s is not %q; refusing to fall back to the "+
+			"legacy allocator, whose lower ids would land below live consumer cursors",
+			ExpectedModeEnv, expectedMode, ModeKey, ModeIncr)
+	}
+	return legacyEventID(ctx, robotID)
+}
+
+// persistHighWater advances the durable mark at most once per highWaterInterval.
+//
+// Best-effort on purpose: the id is already issued and the enqueue must not fail
+// because a bookkeeping write did. A missed write only shortens how far the mark
+// trails, which seedSafetyMargin absorbs.
+func persistHighWater(ctx *config.Context, robotID string, v int64) {
+	if prev, ok := lastPersisted.Load(robotID); ok && v-prev.(int64) < highWaterInterval {
+		return
+	}
+	// The mark records what has been issued, not a reservation above it. Writing
+	// `v + interval` would compound: every seed adds seedSafetyMargin on top of the
+	// mark, so a mark that already ran ahead would push the counter forward by
+	// interval + margin each time it was consulted.
+	mark := v
+	// GREATEST, never a bare assignment. An unconditional overwrite is precisely how
+	// GenSeq lets a lagging replica drag a floor backwards (the root cause of #697),
+	// and this row is a floor.
+	if _, err := ctx.DB().InsertBySql(
+		"insert into `seq`(`key`,min_seq,step) values(?,?,0) "+
+			"on duplicate key update min_seq = GREATEST(min_seq, VALUES(min_seq))",
+		HighWaterSeqKey(robotID), mark).Exec(); err != nil {
+		return
+	}
+	lastPersisted.Store(robotID, v)
 }
 
 // runGate performs the atomic mode-check-and-allocate. -1 means "not activated".
@@ -342,6 +597,10 @@ func runGate(client Scripter, robotID string) (int64, error) {
 	id, ok := v.(int64)
 	if !ok {
 		return 0, fmt.Errorf("botevent: allocate event id for %q: unexpected script result %T", robotID, v)
+	}
+	if id < gateNotActivated || id == 0 {
+		return 0, fmt.Errorf("botevent: counter for %q returned %d, which is neither a valid id "+
+			"nor the not-activated sentinel; refusing to issue it", robotID, id)
 	}
 	return id, nil
 }
@@ -366,7 +625,7 @@ func legacyEventID(ctx *config.Context, robotID string) (int64, error) {
 // seedCounter raises the counter above everything legacy could have handed out
 // for this bot.
 //
-// Both sources are needed. The queue's max score covers ids already enqueued —
+// Three sources are needed. The queue's max score covers ids already enqueued —
 // including by an old replica whose block sits above a regressed `min_seq`. The
 // `seq` row covers the opposite case: a bot whose queue has been fully acked (or
 // has expired) still has clients holding a cursor near the last id it was ever
@@ -381,9 +640,20 @@ func seedCounter(ctx *config.Context, client Scripter, robotID string) error {
 	if err != nil {
 		return err
 	}
+	// The durable mark is the only floor source that does not share Redis's
+	// recovery domain, so it is what makes a post-activation RDB rollback
+	// survivable. The other two both regress with the counter (queue) or stop
+	// advancing at activation (legacy row).
+	durableMax, err := highWaterCeiling(ctx, robotID)
+	if err != nil {
+		return err
+	}
 	floor := queueMax
 	if legacyMax > floor {
 		floor = legacyMax
+	}
+	if durableMax > floor {
+		floor = durableMax
 	}
 	if floor > 0 {
 		// A bot with no queue and no seq row has never been issued an id, so it
@@ -406,6 +676,22 @@ func queueCeiling(client Scripter, robotID string) (int64, error) {
 	return int64(top[0].Score), nil
 }
 
+// highWaterCeiling returns the durable high-water mark for this bot, or 0.
+//
+// Unlike the queue ceiling and the legacy row, this keeps advancing after
+// activation, which is what lets a seed recover from a Redis rollback.
+func highWaterCeiling(ctx *config.Context, robotID string) (int64, error) {
+	if ctx == nil {
+		return 0, errors.New("nil ctx, cannot read high-water mark")
+	}
+	var mark int64
+	if _, err := ctx.DB().Select("min_seq").From("`seq`").
+		Where("`key`=?", HighWaterSeqKey(robotID)).Load(&mark); err != nil {
+		return 0, fmt.Errorf("read high-water mark: %w", err)
+	}
+	return mark, nil
+}
+
 // legacyCeiling returns the legacy `GenSeq` block boundary for this bot's event
 // sequence, or 0 when it never used one.
 //
@@ -425,9 +711,20 @@ func legacyCeiling(ctx *config.Context, robotID string) (int64, error) {
 // ResetSeededForTest clears the process-local seed cache. Tests that seed against
 // different fixtures need it; production never does.
 func ResetSeededForTest() {
-	seeded.Range(func(k, _ interface{}) bool {
-		seeded.Delete(k)
-		return true
-	})
+	for _, m := range []*sync.Map{&seeded, &lastIssued, &lastPersisted, &seedLocks} {
+		m.Range(func(k, _ interface{}) bool {
+			m.Delete(k)
+			return true
+		})
+	}
 	seedFailures.Store(0)
+	rollbacksDetected.Store(0)
+}
+
+// SetExpectedModeForTest overrides the env-derived expectation and returns a
+// restore function.
+func SetExpectedModeForTest(mode string) func() {
+	prev := expectedMode
+	expectedMode = mode
+	return func() { expectedMode = prev }
 }

--- a/pkg/botevent/seq.go
+++ b/pkg/botevent/seq.go
@@ -332,6 +332,11 @@ const (
 	// event became visible again. Failing before issuing is strictly better than
 	// detecting it afterwards. (Review finding 2.2.)
 	gateCounterMissing = -2
+
+	// maxExactScoreID is the largest event id whose successor can still be encoded as a
+	// distinct float64 sorted-set score. At 2^53, 2^53+1 rounds to the same score and
+	// recreates the collision, cursor skip and multi-member ack #697 removes.
+	maxExactScoreID = int64(1<<53 - 1)
 )
 
 const gateSource = `
@@ -635,7 +640,7 @@ func allocate(ctx *config.Context, client Scripter, robotID string, attempt int)
 	}
 	// Seed before the first INCR, never after: an id handed out below the floor is
 	// exactly the unreachable-event bug.
-	if err := reseed(ctx, client, robotID); err != nil {
+	if err := reseed(ctx, client, robotID, b); err != nil {
 		return 0, err
 	}
 	if rebuildMirror {
@@ -670,15 +675,15 @@ func allocateFromCounter(ctx *config.Context, client Scripter, robotID string, b
 		countersLost.inc()
 		seeded.Delete(robotID)
 		lastPersisted.Delete(robotID)
-		if err := reseed(ctx, client, robotID); err != nil {
+		if err := reseed(ctx, client, robotID, b); err != nil {
 			return 0, err
 		}
 		retried, err := runGate(client, robotID, b.mirrorValue())
 		if err != nil {
 			return 0, err
 		}
-		if retried < 0 {
-			return 0, fmt.Errorf("botevent: counter for %q still unusable after re-seed (gate=%d)", robotID, retried)
+		if final, handled, retryErr := handleGateRetrySentinel(ctx, client, robotID, retried, attempt+1); handled {
+			return final, retryErr
 		}
 		return afterIssue(ctx, client, robotID, retried, attempt+1)
 	}
@@ -825,21 +830,21 @@ func afterIssue(ctx *config.Context, client Scripter, robotID string, v int64, a
 		// between, which the next allocation would catch in turn.
 		seeded.Delete(robotID)
 		lastPersisted.Delete(robotID)
-		if err := reseed(ctx, client, robotID); err != nil {
-			return 0, err
-		}
 		b := activeBelief.Load()
 		if b == nil || !b.activated {
 			// The belief cannot have been downgraded (positive is terminal), so this
 			// means it was cleared underneath us — only a test does that.
 			return 0, fmt.Errorf("botevent: allocator belief lost mid-allocation for %q", robotID)
 		}
+		if err := reseed(ctx, client, robotID, b); err != nil {
+			return 0, err
+		}
 		retried, err := runGate(client, robotID, b.mirrorValue())
 		if err != nil {
 			return 0, err
 		}
-		if retried == gateNotActivated {
-			return gateClosed(ctx, client, robotID, attempt+1)
+		if final, handled, retryErr := handleGateRetrySentinel(ctx, client, robotID, retried, attempt+1); handled {
+			return final, retryErr
 		}
 		if retried <= prev {
 			// The floor did not clear the ids this process already handed out, so
@@ -857,6 +862,22 @@ func afterIssue(ctx *config.Context, client Scripter, robotID string, v int64, a
 	// and why bounding it is #704's rather than this function's.
 	persistHighWater(ctx, robotID, v)
 	return v, nil
+}
+
+// handleGateRetrySentinel gives both post-seed retry sites the same explicit handling.
+// A changed mirror re-enters the authority recovery path; a counter that disappears again
+// fails closed with the actual fault instead of being reported as a numeric floor.
+func handleGateRetrySentinel(ctx *config.Context, client Scripter, robotID string, result int64, attempt int) (int64, bool, error) {
+	switch result {
+	case gateNotActivated:
+		id, err := gateClosed(ctx, client, robotID, attempt)
+		return id, true, err
+	case gateCounterMissing:
+		return 0, true, fmt.Errorf("botevent: counter for %q is still missing after re-seed; "+
+			"refusing to issue from an unseeded key", robotID)
+	default:
+		return result, false, nil
+	}
 }
 
 // checkRegression reports this process's high-water for robotID and whether v is
@@ -904,14 +925,17 @@ func recordIssued(robotID string, v int64) {
 // jumping it forward and burning a block of ids per racing caller. The seed is
 // still idempotent (the Lua only raises), so this is about not moving the counter
 // needlessly, not about correctness of a single seed.
-func reseed(ctx *config.Context, client Scripter, robotID string) error {
+func reseed(ctx *config.Context, client Scripter, robotID string, b *belief) error {
 	mu := seedMutex(robotID)
 	mu.Lock()
 	defer mu.Unlock()
 	if _, done := seeded.Load(robotID); done {
 		return nil
 	}
-	if err := seedCounter(ctx, client, robotID); err != nil {
+	if b == nil || !b.activated {
+		return errors.New("botevent: cannot seed without a validated activated belief")
+	}
+	if err := seedCounter(ctx, client, robotID, b.cutoverFloor); err != nil {
 		seedFailures.inc()
 		return fmt.Errorf("botevent: seed event id counter for %q: %w", robotID, err)
 	}
@@ -1046,6 +1070,11 @@ func runGate(client Scripter, robotID, expectMirror string) (int64, error) {
 		return 0, fmt.Errorf("botevent: counter for %q returned %d, which is neither a valid id "+
 			"nor a known sentinel; refusing to issue it", robotID, id)
 	}
+	if id > maxExactScoreID {
+		return 0, fmt.Errorf("botevent: counter for %q returned %d, above the largest event id %d "+
+			"with an exact float64 sorted-set score; refusing to recreate score collisions",
+			robotID, id, maxExactScoreID)
+	}
 	return id, nil
 }
 
@@ -1075,20 +1104,12 @@ func legacyEventID(ctx *config.Context, robotID string) (int64, error) {
 // has expired) still has clients holding a cursor near the last id it was ever
 // issued, and seeding below that cursor would make every new event unreachable —
 // the very failure this change exists to remove, self-inflicted at deploy time.
-func seedCounter(ctx *config.Context, client Scripter, robotID string) error {
+func seedCounter(ctx *config.Context, client Scripter, robotID string, cutoverFloor int64) error {
 	queueMax, err := queueCeiling(client, robotID)
 	if err != nil {
 		return err
 	}
-	legacyMax, err := legacyCeiling(ctx, robotID)
-	if err != nil {
-		return err
-	}
-	// The durable mark is the only floor source that does not share Redis's
-	// recovery domain, so it is what makes a post-activation RDB rollback
-	// survivable. The other two both regress with the counter (queue) or stop
-	// advancing at activation (legacy row).
-	durableMax, err := highWaterCeiling(ctx, robotID)
+	legacyMax, durableMax, err := seqCeilings(ctx, robotID)
 	if err != nil {
 		return err
 	}
@@ -1099,11 +1120,11 @@ func seedCounter(ctx *config.Context, client Scripter, robotID string) error {
 	if durableMax > floor {
 		floor = durableMax
 	}
-	// The floor recorded at activation, validated against the observed maximum at
-	// that time. A backstop for the case where every Redis-side source has been lost
-	// at once and the durable mark has not caught up yet.
-	if stateFloor := stateFloorOrZero(ctx); stateFloor > floor {
-		floor = stateFloor
+	// The floor recorded at activation, validated in the same authority read that
+	// produced the positive belief. It is carried by that immutable belief rather than
+	// re-read here: an unreadable row must not silently turn a validated floor into zero.
+	if cutoverFloor > floor {
+		floor = cutoverFloor
 	}
 	if floor > 0 {
 		// A bot with no queue and no seq row has never been issued an id, so it
@@ -1112,6 +1133,36 @@ func seedCounter(ctx *config.Context, client Scripter, robotID string) error {
 		floor += seedSafetyMargin
 	}
 	return seedScript.Run(client, []string{SeqKey(robotID)}, floor).Err()
+}
+
+// seqCeilings loads the legacy and durable rows with one query.
+//
+// A lost mode mirror invalidates every process-local seed marker. Folding these two
+// same-table point reads into one conditional aggregate keeps that fleet-wide recovery
+// burst to one deadlined MySQL round trip per active bot; the cutover floor itself comes
+// from the already-validated positive belief and needs no third read.
+func seqCeilings(ctx *config.Context, robotID string) (legacy, durable int64, err error) {
+	if ctx == nil {
+		return 0, 0, errors.New("nil ctx, cannot read seq ceilings")
+	}
+	deadline, cancel := context.WithTimeout(context.Background(), authorityTimeout)
+	defer cancel()
+	legacyKey := fmt.Sprintf("seq:%s%s", common.RobotEventSeqKey, robotID)
+	durableKey := HighWaterSeqKey(robotID)
+	var row struct {
+		Legacy  int64 `db:"legacy_ceiling"`
+		Durable int64 `db:"durable_ceiling"`
+	}
+	_, err = ctx.DB().SelectBySql(
+		"SELECT COALESCE(MAX(CASE WHEN `key`=? THEN min_seq END),0) AS legacy_ceiling, "+
+			"COALESCE(MAX(CASE WHEN `key`=? THEN min_seq END),0) AS durable_ceiling "+
+			"FROM `seq` WHERE `key` IN (?,?)",
+		legacyKey, durableKey, legacyKey, durableKey,
+	).LoadContext(deadline, &row)
+	if err != nil {
+		return 0, 0, fmt.Errorf("read legacy and durable seq rows: %w", err)
+	}
+	return row.Legacy, row.Durable, nil
 }
 
 // queueCeiling returns the highest score currently in the bot's queue, or 0.
@@ -1131,17 +1182,8 @@ func queueCeiling(client Scripter, robotID string) (int64, error) {
 // Unlike the queue ceiling and the legacy row, this keeps advancing after
 // activation, which is what lets a seed recover from a Redis rollback.
 func highWaterCeiling(ctx *config.Context, robotID string) (int64, error) {
-	if ctx == nil {
-		return 0, errors.New("nil ctx, cannot read high-water mark")
-	}
-	deadline, cancel := context.WithTimeout(context.Background(), authorityTimeout)
-	defer cancel()
-	var mark int64
-	if _, err := ctx.DB().Select("min_seq").From("`seq`").
-		Where("`key`=?", HighWaterSeqKey(robotID)).LoadContext(deadline, &mark); err != nil {
-		return 0, fmt.Errorf("read high-water mark: %w", err)
-	}
-	return mark, nil
+	_, durable, err := seqCeilings(ctx, robotID)
+	return durable, err
 }
 
 // legacyCeiling returns the legacy `GenSeq` block boundary for this bot's event
@@ -1151,15 +1193,8 @@ func highWaterCeiling(ctx *config.Context, robotID string) (int64, error) {
 // allocate — and allocating from the very source being retired is how a "read"
 // turns into a third live id source.
 func legacyCeiling(ctx *config.Context, robotID string) (int64, error) {
-	deadline, cancel := context.WithTimeout(context.Background(), authorityTimeout)
-	defer cancel()
-	var minSeq int64
-	key := fmt.Sprintf("seq:%s%s", common.RobotEventSeqKey, robotID)
-	if _, err := ctx.DB().Select("min_seq").From("`seq`").
-		Where("`key`=?", key).LoadContext(deadline, &minSeq); err != nil {
-		return 0, fmt.Errorf("read legacy seq row: %w", err)
-	}
-	return minSeq, nil
+	legacy, _, err := seqCeilings(ctx, robotID)
+	return legacy, err
 }
 
 // ResetSeededForTest clears the process-local seed cache. Tests that seed against

--- a/pkg/botevent/seq.go
+++ b/pkg/botevent/seq.go
@@ -122,17 +122,31 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/config"
 	octoredis "github.com/Mininglamp-OSS/octo-server/pkg/redis"
 	rd "github.com/go-redis/redis"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
 const (
-	// SeqKeyPrefix namespaces the per-bot event id counter. Distinct from both
-	// `robotEvent:` and `robotEventBell:` so the counter, the authoritative queue
-	// and the hint can never collide.
-	SeqKeyPrefix = "botEventSeq:"
+	// SeqKeyPrefix namespaces the per-bot event id counter.
+	//
+	// The `counter:` segment is load-bearing, not decoration. It was `botEventSeq:`
+	// while ModeKey was `botEventSeq:mode`, which made SeqKey("mode") *equal* to
+	// ModeKey: a bot whose id was `mode` would have seeded and INCRed the global
+	// activation flag as its own counter, coupling one bot's data path to the gate
+	// for every bot. Robot ids are UUID-hex in practice, so it was unreachable — and
+	// a namespace where one legal input collides with a global key is not something
+	// to leave standing on that basis. TestCounterKeyCannotCollideWithModeKey pins it.
+	SeqKeyPrefix = "botEventSeq:counter:"
 
-	// ModeKey holds the process-wide allocator mode. Absent or anything other than
-	// ModeIncr means legacy, so a deployment with no operator action behaves
-	// exactly like the old binary.
+	// ModeKey is the Redis **mirror** of the authoritative mode in
+	// octo_bot_event_seq_state (see state.go).
+	//
+	// The mirror exists so the mode can be checked inside the same Lua script as the
+	// INCR — atomically, without a DB round trip on the hot path. It is not the
+	// authority: it lives in a Redis running `appendonly no`, so it regresses with an
+	// RDB snapshot, and an absent mirror must therefore mean "consult the DB", never
+	// "fall back to legacy". Falling back would issue GenSeq ids below everything the
+	// counter already handed out — #697 mirrored.
 	ModeKey = "botEventSeq:mode"
 
 	// ModeIncr is the activated state: allocate from the monotonic counter.
@@ -164,6 +178,18 @@ const (
 	// highWaterInterval is how many ids may be issued between durable writes. One
 	// legacy block, so the mark trails the truth by less than seedSafetyMargin.
 	highWaterInterval = legacyGenSeqStep
+
+	// maxAllocAttempts bounds the self-healing retries within one allocation.
+	//
+	// afterIssue and mirrorMissing call each other: a re-seed can land on a gate that
+	// has just lost its mirror, and rebuilding the mirror ends in afterIssue again.
+	// Each hop is legitimate, but the pair is mutually recursive, so a Redis that keeps
+	// losing state (a FLUSHDB loop, a flapping restore) could recurse until the stack
+	// gives out — a process crash, which is strictly worse than failing one enqueue.
+	// Three attempts covers every single-fault recovery the tests exercise; beyond that
+	// the state is changing faster than one allocation can track and the caller should
+	// see an error.
+	maxAllocAttempts = 3
 
 	// rollbackTolerance is how far below this process's high-water an allocation may
 	// land before it is treated as a counter regression rather than ordinary
@@ -247,17 +273,32 @@ var seedScript = rd.NewScript(seedSource)
 // while others still allocate from GenSeq: two live id sources, which is the
 // defect. Reading it inside the same script as the INCR makes a flip take effect
 // on the very next allocation, everywhere, with no window of divergence.
-// gateNotActivated is the sentinel gateSource returns when the mode does not match.
-//
-// It is distinguishable from any legitimate id because a seeded counter is never
-// negative: every floor is >= 0 and INCR only rises. Callers match it **exactly**
-// rather than testing `v < 0`, so a counter that somehow went negative (a manual
-// SET, a corrupted restore) surfaces as an error instead of being mistaken for
-// "not activated" and silently degrading to the legacy allocator.
-const gateNotActivated = -1
+// Sentinels returned by gateSource. Both are distinguishable from any legitimate id
+// because a seeded counter is never negative: every floor is >= 0 and INCR only
+// rises. Callers match them **exactly** rather than testing `v < 0`, so a counter
+// that somehow went negative (a manual SET, a corrupted restore) surfaces as an
+// error instead of being mistaken for a sentinel and silently degrading.
+const (
+	// gateNotActivated: the mode mirror does not say incr.
+	gateNotActivated = -1
+
+	// gateCounterMissing: the mirror says incr but the counter key is gone.
+	//
+	// This guard is why the script does an EXISTS. `INCR` on a missing key returns
+	// **1**, and the only thing that would otherwise stop an unseeded INCR is
+	// `seeded` — a process-local map guarding Redis state. So a partial restore, a
+	// stray DEL, or a FLUSHDB that takes the counter but leaves the mirror, with the
+	// process still up, would renumber that bot's events from 1: arbitrarily far
+	// below its consumer's cursor, and worse than a snapshot rollback because
+	// recovery would require re-issuing the bot's entire historical range before one
+	// event became visible again. Failing before issuing is strictly better than
+	// detecting it afterwards. (Review finding 2.2.)
+	gateCounterMissing = -2
+)
 
 const gateSource = `
 if redis.call('GET', KEYS[1]) ~= ARGV[1] then return -1 end
+if redis.call('EXISTS', KEYS[2]) == 0 then return -2 end
 return redis.call('INCR', KEYS[2])`
 
 var gateScript = rd.NewScript(gateSource)
@@ -272,6 +313,7 @@ var gateScript = rd.NewScript(gateSource)
 // consequences.
 type Scripter interface {
 	Get(key string) *rd.StringCmd
+	Set(key string, value interface{}, expiration time.Duration) *rd.StatusCmd
 	Incr(key string) *rd.IntCmd
 	ZRevRangeWithScores(key string, start, stop int64) *rd.ZSliceCmd
 	Eval(script string, keys []string, args ...interface{}) *rd.Cmd
@@ -309,6 +351,33 @@ const (
 	seqMaxRetries  = 1
 )
 
+// healCounter is a counter that is both visible to Prometheus in production and
+// readable by a test.
+//
+// Both halves are needed. The Prometheus counter is the only way an operator learns
+// that Redis lost state — these four events all *self-heal*, so without a metric they
+// produce no error, no failed enqueue and no log an alert could key on, and the RDB
+// safety margin degrades silently. The atomic is what lets the tests assert the heal
+// actually fired, without pulling prometheus/testutil into production code.
+//
+// Registered through promauto on the default registry, matching pkg/i18n/details.go
+// and modules/oidc/metrics.go. No labels: four distinct names beat one metric with a
+// reason label, and the brief asks for low cardinality.
+type healCounter struct {
+	n atomic.Int64
+	m prometheus.Counter
+}
+
+func newHealCounter(name, help string) *healCounter {
+	return &healCounter{m: promauto.NewCounter(prometheus.CounterOpts{Name: name, Help: help})}
+}
+
+func (c *healCounter) inc()        { c.n.Add(1); c.m.Inc() }
+func (c *healCounter) load() int64 { return c.n.Load() }
+
+// resetForTest zeroes only the test-facing half; a Prometheus counter cannot decrease.
+func (c *healCounter) resetForTest() { c.n.Store(0) }
+
 var (
 	seqClientOnce sync.Once
 	seqClient     *rd.Client
@@ -318,11 +387,9 @@ var (
 	// round trip, never correctness.
 	seeded sync.Map
 
-	// seedFailures counts seeds that could not be established. Exposed for tests
-	// and for the operator check; wiring it to Prometheus belongs to the card
-	// observability work that owns that namespace, as bell.go notes for its own
-	// counter.
-	seedFailures atomic.Int64
+	// seedFailures counts seeds that could not be established.
+	seedFailures = newHealCounter("dmwork_bot_event_seq_seed_failure_total",
+		"Bot event id seeds that could not be established; the enqueue was refused.")
 
 	// lastIssued is the highest id this process has handed out per bot. It is the
 	// rollback detector: Redis INCR cannot go backwards on its own, so an
@@ -337,10 +404,25 @@ var (
 	// so the DB write happens once per highWaterInterval rather than per id.
 	lastPersisted sync.Map
 
+	// countersLost counts allocations that found the mirror set but the counter key
+	// gone, and mirrorRebuilds counts mirrors rebuilt from the DB authority. Both
+	// mean Redis lost data; both are self-healed, and both are worth alerting on.
+	countersLost = newHealCounter("dmwork_bot_event_seq_counter_lost_total",
+		"Allocations that found the mode mirror set but the per-bot counter key gone.")
+	mirrorRebuilds = newHealCounter("dmwork_bot_event_seq_mirror_rebuild_total",
+		"Times the Redis mode mirror was rebuilt from the authoritative DB row.")
+
+	// highWaterWriteFailures counts durable high-water writes that did not land.
+	// The rollback recovery story depends on that mark, so a rising count means the
+	// RDB safety margin has degraded even though nothing else looks wrong.
+	highWaterWriteFailures = newHealCounter("dmwork_bot_event_seq_high_water_write_failure_total",
+		"Durable high-water writes that failed; the RDB rollback safety margin has degraded.")
+
 	// rollbacksDetected counts regressions caught and self-healed. Non-zero means
 	// Redis lost data; the events issued in the lost window are gone regardless,
 	// but delivery recovers without a runbook.
-	rollbacksDetected atomic.Int64
+	rollbacksDetected = newHealCounter("dmwork_bot_event_seq_rollback_total",
+		"Counter regressions detected and self-healed; non-zero means Redis lost data.")
 
 	// expectedMode is read once. Re-reading os.Getenv per allocation would put a
 	// syscall on the hottest producer path for a value that cannot change.
@@ -348,10 +430,19 @@ var (
 )
 
 // SeedFailures reports how many allocations failed at the seed step.
-func SeedFailures() int64 { return seedFailures.Load() }
+func SeedFailures() int64 { return seedFailures.load() }
 
 // RollbacksDetected reports how many counter regressions were caught and healed.
-func RollbacksDetected() int64 { return rollbacksDetected.Load() }
+func RollbacksDetected() int64 { return rollbacksDetected.load() }
+
+// CountersLost reports how many allocations found the counter key missing.
+func CountersLost() int64 { return countersLost.load() }
+
+// MirrorRebuilds reports how many times the mode mirror was rebuilt from the DB.
+func MirrorRebuilds() int64 { return mirrorRebuilds.load() }
+
+// HighWaterWriteFailures reports durable high-water writes that failed.
+func HighWaterWriteFailures() int64 { return highWaterWriteFailures.load() }
 
 // SeqClient returns the shared allocator client, built through octoredis so TLS
 // options are honoured and pkg/redis's raw-client chokepoint guard stays
@@ -393,6 +484,11 @@ func NextEventID(ctx *config.Context, robotID string) (int64, error) {
 // nextEventID is the testable core: it takes the client explicitly so a test can
 // inject one whose seed or INCR fails.
 func nextEventID(ctx *config.Context, client Scripter, robotID string) (int64, error) {
+	return allocate(ctx, client, robotID, 0)
+}
+
+// allocate is nextEventID with the self-healing attempt counter threaded through.
+func allocate(ctx *config.Context, client Scripter, robotID string, attempt int) (int64, error) {
 	if client == nil {
 		return 0, errors.New("botevent: nil redis client, cannot allocate event id")
 	}
@@ -404,10 +500,28 @@ func nextEventID(ctx *config.Context, client Scripter, robotID string) (int64, e
 		if err != nil {
 			return 0, err
 		}
-		if v == gateNotActivated {
-			return modeLost(ctx, robotID)
+		switch v {
+		case gateNotActivated:
+			return mirrorMissing(ctx, client, robotID, attempt+1)
+		case gateCounterMissing:
+			// The mirror says activated but the counter is gone. Re-seed from the
+			// durable floors and retry; issuing would renumber from 1.
+			countersLost.inc()
+			seeded.Delete(robotID)
+			lastPersisted.Delete(robotID)
+			if err := reseed(ctx, client, robotID); err != nil {
+				return 0, err
+			}
+			retried, err := runGate(client, robotID)
+			if err != nil {
+				return 0, err
+			}
+			if retried < 0 {
+				return 0, fmt.Errorf("botevent: counter for %q still unusable after re-seed (gate=%d)", robotID, retried)
+			}
+			return afterIssue(ctx, client, robotID, retried, attempt+1)
 		}
-		return afterIssue(ctx, client, robotID, v)
+		return afterIssue(ctx, client, robotID, v, attempt)
 	}
 
 	mode, err := client.Get(ModeKey).Result()
@@ -415,7 +529,7 @@ func nextEventID(ctx *config.Context, client Scripter, robotID string) (int64, e
 		return 0, fmt.Errorf("botevent: read allocator mode: %w", err)
 	}
 	if mode != ModeIncr {
-		return modeLost(ctx, robotID)
+		return mirrorMissing(ctx, client, robotID, attempt+1)
 	}
 
 	// Activated and this process has not seeded this bot yet. Seed before the
@@ -429,10 +543,11 @@ func nextEventID(ctx *config.Context, client Scripter, robotID string) (int64, e
 	if err != nil {
 		return 0, err
 	}
-	if v == gateNotActivated {
-		return modeLost(ctx, robotID)
+	if v < 0 {
+		return 0, fmt.Errorf("botevent: gate returned %d for %q immediately after a "+
+			"successful seed; the mode mirror or counter is being mutated concurrently", v, robotID)
 	}
-	return afterIssue(ctx, client, robotID, v)
+	return afterIssue(ctx, client, robotID, v, attempt)
 }
 
 // afterIssue validates the freshly allocated id against what this process has
@@ -443,9 +558,14 @@ func nextEventID(ctx *config.Context, client Scripter, robotID string) (int64, e
 // RDB-loss restart, a FLUSHDB, a manual DEL. Without this, a long-running replica
 // would keep INCRing the regressed counter and every id it issues would sit below
 // live consumer cursors, invisible, until the counter climbed back on its own.
-func afterIssue(ctx *config.Context, client Scripter, robotID string, v int64) (int64, error) {
+func afterIssue(ctx *config.Context, client Scripter, robotID string, v int64, attempt int) (int64, error) {
+	if attempt >= maxAllocAttempts {
+		return 0, fmt.Errorf("botevent: gave up allocating for %q after %d self-healing "+
+			"attempts; Redis state is changing faster than one allocation can follow",
+			robotID, attempt)
+	}
 	if prev, regressed := checkRegression(robotID, v); regressed {
-		rollbacksDetected.Add(1)
+		rollbacksDetected.inc()
 		// Re-seed from the durable floor and retry once. One retry is enough: the
 		// seed raises the counter above the high-water mark, so the next INCR
 		// cannot land beneath it again unless Redis regresses a second time in
@@ -460,7 +580,7 @@ func afterIssue(ctx *config.Context, client Scripter, robotID string, v int64) (
 			return 0, err
 		}
 		if retried == gateNotActivated {
-			return modeLost(ctx, robotID)
+			return mirrorMissing(ctx, client, robotID, attempt+1)
 		}
 		if retried <= prev {
 			// The floor did not clear the ids this process already handed out, so
@@ -531,7 +651,7 @@ func reseed(ctx *config.Context, client Scripter, robotID string) error {
 		return nil
 	}
 	if err := seedCounter(ctx, client, robotID); err != nil {
-		seedFailures.Add(1)
+		seedFailures.inc()
 		return fmt.Errorf("botevent: seed event id counter for %q: %w", robotID, err)
 	}
 	seeded.Store(robotID, struct{}{})
@@ -547,19 +667,60 @@ func seedMutex(robotID string) *sync.Mutex {
 	return actual.(*sync.Mutex)
 }
 
-// modeLost handles a mode key that is absent when the caller may have expected it.
+// mirrorMissing handles a mode mirror that does not say incr.
 //
-// Unset expectation means pre-activation, and legacy is correct. An explicit
-// `incr` expectation means the mode was lost or rolled back after activation, and
-// legacy would then issue ids from a lower GenSeq block — beneath live cursors, the
-// same loss mirrored. Fail closed instead.
-func modeLost(ctx *config.Context, robotID string) (int64, error) {
-	if expectedMode == ModeIncr {
-		return 0, fmt.Errorf("botevent: %s=%s but %s is not %q; refusing to fall back to the "+
-			"legacy allocator, whose lower ids would land below live consumer cursors",
-			ExpectedModeEnv, expectedMode, ModeKey, ModeIncr)
+// This is where the Redis key stops being an authority. Before the state table
+// existed, an absent mirror meant "fall back to legacy" — which after activation
+// issues GenSeq ids below everything the counter has handed out, i.e. #697 mirrored.
+// Now the DB row decides:
+//
+//   - row says activated  → the mirror was lost or rolled back. Rebuild it from the
+//     authority, re-seed, and carry on. Self-healing, no runbook.
+//   - row says legacy     → genuinely pre-activation. Legacy is correct.
+//   - row unreadable      → cannot tell. If this replica was told to expect incr,
+//     fail closed; otherwise assume pre-activation (a missing table is what a
+//     pre-migration deploy looks like).
+func mirrorMissing(ctx *config.Context, client Scripter, robotID string, attempt int) (int64, error) {
+	if attempt >= maxAllocAttempts {
+		return 0, fmt.Errorf("botevent: gave up resolving the allocator mode for %q after %d "+
+			"attempts; the mode mirror is being lost repeatedly", robotID, attempt)
 	}
-	return legacyEventID(ctx, robotID)
+	st, err := ReadState(ctx)
+	if err != nil {
+		if expectedMode == ModeIncr {
+			return 0, fmt.Errorf("botevent: %s=%s but the allocator state is unreadable (%v); "+
+				"refusing to fall back to the legacy allocator, whose lower ids would land "+
+				"below live consumer cursors", ExpectedModeEnv, expectedMode, err)
+		}
+		return legacyEventID(ctx, robotID)
+	}
+	if !st.Activated() {
+		if expectedMode == ModeIncr {
+			return 0, fmt.Errorf("botevent: %s=%s but the allocator state says legacy "+
+				"(epoch=%d); refusing to fall back", ExpectedModeEnv, expectedMode, st.Epoch)
+		}
+		return legacyEventID(ctx, robotID)
+	}
+
+	// Authoritative state says activated, so the mirror is stale. Rebuild and retry.
+	mirrorRebuilds.inc()
+	if err := client.Set(ModeKey, ModeIncr, 0).Err(); err != nil {
+		return 0, fmt.Errorf("botevent: rebuild mode mirror for epoch %d: %w", st.Epoch, err)
+	}
+	seeded.Delete(robotID)
+	lastPersisted.Delete(robotID)
+	if err := reseed(ctx, client, robotID); err != nil {
+		return 0, err
+	}
+	v, err := runGate(client, robotID)
+	if err != nil {
+		return 0, err
+	}
+	if v < 0 {
+		return 0, fmt.Errorf("botevent: gate still refuses (%d) for %q after rebuilding the "+
+			"mirror at epoch %d", v, robotID, st.Epoch)
+	}
+	return afterIssue(ctx, client, robotID, v, attempt+1)
 }
 
 // persistHighWater advances the durable mark at most once per highWaterInterval.
@@ -583,6 +744,7 @@ func persistHighWater(ctx *config.Context, robotID string, v int64) {
 		"insert into `seq`(`key`,min_seq,step) values(?,?,0) "+
 			"on duplicate key update min_seq = GREATEST(min_seq, VALUES(min_seq))",
 		HighWaterSeqKey(robotID), mark).Exec(); err != nil {
+		highWaterWriteFailures.inc()
 		return
 	}
 	lastPersisted.Store(robotID, v)
@@ -598,9 +760,12 @@ func runGate(client Scripter, robotID string) (int64, error) {
 	if !ok {
 		return 0, fmt.Errorf("botevent: allocate event id for %q: unexpected script result %T", robotID, v)
 	}
-	if id < gateNotActivated || id == 0 {
+	// Valid results are a positive id, or one of the two sentinels. Anything else --
+	// zero, or a value below the lowest sentinel -- means the counter holds something
+	// it cannot have produced, and issuing it could put an event under a live cursor.
+	if id == 0 || id < gateCounterMissing {
 		return 0, fmt.Errorf("botevent: counter for %q returned %d, which is neither a valid id "+
-			"nor the not-activated sentinel; refusing to issue it", robotID, id)
+			"nor a known sentinel; refusing to issue it", robotID, id)
 	}
 	return id, nil
 }
@@ -654,6 +819,12 @@ func seedCounter(ctx *config.Context, client Scripter, robotID string) error {
 	}
 	if durableMax > floor {
 		floor = durableMax
+	}
+	// The floor recorded at activation, validated against the observed maximum at
+	// that time. A backstop for the case where every Redis-side source has been lost
+	// at once and the durable mark has not caught up yet.
+	if stateFloor := stateFloorOrZero(ctx); stateFloor > floor {
+		floor = stateFloor
 	}
 	if floor > 0 {
 		// A bot with no queue and no seq row has never been issued an id, so it
@@ -717,8 +888,11 @@ func ResetSeededForTest() {
 			return true
 		})
 	}
-	seedFailures.Store(0)
-	rollbacksDetected.Store(0)
+	seedFailures.resetForTest()
+	rollbacksDetected.resetForTest()
+	countersLost.resetForTest()
+	mirrorRebuilds.resetForTest()
+	highWaterWriteFailures.resetForTest()
 }
 
 // SetExpectedModeForTest overrides the env-derived expectation and returns a

--- a/pkg/botevent/seq.go
+++ b/pkg/botevent/seq.go
@@ -50,11 +50,37 @@ package botevent
 // evicted under pressure — the failure mode that would otherwise make an `INCR`
 // counter quietly unusable.
 //
-// # No fallback to GenSeq, deliberately
+// # No fallback to GenSeq on failure — but there IS a legacy mode
 //
-// When allocation fails, callers must fail the enqueue the same way they failed
-// a `GenSeq` error before. Falling back to `GenSeq` would put two live id
-// sources on one queue, which is precisely the condition that produced #697.
+// These are different things and the distinction is load-bearing.
+//
+// Before activation the allocator *deliberately* delegates to GenSeq, exactly as
+// internal/msgextraseq does in `mode=legacy`. That is not a fallback, it is the
+// pre-activation state: every replica behaves identically to the old binary, so
+// deploying the new code changes nothing.
+//
+// After activation, a Redis failure returns an error and the caller fails the
+// enqueue. It must NOT quietly reach for GenSeq, because two live id sources on
+// one queue is the defect being removed.
+//
+// # Why activation cannot be skipped (reviewer P0)
+//
+// An earlier revision of this file seeded the counter above
+// `max(queue ceiling, min_seq)` and switched immediately, on the theory that
+// "new ids are always higher, so mixed old/new replicas are safe". That is
+// backwards. A legacy replica issues ids from the *bottom* of its block upward,
+// so while the new allocator hands out 7001, a legacy replica is still handing
+// out 5001, 5002, … Once a consumer's cursor reaches 7001 every one of those is
+// permanently invisible — the exact loss this change exists to remove, inflicted
+// by the change itself. A larger safety margin makes it worse, not better: the
+// margin *is* the gap that swallows legacy's ids.
+//
+// So the switch is gated on a DB-authoritative-style state flag and is only
+// flipped once every legacy writer is gone. The flag is read atomically with the
+// allocation itself (one script, see gateSource), so a flip takes effect on the
+// very next allocation with no per-process cache window. The one residual window
+// is a request that has already read `legacy` and not yet ZADDed when the flip
+// commits; drain writes for a few seconds around the flip to close it.
 
 import (
 	"errors"
@@ -76,8 +102,20 @@ const (
 	// and the hint can never collide.
 	SeqKeyPrefix = "botEventSeq:"
 
+	// ModeKey holds the process-wide allocator mode. Absent or anything other than
+	// ModeIncr means legacy, so a deployment with no operator action behaves
+	// exactly like the old binary.
+	ModeKey = "botEventSeq:mode"
+
+	// ModeIncr is the activated state: allocate from the monotonic counter.
+	ModeIncr = "incr"
+
+	// ModeLegacy is the pre-activation state, written explicitly by the operator
+	// tool so preflight can tell "not yet activated" from "never configured".
+	ModeLegacy = "legacy"
+
 	// QueueKeyPrefix is the authoritative per-bot event queue. Defined here so the
-	// five producers and the consumer stop each spelling it with their own
+	// producers and the consumer stop each spelling it with their own
 	// fmt.Sprintf — the seed below has to read the very key the producers write.
 	QueueKeyPrefix = "robotEvent:"
 
@@ -89,12 +127,12 @@ const (
 	// seedSafetyMargin is how far above the observed ceiling a first-time seed
 	// starts.
 	//
-	// Two legacy blocks matter, not one. A replica still running the old binary
-	// during a rolling deploy holds a block whose top is up to `seqStep` above the
-	// ids it has enqueued so far, and `min_seq` in the DB may itself have been
-	// moved *backwards* by another replica's unconditional write-back — so the DB
-	// value is a lower bound on what legacy can still hand out, not an upper one.
-	// Two steps covers a block in flight plus one such regression.
+	// This only has to cover a block that legacy had *reserved* but not fully
+	// issued before it went away — activation guarantees no legacy writer is still
+	// running, so there is nothing left racing upward from below. `min_seq` may
+	// itself have been moved backwards by a replica's unconditional write-back, so
+	// it is a lower bound on what legacy could have handed out; two steps covers
+	// one reserved block plus one such regression.
 	seedSafetyMargin = 2 * legacyGenSeqStep
 )
 
@@ -127,6 +165,20 @@ return tonumber(cur)`
 // bell.go and every other Lua site in this repo.
 var seedScript = rd.NewScript(seedSource)
 
+// gateSource reads the mode and allocates in one atomic step, returning -1 when
+// the allocator is not activated.
+//
+// The atomicity is the point. Caching the mode per process — even for a second —
+// would mean that during that second some replicas allocate from the counter
+// while others still allocate from GenSeq: two live id sources, which is the
+// defect. Reading it inside the same script as the INCR makes a flip take effect
+// on the very next allocation, everywhere, with no window of divergence.
+const gateSource = `
+if redis.call('GET', KEYS[1]) ~= ARGV[1] then return -1 end
+return redis.call('INCR', KEYS[2])`
+
+var gateScript = rd.NewScript(gateSource)
+
 // Scripter is the go-redis surface the allocator needs: INCR, the sorted-set read
 // used to observe the current ceiling, and the scripting set *rd.Script.Run
 // requires. octo-lib's *redis.Conn exposes none of the scripting calls, so the
@@ -136,6 +188,7 @@ var seedScript = rd.NewScript(seedSource)
 // whose INCR succeeds while its seed fails, since the two have different
 // consequences.
 type Scripter interface {
+	Get(key string) *rd.StringCmd
 	Incr(key string) *rd.IntCmd
 	ZRevRangeWithScores(key string, start, stop int64) *rd.ZSliceCmd
 	Eval(script string, keys []string, args ...interface{}) *rd.Cmd
@@ -219,18 +272,78 @@ func nextEventID(ctx *config.Context, client Scripter, robotID string) (int64, e
 	if client == nil {
 		return 0, errors.New("botevent: nil redis client, cannot allocate event id")
 	}
-	if _, ok := seeded.Load(robotID); !ok {
-		if err := seedCounter(ctx, client, robotID); err != nil {
-			seedFailures.Add(1)
-			return 0, fmt.Errorf("botevent: seed event id counter for %q: %w", robotID, err)
+
+	// Steady state after activation: one round trip that checks the mode and
+	// allocates atomically.
+	if _, ok := seeded.Load(robotID); ok {
+		v, err := runGate(client, robotID)
+		if err != nil {
+			return 0, err
 		}
-		seeded.Store(robotID, struct{}{})
+		if v >= 0 {
+			return v, nil
+		}
+		// Activated, then not: there is no supported deactivation, so this means
+		// the mode key was cleared out from under us. Legacy is the safe answer —
+		// it is what every other writer would now be doing too.
+		return legacyEventID(ctx, robotID)
 	}
-	v, err := client.Incr(SeqKey(robotID)).Result()
+
+	mode, err := client.Get(ModeKey).Result()
+	if err != nil && err != rd.Nil {
+		return 0, fmt.Errorf("botevent: read allocator mode: %w", err)
+	}
+	if mode != ModeIncr {
+		return legacyEventID(ctx, robotID)
+	}
+
+	// Activated and this process has not seeded this bot yet. Seed before the
+	// first INCR, never after: an id handed out below the floor is exactly the
+	// unreachable-event bug.
+	if err := seedCounter(ctx, client, robotID); err != nil {
+		seedFailures.Add(1)
+		return 0, fmt.Errorf("botevent: seed event id counter for %q: %w", robotID, err)
+	}
+	seeded.Store(robotID, struct{}{})
+
+	v, err := runGate(client, robotID)
+	if err != nil {
+		return 0, err
+	}
+	if v < 0 {
+		return legacyEventID(ctx, robotID)
+	}
+	return v, nil
+}
+
+// runGate performs the atomic mode-check-and-allocate. -1 means "not activated".
+func runGate(client Scripter, robotID string) (int64, error) {
+	v, err := gateScript.Run(client, []string{ModeKey, SeqKey(robotID)}, ModeIncr).Result()
 	if err != nil {
 		return 0, fmt.Errorf("botevent: allocate event id for %q: %w", robotID, err)
 	}
-	return v, nil
+	id, ok := v.(int64)
+	if !ok {
+		return 0, fmt.Errorf("botevent: allocate event id for %q: unexpected script result %T", robotID, v)
+	}
+	return id, nil
+}
+
+// legacyEventID is the pre-activation allocator: the octo-lib GenSeq block
+// allocator this change exists to retire.
+//
+// This is the ONLY permitted GenSeq call site for bot event ids, and the source
+// guard in genseq_guard_test.go allows it here and nowhere else — the same shape
+// internal/msgextraseq uses for its own legacy delegation. It is reached when the
+// allocator has not been activated yet, which is the state every deployment
+// starts in, so it is not dead code and its behaviour still matters: it is
+// bug-compatible with the old binary on purpose, so that deploying the fix
+// changes nothing until an operator flips the mode.
+func legacyEventID(ctx *config.Context, robotID string) (int64, error) {
+	if ctx == nil {
+		return 0, errors.New("botevent: nil ctx, cannot allocate legacy event id")
+	}
+	return ctx.GenSeq(common.RobotEventSeqKey + robotID)
 }
 
 // seedCounter raises the counter above everything legacy could have handed out

--- a/pkg/botevent/seq.go
+++ b/pkg/botevent/seq.go
@@ -56,8 +56,12 @@ package botevent
 //     advanced roughly every `highWaterInterval` ids and folded into every seed's
 //     floor. It does not share Redis's recovery domain, so it survives an RDB
 //     rollback. Persisting every id would be a DB write per allocation; persisting
-//     every ~1000 means the mark can trail the true maximum by at most that much,
-//     which `seedSafetyMargin` (2 × step) already covers.
+//     every ~1000 keeps the mark within one interval of the truth, which
+//     `seedSafetyMargin` (2 × step) covers — **while the writes land**. That
+//     qualifier is load-bearing and was missing: during a DB outage an unbounded
+//     number of ids would otherwise be issued against a frozen mark, so
+//     `highWaterFailureLimit` bounds how many intervals may pass with no durable
+//     write before allocations fail instead (review P1-7).
 //   - **Rollback detection in the issuing process.** The durable mark only helps if
 //     something re-seeds, and a long-running replica would otherwise keep INCRing
 //     the regressed counter forever — its `seeded` entry is already set. So every
@@ -102,17 +106,18 @@ package botevent
 // by the change itself. A larger safety margin makes it worse, not better: the
 // margin *is* the gap that swallows legacy's ids.
 //
-// So the switch is gated on a DB-authoritative-style state flag and is only
-// flipped once every legacy writer is gone. The flag is read atomically with the
-// allocation itself (one script, see gateSource), so a flip takes effect on the
-// very next allocation with no per-process cache window. The one residual window
-// is a request that has already read `legacy` and not yet ZADDed when the flip
-// commits; drain writes for a few seconds around the flip to close it.
+// So the switch is gated on a state flag whose authority is a MySQL row (state.go),
+// mirrored into Redis so the gate can check it inside the same script as the
+// allocation (see gateSource, and mode.go for who is allowed to believe that mirror).
+// A flip takes effect on the very next allocation everywhere, because the mirror the
+// gate compares against is never cached. The one residual window is a request that
+// has already read `legacy` and not yet ZADDed when the flip commits; drain writes for
+// a few seconds around the flip to close it.
 
 import (
+	"context"
 	"errors"
 	"fmt"
-	"os"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -147,13 +152,24 @@ const (
 	// RDB snapshot, and an absent mirror must therefore mean "consult the DB", never
 	// "fall back to legacy". Falling back would issue GenSeq ids below everything the
 	// counter already handed out — #697 mirrored.
+	//
+	// Its value is `incr:{epoch}`, not a bare `incr`, and it is only ever believed
+	// after the authority has confirmed that generation. mode.go has the rules; the
+	// short version is that a mirror alone cannot activate anything.
 	ModeKey = "botEventSeq:mode"
 
-	// ModeIncr is the activated state: allocate from the monotonic counter.
+	// ModeIncr is the activated state: allocate from the monotonic counter. Also the
+	// prefix of the mirror value, and an accepted ExpectedModeEnv value.
 	ModeIncr = "incr"
 
-	// ModeLegacy is the pre-activation state, written explicitly by the operator
-	// tool so preflight can tell "not yet activated" from "never configured".
+	// ModeLegacy is the pre-activation state: delegate to GenSeq.
+	//
+	// It is an accepted ExpectedModeEnv value — a replica may assert that it expects
+	// *not* to be activated, which fails closed if the authority says otherwise. It is
+	// deliberately not a mirror value: the mirror's only job is to claim activation, and
+	// "absent" already means "consult the authority" (an earlier revision claimed the
+	// operator tool wrote this string so preflight could tell "not yet activated" from
+	// "never configured" — it never did, and preflight reads the DB row for that).
 	ModeLegacy = "legacy"
 
 	// HighWaterKeyPrefix names the durable high-water row in the `seq` table.
@@ -170,14 +186,25 @@ const (
 	// `ModeKey` lives in Redis, so it regresses under exactly the RDB rollback
 	// described above — and dropping to legacy then issues *lower* ids beneath live
 	// cursors, the same loss mirrored. Once activation is verified, roll this out as
-	// `incr` and a missing mode refuses the enqueue instead. Same shape as #627's
-	// OCTO_MESSAGE_EXTRA_VERSION_EXPECTED_MODE. Leave it unset until then: a replica
-	// expecting `incr` before the flip fails every enqueue closed.
+	// `incr` and an unconfirmable mode refuses the enqueue instead. Same shape as
+	// #627's OCTO_MESSAGE_EXTRA_VERSION_EXPECTED_MODE, including that a **malformed**
+	// value fails closed rather than reading as "unset" — see mode.go. Accepted values
+	// are `incr` and `legacy`; leave it unset until the flip, because a replica
+	// expecting `incr` beforehand fails every enqueue closed.
 	ExpectedModeEnv = "OCTO_BOTEVENT_EXPECTED_MODE"
 
 	// highWaterInterval is how many ids may be issued between durable writes. One
 	// legacy block, so the mark trails the truth by less than seedSafetyMargin.
 	highWaterInterval = legacyGenSeqStep
+
+	// highWaterFailureLimit is how many consecutive intervals may pass with no
+	// durable high-water write before allocations start failing.
+	//
+	// The mark is what makes a post-rollback seed land above what was issued before
+	// the rollback, and seedSafetyMargin covers a trailing mark only while the writes
+	// land. Three intervals is ~3 × step of exposure — still inside the margin's
+	// order of magnitude — and long enough that a brief DB blip costs nothing.
+	highWaterFailureLimit = 3
 
 	// maxAllocAttempts bounds the self-healing retries within one allocation.
 	//
@@ -265,24 +292,33 @@ return tonumber(cur)`
 // bell.go and every other Lua site in this repo.
 var seedScript = rd.NewScript(seedSource)
 
-// gateSource reads the mode and allocates in one atomic step, returning -1 when
-// the allocator is not activated.
+// gateSource reads the mode mirror and allocates in one atomic step, returning -1
+// when the mirror does not equal the value the caller validated.
 //
-// The atomicity is the point. Caching the mode per process — even for a second —
-// would mean that during that second some replicas allocate from the counter
-// while others still allocate from GenSeq: two live id sources, which is the
-// defect. Reading it inside the same script as the INCR makes a flip take effect
-// on the very next allocation, everywhere, with no window of divergence.
+// The atomicity is the point, and so is the absence of a cache *here*. If the gate
+// decided from a per-process copy of the mode — even a one-second-old one — then for
+// that second some replicas would allocate from the counter while others still
+// allocated from GenSeq: two live id sources, which is the defect. Reading the mirror
+// inside the same script as the INCR makes a flip take effect on the very next
+// allocation, everywhere, with no window of divergence. (What *is* cached, one level
+// up, is the authority behind the mirror, under rules designed to preserve exactly
+// this property — see mode.go.)
+//
+// ARGV[1] is the full expected mirror value including the generation, so a mirror
+// that was lost, hand-written as a bare `incr`, or replaced by a different epoch
+// closes the gate instead of allocating.
+//
 // Sentinels returned by gateSource. Both are distinguishable from any legitimate id
 // because a seeded counter is never negative: every floor is >= 0 and INCR only
-// rises. Callers match them **exactly** rather than testing `v < 0`, so a counter
-// that somehow went negative (a manual SET, a corrupted restore) surfaces as an
-// error instead of being mistaken for a sentinel and silently degrading.
+// rises. runGate normalises the result before returning it — anything that is neither
+// a positive id nor exactly one of these two becomes an error there — so callers may
+// switch on them, and a counter that somehow went negative (a manual SET, a corrupted
+// restore) surfaces as an error rather than being mistaken for a sentinel.
 const (
-	// gateNotActivated: the mode mirror does not say incr.
+	// gateNotActivated: the mode mirror is not the generation the caller validated.
 	gateNotActivated = -1
 
-	// gateCounterMissing: the mirror says incr but the counter key is gone.
+	// gateCounterMissing: the mirror matches but the counter key is gone.
 	//
 	// This guard is why the script does an EXISTS. `INCR` on a missing key returns
 	// **1**, and the only thing that would otherwise stop an unseeded INCR is
@@ -341,9 +377,10 @@ type Scripter interface {
 // record, not a footnote: GenSeq served 999 of every 1000 allocations from its
 // process-local block with **no I/O at all**, while every allocation here is a Redis
 // round trip. It cannot be batched back into blocks without recreating #697 (a block
-// is a second id source), and the mode cannot be cached without recreating the
-// mixed-source window (reviewer P0). Load-test the hottest producer before
-// activation, not after.
+// is a second id source), and the mirror the gate compares against cannot be cached
+// without recreating the mixed-source window (reviewer P0) — only the *authority
+// behind* it can be, which is what keeps the pre-activation path free of DB round
+// trips (mode.go). Load-test the hottest producer before activation, not after.
 const (
 	seqDialTimeout = 500 * time.Millisecond
 	seqReadTimeout = 300 * time.Millisecond
@@ -404,6 +441,11 @@ var (
 	// so the DB write happens once per highWaterInterval rather than per id.
 	lastPersisted sync.Map
 
+	// highWaterFailures counts consecutive durable-write failures per bot. See
+	// noteHighWaterFailure: the count is what bounds how long the allocator may keep
+	// issuing ids whose recovery floor is not advancing.
+	highWaterFailures sync.Map
+
 	// countersLost counts allocations that found the mirror set but the counter key
 	// gone, and mirrorRebuilds counts mirrors rebuilt from the DB authority. Both
 	// mean Redis lost data; both are self-healed, and both are worth alerting on.
@@ -423,10 +465,6 @@ var (
 	// but delivery recovers without a runbook.
 	rollbacksDetected = newHealCounter("dmwork_bot_event_seq_rollback_total",
 		"Counter regressions detected and self-healed; non-zero means Redis lost data.")
-
-	// expectedMode is read once. Re-reading os.Getenv per allocation would put a
-	// syscall on the hottest producer path for a value that cannot change.
-	expectedMode = strings.TrimSpace(os.Getenv(ExpectedModeEnv))
 )
 
 // SeedFailures reports how many allocations failed at the seed step.
@@ -474,9 +512,14 @@ func NextEventID(ctx *config.Context, robotID string) (int64, error) {
 	if ctx == nil {
 		return 0, errors.New("botevent: nil ctx, cannot allocate event id")
 	}
-	robotID = strings.TrimSpace(robotID)
-	if robotID == "" {
-		return 0, errors.New("botevent: empty robotID, cannot allocate event id")
+	// Reject rather than normalise. Trimming here would make the allocator key off a
+	// different string than the caller's own QueueKey(robotID) / Notify(robotID), so a
+	// padded id would seed one counter and enqueue onto another queue. Unreachable
+	// through today's call sites, and the divergence is what makes it worth an error
+	// rather than a silent fix-up (review P2-12).
+	if robotID == "" || strings.TrimSpace(robotID) != robotID {
+		return 0, fmt.Errorf("botevent: robotID %q is empty or padded, cannot allocate event id; "+
+			"the allocator, the queue key and the doorbell must all use the identical string", robotID)
 	}
 	return nextEventID(ctx, SeqClient(ctx.GetConfig()), robotID)
 }
@@ -492,62 +535,160 @@ func allocate(ctx *config.Context, client Scripter, robotID string, attempt int)
 	if client == nil {
 		return 0, errors.New("botevent: nil redis client, cannot allocate event id")
 	}
+	if attempt >= maxAllocAttempts {
+		return 0, fmt.Errorf("botevent: gave up allocating for %q after %d self-healing attempts; "+
+			"Redis state is changing faster than one allocation can follow", robotID, attempt)
+	}
 
-	// Steady state after activation: one round trip that checks the mode and
-	// allocates atomically.
-	if _, ok := seeded.Load(robotID); ok {
-		v, err := runGate(client, robotID)
-		if err != nil {
-			return 0, err
+	// Steady state after activation: the authority is already resolved and this
+	// process has already seeded this bot, so one round trip checks the mirror and
+	// allocates atomically. No DB access, and no cached mode decides the gate — the
+	// gate compares the live mirror against the validated generation itself.
+	if b := activeBelief.Load(); b != nil && b.activated {
+		if _, ok := seeded.Load(robotID); ok {
+			return allocateFromCounter(ctx, client, robotID, b, attempt)
 		}
-		switch v {
-		case gateNotActivated:
-			return mirrorMissing(ctx, client, robotID, attempt+1)
-		case gateCounterMissing:
-			// The mirror says activated but the counter is gone. Re-seed from the
-			// durable floors and retry; issuing would renumber from 1.
-			countersLost.inc()
-			seeded.Delete(robotID)
-			lastPersisted.Delete(robotID)
-			if err := reseed(ctx, client, robotID); err != nil {
-				return 0, err
-			}
-			retried, err := runGate(client, robotID)
-			if err != nil {
-				return 0, err
-			}
-			if retried < 0 {
-				return 0, fmt.Errorf("botevent: counter for %q still unusable after re-seed (gate=%d)", robotID, retried)
-			}
-			return afterIssue(ctx, client, robotID, retried, attempt+1)
-		}
-		return afterIssue(ctx, client, robotID, v, attempt)
 	}
 
-	mode, err := client.Get(ModeKey).Result()
-	if err != nil && err != rd.Nil {
-		return 0, fmt.Errorf("botevent: read allocator mode: %w", err)
-	}
-	if mode != ModeIncr {
-		return mirrorMissing(ctx, client, robotID, attempt+1)
-	}
-
-	// Activated and this process has not seeded this bot yet. Seed before the
-	// first INCR, never after: an id handed out below the floor is exactly the
-	// unreachable-event bug.
-	if err := reseed(ctx, client, robotID); err != nil {
-		return 0, err
-	}
-
-	v, err := runGate(client, robotID)
+	// Otherwise the decision needs the uncached mirror. Pre-activation this is the
+	// whole cost of an allocation before delegating: one Redis GET, exactly as the
+	// old binary's path shape, with the authority read amortised by the belief cache
+	// (review P1-1).
+	mirror, err := readMirror(client)
 	if err != nil {
 		return 0, err
 	}
-	if v < 0 {
-		return 0, fmt.Errorf("botevent: gate returned %d for %q immediately after a "+
-			"successful seed; the mode mirror or counter is being mutated concurrently", v, robotID)
+	decision, b, err := resolveMode(ctx, mirror)
+	if err != nil {
+		return 0, err
+	}
+	if decision == decideLegacy {
+		return legacyDelegate(ctx, robotID)
+	}
+
+	// Activated. Two orderings matter here and both were wrong before.
+	rebuildMirror := mirror != b.mirrorValue()
+	if rebuildMirror {
+		// The mirror is absent, bare, or from an older generation, so Redis lost the
+		// mode key (or never had this generation's). That is evidence Redis lost data,
+		// and every counter this process believes it seeded is suspect — not just this
+		// bot's. Dropping the whole seeded set makes the next allocation for each of
+		// them re-seed from the durable floors. The seed is idempotent and only ever
+		// raises, so the cost is one extra round trip per active bot.
+		mirrorRebuilds.inc()
+		invalidateSeeded()
+	}
+	// Seed before the first INCR, never after: an id handed out below the floor is
+	// exactly the unreachable-event bug.
+	if err := reseed(ctx, client, robotID); err != nil {
+		return 0, err
+	}
+	if rebuildMirror {
+		// Publish the mirror only now. Writing it first opens the gate for **every**
+		// bot in every replica while only this one has been raised to its floor, so any
+		// goroutine holding a stale seeded entry for another bot could pass the gate and
+		// INCR a counter that has not been re-seeded yet (review P1-3). Note the
+		// asymmetry the ordering exists to contain: the mirror is global, the seed is
+		// per-bot.
+		if err := client.Set(ModeKey, b.mirrorValue(), 0).Err(); err != nil {
+			return 0, fmt.Errorf("botevent: rebuild mode mirror for epoch %d: %w", b.epoch, err)
+		}
+	}
+	return allocateFromCounter(ctx, client, robotID, b, attempt)
+}
+
+// allocateFromCounter runs the gate for a bot this process has seeded under a
+// validated belief, and handles the two ways Redis can have lost state underneath it.
+func allocateFromCounter(ctx *config.Context, client Scripter, robotID string, b *belief, attempt int) (int64, error) {
+	v, err := runGate(client, robotID, b.mirrorValue())
+	if err != nil {
+		return 0, err
+	}
+	switch v {
+	case gateNotActivated:
+		// The live mirror no longer equals the generation this process validated: lost,
+		// overwritten, or replaced by a newer epoch. Re-resolve from the authority.
+		return gateClosed(ctx, client, robotID, attempt+1)
+	case gateCounterMissing:
+		// The mirror is intact but the counter key is gone. Re-seed from the durable
+		// floors and retry; issuing would renumber this bot's events from 1.
+		countersLost.inc()
+		seeded.Delete(robotID)
+		lastPersisted.Delete(robotID)
+		if err := reseed(ctx, client, robotID); err != nil {
+			return 0, err
+		}
+		retried, err := runGate(client, robotID, b.mirrorValue())
+		if err != nil {
+			return 0, err
+		}
+		if retried < 0 {
+			return 0, fmt.Errorf("botevent: counter for %q still unusable after re-seed (gate=%d)", robotID, retried)
+		}
+		return afterIssue(ctx, client, robotID, retried, attempt+1)
 	}
 	return afterIssue(ctx, client, robotID, v, attempt)
+}
+
+// gateClosed re-resolves the authority after the gate refused an allocation this
+// process believed was permitted, then retries the allocation from the top.
+//
+// The authority read is forced rather than served from the cached belief: the gate
+// closing means the mirror changed underneath a belief this process was already acting
+// on, which is exactly what the cache must not answer for. If the authority still says
+// activated, the retry below rebuilds the mirror; if it says legacy, refreshAuthority
+// refuses rather than downgrading a process that has already issued counter ids
+// (review P1-4).
+//
+// Dropping the seeded marker is what makes the retry take the slow path. Without it,
+// allocate's post-activation fast path would run the same closed gate again and the
+// pair would spin to maxAllocAttempts — which is how the tests caught this.
+func gateClosed(ctx *config.Context, client Scripter, robotID string, attempt int) (int64, error) {
+	if attempt >= maxAllocAttempts {
+		return 0, fmt.Errorf("botevent: gave up resolving the allocator mode for %q after %d "+
+			"attempts; the mode mirror is being lost or rewritten repeatedly", robotID, attempt)
+	}
+	if _, _, err := refreshAuthority(ctx, false, true); err != nil {
+		return 0, err
+	}
+	seeded.Delete(robotID)
+	return allocate(ctx, client, robotID, attempt)
+}
+
+// legacyDelegate hands the allocation to GenSeq, refusing if this process has ever
+// issued a counter id for this bot.
+//
+// The refusal is unreachable while the positive belief is terminal, which is the
+// point: it asserts the invariant instead of assuming it. A GenSeq id after the
+// counter era has begun is arbitrarily far below the bot's live consumer cursor, so
+// the event would be born invisible — #697, self-inflicted (review P1-4).
+func legacyDelegate(ctx *config.Context, robotID string) (int64, error) {
+	if prev, issued := lastIssued.Load(robotID); issued {
+		return 0, fmt.Errorf("botevent: refusing to allocate a legacy id for %q after this process "+
+			"already issued counter id %v for it; a GenSeq id here would land below the bot's "+
+			"consumer cursor and never be delivered", robotID, prev)
+	}
+	return legacyEventID(ctx, robotID)
+}
+
+// readMirror returns the raw mode mirror value, or "" when the key is absent.
+func readMirror(client Scripter) (string, error) {
+	v, err := client.Get(ModeKey).Result()
+	if err != nil && err != rd.Nil {
+		return "", fmt.Errorf("botevent: read allocator mode mirror: %w", err)
+	}
+	return v, nil
+}
+
+// invalidateSeeded drops every bot's seeded marker. See the mirror-rebuild branch in
+// allocate for why a lost mirror invalidates more than the bot being allocated for.
+func invalidateSeeded() {
+	for _, m := range []*sync.Map{&seeded, &lastPersisted} {
+		m.Range(func(k, _ interface{}) bool {
+			m.Delete(k)
+			return true
+		})
+	}
 }
 
 // afterIssue validates the freshly allocated id against what this process has
@@ -575,12 +716,18 @@ func afterIssue(ctx *config.Context, client Scripter, robotID string, v int64, a
 		if err := reseed(ctx, client, robotID); err != nil {
 			return 0, err
 		}
-		retried, err := runGate(client, robotID)
+		b := activeBelief.Load()
+		if b == nil || !b.activated {
+			// The belief cannot have been downgraded (positive is terminal), so this
+			// means it was cleared underneath us — only a test does that.
+			return 0, fmt.Errorf("botevent: allocator belief lost mid-allocation for %q", robotID)
+		}
+		retried, err := runGate(client, robotID, b.mirrorValue())
 		if err != nil {
 			return 0, err
 		}
 		if retried == gateNotActivated {
-			return mirrorMissing(ctx, client, robotID, attempt+1)
+			return gateClosed(ctx, client, robotID, attempt+1)
 		}
 		if retried <= prev {
 			// The floor did not clear the ids this process already handed out, so
@@ -594,7 +741,12 @@ func afterIssue(ctx *config.Context, client Scripter, robotID string, v int64, a
 		v = retried
 	}
 	recordIssued(robotID, v)
-	persistHighWater(ctx, robotID, v)
+	if err := persistHighWater(ctx, robotID, v); err != nil {
+		// The id is allocated and unique, but the floor that would recover it after a
+		// Redis rollback has stopped advancing for too long. Failing here trades one
+		// enqueue for the RDB safety margin; see noteHighWaterFailure.
+		return 0, err
+	}
 	return v, nil
 }
 
@@ -667,92 +819,108 @@ func seedMutex(robotID string) *sync.Mutex {
 	return actual.(*sync.Mutex)
 }
 
-// mirrorMissing handles a mode mirror that does not say incr.
-//
-// This is where the Redis key stops being an authority. Before the state table
-// existed, an absent mirror meant "fall back to legacy" — which after activation
-// issues GenSeq ids below everything the counter has handed out, i.e. #697 mirrored.
-// Now the DB row decides:
-//
-//   - row says activated  → the mirror was lost or rolled back. Rebuild it from the
-//     authority, re-seed, and carry on. Self-healing, no runbook.
-//   - row says legacy     → genuinely pre-activation. Legacy is correct.
-//   - row unreadable      → cannot tell. If this replica was told to expect incr,
-//     fail closed; otherwise assume pre-activation (a missing table is what a
-//     pre-migration deploy looks like).
-func mirrorMissing(ctx *config.Context, client Scripter, robotID string, attempt int) (int64, error) {
-	if attempt >= maxAllocAttempts {
-		return 0, fmt.Errorf("botevent: gave up resolving the allocator mode for %q after %d "+
-			"attempts; the mode mirror is being lost repeatedly", robotID, attempt)
-	}
-	st, err := ReadState(ctx)
-	if err != nil {
-		if expectedMode == ModeIncr {
-			return 0, fmt.Errorf("botevent: %s=%s but the allocator state is unreadable (%v); "+
-				"refusing to fall back to the legacy allocator, whose lower ids would land "+
-				"below live consumer cursors", ExpectedModeEnv, expectedMode, err)
-		}
-		return legacyEventID(ctx, robotID)
-	}
-	if !st.Activated() {
-		if expectedMode == ModeIncr {
-			return 0, fmt.Errorf("botevent: %s=%s but the allocator state says legacy "+
-				"(epoch=%d); refusing to fall back", ExpectedModeEnv, expectedMode, st.Epoch)
-		}
-		return legacyEventID(ctx, robotID)
-	}
-
-	// Authoritative state says activated, so the mirror is stale. Rebuild and retry.
-	mirrorRebuilds.inc()
-	if err := client.Set(ModeKey, ModeIncr, 0).Err(); err != nil {
-		return 0, fmt.Errorf("botevent: rebuild mode mirror for epoch %d: %w", st.Epoch, err)
-	}
-	seeded.Delete(robotID)
-	lastPersisted.Delete(robotID)
-	if err := reseed(ctx, client, robotID); err != nil {
-		return 0, err
-	}
-	v, err := runGate(client, robotID)
-	if err != nil {
-		return 0, err
-	}
-	if v < 0 {
-		return 0, fmt.Errorf("botevent: gate still refuses (%d) for %q after rebuilding the "+
-			"mirror at epoch %d", v, robotID, st.Epoch)
-	}
-	return afterIssue(ctx, client, robotID, v, attempt+1)
-}
-
 // persistHighWater advances the durable mark at most once per highWaterInterval.
 //
-// Best-effort on purpose: the id is already issued and the enqueue must not fail
-// because a bookkeeping write did. A missed write only shortens how far the mark
-// trails, which seedSafetyMargin absorbs.
-func persistHighWater(ctx *config.Context, robotID string, v int64) {
+// Best-effort about *this* write: the id is already issued and the enqueue must not
+// fail because a bookkeeping write did. Not best-effort about the safety property it
+// underwrites — see highWaterFailureLimit.
+func persistHighWater(ctx *config.Context, robotID string, v int64) error {
 	if prev, ok := lastPersisted.Load(robotID); ok && v-prev.(int64) < highWaterInterval {
-		return
+		return nil
 	}
 	// The mark records what has been issued, not a reservation above it. Writing
 	// `v + interval` would compound: every seed adds seedSafetyMargin on top of the
 	// mark, so a mark that already ran ahead would push the counter forward by
 	// interval + margin each time it was consulted.
 	mark := v
+	deadline, cancel := context.WithTimeout(context.Background(), authorityTimeout)
+	defer cancel()
 	// GREATEST, never a bare assignment. An unconditional overwrite is precisely how
 	// GenSeq lets a lagging replica drag a floor backwards (the root cause of #697),
 	// and this row is a floor.
 	if _, err := ctx.DB().InsertBySql(
 		"insert into `seq`(`key`,min_seq,step) values(?,?,0) "+
 			"on duplicate key update min_seq = GREATEST(min_seq, VALUES(min_seq))",
-		HighWaterSeqKey(robotID), mark).Exec(); err != nil {
+		HighWaterSeqKey(robotID), mark).ExecContext(deadline); err != nil {
 		highWaterWriteFailures.inc()
-		return
+		return noteHighWaterFailure(robotID, v, err)
 	}
-	lastPersisted.Store(robotID, v)
+	highWaterFailures.Delete(robotID)
+	lastPersistedStore(robotID, v)
+	return nil
 }
 
-// runGate performs the atomic mode-check-and-allocate. -1 means "not activated".
-func runGate(client Scripter, robotID string) (int64, error) {
-	v, err := gateScript.Run(client, []string{ModeKey, SeqKey(robotID)}, ModeIncr).Result()
+// noteHighWaterFailure records a failed durable write and decides whether the
+// allocator may keep issuing ids without one.
+//
+// Two things go wrong if a failure is merely counted (review P1-7):
+//
+//   - The once-per-interval guard above keys off lastPersisted, so leaving it unset
+//     means the *next* allocation writes again — one un-deadlined INSERT per event on
+//     the fan-out path for as long as the DB is unhappy. Measured by the reviewer:
+//     50 INSERTs over 50 allocations with the table renamed away, versus 0 healthy.
+//   - The safety argument at the top of this file ("the mark trails the true maximum
+//     by at most highWaterInterval, which seedSafetyMargin covers") is only true while
+//     the writes land. During a prolonged outage an unbounded number of ids is issued
+//     against a frozen mark, and a Redis rollback plus a drained queue after that can
+//     seed below a live cursor.
+//
+// So the mark is advanced *in memory* to re-arm the interval guard — the next attempt
+// happens one interval later, not one id later — and the number of consecutive
+// intervals allowed to pass with no durable write is bounded. Past the bound the
+// allocation fails: refusing one enqueue is recoverable, while silently spending the
+// RDB safety margin is not.
+func noteHighWaterFailure(robotID string, v int64, cause error) error {
+	// Re-arm the interval guard so the retry is one interval away, not one id away.
+	lastPersistedStore(robotID, v)
+
+	n := int64(1)
+	if prev, ok := highWaterFailures.Load(robotID); ok {
+		n = prev.(int64) + 1
+	}
+	highWaterFailures.Store(robotID, n)
+	if n < highWaterFailureLimit {
+		return nil
+	}
+	return fmt.Errorf("botevent: %d consecutive durable high-water writes failed for %q "+
+		"(last error: %w); refusing to keep issuing ids the seed floor cannot recover from "+
+		"after a Redis rollback", n, robotID, cause)
+}
+
+// lastPersistedStore advances the in-memory mark monotonically.
+//
+// CAS rather than a plain Store for the same reason recordIssued uses one: concurrent
+// allocations for one bot arrive out of order, and a lower value overwriting a higher
+// one costs a redundant write later (harmless against the GREATEST upsert, but the
+// asymmetry reads like a bug — review P2-9).
+func lastPersistedStore(robotID string, v int64) {
+	for {
+		prev, loaded := lastPersisted.Load(robotID)
+		if !loaded {
+			if _, already := lastPersisted.LoadOrStore(robotID, v); !already {
+				return
+			}
+			continue
+		}
+		high := prev.(int64)
+		if v <= high {
+			return
+		}
+		if lastPersisted.CompareAndSwap(robotID, high, v) {
+			return
+		}
+	}
+}
+
+// runGate performs the atomic mode-check-and-allocate.
+//
+// expectMirror is the exact ModeKey value this process validated against the
+// authority, including the generation. A mirror that has been lost, downgraded to a
+// bare `incr`, or replaced by another epoch therefore closes the gate rather than
+// allocating — which is what makes a hand-written mirror unable to activate anything
+// (review P1-2).
+func runGate(client Scripter, robotID, expectMirror string) (int64, error) {
+	v, err := gateScript.Run(client, []string{ModeKey, SeqKey(robotID)}, expectMirror).Result()
 	if err != nil {
 		return 0, fmt.Errorf("botevent: allocate event id for %q: %w", robotID, err)
 	}
@@ -855,9 +1023,11 @@ func highWaterCeiling(ctx *config.Context, robotID string) (int64, error) {
 	if ctx == nil {
 		return 0, errors.New("nil ctx, cannot read high-water mark")
 	}
+	deadline, cancel := context.WithTimeout(context.Background(), authorityTimeout)
+	defer cancel()
 	var mark int64
 	if _, err := ctx.DB().Select("min_seq").From("`seq`").
-		Where("`key`=?", HighWaterSeqKey(robotID)).Load(&mark); err != nil {
+		Where("`key`=?", HighWaterSeqKey(robotID)).LoadContext(deadline, &mark); err != nil {
 		return 0, fmt.Errorf("read high-water mark: %w", err)
 	}
 	return mark, nil
@@ -870,10 +1040,12 @@ func highWaterCeiling(ctx *config.Context, robotID string) (int64, error) {
 // allocate — and allocating from the very source being retired is how a "read"
 // turns into a third live id source.
 func legacyCeiling(ctx *config.Context, robotID string) (int64, error) {
+	deadline, cancel := context.WithTimeout(context.Background(), authorityTimeout)
+	defer cancel()
 	var minSeq int64
 	key := fmt.Sprintf("seq:%s%s", common.RobotEventSeqKey, robotID)
 	if _, err := ctx.DB().Select("min_seq").From("`seq`").
-		Where("`key`=?", key).Load(&minSeq); err != nil {
+		Where("`key`=?", key).LoadContext(deadline, &minSeq); err != nil {
 		return 0, fmt.Errorf("read legacy seq row: %w", err)
 	}
 	return minSeq, nil
@@ -882,7 +1054,7 @@ func legacyCeiling(ctx *config.Context, robotID string) (int64, error) {
 // ResetSeededForTest clears the process-local seed cache. Tests that seed against
 // different fixtures need it; production never does.
 func ResetSeededForTest() {
-	for _, m := range []*sync.Map{&seeded, &lastIssued, &lastPersisted, &seedLocks} {
+	for _, m := range []*sync.Map{&seeded, &lastIssued, &lastPersisted, &seedLocks, &highWaterFailures} {
 		m.Range(func(k, _ interface{}) bool {
 			m.Delete(k)
 			return true
@@ -893,12 +1065,8 @@ func ResetSeededForTest() {
 	countersLost.resetForTest()
 	mirrorRebuilds.resetForTest()
 	highWaterWriteFailures.resetForTest()
-}
-
-// SetExpectedModeForTest overrides the env-derived expectation and returns a
-// restore function.
-func SetExpectedModeForTest(mode string) func() {
-	prev := expectedMode
-	expectedMode = mode
-	return func() { expectedMode = prev }
+	// The cached authority belief is process state exactly like `seeded`, and leaving
+	// it behind would make one test's activation leak into the next one's
+	// pre-activation assertions.
+	ResetModeBeliefForTest()
 }

--- a/pkg/botevent/seq.go
+++ b/pkg/botevent/seq.go
@@ -628,7 +628,8 @@ func allocate(ctx *config.Context, client Scripter, robotID string, attempt int)
 		// and every counter this process believes it seeded is suspect — not just this
 		// bot's. Dropping the whole seeded set makes the next allocation for each of
 		// them re-seed from the durable floors. The seed is idempotent and only ever
-		// raises, so the cost is one extra round trip per active bot.
+		// raises, but it is not a cheap probe: each bot pays the durable floor reads
+		// (state, legacy min_seq, and high-water) plus the Redis seed before allocating.
 		mirrorRebuilds.inc()
 		invalidateSeeded()
 	}
@@ -723,13 +724,12 @@ func gateClosed(ctx *config.Context, client Scripter, robotID string, attempt in
 //     regressed underneath an activated fleet" (review P1-A). A GenSeq id in the second
 //     case lands arbitrarily far below the bot's live cursor: #697, self-inflicted.
 //
-// The residual this does NOT cover is stated rather than papered over: if the mirror is
-// absent or invalid, the authority is unreadable, and this bot has no counter yet (new or
-// idle), a cold process has no evidence at all and delegates to GenSeq. A correlated Redis
-// restore can create that shape, but it is not required; an authority outage plus a bot that
-// has never created its counter is enough. Only `OCTO_BOTEVENT_EXPECTED_MODE=incr` closes
-// it, and the rollout arms it after activation is verified (step 5), so the window is open
-// by design during the flip itself.
+// The residual this does NOT cover is stated rather than papered over: any negative belief
+// combined with no counter for this bot can delegate to GenSeq. The authority may be readable
+// but regressed to legacy/missing, or unreadable while the mirror does not claim activation;
+// either way a new or idle bot has no per-bot evidence that the counter era began. Only
+// `OCTO_BOTEVENT_EXPECTED_MODE=incr` closes it, and the rollout arms it after activation is
+// verified (step 5), so the window is open by design during the flip itself.
 //
 // Note what the env guard does and does not buy, because the refusal message below used to
 // get it wrong: it is a fail-closed *assertion*, not a manual override. Setting it makes an

--- a/pkg/botevent/seq.go
+++ b/pkg/botevent/seq.go
@@ -563,6 +563,11 @@ func nextEventID(ctx *config.Context, client Scripter, robotID string) (int64, e
 
 // allocate is nextEventID with the self-healing attempt counter threaded through.
 func allocate(ctx *config.Context, client Scripter, robotID string, attempt int) (int64, error) {
+	// A malformed expected-mode value is process-local configuration. Reject it before
+	// probing Redis or reading the authority; no dependency can make a typo become valid.
+	if err := validateExpectedMode(); err != nil {
+		return 0, err
+	}
 	if client == nil {
 		return 0, errors.New("botevent: nil redis client, cannot allocate event id")
 	}
@@ -576,6 +581,9 @@ func allocate(ctx *config.Context, client Scripter, robotID string, attempt int)
 	// allocates atomically. No DB access, and no cached mode decides the gate — the
 	// gate compares the live mirror against the validated generation itself.
 	if b := activeBelief.Load(); b != nil && b.activated {
+		if err := assertExpectedMode(true); err != nil {
+			return 0, err
+		}
 		if _, ok := seeded.Load(robotID); ok {
 			return allocateFromCounter(ctx, client, robotID, b, attempt)
 		}
@@ -715,11 +723,13 @@ func gateClosed(ctx *config.Context, client Scripter, robotID string, attempt in
 //     regressed underneath an activated fleet" (review P1-A). A GenSeq id in the second
 //     case lands arbitrarily far below the bot's live cursor: #697, self-inflicted.
 //
-// The residual this does NOT cover is stated rather than papered over: if the counter key
-// is gone *as well* — a Redis flush or restore that took it, correlated with an authority
-// that reads legacy — a cold process has no evidence at all and delegates to GenSeq. Only
-// `OCTO_BOTEVENT_EXPECTED_MODE=incr` closes that, and the rollout arms it after activation
-// is verified (step 5), so the window is open by design during the flip itself.
+// The residual this does NOT cover is stated rather than papered over: if the mirror is
+// absent or invalid, the authority is unreadable, and this bot has no counter yet (new or
+// idle), a cold process has no evidence at all and delegates to GenSeq. A correlated Redis
+// restore can create that shape, but it is not required; an authority outage plus a bot that
+// has never created its counter is enough. Only `OCTO_BOTEVENT_EXPECTED_MODE=incr` closes
+// it, and the rollout arms it after activation is verified (step 5), so the window is open
+// by design during the flip itself.
 //
 // Note what the env guard does and does not buy, because the refusal message below used to
 // get it wrong: it is a fail-closed *assertion*, not a manual override. Setting it makes an

--- a/pkg/botevent/seq.go
+++ b/pkg/botevent/seq.go
@@ -138,7 +138,6 @@ import (
 	rd "github.com/go-redis/redis"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
-	"go.uber.org/zap"
 )
 
 const (
@@ -341,12 +340,6 @@ if redis.call('EXISTS', KEYS[2]) == 0 then return -2 end
 return redis.call('INCR', KEYS[2])`
 
 var gateScript = rd.NewScript(gateSource)
-
-const dropMirrorSource = `
-if redis.call('GET', KEYS[1]) == ARGV[1] then return redis.call('DEL', KEYS[1]) end
-return 0`
-
-var dropMirrorScript = rd.NewScript(dropMirrorSource)
 
 // probeSource reads the mode mirror and whether this bot's counter already exists, in one
 // round trip.
@@ -601,11 +594,18 @@ func allocate(ctx *config.Context, client Scripter, robotID string, attempt int)
 	if err != nil {
 		return 0, err
 	}
-	if res.unauthorizedMirror != "" {
-		// The authority denied this mirror, so the correct state for the key is absent.
-		// Best-effort and compare-and-delete: a failure only means the next allocation
-		// re-reads the authority, bounded by repairCooldown.
-		dropUnauthorizedMirror(client, res.unauthorizedMirror)
+	if res.unauthorizedMirror != "" && !counterExists {
+		// The mirror claims an activation the authority denies, and no counter exists for
+		// this bot to contradict the authority — so the mirror is the artifact that is
+		// probably wrong, and the allocation is about to succeed through GenSeq. Suppress
+		// the authority read for a moment so a key nobody clears does not cost a
+		// serialized DB read per allocation. See noteMirrorUnauthorized.
+		//
+		// With a counter present the opposite is true: the *authority* is the artifact that
+		// regressed, legacyDelegate below refuses every allocation for this bot anyway, and
+		// a suppressed read would only delay noticing that the authority came back. So no
+		// cooldown there — deliberately.
+		noteMirrorUnauthorized(res.unauthorizedMirror)
 	}
 	if res.decision == decideLegacy {
 		return legacyDelegate(ctx, robotID, counterExists)
@@ -769,36 +769,21 @@ func probeAllocatorState(client Scripter, robotID string) (mirror string, counte
 	return mirror, exists != 0, nil
 }
 
-// dropUnauthorizedMirror removes a mode mirror the authority denied, if it still holds the
-// exact value that was denied.
-//
-// Compare-and-delete rather than a bare DEL: between the authority read and this call an
-// operator may have activated and written a *different* generation, which must survive.
-//
-// Best-effort. A failure is recorded on the belief so the next allocation is answered from
-// the cached denial for a short cooldown instead of re-reading the authority per
-// allocation — see belief.repairFailedFor. It is not an allocation error: the authority has
-// spoken, legacy is the right answer, and a Redis that rejects this DEL would be failing
-// the counter's own INCR anyway.
-func dropUnauthorizedMirror(client Scripter, denied string) {
-	if err := dropMirrorScript.Run(client, []string{ModeKey}, denied).Err(); err != nil {
-		noteMirrorRepairFailed(denied)
-		unauthorizedWarn.warn("botevent: could not remove the unauthorized mode mirror; "+
-			"allocations stay on the legacy allocator and the authority will be re-read shortly",
-			zap.String("mirrorKey", ModeKey), zap.String("mirrorValue", denied), zap.Error(err))
-	}
-}
-
 // invalidateSeeded drops every bot's seeded marker. See the mirror-rebuild branch in
 // allocate for why a lost mirror invalidates more than the bot being allocated for.
 //
-// `seeded` is cleared **last**, and the order is load-bearing (review P1-2). These are
-// separate unlocked Range passes over every active bot, so a concurrent reseed — which
-// stores its own per-bot state inside seedCounter and only then stores `seeded` — can
-// interleave between them. Clearing `seeded` first would let that reseed's marker survive
-// while its companion state was wiped, i.e. a bot treated as seeded whose bookkeeping this
-// process no longer has. Clearing it last means the worst interleaving leaves a bot
-// *unseeded* with stale bookkeeping, which the next allocation fixes by re-seeding.
+// `seeded` is cleared **last** (review P1-2). These are separate unlocked Range passes over
+// every active bot, so a concurrent reseed — which stores its own per-bot state inside
+// seedCounter and only then stores `seeded` — can interleave between them. Clearing `seeded`
+// first would leave that reseed's marker in place while its companion state was wiped;
+// clearing it last means the worst interleaving leaves a bot *unseeded* with stale
+// bookkeeping, which the next allocation fixes by re-seeding.
+//
+// The stake is smaller than it was when this order was asked for, and the earlier docstring
+// overstated it (review round 7): with the span bound moved to #704, `lastPersisted` is purely
+// a throttle marker, so the worst outcome of the bad interleaving is one redundant durable
+// write. The order is still the right way round — a marker should not outlive the state it
+// stands for — and it costs nothing.
 func invalidateSeeded() {
 	for _, m := range []*sync.Map{&lastPersisted, &seeded} {
 		m.Range(func(k, _ interface{}) bool {

--- a/pkg/botevent/seq.go
+++ b/pkg/botevent/seq.go
@@ -147,9 +147,10 @@ func QueueKey(robotID string) string { return QueueKeyPrefix + robotID }
 // seedSource raises the counter to floor if it is currently lower or unset, and
 // returns the resulting value.
 //
-// Idempotent by construction, which is what lets the fix ship as a single-stage
-// deploy: every replica seeds on its own first use for a given bot, in any order,
-// any number of times, and they all converge. `SET` has no `GT` option in Redis
+// Idempotent by construction: every replica seeds on its own first use for a given
+// bot, in any order, any number of times, and they all converge. That is what lets
+// activation be a single flip rather than a coordinated restart — but it does NOT
+// make the *deploy* safe on its own; see the activation-gate note above. `SET` has no `GT` option in Redis
 // (`GT`/`LT` belong to `EXPIRE` and `ZADD`), so the compare and the write have to
 // share one script to be atomic against a concurrent seeder.
 const seedSource = `
@@ -197,17 +198,33 @@ type Scripter interface {
 	ScriptLoad(script string) *rd.StringCmd
 }
 
-// Unlike the doorbell, this is not best-effort: a failed allocation must fail the
-// enqueue, so the timeouts trade a little more patience for not dropping events.
-// They stay bounded because `saveRobotMessage` allocates inside a `msgSem` slot,
-// where a slow call stalls fan-out for every bot in the process — the same reason
-// the ring is asynchronous. Worst case here is ~3s (1s × 1 try + 2 retries),
-// which is the same order as the DB round trip GenSeq used to make.
+// Unlike the doorbell, this is not best-effort: a failed allocation fails the
+// enqueue. But it cannot be patient either, and the reason is the one that forced
+// the ring off the producer's goroutine in the first place.
+//
+// `saveRobotMessage` allocates inside a `msgSem` slot (capacity 100), held on the
+// listener goroutine. Anything that slows it down holds a slot longer, and once all
+// 100 are held, message fan-out stalls for **every bot in the process** — including
+// bots that never send an interactive card. So a degraded Redis must cost this call
+// ~1s, not ~3s.
+//
+// The trade is explicit: giving up fails one enqueue (one event, recoverable by a
+// D8 re-tap or a resend), while waiting stalls fan-out for everyone. One retry, not
+// two, for the same reason the ring uses none — a retried allocation is an
+// allocation that took twice as long.
+//
+// This is also a real change in I/O shape versus GenSeq and belongs in the review
+// record, not a footnote: GenSeq served 999 of every 1000 allocations from its
+// process-local block with **no I/O at all**, while every allocation here is a Redis
+// round trip. It cannot be batched back into blocks without recreating #697 (a block
+// is a second id source), and the mode cannot be cached without recreating the
+// mixed-source window (reviewer P0). Load-test the hottest producer before
+// activation, not after.
 const (
-	seqDialTimeout = time.Second
-	seqReadTimeout = time.Second
-	seqPoolTimeout = 500 * time.Millisecond
-	seqMaxRetries  = 2
+	seqDialTimeout = 500 * time.Millisecond
+	seqReadTimeout = 300 * time.Millisecond
+	seqPoolTimeout = 200 * time.Millisecond
+	seqMaxRetries  = 1
 )
 
 var (

--- a/pkg/botevent/seq.go
+++ b/pkg/botevent/seq.go
@@ -60,8 +60,8 @@ package botevent
 //     `seedSafetyMargin` (2 × step) covers — **while the writes land**. That
 //     qualifier is load-bearing and was missing: during a DB outage an unbounded
 //     number of ids would otherwise be issued against a frozen mark, so
-//     `highWaterFailureLimit` bounds how many intervals may pass with no durable
-//     write before allocations fail instead (review P1-7).
+//     the refusal in persistHighWater bounds how far an id may run past the last
+//     mark that actually landed (review P1-7, corrected in the round after it).
 //   - **Rollback detection in the issuing process.** The durable mark only helps if
 //     something re-seeds, and a long-running replica would otherwise keep INCRing
 //     the regressed counter forever — its `seeded` entry is already set. So every
@@ -76,6 +76,13 @@ package botevent
 //
 // The counter must still stay in the same Redis instance and db as the queue —
 // splitting them costs the uniqueness half of the argument above.
+//
+// That constraint has a second consequence worth writing down next to it: the gate and
+// probe scripts are multi-key with no hash tag, so they would fail CROSSSLOT under Redis
+// Cluster or a slot-enforcing proxy. Not new — `modules/bot_mention/idempotency.go` has the
+// same shape — and not fixable independently, because a cluster that could place the
+// counter and the queue in different slots is exactly the topology the co-recovery argument
+// already rules out. The two move together or not at all.
 //
 // Production also runs `maxmemory 0` / `noeviction`, so the counter cannot be
 // evicted under pressure — the failure mode that would otherwise make an `INCR`
@@ -194,17 +201,19 @@ const (
 	ExpectedModeEnv = "OCTO_BOTEVENT_EXPECTED_MODE"
 
 	// highWaterInterval is how many ids may be issued between durable writes. One
-	// legacy block, so the mark trails the truth by less than seedSafetyMargin.
+	// legacy block, so in healthy operation the mark trails the truth by less than
+	// seedSafetyMargin with a full interval to spare. What happens when the writes stop
+	// landing is bounded separately, by span rather than by count — see persistHighWater.
 	highWaterInterval = legacyGenSeqStep
 
-	// highWaterFailureLimit is how many consecutive intervals may pass with no
-	// durable high-water write before allocations start failing.
+	// highWaterProbeEvery is how often a bot past its unpersisted-span bound may attempt
+	// the durable write again.
 	//
-	// The mark is what makes a post-rollback seed land above what was issued before
-	// the rollback, and seedSafetyMargin covers a trailing mark only while the writes
-	// land. Three intervals is ~3 × step of exposure — still inside the margin's
-	// order of magnitude — and long enough that a brief DB blip costs nothing.
-	highWaterFailureLimit = 3
+	// The refusal has to be able to end on its own, and it must not depend on the bot's
+	// traffic: the ordinary throttle is measured in ids, so a low-traffic bot would stay
+	// refused long after the DB recovered. A time budget bounds the attempt rate (≤5/s per
+	// bot) while keeping recovery within one budget of the DB coming back.
+	highWaterProbeEvery = 200 * time.Millisecond
 
 	// maxAllocAttempts bounds the self-healing retries within one allocation.
 	//
@@ -339,6 +348,26 @@ return redis.call('INCR', KEYS[2])`
 
 var gateScript = rd.NewScript(gateSource)
 
+// probeSource reads the mode mirror and whether this bot's counter already exists, in one
+// round trip.
+//
+// The second half is cross-process evidence of activation, and it is the only such evidence
+// available without a DB read. A counter key exists only because some replica allocated
+// from it, which can only happen after the authority said `incr`. So a process that has
+// just started, reads an authority saying `legacy`, and finds the counter present knows the
+// authority regressed rather than that it is pre-activation — and can refuse instead of
+// issuing a GenSeq id beneath everything the counter handed out (review P1-A).
+//
+// Folded into the existing mirror read rather than added beside it: the pre-activation path
+// is supposed to cost one Redis round trip, and a second one would be the regression review
+// P1-1 removed, in a smaller size.
+const probeSource = `
+local mode = redis.call('GET', KEYS[1])
+if mode == false then mode = '' end
+return {mode, redis.call('EXISTS', KEYS[2])}`
+
+var probeScript = rd.NewScript(probeSource)
+
 // Scripter is the go-redis surface the allocator needs: INCR, the sorted-set read
 // used to observe the current ceiling, and the scripting set *rd.Script.Run
 // requires. octo-lib's *redis.Conn exposes none of the scripting calls, so the
@@ -437,14 +466,21 @@ var (
 	// seedLocks single-flights the seed per bot; see reseed.
 	seedLocks sync.Map
 
-	// lastPersisted tracks how far the durable high-water mark has been advanced,
-	// so the DB write happens once per highWaterInterval rather than per id.
+	// lastPersisted throttles the durable write to once per highWaterInterval. It
+	// advances on a *failed* write too, so a DB outage costs one attempt per interval
+	// rather than one per event — which is why it cannot double as the record of what
+	// actually landed. That is lastDurable.
 	lastPersisted sync.Map
 
-	// highWaterFailures counts consecutive durable-write failures per bot. See
-	// noteHighWaterFailure: the count is what bounds how long the allocator may keep
-	// issuing ids whose recovery floor is not advancing.
-	highWaterFailures sync.Map
+	// lastDurable is the highest value this process has successfully written to the
+	// durable mark, seeded from the row itself at seed time. persistHighWater measures
+	// the refusal span from this, so it must never advance on a failure.
+	lastDurable sync.Map
+
+	// lastProbe is when a bot past its unpersisted-span bound last attempted the durable
+	// write. See probeDue: past the bound the refusal must be able to end on its own
+	// without turning every doomed allocation into a blocking DB attempt.
+	lastProbe sync.Map
 
 	// countersLost counts allocations that found the mirror set but the counter key
 	// gone, and mirrorRebuilds counts mirrors rebuilt from the DB authority. Both
@@ -465,7 +501,18 @@ var (
 	// but delivery recovers without a runbook.
 	rollbacksDetected = newHealCounter("dmwork_bot_event_seq_rollback_total",
 		"Counter regressions detected and self-healed; non-zero means Redis lost data.")
+
+	// counterFoundWithoutAuthority counts allocations where the authority said legacy but
+	// the bot's counter already existed — i.e. the authority regressed underneath an
+	// activated fleet. Unlike the other counters here this one does NOT self-heal: the
+	// allocation is refused, so it is also visible as failed enqueues. It is a metric
+	// because it names the cause, which the failure alone does not.
+	counterFoundWithoutAuthority = newHealCounter("dmwork_bot_event_seq_counter_without_authority_total",
+		"Allocations refused because a counter existed while the authority said not activated.")
 )
+
+// CounterFoundWithoutAuthority reports refusals caused by a regressed authority.
+func CounterFoundWithoutAuthority() int64 { return counterFoundWithoutAuthority.load() }
 
 // SeedFailures reports how many allocations failed at the seed step.
 func SeedFailures() int64 { return seedFailures.load() }
@@ -551,10 +598,11 @@ func allocate(ctx *config.Context, client Scripter, robotID string, attempt int)
 	}
 
 	// Otherwise the decision needs the uncached mirror. Pre-activation this is the
-	// whole cost of an allocation before delegating: one Redis GET, exactly as the
-	// old binary's path shape, with the authority read amortised by the belief cache
-	// (review P1-1).
-	mirror, err := readMirror(client)
+	// whole cost of an allocation before delegating: one Redis round trip, with the
+	// authority read amortised by the belief cache (review P1-1). The same round trip
+	// reports whether this bot's counter already exists, which is the only cross-process
+	// evidence of activation available without a DB read (review P1-A).
+	mirror, counterExists, err := probeAllocatorState(client, robotID)
 	if err != nil {
 		return 0, err
 	}
@@ -563,7 +611,7 @@ func allocate(ctx *config.Context, client Scripter, robotID string, attempt int)
 		return 0, err
 	}
 	if decision == decideLegacy {
-		return legacyDelegate(ctx, robotID)
+		return legacyDelegate(ctx, robotID, counterExists)
 	}
 
 	// Activated. Two orderings matter here and both were wrong before.
@@ -615,6 +663,7 @@ func allocateFromCounter(ctx *config.Context, client Scripter, robotID string, b
 		countersLost.inc()
 		seeded.Delete(robotID)
 		lastPersisted.Delete(robotID)
+		lastDurable.Delete(robotID)
 		if err := reseed(ctx, client, robotID); err != nil {
 			return 0, err
 		}
@@ -648,42 +697,79 @@ func gateClosed(ctx *config.Context, client Scripter, robotID string, attempt in
 		return 0, fmt.Errorf("botevent: gave up resolving the allocator mode for %q after %d "+
 			"attempts; the mode mirror is being lost or rewritten repeatedly", robotID, attempt)
 	}
-	if _, _, err := refreshAuthority(ctx, false, true); err != nil {
+	if _, _, err := refreshAuthority(ctx, false, "", true); err != nil {
 		return 0, err
 	}
 	seeded.Delete(robotID)
 	return allocate(ctx, client, robotID, attempt)
 }
 
-// legacyDelegate hands the allocation to GenSeq, refusing if this process has ever
-// issued a counter id for this bot.
+// legacyDelegate hands the allocation to GenSeq, refusing when anything says the counter
+// era has already begun for this bot.
 //
-// The refusal is unreachable while the positive belief is terminal, which is the
-// point: it asserts the invariant instead of assuming it. A GenSeq id after the
-// counter era has begun is arbitrarily far below the bot's live consumer cursor, so
-// the event would be born invisible — #697, self-inflicted (review P1-4).
-func legacyDelegate(ctx *config.Context, robotID string) (int64, error) {
+// Two independent pieces of evidence, because they cover different processes:
+//
+//   - `lastIssued` — this process has itself handed out a counter id. Unreachable while
+//     the positive belief is terminal, and asserted rather than assumed because the
+//     consequence is a permanently invisible event.
+//   - `counterExists` — *some* replica has, which can only have happened after the
+//     authority said `incr`. This is what a freshly started process has instead of
+//     memory, and it is the difference between "pre-activation" and "the authority
+//     regressed underneath an activated fleet" (review P1-A). A GenSeq id in the second
+//     case lands arbitrarily far below the bot's live cursor: #697, self-inflicted.
+//
+// The residual this does NOT cover is stated rather than papered over: if the counter key
+// is gone *as well* — a Redis flush or restore that took it, correlated with an authority
+// that reads legacy — a cold process has no evidence at all and delegates to GenSeq. Only
+// `OCTO_BOTEVENT_EXPECTED_MODE=incr` closes that, and the rollout arms it after activation
+// is verified (step 5), so the window is open by design during the flip itself.
+func legacyDelegate(ctx *config.Context, robotID string, counterExists bool) (int64, error) {
 	if prev, issued := lastIssued.Load(robotID); issued {
 		return 0, fmt.Errorf("botevent: refusing to allocate a legacy id for %q after this process "+
 			"already issued counter id %v for it; a GenSeq id here would land below the bot's "+
 			"consumer cursor and never be delivered", robotID, prev)
 	}
+	if counterExists {
+		counterFoundWithoutAuthority.inc()
+		return 0, fmt.Errorf("botevent: the authority says the allocator is not activated, but "+
+			"%q already has a counter — which only exists because some replica allocated from it, "+
+			"i.e. the authority was activated and has regressed. Refusing to issue a legacy id "+
+			"below the counter's range; restore the state row (or set %s=%s) rather than letting "+
+			"two id sources onto one queue",
+			SeqKey(robotID), ExpectedModeEnv, ModeIncr)
+	}
 	return legacyEventID(ctx, robotID)
 }
 
-// readMirror returns the raw mode mirror value, or "" when the key is absent.
-func readMirror(client Scripter) (string, error) {
-	v, err := client.Get(ModeKey).Result()
-	if err != nil && err != rd.Nil {
-		return "", fmt.Errorf("botevent: read allocator mode mirror: %w", err)
+// probeAllocatorState reads the mode mirror and this bot's counter existence in one round
+// trip. mirror is "" when the key is absent.
+func probeAllocatorState(client Scripter, robotID string) (mirror string, counterExists bool, err error) {
+	v, err := probeScript.Run(client, []string{ModeKey, SeqKey(robotID)}).Result()
+	if err != nil {
+		return "", false, fmt.Errorf("botevent: probe allocator state for %q: %w", robotID, err)
 	}
-	return v, nil
+	parts, ok := v.([]interface{})
+	if !ok || len(parts) != 2 {
+		return "", false, fmt.Errorf("botevent: probe allocator state for %q: unexpected result %T", robotID, v)
+	}
+	switch m := parts[0].(type) {
+	case string:
+		mirror = m
+	case nil:
+	default:
+		return "", false, fmt.Errorf("botevent: probe allocator state for %q: unexpected mirror %T", robotID, parts[0])
+	}
+	exists, ok := parts[1].(int64)
+	if !ok {
+		return "", false, fmt.Errorf("botevent: probe allocator state for %q: unexpected counter flag %T", robotID, parts[1])
+	}
+	return mirror, exists != 0, nil
 }
 
 // invalidateSeeded drops every bot's seeded marker. See the mirror-rebuild branch in
 // allocate for why a lost mirror invalidates more than the bot being allocated for.
 func invalidateSeeded() {
-	for _, m := range []*sync.Map{&seeded, &lastPersisted} {
+	for _, m := range []*sync.Map{&seeded, &lastPersisted, &lastDurable} {
 		m.Range(func(k, _ interface{}) bool {
 			m.Delete(k)
 			return true
@@ -713,6 +799,7 @@ func afterIssue(ctx *config.Context, client Scripter, robotID string, v int64, a
 		// between, which the next allocation would catch in turn.
 		seeded.Delete(robotID)
 		lastPersisted.Delete(robotID)
+		lastDurable.Delete(robotID)
 		if err := reseed(ctx, client, robotID); err != nil {
 			return 0, err
 		}
@@ -819,14 +906,54 @@ func seedMutex(robotID string) *sync.Mutex {
 	return actual.(*sync.Mutex)
 }
 
-// persistHighWater advances the durable mark at most once per highWaterInterval.
+// persistHighWater advances the durable mark, and refuses the allocation when the mark
+// has fallen too far behind for a post-rollback seed to recover from it.
 //
-// Best-effort about *this* write: the id is already issued and the enqueue must not
-// fail because a bookkeeping write did. Not best-effort about the safety property it
-// underwrites — see highWaterFailureLimit.
+// # The bound is a span, not a failure count (review: Jerry-Xin 🔴 / yujiawei P1-B)
+//
+// The previous revision counted consecutive failed intervals and claimed "past the bound
+// the allocation fails". It did not fail. `noteHighWaterFailure` re-armed the throttle
+// marker, and the throttle check ran *before* the bound, so only 1 allocation in every
+// `highWaterInterval` even reached the bound — the other 999 returned nil and succeeded.
+// Issuance continued indefinitely against a frozen mark at a 0.1% failure rate, which is
+// the exact "unbounded ids against a frozen mark" the mechanism existed to stop. And the
+// arithmetic made it a loss path rather than only an unmet claim: with a limit of 3
+// intervals, ids up to `M+2999` were issued while a later seed computed from `M` lands at
+// `M+2000`, so a *restarted* process (empty lastIssued, no in-process refusal) resumes at
+// `M+2001` beneath cursors that already reached `M+2999`.
+//
+// So the bound is now the quantity the safety argument actually rests on: how far the
+// issued id has run past the last **durably recorded** mark. A total Redis loss followed
+// by a drained queue leaves `seedCounter` with the durable mark `M` as its only floor
+// source, and it seeds at `M + seedSafetyMargin`. Every id ever issued must therefore be
+// at or below that, so the span is refused at `seedSafetyMargin` and the largest issued id
+// is `M + seedSafetyMargin - 1` — below the first id recovery would hand out. Stated as
+// one inequality instead of a count that had to be reconciled with the margin by hand.
+//
+// The throttle stays: a failed write re-arms the interval marker, so a retry is one
+// interval away rather than one id away, and a DB outage costs one INSERT attempt per
+// `highWaterInterval` rather than one per event. Between the first failed attempt and the
+// span bound there is a full interval of grace, so a transient failure costs nothing.
 func persistHighWater(ctx *config.Context, robotID string, v int64) error {
-	if prev, ok := lastPersisted.Load(robotID); ok && v-prev.(int64) < highWaterInterval {
-		return nil
+	base, span, known := unpersistedSpan(robotID, v)
+	overBound := known && span >= seedSafetyMargin
+
+	// Past the bound the allocation is going to fail anyway, so the only thing left worth
+	// doing is recovering promptly. The ordinary throttle cannot do it: it is measured in
+	// ids, so recovery would wait for another ~1000 (refused) allocations after the DB came
+	// back, and for a low-traffic bot that is unbounded wall-clock time. So the probe
+	// switches to a time budget, which bounds the attempt rate without tying recovery to
+	// traffic. It must stay a throttle of some kind: a failing INSERT with a 300ms deadline
+	// inside a held msgSem slot is the hazard, and it does not stop being one because the
+	// enqueue is doomed — 100 slots each blocked 300ms is a throughput cliff for every bot
+	// in the process, healthy ones included.
+	if overBound && !probeDue(robotID) {
+		return unpersistedSpanError(robotID, v, base, span)
+	}
+	if !overBound {
+		if prev, ok := lastPersisted.Load(robotID); ok && v-prev.(int64) < highWaterInterval {
+			return nil
+		}
 	}
 	// The mark records what has been issued, not a reservation above it. Writing
 	// `v + interval` would compound: every seed adds seedSafetyMargin on top of the
@@ -843,61 +970,95 @@ func persistHighWater(ctx *config.Context, robotID string, v int64) error {
 			"on duplicate key update min_seq = GREATEST(min_seq, VALUES(min_seq))",
 		HighWaterSeqKey(robotID), mark).ExecContext(deadline); err != nil {
 		highWaterWriteFailures.inc()
-		return noteHighWaterFailure(robotID, v, err)
+		// Re-arm the throttle so the retry is one interval away, not one id away. The
+		// durable mark deliberately does NOT advance — it is what the span is measured
+		// from, and advancing it on failure is what made the previous bound unreachable.
+		storeMonotonic(&lastPersisted, robotID, v)
+		if overBound {
+			return unpersistedSpanError(robotID, v, base, span)
+		}
+		return nil
 	}
-	highWaterFailures.Delete(robotID)
-	lastPersistedStore(robotID, v)
+	// The write landed, so the span collapses to zero and an allocation that was being
+	// refused a moment ago succeeds. That is the recovery path, and it is why the probe
+	// interval above shrinks rather than the refusal becoming permanent.
+	storeMonotonic(&lastDurable, robotID, v)
+	storeMonotonic(&lastPersisted, robotID, v)
 	return nil
 }
 
-// noteHighWaterFailure records a failed durable write and decides whether the
-// allocator may keep issuing ids without one.
+// unpersistedSpan reports how far v has run past the last mark that actually landed.
 //
-// Two things go wrong if a failure is merely counted (review P1-7):
-//
-//   - The once-per-interval guard above keys off lastPersisted, so leaving it unset
-//     means the *next* allocation writes again — one un-deadlined INSERT per event on
-//     the fan-out path for as long as the DB is unhappy. Measured by the reviewer:
-//     50 INSERTs over 50 allocations with the table renamed away, versus 0 healthy.
-//   - The safety argument at the top of this file ("the mark trails the true maximum
-//     by at most highWaterInterval, which seedSafetyMargin covers") is only true while
-//     the writes land. During a prolonged outage an unbounded number of ids is issued
-//     against a frozen mark, and a Redis rollback plus a drained queue after that can
-//     seed below a live cursor.
-//
-// So the mark is advanced *in memory* to re-arm the interval guard — the next attempt
-// happens one interval later, not one id later — and the number of consecutive
-// intervals allowed to pass with no durable write is bounded. Past the bound the
-// allocation fails: refusing one enqueue is recoverable, while silently spending the
-// RDB safety margin is not.
-func noteHighWaterFailure(robotID string, v int64, cause error) error {
-	// Re-arm the interval guard so the retry is one interval away, not one id away.
-	lastPersistedStore(robotID, v)
-
-	n := int64(1)
-	if prev, ok := highWaterFailures.Load(robotID); ok {
-		n = prev.(int64) + 1
+// known is false for a bot this process has never seeded and never written for; there is
+// no base to measure from, and the first allocation for a bot is never throttled, so the
+// healthy path establishes one immediately.
+func unpersistedSpan(robotID string, v int64) (base, span int64, known bool) {
+	durable, ok := lastDurable.Load(robotID)
+	if !ok {
+		return 0, 0, false
 	}
-	highWaterFailures.Store(robotID, n)
-	if n < highWaterFailureLimit {
-		return nil
-	}
-	return fmt.Errorf("botevent: %d consecutive durable high-water writes failed for %q "+
-		"(last error: %w); refusing to keep issuing ids the seed floor cannot recover from "+
-		"after a Redis rollback", n, robotID, cause)
+	base = durable.(int64)
+	return base, v - base, true
 }
 
-// lastPersistedStore advances the in-memory mark monotonically.
+// probeDue reports whether a bot past its bound may attempt the durable write again, and
+// claims the slot if so.
+//
+// CAS rather than load-then-store so concurrent refused allocations for one bot cannot all
+// decide they are the probe.
+func probeDue(robotID string) bool {
+	now := time.Now()
+	for {
+		prev, loaded := lastProbe.Load(robotID)
+		if !loaded {
+			if _, already := lastProbe.LoadOrStore(robotID, now); !already {
+				return true
+			}
+			continue
+		}
+		at := prev.(time.Time)
+		if now.Sub(at) < highWaterProbeEvery {
+			return false
+		}
+		if lastProbe.CompareAndSwap(robotID, at, now) {
+			return true
+		}
+	}
+}
+
+// unpersistedSpanError is the refusal when an id has run too far past the last durable
+// mark.
+//
+// The bound is `seedSafetyMargin` because that is the arithmetic the recovery path uses.
+// After a total Redis loss with a drained queue, `seedCounter`'s surviving floor sources
+// are all in MySQL, and it seeds at `base + seedSafetyMargin`. Every id ever issued has to
+// be at or below that seed, so the span may reach `seedSafetyMargin - 1` and no further;
+// refusing there makes the largest issued id exactly one below the first id a recovery
+// would hand out.
+//
+// The alternative — keep issuing and count the failures — is what the previous revision
+// did, and the arithmetic came out the wrong side of the margin: ids ran to `base+2999`
+// against a margin of 2000, so a restarted process with an empty `lastIssued` resumed at
+// `base+2001`, beneath cursors that had already reached `base+2999`.
+func unpersistedSpanError(robotID string, v, base, span int64) error {
+	return fmt.Errorf("botevent: %q has issued id %d, %d past the last durable high-water mark "+
+		"(%d), and durable writes are failing; a seed recovering from that mark alone would land "+
+		"at %d — at or below ids already issued — so refusing to issue more rather than spend the "+
+		"rollback safety margin silently", robotID, v, span, base, base+seedSafetyMargin)
+}
+
+// storeMonotonic advances a per-bot int64 marker, never lowering it.
 //
 // CAS rather than a plain Store for the same reason recordIssued uses one: concurrent
-// allocations for one bot arrive out of order, and a lower value overwriting a higher
-// one costs a redundant write later (harmless against the GREATEST upsert, but the
-// asymmetry reads like a bug — review P2-9).
-func lastPersistedStore(robotID string, v int64) {
+// allocations for one bot arrive out of order, and a lower value overwriting a higher one
+// would both cost a redundant write and — for lastDurable — overstate the span, arriving
+// at the refusal earlier than the facts warrant (review P2-9, and the non-atomic
+// read-modify-write the failure counter used to do).
+func storeMonotonic(m *sync.Map, robotID string, v int64) {
 	for {
-		prev, loaded := lastPersisted.Load(robotID)
+		prev, loaded := m.Load(robotID)
 		if !loaded {
-			if _, already := lastPersisted.LoadOrStore(robotID, v); !already {
+			if _, already := m.LoadOrStore(robotID, v); !already {
 				return
 			}
 			continue
@@ -906,7 +1067,7 @@ func lastPersistedStore(robotID string, v int64) {
 		if v <= high {
 			return
 		}
-		if lastPersisted.CompareAndSwap(robotID, high, v) {
+		if m.CompareAndSwap(robotID, high, v) {
 			return
 		}
 	}
@@ -981,6 +1142,12 @@ func seedCounter(ctx *config.Context, client Scripter, robotID string) error {
 	if err != nil {
 		return err
 	}
+	// Record it as this process's durable base. persistHighWater measures its refusal
+	// span from here, so without this a fresh process would have no base until its
+	// first *successful* write — and if durable writes are already failing, that first
+	// success never comes and the span is never computed. Reading it here costs nothing:
+	// the seed already did the query.
+	storeMonotonic(&lastDurable, robotID, durableMax)
 	floor := queueMax
 	if legacyMax > floor {
 		floor = legacyMax
@@ -1054,7 +1221,7 @@ func legacyCeiling(ctx *config.Context, robotID string) (int64, error) {
 // ResetSeededForTest clears the process-local seed cache. Tests that seed against
 // different fixtures need it; production never does.
 func ResetSeededForTest() {
-	for _, m := range []*sync.Map{&seeded, &lastIssued, &lastPersisted, &seedLocks, &highWaterFailures} {
+	for _, m := range []*sync.Map{&seeded, &lastIssued, &lastPersisted, &lastDurable, &lastProbe, &seedLocks} {
 		m.Range(func(k, _ interface{}) bool {
 			m.Delete(k)
 			return true

--- a/pkg/botevent/seq.go
+++ b/pkg/botevent/seq.go
@@ -50,24 +50,26 @@ package botevent
 // axis a bare INCR counter is strictly worse than GenSeq, whose `min_seq` lives in
 // MySQL and does not regress when Redis does.
 //
-// Two mechanisms close it, because neither suffices alone:
+// Two mechanisms close it, and **neither is complete in this change** — see
+// Mininglamp-OSS/octo-server#704, which gates activation on finishing them:
 //
 //   - **A durable high-water mark in MySQL** (`seq` row `botEventHigh:{robotID}`),
 //     advanced roughly every `highWaterInterval` ids and folded into every seed's
 //     floor. It does not share Redis's recovery domain, so it survives an RDB
 //     rollback. Persisting every id would be a DB write per allocation; persisting
-//     every ~1000 keeps the mark within one interval of the truth, which
-//     `seedSafetyMargin` (2 × step) covers — **while the writes land**. That
-//     qualifier is load-bearing and was missing: during a DB outage an unbounded
-//     number of ids would otherwise be issued against a frozen mark, so
-//     the refusal in persistHighWater bounds how far an id may run past the last
-//     mark that actually landed (review P1-7, corrected in the round after it).
+//     every ~1000 keeps the mark within one interval of the truth in healthy
+//     operation, which `seedSafetyMargin` (2 × step) covers. **While durable writes
+//     are failing it trails without bound**, and two attempts to bound that inside
+//     this PR were both wrong — see persistHighWater for the arithmetic that says why
+//     the fix is a change to what the recovery floor *is*, which is #704's.
 //   - **Rollback detection in the issuing process.** The durable mark only helps if
 //     something re-seeds, and a long-running replica would otherwise keep INCRing
 //     the regressed counter forever — its `seeded` entry is already set. So every
 //     allocation is compared against the last id this process issued for that bot;
 //     a value that did not advance means the counter regressed, and the allocation
-//     re-seeds and retries. That makes recovery automatic rather than a runbook.
+//     re-seeds and retries. That makes recovery automatic rather than a runbook —
+//     but the comparison is process-local and tolerance-bounded, which is the other
+//     half of #704.
 //
 // The high-water write uses `GREATEST(min_seq, VALUES(min_seq))`. It must: an
 // unconditional `ON DUPLICATE KEY UPDATE` is exactly how `GenSeq` lets a lagging
@@ -136,6 +138,7 @@ import (
 	rd "github.com/go-redis/redis"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+	"go.uber.org/zap"
 )
 
 const (
@@ -205,15 +208,6 @@ const (
 	// seedSafetyMargin with a full interval to spare. What happens when the writes stop
 	// landing is bounded separately, by span rather than by count — see persistHighWater.
 	highWaterInterval = legacyGenSeqStep
-
-	// highWaterProbeEvery is how often a bot past its unpersisted-span bound may attempt
-	// the durable write again.
-	//
-	// The refusal has to be able to end on its own, and it must not depend on the bot's
-	// traffic: the ordinary throttle is measured in ids, so a low-traffic bot would stay
-	// refused long after the DB recovered. A time budget bounds the attempt rate (≤5/s per
-	// bot) while keeping recovery within one budget of the DB coming back.
-	highWaterProbeEvery = 200 * time.Millisecond
 
 	// maxAllocAttempts bounds the self-healing retries within one allocation.
 	//
@@ -348,6 +342,12 @@ return redis.call('INCR', KEYS[2])`
 
 var gateScript = rd.NewScript(gateSource)
 
+const dropMirrorSource = `
+if redis.call('GET', KEYS[1]) == ARGV[1] then return redis.call('DEL', KEYS[1]) end
+return 0`
+
+var dropMirrorScript = rd.NewScript(dropMirrorSource)
+
 // probeSource reads the mode mirror and whether this bot's counter already exists, in one
 // round trip.
 //
@@ -468,19 +468,10 @@ var (
 
 	// lastPersisted throttles the durable write to once per highWaterInterval. It
 	// advances on a *failed* write too, so a DB outage costs one attempt per interval
-	// rather than one per event — which is why it cannot double as the record of what
-	// actually landed. That is lastDurable.
+	// rather than one per event, which is the half of review P1-7 that stays fixed. It is
+	// therefore NOT a record of what landed — see persistHighWater for why this revision
+	// does not try to bound the gap and #704 for who does.
 	lastPersisted sync.Map
-
-	// lastDurable is the highest value this process has successfully written to the
-	// durable mark, seeded from the row itself at seed time. persistHighWater measures
-	// the refusal span from this, so it must never advance on a failure.
-	lastDurable sync.Map
-
-	// lastProbe is when a bot past its unpersisted-span bound last attempted the durable
-	// write. See probeDue: past the bound the refusal must be able to end on its own
-	// without turning every doomed allocation into a blocking DB attempt.
-	lastProbe sync.Map
 
 	// countersLost counts allocations that found the mirror set but the counter key
 	// gone, and mirrorRebuilds counts mirrors rebuilt from the DB authority. Both
@@ -606,13 +597,20 @@ func allocate(ctx *config.Context, client Scripter, robotID string, attempt int)
 	if err != nil {
 		return 0, err
 	}
-	decision, b, err := resolveMode(ctx, mirror)
+	res, err := resolveMode(ctx, mirror)
 	if err != nil {
 		return 0, err
 	}
-	if decision == decideLegacy {
+	if res.unauthorizedMirror != "" {
+		// The authority denied this mirror, so the correct state for the key is absent.
+		// Best-effort and compare-and-delete: a failure only means the next allocation
+		// re-reads the authority, bounded by repairCooldown.
+		dropUnauthorizedMirror(client, res.unauthorizedMirror)
+	}
+	if res.decision == decideLegacy {
 		return legacyDelegate(ctx, robotID, counterExists)
 	}
+	b := res.belief
 
 	// Activated. Two orderings matter here and both were wrong before.
 	rebuildMirror := mirror != b.mirrorValue()
@@ -663,7 +661,6 @@ func allocateFromCounter(ctx *config.Context, client Scripter, robotID string, b
 		countersLost.inc()
 		seeded.Delete(robotID)
 		lastPersisted.Delete(robotID)
-		lastDurable.Delete(robotID)
 		if err := reseed(ctx, client, robotID); err != nil {
 			return 0, err
 		}
@@ -697,7 +694,7 @@ func gateClosed(ctx *config.Context, client Scripter, robotID string, attempt in
 		return 0, fmt.Errorf("botevent: gave up resolving the allocator mode for %q after %d "+
 			"attempts; the mode mirror is being lost or rewritten repeatedly", robotID, attempt)
 	}
-	if _, _, err := refreshAuthority(ctx, false, "", true); err != nil {
+	if _, err := refreshAuthority(ctx, false, "", true); err != nil {
 		return 0, err
 	}
 	seeded.Delete(robotID)
@@ -723,6 +720,10 @@ func gateClosed(ctx *config.Context, client Scripter, robotID string, attempt in
 // that reads legacy — a cold process has no evidence at all and delegates to GenSeq. Only
 // `OCTO_BOTEVENT_EXPECTED_MODE=incr` closes that, and the rollout arms it after activation
 // is verified (step 5), so the window is open by design during the flip itself.
+//
+// Note what the env guard does and does not buy, because the refusal message below used to
+// get it wrong: it is a fail-closed *assertion*, not a manual override. Setting it makes an
+// unconfirmable mode refuse loudly on every replica; it never lets one proceed.
 func legacyDelegate(ctx *config.Context, robotID string, counterExists bool) (int64, error) {
 	if prev, issued := lastIssued.Load(robotID); issued {
 		return 0, fmt.Errorf("botevent: refusing to allocate a legacy id for %q after this process "+
@@ -734,9 +735,11 @@ func legacyDelegate(ctx *config.Context, robotID string, counterExists bool) (in
 		return 0, fmt.Errorf("botevent: the authority says the allocator is not activated, but "+
 			"%q already has a counter — which only exists because some replica allocated from it, "+
 			"i.e. the authority was activated and has regressed. Refusing to issue a legacy id "+
-			"below the counter's range; restore the state row (or set %s=%s) rather than letting "+
-			"two id sources onto one queue",
-			SeqKey(robotID), ExpectedModeEnv, ModeIncr)
+			"below the counter's range. Fix the authority: restore %s to mode=1 with the epoch and "+
+			"cutover_floor it had. Setting %s=%s does NOT let this replica proceed — it is a "+
+			"fail-closed assertion, so it only makes every replica refuse loudly instead of some "+
+			"of them degrading",
+			SeqKey(robotID), stateTable, ExpectedModeEnv, ModeIncr)
 	}
 	return legacyEventID(ctx, robotID)
 }
@@ -766,10 +769,38 @@ func probeAllocatorState(client Scripter, robotID string) (mirror string, counte
 	return mirror, exists != 0, nil
 }
 
+// dropUnauthorizedMirror removes a mode mirror the authority denied, if it still holds the
+// exact value that was denied.
+//
+// Compare-and-delete rather than a bare DEL: between the authority read and this call an
+// operator may have activated and written a *different* generation, which must survive.
+//
+// Best-effort. A failure is recorded on the belief so the next allocation is answered from
+// the cached denial for a short cooldown instead of re-reading the authority per
+// allocation — see belief.repairFailedFor. It is not an allocation error: the authority has
+// spoken, legacy is the right answer, and a Redis that rejects this DEL would be failing
+// the counter's own INCR anyway.
+func dropUnauthorizedMirror(client Scripter, denied string) {
+	if err := dropMirrorScript.Run(client, []string{ModeKey}, denied).Err(); err != nil {
+		noteMirrorRepairFailed(denied)
+		unauthorizedWarn.warn("botevent: could not remove the unauthorized mode mirror; "+
+			"allocations stay on the legacy allocator and the authority will be re-read shortly",
+			zap.String("mirrorKey", ModeKey), zap.String("mirrorValue", denied), zap.Error(err))
+	}
+}
+
 // invalidateSeeded drops every bot's seeded marker. See the mirror-rebuild branch in
 // allocate for why a lost mirror invalidates more than the bot being allocated for.
+//
+// `seeded` is cleared **last**, and the order is load-bearing (review P1-2). These are
+// separate unlocked Range passes over every active bot, so a concurrent reseed — which
+// stores its own per-bot state inside seedCounter and only then stores `seeded` — can
+// interleave between them. Clearing `seeded` first would let that reseed's marker survive
+// while its companion state was wiped, i.e. a bot treated as seeded whose bookkeeping this
+// process no longer has. Clearing it last means the worst interleaving leaves a bot
+// *unseeded* with stale bookkeeping, which the next allocation fixes by re-seeding.
 func invalidateSeeded() {
-	for _, m := range []*sync.Map{&seeded, &lastPersisted, &lastDurable} {
+	for _, m := range []*sync.Map{&lastPersisted, &seeded} {
 		m.Range(func(k, _ interface{}) bool {
 			m.Delete(k)
 			return true
@@ -799,7 +830,6 @@ func afterIssue(ctx *config.Context, client Scripter, robotID string, v int64, a
 		// between, which the next allocation would catch in turn.
 		seeded.Delete(robotID)
 		lastPersisted.Delete(robotID)
-		lastDurable.Delete(robotID)
 		if err := reseed(ctx, client, robotID); err != nil {
 			return 0, err
 		}
@@ -828,12 +858,9 @@ func afterIssue(ctx *config.Context, client Scripter, robotID string, v int64, a
 		v = retried
 	}
 	recordIssued(robotID, v)
-	if err := persistHighWater(ctx, robotID, v); err != nil {
-		// The id is allocated and unique, but the floor that would recover it after a
-		// Redis rollback has stopped advancing for too long. Failing here trades one
-		// enqueue for the RDB safety margin; see noteHighWaterFailure.
-		return 0, err
-	}
+	// Best-effort, and deliberately not fatal: see persistHighWater for what that costs
+	// and why bounding it is #704's rather than this function's.
+	persistHighWater(ctx, robotID, v)
 	return v, nil
 }
 
@@ -906,54 +933,53 @@ func seedMutex(robotID string) *sync.Mutex {
 	return actual.(*sync.Mutex)
 }
 
-// persistHighWater advances the durable mark, and refuses the allocation when the mark
-// has fallen too far behind for a post-rollback seed to recover from it.
+// persistHighWater advances the durable mark, throttled to once per highWaterInterval.
 //
-// # The bound is a span, not a failure count (review: Jerry-Xin 🔴 / yujiawei P1-B)
+// # It is best-effort, and this revision stops claiming otherwise
 //
-// The previous revision counted consecutive failed intervals and claimed "past the bound
-// the allocation fails". It did not fail. `noteHighWaterFailure` re-armed the throttle
-// marker, and the throttle check ran *before* the bound, so only 1 allocation in every
-// `highWaterInterval` even reached the bound — the other 999 returned nil and succeeded.
-// Issuance continued indefinitely against a frozen mark at a 0.1% failure rate, which is
-// the exact "unbounded ids against a frozen mark" the mechanism existed to stop. And the
-// arithmetic made it a loss path rather than only an unmet claim: with a limit of 3
-// intervals, ids up to `M+2999` were issued while a later seed computed from `M` lands at
-// `M+2000`, so a *restarted* process (empty lastIssued, no in-process refusal) resumes at
-// `M+2001` beneath cursors that already reached `M+2999`.
+// Two previous revisions put a bound here and both were wrong, in opposite directions:
+// a failure *count* that the throttle short-circuited before ever consulting (so only
+// 1 allocation in `highWaterInterval` failed and 999 succeeded against a frozen mark),
+// then a *span* measured from the durable mark — which is over its bound on the very
+// first allocation after every seed, because `seedCounter` sets the counter to
+// `base + seedSafetyMargin` while the mark stays at `base`. That made the refusal fire
+// on the first failed write with no grace, drop the event, and turn the recovery probe
+// into a storm inside `msgSem` slots.
 //
-// So the bound is now the quantity the safety argument actually rests on: how far the
-// issued id has run past the last **durably recorded** mark. A total Redis loss followed
-// by a drained queue leaves `seedCounter` with the durable mark `M` as its only floor
-// source, and it seeds at `M + seedSafetyMargin`. Every id ever issued must therefore be
-// at or below that, so the span is refused at `seedSafetyMargin` and the largest issued id
-// is `M + seedSafetyMargin - 1` — below the first id recovery would hand out. Stated as
-// one inequality instead of a count that had to be reconciled with the margin by hand.
+// Working the arithmetic out properly says why a third local patch would fail too:
 //
-// The throttle stays: a failed write re-arms the interval marker, so a retry is one
-// interval away rather than one id away, and a DB outage costs one INSERT attempt per
-// `highWaterInterval` rather than one per event. Between the first failed attempt and the
-// span bound there is a full interval of grace, so a transient failure costs nothing.
-func persistHighWater(ctx *config.Context, robotID string, v int64) error {
-	base, span, known := unpersistedSpan(robotID, v)
-	overBound := known && span >= seedSafetyMargin
-
-	// Past the bound the allocation is going to fail anyway, so the only thing left worth
-	// doing is recovering promptly. The ordinary throttle cannot do it: it is measured in
-	// ids, so recovery would wait for another ~1000 (refused) allocations after the DB came
-	// back, and for a low-traffic bot that is unbounded wall-clock time. So the probe
-	// switches to a time budget, which bounds the attempt rate without tying recovery to
-	// traffic. It must stay a throttle of some kind: a failing INSERT with a 300ms deadline
-	// inside a held msgSem slot is the hazard, and it does not stop being one because the
-	// enqueue is doomed — 100 slots each blocked 300ms is a throughput cliff for every bot
-	// in the process, healthy ones included.
-	if overBound && !probeDue(robotID) {
-		return unpersistedSpanError(robotID, v, base, span)
-	}
-	if !overBound {
-		if prev, ok := lastPersisted.Load(robotID); ok && v-prev.(int64) < highWaterInterval {
-			return nil
-		}
+//	A seed sets the counter to S = max(sources) + seedSafetyMargin.
+//	A recovery seed replays the *same* computation over the surviving MySQL sources, so
+//	it lands at S again. Ids issued after a seed are S+1, S+2, …, all of them above S.
+//
+// So the first id after any seed is already outside what a recovery from the unchanged
+// mark could reach — the exposure does not start after some grace, it starts
+// immediately. Closing it requires the mark to advance *at seed time*, and a mark that
+// records the seeded value feeds back into the next seed's floor, so every re-seed
+// compounds it by a block (which also breaks the no-op property
+// TestSeedIsIdempotentAndNeverLowers guards). That is a change to what the recovery
+// floor *is*, not a tweak to a comparison — and it is exactly the question
+// Mininglamp-OSS/octo-server#704 owns, together with rollback detection, which has the
+// same shape ("what state can regress, who detects it, what re-establishes the floor").
+// Both reviewers recommended moving it there in one piece rather than iterating here.
+//
+// # So what this function guarantees, plainly
+//
+// In healthy operation the mark trails the highest issued id by less than
+// `highWaterInterval`, which is what makes a post-rollback seed land above what was
+// issued before the rollback. **While durable writes are failing it trails without
+// bound**, and an unbounded number of ids can be issued against a frozen mark. A Redis
+// rollback plus a drained queue after that can then seed below a live consumer cursor.
+// `dmwork_bot_event_seq_high_water_write_failure_total` is the signal, and #704 is the
+// gate: it must be closed before an operator activates, so this exposure is not
+// reachable by merging.
+//
+// The throttle re-arms on failure, so a DB outage costs one INSERT attempt per
+// `highWaterInterval` rather than one per event. That much was never contested and is
+// the half of the earlier finding (P1-7) that stays fixed here.
+func persistHighWater(ctx *config.Context, robotID string, v int64) {
+	if prev, ok := lastPersisted.Load(robotID); ok && v-prev.(int64) < highWaterInterval {
+		return
 	}
 	// The mark records what has been issued, not a reservation above it. Writing
 	// `v + interval` would compound: every seed adds seedSafetyMargin on top of the
@@ -970,90 +996,19 @@ func persistHighWater(ctx *config.Context, robotID string, v int64) error {
 			"on duplicate key update min_seq = GREATEST(min_seq, VALUES(min_seq))",
 		HighWaterSeqKey(robotID), mark).ExecContext(deadline); err != nil {
 		highWaterWriteFailures.inc()
-		// Re-arm the throttle so the retry is one interval away, not one id away. The
-		// durable mark deliberately does NOT advance — it is what the span is measured
-		// from, and advancing it on failure is what made the previous bound unreachable.
+		// Re-arm the throttle so the retry is one interval away, not one id away.
 		storeMonotonic(&lastPersisted, robotID, v)
-		if overBound {
-			return unpersistedSpanError(robotID, v, base, span)
-		}
-		return nil
+		return
 	}
-	// The write landed, so the span collapses to zero and an allocation that was being
-	// refused a moment ago succeeds. That is the recovery path, and it is why the probe
-	// interval above shrinks rather than the refusal becoming permanent.
-	storeMonotonic(&lastDurable, robotID, v)
 	storeMonotonic(&lastPersisted, robotID, v)
-	return nil
-}
-
-// unpersistedSpan reports how far v has run past the last mark that actually landed.
-//
-// known is false for a bot this process has never seeded and never written for; there is
-// no base to measure from, and the first allocation for a bot is never throttled, so the
-// healthy path establishes one immediately.
-func unpersistedSpan(robotID string, v int64) (base, span int64, known bool) {
-	durable, ok := lastDurable.Load(robotID)
-	if !ok {
-		return 0, 0, false
-	}
-	base = durable.(int64)
-	return base, v - base, true
-}
-
-// probeDue reports whether a bot past its bound may attempt the durable write again, and
-// claims the slot if so.
-//
-// CAS rather than load-then-store so concurrent refused allocations for one bot cannot all
-// decide they are the probe.
-func probeDue(robotID string) bool {
-	now := time.Now()
-	for {
-		prev, loaded := lastProbe.Load(robotID)
-		if !loaded {
-			if _, already := lastProbe.LoadOrStore(robotID, now); !already {
-				return true
-			}
-			continue
-		}
-		at := prev.(time.Time)
-		if now.Sub(at) < highWaterProbeEvery {
-			return false
-		}
-		if lastProbe.CompareAndSwap(robotID, at, now) {
-			return true
-		}
-	}
-}
-
-// unpersistedSpanError is the refusal when an id has run too far past the last durable
-// mark.
-//
-// The bound is `seedSafetyMargin` because that is the arithmetic the recovery path uses.
-// After a total Redis loss with a drained queue, `seedCounter`'s surviving floor sources
-// are all in MySQL, and it seeds at `base + seedSafetyMargin`. Every id ever issued has to
-// be at or below that seed, so the span may reach `seedSafetyMargin - 1` and no further;
-// refusing there makes the largest issued id exactly one below the first id a recovery
-// would hand out.
-//
-// The alternative — keep issuing and count the failures — is what the previous revision
-// did, and the arithmetic came out the wrong side of the margin: ids ran to `base+2999`
-// against a margin of 2000, so a restarted process with an empty `lastIssued` resumed at
-// `base+2001`, beneath cursors that had already reached `base+2999`.
-func unpersistedSpanError(robotID string, v, base, span int64) error {
-	return fmt.Errorf("botevent: %q has issued id %d, %d past the last durable high-water mark "+
-		"(%d), and durable writes are failing; a seed recovering from that mark alone would land "+
-		"at %d — at or below ids already issued — so refusing to issue more rather than spend the "+
-		"rollback safety margin silently", robotID, v, span, base, base+seedSafetyMargin)
 }
 
 // storeMonotonic advances a per-bot int64 marker, never lowering it.
 //
 // CAS rather than a plain Store for the same reason recordIssued uses one: concurrent
 // allocations for one bot arrive out of order, and a lower value overwriting a higher one
-// would both cost a redundant write and — for lastDurable — overstate the span, arriving
-// at the refusal earlier than the facts warrant (review P2-9, and the non-atomic
-// read-modify-write the failure counter used to do).
+// costs a redundant durable write later (harmless against the GREATEST upsert, but the
+// asymmetry reads like a bug — review P2-9).
 func storeMonotonic(m *sync.Map, robotID string, v int64) {
 	for {
 		prev, loaded := m.Load(robotID)
@@ -1142,12 +1097,6 @@ func seedCounter(ctx *config.Context, client Scripter, robotID string) error {
 	if err != nil {
 		return err
 	}
-	// Record it as this process's durable base. persistHighWater measures its refusal
-	// span from here, so without this a fresh process would have no base until its
-	// first *successful* write — and if durable writes are already failing, that first
-	// success never comes and the span is never computed. Reading it here costs nothing:
-	// the seed already did the query.
-	storeMonotonic(&lastDurable, robotID, durableMax)
 	floor := queueMax
 	if legacyMax > floor {
 		floor = legacyMax
@@ -1221,7 +1170,7 @@ func legacyCeiling(ctx *config.Context, robotID string) (int64, error) {
 // ResetSeededForTest clears the process-local seed cache. Tests that seed against
 // different fixtures need it; production never does.
 func ResetSeededForTest() {
-	for _, m := range []*sync.Map{&seeded, &lastIssued, &lastPersisted, &lastDurable, &lastProbe, &seedLocks} {
+	for _, m := range []*sync.Map{&seeded, &lastIssued, &lastPersisted, &seedLocks} {
 		m.Range(func(k, _ interface{}) bool {
 			m.Delete(k)
 			return true

--- a/pkg/botevent/seq_review_test.go
+++ b/pkg/botevent/seq_review_test.go
@@ -1,9 +1,9 @@
 package botevent
 
 import (
-	"errors"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/Mininglamp-OSS/octo-lib/config"
 	rd "github.com/go-redis/redis"
@@ -110,39 +110,200 @@ func TestLostMirrorInvalidatesEverySeededBot(t *testing.T) {
 	}
 }
 
-// TestHighWaterFailuresAreBoundedAndThrottled is review P1-7.
+// TestColdProcessRefusesWhenACounterOutlivesTheAuthority is review P1-A.
 //
-// Counting a failed durable write is not enough. Leaving `lastPersisted` unset means
-// the once-per-interval guard never engages, so the allocator does one un-deadlined
-// INSERT per event while the DB is unhappy. And the safety argument at the top of
-// seq.go — the mark trails by at most one interval, which seedSafetyMargin covers —
-// only holds while the writes land, so the number of intervals allowed to pass without
-// one has to be bounded rather than asserted away.
-func TestHighWaterFailuresAreBoundedAndThrottled(t *testing.T) {
-	robotID := "seqtest_highwaterbound_bot"
-	t.Cleanup(func() {
-		highWaterFailures.Delete(robotID)
-		lastPersisted.Delete(robotID)
-	})
-	highWaterFailures.Delete(robotID)
-	lastPersisted.Delete(robotID)
+// The file header used to claim a denied mirror "does not split the fleet: every replica
+// reads the same authority row and reaches the same conclusion". It does not: a replica
+// with a positive belief never re-reads, and with an intact mirror the gate never closes.
+// So an authority that regresses after activation leaves running replicas on the counter
+// while a freshly started one reads `legacy` and would delegate to GenSeq — two live id
+// sources on one queue, which is #697.
+//
+// The evidence a cold process has instead of memory is the counter key itself: it exists
+// only because some replica allocated from it, which can only happen after the authority
+// said `incr`. So `legacy` plus a live counter must refuse, not degrade.
+func TestColdProcessRefusesWhenACounterOutlivesTheAuthority(t *testing.T) {
+	ctx, client := seqTestCtx(t)
+	robotID := "seqtest_counteroutlives_bot"
+	fixture(t, ctx, client, robotID)
 
-	cause := errors.New("simulated DB outage")
-	for i := 1; i < highWaterFailureLimit; i++ {
-		if err := noteHighWaterFailure(robotID, int64(i)*highWaterInterval, cause); err != nil {
-			t.Fatalf("failure %d must not fail the allocation yet: %v", i, err)
-		}
-		// Re-arming the interval guard is what stops the retry storm: the next write is
-		// one interval away, not one id away.
-		if _, armed := lastPersisted.Load(robotID); !armed {
-			t.Fatalf("failure %d left the interval guard unarmed, so the next allocation would "+
-				"attempt another INSERT immediately", i)
+	issued, err := nextEventID(ctx, client, robotID)
+	if err != nil {
+		t.Fatalf("allocate while activated: %v", err)
+	}
+
+	// The authority regresses, and this process restarts — no belief, no lastIssued, so
+	// nothing in memory remembers the counter era. The mirror is gone too; only the
+	// counter key survives, which is the realistic shape (Redis kept its data, MySQL was
+	// restored).
+	setStateMode(t, ctx, StateModeLegacy, 0)
+	client.Del(ModeKey)
+	ResetSeededForTest()
+
+	before := CounterFoundWithoutAuthority()
+	got, err := nextEventID(ctx, client, robotID)
+	if err == nil {
+		t.Fatalf("a cold process allocated %d from GenSeq while %q still had a counter that had "+
+			"already issued %d; that id lands below the bot's live cursor, and the replicas still "+
+			"running are meanwhile allocating from the counter — two id sources on one queue",
+			got, robotID, issued)
+	}
+	if CounterFoundWithoutAuthority() == before {
+		t.Error("the refusal must be counted; it names the cause, which a failed enqueue alone " +
+			"does not")
+	}
+
+	// And the residual is the *other* shape: with the counter gone as well there is no
+	// evidence at all, and legacy is what a pre-migration deploy looks like. Pinned so the
+	// accepted residual is a test fact rather than a sentence in a comment.
+	client.Del(SeqKey(robotID))
+	ResetSeededForTest()
+	if _, err := nextEventID(ctx, client, robotID); err != nil {
+		t.Fatalf("with neither a mirror nor a counter, legacy is the only available answer "+
+			"(OCTO_BOTEVENT_EXPECTED_MODE=incr is what closes this, by design after the flip): %v", err)
+	}
+
+	setStateMode(t, ctx, StateModeIncr, 0)
+}
+
+// TestDeniedMirrorIsNotRereadPerAllocation is review P1-C.
+//
+// A mirror claiming activation skips the negative TTL by design — that is what makes a
+// flip propagate without waiting. But nothing rewrites or clears a *forged* mirror, so
+// before this fix every allocation performed its own authority read, serialized behind
+// beliefMu, inside a held msgSem slot, with no exit until a human deleted the key. That is
+// the same hazard class as the per-allocation read review P1-1 removed.
+func TestDeniedMirrorIsNotRereadPerAllocation(t *testing.T) {
+	ctx, client := seqTestCtx(t)
+	robotID := "seqtest_deniedmirror_bot"
+	fixture(t, ctx, client, robotID)
+
+	// Authority says legacy; somebody planted a mirror claiming otherwise.
+	setStateMode(t, ctx, StateModeLegacy, 0)
+	ResetSeededForTest()
+	client.Del(SeqKey(robotID))
+	if err := client.Set(ModeKey, MirrorValue(7), 0).Err(); err != nil {
+		t.Fatalf("plant mirror: %v", err)
+	}
+
+	before := AuthorityReads()
+	const allocations = 20
+	for i := 0; i < allocations; i++ {
+		if _, err := nextEventID(ctx, client, robotID); err != nil {
+			t.Fatalf("allocate %d: %v", i, err)
 		}
 	}
-	if err := noteHighWaterFailure(robotID, highWaterFailureLimit*highWaterInterval, cause); err == nil {
-		t.Fatalf("after %d consecutive failures the allocation must fail; issuing ids whose "+
-			"recovery floor is frozen spends the RDB safety margin silently",
-			highWaterFailureLimit)
+	reads := AuthorityReads() - before
+	if reads > 1 {
+		t.Errorf("%d allocations against a denied mirror issued %d authority reads; a forged key "+
+			"nobody clears must not cost a serialized DB read per allocation on the fan-out path",
+			allocations, reads)
+	}
+
+	// A *different* mirror value is still a conflict and must still be read — otherwise a
+	// genuine activation would be swallowed by the cached denial.
+	if err := client.Set(ModeKey, MirrorValue(8), 0).Err(); err != nil {
+		t.Fatalf("change mirror: %v", err)
+	}
+	if _, err := nextEventID(ctx, client, robotID); err != nil {
+		t.Fatalf("allocate after the mirror changed: %v", err)
+	}
+	if AuthorityReads()-before <= reads {
+		t.Error("a mirror value that has not been denied yet must force an authority read; " +
+			"caching the denial by value is what keeps a real flip from being swallowed")
+	}
+}
+
+// round's P1-7 "fix", which both reviewers found did not fail closed.
+//
+// The bound was a count of failed intervals, and `persistHighWater` short-circuited on the
+// throttle marker *before* consulting it — so once the bound was reached only 1 allocation
+// in every `highWaterInterval` even reached the check, and the other 999 succeeded.
+// Issuance continued indefinitely against a frozen mark at a 0.1% failure rate, which is
+// the unbounded exposure the mechanism claimed to prevent. Worse, with a limit of 3 the ids
+// ran to `M+2999` while `seedSafetyMargin` is 2000, so a *restarted* process (empty
+// lastIssued, no in-process refusal) would resume at `M+2001` beneath cursors that had
+// already reached `M+2999`.
+//
+// The previous test could not see any of it: it called `noteHighWaterFailure` directly with
+// values spaced exactly one interval apart, so it never went through the short-circuit that
+// swallowed the intervening 999, and it asserted a helper's return value rather than the
+// allocator's behaviour. This one drives real allocations with the durable write broken,
+// which is the only shape that could have caught it.
+func TestHighWaterFailuresStopIssuanceThroughTheRealPath(t *testing.T) {
+	ctx, client := seqTestCtx(t)
+	robotID := "seqtest_highwaterbound_bot"
+	fixture(t, ctx, client, robotID)
+
+	// One healthy allocation establishes the durable base, as the first allocation for a
+	// bot always does (it is never throttled).
+	first, err := nextEventID(ctx, client, robotID)
+	if err != nil {
+		t.Fatalf("first allocate: %v", err)
+	}
+	base, err := highWaterCeiling(ctx, robotID)
+	if err != nil || base == 0 {
+		t.Fatalf("the first allocation must land the durable mark (base=%d err=%v)", base, err)
+	}
+
+	// Now the durable write breaks. Renaming the row's table out from under the allocator
+	// is the closest thing to a DB outage that leaves Redis usable, which is the state the
+	// bound exists for.
+	if _, err := ctx.DB().Exec("RENAME TABLE `seq` TO `seq_hidden_for_test`"); err != nil {
+		t.Skipf("cannot rename seq table to simulate a durable-write outage: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = ctx.DB().Exec("RENAME TABLE `seq_hidden_for_test` TO `seq`")
+	})
+
+	// Walk the counter forward past the bound. Every allocation must either succeed with an
+	// id inside the recoverable window, or fail — never succeed outside it.
+	var lastOK int64 = first
+	refusedAt := int64(0)
+	for i := 0; i < 3*seedSafetyMargin; i++ {
+		v, err := nextEventID(ctx, client, robotID)
+		if err != nil {
+			refusedAt = lastOK
+			break
+		}
+		if v-base >= seedSafetyMargin {
+			t.Fatalf("allocation %d succeeded at id %d, %d past the frozen durable mark %d; a "+
+				"seed recovering from that mark lands at %d, so this id is unrecoverable and "+
+				"must have been refused", i, v, v-base, base, base+seedSafetyMargin)
+		}
+		lastOK = v
+	}
+	if refusedAt == 0 {
+		t.Fatalf("issuance never stopped: %d allocations succeeded with the durable write "+
+			"failing throughout, which is the unbounded exposure the bound exists to close",
+			3*seedSafetyMargin)
+	}
+
+	// And it stays refused — the bound is not a once-per-interval probe.
+	for i := 0; i < 5; i++ {
+		if _, err := nextEventID(ctx, client, robotID); err == nil {
+			t.Fatalf("allocation %d past the bound succeeded; the refusal must apply to every "+
+				"allocation in the frozen window, not one per interval", i)
+		}
+	}
+
+	// Recovery must be reachable, and must not depend on the bot's traffic: the probe
+	// while past the bound is on a time budget, so one budget after the DB comes back the
+	// next allocation lands the mark and succeeds.
+	if _, err := ctx.DB().Exec("RENAME TABLE `seq_hidden_for_test` TO `seq`"); err != nil {
+		t.Fatalf("restore seq table: %v", err)
+	}
+	deadline := time.Now().Add(5 * highWaterProbeEvery)
+	for {
+		if _, err := nextEventID(ctx, client, robotID); err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("allocation did not resume within %v of durable writes working again; the "+
+				"refusal has to be able to end on its own, not wait for the bot's next %d ids",
+				5*highWaterProbeEvery, highWaterInterval)
+		}
+		time.Sleep(highWaterProbeEvery / 4)
 	}
 }
 

--- a/pkg/botevent/seq_review_test.go
+++ b/pkg/botevent/seq_review_test.go
@@ -165,30 +165,32 @@ func TestColdProcessRefusesWhenACounterOutlivesTheAuthority(t *testing.T) {
 	setStateMode(t, ctx, StateModeIncr, 0)
 }
 
-// TestUnauthorizedMirrorIsRemovedNotCached is review P1-C and, after it, Jerry-Xin's 🔴.
+// TestUnauthorizedMirrorIsLeftAloneAndDoesNotSwallowActivation covers two findings that
+// pull in opposite directions, which is why it asserts both halves.
 //
-// P1-C: a mirror claiming activation skips the negative TTL by design — that is what makes a
-// flip propagate without waiting — but nothing rewrites or clears a *forged* mirror, so every
+// P1-C (round 5): a mirror claiming activation skips the negative TTL by design — that is
+// what makes a flip propagate without waiting — but nothing clears a forged mirror, so every
 // allocation used to perform its own authority read, serialized behind beliefMu inside a held
-// msgSem slot, with no exit until a human deleted the key.
+// msgSem slot, with no exit. So a denial has to be remembered for *something*.
 //
-// The first attempt at that was to cache the denial keyed on the mirror value. Review found
-// it could swallow the real activation: `Activate` bumps epoch 0 → 1 and the tool then writes
-// exactly `incr:1`, so a forged `incr:1` denied beforehand is byte-identical to the genuine
-// mirror, and those replicas keep serving legacy for the whole TTL while others allocate from
-// the counter. Two live id sources at the flip.
+// Jerry-Xin's 🔴 (round 6): remembering it for negativeBeliefTTL swallowed the genuine
+// activation, because `Activate` bumps epoch 0 → 1 and the tool then writes exactly the
+// `incr:1` that may already have been sitting there forged. The denied value and the real one
+// are the same bytes, and nothing visible from Redis tells them apart.
 //
-// So the answer is to *remove* the contradicted key instead of remembering it — the symmetric
-// repair to rebuilding the mirror when the authority says activated. Both properties then hold
-// with no cache to go stale.
-func TestUnauthorizedMirrorIsRemovedNotCached(t *testing.T) {
+// Round 6 answered that by deleting the key instead of remembering it, and round 7 found that
+// deleting is a fleet-wide outage when the *authority* is the regressed party (see
+// TestRegressedAuthorityDoesNotDestroyTheLegitimateMirror). So the answer is: leave the key
+// alone, remember the denial only briefly, and only when there is no counter to contradict
+// the authority.
+func TestUnauthorizedMirrorIsLeftAloneAndDoesNotSwallowActivation(t *testing.T) {
 	ctx, client := seqTestCtx(t)
 	robotID := "seqtest_unauthmirror_bot"
 	fixture(t, ctx, client, robotID)
 
 	// Authority says legacy; somebody planted a mirror claiming otherwise — and planted
 	// exactly the value the first real activation will produce, which is the case that broke
-	// the previous fix.
+	// round 6's fix. No counter for this bot, so the mirror is the artifact in doubt.
 	setStateMode(t, ctx, StateModeLegacy, 0)
 	ResetSeededForTest()
 	client.Del(SeqKey(robotID))
@@ -204,25 +206,29 @@ func TestUnauthorizedMirrorIsRemovedNotCached(t *testing.T) {
 		}
 	}
 	if reads := AuthorityReads() - before; reads > 1 {
-		t.Errorf("%d allocations against an unauthorized mirror issued %d authority reads; the "+
-			"contradicted key must be removed so subsequent allocations take the ordinary "+
-			"negative-TTL path, not a serialized DB read each", allocations, reads)
-	}
-	if v, err := client.Get(ModeKey).Result(); err != rd.Nil {
-		t.Errorf("the unauthorized mirror is still present (%q, err=%v); the authority said "+
-			"legacy, and the correct mirror state for that is absent", v, err)
+		t.Errorf("%d allocations against an unauthorized mirror issued %d authority reads; a key "+
+			"nobody clears must not cost a serialized DB read per allocation on the fan-out path",
+			allocations, reads)
 	}
 
-	// Now the operator activates for real, to the same epoch the forged key claimed. The
-	// flip must take effect on the next allocation — no TTL, no swallowed activation.
+	// The allocator must not have touched the key. It is not the allocator's to write: only
+	// the operator tool writes it, and round 7 showed what deleting it costs when the
+	// authority is the party that regressed.
+	if v, err := client.Get(ModeKey).Result(); err != nil || v != MirrorValue(1) {
+		t.Errorf("the mirror was modified by the allocator (got %q, err=%v); it must be left "+
+			"exactly as found", v, err)
+	}
+
+	// Now the operator activates for real, to the same epoch the forged key claimed, so the
+	// mirror value does not change at all. Once the denial cooldown lapses the flip must take
+	// effect — the cache may delay it by repairCooldown, never swallow it. Ageing the belief
+	// stands in for that second passing.
 	setStateMode(t, ctx, StateModeIncr, 0)
 	if _, err := ctx.DB().UpdateBySql("update `"+stateTable+"` set `epoch`=1 where `singleton_id`=?",
 		stateSingletonID).Exec(); err != nil {
 		t.Fatalf("advance epoch: %v", err)
 	}
-	if err := client.Set(ModeKey, MirrorValue(1), 0).Err(); err != nil {
-		t.Fatalf("write activation mirror: %v", err)
-	}
+	AgeModeBeliefForTest()
 
 	id, err := nextEventID(ctx, client, robotID)
 	if err != nil {
@@ -407,5 +413,83 @@ func TestAckDeletesExactlyTheTargetMember(t *testing.T) {
 				"payload value while its reads and acks are bounded by score, so the two must "+
 				"stay equal", int64(m.Score), payload.EventID)
 		}
+	}
+}
+
+// TestRegressedAuthorityDoesNotDestroyTheLegitimateMirror is review round 7's P1-1, and it
+// is written before the fix so it can be seen failing.
+//
+// The mirror repair that replaced the denied-mirror cache deletes a mirror the authority
+// contradicts. That is right when the *mirror* is the wrong artifact — a forged key against
+// a genuinely pre-activation authority. It is exactly backwards when the **authority** is
+// the wrong artifact, and the allocator already knows which case it is four lines earlier:
+// `counterExists` means some replica allocated from this counter, which can only have
+// happened after the authority said `incr`.
+//
+// The consequence of getting the order wrong is not a metadata loss. One freshly started
+// replica — a rolling restart, an HPA scale-up, a crash-loop — deletes the mirror that every
+// *healthy activated* replica's gate compares against. Their gate then returns
+// gateNotActivated, they force an authority read, the authority says legacy while their
+// belief is activated, and they hit the deliberate refusal. Every enqueue for every bot
+// fails until the state row is restored. Before this mechanism existed the mirror stayed,
+// the cold replica refused only itself, and the rest of the fleet kept allocating correctly.
+//
+// Same family as the P1-3 accepted in round 4: the evidence that invalidates the operation's
+// premise is computed before it and consulted after it.
+func TestRegressedAuthorityDoesNotDestroyTheLegitimateMirror(t *testing.T) {
+	ctx, client := seqTestCtx(t)
+	robotID := "seqtest_authorityregressed_bot"
+	fixture(t, ctx, client, robotID)
+
+	// An activated fleet that has issued at least one id, so the counter exists.
+	issued, err := nextEventID(ctx, client, robotID)
+	if err != nil {
+		t.Fatalf("allocate while activated: %v", err)
+	}
+	if n, _ := client.Exists(SeqKey(robotID)).Result(); n == 0 {
+		t.Fatal("fixture did not create the counter, so this test cannot exercise the case")
+	}
+
+	// Now the authority regresses — a restore of a pre-activation dump, or a manual UPDATE.
+	// Redis keeps everything: the legitimate mirror AND the counter are both intact.
+	setStateMode(t, ctx, StateModeLegacy, 0)
+	mirrorBefore, err := client.Get(ModeKey).Result()
+	if err != nil {
+		t.Fatalf("the mirror must still be present at this point: %v", err)
+	}
+
+	// One freshly started replica allocates once. Cold: no belief, no seeded marker, no
+	// lastIssued — it has only what Redis and the authority tell it.
+	ResetSeededForTest()
+
+	if got, err := nextEventID(ctx, client, robotID); err == nil {
+		t.Fatalf("the cold replica allocated %d instead of refusing; a counter that exists while "+
+			"the authority says legacy means the authority regressed (already issued %d)",
+			got, issued)
+	}
+
+	// That refusal is correct. Deleting the mirror on the way to it is not: it is the only
+	// artifact the healthy activated replicas' gate matches against.
+	if v, err := client.Get(ModeKey).Result(); err != nil {
+		t.Fatalf("the legitimate mirror %q was destroyed (%v). One cold replica has now taken "+
+			"every activated replica's gate down: their runGate compares against %q, gets "+
+			"gateNotActivated, forces an authority read, finds legacy against an activated "+
+			"belief, and refuses every enqueue for every bot until the state row is restored. "+
+			"The mirror must survive when counterExists says the authority is the regressed party",
+			mirrorBefore, err, mirrorBefore)
+	} else if v != mirrorBefore {
+		t.Fatalf("the mirror changed from %q to %q; it must be left exactly as it was", mirrorBefore, v)
+	}
+
+	// And the fleet is still able to allocate once the authority is put back, without any
+	// replica having had to rebuild the mirror.
+	setStateMode(t, ctx, StateModeIncr, 0)
+	ResetSeededForTest()
+	next, err := nextEventID(ctx, client, robotID)
+	if err != nil {
+		t.Fatalf("allocate after restoring the authority: %v", err)
+	}
+	if next <= issued {
+		t.Fatalf("id %d after recovery is not above the %d already issued", next, issued)
 	}
 }

--- a/pkg/botevent/seq_review_test.go
+++ b/pkg/botevent/seq_review_test.go
@@ -3,7 +3,6 @@ package botevent
 import (
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/Mininglamp-OSS/octo-lib/config"
 	rd "github.com/go-redis/redis"
@@ -166,23 +165,34 @@ func TestColdProcessRefusesWhenACounterOutlivesTheAuthority(t *testing.T) {
 	setStateMode(t, ctx, StateModeIncr, 0)
 }
 
-// TestDeniedMirrorIsNotRereadPerAllocation is review P1-C.
+// TestUnauthorizedMirrorIsRemovedNotCached is review P1-C and, after it, Jerry-Xin's 🔴.
 //
-// A mirror claiming activation skips the negative TTL by design — that is what makes a
-// flip propagate without waiting. But nothing rewrites or clears a *forged* mirror, so
-// before this fix every allocation performed its own authority read, serialized behind
-// beliefMu, inside a held msgSem slot, with no exit until a human deleted the key. That is
-// the same hazard class as the per-allocation read review P1-1 removed.
-func TestDeniedMirrorIsNotRereadPerAllocation(t *testing.T) {
+// P1-C: a mirror claiming activation skips the negative TTL by design — that is what makes a
+// flip propagate without waiting — but nothing rewrites or clears a *forged* mirror, so every
+// allocation used to perform its own authority read, serialized behind beliefMu inside a held
+// msgSem slot, with no exit until a human deleted the key.
+//
+// The first attempt at that was to cache the denial keyed on the mirror value. Review found
+// it could swallow the real activation: `Activate` bumps epoch 0 → 1 and the tool then writes
+// exactly `incr:1`, so a forged `incr:1` denied beforehand is byte-identical to the genuine
+// mirror, and those replicas keep serving legacy for the whole TTL while others allocate from
+// the counter. Two live id sources at the flip.
+//
+// So the answer is to *remove* the contradicted key instead of remembering it — the symmetric
+// repair to rebuilding the mirror when the authority says activated. Both properties then hold
+// with no cache to go stale.
+func TestUnauthorizedMirrorIsRemovedNotCached(t *testing.T) {
 	ctx, client := seqTestCtx(t)
-	robotID := "seqtest_deniedmirror_bot"
+	robotID := "seqtest_unauthmirror_bot"
 	fixture(t, ctx, client, robotID)
 
-	// Authority says legacy; somebody planted a mirror claiming otherwise.
+	// Authority says legacy; somebody planted a mirror claiming otherwise — and planted
+	// exactly the value the first real activation will produce, which is the case that broke
+	// the previous fix.
 	setStateMode(t, ctx, StateModeLegacy, 0)
 	ResetSeededForTest()
 	client.Del(SeqKey(robotID))
-	if err := client.Set(ModeKey, MirrorValue(7), 0).Err(); err != nil {
+	if err := client.Set(ModeKey, MirrorValue(1), 0).Err(); err != nil {
 		t.Fatalf("plant mirror: %v", err)
 	}
 
@@ -193,117 +203,140 @@ func TestDeniedMirrorIsNotRereadPerAllocation(t *testing.T) {
 			t.Fatalf("allocate %d: %v", i, err)
 		}
 	}
-	reads := AuthorityReads() - before
-	if reads > 1 {
-		t.Errorf("%d allocations against a denied mirror issued %d authority reads; a forged key "+
-			"nobody clears must not cost a serialized DB read per allocation on the fan-out path",
-			allocations, reads)
+	if reads := AuthorityReads() - before; reads > 1 {
+		t.Errorf("%d allocations against an unauthorized mirror issued %d authority reads; the "+
+			"contradicted key must be removed so subsequent allocations take the ordinary "+
+			"negative-TTL path, not a serialized DB read each", allocations, reads)
+	}
+	if v, err := client.Get(ModeKey).Result(); err != rd.Nil {
+		t.Errorf("the unauthorized mirror is still present (%q, err=%v); the authority said "+
+			"legacy, and the correct mirror state for that is absent", v, err)
 	}
 
-	// A *different* mirror value is still a conflict and must still be read — otherwise a
-	// genuine activation would be swallowed by the cached denial.
-	if err := client.Set(ModeKey, MirrorValue(8), 0).Err(); err != nil {
-		t.Fatalf("change mirror: %v", err)
+	// Now the operator activates for real, to the same epoch the forged key claimed. The
+	// flip must take effect on the next allocation — no TTL, no swallowed activation.
+	setStateMode(t, ctx, StateModeIncr, 0)
+	if _, err := ctx.DB().UpdateBySql("update `"+stateTable+"` set `epoch`=1 where `singleton_id`=?",
+		stateSingletonID).Exec(); err != nil {
+		t.Fatalf("advance epoch: %v", err)
 	}
-	if _, err := nextEventID(ctx, client, robotID); err != nil {
-		t.Fatalf("allocate after the mirror changed: %v", err)
+	if err := client.Set(ModeKey, MirrorValue(1), 0).Err(); err != nil {
+		t.Fatalf("write activation mirror: %v", err)
 	}
-	if AuthorityReads()-before <= reads {
-		t.Error("a mirror value that has not been denied yet must force an authority read; " +
-			"caching the denial by value is what keeps a real flip from being swallowed")
+
+	id, err := nextEventID(ctx, client, robotID)
+	if err != nil {
+		t.Fatalf("allocate after activation: %v", err)
+	}
+	if n, _ := client.Exists(SeqKey(robotID)).Result(); n == 0 {
+		t.Fatalf("the allocation after activation returned %d without creating the counter, so it "+
+			"came from GenSeq: the genuine activation was swallowed because its mirror value "+
+			"happened to equal one that had been denied earlier", id)
 	}
 }
 
-// round's P1-7 "fix", which both reviewers found did not fail closed.
+// TestFailedDurableWriteIsThrottledAndDoesNotFailTheEnqueue pins what the durable mark
+// mechanism actually guarantees, after two attempts to bound it were both wrong.
 //
-// The bound was a count of failed intervals, and `persistHighWater` short-circuited on the
-// throttle marker *before* consulting it — so once the bound was reached only 1 allocation
-// in every `highWaterInterval` even reached the check, and the other 999 succeeded.
-// Issuance continued indefinitely against a frozen mark at a 0.1% failure rate, which is
-// the unbounded exposure the mechanism claimed to prevent. Worse, with a limit of 3 the ids
-// ran to `M+2999` while `seedSafetyMargin` is 2000, so a *restarted* process (empty
-// lastIssued, no in-process refusal) would resume at `M+2001` beneath cursors that had
-// already reached `M+2999`.
+// What is guaranteed:
 //
-// The previous test could not see any of it: it called `noteHighWaterFailure` directly with
-// values spaced exactly one interval apart, so it never went through the short-circuit that
-// swallowed the intervening 999, and it asserted a helper's return value rather than the
-// allocator's behaviour. This one drives real allocations with the durable write broken,
-// which is the only shape that could have caught it.
-func TestHighWaterFailuresStopIssuanceThroughTheRealPath(t *testing.T) {
+//   - A failing durable write does not fail the enqueue. The id is already allocated and
+//     unique; refusing here would trade a live event for bookkeeping.
+//   - The attempt is throttled to roughly one per highWaterInterval rather than one per
+//     event. That is the half of review P1-7 that stays fixed here: leaving the throttle
+//     marker unset on failure put one un-deadlined INSERT on the fan-out path per event.
+//
+// What is NOT guaranteed, and is pinned as a test fact below rather than asserted away:
+// while the writes keep failing the mark trails **without bound**. See persistHighWater for
+// the arithmetic showing why bounding it means changing what the recovery floor is, and
+// Mininglamp-OSS/octo-server#704, which owns that and gates activation.
+func TestFailedDurableWriteIsThrottledAndDoesNotFailTheEnqueue(t *testing.T) {
 	ctx, client := seqTestCtx(t)
-	robotID := "seqtest_highwaterbound_bot"
+	robotID := "seqtest_highwaterthrottle_bot"
 	fixture(t, ctx, client, robotID)
 
-	// One healthy allocation establishes the durable base, as the first allocation for a
-	// bot always does (it is never throttled).
-	first, err := nextEventID(ctx, client, robotID)
-	if err != nil {
+	// One healthy allocation, so the mark exists and the throttle marker is armed.
+	if _, err := nextEventID(ctx, client, robotID); err != nil {
 		t.Fatalf("first allocate: %v", err)
 	}
-	base, err := highWaterCeiling(ctx, robotID)
-	if err != nil || base == 0 {
-		t.Fatalf("the first allocation must land the durable mark (base=%d err=%v)", base, err)
+	mark, err := highWaterCeiling(ctx, robotID)
+	if err != nil || mark == 0 {
+		t.Fatalf("the first allocation must land the durable mark (mark=%d err=%v)", mark, err)
 	}
 
-	// Now the durable write breaks. Renaming the row's table out from under the allocator
-	// is the closest thing to a DB outage that leaves Redis usable, which is the state the
-	// bound exists for.
+	// Renaming the table out from under the allocator is the closest thing to a
+	// write-side DB outage that leaves Redis perfectly usable, which is the state that
+	// matters: the seed's reads already succeeded, so this is reachable without a full
+	// MySQL outage (a read-only failover, disk full, lock contention, or simply the
+	// 300ms deadline under load).
 	if _, err := ctx.DB().Exec("RENAME TABLE `seq` TO `seq_hidden_for_test`"); err != nil {
 		t.Skipf("cannot rename seq table to simulate a durable-write outage: %v", err)
 	}
+	restored := false
 	t.Cleanup(func() {
-		_, _ = ctx.DB().Exec("RENAME TABLE `seq_hidden_for_test` TO `seq`")
+		if !restored {
+			_, _ = ctx.DB().Exec("RENAME TABLE `seq_hidden_for_test` TO `seq`")
+		}
 	})
 
-	// Walk the counter forward past the bound. Every allocation must either succeed with an
-	// id inside the recoverable window, or fail — never succeed outside it.
-	var lastOK int64 = first
-	refusedAt := int64(0)
-	for i := 0; i < 3*seedSafetyMargin; i++ {
-		v, err := nextEventID(ctx, client, robotID)
-		if err != nil {
-			refusedAt = lastOK
-			break
+	before := HighWaterWriteFailures()
+	const allocations = 3 * highWaterInterval
+	for i := 0; i < allocations; i++ {
+		if _, err := nextEventID(ctx, client, robotID); err != nil {
+			t.Fatalf("allocation %d failed while durable writes were broken: %v — the mark is "+
+				"bookkeeping, and a failed write must not cost a live event", i, err)
 		}
-		if v-base >= seedSafetyMargin {
-			t.Fatalf("allocation %d succeeded at id %d, %d past the frozen durable mark %d; a "+
-				"seed recovering from that mark lands at %d, so this id is unrecoverable and "+
-				"must have been refused", i, v, v-base, base, base+seedSafetyMargin)
-		}
-		lastOK = v
 	}
-	if refusedAt == 0 {
-		t.Fatalf("issuance never stopped: %d allocations succeeded with the durable write "+
-			"failing throughout, which is the unbounded exposure the bound exists to close",
-			3*seedSafetyMargin)
+	attempts := HighWaterWriteFailures() - before
+	if attempts == 0 {
+		t.Fatal("no durable write was even attempted, so this test proved nothing about the throttle")
+	}
+	// Roughly one attempt per interval. The bound is generous — what it rules out is the
+	// per-event storm, which would be ~3000 here.
+	if maxAttempts := int64(allocations/highWaterInterval) + 2; attempts > maxAttempts {
+		t.Errorf("%d allocations with the durable write failing produced %d attempts (max %d); "+
+			"the throttle must not be re-armed only on success, or a DB outage puts one "+
+			"un-deadlined INSERT on the fan-out path per event", allocations, attempts, maxAttempts)
 	}
 
-	// And it stays refused — the bound is not a once-per-interval probe.
-	for i := 0; i < 5; i++ {
-		if _, err := nextEventID(ctx, client, robotID); err == nil {
-			t.Fatalf("allocation %d past the bound succeeded; the refusal must apply to every "+
-				"allocation in the frozen window, not one per interval", i)
-		}
-	}
-
-	// Recovery must be reachable, and must not depend on the bot's traffic: the probe
-	// while past the bound is on a time budget, so one budget after the DB comes back the
-	// next allocation lands the mark and succeeds.
+	// The known gap, asserted as still present so it becomes the regression test the day
+	// #704 closes it: the mark has not moved while thousands of ids were issued above it.
 	if _, err := ctx.DB().Exec("RENAME TABLE `seq_hidden_for_test` TO `seq`"); err != nil {
 		t.Fatalf("restore seq table: %v", err)
 	}
-	deadline := time.Now().Add(5 * highWaterProbeEvery)
-	for {
-		if _, err := nextEventID(ctx, client, robotID); err == nil {
-			break
+	restored = true
+	after, err := highWaterCeiling(ctx, robotID)
+	if err != nil {
+		t.Fatalf("read mark: %v", err)
+	}
+	if after != mark {
+		t.Fatalf("the durable mark moved from %d to %d while writes were failing, which this "+
+			"test does not expect — if the mechanism now advances it some other way, this "+
+			"assertion is the one to update", mark, after)
+	}
+	issued, _ := client.Get(SeqKey(robotID)).Int64()
+	if issued-after < seedSafetyMargin {
+		t.Fatalf("only %d ids were issued past the frozen mark, less than seedSafetyMargin (%d); "+
+			"this test is supposed to demonstrate the *unbounded* trail, so it needs to run "+
+			"longer to be meaningful", issued-after, int64(seedSafetyMargin))
+	}
+	t.Logf("known gap (#704): %d ids issued past a frozen durable mark at %d; a seed recovering "+
+		"from that mark alone would land at %d, below ids already issued",
+		issued-after, after, after+seedSafetyMargin)
+
+	// And it recovers on its own once writes work again — after one more interval of ids,
+	// because the throttle marker was re-armed at the last failed attempt. That latency is
+	// the price of not putting an INSERT on every allocation, and it is stated here rather
+	// than assumed: an earlier revision added a second, time-based probe to shorten it,
+	// which is what turned the failure path into a storm inside msgSem slots.
+	for i := 0; i <= highWaterInterval; i++ {
+		if _, err := nextEventID(ctx, client, robotID); err != nil {
+			t.Fatalf("allocate %d after restoring the table: %v", i, err)
 		}
-		if time.Now().After(deadline) {
-			t.Fatalf("allocation did not resume within %v of durable writes working again; the "+
-				"refusal has to be able to end on its own, not wait for the bot's next %d ids",
-				5*highWaterProbeEvery, highWaterInterval)
-		}
-		time.Sleep(highWaterProbeEvery / 4)
+	}
+	if final, err := highWaterCeiling(ctx, robotID); err != nil || final <= after {
+		t.Errorf("the mark must resume advancing once durable writes work (was %d, now %d, err=%v)",
+			after, final, err)
 	}
 }
 

--- a/pkg/botevent/seq_review_test.go
+++ b/pkg/botevent/seq_review_test.go
@@ -1,0 +1,217 @@
+package botevent
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	rd "github.com/go-redis/redis"
+)
+
+// TestNeverDowngradesToLegacyAfterIssuingCounterIDs is review P1-4.
+//
+// Once a process has handed out a counter id for a bot, a GenSeq id for that same bot
+// is arbitrarily far below the bot's live consumer cursor, so the event is born
+// invisible: #697, self-inflicted by the fix. The old code would do exactly that
+// whenever the mirror went missing and the authority came back saying legacy — which
+// is what a migration rollback produces, and `Down` used to drop the table
+// unconditionally.
+//
+// Both shapes are covered: the authority answering "legacy", and the authority
+// vanishing entirely.
+func TestNeverDowngradesToLegacyAfterIssuingCounterIDs(t *testing.T) {
+	cases := []struct {
+		name           string
+		breakAuthority func(t *testing.T, ctx *config.Context)
+	}{
+		{
+			name: "authority rolled back to legacy",
+			breakAuthority: func(t *testing.T, ctx *config.Context) {
+				setStateMode(t, ctx, StateModeLegacy, 0)
+			},
+		},
+		{
+			name: "authority row deleted (migration rollback)",
+			breakAuthority: func(t *testing.T, ctx *config.Context) {
+				if _, err := ctx.DB().DeleteFrom(stateTable).
+					Where("`singleton_id`=?", stateSingletonID).Exec(); err != nil {
+					t.Fatalf("delete state row: %v", err)
+				}
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, client := seqTestCtx(t)
+			robotID := "seqtest_nodowngrade_bot"
+			fixture(t, ctx, client, robotID)
+
+			issued, err := nextEventID(ctx, client, robotID)
+			if err != nil {
+				t.Fatalf("allocate while activated: %v", err)
+			}
+
+			// Now the authority disagrees, and the mirror is gone so the fast path cannot
+			// carry the allocation on its own.
+			tc.breakAuthority(t, ctx)
+			client.Del(ModeKey)
+
+			got, err := nextEventID(ctx, client, robotID)
+			if err == nil {
+				t.Fatalf("allocated %d from the legacy allocator after already issuing counter id "+
+					"%d for this bot; that id lands below the bot's consumer cursor and is never "+
+					"delivered", got, issued)
+			}
+			// Restore the row so fixture cleanup and the next subtest start from a known
+			// state (the deleted-row case removed it).
+			setStateMode(t, ctx, StateModeIncr, 0)
+		})
+	}
+}
+
+// TestLostMirrorInvalidatesEverySeededBot is review P1-3's second half.
+//
+// The mirror is global; a seed is per-bot. So when the mirror has to be rebuilt — the
+// mode key was lost, which is evidence Redis lost data — every counter this process
+// believes it seeded is suspect, not just the one being allocated for. Re-opening the
+// gate while other bots still hold a stale `seeded` marker lets their next allocation
+// INCR a counter that was never re-seeded.
+func TestLostMirrorInvalidatesEverySeededBot(t *testing.T) {
+	ctx, client := seqTestCtx(t)
+	first, second := "seqtest_mirrorwide_a", "seqtest_mirrorwide_b"
+	fixture(t, ctx, client, first)
+	fixture(t, ctx, client, second)
+
+	for _, id := range []string{first, second} {
+		if _, err := nextEventID(ctx, client, id); err != nil {
+			t.Fatalf("seed %s: %v", id, err)
+		}
+		if _, ok := seeded.Load(id); !ok {
+			t.Fatalf("%s should be marked seeded after an allocation", id)
+		}
+	}
+
+	// Redis loses the mode key. The authority still says activated, so the next
+	// allocation rebuilds the mirror.
+	client.Del(ModeKey)
+	if _, err := nextEventID(ctx, client, first); err != nil {
+		t.Fatalf("allocate after mirror loss: %v", err)
+	}
+
+	if _, ok := seeded.Load(second); ok {
+		t.Error("a lost mode mirror left another bot's seeded marker in place; that bot's next " +
+			"allocation would INCR a counter this process never re-seeded, even though the " +
+			"evidence for the rebuild was Redis losing data")
+	}
+	if MirrorRebuilds() == 0 {
+		t.Error("rebuilding the mirror must be counted; it is a self-healing path, so nothing " +
+			"else makes Redis data loss visible")
+	}
+}
+
+// TestHighWaterFailuresAreBoundedAndThrottled is review P1-7.
+//
+// Counting a failed durable write is not enough. Leaving `lastPersisted` unset means
+// the once-per-interval guard never engages, so the allocator does one un-deadlined
+// INSERT per event while the DB is unhappy. And the safety argument at the top of
+// seq.go — the mark trails by at most one interval, which seedSafetyMargin covers —
+// only holds while the writes land, so the number of intervals allowed to pass without
+// one has to be bounded rather than asserted away.
+func TestHighWaterFailuresAreBoundedAndThrottled(t *testing.T) {
+	robotID := "seqtest_highwaterbound_bot"
+	t.Cleanup(func() {
+		highWaterFailures.Delete(robotID)
+		lastPersisted.Delete(robotID)
+	})
+	highWaterFailures.Delete(robotID)
+	lastPersisted.Delete(robotID)
+
+	cause := errors.New("simulated DB outage")
+	for i := 1; i < highWaterFailureLimit; i++ {
+		if err := noteHighWaterFailure(robotID, int64(i)*highWaterInterval, cause); err != nil {
+			t.Fatalf("failure %d must not fail the allocation yet: %v", i, err)
+		}
+		// Re-arming the interval guard is what stops the retry storm: the next write is
+		// one interval away, not one id away.
+		if _, armed := lastPersisted.Load(robotID); !armed {
+			t.Fatalf("failure %d left the interval guard unarmed, so the next allocation would "+
+				"attempt another INSERT immediately", i)
+		}
+	}
+	if err := noteHighWaterFailure(robotID, highWaterFailureLimit*highWaterInterval, cause); err == nil {
+		t.Fatalf("after %d consecutive failures the allocation must fail; issuing ids whose "+
+			"recovery floor is frozen spends the RDB safety margin silently",
+			highWaterFailureLimit)
+	}
+}
+
+// TestAckDeletesExactlyTheTargetMember is the acceptance item the brief asks for and
+// the previous revisions did not have: the ZAdd score equals the payload `event_id`,
+// and an ack addresses the one member it names.
+//
+// The invariant is what couples this allocator to the consumer: the cursor is a payload
+// `event_id` while reads and acks are bounded by *score*
+// (modules/bot_api/events.go). This is the change that makes the id source pluggable,
+// so this is the round where the pin has value — and the ack shape is reproduced here
+// rather than imported to keep pkg/botevent free of a dependency on modules/.
+func TestAckDeletesExactlyTheTargetMember(t *testing.T) {
+	ctx, client := seqTestCtx(t)
+	robotID := "seqtest_ackprecision_bot"
+	fixture(t, ctx, client, robotID)
+
+	const events = 5
+	ids := make([]int64, 0, events)
+	for i := 0; i < events; i++ {
+		id, err := nextEventID(ctx, client, robotID)
+		if err != nil {
+			t.Fatalf("allocate: %v", err)
+		}
+		// Score == payload event_id. A writer that scored by, say, timestamp while
+		// keeping a separate event_id would break the consumer silently.
+		if err := client.ZAdd(QueueKey(robotID), rd.Z{
+			Score:  float64(id),
+			Member: fmt.Sprintf(`{"event_id":%d}`, id),
+		}).Err(); err != nil {
+			t.Fatalf("enqueue: %v", err)
+		}
+		ids = append(ids, id)
+	}
+
+	// Ack the middle event exactly as modules/bot_api does: by score range [id, id].
+	target := ids[events/2]
+	if err := client.ZRemRangeByScore(QueueKey(robotID),
+		fmt.Sprintf("%d", target), fmt.Sprintf("%d", target)).Err(); err != nil {
+		t.Fatalf("ack: %v", err)
+	}
+
+	remaining, err := client.ZRangeWithScores(QueueKey(robotID), 0, -1).Result()
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if len(remaining) != events-1 {
+		t.Fatalf("ack removed %d members, expected exactly 1 — with unique scores an ack must "+
+			"never take a member it was not addressed to (with GenSeq's duplicate scores it did, "+
+			"destroying events that had never been delivered to anybody)",
+			events-len(remaining))
+	}
+	for _, m := range remaining {
+		if int64(m.Score) == target {
+			t.Fatalf("the acked event %d is still in the queue", target)
+		}
+		// The equality invariant, read back from the wire: score and payload agree.
+		var payload struct{ EventID int64 }
+		member, ok := m.Member.(string)
+		if !ok {
+			t.Fatalf("unexpected member type %T", m.Member)
+		}
+		if _, err := fmt.Sscanf(member, `{"event_id":%d}`, &payload.EventID); err != nil {
+			t.Fatalf("decode member %q: %v", member, err)
+		}
+		if payload.EventID != int64(m.Score) {
+			t.Fatalf("score %d and payload event_id %d disagree; the consumer's cursor is the "+
+				"payload value while its reads and acks are bounded by score, so the two must "+
+				"stay equal", int64(m.Score), payload.EventID)
+		}
+	}
+}

--- a/pkg/botevent/seq_test.go
+++ b/pkg/botevent/seq_test.go
@@ -1,9 +1,11 @@
 package botevent
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"sort"
+	"strings"
 	"sync"
 	"testing"
 
@@ -63,6 +65,14 @@ func seqTestCtx(t *testing.T) (*config.Context, *rd.Client) {
 		t.Skipf("no usable MySQL at %s: %v", mysqlAddr, err)
 	}
 
+	if _, err := ctx.DB().Exec("CREATE TABLE IF NOT EXISTS `" + stateTable + "` (" +
+		"`singleton_id` tinyint unsigned NOT NULL, `mode` tinyint NOT NULL DEFAULT 0, " +
+		"`epoch` bigint unsigned NOT NULL DEFAULT 0, `cutover_floor` bigint NOT NULL DEFAULT 0, " +
+		"`updated_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP, PRIMARY KEY (`singleton_id`)) " +
+		"ENGINE=InnoDB DEFAULT CHARSET=utf8mb4"); err != nil {
+		t.Skipf("cannot create %s at %s: %v", stateTable, mysqlAddr, err)
+	}
+
 	client := rd.NewClient(&rd.Options{Addr: redisAddr})
 	if err := client.Ping().Err(); err != nil {
 		t.Skipf("no usable Redis at %s: %v", redisAddr, err)
@@ -85,12 +95,27 @@ func fixture(t *testing.T, ctx *config.Context, client *rd.Client, robotID strin
 		client.Del(SeqKey(robotID), QueueKey(robotID), ModeKey)
 		_, _ = ctx.DB().DeleteFrom("seq").Where("`key`=?", "seq:robotEventSeq:"+robotID).Exec()
 		_, _ = ctx.DB().DeleteFrom("seq").Where("`key`=?", HighWaterSeqKey(robotID)).Exec()
+		setStateMode(t, ctx, StateModeLegacy, 0)
 	}
 	clean()
+	// Activated state: the DB row is the authority, the Redis key only its mirror.
+	setStateMode(t, ctx, StateModeIncr, 0)
 	if err := client.Set(ModeKey, ModeIncr, 0).Err(); err != nil {
-		t.Fatalf("activate: %v", err)
+		t.Fatalf("write mode mirror: %v", err)
 	}
 	t.Cleanup(clean)
+}
+
+// setStateMode forces the authoritative state row, bypassing Activate's floor
+// validation. Tests that exercise Activate itself call it directly.
+func setStateMode(t *testing.T, ctx *config.Context, mode int, floor int64) {
+	t.Helper()
+	if _, err := ctx.DB().InsertBySql(
+		"insert into `"+stateTable+"`(`singleton_id`,`mode`,`epoch`,`cutover_floor`) values(?,?,0,?) "+
+			"on duplicate key update `mode`=VALUES(`mode`), `cutover_floor`=VALUES(`cutover_floor`)",
+		stateSingletonID, mode, floor).Exec(); err != nil {
+		t.Fatalf("set state mode: %v", err)
+	}
 }
 
 // TestNotActivatedDelegatesToLegacy is what makes deploying this change a no-op.
@@ -104,7 +129,9 @@ func TestNotActivatedDelegatesToLegacy(t *testing.T) {
 	ctx, client := seqTestCtx(t)
 	robotID := "seqtest_notactivated_bot"
 	fixture(t, ctx, client, robotID)
-	client.Del(ModeKey) // back to the pre-activation state
+	// Pre-activation: authority says legacy, and the mirror is absent.
+	setStateMode(t, ctx, StateModeLegacy, 0)
+	client.Del(ModeKey)
 
 	first, err := nextEventID(ctx, client, robotID)
 	if err != nil {
@@ -133,6 +160,7 @@ func TestActivationTakesEffectWithoutAProcessCacheWindow(t *testing.T) {
 	ctx, client := seqTestCtx(t)
 	robotID := "seqtest_flip_bot"
 	fixture(t, ctx, client, robotID)
+	setStateMode(t, ctx, StateModeLegacy, 0)
 	client.Del(ModeKey)
 
 	legacyID, err := nextEventID(ctx, client, robotID)
@@ -141,6 +169,7 @@ func TestActivationTakesEffectWithoutAProcessCacheWindow(t *testing.T) {
 	}
 
 	// Activate, with no restart and no cache invalidation of any kind.
+	setStateMode(t, ctx, StateModeIncr, 0)
 	if err := client.Set(ModeKey, ModeIncr, 0).Err(); err != nil {
 		t.Fatalf("activate: %v", err)
 	}
@@ -165,6 +194,7 @@ func TestSeedClearsTheLegacyCeilingAtActivation(t *testing.T) {
 	ctx, client := seqTestCtx(t)
 	robotID := "seqtest_clearceiling_bot"
 	fixture(t, ctx, client, robotID)
+	setStateMode(t, ctx, StateModeLegacy, 0)
 	client.Del(ModeKey)
 
 	// Let legacy issue a few ids and enqueue them, as it would have in production.
@@ -178,6 +208,7 @@ func TestSeedClearsTheLegacyCeilingAtActivation(t *testing.T) {
 		lastLegacy = id
 	}
 
+	setStateMode(t, ctx, StateModeIncr, 0)
 	if err := client.Set(ModeKey, ModeIncr, 0).Err(); err != nil {
 		t.Fatalf("activate: %v", err)
 	}
@@ -537,6 +568,7 @@ func TestSeedRecoversFromTheDurableMarkAlone(t *testing.T) {
 	// Everything Redis knew is gone.
 	client.Del(SeqKey(robotID), QueueKey(robotID))
 	ResetSeededForTest()
+	setStateMode(t, ctx, StateModeIncr, 0)
 	if err := client.Set(ModeKey, ModeIncr, 0).Err(); err != nil {
 		t.Fatalf("activate: %v", err)
 	}
@@ -562,7 +594,10 @@ func TestExpectedModeFailsClosedWhenModeIsLost(t *testing.T) {
 		t.Fatalf("allocate while activated: %v", err)
 	}
 
-	// Redis loses the mode key while this replica expects to be activated.
+	// Redis loses the mode key AND the authority says legacy, while this replica
+	// expects to be activated. (A lost mirror with an activated authority is the
+	// self-healing case, covered by TestMirrorRebuiltFromDBAuthority.)
+	setStateMode(t, ctx, StateModeLegacy, 0)
 	client.Del(ModeKey)
 	restore := SetExpectedModeForTest(ModeIncr)
 	defer restore()
@@ -581,5 +616,199 @@ func TestExpectedModeFailsClosedWhenModeIsLost(t *testing.T) {
 	}
 	if v == 0 {
 		t.Fatal("legacy allocation returned 0")
+	}
+}
+
+// TestCounterKeyCannotCollideWithModeKey pins the key-namespace fix.
+//
+// `SeqKeyPrefix` was `botEventSeq:` while `ModeKey` is `botEventSeq:mode`, so
+// SeqKey("mode") *was* ModeKey: a bot with that id would have seeded and INCRed the
+// global activation flag as its own counter. Unreachable with UUID-hex robot ids, but
+// a namespace where a legal input collides with a global key does not get to stay.
+func TestCounterKeyCannotCollideWithModeKey(t *testing.T) {
+	for _, robotID := range []string{"mode", "counter:mode", "", "counter", "mode:"} {
+		if got := SeqKey(robotID); got == ModeKey {
+			t.Errorf("SeqKey(%q) == ModeKey (%q): one bot's counter would be the global "+
+				"activation flag", robotID, ModeKey)
+		}
+		if got := SeqKey(robotID); got == HighWaterSeqKey(robotID) {
+			t.Errorf("SeqKey(%q) collides with its own durable mark key", robotID)
+		}
+	}
+	// And the inverse: the mode key must not be reachable as any counter key.
+	if strings.HasPrefix(ModeKey, SeqKeyPrefix) {
+		t.Errorf("ModeKey %q lives under the counter prefix %q, so some robotID reaches it",
+			ModeKey, SeqKeyPrefix)
+	}
+}
+
+// TestMissingCounterFailsBeforeIssuingFromOne is the EXISTS guard.
+//
+// INCR on a missing key returns 1. Before the guard, the only thing preventing an
+// unseeded INCR was `seeded` — a process-local map guarding Redis state — so a
+// partial restore or a stray DEL that took the counter but left the mirror, with the
+// process still up, renumbered that bot's events from 1: arbitrarily far below its
+// consumer's cursor, and needing the entire historical range re-issued before one
+// event became visible. Failing before issuing beats detecting afterwards.
+func TestMissingCounterFailsBeforeIssuingFromOne(t *testing.T) {
+	ctx, client := seqTestCtx(t)
+	robotID := "seqtest_counterlost_bot"
+	fixture(t, ctx, client, robotID)
+
+	var highest int64
+	for i := 0; i < 3; i++ {
+		v, err := nextEventID(ctx, client, robotID)
+		if err != nil {
+			t.Fatalf("allocate %d: %v", i, err)
+		}
+		highest = v
+	}
+
+	// The counter vanishes; the mirror and this process's `seeded` entry survive.
+	if err := client.Del(SeqKey(robotID)).Err(); err != nil {
+		t.Fatalf("drop counter: %v", err)
+	}
+	before := CountersLost()
+
+	next, err := nextEventID(ctx, client, robotID)
+	if err != nil {
+		t.Fatalf("allocate after counter loss: %v", err)
+	}
+	if CountersLost() != before+1 {
+		t.Errorf("counter loss was not detected (%d -> %d)", before, CountersLost())
+	}
+	if next <= highest {
+		t.Fatalf("id %d after counter loss is not above the %d already issued; INCR on a "+
+			"missing key returns 1, which is what the EXISTS guard exists to prevent", next, highest)
+	}
+}
+
+// TestMirrorRebuiltFromDBAuthority is why the state row exists.
+//
+// The mode mirror is in the same Redis as everything else, so it regresses with an
+// RDB snapshot. Before the state table, losing it dropped the allocator to legacy —
+// whose ids sit below everything the counter had issued, i.e. #697 mirrored. The DB
+// row now decides, and a lost mirror is rebuilt rather than obeyed.
+func TestMirrorRebuiltFromDBAuthority(t *testing.T) {
+	ctx, client := seqTestCtx(t)
+	robotID := "seqtest_mirror_bot"
+	fixture(t, ctx, client, robotID)
+
+	highest, err := nextEventID(ctx, client, robotID)
+	if err != nil {
+		t.Fatalf("allocate: %v", err)
+	}
+
+	// Redis loses the mirror. The authority still says activated.
+	if err := client.Del(ModeKey).Err(); err != nil {
+		t.Fatalf("drop mirror: %v", err)
+	}
+	before := MirrorRebuilds()
+
+	next, err := nextEventID(ctx, client, robotID)
+	if err != nil {
+		t.Fatalf("allocate after mirror loss: %v", err)
+	}
+	if MirrorRebuilds() != before+1 {
+		t.Errorf("mirror was not rebuilt (%d -> %d)", before, MirrorRebuilds())
+	}
+	if next <= highest {
+		t.Fatalf("id %d after mirror loss is not above the %d already issued — the allocator "+
+			"degraded to legacy instead of consulting the authority", next, highest)
+	}
+	if v, _ := client.Get(ModeKey).Result(); v != ModeIncr {
+		t.Errorf("mirror was not restored (got %q)", v)
+	}
+}
+
+// TestActivateValidatesFloorAndIsIdempotent covers the operator-facing flip.
+func TestActivateValidatesFloorAndIsIdempotent(t *testing.T) {
+	ctx, client := seqTestCtx(t)
+	robotID := "seqtest_activate_bot"
+	fixture(t, ctx, client, robotID)
+	setStateMode(t, ctx, StateModeLegacy, 0)
+	client.Del(ModeKey)
+
+	// A floor at or below what has already been issued would put the first activated
+	// ids under cursors clients already hold.
+	if _, _, err := Activate(ctx, 5000, 5000); !errors.Is(err, ErrFloorTooLow) {
+		t.Fatalf("expected ErrFloorTooLow for floor == observed max, got %v", err)
+	}
+	if _, _, err := Activate(ctx, 4999, 5000); !errors.Is(err, ErrFloorTooLow) {
+		t.Fatalf("expected ErrFloorTooLow for floor < observed max, got %v", err)
+	}
+
+	flipped, epoch, err := Activate(ctx, 7001, 5000)
+	if err != nil || !flipped {
+		t.Fatalf("activate: flipped=%v epoch=%d err=%v", flipped, epoch, err)
+	}
+	st, err := ReadState(ctx)
+	if err != nil || !st.Activated() || st.CutoverFloor != 7001 {
+		t.Fatalf("state after activate: %+v err=%v", st, err)
+	}
+
+	// Idempotent: a second run reports no flip and no error.
+	again, sameEpoch, err := Activate(ctx, 9001, 5000)
+	if err != nil || again {
+		t.Fatalf("second activate should be a no-op: again=%v err=%v", again, err)
+	}
+	if sameEpoch != epoch {
+		t.Errorf("epoch changed on a no-op activate: %d -> %d", epoch, sameEpoch)
+	}
+	if st2, _ := ReadState(ctx); st2.CutoverFloor != 7001 {
+		t.Errorf("a no-op activate must not rewrite the floor (got %d)", st2.CutoverFloor)
+	}
+}
+
+// TestKnownResidualZaddReorderingCanStillSkip records a gap this change does NOT
+// close, so it is a fact in the suite rather than a claim in a PR description.
+//
+// Allocation and publication are two operations. A producer can allocate N, stall
+// (marshal, GC, a slow round trip), while another allocates N+1 and ZADDs — and the
+// doorbell wakes the consumer on precisely that ZADD. The consumer reads N+1, moves
+// its cursor there, and the first producer's ZADD then lands at N, below the cursor,
+// unreachable. Monotonic ids remove collisions and cross-restart inversions; they do
+// not remove this window, which needs a re-delivery window below the cursor
+// (see modules/bot_api/events.go's own note) and is tracked separately.
+//
+// This test asserts the loss still happens. If it starts failing, the residual has
+// been fixed and this test should become the regression test for that fix.
+func TestKnownResidualZaddReorderingCanStillSkip(t *testing.T) {
+	ctx, client := seqTestCtx(t)
+	robotID := "seqtest_residual_bot"
+	fixture(t, ctx, client, robotID)
+
+	stalled, err := nextEventID(ctx, client, robotID) // producer A allocates, then stalls
+	if err != nil {
+		t.Fatalf("allocate A: %v", err)
+	}
+	ahead, err := nextEventID(ctx, client, robotID) // producer B allocates and publishes
+	if err != nil {
+		t.Fatalf("allocate B: %v", err)
+	}
+	client.ZAdd(QueueKey(robotID), rd.Z{
+		Score: float64(ahead), Member: fmt.Sprintf(`{"event_id":%d,"from":"B"}`, ahead)})
+
+	// Consumer wakes on B's doorbell and advances its cursor.
+	page, err := client.ZRangeByScore(QueueKey(robotID), rd.ZRangeBy{
+		Min: "(0", Max: "+inf", Count: 20}).Result()
+	if err != nil || len(page) != 1 {
+		t.Fatalf("consumer read: page=%v err=%v", page, err)
+	}
+	cursor := ahead
+
+	// A's ZADD finally lands, below the cursor.
+	client.ZAdd(QueueKey(robotID), rd.Z{
+		Score: float64(stalled), Member: fmt.Sprintf(`{"event_id":%d,"from":"A"}`, stalled)})
+
+	after, err := client.ZRangeByScore(QueueKey(robotID), rd.ZRangeBy{
+		Min: fmt.Sprintf("(%d", cursor), Max: "+inf", Count: 20}).Result()
+	if err != nil {
+		t.Fatalf("consumer re-read: %v", err)
+	}
+	if len(after) != 0 {
+		t.Fatalf("expected A's event to be unreachable below the cursor (the known residual), "+
+			"but the consumer saw %v — if the re-delivery window has landed, invert this test",
+			after)
 	}
 }

--- a/pkg/botevent/seq_test.go
+++ b/pkg/botevent/seq_test.go
@@ -653,6 +653,52 @@ func TestMalformedExpectedModeFailsClosed(t *testing.T) {
 	}
 }
 
+// TestExpectedModeRefusalDoesNotReadAuthorityPerAllocation is the regression
+// from the post-rebase review on head 6a5cd9a6.
+//
+// A deployment guard mismatch is stable for the lifetime of the process. Once
+// the authority has been resolved, refusing the allocation must not re-read the
+// same row for every message while holding a msgSem slot. A malformed guard is
+// even cheaper: it is process-local configuration and must fail before any DB
+// read at all.
+func TestExpectedModeRefusalDoesNotReadAuthorityPerAllocation(t *testing.T) {
+	cases := []struct {
+		name     string
+		expected string
+		maxReads int64
+	}{
+		{name: "expects incr while authority is legacy", expected: ModeIncr, maxReads: 1},
+		{name: "malformed expectation", expected: "inrc", maxReads: 0},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, client := seqTestCtx(t)
+			robotID := "seqtest_expected_refusal_" + strings.ReplaceAll(tc.name, " ", "_")
+			fixture(t, ctx, client, robotID)
+			setStateMode(t, ctx, StateModeLegacy, 0)
+			client.Del(ModeKey)
+			ResetSeededForTest()
+
+			restore := SetExpectedModeForTest(tc.expected)
+			defer restore()
+
+			before := AuthorityReads()
+			const allocations = 20
+			for i := 0; i < allocations; i++ {
+				if id, err := nextEventID(ctx, client, robotID); err == nil {
+					t.Fatalf("allocation %d returned id %d; the expected-mode guard must fail closed", i, id)
+				}
+			}
+			if reads := AuthorityReads() - before; reads > tc.maxReads {
+				t.Fatalf("%d refused allocations issued %d authority reads, want at most %d; "+
+					"a stable deployment error must not serialize every message on MySQL",
+					allocations, reads, tc.maxReads)
+			}
+		})
+	}
+}
+
 // TestMirrorAloneCannotActivateTheCounter is the review P1-2 / Jerry-Xin 🔴 case.
 //
 // The hot path used to trust a positive mirror outright and never read the authority,

--- a/pkg/botevent/seq_test.go
+++ b/pkg/botevent/seq_test.go
@@ -322,6 +322,33 @@ func TestSeedLoadsBothSeqFloorsWithOneQuery(t *testing.T) {
 	}
 }
 
+func TestSeqCeilingsReturnsLegacyAndDurableRows(t *testing.T) {
+	ctx, client := seqTestCtx(t)
+	robotID := "seqtest_combined_ceilings_bot"
+	fixture(t, ctx, client, robotID)
+
+	const legacy, durable = int64(12_000), int64(34_000)
+	if _, err := ctx.DB().InsertBySql(
+		"INSERT INTO `seq`(`key`, min_seq, step) VALUES(?,?,?)",
+		"seq:robotEventSeq:"+robotID, legacy, legacyGenSeqStep).Exec(); err != nil {
+		t.Fatalf("insert legacy ceiling: %v", err)
+	}
+	if _, err := ctx.DB().InsertBySql(
+		"INSERT INTO `seq`(`key`, min_seq, step) VALUES(?,?,?)",
+		HighWaterSeqKey(robotID), durable, highWaterInterval).Exec(); err != nil {
+		t.Fatalf("insert durable ceiling: %v", err)
+	}
+
+	gotLegacy, gotDurable, err := seqCeilings(ctx, robotID)
+	if err != nil {
+		t.Fatalf("load combined ceilings: %v", err)
+	}
+	if gotLegacy != legacy || gotDurable != durable {
+		t.Fatalf("seqCeilings = (%d, %d), want (%d, %d)",
+			gotLegacy, gotDurable, legacy, durable)
+	}
+}
+
 func TestNextEventIDIsStrictlyMonotonicUnderConcurrency(t *testing.T) {
 	ctx, client := seqTestCtx(t)
 	robotID := "seqtest_monotonic_bot"
@@ -433,7 +460,7 @@ func TestSeedIsIdempotentAndNeverLowers(t *testing.T) {
 
 	client.ZAdd(QueueKey(robotID), rd.Z{Score: 5000, Member: `{"event_id":5000}`})
 
-	if err := seedCounter(ctx, client, robotID); err != nil {
+	if err := seedCounter(ctx, client, robotID, 0); err != nil {
 		t.Fatalf("first seed: %v", err)
 	}
 	afterFirst, _ := client.Get(SeqKey(robotID)).Int64()
@@ -445,7 +472,7 @@ func TestSeedIsIdempotentAndNeverLowers(t *testing.T) {
 	advanced, _ := client.Get(SeqKey(robotID)).Int64()
 
 	for i := 0; i < 3; i++ {
-		if err := seedCounter(ctx, client, robotID); err != nil {
+		if err := seedCounter(ctx, client, robotID, 0); err != nil {
 			t.Fatalf("re-seed %d: %v", i, err)
 		}
 	}

--- a/pkg/botevent/seq_test.go
+++ b/pkg/botevent/seq_test.go
@@ -740,8 +740,8 @@ func TestMirrorAloneCannotActivateTheCounter(t *testing.T) {
 					"it must come from GenSeq", id)
 			}
 			if MirrorUnauthorized() == before {
-				t.Error("an unconfirmed mirror must be counted; it self-heals to legacy, so " +
-					"without the metric a forged or stale mirror is completely invisible")
+				t.Error("an unconfirmed mirror must be counted; the allocator leaves the " +
+					"conflict intact for operator diagnosis, so without the metric it is invisible")
 			}
 		})
 	}

--- a/pkg/botevent/seq_test.go
+++ b/pkg/botevent/seq_test.go
@@ -65,10 +65,16 @@ func seqTestCtx(t *testing.T) (*config.Context, *rd.Client) {
 		t.Skipf("no usable MySQL at %s: %v", mysqlAddr, err)
 	}
 
+	// Matches modules/robot/sql/20260805000001_bot_event_seq_state.sql, including the
+	// singleton CHECK and the ON UPDATE clause. An abbreviated copy would mean the
+	// tests never exercise the shipped schema — and the CHECK is what the migration's
+	// Down relies on to refuse dropping an activated authority (review P2-11).
 	if _, err := ctx.DB().Exec("CREATE TABLE IF NOT EXISTS `" + stateTable + "` (" +
 		"`singleton_id` tinyint unsigned NOT NULL, `mode` tinyint NOT NULL DEFAULT 0, " +
 		"`epoch` bigint unsigned NOT NULL DEFAULT 0, `cutover_floor` bigint NOT NULL DEFAULT 0, " +
-		"`updated_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP, PRIMARY KEY (`singleton_id`)) " +
+		"`updated_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP, " +
+		"PRIMARY KEY (`singleton_id`), " +
+		"CONSTRAINT `chk_bot_event_seq_singleton` CHECK (`singleton_id` = 1)) " +
 		"ENGINE=InnoDB DEFAULT CHARSET=utf8mb4"); err != nil {
 		t.Skipf("cannot create %s at %s: %v", stateTable, mysqlAddr, err)
 	}
@@ -100,7 +106,7 @@ func fixture(t *testing.T, ctx *config.Context, client *rd.Client, robotID strin
 	clean()
 	// Activated state: the DB row is the authority, the Redis key only its mirror.
 	setStateMode(t, ctx, StateModeIncr, 0)
-	if err := client.Set(ModeKey, ModeIncr, 0).Err(); err != nil {
+	if err := client.Set(ModeKey, MirrorValue(0), 0).Err(); err != nil {
 		t.Fatalf("write mode mirror: %v", err)
 	}
 	t.Cleanup(clean)
@@ -110,9 +116,12 @@ func fixture(t *testing.T, ctx *config.Context, client *rd.Client, robotID strin
 // validation. Tests that exercise Activate itself call it directly.
 func setStateMode(t *testing.T, ctx *config.Context, mode int, floor int64) {
 	t.Helper()
+	// epoch is pinned to 0 so the mirror value tests write (MirrorValue(0)) matches.
+	// Without resetting it, a test that ran the real Activate leaves epoch=1 behind and
+	// the next fixture's mirror would be a stale generation.
 	if _, err := ctx.DB().InsertBySql(
 		"insert into `"+stateTable+"`(`singleton_id`,`mode`,`epoch`,`cutover_floor`) values(?,?,0,?) "+
-			"on duplicate key update `mode`=VALUES(`mode`), `cutover_floor`=VALUES(`cutover_floor`)",
+			"on duplicate key update `mode`=VALUES(`mode`), `epoch`=0, `cutover_floor`=VALUES(`cutover_floor`)",
 		stateSingletonID, mode, floor).Exec(); err != nil {
 		t.Fatalf("set state mode: %v", err)
 	}
@@ -170,7 +179,7 @@ func TestActivationTakesEffectWithoutAProcessCacheWindow(t *testing.T) {
 
 	// Activate, with no restart and no cache invalidation of any kind.
 	setStateMode(t, ctx, StateModeIncr, 0)
-	if err := client.Set(ModeKey, ModeIncr, 0).Err(); err != nil {
+	if err := client.Set(ModeKey, MirrorValue(0), 0).Err(); err != nil {
 		t.Fatalf("activate: %v", err)
 	}
 
@@ -209,7 +218,7 @@ func TestSeedClearsTheLegacyCeilingAtActivation(t *testing.T) {
 	}
 
 	setStateMode(t, ctx, StateModeIncr, 0)
-	if err := client.Set(ModeKey, ModeIncr, 0).Err(); err != nil {
+	if err := client.Set(ModeKey, MirrorValue(0), 0).Err(); err != nil {
 		t.Fatalf("activate: %v", err)
 	}
 	first, err := nextEventID(ctx, client, robotID)
@@ -534,7 +543,9 @@ func TestHighWaterNeverMovesBackwards(t *testing.T) {
 	robotID := "seqtest_highwater_bot"
 	fixture(t, ctx, client, robotID)
 
-	persistHighWater(ctx, robotID, 900000)
+	if err := persistHighWater(ctx, robotID, 900000); err != nil {
+		t.Fatalf("persist high-water: %v", err)
+	}
 	high, err := highWaterCeiling(ctx, robotID)
 	if err != nil || high == 0 {
 		t.Fatalf("first write did not land (high=%d err=%v)", high, err)
@@ -543,7 +554,9 @@ func TestHighWaterNeverMovesBackwards(t *testing.T) {
 	// A replica that is behind tries to persist a lower mark, as one would after a
 	// rollback or when running with a stale block.
 	lastPersisted.Delete(robotID)
-	persistHighWater(ctx, robotID, 1000)
+	if err := persistHighWater(ctx, robotID, 1000); err != nil {
+		t.Fatalf("persist lower high-water: %v", err)
+	}
 
 	after, err := highWaterCeiling(ctx, robotID)
 	if err != nil {
@@ -564,12 +577,14 @@ func TestSeedRecoversFromTheDurableMarkAlone(t *testing.T) {
 	fixture(t, ctx, client, robotID)
 
 	const mark = 777000
-	persistHighWater(ctx, robotID, mark)
+	if err := persistHighWater(ctx, robotID, mark); err != nil {
+		t.Fatalf("persist high-water: %v", err)
+	}
 	// Everything Redis knew is gone.
 	client.Del(SeqKey(robotID), QueueKey(robotID))
 	ResetSeededForTest()
 	setStateMode(t, ctx, StateModeIncr, 0)
-	if err := client.Set(ModeKey, ModeIncr, 0).Err(); err != nil {
+	if err := client.Set(ModeKey, MirrorValue(0), 0).Err(); err != nil {
 		t.Fatalf("activate: %v", err)
 	}
 
@@ -590,19 +605,16 @@ func TestExpectedModeFailsClosedWhenModeIsLost(t *testing.T) {
 	robotID := "seqtest_expectedmode_bot"
 	fixture(t, ctx, client, robotID)
 
-	if _, err := nextEventID(ctx, client, robotID); err != nil {
-		t.Fatalf("allocate while activated: %v", err)
-	}
-
-	// Redis loses the mode key AND the authority says legacy, while this replica
-	// expects to be activated. (A lost mirror with an activated authority is the
-	// self-healing case, covered by TestMirrorRebuiltFromDBAuthority.)
+	// A fresh process (no cached belief, nothing issued) meeting a legacy authority
+	// with the mirror gone: that is what a pre-migration deploy looks like, so the
+	// guard is the only thing that distinguishes it from a lost activation.
 	setStateMode(t, ctx, StateModeLegacy, 0)
 	client.Del(ModeKey)
+	ResetSeededForTest()
 	restore := SetExpectedModeForTest(ModeIncr)
-	defer restore()
 
 	if _, err := nextEventID(ctx, client, robotID); err == nil {
+		restore()
 		t.Fatal("expected a lost mode key to fail closed when the replica expects incr, " +
 			"got nil error — falling back to legacy would issue ids below live cursors")
 	}
@@ -616,6 +628,118 @@ func TestExpectedModeFailsClosedWhenModeIsLost(t *testing.T) {
 	}
 	if v == 0 {
 		t.Fatal("legacy allocation returned 0")
+	}
+}
+
+// TestMalformedExpectedModeFailsClosed pins the other half of that guard.
+//
+// The previous revision compared a free-form env string against ModeIncr, so
+// `OCTO_BOTEVENT_EXPECTED_MODE=inrc` was indistinguishable from unset: a typo silently
+// disarmed the one thing standing between a lost mode and a downgrade (review P1-4).
+// Same shape as #627's internal/msgextraseq, which fails closed on a malformed value.
+func TestMalformedExpectedModeFailsClosed(t *testing.T) {
+	ctx, client := seqTestCtx(t)
+	robotID := "seqtest_badexpectedmode_bot"
+	fixture(t, ctx, client, robotID)
+	ResetSeededForTest()
+
+	restore := SetExpectedModeForTest("inrc")
+	defer restore()
+
+	if _, err := nextEventID(ctx, client, robotID); err == nil {
+		t.Fatal("a malformed expected-mode value must fail closed; reading it as \"unset\" is " +
+			"how a typo turns a deployment guard into decoration")
+	}
+}
+
+// TestMirrorAloneCannotActivateTheCounter is the review P1-2 / Jerry-Xin 🔴 case.
+//
+// The hot path used to trust a positive mirror outright and never read the authority,
+// so a stray `SET botEventSeq:mode incr` performed the activation the operator tool
+// exists to gate: no floor validation, no `-yes`, no confirmation that every pre-fix
+// replica is gone. That is the mixed-source loss this whole change removes — an
+// activated replica issuing above the ceiling while a legacy one issues from the
+// bottom of a block.
+//
+// Reachable by hand, by a Redis shared with another environment, by a snapshot
+// restored from an activated era, or by rolling the migration back and leaving the
+// mirror behind.
+func TestMirrorAloneCannotActivateTheCounter(t *testing.T) {
+	ctx, client := seqTestCtx(t)
+	robotID := "seqtest_forgedmirror_bot"
+	fixture(t, ctx, client, robotID)
+
+	for _, mirror := range []string{ModeIncr, MirrorValue(0), MirrorValue(99)} {
+		t.Run(mirror, func(t *testing.T) {
+			// Authority says legacy. Somebody wrote the mirror anyway.
+			setStateMode(t, ctx, StateModeLegacy, 0)
+			ResetSeededForTest()
+			client.Del(SeqKey(robotID))
+			if err := client.Set(ModeKey, mirror, 0).Err(); err != nil {
+				t.Fatalf("plant mirror: %v", err)
+			}
+
+			before := MirrorUnauthorized()
+			id, err := nextEventID(ctx, client, robotID)
+			if err != nil {
+				t.Fatalf("allocate: %v", err)
+			}
+			if n, _ := client.Exists(SeqKey(robotID)).Result(); n != 0 {
+				t.Fatalf("mirror %q activated the counter without the authority; the gate the "+
+					"operator tool implements was bypassed entirely", mirror)
+			}
+			if id < 1000000 {
+				t.Errorf("id %d looks like a counter allocation; with the authority saying legacy "+
+					"it must come from GenSeq", id)
+			}
+			if MirrorUnauthorized() == before {
+				t.Error("an unconfirmed mirror must be counted; it self-heals to legacy, so " +
+					"without the metric a forged or stale mirror is completely invisible")
+			}
+		})
+	}
+}
+
+// TestNotActivatedDoesNotQueryTheAuthorityPerAllocation is review P1-1.
+//
+// The pre-activation path ran `SELECT ... FROM octo_bot_event_seq_state` on **every**
+// allocation, inside a held msgSem slot and with no deadline, which made the PR's
+// central claim ("until an operator activates, every replica delegates to GenSeq
+// exactly as before") false. Nothing pinned it, because the other pre-activation test
+// asserts the id's shape and this is a property of the I/O shape.
+func TestNotActivatedDoesNotQueryTheAuthorityPerAllocation(t *testing.T) {
+	ctx, client := seqTestCtx(t)
+	robotID := "seqtest_noauthorityspam_bot"
+	fixture(t, ctx, client, robotID)
+	setStateMode(t, ctx, StateModeLegacy, 0)
+	client.Del(ModeKey)
+	ResetSeededForTest()
+
+	before := AuthorityReads()
+	const allocations = 20
+	for i := 0; i < allocations; i++ {
+		if _, err := nextEventID(ctx, client, robotID); err != nil {
+			t.Fatalf("allocate %d: %v", i, err)
+		}
+	}
+	reads := AuthorityReads() - before
+	// One read for the cold belief. The negative belief is trusted while the mirror
+	// agrees with it, and the mirror is absent throughout, so nothing forces another.
+	if reads > 1 {
+		t.Errorf("%d allocations issued %d authority reads; the merged-but-not-activated build "+
+			"must not put a DB round trip on the fan-out path (it runs inside a msgSem slot)",
+			allocations, reads)
+	}
+
+	// And the cache must expire rather than pin a stale answer forever: a replica whose
+	// mirror write was lost has to notice the flip on its own.
+	AgeModeBeliefForTest()
+	if _, err := nextEventID(ctx, client, robotID); err != nil {
+		t.Fatalf("allocate after the belief aged out: %v", err)
+	}
+	if AuthorityReads()-before <= reads {
+		t.Error("an aged-out negative belief must be re-read; otherwise a replica that missed " +
+			"the mirror write never notices the activation")
 	}
 }
 
@@ -716,8 +840,12 @@ func TestMirrorRebuiltFromDBAuthority(t *testing.T) {
 		t.Fatalf("id %d after mirror loss is not above the %d already issued — the allocator "+
 			"degraded to legacy instead of consulting the authority", next, highest)
 	}
-	if v, _ := client.Get(ModeKey).Result(); v != ModeIncr {
-		t.Errorf("mirror was not restored (got %q)", v)
+	// Rebuilt with the generation, not a bare `incr`: the gate compares the mirror
+	// against the exact value the authority confirmed, so a bare value would be a claim
+	// the allocator then has to go re-verify on every allocation.
+	if v, _ := client.Get(ModeKey).Result(); v != MirrorValue(0) {
+		t.Errorf("mirror was not restored to the generation-stamped value (got %q, want %q)",
+			v, MirrorValue(0))
 	}
 }
 

--- a/pkg/botevent/seq_test.go
+++ b/pkg/botevent/seq_test.go
@@ -550,9 +550,7 @@ func TestHighWaterNeverMovesBackwards(t *testing.T) {
 	robotID := "seqtest_highwater_bot"
 	fixture(t, ctx, client, robotID)
 
-	if err := persistHighWater(ctx, robotID, 900000); err != nil {
-		t.Fatalf("persist high-water: %v", err)
-	}
+	persistHighWater(ctx, robotID, 900000)
 	high, err := highWaterCeiling(ctx, robotID)
 	if err != nil || high == 0 {
 		t.Fatalf("first write did not land (high=%d err=%v)", high, err)
@@ -561,9 +559,7 @@ func TestHighWaterNeverMovesBackwards(t *testing.T) {
 	// A replica that is behind tries to persist a lower mark, as one would after a
 	// rollback or when running with a stale block.
 	lastPersisted.Delete(robotID)
-	if err := persistHighWater(ctx, robotID, 1000); err != nil {
-		t.Fatalf("persist lower high-water: %v", err)
-	}
+	persistHighWater(ctx, robotID, 1000)
 
 	after, err := highWaterCeiling(ctx, robotID)
 	if err != nil {
@@ -584,9 +580,7 @@ func TestSeedRecoversFromTheDurableMarkAlone(t *testing.T) {
 	fixture(t, ctx, client, robotID)
 
 	const mark = 777000
-	if err := persistHighWater(ctx, robotID, mark); err != nil {
-		t.Fatalf("persist high-water: %v", err)
-	}
+	persistHighWater(ctx, robotID, mark)
 	// Everything Redis knew is gone.
 	client.Del(SeqKey(robotID), QueueKey(robotID))
 	ResetSeededForTest()

--- a/pkg/botevent/seq_test.go
+++ b/pkg/botevent/seq_test.go
@@ -11,30 +11,33 @@ import (
 	rd "github.com/go-redis/redis"
 )
 
-// The allocator's contract is about what two concurrent processes and one
-// exclusive cursor do to each other, so these tests run against a real Redis and
-// a real MySQL `seq` row rather than fakes. Fakes would restate the code.
+// These tests need a real MySQL and Redis: the contract is about what two
+// concurrent processes and one exclusive cursor do to each other, and a fake would
+// only restate the code.
 //
-// tools/genseq-repro holds the mirror image: the same assertions against the
-// legacy GenSeq allocator, which fail. Neither is meaningful without the other —
-// a lossless-delivery test that passes for both allocators is testing nothing.
-
-// These tests use a **dedicated database**, not the shared `test` one, and create
-// the `seq` table themselves.
+// They use the standard `test` database and create the `seq` table themselves.
+// `seq` is migration-owned (modules/common/sql/20211108000001_common_legacy01.sql)
+// and this package does not go through testutil.NewTestServer, so there is no
+// sql-migrate ledger here — a bare CREATE would normally leave a table that
+// `gorp_migrations` has no row for, and the next package's NewTestServer would die
+// with `Table 'seq' already exists`.
 //
-// That is not fastidiousness. `seq` is owned by a migration
-// (modules/common/sql/20211108000001_common_legacy01.sql), and this package does
-// not go through testutil.NewTestServer, so it has no sql-migrate ledger. Creating
-// the table bare in `test` would leave a table that `gorp_migrations` has no row
-// for, and the next package whose NewTestServer runs that migration would die with
-// `Table 'seq' already exists` — the exact failure mode that has most of
-// modules/message's DB tests skipped today.
-const defaultSeqTestDB = "root:demo@tcp(127.0.0.1:3306)/botevent_test?charset=utf8mb4&parseTime=true"
+// That is safe here specifically because CI drops and recreates `test` before
+// **every** package (.github/workflows/ci.yml), so nothing this package creates is
+// visible to the next one. Running several packages locally without that reset will
+// reproduce the `already exists` failure — reset between packages, as CI does.
+//
+// An earlier revision used a dedicated `botevent_test` database to dodge the issue.
+// That was worse: CI never creates it, so every one of these integration tests
+// silently Skipped there, which is indistinguishable from passing.
+//
+// tools/genseq-repro holds the mirror image of these assertions against the legacy
+// GenSeq allocator, where they fail. Neither is meaningful without the other.
 
 func testAddrs() (mysqlAddr, redisAddr string) {
 	mysqlAddr = os.Getenv("OCTO_TEST_MYSQL_ADDR")
 	if mysqlAddr == "" {
-		mysqlAddr = defaultSeqTestDB
+		mysqlAddr = config.New().DB.MySQLAddr
 	}
 	redisAddr = os.Getenv("OCTO_TEST_REDIS_ADDR")
 	if redisAddr == "" {
@@ -57,8 +60,7 @@ func seqTestCtx(t *testing.T) (*config.Context, *rd.Client) {
 		"`key` varchar(100) NOT NULL, `min_seq` bigint NOT NULL DEFAULT 0, " +
 		"`step` int NOT NULL DEFAULT 0, PRIMARY KEY (`key`)) " +
 		"ENGINE=InnoDB DEFAULT CHARSET=utf8mb4"); err != nil {
-		t.Skipf("no usable MySQL at %s (create the database first: "+
-			"CREATE DATABASE botevent_test): %v", mysqlAddr, err)
+		t.Skipf("no usable MySQL at %s: %v", mysqlAddr, err)
 	}
 
 	client := rd.NewClient(&rd.Options{Addr: redisAddr})
@@ -82,6 +84,7 @@ func fixture(t *testing.T, ctx *config.Context, client *rd.Client, robotID strin
 	clean := func() {
 		client.Del(SeqKey(robotID), QueueKey(robotID), ModeKey)
 		_, _ = ctx.DB().DeleteFrom("seq").Where("`key`=?", "seq:robotEventSeq:"+robotID).Exec()
+		_, _ = ctx.DB().DeleteFrom("seq").Where("`key`=?", HighWaterSeqKey(robotID)).Exec()
 	}
 	clean()
 	if err := client.Set(ModeKey, ModeIncr, 0).Err(); err != nil {
@@ -234,8 +237,11 @@ func TestNextEventIDIsStrictlyMonotonicUnderConcurrency(t *testing.T) {
 	// Contiguity is not contractual, but a gap would mean something else is
 	// sharing this counter, which is worth knowing about.
 	if all[len(all)-1]-all[0] != int64(len(all)-1) {
-		t.Errorf("ids are not contiguous (%d..%d for %d allocations) — is another writer sharing %s?",
-			all[0], all[len(all)-1], len(all), SeqKey(robotID))
+		high, _ := highWaterCeiling(ctx, robotID)
+		t.Errorf("ids are not contiguous (%d..%d for %d allocations); rollbacksDetected=%d, "+
+			"durable high-water=%d — a gap means something re-seeded mid-run, which under "+
+			"pure concurrency it must not (see rollbackTolerance)",
+			all[0], all[len(all)-1], len(all), RollbacksDetected(), high)
 	}
 }
 
@@ -427,5 +433,153 @@ func TestExclusiveCursorIsLosslessWithMonotonicIDs(t *testing.T) {
 	if len(delivered) != int(total) {
 		t.Fatalf("exclusive cursor delivered %d of %d members; monotonic ids must make it "+
 			"lossless at any page size", len(delivered), total)
+	}
+}
+
+// TestCounterRollbackIsDetectedAndHealed is the review finding: co-recovery makes
+// ids unique across an RDB rollback but says nothing about consumer cursors, which
+// are external and do not roll back.
+//
+// Simulated by setting the counter back to an earlier value, which is what
+// restoring an older RDB snapshot does to it. The bug this locks is not the
+// regression itself — it is that a replica which has already seeded would keep
+// INCRing the regressed counter and quietly issue every subsequent id below the
+// cursor a client already holds.
+func TestCounterRollbackIsDetectedAndHealed(t *testing.T) {
+	ctx, client := seqTestCtx(t)
+	robotID := "seqtest_rollback_bot"
+	fixture(t, ctx, client, robotID)
+
+	// Issue enough ids to advance the durable mark at least once.
+	var highest int64
+	for i := 0; i < highWaterInterval+5; i++ {
+		v, err := nextEventID(ctx, client, robotID)
+		if err != nil {
+			t.Fatalf("allocate %d: %v", i, err)
+		}
+		highest = v
+	}
+	mark, err := highWaterCeiling(ctx, robotID)
+	if err != nil {
+		t.Fatalf("read high-water: %v", err)
+	}
+	if mark == 0 {
+		t.Fatalf("durable high-water mark was never written after %d allocations; "+
+			"without it a rollback cannot be recovered from", highWaterInterval+5)
+	}
+
+	// The client has read up to `highest`. Now Redis loses data and comes back with
+	// an older counter — the queue would come back older too, but the client's
+	// cursor does not.
+	// Regress by more than rollbackTolerance: smaller regressions are deliberately
+	// indistinguishable from concurrent out-of-order arrival (see that constant).
+	regressedTo := highest - 3*rollbackTolerance
+	if regressedTo < 1 {
+		regressedTo = 1 // a counter is never negative; see gateNotActivated
+	}
+	if err := client.Set(SeqKey(robotID), regressedTo, 0).Err(); err != nil {
+		t.Fatalf("simulate rollback: %v", err)
+	}
+	before := RollbacksDetected()
+
+	next, err := nextEventID(ctx, client, robotID)
+	if err != nil {
+		t.Fatalf("allocate after rollback: %v", err)
+	}
+	if RollbacksDetected() != before+1 {
+		t.Errorf("rollback was not detected (%d -> %d)", before, RollbacksDetected())
+	}
+	if next <= highest {
+		t.Fatalf("id %d after rollback is not above the %d already issued and possibly read; "+
+			"it would land below a live consumer cursor", next, highest)
+	}
+}
+
+// TestHighWaterNeverMovesBackwards pins the GREATEST in the durable write. An
+// unconditional overwrite is exactly how GenSeq lets a lagging replica drag a floor
+// backwards, which is the root cause of #697 — repeating it here would undo the fix.
+func TestHighWaterNeverMovesBackwards(t *testing.T) {
+	ctx, client := seqTestCtx(t)
+	robotID := "seqtest_highwater_bot"
+	fixture(t, ctx, client, robotID)
+
+	persistHighWater(ctx, robotID, 900000)
+	high, err := highWaterCeiling(ctx, robotID)
+	if err != nil || high == 0 {
+		t.Fatalf("first write did not land (high=%d err=%v)", high, err)
+	}
+
+	// A replica that is behind tries to persist a lower mark, as one would after a
+	// rollback or when running with a stale block.
+	lastPersisted.Delete(robotID)
+	persistHighWater(ctx, robotID, 1000)
+
+	after, err := highWaterCeiling(ctx, robotID)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if after < high {
+		t.Fatalf("high-water mark moved backwards from %d to %d; a lagging writer must not "+
+			"be able to lower a floor (this is the #697 root cause)", high, after)
+	}
+}
+
+// TestSeedRecoversFromTheDurableMarkAlone isolates the durable source: no queue, no
+// legacy row, no counter — only the MySQL mark, which is the state left behind by a
+// Redis that lost everything.
+func TestSeedRecoversFromTheDurableMarkAlone(t *testing.T) {
+	ctx, client := seqTestCtx(t)
+	robotID := "seqtest_durableonly_bot"
+	fixture(t, ctx, client, robotID)
+
+	const mark = 777000
+	persistHighWater(ctx, robotID, mark)
+	// Everything Redis knew is gone.
+	client.Del(SeqKey(robotID), QueueKey(robotID))
+	ResetSeededForTest()
+	if err := client.Set(ModeKey, ModeIncr, 0).Err(); err != nil {
+		t.Fatalf("activate: %v", err)
+	}
+
+	first, err := nextEventID(ctx, client, robotID)
+	if err != nil {
+		t.Fatalf("allocate: %v", err)
+	}
+	if first <= mark {
+		t.Fatalf("first id %d after total Redis loss is not above the durable mark %d", first, mark)
+	}
+}
+
+// TestExpectedModeFailsClosedWhenModeIsLost covers the other half of the same
+// rollback: ModeKey also lives in Redis, and dropping to legacy would issue ids from
+// a lower GenSeq block — beneath live cursors, the same loss mirrored.
+func TestExpectedModeFailsClosedWhenModeIsLost(t *testing.T) {
+	ctx, client := seqTestCtx(t)
+	robotID := "seqtest_expectedmode_bot"
+	fixture(t, ctx, client, robotID)
+
+	if _, err := nextEventID(ctx, client, robotID); err != nil {
+		t.Fatalf("allocate while activated: %v", err)
+	}
+
+	// Redis loses the mode key while this replica expects to be activated.
+	client.Del(ModeKey)
+	restore := SetExpectedModeForTest(ModeIncr)
+	defer restore()
+
+	if _, err := nextEventID(ctx, client, robotID); err == nil {
+		t.Fatal("expected a lost mode key to fail closed when the replica expects incr, " +
+			"got nil error — falling back to legacy would issue ids below live cursors")
+	}
+
+	// With no expectation set, the same state is pre-activation and legacy is right.
+	restore()
+	ResetSeededForTest()
+	v, err := nextEventID(ctx, client, robotID)
+	if err != nil {
+		t.Fatalf("without an expectation, a missing mode must mean legacy: %v", err)
+	}
+	if v == 0 {
+		t.Fatal("legacy allocation returned 0")
 	}
 }

--- a/pkg/botevent/seq_test.go
+++ b/pkg/botevent/seq_test.go
@@ -48,6 +48,29 @@ func testAddrs() (mysqlAddr, redisAddr string) {
 	return
 }
 
+// seqTableDDL creates the migration-owned `seq` table. The row is the load-bearing half
+// of the seed: it is the only record of how high the legacy allocator ever went for a bot
+// whose queue is now empty.
+//
+// Shared with probeTestDependencies in main_test.go, which runs the identical statements
+// so a CI environment that cannot execute them fails loudly instead of skipping.
+const seqTableDDL = "CREATE TABLE IF NOT EXISTS `seq` (" +
+	"`key` varchar(100) NOT NULL, `min_seq` bigint NOT NULL DEFAULT 0, " +
+	"`step` int NOT NULL DEFAULT 0, PRIMARY KEY (`key`)) " +
+	"ENGINE=InnoDB DEFAULT CHARSET=utf8mb4"
+
+// stateTableDDL matches modules/robot/sql/20260805000001_bot_event_seq_state.sql,
+// including the singleton CHECK and the ON UPDATE clause. An abbreviated copy would mean
+// the tests never exercise the shipped schema — and the CHECK is what the migration's Down
+// relies on to refuse dropping an activated authority (review P2-11).
+const stateTableDDL = "CREATE TABLE IF NOT EXISTS `" + stateTable + "` (" +
+	"`singleton_id` tinyint unsigned NOT NULL, `mode` tinyint NOT NULL DEFAULT 0, " +
+	"`epoch` bigint unsigned NOT NULL DEFAULT 0, `cutover_floor` bigint NOT NULL DEFAULT 0, " +
+	"`updated_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP, " +
+	"PRIMARY KEY (`singleton_id`), " +
+	"CONSTRAINT `chk_bot_event_seq_singleton` CHECK (`singleton_id` = 1)) " +
+	"ENGINE=InnoDB DEFAULT CHARSET=utf8mb4"
+
 func seqTestCtx(t *testing.T) (*config.Context, *rd.Client) {
 	t.Helper()
 	mysqlAddr, redisAddr := testAddrs()
@@ -56,26 +79,10 @@ func seqTestCtx(t *testing.T) (*config.Context, *rd.Client) {
 	cfg.DB.MySQLAddr = mysqlAddr
 	ctx := config.NewContext(cfg)
 
-	// The `seq` row is the load-bearing half of the seed: it is the only record of
-	// how high the legacy allocator ever went for a bot whose queue is now empty.
-	if _, err := ctx.DB().Exec("CREATE TABLE IF NOT EXISTS `seq` (" +
-		"`key` varchar(100) NOT NULL, `min_seq` bigint NOT NULL DEFAULT 0, " +
-		"`step` int NOT NULL DEFAULT 0, PRIMARY KEY (`key`)) " +
-		"ENGINE=InnoDB DEFAULT CHARSET=utf8mb4"); err != nil {
+	if _, err := ctx.DB().Exec(seqTableDDL); err != nil {
 		t.Skipf("no usable MySQL at %s: %v", mysqlAddr, err)
 	}
-
-	// Matches modules/robot/sql/20260805000001_bot_event_seq_state.sql, including the
-	// singleton CHECK and the ON UPDATE clause. An abbreviated copy would mean the
-	// tests never exercise the shipped schema — and the CHECK is what the migration's
-	// Down relies on to refuse dropping an activated authority (review P2-11).
-	if _, err := ctx.DB().Exec("CREATE TABLE IF NOT EXISTS `" + stateTable + "` (" +
-		"`singleton_id` tinyint unsigned NOT NULL, `mode` tinyint NOT NULL DEFAULT 0, " +
-		"`epoch` bigint unsigned NOT NULL DEFAULT 0, `cutover_floor` bigint NOT NULL DEFAULT 0, " +
-		"`updated_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP, " +
-		"PRIMARY KEY (`singleton_id`), " +
-		"CONSTRAINT `chk_bot_event_seq_singleton` CHECK (`singleton_id` = 1)) " +
-		"ENGINE=InnoDB DEFAULT CHARSET=utf8mb4"); err != nil {
+	if _, err := ctx.DB().Exec(stateTableDDL); err != nil {
 		t.Skipf("cannot create %s at %s: %v", stateTable, mysqlAddr, err)
 	}
 

--- a/pkg/botevent/seq_test.go
+++ b/pkg/botevent/seq_test.go
@@ -1,0 +1,328 @@
+package botevent
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"sync"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	rd "github.com/go-redis/redis"
+)
+
+// The allocator's contract is about what two concurrent processes and one
+// exclusive cursor do to each other, so these tests run against a real Redis and
+// a real MySQL `seq` row rather than fakes. Fakes would restate the code.
+//
+// tools/genseq-repro holds the mirror image: the same assertions against the
+// legacy GenSeq allocator, which fail. Neither is meaningful without the other —
+// a lossless-delivery test that passes for both allocators is testing nothing.
+
+// These tests use a **dedicated database**, not the shared `test` one, and create
+// the `seq` table themselves.
+//
+// That is not fastidiousness. `seq` is owned by a migration
+// (modules/common/sql/20211108000001_common_legacy01.sql), and this package does
+// not go through testutil.NewTestServer, so it has no sql-migrate ledger. Creating
+// the table bare in `test` would leave a table that `gorp_migrations` has no row
+// for, and the next package whose NewTestServer runs that migration would die with
+// `Table 'seq' already exists` — the exact failure mode that has most of
+// modules/message's DB tests skipped today.
+const defaultSeqTestDB = "root:demo@tcp(127.0.0.1:3306)/botevent_test?charset=utf8mb4&parseTime=true"
+
+func testAddrs() (mysqlAddr, redisAddr string) {
+	mysqlAddr = os.Getenv("OCTO_TEST_MYSQL_ADDR")
+	if mysqlAddr == "" {
+		mysqlAddr = defaultSeqTestDB
+	}
+	redisAddr = os.Getenv("OCTO_TEST_REDIS_ADDR")
+	if redisAddr == "" {
+		redisAddr = "127.0.0.1:6379"
+	}
+	return
+}
+
+func seqTestCtx(t *testing.T) (*config.Context, *rd.Client) {
+	t.Helper()
+	mysqlAddr, redisAddr := testAddrs()
+
+	cfg := config.New()
+	cfg.DB.MySQLAddr = mysqlAddr
+	ctx := config.NewContext(cfg)
+
+	// The `seq` row is the load-bearing half of the seed: it is the only record of
+	// how high the legacy allocator ever went for a bot whose queue is now empty.
+	if _, err := ctx.DB().Exec("CREATE TABLE IF NOT EXISTS `seq` (" +
+		"`key` varchar(100) NOT NULL, `min_seq` bigint NOT NULL DEFAULT 0, " +
+		"`step` int NOT NULL DEFAULT 0, PRIMARY KEY (`key`)) " +
+		"ENGINE=InnoDB DEFAULT CHARSET=utf8mb4"); err != nil {
+		t.Skipf("no usable MySQL at %s (create the database first: "+
+			"CREATE DATABASE botevent_test): %v", mysqlAddr, err)
+	}
+
+	client := rd.NewClient(&rd.Options{Addr: redisAddr})
+	if err := client.Ping().Err(); err != nil {
+		t.Skipf("no usable Redis at %s: %v", redisAddr, err)
+	}
+
+	ResetSeededForTest()
+	t.Cleanup(func() {
+		ResetSeededForTest()
+		_ = client.Close()
+	})
+	return ctx, client
+}
+
+// fixture clears every trace of a bot so each test starts from a known floor.
+func fixture(t *testing.T, ctx *config.Context, client *rd.Client, robotID string) {
+	t.Helper()
+	clean := func() {
+		client.Del(SeqKey(robotID), QueueKey(robotID))
+		_, _ = ctx.DB().DeleteFrom("seq").Where("`key`=?", "seq:robotEventSeq:"+robotID).Exec()
+	}
+	clean()
+	t.Cleanup(clean)
+}
+
+func TestNextEventIDIsStrictlyMonotonicUnderConcurrency(t *testing.T) {
+	ctx, client := seqTestCtx(t)
+	robotID := "seqtest_monotonic_bot"
+	fixture(t, ctx, client, robotID)
+
+	const goroutines, each = 8, 25
+	got := make([][]int64, goroutines)
+	var wg sync.WaitGroup
+	for g := 0; g < goroutines; g++ {
+		wg.Add(1)
+		go func(g int) {
+			defer wg.Done()
+			for i := 0; i < each; i++ {
+				v, err := nextEventID(ctx, client, robotID)
+				if err != nil {
+					t.Errorf("goroutine %d: %v", g, err)
+					return
+				}
+				got[g] = append(got[g], v)
+			}
+		}(g)
+	}
+	wg.Wait()
+
+	var all []int64
+	for _, ids := range got {
+		// Within one caller, ids must also be increasing — INCR never reorders.
+		for i := 1; i < len(ids); i++ {
+			if ids[i] <= ids[i-1] {
+				t.Fatalf("ids went backwards within one caller: %d then %d", ids[i-1], ids[i])
+			}
+		}
+		all = append(all, ids...)
+	}
+	sort.Slice(all, func(a, b int) bool { return all[a] < all[b] })
+	if len(all) != goroutines*each {
+		t.Fatalf("expected %d ids, got %d", goroutines*each, len(all))
+	}
+	for i := 1; i < len(all); i++ {
+		if all[i] == all[i-1] {
+			t.Fatalf("duplicate id %d issued to two callers", all[i])
+		}
+	}
+	// Contiguity is not contractual, but a gap would mean something else is
+	// sharing this counter, which is worth knowing about.
+	if all[len(all)-1]-all[0] != int64(len(all)-1) {
+		t.Errorf("ids are not contiguous (%d..%d for %d allocations) — is another writer sharing %s?",
+			all[0], all[len(all)-1], len(all), SeqKey(robotID))
+	}
+}
+
+// TestSeedRaisesAboveQueueCeiling covers the ids legacy already put in the queue.
+func TestSeedRaisesAboveQueueCeiling(t *testing.T) {
+	ctx, client := seqTestCtx(t)
+	robotID := "seqtest_queueceiling_bot"
+	fixture(t, ctx, client, robotID)
+
+	const legacyHigh = 1035010
+	client.ZAdd(QueueKey(robotID), rd.Z{Score: legacyHigh, Member: `{"event_id":1035010}`})
+
+	first, err := nextEventID(ctx, client, robotID)
+	if err != nil {
+		t.Fatalf("allocate: %v", err)
+	}
+	if first <= legacyHigh {
+		t.Fatalf("first id %d is not above the queue ceiling %d — every new event would be "+
+			"born below a client cursor sitting at the ceiling", first, legacyHigh)
+	}
+}
+
+// TestSeedRaisesAboveLegacySeqRowWithEmptyQueue is the self-inflicted-outage case:
+// the queue is empty (fully acked or expired) so it carries no evidence, but
+// clients still hold cursors near the last id legacy ever issued. Seeding from the
+// queue alone would put every new event below those cursors.
+func TestSeedRaisesAboveLegacySeqRowWithEmptyQueue(t *testing.T) {
+	ctx, client := seqTestCtx(t)
+	robotID := "seqtest_legacyrow_bot"
+	fixture(t, ctx, client, robotID)
+
+	const legacyMinSeq = 2040000
+	if _, err := ctx.DB().InsertBySql(
+		"insert into `seq`(`key`,min_seq,step) values(?,?,?)",
+		"seq:robotEventSeq:"+robotID, legacyMinSeq, 1000).Exec(); err != nil {
+		t.Fatalf("seed legacy row: %v", err)
+	}
+	if n, err := client.ZCard(QueueKey(robotID)).Result(); err != nil || n != 0 {
+		t.Fatalf("queue should be empty for this case (n=%d err=%v)", n, err)
+	}
+
+	first, err := nextEventID(ctx, client, robotID)
+	if err != nil {
+		t.Fatalf("allocate: %v", err)
+	}
+	if first <= legacyMinSeq {
+		t.Fatalf("first id %d is not above the legacy seq row %d — clients holding a cursor "+
+			"from before the queue drained would never see another event", first, legacyMinSeq)
+	}
+}
+
+// TestSeedIsIdempotentAndNeverLowers is what licenses the single-stage deploy: any
+// replica may seed at any time, any number of times, in any order.
+func TestSeedIsIdempotentAndNeverLowers(t *testing.T) {
+	ctx, client := seqTestCtx(t)
+	robotID := "seqtest_idempotent_bot"
+	fixture(t, ctx, client, robotID)
+
+	client.ZAdd(QueueKey(robotID), rd.Z{Score: 5000, Member: `{"event_id":5000}`})
+
+	if err := seedCounter(ctx, client, robotID); err != nil {
+		t.Fatalf("first seed: %v", err)
+	}
+	afterFirst, _ := client.Get(SeqKey(robotID)).Int64()
+
+	// Advance well past the floor, then re-seed: a second seeder must not undo it.
+	for i := 0; i < 50; i++ {
+		client.Incr(SeqKey(robotID))
+	}
+	advanced, _ := client.Get(SeqKey(robotID)).Int64()
+
+	for i := 0; i < 3; i++ {
+		if err := seedCounter(ctx, client, robotID); err != nil {
+			t.Fatalf("re-seed %d: %v", i, err)
+		}
+	}
+	afterReseed, _ := client.Get(SeqKey(robotID)).Int64()
+	if afterReseed != advanced {
+		t.Fatalf("re-seeding moved the counter from %d to %d; it must be a no-op once above "+
+			"the floor, or a late-starting replica would rewind live ids", advanced, afterReseed)
+	}
+	if afterFirst <= 5000 {
+		t.Fatalf("first seed left the counter at %d, not above the ceiling 5000", afterFirst)
+	}
+}
+
+// TestNextEventIDFailsClosedWhenSeedFails pins the no-fallback rule. Returning an
+// unseeded id would be worse than returning an error: the error fails one enqueue,
+// an unseeded id silently puts every event for that bot below its client's cursor.
+//
+// The failure is induced with a real Redis rather than a fake, and induced
+// specifically on the *seed* while leaving INCR perfectly usable: the queue key is
+// made a string, so the ceiling read fails with WRONGTYPE while the counter key is
+// untouched. That is the split that matters — a fake whose every call fails could
+// not tell "refused to allocate" from "could not reach Redis at all".
+func TestNextEventIDFailsClosedWhenSeedFails(t *testing.T) {
+	ctx, client := seqTestCtx(t)
+	robotID := "seqtest_failclosed_bot"
+	fixture(t, ctx, client, robotID)
+
+	if err := client.Set(QueueKey(robotID), "not-a-zset", 0).Err(); err != nil {
+		t.Fatalf("plant WRONGTYPE: %v", err)
+	}
+	// Prove INCR on the counter key is genuinely available, so the failure below
+	// can only come from the seed.
+	if err := client.Incr(SeqKey(robotID)).Err(); err != nil {
+		t.Fatalf("counter key should be usable: %v", err)
+	}
+	client.Del(SeqKey(robotID))
+
+	before := SeedFailures()
+	if _, err := nextEventID(ctx, client, robotID); err == nil {
+		t.Fatal("expected a failed seed to fail the allocation, got nil error")
+	}
+	if SeedFailures() != before+1 {
+		t.Errorf("seed failure was not counted (%d -> %d)", before, SeedFailures())
+	}
+	if n, _ := client.Exists(SeqKey(robotID)).Result(); n != 0 {
+		t.Error("a failed seed must not leave a counter behind")
+	}
+	// And it must not have been marked seeded, or a retry would skip the seed and
+	// hand out an unsafe id.
+	if _, ok := seeded.Load(robotID); ok {
+		t.Error("a failed seed must not mark the bot as seeded")
+	}
+}
+
+// TestExclusiveCursorIsLosslessWithMonotonicIDs is the end-to-end assertion, run
+// against the same read shape as modules/bot_api/events.go. Its mirror in
+// tools/genseq-repro fails under the legacy allocator: same consumer, same page
+// size, ids from two blocks instead of one counter.
+func TestExclusiveCursorIsLosslessWithMonotonicIDs(t *testing.T) {
+	ctx, client := seqTestCtx(t)
+	robotID := "seqtest_lossless_bot"
+	fixture(t, ctx, client, robotID)
+
+	// Two concurrent producers, interleaved, as two replicas would be.
+	const perProducer = 40
+	var wg sync.WaitGroup
+	for p := 0; p < 2; p++ {
+		wg.Add(1)
+		go func(p int) {
+			defer wg.Done()
+			for i := 0; i < perProducer; i++ {
+				id, err := nextEventID(ctx, client, robotID)
+				if err != nil {
+					t.Errorf("producer %d: %v", p, err)
+					return
+				}
+				// score == payload event_id, the equality events.go's cursor and
+				// ack both depend on.
+				client.ZAdd(QueueKey(robotID), rd.Z{
+					Score:  float64(id),
+					Member: fmt.Sprintf(`{"event_id":%d,"producer":%d}`, id, p),
+				})
+			}
+		}(p)
+	}
+	wg.Wait()
+
+	total, _ := client.ZCard(QueueKey(robotID)).Result()
+	if total != 2*perProducer {
+		t.Fatalf("expected %d members, got %d — a collision would collapse two into one",
+			2*perProducer, total)
+	}
+
+	// Consume with limit 1, the page size that makes a shared score fatal.
+	delivered := map[string]bool{}
+	var cursor int64
+	for {
+		page, err := client.ZRangeByScore(QueueKey(robotID), rd.ZRangeBy{
+			Min: fmt.Sprintf("(%d", cursor), Max: "+inf", Count: 1,
+		}).Result()
+		if err != nil || len(page) == 0 {
+			break
+		}
+		moved := false
+		for _, m := range page {
+			delivered[m] = true
+			var id int64
+			if _, err := fmt.Sscanf(m, `{"event_id":%d`, &id); err == nil && id > cursor {
+				cursor, moved = id, true
+			}
+		}
+		if !moved {
+			break
+		}
+	}
+	if len(delivered) != int(total) {
+		t.Fatalf("exclusive cursor delivered %d of %d members; monotonic ids must make it "+
+			"lossless at any page size", len(delivered), total)
+	}
+}

--- a/pkg/botevent/seq_test.go
+++ b/pkg/botevent/seq_test.go
@@ -13,6 +13,22 @@ import (
 	rd "github.com/go-redis/redis"
 )
 
+type gateMutationClient struct {
+	*rd.Client
+	gateCalls  int
+	beforeGate func(call int)
+}
+
+func (c *gateMutationClient) EvalSha(hash string, keys []string, args ...interface{}) *rd.Cmd {
+	if hash == gateScript.Hash() {
+		c.gateCalls++
+		if c.beforeGate != nil {
+			c.beforeGate(c.gateCalls)
+		}
+	}
+	return c.Client.EvalSha(hash, keys, args...)
+}
+
 // These tests need a real MySQL and Redis: the contract is about what two
 // concurrent processes and one exclusive cursor do to each other, and a fake would
 // only restate the code.
@@ -235,6 +251,74 @@ func TestSeedClearsTheLegacyCeilingAtActivation(t *testing.T) {
 	if first <= lastLegacy+legacyGenSeqStep {
 		t.Fatalf("first activated id %d does not clear the legacy reserved block above %d; "+
 			"a block legacy reserved but did not finish issuing would overlap", first, lastLegacy)
+	}
+}
+
+// TestValidatedBeliefRetainsTheCutoverFloor covers the stateFloorOrZero hole.
+//
+// Once a process has validated an activated authority, a later seed for another bot must
+// use the cutover floor carried by that positive belief. Re-reading the state row during
+// seed and turning any error/missing row into zero silently discards the one global floor
+// that was validated at activation, allowing a new counter to restart at 1.
+func TestValidatedBeliefRetainsTheCutoverFloor(t *testing.T) {
+	ctx, client := seqTestCtx(t)
+	resolverBot := "seqtest_floor_resolver_bot"
+	newBot := "seqtest_floor_new_bot"
+	fixture(t, ctx, client, resolverBot)
+
+	const cutoverFloor = int64(8_000_000)
+	setStateMode(t, ctx, StateModeIncr, cutoverFloor)
+	ResetSeededForTest()
+	if _, err := nextEventID(ctx, client, resolverBot); err != nil {
+		t.Fatalf("resolve activated authority: %v", err)
+	}
+
+	client.Del(SeqKey(newBot), QueueKey(newBot))
+	_, _ = ctx.DB().DeleteFrom("seq").Where("`key` in ?", []string{
+		"seq:robotEventSeq:" + newBot,
+		HighWaterSeqKey(newBot),
+	}).Exec()
+	if _, err := ctx.DB().DeleteFrom(stateTable).Where("singleton_id=?", stateSingletonID).Exec(); err != nil {
+		t.Fatalf("remove authority after positive resolution: %v", err)
+	}
+
+	got, err := nextEventID(ctx, client, newBot)
+	if err != nil {
+		t.Fatalf("allocate from retained positive belief: %v", err)
+	}
+	if got <= cutoverFloor {
+		t.Fatalf("id %d did not retain validated cutover floor %d after the authority row became unreadable; "+
+			"re-reading the floor during seed and swallowing the error can restart a bot below live cursors",
+			got, cutoverFloor)
+	}
+}
+
+// TestSeedLoadsBothSeqFloorsWithOneQuery is an I/O-shape guard. A mirror rebuild
+// invalidates every active bot's seed marker, so two point SELECTs per bot amplify an
+// already expensive recovery burst. The legacy and durable rows share one table and must
+// be loaded by one conditional aggregate query.
+func TestSeedLoadsBothSeqFloorsWithOneQuery(t *testing.T) {
+	source, err := os.ReadFile("seq.go")
+	if err != nil {
+		t.Fatalf("read seq.go: %v", err)
+	}
+	text := string(source)
+	start := strings.Index(text, "func seedCounter(")
+	if start < 0 {
+		t.Fatal("could not locate seedCounter body")
+	}
+	end := strings.Index(text[start:], "\nfunc queueCeiling(")
+	if end < 0 {
+		t.Fatal("could not locate seedCounter body")
+	}
+	body := text[start : start+end]
+	if !strings.Contains(body, "seqCeilings(ctx, robotID)") {
+		t.Error("seedCounter must load legacy and durable seq floors through one seqCeilings query")
+	}
+	for _, old := range []string{"legacyCeiling(ctx, robotID)", "highWaterCeiling(ctx, robotID)"} {
+		if strings.Contains(body, old) {
+			t.Errorf("seedCounter still calls %s; mirror recovery would issue multiple MySQL reads per bot", old)
+		}
 	}
 }
 
@@ -854,6 +938,75 @@ func TestMissingCounterFailsBeforeIssuingFromOne(t *testing.T) {
 	}
 }
 
+// TestRetryReResolvesWhenTheMirrorChangesAfterReseed covers the retry-specific
+// gateNotActivated sentinel. The mirror can disappear between a successful re-seed and
+// the retrying gate. Treating every negative value as a generic "counter unusable" error
+// loses the existing authority-recovery path and reports the wrong fault.
+func TestRetryReResolvesWhenTheMirrorChangesAfterReseed(t *testing.T) {
+	ctx, client := seqTestCtx(t)
+	robotID := "seqtest_retry_mirror_bot"
+	fixture(t, ctx, client, robotID)
+
+	highest, err := nextEventID(ctx, client, robotID)
+	if err != nil {
+		t.Fatalf("initial allocation: %v", err)
+	}
+	if err := client.Del(SeqKey(robotID)).Err(); err != nil {
+		t.Fatalf("drop counter: %v", err)
+	}
+
+	wrapped := &gateMutationClient{Client: client}
+	wrapped.beforeGate = func(call int) {
+		if call == 2 {
+			_ = client.Del(ModeKey).Err()
+		}
+	}
+	next, err := nextEventID(ctx, wrapped, robotID)
+	if err != nil {
+		t.Fatalf("mirror changed between re-seed and retry: %v", err)
+	}
+	if next <= highest {
+		t.Fatalf("recovered id %d is not above prior id %d", next, highest)
+	}
+}
+
+// TestRegressionRetryNamesACounterThatDisappearsAgain covers gateCounterMissing on
+// the other retry site. Reporting sentinel -2 as a numeric floor reached by re-seeding
+// sends an operator toward the wrong recovery action.
+func TestRegressionRetryNamesACounterThatDisappearsAgain(t *testing.T) {
+	ctx, client := seqTestCtx(t)
+	robotID := "seqtest_retry_counter_bot"
+	fixture(t, ctx, client, robotID)
+	if err := client.Set(SeqKey(robotID), 10_000, 0).Err(); err != nil {
+		t.Fatalf("raise initial counter: %v", err)
+	}
+
+	highest, err := nextEventID(ctx, client, robotID)
+	if err != nil {
+		t.Fatalf("initial allocation: %v", err)
+	}
+	if err := client.Set(SeqKey(robotID), highest-3*rollbackTolerance, 0).Err(); err != nil {
+		t.Fatalf("regress counter: %v", err)
+	}
+
+	wrapped := &gateMutationClient{Client: client}
+	wrapped.beforeGate = func(call int) {
+		if call == 2 {
+			_ = client.Del(SeqKey(robotID)).Err()
+		}
+	}
+	_, err = nextEventID(ctx, wrapped, robotID)
+	if err == nil {
+		t.Fatal("counter disappearing again during rollback recovery must fail closed")
+	}
+	if !strings.Contains(err.Error(), "counter") || !strings.Contains(err.Error(), "missing") {
+		t.Fatalf("error must identify the retry sentinel as a missing counter, got: %v", err)
+	}
+	if strings.Contains(err.Error(), "only reached -2") {
+		t.Fatalf("error misreports gateCounterMissing as a numeric re-seed floor: %v", err)
+	}
+}
+
 // TestMirrorRebuiltFromDBAuthority is why the state row exists.
 //
 // The mode mirror is in the same Redis as everything else, so it regresses with an
@@ -893,6 +1046,58 @@ func TestMirrorRebuiltFromDBAuthority(t *testing.T) {
 	if v, _ := client.Get(ModeKey).Result(); v != MirrorValue(0) {
 		t.Errorf("mirror was not restored to the generation-stamped value (got %q, want %q)",
 			v, MirrorValue(0))
+	}
+}
+
+// TestHigherMirrorEpochForcesAuthorityRefresh prevents an old process from overwriting
+// a newer generation. Positive beliefs are terminal with respect to legacy, but not with
+// respect to a mirror that names a strictly higher epoch.
+func TestHigherMirrorEpochForcesAuthorityRefresh(t *testing.T) {
+	ctx, client := seqTestCtx(t)
+	robotID := "seqtest_higher_epoch_bot"
+	fixture(t, ctx, client, robotID)
+
+	if _, err := ctx.DB().Update(stateTable).
+		Set("mode", StateModeIncr).
+		Set("epoch", 2).
+		Set("cutover_floor", 9000).
+		Where("singleton_id=?", stateSingletonID).Exec(); err != nil {
+		t.Fatalf("advance authority epoch: %v", err)
+	}
+	if err := client.Set(ModeKey, MirrorValue(2), 0).Err(); err != nil {
+		t.Fatalf("write newer mirror: %v", err)
+	}
+	activeBelief.Store(&belief{activated: true, epoch: 1, resolvedAt: beliefNow()})
+	seeded.Delete(robotID)
+	client.Del(SeqKey(robotID), QueueKey(robotID))
+
+	if _, err := nextEventID(ctx, client, robotID); err != nil {
+		t.Fatalf("allocate after observing a higher mirror epoch: %v", err)
+	}
+	if got, err := client.Get(ModeKey).Result(); err != nil || got != MirrorValue(2) {
+		t.Fatalf("older belief overwrote newer mirror: got %q err=%v, want %q", got, err, MirrorValue(2))
+	}
+	if b := activeBelief.Load(); b == nil || b.epoch != 2 {
+		t.Fatalf("authority was not refreshed upward (belief=%+v)", b)
+	}
+}
+
+// TestRunGateRejectsIDsOutsideFloat64ExactIntegerRange protects the wire invariant
+// score == event_id. At 2^53, the next integer cannot be represented as a distinct ZSET
+// score, recreating collision, cursor skip, and multi-member ack.
+func TestRunGateRejectsIDsOutsideFloat64ExactIntegerRange(t *testing.T) {
+	ctx, client := seqTestCtx(t)
+	robotID := "seqtest_float64_limit_bot"
+	fixture(t, ctx, client, robotID)
+
+	const largestSafeID = int64(1<<53 - 1)
+	if err := client.Set(SeqKey(robotID), largestSafeID, 0).Err(); err != nil {
+		t.Fatalf("set counter at exact-integer boundary: %v", err)
+	}
+	if id, err := runGate(client, robotID, MirrorValue(0)); err == nil {
+		t.Fatalf("runGate returned id %d at/above 2^53; adjacent ids no longer have distinct float64 scores", id)
+	} else if !strings.Contains(err.Error(), "float64") {
+		t.Fatalf("boundary refusal must explain the score precision invariant, got: %v", err)
 	}
 }
 

--- a/pkg/botevent/seq_test.go
+++ b/pkg/botevent/seq_test.go
@@ -74,15 +74,118 @@ func seqTestCtx(t *testing.T) (*config.Context, *rd.Client) {
 	return ctx, client
 }
 
-// fixture clears every trace of a bot so each test starts from a known floor.
+// fixture clears every trace of a bot so each test starts from a known floor, and
+// puts the allocator in the ACTIVATED state — most tests are about post-activation
+// behaviour. The pre-activation path has its own tests below.
 func fixture(t *testing.T, ctx *config.Context, client *rd.Client, robotID string) {
 	t.Helper()
 	clean := func() {
-		client.Del(SeqKey(robotID), QueueKey(robotID))
+		client.Del(SeqKey(robotID), QueueKey(robotID), ModeKey)
 		_, _ = ctx.DB().DeleteFrom("seq").Where("`key`=?", "seq:robotEventSeq:"+robotID).Exec()
 	}
 	clean()
+	if err := client.Set(ModeKey, ModeIncr, 0).Err(); err != nil {
+		t.Fatalf("activate: %v", err)
+	}
 	t.Cleanup(clean)
+}
+
+// TestNotActivatedDelegatesToLegacy is what makes deploying this change a no-op.
+//
+// Until an operator activates, every replica must behave exactly like the old
+// binary. If a deploy switched allocators on its own, the new replicas would issue
+// ids above the block that legacy replicas are still issuing from the bottom of,
+// and once a consumer's cursor reached the new range every legacy id behind it
+// would be permanently invisible — the loss of #697, caused by its fix.
+func TestNotActivatedDelegatesToLegacy(t *testing.T) {
+	ctx, client := seqTestCtx(t)
+	robotID := "seqtest_notactivated_bot"
+	fixture(t, ctx, client, robotID)
+	client.Del(ModeKey) // back to the pre-activation state
+
+	first, err := nextEventID(ctx, client, robotID)
+	if err != nil {
+		t.Fatalf("allocate: %v", err)
+	}
+	// GenSeq's first block for a brand-new key starts at 1000001; the counter would
+	// have produced 1. Asserting the shape rather than the exact number keeps this
+	// from breaking if octo-lib changes its base.
+	if first < 1000000 {
+		t.Fatalf("first id %d looks like a counter allocation; before activation it must come "+
+			"from GenSeq so the deploy is behaviour-neutral", first)
+	}
+	if n, _ := client.Exists(SeqKey(robotID)).Result(); n != 0 {
+		t.Error("the counter must not even be created before activation")
+	}
+}
+
+// TestActivationTakesEffectWithoutAProcessCacheWindow pins why the mode is read
+// inside the allocation script rather than cached.
+//
+// A per-process cache — even a one-second one — means that for that second some
+// replicas allocate from the counter while others still allocate from GenSeq. Two
+// live sources is the defect, so the flip has to be visible on the very next
+// allocation.
+func TestActivationTakesEffectWithoutAProcessCacheWindow(t *testing.T) {
+	ctx, client := seqTestCtx(t)
+	robotID := "seqtest_flip_bot"
+	fixture(t, ctx, client, robotID)
+	client.Del(ModeKey)
+
+	legacyID, err := nextEventID(ctx, client, robotID)
+	if err != nil {
+		t.Fatalf("pre-activation allocate: %v", err)
+	}
+
+	// Activate, with no restart and no cache invalidation of any kind.
+	if err := client.Set(ModeKey, ModeIncr, 0).Err(); err != nil {
+		t.Fatalf("activate: %v", err)
+	}
+
+	activatedID, err := nextEventID(ctx, client, robotID)
+	if err != nil {
+		t.Fatalf("post-activation allocate: %v", err)
+	}
+	if n, _ := client.Exists(SeqKey(robotID)).Result(); n == 0 {
+		t.Fatal("the very next allocation after activation still used the legacy path")
+	}
+	if activatedID <= legacyID {
+		t.Fatalf("post-activation id %d must be above the last legacy id %d, or the events "+
+			"issued just before the flip land below the consumer's cursor", activatedID, legacyID)
+	}
+}
+
+// TestSeedClearsTheLegacyCeilingAtActivation is the deploy-time safety property:
+// the first activated id must clear everything legacy could have issued, including
+// a block it had reserved but not finished.
+func TestSeedClearsTheLegacyCeilingAtActivation(t *testing.T) {
+	ctx, client := seqTestCtx(t)
+	robotID := "seqtest_clearceiling_bot"
+	fixture(t, ctx, client, robotID)
+	client.Del(ModeKey)
+
+	// Let legacy issue a few ids and enqueue them, as it would have in production.
+	var lastLegacy int64
+	for i := 0; i < 3; i++ {
+		id, err := nextEventID(ctx, client, robotID)
+		if err != nil {
+			t.Fatalf("legacy allocate: %v", err)
+		}
+		client.ZAdd(QueueKey(robotID), rd.Z{Score: float64(id), Member: fmt.Sprintf(`{"event_id":%d}`, id)})
+		lastLegacy = id
+	}
+
+	if err := client.Set(ModeKey, ModeIncr, 0).Err(); err != nil {
+		t.Fatalf("activate: %v", err)
+	}
+	first, err := nextEventID(ctx, client, robotID)
+	if err != nil {
+		t.Fatalf("activated allocate: %v", err)
+	}
+	if first <= lastLegacy+legacyGenSeqStep {
+		t.Fatalf("first activated id %d does not clear the legacy reserved block above %d; "+
+			"a block legacy reserved but did not finish issuing would overlap", first, lastLegacy)
+	}
 }
 
 func TestNextEventIDIsStrictlyMonotonicUnderConcurrency(t *testing.T) {

--- a/pkg/botevent/state.go
+++ b/pkg/botevent/state.go
@@ -38,10 +38,12 @@ package botevent
 // tools/botevent-seq.
 
 import (
+	"context"
 	"errors"
 	"fmt"
 
 	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/go-sql-driver/mysql"
 )
 
 const (
@@ -77,12 +79,21 @@ type State struct {
 // Activated reports whether the counter is the authoritative allocator.
 func (s State) Activated() bool { return s.Mode == StateModeIncr }
 
-// ReadState reads the singleton row.
+// ReadState reads the singleton row with no deadline. For the operator tool and
+// tests; the allocator uses ReadStateContext so a stalled MySQL cannot hold a msgSem
+// slot open (review P1-1).
+func ReadState(ctx *config.Context) (State, error) {
+	return ReadStateContext(context.Background(), ctx)
+}
+
+// ReadStateContext reads the singleton row under the caller's deadline.
 //
 // A missing row returns ErrStateMissing rather than a zero State, so callers choose
-// what it means: readers fall back to legacy (safe before the migration), while the
-// operator tool refuses to flip.
-func ReadState(ctx *config.Context) (State, error) {
+// what it means: readers treat it as legacy (which is what a pre-migration deploy
+// is), while the operator tool refuses to flip. Callers must distinguish it from
+// every other error — "the table is not there yet" and "the authority is
+// unreachable" have opposite safe answers once the counter era has begun.
+func ReadStateContext(deadline context.Context, ctx *config.Context) (State, error) {
 	if ctx == nil {
 		return State{}, errors.New("botevent: nil ctx, cannot read allocator state")
 	}
@@ -93,14 +104,31 @@ func ReadState(ctx *config.Context) (State, error) {
 	}
 	count, err := ctx.DB().SelectBySql(
 		"SELECT `mode`, `epoch`, `cutover_floor` FROM `"+stateTable+"` WHERE `singleton_id`=?",
-		stateSingletonID).Load(&row)
+		stateSingletonID).LoadContext(deadline, &row)
 	if err != nil {
+		if isMissingTable(err) {
+			// A pre-migration deploy: the same answer as a missing row, and it must not
+			// be confused with an unreachable authority.
+			return State{}, ErrStateMissing
+		}
 		return State{}, fmt.Errorf("botevent: read allocator state: %w", err)
 	}
 	if count == 0 {
 		return State{}, ErrStateMissing
 	}
 	return State{Mode: row.Mode, Epoch: row.Epoch, CutoverFloor: row.CutoverFloor}, nil
+}
+
+// isMissingTable reports whether err is MySQL's "table doesn't exist" (1146).
+//
+// Matched on the driver's error number rather than the message so it survives a
+// server locale change. It matters because a deploy that has not run the migration
+// yet, and a deploy whose DB is unreachable, are the same *error* to dbr and
+// opposite *states* to the allocator: one is legitimately legacy, the other is
+// unknown and must not downgrade a process that has already issued counter ids.
+func isMissingTable(err error) bool {
+	var mysqlErr *mysql.MySQLError
+	return errors.As(err, &mysqlErr) && mysqlErr.Number == 1146
 }
 
 // Activate flips the state row from legacy to incr under a row lock, validating the
@@ -168,9 +196,12 @@ func Activate(ctx *config.Context, floor, observedMax int64) (bool, uint64, erro
 //
 // Used by the seed as one more floor source. Best-effort: an unreadable row must not
 // fail an allocation, because the other floor sources (queue ceiling, legacy row,
-// durable high-water) already cover the cases this one is a backstop for.
+// durable high-water) already cover the cases this one is a backstop for. Deadlined
+// like every other DB read on this path — it runs inside a held msgSem slot.
 func stateFloorOrZero(ctx *config.Context) int64 {
-	st, err := ReadState(ctx)
+	deadline, cancel := context.WithTimeout(context.Background(), authorityTimeout)
+	defer cancel()
+	st, err := ReadStateContext(deadline, ctx)
 	if err != nil {
 		return 0
 	}

--- a/pkg/botevent/state.go
+++ b/pkg/botevent/state.go
@@ -1,0 +1,178 @@
+package botevent
+
+// #697: the DB-authoritative state for the bot event id allocator.
+//
+// # Why the state is not in Redis
+//
+// The allocator itself must stay in Redis: `saveRobotMessage` allocates inside a
+// `msgSem` slot and cannot afford a DB round trip per message (GenSeq amortised one
+// over 1000 ids; a DB sequence would be one per id).
+//
+// The *activation state* is a different question, and review found the answer was
+// wrong. Production runs `appendonly no` with only RDB snapshots, so a Redis-only
+// mode key regresses with the snapshot. Losing it dropped the allocator back to
+// legacy `GenSeq` — whose ids sit **below** everything the counter had already
+// issued, so new events land under live consumer cursors and are permanently
+// invisible. That is #697 mirrored, caused by its own fix.
+//
+// So the authority lives here, in a table that does not share Redis's recovery
+// domain, and the Redis key is only a **mirror**. When the mirror is missing the
+// allocator reads this row and, if activated, rebuilds the mirror and re-seeds
+// rather than degrading.
+//
+// # Deliberately aligned with #627, deliberately not a copy
+//
+// Same shape as `octo_message_extra_version_state`: mode / epoch / cutover_floor, a
+// `FOR UPDATE` compare-and-set flip, and a floor validated against observed maxima.
+//
+// What is **not** reused is that design's `FOR SHARE` drain barrier. It works there
+// because every `message_extra` writer is already inside a DB transaction and can
+// hold the state row until it commits. A `robotEvent` writer is `INCR` + `ZADD` with
+// no transaction at all, so there is nothing to hold a lock until — and wrapping
+// each allocation in a transaction just to borrow the barrier would reintroduce the
+// per-message DB round trip the allocator exists to avoid.
+//
+// The consequence is honest and must stay documented: this design cannot drain
+// in-flight writers at the flip. It relies on the operator having confirmed that no
+// pre-fix replica is running, plus a brief write pause around the flip. See
+// tools/botevent-seq.
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+)
+
+const (
+	// stateTable is the singleton state row's table.
+	stateTable = "octo_bot_event_seq_state"
+
+	// stateSingletonID is the only permitted primary key.
+	stateSingletonID = 1
+
+	// StateModeLegacy delegates to GenSeq. Seeded value, so a deploy is inert.
+	StateModeLegacy = 0
+
+	// StateModeIncr allocates from the Redis counter.
+	StateModeIncr = 1
+)
+
+// ErrFloorTooLow mirrors msgextraseq: a cutover floor at or below what has already
+// been issued would let post-activation ids land under a live consumer cursor.
+var ErrFloorTooLow = errors.New("botevent: cutover floor is below the observed maximum")
+
+// ErrStateMissing means the migration has not run. Treated as legacy by readers so
+// a pre-migration deploy behaves like the old binary, and as a hard error by the
+// operator tool so activation cannot be attempted blind.
+var ErrStateMissing = errors.New("botevent: allocator state row is missing")
+
+// State is the authoritative allocator state.
+type State struct {
+	Mode         int
+	Epoch        uint64
+	CutoverFloor int64
+}
+
+// Activated reports whether the counter is the authoritative allocator.
+func (s State) Activated() bool { return s.Mode == StateModeIncr }
+
+// ReadState reads the singleton row.
+//
+// A missing row returns ErrStateMissing rather than a zero State, so callers choose
+// what it means: readers fall back to legacy (safe before the migration), while the
+// operator tool refuses to flip.
+func ReadState(ctx *config.Context) (State, error) {
+	if ctx == nil {
+		return State{}, errors.New("botevent: nil ctx, cannot read allocator state")
+	}
+	var row struct {
+		Mode         int    `db:"mode"`
+		Epoch        uint64 `db:"epoch"`
+		CutoverFloor int64  `db:"cutover_floor"`
+	}
+	count, err := ctx.DB().SelectBySql(
+		"SELECT `mode`, `epoch`, `cutover_floor` FROM `"+stateTable+"` WHERE `singleton_id`=?",
+		stateSingletonID).Load(&row)
+	if err != nil {
+		return State{}, fmt.Errorf("botevent: read allocator state: %w", err)
+	}
+	if count == 0 {
+		return State{}, ErrStateMissing
+	}
+	return State{Mode: row.Mode, Epoch: row.Epoch, CutoverFloor: row.CutoverFloor}, nil
+}
+
+// Activate flips the state row from legacy to incr under a row lock, validating the
+// floor first.
+//
+// The `FOR UPDATE` here is **not** a drain barrier — see the file header. It only
+// serialises concurrent operators and makes the read-validate-write atomic. Returns
+// flipped=false with a nil error when the row is already activated, so the tool is
+// idempotent.
+func Activate(ctx *config.Context, floor, observedMax int64) (bool, uint64, error) {
+	if ctx == nil {
+		return false, 0, errors.New("botevent: nil ctx, cannot activate")
+	}
+	tx, err := ctx.DB().Begin()
+	if err != nil {
+		return false, 0, fmt.Errorf("botevent: begin activation tx: %w", err)
+	}
+	defer tx.RollbackUnlessCommitted()
+
+	var locked struct {
+		Mode  int    `db:"mode"`
+		Epoch uint64 `db:"epoch"`
+	}
+	count, err := tx.SelectBySql(
+		"SELECT `mode`, `epoch` FROM `"+stateTable+"` WHERE `singleton_id`=? FOR UPDATE",
+		stateSingletonID).Load(&locked)
+	if err != nil {
+		return false, 0, fmt.Errorf("botevent: lock allocator state: %w", err)
+	}
+	if count == 0 {
+		return false, 0, ErrStateMissing
+	}
+	if locked.Mode == StateModeIncr {
+		return false, locked.Epoch, nil
+	}
+	// The floor must clear everything legacy could still hand out. Refusing here is
+	// the difference between an activation and an outage: a floor below the observed
+	// maximum puts the first activated ids under cursors clients already hold.
+	if floor <= observedMax {
+		return false, 0, fmt.Errorf("%w: floor=%d observed max=%d", ErrFloorTooLow, floor, observedMax)
+	}
+	res, err := tx.UpdateBySql(
+		"UPDATE `"+stateTable+"` SET `mode`=?, `epoch`=?, `cutover_floor`=? "+
+			"WHERE `singleton_id`=? AND `mode`=?",
+		StateModeIncr, locked.Epoch+1, floor, stateSingletonID, StateModeLegacy).Exec()
+	if err != nil {
+		return false, 0, fmt.Errorf("botevent: flip allocator state: %w", err)
+	}
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return false, 0, fmt.Errorf("botevent: flip allocator state rows: %w", err)
+	}
+	if affected != 1 {
+		// The row was locked FOR UPDATE, so a mode-conditional UPDATE must match
+		// exactly one row. Anything else means the row changed underneath the lock.
+		return false, 0, fmt.Errorf("botevent: flip matched %d rows, expected 1", affected)
+	}
+	if err := tx.Commit(); err != nil {
+		return false, 0, fmt.Errorf("botevent: commit activation: %w", err)
+	}
+	return true, locked.Epoch + 1, nil
+}
+
+// stateFloorOrZero returns the recorded cutover floor, or 0 when unreadable.
+//
+// Used by the seed as one more floor source. Best-effort: an unreadable row must not
+// fail an allocation, because the other floor sources (queue ceiling, legacy row,
+// durable high-water) already cover the cases this one is a backstop for.
+func stateFloorOrZero(ctx *config.Context) int64 {
+	st, err := ReadState(ctx)
+	if err != nil {
+		return 0
+	}
+	return st.CutoverFloor
+}

--- a/pkg/botevent/state.go
+++ b/pkg/botevent/state.go
@@ -191,19 +191,3 @@ func Activate(ctx *config.Context, floor, observedMax int64) (bool, uint64, erro
 	}
 	return true, locked.Epoch + 1, nil
 }
-
-// stateFloorOrZero returns the recorded cutover floor, or 0 when unreadable.
-//
-// Used by the seed as one more floor source. Best-effort: an unreadable row must not
-// fail an allocation, because the other floor sources (queue ceiling, legacy row,
-// durable high-water) already cover the cases this one is a backstop for. Deadlined
-// like every other DB read on this path — it runs inside a held msgSem slot.
-func stateFloorOrZero(ctx *config.Context) int64 {
-	deadline, cancel := context.WithTimeout(context.Background(), authorityTimeout)
-	defer cancel()
-	st, err := ReadStateContext(deadline, ctx)
-	if err != nil {
-		return 0
-	}
-	return st.CutoverFloor
-}

--- a/tools/botevent-seq/main.go
+++ b/tools/botevent-seq/main.go
@@ -112,6 +112,14 @@ type evidence struct {
 	failures int
 }
 
+const queueScanPageSize int64 = 500
+
+type queueScoreStats struct {
+	members    int
+	duplicates int
+	maxScore   int64
+}
+
 func (e evidence) observedMax() int64 {
 	m := e.maxQueueScore
 	if e.maxLegacyMinSeq > m {
@@ -159,26 +167,56 @@ func gather(ctx *config.Context, client *rd.Client, sample int) evidence {
 	ev.inspected = len(inspect)
 
 	for _, k := range inspect {
-		members, err := client.ZRangeWithScores(k, 0, -1).Result()
+		stats, err := scanQueueScores(func(start, stop int64) ([]rd.Z, error) {
+			return client.ZRangeWithScores(k, start, stop).Result()
+		})
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "  %s: read failed: %v\n", k, err)
 			ev.failures++
 			continue
 		}
-		seen := make(map[float64]struct{}, len(members))
-		for _, m := range members {
-			seen[m.Score] = struct{}{}
-			if int64(m.Score) > ev.maxQueueScore {
-				ev.maxQueueScore = int64(m.Score)
-			}
+		if stats.maxScore > ev.maxQueueScore {
+			ev.maxQueueScore = stats.maxScore
 		}
-		if dup := len(members) - len(seen); dup > 0 {
+		if stats.duplicates > 0 {
 			ev.dupQueues++
-			ev.dupMembers += dup
-			fmt.Printf("  COLLISIONS %s: members=%d distinct=%d dup=%d\n", k, len(members), len(seen), dup)
+			ev.dupMembers += stats.duplicates
+			fmt.Printf("  COLLISIONS %s: members=%d distinct=%d dup=%d\n",
+				k, stats.members, stats.members-stats.duplicates, stats.duplicates)
 		}
 	}
 	return ev
+}
+
+// scanQueueScores reads one sorted set in bounded rank pages and counts adjacent equal
+// scores as duplicates. ZRANGE orders by score and then member, so equal scores remain
+// adjacent even across page boundaries; retaining only the previous score keeps memory O(1)
+// regardless of queue size and caps every Redis response at queueScanPageSize members.
+func scanQueueScores(fetch func(start, stop int64) ([]rd.Z, error)) (queueScoreStats, error) {
+	var stats queueScoreStats
+	var previous float64
+	havePrevious := false
+	for start := int64(0); ; {
+		page, err := fetch(start, start+queueScanPageSize-1)
+		if err != nil {
+			return queueScoreStats{}, err
+		}
+		for _, member := range page {
+			stats.members++
+			if havePrevious && member.Score == previous {
+				stats.duplicates++
+			}
+			previous = member.Score
+			havePrevious = true
+			if score := int64(member.Score); score > stats.maxScore {
+				stats.maxScore = score
+			}
+		}
+		if int64(len(page)) < queueScanPageSize {
+			return stats, nil
+		}
+		start += int64(len(page))
+	}
 }
 
 // maxSeqByPrefix returns the highest min_seq across every `seq` row in a namespace.

--- a/tools/botevent-seq/main.go
+++ b/tools/botevent-seq/main.go
@@ -266,6 +266,7 @@ func activate(ctx *config.Context, client *rd.Client, floor int64, sample int) {
 		fatal("refusing floor=%d: it must be positive and at most %d, above which int64 ids no "+
 			"longer have distinct float64 sorted-set scores", floor, int64(maxSafeFloor))
 	}
+	refuseUnauthorizedMirror(ctx, client)
 	fmt.Printf("\nactivating with floor=%d (observed max=%d)\n", floor, ev.observedMax())
 
 	flipped, epoch, err := botevent.Activate(ctx, floor, ev.observedMax())
@@ -303,6 +304,46 @@ func activate(ctx *config.Context, client *rd.Client, floor int64, sample int) {
 // It must be the exact spelling the allocator validates (botevent.MirrorValue): a bare
 // `incr` is only a claim, and every replica would keep re-reading the authority until
 // somebody wrote the real value.
+// refuseUnauthorizedMirror stops an activation while a mirror claiming activation is
+// already present against a legacy authority.
+//
+// Two reasons, and the second is the one that is easy to miss:
+//
+//   - It is evidence that this Redis is not in the state the operator thinks it is —
+//     someone wrote that key, or it is shared with another environment, or a snapshot from
+//     an activated era was restored. Any of those wants a human look before an
+//     irreversible flip.
+//   - The allocator's repair for such a key is to delete it, and the first activation
+//     produces `incr:1` — byte-identical to a forged `incr:1`. Removing the precondition
+//     here means the delete can never race the genuine mirror write. Replicas would
+//     recover on their own even if it did (they would consult the authority and rebuild),
+//     but "recovers on its own" is not a thing to spend at a supervised step.
+//
+// Runs after the floor checks so the operator sees every other problem in one pass.
+func refuseUnauthorizedMirror(ctx *config.Context, client *rd.Client) {
+	v, err := client.Get(botevent.ModeKey).Result()
+	if err == rd.Nil {
+		return
+	}
+	if err != nil {
+		fatal("cannot read the mode mirror (%v); refusing to activate without knowing whether a "+
+			"stale one is present", err)
+	}
+	if _, ok := botevent.ParseMirrorEpoch(v); !ok {
+		// Not a claim of activation. A malformed value is worth reporting but does not
+		// interact with the flip: the allocator treats it as absent.
+		fmt.Fprintf(os.Stderr, "note: %s holds %q, which is not a valid mirror value; allocators "+
+			"treat it as absent and it will be overwritten by this activation\n", botevent.ModeKey, v)
+		return
+	}
+	fatal("refusing to activate: %s already holds %q while the authority says legacy.\n"+
+		"Nothing should have written that — it means this Redis was activated before, is shared "+
+		"with another environment, or was restored from an activated snapshot. Confirm which, "+
+		"then DEL the key and rerun.\n"+
+		"Allocators are meanwhile ignoring it and staying on the legacy allocator "+
+		"(dmwork_bot_event_seq_mirror_unauthorized_total is counting it).", botevent.ModeKey, v)
+}
+
 func writeMirror(client *rd.Client, epoch uint64) {
 	if err := client.Set(botevent.ModeKey, botevent.MirrorValue(epoch), 0).Err(); err != nil {
 		fmt.Fprintf(os.Stderr, "warning: authority is at epoch %d but the mirror write failed "+

--- a/tools/botevent-seq/main.go
+++ b/tools/botevent-seq/main.go
@@ -3,8 +3,10 @@
 //
 // The authority is the `octo_bot_event_seq_state` row in MySQL, not the Redis key.
 // The Redis key is a mirror that lets the hot path check the mode inside the same Lua
-// script as the allocation; a lost mirror is rebuilt from this row by the allocator
-// itself. Writing only Redis would leave activation state in an instance running
+// script as the allocation. A lost mirror can eventually be rebuilt from this row by
+// an allocator after its negative belief expires, but publishing the mirror is still a
+// required cutover step: this command fails and writes must stay paused if that write
+// does not complete. Writing only Redis would leave activation state in an instance running
 // `appendonly no`, where an RDB rollback would silently drop every replica back to
 // the legacy allocator — whose lower ids land beneath live consumer cursors.
 //
@@ -37,6 +39,19 @@ import (
 	"github.com/spf13/viper"
 )
 
+const activationPreconditions = `activate preconditions this tool CANNOT check:
+  1. Mininglamp-OSS/octo-server#704 is closed, including an independently reviewed
+     cutover floor that cannot inherit a regressed legacy min_seq and land below a
+     cursor already held by a consumer. Merging or deploying #702 is not activation.
+  2. EVERY replica runs the post-#697 image. Activating while a pre-fix replica still
+     allocates from GenSeq puts two id sources on one queue, which is the bug (#697),
+     not the fix.
+  3. Bot-event writes are paused for a few seconds around the flip. This design has no
+     drain barrier (a robotEvent writer is INCR + ZADD with no transaction), so a
+     request that resolved legacy before the flip can otherwise publish a low id after it.
+
+`
+
 func main() {
 	configFile := flag.String("config", "configs/tsdd.yaml", "octo-server config file")
 	action := flag.String("action", "preflight", "preflight | activate")
@@ -59,19 +74,10 @@ func main() {
 	case "preflight":
 		preflight(ctx, client, *sample)
 	case "activate":
+		// -yes confirms these conditions; it must not hide them from the audit log.
+		fmt.Fprint(os.Stderr, activationPreconditions)
 		if !*yes {
-			fatal("activate requires -yes, and three preconditions this tool CANNOT check:\n" +
-				"  1. Mininglamp-OSS/octo-server#704 is closed. Counter-rollback detection is\n" +
-				"     currently tolerance-bounded and process-local, and both gaps are only\n" +
-				"     reachable AFTER activation. Merging #702 did not make activation safe.\n" +
-				"  2. EVERY replica runs the post-#697 image. Activating while a pre-fix replica\n" +
-				"     still allocates from GenSeq puts two id sources on one queue, which is the\n" +
-				"     bug (#697), not the fix.\n" +
-				"  3. Bot-event writes are paused for a few seconds around the flip. This design\n" +
-				"     deliberately has no drain barrier (a robotEvent writer is INCR + ZADD with no\n" +
-				"     transaction, so there is nothing to hold a lock until), so a request that has\n" +
-				"     already resolved `legacy` and not yet ZADDed will land a low id after the\n" +
-				"     flip. The pause is the only thing that closes that window.")
+			fatal("activate requires -yes after every precondition above has been verified")
 		}
 		activate(ctx, client, *floor, *sample)
 	default:
@@ -275,15 +281,18 @@ func activate(ctx *config.Context, client *rd.Client, floor int64, sample int) {
 	}
 	if !flipped {
 		fmt.Printf("already activated at epoch %d; nothing to do\n", epoch)
-		// Still reconcile the mirror: an already-flipped authority with a stale or
-		// missing mirror is the state that makes every replica read the authority on
-		// every allocation until one of them rewrites the key.
-		writeMirror(client, epoch)
+		// Still reconcile the mirror. Failure is operationally incomplete even though
+		// the authority was already committed, so preserve the write pause and exit non-zero.
+		if err := writeMirror(client, epoch); err != nil {
+			fatal("%v", err)
+		}
 		return
 	}
-	// Mirror second: the authority is committed, and the allocator rebuilds the
-	// mirror on its own if this write fails.
-	writeMirror(client, epoch)
+	// Mirror second: the authority is committed. A failure here leaves cached negative
+	// beliefs able to use GenSeq temporarily, so it is not a successful activation.
+	if err := writeMirror(client, epoch); err != nil {
+		fatal("%v", err)
+	}
 	fmt.Printf("activated at epoch %d. Replicas switch on their next allocation.\n\n", epoch)
 	fmt.Printf("Verify now:\n")
 	fmt.Printf("  - no `botevent: seed event id counter` errors in logs (a failed seed refuses\n")
@@ -299,11 +308,6 @@ func activate(ctx *config.Context, client *rd.Client, floor int64, sample int) {
 	fmt.Printf("the same loss, in reverse. Roll forward.\n")
 }
 
-// writeMirror publishes the generation-stamped mirror value.
-//
-// It must be the exact spelling the allocator validates (botevent.MirrorValue): a bare
-// `incr` is only a claim, and every replica would keep re-reading the authority until
-// somebody wrote the real value.
 // mirrorVerdict is what the pre-flip mirror check decided.
 type mirrorVerdict int
 
@@ -400,11 +404,21 @@ func refuseUnauthorizedMirror(ctx *config.Context, client *rd.Client) {
 	}
 }
 
-func writeMirror(client *rd.Client, epoch uint64) {
-	if err := client.Set(botevent.ModeKey, botevent.MirrorValue(epoch), 0).Err(); err != nil {
-		fmt.Fprintf(os.Stderr, "warning: authority is at epoch %d but the mirror write failed "+
-			"(%v). Allocators will rebuild it from the DB on their next allocation.\n", epoch, err)
+// writeMirror publishes the generation-stamped mirror value.
+//
+// It must be the exact spelling the allocator validates (botevent.MirrorValue): a bare
+// `incr` is only a claim. Failure is returned because the MySQL authority is already
+// activated at this point while replicas may retain a negative belief for a bounded
+// interval; callers must exit non-zero and keep bot-event writes paused.
+func writeMirror(client *rd.Client, epoch uint64) error {
+	want := botevent.MirrorValue(epoch)
+	if err := client.Set(botevent.ModeKey, want, 0).Err(); err != nil {
+		return fmt.Errorf("authority is already activated at epoch %d, but writing Redis mirror "+
+			"%s=%q failed: %w; replicas may retain a legacy belief for up to %s, so keep "+
+			"bot-event writes paused until %s exists with expected value %q",
+			epoch, botevent.ModeKey, want, err, botevent.NegativeBeliefTTL(), botevent.ModeKey, want)
 	}
+	return nil
 }
 
 func readMirror(ctx *config.Context) (string, error) {

--- a/tools/botevent-seq/main.go
+++ b/tools/botevent-seq/main.go
@@ -1,16 +1,23 @@
-// Command botevent-seq is the operator side of the #697 fix: it reports whether
-// the monotonic bot-event-id allocator is active and flips it on.
+// Command botevent-seq is the operator side of the #697 fix: it reports the
+// allocator's authoritative state and flips it on.
 //
-// The flip is a runtime state change, not a deploy. It takes effect on every
-// replica at the moment the SET commits, because each allocation reads the mode
-// inside the same Redis script that allocates (pkg/botevent/seq.go).
+// The authority is the `octo_bot_event_seq_state` row in MySQL, not the Redis key.
+// The Redis key is a mirror that lets the hot path check the mode inside the same Lua
+// script as the allocation; a lost mirror is rebuilt from this row by the allocator
+// itself. Writing only Redis would leave activation state in an instance running
+// `appendonly no`, where an RDB rollback would silently drop every replica back to
+// the legacy allocator — whose lower ids land beneath live consumer cursors.
 //
-// Ordering matters and the tool cannot check it for you: activating while any
-// pre-fix replica is still running is unsafe. Those replicas allocate from
-// GenSeq blocks starting at the bottom, while activated replicas allocate above
-// the ceiling — so once a consumer's cursor reaches the new range, every id a
-// legacy replica issues behind it is permanently unreachable. Confirm every
-// replica runs the new image, then activate.
+// Ordering matters and the tool cannot check it for you: activating while any pre-fix
+// replica is still running is unsafe, because those replicas allocate from GenSeq
+// blocks starting at the bottom while activated replicas allocate above the ceiling.
+// Once a consumer's cursor reaches the new range, every id a legacy replica issues
+// behind it is permanently unreachable.
+//
+// This design deliberately does NOT have #627's `FOR SHARE` drain barrier: a
+// robotEvent writer is INCR + ZADD with no transaction, so there is nothing to hold a
+// lock until. Confirm every replica runs the new image, pause writes briefly, then
+// activate.
 package main
 
 import (
@@ -20,6 +27,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/Mininglamp-OSS/octo-lib/common"
 	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-server/pkg/botevent"
 	octoredis "github.com/Mininglamp-OSS/octo-server/pkg/redis"
@@ -31,44 +39,61 @@ func main() {
 	configFile := flag.String("config", "configs/tsdd.yaml", "octo-server config file")
 	action := flag.String("action", "preflight", "preflight | activate")
 	yes := flag.Bool("yes", false, "required for activate")
-	sample := flag.Int("sample", 20, "queues to inspect in preflight (0 = all)")
+	// Defaults to every queue: the rollout treats these totals as the activation
+	// floor evidence, so a sampled default would be a validation that silently
+	// checked 1% of production. Sampling stays available for a quick look.
+	sample := flag.Int("sample", 0, "inspect only the first N queues (0 = all; sampled output is NOT activation evidence)")
+	floor := flag.Int64("floor", 0, "explicit cutover floor (0 = use the computed recommendation)")
 	flag.Parse()
 
 	cfg, err := loadConfig(*configFile)
 	if err != nil {
 		fatal("%v", err)
 	}
+	ctx := config.NewContext(cfg)
 	client := octoredis.NewInstrumentedClient(cfg, func(o *rd.Options) { o.MaxRetries = 2 })
 
 	switch *action {
 	case "preflight":
-		preflight(client, *sample)
+		preflight(ctx, client, *sample)
 	case "activate":
 		if !*yes {
 			fatal("activate requires -yes. Confirm first that EVERY replica runs the post-#697 " +
 				"image: activating while a pre-fix replica still allocates from GenSeq puts two id " +
 				"sources on one queue, which is the bug (#697), not the fix.")
 		}
-		activate(client)
+		activate(ctx, client, *floor, *sample)
 	default:
 		fatal("unsupported -action %q", *action)
 	}
 }
 
-func currentMode(client *rd.Client) string {
-	v, err := client.Get(botevent.ModeKey).Result()
-	if err == rd.Nil {
-		return "(unset — legacy)"
-	}
-	if err != nil {
-		fatal("read mode: %v", err)
-	}
-	return v
+// evidence is everything the floor has to clear, gathered from all three sources the
+// brief requires: the queues, the legacy GenSeq rows, and the durable high-water marks.
+type evidence struct {
+	queues          int
+	inspected       int
+	sampled         bool
+	maxQueueScore   int64
+	maxLegacyMinSeq int64
+	maxHighWater    int64
+	dupQueues       int
+	dupMembers      int
 }
 
-func preflight(client *rd.Client, sample int) {
-	fmt.Printf("mode: %s\n", currentMode(client))
-	fmt.Printf("mode key: %s   counter prefix: %s\n\n", botevent.ModeKey, botevent.SeqKeyPrefix)
+func (e evidence) observedMax() int64 {
+	m := e.maxQueueScore
+	if e.maxLegacyMinSeq > m {
+		m = e.maxLegacyMinSeq
+	}
+	if e.maxHighWater > m {
+		m = e.maxHighWater
+	}
+	return m
+}
+
+func gather(ctx *config.Context, client *rd.Client, sample int) evidence {
+	var ev evidence
 
 	var keys []string
 	iter := client.Scan(0, botevent.QueueKeyPrefix+"*", 500).Iterator()
@@ -79,72 +104,149 @@ func preflight(client *rd.Client, sample int) {
 		fatal("scan queues: %v", err)
 	}
 	sort.Strings(keys)
-	fmt.Printf("bot event queues: %d\n", len(keys))
+	ev.queues = len(keys)
 
 	inspect := keys
 	if sample > 0 && len(inspect) > sample {
-		inspect = inspect[:sample]
-		fmt.Printf("inspecting the first %d (pass -sample 0 for all)\n", sample)
+		inspect, ev.sampled = inspect[:sample], true
 	}
+	ev.inspected = len(inspect)
 
-	// Collision count is the #697 symptom and the number to watch after
-	// activation: it must stop growing. Existing duplicates are not repaired by
-	// this change, so it does not go to zero.
-	totalDup, withDup := 0, 0
 	for _, k := range inspect {
+		robotID := strings.TrimPrefix(k, botevent.QueueKeyPrefix)
+
 		members, err := client.ZRangeWithScores(k, 0, -1).Result()
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "  %s: read failed: %v\n", k, err)
 			continue
 		}
-		seen := make(map[float64]int, len(members))
-		var maxScore float64
+		seen := make(map[float64]struct{}, len(members))
 		for _, m := range members {
-			seen[m.Score]++
-			if m.Score > maxScore {
-				maxScore = m.Score
+			seen[m.Score] = struct{}{}
+			if int64(m.Score) > ev.maxQueueScore {
+				ev.maxQueueScore = int64(m.Score)
 			}
 		}
-		dup := len(members) - len(seen)
-		if dup > 0 {
-			withDup++
-			totalDup += dup
-			robotID := strings.TrimPrefix(k, botevent.QueueKeyPrefix)
-			counter, _ := client.Get(botevent.SeqKey(robotID)).Int64()
-			fmt.Printf("  COLLISIONS %s: members=%d distinct=%d dup=%d maxScore=%.0f counter=%d\n",
-				k, len(members), len(seen), dup, maxScore, counter)
+		if dup := len(members) - len(seen); dup > 0 {
+			ev.dupQueues++
+			ev.dupMembers += dup
+			fmt.Printf("  COLLISIONS %s: members=%d distinct=%d dup=%d\n", k, len(members), len(seen), dup)
+		}
+
+		// The legacy GenSeq row is the upper bound on what the old allocator could
+		// have handed out for this bot, and the durable mark is what the counter had
+		// reached. Both are in MySQL, so neither regresses when Redis does.
+		if v := scalarSeq(ctx, "seq:"+common.RobotEventSeqKey+robotID); v > ev.maxLegacyMinSeq {
+			ev.maxLegacyMinSeq = v
+		}
+		if v := scalarSeq(ctx, botevent.HighWaterSeqKey(robotID)); v > ev.maxHighWater {
+			ev.maxHighWater = v
 		}
 	}
-	fmt.Printf("\nqueues inspected: %d   with duplicate scores: %d   duplicate members: %d\n",
-		len(inspect), withDup, totalDup)
-	fmt.Printf("\nAfter activation this duplicate count must stop increasing. It will not drop:\n")
-	fmt.Printf("existing duplicates are deliberately left alone — an ack deletes every member\n")
-	fmt.Printf("sharing a score, and there is no record of which of a pair was ever delivered.\n")
+	return ev
 }
 
-func activate(client *rd.Client) {
-	before := currentMode(client)
-	if before == botevent.ModeIncr {
-		fmt.Printf("already active (mode=%s), nothing to do\n", before)
-		return
+func scalarSeq(ctx *config.Context, key string) int64 {
+	var v int64
+	if _, err := ctx.DB().SelectBySql("SELECT min_seq FROM `seq` WHERE `key`=?", key).Load(&v); err != nil {
+		return 0
 	}
-	fmt.Printf("mode: %s -> %s\n", before, botevent.ModeIncr)
-	if err := client.Set(botevent.ModeKey, botevent.ModeIncr, 0).Err(); err != nil {
+	return v
+}
+
+func report(ctx *config.Context, ev evidence) int64 {
+	st, err := botevent.ReadState(ctx)
+	switch {
+	case err == botevent.ErrStateMissing:
+		fmt.Printf("state: MISSING — the migration has not run. Readers treat this as legacy.\n")
+	case err != nil:
+		fatal("read state: %v", err)
+	default:
+		mode := "legacy"
+		if st.Activated() {
+			mode = "incr (ACTIVATED)"
+		}
+		fmt.Printf("state: mode=%s epoch=%d cutover_floor=%d\n", mode, st.Epoch, st.CutoverFloor)
+	}
+
+	mirror, mErr := readMirror(ctx)
+	fmt.Printf("mirror (%s): %s\n\n", botevent.ModeKey, mirror)
+	if mErr != nil {
+		fmt.Fprintf(os.Stderr, "note: %v\n", mErr)
+	}
+
+	fmt.Printf("queues: %d   inspected: %d%s\n", ev.queues, ev.inspected,
+		map[bool]string{true: "  ** SAMPLED — not activation evidence, rerun with -sample 0 **"}[ev.sampled])
+	fmt.Printf("max queue score:      %d\n", ev.maxQueueScore)
+	fmt.Printf("max legacy min_seq:   %d\n", ev.maxLegacyMinSeq)
+	fmt.Printf("max durable high-water: %d\n", ev.maxHighWater)
+	fmt.Printf("observed max (all three): %d\n", ev.observedMax())
+	fmt.Printf("queues with duplicate scores: %d   duplicate members: %d\n", ev.dupQueues, ev.dupMembers)
+
+	recommended := ev.observedMax() + 2000
+	fmt.Printf("\nrecommended cutover floor: %d  (observed max + one reserved block + margin)\n", recommended)
+	fmt.Printf("\nAfter activation the duplicate count must stop increasing. It will not drop:\n")
+	fmt.Printf("existing duplicates are deliberately left alone — an ack deletes every member\n")
+	fmt.Printf("sharing a score, and there is no record of which of a pair was ever delivered.\n")
+	return recommended
+}
+
+func preflight(ctx *config.Context, client *rd.Client, sample int) {
+	ev := gather(ctx, client, sample)
+	report(ctx, ev)
+}
+
+func activate(ctx *config.Context, client *rd.Client, floor int64, sample int) {
+	ev := gather(ctx, client, sample)
+	if ev.sampled {
+		fatal("refusing to activate from sampled evidence; rerun without -sample")
+	}
+	recommended := report(ctx, ev)
+	if floor == 0 {
+		floor = recommended
+	}
+	fmt.Printf("\nactivating with floor=%d (observed max=%d)\n", floor, ev.observedMax())
+
+	flipped, epoch, err := botevent.Activate(ctx, floor, ev.observedMax())
+	if err != nil {
 		fatal("activate: %v", err)
 	}
-	fmt.Printf("activated. Every replica switches on its next allocation.\n\n")
+	if !flipped {
+		fmt.Printf("already activated at epoch %d; nothing to do\n", epoch)
+		return
+	}
+	// Mirror second: the authority is committed, and the allocator rebuilds the
+	// mirror on its own if this write fails.
+	if err := client.Set(botevent.ModeKey, botevent.ModeIncr, 0).Err(); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: authority flipped (epoch %d) but the mirror write failed "+
+			"(%v). Allocators will rebuild it from the DB on their next allocation.\n", epoch, err)
+	}
+	fmt.Printf("activated at epoch %d. Replicas switch on their next allocation.\n\n", epoch)
 	fmt.Printf("Verify now:\n")
 	fmt.Printf("  - no `botevent: seed event id counter` errors in logs (a failed seed refuses\n")
 	fmt.Printf("    the enqueue rather than issuing an unsafe id)\n")
-	fmt.Printf("  - re-run preflight: the duplicate count must stop growing\n")
-	fmt.Printf("  - bot events still flowing (POST /v1/bot/events returning results)\n\n")
-	fmt.Printf("There is no online deactivate. Going back means every counter-issued id is\n")
-	fmt.Printf("above what GenSeq would hand out next, so legacy ids would land below consumer\n")
-	fmt.Printf("cursors — the same loss, in reverse. Roll forward.\n")
+	fmt.Printf("  - rerun preflight: the duplicate count must stop growing\n")
+	fmt.Printf("  - bot events still flowing (POST /v1/bot/events returning results)\n")
+	fmt.Printf("  - then roll out OCTO_BOTEVENT_EXPECTED_MODE=incr so a lost mirror AND a lost\n")
+	fmt.Printf("    authority row fail closed instead of degrading\n\n")
+	fmt.Printf("There is no online deactivate. Going back means every counter-issued id is above\n")
+	fmt.Printf("what GenSeq would hand out next, so legacy ids would land below consumer cursors —\n")
+	fmt.Printf("the same loss, in reverse. Roll forward.\n")
 }
 
-// loadConfig mirrors tools/msgextra-version so both operator tools resolve the
-// same file plus the same TS_* environment overrides.
+func readMirror(ctx *config.Context) (string, error) {
+	v, err := ctx.GetRedisConn().GetString(botevent.ModeKey)
+	if err != nil {
+		return "(unreadable)", fmt.Errorf("read mirror: %w", err)
+	}
+	if v == "" {
+		return "(absent — allocators will rebuild it from the authority)", nil
+	}
+	return v, nil
+}
+
+// loadConfig mirrors tools/msgextra-version so both operator tools resolve the same
+// file plus the same TS_* environment overrides.
 func loadConfig(path string) (*config.Config, error) {
 	vp := viper.New()
 	vp.SetConfigFile(path)

--- a/tools/botevent-seq/main.go
+++ b/tools/botevent-seq/main.go
@@ -167,9 +167,14 @@ func gather(ctx *config.Context, client *rd.Client, sample int) evidence {
 	ev.inspected = len(inspect)
 
 	for _, k := range inspect {
-		stats, err := scanQueueScores(func(start, stop int64) ([]rd.Z, error) {
-			return client.ZRangeWithScores(k, start, stop).Result()
-		})
+		stats, err := inspectQueueScores(
+			func() ([]rd.Z, error) {
+				return client.ZRevRangeWithScores(k, 0, 0).Result()
+			},
+			func(start, stop int64) ([]rd.Z, error) {
+				return client.ZRangeWithScores(k, start, stop).Result()
+			},
+		)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "  %s: read failed: %v\n", k, err)
 			ev.failures++
@@ -188,10 +193,38 @@ func gather(ctx *config.Context, client *rd.Client, sample int) evidence {
 	return ev
 }
 
+// inspectQueueScores captures the load-bearing maximum with one atomic Redis command,
+// then gathers diagnostic duplicate counts in bounded rank pages.
+//
+// The separation is deliberate. Pausing producers at cutover does not pause consumer ACKs:
+// ZREM from the low end shifts subsequent ranks, so a paged walk can stop before observing
+// the surviving high end. A ZREVRANGE 0 0 result taken before that walk is an upper bound
+// under ACK-only mutation and therefore safe to validate an irreversible floor against.
+func inspectQueueScores(fetchMax func() ([]rd.Z, error), fetchPage func(start, stop int64) ([]rd.Z, error)) (queueScoreStats, error) {
+	top, err := fetchMax()
+	if err != nil {
+		return queueScoreStats{}, err
+	}
+	stats, err := scanQueueScores(fetchPage)
+	if err != nil {
+		return queueScoreStats{}, err
+	}
+	if len(top) > 0 {
+		atomicMax := int64(top[0].Score)
+		if atomicMax > stats.maxScore {
+			stats.maxScore = atomicMax
+		}
+	}
+	return stats, nil
+}
+
 // scanQueueScores reads one sorted set in bounded rank pages and counts adjacent equal
 // scores as duplicates. ZRANGE orders by score and then member, so equal scores remain
 // adjacent even across page boundaries; retaining only the previous score keeps memory O(1)
 // regardless of queue size and caps every Redis response at queueScanPageSize members.
+// Under concurrent ACKs these diagnostics may be a lower bound; inspectQueueScores obtains
+// the activation-critical maximum independently, so this best-effort walk cannot lower the
+// cutover floor.
 func scanQueueScores(fetch func(start, stop int64) ([]rd.Z, error)) (queueScoreStats, error) {
 	var stats queueScoreStats
 	var previous float64

--- a/tools/botevent-seq/main.go
+++ b/tools/botevent-seq/main.go
@@ -1,0 +1,165 @@
+// Command botevent-seq is the operator side of the #697 fix: it reports whether
+// the monotonic bot-event-id allocator is active and flips it on.
+//
+// The flip is a runtime state change, not a deploy. It takes effect on every
+// replica at the moment the SET commits, because each allocation reads the mode
+// inside the same Redis script that allocates (pkg/botevent/seq.go).
+//
+// Ordering matters and the tool cannot check it for you: activating while any
+// pre-fix replica is still running is unsafe. Those replicas allocate from
+// GenSeq blocks starting at the bottom, while activated replicas allocate above
+// the ceiling — so once a consumer's cursor reaches the new range, every id a
+// legacy replica issues behind it is permanently unreachable. Confirm every
+// replica runs the new image, then activate.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-server/pkg/botevent"
+	octoredis "github.com/Mininglamp-OSS/octo-server/pkg/redis"
+	rd "github.com/go-redis/redis"
+	"github.com/spf13/viper"
+)
+
+func main() {
+	configFile := flag.String("config", "configs/tsdd.yaml", "octo-server config file")
+	action := flag.String("action", "preflight", "preflight | activate")
+	yes := flag.Bool("yes", false, "required for activate")
+	sample := flag.Int("sample", 20, "queues to inspect in preflight (0 = all)")
+	flag.Parse()
+
+	cfg, err := loadConfig(*configFile)
+	if err != nil {
+		fatal("%v", err)
+	}
+	client := octoredis.NewInstrumentedClient(cfg, func(o *rd.Options) { o.MaxRetries = 2 })
+
+	switch *action {
+	case "preflight":
+		preflight(client, *sample)
+	case "activate":
+		if !*yes {
+			fatal("activate requires -yes. Confirm first that EVERY replica runs the post-#697 " +
+				"image: activating while a pre-fix replica still allocates from GenSeq puts two id " +
+				"sources on one queue, which is the bug (#697), not the fix.")
+		}
+		activate(client)
+	default:
+		fatal("unsupported -action %q", *action)
+	}
+}
+
+func currentMode(client *rd.Client) string {
+	v, err := client.Get(botevent.ModeKey).Result()
+	if err == rd.Nil {
+		return "(unset — legacy)"
+	}
+	if err != nil {
+		fatal("read mode: %v", err)
+	}
+	return v
+}
+
+func preflight(client *rd.Client, sample int) {
+	fmt.Printf("mode: %s\n", currentMode(client))
+	fmt.Printf("mode key: %s   counter prefix: %s\n\n", botevent.ModeKey, botevent.SeqKeyPrefix)
+
+	var keys []string
+	iter := client.Scan(0, botevent.QueueKeyPrefix+"*", 500).Iterator()
+	for iter.Next() {
+		keys = append(keys, iter.Val())
+	}
+	if err := iter.Err(); err != nil {
+		fatal("scan queues: %v", err)
+	}
+	sort.Strings(keys)
+	fmt.Printf("bot event queues: %d\n", len(keys))
+
+	inspect := keys
+	if sample > 0 && len(inspect) > sample {
+		inspect = inspect[:sample]
+		fmt.Printf("inspecting the first %d (pass -sample 0 for all)\n", sample)
+	}
+
+	// Collision count is the #697 symptom and the number to watch after
+	// activation: it must stop growing. Existing duplicates are not repaired by
+	// this change, so it does not go to zero.
+	totalDup, withDup := 0, 0
+	for _, k := range inspect {
+		members, err := client.ZRangeWithScores(k, 0, -1).Result()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "  %s: read failed: %v\n", k, err)
+			continue
+		}
+		seen := make(map[float64]int, len(members))
+		var maxScore float64
+		for _, m := range members {
+			seen[m.Score]++
+			if m.Score > maxScore {
+				maxScore = m.Score
+			}
+		}
+		dup := len(members) - len(seen)
+		if dup > 0 {
+			withDup++
+			totalDup += dup
+			robotID := strings.TrimPrefix(k, botevent.QueueKeyPrefix)
+			counter, _ := client.Get(botevent.SeqKey(robotID)).Int64()
+			fmt.Printf("  COLLISIONS %s: members=%d distinct=%d dup=%d maxScore=%.0f counter=%d\n",
+				k, len(members), len(seen), dup, maxScore, counter)
+		}
+	}
+	fmt.Printf("\nqueues inspected: %d   with duplicate scores: %d   duplicate members: %d\n",
+		len(inspect), withDup, totalDup)
+	fmt.Printf("\nAfter activation this duplicate count must stop increasing. It will not drop:\n")
+	fmt.Printf("existing duplicates are deliberately left alone — an ack deletes every member\n")
+	fmt.Printf("sharing a score, and there is no record of which of a pair was ever delivered.\n")
+}
+
+func activate(client *rd.Client) {
+	before := currentMode(client)
+	if before == botevent.ModeIncr {
+		fmt.Printf("already active (mode=%s), nothing to do\n", before)
+		return
+	}
+	fmt.Printf("mode: %s -> %s\n", before, botevent.ModeIncr)
+	if err := client.Set(botevent.ModeKey, botevent.ModeIncr, 0).Err(); err != nil {
+		fatal("activate: %v", err)
+	}
+	fmt.Printf("activated. Every replica switches on its next allocation.\n\n")
+	fmt.Printf("Verify now:\n")
+	fmt.Printf("  - no `botevent: seed event id counter` errors in logs (a failed seed refuses\n")
+	fmt.Printf("    the enqueue rather than issuing an unsafe id)\n")
+	fmt.Printf("  - re-run preflight: the duplicate count must stop growing\n")
+	fmt.Printf("  - bot events still flowing (POST /v1/bot/events returning results)\n\n")
+	fmt.Printf("There is no online deactivate. Going back means every counter-issued id is\n")
+	fmt.Printf("above what GenSeq would hand out next, so legacy ids would land below consumer\n")
+	fmt.Printf("cursors — the same loss, in reverse. Roll forward.\n")
+}
+
+// loadConfig mirrors tools/msgextra-version so both operator tools resolve the
+// same file plus the same TS_* environment overrides.
+func loadConfig(path string) (*config.Config, error) {
+	vp := viper.New()
+	vp.SetConfigFile(path)
+	if err := vp.ReadInConfig(); err != nil {
+		return nil, fmt.Errorf("read config %s: %w", path, err)
+	}
+	vp.SetEnvPrefix("TS")
+	vp.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
+	vp.AutomaticEnv()
+	cfg := config.New()
+	cfg.ConfigureWithViper(vp)
+	return cfg, nil
+}
+
+func fatal(f string, a ...interface{}) {
+	fmt.Fprintf(os.Stderr, "botevent-seq: "+f+"\n", a...)
+	os.Exit(1)
+}

--- a/tools/botevent-seq/main.go
+++ b/tools/botevent-seq/main.go
@@ -304,44 +304,100 @@ func activate(ctx *config.Context, client *rd.Client, floor int64, sample int) {
 // It must be the exact spelling the allocator validates (botevent.MirrorValue): a bare
 // `incr` is only a claim, and every replica would keep re-reading the authority until
 // somebody wrote the real value.
-// refuseUnauthorizedMirror stops an activation while a mirror claiming activation is
-// already present against a legacy authority.
+// mirrorVerdict is what the pre-flip mirror check decided.
+type mirrorVerdict int
+
+const (
+	// mirrorOK: nothing to say.
+	mirrorOK mirrorVerdict = iota
+	// mirrorNote: worth printing, does not stop the flip.
+	mirrorNote
+	// mirrorRefuse: stop.
+	mirrorRefuse
+)
+
+// judgeMirror decides what a pre-flip mirror value means, given whether the authority says
+// the allocator is already activated.
 //
-// Two reasons, and the second is the one that is easy to miss:
+// Split out from the Redis/MySQL plumbing so the matrix is testable without either — this
+// tool carries the whole activation procedure and had no tests at all, which is how the bug
+// below shipped (review round 7 P2-1, found independently by two reviewers).
 //
-//   - It is evidence that this Redis is not in the state the operator thinks it is —
-//     someone wrote that key, or it is shared with another environment, or a snapshot from
-//     an activated era was restored. Any of those wants a human look before an
-//     irreversible flip.
-//   - The allocator's repair for such a key is to delete it, and the first activation
-//     produces `incr:1` — byte-identical to a forged `incr:1`. Removing the precondition
-//     here means the delete can never race the genuine mirror write. Replicas would
-//     recover on their own even if it did (they would consult the authority and rebuild),
-//     but "recovers on its own" is not a thing to spend at a supervised step.
-//
-// Runs after the floor checks so the operator sees every other problem in one pass.
-func refuseUnauthorizedMirror(ctx *config.Context, client *rd.Client) {
-	v, err := client.Get(botevent.ModeKey).Result()
-	if err == rd.Nil {
-		return
+// `activated` is the authority's answer, and reading it first is the entire fix. The previous
+// revision refused on *any* parseable mirror claim without consulting the state row, so
+// re-running `activate -yes` on an already-activated system — a correct mirror, the normal
+// state after a successful flip — died with "already holds incr:1 while the authority says
+// legacy … Confirm which, then DEL the key and rerun". Every clause was false in the common
+// case, it told the operator to delete the live mirror, and it made the documented
+// "already activated; reconcile the mirror" branch unreachable whenever a mirror existed.
+func judgeMirror(activated bool, mirror string, absent bool) (mirrorVerdict, string) {
+	if absent {
+		return mirrorOK, ""
 	}
-	if err != nil {
-		fatal("cannot read the mode mirror (%v); refusing to activate without knowing whether a "+
-			"stale one is present", err)
+	epoch, claims := botevent.ParseMirrorEpoch(mirror)
+	if !claims {
+		// Not a claim of activation. Worth reporting, but it does not interact with the
+		// flip: the allocator treats a malformed value as absent, and this run overwrites it.
+		return mirrorNote, fmt.Sprintf("note: %s holds %q, which is not a valid mirror value; "+
+			"allocators treat it as absent and it will be overwritten\n", botevent.ModeKey, mirror)
 	}
-	if _, ok := botevent.ParseMirrorEpoch(v); !ok {
-		// Not a claim of activation. A malformed value is worth reporting but does not
-		// interact with the flip: the allocator treats it as absent.
-		fmt.Fprintf(os.Stderr, "note: %s holds %q, which is not a valid mirror value; allocators "+
-			"treat it as absent and it will be overwritten by this activation\n", botevent.ModeKey, v)
-		return
+	if activated {
+		// The authority agrees. This is the ordinary re-run, and reconciling the mirror is
+		// exactly what the operator wants — `activate` is documented as idempotent.
+		return mirrorNote, fmt.Sprintf("note: %s already holds %q and the authority agrees "+
+			"(epoch %d); the mirror will be reconciled\n", botevent.ModeKey, mirror, epoch)
 	}
-	fatal("refusing to activate: %s already holds %q while the authority says legacy.\n"+
+	return mirrorRefuse, fmt.Sprintf("refusing to activate: %s holds %q while the authority "+
+		"says the allocator is NOT activated.\n"+
 		"Nothing should have written that — it means this Redis was activated before, is shared "+
 		"with another environment, or was restored from an activated snapshot. Confirm which, "+
 		"then DEL the key and rerun.\n"+
 		"Allocators are meanwhile ignoring it and staying on the legacy allocator "+
-		"(dmwork_bot_event_seq_mirror_unauthorized_total is counting it).", botevent.ModeKey, v)
+		"(dmwork_bot_event_seq_mirror_unauthorized_total is counting it). Note they do NOT "+
+		"delete it: round 7 of #697's review showed that deleting a mirror on the authority's "+
+		"word takes the fleet down when the authority is the party that regressed.",
+		botevent.ModeKey, mirror)
+}
+
+// refuseUnauthorizedMirror stops an activation while a mirror claiming activation sits
+// against an authority that says otherwise.
+//
+// That state means this Redis is not what the operator believes: someone wrote the key, it is
+// shared with another environment, or a snapshot from an activated era was restored. Any of
+// those wants a human look before an irreversible flip — and it is also the precondition for
+// the one residual window in the allocator's denial cooldown (see pkg/botevent/mode.go), so
+// checking it here is where that window gets closed in practice.
+//
+// Runs after the floor checks so the operator sees every other problem in one pass.
+func refuseUnauthorizedMirror(ctx *config.Context, client *rd.Client) {
+	v, err := client.Get(botevent.ModeKey).Result()
+	absent := err == rd.Nil
+	if err != nil && !absent {
+		fatal("cannot read the mode mirror (%v); refusing to activate without knowing whether a "+
+			"stale one is present", err)
+	}
+
+	// Read the authority before judging the mirror. Skipping this is what made a correct
+	// mirror look like a forged one.
+	activated := false
+	switch st, sErr := botevent.ReadState(ctx); {
+	case sErr == nil:
+		activated = st.Activated()
+	case errors.Is(sErr, botevent.ErrStateMissing):
+		// The migration has not run. Not activated, and a mirror claiming otherwise is
+		// exactly the case worth refusing on.
+	default:
+		fatal("cannot read the allocator state (%v); refusing to judge the mirror without it — "+
+			"that is the mistake this check was added to fix", sErr)
+	}
+
+	verdict, msg := judgeMirror(activated, v, absent)
+	switch verdict {
+	case mirrorRefuse:
+		fatal("%s", msg)
+	case mirrorNote:
+		fmt.Fprint(os.Stderr, msg)
+	}
 }
 
 func writeMirror(client *rd.Client, epoch uint64) {

--- a/tools/botevent-seq/main.go
+++ b/tools/botevent-seq/main.go
@@ -21,6 +21,8 @@
 package main
 
 import (
+	"database/sql"
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -58,9 +60,18 @@ func main() {
 		preflight(ctx, client, *sample)
 	case "activate":
 		if !*yes {
-			fatal("activate requires -yes. Confirm first that EVERY replica runs the post-#697 " +
-				"image: activating while a pre-fix replica still allocates from GenSeq puts two id " +
-				"sources on one queue, which is the bug (#697), not the fix.")
+			fatal("activate requires -yes, and three preconditions this tool CANNOT check:\n" +
+				"  1. Mininglamp-OSS/octo-server#704 is closed. Counter-rollback detection is\n" +
+				"     currently tolerance-bounded and process-local, and both gaps are only\n" +
+				"     reachable AFTER activation. Merging #702 did not make activation safe.\n" +
+				"  2. EVERY replica runs the post-#697 image. Activating while a pre-fix replica\n" +
+				"     still allocates from GenSeq puts two id sources on one queue, which is the\n" +
+				"     bug (#697), not the fix.\n" +
+				"  3. Bot-event writes are paused for a few seconds around the flip. This design\n" +
+				"     deliberately has no drain barrier (a robotEvent writer is INCR + ZADD with no\n" +
+				"     transaction, so there is nothing to hold a lock until), so a request that has\n" +
+				"     already resolved `legacy` and not yet ZADDed will land a low id after the\n" +
+				"     flip. The pause is the only thing that closes that window.")
 		}
 		activate(ctx, client, *floor, *sample)
 	default:
@@ -70,6 +81,15 @@ func main() {
 
 // evidence is everything the floor has to clear, gathered from all three sources the
 // brief requires: the queues, the legacy GenSeq rows, and the durable high-water marks.
+//
+// The queue scan alone is NOT enough, and an earlier revision of this tool made
+// exactly that mistake (review P1-8). Bots are discovered by `SCAN robotEvent:*`, so a
+// bot whose queue has fully drained — acked, or expired — has no key, contributes
+// nothing, and its `seq` rows were never read. Such a bot can still have clients
+// holding a high cursor and a `min_seq` that a lagging replica dragged backwards, so
+// the global floor would land below its live cursor while its own per-bot seed, reading
+// that same regressed row, could not catch it either. Both `seq` namespaces are
+// therefore also swept table-wide, independently of Redis.
 type evidence struct {
 	queues          int
 	inspected       int
@@ -79,6 +99,11 @@ type evidence struct {
 	maxHighWater    int64
 	dupQueues       int
 	dupMembers      int
+
+	// failures counts evidence that could not be collected: an unreadable queue, or a
+	// `seq` sweep that errored. Any failure makes the totals a lower bound, and a lower
+	// bound is not something to validate an irreversible flip against.
+	failures int
 }
 
 func (e evidence) observedMax() int64 {
@@ -94,6 +119,21 @@ func (e evidence) observedMax() int64 {
 
 func gather(ctx *config.Context, client *rd.Client, sample int) evidence {
 	var ev evidence
+
+	// Table-wide first, so the floor covers bots the queue scan cannot see at all.
+	// One query per namespace, no per-bot lookups.
+	if v, err := maxSeqByPrefix(ctx, "seq:"+common.RobotEventSeqKey); err != nil {
+		fmt.Fprintf(os.Stderr, "  sweep legacy seq rows failed: %v\n", err)
+		ev.failures++
+	} else {
+		ev.maxLegacyMinSeq = v
+	}
+	if v, err := maxSeqByPrefix(ctx, botevent.HighWaterSeqKey("")); err != nil {
+		fmt.Fprintf(os.Stderr, "  sweep high-water seq rows failed: %v\n", err)
+		ev.failures++
+	} else {
+		ev.maxHighWater = v
+	}
 
 	var keys []string
 	iter := client.Scan(0, botevent.QueueKeyPrefix+"*", 500).Iterator()
@@ -113,11 +153,10 @@ func gather(ctx *config.Context, client *rd.Client, sample int) evidence {
 	ev.inspected = len(inspect)
 
 	for _, k := range inspect {
-		robotID := strings.TrimPrefix(k, botevent.QueueKeyPrefix)
-
 		members, err := client.ZRangeWithScores(k, 0, -1).Result()
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "  %s: read failed: %v\n", k, err)
+			ev.failures++
 			continue
 		}
 		seen := make(map[float64]struct{}, len(members))
@@ -132,32 +171,32 @@ func gather(ctx *config.Context, client *rd.Client, sample int) evidence {
 			ev.dupMembers += dup
 			fmt.Printf("  COLLISIONS %s: members=%d distinct=%d dup=%d\n", k, len(members), len(seen), dup)
 		}
-
-		// The legacy GenSeq row is the upper bound on what the old allocator could
-		// have handed out for this bot, and the durable mark is what the counter had
-		// reached. Both are in MySQL, so neither regresses when Redis does.
-		if v := scalarSeq(ctx, "seq:"+common.RobotEventSeqKey+robotID); v > ev.maxLegacyMinSeq {
-			ev.maxLegacyMinSeq = v
-		}
-		if v := scalarSeq(ctx, botevent.HighWaterSeqKey(robotID)); v > ev.maxHighWater {
-			ev.maxHighWater = v
-		}
 	}
 	return ev
 }
 
-func scalarSeq(ctx *config.Context, key string) int64 {
-	var v int64
-	if _, err := ctx.DB().SelectBySql("SELECT min_seq FROM `seq` WHERE `key`=?", key).Load(&v); err != nil {
-		return 0
+// maxSeqByPrefix returns the highest min_seq across every `seq` row in a namespace.
+//
+// This is the query the per-bot point lookups could not replace: it does not need to
+// know which bots exist, so a drained queue cannot hide one. `_` and `%` are not
+// special in either namespace (both end in `:` after a fixed identifier), so the LIKE
+// pattern needs no escaping beyond the appended wildcard.
+func maxSeqByPrefix(ctx *config.Context, prefix string) (int64, error) {
+	var max sql.NullInt64
+	if _, err := ctx.DB().SelectBySql(
+		"SELECT MAX(min_seq) FROM `seq` WHERE `key` LIKE ?", prefix+"%").Load(&max); err != nil {
+		return 0, err
 	}
-	return v
+	if !max.Valid {
+		return 0, nil
+	}
+	return max.Int64, nil
 }
 
 func report(ctx *config.Context, ev evidence) int64 {
 	st, err := botevent.ReadState(ctx)
 	switch {
-	case err == botevent.ErrStateMissing:
+	case errors.Is(err, botevent.ErrStateMissing):
 		fmt.Printf("state: MISSING — the migration has not run. Readers treat this as legacy.\n")
 	case err != nil:
 		fatal("read state: %v", err)
@@ -178,10 +217,13 @@ func report(ctx *config.Context, ev evidence) int64 {
 	fmt.Printf("queues: %d   inspected: %d%s\n", ev.queues, ev.inspected,
 		map[bool]string{true: "  ** SAMPLED — not activation evidence, rerun with -sample 0 **"}[ev.sampled])
 	fmt.Printf("max queue score:      %d\n", ev.maxQueueScore)
-	fmt.Printf("max legacy min_seq:   %d\n", ev.maxLegacyMinSeq)
-	fmt.Printf("max durable high-water: %d\n", ev.maxHighWater)
+	fmt.Printf("max legacy min_seq:   %d  (whole `seq` namespace, not just bots with a live queue)\n", ev.maxLegacyMinSeq)
+	fmt.Printf("max durable high-water: %d  (whole `seq` namespace)\n", ev.maxHighWater)
 	fmt.Printf("observed max (all three): %d\n", ev.observedMax())
 	fmt.Printf("queues with duplicate scores: %d   duplicate members: %d\n", ev.dupQueues, ev.dupMembers)
+	if ev.failures > 0 {
+		fmt.Printf("\n** %d evidence source(s) could not be read — every total above is a LOWER BOUND **\n", ev.failures)
+	}
 
 	recommended := ev.observedMax() + 2000
 	fmt.Printf("\nrecommended cutover floor: %d  (observed max + one reserved block + margin)\n", recommended)
@@ -196,14 +238,33 @@ func preflight(ctx *config.Context, client *rd.Client, sample int) {
 	report(ctx, ev)
 }
 
+// maxSafeFloor is the highest cutover floor this tool will accept.
+//
+// Sorted-set scores are float64, so above 2^53 distinct int64 ids stop having distinct
+// scores — which recreates the pagination skip and the multi-member ack this whole
+// change removes, from the one command meant to prevent them (review P2-3). 2^50 leaves
+// three orders of magnitude of headroom above any plausible id and is still nowhere
+// near the precision boundary.
+const maxSafeFloor = 1 << 50
+
 func activate(ctx *config.Context, client *rd.Client, floor int64, sample int) {
 	ev := gather(ctx, client, sample)
 	if ev.sampled {
 		fatal("refusing to activate from sampled evidence; rerun without -sample")
 	}
+	if ev.failures > 0 {
+		fatal("refusing to activate from incomplete evidence: %d source(s) could not be read, so "+
+			"the observed maximum is a lower bound. A floor validated against a lower bound can "+
+			"still land beneath a live consumer cursor, which is the loss this flip exists to stop. "+
+			"Fix the read errors above and rerun.", ev.failures)
+	}
 	recommended := report(ctx, ev)
 	if floor == 0 {
 		floor = recommended
+	}
+	if floor <= 0 || floor > maxSafeFloor {
+		fatal("refusing floor=%d: it must be positive and at most %d, above which int64 ids no "+
+			"longer have distinct float64 sorted-set scores", floor, int64(maxSafeFloor))
 	}
 	fmt.Printf("\nactivating with floor=%d (observed max=%d)\n", floor, ev.observedMax())
 
@@ -213,25 +274,40 @@ func activate(ctx *config.Context, client *rd.Client, floor int64, sample int) {
 	}
 	if !flipped {
 		fmt.Printf("already activated at epoch %d; nothing to do\n", epoch)
+		// Still reconcile the mirror: an already-flipped authority with a stale or
+		// missing mirror is the state that makes every replica read the authority on
+		// every allocation until one of them rewrites the key.
+		writeMirror(client, epoch)
 		return
 	}
 	// Mirror second: the authority is committed, and the allocator rebuilds the
 	// mirror on its own if this write fails.
-	if err := client.Set(botevent.ModeKey, botevent.ModeIncr, 0).Err(); err != nil {
-		fmt.Fprintf(os.Stderr, "warning: authority flipped (epoch %d) but the mirror write failed "+
-			"(%v). Allocators will rebuild it from the DB on their next allocation.\n", epoch, err)
-	}
+	writeMirror(client, epoch)
 	fmt.Printf("activated at epoch %d. Replicas switch on their next allocation.\n\n", epoch)
 	fmt.Printf("Verify now:\n")
 	fmt.Printf("  - no `botevent: seed event id counter` errors in logs (a failed seed refuses\n")
 	fmt.Printf("    the enqueue rather than issuing an unsafe id)\n")
 	fmt.Printf("  - rerun preflight: the duplicate count must stop growing\n")
 	fmt.Printf("  - bot events still flowing (POST /v1/bot/events returning results)\n")
+	fmt.Printf("  - dmwork_bot_event_seq_mirror_unauthorized_total stays 0 (non-zero means some\n")
+	fmt.Printf("    replica saw a mode mirror the authority did not confirm)\n")
 	fmt.Printf("  - then roll out OCTO_BOTEVENT_EXPECTED_MODE=incr so a lost mirror AND a lost\n")
 	fmt.Printf("    authority row fail closed instead of degrading\n\n")
 	fmt.Printf("There is no online deactivate. Going back means every counter-issued id is above\n")
 	fmt.Printf("what GenSeq would hand out next, so legacy ids would land below consumer cursors —\n")
 	fmt.Printf("the same loss, in reverse. Roll forward.\n")
+}
+
+// writeMirror publishes the generation-stamped mirror value.
+//
+// It must be the exact spelling the allocator validates (botevent.MirrorValue): a bare
+// `incr` is only a claim, and every replica would keep re-reading the authority until
+// somebody wrote the real value.
+func writeMirror(client *rd.Client, epoch uint64) {
+	if err := client.Set(botevent.ModeKey, botevent.MirrorValue(epoch), 0).Err(); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: authority is at epoch %d but the mirror write failed "+
+			"(%v). Allocators will rebuild it from the DB on their next allocation.\n", epoch, err)
+	}
 }
 
 func readMirror(ctx *config.Context) (string, error) {

--- a/tools/botevent-seq/main_test.go
+++ b/tools/botevent-seq/main_test.go
@@ -3,8 +3,10 @@ package main
 import (
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/Mininglamp-OSS/octo-server/pkg/botevent"
+	rd "github.com/go-redis/redis"
 )
 
 // This is the first test file in tools/botevent-seq, and the reason it exists is that the
@@ -134,5 +136,54 @@ func TestMaxSafeFloorKeepsScoresDistinct(t *testing.T) {
 	if maxSafeFloor < 1<<40 {
 		t.Fatalf("maxSafeFloor = %d leaves too little headroom above plausible ids",
 			int64(maxSafeFloor))
+	}
+}
+
+// TestMirrorWriteFailureStopsActivationAndExplainsPause is the round-8 D-4 regression.
+//
+// Committing the MySQL flip but failing to publish the mirror leaves replicas with cached
+// negative beliefs on the legacy allocator until that cache expires. The operator command
+// must therefore fail non-zero (the caller treats this returned error as fatal), and the
+// message must tell the operator to keep writes paused instead of claiming the next
+// allocation repairs the state immediately.
+func TestMirrorWriteFailureStopsActivationAndExplainsPause(t *testing.T) {
+	client := rd.NewClient(&rd.Options{
+		Addr:         "127.0.0.1:1",
+		DialTimeout:  10 * time.Millisecond,
+		ReadTimeout:  10 * time.Millisecond,
+		WriteTimeout: 10 * time.Millisecond,
+		MaxRetries:   0,
+	})
+	defer client.Close()
+
+	err := writeMirror(client, 7)
+	if err == nil {
+		t.Fatal("mirror write failure returned nil; activate would exit 0 after an incomplete cutover")
+	}
+	for _, want := range []string{
+		"authority is already activated",
+		"keep bot-event writes paused",
+		botevent.ModeKey,
+		botevent.MirrorValue(7),
+		botevent.NegativeBeliefTTL().String(),
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("mirror write error does not contain %q: %v", want, err)
+		}
+	}
+}
+
+// TestActivationPreconditionsRemainVisibleWithYes pins the text printed for every activate
+// invocation. -yes confirms the operator read the warning; it must not suppress the warning.
+func TestActivationPreconditionsRemainVisibleWithYes(t *testing.T) {
+	for _, want := range []string{
+		"#704",
+		"cutover floor",
+		"EVERY replica",
+		"writes are paused",
+	} {
+		if !strings.Contains(activationPreconditions, want) {
+			t.Errorf("activation preconditions do not contain %q", want)
+		}
 	}
 }

--- a/tools/botevent-seq/main_test.go
+++ b/tools/botevent-seq/main_test.go
@@ -1,0 +1,138 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-server/pkg/botevent"
+)
+
+// This is the first test file in tools/botevent-seq, and the reason it exists is that the
+// tool carries the entire activation procedure, is the only component a human runs by hand
+// at the cutover, and had produced two review findings across two rounds with no tests at
+// all (#697 review round 7).
+//
+// judgeMirror is split out from the Redis/MySQL plumbing precisely so this matrix can be
+// covered without either.
+
+func TestJudgeMirror(t *testing.T) {
+	cases := []struct {
+		name        string
+		activated   bool
+		mirror      string
+		absent      bool
+		want        mirrorVerdict
+		msgContains string
+	}{
+		{
+			name:      "no mirror, not activated — the ordinary first flip",
+			activated: false,
+			absent:    true,
+			want:      mirrorOK,
+		},
+		{
+			name:      "no mirror, already activated — the documented mirror-repair case",
+			activated: true,
+			absent:    true,
+			want:      mirrorOK,
+		},
+		{
+			// The bug this file was added for: re-running `activate -yes` after a successful
+			// flip is the normal state, and the previous revision died on it with a message
+			// whose every clause was false, telling the operator to DEL the live mirror.
+			name:        "correct mirror, already activated — must be a note, not a refusal",
+			activated:   true,
+			mirror:      botevent.MirrorValue(1),
+			want:        mirrorNote,
+			msgContains: "the authority agrees",
+		},
+		{
+			// The case the check exists for: a mirror claiming activation the authority has
+			// not granted.
+			name:        "mirror claims activation, authority says no",
+			activated:   false,
+			mirror:      botevent.MirrorValue(1),
+			want:        mirrorRefuse,
+			msgContains: "NOT activated",
+		},
+		{
+			name:        "bare incr against a legacy authority is still a claim",
+			activated:   false,
+			mirror:      "incr",
+			want:        mirrorRefuse,
+			msgContains: "NOT activated",
+		},
+		{
+			name:        "malformed value is a note either way (not activated)",
+			activated:   false,
+			mirror:      "incr:not-a-number",
+			want:        mirrorNote,
+			msgContains: "not a valid mirror value",
+		},
+		{
+			name:        "malformed value is a note either way (activated)",
+			activated:   true,
+			mirror:      "garbage",
+			want:        mirrorNote,
+			msgContains: "not a valid mirror value",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, msg := judgeMirror(tc.activated, tc.mirror, tc.absent)
+			if got != tc.want {
+				t.Fatalf("judgeMirror(activated=%v, mirror=%q, absent=%v) = %v, want %v (msg: %s)",
+					tc.activated, tc.mirror, tc.absent, got, tc.want, msg)
+			}
+			if tc.msgContains != "" && !strings.Contains(msg, tc.msgContains) {
+				t.Errorf("message does not mention %q; the operator reads this string during an "+
+					"incident. Got: %s", tc.msgContains, msg)
+			}
+			if got == mirrorOK && msg != "" {
+				t.Errorf("mirrorOK must carry no message, got %q", msg)
+			}
+		})
+	}
+}
+
+// TestRefusalNeverTellsTheOperatorToDeleteALiveMirror pins the specific harm of the previous
+// revision: it instructed a DEL of the mirror in a state where the mirror was correct.
+//
+// The instruction is right in the refusal case and must not appear in either note case.
+func TestRefusalNeverTellsTheOperatorToDeleteALiveMirror(t *testing.T) {
+	_, refuse := judgeMirror(false, botevent.MirrorValue(1), false)
+	if !strings.Contains(refuse, "DEL the key") {
+		t.Error("the refusal should tell the operator how to clear a genuinely unauthorized key")
+	}
+	for _, tc := range []struct {
+		name      string
+		activated bool
+		mirror    string
+	}{
+		{"already activated with a correct mirror", true, botevent.MirrorValue(1)},
+		{"malformed value", false, "garbage"},
+	} {
+		if _, msg := judgeMirror(tc.activated, tc.mirror, false); strings.Contains(msg, "DEL") {
+			t.Errorf("%s: the message must not instruct a DEL — that is the case where the "+
+				"mirror is live or about to be overwritten anyway. Got: %s", tc.name, msg)
+		}
+	}
+}
+
+// TestMaxSafeFloorKeepsScoresDistinct guards the other operator-facing bound.
+//
+// Sorted-set scores are float64, so above 2^53 distinct int64 ids stop having distinct
+// scores — which would recreate the pagination skip and multi-member ack #697 removes, from
+// the command meant to prevent them.
+func TestMaxSafeFloorKeepsScoresDistinct(t *testing.T) {
+	const float64ExactLimit = 1 << 53
+	if maxSafeFloor >= float64ExactLimit {
+		t.Fatalf("maxSafeFloor = %d is at or above 2^53 (%d), where int64 ids no longer have "+
+			"distinct float64 scores", int64(maxSafeFloor), int64(float64ExactLimit))
+	}
+	// And it has to leave real room, or the cap becomes the thing that blocks an activation.
+	if maxSafeFloor < 1<<40 {
+		t.Fatalf("maxSafeFloor = %d leaves too little headroom above plausible ids",
+			int64(maxSafeFloor))
+	}
+}

--- a/tools/botevent-seq/main_test.go
+++ b/tools/botevent-seq/main_test.go
@@ -212,3 +212,41 @@ func TestPreflightPagesQueueMembers(t *testing.T) {
 		}
 	}
 }
+
+func TestScanQueueScoresCountsDuplicatesAcrossPageBoundaries(t *testing.T) {
+	members := make([]rd.Z, 0, queueScanPageSize+2)
+	for i := int64(0); i < queueScanPageSize-1; i++ {
+		members = append(members, rd.Z{Score: float64(i), Member: i})
+	}
+	// The duplicate straddles page 1 / page 2. An implementation that resets its
+	// previous-score state per page silently misses exactly this case.
+	members = append(members,
+		rd.Z{Score: 10_000, Member: "a"},
+		rd.Z{Score: 10_000, Member: "b"},
+		rd.Z{Score: 10_001, Member: "c"},
+	)
+	var requests [][2]int64
+	stats, err := scanQueueScores(func(start, stop int64) ([]rd.Z, error) {
+		requests = append(requests, [2]int64{start, stop})
+		if stop-start+1 > queueScanPageSize {
+			t.Fatalf("requested unbounded page %d..%d", start, stop)
+		}
+		if start >= int64(len(members)) {
+			return nil, nil
+		}
+		end := stop + 1
+		if end > int64(len(members)) {
+			end = int64(len(members))
+		}
+		return members[start:end], nil
+	})
+	if err != nil {
+		t.Fatalf("scanQueueScores: %v", err)
+	}
+	if len(requests) != 2 {
+		t.Fatalf("requests=%v, want exactly two bounded pages", requests)
+	}
+	if stats.members != len(members) || stats.duplicates != 1 || stats.maxScore != 10_001 {
+		t.Fatalf("stats=%+v, want members=%d duplicates=1 max=10001", stats, len(members))
+	}
+}

--- a/tools/botevent-seq/main_test.go
+++ b/tools/botevent-seq/main_test.go
@@ -250,3 +250,50 @@ func TestScanQueueScoresCountsDuplicatesAcrossPageBoundaries(t *testing.T) {
 		t.Fatalf("stats=%+v, want members=%d duplicates=1 max=10001", stats, len(members))
 	}
 }
+
+// TestInspectQueueScoresKeepsAtomicMaxWhenRankPagesShift reproduces the cutover
+// evidence regression from review round 10. Pausing producers does not pause ACKs:
+// removing members from the low end between rank pages shifts every later rank left,
+// so the diagnostic walk can stop early after observing only scores 1..500 while the
+// queue still contains scores through 2000. The activation floor must use a separate,
+// single-command maximum and never the paged walk's incomplete view.
+func TestInspectQueueScoresKeepsAtomicMaxWhenRankPagesShift(t *testing.T) {
+	members := make([]rd.Z, 0, 2000)
+	for i := 1; i <= 2000; i++ {
+		members = append(members, rd.Z{Score: float64(i), Member: i})
+	}
+
+	pageCalls := 0
+	stats, err := inspectQueueScores(
+		func() ([]rd.Z, error) {
+			return []rd.Z{members[len(members)-1]}, nil
+		},
+		func(start, stop int64) ([]rd.Z, error) {
+			pageCalls++
+			if start >= int64(len(members)) {
+				return nil, nil
+			}
+			end := stop + 1
+			if end > int64(len(members)) {
+				end = int64(len(members))
+			}
+			page := append([]rd.Z(nil), members[start:end]...)
+			if pageCalls == 1 {
+				// Simulate ACKs removing scores 1..1600 after page 1. The next
+				// rank request starts at 500 against a 400-member set and therefore
+				// returns a short/empty page even though score 2000 still exists.
+				members = members[1600:]
+			}
+			return page, nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("inspectQueueScores: %v", err)
+	}
+	if stats.maxScore != 2000 {
+		t.Fatalf("maxScore=%d, want atomic queue maximum 2000; rank paging understated the irreversible cutover evidence", stats.maxScore)
+	}
+	if stats.members != int(queueScanPageSize) {
+		t.Fatalf("diagnostic walk read %d members, want %d to prove the rank view shifted", stats.members, queueScanPageSize)
+	}
+}

--- a/tools/botevent-seq/main_test.go
+++ b/tools/botevent-seq/main_test.go
@@ -206,7 +206,12 @@ func TestPreflightPagesQueueMembers(t *testing.T) {
 			t.Errorf("preflight still uses unbounded queue accounting %q", forbidden)
 		}
 	}
-	for _, required := range []string{"queueScanPageSize", "scanQueueScores"} {
+	for _, required := range []string{
+		"queueScanPageSize",
+		"scanQueueScores",
+		"inspectQueueScores",
+		"ZRevRangeWithScores(k, 0, 0)",
+	} {
 		if !strings.Contains(text, required) {
 			t.Errorf("preflight does not contain bounded paging helper %q", required)
 		}

--- a/tools/botevent-seq/main_test.go
+++ b/tools/botevent-seq/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -184,6 +185,30 @@ func TestActivationPreconditionsRemainVisibleWithYes(t *testing.T) {
 	} {
 		if !strings.Contains(activationPreconditions, want) {
 			t.Errorf("activation preconditions do not contain %q", want)
+		}
+	}
+}
+
+// TestPreflightPagesQueueMembers guards the operator tool's production footprint.
+// ZRANGE 0 -1 returns one unbounded Redis response and the previous implementation then
+// retained a score-sized map. Rank pagination plus adjacent-score accounting bounds both.
+func TestPreflightPagesQueueMembers(t *testing.T) {
+	source, err := os.ReadFile("main.go")
+	if err != nil {
+		t.Fatalf("read main.go: %v", err)
+	}
+	text := string(source)
+	for _, forbidden := range []string{
+		"ZRangeWithScores(k, 0, -1)",
+		"make(map[float64]struct{}",
+	} {
+		if strings.Contains(text, forbidden) {
+			t.Errorf("preflight still uses unbounded queue accounting %q", forbidden)
+		}
+	}
+	for _, required := range []string{"queueScanPageSize", "scanQueueScores"} {
+		if !strings.Contains(text, required) {
+			t.Errorf("preflight does not contain bounded paging helper %q", required)
 		}
 	}
 }

--- a/tools/genseq-repro/main.go
+++ b/tools/genseq-repro/main.go
@@ -1,0 +1,331 @@
+// Command genseq-repro reproduces the #697 defect against a real MySQL and Redis:
+// octo-lib's GenSeq is a per-process HiLo block allocator, so two replicas that
+// cold-start concurrently hand out the SAME sequence numbers — and those numbers
+// are used as sorted-set scores for bot event delivery, which paginates with an
+// exclusive cursor and deletes by score.
+//
+// It calls the real config.Context.GenSeq (no reimplementation) from two child
+// processes, because seqMap/seqLock are package-level in octo-lib and a single
+// process therefore cannot hold two independent block states.
+//
+// Read-only against production is not involved; this talks to local containers.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	rd "github.com/go-redis/redis"
+)
+
+var (
+	mysqlAddr = flag.String("mysql", "root:demo@tcp(host.docker.internal:3306)/genseq_repro?charset=utf8mb4&parseTime=true", "")
+	redisAddr = flag.String("redis", "host.docker.internal:6379", "")
+	child     = flag.Bool("child", false, "run as one replica")
+	label     = flag.String("label", "", "replica label")
+	key       = flag.String("key", "reproRobotEvent", "seq flag")
+	count     = flag.Int("n", 12, "ids per replica")
+	startAt   = flag.Int64("start-at", 0, "unix milli barrier")
+	seedFloor = flag.Int64("seed", 5000, "pre-existing seq.min_seq")
+)
+
+func newCtx() *config.Context {
+	cfg := config.New()
+	cfg.DB.MySQLAddr = *mysqlAddr
+	return config.NewContext(cfg)
+}
+
+// runChild is one replica: cold-start GenSeq, wait for the shared barrier so both
+// replicas read seq.min_seq before either writes it back, then allocate.
+func runChild() {
+	ctx := newCtx()
+	if *startAt > 0 {
+		time.Sleep(time.Until(time.UnixMilli(*startAt)))
+	}
+	out := make([]string, 0, *count)
+	for i := 0; i < *count; i++ {
+		v, err := ctx.GenSeq(*key)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "%s: GenSeq: %v\n", *label, err)
+			os.Exit(1)
+		}
+		out = append(out, strconv.FormatInt(v, 10))
+	}
+	fmt.Println(strings.Join(out, ","))
+}
+
+func main() {
+	flag.Parse()
+	if *child {
+		runChild()
+		return
+	}
+
+	ctx := newCtx()
+	db := ctx.DB()
+	if _, err := db.DeleteFrom("seq").Where("`key`=?", "seq:"+*key).Exec(); err != nil {
+		fatal("clean seq row: %v", err)
+	}
+	if _, err := db.InsertBySql(
+		"insert into `seq`(`key`,min_seq,step) values(?,?,?)",
+		"seq:"+*key, *seedFloor, 1000).Exec(); err != nil {
+		fatal("seed seq row: %v", err)
+	}
+	fmt.Printf("seeded seq:%s min_seq=%d step=1000\n\n", *key, *seedFloor)
+
+	barrier := time.Now().Add(3 * time.Second).UnixMilli()
+	self, err := os.Executable()
+	if err != nil {
+		fatal("executable: %v", err)
+	}
+
+	var wg sync.WaitGroup
+	results := make([][]int64, 2)
+	labels := []string{"replica-A", "replica-B"}
+	for i := range labels {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			cmd := exec.Command(self,
+				"-child", "-label", labels[i],
+				"-mysql", *mysqlAddr, "-key", *key,
+				"-n", strconv.Itoa(*count),
+				"-start-at", strconv.FormatInt(barrier, 10))
+			cmd.Stderr = os.Stderr
+			raw, err := cmd.Output()
+			if err != nil {
+				fatal("%s: %v", labels[i], err)
+			}
+			for _, f := range strings.Split(strings.TrimSpace(string(raw)), ",") {
+				n, _ := strconv.ParseInt(f, 10, 64)
+				results[i] = append(results[i], n)
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	for i, l := range labels {
+		fmt.Printf("%s issued: %v\n", l, results[i])
+	}
+
+	seen := map[int64][]string{}
+	for i, l := range labels {
+		for _, v := range results[i] {
+			seen[v] = append(seen[v], l)
+		}
+	}
+	var dupes []int64
+	for v, who := range seen {
+		if len(who) > 1 {
+			dupes = append(dupes, v)
+		}
+	}
+	sort.Slice(dupes, func(a, b int) bool { return dupes[a] < dupes[b] })
+
+	fmt.Printf("\n--- finding 1: are ids unique across replicas? ---\n")
+	if len(dupes) == 0 {
+		fmt.Printf("UNIQUE — no collision this run (retry; the barrier is best-effort)\n")
+	} else {
+		fmt.Printf("COLLISION: %d ids issued by BOTH replicas: %v\n", len(dupes), dupes)
+	}
+
+	var mysqlAfter int64
+	if _, err := db.Select("min_seq").From("seq").
+		Where("`key`=?", "seq:"+*key).Load(&mysqlAfter); err != nil {
+		fatal("read back min_seq: %v", err)
+	}
+	fmt.Printf("seq.min_seq after both replicas: %d (unconditional ON DUPLICATE KEY UPDATE)\n", mysqlAfter)
+
+	if len(dupes) > 0 {
+		proveDeliveryLoss(results, labels, dupes)
+	}
+}
+
+// proveDeliveryLoss replays the collision through the exact read and ack shape of
+// modules/bot_api/events.go: ZRANGEBYSCORE with an exclusive Min, and
+// ZREMRANGEBYSCORE(id, id) on ack.
+func proveDeliveryLoss(results [][]int64, labels []string, dupes []int64) {
+	client := rd.NewClient(&rd.Options{Addr: *redisAddr})
+	qkey := "reproRobotEvent:zset"
+	client.Del(qkey)
+
+	type ev struct {
+		id  int64
+		who string
+	}
+	var all []ev
+	for i, l := range labels {
+		for _, v := range results[i] {
+			all = append(all, ev{v, l})
+		}
+	}
+	for _, e := range all {
+		// distinct member payload, same score — exactly what the five ZADD
+		// producers do: ZAdd(key, float64(seq), payload{EventID: seq})
+		client.ZAdd(qkey, rd.Z{Score: float64(e.id), Member: fmt.Sprintf(`{"event_id":%d,"from":"%s"}`, e.id, e.who)})
+	}
+	stored, _ := client.ZCard(qkey).Result()
+	fmt.Printf("\n--- finding 2: exclusive-cursor delivery over the collided queue ---\n")
+	fmt.Printf("enqueued %d events, ZSET holds %d members\n", len(all), stored)
+
+	// Consume the way a bot does: cursor advances to max event_id observed.
+	delivered := map[string]bool{}
+	var cursor int64
+	for {
+		page, err := client.ZRangeByScore(qkey, rd.ZRangeBy{
+			Min: fmt.Sprintf("(%d", cursor), Max: "+inf", Count: 20,
+		}).Result()
+		if err != nil || len(page) == 0 {
+			break
+		}
+		for _, m := range page {
+			delivered[m] = true
+			if id := eventIDOf(m); id > cursor {
+				cursor = id
+			}
+		}
+	}
+	fmt.Printf("delivered %d of %d members (cursor ended at %d)\n", len(delivered), stored, cursor)
+
+	var lost []string
+	everything, _ := client.ZRange(qkey, 0, -1).Result()
+	for _, m := range everything {
+		if !delivered[m] {
+			lost = append(lost, m)
+		}
+	}
+	if len(lost) == 0 {
+		fmt.Printf("(a whole-queue read in one pass loses nothing — the skip needs a page\n")
+		fmt.Printf(" boundary on the shared score, or a late low-block enqueue; both below)\n")
+	} else {
+		fmt.Printf("SKIPPED FOREVER (%d): %v\n", len(lost), lost)
+	}
+
+	// finding 3 runs before the two skip scenarios, which rebuild the queue.
+	victim := strconv.FormatInt(dupes[0], 10)
+	before, _ := client.ZRangeByScore(qkey, rd.ZRangeBy{Min: victim, Max: victim}).Result()
+	client.ZRemRangeByScore(qkey, victim, victim)
+	after, _ := client.ZRangeByScore(qkey, rd.ZRangeBy{Min: victim, Max: victim}).Result()
+	fmt.Printf("\n--- finding 3: ack collateral damage ---\n")
+	fmt.Printf("score %s held %d members before ack: %v\n", victim, len(before), before)
+	fmt.Printf("after ZRemRangeByScore(%s,%s): %d remain\n", victim, victim, len(after))
+	if len(before) > 1 {
+		fmt.Printf("ACK DESTROYED %d event(s) while acking 1\n", len(before)-1)
+	}
+
+	proveSkipAtPageBoundary(client, qkey, dupes[0])
+	proveSkipOnLateLowBlock(client, qkey)
+	client.Del(qkey)
+}
+
+// proveSkipAtPageBoundary shows the loss that needs no time inversion at all: when a
+// page ends on the first of two members sharing a score, the exclusive `(cursor` on
+// the next read excludes the second one permanently. events.go uses limit 20..100, so
+// on a queue with >1000 duplicate scores this boundary is hit routinely.
+func proveSkipAtPageBoundary(client *rd.Client, qkey string, shared int64) {
+	client.Del(qkey)
+	client.ZAdd(qkey, rd.Z{Score: float64(shared), Member: fmt.Sprintf(`{"event_id":%d,"from":"replica-A"}`, shared)})
+	client.ZAdd(qkey, rd.Z{Score: float64(shared), Member: fmt.Sprintf(`{"event_id":%d,"from":"replica-B"}`, shared)})
+	client.ZAdd(qkey, rd.Z{Score: float64(shared + 1), Member: fmt.Sprintf(`{"event_id":%d,"from":"replica-A"}`, shared+1)})
+
+	fmt.Printf("\n--- finding 2a: page boundary lands on a shared score ---\n")
+	total, _ := client.ZCard(qkey).Result()
+
+	delivered, cursor := consume(client, qkey, 1) // limit 1 puts the boundary on the shared score
+	fmt.Printf("queue has %d members; consumed with limit=1, cursor ended at %d\n", total, cursor)
+	fmt.Printf("delivered %d:\n", len(delivered))
+	for _, m := range delivered {
+		fmt.Printf("    %s\n", m)
+	}
+	all, _ := client.ZRange(qkey, 0, -1).Result()
+	seen := map[string]bool{}
+	for _, m := range delivered {
+		seen[m] = true
+	}
+	for _, m := range all {
+		if !seen[m] {
+			fmt.Printf("  SKIPPED FOREVER: %s\n", m)
+		}
+	}
+}
+
+// proveSkipOnLateLowBlock reproduces what was actually measured in production: a
+// replica holding a lower block enqueues AFTER the cursor has advanced into a higher
+// block, so its events are born already below the cursor.
+func proveSkipOnLateLowBlock(client *rd.Client, qkey string) {
+	client.Del(qkey)
+	fmt.Printf("\n--- finding 2b: late enqueue from a lower block (the production shape) ---\n")
+
+	// replica-B is on block 6xxx and enqueues first.
+	for _, id := range []int64{6001, 6002} {
+		client.ZAdd(qkey, rd.Z{Score: float64(id), Member: fmt.Sprintf(`{"event_id":%d,"from":"replica-B"}`, id)})
+	}
+	delivered, cursor := consume(client, qkey, 20)
+	fmt.Printf("bot polls: delivered %d, cursor=%d\n", len(delivered), cursor)
+
+	// replica-A is still on block 5xxx and enqueues later in wall-clock time.
+	late := []int64{5013, 5014}
+	for _, id := range late {
+		client.ZAdd(qkey, rd.Z{Score: float64(id), Member: fmt.Sprintf(`{"event_id":%d,"from":"replica-A"}`, id)})
+	}
+	fmt.Printf("replica-A then enqueues %v (later in time, lower score)\n", late)
+
+	page, _ := client.ZRangeByScore(qkey, rd.ZRangeBy{
+		Min: fmt.Sprintf("(%d", cursor), Max: "+inf", Count: 20,
+	}).Result()
+	fmt.Printf("bot polls again from (%d: got %d events\n", cursor, len(page))
+	if len(page) == 0 {
+		fmt.Printf("  SKIPPED FOREVER: %v — born below the cursor, never deliverable\n", late)
+	}
+}
+
+// consume mimics readEventPage: exclusive cursor, advanced to the max event_id seen.
+func consume(client *rd.Client, qkey string, limit int64) ([]string, int64) {
+	var out []string
+	var cursor int64
+	for {
+		page, err := client.ZRangeByScore(qkey, rd.ZRangeBy{
+			Min: fmt.Sprintf("(%d", cursor), Max: "+inf", Count: limit,
+		}).Result()
+		if err != nil || len(page) == 0 {
+			break
+		}
+		moved := false
+		for _, m := range page {
+			out = append(out, m)
+			if id := eventIDOf(m); id > cursor {
+				cursor = id
+				moved = true
+			}
+		}
+		if !moved {
+			break
+		}
+	}
+	return out, cursor
+}
+
+func eventIDOf(member string) int64 {
+	const p = `{"event_id":`
+	i := strings.Index(member, p)
+	if i < 0 {
+		return 0
+	}
+	rest := member[i+len(p):]
+	j := strings.IndexAny(rest, ",}")
+	n, _ := strconv.ParseInt(rest[:j], 10, 64)
+	return n
+}
+
+func fatal(f string, a ...interface{}) {
+	fmt.Fprintf(os.Stderr, "genseq-repro: "+f+"\n", a...)
+	os.Exit(1)
+}

--- a/tools/genseq-repro/main.go
+++ b/tools/genseq-repro/main.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/Mininglamp-OSS/octo-lib/config"
+	octoredis "github.com/Mininglamp-OSS/octo-server/pkg/redis"
 	rd "github.com/go-redis/redis"
 )
 
@@ -37,10 +38,21 @@ var (
 	seedFloor = flag.Int64("seed", 5000, "pre-existing seq.min_seq")
 )
 
-func newCtx() *config.Context {
+func newCfg() *config.Config {
 	cfg := config.New()
 	cfg.DB.MySQLAddr = *mysqlAddr
-	return config.NewContext(cfg)
+	cfg.DB.RedisAddr = *redisAddr
+	return cfg
+}
+
+func newCtx() *config.Context { return config.NewContext(newCfg()) }
+
+// newRedis goes through the octoredis chokepoint rather than rd.NewClient.
+// pkg/redis's TestNoRawRedisClientOutsideChokepoint scans the whole repo, tools
+// included, so a raw client here fails CI — and the instrumentation it enforces
+// (dependency="redis" on every command) is worth having even in a repro tool.
+func newRedis() *rd.Client {
+	return octoredis.NewInstrumentedClient(newCfg(), func(o *rd.Options) { o.MaxRetries = 1 })
 }
 
 // runChild is one replica: cold-start GenSeq, wait for the shared barrier so both
@@ -153,7 +165,7 @@ func main() {
 // modules/bot_api/events.go: ZRANGEBYSCORE with an exclusive Min, and
 // ZREMRANGEBYSCORE(id, id) on ack.
 func proveDeliveryLoss(results [][]int64, labels []string, dupes []int64) {
-	client := rd.NewClient(&rd.Options{Addr: *redisAddr})
+	client := newRedis()
 	qkey := "reproRobotEvent:zset"
 	client.Del(qkey)
 


### PR DESCRIPTION
## Summary

Bot event ids — the sorted-set scores of `robotEvent:{robotID}` — came from
octo-lib `GenSeq`, a **per-process** HiLo block allocator. The queue is read with
an **exclusive** cursor (`ZRANGEBYSCORE key (cursor +inf`) and acked by score
(`ZRemRangeByScore(id, id)`), both of which require strictly monotonic, unique
scores. With three replicas they are neither, and events are permanently lost.

This PR replaces the allocator with a per-bot Redis `INCR` counter behind an
activation gate whose state is authoritative in MySQL. **Merging keeps the same
allocator**: until an operator activates, every replica delegates to `GenSeq`.

The one thing that is *not* the same on merge, stated here rather than further down
because it is the merge-safety claim (review rounds 5–7 all raised it): a
pre-activation allocation now costs **one Redis round trip** before delegating —
`probeAllocatorState`, which reads the mode mirror and whether this bot's counter
exists. `GenSeq` served 999 of every 1000 allocations from a process-local block with
no I/O at all. There is **no** DB round trip (pinned by
`TestNotActivatedDoesNotQueryTheAuthorityPerAllocation`), and for queue writers there
is no new dependency either — the `ZADD` on the same path already requires Redis.
`addInlineQuery` is the sharpest case and worth naming: it writes an in-memory map and
previously needed no Redis at all to obtain an id.

**Scope, stated up front:** this removes the *collision* and *cross-restart
inversion* classes of loss. It does **not** make the exclusive cursor lossless.
Allocation and publication are two operations, so a producer that allocates `N` and
stalls while another publishes `N+1` still loses `N` once the consumer's cursor passes
it — and the doorbell makes that more likely, since the wake is triggered by the very
ZADD that creates the inversion. That residual is unchanged here, is now pinned by a
test asserting it **still happens** (`TestKnownResidualZaddReorderingCanStillSkip`),
and needs a re-delivery window below the cursor, which
`modules/bot_api/events.go:186-199` itself names as the *other* half of the fix. An
earlier revision of this description called the result lossless; that was wrong.

## Related Issue

Part of #697 — **this PR does not close the issue.** It is behaviour-neutral on merge
(the allocator stays on the legacy path until an operator activates it), so closing
requires deploy + activation + the three checks in that issue's acceptance section.
Do not use a closing keyword when merging. Related to #698, #700, and
Mininglamp-OSS/octo-lib#114 for the upstream half of the root cause.

**Merging is not activation clearance.** #704 carries the activation-only recovery and
cutover gaps deliberately separated from this PR, and it must be closed
before `botevent-seq -action activate` is run anywhere. That ordering is safe *because*
this revision makes the merged state genuinely inert (see Round 4 below); it would not
have been safe against the previous head, where a stray Redis key could activate the
counter on its own. The tool's `-yes` refusal names #704 so the gate is not only in this
description.

#697's acceptance criteria were narrowed to match what this PR actually delivers —
collisions and block-driven inversion — with the allocate-then-publish reordering
window split into a follow-up. The rationale is recorded on that issue; the short
version is that the two failures differ in kind (systemic and self-worsening versus
single-event and non-accumulating), and closing the reordering window first requires
resolving an atomicity-boundary conflict with `modules/bot_mention`, which commits an
idempotency claim atomically *with* the queue write and therefore needs the event id
**before** publishing — the opposite of assigning it inside the publish. I prototyped
the atomic version far enough to confirm that conflict, then reverted it rather than
grow this PR into a cross-module design change.

## Linked Spec

`.octospec/tasks/bot-event-score-monotonic/brief.md` (included, with a
"实现记录" section recording where implementation and review corrected the
original brief).

## The defect, measured

One bot queue, 644 events: **19 ordering inversions**, every one on a 1000-block
boundary, **max time regression 6.7 days**. Across 1948 queues, **2624 colliding
scores** in three of them, **still accumulating** (one queue's duplicate count
went 170 → 358 within an hour, five hours after the last restart — so the
`addOrUpdateSeq` write-back races on the *extend* path too, not just on cold
start). Every duplicated score holds exactly two members and every duplicate
range starts at `…X001`, i.e. `min_seq + 1`.

`tools/genseq-repro` reproduces all three loss paths against the real
`config.Context.GenSeq` and the real read/ack shapes:

1. **Collision is deterministic, not a lucky race.** Two child processes whose
   cold-start reads both precede either write-back issue the *same* 12 ids.
2. **A page boundary landing on a shared score** — the next read's exclusive
   `(cursor` excludes the second member forever. No time inversion needed;
   `getEvents` uses limit 20..100, so on a queue with >1000 duplicates this is
   routine.
3. **A late enqueue from a lower block** — those events are born below the
   cursor and no amount of polling reaches them.
4. **Ack collateral damage** — `ZRemRangeByScore(id, id)` deletes every member
   sharing the score, so acking a delivered event destroys an undelivered one.

Field reports match the mechanism's staging exactly: a card works at first, then
some users in a group cannot act on it, then no newly sent card is interactive at
all. The cursor is monotonic and never rewinds, so once it enters a high block
every id the main writer issues from a lower block is invisible — and each
restart opens yet another block, so it recurs.

## Changes

### Allocator (`pkg/botevent/seq.go`)

- Per-bot Redis `INCR`, in the **same instance and db as the queue**. That
  co-location is the durability argument, not an accident: production runs
  `appendonly no`, so a crash rewinds the counter — but it rewinds the queue with
  it, so resuming cannot collide with anything that survived. Recorded as a hard
  constraint, because "moving the counter somewhere more durable" would silently
  break it. `maxmemory 0` / `noeviction` rules out eviction.
- First use per bot seeds above
  `max(queue ceiling, legacy seq row, durable high-water, cutover floor) + 2×step`.
  The cutover floor is carried by the same validated positive authority belief as the
  epoch, so a later state-table read failure cannot silently turn it into zero. The two
  `seq` rows are loaded in one deadlined conditional-aggregate query to bound a
  fleet-wide mirror-recovery burst.
- Allocation failure fails the enqueue. No fallback — two live id sources on one
  queue is the defect.

### Activation state is authoritative in MySQL

`octo_bot_event_seq_state` (singleton: `mode` / `epoch` / `cutover_floor`), flipped
by a `FOR UPDATE` compare-and-set that validates the floor against the observed
maximum and refuses with `ErrFloorTooLow` otherwise. Same shape as
`octo_message_extra_version_state`.

Review found that keeping the mode only in Redis was unsafe: production runs
`appendonly no`, so an RDB rollback drops it, and falling back to legacy then issues
GenSeq ids **below** everything the counter had handed out — #697 mirrored. The Redis
key is now only a **mirror**, whose sole purpose is letting the hot path check the
mode inside the same Lua script as the `INCR`. A missing mirror makes the allocator
read the DB row and, if activated, rebuild the mirror and re-seed rather than degrade.

`FOR SHARE` drain barrier is deliberately **not** copied from #627: a `robotEvent`
writer is `INCR` + `ZADD` with no transaction, so there is nothing to hold a lock
until, and wrapping each allocation in a transaction to borrow the barrier would
reintroduce the per-message DB round trip the allocator exists to avoid. The
consequence is documented rather than hidden: this design cannot drain in-flight
writers at the flip, and relies on the operator confirming no pre-fix replica runs,
plus a brief write pause.

### Activation gate — one entry point, asymmetric cache (`pkg/botevent/mode.go`)

Round 4 found the gate had ordering and trust gaps of its own, all three of them the
same missing thing: no single stateful entry point for "is the counter activated". The
invariant is now one line — **the authority decides, the mirror can only shortcut,
never override** — and the cache behind it is deliberately asymmetric:

- A **positive** belief (activated) is terminal with respect to legacy. Once a process
  resolves `incr` it may refresh the epoch upward but can never decide `legacy` again —
  not on a DB error, a rolled-back row, or a dropped table. The downgrade branch is
  *gone*, not guarded.
- A **negative** belief is trusted only while the mirror agrees with it. A mirror
  claiming `incr` against a cached `legacy` is a **conflict**, and a conflict forces a
  fresh authority read. This is what preserves the no-divergence-window property the
  previous revision achieved by reading the DB per allocation: propagation of the flip
  never waits for a TTL, because the first allocation that sees the new mirror re-reads
  the authority. The TTL only bounds the case where the operator's mirror write failed.
- A **confirmed** conflict is a forged mirror: `legacy`, loudly
  (`dmwork_bot_event_seq_mirror_unauthorized_total`). It does not split the fleet,
  because every replica reads the same row and reaches the same conclusion —
  consistency comes from the authority, not from the mirror. That sentence is what the
  previous revision was missing.

The gate still reads the **uncached** mirror inside the same Lua script as the `INCR`,
so the brief's D2 reasoning is preserved, not overturned: what D2 forbids is deciding
the gate from a cache, and only the authority *behind* the mirror is cached.

The mirror value carries the generation (`incr:{epoch}`) and the gate compares against
the exact string this process validated, so a hand-written `SET botEventSeq:mode incr`
cannot open the gate even for one allocation — it carries no generation, so all it can
do is force an authority read. This is the mechanism `epoch`'s column comment claimed
and did not have.

Ordering: **seed, then publish the mirror.** Writing it first opens the gate for every
bot in every replica while only one has been raised to its floor. And a lost mirror now
invalidates *every* seeded marker, not just the bot being allocated for — a lost mode
key is evidence Redis lost data, so every counter this process believes it seeded is
suspect. The mirror is global; a seed is per-bot.

`tools/botevent-seq` (`preflight` / `activate`) **cannot** verify the three
preconditions that matter, so it demands `-yes` and now names all three: #704 closed,
no pre-fix replica remaining, and the brief write pause. No online deactivate: going
back would put legacy ids below consumer cursors, the same loss mirrored.

### Producers

- All queue writers route through `botevent.NextEventID`, enforced by a source guard.
- Queue keys are **fully** consolidated onto `botevent.QueueKey` now. Two earlier
  revisions of this description got this wrong in opposite directions — first claiming
  it was done, then correctly reporting four of five. `rb.robotEventPrefix` and
  `modules/bot_api`'s own constant are both deleted, so there is one spelling and the
  chokepoint guard can see all of it.
- `payload.robot_id` is validated against `existRobot` like the three sibling branches
  beside it. It is the only branch whose value comes verbatim from a client's message
  payload, and the allocator turns an unknown value into a **permanent** Redis counter
  key (no TTL, `noeviction`) plus a `seq` row that is never reclaimed — where GenSeq
  cost only a TTL'd queue key and a row. This closes one of the three items review asked
  a human to verify; it was answerable from the code.
- `addInlineQuery` shares the same source. Its events are merged with the queue
  by `getEventsResult`, sorted by `EventID` and filtered by one shared cursor, so
  a separate sequence would push the cursor into the millions and permanently
  filter every ordinary event behind it.

### Guards

Two source guards, both proven able to fail: every queue `ZADD` must go through
the allocator, and no bot event id may come from `GenSeq` outside the single
allowlisted delegation. The second guard additionally fails if that delegation
*disappears* — deleting it as dead code would make a deploy switch allocators on
its own. A docstring claiming a single chokepoint was already wrong once
(PR #685); these are tests instead.

### Round 9 follow-up hardening

Seven follow-up gaps were reproduced in `795675f0` before the production fixes in
`2c3a0d18`:

| finding | resolution |
|---|---|
| A validated positive belief could lose its activation `cutover_floor` when a later seed re-read the authority and treated an error as zero | The immutable belief now carries the floor with `activated` and `epoch`; every seed uses the value from the same successful authority read |
| Mirror recovery issued separate MySQL reads for the legacy and durable `seq` rows | One deadlined conditional aggregate returns both ceilings; an integration test verifies real row values in addition to the source-level I/O-shape guard |
| Preflight used `ZRANGE 0 -1` and retained a map proportional to queue size | Duplicate diagnostics use bounded rank pages of 500 entries and O(1) state. The activation-critical maximum comes from one atomic `ZREVRANGE 0 0 WITHSCORES`; ACK-driven `ZREM` may shift diagnostic ranks, but cannot make that separately captured maximum understate the cutover floor |
| The two post-seed retries interpreted `-1` / `-2` differently | One helper routes a changed mirror back through authority recovery and reports a repeatedly missing counter as the actual fail-closed fault |
| A process holding epoch N could overwrite a mirror at epoch N+1 | A higher mirror generation forces an authority refresh; unconfirmed generations are refused, not overwritten |
| Runtime `INCR` could cross the exact-integer limit of Redis ZSET's float64 score | `runGate` refuses ids at or above 2^53, before they can recreate score collisions and score-based ack damage |
| An unknown client `payload.robot_id` caused repeated MySQL misses and prevented a valid sibling mention route | Proven misses are cached for 30 seconds, and routing continues through mention/text unless the payload id is positively verified |

The activation-only recovery gaps remain explicitly owned by #704; these changes do not
turn merge or deploy into activation.

### Round 7 findings fixed here

One blocking finding, and the reviewer reproduced it against real MySQL + Redis. I reproduced
it too — **the test was written and watched failing before any code changed**, which is the
discipline the previous three rounds were missing.

| finding | resolution |
|---|---|
| **yujiawei P1-1** — the mirror repair added last head is a **fleet-wide outage** in the case it was meant to help. `allocate` has `counterExists` at `seq.go:596`, deletes the mirror at `:604`, and only at `:611` uses that same value to conclude "the authority regressed". So it destroys the mirror on the authority's word before establishing the authority is the unreliable party. One cold replica then takes every healthy activated replica's gate down | The allocator **never writes the mirror on the legacy path** now. Not the suggested `!counterExists` guard — that narrows the window without closing it (the mirror is global, a counter is per-bot). The delete's only benefit was suppressing the read storm, which the cooldown also does, so it is gone rather than conditioned |
| **P2-1** — `activate` is not idempotent and its refusal asserts a fact it never checked: it fatalled on any mirror claim without reading the state row, so re-running after a successful flip died telling the operator to `DEL` the live mirror | Reads the authority first. Three cases separate cleanly. Plus **the tool's first test file** — it carries the whole activation procedure, is the only thing a human runs at the cutover, and had produced two findings across two rounds with zero tests |
| **Deviation 1** — "behaviour-neutral … exactly as before", raised in three consecutive rounds | Fixed in the *claim*, not further down: the added Redis round trip is now stated in Summary beside the sentence it qualifies, with `addInlineQuery` named as the only genuinely new dependency |
| **Deviation 2** — `mode.go`'s "the race is benign" was wrong in both halves | Gone with the mechanism it described |
| **P2-3 … P2-6** | `plausibleRobotID` says it bounds bytes deliberately (and why utf8mb4 characters differ, and why that is unreachable today); the write-only `confirmed` field is deleted; `install`'s never-returned error is gone; `invalidateSeeded`'s docstring states the real, smaller stake |
| **P2-2** | The retained per-bot counter comment now says why bot-count-scale leakage is accepted where payload-scale was not — the unit of abuse differs |
| **P2-7 / P2-8** | #704, which gained **Gap 5**: mirror repair has no safe automatic form (both attempts and why each failed), plus the two things it leans on that nobody has audited |

**The cost of the fix, stated rather than hidden.** The denial cooldown is back — 1s, keyed on
the exact denied value — so a genuine activation writing byte-identical bytes to a previously
denied mirror is not noticed for up to that second. That window cannot be zero without reading
the authority per allocation, because nothing visible from Redis distinguishes a forged
`incr:1` from the real one. It is only entered when a mirror claiming activation already sits
against a legacy authority, which `botevent-seq` now refuses to flip on top of, and it is
armed **only when no counter exists** — with one, the authority is the regressed party, every
allocation for that bot is refused anyway, and suppressing the read would only delay noticing
recovery.

### Round 6 findings, and one decision that needs naming

Both blocking reviewers found the same thing again: **the fix from the previous head was
wrong in a new way.** So one item here is a decision rather than a patch.

| finding | resolution |
|---|---|
| **yujiawei P1-1** — the span bound is over its bound on the **first allocation after every seed**, deterministically, for every bot in every process. First failed durable write refuses with no grace and drops the event; the recovery probe becomes a storm inside `msgSem` slots (~67 producing bots saturate 100) | **Moved to #704 in one piece**, with the arithmetic — see below |
| **Jerry-Xin 🔴 / yujiawei P2-1** — the denied-mirror cache swallows the genuine activation: `Activate` bumps epoch 0 → 1 and the tool writes exactly `incr:1`, byte-identical to a forged `incr:1` already in Redis | The contradicted mirror is **removed** (compare-and-delete on the exact value) instead of remembered. No cache, nothing to go stale. `botevent-seq` also refuses to flip while such a key is present |
| **yujiawei P1-2** — `invalidateSeeded`'s delete order can leave a bot marked seeded with its companion state wiped | `seeded` cleared last; the worst interleaving now leaves a bot *unseeded*, which the next allocation fixes |
| **yujiawei P2-3** — the staleness shortcut can answer from a belief resolved against a different mirror observation | Re-checks the mirror claim before serving a negative belief |
| **yujiawei P2-2** — four documentation deviations, including the one string an operator reads during an incident (`EXPECTED_MODE=incr` will *not* unblock a `counterExists` refusal — it is a fail-closed assertion) | All corrected, including Rollout step 6, which now names three metrics and says which one does **not** self-heal |
| **yujiawei P2-5** — the `existRobot` fail-open path can adopt an arbitrary client string | Syntactic bound first: length ≤ the `robot.robot_id` column width, no whitespace or control characters. No charset allowlist — the column stores whatever it is given |
| **spec ❌** — the score-source guard was neither built nor moved | Recorded as #704 Gap 4 and marked DEFERRED in the brief |

#### Why the durable-mark bound leaves this PR

I worked the arithmetic out before patching it a third time, and it says a patch cannot fix
it:

```
A seed sets the counter to  S = max(sources) + seedSafetyMargin
A recovery seed replays the same computation over the surviving MySQL sources, so it
lands at S again. Ids issued after a seed are S+1, S+2, … — all above S.
```

So the first id after any seed is already outside what a recovery from an unchanged mark
could reach: the exposure starts immediately, not after some grace. Closing it requires
advancing the mark **at seed time**, and a mark recording the seeded value feeds back into
the next seed's floor — every re-seed compounds by a block, which also breaks the no-op
property `TestSeedIsIdempotentAndNeverLowers` guards. That is a change to **what the
recovery floor is**, which is the same question #704 already owns for rollback detection.

Both reviewers recommended exactly this, and yujiawei flagged it as needing an owner's call.
Taken: `persistHighWater` keeps the throttle and the metric, and now **says plainly** that
the mark trails without bound while writes fail.
`TestFailedDurableWriteIsThrottledAndDoesNotFailTheEnqueue` asserts the gap is *still
there*, so it becomes the regression test the day #704 closes it. #704 gained the
arithmetic and both failed attempts so the road is not taken a third time.

This is strictly more honest than either previous revision: one asserted a bound it did not
have, the other over-triggered and dropped events. Neither delivered the property, and the
exposure is unreachable before activation — which #704 gates.

### Round 5 findings fixed here

Both blocking reviewers found the same defect, and it was mine from the previous head:
**the P1-7 bound recorded as fixed did not fail closed.** Six items fixed here; the two
rollback-detection findings stay on #704.

| finding | what it was | fix |
|---|---|---|
| **Jerry-Xin 🔴 / P1-B** | The bound counted failed intervals, but the throttle short-circuited *before* consulting it and re-armed unconditionally — so past the bound only 1 allocation in 1000 failed and 999 succeeded against a frozen mark. Arithmetic put ids at `M+2999` against a margin of 2000, so a **restarted** process silently resumed at `M+2001` beneath cursors already at `M+2999` | Bound is now the span past the last mark that *landed*, refused at `seedSafetyMargin`, checked on every allocation. The failure counter (and its non-atomic read-modify-write) is gone |
| **P1-A** | `mode.go`'s central invariant statement was false — a positive belief never re-reads the authority, so a post-activation authority rollback *does* split the fleet — and #704's scoping argument was quoting it | Statement corrected; the same round trip that reads the mirror now also reports whether the bot's counter exists, which is cross-process proof of activation, so a cold process refuses instead of degrading. No DB read, no env var |
| **P1-C** | A denied mirror cost an authority read **per allocation**, serialized behind one mutex inside a `msgSem` slot, with no exit — nothing clears a forged key. Same hazard class as the P1-1 read removed last head | Denial cached keyed on the exact mirror value denied; forced refreshes serve waiters from a read someone else already did |
| **spec deviation** | "Queue keys are fully consolidated" — third revision to state this wrongly. Four `Del` sites still formatted the key, plus a dead field | Finished. `grep -rn '"robotEvent:' modules/` is empty outside tests |
| **spec deviation** | `payload.robot_id` dropped the event when `existRobot` **errored**, turning a DB blip into silently lost bot events | Falls through to the old behaviour on error. The check now only rejects when the bot is known not to exist |
| **P2** | Doorbell guard matched `"robotEvent:%s"` but not `"robotEvent:" + robotID`; `TestMain` probed `SELECT 1`/`PING` but not the two `CREATE TABLE`s that actually gate the tests; the expected-mode test hook raced with production reads | All three closed |
| **P1-D** | `payload.robot_id` is checked for existence, not authorization (pre-existing) | Routed to a human owner as the reviewer asked; not changed here |

Two things the tests forced out, worth naming because a read-only review cannot see
them:

- **The span bound could not self-heal.** With the ordinary id-distance throttle,
  recovery waited for ~1000 more refused allocations after the DB came back — unbounded
  wall-clock time for a low-traffic bot. Past the bound the probe now uses a time budget.
  It has to stay throttled: a failing `INSERT` with a 300ms deadline in a held `msgSem`
  slot is a throughput cliff for every bot in the process, doomed enqueue or not.
- **The span cannot be checked before the write attempt.** A bot with no durable row has
  a base of 0, so checking first refuses its very first allocation before trying to
  record it.

### Round 4 findings fixed here

Both blocking reviewers independently found the same critical defect, and one found a
regression the previous head introduced. Six of the eight P1s are fixed here; two are
#704.

| finding | what it was | fix |
|---|---|---|
| **P1-2 / 🔴** | A positive mirror was trusted on the hot path and the authority was never read, so a stray key performed the gated activation on every replica | Authority consulted once per process before a positive mirror is believed; mirror carries the generation |
| **P1-1** | Pre-activation did an **un-deadlined `SELECT` per allocation** inside a held `msgSem` slot — the merge was not behaviour-neutral, and it re-entered the hazard `aedde27a` bounds | Asymmetric belief cache; one read per process per interval. Pinned by a test that asserts the **I/O** shape, since the existing test asserts only the id's shape |
| **P1-4** | `mirrorMissing` could return a GenSeq id for a bot this process had already issued counter ids for | Positive belief is terminal; `ReadState` distinguishes missing-table from unreachable; `legacyDelegate` refuses if `lastIssued` holds the bot; malformed `EXPECTED_MODE` fails closed |
| **P1-3** | The global mirror was published **before** the per-bot seed | Seed first; a lost mirror invalidates every seeded marker |
| **P1-7** | A failing durable write neither throttled (one `INSERT` per event) nor bounded the exposure the seed margin is supposed to cover | Interval guard re-armed on failure; bounded at `highWaterFailureLimit` consecutive intervals, then allocations fail |
| **P1-8** | Activation evidence came only from `SCAN robotEvent:*`, so a drained-queue bot contributed nothing to the floor that protects it — and `scalarSeq` turned every DB error into 0 | Table-wide `MAX(min_seq)` per namespace; refuses partially failed evidence as it already refused sampled evidence |
| **P1-5 / P1-6** | Rollback detection is tolerance-bounded and process-local, and the "next seed will fix it" rationale is contradicted by the code (`seeded.Delete` only appears in already-detected branches) | **#704**, gated on activation not merge. One design question, only reachable post-activation — which this revision is what makes true |

DB deadlines no longer depend on the DSN: every call on this path uses
`LoadContext`/`ExecContext` with an explicit timeout, so the "does production set
`readTimeout`?" question stops being this path's only protection.

P2s fixed: the migration `Down` refuses while `mode=1` (P2-2); the floor is rejected
above 2^50, where float64 scores stop distinguishing int64 ids and the tool would
recreate the collisions it exists to prevent (P2-3); a `TestMain` fails loudly under
`CI=true` instead of letting the whole integration suite silently reduce to source
guards (P2-11 — the same failure mode as the `botevent_test` database an earlier
revision used); the GenSeq guard asserts on the key symbol rather than on
`GenSeq(...key)` on one line, which a two-line refactor walked past (P2-5); the consumer
docstring no longer describes GenSeq as the id source (P2-10); `lastPersisted` uses the
same CAS as `recordIssued` (P2-9); the bot-teardown decision not to delete the counter
is written down (P2-4); `ModeLegacy`, the sentinel-matching contract, and the
unconditional "seedSafetyMargin covers it" docstrings are corrected (P2-6/P2-7, P1-7);
`NextEventID` rejects a padded robotID rather than trimming it into a different key than
its callers use (P2-12).

Not changed: the `.gitignore` entries for the other operator tools (P2-1 nit). They are
defensive against exactly the mistake an earlier revision of this PR made — a 41 MB tool
binary committed by `git add -A` — so they stay.

### Latency bound

The allocator runs inside a `msgSem` slot on `saveRobotMessage`. 100 held slots
stall fan-out for every bot in the process, which is the hazard that forced the
doorbell off the producer goroutine — except this cannot be asynchronous, since
there is no id to enqueue without it. So it fails fast: 500ms dial / 300ms read,
one retry, ~1s worst case. Giving up fails one enqueue; waiting stalls everyone.

## Testing

Run the way CI runs it — `-race -shuffle=on -count=1` with a **per-package database
reset**, matching `.github/workflows/ci.yml`:

| package | |
|---|---|
| `pkg/botevent` (54 tests, **0 skipped**) | ok |
| `tools/botevent-seq` (new) | ok |
| `pkg/redis` (raw-client chokepoint guard) | ok |
| `modules/robot` | ok |
| `modules/bot_api` | ok |
| `modules/message` | ok |
| `modules/group` | ok |
| `modules/botfather` | ok |

The final follow-up was also run across every package returned by `go list ./...`, exactly
as CI does: a fresh `test` database and Redis `FLUSHALL` per package, then
`-race -shuffle=on -count=1 -timeout=5m`. The only initial failure was
`modules/common` with MySQL `Error 1040` because the local server still had its default
connection ceiling; CI explicitly raises `max_connections=1000`. After applying that
same CI prerequisite, `modules/common` passed and every other package had already passed.

`modules/message` is named by the brief (it owns the `card_action` D4 idempotency
claim) and was missing from an earlier revision of this description — review caught
that. The migration was verified applying through real sql-migrate (`gorp_migrations`
row present, state table created).

A `TestMain` now fails loudly when MySQL or Redis is missing **and** `CI=true`. Every
`seqTestCtx` call site used to `t.Skipf`, so a credential or dependency break would have
left only the source guards running while `go test` exited 0 — indistinguishable from
passing, on the tests that carry the entire safety argument. Locally it still skips.

`pkg/botevent` runs against a real MySQL and Redis in the standard `test` database.
An earlier revision used a dedicated one to avoid creating the migration-owned `seq`
table in a shared schema; that was worse, because CI never creates that database, so
every integration test here silently **Skipped** — indistinguishable from passing. CI
drops and recreates `test` before every package, which is what makes creating the
table here safe. Covers concurrent
strict monotonicity, seeding above both ceilings, seed idempotence and
never-lowering, fail-closed on a seed failure induced while `INCR` stays usable,
pre-activation delegation, activation taking effect with no cache window, and
and draining a quiesced queue through the exclusive cursor at page size 1 (which
proves uniqueness, not the absence of the reordering residual above).

`modules/robot`, `modules/group`, `modules/bot_api` full packages pass, each on a
freshly recreated test database. `go build ./...`, `go vet`, `gofmt`,
`make i18n-extract-check`, `make i18n-lint`, `git diff --check` all clean.

- [x] Unit tests added/updated
- [x] Manually verified (production read-only measurement + local reproduction)

## Rollout

0. **Close #704 first.** Rollback detection is still tolerance-bounded and
   process-local; both gaps are only reachable after activation, so merging is safe and
   activating is not.
1. Deploy to every replica. Same allocator as before: the mode belief resolves to legacy
   once per process per interval and every allocation goes through `GenSeq` with **no DB
   round trip**. One added Redis round trip per allocation — see the note in Summary; it
   is not free, and it is not a new dependency for queue writers.
2. **Confirm no pre-fix replica remains.** The tool cannot check this and it is
   the gate's whole safety precondition — activating while a legacy replica still
   issues from the bottom of a block is the loss this PR fixes, self-inflicted.
3. Load-test the hottest producer. The added Redis round trip from step 1 is already
   there; activation adds the counter `INCR` on top, so every allocation is a Redis round
   trip. Neither batching into blocks nor caching the mirror the gate compares against is
   available — both reintroduce the defect.
4. `botevent-seq -action activate -yes` (it refuses sampled evidence and validates
   the floor against all three sources), then re-run `preflight`: the duplicate count
   must **stop growing**. It will not drop — existing duplicates are left
   alone deliberately, since an ack deletes every member sharing a score and there
   is no record of which of a pair was ever delivered.
5. Only after activation is verified, roll out `OCTO_BOTEVENT_EXPECTED_MODE=incr` so
   a lost mirror **and** an unreadable authority fail closed instead of degrading.
   Setting it before the flip fails every enqueue closed, so it is last. A malformed
   value now fails closed rather than reading as unset, so a typo cannot quietly disarm
   it.
6. Watch two counters, which mean different things and have different urgencies:
   - `dmwork_bot_event_seq_mirror_unauthorized_total` — a replica saw a mode mirror the
     authority did not confirm (a forged key, a shared Redis, a restored snapshot). The
     allocator removes the contradicted key and stays on legacy, so this *is* self-healing
     and the metric is the only signal. `botevent-seq -action activate` also refuses to
     flip while such a key is present, so this should be zero before step 4.
   - `dmwork_bot_event_seq_counter_without_authority_total` — a replica found a bot's
     counter while the authority said not-activated, i.e. the authority regressed under an
     activated fleet. This does **not** self-heal: every enqueue for that bot is refused,
     deliberately, because a GenSeq id there lands below the bot's live cursor. Restore
     the `octo_bot_event_seq_state` row. Setting `OCTO_BOTEVENT_EXPECTED_MODE=incr` does
     not unblock it — that flag is a fail-closed assertion, not an override.
   - `dmwork_bot_event_seq_high_water_write_failure_total` — the durable mark is not
     advancing. Not fatal to delivery, but it is the exposure #704 owns; see the note under
     Round 6 below.

## COMPREHENSION

1. **What does this change actually do to the load-bearing path?**
   It replaces the id source for every bot event with a strictly monotonic
   counter, and puts one Redis round trip on the hottest producer path where
   `GenSeq` mostly used none — **including before activation**, where it is a probe
   rather than an allocation. Until activation the allocator does not change: the
   allocator delegates to `GenSeq`, so the deploy is a no-op and the switch is a
   separate, reversible-only-forward operator action.

2. **What could break because of it (dependents + failure mode)?**
   Activating while a pre-fix replica still runs would lose events exactly as
   today — mitigated by the gate plus an explicit manual precondition, not by
   code, which is why step 2 above is stated as a hard gate. A stray Redis key can
   no longer substitute for that gate: the authority is consulted before a positive
   mirror is believed, and the mirror carries the generation the authority named. Seeding below a
   client's existing cursor would make new events unreachable — mitigated by
   seeding from both the queue ceiling and the `seq` row; the residual case is a
   cursor taken from an already-acked high id combined with a regressed `min_seq`,
   which the 2×step margin covers for one regression but not for many, and which
   can only be confirmed by observing recovery. A slow Redis now costs the
   fan-out path up to ~1s per allocation, bounded deliberately so a degraded
   Redis fails enqueues rather than exhausting `msgSem`.

3. **How do you know it works (specific test/repro/trace)?**
   `tools/genseq-repro` demonstrates the defect end to end — deterministic
   collision, both skip paths, ack collateral damage — and its assertions are
   mirrored in `pkg/botevent` against the new allocator where they pass.
   `TestNotActivatedDelegatesToLegacy` proves the deploy is neutral;
   `TestActivationTakesEffectWithoutAProcessCacheWindow` proves the flip has no
   divergence window; `TestSeedClearsTheLegacyCeilingAtActivation` proves the
   first activated id clears a reserved-but-unfinished legacy block;
   `TestExclusiveCursorIsLosslessWithMonotonicIDs` drains a quiesced queue through
   the real read shape at page size 1 — note it consumes only after production
   finishes, so it proves the allocator's uniqueness and not the absence of the
   reordering residual, which `TestKnownResidualZaddReorderingCanStillSkip` records
   as still present. `TestCounterRollbackIsDetectedAndHealed`,
   `TestMissingCounterFailsBeforeIssuingFromOne` and
   `TestMirrorRebuiltFromDBAuthority` cover the three Redis-data-loss shapes; the
   production numbers come from read-only `SCAN`/`ZRANGE` measurement.

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] PR description is in English
- [x] Added tests for my changes
- [x] Updated documentation (task brief under `.octospec/`)
- [x] Followed commit message conventions (Conventional Commits)
