### PR TITLE
feat: close the card template catalog authorization loop (E3 PR-C)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,6 +82,9 @@ scripts/healthcheck.sh
 .claude/*
 !.claude/commands/
 !.claude/skills/
+# Agent collaboration scratch (redacted command output, hashes, test summaries).
+# Never a PR deliverable — see .octospec/tasks/*/HANDOFF.md fixture policy.
+.context/
 testenv/miniodata/
 
 # TestMakeCompose temporary fixture (modules/file/service_test.go:46)

--- a/.octospec/journal/shared/cardtmpl-runtime-catalog-grants-discovery.md
+++ b/.octospec/journal/shared/cardtmpl-runtime-catalog-grants-discovery.md
@@ -73,6 +73,72 @@ and global to a catalog. "Check the version was never claimed" as a runbook step
 is a step someone eventually skips; as a test-time assertion that names its own
 remedy, it cannot be.
 
+## What three review passes cost, and what they bought
+
+The six slices were written, then reviewed three times. Each pass found defects
+the previous one structurally could not, and two of the passes found regressions
+introduced by the *fixes* from the pass before. That pattern is the most
+transferable thing in this task.
+
+**Pass 1 (Slices 1-4, before any database ran).** Fifteen findings, eight
+confirmed correctness. All were reachable by reading; none needed a database.
+
+**The first real MySQL run.** Two defects that only a live database could show:
+a runtime-catalog integration helper asserting a hardcoded migration count, so
+the grant migration broke four unrelated tests; and `classifyRuntimeStoreError`
+demoting `ErrRuntimeCatalogDisabled` to "unavailable" once activation resolution
+moved inside the snapshot, which would have made the Bot send path report an
+outage where it should have declined quietly.
+
+**Pass 2 (Slices 4-6).** Eleven findings, two of them regressions from pass 1's
+fixes. Recording the target Space in the marker made every group and thread card
+permanently uneditable, because the edit guard compared it against the
+envelope's top-level `space_id`, which only DM sends write. And
+`docsResultVersionFromFrame` keyed off `template_ref`, which only exists on
+post-Slice-1 frames, so the two result-version callers still disagreed for every
+card already delivered. Both were single-point fixes shipped without a
+round-trip test; both were closed by adding one.
+
+**Pass 3.** Eleven findings, and the headline was an *altitude* observation
+rather than a bug: pass 2's Space fix had been applied at the symptom. The
+underlying cause was that `botCatalogPrincipal` collapses "the feature gate is
+closed" and "the group row would not load" into the same zero value, and three
+separate places had grown their own reading of that ambiguity. Fixing the guard
+alone produced two more regressions — a multi-Space Bot locked out of editing
+its own DM cards with a permanent 500, and an edit that erased the Space from a
+group card's marker whenever the gate was dark.
+
+**What actually stopped the cycle** was changing what the code *asks*:
+
+- An edit no longer re-derives the marker's Space. It preserves the one the send
+  recorded, which is already on the frame — the rule `pkg/cardtmpl`'s updater
+  had followed all along. A value that is copied cannot drift from the resolver
+  that produced it, because it never consults one.
+- "Space could not be determined" became a state distinct from "there is no
+  Space", at each of the three layers that had been conflating them, with the
+  unresolvable case reported as a retryable outage rather than a client error.
+- Every fix got a test that reproduces the *reported* failure with the fix
+  reverted. Mutation-checking each one caught two tests that passed for the
+  wrong reason.
+
+**The efficiency finding worth generalizing.** `LoadAuthorizations` batched N
+reads into one — and then propagated `ErrRuntimeCatalogDisabled` from a single
+template, failing the whole call. The caller's only recourse was to re-ask per
+ID, so one administratively disabled template silently reinstated the exact N
+round trips the batch existed to remove, for as long as an operator left it
+disabled. A batch API's error channel is part of its performance contract: if
+one member's ordinary state can fail the batch, the batch is decorative.
+
+**One review finding was wrong about its own mechanism.** Pass 2 reported that
+`storedMarkersForUpdate` turns a transient Space-lookup failure into a permanent
+`ErrUpdateInvalid`. The outcome is real, but `validateUpdateTarget` rejects an
+empty target Space before that code runs, so the fix belonged at the click
+ingress — which now refuses to create an event at all when the card's origin
+Space cannot be read. The retryable error class drafted for the updater was
+deleted once a test proved it unreachable. Shipping a fix at the layer a review
+names, without checking the layer actually executes, is how dead code enters a
+codebase wearing a justification.
+
 ## What was deliberately not done
 
 - Production activation. Both gates keep their `false` defaults and no commit
@@ -93,3 +159,36 @@ remedy, it cannot be.
 - B1 returns `action_contract: null` for dynamic rows; filling it would mean
   compiling every listed artifact, turning one list page into N detail reads.
   Callers read it from B2.
+- **Four independent encodings of "is this Space known"** now coexist:
+  `botCatalogPrincipal.SpaceResolved`, `resolveBotGrantSpaceID`'s
+  `(string, bool)`, `editSpaceCheck`, and `cardActionFrameOrigin.SpaceKnown`.
+  A shared type is buildable — `pkg/cardmsg` has no internal imports and is
+  already used by all three consumers — and was not built here because the
+  refactor spans three modules and this PR is already large. It is the highest-
+  value structural cleanup left.
+- **`RuntimeAuthorizationBatchStore` should probably be a required interface.**
+  It is optional and type-asserted, but both implementations in the repo needed
+  it and had to be hand-edited; `runtime_install.go` carries a comment warning
+  that forgetting to forward it silently drops callers onto the per-ID path.
+  Making it required turns that warning into a compile error.
+- **B1 and B2 now apply different visibility implementations.** B1 uses the SQL
+  predicate in `store_discovery.go`; B2 resolves through the runtime authorizer,
+  which additionally enforces the approved-owner allowlist. B2 is therefore
+  strictly stricter, so nothing leaks — but an owner removed from
+  `approvedRuntimeOwners` after publish would leave rows that B1 lists and B2
+  404s. `LoadDiscoverable` and `selectDiscoverableExactSQL` are now reachable
+  only from tests and should be deleted or reunified with B1.
+- **`CapabilityFor` still issues one `MetaExact` per dynamically granted
+  template**, each opening its own authorization transaction, even though
+  `ListAuthorizedTemplates` already returned that snapshot. The static half is
+  batched; the dynamic half is not.
+- **`ai.reasoning-process` is the wrong shape for this grant model.** Its
+  producers are thousands of user-created BotFather bots, and `principal_id` is
+  an exact identity with no wildcard. Activating that template ID dynamically
+  would make it unsendable for every bot without a grant row — and, because
+  `resolveBotGrantSpaceID` refuses ambiguity, the breakage would be uneven:
+  single-Space bots cut off, multi-Space bots still serving the static version.
+  Either keep that family static, or extend D2 with a principal tier below the
+  exact one (an `any_bot` row that an exact tombstone can still shadow, which
+  preserves "revoking one bot" as a decidable, auditable fact). That is a
+  contract change and belongs in its own PR, not this one.

--- a/.octospec/journal/shared/cardtmpl-runtime-catalog-grants-discovery.md
+++ b/.octospec/journal/shared/cardtmpl-runtime-catalog-grants-discovery.md
@@ -1,0 +1,95 @@
+---
+type: Journal
+title: "Journal: card template runtime catalog grants and discovery (E3 PR-C)"
+description: Record of closing the authorization loop on the dynamic card-template catalog — trusted stored provenance, MySQL producer grants, one-snapshot authorization, Bot static/dynamic merge, visibility-aware discovery and safe export, and one non-production pilot.
+tags: ["card", "cardtmpl", "runtime-catalog", "grant", "discovery", "export", "provenance", "trust-boundary", "auth", "space", "bot-api", "database", "migration", "i18n", "testing"]
+timestamp: 2026-08-05T00:00:00Z
+# --- octospec extension fields ---
+task: cardtmpl-runtime-catalog-grants-discovery
+upstream: "roadmap E3 PR-C; PR-A #674@68e8134d; PR-B #675@49a66475"
+source: self
+---
+# Journal: card template runtime catalog grants and discovery (E3 PR-C)
+
+## What was done
+
+PR-A and PR-B built the machinery: immutable artifacts, a runtime catalog, an
+activation pointer with CAS activate/rollback/block. What they could not answer
+was *who may use any of it* — the production authorizer denied every dynamic
+business access because there was nothing to consult. PR-C supplies the answer
+and wires it through every consumer, in six ordered slices.
+
+1. **Trusted stored provenance.** A dynamic card now carries a server-authored
+   `catalog_provenance` marker next to the existing `template_ref`. Historical
+   edit and action-context stop guessing the producer from `msg.FromUID` and
+   read it from the frame instead. Every raw ingress rejects both keys.
+2. **Grants.** `card_template_grant` with template-ID-level
+   `discover|send|edit`, exact-over-global precedence, revision CAS, and
+   same-transaction audit. Revoke writes a tombstone rather than deleting, so
+   revoke→recreate cannot replay an old revision.
+3. **One-snapshot authorization.** Activation, block and grant are read in a
+   single REPEATABLE READ transaction; the Bot's static allowlist and dynamic
+   grants merge behind one resolver that both the capability manifest and the
+   send path call.
+4. **Discovery and export.** B1/B2 with visibility/Space-aware filtering applied
+   before paging, one indistinguishable not-found, and an immutable safe export
+   projection built at registration/compile time.
+5. **Pilot.** The full loop against real MySQL with the existing `docs` owner,
+   `docs-notify` producer and `docs/access_request.decision` RouteSpec.
+6. **Reconciliation.** Contract docs, runbook and the L2b threshold statement
+   updated to match what shipped rather than what was drafted.
+
+Production gates stay closed. Merging PR-C authorizes nothing.
+
+## Decisions worth remembering
+
+**One authorization decision comes from one read.** The bug PR-C is really
+about is not a missing check — it is a *torn* one. Reading the activation
+pointer, then the block row, then the grant gives three answers from three
+points in time, and a revoke landing between them produces an authorized send
+against a grant that no longer exists. The fix is a store interface the caller
+*cannot pull apart*: one method, one transaction, everything the decision needs.
+That shape is the guarantee; any narrower API would let the split back in.
+
+**Fail-closed means "do not fall back", not "try something else".** Once an
+operator points a template ID at a dynamic version, an ungranted, blocked or
+unreadable outcome must make the whole ID unsendable. Falling back to the static
+card of the same ID would send materially different content under a name the
+producer believes it has replaced. Same reasoning for the Bot's Space: the
+legacy resolver's forgiving fallbacks are right for tagging a DM envelope and
+wrong as an authorization input, so PR-C added a strict twin instead of
+loosening the original.
+
+**Discoverability is not permission, and invisibility has one shape.** Seeing
+that a template exists is deliberately weaker than being allowed to use it.
+Correspondingly, "no such template", "not visible to you" and "blocked" all
+answer the same localized not-found — three distinguishable answers would let
+any authenticated caller map the private catalog by probing IDs. The same logic
+puts visibility/grant filtering *inside* the SQL predicate: filtering after
+paging returns short pages, and the shrinkage is itself a count oracle.
+
+**A permanent identity deserves a gate in code.** A version claim is permanent
+and global to a catalog. "Check the version was never claimed" as a runbook step
+is a step someone eventually skips; as a test-time assertion that names its own
+remedy, it cannot be.
+
+## What was deliberately not done
+
+- Production activation. Both gates keep their `false` defaults and no commit
+  changes them.
+- Publishing any existing static card. `applyStaticCatalogVisibility` ships as
+  an empty list so opening one up stays a separate reviewed decision.
+- Deduplicating `SpaceMiddleware`/`LocalizedSpaceMiddleware` and the two Space
+  resolvers. Both pairs are near-copies whose *only* difference is failure
+  behaviour, and that difference is the point; collapsing them would put a
+  forgiving fallback one boolean away from an authorization path.
+- L2b enablement. PR-C's grants are consumption-side authorization; the L2b
+  threshold asks for upload-side admission, which is untouched.
+
+## Follow-ups
+
+- Quality items recorded but not taken: `ReplaceView`'s extra `Snapshot` round
+  trip, and the double marshal in `cardmsg.validateCatalogMarkers`.
+- B1 returns `action_contract: null` for dynamic rows; filling it would mean
+  compiling every listed artifact, turning one list page into N detail reads.
+  Callers read it from B2.

--- a/.octospec/log.md
+++ b/.octospec/log.md
@@ -4,6 +4,29 @@ Change history for this repo's `.octospec/`, following the
 [OKF](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md)
 change-log convention (§7). Newest first.
 
+## 2026-08-05 (cardtmpl-runtime-catalog-grants-discovery, roadmap E3 PR-C server)
+
+- **Feature** — Task `cardtmpl-runtime-catalog-grants-discovery`: closed the
+  authorization loop on the dynamic card-template catalog that PR-A/PR-B left
+  inert. Six ordered slices: trusted server-authored `catalog_provenance` on
+  dynamic frames (so historical edit and action-context stop guessing the
+  producer from `msg.FromUID`); a `card_template_grant` table with template-ID
+  `discover|send|edit`, exact-over-global precedence, revision CAS and
+  same-transaction audit; **one-snapshot authorization** — activation, block and
+  grant read in a single REPEATABLE READ transaction behind a store interface
+  the caller cannot pull apart, replacing three independent reads that could be
+  assembled from three points in time; a request-scoped Bot capability manifest
+  merging static policy with dynamic grants through the resolver the send path
+  also uses; B1/B2 discovery with visibility/grant filtering applied *before*
+  paging and one indistinguishable not-found for unknown/invisible/blocked; an
+  immutable safe export projection with per-artifact opt-in samples; and a
+  non-production `docs` pilot whose version preflight is a test-time assertion
+  rather than a runbook step. Fail-closed throughout: an ungranted, blocked or
+  unreadable dynamic version makes the whole template ID unsendable rather than
+  reverting to the static card of the same ID. Production gates keep their
+  `false` defaults; merging authorizes nothing. See the
+  [journal](journal/shared/cardtmpl-runtime-catalog-grants-discovery.md).
+
 ## 2026-07-31 (bot-events-longpoll)
 
 - **Feature** — Task `bot-events-longpoll` (card-message-interaction D5 / P3-2):

--- a/.octospec/log.md
+++ b/.octospec/log.md
@@ -27,6 +27,30 @@ change-log convention (§7). Newest first.
   `false` defaults; merging authorizes nothing. See the
   [journal](journal/shared/cardtmpl-runtime-catalog-grants-discovery.md).
 
+- **Verification** — Three review passes plus a real MySQL/Redis/WuKongIM run
+  over the same six slices. The passes were not redundant: the live database
+  exposed two defects no amount of reading would have (a hardcoded migration
+  count, and `ErrRuntimeCatalogDisabled` demoted to "unavailable" once
+  activation moved inside the snapshot), and two of the three passes found
+  regressions introduced by the *previous* pass's fixes. The recurring cause
+  was a single-point fix shipped without a round-trip test; the recurring
+  remedy was a test that reproduces the reported failure with the fix reverted,
+  mutation-checked so it cannot pass for the wrong reason.
+
+  Two structural corrections came out of it. An edit now *preserves* the Space
+  its send recorded instead of re-deriving it, so the marker cannot drift with
+  whatever the resolver happens to answer at edit time. And "this Space could
+  not be determined" became a state distinct from "there is no Space" at the
+  three layers that had been conflating them — conflating them is what turned a
+  transient group-table read into a permanently uneditable card, twice.
+
+  The acceptance matrix is filled with the test that would fail if each
+  property broke (69 named tests, all verified to exist). Two items stay open
+  and are recorded as pre-merge operational prerequisites rather than as work
+  quietly dropped: multi-replica grant/revoke cache convergence, and the pilot
+  against a dedicated non-production deployment with `OCTO_PILOT_CATALOG_DSN`
+  set. Neither is reachable from a single container.
+
 ## 2026-07-31 (bot-events-longpoll)
 
 - **Feature** — Task `bot-events-longpoll` (card-message-interaction D5 / P3-2):

--- a/.octospec/tasks/cardtmpl-runtime-catalog-grants-discovery/HANDOFF.md
+++ b/.octospec/tasks/cardtmpl-runtime-catalog-grants-discovery/HANDOFF.md
@@ -377,33 +377,39 @@ marshal, and the two intentional Space/middleware duplications).
 
 ### Slice 5 — docs-notify dynamic pilot
 
-Production integration files, only where the generic slices do not already
-complete the path:
+Landed (`feat: add the controlled docs catalog pilot`):
 
-- `[modify] modules/notify/card_via_registry.go`
-- `[modify] modules/notify/action_finalizer.go`
-- `[modify] modules/notify/card.go`
-- `[modify] main.go`
+- `[new] modules/card_template_catalog/testdata/pilot/docs.access-request@0.4.0-pilot.20260805/bundle.json`
+  — owner `docs`, producer `internal_producer/docs-notify`, the existing
+  `docs/access_request.decision` RouteSpec, visibility private, and an
+  `export.samples` allowlist with one synthetic sample so the B2 export path is
+  actually exercised. Same template ID as the static card, new prerelease exact
+  version: that is what makes the shadow behaviour observable.
+- `[new] modules/card_template_catalog/testdata/pilot/README.md` — states in one
+  place that the fixture is publish input only: not registered, not embedded,
+  not an activation, not permission to open the production gates.
+- `[new] modules/card_template_catalog/pilot_mysql_integration_test.go` —
+  `requirePilotVersionUnclaimed` (the preflight gate, in code so it cannot be
+  skipped, failing with the remedy) plus the D7 loop: static baseline →
+  publish → prove publish is neither activation nor grant → grant → prove a
+  grant does not move the pointer → activate → dynamic shadows static for new
+  send → private discovery needs a Space grant and another Space sees nothing →
+  rollback while a pinned historical read is unaffected → revoke denies the very
+  next decision and leaves a tombstone. `TestPilotBundleCompilesAndProjectsSafely`
+  runs with no database so a malformed fixture fails everywhere.
+- `[modify] modules/notify/card_via_registry.go` + `card.go` —
+  `preflightDocsAccessRequestSchema` takes the Space. Template resolution became
+  Space-aware in Slice 3, so preflighting against an empty Space would authorize
+  a different decision than the send that follows it.
+- `modules/notify/action_finalizer.go` — no further change: Slice 1 already made
+  the result edit use the stored `template_id@version`.
+- `main.go` — no change was needed. The pilot fixture is never registered, so
+  the composition root has nothing to wire; treating "merged" as "wired" is
+  exactly the confusion the README exists to prevent.
 
-Pilot fixture and test:
-
-- `[new after version preflight] modules/card_template_catalog/testdata/pilot/docs.access-request@<selected-version>/bundle.json`
-- `[new] modules/notify/runtime_catalog_pilot_integration_test.go`
-
-`<selected-version>` is a placeholder, not a default. Before creating the exact
-directory, query the dedicated non-production catalog and prove the candidate
-has never been claimed. If it is already claimed, choose a new reviewed SemVer;
-never overwrite/reuse the key. The fixture is input to publish/E2E only:
-
-- do not add it to `pkg/cardtmpl/docs_access_request/handoff/`;
-- do not register it in `DefaultRegistry`;
-- do not `go:embed` it into production startup;
-- do not treat its presence in Git as activation or authorization.
-
-Exit gate: establish static `docs.access-request@0.3.0` activation baseline,
-then publish→grant→activate→B1/B2→send→Action.Submit→same-version edit→rollback;
-prove old dynamic historical edit while edit grant remains, then revoke and
-prove rejection.
+Exit gate: the pilot proves publish ≠ activate ≠ grant, dynamic-over-static
+shadowing, private discovery, historical pinning across a rollback, and
+immediate denial after revoke — with production gates untouched.
 
 ### Slice 6 — verification, operations and PR closeout
 

--- a/.octospec/tasks/cardtmpl-runtime-catalog-grants-discovery/HANDOFF.md
+++ b/.octospec/tasks/cardtmpl-runtime-catalog-grants-discovery/HANDOFF.md
@@ -379,12 +379,13 @@ marshal, and the two intentional Space/middleware duplications).
 
 Landed (`feat: add the controlled docs catalog pilot`):
 
-- `[new] modules/card_template_catalog/testdata/pilot/docs.access-request@0.4.0-pilot.20260805/bundle.json`
+- `[new] modules/card_template_catalog/testdata/pilot/docs.pilot-access-request@0.4.0-pilot.20260805/bundle.json`
   — owner `docs`, producer `internal_producer/docs-notify`, the existing
   `docs/access_request.decision` RouteSpec, visibility private, and an
   `export.samples` allowlist with one synthetic sample so the B2 export path is
-  actually exercised. Same template ID as the static card, new prerelease exact
-  version: that is what makes the shadow behaviour observable.
+  actually exercised. The ID is dedicated to the pilot (see the second-review
+  entry below: it originally reused the live `docs.access-request` ID, which
+  would have made activation reject every real access-request card).
 - `[new] modules/card_template_catalog/testdata/pilot/README.md` — states in one
   place that the fixture is publish input only: not registered, not embedded,
   not an activation, not permission to open the production gates.
@@ -500,6 +501,61 @@ WuKongIM (`card_template_catalog`, `bot_api`, `notify`, `message`,
 `test` schema — module sets differ, so two packages sharing one make sql-migrate
 report "unknown migration in database" — and `modules/robot` needs a 32-byte
 `OCTO_MASTER_KEY`.
+
+### Post-review coverage and the DM half of D6
+
+Cross-checking the brief against the branch surfaced two gaps that neither
+review caught, because both are about code that was never executed rather than
+code that was wrong.
+
+- **D6 covered group and thread targets but not DM.** `botSendCatalogPrincipal`
+  resolved the authoritative Space from the group row or the thread parent, and
+  fell back to the Bot's own Space for a personal target without checking that
+  the peer is in it. A Bot in two Spaces could therefore send a card authorized
+  against Space A to a peer who is only in Space B. `requireDMPeerInSpace` now
+  downgrades the principal to unresolved when the peer is not a member or the
+  lookup fails, and a self-addressed channel is refused outright
+  (`isUserSpaceMember` in `db.go`, narrower than `isBotSpaceAuthorized`: it is
+  a `space_member ⨝ space` test and deliberately does not honour the platform
+  App Bot rule, which is about Bots rather than about human peers). The check
+  is skipped entirely when the dynamic catalog is dark, so a gates-off
+  deployment still acquires no new DB dependency on the send path.
+- **The `card_template_catalog` handlers had no handler-level tests**, and the
+  discovery store's central promise — filtering before paging — had no
+  real-MySQL evidence. `[new] api_discovery_handler_test.go` drives B1/B2
+  directly (pagination, the not-found equivalence class, ETag/304 with an empty
+  body, the private cache directive, the manager index and its superAdmin gate),
+  and `[new] store_discovery_mysql_integration_test.go` walks the whole listing
+  at several page sizes against seeded public/private/granted/blocked/tombstoned
+  rows. The interleaving in that fixture is the point: a hidden row sits between
+  two visible ones, so post-filtering would show up as a short page rather than
+  as a merely reordered result. Both were mutation-checked — dropping the
+  visibility predicate makes the walk fail. Package coverage 65.9% → 80.4%.
+
+Fixing the 304 gap also changed production code: `c.Status` only records the
+code and leaves the write to the framework, so "304 with no body" depended on
+the caller's plumbing. `writeExport` now calls `WriteHeaderNow`.
+
+## Pre-merge operational prerequisites
+
+Two acceptance items in `brief.md` are environmental and cannot be discharged
+from a single-container checkout. They are prerequisites for merge, not
+leftovers, and each needs an operator to record the result:
+
+1. **Multi-replica grant convergence.** Prove that after a grant or revoke, a
+   replica with a cold cache and a replica with a hot cache converge on the same
+   answer within the configured TTL, and that the revoking replica is denied
+   immediately. Single-process tests cover the linearization point inside one
+   snapshot; they cannot cover the cache-invalidation window between replicas,
+   which is the only place a revoked grant can still be honoured.
+2. **The pilot on the dedicated non-production environment.** The D7 loop in
+   `pilot_mysql_integration_test.go` must run with `OCTO_PILOT_CATALOG_DSN`
+   pointing at that deployment's catalog database, so the exact-version preflight
+   interrogates real claims. Run against a per-test database the preflight is
+   theatre — it was, until the second review — and the test says so out loud
+   when the variable is unset.
+
+Neither authorizes production activation; the gates stay false either way.
 
 ## Review and commit boundaries
 

--- a/.octospec/tasks/cardtmpl-runtime-catalog-grants-discovery/HANDOFF.md
+++ b/.octospec/tasks/cardtmpl-runtime-catalog-grants-discovery/HANDOFF.md
@@ -413,28 +413,41 @@ immediate denial after revoke — with production gates untouched.
 
 ### Slice 6 — verification, operations and PR closeout
 
-Documentation files:
+Landed (`docs: complete E3 PR-C rollout handoff`):
 
-- `[modify] docs/card-template-runtime-catalog-runbook.md` — grant/rollout
-  procedures, plus a note that `l2aOwnerAllowlist` (Registry registration) and
-  `approvedRuntimeOwners` (runtime publish/authorization) are intentionally
-  different lists: a grant for an unapproved runtime owner never enables send.
-- `[modify] docs/card-protocol.md` — §1 additive top-level
-  `template_ref`/`catalog_provenance`; state explicitly that the client render
-  gate still keys on `from_uid` only (provenance is server-side authorization
-  input, not a client rendering contract).
-- `[modify] docs/platform-card-base.md` — §9 actual B1/B2 fields and
-  authorization semantics; §10 new fail-close row for dynamic
-  unauthorized/blocked/DB-unavailable (no fallback-text degradation); §2.2-5
-  note that L2b threshold ④ is not advanced by PR-C.
-- `[modify] .octospec/tasks/cardtmpl-runtime-catalog/brief.md`
-- `[modify] .octospec/tasks/cardtmpl-runtime-catalog-grants-discovery/brief.md`
-- `[modify] this HANDOFF.md` with final SHAs, commands and evidence boundaries.
+- `[new] modules/notify/docs_result_version.go` — one rule for which version a
+  docs result edit renders at, shared by the click finalizer and the sibling
+  mutate endpoint. Closes review findings #1/#15: the two paths had drifted
+  (stored version vs hardcoded V3), which is invisible only while the registry
+  default happens to be V3. A marked `0.2.0` frame is now refused with the
+  reason — that version declares no `result` view, and nothing sends it — rather
+  than failing several layers down inside `ViewFor`.
+- `[modify] modules/notify/{action_finalizer.go,card_mutate_api.go}` — both call
+  the shared helper; the mutate path reads the identity off the frame it is
+  replacing instead of assuming a constant.
+- `[modify] modules/bot_api/card_template_runtime.go` — one nil-context guard up
+  front in `resolveBotGrantSpaceID` (review #11's inconsistency).
+- `[modify] docs/platform-card-base.md` — §9 rewritten to what shipped (B1/B2
+  fields, `action_contract` null semantics, visible ≠ sendable, private by
+  default, one not-found, opt-in samples, pagination/ETag rules); §10 gained the
+  three PR-C fail-closed rows; the L2b threshold ④ progress note now states
+  plainly that PR-C's grants are consumption-side and the threshold is still
+  unmet.
+- `[modify] docs/card-protocol.md` — §1 documents the two server-only markers
+  and their compatibility matrix; §4 gains the stored-provenance verification
+  layer.
+- `[modify] docs/card-template-runtime-catalog-runbook.md` — the two owner
+  allowlists are different on purpose and now say so; the PR-B "avoid consumed
+  template IDs" drill guidance is superseded, and the Bot manifest is
+  request-scoped.
+- `[new] .octospec/journal/shared/cardtmpl-runtime-catalog-grants-discovery.md`,
+  `[modify] .octospec/log.md`.
 
-Exit gate: focused and widened tests, race, build, vet, lint, i18n, source
-guards, real MySQL concurrency, dedicated non-production two-replica
-Redis/WuKongIM pilot, restart/DB-outage and rollback evidence are complete.
-The English PR body links this spec and answers COMPREHENSION; gates stay false.
+Deliberately not done, with reasons recorded in the journal: deduplicating
+`SpaceMiddleware`/`LocalizedSpaceMiddleware` and the two Space resolvers (the
+only difference is failure behaviour, and that difference is the point);
+`ReplaceView`'s extra `Snapshot` round trip; the double marshal in
+`validateCatalogMarkers`; and `action_contract` on B1's dynamic rows.
 
 ## Review and commit boundaries
 

--- a/.octospec/tasks/cardtmpl-runtime-catalog-grants-discovery/HANDOFF.md
+++ b/.octospec/tasks/cardtmpl-runtime-catalog-grants-discovery/HANDOFF.md
@@ -300,44 +300,80 @@ view rather than the deployment's.
 
 ### Slice 4 — B1/B2 discovery and safe export
 
-Production files:
+Landed (`feat: add card template discovery and safe export`):
 
-- `[new] pkg/cardtmpl/export.go`
-- `[modify] pkg/cardtmpl/template.go`
-- `[modify] pkg/cardtmpl/registry.go`
-- `[modify] pkg/cardtmpl/json_artifact.go`
-- `[new] modules/card_template_catalog/store_discovery.go`
-- `[new] modules/card_template_catalog/api_discovery.go`
-- `[modify] modules/card_template_catalog/store_read.go` — manager read-only
-  list summary (source/visibility/active/block + bounded grant summary,
-  includes B1-hidden rows).
-- `[modify] modules/card_template_catalog/api.go`
-- `[modify] modules/card_template_catalog/api_i18n.go`
-- `[modify] modules/card_template_catalog/metrics.go`
-- `[new] pkg/space/middleware_localized.go`
-- `[modify] pkg/errcode/card_template_catalog.go`
-- `[modify] pkg/i18n/locales/active.zh-CN.toml`
-- `[modify] main.go` — composition-root static CatalogMeta injection
-  (visibility/export/sample allowlist); never edit frozen handoff manifests;
-  PR-C keeps every existing static card private.
+- `[new] pkg/cardtmpl/export.go` — `SafeExport`, the immutable B2 projection.
+  Carries manifest/schema/reports plus allowlisted samples; never templates,
+  goldens or canonical bundle bytes. Deterministic export hash (the static
+  ETag), 2 MiB cap, visibility fails closed to private, deep `Clone`.
+- `[modify] pkg/cardtmpl/template.go` — `TemplateMeta.export/contractVersion`
+  plus `Export()`/`ExportHash()`.
+- `[modify] pkg/cardtmpl/registry.go` — projection built at registration from
+  the same reviewed bytes; `rawSchemaBytes`/`rawInteractionReports`;
+  `SetCatalogVisibility` (pre-Freeze composition-root seam) and
+  `StaticCatalog()` for B1.
+- `[modify] pkg/cardtmpl/json_artifact.go` — manifest gains a strict
+  `export.samples` opt-in allowlist; projection built during compile so an
+  allowlist naming a missing sample fails publish rather than serving a hole.
+- `[modify] pkg/cardtmpl/catalog.go` — `CatalogPurposeDiscover`,
+  `CatalogPrincipalSpace`.
+- `[new] modules/card_template_catalog/store_discovery.go` — visibility, block
+  state and the caller's discover grant are all inside the SQL predicate, so
+  they settle before LIMIT; `ErrDiscoveryNotVisible` is the single outcome for
+  unknown/invisible/blocked.
+- `[new] modules/card_template_catalog/api_discovery.go` — B1/B2 handlers, the
+  Space-bound opaque cursor, `{id}@{version}` exact-only refs, ETag/304,
+  `Cache-Control: private, no-cache` for private reads, and the manager
+  template index.
+- `[modify] modules/card_template_catalog/store_read.go` — manager keyset index.
+- `[modify] modules/card_template_catalog/api.go` — B1/B2 route group
+  `Auth → SharedUIDRateLimiter → LocalizedSpaceMiddleware`; manager `GET ""`.
+- `[modify] modules/card_template_catalog/api_i18n.go` — `respondCatalogNotFound`.
+- `[modify] modules/card_template_catalog/runtime_install.go` — public
+  templates are discoverable without a grant; the new-send gate does not apply
+  to discovery.
+- `[new] pkg/space/middleware_localized.go` — same membership rule, cache keys
+  and TTLs as `SpaceMiddleware`; only the failure responses move to `httperr`.
+- `[modify] main.go` — `applyStaticCatalogVisibility`, deliberately an empty
+  list: all five existing L2a cards stay private.
 
-Focused tests:
+Focused tests: `[new] pkg/cardtmpl/export_test.go`,
+`[new] modules/card_template_catalog/api_discovery_test.go`.
 
-- `[new] pkg/cardtmpl/export_test.go`
-- `[new] modules/card_template_catalog/store_discovery_mysql_integration_test.go`
-- `[new] modules/card_template_catalog/api_discovery_test.go`
-- `[new] pkg/space/middleware_localized_test.go`
-- `[modify] modules/card_template_catalog/api_test.go` — add
-  `api_discovery.go` to `TestCatalogNoLegacyErrorResponses`.
+Exit gate: filtering precedes paging; a cursor cannot be replayed across
+Spaces; unknown/invisible/blocked are indistinguishable; samples are opt-in;
+static cards stay private.
 
-Exit gate: public/private/Space/superAdmin matrix, visible-only cursor,
-cross-Space replay rejection, anti-enumeration, ETag/304/cache headers, 2 MiB
-cap and synthetic-only samples are proven. Request handlers read immutable
-projection bytes, never repository source paths. B1 rows expose the
-`action_contract` capability field; existing static cards stay
-private-by-default; the manager list endpoint returns B1-hidden rows to
-superAdmin only and uses `httperr.ResponseErrorL` like every other B1/B2 and
-localized-Space failure.
+### Review follow-ups (post-`/code-review`, folded into Slice 4's commit)
+
+Eight confirmed correctness findings fixed; one finding (MetaDefault losing
+`rejectIntegrity`) verified as a false positive — the unpinned path calls
+`requireReady`, whose error set is a superset.
+
+1. Bot grant Space is resolved only when the dynamic catalog is enabled, so a
+   gates-off deployment keeps `/v1/bot/card/profile` free of a DB dependency.
+2. New-send provenance is stamped with the *authorized* Space (target group or
+   thread parent), not `env.SpaceID`, which send.go fills only for DMs — the
+   downstream D3 guards are `!= ""` and were no-ops for group cards.
+3. `ListAuthorizedTemplates` reads one row past its budget and drops the
+   template the cut landed in, so an exact tombstone can never be separated
+   from its global row.
+4. `dynamicPageFollows` peeks with a budget of one instead of asserting
+   `has_more` at the static/dynamic boundary.
+5. `privateTemplateIDs` deduplicates the grant probe by template ID.
+6. Manager detail serves the rest of the response with `grants_unavailable`
+   when the grant summary read fails, and `ListGrants` orders active rows
+   before tombstones.
+7. `respondCatalogGrantInvalid` logs the rejection reason it previously dropped.
+8. `setupBotCardProfile` resets the `ratelimit:uid:*` bucket now that the route
+   mounts `SharedUIDRateLimiter`.
+
+Still open, tracked for Slice 6: the docs.access-request 0.2.0 result-edit
+guard (`docsResultTemplateVersion` plus the hardcoded V3 in
+`card_mutate_api.go`) — unreachable today because nothing sends 0.2.0, but the
+two call sites need one shared version-selection helper; and the quality
+findings (ReplaceView's extra Snapshot round trip, the provenance double
+marshal, and the two intentional Space/middleware duplications).
 
 ### Slice 5 — docs-notify dynamic pilot
 

--- a/.octospec/tasks/cardtmpl-runtime-catalog-grants-discovery/HANDOFF.md
+++ b/.octospec/tasks/cardtmpl-runtime-catalog-grants-discovery/HANDOFF.md
@@ -560,6 +560,37 @@ the result:
 
 Neither authorizes production activation; the gates stay false either way.
 
+### 3. Make the DM grant scope target-authoritative — blocks the new-send gate
+
+Not a merge item, and deliberately so: it changes no behaviour while
+`OCTO_CARD_RUNTIME_CATALOG_NEW_SEND_ENABLED` is false. It is a hard prerequisite
+for flipping that gate, and nothing else in this document is allowed to be read
+as discharging it.
+
+For a group or thread the grant scope is **target-authoritative**: it is read
+from the group row, so the caller cannot steer it. For a DM there is no target
+row, so the scope is derived from the *sender's* request context — where
+`X-Space-ID` steers it. Three separate defects have now come out of that
+asymmetry (review rounds 3, 4 and 5), each one a case where the Space that
+authorized a decision and the Space that some later layer derived were not the
+same value. The last of them was introduced by the commit whose stated purpose
+was to remove that class.
+
+The point fixes in `f80d30fb` and its successor close every instance found so
+far and are individually regression-tested. They do not remove the asymmetry.
+Before the gate is flipped, resolve the **peer's** Space and scope the DM grant
+to it, the way `botCatalogPrincipalForGroup` already does for a group, instead
+of deriving the scope from the sender's membership and then verifying the peer
+against it. Authorize a historical edit against the Space the *frame* records
+rather than the one the request presents, for the same reason: the frame is the
+authoritative record of what its send was authorized for, and an edit is already
+pinned to the stored version.
+
+Until that lands, treat every new consumer of `botCatalogSpaceState` as
+requiring the same audit — the three-state split is correct but it is a
+description of what a single resolver could establish, not a guarantee that two
+layers consulted the same one.
+
 ## Review and commit boundaries
 
 Keep all slices in one PR-C branch, but make each slice independently

--- a/.octospec/tasks/cardtmpl-runtime-catalog-grants-discovery/HANDOFF.md
+++ b/.octospec/tasks/cardtmpl-runtime-catalog-grants-discovery/HANDOFF.md
@@ -538,9 +538,12 @@ the caller's plumbing. `writeExport` now calls `WriteHeaderNow`.
 
 ## Pre-merge operational prerequisites
 
-Two acceptance items in `brief.md` are environmental and cannot be discharged
-from a single-container checkout. They are prerequisites for merge, not
-leftovers, and each needs an operator to record the result:
+The acceptance matrix in `brief.md` is filled in as of 2026-08-06: 27 of its 29
+items name the test that would fail if the property broke, and every cited test
+name was verified to exist. The two below are the remainder. They are
+environmental, cannot be discharged from a single-container checkout, and are
+prerequisites for merge rather than leftovers — each needs an operator to record
+the result:
 
 1. **Multi-replica grant convergence.** Prove that after a grant or revoke, a
    replica with a cold cache and a replica with a hot cache converge on the same

--- a/.octospec/tasks/cardtmpl-runtime-catalog-grants-discovery/HANDOFF.md
+++ b/.octospec/tasks/cardtmpl-runtime-catalog-grants-discovery/HANDOFF.md
@@ -78,20 +78,34 @@ OpenClaw stop/retry implementation.
 Purpose: make principal/template/Space identity trustworthy before grants are
 introduced.
 
-Production files:
+Production files (ledger updated at Slice 1 GREEN, 2026-08-05 — the wire
+value object landed in `pkg/cardmsg` because `pkg/cardtmpl` imports
+`internal/carddispatch` (updater), so carddispatch could not import a
+cardtmpl-owned marker type without a cycle; envelope-level parsing also
+belongs with `CardTemplateContext`):
 
-- `[new] pkg/cardtmpl/provenance.go` — canonical marker type, strict parse,
-  clone/equality and dynamic validation helpers.
-- `[modify] pkg/cardtmpl/catalog.go` — carry validated provenance in exact/action
-  context without changing raw caller request shape.
-- `[modify] pkg/cardtmpl/updater.go` — Snapshot before dynamic ReplaceView/Append
-  and preserve exact identity.
-- `[modify] internal/carddispatch/types.go`
-- `[modify] internal/carddispatch/registry.go`
-- `[modify] internal/carddispatch/context.go`
-- `[modify] internal/carddispatch/dispatch.go`
-- `[modify] internal/carddispatch/mutation.go` — author producer-bound marker,
-  retain `template_ref`, and expose read-only binding/Snapshot facts.
+- `[new] pkg/cardmsg/provenance.go` — canonical marker wire type, strict
+  parse/marshal, `CatalogFrameMarkers` frame extraction with
+  `template_ref`↔`metadata.octo.template` cross-check, `Validate()`
+  defense-in-depth hook (see `[modify] pkg/cardmsg/validate.go`).
+- `[new] pkg/cardtmpl/provenance.go` — provenance→CatalogPrincipal mapping
+  (the only bridge from stored frames into authorization input).
+- `pkg/cardtmpl/catalog.go` — no change was needed; the mapping lives in
+  `pkg/cardtmpl/provenance.go` and access construction stays at call sites.
+- `[modify] pkg/cardtmpl/updater.go` — Snapshot before ReplaceView, stored
+  identity/Space pinning, marker preservation, provenance-derived edit
+  principal for both ReplaceView and Append.
+- `internal/carddispatch/types.go` / `mutation.go` — no change was needed:
+  markers are authored from already-validated card metadata (no new Card
+  field), and `Snapshot` already exposes the effective frame.
+- `[modify] internal/carddispatch/registry.go` — read-only
+  `ProducerBinding` fact table (disabled specs keep their identity binding;
+  duplicates/invalid shapes never bind).
+- `[modify] internal/carddispatch/context.go` — `ProducerBindingFromContext`
+  (never returns send capability).
+- `[modify] internal/carddispatch/dispatch.go` — author producer-bound
+  markers from `ProducerSpec.ID` + authorized target Space, only for
+  documents carrying validated Registry metadata.
 - `[modify] modules/bot_api/card_template_catalog.go`
 - `[modify] modules/bot_api/send.go` — author Bot marker and reject raw forgery
   on send/edit.
@@ -100,12 +114,18 @@ Production files:
   separate reject helper; do not reuse or change the semantics of the existing
   `__obo_*` silent-strip function (its file-header rationale does not apply to
   keys this PR introduces).
-- `[modify] modules/message/api_card_action.go`
+- `[modify] modules/message/api_card_action.go` — `cardActionFrameOrigin` +
+  `validatedFramePrincipal`; provenance-derived access with sender/binding/
+  Space consistency, legacy sender fallback for unmarked frames.
 - `[modify] internal/cardactiondispatch/contract.go` — persist validated
-  provenance in additive durable `CardContext` fields.
-- `[modify] modules/notify/card_via_registry.go`
-- `[modify] modules/notify/action_finalizer.go` — consume stored exact identity;
-  do not infer producer from sender/owner.
+  provenance in additive durable `CardContext` fields (the frozen
+  octo-card-v1 callback envelope does not grow the principal).
+- `modules/notify/card_via_registry.go` — no change was needed: its send
+  access is already the composition-injected internal producer, and markers
+  are authored inside `carddispatch.producerSender`.
+- `[modify] modules/notify/action_finalizer.go` — `docsResultTemplateVersion`
+  consumes the event's stored exact identity; foreign template IDs fail
+  closed; legacy zero-context events keep static V3.
 
 Focused tests extend the existing package suites:
 
@@ -127,8 +147,12 @@ Focused tests extend the existing package suites:
 - `modules/notify/card_via_registry_test.go`
 - `modules/notify/action_finalizer_v3_test.go`
 
-Add `[new] pkg/cardtmpl/provenance_test.go` only for the new value object's
-table-driven unit matrix. Do not create one new test file per attack case.
+Add `[new] pkg/cardmsg/provenance_test.go` (wire matrix) and
+`[new] pkg/cardtmpl/provenance_test.go` (principal mapping) only for the new
+value object's table-driven unit matrix. Do not create one new test file per
+attack case. `modules/message/api_card_p1_test.go` and the robot/user absolute
+rejection suites are MySQL/Redis-gated: their existing assertions are the
+regression coverage and must run in CI, not be reported green locally.
 
 Exit gate: raw Bot/robot/user/incoming-webhook forge, cross-bot,
 cross-producer, cross-Space, missing/malformed marker, `template_ref` mismatch

--- a/.octospec/tasks/cardtmpl-runtime-catalog-grants-discovery/HANDOFF.md
+++ b/.octospec/tasks/cardtmpl-runtime-catalog-grants-discovery/HANDOFF.md
@@ -449,6 +449,58 @@ only difference is failure behaviour, and that difference is the point);
 `ReplaceView`'s extra `Snapshot` round trip; the double marshal in
 `validateCatalogMarkers`; and `action_contract` on B1's dynamic rows.
 
+### Post-Slice-6: integration run and second review
+
+The branch was first validated against real MySQL/Redis/WuKongIM at this point,
+and separately reviewed over the three commits Slice 4's review had not covered.
+Both found defects the earlier passes structurally could not.
+
+Only a live database could show:
+
+- the runtime-catalog integration helper asserted a hardcoded migration count,
+  so the grant migration broke four unrelated tests;
+- `classifyRuntimeStoreError` demoted `ErrRuntimeCatalogDisabled` to
+  "unavailable" once activation resolution moved inside the snapshot, which
+  would have made the Bot send path report an outage where it should have
+  declined quietly.
+
+The second review found eleven, of which two were regressions introduced by the
+*fixes* to the first review — a reminder that a single-point fix without a
+round-trip test is not a fix:
+
+1. Recording the target Space in the marker made every group/thread card
+   permanently uneditable, because the edit guard compared it against the
+   envelope's top-level `space_id`, which only DM sends write. Both sides now
+   compose the Space the same way, and a group send-then-edit round trip covers
+   it.
+2. `docsResultVersionFromFrame` keyed off the top-level `template_ref`, which
+   only exists on post-Slice-1 frames, so the two callers still disagreed for
+   every card already delivered. It reads `metadata.octo.template` now — the
+   same source the click path uses.
+3. The pilot claimed the live `docs.access-request` ID while declaring its own
+   strict contract; activating it anywhere the notify docs producer runs would
+   have rejected every real access-request card. It has a dedicated ID, and the
+   fixture test asserts the separation.
+4. The version preflight queried the per-test database, which is created empty
+   moments earlier, so it could never fail. It now interrogates
+   `OCTO_PILOT_CATALOG_DSN` and says out loud when it verified nothing.
+5. Smaller: the Bot gate now reads the same accessor the decision reads; the
+   advertised-set truncation only drops a template when the cut landed inside
+   it; the degraded grant summary keeps its DB metric; the other two notify
+   preflights are Space-aware; grant rejections log at Warn; stale comments
+   naming V3 are gone.
+
+One review finding was verified as a false positive: `MetaDefault` did not lose
+its integrity guard — the unpinned path calls `requireReady`, whose error set is
+a superset of `rejectIntegrity`'s.
+
+Verification: every affected package passes against real MySQL, Redis and
+WuKongIM (`card_template_catalog`, `bot_api`, `notify`, `message`,
+`incomingwebhook`, `robot`, all of `pkg/...`). Each package needs its own fresh
+`test` schema — module sets differ, so two packages sharing one make sql-migrate
+report "unknown migration in database" — and `modules/robot` needs a 32-byte
+`OCTO_MASTER_KEY`.
+
 ## Review and commit boundaries
 
 Keep all slices in one PR-C branch, but make each slice independently

--- a/.octospec/tasks/cardtmpl-runtime-catalog-grants-discovery/HANDOFF.md
+++ b/.octospec/tasks/cardtmpl-runtime-catalog-grants-discovery/HANDOFF.md
@@ -3,7 +3,8 @@
 > Forward-looking implementation guide. `brief.md` in this directory is the
 > contract of record; this file says where implementation starts, which
 > repository files belong to each slice, and what must never be committed.
-> Last updated 2026-08-05. All paths below are repository-relative.
+> Last updated 2026-08-05 (round 2 — brief "Plan refinement log" applied to the
+> Slice 1/4/6 ledgers below). All paths below are repository-relative.
 
 ## TL;DR
 
@@ -95,7 +96,10 @@ Production files:
 - `[modify] modules/bot_api/send.go` — author Bot marker and reject raw forgery
   on send/edit.
 - `[modify] modules/robot/sanitize_robot_ingress.go` — reject the server-only
-  template/provenance fields on the legacy raw robot card ingress.
+  template/provenance fields on the legacy raw robot card ingress. Add a
+  separate reject helper; do not reuse or change the semantics of the existing
+  `__obo_*` silent-strip function (its file-header rationale does not apply to
+  keys this PR introduces).
 - `[modify] modules/message/api_card_action.go`
 - `[modify] internal/cardactiondispatch/contract.go` — persist validated
   provenance in additive durable `CardContext` fields.
@@ -211,12 +215,18 @@ Production files:
 - `[modify] pkg/cardtmpl/json_artifact.go`
 - `[new] modules/card_template_catalog/store_discovery.go`
 - `[new] modules/card_template_catalog/api_discovery.go`
+- `[modify] modules/card_template_catalog/store_read.go` — manager read-only
+  list summary (source/visibility/active/block + bounded grant summary,
+  includes B1-hidden rows).
 - `[modify] modules/card_template_catalog/api.go`
 - `[modify] modules/card_template_catalog/api_i18n.go`
 - `[modify] modules/card_template_catalog/metrics.go`
 - `[new] pkg/space/middleware_localized.go`
 - `[modify] pkg/errcode/card_template_catalog.go`
 - `[modify] pkg/i18n/locales/active.zh-CN.toml`
+- `[modify] main.go` — composition-root static CatalogMeta injection
+  (visibility/export/sample allowlist); never edit frozen handoff manifests;
+  PR-C keeps every existing static card private.
 
 Focused tests:
 
@@ -230,7 +240,11 @@ Focused tests:
 Exit gate: public/private/Space/superAdmin matrix, visible-only cursor,
 cross-Space replay rejection, anti-enumeration, ETag/304/cache headers, 2 MiB
 cap and synthetic-only samples are proven. Request handlers read immutable
-projection bytes, never repository source paths.
+projection bytes, never repository source paths. B1 rows expose the
+`action_contract` capability field; existing static cards stay
+private-by-default; the manager list endpoint returns B1-hidden rows to
+superAdmin only and uses `httperr.ResponseErrorL` like every other B1/B2 and
+localized-Space failure.
 
 ### Slice 5 — docs-notify dynamic pilot
 
@@ -266,9 +280,18 @@ prove rejection.
 
 Documentation files:
 
-- `[modify] docs/card-template-runtime-catalog-runbook.md`
-- `[modify] docs/card-protocol.md`
-- `[modify] docs/platform-card-base.md`
+- `[modify] docs/card-template-runtime-catalog-runbook.md` — grant/rollout
+  procedures, plus a note that `l2aOwnerAllowlist` (Registry registration) and
+  `approvedRuntimeOwners` (runtime publish/authorization) are intentionally
+  different lists: a grant for an unapproved runtime owner never enables send.
+- `[modify] docs/card-protocol.md` — §1 additive top-level
+  `template_ref`/`catalog_provenance`; state explicitly that the client render
+  gate still keys on `from_uid` only (provenance is server-side authorization
+  input, not a client rendering contract).
+- `[modify] docs/platform-card-base.md` — §9 actual B1/B2 fields and
+  authorization semantics; §10 new fail-close row for dynamic
+  unauthorized/blocked/DB-unavailable (no fallback-text degradation); §2.2-5
+  note that L2b threshold ④ is not advanced by PR-C.
 - `[modify] .octospec/tasks/cardtmpl-runtime-catalog/brief.md`
 - `[modify] .octospec/tasks/cardtmpl-runtime-catalog-grants-discovery/brief.md`
 - `[modify] this HANDOFF.md` with final SHAs, commands and evidence boundaries.

--- a/.octospec/tasks/cardtmpl-runtime-catalog-grants-discovery/HANDOFF.md
+++ b/.octospec/tasks/cardtmpl-runtime-catalog-grants-discovery/HANDOFF.md
@@ -1,0 +1,361 @@
+# Handoff — E3 PR-C grants, discovery and controlled consumption
+
+> Forward-looking implementation guide. `brief.md` in this directory is the
+> contract of record; this file says where implementation starts, which
+> repository files belong to each slice, and what must never be committed.
+> Last updated 2026-08-05. All paths below are repository-relative.
+
+## TL;DR
+
+- PR-A/#674 and PR-B/#675 are merged. PR-C business code has not started on
+  this checkout; only the OctoSpec documents are modified/untracked.
+- PR-C is one reviewable milestone implemented as six ordered RED→GREEN slices.
+- Slice 1 is provenance, not grants or discovery. It closes the trusted identity
+  gap before any grant can be consumed.
+- A test file or fixture belongs to PR-C only when it proves a named PR-C
+  invariant. “Suggested test artifacts” are not an independent deliverable.
+- The docs pilot bundle is a Slice 5 input, not a Slice 1 prerequisite and not a
+  new built-in/static template. Its exact version is allocated only after the
+  dedicated non-production database proves the candidate key is unclaimed.
+- Production runtime-catalog gates remain false. PR-C merge and the
+  non-production pilot do not authorize production activation.
+
+## Authority and path convention
+
+Use this order when documents disagree:
+
+1. `brief.md` — authorization, consistency, visibility and rollout contract.
+2. this `HANDOFF.md` — execution order, repository file ownership and gates.
+3. current production code and tests — exact existing API and package shape.
+4. `docs/card-template-runtime-catalog-runbook.md` and
+   `docs/card-protocol.md` — operator/client documentation updated in Slice 6.
+
+Paths in this handoff are repository-relative and never include a Conductor
+workspace prefix. `[new]` means the planned file does not exist at handoff time;
+`[modify]` means it exists on `main@40627cc0`. If implementation discovers that
+an existing package boundary makes a planned new file unnecessary, keep the
+same ownership and tests and update this ledger in the same change.
+
+## Baseline and start conditions
+
+Verified at handoff time:
+
+- base: `origin/main@40627cc0`;
+- runtime catalog already provides immutable claim/artifact/audit, activation,
+  rollback, block, cache and default-off control/new-send gates;
+- `CatalogAccess` already carries purpose plus `bot|internal_producer|system`,
+  but the production dynamic authorizer has no grant store and rejects business
+  use;
+- Bot frames keep `template_ref`; internal `carddispatch` frames do not keep
+  producer/template provenance;
+- B1/B2 and `card_template_grant` do not exist;
+- no Go tests or business-code validation have run for this PR-C checkout yet.
+
+Before each slice, re-check `git status`, preserve unrelated worktree changes,
+and write the focused RED test before production code. No slice may enable the
+production gates.
+
+## Deliverable boundary
+
+PR-C must land all of the following together:
+
+1. server-authored, stored and validated dynamic-card provenance;
+2. template-ID grant persistence, CAS, tombstones, audit and control API;
+3. one-snapshot runtime authorization for new-send/edit/action;
+4. request-scoped Bot capability plus authoritative target-Space resolution;
+5. visibility-aware B1/B2 with bounded safe export;
+6. one repeatable non-production docs-notify pilot and operational evidence.
+
+PR-C does not add Bot self-service publishing, production activation, new
+RouteSpecs/secrets/finalizers, per-Space active versions, L2b `ext.*`, or an
+OpenClaw stop/retry implementation.
+
+## Ordered file ledger
+
+### Slice 1 — stored provenance
+
+Purpose: make principal/template/Space identity trustworthy before grants are
+introduced.
+
+Production files:
+
+- `[new] pkg/cardtmpl/provenance.go` — canonical marker type, strict parse,
+  clone/equality and dynamic validation helpers.
+- `[modify] pkg/cardtmpl/catalog.go` — carry validated provenance in exact/action
+  context without changing raw caller request shape.
+- `[modify] pkg/cardtmpl/updater.go` — Snapshot before dynamic ReplaceView/Append
+  and preserve exact identity.
+- `[modify] internal/carddispatch/types.go`
+- `[modify] internal/carddispatch/registry.go`
+- `[modify] internal/carddispatch/context.go`
+- `[modify] internal/carddispatch/dispatch.go`
+- `[modify] internal/carddispatch/mutation.go` — author producer-bound marker,
+  retain `template_ref`, and expose read-only binding/Snapshot facts.
+- `[modify] modules/bot_api/card_template_catalog.go`
+- `[modify] modules/bot_api/send.go` — author Bot marker and reject raw forgery
+  on send/edit.
+- `[modify] modules/robot/sanitize_robot_ingress.go` — reject the server-only
+  template/provenance fields on the legacy raw robot card ingress.
+- `[modify] modules/message/api_card_action.go`
+- `[modify] internal/cardactiondispatch/contract.go` — persist validated
+  provenance in additive durable `CardContext` fields.
+- `[modify] modules/notify/card_via_registry.go`
+- `[modify] modules/notify/action_finalizer.go` — consume stored exact identity;
+  do not infer producer from sender/owner.
+
+Focused tests extend the existing package suites:
+
+- `pkg/cardtmpl/updater_test.go`
+- `internal/carddispatch/dispatch_test.go`
+- `internal/carddispatch/mutation_test.go`
+- `modules/bot_api/card_template_catalog_test.go`
+- `modules/bot_api/card_template_send_test.go`
+- `modules/bot_api/card_template_edit_test.go`
+- `modules/robot/sanitize_robot_ingress_test.go`
+- `modules/robot/card_p1_test.go`
+- `modules/message/api_card_p1_test.go` — retain the absolute user type-17
+  rejection before persistence.
+- `modules/incomingwebhook/util_test.go` and
+  `modules/incomingwebhook/card_test.go` — prove caller `extra` cannot cross the
+  server-built webhook envelope and no dynamic marker is forged.
+- `modules/message/card_action_template_context_test.go`
+- `internal/cardactiondispatch/contract_test.go`
+- `modules/notify/card_via_registry_test.go`
+- `modules/notify/action_finalizer_v3_test.go`
+
+Add `[new] pkg/cardtmpl/provenance_test.go` only for the new value object's
+table-driven unit matrix. Do not create one new test file per attack case.
+
+Exit gate: raw Bot/robot/user/incoming-webhook forge, cross-bot,
+cross-producer, cross-Space, missing/malformed marker, `template_ref` mismatch
+and no-Snapshot mutation are RED then GREEN; static historical frames remain
+compatible. User and incoming-webhook production paths need no new capability:
+their existing absolute card rejection/server-built envelope remains the
+boundary and receives regression coverage only.
+
+### Slice 2 — grant migration, store and manager API
+
+Production files:
+
+- `[new] modules/card_template_catalog/sql/20260805000001_card_template_catalog_grant.sql`
+- `[new] modules/card_template_catalog/store_grant.go`
+- `[new] modules/card_template_catalog/api_grant.go`
+- `[modify] internal/carddispatch/context.go` — consume only the read-only
+  producer-binding resolver installed in Slice 1; the request body cannot
+  construct a `ProducerSpec`.
+- `[modify] modules/card_template_catalog/store.go`
+- `[modify] modules/card_template_catalog/api.go`
+- `[modify] modules/card_template_catalog/api_state.go`
+- `[modify] modules/card_template_catalog/api_i18n.go`
+- `[modify] modules/card_template_catalog/metrics.go`
+- `[modify] pkg/errcode/card_template_catalog.go`
+- `[modify] pkg/i18n/locales/active.zh-CN.toml`
+
+Focused tests:
+
+- `[new] modules/card_template_catalog/store_grant_test.go`
+- `[new] modules/card_template_catalog/store_grant_mysql_integration_test.go`
+- `[new] modules/card_template_catalog/api_grant_test.go`
+- `[modify] modules/card_template_catalog/api_test.go` — add `api_grant.go` to
+  `TestCatalogNoLegacyErrorResponses` and keep the authenticated route guard.
+
+Exit gate: create/update/revoke CAS, exact-over-global, exact tombstone, ABA,
+permission/principal matrix, concurrent winner, same-transaction audit,
+superAdmin/auth/rate-limit/i18n and strict-body behavior are proven. Migration
+Down exists for test rollback; production rollback does not rely on Down.
+
+### Slice 3 — atomic authorization and Bot merge
+
+Production files:
+
+- `[modify] pkg/cardtmpl/catalog.go`
+- `[modify] pkg/cardtmpl/runtime_catalog.go`
+- `[new] modules/card_template_catalog/store_authorization.go`
+- `[modify] modules/card_template_catalog/store_runtime.go`
+- `[modify] modules/card_template_catalog/runtime_install.go`
+- `[modify] modules/bot_api/card_template_catalog.go`
+- `[modify] modules/bot_api/bot_api.go` — mount only the card-profile route as
+  `authBot → botActorUID → SharedUIDRateLimiter`; do not silently rate-limit
+  unrelated legacy Bot routes.
+- `[modify] modules/bot_api/card_profile.go`
+- `[modify] modules/bot_api/send.go`
+- `[modify] modules/bot_api/resolve_targets.go`
+- `[modify] modules/bot_api/space_inject.go`
+- `[modify] main.go` — inject the shared resolver/binding dependencies; do not
+  create a second grant truth.
+
+Focused tests:
+
+- `[modify] pkg/cardtmpl/runtime_catalog_test.go`
+- `[new] modules/card_template_catalog/store_authorization_mysql_integration_test.go`
+- `[modify] modules/card_template_catalog/runtime_db_integration_test.go`
+- `[modify] modules/bot_api/card_template_catalog_test.go`
+- `[modify] modules/bot_api/card_profile_test.go`
+- `[modify] modules/bot_api/card_template_send_test.go`
+- `[modify] modules/bot_api/card_template_edit_test.go`
+- `[modify] modules/bot_api/resolve_targets_test.go`
+- `[modify] modules/bot_api/space_inject_multispace_test.go`
+
+Exit gate: active/block/grant are read in one primary-DB snapshot; profile and
+send share the same resolver but make independent decisions; dynamic active
+shadows static same-ID new-send; revoke/DB failure/invalid or ambiguous Space
+never falls back; static gate-off behavior does not gain a DB dependency.
+
+### Slice 4 — B1/B2 discovery and safe export
+
+Production files:
+
+- `[new] pkg/cardtmpl/export.go`
+- `[modify] pkg/cardtmpl/template.go`
+- `[modify] pkg/cardtmpl/registry.go`
+- `[modify] pkg/cardtmpl/json_artifact.go`
+- `[new] modules/card_template_catalog/store_discovery.go`
+- `[new] modules/card_template_catalog/api_discovery.go`
+- `[modify] modules/card_template_catalog/api.go`
+- `[modify] modules/card_template_catalog/api_i18n.go`
+- `[modify] modules/card_template_catalog/metrics.go`
+- `[new] pkg/space/middleware_localized.go`
+- `[modify] pkg/errcode/card_template_catalog.go`
+- `[modify] pkg/i18n/locales/active.zh-CN.toml`
+
+Focused tests:
+
+- `[new] pkg/cardtmpl/export_test.go`
+- `[new] modules/card_template_catalog/store_discovery_mysql_integration_test.go`
+- `[new] modules/card_template_catalog/api_discovery_test.go`
+- `[new] pkg/space/middleware_localized_test.go`
+- `[modify] modules/card_template_catalog/api_test.go` — add
+  `api_discovery.go` to `TestCatalogNoLegacyErrorResponses`.
+
+Exit gate: public/private/Space/superAdmin matrix, visible-only cursor,
+cross-Space replay rejection, anti-enumeration, ETag/304/cache headers, 2 MiB
+cap and synthetic-only samples are proven. Request handlers read immutable
+projection bytes, never repository source paths.
+
+### Slice 5 — docs-notify dynamic pilot
+
+Production integration files, only where the generic slices do not already
+complete the path:
+
+- `[modify] modules/notify/card_via_registry.go`
+- `[modify] modules/notify/action_finalizer.go`
+- `[modify] modules/notify/card.go`
+- `[modify] main.go`
+
+Pilot fixture and test:
+
+- `[new after version preflight] modules/card_template_catalog/testdata/pilot/docs.access-request@<selected-version>/bundle.json`
+- `[new] modules/notify/runtime_catalog_pilot_integration_test.go`
+
+`<selected-version>` is a placeholder, not a default. Before creating the exact
+directory, query the dedicated non-production catalog and prove the candidate
+has never been claimed. If it is already claimed, choose a new reviewed SemVer;
+never overwrite/reuse the key. The fixture is input to publish/E2E only:
+
+- do not add it to `pkg/cardtmpl/docs_access_request/handoff/`;
+- do not register it in `DefaultRegistry`;
+- do not `go:embed` it into production startup;
+- do not treat its presence in Git as activation or authorization.
+
+Exit gate: establish static `docs.access-request@0.3.0` activation baseline,
+then publish→grant→activate→B1/B2→send→Action.Submit→same-version edit→rollback;
+prove old dynamic historical edit while edit grant remains, then revoke and
+prove rejection.
+
+### Slice 6 — verification, operations and PR closeout
+
+Documentation files:
+
+- `[modify] docs/card-template-runtime-catalog-runbook.md`
+- `[modify] docs/card-protocol.md`
+- `[modify] docs/platform-card-base.md`
+- `[modify] .octospec/tasks/cardtmpl-runtime-catalog/brief.md`
+- `[modify] .octospec/tasks/cardtmpl-runtime-catalog-grants-discovery/brief.md`
+- `[modify] this HANDOFF.md` with final SHAs, commands and evidence boundaries.
+
+Exit gate: focused and widened tests, race, build, vet, lint, i18n, source
+guards, real MySQL concurrency, dedicated non-production two-replica
+Redis/WuKongIM pilot, restart/DB-outage and rollback evidence are complete.
+The English PR body links this spec and answers COMPREHENSION; gates stay false.
+
+## Review and commit boundaries
+
+Keep all slices in one PR-C branch, but make each slice independently
+reviewable. Recommended Conventional Commit boundaries are:
+
+1. Slice 1 RED evidence, then `feat: persist trusted card catalog provenance`;
+2. Slice 2 RED evidence, then `feat: add card template producer grants`;
+3. Slice 3 RED evidence, then `feat: enforce runtime card catalog grants`;
+4. Slice 4 RED evidence, then `feat: add card template discovery APIs`;
+5. Slice 5 RED evidence, then `feat: add controlled docs catalog pilot`;
+6. `docs: complete E3 PR-C rollout handoff` after all verification.
+
+RED evidence may be a separate `test:` commit or recorded in the PR when the
+repository is expected to keep every commit buildable. Do not merge or deploy
+an intermediate slice by itself. Slice 2's migration is not a standalone
+release, and no commit may change production gate defaults.
+
+## Repository fixture policy
+
+The following are PR-C repository deliverables because automated tests consume
+them:
+
+- Go `_test.go` regression/integration tests named above;
+- synthetic compiler/export fixtures under `testdata/` with no real tenant,
+  user, token, document or callback data;
+- the Slice 5 pilot `bundle.json`, only after exact-version preflight and only
+  as publish input.
+
+The following are runtime state/evidence and must not be committed:
+
+- real `card_template_grant`, activation, audit or artifact rows;
+- real Space IDs, user/Bot identities, access tokens, callback secrets or
+  production samples;
+- database dumps, API response captures containing identities, Redis keys or
+  raw service logs;
+- generated canonical-bundle/cache bytes.
+
+Redacted command output, selected hashes/revisions and test summaries may be
+kept under `.context/` for agent collaboration; `.context/` is gitignored and
+is not a PR deliverable.
+
+## First implementation move
+
+Start Slice 1 only. The first RED change should cover the existing boundaries,
+not create grant tables or a pilot fixture:
+
+1. add the provenance value-object table tests;
+2. add raw Bot send/edit forgery tests;
+3. add internal dispatch producer/template/Space authorship tests;
+4. add action durable-context and updater Snapshot tests;
+5. run the focused packages and record expected RED failures;
+6. implement the smallest Slice 1 GREEN without opening gates.
+
+Focused validation after GREEN:
+
+```bash
+go test ./pkg/cardtmpl/... ./internal/carddispatch/... ./internal/cardactiondispatch/...
+go test ./modules/bot_api/... ./modules/message/... ./modules/notify/...
+go test -race ./pkg/cardtmpl/... ./internal/carddispatch/... ./internal/cardactiondispatch/...
+gofmt -w <edited-go-files>
+git diff --check
+```
+
+The MySQL/Redis/WuKongIM environment is not required to author the pure value
+object tests, but DB/transport-backed package tests must not be reported green
+unless their dependencies actually ran rather than skipped or failed setup.
+
+## Stop conditions
+
+Stop the current slice and update the contract instead of improvising if any of
+these occur:
+
+- authorization would need caller-supplied principal or `space_id`;
+- active, block and grant cannot be resolved in one primary-DB snapshot;
+- a dynamic same-ID denial would fall back to static new-send;
+- B2 would expose templates, goldens, canonical storage, grants/audit or real
+  samples;
+- the pilot needs a new RouteSpec, callback secret, finalizer or production
+  Space/data;
+- a candidate pilot exact version is already claimed with any source/content;
+- completing a slice requires enabling production control/new-send gates.

--- a/.octospec/tasks/cardtmpl-runtime-catalog-grants-discovery/HANDOFF.md
+++ b/.octospec/tasks/cardtmpl-runtime-catalog-grants-discovery/HANDOFF.md
@@ -163,21 +163,37 @@ boundary and receives regression coverage only.
 
 ### Slice 2 — grant migration, store and manager API
 
-Production files:
+Production files (ledger updated at Slice 2 GREEN, 2026-08-05):
 
 - `[new] modules/card_template_catalog/sql/20260805000001_card_template_catalog_grant.sql`
-- `[new] modules/card_template_catalog/store_grant.go`
-- `[new] modules/card_template_catalog/api_grant.go`
-- `[modify] internal/carddispatch/context.go` — consume only the read-only
-  producer-binding resolver installed in Slice 1; the request body cannot
-  construct a `ProducerSpec`.
-- `[modify] modules/card_template_catalog/store.go`
-- `[modify] modules/card_template_catalog/api.go`
-- `[modify] modules/card_template_catalog/api_state.go`
-- `[modify] modules/card_template_catalog/api_i18n.go`
-- `[modify] modules/card_template_catalog/metrics.go`
-- `[modify] pkg/errcode/card_template_catalog.go`
-- `[modify] pkg/i18n/locales/active.zh-CN.toml`
+  — grant table with CHECK-enforced D2 shapes (active⇒discover; tombstone⇒no
+  permissions; space⇒discover-only + global sentinel) plus additive audit
+  principal/permission columns.
+- `[new] modules/card_template_catalog/store_grant.go` — CAS upsert/revoke with
+  same-tx audit and the claim FOR UPDATE target guard; `resolveGrantRows` is
+  the single exact-over-global/tombstone precedence implementation Slice 3
+  must reuse.
+- `[new] modules/card_template_catalog/api_grant.go` — PUT/DELETE handlers,
+  `validateGrantPrincipal` seam (production: botidentity Active + carddispatch
+  ProducerBinding + active-space query; revoke skips existence so stale
+  principals stay revocable).
+- `internal/carddispatch/context.go` — no further change; the Slice 1
+  read-only binding resolver is consumed as-is.
+- `modules/card_template_catalog/store.go` — no change was needed (shared
+  helpers `boundedRequiredText`/`isDuplicateKey`/limits already exist).
+- `[modify] modules/card_template_catalog/api.go` — routes + principal
+  validator wiring.
+- `[modify] modules/card_template_catalog/api_state.go` — detail carries the
+  bounded grant summary (limit 32) when the store implements the grant
+  interface.
+- `[modify] modules/card_template_catalog/store_read.go` — audit page exposes
+  the redacted grant principal/permission columns.
+- `[modify] modules/card_template_catalog/api_i18n.go` — `respondCatalogGrantInvalid`.
+- `modules/card_template_catalog/metrics.go` — no change was needed; the
+  existing operation/db counters take grant/revoke as label values.
+- `[modify] pkg/errcode/card_template_catalog.go` — one new code
+  `err.server.card_template_catalog.grant_invalid`.
+- `[modify] pkg/i18n/locales/active.zh-CN.toml` (+ regenerated i18n markers).
 
 Focused tests:
 

--- a/.octospec/tasks/cardtmpl-runtime-catalog-grants-discovery/HANDOFF.md
+++ b/.octospec/tasks/cardtmpl-runtime-catalog-grants-discovery/HANDOFF.md
@@ -210,40 +210,93 @@ Down exists for test rollback; production rollback does not rely on Down.
 
 ### Slice 3 — atomic authorization and Bot merge
 
-Production files:
+Landed (`feat: resolve card catalog authorization in one snapshot`):
 
-- `[modify] pkg/cardtmpl/catalog.go`
-- `[modify] pkg/cardtmpl/runtime_catalog.go`
-- `[new] modules/card_template_catalog/store_authorization.go`
-- `[modify] modules/card_template_catalog/store_runtime.go`
-- `[modify] modules/card_template_catalog/runtime_install.go`
-- `[modify] modules/bot_api/card_template_catalog.go`
-- `[modify] modules/bot_api/bot_api.go` — mount only the card-profile route as
-  `authBot → botActorUID → SharedUIDRateLimiter`; do not silently rate-limit
-  unrelated legacy Bot routes.
-- `[modify] modules/bot_api/card_profile.go`
-- `[modify] modules/bot_api/send.go`
-- `[modify] modules/bot_api/resolve_targets.go`
-- `[modify] modules/bot_api/space_inject.go`
-- `[modify] main.go` — inject the shared resolver/binding dependencies; do not
-  create a second grant truth.
+- `[new] pkg/cardtmpl/runtime_authorization.go` — the D4 contract:
+  `RuntimeGrant` (+`Allows(purpose)`), `RuntimeAuthorizationQuery/…Authorization`,
+  the indivisible `RuntimeAuthorizationStore`, `RuntimeAdvertiser`,
+  `RuntimeAuthorizationSource` (readers + the new-send gate) with
+  `SetDefaultAuthorizationSource`/`DefaultAuthorizationSource`, and the single
+  `ActivationVersion` rule both catalog and store call.
+- `[modify] pkg/cardtmpl/runtime_catalog.go` — `resolveVersion` +
+  `resolveDynamic`'s split reads replaced by one `resolve()` that performs at
+  most one snapshot; `verifyAuthorization` rejects an incoherent receipt;
+  `RuntimeDynamicAuthorizeFunc` now carries the grant. Static/explicit reads
+  still return before any store call, so a gates-off deployment gains no DB
+  dependency. `versionMode` distinguishes new-send (may follow the pointer)
+  from historical-edit/action-context (pinned, never follows it).
+- `pkg/cardtmpl/catalog.go` — no change was needed; `Catalog` stays the render
+  surface and the resolver seam lives beside it.
+- `[new] modules/card_template_catalog/store_authorization.go` — one
+  REPEATABLE READ read-only tx reading activation + claim/artifact/block +
+  exact/global grant rows, reduced through the existing `resolveGrantRows`;
+  plus bounded `ListAuthorizedTemplates` for the Bot advertised set.
+  Compile-time assertion that `*store` is the resolver.
+- `[modify] modules/card_template_catalog/store_runtime.go` — activation and
+  artifact scans take a `rowQuerier` so the standalone and in-snapshot reads
+  share one copy of the shape validation.
+- `[modify] modules/card_template_catalog/runtime_install.go` — the authorizer
+  consumes the snapshot grant (purpose→permission, no IO of its own) and the
+  composition root publishes `runtimeAuthorizationSource` (store + gates).
+- `[new] modules/bot_api/card_template_runtime.go` — `botCatalogPrincipal`,
+  the strict `resolveBotGrantSpaceID` (every ambiguity refuses; an
+  unauthorized/unverifiable `X-Space-ID` never falls through), the
+  target-authoritative `botSendCatalogPrincipal` (group row / thread parent
+  row), the D6 `resolveSendRef`/`decideSendRef` matrix, `advertisedSendRefs`,
+  request-scoped `CapabilityFor`, and `requireSendableRef`.
+- `[modify] modules/bot_api/card_template_catalog.go` — per-template-ID single
+  advertised send version guard (was per exact ref); `staticSendByID`/
+  `staticSendIDs`; `renderPayload` takes a ref-resolver seam so new send
+  re-resolves while historical edit stays pinned to the static allowlist;
+  `templateCapabilityFromMeta` shared by boot and request-scoped manifests.
+- `[modify] modules/bot_api/card_profile.go` — manifest resolved per
+  authenticated bot + Space; a runtime read failure returns a typed error
+  instead of advertising a possibly-shadowed static version.
+- `[modify] modules/bot_api/bot_api.go` — `/card/profile` moved to its own
+  group `authBot → botActorUID → SharedUIDRateLimiter`; the other legacy Bot
+  routes are deliberately left unlimited.
+- `[modify] modules/bot_api/send.go` — new send resolves the grant principal
+  from the target and fails closed on `errBotTemplateRuntimeUnavailable`.
+- `[modify] modules/bot_api/{db.go,space_inject.go}` — `queryGroupSpaceID`
+  added to `botSpaceQuerier`.
+- `modules/bot_api/{resolve_targets.go,card_profile route consts}` and
+  `main.go` — no change was needed: `InstallRuntimeCatalog` already runs before
+  the module factories, and publishing the resolver there avoids a second
+  grant truth without new wiring in `main.go`.
 
 Focused tests:
 
-- `[modify] pkg/cardtmpl/runtime_catalog_test.go`
+- `[new] pkg/cardtmpl/runtime_authorization_test.go` — one-snapshot counting,
+  pinned reads never follow the pointer, incoherent-snapshot rejection,
+  static-exact needs no snapshot, a grant-unaware store can never produce an
+  allow, `Allows`/`ActivationVersion` tables.
+- `[new] modules/card_template_catalog/store_authorization_test.go` — tx shape
+  via sqlmock, precedence table, ungrantable principals issue no grant query.
 - `[new] modules/card_template_catalog/store_authorization_mysql_integration_test.go`
-- `[modify] modules/card_template_catalog/runtime_db_integration_test.go`
-- `[modify] modules/bot_api/card_template_catalog_test.go`
-- `[modify] modules/bot_api/card_profile_test.go`
-- `[modify] modules/bot_api/card_template_send_test.go`
-- `[modify] modules/bot_api/card_template_edit_test.go`
-- `[modify] modules/bot_api/resolve_targets_test.go`
-- `[modify] modules/bot_api/space_inject_multispace_test.go`
+  — the linearization point (a held snapshot is unaffected by a concurrent
+  revoke; the next snapshot is already denied), exact tombstone shadowing a
+  live global grant, block/unknown reported from the snapshot.
+- `[new] modules/bot_api/card_template_runtime_test.go` — the eleven-row shadow
+  matrix, manifest/send agreement, stale-ref rejection, granted-dynamic
+  advertisement, list-failure fail-close, the two-versions-per-ID constructor
+  guard, the strict Space resolver table, target-authoritative group/thread
+  Space.
+- `[modify] modules/card_template_catalog/runtime_gates_test.go` — authorizer
+  purpose→permission matrix.
+- `[modify]` signature migrations in `pkg/cardtmpl/runtime_catalog_test.go`,
+  `modules/card_template_catalog/runtime_db_integration_test.go`,
+  `modules/bot_api/{card_template_catalog_test.go,card_template_edit_test.go,
+  space_inject_test.go}`.
 
 Exit gate: active/block/grant are read in one primary-DB snapshot; profile and
 send share the same resolver but make independent decisions; dynamic active
 shadows static same-ID new-send; revoke/DB failure/invalid or ambiguous Space
 never falls back; static gate-off behavior does not gain a DB dependency.
+
+Deferred to Slice 6 (documentation reconciliation): `resolve_targets.go` needs
+no code change, but the runbook must state that a Bot's advertised catalog is
+now request-scoped, so an operator reading `/card/profile` sees that Bot's
+view rather than the deployment's.
 
 ### Slice 4 — B1/B2 discovery and safe export
 

--- a/.octospec/tasks/cardtmpl-runtime-catalog-grants-discovery/brief.md
+++ b/.octospec/tasks/cardtmpl-runtime-catalog-grants-discovery/brief.md
@@ -445,6 +445,18 @@ finds them directly.
   `TestValidateGrantPermissionsMatrix`, `TestValidateGrantIdentityCanonicalShapes`,
   and the `chk_card_template_grant_space` CHECK constraint, so the shape cannot
   be written even by a future caller that forgets the validator.
+- [x] every domain the Go validator enforces is also stated in the schema, so a
+  write that skips the validator cannot land a row the validator would refuse —
+  `TestGrantSchemaRejectsWritesTheValidatorWouldRefuseRealMySQL` (real rows, each
+  case rejected by the database itself). Two gaps were open: `can_send`/`can_edit`
+  outside `{0,1}` on an active row, and a blank `principal_id`. The first was
+  fail-closed only by accident of the read — `GrantPermissions` scans into Go
+  bools and the driver refuses the value, so the authorization load errored — and
+  a future reader that scanned into an int and tested `!= 0` would have turned the
+  same row into a grant. `chk_card_template_grant_bools` and
+  `chk_card_template_grant_identity` state it where the value is written.
+  (`can_discover` was already pinned by `chk_card_template_grant_shape` on both
+  statuses; it is named in the new constraint for completeness, not coverage.)
 - [x] exact Space grant overrides global; exact tombstone blocks global without
   permission union — `TestResolveGrantRowsPrecedence` (reducer),
   `TestStoreLoadAuthorizationExactTombstoneShadowsGlobalRealMySQL` (real rows and

--- a/.octospec/tasks/cardtmpl-runtime-catalog-grants-discovery/brief.md
+++ b/.octospec/tasks/cardtmpl-runtime-catalog-grants-discovery/brief.md
@@ -459,8 +459,17 @@ finds them directly.
   `cancelled` result, whose replacement frame came from a six-key allowlist
   carrying neither marker, leaving both identity guards in `updater.go` inert.
   Preservation is now enforced at `CardMutator.Mutate` rather than per call
-  site, and `docs.access-request@0.3.0` declares a `cancelled` state so the
-  replacement is a Registry render that legitimately carries the markers.
+  site, and `docs.access-request@0.3.0` declares `cancelled` and `unavailable`
+  states so the replacement is a Registry render that legitimately carries the
+  markers. Selecting the replacement route by state was the defect's shape, so
+  the state list is gone rather than extended — `pending` reached the same
+  branch and a later state would have inherited it silently; what remains is
+  the no-updater fallback the branch was written for.
+  `TestStandardActionFinalizerCannotSilentlyDowngradeAMarkedCard` pins the
+  latent second caller: it is the default finalizer for every non-docs owner and
+  routes every state through the same helper, harmless today only because
+  `BuildApprovalRequestCard` writes no template metadata, so its cards are never
+  marked.
 - [x] every domain the Go validator enforces is also stated in the schema, so a
   write that skips the validator cannot land a row the validator would refuse —
   `TestGrantSchemaRejectsWritesTheValidatorWouldRefuseRealMySQL` (real rows, each

--- a/.octospec/tasks/cardtmpl-runtime-catalog-grants-discovery/brief.md
+++ b/.octospec/tasks/cardtmpl-runtime-catalog-grants-discovery/brief.md
@@ -205,7 +205,9 @@ grant/activation/block 强一致读继续走 primary DB。v1 不引入 Redis 或
 ### D5 — B1/B2 read model
 
 - B1：`GET /v1/message/card/templates`；cursor pagination，default 50/hard 100；只返回
-  visible + unblocked exact versions、source/owner/protocol/contract/version/views 和
+  visible + unblocked exact versions、source/owner/protocol/contract/version/views、
+  `action_contract`（owner+action_type 摘要，纯展示卡为 null——对应 platform-card-base §9
+  承诺的 `actionType` 能力发现字段）和
   `active_for_new_send`，明确 `send_allowed` 不是 B1 的承诺。
 - B2：`GET /v1/message/card/templates/{id}@{version}`；只返回
   manifest/schema/reports/samples 的安全 projection，不返回 templates、goldens、audit、
@@ -226,11 +228,23 @@ grant/activation/block 强一致读继续走 primary DB。v1 不引入 Redis 或
   一个已返回的 visible row 推进，不得让 hidden/blocked row 改变 cursor、count 或空页形状。
   cursor 至少绑定 source + template exact + Space/visibility context，跨 Space 重放 fail-close。
 - static Registry 在 Freeze 前显式注入 `engine/visibility/export` metadata；未配置 visibility
-  fail-close 为 private。注册/compile 时构造 immutable safe export projection 并复制 raw
-  manifest/schema/reports；请求期不读源码目录，也不从 compiled schema 反向猜原文。
-- `samples` 默认不导出；只有 handoff manifest 显式列入 export allowlist、且确认是 synthetic
-  fixture 的 sample 才进入 projection。templates、goldens、未列入 sample 和 canonical bundle
+  fail-close 为 private。注入点是 composition root 的 Go 侧注册参数（`main.go` static
+  CatalogMeta），绝不回改已冻结的 L1 handoff manifest（platform-card-base §2.1 发布即冻结）。
+  PR-C 不改变任何现有 static 卡的 visibility——全部保持 fail-close private；把某张 static 卡
+  对普通调用方开放属后续 reviewed composition-root 变更，不是 PR-C 交付物；public 矩阵由
+  测试 fixture 与 pilot dynamic bundle 覆盖。注册/compile 时构造 immutable safe export
+  projection 并复制 raw manifest/schema/reports；请求期不读源码目录，也不从 compiled schema
+  反向猜原文。
+- `samples` 默认不导出；只有 manifest 显式列入 export allowlist、且确认是 synthetic
+  fixture 的 sample 才进入 projection。static 卡受 L1 冻结约束无法回填 allowlist，现有
+  static 卡的 B2 samples 恒为空；dynamic bundle 在自身 manifest 声明 allowlist（compiler
+  strict 校验，未知键继续拒绝），pilot bundle 必须含至少一个 allowlisted synthetic sample
+  证明导出通路。templates、goldens、未列入 sample 和 canonical bundle
   永不进入 B2。static/dynamic 共用同一 projection builder 与 2 MiB 序列化前 hard cap。
+- wire status 决策：B1/B2 与 localized Space middleware variant 的全部错误响应走既有
+  `httperr.ResponseErrorL`（pinned-400，D14 兼容），与 `modules/card_template_catalog`
+  现有 responder 同一契约；不使用 `ResponseErrorLWithStatus`（未取得新端点偏离 D14 的
+  maintainer 确认）。ETag 命中的 304 与缓存响应头不是 error envelope，不受此约束。
 
 ### D6 — Bot capability and runtime authorization
 
@@ -305,9 +319,11 @@ stop/retry 或 OpenClaw rollout 绑定。
 | --- | --- |
 | `PUT /v1/manager/card-templates/{id}/grants/{principal_type}/{principal_id}` | create/update active grant；strict body 包含 scope_space_id、discover/send/edit、expected_revision、reason、change_ticket |
 | `DELETE /v1/manager/card-templates/{id}/grants/{principal_type}/{principal_id}` | logical revoke；strict body 包含 scope_space_id、expected_revision、reason、change_ticket |
+| `GET /v1/manager/card-templates` | 分页只读列表：全部 template 的 source/visibility/active/block 摘要与 bounded grant summary，含普通 B1 隐藏项；补齐父 brief v1 控制面缺失的最后一个 read API（PR-C 是 E3 收尾切片，不再顺延） |
 
 两条写接口都要求 control gate=true、runtime ready、superAdmin、SharedUIDRateLimiter、
-10s deadline 与 typed localized errors。path/body identity 严格 canonical；body actor 字段拒绝。
+10s deadline 与 typed localized errors。只读列表与既有 manager GET detail/audit 同一
+鉴权/限流/deadline 链，不要求 control gate=true，也不涉及 expected_revision。path/body identity 严格 canonical；body actor 字段拒绝。
 manager API 必须按 D2 canonical shape 校验 scope，并在响应中返回实际命中的 revision；对
 revoked exact row 的 re-activate 必须携带 tombstone 当前 revision，不能再用
 `expected_revision=0` 伪装 create。
@@ -379,6 +395,8 @@ between repository fixtures and non-production runtime state are maintained in
 ### Slice 4 — B1/B2 RED→GREEN
 
 - static export retention/hash + dynamic projection；
+- composition-root static CatalogMeta 注入（visibility/export/sample allowlist；不回改冻结 manifest）；
+- manager 只读列表端点（含 B1 隐藏项与 bounded grant summary）；
 - public/private/Space/superAdmin matrix、pagination/hard cap、ETag/304/cache headers；
 - unauthorized vs nonexistent equality、blocked omission、visible-only cursor、cross-Space cursor replay；
 - localized Space errors、synthetic sample allowlist、Bot cannot use B1/B2 as grant bypass。
@@ -394,7 +412,14 @@ between repository fixtures and non-production runtime state are maintained in
 - focused coverage/race/build/vet/lint/i18n/source guards；
 - real MySQL migration/concurrency/two-replica tests；
 - dedicated non-production Redis/WuKongIM E2E, restart and DB outage；
-- runbook rollout/rollback/metrics/alerts and PR Linked Spec/COMPREHENSION。
+- runbook rollout/rollback/metrics/alerts and PR Linked Spec/COMPREHENSION；
+- 文档收口（与代码同 PR）：platform-card-base §9 的 B1/B2 实际字段与授权语义、§10 新增
+  dynamic unauthorized/blocked/DB-unavailable fail-close 行（不降级为 fallback 文本）；
+  card-protocol §1 补 additive 顶层 `template_ref`/`catalog_provenance` 字段并注明客户端
+  渲染门禁仍只看 `from_uid`（provenance 是服务端授权输入，不是客户端渲染契约）；runbook
+  记录 `l2aOwnerAllowlist`（Registry 注册面）与 `approvedRuntimeOwners`（runtime
+  publish/授权面）是两份刻意不同的清单——给未获批 runtime owner 建 grant 不会使其可发；
+  platform-card-base §2.2-5 注明 L2b 硬门槛 ④ 不因 per-principal grant 落地而推进。
 
 ## Acceptance matrix
 
@@ -483,3 +508,31 @@ Accepted with the explicit instruction to start E3 PR-C implementation on 2026-0
   dynamic-over-static shadow matrix.
 - [x] Accept D7: `docs-notify` + existing docs RouteSpec, including explicit static activation baseline,
   as the non-production interactive pilot.
+
+## Plan refinement log
+
+### 2026-08-05 round 2 — repo-doc cross-check
+
+对照父 brief（`.octospec/tasks/cardtmpl-runtime-catalog/brief.md`）、
+`docs/platform-card-base.md`、`docs/card-protocol.md`、`docs/l2b-owners.md` 与
+`main@40627cc0` 代码复核后落入本 brief 的五项细化。均为收敛/补缺，不改变已确认的
+D1–D7 语义：
+
+1. B1 字段补 `action_contract`（platform-card-base §9 的 `actionType` 能力发现承诺；
+   跨仓 SDK 生成依赖它对齐 callback 路由三元组）。
+2. static visibility/export 注入点定为 composition root Go 侧（`main.go` static
+   CatalogMeta），不回改冻结 L1 manifest；PR-C 不改变现有 static 卡 visibility（保持
+   private fail-close）；static B2 samples 恒空，dynamic 由 bundle manifest allowlist
+   承载，pilot bundle 必须证明导出通路。背景：全部 10 个生产 handoff manifest 均无
+   visibility/allowlist 字段，若无此步 B1/B2 对普通调用方为空壳。
+3. 补父 brief 控制面表中缺失的 `GET /v1/manager/card-templates` 只读列表端点
+   （grant 分散到多 principal 后，运维需要可枚举的权威清单入口）。
+4. B1/B2 wire status 定为 `httperr.ResponseErrorL`（pinned-400），与模块既有 9 个
+   responder 同契约；不引入 `ResponseErrorLWithStatus`。
+5. Slice 6 文档收口清单显式化（platform-card-base §9/§10、card-protocol §1/§4、
+   runbook 双 owner 清单差异、L2b 门槛 ④ 不推进声明）。
+
+另记两条既定实现口径（前轮已确认，此处固化）：robot legacy ingress 对
+`template_ref`/`catalog_provenance` 用显式 reject（新增独立函数，不复用也不改变
+`__obo_*` silent-strip 的既有语义）；pilot exact version 仍以非生产 DB preflight 为准，
+`bundle.json` 目录名在 preflight 后才落盘。

--- a/.octospec/tasks/cardtmpl-runtime-catalog-grants-discovery/brief.md
+++ b/.octospec/tasks/cardtmpl-runtime-catalog-grants-discovery/brief.md
@@ -513,6 +513,28 @@ finds them directly.
   boot-time `EditCompatible` map, which a runtime-published version can never
   be in, so `send` reached the dynamic authorizer and `edit` never did. The
   brief claimed a closure the code did not have until this was wired.
+- [x] the ref gate and the render authorize against the *same* Space, so a
+  per-Space grant works on a group or thread target —
+  `TestGroupSendAuthorizesTheRenderWithTheSameSpaceAsTheGate`,
+  `TestGroupEditAuthorizesTheRenderWithTheSameSpaceAsTheGate`. The round above
+  ticked the edit line on the strength of the resolver alone, and both
+  reviewers pointed out the witness stood at the layer where the bug was not:
+  `renderPayload` rebuilt its `CatalogAccess` from `env.SpaceID`, which send.go
+  populates for DMs only, so `cardtmpl.Render` re-resolved the grant in the
+  global scope and refused every exact-Space grant the gate had just accepted.
+  The render now receives the principal the gate decided on. Both tests assert
+  the recorded `Access` directly *and* fail with `ErrRuntimeCatalogNotAuthorized`
+  when the fix is reverted; `stubAuthorizationSource` gained a `grantSpaceID`
+  because until then it ignored `query.Principal` and this whole class of
+  divergence was unobservable in the package.
+- [x] a Space that could not be established never reverts a shadowed template ID
+  to its static version — `TestBotTemplateSendRefFollowsTheShadowMatrix`
+  ("an unavailable Space does not revert a shadowed ID to static", plus the two
+  rows that bound it: static still answers when nothing shadows the ID, and a
+  Space-less target is still authorized by a global grant). `botCatalogPrincipal`
+  carries three Space states rather than a bool, because "this target has no
+  Space" and "we could not read which Space this target is in" were the same
+  `false` and led to opposite correct answers.
 - [x] one authorization decision never combines activation/block/grant values
   from different DB snapshots — `TestStoreLoadAuthorizationReadsPointerArtifactAndGrantInOneTransaction`,
   `TestRuntimeCatalogDynamicNewSendUsesExactlyOneSnapshot`,

--- a/.octospec/tasks/cardtmpl-runtime-catalog-grants-discovery/brief.md
+++ b/.octospec/tasks/cardtmpl-runtime-catalog-grants-discovery/brief.md
@@ -423,48 +423,168 @@ between repository fixtures and non-production runtime state are maintained in
 
 ## Acceptance matrix
 
+Verified 2026-08-06 against MySQL 8.0 + Redis + WuKongIM. Each box names the
+test that would fail if the property broke; `[ ]` items say plainly what is
+still missing and why. Test names are unique across the repo, so `go test -run`
+finds them directly.
+
 ### Authorization and isolation
 
-- [ ] non-superAdmin cannot grant/revoke or inspect hidden grant details.
-- [ ] Bot A cannot discover/send/edit with Bot B's grant even on the same apiUrl/Space.
-- [ ] a Space discover grant never becomes send/edit authority.
-- [ ] exact Space grant overrides global; exact tombstone blocks global without permission union.
-- [ ] `space` principal rejects non-canonical principal/scope combinations.
-- [ ] cross-Space profile/send/edit/action attempts fail before render/enqueue/mutation.
-- [ ] dynamic DM requires both bot and peer in the selected active Space; invalid/ambiguous hints never fallback.
-- [ ] raw callers cannot forge `template_ref` or `catalog_provenance` through any type-17 ingress/edit.
-- [ ] unauthorized and nonexistent B2 responses are wire-equivalent apart from request correlation.
+- [x] non-superAdmin cannot grant/revoke or inspect hidden grant details —
+  `TestGrantWriteRequiresSuperAdminAndControlGate`,
+  `TestControlEndpointsRejectNonSuperAdminBeforeCompile`,
+  `TestManagerListRejectsCallersWhoAreNotSuperAdmin`,
+  `TestRouteRequiresAuthenticationBeforeControlHandlers`; B1/B2 carry no grant
+  state at all (`TestDiscoveryResponsesCarryNoControlPlaneFields`).
+- [x] Bot A cannot discover/send/edit with Bot B's grant even on the same
+  apiUrl/Space — `TestGrantsDoNotLeakBetweenBotsRealMySQL` (same template, same
+  Space, only the Bot differs; also proves `bot:x` and `internal_producer:x`
+  are different identities), plus
+  `TestBotMessageEditRegistryTemplateRejectsForeignStoredProvenance`.
+- [x] a Space discover grant never becomes send/edit authority —
+  `TestValidateGrantPermissionsMatrix`, `TestValidateGrantIdentityCanonicalShapes`,
+  and the `chk_card_template_grant_space` CHECK constraint, so the shape cannot
+  be written even by a future caller that forgets the validator.
+- [x] exact Space grant overrides global; exact tombstone blocks global without
+  permission union — `TestResolveGrantRowsPrecedence` (reducer),
+  `TestStoreLoadAuthorizationExactTombstoneShadowsGlobalRealMySQL` (real rows and
+  collations), `TestLoadAuthorizationsAppliesExactOverGlobalPrecedenceRealMySQL`
+  (the batch reducer, which is a second implementation).
+- [x] `space` principal rejects non-canonical principal/scope combinations —
+  `TestValidateGrantIdentityCanonicalShapes`, `TestGrantPathIdentityCanonicalValidation`.
+- [x] cross-Space profile/send/edit/action attempts fail before
+  render/enqueue/mutation — send `TestBotSendCatalogPrincipalUsesTheTargetGroupSpace`,
+  edit `TestGroupCardStaysEditableAndKeepsItsAuthorizedSpace` (the cross-Space
+  arm), updater `TestCardUpdaterReplaceViewRejectsCrossSpaceStoredProvenance`,
+  action `TestResolveRegistryCardContextRejectsInconsistentProvenance/cross-space_provenance`.
+- [x] dynamic DM requires both bot and peer in the selected active Space;
+  invalid/ambiguous hints never fallback —
+  `TestDMSendRequiresThePeerToBeInTheAuthorizedSpace`,
+  `TestResolveBotGrantSpaceIDRefusesEveryAmbiguity`,
+  `TestDMPeerCheckIsSkippedWhenTheCatalogIsDark`.
+- [x] raw callers cannot forge `template_ref` or `catalog_provenance` through
+  any type-17 ingress/edit — `TestSendMessageRawCardRejectsForgedCatalogProvenance`,
+  `TestBotRawEditRejectsCatalogProvenanceMarkers`,
+  `TestRawContentEditCannotForgeRegistryProvenance`,
+  `TestSendMessageRegistryModeRejectsCallerProvenanceKey`, plus the robot and
+  incoming-webhook absolute-rejection suites.
+- [x] unauthorized and nonexistent B2 responses are wire-equivalent apart from
+  request correlation — `TestGetTemplateAnswersOneNotFoundForEveryInvisibleReason`
+  (byte-compares the bodies, including a malformed ref),
+  `TestLoadDiscoverableGivesOneIndistinguishableMissRealMySQL`.
 
 ### State and consistency
 
-- [ ] publish, activate, grant remain independent; none creates another implicitly.
-- [ ] grant/revoke CAS has one winner; revoke tombstone prevents ABA; audit and state commit together.
-- [ ] capability and send use the same strong active/grant truth; stale explicit ref never switches version.
-- [ ] one authorization decision never combines activation/block/grant values from different DB snapshots.
-- [ ] revoke send blocks subsequent new-send; revoke edit blocks subsequent edit/action; compiled cache cannot bypass.
-- [ ] rollback changes new-send only; old dynamic card remains same-version editable while edit grant exists.
-- [ ] active dynamic same ID shadows static new-send for allowed, denied, blocked and DB-failure cases exactly
-  as the D6 matrix specifies.
+- [x] publish, activate, grant remain independent; none creates another
+  implicitly — `TestPublishUsesAuthenticatedActorAndKeepsArtifactInactive`, and
+  the D7 loop in `TestPilotDynamicCatalogEndToEndRealMySQL` proves each step
+  separately.
+- [x] grant/revoke CAS has one winner; revoke tombstone prevents ABA; audit and
+  state commit together — `TestStoreGrantConcurrentCASHasOneWinnerRealMySQL`,
+  `TestStoreGrantLifecycleRealMySQL`.
+- [x] capability and send use the same strong active/grant truth; stale explicit
+  ref never switches version — `TestBotTemplateManifestAndSendAgree`,
+  `TestBotTemplateSendRejectsStaleDynamicRef`,
+  `TestAdvertisedSendRefsBatchesAndAgreesWithThePerIDPath` (the batched manifest
+  reaches the same conclusion as the per-ID resolver).
+- [x] one authorization decision never combines activation/block/grant values
+  from different DB snapshots — `TestStoreLoadAuthorizationReadsPointerArtifactAndGrantInOneTransaction`,
+  `TestRuntimeCatalogDynamicNewSendUsesExactlyOneSnapshot`,
+  `TestStoreLoadAuthorizationSnapshotIsTheLinearizationPointRealMySQL`,
+  `TestRuntimeCatalogRejectsIncoherentAuthorizationSnapshot`. B2 violated this
+  until the third review pass — it read the discovery predicate and the
+  authorizer separately — and now resolves once.
+- [x] revoke send blocks subsequent new-send; revoke edit blocks subsequent
+  edit/action; compiled cache cannot bypass —
+  `TestRuntimeCatalogHotCacheCannotOutliveARevoke` (a hot entry answers the
+  revoke from a fresh snapshot without reloading the bundle, and an edit-only
+  grant does not authorize a send), `TestStoreLoadAuthorizationSnapshotIsTheLinearizationPointRealMySQL`,
+  and the revoke arm of the D7 pilot loop.
+- [x] rollback changes new-send only; old dynamic card remains same-version
+  editable while edit grant exists — `TestRuntimeCatalogPinnedReadsNeverFollowActivationPointer`,
+  and the rollback arm of the D7 pilot loop.
+- [x] active dynamic same ID shadows static new-send for allowed, denied,
+  blocked and DB-failure cases exactly as the D6 matrix specifies —
+  `TestBotTemplateSendRefFollowsTheShadowMatrix` (all eleven rows),
+  `TestDecideSendRefRefusesADisabledPointerFromTheBatch`.
 
 ### Discovery/export
 
-- [ ] B1 pagination is deterministic and bounded; blocked/unauthorized rows do not leak.
-- [ ] hidden rows do not advance cursor or alter `has_more`; cursor cannot be replayed across Space contexts.
-- [ ] B2 projection contains only manifest/schema/reports/samples and is capped.
-- [ ] only explicitly allowlisted synthetic samples are exported; request handling never reads source files.
-- [ ] static/dynamic ETag is deterministic; `If-None-Match` returns 304 without body.
-- [ ] private response is not shared-cacheable; no audit/grant/token/real sample data leaks.
-- [ ] all B1/B2 and Space-membership failures use the localized envelope; no raw non-OK JSON response remains.
+- [x] B1 pagination is deterministic and bounded; blocked/unauthorized rows do
+  not leak — `TestListDiscoverableFiltersBeforePagingRealMySQL` walks the whole
+  listing at three page sizes over interleaved public/private/granted/blocked/
+  tombstoned rows; `TestDiscoveryPageLimitBounds`,
+  `TestListTemplatesPaginationIsBoundedAndResumable`.
+- [x] hidden rows do not advance cursor or alter `has_more`; cursor cannot be
+  replayed across Space contexts — `TestStaticPageCursorSkipsHiddenRowsWithoutCountingThem`,
+  `TestListDiscoverableReportsMoreWithoutLeakingTheNextRowRealMySQL`,
+  `TestDiscoveryCursorIsBoundToItsSpace`, `TestDiscoveryCursorRejectsWhatItCannotAccountFor`.
+- [x] B2 projection contains only manifest/schema/reports/samples and is capped
+  — `TestSafeExportOmitsTemplatesGoldensAndBundle`,
+  `TestSafeExportRejectsUnknownExportKeys`,
+  `TestSafeExportRefusesToBuildAnOversizedProjection` (the 2 MiB cap fails the
+  build, not the response, so an oversized artifact cannot reach a client as a
+  truncated body).
+- [x] only explicitly allowlisted synthetic samples are exported; request
+  handling never reads source files — `TestSafeExportShipsNoSamplesUnlessTheManifestOptsIn`,
+  `TestSafeExportRejectsAnAllowlistNamingAMissingSample`,
+  `TestStaticRegistryExportIsPrivateWithNoSamples`. The projection is built at
+  registration/compile time, so the request path has no file access to make.
+- [x] static/dynamic ETag is deterministic; `If-None-Match` returns 304 without
+  body — `TestWriteExportServesETagAndA304WithoutABody`,
+  `TestWriteExportFallsBackToTheExportHashForStaticTemplates`,
+  `TestSafeExportHashIsDeterministicAndCoversVisibility`,
+  `TestMatchesETagHandlesListsWildcardAndWeakValidators`.
+- [x] private response is not shared-cacheable; no audit/grant/token/real sample
+  data leaks — `TestWriteExportServesETagAndA304WithoutABody` asserts
+  `Cache-Control: private, no-cache`; `TestDiscoveryResponsesCarryNoControlPlaneFields`.
+- [x] all B1/B2 and Space-membership failures use the localized envelope; no raw
+  non-OK JSON response remains — `TestCatalogNoLegacyErrorResponses` (source
+  guard) plus `make i18n-lint`; the Space half is
+  `TestLocalizedSpaceMiddlewareRejectsANonMemberOnTheEnvelope`,
+  `...ReportsALookupFailureAsUnavailable`,
+  `...RequiresALoginBeforeCheckingMembership`, and
+  `...ResolvesTheSameSpaceAsTheLegacyOne` keeps the twin from becoming a second
+  definition of the membership rule.
 
 ### Runtime and operations
 
-- [ ] gate-off deployment preserves current static Bot/profile/send/edit/action paths during DB outage.
-- [ ] gate-on dynamic DB failure is observable and fail-closed without static same-ID fallback.
-- [ ] two replicas with cold/hot cache converge after grant/activate/rollback/revoke and restart.
-- [ ] dedicated non-production MySQL, Redis and WuKongIM pilot completes before OctoSpec finish/PR ready-for-review.
-- [ ] changed core packages meet at least 80% coverage; focused race suites pass.
-- [ ] `go build ./...`, focused/full relevant tests, `go vet`, `golangci-lint`,
-  `make i18n-extract-check`, `make i18n-lint`, source guards and `git diff --check` pass.
+- [x] gate-off deployment preserves current static Bot/profile/send/edit/action
+  paths during DB outage — `TestRuntimeCatalogStaticExactNeedsNoSnapshot`,
+  `TestBotCatalogPrincipalSkipsSpaceLookupWhenTheCatalogIsDark`,
+  `TestDMPeerCheckIsSkippedWhenTheCatalogIsDark`,
+  `TestRuntimeCatalogGatesFailClosedOnMissingAndInvalidValues`,
+  `TestEditSpaceCheckSeparatesUnknownFromEmpty` (a dark gate is a configuration
+  state, never an outage).
+- [x] gate-on dynamic DB failure is observable and fail-closed without static
+  same-ID fallback — `TestRuntimeCatalogDefaultDBFailureDoesNotFallbackStatic`,
+  `TestBotTemplateManifestFailsClosedOnListError`,
+  `TestAdvertisedSendRefsFailsClosedWhenTheBatchReadFails`,
+  `TestStaticPageFailsClosedWhenTheGrantProbeFails`.
+- [ ] two replicas with cold/hot cache converge after grant/activate/rollback/
+  revoke and restart. **Partly covered**:
+  `TestRuntimeCatalogMultiReplicaActivationRollbackBlockAndRestart` covers
+  activate, rollback, block and restart across two stores on one database.
+  Grant/revoke convergence is *not* covered and cannot be from a single
+  container — the gap is the cache-invalidation window between replicas, which
+  is the only place a revoked grant can still be honoured. Pre-merge operational
+  prerequisite; see HANDOFF.md › Pre-merge operational prerequisites.
+- [ ] dedicated non-production MySQL, Redis and WuKongIM pilot completes before
+  OctoSpec finish/PR ready-for-review. **Not done.** The D7 loop in
+  `pilot_mysql_integration_test.go` runs green here, but its exact-version
+  preflight only interrogates real claims when `OCTO_PILOT_CATALOG_DSN` points
+  at the dedicated deployment's catalog database; unset, the test says so out
+  loud. Pre-merge operational prerequisite.
+- [x] changed core packages meet at least 80% coverage; focused race suites pass
+  — `modules/card_template_catalog` 80.6%, `pkg/cardtmpl` 81.2%, `pkg/cardmsg`
+  85.1%; `pkg/space`'s new `localizedSpaceMiddleware` is 91.4% (the package
+  total is dominated by pre-existing untested Redis cache helpers this PR does
+  not touch). `go test -race` passes for `pkg/cardtmpl`, `pkg/cardmsg`,
+  `pkg/space`, `internal/carddispatch`, `internal/cardactiondispatch`.
+- [x] `go build ./...`, focused/full relevant tests, `go vet`, `golangci-lint`,
+  `make i18n-extract-check`, `make i18n-lint`, source guards and
+  `git diff --check` pass — all green on 2026-08-06; `golangci-lint run` reports
+  0 issues across the six changed packages.
 
 ## Rollout / rollback
 

--- a/.octospec/tasks/cardtmpl-runtime-catalog-grants-discovery/brief.md
+++ b/.octospec/tasks/cardtmpl-runtime-catalog-grants-discovery/brief.md
@@ -445,6 +445,22 @@ finds them directly.
   `TestValidateGrantPermissionsMatrix`, `TestValidateGrantIdentityCanonicalShapes`,
   and the `chk_card_template_grant_space` CHECK constraint, so the shape cannot
   be written even by a future caller that forgets the validator.
+- [x] a server-authored catalog marker cannot be authored invalid, and cannot be
+  dropped by an edit — `TestSendRefusesToAuthorAMarkerItsReadersWouldReject`,
+  `TestCardMutatorRefusesToDropStoredCatalogMarkers`,
+  `TestDocsActionFinalizerRoutesCancelledThroughTheRegistry`,
+  `TestDocsAccessRequestV3RendersTheCancelledState`. Both halves were regressions
+  this PR introduced, and neither was behind a runtime-catalog gate: the marker
+  paths sit behind the pre-existing `OCTO_CARD_MESSAGE_ENABLED`, so the "both new
+  gates are false" argument never covered them. Authoring ran *after*
+  `cardmsg.Validate`, so the hook written to catch a missed path structurally
+  could not see it, and an untrimmed Space produced a frame every reader
+  refuses — permanently unclickable and uneditable. Erasure needed only a
+  `cancelled` result, whose replacement frame came from a six-key allowlist
+  carrying neither marker, leaving both identity guards in `updater.go` inert.
+  Preservation is now enforced at `CardMutator.Mutate` rather than per call
+  site, and `docs.access-request@0.3.0` declares a `cancelled` state so the
+  replacement is a Registry render that legitimately carries the markers.
 - [x] every domain the Go validator enforces is also stated in the schema, so a
   write that skips the validator cannot land a row the validator would refuse —
   `TestGrantSchemaRejectsWritesTheValidatorWouldRefuseRealMySQL` (real rows, each

--- a/.octospec/tasks/cardtmpl-runtime-catalog-grants-discovery/brief.md
+++ b/.octospec/tasks/cardtmpl-runtime-catalog-grants-discovery/brief.md
@@ -1,0 +1,485 @@
+---
+type: Task
+title: "Task: cardtmpl-runtime-catalog-grants-discovery"
+description: Complete E3 PR-C with authoritative producer grants, visibility-aware B1/B2 discovery and export, dynamic Bot capability integration, trusted stored provenance, and one non-production interactive pilot.
+tags: [card, cardtmpl, runtime-catalog, database, migration, grant, discovery, export, provenance, wire-contract, trust-boundary, auth, acl, space, bot-api, i18n, rate-limit, observability, testing, rollback]
+timestamp: 2026-08-05T00:00:00+08:00
+# --- octospec extension fields ---
+slug: cardtmpl-runtime-catalog-grants-discovery
+upstream: "roadmap E3 PR-C; parent cardtmpl-runtime-catalog; PR-A #674@68e8134d; PR-B #675@49a66475"
+source: self
+---
+
+# Task: cardtmpl-runtime-catalog-grants-discovery
+
+> This brief is the OctoSpec **Plan** contract for octo-server E3 PR-C. It is
+> extracted from the accepted parent brief after rereading current
+> `main@40627cc0`. The decisions below were accepted when implementation was
+> authorized on 2026-08-05. The implementation must remain one reviewable PR-C
+> milestone, built as the ordered test-first slices listed below. Implementers
+> start from [`HANDOFF.md`](./HANDOFF.md), which owns the repository-relative
+> file ledger, commit boundary, fixture policy and verification commands.
+
+## Goal
+
+在 #674/#675 已交付的 immutable artifact、RuntimeCatalog、activate/rollback/block
+基础上，补齐“谁可以看、谁可以发、谁可以继续编辑”的授权闭环：
+
+1. 用 MySQL 权威、可审计、CAS 防并发覆盖的 grant 管理
+   `discover|send|edit`；
+2. 为 B1/B2 提供 visibility/Space-aware 的模板发现与安全制品导出；
+3. 把 Bot 的静态 allowlist 与 dynamic grant 安全合并，使 capability、new send、
+   historical edit 读取同一授权真相；
+4. 为 dynamic card 持久化不可由 raw caller 伪造的 producer/Space provenance，
+   让 action-context 与 historical edit 不再猜 principal；
+5. 在非生产用一个现有 L2a owner、现有 producer 和现有 RouteSpec 跑通
+   publish→grant→activate→discover/export→send→Action.Submit→same-version
+   edit→rollback/revoke。
+
+PR-C 合并表示“dynamic catalog 已具备受控消费能力”，不表示生产 dynamic new-send
+自动开启，也不表示 L2b `ext.*`、Bot 自助上传或 OpenClaw E1e stop/retry 已完成。
+
+## Verified baseline at plan time
+
+- 当前基线：`origin/main@40627cc0`。
+- E3 PR-A #674（`68e8134d`）已交付 shared compiler、immutable claim/artifact/audit
+  store 与 super-admin validate/publish。
+- E3 PR-B #675（`49a66475`）已交付 RuntimeCatalog、MySQL active pointer、CAS
+  activate/rollback/block、compiled cache、readiness 与默认关闭的
+  `OCTO_CARD_RUNTIME_CATALOG_CONTROL_ENABLED` /
+  `OCTO_CARD_RUNTIME_CATALOG_NEW_SEND_ENABLED`。
+- `pkg/cardtmpl.CatalogAccess` 已有 `new_send|historical_edit|action_context` 与
+  `bot|internal_producer|system` typed principal；production authorizer 当前在无下游
+  grant store 时一律拒绝 dynamic business access。
+- 数据库只有 version claim、artifact、audit、activation、capacity guard；没有 grant 表。
+- `modules/bot_api/card_template_catalog.go` 在进程启动时从代码常量构造
+  `AdvertisedSend/EditCompatible` 与固定 capability；它在进入 RuntimeCatalog 前会拒绝
+  不在 static map 的 ref，因此 dynamic grant 尚不可能生效。
+- Bot Registry outbound frame 已保留 server-authored top-level `template_ref`；raw Bot
+  send/edit 不能写该字段。internal `carddispatch` 目前只持久化 card document/profile，
+  不保存 producer ID，也不会在 envelope 中保留 `template_ref`。
+- message action-context 当前对所有 Registry metadata 都以 `msg.FromUID` 猜成 bot
+  principal；`CardUpdater.ReplaceView` 也以 `SenderUID` 猜成 internal producer。这对
+  dynamic grant 不足，且正是 PR-C 必须先修的 provenance 缺口。
+- B1/B2 route 尚不存在。static Registry 未保留完整 B2 export projection/catalog
+  visibility；dynamic canonical bundle 可以提供导出源。
+- server bot events opt-in long-poll #685（`a4d4c924`）和平台卡缺省
+  `render_profile` #688（`60febd8e`）已合并。OpenClaw #194 当前 approve 待合并；
+  它改善事件时延，不改变本 PR 的 grant/provenance 语义。
+
+## Success definition
+
+- **身份闭环**：dynamic new-send/edit/action-context 使用 authenticated 或 stored
+  server-authored principal + authoritative Space；raw payload、query/body principal、
+  template owner 或 sender 猜测均不能形成授权。
+- **授权闭环**：grant/revoke 使用 strong MySQL read、revision CAS、同事务 audit；
+  active/block/grant 在同一 primary-DB snapshot 内形成一次授权决定；revoke 提交后开始的
+  新授权决策立即拒绝，local compiled cache 不缓存 grant 真相。
+- **发现闭环**：B1/B2 的 public/private、Space grant、pagination、ETag 和
+  anti-enumeration 有自动化证据；导出不泄露 audit/grants/DB IDs/template source/goldens。
+- **Bot 闭环**：profile、new send、historical edit 与 action-context 对同一 Bot/Space
+  使用同一 effective active + grant 真相；同一 template ID 最多广告一个 send version。
+- **运行闭环**：两副本、cache 热/冷、DB outage、grant race、activate/rollback/revoke、
+  restart 和真实 MySQL/Redis/WuKongIM pilot 均通过；生产 gates 默认仍关闭。
+
+## Load-bearing invariants
+
+1. `publish != activate != grant`：三者互不隐式产生下一步状态。
+2. static `Registry` 继续冻结；dynamic artifact 不能覆盖任何 static exact key。
+3. active pointer 只影响新消息；historical edit 固定 stored exact version。
+4. compiled cache 只缓存 immutable artifact，不缓存 active/grant/block。
+5. catalog 存在、public visibility 或 B1 可见均不等于 send/edit 授权。
+6. dynamic action 只能从 effective stored frame 恢复 template/principal/Space，再进入
+   既有 owner/RouteSpec/Space/operator/card-action 幂等链。
+7. static 历史卡保持兼容；PR-C 不要求给历史帧回填 provenance。
+8. unauthorized 与 nonexistent 对普通调用方不可形成枚举 oracle。
+9. 首条 dynamic 卡一旦发送，保留 dynamic historical exact reader 成为 binary floor。
+10. grant 是 template-ID 级授权：在 grant 有效期间，后续新版本只有经独立 publish +
+    activate 后才继承该授权；grant 本身绝不选择版本。
+11. 同一 principal/Space 的 exact-scope row 是权威覆盖，不能与 global row 做 permission
+    union；exact tombstone 必须能屏蔽 global active grant。
+12. dynamic active version 对同一 template ID 的 static new-send 形成 shadow；授权失败、
+    blocked、integrity/DB failure 时不得静默降级到 static 同 ID 版本。
+
+## Accepted implementation decisions
+
+### D1 — One PR-C milestone, ordered internal slices
+
+保持一个 octo-server PR-C，避免 migrations/API/runtime wiring 跨 PR 出现“grant 已写入但
+消费边界尚未接线”的半状态。实现按下文 6 个 slices 顺序推进，每个 slice 先 RED 再 GREEN；
+任一中间 commit 均不得打开生产 dynamic new-send。
+
+### D2 — Principal and permission model
+
+- v1 principal kind：`bot`、`internal_producer`、`space`；`system` 仅保留给内部
+  control/readiness/test，不是 grantable business principal。
+- 权限是固定列/枚举 `discover|send|edit`，不得接受任意字符串。
+- `space` principal 只能 discover；`send|edit` 只授予可认证的 `bot` 或
+  `internal_producer`。
+- active grant 至少有一项权限；`send`/`edit` 必须同时包含 `discover`，避免 producer
+  获得无法从 capability/discovery 观察的暗授权。
+- grant 是 **template-ID 级**，不是 version 级：后续版本经 super-admin 独立 activate 后
+  继承该 template ID 的有效 grant。这是 v1 的刻意选择；若不能接受未来版本继承，必须在
+  实现前改主键模型，不允许实现者临时按 version 加隐藏条件。
+- `bot` / `internal_producer` 的 `scope_space_id` 使用 non-null canonical empty-string
+  表示 global，非空值表示 exact Space；非空 Space 必须存在且 active。
+- `space` principal 的唯一合法形状是 `principal_id=<space_id>` 且
+  `scope_space_id=''`，该 Space 必须存在且 active；禁止再叠一层 global/exact scope，避免
+  `(principal space A, scope space B)` 这种无意义或跨租户组合。
+- 对 `bot` / `internal_producer` 在 Space S 的授权解析顺序固定为：若 S 的 exact row 存在，
+  只使用该 row；exact active 按其 permission 判定，exact revoked 直接拒绝；仅当 exact row
+  不存在时才查询 global row。不得 union permissions，也不得让 global active 穿透 exact
+  tombstone。`space` discover 只查上述 canonical `space` row。
+- `new_send` 要求 `send`；`historical_edit` 与 `action_context` 都要求 `edit`。
+  revoke send 不冻结已有卡；revoke edit 阻断后续 edit/action，但不删除最后成功 payload。
+- static new-send/edit 继续服从 code-reviewed policy，不因 dynamic grant 自动扩权；private
+  static B1/B2 discovery 可以使用 `space` discover grant。dynamic new-send/edit/action 才必须
+  经过上述 business grant。
+- grant 不替代 Bot ownership、internal producer registration、target Space/channel、
+  feature gate、RouteSpec、message lifecycle 或 CAS。
+
+### D3 — Stored server-authored catalog provenance
+
+不修改 caller-facing `template_ref/v1` request shape。对 Registry 产出的有效 type-17
+frame 增加 additive、server-only top-level marker：
+
+```json
+{
+  "template_ref": {"id": "docs.access-request", "version": "<pilot-version>"},
+  "catalog_provenance": {
+    "version": 1,
+    "principal_type": "internal_producer",
+    "principal_id": "docs-notify",
+    "space_id": "space_x"
+  }
+}
+```
+
+- Bot Registry path 从 `authBot()` 的 robot ID 与 target-authoritative Space 写入；
+  internal path 由 `carddispatch.producerSender` 从已注册 `ProducerSpec.ID` 和已授权
+  target Space 写入。调用方不能自报 principal。
+- internal Registry send 同时保留 top-level `template_ref`；它必须与
+  `metadata.octo.template` 完全一致。
+- raw Bot/robot/user/incoming-webhook send/edit 对 `template_ref` 与
+  `catalog_provenance` 保持或新增显式拒绝；不能依赖客户端“不会传”。
+- Bot edit、`CardUpdater.ReplaceView`、Append 和 action ingress 从 effective Snapshot
+  恢复并原样校验 provenance；不允许更新时改 principal/Space/template identity。
+- action ingress 把已验证的 principal/Space 作为 `CardContext` 的 additive server-authored
+  字段写入 durable event；finalizer/updater 只消费该字段或重新 Snapshot，不从 sender/owner
+  反推 internal producer。
+- 对 dynamic frame，缺失、畸形或与 stored sender/Space/registered producer 不一致的
+  provenance 一律 fail-close。static 历史 Bot/notify 卡可继续走既有兼容路径。
+- 这一步同时收口 roadmap G13：`ReplaceView` 在 dynamic authorization/render 前必须
+  Snapshot 并验证 effective template identity/provenance，不能只信 `UpdateTarget`。
+
+### D4 — Grant persistence and CAS
+
+新增 `card_template_grant`：
+
+- identity：`template_id + principal_type + principal_id + scope_space_id` unique；
+- state：`status=active|revoked`、`can_discover/can_send/can_edit`、单调 `revision`；
+- audit fields：updated_by/reason/change_ticket/updated_at；
+- revoke 写 tombstone 并 bump revision，不物理删除，避免 revoke→recreate 的 ABA；
+- create 要求 `expected_revision=0`，update/revoke 要求精确 current revision；并发只有一个成功；
+- grant/revoke 状态与 append-only `card_template_audit` 在同一事务提交；audit 扩展记录
+  principal/scope、before/after permissions/revision，不存 token 或卡片 data；
+- grant target 至少存在一个 permanent version claim；不以 activation 存在作为前提；
+- 没有跨 static/dynamic 的 template-level FK 时由同一事务 `SELECT ... FOR UPDATE`
+  claim/guard 验证，不伪造脆弱 FK。
+
+grant/activation/block 强一致读继续走 primary DB。v1 不引入 Redis 或本地 grant cache。
+
+授权读取必须提供一个窄的、不可被调用方拆开的 store resolver：
+
+- dynamic `new_send` 在一个 primary-DB single statement 或同一 consistent read transaction
+  中读取 effective activation、exact artifact/block 与 exact/global grant rows，按 D2 规则
+  产生一个 decision；不能先读 active、再在另一个 snapshot 读 grant。
+- `historical_edit` / `action_context` 不读取 active pointer，但必须在同一 snapshot 中读取
+  stored exact artifact/block 与 grant rows；stored provenance 是 principal/Space 输入。
+- resolver 返回 bounded receipt（template exact、activation revision、grant revision、scope
+  source），仅用于日志、metrics 和同请求校验；receipt 不是 bearer capability，不能跨请求缓存。
+- 授权线性化点定义为 resolver 成功取得的 DB snapshot：snapshot 在 revoke/activate/block
+  commit 之后开始的请求必须看到新状态并拒绝；更早已取得 snapshot 的 in-flight 请求允许完成。
+  Bot profile 与 send 是两个独立决策，send 必须重新 resolve，不能信 profile receipt。
+
+### D5 — B1/B2 read model
+
+- B1：`GET /v1/message/card/templates`；cursor pagination，default 50/hard 100；只返回
+  visible + unblocked exact versions、source/owner/protocol/contract/version/views 和
+  `active_for_new_send`，明确 `send_allowed` 不是 B1 的承诺。
+- B2：`GET /v1/message/card/templates/{id}@{version}`；只返回
+  manifest/schema/reports/samples 的安全 projection，不返回 templates、goldens、audit、
+  grants、internal DB IDs 或 canonical storage bytes。
+- 两者路由链：Auth → SharedUIDRateLimiter → **localized Space middleware/variant**；缺 Space
+  时最多看到 public，private 必须命中经过 middleware 验证的当前 Space grant 或
+  superAdmin。现有 `pkg/space.SpaceMiddleware` 的 raw `AbortWithStatusJSON` 不能直接复用到
+  这两个新端点；PR-C 应增加保持同一 membership/cache 语义、但统一走 `httperr` 的窄 variant，
+  不借机改变所有旧路由 wire status。
+- public 只代表可发现；private 对普通调用方需 `space` discover grant。Bot 仍以
+  `/v1/bot/card/profile` 为权威，不允许拿 B1/B2 绕过 bot grant。
+- unauthorized/nonexistent/blocked 对普通 B2 返回同一个 localized not-found envelope；
+  manager API 保留诊断视角。
+- dynamic ETag 使用 immutable `content_sha256`；static 使用 deterministic export hash；
+  支持 `If-None-Match`/304。private 响应至少 `Cache-Control: private, no-cache`；响应
+  projection 有 2 MiB hard cap。
+- B1 visibility/block/grant 必须在 pagination limit 与 `has_more` 计算前完成；cursor 只从最后
+  一个已返回的 visible row 推进，不得让 hidden/blocked row 改变 cursor、count 或空页形状。
+  cursor 至少绑定 source + template exact + Space/visibility context，跨 Space 重放 fail-close。
+- static Registry 在 Freeze 前显式注入 `engine/visibility/export` metadata；未配置 visibility
+  fail-close 为 private。注册/compile 时构造 immutable safe export projection 并复制 raw
+  manifest/schema/reports；请求期不读源码目录，也不从 compiled schema 反向猜原文。
+- `samples` 默认不导出；只有 handoff manifest 显式列入 export allowlist、且确认是 synthetic
+  fixture 的 sample 才进入 projection。templates、goldens、未列入 sample 和 canonical bundle
+  永不进入 B2。static/dynamic 共用同一 projection builder 与 2 MiB 序列化前 hard cap。
+
+### D6 — Bot capability and runtime authorization
+
+- static `AdvertisedSend/EditCompatible` 继续是 code-reviewed policy；构造期改为按 template ID
+  检查 `AdvertisedSend` 最多一个 version，而非只检查 exact ref duplicate。
+- Bot profile 从固定进程常量改为 request-scoped：`authBot → botActorUID →
+  SharedUIDRateLimiter`，以 authenticated bot + authoritative Space 查询 active/unblocked
+  dynamic send grant，再与 static policy 合并。
+- Bot multi-Space 不做 union 广告。scope=space App Bot 使用认证上下文；显式
+  `X-Space-ID` 必须走现有 authorization；User Bot 只有一个 active Space 时可使用该值，
+  多 Space 且无有效 hint 时 dynamic 部分 fail-close，不选择一个会造成跨 Space 漂移的目录。
+- 对 dynamic profile/send，显式但未授权的 `X-Space-ID` 直接拒绝 dynamic decision，不得像
+  当前 legacy helper 一样 fallback 到 deterministic first Space；DB 错误也不得 fallback。
+- Bot send 在 render 前为 DM/group/thread 解析 target-authoritative Space：group 从
+  authoritative group row 取 Space，thread 从 authoritative parent-group row 取 Space；DM
+  使用 scope=space App Bot context 或经过 authorization 的 `X-Space-ID`，并同时验证 bot 与
+  对端用户都是该 active Space 的有效主体。若无法得到唯一 Space、对端不属于该 Space、
+  multi-Space 无有效 hint 或 hint 非法，dynamic send 在 render/enqueue 前 fail-close。
+  payload/query/body `space_id` 永远不是授权来源。
+- dynamic explicit ref 必须同时是 effective active version + unblocked + 命中 send grant。
+- dynamic historical edit 不跟随 active pointer，只校验 stored exact provenance + edit grant；
+  active 切换不能把旧卡跨版本更新。
+- new-send gate=false 时保留现有 static-only profile/send 行为，不为暗置功能引入 DB outage
+  blast radius；gate=true 后 dynamic capability/send DB 失败必须 fail-close，不能静默广告 static
+  同 ID 版本。
+- profile 与 send 之间若 revision 改变，旧 explicit ref 安全失败，producer 刷新 profile 后重试；
+  server 不偷换版本。
+
+Bot new-send/profile 对同一 template ID 的选择矩阵固定如下，profile 与 send 必须调用同一
+resolver，不能各自实现：
+
+| State | Advertise / send result |
+| --- | --- |
+| new-send gate=false | 只走现有 static policy，完全不访问 runtime DB |
+| gate=true，ID 无 activation row | 使用 static advertised version（若有） |
+| gate=true，active pointer 指向 static exact | 仅当该 exact 在 static policy 中时广告/允许；不查询 business grant |
+| gate=true，dynamic active + unblocked + effective send grant | dynamic exact shadow/替换 static 同 ID |
+| gate=true，dynamic active 但无 grant或 exact tombstone | 整个 ID 不广告；explicit dynamic/static new-send 均拒绝 |
+| gate=true，dynamic active 但 blocked/integrity failure | 整个 ID fail-close，不回退 static |
+| gate=true，runtime DB unavailable | profile 返回 typed localized unavailable；Registry new-send fail-close，不回退 static |
+
+static historical edit 仍按 stored static exact + existing code policy 工作；dynamic activation shadow
+只影响 new-send，不能破坏 static 历史卡兼容。
+
+### D7 — First non-production pilot
+
+pilot 固定使用：
+
+- owner：`docs`（现有 L2a）；
+- producer：`internal_producer/docs-notify`；
+- action contract：现有 `docs/access_request.decision` RouteSpec；
+- visibility：private；
+- identity：never-before-claimed prerelease exact version，禁止复用任何 static key；
+- Space：单一专用测试 Space，不使用生产 Space/用户数据。
+
+pilot 在第一次 dynamic activate 前必须先建立可回滚基线：读取当前 activation；若当前 active
+exact 不是 static known-good `docs.access-request@0.3.0`（包括无 row 或 disabled），先用正常
+`activate` + current expected revision 将该 static exact 记录为 active baseline；CAS conflict 或
+baseline activate 失败就停止 pilot。随后才能 activate prerelease dynamic exact。这样后续
+`rollback` target 确实满足“previously active”；不能把 Registry default 误当成 activation
+audit history。
+
+docs finalizer 对 Registry action 必须使用 event stored `template_id@version` 做 same-version
+result edit；static `0.3.0` 行为不变。pilot 不触碰 `ai.reasoning-process`，不与 E1e
+stop/retry 或 OpenClaw rollout 绑定。
+
+## Control APIs
+
+在现有 super-admin manager group 下新增：
+
+| Method/path | Semantics |
+| --- | --- |
+| `PUT /v1/manager/card-templates/{id}/grants/{principal_type}/{principal_id}` | create/update active grant；strict body 包含 scope_space_id、discover/send/edit、expected_revision、reason、change_ticket |
+| `DELETE /v1/manager/card-templates/{id}/grants/{principal_type}/{principal_id}` | logical revoke；strict body 包含 scope_space_id、expected_revision、reason、change_ticket |
+
+两条写接口都要求 control gate=true、runtime ready、superAdmin、SharedUIDRateLimiter、
+10s deadline 与 typed localized errors。path/body identity 严格 canonical；body actor 字段拒绝。
+manager API 必须按 D2 canonical shape 校验 scope，并在响应中返回实际命中的 revision；对
+revoked exact row 的 re-activate 必须携带 tombstone 当前 revision，不能再用
+`expected_revision=0` 伪装 create。
+
+现有 manager detail 增加 bounded grant summary，audit page 可显示脱敏 grant/revoke identity；
+普通 B1/B2 永不返回这些 control fields。
+
+## Code impact map
+
+- `pkg/cardtmpl`
+  - 增 discover/export purpose、Space principal、typed provenance 与 discovery/export narrow interface；
+  - static Registry 保留 deterministic export projection/hash；
+  - RuntimeCatalog 接入 strong grant authorizer/list/export，不缓存 grant/active/block；
+  - dynamic new-send 校验 effective active exact version，edit/action 校验 stored provenance。
+- `modules/card_template_catalog`
+  - migration、grant store/CAS/audit、principal resolver、manager grant APIs；
+  - B1/B2 route、visibility filter、pagination、ETag、anti-enumeration；
+  - metrics 和 runbook。
+- `pkg/space`
+  - 为 B1/B2 增 localized Space middleware variant；复用现有 membership/cache 检查，避免
+    扩大旧路由 wire-contract 变更。
+- `modules/bot_api`
+  - request-scoped capability、target Space resolution、static+dynamic policy merge；
+  - Bot Registry send/edit provenance；raw forge rejection；profile UID limiter。
+- `modules/robot` / `modules/message` / `modules/incomingwebhook`
+  - legacy robot raw card 显式拒绝 server-only marker；用户 type-17 绝对拒绝与 incoming-webhook
+    server-built/drop-extra 边界增加回归证据，不为这些 raw ingress 新增 dynamic capability。
+- `internal/carddispatch`
+  - trusted sender authors producer provenance/template_ref from `ProducerSpec.ID`；
+  - expose a read-only producer binding resolver for action-context validation，不能让业务 caller
+    传任意 ProducerSpec。
+- `pkg/cardtmpl/updater.go` / `modules/message/api_card_action.go`
+  - Snapshot effective provenance before dynamic edit/action；same-version, same-principal,
+    same-Space validation；将已验证 principal 写入 durable `CardContext`；static history compatibility。
+- `modules/notify`
+  - docs pilot passes template identity through carddispatch；finalizer uses stored event exact version；
+  - existing static sends/results remain byte/behavior compatible except additive server metadata。
+- `main.go` / docs
+  - composition-root static CatalogMeta、grant principal dependencies、runbook/protocol/roadmap updates。
+
+This section names architectural ownership only. The executable, per-slice file list and the distinction
+between repository fixtures and non-production runtime state are maintained in
+[`HANDOFF.md`](./HANDOFF.md); do not infer files or commit pilot data from this broad impact map.
+
+## Test-first implementation slices
+
+### Slice 1 — provenance RED→GREEN
+
+- RED：raw forge、cross-bot、cross-producer、cross-Space、missing/malformed marker、template_ref vs
+  metadata mismatch、ReplaceView without Snapshot。
+- GREEN：typed marker at Bot/carddispatch boundaries；snapshot extraction/preservation；dynamic-only
+  fail-close；static history compatibility。
+
+### Slice 2 — grant schema/store/control RED→GREEN
+
+- migration Up/Down、binary collations/check constraints/global sentinel；
+- create/update/revoke CAS、tombstone ABA、same-transaction audit、concurrent grant race；
+- principal existence/Space binding/permission matrix；exact-over-global、exact tombstone、space
+  canonical shape、future-version inheritance；manager auth/i18n/strict body/rate limit。
+
+### Slice 3 — runtime authorization and Bot merge RED→GREEN
+
+- effective-active send、inactive explicit ref rejection、historical edit/action edit grant；
+- static+dynamic merge、template-ID single-version guard、per-Bot/per-Space isolation；
+- single-snapshot active/block/grant race、revoke/rollback/capability race、gate-off static
+  compatibility、DB outage fail-close；
+- invalid Space hint、multi-Space ambiguity、DM peer non-membership、group/thread authoritative Space。
+
+### Slice 4 — B1/B2 RED→GREEN
+
+- static export retention/hash + dynamic projection；
+- public/private/Space/superAdmin matrix、pagination/hard cap、ETag/304/cache headers；
+- unauthorized vs nonexistent equality、blocked omission、visible-only cursor、cross-Space cursor replay；
+- localized Space errors、synthetic sample allowlist、Bot cannot use B1/B2 as grant bypass。
+
+### Slice 5 — interactive pilot RED→GREEN
+
+- docs-notify dynamic private artifact、stored provenance、existing RouteSpec、same-version finalizer；
+- establish static active baseline→publish→grant→activate→B1/B2→send→submit→edit→rollback→old
+  dynamic edit→revoke→reject。
+
+### Slice 6 — production verification and docs
+
+- focused coverage/race/build/vet/lint/i18n/source guards；
+- real MySQL migration/concurrency/two-replica tests；
+- dedicated non-production Redis/WuKongIM E2E, restart and DB outage；
+- runbook rollout/rollback/metrics/alerts and PR Linked Spec/COMPREHENSION。
+
+## Acceptance matrix
+
+### Authorization and isolation
+
+- [ ] non-superAdmin cannot grant/revoke or inspect hidden grant details.
+- [ ] Bot A cannot discover/send/edit with Bot B's grant even on the same apiUrl/Space.
+- [ ] a Space discover grant never becomes send/edit authority.
+- [ ] exact Space grant overrides global; exact tombstone blocks global without permission union.
+- [ ] `space` principal rejects non-canonical principal/scope combinations.
+- [ ] cross-Space profile/send/edit/action attempts fail before render/enqueue/mutation.
+- [ ] dynamic DM requires both bot and peer in the selected active Space; invalid/ambiguous hints never fallback.
+- [ ] raw callers cannot forge `template_ref` or `catalog_provenance` through any type-17 ingress/edit.
+- [ ] unauthorized and nonexistent B2 responses are wire-equivalent apart from request correlation.
+
+### State and consistency
+
+- [ ] publish, activate, grant remain independent; none creates another implicitly.
+- [ ] grant/revoke CAS has one winner; revoke tombstone prevents ABA; audit and state commit together.
+- [ ] capability and send use the same strong active/grant truth; stale explicit ref never switches version.
+- [ ] one authorization decision never combines activation/block/grant values from different DB snapshots.
+- [ ] revoke send blocks subsequent new-send; revoke edit blocks subsequent edit/action; compiled cache cannot bypass.
+- [ ] rollback changes new-send only; old dynamic card remains same-version editable while edit grant exists.
+- [ ] active dynamic same ID shadows static new-send for allowed, denied, blocked and DB-failure cases exactly
+  as the D6 matrix specifies.
+
+### Discovery/export
+
+- [ ] B1 pagination is deterministic and bounded; blocked/unauthorized rows do not leak.
+- [ ] hidden rows do not advance cursor or alter `has_more`; cursor cannot be replayed across Space contexts.
+- [ ] B2 projection contains only manifest/schema/reports/samples and is capped.
+- [ ] only explicitly allowlisted synthetic samples are exported; request handling never reads source files.
+- [ ] static/dynamic ETag is deterministic; `If-None-Match` returns 304 without body.
+- [ ] private response is not shared-cacheable; no audit/grant/token/real sample data leaks.
+- [ ] all B1/B2 and Space-membership failures use the localized envelope; no raw non-OK JSON response remains.
+
+### Runtime and operations
+
+- [ ] gate-off deployment preserves current static Bot/profile/send/edit/action paths during DB outage.
+- [ ] gate-on dynamic DB failure is observable and fail-closed without static same-ID fallback.
+- [ ] two replicas with cold/hot cache converge after grant/activate/rollback/revoke and restart.
+- [ ] dedicated non-production MySQL, Redis and WuKongIM pilot completes before OctoSpec finish/PR ready-for-review.
+- [ ] changed core packages meet at least 80% coverage; focused race suites pass.
+- [ ] `go build ./...`, focused/full relevant tests, `go vet`, `golangci-lint`,
+  `make i18n-extract-check`, `make i18n-lint`, source guards and `git diff --check` pass.
+
+## Rollout / rollback
+
+1. Deploy PR-C binary with control/new-send gates both false; run migrations and verify readiness/static traffic.
+2. Non-production only: control=true, new-send=false; publish pilot inactive, create grants, verify B1/B2 and audit.
+3. Read current activation. Unless active exact is already static known-good
+   `docs.access-request@0.3.0`, explicitly activate it with the current expected revision to establish
+   auditable rollback history; record the resulting revision and stop on any CAS conflict.
+4. Activate pilot while new-send remains false; prove capability/send still blocked.
+5. Set new-send=true only in the dedicated test environment and only after all replicas run PR-C.
+6. Run the full interactive pilot and two-replica/restart/DB-failure matrix.
+7. Rollback active pointer to the previously active static known-good, verify new static send, then revoke pilot
+   send/edit grants. A rollback target with no prior activation audit is a test/setup failure, not a fallback case.
+8. Return new-send=false, then control=false. Do not delete claim/artifact/grant tombstone/audit rows.
+9. PR-C merge or non-production pilot does not authorize production. First production dynamic activation needs a
+   separate change ticket, backup/restore proof, RPO/RTO, version matrix and go/no-go.
+10. After any dynamic card is sent, rollback must use a binary retaining dynamic historical exact read/edit;
+   never roll directly to pre-E3 code.
+
+## Out of scope
+
+- production dynamic activation or enabling production new-send/control gates;
+- OpenClaw E1e stop/retry, reasoning successor controls, or #194 implementation;
+- L2b `ext.*`, delegated owner publishing, Marketplace, visual editor, Bot self-service publish/activate;
+- per-Space active version; v1 active pointer remains global;
+- user/UID send grants; Space is discover-only;
+- dynamic callback URL/secret/RouteSpec/finalizer creation;
+- cross-version historical edit, artifact hard delete/GC, unblock, active/grant TTL cache or Redis truth;
+- exporting templates/goldens/canonical bundle or production business samples through B2;
+- E2 generic internal notify envelope or C3 generic approval migration.
+
+## Decision confirmation
+
+Accepted with the explicit instruction to start E3 PR-C implementation on 2026-08-05:
+
+- [x] Accept D1: one PR-C milestone with six ordered test-first slices.
+- [x] Accept D2/D4: template-ID grants, exact-over-global scope, typed permissions, tombstone + revision
+  CAS and one-snapshot authorization linearization.
+- [x] Accept D3: additive top-level `catalog_provenance`, raw ingress rejection, dynamic-only strict requirement.
+- [x] Accept D5/D6: localized B1/B2, safe export/cursor rules, request-scoped Bot Space resolution and
+  dynamic-over-static shadow matrix.
+- [x] Accept D7: `docs-notify` + existing docs RouteSpec, including explicit static activation baseline,
+  as the non-production interactive pilot.

--- a/.octospec/tasks/cardtmpl-runtime-catalog-grants-discovery/brief.md
+++ b/.octospec/tasks/cardtmpl-runtime-catalog-grants-discovery/brief.md
@@ -535,6 +535,26 @@ finds them directly.
   carries three Space states rather than a bool, because "this target has no
   Space" and "we could not read which Space this target is in" were the same
   `false` and led to opposite correct answers.
+- [x] every producer of that Space state is witnessed too, not just the pure
+  decision that consumes it — `TestDMSendRequiresThePeerToBeInTheAuthorizedSpace`
+  ("a Bot with no membership never becomes global-scoped on a DM"),
+  `TestAGroupInADisabledSpaceHasNoReadableGrantScope`,
+  `TestEditRefusesAFrameFromAnotherSpaceEvenWhenTheEnvelopeCorroboratesIt`. The
+  round that added the row above ticked it on `decideSendRef` alone, and the
+  reviewer's objection was that the witness stood one layer above the defect:
+  the matrix was green while the *resolver* producing the state was wrong. Three
+  producer-side defects were behind that line — membership absence read as "no
+  Space" (which for platform App Bots, who never get a `space_member` row, made
+  an `X-Space-ID` header the difference between seeing an exact revoke tombstone
+  and not seeing it), a group resolver that alone among this file's four Space
+  resolvers ignored `space.status = 1`, and an edit whose Space check could be
+  satisfied by the frame's own `space_id` while its grant was read in the
+  request's Space. Each has a test that fails when its fix is reverted.
+  **Not closed by these**: the DM scope is still derived from the sender's
+  request context rather than from the target, which is the asymmetry all three
+  came out of. It is recorded in `HANDOFF.md` as a hard prerequisite for
+  flipping the new-send gate, not as a merge item — it changes nothing while the
+  gate is false.
 - [x] one authorization decision never combines activation/block/grant values
   from different DB snapshots — `TestStoreLoadAuthorizationReadsPointerArtifactAndGrantInOneTransaction`,
   `TestRuntimeCatalogDynamicNewSendUsesExactlyOneSnapshot`,

--- a/.octospec/tasks/cardtmpl-runtime-catalog-grants-discovery/brief.md
+++ b/.octospec/tasks/cardtmpl-runtime-catalog-grants-discovery/brief.md
@@ -452,6 +452,16 @@ finds them directly.
   (the batch reducer, which is a second implementation).
 - [x] `space` principal rejects non-canonical principal/scope combinations —
   `TestValidateGrantIdentityCanonicalShapes`, `TestGrantPathIdentityCanonicalValidation`.
+- [x] an unresolvable card-origin Space refuses the action on both branches,
+  whether or not the frame names a Space —
+  `TestUnknownOriginSpaceIsRefusedWhateverTheFrameClaims`. Assigning an unknown
+  origin used to leave the principal's Space empty, which resolves against the
+  global grant row alone — so an active global grant plus an exact tombstone for
+  the card's real Space would have been allowed, defeating invariant 11.
+- [x] B1's listing predicate and B2's authorizer apply the same approved-owner
+  policy — `TestDiscoveryHidesRowsWhoseOwnerLeftTheAllowlistRealMySQL`. Both now
+  derive from `approvedOwnerPredicate`, so narrowing the allowlist during an
+  incident cannot leave B1 listing rows B2 answers not-found for.
 - [x] cross-Space profile/send/edit/action attempts fail before
   render/enqueue/mutation — send `TestBotSendCatalogPrincipalUsesTheTargetGroupSpace`,
   edit `TestGroupCardStaysEditableAndKeepsItsAuthorizedSpace` (the cross-Space
@@ -462,6 +472,14 @@ finds them directly.
   `TestDMSendRequiresThePeerToBeInTheAuthorizedSpace`,
   `TestResolveBotGrantSpaceIDRefusesEveryAmbiguity`,
   `TestDMPeerCheckIsSkippedWhenTheCatalogIsDark`.
+- [x] a markerless frame naming a template the frozen Registry does not know is
+  refused before authorization — `TestMarkerlessFrameNamingAnUnknownTemplateIsRefused`.
+  Raw ingress rejects the two server-only *top-level* keys, but the template
+  identity also appears in `card.metadata.octo`, inside the body a caller
+  controls. Without this the sender-derived fallback principal is the sending
+  Bot's own grant identity and `Allows(action_context)` reads `edit`, so a
+  fabricated frame let an `edit` grant stand in for the `send` grant it never
+  had. Markerless compatibility is now scoped to the pre-PR-C population.
 - [x] raw callers cannot forge `template_ref` or `catalog_provenance` through
   any type-17 ingress/edit — `TestSendMessageRawCardRejectsForgedCatalogProvenance`,
   `TestBotRawEditRejectsCatalogProvenanceMarkers`,
@@ -487,6 +505,14 @@ finds them directly.
   `TestBotTemplateSendRejectsStaleDynamicRef`,
   `TestAdvertisedSendRefsBatchesAndAgreesWithThePerIDPath` (the batched manifest
   reaches the same conclusion as the per-ID resolver).
+- [x] Bot historical edit consults the runtime `edit` grant, not only the static
+  allowlist — `TestBotEditResolvesADynamicRefThroughTheEditGrant` (granted,
+  revoked, send-only and blocked, with the query pinned to the stored exact
+  version), `TestBotEditKeepsStaticRefsAnsweringWithoutTheRuntime`. Two
+  reviewers flagged this independently: `requireEditableRef` consulted only the
+  boot-time `EditCompatible` map, which a runtime-published version can never
+  be in, so `send` reached the dynamic authorizer and `edit` never did. The
+  brief claimed a closure the code did not have until this was wired.
 - [x] one authorization decision never combines activation/block/grant values
   from different DB snapshots — `TestStoreLoadAuthorizationReadsPointerArtifactAndGrantInOneTransaction`,
   `TestRuntimeCatalogDynamicNewSendUsesExactlyOneSnapshot`,

--- a/.octospec/tasks/cardtmpl-runtime-catalog-grants-discovery/context.yaml
+++ b/.octospec/tasks/cardtmpl-runtime-catalog-grants-discovery/context.yaml
@@ -1,0 +1,39 @@
+injected:
+  - id: space-isolation
+    source: repo
+    why: >-
+      PR-C introduces per-Space discovery and producer grants on Bot, notify,
+      message action-context, and manager routes. Principal and Space values must
+      come from authenticated or stored server-authored state, never request JSON.
+  - id: trust-boundary
+    source: repo
+    why: >-
+      B2 exports stored artifacts and dynamic cards cross external producer and
+      client boundaries. Export projection, provenance, canonical hashes, payload
+      bounds, and raw-ingress rejection are load-bearing wire contracts.
+  - id: error-handling
+    source: repo
+    why: >-
+      Grant/revoke and B1/B2 add user-visible failures. They must use registered
+      localized envelopes, hide existence and grant details, and log internal
+      causes before returning internal errors.
+  - id: rate-limit
+    source: repo
+    why: >-
+      Manager and discovery routes are authenticated and must use the shared UID
+      limiter. Bot profile becomes a per-Bot DB read and therefore must mount
+      botActorUID before the same limiter.
+  - id: testing
+    source: repo
+    why: >-
+      PR-C changes a migration, CAS authorization state, multi-tenant discovery,
+      Bot send/edit/profile hot paths, message action ingress, and multi-replica
+      behavior; focused, real-MySQL, Redis/WuKongIM, race, and rollback evidence is
+      required before finish.
+  - id: commit-style
+    source: repo
+    why: >-
+      The eventual commits and PR use English Conventional Commits, an English PR
+      body, Linked Spec, COMPREHENSION answers, and an issue link. Plan phase makes
+      no commit.
+brief: .octospec/tasks/cardtmpl-runtime-catalog-grants-discovery/brief.md

--- a/docs/card-protocol.md
+++ b/docs/card-protocol.md
@@ -31,6 +31,19 @@
 - `card_version` 当前固定 `"1.5"`；`profile` 见 §3。
 - 未知的**额外**顶层字段被容忍（前向兼容）。P2 起信封新增可选字段：
   `card_seq`（整数，乱序防护）、`transient`（bool，进度帧不入变更历史）。
+- E3 PR-C 起另有两个**服务端独占**的顶层标记，用于 Registry / dynamic catalog 帧：
+  `template_ref`（`{id, version}`，已存在）与 `catalog_provenance`
+  （`{version, principal_type, principal_id, space_id}`，新增）。两者都**只能由
+  服务端在渲染出口写入**：raw ingress（bot 原始发卡、robot、incoming webhook）
+  携带任一 key 一律拒绝，编辑路径也不能新增或改写它们。
+  - 兼容矩阵（`cardmsg.CatalogFrameMarkers`）：两者皆无 = pre-PR-C 旧帧，合法；
+    只有 `template_ref` = pre-PR-C 的 Bot Registry 帧，合法；两者皆有 = 严格校验，
+    `template_ref` 必须与 `card.metadata.octo.template` 完全一致；
+    **只有 `catalog_provenance` 而无 `template_ref` = 拒绝**（无法验证它在描述什么）。
+  - `principal_type` 只取 `bot` / `internal_producer`。`space_id` 是这次发送**被授权
+    针对的** Space：群/子区取目标群行的 Space，DM 取 bot 的权威 Space。
+  - 存在这两个标记的意义：历史编辑与 action-context 不再靠 `msg.FromUID` 猜
+    producer 身份，而是从服务端自己写下的帧里恢复。
 
 ## 2. octo/v1 profile（P1 展示白名单）
 
@@ -163,6 +176,11 @@ view/state/wire profile 以及每个 view 的 `submit_actions`；不能从
    ingress —— 渲染门禁是残余风险的最后防线。`from_uid` 由 IM 连接鉴权绑定，
    不可伪造。
 3. **P2 动作端点**再次服务端复验目标消息 sender 身份。
+4. **E3 PR-C：动作端点还复验存储 provenance**。帧带 `catalog_provenance` 时，
+   声明的 principal 必须与存储 `FromUID` 一致（bot），或经只读 producer binding
+   解析回同一个 `FromUID`（internal producer）；声明的 Space 与信封 Space 两者
+   都非空时必须相等。缺失即 pre-PR-C 帧，走既有兼容路径。这一层挡的是「拿到一个
+   合法帧、改掉里面的 principal 去冒充另一个 producer」。
 
 **服务端展示面的对应纪律**：推送 / 搜索命中 / 摘要 / 置顶 / 引用等由服务端
 产出文案的面，对 sender 非 bot/webhook 身份的 type-17 一律显示 `[卡片]`，

--- a/docs/card-template-runtime-catalog-runbook.md
+++ b/docs/card-template-runtime-catalog-runbook.md
@@ -165,14 +165,36 @@ and callback secrets.
    interaction contract, and route configuration. Publish accepts only the
    reviewed runtime-owner allowlist and requires startup catalog readiness;
    validate remains available for offline diagnostics.
+
+   There are **two owner allowlists and they are deliberately different**.
+   `l2aOwnerAllowlist` (`pkg/cardtmpl`) governs which owners may be *registered*
+   as built-in static templates — `docs`, `summary`, `notify`, `action`, `ai`.
+   `approvedRuntimeOwners` (`modules/card_template_catalog`) governs which owners
+   may be *published and authorized at runtime*, and is narrower: `ai` and `docs`
+   only. A template whose owner passes registration will still be refused by
+   publish if it is outside the runtime list. Widening the runtime list is a
+   reviewed change, not a consequence of adding a static card.
 3. Read the current revision, then send an explicit target version and
    `expected_revision`. A stale revision returns a conflict and must be
    refreshed; do not blindly retry the old body.
 4. Confirm the success audit and resulting revision. Exercise exact resolution,
-   rollback, and block while new-send remains disabled. PR-B has no producer
-   grants, so activation drills must use a template ID that no Bot, notify path,
-   or other producer currently consumes; activating a dynamic version for a
-   consumed ID will correctly make that producer fail closed.
+   rollback, and block while new-send remains disabled.
+
+   **Changed by E3 PR-C.** PR-B had no producer grants, so drills had to avoid
+   any consumed template ID. Grants now exist, so a dynamic version for a
+   consumed ID is a supported (and intended) operation — but it fails closed
+   until the consuming producer holds a `send` grant in the Space it sends to.
+   Two consequences for an operator:
+
+   - `publish`, `grant` and `activate` are three separate operations and none
+     implies the next. A published artifact is inert; a granted producer still
+     sends the previously active version; an activated version without a grant
+     makes the whole template ID unsendable rather than falling back to the
+     static card of the same ID.
+   - A Bot's advertised catalog is now **request-scoped**. `GET /v1/bot/card/profile`
+     answers for the authenticated Bot in its authoritative Space, so two Bots in
+     one deployment legitimately see different manifests. When diagnosing "the
+     Bot cannot send X", read the profile *as that Bot*, not as the deployment.
 
 ### Rollback
 

--- a/docs/platform-card-base.md
+++ b/docs/platform-card-base.md
@@ -122,6 +122,12 @@
        - **进度(2026-07)**:注册 + Render + conformance + 字节等价基线维度已达标 —— **5 张** L2a 卡在 Registry 上:`docs.access-request`(v2 交互,#633/#641)、`docs.commented` + `docs.shared`(v1 展示,#649)、`summary.completed` + `summary.failed`(v1 展示,#650),两种视图模式全覆盖。**仍缺"生产灰度"这一维度**(线上放量观测),故门槛 ② 尚未整体满足;`generic.approval` 因动态 owner 与静态 `TemplateActionContract` 冲突暂未迁(见 §15.4)。
      ③ `docs/l2b-owners.md` 空清单已合入,且有至少一份未通过审核的 L2b 申请 PR 作为流程演练;
      ④ callback URL 白名单机制、独立 token 通道、per-owner 观测指标全部在 L0 落地。
+       - **进度(2026-08,E3 PR-C)**:per-owner/per-source 观测指标与 runtime catalog
+         的 resolve/cache/DB 指标已落地;callback 路由仍按 `(owner, action_type)`
+         匹配既有 RouteSpec(见 §11),**未新增** callback URL 白名单机制,也**未新增**
+         独立 token 通道 —— dynamic catalog 复用现有回调链路,不引入新的出站通道。
+         故门槛 ④ 仍未整体满足。PR-C 交付的 grant 机制是**消费侧**授权
+         (谁可以 discover/send/edit 某个模板),不是 L2b 所要求的**上传侧**准入。
    - **消息通道位置**:L2b 卡片在客户端 UI 上默认不做特殊突出显示(与 L2a 同渠道到达);渲染顺序、置顶、折叠策略由客户端自行决定,L0 不承诺。
 
 ### 2.3 现有代码到分层的映射
@@ -593,8 +599,17 @@ type CardUpdater interface {
 |---|---|
 | `POST /v1/internal/notify` | **现有**发送入口；方案 B 阶段外壳不动，内部走 Registry。未来加 envelope 模式后可选显式 `template_id`。 |
 | `POST /v1/message/card/action` | **现有**交互回调入口(挂在 `/v1/message` group,经 `modules/cardtrust` 校验后路由到 `cardactiondispatch`);payload 按第 7 节标准化(客户端上行结构与已有实现一致,基座只统一 owner/action_type/inputs 语义,不改端点)。 |
-| `GET /v1/message/card/templates` | 新增:列出所有已注册模板(id/version/views/protocol/owner/actionType);给业务方/前端做能力发现。 |
-| `GET /v1/message/card/templates/{id}@{version}` | 新增:返回 manifest + data.schema + interaction reports + samples,供跨仓生成 SDK/联调。 |
+| `GET /v1/message/card/templates` | **已交付**(E3 PR-C):列出**调用方可见**的模板 exact version — id/version/source/owner/protocol/contract_version/visibility/`action_contract`/`active_for_new_send`。`action_contract` 是 `{owner, action_type}` 摘要,纯展示卡为 `null`(这个 null 就是「本卡永不产生回调」的承诺)。 |
+| `GET /v1/message/card/templates/{id}@{version}` | **已交付**(E3 PR-C):返回 manifest + data.schema + interaction reports + **manifest 显式 allowlist 的** samples 的安全 projection。 |
+
+关于这两个端点，有四条与早期草案不同、必须按实现理解的约束：
+
+1. **可见 ≠ 可发**。出现在列表里只代表调用方有权看见该模板的契约；能否 new send / historical edit 由 grant 决定，Bot 的权威发现面仍是 `GET /v1/bot/card/profile`。不要拿 B1/B2 绕过 bot grant。
+2. **默认不可见**。static 卡一律 private，是否对外可发现由 composition root 的显式登记决定（`main.go` 的 `applyStaticCatalogVisibility`，PR-C 交付时**故意为空**）；private 模板需要调用方当前 Space 持有 `discover` grant。
+3. **不存在 / 无权见 / 已 block 返回同一个 localized not-found**。三者可区分等于给出私有目录的枚举 oracle。
+4. **samples 是 per-artifact opt-in**。只有 manifest 里 `export.samples` 显式列出、且确认是合成 fixture 的 sample 才会导出；templates、goldens、canonical bundle bytes、audit、grants、内部 DB ID 永不出现在 B2。static L1 manifest 已冻结、无法追加该声明，因此**现有 static 卡的 B2 samples 恒为空**——这是正确答案，不是缺口。
+
+分页与缓存：cursor 分页，默认 50 / 硬上限 100；visibility、block、grant 全部在**分页 limit 之前**结算（否则隐藏行会缩短页面，页长本身就成了计数 oracle）；cursor 绑定发放它的 Space，跨 Space 重放 fail-close 回到第一页。dynamic 用不可变 `content_sha256` 作 ETag、static 用确定性 export hash，支持 `If-None-Match`/304；private 响应至少 `Cache-Control: private, no-cache`。
 
 ---
 
@@ -610,6 +625,9 @@ type CardUpdater interface {
 | **输入校验失败**（schema 不通过、必填缺失） | **400 `ErrNotifyCardInvalid`，零投递，不降级**（对齐 brief 决策 C1，禁止把错请求伪装成成功文本）。 |
 | 服务端 render 错（cardmsg.Validate 失败/marshal 失败） | 打 `cardtmpl_build_total{result=render_error}` metrics，降级为 fallback 文本，保证必达。 |
 | Registry 未命中（composition bug，理论不应发生） | 500 internal error，打 error log；不降级为错文本。 |
+| **dynamic active 但无 grant / 已 block / integrity 失败** | 整个 template ID fail-close：**绝不回退到同 ID 的 static 版本**。运维把某 ID 指向 dynamic 就是要替换它，回退等于用生产者以为已替换的名字发出实质不同的内容。 |
+| **runtime catalog DB 不可用** | Bot profile 返回 typed localized unavailable；Registry new send fail-close。同样不回退 static 同 ID 版本——读失败时无法判断该 ID 是否已被 shadow。 |
+| **new-send gate 关闭**（`OCTO_CARD_RUNTIME_CATALOG_NEW_SEND_ENABLED=false`） | 完全保持既有 static 行为，**不访问 runtime DB**：未启用 dynamic catalog 的部署不因此获得新的 DB 依赖或新的失败模式。 |
 
 ---
 

--- a/internal/cardactiondispatch/contract.go
+++ b/internal/cardactiondispatch/contract.go
@@ -51,10 +51,19 @@ type Event struct {
 
 // CardContext is derived from the effective server-authored card frame before
 // enqueue. Zero value means a legacy card without registry metadata.
+//
+// PrincipalType/PrincipalID/SpaceID are additive PR-C D3 fields: the action
+// ingress copies them from the frame's validated `catalog_provenance` marker
+// after proving consistency with the stored sender and authoritative Space.
+// They are absent on frames sent before provenance existed; consumers must
+// not fall back to guessing a principal from sender/owner when they are set.
 type CardContext struct {
 	TemplateID      string `json:"template_id,omitempty"`
 	TemplateVersion string `json:"template_version,omitempty"`
 	View            string `json:"view,omitempty"`
+	PrincipalType   string `json:"principal_type,omitempty"`
+	PrincipalID     string `json:"principal_id,omitempty"`
+	SpaceID         string `json:"space_id,omitempty"`
 }
 
 type CallbackFormat string

--- a/internal/cardactiondispatch/contract_test.go
+++ b/internal/cardactiondispatch/contract_test.go
@@ -596,3 +596,60 @@ func sha256Hex(body []byte) string {
 	sum := sha256.Sum256(body)
 	return hex.EncodeToString(sum[:])
 }
+
+// ---- PR-C Slice 1 (D3): CardContext carries the validated stored principal
+// as additive durable fields. The cross-repo callback envelope is frozen and
+// must not grow the principal; only the internal event record does. ----
+
+func TestCardContextPrincipalFieldsAreDurableAndAdditive(t *testing.T) {
+	event := Event{
+		EventID: 7, ActionID: "docs-access-approve", OperatorUID: "user-1",
+		MessageID: "1001", ChannelID: "user-1", ChannelType: 1,
+		Card: CardContext{
+			TemplateID: "docs.access-request", TemplateVersion: "0.3.0", View: "pending",
+			PrincipalType: "internal_producer", PrincipalID: "docs-notify", SpaceID: "space-1",
+		},
+	}
+	raw, err := json.Marshal(event)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var decoded Event
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if decoded.Card != event.Card {
+		t.Fatalf("durable round trip = %+v, want %+v", decoded.Card, event.Card)
+	}
+
+	// Old durable events (no principal fields) keep decoding into the same shape.
+	var legacyDecoded Event
+	if err := json.Unmarshal([]byte(`{"event_id":7,"card":{"template_id":"docs.access-request","template_version":"0.3.0","view":"pending"}}`), &legacyDecoded); err != nil {
+		t.Fatal(err)
+	}
+	if legacyDecoded.Card.PrincipalID != "" || legacyDecoded.Card.TemplateVersion != "0.3.0" {
+		t.Fatalf("legacy durable decode = %+v", legacyDecoded.Card)
+	}
+
+	// The frozen octo-card-v1 callback envelope must not leak the principal.
+	body, err := MarshalCallbackRequest(event, CallbackFormatOctoCardV1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var envelope map[string]interface{}
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		t.Fatal(err)
+	}
+	card, _ := envelope["card"].(map[string]interface{})
+	for _, forbidden := range []string{"principal_type", "principal_id", "space_id"} {
+		if _, leaked := card[forbidden]; leaked {
+			t.Fatalf("callback envelope leaked %s: %s", forbidden, body)
+		}
+	}
+
+	// A partially-filled principal context is still a complete octo-card
+	// context for callback purposes (view/template drive the envelope).
+	if event.Card == (CardContext{}) {
+		t.Fatal("populated context compared equal to zero value")
+	}
+}

--- a/internal/carddispatch/context.go
+++ b/internal/carddispatch/context.go
@@ -22,6 +22,21 @@ func Install(ctx ValueStore, registry *Registry) error {
 	return nil
 }
 
+// ProducerBindingFromContext 解析已安装 Registry 的只读 producer 身份绑定
+// （PR-C D3）。Registry 未安装或 producer 未注册一律 (\"\", false)，调用方
+// 对 dynamic provenance fail-close。与 SenderFromContext 不同，它绝不返回
+// 发送能力 —— 业务 caller 无法借它构造 ProducerSpec 或拿到 Sender。
+func ProducerBindingFromContext(ctx ValueStore, id ProducerID) (string, bool) {
+	if ctx == nil {
+		return "", false
+	}
+	registry, ok := ctx.Value(registryContextKey).(*Registry)
+	if !ok || registry == nil {
+		return "", false
+	}
+	return registry.ProducerBinding(id)
+}
+
 func SenderFromContext(ctx ValueStore, id ProducerID) (Sender, error) {
 	if ctx == nil {
 		return nil, categorized(CategoryProducerDisabled, errors.New("application context unavailable"))

--- a/internal/carddispatch/dispatch.go
+++ b/internal/carddispatch/dispatch.go
@@ -122,15 +122,36 @@ func (s *producerSender) Send(ctx context.Context, target Target, card Card) (re
 	// （裸 card 节点），够不到信封顶层，因此无法自报 principal；无模板元数据的
 	// legacy 文档不写标记（principal 只能靠猜，宁缺毋假）。
 	if refID, refVersion, ok := cardDocumentTemplateContext(cardDocument); ok {
-		payload[cardmsg.CatalogTemplateRefKey] = map[string]interface{}{
-			"id": refID, "version": refVersion,
-		}
-		payload[cardmsg.CatalogProvenanceKey] = cardmsg.CatalogProvenance{
+		provenance := cardmsg.CatalogProvenance{
 			Version:       cardmsg.CatalogProvenanceVersion,
 			PrincipalType: cardmsg.CatalogPrincipalWireInternalProducer,
 			PrincipalID:   string(s.spec.ID),
 			SpaceID:       target.SpaceID,
-		}.MarshalMap()
+		}
+		// Validate before stamping, because nothing downstream will. The
+		// cardmsg.Validate call above runs before these keys exist, and
+		// Finalize only builds `plain` and rechecks size — so this is the last
+		// point at which an invalid marker can be refused.
+		//
+		// Refusing here rather than trimming target.SpaceID is deliberate: this
+		// is the one boundary that authors an internal-producer marker, and it
+		// should be unable to author one the readers reject. The readers are
+		// strict (ParseCatalogProvenance requires a trimmed space_id) while the
+		// gate on the way in only tests emptiness, and whether an untrimmed
+		// Space survives the membership lookup is decided by a collation the
+		// application does not choose: space_member declares none and inherits
+		// the database default, and CI creates that database PAD SPACE
+		// (utf8mb4_general_ci), where 'space-a ' matches 'space-a'. A stamped
+		// frame that no reader accepts is unclickable and uneditable forever,
+		// so this refuses the send instead of delivering a broken card.
+		if err := provenance.Validate(); err != nil {
+			terminal = cardErrorCategory(err)
+			return nil, categorized(terminal, err)
+		}
+		payload[cardmsg.CatalogTemplateRefKey] = map[string]interface{}{
+			"id": refID, "version": refVersion,
+		}
+		payload[cardmsg.CatalogProvenanceKey] = provenance.MarshalMap()
 	}
 
 	// Authorization has already established this exact active Space. It is the

--- a/internal/carddispatch/dispatch.go
+++ b/internal/carddispatch/dispatch.go
@@ -116,6 +116,23 @@ func (s *producerSender) Send(ctx context.Context, target Target, card Card) (re
 		return nil, categorized(terminal, validateErr)
 	}
 
+	// PR-C D3：可信派发边界从「已通过 cardmsg.Validate 的 metadata.octo.template」
+	// 与「已注册 ProducerSpec.ID + 已授权 target Space」为 Registry 产出的卡
+	// 写入 server-authored 顶层 catalog 标记。业务调用方只掌握 Card.Document
+	// （裸 card 节点），够不到信封顶层，因此无法自报 principal；无模板元数据的
+	// legacy 文档不写标记（principal 只能靠猜，宁缺毋假）。
+	if refID, refVersion, ok := cardDocumentTemplateContext(cardDocument); ok {
+		payload[cardmsg.CatalogTemplateRefKey] = map[string]interface{}{
+			"id": refID, "version": refVersion,
+		}
+		payload[cardmsg.CatalogProvenanceKey] = cardmsg.CatalogProvenance{
+			Version:       cardmsg.CatalogProvenanceVersion,
+			PrincipalType: cardmsg.CatalogPrincipalWireInternalProducer,
+			PrincipalID:   string(s.spec.ID),
+			SpaceID:       target.SpaceID,
+		}.MarshalMap()
+	}
+
 	// Authorization has already established this exact active Space. It is the
 	// only source allowed to enrich the wire envelope.
 	payload["space_id"] = target.SpaceID
@@ -200,6 +217,23 @@ func validateRequest(ctx context.Context, target Target, card Card) error {
 		return errors.New("unsupported render profile")
 	}
 	return nil
+}
+
+// cardDocumentTemplateContext 从裸 card 节点提取 Registry 模板身份，语义与
+// cardmsg.CardTemplateContext（信封形态）一致：协议必须是 octo-card@1.0，
+// id/version 非空且已 trim；任何偏差都按「非 Registry 文档」处理（不写标记）。
+func cardDocumentTemplateContext(card map[string]interface{}) (string, string, bool) {
+	metadata, _ := card["metadata"].(map[string]interface{})
+	octo, _ := metadata["octo"].(map[string]interface{})
+	template, _ := octo["template"].(map[string]interface{})
+	protocol, _ := octo["protocol"].(string)
+	id, _ := template["id"].(string)
+	version, _ := template["version"].(string)
+	if protocol != "octo-card@1.0" || id == "" || version == "" ||
+		strings.TrimSpace(id) != id || strings.TrimSpace(version) != version {
+		return "", "", false
+	}
+	return id, version, true
 }
 
 func cardErrorCategory(err error) Category {

--- a/internal/carddispatch/dispatch_test.go
+++ b/internal/carddispatch/dispatch_test.go
@@ -698,3 +698,127 @@ func metricHasLabels(pairs []*dto.LabelPair, want map[string]string) bool {
 	}
 	return true
 }
+
+// ---- PR-C Slice 1 (D3): the trusted dispatch boundary authors catalog
+// provenance from the registered ProducerSpec and the authorized target Space.
+// Business callers cannot self-report a principal. ----
+
+func registryCardDocument() json.RawMessage {
+	return json.RawMessage(`{
+		"type":"AdaptiveCard","version":"1.5",
+		"body":[{"type":"TextBlock","text":"pending"}],
+		"metadata":{"octo":{
+			"protocol":"octo-card@1.0",
+			"template":{"id":"docs.access-request","version":"0.3.0"}
+		}}
+	}`)
+}
+
+func TestSendAuthorsCatalogProvenanceForRegistryDocuments(t *testing.T) {
+	registry, _, _, transport, _ := newHarness(t, validSpec())
+	sender, err := registry.Sender("summary-notify")
+	require.NoError(t, err)
+
+	_, err = sender.Send(context.Background(), validTarget(), Card{
+		Profile: cardmsg.ProfileV1, Document: registryCardDocument(),
+	})
+	require.NoError(t, err)
+	_, req := transport.snapshot()
+	require.NotNil(t, req)
+	var wire map[string]interface{}
+	require.NoError(t, json.Unmarshal(req.Payload, &wire))
+
+	ref, _ := wire["template_ref"].(map[string]interface{})
+	require.NotNil(t, ref, "server-authored template_ref missing: %s", req.Payload)
+	assert.Equal(t, "docs.access-request", ref["id"])
+	assert.Equal(t, "0.3.0", ref["version"])
+
+	provenance, err := cardmsg.ParseCatalogProvenance(wire["catalog_provenance"])
+	require.NoError(t, err, "authored provenance must be canonical: %#v", wire["catalog_provenance"])
+	assert.Equal(t, cardmsg.CatalogPrincipalWireInternalProducer, provenance.PrincipalType)
+	assert.Equal(t, "summary-notify", provenance.PrincipalID, "principal is the registered ProducerSpec.ID")
+	assert.Equal(t, "space-a", provenance.SpaceID, "space is the authorized target Space")
+
+	// The outbound frame must satisfy the same strict marker contract the
+	// action ingress will later enforce.
+	markers, err := cardmsg.CatalogFrameMarkers(req.Payload)
+	require.NoError(t, err)
+	assert.True(t, markers.HasRef)
+	assert.True(t, markers.HasProvenance)
+}
+
+func TestSendLeavesLegacyDocumentsUnmarked(t *testing.T) {
+	registry, _, _, transport, _ := newHarness(t, validSpec())
+	sender, err := registry.Sender("summary-notify")
+	require.NoError(t, err)
+
+	_, err = sender.Send(context.Background(), validTarget(), Card{
+		Profile: cardmsg.ProfileV1, Document: validCardDocument(),
+	})
+	require.NoError(t, err)
+	_, req := transport.snapshot()
+	require.NotNil(t, req)
+	var wire map[string]interface{}
+	require.NoError(t, json.Unmarshal(req.Payload, &wire))
+	_, hasRef := wire["template_ref"]
+	_, hasProvenance := wire["catalog_provenance"]
+	assert.False(t, hasRef, "legacy document grew template_ref")
+	assert.False(t, hasProvenance, "legacy document grew catalog_provenance")
+}
+
+func TestProducerBindingExposesReadOnlySenderFacts(t *testing.T) {
+	enabled := validSpec()
+	disabled := validSpec()
+	disabled.ID = "docs-notify"
+	disabled.SenderUID = "notification"
+	disabled.Enabled = false
+	registry := NewRegistry(Dependencies{
+		IdentityResolver: &fakeIdentityResolver{identity: &botidentity.Identity{UID: "summary", Kind: botidentity.KindUserBot}},
+		Authorizer:       &fakeAuthorizer{},
+		Transport:        &fakeTransport{},
+		Metrics:          NewMetrics(prometheus.NewRegistry()),
+	}, []ProducerSpec{enabled, disabled})
+
+	sender, ok := registry.ProducerBinding("summary-notify")
+	require.True(t, ok)
+	assert.Equal(t, "summary", sender)
+
+	// A disabled producer cannot send, but its declared identity binding is
+	// still a fact the action ingress may verify historical frames against.
+	sender, ok = registry.ProducerBinding("docs-notify")
+	require.True(t, ok)
+	assert.Equal(t, "notification", sender)
+
+	_, ok = registry.ProducerBinding("never-registered")
+	assert.False(t, ok)
+
+	store := &fakeValueStore{}
+	require.NoError(t, Install(store, registry))
+	sender, ok = ProducerBindingFromContext(store, "summary-notify")
+	require.True(t, ok)
+	assert.Equal(t, "summary", sender)
+	_, ok = ProducerBindingFromContext(store, "never-registered")
+	assert.False(t, ok)
+	_, ok = ProducerBindingFromContext(&fakeValueStore{}, "summary-notify")
+	assert.False(t, ok, "missing registry must fail closed")
+}
+
+func TestProducerBindingRejectsAmbiguousOrInvalidSpecs(t *testing.T) {
+	duplicateA := validSpec()
+	duplicateB := validSpec()
+	invalid := validSpec()
+	invalid.ID = "docs-notify"
+	invalid.SenderUID = "iwh_webhook"
+	registry := NewRegistry(Dependencies{
+		IdentityResolver: &fakeIdentityResolver{identity: &botidentity.Identity{UID: "summary", Kind: botidentity.KindUserBot}},
+		Authorizer:       &fakeAuthorizer{},
+		Transport:        &fakeTransport{},
+		Metrics:          NewMetrics(prometheus.NewRegistry()),
+	}, []ProducerSpec{duplicateA, duplicateB, invalid})
+	if _, ok := registry.ProducerBinding("summary-notify"); ok {
+		t.Fatal("duplicate producer ID must not expose a binding")
+	}
+	if _, ok := registry.ProducerBinding("docs-notify"); ok {
+		t.Fatal("webhook-prefixed sender must not expose a binding")
+	}
+}

--- a/internal/carddispatch/dispatch_test.go
+++ b/internal/carddispatch/dispatch_test.go
@@ -747,6 +747,41 @@ func TestSendAuthorsCatalogProvenanceForRegistryDocuments(t *testing.T) {
 	assert.True(t, markers.HasProvenance)
 }
 
+// PR-C review round 6 (yujiawei P1-1): the marker-authoring boundary must be
+// unable to author a marker its readers reject.
+//
+// cardmsg.Validate runs before these keys exist and Finalize does not
+// re-validate, so before this guard an untrimmed target Space produced a stored
+// frame that every reader refuses — ParseCatalogProvenance requires a trimmed
+// space_id. The card rendered and then nothing about it worked: every button
+// click and every edit failed permanently, with no way to repair the message.
+//
+// Reaching it needed only an untrimmed Space to survive the membership lookup,
+// and whether it does is decided by a collation the application does not
+// choose. space_member declares none and inherits the database default; CI
+// creates that database utf8mb4_general_ci, which is PAD SPACE, so 'space-a '
+// matches 'space-a'. Measured both ways: PAD SPACE matches, and the MySQL 8.0
+// default utf8mb4_0900_ai_ci (NO PAD) does not. Refusing the send here removes
+// the dependency on that fact entirely.
+func TestSendRefusesToAuthorAMarkerItsReadersWouldReject(t *testing.T) {
+	registry, _, _, transport, _ := newHarness(t, validSpec())
+	sender, err := registry.Sender("summary-notify")
+	require.NoError(t, err)
+
+	untrimmed := validTarget()
+	untrimmed.SpaceID = "space-a "
+
+	_, err = sender.Send(context.Background(), untrimmed, Card{
+		Profile: cardmsg.ProfileV1, Document: registryCardDocument(),
+	})
+	require.Error(t, err, "an untrimmed Space produced a card whose markers no reader accepts")
+	require.ErrorIs(t, err, cardmsg.ErrCatalogMarkerInvalid)
+
+	// Nothing was delivered: the send fails instead of storing a broken card.
+	_, req := transport.snapshot()
+	assert.Nil(t, req, "a frame with an unreadable marker reached the transport")
+}
+
 func TestSendLeavesLegacyDocumentsUnmarked(t *testing.T) {
 	registry, _, _, transport, _ := newHarness(t, validSpec())
 	sender, err := registry.Sender("summary-notify")

--- a/internal/carddispatch/mutation.go
+++ b/internal/carddispatch/mutation.go
@@ -187,6 +187,37 @@ func (m *CardMutator) Mutate(ctx context.Context, request CardMutationRequest) (
 	if revoked || deleted {
 		return CardMutationResult{}, ErrCardMutationNotFound
 	}
+	// The server-authored catalog markers are the card's identity, and identity
+	// does not change under an edit — pkg/cardtmpl/updater.go states exactly
+	// that, but stated it only for the path that happens to go through the
+	// updater. A caller that assembles a replacement frame from its own key set
+	// simply dropped them, and every guard keyed on their presence then went
+	// inert for that message: the stored-version pin and the cross-Space
+	// refusal both begin `if markers.Has…`. A user click was enough to trigger
+	// it, so this is enforced where every replacement passes rather than at
+	// each site that builds one.
+	//
+	// Absent on both sides is the legacy population and stays legal. Present on
+	// the stored frame and absent on the replacement is the erasure, and it is
+	// refused rather than repaired: re-attaching a template_ref would need the
+	// replacement's own card body to carry the matching metadata.octo.template,
+	// which a non-Registry render does not have, so "repair" would either fail
+	// validation anyway or stamp a Registry identity onto a body that is not
+	// one. The caller has to produce a frame that legitimately carries them.
+	stored, err := cardmsg.CatalogFrameMarkers(message.Payload)
+	if err != nil {
+		return CardMutationResult{}, fmt.Errorf("%w: stored frame markers: %v", ErrCardMutationInvalid, err)
+	}
+	if stored.HasRef || stored.HasProvenance {
+		next, markerErr := cardmsg.CatalogFrameMarkers([]byte(request.ContentEdit))
+		if markerErr != nil {
+			return CardMutationResult{}, fmt.Errorf("%w: replacement frame markers: %v", ErrCardMutationInvalid, markerErr)
+		}
+		if stored.HasRef != next.HasRef || stored.HasProvenance != next.HasProvenance {
+			return CardMutationResult{}, fmt.Errorf(
+				"%w: replacement drops the stored catalog markers", ErrCardMutationInvalid)
+		}
+	}
 	normalized, err := cardmsg.NormalizeContentEdit(request.ContentEdit)
 	if err != nil {
 		return CardMutationResult{}, fmt.Errorf("%w: %v", ErrCardMutationInvalid, err)

--- a/internal/carddispatch/mutation_test.go
+++ b/internal/carddispatch/mutation_test.go
@@ -215,3 +215,94 @@ func testCardEnvelope(t *testing.T, cardSeq int64, withAction bool) []byte {
 	}
 	return raw
 }
+
+// markedTestCardEnvelope is testCardEnvelope plus the server-authored catalog
+// markers a Registry render carries: both top-level keys and the matching
+// metadata.octo.template they are validated against.
+func markedTestCardEnvelope(t *testing.T, cardSeq int64, withAction bool) []byte {
+	t.Helper()
+	var envelope map[string]interface{}
+	if err := json.Unmarshal(testCardEnvelope(t, cardSeq, withAction), &envelope); err != nil {
+		t.Fatal(err)
+	}
+	card := envelope["card"].(map[string]interface{})
+	card["metadata"] = map[string]interface{}{
+		"octo": map[string]interface{}{
+			"protocol": "octo-card@1.0",
+			"template": map[string]interface{}{"id": "docs.access-request", "version": "0.3.0"},
+		},
+	}
+	envelope[cardmsg.CatalogTemplateRefKey] = map[string]interface{}{
+		"id": "docs.access-request", "version": "0.3.0",
+	}
+	envelope[cardmsg.CatalogProvenanceKey] = cardmsg.CatalogProvenance{
+		Version:       cardmsg.CatalogProvenanceVersion,
+		PrincipalType: cardmsg.CatalogPrincipalWireInternalProducer,
+		PrincipalID:   "docs-notify",
+		SpaceID:       "space-1",
+	}.MarshalMap()
+	raw, err := json.Marshal(envelope)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return raw
+}
+
+// PR-C review round 6 (yujiawei P1-2), the structural half.
+//
+// The catalog markers are the card's identity and identity does not change
+// under an edit. pkg/cardtmpl/updater.go states that, but only the paths that
+// go through the updater honoured it: a caller assembling a replacement from
+// its own key set simply dropped them, and both identity guards — the
+// stored-version pin and the cross-Space refusal — begin `if markers.Has…`, so
+// they went inert for that message. Enforcing it here means no future call site
+// can silently downgrade a marked card, whatever frame it builds.
+func TestCardMutatorRefusesToDropStoredCatalogMarkers(t *testing.T) {
+	marked := markedTestCardEnvelope(t, 0, true)
+
+	t.Run("a replacement that drops the markers is refused", func(t *testing.T) {
+		backend := &fakeMutationBackend{message: storedCardMessage{
+			MessageID: "1001", MessageSeq: 7, FromUID: "notification", Payload: marked,
+		}}
+		_, err := newCardMutator(backend).Mutate(context.Background(), CardMutationRequest{
+			SenderUID: "notification", MessageID: "1001", ChannelID: "user-b", ChannelType: 1,
+			ContentEdit: string(testCardEnvelope(t, 42, false)), // legacy six-key rebuild
+		})
+		if !errors.Is(err, ErrCardMutationInvalid) {
+			t.Fatalf("Mutate() error = %v, want ErrCardMutationInvalid", err)
+		}
+		if len(backend.writes) != 0 {
+			t.Fatalf("a marker-erasing frame was persisted: %+v", backend.writes)
+		}
+	})
+
+	t.Run("a replacement that carries them through is applied", func(t *testing.T) {
+		backend := &fakeMutationBackend{message: storedCardMessage{
+			MessageID: "1001", MessageSeq: 7, FromUID: "notification", Payload: marked,
+		}}
+		result, err := newCardMutator(backend).Mutate(context.Background(), CardMutationRequest{
+			SenderUID: "notification", MessageID: "1001", ChannelID: "user-b", ChannelType: 1,
+			ContentEdit: string(markedTestCardEnvelope(t, 42, false)),
+		})
+		if err != nil {
+			t.Fatalf("Mutate() error = %v", err)
+		}
+		if !result.Applied || len(backend.writes) != 1 {
+			t.Fatalf("result = %+v writes = %+v", result, backend.writes)
+		}
+	})
+
+	t.Run("the legacy population is untouched", func(t *testing.T) {
+		backend := &fakeMutationBackend{message: storedCardMessage{
+			MessageID: "1001", MessageSeq: 7, FromUID: "notification",
+			Payload: testCardEnvelope(t, 0, true),
+		}}
+		result, err := newCardMutator(backend).Mutate(context.Background(), CardMutationRequest{
+			SenderUID: "notification", MessageID: "1001", ChannelID: "user-b", ChannelType: 1,
+			ContentEdit: string(testCardEnvelope(t, 42, false)),
+		})
+		if err != nil || !result.Applied {
+			t.Fatalf("an unmarked card must still be editable: result = %+v err = %v", result, err)
+		}
+	})
+}

--- a/internal/carddispatch/registry.go
+++ b/internal/carddispatch/registry.go
@@ -18,12 +18,19 @@ var producerIDPattern = regexp.MustCompile(`^[a-z][a-z0-9-]{0,63}$`)
 type Registry struct {
 	senders map[ProducerID]*producerSender
 	invalid map[ProducerID]struct{}
+	// bindings 是 ProducerID → 权威 SenderUID 的只读事实表（PR-C D3）。
+	// action-context 用它校验 stored provenance：帧声明的 internal producer
+	// 是否真的绑定到该消息的 FromUID。disabled 的 spec 也登记 —— 停用只收回
+	// 发送能力，不抹掉身份事实（历史帧仍需校验）；duplicate/畸形 spec 身份
+	// 有歧义，不登记。
+	bindings map[ProducerID]string
 }
 
 func NewRegistry(deps Dependencies, specs []ProducerSpec) *Registry {
 	registry := &Registry{
-		senders: make(map[ProducerID]*producerSender),
-		invalid: make(map[ProducerID]struct{}),
+		senders:  make(map[ProducerID]*producerSender),
+		invalid:  make(map[ProducerID]struct{}),
+		bindings: make(map[ProducerID]string),
 	}
 	counts := make(map[ProducerID]int, len(specs))
 	for _, spec := range specs {
@@ -38,6 +45,7 @@ func NewRegistry(deps Dependencies, specs []ProducerSpec) *Registry {
 			}
 			continue
 		}
+		registry.recordBinding(input)
 		if !input.Enabled {
 			registry.invalid[input.ID] = struct{}{}
 			continue
@@ -76,9 +84,33 @@ func (r *Registry) Sender(id ProducerID) (Sender, error) {
 	return sender, nil
 }
 
+// recordBinding 登记一条身份事实。只接受形状合法的 (ID, SenderUID)：ID 走与
+// 发送侧相同的 pattern，sender 非空且非 incoming-webhook 前缀。
+func (r *Registry) recordBinding(spec ProducerSpec) {
+	if !producerIDPattern.MatchString(string(spec.ID)) {
+		return
+	}
+	sender := strings.TrimSpace(spec.SenderUID)
+	if sender == "" || strings.HasPrefix(sender, "iwh_") {
+		return
+	}
+	r.bindings[spec.ID] = sender
+}
+
+// ProducerBinding 返回 ProducerID 声明的权威 SenderUID。只读事实，不携带
+// 发送能力；调用方不能据此拿到 Sender。
+func (r *Registry) ProducerBinding(id ProducerID) (string, bool) {
+	if r == nil {
+		return "", false
+	}
+	sender, ok := r.bindings[id]
+	return sender, ok
+}
+
 func (r *Registry) reject(deps Dependencies, id ProducerID, reason string) {
 	r.invalid[id] = struct{}{}
 	delete(r.senders, id)
+	delete(r.bindings, id)
 	producer := metricProducerLabel(id)
 	deps.Metrics.configError(producer, reason)
 	if deps.Logger != nil {

--- a/main.go
+++ b/main.go
@@ -754,8 +754,37 @@ func installCardTmplRegistry() *cardtmpl.Registry {
 	registry.RegisterJSON(aireasoningprocess.Assets, aireasoningprocess.HandoffRootV2)
 	registry.RegisterJSON(aireasoningprocess.Assets, aireasoningprocess.HandoffRootV3)
 	registry.SetDefault(aireasoningprocess.TemplateID, aireasoningprocess.TemplateVersionV3)
+	applyStaticCatalogVisibility(registry)
 	registry.Freeze()
 	cardtmpl.SetGlobalMetrics(cardtmpl.NewMetrics(prometheus.DefaultRegisterer))
 	cardtmpl.SetDefaultRegistry(registry)
 	return registry
+}
+
+// applyStaticCatalogVisibility is the composition root's declaration of which
+// frozen static cards the B1/B2 discovery endpoints may show to callers outside
+// the card's own Space (PR-C D5).
+//
+// It lives here, and not in each template's manifest, for two reasons: an L1
+// handoff manifest is frozen at publish and cannot grow a field, and "who may
+// see this card" is a deployment decision that should be reviewable in one
+// place. Every registered template is private until it is named below, so a
+// card becomes publicly discoverable only through an explicit, reviewed edit —
+// never because someone forgot to set something.
+//
+// PR-C deliberately publishes nothing. All five existing L2a cards stay
+// private: opening one up is a separate reviewed change with its own
+// justification, not a side effect of shipping the discovery endpoints. The
+// empty list is the feature; the public path is exercised by test fixtures and
+// by the pilot's dynamic bundle.
+func applyStaticCatalogVisibility(registry *cardtmpl.Registry) {
+	publicStaticTemplates := []struct {
+		id      cardtmpl.ID
+		version string
+	}{
+		// intentionally empty — see the comment above before adding a row.
+	}
+	for _, template := range publicStaticTemplates {
+		registry.SetCatalogVisibility(template.id, template.version, cardtmpl.CatalogVisibilityPublic)
+	}
 }

--- a/modules/bot_api/bot_api.go
+++ b/modules/bot_api/bot_api.go
@@ -21,6 +21,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-server/modules/voice_adapter"
 	"github.com/Mininglamp-OSS/octo-server/pkg/cardrevision"
 	"github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl"
+	appwkhttp "github.com/Mininglamp-OSS/octo-server/pkg/wkhttp"
 )
 
 const (
@@ -320,7 +321,6 @@ func (ba *BotAPI) Route(r *wkhttp.WKHttp) {
 		botAPI.GET("/upload/presigned", ba.botUploadPresigned)
 		botAPI.POST("/message/edit", ba.botMessageEdit)
 		botAPI.POST("/message/card/revisions/clear", ba.botCardRevisionsClear) // D10.6 清除卡片修订(写墓碑)
-		botAPI.GET("/card/profile", ba.botCardProfile)                         // D12 卡片能力清单(feature detection)
 		botAPI.GET("/user/info", ba.getUserInfo)
 		// Voice context API (User Bot only)
 		botAPI.PUT("/voice/context", ba.botPutVoiceContext)
@@ -335,6 +335,20 @@ func (ba *BotAPI) Route(r *wkhttp.WKHttp) {
 		// different from the user-token /v1/obo/* CRUD which mutates
 		// grants on behalf of a logged-in grantor.
 		botAPI.GET("/obo-grant", ba.oboBotGetGrant)
+	}
+
+	// D12 卡片能力清单(feature detection)。PR-C D6 把它从进程常量改为
+	// request-scoped：清单现在按认证 bot + 权威 Space 查询 active/unblocked
+	// dynamic send grant，可能落到 runtime DB，因此单独挂 uid 限流。
+	//
+	// 中间件链与 incoming_webhook / search 一致：authBot（bf_/app_ token →
+	// robot_id）→ botActorUID（把 robot_id 写入 "uid"）→ SharedUIDRateLimiter
+	// （必须在 uid 写入之后，否则读不到 uid 会静默 fail-open）。只包这一条路由，
+	// 不给同组既有 legacy Bot 路由静默加上限流。
+	cardProfileAPI := r.Group("/v1/bot",
+		ba.authBot(), ba.botActorUID(), appwkhttp.SharedUIDRateLimiter(r, ba.ctx))
+	{
+		cardProfileAPI.GET("/card/profile", ba.botCardProfile)
 	}
 
 	// Bot File API (separate group for wildcard conflict avoidance)

--- a/modules/bot_api/card_profile.go
+++ b/modules/bot_api/card_profile.go
@@ -26,14 +26,32 @@ package bot_api
 import (
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
 	"github.com/Mininglamp-OSS/octo-server/pkg/cardmsg"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
+	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
+	"go.uber.org/zap"
 )
 
 // botCardProfile handles GET /v1/bot/card/profile (D12).
 func (ba *BotAPI) botCardProfile(c *wkhttp.Context) {
 	// authBot 已在中间件层校验 bot-token；此处再确认存在 bot 身份（与同组 GET 端点
 	// 一致的防御，非资源属主校验 —— 清单无属主概念）。缺身份 → 既有 bot-auth 拒绝。
-	if getRobotIDFromContext(c) == "" {
+	robotID := getRobotIDFromContext(c)
+	if robotID == "" {
 		ba.respondBotAPIIdentityMissing(c)
+		return
+	}
+	// PR-C D6: templating is no longer a process constant. Two Bots in the same
+	// deployment can hold different grants, so the manifest is resolved for this
+	// authenticated Bot in its authoritative Space. Everything else on this
+	// response stays deployment-level and stays request-independent.
+	templating, err := ba.cardTemplates.CapabilityFor(c.Request.Context(),
+		ba.botCatalogPrincipalFor(c, robotID))
+	if err != nil {
+		// Reporting the static manifest here would advertise versions that the
+		// send path may already be refusing. An honest "temporarily unknown"
+		// lets a producer retry; a confidently wrong manifest does not.
+		ba.Error("Bot 卡片能力清单不可用", zap.Error(err), zap.String("robotID", robotID))
+		httperr.ResponseErrorL(c, errcode.ErrSharedInternal, nil, nil)
 		return
 	}
 	c.Response(map[string]interface{}{
@@ -57,7 +75,7 @@ func (ba *BotAPI) botCardProfile(c *wkhttp.Context) {
 		// only the explicit Bot catalog, never the broader Registry.List(). A nil
 		// catalog occurs only in focused tests that do not install the production
 		// composition root and reports supported:false rather than inventing refs.
-		"templating": ba.cardTemplates.Capability(),
+		"templating": templating,
 		"limits": map[string]interface{}{
 			"max_payload_bytes":    cardmsg.MaxPayloadBytes,
 			"max_nodes":            cardmsg.MaxNodes,

--- a/modules/bot_api/card_profile_test.go
+++ b/modules/bot_api/card_profile_test.go
@@ -7,6 +7,7 @@ package bot_api
 import (
 	"bytes"
 	"encoding/json"
+	"github.com/go-redis/redis"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -38,6 +39,18 @@ func setupBotCardProfile(t *testing.T) (http.Handler, *config.Context) {
 		cpBotID, "owner_cp", cpBotToken,
 	).Exec()
 	assert.NoError(t, err)
+	// PR-C mounted SharedUIDRateLimiter on /v1/bot/card/profile, and the uid
+	// bucket lives in Redis across tests — CleanAllTables does not touch it.
+	// Without this reset the suite starts partway through the burst and later
+	// cases fail with 429s unrelated to the code under test.
+	rds := redis.NewClient(&redis.Options{
+		Addr:     ctx.GetConfig().DB.RedisAddr,
+		Password: ctx.GetConfig().DB.RedisPass,
+	})
+	defer rds.Close()
+	if keys, keysErr := rds.Keys("ratelimit:uid:*").Result(); keysErr == nil && len(keys) > 0 {
+		_ = rds.Del(keys...).Err()
+	}
 	return s.GetRoute(), ctx
 }
 

--- a/modules/bot_api/card_template_catalog.go
+++ b/modules/bot_api/card_template_catalog.go
@@ -716,16 +716,26 @@ func requireEffectiveCardTemplate(
 			return fmt.Errorf("%w: stored provenance does not match editing bot", errBotTemplateRequestInvalid)
 		}
 		if markers.Provenance.SpaceID != "" {
-			// The envelope's own space_id is a second, independent witness: a DM
-			// send writes it, and it is written from the *forgiving* resolver,
-			// which is also what stamped the marker whenever the strict grant
-			// resolver refused. Consulting it first is what keeps a Bot that
-			// spans two Spaces — a permanent property, not a blip — from being
-			// locked out of editing its own DM cards forever.
+			// The envelope's own space_id is a fallback witness: a DM send writes
+			// it from the *forgiving* resolver, which is also what stamped the
+			// marker whenever the strict grant resolver refused. It is what keeps
+			// a Bot that spans two Spaces — a permanent property, not a blip —
+			// from being locked out of editing its own DM cards forever.
+			//
+			// It is a fallback and not an alternative, and the difference is
+			// load-bearing. The envelope is the frame speaking about itself:
+			// matching it proves the frame is internally consistent, never that
+			// the grant behind this edit was read in the frame's Space. While it
+			// could substitute for the real comparison, a Bot in Spaces A and B
+			// could send a card under A's grant, lose A's edit permission, and
+			// then rewrite that card by presenting X-Space-ID: space-B — the
+			// grant was read in B, case 1 failed correctly, and the envelope's
+			// own "space-A" waved it through. So it applies only where there is
+			// no established Space to compare against.
 			envelopeSpace, _ := payload["space_id"].(string)
 			switch {
 			case space.verifiable && markers.Provenance.SpaceID == strings.TrimSpace(space.spaceID):
-			case envelopeSpace != "" && markers.Provenance.SpaceID == envelopeSpace:
+			case !space.verifiable && envelopeSpace != "" && markers.Provenance.SpaceID == envelopeSpace:
 			case space.unavailable && envelopeSpace == "":
 				// Nothing to compare against and something should have been
 				// resolvable. Refuse, but as a retryable outage: the frame may

--- a/modules/bot_api/card_template_catalog.go
+++ b/modules/bot_api/card_template_catalog.go
@@ -326,18 +326,40 @@ func (c *botCardTemplateCatalog) RenderEditPayloadForPrincipal(
 	principal botCatalogPrincipal,
 	inbound map[string]any,
 	env cardtmpl.BuildEnv,
+	storedSpaceID string,
 ) (map[string]any, error) {
 	if c == nil || strings.TrimSpace(principal.BotID) == "" {
 		return nil, errBotTemplateCatalogUnavailable
 	}
-	// The re-stamped marker has to carry the same Space the original send
-	// recorded, so it is composed the same way: the target-authoritative Space
-	// when one could be resolved, and the envelope's own Space otherwise.
-	// Using env.SpaceID unconditionally would erase a group card's Space on its
-	// first edit, because a group envelope has no top-level space_id.
+	// An edit *preserves* the marker's Space; it does not re-derive it. The
+	// stored value is what the send was authorized against, and it is already
+	// on the frame — recomputing it here means the answer depends on whether
+	// the resolver happens to work at edit time, so a gate rollback or a group
+	// row that will not load would quietly rewrite the card with an empty
+	// Space and disable every downstream `if Provenance.SpaceID != ""` guard.
+	// This is the same rule pkg/cardtmpl's updater already follows when it
+	// copies the stored markers through verbatim.
+	//
+	// Only a frame with no stored Space at all falls back to composing one,
+	// which is what a pre-PR-C frame being edited for the first time needs.
+	space := strings.TrimSpace(storedSpaceID)
+	if space == "" {
+		space = provenanceSpaceID(principal, env)
+	}
 	return c.renderPayload(ctx, principal.BotID, cardtmpl.CatalogPurposeHistoricalEdit, inbound, env,
-		c.staticRefResolver(c.editAllowed, "not edit-compatible"), true,
-		provenanceSpaceID(principal, env))
+		c.staticRefResolver(c.editAllowed, "not edit-compatible"), true, space)
+}
+
+// storedProvenanceSpaceID reads the Space a frame's own marker records, or ""
+// when the frame carries no marker (a pre-PR-C card) or cannot be parsed. The
+// guard that runs before it has already rejected a malformed marker, so an
+// empty answer here means "nothing was stored", never "we failed to look".
+func storedProvenanceSpaceID(envelope []byte) string {
+	markers, err := cardmsg.CatalogFrameMarkers(envelope)
+	if err != nil || !markers.HasProvenance {
+		return ""
+	}
+	return markers.Provenance.SpaceID
 }
 
 func (c *botCardTemplateCatalog) renderPayload(
@@ -613,20 +635,29 @@ func requireEffectiveCardTemplate(
 			return fmt.Errorf("%w: stored provenance does not match editing bot", errBotTemplateRequestInvalid)
 		}
 		if markers.Provenance.SpaceID != "" {
-			if space.unavailable {
+			// The envelope's own space_id is a second, independent witness: a DM
+			// send writes it, and it is written from the *forgiving* resolver,
+			// which is also what stamped the marker whenever the strict grant
+			// resolver refused. Consulting it first is what keeps a Bot that
+			// spans two Spaces — a permanent property, not a blip — from being
+			// locked out of editing its own DM cards forever.
+			envelopeSpace, _ := payload["space_id"].(string)
+			switch {
+			case space.verifiable && markers.Provenance.SpaceID == strings.TrimSpace(space.spaceID):
+			case envelopeSpace != "" && markers.Provenance.SpaceID == envelopeSpace:
+			case space.unavailable && envelopeSpace == "":
+				// Nothing to compare against and something should have been
+				// resolvable. Refuse, but as a retryable outage: the frame may
+				// be perfectly valid and the caller cannot fix our lookup.
 				return fmt.Errorf("%w: edit space could not be resolved, stored provenance unverifiable",
 					errBotTemplateRuntimeUnavailable)
-			}
-			if space.verifiable {
-				expectedSpace := strings.TrimSpace(space.spaceID)
-				if expectedSpace == "" {
-					// A DM resolved to no Space still has the envelope's own
-					// value, which is what pre-PR-C sends stamped.
-					expectedSpace, _ = payload["space_id"].(string)
-				}
-				if markers.Provenance.SpaceID != expectedSpace {
-					return fmt.Errorf("%w: stored provenance space mismatch", errBotTemplateRequestInvalid)
-				}
+			case !space.verifiable && envelopeSpace == "":
+				// The deployment establishes no Space at all (the dynamic
+				// catalog is dark), so there is nothing this check can assert.
+				// The canonical bot marker, the PrincipalID comparison above and
+				// Snapshot ownership still bind the edit to the card's author.
+			default:
+				return fmt.Errorf("%w: stored provenance space mismatch", errBotTemplateRequestInvalid)
 			}
 		}
 	}

--- a/modules/bot_api/card_template_catalog.go
+++ b/modules/bot_api/card_template_catalog.go
@@ -244,7 +244,7 @@ func (c *botCardTemplateCatalog) RenderPayload(
 		return nil, errBotTemplateCatalogUnavailable
 	}
 	return c.renderPayload(ctx, "bot-api-compat", cardtmpl.CatalogPurposeNewSend,
-		inbound, env, c.sendAllowed, "not Bot-callable for new send")
+		inbound, env, c.sendAllowed, "not Bot-callable for new send", false)
 }
 
 func (c *botCardTemplateCatalog) RenderPayloadForPrincipal(
@@ -257,7 +257,7 @@ func (c *botCardTemplateCatalog) RenderPayloadForPrincipal(
 		return nil, errBotTemplateCatalogUnavailable
 	}
 	return c.renderPayload(ctx, botID, cardtmpl.CatalogPurposeNewSend,
-		inbound, env, c.sendAllowed, "not Bot-callable for new send")
+		inbound, env, c.sendAllowed, "not Bot-callable for new send", true)
 }
 
 func (c *botCardTemplateCatalog) RenderEditPayload(
@@ -269,7 +269,7 @@ func (c *botCardTemplateCatalog) RenderEditPayload(
 		return nil, errBotTemplateCatalogUnavailable
 	}
 	return c.renderPayload(ctx, "bot-api-compat", cardtmpl.CatalogPurposeHistoricalEdit,
-		inbound, env, c.editAllowed, "not edit-compatible")
+		inbound, env, c.editAllowed, "not edit-compatible", false)
 }
 
 func (c *botCardTemplateCatalog) RenderEditPayloadForPrincipal(
@@ -282,7 +282,7 @@ func (c *botCardTemplateCatalog) RenderEditPayloadForPrincipal(
 		return nil, errBotTemplateCatalogUnavailable
 	}
 	return c.renderPayload(ctx, botID, cardtmpl.CatalogPurposeHistoricalEdit,
-		inbound, env, c.editAllowed, "not edit-compatible")
+		inbound, env, c.editAllowed, "not edit-compatible", true)
 }
 
 func (c *botCardTemplateCatalog) renderPayload(
@@ -293,6 +293,7 @@ func (c *botCardTemplateCatalog) renderPayload(
 	env cardtmpl.BuildEnv,
 	allowed map[botTemplateRef]struct{},
 	denialReason string,
+	authorProvenance bool,
 ) (map[string]any, error) {
 	if c == nil || c.catalog == nil {
 		return nil, errBotTemplateCatalogUnavailable
@@ -344,11 +345,21 @@ func (c *botCardTemplateCatalog) renderPayload(
 		}
 		return nil, fmt.Errorf("bot template render %s@%s: %w", ref.ID, ref.Version, err)
 	}
-	// Retain only the canonical ref as server-authored provenance. Raw Model B
-	// ingress rejects card+template_ref, so edit can distinguish a Registry frame
-	// from a caller-authored card that merely forged metadata.octo.template.
+	// Retain the canonical ref plus the authenticated-principal provenance as
+	// server-authored markers (PR-C D3). Raw Model B ingress rejects both keys,
+	// so edit/action ingress can trust a marked frame came from this boundary.
+	// env.SpaceID is server-resolved (send: resolveBotActiveSpaceID; edit: the
+	// Snapshot-pinned envelope Space) — callers never supply it.
 	rendered["template_ref"] = map[string]any{
 		"id": string(ref.ID), "version": ref.Version,
+	}
+	if authorProvenance {
+		rendered[cardmsg.CatalogProvenanceKey] = cardmsg.CatalogProvenance{
+			Version:       cardmsg.CatalogProvenanceVersion,
+			PrincipalType: cardmsg.CatalogPrincipalWireBot,
+			PrincipalID:   botID,
+			SpaceID:       env.SpaceID,
+		}.MarshalMap()
 	}
 	for _, key := range []string{"mention", "reply"} {
 		if value, ok := inbound[key]; ok {
@@ -440,7 +451,7 @@ func parseBotTemplateRef(value any) (botTemplateRef, error) {
 	return botTemplateRef{ID: cardtmpl.ID(id), Version: version}, nil
 }
 
-func requireEffectiveCardTemplate(envelope []byte, want botTemplateRef) error {
+func requireEffectiveCardTemplate(envelope []byte, want botTemplateRef, editorBotID string) error {
 	decoder := json.NewDecoder(bytes.NewReader(envelope))
 	decoder.UseNumber()
 	var payload map[string]any
@@ -459,6 +470,24 @@ func requireEffectiveCardTemplate(envelope []byte, want botTemplateRef) error {
 	version, _ := template["version"].(string)
 	if id != string(want.ID) || version != want.Version {
 		return fmt.Errorf("%w: effective template mismatch", errBotTemplateRequestInvalid)
+	}
+	// PR-C D3：stored catalog_provenance 存在时必须是本 bot 署名的 canonical
+	// 标记，且声明的 Space 与信封自身一致 —— internal producer 的帧、别的 bot
+	// 的帧或被篡改的标记都不能经 Bot 模板编辑路径改写。缺失即 pre-PR-C 帧，
+	// 走既有兼容路径（Snapshot ownership 已保证 FromUID == 编辑 bot）。
+	markers, err := cardmsg.CatalogFrameMarkers(envelope)
+	if err != nil {
+		return fmt.Errorf("%w: effective catalog markers: %v", errBotTemplateRequestInvalid, err)
+	}
+	if markers.HasProvenance {
+		if markers.Provenance.PrincipalType != cardmsg.CatalogPrincipalWireBot ||
+			markers.Provenance.PrincipalID != editorBotID {
+			return fmt.Errorf("%w: stored provenance does not match editing bot", errBotTemplateRequestInvalid)
+		}
+		envelopeSpace, _ := payload["space_id"].(string)
+		if markers.Provenance.SpaceID != "" && markers.Provenance.SpaceID != envelopeSpace {
+			return fmt.Errorf("%w: stored provenance space mismatch", errBotTemplateRequestInvalid)
+		}
 	}
 	return nil
 }

--- a/modules/bot_api/card_template_catalog.go
+++ b/modules/bot_api/card_template_catalog.go
@@ -323,17 +323,21 @@ func (c *botCardTemplateCatalog) RenderEditPayload(
 
 func (c *botCardTemplateCatalog) RenderEditPayloadForPrincipal(
 	ctx context.Context,
-	botID string,
+	principal botCatalogPrincipal,
 	inbound map[string]any,
 	env cardtmpl.BuildEnv,
 ) (map[string]any, error) {
-	if c == nil || strings.TrimSpace(botID) == "" {
+	if c == nil || strings.TrimSpace(principal.BotID) == "" {
 		return nil, errBotTemplateCatalogUnavailable
 	}
-	return c.renderPayload(ctx, botID, cardtmpl.CatalogPurposeHistoricalEdit, inbound, env,
-		// Historical edit is pinned to a stored frame whose Space the envelope
-		// already carries, so env.SpaceID is the authoritative value here.
-		c.staticRefResolver(c.editAllowed, "not edit-compatible"), true, env.SpaceID)
+	// The re-stamped marker has to carry the same Space the original send
+	// recorded, so it is composed the same way: the target-authoritative Space
+	// when one could be resolved, and the envelope's own Space otherwise.
+	// Using env.SpaceID unconditionally would erase a group card's Space on its
+	// first edit, because a group envelope has no top-level space_id.
+	return c.renderPayload(ctx, principal.BotID, cardtmpl.CatalogPurposeHistoricalEdit, inbound, env,
+		c.staticRefResolver(c.editAllowed, "not edit-compatible"), true,
+		provenanceSpaceID(principal, env))
 }
 
 func (c *botCardTemplateCatalog) renderPayload(
@@ -522,7 +526,21 @@ func parseBotTemplateRef(value any) (botTemplateRef, error) {
 	return botTemplateRef{ID: cardtmpl.ID(id), Version: version}, nil
 }
 
-func requireEffectiveCardTemplate(envelope []byte, want botTemplateRef, editorBotID string) error {
+// requireEffectiveCardTemplate proves the stored frame is the one this edit is
+// entitled to rewrite.
+//
+// authorizedSpaceID is the Space this edit resolved for the target, composed
+// exactly as the send composed the marker it is being compared against. An
+// earlier revision compared the marker to the envelope's top-level `space_id`,
+// which only DM sends ever write — so once group sends started recording their
+// target Space, every group and thread card became permanently uneditable.
+// Comparing two values produced by the same rule means they agree whenever
+// nothing moved, and disagree exactly when the frame did.
+func requireEffectiveCardTemplate(
+	envelope []byte,
+	want botTemplateRef,
+	editorBotID, authorizedSpaceID string,
+) error {
 	decoder := json.NewDecoder(bytes.NewReader(envelope))
 	decoder.UseNumber()
 	var payload map[string]any
@@ -555,8 +573,11 @@ func requireEffectiveCardTemplate(envelope []byte, want botTemplateRef, editorBo
 			markers.Provenance.PrincipalID != editorBotID {
 			return fmt.Errorf("%w: stored provenance does not match editing bot", errBotTemplateRequestInvalid)
 		}
-		envelopeSpace, _ := payload["space_id"].(string)
-		if markers.Provenance.SpaceID != "" && markers.Provenance.SpaceID != envelopeSpace {
+		expectedSpace := strings.TrimSpace(authorizedSpaceID)
+		if expectedSpace == "" {
+			expectedSpace, _ = payload["space_id"].(string)
+		}
+		if markers.Provenance.SpaceID != "" && markers.Provenance.SpaceID != expectedSpace {
 			return fmt.Errorf("%w: stored provenance space mismatch", errBotTemplateRequestInvalid)
 		}
 	}

--- a/modules/bot_api/card_template_catalog.go
+++ b/modules/bot_api/card_template_catalog.go
@@ -526,20 +526,59 @@ func parseBotTemplateRef(value any) (botTemplateRef, error) {
 	return botTemplateRef{ID: cardtmpl.ID(id), Version: version}, nil
 }
 
+// editSpaceCheck is what this edit knows about the Space it is authorized
+// against. Three states, deliberately distinct — collapsing them is what made
+// the Space comparison a source of permanent failures twice over.
+//
+//   - verifiable, with a Space: compare the stored marker against it.
+//   - not verifiable: the deployment never establishes a Space at all (the
+//     dynamic catalog is dark), so there is nothing to compare with. The edit
+//     is still bound to its author by the canonical bot marker, the
+//     PrincipalID == editor check and Snapshot ownership.
+//   - unavailable: a Space should have been resolvable and was not. The edit
+//     cannot be verified now but may well succeed later, so it must not be
+//     reported as a permanent client error.
+type editSpaceCheck struct {
+	spaceID     string
+	verifiable  bool
+	unavailable bool
+}
+
+// editProvenanceSpaceCheck maps the send-side principal onto those three
+// states. dynamicEnabled is read at the call site rather than inferred from the
+// principal because botSendCatalogPrincipal returns the same zero principal for
+// "the gate is closed" and "the group row would not load", and only the second
+// of those is an outage.
+//
+// A DM whose peer turned out to be outside the Bot's Space also lands in
+// `unavailable`. That is a deny wearing an outage's clothes, and the imprecision
+// is deliberate: over-reporting an outage costs a retry, while under-reporting
+// one costs a permanently uneditable card.
+func editProvenanceSpaceCheck(dynamicEnabled bool, principal botCatalogPrincipal) editSpaceCheck {
+	if !dynamicEnabled {
+		return editSpaceCheck{}
+	}
+	if !principal.SpaceResolved {
+		return editSpaceCheck{unavailable: true}
+	}
+	return editSpaceCheck{spaceID: principal.SpaceID, verifiable: true}
+}
+
 // requireEffectiveCardTemplate proves the stored frame is the one this edit is
 // entitled to rewrite.
 //
-// authorizedSpaceID is the Space this edit resolved for the target, composed
-// exactly as the send composed the marker it is being compared against. An
-// earlier revision compared the marker to the envelope's top-level `space_id`,
-// which only DM sends ever write — so once group sends started recording their
-// target Space, every group and thread card became permanently uneditable.
-// Comparing two values produced by the same rule means they agree whenever
-// nothing moved, and disagree exactly when the frame did.
+// space is the Space this edit resolved for the target, composed exactly as the
+// send composed the marker it is being compared against. An earlier revision
+// compared the marker to the envelope's top-level `space_id`, which only DM
+// sends ever write — so once group sends started recording their target Space,
+// every group and thread card became permanently uneditable. Comparing two
+// values produced by the same rule means they agree whenever nothing moved, and
+// disagree exactly when the frame did.
 func requireEffectiveCardTemplate(
 	envelope []byte,
 	want botTemplateRef,
-	editorBotID, authorizedSpaceID string,
+	editorBotID string,
+	space editSpaceCheck,
 ) error {
 	decoder := json.NewDecoder(bytes.NewReader(envelope))
 	decoder.UseNumber()
@@ -573,12 +612,22 @@ func requireEffectiveCardTemplate(
 			markers.Provenance.PrincipalID != editorBotID {
 			return fmt.Errorf("%w: stored provenance does not match editing bot", errBotTemplateRequestInvalid)
 		}
-		expectedSpace := strings.TrimSpace(authorizedSpaceID)
-		if expectedSpace == "" {
-			expectedSpace, _ = payload["space_id"].(string)
-		}
-		if markers.Provenance.SpaceID != "" && markers.Provenance.SpaceID != expectedSpace {
-			return fmt.Errorf("%w: stored provenance space mismatch", errBotTemplateRequestInvalid)
+		if markers.Provenance.SpaceID != "" {
+			if space.unavailable {
+				return fmt.Errorf("%w: edit space could not be resolved, stored provenance unverifiable",
+					errBotTemplateRuntimeUnavailable)
+			}
+			if space.verifiable {
+				expectedSpace := strings.TrimSpace(space.spaceID)
+				if expectedSpace == "" {
+					// A DM resolved to no Space still has the envelope's own
+					// value, which is what pre-PR-C sends stamped.
+					expectedSpace, _ = payload["space_id"].(string)
+				}
+				if markers.Provenance.SpaceID != expectedSpace {
+					return fmt.Errorf("%w: stored provenance space mismatch", errBotTemplateRequestInvalid)
+				}
+			}
 		}
 	}
 	return nil

--- a/modules/bot_api/card_template_catalog.go
+++ b/modules/bot_api/card_template_catalog.go
@@ -445,14 +445,24 @@ func (c *botCardTemplateCatalog) renderPayload(
 		"id": string(ref.ID), "version": ref.Version,
 	}
 	if authorProvenance {
-		rendered[cardmsg.CatalogProvenanceKey] = cardmsg.CatalogProvenance{
+		provenance := cardmsg.CatalogProvenance{
 			Version:       cardmsg.CatalogProvenanceVersion,
 			PrincipalType: cardmsg.CatalogPrincipalWireBot,
 			// The same access the render authorized under, so the marker cannot
 			// name a principal the render did not actually decide for.
 			PrincipalID: access.Principal.ID,
 			SpaceID:     provenanceSpaceID,
-		}.MarshalMap()
+		}
+		// Same reason as the internal-producer boundary in
+		// internal/carddispatch: an authoring site must not be able to write a
+		// marker its readers reject, and no later stage re-validates. These
+		// inputs are DB-derived rather than caller-supplied, so no failure is
+		// constructible here today — which is exactly why it should be a
+		// checked invariant instead of a property of the current callers.
+		if err := provenance.Validate(); err != nil {
+			return nil, fmt.Errorf("%w: %v", errBotTemplateRequestInvalid, err)
+		}
+		rendered[cardmsg.CatalogProvenanceKey] = provenance.MarshalMap()
 	}
 	for _, key := range []string{"mention", "reply"} {
 		if value, ok := inbound[key]; ok {

--- a/modules/bot_api/card_template_catalog.go
+++ b/modules/bot_api/card_template_catalog.go
@@ -347,7 +347,7 @@ func (c *botCardTemplateCatalog) RenderEditPayloadForPrincipal(
 		space = provenanceSpaceID(principal, env)
 	}
 	return c.renderPayload(ctx, principal.BotID, cardtmpl.CatalogPurposeHistoricalEdit, inbound, env,
-		c.staticRefResolver(c.editAllowed, "not edit-compatible"), true, space)
+		c.editRefResolver(principal), true, space)
 }
 
 // storedProvenanceSpaceID reads the Space a frame's own marker records, or ""
@@ -461,6 +461,75 @@ func (c *botCardTemplateCatalog) requireEditableRef(value any) (botTemplateRef, 
 		return botTemplateRef{}, errBotTemplateCatalogUnavailable
 	}
 	return c.requireRef(value, c.editAllowed, "template is not edit-compatible")
+}
+
+// resolveEditRef authorizes one historical-edit ref, static or dynamic.
+//
+// PR-C review: `requireEditableRef` alone consults only `editAllowed`, a
+// boot-time map of code-reviewed static exacts. A version published at runtime
+// can never be in that map, so a Bot that had just been granted `send` on a
+// dynamic template — and had used it — was refused every edit of the card it
+// had itself sent, before stored provenance or the runtime authorizer were ever
+// consulted. `send` reached the dynamic authorizer and `edit` never did, which
+// left the D2 `send|edit` grant half-wired.
+//
+// Two rules make this different from the send path:
+//
+//   - It is pinned. The query carries the stored exact version, so it never
+//     follows the activation pointer; following it would rewrite an existing
+//     card across versions, which is exactly what D6 forbids.
+//   - The static allowlist answers first, without any DB read. That is what
+//     keeps a gates-off deployment on precisely its pre-PR-C behaviour: an
+//     unresolved principal (which is what a dark catalog produces) withholds
+//     only the dynamic overlay.
+func (c *botCardTemplateCatalog) resolveEditRef(
+	ctx context.Context,
+	principal botCatalogPrincipal,
+	value any,
+) (botTemplateRef, error) {
+	if c == nil || c.catalog == nil {
+		return botTemplateRef{}, errBotTemplateCatalogUnavailable
+	}
+	ref, err := parseBotTemplateRef(value)
+	if err != nil {
+		return botTemplateRef{}, err
+	}
+	if _, ok := c.editAllowed[ref]; ok {
+		return ref, nil
+	}
+	notEditable := fmt.Errorf("%w: template is not edit-compatible", errBotTemplateRequestInvalid)
+	source := c.authorizationSource()
+	if source == nil || !principal.SpaceResolved {
+		return botTemplateRef{}, notEditable
+	}
+	auth, err := source.LoadAuthorization(ctx, cardtmpl.RuntimeAuthorizationQuery{
+		ID: ref.ID, Version: ref.Version, Principal: principal.catalogPrincipal(),
+	})
+	if err != nil {
+		// One indistinguishable refusal for "no such version" and "not granted",
+		// matching the send path: a producer must not be able to use edit
+		// rejections to enumerate which versions exist.
+		if errors.Is(err, cardtmpl.ErrTemplateUnknown) ||
+			errors.Is(err, cardtmpl.ErrRuntimeCatalogDisabled) {
+			return botTemplateRef{}, notEditable
+		}
+		return botTemplateRef{}, errors.Join(errBotTemplateRuntimeUnavailable, err)
+	}
+	if auth.Artifact.Blocked || !auth.Grant.Allows(cardtmpl.CatalogPurposeHistoricalEdit) {
+		return botTemplateRef{}, notEditable
+	}
+	return ref, nil
+}
+
+// editRefResolver adapts resolveEditRef to the render path's resolver
+// signature, so the pre-gate and the render agree by construction rather than
+// by two allowlists that happen to match.
+func (c *botCardTemplateCatalog) editRefResolver(
+	principal botCatalogPrincipal,
+) func(context.Context, any) (botTemplateRef, error) {
+	return func(ctx context.Context, value any) (botTemplateRef, error) {
+		return c.resolveEditRef(ctx, principal, value)
+	}
 }
 
 // staticRefResolver adapts a boot-time allowlist to the resolver signature.

--- a/modules/bot_api/card_template_catalog.go
+++ b/modules/bot_api/card_template_catalog.go
@@ -286,7 +286,8 @@ func (c *botCardTemplateCatalog) RenderPayload(
 	if c == nil {
 		return nil, errBotTemplateCatalogUnavailable
 	}
-	return c.renderPayload(ctx, "bot-api-compat", cardtmpl.CatalogPurposeNewSend, inbound, env,
+	return c.renderPayload(ctx,
+		botCatalogAccess(cardtmpl.CatalogPurposeNewSend, "bot-api-compat", env.SpaceID), inbound, env,
 		c.staticRefResolver(c.sendAllowed, "not Bot-callable for new send"), false, "")
 }
 
@@ -303,7 +304,7 @@ func (c *botCardTemplateCatalog) RenderPayloadForPrincipal(
 	if c == nil || strings.TrimSpace(principal.BotID) == "" {
 		return nil, errBotTemplateCatalogUnavailable
 	}
-	return c.renderPayload(ctx, principal.BotID, cardtmpl.CatalogPurposeNewSend, inbound, env,
+	return c.renderPayload(ctx, principal.access(cardtmpl.CatalogPurposeNewSend), inbound, env,
 		func(ctx context.Context, value any) (botTemplateRef, error) {
 			return c.requireSendableRef(ctx, principal, value)
 		}, true, provenanceSpaceID(principal, env))
@@ -317,7 +318,8 @@ func (c *botCardTemplateCatalog) RenderEditPayload(
 	if c == nil {
 		return nil, errBotTemplateCatalogUnavailable
 	}
-	return c.renderPayload(ctx, "bot-api-compat", cardtmpl.CatalogPurposeHistoricalEdit, inbound, env,
+	return c.renderPayload(ctx,
+		botCatalogAccess(cardtmpl.CatalogPurposeHistoricalEdit, "bot-api-compat", env.SpaceID), inbound, env,
 		c.staticRefResolver(c.editAllowed, "not edit-compatible"), false, "")
 }
 
@@ -346,7 +348,7 @@ func (c *botCardTemplateCatalog) RenderEditPayloadForPrincipal(
 	if space == "" {
 		space = provenanceSpaceID(principal, env)
 	}
-	return c.renderPayload(ctx, principal.BotID, cardtmpl.CatalogPurposeHistoricalEdit, inbound, env,
+	return c.renderPayload(ctx, principal.access(cardtmpl.CatalogPurposeHistoricalEdit), inbound, env,
 		c.editRefResolver(principal), true, space)
 }
 
@@ -364,8 +366,13 @@ func storedProvenanceSpaceID(envelope []byte) string {
 
 func (c *botCardTemplateCatalog) renderPayload(
 	ctx context.Context,
-	botID string,
-	purpose cardtmpl.CatalogPurpose,
+	// access is the *authorized* identity, handed down from whoever resolved
+	// the ref. It is a parameter rather than something rebuilt here because
+	// cardtmpl.Render re-resolves the grant from it, and a render that composed
+	// its own Space disagreed with the gate for every group and thread target:
+	// the gate read the target's Space, the render read env.SpaceID, which is
+	// DM-only. An exact-Space grant passed one and was refused by the other.
+	access cardtmpl.CatalogAccess,
 	inbound map[string]any,
 	env cardtmpl.BuildEnv,
 	resolveRef func(context.Context, any) (botTemplateRef, error),
@@ -420,7 +427,7 @@ func (c *botCardTemplateCatalog) renderPayload(
 		return nil, fmt.Errorf("%w: marshal data: %v", errBotTemplateRequestInvalid, err)
 	}
 	rendered, err := c.catalog.Render(ctx, cardtmpl.CatalogRenderRequest{
-		Access: botCatalogAccess(purpose, botID, env.SpaceID),
+		Access: access,
 		ID:     ref.ID, Version: ref.Version, State: cardtmpl.State(state), Fields: rawData, Env: env,
 	})
 	if err != nil {
@@ -441,8 +448,10 @@ func (c *botCardTemplateCatalog) renderPayload(
 		rendered[cardmsg.CatalogProvenanceKey] = cardmsg.CatalogProvenance{
 			Version:       cardmsg.CatalogProvenanceVersion,
 			PrincipalType: cardmsg.CatalogPrincipalWireBot,
-			PrincipalID:   botID,
-			SpaceID:       provenanceSpaceID,
+			// The same access the render authorized under, so the marker cannot
+			// name a principal the render did not actually decide for.
+			PrincipalID: access.Principal.ID,
+			SpaceID:     provenanceSpaceID,
 		}.MarshalMap()
 	}
 	for _, key := range []string{"mention", "reply"} {
@@ -499,7 +508,7 @@ func (c *botCardTemplateCatalog) resolveEditRef(
 	}
 	notEditable := fmt.Errorf("%w: template is not edit-compatible", errBotTemplateRequestInvalid)
 	source := c.authorizationSource()
-	if source == nil || !principal.SpaceResolved {
+	if source == nil || !principal.grantReadable() {
 		return botTemplateRef{}, notEditable
 	}
 	auth, err := source.LoadAuthorization(ctx, cardtmpl.RuntimeAuthorizationQuery{
@@ -649,9 +658,12 @@ func editProvenanceSpaceCheck(dynamicEnabled bool, principal botCatalogPrincipal
 	if !dynamicEnabled {
 		return editSpaceCheck{}
 	}
-	if !principal.SpaceResolved {
+	if principal.Space == botSpaceUnavailable {
 		return editSpaceCheck{unavailable: true}
 	}
+	// botSpaceGlobalOnly lands here too, as `verifiable` with an empty Space:
+	// "we established this target has no Space" is a determination the stored
+	// marker can legitimately be compared against, not an outage.
 	return editSpaceCheck{spaceID: principal.SpaceID, verifiable: true}
 }
 
@@ -741,7 +753,7 @@ func requireEffectiveCardTemplate(
 // env.SpaceID remains the fallback so a DM keeps stamping exactly what it
 // stamped before PR-C's target-authoritative resolution existed.
 func provenanceSpaceID(principal botCatalogPrincipal, env cardtmpl.BuildEnv) string {
-	if principal.SpaceResolved && principal.SpaceID != "" {
+	if principal.Space == botSpaceScoped && principal.SpaceID != "" {
 		return principal.SpaceID
 	}
 	return env.SpaceID

--- a/modules/bot_api/card_template_catalog.go
+++ b/modules/bot_api/card_template_catalog.go
@@ -59,6 +59,17 @@ type botCardTemplateCatalog struct {
 	sendAllowed map[botTemplateRef]struct{}
 	editAllowed map[botTemplateRef]struct{}
 	capability  botTemplatingCapability
+	// staticSendByID is the same policy as sendAllowed, keyed by template ID.
+	// PR-C D6 requires at most one advertised send version per ID, so this is a
+	// total map rather than a convenience index — the constructor rejects a
+	// policy that would make it lossy.
+	staticSendByID map[cardtmpl.ID]botTemplateRef
+	// staticSendIDs preserves a deterministic order for the manifest.
+	staticSendIDs []cardtmpl.ID
+	// authorization overrides the process-wide resolver in tests. Production
+	// leaves it nil and reads cardtmpl.DefaultAuthorizationSource() per request,
+	// so a catalog built before the composition root still picks the resolver up.
+	authorization cardtmpl.RuntimeAuthorizationSource
 }
 
 func defaultBotTemplateRefs() []botTemplateRef {
@@ -101,9 +112,10 @@ func newBotCardTemplateCatalogWithPolicy(
 		return nil, fmt.Errorf("bot template catalog: empty edit-compatible allowlist")
 	}
 	catalog := &botCardTemplateCatalog{
-		catalog:     runtimeCatalog,
-		sendAllowed: make(map[botTemplateRef]struct{}, len(policy.AdvertisedSend)),
-		editAllowed: make(map[botTemplateRef]struct{}, len(policy.EditCompatible)),
+		catalog:        runtimeCatalog,
+		sendAllowed:    make(map[botTemplateRef]struct{}, len(policy.AdvertisedSend)),
+		editAllowed:    make(map[botTemplateRef]struct{}, len(policy.EditCompatible)),
+		staticSendByID: make(map[cardtmpl.ID]botTemplateRef, len(policy.AdvertisedSend)),
 		capability: botTemplatingCapability{
 			Supported: true,
 			Wire:      botTemplateWireV1,
@@ -114,8 +126,15 @@ func newBotCardTemplateCatalogWithPolicy(
 		if strings.TrimSpace(string(ref.ID)) == "" || strings.TrimSpace(ref.Version) == "" {
 			return nil, fmt.Errorf("bot template catalog: id and explicit version are required")
 		}
-		if _, duplicate := catalog.sendAllowed[ref]; duplicate {
-			return nil, fmt.Errorf("bot template catalog: duplicate advertised/send %s@%s", ref.ID, ref.Version)
+		// PR-C D6: the guard is per template ID, not per exact ref. Two
+		// versions of one ID are not a harmless duplicate — the dynamic
+		// activation pointer resolves to a single version per ID, so a policy
+		// advertising two of them has no well-defined answer to "which version
+		// does the pointer shadow", and the manifest and the send path would be
+		// free to pick differently.
+		if existing, duplicate := catalog.staticSendByID[ref.ID]; duplicate {
+			return nil, fmt.Errorf("bot template catalog: %s is advertised at both %s and %s; "+
+				"exactly one send version per template ID", ref.ID, existing.Version, ref.Version)
 		}
 		meta, err := lookupBotTemplateMeta(runtimeCatalog, cardtmpl.CatalogExactRequest{
 			Access: botCatalogAccess(cardtmpl.CatalogPurposeNewSend, "bot-api-manifest", ""),
@@ -128,55 +147,13 @@ func newBotCardTemplateCatalogWithPolicy(
 			return nil, fmt.Errorf("bot template catalog: incomplete metadata for %s@%s", ref.ID, ref.Version)
 		}
 
-		capability := botTemplateCapability{
-			ID: string(meta.ID), Version: meta.Version,
-			Views: make([]botTemplateViewCapability, 0, len(meta.Views)),
+		capability, err := templateCapabilityFromMeta(meta)
+		if err != nil {
+			return nil, err
 		}
-		for view, spec := range meta.Views {
-			if strings.TrimSpace(string(view)) == "" || len(spec.States) == 0 {
-				return nil, fmt.Errorf("bot template catalog: %s@%s has empty view/state metadata", ref.ID, ref.Version)
-			}
-			viewCapability := botTemplateViewCapability{
-				Name:          string(view),
-				WireProfile:   spec.WireProfile,
-				States:        make([]string, 0, len(spec.States)),
-				SubmitActions: make([]string, 0),
-			}
-			for _, state := range spec.States {
-				if strings.TrimSpace(string(state)) == "" {
-					return nil, fmt.Errorf("bot template catalog: %s@%s view %s has empty state", ref.ID, ref.Version, view)
-				}
-				viewCapability.States = append(viewCapability.States, string(state))
-			}
-			sort.Strings(viewCapability.States)
-
-			if spec.WireProfile == cardmsg.ProfileV2 {
-				report, ok := meta.Interaction(view)
-				if !ok {
-					return nil, fmt.Errorf("bot template catalog: %s@%s view %s missing interaction report", ref.ID, ref.Version, view)
-				}
-				seenActions := make(map[string]struct{})
-				for _, action := range report.Actions {
-					if action.Type != "Action.Submit" {
-						continue
-					}
-					if strings.TrimSpace(action.ID) == "" {
-						return nil, fmt.Errorf("bot template catalog: %s@%s view %s has empty Submit id", ref.ID, ref.Version, view)
-					}
-					if _, duplicate := seenActions[action.ID]; duplicate {
-						return nil, fmt.Errorf("bot template catalog: %s@%s view %s has duplicate Submit id %q", ref.ID, ref.Version, view, action.ID)
-					}
-					seenActions[action.ID] = struct{}{}
-					viewCapability.SubmitActions = append(viewCapability.SubmitActions, action.ID)
-				}
-				sort.Strings(viewCapability.SubmitActions)
-			}
-			capability.Views = append(capability.Views, viewCapability)
-		}
-		sort.Slice(capability.Views, func(i, j int) bool {
-			return capability.Views[i].Name < capability.Views[j].Name
-		})
 		catalog.sendAllowed[ref] = struct{}{}
+		catalog.staticSendByID[ref.ID] = ref
+		catalog.staticSendIDs = append(catalog.staticSendIDs, ref.ID)
 		catalog.capability.Templates = append(catalog.capability.Templates, capability)
 	}
 	for _, ref := range policy.EditCompatible {
@@ -210,7 +187,73 @@ func newBotCardTemplateCatalogWithPolicy(
 		}
 		return left.Version < right.Version
 	})
+	sort.Slice(catalog.staticSendIDs, func(i, j int) bool {
+		return catalog.staticSendIDs[i] < catalog.staticSendIDs[j]
+	})
 	return catalog, nil
+}
+
+// templateCapabilityFromMeta projects one template's metadata into the wire
+// capability shape. The constructor and the request-scoped manifest share it so
+// that a dynamic template is described exactly as a static one would be — a
+// producer must not be able to tell the two apart from the manifest, since the
+// whole point of the catalog is that the source is an operator concern.
+func templateCapabilityFromMeta(meta cardtmpl.TemplateMeta) (botTemplateCapability, error) {
+	capability := botTemplateCapability{
+		ID: string(meta.ID), Version: meta.Version,
+		Views: make([]botTemplateViewCapability, 0, len(meta.Views)),
+	}
+	for view, spec := range meta.Views {
+		if strings.TrimSpace(string(view)) == "" || len(spec.States) == 0 {
+			return botTemplateCapability{}, fmt.Errorf(
+				"bot template catalog: %s@%s has empty view/state metadata", meta.ID, meta.Version)
+		}
+		viewCapability := botTemplateViewCapability{
+			Name:          string(view),
+			WireProfile:   spec.WireProfile,
+			States:        make([]string, 0, len(spec.States)),
+			SubmitActions: make([]string, 0),
+		}
+		for _, state := range spec.States {
+			if strings.TrimSpace(string(state)) == "" {
+				return botTemplateCapability{}, fmt.Errorf(
+					"bot template catalog: %s@%s view %s has empty state", meta.ID, meta.Version, view)
+			}
+			viewCapability.States = append(viewCapability.States, string(state))
+		}
+		sort.Strings(viewCapability.States)
+
+		if spec.WireProfile == cardmsg.ProfileV2 {
+			report, ok := meta.Interaction(view)
+			if !ok {
+				return botTemplateCapability{}, fmt.Errorf(
+					"bot template catalog: %s@%s view %s missing interaction report", meta.ID, meta.Version, view)
+			}
+			seenActions := make(map[string]struct{})
+			for _, action := range report.Actions {
+				if action.Type != "Action.Submit" {
+					continue
+				}
+				if strings.TrimSpace(action.ID) == "" {
+					return botTemplateCapability{}, fmt.Errorf(
+						"bot template catalog: %s@%s view %s has empty Submit id", meta.ID, meta.Version, view)
+				}
+				if _, duplicate := seenActions[action.ID]; duplicate {
+					return botTemplateCapability{}, fmt.Errorf(
+						"bot template catalog: %s@%s view %s has duplicate Submit id %q",
+						meta.ID, meta.Version, view, action.ID)
+				}
+				seenActions[action.ID] = struct{}{}
+				viewCapability.SubmitActions = append(viewCapability.SubmitActions, action.ID)
+			}
+			sort.Strings(viewCapability.SubmitActions)
+		}
+		capability.Views = append(capability.Views, viewCapability)
+	}
+	sort.Slice(capability.Views, func(i, j int) bool {
+		return capability.Views[i].Name < capability.Views[j].Name
+	})
+	return capability, nil
 }
 
 func (c *botCardTemplateCatalog) Capability() botTemplatingCapability {
@@ -243,21 +286,27 @@ func (c *botCardTemplateCatalog) RenderPayload(
 	if c == nil {
 		return nil, errBotTemplateCatalogUnavailable
 	}
-	return c.renderPayload(ctx, "bot-api-compat", cardtmpl.CatalogPurposeNewSend,
-		inbound, env, c.sendAllowed, "not Bot-callable for new send", false)
+	return c.renderPayload(ctx, "bot-api-compat", cardtmpl.CatalogPurposeNewSend, inbound, env,
+		c.staticRefResolver(c.sendAllowed, "not Bot-callable for new send"), false)
 }
 
+// RenderPayloadForPrincipal is the authenticated new-send path. Unlike the
+// compat variant above it re-resolves the ref against the runtime catalog for
+// this exact principal, so an activation, block or revoke takes effect on the
+// very next send rather than at the next process restart.
 func (c *botCardTemplateCatalog) RenderPayloadForPrincipal(
 	ctx context.Context,
-	botID string,
+	principal botCatalogPrincipal,
 	inbound map[string]any,
 	env cardtmpl.BuildEnv,
 ) (map[string]any, error) {
-	if c == nil || strings.TrimSpace(botID) == "" {
+	if c == nil || strings.TrimSpace(principal.BotID) == "" {
 		return nil, errBotTemplateCatalogUnavailable
 	}
-	return c.renderPayload(ctx, botID, cardtmpl.CatalogPurposeNewSend,
-		inbound, env, c.sendAllowed, "not Bot-callable for new send", true)
+	return c.renderPayload(ctx, principal.BotID, cardtmpl.CatalogPurposeNewSend, inbound, env,
+		func(ctx context.Context, value any) (botTemplateRef, error) {
+			return c.requireSendableRef(ctx, principal, value)
+		}, true)
 }
 
 func (c *botCardTemplateCatalog) RenderEditPayload(
@@ -268,8 +317,8 @@ func (c *botCardTemplateCatalog) RenderEditPayload(
 	if c == nil {
 		return nil, errBotTemplateCatalogUnavailable
 	}
-	return c.renderPayload(ctx, "bot-api-compat", cardtmpl.CatalogPurposeHistoricalEdit,
-		inbound, env, c.editAllowed, "not edit-compatible", false)
+	return c.renderPayload(ctx, "bot-api-compat", cardtmpl.CatalogPurposeHistoricalEdit, inbound, env,
+		c.staticRefResolver(c.editAllowed, "not edit-compatible"), false)
 }
 
 func (c *botCardTemplateCatalog) RenderEditPayloadForPrincipal(
@@ -281,8 +330,8 @@ func (c *botCardTemplateCatalog) RenderEditPayloadForPrincipal(
 	if c == nil || strings.TrimSpace(botID) == "" {
 		return nil, errBotTemplateCatalogUnavailable
 	}
-	return c.renderPayload(ctx, botID, cardtmpl.CatalogPurposeHistoricalEdit,
-		inbound, env, c.editAllowed, "not edit-compatible", true)
+	return c.renderPayload(ctx, botID, cardtmpl.CatalogPurposeHistoricalEdit, inbound, env,
+		c.staticRefResolver(c.editAllowed, "not edit-compatible"), true)
 }
 
 func (c *botCardTemplateCatalog) renderPayload(
@@ -291,8 +340,7 @@ func (c *botCardTemplateCatalog) renderPayload(
 	purpose cardtmpl.CatalogPurpose,
 	inbound map[string]any,
 	env cardtmpl.BuildEnv,
-	allowed map[botTemplateRef]struct{},
-	denialReason string,
+	resolveRef func(context.Context, any) (botTemplateRef, error),
 	authorProvenance bool,
 ) (map[string]any, error) {
 	if c == nil || c.catalog == nil {
@@ -313,7 +361,7 @@ func (c *botCardTemplateCatalog) renderPayload(
 	if _, hasCard := inbound["card"]; hasCard {
 		return nil, fmt.Errorf("%w: raw card and template_ref are mutually exclusive", errBotTemplateRequestInvalid)
 	}
-	ref, err := c.requireRef(inbound["template_ref"], allowed, denialReason)
+	ref, err := resolveRef(ctx, inbound["template_ref"])
 	if err != nil {
 		return nil, err
 	}
@@ -377,6 +425,19 @@ func (c *botCardTemplateCatalog) requireEditableRef(value any) (botTemplateRef, 
 		return botTemplateRef{}, errBotTemplateCatalogUnavailable
 	}
 	return c.requireRef(value, c.editAllowed, "template is not edit-compatible")
+}
+
+// staticRefResolver adapts a boot-time allowlist to the resolver signature.
+// Historical edit stays on this path on purpose: an edit is pinned to the
+// version already stored in the frame, so following the activation pointer
+// there would rewrite an existing card across versions (D6).
+func (c *botCardTemplateCatalog) staticRefResolver(
+	allowed map[botTemplateRef]struct{},
+	denialReason string,
+) func(context.Context, any) (botTemplateRef, error) {
+	return func(_ context.Context, value any) (botTemplateRef, error) {
+		return c.requireRef(value, allowed, denialReason)
+	}
 }
 
 func (c *botCardTemplateCatalog) requireRef(

--- a/modules/bot_api/card_template_catalog.go
+++ b/modules/bot_api/card_template_catalog.go
@@ -287,7 +287,7 @@ func (c *botCardTemplateCatalog) RenderPayload(
 		return nil, errBotTemplateCatalogUnavailable
 	}
 	return c.renderPayload(ctx, "bot-api-compat", cardtmpl.CatalogPurposeNewSend, inbound, env,
-		c.staticRefResolver(c.sendAllowed, "not Bot-callable for new send"), false)
+		c.staticRefResolver(c.sendAllowed, "not Bot-callable for new send"), false, "")
 }
 
 // RenderPayloadForPrincipal is the authenticated new-send path. Unlike the
@@ -306,7 +306,7 @@ func (c *botCardTemplateCatalog) RenderPayloadForPrincipal(
 	return c.renderPayload(ctx, principal.BotID, cardtmpl.CatalogPurposeNewSend, inbound, env,
 		func(ctx context.Context, value any) (botTemplateRef, error) {
 			return c.requireSendableRef(ctx, principal, value)
-		}, true)
+		}, true, provenanceSpaceID(principal, env))
 }
 
 func (c *botCardTemplateCatalog) RenderEditPayload(
@@ -318,7 +318,7 @@ func (c *botCardTemplateCatalog) RenderEditPayload(
 		return nil, errBotTemplateCatalogUnavailable
 	}
 	return c.renderPayload(ctx, "bot-api-compat", cardtmpl.CatalogPurposeHistoricalEdit, inbound, env,
-		c.staticRefResolver(c.editAllowed, "not edit-compatible"), false)
+		c.staticRefResolver(c.editAllowed, "not edit-compatible"), false, "")
 }
 
 func (c *botCardTemplateCatalog) RenderEditPayloadForPrincipal(
@@ -331,7 +331,9 @@ func (c *botCardTemplateCatalog) RenderEditPayloadForPrincipal(
 		return nil, errBotTemplateCatalogUnavailable
 	}
 	return c.renderPayload(ctx, botID, cardtmpl.CatalogPurposeHistoricalEdit, inbound, env,
-		c.staticRefResolver(c.editAllowed, "not edit-compatible"), true)
+		// Historical edit is pinned to a stored frame whose Space the envelope
+		// already carries, so env.SpaceID is the authoritative value here.
+		c.staticRefResolver(c.editAllowed, "not edit-compatible"), true, env.SpaceID)
 }
 
 func (c *botCardTemplateCatalog) renderPayload(
@@ -342,6 +344,14 @@ func (c *botCardTemplateCatalog) renderPayload(
 	env cardtmpl.BuildEnv,
 	resolveRef func(context.Context, any) (botTemplateRef, error),
 	authorProvenance bool,
+	// provenanceSpaceID is the Space the marker is stamped with. It is a
+	// separate value from env.SpaceID on purpose: env.SpaceID drives rendered
+	// content (deep links) and send.go only populates it for DMs, while the
+	// marker must carry the Space the send was actually *authorized* against —
+	// for a group or thread that is the target's Space, which env.SpaceID never
+	// sees. Stamping "" there would silently disable every downstream D3 Space
+	// guard, since all of them are written as `if Provenance.SpaceID != ""`.
+	provenanceSpaceID string,
 ) (map[string]any, error) {
 	if c == nil || c.catalog == nil {
 		return nil, errBotTemplateCatalogUnavailable
@@ -406,7 +416,7 @@ func (c *botCardTemplateCatalog) renderPayload(
 			Version:       cardmsg.CatalogProvenanceVersion,
 			PrincipalType: cardmsg.CatalogPrincipalWireBot,
 			PrincipalID:   botID,
-			SpaceID:       env.SpaceID,
+			SpaceID:       provenanceSpaceID,
 		}.MarshalMap()
 	}
 	for _, key := range []string{"mention", "reply"} {
@@ -551,4 +561,18 @@ func requireEffectiveCardTemplate(envelope []byte, want botTemplateRef, editorBo
 		}
 	}
 	return nil
+}
+
+// provenanceSpaceID picks the Space a new send's marker is stamped with.
+//
+// The authorization principal wins when it resolved one, because that is the
+// Space the grant decision was actually made against — for a group or thread
+// send it is the target's Space, which env.SpaceID (DM-only) never carries.
+// env.SpaceID remains the fallback so a DM keeps stamping exactly what it
+// stamped before PR-C's target-authoritative resolution existed.
+func provenanceSpaceID(principal botCatalogPrincipal, env cardtmpl.BuildEnv) string {
+	if principal.SpaceResolved && principal.SpaceID != "" {
+		return principal.SpaceID
+	}
+	return env.SpaceID
 }

--- a/modules/bot_api/card_template_catalog_test.go
+++ b/modules/bot_api/card_template_catalog_test.go
@@ -424,18 +424,18 @@ func TestEffectiveCardTemplateIdentity(t *testing.T) {
 		t.Fatal(err)
 	}
 	want := botTemplateRef{ID: aireasoningprocess.TemplateID, Version: aireasoningprocess.TemplateVersion}
-	if err := requireEffectiveCardTemplate(raw, want, "bot-template"); err != nil {
+	if err := requireEffectiveCardTemplate(raw, want, "bot-template", ""); err != nil {
 		t.Fatalf("requireEffectiveCardTemplate: %v", err)
 	}
 	delete(payload, "template_ref")
 	metadataOnly, _ := json.Marshal(payload)
-	if err := requireEffectiveCardTemplate(metadataOnly, want, "bot-template"); !errors.Is(err, errBotTemplateRequestInvalid) {
+	if err := requireEffectiveCardTemplate(metadataOnly, want, "bot-template", ""); !errors.Is(err, errBotTemplateRequestInvalid) {
 		t.Fatalf("metadata-only target error = %v", err)
 	}
-	if err := requireEffectiveCardTemplate(raw, botTemplateRef{ID: want.ID, Version: "9.9.9"}, "bot-template"); !errors.Is(err, errBotTemplateRequestInvalid) {
+	if err := requireEffectiveCardTemplate(raw, botTemplateRef{ID: want.ID, Version: "9.9.9"}, "bot-template", ""); !errors.Is(err, errBotTemplateRequestInvalid) {
 		t.Fatalf("mismatch error = %v", err)
 	}
-	if err := requireEffectiveCardTemplate([]byte(`{"type":17,"card":{}}`), want, "bot-template"); !errors.Is(err, errBotTemplateRequestInvalid) {
+	if err := requireEffectiveCardTemplate([]byte(`{"type":17,"card":{}}`), want, "bot-template", ""); !errors.Is(err, errBotTemplateRequestInvalid) {
 		t.Fatalf("non-registry error = %v", err)
 	}
 }

--- a/modules/bot_api/card_template_catalog_test.go
+++ b/modules/bot_api/card_template_catalog_test.go
@@ -478,6 +478,11 @@ func (s *botCatalogSpy) Render(ctx context.Context, request cardtmpl.CatalogRend
 // verifiableEditSpace is the "we know the Space, and it is this" state, which
 // is what every edit-guard test that predates the three-state check meant by
 // passing a bare string.
+//
+// Note that verifiableEditSpace("") is a real state and not a don't-care: it
+// asserts the target was established to have no Space, so a frame carrying one
+// is a mismatch. A test that only wants to skip the Space comparison wants the
+// gates-dark check, editSpaceCheck{}.
 func verifiableEditSpace(spaceID string) editSpaceCheck {
 	return editSpaceCheck{spaceID: spaceID, verifiable: true}
 }

--- a/modules/bot_api/card_template_catalog_test.go
+++ b/modules/bot_api/card_template_catalog_test.go
@@ -114,7 +114,7 @@ func TestBotCardTemplateCatalogPassesAuthoritativePrincipalAndPurpose(t *testing
 		"data":  rawJSONToMap(t, testReasoningData(t, "reasoning")),
 	}
 	if _, err := catalog.RenderPayloadForPrincipal(
-		context.Background(), botCatalogPrincipal{BotID: "bot-42", SpaceID: "space-7", SpaceResolved: true},
+		context.Background(), botCatalogPrincipal{BotID: "bot-42", SpaceID: "space-7", Space: botSpaceScoped},
 		payload, cardtmpl.BuildEnv{SpaceID: "space-7"},
 	); err != nil {
 		t.Fatalf("RenderPayloadForPrincipal: %v", err)

--- a/modules/bot_api/card_template_catalog_test.go
+++ b/modules/bot_api/card_template_catalog_test.go
@@ -423,18 +423,18 @@ func TestEffectiveCardTemplateIdentity(t *testing.T) {
 		t.Fatal(err)
 	}
 	want := botTemplateRef{ID: aireasoningprocess.TemplateID, Version: aireasoningprocess.TemplateVersion}
-	if err := requireEffectiveCardTemplate(raw, want); err != nil {
+	if err := requireEffectiveCardTemplate(raw, want, "bot-template"); err != nil {
 		t.Fatalf("requireEffectiveCardTemplate: %v", err)
 	}
 	delete(payload, "template_ref")
 	metadataOnly, _ := json.Marshal(payload)
-	if err := requireEffectiveCardTemplate(metadataOnly, want); !errors.Is(err, errBotTemplateRequestInvalid) {
+	if err := requireEffectiveCardTemplate(metadataOnly, want, "bot-template"); !errors.Is(err, errBotTemplateRequestInvalid) {
 		t.Fatalf("metadata-only target error = %v", err)
 	}
-	if err := requireEffectiveCardTemplate(raw, botTemplateRef{ID: want.ID, Version: "9.9.9"}); !errors.Is(err, errBotTemplateRequestInvalid) {
+	if err := requireEffectiveCardTemplate(raw, botTemplateRef{ID: want.ID, Version: "9.9.9"}, "bot-template"); !errors.Is(err, errBotTemplateRequestInvalid) {
 		t.Fatalf("mismatch error = %v", err)
 	}
-	if err := requireEffectiveCardTemplate([]byte(`{"type":17,"card":{}}`), want); !errors.Is(err, errBotTemplateRequestInvalid) {
+	if err := requireEffectiveCardTemplate([]byte(`{"type":17,"card":{}}`), want, "bot-template"); !errors.Is(err, errBotTemplateRequestInvalid) {
 		t.Fatalf("non-registry error = %v", err)
 	}
 }

--- a/modules/bot_api/card_template_catalog_test.go
+++ b/modules/bot_api/card_template_catalog_test.go
@@ -114,7 +114,8 @@ func TestBotCardTemplateCatalogPassesAuthoritativePrincipalAndPurpose(t *testing
 		"data":  rawJSONToMap(t, testReasoningData(t, "reasoning")),
 	}
 	if _, err := catalog.RenderPayloadForPrincipal(
-		context.Background(), "bot-42", payload, cardtmpl.BuildEnv{SpaceID: "space-7"},
+		context.Background(), botCatalogPrincipal{BotID: "bot-42", SpaceID: "space-7", SpaceResolved: true},
+		payload, cardtmpl.BuildEnv{SpaceID: "space-7"},
 	); err != nil {
 		t.Fatalf("RenderPayloadForPrincipal: %v", err)
 	}

--- a/modules/bot_api/card_template_catalog_test.go
+++ b/modules/bot_api/card_template_catalog_test.go
@@ -424,18 +424,18 @@ func TestEffectiveCardTemplateIdentity(t *testing.T) {
 		t.Fatal(err)
 	}
 	want := botTemplateRef{ID: aireasoningprocess.TemplateID, Version: aireasoningprocess.TemplateVersion}
-	if err := requireEffectiveCardTemplate(raw, want, "bot-template", ""); err != nil {
+	if err := requireEffectiveCardTemplate(raw, want, "bot-template", verifiableEditSpace("")); err != nil {
 		t.Fatalf("requireEffectiveCardTemplate: %v", err)
 	}
 	delete(payload, "template_ref")
 	metadataOnly, _ := json.Marshal(payload)
-	if err := requireEffectiveCardTemplate(metadataOnly, want, "bot-template", ""); !errors.Is(err, errBotTemplateRequestInvalid) {
+	if err := requireEffectiveCardTemplate(metadataOnly, want, "bot-template", verifiableEditSpace("")); !errors.Is(err, errBotTemplateRequestInvalid) {
 		t.Fatalf("metadata-only target error = %v", err)
 	}
-	if err := requireEffectiveCardTemplate(raw, botTemplateRef{ID: want.ID, Version: "9.9.9"}, "bot-template", ""); !errors.Is(err, errBotTemplateRequestInvalid) {
+	if err := requireEffectiveCardTemplate(raw, botTemplateRef{ID: want.ID, Version: "9.9.9"}, "bot-template", verifiableEditSpace("")); !errors.Is(err, errBotTemplateRequestInvalid) {
 		t.Fatalf("mismatch error = %v", err)
 	}
-	if err := requireEffectiveCardTemplate([]byte(`{"type":17,"card":{}}`), want, "bot-template", ""); !errors.Is(err, errBotTemplateRequestInvalid) {
+	if err := requireEffectiveCardTemplate([]byte(`{"type":17,"card":{}}`), want, "bot-template", verifiableEditSpace("")); !errors.Is(err, errBotTemplateRequestInvalid) {
 		t.Fatalf("non-registry error = %v", err)
 	}
 }
@@ -473,4 +473,11 @@ func (s *botCatalogSpy) MetaExact(
 func (s *botCatalogSpy) Render(ctx context.Context, request cardtmpl.CatalogRenderRequest) (map[string]any, error) {
 	s.lastRender = request
 	return s.Catalog.Render(ctx, request)
+}
+
+// verifiableEditSpace is the "we know the Space, and it is this" state, which
+// is what every edit-guard test that predates the three-state check meant by
+// passing a bare string.
+func verifiableEditSpace(spaceID string) editSpaceCheck {
+	return editSpaceCheck{spaceID: spaceID, verifiable: true}
 }

--- a/modules/bot_api/card_template_edit_test.go
+++ b/modules/bot_api/card_template_edit_test.go
@@ -80,7 +80,7 @@ func TestBotMessageEditRegistryTemplateRendersSameIdentity(t *testing.T) {
 	}
 	if err := requireEffectiveCardTemplate([]byte(request.ContentEdit), botTemplateRef{
 		ID: aireasoningprocess.TemplateID, Version: aireasoningprocess.TemplateVersion,
-	}, "bot-template", ""); err != nil {
+	}, "bot-template", verifiableEditSpace("")); err != nil {
 		t.Fatalf("replacement identity: %v", err)
 	}
 }
@@ -123,7 +123,7 @@ func TestBotMessageEditRegistryTemplateKeepsHistoricalVersionsEditable(t *testin
 			}
 			if err := requireEffectiveCardTemplate([]byte(mutator.mutateRequests[0].ContentEdit), botTemplateRef{
 				ID: aireasoningprocess.TemplateID, Version: historical.version,
-			}, "bot-template", ""); err != nil {
+			}, "bot-template", verifiableEditSpace("")); err != nil {
 				t.Fatalf("historical replacement identity: %v", err)
 			}
 		})

--- a/modules/bot_api/card_template_edit_test.go
+++ b/modules/bot_api/card_template_edit_test.go
@@ -549,7 +549,7 @@ func markedRegistryEnvelope(t *testing.T, catalog *botCardTemplateCatalog, botID
 	t.Helper()
 	env := cardtmplBuildEnvForTest()
 	payload, err := catalog.RenderPayloadForPrincipal(context.Background(),
-		botCatalogPrincipal{BotID: botID, SpaceID: env.SpaceID, SpaceResolved: true},
+		botCatalogPrincipal{BotID: botID, SpaceID: env.SpaceID, Space: botSpaceScoped},
 		registrySendBody(t, "reasoning", testReasoningData(t, "reasoning"))["payload"].(map[string]any), env)
 	if err != nil {
 		t.Fatal(err)

--- a/modules/bot_api/card_template_edit_test.go
+++ b/modules/bot_api/card_template_edit_test.go
@@ -80,7 +80,7 @@ func TestBotMessageEditRegistryTemplateRendersSameIdentity(t *testing.T) {
 	}
 	if err := requireEffectiveCardTemplate([]byte(request.ContentEdit), botTemplateRef{
 		ID: aireasoningprocess.TemplateID, Version: aireasoningprocess.TemplateVersion,
-	}); err != nil {
+	}, "bot-template"); err != nil {
 		t.Fatalf("replacement identity: %v", err)
 	}
 }
@@ -123,7 +123,7 @@ func TestBotMessageEditRegistryTemplateKeepsHistoricalVersionsEditable(t *testin
 			}
 			if err := requireEffectiveCardTemplate([]byte(mutator.mutateRequests[0].ContentEdit), botTemplateRef{
 				ID: aireasoningprocess.TemplateID, Version: historical.version,
-			}); err != nil {
+			}, "bot-template"); err != nil {
 				t.Fatalf("historical replacement identity: %v", err)
 			}
 		})
@@ -539,4 +539,107 @@ func invokeTemplateEdit(t *testing.T, ba *BotAPI, body map[string]any) *httptest
 
 func cardtmplBuildEnvForTest() cardtmpl.BuildEnv {
 	return cardtmpl.BuildEnv{Lang: "zh-CN", SpaceID: "space-1"}
+}
+
+// ---- PR-C Slice 1 (D3): Bot template edit re-authors the same-identity
+// provenance, rejects cross-principal stored frames, and raw edit cannot
+// forge or overwrite the server-only markers. ----
+
+func markedRegistryEnvelope(t *testing.T, catalog *botCardTemplateCatalog, botID string) []byte {
+	t.Helper()
+	env := cardtmplBuildEnvForTest()
+	payload, err := catalog.RenderPayloadForPrincipal(context.Background(), botID, registrySendBody(t,
+		"reasoning", testReasoningData(t, "reasoning"))["payload"].(map[string]any), env)
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload["space_id"] = env.SpaceID
+	payload["card_seq"] = int64(1)
+	if err := cardmsg.Finalize(payload); err != nil {
+		t.Fatal(err)
+	}
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return raw
+}
+
+func TestBotMessageEditRegistryTemplateReAuthorsSameProvenance(t *testing.T) {
+	t.Setenv(cardmsg.EnvEnabled, "true")
+	catalog, err := newBotCardTemplateCatalog(testBotTemplateRegistry(t), defaultBotTemplateRefs())
+	if err != nil {
+		t.Fatal(err)
+	}
+	mutator := &fakeBotCardMutator{
+		snapshot:     carddispatch.CardMutationSnapshot{Envelope: markedRegistryEnvelope(t, catalog, "bot-template"), CardSeq: 1},
+		mutateResult: carddispatch.CardMutationResult{Applied: true},
+	}
+	ba := &BotAPI{
+		Log:           log.NewTLog("BotAPI-template-edit-provenance"),
+		cardTemplates: catalog,
+		cardMutator:   mutator,
+	}
+	recorder := invokeTemplateEdit(t, ba, registryEditBody(t, "completed", testReasoningData(t, "completed"), 2, false))
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", recorder.Code, recorder.Body.String())
+	}
+	markers, err := cardmsg.CatalogFrameMarkers([]byte(mutator.mutateRequests[0].ContentEdit))
+	if err != nil {
+		t.Fatalf("replacement markers: %v", err)
+	}
+	if !markers.HasProvenance || markers.Provenance.PrincipalType != cardmsg.CatalogPrincipalWireBot ||
+		markers.Provenance.PrincipalID != "bot-template" {
+		t.Fatalf("replacement provenance = %+v", markers)
+	}
+	stored, err := cardmsg.CatalogFrameMarkers(mutator.snapshot.Envelope)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if markers.Provenance != stored.Provenance {
+		t.Fatalf("provenance changed across edit: stored=%+v replacement=%+v", stored.Provenance, markers.Provenance)
+	}
+}
+
+func TestBotMessageEditRegistryTemplateRejectsForeignStoredProvenance(t *testing.T) {
+	t.Setenv(cardmsg.EnvEnabled, "true")
+	catalog, err := newBotCardTemplateCatalog(testBotTemplateRegistry(t), defaultBotTemplateRefs())
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Same template, but the stored frame is signed by a different principal.
+	// Even if a Snapshot ownership gap ever let the lookup succeed, the stored
+	// provenance must fail the edit closed.
+	envelope := markedRegistryEnvelope(t, catalog, "another-bot")
+	mutator := &fakeBotCardMutator{
+		snapshot:     carddispatch.CardMutationSnapshot{Envelope: envelope, CardSeq: 1},
+		mutateResult: carddispatch.CardMutationResult{Applied: true},
+	}
+	ba := &BotAPI{
+		Log:           log.NewTLog("BotAPI-template-edit-foreign"),
+		cardTemplates: catalog,
+		cardMutator:   mutator,
+	}
+	recorder := invokeTemplateEdit(t, ba, registryEditBody(t, "completed", testReasoningData(t, "completed"), 2, false))
+	if recorder.Code != http.StatusBadRequest {
+		t.Fatalf("foreign provenance edit status=%d body=%s", recorder.Code, recorder.Body.String())
+	}
+	if len(mutator.mutateRequests) != 0 {
+		t.Fatal("foreign provenance edit reached mutation")
+	}
+}
+
+func TestBotRawEditRejectsCatalogProvenanceMarkers(t *testing.T) {
+	// The raw-edit guard treats either server-only marker as Registry
+	// authorship: a target carrying only catalog_provenance is still not
+	// raw-editable, and a raw content_edit carrying it is a forgery.
+	if !cardEnvelopeHasTemplateRef([]byte(`{"type":17,"catalog_provenance":{"version":1}}`)) {
+		t.Fatal("provenance-marked target not recognized as Registry-authored")
+	}
+	if !contentEditHasTemplateRef(`{"type":17,"catalog_provenance":{"version":1,"principal_type":"bot","principal_id":"x","space_id":""}}`) {
+		t.Fatal("raw content_edit forging catalog_provenance not recognized")
+	}
+	if cardEnvelopeHasTemplateRef([]byte(`{"type":17,"card":{"body":[]}}`)) {
+		t.Fatal("legacy raw frame misclassified as Registry-authored")
+	}
 }

--- a/modules/bot_api/card_template_edit_test.go
+++ b/modules/bot_api/card_template_edit_test.go
@@ -78,9 +78,13 @@ func TestBotMessageEditRegistryTemplateRendersSameIdentity(t *testing.T) {
 	if plain, _ := frame["plain"].(string); plain == "" {
 		t.Fatal("replacement plain missing")
 	}
+	// The frame lives in the fixture's Space, so that is what an edit of it
+	// resolves. Passing "" here used to read as "don't care"; it now means "we
+	// established this target has no Space", which a space-1 frame correctly
+	// fails. Asserting the real Space also checks the replacement kept it.
 	if err := requireEffectiveCardTemplate([]byte(request.ContentEdit), botTemplateRef{
 		ID: aireasoningprocess.TemplateID, Version: aireasoningprocess.TemplateVersion,
-	}, "bot-template", verifiableEditSpace("")); err != nil {
+	}, "bot-template", verifiableEditSpace(cardtmplBuildEnvForTest().SpaceID)); err != nil {
 		t.Fatalf("replacement identity: %v", err)
 	}
 }
@@ -123,7 +127,7 @@ func TestBotMessageEditRegistryTemplateKeepsHistoricalVersionsEditable(t *testin
 			}
 			if err := requireEffectiveCardTemplate([]byte(mutator.mutateRequests[0].ContentEdit), botTemplateRef{
 				ID: aireasoningprocess.TemplateID, Version: historical.version,
-			}, "bot-template", verifiableEditSpace("")); err != nil {
+			}, "bot-template", verifiableEditSpace(cardtmplBuildEnvForTest().SpaceID)); err != nil {
 				t.Fatalf("historical replacement identity: %v", err)
 			}
 		})

--- a/modules/bot_api/card_template_edit_test.go
+++ b/modules/bot_api/card_template_edit_test.go
@@ -548,8 +548,9 @@ func cardtmplBuildEnvForTest() cardtmpl.BuildEnv {
 func markedRegistryEnvelope(t *testing.T, catalog *botCardTemplateCatalog, botID string) []byte {
 	t.Helper()
 	env := cardtmplBuildEnvForTest()
-	payload, err := catalog.RenderPayloadForPrincipal(context.Background(), botID, registrySendBody(t,
-		"reasoning", testReasoningData(t, "reasoning"))["payload"].(map[string]any), env)
+	payload, err := catalog.RenderPayloadForPrincipal(context.Background(),
+		botCatalogPrincipal{BotID: botID, SpaceID: env.SpaceID, SpaceResolved: true},
+		registrySendBody(t, "reasoning", testReasoningData(t, "reasoning"))["payload"].(map[string]any), env)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/bot_api/card_template_edit_test.go
+++ b/modules/bot_api/card_template_edit_test.go
@@ -80,7 +80,7 @@ func TestBotMessageEditRegistryTemplateRendersSameIdentity(t *testing.T) {
 	}
 	if err := requireEffectiveCardTemplate([]byte(request.ContentEdit), botTemplateRef{
 		ID: aireasoningprocess.TemplateID, Version: aireasoningprocess.TemplateVersion,
-	}, "bot-template"); err != nil {
+	}, "bot-template", ""); err != nil {
 		t.Fatalf("replacement identity: %v", err)
 	}
 }
@@ -123,7 +123,7 @@ func TestBotMessageEditRegistryTemplateKeepsHistoricalVersionsEditable(t *testin
 			}
 			if err := requireEffectiveCardTemplate([]byte(mutator.mutateRequests[0].ContentEdit), botTemplateRef{
 				ID: aireasoningprocess.TemplateID, Version: historical.version,
-			}, "bot-template"); err != nil {
+			}, "bot-template", ""); err != nil {
 				t.Fatalf("historical replacement identity: %v", err)
 			}
 		})

--- a/modules/bot_api/card_template_runtime.go
+++ b/modules/bot_api/card_template_runtime.go
@@ -47,23 +47,69 @@ import (
 // cannot tell us whether it was.
 var errBotTemplateRuntimeUnavailable = errors.New("bot template runtime catalog unavailable")
 
+// botCatalogSpaceState is what this request could establish about the Space a
+// grant would be read in.
+//
+// Three states rather than a bool, because "this target has no Space" and "we
+// could not tell which Space this target is in" lead to opposite decisions and
+// were previously the same `false`. Collapsing them meant a transient group-row
+// read failure handed back the static card of a template ID that had already
+// been shadowed by an active dynamic version — the exact fallback D6 forbids,
+// because the static card is materially different content under a name the
+// producer believes it has replaced.
+type botCatalogSpaceState uint8
+
+const (
+	// botSpaceUnavailable — the Space could not be established, or was
+	// established and then refused: a DB error, an ambiguous multi-Space Bot, a
+	// rejected X-Space-ID, a DM peer outside the Bot's Space. No grant may be
+	// read for it, and no dynamic decision may be answered from static policy.
+	// It is the zero value on purpose: a principal nobody filled in authorizes
+	// nothing.
+	botSpaceUnavailable botCatalogSpaceState = iota
+	// botSpaceGlobalOnly — established, and there is no Space: a group that
+	// belongs to no Space, or a Bot with no membership at all. Only
+	// global-scoped grants can apply, which is what the empty scope sentinel
+	// already means in the grant table.
+	botSpaceGlobalOnly
+	// botSpaceScoped — established, with an identity. Exact-over-global.
+	botSpaceScoped
+)
+
 // botCatalogPrincipal is the authenticated identity one decision is made for.
 // It is always server-derived: the bot ID from the bot token, the Space from
 // the strict resolver below. No part of it comes from the request payload.
 type botCatalogPrincipal struct {
 	BotID   string
 	SpaceID string
-	// SpaceResolved is false when the Bot's Space could not be established
-	// unambiguously. Static policy still applies; every dynamic decision fails
-	// closed, because a grant is meaningless without knowing which Space's
-	// grant to read.
-	SpaceResolved bool
+	Space   botCatalogSpaceState
 }
 
 func (p botCatalogPrincipal) catalogPrincipal() cardtmpl.CatalogPrincipal {
 	return cardtmpl.CatalogPrincipal{
 		Kind: cardtmpl.CatalogPrincipalBot, ID: p.BotID, SpaceID: p.SpaceID,
 	}
+}
+
+// grantReadable reports whether a grant lookup for this principal means
+// anything. It is false only for botSpaceUnavailable, where the scope the grant
+// would be read in is precisely what we failed to establish.
+func (p botCatalogPrincipal) grantReadable() bool {
+	return p.Space != botSpaceUnavailable
+}
+
+// access is the single place a render's authorization identity comes from.
+//
+// The ref gate and cardtmpl.Render both re-resolve the grant, and until this
+// existed they resolved it from *different* Space values — the gate from the
+// target-authoritative principal, the render from env.SpaceID, which send.go
+// populates for DMs only. A Bot holding an exact grant for the target's Space
+// therefore passed the gate and was then refused by the render, making
+// per-Space grants — the primary Bot grant shape — inert for every group and
+// thread. Handing the render the same value the gate decided on is what makes
+// the two agree by construction instead of by coincidence.
+func (p botCatalogPrincipal) access(purpose cardtmpl.CatalogPurpose) cardtmpl.CatalogAccess {
+	return cardtmpl.CatalogAccess{Purpose: purpose, Principal: p.catalogPrincipal()}
 }
 
 // resolveBotGrantSpaceID is the authorization-grade Space resolver.
@@ -80,22 +126,22 @@ func (p botCatalogPrincipal) catalogPrincipal() cardtmpl.CatalogPrincipal {
 //     Bot in several Spaces with no hint has no single answer, and picking the
 //     earliest-joined one would silently move a producer's grants between
 //     tenants.
-func (ba *BotAPI) resolveBotGrantSpaceID(c *wkhttp.Context, robotID string) (string, bool) {
+func (ba *BotAPI) resolveBotGrantSpaceID(c *wkhttp.Context, robotID string) (string, botCatalogSpaceState) {
 	// One guard up front rather than a mix of guarded and unguarded uses: a nil
 	// context has no signals at all, and "no signals" is a refusal.
 	if c == nil {
-		return "", false
+		return "", botSpaceUnavailable
 	}
 	if scope, _ := c.Get(CtxKeyAppBotScope); scope == "space" {
 		if v, ok := c.Get(CtxKeyAppBotSpaceID); ok {
 			if s, _ := v.(string); s != "" {
-				return s, true
+				return s, botSpaceScoped
 			}
 		}
 	}
 	querier := ba.spaceQuerierOrDefault()
 	if querier == nil {
-		return "", false
+		return "", botSpaceUnavailable
 	}
 	if c.Request != nil {
 		if hint := strings.TrimSpace(c.GetHeader("X-Space-ID")); hint != "" {
@@ -103,36 +149,49 @@ func (ba *BotAPI) resolveBotGrantSpaceID(c *wkhttp.Context, robotID string) (str
 			if err != nil {
 				ba.Warn("bot_grant_space_hint_unverifiable",
 					zap.String("robotID", robotID), zap.String("hint", hint), zap.Error(err))
-				return "", false
+				return "", botSpaceUnavailable
 			}
 			if !authorized {
 				ba.Warn("bot_grant_space_hint_rejected",
 					zap.Bool("x_space_id_header_rejected", true),
 					zap.String("robotID", robotID), zap.String("hint", hint))
-				return "", false
+				return "", botSpaceUnavailable
 			}
-			return hint, true
+			return hint, botSpaceScoped
 		}
 	}
 	primary, all, err := querier.querySpaceIDsByRobotID(robotID)
 	if err != nil {
-		if !errors.Is(err, dbr.ErrNotFound) {
-			ba.Warn("bot_grant_space_lookup_failed",
-				zap.String("robotID", robotID), zap.Error(err))
+		if errors.Is(err, dbr.ErrNotFound) {
+			// The query ran and found no membership. That is a determination,
+			// not a failure: this Bot has no Space-scoped grants by definition,
+			// so global scope is the whole truth for it — exactly what the empty
+			// scope sentinel means in the grant table. Both the production
+			// querier and the test fake report "no rows" through this sentinel
+			// rather than as an empty slice, so this is the branch that carries
+			// the case; a Bot attached to no Space is otherwise unable to send a
+			// dynamic template even holding a global grant.
+			return "", botSpaceGlobalOnly
 		}
-		return "", false
+		ba.Warn("bot_grant_space_lookup_failed",
+			zap.String("robotID", robotID), zap.Error(err))
+		return "", botSpaceUnavailable
 	}
-	if len(all) != 1 || primary == "" {
-		// Zero Spaces: nothing to authorize against. More than one: the caller
-		// must disambiguate with X-Space-ID rather than have the server guess.
-		if len(all) > 1 {
-			ba.Warn("bot_grant_space_ambiguous",
-				zap.Bool("multi_space_membership", true),
-				zap.String("robotID", robotID), zap.Strings("all_space_ids", all))
-		}
-		return "", false
+	if len(all) > 1 {
+		// The caller must disambiguate with X-Space-ID rather than have the
+		// server guess: picking one would silently move a producer's grants
+		// between tenants.
+		ba.Warn("bot_grant_space_ambiguous",
+			zap.Bool("multi_space_membership", true),
+			zap.String("robotID", robotID), zap.Strings("all_space_ids", all))
+		return "", botSpaceUnavailable
 	}
-	return primary, true
+	if primary == "" {
+		// A membership row that names no Space contradicts the query that
+		// produced it. Treat it as unreadable rather than inventing a meaning.
+		return "", botSpaceUnavailable
+	}
+	return primary, botSpaceScoped
 }
 
 // dynamicCatalogEnabled reports whether any dynamic decision can be reached at
@@ -155,8 +214,8 @@ func (ba *BotAPI) botCatalogPrincipalFor(c *wkhttp.Context, robotID string) botC
 	if !ba.cardTemplates.dynamicCatalogEnabled() {
 		return botCatalogPrincipal{BotID: robotID}
 	}
-	spaceID, resolved := ba.resolveBotGrantSpaceID(c, robotID)
-	return botCatalogPrincipal{BotID: robotID, SpaceID: spaceID, SpaceResolved: resolved}
+	spaceID, state := ba.resolveBotGrantSpaceID(c, robotID)
+	return botCatalogPrincipal{BotID: robotID, SpaceID: spaceID, Space: state}
 }
 
 // botSendCatalogPrincipal resolves the Space one *send* is authorized against.
@@ -199,17 +258,22 @@ func (ba *BotAPI) botSendCatalogPrincipal(
 		// outside that Space, which is a cross-tenant delivery dressed up as a
 		// DM.
 		principal := ba.botCatalogPrincipalFor(c, robotID)
-		if !principal.SpaceResolved {
+		if principal.Space != botSpaceScoped {
+			// Nothing to check the peer against: either we could not establish
+			// a Space (already refusing) or there is none to be outside of.
 			return principal
 		}
 		return ba.requireDMPeerInSpace(principal, channelID, robotID)
 	}
 }
 
-// requireDMPeerInSpace downgrades the principal to unresolved unless the DM's
-// peer holds an active membership in the resolved Space. Downgrading rather
-// than erroring keeps the static path working: what is withheld is the dynamic
-// overlay, which is the only thing the Space was needed for.
+// requireDMPeerInSpace withdraws the Space unless the DM's peer holds an active
+// membership in it. Every outcome here is botSpaceUnavailable rather than
+// botSpaceGlobalOnly: a peer we could not verify, and a peer we verified to be
+// outside the Space, are both reasons this Bot's grants must not be read — not
+// evidence that the target has no Space. Reading the global grant instead would
+// turn "you may send this anywhere" into a way around the tenant check that
+// just refused.
 func (ba *BotAPI) requireDMPeerInSpace(
 	principal botCatalogPrincipal,
 	channelID, robotID string,
@@ -256,6 +320,9 @@ func (ba *BotAPI) botCatalogPrincipalForGroup(robotID, groupNo string) botCatalo
 	}
 	spaceID, err := querier.queryGroupSpaceID(groupNo)
 	if err != nil {
+		// Including dbr.ErrNotFound: a group row we cannot read tells us nothing
+		// about which tenant this send lands in, so the grant scope is
+		// unavailable rather than absent.
 		if !errors.Is(err, dbr.ErrNotFound) {
 			ba.Warn("bot_grant_group_space_lookup_failed",
 				zap.String("robotID", robotID), zap.String("groupNo", groupNo), zap.Error(err))
@@ -263,11 +330,12 @@ func (ba *BotAPI) botCatalogPrincipalForGroup(robotID, groupNo string) botCatalo
 		return botCatalogPrincipal{BotID: robotID}
 	}
 	if strings.TrimSpace(spaceID) == "" {
-		// A group outside any Space has no grant scope to read. Static policy
-		// still applies; the dynamic overlay does not.
-		return botCatalogPrincipal{BotID: robotID}
+		// The row loaded and names no Space. That is a determination: this group
+		// belongs to no tenant, so only a global grant can authorize a send into
+		// it. It is emphatically not the same as the read failing above.
+		return botCatalogPrincipal{BotID: robotID, Space: botSpaceGlobalOnly}
 	}
-	return botCatalogPrincipal{BotID: robotID, SpaceID: spaceID, SpaceResolved: true}
+	return botCatalogPrincipal{BotID: robotID, SpaceID: spaceID, Space: botSpaceScoped}
 }
 
 // resolveSendRef implements the D6 decision table for one template ID. The
@@ -283,12 +351,24 @@ func (ba *BotAPI) botCatalogPrincipalForGroup(robotID, groupNo string) botCatalo
 //	                                NOT reappear, because the operator's intent
 //	                                was to replace it
 //	pointer → dynamic, blocked    → nothing for this ID, same reasoning
+//	pointer → dynamic, Space
+//	  unavailable                 → nothing for this ID, same reasoning: an
+//	                                unreadable grant scope is an unreadable
+//	                                grant
 //	runtime DB unreachable        → typed error; callers fail closed
 //
-// The two "nothing for this ID" rows are the ones worth restating: once an
-// operator points a template ID at a dynamic version, falling back to the
-// static card of the same ID would send materially different content under a
-// name the producer believes it has replaced. Refusing is the safe answer.
+// The "nothing for this ID" rows are the ones worth restating: once an operator
+// points a template ID at a dynamic version, falling back to the static card of
+// the same ID would send materially different content under a name the producer
+// believes it has replaced. Refusing is the safe answer.
+//
+// Note where the Space state is consulted, and where it is not. Only the last
+// dynamic row reads it. An earlier revision short-circuited to static policy the
+// moment the Space was unresolved, before any read — which meant a transient
+// group-row failure produced exactly the fallback the rows above forbid, and
+// did it silently. Whether an ID has been shadowed is a fact about the
+// activation pointer, not about the caller, so it is now always read when the
+// gate is open; the Space state only decides whether a grant can be honoured.
 func (c *botCardTemplateCatalog) resolveSendRef(
 	ctx context.Context,
 	principal botCatalogPrincipal,
@@ -310,10 +390,11 @@ func (c *botCardTemplateCatalog) resolveSendRefFrom(
 ) (botTemplateRef, error) {
 	staticRef, hasStatic := c.staticSendVersion(id)
 	source := c.authorizationSource()
-	// Gate closed, no resolver installed, or a Space we could not establish:
-	// the static half of the answer never depended on any of those, so it
-	// stands unchanged and the dynamic overlay is simply withheld.
-	if source == nil || !source.NewSendEnabled() || !principal.SpaceResolved {
+	// Gate closed or no resolver installed: no activation pointer can exist to
+	// shadow anything, so the static half of the answer is the whole answer and
+	// this deployment acquires no runtime DB dependency. The caller's Space is
+	// deliberately *not* part of this condition — see the table above.
+	if source == nil || !source.NewSendEnabled() {
 		if hasStatic {
 			return staticRef, nil
 		}
@@ -335,7 +416,7 @@ func (c *botCardTemplateCatalog) resolveSendRefFrom(
 			return botTemplateRef{}, errors.Join(errBotTemplateRuntimeUnavailable, err)
 		}
 	}
-	return c.decideSendRef(id, staticRef, hasStatic, auth), nil
+	return c.decideSendRef(id, staticRef, hasStatic, auth, principal.Space), nil
 }
 
 // resolveStaticSendAuthorizations pre-resolves every statically advertised ID in
@@ -347,7 +428,7 @@ func (c *botCardTemplateCatalog) resolveStaticSendAuthorizations(
 	principal botCatalogPrincipal,
 ) (map[cardtmpl.ID]cardtmpl.RuntimeAuthorization, error) {
 	source := c.authorizationSource()
-	if source == nil || !source.NewSendEnabled() || !principal.SpaceResolved || len(c.staticSendIDs) == 0 {
+	if source == nil || !source.NewSendEnabled() || len(c.staticSendIDs) == 0 {
 		return nil, nil
 	}
 	batch, ok := source.(cardtmpl.RuntimeAuthorizationBatchStore)
@@ -372,6 +453,7 @@ func (c *botCardTemplateCatalog) decideSendRef(
 	staticRef botTemplateRef,
 	hasStatic bool,
 	auth cardtmpl.RuntimeAuthorization,
+	space botCatalogSpaceState,
 ) botTemplateRef {
 	if auth.Activation.Status == cardtmpl.RuntimeActivationDisabled {
 		// A disabled pointer is a deliberate operator state rather than an
@@ -394,6 +476,15 @@ func (c *botCardTemplateCatalog) decideSendRef(
 		if _, listed := c.sendAllowed[pointed]; listed {
 			return pointed
 		}
+		return botTemplateRef{}
+	}
+	if space == botSpaceUnavailable {
+		// The pointer says this ID is now a dynamic version, and we could not
+		// establish the scope its grant would be read in. Both answers are
+		// therefore unavailable — the dynamic one because no grant is readable,
+		// the static one because it has been replaced. Returning staticRef here
+		// is the D6 violation this guard exists to prevent, and it is reachable
+		// from an ordinary transient failure: a group-row read that times out.
 		return botTemplateRef{}
 	}
 	if auth.Artifact.Blocked || !auth.Grant.Allows(cardtmpl.CatalogPurposeNewSend) {
@@ -450,7 +541,11 @@ func (c *botCardTemplateCatalog) advertisedSendRefs(
 	}
 
 	source := c.authorizationSource()
-	if source == nil || !source.NewSendEnabled() || !principal.SpaceResolved {
+	// Beyond the static policy IDs the manifest only has grants to go on, so an
+	// unreadable grant scope really does end the list here — unlike the loop
+	// above, there is no activation pointer to check for an ID we only learn
+	// about from a grant.
+	if source == nil || !source.NewSendEnabled() || !principal.grantReadable() {
 		return refs, nil
 	}
 	granted, err := source.ListAuthorizedTemplates(ctx, principal.catalogPrincipal(), 0)
@@ -462,7 +557,8 @@ func (c *botCardTemplateCatalog) advertisedSendRefs(
 			continue
 		}
 		seen[candidate.ID] = struct{}{}
-		if ref := c.decideSendRef(candidate.ID, botTemplateRef{}, false, candidate.Authorization); ref.ID != "" {
+		if ref := c.decideSendRef(candidate.ID, botTemplateRef{}, false,
+			candidate.Authorization, principal.Space); ref.ID != "" {
 			refs = append(refs, ref)
 		}
 	}

--- a/modules/bot_api/card_template_runtime.go
+++ b/modules/bot_api/card_template_runtime.go
@@ -356,12 +356,10 @@ func (c *botCardTemplateCatalog) resolveStaticSendAuthorizations(
 	}
 	resolved, err := batch.LoadAuthorizations(ctx, c.staticSendIDs, principal.catalogPrincipal())
 	if err != nil {
-		if errors.Is(err, cardtmpl.ErrRuntimeCatalogDisabled) {
-			// One disabled pointer among the policy IDs is an operator state,
-			// not an outage. Fall back to the per-ID path so each template gets
-			// its own answer instead of the whole manifest inheriting one.
-			return nil, nil
-		}
+		// Per contract a disabled template is reported per ID rather than as a
+		// batch-wide error, so anything that reaches here really is an outage
+		// and the manifest fails closed rather than advertising a version that
+		// may already have been shadowed.
 		return nil, errors.Join(errBotTemplateRuntimeUnavailable, err)
 	}
 	return resolved, nil
@@ -375,6 +373,16 @@ func (c *botCardTemplateCatalog) decideSendRef(
 	hasStatic bool,
 	auth cardtmpl.RuntimeAuthorization,
 ) botTemplateRef {
+	if auth.Activation.Status == cardtmpl.RuntimeActivationDisabled {
+		// A disabled pointer is a deliberate operator state rather than an
+		// outage, but the outcome matches the ungranted row: this ID is not
+		// sendable, and it does not revert to its static version. The per-ID
+		// resolver learns this from ErrRuntimeCatalogDisabled; the batch
+		// resolver reports it as an activation status, because failing a whole
+		// batch over one disabled template would cost every other template in
+		// it a separate round trip.
+		return botTemplateRef{}
+	}
 	if auth.Version == "" {
 		if hasStatic {
 			return staticRef

--- a/modules/bot_api/card_template_runtime.go
+++ b/modules/bot_api/card_template_runtime.go
@@ -130,7 +130,20 @@ func (ba *BotAPI) resolveBotGrantSpaceID(c *wkhttp.Context, robotID string) (str
 	return primary, true
 }
 
+// dynamicCatalogEnabled reports whether any dynamic decision can be reached at
+// all. When it is false there is nothing to authorize against, so resolving the
+// caller's Space would be pure cost: a Space lookup this deployment did not
+// perform before PR-C, plus — for a multi-Space Bot — an ambiguity warn on
+// every poll of an endpoint that never touched the database.
+func dynamicCatalogEnabled() bool {
+	source := cardtmpl.DefaultAuthorizationSource()
+	return source != nil && source.NewSendEnabled()
+}
+
 func (ba *BotAPI) botCatalogPrincipalFor(c *wkhttp.Context, robotID string) botCatalogPrincipal {
+	if !dynamicCatalogEnabled() {
+		return botCatalogPrincipal{BotID: robotID}
+	}
 	spaceID, resolved := ba.resolveBotGrantSpaceID(c, robotID)
 	return botCatalogPrincipal{BotID: robotID, SpaceID: spaceID, SpaceResolved: resolved}
 }
@@ -152,6 +165,12 @@ func (ba *BotAPI) botSendCatalogPrincipal(
 	robotID, channelID string,
 	channelType uint8,
 ) botCatalogPrincipal {
+	if !dynamicCatalogEnabled() {
+		// Same reasoning as botCatalogPrincipalFor: with the gate closed the
+		// send path resolves purely from static policy, so it must not start
+		// reading group rows to answer a question nobody will ask.
+		return botCatalogPrincipal{BotID: robotID}
+	}
 	switch channelType {
 	case common.ChannelTypeGroup.Uint8():
 		return ba.botCatalogPrincipalForGroup(robotID, channelID)

--- a/modules/bot_api/card_template_runtime.go
+++ b/modules/bot_api/card_template_runtime.go
@@ -140,13 +140,19 @@ func (ba *BotAPI) resolveBotGrantSpaceID(c *wkhttp.Context, robotID string) (str
 // caller's Space would be pure cost: a Space lookup this deployment did not
 // perform before PR-C, plus — for a multi-Space Bot — an ambiguity warn on
 // every poll of an endpoint that never touched the database.
-func dynamicCatalogEnabled() bool {
-	source := cardtmpl.DefaultAuthorizationSource()
+//
+// It goes through the catalog's own accessor rather than the process global.
+// The two can differ — an instance resolver exists precisely to override the
+// global one — and if the gate that decides whether to resolve a Space read a
+// different source than the gate that decides whether to use it, grants would
+// be silently ignored in one direction and paid for pointlessly in the other.
+func (c *botCardTemplateCatalog) dynamicCatalogEnabled() bool {
+	source := c.authorizationSource()
 	return source != nil && source.NewSendEnabled()
 }
 
 func (ba *BotAPI) botCatalogPrincipalFor(c *wkhttp.Context, robotID string) botCatalogPrincipal {
-	if !dynamicCatalogEnabled() {
+	if !ba.cardTemplates.dynamicCatalogEnabled() {
 		return botCatalogPrincipal{BotID: robotID}
 	}
 	spaceID, resolved := ba.resolveBotGrantSpaceID(c, robotID)
@@ -170,7 +176,7 @@ func (ba *BotAPI) botSendCatalogPrincipal(
 	robotID, channelID string,
 	channelType uint8,
 ) botCatalogPrincipal {
-	if !dynamicCatalogEnabled() {
+	if !ba.cardTemplates.dynamicCatalogEnabled() {
 		// Same reasoning as botCatalogPrincipalFor: with the gate closed the
 		// send path resolves purely from static policy, so it must not start
 		// reading group rows to answer a question nobody will ask.

--- a/modules/bot_api/card_template_runtime.go
+++ b/modules/bot_api/card_template_runtime.go
@@ -294,6 +294,20 @@ func (c *botCardTemplateCatalog) resolveSendRef(
 	principal botCatalogPrincipal,
 	id cardtmpl.ID,
 ) (botTemplateRef, error) {
+	return c.resolveSendRefFrom(ctx, principal, id, nil)
+}
+
+// resolveSendRefFrom is resolveSendRef with an optional pre-resolved snapshot
+// for this principal. The manifest resolves every policy ID in one batch and
+// passes the result here; the send path passes nil and reads the single ID it
+// needs. Both then run the identical decision, so the manifest cannot come to a
+// different conclusion than the send it is advertising.
+func (c *botCardTemplateCatalog) resolveSendRefFrom(
+	ctx context.Context,
+	principal botCatalogPrincipal,
+	id cardtmpl.ID,
+	batch map[cardtmpl.ID]cardtmpl.RuntimeAuthorization,
+) (botTemplateRef, error) {
 	staticRef, hasStatic := c.staticSendVersion(id)
 	source := c.authorizationSource()
 	// Gate closed, no resolver installed, or a Space we could not establish:
@@ -305,19 +319,52 @@ func (c *botCardTemplateCatalog) resolveSendRef(
 		}
 		return botTemplateRef{}, nil
 	}
-	auth, err := source.LoadAuthorization(ctx, cardtmpl.RuntimeAuthorizationQuery{
-		ID: id, Principal: principal.catalogPrincipal(),
-	})
-	if err != nil {
-		if errors.Is(err, cardtmpl.ErrRuntimeCatalogDisabled) {
-			// A disabled pointer is a deliberate operator state rather than an
-			// outage, but the outcome matches the ungranted row: this ID is not
-			// sendable, and it does not revert to its static version.
-			return botTemplateRef{}, nil
+	auth, ok := batch[id]
+	if !ok {
+		var err error
+		auth, err = source.LoadAuthorization(ctx, cardtmpl.RuntimeAuthorizationQuery{
+			ID: id, Principal: principal.catalogPrincipal(),
+		})
+		if err != nil {
+			if errors.Is(err, cardtmpl.ErrRuntimeCatalogDisabled) {
+				// A disabled pointer is a deliberate operator state rather than
+				// an outage, but the outcome matches the ungranted row: this ID
+				// is not sendable, and it does not revert to its static version.
+				return botTemplateRef{}, nil
+			}
+			return botTemplateRef{}, errors.Join(errBotTemplateRuntimeUnavailable, err)
 		}
-		return botTemplateRef{}, errors.Join(errBotTemplateRuntimeUnavailable, err)
 	}
 	return c.decideSendRef(id, staticRef, hasStatic, auth), nil
+}
+
+// resolveStaticSendAuthorizations pre-resolves every statically advertised ID in
+// one round trip when the store offers a batch read. A nil result is not a
+// failure: the caller falls back to one read per ID, which is what a store
+// without the batch interface gets.
+func (c *botCardTemplateCatalog) resolveStaticSendAuthorizations(
+	ctx context.Context,
+	principal botCatalogPrincipal,
+) (map[cardtmpl.ID]cardtmpl.RuntimeAuthorization, error) {
+	source := c.authorizationSource()
+	if source == nil || !source.NewSendEnabled() || !principal.SpaceResolved || len(c.staticSendIDs) == 0 {
+		return nil, nil
+	}
+	batch, ok := source.(cardtmpl.RuntimeAuthorizationBatchStore)
+	if !ok {
+		return nil, nil
+	}
+	resolved, err := batch.LoadAuthorizations(ctx, c.staticSendIDs, principal.catalogPrincipal())
+	if err != nil {
+		if errors.Is(err, cardtmpl.ErrRuntimeCatalogDisabled) {
+			// One disabled pointer among the policy IDs is an operator state,
+			// not an outage. Fall back to the per-ID path so each template gets
+			// its own answer instead of the whole manifest inheriting one.
+			return nil, nil
+		}
+		return nil, errors.Join(errBotTemplateRuntimeUnavailable, err)
+	}
+	return resolved, nil
 }
 
 // decideSendRef is the pure half of the table above, split out so the matrix is
@@ -379,8 +426,12 @@ func (c *botCardTemplateCatalog) advertisedSendRefs(
 	}
 	seen := make(map[cardtmpl.ID]struct{}, len(c.staticSendByID))
 	refs := make([]botTemplateRef, 0, len(c.staticSendByID))
+	staticAuth, err := c.resolveStaticSendAuthorizations(ctx, principal)
+	if err != nil {
+		return nil, err
+	}
 	for _, id := range c.staticSendIDs {
-		ref, err := c.resolveSendRef(ctx, principal, id)
+		ref, err := c.resolveSendRefFrom(ctx, principal, id, staticAuth)
 		if err != nil {
 			return nil, err
 		}

--- a/modules/bot_api/card_template_runtime.go
+++ b/modules/bot_api/card_template_runtime.go
@@ -1,0 +1,427 @@
+package bot_api
+
+// PR-C D6 — merging the code-reviewed static Bot policy with dynamic grants.
+//
+// Two things meet here, and both are easy to get subtly wrong:
+//
+//  1. *Which version of a template ID may this Bot send right now.* Before
+//     PR-C the answer was a process constant. Now the activation pointer can
+//     shadow it with a dynamic version, but only when this Bot actually holds
+//     a send grant in this Space. The full decision table lives in
+//     resolveSendRef below and is the single implementation both the capability
+//     manifest and the send path call — an advertised set that disagreed with
+//     what send accepts is a support incident waiting to happen.
+//
+//  2. *Which Space this Bot is acting in.* The legacy resolver in
+//     space_inject.go is deliberately forgiving: on an unauthorized header, a
+//     DB error or an ambiguous multi-Space Bot it falls back to a
+//     deterministic first Space so that DM delivery keeps working. That
+//     forgiveness is fine for "which Space tag do we stamp on a message"; it is
+//     not fine as an authorization input, because it would let an unauthorized
+//     X-Space-ID header silently downgrade into some *other* Space's grants.
+//     resolveBotGrantSpaceID below is the strict twin: same signals, but every
+//     ambiguity is a refusal.
+//
+// Nothing here loosens the static path. With the new-send gate closed the
+// resolver returns the static policy without touching the runtime DB at all,
+// so a deployment that has not opted into the dynamic catalog cannot acquire a
+// new database dependency — or a new failure mode — from this file.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl"
+	"github.com/gocraft/dbr/v2"
+	"go.uber.org/zap"
+)
+
+// errBotTemplateRuntimeUnavailable marks a runtime-catalog read that could not
+// be completed. Callers must fail closed on it: the whole point of the dynamic
+// overlay is that a template ID may have been shadowed, and a failed read
+// cannot tell us whether it was.
+var errBotTemplateRuntimeUnavailable = errors.New("bot template runtime catalog unavailable")
+
+// botCatalogPrincipal is the authenticated identity one decision is made for.
+// It is always server-derived: the bot ID from the bot token, the Space from
+// the strict resolver below. No part of it comes from the request payload.
+type botCatalogPrincipal struct {
+	BotID   string
+	SpaceID string
+	// SpaceResolved is false when the Bot's Space could not be established
+	// unambiguously. Static policy still applies; every dynamic decision fails
+	// closed, because a grant is meaningless without knowing which Space's
+	// grant to read.
+	SpaceResolved bool
+}
+
+func (p botCatalogPrincipal) catalogPrincipal() cardtmpl.CatalogPrincipal {
+	return cardtmpl.CatalogPrincipal{
+		Kind: cardtmpl.CatalogPrincipalBot, ID: p.BotID, SpaceID: p.SpaceID,
+	}
+}
+
+// resolveBotGrantSpaceID is the authorization-grade Space resolver.
+//
+// It shares its signals with resolveBotActiveSpaceID but not its fallbacks:
+//
+//   - App Bot scope=space — the strongest server-authoritative signal, taken
+//     directly from the authenticated context.
+//   - An explicit X-Space-ID header — honoured only when the Bot is authorized
+//     for that Space. An unauthorized or unverifiable header is a hard refusal
+//     and never falls through to a different Space, which is precisely the
+//     downgrade the legacy resolver would allow.
+//   - Otherwise the Bot's own membership, and only when it is unambiguous. A
+//     Bot in several Spaces with no hint has no single answer, and picking the
+//     earliest-joined one would silently move a producer's grants between
+//     tenants.
+func (ba *BotAPI) resolveBotGrantSpaceID(c *wkhttp.Context, robotID string) (string, bool) {
+	if scope, _ := c.Get(CtxKeyAppBotScope); scope == "space" {
+		if v, ok := c.Get(CtxKeyAppBotSpaceID); ok {
+			if s, _ := v.(string); s != "" {
+				return s, true
+			}
+		}
+	}
+	querier := ba.spaceQuerierOrDefault()
+	if querier == nil {
+		return "", false
+	}
+	if c != nil && c.Request != nil {
+		if hint := strings.TrimSpace(c.GetHeader("X-Space-ID")); hint != "" {
+			authorized, err := querier.isBotSpaceAuthorized(robotID, hint)
+			if err != nil {
+				ba.Warn("bot_grant_space_hint_unverifiable",
+					zap.String("robotID", robotID), zap.String("hint", hint), zap.Error(err))
+				return "", false
+			}
+			if !authorized {
+				ba.Warn("bot_grant_space_hint_rejected",
+					zap.Bool("x_space_id_header_rejected", true),
+					zap.String("robotID", robotID), zap.String("hint", hint))
+				return "", false
+			}
+			return hint, true
+		}
+	}
+	primary, all, err := querier.querySpaceIDsByRobotID(robotID)
+	if err != nil {
+		if !errors.Is(err, dbr.ErrNotFound) {
+			ba.Warn("bot_grant_space_lookup_failed",
+				zap.String("robotID", robotID), zap.Error(err))
+		}
+		return "", false
+	}
+	if len(all) != 1 || primary == "" {
+		// Zero Spaces: nothing to authorize against. More than one: the caller
+		// must disambiguate with X-Space-ID rather than have the server guess.
+		if len(all) > 1 {
+			ba.Warn("bot_grant_space_ambiguous",
+				zap.Bool("multi_space_membership", true),
+				zap.String("robotID", robotID), zap.Strings("all_space_ids", all))
+		}
+		return "", false
+	}
+	return primary, true
+}
+
+func (ba *BotAPI) botCatalogPrincipalFor(c *wkhttp.Context, robotID string) botCatalogPrincipal {
+	spaceID, resolved := ba.resolveBotGrantSpaceID(c, robotID)
+	return botCatalogPrincipal{BotID: robotID, SpaceID: spaceID, SpaceResolved: resolved}
+}
+
+// botSendCatalogPrincipal resolves the Space one *send* is authorized against.
+//
+// The target decides, not the sender. A Bot can belong to Space A and still be
+// a member of a group that lives in Space B; authorizing that send against
+// Space A's grants would let a grant in one tenant deliver cards into another.
+// So for a group the Space comes from the authoritative group row, for a thread
+// from its parent group's row, and only a personal DM falls back to the Bot's
+// own context — where there is no target row to consult.
+//
+// Every failure is a refusal rather than a fallback: a malformed thread channel
+// ID, a missing group row and a DB error all leave the principal unresolved,
+// which fails the dynamic decision closed while leaving static policy intact.
+func (ba *BotAPI) botSendCatalogPrincipal(
+	c *wkhttp.Context,
+	robotID, channelID string,
+	channelType uint8,
+) botCatalogPrincipal {
+	switch channelType {
+	case common.ChannelTypeGroup.Uint8():
+		return ba.botCatalogPrincipalForGroup(robotID, channelID)
+	case common.ChannelTypeCommunityTopic.Uint8():
+		parts := strings.SplitN(channelID, threadChannelIDSeparator, 2)
+		if len(parts) != 2 || strings.TrimSpace(parts[0]) == "" {
+			return botCatalogPrincipal{BotID: robotID}
+		}
+		return ba.botCatalogPrincipalForGroup(robotID, parts[0])
+	default:
+		return ba.botCatalogPrincipalFor(c, robotID)
+	}
+}
+
+func (ba *BotAPI) botCatalogPrincipalForGroup(robotID, groupNo string) botCatalogPrincipal {
+	querier := ba.spaceQuerierOrDefault()
+	if querier == nil {
+		return botCatalogPrincipal{BotID: robotID}
+	}
+	spaceID, err := querier.queryGroupSpaceID(groupNo)
+	if err != nil {
+		if !errors.Is(err, dbr.ErrNotFound) {
+			ba.Warn("bot_grant_group_space_lookup_failed",
+				zap.String("robotID", robotID), zap.String("groupNo", groupNo), zap.Error(err))
+		}
+		return botCatalogPrincipal{BotID: robotID}
+	}
+	if strings.TrimSpace(spaceID) == "" {
+		// A group outside any Space has no grant scope to read. Static policy
+		// still applies; the dynamic overlay does not.
+		return botCatalogPrincipal{BotID: robotID}
+	}
+	return botCatalogPrincipal{BotID: robotID, SpaceID: spaceID, SpaceResolved: true}
+}
+
+// resolveSendRef implements the D6 decision table for one template ID. The
+// rows, in the order the code checks them:
+//
+//	new-send gate closed          → static policy only, no runtime DB access
+//	no activation row             → static policy version, if the policy has one
+//	pointer → a static exact      → that exact, but only if the policy lists it;
+//	                                a static exact is code-reviewed policy, so no
+//	                                business grant is consulted for it
+//	pointer → dynamic, granted    → the dynamic exact shadows the static version
+//	pointer → dynamic, ungranted  → nothing for this ID; the static version does
+//	                                NOT reappear, because the operator's intent
+//	                                was to replace it
+//	pointer → dynamic, blocked    → nothing for this ID, same reasoning
+//	runtime DB unreachable        → typed error; callers fail closed
+//
+// The two "nothing for this ID" rows are the ones worth restating: once an
+// operator points a template ID at a dynamic version, falling back to the
+// static card of the same ID would send materially different content under a
+// name the producer believes it has replaced. Refusing is the safe answer.
+func (c *botCardTemplateCatalog) resolveSendRef(
+	ctx context.Context,
+	principal botCatalogPrincipal,
+	id cardtmpl.ID,
+) (botTemplateRef, error) {
+	staticRef, hasStatic := c.staticSendVersion(id)
+	source := c.authorizationSource()
+	// Gate closed, no resolver installed, or a Space we could not establish:
+	// the static half of the answer never depended on any of those, so it
+	// stands unchanged and the dynamic overlay is simply withheld.
+	if source == nil || !source.NewSendEnabled() || !principal.SpaceResolved {
+		if hasStatic {
+			return staticRef, nil
+		}
+		return botTemplateRef{}, nil
+	}
+	auth, err := source.LoadAuthorization(ctx, cardtmpl.RuntimeAuthorizationQuery{
+		ID: id, Principal: principal.catalogPrincipal(),
+	})
+	if err != nil {
+		if errors.Is(err, cardtmpl.ErrRuntimeCatalogDisabled) {
+			// A disabled pointer is a deliberate operator state rather than an
+			// outage, but the outcome matches the ungranted row: this ID is not
+			// sendable, and it does not revert to its static version.
+			return botTemplateRef{}, nil
+		}
+		return botTemplateRef{}, errors.Join(errBotTemplateRuntimeUnavailable, err)
+	}
+	return c.decideSendRef(id, staticRef, hasStatic, auth), nil
+}
+
+// decideSendRef is the pure half of the table above, split out so the matrix is
+// testable without a store.
+func (c *botCardTemplateCatalog) decideSendRef(
+	id cardtmpl.ID,
+	staticRef botTemplateRef,
+	hasStatic bool,
+	auth cardtmpl.RuntimeAuthorization,
+) botTemplateRef {
+	if auth.Version == "" {
+		if hasStatic {
+			return staticRef
+		}
+		return botTemplateRef{}
+	}
+	pointed := botTemplateRef{ID: id, Version: auth.Version}
+	if auth.Artifact.Source == cardtmpl.RuntimeSourceStatic {
+		if _, listed := c.sendAllowed[pointed]; listed {
+			return pointed
+		}
+		return botTemplateRef{}
+	}
+	if auth.Artifact.Blocked || !auth.Grant.Allows(cardtmpl.CatalogPurposeNewSend) {
+		return botTemplateRef{}
+	}
+	return pointed
+}
+
+// staticSendVersion returns the code-reviewed advertised version for an ID.
+func (c *botCardTemplateCatalog) staticSendVersion(id cardtmpl.ID) (botTemplateRef, bool) {
+	ref, ok := c.staticSendByID[id]
+	return ref, ok
+}
+
+func (c *botCardTemplateCatalog) authorizationSource() cardtmpl.RuntimeAuthorizationSource {
+	if c == nil {
+		return nil
+	}
+	if c.authorization != nil {
+		return c.authorization
+	}
+	return cardtmpl.DefaultAuthorizationSource()
+}
+
+// advertisedSendRefs is the effective advertised set for one principal: every
+// static-policy ID resolved through the table above, plus every additional
+// template the Bot holds an active send grant on.
+//
+// A capability manifest is a hint, not a permit. It is assembled from several
+// snapshots on purpose — binding it into one would suggest a guarantee that
+// send deliberately does not honour, since send always re-resolves.
+func (c *botCardTemplateCatalog) advertisedSendRefs(
+	ctx context.Context,
+	principal botCatalogPrincipal,
+) ([]botTemplateRef, error) {
+	if c == nil {
+		return nil, errBotTemplateCatalogUnavailable
+	}
+	seen := make(map[cardtmpl.ID]struct{}, len(c.staticSendByID))
+	refs := make([]botTemplateRef, 0, len(c.staticSendByID))
+	for _, id := range c.staticSendIDs {
+		ref, err := c.resolveSendRef(ctx, principal, id)
+		if err != nil {
+			return nil, err
+		}
+		seen[id] = struct{}{}
+		if ref.ID != "" {
+			refs = append(refs, ref)
+		}
+	}
+
+	source := c.authorizationSource()
+	if source == nil || !source.NewSendEnabled() || !principal.SpaceResolved {
+		return refs, nil
+	}
+	granted, err := source.ListAuthorizedTemplates(ctx, principal.catalogPrincipal(), 0)
+	if err != nil {
+		return nil, errors.Join(errBotTemplateRuntimeUnavailable, err)
+	}
+	for _, candidate := range granted {
+		if _, done := seen[candidate.ID]; done {
+			continue
+		}
+		seen[candidate.ID] = struct{}{}
+		if ref := c.decideSendRef(candidate.ID, botTemplateRef{}, false, candidate.Authorization); ref.ID != "" {
+			refs = append(refs, ref)
+		}
+	}
+	return refs, nil
+}
+
+// CapabilityFor is the request-scoped manifest. Before PR-C this was a process
+// constant; it is now resolved per authenticated Bot and Space, because two
+// Bots in the same deployment can legitimately be granted different templates.
+//
+// A runtime read failure is reported to the caller rather than degraded into
+// the static manifest: advertising the static version of an ID that may have
+// been shadowed would tell a producer it can send something the send path will
+// refuse, which is worse than admitting the catalog is briefly unreadable.
+func (c *botCardTemplateCatalog) CapabilityFor(
+	ctx context.Context,
+	principal botCatalogPrincipal,
+) (botTemplatingCapability, error) {
+	if c == nil {
+		return c.Capability(), nil
+	}
+	refs, err := c.advertisedSendRefs(ctx, principal)
+	if err != nil {
+		return botTemplatingCapability{}, err
+	}
+	manifest := botTemplatingCapability{
+		Supported: true, Wire: botTemplateWireV1,
+		Templates: make([]botTemplateCapability, 0, len(refs)),
+	}
+	staticByRef := make(map[botTemplateRef]botTemplateCapability, len(c.capability.Templates))
+	for _, template := range c.capability.Templates {
+		staticByRef[botTemplateRef{ID: cardtmpl.ID(template.ID), Version: template.Version}] = template
+	}
+	for _, ref := range refs {
+		if precomputed, ok := staticByRef[ref]; ok {
+			manifest.Templates = append(manifest.Templates, cloneTemplateCapability(precomputed))
+			continue
+		}
+		meta, err := c.catalog.MetaExact(ctx, cardtmpl.CatalogExactRequest{
+			Access: botCatalogAccess(cardtmpl.CatalogPurposeNewSend, principal.BotID, principal.SpaceID),
+			ID:     ref.ID, Version: ref.Version,
+		})
+		if err != nil {
+			return botTemplatingCapability{}, errors.Join(errBotTemplateRuntimeUnavailable, err)
+		}
+		capability, err := templateCapabilityFromMeta(meta)
+		if err != nil {
+			return botTemplatingCapability{}, errors.Join(errBotTemplateRuntimeUnavailable, err)
+		}
+		manifest.Templates = append(manifest.Templates, capability)
+	}
+	sort.Slice(manifest.Templates, func(i, j int) bool {
+		left, right := manifest.Templates[i], manifest.Templates[j]
+		if left.ID != right.ID {
+			return left.ID < right.ID
+		}
+		return left.Version < right.Version
+	})
+	return manifest, nil
+}
+
+// requireSendableRef is the send-path authorization boundary for a
+// caller-supplied template_ref. It re-resolves rather than trusting whatever
+// the producer read from a capability manifest: the manifest may be arbitrarily
+// old, and an activate, block or revoke since then must take effect now.
+func (c *botCardTemplateCatalog) requireSendableRef(
+	ctx context.Context,
+	principal botCatalogPrincipal,
+	value any,
+) (botTemplateRef, error) {
+	if c == nil || c.catalog == nil {
+		return botTemplateRef{}, errBotTemplateCatalogUnavailable
+	}
+	ref, err := parseBotTemplateRef(value)
+	if err != nil {
+		return botTemplateRef{}, err
+	}
+	allowed, err := c.resolveSendRef(ctx, principal, ref.ID)
+	if err != nil {
+		return botTemplateRef{}, err
+	}
+	if allowed != ref {
+		// One message for "unknown template", "wrong version" and "not granted"
+		// alike: a producer must not be able to use send rejections to
+		// enumerate which templates exist or which other Bots hold grants.
+		return botTemplateRef{}, fmt.Errorf("%w: not Bot-callable for new send", errBotTemplateRequestInvalid)
+	}
+	return ref, nil
+}
+
+func cloneTemplateCapability(template botTemplateCapability) botTemplateCapability {
+	out := botTemplateCapability{
+		ID: template.ID, Version: template.Version,
+		Views: make([]botTemplateViewCapability, len(template.Views)),
+	}
+	for i, view := range template.Views {
+		out.Views[i] = botTemplateViewCapability{
+			Name: view.Name, WireProfile: view.WireProfile,
+			States:        append(make([]string, 0, len(view.States)), view.States...),
+			SubmitActions: append(make([]string, 0, len(view.SubmitActions)), view.SubmitActions...),
+		}
+	}
+	return out
+}

--- a/modules/bot_api/card_template_runtime.go
+++ b/modules/bot_api/card_template_runtime.go
@@ -192,8 +192,61 @@ func (ba *BotAPI) botSendCatalogPrincipal(
 		}
 		return ba.botCatalogPrincipalForGroup(robotID, parts[0])
 	default:
-		return ba.botCatalogPrincipalFor(c, robotID)
+		// A DM has no target row to read a Space from, so the Bot's own context
+		// supplies it — but the peer has to actually be in that Space. D6 asks
+		// for *both* principals to be valid members: without the peer check a
+		// Bot could use its own Space's grant to deliver a card to somebody
+		// outside that Space, which is a cross-tenant delivery dressed up as a
+		// DM.
+		principal := ba.botCatalogPrincipalFor(c, robotID)
+		if !principal.SpaceResolved {
+			return principal
+		}
+		return ba.requireDMPeerInSpace(principal, channelID, robotID)
 	}
+}
+
+// requireDMPeerInSpace downgrades the principal to unresolved unless the DM's
+// peer holds an active membership in the resolved Space. Downgrading rather
+// than erroring keeps the static path working: what is withheld is the dynamic
+// overlay, which is the only thing the Space was needed for.
+func (ba *BotAPI) requireDMPeerInSpace(
+	principal botCatalogPrincipal,
+	channelID, robotID string,
+) botCatalogPrincipal {
+	peer := strings.TrimSpace(dmPeerUID(channelID, robotID))
+	if peer == "" {
+		return botCatalogPrincipal{BotID: robotID}
+	}
+	querier := ba.spaceQuerierOrDefault()
+	if querier == nil {
+		return botCatalogPrincipal{BotID: robotID}
+	}
+	member, err := querier.isUserSpaceMember(peer, principal.SpaceID)
+	if err != nil {
+		ba.Warn("bot_grant_dm_peer_lookup_failed",
+			zap.String("robotID", robotID), zap.String("spaceID", principal.SpaceID), zap.Error(err))
+		return botCatalogPrincipal{BotID: robotID}
+	}
+	if !member {
+		ba.Warn("bot_grant_dm_peer_outside_space",
+			zap.Bool("dm_peer_outside_space", true),
+			zap.String("robotID", robotID), zap.String("spaceID", principal.SpaceID))
+		return botCatalogPrincipal{BotID: robotID}
+	}
+	return principal
+}
+
+// dmPeerUID extracts the other side of a personal DM channel. WuKongIM routes
+// person channels by the peer's bare uid, so for a Bot-initiated DM the channel
+// ID is the recipient; the guard against a self-channel keeps a malformed
+// request from being read as "the Bot is its own peer".
+func dmPeerUID(channelID, robotID string) string {
+	channelID = strings.TrimSpace(channelID)
+	if channelID == "" || channelID == strings.TrimSpace(robotID) {
+		return ""
+	}
+	return channelID
 }
 
 func (ba *BotAPI) botCatalogPrincipalForGroup(robotID, groupNo string) botCatalogPrincipal {

--- a/modules/bot_api/card_template_runtime.go
+++ b/modules/bot_api/card_template_runtime.go
@@ -81,6 +81,11 @@ func (p botCatalogPrincipal) catalogPrincipal() cardtmpl.CatalogPrincipal {
 //     earliest-joined one would silently move a producer's grants between
 //     tenants.
 func (ba *BotAPI) resolveBotGrantSpaceID(c *wkhttp.Context, robotID string) (string, bool) {
+	// One guard up front rather than a mix of guarded and unguarded uses: a nil
+	// context has no signals at all, and "no signals" is a refusal.
+	if c == nil {
+		return "", false
+	}
 	if scope, _ := c.Get(CtxKeyAppBotScope); scope == "space" {
 		if v, ok := c.Get(CtxKeyAppBotSpaceID); ok {
 			if s, _ := v.(string); s != "" {
@@ -92,7 +97,7 @@ func (ba *BotAPI) resolveBotGrantSpaceID(c *wkhttp.Context, robotID string) (str
 	if querier == nil {
 		return "", false
 	}
-	if c != nil && c.Request != nil {
+	if c.Request != nil {
 		if hint := strings.TrimSpace(c.GetHeader("X-Space-ID")); hint != "" {
 			authorized, err := querier.isBotSpaceAuthorized(robotID, hint)
 			if err != nil {

--- a/modules/bot_api/card_template_runtime.go
+++ b/modules/bot_api/card_template_runtime.go
@@ -162,19 +162,27 @@ func (ba *BotAPI) resolveBotGrantSpaceID(c *wkhttp.Context, robotID string) (str
 	}
 	primary, all, err := querier.querySpaceIDsByRobotID(robotID)
 	if err != nil {
-		if errors.Is(err, dbr.ErrNotFound) {
-			// The query ran and found no membership. That is a determination,
-			// not a failure: this Bot has no Space-scoped grants by definition,
-			// so global scope is the whole truth for it — exactly what the empty
-			// scope sentinel means in the grant table. Both the production
-			// querier and the test fake report "no rows" through this sentinel
-			// rather than as an empty slice, so this is the branch that carries
-			// the case; a Bot attached to no Space is otherwise unable to send a
-			// dynamic template even holding a global grant.
-			return "", botSpaceGlobalOnly
+		// Including dbr.ErrNotFound, which this query returns for "no rows".
+		//
+		// An earlier revision read that sentinel as "this Bot belongs to no
+		// Space" and answered botSpaceGlobalOnly. It is not that determination,
+		// because a whole production population has no space_member row *and is
+		// still authorized for Spaces*: platform App Bots are visible in every
+		// active Space and never get a membership insert (db.go's
+		// isBotSpaceAuthorized, branch 2). For them the sentinel meant "global
+		// scope" while isBotSpaceAuthorized would happily have confirmed any
+		// active Space — so the two answers disagreed, and which one a request
+		// got was decided by whether it sent an X-Space-ID header. Omitting the
+		// header selected the global scope, where an exact revoke tombstone for
+		// the target Space is not even visible to the grant query. A revoke was
+		// bypassable by dropping one header.
+		//
+		// Membership absence therefore cannot be read as a Space determination
+		// here at all. It is one more thing this resolver could not establish.
+		if !errors.Is(err, dbr.ErrNotFound) {
+			ba.Warn("bot_grant_space_lookup_failed",
+				zap.String("robotID", robotID), zap.Error(err))
 		}
-		ba.Warn("bot_grant_space_lookup_failed",
-			zap.String("robotID", robotID), zap.Error(err))
 		return "", botSpaceUnavailable
 	}
 	if len(all) > 1 {
@@ -318,7 +326,7 @@ func (ba *BotAPI) botCatalogPrincipalForGroup(robotID, groupNo string) botCatalo
 	if querier == nil {
 		return botCatalogPrincipal{BotID: robotID}
 	}
-	spaceID, err := querier.queryGroupSpaceID(groupNo)
+	spaceID, spaceActive, err := querier.queryGroupSpaceID(groupNo)
 	if err != nil {
 		// Including dbr.ErrNotFound: a group row we cannot read tells us nothing
 		// about which tenant this send lands in, so the grant scope is
@@ -334,6 +342,19 @@ func (ba *BotAPI) botCatalogPrincipalForGroup(robotID, groupNo string) botCatalo
 		// belongs to no tenant, so only a global grant can authorize a send into
 		// it. It is emphatically not the same as the read failing above.
 		return botCatalogPrincipal{BotID: robotID, Space: botSpaceGlobalOnly}
+	}
+	if !spaceActive {
+		// The group names a Space that is no longer active. Reading that Space's
+		// grants would honour a scope the rest of the system already refuses —
+		// membership, the X-Space-ID header and the DM peer check all require an
+		// active Space. A disabled Space is not "no Space" either: falling
+		// through to global scope would let a global grant deliver where the
+		// scoped one has been switched off.
+		ba.Warn("bot_grant_group_space_inactive",
+			zap.Bool("group_space_inactive", true),
+			zap.String("robotID", robotID), zap.String("groupNo", groupNo),
+			zap.String("spaceID", spaceID))
+		return botCatalogPrincipal{BotID: robotID}
 	}
 	return botCatalogPrincipal{BotID: robotID, SpaceID: spaceID, Space: botSpaceScoped}
 }

--- a/modules/bot_api/card_template_runtime_test.go
+++ b/modules/bot_api/card_template_runtime_test.go
@@ -461,6 +461,13 @@ func TestResolveBotGrantSpaceIDRefusesEveryAmbiguity(t *testing.T) {
 // sending Bot's own — otherwise a grant in one tenant would deliver into
 // another.
 func TestBotSendCatalogPrincipalUsesTheTargetGroupSpace(t *testing.T) {
+	// The target-authoritative resolution only runs when there is a dynamic
+	// decision to make; with the gate closed it is deliberately skipped (see
+	// TestBotCatalogPrincipalSkipsSpaceLookupWhenTheCatalogIsDark).
+	previous := cardtmpl.DefaultAuthorizationSource()
+	cardtmpl.SetDefaultAuthorizationSource(&stubAuthorizationSource{newSend: true})
+	t.Cleanup(func() { cardtmpl.SetDefaultAuthorizationSource(previous) })
+
 	querier := &fakeSpaceQuerier{
 		multiRows:   map[string][]string{"bot-42": {"space-bot"}},
 		groupSpaces: map[string]string{"group-1": "space-group"},
@@ -488,5 +495,64 @@ func TestBotSendCatalogPrincipalUsesTheTargetGroupSpace(t *testing.T) {
 		if unresolved.SpaceResolved || unresolved.SpaceID != "" {
 			t.Fatalf("principal = %+v, want unresolved", unresolved)
 		}
+	}
+}
+
+// Review follow-up (#6): with the dynamic catalog dark there is nothing to
+// authorize against, so the request must not resolve a Space at all. Before
+// this fix a gates-off deployment paid a space_member/app_bot query on every
+// feature-detection poll — a database dependency the endpoint never had.
+func TestBotCatalogPrincipalSkipsSpaceLookupWhenTheCatalogIsDark(t *testing.T) {
+	previous := cardtmpl.DefaultAuthorizationSource()
+	t.Cleanup(func() { cardtmpl.SetDefaultAuthorizationSource(previous) })
+
+	querier := &fakeSpaceQuerier{multiRows: map[string][]string{"bot-42": {"space-1"}}}
+	ba := newTestBotAPI(querier)
+	ctx := newGrantSpaceContext(t, "")
+
+	for _, source := range []cardtmpl.RuntimeAuthorizationSource{
+		nil,
+		&stubAuthorizationSource{newSend: false},
+	} {
+		querier.calls = nil
+		cardtmpl.SetDefaultAuthorizationSource(source)
+
+		principal := ba.botCatalogPrincipalFor(ctx, "bot-42")
+		if principal.SpaceResolved || principal.SpaceID != "" {
+			t.Fatalf("dark catalog resolved a Space: %+v", principal)
+		}
+		send := ba.botSendCatalogPrincipal(ctx, "bot-42", "group-1", common.ChannelTypeGroup.Uint8())
+		if send.SpaceResolved || send.SpaceID != "" {
+			t.Fatalf("dark catalog resolved a send Space: %+v", send)
+		}
+		if len(querier.calls) != 0 {
+			t.Fatalf("dark catalog issued %v", querier.calls)
+		}
+	}
+
+	cardtmpl.SetDefaultAuthorizationSource(&stubAuthorizationSource{newSend: true})
+	if principal := ba.botCatalogPrincipalFor(ctx, "bot-42"); !principal.SpaceResolved {
+		t.Fatalf("enabled catalog did not resolve a Space: %+v", principal)
+	}
+}
+
+// Review follow-up (#2): a group send authorizes against the target's Space, so
+// the stored marker must carry that Space too. Stamping env.SpaceID (which
+// send.go only fills for DMs) left every group card with space_id:"" — and all
+// three downstream D3 guards are written as `if SpaceID != ""`, so they became
+// no-ops for exactly the frames that cross Space boundaries.
+func TestProvenanceSpacePrefersTheAuthorizedSpaceOverTheRenderEnv(t *testing.T) {
+	group := botCatalogPrincipal{BotID: "bot-42", SpaceID: "space-group", SpaceResolved: true}
+	if got := provenanceSpaceID(group, cardtmpl.BuildEnv{}); got != "space-group" {
+		t.Fatalf("group provenance Space = %q, want the authorized Space", got)
+	}
+	// A DM keeps stamping exactly what it stamped before the target-authoritative
+	// resolver existed.
+	dm := botCatalogPrincipal{BotID: "bot-42"}
+	if got := provenanceSpaceID(dm, cardtmpl.BuildEnv{SpaceID: "space-dm"}); got != "space-dm" {
+		t.Fatalf("DM provenance Space = %q, want the render env Space", got)
+	}
+	if got := provenanceSpaceID(dm, cardtmpl.BuildEnv{}); got != "" {
+		t.Fatalf("unresolved provenance Space = %q, want empty", got)
 	}
 }

--- a/modules/bot_api/card_template_runtime_test.go
+++ b/modules/bot_api/card_template_runtime_test.go
@@ -617,7 +617,7 @@ func TestGroupCardStaysEditableAndKeepsItsAuthorizedSpace(t *testing.T) {
 	// the guard passes even though the envelope carries no space_id.
 	editPrincipal := ba.botSendCatalogPrincipal(ctx, "bot-42", "group-1", common.ChannelTypeGroup.Uint8())
 	ref := botTemplateRef{ID: aireasoningprocess.TemplateID, Version: aireasoningprocess.TemplateVersionV3}
-	if err := requireEffectiveCardTemplate(envelope, ref, "bot-42", editPrincipal.SpaceID); err != nil {
+	if err := requireEffectiveCardTemplate(envelope, ref, "bot-42", editProvenanceSpaceCheck(true, editPrincipal)); err != nil {
 		t.Fatalf("group card was refused by its own edit guard: %v", err)
 	}
 
@@ -640,7 +640,7 @@ func TestGroupCardStaysEditableAndKeepsItsAuthorizedSpace(t *testing.T) {
 	}
 
 	// A frame replayed against a target in another Space is still refused.
-	if err := requireEffectiveCardTemplate(envelope, ref, "bot-42", "space-elsewhere"); err == nil {
+	if err := requireEffectiveCardTemplate(envelope, ref, "bot-42", verifiableEditSpace("space-elsewhere")); err == nil {
 		t.Fatal("a frame moved to another Space was accepted")
 	}
 }
@@ -713,5 +713,193 @@ func TestDMPeerCheckIsSkippedWhenTheCatalogIsDark(t *testing.T) {
 	}
 	if len(querier.calls) != 0 {
 		t.Fatalf("dark catalog queried %v", querier.calls)
+	}
+}
+
+// The Space guard has to tell "we know of no Space" apart from "we could not
+// find out". Conflating them is what made every group card permanently
+// uneditable the first time; this covers the general form rather than the one
+// path that was reported.
+func TestEditSpaceCheckSeparatesUnknownFromEmpty(t *testing.T) {
+	resolved := botCatalogPrincipal{BotID: "bot-1", SpaceID: "space-a", SpaceResolved: true}
+	unresolved := botCatalogPrincipal{BotID: "bot-1"}
+
+	if got := editProvenanceSpaceCheck(true, resolved); !got.verifiable || got.unavailable ||
+		got.spaceID != "space-a" {
+		t.Fatalf("a resolved Space produced %+v", got)
+	}
+	if got := editProvenanceSpaceCheck(true, unresolved); got.verifiable || !got.unavailable {
+		t.Fatalf("an unresolvable Space under a live gate produced %+v", got)
+	}
+	// The gate being closed is a configuration state, not an outage: nothing
+	// ever asked for a Space, so there is nothing to be unavailable.
+	if got := editProvenanceSpaceCheck(false, unresolved); got.verifiable || got.unavailable {
+		t.Fatalf("a dark catalog produced %+v", got)
+	}
+	if got := editProvenanceSpaceCheck(false, resolved); got.verifiable || got.unavailable {
+		t.Fatalf("a dark catalog with a stale principal produced %+v", got)
+	}
+}
+
+// The regression this closes: a group card sent while the dynamic catalog was
+// live records the group's Space, and rolling the gate back must not make that
+// card uneditable forever. A transient lookup failure must not make it
+// uneditable either — but it must not silently pass the check, so it reports a
+// retryable outage instead of a permanent client error.
+func TestGroupCardStaysEditableAcrossAGateRollback(t *testing.T) {
+	ba := newTestBotAPIWithCatalog(t, &fakeSpaceQuerier{
+		multiRows:   map[string][]string{"bot-42": {"space-bot"}},
+		groupSpaces: map[string]string{"group-1": "space-group"},
+	}, &stubAuthorizationSource{newSend: true})
+	ctx := newGrantSpaceContext(t, "")
+	catalog := ba.cardTemplates
+
+	principal := ba.botSendCatalogPrincipal(ctx, "bot-42", "group-1", common.ChannelTypeGroup.Uint8())
+	if !principal.SpaceResolved || principal.SpaceID != "space-group" {
+		t.Fatalf("send principal = %+v", principal)
+	}
+	sent, err := catalog.RenderPayloadForPrincipal(context.Background(), principal,
+		registrySendBody(t, "reasoning", testReasoningData(t, "reasoning"))["payload"].(map[string]any),
+		cardtmpl.BuildEnv{Lang: "zh-CN"})
+	if err != nil {
+		t.Fatalf("group send: %v", err)
+	}
+	envelope, err := json.Marshal(sent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ref := botTemplateRef{ID: aireasoningprocess.TemplateID, Version: aireasoningprocess.TemplateVersionV3}
+
+	// The gate rolls back. The card still names space-group, and the edit path
+	// can no longer resolve any Space at all.
+	dark := editProvenanceSpaceCheck(false, botCatalogPrincipal{BotID: "bot-42"})
+	if err := requireEffectiveCardTemplate(envelope, ref, "bot-42", dark); err != nil {
+		t.Fatalf("a gate rollback made an existing group card uneditable: %v", err)
+	}
+
+	// The gate is live but the group row will not load. That is an outage, and
+	// it must be reported as one — never as "your request is malformed".
+	blind := editProvenanceSpaceCheck(true, botCatalogPrincipal{BotID: "bot-42"})
+	err = requireEffectiveCardTemplate(envelope, ref, "bot-42", blind)
+	if !errors.Is(err, errBotTemplateRuntimeUnavailable) {
+		t.Fatalf("an unresolvable Space error = %v, want errBotTemplateRuntimeUnavailable", err)
+	}
+	// And it is still not an invalid-request error, which is what the handler
+	// branches on to decide between 500 and 400.
+	if errors.Is(err, errBotTemplateRequestInvalid) {
+		t.Fatal("an outage was also classified as a client error")
+	}
+
+	// A genuinely different Space is still refused, permanently.
+	if err := requireEffectiveCardTemplate(envelope, ref, "bot-42",
+		verifiableEditSpace("space-elsewhere")); !errors.Is(err, errBotTemplateRequestInvalid) {
+		t.Fatalf("cross-Space edit error = %v, want errBotTemplateRequestInvalid", err)
+	}
+}
+
+// batchAuthorizationSource is stubAuthorizationSource plus the optional batch
+// interface, so the manifest takes the fast path. It answers from the same map,
+// which is the point: the two paths must not be able to disagree.
+type batchAuthorizationSource struct {
+	stubAuthorizationSource
+	batches    int
+	batchErr   error
+	batchedIDs [][]cardtmpl.ID
+}
+
+func (s *batchAuthorizationSource) LoadAuthorizations(
+	_ context.Context, ids []cardtmpl.ID, _ cardtmpl.CatalogPrincipal,
+) (map[cardtmpl.ID]cardtmpl.RuntimeAuthorization, error) {
+	s.batches++
+	s.batchedIDs = append(s.batchedIDs, append([]cardtmpl.ID(nil), ids...))
+	if s.batchErr != nil {
+		return nil, s.batchErr
+	}
+	out := make(map[cardtmpl.ID]cardtmpl.RuntimeAuthorization, len(ids))
+	for _, id := range ids {
+		out[id] = s.auth[id]
+	}
+	return out, nil
+}
+
+// The manifest resolves the whole static policy list in one round trip, and
+// reaches the same conclusion it reached one query at a time. The second half
+// is what matters: a batch that saved round trips by dropping the "activated
+// but ungranted" row would silently re-advertise the static version of a
+// template an operator had already moved to a dynamic one.
+func TestAdvertisedSendRefsBatchesAndAgreesWithThePerIDPath(t *testing.T) {
+	authorizations := map[cardtmpl.ID]cardtmpl.RuntimeAuthorization{
+		// Activated dynamically, but this Bot holds no grant: the ID becomes
+		// unsendable and must NOT fall back to its static version.
+		aireasoningprocess.TemplateID: {
+			Version: "0.4.0-dyn",
+			Artifact: cardtmpl.RuntimeArtifactMeta{
+				ID: aireasoningprocess.TemplateID, Version: "0.4.0-dyn",
+				Source: cardtmpl.RuntimeSourceDynamic,
+			},
+		},
+	}
+	batched := &batchAuthorizationSource{
+		stubAuthorizationSource: stubAuthorizationSource{newSend: true, auth: authorizations},
+	}
+	perID := &stubAuthorizationSource{newSend: true, auth: authorizations}
+
+	principal := botCatalogPrincipal{BotID: "bot-1", SpaceID: "space-1", SpaceResolved: true}
+	batchedCatalog := newMustTestCatalog(t)
+	batchedCatalog.authorization = batched
+	perIDCatalog := newMustTestCatalog(t)
+	perIDCatalog.authorization = perID
+
+	fromBatch, err := batchedCatalog.advertisedSendRefs(context.Background(), principal)
+	if err != nil {
+		t.Fatalf("batched advertisedSendRefs: %v", err)
+	}
+	fromLoop, err := perIDCatalog.advertisedSendRefs(context.Background(), principal)
+	if err != nil {
+		t.Fatalf("per-ID advertisedSendRefs: %v", err)
+	}
+	if len(fromBatch) != len(fromLoop) {
+		t.Fatalf("batched = %+v, per-ID = %+v", fromBatch, fromLoop)
+	}
+	for i := range fromBatch {
+		if fromBatch[i] != fromLoop[i] {
+			t.Fatalf("batched = %+v, per-ID = %+v", fromBatch, fromLoop)
+		}
+	}
+	for _, ref := range fromBatch {
+		if ref.ID == aireasoningprocess.TemplateID {
+			t.Fatalf("an activated-but-ungranted template was still advertised: %+v", ref)
+		}
+	}
+
+	// One batch, and no per-ID reads left over for the policy list.
+	if batched.batches != 1 {
+		t.Fatalf("batch calls = %d, want exactly one", batched.batches)
+	}
+	if batched.loads != 0 {
+		t.Fatalf("the batched source still issued %d per-ID reads", batched.loads)
+	}
+	if len(batched.batchedIDs) != 1 || len(batched.batchedIDs[0]) != len(perIDCatalog.staticSendIDs) {
+		t.Fatalf("batched IDs = %+v, want the whole policy list", batched.batchedIDs)
+	}
+	if perID.loads != len(perIDCatalog.staticSendIDs) {
+		t.Fatalf("per-ID reads = %d, want one per policy ID", perID.loads)
+	}
+}
+
+// A batch read that fails is an outage, and the manifest must fail closed
+// rather than quietly degrading to the static answer — advertising a version
+// that may have been shadowed is exactly the D6 row this whole path exists for.
+func TestAdvertisedSendRefsFailsClosedWhenTheBatchReadFails(t *testing.T) {
+	batched := &batchAuthorizationSource{
+		stubAuthorizationSource: stubAuthorizationSource{newSend: true},
+		batchErr:                errors.New("db unavailable"),
+	}
+	catalog := newMustTestCatalog(t)
+	catalog.authorization = batched
+	_, err := catalog.advertisedSendRefs(context.Background(),
+		botCatalogPrincipal{BotID: "bot-1", SpaceID: "space-1", SpaceResolved: true})
+	if !errors.Is(err, errBotTemplateRuntimeUnavailable) {
+		t.Fatalf("err = %v, want errBotTemplateRuntimeUnavailable", err)
 	}
 }

--- a/modules/bot_api/card_template_runtime_test.go
+++ b/modules/bot_api/card_template_runtime_test.go
@@ -30,7 +30,8 @@ type stubAuthorizationSource struct {
 	granted []cardtmpl.RuntimeAdvertisedTemplate
 	listErr error
 
-	loads int
+	loads   int
+	queries []cardtmpl.RuntimeAuthorizationQuery
 }
 
 func (s *stubAuthorizationSource) LoadAuthorization(
@@ -38,6 +39,7 @@ func (s *stubAuthorizationSource) LoadAuthorization(
 	query cardtmpl.RuntimeAuthorizationQuery,
 ) (cardtmpl.RuntimeAuthorization, error) {
 	s.loads++
+	s.queries = append(s.queries, query)
 	if s.err != nil {
 		return cardtmpl.RuntimeAuthorization{}, s.err
 	}
@@ -1038,5 +1040,118 @@ func TestDecideSendRefRefusesADisabledPointerFromTheBatch(t *testing.T) {
 	none := cardtmpl.RuntimeAuthorization{}
 	if ref := catalog.decideSendRef(aireasoningprocess.TemplateID, staticRef, true, none); ref != staticRef {
 		t.Fatalf("an unactivated template lost its static version: %+v", ref)
+	}
+}
+
+// Review (Jerry-Xin blocking / yujiawei S2+P1-2): the `send|edit` grant was
+// half-wired. `send` reached the dynamic authorizer; `edit` was gated on a
+// boot-time map of static exacts that a runtime-published version can never be
+// in, so a Bot could be granted a dynamic template, send it, and then have no
+// way to edit the card it had just sent. For a state-machine card that is a
+// dead end.
+func TestBotEditResolvesADynamicRefThroughTheEditGrant(t *testing.T) {
+	dynamicRef := botTemplateRef{ID: aireasoningprocess.TemplateID, Version: "9.9.9-dyn"}
+	principal := botCatalogPrincipal{BotID: "bot-1", SpaceID: "space-1", SpaceResolved: true}
+	authorized := func(grant cardtmpl.RuntimeGrant) *stubAuthorizationSource {
+		return &stubAuthorizationSource{
+			newSend: true,
+			auth: map[cardtmpl.ID]cardtmpl.RuntimeAuthorization{
+				dynamicRef.ID: {
+					Version: dynamicRef.Version,
+					Artifact: cardtmpl.RuntimeArtifactMeta{
+						ID: dynamicRef.ID, Version: dynamicRef.Version,
+						Source: cardtmpl.RuntimeSourceDynamic,
+					},
+					Grant: grant,
+				},
+			},
+		}
+	}
+	refValue := map[string]any{"id": string(dynamicRef.ID), "version": dynamicRef.Version}
+
+	// Granted edit: the dynamic exact resolves even though it is absent from
+	// the static EditCompatible allowlist.
+	catalog := newMustTestCatalog(t)
+	catalog.authorization = authorized(cardtmpl.RuntimeGrant{
+		Found: true, Scope: cardtmpl.RuntimeGrantScopeExact, Discover: true, Edit: true,
+	})
+	if _, ok := catalog.editAllowed[dynamicRef]; ok {
+		t.Fatal("fixture precondition broken: the dynamic ref is in the static allowlist")
+	}
+	got, err := catalog.resolveEditRef(context.Background(), principal, refValue)
+	if err != nil {
+		t.Fatalf("a granted dynamic edit was refused: %v", err)
+	}
+	if got != dynamicRef {
+		t.Fatalf("resolved %+v, want %+v", got, dynamicRef)
+	}
+
+	// The read is pinned to the stored exact version — an edit must never
+	// follow the activation pointer, or it would rewrite a card across
+	// versions (D6).
+	if len(catalog.authorization.(*stubAuthorizationSource).queries) > 0 {
+		if v := catalog.authorization.(*stubAuthorizationSource).queries[0].Version; v != dynamicRef.Version {
+			t.Fatalf("edit query version = %q, want the stored exact %q", v, dynamicRef.Version)
+		}
+	}
+
+	// Revoked (a tombstone: found, no permissions) → refused, and refused as a
+	// client error rather than an outage.
+	revoked := newMustTestCatalog(t)
+	revoked.authorization = authorized(cardtmpl.RuntimeGrant{
+		Found: true, Scope: cardtmpl.RuntimeGrantScopeExact,
+	})
+	if _, err := revoked.resolveEditRef(context.Background(), principal, refValue); !errors.Is(err, errBotTemplateRequestInvalid) {
+		t.Fatalf("revoked edit error = %v, want errBotTemplateRequestInvalid", err)
+	}
+
+	// A send-only grant does not confer edit.
+	sendOnly := newMustTestCatalog(t)
+	sendOnly.authorization = authorized(cardtmpl.RuntimeGrant{
+		Found: true, Scope: cardtmpl.RuntimeGrantScopeExact, Discover: true, Send: true,
+	})
+	if _, err := sendOnly.resolveEditRef(context.Background(), principal, refValue); !errors.Is(err, errBotTemplateRequestInvalid) {
+		t.Fatalf("send-only edit error = %v, want errBotTemplateRequestInvalid", err)
+	}
+
+	// Blocked artifact refuses even with an edit grant.
+	blockedSource := authorized(cardtmpl.RuntimeGrant{
+		Found: true, Scope: cardtmpl.RuntimeGrantScopeExact, Discover: true, Edit: true,
+	})
+	blockedAuth := blockedSource.auth[dynamicRef.ID]
+	blockedAuth.Artifact.Blocked = true
+	blockedSource.auth[dynamicRef.ID] = blockedAuth
+	blocked := newMustTestCatalog(t)
+	blocked.authorization = blockedSource
+	if _, err := blocked.resolveEditRef(context.Background(), principal, refValue); !errors.Is(err, errBotTemplateRequestInvalid) {
+		t.Fatalf("blocked edit error = %v, want errBotTemplateRequestInvalid", err)
+	}
+}
+
+// The static half must not acquire a DB dependency: a code-reviewed static
+// exact stays editable with no resolver at all, which is what keeps a
+// gates-off deployment on exactly its pre-PR-C behaviour.
+func TestBotEditKeepsStaticRefsAnsweringWithoutTheRuntime(t *testing.T) {
+	catalog := newMustTestCatalog(t)
+	staticRef := botTemplateRef{ID: aireasoningprocess.TemplateID, Version: aireasoningprocess.TemplateVersionV3}
+	if _, ok := catalog.editAllowed[staticRef]; !ok {
+		t.Fatal("fixture precondition broken: the static ref is not edit-compatible")
+	}
+	refValue := map[string]any{"id": string(staticRef.ID), "version": staticRef.Version}
+
+	// No resolver, unresolved principal — the dark-catalog shape.
+	got, err := catalog.resolveEditRef(context.Background(), botCatalogPrincipal{BotID: "bot-1"}, refValue)
+	if err != nil {
+		t.Fatalf("a static edit needed the runtime: %v", err)
+	}
+	if got != staticRef {
+		t.Fatalf("resolved %+v, want %+v", got, staticRef)
+	}
+
+	// And an unknown dynamic ref is still refused there, rather than falling
+	// open because no resolver was available to say no.
+	unknown := map[string]any{"id": string(aireasoningprocess.TemplateID), "version": "9.9.9-dyn"}
+	if _, err := catalog.resolveEditRef(context.Background(), botCatalogPrincipal{BotID: "bot-1"}, unknown); !errors.Is(err, errBotTemplateRequestInvalid) {
+		t.Fatalf("dark-catalog dynamic edit error = %v, want errBotTemplateRequestInvalid", err)
 	}
 }

--- a/modules/bot_api/card_template_runtime_test.go
+++ b/modules/bot_api/card_template_runtime_test.go
@@ -644,3 +644,74 @@ func TestGroupCardStaysEditableAndKeepsItsAuthorizedSpace(t *testing.T) {
 		t.Fatal("a frame moved to another Space was accepted")
 	}
 }
+
+// D6 requires *both* DM principals to be valid members of the Space a dynamic
+// send is authorized against. Checking only the Bot would let its own Space's
+// grant deliver a card to somebody outside that Space — a cross-tenant delivery
+// wearing a DM's clothes.
+func TestDMSendRequiresThePeerToBeInTheAuthorizedSpace(t *testing.T) {
+	dm := common.ChannelTypePerson.Uint8()
+	for _, test := range []struct {
+		name       string
+		querier    *fakeSpaceQuerier
+		peer       string
+		wantSpace  string
+		wantResolv bool
+	}{
+		{
+			name: "peer in the Bot's Space authorizes the send",
+			querier: &fakeSpaceQuerier{
+				multiRows:    map[string][]string{"bot-42": {"space-1"}},
+				memberSpaces: map[string]map[string]bool{"user-in": {"space-1": true}},
+			},
+			peer: "user-in", wantSpace: "space-1", wantResolv: true,
+		},
+		{
+			name: "peer outside the Space withholds the dynamic overlay",
+			querier: &fakeSpaceQuerier{
+				multiRows:    map[string][]string{"bot-42": {"space-1"}},
+				memberSpaces: map[string]map[string]bool{"user-in": {"space-1": true}},
+			},
+			peer: "user-elsewhere", wantResolv: false,
+		},
+		{
+			name: "a peer membership lookup failure refuses rather than assumes",
+			querier: &fakeSpaceQuerier{
+				multiRows:      map[string][]string{"bot-42": {"space-1"}},
+				memberSpaceErr: errors.New("db unavailable"),
+			},
+			peer: "user-in", wantResolv: false,
+		},
+		{
+			name: "a self-addressed channel is not a peer",
+			querier: &fakeSpaceQuerier{
+				multiRows:    map[string][]string{"bot-42": {"space-1"}},
+				memberSpaces: map[string]map[string]bool{"bot-42": {"space-1": true}},
+			},
+			peer: "bot-42", wantResolv: false,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			ba := newTestBotAPIWithCatalog(t, test.querier, &stubAuthorizationSource{newSend: true})
+			got := ba.botSendCatalogPrincipal(newGrantSpaceContext(t, ""), "bot-42", test.peer, dm)
+			if got.SpaceResolved != test.wantResolv || got.SpaceID != test.wantSpace {
+				t.Fatalf("DM principal = %+v, want space=%q resolved=%v",
+					got, test.wantSpace, test.wantResolv)
+			}
+		})
+	}
+}
+
+// With the catalog dark the peer is never consulted either — the whole point of
+// the gate is that a gates-off deployment issues no new queries.
+func TestDMPeerCheckIsSkippedWhenTheCatalogIsDark(t *testing.T) {
+	querier := &fakeSpaceQuerier{multiRows: map[string][]string{"bot-42": {"space-1"}}}
+	ba := newTestBotAPIWithCatalog(t, querier, &stubAuthorizationSource{newSend: false})
+	if got := ba.botSendCatalogPrincipal(newGrantSpaceContext(t, ""), "bot-42",
+		"user-in", common.ChannelTypePerson.Uint8()); got.SpaceResolved {
+		t.Fatalf("dark catalog resolved a DM Space: %+v", got)
+	}
+	if len(querier.calls) != 0 {
+		t.Fatalf("dark catalog queried %v", querier.calls)
+	}
+}

--- a/modules/bot_api/card_template_runtime_test.go
+++ b/modules/bot_api/card_template_runtime_test.go
@@ -1,0 +1,492 @@
+package bot_api
+
+// PR-C D6 evidence: the shadow matrix, the strict Space resolver, and the fact
+// that the capability manifest and the send path reach the same verdict.
+//
+// The matrix table below is the specification transcribed row for row. If a
+// future change makes an ungranted or blocked dynamic pointer quietly fall back
+// to the static card of the same ID, exactly one line here goes red.
+
+import (
+	"context"
+	"errors"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl"
+	aireasoningprocess "github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl/ai_reasoning_process"
+	"github.com/gin-gonic/gin"
+	"github.com/gocraft/dbr/v2"
+)
+
+type stubAuthorizationSource struct {
+	newSend bool
+	auth    map[cardtmpl.ID]cardtmpl.RuntimeAuthorization
+	err     error
+	granted []cardtmpl.RuntimeAdvertisedTemplate
+	listErr error
+
+	loads int
+}
+
+func (s *stubAuthorizationSource) LoadAuthorization(
+	_ context.Context,
+	query cardtmpl.RuntimeAuthorizationQuery,
+) (cardtmpl.RuntimeAuthorization, error) {
+	s.loads++
+	if s.err != nil {
+		return cardtmpl.RuntimeAuthorization{}, s.err
+	}
+	return s.auth[query.ID], nil
+}
+
+func (s *stubAuthorizationSource) ListAuthorizedTemplates(
+	context.Context, cardtmpl.CatalogPrincipal, int,
+) ([]cardtmpl.RuntimeAdvertisedTemplate, error) {
+	if s.listErr != nil {
+		return nil, s.listErr
+	}
+	return s.granted, nil
+}
+
+func (s *stubAuthorizationSource) NewSendEnabled() bool { return s.newSend }
+
+func dynamicAuthorization(version string, blocked bool, grant cardtmpl.RuntimeGrant) cardtmpl.RuntimeAuthorization {
+	return cardtmpl.RuntimeAuthorization{
+		Activation: cardtmpl.RuntimeActivation{
+			Exists: true, Status: cardtmpl.RuntimeActivationActive, Version: version, Revision: 3,
+		},
+		Version: version,
+		Artifact: cardtmpl.RuntimeArtifactMeta{
+			ID: aireasoningprocess.TemplateID, Version: version,
+			Source: cardtmpl.RuntimeSourceDynamic, Owner: "ai", Blocked: blocked,
+		},
+		Grant: grant,
+	}
+}
+
+func sendGrant() cardtmpl.RuntimeGrant {
+	return cardtmpl.RuntimeGrant{
+		Found: true, Scope: cardtmpl.RuntimeGrantScopeExact, Revision: 2, Discover: true, Send: true,
+	}
+}
+
+func resolvedPrincipal() botCatalogPrincipal {
+	return botCatalogPrincipal{BotID: "bot-42", SpaceID: "space-1", SpaceResolved: true}
+}
+
+func TestBotTemplateSendRefFollowsTheShadowMatrix(t *testing.T) {
+	staticVersion := aireasoningprocess.TemplateVersionV3
+	id := aireasoningprocess.TemplateID
+
+	for _, test := range []struct {
+		name      string
+		source    *stubAuthorizationSource
+		principal botCatalogPrincipal
+		want      botTemplateRef
+		wantErr   bool
+	}{
+		{
+			name:      "gate closed keeps the static policy and never reads the runtime DB",
+			source:    &stubAuthorizationSource{newSend: false},
+			principal: resolvedPrincipal(),
+			want:      botTemplateRef{ID: id, Version: staticVersion},
+		},
+		{
+			name: "no activation row keeps the static policy",
+			source: &stubAuthorizationSource{newSend: true, auth: map[cardtmpl.ID]cardtmpl.RuntimeAuthorization{
+				id: {},
+			}},
+			principal: resolvedPrincipal(),
+			want:      botTemplateRef{ID: id, Version: staticVersion},
+		},
+		{
+			name: "pointer at a policy-listed static exact is advertised without a grant",
+			source: &stubAuthorizationSource{newSend: true, auth: map[cardtmpl.ID]cardtmpl.RuntimeAuthorization{
+				id: {
+					Activation: cardtmpl.RuntimeActivation{
+						Exists: true, Status: cardtmpl.RuntimeActivationActive, Version: staticVersion,
+					},
+					Version:  staticVersion,
+					Artifact: cardtmpl.RuntimeArtifactMeta{Source: cardtmpl.RuntimeSourceStatic},
+				},
+			}},
+			principal: resolvedPrincipal(),
+			want:      botTemplateRef{ID: id, Version: staticVersion},
+		},
+		{
+			name: "pointer at a static exact outside the policy advertises nothing",
+			source: &stubAuthorizationSource{newSend: true, auth: map[cardtmpl.ID]cardtmpl.RuntimeAuthorization{
+				id: {
+					Activation: cardtmpl.RuntimeActivation{
+						Exists: true, Status: cardtmpl.RuntimeActivationActive, Version: "0.0.1",
+					},
+					Version:  "0.0.1",
+					Artifact: cardtmpl.RuntimeArtifactMeta{Source: cardtmpl.RuntimeSourceStatic},
+				},
+			}},
+			principal: resolvedPrincipal(),
+			want:      botTemplateRef{},
+		},
+		{
+			name: "granted dynamic active shadows the static version",
+			source: &stubAuthorizationSource{newSend: true, auth: map[cardtmpl.ID]cardtmpl.RuntimeAuthorization{
+				id: dynamicAuthorization("9.0.0", false, sendGrant()),
+			}},
+			principal: resolvedPrincipal(),
+			want:      botTemplateRef{ID: id, Version: "9.0.0"},
+		},
+		{
+			name: "ungranted dynamic active does not fall back to the static version",
+			source: &stubAuthorizationSource{newSend: true, auth: map[cardtmpl.ID]cardtmpl.RuntimeAuthorization{
+				id: dynamicAuthorization("9.0.0", false, cardtmpl.RuntimeGrant{}),
+			}},
+			principal: resolvedPrincipal(),
+			want:      botTemplateRef{},
+		},
+		{
+			name: "an exact tombstone denies just like an absent grant",
+			source: &stubAuthorizationSource{newSend: true, auth: map[cardtmpl.ID]cardtmpl.RuntimeAuthorization{
+				id: dynamicAuthorization("9.0.0", false, cardtmpl.RuntimeGrant{
+					Found: true, Scope: cardtmpl.RuntimeGrantScopeExact, Revision: 7,
+				}),
+			}},
+			principal: resolvedPrincipal(),
+			want:      botTemplateRef{},
+		},
+		{
+			name: "blocked dynamic active fails the whole ID closed",
+			source: &stubAuthorizationSource{newSend: true, auth: map[cardtmpl.ID]cardtmpl.RuntimeAuthorization{
+				id: dynamicAuthorization("9.0.0", true, sendGrant()),
+			}},
+			principal: resolvedPrincipal(),
+			want:      botTemplateRef{},
+		},
+		{
+			name:      "a runtime DB failure is an error, not a static fallback",
+			source:    &stubAuthorizationSource{newSend: true, err: errors.New("db unavailable")},
+			principal: resolvedPrincipal(),
+			wantErr:   true,
+		},
+		{
+			name: "a disabled pointer withholds the ID without reverting to static",
+			source: &stubAuthorizationSource{
+				newSend: true, err: cardtmpl.ErrRuntimeCatalogDisabled,
+			},
+			principal: resolvedPrincipal(),
+			want:      botTemplateRef{},
+		},
+		{
+			name: "an unresolved Space withholds the dynamic overlay only",
+			source: &stubAuthorizationSource{newSend: true, auth: map[cardtmpl.ID]cardtmpl.RuntimeAuthorization{
+				id: dynamicAuthorization("9.0.0", false, sendGrant()),
+			}},
+			principal: botCatalogPrincipal{BotID: "bot-42"},
+			want:      botTemplateRef{ID: id, Version: staticVersion},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			catalog := newMustTestCatalog(t)
+			catalog.authorization = test.source
+
+			got, err := catalog.resolveSendRef(context.Background(), test.principal, id)
+			if test.wantErr {
+				if !errors.Is(err, errBotTemplateRuntimeUnavailable) {
+					t.Fatalf("error = %v, want errBotTemplateRuntimeUnavailable", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("resolveSendRef: %v", err)
+			}
+			if got != test.want {
+				t.Fatalf("ref = %+v, want %+v", got, test.want)
+			}
+			if !test.source.newSend && test.source.loads != 0 {
+				t.Fatalf("gate-off resolution issued %d runtime reads, want 0", test.source.loads)
+			}
+		})
+	}
+}
+
+// The manifest and the send path must not be able to disagree. Rather than
+// assert each separately against a hand-written expectation, this drives both
+// off the same state and compares them to each other.
+func TestBotTemplateManifestAndSendAgree(t *testing.T) {
+	id := aireasoningprocess.TemplateID
+	for _, test := range []struct {
+		name   string
+		source *stubAuthorizationSource
+	}{
+		{"gate closed", &stubAuthorizationSource{}},
+		{"granted dynamic", &stubAuthorizationSource{
+			newSend: true,
+			auth: map[cardtmpl.ID]cardtmpl.RuntimeAuthorization{
+				id: dynamicAuthorization("9.0.0", false, sendGrant()),
+			},
+		}},
+		{"ungranted dynamic", &stubAuthorizationSource{
+			newSend: true,
+			auth: map[cardtmpl.ID]cardtmpl.RuntimeAuthorization{
+				id: dynamicAuthorization("9.0.0", false, cardtmpl.RuntimeGrant{}),
+			},
+		}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			catalog := newMustTestCatalog(t)
+			catalog.authorization = test.source
+			principal := resolvedPrincipal()
+
+			advertised, err := catalog.advertisedSendRefs(context.Background(), principal)
+			if err != nil {
+				t.Fatalf("advertisedSendRefs: %v", err)
+			}
+			for _, ref := range advertised {
+				accepted, err := catalog.requireSendableRef(context.Background(), principal,
+					map[string]any{"id": string(ref.ID), "version": ref.Version})
+				if err != nil {
+					t.Fatalf("send refused the advertised ref %+v: %v", ref, err)
+				}
+				if accepted != ref {
+					t.Fatalf("send accepted %+v for advertised %+v", accepted, ref)
+				}
+			}
+			if len(advertised) == 0 {
+				// Nothing advertised means the static version must be refused
+				// too — an advertised-empty manifest with a sendable ref would
+				// be the exact drift this test exists to catch.
+				if _, err := catalog.requireSendableRef(context.Background(), principal, map[string]any{
+					"id": string(id), "version": aireasoningprocess.TemplateVersionV3,
+				}); !errors.Is(err, errBotTemplateRequestInvalid) {
+					t.Fatalf("empty manifest still accepted the static ref: %v", err)
+				}
+			}
+		})
+	}
+}
+
+// A dynamic ref the producer read from an older manifest must be re-checked,
+// not trusted: the send path re-resolves on every call.
+func TestBotTemplateSendRejectsStaleDynamicRef(t *testing.T) {
+	id := aireasoningprocess.TemplateID
+	source := &stubAuthorizationSource{
+		newSend: true,
+		auth: map[cardtmpl.ID]cardtmpl.RuntimeAuthorization{
+			id: dynamicAuthorization("9.0.0", false, sendGrant()),
+		},
+	}
+	catalog := newMustTestCatalog(t)
+	catalog.authorization = source
+	principal := resolvedPrincipal()
+	stale := map[string]any{"id": string(id), "version": "8.0.0"}
+
+	if _, err := catalog.requireSendableRef(context.Background(), principal, stale); !errors.Is(err, errBotTemplateRequestInvalid) {
+		t.Fatalf("stale version error = %v, want errBotTemplateRequestInvalid", err)
+	}
+	// The revoke lands between the manifest read and the send.
+	source.auth[id] = dynamicAuthorization("9.0.0", false, cardtmpl.RuntimeGrant{})
+	if _, err := catalog.requireSendableRef(context.Background(), principal, map[string]any{
+		"id": string(id), "version": "9.0.0",
+	}); !errors.Is(err, errBotTemplateRequestInvalid) {
+		t.Fatalf("revoked ref error = %v, want errBotTemplateRequestInvalid", err)
+	}
+}
+
+// The advertised set is the union of the static policy and the Bot's other
+// granted templates, with the static IDs resolved through the same matrix.
+func TestBotTemplateManifestIncludesGrantedDynamicTemplates(t *testing.T) {
+	extra := cardtmpl.ID("pilot.docs-card")
+	source := &stubAuthorizationSource{
+		newSend: true,
+		auth: map[cardtmpl.ID]cardtmpl.RuntimeAuthorization{
+			aireasoningprocess.TemplateID: {},
+		},
+		granted: []cardtmpl.RuntimeAdvertisedTemplate{
+			{ID: extra, Authorization: cardtmpl.RuntimeAuthorization{
+				Version: "0.4.0",
+				Artifact: cardtmpl.RuntimeArtifactMeta{
+					ID: extra, Version: "0.4.0", Source: cardtmpl.RuntimeSourceDynamic, Owner: "docs",
+				},
+				Grant: sendGrant(),
+			}},
+			{ID: "pilot.blocked", Authorization: cardtmpl.RuntimeAuthorization{
+				Version: "0.1.0",
+				Artifact: cardtmpl.RuntimeArtifactMeta{
+					Source: cardtmpl.RuntimeSourceDynamic, Blocked: true,
+				},
+				Grant: sendGrant(),
+			}},
+		},
+	}
+	catalog := newMustTestCatalog(t)
+	catalog.authorization = source
+
+	refs, err := catalog.advertisedSendRefs(context.Background(), resolvedPrincipal())
+	if err != nil {
+		t.Fatalf("advertisedSendRefs: %v", err)
+	}
+	found := map[cardtmpl.ID]string{}
+	for _, ref := range refs {
+		found[ref.ID] = ref.Version
+	}
+	if found[aireasoningprocess.TemplateID] != aireasoningprocess.TemplateVersionV3 {
+		t.Fatalf("static policy ref missing from %+v", refs)
+	}
+	if found[extra] != "0.4.0" {
+		t.Fatalf("granted dynamic ref missing from %+v", refs)
+	}
+	if _, blocked := found["pilot.blocked"]; blocked {
+		t.Fatalf("blocked template was advertised: %+v", refs)
+	}
+}
+
+// A list failure fails the manifest closed rather than quietly shrinking it to
+// the static policy, which would look identical to "you have no grants".
+func TestBotTemplateManifestFailsClosedOnListError(t *testing.T) {
+	catalog := newMustTestCatalog(t)
+	catalog.authorization = &stubAuthorizationSource{
+		newSend: true,
+		auth: map[cardtmpl.ID]cardtmpl.RuntimeAuthorization{
+			aireasoningprocess.TemplateID: {},
+		},
+		listErr: errors.New("db unavailable"),
+	}
+	if _, err := catalog.advertisedSendRefs(context.Background(), resolvedPrincipal()); !errors.Is(
+		err, errBotTemplateRuntimeUnavailable) {
+		t.Fatalf("list error = %v, want errBotTemplateRuntimeUnavailable", err)
+	}
+}
+
+// The advertised policy must have exactly one send version per template ID:
+// the activation pointer resolves one version per ID, so two would leave
+// "which version does the pointer shadow" undefined.
+func TestBotTemplateCatalogRejectsTwoSendVersionsOfOneID(t *testing.T) {
+	_, err := newBotCardTemplateCatalogWithPolicy(testBotTemplateRegistry(t), botTemplatePolicy{
+		AdvertisedSend: []botTemplateRef{
+			{ID: aireasoningprocess.TemplateID, Version: aireasoningprocess.TemplateVersionV2},
+			{ID: aireasoningprocess.TemplateID, Version: aireasoningprocess.TemplateVersionV3},
+		},
+		EditCompatible: []botTemplateRef{
+			{ID: aireasoningprocess.TemplateID, Version: aireasoningprocess.TemplateVersionV2},
+			{ID: aireasoningprocess.TemplateID, Version: aireasoningprocess.TemplateVersionV3},
+		},
+	})
+	if err == nil {
+		t.Fatal("policy advertising two versions of one template ID was accepted")
+	}
+}
+
+func newGrantSpaceContext(t *testing.T, header string) *wkhttp.Context {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	ginCtx, _ := gin.CreateTestContext(httptest.NewRecorder())
+	ginCtx.Request = httptest.NewRequest("GET", "/v1/bot/card/profile", nil)
+	if header != "" {
+		ginCtx.Request.Header.Set("X-Space-ID", header)
+	}
+	return &wkhttp.Context{Context: ginCtx}
+}
+
+// The grant Space resolver refuses every ambiguity the dispatch-tagging
+// resolver is allowed to paper over.
+func TestResolveBotGrantSpaceIDRefusesEveryAmbiguity(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		header  string
+		querier *fakeSpaceQuerier
+		want    string
+		wantOK  bool
+	}{
+		{
+			name:    "single membership resolves",
+			querier: &fakeSpaceQuerier{multiRows: map[string][]string{"bot-42": {"space-1"}}},
+			want:    "space-1", wantOK: true,
+		},
+		{
+			name:    "multi-Space with no hint refuses instead of picking the first",
+			querier: &fakeSpaceQuerier{multiRows: map[string][]string{"bot-42": {"space-1", "space-2"}}},
+			wantOK:  false,
+		},
+		{
+			name:    "no membership refuses",
+			querier: &fakeSpaceQuerier{defaultErr: dbr.ErrNotFound},
+			wantOK:  false,
+		},
+		{
+			name:    "a DB error refuses rather than falling back",
+			querier: &fakeSpaceQuerier{defaultErr: errors.New("db unavailable")},
+			wantOK:  false,
+		},
+		{
+			name:   "an authorized header is honoured",
+			header: "space-9",
+			querier: &fakeSpaceQuerier{
+				authDefault: true,
+				multiRows:   map[string][]string{"bot-42": {"space-1", "space-2"}},
+			},
+			want: "space-9", wantOK: true,
+		},
+		{
+			name:   "an unauthorized header refuses and never falls through",
+			header: "space-victim",
+			querier: &fakeSpaceQuerier{
+				authDefault: false,
+				multiRows:   map[string][]string{"bot-42": {"space-1"}},
+			},
+			wantOK: false,
+		},
+		{
+			name:   "an unverifiable header refuses",
+			header: "space-9",
+			querier: &fakeSpaceQuerier{
+				authErr:   errors.New("db unavailable"),
+				multiRows: map[string][]string{"bot-42": {"space-1"}},
+			},
+			wantOK: false,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			ba := newTestBotAPI(test.querier)
+			got, ok := ba.resolveBotGrantSpaceID(newGrantSpaceContext(t, test.header), "bot-42")
+			if ok != test.wantOK || got != test.want {
+				t.Fatalf("resolveBotGrantSpaceID = (%q, %v), want (%q, %v)", got, ok, test.want, test.wantOK)
+			}
+		})
+	}
+}
+
+// A card sent into a group is authorized against the group's Space, not the
+// sending Bot's own — otherwise a grant in one tenant would deliver into
+// another.
+func TestBotSendCatalogPrincipalUsesTheTargetGroupSpace(t *testing.T) {
+	querier := &fakeSpaceQuerier{
+		multiRows:   map[string][]string{"bot-42": {"space-bot"}},
+		groupSpaces: map[string]string{"group-1": "space-group"},
+	}
+	ba := newTestBotAPI(querier)
+	ctx := newGrantSpaceContext(t, "")
+
+	principal := ba.botSendCatalogPrincipal(ctx, "bot-42", "group-1", common.ChannelTypeGroup.Uint8())
+	if !principal.SpaceResolved || principal.SpaceID != "space-group" {
+		t.Fatalf("group principal = %+v, want the group's Space", principal)
+	}
+
+	thread := ba.botSendCatalogPrincipal(ctx, "bot-42",
+		"group-1"+threadChannelIDSeparator+"t-9", common.ChannelTypeCommunityTopic.Uint8())
+	if !thread.SpaceResolved || thread.SpaceID != "space-group" {
+		t.Fatalf("thread principal = %+v, want the parent group's Space", thread)
+	}
+
+	// A group with no row, a group outside any Space and a malformed thread
+	// channel all refuse rather than borrowing the Bot's own Space.
+	for _, unresolved := range []botCatalogPrincipal{
+		ba.botSendCatalogPrincipal(ctx, "bot-42", "group-missing", common.ChannelTypeGroup.Uint8()),
+		ba.botSendCatalogPrincipal(ctx, "bot-42", "malformed", common.ChannelTypeCommunityTopic.Uint8()),
+	} {
+		if unresolved.SpaceResolved || unresolved.SpaceID != "" {
+			t.Fatalf("principal = %+v, want unresolved", unresolved)
+		}
+	}
+}

--- a/modules/bot_api/card_template_runtime_test.go
+++ b/modules/bot_api/card_template_runtime_test.go
@@ -466,14 +466,16 @@ func TestResolveBotGrantSpaceIDRefusesEveryAmbiguity(t *testing.T) {
 			wantState: botSpaceUnavailable,
 		},
 		{
-			// Not a refusal: the query ran and answered "none". A Bot attached
-			// to no Space has no exact grants that could shadow a global one, so
-			// global scope is the honest reading — and treating it as an outage
-			// would make every such Bot permanently unable to send a dynamic
-			// template even with a global grant.
-			name:      "no membership is a determination, not an outage",
+			// The previous round read this sentinel as "this Bot belongs to no
+			// Space" and answered GlobalOnly. It cannot mean that: platform App
+			// Bots are authorized for every active Space and never get a
+			// space_member row, so for them "no membership" and "no Space" are
+			// different facts, and answering the second let an X-Space-ID header
+			// choose between a scope that sees an exact revoke tombstone and one
+			// that does not.
+			name:      "no membership is something this resolver could not establish",
 			querier:   &fakeSpaceQuerier{defaultErr: dbr.ErrNotFound},
-			wantState: botSpaceGlobalOnly,
+			wantState: botSpaceUnavailable,
 		},
 		{
 			name:      "a DB error refuses rather than falling back",
@@ -857,6 +859,99 @@ func TestGroupCardStaysEditableAndKeepsItsAuthorizedSpace(t *testing.T) {
 	}
 }
 
+// PR-C review round 5 — yujiawei P1-2.
+//
+// requireEffectiveCardTemplate accepts the envelope's own top-level space_id as
+// a witness for the stored marker. That value is server-authored and pinned by
+// Snapshot, so it is a trustworthy record of what the send wrote — but it is the
+// frame speaking about itself. Matching it proves the frame is internally
+// consistent; it proves nothing about which Space the grant behind *this* edit
+// was read in, and resolveEditRef reads that grant from principal.SpaceID, which
+// for a DM comes from the current request's X-Space-ID header.
+//
+// So while the envelope could substitute for the real comparison, a Bot in
+// Spaces A and B could send a card under A's grant, lose A's edit permission,
+// then rewrite that same card by presenting X-Space-ID: space-B — case 1 failed
+// correctly, and the frame's own "space-A" waved it through. The witness now
+// applies only where no Space was established at all, which is the multi-Space
+// DM lockout it was added for.
+func TestEditRefusesAFrameFromAnotherSpaceEvenWhenTheEnvelopeCorroboratesIt(t *testing.T) {
+	catalog := newMustTestCatalog(t)
+	catalog.authorization = &stubAuthorizationSource{newSend: false}
+
+	principal := botCatalogPrincipal{BotID: "bot-42", SpaceID: "space-a", Space: botSpaceScoped}
+	sent, err := catalog.RenderPayloadForPrincipal(context.Background(), principal,
+		registrySendBody(t, "reasoning", testReasoningData(t, "reasoning"))["payload"].(map[string]any),
+		cardtmpl.BuildEnv{SpaceID: "space-a"})
+	if err != nil {
+		t.Fatalf("DM send: %v", err)
+	}
+	// What the DM send path stamps on the envelope after rendering.
+	sent["space_id"] = "space-a"
+	envelope, err := json.Marshal(sent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ref := botTemplateRef{ID: aireasoningprocess.TemplateID, Version: aireasoningprocess.TemplateVersionV3}
+
+	// The grant behind this edit was read in space-b. The frame's own claim of
+	// space-a must not stand in for the comparison that just failed.
+	if err := requireEffectiveCardTemplate(envelope, ref, "bot-42",
+		verifiableEditSpace("space-b")); !errors.Is(err, errBotTemplateRequestInvalid) {
+		t.Fatalf("cross-Space edit error = %v, want errBotTemplateRequestInvalid", err)
+	}
+	// Authorized in the frame's own Space: accepted, as before.
+	if err := requireEffectiveCardTemplate(envelope, ref, "bot-42",
+		verifiableEditSpace("space-a")); err != nil {
+		t.Fatalf("same-Space edit refused: %v", err)
+	}
+	// And the case the witness exists for is preserved: a multi-Space Bot with
+	// no header establishes no Space, so the envelope is all there is.
+	if err := requireEffectiveCardTemplate(envelope, ref, "bot-42",
+		editSpaceCheck{unavailable: true}); err != nil {
+		t.Fatalf("multi-Space DM edit lost its envelope witness: %v", err)
+	}
+}
+
+// PR-C review round 5 — yujiawei P2-5, and the group half of Octo-Q's C4.
+//
+// space.status = 1 is load-bearing in every other Space resolver in
+// modules/bot_api/db.go — querySpaceIDsByRobotID, both branches of
+// isBotSpaceAuthorized, and isUserSpaceMember all require it. queryGroupSpaceID
+// did not, so a grant scoped to a Space an operator had disabled still
+// authorized sends into that Space's groups, while the same bot's membership,
+// an X-Space-ID naming it, and a DM peer inside it were all refused.
+//
+// A disabled Space is not "no Space" either: answering botSpaceGlobalOnly would
+// let a global grant deliver where the scoped one had just been switched off.
+func TestAGroupInADisabledSpaceHasNoReadableGrantScope(t *testing.T) {
+	querier := &fakeSpaceQuerier{
+		multiRows: map[string][]string{"bot-42": {"space-bot"}},
+		groupSpaces: map[string]string{
+			"group-live":      "space-live",
+			"group-disabled":  "space-disabled",
+			"group-spaceless": "",
+		},
+		inactiveSpaces: map[string]bool{"space-disabled": true},
+	}
+	ba := newTestBotAPIWithCatalog(t, querier, &stubAuthorizationSource{newSend: true})
+	ctx := newGrantSpaceContext(t, "")
+	group := common.ChannelTypeGroup.Uint8()
+
+	if got := ba.botSendCatalogPrincipal(ctx, "bot-42", "group-live", group); got.Space != botSpaceScoped ||
+		got.SpaceID != "space-live" {
+		t.Fatalf("active group principal = %+v, want scoped to space-live", got)
+	}
+	if got := ba.botSendCatalogPrincipal(ctx, "bot-42", "group-disabled", group); got.Space != botSpaceUnavailable ||
+		got.SpaceID != "" {
+		t.Fatalf("disabled-Space group principal = %+v, want unavailable with no Space", got)
+	}
+	// The determination this must stay distinct from.
+	if got := ba.botSendCatalogPrincipal(ctx, "bot-42", "group-spaceless", group); got.Space != botSpaceGlobalOnly {
+		t.Fatalf("Space-less group principal = %+v, want global-only", got)
+	}
+}
+
 // D6 requires *both* DM principals to be valid members of the Space a dynamic
 // send is authorized against. Checking only the Bot would let its own Space's
 // grant deliver a card to somebody outside that Space — a cross-tenant delivery
@@ -901,6 +996,26 @@ func TestDMSendRequiresThePeerToBeInTheAuthorizedSpace(t *testing.T) {
 				memberSpaces: map[string]map[string]bool{"bot-42": {"space-1": true}},
 			},
 			peer: "bot-42", wantState: botSpaceUnavailable,
+		},
+		{
+			// The cell no case in this table could previously construct: every
+			// other one seeds a membership, so the resolver never returned
+			// dbr.ErrNotFound and the DM × "no membership" combination went
+			// unexercised.
+			//
+			// It is the platform App Bot population — visible in every active
+			// Space, never given a space_member row (db.go isBotSpaceAuthorized
+			// branch 2). Reading that absence as "this Bot has no Space" made the
+			// principal global-scoped, which skips requireDMPeerInSpace entirely
+			// and reads the grant with scope_space_id IN ('',''), where an exact
+			// revoke tombstone for the peer's Space is not even visible. Sending
+			// X-Space-ID would have been refused by that tombstone, so omitting
+			// one header selected the more permissive of two answers.
+			name: "a Bot with no membership never becomes global-scoped on a DM",
+			querier: &fakeSpaceQuerier{
+				memberSpaces: map[string]map[string]bool{"user-in": {"space-1": true}},
+			},
+			peer: "user-in", wantState: botSpaceUnavailable,
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {

--- a/modules/bot_api/card_template_runtime_test.go
+++ b/modules/bot_api/card_template_runtime_test.go
@@ -29,6 +29,16 @@ type stubAuthorizationSource struct {
 	err     error
 	granted []cardtmpl.RuntimeAdvertisedTemplate
 	listErr error
+	// grantSpaceID, when set, models an *exact-Space* grant row: the stored
+	// RuntimeGrant reaches only a query whose principal names that Space, and
+	// every other principal sees the same authorization with no grant at all.
+	//
+	// Until this existed the stub answered s.auth[query.ID] for every caller and
+	// ignored query.Principal entirely, so no test in this package could observe
+	// two layers authorizing against different Spaces. That blind spot is how
+	// the ref gate and the render came to disagree about which Space to read a
+	// grant in and stayed that way across three review rounds.
+	grantSpaceID string
 
 	loads   int
 	queries []cardtmpl.RuntimeAuthorizationQuery
@@ -43,7 +53,11 @@ func (s *stubAuthorizationSource) LoadAuthorization(
 	if s.err != nil {
 		return cardtmpl.RuntimeAuthorization{}, s.err
 	}
-	return s.auth[query.ID], nil
+	auth := s.auth[query.ID]
+	if s.grantSpaceID != "" && query.Principal.SpaceID != s.grantSpaceID {
+		auth.Grant = cardtmpl.RuntimeGrant{}
+	}
+	return auth, nil
 }
 
 func (s *stubAuthorizationSource) ListAuthorizedTemplates(
@@ -77,8 +91,17 @@ func sendGrant() cardtmpl.RuntimeGrant {
 	}
 }
 
+// globalSendGrant is the row a Space-less target can still be authorized by:
+// the store has already applied exact-over-global precedence, so what reaches
+// the decision is a grant whose scope is the empty sentinel.
+func globalSendGrant() cardtmpl.RuntimeGrant {
+	return cardtmpl.RuntimeGrant{
+		Found: true, Scope: cardtmpl.RuntimeGrantScopeGlobal, Revision: 2, Discover: true, Send: true,
+	}
+}
+
 func resolvedPrincipal() botCatalogPrincipal {
-	return botCatalogPrincipal{BotID: "bot-42", SpaceID: "space-1", SpaceResolved: true}
+	return botCatalogPrincipal{BotID: "bot-42", SpaceID: "space-1", Space: botSpaceScoped}
 }
 
 func TestBotTemplateSendRefFollowsTheShadowMatrix(t *testing.T) {
@@ -183,12 +206,41 @@ func TestBotTemplateSendRefFollowsTheShadowMatrix(t *testing.T) {
 			want:      botTemplateRef{},
 		},
 		{
-			name: "an unresolved Space withholds the dynamic overlay only",
+			// The row this replaces asserted the opposite, and two reviewers
+			// cited it as codifying the bug: an unavailable Space short-circuited
+			// to static policy *before* the pointer was ever read, so a group-row
+			// read that timed out sent the static card of an ID an operator had
+			// already replaced. The pointer is a fact about the template, not
+			// about the caller, so it is read either way; only the grant needs a
+			// scope to be read in.
+			name: "an unavailable Space does not revert a shadowed ID to static",
 			source: &stubAuthorizationSource{newSend: true, auth: map[cardtmpl.ID]cardtmpl.RuntimeAuthorization{
 				id: dynamicAuthorization("9.0.0", false, sendGrant()),
 			}},
 			principal: botCatalogPrincipal{BotID: "bot-42"},
+			want:      botTemplateRef{},
+		},
+		{
+			// The other half of the same rule: withholding static is warranted
+			// only because something shadowed it. With no activation row the
+			// static policy is still the whole truth, unavailable Space or not,
+			// and refusing here would take down cards nothing had replaced.
+			name: "an unavailable Space still answers static when nothing shadows the ID",
+			source: &stubAuthorizationSource{newSend: true, auth: map[cardtmpl.ID]cardtmpl.RuntimeAuthorization{
+				id: {},
+			}},
+			principal: botCatalogPrincipal{BotID: "bot-42"},
 			want:      botTemplateRef{ID: id, Version: staticVersion},
+		},
+		{
+			// A group that belongs to no Space is a determination, not a
+			// failure. Only global grants can apply to it, and one does.
+			name: "a Space-less target is authorized by a global grant",
+			source: &stubAuthorizationSource{newSend: true, auth: map[cardtmpl.ID]cardtmpl.RuntimeAuthorization{
+				id: dynamicAuthorization("9.0.0", false, globalSendGrant()),
+			}},
+			principal: botCatalogPrincipal{BotID: "bot-42", Space: botSpaceGlobalOnly},
+			want:      botTemplateRef{ID: id, Version: "9.0.0"},
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
@@ -397,31 +449,36 @@ func newGrantSpaceContext(t *testing.T, header string) *wkhttp.Context {
 // resolver is allowed to paper over.
 func TestResolveBotGrantSpaceIDRefusesEveryAmbiguity(t *testing.T) {
 	for _, test := range []struct {
-		name    string
-		header  string
-		querier *fakeSpaceQuerier
-		want    string
-		wantOK  bool
+		name      string
+		header    string
+		querier   *fakeSpaceQuerier
+		want      string
+		wantState botCatalogSpaceState
 	}{
 		{
 			name:    "single membership resolves",
 			querier: &fakeSpaceQuerier{multiRows: map[string][]string{"bot-42": {"space-1"}}},
-			want:    "space-1", wantOK: true,
+			want:    "space-1", wantState: botSpaceScoped,
 		},
 		{
-			name:    "multi-Space with no hint refuses instead of picking the first",
-			querier: &fakeSpaceQuerier{multiRows: map[string][]string{"bot-42": {"space-1", "space-2"}}},
-			wantOK:  false,
+			name:      "multi-Space with no hint refuses instead of picking the first",
+			querier:   &fakeSpaceQuerier{multiRows: map[string][]string{"bot-42": {"space-1", "space-2"}}},
+			wantState: botSpaceUnavailable,
 		},
 		{
-			name:    "no membership refuses",
-			querier: &fakeSpaceQuerier{defaultErr: dbr.ErrNotFound},
-			wantOK:  false,
+			// Not a refusal: the query ran and answered "none". A Bot attached
+			// to no Space has no exact grants that could shadow a global one, so
+			// global scope is the honest reading — and treating it as an outage
+			// would make every such Bot permanently unable to send a dynamic
+			// template even with a global grant.
+			name:      "no membership is a determination, not an outage",
+			querier:   &fakeSpaceQuerier{defaultErr: dbr.ErrNotFound},
+			wantState: botSpaceGlobalOnly,
 		},
 		{
-			name:    "a DB error refuses rather than falling back",
-			querier: &fakeSpaceQuerier{defaultErr: errors.New("db unavailable")},
-			wantOK:  false,
+			name:      "a DB error refuses rather than falling back",
+			querier:   &fakeSpaceQuerier{defaultErr: errors.New("db unavailable")},
+			wantState: botSpaceUnavailable,
 		},
 		{
 			name:   "an authorized header is honoured",
@@ -430,7 +487,7 @@ func TestResolveBotGrantSpaceIDRefusesEveryAmbiguity(t *testing.T) {
 				authDefault: true,
 				multiRows:   map[string][]string{"bot-42": {"space-1", "space-2"}},
 			},
-			want: "space-9", wantOK: true,
+			want: "space-9", wantState: botSpaceScoped,
 		},
 		{
 			name:   "an unauthorized header refuses and never falls through",
@@ -439,7 +496,7 @@ func TestResolveBotGrantSpaceIDRefusesEveryAmbiguity(t *testing.T) {
 				authDefault: false,
 				multiRows:   map[string][]string{"bot-42": {"space-1"}},
 			},
-			wantOK: false,
+			wantState: botSpaceUnavailable,
 		},
 		{
 			name:   "an unverifiable header refuses",
@@ -448,14 +505,14 @@ func TestResolveBotGrantSpaceIDRefusesEveryAmbiguity(t *testing.T) {
 				authErr:   errors.New("db unavailable"),
 				multiRows: map[string][]string{"bot-42": {"space-1"}},
 			},
-			wantOK: false,
+			wantState: botSpaceUnavailable,
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			ba := newTestBotAPI(test.querier)
-			got, ok := ba.resolveBotGrantSpaceID(newGrantSpaceContext(t, test.header), "bot-42")
-			if ok != test.wantOK || got != test.want {
-				t.Fatalf("resolveBotGrantSpaceID = (%q, %v), want (%q, %v)", got, ok, test.want, test.wantOK)
+			got, state := ba.resolveBotGrantSpaceID(newGrantSpaceContext(t, test.header), "bot-42")
+			if state != test.wantState || got != test.want {
+				t.Fatalf("resolveBotGrantSpaceID = (%q, %v), want (%q, %v)", got, state, test.want, test.wantState)
 			}
 		})
 	}
@@ -480,13 +537,13 @@ func TestBotSendCatalogPrincipalUsesTheTargetGroupSpace(t *testing.T) {
 	ctx := newGrantSpaceContext(t, "")
 
 	principal := ba.botSendCatalogPrincipal(ctx, "bot-42", "group-1", common.ChannelTypeGroup.Uint8())
-	if !principal.SpaceResolved || principal.SpaceID != "space-group" {
+	if principal.Space != botSpaceScoped || principal.SpaceID != "space-group" {
 		t.Fatalf("group principal = %+v, want the group's Space", principal)
 	}
 
 	thread := ba.botSendCatalogPrincipal(ctx, "bot-42",
 		"group-1"+threadChannelIDSeparator+"t-9", common.ChannelTypeCommunityTopic.Uint8())
-	if !thread.SpaceResolved || thread.SpaceID != "space-group" {
+	if thread.Space != botSpaceScoped || thread.SpaceID != "space-group" {
 		t.Fatalf("thread principal = %+v, want the parent group's Space", thread)
 	}
 
@@ -496,7 +553,7 @@ func TestBotSendCatalogPrincipalUsesTheTargetGroupSpace(t *testing.T) {
 		ba.botSendCatalogPrincipal(ctx, "bot-42", "group-missing", common.ChannelTypeGroup.Uint8()),
 		ba.botSendCatalogPrincipal(ctx, "bot-42", "malformed", common.ChannelTypeCommunityTopic.Uint8()),
 	} {
-		if unresolved.SpaceResolved || unresolved.SpaceID != "" {
+		if unresolved.Space != botSpaceUnavailable || unresolved.SpaceID != "" {
 			t.Fatalf("principal = %+v, want unresolved", unresolved)
 		}
 	}
@@ -518,11 +575,11 @@ func TestBotCatalogPrincipalSkipsSpaceLookupWhenTheCatalogIsDark(t *testing.T) {
 		ba := newTestBotAPIWithCatalog(t, querier, source)
 
 		principal := ba.botCatalogPrincipalFor(ctx, "bot-42")
-		if principal.SpaceResolved || principal.SpaceID != "" {
+		if principal.Space != botSpaceUnavailable || principal.SpaceID != "" {
 			t.Fatalf("dark catalog resolved a Space: %+v", principal)
 		}
 		send := ba.botSendCatalogPrincipal(ctx, "bot-42", "group-1", common.ChannelTypeGroup.Uint8())
-		if send.SpaceResolved || send.SpaceID != "" {
+		if send.Space != botSpaceUnavailable || send.SpaceID != "" {
 			t.Fatalf("dark catalog resolved a send Space: %+v", send)
 		}
 		if len(querier.calls) != 0 {
@@ -531,7 +588,7 @@ func TestBotCatalogPrincipalSkipsSpaceLookupWhenTheCatalogIsDark(t *testing.T) {
 	}
 
 	enabled := newTestBotAPIWithCatalog(t, querier, &stubAuthorizationSource{newSend: true})
-	if principal := enabled.botCatalogPrincipalFor(ctx, "bot-42"); !principal.SpaceResolved {
+	if principal := enabled.botCatalogPrincipalFor(ctx, "bot-42"); principal.Space != botSpaceScoped {
 		t.Fatalf("enabled catalog did not resolve a Space: %+v", principal)
 	}
 }
@@ -540,6 +597,158 @@ func TestBotCatalogPrincipalSkipsSpaceLookupWhenTheCatalogIsDark(t *testing.T) {
 // given resolver. The gate and the decision both read the catalog's accessor,
 // so a test that set only the process global would be exercising a path
 // production never takes.
+// grantEnforcingCatalog models the one thing cardtmpl.RuntimeCatalog.Render
+// does that the static test registry does not: it re-resolves the caller's
+// grant from request.Access, the way resolveDynamic does before it will render a
+// dynamic version. The static registry renders whatever it is given, so without
+// this model the render half of an authorization is invisible to this package —
+// and an invisible half is precisely what let the gate and the render disagree.
+type grantEnforcingCatalog struct {
+	cardtmpl.Catalog
+	source     *stubAuthorizationSource
+	lastRender cardtmpl.CatalogRenderRequest
+}
+
+func (c *grantEnforcingCatalog) Render(
+	ctx context.Context,
+	request cardtmpl.CatalogRenderRequest,
+) (map[string]any, error) {
+	c.lastRender = request
+	auth, err := c.source.LoadAuthorization(ctx, cardtmpl.RuntimeAuthorizationQuery{
+		ID: request.ID, Version: request.Version, Principal: request.Access.Principal,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if !auth.Grant.Allows(request.Access.Purpose) {
+		return nil, cardtmpl.ErrRuntimeCatalogNotAuthorized
+	}
+	return map[string]any{
+		"type":         cardmsg.InteractiveCard.Int(),
+		"card_version": cardmsg.CardVersion,
+		"card":         map[string]any{"type": "AdaptiveCard", "body": []any{}},
+	}, nil
+}
+
+// PR-C review round 4 — Jerry-Xin "Critical 2" and yujiawei P1-1, found
+// independently by both.
+//
+// requireSendableRef resolves the grant against the *target's* Space, which for
+// a group comes from the authoritative group row. renderPayload then hands the
+// ref to cardtmpl.Render, which re-resolves the grant from request.Access — and
+// used to compose that Access from env.SpaceID, which send.go populates for DMs
+// only. So a Bot holding an exact grant for the target's Space passed the gate
+// and was then refused by the render, and per-Space grants — the primary Bot
+// grant shape, and the entire reason resolveBotGrantSpaceID exists — were inert
+// for every group and thread target.
+//
+// Reverting renderPayload to botCatalogAccess(purpose, botID, env.SpaceID)
+// fails this test with ErrRuntimeCatalogNotAuthorized.
+func TestGroupSendAuthorizesTheRenderWithTheSameSpaceAsTheGate(t *testing.T) {
+	const groupSpace = "space-group"
+	const dynamicVersion = "9.0.0"
+	id := aireasoningprocess.TemplateID
+
+	source := &stubAuthorizationSource{
+		newSend: true,
+		auth: map[cardtmpl.ID]cardtmpl.RuntimeAuthorization{
+			id: dynamicAuthorization(dynamicVersion, false, sendGrant()),
+		},
+		// An exact row for the group's Space and no global row: the shape
+		// TestGrantsDoNotLeakBetweenBotsRealMySQL exists to protect, and the
+		// only one that can express a per-tenant grant.
+		grantSpaceID: groupSpace,
+	}
+	querier := &fakeSpaceQuerier{
+		// Deliberately different from the group's Space, so a render that fell
+		// back to the *sender's* membership would also be caught.
+		multiRows:   map[string][]string{"bot-42": {"space-bot"}},
+		groupSpaces: map[string]string{"group-1": groupSpace},
+	}
+	ba := newTestBotAPIWithCatalog(t, querier, source)
+	rendering := &grantEnforcingCatalog{source: source}
+	ba.cardTemplates.catalog = rendering
+
+	principal := ba.botSendCatalogPrincipal(newGrantSpaceContext(t, ""), "bot-42",
+		"group-1", common.ChannelTypeGroup.Uint8())
+	if principal.Space != botSpaceScoped || principal.SpaceID != groupSpace {
+		t.Fatalf("gate principal = %+v, want the group's Space %q", principal, groupSpace)
+	}
+
+	// BuildEnv carries no Space, exactly as send.go leaves it for a group
+	// target — that emptiness is what the render used to authorize with.
+	rendered, err := ba.cardTemplates.RenderPayloadForPrincipal(context.Background(), principal,
+		map[string]any{
+			"type":         cardmsg.InteractiveCard.Int(),
+			"template_ref": map[string]any{"id": string(id), "version": dynamicVersion},
+			"state":        "thinking",
+			"data":         map[string]any{"title": "t"},
+		}, cardtmpl.BuildEnv{})
+	if err != nil {
+		t.Fatalf("group dynamic send refused: %v", err)
+	}
+
+	// The ground truth: the Space the render authorized against is the one the
+	// gate decided on, not env.SpaceID and not the sender's own membership.
+	if got := rendering.lastRender.Access.Principal.SpaceID; got != groupSpace {
+		t.Fatalf("render authorized against Space %q, gate used %q", got, groupSpace)
+	}
+	if got := rendering.lastRender.Access.Principal.ID; got != "bot-42" {
+		t.Fatalf("render principal ID = %q, want the authenticated bot", got)
+	}
+	if got := rendering.lastRender.Access.Purpose; got != cardtmpl.CatalogPurposeNewSend {
+		t.Fatalf("render purpose = %v, want new_send", got)
+	}
+	// The marker records that same authorized Space, so the D3 guards
+	// downstream compare against what the send was actually authorized for.
+	provenance, _ := rendered[cardmsg.CatalogProvenanceKey].(map[string]any)
+	if got, _ := provenance["space_id"].(string); got != groupSpace {
+		t.Fatalf("provenance space = %q, want %q", got, groupSpace)
+	}
+}
+
+// The edit half of the same seam: resolveEditRef pins the stored version and
+// authorizes it against the principal's Space, so the render that follows must
+// use that Space too or a per-Space `edit` grant is just as inert as the send
+// one was.
+func TestGroupEditAuthorizesTheRenderWithTheSameSpaceAsTheGate(t *testing.T) {
+	const groupSpace = "space-group"
+	const dynamicVersion = "9.0.0"
+	id := aireasoningprocess.TemplateID
+
+	source := &stubAuthorizationSource{
+		newSend: true,
+		auth: map[cardtmpl.ID]cardtmpl.RuntimeAuthorization{
+			id: dynamicAuthorization(dynamicVersion, false, cardtmpl.RuntimeGrant{
+				Found: true, Scope: cardtmpl.RuntimeGrantScopeExact,
+				Revision: 4, Discover: true, Send: true, Edit: true,
+			}),
+		},
+		grantSpaceID: groupSpace,
+	}
+	catalog := newMustTestCatalog(t)
+	catalog.authorization = source
+	rendering := &grantEnforcingCatalog{source: source}
+	catalog.catalog = rendering
+
+	principal := botCatalogPrincipal{BotID: "bot-42", SpaceID: groupSpace, Space: botSpaceScoped}
+	if _, err := catalog.RenderEditPayloadForPrincipal(context.Background(), principal,
+		map[string]any{
+			"type":         cardmsg.InteractiveCard.Int(),
+			"template_ref": map[string]any{"id": string(id), "version": dynamicVersion},
+			"state":        "thinking",
+			"data":         map[string]any{"title": "t"},
+		}, cardtmpl.BuildEnv{}, groupSpace); err != nil {
+		t.Fatalf("group dynamic edit refused: %v", err)
+	}
+	if got := rendering.lastRender.Access.Principal.SpaceID; got != groupSpace {
+		t.Fatalf("edit render authorized against Space %q, want %q", got, groupSpace)
+	}
+	if got := rendering.lastRender.Access.Purpose; got != cardtmpl.CatalogPurposeHistoricalEdit {
+		t.Fatalf("edit render purpose = %v, want historical_edit", got)
+	}
+}
+
 func newTestBotAPIWithCatalog(
 	t *testing.T,
 	querier botSpaceQuerier,
@@ -559,7 +768,7 @@ func newTestBotAPIWithCatalog(
 // three downstream D3 guards are written as `if SpaceID != ""`, so they became
 // no-ops for exactly the frames that cross Space boundaries.
 func TestProvenanceSpacePrefersTheAuthorizedSpaceOverTheRenderEnv(t *testing.T) {
-	group := botCatalogPrincipal{BotID: "bot-42", SpaceID: "space-group", SpaceResolved: true}
+	group := botCatalogPrincipal{BotID: "bot-42", SpaceID: "space-group", Space: botSpaceScoped}
 	if got := provenanceSpaceID(group, cardtmpl.BuildEnv{}); got != "space-group" {
 		t.Fatalf("group provenance Space = %q, want the authorized Space", got)
 	}
@@ -655,11 +864,11 @@ func TestGroupCardStaysEditableAndKeepsItsAuthorizedSpace(t *testing.T) {
 func TestDMSendRequiresThePeerToBeInTheAuthorizedSpace(t *testing.T) {
 	dm := common.ChannelTypePerson.Uint8()
 	for _, test := range []struct {
-		name       string
-		querier    *fakeSpaceQuerier
-		peer       string
-		wantSpace  string
-		wantResolv bool
+		name      string
+		querier   *fakeSpaceQuerier
+		peer      string
+		wantSpace string
+		wantState botCatalogSpaceState
 	}{
 		{
 			name: "peer in the Bot's Space authorizes the send",
@@ -667,7 +876,7 @@ func TestDMSendRequiresThePeerToBeInTheAuthorizedSpace(t *testing.T) {
 				multiRows:    map[string][]string{"bot-42": {"space-1"}},
 				memberSpaces: map[string]map[string]bool{"user-in": {"space-1": true}},
 			},
-			peer: "user-in", wantSpace: "space-1", wantResolv: true,
+			peer: "user-in", wantSpace: "space-1", wantState: botSpaceScoped,
 		},
 		{
 			name: "peer outside the Space withholds the dynamic overlay",
@@ -675,7 +884,7 @@ func TestDMSendRequiresThePeerToBeInTheAuthorizedSpace(t *testing.T) {
 				multiRows:    map[string][]string{"bot-42": {"space-1"}},
 				memberSpaces: map[string]map[string]bool{"user-in": {"space-1": true}},
 			},
-			peer: "user-elsewhere", wantResolv: false,
+			peer: "user-elsewhere", wantState: botSpaceUnavailable,
 		},
 		{
 			name: "a peer membership lookup failure refuses rather than assumes",
@@ -683,7 +892,7 @@ func TestDMSendRequiresThePeerToBeInTheAuthorizedSpace(t *testing.T) {
 				multiRows:      map[string][]string{"bot-42": {"space-1"}},
 				memberSpaceErr: errors.New("db unavailable"),
 			},
-			peer: "user-in", wantResolv: false,
+			peer: "user-in", wantState: botSpaceUnavailable,
 		},
 		{
 			name: "a self-addressed channel is not a peer",
@@ -691,15 +900,15 @@ func TestDMSendRequiresThePeerToBeInTheAuthorizedSpace(t *testing.T) {
 				multiRows:    map[string][]string{"bot-42": {"space-1"}},
 				memberSpaces: map[string]map[string]bool{"bot-42": {"space-1": true}},
 			},
-			peer: "bot-42", wantResolv: false,
+			peer: "bot-42", wantState: botSpaceUnavailable,
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			ba := newTestBotAPIWithCatalog(t, test.querier, &stubAuthorizationSource{newSend: true})
 			got := ba.botSendCatalogPrincipal(newGrantSpaceContext(t, ""), "bot-42", test.peer, dm)
-			if got.SpaceResolved != test.wantResolv || got.SpaceID != test.wantSpace {
-				t.Fatalf("DM principal = %+v, want space=%q resolved=%v",
-					got, test.wantSpace, test.wantResolv)
+			if got.Space != test.wantState || got.SpaceID != test.wantSpace {
+				t.Fatalf("DM principal = %+v, want space=%q state=%v",
+					got, test.wantSpace, test.wantState)
 			}
 		})
 	}
@@ -711,7 +920,7 @@ func TestDMPeerCheckIsSkippedWhenTheCatalogIsDark(t *testing.T) {
 	querier := &fakeSpaceQuerier{multiRows: map[string][]string{"bot-42": {"space-1"}}}
 	ba := newTestBotAPIWithCatalog(t, querier, &stubAuthorizationSource{newSend: false})
 	if got := ba.botSendCatalogPrincipal(newGrantSpaceContext(t, ""), "bot-42",
-		"user-in", common.ChannelTypePerson.Uint8()); got.SpaceResolved {
+		"user-in", common.ChannelTypePerson.Uint8()); got.Space == botSpaceScoped {
 		t.Fatalf("dark catalog resolved a DM Space: %+v", got)
 	}
 	if len(querier.calls) != 0 {
@@ -724,7 +933,7 @@ func TestDMPeerCheckIsSkippedWhenTheCatalogIsDark(t *testing.T) {
 // uneditable the first time; this covers the general form rather than the one
 // path that was reported.
 func TestEditSpaceCheckSeparatesUnknownFromEmpty(t *testing.T) {
-	resolved := botCatalogPrincipal{BotID: "bot-1", SpaceID: "space-a", SpaceResolved: true}
+	resolved := botCatalogPrincipal{BotID: "bot-1", SpaceID: "space-a", Space: botSpaceScoped}
 	unresolved := botCatalogPrincipal{BotID: "bot-1"}
 
 	if got := editProvenanceSpaceCheck(true, resolved); !got.verifiable || got.unavailable ||
@@ -758,7 +967,7 @@ func TestGroupCardStaysEditableAcrossAGateRollback(t *testing.T) {
 	catalog := ba.cardTemplates
 
 	principal := ba.botSendCatalogPrincipal(ctx, "bot-42", "group-1", common.ChannelTypeGroup.Uint8())
-	if !principal.SpaceResolved || principal.SpaceID != "space-group" {
+	if principal.Space != botSpaceScoped || principal.SpaceID != "space-group" {
 		t.Fatalf("send principal = %+v", principal)
 	}
 	sent, err := catalog.RenderPayloadForPrincipal(context.Background(), principal,
@@ -847,7 +1056,7 @@ func TestAdvertisedSendRefsBatchesAndAgreesWithThePerIDPath(t *testing.T) {
 	}
 	perID := &stubAuthorizationSource{newSend: true, auth: authorizations}
 
-	principal := botCatalogPrincipal{BotID: "bot-1", SpaceID: "space-1", SpaceResolved: true}
+	principal := botCatalogPrincipal{BotID: "bot-1", SpaceID: "space-1", Space: botSpaceScoped}
 	batchedCatalog := newMustTestCatalog(t)
 	batchedCatalog.authorization = batched
 	perIDCatalog := newMustTestCatalog(t)
@@ -901,7 +1110,7 @@ func TestAdvertisedSendRefsFailsClosedWhenTheBatchReadFails(t *testing.T) {
 	catalog := newMustTestCatalog(t)
 	catalog.authorization = batched
 	_, err := catalog.advertisedSendRefs(context.Background(),
-		botCatalogPrincipal{BotID: "bot-1", SpaceID: "space-1", SpaceResolved: true})
+		botCatalogPrincipal{BotID: "bot-1", SpaceID: "space-1", Space: botSpaceScoped})
 	if !errors.Is(err, errBotTemplateRuntimeUnavailable) {
 		t.Fatalf("err = %v, want errBotTemplateRuntimeUnavailable", err)
 	}
@@ -920,7 +1129,7 @@ func TestDMCardStaysEditableWhenTheStrictResolverCannotAgree(t *testing.T) {
 
 	// Ambiguous membership: the grant principal refuses to resolve.
 	principal := ba.botSendCatalogPrincipal(ctx, "bot-42", "peer-1", common.ChannelTypePerson.Uint8())
-	if principal.SpaceResolved {
+	if principal.Space == botSpaceScoped {
 		t.Fatalf("a two-Space Bot resolved a grant Space: %+v", principal)
 	}
 	// The DM send path still injects the forgiving resolver's Space, and the
@@ -1032,13 +1241,13 @@ func TestDecideSendRefRefusesADisabledPointerFromTheBatch(t *testing.T) {
 	disabled := cardtmpl.RuntimeAuthorization{
 		Activation: cardtmpl.RuntimeActivation{Exists: true, Status: cardtmpl.RuntimeActivationDisabled},
 	}
-	if ref := catalog.decideSendRef(aireasoningprocess.TemplateID, staticRef, true, disabled); ref.ID != "" {
+	if ref := catalog.decideSendRef(aireasoningprocess.TemplateID, staticRef, true, disabled, botSpaceScoped); ref.ID != "" {
 		t.Fatalf("a disabled pointer fell back to the static version: %+v", ref)
 	}
 	// And it is the *disabled status* doing the work, not the empty version: a
 	// template with no activation row at all still keeps its static version.
 	none := cardtmpl.RuntimeAuthorization{}
-	if ref := catalog.decideSendRef(aireasoningprocess.TemplateID, staticRef, true, none); ref != staticRef {
+	if ref := catalog.decideSendRef(aireasoningprocess.TemplateID, staticRef, true, none, botSpaceScoped); ref != staticRef {
 		t.Fatalf("an unactivated template lost its static version: %+v", ref)
 	}
 }
@@ -1051,7 +1260,7 @@ func TestDecideSendRefRefusesADisabledPointerFromTheBatch(t *testing.T) {
 // dead end.
 func TestBotEditResolvesADynamicRefThroughTheEditGrant(t *testing.T) {
 	dynamicRef := botTemplateRef{ID: aireasoningprocess.TemplateID, Version: "9.9.9-dyn"}
-	principal := botCatalogPrincipal{BotID: "bot-1", SpaceID: "space-1", SpaceResolved: true}
+	principal := botCatalogPrincipal{BotID: "bot-1", SpaceID: "space-1", Space: botSpaceScoped}
 	authorized := func(grant cardtmpl.RuntimeGrant) *stubAuthorizationSource {
 		return &stubAuthorizationSource{
 			newSend: true,

--- a/modules/bot_api/card_template_runtime_test.go
+++ b/modules/bot_api/card_template_runtime_test.go
@@ -623,7 +623,8 @@ func TestGroupCardStaysEditableAndKeepsItsAuthorizedSpace(t *testing.T) {
 
 	// And the re-stamped marker keeps the Space rather than blanking it.
 	edited, err := catalog.RenderEditPayloadForPrincipal(context.Background(), editPrincipal,
-		registrySendBody(t, "reasoning", testReasoningData(t, "reasoning"))["payload"].(map[string]any), env)
+		registrySendBody(t, "reasoning", testReasoningData(t, "reasoning"))["payload"].(map[string]any), env,
+		storedProvenanceSpaceID(envelope))
 	if err != nil {
 		t.Fatalf("group edit: %v", err)
 	}
@@ -901,5 +902,141 @@ func TestAdvertisedSendRefsFailsClosedWhenTheBatchReadFails(t *testing.T) {
 		botCatalogPrincipal{BotID: "bot-1", SpaceID: "space-1", SpaceResolved: true})
 	if !errors.Is(err, errBotTemplateRuntimeUnavailable) {
 		t.Fatalf("err = %v, want errBotTemplateRuntimeUnavailable", err)
+	}
+}
+
+// A Bot that belongs to two Spaces can never satisfy the strict grant resolver
+// — the ambiguity is a permanent property of that Bot, not a blip. Its DM sends
+// still stamp a marker, from the forgiving resolver that also fills the
+// envelope's space_id. If the edit guard only ever consulted the strict
+// resolver, every one of those cards would be uneditable forever.
+func TestDMCardStaysEditableWhenTheStrictResolverCannotAgree(t *testing.T) {
+	ba := newTestBotAPIWithCatalog(t, &fakeSpaceQuerier{
+		multiRows: map[string][]string{"bot-42": {"space-one", "space-two"}},
+	}, &stubAuthorizationSource{newSend: true})
+	ctx := newGrantSpaceContext(t, "")
+
+	// Ambiguous membership: the grant principal refuses to resolve.
+	principal := ba.botSendCatalogPrincipal(ctx, "bot-42", "peer-1", common.ChannelTypePerson.Uint8())
+	if principal.SpaceResolved {
+		t.Fatalf("a two-Space Bot resolved a grant Space: %+v", principal)
+	}
+	// The DM send path still injects the forgiving resolver's Space, and the
+	// marker is stamped from the same value.
+	env := cardtmpl.BuildEnv{Lang: "zh-CN", SpaceID: "space-one"}
+	sent, err := ba.cardTemplates.RenderPayloadForPrincipal(context.Background(), principal,
+		registrySendBody(t, "reasoning", testReasoningData(t, "reasoning"))["payload"].(map[string]any), env)
+	if err != nil {
+		t.Fatalf("dm send: %v", err)
+	}
+	sent = ba.enrichBotPayloadWithResolvedSpaceID("bot-42", sent, "space-one")
+	envelope, err := json.Marshal(sent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	markers, err := cardmsg.CatalogFrameMarkers(envelope)
+	if err != nil {
+		t.Fatalf("stored markers: %v", err)
+	}
+	if markers.Provenance.SpaceID != "space-one" {
+		t.Fatalf("dm marker Space = %q", markers.Provenance.SpaceID)
+	}
+
+	ref := botTemplateRef{ID: aireasoningprocess.TemplateID, Version: aireasoningprocess.TemplateVersionV3}
+	check := editProvenanceSpaceCheck(true, principal)
+	if !check.unavailable {
+		t.Fatalf("expected the strict resolver to report unavailable, got %+v", check)
+	}
+	if err := requireEffectiveCardTemplate(envelope, ref, "bot-42", check); err != nil {
+		t.Fatalf("a multi-Space Bot was locked out of editing its own DM card: %v", err)
+	}
+
+	// A marker naming a Space the envelope does not corroborate is still
+	// refused — the envelope is a witness, not a bypass.
+	forged := map[string]any{}
+	if err := json.Unmarshal(envelope, &forged); err != nil {
+		t.Fatal(err)
+	}
+	forged["space_id"] = "space-elsewhere"
+	forgedEnvelope, err := json.Marshal(forged)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := requireEffectiveCardTemplate(forgedEnvelope, ref, "bot-42", check); err == nil {
+		t.Fatal("a marker contradicting both witnesses was accepted")
+	}
+}
+
+// An edit preserves the Space the send recorded. Re-deriving it means the answer
+// depends on whether the resolver happens to work at edit time, so a gate
+// rollback would rewrite the card with an empty Space and quietly disable every
+// downstream `if Provenance.SpaceID != ""` guard for it.
+func TestEditPreservesTheStoredProvenanceSpaceEvenWhenTheGateIsDark(t *testing.T) {
+	ba := newTestBotAPIWithCatalog(t, &fakeSpaceQuerier{
+		multiRows:   map[string][]string{"bot-42": {"space-bot"}},
+		groupSpaces: map[string]string{"group-1": "space-group"},
+	}, &stubAuthorizationSource{newSend: true})
+	ctx := newGrantSpaceContext(t, "")
+	catalog := ba.cardTemplates
+
+	principal := ba.botSendCatalogPrincipal(ctx, "bot-42", "group-1", common.ChannelTypeGroup.Uint8())
+	sent, err := catalog.RenderPayloadForPrincipal(context.Background(), principal,
+		registrySendBody(t, "reasoning", testReasoningData(t, "reasoning"))["payload"].(map[string]any),
+		cardtmpl.BuildEnv{Lang: "zh-CN"})
+	if err != nil {
+		t.Fatalf("group send: %v", err)
+	}
+	envelope, err := json.Marshal(sent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := storedProvenanceSpaceID(envelope); got != "space-group" {
+		t.Fatalf("stored Space = %q", got)
+	}
+
+	// The gate is rolled back: no principal Space, and a group envelope has no
+	// top-level space_id to fall back to either.
+	dark := botCatalogPrincipal{BotID: "bot-42"}
+	edited, err := catalog.RenderEditPayloadForPrincipal(context.Background(), dark,
+		registrySendBody(t, "reasoning", testReasoningData(t, "reasoning"))["payload"].(map[string]any),
+		cardtmpl.BuildEnv{Lang: "zh-CN"}, storedProvenanceSpaceID(envelope))
+	if err != nil {
+		t.Fatalf("dark-gate edit: %v", err)
+	}
+	editedEnvelope, err := json.Marshal(edited)
+	if err != nil {
+		t.Fatal(err)
+	}
+	editedMarkers, err := cardmsg.CatalogFrameMarkers(editedEnvelope)
+	if err != nil {
+		t.Fatalf("edited markers: %v", err)
+	}
+	if editedMarkers.Provenance.SpaceID != "space-group" {
+		t.Fatalf("the edit rewrote the Space to %q, erasing the send's record",
+			editedMarkers.Provenance.SpaceID)
+	}
+}
+
+// The batch reports a disabled pointer as a status rather than an error, so the
+// pure decision has to recognise it. If it did not, a disabled template would
+// look like "no dynamic version" and fall back to its static version — the one
+// outcome D6 forbids, because the operator disabled that ID deliberately.
+func TestDecideSendRefRefusesADisabledPointerFromTheBatch(t *testing.T) {
+	catalog := newMustTestCatalog(t)
+	staticRef, hasStatic := catalog.staticSendVersion(aireasoningprocess.TemplateID)
+	if !hasStatic {
+		t.Fatal("fixture lost its static send policy")
+	}
+	disabled := cardtmpl.RuntimeAuthorization{
+		Activation: cardtmpl.RuntimeActivation{Exists: true, Status: cardtmpl.RuntimeActivationDisabled},
+	}
+	if ref := catalog.decideSendRef(aireasoningprocess.TemplateID, staticRef, true, disabled); ref.ID != "" {
+		t.Fatalf("a disabled pointer fell back to the static version: %+v", ref)
+	}
+	// And it is the *disabled status* doing the work, not the empty version: a
+	// template with no activation row at all still keeps its static version.
+	none := cardtmpl.RuntimeAuthorization{}
+	if ref := catalog.decideSendRef(aireasoningprocess.TemplateID, staticRef, true, none); ref != staticRef {
+		t.Fatalf("an unactivated template lost its static version: %+v", ref)
 	}
 }

--- a/modules/bot_api/card_template_runtime_test.go
+++ b/modules/bot_api/card_template_runtime_test.go
@@ -9,12 +9,14 @@ package bot_api
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"net/http/httptest"
 	"testing"
 
 	"github.com/Mininglamp-OSS/octo-lib/common"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardmsg"
 	"github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl"
 	aireasoningprocess "github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl/ai_reasoning_process"
 	"github.com/gin-gonic/gin"
@@ -472,7 +474,7 @@ func TestBotSendCatalogPrincipalUsesTheTargetGroupSpace(t *testing.T) {
 		multiRows:   map[string][]string{"bot-42": {"space-bot"}},
 		groupSpaces: map[string]string{"group-1": "space-group"},
 	}
-	ba := newTestBotAPI(querier)
+	ba := newTestBotAPIWithCatalog(t, querier, &stubAuthorizationSource{newSend: true})
 	ctx := newGrantSpaceContext(t, "")
 
 	principal := ba.botSendCatalogPrincipal(ctx, "bot-42", "group-1", common.ChannelTypeGroup.Uint8())
@@ -503,11 +505,7 @@ func TestBotSendCatalogPrincipalUsesTheTargetGroupSpace(t *testing.T) {
 // this fix a gates-off deployment paid a space_member/app_bot query on every
 // feature-detection poll — a database dependency the endpoint never had.
 func TestBotCatalogPrincipalSkipsSpaceLookupWhenTheCatalogIsDark(t *testing.T) {
-	previous := cardtmpl.DefaultAuthorizationSource()
-	t.Cleanup(func() { cardtmpl.SetDefaultAuthorizationSource(previous) })
-
 	querier := &fakeSpaceQuerier{multiRows: map[string][]string{"bot-42": {"space-1"}}}
-	ba := newTestBotAPI(querier)
 	ctx := newGrantSpaceContext(t, "")
 
 	for _, source := range []cardtmpl.RuntimeAuthorizationSource{
@@ -515,7 +513,7 @@ func TestBotCatalogPrincipalSkipsSpaceLookupWhenTheCatalogIsDark(t *testing.T) {
 		&stubAuthorizationSource{newSend: false},
 	} {
 		querier.calls = nil
-		cardtmpl.SetDefaultAuthorizationSource(source)
+		ba := newTestBotAPIWithCatalog(t, querier, source)
 
 		principal := ba.botCatalogPrincipalFor(ctx, "bot-42")
 		if principal.SpaceResolved || principal.SpaceID != "" {
@@ -530,10 +528,27 @@ func TestBotCatalogPrincipalSkipsSpaceLookupWhenTheCatalogIsDark(t *testing.T) {
 		}
 	}
 
-	cardtmpl.SetDefaultAuthorizationSource(&stubAuthorizationSource{newSend: true})
-	if principal := ba.botCatalogPrincipalFor(ctx, "bot-42"); !principal.SpaceResolved {
+	enabled := newTestBotAPIWithCatalog(t, querier, &stubAuthorizationSource{newSend: true})
+	if principal := enabled.botCatalogPrincipalFor(ctx, "bot-42"); !principal.SpaceResolved {
 		t.Fatalf("enabled catalog did not resolve a Space: %+v", principal)
 	}
+}
+
+// newTestBotAPIWithCatalog wires a Bot API whose template catalog carries the
+// given resolver. The gate and the decision both read the catalog's accessor,
+// so a test that set only the process global would be exercising a path
+// production never takes.
+func newTestBotAPIWithCatalog(
+	t *testing.T,
+	querier botSpaceQuerier,
+	source cardtmpl.RuntimeAuthorizationSource,
+) *BotAPI {
+	t.Helper()
+	ba := newTestBotAPI(querier)
+	catalog := newMustTestCatalog(t)
+	catalog.authorization = source
+	ba.cardTemplates = catalog
+	return ba
 }
 
 // Review follow-up (#2): a group send authorizes against the target's Space, so
@@ -554,5 +569,78 @@ func TestProvenanceSpacePrefersTheAuthorizedSpaceOverTheRenderEnv(t *testing.T) 
 	}
 	if got := provenanceSpaceID(dm, cardtmpl.BuildEnv{}); got != "" {
 		t.Fatalf("unresolved provenance Space = %q, want empty", got)
+	}
+}
+
+// Review follow-up (#1/#3): a group card must stay editable after PR-C started
+// recording the target's Space in the marker.
+//
+// The send stamps the group's Space; a group envelope has no top-level
+// space_id, so an edit guard that compared the marker against the envelope
+// would refuse — and the round trip below is exactly the coverage whose absence
+// let that regression through. The edit must also re-stamp the same Space
+// rather than blanking it, since every downstream guard is written as
+// `if SpaceID != ""`.
+func TestGroupCardStaysEditableAndKeepsItsAuthorizedSpace(t *testing.T) {
+	ba := newTestBotAPIWithCatalog(t, &fakeSpaceQuerier{
+		multiRows:   map[string][]string{"bot-42": {"space-bot"}},
+		groupSpaces: map[string]string{"group-1": "space-group"},
+	}, &stubAuthorizationSource{newSend: true})
+	ctx := newGrantSpaceContext(t, "")
+	catalog := ba.cardTemplates
+
+	// Send into a group: the marker records the group's Space, not the Bot's.
+	sendPrincipal := ba.botSendCatalogPrincipal(ctx, "bot-42", "group-1", common.ChannelTypeGroup.Uint8())
+	if sendPrincipal.SpaceID != "space-group" {
+		t.Fatalf("send principal = %+v, want the group's Space", sendPrincipal)
+	}
+	env := cardtmpl.BuildEnv{Lang: "zh-CN"} // group sends leave env.SpaceID empty
+	sent, err := catalog.RenderPayloadForPrincipal(context.Background(), sendPrincipal,
+		registrySendBody(t, "reasoning", testReasoningData(t, "reasoning"))["payload"].(map[string]any), env)
+	if err != nil {
+		t.Fatalf("group send: %v", err)
+	}
+	envelope, err := json.Marshal(sent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	markers, err := cardmsg.CatalogFrameMarkers(envelope)
+	if err != nil {
+		t.Fatalf("stored markers: %v", err)
+	}
+	if markers.Provenance.SpaceID != "space-group" {
+		t.Fatalf("stored provenance Space = %q, want the authorized group Space",
+			markers.Provenance.SpaceID)
+	}
+
+	// Editing the same card resolves the same Space from the same target, so
+	// the guard passes even though the envelope carries no space_id.
+	editPrincipal := ba.botSendCatalogPrincipal(ctx, "bot-42", "group-1", common.ChannelTypeGroup.Uint8())
+	ref := botTemplateRef{ID: aireasoningprocess.TemplateID, Version: aireasoningprocess.TemplateVersionV3}
+	if err := requireEffectiveCardTemplate(envelope, ref, "bot-42", editPrincipal.SpaceID); err != nil {
+		t.Fatalf("group card was refused by its own edit guard: %v", err)
+	}
+
+	// And the re-stamped marker keeps the Space rather than blanking it.
+	edited, err := catalog.RenderEditPayloadForPrincipal(context.Background(), editPrincipal,
+		registrySendBody(t, "reasoning", testReasoningData(t, "reasoning"))["payload"].(map[string]any), env)
+	if err != nil {
+		t.Fatalf("group edit: %v", err)
+	}
+	editedEnvelope, err := json.Marshal(edited)
+	if err != nil {
+		t.Fatal(err)
+	}
+	editedMarkers, err := cardmsg.CatalogFrameMarkers(editedEnvelope)
+	if err != nil {
+		t.Fatalf("edited markers: %v", err)
+	}
+	if editedMarkers.Provenance.SpaceID != "space-group" {
+		t.Fatalf("edit erased the authorized Space: %q", editedMarkers.Provenance.SpaceID)
+	}
+
+	// A frame replayed against a target in another Space is still refused.
+	if err := requireEffectiveCardTemplate(envelope, ref, "bot-42", "space-elsewhere"); err == nil {
+		t.Fatal("a frame moved to another Space was accepted")
 	}
 }

--- a/modules/bot_api/card_template_send_test.go
+++ b/modules/bot_api/card_template_send_test.go
@@ -368,3 +368,109 @@ func invokeTemplateSend(t *testing.T, ba *BotAPI, body map[string]any, onBehalfO
 	ba.sendMessage(ctx)
 	return recorder
 }
+
+// ---- PR-C Slice 1 (D3): the Bot Registry path authors catalog provenance
+// from the authenticated bot; raw callers cannot forge either server-only
+// marker through send. ----
+
+func TestSendMessageRegistryTemplateAuthorsCatalogProvenance(t *testing.T) {
+	t.Setenv(cardmsg.EnvEnabled, "true")
+	gin.SetMode(gin.TestMode)
+	dispatch := &dispatchCapture{}
+	catalog, err := newBotCardTemplateCatalog(testBotTemplateRegistry(t), defaultBotTemplateRefs())
+	if err != nil {
+		t.Fatal(err)
+	}
+	ba := &BotAPI{
+		Log:              log.NewTLog("BotAPI-template-provenance"),
+		cardTemplates:    catalog,
+		spaceQuerier:     &fakeSpaceQuerier{defaultSpace: "space-authoritative"},
+		dispatchOverride: dispatch.hook,
+	}
+	recorder := invokeTemplateSend(t, ba, registrySendBody(t, "reasoning", testReasoningData(t, "reasoning")), "")
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", recorder.Code, recorder.Body.String())
+	}
+	dispatch.mu.Lock()
+	captured := dispatch.captured
+	dispatch.mu.Unlock()
+	if captured == nil {
+		t.Fatal("expected one dispatch")
+	}
+	markers, err := cardmsg.CatalogFrameMarkers(captured.Payload)
+	if err != nil {
+		t.Fatalf("outbound markers: %v", err)
+	}
+	if !markers.HasRef || !markers.HasProvenance {
+		t.Fatalf("outbound frame missing markers: %+v", markers)
+	}
+	if markers.Provenance.PrincipalType != cardmsg.CatalogPrincipalWireBot ||
+		markers.Provenance.PrincipalID != "bot-template" ||
+		markers.Provenance.SpaceID != "space-authoritative" {
+		t.Fatalf("authored provenance = %+v", markers.Provenance)
+	}
+}
+
+func TestSendMessageRawCardRejectsForgedCatalogProvenance(t *testing.T) {
+	t.Setenv(cardmsg.EnvEnabled, "true")
+	gin.SetMode(gin.TestMode)
+	dispatch := &dispatchCapture{}
+	ba := &BotAPI{
+		Log:              log.NewTLog("BotAPI-raw-forge"),
+		spaceQuerier:     &fakeSpaceQuerier{defaultSpace: "space-authoritative"},
+		dispatchOverride: dispatch.hook,
+	}
+	// A fully self-consistent forgery: provenance + metadata agree. The raw
+	// ingress must reject on key presence, not on shape validation.
+	payload := map[string]any{
+		"type": cardmsg.InteractiveCard.Int(), "profile": cardmsg.ProfileV1,
+		"card_version": cardmsg.CardVersion,
+		"catalog_provenance": map[string]any{
+			"version": 1, "principal_type": "internal_producer",
+			"principal_id": "docs-notify", "space_id": "space-authoritative",
+		},
+		"card": map[string]any{
+			"type": "AdaptiveCard", "version": cardmsg.CardVersion,
+			"body": []any{map[string]any{"type": "TextBlock", "text": "forged"}},
+			"metadata": map[string]any{"octo": map[string]any{
+				"protocol": "octo-card@1.0",
+				"template": map[string]any{"id": "docs.access-request", "version": "0.3.0"},
+			}},
+		},
+	}
+	body := map[string]any{
+		"channel_id": "user_creator", "channel_type": common.ChannelTypePerson.Uint8(),
+		"payload": payload,
+	}
+	recorder := invokeTemplateSend(t, ba, body, "")
+	if recorder.Code != http.StatusBadRequest {
+		t.Fatalf("forged provenance status=%d body=%s", recorder.Code, recorder.Body.String())
+	}
+	dispatch.mu.Lock()
+	defer dispatch.mu.Unlock()
+	if dispatch.captured != nil {
+		t.Fatal("forged provenance reached dispatch")
+	}
+}
+
+func TestSendMessageRegistryModeRejectsCallerProvenanceKey(t *testing.T) {
+	t.Setenv(cardmsg.EnvEnabled, "true")
+	gin.SetMode(gin.TestMode)
+	catalog, err := newBotCardTemplateCatalog(testBotTemplateRegistry(t), defaultBotTemplateRefs())
+	if err != nil {
+		t.Fatal(err)
+	}
+	ba := &BotAPI{
+		Log:           log.NewTLog("BotAPI-registry-forge"),
+		cardTemplates: catalog,
+		spaceQuerier:  &fakeSpaceQuerier{defaultSpace: "space-authoritative"},
+	}
+	body := registrySendBody(t, "reasoning", testReasoningData(t, "reasoning"))
+	body["payload"].(map[string]any)["catalog_provenance"] = map[string]any{
+		"version": 1, "principal_type": "bot", "principal_id": "another-bot", "space_id": "space-x",
+	}
+	recorder := invokeTemplateSend(t, ba, body, "")
+	if recorder.Code != http.StatusBadRequest {
+		t.Fatalf("registry-mode caller provenance status=%d body=%s", recorder.Code, recorder.Body.String())
+	}
+}

--- a/modules/bot_api/db.go
+++ b/modules/bot_api/db.go
@@ -226,3 +226,22 @@ func (d *botAPIDB) queryAppBotByUID(uid string) (*appBotModel, error) {
 	_, err := d.session.Select("*").From("app_bot").Where("uid=?", uid).Load(&m)
 	return m, err
 }
+
+// queryGroupSpaceID returns the authoritative Space of a group row. It is the
+// Space a card sent into that group is authorized against — the Bot's own
+// membership Space is not, since a Bot can belong to one Space and be a member
+// of a group that lives in another. An empty result is dbr.ErrNotFound so the
+// caller fails closed rather than treating "no row" as "no Space needed".
+func (d *botAPIDB) queryGroupSpaceID(groupNo string) (string, error) {
+	var spaceIDs []string
+	_, err := d.session.SelectBySql(
+		"SELECT `group`.space_id FROM `group` WHERE `group`.group_no=? LIMIT 1", groupNo,
+	).Load(&spaceIDs)
+	if err != nil {
+		return "", err
+	}
+	if len(spaceIDs) == 0 {
+		return "", dbr.ErrNotFound
+	}
+	return spaceIDs[0], nil
+}

--- a/modules/bot_api/db.go
+++ b/modules/bot_api/db.go
@@ -4,6 +4,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/db"
 	"github.com/gocraft/dbr/v2"
+	"strings"
 )
 
 type botAPIDB struct {
@@ -244,4 +245,27 @@ func (d *botAPIDB) queryGroupSpaceID(groupNo string) (string, error) {
 		return "", dbr.ErrNotFound
 	}
 	return spaceIDs[0], nil
+}
+
+// isUserSpaceMember reports whether a plain user holds an active membership in
+// an active Space.
+//
+// It is deliberately narrower than isBotSpaceAuthorized: that rule also honours
+// platform App Bots, which are visible in every Space by construction. A human
+// recipient has no such blanket visibility, so a DM's peer is checked against
+// space_member alone.
+func (d *botAPIDB) isUserSpaceMember(uid, spaceID string) (bool, error) {
+	if strings.TrimSpace(uid) == "" || strings.TrimSpace(spaceID) == "" {
+		return false, nil
+	}
+	var count int
+	err := d.session.SelectBySql(
+		"SELECT COUNT(*) FROM space_member sm INNER JOIN space s ON s.space_id = sm.space_id "+
+			"WHERE sm.uid=? AND sm.space_id=? AND sm.status=1 AND s.status=1",
+		uid, spaceID,
+	).LoadOne(&count)
+	if err != nil {
+		return false, err
+	}
+	return count > 0, nil
 }

--- a/modules/bot_api/db.go
+++ b/modules/bot_api/db.go
@@ -228,23 +228,39 @@ func (d *botAPIDB) queryAppBotByUID(uid string) (*appBotModel, error) {
 	return m, err
 }
 
-// queryGroupSpaceID returns the authoritative Space of a group row. It is the
-// Space a card sent into that group is authorized against — the Bot's own
-// membership Space is not, since a Bot can belong to one Space and be a member
-// of a group that lives in another. An empty result is dbr.ErrNotFound so the
-// caller fails closed rather than treating "no row" as "no Space needed".
-func (d *botAPIDB) queryGroupSpaceID(groupNo string) (string, error) {
-	var spaceIDs []string
-	_, err := d.session.SelectBySql(
-		"SELECT `group`.space_id FROM `group` WHERE `group`.group_no=? LIMIT 1", groupNo,
-	).Load(&spaceIDs)
+// queryGroupSpaceID returns the authoritative Space of a group row, and whether
+// that Space is currently active. It is the Space a card sent into that group is
+// authorized against — the Bot's own membership Space is not, since a Bot can
+// belong to one Space and be a member of a group that lives in another. An empty
+// result is dbr.ErrNotFound so the caller fails closed rather than treating "no
+// row" as "no Space needed".
+//
+// The active flag exists because every other Space resolver in this file treats
+// `space.status = 1` as load-bearing — querySpaceIDsByRobotID, both branches of
+// isBotSpaceAuthorized, and isUserSpaceMember all require it — and this one did
+// not. A grant scoped to a Space an operator had disabled therefore still
+// authorized sends into that Space's groups, while the same bot's membership,
+// an X-Space-ID header naming it, and a DM peer inside it were all refused. The
+// join is LEFT rather than INNER so that "this group belongs to no Space" stays
+// distinguishable from "this group's Space is disabled": the first is a
+// determination the caller can act on, the second is a Space it must not use.
+func (d *botAPIDB) queryGroupSpaceID(groupNo string) (spaceID string, spaceActive bool, err error) {
+	var rows []struct {
+		SpaceID string `db:"space_id"`
+		Active  bool   `db:"active"`
+	}
+	_, err = d.session.SelectBySql(
+		"SELECT `group`.space_id AS space_id, (s.space_id IS NOT NULL) AS active "+
+			"FROM `group` LEFT JOIN space s ON s.space_id = `group`.space_id AND s.status = 1 "+
+			"WHERE `group`.group_no=? LIMIT 1", groupNo,
+	).Load(&rows)
 	if err != nil {
-		return "", err
+		return "", false, err
 	}
-	if len(spaceIDs) == 0 {
-		return "", dbr.ErrNotFound
+	if len(rows) == 0 {
+		return "", false, dbr.ErrNotFound
 	}
-	return spaceIDs[0], nil
+	return rows[0].SpaceID, rows[0].Active, nil
 }
 
 // isUserSpaceMember reports whether a plain user holds an active membership in

--- a/modules/bot_api/send.go
+++ b/modules/bot_api/send.go
@@ -1206,7 +1206,14 @@ func (ba *BotAPI) botMessageEditViaRegistry(c *wkhttp.Context, req *botMessageEd
 		httperr.ResponseErrorL(c, errcode.ErrSharedInternal, nil, nil)
 		return
 	}
-	ref, err := ba.cardTemplates.requireEditableRef(req.TemplateRef)
+	// Resolve the edit's Space from the target, the same way the send did, so
+	// the ref gate below, the provenance guard and the re-stamped marker all
+	// compare like with like (see requireEffectiveCardTemplate). This runs
+	// before the ref gate because a dynamic ref is authorized by *this
+	// principal's* edit grant — the static allowlist alone cannot answer for a
+	// version published at runtime.
+	editPrincipal := ba.botSendCatalogPrincipal(c, robotID, req.ChannelID, req.ChannelType)
+	ref, err := ba.cardTemplates.resolveEditRef(c.Request.Context(), editPrincipal, req.TemplateRef)
 	if err != nil {
 		if errors.Is(err, errBotTemplateRequestInvalid) {
 			ba.Warn("Bot Registry edit template_ref 非法或未开放", zap.Error(err))
@@ -1226,10 +1233,6 @@ func (ba *BotAPI) botMessageEditViaRegistry(c *wkhttp.Context, req *botMessageEd
 		ba.respondBotTemplateSnapshotError(c, req.MessageID, err)
 		return
 	}
-	// Resolve the edit's Space from the target, the same way the send did, so
-	// the guard below and the re-stamped marker are both comparing like with
-	// like (see requireEffectiveCardTemplate).
-	editPrincipal := ba.botSendCatalogPrincipal(c, robotID, req.ChannelID, req.ChannelType)
 	spaceCheck := editProvenanceSpaceCheck(ba.cardTemplates.dynamicCatalogEnabled(), editPrincipal)
 	if err := requireEffectiveCardTemplate(snapshot.Envelope, ref, robotID, spaceCheck); err != nil {
 		if errors.Is(err, errBotTemplateRuntimeUnavailable) {

--- a/modules/bot_api/send.go
+++ b/modules/bot_api/send.go
@@ -265,12 +265,26 @@ func (ba *BotAPI) sendMessage(c *wkhttp.Context) {
 		if ba.ctx != nil && ba.ctx.GetConfig() != nil {
 			webLoginURL = ba.ctx.GetConfig().External.WebLoginURL
 		}
-		rendered, renderErr := ba.cardTemplates.RenderPayloadForPrincipal(c.Request.Context(), robotID, req.Payload, cardtmpl.BuildEnv{
+		// PR-C D6: the grant principal is resolved from the *target*, not from
+		// the sender's own membership, and it is a separate value from the
+		// dispatch space_id above — the latter tags the DM envelope for client
+		// SpaceFilter and is deliberately forgiving, while this one authorizes
+		// and is deliberately not.
+		principal := ba.botSendCatalogPrincipal(c, robotID, channelID, req.ChannelType)
+		rendered, renderErr := ba.cardTemplates.RenderPayloadForPrincipal(c.Request.Context(), principal, req.Payload, cardtmpl.BuildEnv{
 			WebLoginURL: webLoginURL,
 			Lang:        i18n.OutboundLanguage(c.Request.Context()),
 			SpaceID:     spaceID,
 		})
 		if renderErr != nil {
+			if errors.Is(renderErr, errBotTemplateRuntimeUnavailable) {
+				// The runtime catalog could not be read, so we cannot tell
+				// whether this template ID has been shadowed. Refuse rather
+				// than fall back to the static version of the same ID.
+				ba.Error("Bot 模板运行时目录不可用", zap.Error(renderErr), zap.String("channelID", channelID))
+				httperr.ResponseErrorL(c, errcode.ErrSharedInternal, nil, nil)
+				return
+			}
 			if errors.Is(renderErr, errBotTemplateRequestInvalid) {
 				ba.Warn("Bot Registry 模板请求非法", zap.Error(renderErr), zap.String("channelID", channelID))
 				httperr.ResponseErrorL(c, errcode.ErrBotAPICardInvalid, nil, nil)

--- a/modules/bot_api/send.go
+++ b/modules/bot_api/send.go
@@ -1230,7 +1230,17 @@ func (ba *BotAPI) botMessageEditViaRegistry(c *wkhttp.Context, req *botMessageEd
 	// the guard below and the re-stamped marker are both comparing like with
 	// like (see requireEffectiveCardTemplate).
 	editPrincipal := ba.botSendCatalogPrincipal(c, robotID, req.ChannelID, req.ChannelType)
-	if err := requireEffectiveCardTemplate(snapshot.Envelope, ref, robotID, editPrincipal.SpaceID); err != nil {
+	spaceCheck := editProvenanceSpaceCheck(ba.cardTemplates.dynamicCatalogEnabled(), editPrincipal)
+	if err := requireEffectiveCardTemplate(snapshot.Envelope, ref, robotID, spaceCheck); err != nil {
+		if errors.Is(err, errBotTemplateRuntimeUnavailable) {
+			// The frame may be entirely valid; we could not read the Space to
+			// check it. Answering 400 would tell the Bot its request is
+			// malformed and not to retry, which is the opposite of the truth.
+			ba.Error("Bot Registry edit 无法解析目标 Space", zap.Error(err),
+				zap.String("messageID", req.MessageID))
+			httperr.ResponseErrorL(c, errcode.ErrSharedInternal, nil, nil)
+			return
+		}
 		ba.Warn("Bot Registry edit 目标模板不匹配", zap.Error(err), zap.String("messageID", req.MessageID))
 		httperr.ResponseErrorL(c, errcode.ErrBotAPICardInvalid, nil, nil)
 		return

--- a/modules/bot_api/send.go
+++ b/modules/bot_api/send.go
@@ -127,6 +127,15 @@ func (ba *BotAPI) sendMessage(c *wkhttp.Context) {
 				return
 			}
 		} else {
+			// PR-C D3：catalog_provenance 是 server-only 顶层键，raw Bot 卡片按
+			// 键存在显式拒绝（不依赖形状校验，也不依赖客户端"不会传"）。
+			// template_ref 由上方 XOR 覆盖：出现即进 Registry 模式，raw card 共存
+			// 已被拒绝。
+			if _, forged := req.Payload[cardmsg.CatalogProvenanceKey]; forged {
+				ba.Warn("raw Bot 卡片试图伪造 catalog_provenance", zap.String("channelID", req.ChannelID))
+				httperr.ResponseErrorL(c, errcode.ErrBotAPICardInvalid, nil, nil)
+				return
+			}
 			if err := cardmsg.Validate(req.Payload); err != nil {
 				ba.Warn("InteractiveCard payload 校验失败", zap.Error(err), zap.String("channelID", req.ChannelID))
 				httperr.ResponseErrorL(c, errcode.ErrBotAPICardInvalid, nil, nil)
@@ -1203,7 +1212,7 @@ func (ba *BotAPI) botMessageEditViaRegistry(c *wkhttp.Context, req *botMessageEd
 		ba.respondBotTemplateSnapshotError(c, req.MessageID, err)
 		return
 	}
-	if err := requireEffectiveCardTemplate(snapshot.Envelope, ref); err != nil {
+	if err := requireEffectiveCardTemplate(snapshot.Envelope, ref, robotID); err != nil {
 		ba.Warn("Bot Registry edit 目标模板不匹配", zap.Error(err), zap.String("messageID", req.MessageID))
 		httperr.ResponseErrorL(c, errcode.ErrBotAPICardInvalid, nil, nil)
 		return
@@ -1330,12 +1339,19 @@ func contentEditHasTemplateRef(contentEdit string) bool {
 	return cardEnvelopeHasTemplateRef([]byte(contentEdit))
 }
 
+// cardEnvelopeHasTemplateRef 报告一个信封是否携带任一 server-only catalog
+// 标记（template_ref / catalog_provenance，PR-C D3）。raw 编辑路径用它双向
+// 拒绝：目标是 Registry/internal 产出的帧 → raw 不能覆盖；编辑体携带标记 →
+// raw 不能伪造。
 func cardEnvelopeHasTemplateRef(raw []byte) bool {
 	var payload map[string]any
 	if err := json.Unmarshal(raw, &payload); err != nil {
 		return false
 	}
-	_, exists := payload["template_ref"]
+	if _, exists := payload[cardmsg.CatalogTemplateRefKey]; exists {
+		return true
+	}
+	_, exists := payload[cardmsg.CatalogProvenanceKey]
 	return exists
 }
 

--- a/modules/bot_api/send.go
+++ b/modules/bot_api/send.go
@@ -1226,7 +1226,11 @@ func (ba *BotAPI) botMessageEditViaRegistry(c *wkhttp.Context, req *botMessageEd
 		ba.respondBotTemplateSnapshotError(c, req.MessageID, err)
 		return
 	}
-	if err := requireEffectiveCardTemplate(snapshot.Envelope, ref, robotID); err != nil {
+	// Resolve the edit's Space from the target, the same way the send did, so
+	// the guard below and the re-stamped marker are both comparing like with
+	// like (see requireEffectiveCardTemplate).
+	editPrincipal := ba.botSendCatalogPrincipal(c, robotID, req.ChannelID, req.ChannelType)
+	if err := requireEffectiveCardTemplate(snapshot.Envelope, ref, robotID, editPrincipal.SpaceID); err != nil {
 		ba.Warn("Bot Registry edit 目标模板不匹配", zap.Error(err), zap.String("messageID", req.MessageID))
 		httperr.ResponseErrorL(c, errcode.ErrBotAPICardInvalid, nil, nil)
 		return
@@ -1256,7 +1260,7 @@ func (ba *BotAPI) botMessageEditViaRegistry(c *wkhttp.Context, req *botMessageEd
 		webLoginURL = ba.ctx.GetConfig().External.WebLoginURL
 	}
 	spaceID := effectiveEnvelopeSpaceID(snapshot.Envelope)
-	rendered, err := ba.cardTemplates.RenderEditPayloadForPrincipal(c.Request.Context(), robotID, map[string]any{
+	rendered, err := ba.cardTemplates.RenderEditPayloadForPrincipal(c.Request.Context(), editPrincipal, map[string]any{
 		"type":         cardmsg.InteractiveCard.Int(),
 		"template_ref": req.TemplateRef,
 		"state":        req.State,

--- a/modules/bot_api/send.go
+++ b/modules/bot_api/send.go
@@ -1279,7 +1279,7 @@ func (ba *BotAPI) botMessageEditViaRegistry(c *wkhttp.Context, req *botMessageEd
 		WebLoginURL: webLoginURL,
 		Lang:        i18n.OutboundLanguage(c.Request.Context()),
 		SpaceID:     spaceID,
-	})
+	}, storedProvenanceSpaceID(snapshot.Envelope))
 	if err != nil {
 		if errors.Is(err, errBotTemplateRequestInvalid) {
 			ba.Warn("Bot Registry edit 模板请求非法", zap.Error(err), zap.String("messageID", req.MessageID))

--- a/modules/bot_api/space_inject.go
+++ b/modules/bot_api/space_inject.go
@@ -64,10 +64,15 @@ import (
 //     space_member: it also recognizes platform App Bots (scope='platform'
 //     visible in every active Space) and scope=space App Bots dispatching
 //     into their own Space — see modules/bot_api/db.go for the full rule.
+//
+// PR-C adds queryGroupSpaceID for the dynamic-catalog grant resolver: a card
+// sent into a group is authorized against the *group's* Space, which is not
+// necessarily the Bot's own.
 type botSpaceQuerier interface {
 	querySpaceIDByRobotID(robotID string) (string, error)
 	querySpaceIDsByRobotID(robotID string) (string, []string, error)
 	isBotSpaceAuthorized(robotID, spaceID string) (bool, error)
+	queryGroupSpaceID(groupNo string) (string, error)
 }
 
 // enrichBotPayloadWithSpaceID 在 PERSONAL DM 派发前用 Bot 的权威 SpaceID 覆盖

--- a/modules/bot_api/space_inject.go
+++ b/modules/bot_api/space_inject.go
@@ -72,7 +72,7 @@ type botSpaceQuerier interface {
 	querySpaceIDByRobotID(robotID string) (string, error)
 	querySpaceIDsByRobotID(robotID string) (string, []string, error)
 	isBotSpaceAuthorized(robotID, spaceID string) (bool, error)
-	queryGroupSpaceID(groupNo string) (string, error)
+	queryGroupSpaceID(groupNo string) (spaceID string, spaceActive bool, err error)
 	isUserSpaceMember(uid, spaceID string) (bool, error)
 }
 

--- a/modules/bot_api/space_inject.go
+++ b/modules/bot_api/space_inject.go
@@ -73,6 +73,7 @@ type botSpaceQuerier interface {
 	querySpaceIDsByRobotID(robotID string) (string, []string, error)
 	isBotSpaceAuthorized(robotID, spaceID string) (bool, error)
 	queryGroupSpaceID(groupNo string) (string, error)
+	isUserSpaceMember(uid, spaceID string) (bool, error)
 }
 
 // enrichBotPayloadWithSpaceID 在 PERSONAL DM 派发前用 Bot 的权威 SpaceID 覆盖

--- a/modules/bot_api/space_inject_test.go
+++ b/modules/bot_api/space_inject_test.go
@@ -62,6 +62,10 @@ type fakeSpaceQuerier struct {
 	// default rather than something a test has to opt into.
 	groupSpaces   map[string]string
 	groupSpaceErr error
+	// inactiveSpaces marks a Space as space.status != 1 for the group resolver,
+	// which is the only way to reach the "the group names a Space that is no
+	// longer active" branch.
+	inactiveSpaces map[string]bool
 	// memberSpaces answers the DM peer membership check, keyed uid -> spaceID.
 	memberSpaces   map[string]map[string]bool
 	memberSpaceErr error
@@ -77,15 +81,23 @@ func (f *fakeSpaceQuerier) isUserSpaceMember(uid, spaceID string) (bool, error) 
 	return f.memberSpaces[uid][spaceID], nil
 }
 
-func (f *fakeSpaceQuerier) queryGroupSpaceID(groupNo string) (string, error) {
+// queryGroupSpaceID mirrors the production LEFT JOIN: a group whose Space is
+// listed in inactiveSpaces resolves its space_id but reports the Space inactive,
+// which is a different answer from "this group has no Space" (empty space_id)
+// and from "no such group" (dbr.ErrNotFound).
+func (f *fakeSpaceQuerier) queryGroupSpaceID(groupNo string) (string, bool, error) {
 	f.calls = append(f.calls, "queryGroupSpaceID:"+groupNo)
 	if f.groupSpaceErr != nil {
-		return "", f.groupSpaceErr
+		return "", false, f.groupSpaceErr
 	}
-	if spaceID, ok := f.groupSpaces[groupNo]; ok {
-		return spaceID, nil
+	spaceID, ok := f.groupSpaces[groupNo]
+	if !ok {
+		return "", false, dbr.ErrNotFound
 	}
-	return "", dbr.ErrNotFound
+	if spaceID == "" {
+		return "", false, nil
+	}
+	return spaceID, !f.inactiveSpaces[spaceID], nil
 }
 
 type appBotShape struct {

--- a/modules/bot_api/space_inject_test.go
+++ b/modules/bot_api/space_inject_test.go
@@ -51,12 +51,28 @@ type fakeSpaceQuerier struct {
 	//       `activeSpaces[spaceID] != false` → scope=space App Bot in own Space
 	// `activeSpaces` defaults to true for any spaceID not explicitly set to
 	// false, so tests that don't care about Space status can omit it.
-	memberships   map[string]map[string]bool
-	authCalls     []memberCall
-	authDefault   bool
-	authErr       error
-	appBots       map[string]appBotShape
-	activeSpaces  map[string]bool
+	memberships  map[string]map[string]bool
+	authCalls    []memberCall
+	authDefault  bool
+	authErr      error
+	appBots      map[string]appBotShape
+	activeSpaces map[string]bool
+	// PR-C: group_no -> Space of the authoritative `group` row. An absent key
+	// answers dbr.ErrNotFound so the grant resolver's fail-closed branch is the
+	// default rather than something a test has to opt into.
+	groupSpaces   map[string]string
+	groupSpaceErr error
+}
+
+func (f *fakeSpaceQuerier) queryGroupSpaceID(groupNo string) (string, error) {
+	f.calls = append(f.calls, "queryGroupSpaceID:"+groupNo)
+	if f.groupSpaceErr != nil {
+		return "", f.groupSpaceErr
+	}
+	if spaceID, ok := f.groupSpaces[groupNo]; ok {
+		return spaceID, nil
+	}
+	return "", dbr.ErrNotFound
 }
 
 type appBotShape struct {

--- a/modules/bot_api/space_inject_test.go
+++ b/modules/bot_api/space_inject_test.go
@@ -62,6 +62,19 @@ type fakeSpaceQuerier struct {
 	// default rather than something a test has to opt into.
 	groupSpaces   map[string]string
 	groupSpaceErr error
+	// memberSpaces answers the DM peer membership check, keyed uid -> spaceID.
+	memberSpaces   map[string]map[string]bool
+	memberSpaceErr error
+}
+
+// PR-C: memberSpaces[uid][spaceID] answers the DM peer check. An absent entry
+// means "not a member", so a test opts a peer in rather than out.
+func (f *fakeSpaceQuerier) isUserSpaceMember(uid, spaceID string) (bool, error) {
+	f.calls = append(f.calls, "isUserSpaceMember:"+uid+":"+spaceID)
+	if f.memberSpaceErr != nil {
+		return false, f.memberSpaceErr
+	}
+	return f.memberSpaces[uid][spaceID], nil
 }
 
 func (f *fakeSpaceQuerier) queryGroupSpaceID(groupNo string) (string, error) {

--- a/modules/card_template_catalog/api.go
+++ b/modules/card_template_catalog/api.go
@@ -48,7 +48,10 @@ type API struct {
 	controlEnabled         bool
 	// discovery overrides the B1/B2 read surface in tests. Production leaves it
 	// nil and type-asserts the shared store, so there is one read model.
-	discovery     discoveryStore
+	discovery discoveryStore
+	// staticEntries overrides the frozen Registry listing in tests; see
+	// API.staticCatalog. Production leaves it nil.
+	staticEntries func() []cardtmpl.StaticCatalogEntry
 	registry      *cardtmpl.Registry
 	readiness     *runtimeCatalogReadiness
 	startupMu     sync.Mutex

--- a/modules/card_template_catalog/api.go
+++ b/modules/card_template_catalog/api.go
@@ -40,14 +40,18 @@ type API struct {
 	store               catalogStore
 	compile             compileArtifactFunc
 	validateStateTarget func(context.Context, cardtmpl.ID, string) (stateTargetReceipt, error)
-	controlEnabled      bool
-	registry            *cardtmpl.Registry
-	readiness           *runtimeCatalogReadiness
-	startupMu           sync.Mutex
-	startupCancel       context.CancelFunc
-	startupDone         chan struct{}
-	logger              log.Log
-	metrics             *catalogMetrics
+	// validateGrantPrincipal 校验 grant principal/scope 的存在性（D2：bot 活跃、
+	// internal producer 已注册、Space 存在且 active）。生产走
+	// productionGrantPrincipalCheck；测试注入。未接线时 grant 写 fail-close。
+	validateGrantPrincipal func(context.Context, GrantIdentity) error
+	controlEnabled         bool
+	registry               *cardtmpl.Registry
+	readiness              *runtimeCatalogReadiness
+	startupMu              sync.Mutex
+	startupCancel          context.CancelFunc
+	startupDone            chan struct{}
+	logger                 log.Log
+	metrics                *catalogMetrics
 }
 
 func New(ctx *config.Context) *API {
@@ -69,6 +73,7 @@ func New(ctx *config.Context) *API {
 		metrics:        metrics,
 	}
 	api.validateStateTarget = api.validateTarget
+	api.validateGrantPrincipal = api.productionGrantPrincipalCheck
 	registry := cardtmpl.DefaultRegistry()
 	if registry == nil {
 		if !ctx.GetConfig().Test {
@@ -132,6 +137,8 @@ func (a *API) Route(r *wkhttp.WKHttp) {
 	manager.PUT("/:id/active", a.activate)
 	manager.POST("/:id/rollback", a.rollback)
 	manager.POST("/:id/block", a.block)
+	manager.PUT("/:id/grants/:principal_type/:principal_id", a.grantUpsert)
+	manager.DELETE("/:id/grants/:principal_type/:principal_id", a.grantRevoke)
 }
 
 type controlRequest struct {

--- a/modules/card_template_catalog/api.go
+++ b/modules/card_template_catalog/api.go
@@ -14,6 +14,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
 	"github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl"
+	"github.com/Mininglamp-OSS/octo-server/pkg/space"
 	appwkhttp "github.com/Mininglamp-OSS/octo-server/pkg/wkhttp"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/zap"
@@ -45,13 +46,16 @@ type API struct {
 	// productionGrantPrincipalCheck；测试注入。未接线时 grant 写 fail-close。
 	validateGrantPrincipal func(context.Context, GrantIdentity) error
 	controlEnabled         bool
-	registry               *cardtmpl.Registry
-	readiness              *runtimeCatalogReadiness
-	startupMu              sync.Mutex
-	startupCancel          context.CancelFunc
-	startupDone            chan struct{}
-	logger                 log.Log
-	metrics                *catalogMetrics
+	// discovery overrides the B1/B2 read surface in tests. Production leaves it
+	// nil and type-asserts the shared store, so there is one read model.
+	discovery     discoveryStore
+	registry      *cardtmpl.Registry
+	readiness     *runtimeCatalogReadiness
+	startupMu     sync.Mutex
+	startupCancel context.CancelFunc
+	startupDone   chan struct{}
+	logger        log.Log
+	metrics       *catalogMetrics
 }
 
 func New(ctx *config.Context) *API {
@@ -130,6 +134,7 @@ func (a *API) Route(r *wkhttp.WKHttp) {
 		a.ctx.AuthMiddleware(r),
 		appwkhttp.SharedUIDRateLimiter(r, a.ctx),
 	)
+	manager.GET("", a.managerList)
 	manager.POST("/validate", a.validate)
 	manager.POST("/publish", a.publish)
 	manager.GET("/:id/audit", a.audit)
@@ -139,6 +144,21 @@ func (a *API) Route(r *wkhttp.WKHttp) {
 	manager.POST("/:id/block", a.block)
 	manager.PUT("/:id/grants/:principal_type/:principal_id", a.grantUpsert)
 	manager.DELETE("/:id/grants/:principal_type/:principal_id", a.grantRevoke)
+
+	// PR-C D5 — B1/B2. Unlike the manager plane these are ordinary
+	// authenticated reads, so they run behind the Space middleware: a caller
+	// with no Space context sees only public templates, and a caller claiming
+	// one has that claim verified before any visibility decision uses it. The
+	// localized variant keeps these responses on the card catalog's error
+	// envelope instead of the legacy raw-JSON one.
+	discovery := r.Group(
+		"/v1/message/card/templates",
+		a.ctx.AuthMiddleware(r),
+		appwkhttp.SharedUIDRateLimiter(r, a.ctx),
+		space.LocalizedSpaceMiddleware(a.ctx),
+	)
+	discovery.GET("", a.listTemplates)
+	discovery.GET("/:ref", a.getTemplate)
 }
 
 type controlRequest struct {

--- a/modules/card_template_catalog/api_discovery.go
+++ b/modules/card_template_catalog/api_discovery.go
@@ -174,13 +174,14 @@ func (a *API) listTemplates(c *wkhttp.Context) {
 
 	remaining := limit - len(page.Templates)
 	if remaining <= 0 {
-		// Static filled the page exactly. Hand back a dynamic cursor at the top
-		// rather than querying with a zero budget, which the store's clamp
-		// would silently turn back into a full page.
-		page.NextCursor = encodeDiscoveryCursor(discoveryCursor{
-			Version: discoveryCursorVersion, Space: spaceID, Source: discoverySourceDynamic,
-		})
-		page.HasMore = true
+		// Static filled the page exactly, so whether another page exists is a
+		// question about the dynamic source, not something to assume.
+		next, more, err := dynamicPageFollows(ctx, store, spaceID)
+		if err != nil {
+			respondCatalogUnavailable(c)
+			return
+		}
+		page.NextCursor, page.HasMore = next, more
 		writeDiscoveryCacheHeaders(c, spaceID)
 		c.Response(page)
 		return
@@ -220,16 +221,7 @@ func (a *API) staticPage(
 	if len(entries) == 0 {
 		return nil, nil, nil
 	}
-	// Only private entries need a grant lookup, and only for IDs the caller
-	// could still reach on this page — a Space with no grants pays for one
-	// bounded query, not one per template.
-	privateIDs := make([]cardtmpl.ID, 0, len(entries))
-	for _, entry := range entries {
-		if entry.Visibility != cardtmpl.CatalogVisibilityPublic {
-			privateIDs = append(privateIDs, entry.ID)
-		}
-	}
-	granted, err := store.StaticDiscoverGrants(ctx, spaceID, privateIDs)
+	granted, err := store.StaticDiscoverGrants(ctx, spaceID, privateTemplateIDs(entries))
 	if err != nil {
 		return nil, nil, err
 	}
@@ -257,6 +249,50 @@ func (a *API) staticPage(
 		items = append(items, staticListItem(entry))
 	}
 	return items, nil, nil
+}
+
+// dynamicPageFollows peeks at the dynamic source with a budget of one row.
+//
+// The alternative — declaring has_more:true because the static source happened
+// to fill the page — costs every caller iterating this boundary a guaranteed
+// empty round trip, and, worse, teaches them that has_more is not something
+// they can act on anywhere else either.
+func dynamicPageFollows(
+	ctx context.Context,
+	store discoveryStore,
+	spaceID string,
+) (cursor string, hasMore bool, err error) {
+	peek, _, err := store.ListDiscoverable(ctx, spaceID, "", "", 1)
+	if err != nil {
+		return "", false, err
+	}
+	if len(peek) == 0 {
+		return "", false, nil
+	}
+	return encodeDiscoveryCursor(discoveryCursor{
+		Version: discoveryCursorVersion, Space: spaceID, Source: discoverySourceDynamic,
+	}), true, nil
+}
+
+// privateTemplateIDs is the deduplicated set of static template IDs that need a
+// discover-grant probe. Keying by ID rather than by exact version matters: a
+// card registered at three versions would otherwise take three slots in the
+// bounded IN-list and could push a genuinely granted template past the cut,
+// where it is silently treated as ungranted.
+func privateTemplateIDs(entries []cardtmpl.StaticCatalogEntry) []cardtmpl.ID {
+	ids := make([]cardtmpl.ID, 0, len(entries))
+	seen := make(map[cardtmpl.ID]struct{}, len(entries))
+	for _, entry := range entries {
+		if entry.Visibility == cardtmpl.CatalogVisibilityPublic {
+			continue
+		}
+		if _, done := seen[entry.ID]; done {
+			continue
+		}
+		seen[entry.ID] = struct{}{}
+		ids = append(ids, entry.ID)
+	}
+	return ids
 }
 
 func afterStaticCursor(entry cardtmpl.StaticCatalogEntry, cursor discoveryCursor) bool {

--- a/modules/card_template_catalog/api_discovery.go
+++ b/modules/card_template_catalog/api_discovery.go
@@ -372,18 +372,21 @@ func (a *API) getTemplate(c *wkhttp.Context) {
 		return
 	}
 
-	row, err := store.LoadDiscoverable(ctx, spaceID, id, version)
-	if err != nil {
-		if errors.Is(err, ErrDiscoveryNotVisible) {
-			respondCatalogNotFound(c)
-			return
-		}
-		respondCatalogUnavailable(c)
-		return
-	}
-	// The projection comes from the compiled artifact, which is the same
-	// immutable object the renderer uses. Building it here from the row would
-	// mean two definitions of "what this template promises".
+	// One authorized read decides everything about this response — that the
+	// caller may see the template, what its contract says, and which validator
+	// and cache directive describe it.
+	//
+	// An earlier revision asked twice: the discovery predicate for visibility
+	// and the ETag source, then the runtime catalog for the projection. Two
+	// independent reads mean two instants, and a grant that moved between them
+	// produced either a 404 for a template the caller could see a millisecond
+	// earlier or a response whose headers described a snapshot the body did not
+	// come from. That is precisely the torn read the one-snapshot resolver
+	// exists to eliminate, so B2 no longer performs it.
+	//
+	// Dropping the predicate read cannot widen what is served: the authorizer
+	// applies the same visibility-or-grant rule *plus* the owner allowlist, and
+	// rejects blocked and unknown artifacts on its own.
 	meta, err := a.discoveryMeta(ctx, spaceID, id, version)
 	if err != nil {
 		if errors.Is(err, cardtmpl.ErrTemplateUnknown) ||
@@ -400,11 +403,12 @@ func (a *API) getTemplate(c *wkhttp.Context) {
 		respondCatalogNotFound(c)
 		return
 	}
-	// A dynamic template's ETag is its immutable content hash rather than the
-	// projection digest: the content hash also covers the documents the
-	// projection omits, so it can never collide across two artifacts that
-	// happen to project identically.
-	a.writeExport(c, spaceID, row.Visibility, row.ContentSHA256, export)
+	// The validator is the projection's own deterministic digest, which is the
+	// one hash guaranteed to describe the bytes being written. Two artifacts
+	// that project identically therefore share a validator — correct for a
+	// cache, since the responses are byte-identical. Visibility likewise comes
+	// from the projection, which fails closed to private.
+	a.writeExport(c, spaceID, export.Visibility, export.Hash, export)
 }
 
 // writeExport emits the projection with conditional-request and cache headers.

--- a/modules/card_template_catalog/api_discovery.go
+++ b/modules/card_template_catalog/api_discovery.go
@@ -426,7 +426,11 @@ func (a *API) writeExport(
 	etag := `"` + etagSource + `"`
 	c.Header("ETag", etag)
 	if matchesETag(c.GetHeader("If-None-Match"), etag) {
+		// Flush explicitly. c.Status only records the code and leaves the write
+		// to whenever the framework gets around to it, which makes "304 with no
+		// body" depend on the caller's plumbing rather than on this handler.
 		c.Status(http.StatusNotModified)
+		c.Writer.WriteHeaderNow()
 		return
 	}
 	c.Response(export)
@@ -519,7 +523,7 @@ func (a *API) managerList(c *wkhttp.Context) {
 	if !a.requireSuperAdmin(c) {
 		return
 	}
-	store, ok := a.store.(managerTemplateStore)
+	store, ok := a.managerTemplateStore()
 	if !ok {
 		respondCatalogUnavailable(c)
 		return
@@ -548,6 +552,22 @@ func (a *API) managerList(c *wkhttp.Context) {
 	c.Response(response)
 }
 
+// managerTemplateStore resolves the operator index reader. It prefers the test
+// seam for the same reason discoveryStore does: a handler test should not have
+// to stand up the publish store to assert a projection.
+func (a *API) managerTemplateStore() (managerTemplateStore, bool) {
+	if a == nil {
+		return nil, false
+	}
+	if a.discovery != nil {
+		if store, ok := a.discovery.(managerTemplateStore); ok {
+			return store, true
+		}
+	}
+	store, ok := a.store.(managerTemplateStore)
+	return store, ok
+}
+
 // discoveryStore returns the read surface, or false when this API has no store
 // that implements it. Failing closed matters more than degrading: a listing
 // that silently returned only static templates would look like a complete
@@ -565,8 +585,19 @@ func (a *API) discoveryStore() (discoveryStore, bool) {
 
 // staticCatalog lists the frozen Registry. An API constructed without one (as
 // some focused tests are) simply has no static half.
+//
+// staticEntries is a test seam. The frozen Registry is built from embedded
+// template assets that this package does not carry, so without it the static
+// half of pagination — including the rule that a hidden row must not advance
+// the cursor — would have no coverage at all.
 func (a *API) staticCatalog() []cardtmpl.StaticCatalogEntry {
-	if a == nil || a.registry == nil {
+	if a == nil {
+		return nil
+	}
+	if a.staticEntries != nil {
+		return a.staticEntries()
+	}
+	if a.registry == nil {
 		return nil
 	}
 	return a.registry.StaticCatalog()

--- a/modules/card_template_catalog/api_discovery.go
+++ b/modules/card_template_catalog/api_discovery.go
@@ -1,0 +1,580 @@
+package card_template_catalog
+
+// PR-C D5 — B1 (list) and B2 (contract detail).
+//
+// These are the only card-catalog endpoints an ordinary caller reaches, and
+// their whole job is to answer "what can I build against" without answering
+// "what exists that I may not see". Three rules carry that:
+//
+//  1. Everything invisible is invisible the same way. Unknown, private-without-
+//     a-grant and blocked all return one localized not-found. A caller that
+//     could distinguish them could map the private catalog by probing IDs.
+//  2. Discoverability is not permission. A template appearing here says nothing
+//     about whether this caller may send or edit it (invariant 5); Bots keep
+//     using /v1/bot/card/profile, which is the authoritative send surface.
+//  3. Filtering happens before paging, in SQL. See store_discovery.go for why
+//     the reverse order leaks a count.
+//
+// The two sources are paged in sequence — the frozen static Registry first,
+// then dynamic rows — rather than merged into one ordering. The cursor names
+// which source it is in, so a page boundary never has to reconcile an
+// in-memory list against a SQL scan, and adding a dynamic template can never
+// shift a static page under a caller mid-iteration.
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl"
+	"github.com/Mininglamp-OSS/octo-server/pkg/space"
+)
+
+const (
+	discoveryCursorVersion = 1
+	discoverySourceStatic  = "static"
+	discoverySourceDynamic = "dynamic"
+	// discoveryDetailSeparator splits {id}@{version} in the B2 path.
+	discoveryDetailSeparator = "@"
+)
+
+// discoveryCursor is an opaque, self-describing page position.
+//
+// It carries the Space it was issued for so that replaying a cursor from
+// another Space fails closed rather than resuming a scan whose visibility
+// predicate no longer holds. It is not a capability and needs no signature:
+// every field is re-validated against the current request, and a forged cursor
+// can only move the caller within what they are already allowed to see.
+type discoveryCursor struct {
+	Version int    `json:"v"`
+	Space   string `json:"s"`
+	Source  string `json:"src"`
+	ID      string `json:"id"`
+	Exact   string `json:"ver"`
+}
+
+func encodeDiscoveryCursor(cursor discoveryCursor) string {
+	raw, err := json.Marshal(cursor)
+	if err != nil {
+		return ""
+	}
+	return base64.RawURLEncoding.EncodeToString(raw)
+}
+
+// decodeDiscoveryCursor rejects anything it cannot fully account for. A cursor
+// that is malformed, from another cursor version, or bound to a different Space
+// restarts the caller at the beginning instead of silently resuming somewhere
+// unintended.
+func decodeDiscoveryCursor(encoded, spaceID string) (discoveryCursor, bool) {
+	if strings.TrimSpace(encoded) == "" {
+		return discoveryCursor{Version: discoveryCursorVersion, Space: spaceID, Source: discoverySourceStatic}, true
+	}
+	raw, err := base64.RawURLEncoding.DecodeString(encoded)
+	if err != nil {
+		return discoveryCursor{}, false
+	}
+	var cursor discoveryCursor
+	if err := json.Unmarshal(raw, &cursor); err != nil {
+		return discoveryCursor{}, false
+	}
+	if cursor.Version != discoveryCursorVersion || cursor.Space != spaceID {
+		return discoveryCursor{}, false
+	}
+	if cursor.Source != discoverySourceStatic && cursor.Source != discoverySourceDynamic {
+		return discoveryCursor{}, false
+	}
+	return cursor, true
+}
+
+type discoveryActionContract struct {
+	Owner      string `json:"owner"`
+	ActionType string `json:"action_type"`
+}
+
+type discoveryListItem struct {
+	ID      string `json:"id"`
+	Version string `json:"version"`
+	Source  string `json:"source"`
+	Owner   string `json:"owner,omitempty"`
+	// Protocol and ContractVersion let a producer decide compatibility without
+	// fetching the full contract.
+	Protocol        string `json:"protocol"`
+	ContractVersion string `json:"contract_version,omitempty"`
+	Visibility      string `json:"visibility"`
+	// ActionContract is null for a display-only card. That null is the
+	// platform-card-base §9 promise: it tells a producer no callback will ever
+	// arrive for this template, which "absent field" could not distinguish
+	// from "not populated yet".
+	ActionContract *discoveryActionContract `json:"action_contract"`
+	// ActiveForNewSend reports that this exact version is what the activation
+	// pointer resolves to. It is emphatically not a statement that the caller
+	// may send it — send authorization lives behind the Bot profile.
+	ActiveForNewSend bool `json:"active_for_new_send"`
+}
+
+type discoveryListResponse struct {
+	Templates  []discoveryListItem `json:"templates"`
+	NextCursor string              `json:"next_cursor,omitempty"`
+	HasMore    bool                `json:"has_more"`
+}
+
+// discoveryStore is the read surface B1/B2 need. It is an interface so the
+// handler tests can drive the visibility matrix without a database.
+type discoveryStore interface {
+	ListDiscoverable(ctx context.Context, spaceID string, afterID cardtmpl.ID,
+		afterVersion string, limit int) ([]DiscoveryRow, bool, error)
+	LoadDiscoverable(ctx context.Context, spaceID string, id cardtmpl.ID,
+		version string) (DiscoveryRow, error)
+	StaticDiscoverGrants(ctx context.Context, spaceID string,
+		ids []cardtmpl.ID) (map[cardtmpl.ID]struct{}, error)
+}
+
+// listTemplates handles B1.
+func (a *API) listTemplates(c *wkhttp.Context) {
+	store, ok := a.discoveryStore()
+	if !ok {
+		respondCatalogUnavailable(c)
+		return
+	}
+	spaceID := space.GetSpaceID(c)
+	cursor, valid := decodeDiscoveryCursor(strings.TrimSpace(c.Query("cursor")), spaceID)
+	if !valid {
+		respondCatalogRequestInvalid(c, errors.New("cursor is not valid for this Space"))
+		return
+	}
+	limit, valid := discoveryPageLimit(c.Query("limit"))
+	if !valid {
+		respondCatalogRequestInvalid(c, errors.New("limit is out of range"))
+		return
+	}
+
+	ctx := c.Request.Context()
+	page := discoveryListResponse{Templates: []discoveryListItem{}}
+	if cursor.Source == discoverySourceStatic {
+		items, next, err := a.staticPage(ctx, store, spaceID, cursor, limit)
+		if err != nil {
+			respondCatalogUnavailable(c)
+			return
+		}
+		page.Templates = append(page.Templates, items...)
+		if next != nil {
+			page.NextCursor, page.HasMore = encodeDiscoveryCursor(*next), true
+			writeDiscoveryCacheHeaders(c, spaceID)
+			c.Response(page)
+			return
+		}
+		// The static source is exhausted; continue into dynamic from the top.
+		cursor = discoveryCursor{Version: discoveryCursorVersion, Space: spaceID, Source: discoverySourceDynamic}
+	}
+
+	remaining := limit - len(page.Templates)
+	if remaining <= 0 {
+		// Static filled the page exactly. Hand back a dynamic cursor at the top
+		// rather than querying with a zero budget, which the store's clamp
+		// would silently turn back into a full page.
+		page.NextCursor = encodeDiscoveryCursor(discoveryCursor{
+			Version: discoveryCursorVersion, Space: spaceID, Source: discoverySourceDynamic,
+		})
+		page.HasMore = true
+		writeDiscoveryCacheHeaders(c, spaceID)
+		c.Response(page)
+		return
+	}
+	rows, hasMore, err := store.ListDiscoverable(ctx, spaceID,
+		cardtmpl.ID(cursor.ID), cursor.Exact, remaining)
+	if err != nil {
+		respondCatalogUnavailable(c)
+		return
+	}
+	for _, row := range rows {
+		page.Templates = append(page.Templates, dynamicListItem(row))
+	}
+	if hasMore && len(rows) > 0 {
+		last := rows[len(rows)-1]
+		page.NextCursor = encodeDiscoveryCursor(discoveryCursor{
+			Version: discoveryCursorVersion, Space: spaceID, Source: discoverySourceDynamic,
+			ID: string(last.ID), Exact: last.Version,
+		})
+		page.HasMore = true
+	}
+	writeDiscoveryCacheHeaders(c, spaceID)
+	c.Response(page)
+}
+
+// staticPage returns the frozen templates visible to this caller, starting
+// after the cursor. A non-nil next cursor means the static source itself has
+// more rows; nil means the caller should move on to dynamic.
+func (a *API) staticPage(
+	ctx context.Context,
+	store discoveryStore,
+	spaceID string,
+	cursor discoveryCursor,
+	limit int,
+) ([]discoveryListItem, *discoveryCursor, error) {
+	entries := a.staticCatalog()
+	if len(entries) == 0 {
+		return nil, nil, nil
+	}
+	// Only private entries need a grant lookup, and only for IDs the caller
+	// could still reach on this page — a Space with no grants pays for one
+	// bounded query, not one per template.
+	privateIDs := make([]cardtmpl.ID, 0, len(entries))
+	for _, entry := range entries {
+		if entry.Visibility != cardtmpl.CatalogVisibilityPublic {
+			privateIDs = append(privateIDs, entry.ID)
+		}
+	}
+	granted, err := store.StaticDiscoverGrants(ctx, spaceID, privateIDs)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	items := make([]discoveryListItem, 0, limit)
+	for _, entry := range entries {
+		if !afterStaticCursor(entry, cursor) {
+			continue
+		}
+		if entry.Visibility != cardtmpl.CatalogVisibilityPublic {
+			if _, ok := granted[entry.ID]; !ok {
+				continue
+			}
+		}
+		if len(items) == limit {
+			// A visible row exists beyond this page, so hand back a cursor
+			// pointing at the last row we actually returned. Skipped rows never
+			// move the cursor — that is what keeps a hidden template from
+			// changing the shape of anyone else's pagination.
+			return items, &discoveryCursor{
+				Version: discoveryCursorVersion, Space: spaceID, Source: discoverySourceStatic,
+				ID: string(items[len(items)-1].ID), Exact: items[len(items)-1].Version,
+			}, nil
+		}
+		items = append(items, staticListItem(entry))
+	}
+	return items, nil, nil
+}
+
+func afterStaticCursor(entry cardtmpl.StaticCatalogEntry, cursor discoveryCursor) bool {
+	if cursor.ID == "" {
+		return true
+	}
+	if string(entry.ID) != cursor.ID {
+		return string(entry.ID) > cursor.ID
+	}
+	return entry.Version > cursor.Exact
+}
+
+func staticListItem(entry cardtmpl.StaticCatalogEntry) discoveryListItem {
+	item := discoveryListItem{
+		ID: string(entry.ID), Version: entry.Version, Source: discoverySourceStatic,
+		Owner: entry.Owner, Protocol: entry.Protocol,
+		ContractVersion: entry.ContractVersion, Visibility: entry.Visibility,
+		// A static template has no activation row of its own here; the default
+		// version registered in the frozen Registry is what a static new send
+		// resolves to.
+		ActiveForNewSend: entry.IsDefault,
+	}
+	if entry.ActionContract != nil {
+		item.ActionContract = &discoveryActionContract{
+			Owner: entry.ActionContract.Owner, ActionType: entry.ActionContract.ActionType,
+		}
+	}
+	return item
+}
+
+func dynamicListItem(row DiscoveryRow) discoveryListItem {
+	return discoveryListItem{
+		ID: string(row.ID), Version: row.Version, Source: discoverySourceDynamic,
+		Owner: row.Owner, Protocol: row.Protocol,
+		ContractVersion: row.ContractVersion, Visibility: row.Visibility,
+		ActiveForNewSend: row.ActiveForNewSend,
+		// The action contract of a dynamic template lives in its compiled
+		// projection, which B1 does not load — B1 is a metadata listing, and
+		// compiling every row to fill one field would make a list page cost as
+		// much as N detail requests. Callers read it from B2.
+	}
+}
+
+// getTemplate handles B2.
+func (a *API) getTemplate(c *wkhttp.Context) {
+	store, ok := a.discoveryStore()
+	if !ok {
+		respondCatalogUnavailable(c)
+		return
+	}
+	id, version, ok := parseDiscoveryRef(c.Param("ref"))
+	if !ok {
+		respondCatalogNotFound(c)
+		return
+	}
+	spaceID := space.GetSpaceID(c)
+	ctx := c.Request.Context()
+
+	if entry, found := a.staticEntry(id, version); found {
+		if entry.Visibility != cardtmpl.CatalogVisibilityPublic {
+			granted, err := store.StaticDiscoverGrants(ctx, spaceID, []cardtmpl.ID{id})
+			if err != nil {
+				respondCatalogUnavailable(c)
+				return
+			}
+			if _, ok := granted[id]; !ok {
+				respondCatalogNotFound(c)
+				return
+			}
+		}
+		export := a.staticExport(id, version)
+		if export == nil {
+			respondCatalogNotFound(c)
+			return
+		}
+		a.writeExport(c, spaceID, entry.Visibility, entry.ExportHash, export)
+		return
+	}
+
+	row, err := store.LoadDiscoverable(ctx, spaceID, id, version)
+	if err != nil {
+		if errors.Is(err, ErrDiscoveryNotVisible) {
+			respondCatalogNotFound(c)
+			return
+		}
+		respondCatalogUnavailable(c)
+		return
+	}
+	// The projection comes from the compiled artifact, which is the same
+	// immutable object the renderer uses. Building it here from the row would
+	// mean two definitions of "what this template promises".
+	meta, err := a.discoveryMeta(ctx, spaceID, id, version)
+	if err != nil {
+		if errors.Is(err, cardtmpl.ErrTemplateUnknown) ||
+			errors.Is(err, cardtmpl.ErrRuntimeCatalogNotAuthorized) ||
+			errors.Is(err, cardtmpl.ErrRuntimeCatalogBlocked) {
+			respondCatalogNotFound(c)
+			return
+		}
+		respondCatalogUnavailable(c)
+		return
+	}
+	export := meta.Export()
+	if export == nil {
+		respondCatalogNotFound(c)
+		return
+	}
+	// A dynamic template's ETag is its immutable content hash rather than the
+	// projection digest: the content hash also covers the documents the
+	// projection omits, so it can never collide across two artifacts that
+	// happen to project identically.
+	a.writeExport(c, spaceID, row.Visibility, row.ContentSHA256, export)
+}
+
+// writeExport emits the projection with conditional-request and cache headers.
+func (a *API) writeExport(
+	c *wkhttp.Context,
+	spaceID, visibility, etagSource string,
+	export *cardtmpl.SafeExport,
+) {
+	writeDiscoveryCacheHeaders(c, spaceID)
+	if visibility != cardtmpl.CatalogVisibilityPublic {
+		// A private contract must not be retained by a shared cache even when
+		// the caller is entitled to it — the next caller through that cache may
+		// not be.
+		c.Header("Cache-Control", "private, no-cache")
+	}
+	if etagSource == "" {
+		etagSource = export.Hash
+	}
+	etag := `"` + etagSource + `"`
+	c.Header("ETag", etag)
+	if matchesETag(c.GetHeader("If-None-Match"), etag) {
+		c.Status(http.StatusNotModified)
+		return
+	}
+	c.Response(export)
+}
+
+// matchesETag implements the subset of If-None-Match this endpoint needs:
+// a comma-separated list of entity tags, or "*". Weak validators are compared
+// by their opaque part, since the projection is byte-identical either way.
+func matchesETag(header, etag string) bool {
+	header = strings.TrimSpace(header)
+	if header == "" {
+		return false
+	}
+	if header == "*" {
+		return true
+	}
+	for _, candidate := range strings.Split(header, ",") {
+		candidate = strings.TrimSpace(candidate)
+		candidate = strings.TrimPrefix(candidate, "W/")
+		if candidate == etag {
+			return true
+		}
+	}
+	return false
+}
+
+func writeDiscoveryCacheHeaders(c *wkhttp.Context, spaceID string) {
+	if spaceID != "" {
+		c.Header("Cache-Control", "private, no-cache")
+		return
+	}
+	c.Header("Cache-Control", "no-cache")
+}
+
+// parseDiscoveryRef splits the {id}@{version} path segment. Both halves are
+// required: a bare ID would have to resolve through the activation pointer,
+// and a discovery read that followed the pointer would report a different
+// contract from one moment to the next.
+func parseDiscoveryRef(ref string) (cardtmpl.ID, string, bool) {
+	ref = strings.TrimSpace(ref)
+	at := strings.LastIndex(ref, discoveryDetailSeparator)
+	if at <= 0 || at == len(ref)-1 {
+		return "", "", false
+	}
+	id, version := strings.TrimSpace(ref[:at]), strings.TrimSpace(ref[at+1:])
+	if id == "" || version == "" {
+		return "", "", false
+	}
+	return cardtmpl.ID(id), version, true
+}
+
+func discoveryPageLimit(raw string) (int, bool) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return defaultDiscoveryPageSize, true
+	}
+	limit, err := strconv.Atoi(raw)
+	if err != nil || limit < 1 || limit > maxDiscoveryPageSize {
+		return 0, false
+	}
+	return limit, true
+}
+
+// managerTemplateStore is the operator index read. Separate from
+// discoveryStore because the two answer different questions: this one shows
+// everything, that one shows what a caller may see.
+type managerTemplateStore interface {
+	ListTemplates(ctx context.Context, after string, limit int) (ManagerTemplatePage, error)
+}
+
+type managerTemplateItem struct {
+	ID               string `json:"id"`
+	VersionCount     int    `json:"version_count"`
+	LatestVersion    string `json:"latest_version,omitempty"`
+	ActiveVersion    string `json:"active_version,omitempty"`
+	ActivationStatus string `json:"activation_status,omitempty"`
+	BlockedVersions  int    `json:"blocked_versions"`
+}
+
+type managerTemplateListResponse struct {
+	Templates  []managerTemplateItem `json:"templates"`
+	NextCursor string                `json:"next_cursor,omitempty"`
+}
+
+// managerList handles GET /v1/manager/card-templates. It is the read-only
+// index the control plane was missing: every other manager route needs a
+// template ID the operator already knows, which makes a freshly published or
+// half-rolled-back template hard to find.
+func (a *API) managerList(c *wkhttp.Context) {
+	if !a.requireSuperAdmin(c) {
+		return
+	}
+	store, ok := a.store.(managerTemplateStore)
+	if !ok {
+		respondCatalogUnavailable(c)
+		return
+	}
+	limit, valid := discoveryPageLimit(c.Query("limit"))
+	if !valid {
+		respondCatalogRequestInvalid(c, errors.New("limit is out of range"))
+		return
+	}
+	page, err := store.ListTemplates(c.Request.Context(), strings.TrimSpace(c.Query("cursor")), limit)
+	if err != nil {
+		respondCatalogUnavailable(c)
+		return
+	}
+	response := managerTemplateListResponse{
+		Templates:  make([]managerTemplateItem, 0, len(page.Templates)),
+		NextCursor: page.NextCursor,
+	}
+	for _, summary := range page.Templates {
+		response.Templates = append(response.Templates, managerTemplateItem{
+			ID: string(summary.ID), VersionCount: summary.VersionCount,
+			LatestVersion: summary.LatestVersion, ActiveVersion: summary.ActiveVersion,
+			ActivationStatus: summary.ActivationStatus, BlockedVersions: summary.BlockedVersions,
+		})
+	}
+	c.Response(response)
+}
+
+// discoveryStore returns the read surface, or false when this API has no store
+// that implements it. Failing closed matters more than degrading: a listing
+// that silently returned only static templates would look like a complete
+// answer.
+func (a *API) discoveryStore() (discoveryStore, bool) {
+	if a == nil {
+		return nil, false
+	}
+	if a.discovery != nil {
+		return a.discovery, true
+	}
+	store, ok := a.store.(discoveryStore)
+	return store, ok
+}
+
+// staticCatalog lists the frozen Registry. An API constructed without one (as
+// some focused tests are) simply has no static half.
+func (a *API) staticCatalog() []cardtmpl.StaticCatalogEntry {
+	if a == nil || a.registry == nil {
+		return nil
+	}
+	return a.registry.StaticCatalog()
+}
+
+func (a *API) staticEntry(id cardtmpl.ID, version string) (cardtmpl.StaticCatalogEntry, bool) {
+	for _, entry := range a.staticCatalog() {
+		if entry.ID == id && entry.Version == version {
+			return entry, true
+		}
+	}
+	return cardtmpl.StaticCatalogEntry{}, false
+}
+
+func (a *API) staticExport(id cardtmpl.ID, version string) *cardtmpl.SafeExport {
+	if a == nil || a.registry == nil {
+		return nil
+	}
+	return a.registry.ExportFor(id, version)
+}
+
+// discoveryMeta resolves a dynamic template's compiled metadata through the
+// runtime catalog, so the projection served here is the same object the
+// renderer would use and the read passes the same one-snapshot authorization
+// every other dynamic access does.
+func (a *API) discoveryMeta(
+	ctx context.Context,
+	spaceID string,
+	id cardtmpl.ID,
+	version string,
+) (cardtmpl.TemplateMeta, error) {
+	catalog := cardtmpl.DefaultCatalog()
+	if catalog == nil {
+		return cardtmpl.TemplateMeta{}, cardtmpl.ErrRuntimeCatalogUnavailable
+	}
+	return catalog.MetaExact(ctx, cardtmpl.CatalogExactRequest{
+		Access: cardtmpl.CatalogAccess{
+			Purpose: cardtmpl.CatalogPurposeDiscover,
+			Principal: cardtmpl.CatalogPrincipal{
+				// A Space principal's grants are always global-scoped (D2), so
+				// the identity is the Space itself and the scope stays empty.
+				Kind: cardtmpl.CatalogPrincipalSpace, ID: spaceID,
+			},
+		},
+		ID: id, Version: version,
+	})
+}

--- a/modules/card_template_catalog/api_discovery_handler_test.go
+++ b/modules/card_template_catalog/api_discovery_handler_test.go
@@ -179,11 +179,30 @@ func TestListTemplatesFailsClosedWithoutAStore(t *testing.T) {
 	}
 }
 
+// installEmptyRuntimeCatalog points the process default at a catalog that knows
+// no templates, so every dynamic B2 resolve answers ErrTemplateUnknown. B2 is
+// decided entirely by the runtime catalog now — it deliberately no longer asks
+// the discovery predicate a second time — so a handler test that says anything
+// about B2's answers has to install one.
+func installEmptyRuntimeCatalog(t *testing.T) {
+	t.Helper()
+	registry := cardtmpl.NewRegistry()
+	registry.Freeze()
+	catalog, err := cardtmpl.NewStaticCatalog(registry)
+	if err != nil {
+		t.Fatalf("build empty catalog: %v", err)
+	}
+	previous := cardtmpl.DefaultCatalog()
+	cardtmpl.SetDefaultCatalog(catalog)
+	t.Cleanup(func() { cardtmpl.SetDefaultCatalog(previous) })
+}
+
 // Unknown, invisible and blocked must be wire-identical. If they were not, an
-// authenticated caller could map the private catalog by probing IDs.
+// authenticated caller could map the private catalog by probing IDs. A
+// malformed ref has to land on the same answer too, since a distinguishable
+// parse error would confirm that the rest of the path exists.
 func TestGetTemplateAnswersOneNotFoundForEveryInvisibleReason(t *testing.T) {
-	// The fake's LoadDiscoverable always reports ErrDiscoveryNotVisible, which
-	// is precisely the store's single answer for all three reasons.
+	installEmptyRuntimeCatalog(t)
 	store := &fakeDiscoveryStore{}
 	var bodies []string
 	for _, ref := range []string{

--- a/modules/card_template_catalog/api_discovery_handler_test.go
+++ b/modules/card_template_catalog/api_discovery_handler_test.go
@@ -1,0 +1,569 @@
+package card_template_catalog
+
+// PR-C D5 evidence at the HTTP boundary.
+//
+// The sibling file covers the pure decisions (cursor binding, ETag comparison,
+// page bounds). This one drives the handlers themselves, because several
+// acceptance promises are only observable in the response: that a 304 carries
+// no body, that a private contract is not shared-cacheable, that unknown and
+// invisible are wire-identical, and that a hidden row cannot change the shape
+// of anyone's pagination.
+//
+// The handlers are exercised directly rather than through the router. Route
+// wiring and middleware are covered by the authenticated-route guard in
+// api_test.go; what needs proving here is what the handler writes, and going
+// through the full stack would mean standing up auth and Space membership to
+// observe a cache header.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl"
+	"github.com/gin-gonic/gin"
+)
+
+// newDiscoveryRequest builds a context for one discovery call. spaceID is set
+// the way the localized Space middleware sets it, so the handler sees exactly
+// what it would see in production after membership was verified.
+func newDiscoveryRequest(t *testing.T, target, spaceID string, header http.Header) (
+	*wkhttp.Context, *httptest.ResponseRecorder,
+) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	recorder := httptest.NewRecorder()
+	ginCtx, _ := gin.CreateTestContext(recorder)
+	ginCtx.Request = httptest.NewRequest(http.MethodGet, target, nil)
+	if header != nil {
+		ginCtx.Request.Header = header
+	}
+	if spaceID != "" {
+		ginCtx.Set("space_id", spaceID)
+	}
+	return &wkhttp.Context{Context: ginCtx}, recorder
+}
+
+// discoveryAPI wires only the read surface. The discovery field is the test
+// seam for exactly this: a handler test has no business standing up the publish
+// store to observe a cache header.
+func discoveryAPI(store discoveryStore) *API {
+	return &API{discovery: store}
+}
+
+func decodeListResponse(t *testing.T, recorder *httptest.ResponseRecorder) discoveryListResponse {
+	t.Helper()
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
+	}
+	var page discoveryListResponse
+	if err := json.Unmarshal(recorder.Body.Bytes(), &page); err != nil {
+		t.Fatalf("decode list response: %v (body %s)", err, recorder.Body.String())
+	}
+	return page
+}
+
+func dynamicRow(id cardtmpl.ID, version string, active bool) DiscoveryRow {
+	return DiscoveryRow{
+		ID: id, Version: version, Owner: "docs", Protocol: cardtmpl.Protocol,
+		ContractVersion: "1.0.0", Visibility: cardtmpl.CatalogVisibilityPrivate,
+		ContentSHA256: strings.Repeat("a", 64), ActiveForNewSend: active,
+	}
+}
+
+func TestListTemplatesReturnsVisibleRowsAndAdvancesTheCursor(t *testing.T) {
+	store := &fakeDiscoveryStore{rows: []DiscoveryRow{
+		dynamicRow("pilot.one", "1.0.0", true),
+		dynamicRow("pilot.two", "2.0.0", false),
+	}}
+	c, recorder := newDiscoveryRequest(t, "/v1/message/card/templates", "space-1", nil)
+	discoveryAPI(store).listTemplates(c)
+
+	page := decodeListResponse(t, recorder)
+	if len(page.Templates) != 2 {
+		t.Fatalf("templates = %+v", page.Templates)
+	}
+	first := page.Templates[0]
+	if first.ID != "pilot.one" || first.Source != discoverySourceDynamic ||
+		first.Visibility != cardtmpl.CatalogVisibilityPrivate || !first.ActiveForNewSend {
+		t.Fatalf("first row = %+v", first)
+	}
+	// active_for_new_send says which version the pointer resolves to. It must
+	// not be read as permission — nothing in this response grants anything.
+	if page.Templates[1].ActiveForNewSend {
+		t.Fatalf("second row claimed to be active: %+v", page.Templates[1])
+	}
+	if page.HasMore || page.NextCursor != "" {
+		t.Fatalf("exhausted page still advertised more: %+v", page)
+	}
+	// A Space-scoped read must not be retained by a shared cache.
+	if got := recorder.Header().Get("Cache-Control"); got != "private, no-cache" {
+		t.Fatalf("Cache-Control = %q, want private, no-cache", got)
+	}
+}
+
+// A page that fills the limit hands back a cursor bound to this Space, and the
+// caller can resume with it.
+func TestListTemplatesPaginationIsBoundedAndResumable(t *testing.T) {
+	store := &fakeDiscoveryStore{rows: []DiscoveryRow{
+		dynamicRow("pilot.one", "1.0.0", true),
+		dynamicRow("pilot.two", "2.0.0", false),
+	}}
+	c, recorder := newDiscoveryRequest(t, "/v1/message/card/templates?limit=1", "space-1", nil)
+	discoveryAPI(store).listTemplates(c)
+
+	page := decodeListResponse(t, recorder)
+	if len(page.Templates) != 1 || !page.HasMore || page.NextCursor == "" {
+		t.Fatalf("bounded page = %+v", page)
+	}
+	if store.listCalls[0] != 1 {
+		t.Fatalf("store was asked for %d rows, want the requested limit", store.listCalls[0])
+	}
+	cursor, ok := decodeDiscoveryCursor(page.NextCursor, "space-1")
+	if !ok || cursor.ID != "pilot.one" || cursor.Exact != "1.0.0" {
+		t.Fatalf("next cursor = %+v ok=%v, want the last returned row", cursor, ok)
+	}
+	// The same cursor is refused in another Space, so it cannot be used to
+	// resume a scan whose visibility predicate no longer holds.
+	replay, replayRecorder := newDiscoveryRequest(t,
+		"/v1/message/card/templates?cursor="+page.NextCursor, "space-other", nil)
+	discoveryAPI(store).listTemplates(replay)
+	if replayRecorder.Code == http.StatusOK {
+		t.Fatalf("a cursor from space-1 was accepted in space-other: %s", replayRecorder.Body.String())
+	}
+}
+
+func TestListTemplatesRejectsAnOutOfRangeLimit(t *testing.T) {
+	store := &fakeDiscoveryStore{}
+	for _, target := range []string{
+		"/v1/message/card/templates?limit=0",
+		"/v1/message/card/templates?limit=101",
+		"/v1/message/card/templates?limit=abc",
+	} {
+		c, recorder := newDiscoveryRequest(t, target, "space-1", nil)
+		discoveryAPI(store).listTemplates(c)
+		if recorder.Code == http.StatusOK {
+			t.Fatalf("%s was accepted", target)
+		}
+	}
+}
+
+// A caller with no Space context still gets a well-formed page — the public
+// catalog — and a response that is merely not-cacheable rather than private.
+func TestListTemplatesWithoutSpaceContextStillAnswers(t *testing.T) {
+	store := &fakeDiscoveryStore{}
+	c, recorder := newDiscoveryRequest(t, "/v1/message/card/templates", "", nil)
+	discoveryAPI(store).listTemplates(c)
+
+	page := decodeListResponse(t, recorder)
+	// Never null: a caller should not have to distinguish "no templates" from
+	// "field missing".
+	if page.Templates == nil || len(page.Templates) != 0 {
+		t.Fatalf("templates = %+v, want an empty array", page.Templates)
+	}
+	if got := recorder.Header().Get("Cache-Control"); got != "no-cache" {
+		t.Fatalf("Cache-Control = %q", got)
+	}
+}
+
+func TestListTemplatesFailsClosedWithoutAStore(t *testing.T) {
+	c, recorder := newDiscoveryRequest(t, "/v1/message/card/templates", "space-1", nil)
+	(&API{}).listTemplates(c)
+	if recorder.Code == http.StatusOK {
+		t.Fatalf("a listing without a store answered OK: %s", recorder.Body.String())
+	}
+}
+
+// Unknown, invisible and blocked must be wire-identical. If they were not, an
+// authenticated caller could map the private catalog by probing IDs.
+func TestGetTemplateAnswersOneNotFoundForEveryInvisibleReason(t *testing.T) {
+	// The fake's LoadDiscoverable always reports ErrDiscoveryNotVisible, which
+	// is precisely the store's single answer for all three reasons.
+	store := &fakeDiscoveryStore{}
+	var bodies []string
+	for _, ref := range []string{
+		"pilot.does-not-exist@1.0.0", // unknown
+		"pilot.private@1.0.0",        // exists, not visible to this Space
+		"pilot.blocked@1.0.0",        // exists, visible, blocked
+	} {
+		c, recorder := newDiscoveryRequest(t, "/v1/message/card/templates/"+ref, "space-1", nil)
+		c.Params = gin.Params{{Key: "ref", Value: ref}}
+		discoveryAPI(store).getTemplate(c)
+		if recorder.Code == http.StatusOK {
+			t.Fatalf("%s answered OK", ref)
+		}
+		bodies = append(bodies, recorder.Body.String())
+	}
+	for _, body := range bodies[1:] {
+		if body != bodies[0] {
+			t.Fatalf("invisible reasons are distinguishable:\n%s\n%s", bodies[0], body)
+		}
+	}
+	// A malformed ref must land on the same answer rather than a parse error
+	// that confirms the rest of the path exists.
+	c, recorder := newDiscoveryRequest(t, "/v1/message/card/templates/no-version", "space-1", nil)
+	c.Params = gin.Params{{Key: "ref", Value: "no-version"}}
+	discoveryAPI(store).getTemplate(c)
+	if recorder.Body.String() != bodies[0] {
+		t.Fatalf("a malformed ref is distinguishable:\n%s\n%s", bodies[0], recorder.Body.String())
+	}
+}
+
+// writeExport is the only place the projection reaches a caller, so the
+// conditional-request and cache contract is asserted on it directly.
+func TestWriteExportServesETagAndA304WithoutABody(t *testing.T) {
+	export := &cardtmpl.SafeExport{
+		ID: "pilot.card", Version: "1.0.0", Visibility: cardtmpl.CatalogVisibilityPrivate,
+		Samples: map[string]json.RawMessage{},
+		Hash:    "exporthash",
+	}
+	api := discoveryAPI(&fakeDiscoveryStore{})
+	const contentHash = "contenthash"
+
+	c, recorder := newDiscoveryRequest(t, "/v1/message/card/templates/pilot.card@1.0.0", "space-1", nil)
+	api.writeExport(c, "space-1", cardtmpl.CatalogVisibilityPrivate, contentHash, export)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d", recorder.Code)
+	}
+	etag := recorder.Header().Get("ETag")
+	if etag != `"`+contentHash+`"` {
+		t.Fatalf("ETag = %q, want the immutable content hash", etag)
+	}
+	if recorder.Body.Len() == 0 {
+		t.Fatal("first response carried no projection")
+	}
+	if got := recorder.Header().Get("Cache-Control"); got != "private, no-cache" {
+		t.Fatalf("private Cache-Control = %q", got)
+	}
+
+	// Same ETag back → 304, and nothing in the body.
+	header := http.Header{}
+	header.Set("If-None-Match", etag)
+	conditional, conditionalRecorder := newDiscoveryRequest(t,
+		"/v1/message/card/templates/pilot.card@1.0.0", "space-1", header)
+	api.writeExport(conditional, "space-1", cardtmpl.CatalogVisibilityPrivate, contentHash, export)
+	if conditionalRecorder.Code != http.StatusNotModified {
+		t.Fatalf("conditional status = %d, want 304", conditionalRecorder.Code)
+	}
+	if conditionalRecorder.Body.Len() != 0 {
+		t.Fatalf("304 carried a body: %s", conditionalRecorder.Body.String())
+	}
+
+	// A stale ETag gets the projection again.
+	stale := http.Header{}
+	stale.Set("If-None-Match", `"someotherhash"`)
+	fresh, freshRecorder := newDiscoveryRequest(t,
+		"/v1/message/card/templates/pilot.card@1.0.0", "space-1", stale)
+	api.writeExport(fresh, "space-1", cardtmpl.CatalogVisibilityPrivate, contentHash, export)
+	if freshRecorder.Code != http.StatusOK || freshRecorder.Body.Len() == 0 {
+		t.Fatalf("stale validator = %d body=%d", freshRecorder.Code, freshRecorder.Body.Len())
+	}
+}
+
+// A static template has no immutable content hash, so its deterministic export
+// digest is the validator instead.
+func TestWriteExportFallsBackToTheExportHashForStaticTemplates(t *testing.T) {
+	export := &cardtmpl.SafeExport{
+		ID: "test.static", Version: "1.0.0", Visibility: cardtmpl.CatalogVisibilityPublic,
+		Samples: map[string]json.RawMessage{}, Hash: "staticexporthash",
+	}
+	c, recorder := newDiscoveryRequest(t, "/v1/message/card/templates/test.static@1.0.0", "", nil)
+	discoveryAPI(&fakeDiscoveryStore{}).writeExport(c, "", cardtmpl.CatalogVisibilityPublic, "", export)
+	if got := recorder.Header().Get("ETag"); got != `"staticexporthash"` {
+		t.Fatalf("static ETag = %q", got)
+	}
+	// A public contract read outside any Space is cacheable-with-revalidation
+	// rather than private.
+	if got := recorder.Header().Get("Cache-Control"); got != "no-cache" {
+		t.Fatalf("public Cache-Control = %q", got)
+	}
+}
+
+// The response must never carry control-plane state, whatever the projection
+// happens to hold.
+func TestDiscoveryResponsesCarryNoControlPlaneFields(t *testing.T) {
+	store := &fakeDiscoveryStore{rows: []DiscoveryRow{dynamicRow("pilot.one", "1.0.0", true)}}
+	c, recorder := newDiscoveryRequest(t, "/v1/message/card/templates", "space-1", nil)
+	discoveryAPI(store).listTemplates(c)
+
+	body := recorder.Body.String()
+	for _, forbidden := range []string{
+		"grant", "revision", "audit", "actor", "change_ticket", "canonical_bundle", "blocked_at",
+	} {
+		if strings.Contains(body, forbidden) {
+			t.Fatalf("discovery response leaked %q: %s", forbidden, body)
+		}
+	}
+}
+
+func staticEntry(id cardtmpl.ID, version, visibility string, isDefault bool) cardtmpl.StaticCatalogEntry {
+	entry := cardtmpl.StaticCatalogEntry{
+		ID: id, Version: version, Owner: "docs", Protocol: cardtmpl.Protocol,
+		ContractVersion: "1.1.0", Visibility: visibility,
+		ExportHash: "hash-" + string(id) + "-" + version, IsDefault: isDefault,
+	}
+	if visibility == cardtmpl.CatalogVisibilityPublic {
+		entry.ActionContract = &cardtmpl.TemplateActionContract{
+			Owner: "docs", ActionType: "access_request.decision",
+		}
+	}
+	return entry
+}
+
+func staticDiscoveryAPI(store discoveryStore, entries ...cardtmpl.StaticCatalogEntry) *API {
+	api := discoveryAPI(store)
+	api.staticEntries = func() []cardtmpl.StaticCatalogEntry { return entries }
+	return api
+}
+
+// A static template is private unless the composition root published it, and a
+// private one needs the caller's Space to hold a discover grant.
+func TestStaticPageShowsPublicAndGrantedPrivateOnly(t *testing.T) {
+	store := &fakeDiscoveryStore{granted: map[cardtmpl.ID]struct{}{"docs.granted": {}}}
+	api := staticDiscoveryAPI(store,
+		staticEntry("docs.granted", "1.0.0", cardtmpl.CatalogVisibilityPrivate, true),
+		staticEntry("docs.hidden", "1.0.0", cardtmpl.CatalogVisibilityPrivate, true),
+		staticEntry("docs.open", "1.0.0", cardtmpl.CatalogVisibilityPublic, false),
+	)
+	c, recorder := newDiscoveryRequest(t, "/v1/message/card/templates", "space-1", nil)
+	api.listTemplates(c)
+
+	page := decodeListResponse(t, recorder)
+	seen := map[string]discoveryListItem{}
+	for _, item := range page.Templates {
+		seen[item.ID] = item
+	}
+	if _, hidden := seen["docs.hidden"]; hidden {
+		t.Fatalf("an ungranted private template was listed: %+v", page.Templates)
+	}
+	if len(seen) != 2 {
+		t.Fatalf("templates = %+v, want the granted private and the public one", page.Templates)
+	}
+	if got := seen["docs.granted"]; got.Source != discoverySourceStatic || !got.ActiveForNewSend {
+		t.Fatalf("granted static row = %+v", got)
+	}
+	// A display-only card reports action_contract:null; a card with a callback
+	// reports the routing pair. That null is the §9 promise, so it is asserted
+	// on the decoded item rather than inferred from the struct.
+	if seen["docs.granted"].ActionContract != nil {
+		t.Fatalf("private fixture unexpectedly carried a contract: %+v", seen["docs.granted"])
+	}
+	contract := seen["docs.open"].ActionContract
+	if contract == nil || contract.Owner != "docs" || contract.ActionType != "access_request.decision" {
+		t.Fatalf("public row action_contract = %+v", contract)
+	}
+}
+
+// The cursor advances only past rows the caller actually received. If a hidden
+// row could move it, the page length would leak how many templates exist that
+// this caller may not see.
+func TestStaticPageCursorSkipsHiddenRowsWithoutCountingThem(t *testing.T) {
+	store := &fakeDiscoveryStore{granted: map[cardtmpl.ID]struct{}{
+		"docs.a": {}, "docs.c": {},
+	}}
+	api := staticDiscoveryAPI(store,
+		staticEntry("docs.a", "1.0.0", cardtmpl.CatalogVisibilityPrivate, true),
+		staticEntry("docs.b", "1.0.0", cardtmpl.CatalogVisibilityPrivate, true), // hidden
+		staticEntry("docs.c", "1.0.0", cardtmpl.CatalogVisibilityPrivate, true),
+	)
+	c, recorder := newDiscoveryRequest(t, "/v1/message/card/templates?limit=1", "space-1", nil)
+	api.listTemplates(c)
+
+	page := decodeListResponse(t, recorder)
+	if len(page.Templates) != 1 || page.Templates[0].ID != "docs.a" || !page.HasMore {
+		t.Fatalf("first page = %+v", page)
+	}
+	cursor, ok := decodeDiscoveryCursor(page.NextCursor, "space-1")
+	if !ok || cursor.ID != "docs.a" || cursor.Source != discoverySourceStatic {
+		t.Fatalf("cursor = %+v ok=%v, want the last *returned* row", cursor, ok)
+	}
+
+	// Resuming lands on the next visible row, and the hidden one never appears.
+	next, nextRecorder := newDiscoveryRequest(t,
+		"/v1/message/card/templates?limit=1&cursor="+page.NextCursor, "space-1", nil)
+	api.listTemplates(next)
+	second := decodeListResponse(t, nextRecorder)
+	if len(second.Templates) != 1 || second.Templates[0].ID != "docs.c" {
+		t.Fatalf("second page = %+v, want docs.c", second.Templates)
+	}
+}
+
+// A static-source page that fills the limit exactly must not claim another page
+// unless the dynamic source really holds one.
+func TestStaticPageBoundaryConsultsTheDynamicSource(t *testing.T) {
+	entries := []cardtmpl.StaticCatalogEntry{
+		staticEntry("docs.open", "1.0.0", cardtmpl.CatalogVisibilityPublic, true),
+	}
+	empty := &fakeDiscoveryStore{}
+	c, recorder := newDiscoveryRequest(t, "/v1/message/card/templates?limit=1", "space-1", nil)
+	staticDiscoveryAPI(empty, entries...).listTemplates(c)
+	if page := decodeListResponse(t, recorder); page.HasMore || page.NextCursor != "" {
+		t.Fatalf("empty dynamic source still advertised a page: %+v", page)
+	}
+	if len(empty.listCalls) != 1 || empty.listCalls[0] != 1 {
+		t.Fatalf("boundary probe budgets = %v, want a single one-row peek", empty.listCalls)
+	}
+
+	stocked := &fakeDiscoveryStore{rows: []DiscoveryRow{dynamicRow("pilot.one", "1.0.0", true)}}
+	c2, recorder2 := newDiscoveryRequest(t, "/v1/message/card/templates?limit=1", "space-1", nil)
+	staticDiscoveryAPI(stocked, entries...).listTemplates(c2)
+	page := decodeListResponse(t, recorder2)
+	if !page.HasMore || page.NextCursor == "" {
+		t.Fatalf("stocked dynamic source was not advertised: %+v", page)
+	}
+	cursor, _ := decodeDiscoveryCursor(page.NextCursor, "space-1")
+	if cursor.Source != discoverySourceDynamic || cursor.ID != "" {
+		t.Fatalf("boundary cursor = %+v, want the top of the dynamic source", cursor)
+	}
+}
+
+// A grant-probe failure fails the listing closed. Serving only the public rows
+// would look like a complete answer to a caller who should have seen more.
+func TestStaticPageFailsClosedWhenTheGrantProbeFails(t *testing.T) {
+	store := &grantProbeFailureStore{}
+	api := staticDiscoveryAPI(store,
+		staticEntry("docs.hidden", "1.0.0", cardtmpl.CatalogVisibilityPrivate, true))
+	c, recorder := newDiscoveryRequest(t, "/v1/message/card/templates", "space-1", nil)
+	api.listTemplates(c)
+	if recorder.Code == http.StatusOK {
+		t.Fatalf("a failed grant probe answered OK: %s", recorder.Body.String())
+	}
+}
+
+type grantProbeFailureStore struct{ fakeDiscoveryStore }
+
+func (s *grantProbeFailureStore) StaticDiscoverGrants(
+	context.Context, string, []cardtmpl.ID,
+) (map[cardtmpl.ID]struct{}, error) {
+	return nil, errors.New("db unavailable")
+}
+
+type fakeManagerStore struct {
+	fakeDiscoveryStore
+	page ManagerTemplatePage
+	err  error
+}
+
+func (s *fakeManagerStore) ListTemplates(context.Context, string, int) (ManagerTemplatePage, error) {
+	if s.err != nil {
+		return ManagerTemplatePage{}, s.err
+	}
+	return s.page, nil
+}
+
+// newManagerRequest is newDiscoveryRequest plus the role AuthMiddleware writes
+// for a super admin. The manager surface is superAdmin-only; without the role
+// every call short-circuits on the permission check and the projection below
+// would never be reached.
+func newManagerRequest(t *testing.T, target string) (*wkhttp.Context, *httptest.ResponseRecorder) {
+	t.Helper()
+	c, recorder := newDiscoveryRequest(t, target, "", nil)
+	c.Set("role", string(wkhttp.SuperAdmin))
+	return c, recorder
+}
+
+// A non-superAdmin must not reach the control plane at all: the manager index
+// reports blocked and disabled templates across every Space, which is exactly
+// the inventory a tenant caller should never see.
+func TestManagerListRejectsCallersWhoAreNotSuperAdmin(t *testing.T) {
+	for _, role := range []string{"", "admin", "common"} {
+		c, recorder := newDiscoveryRequest(t, "/v1/manager/card-templates", "", nil)
+		if role != "" {
+			c.Set("role", role)
+		}
+		(&API{discovery: &fakeManagerStore{}}).managerList(c)
+		if recorder.Code == http.StatusOK {
+			t.Fatalf("role %q reached the manager index: %s", role, recorder.Body.String())
+		}
+	}
+}
+
+// The manager index deliberately shows everything, including blocked and
+// disabled templates — hiding rows on the control plane would remove exactly
+// what an operator needs during an incident.
+func TestManagerListReportsEveryTemplateIncludingBrokenOnes(t *testing.T) {
+	store := &fakeManagerStore{page: ManagerTemplatePage{
+		Templates: []ManagerTemplateSummary{
+			{ID: "docs.a", VersionCount: 3, LatestVersion: "1.2.0",
+				ActiveVersion: "1.1.0", ActivationStatus: "active", BlockedVersions: 1},
+			{ID: "docs.b", VersionCount: 1, LatestVersion: "0.1.0", ActivationStatus: "disabled"},
+		},
+		NextCursor: "docs.b",
+	}}
+	api := &API{discovery: store}
+	c, recorder := newManagerRequest(t, "/v1/manager/card-templates")
+	api.managerList(c)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d body = %s", recorder.Code, recorder.Body.String())
+	}
+	var response managerTemplateListResponse
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(response.Templates) != 2 || response.NextCursor != "docs.b" {
+		t.Fatalf("response = %+v", response)
+	}
+	if response.Templates[0].BlockedVersions != 1 || response.Templates[1].ActivationStatus != "disabled" {
+		t.Fatalf("manager rows hid diagnostic state: %+v", response.Templates)
+	}
+}
+
+func TestManagerListRejectsABadLimitAndFailsClosedOnStoreError(t *testing.T) {
+	c, recorder := newDiscoveryRequest(t, "/v1/manager/card-templates?limit=999", "", nil)
+	(&API{discovery: &fakeManagerStore{}}).managerList(c)
+	if recorder.Code == http.StatusOK {
+		t.Fatal("an out-of-range limit was accepted")
+	}
+
+	failing, failingRecorder := newDiscoveryRequest(t, "/v1/manager/card-templates", "", nil)
+	(&API{discovery: &fakeManagerStore{err: errors.New("db unavailable")}}).managerList(failing)
+	if failingRecorder.Code == http.StatusOK {
+		t.Fatal("a store failure answered OK")
+	}
+}
+
+// visibleRowStore reports a dynamic row as discoverable. It exists to drive the
+// half of B2 the ordinary fakes cannot reach: the point where the discovery
+// predicate has already said yes and the runtime catalog is asked to authorize
+// the same read.
+type visibleRowStore struct {
+	fakeDiscoveryStore
+	row DiscoveryRow
+}
+
+func (s *visibleRowStore) LoadDiscoverable(
+	context.Context, string, cardtmpl.ID, string,
+) (DiscoveryRow, error) {
+	return s.row, nil
+}
+
+// The discovery predicate and the runtime authorizer are two different reads,
+// and they can disagree — a row visible to the SQL predicate may still be one
+// the runtime catalog refuses to resolve for this principal. When they
+// disagree, discovery must not be the one that wins: B2 serves the projection
+// only when the runtime catalog produced it, never from the listing row alone.
+//
+// The assertion is deliberately on "not OK" rather than on a specific status.
+// Both refusals are correct here (unresolvable → unavailable, unauthorized or
+// unknown → the single not-found), and which one a deployment hits depends on
+// whether a runtime catalog is installed at all. Pinning the code would be
+// pinning the test environment, not the contract.
+func TestGetTemplateWillNotServeARowTheRuntimeCatalogCannotAuthorize(t *testing.T) {
+	store := &visibleRowStore{row: dynamicRow("pilot.unresolvable", "1.0.0", true)}
+	const ref = "pilot.unresolvable@1.0.0"
+	c, recorder := newDiscoveryRequest(t, "/v1/message/card/templates/"+ref, "space-1", nil)
+	c.Params = gin.Params{{Key: "ref", Value: ref}}
+	discoveryAPI(store).getTemplate(c)
+	if recorder.Code == http.StatusOK {
+		t.Fatalf("B2 served a projection the runtime catalog never produced: %s",
+			recorder.Body.String())
+	}
+	if strings.Contains(recorder.Body.String(), "content_sha256") {
+		t.Fatalf("the refusal leaked listing-row state: %s", recorder.Body.String())
+	}
+}

--- a/modules/card_template_catalog/api_discovery_test.go
+++ b/modules/card_template_catalog/api_discovery_test.go
@@ -1,0 +1,134 @@
+package card_template_catalog
+
+// PR-C D5 evidence for the discovery request plumbing.
+//
+// These cover the parts that decide *what a caller can reach* before any store
+// is consulted: the cursor's Space binding, the exact-ref requirement, the
+// conditional-request comparison and the page bounds. Each one is a place where
+// being permissive would either leak the private catalog or quietly change what
+// a paginating caller sees.
+
+import (
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl"
+)
+
+// A cursor is bound to the Space it was issued for. Replaying one against a
+// different Space must restart the caller rather than resume a scan whose
+// visibility predicate no longer holds — otherwise a cursor obtained in a Space
+// with broad grants becomes a way to page through another Space's view.
+func TestDiscoveryCursorIsBoundToItsSpace(t *testing.T) {
+	issued := encodeDiscoveryCursor(discoveryCursor{
+		Version: discoveryCursorVersion, Space: "space-1",
+		Source: discoverySourceDynamic, ID: "pilot.card", Exact: "1.0.0",
+	})
+	if issued == "" {
+		t.Fatal("cursor did not encode")
+	}
+
+	decoded, ok := decodeDiscoveryCursor(issued, "space-1")
+	if !ok || decoded.ID != "pilot.card" || decoded.Exact != "1.0.0" ||
+		decoded.Source != discoverySourceDynamic {
+		t.Fatalf("round trip = %+v ok=%v", decoded, ok)
+	}
+
+	for _, replay := range []string{"space-2", ""} {
+		if _, ok := decodeDiscoveryCursor(issued, replay); ok {
+			t.Fatalf("cursor issued for space-1 was accepted in %q", replay)
+		}
+	}
+}
+
+func TestDiscoveryCursorRejectsWhatItCannotAccountFor(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		encoded string
+	}{
+		{"not base64", "!!!not-base64!!!"},
+		{"not json", "bm90LWpzb24"},
+		{"unknown cursor version", encodeDiscoveryCursor(discoveryCursor{
+			Version: discoveryCursorVersion + 1, Space: "space-1", Source: discoverySourceStatic})},
+		{"unknown source", encodeDiscoveryCursor(discoveryCursor{
+			Version: discoveryCursorVersion, Space: "space-1", Source: "elsewhere"})},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if _, ok := decodeDiscoveryCursor(test.encoded, "space-1"); ok {
+				t.Fatal("cursor was accepted")
+			}
+		})
+	}
+
+	// An absent cursor is not an error: it is the first page, and it starts on
+	// the static source so the two sources are paged in a fixed order.
+	first, ok := decodeDiscoveryCursor("", "space-1")
+	if !ok || first.Source != discoverySourceStatic || first.ID != "" {
+		t.Fatalf("empty cursor = %+v ok=%v", first, ok)
+	}
+}
+
+// B2 requires an exact version. A bare ID would have to resolve through the
+// activation pointer, and a discovery read that followed the pointer would
+// describe a different contract from one request to the next.
+func TestParseDiscoveryRefRequiresAnExactVersion(t *testing.T) {
+	id, version, ok := parseDiscoveryRef("pilot.docs-card@0.4.0-pilot.1")
+	if !ok || id != cardtmpl.ID("pilot.docs-card") || version != "0.4.0-pilot.1" {
+		t.Fatalf("ref = %s@%s ok=%v", id, version, ok)
+	}
+	for _, malformed := range []string{"", "pilot.docs-card", "@1.0.0", "pilot.docs-card@", "   "} {
+		if _, _, ok := parseDiscoveryRef(malformed); ok {
+			t.Fatalf("malformed ref %q was accepted", malformed)
+		}
+	}
+}
+
+func TestMatchesETagHandlesListsWildcardAndWeakValidators(t *testing.T) {
+	const etag = `"abc123"`
+	for _, test := range []struct {
+		header string
+		want   bool
+	}{
+		{"", false},
+		{`"abc123"`, true},
+		{`W/"abc123"`, true},
+		{`"other", "abc123"`, true},
+		{"*", true},
+		{`"other"`, false},
+		{`"abc1234"`, false},
+	} {
+		if got := matchesETag(test.header, etag); got != test.want {
+			t.Fatalf("If-None-Match %q matched = %v, want %v", test.header, got, test.want)
+		}
+	}
+}
+
+func TestDiscoveryPageLimitBounds(t *testing.T) {
+	if limit, ok := discoveryPageLimit(""); !ok || limit != defaultDiscoveryPageSize {
+		t.Fatalf("default limit = %d ok=%v", limit, ok)
+	}
+	if limit, ok := discoveryPageLimit("100"); !ok || limit != maxDiscoveryPageSize {
+		t.Fatalf("max limit = %d ok=%v", limit, ok)
+	}
+	// Out-of-range is a rejection, not a clamp: silently returning a different
+	// page size than asked for makes a caller's own paging arithmetic wrong.
+	for _, raw := range []string{"0", "-1", "101", "abc", "1e2"} {
+		if _, ok := discoveryPageLimit(raw); ok {
+			t.Fatalf("limit %q was accepted", raw)
+		}
+	}
+}
+
+// boundedDiscoveryLimit is the store's own clamp, which exists so a caller that
+// reached it through a different path than the handler still cannot ask for an
+// unbounded page.
+func TestBoundedDiscoveryLimitClampsAtTheStore(t *testing.T) {
+	if got := boundedDiscoveryLimit(0); got != defaultDiscoveryPageSize {
+		t.Fatalf("zero limit = %d", got)
+	}
+	if got := boundedDiscoveryLimit(1_000); got != maxDiscoveryPageSize {
+		t.Fatalf("oversized limit = %d", got)
+	}
+	if got := boundedDiscoveryLimit(7); got != 7 {
+		t.Fatalf("in-range limit = %d", got)
+	}
+}

--- a/modules/card_template_catalog/api_discovery_test.go
+++ b/modules/card_template_catalog/api_discovery_test.go
@@ -9,6 +9,8 @@ package card_template_catalog
 // a paginating caller sees.
 
 import (
+	"context"
+	"errors"
 	"testing"
 
 	"github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl"
@@ -130,5 +132,112 @@ func TestBoundedDiscoveryLimitClampsAtTheStore(t *testing.T) {
 	}
 	if got := boundedDiscoveryLimit(7); got != 7 {
 		t.Fatalf("in-range limit = %d", got)
+	}
+}
+
+// fakeDiscoveryStore records what the handler asked for so the tests can assert
+// on the shape of the probe, not only on the answer.
+type fakeDiscoveryStore struct {
+	rows      []DiscoveryRow
+	hasMore   bool
+	listErr   error
+	listCalls []int
+	probedIDs [][]cardtmpl.ID
+	granted   map[cardtmpl.ID]struct{}
+}
+
+func (s *fakeDiscoveryStore) ListDiscoverable(
+	_ context.Context, _ string, _ cardtmpl.ID, _ string, limit int,
+) ([]DiscoveryRow, bool, error) {
+	s.listCalls = append(s.listCalls, limit)
+	if s.listErr != nil {
+		return nil, false, s.listErr
+	}
+	if len(s.rows) > limit {
+		return s.rows[:limit], true, nil
+	}
+	return s.rows, s.hasMore, nil
+}
+
+func (s *fakeDiscoveryStore) LoadDiscoverable(
+	_ context.Context, _ string, _ cardtmpl.ID, _ string,
+) (DiscoveryRow, error) {
+	return DiscoveryRow{}, ErrDiscoveryNotVisible
+}
+
+func (s *fakeDiscoveryStore) StaticDiscoverGrants(
+	_ context.Context, _ string, ids []cardtmpl.ID,
+) (map[cardtmpl.ID]struct{}, error) {
+	s.probedIDs = append(s.probedIDs, append([]cardtmpl.ID(nil), ids...))
+	if s.granted == nil {
+		return map[cardtmpl.ID]struct{}{}, nil
+	}
+	return s.granted, nil
+}
+
+// Review follow-up (#14): the private-ID probe is keyed by template ID. A card
+// registered at several versions must not take several slots in the bounded
+// IN-list, or a genuinely granted template can fall past the cut and be
+// silently treated as ungranted.
+func TestPrivateTemplateIDsDeduplicatesAndDropsPublic(t *testing.T) {
+	entries := []cardtmpl.StaticCatalogEntry{
+		{ID: "docs.access-request", Version: "0.2.0", Visibility: cardtmpl.CatalogVisibilityPrivate},
+		{ID: "docs.access-request", Version: "0.3.0", Visibility: cardtmpl.CatalogVisibilityPrivate},
+		{ID: "ai.reasoning-process", Version: "0.1.0", Visibility: cardtmpl.CatalogVisibilityPrivate},
+		{ID: "ai.reasoning-process", Version: "0.2.0", Visibility: cardtmpl.CatalogVisibilityPrivate},
+		{ID: "ai.reasoning-process", Version: "0.3.0", Visibility: cardtmpl.CatalogVisibilityPrivate},
+		{ID: "docs.shared", Version: "1.0.0", Visibility: cardtmpl.CatalogVisibilityPublic},
+	}
+	got := privateTemplateIDs(entries)
+	want := []cardtmpl.ID{"docs.access-request", "ai.reasoning-process"}
+	if len(got) != len(want) {
+		t.Fatalf("probe ids = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("probe ids = %v, want %v (registration order preserved)", got, want)
+		}
+	}
+	// A public template needs no grant, so probing for one would be pure noise.
+	for _, id := range got {
+		if id == "docs.shared" {
+			t.Fatal("a public template was probed for a discover grant")
+		}
+	}
+}
+
+// Review follow-up (#13): when the static source exactly fills the page,
+// has_more must reflect whether the dynamic source actually holds a row.
+func TestDynamicPageFollowsPeeksInsteadOfAssuming(t *testing.T) {
+	empty := &fakeDiscoveryStore{}
+	cursor, more, err := dynamicPageFollows(context.Background(), empty, "space-1")
+	if err != nil {
+		t.Fatalf("peek: %v", err)
+	}
+	if more || cursor != "" {
+		t.Fatalf("empty dynamic source advertised another page: cursor=%q more=%v", cursor, more)
+	}
+	// The peek answers "is there anything" — it must not fetch a page nobody
+	// asked for.
+	if len(empty.listCalls) != 1 || empty.listCalls[0] != 1 {
+		t.Fatalf("peek budgets = %v, want [1]", empty.listCalls)
+	}
+
+	stocked := &fakeDiscoveryStore{rows: []DiscoveryRow{{ID: "pilot.card", Version: "1.0.0"}}}
+	cursor, more, err = dynamicPageFollows(context.Background(), stocked, "space-1")
+	if err != nil {
+		t.Fatalf("peek: %v", err)
+	}
+	if !more || cursor == "" {
+		t.Fatalf("stocked dynamic source did not advertise another page: cursor=%q more=%v", cursor, more)
+	}
+	decoded, ok := decodeDiscoveryCursor(cursor, "space-1")
+	if !ok || decoded.Source != discoverySourceDynamic || decoded.ID != "" {
+		t.Fatalf("boundary cursor = %+v ok=%v, want the top of the dynamic source", decoded, ok)
+	}
+
+	failing := &fakeDiscoveryStore{listErr: errors.New("db unavailable")}
+	if _, _, err := dynamicPageFollows(context.Background(), failing, "space-1"); err == nil {
+		t.Fatal("a failed peek was reported as no-more-pages")
 	}
 }

--- a/modules/card_template_catalog/api_grant.go
+++ b/modules/card_template_catalog/api_grant.go
@@ -1,0 +1,328 @@
+package card_template_catalog
+
+// PR-C D2/D4 Control APIs（spec: .octospec/tasks/
+// cardtmpl-runtime-catalog-grants-discovery/brief.md）：superAdmin manager
+// grant 写接口。
+//
+//   PUT    /v1/manager/card-templates/{id}/grants/{principal_type}/{principal_id}
+//   DELETE /v1/manager/card-templates/{id}/grants/{principal_type}/{principal_id}
+//
+// 两条都要求 control gate=true、runtime ready、superAdmin、strict body、
+// 10s deadline；actor 只取认证上下文（body 内 actor 字段随 strict decode
+// 被拒）；principal/scope 先过 D2 canonical 校验与存在性校验（bot 活跃、
+// internal producer 已注册、Space 存在且 active），再进 store CAS。响应回
+// 实际命中的 resulting revision，manager 据此做下一次 CAS。
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/internal/carddispatch"
+	"github.com/Mininglamp-OSS/octo-server/modules/botidentity"
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl"
+)
+
+// catalogGrantStore 是 grant 写/读的窄接口；生产 *store 实现，测试注入 fake。
+type catalogGrantStore interface {
+	UpsertGrant(context.Context, UpsertGrantRequest) (GrantResult, error)
+	RevokeGrant(context.Context, RevokeGrantRequest) (GrantResult, error)
+	ListGrants(context.Context, cardtmpl.ID, int) ([]GrantRecord, bool, error)
+}
+
+// grantSummaryLimit bounds the manager-detail grant summary (D5: control
+// fields never reach ordinary B1/B2; the full list pages through audit).
+const grantSummaryLimit = 32
+
+type grantUpsertControlRequest struct {
+	ScopeSpaceID     string `json:"scope_space_id"`
+	Discover         bool   `json:"discover"`
+	Send             bool   `json:"send"`
+	Edit             bool   `json:"edit"`
+	ExpectedRevision uint64 `json:"expected_revision"`
+	Reason           string `json:"reason"`
+	ChangeTicket     string `json:"change_ticket"`
+}
+
+type grantRevokeControlRequest struct {
+	ScopeSpaceID     string `json:"scope_space_id"`
+	ExpectedRevision uint64 `json:"expected_revision"`
+	Reason           string `json:"reason"`
+	ChangeTicket     string `json:"change_ticket"`
+}
+
+type grantControlResponse struct {
+	TemplateID    string `json:"template_id"`
+	PrincipalType string `json:"principal_type"`
+	PrincipalID   string `json:"principal_id"`
+	ScopeSpaceID  string `json:"scope_space_id"`
+	Status        string `json:"status"`
+	Discover      bool   `json:"discover"`
+	Send          bool   `json:"send"`
+	Edit          bool   `json:"edit"`
+	Revision      uint64 `json:"revision"`
+	Created       bool   `json:"created,omitempty"`
+}
+
+func (a *API) grantUpsert(c *wkhttp.Context) {
+	resultLabel := "rejected"
+	defer func() { a.metrics.observeOperation("grant", resultLabel) }()
+	if !a.requireSuperAdmin(c) {
+		return
+	}
+	if !a.controlEnabled {
+		resultLabel = "disabled"
+		respondCatalogControlDisabled(c)
+		return
+	}
+	if ready, result := a.requireRuntimeReady(c); !ready {
+		resultLabel = result
+		return
+	}
+	identity, ok := a.parseGrantPath(c)
+	if !ok {
+		return
+	}
+	var request grantUpsertControlRequest
+	if !readStrictStateRequest(c, &request,
+		"scope_space_id", "discover", "send", "edit", "expected_revision", "reason", "change_ticket") {
+		return
+	}
+	identity.ScopeSpaceID = request.ScopeSpaceID
+	permissions := GrantPermissions{Discover: request.Discover, Send: request.Send, Edit: request.Edit}
+	if err := validateGrantIdentity(identity); err != nil {
+		respondCatalogGrantInvalid(c, err)
+		return
+	}
+	if err := validateGrantPermissions(identity.PrincipalType, permissions); err != nil {
+		respondCatalogGrantInvalid(c, err)
+		return
+	}
+	if !validStateControlText(request.Reason, request.ChangeTicket) {
+		respondCatalogGrantInvalid(c, ErrGrantRequestInvalid)
+		return
+	}
+	ctx, cancel := context.WithTimeout(c.Request.Context(), stateControlTimeout)
+	defer cancel()
+	if !a.requireGrantPrincipal(c, ctx, identity) {
+		return
+	}
+	store, ok := a.grantStore(c)
+	if !ok {
+		return
+	}
+	result, err := store.UpsertGrant(ctx, UpsertGrantRequest{
+		Identity: identity, Permissions: permissions,
+		ExpectedRevision: request.ExpectedRevision,
+		ActorUID:         c.GetLoginUID(),
+		Reason:           request.Reason, ChangeTicket: request.ChangeTicket,
+	})
+	if err != nil {
+		resultLabel = a.respondGrantError(c, "grant", err)
+		return
+	}
+	resultLabel = "ok"
+	a.metrics.observeDB("grant", "ok")
+	c.Response(grantResponse(result))
+}
+
+func (a *API) grantRevoke(c *wkhttp.Context) {
+	resultLabel := "rejected"
+	defer func() { a.metrics.observeOperation("revoke", resultLabel) }()
+	if !a.requireSuperAdmin(c) {
+		return
+	}
+	if !a.controlEnabled {
+		resultLabel = "disabled"
+		respondCatalogControlDisabled(c)
+		return
+	}
+	if ready, result := a.requireRuntimeReady(c); !ready {
+		resultLabel = result
+		return
+	}
+	identity, ok := a.parseGrantPath(c)
+	if !ok {
+		return
+	}
+	var request grantRevokeControlRequest
+	if !readStrictStateRequest(c, &request,
+		"scope_space_id", "expected_revision", "reason", "change_ticket") {
+		return
+	}
+	identity.ScopeSpaceID = request.ScopeSpaceID
+	if err := validateGrantIdentity(identity); err != nil {
+		respondCatalogGrantInvalid(c, err)
+		return
+	}
+	if !validStateControlText(request.Reason, request.ChangeTicket) {
+		respondCatalogGrantInvalid(c, ErrGrantRequestInvalid)
+		return
+	}
+	// Revoke 不做 principal 存在性校验：principal 事后被删除/停用时，撤销
+	// 其残留 grant 恰恰是必须可行的运维操作。
+	ctx, cancel := context.WithTimeout(c.Request.Context(), stateControlTimeout)
+	defer cancel()
+	store, ok := a.grantStore(c)
+	if !ok {
+		return
+	}
+	result, err := store.RevokeGrant(ctx, RevokeGrantRequest{
+		Identity:         identity,
+		ExpectedRevision: request.ExpectedRevision,
+		ActorUID:         c.GetLoginUID(),
+		Reason:           request.Reason, ChangeTicket: request.ChangeTicket,
+	})
+	if err != nil {
+		resultLabel = a.respondGrantError(c, "revoke", err)
+		return
+	}
+	resultLabel = "ok"
+	a.metrics.observeDB("revoke", "ok")
+	c.Response(grantResponse(result))
+}
+
+func (a *API) parseGrantPath(c *wkhttp.Context) (GrantIdentity, bool) {
+	id, ok := parseManagerTemplateID(c.Param("id"))
+	if !ok {
+		respondCatalogGrantInvalid(c, ErrGrantRequestInvalid)
+		return GrantIdentity{}, false
+	}
+	principalType := GrantPrincipalType(c.Param("principal_type"))
+	switch principalType {
+	case GrantPrincipalBot, GrantPrincipalInternalProducer, GrantPrincipalSpace:
+	default:
+		respondCatalogGrantInvalid(c, fmt.Errorf("%w: principal type %q", ErrGrantRequestInvalid, principalType))
+		return GrantIdentity{}, false
+	}
+	principalID := c.Param("principal_id")
+	if principalID == "" || principalID != strings.TrimSpace(principalID) ||
+		len([]rune(principalID)) > maxGrantPrincipalIDRunes {
+		respondCatalogGrantInvalid(c, ErrGrantRequestInvalid)
+		return GrantIdentity{}, false
+	}
+	return GrantIdentity{TemplateID: id, PrincipalType: principalType, PrincipalID: principalID}, true
+}
+
+// requireGrantPrincipal 校验 principal（与非空 scope Space）真实存在且可认证
+// （D2）。validator 未接线是组合根 bug —— fail-close 到 unavailable，绝不放行。
+func (a *API) requireGrantPrincipal(c *wkhttp.Context, ctx context.Context, identity GrantIdentity) bool {
+	if a.validateGrantPrincipal == nil {
+		a.logStateError("card template grant principal validator is not wired", "grant", nil)
+		respondCatalogUnavailable(c)
+		return false
+	}
+	if err := a.validateGrantPrincipal(ctx, identity); err != nil {
+		if errors.Is(err, ErrGrantRequestInvalid) {
+			respondCatalogGrantInvalid(c, err)
+			return false
+		}
+		a.logStateError("card template grant principal validation failed", "grant", err)
+		respondCatalogUnavailable(c)
+		return false
+	}
+	return true
+}
+
+func (a *API) grantStore(c *wkhttp.Context) (catalogGrantStore, bool) {
+	store, ok := a.store.(catalogGrantStore)
+	if !ok || store == nil {
+		respondCatalogUnavailable(c)
+		return nil, false
+	}
+	return store, true
+}
+
+func (a *API) respondGrantError(c *wkhttp.Context, operation string, err error) string {
+	switch {
+	case errors.Is(err, ErrGrantConflict), errors.Is(err, ErrGrantAlreadyRevoked):
+		a.metrics.observeDB(operation, "conflict")
+		respondCatalogStateConflict(c)
+		return "conflict"
+	case errors.Is(err, ErrGrantRequestInvalid), errors.Is(err, ErrGrantTargetUnknown),
+		errors.Is(err, ErrGrantNotFound):
+		a.metrics.observeDB(operation, "rejected")
+		respondCatalogGrantInvalid(c, err)
+		return "rejected"
+	case errors.Is(err, ErrCatalogIntegrity):
+		a.metrics.observeDB(operation, "integrity_error")
+		a.logStateError("card template catalog integrity failure", operation, err)
+		respondCatalogIntegrityFailure(c)
+		return "integrity_error"
+	case errors.Is(err, context.Canceled):
+		a.metrics.observeDB(operation, "canceled")
+		respondCatalogUnavailable(c)
+		return "canceled"
+	case errors.Is(err, context.DeadlineExceeded):
+		a.metrics.observeDB(operation, "timeout")
+		respondCatalogUnavailable(c)
+		return "timeout"
+	default:
+		a.metrics.observeDB(operation, "error")
+		a.logStateError("card template grant operation failed", operation, err)
+		respondCatalogUnavailable(c)
+		return "error"
+	}
+}
+
+func grantResponse(result GrantResult) grantControlResponse {
+	record := result.Record
+	return grantControlResponse{
+		TemplateID:    string(record.Identity.TemplateID),
+		PrincipalType: string(record.Identity.PrincipalType),
+		PrincipalID:   record.Identity.PrincipalID,
+		ScopeSpaceID:  record.Identity.ScopeSpaceID,
+		Status:        string(record.Status),
+		Discover:      record.Permissions.Discover,
+		Send:          record.Permissions.Send,
+		Edit:          record.Permissions.Edit,
+		Revision:      record.Revision,
+		Created:       result.Created,
+	}
+}
+
+// productionGrantPrincipalCheck 是组合根接线的存在性校验实现：
+//   - bot：botidentity（robot/app-bot 表）活跃身份；
+//   - internal_producer：carddispatch 注册表的只读身份绑定；
+//   - space principal 与非空 scope Space：space 表存在且 status=1。
+func (a *API) productionGrantPrincipalCheck(ctx context.Context, identity GrantIdentity) error {
+	switch identity.PrincipalType {
+	case GrantPrincipalBot:
+		active, err := botidentity.New(a.ctx).Active(identity.PrincipalID)
+		if err != nil {
+			return fmt.Errorf("card template catalog: resolve bot principal: %w", err)
+		}
+		if !active {
+			return fmt.Errorf("%w: bot principal is not an active bot", ErrGrantRequestInvalid)
+		}
+	case GrantPrincipalInternalProducer:
+		if _, ok := carddispatch.ProducerBindingFromContext(a.ctx, carddispatch.ProducerID(identity.PrincipalID)); !ok {
+			return fmt.Errorf("%w: internal producer is not registered", ErrGrantRequestInvalid)
+		}
+	case GrantPrincipalSpace:
+		if err := a.requireActiveSpace(ctx, identity.PrincipalID); err != nil {
+			return err
+		}
+	default:
+		return fmt.Errorf("%w: principal type %q", ErrGrantRequestInvalid, identity.PrincipalType)
+	}
+	if identity.ScopeSpaceID != "" {
+		return a.requireActiveSpace(ctx, identity.ScopeSpaceID)
+	}
+	return nil
+}
+
+func (a *API) requireActiveSpace(ctx context.Context, spaceID string) error {
+	var count int
+	err := a.ctx.DB().DB.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM space WHERE space_id = ? AND status = 1", spaceID).Scan(&count)
+	if err != nil {
+		return fmt.Errorf("card template catalog: resolve space: %w", err)
+	}
+	if count == 0 {
+		return fmt.Errorf("%w: space does not exist or is not active", ErrGrantRequestInvalid)
+	}
+	return nil
+}

--- a/modules/card_template_catalog/api_grant.go
+++ b/modules/card_template_catalog/api_grant.go
@@ -93,15 +93,15 @@ func (a *API) grantUpsert(c *wkhttp.Context) {
 	identity.ScopeSpaceID = request.ScopeSpaceID
 	permissions := GrantPermissions{Discover: request.Discover, Send: request.Send, Edit: request.Edit}
 	if err := validateGrantIdentity(identity); err != nil {
-		respondCatalogGrantInvalid(c, err)
+		a.respondCatalogGrantInvalid(c, err)
 		return
 	}
 	if err := validateGrantPermissions(identity.PrincipalType, permissions); err != nil {
-		respondCatalogGrantInvalid(c, err)
+		a.respondCatalogGrantInvalid(c, err)
 		return
 	}
 	if !validStateControlText(request.Reason, request.ChangeTicket) {
-		respondCatalogGrantInvalid(c, ErrGrantRequestInvalid)
+		a.respondCatalogGrantInvalid(c, ErrGrantRequestInvalid)
 		return
 	}
 	ctx, cancel := context.WithTimeout(c.Request.Context(), stateControlTimeout)
@@ -154,11 +154,11 @@ func (a *API) grantRevoke(c *wkhttp.Context) {
 	}
 	identity.ScopeSpaceID = request.ScopeSpaceID
 	if err := validateGrantIdentity(identity); err != nil {
-		respondCatalogGrantInvalid(c, err)
+		a.respondCatalogGrantInvalid(c, err)
 		return
 	}
 	if !validStateControlText(request.Reason, request.ChangeTicket) {
-		respondCatalogGrantInvalid(c, ErrGrantRequestInvalid)
+		a.respondCatalogGrantInvalid(c, ErrGrantRequestInvalid)
 		return
 	}
 	// Revoke 不做 principal 存在性校验：principal 事后被删除/停用时，撤销
@@ -187,20 +187,20 @@ func (a *API) grantRevoke(c *wkhttp.Context) {
 func (a *API) parseGrantPath(c *wkhttp.Context) (GrantIdentity, bool) {
 	id, ok := parseManagerTemplateID(c.Param("id"))
 	if !ok {
-		respondCatalogGrantInvalid(c, ErrGrantRequestInvalid)
+		a.respondCatalogGrantInvalid(c, ErrGrantRequestInvalid)
 		return GrantIdentity{}, false
 	}
 	principalType := GrantPrincipalType(c.Param("principal_type"))
 	switch principalType {
 	case GrantPrincipalBot, GrantPrincipalInternalProducer, GrantPrincipalSpace:
 	default:
-		respondCatalogGrantInvalid(c, fmt.Errorf("%w: principal type %q", ErrGrantRequestInvalid, principalType))
+		a.respondCatalogGrantInvalid(c, fmt.Errorf("%w: principal type %q", ErrGrantRequestInvalid, principalType))
 		return GrantIdentity{}, false
 	}
 	principalID := c.Param("principal_id")
 	if principalID == "" || principalID != strings.TrimSpace(principalID) ||
 		len([]rune(principalID)) > maxGrantPrincipalIDRunes {
-		respondCatalogGrantInvalid(c, ErrGrantRequestInvalid)
+		a.respondCatalogGrantInvalid(c, ErrGrantRequestInvalid)
 		return GrantIdentity{}, false
 	}
 	return GrantIdentity{TemplateID: id, PrincipalType: principalType, PrincipalID: principalID}, true
@@ -216,7 +216,7 @@ func (a *API) requireGrantPrincipal(c *wkhttp.Context, ctx context.Context, iden
 	}
 	if err := a.validateGrantPrincipal(ctx, identity); err != nil {
 		if errors.Is(err, ErrGrantRequestInvalid) {
-			respondCatalogGrantInvalid(c, err)
+			a.respondCatalogGrantInvalid(c, err)
 			return false
 		}
 		a.logStateError("card template grant principal validation failed", "grant", err)
@@ -244,7 +244,7 @@ func (a *API) respondGrantError(c *wkhttp.Context, operation string, err error) 
 	case errors.Is(err, ErrGrantRequestInvalid), errors.Is(err, ErrGrantTargetUnknown),
 		errors.Is(err, ErrGrantNotFound):
 		a.metrics.observeDB(operation, "rejected")
-		respondCatalogGrantInvalid(c, err)
+		a.respondCatalogGrantInvalid(c, err)
 		return "rejected"
 	case errors.Is(err, ErrCatalogIntegrity):
 		a.metrics.observeDB(operation, "integrity_error")

--- a/modules/card_template_catalog/api_grant_test.go
+++ b/modules/card_template_catalog/api_grant_test.go
@@ -1,0 +1,288 @@
+package card_template_catalog
+
+// PR-C Slice 2 RED (D2/D4 + Control APIs): the manager grant endpoints are
+// superAdmin-only, control-gated, strict-body, principal-validated, and map
+// every store outcome onto the localized envelope with the resulting
+// revision in the success body.
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl"
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
+)
+
+type fakeGrantCatalogStore struct {
+	fakeCatalogStore
+	upsertResult GrantResult
+	upsertErr    error
+	upsertCalls  int
+	lastUpsert   UpsertGrantRequest
+	revokeResult GrantResult
+	revokeErr    error
+	revokeCalls  int
+	lastRevoke   RevokeGrantRequest
+	grants       []GrantRecord
+	grantsErr    error
+}
+
+func (s *fakeGrantCatalogStore) UpsertGrant(_ context.Context, request UpsertGrantRequest) (GrantResult, error) {
+	s.upsertCalls++
+	s.lastUpsert = request
+	return s.upsertResult, s.upsertErr
+}
+
+func (s *fakeGrantCatalogStore) RevokeGrant(_ context.Context, request RevokeGrantRequest) (GrantResult, error) {
+	s.revokeCalls++
+	s.lastRevoke = request
+	return s.revokeResult, s.revokeErr
+}
+
+func (s *fakeGrantCatalogStore) ListGrants(context.Context, cardtmpl.ID, int) ([]GrantRecord, bool, error) {
+	return s.grants, false, s.grantsErr
+}
+
+func doGrantRequest(
+	t *testing.T,
+	api *API,
+	role wkhttp.UserRole,
+	method, target, body string,
+) *httptest.ResponseRecorder {
+	t.Helper()
+	route := wkhttp.New()
+	route.SetErrorRenderer(i18n.NewErrorRenderer(i18n.NewLocalizer(i18n.DefaultLanguage)))
+	route.Use(func(c *wkhttp.Context) {
+		c.Set("uid", "admin-1")
+		c.Set("role", string(role))
+	})
+	group := route.Group("")
+	group.PUT("/:id/grants/:principal_type/:principal_id", api.grantUpsert)
+	group.DELETE("/:id/grants/:principal_type/:principal_id", api.grantRevoke)
+	request := httptest.NewRequest(method, target, bytes.NewBufferString(body))
+	request.Header.Set("Content-Type", "application/json")
+	recorder := httptest.NewRecorder()
+	route.ServeHTTP(recorder, request)
+	return recorder
+}
+
+func grantUpsertBody() string {
+	return `{"scope_space_id":"space-1","discover":true,"send":true,"edit":false,` +
+		`"expected_revision":0,"reason":"pilot rollout","change_ticket":"CHG-9"}`
+}
+
+func allowAllGrantPrincipals(context.Context, GrantIdentity) error { return nil }
+
+func TestGrantWriteRequiresSuperAdminAndControlGate(t *testing.T) {
+	store := &fakeGrantCatalogStore{}
+	api := &API{store: store, controlEnabled: true, validateGrantPrincipal: allowAllGrantPrincipals}
+	response := doGrantRequest(t, api, wkhttp.Admin, http.MethodPut,
+		"/docs.access-request/grants/bot/bot-1", grantUpsertBody())
+	assertCatalogError(t, response, "err.server.card_template_catalog.forbidden", http.StatusForbidden)
+
+	api = &API{store: store, controlEnabled: false, validateGrantPrincipal: allowAllGrantPrincipals}
+	response = doGrantRequest(t, api, wkhttp.SuperAdmin, http.MethodPut,
+		"/docs.access-request/grants/bot/bot-1", grantUpsertBody())
+	assertCatalogError(t, response, "err.server.card_template_catalog.control_disabled", http.StatusServiceUnavailable)
+
+	response = doGrantRequest(t, api, wkhttp.SuperAdmin, http.MethodDelete,
+		"/docs.access-request/grants/bot/bot-1",
+		`{"scope_space_id":"space-1","expected_revision":3,"reason":"offboard","change_ticket":"CHG-10"}`)
+	assertCatalogError(t, response, "err.server.card_template_catalog.control_disabled", http.StatusServiceUnavailable)
+	if store.upsertCalls != 0 || store.revokeCalls != 0 {
+		t.Fatalf("gated requests reached store: %d/%d", store.upsertCalls, store.revokeCalls)
+	}
+}
+
+func TestGrantUpsertHappyPathReturnsResultingRevision(t *testing.T) {
+	store := &fakeGrantCatalogStore{upsertResult: GrantResult{
+		Record: GrantRecord{
+			Identity: GrantIdentity{
+				TemplateID: "docs.access-request", PrincipalType: GrantPrincipalBot,
+				PrincipalID: "bot-1", ScopeSpaceID: "space-1",
+			},
+			Status: GrantStatusActive, Permissions: GrantPermissions{Discover: true, Send: true},
+			Revision: 1,
+		},
+		Created: true,
+	}}
+	api := &API{store: store, controlEnabled: true, validateGrantPrincipal: allowAllGrantPrincipals}
+	response := doGrantRequest(t, api, wkhttp.SuperAdmin, http.MethodPut,
+		"/docs.access-request/grants/bot/bot-1", grantUpsertBody())
+	if response.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", response.Code, response.Body.String())
+	}
+	if store.upsertCalls != 1 {
+		t.Fatalf("upsert calls = %d", store.upsertCalls)
+	}
+	request := store.lastUpsert
+	if request.Identity.PrincipalType != GrantPrincipalBot || request.Identity.PrincipalID != "bot-1" ||
+		request.Identity.ScopeSpaceID != "space-1" || request.ActorUID != "admin-1" {
+		t.Fatalf("store request = %+v", request)
+	}
+	body := response.Body.String()
+	for _, needle := range []string{`"revision":1`, `"status":"active"`, `"created":true`, `"send":true`} {
+		if !bytes.Contains([]byte(body), []byte(needle)) {
+			t.Fatalf("response missing %s: %s", needle, body)
+		}
+	}
+}
+
+func TestGrantWriteStrictBodyRejections(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+	}{
+		{name: "actor field rejected", body: `{"scope_space_id":"","discover":true,"send":false,"edit":false,` +
+			`"expected_revision":0,"reason":"r","change_ticket":"t","updated_by":"spoof"}`},
+		{name: "missing scope key", body: `{"discover":true,"send":false,"edit":false,` +
+			`"expected_revision":0,"reason":"r","change_ticket":"t"}`},
+		{name: "missing permission key", body: `{"scope_space_id":"","discover":true,"send":false,` +
+			`"expected_revision":0,"reason":"r","change_ticket":"t"}`},
+		{name: "null expected_revision", body: `{"scope_space_id":"","discover":true,"send":false,"edit":false,` +
+			`"expected_revision":null,"reason":"r","change_ticket":"t"}`},
+		{name: "dark grant send without discover", body: `{"scope_space_id":"","discover":false,"send":true,"edit":false,` +
+			`"expected_revision":0,"reason":"r","change_ticket":"t"}`},
+		{name: "blank reason", body: `{"scope_space_id":"","discover":true,"send":false,"edit":false,` +
+			`"expected_revision":0,"reason":" ","change_ticket":"t"}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			store := &fakeGrantCatalogStore{}
+			api := &API{store: store, controlEnabled: true, validateGrantPrincipal: allowAllGrantPrincipals}
+			response := doGrantRequest(t, api, wkhttp.SuperAdmin, http.MethodPut,
+				"/docs.access-request/grants/bot/bot-1", tc.body)
+			if response.Code != http.StatusBadRequest {
+				t.Fatalf("status=%d body=%s", response.Code, response.Body.String())
+			}
+			if store.upsertCalls != 0 {
+				t.Fatal("invalid body reached store")
+			}
+		})
+	}
+}
+
+func TestGrantPathIdentityCanonicalValidation(t *testing.T) {
+	cases := []struct {
+		name   string
+		target string
+		body   string
+	}{
+		{name: "unknown principal type", target: "/docs.access-request/grants/user/u-1", body: grantUpsertBody()},
+		{name: "system not grantable", target: "/docs.access-request/grants/system/readiness", body: grantUpsertBody()},
+		{name: "malformed template id", target: "/DOCS!!/grants/bot/bot-1", body: grantUpsertBody()},
+		{name: "space principal with exact scope", target: "/docs.access-request/grants/space/space-1",
+			body: `{"scope_space_id":"space-1","discover":true,"send":false,"edit":false,` +
+				`"expected_revision":0,"reason":"r","change_ticket":"t"}`},
+		{name: "space principal with send", target: "/docs.access-request/grants/space/space-1",
+			body: `{"scope_space_id":"","discover":true,"send":true,"edit":false,` +
+				`"expected_revision":0,"reason":"r","change_ticket":"t"}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			store := &fakeGrantCatalogStore{}
+			api := &API{store: store, controlEnabled: true, validateGrantPrincipal: allowAllGrantPrincipals}
+			response := doGrantRequest(t, api, wkhttp.SuperAdmin, http.MethodPut, tc.target, tc.body)
+			if response.Code != http.StatusBadRequest {
+				t.Fatalf("status=%d body=%s", response.Code, response.Body.String())
+			}
+			if store.upsertCalls != 0 {
+				t.Fatal("non-canonical identity reached store")
+			}
+		})
+	}
+}
+
+func TestGrantPrincipalExistenceFailsClosed(t *testing.T) {
+	store := &fakeGrantCatalogStore{}
+	principalErr := ErrGrantRequestInvalid
+	api := &API{store: store, controlEnabled: true,
+		validateGrantPrincipal: func(context.Context, GrantIdentity) error { return principalErr }}
+	response := doGrantRequest(t, api, wkhttp.SuperAdmin, http.MethodPut,
+		"/docs.access-request/grants/bot/ghost-bot", grantUpsertBody())
+	assertCatalogError(t, response, "err.server.card_template_catalog.grant_invalid", http.StatusBadRequest)
+	if store.upsertCalls != 0 {
+		t.Fatal("unknown principal reached store")
+	}
+
+	// A missing validator is a wiring bug and must fail closed, not open.
+	api = &API{store: store, controlEnabled: true}
+	response = doGrantRequest(t, api, wkhttp.SuperAdmin, http.MethodPut,
+		"/docs.access-request/grants/bot/bot-1", grantUpsertBody())
+	assertCatalogError(t, response, "err.server.card_template_catalog.unavailable", http.StatusServiceUnavailable)
+	if store.upsertCalls != 0 {
+		t.Fatal("request without principal validator reached store")
+	}
+}
+
+func TestGrantStoreErrorMapping(t *testing.T) {
+	cases := []struct {
+		name       string
+		upsertErr  error
+		wantCodeID string
+		wantStatus int
+	}{
+		{name: "revision conflict", upsertErr: ErrGrantConflict,
+			wantCodeID: "err.server.card_template_catalog.state_conflict", wantStatus: http.StatusConflict},
+		{name: "target without claim", upsertErr: ErrGrantTargetUnknown,
+			wantCodeID: "err.server.card_template_catalog.grant_invalid", wantStatus: http.StatusBadRequest},
+		{name: "integrity", upsertErr: ErrCatalogIntegrity,
+			wantCodeID: "err.shared.internal", wantStatus: http.StatusInternalServerError},
+		{name: "invalid", upsertErr: ErrGrantRequestInvalid,
+			wantCodeID: "err.server.card_template_catalog.grant_invalid", wantStatus: http.StatusBadRequest},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			store := &fakeGrantCatalogStore{upsertErr: tc.upsertErr}
+			api := &API{store: store, controlEnabled: true, validateGrantPrincipal: allowAllGrantPrincipals}
+			response := doGrantRequest(t, api, wkhttp.SuperAdmin, http.MethodPut,
+				"/docs.access-request/grants/bot/bot-1", grantUpsertBody())
+			assertCatalogError(t, response, tc.wantCodeID, tc.wantStatus)
+		})
+	}
+}
+
+func TestGrantRevokeFlow(t *testing.T) {
+	store := &fakeGrantCatalogStore{revokeResult: GrantResult{
+		Record: GrantRecord{
+			Identity: GrantIdentity{
+				TemplateID: "docs.access-request", PrincipalType: GrantPrincipalInternalProducer,
+				PrincipalID: "docs-notify", ScopeSpaceID: "",
+			},
+			Status: GrantStatusRevoked, Revision: 4,
+		},
+	}}
+	api := &API{store: store, controlEnabled: true, validateGrantPrincipal: allowAllGrantPrincipals}
+	response := doGrantRequest(t, api, wkhttp.SuperAdmin, http.MethodDelete,
+		"/docs.access-request/grants/internal_producer/docs-notify",
+		`{"scope_space_id":"","expected_revision":3,"reason":"offboard","change_ticket":"CHG-11"}`)
+	if response.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", response.Code, response.Body.String())
+	}
+	if store.revokeCalls != 1 || store.lastRevoke.ExpectedRevision != 3 || store.lastRevoke.ActorUID != "admin-1" {
+		t.Fatalf("revoke request = %+v calls=%d", store.lastRevoke, store.revokeCalls)
+	}
+	body := response.Body.String()
+	for _, needle := range []string{`"revision":4`, `"status":"revoked"`} {
+		if !bytes.Contains([]byte(body), []byte(needle)) {
+			t.Fatalf("response missing %s: %s", needle, body)
+		}
+	}
+
+	// Already-revoked and not-found map to distinct manager-facing outcomes.
+	store.revokeErr = ErrGrantAlreadyRevoked
+	response = doGrantRequest(t, api, wkhttp.SuperAdmin, http.MethodDelete,
+		"/docs.access-request/grants/internal_producer/docs-notify",
+		`{"scope_space_id":"","expected_revision":4,"reason":"again","change_ticket":"CHG-12"}`)
+	assertCatalogError(t, response, "err.server.card_template_catalog.state_conflict", http.StatusConflict)
+
+	store.revokeErr = ErrGrantNotFound
+	response = doGrantRequest(t, api, wkhttp.SuperAdmin, http.MethodDelete,
+		"/docs.access-request/grants/internal_producer/ghost",
+		`{"scope_space_id":"","expected_revision":0,"reason":"noop","change_ticket":"CHG-13"}`)
+	assertCatalogError(t, response, "err.server.card_template_catalog.grant_invalid", http.StatusBadRequest)
+}

--- a/modules/card_template_catalog/api_grant_test.go
+++ b/modules/card_template_catalog/api_grant_test.go
@@ -8,6 +8,7 @@ package card_template_catalog
 import (
 	"bytes"
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -285,4 +286,27 @@ func TestGrantRevokeFlow(t *testing.T) {
 		"/docs.access-request/grants/internal_producer/ghost",
 		`{"scope_space_id":"","expected_revision":0,"reason":"noop","change_ticket":"CHG-13"}`)
 	assertCatalogError(t, response, "err.server.card_template_catalog.grant_invalid", http.StatusBadRequest)
+}
+
+// The production principal check is the composition-root implementation of the
+// hook the test above stubs. Its bot / internal_producer / space arms each need
+// a live server context, but its default arm does not — and that arm is the one
+// that must never be reached by accident. A principal type the switch does not
+// recognize has to be rejected outright: falling through to "no scope, nothing
+// to check, return nil" would grant a principal nobody can name.
+func TestProductionGrantPrincipalCheckRejectsAnUnknownPrincipalType(t *testing.T) {
+	api := &API{}
+	err := api.productionGrantPrincipalCheck(context.Background(), GrantIdentity{
+		TemplateID: "docs.access-request", PrincipalType: "operator", PrincipalID: "someone",
+	})
+	if !errors.Is(err, ErrGrantRequestInvalid) {
+		t.Fatalf("err = %v, want ErrGrantRequestInvalid", err)
+	}
+	// The empty principal type is the shape a partly-decoded request produces;
+	// it must land in the same place rather than in a nil-typed arm.
+	if err := api.productionGrantPrincipalCheck(context.Background(), GrantIdentity{
+		TemplateID: "docs.access-request", PrincipalID: "someone",
+	}); !errors.Is(err, ErrGrantRequestInvalid) {
+		t.Fatalf("empty principal type err = %v, want ErrGrantRequestInvalid", err)
+	}
 }

--- a/modules/card_template_catalog/api_i18n.go
+++ b/modules/card_template_catalog/api_i18n.go
@@ -75,7 +75,10 @@ func respondCatalogNotFound(c *wkhttp.Context) {
 // generic 400 and nothing anywhere to explain it.
 func (a *API) respondCatalogGrantInvalid(c *wkhttp.Context, err error) {
 	if a != nil && a.logger != nil && err != nil {
-		a.logger.Error("card template grant request rejected",
+		// Warn, not Error: a malformed principal type or an over-long id is an
+		// expected 4xx, and logging it at Error would put routine caller
+		// mistakes into the same bucket as integrity and availability failures.
+		a.logger.Warn("card template grant request rejected",
 			zap.String("operation", "grant"), zap.Error(err))
 	}
 	httperr.ResponseErrorL(c, errcode.ErrCardTemplateCatalogGrantInvalid, nil, nil)

--- a/modules/card_template_catalog/api_i18n.go
+++ b/modules/card_template_catalog/api_i18n.go
@@ -59,6 +59,14 @@ func respondCatalogIntegrityFailure(c *wkhttp.Context) {
 	httperr.ResponseErrorL(c, errcode.ErrSharedInternal, nil, nil)
 }
 
+// respondCatalogNotFound is the single answer B2 gives for "no such template",
+// "you may not see it" and "it is blocked". Three distinguishable answers would
+// let any authenticated caller enumerate the private catalog by probing IDs
+// (D5 anti-enumeration), so the reason stays in the logs and never on the wire.
+func respondCatalogNotFound(c *wkhttp.Context) {
+	httperr.ResponseErrorL(c, errcode.ErrSharedNotFound, nil, nil)
+}
+
 func respondCatalogGrantInvalid(c *wkhttp.Context, err error) {
 	// 具体拒绝原因只进日志/错误链，响应保持单一 localized envelope（管理面
 	// 也不回显任意错误文本，防 details 泄漏内部结构）。

--- a/modules/card_template_catalog/api_i18n.go
+++ b/modules/card_template_catalog/api_i18n.go
@@ -58,3 +58,10 @@ func respondCatalogBlocked(c *wkhttp.Context) {
 func respondCatalogIntegrityFailure(c *wkhttp.Context) {
 	httperr.ResponseErrorL(c, errcode.ErrSharedInternal, nil, nil)
 }
+
+func respondCatalogGrantInvalid(c *wkhttp.Context, err error) {
+	// 具体拒绝原因只进日志/错误链，响应保持单一 localized envelope（管理面
+	// 也不回显任意错误文本，防 details 泄漏内部结构）。
+	_ = err
+	httperr.ResponseErrorL(c, errcode.ErrCardTemplateCatalogGrantInvalid, nil, nil)
+}

--- a/modules/card_template_catalog/api_i18n.go
+++ b/modules/card_template_catalog/api_i18n.go
@@ -2,6 +2,7 @@ package card_template_catalog
 
 import (
 	"errors"
+	"net/http"
 
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
 	"github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl"
@@ -78,8 +79,18 @@ func (a *API) respondCatalogGrantInvalid(c *wkhttp.Context, err error) {
 		// Warn, not Error: a malformed principal type or an over-long id is an
 		// expected 4xx, and logging it at Error would put routine caller
 		// mistakes into the same bucket as integrity and availability failures.
+		// Label the operation the way the sibling metric does. The helper is
+		// shared by the upsert and revoke handlers, so a hardcoded "grant"
+		// logged every rejected revoke as a grant — the log and the
+		// observeOperation("revoke", ...) counter disagreed about the same
+		// request. The route method is the discriminator: PUT creates or
+		// updates, DELETE revokes.
+		operation := "grant"
+		if c != nil && c.Request != nil && c.Request.Method == http.MethodDelete {
+			operation = "revoke"
+		}
 		a.logger.Warn("card template grant request rejected",
-			zap.String("operation", "grant"), zap.Error(err))
+			zap.String("operation", operation), zap.Error(err))
 	}
 	httperr.ResponseErrorL(c, errcode.ErrCardTemplateCatalogGrantInvalid, nil, nil)
 }

--- a/modules/card_template_catalog/api_i18n.go
+++ b/modules/card_template_catalog/api_i18n.go
@@ -8,6 +8,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
 	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
 	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
+	"go.uber.org/zap"
 )
 
 func respondCatalogForbidden(c *wkhttp.Context) {
@@ -67,9 +68,15 @@ func respondCatalogNotFound(c *wkhttp.Context) {
 	httperr.ResponseErrorL(c, errcode.ErrSharedNotFound, nil, nil)
 }
 
-func respondCatalogGrantInvalid(c *wkhttp.Context, err error) {
-	// 具体拒绝原因只进日志/错误链，响应保持单一 localized envelope（管理面
-	// 也不回显任意错误文本，防 details 泄漏内部结构）。
-	_ = err
+// respondCatalogGrantInvalid keeps the wire answer to a single localized
+// envelope — the manager plane does not echo arbitrary error text either, so a
+// details map cannot leak internal structure — while the specific reason goes
+// to the log. Dropping the reason entirely would leave an operator with a
+// generic 400 and nothing anywhere to explain it.
+func (a *API) respondCatalogGrantInvalid(c *wkhttp.Context, err error) {
+	if a != nil && a.logger != nil && err != nil {
+		a.logger.Error("card template grant request rejected",
+			zap.String("operation", "grant"), zap.Error(err))
+	}
 	httperr.ResponseErrorL(c, errcode.ErrCardTemplateCatalogGrantInvalid, nil, nil)
 }

--- a/modules/card_template_catalog/api_state.go
+++ b/modules/card_template_catalog/api_state.go
@@ -289,6 +289,11 @@ func (a *API) detail(c *wkhttp.Context) {
 			c.Response(response)
 			return
 		}
+		// The matching success observation. Without it the error counter above
+		// is the only sample the detail_grants metric ever takes, so the
+		// error-rate panel it exists to feed reads 100% the moment it has any
+		// data at all — the exact inverse of the blind spot it was added for.
+		a.metrics.observeDB("detail_grants", "ok")
 		response.Grants = make([]grantSummaryResponse, len(grants))
 		for i, record := range grants {
 			response.Grants[i] = grantSummaryResponse{

--- a/modules/card_template_catalog/api_state.go
+++ b/modules/card_template_catalog/api_state.go
@@ -273,7 +273,15 @@ func (a *API) detail(c *wkhttp.Context) {
 	if grantStore, ok := a.store.(catalogGrantStore); ok && grantStore != nil {
 		grants, truncated, grantsErr := grantStore.ListGrants(ctx, id, grantSummaryLimit)
 		if grantsErr != nil {
-			a.respondStateError(c, "detail_grants", grantsErr)
+			// The grant summary is an add-on to a control-plane read that
+			// worked long before grants existed. Failing the whole response
+			// would take activation state, versions and revisions away from an
+			// operator at exactly the moment they need them — including the
+			// case where the grant migration has not been applied yet. Report
+			// the outage in the logs and serve the rest.
+			a.logStateError("card template detail grant summary unavailable", "detail_grants", grantsErr)
+			response.GrantsUnavailable = true
+			c.Response(response)
 			return
 		}
 		response.Grants = make([]grantSummaryResponse, len(grants))
@@ -489,8 +497,12 @@ type detailReadResponse struct {
 	Truncated  bool                   `json:"truncated"`
 	// Grants 是 bounded grant summary（PR-C Control APIs）：只在 superAdmin
 	// manager detail 出现，普通 B1/B2 永不返回这些 control fields。
-	Grants          []grantSummaryResponse `json:"grants"`
-	GrantsTruncated bool                   `json:"grants_truncated,omitempty"`
+	Grants []grantSummaryResponse `json:"grants"`
+	// GrantsUnavailable marks a response whose grant summary could not be read.
+	// It is distinct from an empty Grants array — "this template has no grants"
+	// and "we could not tell" are different answers for an operator.
+	GrantsUnavailable bool `json:"grants_unavailable,omitempty"`
+	GrantsTruncated   bool `json:"grants_truncated,omitempty"`
 }
 
 type grantSummaryResponse struct {

--- a/modules/card_template_catalog/api_state.go
+++ b/modules/card_template_catalog/api_state.go
@@ -279,6 +279,11 @@ func (a *API) detail(c *wkhttp.Context) {
 			// operator at exactly the moment they need them — including the
 			// case where the grant migration has not been applied yet. Report
 			// the outage in the logs and serve the rest.
+			// Still record the DB outcome. Degrading the response must not also
+			// degrade observability: without this the detail_grants metric never
+			// fires for any outcome, and a persistent grant-store outage reads
+			// as 100% success on the dashboard that exists to catch it.
+			a.metrics.observeDB("detail_grants", "error")
 			a.logStateError("card template detail grant summary unavailable", "detail_grants", grantsErr)
 			response.GrantsUnavailable = true
 			c.Response(response)

--- a/modules/card_template_catalog/api_state.go
+++ b/modules/card_template_catalog/api_state.go
@@ -267,7 +267,32 @@ func (a *API) detail(c *wkhttp.Context) {
 		a.respondStateError(c, "detail", err)
 		return
 	}
-	c.Response(templateDetailResponse(detail))
+	response := templateDetailResponse(detail)
+	// Bounded grant summary（PR-C）：grant store 可用时附带；fake/legacy store
+	// 不实现该接口则省略（响应 grants 恒为数组，不因缺失变形）。
+	if grantStore, ok := a.store.(catalogGrantStore); ok && grantStore != nil {
+		grants, truncated, grantsErr := grantStore.ListGrants(ctx, id, grantSummaryLimit)
+		if grantsErr != nil {
+			a.respondStateError(c, "detail_grants", grantsErr)
+			return
+		}
+		response.Grants = make([]grantSummaryResponse, len(grants))
+		for i, record := range grants {
+			response.Grants[i] = grantSummaryResponse{
+				PrincipalType: string(record.Identity.PrincipalType),
+				PrincipalID:   record.Identity.PrincipalID,
+				ScopeSpaceID:  record.Identity.ScopeSpaceID,
+				Status:        string(record.Status),
+				Discover:      record.Permissions.Discover,
+				Send:          record.Permissions.Send,
+				Edit:          record.Permissions.Edit,
+				Revision:      record.Revision,
+				UpdatedBy:     record.UpdatedBy,
+			}
+		}
+		response.GrantsTruncated = truncated
+	}
+	c.Response(response)
 }
 
 func (a *API) audit(c *wkhttp.Context) {
@@ -462,11 +487,27 @@ type detailReadResponse struct {
 	Activation activationReadResponse `json:"activation"`
 	Versions   []versionReadResponse  `json:"versions"`
 	Truncated  bool                   `json:"truncated"`
+	// Grants 是 bounded grant summary（PR-C Control APIs）：只在 superAdmin
+	// manager detail 出现，普通 B1/B2 永不返回这些 control fields。
+	Grants          []grantSummaryResponse `json:"grants"`
+	GrantsTruncated bool                   `json:"grants_truncated,omitempty"`
+}
+
+type grantSummaryResponse struct {
+	PrincipalType string `json:"principal_type"`
+	PrincipalID   string `json:"principal_id"`
+	ScopeSpaceID  string `json:"scope_space_id"`
+	Status        string `json:"status"`
+	Discover      bool   `json:"discover"`
+	Send          bool   `json:"send"`
+	Edit          bool   `json:"edit"`
+	Revision      uint64 `json:"revision"`
+	UpdatedBy     string `json:"updated_by"`
 }
 
 func templateDetailResponse(detail TemplateDetail) detailReadResponse {
 	response := detailReadResponse{
-		TemplateID: detail.TemplateID,
+		TemplateID: detail.TemplateID, Grants: []grantSummaryResponse{},
 		Activation: activationReadResponse{
 			Exists: detail.Activation.Exists, Version: detail.Activation.Version,
 			Status: string(detail.Activation.Status), Revision: detail.Activation.Revision,

--- a/modules/card_template_catalog/api_test.go
+++ b/modules/card_template_catalog/api_test.go
@@ -221,7 +221,7 @@ func TestReconcileStaticInventoryUsesFrozenRegistryList(t *testing.T) {
 }
 
 func TestCatalogNoLegacyErrorResponses(t *testing.T) {
-	files := []string{"api.go", "api_state.go", "api_i18n.go", "api_grant.go"}
+	files := []string{"api.go", "api_state.go", "api_i18n.go", "api_grant.go", "api_discovery.go"}
 	banned := []string{".ResponseError(", ".ResponseErrorf(", ".ResponseErrorWithStatus(", ".AbortWithStatusJSON(", ".AbortWithStatus(", `.Response("`}
 	for _, file := range files {
 		data, err := os.ReadFile(file)

--- a/modules/card_template_catalog/api_test.go
+++ b/modules/card_template_catalog/api_test.go
@@ -221,7 +221,7 @@ func TestReconcileStaticInventoryUsesFrozenRegistryList(t *testing.T) {
 }
 
 func TestCatalogNoLegacyErrorResponses(t *testing.T) {
-	files := []string{"api.go", "api_state.go", "api_i18n.go"}
+	files := []string{"api.go", "api_state.go", "api_i18n.go", "api_grant.go"}
 	banned := []string{".ResponseError(", ".ResponseErrorf(", ".ResponseErrorWithStatus(", ".AbortWithStatusJSON(", ".AbortWithStatus(", `.Response("`}
 	for _, file := range files {
 		data, err := os.ReadFile(file)

--- a/modules/card_template_catalog/owner_policy.go
+++ b/modules/card_template_catalog/owner_policy.go
@@ -1,5 +1,10 @@
 package card_template_catalog
 
+import (
+	"sort"
+	"strings"
+)
+
 // approvedRuntimeOwners is the E3 v1 server-authored owner policy. Adding an
 // owner is a reviewed code/config capability change; a manifest cannot grant
 // itself authority by declaring an arbitrary owner or an ext.* namespace.
@@ -11,4 +16,34 @@ var approvedRuntimeOwners = map[string]struct{}{
 func isApprovedRuntimeOwner(owner string) bool {
 	_, ok := approvedRuntimeOwners[owner]
 	return ok
+}
+
+// approvedRuntimeOwnerList is the same policy in the shape SQL needs, sorted so
+// the generated predicate is stable across processes.
+//
+// B1 and B2 have to agree on this or the allowlist stops being a kill switch:
+// B2 resolves through the runtime authorizer, which rejects an unapproved
+// owner, while B1's predicate had no owner clause at all. Narrow the list
+// during an incident and B1 would keep listing every affected template with
+// full metadata — and keep spending LIMIT slots on rows B2 answers not-found
+// for. Deriving both from this one source is what stops them drifting.
+func approvedRuntimeOwnerList() []string {
+	owners := make([]string, 0, len(approvedRuntimeOwners))
+	for owner := range approvedRuntimeOwners {
+		owners = append(owners, owner)
+	}
+	sort.Strings(owners)
+	return owners
+}
+
+// approvedOwnerPredicate renders `a.owner IN (?,?)` plus its arguments.
+func approvedOwnerPredicate(column string) (string, []any) {
+	owners := approvedRuntimeOwnerList()
+	placeholders := make([]string, 0, len(owners))
+	args := make([]any, 0, len(owners))
+	for _, owner := range owners {
+		placeholders = append(placeholders, "?")
+		args = append(args, owner)
+	}
+	return column + " IN (" + strings.Join(placeholders, ",") + ")", args
 }

--- a/modules/card_template_catalog/pilot_mysql_integration_test.go
+++ b/modules/card_template_catalog/pilot_mysql_integration_test.go
@@ -1,0 +1,359 @@
+package card_template_catalog
+
+// PR-C D7 — the first non-production dynamic pilot, end to end.
+//
+// This drives the whole loop against real MySQL: version preflight → static
+// baseline → publish → grant → activate → discover → authorize a send →
+// same-version edit → rollback → revoke. Each step asserts the property the
+// slice it came from is responsible for, so a regression anywhere in PR-C
+// surfaces here as a specific failed step rather than as "the pilot broke".
+//
+// Two things this deliberately does NOT do:
+//
+//   - It never touches production. The bundle fixture is publish *input*; it is
+//     not registered in DefaultRegistry, not embedded at startup, and its
+//     presence in Git is not activation. The gates stay closed in production
+//     regardless of what this test proves.
+//   - It never reuses an identity. The version below is a dated prerelease, and
+//     the preflight step below refuses to run if the catalog has ever seen it —
+//     a version claim is permanent, so publishing over one would either be
+//     rejected as an immutability violation or, worse, quietly resolve to
+//     someone else's artifact.
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl"
+)
+
+const (
+	// pilotTemplateID reuses the existing docs L2a template ID on purpose: the
+	// pilot's point is that a dynamic version can shadow a static one for new
+	// sends while historical cards keep rendering at their stored version.
+	pilotTemplateID = cardtmpl.ID("docs.access-request")
+	// pilotVersion is a dated prerelease that has never been claimed. It is not
+	// a default and must not be edited in place: if the preflight below ever
+	// finds it claimed, pick a new reviewed SemVer rather than overwriting.
+	pilotVersion = "0.4.0-pilot.20260805"
+	// pilotStaticBaseline is the known-good static exact the pilot activates
+	// first, so the later rollback has a genuine previously-active target
+	// instead of inferring one from the Registry default.
+	pilotStaticBaseline = "0.3.0"
+
+	pilotProducerID = "docs-notify"
+	pilotSpaceID    = "space-cardtmpl-pilot"
+	pilotActor      = "admin-pilot"
+)
+
+func pilotBundlePath() string {
+	return filepath.Join("testdata", "pilot",
+		string(pilotTemplateID)+"@"+pilotVersion, "bundle.json")
+}
+
+func loadPilotBundle(t *testing.T) cardtmpl.Bundle {
+	t.Helper()
+	raw, err := os.ReadFile(pilotBundlePath())
+	if err != nil {
+		t.Fatalf("read pilot bundle: %v", err)
+	}
+	var bundle cardtmpl.Bundle
+	if err := json.Unmarshal(raw, &bundle); err != nil {
+		t.Fatalf("decode pilot bundle: %v", err)
+	}
+	return bundle
+}
+
+// requirePilotVersionUnclaimed is the preflight gate.
+//
+// A version claim is permanent and global to the catalog, so "has anyone ever
+// claimed this exact version" is the one question that must be answered before
+// the fixture is published anywhere — including on a shared non-production
+// database that other branches also publish to. Answering it in code rather
+// than in a runbook step means it cannot be skipped by whoever runs the pilot
+// next, and the failure names the remedy instead of surfacing later as an
+// opaque immutability conflict.
+func requirePilotVersionUnclaimed(t *testing.T, db *sql.DB, id cardtmpl.ID, version string) {
+	t.Helper()
+	var claimed int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM card_template_version_claim
+        WHERE template_id = ? AND version = ?`, string(id), version).Scan(&claimed); err != nil {
+		t.Fatalf("pilot version preflight: %v", err)
+	}
+	if claimed != 0 {
+		t.Fatalf("pilot version preflight: %s@%s is already claimed in this catalog. "+
+			"A claim is permanent — do not overwrite or reuse it. Choose a new reviewed "+
+			"prerelease version, rename the testdata/pilot directory to match, and update "+
+			"pilotVersion.", id, version)
+	}
+}
+
+// seedPilotStaticBaseline records the known-good static exact as active before
+// any dynamic activation, per D7. Without it the later rollback would have no
+// previously-active target and the pilot would prove a rollback that operators
+// could not actually perform.
+func seedPilotStaticBaseline(t *testing.T, db *sql.DB) {
+	t.Helper()
+	if _, err := db.Exec(`INSERT INTO card_template_version_claim
+        (template_id, version, source) VALUES (?, ?, 'static')`,
+		string(pilotTemplateID), pilotStaticBaseline); err != nil {
+		t.Fatalf("seed static baseline claim: %v", err)
+	}
+	if _, err := db.Exec(`INSERT INTO card_template_activation
+        (template_id, active_version, status, revision, updated_by, reason, change_ticket)
+        VALUES (?, ?, 'active', 1, ?, 'pilot static baseline', 'PILOT-0')`,
+		string(pilotTemplateID), pilotStaticBaseline, pilotActor); err != nil {
+		t.Fatalf("seed static baseline activation: %v", err)
+	}
+	if _, err := db.Exec(`INSERT INTO card_template_audit
+        (actor_uid, operation, template_id, version, resulting_version,
+         previous_revision, resulting_revision, result, reason, change_ticket)
+        VALUES (?, 'activate', ?, ?, ?, 0, 1, 'ok', 'pilot static baseline', 'PILOT-0')`,
+		pilotActor, string(pilotTemplateID), pilotStaticBaseline, pilotStaticBaseline); err != nil {
+		t.Fatalf("seed static baseline audit: %v", err)
+	}
+}
+
+func pilotProducerPrincipal() cardtmpl.CatalogPrincipal {
+	return cardtmpl.CatalogPrincipal{
+		Kind: cardtmpl.CatalogPrincipalInternalProducer, ID: pilotProducerID, SpaceID: pilotSpaceID,
+	}
+}
+
+func pilotGrantIdentity() GrantIdentity {
+	return GrantIdentity{
+		TemplateID:    pilotTemplateID,
+		PrincipalType: GrantPrincipalInternalProducer,
+		PrincipalID:   pilotProducerID,
+		ScopeSpaceID:  pilotSpaceID,
+	}
+}
+
+// The pilot bundle must compile with no database at all. Keeping this separate
+// means a malformed fixture is caught on every developer machine, not only
+// where MySQL happens to be running.
+func TestPilotBundleCompilesAndProjectsSafely(t *testing.T) {
+	bundle := loadPilotBundle(t)
+	artifact, err := cardtmpl.CompileJSONArtifact(context.Background(), bundle, cardtmpl.DefaultCompileLimits())
+	if err != nil {
+		t.Fatalf("compile pilot bundle: %v", err)
+	}
+	if artifact.Meta.ID != pilotTemplateID || artifact.Meta.Version != pilotVersion {
+		t.Fatalf("pilot identity = %s@%s", artifact.Meta.ID, artifact.Meta.Version)
+	}
+	if artifact.Owner != "docs" || artifact.Visibility != cardtmpl.CatalogVisibilityPrivate {
+		t.Fatalf("pilot owner/visibility = %s/%s, want docs/private", artifact.Owner, artifact.Visibility)
+	}
+	contract := artifact.Meta.ActionContract
+	if contract == nil || contract.Owner != "docs" || contract.ActionType != "access_request.decision" {
+		t.Fatalf("pilot action contract = %+v, want the existing docs RouteSpec", contract)
+	}
+	export := artifact.Meta.Export()
+	if export == nil {
+		t.Fatal("pilot bundle produced no export projection")
+	}
+	// D5 requires the pilot to prove the export path end to end, which means at
+	// least one allowlisted synthetic sample — and nothing beyond the allowlist.
+	if len(export.Samples) != 1 {
+		t.Fatalf("pilot exported samples = %v, want exactly the allowlisted one", export.Samples)
+	}
+	if _, allowlisted := export.Samples["pending"]; !allowlisted {
+		t.Fatalf("pilot exported the wrong sample set: %v", export.Samples)
+	}
+}
+
+// TestPilotDynamicCatalogEndToEndRealMySQL is the D7 loop.
+func TestPilotDynamicCatalogEndToEndRealMySQL(t *testing.T) {
+	db := newCatalogStoreIntegrationDB(t)
+	catalogStore := newStore(db)
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	// 1. Preflight: the exact version has never been claimed.
+	requirePilotVersionUnclaimed(t, db, pilotTemplateID, pilotVersion)
+
+	// 2. Baseline: the known-good static exact is active and audited, so the
+	//    rollback in step 9 has a real previously-active target.
+	seedPilotStaticBaseline(t, db)
+
+	// 3. Publish the prerelease dynamic artifact. Publishing is not activation
+	//    and not authorization — the next two steps prove both.
+	artifact, err := cardtmpl.CompileJSONArtifact(ctx, loadPilotBundle(t), cardtmpl.DefaultCompileLimits())
+	if err != nil {
+		t.Fatalf("compile pilot bundle: %v", err)
+	}
+	published, err := catalogStore.Publish(ctx, PublishRequest{
+		Artifact: artifact, ActorUID: pilotActor,
+		Reason: "non-production pilot", ChangeTicket: "PILOT-1",
+	})
+	if err != nil {
+		t.Fatalf("publish pilot artifact: %v", err)
+	}
+	if !published.Created || published.Blocked {
+		t.Fatalf("publish result = %+v, want a fresh unblocked claim", published)
+	}
+
+	// 4. Published but neither active nor granted: a new send still resolves to
+	//    the static baseline, and the producer holds nothing.
+	auth, err := catalogStore.LoadAuthorization(ctx, cardtmpl.RuntimeAuthorizationQuery{
+		ID: pilotTemplateID, Principal: pilotProducerPrincipal(),
+	})
+	if err != nil {
+		t.Fatalf("post-publish authorization: %v", err)
+	}
+	if auth.Version != pilotStaticBaseline || auth.Grant.Found {
+		t.Fatalf("publish implied activation or a grant: %+v", auth)
+	}
+
+	// 5. Grant send+edit+discover to the producer in the pilot Space.
+	if _, err := catalogStore.UpsertGrant(ctx, UpsertGrantRequest{
+		Identity:    pilotGrantIdentity(),
+		Permissions: GrantPermissions{Discover: true, Send: true, Edit: true},
+		ActorUID:    pilotActor, Reason: "pilot producer", ChangeTicket: "PILOT-2",
+	}); err != nil {
+		t.Fatalf("grant pilot producer: %v", err)
+	}
+	// A grant is still not an activation: new sends keep resolving to static.
+	auth, err = catalogStore.LoadAuthorization(ctx, cardtmpl.RuntimeAuthorizationQuery{
+		ID: pilotTemplateID, Principal: pilotProducerPrincipal(),
+	})
+	if err != nil {
+		t.Fatalf("post-grant authorization: %v", err)
+	}
+	if auth.Version != pilotStaticBaseline {
+		t.Fatalf("grant moved the activation pointer to %q", auth.Version)
+	}
+	if !auth.Grant.Allows(cardtmpl.CatalogPurposeNewSend) {
+		t.Fatalf("granted producer cannot send: %+v", auth.Grant)
+	}
+
+	// 6. Activate the dynamic exact with the baseline's current revision.
+	activated, err := catalogStore.Activate(ctx, ActivationRequest{
+		TemplateID: pilotTemplateID, TargetVersion: pilotVersion, ExpectedRevision: 1,
+		ActorUID: pilotActor, Reason: "pilot activation", ChangeTicket: "PILOT-3",
+		targetReceipt: stateTargetReceipt{meta: cardtmpl.RuntimeArtifactMeta{
+			ID: pilotTemplateID, Version: pilotVersion, Source: cardtmpl.RuntimeSourceDynamic,
+			Engine: cardtmpl.JSONTemplateEngineV1, Hash: artifact.Hash, Owner: artifact.Owner,
+			Visibility: artifact.Visibility, Protocol: cardtmpl.Protocol,
+			ContractVersion: artifact.ContractVersion,
+		}},
+	})
+	if err != nil {
+		t.Fatalf("activate pilot version: %v", err)
+	}
+	if activated.ActiveVersion != pilotVersion {
+		t.Fatalf("active version = %q, want the pilot prerelease", activated.ActiveVersion)
+	}
+
+	// 7. The dynamic version now shadows the static baseline for new sends, and
+	//    the whole decision comes from one snapshot.
+	auth, err = catalogStore.LoadAuthorization(ctx, cardtmpl.RuntimeAuthorizationQuery{
+		ID: pilotTemplateID, Principal: pilotProducerPrincipal(),
+	})
+	if err != nil {
+		t.Fatalf("post-activate authorization: %v", err)
+	}
+	if auth.Version != pilotVersion || auth.Artifact.Source != cardtmpl.RuntimeSourceDynamic ||
+		auth.Artifact.Blocked || !auth.Grant.Allows(cardtmpl.CatalogPurposeNewSend) {
+		t.Fatalf("dynamic new-send authorization = %+v", auth)
+	}
+
+	// 8. Discovery: the Space sees the private pilot only with a space grant,
+	//    and a Space without one gets the same answer as for a template that
+	//    does not exist.
+	if _, err := catalogStore.LoadDiscoverable(ctx, pilotSpaceID, pilotTemplateID, pilotVersion); !errors.Is(
+		err, ErrDiscoveryNotVisible) {
+		t.Fatalf("private pilot was discoverable without a space grant: %v", err)
+	}
+	if _, err := catalogStore.UpsertGrant(ctx, UpsertGrantRequest{
+		Identity: GrantIdentity{
+			TemplateID: pilotTemplateID, PrincipalType: GrantPrincipalSpace, PrincipalID: pilotSpaceID,
+		},
+		Permissions: GrantPermissions{Discover: true},
+		ActorUID:    pilotActor, Reason: "pilot discovery", ChangeTicket: "PILOT-4",
+	}); err != nil {
+		t.Fatalf("grant space discovery: %v", err)
+	}
+	row, err := catalogStore.LoadDiscoverable(ctx, pilotSpaceID, pilotTemplateID, pilotVersion)
+	if err != nil {
+		t.Fatalf("granted space cannot discover the pilot: %v", err)
+	}
+	if row.Visibility != cardtmpl.CatalogVisibilityPrivate || !row.ActiveForNewSend ||
+		row.ContentSHA256 != artifact.Hash {
+		t.Fatalf("discovered row = %+v", row)
+	}
+	if _, err := catalogStore.LoadDiscoverable(ctx, "space-somewhere-else",
+		pilotTemplateID, pilotVersion); !errors.Is(err, ErrDiscoveryNotVisible) {
+		t.Fatalf("another Space could see the pilot: %v", err)
+	}
+
+	// 9. A historical card pins its stored exact version, so a rollback of the
+	//    pointer must not change what an existing card resolves to. Read the
+	//    pinned authorization before and after the rollback and compare.
+	pinnedBefore, err := catalogStore.LoadAuthorization(ctx, cardtmpl.RuntimeAuthorizationQuery{
+		ID: pilotTemplateID, Version: pilotVersion, Principal: pilotProducerPrincipal(),
+	})
+	if err != nil {
+		t.Fatalf("pinned authorization before rollback: %v", err)
+	}
+	if !pinnedBefore.Grant.Allows(cardtmpl.CatalogPurposeHistoricalEdit) ||
+		!pinnedBefore.Grant.Allows(cardtmpl.CatalogPurposeActionContext) {
+		t.Fatalf("pinned edit/action authorization = %+v", pinnedBefore.Grant)
+	}
+	if _, err := catalogStore.Rollback(ctx, RollbackRequest{
+		TemplateID: pilotTemplateID, TargetVersion: pilotStaticBaseline, ExpectedRevision: activated.Revision,
+		ActorUID: pilotActor, Reason: "pilot rollback", ChangeTicket: "PILOT-5",
+		targetReceipt: stateTargetReceipt{meta: cardtmpl.RuntimeArtifactMeta{
+			ID: pilotTemplateID, Version: pilotStaticBaseline, Source: cardtmpl.RuntimeSourceStatic,
+		}},
+	}); err != nil {
+		t.Fatalf("rollback to the static baseline: %v", err)
+	}
+	pinnedAfter, err := catalogStore.LoadAuthorization(ctx, cardtmpl.RuntimeAuthorizationQuery{
+		ID: pilotTemplateID, Version: pilotVersion, Principal: pilotProducerPrincipal(),
+	})
+	if err != nil {
+		t.Fatalf("pinned authorization after rollback: %v", err)
+	}
+	if pinnedAfter.Version != pilotVersion || !pinnedAfter.Grant.Allows(cardtmpl.CatalogPurposeHistoricalEdit) {
+		t.Fatalf("rollback broke historical edit of an already-sent card: %+v", pinnedAfter)
+	}
+	// New sends, meanwhile, are back on the static baseline.
+	auth, err = catalogStore.LoadAuthorization(ctx, cardtmpl.RuntimeAuthorizationQuery{
+		ID: pilotTemplateID, Principal: pilotProducerPrincipal(),
+	})
+	if err != nil {
+		t.Fatalf("post-rollback authorization: %v", err)
+	}
+	if auth.Version != pilotStaticBaseline {
+		t.Fatalf("post-rollback new-send version = %q, want the static baseline", auth.Version)
+	}
+
+	// 10. Revoke: the very next decision is denied, for the pinned historical
+	//     path as well as for new sends.
+	if _, err := catalogStore.RevokeGrant(ctx, RevokeGrantRequest{
+		Identity: pilotGrantIdentity(), ExpectedRevision: 1,
+		ActorUID: pilotActor, Reason: "pilot complete", ChangeTicket: "PILOT-6",
+	}); err != nil {
+		t.Fatalf("revoke pilot grant: %v", err)
+	}
+	revoked, err := catalogStore.LoadAuthorization(ctx, cardtmpl.RuntimeAuthorizationQuery{
+		ID: pilotTemplateID, Version: pilotVersion, Principal: pilotProducerPrincipal(),
+	})
+	if err != nil {
+		t.Fatalf("post-revoke authorization: %v", err)
+	}
+	if revoked.Grant.Allows(cardtmpl.CatalogPurposeHistoricalEdit) ||
+		revoked.Grant.Allows(cardtmpl.CatalogPurposeNewSend) {
+		t.Fatalf("revoked producer still authorized: %+v", revoked.Grant)
+	}
+	if !revoked.Grant.Found {
+		t.Fatal("revoke deleted the row instead of writing a tombstone")
+	}
+}

--- a/modules/card_template_catalog/pilot_mysql_integration_test.go
+++ b/modules/card_template_catalog/pilot_mysql_integration_test.go
@@ -27,6 +27,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -34,10 +35,17 @@ import (
 )
 
 const (
-	// pilotTemplateID reuses the existing docs L2a template ID on purpose: the
-	// pilot's point is that a dynamic version can shadow a static one for new
-	// sends while historical cards keep rendering at their stored version.
-	pilotTemplateID = cardtmpl.ID("docs.access-request")
+	// pilotTemplateID is a dedicated ID, NOT the live docs.access-request.
+	//
+	// An earlier revision reused the production ID so the shadow behaviour would
+	// be observable on a real card. That is unsafe: the pilot bundle declares its
+	// own `additionalProperties:false` contract, so activating it for the live ID
+	// in any catalog where the notify docs producer runs would make every real
+	// access-request card fail preflight with a 400 and zero delivery. The
+	// shadow path is proven below by activating over a *seeded* static baseline
+	// under this dedicated ID, which exercises the same code with none of that
+	// blast radius.
+	pilotTemplateID = cardtmpl.ID("docs.pilot-access-request")
 	// pilotVersion is a dated prerelease that has never been claimed. It is not
 	// a default and must not be edited in place: if the preflight below ever
 	// finds it claimed, pick a new reviewed SemVer rather than overwriting.
@@ -46,10 +54,18 @@ const (
 	// first, so the later rollback has a genuine previously-active target
 	// instead of inferring one from the Registry default.
 	pilotStaticBaseline = "0.3.0"
+	// pilotProductionTemplateID is the live ID the pilot must never claim. The
+	// test asserts this rather than leaving it to a reader of the constant.
+	pilotProductionTemplateID = cardtmpl.ID("docs.access-request")
 
 	pilotProducerID = "docs-notify"
 	pilotSpaceID    = "space-cardtmpl-pilot"
 	pilotActor      = "admin-pilot"
+
+	// pilotCatalogDSNEnv names the shared non-production catalog the version
+	// preflight interrogates. The per-test database cannot answer the question:
+	// it is created empty moments before the check runs.
+	pilotCatalogDSNEnv = "OCTO_PILOT_CATALOG_DSN"
 )
 
 func pilotBundlePath() string {
@@ -72,22 +88,44 @@ func loadPilotBundle(t *testing.T) cardtmpl.Bundle {
 
 // requirePilotVersionUnclaimed is the preflight gate.
 //
-// A version claim is permanent and global to the catalog, so "has anyone ever
-// claimed this exact version" is the one question that must be answered before
-// the fixture is published anywhere — including on a shared non-production
-// database that other branches also publish to. Answering it in code rather
-// than in a runbook step means it cannot be skipped by whoever runs the pilot
-// next, and the failure names the remedy instead of surfacing later as an
-// opaque immutability conflict.
-func requirePilotVersionUnclaimed(t *testing.T, db *sql.DB, id cardtmpl.ID, version string) {
+// A version claim is permanent and global to a catalog, so "has anyone ever
+// claimed this exact version" must be answered before the fixture is published
+// anywhere. The subtlety is *which* catalog to ask.
+//
+// An earlier revision asked the per-test database — which
+// newCatalogStoreIntegrationDB drops and recreates immediately beforehand, so
+// the answer was unconditionally "no" and the gate could never fire. It read
+// like a safety check and was theatre.
+//
+// The real question is about whatever shared non-production catalog the
+// operator is publishing into, which this process only knows about through
+// OCTO_PILOT_CATALOG_DSN. When that is set the gate queries it for real; when
+// it is not, the gate says so out loud and skips rather than passing silently,
+// because "no shared catalog configured" and "the version is free" are
+// different answers and only one of them is evidence.
+func requirePilotVersionUnclaimed(t *testing.T, id cardtmpl.ID, version string) {
 	t.Helper()
+	dsn := strings.TrimSpace(os.Getenv(pilotCatalogDSNEnv))
+	if dsn == "" {
+		t.Logf("pilot version preflight SKIPPED: %s is unset, so no shared catalog was "+
+			"checked for %s@%s. Set it to the non-production catalog DSN before publishing "+
+			"this fixture anywhere shared.", pilotCatalogDSNEnv, id, version)
+		return
+	}
+	shared, err := sql.Open("mysql", dsn)
+	if err != nil {
+		t.Fatalf("pilot version preflight: open %s: %v", pilotCatalogDSNEnv, err)
+	}
+	defer func() { _ = shared.Close() }()
+
 	var claimed int
-	if err := db.QueryRow(`SELECT COUNT(*) FROM card_template_version_claim
-        WHERE template_id = ? AND version = ?`, string(id), version).Scan(&claimed); err != nil {
-		t.Fatalf("pilot version preflight: %v", err)
+	err = shared.QueryRow(`SELECT COUNT(*) FROM card_template_version_claim
+        WHERE template_id = ? AND version = ?`, string(id), version).Scan(&claimed)
+	if err != nil {
+		t.Fatalf("pilot version preflight: query shared catalog: %v", err)
 	}
 	if claimed != 0 {
-		t.Fatalf("pilot version preflight: %s@%s is already claimed in this catalog. "+
+		t.Fatalf("pilot version preflight: %s@%s is already claimed in the shared catalog. "+
 			"A claim is permanent — do not overwrite or reuse it. Choose a new reviewed "+
 			"prerelease version, rename the testdata/pilot directory to match, and update "+
 			"pilotVersion.", id, version)
@@ -166,6 +204,12 @@ func TestPilotBundleCompilesAndProjectsSafely(t *testing.T) {
 	if _, allowlisted := export.Samples["pending"]; !allowlisted {
 		t.Fatalf("pilot exported the wrong sample set: %v", export.Samples)
 	}
+	// The fixture declares its own strict data contract, so claiming the live
+	// template ID would make activating it reject every real access-request
+	// card. Assert the separation rather than trusting a comment on a constant.
+	if artifact.Meta.ID == pilotProductionTemplateID {
+		t.Fatalf("the pilot fixture claims the production template ID %s", pilotProductionTemplateID)
+	}
 }
 
 // TestPilotDynamicCatalogEndToEndRealMySQL is the D7 loop.
@@ -176,7 +220,7 @@ func TestPilotDynamicCatalogEndToEndRealMySQL(t *testing.T) {
 	defer cancel()
 
 	// 1. Preflight: the exact version has never been claimed.
-	requirePilotVersionUnclaimed(t, db, pilotTemplateID, pilotVersion)
+	requirePilotVersionUnclaimed(t, pilotTemplateID, pilotVersion)
 
 	// 2. Baseline: the known-good static exact is active and audited, so the
 	//    rollback in step 9 has a real previously-active target.

--- a/modules/card_template_catalog/runtime_db_integration_test.go
+++ b/modules/card_template_catalog/runtime_db_integration_test.go
@@ -277,14 +277,25 @@ func newRuntimeCatalogIntegrationDB(t *testing.T) *sql.DB {
 		t.Fatalf("ping integration database: %v", err)
 	}
 	source := runtimeCatalogMigrationSource{}
-	if applied, err := migrate.Exec(db, "mysql", source, migrate.Up); err != nil || applied != 2 {
+	// Derive the expected count from the source rather than hardcoding it. A
+	// hardcoded 2 meant that adding the grant migration broke four unrelated
+	// tests with a message about migration counts — and only on a machine with
+	// MySQL, so the breakage was invisible everywhere else.
+	migrations, err := source.FindMigrations()
+	if err != nil {
 		_ = db.Close()
 		_ = bootstrap.Close()
-		t.Fatalf("apply catalog migrations: applied=%d err=%v", applied, err)
+		t.Fatalf("find catalog migrations: %v", err)
+	}
+	if applied, err := migrate.Exec(db, "mysql", source, migrate.Up); err != nil || applied != len(migrations) {
+		_ = db.Close()
+		_ = bootstrap.Close()
+		t.Fatalf("apply catalog migrations: applied=%d want=%d err=%v", applied, len(migrations), err)
 	}
 	t.Cleanup(func() {
-		if reverted, err := migrate.Exec(db, "mysql", source, migrate.Down); err != nil || reverted != 2 {
-			t.Errorf("revert catalog migrations: reverted=%d err=%v", reverted, err)
+		if reverted, err := migrate.Exec(db, "mysql", source, migrate.Down); err != nil || reverted != len(migrations) {
+			t.Errorf("revert catalog migrations: reverted=%d want=%d err=%v",
+				reverted, len(migrations), err)
 		}
 		if err := db.Close(); err != nil {
 			t.Errorf("close integration database: %v", err)

--- a/modules/card_template_catalog/runtime_db_integration_test.go
+++ b/modules/card_template_catalog/runtime_db_integration_test.go
@@ -406,7 +406,8 @@ func integrationRuntimeCatalog(t *testing.T, registry *cardtmpl.Registry, store 
 	t.Helper()
 	catalog, err := cardtmpl.NewRuntimeCatalog(registry, store, cardtmpl.RuntimeCatalogConfig{
 		MaxCacheEntries: 8, MaxCacheBytes: 8 << 20, CompileTimeout: 5 * time.Second,
-		AuthorizeDynamic: func(context.Context, cardtmpl.CatalogAccess, cardtmpl.RuntimeArtifactMeta) error {
+		AuthorizeDynamic: func(context.Context, cardtmpl.CatalogAccess, cardtmpl.RuntimeArtifactMeta,
+			cardtmpl.RuntimeGrant) error {
 			return nil
 		},
 	})

--- a/modules/card_template_catalog/runtime_gates_test.go
+++ b/modules/card_template_catalog/runtime_gates_test.go
@@ -55,17 +55,64 @@ func TestRuntimeCatalogCacheConfigFromEnvIsBounded(t *testing.T) {
 
 func TestRuntimeDynamicAuthorizerKeepsNewSendDarkAndRequiresGrant(t *testing.T) {
 	access := cardtmpl.CatalogAccess{Purpose: cardtmpl.CatalogPurposeNewSend}
+	sendGrant := cardtmpl.RuntimeGrant{Found: true, Scope: cardtmpl.RuntimeGrantScopeExact, Discover: true, Send: true}
+	approved := cardtmpl.RuntimeArtifactMeta{Owner: "docs"}
+
+	// The new-send gate is checked before anything principal-specific, so a
+	// dark deployment cannot be used to probe grants.
 	authorize := runtimeDynamicAuthorizer(runtimeCatalogGates{}, nil)
-	if err := authorize(context.Background(), access, cardtmpl.RuntimeArtifactMeta{}); !errors.Is(err, cardtmpl.ErrRuntimeCatalogNewSendDisabled) {
+	if err := authorize(context.Background(), access, approved, sendGrant); !errors.Is(err, cardtmpl.ErrRuntimeCatalogNewSendDisabled) {
 		t.Fatalf("dark new-send error = %v, want ErrRuntimeCatalogNewSendDisabled", err)
 	}
 	authorize = runtimeDynamicAuthorizer(runtimeCatalogGates{newSendEnabled: true}, nil)
-	if err := authorize(context.Background(), access, cardtmpl.RuntimeArtifactMeta{}); !errors.Is(err, cardtmpl.ErrRuntimeCatalogNotAuthorized) {
+	if err := authorize(context.Background(), access, approved, cardtmpl.RuntimeGrant{}); !errors.Is(err, cardtmpl.ErrRuntimeCatalogNotAuthorized) {
 		t.Fatalf("ungranted new-send error = %v, want ErrRuntimeCatalogNotAuthorized", err)
 	}
-	authorize = runtimeDynamicAuthorizer(runtimeCatalogGates{newSendEnabled: true},
-		func(context.Context, cardtmpl.CatalogAccess, cardtmpl.RuntimeArtifactMeta) error { return nil })
-	if err := authorize(context.Background(), access, cardtmpl.RuntimeArtifactMeta{Owner: "ext.vendor"}); !errors.Is(err, cardtmpl.ErrRuntimeCatalogNotAuthorized) {
+	if err := authorize(context.Background(), access, cardtmpl.RuntimeArtifactMeta{Owner: "ext.vendor"}, sendGrant); !errors.Is(err, cardtmpl.ErrRuntimeCatalogNotAuthorized) {
 		t.Fatalf("unapproved owner error = %v, want ErrRuntimeCatalogNotAuthorized", err)
+	}
+	if err := authorize(context.Background(), access, approved, sendGrant); err != nil {
+		t.Fatalf("granted new-send: %v", err)
+	}
+}
+
+// A grant is per-permission, not a blanket pass: holding discover never
+// implies send, and a revoked tombstone (Found with nothing allowed) denies
+// exactly like an absent row.
+func TestRuntimeDynamicAuthorizerMatchesPurposeToPermission(t *testing.T) {
+	authorize := runtimeDynamicAuthorizer(runtimeCatalogGates{newSendEnabled: true}, nil)
+	meta := cardtmpl.RuntimeArtifactMeta{Owner: "docs"}
+	discoverOnly := cardtmpl.RuntimeGrant{Found: true, Scope: cardtmpl.RuntimeGrantScopeGlobal, Discover: true}
+	tombstone := cardtmpl.RuntimeGrant{Found: true, Scope: cardtmpl.RuntimeGrantScopeExact, Revision: 4}
+
+	for _, test := range []struct {
+		name    string
+		purpose cardtmpl.CatalogPurpose
+		grant   cardtmpl.RuntimeGrant
+		allow   bool
+	}{
+		{"discover does not imply send", cardtmpl.CatalogPurposeNewSend, discoverOnly, false},
+		{"discover does not imply edit", cardtmpl.CatalogPurposeHistoricalEdit, discoverOnly, false},
+		{"send does not imply edit", cardtmpl.CatalogPurposeNewSend,
+			cardtmpl.RuntimeGrant{Found: true, Discover: true, Send: true}, true},
+		{"edit covers historical edit", cardtmpl.CatalogPurposeHistoricalEdit,
+			cardtmpl.RuntimeGrant{Found: true, Discover: true, Edit: true}, true},
+		{"edit covers action context", cardtmpl.CatalogPurposeActionContext,
+			cardtmpl.RuntimeGrant{Found: true, Discover: true, Edit: true}, true},
+		{"send alone cannot answer an action", cardtmpl.CatalogPurposeActionContext,
+			cardtmpl.RuntimeGrant{Found: true, Discover: true, Send: true}, false},
+		{"tombstone denies send", cardtmpl.CatalogPurposeNewSend, tombstone, false},
+		{"tombstone denies edit", cardtmpl.CatalogPurposeHistoricalEdit, tombstone, false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			err := authorize(context.Background(),
+				cardtmpl.CatalogAccess{Purpose: test.purpose}, meta, test.grant)
+			if test.allow && err != nil {
+				t.Fatalf("authorize = %v, want allow", err)
+			}
+			if !test.allow && !errors.Is(err, cardtmpl.ErrRuntimeCatalogNotAuthorized) {
+				t.Fatalf("authorize = %v, want ErrRuntimeCatalogNotAuthorized", err)
+			}
+		})
 	}
 }

--- a/modules/card_template_catalog/runtime_install.go
+++ b/modules/card_template_catalog/runtime_install.go
@@ -102,6 +102,17 @@ func (s *runtimeAuthorizationSource) LoadAuthorization(
 	return s.store.LoadAuthorization(ctx, query)
 }
 
+// LoadAuthorizations exposes the store's batched resolver. Consumers type-assert
+// for cardtmpl.RuntimeAuthorizationBatchStore, so forgetting to forward it here
+// would silently drop them back onto the per-ID path.
+func (s *runtimeAuthorizationSource) LoadAuthorizations(
+	ctx context.Context,
+	ids []cardtmpl.ID,
+	principal cardtmpl.CatalogPrincipal,
+) (map[cardtmpl.ID]cardtmpl.RuntimeAuthorization, error) {
+	return s.store.LoadAuthorizations(ctx, ids, principal)
+}
+
 func (s *runtimeAuthorizationSource) ListAuthorizedTemplates(
 	ctx context.Context,
 	principal cardtmpl.CatalogPrincipal,

--- a/modules/card_template_catalog/runtime_install.go
+++ b/modules/card_template_catalog/runtime_install.go
@@ -253,6 +253,16 @@ func runtimeDynamicAuthorizer(
 		if !isApprovedRuntimeOwner(meta.Owner) {
 			return cardtmpl.ErrRuntimeCatalogNotAuthorized
 		}
+		// Discovery is the one purpose a grant is not strictly required for:
+		// a public template is discoverable by anyone who can reach the API,
+		// which is what "public" means. It stays weaker than use — seeing a
+		// template never implies being able to send or edit it (invariant 5) —
+		// and the new-send gate deliberately does not apply, because reading a
+		// contract is not sending a card.
+		if access.Purpose == cardtmpl.CatalogPurposeDiscover &&
+			meta.Visibility == cardtmpl.CatalogVisibilityPublic {
+			return nil
+		}
 		// A grantable principal is required: `system` and blank identities are
 		// control-plane concepts, never business producers (D2), and the
 		// resolver reports them as ungranted rather than erroring.

--- a/modules/card_template_catalog/runtime_install.go
+++ b/modules/card_template_catalog/runtime_install.go
@@ -77,8 +77,40 @@ func InstallRuntimeCatalog(
 	setInstalledRuntimeGates(gates)
 	setInstalledRuntimeReadiness(readiness)
 	cardtmpl.SetDefaultCatalog(catalog)
+	// Publish the resolver so consumers outside this module (the Bot capability
+	// manifest, chiefly) read the same grant truth through the same snapshot
+	// contract instead of growing a second one.
+	cardtmpl.SetDefaultAuthorizationSource(&runtimeAuthorizationSource{
+		store: runtimeStore, gates: gates,
+	})
 	return catalog, nil
 }
+
+// runtimeAuthorizationSource binds the store's readers to the deployment gate.
+// It exists so that "new-send is dark" is answerable without a DB round trip:
+// a gated-off deployment must keep its pre-PR-C static behaviour exactly, and
+// that includes not acquiring a runtime DB dependency it did not have before.
+type runtimeAuthorizationSource struct {
+	store *store
+	gates runtimeCatalogGates
+}
+
+func (s *runtimeAuthorizationSource) LoadAuthorization(
+	ctx context.Context,
+	query cardtmpl.RuntimeAuthorizationQuery,
+) (cardtmpl.RuntimeAuthorization, error) {
+	return s.store.LoadAuthorization(ctx, query)
+}
+
+func (s *runtimeAuthorizationSource) ListAuthorizedTemplates(
+	ctx context.Context,
+	principal cardtmpl.CatalogPrincipal,
+	limit int,
+) ([]cardtmpl.RuntimeAdvertisedTemplate, error) {
+	return s.store.ListAuthorizedTemplates(ctx, principal, limit)
+}
+
+func (s *runtimeAuthorizationSource) NewSendEnabled() bool { return s.gates.newSendEnabled }
 
 func runtimeCatalogConfigFromEnv(
 	config cardtmpl.RuntimeCatalogConfig,
@@ -197,20 +229,39 @@ func strictRuntimeBool(raw string) (bool, bool) {
 	}
 }
 
+// runtimeDynamicAuthorizer turns one snapshot into one allow/deny. Every input
+// it reads — purpose, owner, grant — was captured at the same instant by the
+// resolver; the function performs no IO of its own, which is what keeps the
+// decision linearizable against a concurrent revoke or block.
+//
+// The checks are ordered cheapest-and-most-global first so that a deployment
+// with the new-send gate closed never reveals anything about grants, and an
+// unapproved owner is rejected before any per-principal state is considered.
 func runtimeDynamicAuthorizer(
 	gates runtimeCatalogGates,
 	downstream cardtmpl.RuntimeDynamicAuthorizeFunc,
 ) cardtmpl.RuntimeDynamicAuthorizeFunc {
-	return func(ctx context.Context, access cardtmpl.CatalogAccess, meta cardtmpl.RuntimeArtifactMeta) error {
+	return func(
+		ctx context.Context,
+		access cardtmpl.CatalogAccess,
+		meta cardtmpl.RuntimeArtifactMeta,
+		grant cardtmpl.RuntimeGrant,
+	) error {
 		if access.Purpose == cardtmpl.CatalogPurposeNewSend && !gates.newSendEnabled {
 			return cardtmpl.ErrRuntimeCatalogNewSendDisabled
 		}
 		if !isApprovedRuntimeOwner(meta.Owner) {
 			return cardtmpl.ErrRuntimeCatalogNotAuthorized
 		}
-		if downstream == nil {
+		// A grantable principal is required: `system` and blank identities are
+		// control-plane concepts, never business producers (D2), and the
+		// resolver reports them as ungranted rather than erroring.
+		if !grant.Allows(access.Purpose) {
 			return cardtmpl.ErrRuntimeCatalogNotAuthorized
 		}
-		return downstream(ctx, access, meta)
+		if downstream == nil {
+			return nil
+		}
+		return downstream(ctx, access, meta, grant)
 	}
 }

--- a/modules/card_template_catalog/sql/20260805000001_card_template_catalog_grant.sql
+++ b/modules/card_template_catalog/sql/20260805000001_card_template_catalog_grant.sql
@@ -1,0 +1,65 @@
+-- +migrate Up
+
+-- PR-C D4 (spec: .octospec/tasks/cardtmpl-runtime-catalog-grants-discovery/brief.md):
+-- template-ID level producer/space grants. Identity columns use binary
+-- collations (no case folding); the global scope is the canonical empty
+-- string, kept NOT NULL so the unique primary key cannot admit duplicate
+-- "NULL scope" rows. Revoke is a tombstone (status='revoked', permissions
+-- zeroed, revision bumped) — rows are never deleted, so revoke→recreate
+-- cannot replay a stale revision (ABA). Grants deliberately have no version
+-- column: authorization is template-ID scoped (brief invariant 10) and no FK
+-- reaches across static/dynamic claims — target existence is enforced by a
+-- same-transaction SELECT ... FOR UPDATE on card_template_version_claim.
+CREATE TABLE card_template_grant (
+    template_id    VARCHAR(128) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    principal_type VARCHAR(24)  CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    principal_id   VARCHAR(128) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL,
+    scope_space_id VARCHAR(128) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL DEFAULT '',
+    status         VARCHAR(16)  CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    can_discover   TINYINT(1) NOT NULL DEFAULT 0,
+    can_send       TINYINT(1) NOT NULL DEFAULT 0,
+    can_edit       TINYINT(1) NOT NULL DEFAULT 0,
+    revision       BIGINT UNSIGNED NOT NULL,
+    updated_by     VARCHAR(128) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL,
+    reason         VARCHAR(512) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL,
+    change_ticket  VARCHAR(128) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL,
+    created_at     DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at     DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+    PRIMARY KEY (template_id, principal_type, principal_id, scope_space_id),
+    KEY idx_card_template_grant_principal (principal_type, principal_id, scope_space_id),
+    CONSTRAINT chk_card_template_grant_type
+        CHECK (principal_type IN ('bot', 'internal_producer', 'space')),
+    CONSTRAINT chk_card_template_grant_status
+        CHECK (status IN ('active', 'revoked')),
+    -- D2: an active grant always includes discover (send/edit imply it and a
+    -- permissionless active row is meaningless); a tombstone carries no
+    -- permissions so a reader that forgets the status column stays safe.
+    CONSTRAINT chk_card_template_grant_shape
+        CHECK ((status = 'active' AND can_discover = 1) OR
+               (status = 'revoked' AND can_discover = 0 AND can_send = 0 AND can_edit = 0)),
+    -- D2: a space principal is discover-only and its only canonical shape is
+    -- principal_id=<space_id> with the global sentinel scope.
+    CONSTRAINT chk_card_template_grant_space
+        CHECK (principal_type <> 'space' OR (can_send = 0 AND can_edit = 0 AND scope_space_id = ''))
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+
+-- Grant/revoke audit rides the existing append-only card_template_audit in
+-- the same transaction as the state write. The additive columns record the
+-- principal identity and the before/after permission sets; version stays ''
+-- because grants are template-ID scoped.
+ALTER TABLE card_template_audit
+    ADD COLUMN principal_type VARCHAR(24) CHARACTER SET ascii COLLATE ascii_bin NOT NULL DEFAULT '' AFTER resulting_revision,
+    ADD COLUMN principal_id VARCHAR(128) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL DEFAULT '' AFTER principal_type,
+    ADD COLUMN scope_space_id VARCHAR(128) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL DEFAULT '' AFTER principal_id,
+    ADD COLUMN previous_permissions VARCHAR(32) CHARACTER SET ascii COLLATE ascii_bin NOT NULL DEFAULT '' AFTER scope_space_id,
+    ADD COLUMN resulting_permissions VARCHAR(32) CHARACTER SET ascii COLLATE ascii_bin NOT NULL DEFAULT '' AFTER previous_permissions;
+
+-- +migrate Down
+ALTER TABLE card_template_audit
+    DROP COLUMN resulting_permissions,
+    DROP COLUMN previous_permissions,
+    DROP COLUMN scope_space_id,
+    DROP COLUMN principal_id,
+    DROP COLUMN principal_type;
+
+DROP TABLE IF EXISTS card_template_grant;

--- a/modules/card_template_catalog/sql/20260805000001_card_template_catalog_grant.sql
+++ b/modules/card_template_catalog/sql/20260805000001_card_template_catalog_grant.sql
@@ -40,7 +40,26 @@ CREATE TABLE card_template_grant (
     -- D2: a space principal is discover-only and its only canonical shape is
     -- principal_id=<space_id> with the global sentinel scope.
     CONSTRAINT chk_card_template_grant_space
-        CHECK (principal_type <> 'space' OR (can_send = 0 AND can_edit = 0 AND scope_space_id = ''))
+        CHECK (principal_type <> 'space' OR (can_send = 0 AND can_edit = 0 AND scope_space_id = '')),
+    -- The permission columns are booleans, and TINYINT(1) is not. The shape and
+    -- space constraints above already pin can_discover on both statuses, and
+    -- send/edit on a tombstone or a space principal — but an active bot or
+    -- producer row could hold any TINYINT in can_send/can_edit. Today that is
+    -- caught downstream, because GrantPermissions scans into Go bools and the
+    -- driver refuses a value outside {0,1}, so the authorization read errors and
+    -- the caller denies. That is fail-closed by accident of the scan type, not
+    -- by the schema: a future reader that scanned into an int and tested != 0
+    -- would turn the same row into a grant. State the domain where the value is
+    -- written instead of relying on how it is later read.
+    CONSTRAINT chk_card_template_grant_bools
+        CHECK (can_discover IN (0, 1) AND can_send IN (0, 1) AND can_edit IN (0, 1)),
+    -- An unnamed principal is not a principal. The Go canonical-shape validator
+    -- rejects a blank identity before any write, and grantPrincipal refuses to
+    -- map one on the read side, so a blank row can only arrive by direct SQL —
+    -- where it would sit in the table looking like a grant that no lookup can
+    -- ever match.
+    CONSTRAINT chk_card_template_grant_identity
+        CHECK (principal_id <> '')
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
 
 -- Grant/revoke audit rides the existing append-only card_template_audit in

--- a/modules/card_template_catalog/store_authorization.go
+++ b/modules/card_template_catalog/store_authorization.go
@@ -49,12 +49,16 @@ const (
 	// selectPrincipalGrantsSQL lists a principal's grant rows across templates
 	// for the Bot advertised set. It is bounded by the caller and covers both
 	// scopes so the same precedence rule applies per template ID.
+	// selectPrincipalGrantsSQL lists a principal's grant rows across templates.
+	// The secondary sort key is not cosmetic: a template's exact and global rows
+	// must be adjacent and in a defined order so the row budget can be truncated
+	// at a template boundary rather than through the middle of a pair.
 	selectPrincipalGrantsSQL = `SELECT template_id, scope_space_id, status,
             can_discover, can_send, can_edit, revision
         FROM card_template_grant
         WHERE principal_type = ? AND principal_id = ?
           AND scope_space_id IN (?, '')
-        ORDER BY template_id ASC
+        ORDER BY template_id ASC, scope_space_id ASC
         LIMIT ?`
 )
 
@@ -314,8 +318,13 @@ func scanPrincipalGrants(
 	principalID, scope string,
 	rowLimit int,
 ) (map[cardtmpl.ID]GrantDecision, error) {
+	// Read one row past the budget so a truncated result is detectable. A
+	// template's exact and global rows are adjacent in this ordering, so a cut
+	// can only ever split the *last* template — and half a pair is worse than
+	// no pair: losing the exact tombstone of a template whose global row is
+	// still active would report a revoked principal as granted.
 	rows, err := tx.QueryContext(ctx, selectPrincipalGrantsSQL,
-		string(principalType), principalID, scope, rowLimit)
+		string(principalType), principalID, scope, rowLimit+1)
 	if err != nil {
 		return nil, fmt.Errorf("card template catalog: list principal grants: %w", err)
 	}
@@ -323,7 +332,16 @@ func scanPrincipalGrants(
 
 	exact := make(map[cardtmpl.ID]GrantRecord)
 	global := make(map[cardtmpl.ID]GrantRecord)
+	var order []cardtmpl.ID
+	seen := make(map[cardtmpl.ID]struct{})
+	truncated := false
+	scanned := 0
 	for rows.Next() {
+		scanned++
+		if scanned > rowLimit {
+			truncated = true
+			break
+		}
 		var templateID string
 		var scopeSpaceID, status string
 		record := GrantRecord{}
@@ -342,6 +360,10 @@ func scanPrincipalGrants(
 			TemplateID: id, PrincipalType: principalType,
 			PrincipalID: principalID, ScopeSpaceID: scopeSpaceID,
 		}
+		if _, ok := seen[id]; !ok {
+			seen[id] = struct{}{}
+			order = append(order, id)
+		}
 		if scopeSpaceID == "" {
 			global[id] = record
 			continue
@@ -350,6 +372,15 @@ func scanPrincipalGrants(
 	}
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("card template catalog: iterate principal grants: %w", err)
+	}
+	if truncated && len(order) > 0 {
+		// Drop the template the cut landed in. Every earlier template is
+		// complete because the ordering keeps a template's rows contiguous, so
+		// this trades one advertised template for the guarantee that no
+		// remaining decision was made on a partial row set.
+		incomplete := order[len(order)-1]
+		delete(exact, incomplete)
+		delete(global, incomplete)
 	}
 
 	decisions := make(map[cardtmpl.ID]GrantDecision, len(exact)+len(global))

--- a/modules/card_template_catalog/store_authorization.go
+++ b/modules/card_template_catalog/store_authorization.go
@@ -49,7 +49,6 @@ const (
 	// selectPrincipalGrantsSQL lists a principal's grant rows across templates
 	// for the Bot advertised set. It is bounded by the caller and covers both
 	// scopes so the same precedence rule applies per template ID.
-	// selectPrincipalGrantsSQL lists a principal's grant rows across templates.
 	// The secondary sort key is not cosmetic: a template's exact and global rows
 	// must be adjacent and in a defined order so the row budget can be truncated
 	// at a template boundary rather than through the middle of a pair.
@@ -338,10 +337,6 @@ func scanPrincipalGrants(
 	scanned := 0
 	for rows.Next() {
 		scanned++
-		if scanned > rowLimit {
-			truncated = true
-			break
-		}
 		var templateID string
 		var scopeSpaceID, status string
 		record := GrantRecord{}
@@ -356,6 +351,16 @@ func scanPrincipalGrants(
 			return nil, fmt.Errorf("%w: invalid grant status %q", ErrCatalogIntegrity, status)
 		}
 		id := cardtmpl.ID(templateID)
+		if scanned > rowLimit {
+			// The peek row. Read its template ID before stopping: it is the only
+			// way to tell a cut that landed inside a template from one that
+			// landed cleanly on a boundary, and dropping a fully-read template
+			// because the *next* one was truncated loses a grant for nothing.
+			if len(order) > 0 && order[len(order)-1] == id {
+				truncated = true
+			}
+			break
+		}
 		record.Identity = GrantIdentity{
 			TemplateID: id, PrincipalType: principalType,
 			PrincipalID: principalID, ScopeSpaceID: scopeSpaceID,
@@ -374,10 +379,11 @@ func scanPrincipalGrants(
 		return nil, fmt.Errorf("card template catalog: iterate principal grants: %w", err)
 	}
 	if truncated && len(order) > 0 {
-		// Drop the template the cut landed in. Every earlier template is
-		// complete because the ordering keeps a template's rows contiguous, so
-		// this trades one advertised template for the guarantee that no
-		// remaining decision was made on a partial row set.
+		// The cut landed inside this template, so its row set is partial. Drop
+		// it: half a pair is worse than none, because losing an exact tombstone
+		// whose global row is still active reports a revoked principal as
+		// granted. Every earlier template is complete, since the ordering keeps
+		// a template's rows contiguous.
 		incomplete := order[len(order)-1]
 		delete(exact, incomplete)
 		delete(global, incomplete)

--- a/modules/card_template_catalog/store_authorization.go
+++ b/modules/card_template_catalog/store_authorization.go
@@ -138,6 +138,243 @@ func (s *store) LoadAuthorization(
 	return result, nil
 }
 
+// LoadAuthorizations answers the same question as LoadAuthorization for a whole
+// set of templates, from one snapshot and a bounded number of statements.
+//
+// It exists for the capability manifest, which asks about every ID in a static
+// policy list on every poll. One transaction per ID turned a feature-detection
+// read into N round trips, and a deployment whose Bots are user-created —
+// thousands of them — multiplies that into steady primary-DB load for an answer
+// that mostly has not changed.
+//
+// The semantics are LoadAuthorization's, deliberately and exactly: a template
+// with no activation row yields a zero Version (the caller keeps its static
+// behaviour), and a malformed activation or artifact is an error rather than a
+// silent omission. That last part is what separates this from
+// ListAuthorizedTemplates, which skips a broken template because one bad row
+// must not empty an entire listing; here a broken row must fail the manifest
+// closed, exactly as the per-ID loop did.
+func (s *store) LoadAuthorizations(
+	ctx context.Context,
+	ids []cardtmpl.ID,
+	principal cardtmpl.CatalogPrincipal,
+) (map[cardtmpl.ID]cardtmpl.RuntimeAuthorization, error) {
+	out := make(map[cardtmpl.ID]cardtmpl.RuntimeAuthorization, len(ids))
+	unique := make([]cardtmpl.ID, 0, len(ids))
+	seen := make(map[cardtmpl.ID]struct{}, len(ids))
+	for _, id := range ids {
+		if strings.TrimSpace(string(id)) == "" {
+			return nil, fmt.Errorf("%w: authorization query has no template", cardtmpl.ErrTemplateUnknown)
+		}
+		if _, done := seen[id]; done {
+			continue
+		}
+		seen[id] = struct{}{}
+		unique = append(unique, id)
+	}
+	if len(unique) == 0 {
+		return out, nil
+	}
+	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelRepeatableRead, ReadOnly: true})
+	if err != nil {
+		return nil, fmt.Errorf("card template catalog: begin batch authorization: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	pointers, err := scanActivationPointers(ctx, tx, unique)
+	if err != nil {
+		return nil, err
+	}
+	grants, err := scanScopedGrantDecisions(ctx, tx, unique, principal)
+	if err != nil {
+		return nil, err
+	}
+	for _, id := range unique {
+		result := cardtmpl.RuntimeAuthorization{Grant: grants[id]}
+		if pointer, ok := pointers[id]; ok {
+			version, err := cardtmpl.ActivationVersion(id, pointer.activation)
+			if err != nil {
+				return nil, err
+			}
+			result.Activation, result.Version = pointer.activation, version
+			if version != "" {
+				if version != pointer.version {
+					// The pointer moved between the two halves of one snapshot,
+					// which cannot happen inside REPEATABLE READ. Refuse rather
+					// than serve an artifact from a version nobody pointed at.
+					return nil, fmt.Errorf("%w: activation pointer disagrees with its joined artifact",
+						cardtmpl.ErrRuntimeCatalogIntegrity)
+				}
+				meta, err := buildRuntimeArtifactMeta(id, version, pointer.source, pointer.columns, pointer.blocked)
+				if err != nil {
+					return nil, err
+				}
+				result.Artifact = meta
+			}
+		}
+		out[id] = result
+	}
+	// Commit for the same reason the single read does: a connection-level
+	// failure must surface as an error, not as a truncated read that reads like
+	// a denial.
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("card template catalog: commit batch authorization: %w", err)
+	}
+	return out, nil
+}
+
+// activationPointer is one template's activation row joined to the artifact it
+// points at, as the batch read returns them together.
+type activationPointer struct {
+	activation cardtmpl.RuntimeActivation
+	version    string
+	source     string
+	columns    artifactMetaColumns
+	blocked    bool
+}
+
+// selectActivationPointersSQL is the batch form of the activation + artifact
+// reads. The join is LEFT so a disabled pointer (NULL active_version) still
+// produces its activation row: the caller has to distinguish "disabled" from
+// "no activation row at all", and an inner join would erase that difference.
+const selectActivationPointersSQL = `SELECT act.template_id, act.active_version, act.status, act.revision,
+        c.source, a.owner, a.visibility, a.engine_contract, a.protocol,
+        a.contract_version, a.content_sha256, a.blocked_at IS NOT NULL
+    FROM card_template_activation act
+    LEFT JOIN card_template_version_claim c
+      ON c.template_id = act.template_id AND c.version = act.active_version
+    LEFT JOIN card_template_artifact a
+      ON a.template_id = c.template_id AND a.version = c.version
+    WHERE act.template_id IN (`
+
+func scanActivationPointers(
+	ctx context.Context,
+	tx *sql.Tx,
+	ids []cardtmpl.ID,
+) (map[cardtmpl.ID]activationPointer, error) {
+	query, args := inListQuery(selectActivationPointersSQL, ids)
+	rows, err := tx.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("card template catalog: load activation pointers: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	out := make(map[cardtmpl.ID]activationPointer, len(ids))
+	for rows.Next() {
+		var templateID, status string
+		var activeVersion, source sql.NullString
+		var revision uint64
+		var columns artifactMetaColumns
+		var blocked bool
+		if err := rows.Scan(&templateID, &activeVersion, &status, &revision, &source,
+			&columns.owner, &columns.visibility, &columns.engine, &columns.protocol,
+			&columns.contractVersion, &columns.hash, &blocked); err != nil {
+			return nil, fmt.Errorf("card template catalog: scan activation pointer: %w", err)
+		}
+		activation, err := buildRuntimeActivation(activeVersion, status, revision)
+		if err != nil {
+			return nil, err
+		}
+		if activeVersion.Valid && activeVersion.String != "" && !source.Valid {
+			// An active pointer whose claim row is missing is the integrity
+			// failure scanRuntimeArtifactMeta reports as an unknown template.
+			return nil, fmt.Errorf("%w: %s@%s", cardtmpl.ErrTemplateUnknown, templateID, activeVersion.String)
+		}
+		out[cardtmpl.ID(templateID)] = activationPointer{
+			activation: activation, version: activeVersion.String,
+			source: source.String, columns: columns, blocked: blocked,
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("card template catalog: iterate activation pointers: %w", err)
+	}
+	return out, nil
+}
+
+// selectScopedGrantsSQL is loadGrantDecision's query widened to a set of
+// templates. It keeps both candidate scopes per template for the same reason
+// the single-template form does: an exact tombstone has to be able to shadow an
+// active global grant, and a "first match wins" query cannot express that.
+const selectScopedGrantsSQL = `SELECT template_id, scope_space_id, status,
+        can_discover, can_send, can_edit, revision
+    FROM card_template_grant
+    WHERE principal_type = ? AND principal_id = ? AND scope_space_id IN (?, '')
+      AND template_id IN (`
+
+func scanScopedGrantDecisions(
+	ctx context.Context,
+	tx *sql.Tx,
+	ids []cardtmpl.ID,
+	principal cardtmpl.CatalogPrincipal,
+) (map[cardtmpl.ID]cardtmpl.RuntimeGrant, error) {
+	out := make(map[cardtmpl.ID]cardtmpl.RuntimeGrant, len(ids))
+	principalType, principalID, grantable := grantPrincipal(principal)
+	if !grantable {
+		return out, nil
+	}
+	scope := strings.TrimSpace(principal.SpaceID)
+	query, idArgs := inListQuery(selectScopedGrantsSQL, ids)
+	args := append([]any{string(principalType), principalID, scope}, idArgs...)
+	rows, err := tx.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("card template catalog: load batch authorization grants: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	exact := make(map[cardtmpl.ID]GrantRecord, len(ids))
+	global := make(map[cardtmpl.ID]GrantRecord, len(ids))
+	for rows.Next() {
+		var templateID string
+		var record GrantRecord
+		var status string
+		if err := rows.Scan(&templateID, &record.Identity.ScopeSpaceID, &status,
+			&record.Permissions.Discover, &record.Permissions.Send, &record.Permissions.Edit,
+			&record.Revision); err != nil {
+			return nil, fmt.Errorf("card template catalog: scan batch authorization grant: %w", err)
+		}
+		record.Status = GrantStatus(status)
+		if record.Status != GrantStatusActive && record.Status != GrantStatusRevoked {
+			return nil, fmt.Errorf("%w: invalid grant status %q", ErrCatalogIntegrity, status)
+		}
+		id := cardtmpl.ID(templateID)
+		record.Identity.TemplateID = id
+		record.Identity.PrincipalType, record.Identity.PrincipalID = principalType, principalID
+		if record.Identity.ScopeSpaceID == "" {
+			global[id] = record
+			continue
+		}
+		if record.Identity.ScopeSpaceID != scope {
+			return nil, fmt.Errorf("%w: grant scope %q is outside the query",
+				ErrCatalogIntegrity, record.Identity.ScopeSpaceID)
+		}
+		exact[id] = record
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("card template catalog: iterate batch authorization grants: %w", err)
+	}
+	for _, id := range ids {
+		var exactRow, globalRow *GrantRecord
+		if record, ok := exact[id]; ok {
+			exactRow = &record
+		}
+		if record, ok := global[id]; ok {
+			globalRow = &record
+		}
+		out[id] = runtimeGrantFromDecision(resolveGrantRows(exactRow, globalRow))
+	}
+	return out, nil
+}
+
+// inListQuery closes an `... IN (` prefix with one placeholder per id.
+func inListQuery(prefix string, ids []cardtmpl.ID) (string, []any) {
+	placeholders := make([]string, 0, len(ids))
+	args := make([]any, 0, len(ids))
+	for _, id := range ids {
+		placeholders = append(placeholders, "?")
+		args = append(args, string(id))
+	}
+	return prefix + strings.Join(placeholders, ",") + ")", args
+}
+
 // loadGrantDecision reads both candidate rows and reduces them through the one
 // precedence implementation shared with the manager control plane.
 func loadGrantDecision(
@@ -254,16 +491,28 @@ func (s *store) ListAuthorizedTemplates(
 	if err != nil {
 		return nil, err
 	}
-	results := make([]cardtmpl.RuntimeAdvertisedTemplate, 0, len(decisions))
+	grants := make(map[cardtmpl.ID]cardtmpl.RuntimeGrant, len(decisions))
+	candidates := make([]cardtmpl.ID, 0, len(decisions))
 	for _, id := range sortedTemplateIDs(decisions) {
 		grant := runtimeGrantFromDecision(decisions[id])
 		if !grant.Discover && !grant.Send && !grant.Edit {
 			continue
 		}
-		authorization, ok, err := loadActiveAuthorization(ctx, tx, id, grant)
-		if err != nil {
-			return nil, err
-		}
+		grants[id] = grant
+		candidates = append(candidates, id)
+	}
+	// One statement for every candidate rather than two per candidate. The old
+	// loop held this REPEATABLE READ snapshot open across up to 129 round trips
+	// to assemble a manifest that a Bot polls for feature detection; with a
+	// fleet of Bots that is steady primary-DB load for an answer the fleet
+	// mostly already knows.
+	active, err := loadAdvertisableAuthorizations(ctx, tx, candidates, grants)
+	if err != nil {
+		return nil, err
+	}
+	results := make([]cardtmpl.RuntimeAdvertisedTemplate, 0, len(candidates))
+	for _, id := range candidates {
+		authorization, ok := active[id]
 		if !ok {
 			continue
 		}
@@ -278,36 +527,87 @@ func (s *store) ListAuthorizedTemplates(
 	return results, nil
 }
 
-// loadActiveAuthorization completes one listed template's snapshot. A pointer
-// that is absent, disabled or malformed yields ok=false: the template simply is
-// not advertisable right now, which is different from an error.
-func loadActiveAuthorization(
+// selectActiveAuthorizationsSQL resolves the active pointer and its artifact
+// for a bounded set of template IDs in one pass. The inner join on
+// active_version does the same filtering the per-template loop did by
+// discarding absent and disabled pointers: a disabled row has a NULL
+// active_version and joins to nothing, and a template with no activation row
+// simply does not appear.
+const selectActiveAuthorizationsSQL = `SELECT act.template_id, act.active_version, act.status, act.revision,
+        c.source, a.owner, a.visibility, a.engine_contract, a.protocol,
+        a.contract_version, a.content_sha256, a.blocked_at IS NOT NULL
+    FROM card_template_activation act
+    JOIN card_template_version_claim c
+      ON c.template_id = act.template_id AND c.version = act.active_version
+    LEFT JOIN card_template_artifact a
+      ON a.template_id = c.template_id AND a.version = c.version
+    WHERE act.template_id IN (`
+
+// loadActiveAuthorizations completes the snapshot for every candidate at once.
+// A pointer or artifact that is absent, disabled or malformed is omitted rather
+// than reported: the template simply is not advertisable right now, which is a
+// different thing from the read having failed. That is the same rule the
+// single-template path applies, so the two cannot drift.
+func loadAdvertisableAuthorizations(
 	ctx context.Context,
 	tx *sql.Tx,
-	id cardtmpl.ID,
-	grant cardtmpl.RuntimeGrant,
-) (cardtmpl.RuntimeAuthorization, bool, error) {
-	activation, err := scanRuntimeActivation(ctx, tx, id)
+	ids []cardtmpl.ID,
+	grants map[cardtmpl.ID]cardtmpl.RuntimeGrant,
+) (map[cardtmpl.ID]cardtmpl.RuntimeAuthorization, error) {
+	out := make(map[cardtmpl.ID]cardtmpl.RuntimeAuthorization, len(ids))
+	if len(ids) == 0 {
+		return out, nil
+	}
+	args := make([]any, 0, len(ids))
+	placeholders := make([]string, 0, len(ids))
+	for _, id := range ids {
+		placeholders = append(placeholders, "?")
+		args = append(args, string(id))
+	}
+	rows, err := tx.QueryContext(ctx, selectActiveAuthorizationsSQL+strings.Join(placeholders, ",")+")", args...)
 	if err != nil {
-		if errors.Is(err, cardtmpl.ErrRuntimeCatalogIntegrity) {
-			return cardtmpl.RuntimeAuthorization{}, false, nil
+		return nil, fmt.Errorf("card template catalog: load active authorizations: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		var templateID, status string
+		var version sql.NullString
+		var revision uint64
+		var source string
+		var columns artifactMetaColumns
+		var blocked bool
+		if err := rows.Scan(&templateID, &version, &status, &revision, &source,
+			&columns.owner, &columns.visibility, &columns.engine, &columns.protocol,
+			&columns.contractVersion, &columns.hash, &blocked); err != nil {
+			return nil, fmt.Errorf("card template catalog: scan active authorization: %w", err)
 		}
-		return cardtmpl.RuntimeAuthorization{}, false, err
-	}
-	version, err := cardtmpl.ActivationVersion(id, activation)
-	if err != nil || version == "" {
-		return cardtmpl.RuntimeAuthorization{}, false, nil
-	}
-	meta, err := scanRuntimeArtifactMeta(ctx, tx, id, version)
-	if err != nil {
-		if errors.Is(err, cardtmpl.ErrTemplateUnknown) || errors.Is(err, cardtmpl.ErrRuntimeCatalogIntegrity) {
-			return cardtmpl.RuntimeAuthorization{}, false, nil
+		id := cardtmpl.ID(templateID)
+		activation, err := buildRuntimeActivation(version, status, revision)
+		if err != nil {
+			if errors.Is(err, cardtmpl.ErrRuntimeCatalogIntegrity) {
+				continue
+			}
+			return nil, err
 		}
-		return cardtmpl.RuntimeAuthorization{}, false, err
+		activeVersion, err := cardtmpl.ActivationVersion(id, activation)
+		if err != nil || activeVersion == "" {
+			continue
+		}
+		meta, err := buildRuntimeArtifactMeta(id, activeVersion, source, columns, blocked)
+		if err != nil {
+			if errors.Is(err, cardtmpl.ErrTemplateUnknown) || errors.Is(err, cardtmpl.ErrRuntimeCatalogIntegrity) {
+				continue
+			}
+			return nil, err
+		}
+		out[id] = cardtmpl.RuntimeAuthorization{
+			Activation: activation, Version: activeVersion, Artifact: meta, Grant: grants[id],
+		}
 	}
-	return cardtmpl.RuntimeAuthorization{
-		Activation: activation, Version: version, Artifact: meta, Grant: grant,
-	}, true, nil
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("card template catalog: iterate active authorizations: %w", err)
+	}
+	return out, nil
 }
 
 func scanPrincipalGrants(

--- a/modules/card_template_catalog/store_authorization.go
+++ b/modules/card_template_catalog/store_authorization.go
@@ -77,6 +77,8 @@ func grantPrincipal(principal cardtmpl.CatalogPrincipal) (GrantPrincipalType, st
 		return GrantPrincipalBot, id, true
 	case cardtmpl.CatalogPrincipalInternalProducer:
 		return GrantPrincipalInternalProducer, id, true
+	case cardtmpl.CatalogPrincipalSpace:
+		return GrantPrincipalSpace, id, true
 	default:
 		return "", "", false
 	}

--- a/modules/card_template_catalog/store_authorization.go
+++ b/modules/card_template_catalog/store_authorization.go
@@ -147,13 +147,19 @@ func (s *store) LoadAuthorization(
 // thousands of them — multiplies that into steady primary-DB load for an answer
 // that mostly has not changed.
 //
-// The semantics are LoadAuthorization's, deliberately and exactly: a template
-// with no activation row yields a zero Version (the caller keeps its static
-// behaviour), and a malformed activation or artifact is an error rather than a
-// silent omission. That last part is what separates this from
+// The semantics are LoadAuthorization's, with one documented exception. A
+// template with no activation row yields a zero Version (the caller keeps its
+// static behaviour), and a malformed activation or artifact is an error rather
+// than a silent omission — that is what separates this from
 // ListAuthorizedTemplates, which skips a broken template because one bad row
-// must not empty an entire listing; here a broken row must fail the manifest
-// closed, exactly as the per-ID loop did.
+// must not empty an entire listing.
+//
+// The exception is a *disabled* pointer. The per-ID form returns
+// ErrRuntimeCatalogDisabled because an error is the only channel it has; here
+// that would fail every other template in the batch and push the caller back
+// onto one-ID-at-a-time reads for as long as an operator leaves one template
+// disabled. So it is reported as an entry whose Activation.Status is disabled,
+// and callers treat that as "not usable" — see RuntimeAuthorizationBatchStore.
 func (s *store) LoadAuthorizations(
 	ctx context.Context,
 	ids []cardtmpl.ID,
@@ -181,7 +187,7 @@ func (s *store) LoadAuthorizations(
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	pointers, err := scanActivationPointers(ctx, tx, unique)
+	pointers, err := scanActivationPointers(ctx, tx, unique, failOnBrokenRow)
 	if err != nil {
 		return nil, err
 	}
@@ -193,23 +199,28 @@ func (s *store) LoadAuthorizations(
 		result := cardtmpl.RuntimeAuthorization{Grant: grants[id]}
 		if pointer, ok := pointers[id]; ok {
 			version, err := cardtmpl.ActivationVersion(id, pointer.activation)
-			if err != nil {
+			switch {
+			case errors.Is(err, cardtmpl.ErrRuntimeCatalogDisabled):
+				// A disabled pointer is one template's deliberate operator
+				// state, and it must stay one template's problem. Propagating
+				// it would fail the whole batch, and the caller's only recourse
+				// is to re-ask per ID — which is exactly the N round trips this
+				// method exists to avoid, for as long as that template stays
+				// disabled. The activation is recorded as it stands; the caller
+				// reads Status and decides, the same way the per-ID path lets
+				// it decide from the returned error.
+				result.Activation = pointer.activation
+			case err != nil:
 				return nil, err
-			}
-			result.Activation, result.Version = pointer.activation, version
-			if version != "" {
-				if version != pointer.version {
-					// The pointer moved between the two halves of one snapshot,
-					// which cannot happen inside REPEATABLE READ. Refuse rather
-					// than serve an artifact from a version nobody pointed at.
-					return nil, fmt.Errorf("%w: activation pointer disagrees with its joined artifact",
-						cardtmpl.ErrRuntimeCatalogIntegrity)
+			default:
+				result.Activation, result.Version = pointer.activation, version
+				if version != "" {
+					meta, err := buildRuntimeArtifactMeta(id, version, pointer.source, pointer.columns, pointer.blocked)
+					if err != nil {
+						return nil, err
+					}
+					result.Artifact = meta
 				}
-				meta, err := buildRuntimeArtifactMeta(id, version, pointer.source, pointer.columns, pointer.blocked)
-				if err != nil {
-					return nil, err
-				}
-				result.Artifact = meta
 			}
 		}
 		out[id] = result
@@ -247,10 +258,24 @@ const selectActivationPointersSQL = `SELECT act.template_id, act.active_version,
       ON a.template_id = c.template_id AND a.version = c.version
     WHERE act.template_id IN (`
 
+// integrityPolicy decides what a structurally broken activation or claim row
+// means to the reader that hit it. The two readers genuinely disagree, and that
+// disagreement is the only reason they are not one call: an authorization read
+// must fail rather than answer from a row it could not parse, while the
+// advertised set drops that one template so a single bad row cannot blank a
+// Bot's entire capability manifest.
+type integrityPolicy int
+
+const (
+	failOnBrokenRow integrityPolicy = iota
+	skipBrokenRow
+)
+
 func scanActivationPointers(
 	ctx context.Context,
 	tx *sql.Tx,
 	ids []cardtmpl.ID,
+	policy integrityPolicy,
 ) (map[cardtmpl.ID]activationPointer, error) {
 	query, args := inListQuery(selectActivationPointersSQL, ids)
 	rows, err := tx.QueryContext(ctx, query, args...)
@@ -272,11 +297,17 @@ func scanActivationPointers(
 		}
 		activation, err := buildRuntimeActivation(activeVersion, status, revision)
 		if err != nil {
+			if policy == skipBrokenRow {
+				continue
+			}
 			return nil, err
 		}
 		if activeVersion.Valid && activeVersion.String != "" && !source.Valid {
 			// An active pointer whose claim row is missing is the integrity
 			// failure scanRuntimeArtifactMeta reports as an unknown template.
+			if policy == skipBrokenRow {
+				continue
+			}
 			return nil, fmt.Errorf("%w: %s@%s", cardtmpl.ErrTemplateUnknown, templateID, activeVersion.String)
 		}
 		out[cardtmpl.ID(templateID)] = activationPointer{
@@ -527,27 +558,11 @@ func (s *store) ListAuthorizedTemplates(
 	return results, nil
 }
 
-// selectActiveAuthorizationsSQL resolves the active pointer and its artifact
-// for a bounded set of template IDs in one pass. The inner join on
-// active_version does the same filtering the per-template loop did by
-// discarding absent and disabled pointers: a disabled row has a NULL
-// active_version and joins to nothing, and a template with no activation row
-// simply does not appear.
-const selectActiveAuthorizationsSQL = `SELECT act.template_id, act.active_version, act.status, act.revision,
-        c.source, a.owner, a.visibility, a.engine_contract, a.protocol,
-        a.contract_version, a.content_sha256, a.blocked_at IS NOT NULL
-    FROM card_template_activation act
-    JOIN card_template_version_claim c
-      ON c.template_id = act.template_id AND c.version = act.active_version
-    LEFT JOIN card_template_artifact a
-      ON a.template_id = c.template_id AND a.version = c.version
-    WHERE act.template_id IN (`
-
-// loadActiveAuthorizations completes the snapshot for every candidate at once.
-// A pointer or artifact that is absent, disabled or malformed is omitted rather
-// than reported: the template simply is not advertisable right now, which is a
-// different thing from the read having failed. That is the same rule the
-// single-template path applies, so the two cannot drift.
+// loadAdvertisableAuthorizations keeps only the candidates that are advertisable
+// right now. It shares the batch read and the shape validation with
+// LoadAuthorizations and differs only in policy: a pointer that is absent,
+// disabled or structurally broken drops that one template instead of failing
+// the listing.
 func loadAdvertisableAuthorizations(
 	ctx context.Context,
 	tx *sql.Tx,
@@ -558,42 +573,16 @@ func loadAdvertisableAuthorizations(
 	if len(ids) == 0 {
 		return out, nil
 	}
-	args := make([]any, 0, len(ids))
-	placeholders := make([]string, 0, len(ids))
-	for _, id := range ids {
-		placeholders = append(placeholders, "?")
-		args = append(args, string(id))
-	}
-	rows, err := tx.QueryContext(ctx, selectActiveAuthorizationsSQL+strings.Join(placeholders, ",")+")", args...)
+	pointers, err := scanActivationPointers(ctx, tx, ids, skipBrokenRow)
 	if err != nil {
-		return nil, fmt.Errorf("card template catalog: load active authorizations: %w", err)
+		return nil, err
 	}
-	defer func() { _ = rows.Close() }()
-	for rows.Next() {
-		var templateID, status string
-		var version sql.NullString
-		var revision uint64
-		var source string
-		var columns artifactMetaColumns
-		var blocked bool
-		if err := rows.Scan(&templateID, &version, &status, &revision, &source,
-			&columns.owner, &columns.visibility, &columns.engine, &columns.protocol,
-			&columns.contractVersion, &columns.hash, &blocked); err != nil {
-			return nil, fmt.Errorf("card template catalog: scan active authorization: %w", err)
-		}
-		id := cardtmpl.ID(templateID)
-		activation, err := buildRuntimeActivation(version, status, revision)
-		if err != nil {
-			if errors.Is(err, cardtmpl.ErrRuntimeCatalogIntegrity) {
-				continue
-			}
-			return nil, err
-		}
-		activeVersion, err := cardtmpl.ActivationVersion(id, activation)
-		if err != nil || activeVersion == "" {
+	for id, pointer := range pointers {
+		version, err := cardtmpl.ActivationVersion(id, pointer.activation)
+		if err != nil || version == "" {
 			continue
 		}
-		meta, err := buildRuntimeArtifactMeta(id, activeVersion, source, columns, blocked)
+		meta, err := buildRuntimeArtifactMeta(id, version, pointer.source, pointer.columns, pointer.blocked)
 		if err != nil {
 			if errors.Is(err, cardtmpl.ErrTemplateUnknown) || errors.Is(err, cardtmpl.ErrRuntimeCatalogIntegrity) {
 				continue
@@ -601,11 +590,8 @@ func loadAdvertisableAuthorizations(
 			return nil, err
 		}
 		out[id] = cardtmpl.RuntimeAuthorization{
-			Activation: activation, Version: activeVersion, Artifact: meta, Grant: grants[id],
+			Activation: pointer.activation, Version: version, Artifact: meta, Grant: grants[id],
 		}
-	}
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("card template catalog: iterate active authorizations: %w", err)
 	}
 	return out, nil
 }

--- a/modules/card_template_catalog/store_authorization.go
+++ b/modules/card_template_catalog/store_authorization.go
@@ -1,0 +1,379 @@
+package card_template_catalog
+
+// PR-C D4 — the one-snapshot authorization resolver.
+//
+// Everything one dynamic authorization decision depends on is read here, in a
+// single REPEATABLE READ transaction against the primary: the activation
+// pointer, the claim/artifact/block row for the version that pointer resolves
+// to, and the principal's exact + global grant rows. InnoDB gives that
+// transaction one consistent snapshot, so an activate, block or revoke that
+// commits while the transaction is open cannot show up in half of the answer.
+//
+// The transaction is the linearization point. A request whose snapshot began
+// before a revoke committed is allowed to finish; a request whose snapshot
+// begins after it must see the tombstone and be denied. There is no third
+// outcome, and in particular there is no "read the pointer now, check the
+// grant later" path left in the codebase for one to leak back through.
+//
+// Nothing here is cached. Grant truth lives only in MySQL (D4: no Redis, no
+// local grant cache in v1); the compiled-artifact cache upstream keys on the
+// immutable content hash and therefore holds no activation, block or grant
+// state at all.
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl"
+)
+
+// Compile-time proof that the production store really is the indivisible
+// resolver. If this ever stops holding, RuntimeCatalog silently degrades to
+// the grant-unaware split-read path and every dynamic business access starts
+// failing closed — loud in tests, but this assertion catches it at build time.
+var _ cardtmpl.RuntimeAuthorizationStore = (*store)(nil)
+
+const (
+	// selectAuthorizationGrantsSQL fetches at most the two rows that can decide
+	// one principal's access: the row scoped to this Space and the global row.
+	// Both are needed because an exact tombstone must be able to shadow an
+	// active global grant, which a "first match wins" query could not express.
+	selectAuthorizationGrantsSQL = `SELECT scope_space_id, status, can_discover, can_send, can_edit, revision
+        FROM card_template_grant
+        WHERE template_id = ? AND principal_type = ? AND principal_id = ?
+          AND scope_space_id IN (?, '')`
+	// selectPrincipalGrantsSQL lists a principal's grant rows across templates
+	// for the Bot advertised set. It is bounded by the caller and covers both
+	// scopes so the same precedence rule applies per template ID.
+	selectPrincipalGrantsSQL = `SELECT template_id, scope_space_id, status,
+            can_discover, can_send, can_edit, revision
+        FROM card_template_grant
+        WHERE principal_type = ? AND principal_id = ?
+          AND scope_space_id IN (?, '')
+        ORDER BY template_id ASC
+        LIMIT ?`
+)
+
+// maxAuthorizedTemplates bounds the per-principal advertised set. A Bot with
+// more granted templates than this is a control-plane problem, not something
+// to silently paginate inside a capability manifest.
+const maxAuthorizedTemplates = 64
+
+// grantPrincipal maps a runtime principal onto the grant table's identity
+// space. `system` and blank identities are not grantable business principals
+// (D2), so they resolve to no lookup at all rather than to an empty-string
+// principal that could accidentally match a row.
+func grantPrincipal(principal cardtmpl.CatalogPrincipal) (GrantPrincipalType, string, bool) {
+	id := strings.TrimSpace(principal.ID)
+	if id == "" {
+		return "", "", false
+	}
+	switch principal.Kind {
+	case cardtmpl.CatalogPrincipalBot:
+		return GrantPrincipalBot, id, true
+	case cardtmpl.CatalogPrincipalInternalProducer:
+		return GrantPrincipalInternalProducer, id, true
+	default:
+		return "", "", false
+	}
+}
+
+// LoadAuthorization answers one query from one snapshot.
+func (s *store) LoadAuthorization(
+	ctx context.Context,
+	query cardtmpl.RuntimeAuthorizationQuery,
+) (cardtmpl.RuntimeAuthorization, error) {
+	if strings.TrimSpace(string(query.ID)) == "" {
+		return cardtmpl.RuntimeAuthorization{},
+			fmt.Errorf("%w: authorization query has no template", cardtmpl.ErrTemplateUnknown)
+	}
+	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelRepeatableRead, ReadOnly: true})
+	if err != nil {
+		return cardtmpl.RuntimeAuthorization{}, fmt.Errorf("card template catalog: begin authorization: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	result := cardtmpl.RuntimeAuthorization{Version: query.Version}
+	if query.Version == "" {
+		activation, err := scanRuntimeActivation(ctx, tx, query.ID)
+		if err != nil {
+			return cardtmpl.RuntimeAuthorization{}, err
+		}
+		version, err := cardtmpl.ActivationVersion(query.ID, activation)
+		if err != nil {
+			return cardtmpl.RuntimeAuthorization{}, err
+		}
+		result.Activation, result.Version = activation, version
+	}
+	if result.Version != "" {
+		meta, err := scanRuntimeArtifactMeta(ctx, tx, query.ID, result.Version)
+		if err != nil {
+			return cardtmpl.RuntimeAuthorization{}, err
+		}
+		result.Artifact = meta
+	}
+	grant, err := loadGrantDecision(ctx, tx, query.ID, query.Principal)
+	if err != nil {
+		return cardtmpl.RuntimeAuthorization{}, err
+	}
+	result.Grant = grant
+
+	// Commit a read-only transaction rather than relying on the deferred
+	// rollback: it releases the snapshot deterministically and turns a
+	// connection-level failure into an error instead of a silently truncated
+	// read that would look like "no grant" — a denial we could not distinguish
+	// from a real one.
+	if err := tx.Commit(); err != nil {
+		return cardtmpl.RuntimeAuthorization{}, fmt.Errorf("card template catalog: commit authorization: %w", err)
+	}
+	return result, nil
+}
+
+// loadGrantDecision reads both candidate rows and reduces them through the one
+// precedence implementation shared with the manager control plane.
+func loadGrantDecision(
+	ctx context.Context,
+	tx *sql.Tx,
+	id cardtmpl.ID,
+	principal cardtmpl.CatalogPrincipal,
+) (cardtmpl.RuntimeGrant, error) {
+	principalType, principalID, grantable := grantPrincipal(principal)
+	if !grantable {
+		return cardtmpl.RuntimeGrant{}, nil
+	}
+	scope := strings.TrimSpace(principal.SpaceID)
+	rows, err := tx.QueryContext(ctx, selectAuthorizationGrantsSQL,
+		string(id), string(principalType), principalID, scope)
+	if err != nil {
+		return cardtmpl.RuntimeGrant{}, fmt.Errorf("card template catalog: load authorization grants: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var exact, global *GrantRecord
+	for rows.Next() {
+		record, err := scanGrantScopeRow(rows, id, principalType, principalID)
+		if err != nil {
+			return cardtmpl.RuntimeGrant{}, err
+		}
+		// A blank scope is the canonical global sentinel. When the principal
+		// itself carries no Space, the IN list collapses and the single row
+		// returned is the global one — never an "exact" match on emptiness.
+		if record.Identity.ScopeSpaceID == "" {
+			global = &record
+			continue
+		}
+		if record.Identity.ScopeSpaceID != scope {
+			return cardtmpl.RuntimeGrant{}, fmt.Errorf("%w: grant scope %q is outside the query",
+				ErrCatalogIntegrity, record.Identity.ScopeSpaceID)
+		}
+		exact = &record
+	}
+	if err := rows.Err(); err != nil {
+		return cardtmpl.RuntimeGrant{}, fmt.Errorf("card template catalog: iterate authorization grants: %w", err)
+	}
+	return runtimeGrantFromDecision(resolveGrantRows(exact, global)), nil
+}
+
+func runtimeGrantFromDecision(decision GrantDecision) cardtmpl.RuntimeGrant {
+	if decision.ScopeSource == "" {
+		return cardtmpl.RuntimeGrant{}
+	}
+	return cardtmpl.RuntimeGrant{
+		Found:    true,
+		Scope:    cardtmpl.RuntimeGrantScope(decision.ScopeSource),
+		Revision: decision.Revision,
+		Discover: decision.Allowed.Discover,
+		Send:     decision.Allowed.Send,
+		Edit:     decision.Allowed.Edit,
+	}
+}
+
+func scanGrantScopeRow(
+	rows *sql.Rows,
+	id cardtmpl.ID,
+	principalType GrantPrincipalType,
+	principalID string,
+) (GrantRecord, error) {
+	record := GrantRecord{Identity: GrantIdentity{
+		TemplateID: id, PrincipalType: principalType, PrincipalID: principalID,
+	}}
+	var status string
+	if err := rows.Scan(&record.Identity.ScopeSpaceID, &status,
+		&record.Permissions.Discover, &record.Permissions.Send, &record.Permissions.Edit,
+		&record.Revision,
+	); err != nil {
+		return GrantRecord{}, fmt.Errorf("card template catalog: scan authorization grant: %w", err)
+	}
+	record.Status = GrantStatus(status)
+	if record.Status != GrantStatusActive && record.Status != GrantStatusRevoked {
+		return GrantRecord{}, fmt.Errorf("%w: invalid grant status %q", ErrCatalogIntegrity, status)
+	}
+	return record, nil
+}
+
+// ListAuthorizedTemplates returns every template ID the principal holds an
+// effective grant on, together with that template's activation and artifact
+// state — all from one snapshot, for the same reason LoadAuthorization uses
+// one. Templates whose pointer is absent, disabled or integrity-broken are
+// skipped rather than failing the whole listing: one bad template must not
+// take a Bot's entire capability manifest down with it.
+//
+// Purpose filtering is deliberately left to the caller. This returns the
+// snapshot; deciding what `send` or `edit` means for it stays with the single
+// authorizer, so the permission rule is never re-implemented here.
+func (s *store) ListAuthorizedTemplates(
+	ctx context.Context,
+	principal cardtmpl.CatalogPrincipal,
+	limit int,
+) ([]cardtmpl.RuntimeAdvertisedTemplate, error) {
+	principalType, principalID, grantable := grantPrincipal(principal)
+	if !grantable {
+		return nil, nil
+	}
+	if limit < 1 || limit > maxAuthorizedTemplates {
+		limit = maxAuthorizedTemplates
+	}
+	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelRepeatableRead, ReadOnly: true})
+	if err != nil {
+		return nil, fmt.Errorf("card template catalog: begin authorized templates: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	scope := strings.TrimSpace(principal.SpaceID)
+	// Two scopes per template, so read twice the row budget before reducing.
+	decisions, err := scanPrincipalGrants(ctx, tx, principalType, principalID, scope, limit*2)
+	if err != nil {
+		return nil, err
+	}
+	results := make([]cardtmpl.RuntimeAdvertisedTemplate, 0, len(decisions))
+	for _, id := range sortedTemplateIDs(decisions) {
+		grant := runtimeGrantFromDecision(decisions[id])
+		if !grant.Discover && !grant.Send && !grant.Edit {
+			continue
+		}
+		authorization, ok, err := loadActiveAuthorization(ctx, tx, id, grant)
+		if err != nil {
+			return nil, err
+		}
+		if !ok {
+			continue
+		}
+		results = append(results, cardtmpl.RuntimeAdvertisedTemplate{ID: id, Authorization: authorization})
+		if len(results) == limit {
+			break
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("card template catalog: commit authorized templates: %w", err)
+	}
+	return results, nil
+}
+
+// loadActiveAuthorization completes one listed template's snapshot. A pointer
+// that is absent, disabled or malformed yields ok=false: the template simply is
+// not advertisable right now, which is different from an error.
+func loadActiveAuthorization(
+	ctx context.Context,
+	tx *sql.Tx,
+	id cardtmpl.ID,
+	grant cardtmpl.RuntimeGrant,
+) (cardtmpl.RuntimeAuthorization, bool, error) {
+	activation, err := scanRuntimeActivation(ctx, tx, id)
+	if err != nil {
+		if errors.Is(err, cardtmpl.ErrRuntimeCatalogIntegrity) {
+			return cardtmpl.RuntimeAuthorization{}, false, nil
+		}
+		return cardtmpl.RuntimeAuthorization{}, false, err
+	}
+	version, err := cardtmpl.ActivationVersion(id, activation)
+	if err != nil || version == "" {
+		return cardtmpl.RuntimeAuthorization{}, false, nil
+	}
+	meta, err := scanRuntimeArtifactMeta(ctx, tx, id, version)
+	if err != nil {
+		if errors.Is(err, cardtmpl.ErrTemplateUnknown) || errors.Is(err, cardtmpl.ErrRuntimeCatalogIntegrity) {
+			return cardtmpl.RuntimeAuthorization{}, false, nil
+		}
+		return cardtmpl.RuntimeAuthorization{}, false, err
+	}
+	return cardtmpl.RuntimeAuthorization{
+		Activation: activation, Version: version, Artifact: meta, Grant: grant,
+	}, true, nil
+}
+
+func scanPrincipalGrants(
+	ctx context.Context,
+	tx *sql.Tx,
+	principalType GrantPrincipalType,
+	principalID, scope string,
+	rowLimit int,
+) (map[cardtmpl.ID]GrantDecision, error) {
+	rows, err := tx.QueryContext(ctx, selectPrincipalGrantsSQL,
+		string(principalType), principalID, scope, rowLimit)
+	if err != nil {
+		return nil, fmt.Errorf("card template catalog: list principal grants: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	exact := make(map[cardtmpl.ID]GrantRecord)
+	global := make(map[cardtmpl.ID]GrantRecord)
+	for rows.Next() {
+		var templateID string
+		var scopeSpaceID, status string
+		record := GrantRecord{}
+		if err := rows.Scan(&templateID, &scopeSpaceID, &status,
+			&record.Permissions.Discover, &record.Permissions.Send, &record.Permissions.Edit,
+			&record.Revision,
+		); err != nil {
+			return nil, fmt.Errorf("card template catalog: scan principal grant: %w", err)
+		}
+		record.Status = GrantStatus(status)
+		if record.Status != GrantStatusActive && record.Status != GrantStatusRevoked {
+			return nil, fmt.Errorf("%w: invalid grant status %q", ErrCatalogIntegrity, status)
+		}
+		id := cardtmpl.ID(templateID)
+		record.Identity = GrantIdentity{
+			TemplateID: id, PrincipalType: principalType,
+			PrincipalID: principalID, ScopeSpaceID: scopeSpaceID,
+		}
+		if scopeSpaceID == "" {
+			global[id] = record
+			continue
+		}
+		exact[id] = record
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("card template catalog: iterate principal grants: %w", err)
+	}
+
+	decisions := make(map[cardtmpl.ID]GrantDecision, len(exact)+len(global))
+	for id := range exact {
+		record := exact[id]
+		var globalRow *GrantRecord
+		if row, ok := global[id]; ok {
+			globalRow = &row
+		}
+		decisions[id] = resolveGrantRows(&record, globalRow)
+	}
+	for id := range global {
+		if _, resolved := decisions[id]; resolved {
+			continue
+		}
+		record := global[id]
+		decisions[id] = resolveGrantRows(nil, &record)
+	}
+	return decisions, nil
+}
+
+func sortedTemplateIDs(decisions map[cardtmpl.ID]GrantDecision) []cardtmpl.ID {
+	ids := make([]cardtmpl.ID, 0, len(decisions))
+	for id := range decisions {
+		ids = append(ids, id)
+	}
+	sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
+	return ids
+}

--- a/modules/card_template_catalog/store_authorization_mysql_integration_test.go
+++ b/modules/card_template_catalog/store_authorization_mysql_integration_test.go
@@ -244,3 +244,58 @@ func TestStoreLoadAuthorizationReportsBlockAndUnknownFromTheSnapshotRealMySQL(t 
 		t.Fatalf("unknown pinned version error = %v, want ErrTemplateUnknown", err)
 	}
 }
+
+// runtimeAuthorizationSource is the seam every consumer outside this module
+// reads grants through — the Bot capability manifest chiefly. Two things about
+// it are load-bearing and neither is visible from the store alone: it must
+// answer from the same store the runtime resolves against (a second reader
+// would be a second grant truth), and NewSendEnabled must come from the
+// deployment gate rather than from the data, so a dark deployment answers
+// "no new-send" without acquiring the DB dependency it did not have before
+// PR-C.
+func TestRuntimeAuthorizationSourceReadsTheStoreAndTheGateRealMySQL(t *testing.T) {
+	db := newCatalogStoreIntegrationDB(t)
+	seedAuthorizationTarget(t, db, "1.0.0")
+	catalogStore := newStore(db)
+	identity := authorizationIntegrationIdentity()
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	if _, err := catalogStore.UpsertGrant(ctx, UpsertGrantRequest{
+		Identity: identity, Permissions: GrantPermissions{Discover: true, Send: true},
+		ActorUID: "admin-1", Reason: "pilot", ChangeTicket: "CHG-A4",
+	}); err != nil {
+		t.Fatalf("seed grant: %v", err)
+	}
+
+	dark := &runtimeAuthorizationSource{store: catalogStore, gates: runtimeCatalogGates{}}
+	if dark.NewSendEnabled() {
+		t.Fatal("a gated-off deployment reported new-send as enabled")
+	}
+	live := &runtimeAuthorizationSource{
+		store: catalogStore,
+		gates: runtimeCatalogGates{controlEnabled: true, newSendEnabled: true},
+	}
+	if !live.NewSendEnabled() {
+		t.Fatal("an enabled deployment reported new-send as dark")
+	}
+
+	// The grant the source reports must be the grant the store holds, down to
+	// the permission bits — this is the read the capability manifest trusts.
+	auth, err := live.LoadAuthorization(ctx, cardtmpl.RuntimeAuthorizationQuery{
+		ID: authorizationIntegrationTemplateID, Principal: authorizationIntegrationPrincipal(),
+	})
+	if err != nil {
+		t.Fatalf("source LoadAuthorization: %v", err)
+	}
+	if !auth.Grant.Found || !auth.Grant.Send {
+		t.Fatalf("source grant = %+v", auth.Grant)
+	}
+
+	advertised, err := live.ListAuthorizedTemplates(ctx, authorizationIntegrationPrincipal(), 10)
+	if err != nil {
+		t.Fatalf("source ListAuthorizedTemplates: %v", err)
+	}
+	if len(advertised) != 1 || advertised[0].ID != authorizationIntegrationTemplateID {
+		t.Fatalf("source advertised %+v", advertised)
+	}
+}

--- a/modules/card_template_catalog/store_authorization_mysql_integration_test.go
+++ b/modules/card_template_catalog/store_authorization_mysql_integration_test.go
@@ -1,0 +1,246 @@
+package card_template_catalog
+
+// PR-C D4 real-MySQL evidence for the authorization linearization point.
+//
+// The property under test is not "a revoked grant is denied" — that is obvious
+// from the rows. It is *when* the denial takes effect: a snapshot opened before
+// the revoke commits keeps its answer for its whole lifetime, and a snapshot
+// opened afterwards can never see the pre-revoke state. sqlmock cannot express
+// that; only a real InnoDB REPEATABLE READ transaction can.
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl"
+)
+
+const authorizationIntegrationTemplateID = cardtmpl.ID("test.authorization-target")
+
+func seedAuthorizationTarget(t *testing.T, db *sql.DB, version string) {
+	t.Helper()
+	if _, err := db.Exec(`INSERT INTO card_template_version_claim
+        (template_id, version, source) VALUES (?, ?, 'dynamic')`,
+		string(authorizationIntegrationTemplateID), version); err != nil {
+		t.Fatalf("seed authorization claim: %v", err)
+	}
+	if _, err := db.Exec(`INSERT INTO card_template_artifact
+        (template_id, version, owner, visibility, engine_contract, protocol,
+         contract_version, canonical_bundle, content_sha256, created_by)
+        VALUES (?, ?, 'docs', ?, ?, ?, '1.0.0', ?, ?, 'admin-1')`,
+		string(authorizationIntegrationTemplateID), version,
+		cardtmpl.CatalogVisibilityPrivate, cardtmpl.JSONTemplateEngineV1, cardtmpl.Protocol,
+		`{"canonical":true}`, strings.Repeat("a", 64)); err != nil {
+		t.Fatalf("seed authorization artifact: %v", err)
+	}
+	if _, err := db.Exec(`INSERT INTO card_template_activation
+        (template_id, active_version, status, revision, updated_by, reason, change_ticket)
+        VALUES (?, ?, 'active', 1, 'admin-1', 'pilot', 'CHG-A1')`,
+		string(authorizationIntegrationTemplateID), version); err != nil {
+		t.Fatalf("seed authorization activation: %v", err)
+	}
+}
+
+func authorizationIntegrationIdentity() GrantIdentity {
+	return GrantIdentity{
+		TemplateID:    authorizationIntegrationTemplateID,
+		PrincipalType: GrantPrincipalBot,
+		PrincipalID:   "bot-authorization",
+		ScopeSpaceID:  "space-authorization",
+	}
+}
+
+func authorizationIntegrationPrincipal() cardtmpl.CatalogPrincipal {
+	return cardtmpl.CatalogPrincipal{
+		Kind:    cardtmpl.CatalogPrincipalBot,
+		ID:      authorizationIntegrationIdentity().PrincipalID,
+		SpaceID: authorizationIntegrationIdentity().ScopeSpaceID,
+	}
+}
+
+func TestStoreLoadAuthorizationSnapshotIsTheLinearizationPointRealMySQL(t *testing.T) {
+	db := newCatalogStoreIntegrationDB(t)
+	seedAuthorizationTarget(t, db, "1.0.0")
+	catalogStore := newStore(db)
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	identity := authorizationIntegrationIdentity()
+	query := cardtmpl.RuntimeAuthorizationQuery{
+		ID: authorizationIntegrationTemplateID, Principal: authorizationIntegrationPrincipal(),
+	}
+
+	// Ungranted: the pointer and artifact resolve, but nothing is allowed.
+	auth, err := catalogStore.LoadAuthorization(ctx, query)
+	if err != nil {
+		t.Fatalf("ungranted LoadAuthorization: %v", err)
+	}
+	if auth.Version != "1.0.0" || auth.Artifact.Owner != "docs" || auth.Grant.Found {
+		t.Fatalf("ungranted authorization = %+v", auth)
+	}
+
+	if _, err := catalogStore.UpsertGrant(ctx, UpsertGrantRequest{
+		Identity: identity, Permissions: GrantPermissions{Discover: true, Send: true},
+		ActorUID: "admin-1", Reason: "pilot", ChangeTicket: "CHG-A2",
+	}); err != nil {
+		t.Fatalf("grant send: %v", err)
+	}
+	auth, err = catalogStore.LoadAuthorization(ctx, query)
+	if err != nil {
+		t.Fatalf("granted LoadAuthorization: %v", err)
+	}
+	if !auth.Grant.Allows(cardtmpl.CatalogPurposeNewSend) ||
+		auth.Grant.Scope != cardtmpl.RuntimeGrantScopeExact || auth.Grant.Revision != 1 {
+		t.Fatalf("granted authorization grant = %+v", auth.Grant)
+	}
+	if auth.Grant.Allows(cardtmpl.CatalogPurposeHistoricalEdit) {
+		t.Fatal("a send grant leaked edit permission")
+	}
+
+	// Hold a snapshot open, revoke from another connection, and confirm the
+	// open snapshot is unaffected while a fresh one is already denied. This is
+	// the whole contract: in-flight requests finish, new ones see the revoke.
+	held, err := db.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelRepeatableRead, ReadOnly: true})
+	if err != nil {
+		t.Fatalf("open held snapshot: %v", err)
+	}
+	defer func() { _ = held.Rollback() }()
+	beforeRevoke, err := loadGrantDecision(ctx, held, authorizationIntegrationTemplateID,
+		authorizationIntegrationPrincipal())
+	if err != nil {
+		t.Fatalf("held snapshot first read: %v", err)
+	}
+	if !beforeRevoke.Send {
+		t.Fatalf("held snapshot first read = %+v, want send", beforeRevoke)
+	}
+
+	if _, err := catalogStore.RevokeGrant(ctx, RevokeGrantRequest{
+		Identity: identity, ExpectedRevision: 1,
+		ActorUID: "admin-1", Reason: "offboard", ChangeTicket: "CHG-A3",
+	}); err != nil {
+		t.Fatalf("revoke grant: %v", err)
+	}
+
+	stillHeld, err := loadGrantDecision(ctx, held, authorizationIntegrationTemplateID,
+		authorizationIntegrationPrincipal())
+	if err != nil {
+		t.Fatalf("held snapshot second read: %v", err)
+	}
+	if stillHeld != beforeRevoke {
+		t.Fatalf("held snapshot changed under a concurrent revoke: %+v -> %+v", beforeRevoke, stillHeld)
+	}
+
+	afterRevoke, err := catalogStore.LoadAuthorization(ctx, query)
+	if err != nil {
+		t.Fatalf("post-revoke LoadAuthorization: %v", err)
+	}
+	if afterRevoke.Grant.Allows(cardtmpl.CatalogPurposeNewSend) {
+		t.Fatalf("post-revoke grant still allows send: %+v", afterRevoke.Grant)
+	}
+	if !afterRevoke.Grant.Found || afterRevoke.Grant.Revision != 2 {
+		t.Fatalf("post-revoke grant = %+v, want the tombstone at revision 2", afterRevoke.Grant)
+	}
+}
+
+// An exact tombstone must shadow an active global grant against real rows and
+// real collations, not only in the reducer's unit test.
+func TestStoreLoadAuthorizationExactTombstoneShadowsGlobalRealMySQL(t *testing.T) {
+	db := newCatalogStoreIntegrationDB(t)
+	seedAuthorizationTarget(t, db, "1.0.0")
+	catalogStore := newStore(db)
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	global := authorizationIntegrationIdentity()
+	global.ScopeSpaceID = ""
+	if _, err := catalogStore.UpsertGrant(ctx, UpsertGrantRequest{
+		Identity: global, Permissions: GrantPermissions{Discover: true, Send: true, Edit: true},
+		ActorUID: "admin-1", Reason: "fleet-wide", ChangeTicket: "CHG-G1",
+	}); err != nil {
+		t.Fatalf("global grant: %v", err)
+	}
+	query := cardtmpl.RuntimeAuthorizationQuery{
+		ID: authorizationIntegrationTemplateID, Principal: authorizationIntegrationPrincipal(),
+	}
+	auth, err := catalogStore.LoadAuthorization(ctx, query)
+	if err != nil {
+		t.Fatalf("global-only LoadAuthorization: %v", err)
+	}
+	if auth.Grant.Scope != cardtmpl.RuntimeGrantScopeGlobal || !auth.Grant.Send {
+		t.Fatalf("global-only grant = %+v", auth.Grant)
+	}
+
+	exact := authorizationIntegrationIdentity()
+	if _, err := catalogStore.UpsertGrant(ctx, UpsertGrantRequest{
+		Identity: exact, Permissions: GrantPermissions{Discover: true},
+		ActorUID: "admin-1", Reason: "narrow this space", ChangeTicket: "CHG-G2",
+	}); err != nil {
+		t.Fatalf("exact grant: %v", err)
+	}
+	if _, err := catalogStore.RevokeGrant(ctx, RevokeGrantRequest{
+		Identity: exact, ExpectedRevision: 1,
+		ActorUID: "admin-1", Reason: "block this space", ChangeTicket: "CHG-G3",
+	}); err != nil {
+		t.Fatalf("exact revoke: %v", err)
+	}
+
+	auth, err = catalogStore.LoadAuthorization(ctx, query)
+	if err != nil {
+		t.Fatalf("shadowed LoadAuthorization: %v", err)
+	}
+	// The global row is still active and still grants send/edit. It must not
+	// be reachable: permissions are never unioned across scopes.
+	if auth.Grant.Scope != cardtmpl.RuntimeGrantScopeExact ||
+		auth.Grant.Discover || auth.Grant.Send || auth.Grant.Edit {
+		t.Fatalf("shadowed grant = %+v, want the exact tombstone to win", auth.Grant)
+	}
+
+	// A principal in a different Space still falls through to the global row:
+	// the tombstone shadows one Space, not the whole grant.
+	elsewhere := authorizationIntegrationPrincipal()
+	elsewhere.SpaceID = "space-elsewhere"
+	auth, err = catalogStore.LoadAuthorization(ctx, cardtmpl.RuntimeAuthorizationQuery{
+		ID: authorizationIntegrationTemplateID, Principal: elsewhere,
+	})
+	if err != nil {
+		t.Fatalf("other-space LoadAuthorization: %v", err)
+	}
+	if auth.Grant.Scope != cardtmpl.RuntimeGrantScopeGlobal || !auth.Grant.Send {
+		t.Fatalf("other-space grant = %+v, want the global row", auth.Grant)
+	}
+}
+
+// A blocked artifact and a missing claim are both reported through the
+// snapshot rather than by a second read, so the authorizer upstream can fail
+// closed on the same data it authorized against.
+func TestStoreLoadAuthorizationReportsBlockAndUnknownFromTheSnapshotRealMySQL(t *testing.T) {
+	db := newCatalogStoreIntegrationDB(t)
+	seedAuthorizationTarget(t, db, "1.0.0")
+	catalogStore := newStore(db)
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	if _, err := db.Exec(`UPDATE card_template_artifact SET blocked_at = NOW(), blocked_by = 'admin-1'
+        WHERE template_id = ? AND version = '1.0.0'`, string(authorizationIntegrationTemplateID)); err != nil {
+		t.Fatalf("block artifact: %v", err)
+	}
+	auth, err := catalogStore.LoadAuthorization(ctx, cardtmpl.RuntimeAuthorizationQuery{
+		ID: authorizationIntegrationTemplateID, Principal: authorizationIntegrationPrincipal(),
+	})
+	if err != nil {
+		t.Fatalf("blocked LoadAuthorization: %v", err)
+	}
+	if !auth.Artifact.Blocked {
+		t.Fatalf("blocked artifact = %+v", auth.Artifact)
+	}
+
+	if _, err := catalogStore.LoadAuthorization(ctx, cardtmpl.RuntimeAuthorizationQuery{
+		ID: authorizationIntegrationTemplateID, Version: "9.9.9",
+		Principal: authorizationIntegrationPrincipal(),
+	}); !errors.Is(err, cardtmpl.ErrTemplateUnknown) {
+		t.Fatalf("unknown pinned version error = %v, want ErrTemplateUnknown", err)
+	}
+}

--- a/modules/card_template_catalog/store_authorization_mysql_integration_test.go
+++ b/modules/card_template_catalog/store_authorization_mysql_integration_test.go
@@ -451,3 +451,53 @@ func TestLoadAuthorizationsAppliesExactOverGlobalPrecedenceRealMySQL(t *testing.
 		t.Fatal("an exact tombstone failed to shadow the global grant in the batch reducer")
 	}
 }
+
+// One disabled template must not cost the batch its whole reason to exist. The
+// per-ID resolver signals a disabled pointer with an error because an error is
+// its only channel; a batch that did the same would fail every other template
+// in the call and send the caller back to one-ID-at-a-time reads for as long as
+// an operator left that template disabled.
+func TestLoadAuthorizationsKeepsAnsweringAroundADisabledTemplateRealMySQL(t *testing.T) {
+	db := newCatalogStoreIntegrationDB(t)
+	catalogStore := newStore(db)
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	seedAuthorizationTarget(t, db, "1.0.0")
+	seedDiscoveryVersion(t, db, "test.disabled-one", "1.0.0", cardtmpl.CatalogVisibilityPrivate, false)
+	seedDiscoveryActivation(t, db, "test.disabled-one", "1.0.0")
+	if _, err := db.Exec(`UPDATE card_template_activation
+        SET status = 'disabled', active_version = NULL WHERE template_id = ?`,
+		"test.disabled-one"); err != nil {
+		t.Fatalf("disable pointer: %v", err)
+	}
+
+	ids := []cardtmpl.ID{authorizationIntegrationTemplateID, "test.disabled-one"}
+	batch, err := catalogStore.LoadAuthorizations(ctx, ids, authorizationIntegrationPrincipal())
+	if err != nil {
+		t.Fatalf("a disabled template failed the whole batch: %v", err)
+	}
+	if len(batch) != 2 {
+		t.Fatalf("batch answered %d of 2: %+v", len(batch), batch)
+	}
+	// The healthy template still resolves normally.
+	if batch[authorizationIntegrationTemplateID].Version != "1.0.0" {
+		t.Fatalf("healthy template = %+v", batch[authorizationIntegrationTemplateID])
+	}
+	// The disabled one reports its status rather than a version, so a caller
+	// cannot mistake it for "no dynamic version, keep your static behaviour".
+	disabled := batch["test.disabled-one"]
+	if disabled.Version != "" {
+		t.Fatalf("disabled template offered version %q", disabled.Version)
+	}
+	if disabled.Activation.Status != cardtmpl.RuntimeActivationDisabled {
+		t.Fatalf("disabled template = %+v, want the disabled status carried through", disabled)
+	}
+	// The per-ID form still reports it as an error — that difference is the
+	// documented contract, not a drift.
+	if _, err := catalogStore.LoadAuthorization(ctx, cardtmpl.RuntimeAuthorizationQuery{
+		ID: "test.disabled-one", Principal: authorizationIntegrationPrincipal(),
+	}); !errors.Is(err, cardtmpl.ErrRuntimeCatalogDisabled) {
+		t.Fatalf("per-ID disabled error = %v, want ErrRuntimeCatalogDisabled", err)
+	}
+}

--- a/modules/card_template_catalog/store_authorization_mysql_integration_test.go
+++ b/modules/card_template_catalog/store_authorization_mysql_integration_test.go
@@ -501,3 +501,69 @@ func TestLoadAuthorizationsKeepsAnsweringAroundADisabledTemplateRealMySQL(t *tes
 		t.Fatalf("per-ID disabled error = %v, want ErrRuntimeCatalogDisabled", err)
 	}
 }
+
+// A grant belongs to the principal it names and to nobody else. This is the
+// isolation the whole per-principal model rests on, and it had no direct
+// evidence: every other test asks with the principal it just granted, so a
+// resolver that ignored principal_id entirely would have passed them all.
+func TestGrantsDoNotLeakBetweenBotsRealMySQL(t *testing.T) {
+	db := newCatalogStoreIntegrationDB(t)
+	catalogStore := newStore(db)
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	seedAuthorizationTarget(t, db, "1.0.0")
+
+	granted := authorizationIntegrationIdentity()
+	if _, err := catalogStore.UpsertGrant(ctx, UpsertGrantRequest{
+		Identity: granted, Permissions: GrantPermissions{Discover: true, Send: true, Edit: true},
+		ActorUID: "admin-1", Reason: "pilot", ChangeTicket: "CHG-I1",
+	}); err != nil {
+		t.Fatalf("seed grant: %v", err)
+	}
+
+	// Same Space, same template, same deployment — only the Bot differs.
+	neighbour := cardtmpl.CatalogPrincipal{
+		Kind: cardtmpl.CatalogPrincipalBot, ID: "bot-neighbour",
+		SpaceID: granted.ScopeSpaceID,
+	}
+	auth, err := catalogStore.LoadAuthorization(ctx, cardtmpl.RuntimeAuthorizationQuery{
+		ID: authorizationIntegrationTemplateID, Principal: neighbour,
+	})
+	if err != nil {
+		t.Fatalf("neighbour LoadAuthorization: %v", err)
+	}
+	if auth.Grant.Found || auth.Grant.Discover || auth.Grant.Send || auth.Grant.Edit {
+		t.Fatalf("another Bot's grant was visible to bot-neighbour: %+v", auth.Grant)
+	}
+	// It still resolves the template itself — the denial is about the grant,
+	// not about the Bot being unable to see that the ID exists.
+	if auth.Version != "1.0.0" {
+		t.Fatalf("neighbour authorization = %+v", auth)
+	}
+
+	// The advertised set is the other half: a Bot must not be told about a
+	// template it holds no grant on, however many other Bots do.
+	advertised, err := catalogStore.ListAuthorizedTemplates(ctx, neighbour, 10)
+	if err != nil {
+		t.Fatalf("neighbour ListAuthorizedTemplates: %v", err)
+	}
+	if len(advertised) != 0 {
+		t.Fatalf("neighbour was advertised %+v", advertised)
+	}
+
+	// A principal type change must not match either: bot "x" and
+	// internal_producer "x" are different identities.
+	impostor := cardtmpl.CatalogPrincipal{
+		Kind: cardtmpl.CatalogPrincipalInternalProducer, ID: granted.PrincipalID,
+		SpaceID: granted.ScopeSpaceID,
+	}
+	auth, err = catalogStore.LoadAuthorization(ctx, cardtmpl.RuntimeAuthorizationQuery{
+		ID: authorizationIntegrationTemplateID, Principal: impostor,
+	})
+	if err != nil {
+		t.Fatalf("impostor LoadAuthorization: %v", err)
+	}
+	if auth.Grant.Found {
+		t.Fatalf("a bot grant matched an internal_producer of the same name: %+v", auth.Grant)
+	}
+}

--- a/modules/card_template_catalog/store_authorization_mysql_integration_test.go
+++ b/modules/card_template_catalog/store_authorization_mysql_integration_test.go
@@ -299,3 +299,155 @@ func TestRuntimeAuthorizationSourceReadsTheStoreAndTheGateRealMySQL(t *testing.T
 		t.Fatalf("source advertised %+v", advertised)
 	}
 }
+
+// The batch resolver exists only to save round trips, so the property that
+// matters is that it saves nothing else: for every template it must return
+// exactly what the per-ID resolver would have. A divergence here would be
+// invisible — the manifest and the send it advertises would simply disagree,
+// and only for whichever templates happened to differ.
+func TestLoadAuthorizationsAgreesWithThePerTemplateResolverRealMySQL(t *testing.T) {
+	db := newCatalogStoreIntegrationDB(t)
+	catalogStore := newStore(db)
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	principal := authorizationIntegrationPrincipal()
+
+	// One template of each shape the resolver distinguishes.
+	seedAuthorizationTarget(t, db, "1.0.0") // active pointer, grant added below
+	seedDiscoveryVersion(t, db, "test.batch-no-activation", "1.0.0",
+		cardtmpl.CatalogVisibilityPrivate, false) // claimed, never activated
+	seedDiscoveryVersion(t, db, "test.batch-blocked", "1.0.0",
+		cardtmpl.CatalogVisibilityPublic, true)
+	seedDiscoveryActivation(t, db, "test.batch-blocked", "1.0.0")
+	seedDiscoveryVersion(t, db, "test.batch-ungranted", "1.0.0",
+		cardtmpl.CatalogVisibilityPrivate, false)
+	seedDiscoveryActivation(t, db, "test.batch-ungranted", "1.0.0")
+	if _, err := catalogStore.UpsertGrant(ctx, UpsertGrantRequest{
+		Identity:    authorizationIntegrationIdentity(),
+		Permissions: GrantPermissions{Discover: true, Send: true},
+		ActorUID:    "admin-1", Reason: "pilot", ChangeTicket: "CHG-B1",
+	}); err != nil {
+		t.Fatalf("seed grant: %v", err)
+	}
+
+	ids := []cardtmpl.ID{
+		authorizationIntegrationTemplateID,
+		"test.batch-no-activation",
+		"test.batch-blocked",
+		"test.batch-ungranted",
+		"test.batch-does-not-exist",
+	}
+	batch, err := catalogStore.LoadAuthorizations(ctx, ids, principal)
+	if err != nil {
+		t.Fatalf("LoadAuthorizations: %v", err)
+	}
+	if len(batch) != len(ids) {
+		t.Fatalf("batch answered %d of %d templates", len(batch), len(ids))
+	}
+	for _, id := range ids {
+		single, err := catalogStore.LoadAuthorization(ctx, cardtmpl.RuntimeAuthorizationQuery{
+			ID: id, Principal: principal,
+		})
+		if err != nil {
+			t.Fatalf("per-template LoadAuthorization(%s): %v", id, err)
+		}
+		if batch[id] != single {
+			t.Fatalf("%s: batch = %+v, per-template = %+v", id, batch[id], single)
+		}
+	}
+
+	// The interesting rows, spelled out so a future change that makes both
+	// paths wrong in the same way still fails.
+	if got := batch[authorizationIntegrationTemplateID]; got.Version != "1.0.0" || !got.Grant.Send {
+		t.Fatalf("granted active template = %+v", got)
+	}
+	if got := batch["test.batch-no-activation"]; got.Version != "" || got.Grant.Found {
+		t.Fatalf("unactivated template = %+v, want a zero version and no grant", got)
+	}
+	if got := batch["test.batch-blocked"]; got.Version != "1.0.0" || !got.Artifact.Blocked {
+		t.Fatalf("blocked template = %+v", got)
+	}
+	if got := batch["test.batch-ungranted"]; got.Version != "1.0.0" || got.Grant.Found {
+		t.Fatalf("ungranted active template = %+v", got)
+	}
+	if got := batch["test.batch-does-not-exist"]; got.Version != "" || got.Grant.Found {
+		t.Fatalf("unknown template = %+v", got)
+	}
+
+	// A revoke has to move both paths at the same instant.
+	if _, err := catalogStore.RevokeGrant(ctx, RevokeGrantRequest{
+		Identity: authorizationIntegrationIdentity(), ExpectedRevision: 1,
+		ActorUID: "admin-1", Reason: "offboard", ChangeTicket: "CHG-B2",
+	}); err != nil {
+		t.Fatalf("revoke: %v", err)
+	}
+	after, err := catalogStore.LoadAuthorizations(ctx, ids, principal)
+	if err != nil {
+		t.Fatalf("post-revoke LoadAuthorizations: %v", err)
+	}
+	single, err := catalogStore.LoadAuthorization(ctx, cardtmpl.RuntimeAuthorizationQuery{
+		ID: authorizationIntegrationTemplateID, Principal: principal,
+	})
+	if err != nil {
+		t.Fatalf("post-revoke LoadAuthorization: %v", err)
+	}
+	if after[authorizationIntegrationTemplateID] != single {
+		t.Fatalf("post-revoke batch = %+v, per-template = %+v",
+			after[authorizationIntegrationTemplateID], single)
+	}
+	if after[authorizationIntegrationTemplateID].Grant.Send {
+		t.Fatal("the batch still reports send after a revoke")
+	}
+}
+
+// An exact tombstone must shadow a live global grant in the batch reducer too —
+// the batch reads both scopes per template for exactly this reason, and a
+// reducer that took "first row wins" would silently re-grant every offboarded
+// principal that still holds a global row.
+func TestLoadAuthorizationsAppliesExactOverGlobalPrecedenceRealMySQL(t *testing.T) {
+	db := newCatalogStoreIntegrationDB(t)
+	catalogStore := newStore(db)
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	identity := authorizationIntegrationIdentity()
+	seedAuthorizationTarget(t, db, "1.0.0")
+
+	global := identity
+	global.ScopeSpaceID = ""
+	if _, err := catalogStore.UpsertGrant(ctx, UpsertGrantRequest{
+		Identity: global, Permissions: GrantPermissions{Discover: true, Send: true},
+		ActorUID: "admin-1", Reason: "fleet", ChangeTicket: "CHG-B3",
+	}); err != nil {
+		t.Fatalf("seed global grant: %v", err)
+	}
+	if _, err := catalogStore.UpsertGrant(ctx, UpsertGrantRequest{
+		Identity: identity, Permissions: GrantPermissions{Discover: true, Send: true},
+		ActorUID: "admin-1", Reason: "exact", ChangeTicket: "CHG-B4",
+	}); err != nil {
+		t.Fatalf("seed exact grant: %v", err)
+	}
+	if _, err := catalogStore.RevokeGrant(ctx, RevokeGrantRequest{
+		Identity: identity, ExpectedRevision: 1,
+		ActorUID: "admin-1", Reason: "offboard", ChangeTicket: "CHG-B5",
+	}); err != nil {
+		t.Fatalf("revoke exact grant: %v", err)
+	}
+
+	ids := []cardtmpl.ID{authorizationIntegrationTemplateID}
+	batch, err := catalogStore.LoadAuthorizations(ctx, ids, authorizationIntegrationPrincipal())
+	if err != nil {
+		t.Fatalf("LoadAuthorizations: %v", err)
+	}
+	single, err := catalogStore.LoadAuthorization(ctx, cardtmpl.RuntimeAuthorizationQuery{
+		ID: authorizationIntegrationTemplateID, Principal: authorizationIntegrationPrincipal(),
+	})
+	if err != nil {
+		t.Fatalf("LoadAuthorization: %v", err)
+	}
+	if batch[authorizationIntegrationTemplateID] != single {
+		t.Fatalf("batch = %+v, per-template = %+v", batch[authorizationIntegrationTemplateID], single)
+	}
+	if batch[authorizationIntegrationTemplateID].Grant.Send {
+		t.Fatal("an exact tombstone failed to shadow the global grant in the batch reducer")
+	}
+}

--- a/modules/card_template_catalog/store_authorization_test.go
+++ b/modules/card_template_catalog/store_authorization_test.go
@@ -1,0 +1,319 @@
+package card_template_catalog
+
+// PR-C D4 evidence at the SQL boundary: the resolver issues its reads inside
+// one transaction, in the right shape, and reduces the two candidate grant rows
+// through the same precedence function the manager control plane uses.
+//
+// sqlmock is strict about ordering, so "begin, these queries, commit" is an
+// assertion about the transaction itself — a future change that moves the grant
+// read outside the tx, or drops the tx entirely, fails here.
+
+import (
+	"context"
+	"errors"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl"
+)
+
+const (
+	authActivationPattern = `SELECT active_version, status, revision`
+	authArtifactPattern   = `SELECT c.source, a.owner, a.visibility`
+	authGrantPattern      = `SELECT scope_space_id, status, can_discover, can_send, can_edit, revision`
+	authPrincipalPattern  = `SELECT template_id, scope_space_id, status`
+)
+
+func dynamicArtifactRows() *sqlmock.Rows {
+	return sqlmock.NewRows([]string{
+		"source", "owner", "visibility", "engine_contract",
+		"protocol", "contract_version", "content_sha256", "blocked",
+	}).AddRow(claimSourceDynamic, "docs", cardtmpl.CatalogVisibilityPrivate,
+		cardtmpl.JSONTemplateEngineV1, cardtmpl.Protocol, "1.0.0", strings.Repeat("a", 64), false)
+}
+
+func grantScopeRows() *sqlmock.Rows {
+	return sqlmock.NewRows([]string{
+		"scope_space_id", "status", "can_discover", "can_send", "can_edit", "revision",
+	})
+}
+
+func botAuthPrincipal() cardtmpl.CatalogPrincipal {
+	return cardtmpl.CatalogPrincipal{
+		Kind: cardtmpl.CatalogPrincipalBot, ID: "bot-1", SpaceID: "space-1",
+	}
+}
+
+func TestStoreLoadAuthorizationReadsPointerArtifactAndGrantInOneTransaction(t *testing.T) {
+	store, mock, closeDB := newMockStore(t)
+	defer closeDB()
+
+	mock.ExpectBegin()
+	mock.ExpectQuery(regexp.QuoteMeta(authActivationPattern)).
+		WithArgs("test.runtime-card").
+		WillReturnRows(sqlmock.NewRows([]string{"active_version", "status", "revision"}).
+			AddRow("1.1.0", string(activationStatusActive), 6))
+	mock.ExpectQuery(regexp.QuoteMeta(authArtifactPattern)).
+		WithArgs("test.runtime-card", "1.1.0").
+		WillReturnRows(dynamicArtifactRows())
+	mock.ExpectQuery(regexp.QuoteMeta(authGrantPattern)).
+		WithArgs("test.runtime-card", string(GrantPrincipalBot), "bot-1", "space-1").
+		WillReturnRows(grantScopeRows().AddRow("space-1", string(GrantStatusActive), true, true, false, 4))
+	mock.ExpectCommit()
+
+	auth, err := store.LoadAuthorization(context.Background(), cardtmpl.RuntimeAuthorizationQuery{
+		ID: "test.runtime-card", Principal: botAuthPrincipal(),
+	})
+	if err != nil {
+		t.Fatalf("LoadAuthorization: %v", err)
+	}
+	if auth.Version != "1.1.0" || auth.Activation.Revision != 6 {
+		t.Fatalf("authorization pointer = %+v", auth)
+	}
+	if auth.Artifact.Owner != "docs" || auth.Artifact.Source != cardtmpl.RuntimeSourceDynamic || auth.Artifact.Blocked {
+		t.Fatalf("authorization artifact = %+v", auth.Artifact)
+	}
+	want := cardtmpl.RuntimeGrant{
+		Found: true, Scope: cardtmpl.RuntimeGrantScopeExact, Revision: 4, Discover: true, Send: true,
+	}
+	if auth.Grant != want {
+		t.Fatalf("authorization grant = %+v, want %+v", auth.Grant, want)
+	}
+	assertMockExpectations(t, mock)
+}
+
+// A pinned read is what historical edit and action context perform. It must not
+// issue the activation query at all: reading the pointer there is how a version
+// switch would silently retarget an already-sent card.
+func TestStoreLoadAuthorizationPinnedVersionSkipsActivationRead(t *testing.T) {
+	store, mock, closeDB := newMockStore(t)
+	defer closeDB()
+
+	mock.ExpectBegin()
+	mock.ExpectQuery(regexp.QuoteMeta(authArtifactPattern)).
+		WithArgs("test.runtime-card", "1.0.0").
+		WillReturnRows(dynamicArtifactRows())
+	mock.ExpectQuery(regexp.QuoteMeta(authGrantPattern)).
+		WithArgs("test.runtime-card", string(GrantPrincipalInternalProducer), "docs-notify", "space-1").
+		WillReturnRows(grantScopeRows().AddRow("", string(GrantStatusActive), true, false, true, 2))
+	mock.ExpectCommit()
+
+	auth, err := store.LoadAuthorization(context.Background(), cardtmpl.RuntimeAuthorizationQuery{
+		ID: "test.runtime-card", Version: "1.0.0",
+		Principal: cardtmpl.CatalogPrincipal{
+			Kind: cardtmpl.CatalogPrincipalInternalProducer, ID: "docs-notify", SpaceID: "space-1",
+		},
+	})
+	if err != nil {
+		t.Fatalf("LoadAuthorization: %v", err)
+	}
+	if auth.Activation.Exists || auth.Version != "1.0.0" {
+		t.Fatalf("pinned authorization = %+v, want no pointer state", auth)
+	}
+	if auth.Grant.Scope != cardtmpl.RuntimeGrantScopeGlobal || !auth.Grant.Edit || auth.Grant.Send {
+		t.Fatalf("pinned grant = %+v", auth.Grant)
+	}
+	assertMockExpectations(t, mock)
+}
+
+// The precedence rule is exercised through the real SQL path so that the row
+// shapes the query returns — not just the in-memory records — are known to
+// reduce correctly. Especially: an exact tombstone wins over an active global
+// row, and permissions are never unioned across scopes.
+func TestStoreLoadAuthorizationAppliesExactOverGlobalPrecedence(t *testing.T) {
+	type row struct {
+		scope    string
+		status   GrantStatus
+		discover bool
+		send     bool
+		edit     bool
+		revision uint64
+	}
+	for _, test := range []struct {
+		name string
+		rows []row
+		want cardtmpl.RuntimeGrant
+	}{
+		{
+			name: "no rows is no grant",
+			want: cardtmpl.RuntimeGrant{},
+		},
+		{
+			name: "global row applies when there is no exact row",
+			rows: []row{{"", GrantStatusActive, true, true, false, 2}},
+			want: cardtmpl.RuntimeGrant{
+				Found: true, Scope: cardtmpl.RuntimeGrantScopeGlobal, Revision: 2, Discover: true, Send: true},
+		},
+		{
+			name: "exact row overrides the global row entirely",
+			rows: []row{
+				{"", GrantStatusActive, true, true, true, 2},
+				{"space-1", GrantStatusActive, true, false, false, 5},
+			},
+			want: cardtmpl.RuntimeGrant{
+				Found: true, Scope: cardtmpl.RuntimeGrantScopeExact, Revision: 5, Discover: true},
+		},
+		{
+			name: "exact tombstone shadows an active global grant",
+			rows: []row{
+				{"", GrantStatusActive, true, true, true, 2},
+				{"space-1", GrantStatusRevoked, false, false, false, 9},
+			},
+			want: cardtmpl.RuntimeGrant{Found: true, Scope: cardtmpl.RuntimeGrantScopeExact, Revision: 9},
+		},
+		{
+			name: "global tombstone denies without consulting anything else",
+			rows: []row{{"", GrantStatusRevoked, false, false, false, 3}},
+			want: cardtmpl.RuntimeGrant{Found: true, Scope: cardtmpl.RuntimeGrantScopeGlobal, Revision: 3},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			store, mock, closeDB := newMockStore(t)
+			defer closeDB()
+
+			grantRows := grantScopeRows()
+			for _, r := range test.rows {
+				grantRows.AddRow(r.scope, string(r.status), r.discover, r.send, r.edit, r.revision)
+			}
+			mock.ExpectBegin()
+			mock.ExpectQuery(regexp.QuoteMeta(authArtifactPattern)).
+				WillReturnRows(dynamicArtifactRows())
+			mock.ExpectQuery(regexp.QuoteMeta(authGrantPattern)).WillReturnRows(grantRows)
+			mock.ExpectCommit()
+
+			auth, err := store.LoadAuthorization(context.Background(), cardtmpl.RuntimeAuthorizationQuery{
+				ID: "test.runtime-card", Version: "1.0.0", Principal: botAuthPrincipal(),
+			})
+			if err != nil {
+				t.Fatalf("LoadAuthorization: %v", err)
+			}
+			if auth.Grant != test.want {
+				t.Fatalf("grant = %+v, want %+v", auth.Grant, test.want)
+			}
+			assertMockExpectations(t, mock)
+		})
+	}
+}
+
+// `system` and blank principals are control-plane identities, not producers.
+// The resolver must not even ask the grant table about them — an empty-string
+// principal_id in a query is one schema slip away from matching a real row.
+func TestStoreLoadAuthorizationSkipsGrantLookupForUngrantablePrincipals(t *testing.T) {
+	for _, principal := range []cardtmpl.CatalogPrincipal{
+		{Kind: cardtmpl.CatalogPrincipalSystem, ID: "startup", SpaceID: "space-1"},
+		{Kind: cardtmpl.CatalogPrincipalBot, ID: "   ", SpaceID: "space-1"},
+		{},
+	} {
+		store, mock, closeDB := newMockStore(t)
+		mock.ExpectBegin()
+		mock.ExpectQuery(regexp.QuoteMeta(authArtifactPattern)).WillReturnRows(dynamicArtifactRows())
+		mock.ExpectCommit()
+
+		auth, err := store.LoadAuthorization(context.Background(), cardtmpl.RuntimeAuthorizationQuery{
+			ID: "test.runtime-card", Version: "1.0.0", Principal: principal,
+		})
+		if err != nil {
+			t.Fatalf("LoadAuthorization(%+v): %v", principal, err)
+		}
+		if auth.Grant.Found {
+			t.Fatalf("principal %+v produced a grant %+v", principal, auth.Grant)
+		}
+		assertMockExpectations(t, mock)
+		closeDB()
+	}
+}
+
+// A template with no activation row resolves to no version, so the artifact
+// read is skipped — the caller falls back to the frozen Registry.
+func TestStoreLoadAuthorizationWithoutActivationSkipsArtifactRead(t *testing.T) {
+	store, mock, closeDB := newMockStore(t)
+	defer closeDB()
+
+	mock.ExpectBegin()
+	mock.ExpectQuery(regexp.QuoteMeta(authActivationPattern)).
+		WillReturnRows(sqlmock.NewRows([]string{"active_version", "status", "revision"}))
+	mock.ExpectQuery(regexp.QuoteMeta(authGrantPattern)).WillReturnRows(grantScopeRows())
+	mock.ExpectCommit()
+
+	auth, err := store.LoadAuthorization(context.Background(), cardtmpl.RuntimeAuthorizationQuery{
+		ID: "test.runtime-card", Principal: botAuthPrincipal(),
+	})
+	if err != nil {
+		t.Fatalf("LoadAuthorization: %v", err)
+	}
+	if auth.Version != "" || auth.Activation.Exists {
+		t.Fatalf("authorization = %+v, want no activation", auth)
+	}
+	assertMockExpectations(t, mock)
+}
+
+func TestStoreLoadAuthorizationRequiresATemplate(t *testing.T) {
+	store, _, closeDB := newMockStore(t)
+	defer closeDB()
+
+	if _, err := store.LoadAuthorization(context.Background(), cardtmpl.RuntimeAuthorizationQuery{
+		Principal: botAuthPrincipal(),
+	}); !errors.Is(err, cardtmpl.ErrTemplateUnknown) {
+		t.Fatalf("blank template error = %v, want ErrTemplateUnknown", err)
+	}
+}
+
+// The advertised set reads every candidate from the same snapshot, and drops a
+// template whose pointer is absent or disabled instead of failing the whole
+// listing — one broken template must not blank a Bot's capability manifest.
+func TestStoreListAuthorizedTemplatesSkipsUnadvertisableTemplates(t *testing.T) {
+	store, mock, closeDB := newMockStore(t)
+	defer closeDB()
+
+	mock.ExpectBegin()
+	mock.ExpectQuery(regexp.QuoteMeta(authPrincipalPattern)).
+		WithArgs(string(GrantPrincipalBot), "bot-1", "space-1", maxAuthorizedTemplates*2).
+		WillReturnRows(sqlmock.NewRows([]string{
+			"template_id", "scope_space_id", "status",
+			"can_discover", "can_send", "can_edit", "revision",
+		}).
+			AddRow("test.active", "space-1", string(GrantStatusActive), true, true, false, 3).
+			AddRow("test.disabled", "", string(GrantStatusActive), true, true, false, 1).
+			AddRow("test.revoked", "space-1", string(GrantStatusRevoked), false, false, false, 8))
+
+	// Sorted by template ID: active, then disabled. The revoked one never gets
+	// a state read at all — a tombstone is decided before touching activation.
+	mock.ExpectQuery(regexp.QuoteMeta(authActivationPattern)).
+		WithArgs("test.active").
+		WillReturnRows(sqlmock.NewRows([]string{"active_version", "status", "revision"}).
+			AddRow("2.0.0", string(activationStatusActive), 4))
+	mock.ExpectQuery(regexp.QuoteMeta(authArtifactPattern)).
+		WithArgs("test.active", "2.0.0").
+		WillReturnRows(dynamicArtifactRows())
+	mock.ExpectQuery(regexp.QuoteMeta(authActivationPattern)).
+		WithArgs("test.disabled").
+		WillReturnRows(sqlmock.NewRows([]string{"active_version", "status", "revision"}).
+			AddRow(nil, string(activationStatusDisabled), 2))
+	mock.ExpectCommit()
+
+	templates, err := store.ListAuthorizedTemplates(context.Background(), botAuthPrincipal(), 0)
+	if err != nil {
+		t.Fatalf("ListAuthorizedTemplates: %v", err)
+	}
+	if len(templates) != 1 || templates[0].ID != "test.active" {
+		t.Fatalf("templates = %+v, want only test.active", templates)
+	}
+	if templates[0].Authorization.Version != "2.0.0" || !templates[0].Authorization.Grant.Send {
+		t.Fatalf("advertised authorization = %+v", templates[0].Authorization)
+	}
+	assertMockExpectations(t, mock)
+}
+
+func TestStoreListAuthorizedTemplatesIgnoresUngrantablePrincipals(t *testing.T) {
+	store, mock, closeDB := newMockStore(t)
+	defer closeDB()
+
+	templates, err := store.ListAuthorizedTemplates(context.Background(),
+		cardtmpl.CatalogPrincipal{Kind: cardtmpl.CatalogPrincipalSystem, ID: "startup"}, 10)
+	if err != nil || templates != nil {
+		t.Fatalf("templates = %+v err = %v, want no lookup at all", templates, err)
+	}
+	assertMockExpectations(t, mock)
+}

--- a/modules/card_template_catalog/store_authorization_test.go
+++ b/modules/card_template_catalog/store_authorization_test.go
@@ -24,7 +24,28 @@ const (
 	authArtifactPattern   = `SELECT c.source, a.owner, a.visibility`
 	authGrantPattern      = `SELECT scope_space_id, status, can_discover, can_send, can_edit, revision`
 	authPrincipalPattern  = `SELECT template_id, scope_space_id, status`
+	// The advertised set resolves every candidate's pointer and artifact in one
+	// statement; the per-template pair above is the single-template path.
+	authAdvertisePattern = `SELECT act.template_id, act.active_version, act.status, act.revision`
+	authBatchGrantPrefix = `SELECT template_id, scope_space_id, status,
+        can_discover, can_send, can_edit, revision
+    FROM card_template_grant`
 )
+
+// advertiseRows are the columns of the batched activation+artifact read.
+func advertiseRows() *sqlmock.Rows {
+	return sqlmock.NewRows([]string{
+		"template_id", "active_version", "status", "revision",
+		"source", "owner", "visibility", "engine_contract",
+		"protocol", "contract_version", "content_sha256", "blocked",
+	})
+}
+
+func dynamicAdvertiseRow(rows *sqlmock.Rows, id, version string, revision int) *sqlmock.Rows {
+	return rows.AddRow(id, version, string(activationStatusActive), revision,
+		claimSourceDynamic, "docs", cardtmpl.CatalogVisibilityPrivate,
+		cardtmpl.JSONTemplateEngineV1, cardtmpl.Protocol, "1.0.0", strings.Repeat("a", 64), false)
+}
 
 func dynamicArtifactRows() *sqlmock.Rows {
 	return sqlmock.NewRows([]string{
@@ -279,19 +300,14 @@ func TestStoreListAuthorizedTemplatesSkipsUnadvertisableTemplates(t *testing.T) 
 			AddRow("test.disabled", "", string(GrantStatusActive), true, true, false, 1).
 			AddRow("test.revoked", "space-1", string(GrantStatusRevoked), false, false, false, 8))
 
-	// Sorted by template ID: active, then disabled. The revoked one never gets
-	// a state read at all — a tombstone is decided before touching activation.
-	mock.ExpectQuery(regexp.QuoteMeta(authActivationPattern)).
-		WithArgs("test.active").
-		WillReturnRows(sqlmock.NewRows([]string{"active_version", "status", "revision"}).
-			AddRow("2.0.0", string(activationStatusActive), 4))
-	mock.ExpectQuery(regexp.QuoteMeta(authArtifactPattern)).
-		WithArgs("test.active", "2.0.0").
-		WillReturnRows(dynamicArtifactRows())
-	mock.ExpectQuery(regexp.QuoteMeta(authActivationPattern)).
-		WithArgs("test.disabled").
-		WillReturnRows(sqlmock.NewRows([]string{"active_version", "status", "revision"}).
-			AddRow(nil, string(activationStatusDisabled), 2))
+	// One batched state read for both surviving candidates, sorted by template
+	// ID. The revoked one is not among them at all — a tombstone is decided
+	// before touching activation. test.disabled has no row in the result
+	// because the inner join on active_version drops a disabled pointer, which
+	// is the same outcome the per-template loop produced by discarding it.
+	mock.ExpectQuery(regexp.QuoteMeta(authAdvertisePattern)).
+		WithArgs("test.active", "test.disabled").
+		WillReturnRows(dynamicAdvertiseRow(advertiseRows(), "test.active", "2.0.0", 4))
 	mock.ExpectCommit()
 
 	templates, err := store.ListAuthorizedTemplates(context.Background(), botAuthPrincipal(), 0)
@@ -315,6 +331,106 @@ func TestStoreListAuthorizedTemplatesIgnoresUngrantablePrincipals(t *testing.T) 
 		cardtmpl.CatalogPrincipal{Kind: cardtmpl.CatalogPrincipalSystem, ID: "startup"}, 10)
 	if err != nil || templates != nil {
 		t.Fatalf("templates = %+v err = %v, want no lookup at all", templates, err)
+	}
+	assertMockExpectations(t, mock)
+}
+
+// The batch resolver's whole reason to exist is the shape of its transaction:
+// one snapshot, one activation/artifact statement, one grant statement, however
+// many templates were asked about. sqlmock is the only place that shape can be
+// asserted — a real-MySQL test proves the answers agree but says nothing about
+// how many round trips produced them.
+func TestStoreLoadAuthorizationsUsesTwoStatementsForManyTemplates(t *testing.T) {
+	store, mock, closeDB := newMockStore(t)
+	defer closeDB()
+
+	mock.ExpectBegin()
+	mock.ExpectQuery(regexp.QuoteMeta(authAdvertisePattern)).
+		WithArgs("test.a", "test.b", "test.c").
+		WillReturnRows(dynamicAdvertiseRow(advertiseRows(), "test.a", "1.0.0", 2))
+	mock.ExpectQuery(regexp.QuoteMeta(authBatchGrantPrefix)).
+		WithArgs(string(GrantPrincipalBot), "bot-1", "space-1", "test.a", "test.b", "test.c").
+		WillReturnRows(sqlmock.NewRows([]string{
+			"template_id", "scope_space_id", "status",
+			"can_discover", "can_send", "can_edit", "revision",
+		}).AddRow("test.a", "space-1", string(GrantStatusActive), true, true, false, 5))
+	mock.ExpectCommit()
+
+	got, err := store.LoadAuthorizations(context.Background(),
+		[]cardtmpl.ID{"test.a", "test.b", "test.c"}, botAuthPrincipal())
+	if err != nil {
+		t.Fatalf("LoadAuthorizations: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("answered %d of 3 templates: %+v", len(got), got)
+	}
+	if got["test.a"].Version != "1.0.0" || !got["test.a"].Grant.Send {
+		t.Fatalf("test.a = %+v", got["test.a"])
+	}
+	// A template with no activation row still gets an entry, because "no
+	// dynamic version" is an answer the caller acts on (it keeps its static
+	// behaviour) rather than an absence it has to guess about.
+	for _, id := range []cardtmpl.ID{"test.b", "test.c"} {
+		if entry, ok := got[id]; !ok || entry.Version != "" || entry.Grant.Found {
+			t.Fatalf("%s = %+v (present=%v)", id, entry, ok)
+		}
+	}
+	assertMockExpectations(t, mock)
+}
+
+// A duplicated ID must not widen the IN list, and a blank one is a caller bug
+// that has to surface rather than quietly resolving to nothing.
+func TestStoreLoadAuthorizationsRejectsBlankIDsAndDeduplicates(t *testing.T) {
+	store, mock, closeDB := newMockStore(t)
+	defer closeDB()
+
+	if _, err := store.LoadAuthorizations(context.Background(),
+		[]cardtmpl.ID{"test.a", "  "}, botAuthPrincipal()); !errors.Is(err, cardtmpl.ErrTemplateUnknown) {
+		t.Fatalf("blank id error = %v, want ErrTemplateUnknown", err)
+	}
+
+	mock.ExpectBegin()
+	mock.ExpectQuery(regexp.QuoteMeta(authAdvertisePattern)).
+		WithArgs("test.a").
+		WillReturnRows(advertiseRows())
+	mock.ExpectQuery(regexp.QuoteMeta(authBatchGrantPrefix)).
+		WithArgs(string(GrantPrincipalBot), "bot-1", "space-1", "test.a").
+		WillReturnRows(sqlmock.NewRows([]string{
+			"template_id", "scope_space_id", "status",
+			"can_discover", "can_send", "can_edit", "revision",
+		}))
+	mock.ExpectCommit()
+	got, err := store.LoadAuthorizations(context.Background(),
+		[]cardtmpl.ID{"test.a", "test.a"}, botAuthPrincipal())
+	if err != nil {
+		t.Fatalf("LoadAuthorizations: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("deduplicated result = %+v", got)
+	}
+	assertMockExpectations(t, mock)
+}
+
+// An ungrantable principal issues no grant query, exactly as the single-template
+// path does — `system` and blank identities are control-plane concepts, and a
+// lookup on them could accidentally match an empty-string row.
+func TestStoreLoadAuthorizationsSkipsTheGrantQueryForUngrantablePrincipals(t *testing.T) {
+	store, mock, closeDB := newMockStore(t)
+	defer closeDB()
+
+	mock.ExpectBegin()
+	mock.ExpectQuery(regexp.QuoteMeta(authAdvertisePattern)).
+		WithArgs("test.a").
+		WillReturnRows(dynamicAdvertiseRow(advertiseRows(), "test.a", "1.0.0", 2))
+	mock.ExpectCommit()
+
+	got, err := store.LoadAuthorizations(context.Background(), []cardtmpl.ID{"test.a"},
+		cardtmpl.CatalogPrincipal{Kind: cardtmpl.CatalogPrincipalSystem, ID: "startup"})
+	if err != nil {
+		t.Fatalf("LoadAuthorizations: %v", err)
+	}
+	if got["test.a"].Grant.Found {
+		t.Fatalf("a system principal was issued a grant: %+v", got["test.a"])
 	}
 	assertMockExpectations(t, mock)
 }

--- a/modules/card_template_catalog/store_authorization_test.go
+++ b/modules/card_template_catalog/store_authorization_test.go
@@ -269,7 +269,8 @@ func TestStoreListAuthorizedTemplatesSkipsUnadvertisableTemplates(t *testing.T) 
 
 	mock.ExpectBegin()
 	mock.ExpectQuery(regexp.QuoteMeta(authPrincipalPattern)).
-		WithArgs(string(GrantPrincipalBot), "bot-1", "space-1", maxAuthorizedTemplates*2).
+		// One row past the budget so a truncated read is detectable.
+		WithArgs(string(GrantPrincipalBot), "bot-1", "space-1", maxAuthorizedTemplates*2+1).
 		WillReturnRows(sqlmock.NewRows([]string{
 			"template_id", "scope_space_id", "status",
 			"can_discover", "can_send", "can_edit", "revision",

--- a/modules/card_template_catalog/store_discovery.go
+++ b/modules/card_template_catalog/store_discovery.go
@@ -22,7 +22,9 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
 	"github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl"
+	"go.uber.org/zap"
 )
 
 const (
@@ -175,6 +177,16 @@ func (s *store) StaticDiscoverGrants(
 		return granted, nil
 	}
 	if len(ids) > maxStaticGrantProbe {
+		// Dropping the tail is safe — a missing grant can only hide a template,
+		// never reveal one — but it is not silent. Without this an operator who
+		// granted a Space access to the 129th private static template would see
+		// the grant land in the table, take effect nowhere, and have nothing
+		// anywhere telling them why.
+		log.Warn("static discover grant probe truncated",
+			zap.Bool("static_grant_probe_truncated", true),
+			zap.String("space_id", space),
+			zap.Int("requested", len(ids)),
+			zap.Int("probed", maxStaticGrantProbe))
 		ids = ids[:maxStaticGrantProbe]
 	}
 	args := make([]any, 0, len(ids)+1)

--- a/modules/card_template_catalog/store_discovery.go
+++ b/modules/card_template_catalog/store_discovery.go
@@ -1,0 +1,235 @@
+package card_template_catalog
+
+// PR-C D5 — the discovery read model behind B1/B2.
+//
+// The load-bearing property here is an ordering one: visibility, block state
+// and the caller's discover grant are applied *inside* the SQL predicate, so
+// they are settled before LIMIT runs. The obvious alternative — fetch a page,
+// then drop the rows the caller may not see — silently returns short pages,
+// lets a hidden row consume a slot, and turns `has_more` into a lie. Worse, the
+// count of dropped rows is itself an enumeration oracle: a caller could infer
+// how many private templates exist by watching pages shrink.
+//
+// A `space` principal is the caller's Space acting on its own behalf. Its grant
+// rows are always global-scoped (D2 forbids a Space-scoped grant *to* a Space,
+// which would be a scope of a scope), so the lookup below matches on the
+// canonical empty sentinel rather than going through the two-row precedence
+// reducer that producer principals need.
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl"
+)
+
+const (
+	// defaultDiscoveryPageSize / maxDiscoveryPageSize are the D5 page bounds.
+	defaultDiscoveryPageSize = 50
+	maxDiscoveryPageSize     = 100
+	// maxStaticGrantProbe bounds the IN-list used to check discover grants on
+	// static template IDs. The static Registry is a code-reviewed, small set;
+	// a deployment past this bound has outgrown a single-page listing anyway.
+	maxStaticGrantProbe = 128
+)
+
+const (
+	// selectDiscoverableSQL is one row per visible, unblocked dynamic exact
+	// version. The row-value cursor comparison keeps the scan on the primary
+	// key order, and the grant join is an existence test rather than a fetch —
+	// nothing about the grant reaches the response.
+	selectDiscoverableSQL = `SELECT c.template_id, c.version, a.owner, a.protocol,
+            a.contract_version, a.visibility, a.content_sha256,
+            act.active_version IS NOT NULL AND act.active_version = c.version
+        FROM card_template_version_claim c
+        JOIN card_template_artifact a
+          ON a.template_id = c.template_id AND a.version = c.version
+        LEFT JOIN card_template_activation act
+          ON act.template_id = c.template_id AND act.status = 'active'
+        LEFT JOIN card_template_grant g
+          ON g.template_id = c.template_id AND g.principal_type = 'space'
+         AND g.principal_id = ? AND g.scope_space_id = ''
+         AND g.status = 'active' AND g.can_discover = 1
+        WHERE c.source = 'dynamic'
+          AND a.blocked_at IS NULL
+          AND (a.visibility = ? OR g.template_id IS NOT NULL)
+          AND (c.template_id, c.version) > (?, ?)
+        ORDER BY c.template_id ASC, c.version ASC
+        LIMIT ?`
+	// selectDiscoverableExactSQL is the B2 metadata read. It applies the same
+	// predicate, so an invisible, blocked or unknown template is a single
+	// indistinguishable empty result — the caller cannot tell which.
+	selectDiscoverableExactSQL = `SELECT c.template_id, c.version, a.owner, a.protocol,
+            a.contract_version, a.visibility, a.content_sha256,
+            act.active_version IS NOT NULL AND act.active_version = c.version
+        FROM card_template_version_claim c
+        JOIN card_template_artifact a
+          ON a.template_id = c.template_id AND a.version = c.version
+        LEFT JOIN card_template_activation act
+          ON act.template_id = c.template_id AND act.status = 'active'
+        LEFT JOIN card_template_grant g
+          ON g.template_id = c.template_id AND g.principal_type = 'space'
+         AND g.principal_id = ? AND g.scope_space_id = ''
+         AND g.status = 'active' AND g.can_discover = 1
+        WHERE c.template_id = ? AND c.version = ?
+          AND c.source = 'dynamic'
+          AND a.blocked_at IS NULL
+          AND (a.visibility = ? OR g.template_id IS NOT NULL)`
+)
+
+// ErrDiscoveryNotVisible is the single outcome for "no such template", "you may
+// not see it" and "it is blocked". Callers must not widen it: three distinct
+// answers would let anyone map the private catalog by probing IDs.
+var ErrDiscoveryNotVisible = fmt.Errorf("card template is not discoverable")
+
+// DiscoveryRow is one visible exact version as B1 reports it. It carries no
+// grant, audit or storage state — only the contract surface a producer needs
+// to decide whether to look the template up in full.
+type DiscoveryRow struct {
+	ID               cardtmpl.ID
+	Version          string
+	Owner            string
+	Protocol         string
+	ContractVersion  string
+	Visibility       string
+	ContentSHA256    string
+	ActiveForNewSend bool
+}
+
+// ListDiscoverable returns one page of visible dynamic versions after the
+// cursor position, plus whether more remain.
+func (s *store) ListDiscoverable(
+	ctx context.Context,
+	spaceID string,
+	afterID cardtmpl.ID,
+	afterVersion string,
+	limit int,
+) ([]DiscoveryRow, bool, error) {
+	limit = boundedDiscoveryLimit(limit)
+	rows, err := s.db.QueryContext(ctx, selectDiscoverableSQL,
+		strings.TrimSpace(spaceID), cardtmpl.CatalogVisibilityPublic,
+		string(afterID), afterVersion, limit+1)
+	if err != nil {
+		return nil, false, fmt.Errorf("card template catalog: list discoverable: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	page := make([]DiscoveryRow, 0, limit)
+	for rows.Next() {
+		row, err := scanDiscoveryRow(rows)
+		if err != nil {
+			return nil, false, err
+		}
+		page = append(page, row)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, false, fmt.Errorf("card template catalog: iterate discoverable: %w", err)
+	}
+	if len(page) > limit {
+		return page[:limit], true, nil
+	}
+	return page, false, nil
+}
+
+// LoadDiscoverable answers B2's metadata half. ErrDiscoveryNotVisible covers
+// every reason the row is absent.
+func (s *store) LoadDiscoverable(
+	ctx context.Context,
+	spaceID string,
+	id cardtmpl.ID,
+	version string,
+) (DiscoveryRow, error) {
+	rows, err := s.db.QueryContext(ctx, selectDiscoverableExactSQL,
+		strings.TrimSpace(spaceID), string(id), version, cardtmpl.CatalogVisibilityPublic)
+	if err != nil {
+		return DiscoveryRow{}, fmt.Errorf("card template catalog: load discoverable: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	if !rows.Next() {
+		if err := rows.Err(); err != nil {
+			return DiscoveryRow{}, fmt.Errorf("card template catalog: load discoverable: %w", err)
+		}
+		return DiscoveryRow{}, ErrDiscoveryNotVisible
+	}
+	row, err := scanDiscoveryRow(rows)
+	if err != nil {
+		return DiscoveryRow{}, err
+	}
+	return row, nil
+}
+
+// StaticDiscoverGrants reports which of the given template IDs this Space holds
+// an active discover grant on. Static templates are private by default, so
+// without this a granted static card would be invisible even to the Space it
+// was granted to.
+func (s *store) StaticDiscoverGrants(
+	ctx context.Context,
+	spaceID string,
+	ids []cardtmpl.ID,
+) (map[cardtmpl.ID]struct{}, error) {
+	granted := make(map[cardtmpl.ID]struct{})
+	space := strings.TrimSpace(spaceID)
+	if space == "" || len(ids) == 0 {
+		return granted, nil
+	}
+	if len(ids) > maxStaticGrantProbe {
+		ids = ids[:maxStaticGrantProbe]
+	}
+	args := make([]any, 0, len(ids)+1)
+	args = append(args, space)
+	placeholders := make([]string, 0, len(ids))
+	for _, id := range ids {
+		placeholders = append(placeholders, "?")
+		args = append(args, string(id))
+	}
+	query := `SELECT template_id FROM card_template_grant
+        WHERE principal_type = 'space' AND principal_id = ? AND scope_space_id = ''
+          AND status = 'active' AND can_discover = 1
+          AND template_id IN (` + strings.Join(placeholders, ",") + `)`
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("card template catalog: static discover grants: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, fmt.Errorf("card template catalog: scan static discover grant: %w", err)
+		}
+		granted[cardtmpl.ID(id)] = struct{}{}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("card template catalog: iterate static discover grants: %w", err)
+	}
+	return granted, nil
+}
+
+func scanDiscoveryRow(rows *sql.Rows) (DiscoveryRow, error) {
+	var row DiscoveryRow
+	var templateID string
+	var owner, protocol, contractVersion, visibility, hash sql.NullString
+	if err := rows.Scan(&templateID, &row.Version, &owner, &protocol,
+		&contractVersion, &visibility, &hash, &row.ActiveForNewSend); err != nil {
+		return DiscoveryRow{}, fmt.Errorf("card template catalog: scan discoverable: %w", err)
+	}
+	row.ID = cardtmpl.ID(templateID)
+	row.Owner, row.Protocol = owner.String, protocol.String
+	row.ContractVersion, row.ContentSHA256 = contractVersion.String, hash.String
+	row.Visibility = cardtmpl.CatalogVisibilityPrivate
+	if visibility.String == cardtmpl.CatalogVisibilityPublic {
+		row.Visibility = cardtmpl.CatalogVisibilityPublic
+	}
+	return row, nil
+}
+
+func boundedDiscoveryLimit(limit int) int {
+	if limit <= 0 {
+		return defaultDiscoveryPageSize
+	}
+	if limit > maxDiscoveryPageSize {
+		return maxDiscoveryPageSize
+	}
+	return limit
+}

--- a/modules/card_template_catalog/store_discovery.go
+++ b/modules/card_template_catalog/store_discovery.go
@@ -42,7 +42,10 @@ const (
 	// version. The row-value cursor comparison keeps the scan on the primary
 	// key order, and the grant join is an existence test rather than a fetch —
 	// nothing about the grant reaches the response.
-	selectDiscoverableSQL = `SELECT c.template_id, c.version, a.owner, a.protocol,
+	// %s is the approved-owner predicate, injected from the one policy B2's
+	// authorizer also enforces (owner_policy.go). It is not inlined because a
+	// second literal list here is exactly how the two surfaces drift.
+	selectDiscoverableSQLTemplate = `SELECT c.template_id, c.version, a.owner, a.protocol,
             a.contract_version, a.visibility, a.content_sha256,
             act.active_version IS NOT NULL AND act.active_version = c.version
         FROM card_template_version_claim c
@@ -57,13 +60,14 @@ const (
         WHERE c.source = 'dynamic'
           AND a.blocked_at IS NULL
           AND (a.visibility = ? OR g.template_id IS NOT NULL)
+          AND %s
           AND (c.template_id, c.version) > (?, ?)
         ORDER BY c.template_id ASC, c.version ASC
         LIMIT ?`
 	// selectDiscoverableExactSQL is the B2 metadata read. It applies the same
 	// predicate, so an invisible, blocked or unknown template is a single
 	// indistinguishable empty result — the caller cannot tell which.
-	selectDiscoverableExactSQL = `SELECT c.template_id, c.version, a.owner, a.protocol,
+	selectDiscoverableExactSQLTemplate = `SELECT c.template_id, c.version, a.owner, a.protocol,
             a.contract_version, a.visibility, a.content_sha256,
             act.active_version IS NOT NULL AND act.active_version = c.version
         FROM card_template_version_claim c
@@ -78,7 +82,8 @@ const (
         WHERE c.template_id = ? AND c.version = ?
           AND c.source = 'dynamic'
           AND a.blocked_at IS NULL
-          AND (a.visibility = ? OR g.template_id IS NOT NULL)`
+          AND (a.visibility = ? OR g.template_id IS NOT NULL)
+          AND %s`
 )
 
 // ErrDiscoveryNotVisible is the single outcome for "no such template", "you may
@@ -110,9 +115,12 @@ func (s *store) ListDiscoverable(
 	limit int,
 ) ([]DiscoveryRow, bool, error) {
 	limit = boundedDiscoveryLimit(limit)
-	rows, err := s.db.QueryContext(ctx, selectDiscoverableSQL,
-		strings.TrimSpace(spaceID), cardtmpl.CatalogVisibilityPublic,
-		string(afterID), afterVersion, limit+1)
+	ownerPredicate, ownerArgs := approvedOwnerPredicate("a.owner")
+	args := []any{strings.TrimSpace(spaceID), cardtmpl.CatalogVisibilityPublic}
+	args = append(args, ownerArgs...)
+	args = append(args, string(afterID), afterVersion, limit+1)
+	rows, err := s.db.QueryContext(ctx,
+		fmt.Sprintf(selectDiscoverableSQLTemplate, ownerPredicate), args...)
 	if err != nil {
 		return nil, false, fmt.Errorf("card template catalog: list discoverable: %w", err)
 	}
@@ -143,8 +151,11 @@ func (s *store) LoadDiscoverable(
 	id cardtmpl.ID,
 	version string,
 ) (DiscoveryRow, error) {
-	rows, err := s.db.QueryContext(ctx, selectDiscoverableExactSQL,
-		strings.TrimSpace(spaceID), string(id), version, cardtmpl.CatalogVisibilityPublic)
+	ownerPredicate, ownerArgs := approvedOwnerPredicate("a.owner")
+	args := []any{strings.TrimSpace(spaceID), string(id), version, cardtmpl.CatalogVisibilityPublic}
+	args = append(args, ownerArgs...)
+	rows, err := s.db.QueryContext(ctx,
+		fmt.Sprintf(selectDiscoverableExactSQLTemplate, ownerPredicate), args...)
 	if err != nil {
 		return DiscoveryRow{}, fmt.Errorf("card template catalog: load discoverable: %w", err)
 	}

--- a/modules/card_template_catalog/store_discovery_mysql_integration_test.go
+++ b/modules/card_template_catalog/store_discovery_mysql_integration_test.go
@@ -448,3 +448,51 @@ func TestListTemplatesPagesByKeysetRealMySQL(t *testing.T) {
 		}
 	}
 }
+
+// Review P2-1: B1's predicate had no owner clause while B2's authorizer
+// enforces the approved-owner allowlist, so the two could disagree about the
+// same row. Latent while publish gates on the same list — but that list is the
+// per-owner kill switch. Narrow it during an incident and B1 would keep listing
+// every affected template with full metadata, and keep spending LIMIT slots on
+// rows B2 answers not-found for.
+//
+// The row is seeded directly rather than published, because publish rejects an
+// unapproved owner: the state under test is one that already existed when the
+// allowlist was narrowed, which is exactly the incident.
+func TestDiscoveryHidesRowsWhoseOwnerLeftTheAllowlistRealMySQL(t *testing.T) {
+	db := newCatalogStoreIntegrationDB(t)
+	seedDiscoveryFixture(t, db)
+	catalogStore := newStore(db)
+	ctx := discoveryIntegrationContext(t)
+
+	const retiredOwner = "retired-owner"
+	if isApprovedRuntimeOwner(retiredOwner) {
+		t.Fatalf("fixture precondition broken: %q is still approved", retiredOwner)
+	}
+	seedDiscoveryVersion(t, db, "test.disco-g-retired", "1.0.0", cardtmpl.CatalogVisibilityPublic, false)
+	if _, err := db.Exec(`UPDATE card_template_artifact SET owner = ?
+        WHERE template_id = ? AND version = '1.0.0'`, retiredOwner, "test.disco-g-retired"); err != nil {
+		t.Fatalf("retire owner: %v", err)
+	}
+
+	// B1: absent from every page, and it does not consume a slot on the way.
+	walked := discoveryRowIDs(walkDiscoverable(t, ctx, catalogStore, discoveryIntegrationSpaceID, 2))
+	for _, id := range walked {
+		if strings.HasPrefix(id, "test.disco-g-retired@") {
+			t.Fatalf("a retired-owner row was listed: %v", walked)
+		}
+	}
+
+	// B2: the same row is not visible either, so list and detail agree.
+	if _, err := catalogStore.LoadDiscoverable(ctx, discoveryIntegrationSpaceID,
+		"test.disco-g-retired", "1.0.0"); !errors.Is(err, ErrDiscoveryNotVisible) {
+		t.Fatalf("retired-owner detail err = %v, want ErrDiscoveryNotVisible", err)
+	}
+
+	// An approved owner is untouched — the predicate narrows, it does not
+	// swallow the catalog.
+	if _, err := catalogStore.LoadDiscoverable(ctx, discoveryIntegrationSpaceID,
+		"test.disco-a-public", "1.0.0"); err != nil {
+		t.Fatalf("an approved-owner row was hidden: %v", err)
+	}
+}

--- a/modules/card_template_catalog/store_discovery_mysql_integration_test.go
+++ b/modules/card_template_catalog/store_discovery_mysql_integration_test.go
@@ -1,0 +1,450 @@
+package card_template_catalog
+
+// PR-C D5 real-MySQL evidence for the discovery read model.
+//
+// The claim these tests exist to defend is an ordering one: visibility, block
+// state and the caller's discover grant are settled *inside* the predicate, so
+// they apply before LIMIT. That is a property of the SQL, not of the Go around
+// it — sqlmock would only replay whatever rows the test itself handed back, so
+// it can assert the arguments but never the predicate. The distinction matters
+// because the failure mode of post-filtering is silent: pages get shorter, the
+// has_more flag starts lying, and the number of missing rows becomes a count
+// oracle over the private catalog.
+//
+// The manager index is exercised in the same file because it is the deliberate
+// opposite: no visibility predicate at all, since hiding blocked and disabled
+// templates from an operator would remove exactly the rows an incident is
+// about. Asserting both against one seeded fixture is what makes the contrast
+// checkable rather than merely documented.
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl"
+)
+
+const discoveryIntegrationSpaceID = "space-discovery"
+
+// seedDiscoveryVersion writes one claim + artifact pair. blocked stamps the
+// artifact the way Block does, which is the only signal ListDiscoverable uses.
+func seedDiscoveryVersion(
+	t *testing.T, db *sql.DB, id cardtmpl.ID, version, visibility string, blocked bool,
+) {
+	t.Helper()
+	if _, err := db.Exec(`INSERT INTO card_template_version_claim
+        (template_id, version, source) VALUES (?, ?, 'dynamic')`,
+		string(id), version); err != nil {
+		t.Fatalf("seed discovery claim %s@%s: %v", id, version, err)
+	}
+	blockedAt := "NULL"
+	if blocked {
+		blockedAt = "CURRENT_TIMESTAMP(6)"
+	}
+	if _, err := db.Exec(`INSERT INTO card_template_artifact
+        (template_id, version, owner, visibility, engine_contract, protocol,
+         contract_version, canonical_bundle, content_sha256, created_by, blocked_at)
+        VALUES (?, ?, 'docs', ?, ?, ?, '1.0.0', ?, ?, 'admin-1', `+blockedAt+`)`,
+		string(id), version, visibility, cardtmpl.JSONTemplateEngineV1, cardtmpl.Protocol,
+		`{"canonical":true}`, strings.Repeat("b", 64)); err != nil {
+		t.Fatalf("seed discovery artifact %s@%s: %v", id, version, err)
+	}
+}
+
+func seedDiscoveryActivation(t *testing.T, db *sql.DB, id cardtmpl.ID, version string) {
+	t.Helper()
+	if _, err := db.Exec(`INSERT INTO card_template_activation
+        (template_id, active_version, status, revision, updated_by, reason, change_ticket)
+        VALUES (?, ?, 'active', 1, 'admin-1', 'pilot', 'CHG-D1')`,
+		string(id), version); err != nil {
+		t.Fatalf("seed discovery activation %s: %v", id, err)
+	}
+}
+
+// seedSpaceDiscoverGrant writes the only canonical shape a `space` principal
+// has: global scope, discover-only. The CHECK constraints reject anything else,
+// so a test that drifts from the D2 shape fails at INSERT rather than silently
+// proving something the production writer could never create.
+func seedSpaceDiscoverGrant(t *testing.T, db *sql.DB, id cardtmpl.ID, spaceID, status string) {
+	t.Helper()
+	discover := 1
+	if status != string(GrantStatusActive) {
+		discover = 0
+	}
+	if _, err := db.Exec(`INSERT INTO card_template_grant
+        (template_id, principal_type, principal_id, scope_space_id, status,
+         can_discover, can_send, can_edit, revision, updated_by, reason, change_ticket)
+        VALUES (?, 'space', ?, '', ?, ?, 0, 0, 1, 'admin-1', 'pilot', 'CHG-D2')`,
+		string(id), spaceID, status, discover); err != nil {
+		t.Fatalf("seed space grant %s: %v", id, err)
+	}
+}
+
+func discoveryIntegrationContext(t *testing.T) context.Context {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	t.Cleanup(cancel)
+	return ctx
+}
+
+func discoveryRowIDs(rows []DiscoveryRow) []string {
+	ids := make([]string, 0, len(rows))
+	for _, row := range rows {
+		ids = append(ids, string(row.ID)+"@"+row.Version)
+	}
+	return ids
+}
+
+// walkDiscoverable pages through the whole listing the way B1's cursor does and
+// returns the flattened result. Anything the predicate hides must be absent
+// from *every* page, not merely from the first.
+func walkDiscoverable(
+	t *testing.T, ctx context.Context, s *store, spaceID string, limit int,
+) []DiscoveryRow {
+	t.Helper()
+	var (
+		all          []DiscoveryRow
+		afterID      cardtmpl.ID
+		afterVersion string
+	)
+	for page := 0; page < 20; page++ {
+		rows, more, err := s.ListDiscoverable(ctx, spaceID, afterID, afterVersion, limit)
+		if err != nil {
+			t.Fatalf("ListDiscoverable page %d: %v", page, err)
+		}
+		if len(rows) > limit {
+			t.Fatalf("page %d returned %d rows over the limit %d", page, len(rows), limit)
+		}
+		if more && len(rows) != limit {
+			t.Fatalf("page %d claims more rows follow but returned a short page of %d",
+				page, len(rows))
+		}
+		all = append(all, rows...)
+		if !more {
+			return all
+		}
+		last := rows[len(rows)-1]
+		afterID, afterVersion = last.ID, last.Version
+	}
+	t.Fatal("cursor never terminated")
+	return nil
+}
+
+// seedDiscoveryFixture lays out one row of each kind the predicate must
+// distinguish, interleaved in primary-key order so that a hidden row sits
+// between two visible ones. That interleaving is the point: if filtering ran
+// after LIMIT, the hidden middle row would eat a page slot and the walk below
+// would come back short.
+func seedDiscoveryFixture(t *testing.T, db *sql.DB) {
+	t.Helper()
+	seedDiscoveryVersion(t, db, "test.disco-a-public", "1.0.0", cardtmpl.CatalogVisibilityPublic, false)
+	seedDiscoveryVersion(t, db, "test.disco-b-private", "1.0.0", cardtmpl.CatalogVisibilityPrivate, false)
+	seedDiscoveryVersion(t, db, "test.disco-c-granted", "1.0.0", cardtmpl.CatalogVisibilityPrivate, false)
+	seedDiscoveryVersion(t, db, "test.disco-d-blocked", "1.0.0", cardtmpl.CatalogVisibilityPublic, true)
+	seedDiscoveryVersion(t, db, "test.disco-e-revoked", "1.0.0", cardtmpl.CatalogVisibilityPrivate, false)
+	seedDiscoveryVersion(t, db, "test.disco-f-public", "1.0.0", cardtmpl.CatalogVisibilityPublic, false)
+	seedDiscoveryVersion(t, db, "test.disco-f-public", "2.0.0", cardtmpl.CatalogVisibilityPublic, false)
+	seedDiscoveryActivation(t, db, "test.disco-f-public", "1.0.0")
+
+	seedSpaceDiscoverGrant(t, db, "test.disco-c-granted", discoveryIntegrationSpaceID,
+		string(GrantStatusActive))
+	seedSpaceDiscoverGrant(t, db, "test.disco-e-revoked", discoveryIntegrationSpaceID,
+		string(GrantStatusRevoked))
+	// Another Space holds an active grant on the same private row. It must not
+	// widen what this Space can see; a grant that leaked across Spaces would
+	// make the whole per-Space model decorative.
+	seedSpaceDiscoverGrant(t, db, "test.disco-b-private", "space-someone-else",
+		string(GrantStatusActive))
+}
+
+// The visible set is exactly: public unblocked rows, plus private rows this
+// Space holds an *active* discover grant on. Everything else — private without
+// a grant, blocked regardless of visibility, and a tombstoned grant — is absent
+// from every page.
+func TestListDiscoverableFiltersBeforePagingRealMySQL(t *testing.T) {
+	db := newCatalogStoreIntegrationDB(t)
+	seedDiscoveryFixture(t, db)
+	catalogStore := newStore(db)
+	ctx := discoveryIntegrationContext(t)
+
+	want := []string{
+		"test.disco-a-public@1.0.0",
+		"test.disco-c-granted@1.0.0",
+		"test.disco-f-public@1.0.0",
+		"test.disco-f-public@2.0.0",
+	}
+	// A limit of 1 forces every boundary to be a page boundary, so a hidden row
+	// consuming a slot would show up as a short or empty page rather than as a
+	// merely reordered result.
+	for _, limit := range []int{1, 2, 50} {
+		got := discoveryRowIDs(walkDiscoverable(t, ctx, catalogStore, discoveryIntegrationSpaceID, limit))
+		if strings.Join(got, ",") != strings.Join(want, ",") {
+			t.Fatalf("limit %d walked %v, want %v", limit, got, want)
+		}
+	}
+
+	// The same walk from a Space with no grants at all sees only public rows.
+	// The difference between the two sets is exactly the granted row, which is
+	// what "the grant is applied in the predicate" means observationally.
+	ungranted := discoveryRowIDs(walkDiscoverable(t, ctx, catalogStore, "space-no-grants", 2))
+	wantUngranted := []string{
+		"test.disco-a-public@1.0.0",
+		"test.disco-f-public@1.0.0",
+		"test.disco-f-public@2.0.0",
+	}
+	if strings.Join(ungranted, ",") != strings.Join(wantUngranted, ",") {
+		t.Fatalf("ungranted Space walked %v, want %v", ungranted, wantUngranted)
+	}
+}
+
+// has_more is a promise about the *next* page, and the +1 peek is how it is
+// kept. A row that exists only beyond the limit must flip the flag without
+// appearing in the page.
+func TestListDiscoverableReportsMoreWithoutLeakingTheNextRowRealMySQL(t *testing.T) {
+	db := newCatalogStoreIntegrationDB(t)
+	seedDiscoveryFixture(t, db)
+	catalogStore := newStore(db)
+	ctx := discoveryIntegrationContext(t)
+
+	rows, more, err := catalogStore.ListDiscoverable(ctx, discoveryIntegrationSpaceID, "", "", 1)
+	if err != nil {
+		t.Fatalf("ListDiscoverable: %v", err)
+	}
+	if len(rows) != 1 || !more {
+		t.Fatalf("rows = %v more = %v", discoveryRowIDs(rows), more)
+	}
+	if rows[0].ID != "test.disco-a-public" {
+		t.Fatalf("first row = %+v", rows[0])
+	}
+
+	// The last visible row must not claim a successor. Reading the peek row as
+	// part of the page would report more=true here and hand the caller a cursor
+	// that returns nothing.
+	last, moreAfterLast, err := catalogStore.ListDiscoverable(
+		ctx, discoveryIntegrationSpaceID, "test.disco-f-public", "1.0.0", 10)
+	if err != nil {
+		t.Fatalf("ListDiscoverable tail: %v", err)
+	}
+	if moreAfterLast || len(last) != 1 || last[0].Version != "2.0.0" {
+		t.Fatalf("tail = %v more = %v", discoveryRowIDs(last), moreAfterLast)
+	}
+}
+
+// active_for_new_send follows the activation pointer exactly. A template with
+// two versions and a pointer at the older one must report the newer as
+// inactive, or a producer would send against a version the runtime will not
+// resolve.
+func TestListDiscoverableReportsTheActivationPointerRealMySQL(t *testing.T) {
+	db := newCatalogStoreIntegrationDB(t)
+	seedDiscoveryFixture(t, db)
+	catalogStore := newStore(db)
+	ctx := discoveryIntegrationContext(t)
+
+	rows := walkDiscoverable(t, ctx, catalogStore, discoveryIntegrationSpaceID, 50)
+	active := map[string]bool{}
+	for _, row := range rows {
+		active[string(row.ID)+"@"+row.Version] = row.ActiveForNewSend
+	}
+	if !active["test.disco-f-public@1.0.0"] {
+		t.Fatal("the pointed-at version is not reported active")
+	}
+	if active["test.disco-f-public@2.0.0"] {
+		t.Fatal("a newer unpointed version is reported active")
+	}
+	if active["test.disco-a-public@1.0.0"] {
+		t.Fatal("a template with no activation row is reported active")
+	}
+}
+
+// B2 has one negative answer. Unknown, invisible and blocked must be
+// indistinguishable at this layer, because the handler above cannot invent a
+// distinction the store did not make.
+func TestLoadDiscoverableGivesOneIndistinguishableMissRealMySQL(t *testing.T) {
+	db := newCatalogStoreIntegrationDB(t)
+	seedDiscoveryFixture(t, db)
+	catalogStore := newStore(db)
+	ctx := discoveryIntegrationContext(t)
+
+	row, err := catalogStore.LoadDiscoverable(ctx, discoveryIntegrationSpaceID,
+		"test.disco-c-granted", "1.0.0")
+	if err != nil {
+		t.Fatalf("granted private LoadDiscoverable: %v", err)
+	}
+	if row.Visibility != cardtmpl.CatalogVisibilityPrivate || row.Owner != "docs" {
+		t.Fatalf("row = %+v", row)
+	}
+
+	for _, miss := range []struct {
+		name    string
+		id      cardtmpl.ID
+		version string
+	}{
+		{"unknown template", "test.disco-nonexistent", "1.0.0"},
+		{"known template, unknown version", "test.disco-a-public", "9.9.9"},
+		{"private without a grant", "test.disco-b-private", "1.0.0"},
+		{"private with a revoked grant", "test.disco-e-revoked", "1.0.0"},
+		{"blocked but public", "test.disco-d-blocked", "1.0.0"},
+	} {
+		_, err := catalogStore.LoadDiscoverable(ctx, discoveryIntegrationSpaceID, miss.id, miss.version)
+		if !errors.Is(err, ErrDiscoveryNotVisible) {
+			t.Fatalf("%s: err = %v, want ErrDiscoveryNotVisible", miss.name, err)
+		}
+	}
+}
+
+// Static templates are private by default, so a granted static card is only
+// visible through this probe. The probe must honor the same three predicates as
+// the dynamic path — right Space, active status, discover permission.
+func TestStaticDiscoverGrantsHonorsSpaceAndStatusRealMySQL(t *testing.T) {
+	db := newCatalogStoreIntegrationDB(t)
+	seedDiscoveryFixture(t, db)
+	catalogStore := newStore(db)
+	ctx := discoveryIntegrationContext(t)
+
+	probe := []cardtmpl.ID{
+		"test.disco-c-granted", "test.disco-e-revoked",
+		"test.disco-b-private", "test.disco-nonexistent",
+	}
+	granted, err := catalogStore.StaticDiscoverGrants(ctx, discoveryIntegrationSpaceID, probe)
+	if err != nil {
+		t.Fatalf("StaticDiscoverGrants: %v", err)
+	}
+	if len(granted) != 1 {
+		t.Fatalf("granted = %v, want only the active grant", granted)
+	}
+	if _, ok := granted["test.disco-c-granted"]; !ok {
+		t.Fatalf("granted = %v", granted)
+	}
+
+	// An empty Space cannot hold a grant; probing with one must not degrade
+	// into a query that matches the '' sentinel rows.
+	empty, err := catalogStore.StaticDiscoverGrants(ctx, "  ", probe)
+	if err != nil || len(empty) != 0 {
+		t.Fatalf("blank Space: granted = %v err = %v", empty, err)
+	}
+	none, err := catalogStore.StaticDiscoverGrants(ctx, discoveryIntegrationSpaceID, nil)
+	if err != nil || len(none) != 0 {
+		t.Fatalf("empty probe: granted = %v err = %v", none, err)
+	}
+}
+
+// The IN-list is bounded so a caller cannot turn one request into an unbounded
+// query. Truncation drops the tail rather than failing, which is safe only
+// because dropping a grant can never widen what is shown.
+func TestStaticDiscoverGrantsBoundsTheProbeRealMySQL(t *testing.T) {
+	db := newCatalogStoreIntegrationDB(t)
+	seedDiscoveryFixture(t, db)
+	catalogStore := newStore(db)
+	ctx := discoveryIntegrationContext(t)
+
+	oversized := make([]cardtmpl.ID, 0, maxStaticGrantProbe+8)
+	for i := 0; i < maxStaticGrantProbe+7; i++ {
+		oversized = append(oversized, cardtmpl.ID("test.disco-filler-"+string(rune('a'+i%26))+
+			strings.Repeat("x", i%3)))
+	}
+	// The genuinely granted ID sits past the bound, so it must be dropped.
+	oversized = append(oversized, "test.disco-c-granted")
+	granted, err := catalogStore.StaticDiscoverGrants(ctx, discoveryIntegrationSpaceID, oversized)
+	if err != nil {
+		t.Fatalf("oversized probe: %v", err)
+	}
+	if len(granted) != 0 {
+		t.Fatalf("a probe past the bound was answered: %v", granted)
+	}
+}
+
+// The operator index is the deliberate inverse of B1: every claimed template
+// appears, including the blocked and the ungranted, with the counts an incident
+// responder needs.
+func TestListTemplatesShowsTheWholeCatalogToOperatorsRealMySQL(t *testing.T) {
+	db := newCatalogStoreIntegrationDB(t)
+	seedDiscoveryFixture(t, db)
+	catalogStore := newStore(db)
+	ctx := discoveryIntegrationContext(t)
+
+	page, err := catalogStore.ListTemplates(ctx, "", 0)
+	if err != nil {
+		t.Fatalf("ListTemplates: %v", err)
+	}
+	summaries := map[cardtmpl.ID]ManagerTemplateSummary{}
+	for _, summary := range page.Templates {
+		summaries[summary.ID] = summary
+	}
+	if len(summaries) != 6 {
+		t.Fatalf("manager index reported %d templates: %+v", len(summaries), page.Templates)
+	}
+	if _, ok := summaries["test.disco-d-blocked"]; !ok {
+		t.Fatal("the blocked template is missing from the operator index")
+	}
+	if _, ok := summaries["test.disco-b-private"]; !ok {
+		t.Fatal("an ungranted private template is missing from the operator index")
+	}
+	if got := summaries["test.disco-d-blocked"].BlockedVersions; got != 1 {
+		t.Fatalf("blocked_versions = %d", got)
+	}
+	multi := summaries["test.disco-f-public"]
+	if multi.VersionCount != 2 || multi.LatestVersion != "2.0.0" {
+		t.Fatalf("multi-version summary = %+v", multi)
+	}
+	if multi.ActiveVersion != "1.0.0" || multi.ActivationStatus != "active" {
+		t.Fatalf("activation pointer lost in the summary: %+v", multi)
+	}
+	if summaries["test.disco-a-public"].ActivationStatus != "" {
+		t.Fatalf("a template with no activation row claimed a status: %+v",
+			summaries["test.disco-a-public"])
+	}
+}
+
+// Keyset paging, not offset: a publish landing between two pages must not make
+// the operator skip a row.
+func TestListTemplatesPagesByKeysetRealMySQL(t *testing.T) {
+	db := newCatalogStoreIntegrationDB(t)
+	seedDiscoveryFixture(t, db)
+	catalogStore := newStore(db)
+	ctx := discoveryIntegrationContext(t)
+
+	first, err := catalogStore.ListTemplates(ctx, "", 2)
+	if err != nil {
+		t.Fatalf("first page: %v", err)
+	}
+	if len(first.Templates) != 2 || first.NextCursor != "test.disco-b-private" {
+		t.Fatalf("first page = %+v cursor = %q", first.Templates, first.NextCursor)
+	}
+
+	// A template that sorts before the cursor is inserted between the reads.
+	// Under offset paging this would shift every later row and the operator
+	// would silently lose one; under keyset it simply is not in the tail.
+	seedDiscoveryVersion(t, db, "test.disco-aa-late", "1.0.0", cardtmpl.CatalogVisibilityPublic, false)
+
+	var walked []cardtmpl.ID
+	for _, summary := range first.Templates {
+		walked = append(walked, summary.ID)
+	}
+	cursor := first.NextCursor
+	for page := 0; page < 20 && cursor != ""; page++ {
+		next, err := catalogStore.ListTemplates(ctx, cursor, 2)
+		if err != nil {
+			t.Fatalf("page after %q: %v", cursor, err)
+		}
+		for _, summary := range next.Templates {
+			walked = append(walked, summary.ID)
+		}
+		cursor = next.NextCursor
+	}
+	want := []cardtmpl.ID{
+		"test.disco-a-public", "test.disco-b-private", "test.disco-c-granted",
+		"test.disco-d-blocked", "test.disco-e-revoked", "test.disco-f-public",
+	}
+	if len(walked) != len(want) {
+		t.Fatalf("walked %v, want %v", walked, want)
+	}
+	for i := range want {
+		if walked[i] != want[i] {
+			t.Fatalf("walked %v, want %v", walked, want)
+		}
+	}
+}

--- a/modules/card_template_catalog/store_grant.go
+++ b/modules/card_template_catalog/store_grant.go
@@ -140,7 +140,11 @@ const (
          can_discover, can_send, can_edit, revision, updated_by, reason, change_ticket, updated_at
         FROM card_template_grant
         WHERE template_id = ?
-        ORDER BY principal_type, principal_id, scope_space_id
+        -- Active rows first. A revoke writes a permanent tombstone rather than
+        -- deleting, so without this a template with a long revoke history would
+        -- let dead rows consume the bounded summary and hide the grants that
+        -- are actually in force.
+        ORDER BY status ASC, principal_type, principal_id, scope_space_id
         LIMIT ?`
 )
 

--- a/modules/card_template_catalog/store_grant.go
+++ b/modules/card_template_catalog/store_grant.go
@@ -1,0 +1,508 @@
+package card_template_catalog
+
+// PR-C D2/D4（spec: .octospec/tasks/cardtmpl-runtime-catalog-grants-discovery/
+// brief.md）：template-ID 级 grant 的持久化与 CAS。
+//
+//   - identity = (template_id, principal_type, principal_id, scope_space_id)
+//     unique；global scope 用 canonical 空串 sentinel；
+//   - create 要求 expected_revision=0；update/revoke 要求精确当前 revision，
+//     并发只有一个赢家；revoke 写 tombstone（权限清零 + revision 递增），
+//     绝不物理删除 —— revoke→recreate 拿不回旧 revision（防 ABA）；
+//   - grant target 只要求「至少存在一个 permanent version claim」（任意
+//     source），用同事务 SELECT ... FOR UPDATE 验证，不造跨 static/dynamic
+//     的脆弱 FK；
+//   - 状态写与 append-only audit 同事务提交（audit 记 principal/scope 与
+//     before/after permissions/revision，不存 token/卡片 data）；
+//   - 精确覆盖顺序（exact-over-global、tombstone 屏蔽）collapse 在唯一的
+//     resolveGrantRows 上，Slice 3 的 one-snapshot authorizer 复用同一函数，
+//     不允许第二处实现。
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl"
+)
+
+type GrantPrincipalType string
+
+const (
+	GrantPrincipalBot              GrantPrincipalType = "bot"
+	GrantPrincipalInternalProducer GrantPrincipalType = "internal_producer"
+	GrantPrincipalSpace            GrantPrincipalType = "space"
+)
+
+type GrantStatus string
+
+const (
+	GrantStatusActive  GrantStatus = "active"
+	GrantStatusRevoked GrantStatus = "revoked"
+
+	auditOperationGrant  = "grant"
+	auditOperationRevoke = "revoke"
+
+	maxGrantPrincipalIDRunes = 128
+	maxGrantScopeSpaceRunes  = 128
+)
+
+var (
+	ErrGrantRequestInvalid = errors.New("card template grant request invalid")
+	ErrGrantConflict       = errors.New("card template grant revision conflict")
+	ErrGrantTargetUnknown  = errors.New("card template grant target has no version claim")
+	ErrGrantNotFound       = errors.New("card template grant does not exist")
+	ErrGrantAlreadyRevoked = errors.New("card template grant is already revoked")
+)
+
+type GrantPermissions struct {
+	Discover bool
+	Send     bool
+	Edit     bool
+}
+
+type GrantIdentity struct {
+	TemplateID    cardtmpl.ID
+	PrincipalType GrantPrincipalType
+	PrincipalID   string
+	// ScopeSpaceID 的 canonical 空串表示 global scope。
+	ScopeSpaceID string
+}
+
+type GrantRecord struct {
+	Identity     GrantIdentity
+	Status       GrantStatus
+	Permissions  GrantPermissions
+	Revision     uint64
+	UpdatedBy    string
+	Reason       string
+	ChangeTicket string
+	UpdatedAt    time.Time
+}
+
+type UpsertGrantRequest struct {
+	Identity         GrantIdentity
+	Permissions      GrantPermissions
+	ExpectedRevision uint64
+	ActorUID         string
+	Reason           string
+	ChangeTicket     string
+}
+
+type RevokeGrantRequest struct {
+	Identity         GrantIdentity
+	ExpectedRevision uint64
+	ActorUID         string
+	Reason           string
+	ChangeTicket     string
+}
+
+type GrantResult struct {
+	Record  GrantRecord
+	Created bool
+}
+
+// GrantDecision 是 resolveGrantRows 的输出：生效权限 + 命中的 scope 来源
+// （"exact" / "global" / ""），供 receipt/日志与授权判定使用。
+type GrantDecision struct {
+	Allowed     GrantPermissions
+	ScopeSource string
+	Revision    uint64
+}
+
+const (
+	selectGrantForUpdateSQL = `SELECT status, can_discover, can_send, can_edit, revision
+        FROM card_template_grant
+        WHERE template_id = ? AND principal_type = ? AND principal_id = ? AND scope_space_id = ?
+        FOR UPDATE`
+	selectAnyClaimForUpdateSQL = `SELECT version FROM card_template_version_claim
+        WHERE template_id = ?
+        LIMIT 1
+        FOR UPDATE`
+	insertGrantSQL = `INSERT INTO card_template_grant
+        (template_id, principal_type, principal_id, scope_space_id, status,
+         can_discover, can_send, can_edit, revision, updated_by, reason, change_ticket)
+        VALUES (?, ?, ?, ?, 'active', ?, ?, ?, 1, ?, ?, ?)`
+	updateGrantSQL = `UPDATE card_template_grant
+        SET status = ?, can_discover = ?, can_send = ?, can_edit = ?,
+            revision = revision + 1, updated_by = ?, reason = ?, change_ticket = ?,
+            updated_at = CURRENT_TIMESTAMP(6)
+        WHERE template_id = ? AND principal_type = ? AND principal_id = ? AND scope_space_id = ?
+          AND revision = ?`
+	insertGrantAuditSQL = `INSERT INTO card_template_audit
+        (actor_uid, operation, template_id, version, previous_version, resulting_version,
+         previous_revision, resulting_revision, principal_type, principal_id, scope_space_id,
+         previous_permissions, resulting_permissions, content_sha256, result, reason, change_ticket)
+        VALUES (?, ?, ?, '', '', '', ?, ?, ?, ?, ?, ?, ?, '', 'ok', ?, ?)`
+	selectGrantsByTemplateSQL = `SELECT principal_type, principal_id, scope_space_id, status,
+         can_discover, can_send, can_edit, revision, updated_by, reason, change_ticket, updated_at
+        FROM card_template_grant
+        WHERE template_id = ?
+        ORDER BY principal_type, principal_id, scope_space_id
+        LIMIT ?`
+)
+
+func (s *store) UpsertGrant(ctx context.Context, request UpsertGrantRequest) (GrantResult, error) {
+	if err := validateUpsertGrantRequest(request); err != nil {
+		return GrantResult{}, err
+	}
+	return executeStateWithRetry(ctx, func() (GrantResult, error) {
+		return s.upsertGrantOnce(ctx, request)
+	})
+}
+
+func (s *store) upsertGrantOnce(ctx context.Context, request UpsertGrantRequest) (GrantResult, error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return GrantResult{}, fmt.Errorf("card template catalog: begin grant: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if err := requireAnyVersionClaim(ctx, tx, request.Identity.TemplateID); err != nil {
+		return GrantResult{}, err
+	}
+	current, exists, err := loadGrantForUpdate(ctx, tx, request.Identity)
+	if err != nil {
+		return GrantResult{}, err
+	}
+	if !exists {
+		if request.ExpectedRevision != 0 {
+			return GrantResult{}, fmt.Errorf("%w: expected %d, grant does not exist",
+				ErrGrantConflict, request.ExpectedRevision)
+		}
+		if _, err := tx.ExecContext(ctx, insertGrantSQL,
+			string(request.Identity.TemplateID), string(request.Identity.PrincipalType),
+			request.Identity.PrincipalID, request.Identity.ScopeSpaceID,
+			request.Permissions.Discover, request.Permissions.Send, request.Permissions.Edit,
+			request.ActorUID, request.Reason, request.ChangeTicket,
+		); err != nil {
+			if isDuplicateKey(err) {
+				return GrantResult{}, fmt.Errorf("%w: concurrent first grant", ErrGrantConflict)
+			}
+			return GrantResult{}, fmt.Errorf("card template catalog: insert grant: %w", err)
+		}
+	} else {
+		// update / re-activate-tombstone 都要求携带当前精确 revision；对
+		// revoked row 不能再用 expected_revision=0 伪装 create（D4 反 ABA）。
+		if request.ExpectedRevision != current.Revision {
+			return GrantResult{}, fmt.Errorf("%w: expected %d, current %d",
+				ErrGrantConflict, request.ExpectedRevision, current.Revision)
+		}
+		result, err := tx.ExecContext(ctx, updateGrantSQL,
+			GrantStatusActive, request.Permissions.Discover, request.Permissions.Send, request.Permissions.Edit,
+			request.ActorUID, request.Reason, request.ChangeTicket,
+			string(request.Identity.TemplateID), string(request.Identity.PrincipalType),
+			request.Identity.PrincipalID, request.Identity.ScopeSpaceID, request.ExpectedRevision,
+		)
+		if err != nil {
+			return GrantResult{}, fmt.Errorf("card template catalog: update grant: %w", err)
+		}
+		if err := requireOneStateRow(result); err != nil {
+			return GrantResult{}, err
+		}
+	}
+	nextRevision := current.Revision + 1
+	if err := insertGrantAudit(ctx, tx, grantAudit{
+		actorUID: request.ActorUID, operation: auditOperationGrant,
+		identity:          request.Identity,
+		previousRevision:  current.Revision,
+		resultingRevision: nextRevision,
+		previousPerms:     current.Permissions,
+		previousStatus:    current.Status,
+		previousExists:    exists,
+		resultingPerms:    request.Permissions,
+		reason:            request.Reason,
+		changeTicket:      request.ChangeTicket,
+	}); err != nil {
+		return GrantResult{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return GrantResult{}, fmt.Errorf("card template catalog: commit grant: %w", err)
+	}
+	return GrantResult{
+		Record: GrantRecord{
+			Identity: request.Identity, Status: GrantStatusActive,
+			Permissions: request.Permissions, Revision: nextRevision,
+			UpdatedBy: request.ActorUID, Reason: request.Reason, ChangeTicket: request.ChangeTicket,
+		},
+		Created: !exists,
+	}, nil
+}
+
+func (s *store) RevokeGrant(ctx context.Context, request RevokeGrantRequest) (GrantResult, error) {
+	if err := validateRevokeGrantRequest(request); err != nil {
+		return GrantResult{}, err
+	}
+	return executeStateWithRetry(ctx, func() (GrantResult, error) {
+		return s.revokeGrantOnce(ctx, request)
+	})
+}
+
+func (s *store) revokeGrantOnce(ctx context.Context, request RevokeGrantRequest) (GrantResult, error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return GrantResult{}, fmt.Errorf("card template catalog: begin revoke: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	current, exists, err := loadGrantForUpdate(ctx, tx, request.Identity)
+	if err != nil {
+		return GrantResult{}, err
+	}
+	if !exists {
+		return GrantResult{}, fmt.Errorf("%w: %s/%s", ErrGrantNotFound,
+			request.Identity.PrincipalType, request.Identity.PrincipalID)
+	}
+	if current.Status == GrantStatusRevoked {
+		return GrantResult{}, fmt.Errorf("%w: revision %d", ErrGrantAlreadyRevoked, current.Revision)
+	}
+	if request.ExpectedRevision != current.Revision {
+		return GrantResult{}, fmt.Errorf("%w: expected %d, current %d",
+			ErrGrantConflict, request.ExpectedRevision, current.Revision)
+	}
+	result, err := tx.ExecContext(ctx, updateGrantSQL,
+		GrantStatusRevoked, false, false, false,
+		request.ActorUID, request.Reason, request.ChangeTicket,
+		string(request.Identity.TemplateID), string(request.Identity.PrincipalType),
+		request.Identity.PrincipalID, request.Identity.ScopeSpaceID, request.ExpectedRevision,
+	)
+	if err != nil {
+		return GrantResult{}, fmt.Errorf("card template catalog: revoke grant: %w", err)
+	}
+	if err := requireOneStateRow(result); err != nil {
+		return GrantResult{}, err
+	}
+	nextRevision := current.Revision + 1
+	if err := insertGrantAudit(ctx, tx, grantAudit{
+		actorUID: request.ActorUID, operation: auditOperationRevoke,
+		identity:          request.Identity,
+		previousRevision:  current.Revision,
+		resultingRevision: nextRevision,
+		previousPerms:     current.Permissions,
+		previousStatus:    current.Status,
+		previousExists:    true,
+		resultingPerms:    GrantPermissions{},
+		reason:            request.Reason,
+		changeTicket:      request.ChangeTicket,
+	}); err != nil {
+		return GrantResult{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return GrantResult{}, fmt.Errorf("card template catalog: commit revoke: %w", err)
+	}
+	return GrantResult{
+		Record: GrantRecord{
+			Identity: request.Identity, Status: GrantStatusRevoked,
+			Revision: nextRevision, UpdatedBy: request.ActorUID,
+			Reason: request.Reason, ChangeTicket: request.ChangeTicket,
+		},
+	}, nil
+}
+
+// ListGrants 返回 template 的 bounded grant 清单（manager detail 摘要用；
+// 普通 B1/B2 永不透出）。truncated=true 表示还有更多行未返回。
+func (s *store) ListGrants(ctx context.Context, id cardtmpl.ID, limit int) ([]GrantRecord, bool, error) {
+	if strings.TrimSpace(string(id)) == "" || limit < 1 {
+		return nil, false, fmt.Errorf("%w: list requires template and positive limit", ErrGrantRequestInvalid)
+	}
+	rows, err := s.db.QueryContext(ctx, selectGrantsByTemplateSQL, string(id), limit+1)
+	if err != nil {
+		return nil, false, fmt.Errorf("card template catalog: list grants: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	records := make([]GrantRecord, 0, limit)
+	for rows.Next() {
+		record := GrantRecord{Identity: GrantIdentity{TemplateID: id}}
+		var principalType, status string
+		if err := rows.Scan(&principalType, &record.Identity.PrincipalID, &record.Identity.ScopeSpaceID,
+			&status, &record.Permissions.Discover, &record.Permissions.Send, &record.Permissions.Edit,
+			&record.Revision, &record.UpdatedBy, &record.Reason, &record.ChangeTicket, &record.UpdatedAt,
+		); err != nil {
+			return nil, false, fmt.Errorf("card template catalog: scan grant: %w", err)
+		}
+		record.Identity.PrincipalType = GrantPrincipalType(principalType)
+		record.Status = GrantStatus(status)
+		records = append(records, record)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, false, fmt.Errorf("card template catalog: iterate grants: %w", err)
+	}
+	if len(records) > limit {
+		return records[:limit], true, nil
+	}
+	return records, false, nil
+}
+
+// resolveGrantRows 是 exact-over-global 覆盖顺序的唯一实现（D2）：
+// exact row 存在（active 或 tombstone）就完全遮蔽 global row —— active 按其
+// permission 判定、tombstone 直接拒绝；只有 exact row 不存在才看 global。
+// 权限绝不 union。
+func resolveGrantRows(exact, global *GrantRecord) GrantDecision {
+	row := exact
+	source := "exact"
+	if row == nil {
+		row = global
+		source = "global"
+	}
+	if row == nil {
+		return GrantDecision{}
+	}
+	decision := GrantDecision{ScopeSource: source, Revision: row.Revision}
+	if row.Status == GrantStatusActive {
+		decision.Allowed = row.Permissions
+	}
+	return decision
+}
+
+func validateGrantIdentity(identity GrantIdentity) error {
+	if strings.TrimSpace(string(identity.TemplateID)) == "" ||
+		string(identity.TemplateID) != strings.TrimSpace(string(identity.TemplateID)) {
+		return fmt.Errorf("%w: template id is required", ErrGrantRequestInvalid)
+	}
+	if !boundedRequiredText(identity.PrincipalID, maxGrantPrincipalIDRunes) ||
+		identity.PrincipalID != strings.TrimSpace(identity.PrincipalID) {
+		return fmt.Errorf("%w: principal id is required and bounded", ErrGrantRequestInvalid)
+	}
+	if identity.ScopeSpaceID != strings.TrimSpace(identity.ScopeSpaceID) ||
+		len([]rune(identity.ScopeSpaceID)) > maxGrantScopeSpaceRunes {
+		return fmt.Errorf("%w: scope space id must be trimmed and bounded", ErrGrantRequestInvalid)
+	}
+	switch identity.PrincipalType {
+	case GrantPrincipalBot, GrantPrincipalInternalProducer:
+		return nil
+	case GrantPrincipalSpace:
+		// D2 canonical shape：space principal 只有 principal_id=<space_id> +
+		// global sentinel scope 一种形状，杜绝 (principal space A, scope
+		// space B) 的跨租户组合。
+		if identity.ScopeSpaceID != "" {
+			return fmt.Errorf("%w: space principal must use the global scope sentinel", ErrGrantRequestInvalid)
+		}
+		return nil
+	default:
+		return fmt.Errorf("%w: principal type %q is not grantable", ErrGrantRequestInvalid, identity.PrincipalType)
+	}
+}
+
+func validateGrantPermissions(principalType GrantPrincipalType, permissions GrantPermissions) error {
+	// D2：active grant 至少一项权限，且 send/edit 必须伴随 discover（否则是
+	// capability/discovery 观察不到的暗授权）—— 合并后等价于必须包含 discover。
+	if !permissions.Discover {
+		return fmt.Errorf("%w: an active grant must include discover", ErrGrantRequestInvalid)
+	}
+	if principalType == GrantPrincipalSpace && (permissions.Send || permissions.Edit) {
+		return fmt.Errorf("%w: a space principal is discover-only", ErrGrantRequestInvalid)
+	}
+	return nil
+}
+
+func validateUpsertGrantRequest(request UpsertGrantRequest) error {
+	if err := validateGrantIdentity(request.Identity); err != nil {
+		return err
+	}
+	if err := validateGrantPermissions(request.Identity.PrincipalType, request.Permissions); err != nil {
+		return err
+	}
+	return validateGrantControlText(request.ActorUID, request.Reason, request.ChangeTicket)
+}
+
+func validateRevokeGrantRequest(request RevokeGrantRequest) error {
+	if err := validateGrantIdentity(request.Identity); err != nil {
+		return err
+	}
+	return validateGrantControlText(request.ActorUID, request.Reason, request.ChangeTicket)
+}
+
+func validateGrantControlText(actorUID, reason, changeTicket string) error {
+	if !boundedRequiredText(actorUID, maxActorUIDRunes) ||
+		!boundedRequiredText(reason, maxReasonRunes) ||
+		!boundedRequiredText(changeTicket, maxChangeTicketRunes) {
+		return fmt.Errorf("%w: actor, reason and change ticket are required and bounded", ErrGrantRequestInvalid)
+	}
+	return nil
+}
+
+// requireAnyVersionClaim 用同事务锁定验证 grant target 至少有一个 permanent
+// version claim（任意 source；不以 activation 存在为前提，D4）。
+func requireAnyVersionClaim(ctx context.Context, tx *sql.Tx, id cardtmpl.ID) error {
+	var version string
+	err := tx.QueryRowContext(ctx, selectAnyClaimForUpdateSQL, string(id)).Scan(&version)
+	if errors.Is(err, sql.ErrNoRows) {
+		return fmt.Errorf("%w: %s", ErrGrantTargetUnknown, id)
+	}
+	if err != nil {
+		return fmt.Errorf("card template catalog: lock grant target claim: %w", err)
+	}
+	return nil
+}
+
+func loadGrantForUpdate(ctx context.Context, tx *sql.Tx, identity GrantIdentity) (GrantRecord, bool, error) {
+	record := GrantRecord{Identity: identity}
+	var status string
+	err := tx.QueryRowContext(ctx, selectGrantForUpdateSQL,
+		string(identity.TemplateID), string(identity.PrincipalType),
+		identity.PrincipalID, identity.ScopeSpaceID,
+	).Scan(&status, &record.Permissions.Discover, &record.Permissions.Send,
+		&record.Permissions.Edit, &record.Revision)
+	if errors.Is(err, sql.ErrNoRows) {
+		return GrantRecord{Identity: identity}, false, nil
+	}
+	if err != nil {
+		return GrantRecord{}, false, fmt.Errorf("card template catalog: load grant: %w", err)
+	}
+	record.Status = GrantStatus(status)
+	if record.Status != GrantStatusActive && record.Status != GrantStatusRevoked {
+		return GrantRecord{}, false, fmt.Errorf("%w: invalid grant status %q", ErrCatalogIntegrity, status)
+	}
+	return record, true, nil
+}
+
+type grantAudit struct {
+	actorUID          string
+	operation         string
+	identity          GrantIdentity
+	previousRevision  uint64
+	resultingRevision uint64
+	previousPerms     GrantPermissions
+	previousStatus    GrantStatus
+	previousExists    bool
+	resultingPerms    GrantPermissions
+	reason            string
+	changeTicket      string
+}
+
+func insertGrantAudit(ctx context.Context, tx *sql.Tx, audit grantAudit) error {
+	previousLabel := ""
+	if audit.previousExists && audit.previousStatus == GrantStatusActive {
+		previousLabel = grantPermissionsLabel(audit.previousPerms)
+	}
+	resultingLabel := ""
+	if audit.operation == auditOperationGrant {
+		resultingLabel = grantPermissionsLabel(audit.resultingPerms)
+	}
+	if _, err := tx.ExecContext(ctx, insertGrantAuditSQL,
+		audit.actorUID, audit.operation, string(audit.identity.TemplateID),
+		audit.previousRevision, audit.resultingRevision,
+		string(audit.identity.PrincipalType), audit.identity.PrincipalID, audit.identity.ScopeSpaceID,
+		previousLabel, resultingLabel, audit.reason, audit.changeTicket,
+	); err != nil {
+		return fmt.Errorf("card template catalog: insert %s audit: %w", audit.operation, err)
+	}
+	return nil
+}
+
+// grantPermissionsLabel 输出 audit 用的 canonical 权限标签（固定顺序）。
+func grantPermissionsLabel(permissions GrantPermissions) string {
+	parts := make([]string, 0, 3)
+	if permissions.Discover {
+		parts = append(parts, "discover")
+	}
+	if permissions.Send {
+		parts = append(parts, "send")
+	}
+	if permissions.Edit {
+		parts = append(parts, "edit")
+	}
+	return strings.Join(parts, ",")
+}

--- a/modules/card_template_catalog/store_grant_mysql_integration_test.go
+++ b/modules/card_template_catalog/store_grant_mysql_integration_test.go
@@ -48,6 +48,69 @@ func countGrantAuditRows(t *testing.T, db *sql.DB, operation string) int {
 	return count
 }
 
+// PR-C review round 5 (Jerry-Xin, plus the S4 identity item): the grant table's
+// CHECK constraints are the last line that holds when a write does not come
+// through the Go validator, so every domain the validator enforces has to be
+// stated in the schema too.
+//
+// The two gaps this covers were both reachable by direct SQL against the
+// previous schema. can_send/can_edit outside {0,1} on an active row was caught
+// only downstream, where GrantPermissions scans into Go bools and the driver
+// refuses the value — fail-closed by accident of the scan type rather than by
+// the schema. A blank principal_id was accepted outright.
+func TestGrantSchemaRejectsWritesTheValidatorWouldRefuseRealMySQL(t *testing.T) {
+	db := newCatalogStoreIntegrationDB(t)
+	seedGrantTargetClaim(t, db)
+
+	insert := `INSERT INTO card_template_grant
+        (template_id, principal_type, principal_id, scope_space_id, status,
+         can_discover, can_send, can_edit, revision, updated_by, reason, change_ticket)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, 1, 'operator', 'reason', 'ticket')`
+	tmpl := string(grantIntegrationTemplateID)
+
+	for _, test := range []struct {
+		name string
+		args []any
+	}{
+		{
+			name: "can_send outside the boolean domain",
+			args: []any{tmpl, "bot", "bot-send", "", "active", 1, 7, 0},
+		},
+		{
+			name: "can_edit outside the boolean domain",
+			args: []any{tmpl, "bot", "bot-edit", "", "active", 1, 0, 2},
+		},
+		{
+			// Redundant with chk_card_template_grant_shape, which already pins
+			// can_discover to 1 on an active row and 0 on a tombstone — so this
+			// cell passes with or without the new constraint. It is here because
+			// the column belongs in the stated domain regardless of which
+			// constraint currently enforces it.
+			name: "can_discover outside the boolean domain",
+			args: []any{tmpl, "bot", "bot-discover", "", "active", 3, 0, 0},
+		},
+		{
+			name: "a grant with no principal",
+			args: []any{tmpl, "bot", "", "", "active", 1, 1, 0},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			// A distinct principal per case, so that a schema which wrongly
+			// accepts one row cannot make a later case fail on a duplicate key
+			// instead of on its own claim.
+			if _, err := db.Exec(insert, test.args...); err == nil {
+				t.Fatal("the schema accepted a row the validator would refuse")
+			}
+		})
+	}
+
+	// The canonical shape it must still accept, so the constraints are not
+	// merely rejecting everything.
+	if _, err := db.Exec(insert, tmpl, "bot", "bot-valid", "", "active", 1, 1, 1); err != nil {
+		t.Fatalf("a valid grant was rejected: %v", err)
+	}
+}
+
 func TestStoreGrantLifecycleRealMySQL(t *testing.T) {
 	db := newCatalogStoreIntegrationDB(t)
 	seedGrantTargetClaim(t, db)

--- a/modules/card_template_catalog/store_grant_mysql_integration_test.go
+++ b/modules/card_template_catalog/store_grant_mysql_integration_test.go
@@ -1,0 +1,260 @@
+package card_template_catalog
+
+// PR-C Slice 2 (D4) real-MySQL evidence: grant create/update/revoke CAS with
+// exactly one concurrent winner, tombstone ABA protection, the same-transaction
+// audit invariant, and the version-claim target guard. Shares
+// newCatalogStoreIntegrationDB with the PR-A/PR-B suites, so every run also
+// exercises the grant migration Up and (via cleanup) Down.
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl"
+)
+
+const grantIntegrationTemplateID = cardtmpl.ID("test.grant-target")
+
+func seedGrantTargetClaim(t *testing.T, db *sql.DB) {
+	t.Helper()
+	if _, err := db.Exec(`INSERT INTO card_template_version_claim
+        (template_id, version, source) VALUES (?, '1.0.0', 'dynamic')`,
+		string(grantIntegrationTemplateID)); err != nil {
+		t.Fatalf("seed grant target claim: %v", err)
+	}
+}
+
+func grantIntegrationIdentity() GrantIdentity {
+	return GrantIdentity{
+		TemplateID:    grantIntegrationTemplateID,
+		PrincipalType: GrantPrincipalBot,
+		PrincipalID:   "bot-integration",
+		ScopeSpaceID:  "space-integration",
+	}
+}
+
+func countGrantAuditRows(t *testing.T, db *sql.DB, operation string) int {
+	t.Helper()
+	var count int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM card_template_audit
+        WHERE template_id = ? AND operation = ? AND result = 'ok'`,
+		string(grantIntegrationTemplateID), operation).Scan(&count); err != nil {
+		t.Fatalf("count %s audit: %v", operation, err)
+	}
+	return count
+}
+
+func TestStoreGrantLifecycleRealMySQL(t *testing.T) {
+	db := newCatalogStoreIntegrationDB(t)
+	seedGrantTargetClaim(t, db)
+	catalogStore := newStore(db)
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	identity := grantIntegrationIdentity()
+
+	// Target without any claim fails closed before any write.
+	orphan := identity
+	orphan.TemplateID = "test.never-claimed"
+	if _, err := catalogStore.UpsertGrant(ctx, UpsertGrantRequest{
+		Identity: orphan, Permissions: GrantPermissions{Discover: true},
+		ActorUID: "admin", Reason: "r", ChangeTicket: "t",
+	}); !errors.Is(err, ErrGrantTargetUnknown) {
+		t.Fatalf("orphan target error = %v, want ErrGrantTargetUnknown", err)
+	}
+
+	// Create requires expected_revision=0 and lands revision 1 + audit in the
+	// same transaction.
+	created, err := catalogStore.UpsertGrant(ctx, UpsertGrantRequest{
+		Identity: identity, Permissions: GrantPermissions{Discover: true, Send: true},
+		ExpectedRevision: 0, ActorUID: "admin", Reason: "pilot", ChangeTicket: "CHG-1",
+	})
+	if err != nil {
+		t.Fatalf("create grant: %v", err)
+	}
+	if !created.Created || created.Record.Revision != 1 {
+		t.Fatalf("create result = %+v", created)
+	}
+	if got := countGrantAuditRows(t, db, auditOperationGrant); got != 1 {
+		t.Fatalf("grant audit rows = %d, want 1", got)
+	}
+
+	// Update with a stale revision loses; with the exact revision wins.
+	if _, err := catalogStore.UpsertGrant(ctx, UpsertGrantRequest{
+		Identity: identity, Permissions: GrantPermissions{Discover: true},
+		ExpectedRevision: 0, ActorUID: "admin", Reason: "stale", ChangeTicket: "CHG-2",
+	}); !errors.Is(err, ErrGrantConflict) {
+		t.Fatalf("stale create-as-update error = %v, want ErrGrantConflict", err)
+	}
+	updated, err := catalogStore.UpsertGrant(ctx, UpsertGrantRequest{
+		Identity: identity, Permissions: GrantPermissions{Discover: true, Send: true, Edit: true},
+		ExpectedRevision: 1, ActorUID: "admin", Reason: "widen", ChangeTicket: "CHG-3",
+	})
+	if err != nil || updated.Created || updated.Record.Revision != 2 {
+		t.Fatalf("update result = %+v err=%v", updated, err)
+	}
+
+	// Revoke writes a tombstone with zeroed permissions and bumps revision.
+	revoked, err := catalogStore.RevokeGrant(ctx, RevokeGrantRequest{
+		Identity: identity, ExpectedRevision: 2,
+		ActorUID: "admin", Reason: "offboard", ChangeTicket: "CHG-4",
+	})
+	if err != nil || revoked.Record.Status != GrantStatusRevoked || revoked.Record.Revision != 3 {
+		t.Fatalf("revoke result = %+v err=%v", revoked, err)
+	}
+	var status string
+	var discover, send, edit bool
+	if err := db.QueryRow(`SELECT status, can_discover, can_send, can_edit FROM card_template_grant
+        WHERE template_id = ? AND principal_type = 'bot' AND principal_id = ? AND scope_space_id = ?`,
+		string(identity.TemplateID), identity.PrincipalID, identity.ScopeSpaceID,
+	).Scan(&status, &discover, &send, &edit); err != nil {
+		t.Fatalf("read tombstone: %v", err)
+	}
+	if status != string(GrantStatusRevoked) || discover || send || edit {
+		t.Fatalf("tombstone row = %s/%v/%v/%v", status, discover, send, edit)
+	}
+
+	// Double revoke and revoke of a missing grant are typed failures.
+	if _, err := catalogStore.RevokeGrant(ctx, RevokeGrantRequest{
+		Identity: identity, ExpectedRevision: 3,
+		ActorUID: "admin", Reason: "again", ChangeTicket: "CHG-5",
+	}); !errors.Is(err, ErrGrantAlreadyRevoked) {
+		t.Fatalf("double revoke error = %v, want ErrGrantAlreadyRevoked", err)
+	}
+	missing := identity
+	missing.PrincipalID = "bot-ghost"
+	if _, err := catalogStore.RevokeGrant(ctx, RevokeGrantRequest{
+		Identity: missing, ExpectedRevision: 1,
+		ActorUID: "admin", Reason: "noop", ChangeTicket: "CHG-6",
+	}); !errors.Is(err, ErrGrantNotFound) {
+		t.Fatalf("missing revoke error = %v, want ErrGrantNotFound", err)
+	}
+
+	// ABA guard: re-activating the tombstone must carry its CURRENT revision;
+	// expected_revision=0 can never disguise a create again.
+	if _, err := catalogStore.UpsertGrant(ctx, UpsertGrantRequest{
+		Identity: identity, Permissions: GrantPermissions{Discover: true},
+		ExpectedRevision: 0, ActorUID: "admin", Reason: "aba", ChangeTicket: "CHG-7",
+	}); !errors.Is(err, ErrGrantConflict) {
+		t.Fatalf("tombstone create-disguise error = %v, want ErrGrantConflict", err)
+	}
+	reactivated, err := catalogStore.UpsertGrant(ctx, UpsertGrantRequest{
+		Identity: identity, Permissions: GrantPermissions{Discover: true},
+		ExpectedRevision: 3, ActorUID: "admin", Reason: "re-grant", ChangeTicket: "CHG-8",
+	})
+	if err != nil || reactivated.Created || reactivated.Record.Revision != 4 ||
+		reactivated.Record.Status != GrantStatusActive {
+		t.Fatalf("re-activate result = %+v err=%v", reactivated, err)
+	}
+
+	// The audit ledger recorded every successful transition with principal
+	// identity and permission diffs.
+	if got := countGrantAuditRows(t, db, auditOperationGrant); got != 3 {
+		t.Fatalf("grant audit rows = %d, want 3", got)
+	}
+	if got := countGrantAuditRows(t, db, auditOperationRevoke); got != 1 {
+		t.Fatalf("revoke audit rows = %d, want 1", got)
+	}
+	var principalID, previousPerms, resultingPerms string
+	if err := db.QueryRow(`SELECT principal_id, previous_permissions, resulting_permissions
+        FROM card_template_audit
+        WHERE template_id = ? AND operation = 'revoke'
+        ORDER BY id DESC LIMIT 1`,
+		string(identity.TemplateID)).Scan(&principalID, &previousPerms, &resultingPerms); err != nil {
+		t.Fatalf("read revoke audit: %v", err)
+	}
+	if principalID != identity.PrincipalID || previousPerms != "discover,send,edit" || resultingPerms != "" {
+		t.Fatalf("revoke audit = %s / %q -> %q", principalID, previousPerms, resultingPerms)
+	}
+
+	// Bounded list returns both shapes for the manager summary.
+	records, truncated, err := catalogStore.ListGrants(ctx, identity.TemplateID, 10)
+	if err != nil || truncated || len(records) != 1 {
+		t.Fatalf("list grants = %+v truncated=%v err=%v", records, truncated, err)
+	}
+}
+
+func TestStoreGrantConcurrentCASHasOneWinnerRealMySQL(t *testing.T) {
+	db := newCatalogStoreIntegrationDB(t)
+	seedGrantTargetClaim(t, db)
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	identity := grantIntegrationIdentity()
+	stores := []*store{newStore(db), newStore(db)}
+
+	// Concurrent create: exactly one revision-1 winner.
+	start := make(chan struct{})
+	results := make([]error, len(stores))
+	var wg sync.WaitGroup
+	for i, contender := range stores {
+		wg.Add(1)
+		go func(i int, s *store) {
+			defer wg.Done()
+			<-start
+			_, err := s.UpsertGrant(ctx, UpsertGrantRequest{
+				Identity: identity, Permissions: GrantPermissions{Discover: true},
+				ExpectedRevision: 0, ActorUID: "admin", Reason: "race", ChangeTicket: "CHG-R1",
+			})
+			results[i] = err
+		}(i, contender)
+	}
+	close(start)
+	wg.Wait()
+	winners := 0
+	for _, err := range results {
+		if err == nil {
+			winners++
+		} else if !errors.Is(err, ErrGrantConflict) {
+			t.Fatalf("concurrent create error = %v, want ErrGrantConflict", err)
+		}
+	}
+	if winners != 1 {
+		t.Fatalf("concurrent create winners = %d, want 1", winners)
+	}
+
+	// Concurrent revoke against the same revision: one winner, one conflict.
+	start = make(chan struct{})
+	for i, contender := range stores {
+		wg.Add(1)
+		go func(i int, s *store) {
+			defer wg.Done()
+			<-start
+			_, err := s.RevokeGrant(ctx, RevokeGrantRequest{
+				Identity: identity, ExpectedRevision: 1,
+				ActorUID: "admin", Reason: "race", ChangeTicket: "CHG-R2",
+			})
+			results[i] = err
+		}(i, contender)
+	}
+	close(start)
+	wg.Wait()
+	winners = 0
+	for _, err := range results {
+		if err == nil {
+			winners++
+		} else if !errors.Is(err, ErrGrantConflict) && !errors.Is(err, ErrGrantAlreadyRevoked) {
+			t.Fatalf("concurrent revoke error = %v", err)
+		}
+	}
+	if winners != 1 {
+		t.Fatalf("concurrent revoke winners = %d, want 1", winners)
+	}
+
+	// State and audit agree: revision 2, one grant + one revoke audit row.
+	var revision uint64
+	if err := db.QueryRow(`SELECT revision FROM card_template_grant
+        WHERE template_id = ? AND principal_type = 'bot' AND principal_id = ? AND scope_space_id = ?`,
+		string(identity.TemplateID), identity.PrincipalID, identity.ScopeSpaceID).Scan(&revision); err != nil {
+		t.Fatalf("read final revision: %v", err)
+	}
+	if revision != 2 {
+		t.Fatalf("final revision = %d, want 2", revision)
+	}
+	if grants, revokes := countGrantAuditRows(t, db, auditOperationGrant),
+		countGrantAuditRows(t, db, auditOperationRevoke); grants != 1 || revokes != 1 {
+		t.Fatalf("audit rows grant/revoke = %d/%d, want 1/1", grants, revokes)
+	}
+}

--- a/modules/card_template_catalog/store_grant_test.go
+++ b/modules/card_template_catalog/store_grant_test.go
@@ -1,0 +1,215 @@
+package card_template_catalog
+
+// PR-C Slice 2 RED (D2/D4): the grant model's pure invariants — canonical
+// identity shape, the fixed permission matrix, and the exact-over-global /
+// tombstone resolution order — are locked by unit tests before any SQL runs.
+// The CAS/transaction behavior itself is proven by the MySQL integration
+// suite (store_grant_mysql_integration_test.go).
+
+import (
+	"errors"
+	"testing"
+)
+
+func validBotIdentity() GrantIdentity {
+	return GrantIdentity{
+		TemplateID:    "docs.access-request",
+		PrincipalType: GrantPrincipalBot,
+		PrincipalID:   "bot-1",
+		ScopeSpaceID:  "space-1",
+	}
+}
+
+func TestValidateGrantIdentityCanonicalShapes(t *testing.T) {
+	cases := []struct {
+		name    string
+		mutate  func(*GrantIdentity)
+		wantErr bool
+	}{
+		{name: "bot exact scope", mutate: func(g *GrantIdentity) {}},
+		{name: "bot global scope", mutate: func(g *GrantIdentity) { g.ScopeSpaceID = "" }},
+		{name: "internal producer global", mutate: func(g *GrantIdentity) {
+			g.PrincipalType = GrantPrincipalInternalProducer
+			g.PrincipalID = "docs-notify"
+			g.ScopeSpaceID = ""
+		}},
+		{name: "space canonical", mutate: func(g *GrantIdentity) {
+			g.PrincipalType = GrantPrincipalSpace
+			g.PrincipalID = "space-1"
+			g.ScopeSpaceID = ""
+		}},
+		{name: "space with exact scope is non-canonical", mutate: func(g *GrantIdentity) {
+			g.PrincipalType = GrantPrincipalSpace
+			g.PrincipalID = "space-1"
+			g.ScopeSpaceID = "space-1"
+		}, wantErr: true},
+		{name: "space scoped to another space", mutate: func(g *GrantIdentity) {
+			g.PrincipalType = GrantPrincipalSpace
+			g.PrincipalID = "space-1"
+			g.ScopeSpaceID = "space-2"
+		}, wantErr: true},
+		{name: "system is not grantable", mutate: func(g *GrantIdentity) {
+			g.PrincipalType = "system"
+		}, wantErr: true},
+		{name: "unknown principal type", mutate: func(g *GrantIdentity) {
+			g.PrincipalType = "user"
+		}, wantErr: true},
+		{name: "empty principal id", mutate: func(g *GrantIdentity) {
+			g.PrincipalID = ""
+		}, wantErr: true},
+		{name: "untrimmed principal id", mutate: func(g *GrantIdentity) {
+			g.PrincipalID = " bot-1"
+		}, wantErr: true},
+		{name: "untrimmed scope", mutate: func(g *GrantIdentity) {
+			g.ScopeSpaceID = "space-1 "
+		}, wantErr: true},
+		{name: "empty template id", mutate: func(g *GrantIdentity) {
+			g.TemplateID = ""
+		}, wantErr: true},
+		{name: "oversized principal id", mutate: func(g *GrantIdentity) {
+			raw := make([]byte, 129)
+			for i := range raw {
+				raw[i] = 'a'
+			}
+			g.PrincipalID = string(raw)
+		}, wantErr: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			identity := validBotIdentity()
+			tc.mutate(&identity)
+			err := validateGrantIdentity(identity)
+			if tc.wantErr && err == nil {
+				t.Fatalf("non-canonical identity accepted: %+v", identity)
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("canonical identity rejected: %v", err)
+			}
+			if tc.wantErr && !errors.Is(err, ErrGrantRequestInvalid) {
+				t.Fatalf("error = %v, want ErrGrantRequestInvalid", err)
+			}
+		})
+	}
+}
+
+func TestValidateGrantPermissionsMatrix(t *testing.T) {
+	cases := []struct {
+		name          string
+		principalType GrantPrincipalType
+		permissions   GrantPermissions
+		wantErr       bool
+	}{
+		{name: "bot discover only", principalType: GrantPrincipalBot,
+			permissions: GrantPermissions{Discover: true}},
+		{name: "bot full", principalType: GrantPrincipalBot,
+			permissions: GrantPermissions{Discover: true, Send: true, Edit: true}},
+		{name: "producer send+discover", principalType: GrantPrincipalInternalProducer,
+			permissions: GrantPermissions{Discover: true, Send: true}},
+		{name: "space discover only", principalType: GrantPrincipalSpace,
+			permissions: GrantPermissions{Discover: true}},
+		{name: "no permission at all", principalType: GrantPrincipalBot,
+			permissions: GrantPermissions{}, wantErr: true},
+		{name: "send without discover is a dark grant", principalType: GrantPrincipalBot,
+			permissions: GrantPermissions{Send: true}, wantErr: true},
+		{name: "edit without discover is a dark grant", principalType: GrantPrincipalInternalProducer,
+			permissions: GrantPermissions{Edit: true}, wantErr: true},
+		{name: "space can never send", principalType: GrantPrincipalSpace,
+			permissions: GrantPermissions{Discover: true, Send: true}, wantErr: true},
+		{name: "space can never edit", principalType: GrantPrincipalSpace,
+			permissions: GrantPermissions{Discover: true, Edit: true}, wantErr: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateGrantPermissions(tc.principalType, tc.permissions)
+			if tc.wantErr && err == nil {
+				t.Fatal("invalid permission shape accepted")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("valid permission shape rejected: %v", err)
+			}
+		})
+	}
+}
+
+func TestGrantPermissionsLabel(t *testing.T) {
+	if got := grantPermissionsLabel(GrantPermissions{}); got != "" {
+		t.Fatalf("empty label = %q", got)
+	}
+	if got := grantPermissionsLabel(GrantPermissions{Discover: true}); got != "discover" {
+		t.Fatalf("discover label = %q", got)
+	}
+	if got := grantPermissionsLabel(GrantPermissions{Discover: true, Send: true, Edit: true}); got != "discover,send,edit" {
+		t.Fatalf("full label = %q", got)
+	}
+}
+
+// resolveGrantRows is the single precedence rule shared by every consumer
+// (Slice 3's one-snapshot authorizer included): an exact row — active OR
+// tombstone — completely shadows the global row; permissions never union.
+func TestResolveGrantRowsPrecedence(t *testing.T) {
+	active := func(scope string, perms GrantPermissions) *GrantRecord {
+		identity := validBotIdentity()
+		identity.ScopeSpaceID = scope
+		return &GrantRecord{Identity: identity, Status: GrantStatusActive, Permissions: perms, Revision: 3}
+	}
+	revoked := func(scope string) *GrantRecord {
+		identity := validBotIdentity()
+		identity.ScopeSpaceID = scope
+		return &GrantRecord{Identity: identity, Status: GrantStatusRevoked, Revision: 4}
+	}
+	cases := []struct {
+		name          string
+		exact, global *GrantRecord
+		wantAllowed   GrantPermissions
+		wantSource    string
+	}{
+		{name: "no rows denies", wantAllowed: GrantPermissions{}, wantSource: ""},
+		{name: "global only", global: active("", GrantPermissions{Discover: true, Send: true}),
+			wantAllowed: GrantPermissions{Discover: true, Send: true}, wantSource: "global"},
+		{name: "exact overrides wider global", exact: active("space-1", GrantPermissions{Discover: true}),
+			global:      active("", GrantPermissions{Discover: true, Send: true, Edit: true}),
+			wantAllowed: GrantPermissions{Discover: true}, wantSource: "exact"},
+		{name: "exact tombstone blocks active global", exact: revoked("space-1"),
+			global:      active("", GrantPermissions{Discover: true, Send: true}),
+			wantAllowed: GrantPermissions{}, wantSource: "exact"},
+		{name: "revoked global denies", global: revoked(""),
+			wantAllowed: GrantPermissions{}, wantSource: "global"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			decision := resolveGrantRows(tc.exact, tc.global)
+			if decision.Allowed != tc.wantAllowed {
+				t.Fatalf("allowed = %+v, want %+v", decision.Allowed, tc.wantAllowed)
+			}
+			if decision.ScopeSource != tc.wantSource {
+				t.Fatalf("scope source = %q, want %q", decision.ScopeSource, tc.wantSource)
+			}
+		})
+	}
+}
+
+func TestValidateUpsertGrantRequestBounds(t *testing.T) {
+	valid := UpsertGrantRequest{
+		Identity:    validBotIdentity(),
+		Permissions: GrantPermissions{Discover: true},
+		ActorUID:    "admin", Reason: "pilot", ChangeTicket: "CHG-1",
+	}
+	if err := validateUpsertGrantRequest(valid); err != nil {
+		t.Fatalf("valid request rejected: %v", err)
+	}
+	missingReason := valid
+	missingReason.Reason = " "
+	if err := validateUpsertGrantRequest(missingReason); !errors.Is(err, ErrGrantRequestInvalid) {
+		t.Fatalf("blank reason error = %v", err)
+	}
+	missingActor := valid
+	missingActor.ActorUID = ""
+	if err := validateUpsertGrantRequest(missingActor); !errors.Is(err, ErrGrantRequestInvalid) {
+		t.Fatalf("missing actor error = %v", err)
+	}
+	darkGrant := valid
+	darkGrant.Permissions = GrantPermissions{Send: true}
+	if err := validateUpsertGrantRequest(darkGrant); !errors.Is(err, ErrGrantRequestInvalid) {
+		t.Fatalf("dark grant error = %v", err)
+	}
+}

--- a/modules/card_template_catalog/store_read.go
+++ b/modules/card_template_catalog/store_read.go
@@ -21,6 +21,26 @@ const (
         WHERE c.template_id = ?
         ORDER BY c.version ASC
         LIMIT ?`
+	// selectManagerTemplatesSQL is the operator's index of every claimed
+	// template ID. Unlike B1 it applies no visibility or grant predicate — the
+	// manager plane is already super-admin only, and hiding rows there would
+	// make the control surface useless for diagnosing exactly the templates an
+	// operator most needs to see (blocked, ungranted, disabled).
+	selectManagerTemplatesSQL = `SELECT c.template_id,
+            COUNT(*) AS version_count,
+            MAX(c.version) AS latest_version,
+            MAX(act.active_version) AS active_version,
+            MAX(act.status) AS activation_status,
+            SUM(a.blocked_at IS NOT NULL) AS blocked_versions
+        FROM card_template_version_claim c
+        LEFT JOIN card_template_artifact a
+          ON a.template_id = c.template_id AND a.version = c.version
+        LEFT JOIN card_template_activation act
+          ON act.template_id = c.template_id
+        WHERE c.template_id > ?
+        GROUP BY c.template_id
+        ORDER BY c.template_id ASC
+        LIMIT ?`
 	selectTemplateAuditSQL = `SELECT id, actor_uid, operation, version, previous_version, resulting_version,
         previous_revision, resulting_revision, principal_type, principal_id, scope_space_id,
         previous_permissions, resulting_permissions, result, reason, change_ticket, created_at
@@ -186,6 +206,64 @@ func (s *store) ListAudit(
 	if len(entries) > limit {
 		page.Entries = entries[:limit]
 		page.NextCursor = page.Entries[len(page.Entries)-1].ID
+	}
+	return page, nil
+}
+
+// ManagerTemplateSummary is one template ID as the operator index shows it.
+// It is intentionally coarse: counts and pointers, no per-version metadata and
+// no grant state. An operator drills into a single template with the existing
+// detail endpoint, which is where the bounded grant summary already lives.
+type ManagerTemplateSummary struct {
+	ID               cardtmpl.ID
+	VersionCount     int
+	LatestVersion    string
+	ActiveVersion    string
+	ActivationStatus string
+	BlockedVersions  int
+}
+
+// ManagerTemplatePage is a keyset page over template IDs.
+type ManagerTemplatePage struct {
+	Templates []ManagerTemplateSummary
+	// NextCursor is the last returned template ID, empty when the page is the
+	// last one. Keyset rather than offset so a concurrent publish cannot make
+	// the operator skip a row.
+	NextCursor string
+}
+
+// ListTemplates returns the operator index of claimed template IDs.
+func (s *store) ListTemplates(ctx context.Context, after string, limit int) (ManagerTemplatePage, error) {
+	limit = normalizeManagerReadLimit(limit)
+	rows, err := s.db.QueryContext(ctx, selectManagerTemplatesSQL, after, limit+1)
+	if err != nil {
+		return ManagerTemplatePage{}, fmt.Errorf("card template catalog: list templates: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	summaries := make([]ManagerTemplateSummary, 0, limit)
+	for rows.Next() {
+		var summary ManagerTemplateSummary
+		var templateID string
+		var latest, active, status sql.NullString
+		var blocked sql.NullInt64
+		if err := rows.Scan(&templateID, &summary.VersionCount, &latest,
+			&active, &status, &blocked); err != nil {
+			return ManagerTemplatePage{}, fmt.Errorf("card template catalog: scan template summary: %w", err)
+		}
+		summary.ID = cardtmpl.ID(templateID)
+		summary.LatestVersion, summary.ActiveVersion = latest.String, active.String
+		summary.ActivationStatus = status.String
+		summary.BlockedVersions = int(blocked.Int64)
+		summaries = append(summaries, summary)
+	}
+	if err := rows.Err(); err != nil {
+		return ManagerTemplatePage{}, fmt.Errorf("card template catalog: iterate templates: %w", err)
+	}
+	page := ManagerTemplatePage{Templates: summaries}
+	if len(summaries) > limit {
+		page.Templates = summaries[:limit]
+		page.NextCursor = string(page.Templates[len(page.Templates)-1].ID)
 	}
 	return page, nil
 }

--- a/modules/card_template_catalog/store_read.go
+++ b/modules/card_template_catalog/store_read.go
@@ -22,7 +22,8 @@ const (
         ORDER BY c.version ASC
         LIMIT ?`
 	selectTemplateAuditSQL = `SELECT id, actor_uid, operation, version, previous_version, resulting_version,
-        previous_revision, resulting_revision, result, reason, change_ticket, created_at
+        previous_revision, resulting_revision, principal_type, principal_id, scope_space_id,
+        previous_permissions, resulting_permissions, result, reason, change_ticket, created_at
         FROM card_template_audit
         WHERE template_id = ? AND (? = 0 OR id < ?)
         ORDER BY id DESC
@@ -51,18 +52,25 @@ type TemplateDetail struct {
 }
 
 type TemplateAuditEntry struct {
-	ID                uint64    `json:"id"`
-	ActorUID          string    `json:"actor_uid"`
-	Operation         string    `json:"operation"`
-	Version           string    `json:"version,omitempty"`
-	PreviousVersion   string    `json:"previous_version,omitempty"`
-	ResultingVersion  string    `json:"resulting_version,omitempty"`
-	PreviousRevision  *uint64   `json:"previous_revision,omitempty"`
-	ResultingRevision *uint64   `json:"resulting_revision,omitempty"`
-	Result            string    `json:"result"`
-	Reason            string    `json:"reason"`
-	ChangeTicket      string    `json:"change_ticket"`
-	CreatedAt         time.Time `json:"created_at"`
+	ID                uint64  `json:"id"`
+	ActorUID          string  `json:"actor_uid"`
+	Operation         string  `json:"operation"`
+	Version           string  `json:"version,omitempty"`
+	PreviousVersion   string  `json:"previous_version,omitempty"`
+	ResultingVersion  string  `json:"resulting_version,omitempty"`
+	PreviousRevision  *uint64 `json:"previous_revision,omitempty"`
+	ResultingRevision *uint64 `json:"resulting_revision,omitempty"`
+	// PR-C grant/revoke 审计的脱敏 principal 身份与权限差异（无 token、无
+	// 卡片 data）；非 grant 操作行恒为空串。
+	PrincipalType        string    `json:"principal_type,omitempty"`
+	PrincipalID          string    `json:"principal_id,omitempty"`
+	ScopeSpaceID         string    `json:"scope_space_id,omitempty"`
+	PreviousPermissions  string    `json:"previous_permissions,omitempty"`
+	ResultingPermissions string    `json:"resulting_permissions,omitempty"`
+	Result               string    `json:"result"`
+	Reason               string    `json:"reason"`
+	ChangeTicket         string    `json:"change_ticket"`
+	CreatedAt            time.Time `json:"created_at"`
 }
 
 type TemplateAuditPage struct {
@@ -147,7 +155,10 @@ func (s *store) ListAudit(
 		if err := rows.Scan(
 			&entry.ID, &entry.ActorUID, &entry.Operation, &entry.Version,
 			&entry.PreviousVersion, &entry.ResultingVersion,
-			&previousRevision, &resultingRevision, &entry.Result, &entry.Reason,
+			&previousRevision, &resultingRevision,
+			&entry.PrincipalType, &entry.PrincipalID, &entry.ScopeSpaceID,
+			&entry.PreviousPermissions, &entry.ResultingPermissions,
+			&entry.Result, &entry.Reason,
 			&entry.ChangeTicket, &entry.CreatedAt,
 		); err != nil {
 			return TemplateAuditPage{}, fmt.Errorf("card template catalog: scan audit: %w", err)

--- a/modules/card_template_catalog/store_read_test.go
+++ b/modules/card_template_catalog/store_read_test.go
@@ -50,11 +50,14 @@ func TestStoreListAuditUsesDescendingCursorAndHardLimit(t *testing.T) {
 		WithArgs("test.runtime-card", uint64(50), uint64(50), 3).
 		WillReturnRows(sqlmock.NewRows([]string{
 			"id", "actor_uid", "operation", "version", "previous_version", "resulting_version",
-			"previous_revision", "resulting_revision", "result", "reason", "change_ticket", "created_at",
+			"previous_revision", "resulting_revision",
+			"principal_type", "principal_id", "scope_space_id",
+			"previous_permissions", "resulting_permissions",
+			"result", "reason", "change_ticket", "created_at",
 		}).
-			AddRow(49, "admin-1", "rollback", "1.0.0", "1.1.0", "1.0.0", 3, 4, "ok", "incident", "INC-1", now).
-			AddRow(48, "admin-1", "activate", "1.1.0", "1.0.0", "1.1.0", 2, 3, "ok", "rollout", "CHG-2", now).
-			AddRow(47, "admin-1", "publish", "1.1.0", "", "", nil, nil, "created", "reviewed", "CHG-1", now))
+			AddRow(49, "admin-1", "rollback", "1.0.0", "1.1.0", "1.0.0", 3, 4, "", "", "", "", "", "ok", "incident", "INC-1", now).
+			AddRow(48, "admin-1", "grant", "", "", "", 0, 1, "bot", "bot-1", "space-1", "", "discover,send", "ok", "pilot", "CHG-2", now).
+			AddRow(47, "admin-1", "publish", "1.1.0", "", "", nil, nil, "", "", "", "", "", "created", "reviewed", "CHG-1", now))
 
 	page, err := store.ListAudit(context.Background(), "test.runtime-card", 50, 2)
 	if err != nil {

--- a/modules/card_template_catalog/store_runtime.go
+++ b/modules/card_template_catalog/store_runtime.go
@@ -50,7 +50,18 @@ func scanRuntimeActivation(
 	if err != nil {
 		return cardtmpl.RuntimeActivation{}, fmt.Errorf("card template catalog: load runtime activation: %w", err)
 	}
+	return buildRuntimeActivation(version, status, revision)
+}
 
+// buildRuntimeActivation validates one activation row's shape. It is separate
+// from the query so the single-row read and the batched advertised-set read
+// share one copy — two copies of a shape check are two chances to disagree
+// about what a malformed row means.
+func buildRuntimeActivation(
+	version sql.NullString,
+	status string,
+	revision uint64,
+) (cardtmpl.RuntimeActivation, error) {
 	result := cardtmpl.RuntimeActivation{Exists: true, Version: version.String, Revision: revision}
 	switch status {
 	case string(activationStatusActive):
@@ -95,7 +106,32 @@ func scanRuntimeArtifactMeta(
 	if err != nil {
 		return cardtmpl.RuntimeArtifactMeta{}, fmt.Errorf("card template catalog: load runtime artifact metadata: %w", err)
 	}
+	return buildRuntimeArtifactMeta(id, version, source,
+		artifactMetaColumns{owner, visibility, engine, protocol, contractVersion, hash}, blocked)
+}
 
+// artifactMetaColumns groups the nullable artifact columns so the shared shape
+// check below reads as one thing rather than as six positional arguments.
+type artifactMetaColumns struct {
+	owner           sql.NullString
+	visibility      sql.NullString
+	engine          sql.NullString
+	protocol        sql.NullString
+	contractVersion sql.NullString
+	hash            sql.NullString
+}
+
+// buildRuntimeArtifactMeta validates one claim/artifact pair, shared by the
+// single-row read and the batched advertised-set read for the same reason
+// buildRuntimeActivation is.
+func buildRuntimeArtifactMeta(
+	id cardtmpl.ID,
+	version, source string,
+	columns artifactMetaColumns,
+	blocked bool,
+) (cardtmpl.RuntimeArtifactMeta, error) {
+	owner, visibility, engine := columns.owner, columns.visibility, columns.engine
+	protocol, contractVersion, hash := columns.protocol, columns.contractVersion, columns.hash
 	result := cardtmpl.RuntimeArtifactMeta{ID: id, Version: version, Blocked: blocked}
 	switch source {
 	case claimSourceStatic:

--- a/modules/card_template_catalog/store_runtime.go
+++ b/modules/card_template_catalog/store_runtime.go
@@ -23,11 +23,26 @@ const (
         WHERE template_id = ? AND version = ? AND content_sha256 = ?`
 )
 
+// rowQuerier lets the activation/artifact readers run either standalone or
+// inside the single authorization snapshot without a second copy of the shape
+// validation below. *sql.DB and *sql.Tx both satisfy it.
+type rowQuerier interface {
+	QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row
+}
+
 func (s *store) LoadActivation(ctx context.Context, id cardtmpl.ID) (cardtmpl.RuntimeActivation, error) {
+	return scanRuntimeActivation(ctx, s.db, id)
+}
+
+func scanRuntimeActivation(
+	ctx context.Context,
+	querier rowQuerier,
+	id cardtmpl.ID,
+) (cardtmpl.RuntimeActivation, error) {
 	var version sql.NullString
 	var status string
 	var revision uint64
-	err := s.db.QueryRowContext(ctx, selectRuntimeActivationSQL, string(id)).
+	err := querier.QueryRowContext(ctx, selectRuntimeActivationSQL, string(id)).
 		Scan(&version, &status, &revision)
 	if errors.Is(err, sql.ErrNoRows) {
 		return cardtmpl.RuntimeActivation{}, nil
@@ -59,10 +74,19 @@ func (s *store) LoadArtifactMeta(
 	id cardtmpl.ID,
 	version string,
 ) (cardtmpl.RuntimeArtifactMeta, error) {
+	return scanRuntimeArtifactMeta(ctx, s.db, id, version)
+}
+
+func scanRuntimeArtifactMeta(
+	ctx context.Context,
+	querier rowQuerier,
+	id cardtmpl.ID,
+	version string,
+) (cardtmpl.RuntimeArtifactMeta, error) {
 	var source string
 	var owner, visibility, engine, protocol, contractVersion, hash sql.NullString
 	var blocked bool
-	err := s.db.QueryRowContext(ctx, selectRuntimeArtifactMetaSQL, string(id), version).Scan(
+	err := querier.QueryRowContext(ctx, selectRuntimeArtifactMetaSQL, string(id), version).Scan(
 		&source, &owner, &visibility, &engine, &protocol, &contractVersion, &hash, &blocked,
 	)
 	if errors.Is(err, sql.ErrNoRows) {

--- a/modules/card_template_catalog/testdata/pilot/README.md
+++ b/modules/card_template_catalog/testdata/pilot/README.md
@@ -15,16 +15,32 @@ Specifically, a bundle here is:
   `OCTO_CARD_RUNTIME_CATALOG_CONTROL_ENABLED` and
   `OCTO_CARD_RUNTIME_CATALOG_NEW_SEND_ENABLED` stay false.
 
+## A pilot never claims a production template ID
+
+The bundle declares its own `additionalProperties:false` data contract, which
+does not match any live producer's field shape. Activating it under a template
+ID a real producer sends would make every one of that producer's cards fail
+preflight with a 400 and zero delivery. Pilots therefore use a dedicated ID
+(`docs.pilot-access-request`, not `docs.access-request`); the fixture test
+asserts this rather than trusting the constant's comment.
+
 ## The version is claimed once, forever
 
-A version claim is permanent and global to a catalog database. Before adding a
-new pilot directory, the exact `(template_id, version)` must be proven to have
-never been claimed in the target catalog. `requirePilotVersionUnclaimed` in
-`pilot_mysql_integration_test.go` enforces this at test time so the check cannot
-be skipped, and it fails with the remedy spelled out.
+A version claim is permanent and global to a catalog database, so the exact
+`(template_id, version)` must be proven never claimed **in the catalog you are
+publishing into**.
 
-If the version is already claimed — most likely because a shared non-production
-database has seen an earlier run — **do not overwrite or reuse the directory**.
+`requirePilotVersionUnclaimed` interrogates the database named by
+`OCTO_PILOT_CATALOG_DSN`. Set it to the shared non-production catalog before
+running the pilot there. With it unset the check logs, loudly, that it verified
+nothing — "no shared catalog configured" and "the version is free" are different
+answers and only one of them is evidence.
+
+The per-test database cannot answer this question: `newCatalogStoreIntegrationDB`
+drops and recreates it moments before the check runs, so it is always empty. An
+earlier revision queried exactly that database and could therefore never fail.
+
+If the version is already claimed, **do not overwrite or reuse the directory**.
 Pick a new reviewed prerelease (the convention is `<next>.0-pilot.<yyyymmdd>`),
 rename the directory to match, and update `pilotVersion`.
 

--- a/modules/card_template_catalog/testdata/pilot/README.md
+++ b/modules/card_template_catalog/testdata/pilot/README.md
@@ -1,0 +1,37 @@
+# Non-production card-template pilot fixtures
+
+`bundle.json` under `<template-id>@<version>/` is **publish input for the D7
+pilot test**. It is not a released template and its presence in this repository
+carries no runtime meaning.
+
+Specifically, a bundle here is:
+
+- **not** registered in `DefaultRegistry` and **not** `go:embed`-ed into startup;
+- **not** copied into `pkg/cardtmpl/*/handoff/` (those are frozen L1 handoffs);
+- **not** an activation and **not** an authorization — publish, activate and
+  grant are three separate operations, and merging this file changes none of
+  them;
+- **not** permission to enable the production gates. Both
+  `OCTO_CARD_RUNTIME_CATALOG_CONTROL_ENABLED` and
+  `OCTO_CARD_RUNTIME_CATALOG_NEW_SEND_ENABLED` stay false.
+
+## The version is claimed once, forever
+
+A version claim is permanent and global to a catalog database. Before adding a
+new pilot directory, the exact `(template_id, version)` must be proven to have
+never been claimed in the target catalog. `requirePilotVersionUnclaimed` in
+`pilot_mysql_integration_test.go` enforces this at test time so the check cannot
+be skipped, and it fails with the remedy spelled out.
+
+If the version is already claimed — most likely because a shared non-production
+database has seen an earlier run — **do not overwrite or reuse the directory**.
+Pick a new reviewed prerelease (the convention is `<next>.0-pilot.<yyyymmdd>`),
+rename the directory to match, and update `pilotVersion`.
+
+## Content rules
+
+Everything in a pilot bundle is synthetic. No real tenant, Space, user, bot,
+document, token or callback data, and no production samples — the bundle is
+committed and readable by anyone with repository access, and its allowlisted
+samples are additionally served over B2 to any caller that can discover the
+template.

--- a/modules/card_template_catalog/testdata/pilot/docs.access-request@0.4.0-pilot.20260805/bundle.json
+++ b/modules/card_template_catalog/testdata/pilot/docs.access-request@0.4.0-pilot.20260805/bundle.json
@@ -1,0 +1,290 @@
+{
+  "catalog": {
+    "engine": "octo-json-template/v1",
+    "visibility": "private"
+  },
+  "manifest": {
+    "schemaVersion": 2,
+    "id": "docs.access-request",
+    "name": "Docs access request (non-production pilot)",
+    "version": "0.4.0-pilot.20260805",
+    "contractVersion": "1.1.0",
+    "protocol": "octo-card@1.0",
+    "adaptiveCardVersion": "1.5",
+    "renderProfile": "octo-chat@1.2.0-rc.1",
+    "renderProfileCompatibility": "octo-chat/v1",
+    "defaultLocale": "zh-CN",
+    "owner": "docs",
+    "actionType": "access_request.decision",
+    "dataSchema": "contract/data.schema.json",
+    "export": {
+      "samples": [
+        "pending"
+      ]
+    },
+    "views": {
+      "pending": {
+        "wireProfile": "octo/v2",
+        "states": [
+          "pending"
+        ],
+        "template": "templates/pending.template.json",
+        "samples": [
+          "samples/pending.json"
+        ]
+      },
+      "result": {
+        "wireProfile": "octo/v1",
+        "states": [
+          "approved",
+          "rejected"
+        ],
+        "template": "templates/result.template.json",
+        "samples": [
+          "samples/approved.json",
+          "samples/rejected.json"
+        ]
+      }
+    }
+  },
+  "schema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "additionalProperties": false,
+    "required": [
+      "state",
+      "title",
+      "requesterName",
+      "docTitle"
+    ],
+    "properties": {
+      "state": {
+        "type": "string",
+        "enum": [
+          "pending",
+          "approved",
+          "rejected"
+        ]
+      },
+      "title": {
+        "type": "string",
+        "maxLength": 120
+      },
+      "requesterName": {
+        "type": "string",
+        "maxLength": 64
+      },
+      "docTitle": {
+        "type": "string",
+        "maxLength": 120
+      },
+      "requestId": {
+        "type": "string",
+        "maxLength": 64
+      },
+      "resultLabel": {
+        "type": "string",
+        "maxLength": 64
+      },
+      "resultTone": {
+        "type": "string",
+        "enum": [
+          "Good",
+          "Attention",
+          "Default"
+        ]
+      },
+      "decidedBy": {
+        "type": "string",
+        "maxLength": 64
+      },
+      "decidedAt": {
+        "type": "string",
+        "maxLength": 64
+      },
+      "denyReason": {
+        "type": "string",
+        "maxLength": 200
+      }
+    }
+  },
+  "templates": {
+    "pending": {
+      "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+      "type": "AdaptiveCard",
+      "version": "1.5",
+      "body": [
+        {
+          "type": "TextBlock",
+          "text": "${title}",
+          "weight": "Bolder",
+          "wrap": true,
+          "spacing": "None"
+        },
+        {
+          "type": "TextBlock",
+          "text": "${requesterName}",
+          "isSubtle": true,
+          "wrap": true,
+          "spacing": "Small"
+        },
+        {
+          "type": "TextBlock",
+          "text": "${docTitle}",
+          "wrap": true,
+          "spacing": "Small"
+        },
+        {
+          "type": "Input.Text",
+          "id": "deny_reason",
+          "isVisible": false,
+          "isMultiline": true,
+          "maxLength": 200,
+          "placeholder": "拒绝原因"
+        },
+        {
+          "type": "ActionSet",
+          "horizontalAlignment": "Right",
+          "spacing": "Medium",
+          "actions": [
+            {
+              "type": "Action.Submit",
+              "id": "approve",
+              "title": "同意",
+              "style": "positive",
+              "data": {
+                "owner": "docs",
+                "action_type": "access_request.decision",
+                "decision": "approve"
+              }
+            },
+            {
+              "type": "Action.Submit",
+              "id": "deny",
+              "title": "拒绝",
+              "style": "destructive",
+              "data": {
+                "owner": "docs",
+                "action_type": "access_request.decision",
+                "decision": "deny"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "result": {
+      "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+      "type": "AdaptiveCard",
+      "version": "1.5",
+      "body": [
+        {
+          "type": "TextBlock",
+          "text": "${title}",
+          "weight": "Bolder",
+          "wrap": true,
+          "spacing": "None"
+        },
+        {
+          "type": "TextBlock",
+          "text": "${docTitle}",
+          "wrap": true,
+          "spacing": "Small"
+        },
+        {
+          "type": "TextBlock",
+          "text": "${resultLabel}",
+          "color": "${resultTone}",
+          "weight": "Bolder",
+          "wrap": true,
+          "spacing": "Medium"
+        },
+        {
+          "type": "TextBlock",
+          "text": "${decidedBy}",
+          "isSubtle": true,
+          "size": "Small",
+          "wrap": true,
+          "spacing": "Small"
+        },
+        {
+          "type": "TextBlock",
+          "text": "${decidedAt}",
+          "isSubtle": true,
+          "size": "Small",
+          "wrap": true,
+          "spacing": "None"
+        }
+      ]
+    }
+  },
+  "reports": {
+    "pending": {
+      "actions": [
+        {
+          "id": "approve",
+          "type": "Action.Submit",
+          "dataKeys": [
+            "owner",
+            "action_type",
+            "decision"
+          ],
+          "inputIds": [
+            "deny_reason"
+          ]
+        },
+        {
+          "id": "deny",
+          "type": "Action.Submit",
+          "dataKeys": [
+            "owner",
+            "action_type",
+            "decision"
+          ],
+          "inputIds": [
+            "deny_reason"
+          ]
+        }
+      ],
+      "inputs": [
+        {
+          "id": "deny_reason",
+          "type": "Input.Text",
+          "isVisible": false
+        }
+      ]
+    }
+  },
+  "samples": {
+    "pending": {
+      "state": "pending",
+      "title": "文档访问申请",
+      "requesterName": "申请人 A",
+      "docTitle": "季度复盘（示例文档）",
+      "requestId": "pilot-request-0001"
+    },
+    "approved": {
+      "state": "approved",
+      "title": "文档访问申请",
+      "requesterName": "申请人 A",
+      "docTitle": "季度复盘（示例文档）",
+      "requestId": "pilot-request-0001",
+      "resultLabel": "已同意",
+      "resultTone": "Good",
+      "decidedBy": "审批人 B",
+      "decidedAt": "2026-08-05 10:00"
+    },
+    "rejected": {
+      "state": "rejected",
+      "title": "文档访问申请",
+      "requesterName": "申请人 A",
+      "docTitle": "季度复盘（示例文档）",
+      "requestId": "pilot-request-0001",
+      "resultLabel": "已拒绝",
+      "resultTone": "Attention",
+      "decidedBy": "审批人 B",
+      "decidedAt": "2026-08-05 10:05",
+      "denyReason": "该文档仅限项目组成员访问。"
+    }
+  }
+}

--- a/modules/card_template_catalog/testdata/pilot/docs.pilot-access-request@0.4.0-pilot.20260805/bundle.json
+++ b/modules/card_template_catalog/testdata/pilot/docs.pilot-access-request@0.4.0-pilot.20260805/bundle.json
@@ -5,8 +5,8 @@
   },
   "manifest": {
     "schemaVersion": 2,
-    "id": "docs.access-request",
-    "name": "Docs access request (non-production pilot)",
+    "id": "docs.pilot-access-request",
+    "name": "Docs access request — non-production pilot (dedicated ID)",
     "version": "0.4.0-pilot.20260805",
     "contractVersion": "1.1.0",
     "protocol": "octo-card@1.0",

--- a/modules/incomingwebhook/card_test.go
+++ b/modules/incomingwebhook/card_test.go
@@ -87,3 +87,29 @@ func TestBuildCardPayload(t *testing.T) {
 	}, false)
 	assert.True(t, errors.Is(err, cardmsg.ErrCardPayloadTooLarge), "err=%v", err)
 }
+
+// PR-C Slice 1 (D3) regression: the webhook envelope is server-built from a
+// fixed key allowlist. A caller-forged Registry identity (metadata inside the
+// card doc) must not surface the server-only top-level catalog markers, and
+// no dynamic capability exists on this ingress.
+func TestBuildCardPayloadNeverEmitsCatalogMarkers(t *testing.T) {
+	t.Setenv(cardmsg.EnvEnabled, "true")
+	p, err := buildCardPayload(cardTestModel(), &pushPayloadReq{
+		MsgType: msgTypeCard,
+		Card: map[string]interface{}{
+			"type": "AdaptiveCard", "version": "1.5",
+			"body": []interface{}{
+				map[string]interface{}{"type": "TextBlock", "text": "forged registry lookalike"},
+			},
+			"metadata": map[string]interface{}{"octo": map[string]interface{}{
+				"protocol": "octo-card@1.0",
+				"template": map[string]interface{}{"id": "docs.access-request", "version": "0.3.0"},
+			}},
+		},
+	}, false)
+	assert.NoError(t, err)
+	_, hasRef := p[cardmsg.CatalogTemplateRefKey]
+	_, hasProvenance := p[cardmsg.CatalogProvenanceKey]
+	assert.False(t, hasRef, "webhook envelope grew template_ref")
+	assert.False(t, hasProvenance, "webhook envelope grew catalog_provenance")
+}

--- a/modules/message/api_card_action.go
+++ b/modules/message/api_card_action.go
@@ -33,6 +33,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/common"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
 	"github.com/Mininglamp-OSS/octo-server/internal/cardactiondispatch"
+	"github.com/Mininglamp-OSS/octo-server/internal/carddispatch"
 	"github.com/Mininglamp-OSS/octo-server/modules/group"
 	"github.com/Mininglamp-OSS/octo-server/modules/thread"
 	"github.com/Mininglamp-OSS/octo-server/pkg/cardmsg"
@@ -221,10 +222,14 @@ func (m *Message) cardAction(c *wkhttp.Context) {
 		return
 	}
 	cardSpaceID := m.resolveCardOriginSpaceID(msgM)
-	cardContext, err := resolveRegistryCardContext(c.Request.Context(), cardtmpl.CatalogAccess{
-		Purpose: cardtmpl.CatalogPurposeActionContext,
-		Principal: cardtmpl.CatalogPrincipal{
-			Kind: cardtmpl.CatalogPrincipalBot, ID: msgM.FromUID, SpaceID: cardSpaceID,
+	// PR-C D3：principal 从生效帧的 stored provenance 恢复并校验（sender/
+	// producer 绑定/Space 一致性都在 resolveRegistryCardContext 内 fail-close）；
+	// 无标记的 legacy 帧沿用 sender 派生的 bot principal（static 兼容）。
+	cardContext, err := resolveRegistryCardContext(c.Request.Context(), cardActionFrameOrigin{
+		SenderUID: msgM.FromUID,
+		SpaceID:   cardSpaceID,
+		ProducerBinding: func(producerID string) (string, bool) {
+			return carddispatch.ProducerBindingFromContext(m.ctx, carddispatch.ProducerID(producerID))
 		},
 	}, effective, req.ActionID, actionData)
 	if err != nil {
@@ -300,12 +305,29 @@ func (m *Message) cardAction(c *wkhttp.Context) {
 	c.Response(map[string]interface{}{"accepted": true, "replay": false})
 }
 
+// cardActionFrameOrigin carries the server-side facts a stored frame's
+// provenance is validated against: the stored sender, the card's
+// authoritative origin Space, and the read-only producer-binding resolver.
+// None of these values comes from the click request.
+type cardActionFrameOrigin struct {
+	SenderUID       string
+	SpaceID         string
+	ProducerBinding func(producerID string) (senderUID string, ok bool)
+}
+
 // resolveRegistryCardContext binds callback context to metadata and interaction
 // reports from the effective server-authored frame. Cards without octo-card
 // template metadata retain the legacy zero context.
+//
+// PR-C D3：帧携带 catalog_provenance 时，它是 principal 的唯一来源 —— 先证明
+// 与 stored sender（bot：principal_id==FromUID；internal producer：注册的
+// binding SenderUID==FromUID）及权威 Space 一致，才进入 catalog access 与
+// durable CardContext；任何畸形/不一致 fail-close。无 provenance 的帧（含
+// pre-PR-C 的 template_ref-only Bot 帧）保留 sender 派生的 legacy bot
+// principal，且绝不给 CardContext 发明 validated principal 字段。
 func resolveRegistryCardContext(
 	ctx context.Context,
-	access cardtmpl.CatalogAccess,
+	origin cardActionFrameOrigin,
 	effective []byte,
 	actionID string,
 	actionData map[string]interface{},
@@ -316,6 +338,29 @@ func resolveRegistryCardContext(
 			return cardactiondispatch.CardContext{}, errors.New("message: card template metadata is incomplete")
 		}
 		return cardactiondispatch.CardContext{}, nil
+	}
+	markers, err := cardmsg.CatalogFrameMarkers(effective)
+	if err != nil {
+		return cardactiondispatch.CardContext{}, err
+	}
+	access := cardtmpl.CatalogAccess{
+		Purpose: cardtmpl.CatalogPurposeActionContext,
+		Principal: cardtmpl.CatalogPrincipal{
+			Kind: cardtmpl.CatalogPrincipalBot, ID: origin.SenderUID, SpaceID: origin.SpaceID,
+		},
+	}
+	var validated *cardactiondispatch.CardContext
+	if markers.HasProvenance {
+		principal, err := validatedFramePrincipal(origin, markers.Provenance)
+		if err != nil {
+			return cardactiondispatch.CardContext{}, err
+		}
+		access.Principal = principal
+		validated = &cardactiondispatch.CardContext{
+			PrincipalType: markers.Provenance.PrincipalType,
+			PrincipalID:   principal.ID,
+			SpaceID:       principal.SpaceID,
+		}
 	}
 	catalog := cardtmpl.DefaultCatalog()
 	if catalog == nil {
@@ -342,9 +387,50 @@ func resolveRegistryCardContext(
 			return cardactiondispatch.CardContext{}, errors.New("message: card template owner does not match action route owner")
 		}
 	}
-	return cardactiondispatch.CardContext{
+	cardContext := cardactiondispatch.CardContext{
 		TemplateID: ref.ID, TemplateVersion: ref.Version, View: string(resolved.View),
-	}, nil
+	}
+	if validated != nil {
+		cardContext.PrincipalType = validated.PrincipalType
+		cardContext.PrincipalID = validated.PrincipalID
+		cardContext.SpaceID = validated.SpaceID
+	}
+	return cardContext, nil
+}
+
+// validatedFramePrincipal 证明 stored provenance 与服务端事实一致后，返回
+// catalog principal。失败即篡改/配置漂移信号，一律 fail-close：
+//   - bot principal 必须等于存储行 FromUID（IM 连接鉴权绑定，不可伪造）；
+//   - internal producer 必须在 carddispatch 注册表中绑定到 FromUID；
+//   - provenance 声明的 Space 非空且权威来源 Space 非空时必须一致。
+func validatedFramePrincipal(origin cardActionFrameOrigin, provenance cardmsg.CatalogProvenance) (cardtmpl.CatalogPrincipal, error) {
+	principal, err := cardtmpl.CatalogPrincipalFromProvenance(provenance)
+	if err != nil {
+		return cardtmpl.CatalogPrincipal{}, err
+	}
+	switch principal.Kind {
+	case cardtmpl.CatalogPrincipalBot:
+		if principal.ID != origin.SenderUID {
+			return cardtmpl.CatalogPrincipal{}, errors.New("message: stored bot provenance does not match message sender")
+		}
+	case cardtmpl.CatalogPrincipalInternalProducer:
+		if origin.ProducerBinding == nil {
+			return cardtmpl.CatalogPrincipal{}, errors.New("message: producer binding resolver unavailable")
+		}
+		boundSender, ok := origin.ProducerBinding(principal.ID)
+		if !ok || boundSender != origin.SenderUID {
+			return cardtmpl.CatalogPrincipal{}, errors.New("message: stored producer provenance does not match registered sender")
+		}
+	default:
+		return cardtmpl.CatalogPrincipal{}, errors.New("message: unsupported stored principal kind")
+	}
+	if principal.SpaceID != "" && origin.SpaceID != "" && principal.SpaceID != origin.SpaceID {
+		return cardtmpl.CatalogPrincipal{}, errors.New("message: stored provenance space does not match card origin space")
+	}
+	if principal.SpaceID == "" {
+		principal.SpaceID = origin.SpaceID
+	}
+	return principal, nil
 }
 
 var errInternalCardActionRouteRejected = errors.New("internal card action route rejected")

--- a/modules/message/api_card_action.go
+++ b/modules/message/api_card_action.go
@@ -26,6 +26,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"strings"
 	"time"
@@ -221,19 +222,30 @@ func (m *Message) cardAction(c *wkhttp.Context) {
 		httperr.ResponseErrorL(c, errcode.ErrMessageCardActionInvalid, nil, nil)
 		return
 	}
-	cardSpaceID := m.resolveCardOriginSpaceID(msgM)
+	cardSpaceID, cardSpaceKnown := m.resolveCardOriginSpaceID(msgM)
 	// PR-C D3：principal 从生效帧的 stored provenance 恢复并校验（sender/
 	// producer 绑定/Space 一致性都在 resolveRegistryCardContext 内 fail-close）；
 	// 无标记的 legacy 帧沿用 sender 派生的 bot principal（static 兼容）。
 	cardContext, err := resolveRegistryCardContext(c.Request.Context(), cardActionFrameOrigin{
-		SenderUID: msgM.FromUID,
-		SpaceID:   cardSpaceID,
+		SenderUID:  msgM.FromUID,
+		SpaceID:    cardSpaceID,
+		SpaceKnown: cardSpaceKnown,
 		ProducerBinding: func(producerID string) (string, bool) {
 			return carddispatch.ProducerBindingFromContext(m.ctx, carddispatch.ProducerID(producerID))
 		},
 	}, effective, req.ActionID, actionData)
 	if err != nil {
 		m.releaseCardClaim(idemKey)
+		if errors.Is(err, errCardOriginSpaceUnavailable) {
+			// The click is well formed and the frame may be perfectly valid; we
+			// simply could not read the card's Space to check it against. That
+			// is an outage on our side, and answering 400 would both mislead
+			// the operator and tell the client not to retry.
+			m.Error("卡片来源 Space 不可用,无法校验 stored provenance",
+				zap.Error(err), zap.String("messageID", req.MessageID))
+			httperr.ResponseErrorL(c, errcode.ErrSharedInternal, nil, nil)
+			return
+		}
 		m.Warn("registry 卡片 action 与已发布交互契约不一致,拒绝",
 			zap.Error(err), zap.String("messageID", req.MessageID), zap.String("actionID", req.ActionID))
 		httperr.ResponseErrorL(c, errcode.ErrMessageCardActionInvalid, nil, nil)
@@ -310,8 +322,13 @@ func (m *Message) cardAction(c *wkhttp.Context) {
 // authoritative origin Space, and the read-only producer-binding resolver.
 // None of these values comes from the click request.
 type cardActionFrameOrigin struct {
-	SenderUID       string
-	SpaceID         string
+	SenderUID string
+	SpaceID   string
+	// SpaceKnown reports that SpaceID is a determined fact. False means the
+	// origin lookup did not answer, which is not the same as "this card is in
+	// no Space" — see resolveCardOriginSpaceID. A frame's provenance can only
+	// be validated against a Space that was actually established.
+	SpaceKnown      bool
 	ProducerBinding func(producerID string) (senderUID string, ok bool)
 }
 
@@ -424,14 +441,35 @@ func validatedFramePrincipal(origin cardActionFrameOrigin, provenance cardmsg.Ca
 	default:
 		return cardtmpl.CatalogPrincipal{}, errors.New("message: unsupported stored principal kind")
 	}
-	if principal.SpaceID != "" && origin.SpaceID != "" && principal.SpaceID != origin.SpaceID {
-		return cardtmpl.CatalogPrincipal{}, errors.New("message: stored provenance space does not match card origin space")
+	// A frame that names a Space is only trustworthy once that claim has been
+	// checked against the server's own answer. Skipping the check when the
+	// origin could not be determined would leave principal.SpaceID set to
+	// whatever the frame said, and that value becomes the grant scope for the
+	// action_context authorization — so a frame that reached storage without
+	// passing a trusted boundary could name any Space it liked. The bot branch
+	// above pins the principal *id* to the stored sender; nothing pins the
+	// Space but this.
+	if principal.SpaceID != "" {
+		if !origin.SpaceKnown {
+			return cardtmpl.CatalogPrincipal{}, fmt.Errorf(
+				"%w: card origin space is unavailable, cannot verify stored provenance space",
+				errCardOriginSpaceUnavailable)
+		}
+		if principal.SpaceID != origin.SpaceID {
+			return cardtmpl.CatalogPrincipal{}, errors.New("message: stored provenance space does not match card origin space")
+		}
 	}
 	if principal.SpaceID == "" {
 		principal.SpaceID = origin.SpaceID
 	}
 	return principal, nil
 }
+
+// errCardOriginSpaceUnavailable separates "the card's Space could not be read
+// right now" from "this click is malformed". Both refuse the action, but only
+// the first is worth retrying, and reporting it as a client error would tell an
+// operator to go looking at the payload instead of at the group table.
+var errCardOriginSpaceUnavailable = errors.New("message: card origin space unavailable")
 
 var errInternalCardActionRouteRejected = errors.New("internal card action route rejected")
 
@@ -585,14 +623,23 @@ func (m *Message) authorizeCardChannelMember(c *wkhttp.Context, loginUID, messag
 //
 // 任一步取不到 → 返回 ""(fail-closed:调用方省略 event_data.space_id,与 send 路径
 // 无权威值时 strip 客户端 space 的行为对齐;绝不回退到客户端可影响的上下文 Space)。
-func (m *Message) resolveCardOriginSpaceID(msgM *messageModel) string {
+//
+// The second return value separates two outcomes that used to share one empty
+// string. `known=true, spaceID=""` is a determined fact — a DM outside any
+// Space. `known=false` means the lookup itself did not answer: a group row that
+// could not be read, a malformed thread channel, an unparseable payload. The
+// distinction is load-bearing downstream: a frame's provenance can only be
+// checked against an origin Space that was actually established, and treating
+// "could not determine" as "there is none" both skips that check and turns
+// transient outages into permanent-looking rejections.
+func (m *Message) resolveCardOriginSpaceID(msgM *messageModel) (string, bool) {
 	switch msgM.ChannelType {
 	case common.ChannelTypeGroup.Uint8():
 		return m.groupSpaceIDOrEmpty(msgM.ChannelID)
 	case common.ChannelTypeCommunityTopic.Uint8():
 		parent, err := m.resolveParentGroupNo(msgM.ChannelID)
 		if err != nil || parent == "" {
-			return ""
+			return "", false
 		}
 		return m.groupSpaceIDOrEmpty(parent)
 	case common.ChannelTypePerson.Uint8():
@@ -600,21 +647,24 @@ func (m *Message) resolveCardOriginSpaceID(msgM *messageModel) string {
 			SpaceID string `json:"space_id"`
 		}
 		if err := json.Unmarshal(msgM.Payload, &env); err != nil {
-			return ""
+			return "", false
 		}
-		return env.SpaceID
+		// A DM payload legitimately carries no Space when the sender had none
+		// to stamp, so an absent value here is an answer rather than a failure.
+		return env.SpaceID, true
 	default:
-		return ""
+		return "", false
 	}
 }
 
-// groupSpaceIDOrEmpty 查群的权威 SpaceID;任何错误 / 空群 / 空 SpaceID → ""。
-func (m *Message) groupSpaceIDOrEmpty(groupNo string) string {
+// groupSpaceIDOrEmpty 查群的权威 SpaceID。查询失败 / 群不存在 → ("", false):
+// 未能判定。群存在但没有 SpaceID → ("", true):判定为「不属于任何 Space」。
+func (m *Message) groupSpaceIDOrEmpty(groupNo string) (string, bool) {
 	g, err := m.groupService.GetGroupWithGroupNo(groupNo)
 	if err != nil || g == nil {
-		return ""
+		return "", false
 	}
-	return g.SpaceID
+	return g.SpaceID, true
 }
 
 // cardCanonicalVisibleToViewer 复刻单条读 respondSingleMessage 的「内容可见性」层

--- a/modules/message/api_card_action.go
+++ b/modules/message/api_card_action.go
@@ -378,6 +378,25 @@ func resolveRegistryCardContext(
 			PrincipalID:   principal.ID,
 			SpaceID:       principal.SpaceID,
 		}
+	} else if !frozenRegistryKnows(cardtmpl.ID(ref.ID), ref.Version) {
+		// D3 fail-close for a markerless frame that names a *dynamic* version.
+		//
+		// The identity above comes from `card.metadata.octo.template`, which
+		// lives inside the card body a raw caller controls; raw ingress rejects
+		// the two server-only *top-level* keys, not this. Without this branch a
+		// frame carrying no server-authored provenance is authorized against
+		// the sender-derived Bot principal — which is the sending Bot's own
+		// grant identity — and `Allows(action_context)` reads `edit`. So a Bot
+		// holding only `discover+edit` could fabricate a frame naming an active
+		// dynamic version and drive its action route, with `edit` standing in
+		// for the `send` grant the frame never had.
+		//
+		// Markerless compatibility exists for one population: cards delivered
+		// before PR-C, every one of which names a version the frozen Registry
+		// knows. Scoping the fallback to exactly that population keeps invariant
+		// 7 intact and closes the substitution.
+		return cardactiondispatch.CardContext{}, fmt.Errorf(
+			"%w: %s@%s", errMarkerlessDynamicFrame, ref.ID, ref.Version)
 	}
 	catalog := cardtmpl.DefaultCatalog()
 	if catalog == nil {
@@ -449,15 +468,21 @@ func validatedFramePrincipal(origin cardActionFrameOrigin, provenance cardmsg.Ca
 	// passing a trusted boundary could name any Space it liked. The bot branch
 	// above pins the principal *id* to the stored sender; nothing pins the
 	// Space but this.
-	if principal.SpaceID != "" {
-		if !origin.SpaceKnown {
-			return cardtmpl.CatalogPrincipal{}, fmt.Errorf(
-				"%w: card origin space is unavailable, cannot verify stored provenance space",
-				errCardOriginSpaceUnavailable)
-		}
-		if principal.SpaceID != origin.SpaceID {
-			return cardtmpl.CatalogPrincipal{}, errors.New("message: stored provenance space does not match card origin space")
-		}
+	// Refuse whenever the origin Space is unknown, whether or not the frame
+	// names one. The empty-Space branch looks harmless and is not: assigning an
+	// unknown origin leaves principal.SpaceID == "", which loadGrantDecision
+	// resolves against the *global* row alone. A principal holding an active
+	// global grant plus an exact tombstone for the card's real Space would then
+	// be allowed — defeating invariant 11, which exists precisely so an exact
+	// tombstone can shadow a live global grant. A transient group-row read is
+	// enough to reach it, so the unknown case has to fail closed on both sides.
+	if !origin.SpaceKnown {
+		return cardtmpl.CatalogPrincipal{}, fmt.Errorf(
+			"%w: card origin space is unavailable, cannot resolve the grant scope",
+			errCardOriginSpaceUnavailable)
+	}
+	if principal.SpaceID != "" && principal.SpaceID != origin.SpaceID {
+		return cardtmpl.CatalogPrincipal{}, errors.New("message: stored provenance space does not match card origin space")
 	}
 	if principal.SpaceID == "" {
 		principal.SpaceID = origin.SpaceID
@@ -470,6 +495,27 @@ func validatedFramePrincipal(origin cardActionFrameOrigin, provenance cardmsg.Ca
 // the first is worth retrying, and reporting it as a client error would tell an
 // operator to go looking at the payload instead of at the group table.
 var errCardOriginSpaceUnavailable = errors.New("message: card origin space unavailable")
+
+// errMarkerlessDynamicFrame is the refusal for a frame that names a template
+// the frozen Registry does not know and carries no server-authored provenance.
+// It is deliberately not merged into the generic invalid-action error class at
+// the source so the reason survives into the logs; the handler still collapses
+// it onto the one client-visible 400, because telling a caller *which* of the
+// action rejections it hit is an enumeration aid.
+var errMarkerlessDynamicFrame = errors.New("message: dynamic frame carries no server-authored provenance")
+
+// frozenRegistryKnows reports whether the process Registry holds this exact
+// version. It is the test for "this card predates the dynamic catalog", not a
+// permission check — a static template being known here says nothing about who
+// may act on it, which is still decided by the authorizer downstream.
+func frozenRegistryKnows(id cardtmpl.ID, version string) bool {
+	registry := cardtmpl.DefaultRegistry()
+	if registry == nil {
+		return false
+	}
+	_, err := registry.Lookup(id, version)
+	return err == nil
+}
 
 var errInternalCardActionRouteRejected = errors.New("internal card action route rejected")
 

--- a/modules/message/card_action_template_context_test.go
+++ b/modules/message/card_action_template_context_test.go
@@ -108,7 +108,14 @@ func TestResolveRegistryCardContextRejectsV3LegacyControlIDs(t *testing.T) {
 	}
 	previousCatalog := cardtmpl.DefaultCatalog()
 	cardtmpl.SetDefaultCatalog(static)
-	t.Cleanup(func() { cardtmpl.SetDefaultCatalog(previousCatalog) })
+	// Install the Registry too: the markerless-frame guard consults it, and
+	// production always has one (DefaultCatalog itself falls back to it).
+	previousRegistry := cardtmpl.DefaultRegistry()
+	cardtmpl.SetDefaultRegistry(registry)
+	t.Cleanup(func() {
+		cardtmpl.SetDefaultCatalog(previousCatalog)
+		cardtmpl.SetDefaultRegistry(previousRegistry)
+	})
 
 	origin := cardActionFrameOrigin{SenderUID: "bot-reasoning", SpaceID: "space-1", SpaceKnown: true}
 	for _, tc := range []struct {
@@ -202,7 +209,17 @@ func provenanceActionFixture(t *testing.T) (*cardtmpl.Registry, *actionContextCa
 	spy := &actionContextCatalogSpy{Catalog: static}
 	previousCatalog := cardtmpl.DefaultCatalog()
 	cardtmpl.SetDefaultCatalog(spy)
-	t.Cleanup(func() { cardtmpl.SetDefaultCatalog(previousCatalog) })
+	// The markerless-frame guard asks the frozen Registry whether it knows the
+	// version a frame names, so the fixture has to install one the way the
+	// composition root does. Without it the guard sees no Registry, answers
+	// "unknown" for everything, and every legacy frame is refused — fail-closed,
+	// but it would make this fixture disagree with production.
+	previousRegistry := cardtmpl.DefaultRegistry()
+	cardtmpl.SetDefaultRegistry(registry)
+	t.Cleanup(func() {
+		cardtmpl.SetDefaultCatalog(previousCatalog)
+		cardtmpl.SetDefaultRegistry(previousRegistry)
+	})
 	return registry, spy
 }
 
@@ -393,5 +410,113 @@ func TestValidatedFramePrincipalRefusesAFrameSpaceItCannotCheck(t *testing.T) {
 	if _, err := resolveRegistryCardContext(context.Background(), blind, plain,
 		cardtmpl.DocsApproveActionID, plainData); errors.Is(err, errCardOriginSpaceUnavailable) {
 		t.Fatalf("an unmarked frame was refused for a Space it never claimed: %v", err)
+	}
+}
+
+// Review P1-1: the escalation this closes. A markerless frame's template
+// identity comes from `card.metadata.octo.template` — inside the card body a
+// raw caller controls — while raw ingress only rejects the two *top-level*
+// server-only keys. With no marker the principal fell back to the sending
+// Bot's own identity, and `Allows(action_context)` reads `edit`. So a Bot with
+// only `discover+edit` could fabricate a frame naming an active dynamic version
+// and drive its action route, with `edit` standing in for the `send` grant the
+// frame never had.
+//
+// Markerless compatibility exists for cards delivered before PR-C, every one of
+// which names a version the frozen Registry knows. Scoping the fallback to
+// exactly that population keeps invariant 7 and closes the substitution.
+func TestMarkerlessFrameNamingAnUnknownTemplateIsRefused(t *testing.T) {
+	registry, _ := provenanceActionFixture(t)
+	binding := func(string) (string, bool) { return "", false }
+	origin := cardActionFrameOrigin{
+		SenderUID: "notification", SpaceID: "space-1", SpaceKnown: true, ProducerBinding: binding,
+	}
+
+	// A markerless frame naming the frozen Registry's own version still works —
+	// that is the entire legacy population and it must not regress.
+	legacy, legacyData := markedActionFrame(t, registry, nil)
+	if _, err := resolveRegistryCardContext(context.Background(), origin, legacy,
+		cardtmpl.DocsApproveActionID, legacyData); err != nil {
+		t.Fatalf("a legacy markerless frame was refused: %v", err)
+	}
+
+	// The raw-forgery shape: no top-level marker at all (ingress rejects those
+	// by key presence), only the nested metadata a caller controls, pointed at
+	// a version the Registry does not know. Refused before any authorization.
+	forged := retargetFrameTemplateVersion(t, legacy, "9.9.9-dyn")
+	_, err := resolveRegistryCardContext(context.Background(), origin, forged,
+		cardtmpl.DocsApproveActionID, legacyData)
+	if !errors.Is(err, errMarkerlessDynamicFrame) {
+		t.Fatalf("err = %v, want errMarkerlessDynamicFrame", err)
+	}
+}
+
+// retargetFrameTemplateVersion rewrites metadata.octo.template.version, which is
+// the field a raw caller controls, leaving everything else intact.
+func retargetFrameTemplateVersion(t *testing.T, frame []byte, version string) []byte {
+	t.Helper()
+	var envelope map[string]any
+	if err := json.Unmarshal(frame, &envelope); err != nil {
+		t.Fatalf("decode frame: %v", err)
+	}
+	// A raw caller cannot set the top-level marker — ingress rejects it by key
+	// presence — so the forgery has to work without one.
+	delete(envelope, "template_ref")
+	card, _ := envelope["card"].(map[string]any)
+	metadata, _ := card["metadata"].(map[string]any)
+	octo, _ := metadata["octo"].(map[string]any)
+	template, _ := octo["template"].(map[string]any)
+	if template == nil {
+		t.Fatal("frame carries no metadata.octo.template")
+	}
+	template["version"] = version
+	retargeted, err := json.Marshal(envelope)
+	if err != nil {
+		t.Fatalf("encode frame: %v", err)
+	}
+	return retargeted
+}
+
+// Review P2-3: an unknown origin Space had to fail closed on *both* branches.
+// The empty-Space branch looks harmless and is not — assigning an unknown
+// origin leaves the principal's Space empty, which resolves against the global
+// grant row alone, so a principal holding an active global grant plus an exact
+// tombstone for the card's real Space would be allowed. That defeats invariant
+// 11, whose whole purpose is letting an exact tombstone shadow a live global
+// grant, and a transient group-row read failure is enough to reach it.
+func TestUnknownOriginSpaceIsRefusedWhateverTheFrameClaims(t *testing.T) {
+	registry, _ := provenanceActionFixture(t)
+	binding := func(producerID string) (string, bool) {
+		if producerID == "docs-notify" {
+			return "notification", true
+		}
+		return "", false
+	}
+	blind := cardActionFrameOrigin{SenderUID: "notification", ProducerBinding: binding}
+
+	for _, frameSpace := range []string{"space-1", ""} {
+		raw, actionData := markedActionFrame(t, registry, map[string]interface{}{
+			"version": 1, "principal_type": "internal_producer",
+			"principal_id": "docs-notify", "space_id": frameSpace,
+		})
+		_, err := resolveRegistryCardContext(context.Background(), blind, raw,
+			cardtmpl.DocsApproveActionID, actionData)
+		if !errors.Is(err, errCardOriginSpaceUnavailable) {
+			t.Fatalf("frame space %q: err = %v, want errCardOriginSpaceUnavailable", frameSpace, err)
+		}
+	}
+
+	// A determined origin still resolves, so the refusal is about not knowing
+	// rather than about the Space being absent.
+	known := blind
+	known.SpaceKnown = true
+	known.SpaceID = "space-1"
+	raw, actionData := markedActionFrame(t, registry, map[string]interface{}{
+		"version": 1, "principal_type": "internal_producer",
+		"principal_id": "docs-notify", "space_id": "space-1",
+	})
+	if _, err := resolveRegistryCardContext(context.Background(), known, raw,
+		cardtmpl.DocsApproveActionID, actionData); err != nil {
+		t.Fatalf("a determined origin Space was refused: %v", err)
 	}
 }

--- a/modules/message/card_action_template_context_test.go
+++ b/modules/message/card_action_template_context_test.go
@@ -42,13 +42,8 @@ func TestResolveRegistryCardContextUsesEffectiveMetadataAndReport(t *testing.T) 
 	if !ok {
 		t.Fatal("approve action not found in rendered card")
 	}
-	access := cardtmpl.CatalogAccess{
-		Purpose: cardtmpl.CatalogPurposeActionContext,
-		Principal: cardtmpl.CatalogPrincipal{
-			Kind: cardtmpl.CatalogPrincipalBot, ID: "notification", SpaceID: "space-1",
-		},
-	}
-	got, err := resolveRegistryCardContext(context.Background(), access, raw, cardtmpl.DocsApproveActionID, actionData)
+	origin := cardActionFrameOrigin{SenderUID: "notification", SpaceID: "space-1"}
+	got, err := resolveRegistryCardContext(context.Background(), origin, raw, cardtmpl.DocsApproveActionID, actionData)
 	if err != nil {
 		t.Fatalf("resolveRegistryCardContext: %v", err)
 	}
@@ -56,16 +51,22 @@ func TestResolveRegistryCardContextUsesEffectiveMetadataAndReport(t *testing.T) 
 	if got != want {
 		t.Fatalf("card context = %+v, want %+v", got, want)
 	}
-	if spy.lastRequest.Access != access {
-		t.Fatalf("action catalog access = %+v, want %+v", spy.lastRequest.Access, access)
+	wantAccess := cardtmpl.CatalogAccess{
+		Purpose: cardtmpl.CatalogPurposeActionContext,
+		Principal: cardtmpl.CatalogPrincipal{
+			Kind: cardtmpl.CatalogPrincipalBot, ID: "notification", SpaceID: "space-1",
+		},
 	}
-	if _, err := resolveRegistryCardContext(context.Background(), access, raw, "missing", nil); err == nil {
+	if spy.lastRequest.Access != wantAccess {
+		t.Fatalf("action catalog access = %+v, want %+v", spy.lastRequest.Access, wantAccess)
+	}
+	if _, err := resolveRegistryCardContext(context.Background(), origin, raw, "missing", nil); err == nil {
 		t.Fatal("undeclared action resolved without error")
 	}
 
 	// P2-b(PR#641 review):route owner(Action.data.owner)与 template owner 不一致
 	// 必须拒绝 —— 防止带 docs 身份的信封投递到别的路由。
-	if _, err := resolveRegistryCardContext(context.Background(), access, raw, cardtmpl.DocsApproveActionID,
+	if _, err := resolveRegistryCardContext(context.Background(), origin, raw, cardtmpl.DocsApproveActionID,
 		map[string]interface{}{"owner": "summary", "action_type": "access_request.decision"}); err == nil {
 		t.Fatal("owner mismatch resolved without error")
 	}
@@ -77,7 +78,7 @@ func TestResolveRegistryCardContextUsesEffectiveMetadataAndReport(t *testing.T) 
 	template := octo["template"].(map[string]any)
 	delete(template, "version")
 	partialRaw, _ := json.Marshal(payload)
-	if _, err := resolveRegistryCardContext(context.Background(), access, partialRaw, cardtmpl.DocsApproveActionID, actionData); err == nil {
+	if _, err := resolveRegistryCardContext(context.Background(), origin, partialRaw, cardtmpl.DocsApproveActionID, actionData); err == nil {
 		t.Fatal("partial registry metadata resolved as a legacy card")
 	}
 
@@ -87,11 +88,11 @@ func TestResolveRegistryCardContextUsesEffectiveMetadataAndReport(t *testing.T) 
 		"metadata": map[string]any{"octo": "corrupt"},
 	}}
 	corruptRaw, _ := json.Marshal(corrupt)
-	if _, err := resolveRegistryCardContext(context.Background(), access, corruptRaw, "any", nil); err == nil {
+	if _, err := resolveRegistryCardContext(context.Background(), origin, corruptRaw, "any", nil); err == nil {
 		t.Fatal("corrupt octo metadata resolved as a legacy card")
 	}
 
-	legacy, err := resolveRegistryCardContext(context.Background(), access, []byte(`{"type":17,"card":{"body":[]}}`), "legacy", nil)
+	legacy, err := resolveRegistryCardContext(context.Background(), origin, []byte(`{"type":17,"card":{"body":[]}}`), "legacy", nil)
 	if err != nil || legacy != (cardactiondispatch.CardContext{}) {
 		t.Fatalf("legacy context = (%+v, %v)", legacy, err)
 	}
@@ -109,12 +110,7 @@ func TestResolveRegistryCardContextRejectsV3LegacyControlIDs(t *testing.T) {
 	cardtmpl.SetDefaultCatalog(static)
 	t.Cleanup(func() { cardtmpl.SetDefaultCatalog(previousCatalog) })
 
-	access := cardtmpl.CatalogAccess{
-		Purpose: cardtmpl.CatalogPurposeActionContext,
-		Principal: cardtmpl.CatalogPrincipal{
-			Kind: cardtmpl.CatalogPrincipalBot, ID: "bot-reasoning", SpaceID: "space-1",
-		},
-	}
+	origin := cardActionFrameOrigin{SenderUID: "bot-reasoning", SpaceID: "space-1"}
 	for _, tc := range []struct {
 		state    cardtmpl.State
 		actionID string
@@ -138,7 +134,7 @@ func TestResolveRegistryCardContextRejectsV3LegacyControlIDs(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			_, err = resolveRegistryCardContext(context.Background(), access, raw, tc.actionID,
+			_, err = resolveRegistryCardContext(context.Background(), origin, raw, tc.actionID,
 				map[string]interface{}{"owner": "ai", "action_type": "reasoning.control"})
 			if !errors.Is(err, cardtmpl.ErrActionUnknown) {
 				t.Fatalf("resolve legacy action error = %v, want ErrActionUnknown", err)
@@ -158,4 +154,198 @@ func (s *actionContextCatalogSpy) ActionContext(
 ) (cardtmpl.CatalogActionContext, error) {
 	s.lastRequest = request
 	return s.Catalog.ActionContext(ctx, request)
+}
+
+// ---- PR-C Slice 1 (D3): the action ingress derives the catalog principal
+// from the frame's stored catalog_provenance after proving it consistent with
+// the stored sender and authoritative Space — never from raw guesses. ----
+
+func markedActionFrame(t *testing.T, registry *cardtmpl.Registry, provenance map[string]interface{}) ([]byte, map[string]interface{}) {
+	t.Helper()
+	sample, err := docsaccessrequest.Assets.ReadFile(docsaccessrequest.HandoffRoot + "/samples/pending.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload, err := registry.Render(context.Background(), docsaccessrequest.TemplateID, "",
+		docsaccessrequest.StatePending, sample,
+		cardtmpl.BuildEnv{WebLoginURL: "https://web.example.com", Lang: "en", SpaceID: "space-1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload["template_ref"] = map[string]interface{}{
+		"id": string(docsaccessrequest.TemplateID), "version": docsaccessrequest.TemplateVersion,
+	}
+	if provenance != nil {
+		payload["catalog_provenance"] = provenance
+	}
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	actionData, ok := cardmsg.SubmitAction(raw, cardtmpl.DocsApproveActionID)
+	if !ok {
+		t.Fatal("approve action not found")
+	}
+	return raw, actionData
+}
+
+func provenanceActionFixture(t *testing.T) (*cardtmpl.Registry, *actionContextCatalogSpy) {
+	t.Helper()
+	registry := cardtmpl.NewRegistry()
+	registry.Register(docsaccessrequest.New(), docsaccessrequest.Assets, docsaccessrequest.HandoffRoot)
+	registry.SetDefault(docsaccessrequest.TemplateID, docsaccessrequest.TemplateVersion)
+	registry.Freeze()
+	static, err := cardtmpl.NewStaticCatalog(registry)
+	if err != nil {
+		t.Fatal(err)
+	}
+	spy := &actionContextCatalogSpy{Catalog: static}
+	previousCatalog := cardtmpl.DefaultCatalog()
+	cardtmpl.SetDefaultCatalog(spy)
+	t.Cleanup(func() { cardtmpl.SetDefaultCatalog(previousCatalog) })
+	return registry, spy
+}
+
+func TestResolveRegistryCardContextUsesStoredProvenancePrincipal(t *testing.T) {
+	registry, spy := provenanceActionFixture(t)
+	raw, actionData := markedActionFrame(t, registry, map[string]interface{}{
+		"version": 1, "principal_type": "internal_producer",
+		"principal_id": "docs-notify", "space_id": "space-1",
+	})
+	origin := cardActionFrameOrigin{
+		SenderUID: "notification", SpaceID: "space-1",
+		ProducerBinding: func(producerID string) (string, bool) {
+			if producerID == "docs-notify" {
+				return "notification", true
+			}
+			return "", false
+		},
+	}
+	got, err := resolveRegistryCardContext(context.Background(), origin, raw, cardtmpl.DocsApproveActionID, actionData)
+	if err != nil {
+		t.Fatalf("resolveRegistryCardContext: %v", err)
+	}
+	want := cardactiondispatch.CardContext{
+		TemplateID: "docs.access-request", TemplateVersion: "0.2.0", View: "pending",
+		PrincipalType: "internal_producer", PrincipalID: "docs-notify", SpaceID: "space-1",
+	}
+	if got != want {
+		t.Fatalf("card context = %+v, want %+v", got, want)
+	}
+	wantPrincipal := cardtmpl.CatalogPrincipal{
+		Kind: cardtmpl.CatalogPrincipalInternalProducer, ID: "docs-notify", SpaceID: "space-1",
+	}
+	if spy.lastRequest.Access.Principal != wantPrincipal {
+		t.Fatalf("catalog access principal = %+v, want %+v", spy.lastRequest.Access.Principal, wantPrincipal)
+	}
+	if spy.lastRequest.Access.Purpose != cardtmpl.CatalogPurposeActionContext {
+		t.Fatalf("catalog access purpose = %v", spy.lastRequest.Access.Purpose)
+	}
+}
+
+func TestResolveRegistryCardContextRejectsInconsistentProvenance(t *testing.T) {
+	registry, _ := provenanceActionFixture(t)
+	binding := func(producerID string) (string, bool) {
+		if producerID == "docs-notify" {
+			return "notification", true
+		}
+		return "", false
+	}
+	cases := []struct {
+		name       string
+		provenance map[string]interface{}
+		origin     cardActionFrameOrigin
+	}{
+		{
+			name: "producer binding does not match stored sender",
+			provenance: map[string]interface{}{
+				"version": 1, "principal_type": "internal_producer",
+				"principal_id": "docs-notify", "space_id": "space-1",
+			},
+			origin: cardActionFrameOrigin{SenderUID: "other-bot", SpaceID: "space-1", ProducerBinding: binding},
+		},
+		{
+			name: "unregistered producer",
+			provenance: map[string]interface{}{
+				"version": 1, "principal_type": "internal_producer",
+				"principal_id": "rogue-producer", "space_id": "space-1",
+			},
+			origin: cardActionFrameOrigin{SenderUID: "notification", SpaceID: "space-1", ProducerBinding: binding},
+		},
+		{
+			name: "bot provenance names a different bot",
+			provenance: map[string]interface{}{
+				"version": 1, "principal_type": "bot",
+				"principal_id": "bot-a", "space_id": "space-1",
+			},
+			origin: cardActionFrameOrigin{SenderUID: "bot-b", SpaceID: "space-1", ProducerBinding: binding},
+		},
+		{
+			name: "cross-space provenance",
+			provenance: map[string]interface{}{
+				"version": 1, "principal_type": "internal_producer",
+				"principal_id": "docs-notify", "space_id": "space-2",
+			},
+			origin: cardActionFrameOrigin{SenderUID: "notification", SpaceID: "space-1", ProducerBinding: binding},
+		},
+		{
+			name: "malformed provenance",
+			provenance: map[string]interface{}{
+				"version": 1, "principal_type": "internal_producer",
+				"principal_id": "docs-notify", "space_id": "space-1", "extra": true,
+			},
+			origin: cardActionFrameOrigin{SenderUID: "notification", SpaceID: "space-1", ProducerBinding: binding},
+		},
+		{
+			name: "no binding resolver fails closed",
+			provenance: map[string]interface{}{
+				"version": 1, "principal_type": "internal_producer",
+				"principal_id": "docs-notify", "space_id": "space-1",
+			},
+			origin: cardActionFrameOrigin{SenderUID: "notification", SpaceID: "space-1"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			raw, actionData := markedActionFrame(t, registry, tc.provenance)
+			if _, err := resolveRegistryCardContext(context.Background(), tc.origin, raw, cardtmpl.DocsApproveActionID, actionData); err == nil {
+				t.Fatal("inconsistent stored provenance accepted")
+			}
+		})
+	}
+}
+
+func TestResolveRegistryCardContextBotProvenanceMatchesSender(t *testing.T) {
+	registry, _ := provenanceActionFixture(t)
+	raw, actionData := markedActionFrame(t, registry, map[string]interface{}{
+		"version": 1, "principal_type": "bot", "principal_id": "bot-a", "space_id": "space-1",
+	})
+	origin := cardActionFrameOrigin{SenderUID: "bot-a", SpaceID: "space-1"}
+	got, err := resolveRegistryCardContext(context.Background(), origin, raw, cardtmpl.DocsApproveActionID, actionData)
+	if err != nil {
+		t.Fatalf("resolveRegistryCardContext: %v", err)
+	}
+	if got.PrincipalType != "bot" || got.PrincipalID != "bot-a" || got.SpaceID != "space-1" {
+		t.Fatalf("card context principal = %+v", got)
+	}
+}
+
+func TestResolveRegistryCardContextLegacyFrameKeepsSenderPrincipal(t *testing.T) {
+	registry, spy := provenanceActionFixture(t)
+	// Pre-PR-C Bot Registry frame: template_ref only, no provenance.
+	raw, actionData := markedActionFrame(t, registry, nil)
+	origin := cardActionFrameOrigin{SenderUID: "notification", SpaceID: "space-1"}
+	got, err := resolveRegistryCardContext(context.Background(), origin, raw, cardtmpl.DocsApproveActionID, actionData)
+	if err != nil {
+		t.Fatalf("resolveRegistryCardContext: %v", err)
+	}
+	if got.PrincipalType != "" || got.PrincipalID != "" {
+		t.Fatalf("legacy frame invented a validated principal: %+v", got)
+	}
+	wantPrincipal := cardtmpl.CatalogPrincipal{
+		Kind: cardtmpl.CatalogPrincipalBot, ID: "notification", SpaceID: "space-1",
+	}
+	if spy.lastRequest.Access.Principal != wantPrincipal {
+		t.Fatalf("legacy catalog access = %+v, want %+v", spy.lastRequest.Access.Principal, wantPrincipal)
+	}
 }

--- a/modules/message/card_action_template_context_test.go
+++ b/modules/message/card_action_template_context_test.go
@@ -42,7 +42,7 @@ func TestResolveRegistryCardContextUsesEffectiveMetadataAndReport(t *testing.T) 
 	if !ok {
 		t.Fatal("approve action not found in rendered card")
 	}
-	origin := cardActionFrameOrigin{SenderUID: "notification", SpaceID: "space-1"}
+	origin := cardActionFrameOrigin{SenderUID: "notification", SpaceID: "space-1", SpaceKnown: true}
 	got, err := resolveRegistryCardContext(context.Background(), origin, raw, cardtmpl.DocsApproveActionID, actionData)
 	if err != nil {
 		t.Fatalf("resolveRegistryCardContext: %v", err)
@@ -110,7 +110,7 @@ func TestResolveRegistryCardContextRejectsV3LegacyControlIDs(t *testing.T) {
 	cardtmpl.SetDefaultCatalog(static)
 	t.Cleanup(func() { cardtmpl.SetDefaultCatalog(previousCatalog) })
 
-	origin := cardActionFrameOrigin{SenderUID: "bot-reasoning", SpaceID: "space-1"}
+	origin := cardActionFrameOrigin{SenderUID: "bot-reasoning", SpaceID: "space-1", SpaceKnown: true}
 	for _, tc := range []struct {
 		state    cardtmpl.State
 		actionID string
@@ -213,7 +213,7 @@ func TestResolveRegistryCardContextUsesStoredProvenancePrincipal(t *testing.T) {
 		"principal_id": "docs-notify", "space_id": "space-1",
 	})
 	origin := cardActionFrameOrigin{
-		SenderUID: "notification", SpaceID: "space-1",
+		SenderUID: "notification", SpaceID: "space-1", SpaceKnown: true,
 		ProducerBinding: func(producerID string) (string, bool) {
 			if producerID == "docs-notify" {
 				return "notification", true
@@ -262,7 +262,7 @@ func TestResolveRegistryCardContextRejectsInconsistentProvenance(t *testing.T) {
 				"version": 1, "principal_type": "internal_producer",
 				"principal_id": "docs-notify", "space_id": "space-1",
 			},
-			origin: cardActionFrameOrigin{SenderUID: "other-bot", SpaceID: "space-1", ProducerBinding: binding},
+			origin: cardActionFrameOrigin{SenderUID: "other-bot", SpaceID: "space-1", SpaceKnown: true, ProducerBinding: binding},
 		},
 		{
 			name: "unregistered producer",
@@ -270,7 +270,7 @@ func TestResolveRegistryCardContextRejectsInconsistentProvenance(t *testing.T) {
 				"version": 1, "principal_type": "internal_producer",
 				"principal_id": "rogue-producer", "space_id": "space-1",
 			},
-			origin: cardActionFrameOrigin{SenderUID: "notification", SpaceID: "space-1", ProducerBinding: binding},
+			origin: cardActionFrameOrigin{SenderUID: "notification", SpaceID: "space-1", SpaceKnown: true, ProducerBinding: binding},
 		},
 		{
 			name: "bot provenance names a different bot",
@@ -278,7 +278,7 @@ func TestResolveRegistryCardContextRejectsInconsistentProvenance(t *testing.T) {
 				"version": 1, "principal_type": "bot",
 				"principal_id": "bot-a", "space_id": "space-1",
 			},
-			origin: cardActionFrameOrigin{SenderUID: "bot-b", SpaceID: "space-1", ProducerBinding: binding},
+			origin: cardActionFrameOrigin{SenderUID: "bot-b", SpaceID: "space-1", SpaceKnown: true, ProducerBinding: binding},
 		},
 		{
 			name: "cross-space provenance",
@@ -286,7 +286,7 @@ func TestResolveRegistryCardContextRejectsInconsistentProvenance(t *testing.T) {
 				"version": 1, "principal_type": "internal_producer",
 				"principal_id": "docs-notify", "space_id": "space-2",
 			},
-			origin: cardActionFrameOrigin{SenderUID: "notification", SpaceID: "space-1", ProducerBinding: binding},
+			origin: cardActionFrameOrigin{SenderUID: "notification", SpaceID: "space-1", SpaceKnown: true, ProducerBinding: binding},
 		},
 		{
 			name: "malformed provenance",
@@ -294,7 +294,7 @@ func TestResolveRegistryCardContextRejectsInconsistentProvenance(t *testing.T) {
 				"version": 1, "principal_type": "internal_producer",
 				"principal_id": "docs-notify", "space_id": "space-1", "extra": true,
 			},
-			origin: cardActionFrameOrigin{SenderUID: "notification", SpaceID: "space-1", ProducerBinding: binding},
+			origin: cardActionFrameOrigin{SenderUID: "notification", SpaceID: "space-1", SpaceKnown: true, ProducerBinding: binding},
 		},
 		{
 			name: "no binding resolver fails closed",
@@ -302,7 +302,7 @@ func TestResolveRegistryCardContextRejectsInconsistentProvenance(t *testing.T) {
 				"version": 1, "principal_type": "internal_producer",
 				"principal_id": "docs-notify", "space_id": "space-1",
 			},
-			origin: cardActionFrameOrigin{SenderUID: "notification", SpaceID: "space-1"},
+			origin: cardActionFrameOrigin{SenderUID: "notification", SpaceID: "space-1", SpaceKnown: true},
 		},
 	}
 	for _, tc := range cases {
@@ -320,7 +320,7 @@ func TestResolveRegistryCardContextBotProvenanceMatchesSender(t *testing.T) {
 	raw, actionData := markedActionFrame(t, registry, map[string]interface{}{
 		"version": 1, "principal_type": "bot", "principal_id": "bot-a", "space_id": "space-1",
 	})
-	origin := cardActionFrameOrigin{SenderUID: "bot-a", SpaceID: "space-1"}
+	origin := cardActionFrameOrigin{SenderUID: "bot-a", SpaceID: "space-1", SpaceKnown: true}
 	got, err := resolveRegistryCardContext(context.Background(), origin, raw, cardtmpl.DocsApproveActionID, actionData)
 	if err != nil {
 		t.Fatalf("resolveRegistryCardContext: %v", err)
@@ -334,7 +334,7 @@ func TestResolveRegistryCardContextLegacyFrameKeepsSenderPrincipal(t *testing.T)
 	registry, spy := provenanceActionFixture(t)
 	// Pre-PR-C Bot Registry frame: template_ref only, no provenance.
 	raw, actionData := markedActionFrame(t, registry, nil)
-	origin := cardActionFrameOrigin{SenderUID: "notification", SpaceID: "space-1"}
+	origin := cardActionFrameOrigin{SenderUID: "notification", SpaceID: "space-1", SpaceKnown: true}
 	got, err := resolveRegistryCardContext(context.Background(), origin, raw, cardtmpl.DocsApproveActionID, actionData)
 	if err != nil {
 		t.Fatalf("resolveRegistryCardContext: %v", err)
@@ -347,5 +347,51 @@ func TestResolveRegistryCardContextLegacyFrameKeepsSenderPrincipal(t *testing.T)
 	}
 	if spy.lastRequest.Access.Principal != wantPrincipal {
 		t.Fatalf("legacy catalog access = %+v, want %+v", spy.lastRequest.Access.Principal, wantPrincipal)
+	}
+}
+
+// A frame that names a Space is only as trustworthy as the check against the
+// server's own answer. When that answer is unavailable the click must be
+// refused — and refused as an outage, because the frame may be perfectly valid
+// and the caller has no way to fix a group-table read from its side.
+func TestValidatedFramePrincipalRefusesAFrameSpaceItCannotCheck(t *testing.T) {
+	registry, _ := provenanceActionFixture(t)
+	raw, actionData := markedActionFrame(t, registry, map[string]interface{}{
+		"version": 1, "principal_type": "internal_producer",
+		"principal_id": "docs-notify", "space_id": "space-1",
+	})
+	binding := func(producerID string) (string, bool) {
+		if producerID == "docs-notify" {
+			return "notification", true
+		}
+		return "", false
+	}
+	blind := cardActionFrameOrigin{
+		SenderUID: "notification", ProducerBinding: binding,
+		// SpaceKnown deliberately false: the group row would not load.
+	}
+	_, err := resolveRegistryCardContext(context.Background(), blind, raw,
+		cardtmpl.DocsApproveActionID, actionData)
+	if !errors.Is(err, errCardOriginSpaceUnavailable) {
+		t.Fatalf("err = %v, want errCardOriginSpaceUnavailable", err)
+	}
+
+	// A determined "this card is in no Space" is a different answer, and a
+	// frame claiming one then genuinely disagrees with the server.
+	determined := cardActionFrameOrigin{
+		SenderUID: "notification", SpaceKnown: true, ProducerBinding: binding,
+	}
+	_, err = resolveRegistryCardContext(context.Background(), determined, raw,
+		cardtmpl.DocsApproveActionID, actionData)
+	if err == nil || errors.Is(err, errCardOriginSpaceUnavailable) {
+		t.Fatalf("err = %v, want a plain mismatch rejection", err)
+	}
+
+	// An unmarked frame carries no Space claim, so an unavailable origin is
+	// nothing to verify and the legacy path stays open.
+	plain, plainData := markedActionFrame(t, registry, nil)
+	if _, err := resolveRegistryCardContext(context.Background(), blind, plain,
+		cardtmpl.DocsApproveActionID, plainData); errors.Is(err, errCardOriginSpaceUnavailable) {
+		t.Fatalf("an unmarked frame was refused for a Space it never claimed: %v", err)
 	}
 }

--- a/modules/notify/action_finalizer.go
+++ b/modules/notify/action_finalizer.go
@@ -98,7 +98,16 @@ func (f *DocsActionFinalizer) Finalize(ctx context.Context, event cardactiondisp
 		denyReason = strings.TrimSpace(v)
 	}
 	terminal := result.State == cardactiondispatch.StateApproved || result.State == cardactiondispatch.StateDenied
-	if terminal && f.updater != nil {
+	// Cancelled renders through the Registry as well, even though it is not a
+	// terminal decision. The pending card is a Registry render and therefore
+	// carries the server-authored catalog markers; the legacy rebuild below
+	// emits a plain resource card that cannot carry them, so taking that branch
+	// for a marked card erased the markers on an ordinary user click and left
+	// the identity guards in pkg/cardtmpl/updater.go inert for that message.
+	// `terminal` still means "decided" for the notification below — only the
+	// replacement route widens.
+	registryReplaceable := terminal || result.State == cardactiondispatch.StateCancelled
+	if registryReplaceable && f.updater != nil {
 		if err := f.replaceWithRegistryResult(ctx, event, result, channelID, lang, title, denyReason); err != nil {
 			return err
 		}
@@ -178,6 +187,7 @@ func (f *DocsActionFinalizer) replaceWithRegistryResult(ctx context.Context, eve
 		DecidedAtDisplay: result.Display["decided_at"],
 		DenyReason:       denyReason,
 		Denied:           result.State == cardactiondispatch.StateDenied,
+		Cancelled:        result.State == cardactiondispatch.StateCancelled,
 	})
 	if err != nil {
 		return err
@@ -207,6 +217,7 @@ type docsResultRenderInput struct {
 	DecidedAtDisplay string
 	DenyReason       string
 	Denied           bool
+	Cancelled        bool
 }
 
 func buildDocsAccessResultFields(lang string, input docsResultRenderInput) (json.RawMessage, cardtmpl.State, error) {
@@ -234,9 +245,11 @@ func buildDocsAccessResultFields(lang string, input docsResultRenderInput) (json
 	}
 	state := docsaccessrequest.StateApproved
 	wireState := "approved"
-	if input.Denied {
-		state = docsaccessrequest.StateRejected
-		wireState = "rejected"
+	switch {
+	case input.Cancelled:
+		state, wireState = docsaccessrequest.StateCancelled, "cancelled"
+	case input.Denied:
+		state, wireState = docsaccessrequest.StateRejected, "rejected"
 	}
 	actor := stringEventData(input.Data, "actor")
 	document := map[string]any{
@@ -256,10 +269,16 @@ func buildDocsAccessResultFields(lang string, input docsResultRenderInput) (json
 		"state":     wireState,
 		"document":  document,
 		"requester": requester,
-		"decision": map[string]any{
+	}
+	// A cancelled request was never decided, so it has no operator and no
+	// decision time. The data contract requires `decision` only for
+	// approved/rejected; emitting one here would put the generic operator
+	// placeholder on a card nobody acted on.
+	if !input.Cancelled {
+		fields["decision"] = map[string]any{
 			"operatorName":     truncRunes(operatorName, capResultName),
 			"decidedAtDisplay": truncRunes(strings.TrimSpace(input.DecidedAtDisplay), capResultShortLabel),
-		},
+		}
 	}
 	dataCaps := map[string]int{
 		"requestReason":      capResultReason,

--- a/modules/notify/action_finalizer.go
+++ b/modules/notify/action_finalizer.go
@@ -98,16 +98,20 @@ func (f *DocsActionFinalizer) Finalize(ctx context.Context, event cardactiondisp
 		denyReason = strings.TrimSpace(v)
 	}
 	terminal := result.State == cardactiondispatch.StateApproved || result.State == cardactiondispatch.StateDenied
-	// Cancelled renders through the Registry as well, even though it is not a
-	// terminal decision. The pending card is a Registry render and therefore
-	// carries the server-authored catalog markers; the legacy rebuild below
-	// emits a plain resource card that cannot carry them, so taking that branch
-	// for a marked card erased the markers on an ordinary user click and left
-	// the identity guards in pkg/cardtmpl/updater.go inert for that message.
-	// `terminal` still means "decided" for the notification below — only the
-	// replacement route widens.
-	registryReplaceable := terminal || result.State == cardactiondispatch.StateCancelled
-	if registryReplaceable && f.updater != nil {
+	// Every state renders through the Registry when an updater is present, not
+	// just the decided ones. The pending card is a Registry render and so
+	// carries the server-authored catalog markers; the fallback below rebuilds
+	// the frame from a six-key allowlist that holds neither, so routing a
+	// marked card there erased both on an ordinary user click and left the
+	// identity guards in pkg/cardtmpl/updater.go inert for that message.
+	//
+	// Selecting the route by state was the bug's shape, so the state list is
+	// gone rather than extended: `cancelled` was the reported case, `pending`
+	// reaches the same branch, and a state added later would have inherited the
+	// defect silently. What remains is the distinction the fallback was written
+	// for — a deployment with no updater at all. `terminal` still means
+	// "decided", and still gates the notification below.
+	if f.updater != nil {
 		if err := f.replaceWithRegistryResult(ctx, event, result, channelID, lang, title, denyReason); err != nil {
 			return err
 		}
@@ -188,6 +192,13 @@ func (f *DocsActionFinalizer) replaceWithRegistryResult(ctx context.Context, eve
 		DenyReason:       denyReason,
 		Denied:           result.State == cardactiondispatch.StateDenied,
 		Cancelled:        result.State == cardactiondispatch.StateCancelled,
+		// Anything that is not a decision and not an explicit cancellation —
+		// `pending` today, whatever a later contract adds — renders as
+		// unavailable, which is what the pre-Registry fallback already showed
+		// for those states.
+		Unavailable: result.State != cardactiondispatch.StateApproved &&
+			result.State != cardactiondispatch.StateDenied &&
+			result.State != cardactiondispatch.StateCancelled,
 	})
 	if err != nil {
 		return err
@@ -218,6 +229,7 @@ type docsResultRenderInput struct {
 	DenyReason       string
 	Denied           bool
 	Cancelled        bool
+	Unavailable      bool
 }
 
 func buildDocsAccessResultFields(lang string, input docsResultRenderInput) (json.RawMessage, cardtmpl.State, error) {
@@ -246,6 +258,8 @@ func buildDocsAccessResultFields(lang string, input docsResultRenderInput) (json
 	state := docsaccessrequest.StateApproved
 	wireState := "approved"
 	switch {
+	case input.Unavailable:
+		state, wireState = docsaccessrequest.StateUnavailable, "unavailable"
 	case input.Cancelled:
 		state, wireState = docsaccessrequest.StateCancelled, "cancelled"
 	case input.Denied:
@@ -274,7 +288,7 @@ func buildDocsAccessResultFields(lang string, input docsResultRenderInput) (json
 	// decision time. The data contract requires `decision` only for
 	// approved/rejected; emitting one here would put the generic operator
 	// placeholder on a card nobody acted on.
-	if !input.Cancelled {
+	if !input.Cancelled && !input.Unavailable {
 		fields["decision"] = map[string]any{
 			"operatorName":     truncRunes(operatorName, capResultName),
 			"decidedAtDisplay": truncRunes(strings.TrimSpace(input.DecidedAtDisplay), capResultShortLabel),

--- a/modules/notify/action_finalizer.go
+++ b/modules/notify/action_finalizer.go
@@ -158,20 +158,11 @@ func truncRunes(s string, max int) string {
 	return s
 }
 
-// docsResultTemplateVersion 选择 same-version result edit 的目标版本
-// （PR-C D3/D7）：durable event 携带 stored card context 时，它是权威 exact
-// version —— Registry 帧的动作必须回到发送时的版本，绝不跟随常量或 active
-// pointer；context 声明了别的 template ID 则是路由错配，fail-close。
-// pre-registry 的 legacy event（零 context）保持 static V3 行为不变。
+// docsResultTemplateVersion resolves the click-driven result edit's target
+// version from the durable event's stored card context. The rules live in
+// docsResultVersion so the sibling mutate endpoint cannot drift from them.
 func docsResultTemplateVersion(event cardactiondispatch.Event) (string, error) {
-	if event.Card.TemplateID == "" && event.Card.TemplateVersion == "" {
-		return docsaccessrequest.TemplateVersionV3, nil
-	}
-	if event.Card.TemplateID != string(docsaccessrequest.TemplateID) ||
-		strings.TrimSpace(event.Card.TemplateVersion) == "" {
-		return "", errors.New("notify: stored card context does not identify docs.access-request")
-	}
-	return event.Card.TemplateVersion, nil
+	return docsResultVersion(event.Card.TemplateID, event.Card.TemplateVersion)
 }
 
 func (f *DocsActionFinalizer) replaceWithRegistryResult(ctx context.Context, event cardactiondispatch.Event,

--- a/modules/notify/action_finalizer.go
+++ b/modules/notify/action_finalizer.go
@@ -322,7 +322,7 @@ func (f *DocsActionFinalizer) buildTerminalDocument(ctx context.Context, lang, d
 }
 
 // buildDocsDecisionTerminalDocument renders the legacy/no-updater fallback for
-// approved/denied outcomes. Production V3 result updates use CardUpdater.
+// approved/denied outcomes. Production result updates use CardUpdater at the card's stored version.
 func buildDocsDecisionTerminalDocument(ctx context.Context, webLoginURL, lang, docID, spaceID, title, denyReason string, denied bool) (json.RawMessage, error) {
 	labels := docsLabelsFor(lang)
 	if denied {

--- a/modules/notify/action_finalizer.go
+++ b/modules/notify/action_finalizer.go
@@ -158,8 +158,28 @@ func truncRunes(s string, max int) string {
 	return s
 }
 
+// docsResultTemplateVersion 选择 same-version result edit 的目标版本
+// （PR-C D3/D7）：durable event 携带 stored card context 时，它是权威 exact
+// version —— Registry 帧的动作必须回到发送时的版本，绝不跟随常量或 active
+// pointer；context 声明了别的 template ID 则是路由错配，fail-close。
+// pre-registry 的 legacy event（零 context）保持 static V3 行为不变。
+func docsResultTemplateVersion(event cardactiondispatch.Event) (string, error) {
+	if event.Card.TemplateID == "" && event.Card.TemplateVersion == "" {
+		return docsaccessrequest.TemplateVersionV3, nil
+	}
+	if event.Card.TemplateID != string(docsaccessrequest.TemplateID) ||
+		strings.TrimSpace(event.Card.TemplateVersion) == "" {
+		return "", errors.New("notify: stored card context does not identify docs.access-request")
+	}
+	return event.Card.TemplateVersion, nil
+}
+
 func (f *DocsActionFinalizer) replaceWithRegistryResult(ctx context.Context, event cardactiondispatch.Event,
 	result cardactiondispatch.DecisionResult, channelID, lang, title, denyReason string) error {
+	version, err := docsResultTemplateVersion(event)
+	if err != nil {
+		return err
+	}
 	fields, state, err := buildDocsAccessResultFields(lang, docsResultRenderInput{
 		Data:             event.Data,
 		Title:            title,
@@ -180,7 +200,7 @@ func (f *DocsActionFinalizer) replaceWithRegistryResult(ctx context.Context, eve
 		// .octospec/learnings/pending/cardtmpl-interaction-closure.md)。若未来 event
 		// ID 生成器改为非单调,CAS 会静默丢弃合法更新——务必同步复核。
 		SenderUID: event.SenderUID, MessageID: event.MessageID, CardSeq: event.EventID,
-	}, docsaccessrequest.TemplateID, docsaccessrequest.TemplateVersionV3, state, fields, cardtmpl.BuildEnv{
+	}, docsaccessrequest.TemplateID, version, state, fields, cardtmpl.BuildEnv{
 		WebLoginURL: f.ctx.GetConfig().External.WebLoginURL, Lang: lang, SpaceID: event.SpaceID,
 	})
 }

--- a/modules/notify/action_finalizer_v3_test.go
+++ b/modules/notify/action_finalizer_v3_test.go
@@ -338,40 +338,205 @@ func TestDocsActionFinalizerRoutesCancelledThroughTheRegistry(t *testing.T) {
 
 // The template must actually be able to render what the finalizer now asks of
 // it — a state the manifest does not declare fails ViewFor with ErrStateUnknown,
-// which would turn the fix above into a runtime error instead of a card.
-func TestDocsAccessRequestV3RendersTheCancelledState(t *testing.T) {
-	fields, state, err := buildDocsAccessResultFields("zh-CN", docsResultRenderInput{
-		Data:      map[string]any{"request_id": "request-1", "doc_id": "doc-1"},
-		Title:     "Roadmap",
-		Cancelled: true,
-	})
-	if err != nil {
-		t.Fatalf("buildDocsAccessResultFields: %v", err)
-	}
-	if state != docsaccessrequest.StateCancelled {
-		t.Fatalf("state = %q", state)
-	}
+// which would turn the routing fix into a runtime error instead of a card. The
+// finalizer tests above drive a capturing fake and never reach ViewFor, so this
+// is the only thing that witnesses the manifest declaration.
+func TestDocsAccessRequestV3RendersTheNonDecisionStates(t *testing.T) {
 	registry := cardtmpl.NewRegistry()
 	registry.Register(docsaccessrequest.NewV3(), docsaccessrequest.Assets, docsaccessrequest.HandoffRootV3)
 	registry.Freeze()
-	payload, err := registry.Render(context.Background(),
-		docsaccessrequest.TemplateID, docsaccessrequest.TemplateVersionV3, state, fields,
-		cardtmpl.BuildEnv{Lang: "zh-CN", SpaceID: "space-1", WebLoginURL: "https://im.example.com/login"})
-	if err != nil {
-		t.Fatalf("render cancelled: %v", err)
+
+	for _, test := range []struct {
+		name        string
+		input       docsResultRenderInput
+		wantState   cardtmpl.State
+		wantVariant string
+	}{
+		{
+			name:        "cancelled",
+			input:       docsResultRenderInput{Cancelled: true},
+			wantState:   docsaccessrequest.StateCancelled,
+			wantVariant: docsaccessrequest.VariantCancelled,
+		},
+		{
+			name:        "unavailable",
+			input:       docsResultRenderInput{Unavailable: true},
+			wantState:   docsaccessrequest.StateUnavailable,
+			wantVariant: docsaccessrequest.VariantUnavailable,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			input := test.input
+			input.Data = map[string]any{"request_id": "request-1", "doc_id": "doc-1"}
+			input.Title = "Roadmap"
+			fields, state, err := buildDocsAccessResultFields("zh-CN", input)
+			if err != nil {
+				t.Fatalf("buildDocsAccessResultFields: %v", err)
+			}
+			if state != test.wantState {
+				t.Fatalf("state = %q, want %q", state, test.wantState)
+			}
+			payload, err := registry.Render(context.Background(),
+				docsaccessrequest.TemplateID, docsaccessrequest.TemplateVersionV3, state, fields,
+				cardtmpl.BuildEnv{Lang: "zh-CN", SpaceID: "space-1", WebLoginURL: "https://im.example.com/login"})
+			if err != nil {
+				t.Fatalf("render %s: %v", test.wantState, err)
+			}
+			raw, err := json.Marshal(payload)
+			if err != nil {
+				t.Fatal(err)
+			}
+			// The render is what makes the markers legal on the replacement
+			// frame: only a Registry render writes metadata.octo.template, which
+			// template_ref must agree with.
+			if tmplCtx, ok := cardmsg.CardTemplateContext(raw); !ok ||
+				tmplCtx.ID != string(docsaccessrequest.TemplateID) ||
+				tmplCtx.Version != docsaccessrequest.TemplateVersionV3 {
+				t.Fatalf("%s render lost its template identity: %+v ok=%v", test.wantState, tmplCtx, ok)
+			}
+			if variant, _ := cardmsg.CardVariant(raw); variant != test.wantVariant {
+				t.Fatalf("variant = %q, want %q", variant, test.wantVariant)
+			}
+			// Nobody decided these, so they carry no operator: emitting one
+			// would put the generic approver placeholder on an untouched card.
+			var decoded map[string]any
+			if err := json.Unmarshal(fields, &decoded); err != nil {
+				t.Fatal(err)
+			}
+			if _, present := decoded["decision"]; present {
+				t.Fatalf("%s invented a decision: %+v", test.wantState, decoded["decision"])
+			}
+		})
 	}
-	raw, err := json.Marshal(payload)
+}
+
+// markerEnforcingCardMutator applies the same rule production applies at
+// carddispatch.CardMutator.Mutate, through the same exported helper, against a
+// stored frame the test supplies. It exists because the notify package cannot
+// construct a real CardMutator (its constructor takes an unexported backend),
+// and the point of the test below is what StandardActionFinalizer's *output*
+// would do at that boundary — not what the fake does.
+type markerEnforcingCardMutator struct {
+	stored   []byte
+	requests []carddispatch.CardMutationRequest
+}
+
+func (m *markerEnforcingCardMutator) Mutate(_ context.Context,
+	request carddispatch.CardMutationRequest) (carddispatch.CardMutationResult, error) {
+	stored, err := cardmsg.CatalogFrameMarkers(m.stored)
+	if err != nil {
+		return carddispatch.CardMutationResult{}, err
+	}
+	next, err := cardmsg.CatalogFrameMarkers([]byte(request.ContentEdit))
+	if err != nil {
+		return carddispatch.CardMutationResult{}, err
+	}
+	if stored.HasRef != next.HasRef || stored.HasProvenance != next.HasProvenance {
+		return carddispatch.CardMutationResult{}, carddispatch.ErrCardMutationInvalid
+	}
+	m.requests = append(m.requests, request)
+	return carddispatch.CardMutationResult{Applied: true}, nil
+}
+
+// PR-C review round 7 (yujiawei): StandardActionFinalizer is the default
+// finalizer for every owner except docs, it has no updater, and it routes every
+// state — approved and denied included — through buildTerminalEnvelope.
+//
+// It is latent rather than live today, and the reason is worth pinning down
+// rather than assuming: BuildApprovalRequestCard hand-builds its document
+// without metadata.octo.protocol/template, so cardDocumentTemplateContext
+// returns false and those cards are never marked in the first place. The moment
+// any non-docs owner's card becomes a Registry render, it would be marked, and
+// this finalizer would erase the markers on every finalize.
+//
+// The mutation boundary is what stops that becoming a silent regression, so
+// this asserts the boundary refuses it — the finalizer fails loudly instead of
+// downgrading a marked card. Today's unmarked cards keep working unchanged.
+func TestStandardActionFinalizerCannotSilentlyDowngradeAMarkedCard(t *testing.T) {
+	newEvent := func() (cardactiondispatch.Event, cardactiondispatch.DecisionResult) {
+		return cardactiondispatch.Event{
+				EventID: 85, SenderUID: NotifyBotUIDValue, Owner: "tasks", ActionType: "task.decision",
+				MessageID: "2002", ChannelID: NotifyBotUIDValue, ChannelType: 1, SpaceID: "space-1",
+				OperatorUID: "user-b",
+			}, cardactiondispatch.DecisionResult{
+				Disposition: cardactiondispatch.DispositionApplied,
+				State:       cardactiondispatch.StateApproved, RequesterUID: "user-a",
+				Display: map[string]string{"title": "Deploy release"},
+			}
+	}
+
+	t.Run("a marked stored frame is refused, not erased", func(t *testing.T) {
+		mutator := &markerEnforcingCardMutator{stored: markedNotifyFrame(t)}
+		finalizer, err := NewStandardActionFinalizer(mutator, &capturingCardSender{})
+		if err != nil {
+			t.Fatalf("NewStandardActionFinalizer: %v", err)
+		}
+		event, result := newEvent()
+		if err := finalizer.Finalize(context.Background(), event, result); err == nil {
+			t.Fatal("a marked card was silently downgraded by the standard finalizer")
+		}
+		if len(mutator.requests) != 0 {
+			t.Fatalf("a marker-erasing frame was persisted: %+v", mutator.requests)
+		}
+	})
+
+	t.Run("today's unmarked cards are unaffected", func(t *testing.T) {
+		mutator := &markerEnforcingCardMutator{stored: unmarkedNotifyFrame(t)}
+		finalizer, err := NewStandardActionFinalizer(mutator, &capturingCardSender{})
+		if err != nil {
+			t.Fatalf("NewStandardActionFinalizer: %v", err)
+		}
+		event, result := newEvent()
+		if err := finalizer.Finalize(context.Background(), event, result); err != nil {
+			t.Fatalf("an unmarked card must still finalize: %v", err)
+		}
+		if len(mutator.requests) != 1 {
+			t.Fatalf("mutation count = %d, want 1", len(mutator.requests))
+		}
+	})
+}
+
+func unmarkedNotifyFrame(t *testing.T) []byte {
+	t.Helper()
+	raw, err := json.Marshal(map[string]any{
+		"type": cardmsg.InteractiveCard.Int(), "card_version": cardmsg.CardVersion,
+		"profile": cardmsg.ProfileV2, "space_id": "space-1", "card_seq": 1,
+		"card": map[string]any{
+			"type": "AdaptiveCard", "version": cardmsg.CardVersion,
+			"body": []any{map[string]any{"type": "TextBlock", "text": "Deploy release"}},
+		},
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
-	// The render is what makes the markers legal on the replacement frame: only
-	// a Registry render writes metadata.octo.template, which template_ref must
-	// agree with.
-	if tmplCtx, ok := cardmsg.CardTemplateContext(raw); !ok ||
-		tmplCtx.ID != string(docsaccessrequest.TemplateID) || tmplCtx.Version != docsaccessrequest.TemplateVersionV3 {
-		t.Fatalf("cancelled render lost its template identity: %+v ok=%v", tmplCtx, ok)
+	return raw
+}
+
+// markedNotifyFrame is what a Registry-rendered card of this family would look
+// like: the top-level markers plus the metadata.octo.template they are checked
+// against.
+func markedNotifyFrame(t *testing.T) []byte {
+	t.Helper()
+	var frame map[string]any
+	if err := json.Unmarshal(unmarkedNotifyFrame(t), &frame); err != nil {
+		t.Fatal(err)
 	}
-	if variant, _ := cardmsg.CardVariant(raw); variant != docsaccessrequest.VariantCancelled {
-		t.Fatalf("variant = %q, want %q", variant, docsaccessrequest.VariantCancelled)
+	frame["card"].(map[string]any)["metadata"] = map[string]any{
+		"octo": map[string]any{
+			"protocol": "octo-card@1.0",
+			"template": map[string]any{"id": "tasks.decision", "version": "1.0.0"},
+		},
 	}
+	frame[cardmsg.CatalogTemplateRefKey] = map[string]any{"id": "tasks.decision", "version": "1.0.0"}
+	frame[cardmsg.CatalogProvenanceKey] = cardmsg.CatalogProvenance{
+		Version:       cardmsg.CatalogProvenanceVersion,
+		PrincipalType: cardmsg.CatalogPrincipalWireInternalProducer,
+		PrincipalID:   "tasks-notify",
+		SpaceID:       "space-1",
+	}.MarshalMap()
+	raw, err := json.Marshal(frame)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return raw
 }

--- a/modules/notify/action_finalizer_v3_test.go
+++ b/modules/notify/action_finalizer_v3_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/Mininglamp-OSS/octo-server/internal/cardactiondispatch"
 	"github.com/Mininglamp-OSS/octo-server/internal/carddispatch"
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardmsg"
 	"github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl"
 	docsaccessrequest "github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl/docs_access_request"
 )
@@ -268,5 +269,109 @@ func TestDocsActionFinalizerRejectsForeignStoredTemplate(t *testing.T) {
 	}
 	if updater.calls != 0 {
 		t.Fatalf("foreign identity still edited the card: %d calls", updater.calls)
+	}
+}
+
+// PR-C review round 6 (yujiawei P1-2): a cancelled result must not downgrade a
+// marked card to the legacy rebuild.
+//
+// The pending card is a Registry render, so it carries the server-authored
+// catalog markers. buildTerminalEnvelope assembles a replacement from a fixed
+// six-key allowlist that includes neither, and the marker-preserving branch was
+// taken only for approved/denied — so an ordinary user click on a route that
+// answers `cancelled` erased both markers. Both identity guards in
+// pkg/cardtmpl/updater.go begin `if markers.Has…`, so they went inert for that
+// message, and the frame silently rejoined the legacy population.
+//
+// The absence of any test for a non-terminal finalizer state is why this was
+// invisible for six rounds.
+func TestDocsActionFinalizerRoutesCancelledThroughTheRegistry(t *testing.T) {
+	wk := newWuKongServer()
+	defer wk.close()
+	ctx := newTestContext(t, wk)
+	ctx.GetConfig().External.WebLoginURL = "https://im.example.com/login"
+	updater := &captureViewUpdater{}
+	legacyMutator := &captureCardMutator{}
+	finalizer, err := NewDocsActionFinalizerWithUpdater(ctx, updater, legacyMutator, &capturingCardSender{})
+	if err != nil {
+		t.Fatalf("NewDocsActionFinalizerWithUpdater: %v", err)
+	}
+	event := cardactiondispatch.Event{
+		EventID: 43, SenderUID: NotifyBotUIDValue, Owner: "docs", ActionType: "access_request.decision",
+		MessageID: "1002", ChannelID: NotifyBotUIDValue, ChannelType: 1, SpaceID: "space-1", OperatorUID: "reviewer-1",
+		Data: map[string]any{
+			"doc_id": "doc-1", "request_id": "request-1", "doc_title": "Roadmap", "actor": "Alice",
+			"permission_label": "Access", "permission_role_label": "Editor", "source_name": "Docs",
+		},
+	}
+	result := cardactiondispatch.DecisionResult{
+		Disposition: cardactiondispatch.DispositionApplied,
+		State:       cardactiondispatch.StateCancelled,
+		Display:     map[string]string{"title": "Roadmap"},
+	}
+	if err := finalizer.Finalize(context.Background(), event, result); err != nil {
+		t.Fatalf("Finalize(cancelled): %v", err)
+	}
+	if len(legacyMutator.requests) != 0 {
+		t.Fatalf("cancelled took the marker-erasing legacy path: %+v", legacyMutator.requests)
+	}
+	if updater.calls != 1 {
+		t.Fatalf("registry replacement calls = %d, want 1", updater.calls)
+	}
+	if updater.id != docsaccessrequest.TemplateID || updater.version != docsaccessrequest.TemplateVersionV3 ||
+		updater.state != docsaccessrequest.StateCancelled {
+		t.Fatalf("update selection = %s@%s/%s", updater.id, updater.version, updater.state)
+	}
+	var fields map[string]any
+	if err := json.Unmarshal(updater.fields, &fields); err != nil {
+		t.Fatalf("decode fields: %v", err)
+	}
+	if fields["state"] != "cancelled" {
+		t.Fatalf("wire state = %v", fields["state"])
+	}
+	// Nobody decided a cancelled request, so it carries no operator: emitting
+	// one would put the generic approver placeholder on a card no one acted on.
+	if _, present := fields["decision"]; present {
+		t.Fatalf("cancelled result invented a decision: %+v", fields["decision"])
+	}
+}
+
+// The template must actually be able to render what the finalizer now asks of
+// it — a state the manifest does not declare fails ViewFor with ErrStateUnknown,
+// which would turn the fix above into a runtime error instead of a card.
+func TestDocsAccessRequestV3RendersTheCancelledState(t *testing.T) {
+	fields, state, err := buildDocsAccessResultFields("zh-CN", docsResultRenderInput{
+		Data:      map[string]any{"request_id": "request-1", "doc_id": "doc-1"},
+		Title:     "Roadmap",
+		Cancelled: true,
+	})
+	if err != nil {
+		t.Fatalf("buildDocsAccessResultFields: %v", err)
+	}
+	if state != docsaccessrequest.StateCancelled {
+		t.Fatalf("state = %q", state)
+	}
+	registry := cardtmpl.NewRegistry()
+	registry.Register(docsaccessrequest.NewV3(), docsaccessrequest.Assets, docsaccessrequest.HandoffRootV3)
+	registry.Freeze()
+	payload, err := registry.Render(context.Background(),
+		docsaccessrequest.TemplateID, docsaccessrequest.TemplateVersionV3, state, fields,
+		cardtmpl.BuildEnv{Lang: "zh-CN", SpaceID: "space-1", WebLoginURL: "https://im.example.com/login"})
+	if err != nil {
+		t.Fatalf("render cancelled: %v", err)
+	}
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The render is what makes the markers legal on the replacement frame: only
+	// a Registry render writes metadata.octo.template, which template_ref must
+	// agree with.
+	if tmplCtx, ok := cardmsg.CardTemplateContext(raw); !ok ||
+		tmplCtx.ID != string(docsaccessrequest.TemplateID) || tmplCtx.Version != docsaccessrequest.TemplateVersionV3 {
+		t.Fatalf("cancelled render lost its template identity: %+v ok=%v", tmplCtx, ok)
+	}
+	if variant, _ := cardmsg.CardVariant(raw); variant != docsaccessrequest.VariantCancelled {
+		t.Fatalf("variant = %q, want %q", variant, docsaccessrequest.VariantCancelled)
 	}
 }

--- a/modules/notify/action_finalizer_v3_test.go
+++ b/modules/notify/action_finalizer_v3_test.go
@@ -19,10 +19,12 @@ type captureViewUpdater struct {
 	state   cardtmpl.State
 	fields  json.RawMessage
 	env     cardtmpl.BuildEnv
+	calls   int
 }
 
 func (u *captureViewUpdater) ReplaceView(_ context.Context, target cardtmpl.UpdateTarget, id cardtmpl.ID,
 	version string, state cardtmpl.State, fields json.RawMessage, env cardtmpl.BuildEnv) error {
+	u.calls++
 	u.target, u.id, u.version, u.state, u.fields, u.env = target, id, version, state, fields, env
 	return nil
 }
@@ -198,5 +200,73 @@ func TestDocsActionFinalizerV3TruncatesOversizedDisplayFields(t *testing.T) {
 	}
 	if !mut.mutated {
 		t.Fatal("mutator was never called — terminal update did not persist")
+	}
+}
+
+// ---- PR-C Slice 1 (D3/D7): the finalizer's result edit pins the version the
+// event's stored frame actually used — never a hardcoded constant, never a
+// foreign template identity. ----
+
+func storedVersionFinalizerFixture(t *testing.T) (*captureViewUpdater, *DocsActionFinalizer, cardactiondispatch.Event, cardactiondispatch.DecisionResult) {
+	t.Helper()
+	wk := newWuKongServer()
+	t.Cleanup(wk.close)
+	ctx := newTestContext(t, wk)
+	ctx.GetConfig().External.WebLoginURL = "https://im.example.com/login"
+	updater := &captureViewUpdater{}
+	finalizer, err := NewDocsActionFinalizerWithUpdater(ctx, updater, &captureCardMutator{}, &capturingCardSender{})
+	if err != nil {
+		t.Fatalf("NewDocsActionFinalizerWithUpdater: %v", err)
+	}
+	event := cardactiondispatch.Event{
+		EventID: 42, SenderUID: NotifyBotUIDValue, Owner: "docs", ActionType: "access_request.decision",
+		MessageID: "1001", ChannelID: NotifyBotUIDValue, ChannelType: 1, SpaceID: "space-1", OperatorUID: "reviewer-1",
+		Data: map[string]any{"doc_id": "doc-1", "request_id": "request-1", "doc_title": "Roadmap"},
+	}
+	result := cardactiondispatch.DecisionResult{
+		Disposition: cardactiondispatch.DispositionApplied, State: cardactiondispatch.StateApproved,
+		RequesterUID: "user-a", Display: map[string]string{"title": "Roadmap"},
+	}
+	return updater, finalizer, event, result
+}
+
+func TestDocsActionFinalizerUsesEventStoredTemplateVersion(t *testing.T) {
+	updater, finalizer, event, result := storedVersionFinalizerFixture(t)
+	// A dynamic pilot frame stores its own exact version in the durable event.
+	event.Card = cardactiondispatch.CardContext{
+		TemplateID: string(docsaccessrequest.TemplateID), TemplateVersion: "0.4.0-test.1", View: "pending",
+	}
+	if err := finalizer.Finalize(context.Background(), event, result); err != nil {
+		t.Fatalf("Finalize: %v", err)
+	}
+	if updater.version != "0.4.0-test.1" {
+		t.Fatalf("result edit version = %q, want the event's stored exact version", updater.version)
+	}
+	if updater.id != docsaccessrequest.TemplateID {
+		t.Fatalf("result edit template = %q", updater.id)
+	}
+}
+
+func TestDocsActionFinalizerLegacyEventKeepsStaticVersion(t *testing.T) {
+	updater, finalizer, event, result := storedVersionFinalizerFixture(t)
+	// Pre-registry durable events carry no card context.
+	if err := finalizer.Finalize(context.Background(), event, result); err != nil {
+		t.Fatalf("Finalize: %v", err)
+	}
+	if updater.version != docsaccessrequest.TemplateVersionV3 {
+		t.Fatalf("legacy result edit version = %q, want %q", updater.version, docsaccessrequest.TemplateVersionV3)
+	}
+}
+
+func TestDocsActionFinalizerRejectsForeignStoredTemplate(t *testing.T) {
+	updater, finalizer, event, result := storedVersionFinalizerFixture(t)
+	event.Card = cardactiondispatch.CardContext{
+		TemplateID: "summary.completed", TemplateVersion: "0.1.0", View: "default",
+	}
+	if err := finalizer.Finalize(context.Background(), event, result); err == nil {
+		t.Fatal("foreign stored template identity finalized")
+	}
+	if updater.calls != 0 {
+		t.Fatalf("foreign identity still edited the card: %d calls", updater.calls)
 	}
 }

--- a/modules/notify/card.go
+++ b/modules/notify/card.go
@@ -66,7 +66,7 @@ func (n *Notify) deliverCardNotification(ctx context.Context, req *NotifyReq) (*
 	} else {
 		summaryTid = summaryfailed.TemplateID
 	}
-	if err := preflightSummarySchema(ctx, card, summaryTid); err != nil {
+	if err := preflightSummarySchema(ctx, req.SpaceID, card, summaryTid); err != nil {
 		if failure, ok := classifyNotifyCatalogRuntimeFailure(err); ok {
 			n.Error("summary card preflight rejected by runtime catalog",
 				zap.String("catalog_result", failure.result), zap.Error(err),
@@ -415,7 +415,7 @@ func (n *Notify) deliverDocsCardNotification(ctx context.Context, req *NotifyReq
 		} else {
 			tid = docsshared.TemplateID
 		}
-		if err := preflightDocsDisplaySchema(ctx, card, tid); err != nil {
+		if err := preflightDocsDisplaySchema(ctx, req.SpaceID, card, tid); err != nil {
 			if failure, ok := classifyNotifyCatalogRuntimeFailure(err); ok {
 				n.Error("docs display card preflight rejected by runtime catalog",
 					zap.String("catalog_result", failure.result), zap.Error(err),

--- a/modules/notify/card.go
+++ b/modules/notify/card.go
@@ -535,7 +535,7 @@ func (n *Notify) deliverDocsCardNotification(ctx context.Context, req *NotifyReq
 	}
 	fallbackText := ""
 	if !canCard {
-		fallbackText = buildDocsFallbackText(card, lang)
+		fallbackText = buildDocsFallbackText(card, lang, req.SpaceID)
 	}
 
 	type sendResult struct {
@@ -762,9 +762,15 @@ func docsAttributionAndVariant(kind, actorName string, labels docsLabels) (strin
 // pilot Template. Other kinds keep the historical multi-line composition.
 // If Template.FallbackText is unavailable (Registry unwired / mapping fails),
 // fall back to the historical composition so callers never lose the text path.
-func buildDocsFallbackText(card *DocsCardFields, lang string) string {
+// spaceID is the Space the accompanying send is authorized against. It is not
+// decoration: template resolution became Space-aware in Slice 3, so resolving
+// the fallback with an empty Space would authorize a different principal than
+// the send this text belongs to — and the only visible symptom would be a card
+// rendered from the dynamic template whose plain-text twin came from the legacy
+// hardcoded labels.
+func buildDocsFallbackText(card *DocsCardFields, lang, spaceID string) string {
 	if card != nil && card.Kind == DocsCardKindAccessRequested && docsApprovalCardsEnabled() {
-		if text, ok := templateFallbackText(card, lang); ok {
+		if text, ok := templateFallbackText(card, lang, spaceID); ok {
 			return text
 		}
 	}

--- a/modules/notify/card.go
+++ b/modules/notify/card.go
@@ -387,7 +387,7 @@ func (n *Notify) deliverDocsCardNotification(ctx context.Context, req *NotifyReq
 	// Only the access_requested + gate-on branch flows through Registry.Render;
 	// other kinds keep the historical validate-in-builder behavior.
 	if card.Kind == DocsCardKindAccessRequested && docsApprovalCardsEnabled() {
-		if err := preflightDocsAccessRequestSchema(ctx, card); err != nil {
+		if err := preflightDocsAccessRequestSchema(ctx, req.SpaceID, card); err != nil {
 			if failure, ok := classifyNotifyCatalogRuntimeFailure(err); ok {
 				n.Error("docs access-request card preflight rejected by runtime catalog",
 					zap.String("catalog_result", failure.result), zap.Error(err),

--- a/modules/notify/card_action_test.go
+++ b/modules/notify/card_action_test.go
@@ -138,7 +138,7 @@ func TestDocsOutcomeCardsAreV1AndDeniedDoesNotLeakApproverOrReason(t *testing.T)
 		if kind == DocsCardKindAccessDenied {
 			assert.NotContains(t, string(document), "denial-reason-secret")
 			assert.Contains(t, string(document), "访问申请已拒绝")
-			fallback := buildDocsFallbackText(card, "zh-CN")
+			fallback := buildDocsFallbackText(card, "zh-CN", "")
 			assert.NotContains(t, fallback, "approver-secret")
 			assert.NotContains(t, fallback, "denial-reason-secret")
 		} else {

--- a/modules/notify/card_c1_regression_test.go
+++ b/modules/notify/card_c1_regression_test.go
@@ -137,7 +137,7 @@ func TestPreflightDocsAccessRequestSchema_AvatarSemantics(t *testing.T) {
 	for _, u := range bad {
 		card := validAccessRequestDocsCard()
 		card.ActorAvatarURL = u
-		if err := preflightDocsAccessRequestSchema(context.Background(), card); !errors.Is(err, cardtmpl.ErrFieldsInvalid) {
+		if err := preflightDocsAccessRequestSchema(context.Background(), "space-preflight", card); !errors.Is(err, cardtmpl.ErrFieldsInvalid) {
 			t.Errorf("avatar %q: want ErrFieldsInvalid, got %v", u, err)
 		}
 	}
@@ -146,7 +146,7 @@ func TestPreflightDocsAccessRequestSchema_AvatarSemantics(t *testing.T) {
 	for _, u := range ok {
 		card := validAccessRequestDocsCard()
 		card.ActorAvatarURL = u
-		if err := preflightDocsAccessRequestSchema(context.Background(), card); err != nil {
+		if err := preflightDocsAccessRequestSchema(context.Background(), "space-preflight", card); err != nil {
 			t.Errorf("avatar %q: want pass, got %v", u, err)
 		}
 	}
@@ -163,7 +163,7 @@ func TestPreflight_EmitsFieldsInvalidMetric(t *testing.T) {
 
 	card := validAccessRequestDocsCard()
 	card.Title = "" // schema violation: document.title minLength=1
-	if err := preflightDocsAccessRequestSchema(context.Background(), card); !errors.Is(err, cardtmpl.ErrFieldsInvalid) {
+	if err := preflightDocsAccessRequestSchema(context.Background(), "space-preflight", card); !errors.Is(err, cardtmpl.ErrFieldsInvalid) {
 		t.Fatalf("want ErrFieldsInvalid, got %v", err)
 	}
 

--- a/modules/notify/card_mutate_api.go
+++ b/modules/notify/card_mutate_api.go
@@ -243,6 +243,12 @@ func replaceSiblingWithRegistryResult(ctx context.Context, updater cardtmpl.Card
 	if storedDocID == "" || storedDocID != strings.TrimSpace(req.DocID) {
 		return fmt.Errorf("%w: document mismatch", errDocsSiblingContextInvalid)
 	}
+	// The version comes from the frame being replaced, exactly as the
+	// click-driven finalizer takes it from the stored card context.
+	version, err := docsResultVersionFromFrame(snapshot.Envelope)
+	if err != nil {
+		return fmt.Errorf("%w: %v", errDocsSiblingContextInvalid, err)
+	}
 	denied := req.Kind == DocsCardKindAccessDenied
 	fields, state, err := buildDocsAccessResultFields(env.Lang, docsResultRenderInput{
 		Data:             data,
@@ -260,5 +266,5 @@ func replaceSiblingWithRegistryResult(ctx context.Context, updater cardtmpl.Card
 			SpaceID: req.SpaceID, ChannelID: req.ChannelID, ChannelType: req.ChannelType,
 		},
 		SenderUID: NotifyBotUIDValue, MessageID: req.MessageID, CardSeq: cardSeq,
-	}, docsaccessrequest.TemplateID, docsaccessrequest.TemplateVersionV3, state, fields, env)
+	}, docsaccessrequest.TemplateID, version, state, fields, env)
 }

--- a/modules/notify/card_mutate_api.go
+++ b/modules/notify/card_mutate_api.go
@@ -99,7 +99,7 @@ type CardMutateResp struct {
 
 // mutateCard handles POST /v1/internal/cards/mutate. It drives one already-
 // delivered docs access card to its terminal (approved/denied) state in place,
-// reusing the same V3 Registry field mapping as the click-driven finalizer.
+// reusing the same Registry field mapping as the click-driven finalizer.
 // Docs capability only.
 func (n *Notify) mutateCard(c *wkhttp.Context) {
 	capability, _ := c.Get(notifyCapabilityContextKey)

--- a/modules/notify/card_test.go
+++ b/modules/notify/card_test.go
@@ -313,7 +313,7 @@ func TestBuildDocsCard_RejectsNonHTTPSDeepLinkOrigin(t *testing.T) {
 }
 
 func TestBuildDocsFallbackText(t *testing.T) {
-	text := buildDocsFallbackText(validDocsCard(), "zh-CN")
+	text := buildDocsFallbackText(validDocsCard(), "zh-CN", "")
 	assert.Contains(t, text, "Alice 分享了文档")
 	assert.Contains(t, text, "文档：产品设计方案")
 	assert.Contains(t, text, "Q3 上线计划已确认")
@@ -331,7 +331,7 @@ func TestBuildDocsFallbackText_AccessRequestedPreservesExcerptAndTime(t *testing
 	card.Excerpt = "需要评审季度计划"
 	card.UpdatedAt = "2026-07-20 09:30"
 
-	text := buildDocsFallbackText(card, "zh-CN")
+	text := buildDocsFallbackText(card, "zh-CN", "")
 	assert.Contains(t, text, "需要评审季度计划", "access-request fallback dropped the excerpt")
 	assert.Contains(t, text, "2026-07-20 09:30", "access-request fallback dropped the time")
 	assert.Contains(t, text, "Alice", "actor should still appear")
@@ -385,7 +385,7 @@ func TestBuildDocsFallbackText_StripsNewlineInjection(t *testing.T) {
 	card := validDocsCard()
 	card.ActorName = "Alice\n系统管理员"
 	card.Title = "标题\n伪造：越权提示"
-	text := buildDocsFallbackText(card, "zh-CN")
+	text := buildDocsFallbackText(card, "zh-CN", "")
 	assert.NotContains(t, text, "\n伪造", "an embedded title newline must not start a new line")
 	assert.Contains(t, text, "Alice 系统管理员 分享了文档", "actor newline collapses to a space in the attribution")
 }

--- a/modules/notify/card_via_registry.go
+++ b/modules/notify/card_via_registry.go
@@ -290,7 +290,12 @@ func (n *Notify) buildDocsDisplayCardViaRegistry(
 // preflightDocsDisplaySchema 与 preflightDocsAccessRequestSchema 同思路:在
 // memberCache/docsSender/gate 之前独立跑一次 InputSchema 校验(C1 不被绕过)。
 // docs.commented / docs.shared 无用户可控 URL 字段,不需要 avatar https 前置校验。
-func preflightDocsDisplaySchema(parent context.Context, card *DocsCardFields, templateID cardtmpl.ID) error {
+// spaceID is threaded for the same reason preflightDocsAccessRequestSchema
+// takes it: template resolution is Space-aware, so preflighting against an
+// empty Space would validate a different version than the send resolves.
+func preflightDocsDisplaySchema(
+	parent context.Context, spaceID string, card *DocsCardFields, templateID cardtmpl.ID,
+) error {
 	catalog := cardtmpl.DefaultCatalog()
 	if catalog == nil {
 		return fmt.Errorf("%w: default catalog not wired", errCardTmplUnavailable)
@@ -298,7 +303,7 @@ func preflightDocsDisplaySchema(parent context.Context, card *DocsCardFields, te
 	ctx, cancel := boundedNotifyCatalogContext(parent)
 	defer cancel()
 	meta, err := catalog.MetaDefault(ctx, cardtmpl.CatalogDefaultRequest{
-		Access: notifyCatalogAccess(docsNotifyProducerID, ""), ID: templateID,
+		Access: notifyCatalogAccess(docsNotifyProducerID, spaceID), ID: templateID,
 	})
 	if err != nil {
 		return notifyCatalogLookupError(templateID, err)
@@ -479,7 +484,10 @@ func (n *Notify) buildSummaryCardViaRegistry(
 // preflightSummarySchema 与 preflightDocsDisplaySchema 同思路:在 memberCache /
 // docsSender / gate 之前独立跑一次 InputSchema 校验(C1 不被绕过)。summary 卡
 // 无用户可控 URL 字段,不需要 https 前置校验。
-func preflightSummarySchema(parent context.Context, card *SummaryCardFields, templateID cardtmpl.ID) error {
+// spaceID is threaded for the same reason the docs preflights take it.
+func preflightSummarySchema(
+	parent context.Context, spaceID string, card *SummaryCardFields, templateID cardtmpl.ID,
+) error {
 	catalog := cardtmpl.DefaultCatalog()
 	if catalog == nil {
 		return fmt.Errorf("%w: default catalog not wired", errCardTmplUnavailable)
@@ -487,7 +495,7 @@ func preflightSummarySchema(parent context.Context, card *SummaryCardFields, tem
 	ctx, cancel := boundedNotifyCatalogContext(parent)
 	defer cancel()
 	meta, err := catalog.MetaDefault(ctx, cardtmpl.CatalogDefaultRequest{
-		Access: notifyCatalogAccess(summaryNotifyProducerID, ""), ID: templateID,
+		Access: notifyCatalogAccess(summaryNotifyProducerID, spaceID), ID: templateID,
 	})
 	if err != nil {
 		return notifyCatalogLookupError(templateID, err)

--- a/modules/notify/card_via_registry.go
+++ b/modules/notify/card_via_registry.go
@@ -83,7 +83,7 @@ const notifyCatalogCallTimeout = 10 * time.Second
 // buildDocsFallbackText 会先调本函数,让 fallback 文本走 pilot Template 的 L0
 // 定义。Registry 未注入 / Template 未注册 / mapping/unmarshal 失败 → 返 ok=false,
 // caller 兜回 legacy 多行组装。
-func templateFallbackText(card *DocsCardFields, lang string) (string, bool) {
+func templateFallbackText(card *DocsCardFields, lang, spaceID string) (string, bool) {
 	catalog := cardtmpl.DefaultCatalog()
 	if catalog == nil {
 		return "", false
@@ -95,7 +95,7 @@ func templateFallbackText(card *DocsCardFields, lang string) (string, bool) {
 	ctx, cancel := boundedNotifyCatalogContext(context.Background())
 	defer cancel()
 	text, err := catalog.FallbackText(ctx, cardtmpl.CatalogFallbackRequest{
-		Access: notifyCatalogAccess(docsNotifyProducerID, ""),
+		Access: notifyCatalogAccess(docsNotifyProducerID, spaceID),
 		ID:     docsaccessrequest.TemplateID, State: docsaccessrequest.StatePending,
 		Fields: fields, Lang: lang,
 	})

--- a/modules/notify/card_via_registry.go
+++ b/modules/notify/card_via_registry.go
@@ -115,7 +115,13 @@ func templateFallbackText(card *DocsCardFields, lang string) (string, bool) {
 // R2-2 修正:前版当 registry nil 时返 nil 让 caller 继续走 v2 分支,后者最终降级
 // 文本 —— 那样"错请求"仍然会成功送达一条文本,与 §10 / A14 冲突。现在 preflight
 // 阶段就报 500,让 wiring bug 立刻可见。
-func preflightDocsAccessRequestSchema(parent context.Context, card *DocsCardFields) error {
+// preflightDocsAccessRequestSchema validates the caller's fields against the
+// template contract before anything is delivered (C1). It takes the Space
+// because PR-C made template resolution Space-aware: when the activation
+// pointer resolves to a dynamic version, the producer's grant is read for this
+// Space, and preflighting against an empty Space would authorize a different
+// decision than the send that follows it.
+func preflightDocsAccessRequestSchema(parent context.Context, spaceID string, card *DocsCardFields) error {
 	catalog := cardtmpl.DefaultCatalog()
 	if catalog == nil {
 		return fmt.Errorf("%w: default catalog not wired", errCardTmplUnavailable)
@@ -123,7 +129,7 @@ func preflightDocsAccessRequestSchema(parent context.Context, card *DocsCardFiel
 	ctx, cancel := boundedNotifyCatalogContext(parent)
 	defer cancel()
 	meta, err := catalog.MetaDefault(ctx, cardtmpl.CatalogDefaultRequest{
-		Access: notifyCatalogAccess(docsNotifyProducerID, ""), ID: docsaccessrequest.TemplateID,
+		Access: notifyCatalogAccess(docsNotifyProducerID, spaceID), ID: docsaccessrequest.TemplateID,
 	})
 	if err != nil {
 		return notifyCatalogLookupError(docsaccessrequest.TemplateID, err)

--- a/modules/notify/card_via_registry_display_baseline_test.go
+++ b/modules/notify/card_via_registry_display_baseline_test.go
@@ -44,7 +44,7 @@ func TestMapDocsDisplayFields_TruncatesDisplayFields(t *testing.T) {
 		Excerpt:   strings.Repeat("评", 1000), // cap 300
 		UpdatedAt: strings.Repeat("时", 300),  // cap 80
 	}
-	if err := preflightDocsDisplaySchema(context.Background(), huge, docscommented.TemplateID); err != nil {
+	if err := preflightDocsDisplaySchema(context.Background(), "space-preflight", huge, docscommented.TemplateID); err != nil {
 		t.Fatalf("preflight should PASS after truncation, got %v", err)
 	}
 	if _, _, err := n.buildDocsDisplayCardViaRegistry(context.Background(),
@@ -56,7 +56,7 @@ func TestMapDocsDisplayFields_TruncatesDisplayFields(t *testing.T) {
 	badDoc := &DocsCardFields{
 		DocID: strings.Repeat("x", 300), Title: "OK", Kind: DocsCardKindShared,
 	}
-	err := preflightDocsDisplaySchema(context.Background(), badDoc, docsshared.TemplateID)
+	err := preflightDocsDisplaySchema(context.Background(), "space-preflight", badDoc, docsshared.TemplateID)
 	if err == nil || !errorsIsFieldsInvalid(err) {
 		t.Fatalf("over-length docId must stay C1 400, got %v", err)
 	}
@@ -231,7 +231,7 @@ func TestPreflightDocsDisplaySchema_C1RejectsEmptyDocID(t *testing.T) {
 
 	// docId 空 → schema minLength=1 违规
 	card := &DocsCardFields{DocID: "", Title: "T", Kind: DocsCardKindCommented}
-	err := preflightDocsDisplaySchema(context.Background(), card, docscommented.TemplateID)
+	err := preflightDocsDisplaySchema(context.Background(), "space-preflight", card, docscommented.TemplateID)
 	if err == nil {
 		t.Fatal("expected ErrFieldsInvalid, got nil")
 	}

--- a/modules/notify/card_via_registry_summary_baseline_test.go
+++ b/modules/notify/card_via_registry_summary_baseline_test.go
@@ -47,7 +47,7 @@ func TestMapSummaryFields_TruncatesDisplayFields(t *testing.T) {
 		Members:     -5,
 		MsgCount:    -1,
 	}
-	if err := preflightSummarySchema(context.Background(), huge, summaryfailed.TemplateID); err != nil {
+	if err := preflightSummarySchema(context.Background(), "space-preflight", huge, summaryfailed.TemplateID); err != nil {
 		t.Fatalf("preflight should PASS after truncation, got %v", err)
 	}
 	if _, _, err := n.buildSummaryCardViaRegistry(context.Background(),
@@ -59,7 +59,7 @@ func TestMapSummaryFields_TruncatesDisplayFields(t *testing.T) {
 	badTask := &SummaryCardFields{
 		TaskNo: strings.Repeat("x", 300), Title: "OK", Kind: SummaryCardKindCompleted,
 	}
-	err := preflightSummarySchema(context.Background(), badTask, summarycompleted.TemplateID)
+	err := preflightSummarySchema(context.Background(), "space-preflight", badTask, summarycompleted.TemplateID)
 	if err == nil || !errorsIsFieldsInvalid(err) {
 		t.Fatalf("over-length taskNo must stay C1 400, got %v", err)
 	}
@@ -130,7 +130,7 @@ func TestMapSummaryFields_ClampsOverMaxCounts(t *testing.T) {
 			if s.kind == SummaryCardKindFailed {
 				card.Reason = "boom"
 			}
-			if err := preflightSummarySchema(context.Background(), card, s.templateID); err != nil {
+			if err := preflightSummarySchema(context.Background(), "space-preflight", card, s.templateID); err != nil {
 				t.Fatalf("preflight should PASS after count clamp, got %v", err)
 			}
 			if _, _, err := n.buildSummaryCardViaRegistry(context.Background(),
@@ -350,7 +350,7 @@ func TestPreflightSummarySchema_C1RejectsEmptyTaskNo(t *testing.T) {
 
 	// taskNo 空 → schema minLength=1 违规(completed 分支)
 	badCompleted := &SummaryCardFields{TaskNo: "", Title: "T", Kind: SummaryCardKindCompleted}
-	err := preflightSummarySchema(context.Background(), badCompleted, summarycompleted.TemplateID)
+	err := preflightSummarySchema(context.Background(), "space-preflight", badCompleted, summarycompleted.TemplateID)
 	if err == nil {
 		t.Fatal("expected ErrFieldsInvalid (completed), got nil")
 	}
@@ -360,7 +360,7 @@ func TestPreflightSummarySchema_C1RejectsEmptyTaskNo(t *testing.T) {
 
 	// 同样 taskNo 空 → schema minLength=1 违规(failed 分支)
 	badFailed := &SummaryCardFields{TaskNo: "", Title: "T", Kind: SummaryCardKindFailed, Reason: "r"}
-	err = preflightSummarySchema(context.Background(), badFailed, summaryfailed.TemplateID)
+	err = preflightSummarySchema(context.Background(), "space-preflight", badFailed, summaryfailed.TemplateID)
 	if err == nil {
 		t.Fatal("expected ErrFieldsInvalid (failed), got nil")
 	}
@@ -377,7 +377,7 @@ func TestPreflightSummarySchema_F7RegistryUnwired(t *testing.T) {
 	defer cardtmpl.SetDefaultRegistry(prev)
 
 	card := &SummaryCardFields{TaskNo: "t", Title: "T", Kind: SummaryCardKindCompleted}
-	err := preflightSummarySchema(context.Background(), card, summarycompleted.TemplateID)
+	err := preflightSummarySchema(context.Background(), "space-preflight", card, summarycompleted.TemplateID)
 	if err == nil {
 		t.Fatal("expected errCardTmplUnavailable, got nil")
 	}

--- a/modules/notify/card_via_registry_test.go
+++ b/modules/notify/card_via_registry_test.go
@@ -162,7 +162,7 @@ func TestNotifyCatalogOperationsUseBoundedContexts(t *testing.T) {
 
 	parent, cancel := context.WithCancel(context.Background())
 	cancel()
-	if err := preflightDocsAccessRequestSchema(parent, card); err != nil {
+	if err := preflightDocsAccessRequestSchema(parent, "space-preflight", card); err != nil {
 		t.Fatalf("preflight: %v", err)
 	}
 	if _, ok := templateFallbackText(card, "zh-CN"); !ok {
@@ -196,7 +196,7 @@ func TestPreflightDocsAccessRequestPreservesRuntimeCatalogFailures(t *testing.T)
 			cardtmpl.SetDefaultCatalog(&notifyFailureCatalog{Catalog: static, metaErr: cause})
 			t.Cleanup(func() { cardtmpl.SetDefaultCatalog(nil) })
 
-			err := preflightDocsAccessRequestSchema(context.Background(), validAccessRequestDocsCard())
+			err := preflightDocsAccessRequestSchema(context.Background(), "space-preflight", validAccessRequestDocsCard())
 			if !errors.Is(err, cause) {
 				t.Fatalf("preflight error = %v, want cause %v", err, cause)
 			}

--- a/modules/notify/card_via_registry_test.go
+++ b/modules/notify/card_via_registry_test.go
@@ -165,7 +165,7 @@ func TestNotifyCatalogOperationsUseBoundedContexts(t *testing.T) {
 	if err := preflightDocsAccessRequestSchema(parent, "space-preflight", card); err != nil {
 		t.Fatalf("preflight: %v", err)
 	}
-	if _, ok := templateFallbackText(card, "zh-CN"); !ok {
+	if _, ok := templateFallbackText(card, "zh-CN", ""); !ok {
 		t.Fatal("template fallback was unavailable")
 	}
 	n := newTestNotify(ctx, nil, nil, nil, "tk")

--- a/modules/notify/docs_result_version.go
+++ b/modules/notify/docs_result_version.go
@@ -63,15 +63,26 @@ func docsResultVersion(storedID, storedVersion string) (string, error) {
 }
 
 // docsResultVersionFromFrame reads the stored identity off a persisted envelope
-// and resolves the result version from it. An envelope with no template marker
-// is a pre-PR-C frame and takes the legacy branch above.
+// and resolves the result version from it.
+//
+// The identity comes from `card.metadata.octo.template`, which is where the
+// click path reads it too (`cardmsg.CardTemplateContext`, via
+// resolveRegistryCardContext). Keying off the top-level `template_ref` instead
+// would look equivalent but is not: that marker only exists on frames sent
+// since PR-C Slice 1, so every card already delivered carries the metadata and
+// no marker — and the two callers would answer differently for exactly the
+// population this helper was written to keep consistent.
+//
+// The marker check still runs first. It does not supply the identity; it
+// rejects a frame whose two identities disagree, which is a tampering signal
+// rather than a version question.
 func docsResultVersionFromFrame(envelope []byte) (string, error) {
-	markers, err := cardmsg.CatalogFrameMarkers(envelope)
-	if err != nil {
+	if _, err := cardmsg.CatalogFrameMarkers(envelope); err != nil {
 		return "", fmt.Errorf("%w: %v", errDocsResultVersion, err)
 	}
-	if !markers.HasRef {
+	stored, ok := cardmsg.CardTemplateContext(envelope)
+	if !ok {
 		return docsResultVersion("", "")
 	}
-	return docsResultVersion(markers.Ref.ID, markers.Ref.Version)
+	return docsResultVersion(stored.ID, stored.Version)
 }

--- a/modules/notify/docs_result_version.go
+++ b/modules/notify/docs_result_version.go
@@ -1,0 +1,77 @@
+package notify
+
+// PR-C review follow-up — one place decides which version a docs
+// access-request result edit renders at.
+//
+// There are two callers: the click-driven finalizer, which learns the version
+// from the durable event's stored card context, and the sibling mutate
+// endpoint, which learns it from the stored frame it is about to replace. They
+// used to disagree — the finalizer followed the stored version while the mutate
+// endpoint hardcoded V3 — which is fine only for as long as the registry
+// default happens to be V3. The moment it moves (as it already moved off
+// 0.2.0), one path renders the stored version, the other renders a constant,
+// and `CardUpdater.ReplaceView`'s stored-identity guard rejects whichever one
+// guessed wrong. A card half-finalized by whichever path the user happened to
+// trigger is not a failure mode worth keeping.
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardmsg"
+	docsaccessrequest "github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl/docs_access_request"
+)
+
+// errDocsResultVersion marks a result edit whose target version cannot be
+// determined, or which was routed to the wrong template entirely.
+var errDocsResultVersion = errors.New("notify: docs result edit has no usable template version")
+
+// docsResultVersion resolves the exact version for a result-view edit from the
+// template identity stored on the card.
+//
+// A card is always edited at the version it was sent as: the result view has to
+// exist in *that* contract, and following the activation pointer instead would
+// rewrite an existing card across versions. The three cases:
+//
+//   - No stored identity at all. The frame predates PR-C's provenance markers,
+//     so there is nothing to honour and the historical behaviour — render V3 —
+//     is preserved exactly.
+//   - A stored identity naming some other template. That is a routing mistake,
+//     not something to paper over by rendering the docs card anyway.
+//   - A stored identity naming 0.2.0. That version's manifest declares only the
+//     `pending` view, so it has no `result` to render into. Nothing sends 0.2.0
+//     today — new sends resolve through the registry default — so a *marked*
+//     0.2.0 frame is an impossible state rather than a case to upgrade. Say so
+//     here instead of failing several layers down inside ViewFor, where the
+//     error names a missing view and not the reason it is missing.
+func docsResultVersion(storedID, storedVersion string) (string, error) {
+	storedID, storedVersion = strings.TrimSpace(storedID), strings.TrimSpace(storedVersion)
+	if storedID == "" && storedVersion == "" {
+		return docsaccessrequest.TemplateVersionV3, nil
+	}
+	if storedID != string(docsaccessrequest.TemplateID) || storedVersion == "" {
+		return "", fmt.Errorf("%w: stored card context identifies %q@%q, not docs.access-request",
+			errDocsResultVersion, storedID, storedVersion)
+	}
+	if storedVersion == docsaccessrequest.TemplateVersion {
+		return "", fmt.Errorf("%w: %s@%s declares no result view; a marked frame at this version "+
+			"should not exist because new sends resolve through the registry default",
+			errDocsResultVersion, storedID, storedVersion)
+	}
+	return storedVersion, nil
+}
+
+// docsResultVersionFromFrame reads the stored identity off a persisted envelope
+// and resolves the result version from it. An envelope with no template marker
+// is a pre-PR-C frame and takes the legacy branch above.
+func docsResultVersionFromFrame(envelope []byte) (string, error) {
+	markers, err := cardmsg.CatalogFrameMarkers(envelope)
+	if err != nil {
+		return "", fmt.Errorf("%w: %v", errDocsResultVersion, err)
+	}
+	if !markers.HasRef {
+		return docsResultVersion("", "")
+	}
+	return docsResultVersion(markers.Ref.ID, markers.Ref.Version)
+}

--- a/modules/notify/docs_result_version_test.go
+++ b/modules/notify/docs_result_version_test.go
@@ -79,6 +79,21 @@ func TestDocsResultVersionFromFrameMatchesTheStoredContext(t *testing.T) {
 		t.Fatalf("unmarked frame = %q err=%v, want the legacy V3 branch", got, err)
 	}
 
+	// The population that matters: a card delivered before PR-C Slice 1 has
+	// metadata.octo.template but no top-level template_ref. Reading only the
+	// marker would send this frame down the legacy V3 branch while the click
+	// path resolved 0.2.0 — the exact disagreement this helper exists to remove.
+	metadataOnly := []byte(`{"type":17,"card":{"metadata":{"octo":{"protocol":"octo-card@1.0",` +
+		`"template":{"id":"docs.access-request","version":"0.2.0"}}}}}`)
+	if _, err := docsResultVersionFromFrame(metadataOnly); !errors.Is(err, errDocsResultVersion) {
+		t.Fatalf("metadata-only 0.2.0 frame = %v, want the same refusal the click path gives", err)
+	}
+	metadataOnlyV3 := []byte(`{"type":17,"card":{"metadata":{"octo":{"protocol":"octo-card@1.0",` +
+		`"template":{"id":"docs.access-request","version":"0.3.0"}}}}}`)
+	if got, err := docsResultVersionFromFrame(metadataOnlyV3); err != nil || got != "0.3.0" {
+		t.Fatalf("metadata-only 0.3.0 frame = %q err=%v, want 0.3.0", got, err)
+	}
+
 	marked := []byte(`{"type":17,"template_ref":{"id":"docs.access-request","version":"0.3.0"},` +
 		`"card":{"metadata":{"octo":{"protocol":"octo-card@1.0",` +
 		`"template":{"id":"docs.access-request","version":"0.3.0"}}}}}`)

--- a/modules/notify/docs_result_version_test.go
+++ b/modules/notify/docs_result_version_test.go
@@ -1,0 +1,96 @@
+package notify
+
+// PR-C review follow-up evidence: the click path and the mutate path resolve
+// the result-edit version through one rule, and that rule refuses the two cases
+// that used to fail deep inside the renderer.
+
+import (
+	"errors"
+	"testing"
+
+	docsaccessrequest "github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl/docs_access_request"
+)
+
+func TestDocsResultVersionRules(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		id      string
+		version string
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "an unmarked legacy frame keeps rendering V3",
+			want: docsaccessrequest.TemplateVersionV3,
+		},
+		{
+			name: "a marked frame renders at its own stored version",
+			id:   string(docsaccessrequest.TemplateID), version: docsaccessrequest.TemplateVersionV3,
+			want: docsaccessrequest.TemplateVersionV3,
+		},
+		{
+			// A dynamic pilot version is not in the static registry, and that is
+			// fine: the stored version is authoritative and the catalog fails
+			// loudly on its own if it cannot render.
+			name: "a dynamic version is honoured verbatim",
+			id:   string(docsaccessrequest.TemplateID), version: "0.4.0-pilot.20260805",
+			want: "0.4.0-pilot.20260805",
+		},
+		{
+			name: "0.2.0 has no result view and is refused with the reason",
+			id:   string(docsaccessrequest.TemplateID), version: docsaccessrequest.TemplateVersion,
+			wantErr: true,
+		},
+		{
+			name: "another template is a routing mistake",
+			id:   "ai.reasoning-process", version: "0.3.0",
+			wantErr: true,
+		},
+		{
+			name:    "a marked frame with no version cannot be resolved",
+			id:      string(docsaccessrequest.TemplateID),
+			wantErr: true,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := docsResultVersion(test.id, test.version)
+			if test.wantErr {
+				if !errors.Is(err, errDocsResultVersion) {
+					t.Fatalf("error = %v, want errDocsResultVersion", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("docsResultVersion: %v", err)
+			}
+			if got != test.want {
+				t.Fatalf("version = %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
+// The two callers must not be able to drift apart again: both go through
+// docsResultVersion, so the same stored identity yields the same answer.
+func TestDocsResultVersionFromFrameMatchesTheStoredContext(t *testing.T) {
+	unmarked := []byte(`{"type":17,"card":{"type":"AdaptiveCard"}}`)
+	got, err := docsResultVersionFromFrame(unmarked)
+	if err != nil || got != docsaccessrequest.TemplateVersionV3 {
+		t.Fatalf("unmarked frame = %q err=%v, want the legacy V3 branch", got, err)
+	}
+
+	marked := []byte(`{"type":17,"template_ref":{"id":"docs.access-request","version":"0.3.0"},` +
+		`"card":{"metadata":{"octo":{"protocol":"octo-card@1.0",` +
+		`"template":{"id":"docs.access-request","version":"0.3.0"}}}}}`)
+	got, err = docsResultVersionFromFrame(marked)
+	if err != nil {
+		t.Fatalf("marked frame: %v", err)
+	}
+	want, err := docsResultVersion("docs.access-request", "0.3.0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != want {
+		t.Fatalf("frame path = %q, stored-context path = %q", got, want)
+	}
+}

--- a/modules/robot/api.go
+++ b/modules/robot/api.go
@@ -867,6 +867,13 @@ func (rb *Robot) payloadIsVail(payloadResult maputil.Data) bool {
 			rb.Warn("卡片消息未启用,robot ingress 拒绝(部署总开关或 bot 子开关关闭)")
 			return false
 		}
+		// PR-C D3：server-only catalog 标记（template_ref / catalog_provenance）
+		// 只能由可信边界写入；robot ingress 按键存在显式拒绝（与 bot_api 的
+		// reject 口径对称，不走 __obo_* 的静默 strip —— 见 sanitize_robot_ingress.go）。
+		if robotCardPayloadForgesCatalogMarker(map[string]interface{}(payloadResult)) {
+			rb.Warn("robot 卡片试图伪造 server-only catalog 标记,拒绝")
+			return false
+		}
 		if err := cardmsg.Validate(map[string]interface{}(payloadResult)); err != nil {
 			rb.Warn("InteractiveCard payload 校验失败", zap.Error(err))
 			return false

--- a/modules/robot/sanitize_robot_ingress.go
+++ b/modules/robot/sanitize_robot_ingress.go
@@ -45,6 +45,7 @@
 package robot
 
 import (
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardmsg"
 	"github.com/Mininglamp-OSS/octo-server/pkg/obopayload"
 	"go.uber.org/zap"
 )
@@ -79,4 +80,24 @@ func sanitizeRobotIngressPayload(payload map[string]interface{}, channelID strin
 			zap.Int("stripped_count", stripped))
 	}
 	return stripped
+}
+
+// robotCardPayloadForgesCatalogMarker reports whether a robot-supplied
+// type-17 payload carries a server-only catalog marker (PR-C D3:
+// `template_ref` / `catalog_provenance`). These are authored exclusively by
+// the trusted Bot Registry and internal carddispatch boundaries; the legacy
+// robot ingress must REJECT them (loud 400-shaped false at the card gate),
+// deliberately diverging from the silent `__obo_*` strip above — the strip's
+// legacy-collision rationale does not apply to keys this PR introduces, and a
+// forged principal must never persist quietly. Presence alone rejects; shape
+// is irrelevant (a "well-formed" forgery is still a forgery).
+func robotCardPayloadForgesCatalogMarker(payload map[string]interface{}) bool {
+	if payload == nil {
+		return false
+	}
+	if _, exists := payload[cardmsg.CatalogTemplateRefKey]; exists {
+		return true
+	}
+	_, exists := payload[cardmsg.CatalogProvenanceKey]
+	return exists
 }

--- a/modules/robot/sanitize_robot_ingress_test.go
+++ b/modules/robot/sanitize_robot_ingress_test.go
@@ -263,3 +263,40 @@ func TestRobotMessage_R6FanoutKeysStripped(t *testing.T) {
 	assert.Equal(t, 1, payload["type"])
 	assert.Len(t, cl.calls, 1, "one warn log even for multiple reserved keys")
 }
+
+// ---- PR-C Slice 1 (D3): the legacy robot ingress explicitly rejects the
+// server-only catalog markers. Unlike the __obo_* strip above (a reserved
+// namespace legacy callers may collide with by accident), these keys are new
+// PR-C semantics with no legacy-caller precedent — forging them must be loud,
+// matching the bot API reject posture. ----
+
+func TestRobotCardPayloadForgesCatalogMarker(t *testing.T) {
+	cases := []struct {
+		name    string
+		payload map[string]interface{}
+		want    bool
+	}{
+		{name: "nil payload", payload: nil, want: false},
+		{name: "plain card", payload: map[string]interface{}{"type": 17, "card": map[string]interface{}{}}, want: false},
+		{name: "template_ref forge", payload: map[string]interface{}{
+			"type": 17, "card": map[string]interface{}{},
+			"template_ref": map[string]interface{}{"id": "docs.access-request", "version": "0.3.0"},
+		}, want: true},
+		{name: "catalog_provenance forge", payload: map[string]interface{}{
+			"type": 17, "card": map[string]interface{}{},
+			"catalog_provenance": map[string]interface{}{
+				"version": 1, "principal_type": "bot", "principal_id": "x", "space_id": "",
+			},
+		}, want: true},
+		{name: "null-valued marker still rejects", payload: map[string]interface{}{
+			"type": 17, "card": map[string]interface{}{}, "template_ref": nil,
+		}, want: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := robotCardPayloadForgesCatalogMarker(tc.payload); got != tc.want {
+				t.Fatalf("robotCardPayloadForgesCatalogMarker(%v) = %v, want %v", tc.payload, got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/cardmsg/provenance.go
+++ b/pkg/cardmsg/provenance.go
@@ -1,0 +1,242 @@
+package cardmsg
+
+// PR-C D3（spec: .octospec/tasks/cardtmpl-runtime-catalog-grants-discovery/
+// brief.md）：type-17 信封的 server-authored 顶层 catalog 标记。
+//
+// 两个标记都只能由可信边界写入 —— Bot Registry 路径（authBot 身份）与
+// internal carddispatch（已注册 ProducerSpec）；任何 raw ingress
+// （bot raw / robot legacy / user / incoming-webhook）必须显式拒绝携带它们。
+// 这里只定义 wire 形状与 strict parse：畸形标记是篡改信号，一律返回错误，
+// 绝不退化成 legacy 空标记（与 CardTemplateContext 的 PR#641 fail-close
+// 口径一致）。principal 与授权语义在 pkg/cardtmpl 层（cardmsg 不做授权）。
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+const (
+	// CatalogProvenanceKey / CatalogTemplateRefKey 是 type-17 信封的
+	// server-only 顶层键。raw ingress 检测/拒绝时统一引用这两个常量。
+	CatalogProvenanceKey  = "catalog_provenance"
+	CatalogTemplateRefKey = "template_ref"
+
+	// CatalogProvenanceVersion 是 v1 标记版本；未来演进 bump 该值并保持
+	// 旧版本可解析（额外形状仍然 strict）。
+	CatalogProvenanceVersion = 1
+
+	// Wire principal 类型。只有可认证的发送主体能成为 wire principal；
+	// space 是 discover-only grant principal（D2），system 是内部保留值，
+	// 二者都不会出现在存储帧里。
+	CatalogPrincipalWireBot              = "bot"
+	CatalogPrincipalWireInternalProducer = "internal_producer"
+)
+
+// ErrCatalogMarkerInvalid 标识畸形/不一致的 server-authored catalog 标记。
+var ErrCatalogMarkerInvalid = errors.New("cardmsg: invalid catalog marker")
+
+// CatalogProvenance 是 catalog_provenance 顶层标记的 typed 值对象。
+// 字段与 wire 形状一一对应；SpaceID 允许为空（发送边界没有权威 Space 的
+// 频道形态，如 Slice 3 之前的群聊 Bot 发送），非空值必须已 trim。
+type CatalogProvenance struct {
+	Version       int
+	PrincipalType string
+	PrincipalID   string
+	SpaceID       string
+}
+
+// Validate 校验 canonical v1 形状。
+func (p CatalogProvenance) Validate() error {
+	if p.Version != CatalogProvenanceVersion {
+		return fmt.Errorf("%w: unsupported provenance version %d", ErrCatalogMarkerInvalid, p.Version)
+	}
+	if p.PrincipalType != CatalogPrincipalWireBot && p.PrincipalType != CatalogPrincipalWireInternalProducer {
+		return fmt.Errorf("%w: unsupported principal_type %q", ErrCatalogMarkerInvalid, p.PrincipalType)
+	}
+	if p.PrincipalID == "" || strings.TrimSpace(p.PrincipalID) != p.PrincipalID {
+		return fmt.Errorf("%w: principal_id is required and must be trimmed", ErrCatalogMarkerInvalid)
+	}
+	if strings.TrimSpace(p.SpaceID) != p.SpaceID {
+		return fmt.Errorf("%w: space_id must be trimmed", ErrCatalogMarkerInvalid)
+	}
+	return nil
+}
+
+// MarshalMap 输出 canonical wire map。key 集合与 ParseCatalogProvenance 的
+// strict 校验互为镜像；新增字段必须同时改两处并 bump version 语义评审。
+func (p CatalogProvenance) MarshalMap() map[string]interface{} {
+	return map[string]interface{}{
+		"version":        p.Version,
+		"principal_type": p.PrincipalType,
+		"principal_id":   p.PrincipalID,
+		"space_id":       p.SpaceID,
+	}
+}
+
+// ParseCatalogProvenance strict 解析一个 catalog_provenance 值。未知键、
+// 缺键、类型错误、未知 principal、未 trim 值全部拒绝。
+func ParseCatalogProvenance(value interface{}) (CatalogProvenance, error) {
+	object, ok := value.(map[string]interface{})
+	if !ok || object == nil {
+		return CatalogProvenance{}, fmt.Errorf("%w: catalog_provenance must be an object", ErrCatalogMarkerInvalid)
+	}
+	allowed := map[string]struct{}{"version": {}, "principal_type": {}, "principal_id": {}, "space_id": {}}
+	for key := range object {
+		if _, known := allowed[key]; !known {
+			return CatalogProvenance{}, fmt.Errorf("%w: unknown catalog_provenance key %q", ErrCatalogMarkerInvalid, key)
+		}
+	}
+	for key := range allowed {
+		if _, present := object[key]; !present {
+			return CatalogProvenance{}, fmt.Errorf("%w: catalog_provenance missing key %q", ErrCatalogMarkerInvalid, key)
+		}
+	}
+	version, ok := provenanceVersion(object["version"])
+	if !ok {
+		return CatalogProvenance{}, fmt.Errorf("%w: catalog_provenance version is not an integer", ErrCatalogMarkerInvalid)
+	}
+	principalType, ok := object["principal_type"].(string)
+	if !ok {
+		return CatalogProvenance{}, fmt.Errorf("%w: principal_type must be a string", ErrCatalogMarkerInvalid)
+	}
+	principalID, ok := object["principal_id"].(string)
+	if !ok {
+		return CatalogProvenance{}, fmt.Errorf("%w: principal_id must be a string", ErrCatalogMarkerInvalid)
+	}
+	spaceID, ok := object["space_id"].(string)
+	if !ok {
+		return CatalogProvenance{}, fmt.Errorf("%w: space_id must be a string", ErrCatalogMarkerInvalid)
+	}
+	parsed := CatalogProvenance{Version: version, PrincipalType: principalType, PrincipalID: principalID, SpaceID: spaceID}
+	if err := parsed.Validate(); err != nil {
+		return CatalogProvenance{}, err
+	}
+	return parsed, nil
+}
+
+// provenanceVersion 接受 int / json.Number / 整数值 float64（三种解码路径），
+// 拒绝任何有小数部分或非数值的形状。
+func provenanceVersion(value interface{}) (int, bool) {
+	switch typed := value.(type) {
+	case int:
+		return typed, true
+	case int64:
+		return int(typed), true
+	case json.Number:
+		parsed, err := typed.Int64()
+		if err != nil {
+			return 0, false
+		}
+		return int(parsed), true
+	case float64:
+		if typed != float64(int64(typed)) {
+			return 0, false
+		}
+		return int(typed), true
+	default:
+		return 0, false
+	}
+}
+
+// CatalogTemplateRef 是顶层 template_ref 的 typed 值对象。
+type CatalogTemplateRef struct {
+	ID      string
+	Version string
+}
+
+// ParseCatalogTemplateRef strict 解析顶层 template_ref：恰好 {id, version}
+// 两个非空已 trim 字符串键（与 bot_api 的 caller-facing template_ref/v1
+// request 形状一致）。
+func ParseCatalogTemplateRef(value interface{}) (CatalogTemplateRef, error) {
+	object, ok := value.(map[string]interface{})
+	if !ok || len(object) != 2 {
+		return CatalogTemplateRef{}, fmt.Errorf("%w: template_ref must contain exactly id and version", ErrCatalogMarkerInvalid)
+	}
+	id, idOK := object["id"].(string)
+	version, versionOK := object["version"].(string)
+	if !idOK || !versionOK || id == "" || version == "" ||
+		strings.TrimSpace(id) != id || strings.TrimSpace(version) != version {
+		return CatalogTemplateRef{}, fmt.Errorf("%w: template_ref id/version are required", ErrCatalogMarkerInvalid)
+	}
+	return CatalogTemplateRef{ID: id, Version: version}, nil
+}
+
+// FrameCatalogMarkers 是一个有效帧的 server-authored catalog 身份快照。
+type FrameCatalogMarkers struct {
+	Ref           CatalogTemplateRef
+	Provenance    CatalogProvenance
+	HasRef        bool
+	HasProvenance bool
+}
+
+// CatalogFrameMarkers 从一个有效 type-17 帧提取并校验顶层 catalog 标记。
+//
+// 兼容矩阵（D3 + invariant 7 static 历史兼容）：
+//   - 两个标记都缺失 → legacy 帧，零值返回（不报错）；
+//   - 只有 template_ref → pre-PR-C Bot Registry 帧，合法；
+//   - 两个都有 → 都 strict 校验；
+//   - 只有 catalog_provenance → 服务端从不产出该形状，拒绝；
+//   - 任一存在时，template_ref 必须与 metadata.octo.template 完全一致
+//     （metadata 缺失/畸形同样拒绝 —— 标记只可能由 Registry 产出，而
+//     Registry 必然写 metadata）。
+//
+// 非 type-17 payload 返回零值（调用方对非卡片本就不该看标记）。
+func CatalogFrameMarkers(envelopeRaw []byte) (FrameCatalogMarkers, error) {
+	payload, err := decodeEnvelope(string(envelopeRaw))
+	if err != nil || !IsCardPayload(payload) {
+		return FrameCatalogMarkers{}, nil
+	}
+	return catalogMarkersFromPayload(payload, envelopeRaw)
+}
+
+func catalogMarkersFromPayload(payload map[string]interface{}, envelopeRaw []byte) (FrameCatalogMarkers, error) {
+	refValue, hasRef := payload[CatalogTemplateRefKey]
+	provenanceValue, hasProvenance := payload[CatalogProvenanceKey]
+	if !hasRef && !hasProvenance {
+		return FrameCatalogMarkers{}, nil
+	}
+	if !hasRef {
+		return FrameCatalogMarkers{}, fmt.Errorf("%w: catalog_provenance without template_ref", ErrCatalogMarkerInvalid)
+	}
+	markers := FrameCatalogMarkers{HasRef: true}
+	ref, err := ParseCatalogTemplateRef(refValue)
+	if err != nil {
+		return FrameCatalogMarkers{}, err
+	}
+	markers.Ref = ref
+	if envelopeRaw == nil {
+		encoded, marshalErr := json.Marshal(payload)
+		if marshalErr != nil {
+			return FrameCatalogMarkers{}, fmt.Errorf("%w: encode envelope: %v", ErrCatalogMarkerInvalid, marshalErr)
+		}
+		envelopeRaw = encoded
+	}
+	template, ok := CardTemplateContext(envelopeRaw)
+	if !ok || template.ID != ref.ID || template.Version != ref.Version {
+		return FrameCatalogMarkers{}, fmt.Errorf("%w: template_ref does not match metadata.octo.template", ErrCatalogMarkerInvalid)
+	}
+	if hasProvenance {
+		provenance, err := ParseCatalogProvenance(provenanceValue)
+		if err != nil {
+			return FrameCatalogMarkers{}, err
+		}
+		markers.Provenance = provenance
+		markers.HasProvenance = true
+	}
+	return markers, nil
+}
+
+// validateCatalogMarkers 是 Validate 的 defense-in-depth 钩子：任何携带
+// catalog 标记的信封（send 或 NormalizeContentEdit 路径）都必须是 canonical
+// 形状。raw ingress 的显式拒绝仍在各自边界；这里兜住遗漏的路径。
+func validateCatalogMarkers(payload map[string]interface{}) error {
+	_, hasRef := payload[CatalogTemplateRefKey]
+	_, hasProvenance := payload[CatalogProvenanceKey]
+	if !hasRef && !hasProvenance {
+		return nil
+	}
+	_, err := catalogMarkersFromPayload(payload, nil)
+	return err
+}

--- a/pkg/cardmsg/provenance_test.go
+++ b/pkg/cardmsg/provenance_test.go
@@ -1,0 +1,289 @@
+package cardmsg
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// Slice 1 RED (PR-C D3): the server-authored top-level catalog markers are a
+// strict wire value object. Anything that does not match the canonical v1
+// shape must fail parsing — a malformed marker is a tamper signal, never a
+// legacy fallback.
+
+func validProvenanceMap() map[string]interface{} {
+	return map[string]interface{}{
+		"version":        1,
+		"principal_type": "internal_producer",
+		"principal_id":   "docs-notify",
+		"space_id":       "space-1",
+	}
+}
+
+func TestParseCatalogProvenanceStrictShape(t *testing.T) {
+	cases := []struct {
+		name    string
+		mutate  func(map[string]interface{})
+		value   interface{}
+		wantErr bool
+	}{
+		{name: "canonical internal producer", mutate: func(m map[string]interface{}) {}},
+		{name: "canonical bot", mutate: func(m map[string]interface{}) {
+			m["principal_type"] = "bot"
+			m["principal_id"] = "bot-1"
+		}},
+		{name: "empty space is allowed pre target-space resolution", mutate: func(m map[string]interface{}) {
+			m["space_id"] = ""
+		}},
+		{name: "json.Number version from UseNumber decode", mutate: func(m map[string]interface{}) {
+			m["version"] = json.Number("1")
+		}},
+		{name: "float64 version from plain decode", mutate: func(m map[string]interface{}) {
+			m["version"] = float64(1)
+		}},
+		{name: "not a map", value: "forged", wantErr: true},
+		{name: "nil value", value: nil, wantErr: true},
+		{name: "unknown extra key", mutate: func(m map[string]interface{}) {
+			m["actor"] = "attacker"
+		}, wantErr: true},
+		{name: "missing version", mutate: func(m map[string]interface{}) {
+			delete(m, "version")
+		}, wantErr: true},
+		{name: "unsupported version", mutate: func(m map[string]interface{}) {
+			m["version"] = 2
+		}, wantErr: true},
+		{name: "missing principal_type", mutate: func(m map[string]interface{}) {
+			delete(m, "principal_type")
+		}, wantErr: true},
+		{name: "unknown principal_type", mutate: func(m map[string]interface{}) {
+			m["principal_type"] = "space"
+		}, wantErr: true},
+		{name: "system principal is not a wire principal", mutate: func(m map[string]interface{}) {
+			m["principal_type"] = "system"
+		}, wantErr: true},
+		{name: "missing principal_id", mutate: func(m map[string]interface{}) {
+			delete(m, "principal_id")
+		}, wantErr: true},
+		{name: "empty principal_id", mutate: func(m map[string]interface{}) {
+			m["principal_id"] = ""
+		}, wantErr: true},
+		{name: "untrimmed principal_id", mutate: func(m map[string]interface{}) {
+			m["principal_id"] = " docs-notify"
+		}, wantErr: true},
+		{name: "missing space_id key", mutate: func(m map[string]interface{}) {
+			delete(m, "space_id")
+		}, wantErr: true},
+		{name: "untrimmed space_id", mutate: func(m map[string]interface{}) {
+			m["space_id"] = "space-1 "
+		}, wantErr: true},
+		{name: "non-string principal_id", mutate: func(m map[string]interface{}) {
+			m["principal_id"] = 42
+		}, wantErr: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			value := tc.value
+			if tc.mutate != nil {
+				m := validProvenanceMap()
+				tc.mutate(m)
+				value = m
+			}
+			parsed, err := ParseCatalogProvenance(value)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("ParseCatalogProvenance(%#v) accepted a non-canonical marker: %+v", value, parsed)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ParseCatalogProvenance(%#v): %v", value, err)
+			}
+			if parsed.Version != CatalogProvenanceVersion {
+				t.Fatalf("version = %d", parsed.Version)
+			}
+		})
+	}
+}
+
+func TestCatalogProvenanceMarshalRoundTrip(t *testing.T) {
+	original := CatalogProvenance{
+		Version:       CatalogProvenanceVersion,
+		PrincipalType: CatalogPrincipalWireBot,
+		PrincipalID:   "bot-7",
+		SpaceID:       "space-9",
+	}
+	parsed, err := ParseCatalogProvenance(original.MarshalMap())
+	if err != nil {
+		t.Fatalf("round trip parse: %v", err)
+	}
+	if parsed != original {
+		t.Fatalf("round trip = %+v, want %+v", parsed, original)
+	}
+	// The map must survive a JSON encode/decode cycle (durable event storage).
+	raw, err := json.Marshal(original.MarshalMap())
+	if err != nil {
+		t.Fatal(err)
+	}
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	parsed, err = ParseCatalogProvenance(decoded)
+	if err != nil {
+		t.Fatalf("post-JSON parse: %v", err)
+	}
+	if parsed != original {
+		t.Fatalf("post-JSON round trip = %+v, want %+v", parsed, original)
+	}
+}
+
+func registryFrame(t *testing.T, mutate func(map[string]interface{})) []byte {
+	t.Helper()
+	frame := map[string]interface{}{
+		"type":         17,
+		"card_version": CardVersion,
+		"profile":      "octo/v1",
+		"template_ref": map[string]interface{}{"id": "docs.access-request", "version": "0.3.0"},
+		"catalog_provenance": map[string]interface{}{
+			"version": 1, "principal_type": "internal_producer",
+			"principal_id": "docs-notify", "space_id": "space-1",
+		},
+		"card": map[string]interface{}{
+			"type": "AdaptiveCard", "version": CardVersion,
+			"body": []interface{}{map[string]interface{}{"type": "TextBlock", "text": "hi"}},
+			"metadata": map[string]interface{}{"octo": map[string]interface{}{
+				"protocol": "octo-card@1.0",
+				"template": map[string]interface{}{"id": "docs.access-request", "version": "0.3.0"},
+			}},
+		},
+	}
+	if mutate != nil {
+		mutate(frame)
+	}
+	raw, err := json.Marshal(frame)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return raw
+}
+
+func TestCatalogFrameMarkersMatrix(t *testing.T) {
+	t.Run("both markers canonical", func(t *testing.T) {
+		markers, err := CatalogFrameMarkers(registryFrame(t, nil))
+		if err != nil {
+			t.Fatalf("CatalogFrameMarkers: %v", err)
+		}
+		if !markers.HasRef || !markers.HasProvenance {
+			t.Fatalf("markers presence = %+v", markers)
+		}
+		if markers.Ref.ID != "docs.access-request" || markers.Ref.Version != "0.3.0" {
+			t.Fatalf("ref = %+v", markers.Ref)
+		}
+		if markers.Provenance.PrincipalID != "docs-notify" || markers.Provenance.SpaceID != "space-1" {
+			t.Fatalf("provenance = %+v", markers.Provenance)
+		}
+	})
+	t.Run("legacy frame without markers", func(t *testing.T) {
+		markers, err := CatalogFrameMarkers(registryFrame(t, func(f map[string]interface{}) {
+			delete(f, "template_ref")
+			delete(f, "catalog_provenance")
+		}))
+		if err != nil {
+			t.Fatalf("legacy frame must stay compatible: %v", err)
+		}
+		if markers.HasRef || markers.HasProvenance {
+			t.Fatalf("legacy frame reported markers: %+v", markers)
+		}
+	})
+	t.Run("pre-PR-C bot frame keeps ref-only compatibility", func(t *testing.T) {
+		markers, err := CatalogFrameMarkers(registryFrame(t, func(f map[string]interface{}) {
+			delete(f, "catalog_provenance")
+		}))
+		if err != nil {
+			t.Fatalf("ref-only frame must stay compatible: %v", err)
+		}
+		if !markers.HasRef || markers.HasProvenance {
+			t.Fatalf("ref-only markers = %+v", markers)
+		}
+	})
+	t.Run("provenance without ref is never a server shape", func(t *testing.T) {
+		if _, err := CatalogFrameMarkers(registryFrame(t, func(f map[string]interface{}) {
+			delete(f, "template_ref")
+		})); err == nil {
+			t.Fatal("provenance without template_ref accepted")
+		}
+	})
+	t.Run("ref mismatching metadata is rejected", func(t *testing.T) {
+		if _, err := CatalogFrameMarkers(registryFrame(t, func(f map[string]interface{}) {
+			f["template_ref"] = map[string]interface{}{"id": "docs.access-request", "version": "0.2.0"}
+		})); err == nil {
+			t.Fatal("template_ref/metadata version mismatch accepted")
+		}
+	})
+	t.Run("ref without template metadata is rejected", func(t *testing.T) {
+		if _, err := CatalogFrameMarkers(registryFrame(t, func(f map[string]interface{}) {
+			card := f["card"].(map[string]interface{})
+			delete(card, "metadata")
+		})); err == nil {
+			t.Fatal("template_ref without metadata.octo.template accepted")
+		}
+	})
+	t.Run("malformed provenance is rejected", func(t *testing.T) {
+		if _, err := CatalogFrameMarkers(registryFrame(t, func(f map[string]interface{}) {
+			f["catalog_provenance"] = "forged"
+		})); err == nil {
+			t.Fatal("malformed catalog_provenance accepted")
+		}
+	})
+	t.Run("malformed ref is rejected", func(t *testing.T) {
+		if _, err := CatalogFrameMarkers(registryFrame(t, func(f map[string]interface{}) {
+			f["template_ref"] = map[string]interface{}{"id": "docs.access-request"}
+		})); err == nil {
+			t.Fatal("template_ref missing version accepted")
+		}
+	})
+	t.Run("non-card payload has no markers", func(t *testing.T) {
+		markers, err := CatalogFrameMarkers([]byte(`{"type":1,"content":"hello"}`))
+		if err != nil || markers.HasRef || markers.HasProvenance {
+			t.Fatalf("non-card = %+v err=%v", markers, err)
+		}
+	})
+}
+
+// Validate must reject malformed markers as defense in depth on every path
+// that funnels a full envelope through it (send + NormalizeContentEdit).
+func TestValidateRejectsMalformedCatalogMarkers(t *testing.T) {
+	decode := func(raw []byte) map[string]interface{} {
+		var payload map[string]interface{}
+		if err := json.Unmarshal(raw, &payload); err != nil {
+			t.Fatal(err)
+		}
+		return payload
+	}
+	if err := Validate(decode(registryFrame(t, nil))); err != nil {
+		t.Fatalf("canonical markers must pass Validate: %v", err)
+	}
+	for name, mutate := range map[string]func(map[string]interface{}){
+		"provenance not object": func(f map[string]interface{}) { f["catalog_provenance"] = 7 },
+		"provenance extra key": func(f map[string]interface{}) {
+			f["catalog_provenance"].(map[string]interface{})["grantor"] = "x"
+		},
+		"provenance without ref": func(f map[string]interface{}) { delete(f, "template_ref") },
+		"ref not object":         func(f map[string]interface{}) { f["template_ref"] = []interface{}{} },
+		"ref metadata mismatch": func(f map[string]interface{}) {
+			f["template_ref"].(map[string]interface{})["version"] = "9.9.9"
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			payload := decode(registryFrame(t, nil))
+			mutate(payload)
+			err := Validate(payload)
+			if err == nil {
+				t.Fatal("Validate accepted a malformed catalog marker")
+			}
+			if !strings.Contains(err.Error(), "catalog") {
+				t.Fatalf("error should identify the catalog marker: %v", err)
+			}
+		})
+	}
+}

--- a/pkg/cardmsg/validate.go
+++ b/pkg/cardmsg/validate.go
@@ -44,6 +44,12 @@ func Validate(payload map[string]interface{}) error {
 			return fmt.Errorf("%w: render_profile=%q", ErrCardProfileUnsupported, renderProfile)
 		}
 	}
+	// PR-C D3 defense in depth：携带 server-authored catalog 标记的信封必须是
+	// canonical 形状（strict parse + template_ref↔metadata 一致）。raw ingress
+	// 的显式拒绝在各自边界；这里兜住任何遗漏路径与编辑重写。
+	if err := validateCatalogMarkers(payload); err != nil {
+		return err
+	}
 	card, ok := payload["card"].(map[string]interface{})
 	if !ok || len(card) == 0 {
 		return ErrCardMissing

--- a/pkg/cardtmpl/catalog.go
+++ b/pkg/cardtmpl/catalog.go
@@ -15,6 +15,11 @@ const (
 	CatalogPurposeNewSend        CatalogPurpose = "new_send"
 	CatalogPurposeHistoricalEdit CatalogPurpose = "historical_edit"
 	CatalogPurposeActionContext  CatalogPurpose = "action_context"
+	// CatalogPurposeDiscover is a read of the catalog's contract surface (B1/B2).
+	// It carries no permission to send or edit: being able to see that a
+	// template exists is deliberately weaker than being able to use it, which
+	// is why discovery has its own purpose rather than reusing new_send.
+	CatalogPurposeDiscover CatalogPurpose = "discover"
 )
 
 type CatalogPrincipalKind string
@@ -23,6 +28,10 @@ const (
 	CatalogPrincipalBot              CatalogPrincipalKind = "bot"
 	CatalogPrincipalInternalProducer CatalogPrincipalKind = "internal_producer"
 	CatalogPrincipalSystem           CatalogPrincipalKind = "system"
+	// CatalogPrincipalSpace is a human caller acting inside one Space. It is
+	// grantable for discovery only (D2): a Space cannot authenticate as a
+	// producer, so it can never hold send or edit.
+	CatalogPrincipalSpace CatalogPrincipalKind = "space"
 )
 
 type CatalogPrincipal struct {

--- a/pkg/cardtmpl/docs_access_request/handoff/docs.access-request@0.3.0/contract/data.schema.json
+++ b/pkg/cardtmpl/docs_access_request/handoff/docs.access-request@0.3.0/contract/data.schema.json
@@ -20,7 +20,8 @@
         "pending",
         "approved",
         "rejected",
-        "cancelled"
+        "cancelled",
+        "unavailable"
       ]
     },
     "document": {

--- a/pkg/cardtmpl/docs_access_request/handoff/docs.access-request@0.3.0/contract/data.schema.json
+++ b/pkg/cardtmpl/docs_access_request/handoff/docs.access-request@0.3.0/contract/data.schema.json
@@ -3,55 +3,133 @@
   "title": "文档访问申请卡数据契约 0.3.0",
   "type": "object",
   "additionalProperties": false,
-  "required": ["requestId", "state", "document"],
+  "required": [
+    "requestId",
+    "state",
+    "document"
+  ],
   "properties": {
-    "requestId": {"type": "string", "minLength": 1, "maxLength": 200},
-    "state": {"type": "string", "enum": ["pending", "approved", "rejected"]},
+    "requestId": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 200
+    },
+    "state": {
+      "type": "string",
+      "enum": [
+        "pending",
+        "approved",
+        "rejected",
+        "cancelled"
+      ]
+    },
     "document": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["title"],
+      "required": [
+        "title"
+      ],
       "properties": {
-        "docId": {"type": "string", "maxLength": 200},
-        "title": {"type": "string", "minLength": 1, "maxLength": 200},
-        "url": {"type": "string", "maxLength": 2048},
-        "sourceName": {"type": "string", "maxLength": 200}
+        "docId": {
+          "type": "string",
+          "maxLength": 200
+        },
+        "title": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 200
+        },
+        "url": {
+          "type": "string",
+          "maxLength": 2048
+        },
+        "sourceName": {
+          "type": "string",
+          "maxLength": 200
+        }
       }
     },
     "requester": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "name": {"type": "string", "maxLength": 120},
-        "avatarUrl": {"type": "string", "maxLength": 2048, "pattern": "^(|https://[^/].*)$"}
+        "name": {
+          "type": "string",
+          "maxLength": 120
+        },
+        "avatarUrl": {
+          "type": "string",
+          "maxLength": 2048,
+          "pattern": "^(|https://[^/].*)$"
+        }
       }
     },
     "permission": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {"type": "string", "maxLength": 80},
-        "roleLabel": {"type": "string", "maxLength": 80}
+        "label": {
+          "type": "string",
+          "maxLength": 80
+        },
+        "roleLabel": {
+          "type": "string",
+          "maxLength": 80
+        }
       }
     },
-    "requestReason": {"type": "string", "maxLength": 300},
-    "requestedAtDisplay": {"type": "string", "maxLength": 80},
-    "messageTimeDisplay": {"type": "string", "maxLength": 80},
+    "requestReason": {
+      "type": "string",
+      "maxLength": 300
+    },
+    "requestedAtDisplay": {
+      "type": "string",
+      "maxLength": 80
+    },
+    "messageTimeDisplay": {
+      "type": "string",
+      "maxLength": 80
+    },
     "decision": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["operatorName"],
+      "required": [
+        "operatorName"
+      ],
       "properties": {
-        "operatorName": {"type": "string", "minLength": 1, "maxLength": 120},
-        "decidedAtDisplay": {"type": "string", "maxLength": 80},
-        "rejectionReason": {"type": "string", "maxLength": 300}
+        "operatorName": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 120
+        },
+        "decidedAtDisplay": {
+          "type": "string",
+          "maxLength": 80
+        },
+        "rejectionReason": {
+          "type": "string",
+          "maxLength": 300
+        }
       }
     }
   },
   "allOf": [
     {
-      "if": {"properties": {"state": {"enum": ["approved", "rejected"]}}},
-      "then": {"required": ["decision"]}
+      "if": {
+        "properties": {
+          "state": {
+            "enum": [
+              "approved",
+              "rejected"
+            ]
+          }
+        }
+      },
+      "then": {
+        "required": [
+          "decision"
+        ]
+      }
     }
   ]
 }

--- a/pkg/cardtmpl/docs_access_request/handoff/docs.access-request@0.3.0/manifest.json
+++ b/pkg/cardtmpl/docs_access_request/handoff/docs.access-request@0.3.0/manifest.json
@@ -28,12 +28,14 @@
       "states": [
         "approved",
         "rejected",
-        "cancelled"
+        "cancelled",
+        "unavailable"
       ],
       "samples": [
         "samples/approved.json",
         "samples/rejected.json",
-        "samples/cancelled.json"
+        "samples/cancelled.json",
+        "samples/unavailable.json"
       ]
     }
   }

--- a/pkg/cardtmpl/docs_access_request/handoff/docs.access-request@0.3.0/manifest.json
+++ b/pkg/cardtmpl/docs_access_request/handoff/docs.access-request@0.3.0/manifest.json
@@ -16,13 +16,25 @@
   "views": {
     "pending": {
       "wireProfile": "octo/v2",
-      "states": ["pending"],
-      "samples": ["samples/pending.json"]
+      "states": [
+        "pending"
+      ],
+      "samples": [
+        "samples/pending.json"
+      ]
     },
     "result": {
       "wireProfile": "octo/v1",
-      "states": ["approved", "rejected"],
-      "samples": ["samples/approved.json", "samples/rejected.json"]
+      "states": [
+        "approved",
+        "rejected",
+        "cancelled"
+      ],
+      "samples": [
+        "samples/approved.json",
+        "samples/rejected.json",
+        "samples/cancelled.json"
+      ]
     }
   }
 }

--- a/pkg/cardtmpl/docs_access_request/handoff/docs.access-request@0.3.0/samples/cancelled.json
+++ b/pkg/cardtmpl/docs_access_request/handoff/docs.access-request@0.3.0/samples/cancelled.json
@@ -1,0 +1,10 @@
+{
+  "requestId": "DOC-REQ-025",
+  "state": "cancelled",
+  "document": {"docId": "d_2026-q3-okr", "title": "2026 Q3 OKR", "sourceName": "Q3 产品规划"},
+  "requester": {"name": "张三"},
+  "permission": {"label": "协作权限", "roleLabel": "协作者"},
+  "requestReason": "希望加入协作，以补充 KR3 数据。",
+  "requestedAtDisplay": "2026-07-16 11:00",
+  "messageTimeDisplay": "刚刚"
+}

--- a/pkg/cardtmpl/docs_access_request/handoff/docs.access-request@0.3.0/samples/unavailable.json
+++ b/pkg/cardtmpl/docs_access_request/handoff/docs.access-request@0.3.0/samples/unavailable.json
@@ -1,0 +1,10 @@
+{
+  "requestId": "DOC-REQ-026",
+  "state": "unavailable",
+  "document": {"docId": "d_2026-q3-okr", "title": "2026 Q3 OKR", "sourceName": "Q3 产品规划"},
+  "requester": {"name": "张三"},
+  "permission": {"label": "协作权限", "roleLabel": "协作者"},
+  "requestReason": "希望加入协作，以补充 KR3 数据。",
+  "requestedAtDisplay": "2026-07-16 11:00",
+  "messageTimeDisplay": "刚刚"
+}

--- a/pkg/cardtmpl/docs_access_request/v3.go
+++ b/pkg/cardtmpl/docs_access_request/v3.go
@@ -22,10 +22,16 @@ const (
 	// outside the Registry: the markers assert a template identity, and only a
 	// Registry render produces the metadata.octo.template they must agree with.
 	StateCancelled cardtmpl.State = "cancelled"
+	// StateUnavailable is the outcome for an action that reached no decision at
+	// all — the finalizer's catch-all, which previously rendered a plain
+	// resource card. It exists for the same reason StateCancelled does: the
+	// replacement for a marked card has to be a Registry render.
+	StateUnavailable cardtmpl.State = "unavailable"
 
-	VariantApproved  = "docs.access_approved"
-	VariantRejected  = "docs.access_denied"
-	VariantCancelled = "docs.access_cancelled"
+	VariantApproved    = "docs.access_approved"
+	VariantRejected    = "docs.access_denied"
+	VariantCancelled   = "docs.access_cancelled"
+	VariantUnavailable = "docs.access_unavailable"
 )
 
 type TemplateV3 struct {
@@ -98,7 +104,8 @@ func (t *TemplateV3) Build(ctx context.Context, state cardtmpl.State, fields jso
 			Body: body, Variant: Variant, DeepLink: deepLink, Source: &source,
 		}, nil
 	}
-	if state != StateApproved && state != StateRejected && state != StateCancelled {
+	if state != StateApproved && state != StateRejected &&
+		state != StateCancelled && state != StateUnavailable {
 		return cardtmpl.BuildResult{}, fmt.Errorf("docs.access-request@0.3.0: unsupported state %q", state)
 	}
 	var input v3Fields
@@ -116,6 +123,8 @@ func (t *TemplateV3) Build(ctx context.Context, state cardtmpl.State, fields jso
 		variant = VariantRejected
 	case StateCancelled:
 		labels, variant = cancelledLabels(env.Lang), VariantCancelled
+	case StateUnavailable:
+		labels, variant = unavailableLabels(env.Lang), VariantUnavailable
 	}
 	body, deepLink, err := cardtmpl.BuildDocsApprovalOutcomeV3BodyWithLang(env.Lang, env.WebLoginURL, docID, env.SpaceID, cardtmpl.DocsOutcomeContent{
 		// Denied selects the L0 "not granted" treatment rather than the green
@@ -146,7 +155,8 @@ func (t *TemplateV3) FallbackText(state cardtmpl.State, fields json.RawMessage, 
 	if state == StatePending {
 		return New().FallbackText(state, fields, lang)
 	}
-	if state != StateApproved && state != StateRejected && state != StateCancelled {
+	if state != StateApproved && state != StateRejected &&
+		state != StateCancelled && state != StateUnavailable {
 		return "", fmt.Errorf("docs.access-request@0.3.0: unsupported fallback state %q", state)
 	}
 	var input v3Fields
@@ -154,8 +164,11 @@ func (t *TemplateV3) FallbackText(state cardtmpl.State, fields json.RawMessage, 
 		return "", err
 	}
 	labels := resultLabels(lang, state == StateRejected)
-	if state == StateCancelled {
+	switch state {
+	case StateCancelled:
 		labels = cancelledLabels(lang)
+	case StateUnavailable:
+		labels = unavailableLabels(lang)
 	}
 	return strings.TrimSpace(input.Document.Title) + " - " + labels.status, nil
 }
@@ -183,6 +196,21 @@ func (l resultLabelSet) banner(role string) string {
 		role = "viewer"
 	}
 	return "requested " + role + " access to this document."
+}
+
+// unavailableLabels describes an action that reached no decision at all — the
+// finalizer's catch-all when a route answers something other than a decision.
+func unavailableLabels(lang string) resultLabelSet {
+	if strings.EqualFold(lang, "zh-CN") || strings.HasPrefix(strings.ToLower(lang), "zh") {
+		return resultLabelSet{
+			header: "文档申请", status: "暂不可用", result: "本次访问申请暂时无法处理，权限未发生变更。",
+			reason: "拒绝原因", role: "申请人", requestReason: "申请原因", processedAt: "处理于", zh: true,
+		}
+	}
+	return resultLabelSet{
+		header: "Document access", status: "Unavailable", result: "The access request could not be processed; no permission changed.",
+		reason: "Reason", role: "Requester", requestReason: "Reason", processedAt: "Processed at",
+	}
 }
 
 // cancelledLabels describes a request that ended without a decision. It reuses

--- a/pkg/cardtmpl/docs_access_request/v3.go
+++ b/pkg/cardtmpl/docs_access_request/v3.go
@@ -15,9 +15,17 @@ const (
 
 	StateApproved cardtmpl.State = "approved"
 	StateRejected cardtmpl.State = "rejected"
+	// StateCancelled is a request withdrawn or expired rather than decided, so
+	// it carries no `decision` block — the data contract requires one only for
+	// approved/rejected. It renders through the result view like the other two
+	// because a card that has been marked cannot be replaced by a frame built
+	// outside the Registry: the markers assert a template identity, and only a
+	// Registry render produces the metadata.octo.template they must agree with.
+	StateCancelled cardtmpl.State = "cancelled"
 
-	VariantApproved = "docs.access_approved"
-	VariantRejected = "docs.access_denied"
+	VariantApproved  = "docs.access_approved"
+	VariantRejected  = "docs.access_denied"
+	VariantCancelled = "docs.access_cancelled"
 )
 
 type TemplateV3 struct {
@@ -90,7 +98,7 @@ func (t *TemplateV3) Build(ctx context.Context, state cardtmpl.State, fields jso
 			Body: body, Variant: Variant, DeepLink: deepLink, Source: &source,
 		}, nil
 	}
-	if state != StateApproved && state != StateRejected {
+	if state != StateApproved && state != StateRejected && state != StateCancelled {
 		return cardtmpl.BuildResult{}, fmt.Errorf("docs.access-request@0.3.0: unsupported state %q", state)
 	}
 	var input v3Fields
@@ -103,11 +111,20 @@ func (t *TemplateV3) Build(ctx context.Context, state cardtmpl.State, fields jso
 	}
 	labels := resultLabels(env.Lang, state == StateRejected)
 	variant := VariantApproved
-	if state == StateRejected {
+	switch state {
+	case StateRejected:
 		variant = VariantRejected
+	case StateCancelled:
+		labels, variant = cancelledLabels(env.Lang), VariantCancelled
 	}
 	body, deepLink, err := cardtmpl.BuildDocsApprovalOutcomeV3BodyWithLang(env.Lang, env.WebLoginURL, docID, env.SpaceID, cardtmpl.DocsOutcomeContent{
-		Title: input.Document.Title, Variant: variant, Denied: state == StateRejected,
+		// Denied selects the L0 "not granted" treatment rather than the green
+		// approved one. Cancelled is not a denial, but the outcome builder
+		// carries a two-way flag and the honest half of it is that access was
+		// not granted; the wording comes from the labels above. Giving the base
+		// card a third treatment would change a shared L0 contract for a
+		// display nuance, which does not belong in this fix.
+		Title: input.Document.Title, Variant: variant, Denied: state != StateApproved,
 		HeaderLabel: labels.header, SourceName: input.Document.SourceName,
 		StatusLabel: labels.status, PermissionLabel: input.Permission.Label, ResultText: labels.result,
 		ReasonLabel: labels.reason, Reason: input.Decision.RejectionReason,
@@ -129,7 +146,7 @@ func (t *TemplateV3) FallbackText(state cardtmpl.State, fields json.RawMessage, 
 	if state == StatePending {
 		return New().FallbackText(state, fields, lang)
 	}
-	if state != StateApproved && state != StateRejected {
+	if state != StateApproved && state != StateRejected && state != StateCancelled {
 		return "", fmt.Errorf("docs.access-request@0.3.0: unsupported fallback state %q", state)
 	}
 	var input v3Fields
@@ -137,6 +154,9 @@ func (t *TemplateV3) FallbackText(state cardtmpl.State, fields json.RawMessage, 
 		return "", err
 	}
 	labels := resultLabels(lang, state == StateRejected)
+	if state == StateCancelled {
+		labels = cancelledLabels(lang)
+	}
 	return strings.TrimSpace(input.Document.Title) + " - " + labels.status, nil
 }
 
@@ -163,6 +183,22 @@ func (l resultLabelSet) banner(role string) string {
 		role = "viewer"
 	}
 	return "requested " + role + " access to this document."
+}
+
+// cancelledLabels describes a request that ended without a decision. It reuses
+// resultLabelSet so the outcome body needs no new shape; the reason row stays
+// empty because a cancelled request has no operator and no rejection reason.
+func cancelledLabels(lang string) resultLabelSet {
+	if strings.EqualFold(lang, "zh-CN") || strings.HasPrefix(strings.ToLower(lang), "zh") {
+		return resultLabelSet{
+			header: "文档申请", status: "已取消", result: "本次访问申请已取消，权限未发生变更。",
+			reason: "拒绝原因", role: "申请人", requestReason: "申请原因", processedAt: "处理于", zh: true,
+		}
+	}
+	return resultLabelSet{
+		header: "Document access", status: "Cancelled", result: "The access request was cancelled; no permission changed.",
+		reason: "Reason", role: "Requester", requestReason: "Reason", processedAt: "Processed at",
+	}
 }
 
 func resultLabels(lang string, denied bool) resultLabelSet {

--- a/pkg/cardtmpl/export.go
+++ b/pkg/cardtmpl/export.go
@@ -1,0 +1,255 @@
+package cardtmpl
+
+// PR-C D5 — the safe export projection served by B2.
+//
+// A template's on-disk or in-bundle form contains things a discovery caller
+// must never receive: the view templates themselves, golden files, and (for a
+// dynamic artifact) the canonical bytes that hash to its identity. What a
+// caller legitimately needs is the *contract* — what states exist, what shape
+// the input takes, which actions a view declares, and one or two examples of
+// valid input.
+//
+// The projection is built once, at registration or compile time, and is
+// immutable thereafter. Two consequences are deliberate:
+//
+//   - No request ever reads a source directory, and nothing is reconstructed
+//     by inspecting a compiled schema. What ships is a copy of the reviewed
+//     bytes, or nothing at all.
+//   - The set of exportable documents is fixed when the artifact is built, so a
+//     later change to serving code cannot widen it. Widening requires a new
+//     artifact version, which goes through publish review.
+//
+// Samples are the one part a template opts *into*. They are caller-authored
+// input fixtures and can easily carry real tenant data, so the default is to
+// export none; a bundle must name each exportable sample in its manifest, and
+// the compiler rejects a name that does not exist. Static L1 cards are frozen
+// and cannot grow that declaration, so their exported sample set is always
+// empty — which is the correct answer, not a gap.
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"sort"
+)
+
+// maxSafeExportBytes bounds one serialized projection. It is checked before
+// marshalling reaches a response buffer so an oversized artifact fails as an
+// integrity problem at build time rather than as a truncated HTTP body.
+const maxSafeExportBytes = 2 << 20
+
+// ExportView is one view's contract, without its template document.
+type ExportView struct {
+	Name        string   `json:"name"`
+	WireProfile string   `json:"wire_profile"`
+	States      []string `json:"states"`
+	// SubmitActions lists the view's declared Action.Submit ids. Present only
+	// for interactive views; a display-only view reports an empty list rather
+	// than null so callers need no special case.
+	SubmitActions []string `json:"submit_actions"`
+}
+
+// ExportActionContract is the callback routing a card's Submit actions carry.
+// It is nil for a display-only card, which is exactly the signal a producer
+// needs to know no callback will ever arrive (platform-card-base §9).
+type ExportActionContract struct {
+	Owner      string `json:"owner"`
+	ActionType string `json:"action_type"`
+}
+
+// SafeExport is the immutable projection. Every field on it is safe to return
+// to any caller that has already passed the visibility check; there is no
+// second filtering step at serving time, because a projection that needed one
+// would be a projection that had already been built wrong.
+type SafeExport struct {
+	ID              string                `json:"id"`
+	Version         string                `json:"version"`
+	Protocol        string                `json:"protocol"`
+	ContractVersion string                `json:"contract_version,omitempty"`
+	Owner           string                `json:"owner,omitempty"`
+	Engine          string                `json:"engine,omitempty"`
+	Visibility      string                `json:"visibility"`
+	ActionContract  *ExportActionContract `json:"action_contract"`
+	Views           []ExportView          `json:"views"`
+
+	Manifest json.RawMessage            `json:"manifest"`
+	Schema   json.RawMessage            `json:"schema,omitempty"`
+	Reports  map[string]json.RawMessage `json:"reports,omitempty"`
+	// Samples holds only the fixtures the manifest opted into exporting.
+	Samples map[string]json.RawMessage `json:"samples"`
+
+	// Hash is a deterministic digest of everything above. Static templates use
+	// it as their ETag; dynamic ones use their immutable content hash, which is
+	// stronger because it also covers the documents this projection omits.
+	Hash string `json:"-"`
+}
+
+// exportSamples is the manifest's opt-in allowlist. It is a separate struct so
+// the strict unknown-key check in decodeManifest has something concrete to
+// validate against.
+type exportSamples struct {
+	Samples []string `json:"samples"`
+}
+
+// buildSafeExport assembles the projection. It returns an error rather than a
+// partial result: an artifact whose contract cannot be projected safely is one
+// that should fail to compile, not one that should be served with holes.
+func buildSafeExport(
+	meta TemplateMeta,
+	engine, visibility, owner string,
+	schema json.RawMessage,
+	reports map[string]json.RawMessage,
+	samples map[string]json.RawMessage,
+	allowlist []string,
+) (*SafeExport, error) {
+	export := &SafeExport{
+		ID:              string(meta.ID),
+		Version:         meta.Version,
+		Protocol:        meta.Protocol,
+		ContractVersion: meta.contractVersion,
+		Owner:           owner,
+		Engine:          engine,
+		Visibility:      normalizeExportVisibility(visibility),
+		Views:           make([]ExportView, 0, len(meta.Views)),
+		Samples:         map[string]json.RawMessage{},
+	}
+	if meta.ActionContract != nil {
+		export.ActionContract = &ExportActionContract{
+			Owner: meta.ActionContract.Owner, ActionType: meta.ActionContract.ActionType,
+		}
+	}
+	for _, name := range sortedViewNames(meta.Views) {
+		spec := meta.Views[ViewKey(name)]
+		view := ExportView{
+			Name: name, WireProfile: spec.WireProfile,
+			States:        make([]string, 0, len(spec.States)),
+			SubmitActions: []string{},
+		}
+		for _, state := range spec.States {
+			view.States = append(view.States, string(state))
+		}
+		sort.Strings(view.States)
+		if report, ok := meta.Interaction(ViewKey(name)); ok {
+			for _, action := range report.Actions {
+				if action.Type == "Action.Submit" && action.ID != "" {
+					view.SubmitActions = append(view.SubmitActions, action.ID)
+				}
+			}
+			sort.Strings(view.SubmitActions)
+		}
+		export.Views = append(export.Views, view)
+	}
+	if meta.Manifest != nil {
+		export.Manifest = append(json.RawMessage(nil), meta.Manifest...)
+	}
+	if schema != nil {
+		export.Schema = append(json.RawMessage(nil), schema...)
+	}
+	if len(reports) > 0 {
+		export.Reports = cloneRawMessageMap(reports)
+	}
+	for _, key := range allowlist {
+		raw, ok := samples[key]
+		if !ok {
+			return nil, fmt.Errorf("export allowlist names sample %q, which does not exist", key)
+		}
+		export.Samples[key] = append(json.RawMessage(nil), raw...)
+	}
+
+	hash, size, err := hashSafeExport(export)
+	if err != nil {
+		return nil, err
+	}
+	if size > maxSafeExportBytes {
+		return nil, fmt.Errorf("export projection is %d bytes, over the %d byte cap", size, maxSafeExportBytes)
+	}
+	export.Hash = hash
+	return export, nil
+}
+
+// hashSafeExport digests the projection through canonical JSON so the value is
+// stable across process restarts and across replicas — an ETag that varied by
+// map iteration order would silently defeat every conditional request.
+func hashSafeExport(export *SafeExport) (string, int, error) {
+	encoded, err := json.Marshal(export)
+	if err != nil {
+		return "", 0, fmt.Errorf("marshal export projection: %w", err)
+	}
+	var normalized any
+	if err := json.Unmarshal(encoded, &normalized); err != nil {
+		return "", 0, fmt.Errorf("normalize export projection: %w", err)
+	}
+	canonical, err := marshalCanonicalJSON(normalized)
+	if err != nil {
+		return "", 0, fmt.Errorf("canonicalize export projection: %w", err)
+	}
+	sum := sha256.Sum256(canonical)
+	return hex.EncodeToString(sum[:]), len(canonical), nil
+}
+
+// normalizeExportVisibility fails closed. An artifact that never declared its
+// visibility is private, because the alternative — treating "unset" as public
+// — turns every future omission into a disclosure.
+func normalizeExportVisibility(visibility string) string {
+	if visibility == CatalogVisibilityPublic {
+		return CatalogVisibilityPublic
+	}
+	return CatalogVisibilityPrivate
+}
+
+// Clone returns a deep copy. The projection is immutable by construction, but
+// it crosses a package boundary into HTTP handlers, and a handler that mutated
+// a shared map would corrupt every later response rather than just its own.
+func (e *SafeExport) Clone() *SafeExport {
+	if e == nil {
+		return nil
+	}
+	out := *e
+	if e.ActionContract != nil {
+		contract := *e.ActionContract
+		out.ActionContract = &contract
+	}
+	out.Views = make([]ExportView, len(e.Views))
+	for i, view := range e.Views {
+		out.Views[i] = ExportView{
+			Name: view.Name, WireProfile: view.WireProfile,
+			States:        append([]string(nil), view.States...),
+			SubmitActions: append([]string(nil), view.SubmitActions...),
+		}
+	}
+	if e.Manifest != nil {
+		out.Manifest = append(json.RawMessage(nil), e.Manifest...)
+	}
+	if e.Schema != nil {
+		out.Schema = append(json.RawMessage(nil), e.Schema...)
+	}
+	out.Reports = cloneRawMessageMap(e.Reports)
+	out.Samples = cloneRawMessageMap(e.Samples)
+	if out.Samples == nil {
+		out.Samples = map[string]json.RawMessage{}
+	}
+	return &out
+}
+
+// Export returns the projection for this template, or nil when none was built.
+// A nil return means B2 has nothing safe to serve and must answer not-found
+// rather than improvise a projection at request time.
+func (m TemplateMeta) Export() *SafeExport { return m.export.Clone() }
+
+// ExportHash is the deterministic digest, empty when there is no projection.
+func (m TemplateMeta) ExportHash() string {
+	if m.export == nil {
+		return ""
+	}
+	return m.export.Hash
+}
+
+func sortedViewNames(views map[ViewKey]ViewSpec) []string {
+	names := make([]string, 0, len(views))
+	for view := range views {
+		names = append(names, string(view))
+	}
+	sort.Strings(names)
+	return names
+}

--- a/pkg/cardtmpl/export_test.go
+++ b/pkg/cardtmpl/export_test.go
@@ -206,3 +206,38 @@ func TestRegistryStaticCatalogReportsVisibilityAndDefault(t *testing.T) {
 	}()
 	registry.SetCatalogVisibility("test.runtime-parity", "1.0.0", CatalogVisibilityPrivate)
 }
+
+// The 2 MiB cap has to fail the *build*, not the response. A projection that
+// only blew up on the way out would reach a client as a truncated body — and
+// because the projection is built once at registration or compile time, the
+// failure belongs there, where an operator publishing the artifact sees it.
+func TestSafeExportRefusesToBuildAnOversizedProjection(t *testing.T) {
+	artifact := compileBundleForExport(t, validJSONArtifactBundle())
+	meta := artifact.Meta
+
+	// One sample past the cap. Samples are the only unbounded input a manifest
+	// controls, which is why the allowlist is opt-in in the first place.
+	oversized := json.RawMessage(`{"blob":"` + strings.Repeat("a", maxSafeExportBytes+1024) + `"}`)
+	_, err := buildSafeExport(meta, JSONTemplateEngineV1, CatalogVisibilityPrivate, "docs",
+		json.RawMessage(`{"type":"object"}`), nil,
+		map[string]json.RawMessage{"huge": oversized}, []string{"huge"})
+	if err == nil {
+		t.Fatal("an oversized projection was built")
+	}
+	if !strings.Contains(err.Error(), "export") {
+		t.Fatalf("err = %v, want the failure to name the export projection", err)
+	}
+
+	// Just under the cap still builds, so the guard is a bound rather than a
+	// blanket refusal of samples.
+	modest := json.RawMessage(`{"blob":"` + strings.Repeat("a", 1024) + `"}`)
+	export, err := buildSafeExport(meta, JSONTemplateEngineV1, CatalogVisibilityPrivate, "docs",
+		json.RawMessage(`{"type":"object"}`), nil,
+		map[string]json.RawMessage{"modest": modest}, []string{"modest"})
+	if err != nil {
+		t.Fatalf("a projection under the cap was refused: %v", err)
+	}
+	if _, ok := export.Samples["modest"]; !ok {
+		t.Fatalf("the allowlisted sample is missing: %+v", export.Samples)
+	}
+}

--- a/pkg/cardtmpl/export_test.go
+++ b/pkg/cardtmpl/export_test.go
@@ -1,0 +1,208 @@
+package cardtmpl
+
+// PR-C D5 evidence for the safe export projection.
+//
+// Two properties matter more than the field-by-field shape. First, what is
+// *absent*: view templates, goldens and the canonical bundle must never appear,
+// because those are the documents a caller could use to clone or probe a card
+// rather than build against it. Second, that samples are opt-in per artifact —
+// a fixture is caller-authored data and the default has to be "do not ship it".
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func compileBundleForExport(t *testing.T, bundle Bundle) *CompiledArtifact {
+	t.Helper()
+	artifact, err := CompileJSONArtifact(context.Background(), bundle, DefaultCompileLimits())
+	if err != nil {
+		t.Fatalf("CompileJSONArtifact: %v", err)
+	}
+	return artifact
+}
+
+func TestSafeExportOmitsTemplatesGoldensAndBundle(t *testing.T) {
+	artifact := compileBundleForExport(t, validJSONArtifactBundle())
+	export := artifact.Meta.Export()
+	if export == nil {
+		t.Fatal("compiled artifact has no export projection")
+	}
+	encoded, err := json.Marshal(export)
+	if err != nil {
+		t.Fatalf("marshal export: %v", err)
+	}
+	// The golden body text and the template's substitution syntax are the two
+	// strings that would prove a leak of either document.
+	for _, forbidden := range []string{"${title}", "AdaptiveCard", "canonical"} {
+		if bytes.Contains(encoded, []byte(forbidden)) {
+			t.Fatalf("export leaked %q: %s", forbidden, encoded)
+		}
+	}
+	if export.ID != "test.runtime-card" || export.Version != "1.0.0" ||
+		export.Owner != "ai" || export.Engine != JSONTemplateEngineV1 {
+		t.Fatalf("export identity = %+v", export)
+	}
+	if len(export.Views) != 1 || export.Views[0].Name != "main" ||
+		len(export.Views[0].States) != 1 || export.Views[0].States[0] != "shown" {
+		t.Fatalf("export views = %+v", export.Views)
+	}
+	if len(export.Manifest) == 0 || len(export.Schema) == 0 {
+		t.Fatal("export dropped the reviewed manifest/schema bytes")
+	}
+}
+
+func TestSafeExportShipsNoSamplesUnlessTheManifestOptsIn(t *testing.T) {
+	artifact := compileBundleForExport(t, validJSONArtifactBundle())
+	export := artifact.Meta.Export()
+	if len(export.Samples) != 0 {
+		t.Fatalf("samples exported without an allowlist: %+v", export.Samples)
+	}
+	// An empty map rather than null: a caller should not have to distinguish
+	// "no exportable samples" from "field missing".
+	encoded, _ := json.Marshal(export)
+	if !bytes.Contains(encoded, []byte(`"samples":{}`)) {
+		t.Fatalf("samples should serialize as an empty object: %s", encoded)
+	}
+
+	opted := validJSONArtifactBundle()
+	opted.Manifest = json.RawMessage(strings.Replace(string(opted.Manifest),
+		`"owner":"ai",`, `"owner":"ai","export":{"samples":["shown"]},`, 1))
+	export = compileBundleForExport(t, opted).Meta.Export()
+	if len(export.Samples) != 1 {
+		t.Fatalf("allowlisted sample missing: %+v", export.Samples)
+	}
+	if !bytes.Contains(export.Samples["shown"], []byte("hello")) {
+		t.Fatalf("allowlisted sample content = %s", export.Samples["shown"])
+	}
+}
+
+// An allowlist naming a sample that does not exist is a manifest bug. Failing
+// the compile surfaces it at publish review; serving an empty samples map
+// instead would hide it until someone noticed the docs were thin.
+func TestSafeExportRejectsAnAllowlistNamingAMissingSample(t *testing.T) {
+	bundle := validJSONArtifactBundle()
+	bundle.Manifest = json.RawMessage(strings.Replace(string(bundle.Manifest),
+		`"owner":"ai",`, `"owner":"ai","export":{"samples":["does-not-exist"]},`, 1))
+	if _, err := CompileJSONArtifact(context.Background(), bundle, DefaultCompileLimits()); err == nil {
+		t.Fatal("compile accepted an allowlist naming a missing sample")
+	}
+}
+
+func TestSafeExportRejectsUnknownExportKeys(t *testing.T) {
+	bundle := validJSONArtifactBundle()
+	bundle.Manifest = json.RawMessage(strings.Replace(string(bundle.Manifest),
+		`"owner":"ai",`, `"owner":"ai","export":{"samples":["shown"],"goldens":["shown"]},`, 1))
+	if _, err := CompileJSONArtifact(context.Background(), bundle, DefaultCompileLimits()); err == nil {
+		t.Fatal("compile accepted an unknown export key")
+	}
+}
+
+// Visibility fails closed. An artifact that declared nothing, or declared
+// something unrecognised, is private — the alternative turns every future
+// omission into a disclosure.
+func TestSafeExportVisibilityFailsClosed(t *testing.T) {
+	for _, declared := range []string{"", "internal", "PUBLIC"} {
+		if got := normalizeExportVisibility(declared); got != CatalogVisibilityPrivate {
+			t.Fatalf("visibility %q normalized to %q, want private", declared, got)
+		}
+	}
+	if got := normalizeExportVisibility(CatalogVisibilityPublic); got != CatalogVisibilityPublic {
+		t.Fatalf("public visibility normalized to %q", got)
+	}
+}
+
+// The hash is the static ETag, so it must be stable across builds of the same
+// artifact and must move when anything a caller can observe changes.
+func TestSafeExportHashIsDeterministicAndCoversVisibility(t *testing.T) {
+	first := compileBundleForExport(t, validJSONArtifactBundle()).Meta.Export()
+	second := compileBundleForExport(t, validJSONArtifactBundle()).Meta.Export()
+	if first.Hash == "" || first.Hash != second.Hash {
+		t.Fatalf("export hash is not deterministic: %q vs %q", first.Hash, second.Hash)
+	}
+
+	public := validJSONArtifactBundle()
+	public.Catalog.Visibility = CatalogVisibilityPublic
+	changed := compileBundleForExport(t, public).Meta.Export()
+	if changed.Hash == first.Hash {
+		t.Fatal("export hash ignored a visibility change")
+	}
+}
+
+// Clone must be deep: the projection is shared by every request for that
+// template, so a handler that mutated a returned map would corrupt all of them.
+func TestSafeExportCloneIsDeep(t *testing.T) {
+	bundle := validJSONArtifactBundle()
+	bundle.Manifest = json.RawMessage(strings.Replace(string(bundle.Manifest),
+		`"owner":"ai",`, `"owner":"ai","export":{"samples":["shown"]},`, 1))
+	meta := compileBundleForExport(t, bundle).Meta
+
+	first := meta.Export()
+	first.Samples["shown"] = json.RawMessage(`{"tampered":true}`)
+	first.Views[0].States[0] = "tampered"
+
+	second := meta.Export()
+	if bytes.Contains(second.Samples["shown"], []byte("tampered")) {
+		t.Fatalf("sample mutation escaped the clone: %s", second.Samples["shown"])
+	}
+	if second.Views[0].States[0] != "shown" {
+		t.Fatalf("view mutation escaped the clone: %+v", second.Views[0])
+	}
+}
+
+// A frozen static card cannot declare an export allowlist, so its exported
+// sample set is permanently empty — and it is still private by default.
+func TestStaticRegistryExportIsPrivateWithNoSamples(t *testing.T) {
+	registry := runtimeStaticRegistry(t)
+	template, err := registry.Lookup("test.runtime-parity", "1.0.0")
+	if err != nil {
+		t.Fatalf("Lookup: %v", err)
+	}
+	export := template.Meta().Export()
+	if export == nil {
+		t.Fatal("static template has no export projection")
+	}
+	if export.Visibility != CatalogVisibilityPrivate {
+		t.Fatalf("static visibility = %q, want private", export.Visibility)
+	}
+	if len(export.Samples) != 0 {
+		t.Fatalf("static export carried samples: %+v", export.Samples)
+	}
+}
+
+func TestRegistryStaticCatalogReportsVisibilityAndDefault(t *testing.T) {
+	registry := NewRegistry()
+	registry.RegisterJSON(jsonCardTestData, "testdata/test.runtime-parity@1.0.0")
+	registry.SetDefault("test.runtime-parity", "1.0.0")
+
+	entries := registry.StaticCatalog()
+	if len(entries) != 1 {
+		t.Fatalf("static catalog = %+v", entries)
+	}
+	if entries[0].Visibility != CatalogVisibilityPrivate || !entries[0].IsDefault {
+		t.Fatalf("entry = %+v, want private default", entries[0])
+	}
+	if entries[0].ExportHash == "" {
+		t.Fatal("entry has no export hash to use as an ETag")
+	}
+
+	registry.SetCatalogVisibility("test.runtime-parity", "1.0.0", CatalogVisibilityPublic)
+	entries = registry.StaticCatalog()
+	if entries[0].Visibility != CatalogVisibilityPublic {
+		t.Fatalf("visibility after publish = %q", entries[0].Visibility)
+	}
+	if entries[0].ExportHash == "" {
+		t.Fatal("publishing dropped the export hash")
+	}
+
+	registry.Freeze()
+	defer func() {
+		if recover() == nil {
+			t.Fatal("SetCatalogVisibility succeeded after Freeze")
+		}
+	}()
+	registry.SetCatalogVisibility("test.runtime-parity", "1.0.0", CatalogVisibilityPrivate)
+}

--- a/pkg/cardtmpl/json_artifact.go
+++ b/pkg/cardtmpl/json_artifact.go
@@ -488,6 +488,15 @@ func CompileJSONArtifact(ctx context.Context, bundle Bundle, limits CompileLimit
 	if err != nil {
 		return nil, artifactValidationError("manifest", "manifest", err)
 	}
+	// PR-C D5: build the projection before the conformance self-check, so an
+	// artifact whose export allowlist names a sample that does not exist fails
+	// to compile rather than publishing and then serving an empty samples map.
+	export, err := buildSafeExport(meta, bundle.Catalog.Engine, bundle.Catalog.Visibility, mf.Owner,
+		bundle.Schema, bundle.Reports, bundle.Samples, exportSampleAllowlist(mf))
+	if err != nil {
+		return nil, artifactValidationError("export", "manifest", err)
+	}
+	meta.export = export
 	template := &jsonTemplate{
 		meta:                 meta,
 		viewAST:              parsedTemplates,
@@ -614,8 +623,18 @@ func decodeManifest(parsed any) (manifestFile, error) {
 		"schemaVersion", "id", "name", "version", "contractVersion", "protocol",
 		"adaptiveCardVersion", "renderProfile", "renderProfileCompatibility", "defaultLocale",
 		"owner", "actionType", "dataSchema", "views", "sourceLabel", "sourceIconUrl",
+		"export",
 	); err != nil {
 		return manifestFile{}, err
+	}
+	if raw, declared := root["export"]; declared {
+		exportMap, ok := raw.(map[string]any)
+		if !ok {
+			return manifestFile{}, errors.New("export must be an object")
+		}
+		if err := rejectUnknownKeys(exportMap, "samples"); err != nil {
+			return manifestFile{}, fmt.Errorf("export: %w", err)
+		}
 	}
 	views, ok := root["views"].(map[string]any)
 	if !ok {
@@ -1785,4 +1804,18 @@ func (i *utf16Iterator) next() (uint16, bool) {
 	i.pending = uint16(0xdc00 + (r & 0x3ff))
 	i.hasPending = true
 	return uint16(0xd800 + (r >> 10)), true
+}
+
+// exportSampleAllowlist returns the manifest's declared exportable samples in a
+// deterministic order. An absent declaration yields nothing: samples are
+// caller-authored input fixtures and can carry real tenant data, so exporting
+// them is opt-in per artifact rather than a default anyone can forget to turn
+// off (PR-C D5).
+func exportSampleAllowlist(mf manifestFile) []string {
+	if mf.Export == nil || len(mf.Export.Samples) == 0 {
+		return nil
+	}
+	allowlist := append([]string(nil), mf.Export.Samples...)
+	sort.Strings(allowlist)
+	return allowlist
 }

--- a/pkg/cardtmpl/provenance.go
+++ b/pkg/cardtmpl/provenance.go
@@ -1,0 +1,35 @@
+package cardtmpl
+
+// PR-C D3（spec: .octospec/tasks/cardtmpl-runtime-catalog-grants-discovery/
+// brief.md）：stored server-authored provenance 与 catalog principal 的唯一
+// 桥接。wire 形状与 strict parse 在 pkg/cardmsg/provenance.go（信封权威层，
+// carddispatch 也要写标记而 cardtmpl 依赖 carddispatch，值对象放这里会成环）；
+// 本文件只做 typed principal 映射 —— historical_edit / action_context 的
+// principal 输入从此来自 stored marker，而不是 sender/owner 猜测。
+
+import (
+	"fmt"
+
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardmsg"
+)
+
+// CatalogPrincipalFromProvenance 把一个已存储的 wire marker 映射为 catalog
+// principal。marker 先过 strict Validate；wire principal 只有 bot 与
+// internal_producer 两种（space 是 discover-only grant principal、system 是
+// 内部保留值，都不可能出现在存储帧里），未知类型 fail-close。
+func CatalogPrincipalFromProvenance(provenance cardmsg.CatalogProvenance) (CatalogPrincipal, error) {
+	if err := provenance.Validate(); err != nil {
+		return CatalogPrincipal{}, err
+	}
+	var kind CatalogPrincipalKind
+	switch provenance.PrincipalType {
+	case cardmsg.CatalogPrincipalWireBot:
+		kind = CatalogPrincipalBot
+	case cardmsg.CatalogPrincipalWireInternalProducer:
+		kind = CatalogPrincipalInternalProducer
+	default:
+		return CatalogPrincipal{}, fmt.Errorf("%w: principal_type %q is not a catalog principal",
+			cardmsg.ErrCatalogMarkerInvalid, provenance.PrincipalType)
+	}
+	return CatalogPrincipal{Kind: kind, ID: provenance.PrincipalID, SpaceID: provenance.SpaceID}, nil
+}

--- a/pkg/cardtmpl/provenance_test.go
+++ b/pkg/cardtmpl/provenance_test.go
@@ -1,0 +1,80 @@
+package cardtmpl_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardmsg"
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl"
+)
+
+// Slice 1 RED (PR-C D3): the wire marker maps onto exactly one typed catalog
+// principal. Unknown or non-sendable wire principals must not become catalog
+// principals — the mapping is the only bridge between stored frames and
+// authorization input.
+func TestCatalogPrincipalFromProvenance(t *testing.T) {
+	cases := []struct {
+		name       string
+		provenance cardmsg.CatalogProvenance
+		want       cardtmpl.CatalogPrincipal
+		wantErr    bool
+	}{
+		{
+			name: "bot",
+			provenance: cardmsg.CatalogProvenance{
+				Version:       cardmsg.CatalogProvenanceVersion,
+				PrincipalType: cardmsg.CatalogPrincipalWireBot,
+				PrincipalID:   "bot-1", SpaceID: "space-1",
+			},
+			want: cardtmpl.CatalogPrincipal{
+				Kind: cardtmpl.CatalogPrincipalBot, ID: "bot-1", SpaceID: "space-1",
+			},
+		},
+		{
+			name: "internal producer with empty space",
+			provenance: cardmsg.CatalogProvenance{
+				Version:       cardmsg.CatalogProvenanceVersion,
+				PrincipalType: cardmsg.CatalogPrincipalWireInternalProducer,
+				PrincipalID:   "docs-notify",
+			},
+			want: cardtmpl.CatalogPrincipal{
+				Kind: cardtmpl.CatalogPrincipalInternalProducer, ID: "docs-notify",
+			},
+		},
+		{
+			name: "invalid marker never maps",
+			provenance: cardmsg.CatalogProvenance{
+				Version: 99, PrincipalType: cardmsg.CatalogPrincipalWireBot, PrincipalID: "bot-1",
+			},
+			wantErr: true,
+		},
+		{
+			name: "system is not a stored-frame principal",
+			provenance: cardmsg.CatalogProvenance{
+				Version:       cardmsg.CatalogProvenanceVersion,
+				PrincipalType: "system", PrincipalID: "readiness",
+			},
+			wantErr: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := cardtmpl.CatalogPrincipalFromProvenance(tc.provenance)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("mapped invalid provenance to %+v", got)
+				}
+				if !errors.Is(err, cardmsg.ErrCatalogMarkerInvalid) {
+					t.Fatalf("error = %v, want ErrCatalogMarkerInvalid", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("CatalogPrincipalFromProvenance: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("principal = %+v, want %+v", got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/cardtmpl/registry.go
+++ b/pkg/cardtmpl/registry.go
@@ -62,6 +62,10 @@ type manifestFile struct {
 	// SourceLabel / SourceIconURL 可选,若手动指定则覆盖 Template 默认 Source。
 	SourceLabel   string `json:"sourceLabel,omitempty"`
 	SourceIconURL string `json:"sourceIconUrl,omitempty"`
+	// Export is the PR-C D5 opt-in allowlist for B2. Absent means "export no
+	// samples", which is the safe default and the permanent answer for frozen
+	// static cards.
+	Export *exportSamples `json:"export,omitempty"`
 }
 
 // manifestView is one entry of manifest.views. Template/Samples are only present
@@ -179,6 +183,16 @@ func (r *Registry) Register(t Template, assets embed.FS, root string) {
 	if err != nil {
 		panic(fmt.Errorf("cardtmpl: register %s: %w", root, err))
 	}
+	// PR-C D5: the B2 projection is built here, from the same reviewed bytes
+	// the template itself was built from, and never at request time. A static
+	// L1 card cannot declare an export sample allowlist — its manifest is
+	// frozen — so its exported sample set is permanently empty.
+	export, err := buildSafeExport(meta, "", CatalogVisibilityPrivate, mf.Owner,
+		rawSchemaBytes(assets, root), rawInteractionReports(assets, root, mf.Views), nil, nil)
+	if err != nil {
+		panic(fmt.Errorf("cardtmpl: register export projection %s: %w", root, err))
+	}
+	meta.export = export
 
 	// 注入 Meta 到 Template
 	setter, ok := t.(metaSetter)
@@ -285,6 +299,7 @@ func assembleTemplateMeta(
 		Source:                     Source{Label: mf.SourceLabel, IconURL: mf.SourceIconURL},
 		stateIndex:                 stateIndex,
 		interactions:               interactions,
+		contractVersion:            mf.ContractVersion,
 	}, nil
 }
 
@@ -647,4 +662,150 @@ func walkSubmitActions(value any, path string, visit func(string, map[string]any
 		}
 	}
 	return nil
+}
+
+// rawSchemaBytes returns the reviewed data-schema document verbatim. B2 ships
+// this copy rather than re-serializing the compiled schema, because a
+// round-trip through the compiler loses annotations, examples and key order
+// that a producer reads the schema for.
+func rawSchemaBytes(assets embed.FS, root string) json.RawMessage {
+	raw, err := assets.ReadFile(path.Join(root, "contract", "data.schema.json"))
+	if err != nil {
+		return nil
+	}
+	return append(json.RawMessage(nil), raw...)
+}
+
+// rawInteractionReports returns the v2 views' interaction reports verbatim.
+// loadInteractionReports already proved each one exists and parses, so a read
+// failure here can only mean the embedded FS changed underneath us.
+func rawInteractionReports(assets embed.FS, root string, views map[ViewKey]manifestView) map[string]json.RawMessage {
+	out := make(map[string]json.RawMessage, len(views))
+	for view, spec := range views {
+		if spec.WireProfile != profileV2 {
+			continue
+		}
+		raw, err := assets.ReadFile(path.Join(root, "reports", string(view)+".interaction.json"))
+		if err != nil {
+			continue
+		}
+		out[string(view)] = append(json.RawMessage(nil), raw...)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// SetCatalogVisibility marks a registered static template as discoverable by
+// callers outside its owning Space. It must run before Freeze.
+//
+// PR-C D5 puts this at the composition root rather than in the template's own
+// manifest for two reasons: an L1 manifest is frozen at publish and cannot grow
+// a field, and "who may see this card" is a deployment decision that deserves
+// to be reviewable in one place rather than spread across template packages.
+// Every static template is private until named here, so a card becomes visible
+// only by an explicit, reviewed edit — never by an omission.
+func (r *Registry) SetCatalogVisibility(id ID, version, visibility string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.frozen {
+		panic(fmt.Errorf("%w: cannot SetCatalogVisibility after Freeze", ErrRegistryFrozen))
+	}
+	if visibility != CatalogVisibilityPublic && visibility != CatalogVisibilityPrivate {
+		panic(fmt.Errorf("cardtmpl: unsupported catalog visibility %q for %s@%s", visibility, id, version))
+	}
+	e, ok := r.entries[registryKey{id: id, version: version}]
+	if !ok {
+		panic(fmt.Errorf("cardtmpl: SetCatalogVisibility for unregistered %s@%s", id, version))
+	}
+	if e.meta.export == nil {
+		panic(fmt.Errorf("cardtmpl: %s@%s has no export projection to publish", id, version))
+	}
+	updated := e.meta.export.Clone()
+	updated.Visibility = visibility
+	hash, _, err := hashSafeExport(updated)
+	if err != nil {
+		panic(fmt.Errorf("cardtmpl: rehash export projection %s@%s: %w", id, version, err))
+	}
+	updated.Hash = hash
+	e.meta.export = updated
+}
+
+// ExportFor returns the B2 projection for one frozen template, or nil when the
+// template is unknown.
+//
+// It reads the registry entry rather than Template.Meta() on purpose: a
+// Template holds the copy of its metadata that was injected at registration,
+// and SetCatalogVisibility deliberately does not push a new copy into it (not
+// every Template implementation accepts one). The registry entry is the single
+// place where the current projection lives.
+func (r *Registry) ExportFor(id ID, version string) *SafeExport {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	if version == "" {
+		v, ok := r.defaults[id]
+		if !ok {
+			return nil
+		}
+		version = v
+	}
+	e, ok := r.entries[registryKey{id: id, version: version}]
+	if !ok {
+		return nil
+	}
+	return e.meta.export.Clone()
+}
+
+// StaticCatalogEntry is one frozen template as the discovery layer sees it.
+type StaticCatalogEntry struct {
+	ID              ID
+	Version         string
+	Owner           string
+	Protocol        string
+	ContractVersion string
+	Visibility      string
+	ActionContract  *TemplateActionContract
+	ExportHash      string
+	// IsDefault reports whether this exact version is the ID's registered
+	// default, which is what a static new send would resolve to.
+	IsDefault bool
+}
+
+// StaticCatalog lists the frozen templates for B1. It returns metadata only:
+// the projection itself is fetched per template by B2, so a list response never
+// carries manifest or schema bytes.
+func (r *Registry) StaticCatalog() []StaticCatalogEntry {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make([]StaticCatalogEntry, 0, len(r.entries))
+	for key, e := range r.entries {
+		entry := StaticCatalogEntry{
+			ID: key.id, Version: key.version,
+			Protocol:        e.meta.Protocol,
+			ContractVersion: e.meta.contractVersion,
+			Visibility:      CatalogVisibilityPrivate,
+			IsDefault:       r.defaults[key.id] == key.version,
+		}
+		if e.meta.ActionContract != nil {
+			contract := *e.meta.ActionContract
+			entry.ActionContract = &contract
+			entry.Owner = contract.Owner
+		}
+		if e.meta.export != nil {
+			entry.Visibility = e.meta.export.Visibility
+			entry.ExportHash = e.meta.export.Hash
+			if entry.Owner == "" {
+				entry.Owner = e.meta.export.Owner
+			}
+		}
+		out = append(out, entry)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].ID != out[j].ID {
+			return out[i].ID < out[j].ID
+		}
+		return out[i].Version < out[j].Version
+	})
+	return out
 }

--- a/pkg/cardtmpl/runtime_authorization.go
+++ b/pkg/cardtmpl/runtime_authorization.go
@@ -116,6 +116,22 @@ type RuntimeAuthorizationStore interface {
 	LoadAuthorization(context.Context, RuntimeAuthorizationQuery) (RuntimeAuthorization, error)
 }
 
+// RuntimeAuthorizationBatchStore is the optional batched form of
+// LoadAuthorization, for callers that must ask the same question about a whole
+// policy list at once — the Bot capability manifest, chiefly. Answering those
+// one transaction at a time turns a feature-detection poll into N round trips,
+// and a deployment with a large Bot population multiplies that into standing
+// primary-DB load.
+//
+// It is a separate interface rather than a third method on the required one so
+// that an implementation without it keeps working through the per-ID path. An
+// implementation that does provide it MUST return, for every requested ID,
+// exactly what LoadAuthorization would have returned for that ID with an empty
+// Version — the batch buys round trips, never a relaxed check.
+type RuntimeAuthorizationBatchStore interface {
+	LoadAuthorizations(context.Context, []ID, CatalogPrincipal) (map[ID]RuntimeAuthorization, error)
+}
+
 // RuntimeAdvertisedTemplate is one template a principal holds a grant on,
 // paired with the activation snapshot that decides whether it is advertisable
 // right now.

--- a/pkg/cardtmpl/runtime_authorization.go
+++ b/pkg/cardtmpl/runtime_authorization.go
@@ -65,6 +65,8 @@ func (g RuntimeGrant) Allows(purpose CatalogPurpose) bool {
 	switch purpose {
 	case CatalogPurposeNewSend:
 		return g.Send
+	case CatalogPurposeDiscover:
+		return g.Discover
 	case CatalogPurposeHistoricalEdit, CatalogPurposeActionContext:
 		// action_context is gated on edit rather than on discover: an action
 		// callback is the precondition of the edit that answers it, so a

--- a/pkg/cardtmpl/runtime_authorization.go
+++ b/pkg/cardtmpl/runtime_authorization.go
@@ -128,6 +128,16 @@ type RuntimeAuthorizationStore interface {
 // implementation that does provide it MUST return, for every requested ID,
 // exactly what LoadAuthorization would have returned for that ID with an empty
 // Version — the batch buys round trips, never a relaxed check.
+//
+// One difference is forced by batching and is part of the contract: a template
+// whose activation pointer is *disabled* is reported as an entry whose
+// Activation.Status is RuntimeActivationDisabled, not as an error. The per-ID
+// form has only one channel and returns ErrRuntimeCatalogDisabled there, but a
+// batch that failed over one disabled template would send its caller back to
+// asking one ID at a time — reinstating exactly the round trips this interface
+// exists to remove, for as long as an operator leaves that template disabled.
+// Callers must therefore treat a disabled status as "not usable" themselves;
+// it is not a version they may fall back from.
 type RuntimeAuthorizationBatchStore interface {
 	LoadAuthorizations(context.Context, []ID, CatalogPrincipal) (map[ID]RuntimeAuthorization, error)
 }

--- a/pkg/cardtmpl/runtime_authorization.go
+++ b/pkg/cardtmpl/runtime_authorization.go
@@ -1,0 +1,190 @@
+package cardtmpl
+
+// PR-C D4 — the narrow authorization resolver contract.
+//
+// Before PR-C the runtime read the activation pointer, then the artifact/block
+// row, then (had there been one) a grant row, each in its own statement. Three
+// independent reads can interleave with an activate/block/revoke commit and
+// produce a decision assembled from three different points in time — a card
+// authorized against an activation that no longer exists, or against a grant
+// that was revoked between the two reads.
+//
+// This file defines the replacement: a single store call that returns every
+// input of one authorization decision, read in one primary-DB snapshot. The
+// catalog cannot pull the call apart, so there is no way to reintroduce the
+// torn read by accident.
+//
+// The returned value is a *receipt*, not a bearer capability. It describes the
+// snapshot that produced it and is valid only for the request that asked for
+// it: it is never cached, never handed to another request, and never used to
+// skip a later re-resolve. Bot profile and Bot send are two separate decisions
+// precisely because of this — send re-resolves rather than trusting the
+// profile's receipt.
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+)
+
+// RuntimeGrantScope names which stored row won the exact-over-global
+// precedence rule. It exists for logs, metrics and same-request assertions.
+type RuntimeGrantScope string
+
+const (
+	// RuntimeGrantScopeExact is a row scoped to the requesting principal's own
+	// Space. It is authoritative: an exact row overrides the global row
+	// entirely, including an exact tombstone shadowing an active global grant.
+	RuntimeGrantScopeExact RuntimeGrantScope = "exact"
+	// RuntimeGrantScopeGlobal is the Space-independent fallback row, consulted
+	// only when the principal has no row scoped to this Space.
+	RuntimeGrantScopeGlobal RuntimeGrantScope = "global"
+)
+
+// RuntimeGrant is the effective permission set for one principal against one
+// template ID, already reduced by the store's precedence rule. Permissions are
+// never a union across scopes (invariant 11), so this carries the winning
+// row's permissions verbatim — a revoked winner yields all-false, which is a
+// denial and not an invitation to look at the loser.
+type RuntimeGrant struct {
+	// Found reports that some row existed for this principal, active or
+	// revoked. A false Found and a revoked-tombstone Found are both denials;
+	// they differ only in what gets logged.
+	Found    bool
+	Scope    RuntimeGrantScope
+	Revision uint64
+
+	Discover bool
+	Send     bool
+	Edit     bool
+}
+
+// Allows reports whether this grant carries the permission the purpose needs.
+func (g RuntimeGrant) Allows(purpose CatalogPurpose) bool {
+	switch purpose {
+	case CatalogPurposeNewSend:
+		return g.Send
+	case CatalogPurposeHistoricalEdit, CatalogPurposeActionContext:
+		// action_context is gated on edit rather than on discover: an action
+		// callback is the precondition of the edit that answers it, so a
+		// producer whose edit grant was revoked must stop being able to drive
+		// the card at all, not merely stop being able to write the result.
+		return g.Edit
+	default:
+		return false
+	}
+}
+
+// RuntimeAuthorizationQuery is the input of one snapshot.
+type RuntimeAuthorizationQuery struct {
+	ID ID
+	// Version pins the stored exact version for historical_edit and
+	// action_context, which must never follow the activation pointer. Empty
+	// asks the store to resolve the pointer inside the same snapshot, which is
+	// the only correct way to serve a new send's default version.
+	Version string
+	// Principal is the authenticated or stored server-authored identity. A
+	// principal the grant model cannot express (system, or a blank ID) yields
+	// an empty RuntimeGrant rather than an error: it is simply ungranted.
+	Principal CatalogPrincipal
+}
+
+// RuntimeAuthorization is the bounded receipt of one primary-DB snapshot.
+type RuntimeAuthorization struct {
+	// Activation is the pointer as it existed in the snapshot. It is zero when
+	// the query pinned an explicit version, because a pinned read must not
+	// consult the pointer at all.
+	Activation RuntimeActivation
+	// Version is the effective version the snapshot resolved to. Empty means
+	// the template has no activation row and the caller falls back to whatever
+	// the frozen static Registry provides.
+	Version string
+	// Artifact is the claim/artifact/block row for Version, loaded in the same
+	// snapshot. It is zero when Version is empty.
+	Artifact RuntimeArtifactMeta
+	// Grant is the reduced permission set for Principal against ID.
+	Grant RuntimeGrant
+}
+
+// RuntimeAuthorizationStore is the indivisible resolver. Implementations MUST
+// answer the whole query from one consistent read; returning fields gathered
+// from separate statements defeats the entire point of this interface.
+type RuntimeAuthorizationStore interface {
+	LoadAuthorization(context.Context, RuntimeAuthorizationQuery) (RuntimeAuthorization, error)
+}
+
+// RuntimeAdvertisedTemplate is one template a principal holds a grant on,
+// paired with the activation snapshot that decides whether it is advertisable
+// right now.
+type RuntimeAdvertisedTemplate struct {
+	ID            ID
+	Authorization RuntimeAuthorization
+}
+
+// RuntimeAdvertiser enumerates a principal's granted templates. It exists for
+// capability manifests, which describe what a producer *could* ask for. It is
+// explicitly not an authorization decision: a manifest is assembled from
+// several snapshots and can be stale by the time the producer acts on it,
+// which is why every send re-resolves through RuntimeAuthorizationStore rather
+// than trusting what the manifest said.
+type RuntimeAdvertiser interface {
+	ListAuthorizedTemplates(context.Context, CatalogPrincipal, int) ([]RuntimeAdvertisedTemplate, error)
+}
+
+// RuntimeAuthorizationSource is the process-wide seam consumers bind to. It
+// carries the new-send gate alongside the readers so that a caller can honour
+// "gate off means do not touch the runtime DB at all" without having to import
+// the module that owns the environment variables.
+type RuntimeAuthorizationSource interface {
+	RuntimeAuthorizationStore
+	RuntimeAdvertiser
+	// NewSendEnabled reports the deployment's dynamic new-send gate. When it is
+	// false the dynamic catalog is dark: callers keep their existing static
+	// behaviour and must not acquire a runtime DB dependency for it.
+	NewSendEnabled() bool
+}
+
+var (
+	defaultAuthorizationMu     sync.RWMutex
+	defaultAuthorizationSource RuntimeAuthorizationSource
+)
+
+// SetDefaultAuthorizationSource installs the process resolver. Production
+// installs it once in the composition root; passing nil (as tests do) leaves
+// consumers with no dynamic overlay, which is the pre-PR-C behaviour.
+func SetDefaultAuthorizationSource(source RuntimeAuthorizationSource) {
+	defaultAuthorizationMu.Lock()
+	defer defaultAuthorizationMu.Unlock()
+	defaultAuthorizationSource = source
+}
+
+// DefaultAuthorizationSource returns the installed resolver, or nil when none
+// is installed. A nil return means "no dynamic catalog", never "allow".
+func DefaultAuthorizationSource() RuntimeAuthorizationSource {
+	defaultAuthorizationMu.RLock()
+	defer defaultAuthorizationMu.RUnlock()
+	return defaultAuthorizationSource
+}
+
+// ActivationVersion maps an activation row to the version new sends resolve
+// to. Both the catalog and the store call this — the store to decide which
+// artifact row to read inside the snapshot, the catalog to re-derive the same
+// answer and reject a store that disagreed. Two callers, one implementation,
+// so the rule cannot drift into two subtly different truths.
+func ActivationVersion(id ID, activation RuntimeActivation) (string, error) {
+	if !activation.Exists {
+		return "", nil
+	}
+	switch activation.Status {
+	case RuntimeActivationDisabled:
+		return "", fmt.Errorf("%w: %s revision %d", ErrRuntimeCatalogDisabled, id, activation.Revision)
+	case RuntimeActivationActive:
+		if strings.TrimSpace(activation.Version) == "" {
+			return "", fmt.Errorf("%w: active row has no version", ErrRuntimeCatalogIntegrity)
+		}
+		return activation.Version, nil
+	default:
+		return "", fmt.Errorf("%w: unknown activation status %q", ErrRuntimeCatalogIntegrity, activation.Status)
+	}
+}

--- a/pkg/cardtmpl/runtime_authorization_test.go
+++ b/pkg/cardtmpl/runtime_authorization_test.go
@@ -319,3 +319,65 @@ func TestActivationVersionIsTheSingleActivationRule(t *testing.T) {
 		})
 	}
 }
+
+// The compiled-artifact cache must not be able to outlive a revoke. It is keyed
+// on the immutable content hash and holds no grant state, so a hot entry cannot
+// carry a stale permission — but that is an argument, and the acceptance matrix
+// asks for evidence. The sibling test covers a hot cache against a *block*;
+// this one covers it against a revoke, which is the case an operator reaches
+// for when a producer has to be cut off right now.
+func TestRuntimeCatalogHotCacheCannotOutliveARevoke(t *testing.T) {
+	artifact := compileRuntimeFixture(t)
+	store := newAuthorizationStoreStub(artifact, grantedSend())
+	// The permission rule the production authorizer applies. Using the
+	// allow-everything stub here would make the test pass without ever
+	// consulting the grant, which is the very thing being checked.
+	enforceGrant := func(_ context.Context, access CatalogAccess, _ RuntimeArtifactMeta, grant RuntimeGrant) error {
+		if !grant.Allows(access.Purpose) {
+			return ErrRuntimeCatalogNotAuthorized
+		}
+		return nil
+	}
+	catalog := newRuntimeCatalogForTest(t, runtimeStaticRegistry(t), store, enforceGrant)
+	request := dynamicDefaultRequest()
+
+	if _, err := catalog.Render(context.Background(), request); err != nil {
+		t.Fatalf("warm the cache: %v", err)
+	}
+	warmBundleCalls := store.bundleCalls
+	warmSnapshots := store.snapshotCalls()
+	if warmSnapshots == 0 {
+		t.Fatal("the warm render took no snapshot at all")
+	}
+
+	// Revoke: the row becomes a tombstone, which is a *found* grant with no
+	// permissions — not an absent one.
+	store.authMu.Lock()
+	store.auth.Grant = RuntimeGrant{Found: true, Scope: RuntimeGrantScopeExact, Revision: 4}
+	store.authMu.Unlock()
+
+	if _, err := catalog.Render(context.Background(), request); !errors.Is(err, ErrRuntimeCatalogNotAuthorized) {
+		t.Fatalf("post-revoke hot render error = %v, want ErrRuntimeCatalogNotAuthorized", err)
+	}
+	// The denial came from a fresh snapshot, not from a cached decision.
+	if store.snapshotCalls() <= warmSnapshots {
+		t.Fatalf("the hot path answered without re-reading the grant (snapshots %d -> %d)",
+			warmSnapshots, store.snapshotCalls())
+	}
+	// And it did not need to reload the bundle to find out, which is what makes
+	// "the cache holds bytes, never permissions" observable rather than merely
+	// asserted.
+	if store.bundleCalls != warmBundleCalls {
+		t.Fatalf("bundle calls = %d, want the warm load only (%d)", store.bundleCalls, warmBundleCalls)
+	}
+
+	// An edit grant is a separate permission: revoking send must not leave edit
+	// standing, and restoring only edit must not re-enable send.
+	store.authMu.Lock()
+	store.auth.Grant = RuntimeGrant{Found: true, Scope: RuntimeGrantScopeExact, Revision: 5,
+		Discover: true, Edit: true}
+	store.authMu.Unlock()
+	if _, err := catalog.Render(context.Background(), request); !errors.Is(err, ErrRuntimeCatalogNotAuthorized) {
+		t.Fatalf("an edit-only grant authorized a new send: %v", err)
+	}
+}

--- a/pkg/cardtmpl/runtime_authorization_test.go
+++ b/pkg/cardtmpl/runtime_authorization_test.go
@@ -1,0 +1,321 @@
+package cardtmpl
+
+// PR-C D4 evidence: one authorization decision comes from one snapshot.
+//
+// The stub below counts snapshot calls and records the query it was asked, so
+// the tests can assert the property that actually matters — not "the answer was
+// right" but "the answer came from a single read". A future refactor that
+// reintroduces a read-pointer-then-check-grant split fails here even if every
+// individual answer stays correct.
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+)
+
+type authorizationStoreStub struct {
+	runtimeStoreStub
+
+	authMu    sync.Mutex
+	authCalls int
+	queries   []RuntimeAuthorizationQuery
+
+	auth    RuntimeAuthorization
+	authErr error
+	// mutate lets a test bend one reply into an incoherent shape.
+	mutate func(RuntimeAuthorizationQuery, RuntimeAuthorization) RuntimeAuthorization
+}
+
+func (s *authorizationStoreStub) LoadAuthorization(
+	_ context.Context,
+	query RuntimeAuthorizationQuery,
+) (RuntimeAuthorization, error) {
+	s.authMu.Lock()
+	defer s.authMu.Unlock()
+	s.authCalls++
+	s.queries = append(s.queries, query)
+	if s.authErr != nil {
+		return RuntimeAuthorization{}, s.authErr
+	}
+	reply := s.auth
+	if query.Version != "" {
+		// A pinned query must be answered without the pointer.
+		reply.Activation = RuntimeActivation{}
+		reply.Version = query.Version
+	}
+	if s.mutate != nil {
+		reply = s.mutate(query, reply)
+	}
+	return reply, nil
+}
+
+func (s *authorizationStoreStub) snapshotCalls() int {
+	s.authMu.Lock()
+	defer s.authMu.Unlock()
+	return s.authCalls
+}
+
+func (s *authorizationStoreStub) lastQuery(t *testing.T) RuntimeAuthorizationQuery {
+	t.Helper()
+	s.authMu.Lock()
+	defer s.authMu.Unlock()
+	if len(s.queries) == 0 {
+		t.Fatal("no authorization query was issued")
+	}
+	return s.queries[len(s.queries)-1]
+}
+
+func newAuthorizationStoreStub(artifact *CompiledArtifact, grant RuntimeGrant) *authorizationStoreStub {
+	meta := runtimeArtifactMeta(artifact)
+	stub := &authorizationStoreStub{
+		auth: RuntimeAuthorization{
+			Activation: RuntimeActivation{
+				Exists: true, Status: RuntimeActivationActive, Version: meta.Version, Revision: 7,
+			},
+			Version: meta.Version, Artifact: meta, Grant: grant,
+		},
+	}
+	stub.bundle = artifact.Bundle
+	return stub
+}
+
+func grantedSend() RuntimeGrant {
+	return RuntimeGrant{Found: true, Scope: RuntimeGrantScopeExact, Revision: 3, Discover: true, Send: true}
+}
+
+func TestRuntimeCatalogDynamicNewSendUsesExactlyOneSnapshot(t *testing.T) {
+	artifact := compileRuntimeFixture(t)
+	store := newAuthorizationStoreStub(artifact, grantedSend())
+	var seen RuntimeGrant
+	catalog := newRuntimeCatalogForTest(t, runtimeStaticRegistry(t), store,
+		func(_ context.Context, _ CatalogAccess, _ RuntimeArtifactMeta, grant RuntimeGrant) error {
+			seen = grant
+			return nil
+		})
+
+	if _, err := catalog.Render(context.Background(), dynamicDefaultRequest()); err != nil {
+		t.Fatalf("dynamic default render: %v", err)
+	}
+	if store.snapshotCalls() != 1 {
+		t.Fatalf("snapshot calls = %d, want 1", store.snapshotCalls())
+	}
+	// The legacy split readers must not have been consulted at all: if either
+	// still runs, the decision is again spread across several points in time.
+	if store.activationCalls != 0 || store.metaCalls != 0 {
+		t.Fatalf("split reads activation/meta = %d/%d, want 0/0", store.activationCalls, store.metaCalls)
+	}
+	if seen != grantedSend() {
+		t.Fatalf("authorizer grant = %+v, want %+v", seen, grantedSend())
+	}
+	if query := store.lastQuery(t); query.Version != "" || query.ID != "test.runtime-card" {
+		t.Fatalf("new-send query = %+v, want the activation pointer resolved for the template", query)
+	}
+}
+
+func TestRuntimeCatalogPinnedReadsNeverFollowActivationPointer(t *testing.T) {
+	artifact := compileRuntimeFixture(t)
+	artifact.Meta.interactions = map[ViewKey]InteractionReport{
+		"main": {Actions: []DeclaredAction{{Type: "Action.Submit", ID: "submit"}}},
+	}
+	store := newAuthorizationStoreStub(artifact, RuntimeGrant{
+		Found: true, Scope: RuntimeGrantScopeGlobal, Discover: true, Edit: true,
+	})
+	catalog := newRuntimeCatalogForTest(t, runtimeStaticRegistry(t), store, allowDynamicForTest)
+	catalog.compile = func(context.Context, Bundle, CompileLimits) (*CompiledArtifact, error) {
+		return artifact, nil
+	}
+
+	access := CatalogAccess{Purpose: CatalogPurposeActionContext, Principal: CatalogPrincipal{
+		Kind: CatalogPrincipalInternalProducer, ID: "docs-notify", SpaceID: "space-1",
+	}}
+	if _, err := catalog.ActionContext(context.Background(), CatalogActionRequest{
+		CatalogExactRequest: CatalogExactRequest{
+			Access: access, ID: artifact.Meta.ID, Version: artifact.Meta.Version,
+		},
+		ActionID: "submit",
+	}); err != nil {
+		t.Fatalf("dynamic action context: %v", err)
+	}
+	if query := store.lastQuery(t); query.Version != artifact.Meta.Version {
+		t.Fatalf("action query = %+v, want the stored exact version pinned", query)
+	}
+	if store.snapshotCalls() != 1 {
+		t.Fatalf("snapshot calls = %d, want 1", store.snapshotCalls())
+	}
+}
+
+// A store that answers a pinned query with pointer state, or that resolves a
+// different version than the activation row implies, has produced a snapshot
+// that cannot be reasoned about. The catalog rejects it instead of picking
+// whichever half looks more plausible.
+func TestRuntimeCatalogRejectsIncoherentAuthorizationSnapshot(t *testing.T) {
+	artifact := compileRuntimeFixture(t)
+	for _, test := range []struct {
+		name    string
+		pinned  bool
+		mutate  func(RuntimeAuthorizationQuery, RuntimeAuthorization) RuntimeAuthorization
+		wantErr error
+	}{
+		{
+			name:   "pinned reply leaks the activation pointer",
+			pinned: true,
+			mutate: func(_ RuntimeAuthorizationQuery, auth RuntimeAuthorization) RuntimeAuthorization {
+				auth.Activation = RuntimeActivation{Exists: true, Status: RuntimeActivationActive, Version: "9.9.9"}
+				return auth
+			},
+			wantErr: ErrRuntimeCatalogIntegrity,
+		},
+		{
+			name: "resolved version disagrees with the activation row",
+			mutate: func(_ RuntimeAuthorizationQuery, auth RuntimeAuthorization) RuntimeAuthorization {
+				auth.Version = "9.9.9"
+				return auth
+			},
+			wantErr: ErrRuntimeCatalogIntegrity,
+		},
+		{
+			name: "activation row carries an unknown status",
+			mutate: func(_ RuntimeAuthorizationQuery, auth RuntimeAuthorization) RuntimeAuthorization {
+				auth.Activation.Status = "half-active"
+				return auth
+			},
+			wantErr: ErrRuntimeCatalogIntegrity,
+		},
+		{
+			name: "disabled pointer never degrades to a static same-ID version",
+			mutate: func(_ RuntimeAuthorizationQuery, auth RuntimeAuthorization) RuntimeAuthorization {
+				auth.Activation = RuntimeActivation{Exists: true, Status: RuntimeActivationDisabled, Revision: 5}
+				auth.Version = ""
+				return auth
+			},
+			wantErr: ErrRuntimeCatalogDisabled,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			store := newAuthorizationStoreStub(artifact, grantedSend())
+			store.mutate = test.mutate
+			catalog := newRuntimeCatalogForTest(t, runtimeStaticRegistry(t), store, allowDynamicForTest)
+
+			var err error
+			if test.pinned {
+				_, err = catalog.MetaExact(context.Background(), CatalogExactRequest{
+					Access: dynamicDefaultRequest().Access, ID: artifact.Meta.ID, Version: artifact.Meta.Version,
+				})
+			} else {
+				_, err = catalog.Render(context.Background(), dynamicDefaultRequest())
+			}
+			if !errors.Is(err, test.wantErr) {
+				t.Fatalf("error = %v, want %v", err, test.wantErr)
+			}
+		})
+	}
+}
+
+// The single-snapshot rework must not put the runtime DB in the path of a
+// frozen static card: an explicit static exact stays readable with the store
+// entirely unreachable, which is what keeps a gates-off deployment unaffected.
+func TestRuntimeCatalogStaticExactNeedsNoSnapshot(t *testing.T) {
+	store := &authorizationStoreStub{authErr: errors.New("db unavailable")}
+	store.activationErr = errors.New("db unavailable")
+	catalog := newRuntimeCatalogForTest(t, runtimeStaticRegistry(t), store, nil)
+
+	request := staticDefaultRequest()
+	request.Version = "1.0.0"
+	if _, err := catalog.Render(context.Background(), request); err != nil {
+		t.Fatalf("explicit static render with an unreachable store: %v", err)
+	}
+	fallback := CatalogFallbackRequest{
+		Access: request.Access, ID: request.ID, Version: "1.0.0",
+		State: request.State, Fields: request.Fields, Lang: "en-US",
+	}
+	if _, err := catalog.FallbackText(context.Background(), fallback); err != nil {
+		t.Fatalf("explicit static fallback with an unreachable store: %v", err)
+	}
+	if store.snapshotCalls() != 0 {
+		t.Fatalf("snapshot calls = %d, want 0", store.snapshotCalls())
+	}
+}
+
+// A grant-unaware store can still serve static resolution, but it can never
+// produce an allow for a dynamic business purpose — so the split read it
+// performs cannot be used to smuggle an authorization decision.
+func TestRuntimeCatalogWithoutResolverCannotAuthorizeDynamic(t *testing.T) {
+	artifact := compileRuntimeFixture(t)
+	store := &runtimeStoreStub{
+		activation: RuntimeActivation{
+			Exists: true, Status: RuntimeActivationActive, Version: artifact.Meta.Version, Revision: 2,
+		},
+		meta:   runtimeArtifactMeta(artifact),
+		bundle: artifact.Bundle,
+	}
+	granted := false
+	catalog := newRuntimeCatalogForTest(t, runtimeStaticRegistry(t), store,
+		func(_ context.Context, _ CatalogAccess, _ RuntimeArtifactMeta, grant RuntimeGrant) error {
+			if grant.Allows(CatalogPurposeNewSend) {
+				granted = true
+				return nil
+			}
+			return ErrRuntimeCatalogNotAuthorized
+		})
+
+	_, err := catalog.Render(context.Background(), dynamicDefaultRequest())
+	if !errors.Is(err, ErrRuntimeCatalogNotAuthorized) {
+		t.Fatalf("render error = %v, want ErrRuntimeCatalogNotAuthorized", err)
+	}
+	if granted {
+		t.Fatal("a store without the resolver produced an authorized dynamic access")
+	}
+}
+
+func TestRuntimeGrantAllowsMapsPurposeToPermission(t *testing.T) {
+	full := RuntimeGrant{Found: true, Discover: true, Send: true, Edit: true}
+	for _, test := range []struct {
+		purpose CatalogPurpose
+		grant   RuntimeGrant
+		want    bool
+	}{
+		{CatalogPurposeNewSend, full, true},
+		{CatalogPurposeHistoricalEdit, full, true},
+		{CatalogPurposeActionContext, full, true},
+		{CatalogPurposeNewSend, RuntimeGrant{Found: true, Discover: true}, false},
+		{CatalogPurposeHistoricalEdit, RuntimeGrant{Found: true, Discover: true, Send: true}, false},
+		{CatalogPurposeActionContext, RuntimeGrant{Found: true, Discover: true, Send: true}, false},
+		{CatalogPurpose("unheard-of"), full, false},
+		{CatalogPurposeNewSend, RuntimeGrant{}, false},
+	} {
+		if got := test.grant.Allows(test.purpose); got != test.want {
+			t.Fatalf("%s grant %+v allows = %v, want %v", test.purpose, test.grant, got, test.want)
+		}
+	}
+}
+
+func TestActivationVersionIsTheSingleActivationRule(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		activation RuntimeActivation
+		want       string
+		wantErr    error
+	}{
+		{"absent row has no version", RuntimeActivation{}, "", nil},
+		{"active row resolves", RuntimeActivation{
+			Exists: true, Status: RuntimeActivationActive, Version: "1.2.3"}, "1.2.3", nil},
+		{"disabled row is a typed denial", RuntimeActivation{
+			Exists: true, Status: RuntimeActivationDisabled, Revision: 9}, "", ErrRuntimeCatalogDisabled},
+		{"active row without a version is corrupt", RuntimeActivation{
+			Exists: true, Status: RuntimeActivationActive, Version: "  "}, "", ErrRuntimeCatalogIntegrity},
+		{"unknown status is corrupt", RuntimeActivation{
+			Exists: true, Status: "paused"}, "", ErrRuntimeCatalogIntegrity},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := ActivationVersion("test.runtime-card", test.activation)
+			if !errors.Is(err, test.wantErr) {
+				t.Fatalf("error = %v, want %v", err, test.wantErr)
+			}
+			if got != test.want {
+				t.Fatalf("version = %q, want %q", got, test.want)
+			}
+		})
+	}
+}

--- a/pkg/cardtmpl/runtime_catalog.go
+++ b/pkg/cardtmpl/runtime_catalog.go
@@ -621,12 +621,27 @@ func validateCompiledArtifact(meta RuntimeArtifactMeta, artifact *CompiledArtifa
 	return nil
 }
 
+// classifyRuntimeStoreError turns a store failure into a typed catalog error.
+// Anything it does not recognise becomes "unavailable", which is the right
+// default for a raw driver error but the wrong answer for a verdict the store
+// already reached.
+//
+// The distinction is load-bearing downstream: `disabled` means an operator
+// deliberately turned this template off and callers withhold it quietly, while
+// `unavailable` means we could not tell and callers surface an outage. Since
+// PR-C moved activation resolution inside the snapshot, a disabled pointer is
+// produced by the store rather than by the catalog — so every typed error the
+// catalog owns has to pass through intact instead of only the two that happened
+// to be listed when the store could not produce the others.
 func classifyRuntimeStoreError(operation string, err error) error {
 	switch {
 	case err == nil:
 		return nil
 	case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded),
-		errors.Is(err, ErrTemplateUnknown), errors.Is(err, ErrRuntimeCatalogIntegrity):
+		errors.Is(err, ErrTemplateUnknown), errors.Is(err, ErrRuntimeCatalogIntegrity),
+		errors.Is(err, ErrRuntimeCatalogDisabled), errors.Is(err, ErrRuntimeCatalogBlocked),
+		errors.Is(err, ErrRuntimeCatalogNotAuthorized), errors.Is(err, ErrRuntimeCatalogNewSendDisabled),
+		errors.Is(err, ErrRuntimeCatalogUnavailable):
 		return fmt.Errorf("cardtmpl: %s: %w", operation, err)
 	default:
 		return fmt.Errorf("%w: %s: %v", ErrRuntimeCatalogUnavailable, operation, err)

--- a/pkg/cardtmpl/runtime_catalog.go
+++ b/pkg/cardtmpl/runtime_catalog.go
@@ -68,7 +68,11 @@ type RuntimeArtifactStore interface {
 	LoadArtifactBundle(context.Context, ID, string, string) (CanonicalBundle, error)
 }
 
-type RuntimeDynamicAuthorizeFunc func(context.Context, CatalogAccess, RuntimeArtifactMeta) error
+// RuntimeDynamicAuthorizeFunc decides one dynamic access. The grant argument
+// comes from the same snapshot as the artifact metadata (see
+// runtime_authorization.go); an implementation must never go read a grant of
+// its own, because a second read is a second point in time.
+type RuntimeDynamicAuthorizeFunc func(context.Context, CatalogAccess, RuntimeArtifactMeta, RuntimeGrant) error
 
 type RuntimeCatalogHooks struct {
 	OnResolve   func(RuntimeSource, string)
@@ -86,8 +90,12 @@ type RuntimeCatalogConfig struct {
 }
 
 type RuntimeCatalog struct {
-	static           *StaticCatalog
-	store            RuntimeArtifactStore
+	static *StaticCatalog
+	store  RuntimeArtifactStore
+	// authorization is the single-snapshot resolver, present whenever the store
+	// implements it. Production always does; see loadAuthorization for what a
+	// store without it can and cannot do.
+	authorization    RuntimeAuthorizationStore
 	cache            *compiledArtifactCache
 	compileTimeout   time.Duration
 	compile          func(context.Context, Bundle, CompileLimits) (*CompiledArtifact, error)
@@ -119,8 +127,9 @@ func NewRuntimeCatalog(
 	if err != nil {
 		return nil, err
 	}
+	authorization, _ := store.(RuntimeAuthorizationStore)
 	return &RuntimeCatalog{
-		static: static, store: store,
+		static: static, store: store, authorization: authorization,
 		cache: newCompiledArtifactCache(entries, bytes), compileTimeout: timeout,
 		compile:          CompileJSONArtifact,
 		checkReady:       config.CheckReady,
@@ -153,32 +162,17 @@ func (c *RuntimeCatalog) Render(ctx context.Context, request CatalogRenderReques
 	if c == nil || c.static == nil || c.store == nil {
 		return nil, ErrRuntimeCatalogUnavailable
 	}
-	explicit := request.Version != ""
-	version, err := c.resolveVersion(ctx, request.ID, request.Version)
+	resolution, err := c.resolve(ctx, request.Access, request.ID, request.Version, followActivation)
 	if err != nil {
 		return nil, err
 	}
-	if version == "" {
-		payload, err := c.static.Render(ctx, request)
-		c.observeResolve(RuntimeSourceStatic, err)
-		return payload, err
-	}
-	if _, err := c.static.registry.Lookup(request.ID, version); err == nil {
-		if explicit {
-			if err := c.rejectIntegrity(); err != nil {
-				c.observeResolve(RuntimeSourceStatic, err)
-				return nil, err
-			}
-		}
-		request.Version = version
+	request.Version = resolution.version
+	if resolution.serveStatic {
 		payload, renderErr := c.static.Render(ctx, request)
 		c.observeResolve(RuntimeSourceStatic, renderErr)
 		return payload, renderErr
-	} else if !errors.Is(err, ErrTemplateUnknown) {
-		return nil, err
 	}
-	request.Version = version
-	artifact, err := c.resolveDynamic(ctx, request.Access, request.ID, version)
+	artifact, err := c.resolveDynamic(ctx, request.Access, resolution)
 	if err != nil {
 		return nil, err
 	}
@@ -192,17 +186,18 @@ func (c *RuntimeCatalog) MetaExact(ctx context.Context, request CatalogExactRequ
 	if strings.TrimSpace(request.Version) == "" {
 		return TemplateMeta{}, fmt.Errorf("%w: explicit version is required", ErrTemplateUnknown)
 	}
-	if meta, err := c.static.MetaExact(ctx, request); err == nil {
-		if err := c.rejectIntegrity(); err != nil {
-			c.observeResolve(RuntimeSourceStatic, err)
-			return TemplateMeta{}, err
-		}
-		c.observeResolve(RuntimeSourceStatic, nil)
-		return meta, nil
-	} else if !errors.Is(err, ErrTemplateUnknown) {
+	resolution, err := c.resolve(ctx, request.Access, request.ID, request.Version, pinExactVersion)
+	if err != nil {
 		return TemplateMeta{}, err
 	}
-	artifact, err := c.resolveDynamic(ctx, request.Access, request.ID, request.Version)
+	if resolution.serveStatic {
+		meta, metaErr := c.static.MetaExact(ctx, CatalogExactRequest{
+			Access: request.Access, ID: request.ID, Version: resolution.version,
+		})
+		c.observeResolve(RuntimeSourceStatic, metaErr)
+		return meta, metaErr
+	}
+	artifact, err := c.resolveDynamic(ctx, request.Access, resolution)
 	if err != nil {
 		return TemplateMeta{}, err
 	}
@@ -213,44 +208,51 @@ func (c *RuntimeCatalog) MetaDefault(ctx context.Context, request CatalogDefault
 	if c == nil || c.static == nil || c.store == nil {
 		return TemplateMeta{}, ErrRuntimeCatalogUnavailable
 	}
-	version, err := c.resolveVersion(ctx, request.ID, "")
+	resolution, err := c.resolve(ctx, request.Access, request.ID, "", followActivation)
 	if err != nil {
 		return TemplateMeta{}, err
 	}
-	if version == "" {
-		meta, metaErr := c.static.MetaDefault(ctx, request)
+	if resolution.serveStatic {
+		var meta TemplateMeta
+		var metaErr error
+		if resolution.version == "" {
+			meta, metaErr = c.static.MetaDefault(ctx, request)
+		} else {
+			meta, metaErr = c.static.MetaExact(ctx, CatalogExactRequest{
+				Access: request.Access, ID: request.ID, Version: resolution.version,
+			})
+		}
 		c.observeResolve(RuntimeSourceStatic, metaErr)
 		return meta, metaErr
 	}
-	return c.MetaExact(ctx, CatalogExactRequest{Access: request.Access, ID: request.ID, Version: version})
+	artifact, err := c.resolveDynamic(ctx, request.Access, resolution)
+	if err != nil {
+		return TemplateMeta{}, err
+	}
+	return artifact.Meta.Clone(), nil
 }
 
 func (c *RuntimeCatalog) FallbackText(ctx context.Context, request CatalogFallbackRequest) (string, error) {
 	if c == nil || c.static == nil || c.store == nil {
 		return "", ErrRuntimeCatalogUnavailable
 	}
-	explicit := request.Version != ""
-	version, err := c.resolveVersion(ctx, request.ID, request.Version)
+	resolution, err := c.resolve(ctx, request.Access, request.ID, request.Version, followActivation)
 	if err != nil {
 		return "", err
 	}
-	if template, lookupErr := c.static.registry.Lookup(request.ID, version); lookupErr == nil {
-		if explicit {
-			if err := c.rejectIntegrity(); err != nil {
-				c.observeResolve(RuntimeSourceStatic, err)
-				return "", err
+	if resolution.serveStatic {
+		template, lookupErr := c.static.registry.Lookup(request.ID, resolution.version)
+		if lookupErr != nil {
+			if resolution.version == "" && errors.Is(lookupErr, ErrTemplateUnknown) {
+				return "", fmt.Errorf("%w: %s has no default", ErrTemplateUnknown, request.ID)
 			}
+			return "", lookupErr
 		}
 		text, fallbackErr := template.FallbackText(request.State, request.Fields, request.Lang)
 		c.observeResolve(RuntimeSourceStatic, fallbackErr)
 		return text, fallbackErr
-	} else if !errors.Is(lookupErr, ErrTemplateUnknown) {
-		return "", lookupErr
 	}
-	if version == "" {
-		return "", fmt.Errorf("%w: %s has no default", ErrTemplateUnknown, request.ID)
-	}
-	artifact, err := c.resolveDynamic(ctx, request.Access, request.ID, version)
+	artifact, err := c.resolveDynamic(ctx, request.Access, resolution)
 	if err != nil {
 		return "", err
 	}
@@ -261,18 +263,20 @@ func (c *RuntimeCatalog) ActionContext(ctx context.Context, request CatalogActio
 	if c == nil || c.static == nil || c.store == nil {
 		return CatalogActionContext{}, ErrRuntimeCatalogUnavailable
 	}
-	if _, err := c.static.registry.Lookup(request.ID, request.Version); err == nil {
-		if err := c.rejectIntegrity(); err != nil {
-			c.observeResolve(RuntimeSourceStatic, err)
-			return CatalogActionContext{}, err
-		}
+	// An action callback answers a card that already exists, so it reads the
+	// stored exact version and must never follow the activation pointer (D4);
+	// flipping the pointer cannot retarget a button on a card already sent.
+	resolution, err := c.resolve(ctx, request.Access, request.ID, request.Version, pinExactVersion)
+	if err != nil {
+		return CatalogActionContext{}, err
+	}
+	if resolution.serveStatic {
+		request.Version = resolution.version
 		result, actionErr := c.static.ActionContext(ctx, request)
 		c.observeResolve(RuntimeSourceStatic, actionErr)
 		return result, actionErr
-	} else if !errors.Is(err, ErrTemplateUnknown) {
-		return CatalogActionContext{}, err
 	}
-	artifact, err := c.resolveDynamic(ctx, request.Access, request.ID, request.Version)
+	artifact, err := c.resolveDynamic(ctx, request.Access, resolution)
 	if err != nil {
 		return CatalogActionContext{}, err
 	}
@@ -283,63 +287,172 @@ func (c *RuntimeCatalog) ActionContext(ctx context.Context, request CatalogActio
 	return CatalogActionContext{View: view, Meta: artifact.Meta.Clone()}, nil
 }
 
-func (c *RuntimeCatalog) resolveDynamic(
+// versionMode says whether a read is allowed to follow the activation pointer.
+type versionMode bool
+
+const (
+	// followActivation resolves an absent version from the activation pointer.
+	// Only new sends may do this.
+	followActivation versionMode = true
+	// pinExactVersion forbids consulting the pointer, so an absent version can
+	// only be answered by the frozen Registry's own default.
+	pinExactVersion versionMode = false
+)
+
+// runtimeResolution is what at most one DB snapshot decided for one request.
+type runtimeResolution struct {
+	id      ID
+	version string
+	// serveStatic routes the request to the frozen Registry. Static reads never
+	// consult a business grant: a static exact is code-reviewed policy, not
+	// producer-granted state (D6 row 3).
+	serveStatic bool
+	auth        RuntimeAuthorization
+}
+
+// resolve performs at most one primary-DB snapshot and decides static versus
+// dynamic from it. The static branches below deliberately return before any
+// store call so that a deployment with the runtime gates off — or one whose DB
+// is briefly unreachable — keeps serving frozen static cards exactly as it did
+// before the runtime catalog existed.
+func (c *RuntimeCatalog) resolve(
 	ctx context.Context,
 	access CatalogAccess,
 	id ID,
 	version string,
+	mode versionMode,
+) (runtimeResolution, error) {
+	if version != "" || mode == pinExactVersion {
+		if _, err := c.static.registry.Lookup(id, version); err == nil {
+			// A persistent startup integrity failure (a static/dynamic key
+			// collision) still fails closed; a transient DB outage does not.
+			if err := c.rejectIntegrity(); err != nil {
+				c.observeResolve(RuntimeSourceStatic, err)
+				return runtimeResolution{}, err
+			}
+			return runtimeResolution{id: id, version: version, serveStatic: true}, nil
+		} else if !errors.Is(err, ErrTemplateUnknown) {
+			return runtimeResolution{}, err
+		}
+		if version == "" {
+			return runtimeResolution{}, fmt.Errorf("%w: %s has no default", ErrTemplateUnknown, id)
+		}
+	}
+	if err := c.requireReady(); err != nil {
+		c.observeResolve(RuntimeSourceDynamic, err)
+		return runtimeResolution{}, err
+	}
+	auth, err := c.loadAuthorization(ctx, RuntimeAuthorizationQuery{
+		ID: id, Version: version, Principal: access.Principal,
+	})
+	if err != nil {
+		c.observeResolve(RuntimeSourceDynamic, err)
+		return runtimeResolution{}, err
+	}
+	if auth.Version == "" {
+		// No activation row at all: the ID belongs entirely to the frozen
+		// Registry, if it knows it.
+		return runtimeResolution{id: id, serveStatic: true}, nil
+	}
+	if _, err := c.static.registry.Lookup(id, auth.Version); err == nil {
+		return runtimeResolution{id: id, version: auth.Version, serveStatic: true, auth: auth}, nil
+	} else if !errors.Is(err, ErrTemplateUnknown) {
+		return runtimeResolution{}, err
+	}
+	return runtimeResolution{id: id, version: auth.Version, auth: auth}, nil
+}
+
+// loadAuthorization is the single point where an authorization decision's
+// inputs enter the process.
+func (c *RuntimeCatalog) loadAuthorization(
+	ctx context.Context,
+	query RuntimeAuthorizationQuery,
+) (RuntimeAuthorization, error) {
+	if c.authorization != nil {
+		auth, err := c.authorization.LoadAuthorization(ctx, query)
+		if err != nil {
+			return RuntimeAuthorization{}, classifyRuntimeStoreError("load authorization", err)
+		}
+		if err := c.verifyAuthorization(query, auth); err != nil {
+			return RuntimeAuthorization{}, err
+		}
+		return auth, nil
+	}
+	// A store that predates the resolver (test fakes, and any embedding that
+	// never had grants) can still answer version resolution and metadata, but
+	// it returns no grant — so every dynamic business purpose is denied
+	// downstream. A split read therefore cannot manufacture an *allow*, which
+	// is the only direction that matters for the single-snapshot invariant.
+	auth := RuntimeAuthorization{Version: query.Version}
+	if query.Version == "" {
+		activation, err := c.store.LoadActivation(ctx, query.ID)
+		if err != nil {
+			return RuntimeAuthorization{}, classifyRuntimeStoreError("load activation", err)
+		}
+		version, err := ActivationVersion(query.ID, activation)
+		if err != nil {
+			return RuntimeAuthorization{}, err
+		}
+		auth.Activation, auth.Version = activation, version
+		if version == "" {
+			return auth, nil
+		}
+	}
+	meta, err := c.store.LoadArtifactMeta(ctx, query.ID, auth.Version)
+	if err != nil {
+		return RuntimeAuthorization{}, classifyRuntimeStoreError("load artifact metadata", err)
+	}
+	auth.Artifact = meta
+	return auth, nil
+}
+
+// verifyAuthorization re-derives the parts of the receipt the catalog can check
+// itself. A store that answered for a different template, followed the pointer
+// when it was told not to, or disagreed with ActivationVersion has produced an
+// incoherent snapshot, and an incoherent snapshot is an integrity failure — not
+// something to paper over with a second read.
+func (c *RuntimeCatalog) verifyAuthorization(query RuntimeAuthorizationQuery, auth RuntimeAuthorization) error {
+	if query.Version != "" {
+		if auth.Version != query.Version || auth.Activation.Exists {
+			return fmt.Errorf("%w: pinned authorization snapshot for %s@%s is incoherent",
+				ErrRuntimeCatalogIntegrity, query.ID, query.Version)
+		}
+		return nil
+	}
+	expected, err := ActivationVersion(query.ID, auth.Activation)
+	if err != nil {
+		return err
+	}
+	if auth.Version != expected {
+		return fmt.Errorf("%w: authorization snapshot for %s resolved %q against activation %q",
+			ErrRuntimeCatalogIntegrity, query.ID, auth.Version, expected)
+	}
+	return nil
+}
+
+func (c *RuntimeCatalog) resolveDynamic(
+	ctx context.Context,
+	access CatalogAccess,
+	resolution runtimeResolution,
 ) (artifact *CompiledArtifact, err error) {
 	defer func() { c.observeResolve(RuntimeSourceDynamic, err) }()
-	if err := c.requireReady(); err != nil {
-		return nil, err
-	}
 	if c.authorizeDynamic == nil {
 		return nil, ErrRuntimeCatalogNotAuthorized
 	}
-	meta, err := c.store.LoadArtifactMeta(ctx, id, version)
-	if err != nil {
-		return nil, classifyRuntimeStoreError("load artifact metadata", err)
-	}
-	if err := validateRuntimeArtifactMeta(id, version, meta); err != nil {
+	meta := resolution.auth.Artifact
+	if err := validateRuntimeArtifactMeta(resolution.id, resolution.version, meta); err != nil {
 		return nil, err
 	}
 	if meta.Blocked {
-		return nil, fmt.Errorf("%w: %s@%s", ErrRuntimeCatalogBlocked, id, version)
+		return nil, fmt.Errorf("%w: %s@%s", ErrRuntimeCatalogBlocked, resolution.id, resolution.version)
 	}
-	if err := c.authorizeDynamic(ctx, access, meta); err != nil {
+	if err := c.authorizeDynamic(ctx, access, meta, resolution.auth.Grant); err != nil {
 		if errors.Is(err, ErrRuntimeCatalogNotAuthorized) || errors.Is(err, ErrRuntimeCatalogNewSendDisabled) {
 			return nil, err
 		}
 		return nil, fmt.Errorf("%w: authorize dynamic artifact: %w", ErrRuntimeCatalogUnavailable, err)
 	}
 	return c.loadCompiled(ctx, meta)
-}
-
-func (c *RuntimeCatalog) resolveVersion(ctx context.Context, id ID, explicit string) (string, error) {
-	if explicit != "" {
-		return explicit, nil
-	}
-	if err := c.requireReady(); err != nil {
-		return "", err
-	}
-	activation, err := c.store.LoadActivation(ctx, id)
-	if err != nil {
-		return "", classifyRuntimeStoreError("load activation", err)
-	}
-	if !activation.Exists {
-		return "", nil
-	}
-	switch activation.Status {
-	case RuntimeActivationDisabled:
-		return "", fmt.Errorf("%w: %s revision %d", ErrRuntimeCatalogDisabled, id, activation.Revision)
-	case RuntimeActivationActive:
-		if strings.TrimSpace(activation.Version) == "" {
-			return "", fmt.Errorf("%w: active row has no version", ErrRuntimeCatalogIntegrity)
-		}
-		return activation.Version, nil
-	default:
-		return "", fmt.Errorf("%w: unknown activation status %q", ErrRuntimeCatalogIntegrity, activation.Status)
-	}
 }
 
 func (c *RuntimeCatalog) loadCompiled(ctx context.Context, meta RuntimeArtifactMeta) (*CompiledArtifact, error) {

--- a/pkg/cardtmpl/runtime_catalog_test.go
+++ b/pkg/cardtmpl/runtime_catalog_test.go
@@ -746,7 +746,9 @@ func dynamicDefaultRequest() CatalogRenderRequest {
 	}
 }
 
-func allowDynamicForTest(context.Context, CatalogAccess, RuntimeArtifactMeta) error { return nil }
+func allowDynamicForTest(context.Context, CatalogAccess, RuntimeArtifactMeta, RuntimeGrant) error {
+	return nil
+}
 
 type runtimeStoreStub struct {
 	mu              sync.Mutex

--- a/pkg/cardtmpl/template.go
+++ b/pkg/cardtmpl/template.go
@@ -76,6 +76,13 @@ type TemplateMeta struct {
 	// 查询走 ViewFor / Interaction,不允许直接读。
 	stateIndex   map[State]ViewKey
 	interactions map[ViewKey]InteractionReport
+	// contractVersion mirrors manifest.contractVersion. It is unexported
+	// because it exists for the B2 projection, not for render-time behaviour.
+	contractVersion string
+	// export is the immutable B2 projection built at registration or compile
+	// time (PR-C D5). Nil means this template has nothing safe to export, and
+	// B2 must answer not-found rather than assemble something at request time.
+	export *SafeExport
 }
 
 // ViewFor 返回 state 归属的视图。业务代码不允许自行维护映射,统一走本方法。
@@ -177,6 +184,10 @@ func (m TemplateMeta) Clone() TemplateMeta {
 		RenderProfileCompatibility: m.RenderProfileCompatibility,
 		Source:                     m.Source,
 		InputSchema:                m.InputSchema,
+		contractVersion:            m.contractVersion,
+		// The projection is immutable, so the clone shares the pointer; callers
+		// that need their own copy go through Export(), which deep-copies.
+		export: m.export,
 	}
 	if m.Manifest != nil {
 		out.Manifest = append(json.RawMessage(nil), m.Manifest...)

--- a/pkg/cardtmpl/updater.go
+++ b/pkg/cardtmpl/updater.go
@@ -208,6 +208,22 @@ func storedMarkersForUpdate(envelope json.RawMessage, target UpdateTarget) (card
 // updaterCatalogAccess 构造 historical_edit 的 catalog access。stored
 // provenance 存在时它是 principal 的唯一来源（D3：不从 sender 反推）；
 // legacy 无标记帧保留既有 sender 派生口径（static 历史兼容，invariant 7）。
+//
+// Review asked whether this fallback needs the same scoping the action ingress
+// just grew — refuse a markerless frame that names a version only the runtime
+// catalog knows. It does not, and the difference is the threat model rather
+// than the shape. At the action ingress the template identity comes from
+// `card.metadata.octo`, inside a card body a raw caller controls, and the
+// derived principal is the *sending Bot's own* grant identity, so a fabricated
+// frame turns an `edit` grant into a substitute for `send`. Here the identity
+// is the caller's own `target.SenderUID`, every caller is an in-process
+// internal producer, and `Snapshot` has already proven that sender owns the
+// stored message. There is no path by which a request supplies it.
+//
+// Adding the check anyway would mean threading a Registry through
+// NewCardUpdater purely to guard a hole nothing can reach, and it would refuse
+// legitimate edits of pre-PR-C frames in any deployment whose default Registry
+// is not the one the updater was built over. Recorded rather than done.
 func updaterCatalogAccess(target UpdateTarget, markers cardmsg.FrameCatalogMarkers) (CatalogAccess, error) {
 	if markers.HasProvenance {
 		principal, err := CatalogPrincipalFromProvenance(markers.Provenance)

--- a/pkg/cardtmpl/updater.go
+++ b/pkg/cardtmpl/updater.go
@@ -189,6 +189,14 @@ func storedMarkersForUpdate(envelope json.RawMessage, target UpdateTarget) (card
 	if err != nil {
 		return cardmsg.FrameCatalogMarkers{}, fmt.Errorf("%w: %v", ErrUpdateInvalid, err)
 	}
+	// An *empty* target Space never reaches here: validateUpdateTarget rejects
+	// one at the entry to both ReplaceView and Append, so by this point the
+	// caller has established a Space and a mismatch really is a mismatch. That
+	// is worth stating, because the neighbouring guards in bot_api and
+	// modules/message had to grow an explicit "unknown is not empty" state and
+	// this one looks like it is missing the same treatment. It is not — the
+	// distinction is enforced one layer up, and the click ingress refuses to
+	// create an event at all when the card's origin Space cannot be read.
 	if markers.HasProvenance && markers.Provenance.SpaceID != "" &&
 		markers.Provenance.SpaceID != target.Target.SpaceID {
 		return cardmsg.FrameCatalogMarkers{}, fmt.Errorf("%w: stored provenance space %q does not match target space %q",

--- a/pkg/cardtmpl/updater.go
+++ b/pkg/cardtmpl/updater.go
@@ -57,8 +57,27 @@ func (u *updater) ReplaceView(ctx context.Context, target UpdateTarget, id ID, v
 	if id == "" || version == "" || env.SpaceID != target.Target.SpaceID {
 		return ErrUpdateInvalid
 	}
+	// PR-C D3/G13：先 Snapshot 生效帧，再做任何 authorization/render。stored
+	// server-authored 标记钉住 template identity / principal / Space —— 调用方
+	// 的 UpdateTarget 与 id@version 只有与 stored 一致才被接受，不能靠它们把
+	// 一张卡跨版本/跨身份/跨 Space 改写。
+	snapshot, err := u.mutator.Snapshot(ctx, mutationTarget(target))
+	if err != nil {
+		return err
+	}
+	markers, err := storedMarkersForUpdate(snapshot.Envelope, target)
+	if err != nil {
+		return err
+	}
+	if markers.HasRef && (markers.Ref.ID != string(id) || markers.Ref.Version != version) {
+		return fmt.Errorf("%w: stored template identity is %s@%s", ErrUpdateInvalid, markers.Ref.ID, markers.Ref.Version)
+	}
+	access, err := updaterCatalogAccess(target, markers)
+	if err != nil {
+		return err
+	}
 	meta, err := u.catalog.MetaExact(ctx, CatalogExactRequest{
-		Access: updaterCatalogAccess(target), ID: id, Version: version,
+		Access: access, ID: id, Version: version,
 	})
 	if err != nil {
 		return err
@@ -71,13 +90,13 @@ func (u *updater) ReplaceView(ctx context.Context, target UpdateTarget, id ID, v
 		recordUpdate(meta.ID, meta.Version, result)
 	}()
 	document, profile, renderProfile, err := RenderCatalogCardWithProfiles(ctx, u.catalog, CatalogRenderRequest{
-		Access: updaterCatalogAccess(target), ID: id, Version: version,
+		Access: access, ID: id, Version: version,
 		State: state, Fields: fields, Env: env,
 	})
 	if err != nil {
 		return err
 	}
-	contentEdit, err := updateEnvelope(document, profile, renderProfile, target.Target.SpaceID, target.CardSeq)
+	contentEdit, err := updateEnvelope(document, profile, renderProfile, target.Target.SpaceID, target.CardSeq, markers)
 	if err != nil {
 		return err
 	}
@@ -112,9 +131,19 @@ func (u *updater) Append(ctx context.Context, target UpdateTarget, element json.
 	if snapshot.CardSeq < 0 || target.CardSeq-1 != snapshot.CardSeq {
 		return carddispatch.ErrCardMutationConflict
 	}
+	// PR-C D3：stored 标记畸形即篡改信号 fail-close；provenance 存在时它是
+	// edit principal 的唯一来源（re-marshal 会原样保留两个顶层标记）。
+	markers, err := storedMarkersForUpdate(snapshot.Envelope, target)
+	if err != nil {
+		return err
+	}
+	access, err := updaterCatalogAccess(target, markers)
+	if err != nil {
+		return err
+	}
 	if template, ok := cardmsg.CardTemplateContext(snapshot.Envelope); ok {
 		meta, lookupErr := u.catalog.MetaExact(ctx, CatalogExactRequest{
-			Access: updaterCatalogAccess(target), ID: ID(template.ID), Version: template.Version,
+			Access: access, ID: ID(template.ID), Version: template.Version,
 		})
 		if lookupErr != nil && !errors.Is(lookupErr, ErrTemplateUnknown) {
 			return lookupErr
@@ -152,13 +181,39 @@ func (u *updater) Append(ctx context.Context, target UpdateTarget, element json.
 	return err
 }
 
-func updaterCatalogAccess(target UpdateTarget) CatalogAccess {
+// storedMarkersForUpdate 从生效帧提取 catalog 标记并做 update 边界校验：
+// 畸形标记 fail-close；stored provenance 声明的 Space 非空时必须与权威
+// UpdateTarget Space 一致 —— 跨 Space 的 mutation 在 render 前拒绝。
+func storedMarkersForUpdate(envelope json.RawMessage, target UpdateTarget) (cardmsg.FrameCatalogMarkers, error) {
+	markers, err := cardmsg.CatalogFrameMarkers(envelope)
+	if err != nil {
+		return cardmsg.FrameCatalogMarkers{}, fmt.Errorf("%w: %v", ErrUpdateInvalid, err)
+	}
+	if markers.HasProvenance && markers.Provenance.SpaceID != "" &&
+		markers.Provenance.SpaceID != target.Target.SpaceID {
+		return cardmsg.FrameCatalogMarkers{}, fmt.Errorf("%w: stored provenance space %q does not match target space %q",
+			ErrUpdateInvalid, markers.Provenance.SpaceID, target.Target.SpaceID)
+	}
+	return markers, nil
+}
+
+// updaterCatalogAccess 构造 historical_edit 的 catalog access。stored
+// provenance 存在时它是 principal 的唯一来源（D3：不从 sender 反推）；
+// legacy 无标记帧保留既有 sender 派生口径（static 历史兼容，invariant 7）。
+func updaterCatalogAccess(target UpdateTarget, markers cardmsg.FrameCatalogMarkers) (CatalogAccess, error) {
+	if markers.HasProvenance {
+		principal, err := CatalogPrincipalFromProvenance(markers.Provenance)
+		if err != nil {
+			return CatalogAccess{}, fmt.Errorf("%w: %v", ErrUpdateInvalid, err)
+		}
+		return CatalogAccess{Purpose: CatalogPurposeHistoricalEdit, Principal: principal}, nil
+	}
 	return CatalogAccess{
 		Purpose: CatalogPurposeHistoricalEdit,
 		Principal: CatalogPrincipal{
 			Kind: CatalogPrincipalInternalProducer, ID: target.SenderUID, SpaceID: target.Target.SpaceID,
 		},
-	}
+	}, nil
 }
 
 func validateUpdateTarget(ctx context.Context, target UpdateTarget) error {
@@ -183,7 +238,8 @@ func mutationRequest(target UpdateTarget, contentEdit string) carddispatch.CardM
 	}
 }
 
-func updateEnvelope(document json.RawMessage, profile, renderProfile, spaceID string, cardSeq int64) (string, error) {
+func updateEnvelope(document json.RawMessage, profile, renderProfile, spaceID string, cardSeq int64,
+	markers cardmsg.FrameCatalogMarkers) (string, error) {
 	var card map[string]interface{}
 	if err := json.Unmarshal(document, &card); err != nil || card == nil {
 		return "", fmt.Errorf("%w: decode rendered card", ErrUpdateInvalid)
@@ -194,6 +250,16 @@ func updateEnvelope(document json.RawMessage, profile, renderProfile, spaceID st
 	}
 	if renderProfile != "" {
 		envelope["render_profile"] = renderProfile
+	}
+	// PR-C D3：stored 标记原样保留到替换帧 —— identity/principal/Space 在
+	// mutation 中不可变；legacy 无标记帧不凭空长出标记（principal 会是猜测）。
+	if markers.HasRef {
+		envelope[cardmsg.CatalogTemplateRefKey] = map[string]interface{}{
+			"id": markers.Ref.ID, "version": markers.Ref.Version,
+		}
+	}
+	if markers.HasProvenance {
+		envelope[cardmsg.CatalogProvenanceKey] = markers.Provenance.MarshalMap()
 	}
 	raw, err := json.Marshal(envelope)
 	if err != nil {

--- a/pkg/cardtmpl/updater_test.go
+++ b/pkg/cardtmpl/updater_test.go
@@ -276,3 +276,238 @@ func assertUpdateEnvelope(t *testing.T, raw string, seq int64, profile, renderPr
 		t.Fatalf("template.version = %v, want %q", template["version"], version)
 	}
 }
+
+// ---- PR-C Slice 1 (D3/G13): stored catalog markers pin identity, principal
+// and Space through every mutation. ----
+
+type accessCaptureCatalog struct {
+	cardtmpl.Catalog
+	metaAccess   []cardtmpl.CatalogAccess
+	renderAccess []cardtmpl.CatalogAccess
+}
+
+func (c *accessCaptureCatalog) MetaExact(ctx context.Context, request cardtmpl.CatalogExactRequest) (cardtmpl.TemplateMeta, error) {
+	c.metaAccess = append(c.metaAccess, request.Access)
+	return c.Catalog.MetaExact(ctx, request)
+}
+
+func (c *accessCaptureCatalog) Render(ctx context.Context, request cardtmpl.CatalogRenderRequest) (map[string]any, error) {
+	c.renderAccess = append(c.renderAccess, request.Access)
+	return c.Catalog.Render(ctx, request)
+}
+
+func markedV3Snapshot(t *testing.T, mutate func(map[string]any)) json.RawMessage {
+	t.Helper()
+	frame := map[string]any{
+		"type": 17, "card_version": cardmsg.CardVersion, "profile": cardmsg.ProfileV2,
+		"space_id": "space-1", "card_seq": 4,
+		"template_ref": map[string]any{
+			"id": string(docsaccessrequest.TemplateID), "version": docsaccessrequest.TemplateVersionV3,
+		},
+		"catalog_provenance": map[string]any{
+			"version": 1, "principal_type": "internal_producer",
+			"principal_id": "docs-notify", "space_id": "space-1",
+		},
+		"card": map[string]any{
+			"type": "AdaptiveCard", "version": cardmsg.CardVersion,
+			"body": []any{map[string]any{"type": "TextBlock", "text": "pending"}},
+			"metadata": map[string]any{"octo": map[string]any{
+				"protocol": cardtmpl.Protocol,
+				"template": map[string]any{
+					"id": string(docsaccessrequest.TemplateID), "version": docsaccessrequest.TemplateVersionV3,
+				},
+			}},
+		},
+	}
+	if mutate != nil {
+		mutate(frame)
+	}
+	raw, err := json.Marshal(frame)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return raw
+}
+
+func v3UpdaterFixture(t *testing.T, snapshot json.RawMessage) (*accessCaptureCatalog, *captureMutationGateway, cardtmpl.CardUpdater) {
+	t.Helper()
+	r := cardtmpl.NewRegistry()
+	r.Register(docsaccessrequest.NewV3(), docsaccessrequest.Assets, docsaccessrequest.HandoffRootV3)
+	r.SetDefault(docsaccessrequest.TemplateID, docsaccessrequest.TemplateVersionV3)
+	r.Freeze()
+	catalog := &accessCaptureCatalog{Catalog: staticCatalog(t, r)}
+	gateway := &captureMutationGateway{
+		snapshot: carddispatch.CardMutationSnapshot{Envelope: snapshot, CardSeq: 4},
+		result:   carddispatch.CardMutationResult{Applied: true},
+	}
+	updater, err := cardtmpl.NewCardUpdater(catalog, gateway)
+	if err != nil {
+		t.Fatalf("NewCardUpdater: %v", err)
+	}
+	return catalog, gateway, updater
+}
+
+func approvedV3Fields() json.RawMessage {
+	return json.RawMessage(`{
+		"requestId":"request-1","state":"approved",
+		"document":{"docId":"doc-1","title":"Roadmap"},
+		"requester":{"name":"Alice"},"decision":{"operatorName":"Bob"}
+	}`)
+}
+
+func v3UpdateTarget() cardtmpl.UpdateTarget {
+	return cardtmpl.UpdateTarget{
+		Target:    carddispatch.Target{SpaceID: "space-1", ChannelID: "user-b", ChannelType: 1},
+		SenderUID: "notification", MessageID: "1001", MessageSeq: 7, CardSeq: 42,
+	}
+}
+
+func TestCardUpdaterReplaceViewPreservesStoredCatalogMarkers(t *testing.T) {
+	catalog, gateway, updater := v3UpdaterFixture(t, markedV3Snapshot(t, nil))
+	if err := updater.ReplaceView(context.Background(), v3UpdateTarget(), docsaccessrequest.TemplateID,
+		docsaccessrequest.TemplateVersionV3, docsaccessrequest.StateApproved, approvedV3Fields(),
+		cardtmpl.BuildEnv{WebLoginURL: "https://web.example.com", Lang: "en", SpaceID: "space-1"}); err != nil {
+		t.Fatalf("ReplaceView: %v", err)
+	}
+	if len(gateway.requests) != 1 {
+		t.Fatalf("mutation count = %d", len(gateway.requests))
+	}
+	var envelope map[string]any
+	if err := json.Unmarshal([]byte(gateway.requests[0].ContentEdit), &envelope); err != nil {
+		t.Fatal(err)
+	}
+	ref, _ := envelope["template_ref"].(map[string]any)
+	if ref == nil || ref["id"] != string(docsaccessrequest.TemplateID) || ref["version"] != docsaccessrequest.TemplateVersionV3 {
+		t.Fatalf("replacement frame lost template_ref: %#v", envelope["template_ref"])
+	}
+	provenance, _ := envelope["catalog_provenance"].(map[string]any)
+	if provenance == nil || provenance["principal_type"] != "internal_producer" ||
+		provenance["principal_id"] != "docs-notify" || provenance["space_id"] != "space-1" {
+		t.Fatalf("replacement frame lost catalog_provenance: %#v", envelope["catalog_provenance"])
+	}
+	// The stored provenance — not the SenderUID guess — is the edit principal.
+	want := cardtmpl.CatalogPrincipal{
+		Kind: cardtmpl.CatalogPrincipalInternalProducer, ID: "docs-notify", SpaceID: "space-1",
+	}
+	if len(catalog.renderAccess) == 0 || catalog.renderAccess[0].Principal != want {
+		t.Fatalf("render access = %+v, want principal %+v", catalog.renderAccess, want)
+	}
+	if catalog.renderAccess[0].Purpose != cardtmpl.CatalogPurposeHistoricalEdit {
+		t.Fatalf("render purpose = %v", catalog.renderAccess[0].Purpose)
+	}
+}
+
+func TestCardUpdaterReplaceViewRejectsStoredIdentityMismatch(t *testing.T) {
+	_, gateway, updater := v3UpdaterFixture(t, markedV3Snapshot(t, nil))
+	err := updater.ReplaceView(context.Background(), v3UpdateTarget(), docsaccessrequest.TemplateID,
+		"9.9.9", docsaccessrequest.StateApproved, approvedV3Fields(),
+		cardtmpl.BuildEnv{WebLoginURL: "https://web.example.com", Lang: "en", SpaceID: "space-1"})
+	if !errors.Is(err, cardtmpl.ErrUpdateInvalid) {
+		t.Fatalf("ReplaceView(version drift) error = %v, want ErrUpdateInvalid", err)
+	}
+	if len(gateway.requests) != 0 {
+		t.Fatalf("identity drift still mutated: %+v", gateway.requests)
+	}
+}
+
+func TestCardUpdaterReplaceViewRejectsMalformedStoredMarkers(t *testing.T) {
+	snapshot := markedV3Snapshot(t, func(frame map[string]any) {
+		delete(frame, "template_ref") // provenance without ref is never a server shape
+	})
+	_, gateway, updater := v3UpdaterFixture(t, snapshot)
+	err := updater.ReplaceView(context.Background(), v3UpdateTarget(), docsaccessrequest.TemplateID,
+		docsaccessrequest.TemplateVersionV3, docsaccessrequest.StateApproved, approvedV3Fields(),
+		cardtmpl.BuildEnv{WebLoginURL: "https://web.example.com", Lang: "en", SpaceID: "space-1"})
+	if !errors.Is(err, cardtmpl.ErrUpdateInvalid) {
+		t.Fatalf("ReplaceView(malformed markers) error = %v, want ErrUpdateInvalid", err)
+	}
+	if len(gateway.requests) != 0 {
+		t.Fatalf("malformed markers still mutated: %+v", gateway.requests)
+	}
+}
+
+func TestCardUpdaterReplaceViewRejectsCrossSpaceStoredProvenance(t *testing.T) {
+	snapshot := markedV3Snapshot(t, func(frame map[string]any) {
+		frame["catalog_provenance"].(map[string]any)["space_id"] = "space-2"
+	})
+	_, gateway, updater := v3UpdaterFixture(t, snapshot)
+	err := updater.ReplaceView(context.Background(), v3UpdateTarget(), docsaccessrequest.TemplateID,
+		docsaccessrequest.TemplateVersionV3, docsaccessrequest.StateApproved, approvedV3Fields(),
+		cardtmpl.BuildEnv{WebLoginURL: "https://web.example.com", Lang: "en", SpaceID: "space-1"})
+	if !errors.Is(err, cardtmpl.ErrUpdateInvalid) {
+		t.Fatalf("ReplaceView(cross-space provenance) error = %v, want ErrUpdateInvalid", err)
+	}
+	if len(gateway.requests) != 0 {
+		t.Fatalf("cross-space provenance still mutated: %+v", gateway.requests)
+	}
+}
+
+func TestCardUpdaterReplaceViewLegacyFrameStaysUnmarked(t *testing.T) {
+	snapshot := markedV3Snapshot(t, func(frame map[string]any) {
+		delete(frame, "template_ref")
+		delete(frame, "catalog_provenance")
+	})
+	catalog, gateway, updater := v3UpdaterFixture(t, snapshot)
+	if err := updater.ReplaceView(context.Background(), v3UpdateTarget(), docsaccessrequest.TemplateID,
+		docsaccessrequest.TemplateVersionV3, docsaccessrequest.StateApproved, approvedV3Fields(),
+		cardtmpl.BuildEnv{WebLoginURL: "https://web.example.com", Lang: "en", SpaceID: "space-1"}); err != nil {
+		t.Fatalf("ReplaceView(legacy frame): %v", err)
+	}
+	var envelope map[string]any
+	if err := json.Unmarshal([]byte(gateway.requests[0].ContentEdit), &envelope); err != nil {
+		t.Fatal(err)
+	}
+	if _, forged := envelope["template_ref"]; forged {
+		t.Fatalf("legacy replacement grew template_ref: %#v", envelope["template_ref"])
+	}
+	if _, forged := envelope["catalog_provenance"]; forged {
+		t.Fatalf("legacy replacement grew catalog_provenance: %#v", envelope["catalog_provenance"])
+	}
+	// Without stored provenance the legacy sender-derived principal remains.
+	want := cardtmpl.CatalogPrincipal{
+		Kind: cardtmpl.CatalogPrincipalInternalProducer, ID: "notification", SpaceID: "space-1",
+	}
+	if len(catalog.renderAccess) == 0 || catalog.renderAccess[0].Principal != want {
+		t.Fatalf("legacy render access = %+v, want principal %+v", catalog.renderAccess, want)
+	}
+}
+
+func TestCardUpdaterAppendValidatesStoredMarkers(t *testing.T) {
+	t.Run("markers preserved and provenance principal used", func(t *testing.T) {
+		catalog, gateway, updater := v3UpdaterFixture(t, markedV3Snapshot(t, nil))
+		target := v3UpdateTarget()
+		target.CardSeq = 5
+		if err := updater.Append(context.Background(), target, json.RawMessage(`{"type":"TextBlock","text":"after"}`)); err != nil {
+			t.Fatalf("Append: %v", err)
+		}
+		var envelope map[string]any
+		if err := json.Unmarshal([]byte(gateway.requests[0].ContentEdit), &envelope); err != nil {
+			t.Fatal(err)
+		}
+		provenance, _ := envelope["catalog_provenance"].(map[string]any)
+		if provenance == nil || provenance["principal_id"] != "docs-notify" {
+			t.Fatalf("append frame lost catalog_provenance: %#v", envelope["catalog_provenance"])
+		}
+		want := cardtmpl.CatalogPrincipal{
+			Kind: cardtmpl.CatalogPrincipalInternalProducer, ID: "docs-notify", SpaceID: "space-1",
+		}
+		if len(catalog.metaAccess) == 0 || catalog.metaAccess[0].Principal != want {
+			t.Fatalf("append meta access = %+v, want principal %+v", catalog.metaAccess, want)
+		}
+	})
+	t.Run("malformed markers fail closed", func(t *testing.T) {
+		snapshot := markedV3Snapshot(t, func(frame map[string]any) {
+			frame["catalog_provenance"] = "forged"
+		})
+		_, gateway, updater := v3UpdaterFixture(t, snapshot)
+		target := v3UpdateTarget()
+		target.CardSeq = 5
+		err := updater.Append(context.Background(), target, json.RawMessage(`{"type":"TextBlock","text":"after"}`))
+		if !errors.Is(err, cardtmpl.ErrUpdateInvalid) {
+			t.Fatalf("Append(malformed markers) error = %v, want ErrUpdateInvalid", err)
+		}
+		if len(gateway.requests) != 0 {
+			t.Fatalf("malformed markers still mutated: %+v", gateway.requests)
+		}
+	})
+}

--- a/pkg/errcode/card_template_catalog.go
+++ b/pkg/errcode/card_template_catalog.go
@@ -50,4 +50,9 @@ var (
 		HTTPStatus:     http.StatusConflict,
 		DefaultMessage: "The card template version is blocked.",
 	})
+	ErrCardTemplateCatalogGrantInvalid = register(codes.Code{
+		ID:             "err.server.card_template_catalog.grant_invalid",
+		HTTPStatus:     http.StatusBadRequest,
+		DefaultMessage: "The card template grant request is invalid.",
+	})
 )

--- a/pkg/i18n/locales/active.zh-CN.toml
+++ b/pkg/i18n/locales/active.zh-CN.toml
@@ -1319,6 +1319,9 @@ other = "卡片模板状态已变化，请刷新后重试。"
 ["err.server.card_template_catalog.blocked"]
 other = "该卡片模板版本已被阻断。"
 
+["err.server.card_template_catalog.grant_invalid"]
+other = "卡片模板授权请求无效。"
+
 ["err.server.bot_mention.in_progress"]
 other = "相同幂等键的请求仍在处理中，请稍后重试。"
 

--- a/pkg/space/middleware_localized.go
+++ b/pkg/space/middleware_localized.go
@@ -1,0 +1,94 @@
+package space
+
+// PR-C D5 — a localized twin of SpaceMiddleware.
+//
+// SpaceMiddleware answers with raw AbortWithStatusJSON and hardcoded Chinese
+// strings. Every endpoint mounted on it today has clients that depend on those
+// exact shapes, so it cannot be changed in place; but a new endpoint must not
+// inherit them either, because the rest of the card-catalog surface answers
+// through the i18n error envelope and a caller should not have to parse two
+// error formats from one request chain.
+//
+// This variant is deliberately a twin, not a refactor: identical membership
+// rule, identical cache keys and TTLs, identical "no space_id means skip".
+// Only the failure responses differ. Keeping the logic duplicated for one
+// release is cheaper than migrating every legacy route's wire contract as a
+// side effect of adding two read endpoints — and the duplication is small,
+// visible, and covered by tests on both sides.
+
+import (
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
+	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
+)
+
+// LocalizedSpaceMiddleware validates the requested Space the same way
+// SpaceMiddleware does, but reports failures through the localized envelope.
+//
+// An absent space_id is not an error: it means "no Space context", and the
+// handler downstream is responsible for showing only what is visible without
+// one. That is how a caller outside any Space still gets the public catalog.
+func LocalizedSpaceMiddleware(ctx *config.Context) wkhttp.HandlerFunc {
+	cache := NewRedisMembershipCache(ctx.GetRedisConn())
+	return localizedSpaceMiddleware(func(spaceID, uid string) (bool, error) {
+		return CheckMembership(ctx.DB(), spaceID, uid)
+	}, cache)
+}
+
+func localizedSpaceMiddleware(check MembershipChecker, cache MembershipCache) wkhttp.HandlerFunc {
+	return func(c *wkhttp.Context) {
+		spaceID := c.Query("space_id")
+		if spaceID == "" {
+			spaceID = c.GetHeader("X-Space-ID")
+		}
+		if spaceID == "" {
+			c.Next()
+			return
+		}
+
+		uid := c.GetLoginUID()
+		if uid == "" {
+			httperr.ResponseErrorL(c, errcode.ErrSharedAuthRequired, nil, nil)
+			c.Abort()
+			return
+		}
+
+		if isMember, found := cache.Get(spaceID, uid); found {
+			if !isMember {
+				httperr.ResponseErrorL(c, errcode.ErrSharedForbidden, nil, nil)
+				c.Abort()
+				return
+			}
+			c.Set("space_id", spaceID)
+			c.Next()
+			return
+		}
+
+		isMember, err := check(spaceID, uid)
+		if err != nil {
+			// A membership check that failed is not a membership check that
+			// said no: answering "forbidden" here would train callers to retry
+			// with a different Space, and answering "allowed" would be a
+			// tenant-isolation hole. Report the outage.
+			httperr.ResponseErrorL(c, errcode.ErrSharedInternal, nil, nil)
+			c.Abort()
+			return
+		}
+
+		ttl := cacheTTL
+		if !isMember {
+			ttl = negativeCacheTTL
+		}
+		cache.Set(spaceID, uid, isMember, ttl)
+
+		if !isMember {
+			httperr.ResponseErrorL(c, errcode.ErrSharedForbidden, nil, nil)
+			c.Abort()
+			return
+		}
+
+		c.Set("space_id", spaceID)
+		c.Next()
+	}
+}

--- a/pkg/space/middleware_localized_test.go
+++ b/pkg/space/middleware_localized_test.go
@@ -1,0 +1,211 @@
+package space
+
+// PR-C acceptance evidence: every Space-membership failure on the B1/B2 routes
+// answers through the localized error envelope, and it resolves the same Space
+// the legacy middleware would.
+//
+// This twin exists only because the card catalog's read endpoints must not
+// return the legacy raw-JSON shape while every other response they can produce
+// is localized. That makes two properties worth pinning: the failures really
+// are localized (otherwise the twin has no reason to exist), and the membership
+// rule really is unchanged (otherwise the twin is a second, divergent
+// definition of which Space a route resolves).
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
+	"github.com/gin-gonic/gin"
+)
+
+// setupLocalizedRouter mirrors setupRouter, so any behavioural difference
+// between the two middlewares shows up as a difference between the two suites
+// rather than being hidden by different harnesses.
+func setupLocalizedRouter(checker MembershipChecker) (*wkhttp.WKHttp, *InMemoryMembershipCache) {
+	return newLocalizedRouter(checker, true)
+}
+
+// newLocalizedRouter builds the real wkhttp router with the production error
+// renderer installed. A bare gin engine would fall back to wkhttp's default
+// renderer, which emits a message but no `error` object — so the whole point of
+// this middleware, the localized envelope, would go unasserted.
+func newLocalizedRouter(checker MembershipChecker, authenticated bool) (*wkhttp.WKHttp, *InMemoryMembershipCache) {
+	cache := NewInMemoryMembershipCache()
+	route := wkhttp.New()
+	route.SetErrorRenderer(i18n.NewErrorRenderer(i18n.NewLocalizer(i18n.DefaultLanguage)))
+	if authenticated {
+		route.Use(func(c *wkhttp.Context) {
+			c.Set("uid", "testuser")
+			c.Set("name", "Test")
+		})
+	}
+	route.Use(localizedSpaceMiddleware(checker, cache))
+	route.GET("/test", func(c *wkhttp.Context) {
+		spaceID, _ := c.Get("space_id")
+		c.JSON(http.StatusOK, gin.H{"space_id": spaceID})
+	})
+	return route, cache
+}
+
+// localizedEnvelope decodes the shape httperr.ResponseErrorL writes. A legacy
+// raw response has no `error` object, so its absence is the failure signal.
+type localizedEnvelope struct {
+	Status int    `json:"status"`
+	Msg    string `json:"msg"`
+	Error  *struct {
+		Code       string `json:"code"`
+		HTTPStatus int    `json:"http_status"`
+	} `json:"error"`
+}
+
+func requireLocalizedEnvelope(t *testing.T, recorder *httptest.ResponseRecorder, wantCode string) {
+	t.Helper()
+	var envelope localizedEnvelope
+	if err := json.Unmarshal(recorder.Body.Bytes(), &envelope); err != nil {
+		t.Fatalf("decode response: %v (body %s)", err, recorder.Body.String())
+	}
+	if envelope.Error == nil {
+		t.Fatalf("response is not on the localized envelope: %s", recorder.Body.String())
+	}
+	if envelope.Error.Code != wantCode {
+		t.Fatalf("error code = %q, want %q (body %s)",
+			envelope.Error.Code, wantCode, recorder.Body.String())
+	}
+	if envelope.Msg == "" {
+		t.Fatalf("localized envelope carried no message: %s", recorder.Body.String())
+	}
+}
+
+func TestLocalizedSpaceMiddlewareRejectsANonMemberOnTheEnvelope(t *testing.T) {
+	router, _ := setupLocalizedRouter(func(string, string) (bool, error) {
+		return false, nil
+	})
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/test?space_id=space-1", nil)
+	router.ServeHTTP(recorder, request)
+
+	if recorder.Code == http.StatusOK {
+		t.Fatalf("a non-member reached the handler: %s", recorder.Body.String())
+	}
+	requireLocalizedEnvelope(t, recorder, "err.shared.auth.forbidden")
+}
+
+func TestLocalizedSpaceMiddlewareReportsALookupFailureAsUnavailable(t *testing.T) {
+	router, _ := setupLocalizedRouter(func(string, string) (bool, error) {
+		return false, errors.New("db unavailable")
+	})
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/test?space_id=space-1", nil)
+	router.ServeHTTP(recorder, request)
+
+	if recorder.Code == http.StatusOK {
+		t.Fatalf("a failed membership check reached the handler: %s", recorder.Body.String())
+	}
+	// An outage must not be reported as a permission decision — the caller
+	// would stop retrying and an operator would look in the wrong place.
+	requireLocalizedEnvelope(t, recorder, "err.shared.internal")
+}
+
+func TestLocalizedSpaceMiddlewareRequiresALoginBeforeCheckingMembership(t *testing.T) {
+	checked := false
+	router, _ := newLocalizedRouter(func(string, string) (bool, error) {
+		checked = true
+		return true, nil
+	}, false)
+
+	recorder := httptest.NewRecorder()
+	router.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/test?space_id=space-1", nil))
+	if recorder.Code == http.StatusOK {
+		t.Fatalf("an unauthenticated caller reached the handler: %s", recorder.Body.String())
+	}
+	if checked {
+		t.Fatal("membership was checked for a caller with no uid")
+	}
+	requireLocalizedEnvelope(t, recorder, "err.shared.auth.required")
+}
+
+// The membership rule itself must be the legacy one, down to the header
+// fallback, the pass-through when no Space is claimed, and the cache write.
+// This is the half that keeps the twin from becoming a second definition.
+func TestLocalizedSpaceMiddlewareResolvesTheSameSpaceAsTheLegacyOne(t *testing.T) {
+	for _, target := range []struct {
+		name   string
+		url    string
+		header string
+	}{
+		{"query parameter", "/test?space_id=space-1", ""},
+		{"header fallback", "/test", "space-1"},
+	} {
+		t.Run(target.name, func(t *testing.T) {
+			router, cache := setupLocalizedRouter(func(spaceID, uid string) (bool, error) {
+				if spaceID != "space-1" || uid != "testuser" {
+					t.Fatalf("membership asked about %q/%q", spaceID, uid)
+				}
+				return true, nil
+			})
+			recorder := httptest.NewRecorder()
+			request := httptest.NewRequest(http.MethodGet, target.url, nil)
+			if target.header != "" {
+				request.Header.Set("X-Space-ID", target.header)
+			}
+			router.ServeHTTP(recorder, request)
+
+			if recorder.Code != http.StatusOK {
+				t.Fatalf("a member was rejected: %d %s", recorder.Code, recorder.Body.String())
+			}
+			var body struct {
+				SpaceID string `json:"space_id"`
+			}
+			if err := json.Unmarshal(recorder.Body.Bytes(), &body); err != nil {
+				t.Fatalf("decode: %v", err)
+			}
+			if body.SpaceID != "space-1" {
+				t.Fatalf("handler saw space_id = %q", body.SpaceID)
+			}
+			// The positive result is cached, exactly as the legacy middleware
+			// does — a divergence here would mean two different TTL regimes for
+			// one membership fact.
+			if isMember, found := cache.Get("space-1", "testuser"); !found || !isMember {
+				t.Fatalf("membership was not cached (found=%v member=%v)", found, isMember)
+			}
+		})
+	}
+
+	// No Space claimed at all is a pass-through, not a rejection: the catalog's
+	// read endpoints answer with the public catalog in that case.
+	router, _ := setupLocalizedRouter(func(string, string) (bool, error) {
+		t.Fatal("membership was checked without a Space claim")
+		return false, nil
+	})
+	recorder := httptest.NewRecorder()
+	router.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/test", nil))
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("a request claiming no Space was rejected: %d %s", recorder.Code, recorder.Body.String())
+	}
+}
+
+// A cached negative must reject without re-checking, the same way the legacy
+// middleware trusts its cache — otherwise the twin quietly doubles the DB load
+// of every rejected request.
+func TestLocalizedSpaceMiddlewareTrustsACachedNegative(t *testing.T) {
+	checks := 0
+	router, _ := setupLocalizedRouter(func(string, string) (bool, error) {
+		checks++
+		return false, nil
+	})
+	for i := 0; i < 3; i++ {
+		recorder := httptest.NewRecorder()
+		router.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/test?space_id=space-1", nil))
+		if recorder.Code == http.StatusOK {
+			t.Fatalf("attempt %d let a non-member through", i)
+		}
+	}
+	if checks != 1 {
+		t.Fatalf("membership was checked %d times, want one lookup plus two cache hits", checks)
+	}
+}

--- a/tools/i18nmarkers/server/active.en-US.toml
+++ b/tools/i18nmarkers/server/active.en-US.toml
@@ -273,6 +273,9 @@ other = "Card template activation is disabled."
 ["err.server.card_template_catalog.forbidden"]
 other = "Only a super admin can manage card templates."
 
+["err.server.card_template_catalog.grant_invalid"]
+other = "The card template grant request is invalid."
+
 ["err.server.card_template_catalog.request_invalid"]
 other = "The card template bundle is invalid."
 


### PR DESCRIPTION
## Summary

PR-A (#674) and PR-B (#675) built the machinery — immutable artifacts, a runtime catalog, an activation pointer with CAS activate/rollback/block. What they could not answer was **who may use any of it**: the production authorizer denied every dynamic business access because there was nothing to consult.

This PR supplies the answer and wires it through every consumer. It adds server-authored provenance so a stored frame's producer is a fact rather than a guess, a grant table with template-ID-level `discover|send|edit`, one-snapshot authorization, a request-scoped Bot capability manifest, visibility-aware discovery (B1/B2) with a bounded safe export, and one repeatable non-production pilot.

**Merging authorizes nothing new in the dynamic catalog.** Both runtime-catalog gates keep their `false` defaults, no commit changes them, and the non-production pilot does not authorize production activation. One slice does take effect on merge and is not behind either gate — the D3 provenance markers, which sit behind the pre-existing `OCTO_CARD_MESSAGE_ENABLED` switch. COMPREHENSION Q2 states exactly what changes there.

## Related Issue

Roadmap E3 PR-C, the third and final server PR of the runtime-catalog series after #674 (PR-A) and #675 (PR-B). No separate tracking issue.

## Linked Spec

- Contract of record: [`.octospec/tasks/cardtmpl-runtime-catalog-grants-discovery/brief.md`](.octospec/tasks/cardtmpl-runtime-catalog-grants-discovery/brief.md) — the acceptance matrix there names, per property, the test that would fail if it broke.
- Execution ledger and pre-merge prerequisites: [`HANDOFF.md`](.octospec/tasks/cardtmpl-runtime-catalog-grants-discovery/HANDOFF.md)
- Journal: [`.octospec/journal/shared/cardtmpl-runtime-catalog-grants-discovery.md`](.octospec/journal/shared/cardtmpl-runtime-catalog-grants-discovery.md)

## Changes

- **Trusted stored provenance** — a dynamic card carries a server-authored `catalog_provenance` marker beside the existing `template_ref`. Historical edit and action-context read the producer from the frame instead of inferring it from `msg.FromUID`. Every raw ingress (Bot, robot, user, incoming webhook) rejects both keys.
- **Grants** — `card_template_grant` with `discover|send|edit`, principals `bot|internal_producer|space`, exact-over-global precedence, revision CAS and same-transaction audit. Revoke writes a tombstone rather than deleting, so revoke→recreate cannot replay an old revision. DB CHECK constraints enforce the D2 shapes, so an invalid grant cannot be written even by a caller that skips the validator.
- **One-snapshot authorization** — activation pointer, claim/artifact/block row and the principal's exact + global grant rows are read in a single `REPEATABLE READ` transaction. That transaction is the linearization point: a request whose snapshot opened before a revoke committed finishes; one that opens after is already denied. There is no read-pointer-then-check-grant path left for a third outcome to leak through.
- **Bot capability + send merge** — the manifest is resolved per authenticated Bot and Space rather than being a process constant, and it goes through the same resolver the send path uses. A send always re-resolves; a manifest is a hint, never a permit. An active dynamic version shadows the static card of the same ID, and an ungranted, blocked or unreadable one makes the whole template ID unsendable rather than reverting to static.
- **Discovery and export (B1/B2)** — visibility, block state and the caller's discover grant are applied *inside* the SQL predicate, so they settle before `LIMIT`; post-filtering would return short pages and turn the dropped-row count into an enumeration oracle. Unknown, invisible and blocked are one indistinguishable not-found. The B2 projection is immutable, built at registration/compile time, capped at 2 MiB, and carries samples only when a manifest opts in by name.
- **Localized Space middleware** — a twin of `SpaceMiddleware` with the identical membership rule, cache keys and TTLs; only the failure responses move to the i18n envelope, so the catalog's read endpoints never mix a localized body with a legacy raw one.
- **Pilot** — the full D7 loop against real MySQL on a dedicated non-production template ID, proving publish ≠ activate ≠ grant, dynamic-over-static shadowing, private discovery, historical pinning across a rollback, and immediate denial after revoke.
- **Docs** — `docs/platform-card-base.md` §9/§10, `docs/card-protocol.md` §1/§4 and the runtime-catalog runbook reconciled to what shipped.

## Testing

```bash
go build ./...
go vet ./...
go test ./modules/card_template_catalog/ ./modules/bot_api/ ./modules/notify/ ./modules/message/ -count=1
go test ./pkg/... ./internal/... -count=1
go test -race ./pkg/cardtmpl/... ./pkg/cardmsg/... ./pkg/space/... ./internal/carddispatch/... ./internal/cardactiondispatch/...
golangci-lint run ./modules/card_template_catalog/... ./modules/bot_api/... ./pkg/cardtmpl/... ./pkg/space/... ./modules/message/... ./modules/notify/...
make i18n-extract-check && make i18n-lint
```

All green against MySQL 8.0 + Redis + WuKongIM. `golangci-lint` reports 0 issues. Coverage on the changed core packages: `modules/card_template_catalog` 80.6%, `pkg/cardtmpl` 81.2%, `pkg/cardmsg` 85.1%; the new `localizedSpaceMiddleware` is 91.4%.

Note for reviewers running this locally: each package needs a **fresh** `test` schema — module sets differ, so two packages sharing one make sql-migrate report "unknown migration in database" — and `modules/robot` needs a 32-byte `OCTO_MASTER_KEY`. Create it with the collation CI uses (`CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci`); the MySQL 8.0 default `utf8mb4_0900_ai_ci` differs in PAD behaviour.

- [x] Unit tests added/updated
- [x] Manually verified

**Two acceptance items stay open on purpose**, recorded in HANDOFF as pre-merge operational prerequisites because neither is reachable from a single container:

1. Multi-replica cold/hot cache convergence after grant/revoke. Single-process tests cover the linearization point inside one snapshot; they cannot cover the cache-invalidation window between replicas, which is the only place a revoked grant can still be honoured.
2. The pilot against the dedicated non-production deployment with `OCTO_PILOT_CATALOG_DSN` set, so the exact-version preflight interrogates real claims rather than a per-test database.

## COMPREHENSION

**1. What does this change actually do to the load-bearing path?**

It makes authorization for dynamic card templates a real decision, and makes that decision atomic. Before this PR the production dynamic authorizer had no grant store, so it denied everything and the dynamic path was inert. Now three facts an authorization depends on — is this version active, is it blocked, does this principal hold the permission — are read in one `REPEATABLE READ` transaction against the primary, behind a store interface the caller cannot pull apart. Previously equivalent logic would have been three independent reads assembled from three points in time.

It also changes what the send and edit paths *trust*. A frame's producer identity used to be inferred from `msg.FromUID`; it is now a server-authored marker on the frame, validated against the stored sender and the card's authoritative origin Space before it becomes authorization input. The Bot capability manifest moved from a process constant to a per-Bot, per-Space resolution, because two Bots in one deployment can legitimately be granted different templates.

**2. What could break because of it (dependents + failure mode)?**

The fail-closed rule is the sharp edge, and it is deliberate: once a template ID has an active dynamic version, an ungranted / blocked / unreadable outcome makes **the whole ID unsendable** and does not revert to the static card of the same ID. Falling back would send materially different content under a name the producer believes it has replaced. Operational consequence: configure the grant **before** activating, or there is a window in which the previously working static version also stops.

`ai.reasoning-process` is currently the wrong shape for this model and should stay static for now. Its producers are thousands of user-created BotFather bots, and `principal_id` is an exact identity with no wildcard — activating that ID dynamically would require one grant row per bot, and the breakage would be uneven (single-Space bots cut off, multi-Space bots still serving the static version, because the grant Space resolver refuses ambiguity). Extending D2 with a principal tier below the exact one is a contract change and belongs in its own PR. This is recorded in the journal follow-ups.

The gated body is gated. With `OCTO_CARD_RUNTIME_CATALOG_CONTROL_ENABLED` and `_NEW_SEND_ENABLED` both false — their defaults, unchanged by this PR — grants, one-snapshot authorization, discovery/export and the dynamic send/edit paths are inert, and the static Bot/profile/send/edit/action paths acquire no new DB dependency, including during a database outage.

**One slice is not behind either of those gates, and this is the honest statement of it.** The D3 provenance markers are authored in `internal/carddispatch`, gated only on the pre-existing `OCTO_CARD_MESSAGE_ENABLED` master switch. Wherever the card feature is already on, merging this PR changes that path in two ways:

1. **Stored bytes change.** Every internal-producer card whose document carries `metadata.octo.template` gains top-level `template_ref` and `catalog_provenance`. Readers that ignore unknown keys are unaffected, but the persisted frame is not byte-identical to before.
2. **A send that used to succeed can now fail.** The authoring boundary validates the marker before stamping it and refuses the send if it would be invalid. In practice that means a `space_id` with surrounding whitespace, which the three card ingresses (`modules/notify/card.go`, `approval_card.go`) pass through verbatim after only an emptiness check. This is deliberate — the alternative is delivering a card whose markers no reader accepts, which is permanently uneditable — but "behaves exactly as before" is not true for that input, and callers sending an untrimmed Space will see the failure.

Card mutation is affected on the same switch: a replacement frame may no longer drop the markers a stored frame carries. Every in-tree caller either preserves them or now renders through the Registry; the guard exists so a future one cannot silently downgrade a marked card.

**3. How do you know it works (specific test/repro/trace)?**

The acceptance matrix in the brief names, for each of its properties, the test that would fail if the property broke, and says plainly which are still missing. All cited test names were script-verified to exist, so a rename cannot leave the matrix pointing at nothing.

The load-bearing ones:

- `TestStoreLoadAuthorizationSnapshotIsTheLinearizationPointRealMySQL` holds a snapshot open, revokes from another connection, and proves the open snapshot is unaffected while the next one is already denied.
- `TestListDiscoverableFiltersBeforePagingRealMySQL` walks the whole listing at three page sizes over interleaved public/private/granted/blocked/tombstoned rows. Removing the visibility predicate from the SQL makes it fail — verified by mutation.
- `TestBotTemplateSendRefFollowsTheShadowMatrix` covers all eleven rows of the D6 static/dynamic decision table.
- `TestGrantsDoNotLeakBetweenBotsRealMySQL` grants one Bot and asks as another on the same template in the same Space.
- `TestRuntimeCatalogHotCacheCannotOutliveARevoke` proves a warm compiled artifact answers a revoke from a fresh snapshot without reloading the bundle.
- On the ungated slice above: `TestSendRefusesToAuthorAMarkerItsReadersWouldReject` (a marker cannot be authored invalid), `TestCardMutatorRefusesToDropStoredCatalogMarkers` (and cannot be dropped by a replacement), and `TestDocsActionFinalizerRoutesEveryStateThroughTheRegistry` (every finalizer state, not an allowlist of them).

Successive review passes ran over the same six slices. They were not redundant: the live database exposed two defects no amount of reading would have, and several passes found regressions introduced by the *previous* pass's fixes. The recurring cause was a single-point fix shipped without a round-trip test; every fix in the later passes now has a test that reproduces the reported failure with the fix reverted, mutation-checked so it cannot pass for the wrong reason. The journal records this in full, including one review finding whose stated mechanism turned out to be unreachable — the fix drafted for it was deleted rather than shipped as dead code.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] PR description is in English
- [x] Added tests for my changes
- [x] Updated documentation
- [x] Followed commit message conventions (Conventional Commits)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1YA6kPCqbvC1ShXoMYMnq)_