### PR TITLE
feat(robot): add a generic per-bot config store behind the card switches

### DIFF
--- a/.octospec/journal/shared/bot-setting-store.md
+++ b/.octospec/journal/shared/bot-setting-store.md
@@ -1,0 +1,110 @@
+---
+type: Journal
+title: "Journal: bot-setting-store"
+description: Add a generic per-bot config store (bot_setting) with a bot → system_setting → code-default resolution chain, and put the four bot-level card switches on it.
+tags: ["bot-api", "robot", "config", "wire-contract", "auth", "rate-limit", "testing"]
+timestamp: 2026-08-06T16:20:00+08:00
+# --- octospec extension fields ---
+task: bot-setting-store
+upstream: "openclaw-channel-octo 推理进度卡策略请求"
+source: user
+---
+
+# Journal: bot-setting-store
+
+## What was done
+
+- Added `bot_setting`, a sparse `(robot_id, key_name)` override table, plus a
+  registry in `modules/robot/bot_setting.go` that is simultaneously the write
+  whitelist, the owner-facing catalog, and the resolution chain. A new config
+  key is a registry entry, not a migration.
+- Resolution: bot override → `system_setting` deployment default → code default.
+  Deleting an override falls back to the layer underneath rather than latching
+  false; the read endpoint returns `value` / `effective_value` / `source`
+  separately so a restore-default control can tell "I chose off" from "I never
+  set it".
+- Owner endpoints on `/v1/robot/:robot_id/settings` (GET catalog + echo, PUT
+  batch write, DELETE one override), guarded by `assertRobotOwner` and mounting
+  `SharedUIDRateLimiter` per route.
+- First consumer: four card switches. `bot.card_enabled` is derived from
+  `cardmsg.BotEnabled()` and rejects writes; `display` / `interaction` /
+  `reasoning` are owner-editable and default true.
+- `GET /v1/bot/card/profile` gained one additive `config` object carrying the
+  already-AND-ed values, with the ref invariants asserted in tests.
+  `sendMessage` enforces the same config independently.
+- Writes enqueue a valueless typed bot event so an adapter drops its cached
+  profile immediately instead of waiting out a TTL.
+
+## Decisions worth keeping
+
+**The precedent that looked right was the wrong one.** `bot_mention_pref` is a
+sparse table, so it reads as "this repo prefers sparse tables for bot config".
+It is not: its dimension is `(robot_id, group_no)`, and a `robot` column cannot
+express two dimensions — the table was forced, not chosen. The actual precedent
+for *one-dimensional* bot config is a column on `robot` (`auto_approve`,
+`inline_on`, `placeholder`, `bot_commands`). So this task replaces
+"keep adding columns", and borrows only mention_pref's *surrounding* shape:
+owner guard, delete-means-fall-back, post-write cache invalidation, and the
+owner-writes / adapter-reads split across two modules.
+
+**A derived key must not be storable.** `card_enabled` reflects the deployment
+env chain. Had it been a normal stored key, the DB could hold `true` while the
+env holds it off — the manifest would advertise a capability the send path
+refuses, breaking the "manifest agrees with the send gate" invariant
+`pkg/cardmsg` already established. Making it read-only and rejecting writes
+removes the state rather than documenting it.
+
+**Sub-switches default true because the master switch is already fail-closed.**
+The upstream asked for a conservative default. `OCTO_CARD_MESSAGE_ENABLED`
+defaults to false, so with sub-switches at true the effective outcome is still
+"no cards" until an operator opts in. Defaulting them false as well would have
+made operators opt in twice for no extra safety.
+
+**Three switches, not a profile filter.** The upstream proposed clipping
+`profiles` per bot (octo/v1 = display, octo/v2 = interaction). Two reasons not
+to: `pkg/cardmsg/profiles.go` documents `acceptedProfiles` as the single
+authority shared by the validator and the D12 manifest, and clipping breaks that
+by design; and the reasoning card spans both profiles (active/error are
+`octo/v2`, result is `octo/v1`), so a profile-shaped switch would leave it with
+only its terminal state or only its progress states. The three switches are
+orthogonal: display/interaction gate the raw-card path, reasoning gates the
+template path.
+
+**No per-bot cache, on purpose.** Reads go to MySQL every time, so an owner's
+change on one replica is visible on every other immediately. A process-local
+cache would trade that for TTL drift, and the invalidation event reaches only
+the bot, not sibling replicas — Redis pub/sub would be required to close it.
+Cost of the no-cache choice: one indexed single-row read per card *creation*
+(non-card sends never enter the gate; streaming updates go through
+`message/edit`, which is deliberately ungated so an in-flight card can still
+reach its terminal state).
+
+## What went wrong on the way
+
+1. **A hot-path global mutex, found only because performance was questioned.**
+   The resolver called `common.EnsureSystemSettings` per request, and that
+   function takes a process-wide `sync.Mutex` on *every* call — on the card send
+   path. `SystemSettings` is explicitly built so readers never take a lock
+   (atomic.Pointer snapshot); calling the constructor-shaped accessor per request
+   silently undid that. Fixed by resolving the singleton once at construction and
+   holding it on `Robot` / `Service`.
+
+2. **Test isolation broke under `-shuffle`, and the cause is a production
+   property.** `EnsureSystemSettings` is a process-wide singleton whose in-memory
+   snapshot `CleanAllTables` does not touch. A case that wrote a deployment
+   default leaked it into every later case in the binary, surfacing as
+   `source="global"` where `"default"` was expected. Fixed by forcing `Reload()`
+   in setup. Same family as the already-documented "CleanAllTables does not clear
+   Redis rate-limit buckets" — staged as a learning.
+
+3. **The contract guard did its job.** `TestBotCardProfile_AdditiveContractFieldSet`
+   freezes the profile's top-level field set, so adding `config` failed it. The
+   fix is to extend the frozen set — and `config`'s own five sub-fields were
+   frozen the same way `limits` already is.
+
+## Verification
+
+`go build ./...`, `go vet`, `make i18n-extract-check`, `make i18n-lint`, both
+modules' `NoLegacyResponseError` source guards, and `-race -shuffle=on` on
+`modules/robot` and `modules/bot_api` against MySQL 8 + Redis + WuKongIM
+v2.2.4, run per-package with the CI drop/create + FLUSHALL discipline.

--- a/.octospec/journal/shared/bot-setting-store.md
+++ b/.octospec/journal/shared/bot-setting-store.md
@@ -351,6 +351,25 @@ intended, because a per-party test passes fine while they disagree.
   Remaining on that handler: no `payloadIsVail`/`Validate` for non-card payloads,
   i.e. it is still the one ingress without shape validation. Deliberate — see the
   brief for why refusing cards beats rebuilding the pipeline here.
+  **Order is part of the fix, not cosmetics.** Identity → channel → content, the
+  same rule the settings endpoints landed on after three rounds ("answering about
+  content before establishing authorization contradicts the endpoint's own 403").
+  The first draft had the card gate first, which meant a non-member sending a card
+  got `content_invalid` instead of `channel_send_forbidden`. Caught in self-review
+  by diffing against `sendMessage`, where `allowSendToChannel` precedes
+  `payloadIsVail`. Pinned by `TestStreamStart_ChannelCheckPrecedesTheCardGate` —
+  which is the only case that fails when the two are swapped, because every other
+  case trips exactly one gate and stays green either way.
+- **`streamEnd` has no caller binding, and one review's description of it is
+  wrong.** An automated review suggested a stream's final content could smuggle a
+  card via `streamEnd`. It cannot: `config.MessageStreamEndReq` is
+  `{StreamNo, ChannelID, ChannelType}` with no payload field, so there is nothing
+  there to validate. Recorded because inheriting that claim would send the next
+  person hunting for a gate with nothing to gate. The *real* gap on that handler
+  is different and untouched: `StreamNo` is not bound to the caller, so any
+  authenticated bot can end any stream whose number it can name. Pre-existing,
+  byte-identical to the merge-base, out of scope here — and since no issue was
+  opened by instruction, this paragraph is its only record.
 - **`TestBotMessageEdit_StillReachesTerminalStateWhenReasoningOff` is inert.**
   It injects a `stubCardConfig` with every sub-switch off, but
   `botMessageEditViaRegistry` never calls `resolveBotCardConfig`, so the stub

--- a/.octospec/journal/shared/bot-setting-store.md
+++ b/.octospec/journal/shared/bot-setting-store.md
@@ -387,6 +387,33 @@ intended, because a per-party test passes fine while they disagree.
   does mean `sendMessage` and `typing` gain subarea support as a side effect,
   which is a behaviour change on two endpoints this task does not otherwise own —
   recorded here rather than left to be discovered.
+
+  **And the first version of that grant used the wrong membership predicate —
+  the fourth instance of this branch's signature mistake.** It called
+  `ExistMember`, which filters `is_deleted=0` only and therefore returns true for
+  a blacklisted member. The strict variant `ExistMemberActive` also requires
+  `status=Normal`, and its doc comment in `group/service.go` names this exact
+  situation: *"子区(CommunityTopic)读/发门禁用它替代 ExistMember，避免被拉黑用户越权
+  读/发（YUJ-4185 CR 整改）"*. Every other subarea gate in the tree — `thread`,
+  `message`, `messages_search`, `bot_api/threads.go` — uses the strict one. The
+  new line was the only subarea gate in the repository on the loose predicate,
+  and it mattered more here than elsewhere: robot ingresses send server-side and
+  bypass the IM datasource, so they never receive `thread`'s subarea blacklist
+  inheritance and this local check is the only defence.
+
+  The lesson is the one already written three sections above, applied to the
+  wrong noun. "Enumerate everyone who implements the shared rule" was followed
+  for `allowSendToChannel` — its three *callers* were all found. It was not
+  followed for "how does this repo decide subarea membership", whose
+  *implementers* were never enumerated. **The unit of enumeration is the
+  decision, not the function**: introducing a new authorization grant means
+  finding every existing grant of the same kind and matching its predicate,
+  before writing the call.
+
+  The test that pins it holds `member=true, activeMember=false` — precisely a
+  blacklisted row — so it fails if the predicate is swapped back, and asserts on
+  *which method was called* rather than only on the verdict, because a stub with
+  one shared result would answer both identically and stay green.
 - **`streamEnd` has no caller binding, and one review's description of it is
   wrong.** An automated review suggested a stream's final content could smuggle a
   card via `streamEnd`. It cannot: `config.MessageStreamEndReq` is

--- a/.octospec/journal/shared/bot-setting-store.md
+++ b/.octospec/journal/shared/bot-setting-store.md
@@ -360,6 +360,33 @@ intended, because a per-party test passes fine while they disagree.
   `payloadIsVail`. Pinned by `TestStreamStart_ChannelCheckPrecedesTheCardGate` —
   which is the only case that fails when the two are swapped, because every other
   case trips exactly one gate and stays green either way.
+- **Adding the channel gate exposed that `allowSendToChannel` never handled
+  subareas — in three handlers, not one.** Review caught that the new gate turned
+  community-topic (`ChannelType` 5) streaming into a 403, because
+  `allowSendToChannel` recognised only Person and Group and fell through to
+  `return false`. Real regression, and it was unpinned: the stream tests covered
+  only types 1 and 2.
+
+  The supporting argument was that `streamStart`'s community-topic disband guard
+  had become unreachable — a guard written for a type the function now refuses.
+  True, but checking the other call sites changed the conclusion: `sendMessage`
+  (check at :746, dead subarea branch at :761) and `typing` (:679 / :694) carry
+  the *identical* unreachable branch on `main` today. So subareas were already
+  refused on both of those, and `streamStart` was not the victim of a new
+  narrowing — it was the one path where the missing check had accidentally left
+  subareas working. Three guards that resolve a parent group, all dead, is not
+  three mistakes; it is one missing case in the shared predicate.
+
+  Fixed there rather than in `streamStart`: `allowSendToChannel` now resolves the
+  parent group for type 5 and checks membership on it, which is where subarea
+  membership actually lives. Deliberately **not** a local branch in `streamStart`
+  — that would have been a fourth private copy of the channel rule, the exact
+  drift this task spent three rounds eliminating elsewhere. The change is strictly
+  permissive (type 5: always-deny → membership-checked), so nothing that works
+  today stops working; only previously-403'd subarea requests are affected. It
+  does mean `sendMessage` and `typing` gain subarea support as a side effect,
+  which is a behaviour change on two endpoints this task does not otherwise own —
+  recorded here rather than left to be discovered.
 - **`streamEnd` has no caller binding, and one review's description of it is
   wrong.** An automated review suggested a stream's final content could smuggle a
   card via `streamEnd`. It cannot: `config.MessageStreamEndReq` is

--- a/.octospec/journal/shared/bot-setting-store.md
+++ b/.octospec/journal/shared/bot-setting-store.md
@@ -245,6 +245,26 @@ The structural fix is delegation, not duplication: the getters now call
 `SettingBoolOK`, so there is one lexer for one column and the next change cannot
 land on only one side.
 
+**And the commit that said so was still wrong.** Review found a second pair of
+lexers inside `bot_setting.go` itself — the file that commit edited, under a
+title claiming the class was closed. `normalizeBotSettingBool` (write) trimmed
+and accepted `True`; `parseBotSettingBool` (read) did neither. A hand-written
+`value='True'` was therefore read as "malformed, ignored, fell back" even though
+the write endpoint would have accepted that exact literal. Unreachable through
+the API — writes always normalise to `"1"`/`"0"` — but the same class, one layer
+down, found only because a reviewer read the file the fix touched rather than the
+fix's diff.
+
+Both now share one lexer by delegation, and the rule is the same one
+`SettingBoolOK` uses: trim, case-fold, vocabulary `{1,0,true,false}`. The
+enumerate-the-variants style (`"true", "TRUE", "True"`) was itself the cause —
+omitting a variant produces no error, only a literal that silently stops working
+— so all three sites now fold instead of listing.
+
+The invariant that would have caught it — the write-accepted set and the
+read-accepted set are the same set — had no test at all until now. Three rounds
+of tests asserted what each function does; none asserted that the two agree.
+
 Two smaller ones fixed alongside, both also mine from round 3 or earlier:
 
 - The new malformed-override warning fired on `''`, which
@@ -258,6 +278,14 @@ Two smaller ones fixed alongside, both also mine from round 3 or earlier:
   journal explicitly warns reopens the display bypass if acted on. The brief was
   amended at the time; the comments were not. Both now state display-as-floor and
   point at the shared predicates.
+
+**The generalisable rule, after three instances of it.** Round 1 was a sibling
+path (the raw edit branch), round 2 a sibling consumer (the manifest), rounds 3
+and 6 a sibling *function* reading the same column. Every one was found by
+looking at the neighbourhood rather than the change. **Fixing a shared rule means
+enumerating everyone who implements it, not everyone the diff touches** — and the
+test that proves it must assert the parties *agree*, not that each behaves as
+intended, because a per-party test passes fine while they disagree.
 
 ## Known gaps at merge
 
@@ -286,6 +314,29 @@ Two smaller ones fixed alongside, both also mine from round 3 or earlier:
   contradiction relocated to the owner surface. Needs an explicit decision
   (dominate `effective_value`, or document this as the pre-master-switch tier),
   not another round of implicit.
+- **The "three card producer ingresses" claim may be wrong, and this branch's
+  design rests on it.** `POST /v1/robots/:robot_id/:app_key/stream/start`
+  (`modules/robot/api.go:482`) binds a request whose `Payload` is a raw `[]byte`
+  and hands it straight to `IMStreamStart`. No `payloadIsVail`, no
+  `IsCardPayload`, no `cardmsg.Validate`, no `BotEnabled()`, no per-bot gate —
+  and, unlike the sibling `typing` handler, no `allowSendToChannel` and no
+  override of `req.FromUID` with the authenticated `robot_id` from the path. So
+  on its face an authenticated bot can start a stream carrying a `type:17`
+  payload under an arbitrary `from_uid`. **Entirely pre-existing; this diff does
+  not touch that handler.** What decides whether it is a stale comment or a real
+  bypass is one fact not answerable from this repo: do the clients render a
+  stream payload as a card? Recorded here rather than as an issue by explicit
+  instruction — which means this paragraph is the only record, so whoever picks
+  up the follow-ups should start here. The claim it undermines is asserted in
+  both `payloadIsVail`'s comment and the brief's load-bearing list.
+- **`TestBotMessageEdit_StillReachesTerminalStateWhenReasoningOff` is inert.**
+  It injects a `stubCardConfig` with every sub-switch off, but
+  `botMessageEditViaRegistry` never calls `resolveBotCardConfig`, so the stub
+  changes nothing and the test passes identically with all switches on. It pins
+  none of the condition in its own name. Second instance of this shape on the
+  branch (the first was the atomicity test in round 1), and the tell is the same
+  both times: **the test never fails when the thing it names is broken, because
+  the thing it names is not on the path it drives.**
 - `TestListGroups_CarriesGroupAllowNoMention` (`mention_pref_test.go`, unrelated
   to this task) panics in the local sandbox because the endpoint returns an empty
   list. It reproduces identically on the pre-change HEAD and is green in CI, so it

--- a/.octospec/journal/shared/bot-setting-store.md
+++ b/.octospec/journal/shared/bot-setting-store.md
@@ -299,6 +299,33 @@ enumerating everyone who implements it, not everyone the diff touches** — and 
 test that proves it must assert the parties *agree*, not that each behaves as
 intended, because a per-party test passes fine while they disagree.
 
+## Split out deliberately, not forgotten
+
+Review recommended landing the config store and taking the authorization work as
+its own change, reviewed as the authorization change it is. Agreed — the last
+rounds were spent on `stream/start` and `allowSendToChannel`, and the one P1 came
+out of that expansion rather than out of the store. What stays behind, with the
+reason it is safe to defer:
+
+- **`stream/end` has no ownership check on `StreamNo`.** Bot A can observe Bot B's
+  stream number and end B's stream — a denial of service against a peer. Byte-
+  identical to the merge-base and untouched here. Note that the rebuttal recorded
+  above (a card cannot be smuggled through `streamEnd`, since
+  `MessageStreamEndReq` has no payload field) answers only the *card* question;
+  it does not clear the endpoint on ownership, and should not be read as if it
+  did.
+- **The `ChannelTypeGroup` branch of `allowSendToChannel` still uses
+  `ExistMember`.** So a blacklisted bot can post to a parent group while being
+  correctly refused from its subareas. That asymmetry mirrors the repo's existing
+  one and is now documented at the call site, but it deserves a decision rather
+  than inheritance.
+- **App Bots are not covered by this store at all.** They live in `app_bot` with
+  no `robot` row, and `assertRobotOwner` reads `robot` — so
+  `PUT /v1/robot/<appBotUID>/settings` can only ever 404 and no override is
+  expressible for them. Not a regression (the three editable switches default
+  true, i.e. pre-PR behaviour) and the global `system_setting` tier still applies,
+  but `BotCardConfig`'s doc comment reads as though it covers every bot.
+
 ## Known gaps at merge
 
 - `SettingBoolOK` remains a **best-effort** tier, as its doc comment says: a
@@ -414,6 +441,29 @@ intended, because a per-party test passes fine while they disagree.
   blacklisted row — so it fails if the predicate is swapped back, and asserts on
   *which method was called* rather than only on the verdict, because a stub with
   one shared result would answer both identically and stay green.
+
+  **Then the same thing again, one line over.** The next round found
+  `resolveParentGroupNo` — the parser feeding that very gate — splitting with
+  `SplitN(channelID, "____", 2)`, while the repo's `thread.ParseChannelID` uses
+  `Split`, requires exactly two parts, and requires both non-empty. Harmless while
+  it only fed disband guards; not harmless once it decides *which group's
+  membership is checked*. `groupA____topic____extra` and `groupA____` both yielded
+  `parts[0] == "groupA"`, passed membership, and were dispatched under the
+  non-canonical id — which every downstream reader then rejected via
+  `ParseChannelID`, so the gate and the delivery target disagreed about what a
+  subarea id even is. Now delegates to `ParseChannelID`.
+
+  Deliberately **not** also applying `thread.IsValidShortID` (15–20 digits): the
+  property this function owes is "the group whose membership was checked is the
+  group the message reaches", and exactly-two-non-empty-parts is what makes
+  `parts[0]` unambiguous. The short-id value domain is a separate question whose
+  blast radius could not be verified here.
+
+  Two instances of one mistake in adjacent lines, found in consecutive rounds, is
+  the strongest evidence on this branch for the rule stated above: **the unit of
+  enumeration is the decision, not the function.** Both were the robot module
+  re-implementing a repo-wide judgement more loosely than every other caller. The
+  fix in both cases was to delete the local implementation, not to tighten it.
 - **`streamEnd` has no caller binding, and one review's description of it is
   wrong.** An automated review suggested a stream's final content could smuggle a
   card via `streamEnd`. It cannot: `config.MessageStreamEndReq` is

--- a/.octospec/journal/shared/bot-setting-store.md
+++ b/.octospec/journal/shared/bot-setting-store.md
@@ -207,13 +207,57 @@ each one's failure direction is "a control silently does not apply":
   code default on top, and for all three card switches that default is `true` —
   so `False` being read as "unconfigured" left on exactly the capability the
   operator was trying to disable, silently. The *vocabulary* deliberately stays
-  identical to `parseSettingBool`'s; only the lexing relaxed, so one column cannot
-  come to mean different things to two readers of the same table. Pinned by a test
-  that asserts on/off/yes/no are rejected by **both** readers.
+  identical to `parseSettingBool`'s; only the lexing relaxed. **This fix was
+  itself half-done and shipped a regression for one round — see below.**
 - **A malformed stored override now warns** instead of falling back mutely, once
   per `(robot, key)`. The dedupe is not polish: resolution runs on every card send
   and every profile read, and a dirty row is persistent state, so an un-deduped
   warning is a log flood — which is the same outcome as no log at all.
+
+## The round-3 fix that broke the thing it was fixing
+
+Worth its own section because it is the sharpest lesson on this branch, and
+because it was caught by review rather than by me.
+
+`SettingBoolOK` was relaxed to trim and case-fold. The three
+`BotCard*EnabledDefault()` getters — the *other* reader of the very same
+`botcard` rows, feeding the admin console's `effective_value` — were left on
+`getBool` → `parseSettingBool`, which still matched exactly. So after the fix:
+
+| reader | `botcard.display_enabled = "False"` |
+|---|---|
+| per-bot resolver (`SettingBoolOK`) | explicitly **false** |
+| admin console (`parseSettingBool`) | unparseable → fallback → **true** |
+
+An operator would see "display cards on" in the console while every bot resolved
+it off. The comment I wrote directly above the fix says one column must not come
+to mean different things to two readers — and the fix made that false in exactly
+the dimension it touched.
+
+The test missed it for a reason worth naming: it pinned the **vocabulary** axis
+(`on`/`off`/`yes`/`no` rejected by both readers) because that was the axis I had
+been thinking about while writing the fix. The axis I *changed* — lexing — went
+unpinned. **A test written from the same mental model as the fix inherits the
+fix's blind spot.** The replacement asserts the two readers agree literal-by-
+literal, including whitespace and case forms, rather than restating the intent.
+
+The structural fix is delegation, not duplication: the getters now call
+`SettingBoolOK`, so there is one lexer for one column and the next change cannot
+land on only one side.
+
+Two smaller ones fixed alongside, both also mine from round 3 or earlier:
+
+- The new malformed-override warning fired on `''`, which
+  `sql/20260806000001_bot_setting.sql` itself defines as "not configured" — so a
+  perfectly legal empty row was logged as corrupt. Empty values are now dropped
+  in `queryBotSettingOverrides`, matching how `system_settings.lookup` already
+  treats `""`. Fallback behaviour is identical either way; the difference is
+  whether the log tells the truth, which is the entire point of that line.
+- Two code comments (`bot_setting.go`, `system_setting_schema.go`) still said the
+  three switches were "三者正交" — the claim round 1 overturned, and the one this
+  journal explicitly warns reopens the display bypass if acted on. The brief was
+  amended at the time; the comments were not. Both now state display-as-floor and
+  point at the shared predicates.
 
 ## Known gaps at merge
 
@@ -222,10 +266,26 @@ each one's failure direction is "a control silently does not apply":
   indistinguishable from "not configured", so it reports `configured=false` for up
   to one reload TTL. Tolerant lexing does not touch this; an operator who needs a
   capability genuinely off should set it at the tier that enforces.
-- `AdvertisedRef` iterates the capability list twice where once would do
-  (round-3 P2-4). Cosmetic, left alone — the second loop is what makes an
-  ambiguous id fail closed, and rewriting it to save a pass is not worth
-  re-opening a reviewed fail-closed path.
+- **`AdvertisedRef` fails closed loudly on the manifest and silently everywhere
+  else.** Advertising two versions of one template id — which
+  `newBotCardTemplateCatalog` permits, rejecting only exact duplicates — makes it
+  return `(zero, false)`, which degrades one manifest field but rejects *every*
+  template send. Reasoning cards would be completely dead with only a `Warn` line
+  as the signal. The loop count (round-3 P2-4) was never the issue; the missing
+  invariant is. The fix is to reject such a policy at catalog construction so a
+  silent production outage becomes a startup error — deliberately deferred, as it
+  changes a constructor's contract and belongs with the other template-catalog
+  follow-ups rather than in a round-4 hotfix.
+- **The owner catalog's `effective_value` is not master-switch-dominated.**
+  `listBotSettings` returns the raw resolution while `botCardConfigFrom` applies
+  `applyCardMasterSwitch`, so with cards off at the deployment level the Bot
+  management page shows `display_enabled: true` while the profile says false and
+  every send 400s. The same response carries `bot.card_enabled` with
+  `source:"env"`, so a client *can* compose the truth — but nothing in the
+  contract obliges it to, which makes this the "manifest disagrees with the gate"
+  contradiction relocated to the owner surface. Needs an explicit decision
+  (dominate `effective_value`, or document this as the pre-master-switch tier),
+  not another round of implicit.
 - `TestListGroups_CarriesGroupAllowNoMention` (`mention_pref_test.go`, unrelated
   to this task) panics in the local sandbox because the endpoint returns an empty
   list. It reproduces identically on the pre-change HEAD and is green in CI, so it

--- a/.octospec/journal/shared/bot-setting-store.md
+++ b/.octospec/journal/shared/bot-setting-store.md
@@ -177,29 +177,72 @@ sibling consumer that was not updated when a new gate was introduced.**
    documents 404/403 — a contradiction with its own stated semantics, not a
    hardening preference.
 
+7. **Two predicates for one question is a gap by construction.** The legacy
+   ingress decides "is this a card?" with `maputil.Data.Int("type")`, which
+   coerces strings; `cardmsg.IsCardPayload` — the predicate `Validate` itself
+   short-circuits on — deliberately does not. Nothing was wrong with either
+   function; the defect lived in the gap between them, and it swallowed the URL
+   allowlist, the node/depth caps, profile negotiation, `Finalize` **and** these
+   new switches for any `{"type":"17"}` payload. Same family as lessons 1 and 2
+   (a sibling path, then a sibling consumer) with the radius shrunk to a single
+   function: **when a branch's guard and its body disagree about what reached
+   them, the body wins and the guard is decoration.** Closed by routing on the
+   validator's own predicate, so reachability and enforcement cannot drift.
+
+## Closed after round 3
+
+Three review follow-ups were fixed in this branch rather than deferred, because
+each one's failure direction is "a control silently does not apply":
+
+- **`payloadIsVail` no longer routes on a coerced `type`.** The card branch now
+  guards on `cardmsg.IsCardPayload` — the same predicate `Validate` short-circuits
+  on — so a string `"17"` is refused instead of entering the card branch and
+  skipping every check (see lesson 7 above). This ingress was the **only** one in
+  the repo dispatching on `maputil.Data.Int`; `bot_api`, `message` and `notify`
+  already called `IsCardPayload` directly. The regression test asserts both halves
+  of the gap still exist (`Int` coerces, `IsCardPayload` does not) so it deletes
+  itself honestly if either upstream ever changes, and it uses a `javascript:` URL
+  so a pass means the allowlist ran, not merely that the type was rejected.
+- **`SettingBoolOK` lexes tolerantly** (trim + case-fold). Its callers layer a
+  code default on top, and for all three card switches that default is `true` —
+  so `False` being read as "unconfigured" left on exactly the capability the
+  operator was trying to disable, silently. The *vocabulary* deliberately stays
+  identical to `parseSettingBool`'s; only the lexing relaxed, so one column cannot
+  come to mean different things to two readers of the same table. Pinned by a test
+  that asserts on/off/yes/no are rejected by **both** readers.
+- **A malformed stored override now warns** instead of falling back mutely, once
+  per `(robot, key)`. The dedupe is not polish: resolution runs on every card send
+  and every profile read, and a dirty row is persistent state, so an un-deduped
+  warning is a log flood — which is the same outcome as no log at all.
+
 ## Known gaps at merge
 
-- **`payloadIsVail` routes on a coerced `type`.** `maputil.Data.Int` runs
-  `strconv.Atoi` on strings while `cardmsg.IsCardPayload` deliberately rejects a
-  string `"17"`, and `Validate` no-ops when `IsCardPayload` is false. A
-  `{"type":"17"}` payload therefore enters the card branch on the legacy ingress
-  and skips the URL allowlist, the node/depth caps, profile negotiation,
-  `Finalize`, and these switches. **Pre-existing and outside this change** — the
-  new gate's reachability predicate is `IsCardPayload`, the same predicate the
-  repo's own validator uses, so the gate is exactly as reachable as validation
-  is. Severity depends on whether any client renders a string-typed `type`;
-  tracked separately rather than grown into this task.
-- `SettingBoolOK` matches bool literals exactly, so an operator writing `False`
-  or `off` into a `botcard` global default falls through to the code default —
-  which for all three switches is `true`, i.e. the capability the operator meant
-  to disable stays on. Consistent with every other `system_setting` bool, but the
-  failure direction is worse here; a trimmed, case-insensitive parse is the fix.
-- A malformed stored per-bot override falls through silently with no log line.
+- `SettingBoolOK` remains a **best-effort** tier, as its doc comment says: a
+  replica whose startup `Load()` blipped has an empty snapshot, which is
+  indistinguishable from "not configured", so it reports `configured=false` for up
+  to one reload TTL. Tolerant lexing does not touch this; an operator who needs a
+  capability genuinely off should set it at the tier that enforces.
+- `AdvertisedRef` iterates the capability list twice where once would do
+  (round-3 P2-4). Cosmetic, left alone — the second loop is what makes an
+  ambiguous id fail closed, and rewriting it to save a pass is not worth
+  re-opening a reviewed fail-closed path.
+- `TestListGroups_CarriesGroupAllowNoMention` (`mention_pref_test.go`, unrelated
+  to this task) panics in the local sandbox because the endpoint returns an empty
+  list. It reproduces identically on the pre-change HEAD and is green in CI, so it
+  is an environment difference, not a regression from this branch — recorded so
+  the next person running these packages locally does not chase it.
 
 ## Verification
 
-All 18 CI checks green at the merge head, including the DB-backed `Test` job.
-Locally: `go build ./...`, `go vet`, `make i18n-extract-check`, `make i18n-lint`,
-both modules' `NoLegacyResponseError` source guards, and `-race -shuffle=on` on
-`modules/robot` and `modules/bot_api` against MySQL 8 + Redis + WuKongIM
-v2.2.4, run per-package with the CI drop/create + FLUSHALL discipline.
+All 18 CI checks green at the review head, including the DB-backed `Test` job.
+Locally: `go build ./...`, `go vet ./...`, `make i18n-extract-check`,
+`make i18n-lint`, both modules' `NoLegacyResponseError` source guards, and
+`-race -shuffle=on` on `modules/common`, `modules/robot` and `modules/bot_api`
+against MySQL 8 + Redis + WuKongIM v2.2.4, run per-package with the CI
+drop/create + FLUSHALL discipline.
+
+Each round-3 fix was verified by **reverting only that fix and confirming its
+test fails** — the discipline round 1 taught the hard way, when an atomicity test
+turned out to pass against the code it was written to catch. `SettingBoolOK`'s
+test fails on `"\tfalse\n"`; the ingress test fails with the `javascript:` card
+accepted.

--- a/.octospec/journal/shared/bot-setting-store.md
+++ b/.octospec/journal/shared/bot-setting-store.md
@@ -279,6 +279,18 @@ Two smaller ones fixed alongside, both also mine from round 3 or earlier:
   amended at the time; the comments were not. Both now state display-as-floor and
   point at the shared predicates.
 
+**A fourth inert test, caught by the revert discipline rather than by review.**
+The first `from_uid` regression test passed with the pin deleted. The handler
+pinned `req.FromUID = robotID` and then called `allowSendToChannel(robotID, …)`
+— checking a *parallel variable* rather than the field it had just assigned — so
+the stub recorded the right uid whether or not the pin existed. The test observed
+something that could not vary. Fixed on both sides: the handler now checks
+`req.FromUID` after pinning it, so one variable carries identity end to end, and
+the test discriminates. The general form is worth naming because it is not the
+same as the earlier three: **an assertion on a value that is correct for a reason
+other than the one under test is inert**, and the only reliable detector is
+deleting the fix and watching the test go red.
+
 **The generalisable rule, after three instances of it.** Round 1 was a sibling
 path (the raw edit branch), round 2 a sibling consumer (the manifest), rounds 3
 and 6 a sibling *function* reading the same column. Every one was found by
@@ -314,21 +326,31 @@ intended, because a per-party test passes fine while they disagree.
   contradiction relocated to the owner surface. Needs an explicit decision
   (dominate `effective_value`, or document this as the pre-master-switch tier),
   not another round of implicit.
-- **The "three card producer ingresses" claim may be wrong, and this branch's
-  design rests on it.** `POST /v1/robots/:robot_id/:app_key/stream/start`
-  (`modules/robot/api.go:482`) binds a request whose `Payload` is a raw `[]byte`
-  and hands it straight to `IMStreamStart`. No `payloadIsVail`, no
-  `IsCardPayload`, no `cardmsg.Validate`, no `BotEnabled()`, no per-bot gate —
-  and, unlike the sibling `typing` handler, no `allowSendToChannel` and no
-  override of `req.FromUID` with the authenticated `robot_id` from the path. So
-  on its face an authenticated bot can start a stream carrying a `type:17`
-  payload under an arbitrary `from_uid`. **Entirely pre-existing; this diff does
-  not touch that handler.** What decides whether it is a stale comment or a real
-  bypass is one fact not answerable from this repo: do the clients render a
-  stream payload as a card? Recorded here rather than as an issue by explicit
-  instruction — which means this paragraph is the only record, so whoever picks
-  up the follow-ups should start here. The claim it undermines is asserted in
-  both `payloadIsVail`'s comment and the brief's load-bearing list.
+- **`stream/start` — card path closed, two pre-existing holes still open.**
+  Review found a fourth authenticated path: `streamStart`
+  (`modules/robot/api.go:482`) hands a raw `[]byte` `Payload` straight to
+  `IMStreamStart` with no shape validation and none of this task's gates, so a
+  bot could still emit `type:17` after its owner disabled cards. Two reviewers
+  agreed on every fact and split on scope — one blocked (the PR ships a
+  guarantee it does not deliver), one verified the handler is byte-identical to
+  the merge-base and argued it belongs in its own security issue. **Resolved by
+  taking the narrow half**: the handler now refuses card payloads outright
+  (`cardmsg.IsCardRawPayload`), which makes the guarantee true without rebuilding
+  the whole `sendMessage` pipeline on a path whose purpose is incremental text.
+  Refusing rather than gating is the point — a second full validation pipeline is
+  a second thing to drift.
+  **The identity half turned out to be the real blocker, and is now also fixed.**
+  The card refusal alone did not satisfy the blocking review: it separated the
+  two and called the forgeable `from_uid` "a real authorization-symmetry gap
+  independent of card rendering", with "documenting the gap does not close" it.
+  Correct — `sendMessage` and `typing` in the same `robotAuth` group both pin
+  `FromUID` to `c.Param("robot_id")` and both call `allowSendToChannel`;
+  `streamStart` was the lone exception, so auth answered "who are you" while the
+  body got to overwrite "who you say you are". Both are now aligned with the
+  siblings.
+  Remaining on that handler: no `payloadIsVail`/`Validate` for non-card payloads,
+  i.e. it is still the one ingress without shape validation. Deliberate — see the
+  brief for why refusing cards beats rebuilding the pipeline here.
 - **`TestBotMessageEdit_StillReachesTerminalStateWhenReasoningOff` is inert.**
   It injects a `stubCardConfig` with every sub-switch off, but
   `botMessageEditViaRegistry` never calls `resolveBotCardConfig`, so the stub

--- a/.octospec/journal/shared/bot-setting-store.md
+++ b/.octospec/journal/shared/bot-setting-store.md
@@ -66,18 +66,37 @@ to: `pkg/cardmsg/profiles.go` documents `acceptedProfiles` as the single
 authority shared by the validator and the D12 manifest, and clipping breaks that
 by design; and the reasoning card spans both profiles (active/error are
 `octo/v2`, result is `octo/v1`), so a profile-shaped switch would leave it with
-only its terminal state or only its progress states. The three switches are
-orthogonal: display/interaction gate the raw-card path, reasoning gates the
-template path.
+only its terminal state or only its progress states.
+
+The raw pair and the template switch are orthogonal — display/interaction gate
+the raw-card path, reasoning gates the template path — but **display and
+interaction are not orthogonal to each other**, and an earlier draft of this
+journal said they were. Review found the bypass that claim licences: `octo/v2`
+is a strict superset of `octo/v1` (the `interactive` flag in
+`cardmsg.validateCard` only ever relaxes checks, never requires an interactive
+element), so with the two treated as peers a bot defeats `display_enabled=false`
+by changing one string and sending byte-identical display-only cards as
+`octo/v2`. Display is a **floor**: `octo/v1` needs display, `octo/v2` needs
+display AND interaction. Both live on `BotCardConfig.AllowsRawDisplayCard()` /
+`AllowsRawInteractiveCard()`, which every gate and the manifest call — restoring
+"orthogonality" here reopens the bypass.
 
 **No per-bot cache, on purpose.** Reads go to MySQL every time, so an owner's
 change on one replica is visible on every other immediately. A process-local
 cache would trade that for TTL drift, and the invalidation event reaches only
 the bot, not sibling replicas — Redis pub/sub would be required to close it.
-Cost of the no-cache choice: one indexed single-row read per card *creation*
-(non-card sends never enter the gate; streaming updates go through
-`message/edit`, which is deliberately ungated so an in-flight card can still
-reach its terminal state).
+
+Cost of the no-cache choice, per path: non-card sends never enter any gate;
+raw-card creation and raw-card edit each cost one indexed single-row read;
+template creation costs one. Only the **template** branch of `message/edit` is
+ungated, which is what lets a streaming card reach its terminal state — the raw
+branch is gated, because `cardmsg.Validate` accepts any profile in the accepted
+set and never compares the edit frame to the original, so leaving it open was a
+privilege-escalation path (send `octo/v1`, then edit into an `octo/v2` frame
+carrying `Action.Submit`, which is the frame the action endpoint trusts).
+A producer streaming through raw card edits therefore pays one read per frame;
+the shipped reasoning-card consumer streams through the template branch and
+pays nothing per frame.
 
 ## What went wrong on the way
 
@@ -102,9 +121,85 @@ reach its terminal state).
    fix is to extend the frozen set — and `config`'s own five sub-fields were
    frozen the same way `limits` already is.
 
+## What review found that the author did not
+
+Three rounds of review across four heads. Recording these because the pattern in
+them is more useful than any individual fix: **every one was a sibling path or a
+sibling consumer that was not updated when a new gate was introduced.**
+
+1. **A new gate does not gate what it does not reach.** Round 1 found the raw
+   branch of `/v1/bot/message/edit` ungated: `cardmsg.Validate` accepts any
+   accepted profile and never compares the edit frame to the original, so a bot
+   with interaction off could send `octo/v1` and then edit into an `octo/v2`
+   frame with `Action.Submit` — the frame the action endpoint treats as
+   authoritative. Round 2 then found the same shape one door further out: the
+   legacy `POST /v1/robots/:robot_id/:app_key/sendMessage` ingress consulted no
+   per-bot config at all, while being keyed on the *same* `robot_id` column. The
+   comment at `payloadIsVail` already stated the three card ingresses must stay
+   symmetric; the new layer broke an invariant the code asserts about itself.
+   **When adding an authorization layer, enumerate every authenticated path that
+   reaches the same resource before writing the first gate** — the search radius,
+   not the gate, is what was wrong both times.
+
+2. **Fixing a gate splits it from whatever advertises it.** The round-1 floor fix
+   changed what the send path accepts; the manifest kept echoing the raw switch,
+   so `/v1/bot/card/profile` advertised `interaction_enabled:true` while every
+   `octo/v2` card was refused — precisely the ambiguity that endpoint exists to
+   remove. "Both read the same resolver" was true and not enough: they combined
+   the same fields differently. Closed by making the *predicates* the shared
+   thing (`AllowsRawDisplayCard` / `AllowsRawInteractiveCard`) rather than the
+   data, so a future divergence requires bypassing a named function.
+
+3. **A test named after a guarantee it does not exercise.** The first atomicity
+   test drove the batch through a validation failure — which returns before
+   `Begin()` — so it passed identically against the pre-transaction code. Review
+   caught that the name promised more than the body delivered. Split into a
+   validation test named for what it covers, plus a real rollback test that
+   provokes a mid-batch MySQL error (an over-long `key_name`) via an extracted
+   `writeBotSettingOverrides`. The extraction is the point: the failure needed to
+   test the transaction was, by design, unreachable through the endpoint.
+
+4. **Transactionality is not free.** Wrapping the batch in one transaction holds
+   row locks to commit, which made two concurrent opposite-order batches
+   deadlockable in a way per-statement autocommit was not. Sorting `plans` by key
+   removes the ordering variable — the repo already had the precedent under
+   "#627 D4 uniform lock order".
+
+5. **A copied header can be worse than no header.** `Vary: Authorization` was
+   carried over to the owner settings routes from the bot profile endpoint. Those
+   routes authenticate with `token`, so it named a header with no effect on the
+   response — the appearance of cache isolation without the substance.
+
+6. **A recurring nit is evidence.** Ownership-after-shape-validation was raised
+   by three reviewers across three rounds, and twice deflected on "shape errors
+   need no DB query". The framing that landed was different in kind: it made a
+   malformed request against an unknown bot answer 400 where the endpoint
+   documents 404/403 — a contradiction with its own stated semantics, not a
+   hardening preference.
+
+## Known gaps at merge
+
+- **`payloadIsVail` routes on a coerced `type`.** `maputil.Data.Int` runs
+  `strconv.Atoi` on strings while `cardmsg.IsCardPayload` deliberately rejects a
+  string `"17"`, and `Validate` no-ops when `IsCardPayload` is false. A
+  `{"type":"17"}` payload therefore enters the card branch on the legacy ingress
+  and skips the URL allowlist, the node/depth caps, profile negotiation,
+  `Finalize`, and these switches. **Pre-existing and outside this change** — the
+  new gate's reachability predicate is `IsCardPayload`, the same predicate the
+  repo's own validator uses, so the gate is exactly as reachable as validation
+  is. Severity depends on whether any client renders a string-typed `type`;
+  tracked separately rather than grown into this task.
+- `SettingBoolOK` matches bool literals exactly, so an operator writing `False`
+  or `off` into a `botcard` global default falls through to the code default —
+  which for all three switches is `true`, i.e. the capability the operator meant
+  to disable stays on. Consistent with every other `system_setting` bool, but the
+  failure direction is worse here; a trimmed, case-insensitive parse is the fix.
+- A malformed stored per-bot override falls through silently with no log line.
+
 ## Verification
 
-`go build ./...`, `go vet`, `make i18n-extract-check`, `make i18n-lint`, both
-modules' `NoLegacyResponseError` source guards, and `-race -shuffle=on` on
+All 18 CI checks green at the merge head, including the DB-backed `Test` job.
+Locally: `go build ./...`, `go vet`, `make i18n-extract-check`, `make i18n-lint`,
+both modules' `NoLegacyResponseError` source guards, and `-race -shuffle=on` on
 `modules/robot` and `modules/bot_api` against MySQL 8 + Redis + WuKongIM
 v2.2.4, run per-package with the CI drop/create + FLUSHALL discipline.

--- a/.octospec/learnings/pending/cleanalltables-does-not-reset-in-process-caches.md
+++ b/.octospec/learnings/pending/cleanalltables-does-not-reset-in-process-caches.md
@@ -1,0 +1,77 @@
+---
+type: Learning
+title: "CleanAllTables clears tables, not in-process caches — and the leak only shows under -shuffle"
+description: Process-wide singletons holding an in-memory snapshot (SystemSettings) survive CleanAllTables exactly like the Redis rate-limit buckets do, so a case that writes a deployment default leaks it into every later case in the binary. Order-dependent, so the default sequential run hides it. Setup must reset every layer the case writes to, not just the DB.
+tags: ["testing", "config", "system-setting", "flaky"]
+timestamp: 2026-08-06T16:20:00+08:00
+# --- octospec extension fields ---
+source: self
+origin_task: bot-setting-store
+status: pending
+candidate_rule: testing
+---
+
+# CleanAllTables clears tables, not in-process caches
+
+## Context
+
+The `testing` rule already carries one instance of this:
+
+> `CleanAllTables` does NOT clear Redis rate-limit buckets — reset them
+> explicitly in setup when a test hits a rate-limited route.
+
+`bot-setting-store` hit the same shape in a second place, which suggests the
+rule's phrasing is one example short of the general statement.
+
+## What happened
+
+The per-bot config resolver reads `modules/common`'s `SystemSettings` as its
+middle tier. That type is a **process-wide singleton** holding an immutable
+snapshot swapped by `Load`/`Reload`, refreshed on a 60s timer — by design, so
+readers never take a lock.
+
+One integration case wrote a `system_setting` row (a deployment default) and
+called `Reload()` to observe it. The next case called `CleanAllTables`, which
+truncated the row — but nothing reloaded the snapshot, so the singleton kept
+serving the deleted value. The later case saw `source="global"` where it
+expected `source="default"`.
+
+Under the default sequential order the writer happened to run last and
+everything passed. `go test -shuffle=on` (which CI runs) failed on 2 of 4 seeds.
+
+## The general statement
+
+**Test setup must reset every layer the case under test can write to, not just
+the database.** In this repo that is at least three layers:
+
+| Layer | Cleared by `CleanAllTables`? |
+|---|---|
+| MySQL tables | yes |
+| Redis (rate-limit buckets, locks, queues) | **no** |
+| In-process singletons holding a snapshot (`SystemSettings`) | **no** |
+
+The tell for the third layer: the value is served by something constructed via
+an `EnsureXxx` / `sync.Once` accessor. Anything reachable that way outlives
+`CleanAllTables` and outlives the individual test.
+
+## What to do
+
+In setup, after `CleanAllTables`, explicitly reset each non-DB layer the case
+touches:
+
+```go
+assert.NoError(t, testutil.CleanAllTables(ctx))
+resetUIDRateLimit(t, ctx)                                  // Redis
+assert.NoError(t, common.EnsureSystemSettings(ctx).Reload()) // in-process snapshot
+```
+
+And run new integration tests with `-shuffle=on` at least once before opening
+the PR: a leak of this kind is invisible in the authored order and only appears
+when some other case runs first.
+
+## Why it is worth a rule line
+
+The failure does not look like a test bug. It surfaces as an assertion on
+business semantics (`source` reporting the wrong layer), so the natural first
+reading is "the resolver has a priority bug" — and the resolver is fine. Naming
+the three layers turns a confusing debugging session into a checklist.

--- a/.octospec/log.md
+++ b/.octospec/log.md
@@ -4,6 +4,27 @@ Change history for this repo's `.octospec/`, following the
 [OKF](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md)
 change-log convention (§7). Newest first.
 
+## 2026-08-06 (bot-setting-store)
+
+- **Task** — `bot-setting-store`: added `bot_setting`, a generic per-bot config
+  store, replacing "add another column to `robot`" as the way a bot-level switch
+  gets stored. One registry backs the write whitelist, the owner-facing catalog,
+  and the bot → `system_setting` → code-default resolution chain, so a new key
+  is an entry rather than a migration. First consumer is the four card switches
+  (`card_enabled` derived read-only from the deployment env; display /
+  interaction / reasoning owner-editable, default true because the master switch
+  is already fail-closed). `GET /v1/bot/card/profile` gained one additive
+  `config` object; `sendMessage` enforces the same values independently.
+  The precedent that looked right was the wrong one — `bot_mention_pref` is a
+  table because it is two-dimensional, not because tables are preferred. See
+  [journal](journal/shared/bot-setting-store.md).
+- **Learning (pending)** —
+  [`cleanalltables-does-not-reset-in-process-caches`](learnings/pending/cleanalltables-does-not-reset-in-process-caches.md):
+  generalizes the existing "CleanAllTables does not clear Redis rate-limit
+  buckets" note to every non-DB layer, after a process-wide `SystemSettings`
+  snapshot leaked between cases and failed only under `-shuffle`.
+  Candidate rule: `testing`.
+
 ## 2026-08-05 (bot-api-per-bot-ratelimit)
 
 - **Task** — `bot-api-per-bot-ratelimit` (#696): moved bot rate limiting off the

--- a/.octospec/log.md
+++ b/.octospec/log.md
@@ -18,6 +18,11 @@ change-log convention (§7). Newest first.
   The precedent that looked right was the wrong one — `bot_mention_pref` is a
   table because it is two-dimensional, not because tables are preferred. See
   [journal](journal/shared/bot-setting-store.md).
+  Three review rounds across four heads found three P1s, every one a sibling
+  path or sibling consumer left behind when a new gate went in: the raw branch
+  of `bot/message/edit`, the legacy robot send ingress, and the manifest that
+  advertises what the gate accepts. The journal's "What review found that the
+  author did not" section records the pattern rather than only the fixes.
 - **Learning (pending)** —
   [`cleanalltables-does-not-reset-in-process-caches`](learnings/pending/cleanalltables-does-not-reset-in-process-caches.md):
   generalizes the existing "CleanAllTables does not clear Redis rate-limit

--- a/.octospec/tasks/bot-setting-store/brief.md
+++ b/.octospec/tasks/bot-setting-store/brief.md
@@ -116,13 +116,17 @@ owner 读与 adapter 读分属两个模块）。
   具体原因只进日志（防枚举）。
   用户 ingress 与 robot 的 `message/edit` 无需加门：前者无条件拒卡，后者经
   `cardmsg.RejectsCardEdit` 拒绝一切卡片编辑。
-  **「三个」是本任务的口径，不是已证实的全仓完备性**（round-7 评审）：
+  **第四条路径 `stream/start`：拒卡，而不是补门**（round-7 评审阻塞项）：
   `POST /v1/robots/:robot_id/:app_key/stream/start` 把 `Payload []byte` 原样转给
-  WuKongIM，没有形状校验、没有 `allowSendToChannel`、也没有用已鉴权的 `robot_id`
-  覆盖调用方传入的 `from_uid`。该 handler 与 merge-base 逐字节相同、本任务一行未碰，
-  但它是否算第四个卡片入口取决于「客户端会不会把 stream payload 渲染成卡片」——这个
-  事实本仓答不出。**在它被 triage 之前，本条不得被读作「全仓卡片入口已枚举完毕」。**
-  详见 journal 的 known-gaps。
+  WuKongIM，没有任何形状校验与本任务的门。它与 merge-base 逐字节相同，但只要它能发出
+  `type:17`，上面那句「每条已鉴权的发卡路径都按有效配置校验」就是假的。现在在
+  `BindJSON` 之后直接 `cardmsg.IsCardRawPayload` 拒绝。
+  **拒绝而非补门是刻意的**：补门要在这条路上重建形状校验、URL 白名单、节点/深度上限与
+  profile 协商，等于把 `sendMessage` 的流水线复制一遍，也就再造一处会漂移的判定；而流式
+  消息的用途是增量文本，卡片有 `sendMessage` 与模板 `message/edit` 两条正规入口。
+  **该 handler 另外两个先于本任务存在的问题不在本任务范围，也不该被这道门掩盖**：缺少
+  `allowSendToChannel`，以及 `from_uid` 由调用方指定而非取自已鉴权的 `robot_id`（冒充
+  类，评审认为比卡片那条更严重）。详见 journal 的 known-gaps。
 - **关闭只拦模板卡的续帧，不拦 raw 卡的改写**（round-1 评审后修订）：`sendMessage`
   全量加门；`botMessageEdit` 的**模板分支**不加门——流式推理卡必须能编辑到终态，
   否则线上残留「永久处理中」的卡。但**raw 分支必须加门**：`cardmsg.Validate` 接受

--- a/.octospec/tasks/bot-setting-store/brief.md
+++ b/.octospec/tasks/bot-setting-store/brief.md
@@ -1,7 +1,7 @@
 ---
 type: Task
 title: "Task: bot-setting-store"
-description: Generic per-bot config store (bot_setting) with a bot → global → code-default resolution chain; first consumer is the reasoning-progress card policy.
+description: Generic per-bot config store (bot_setting) with a bot → global → code-default resolution chain; first consumers are the four bot-level card switches.
 tags: ["bot-api", "auth", "error-response", "wire-contract", "rate-limit", "testing"]
 timestamp: 2026-08-06T00:00:00Z
 slug: bot-setting-store
@@ -27,11 +27,18 @@ bot_setting（该 Bot 的覆盖）→ system_setting（服务端全局默认）�
    「Bot 管理」页要能**查询本部署有哪些可配置项**并**回显当前值**，而不是由客户端
    硬编码一张列表。读接口返回全部已注册键 + 该 Bot 的覆盖值 + 三层解析后的有效值 +
    值来源；写/删接口改这一份覆盖。
-2. **adapter 消费面**（`GET /v1/bot/card/profile`，botToken）——下发**已解析好**的
-   卡片有效配置（`reasoning_progress.mode` / `template_ref`），插件不再自行推断。
-3. **发送端**（`POST /v1/bot/sendMessage` 模板分支）——按同一份有效配置二次校验。
+2. **adapter 消费面**（`GET /v1/bot/card/profile`，botToken）——新增 `config` 对象，
+   下发**已经 AND 完的有效值**，插件直接用、不自行推断。
+3. **发送端**（`POST /v1/bot/sendMessage`）——按同一份有效配置二次校验。
 
-首个消费者是推理进度卡策略：Bot 级的 `mode`(off|on) 与 `template_ref`。
+首批四个键：
+
+| 键 | 管什么 | 存储 | 代码默认 |
+|---|---|---|---|
+| `bot.card_enabled` | 该 Bot 的卡片总闸 | **不存**，取 `cardmsg.BotEnabled()` | 随 env（未设 = false） |
+| `bot.display_enabled` | **raw 展示卡**（bot 自拼 octo/v1 卡） | `bot_setting` | `true` |
+| `bot.interaction_enabled` | **raw 交互卡**（bot 自拼 octo/v2 卡） | `bot_setting` | `true` |
+| `bot.reasoning_enabled` | **Registry 推理进度卡** | `bot_setting` | `true` |
 
 ## Background
 
@@ -51,43 +58,55 @@ owner 读与 adapter 读分属两个模块）。
 校验 + DB→fallback 解析链 + 管理端 `effective_value` 回显」做完并在生产验证过。本任务
 按同一形状做 per-bot 版本，并把它作为解析链的第二层。
 
-上游诉求（推理卡）要求服务端是配置权威、用户不改插件配置文件；`mode=off` 只阻止
-**新建**进度卡，已发出的卡仍可编辑到终态。
+**三个子开关默认 `true` 是安全的**，因为安全性由总闸承担：`OCTO_CARD_MESSAGE_ENABLED`
+未设即 `false`（`pkg/cardmsg/cardmsg.go:168-175` fail-closed），`card_enabled` 为假时
+三个子开关的有效值恒为假。上游诉求里的「安全默认关闭推理卡」由总闸满足，子开关不必
+再各自默认关——否则运维开了总闸还要逐 Bot 再开一次，反而制造困惑。
 
 ## Load-bearing list
 
 - **`bot_setting` 稀疏语义**：只存偏离全局默认的覆盖项；无行 / 空串 value = 未配置，
-  回退下一层。删除覆盖 == 回落全局，不是「设为 off」。
-- **解析优先级**：bot 覆盖恒优先于全局默认；全局默认恒优先于代码默认。代码默认为
-  `mode=off`（未升级/未配置的部署行为不变，零回归）。
+  回退下一层。删除覆盖 == 回落上一层，不是「设为 false」。
+- **解析优先级**：bot 覆盖 → `system_setting` 全局默认 → 代码默认（三个子开关均为
+  `true`）。未升级/未配置的部署行为不变，零回归。
+- **`card_enabled` 是派生值，不可写**：它恒等于 `cardmsg.BotEnabled()`
+  （`OCTO_CARD_MESSAGE_ENABLED` AND `OCTO_BOT_CARD_ENABLED`），不落 `bot_setting`。
+  owner 目录里以只读项出现（`editable:false`，`source:"env"`），写入必须 400 ——
+  否则会出现「库里写着 true、env 关着」的假象。
+- **总闸支配子开关**：`card_enabled==false` ⟹ 三个子开关的有效值全为 `false`。
+  profile 绝不能报某个子开关为 true 而发卡被 `card_disabled` 拒
+  （`pkg/cardmsg/cardmsg.go:177-200` 已确立的「清单与发卡门禁同源」不变量）。
+- **display / interaction / reasoning 三者正交**：`display_enabled` 与
+  `interaction_enabled` 只管 **raw 卡路径**（bot 自拼 card JSON），**绝不可**实现成
+  「按 wire profile 一刀切」。推理卡自身横跨两档
+  （`ai.reasoning-process@0.3.0/manifest.json`：active/error = `octo/v2`，
+  result = `octo/v1`），按 profile 切会把它砍成只剩终态或只剩过程。模板卡只看
+  `reasoning_enabled`。
 - **键白名单是可查询的**：同一份注册表既是写入校验的白名单，也是 owner 读接口
   返回的「可配置项目录」——客户端据此渲染「Bot 管理」列表，新增一个键不需要客户端
   发版。未注册的 key 写入必须 400，不得长出野键（同 `system_setting` 的 `settingDef`）。
-- **回显三态必须可区分**：读接口对每个键同时返回 `value`（该 Bot 的显式覆盖，未设
-  为空）、`effective_value`（三层解析结果）与 `source`（`bot`/`global`/`default`）。
-  只返回一个合并值，UI 就无法区分「我显式设成了 off」与「我没设、跟随全局默认 off」，
-  也就无法正确渲染「恢复默认」。
-- **`enabled` 从属关系**：`cardmsg.BotEnabled()`（`OCTO_CARD_MESSAGE_ENABLED` AND
-  `OCTO_BOT_CARD_ENABLED`）为假时，profile 下发的有效 `mode` 必须是 `off` ——
-  清单绝不能报 `on` 而发卡被 `card_disabled` 拒（`pkg/cardmsg/cardmsg.go:177-200`
-  已确立的「清单与发卡门禁同源」不变量）。
-- **`reasoning_progress` 与 `templating` 自洽**：`mode=="on"` ⟹ 下发的 `template_ref`
-  必在同一响应的 `templating.templates` 内（即部署广告集
-  `defaultBotTemplatePolicy().AdvertisedSend`）。
+- **回显三态必须可区分**：读接口对每个键同时返回 `value`（该 Bot 的显式覆盖，未设为
+  `null`）、`effective_value`（解析后的有效值）与 `source`（`bot`/`global`/`default`/`env`）。
+  只返回一个合并值，UI 就无法区分「我显式设成了 false」与「我没设、跟随全局默认
+  false」，也就无法正确渲染「恢复默认」。
+- **`reasoning_template_ref` 由服务端解析，非 owner 可配**：`reasoning_enabled==true`
+  时下发的 ref 必在同一响应的 `templating.templates` 内（即部署广告集
+  `defaultBotTemplatePolicy().AdvertisedSend`）；`false` 时必须为 `null`。
 - **`/v1/bot/card/profile` wire 契约 additive-only**（`modules/bot_api/card_profile.go:23-24`）：
-  只增字段，不改名/不删/不改类型。
-- **发送端二次校验**：profile 是能力清单，`sendMessage` 模板分支必须独立按有效配置
-  校验（`mode==off` 拒绝；`template_ref` 必须等于该 Bot 的有效 ref），拒绝走单一
-  泛化码 `err.server.bot_api.card_invalid`，具体原因只进日志（防枚举）。
-- **`mode=off` 只拦新发**：`send.go` 模板分支加门，`botMessageEdit` 的模板分支不加 ——
-  已发出的卡必须能编辑到终态，否则线上残留「永久处理中」的卡。
+  只增 `config` 对象，现有字段（含 `enabled`）不改名/不删/不改类型/不改语义。
+- **发送端二次校验**：profile 是能力清单，`sendMessage` 必须独立按有效配置校验
+  （模板分支 `reasoning_enabled==false` 拒绝；raw 分支按 `display_enabled` /
+  `interaction_enabled` 拒绝），拒绝走单一泛化码 `err.server.bot_api.card_invalid`，
+  具体原因只进日志（防枚举）。
+- **关闭只拦新发**：门加在 `send.go`，`botMessageEdit` 的模板分支不加 —— 已发出的卡
+  必须能编辑到终态，否则线上残留「永久处理中」的卡。
 - **写入口鉴权 = bot owner 自助**：对齐 `setAutoApprove` / `setMentionPref` 的
   `assertRobotOwner`（`creator_uid == loginUID`，robot 不存在 → 404、非 owner → 403、
   DB 故障 → 500 且不得伪装成 404）。挂在 `/v1/robot/:robot_id/*`（user session）。
-  `/v1/manager/robots/*` 是平台运维面（状态/删除/重置 token），不是产品配置面。
+  `/v1/bot/card/profile` 保持 botToken —— 它的语义是「bot 读自己的有效配置」，
+  owner 化等于废掉它（插件没有 user session）。
   `updated_by` 记录操作者 UID（即审计，不另开审计表）。
-- **删除覆盖 = 回落上一层，幂等**：删不存在的覆盖也返回 200（对齐
-  `deleteMentionPref`）。删除 ≠ 设为 `off`。
+- **删除覆盖 = 回落上一层，幂等**：删不存在的覆盖也返回 200（对齐 `deleteMentionPref`）。
 - **写后推事件失效插件缓存**：配置变更后向该 Bot 投递一条合成事件，插件据此即时
   重拉 profile，消除「改了开关要等插件 TTL」的窗口（对齐
   `sendMentionPrefNotification` 的动机）。账号级配置无频道上下文，用既有的
@@ -98,8 +117,8 @@ owner 读与 adapter 读分属两个模块）。
 ## Out of scope
 
 - `profiles` 按 Bot 裁剪。`pkg/cardmsg/profiles.go:16-35` 明确 `acceptedProfiles` 是
-  校验器接受集与 D12 清单的**单一权威**，按 Bot 裁剪会打破该不变量，且推理卡的
-  active/error 两个 view 本身是 `octo/v2`，裁掉会把卡砍成只剩终态。单独立项。
+  校验器接受集与 D12 清单的**单一权威**，按 Bot 裁剪会打破该不变量。本任务改用
+  `display_enabled` / `interaction_enabled` 两个显式布尔表达同一意图。
 - 静态内置模板的 block 通道（`Blocked` 只存在于动态 artifact meta）。
 - per-bot 模板可见性 / grant 模型。本任务的可见性 == `template_ref` 必须在部署广告集内。
 - 平台管理端（`/v1/manager/robots/*`）的配置写入口与「管理员覆盖 owner」的优先级。
@@ -116,29 +135,54 @@ owner 读与 adapter 读分属两个模块）。
 
 ## Acceptance
 
-- 无 `bot_setting` 行且无 `system_setting` 行 → 有效 `mode=="off"`；profile 下发
-  `reasoning_progress.mode=="off"`；模板发送被拒（`err.server.bot_api.card_invalid`）。
-- Bot A 写 `mode=on` → profile 下发 `on` + `template_ref`；模板发送成功；Bot B 无记录
-  仍为 `off`，互不影响。
-- `system_setting` 全局设 `on`、Bot B 显式覆盖 `off` → B 有效值仍是 `off`（bot 层优先）。
-- 覆盖行被删除（写空 value）→ 该 Bot 回落全局默认，而非落到代码默认。
-- `cardmsg.BotEnabled()==false` 时，无论 bot/全局配置为何，profile 的
-  `reasoning_progress.mode` 恒为 `off`。
-- `mode=="on"` 时，profile 里的 `template_ref` 必然出现在同一响应的
-  `templating.templates` 中（断言两者一致，防止自相矛盾）。
-- Bot A 用不等于自己有效配置的 `template_ref` 发送 → 400 `err.server.bot_api.card_invalid`，
-  且响应体不透出「该模板属于其他 Bot」之类可枚举信息。
-- 未注册 key 写入 → 400；已注册 key 的非法值（`mode` 非 off/on）→ 400。
-- owner 读接口返回全部已注册键；每个键的 `value` / `effective_value` / `source`
-  三者可区分：未设覆盖时 `value==""` 且 `source!="bot"`；显式设为与全局同值时
-  `value` 非空且 `source=="bot"`。
-- 新注册一个键后，owner 读接口立即返回它（客户端无需发版即可发现新配置项）。
-- 非 owner 读/写该 Bot 配置 → 403；robot 不存在/无 `creator_uid` → 404；DB 故障 → 500
-  且不被伪装成 404。
-- 删除不存在的覆盖 → 200（幂等）；删除后有效值回落全局默认而非代码默认。
+**解析链**
+
+- 无 `bot_setting` 行且无 `system_setting` 行 → 三个子开关有效值均为 `true`（在
+  `card_enabled==true` 前提下）。
+- Bot A 显式写 `bot.reasoning_enabled=false` → 只影响 A；Bot B 无记录仍为 `true`。
+- `system_setting` 全局设 `false`、Bot B 显式覆盖 `true` → B 有效值为 `true`（bot 层优先）。
+- 删除 Bot B 的覆盖 → 回落**全局默认**而非代码默认；删不存在的覆盖 → 200（幂等）。
+
+**总闸与派生值**
+
+- `cardmsg.BotEnabled()==false` 时，无论 bot / 全局配置为何，profile 的
+  `config.*` 四个布尔恒为 `false`，且 `reasoning_template_ref==null`。
+- 写 `bot.card_enabled` → 400（派生值不可写）。
+- owner 目录中 `bot.card_enabled` 以 `editable:false` / `source:"env"` 返回。
+
+**profile wire**
+
+- `config.reasoning_enabled==true` ⟹ `reasoning_template_ref` 非 null 且必然出现在
+  同一响应的 `templating.templates` 中（断言两者一致，防止自相矛盾）。
+- `config.reasoning_enabled==false` ⟹ `reasoning_template_ref==null`。
+- 现有字段 `enabled` / `card_version` / `profiles` / `elements` / `inputs` / `actions` /
+  `templating` / `limits` 的值与形状不因本任务改变。
+
+**发送端**
+
+- `reasoning_enabled==false` 时模板发送 → 400 `err.server.bot_api.card_invalid`，
+  且响应体不透出可枚举信息。
+- Bot A 用不等于自己有效配置的 `template_ref` 发送 → 同上单一泛化码。
+- `reasoning_enabled==false` 时 `POST /v1/bot/message/edit` 的模板分支仍可把已发卡
+  编辑到终态。
+- `display_enabled==false` 时 raw octo/v1 卡被拒；`interaction_enabled==false` 时
+  raw octo/v2 卡被拒；两者均**不影响**模板渲染出的推理卡。
+
+**owner 面**
+
+- 读接口返回全部已注册键；`value` / `effective_value` / `source` 三者可区分：
+  未设覆盖时 `value==null` 且 `source!="bot"`；显式设为与全局同值时 `value` 非 null
+  且 `source=="bot"`。
+- 新注册一个键后，读接口立即返回它（客户端无需发版即可发现新配置项）。
+- 未注册 key 写入 → 400；已注册 bool 键的非法值 → 400。
+- 非 owner 读/写 → 403；robot 不存在/无 `creator_uid` → 404；DB 故障 → 500 且不被
+  伪装成 404。
 - 写入成功后向该 Bot 的 `/v1/bot/events` 队列投递一条配置变更事件；事件投递失败
   不影响写接口返回 200。
-- `mode==off` 时 `POST /v1/bot/message/edit` 的模板分支仍可把已发卡编辑到终态。
+
+**工程门**
+
 - 新增 handler 文件已加入 `modules/robot/api_i18n_test.go` 与
   `modules/bot_api/api_i18n_test.go` 的 `NoLegacyResponseError` 守卫列表。
+- 新增 owner 路由挂 `SharedUIDRateLimiter`（`AuthMiddleware` 之后）。
 - `go build ./...`、相关模块 `go test`、`make i18n-extract-check`、`make i18n-lint` 通过。

--- a/.octospec/tasks/bot-setting-store/brief.md
+++ b/.octospec/tasks/bot-setting-store/brief.md
@@ -107,7 +107,7 @@ owner 读与 adapter 读分属两个模块）。
   也不留——配置改动要即时生效）。owner 读接口同口径。两处都有测试钉住。
 - **三个卡片生产者入口都必须二次校验**（round-2 评审后修订）：profile 只是能力清单，
   producer 可以持有陈旧副本或干脆不读，所以每条**已鉴权**的发送路径都要独立按有效
-  配置校验。本仓有三个 ingress，`payloadIsVail` 的注释即写明三者须**对称**：
+  配置校验。本任务口径内有三个 ingress，`payloadIsVail` 的注释即写明三者须**对称**：
   `bot_api` 的 `sendMessage`、`bot_api` 的 raw `message/edit`、以及 legacy
   `POST /v1/robots/:robot_id/:app_key/sendMessage`（`modules/robot`）。它们共用同一个
   Bot 身份（`bot_setting.robot_id` 与 `authRobot` / `assertRobotOwner` 取自同一列），
@@ -116,6 +116,13 @@ owner 读与 adapter 读分属两个模块）。
   具体原因只进日志（防枚举）。
   用户 ingress 与 robot 的 `message/edit` 无需加门：前者无条件拒卡，后者经
   `cardmsg.RejectsCardEdit` 拒绝一切卡片编辑。
+  **「三个」是本任务的口径，不是已证实的全仓完备性**（round-7 评审）：
+  `POST /v1/robots/:robot_id/:app_key/stream/start` 把 `Payload []byte` 原样转给
+  WuKongIM，没有形状校验、没有 `allowSendToChannel`、也没有用已鉴权的 `robot_id`
+  覆盖调用方传入的 `from_uid`。该 handler 与 merge-base 逐字节相同、本任务一行未碰，
+  但它是否算第四个卡片入口取决于「客户端会不会把 stream payload 渲染成卡片」——这个
+  事实本仓答不出。**在它被 triage 之前，本条不得被读作「全仓卡片入口已枚举完毕」。**
+  详见 journal 的 known-gaps。
 - **关闭只拦模板卡的续帧，不拦 raw 卡的改写**（round-1 评审后修订）：`sendMessage`
   全量加门；`botMessageEdit` 的**模板分支**不加门——流式推理卡必须能编辑到终态，
   否则线上残留「永久处理中」的卡。但**raw 分支必须加门**：`cardmsg.Validate` 接受

--- a/.octospec/tasks/bot-setting-store/brief.md
+++ b/.octospec/tasks/bot-setting-store/brief.md
@@ -110,9 +110,24 @@ owner 读与 adapter 读分属两个模块）。
 - **写后推事件失效插件缓存**：配置变更后向该 Bot 投递一条合成事件，插件据此即时
   重拉 profile，消除「改了开关要等插件 TTL」的窗口（对齐
   `sendMentionPrefNotification` 的动机）。账号级配置无频道上下文，用既有的
-  `robot.IService.EnqueueBotEvent`（`modules/robot/api.go:81-86`）投进
-  `/v1/bot/events` 队列，**不**照抄 mention_pref 的群频道消息。
+  类型化事件通道 `robot.IService.EnqueueBotTypedEvent`（`modules/robot/api.go`），
+  **不**照抄 mention_pref 的群频道消息——那条走群频道是因为免@偏好本身是群维度的。
+  事件**不携带具体新值**：带值就意味着事件与 profile 两条下发路径各自维护同一份
+  语义，一旦漂移，adapter 会拿事件里的旧形状覆盖 profile 的权威结果。
   best-effort：异步 + recover，投递失败只记日志，绝不影响写接口返回 200。
+- **多副本一致性分两档，且是刻意的**：per-Bot 覆盖**不做进程内缓存**，每次解析直读
+  MySQL，因此 owner 在副本 A 的改动对副本 B 立即可见；全局默认层继承
+  `system_setting` 的进程内快照 + `defaultReloadTTL=60s` 轮询，故改**全局默认**
+  最多 60s 才在所有副本生效。加 per-Bot 缓存会把即时一致换成 TTL 漂移，而失效事件
+  只到得了 Bot、到不了其它副本（要做得上 Redis pub/sub）——一致性优先于这点开销。
+- **热路径不得取进程级锁**：`common.EnsureSystemSettings` 每次调用都取全局 mutex
+  （`modules/common/system_settings.go`），而 `SystemSettings` 的设计前提是
+  「readers 走 atomic.Pointer、永不取锁」。解析器必须在**构造期**解析一次并持有实例
+  （`Robot.systemSettings` / `Service.systemSettings`），绝不可在每次请求里调
+  `EnsureSystemSettings`，否则等于把全局锁加到发卡路径上。
+- **门只加在新建路径**：`sendMessage` 的门在 `if cardIntent` 之内，非卡片消息零开销；
+  推理卡的流式更新走 `message/edit`，该路径**刻意不加门**（关闭只拦新建，已发卡要能
+  进终态）。故新增成本是「每张卡创建一次索引单行读」，而该路径本就有多次 DB 查询。
 
 ## Out of scope
 

--- a/.octospec/tasks/bot-setting-store/brief.md
+++ b/.octospec/tasks/bot-setting-store/brief.md
@@ -1,0 +1,123 @@
+---
+type: Task
+title: "Task: bot-setting-store"
+description: Generic per-bot config store (bot_setting) with a bot → global → code-default resolution chain; first consumer is the reasoning-progress card policy.
+tags: ["bot-api", "auth", "error-response", "wire-contract", "rate-limit", "testing"]
+timestamp: 2026-08-06T00:00:00Z
+slug: bot-setting-store
+upstream: openclaw-channel-octo 推理进度卡策略请求
+source: user
+---
+
+# Task: bot-setting-store
+
+## Goal
+
+给 Bot 一个**通用**的服务端配置存储，取代「一个开关加一列 `robot` 表」的现状。
+
+新增 `bot_setting` 稀疏覆盖表，解析链固定为：
+
+```
+bot_setting（该 Bot 的覆盖）→ system_setting（服务端全局默认）→ 代码默认
+```
+
+首个消费者是推理进度卡策略：Bot 级的 `mode`(off|on) 与 `template_ref`，由
+`GET /v1/bot/card/profile` 下发已解析好的有效配置，插件不再自行推断；
+`POST /v1/bot/sendMessage` 的模板分支按同一份有效配置二次校验。
+
+## Background
+
+**一维 per-bot 配置在本仓的既有做法是「给 `robot` 扩一列 + 一个 owner 自助端点」**：
+`auto_approve`（`modules/robot/api.go:1516-1554`）、`inline_on`、`placeholder`、
+`bot_commands`、`app_bot.welcome_msg` 都是这个形状。`robot` 表初始 7 列，之后 7 个
+迁移累计追加十余列，混装了身份、凭据、上报元数据与产品配置；滚动发布下 ALTER 还需
+手写并发守卫（`modules/botfather/sql/20260603000001_botfather_legacy01.sql:7-12`）。
+**本任务取代的正是「继续扩列」这条路**——因为 Bot 级配置项还会继续增加。
+
+`bot_mention_pref` 不是本任务的先例，也不迁入 `bot_setting`：它的维度是
+`(robot_id, group_no)` **二维**，`robot` 扩列在结构上做不到，开表是唯一选择。但它的
+**周边形状**是本任务要照搬的样板（owner 守卫、删除即回落、写后推事件失效缓存、
+owner 读与 adapter 读分属两个模块）。
+
+`system_setting`（`modules/common/system_settings.go`）已经把「schema 白名单 + 类型
+校验 + DB→fallback 解析链 + 管理端 `effective_value` 回显」做完并在生产验证过。本任务
+按同一形状做 per-bot 版本，并把它作为解析链的第二层。
+
+上游诉求（推理卡）要求服务端是配置权威、用户不改插件配置文件；`mode=off` 只阻止
+**新建**进度卡，已发出的卡仍可编辑到终态。
+
+## Load-bearing list
+
+- **`bot_setting` 稀疏语义**：只存偏离全局默认的覆盖项；无行 / 空串 value = 未配置，
+  回退下一层。删除覆盖 == 回落全局，不是「设为 off」。
+- **解析优先级**：bot 覆盖恒优先于全局默认；全局默认恒优先于代码默认。代码默认为
+  `mode=off`（未升级/未配置的部署行为不变，零回归）。
+- **键白名单**：未注册的 key 写入必须 400，不得长出野键（同 `system_setting` 的
+  `settingDef` 契约）。
+- **`enabled` 从属关系**：`cardmsg.BotEnabled()`（`OCTO_CARD_MESSAGE_ENABLED` AND
+  `OCTO_BOT_CARD_ENABLED`）为假时，profile 下发的有效 `mode` 必须是 `off` ——
+  清单绝不能报 `on` 而发卡被 `card_disabled` 拒（`pkg/cardmsg/cardmsg.go:177-200`
+  已确立的「清单与发卡门禁同源」不变量）。
+- **`reasoning_progress` 与 `templating` 自洽**：`mode=="on"` ⟹ 下发的 `template_ref`
+  必在同一响应的 `templating.templates` 内（即部署广告集
+  `defaultBotTemplatePolicy().AdvertisedSend`）。
+- **`/v1/bot/card/profile` wire 契约 additive-only**（`modules/bot_api/card_profile.go:23-24`）：
+  只增字段，不改名/不删/不改类型。
+- **发送端二次校验**：profile 是能力清单，`sendMessage` 模板分支必须独立按有效配置
+  校验（`mode==off` 拒绝；`template_ref` 必须等于该 Bot 的有效 ref），拒绝走单一
+  泛化码 `err.server.bot_api.card_invalid`，具体原因只进日志（防枚举）。
+- **`mode=off` 只拦新发**：`send.go` 模板分支加门，`botMessageEdit` 的模板分支不加 ——
+  已发出的卡必须能编辑到终态，否则线上残留「永久处理中」的卡。
+- **写入口鉴权 = bot owner 自助**：对齐 `setAutoApprove` / `setMentionPref` 的
+  `assertRobotOwner`（`creator_uid == loginUID`，robot 不存在 → 404、非 owner → 403、
+  DB 故障 → 500 且不得伪装成 404）。挂在 `/v1/robot/:robot_id/*`（user session）。
+  `/v1/manager/robots/*` 是平台运维面（状态/删除/重置 token），不是产品配置面。
+  `updated_by` 记录操作者 UID（即审计，不另开审计表）。
+- **删除覆盖 = 回落上一层，幂等**：删不存在的覆盖也返回 200（对齐
+  `deleteMentionPref`）。删除 ≠ 设为 `off`。
+- **写后推事件失效插件缓存**：配置变更后向该 Bot 投递一条合成事件，插件据此即时
+  重拉 profile，消除「改了开关要等插件 TTL」的窗口（对齐
+  `sendMentionPrefNotification` 的动机）。账号级配置无频道上下文，用既有的
+  `robot.IService.EnqueueBotEvent`（`modules/robot/api.go:81-86`）投进
+  `/v1/bot/events` 队列，**不**照抄 mention_pref 的群频道消息。
+  best-effort：异步 + recover，投递失败只记日志，绝不影响写接口返回 200。
+
+## Out of scope
+
+- `profiles` 按 Bot 裁剪。`pkg/cardmsg/profiles.go:16-35` 明确 `acceptedProfiles` 是
+  校验器接受集与 D12 清单的**单一权威**，按 Bot 裁剪会打破该不变量，且推理卡的
+  active/error 两个 view 本身是 `octo/v2`，裁掉会把卡砍成只剩终态。单独立项。
+- 静态内置模板的 block 通道（`Blocked` 只存在于动态 artifact meta）。
+- per-bot 模板可见性 / grant 模型。本任务的可见性 == `template_ref` 必须在部署广告集内。
+- 平台管理端（`/v1/manager/robots/*`）的配置写入口与「管理员覆盖 owner」的优先级。
+  本任务只做 owner 自助写；管理端若需要，是后续一期。
+- 存量 `robot` 表配置列（`inline_on`/`auto_approve`/…）的迁移或读路径收口。
+- `bot_mention_pref` 的迁入。它是 `(robot_id, group_no)` 二维配置，不属于
+  `bot_setting` 的一维模型，保持独立。
+- 配置读缓存。v1 走单行主键查询，与 send 路径已有的 DB 查询同量级。
+- 插件侧改造（Model B 废弃、`cardProgress` 移除等）。
+
+## Acceptance
+
+- 无 `bot_setting` 行且无 `system_setting` 行 → 有效 `mode=="off"`；profile 下发
+  `reasoning_progress.mode=="off"`；模板发送被拒（`err.server.bot_api.card_invalid`）。
+- Bot A 写 `mode=on` → profile 下发 `on` + `template_ref`；模板发送成功；Bot B 无记录
+  仍为 `off`，互不影响。
+- `system_setting` 全局设 `on`、Bot B 显式覆盖 `off` → B 有效值仍是 `off`（bot 层优先）。
+- 覆盖行被删除（写空 value）→ 该 Bot 回落全局默认，而非落到代码默认。
+- `cardmsg.BotEnabled()==false` 时，无论 bot/全局配置为何，profile 的
+  `reasoning_progress.mode` 恒为 `off`。
+- `mode=="on"` 时，profile 里的 `template_ref` 必然出现在同一响应的
+  `templating.templates` 中（断言两者一致，防止自相矛盾）。
+- Bot A 用不等于自己有效配置的 `template_ref` 发送 → 400 `err.server.bot_api.card_invalid`，
+  且响应体不透出「该模板属于其他 Bot」之类可枚举信息。
+- 未注册 key 写入 → 400；已注册 key 的非法值（`mode` 非 off/on）→ 400。
+- 非 owner 写该 Bot 配置 → 403；robot 不存在/无 `creator_uid` → 404；DB 故障 → 500
+  且不被伪装成 404。
+- 删除不存在的覆盖 → 200（幂等）；删除后有效值回落全局默认而非代码默认。
+- 写入成功后向该 Bot 的 `/v1/bot/events` 队列投递一条配置变更事件；事件投递失败
+  不影响写接口返回 200。
+- `mode==off` 时 `POST /v1/bot/message/edit` 的模板分支仍可把已发卡编辑到终态。
+- 新增 handler 文件已加入 `modules/robot/api_i18n_test.go` 与
+  `modules/bot_api/api_i18n_test.go` 的 `NoLegacyResponseError` 守卫列表。
+- `go build ./...`、相关模块 `go test`、`make i18n-extract-check`、`make i18n-lint` 通过。

--- a/.octospec/tasks/bot-setting-store/brief.md
+++ b/.octospec/tasks/bot-setting-store/brief.md
@@ -76,12 +76,18 @@ owner 读与 adapter 读分属两个模块）。
 - **总闸支配子开关**：`card_enabled==false` ⟹ 三个子开关的有效值全为 `false`。
   profile 绝不能报某个子开关为 true 而发卡被 `card_disabled` 拒
   （`pkg/cardmsg/cardmsg.go:177-200` 已确立的「清单与发卡门禁同源」不变量）。
-- **display / interaction / reasoning 三者正交**：`display_enabled` 与
-  `interaction_enabled` 只管 **raw 卡路径**（bot 自拼 card JSON），**绝不可**实现成
-  「按 wire profile 一刀切」。推理卡自身横跨两档
-  （`ai.reasoning-process@0.3.0/manifest.json`：active/error = `octo/v2`，
-  result = `octo/v1`），按 profile 切会把它砍成只剩终态或只剩过程。模板卡只看
-  `reasoning_enabled`。
+- **raw 卡两档 vs 模板卡正交；display 是 raw 档内的下限**（round-1/2 评审后修订）：
+  `display_enabled` / `interaction_enabled` 只管 **raw 卡路径**（bot 自拼 card JSON），
+  `reasoning_enabled` 只管**模板卡**——这两组之间正交，**绝不可**按 wire profile 一刀切。
+  推理卡自身横跨两档（`ai.reasoning-process@0.3.0/manifest.json`：active/error =
+  `octo/v2`，result = `octo/v1`），按 profile 切会把它砍成只剩终态或只剩过程。
+  但 raw 档**内部**，display 与 interaction 不是并列关系：`octo/v2` 是 `octo/v1` 的
+  严格超集（`cardmsg.validateCard` 的 `interactive` 只放宽校验、从不要求必须有交互
+  元素），所以 `octo/v1` 需要 `display`，`octo/v2` 需要 **`display` AND `interaction`**。
+  并列会让「改一个 profile 字符串」绕过 `display_enabled=false`。
+  判定收口在 `BotCardConfig.AllowsRawDisplayCard()` /
+  `AllowsRawInteractiveCard()`，**发送门、编辑门与 profile 清单三处共用**，不得各自
+  组合布尔——否则会出现清单报 true 而发卡被拒的自相矛盾。
 - **键白名单是可查询的**：同一份注册表既是写入校验的白名单，也是 owner 读接口
   返回的「可配置项目录」——客户端据此渲染「Bot 管理」列表，新增一个键不需要客户端
   发版。未注册的 key 写入必须 400，不得长出野键（同 `system_setting` 的 `settingDef`）。
@@ -99,12 +105,23 @@ owner 读与 adapter 读分属两个模块）。
   头。任何按 URL 缓存的共享代理都会把 Bot A 的配置回给 Bot B。成功路径必须下发
   `Cache-Control: private, no-store`（`private` 禁共享缓存，`no-store` 连私有副本
   也不留——配置改动要即时生效）。owner 读接口同口径。两处都有测试钉住。
-- **发送端二次校验**：profile 是能力清单，`sendMessage` 必须独立按有效配置校验
-  （模板分支 `reasoning_enabled==false` 拒绝；raw 分支按 `display_enabled` /
-  `interaction_enabled` 拒绝），拒绝走单一泛化码 `err.server.bot_api.card_invalid`，
+- **三个卡片生产者入口都必须二次校验**（round-2 评审后修订）：profile 只是能力清单，
+  producer 可以持有陈旧副本或干脆不读，所以每条**已鉴权**的发送路径都要独立按有效
+  配置校验。本仓有三个 ingress，`payloadIsVail` 的注释即写明三者须**对称**：
+  `bot_api` 的 `sendMessage`、`bot_api` 的 raw `message/edit`、以及 legacy
+  `POST /v1/robots/:robot_id/:app_key/sendMessage`（`modules/robot`）。它们共用同一个
+  Bot 身份（`bot_setting.robot_id` 与 `authRobot` / `assertRobotOwner` 取自同一列），
+  漏掉任何一条，这个开关就只是建议而非能力控制。拒绝一律走各自 ingress 既有的单一
+  泛化码（`bot_api` → `err.server.bot_api.card_invalid`；robot → content-invalid），
   具体原因只进日志（防枚举）。
-- **关闭只拦新发**：门加在 `send.go`，`botMessageEdit` 的模板分支不加 —— 已发出的卡
-  必须能编辑到终态，否则线上残留「永久处理中」的卡。
+  用户 ingress 与 robot 的 `message/edit` 无需加门：前者无条件拒卡，后者经
+  `cardmsg.RejectsCardEdit` 拒绝一切卡片编辑。
+- **关闭只拦模板卡的续帧，不拦 raw 卡的改写**（round-1 评审后修订）：`sendMessage`
+  全量加门；`botMessageEdit` 的**模板分支**不加门——流式推理卡必须能编辑到终态，
+  否则线上残留「永久处理中」的卡。但**raw 分支必须加门**：`cardmsg.Validate` 接受
+  接受集内的任意 profile 且不比对编辑帧与原消息，缺了这道门就有提权通道（先发
+  `octo/v1`，再把 `content_edit` 换成带 `Action.Submit` 的 `octo/v2` 帧，而该帧正是
+  动作端点信任的生效帧）。
 - **写入口鉴权 = bot owner 自助**：对齐 `setAutoApprove` / `setMentionPref` 的
   `assertRobotOwner`（`creator_uid == loginUID`，robot 不存在 → 404、非 owner → 403、
   DB 故障 → 500 且不得伪装成 404）。挂在 `/v1/robot/:robot_id/*`（user session）。
@@ -130,9 +147,10 @@ owner 读与 adapter 读分属两个模块）。
   「readers 走 atomic.Pointer、永不取锁」。解析器必须在**构造期**解析一次并持有实例
   （`Robot.systemSettings` / `Service.systemSettings`），绝不可在每次请求里调
   `EnsureSystemSettings`，否则等于把全局锁加到发卡路径上。
-- **门只加在新建路径**：`sendMessage` 的门在 `if cardIntent` 之内，非卡片消息零开销；
-  推理卡的流式更新走 `message/edit`，该路径**刻意不加门**（关闭只拦新建，已发卡要能
-  进终态）。故新增成本是「每张卡创建一次索引单行读」，而该路径本就有多次 DB 查询。
+- **成本只落在卡片路径上**：门都在「这条消息是不是卡」的判断之内，非卡片消息零开销。
+  按路径计：raw 卡新建、raw 卡编辑各一次索引单行读；模板卡只在新建时读一次，
+  流式续帧走 `message/edit` 的模板分支，不加门也就没有额外读。这些路径本就有多次
+  DB 查询，量级相当。
 
 ## Out of scope
 

--- a/.octospec/tasks/bot-setting-store/brief.md
+++ b/.octospec/tasks/bot-setting-store/brief.md
@@ -94,6 +94,11 @@ owner 读与 adapter 读分属两个模块）。
   `defaultBotTemplatePolicy().AdvertisedSend`）；`false` 时必须为 `null`。
 - **`/v1/bot/card/profile` wire 契约 additive-only**（`modules/bot_api/card_profile.go:23-24`）：
   只增 `config` 对象，现有字段（含 `enabled`）不改名/不删/不改类型/不改语义。
+- **响应变私有后必须禁共享缓存**：加了 `config` 之后该端点不再是「所有 Bot 同一份的
+  部署级常量」，但 **URL 对所有 Bot 逐字节相同**——区分调用者的只有 Authorization
+  头。任何按 URL 缓存的共享代理都会把 Bot A 的配置回给 Bot B。成功路径必须下发
+  `Cache-Control: private, no-store`（`private` 禁共享缓存，`no-store` 连私有副本
+  也不留——配置改动要即时生效）。owner 读接口同口径。两处都有测试钉住。
 - **发送端二次校验**：profile 是能力清单，`sendMessage` 必须独立按有效配置校验
   （模板分支 `reasoning_enabled==false` 拒绝；raw 分支按 `display_enabled` /
   `interaction_enabled` 拒绝），拒绝走单一泛化码 `err.server.bot_api.card_invalid`，

--- a/.octospec/tasks/bot-setting-store/brief.md
+++ b/.octospec/tasks/bot-setting-store/brief.md
@@ -124,9 +124,19 @@ owner 读与 adapter 读分属两个模块）。
   **拒绝而非补门是刻意的**：补门要在这条路上重建形状校验、URL 白名单、节点/深度上限与
   profile 协商，等于把 `sendMessage` 的流水线复制一遍，也就再造一处会漂移的判定；而流式
   消息的用途是增量文本，卡片有 `sendMessage` 与模板 `message/edit` 两条正规入口。
-  **该 handler 另外两个先于本任务存在的问题不在本任务范围，也不该被这道门掩盖**：缺少
-  `allowSendToChannel`，以及 `from_uid` 由调用方指定而非取自已鉴权的 `robot_id`（冒充
-  类，评审认为比卡片那条更严重）。详见 journal 的 known-gaps。
+  **本任务确实扩到了这两条，规格在此认下**（round-8 评审指出 spec 与实现矛盾）：
+  `from_uid` 现钉为 `c.Param("robot_id")`，`allowSendToChannel` 现被调用。它们最初写在
+  「不在范围」里，随后评审判定卡片拒绝**单独不足以**解除阻塞——「documenting the gap does
+  not close the forgeable `from_uid` symmetry break」——于是同轮补上。留着旧措辞会让规格
+  与代码互相打架，所以改的是规格，不是代码。
+  连带影响必须写在规格里而不是只写在 journal 里：`allowSendToChannel` 是三条 robot
+  ingress 共用的谓词，补上子区（`ChannelTypeCommunityTopic`）判定后，`sendMessage` 与
+  `typing` **也**获得了子区支持——两个本任务不拥有的端点的行为变更。方向是放宽（子区：
+  永远拒 → 按父群活跃成员判定），故不会让今天能发的变成不能发。
+  子区成员判定用 **`ExistMemberActive`**（`is_deleted=0` AND `status=Normal`），不是
+  `ExistMember`：后者对被拉黑成员仍返回 true，而 robot ingress 服务端直发、不经 IM
+  datasource，拿不到 thread 的子区拉黑继承，本地这道门是唯一防线。全仓每一处子区门禁
+  都用严格变体，这里一度是唯一例外（round-8 评审 P1）。
 - **关闭只拦模板卡的续帧，不拦 raw 卡的改写**（round-1 评审后修订）：`sendMessage`
   全量加门；`botMessageEdit` 的**模板分支**不加门——流式推理卡必须能编辑到终态，
   否则线上残留「永久处理中」的卡。但**raw 分支必须加门**：`cardmsg.Validate` 接受

--- a/.octospec/tasks/bot-setting-store/brief.md
+++ b/.octospec/tasks/bot-setting-store/brief.md
@@ -21,9 +21,17 @@ source: user
 bot_setting（该 Bot 的覆盖）→ system_setting（服务端全局默认）→ 代码默认
 ```
 
-首个消费者是推理进度卡策略：Bot 级的 `mode`(off|on) 与 `template_ref`，由
-`GET /v1/bot/card/profile` 下发已解析好的有效配置，插件不再自行推断；
-`POST /v1/bot/sendMessage` 的模板分支按同一份有效配置二次校验。
+三个面向：
+
+1. **owner 配置面**（`/v1/robot/:robot_id/settings`，user session + `assertRobotOwner`）——
+   「Bot 管理」页要能**查询本部署有哪些可配置项**并**回显当前值**，而不是由客户端
+   硬编码一张列表。读接口返回全部已注册键 + 该 Bot 的覆盖值 + 三层解析后的有效值 +
+   值来源；写/删接口改这一份覆盖。
+2. **adapter 消费面**（`GET /v1/bot/card/profile`，botToken）——下发**已解析好**的
+   卡片有效配置（`reasoning_progress.mode` / `template_ref`），插件不再自行推断。
+3. **发送端**（`POST /v1/bot/sendMessage` 模板分支）——按同一份有效配置二次校验。
+
+首个消费者是推理进度卡策略：Bot 级的 `mode`(off|on) 与 `template_ref`。
 
 ## Background
 
@@ -52,8 +60,13 @@ owner 读与 adapter 读分属两个模块）。
   回退下一层。删除覆盖 == 回落全局，不是「设为 off」。
 - **解析优先级**：bot 覆盖恒优先于全局默认；全局默认恒优先于代码默认。代码默认为
   `mode=off`（未升级/未配置的部署行为不变，零回归）。
-- **键白名单**：未注册的 key 写入必须 400，不得长出野键（同 `system_setting` 的
-  `settingDef` 契约）。
+- **键白名单是可查询的**：同一份注册表既是写入校验的白名单，也是 owner 读接口
+  返回的「可配置项目录」——客户端据此渲染「Bot 管理」列表，新增一个键不需要客户端
+  发版。未注册的 key 写入必须 400，不得长出野键（同 `system_setting` 的 `settingDef`）。
+- **回显三态必须可区分**：读接口对每个键同时返回 `value`（该 Bot 的显式覆盖，未设
+  为空）、`effective_value`（三层解析结果）与 `source`（`bot`/`global`/`default`）。
+  只返回一个合并值，UI 就无法区分「我显式设成了 off」与「我没设、跟随全局默认 off」，
+  也就无法正确渲染「恢复默认」。
 - **`enabled` 从属关系**：`cardmsg.BotEnabled()`（`OCTO_CARD_MESSAGE_ENABLED` AND
   `OCTO_BOT_CARD_ENABLED`）为假时，profile 下发的有效 `mode` 必须是 `off` ——
   清单绝不能报 `on` 而发卡被 `card_disabled` 拒（`pkg/cardmsg/cardmsg.go:177-200`
@@ -95,6 +108,10 @@ owner 读与 adapter 读分属两个模块）。
 - `bot_mention_pref` 的迁入。它是 `(robot_id, group_no)` 二维配置，不属于
   `bot_setting` 的一维模型，保持独立。
 - 配置读缓存。v1 走单行主键查询，与 send 路径已有的 DB 查询同量级。
+- **配置项标题/副标题的服务端本地化下发**。读接口只返回 `key` / `type` / `options`
+  等结构信息，展示文案由客户端按 key 自持（现状「Bot 管理」页的免@回答等条目已是
+  客户端文案）。服务端下发本地化文案需要一套非错误码的 i18n 消息注册面，本任务不建。
+  客户端遇到不认识的 key 应跳过，不阻塞渲染。
 - 插件侧改造（Model B 废弃、`cardProgress` 移除等）。
 
 ## Acceptance
@@ -112,7 +129,11 @@ owner 读与 adapter 读分属两个模块）。
 - Bot A 用不等于自己有效配置的 `template_ref` 发送 → 400 `err.server.bot_api.card_invalid`，
   且响应体不透出「该模板属于其他 Bot」之类可枚举信息。
 - 未注册 key 写入 → 400；已注册 key 的非法值（`mode` 非 off/on）→ 400。
-- 非 owner 写该 Bot 配置 → 403；robot 不存在/无 `creator_uid` → 404；DB 故障 → 500
+- owner 读接口返回全部已注册键；每个键的 `value` / `effective_value` / `source`
+  三者可区分：未设覆盖时 `value==""` 且 `source!="bot"`；显式设为与全局同值时
+  `value` 非空且 `source=="bot"`。
+- 新注册一个键后，owner 读接口立即返回它（客户端无需发版即可发现新配置项）。
+- 非 owner 读/写该 Bot 配置 → 403；robot 不存在/无 `creator_uid` → 404；DB 故障 → 500
   且不被伪装成 404。
 - 删除不存在的覆盖 → 200（幂等）；删除后有效值回落全局默认而非代码默认。
 - 写入成功后向该 Bot 的 `/v1/bot/events` 队列投递一条配置变更事件；事件投递失败

--- a/.octospec/tasks/bot-setting-store/context.yaml
+++ b/.octospec/tasks/bot-setting-store/context.yaml
@@ -1,0 +1,53 @@
+injected:
+  - id: space-isolation
+    source: repo
+    why: |
+      本任务主轴。brief touches auth/bot-api，且改动落在 modules/**/*.go。
+      落实点：owner 端点全部经 assertRobotOwner（creator_uid == loginUID）后才
+      触碰 bot_setting；/v1/bot/card/profile 与 sendMessage 的 robotID 一律取自
+      authBot 上下文，绝不信任 query/body。bot_setting 是 (robot_id) 一维、
+      非 Space 维数据，不挂 SpaceMiddleware——与既有 bot_mention_pref 同口径。
+  - id: error-handling
+    source: repo
+    why: |
+      touches error-response/i18n/wire-contract。所有新响应走
+      httperr.ResponseErrorL + 已注册 errcode；复用 robot 既有码
+      （ErrRobotRequestInvalid / ErrRobotNotFound / ErrRobotCreatorOnly /
+      ErrRobotQueryFailed / ErrRobotStoreFailed）与 bot_api 的
+      ErrBotAPICardInvalid，本任务不新增错误码。发送端拒绝统一收敛到
+      card_invalid 单码（防枚举），具体原因只进日志。
+  - id: rate-limit
+    source: repo
+    why: |
+      新增三个已鉴权 owner 路由。robot 的主 auth 组
+      （api.go:387 r.Group("/v1", AuthMiddleware)）没有挂 UID 限流，
+      为不改动既有路由的行为，新路由按 per-route middleware 挂
+      appwkhttp.SharedUIDRateLimiter，顺序在 AuthMiddleware 之后（否则读不到
+      uid 会静默 fail-open）。不自建 Redis 计数器。
+  - id: trust-boundary
+    source: repo
+    why: |
+      经 touches wire-contract 命中。已通读——本任务不渲染外部内容、不产出
+      markdown/URL 目标，转义与适配器对等条款不适用。保留的精神是「在调用方
+      跨不过去的边界上校验」：键白名单与 bool 字面量校验放在服务端写入路径，
+      而不是依赖客户端只提交合法值；card_enabled 做成派生只读，调用方无法
+      通过写库伪造「卡片已启用」。
+  - id: testing
+    source: repo
+    why: 新增测试文件；解析链与守卫判定抽成纯函数以便无 DB 单测。
+  - id: commit-style
+    source: repo
+    why: paths ["**"] 全匹配；提交信息用英文 Conventional Commits。
+
+brief: .octospec/tasks/bot-setting-store/brief.md
+
+notes:
+  - _global 未同步（.octospec/_global/ 不存在），仅 repo 层规则生效。
+  - 解析链第二层复用 modules/common 的 system_setting。modules/robot 此前不依赖
+    modules/common，已确认无环：modules/common 只导入 modules/base/common，
+    后者不导入 modules/robot。
+  - bot_setting 的稀疏语义与 updated_by 审计列照搬 bot_mention_pref
+    （modules/robot/sql/20260603000001_bot_mention_pref.sql）。
+  - 配置变更事件用 robot.IService.EnqueueBotEvent（账号级、无频道上下文），
+    不照抄 sendMentionPrefNotification 的群频道消息——后者走群频道是因为它的
+    偏好本身是群维度的。

--- a/modules/bot_api/bot_api.go
+++ b/modules/bot_api/bot_api.go
@@ -54,6 +54,16 @@ type BotAPI struct {
 	// AFTER dispatchFanout succeeds so we only enqueue events that
 	// WuKongIM actually accepted.
 	robotService robot.IService
+	// cardConfig resolves the per-Bot card capability switches (task
+	// bot-setting-store). Production points it at the same robotService
+	// instance above; it is a separate, one-method field so focused tests can
+	// inject a fake without implementing all of robot.IService — same reason
+	// modules/file declares stickerSystemSettings instead of taking the whole
+	// *common.SystemSettings.
+	//
+	// A nil value is a wiring error, not a permissive default: the card paths
+	// fail closed rather than assume every switch is on.
+	cardConfig botCardConfigResolver
 	// ackFilteredEvent overrides the auto-ACK write in filterAppBotEvents.
 	// Production leaves it nil (see BotAPI.ackEvent); tests set it to inject a
 	// Redis whose reads succeed while writes fail, which is the state the
@@ -244,6 +254,8 @@ func NewBotAPI(ctx *config.Context) *BotAPI {
 		}
 	}
 
+	robotService := robot.NewService(ctx)
+
 	ba := &BotAPI{
 		ctx:                   ctx,
 		db:                    newBotAPIDB(ctx),
@@ -252,7 +264,8 @@ func NewBotAPI(ctx *config.Context) *BotAPI {
 		groupService:          group.NewService(ctx),
 		userDB:                user.NewDB(ctx),
 		threadService:         thread.NewService(ctx),
-		robotService:          robot.NewService(ctx),
+		robotService:          robotService,
+		cardConfig:            robotService,
 		cardRevisions:         cardrevision.NewStore(ctx.DB()),
 		cardMutator:           carddispatch.NewCardMutator(ctx),
 		cardTemplates:         cardTemplates,

--- a/modules/bot_api/bot_setting_card_test.go
+++ b/modules/bot_api/bot_setting_card_test.go
@@ -548,3 +548,56 @@ func TestBotMessageEdit_RawCardCannotEscalateProfile(t *testing.T) {
 		t.Fatalf("edit refused with every switch on; body=%s", okRecorder.Body.String())
 	}
 }
+
+// TestBotCardConfigResponse_ManifestAgreesWithTheGate is the regression for
+// round-2 P1-2: the round-1 floor fix changed what the gate accepts but not what
+// the manifest advertised, so with display=false/interaction=true the profile
+// reported interaction_enabled:true while the gate refused every octo/v2 card.
+//
+// That is the precise failure this endpoint exists to prevent — a producer is
+// supposed to read the manifest instead of probing with "send one and see if it
+// 400s", because a 400 cannot distinguish "capability off" from "card illegal".
+//
+// Asserted as agreement rather than as a literal, so the two can never be
+// changed apart again.
+func TestBotCardConfigResponse_ManifestAgreesWithTheGate(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	catalog, err := newBotCardTemplateCatalog(testBotTemplateRegistry(t), defaultBotTemplateRefs())
+	if err != nil {
+		t.Fatal(err)
+	}
+	ba := &BotAPI{Log: log.NewTLog("BotAPI-manifest-gate-agree"), cardTemplates: catalog}
+
+	// Every reachable combination of the two raw switches, master on.
+	for _, display := range []bool{false, true} {
+		for _, interaction := range []bool{false, true} {
+			cfg := robot.BotCardConfig{
+				CardEnabled: true, DisplayEnabled: display, InteractionEnabled: interaction,
+			}
+			out := ba.botCardConfigResponse(cfg)
+
+			for _, tc := range []struct {
+				field   string
+				profile string
+			}{
+				{"display_enabled", cardmsg.ProfileV1},
+				{"interaction_enabled", cardmsg.ProfileV2},
+			} {
+				advertised, _ := out[tc.field].(bool)
+
+				recorder := httptest.NewRecorder()
+				ginContext, _ := gin.CreateTestContext(recorder)
+				ginContext.Request = httptest.NewRequest(http.MethodPost, "/x", nil)
+				gateRefused := ba.rejectRawCardByProfile(
+					&wkhttp.Context{Context: ginContext}, "bot-1", tc.profile, cfg)
+
+				if advertised == gateRefused {
+					t.Errorf("display=%v interaction=%v: manifest %s=%v but gate refused=%v — "+
+						"the manifest advertises a capability the send path does not accept",
+						display, interaction, tc.field, advertised, gateRefused)
+				}
+			}
+		}
+	}
+}

--- a/modules/bot_api/bot_setting_card_test.go
+++ b/modules/bot_api/bot_setting_card_test.go
@@ -8,10 +8,12 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/Mininglamp-OSS/octo-lib/common"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
 	"github.com/Mininglamp-OSS/octo-server/internal/carddispatch"
 	"github.com/Mininglamp-OSS/octo-server/modules/robot"
 	"github.com/Mininglamp-OSS/octo-server/pkg/cardmsg"
@@ -391,4 +393,158 @@ func errorMessageOf(t *testing.T, body []byte) string {
 		return envelope.Error.Message
 	}
 	return envelope.Msg
+}
+
+// TestRejectRawCardByProfile_DisplayIsAFloorNotAPeer is the regression for the
+// bypass review round 1 found: octo/v2 is a strict superset of octo/v1 (the
+// `interactive` flag in cardmsg.validateCard only ever relaxes checks, never
+// requires an interactive element), so if the two switches were parallel arms a
+// bot could defeat display_enabled=false by flipping one string and sending
+// byte-identical display-only cards.
+func TestRejectRawCardByProfile_DisplayIsAFloorNotAPeer(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	cases := []struct {
+		name       string
+		profile    string
+		config     robot.BotCardConfig
+		wantReject bool
+	}{
+		{
+			name: "display off rejects octo/v1", profile: cardmsg.ProfileV1,
+			config:     robot.BotCardConfig{CardEnabled: true, InteractionEnabled: true},
+			wantReject: true,
+		},
+		{
+			name: "display off ALSO rejects octo/v2 — the bypass", profile: cardmsg.ProfileV2,
+			config:     robot.BotCardConfig{CardEnabled: true, InteractionEnabled: true},
+			wantReject: true,
+		},
+		{
+			name: "interaction off rejects octo/v2", profile: cardmsg.ProfileV2,
+			config:     robot.BotCardConfig{CardEnabled: true, DisplayEnabled: true},
+			wantReject: true,
+		},
+		{
+			name: "interaction off leaves octo/v1 alone", profile: cardmsg.ProfileV1,
+			config:     robot.BotCardConfig{CardEnabled: true, DisplayEnabled: true},
+			wantReject: false,
+		},
+		{
+			name: "both on accepts octo/v2", profile: cardmsg.ProfileV2,
+			config: robot.BotCardConfig{
+				CardEnabled: true, DisplayEnabled: true, InteractionEnabled: true,
+			},
+			wantReject: false,
+		},
+		{
+			name: "an unknown profile fails closed", profile: "octo/v9",
+			config: robot.BotCardConfig{
+				CardEnabled: true, DisplayEnabled: true, InteractionEnabled: true,
+			},
+			wantReject: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ba := &BotAPI{Log: log.NewTLog("BotAPI-raw-profile-floor")}
+			recorder := httptest.NewRecorder()
+			ginContext, _ := gin.CreateTestContext(recorder)
+			ginContext.Request = httptest.NewRequest(http.MethodPost, "/x", nil)
+			ctx := &wkhttp.Context{Context: ginContext}
+
+			got := ba.rejectRawCardByProfile(ctx, "bot-1", tc.profile, tc.config)
+			if got != tc.wantReject {
+				t.Fatalf("reject=%v, want %v", got, tc.wantReject)
+			}
+		})
+	}
+}
+
+// TestBotTemplateSwitchCoversAdvertisedSet keeps the template gate honest: every
+// template this deployment advertises for new sends must map to a per-Bot
+// switch. Without this, adding a second template to AdvertisedSend would let it
+// slip past the per-Bot policy entirely, and nothing would say so.
+func TestBotTemplateSwitchCoversAdvertisedSet(t *testing.T) {
+	allOn := robot.BotCardConfig{
+		CardEnabled: true, DisplayEnabled: true,
+		InteractionEnabled: true, ReasoningEnabled: true,
+	}
+	for _, ref := range defaultBotTemplatePolicy().AdvertisedSend {
+		if _, mapped := botTemplateSwitchFor(ref.ID, allOn); !mapped {
+			t.Errorf("advertised template %s has no per-Bot switch; the send gate would not govern it", ref.ID)
+		}
+	}
+	// And an unmapped id must report "no mapping" so the caller fails closed.
+	if _, mapped := botTemplateSwitchFor("some.future-template", allOn); mapped {
+		t.Error("an unmapped template reported a mapping")
+	}
+}
+
+// TestBotMessageEdit_RawCardCannotEscalateProfile is the regression for the
+// privilege-escalation path review round 1 found.
+//
+// cardmsg.Validate accepts any profile in the accepted set and never compares
+// the edit frame against the original message, so before the gate was added to
+// the raw edit path a bot with interaction_enabled=false could: send an octo/v1
+// display card (allowed), then edit content_edit into an octo/v2 frame carrying
+// Action.Submit. That normalized frame is the one the action endpoint treats as
+// authoritative, so the result was a live, clickable card from a bot whose owner
+// had switched interaction off — and any card sent before the flip was a
+// permanent foothold.
+func TestBotMessageEdit_RawCardCannotEscalateProfile(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	t.Setenv(cardmsg.EnvEnabled, "true")
+
+	interactionOff := robot.BotCardConfig{
+		CardEnabled: true, DisplayEnabled: true, InteractionEnabled: false,
+	}
+	escalatingEdit := map[string]any{
+		"type": cardmsg.InteractiveCard.Int(), "profile": cardmsg.ProfileV2,
+		"card_version": cardmsg.CardVersion,
+		"card": map[string]any{
+			"type": "AdaptiveCard", "version": cardmsg.CardVersion,
+			"body": []any{map[string]any{"type": "TextBlock", "text": "escalated"}},
+			"actions": []any{map[string]any{
+				"type": "Action.Submit", "id": "escalate", "title": "click me",
+			}},
+		},
+	}
+	raw, err := json.Marshal(escalatingEdit)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ba := &BotAPI{
+		Log:        log.NewTLog("BotAPI-edit-escalation"),
+		cardConfig: stubCardConfig{config: interactionOff},
+	}
+	recorder := httptest.NewRecorder()
+	ginContext, _ := gin.CreateTestContext(recorder)
+	ginContext.Request = httptest.NewRequest(http.MethodPost, "/x", nil)
+	ctx := &wkhttp.Context{Context: ginContext}
+	ctx.Set(CtxKeyRobotID, "bot-escalation")
+
+	if !ba.rejectRawCardEditByPolicy(ctx, string(raw)) {
+		t.Fatal("an octo/v2 edit frame was accepted while interaction is off")
+	}
+	if msg := errorMessageOf(t, recorder.Body.Bytes()); msg != errcode.ErrBotAPICardInvalid.DefaultMessage {
+		t.Fatalf("msg=%q, want the generic card_invalid", msg)
+	}
+
+	// The same frame is fine once interaction is on — the gate is about policy,
+	// not about rejecting v2 edits wholesale.
+	allowed := &BotAPI{
+		Log:        log.NewTLog("BotAPI-edit-escalation-allowed"),
+		cardConfig: allCardCapabilitiesOn(),
+	}
+	okRecorder := httptest.NewRecorder()
+	okGin, _ := gin.CreateTestContext(okRecorder)
+	okGin.Request = httptest.NewRequest(http.MethodPost, "/x", nil)
+	okCtx := &wkhttp.Context{Context: okGin}
+	okCtx.Set(CtxKeyRobotID, "bot-escalation")
+	if allowed.rejectRawCardEditByPolicy(okCtx, string(raw)) {
+		t.Fatalf("edit refused with every switch on; body=%s", okRecorder.Body.String())
+	}
 }

--- a/modules/bot_api/bot_setting_card_test.go
+++ b/modules/bot_api/bot_setting_card_test.go
@@ -1,0 +1,139 @@
+package bot_api
+
+// task bot-setting-store —— /v1/bot/card/profile 的 config 对象与 sendMessage
+// 的 per-Bot 策略门。这里只覆盖不需要 DB 的部分（清单渲染的两条不变量），
+// 端到端行为在 card_profile_test.go / card_template_send_test.go 里。
+
+import (
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
+	"github.com/Mininglamp-OSS/octo-server/modules/robot"
+	aireasoningprocess "github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl/ai_reasoning_process"
+)
+
+// stubCardConfig is the fake botCardConfigResolver focused tests inject in
+// place of the real robot service.
+type stubCardConfig struct {
+	config robot.BotCardConfig
+	err    error
+}
+
+func (s stubCardConfig) BotCardConfig(string) (robot.BotCardConfig, error) {
+	return s.config, s.err
+}
+
+// allCardCapabilitiesOn is the resolver a focused send test wants when the
+// per-Bot policy is not what it is exercising.
+func allCardCapabilitiesOn() stubCardConfig {
+	return stubCardConfig{config: robot.BotCardConfig{
+		CardEnabled: true, DisplayEnabled: true,
+		InteractionEnabled: true, ReasoningEnabled: true,
+	}}
+}
+
+// TestBotCardConfigResponse_ReasoningRefMatchesAdvertisedCatalog pins the two
+// invariants the manifest owes a producer: a ref never accompanies a false
+// switch, and a ref that IS present is one the send path will accept.
+//
+// The second half is the one worth a test: the profile response and the send
+// allowlist are built in different functions, and a hand-written version string
+// in the manifest would drift silently the first time the advertised template
+// version moves.
+func TestBotCardConfigResponse_ReasoningRefMatchesAdvertisedCatalog(t *testing.T) {
+	catalog, err := newBotCardTemplateCatalog(testBotTemplateRegistry(t), defaultBotTemplateRefs())
+	if err != nil {
+		t.Fatal(err)
+	}
+	ba := &BotAPI{Log: log.NewTLog("BotAPI-card-config"), cardTemplates: catalog}
+
+	t.Run("enabled advertises a ref the send path accepts", func(t *testing.T) {
+		out := ba.botCardConfigResponse(robot.BotCardConfig{
+			CardEnabled: true, DisplayEnabled: true,
+			InteractionEnabled: true, ReasoningEnabled: true,
+		})
+		if out["reasoning_enabled"] != true {
+			t.Fatalf("reasoning_enabled = %v, want true", out["reasoning_enabled"])
+		}
+		ref, ok := out["reasoning_template_ref"].(map[string]interface{})
+		if !ok {
+			t.Fatalf("reasoning_template_ref = %#v, want an object", out["reasoning_template_ref"])
+		}
+		// The advertised ref must be present in templating.templates of the very
+		// same response — that is what makes "manifest says on" imply "send works".
+		advertised := false
+		for _, template := range catalog.Capability().Templates {
+			if template.ID == ref["id"] && template.Version == ref["version"] {
+				advertised = true
+			}
+		}
+		if !advertised {
+			t.Fatalf("ref %#v is not in the advertised catalog", ref)
+		}
+		// And it must survive the send-path allowlist check verbatim.
+		if _, err := catalog.requireRef(
+			map[string]any{"id": ref["id"], "version": ref["version"]},
+			catalog.sendAllowed, "not Bot-callable for new send",
+		); err != nil {
+			t.Fatalf("advertised ref rejected by send allowlist: %v", err)
+		}
+	})
+
+	t.Run("disabled carries no ref", func(t *testing.T) {
+		out := ba.botCardConfigResponse(robot.BotCardConfig{
+			CardEnabled: true, DisplayEnabled: true,
+			InteractionEnabled: true, ReasoningEnabled: false,
+		})
+		if out["reasoning_enabled"] != false {
+			t.Fatalf("reasoning_enabled = %v, want false", out["reasoning_enabled"])
+		}
+		if out["reasoning_template_ref"] != nil {
+			t.Fatalf("reasoning_template_ref = %#v, want nil", out["reasoning_template_ref"])
+		}
+	})
+}
+
+// TestBotCardConfigResponse_NoCatalogForcesReasoningOff covers the deployment
+// whose catalog does not advertise the reasoning template: the switch alone is
+// not enough, so the manifest must report the capability as off rather than
+// advertise a template nothing can render.
+func TestBotCardConfigResponse_NoCatalogForcesReasoningOff(t *testing.T) {
+	ba := &BotAPI{Log: log.NewTLog("BotAPI-card-config-nocatalog")} // cardTemplates nil
+
+	out := ba.botCardConfigResponse(robot.BotCardConfig{
+		CardEnabled: true, DisplayEnabled: true,
+		InteractionEnabled: true, ReasoningEnabled: true,
+	})
+	if out["reasoning_enabled"] != false {
+		t.Fatalf("reasoning_enabled = %v, want false when nothing is advertised", out["reasoning_enabled"])
+	}
+	if out["reasoning_template_ref"] != nil {
+		t.Fatalf("reasoning_template_ref = %#v, want nil", out["reasoning_template_ref"])
+	}
+}
+
+// TestAdvertisedRef_UnknownTemplateIsNotAdvertised guards the lookup itself:
+// asking for a template this deployment does not advertise must report "no",
+// never fall back to some other entry.
+func TestAdvertisedRef_UnknownTemplateIsNotAdvertised(t *testing.T) {
+	catalog, err := newBotCardTemplateCatalog(testBotTemplateRegistry(t), defaultBotTemplateRefs())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := catalog.AdvertisedRef("docs.access-request"); ok {
+		t.Fatal("AdvertisedRef returned a ref for a template that is not advertised to bots")
+	}
+	if ref, ok := catalog.AdvertisedRef(aireasoningprocess.TemplateID); !ok ||
+		ref.Version != aireasoningprocess.TemplateVersionV3 {
+		t.Fatalf("AdvertisedRef(%s) = %#v ok=%v", aireasoningprocess.TemplateID, ref, ok)
+	}
+}
+
+// TestResolveBotCardConfig_FailsClosedWithoutResolver pins the wiring-error
+// posture: no resolver must not read as "every capability is on".
+func TestResolveBotCardConfig_FailsClosedWithoutResolver(t *testing.T) {
+	ba := &BotAPI{Log: log.NewTLog("BotAPI-card-config-unwired")}
+	if _, err := ba.resolveBotCardConfig("bot-1"); err == nil {
+		t.Fatal("resolveBotCardConfig succeeded without a resolver; must fail closed")
+	}
+}

--- a/modules/bot_api/bot_setting_card_test.go
+++ b/modules/bot_api/bot_setting_card_test.go
@@ -5,11 +5,19 @@ package bot_api
 // 端到端行为在 card_profile_test.go / card_template_send_test.go 里。
 
 import (
+	"encoding/json"
+	"errors"
+	"net/http"
 	"testing"
 
+	"github.com/Mininglamp-OSS/octo-lib/common"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
+	"github.com/Mininglamp-OSS/octo-server/internal/carddispatch"
 	"github.com/Mininglamp-OSS/octo-server/modules/robot"
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardmsg"
 	aireasoningprocess "github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl/ai_reasoning_process"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
+	"github.com/gin-gonic/gin"
 )
 
 // stubCardConfig is the fake botCardConfigResolver focused tests inject in
@@ -136,4 +144,251 @@ func TestResolveBotCardConfig_FailsClosedWithoutResolver(t *testing.T) {
 	if _, err := ba.resolveBotCardConfig("bot-1"); err == nil {
 		t.Fatal("resolveBotCardConfig succeeded without a resolver; must fail closed")
 	}
+}
+
+// TestBotCardConfigResponse_MasterSwitchOffZeroesEverything pins the manifest
+// side of the master-switch invariant: with the deployment gate off, no
+// sub-capability may be advertised and no ref may be handed out. Advertising
+// either would point a producer at a send that BotEnabled() refuses outright.
+func TestBotCardConfigResponse_MasterSwitchOffZeroesEverything(t *testing.T) {
+	catalog, err := newBotCardTemplateCatalog(testBotTemplateRegistry(t), defaultBotTemplateRefs())
+	if err != nil {
+		t.Fatal(err)
+	}
+	ba := &BotAPI{Log: log.NewTLog("BotAPI-card-config-master-off"), cardTemplates: catalog}
+
+	// This is what robot.BotCardConfig returns once applyCardMasterSwitch has
+	// run with the deployment gate off.
+	out := ba.botCardConfigResponse(robot.BotCardConfig{})
+	for _, key := range []string{
+		"card_enabled", "display_enabled", "interaction_enabled", "reasoning_enabled",
+	} {
+		if out[key] != false {
+			t.Errorf("%s = %v, want false when the master switch is off", key, out[key])
+		}
+	}
+	if out["reasoning_template_ref"] != nil {
+		t.Errorf("reasoning_template_ref = %#v, want nil", out["reasoning_template_ref"])
+	}
+}
+
+// TestSendMessage_RejectedByBotCardPolicy covers the enforcement half: the
+// manifest is advisory (a producer can hold a stale copy or ignore it), so each
+// switch has to be refused where the message is actually accepted.
+//
+// Every case must come back as the same generic card_invalid — a distinct code
+// per reason would let a caller probe another bot's configuration by diffing
+// error codes.
+func TestSendMessage_RejectedByBotCardPolicy(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	// Open the deployment master switch, otherwise the pre-existing
+	// BotEnabled() gate refuses everything with card_disabled and these cases
+	// would pass on the right status for the wrong reason.
+	t.Setenv(cardmsg.EnvEnabled, "true")
+
+	rawCard := func(profile string) map[string]any {
+		body := []any{map[string]any{"type": "TextBlock", "text": "policy gate"}}
+		card := map[string]any{"type": "AdaptiveCard", "version": cardmsg.CardVersion, "body": body}
+		if profile == cardmsg.ProfileV2 {
+			// octo/v2 needs an interactive affordance to be a meaningful v2 card.
+			card["actions"] = []any{map[string]any{
+				"type": "Action.Submit", "id": "ack", "title": "ack",
+			}}
+		}
+		return map[string]any{
+			"channel_id":   "user_creator",
+			"channel_type": common.ChannelTypePerson.Uint8(),
+			"payload": map[string]any{
+				"type": cardmsg.InteractiveCard.Int(), "profile": profile,
+				"card_version": cardmsg.CardVersion, "card": card,
+			},
+		}
+	}
+
+	cases := []struct {
+		name   string
+		config robot.BotCardConfig
+		body   func(t *testing.T) map[string]any
+	}{
+		{
+			name: "display off rejects a raw octo/v1 card",
+			config: robot.BotCardConfig{
+				CardEnabled: true, DisplayEnabled: false,
+				InteractionEnabled: true, ReasoningEnabled: true,
+			},
+			body: func(*testing.T) map[string]any { return rawCard(cardmsg.ProfileV1) },
+		},
+		{
+			name: "interaction off rejects a raw octo/v2 card",
+			config: robot.BotCardConfig{
+				CardEnabled: true, DisplayEnabled: true,
+				InteractionEnabled: false, ReasoningEnabled: true,
+			},
+			body: func(*testing.T) map[string]any { return rawCard(cardmsg.ProfileV2) },
+		},
+		{
+			name: "reasoning off rejects the template ref",
+			config: robot.BotCardConfig{
+				CardEnabled: true, DisplayEnabled: true,
+				InteractionEnabled: true, ReasoningEnabled: false,
+			},
+			body: func(t *testing.T) map[string]any {
+				return registrySendBody(t, "reasoning", testReasoningData(t, "reasoning"))
+			},
+		},
+		{
+			name: "a version this deployment does not advertise is refused even with reasoning on",
+			config: robot.BotCardConfig{
+				CardEnabled: true, DisplayEnabled: true,
+				InteractionEnabled: true, ReasoningEnabled: true,
+			},
+			body: func(t *testing.T) map[string]any {
+				// V1 stays edit-compatible but is not advertised for new sends.
+				return registrySendBodyVersion(t, aireasoningprocess.TemplateVersionV1,
+					"reasoning", testReasoningData(t, "reasoning"))
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			catalog, err := newBotCardTemplateCatalog(testBotTemplateRegistry(t), defaultBotTemplateRefs())
+			if err != nil {
+				t.Fatal(err)
+			}
+			dispatch := &dispatchCapture{}
+			ba := &BotAPI{
+				Log:              log.NewTLog("BotAPI-card-policy-gate"),
+				cardTemplates:    catalog,
+				cardConfig:       stubCardConfig{config: tc.config},
+				spaceQuerier:     &fakeSpaceQuerier{defaultSpace: "space-authoritative"},
+				dispatchOverride: dispatch.hook,
+			}
+
+			recorder := invokeTemplateSend(t, ba, tc.body(t), "")
+			if recorder.Code != http.StatusBadRequest {
+				t.Fatalf("status=%d, want 400; body=%s", recorder.Code, recorder.Body.String())
+			}
+			// Compared against the code's own DefaultMessage rather than a
+			// literal, so this asserts *which gate* refused without pinning
+			// copy. Distinguishing card_invalid from card_disabled matters:
+			// the latter would mean the deployment switch fired and the
+			// per-bot gate was never reached.
+			if msg := errorMessageOf(t, recorder.Body.Bytes()); msg != errcode.ErrBotAPICardInvalid.DefaultMessage {
+				t.Fatalf("msg=%q, want the generic card_invalid (anti-enumeration)", msg)
+			}
+			dispatch.mu.Lock()
+			captured := dispatch.captured
+			dispatch.mu.Unlock()
+			if captured != nil {
+				t.Fatal("a refused card must not reach dispatch")
+			}
+		})
+	}
+}
+
+// TestSendMessage_ConfigReadFailureFailsClosed pins that an unreadable config
+// refuses the send rather than falling back to permissive defaults, and that it
+// is reported as an internal error rather than as a caller mistake.
+func TestSendMessage_ConfigReadFailureFailsClosed(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	t.Setenv(cardmsg.EnvEnabled, "true")
+
+	catalog, err := newBotCardTemplateCatalog(testBotTemplateRegistry(t), defaultBotTemplateRefs())
+	if err != nil {
+		t.Fatal(err)
+	}
+	dispatch := &dispatchCapture{}
+	ba := &BotAPI{
+		Log:              log.NewTLog("BotAPI-card-policy-unreadable"),
+		cardTemplates:    catalog,
+		cardConfig:       stubCardConfig{err: errors.New("db is down")},
+		spaceQuerier:     &fakeSpaceQuerier{defaultSpace: "space-authoritative"},
+		dispatchOverride: dispatch.hook,
+	}
+
+	body := registrySendBody(t, "reasoning", testReasoningData(t, "reasoning"))
+	recorder := invokeTemplateSend(t, ba, body, "")
+	if recorder.Code == http.StatusOK {
+		t.Fatal("send succeeded while the config was unreadable; must fail closed")
+	}
+	if msg := errorMessageOf(t, recorder.Body.Bytes()); msg != errcode.ErrSharedInternal.DefaultMessage {
+		t.Fatalf("msg=%q, want the internal-error message", msg)
+	}
+	dispatch.mu.Lock()
+	captured := dispatch.captured
+	dispatch.mu.Unlock()
+	if captured != nil {
+		t.Fatal("dispatch happened despite an unreadable config")
+	}
+}
+
+// TestBotMessageEdit_StillReachesTerminalStateWhenReasoningOff is the other
+// half of the switch's contract, and the reason the gate lives in sendMessage
+// only.
+//
+// Turning reasoning off must stop *new* cards, not freeze the ones already on
+// screen: a card whose progress frames are in flight would otherwise be stranded
+// showing "thinking" forever, with no way for the producer to move it to
+// completed. So the edit path is deliberately ungated, and this test would fail
+// the moment someone "fixes" that asymmetry.
+func TestBotMessageEdit_StillReachesTerminalStateWhenReasoningOff(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	t.Setenv(cardmsg.EnvEnabled, "true")
+
+	catalog, err := newBotCardTemplateCatalog(testBotTemplateRegistry(t), defaultBotTemplateRefs())
+	if err != nil {
+		t.Fatal(err)
+	}
+	mutator := &fakeBotCardMutator{
+		snapshot:     carddispatch.CardMutationSnapshot{Envelope: initialRegistryEnvelope(t, catalog), CardSeq: 1},
+		mutateResult: carddispatch.CardMutationResult{Applied: true},
+	}
+	ba := &BotAPI{
+		Log:           log.NewTLog("BotAPI-edit-reasoning-off"),
+		cardTemplates: catalog,
+		cardMutator:   mutator,
+		// Every card capability is off for this bot — including the one that
+		// governs creating the card being edited.
+		cardConfig: stubCardConfig{config: robot.BotCardConfig{CardEnabled: true}},
+	}
+
+	body := registryEditBody(t, "completed", testReasoningData(t, "completed"), 2, true)
+	recorder := invokeTemplateEdit(t, ba, body)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status=%d, want 200 — an in-flight card must still reach its terminal state; body=%s",
+			recorder.Code, recorder.Body.String())
+	}
+	if len(mutator.mutateRequests) != 1 {
+		t.Fatalf("mutate calls = %d, want 1", len(mutator.mutateRequests))
+	}
+}
+
+// errorMessageOf pulls the message out of an error response.
+//
+// These focused tests drive the handler with a synthetic gin context, so no
+// wkhttp router — and therefore no i18n ErrorRenderer — is attached and the
+// body carries only the legacy {msg,status} shape. `msg` still falls back to
+// the code's DefaultMessage, which is enough to tell the gates apart; the full
+// error.code envelope is covered by the server-backed tests.
+//
+// The wire status is pinned to 400 by ResponseErrorL, so status alone cannot
+// distinguish a caller mistake from an internal failure — hence asserting on
+// the message.
+func errorMessageOf(t *testing.T, body []byte) string {
+	t.Helper()
+	var envelope struct {
+		Error struct {
+			Code    string `json:"code"`
+			Message string `json:"message"`
+		} `json:"error"`
+		Msg string `json:"msg"`
+	}
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		t.Fatalf("decode error envelope: %v (body=%s)", err, body)
+	}
+	if envelope.Error.Message != "" {
+		return envelope.Error.Message
+	}
+	return envelope.Msg
 }

--- a/modules/bot_api/card_profile.go
+++ b/modules/bot_api/card_profile.go
@@ -24,16 +24,60 @@ package bot_api
 // 改名/删除/改类型 —— SDK 与适配器据此做能力探测与上限读取，改名等同破坏 event_data。
 
 import (
+	"errors"
+
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/modules/robot"
 	"github.com/Mininglamp-OSS/octo-server/pkg/cardmsg"
+	aireasoningprocess "github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl/ai_reasoning_process"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
+	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
+	"go.uber.org/zap"
 )
+
+// botCardConfigResolver is the narrow slice of robot.IService the card paths
+// need: resolve one bot's effective card switches. Both the manifest and the
+// send gate go through it, so what this deployment advertises and what it
+// accepts are computed from one source.
+type botCardConfigResolver interface {
+	BotCardConfig(robotID string) (robot.BotCardConfig, error)
+}
+
+// resolveBotCardConfig reads the caller's effective switches, failing closed.
+//
+// Fail-closed matters in both directions: an unwired resolver or a DB error
+// must not be answered with "everything is on", because that would re-open a
+// capability the owner switched off, and it would make the manifest disagree
+// with the send gate for the duration of the blip.
+func (ba *BotAPI) resolveBotCardConfig(robotID string) (robot.BotCardConfig, error) {
+	if ba.cardConfig == nil {
+		return robot.BotCardConfig{}, errBotCardConfigUnavailable
+	}
+	return ba.cardConfig.BotCardConfig(robotID)
+}
+
+var errBotCardConfigUnavailable = errors.New("bot_api: card config resolver unavailable")
 
 // botCardProfile handles GET /v1/bot/card/profile (D12).
 func (ba *BotAPI) botCardProfile(c *wkhttp.Context) {
 	// authBot 已在中间件层校验 bot-token；此处再确认存在 bot 身份（与同组 GET 端点
-	// 一致的防御，非资源属主校验 —— 清单无属主概念）。缺身份 → 既有 bot-auth 拒绝。
-	if getRobotIDFromContext(c) == "" {
+	// 一致的防御）。缺身份 → 既有 bot-auth 拒绝。
+	//
+	// 注意本端点**保持 botToken 鉴权、不做 owner 化**：它的语义是「Bot 读自己的
+	// 有效配置」，而插件手里只有 bot token、没有 user session。owner 化等于废掉它。
+	// 配置的**写**面才是 owner 专属（/v1/robot/:robot_id/settings）。
+	robotID := getRobotIDFromContext(c)
+	if robotID == "" {
 		ba.respondBotAPIIdentityMissing(c)
+		return
+	}
+	// 卡片能力的 per-Bot 有效配置（task bot-setting-store）。读失败必须 fail-closed：
+	// 用默认值顶上会让一次 DB 抖动把 owner 关掉的能力静默放开，且此刻下发的清单会
+	// 与 sendMessage 的门禁背离。
+	cardConfig, err := ba.resolveBotCardConfig(robotID)
+	if err != nil {
+		ba.Error("查询 Bot 卡片配置失败", zap.Error(err), zap.String("robot", robotID))
+		httperr.ResponseErrorL(c, errcode.ErrSharedInternal, nil, nil)
 		return
 	}
 	c.Response(map[string]interface{}{
@@ -53,6 +97,10 @@ func (ba *BotAPI) botCardProfile(c *wkhttp.Context) {
 		// ToggleVisibility / CopyToClipboard 等 additive 新增本地动作。Action.Submit 属
 		// octo/v2 交互档，经 profiles 隐式发现、不在此列。
 		"actions": cardmsg.DisplayActions(),
+		// config is the per-Bot effective card policy (task bot-setting-store).
+		// Values are already AND-ed with the deployment master switch, so a
+		// producer reads one field instead of recombining `enabled` itself.
+		"config": ba.botCardConfigResponse(cardConfig),
 		// templating is additive to the raw-card capability manifest. It advertises
 		// only the explicit Bot catalog, never the broader Registry.List(). A nil
 		// catalog occurs only in focused tests that do not install the production
@@ -69,4 +117,39 @@ func (ba *BotAPI) botCardProfile(c *wkhttp.Context) {
 			"max_copy_text_bytes": cardmsg.MaxCopyTextBytes,
 		},
 	})
+}
+
+// botCardConfigResponse renders the per-Bot effective card policy.
+//
+// Two invariants this function is responsible for, both asserted in tests:
+//
+//  1. reasoning_enabled=false ⟹ reasoning_template_ref is null. A ref alongside
+//     a false switch invites a producer to send it anyway.
+//  2. reasoning_enabled=true ⟹ the ref is one this deployment also advertises
+//     under `templating.templates` in the same response, and therefore one the
+//     send path will accept. Resolving it through AdvertisedRef (rather than
+//     naming a version here) is what makes that hold by construction.
+//
+// A deployment whose catalog does not advertise the reasoning template at all
+// reports reasoning_enabled=false regardless of configuration: the switch says
+// "allowed", the catalog says "possible", and sending needs both.
+func (ba *BotAPI) botCardConfigResponse(cfg robot.BotCardConfig) map[string]interface{} {
+	reasoningEnabled := cfg.ReasoningEnabled
+	var templateRef interface{}
+	if reasoningEnabled {
+		if ref, ok := ba.cardTemplates.AdvertisedRef(aireasoningprocess.TemplateID); ok {
+			templateRef = map[string]interface{}{
+				"id": string(ref.ID), "version": ref.Version,
+			}
+		} else {
+			reasoningEnabled = false
+		}
+	}
+	return map[string]interface{}{
+		"card_enabled":           cfg.CardEnabled,
+		"display_enabled":        cfg.DisplayEnabled,
+		"interaction_enabled":    cfg.InteractionEnabled,
+		"reasoning_enabled":      reasoningEnabled,
+		"reasoning_template_ref": templateRef,
+	}
 }

--- a/modules/bot_api/card_profile.go
+++ b/modules/bot_api/card_profile.go
@@ -80,6 +80,11 @@ func (ba *BotAPI) botCardProfile(c *wkhttp.Context) {
 		httperr.ResponseErrorL(c, errcode.ErrSharedInternal, nil, nil)
 		return
 	}
+	// 本响应自带 `config` 起就是**Bot 私有**的，而 URL 对所有 Bot 完全相同——区分调用
+	// 者的只有 Authorization 头。任何按 URL 缓存的共享代理都会把 Bot A 的配置回给
+	// Bot B。private 禁掉共享缓存，no-store 连私有缓存也不留副本（配置改动要即时生效，
+	// 本就不该有陈旧副本）。加在成功路径的最前面，确保和响应体一起写出。
+	c.Header("Cache-Control", "private, no-store")
 	c.Response(map[string]interface{}{
 		"enabled":      cardmsg.BotEnabled(),
 		"card_version": cardmsg.CardVersion,

--- a/modules/bot_api/card_profile.go
+++ b/modules/bot_api/card_profile.go
@@ -85,6 +85,10 @@ func (ba *BotAPI) botCardProfile(c *wkhttp.Context) {
 	// Bot B。private 禁掉共享缓存，no-store 连私有缓存也不留副本（配置改动要即时生效，
 	// 本就不该有陈旧副本）。加在成功路径的最前面，确保和响应体一起写出。
 	c.Header("Cache-Control", "private, no-store")
+	// Belt-and-braces for an intermediary that honours Vary but mishandles
+	// no-store: the response body is a function of the bot token, so a cache
+	// keyed on URL alone would be keyed on the wrong thing.
+	c.Header("Vary", "Authorization")
 	c.Response(map[string]interface{}{
 		"enabled":      cardmsg.BotEnabled(),
 		"card_version": cardmsg.CardVersion,

--- a/modules/bot_api/card_profile.go
+++ b/modules/bot_api/card_profile.go
@@ -155,9 +155,14 @@ func (ba *BotAPI) botCardConfigResponse(cfg robot.BotCardConfig) map[string]inte
 		}
 	}
 	return map[string]interface{}{
-		"card_enabled":           cfg.CardEnabled,
-		"display_enabled":        cfg.DisplayEnabled,
-		"interaction_enabled":    cfg.InteractionEnabled,
+		"card_enabled": cfg.CardEnabled,
+		// Both booleans come from the same predicates the send/edit gates call,
+		// never from the raw struct fields. interaction_enabled in particular is
+		// display AND interaction: advertising the raw switch while the gate
+		// requires both is exactly the "manifest says yes, send says 400"
+		// contradiction this endpoint exists to prevent.
+		"display_enabled":        cfg.AllowsRawDisplayCard(),
+		"interaction_enabled":    cfg.AllowsRawInteractiveCard(),
 		"reasoning_enabled":      reasoningEnabled,
 		"reasoning_template_ref": templateRef,
 	}

--- a/modules/bot_api/card_profile_test.go
+++ b/modules/bot_api/card_profile_test.go
@@ -226,7 +226,11 @@ func TestBotCardProfile_AdditiveContractFieldSet(t *testing.T) {
 	for k := range raw {
 		gotTop = append(gotTop, k)
 	}
-	assert.ElementsMatch(t, []string{"enabled", "card_version", "profiles", "limits", "elements", "inputs", "actions", "templating"}, gotTop,
+	assert.ElementsMatch(t, []string{
+		"enabled", "card_version", "profiles", "limits", "elements", "inputs", "actions", "templating",
+		// config：per-Bot 卡片策略（task bot-setting-store）。additive 新增。
+		"config",
+	}, gotTop,
 		"D12 additive-only：顶层字段集冻结（新增新字段，绝不改名/删除）")
 
 	var limits map[string]json.RawMessage
@@ -239,6 +243,18 @@ func TestBotCardProfile_AdditiveContractFieldSet(t *testing.T) {
 		"max_payload_bytes", "max_nodes", "max_depth", "max_input_text_bytes", "max_inputs_bytes",
 		"max_copy_text_bytes",
 	}, gotLimits, "D12 additive-only：limits 字段集冻结")
+
+	// config 的子字段集同样冻结：插件按名读这五个键，改名等同破坏 event_data。
+	var cfg map[string]json.RawMessage
+	assert.NoError(t, json.Unmarshal(raw["config"], &cfg))
+	gotConfig := make([]string, 0, len(cfg))
+	for k := range cfg {
+		gotConfig = append(gotConfig, k)
+	}
+	assert.ElementsMatch(t, []string{
+		"card_enabled", "display_enabled", "interaction_enabled", "reasoning_enabled",
+		"reasoning_template_ref",
+	}, gotConfig, "D12 additive-only：config 字段集冻结")
 }
 
 func newMustTestCatalog(t *testing.T) *botCardTemplateCatalog {

--- a/modules/bot_api/card_profile_test.go
+++ b/modules/bot_api/card_profile_test.go
@@ -211,6 +211,25 @@ func TestBotCardProfile_Unauthenticated(t *testing.T) {
 	assert.NotEqual(t, http.StatusOK, w2.Code, "非法 token 必须被拒绝; body=%s", w2.Body.String())
 }
 
+// TestBotCardProfile_IsNotSharedCacheable pins Cache-Control on the success
+// path. Since the response carries per-Bot `config`, and the URL is byte-identical
+// for every Bot (only the Authorization header differs), a shared proxy caching
+// by URL would hand Bot A's configuration to Bot B. The header is the only thing
+// standing between the two.
+func TestBotCardProfile_IsNotSharedCacheable(t *testing.T) {
+	t.Setenv(cardmsg.EnvEnabled, "true")
+	handler, _ := setupBotCardProfile(t)
+
+	w := getCardProfile(t, handler, cpBotToken)
+	assert.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	cacheControl := w.Header().Get("Cache-Control")
+	assert.Contains(t, cacheControl, "private",
+		"响应含 per-Bot config，必须禁止共享代理缓存")
+	assert.Contains(t, cacheControl, "no-store",
+		"配置改动要即时生效，不得留缓存副本")
+}
+
 // TestBotCardProfile_AdditiveContractFieldSet（D12.4）：pin 死顶层 + limits 字段集，
 // 任何改名/删除都会让本测试失败（additive-only：只许新增字段）。
 func TestBotCardProfile_AdditiveContractFieldSet(t *testing.T) {

--- a/modules/bot_api/card_template_catalog.go
+++ b/modules/bot_api/card_template_catalog.go
@@ -246,8 +246,24 @@ func (c *botCardTemplateCatalog) AdvertisedRef(id cardtmpl.ID) (botTemplateRef, 
 	if c == nil {
 		return botTemplateRef{}, false
 	}
+	// Ambiguity is reported, not silently resolved. Today AdvertisedSend holds
+	// exactly one version per id, so there is nothing to pick between; the day a
+	// second version of one template is advertised for new sends, binding to
+	// "whichever the sort happened to put first" would decide the wire contract
+	// by accident. Fail closed instead and make that a deliberate decision.
+	var found botTemplateRef
+	matches := 0
 	for _, template := range c.capability.Templates {
-		if template.ID != string(id) {
+		if template.ID == string(id) {
+			matches++
+			found = botTemplateRef{ID: cardtmpl.ID(template.ID), Version: template.Version}
+		}
+	}
+	if matches != 1 {
+		return botTemplateRef{}, false
+	}
+	for _, template := range c.capability.Templates {
+		if template.ID != string(id) || template.Version != found.Version {
 			continue
 		}
 		ref := botTemplateRef{ID: cardtmpl.ID(template.ID), Version: template.Version}

--- a/modules/bot_api/card_template_catalog.go
+++ b/modules/bot_api/card_template_catalog.go
@@ -235,6 +235,33 @@ func (c *botCardTemplateCatalog) Capability() botTemplatingCapability {
 	return out
 }
 
+// AdvertisedRef returns the ref this deployment advertises for id, if any.
+//
+// The manifest's reasoning_template_ref must be resolvable from exactly the
+// same source the send allowlist checks, so a bot can never be handed a ref
+// that requireRef would then reject. Iterating the capability (rather than
+// sendAllowed) also keeps the answer aligned with what the same response
+// advertises under `templating.templates`.
+func (c *botCardTemplateCatalog) AdvertisedRef(id cardtmpl.ID) (botTemplateRef, bool) {
+	if c == nil {
+		return botTemplateRef{}, false
+	}
+	for _, template := range c.capability.Templates {
+		if template.ID != string(id) {
+			continue
+		}
+		ref := botTemplateRef{ID: cardtmpl.ID(template.ID), Version: template.Version}
+		if _, ok := c.sendAllowed[ref]; !ok {
+			// Defensive: the constructor builds both from one policy, so a
+			// mismatch means the invariant broke. Report "not advertised"
+			// rather than handing out a ref the send path would reject.
+			return botTemplateRef{}, false
+		}
+		return ref, true
+	}
+	return botTemplateRef{}, false
+}
+
 func (c *botCardTemplateCatalog) RenderPayload(
 	ctx context.Context,
 	inbound map[string]any,

--- a/modules/bot_api/card_template_send_test.go
+++ b/modules/bot_api/card_template_send_test.go
@@ -27,6 +27,7 @@ func TestSendMessageRegistryTemplateRendersAndDispatches(t *testing.T) {
 	ba := &BotAPI{
 		Log:              log.NewTLog("BotAPI-template-send"),
 		cardTemplates:    catalog,
+		cardConfig:       allCardCapabilitiesOn(),
 		spaceQuerier:     &fakeSpaceQuerier{defaultSpace: "space-authoritative"},
 		dispatchOverride: dispatch.hook,
 	}
@@ -97,6 +98,7 @@ func TestSendMessageRawCardAuthorsRenderProfile(t *testing.T) {
 			dispatch := &dispatchCapture{}
 			ba := &BotAPI{
 				Log:              log.NewTLog("BotAPI-raw-card-render-profile"),
+				cardConfig:       allCardCapabilitiesOn(),
 				spaceQuerier:     &fakeSpaceQuerier{defaultSpace: "space-authoritative"},
 				dispatchOverride: dispatch.hook,
 			}
@@ -190,6 +192,7 @@ func TestSendMessageRegistryTemplateRejectsHistoricalVersionsWithoutDispatch(t *
 			ba := &BotAPI{
 				Log:              log.NewTLog("BotAPI-template-send-historical"),
 				cardTemplates:    catalog,
+				cardConfig:       allCardCapabilitiesOn(),
 				spaceQuerier:     &fakeSpaceQuerier{defaultSpace: "space-authoritative"},
 				dispatchOverride: dispatch.hook,
 			}
@@ -266,6 +269,7 @@ func TestSendMessageRegistryTemplateRejectsInvalidWithoutDispatch(t *testing.T) 
 			ba := &BotAPI{
 				Log:              log.NewTLog("BotAPI-template-send-invalid"),
 				cardTemplates:    catalog,
+				cardConfig:       allCardCapabilitiesOn(),
 				spaceQuerier:     &fakeSpaceQuerier{defaultSpace: "space-authoritative"},
 				dispatchOverride: dispatch.hook,
 			}
@@ -295,6 +299,7 @@ func TestSendMessageRegistryTemplateKeepsOBOCardExclusion(t *testing.T) {
 	ba := &BotAPI{
 		Log:              log.NewTLog("BotAPI-template-send-obo"),
 		cardTemplates:    catalog,
+		cardConfig:       allCardCapabilitiesOn(),
 		spaceQuerier:     &fakeSpaceQuerier{defaultSpace: "space-authoritative"},
 		dispatchOverride: dispatch.hook,
 	}

--- a/modules/bot_api/send.go
+++ b/modules/bot_api/send.go
@@ -17,6 +17,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-server/internal/carddispatch"
 	"github.com/Mininglamp-OSS/octo-server/internal/msgextraseq"
 	"github.com/Mininglamp-OSS/octo-server/modules/group"
+	"github.com/Mininglamp-OSS/octo-server/modules/robot"
 	"github.com/Mininglamp-OSS/octo-server/pkg/cardmsg"
 	"github.com/Mininglamp-OSS/octo-server/pkg/cardrevision"
 	"github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl"
@@ -1057,6 +1058,18 @@ func (ba *BotAPI) botMessageEdit(c *wkhttp.Context) {
 			httperr.ResponseErrorL(c, errcode.ErrBotAPICardInvalid, nil, nil)
 			return
 		}
+		// per-Bot 策略门（task bot-setting-store）。**必须**加在 raw 编辑路径上：
+		// cardmsg.Validate 接受 acceptedProfiles 里的任意 profile，且不校验编辑帧与
+		// 原消息的档位是否一致，所以缺了这道门就有一条提权通道 —— 先用 octo/v1 发一张
+		// 展示卡（display 开着即放行），再把 content_edit 换成带 Action.Submit 的
+		// octo/v2 帧；该帧正是动作端点信任的生效帧，于是 interaction_enabled=false 的
+		// Bot 也能产出可点击的交互卡。这与上方 BotEnabled() 出现在本路径的理由同源。
+		//
+		// 只作用于 raw 分支。模板分支（下方 botMessageEditRegistry）刻意不加门 ——
+		// 流式推理卡必须能编辑到终态，否则线上残留「永久处理中」的卡。
+		if ba.rejectRawCardEditByPolicy(c, normalized) {
+			return
+		}
 		req.ContentEdit = normalized
 		cardSeq, hasCardSeq = cardmsg.CardSeqFromContentEdit(normalized)
 	} else {
@@ -1384,12 +1397,18 @@ func (ba *BotAPI) rejectByBotCardPolicy(c *wkhttp.Context, payload map[string]in
 			httperr.ResponseErrorL(c, errcode.ErrBotAPICardInvalid, nil, nil)
 			return true
 		}
-		if ref.ID != aireasoningprocess.TemplateID {
-			// 当前部署只广告推理卡一张模板。出现别的 id 说明调用方在猜 ref，
-			// 交给下游 requireRef 用同一个泛化码拒。
-			return false
+		allowed, mapped := botTemplateSwitchFor(ref.ID, config)
+		if !mapped {
+			// 未映射到任何开关的模板 id：**fail closed**。今天只广告推理卡一张，
+			// 但若日后往 AdvertisedSend 里加了模板却忘了给它配开关，放行会让它
+			// 完全绕过 per-Bot 策略。未广告的 id 走到这里同样被拒，与下游
+			// requireRef 的结论一致（同一个泛化码）。
+			ba.Warn("模板 id 未映射到 per-Bot 开关，fail-closed 拒绝",
+				zap.String("robot", robotID), zap.String("template", string(ref.ID)))
+			httperr.ResponseErrorL(c, errcode.ErrBotAPICardInvalid, nil, nil)
+			return true
 		}
-		if !config.ReasoningEnabled {
+		if !allowed {
 			ba.Warn("Bot 推理卡已关闭，拒绝模板发送", zap.String("robot", robotID))
 			httperr.ResponseErrorL(c, errcode.ErrBotAPICardInvalid, nil, nil)
 			return true
@@ -1404,19 +1423,91 @@ func (ba *BotAPI) rejectByBotCardPolicy(c *wkhttp.Context, payload map[string]in
 		return false
 	}
 
-	// raw 卡：按已校验的 profile 分档。octo/v1 = 展示，octo/v2 = 交互。
-	// 这两个开关只作用于 Bot 自拼的 raw 卡，绝不用来切模板卡的 wire profile。
+	// raw 卡：按已校验的 profile 分档。这两个开关只作用于 Bot 自拼的 raw 卡，
+	// 绝不用来切模板卡的 wire profile。
 	profile, _ := payload["profile"].(string)
+	return ba.rejectRawCardByProfile(c, robotID, profile, config)
+}
+
+// botTemplateSwitchFor maps an advertised template to the per-Bot switch that
+// governs it. The second return is false for any template with no mapping, and
+// callers must fail closed on that.
+//
+// Deliberately a lookup rather than an `if id == reasoning` check: the send gate
+// would otherwise let a newly advertised template through untouched, and that
+// regression would be silent. TestBotTemplateSwitchCoversAdvertisedSet asserts
+// this map covers everything defaultBotTemplatePolicy advertises, so adding a
+// template without a switch fails the build's tests instead of production.
+func botTemplateSwitchFor(id cardtmpl.ID, config robot.BotCardConfig) (allowed, mapped bool) {
+	switch id {
+	case aireasoningprocess.TemplateID:
+		return config.ReasoningEnabled, true
+	default:
+		return false, false
+	}
+}
+
+// rejectRawCardEditByPolicy applies the raw-card switches to an already
+// normalized edit frame. Returns true when it has written a response.
+//
+// The edit frame's own profile is what matters, not the original message's:
+// cardmsg.Validate accepts any profile in the accepted set and does not compare
+// the two, so an edit is free to escalate octo/v1 → octo/v2. Checking the frame
+// being written closes that without needing to load the original.
+func (ba *BotAPI) rejectRawCardEditByPolicy(c *wkhttp.Context, normalizedEdit string) bool {
+	robotID := getRobotIDFromContext(c)
+	if robotID == "" {
+		ba.respondBotAPIIdentityMissing(c)
+		return true
+	}
+	config, err := ba.resolveBotCardConfig(robotID)
+	if err != nil {
+		ba.Error("查询 Bot 卡片配置失败", zap.Error(err), zap.String("robot", robotID))
+		httperr.ResponseErrorL(c, errcode.ErrSharedInternal, nil, nil)
+		return true
+	}
+	var payload map[string]interface{}
+	if err := json.Unmarshal([]byte(normalizedEdit), &payload); err != nil {
+		// Unreachable in practice: NormalizeContentEdit already produced this
+		// JSON. Fail closed rather than silently skipping the gate.
+		ba.Warn("解析已归一化的卡片编辑帧失败", zap.Error(err), zap.String("robot", robotID))
+		httperr.ResponseErrorL(c, errcode.ErrBotAPICardInvalid, nil, nil)
+		return true
+	}
+	profile, _ := payload["profile"].(string)
+	return ba.rejectRawCardByProfile(c, robotID, profile, config)
+}
+
+// rejectRawCardByProfile applies the display/interaction switches to one raw
+// frame's declared profile. Shared by the send and edit paths so a frame cannot
+// be refused on creation and then accepted as an edit.
+//
+// **display is a floor, not a peer of interaction.** octo/v2 is a strict
+// superset of octo/v1 — in cardmsg.validateCard the `interactive` flag only ever
+// relaxes checks, never requires an interactive element — so every card legal as
+// octo/v1 is also legal as octo/v2. Were the two switches treated as parallel
+// arms, a bot could defeat display_enabled=false by changing one string
+// (`"profile":"octo/v2"`) and sending byte-identical display-only cards. So an
+// octo/v2 frame needs BOTH switches: it is a display card that additionally
+// carries interaction.
+func (ba *BotAPI) rejectRawCardByProfile(
+	c *wkhttp.Context,
+	robotID, profile string,
+	config robot.BotCardConfig,
+) bool {
 	switch profile {
 	case cardmsg.ProfileV1:
 		if !config.DisplayEnabled {
-			ba.Warn("Bot 展示卡已关闭，拒绝 raw 发送", zap.String("robot", robotID))
+			ba.Warn("Bot 展示卡已关闭，拒绝 raw 卡", zap.String("robot", robotID))
 			httperr.ResponseErrorL(c, errcode.ErrBotAPICardInvalid, nil, nil)
 			return true
 		}
 	case cardmsg.ProfileV2:
-		if !config.InteractionEnabled {
-			ba.Warn("Bot 交互卡已关闭，拒绝 raw 发送", zap.String("robot", robotID))
+		if !config.DisplayEnabled || !config.InteractionEnabled {
+			ba.Warn("Bot 展示卡或交互卡已关闭，拒绝 raw 交互卡",
+				zap.String("robot", robotID),
+				zap.Bool("display", config.DisplayEnabled),
+				zap.Bool("interaction", config.InteractionEnabled))
 			httperr.ResponseErrorL(c, errcode.ErrBotAPICardInvalid, nil, nil)
 			return true
 		}

--- a/modules/bot_api/send.go
+++ b/modules/bot_api/send.go
@@ -20,6 +20,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-server/pkg/cardmsg"
 	"github.com/Mininglamp-OSS/octo-server/pkg/cardrevision"
 	"github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl"
+	aireasoningprocess "github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl/ai_reasoning_process"
 	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
 	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
 	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
@@ -137,6 +138,11 @@ func (ba *BotAPI) sendMessage(c *wkhttp.Context) {
 			// any explicit inbound value first for backward-compatible fail-close,
 			// then author the stable outbound key so callers do not need to send it.
 			req.Payload["render_profile"] = cardmsg.RenderProfileOctoChatV1
+		}
+		// per-Bot 卡片策略门（task bot-setting-store）。排在形状校验之后，因为
+		// raw 分支要用已校验过的 profile 决定查 display 还是 interaction。
+		if ba.rejectByBotCardPolicy(c, req.Payload, templateMode) {
+			return
 		}
 	}
 
@@ -1337,6 +1343,91 @@ func cardEnvelopeHasTemplateRef(raw []byte) bool {
 	}
 	_, exists := payload["template_ref"]
 	return exists
+}
+
+// rejectByBotCardPolicy enforces the per-Bot card switches on the send path
+// (task bot-setting-store). Returns true when it has already written a
+// response and the caller must return.
+//
+// This is deliberately a second gate rather than trusting the manifest: a
+// producer can hold a stale /v1/bot/card/profile, or simply ignore it, so the
+// switch has to be enforced where the message is actually accepted. Both sides
+// read robot.IService.BotCardConfig, so what the manifest advertises and what
+// this accepts cannot drift.
+//
+// Every rejection collapses into the single generic ErrBotAPICardInvalid and
+// the specific reason goes to the log only. Splitting it into "reasoning is off
+// for you" vs "that template is not yours" would let a caller probe another
+// bot's configuration by差分 the error code.
+func (ba *BotAPI) rejectByBotCardPolicy(c *wkhttp.Context, payload map[string]interface{}, templateMode bool) bool {
+	robotID := getRobotIDFromContext(c)
+	if robotID == "" {
+		ba.respondBotAPIIdentityMissing(c)
+		return true
+	}
+	config, err := ba.resolveBotCardConfig(robotID)
+	if err != nil {
+		// Fail closed. Substituting defaults here would let a DB blip re-open a
+		// capability the owner switched off.
+		ba.Error("查询 Bot 卡片配置失败", zap.Error(err), zap.String("robot", robotID))
+		httperr.ResponseErrorL(c, errcode.ErrSharedInternal, nil, nil)
+		return true
+	}
+
+	if templateMode {
+		// 模板卡只看 reasoning 开关，**不看** display/interaction —— 推理卡自身
+		// 横跨两档（active/error 是 octo/v2、result 是 octo/v1），若让 interaction
+		// 参与判定，关掉交互卡会把推理卡砍成只剩终态。
+		ref, refErr := parseBotTemplateRef(payload["template_ref"])
+		if refErr != nil {
+			ba.Warn("Bot 模板 ref 形状非法", zap.Error(refErr), zap.String("robot", robotID))
+			httperr.ResponseErrorL(c, errcode.ErrBotAPICardInvalid, nil, nil)
+			return true
+		}
+		if ref.ID != aireasoningprocess.TemplateID {
+			// 当前部署只广告推理卡一张模板。出现别的 id 说明调用方在猜 ref，
+			// 交给下游 requireRef 用同一个泛化码拒。
+			return false
+		}
+		if !config.ReasoningEnabled {
+			ba.Warn("Bot 推理卡已关闭，拒绝模板发送", zap.String("robot", robotID))
+			httperr.ResponseErrorL(c, errcode.ErrBotAPICardInvalid, nil, nil)
+			return true
+		}
+		advertised, ok := ba.cardTemplates.AdvertisedRef(ref.ID)
+		if !ok || advertised != ref {
+			ba.Warn("Bot 模板 ref 与本部署广告集不一致，拒绝",
+				zap.String("robot", robotID), zap.String("version", ref.Version))
+			httperr.ResponseErrorL(c, errcode.ErrBotAPICardInvalid, nil, nil)
+			return true
+		}
+		return false
+	}
+
+	// raw 卡：按已校验的 profile 分档。octo/v1 = 展示，octo/v2 = 交互。
+	// 这两个开关只作用于 Bot 自拼的 raw 卡，绝不用来切模板卡的 wire profile。
+	profile, _ := payload["profile"].(string)
+	switch profile {
+	case cardmsg.ProfileV1:
+		if !config.DisplayEnabled {
+			ba.Warn("Bot 展示卡已关闭，拒绝 raw 发送", zap.String("robot", robotID))
+			httperr.ResponseErrorL(c, errcode.ErrBotAPICardInvalid, nil, nil)
+			return true
+		}
+	case cardmsg.ProfileV2:
+		if !config.InteractionEnabled {
+			ba.Warn("Bot 交互卡已关闭，拒绝 raw 发送", zap.String("robot", robotID))
+			httperr.ResponseErrorL(c, errcode.ErrBotAPICardInvalid, nil, nil)
+			return true
+		}
+	default:
+		// cardmsg.Validate 已经把 profile 钉在接受集内，走到这里说明校验被绕过。
+		ba.Warn("Bot raw 卡 profile 不在接受集，拒绝",
+			zap.String("robot", robotID), zap.String("profile", profile))
+		httperr.ResponseErrorL(c, errcode.ErrBotAPICardInvalid, nil, nil)
+		return true
+	}
+	return false
 }
 
 // authorBotRawCardRenderProfile adds the deployment-owned visual compatibility

--- a/modules/bot_api/send.go
+++ b/modules/bot_api/send.go
@@ -1497,13 +1497,13 @@ func (ba *BotAPI) rejectRawCardByProfile(
 ) bool {
 	switch profile {
 	case cardmsg.ProfileV1:
-		if !config.DisplayEnabled {
+		if !config.AllowsRawDisplayCard() {
 			ba.Warn("Bot 展示卡已关闭，拒绝 raw 卡", zap.String("robot", robotID))
 			httperr.ResponseErrorL(c, errcode.ErrBotAPICardInvalid, nil, nil)
 			return true
 		}
 	case cardmsg.ProfileV2:
-		if !config.DisplayEnabled || !config.InteractionEnabled {
+		if !config.AllowsRawInteractiveCard() {
 			ba.Warn("Bot 展示卡或交互卡已关闭，拒绝 raw 交互卡",
 				zap.String("robot", robotID),
 				zap.Bool("display", config.DisplayEnabled),

--- a/modules/common/system_setting_schema.go
+++ b/modules/common/system_setting_schema.go
@@ -27,6 +27,11 @@ const (
 	settingIntMax = 3650
 )
 
+// defaultBotCardSwitchEnabled is the code default for every per-bot card
+// capability switch (display / interaction / reasoning). See the "botcard"
+// entries in systemSettingSchema for why true is the safe choice here.
+const defaultBotCardSwitchEnabled = true
+
 // Sidebar recent-tab activity-filter defaults (issue #289). The recent tab of
 // POST /v1/sidebar/sync hides conversations whose last activity is older than
 // a per-channel-type window. These defaults reproduce the historical
@@ -201,6 +206,26 @@ var systemSettingSchema = []settingDef{
 		Effective: func(s *SystemSettings) string { return floatToCanonical(s.BotRateLimitRegisterRPS()) }},
 	{Category: "botratelimit", Key: "register_burst", Type: settingTypeInt, Description: "单个 Bot token 的注册/刷新突发上限（令牌桶 burst）；读取侧夹到 register_rps×20 以内——TTL 是 ceil(burst/rps×2)，而 register 的 key 由客户端提供的 token 决定基数，所以放大比值会放大每 IP 的 live key 数。调低 rps 会同时压低有效 burst，实际生效值见本列", Positive: true,
 		Effective: func(s *SystemSettings) string { return strconv.Itoa(s.BotRateLimitRegisterBurst()) }},
+
+	// Bot 卡片能力的**服务端全局默认**（task bot-setting-store）。这一层介于
+	// bot_setting 的 per-Bot 覆盖与代码默认之间：某个 Bot 没有写过覆盖时读到这里，
+	// 这里也没配时落到代码默认 true。
+	//
+	// 三个键都不含「总闸」——总闸是 cardmsg.BotEnabled()（OCTO_CARD_MESSAGE_ENABLED
+	// AND OCTO_BOT_CARD_ENABLED），派生只读，不可写；它为假时下面三项的有效值恒为假。
+	// 正因为总闸默认 fail-closed，这三项默认 true 才是安全的：运维开总闸即得到完整
+	// 卡片能力，不必再逐 Bot 开一次。
+	//
+	// display/interaction 只作用于 **raw 卡路径**（Bot 自拼 card JSON），
+	// reasoning 只作用于 **Registry 模板卡**，三者正交。绝不可实现成「按 wire profile
+	// 一刀切」：推理卡自身横跨两档（active/error 是 octo/v2、result 是 octo/v1），
+	// 按 profile 切会把它砍成只剩终态或只剩过程。
+	{Category: "botcard", Key: "display_enabled", Type: settingTypeBool, Description: "Bot 未单独配置时，是否允许其发送展示型 raw 卡片（octo/v1，Bot 自拼卡片 JSON）；受卡片总闸 OCTO_CARD_MESSAGE_ENABLED 支配，总闸关闭时本项无效",
+		Effective: func(s *SystemSettings) string { return boolToCanonical(s.BotCardDisplayEnabledDefault()) }},
+	{Category: "botcard", Key: "interaction_enabled", Type: settingTypeBool, Description: "Bot 未单独配置时，是否允许其发送交互型 raw 卡片（octo/v2，含 Action.Submit / Input.*）；不影响服务端模板渲染出的推理进度卡",
+		Effective: func(s *SystemSettings) string { return boolToCanonical(s.BotCardInteractionEnabledDefault()) }},
+	{Category: "botcard", Key: "reasoning_enabled", Type: settingTypeBool, Description: "Bot 未单独配置时，是否允许其发送推理进度卡（服务端 Registry 模板卡）；关闭只阻止新建，已发出的卡仍可编辑到终态",
+		Effective: func(s *SystemSettings) string { return boolToCanonical(s.BotCardReasoningEnabledDefault()) }},
 
 	// App Bot 共享鉴权缓存的安全网 TTL（秒）。吊销靠共享 DEL 即时生效，此 TTL 仅兜底
 	// DEL 失败 / 极窄的失效-回填竞态（见 modules/bot_api/registry_redis.go）。实时热更新

--- a/modules/common/system_setting_schema.go
+++ b/modules/common/system_setting_schema.go
@@ -217,9 +217,13 @@ var systemSettingSchema = []settingDef{
 	// 卡片能力，不必再逐 Bot 开一次。
 	//
 	// display/interaction 只作用于 **raw 卡路径**（Bot 自拼 card JSON），
-	// reasoning 只作用于 **Registry 模板卡**，三者正交。绝不可实现成「按 wire profile
-	// 一刀切」：推理卡自身横跨两档（active/error 是 octo/v2、result 是 octo/v1），
-	// 按 profile 切会把它砍成只剩终态或只剩过程。
+	// reasoning 只作用于 **Registry 模板卡**：raw 这一组与 reasoning 正交，但
+	// **display 与 interaction 之间不正交** —— display 是 raw 档内的下限（octo/v1 要
+	// display，octo/v2 要 display AND interaction，因为 octo/v2 是 octo/v1 的严格超集）。
+	// 判定收口在 modules/robot 的 AllowsRawDisplayCard / AllowsRawInteractiveCard；
+	// 这里只是这两个开关的**全局默认值**，不重述判定。
+	// 绝不可实现成「按 wire profile 一刀切」：推理卡自身横跨两档（active/error 是
+	// octo/v2、result 是 octo/v1），按 profile 切会把它砍成只剩终态或只剩过程。
 	{Category: "botcard", Key: "display_enabled", Type: settingTypeBool, Description: "Bot 未单独配置时，是否允许其发送展示型 raw 卡片（octo/v1，Bot 自拼卡片 JSON）；受卡片总闸 OCTO_CARD_MESSAGE_ENABLED 支配，总闸关闭时本项无效",
 		Effective: func(s *SystemSettings) string { return boolToCanonical(s.BotCardDisplayEnabledDefault()) }},
 	{Category: "botcard", Key: "interaction_enabled", Type: settingTypeBool, Description: "Bot 未单独配置时，是否允许其发送交互型 raw 卡片（octo/v2，含 Action.Submit / Input.*）；不影响服务端模板渲染出的推理进度卡",

--- a/modules/common/system_settings.go
+++ b/modules/common/system_settings.go
@@ -204,6 +204,33 @@ func (s *SystemSettings) getBool(category, key string, fallback bool) bool {
 	return parseSettingBool(v, fallback)
 }
 
+// SettingBoolOK reports the configured bool for (category, key) and whether the
+// key is configured at all.
+//
+// getBool collapses "unset" and "explicitly false" into the same `false`, which
+// is fine for a two-tier (DB → yaml) key but wrong for a caller that layers its
+// own override on top of this one: a per-bot resolver must be able to tell
+// "the deployment default says false" from "the deployment has no opinion, fall
+// through to the code default". Hence the second return.
+//
+// An unparseable literal reports configured=false so the caller falls through
+// rather than inheriting a silent false — same fail-forward posture getBool
+// takes with its fallback.
+func (s *SystemSettings) SettingBoolOK(category, key string) (value bool, configured bool) {
+	v, ok := s.lookup(category, key)
+	if !ok {
+		return false, false
+	}
+	switch v {
+	case "1", "true", "TRUE":
+		return true, true
+	case "0", "false", "FALSE":
+		return false, true
+	default:
+		return false, false
+	}
+}
+
 // parseSettingBool applies the canonical system_setting bool literal rules
 // (1/true/TRUE → true, 0/false/FALSE → false, anything else → fallback).
 // Shared by getBool and the atomic SpaceWelcomeConfig reader so both spell the
@@ -1010,6 +1037,27 @@ const (
 	// live key 上界因此恒为 100 rps × 40s ≈ 4000。
 	botRateLimitMinRegisterRPS = 1.0 / botRateLimitMaxRegisterFillRatio
 )
+
+// BotCardDisplayEnabledDefault 等三个 getter 是 Bot 卡片能力的**服务端全局默认**
+// （task bot-setting-store）。它们只回答「某个 Bot 没写过覆盖时该取什么」，不含
+// per-Bot 覆盖，也不含卡片总闸 cardmsg.BotEnabled() —— 完整解析链由
+// modules/robot 的 bot_setting 解析器组合，管理端的 effective_value 展示的也正是
+// 本层的值（全局默认），而非某个具体 Bot 的有效值。
+//
+// 代码默认一律 true：总闸本身 fail-closed（OCTO_CARD_MESSAGE_ENABLED 未设即关），
+// 安全默认由总闸承担；若这三项再各自默认 false，运维开了总闸还要逐 Bot 补开，
+// 徒增困惑。
+func (s *SystemSettings) BotCardDisplayEnabledDefault() bool {
+	return s.getBool("botcard", "display_enabled", defaultBotCardSwitchEnabled)
+}
+
+func (s *SystemSettings) BotCardInteractionEnabledDefault() bool {
+	return s.getBool("botcard", "interaction_enabled", defaultBotCardSwitchEnabled)
+}
+
+func (s *SystemSettings) BotCardReasoningEnabledDefault() bool {
+	return s.getBool("botcard", "reasoning_enabled", defaultBotCardSwitchEnabled)
+}
 
 // BotRateLimitBusinessEnabled 等三组 getter 的回退链均为 DB → env → code default。
 func (s *SystemSettings) BotRateLimitBusinessEnabled() bool {

--- a/modules/common/system_settings.go
+++ b/modules/common/system_settings.go
@@ -217,6 +217,20 @@ func (s *SystemSettings) getBool(category, key string, fallback bool) bool {
 // rather than inheriting a silent false — same fail-forward posture getBool
 // takes with its fallback.
 //
+// The literal is trimmed and matched case-insensitively, which getBool's
+// parseSettingBool is not (round-3 evaluation P2-3). The reason is the fallback
+// direction, not taste: this tier's callers layer their own code default on top,
+// and for every key that uses it today (the bot card switches) that default is
+// `true`. So an operator typing `False`, `FALSE ` or `\tfalse` into a
+// system_setting row does not get "no opinion, keep the code default" in some
+// harmless sense — they get **the capability they meant to disable left on**,
+// with no error anywhere. Tolerant lexing removes the class.
+//
+// Deliberately the same *vocabulary* as parseSettingBool (1/0/true/false), only
+// lexed more forgivingly. Accepting on/off/yes/no here would make one column
+// mean different things to two readers of the same table — the divergence
+// pattern this module is meant to avoid, not a convenience.
+//
 // **This tier is best-effort, not enforcement.** EnsureSystemSettings tolerates
 // a failed startup Load() and leaves an empty snapshot for the auto-reload to
 // repair, and an empty snapshot is indistinguishable here from "key not
@@ -231,10 +245,10 @@ func (s *SystemSettings) SettingBoolOK(category, key string) (value bool, config
 	if !ok {
 		return false, false
 	}
-	switch v {
-	case "1", "true", "TRUE":
+	switch strings.ToLower(strings.TrimSpace(v)) {
+	case "1", "true":
 		return true, true
-	case "0", "false", "FALSE":
+	case "0", "false":
 		return false, true
 	default:
 		return false, false

--- a/modules/common/system_settings.go
+++ b/modules/common/system_settings.go
@@ -216,6 +216,16 @@ func (s *SystemSettings) getBool(category, key string, fallback bool) bool {
 // An unparseable literal reports configured=false so the caller falls through
 // rather than inheriting a silent false — same fail-forward posture getBool
 // takes with its fallback.
+//
+// **This tier is best-effort, not enforcement.** EnsureSystemSettings tolerates
+// a failed startup Load() and leaves an empty snapshot for the auto-reload to
+// repair, and an empty snapshot is indistinguishable here from "key not
+// configured" — so a replica whose startup load blipped reports configured=false
+// and its caller falls through to the code default for up to one reload TTL.
+// A caller that layers a fail-closed control on top (see modules/robot's
+// bot_setting resolver) fails closed only in ITS own tier; do not read that
+// posture as covering this one. An operator who needs a capability genuinely
+// disabled should set it at the layer that enforces, not only here.
 func (s *SystemSettings) SettingBoolOK(category, key string) (value bool, configured bool) {
 	v, ok := s.lookup(category, key)
 	if !ok {

--- a/modules/common/system_settings.go
+++ b/modules/common/system_settings.go
@@ -1071,16 +1071,29 @@ const (
 // 代码默认一律 true：总闸本身 fail-closed（OCTO_CARD_MESSAGE_ENABLED 未设即关），
 // 安全默认由总闸承担；若这三项再各自默认 false，运维开了总闸还要逐 Bot 补开，
 // 徒增困惑。
+//
+// 三者都委托给 SettingBoolOK 而不是 getBool，是因为 modules/robot 的解析器读的正是
+// SettingBoolOK：走两条路就等于同一列有两套词法。上一轮把 SettingBoolOK 放宽成
+// trim + 折叠大小写却没动这里，`botcard` 里一行 `False` 就会让管理台显示「开」而每个
+// Bot 解析成「关」—— 同一列对两个读者含义不同，正是本层要消灭的东西。委托而非复制：
+// 词法只有一份，下次再改也不会只改一边。
 func (s *SystemSettings) BotCardDisplayEnabledDefault() bool {
-	return s.getBool("botcard", "display_enabled", defaultBotCardSwitchEnabled)
+	return s.botCardSwitchDefault("display_enabled")
 }
 
 func (s *SystemSettings) BotCardInteractionEnabledDefault() bool {
-	return s.getBool("botcard", "interaction_enabled", defaultBotCardSwitchEnabled)
+	return s.botCardSwitchDefault("interaction_enabled")
 }
 
 func (s *SystemSettings) BotCardReasoningEnabledDefault() bool {
-	return s.getBool("botcard", "reasoning_enabled", defaultBotCardSwitchEnabled)
+	return s.botCardSwitchDefault("reasoning_enabled")
+}
+
+func (s *SystemSettings) botCardSwitchDefault(key string) bool {
+	if v, configured := s.SettingBoolOK("botcard", key); configured {
+		return v
+	}
+	return defaultBotCardSwitchEnabled
 }
 
 // BotRateLimitBusinessEnabled 等三组 getter 的回退链均为 DB → env → code default。

--- a/modules/common/system_settings_bool_ok_test.go
+++ b/modules/common/system_settings_bool_ok_test.go
@@ -37,6 +37,46 @@ func TestSettingBoolOK_LexingIsForgiving(t *testing.T) {
 	}
 }
 
+// TestBotCardDefaults_AgreeWithTheResolverOnEveryLiteral —— 同一列必须只有一套词法。
+//
+// 这条是补上一轮**自己捅的窟窿**。上一轮把 SettingBoolOK 放宽成 trim + 折叠大小写，
+// 却没动这三个 getter（当时走 getBool → parseSettingBool，精确匹配），于是同一列
+// `botcard.display_enabled` 出现了两个读者两套词法：
+//
+//	resolver（SettingBoolOK）      → "False" = 显式关闭
+//	管理台 effective_value（getBool）→ "False" 解析失败、回落 true = 开启
+//
+// 运维会在控制台看到「展示卡开着」，而每个 Bot 都解析成关。上一轮的测试只在**词表**
+// 轴上钉住了（下面那条），恰恰漏了自己动过的**词法**轴——所以这条按字面量逐个比对
+// 两个读者，而不是再断言一次「行为应该一致」。
+func TestBotCardDefaults_AgreeWithTheResolverOnEveryLiteral(t *testing.T) {
+	getters := map[string]func(*SystemSettings) bool{
+		"display_enabled":     (*SystemSettings).BotCardDisplayEnabledDefault,
+		"interaction_enabled": (*SystemSettings).BotCardInteractionEnabledDefault,
+		"reasoning_enabled":   (*SystemSettings).BotCardReasoningEnabledDefault,
+	}
+	// 含放宽后才被接受的写法，以及仍应回落的脏值。
+	for _, raw := range []string{
+		"true", "TRUE", "True", "1", " true ", "\ttrue\n",
+		"false", "FALSE", "False", "0", " false ", "\tfalse\n",
+		"", "maybe", "on", "off",
+	} {
+		for key, getter := range getters {
+			s := &SystemSettings{Log: log.NewTLog("SystemSettingsTest")}
+			m := map[string]string{schemaKey("botcard", key): raw}
+			s.snapshot.Store(&m)
+
+			// 解析器看到的答案 —— per-Bot 解析链的中间层就是这个。
+			want, configured := s.SettingBoolOK("botcard", key)
+			if !configured {
+				want = defaultBotCardSwitchEnabled
+			}
+			assert.Equal(t, want, getter(s),
+				"botcard.%s = %q：管理台 getter 与 SettingBoolOK 结论不一致，同一列出现了两套词法", key, raw)
+		}
+	}
+}
+
 // TestSettingBoolOK_VocabularyMatchesParseSettingBool —— 词表故意不扩张。
 //
 // 放宽的只是词法（trim + 大小写），不是词表。把 on/off/yes/no 也收进来，会让

--- a/modules/common/system_settings_bool_ok_test.go
+++ b/modules/common/system_settings_bool_ok_test.go
@@ -1,0 +1,67 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
+	"github.com/stretchr/testify/assert"
+)
+
+// SettingBoolOK 的解析规则测试（round-3 评审 P2-3）。
+//
+// 无基础设施：直接塞 snapshot，同 botRLSettings 的模式。
+func boolOKSettings(value string) *SystemSettings {
+	s := &SystemSettings{Log: log.NewTLog("SystemSettingsTest")}
+	m := map[string]string{schemaKey("botcard", "display_enabled"): value}
+	s.snapshot.Store(&m)
+	return s
+}
+
+// TestSettingBoolOK_LexingIsForgiving —— 大小写与首尾空白不得让一次配置「消失」。
+//
+// 这条守的是**失败方向**而非美观。SettingBoolOK 的调用方会在其上再叠一层代码默认，
+// 而今天用它的三个键（Bot 卡片开关）代码默认全是 true。所以运维在 system_setting
+// 里写下 `False` 却被判成「未配置」时，得到的不是一个中性的回落，而是**他本想关掉
+// 的能力继续开着**，且全链路没有任何报错。
+func TestSettingBoolOK_LexingIsForgiving(t *testing.T) {
+	for _, tc := range []struct {
+		raw   string
+		value bool
+	}{
+		{"true", true}, {"TRUE", true}, {"True", true}, {"1", true}, {" true ", true},
+		{"false", false}, {"FALSE", false}, {"False", false}, {"0", false}, {"\tfalse\n", false},
+	} {
+		value, configured := boolOKSettings(tc.raw).SettingBoolOK("botcard", "display_enabled")
+		assert.True(t, configured, "%q 必须被认作已配置", tc.raw)
+		assert.Equal(t, tc.value, value, "%q 解析成了 %v", tc.raw, value)
+	}
+}
+
+// TestSettingBoolOK_VocabularyMatchesParseSettingBool —— 词表故意不扩张。
+//
+// 放宽的只是词法（trim + 大小写），不是词表。把 on/off/yes/no 也收进来，会让
+// system_setting 的同一列对两个读者（getBool / SettingBoolOK）含义不同——这正是
+// 本模块要避免的分叉，而不是顺手的便利。任何一天要加词，两处一起加。
+func TestSettingBoolOK_VocabularyMatchesParseSettingBool(t *testing.T) {
+	for _, raw := range []string{"on", "off", "yes", "no", "enabled", "2", "null"} {
+		_, configured := boolOKSettings(raw).SettingBoolOK("botcard", "display_enabled")
+		assert.False(t, configured, "%q 不该被 SettingBoolOK 单方面接受", raw)
+
+		// 同一个词在 getBool 侧同样落 fallback —— 两个读者始终同词表。
+		assert.True(t, parseSettingBool(raw, true), "%q 在 getBool 侧被解析了，两处词表已分叉", raw)
+		assert.False(t, parseSettingBool(raw, false), "%q 在 getBool 侧被解析了，两处词表已分叉", raw)
+	}
+}
+
+// TestSettingBoolOK_UnsetAndUnparseableBothFallThrough —— 「没配」与「配错了」在
+// 本层同样报 configured=false（调用方据此回落），区别只在日志：脏值由调用方
+// （modules/robot 的 bot_setting 解析器）告警，本层不知道调用方的期望。
+func TestSettingBoolOK_UnsetAndUnparseableBothFallThrough(t *testing.T) {
+	value, configured := boolOKSettings("").SettingBoolOK("botcard", "display_enabled")
+	assert.False(t, configured)
+	assert.False(t, value)
+
+	value, configured = boolOKSettings("maybe").SettingBoolOK("botcard", "display_enabled")
+	assert.False(t, configured)
+	assert.False(t, value)
+}

--- a/modules/robot/api.go
+++ b/modules/robot/api.go
@@ -1016,6 +1016,22 @@ func (rb *Robot) payloadIsVail(payloadResult maputil.Data) bool {
 }
 
 // 是否允许发送消息到频道
+//
+// 三个 robot ingress（sendMessage / typing / streamStart）共用这一份判定，所以这里
+// 少认一种频道类型，那种类型就在三条路上同时不可用。
+//
+// **子区（CommunityTopic）此前落在末尾的「未知类型」里被一律拒绝**，而 sendMessage、
+// typing、streamStart 三处各自都写着一个解析父群的子区解散守卫——那三个分支因此永远
+// 不可达。守卫会去 resolveParentGroupNo 说明作者本就打算让子区能用，是本函数漏了这个
+// case，不是那三处多写了。streamStart 补上频道校验时（round-8 评审）这个洞才暴露出来：
+// 那条路先前没有校验，于是成了三条里唯一「子区能发」的例外。
+//
+// 子区的成员资格取决于**父群**：子区 channelID 形如 `<parentGroupNo>____<topicNo>`，
+// 权限模型里子区不单独持有成员表。因此解析出父群再查成员，与群分支同一条规则、同一次
+// 查询，解析是纯字符串操作、不额外碰库。
+//
+// 方向上这是**放宽**（type 5：永远拒 → 按父群成员判定），所以今天能发的一样能发；
+// 受影响的只有先前被无条件 403 的子区请求。
 func (rb *Robot) allowSendToChannel(robotID string, channelID string, channelType uint8) bool {
 	if channelType == common.ChannelTypePerson.Uint8() {
 		// 个人频道允许机器人发送消息
@@ -1026,6 +1042,20 @@ func (rb *Robot) allowSendToChannel(robotID string, channelID string, channelTyp
 		exist, err := rb.groupService.ExistMember(channelID, robotID)
 		if err != nil {
 			rb.Error("检查机器人是否是频道成员失败！", zap.Error(err), zap.String("robotID", robotID), zap.String("channelID", channelID))
+			return false
+		}
+		return exist
+	}
+	if channelType == common.ChannelTypeCommunityTopic.Uint8() {
+		// 子区：成员资格在父群上。channelID 形状不合法时 fail-closed。
+		parentGroupNo, err := rb.resolveParentGroupNo(channelID)
+		if err != nil {
+			rb.Error("解析子区父群失败！", zap.Error(err), zap.String("robotID", robotID), zap.String("channelID", channelID))
+			return false
+		}
+		exist, err := rb.groupService.ExistMember(parentGroupNo, robotID)
+		if err != nil {
+			rb.Error("检查机器人是否是子区父群成员失败！", zap.Error(err), zap.String("robotID", robotID), zap.String("channelID", channelID))
 			return false
 		}
 		return exist

--- a/modules/robot/api.go
+++ b/modules/robot/api.go
@@ -1027,8 +1027,13 @@ func (rb *Robot) payloadIsVail(payloadResult maputil.Data) bool {
 // 那条路先前没有校验，于是成了三条里唯一「子区能发」的例外。
 //
 // 子区的成员资格取决于**父群**：子区 channelID 形如 `<parentGroupNo>____<topicNo>`，
-// 权限模型里子区不单独持有成员表。因此解析出父群再查成员，与群分支同一条规则、同一次
-// 查询，解析是纯字符串操作、不额外碰库。
+// 权限模型里子区不单独持有成员表。因此解析出父群再查成员，解析是纯字符串操作、不额外碰库。
+//
+// **但用的谓词比群分支严**，不是同一条规则：群分支是 ExistMember（只看 is_deleted），
+// 子区分支是 ExistMemberActive（还要求 status=Normal）。这个不对称是全仓既有口径——
+// 子区门禁在 YUJ-4185 被专门加固过，thread / message / messages_search / bot_api 各处
+// 都用严格变体，群门禁则仍是松的。所以「被拉黑的 bot 能发父群、不能发子区」是刻意的，
+// 不是遗漏。收紧群分支是更大范围的行为变更，另行评估。
 //
 // 方向上这是**放宽**（type 5：永远拒 → 按父群成员判定），所以今天能发的一样能发；
 // 受影响的只有先前被无条件 403 的子区请求。
@@ -1053,9 +1058,19 @@ func (rb *Robot) allowSendToChannel(robotID string, channelID string, channelTyp
 			rb.Error("解析子区父群失败！", zap.Error(err), zap.String("robotID", robotID), zap.String("channelID", channelID))
 			return false
 		}
-		exist, err := rb.groupService.ExistMember(parentGroupNo, robotID)
+		// **必须是 ExistMemberActive，不是上面群分支那个 ExistMember**（round-8 评审 P1）。
+		// ExistMember 只过滤 is_deleted=0，被拉黑成员（status=Blacklist）照样返回 true；
+		// ExistMemberActive 额外要求 status=Normal。group/service.go 上该方法的注释点名了
+		// 这个场景：「子区(CommunityTopic)读/发门禁用它替代 ExistMember，避免被拉黑用户
+		// 越权读/发（YUJ-4185 CR 整改）」，thread / message / messages_search / bot_api
+		// 的每一处子区门禁也都用它。
+		//
+		// 这条路尤其不能松：robot ingress 是服务端直发，不经过 IM datasource，因而拿不到
+		// thread 模块的子区拉黑继承（thread/1module.go）——本地这道门就是唯一防线，正是
+		// group/db.go 里「用于绕过 IM 层的接口」那句话所指的情形。
+		exist, err := rb.groupService.ExistMemberActive(parentGroupNo, robotID)
 		if err != nil {
-			rb.Error("检查机器人是否是子区父群成员失败！", zap.Error(err), zap.String("robotID", robotID), zap.String("channelID", channelID))
+			rb.Error("检查机器人是否是子区父群活跃成员失败！", zap.Error(err), zap.String("robotID", robotID), zap.String("channelID", channelID))
 			return false
 		}
 		return exist

--- a/modules/robot/api.go
+++ b/modules/robot/api.go
@@ -32,6 +32,7 @@ import (
 	commonmodule "github.com/Mininglamp-OSS/octo-server/modules/common"
 	"github.com/Mininglamp-OSS/octo-server/modules/file"
 	"github.com/Mininglamp-OSS/octo-server/modules/group"
+	"github.com/Mininglamp-OSS/octo-server/modules/thread"
 	"github.com/Mininglamp-OSS/octo-server/modules/user"
 	"github.com/Mininglamp-OSS/octo-server/pkg/botevent"
 	"github.com/Mininglamp-OSS/octo-server/pkg/cardmsg"
@@ -2427,10 +2428,27 @@ func (rb *Robot) isGroupDisbanded(groupNo string) (bool, error) {
 
 // resolveParentGroupNo 从子区 channelID 解析父群号。
 // 子区 channelID 格式：groupNo____threadID（4个下划线分隔）
+// resolveParentGroupNo 从子区 channelID 解析父群号。
+//
+// 委托给 thread.ParseChannelID，**不自己写解析**（round-9 评审 P2-2）。原实现用
+// `SplitN(channelID, "____", 2)`，只要能切出两段就通过；标准解析器用 `Split`（非
+// SplitN）要求**恰好**两段、且两段都非空。差别在本函数只喂解散守卫时无害，但现在它
+// 还喂 allowSendToChannel 的子区分支——也就是**鉴权判定**：
+//
+//	"groupA____topic____extra" → SplitN 给出 parts[0]="groupA"，成员校验按 groupA 过，
+//	而派发出去的是原始的非规范 channelID；下游一律走 ParseChannelID，于是那条消息
+//	解析失败、投不到任何订阅者。门与投递目标对「什么是合法子区 ID」的判断不一致。
+//
+// 这与刚修的 P1（子区成员判定用了比全仓更松的谓词）是同一族问题：robot 模块把一个
+// 全仓已有的判定又实现了一遍，而且更松。所以这里不再「顺手收紧」，直接用那一份。
+//
+// 不额外套 thread.IsValidShortID（15–20 位数字）：本函数要保证的性质是「校验成员的
+// 群 == 消息实际投递的群」，恰好两段非空即可确定 parts[0] 无歧义；short id 的取值域
+// 是另一回事，收紧它的影响面本处无法核实。
 func (rb *Robot) resolveParentGroupNo(channelID string) (string, error) {
-	parts := strings.SplitN(channelID, "____", 2)
-	if len(parts) != 2 {
-		return "", fmt.Errorf("invalid community topic channelID format: %s", channelID)
+	groupNo, _, err := thread.ParseChannelID(channelID)
+	if err != nil {
+		return "", fmt.Errorf("invalid community topic channelID format: %s: %w", channelID, err)
 	}
-	return parts[0], nil
+	return groupNo, nil
 }

--- a/modules/robot/api.go
+++ b/modules/robot/api.go
@@ -755,6 +755,36 @@ func (rb *Robot) sendMessage(c *wkhttp.Context) {
 		respondRobotContentInvalid(c, "payload")
 		return
 	}
+
+	// per-Bot 卡片策略门（task bot-setting-store，round-2 评审 P1-1）。
+	//
+	// 本仓有**三个**卡片生产者入口，payloadIsVail 的 InteractiveCard 分支自己就写着
+	// 「与 bot_api 的 send gate 对称」。bot_setting 上线时只给 bot_api 那道门加了
+	// per-Bot 判定，这条 legacy 路径仍只有部署总闸 + Validate —— 而两条路的身份是**同
+	// 一列**（authRobot 按 robot.robot_id 解析，bot_setting.robot_id 与 assertRobotOwner
+	// 的 creator_uid 取自同一张表）。于是 owner 关掉展示/交互卡后，同一个 Bot 换这个
+	// 端点仍能把卡发出去：一个被某条已鉴权路径忽略的能力开关，就不成其为能力开关。
+	//
+	// 排在 payloadIsVail 之后：形状先过，策略再判，拒绝形状与本 ingress 既有口径一致
+	// （单一 content-invalid，防枚举；具体原因只进日志）。
+	if rejectRobotCardBySetting(payloadResult) {
+		cfg, cfgErr := rb.BotCardConfig(robotID)
+		if cfgErr != nil {
+			// fail-closed：配置读不到时不得放行，否则一次 DB 抖动就把 owner 关掉的
+			// 能力从这条路放开（与 bot_api 侧同姿态）。
+			rb.Error("查询 Bot 卡片配置失败", zap.Error(cfgErr), zap.String("robot_id", robotID))
+			httperr.ResponseErrorL(c, errcode.ErrRobotQueryFailed, nil, nil)
+			return
+		}
+		if !robotCardPolicyAllows(payloadResult, cfg) {
+			rb.Warn("Bot 卡片能力已关闭，legacy robot ingress 拒绝",
+				zap.String("robot_id", robotID),
+				zap.Bool("display", cfg.DisplayEnabled),
+				zap.Bool("interaction", cfg.InteractionEnabled))
+			respondRobotContentInvalid(c, "payload")
+			return
+		}
+	}
 	userResp, err := rb.userService.GetUserWithUsername(robotID)
 	if err != nil {
 		rb.Error("查询机器人的用户信息失败！", zap.Error(err))

--- a/modules/robot/api.go
+++ b/modules/robot/api.go
@@ -29,6 +29,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-server/internal/msgextraseq"
 	"github.com/Mininglamp-OSS/octo-server/modules/base/app"
 	"github.com/Mininglamp-OSS/octo-server/modules/botfather/cmdmenu"
+	commonmodule "github.com/Mininglamp-OSS/octo-server/modules/common"
 	"github.com/Mininglamp-OSS/octo-server/modules/file"
 	"github.com/Mininglamp-OSS/octo-server/modules/group"
 	"github.com/Mininglamp-OSS/octo-server/modules/user"
@@ -111,6 +112,17 @@ type IService interface {
 	// EnqueueBotTypedEvent without making it visible. The returned event is
 	// intended for an atomic fenced commit by another module.
 	PrepareBotTypedEvent(robotID, eventType string, eventData map[string]interface{}) (PreparedBotTypedEvent, error)
+	// BotCardConfig resolves the bot's effective card capability switches
+	// (task bot-setting-store): the bot_setting override, then the
+	// system_setting deployment default, then the code default — already
+	// AND-ed with the deployment master switch cardmsg.BotEnabled().
+	//
+	// Both the /v1/bot/card/profile manifest and the sendMessage gate read
+	// it, so the advertised capability and what the send path accepts cannot
+	// drift. An error means the config could not be read; callers must fail
+	// closed rather than substituting defaults — a DB blip must not silently
+	// re-open a capability the owner turned off.
+	BotCardConfig(robotID string) (BotCardConfig, error)
 }
 
 // Service robot 模块对外暴露的只读服务实现，供其它模块注入使用。
@@ -120,13 +132,17 @@ type Service struct {
 	ctx          *config.Context
 	db           *robotDB
 	creatorCache sync.Map // robotID -> creatorUID
+	// systemSettings mirrors the Robot field: resolved once at construction so
+	// the per-request path never takes common's process-wide singleton mutex.
+	systemSettings *commonmodule.SystemSettings
 }
 
 // NewService 构造一个只读 robot 服务，满足 IService 接口。
 func NewService(ctx *config.Context) IService {
 	return &Service{
-		ctx: ctx,
-		db:  newBotDB(ctx),
+		ctx:            ctx,
+		db:             newBotDB(ctx),
+		systemSettings: commonmodule.EnsureSystemSettings(ctx),
 	}
 }
 
@@ -356,6 +372,12 @@ type Robot struct {
 	// it; it selects legacy GenSeq vs the transactional channel sequence by the
 	// DB-authoritative state row.
 	seqStore *msgextraseq.Store
+	// systemSettings is the process-wide admin-config snapshot, resolved once
+	// here rather than per call. common.EnsureSystemSettings takes a global
+	// mutex on every invocation, so calling it per request would put a
+	// process-wide lock on the card send path and defeat the lock-free
+	// atomic.Pointer read the snapshot is designed around.
+	systemSettings *commonmodule.SystemSettings
 }
 
 func New(ctx *config.Context) *Robot {
@@ -373,6 +395,7 @@ func New(ctx *config.Context) *Robot {
 		mentionRegexp:                 regexp.MustCompile(`@\S+`),
 		msgSem:                        make(chan struct{}, 100), // limit concurrent message processing goroutines
 		seqStore:                      msgextraseq.New(ctx),
+		systemSettings:                commonmodule.EnsureSystemSettings(ctx),
 	}
 	ctx.AddMessagesListener(rb.messagesListen)
 
@@ -397,6 +420,14 @@ func (rb *Robot) Route(r *wkhttp.WKHttp) {
 		auth.PUT("/robot/:robot_id/groups/:group_no/mention_pref", rb.setMentionPref)       // UPSERT 群级免@偏好
 		auth.DELETE("/robot/:robot_id/groups/:group_no/mention_pref", rb.deleteMentionPref) // 删除回退默认（幂等）
 		auth.GET("/robot/:robot_id/groups/:group_no/mention_pref", rb.getMentionPref)       // 读群级免@偏好
+		// Bot 级配置（task bot-setting-store）：owner 目录查询 / 批量写 / 删除覆盖。
+		//
+		// SharedUIDRateLimiter 逐路由挂而非挂在整个 auth 组上：本组已有十余个既有
+		// 路由，给整组加限流会改变它们的行为，超出本任务范围。顺序必须在
+		// AuthMiddleware 之后——限流器读不到 uid 会静默 fail-open。
+		auth.GET("/robot/:robot_id/settings", appwkhttp.SharedUIDRateLimiter(r, rb.ctx), rb.listBotSettings)
+		auth.PUT("/robot/:robot_id/settings", appwkhttp.SharedUIDRateLimiter(r, rb.ctx), rb.updateBotSettings)
+		auth.DELETE("/robot/:robot_id/settings/:key", appwkhttp.SharedUIDRateLimiter(r, rb.ctx), rb.deleteBotSetting)
 	}
 
 	ownedBots := r.Group("/v1", rb.ctx.AuthMiddleware(r), appwkhttp.SharedUIDRateLimiter(r, rb.ctx))

--- a/modules/robot/api.go
+++ b/modules/robot/api.go
@@ -487,6 +487,49 @@ func (rb *Robot) streamStart(c *wkhttp.Context) {
 		return
 	}
 
+	// 流式入口一律不接受卡片 payload（task bot-setting-store，round-7 评审阻塞项）。
+	//
+	// 本 handler 把 req.Payload（裸 []byte）原样转给 WuKongIM：没有 payloadIsVail、
+	// 没有 cardmsg.Validate、没有 BotEnabled() 总闸、也没有 per-Bot 门。于是 owner 关掉
+	// 展示/交互卡之后，同一个 Bot 换这个端点仍能把 type:17 送出去——本任务对外承诺的是
+	// 「每条已鉴权的发卡路径都按有效配置校验」，少一条这个承诺就是假的。
+	//
+	// 这里**拒绝**而不是补一套完整门禁，是刻意的：补门意味着要在这条路上重建形状校验、
+	// URL 白名单、节点/深度上限与 profile 协商，那是把 sendMessage 的整条流水线复制一遍；
+	// 而流式消息的用途是增量文本，卡片有 sendMessage 与模板 message/edit 两条正规入口，
+	// 没有理由从这里发。拒绝让承诺变真，且不新增一套会和 sendMessage 漂移的判定。
+	//
+	// 本 handler 另有两个**先于本任务存在**的问题不在这里处理，也不该被这道门掩盖：
+	// 缺少 allowSendToChannel，以及 req.FromUID 由调用方指定而非取自已鉴权的 robot_id
+	// （冒充类）。它们与 merge-base 逐字节相同，详见 journal 的 known-gaps。
+	robotID := c.Param("robot_id")
+	if cardmsg.IsCardRawPayload(req.Payload) {
+		rb.Warn("stream/start 不接受卡片 payload，已拒绝", zap.String("robot_id", robotID))
+		respondRobotContentInvalid(c, "payload")
+		return
+	}
+
+	// 身份与频道对齐同组的 sendMessage / typing（round-7 评审阻塞项）。
+	//
+	// FromUID 此前直接取调用方传入的值。同一个 robotAuth 组里，sendMessage 把它钉成
+	// c.Param("robot_id")，typing 同理——只有本 handler 是例外，于是一个已鉴权的 Bot 能
+	// 以**任意 uid** 的身份开流。鉴权解决的是「你是谁」，这里却让请求体决定「你说你是谁」，
+	// 两者不一致时冒充就成立。评审判定这条比卡片那条更重，且与客户端是否渲染卡片无关。
+	//
+	// allowSendToChannel 同理：sendMessage 与 typing 都查，本 handler 不查，于是 Bot 能
+	// 往它并非成员的群开流。两处都不是新增策略，是把这条路补回同组既有口径。
+	// 先钉身份，再拿**钉过之后的 req.FromUID** 去查频道权限——不是拿旁边的 robotID。
+	// 两者此刻等值，但校验的必须是真正会被派发的那个字段：若哪天钉住被删或被移到后面，
+	// 用 robotID 校验会让频道门继续看到正确身份、而 IM 收到伪造身份，门就成了摆设。
+	// 一个变量走到底，这种漂移就不可能发生。
+	req.FromUID = robotID
+	if !rb.allowSendToChannel(req.FromUID, req.ChannelID, req.ChannelType) {
+		rb.Warn("robot 无权向该频道开流",
+			zap.String("robot_id", robotID), zap.String("channel_id", req.ChannelID))
+		httperr.ResponseErrorL(c, errcode.ErrRobotChannelSendForbidden, nil, nil)
+		return
+	}
+
 	// 解散守卫：群或子区解散后禁止开始流式消息
 	if req.ChannelType == common.ChannelTypeGroup.Uint8() {
 		if disbanded, err := rb.isGroupDisbanded(req.ChannelID); err != nil {

--- a/modules/robot/api.go
+++ b/modules/robot/api.go
@@ -487,46 +487,51 @@ func (rb *Robot) streamStart(c *wkhttp.Context) {
 		return
 	}
 
-	// 流式入口一律不接受卡片 payload（task bot-setting-store，round-7 评审阻塞项）。
+	// 身份 → 频道 → 内容，与同组 sendMessage 逐条对齐（round-7 评审阻塞项）。
+	//
+	// 顺序本身是契约的一部分，不是排版：sendMessage 先 allowSendToChannel 再
+	// payloadIsVail，即**先确定你有没有资格往这里发，再看你发的是什么**。本分支已经为
+	// 同一条原则改过一次——settings 三个端点的属主校验被三位 reviewer 连提三轮，最终
+	// 前移到形状校验之前，理由是「对未知/无权资源返回 400 与端点自述的 404/403 语义
+	// 矛盾」。这里同理：非群成员发一张卡，该答 channel_send_forbidden（你没资格），
+	// 而不是 content_invalid（你东西不对）——后者等于在鉴权之前就对内容表态。
+	robotID := c.Param("robot_id")
+
+	// FromUID 此前直接取调用方传入的值。同一个 robotAuth 组里 sendMessage 与 typing 都把
+	// 它钉成 c.Param("robot_id")，只有本 handler 是例外，于是一个已鉴权的 Bot 能以**任意
+	// uid** 开流。鉴权解决的是「你是谁」，这里却让请求体决定「你说你是谁」。评审判定这条
+	// 比卡片那条更重，且与客户端是否渲染卡片无关。
+	//
+	// 钉完之后拿**钉过的 req.FromUID** 去查频道权限，而不是旁边的 robotID：两者此刻等值，
+	// 但校验的必须是真正会被派发的那个字段。若哪天钉住被删或被移到后面，用 robotID 校验会
+	// 让频道门继续看到正确身份、而 IM 收到伪造身份，门就成了摆设。一个变量走到底，这种漂移
+	// 不可能发生。
+	req.FromUID = robotID
+	if !rb.allowSendToChannel(req.FromUID, req.ChannelID, req.ChannelType) {
+		rb.Warn("robot 无权向该频道开流",
+			zap.String("robot_id", robotID), zap.String("channel_id", req.ChannelID))
+		httperr.ResponseErrorL(c, errcode.ErrRobotChannelSendForbidden, nil, nil)
+		return
+	}
+
+	// 流式入口一律不接受卡片 payload。
 	//
 	// 本 handler 把 req.Payload（裸 []byte）原样转给 WuKongIM：没有 payloadIsVail、
 	// 没有 cardmsg.Validate、没有 BotEnabled() 总闸、也没有 per-Bot 门。于是 owner 关掉
 	// 展示/交互卡之后，同一个 Bot 换这个端点仍能把 type:17 送出去——本任务对外承诺的是
 	// 「每条已鉴权的发卡路径都按有效配置校验」，少一条这个承诺就是假的。
 	//
-	// 这里**拒绝**而不是补一套完整门禁，是刻意的：补门意味着要在这条路上重建形状校验、
+	// **拒绝**而不是补一套完整门禁，是刻意的：补门意味着要在这条路上重建形状校验、
 	// URL 白名单、节点/深度上限与 profile 协商，那是把 sendMessage 的整条流水线复制一遍；
 	// 而流式消息的用途是增量文本，卡片有 sendMessage 与模板 message/edit 两条正规入口，
 	// 没有理由从这里发。拒绝让承诺变真，且不新增一套会和 sendMessage 漂移的判定。
 	//
-	// 本 handler 另有两个**先于本任务存在**的问题不在这里处理，也不该被这道门掩盖：
-	// 缺少 allowSendToChannel，以及 req.FromUID 由调用方指定而非取自已鉴权的 robot_id
-	// （冒充类）。它们与 merge-base 逐字节相同，详见 journal 的 known-gaps。
-	robotID := c.Param("robot_id")
+	// 边界：IsCardRawPayload 只认 JSON 数字 type，与 IsCardPayload 同源。本 handler 不做
+	// 类型分发，因此不存在 legacy sendMessage 那个「路由强转字符串、校验不认」的夹缝
+	// （round-3 P2-1）；`{"type":"17"}` 在这里当普通 payload 转发，见 journal known-gaps。
 	if cardmsg.IsCardRawPayload(req.Payload) {
 		rb.Warn("stream/start 不接受卡片 payload，已拒绝", zap.String("robot_id", robotID))
 		respondRobotContentInvalid(c, "payload")
-		return
-	}
-
-	// 身份与频道对齐同组的 sendMessage / typing（round-7 评审阻塞项）。
-	//
-	// FromUID 此前直接取调用方传入的值。同一个 robotAuth 组里，sendMessage 把它钉成
-	// c.Param("robot_id")，typing 同理——只有本 handler 是例外，于是一个已鉴权的 Bot 能
-	// 以**任意 uid** 的身份开流。鉴权解决的是「你是谁」，这里却让请求体决定「你说你是谁」，
-	// 两者不一致时冒充就成立。评审判定这条比卡片那条更重，且与客户端是否渲染卡片无关。
-	//
-	// allowSendToChannel 同理：sendMessage 与 typing 都查，本 handler 不查，于是 Bot 能
-	// 往它并非成员的群开流。两处都不是新增策略，是把这条路补回同组既有口径。
-	// 先钉身份，再拿**钉过之后的 req.FromUID** 去查频道权限——不是拿旁边的 robotID。
-	// 两者此刻等值，但校验的必须是真正会被派发的那个字段：若哪天钉住被删或被移到后面，
-	// 用 robotID 校验会让频道门继续看到正确身份、而 IM 收到伪造身份，门就成了摆设。
-	// 一个变量走到底，这种漂移就不可能发生。
-	req.FromUID = robotID
-	if !rb.allowSendToChannel(req.FromUID, req.ChannelID, req.ChannelType) {
-		rb.Warn("robot 无权向该频道开流",
-			zap.String("robot_id", robotID), zap.String("channel_id", req.ChannelID))
-		httperr.ResponseErrorL(c, errcode.ErrRobotChannelSendForbidden, nil, nil)
 		return
 	}
 

--- a/modules/robot/api.go
+++ b/modules/robot/api.go
@@ -129,7 +129,8 @@ type IService interface {
 // 与 *Robot 共享底层表结构，但不承担消息/事件监听等副作用，
 // 因此可以被重复 New 出来而不会导致重复注册 listener。
 type Service struct {
-	ctx          *config.Context
+	ctx *config.Context
+	log.Log
 	db           *robotDB
 	creatorCache sync.Map // robotID -> creatorUID
 	// systemSettings mirrors the Robot field: resolved once at construction so
@@ -141,6 +142,7 @@ type Service struct {
 func NewService(ctx *config.Context) IService {
 	return &Service{
 		ctx:            ctx,
+		Log:            log.NewTLog("RobotService"),
 		db:             newBotDB(ctx),
 		systemSettings: commonmodule.EnsureSystemSettings(ctx),
 	}
@@ -921,6 +923,21 @@ func (rb *Robot) payloadIsVail(payloadResult maputil.Data) bool {
 		// 的 send gate 对称（rollout flag + write-strict Validate）。本 ingress
 		// 的错误形状是单一 content-invalid 400（防枚举）——flag 关闭 / 白名单 /
 		// 大小 / URL 失败的具体原因只进日志。
+		//
+		// 路由谓词与校验谓词必须是同一个（round-3 评审 P2-1）。本 ingress 是全仓
+		// **唯一**用 maputil.Data.Int("type") 分发的入口（bot_api / message / notify
+		// 都直接调 IsCardPayload），而 Int 会对字符串跑 strconv.Atoi，IsCardPayload
+		// 则只认 float64/int/json.Number、**故意**拒掉字符串 "17"。两者不一致时，
+		// {"type":"17"} 会：进本分支 → Validate 因 IsCardPayload=false 直接 return nil
+		// （pkg/cardmsg/validate.go）→ rejectRobotCardBySetting 同样判 false 而跳过全部
+		// per-Bot 开关 → Finalize no-op。于是一棵没过 URL 白名单、节点/深度上限、
+		// profile 协商与能力开关的卡片树被派发出去，只要有客户端对 type 做宽松转换
+		// 就能渲染。在这里收口成 IsCardPayload：卡片分支的可达性从此与校验、与门禁
+		// 完全同源，不再存在「路由认为是卡片、校验认为不是」的夹缝。
+		if !cardmsg.IsCardPayload(payloadResult) {
+			rb.Warn("payload.type 非 JSON 数字，不认作卡片（拒绝而非降级放行）")
+			return false
+		}
 		if !cardmsg.BotEnabled() {
 			// bot 侧有效门禁：总开关 OCTO_CARD_MESSAGE_ENABLED（Decision 2 rollout
 			// gate）AND bot 子开关 OCTO_BOT_CARD_ENABLED；robot 是 bot 生产者之一，

--- a/modules/robot/api_i18n_test.go
+++ b/modules/robot/api_i18n_test.go
@@ -30,7 +30,7 @@ func httperrL(c *wkhttp.Context, code codes.Code) {
 // envelope (respondRobotAuth* helpers) and the inline-query timeout via
 // respondRobotInlineQueryTimeout, so no raw gin abort should remain.
 func TestRobotNoLegacyResponseError(t *testing.T) {
-	files := []string{"api.go", "api_manager.go", "mention_pref.go"}
+	files := []string{"api.go", "api_manager.go", "mention_pref.go", "bot_setting.go"}
 	banned := []string{
 		".ResponseError(",
 		".ResponseErrorf(",

--- a/modules/robot/bot_setting.go
+++ b/modules/robot/bot_setting.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"sort"
 	"strings"
+	"sync"
 
 	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
@@ -301,12 +302,34 @@ func queryBotSettingOverrides(ctx *config.Context, robotID string) (map[string]s
 	return out, nil
 }
 
+// malformedBotSettingSeen 去重「脏覆盖值」告警：脏值是持久状态（人工改库 / 迁移
+// 出错），而解析发生在每次发卡与每次 profile 读上，不去重就是每请求一条 Warn。
+// 只有真正脏的 (robot, key) 才会入表，条目数被损坏行数界定，修好数据后重启即清。
+var malformedBotSettingSeen sync.Map
+
+// warnMalformedBotSetting 每个 (robot, key) 只喊一次。
+func warnMalformedBotSetting(warn func(string, ...zap.Field), robotID, key, raw string) {
+	if warn == nil {
+		return
+	}
+	if _, dup := malformedBotSettingSeen.LoadOrStore(robotID+"\x00"+key, struct{}{}); dup {
+		return
+	}
+	warn("bot_setting 覆盖值非法，已忽略并回落上一层（该 Bot 的这项配置未按你设置的生效）",
+		zap.String("robot_id", robotID), zap.String("key", key), zap.String("value", raw))
+}
+
 // resolveBotSettings 解析该 Bot 的全部已注册键。DB 故障向上抛——配置读不到时
 // **不能**假装成「用默认值」：那会让一次 DB 抖动静默放开本该关闭的能力。
+//
+// warn 收「脏值回落」的告警。它是参数而不是包级 logger，因为两个调用方
+// （*Service 供 bot_api、*Robot 供 legacy ingress）各自有 tag 化的 log.Log，
+// 日志里能看出是哪条路读到的脏值；测试传 nil 即静默。
 func resolveBotSettings(
 	ctx *config.Context,
 	settings *commonmodule.SystemSettings,
 	robotID string,
+	warn func(string, ...zap.Field),
 ) ([]botSettingResolution, error) {
 	overrides, err := queryBotSettingOverrides(ctx, robotID)
 	if err != nil {
@@ -318,6 +341,11 @@ func resolveBotSettings(
 		if raw, ok := overrides[def.Key]; ok && def.Editable {
 			if v, valid := parseBotSettingBool(raw); valid {
 				override = &v
+			} else {
+				// 脏值当作「未配置」回落，而不是当 false 生效——但必须留痕：
+				// 静默回落时 owner 只会看到「跟随默认」，而他明明写过一个值
+				// （round-3 评审 P2-6）。
+				warnMalformedBotSetting(warn, robotID, def.Key, raw)
 			}
 		}
 		var globalValue, globalOK bool
@@ -350,7 +378,7 @@ func botCardConfigFrom(resolutions []botSettingResolution) BotCardConfig {
 // BotCardConfig — IService — 返回该 Bot 的卡片能力有效配置（已 AND 总闸）。
 // bot_api 的 profile 下发与 sendMessage 门禁共用它。
 func (s *Service) BotCardConfig(robotID string) (BotCardConfig, error) {
-	resolutions, err := resolveBotSettings(s.ctx, s.systemSettings, robotID)
+	resolutions, err := resolveBotSettings(s.ctx, s.systemSettings, robotID, s.Warn)
 	if err != nil {
 		return BotCardConfig{}, err
 	}
@@ -359,7 +387,7 @@ func (s *Service) BotCardConfig(robotID string) (BotCardConfig, error) {
 
 // BotCardConfig — IService — *Robot 变体，与 Service 走同一份解析。
 func (rb *Robot) BotCardConfig(robotID string) (BotCardConfig, error) {
-	resolutions, err := resolveBotSettings(rb.ctx, rb.systemSettings, robotID)
+	resolutions, err := resolveBotSettings(rb.ctx, rb.systemSettings, robotID, rb.Warn)
 	if err != nil {
 		return BotCardConfig{}, err
 	}
@@ -379,7 +407,7 @@ func (rb *Robot) listBotSettings(c *wkhttp.Context) {
 		return
 	}
 
-	resolutions, err := resolveBotSettings(rb.ctx, rb.systemSettings, robotID)
+	resolutions, err := resolveBotSettings(rb.ctx, rb.systemSettings, robotID, rb.Warn)
 	if err != nil {
 		rb.Error("查询 bot_setting 失败", zap.Error(err), zap.String("robot_id", robotID))
 		httperr.ResponseErrorL(c, errcode.ErrRobotQueryFailed, nil, nil)

--- a/modules/robot/bot_setting.go
+++ b/modules/robot/bot_setting.go
@@ -385,11 +385,15 @@ func (rb *Robot) listBotSettings(c *wkhttp.Context) {
 		httperr.ResponseErrorL(c, errcode.ErrRobotQueryFailed, nil, nil)
 		return
 	}
-	// 该响应是某个 Bot 的私有配置，且只有登录态区分调用者。与
-	// /v1/bot/card/profile 同口径：private 禁共享代理缓存，no-store 不留副本
-	// —— 改完配置立刻重读要看到新值。
+	// 该响应是某个 Bot 的私有配置，且只有登录态区分调用者：private 禁共享代理
+	// 缓存，no-store 不留副本 —— 改完配置立刻重读要看到新值。
+	//
+	// Vary 命名的是**本路由实际使用的**鉴权头。用户会话走 `token`
+	// （octo-lib/pkg/wkhttp/http.go 的 c.GetHeader("token")），不是 Authorization ——
+	// /v1/bot/card/profile 才是 Authorization（bot token）。照抄那边会声明一个不影响
+	// 响应的头，读起来像做了隔离其实没有。
 	c.Header("Cache-Control", "private, no-store")
-	c.Header("Vary", "Authorization")
+	c.Header("Vary", "token")
 	c.Response(map[string]interface{}{"list": resolutions})
 }
 
@@ -428,6 +432,14 @@ func (rb *Robot) updateBotSettings(c *wkhttp.Context) {
 		return
 	}
 
+	// 属主校验放在逐项校验**之前**（round-2/3 评审反复提到）：否则一个非属主用户
+	// 能靠 400 与 403 的差别探测「某个键是否已注册且可写」，且对不存在 / 非自己的
+	// Bot 会收到 400 而不是文档承诺的 404 / 403 —— 削弱的是本端点自己声明的属主语义。
+	// 代价只是给形状错误的请求多一次查库，可以忽略。
+	if rb.assertRobotOwner(c, robotID, loginUID) {
+		return
+	}
+
 	plans := make([]botSettingWritePlan, 0, len(req.Items))
 	seen := make(map[string]struct{}, len(req.Items))
 	for _, item := range req.Items {
@@ -462,12 +474,6 @@ func (rb *Robot) updateBotSettings(c *wkhttp.Context) {
 	// 死锁（MySQL 1213）。逐条自动提交时锁立即释放、窗口可忽略，事务化之后不再是。
 	// 统一锁序是本仓既有做法（见 send.go 的 "#627 D4 uniform lock order"）。
 	sort.Slice(plans, func(i, j int) bool { return plans[i].key < plans[j].key })
-
-	// 属主校验放在形状校验之后、写库之前：形状错误无需查库即可拒，而任何写入都
-	// 必须先过属主门。
-	if rb.assertRobotOwner(c, robotID, loginUID) {
-		return
-	}
 
 	// 单事务提交整批。逐条自动提交会让「校验全过、第 2 条写失败」留下半应用状态：
 	// 调用方收到 500 以为什么都没生效，实际前面几项已经落库；更糟的是错误路径会跳过
@@ -526,13 +532,13 @@ func (rb *Robot) deleteBotSetting(c *wkhttp.Context) {
 	robotID := c.Param("robot_id")
 	key := c.Param("key")
 
-	def := findBotSettingDef(key)
-	if def == nil || !def.Editable {
-		respondRobotRequestInvalid(c, "key")
+	if rb.assertRobotOwner(c, robotID, loginUID) {
 		return
 	}
 
-	if rb.assertRobotOwner(c, robotID, loginUID) {
+	def := findBotSettingDef(key)
+	if def == nil || !def.Editable {
+		respondRobotRequestInvalid(c, "key")
 		return
 	}
 

--- a/modules/robot/bot_setting.go
+++ b/modules/robot/bot_setting.go
@@ -19,6 +19,7 @@ package robot
 // 能正确渲染的前提，也是读接口必须同时返回 value / effective_value / source 的原因。
 
 import (
+	"encoding/json"
 	"errors"
 	"strings"
 
@@ -137,6 +138,32 @@ func normalizeBotSettingBool(raw string) (string, bool) {
 	default:
 		return "", false
 	}
+}
+
+// normalizeBotSettingValue 归一化一个入站 JSON value。
+//
+// 同时接受 JSON bool（`true`）与字符串字面量（`"true"` / `"1"`），使读接口下发的
+// 形状可以原样写回：读侧给的是 bool，若写侧只认字符串，「读目录→改一项→PUT 回去」
+// 这条最自然的客户端路径会直接 400。空值 / null / 其它类型一律拒绝。
+func normalizeBotSettingValue(raw json.RawMessage) (string, bool) {
+	trimmed := strings.TrimSpace(string(raw))
+	if trimmed == "" || trimmed == "null" {
+		return "", false
+	}
+	// JSON bool：读接口的下发形状。
+	var asBool bool
+	if err := json.Unmarshal(raw, &asBool); err == nil {
+		if asBool {
+			return botSettingTrue, true
+		}
+		return botSettingFalse, true
+	}
+	// 字符串字面量："1"/"0"/"true"/"false"，兼容既有调用方。
+	var asString string
+	if err := json.Unmarshal(raw, &asString); err == nil {
+		return normalizeBotSettingBool(asString)
+	}
+	return "", false
 }
 
 // parseBotSettingBool 解析库里的 bool 值。非法值（人工改库等）视为未配置，
@@ -325,10 +352,15 @@ func (rb *Robot) listBotSettings(c *wkhttp.Context) {
 
 // botSettingUpdateReq 是批量写入体。批量而非单键，是为了让「同时关展示卡和交互卡」
 // 这类操作只产生一次事件推送。
+//
+// Value 是 json.RawMessage 而非 string：读接口把 value 下发成 JSON bool
+// （`true` / `false` / `null`），而 owner UI 的自然写法就是「读目录 → 改一项 → 写回」。
+// 若写侧只收字符串，那条往返会在 BindJSON 就 400，每个客户端都得先自己 stringify。
+// 收原始 JSON 后由 normalizeBotSettingValue 同时接受 bool 与字符串字面量。
 type botSettingUpdateReq struct {
 	Items []struct {
-		Key   string `json:"key"`
-		Value string `json:"value"`
+		Key   string          `json:"key"`
+		Value json.RawMessage `json:"value"`
 	} `json:"items"`
 }
 
@@ -372,7 +404,7 @@ func (rb *Robot) updateBotSettings(c *wkhttp.Context) {
 		}
 		seen[item.Key] = struct{}{}
 
-		normalized, ok := normalizeBotSettingBool(item.Value)
+		normalized, ok := normalizeBotSettingValue(item.Value)
 		if !ok {
 			respondRobotRequestInvalid(c, "value")
 			return
@@ -386,16 +418,27 @@ func (rb *Robot) updateBotSettings(c *wkhttp.Context) {
 		return
 	}
 
+	// 单事务提交整批。逐条自动提交会让「校验全过、第 2 条写失败」留下半应用状态：
+	// 调用方收到 500 以为什么都没生效，实际前面几项已经落库；更糟的是错误路径会跳过
+	// notifyBotSettingChanged，adapter 继续用旧缓存直到自己的 TTL 到期——正是该事件
+	// 要消灭的那个窗口。事务失败即整批回滚，"绝不半应用"才真正成立。
+	tx, err := rb.ctx.DB().Begin()
+	if err != nil {
+		rb.Error("开启 bot_setting 事务失败", zap.Error(err), zap.String("robot_id", robotID))
+		httperr.ResponseErrorL(c, errcode.ErrRobotStoreFailed, nil, nil)
+		return
+	}
+	defer tx.RollbackUnlessCommitted()
+
 	for _, p := range plans {
 		// dbr 的 InsertStmt 不暴露 Suffix，用 InsertBySql + ON DUPLICATE KEY UPDATE
 		// 完成 upsert（同 setMentionPref）。updated_at 走列默认自动更新。
-		_, err := rb.ctx.DB().InsertBySql(
+		if _, err := tx.InsertBySql(
 			"INSERT INTO bot_setting (robot_id, key_name, value, updated_by) "+
 				"VALUES (?, ?, ?, ?) "+
 				"ON DUPLICATE KEY UPDATE value=VALUES(value), updated_by=VALUES(updated_by)",
 			robotID, p.key, p.value, loginUID,
-		).Exec()
-		if err != nil {
+		).Exec(); err != nil {
 			rb.Error("写入 bot_setting 失败", zap.Error(err),
 				zap.String("robot_id", robotID), zap.String("key", p.key))
 			httperr.ResponseErrorL(c, errcode.ErrRobotStoreFailed, nil, nil)
@@ -403,6 +446,14 @@ func (rb *Robot) updateBotSettings(c *wkhttp.Context) {
 		}
 	}
 
+	if err := tx.Commit(); err != nil {
+		rb.Error("提交 bot_setting 事务失败", zap.Error(err), zap.String("robot_id", robotID))
+		httperr.ResponseErrorL(c, errcode.ErrRobotStoreFailed, nil, nil)
+		return
+	}
+
+	// 事件只在提交成功之后推：提交失败时没有任何变更生效，推事件会让 adapter 白白
+	// 重拉一次并读到与它已有缓存相同的值。
 	rb.notifyBotSettingChanged(robotID)
 	c.ResponseOK()
 }

--- a/modules/robot/bot_setting.go
+++ b/modules/robot/bot_setting.go
@@ -1,0 +1,473 @@
+package robot
+
+// bot_setting —— Bot 级配置的通用存储与解析（task bot-setting-store）。
+//
+// 为什么不继续给 `robot` 表加列：本仓此前的一维 Bot 配置一律是列
+// （inline_on / auto_approve / placeholder / bot_commands / app_bot.welcome_msg），
+// 每加一个开关一次 ALTER，滚动发布还要手写并发守卫。本文件把后续 Bot 级配置收敛到
+// KV，新增配置项只改注册表、不动 DDL。
+//
+// 与 bot_mention_pref 的关系：那张表是 (robot_id, group_no) **二维**，`robot` 扩列
+// 在结构上做不到，开表是唯一选择，因此它不是本文件的先例——但它的**周边形状**是本
+// 文件照搬的样板：owner 守卫、删除即回落、写后推事件失效 adapter 缓存。
+//
+// 解析链（三层，短路即返回）：
+//
+//	bot_setting 该 Bot 的显式覆盖 → system_setting 服务端全局默认 → 代码默认
+//
+// 「删除覆盖」== 回落上一层，**不是**「设为 false」。这个区分是 owner UI「恢复默认」
+// 能正确渲染的前提，也是读接口必须同时返回 value / effective_value / source 的原因。
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	commonmodule "github.com/Mininglamp-OSS/octo-server/modules/common"
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardmsg"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
+	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
+	"github.com/gocraft/dbr/v2"
+	"go.uber.org/zap"
+)
+
+// 配置值来源。owner 读接口把它原样下发，UI 据此渲染「跟随默认 / 已自定义」。
+const (
+	botSettingSourceBot     = "bot"     // 该 Bot 在 bot_setting 里的显式覆盖
+	botSettingSourceGlobal  = "global"  // system_setting 的服务端全局默认
+	botSettingSourceDefault = "default" // 代码默认
+	botSettingSourceEnv     = "env"     // 派生自部署环境变量，不可写
+)
+
+const botSettingTypeBool = "bool"
+
+// bot_setting 的 bool 字面量。与 system_setting 同口径（读侧另接受 true/false），
+// 写入一律归一化成 "1"/"0"，避免库里出现三种写法。
+const (
+	botSettingTrue  = "1"
+	botSettingFalse = "0"
+)
+
+// 已注册的 Bot 配置键。**新增配置项只改这里**：写入校验、owner 目录、
+// 解析链三处共用同一份定义，不可能漂移。
+//
+// 卡片能力四键的分工（brief 的 load-bearing 项，改动前先读）：
+//   - card_enabled 是**派生只读**值，等于 cardmsg.BotEnabled()，不落库、不可写。
+//     做成只读是为了堵一个具体的坑：否则库里可以写着 true 而 env 关着，profile 报
+//     能发、发出去被 card_disabled 拒，正好违反 pkg/cardmsg 已确立的「清单与发卡
+//     门禁同源」不变量。
+//   - display/interaction 只作用于 **raw 卡路径**（Bot 自拼 card JSON）；
+//     reasoning 只作用于 **Registry 模板卡**。三者正交。
+//     绝不可实现成「按 wire profile 一刀切」：推理卡自身横跨两档
+//     （active/error 是 octo/v2、result 是 octo/v1），按 profile 切会把它砍成只剩
+//     终态或只剩过程。
+const (
+	BotSettingKeyCardEnabled        = "bot.card_enabled"
+	BotSettingKeyDisplayEnabled     = "bot.display_enabled"
+	BotSettingKeyInteractionEnabled = "bot.interaction_enabled"
+	BotSettingKeyReasoningEnabled   = "bot.reasoning_enabled"
+)
+
+// botSettingDef 是一个配置键的完整定义。
+type botSettingDef struct {
+	Key  string
+	Type string
+	// Editable=false 表示派生只读键：不落 bot_setting，写入必须被拒。
+	Editable bool
+	// GlobalDefault 读 system_setting 层。派生键为 nil。
+	// 返回 (值, 是否已配置)——第二个返回值让解析器能区分「全局显式配了 false」
+	// 与「全局没意见、落到代码默认」，否则 source 会报错层。
+	GlobalDefault func(*commonmodule.SystemSettings) (bool, bool)
+	// CodeDefault 是解析链最后一层。
+	CodeDefault bool
+	// Derived 非 nil 表示该键的值完全由服务端环境派生，忽略前两层。
+	Derived func() bool
+}
+
+var botSettingDefs = []botSettingDef{
+	{
+		Key: BotSettingKeyCardEnabled, Type: botSettingTypeBool, Editable: false,
+		// 总闸：OCTO_CARD_MESSAGE_ENABLED AND OCTO_BOT_CARD_ENABLED。未设即 false
+		// （fail-closed）——正因为总闸保守，下面三项默认 true 才是安全的。
+		Derived: cardmsg.BotEnabled,
+	},
+	{
+		Key: BotSettingKeyDisplayEnabled, Type: botSettingTypeBool, Editable: true,
+		GlobalDefault: func(s *commonmodule.SystemSettings) (bool, bool) {
+			return s.SettingBoolOK("botcard", "display_enabled")
+		},
+		CodeDefault: true,
+	},
+	{
+		Key: BotSettingKeyInteractionEnabled, Type: botSettingTypeBool, Editable: true,
+		GlobalDefault: func(s *commonmodule.SystemSettings) (bool, bool) {
+			return s.SettingBoolOK("botcard", "interaction_enabled")
+		},
+		CodeDefault: true,
+	},
+	{
+		Key: BotSettingKeyReasoningEnabled, Type: botSettingTypeBool, Editable: true,
+		GlobalDefault: func(s *commonmodule.SystemSettings) (bool, bool) {
+			return s.SettingBoolOK("botcard", "reasoning_enabled")
+		},
+		CodeDefault: true,
+	},
+}
+
+// findBotSettingDef 返回 key 的定义；未注册返回 nil。写入路径据此拒绝野键。
+func findBotSettingDef(key string) *botSettingDef {
+	for i := range botSettingDefs {
+		if botSettingDefs[i].Key == key {
+			return &botSettingDefs[i]
+		}
+	}
+	return nil
+}
+
+// normalizeBotSettingBool 把入站 bool 字面量归一化成 "1"/"0"。第二个返回值为 false
+// 表示非法值，调用方必须 400 —— 不接受「猜一个默认」，否则 owner 以为设成了 A，
+// 实际存的是 B。
+func normalizeBotSettingBool(raw string) (string, bool) {
+	switch strings.TrimSpace(raw) {
+	case "1", "true", "TRUE", "True":
+		return botSettingTrue, true
+	case "0", "false", "FALSE", "False":
+		return botSettingFalse, true
+	default:
+		return "", false
+	}
+}
+
+// parseBotSettingBool 解析库里的 bool 值。非法值（人工改库等）视为未配置，
+// 让解析器落到下一层，而不是把脏值当 false 生效。
+func parseBotSettingBool(raw string) (value bool, ok bool) {
+	switch raw {
+	case botSettingTrue, "true", "TRUE":
+		return true, true
+	case botSettingFalse, "false", "FALSE":
+		return false, true
+	default:
+		return false, false
+	}
+}
+
+// botSettingResolution 是单个键的解析结果，同时是 owner 读接口的一行。
+type botSettingResolution struct {
+	Key string `json:"key"`
+	Typ string `json:"type"`
+	// Override 是该 Bot 在 bot_setting 里的显式覆盖；未设为 nil（JSON null）。
+	// 用指针而非 bool 是刻意的：合并成单值后，UI 就分不出「我显式设成了 false」
+	// 与「我没设、上层默认 false」，「恢复默认」也就无从渲染。
+	Override *bool  `json:"value"`
+	Eff      bool   `json:"effective_value"`
+	Source   string `json:"source"`
+	Editable bool   `json:"editable"`
+}
+
+// resolveBotSettingBool 是三层解析的**纯函数**核心：给定该 Bot 的覆盖行与全局默认，
+// 算出有效值与来源。抽成纯函数是为了让优先级、来源标注与派生键短路都能无 DB 单测。
+//
+// override 为 nil 表示该 Bot 没有覆盖行（或行里是脏值）；
+// globalValue/globalOK 来自 system_setting。
+func resolveBotSettingBool(def botSettingDef, override *bool, globalValue, globalOK bool) botSettingResolution {
+	out := botSettingResolution{Key: def.Key, Typ: def.Type, Editable: def.Editable}
+	// 派生键短路：环境说了算，前两层一律忽略（也不该有覆盖行）。
+	if def.Derived != nil {
+		out.Eff = def.Derived()
+		out.Source = botSettingSourceEnv
+		return out
+	}
+	switch {
+	case override != nil:
+		out.Override = override
+		out.Eff = *override
+		out.Source = botSettingSourceBot
+	case globalOK:
+		out.Eff = globalValue
+		out.Source = botSettingSourceGlobal
+	default:
+		out.Eff = def.CodeDefault
+		out.Source = botSettingSourceDefault
+	}
+	return out
+}
+
+// BotCardConfig 是一个 Bot 的卡片能力有效配置——**已经和总闸 AND 过**。
+// 消费方（/v1/bot/card/profile 下发、sendMessage 门禁）直接用，不再自行组合，
+// 避免两处各算一遍而漂移。
+type BotCardConfig struct {
+	CardEnabled        bool
+	DisplayEnabled     bool
+	InteractionEnabled bool
+	ReasoningEnabled   bool
+}
+
+// applyCardMasterSwitch 把总闸支配关系落到实处：总闸为假时三个子开关的有效值恒为假。
+// 单独抽出来是因为它是 brief 的 load-bearing 不变量，需要被单测直接钉住。
+func applyCardMasterSwitch(cfg BotCardConfig) BotCardConfig {
+	if cfg.CardEnabled {
+		return cfg
+	}
+	return BotCardConfig{}
+}
+
+// queryBotSettingOverrides 读该 Bot 的全部覆盖行。无行返回空 map，不是错误。
+func queryBotSettingOverrides(ctx *config.Context, robotID string) (map[string]string, error) {
+	type row struct {
+		KeyName string `db:"key_name"`
+		Value   string `db:"value"`
+	}
+	var rows []row
+	_, err := ctx.DB().Select("key_name", "value").From("bot_setting").
+		Where("robot_id=?", robotID).Load(&rows)
+	if err != nil && !errors.Is(err, dbr.ErrNotFound) {
+		return nil, err
+	}
+	out := make(map[string]string, len(rows))
+	for _, r := range rows {
+		out[r.KeyName] = r.Value
+	}
+	return out, nil
+}
+
+// resolveBotSettings 解析该 Bot 的全部已注册键。DB 故障向上抛——配置读不到时
+// **不能**假装成「用默认值」：那会让一次 DB 抖动静默放开本该关闭的能力。
+func resolveBotSettings(
+	ctx *config.Context,
+	settings *commonmodule.SystemSettings,
+	robotID string,
+) ([]botSettingResolution, error) {
+	overrides, err := queryBotSettingOverrides(ctx, robotID)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]botSettingResolution, 0, len(botSettingDefs))
+	for _, def := range botSettingDefs {
+		var override *bool
+		if raw, ok := overrides[def.Key]; ok && def.Editable {
+			if v, valid := parseBotSettingBool(raw); valid {
+				override = &v
+			}
+		}
+		var globalValue, globalOK bool
+		if def.GlobalDefault != nil && settings != nil {
+			globalValue, globalOK = def.GlobalDefault(settings)
+		}
+		out = append(out, resolveBotSettingBool(def, override, globalValue, globalOK))
+	}
+	return out, nil
+}
+
+// botCardConfigFrom 把解析结果投影成卡片四键，并施加总闸支配。
+func botCardConfigFrom(resolutions []botSettingResolution) BotCardConfig {
+	var cfg BotCardConfig
+	for _, r := range resolutions {
+		switch r.Key {
+		case BotSettingKeyCardEnabled:
+			cfg.CardEnabled = r.Eff
+		case BotSettingKeyDisplayEnabled:
+			cfg.DisplayEnabled = r.Eff
+		case BotSettingKeyInteractionEnabled:
+			cfg.InteractionEnabled = r.Eff
+		case BotSettingKeyReasoningEnabled:
+			cfg.ReasoningEnabled = r.Eff
+		}
+	}
+	return applyCardMasterSwitch(cfg)
+}
+
+// BotCardConfig — IService — 返回该 Bot 的卡片能力有效配置（已 AND 总闸）。
+// bot_api 的 profile 下发与 sendMessage 门禁共用它。
+func (s *Service) BotCardConfig(robotID string) (BotCardConfig, error) {
+	resolutions, err := resolveBotSettings(s.ctx, s.systemSettings, robotID)
+	if err != nil {
+		return BotCardConfig{}, err
+	}
+	return botCardConfigFrom(resolutions), nil
+}
+
+// BotCardConfig — IService — *Robot 变体，与 Service 走同一份解析。
+func (rb *Robot) BotCardConfig(robotID string) (BotCardConfig, error) {
+	resolutions, err := resolveBotSettings(rb.ctx, rb.systemSettings, robotID)
+	if err != nil {
+		return BotCardConfig{}, err
+	}
+	return botCardConfigFrom(resolutions), nil
+}
+
+// listBotSettings 处理 GET /v1/robot/:robot_id/settings。
+//
+// 返回**全部已注册键**（不只是有覆盖行的），因为这份响应同时是 owner UI 的
+// 「可配置项目录」——服务端注册一个新键，客户端不发版就能看到它。客户端遇到不认识
+// 的 key 应跳过，不阻塞渲染。展示文案由客户端按 key 自持，服务端只给结构。
+func (rb *Robot) listBotSettings(c *wkhttp.Context) {
+	loginUID := c.GetLoginUID()
+	robotID := c.Param("robot_id")
+
+	if rb.assertRobotOwner(c, robotID, loginUID) {
+		return
+	}
+
+	resolutions, err := resolveBotSettings(rb.ctx, rb.systemSettings, robotID)
+	if err != nil {
+		rb.Error("查询 bot_setting 失败", zap.Error(err), zap.String("robot_id", robotID))
+		httperr.ResponseErrorL(c, errcode.ErrRobotQueryFailed, nil, nil)
+		return
+	}
+	c.Response(map[string]interface{}{"list": resolutions})
+}
+
+// botSettingUpdateReq 是批量写入体。批量而非单键，是为了让「同时关展示卡和交互卡」
+// 这类操作只产生一次事件推送。
+type botSettingUpdateReq struct {
+	Items []struct {
+		Key   string `json:"key"`
+		Value string `json:"value"`
+	} `json:"items"`
+}
+
+// updateBotSettings 处理 PUT /v1/robot/:robot_id/settings。
+//
+// 全量先校验、再统一写：一条 item 非法就整批拒绝，绝不半应用——否则 owner 在 UI 上
+// 一次改三项、失败后看到的是三项里随机两项生效的中间态。
+func (rb *Robot) updateBotSettings(c *wkhttp.Context) {
+	loginUID := c.GetLoginUID()
+	robotID := c.Param("robot_id")
+
+	var req botSettingUpdateReq
+	if err := c.BindJSON(&req); err != nil {
+		respondRobotRequestInvalid(c, "")
+		return
+	}
+	if len(req.Items) == 0 {
+		respondRobotRequestInvalid(c, "items")
+		return
+	}
+
+	type plan struct{ key, value string }
+	plans := make([]plan, 0, len(req.Items))
+	seen := make(map[string]struct{}, len(req.Items))
+	for _, item := range req.Items {
+		def := findBotSettingDef(item.Key)
+		if def == nil {
+			// 未注册键：拒绝，不得长出野键（同 system_setting 的 schema 白名单契约）。
+			respondRobotRequestInvalid(c, "key")
+			return
+		}
+		if !def.Editable {
+			// 派生只读键（card_enabled）：写入必须失败，否则库里会出现与 env
+			// 相矛盾的值，profile 与发卡门禁随之背离。
+			respondRobotRequestInvalid(c, "key")
+			return
+		}
+		if _, dup := seen[item.Key]; dup {
+			respondRobotRequestInvalid(c, "key")
+			return
+		}
+		seen[item.Key] = struct{}{}
+
+		normalized, ok := normalizeBotSettingBool(item.Value)
+		if !ok {
+			respondRobotRequestInvalid(c, "value")
+			return
+		}
+		plans = append(plans, plan{key: item.Key, value: normalized})
+	}
+
+	// 属主校验放在形状校验之后、写库之前：形状错误无需查库即可拒，而任何写入都
+	// 必须先过属主门。
+	if rb.assertRobotOwner(c, robotID, loginUID) {
+		return
+	}
+
+	for _, p := range plans {
+		// dbr 的 InsertStmt 不暴露 Suffix，用 InsertBySql + ON DUPLICATE KEY UPDATE
+		// 完成 upsert（同 setMentionPref）。updated_at 走列默认自动更新。
+		_, err := rb.ctx.DB().InsertBySql(
+			"INSERT INTO bot_setting (robot_id, key_name, value, updated_by) "+
+				"VALUES (?, ?, ?, ?) "+
+				"ON DUPLICATE KEY UPDATE value=VALUES(value), updated_by=VALUES(updated_by)",
+			robotID, p.key, p.value, loginUID,
+		).Exec()
+		if err != nil {
+			rb.Error("写入 bot_setting 失败", zap.Error(err),
+				zap.String("robot_id", robotID), zap.String("key", p.key))
+			httperr.ResponseErrorL(c, errcode.ErrRobotStoreFailed, nil, nil)
+			return
+		}
+	}
+
+	rb.notifyBotSettingChanged(robotID)
+	c.ResponseOK()
+}
+
+// deleteBotSetting 处理 DELETE /v1/robot/:robot_id/settings/:key。
+// 删除覆盖 == 回落上一层（全局默认 → 代码默认），**不是**设为 false。
+// 幂等：删不存在的覆盖也返回 200（同 deleteMentionPref）。
+func (rb *Robot) deleteBotSetting(c *wkhttp.Context) {
+	loginUID := c.GetLoginUID()
+	robotID := c.Param("robot_id")
+	key := c.Param("key")
+
+	def := findBotSettingDef(key)
+	if def == nil || !def.Editable {
+		respondRobotRequestInvalid(c, "key")
+		return
+	}
+
+	if rb.assertRobotOwner(c, robotID, loginUID) {
+		return
+	}
+
+	_, err := rb.ctx.DB().DeleteFrom("bot_setting").
+		Where("robot_id=? AND key_name=?", robotID, key).Exec()
+	if err != nil {
+		rb.Error("删除 bot_setting 失败", zap.Error(err),
+			zap.String("robot_id", robotID), zap.String("key", key))
+		httperr.ResponseErrorL(c, errcode.ErrRobotStoreFailed, nil, nil)
+		return
+	}
+
+	rb.notifyBotSettingChanged(robotID)
+	c.ResponseOK()
+}
+
+// botSettingChangedEventType 是配置变更事件的 event_type。
+const botSettingChangedEventType = "bot_setting_updated"
+
+// notifyBotSettingChanged 在配置变更后给该 Bot 推一条事件，让 adapter 即时重拉
+// /v1/bot/card/profile，消除「改了开关要等插件缓存 TTL」的窗口。
+//
+// 用 EnqueueBotTypedEvent 而非 mention_pref 那条**群频道消息**路径：免@偏好本身是
+// 群维度的，adapter 需要知道是哪个群，走群频道自然；Bot 级配置没有频道上下文，硬造
+// 一个频道既不自然、又要求 Bot 是该频道成员（不成立时事件会静默丢失，退化成 TTL）。
+// 类型化事件走同一个 GenSeq / ZAdd 收口，不需要伪造消息载荷。
+//
+// best-effort：异步 + recover，投递失败只记日志。写接口已经成功返回，事件只是加速
+// 生效；插件侧的缓存 TTL 是兜底。
+func (rb *Robot) notifyBotSettingChanged(robotID string) {
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				rb.Error("notifyBotSettingChanged panic", zap.Any("recover", r))
+			}
+		}()
+		if _, err := rb.EnqueueBotTypedEvent(
+			robotID, botSettingChangedEventType, buildBotSettingChangedEventData(),
+		); err != nil {
+			rb.Error("投递 bot_setting_updated 事件失败", zap.Error(err),
+				zap.String("robot_id", robotID))
+		}
+	}()
+}
+
+// buildBotSettingChangedEventData 构造配置变更事件的 event_data。
+//
+// 刻意**不携带具体新值**：事件只是「你的配置变了，去重拉」的信号。带值就意味着两条
+// 下发路径（事件 与 profile 接口）各自维护同一份语义，一旦漂移，adapter 会拿事件里
+// 的旧形状去覆盖 profile 的权威结果。scope 字段留给未来区分变更域（卡片 / 其它），
+// 让 adapter 能只重拉相关面而不是全量。
+func buildBotSettingChangedEventData() map[string]interface{} {
+	return map[string]interface{}{"scope": "bot_setting"}
+}

--- a/modules/robot/bot_setting.go
+++ b/modules/robot/bot_setting.go
@@ -274,6 +274,11 @@ func rejectRobotCardBySetting(payload map[string]interface{}) bool {
 // 对称」要求的。未知 profile 一律拒（cardmsg.Validate 已经把 profile 钉在接受集内，
 // 走到这里说明形状校验被绕过）。
 //
+// 「三个入口」是**本任务的口径，不是已证实的全仓完备性**：streamStart（本文件同模块，
+// api.go:482）把 payload 原样转给 WuKongIM，不走任何形状校验与本门。它与 merge-base
+// 逐字节相同、本任务未触碰，但在它被 triage 之前，别把这句读成「枚举已闭合」。
+// 详见 .octospec/journal/shared/bot-setting-store.md 的 known-gaps。
+//
 // 本 ingress 不接受 Registry 模板（template_ref 只在 bot_api 实现），故无需 reasoning
 // 判定；模板 ref 出现在这里会先被 cardmsg.Validate 按未知字段/形状拒掉。
 func robotCardPolicyAllows(payload map[string]interface{}, cfg BotCardConfig) bool {

--- a/modules/robot/bot_setting.go
+++ b/modules/robot/bot_setting.go
@@ -21,6 +21,7 @@ package robot
 import (
 	"encoding/json"
 	"errors"
+	"sort"
 	"strings"
 
 	"github.com/Mininglamp-OSS/octo-lib/config"
@@ -230,6 +231,48 @@ type BotCardConfig struct {
 	ReasoningEnabled   bool
 }
 
+// AllowsRawDisplayCard / AllowsRawInteractiveCard 是 raw 卡两个档位的**唯一判定**。
+// 发送门、编辑门与 /v1/bot/card/profile 的清单都必须经它们，绝不各自组合布尔 ——
+// round-2 评审逮到的正是这个：门改成了「v2 要 display AND interaction」，清单却仍
+// 直接回显 InteractionEnabled，于是出现 profile 报 interaction_enabled:true、发卡却
+// 被拒的自相矛盾，恰好是该端点存在的意义（免去「发一条卡看是否 400」）的反面。
+//
+// display 是**下限**而非并列档：octo/v2 是 octo/v1 的严格超集（cardmsg.validateCard
+// 里的 interactive 只放宽校验、从不要求必须有交互元素），所以一张 v2 卡首先是展示卡，
+// 只是额外带了交互面。若两者并列，关掉 display 就能被「改一个 profile 字符串」绕过。
+func (c BotCardConfig) AllowsRawDisplayCard() bool { return c.DisplayEnabled }
+
+func (c BotCardConfig) AllowsRawInteractiveCard() bool {
+	return c.DisplayEnabled && c.InteractionEnabled
+}
+
+// rejectRobotCardBySetting 报告一个 legacy robot ingress 的 payload 是否需要经过
+// per-Bot 卡片策略判定（即它是不是一张卡）。非卡片消息完全不查配置，零开销。
+func rejectRobotCardBySetting(payload map[string]interface{}) bool {
+	return cardmsg.IsCardPayload(payload)
+}
+
+// robotCardPolicyAllows 判定一张 legacy ingress 的 raw 卡是否被该 Bot 的配置放行。
+//
+// 与 bot_api 的 raw 门共用 AllowsRawDisplayCard / AllowsRawInteractiveCard，所以两条
+// ingress 不可能对同一张卡给出不同结论 —— 这正是 payloadIsVail 注释里那句「三个入口
+// 对称」要求的。未知 profile 一律拒（cardmsg.Validate 已经把 profile 钉在接受集内，
+// 走到这里说明形状校验被绕过）。
+//
+// 本 ingress 不接受 Registry 模板（template_ref 只在 bot_api 实现），故无需 reasoning
+// 判定；模板 ref 出现在这里会先被 cardmsg.Validate 按未知字段/形状拒掉。
+func robotCardPolicyAllows(payload map[string]interface{}, cfg BotCardConfig) bool {
+	profile, _ := payload["profile"].(string)
+	switch profile {
+	case cardmsg.ProfileV1:
+		return cfg.AllowsRawDisplayCard()
+	case cardmsg.ProfileV2:
+		return cfg.AllowsRawInteractiveCard()
+	default:
+		return false
+	}
+}
+
 // applyCardMasterSwitch 把总闸支配关系落到实处：总闸为假时三个子开关的有效值恒为假。
 // 单独抽出来是因为它是 brief 的 load-bearing 不变量，需要被单测直接钉住。
 func applyCardMasterSwitch(cfg BotCardConfig) BotCardConfig {
@@ -350,6 +393,9 @@ func (rb *Robot) listBotSettings(c *wkhttp.Context) {
 	c.Response(map[string]interface{}{"list": resolutions})
 }
 
+// botSettingWritePlan 是一条已校验、已归一化的待写项。
+type botSettingWritePlan struct{ key, value string }
+
 // botSettingUpdateReq 是批量写入体。批量而非单键，是为了让「同时关展示卡和交互卡」
 // 这类操作只产生一次事件推送。
 //
@@ -382,8 +428,7 @@ func (rb *Robot) updateBotSettings(c *wkhttp.Context) {
 		return
 	}
 
-	type plan struct{ key, value string }
-	plans := make([]plan, 0, len(req.Items))
+	plans := make([]botSettingWritePlan, 0, len(req.Items))
 	seen := make(map[string]struct{}, len(req.Items))
 	for _, item := range req.Items {
 		def := findBotSettingDef(item.Key)
@@ -409,8 +454,14 @@ func (rb *Robot) updateBotSettings(c *wkhttp.Context) {
 			respondRobotRequestInvalid(c, "value")
 			return
 		}
-		plans = append(plans, plan{key: item.Key, value: normalized})
+		plans = append(plans, botSettingWritePlan{key: item.Key, value: normalized})
 	}
+
+	// 按 key 排序后再写：升级成单事务后，行锁要持有到 commit，两个并发批次若以相反
+	// 顺序提交同样两个键（[display, interaction] vs [interaction, display]）就能互等成
+	// 死锁（MySQL 1213）。逐条自动提交时锁立即释放、窗口可忽略，事务化之后不再是。
+	// 统一锁序是本仓既有做法（见 send.go 的 "#627 D4 uniform lock order"）。
+	sort.Slice(plans, func(i, j int) bool { return plans[i].key < plans[j].key })
 
 	// 属主校验放在形状校验之后、写库之前：形状错误无需查库即可拒，而任何写入都
 	// 必须先过属主门。
@@ -422,11 +473,33 @@ func (rb *Robot) updateBotSettings(c *wkhttp.Context) {
 	// 调用方收到 500 以为什么都没生效，实际前面几项已经落库；更糟的是错误路径会跳过
 	// notifyBotSettingChanged，adapter 继续用旧缓存直到自己的 TTL 到期——正是该事件
 	// 要消灭的那个窗口。事务失败即整批回滚，"绝不半应用"才真正成立。
-	tx, err := rb.ctx.DB().Begin()
-	if err != nil {
-		rb.Error("开启 bot_setting 事务失败", zap.Error(err), zap.String("robot_id", robotID))
+	if err := writeBotSettingOverrides(rb.ctx, robotID, loginUID, plans); err != nil {
+		rb.Error("写入 bot_setting 失败", zap.Error(err), zap.String("robot_id", robotID))
 		httperr.ResponseErrorL(c, errcode.ErrRobotStoreFailed, nil, nil)
 		return
+	}
+
+	// 事件只在提交成功之后推：提交失败时没有任何变更生效，推事件会让 adapter 白白
+	// 重拉一次并读到与它已有缓存相同的值。
+	rb.notifyBotSettingChanged(robotID)
+	c.ResponseOK()
+}
+
+// writeBotSettingOverrides 在单事务里 upsert 整批覆盖。
+//
+// 抽成函数不只是为了短：它让「事务中途失败 → 整批回滚」能被直接测到。经 HTTP 走的
+// 话，唯一可达的失败是校验失败，而校验在 Begin() 之前就返回了——那条路径对修复前后
+// 的代码表现完全相同，测不出事务本身。
+//
+// 调用方负责：先校验、先排序（统一锁序）、先过属主门；提交成功后才推变更事件。
+func writeBotSettingOverrides(
+	ctx *config.Context,
+	robotID, updatedBy string,
+	plans []botSettingWritePlan,
+) error {
+	tx, err := ctx.DB().Begin()
+	if err != nil {
+		return err
 	}
 	defer tx.RollbackUnlessCommitted()
 
@@ -437,25 +510,12 @@ func (rb *Robot) updateBotSettings(c *wkhttp.Context) {
 			"INSERT INTO bot_setting (robot_id, key_name, value, updated_by) "+
 				"VALUES (?, ?, ?, ?) "+
 				"ON DUPLICATE KEY UPDATE value=VALUES(value), updated_by=VALUES(updated_by)",
-			robotID, p.key, p.value, loginUID,
+			robotID, p.key, p.value, updatedBy,
 		).Exec(); err != nil {
-			rb.Error("写入 bot_setting 失败", zap.Error(err),
-				zap.String("robot_id", robotID), zap.String("key", p.key))
-			httperr.ResponseErrorL(c, errcode.ErrRobotStoreFailed, nil, nil)
-			return
+			return err
 		}
 	}
-
-	if err := tx.Commit(); err != nil {
-		rb.Error("提交 bot_setting 事务失败", zap.Error(err), zap.String("robot_id", robotID))
-		httperr.ResponseErrorL(c, errcode.ErrRobotStoreFailed, nil, nil)
-		return
-	}
-
-	// 事件只在提交成功之后推：提交失败时没有任何变更生效，推事件会让 adapter 白白
-	// 重拉一次并读到与它已有缓存相同的值。
-	rb.notifyBotSettingChanged(robotID)
-	c.ResponseOK()
+	return tx.Commit()
 }
 
 // deleteBotSetting 处理 DELETE /v1/robot/:robot_id/settings/:key。

--- a/modules/robot/bot_setting.go
+++ b/modules/robot/bot_setting.go
@@ -61,7 +61,11 @@ const (
 //     能发、发出去被 card_disabled 拒，正好违反 pkg/cardmsg 已确立的「清单与发卡
 //     门禁同源」不变量。
 //   - display/interaction 只作用于 **raw 卡路径**（Bot 自拼 card JSON）；
-//     reasoning 只作用于 **Registry 模板卡**。三者正交。
+//     reasoning 只作用于 **Registry 模板卡**。**raw 这一组与 reasoning 正交，但
+//     display 与 interaction 之间不正交**：display 是 raw 档内的下限，octo/v1 要
+//     display，octo/v2 要 display AND interaction。把三者一律说成「正交」是 round-1
+//     评审推翻过的说法，照着它改会重开旁路——判定一律走 AllowsRawDisplayCard /
+//     AllowsRawInteractiveCard，理由见那两个方法上的注释。
 //     绝不可实现成「按 wire profile 一刀切」：推理卡自身横跨两档
 //     （active/error 是 octo/v2、result 是 octo/v1），按 profile 切会把它砍成只剩
 //     终态或只剩过程。
@@ -297,6 +301,13 @@ func queryBotSettingOverrides(ctx *config.Context, robotID string) (map[string]s
 	}
 	out := make(map[string]string, len(rows))
 	for _, r := range rows {
+		// 空值 == 未配置，是本表 DDL 自己写下的定义（见 sql/20260806000001_bot_setting.sql）。
+		// 在这里就丢掉，而不是留给 parseBotSettingBool 落进 default 分支——否则一行空值
+		// 会被当成脏值告警「覆盖值非法」，与迁移里的定义自相矛盾。回落行为两种写法一致，
+		// 差别只在日志说了真话还是假话。与 system_settings.lookup 把 "" 视作未命中同义。
+		if r.Value == "" {
+			continue
+		}
 		out[r.KeyName] = r.Value
 	}
 	return out, nil

--- a/modules/robot/bot_setting.go
+++ b/modules/robot/bot_setting.go
@@ -315,6 +315,10 @@ func (rb *Robot) listBotSettings(c *wkhttp.Context) {
 		httperr.ResponseErrorL(c, errcode.ErrRobotQueryFailed, nil, nil)
 		return
 	}
+	// 该响应是某个 Bot 的私有配置，且只有登录态区分调用者。与
+	// /v1/bot/card/profile 同口径：private 禁共享代理缓存，no-store 不留副本
+	// —— 改完配置立刻重读要看到新值。
+	c.Header("Cache-Control", "private, no-store")
 	c.Response(map[string]interface{}{"list": resolutions})
 }
 

--- a/modules/robot/bot_setting.go
+++ b/modules/robot/bot_setting.go
@@ -135,11 +135,19 @@ func findBotSettingDef(key string) *botSettingDef {
 // normalizeBotSettingBool 把入站 bool 字面量归一化成 "1"/"0"。第二个返回值为 false
 // 表示非法值，调用方必须 400 —— 不接受「猜一个默认」，否则 owner 以为设成了 A，
 // 实际存的是 B。
+//
+// 这是本 feature bool 字面量的**唯一词法**：trim + 折叠大小写，词表 {1,0,true,false}。
+// 写侧（本函数）、读侧（parseBotSettingBool）、以及下一层 system_setting 的
+// SettingBoolOK 三处必须完全一致——它们串在同一条解析链上，任一处的口径不同，都会
+// 出现「这个字面量在这层算数、在那层不算数」。评审逮到过两次同型问题：一次是
+// SettingBoolOK 放宽后管理台 getter 没跟上，一次就是本函数与 parseBotSettingBool
+// 各写各的（后者当时既不 trim 也不认 True）。所以这里不再逐个列举大小写变体，
+// 而是折叠——列举法正是上次分叉的成因：少列一个变体不会报错，只会静默不生效。
 func normalizeBotSettingBool(raw string) (string, bool) {
-	switch strings.TrimSpace(raw) {
-	case "1", "true", "TRUE", "True":
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "1", "true":
 		return botSettingTrue, true
-	case "0", "false", "FALSE", "False":
+	case "0", "false":
 		return botSettingFalse, true
 	default:
 		return "", false
@@ -174,15 +182,17 @@ func normalizeBotSettingValue(raw json.RawMessage) (string, bool) {
 
 // parseBotSettingBool 解析库里的 bool 值。非法值（人工改库等）视为未配置，
 // 让解析器落到下一层，而不是把脏值当 false 生效。
+//
+// **委托给写侧的 normalizeBotSettingBool，不另写一份 switch**：读侧接受的集合从此
+// 恒等于写侧接受的集合。此前两处各写各的，写侧 trim 且认 True、读侧两样都不认，于是
+// 手工写入 value='True' 会被读成「覆盖值非法、已忽略」，而同一个字面量走写接口是被
+// 接受的——同一列两套词法。委托是唯一能让这种漂移在语法上无法发生的写法。
 func parseBotSettingBool(raw string) (value bool, ok bool) {
-	switch raw {
-	case botSettingTrue, "true", "TRUE":
-		return true, true
-	case botSettingFalse, "false", "FALSE":
-		return false, true
-	default:
+	normalized, ok := normalizeBotSettingBool(raw)
+	if !ok {
 		return false, false
 	}
+	return normalized == botSettingTrue, true
 }
 
 // botSettingResolution 是单个键的解析结果，同时是 owner 读接口的一行。

--- a/modules/robot/bot_setting.go
+++ b/modules/robot/bot_setting.go
@@ -319,6 +319,7 @@ func (rb *Robot) listBotSettings(c *wkhttp.Context) {
 	// /v1/bot/card/profile 同口径：private 禁共享代理缓存，no-store 不留副本
 	// —— 改完配置立刻重读要看到新值。
 	c.Header("Cache-Control", "private, no-store")
+	c.Header("Vary", "Authorization")
 	c.Response(map[string]interface{}{"list": resolutions})
 }
 

--- a/modules/robot/bot_setting_ingress_test.go
+++ b/modules/robot/bot_setting_ingress_test.go
@@ -1,0 +1,102 @@
+package robot
+
+// task bot-setting-store round-2 P1-1 —— legacy robot ingress 的 per-Bot 卡片门。
+//
+// 这条 ingress 与 bot_api 的 send gate 共用同一个 Bot 身份（authRobot 按
+// robot.robot_id 解析，bot_setting.robot_id 是同一列），payloadIsVail 的注释也
+// 明确写着「三个卡片生产者入口对称」。bot_setting 首版只给 bot_api 那道门加了
+// per-Bot 判定，于是 owner 关掉能力后换这条路仍能发卡。
+
+import (
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardmsg"
+)
+
+func cardPayloadWithProfile(profile string) map[string]interface{} {
+	return map[string]interface{}{
+		"type":         cardmsg.InteractiveCard.Int(),
+		"profile":      profile,
+		"card_version": cardmsg.CardVersion,
+		"card": map[string]interface{}{
+			"type": "AdaptiveCard", "version": cardmsg.CardVersion,
+			"body": []interface{}{
+				map[string]interface{}{"type": "TextBlock", "text": "legacy ingress"},
+			},
+		},
+	}
+}
+
+// TestRejectRobotCardBySetting_OnlyCardsConsultTheConfig keeps the cost claim
+// honest: an ordinary robot message must not trigger a config read.
+func TestRejectRobotCardBySetting_OnlyCardsConsultTheConfig(t *testing.T) {
+	if rejectRobotCardBySetting(map[string]interface{}{"type": 1, "content": "hi"}) {
+		t.Error("a plain text payload asked for a card policy decision")
+	}
+	if !rejectRobotCardBySetting(cardPayloadWithProfile(cardmsg.ProfileV1)) {
+		t.Error("a type-17 payload did not ask for a card policy decision")
+	}
+}
+
+// TestRobotCardPolicyAllows_MatchesBotAPIGate pins that the legacy ingress
+// reaches the same verdict as the bot_api gate for the same card and the same
+// config — the symmetry payloadIsVail's own comment requires. Both call
+// AllowsRawDisplayCard / AllowsRawInteractiveCard, so a divergence here would
+// mean somebody re-derived the booleans locally.
+func TestRobotCardPolicyAllows_MatchesBotAPIGate(t *testing.T) {
+	cases := []struct {
+		name    string
+		profile string
+		cfg     BotCardConfig
+		want    bool
+	}{
+		{
+			name: "display off refuses octo/v1", profile: cardmsg.ProfileV1,
+			cfg:  BotCardConfig{CardEnabled: true, InteractionEnabled: true},
+			want: false,
+		},
+		{
+			name: "display off refuses octo/v2 too (display is a floor)", profile: cardmsg.ProfileV2,
+			cfg:  BotCardConfig{CardEnabled: true, InteractionEnabled: true},
+			want: false,
+		},
+		{
+			name: "interaction off refuses octo/v2", profile: cardmsg.ProfileV2,
+			cfg:  BotCardConfig{CardEnabled: true, DisplayEnabled: true},
+			want: false,
+		},
+		{
+			name: "interaction off still allows octo/v1", profile: cardmsg.ProfileV1,
+			cfg:  BotCardConfig{CardEnabled: true, DisplayEnabled: true},
+			want: true,
+		},
+		{
+			name: "everything on allows octo/v2", profile: cardmsg.ProfileV2,
+			cfg: BotCardConfig{
+				CardEnabled: true, DisplayEnabled: true, InteractionEnabled: true,
+			},
+			want: true,
+		},
+		{
+			name: "master switch off refuses everything", profile: cardmsg.ProfileV1,
+			// What applyCardMasterSwitch produces when the deployment gate is off.
+			cfg:  BotCardConfig{},
+			want: false,
+		},
+		{
+			name: "an unknown profile fails closed", profile: "octo/v9",
+			cfg: BotCardConfig{
+				CardEnabled: true, DisplayEnabled: true, InteractionEnabled: true,
+			},
+			want: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := robotCardPolicyAllows(cardPayloadWithProfile(tc.profile), tc.cfg)
+			if got != tc.want {
+				t.Fatalf("allow=%v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/modules/robot/bot_setting_integration_test.go
+++ b/modules/robot/bot_setting_integration_test.go
@@ -397,8 +397,23 @@ func TestBotSettings_BatchValidationRejectsAtomically(t *testing.T) {
 // It calls the writer directly rather than going through HTTP because the
 // registry whitelist makes an over-long key unreachable from the endpoint — which
 // is the point: the only failure the HTTP path can produce trips before Begin().
+//
+// The provocation is sql_mode-dependent, so the mode is asserted rather than
+// assumed (round-3 review P2-5): without STRICT_*_TABLES MySQL truncates the
+// over-long key to 128 chars and the INSERT succeeds, so there is no mid-batch
+// error left to roll back and the test would report a rollback failure that is
+// really a DB-config difference. MySQL 8 is strict by default and CI runs the
+// default, so this skips only on a deliberately loosened local server — and says
+// what coverage that costs rather than passing quietly.
 func TestWriteBotSettingOverrides_RollsBackOnMidBatchFailure(t *testing.T) {
 	_, ctx := setupBotSettings(t)
+
+	var sqlMode string
+	assert.NoError(t, ctx.DB().SelectBySql("SELECT @@SESSION.sql_mode").LoadOne(&sqlMode))
+	if !strings.Contains(sqlMode, "STRICT_TRANS_TABLES") && !strings.Contains(sqlMode, "STRICT_ALL_TABLES") {
+		t.Skipf("rollback coverage skipped: sql_mode=%q is not strict, so an over-long "+
+			"key_name truncates instead of erroring and cannot provoke a mid-batch failure", sqlMode)
+	}
 
 	overlong := strings.Repeat("k", 200) // key_name is VARCHAR(128)
 	err := writeBotSettingOverrides(ctx, settingsRobotID, testutil.UID, []botSettingWritePlan{

--- a/modules/robot/bot_setting_integration_test.go
+++ b/modules/robot/bot_setting_integration_test.go
@@ -436,3 +436,34 @@ func TestWriteBotSettingOverrides_RollsBackOnMidBatchFailure(t *testing.T) {
 	assert.NoError(t, queryErr)
 	assert.Len(t, overrides, 2)
 }
+
+// TestQueryBotSettingOverrides_EmptyValueIsNotConfigured —— 空值即未配置，且**不是**脏值。
+//
+// 迁移里 `value` 的 DEFAULT ” 就是「未配置」的定义（sql/20260806000001_bot_setting.sql）。
+// 上一轮加脏值告警时没照顾到这条：空串落进 parseBotSettingBool 的 default 分支，于是一行
+// 合法的「未配置」会被喊成「覆盖值非法」，和迁移自己的定义打架。回落行为两种写法一致，
+// 差别只在日志说的是真话还是假话——而这条告警存在的全部意义就是让运维看见真相。
+//
+// 写入路径永远不会存 ”（normalizeBotSettingValue 只产出 "0"/"1"），所以直接插库构造。
+func TestQueryBotSettingOverrides_EmptyValueIsNotConfigured(t *testing.T) {
+	handler, ctx := setupBotSettings(t)
+
+	_, err := ctx.DB().InsertBySql(
+		"INSERT INTO bot_setting (robot_id, key_name, value) VALUES (?, ?, '')",
+		settingsRobotID, BotSettingKeyDisplayEnabled,
+	).Exec()
+	assert.NoError(t, err)
+
+	overrides, err := queryBotSettingOverrides(ctx, settingsRobotID)
+	assert.NoError(t, err)
+	assert.NotContains(t, overrides, BotSettingKeyDisplayEnabled,
+		"空值行被当成了覆盖，会走脏值告警路径并与迁移里 '' == 未配置 的定义矛盾")
+
+	// 回落行为不变：读接口仍报「跟随默认」，而不是「显式关闭」。
+	var resp settingsListResp
+	assert.NoError(t, json.Unmarshal(getSettings(t, handler, settingsRobotID).Body.Bytes(), &resp))
+	item := findSetting(t, resp, BotSettingKeyDisplayEnabled)
+	assert.Nil(t, item.Value, "空值必须回显为「未设置」")
+	assert.Equal(t, botSettingSourceDefault, item.Source)
+	assert.True(t, item.Effective)
+}

--- a/modules/robot/bot_setting_integration_test.go
+++ b/modules/robot/bot_setting_integration_test.go
@@ -97,7 +97,7 @@ func getSettings(t *testing.T, handler http.Handler, robotID string) *httptest.R
 	return w
 }
 
-func putSettings(t *testing.T, handler http.Handler, robotID string, items ...map[string]string) *httptest.ResponseRecorder {
+func putSettings(t *testing.T, handler http.Handler, robotID string, items ...map[string]any) *httptest.ResponseRecorder {
 	t.Helper()
 	body, err := json.Marshal(map[string]interface{}{"items": items})
 	assert.NoError(t, err)
@@ -179,7 +179,7 @@ func TestBotSettings_OverrideThenDeleteFallsBack(t *testing.T) {
 	handler, _ := setupBotSettings(t)
 
 	w := putSettings(t, handler, settingsRobotID,
-		map[string]string{"key": BotSettingKeyReasoningEnabled, "value": "false"})
+		map[string]any{"key": BotSettingKeyReasoningEnabled, "value": "false"})
 	assert.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
 
 	var resp settingsListResp
@@ -230,7 +230,7 @@ func TestBotSettings_GlobalDefaultLayer(t *testing.T) {
 
 	// A per-bot override outranks the global default even when it disagrees.
 	w := putSettings(t, handler, settingsRobotID,
-		map[string]string{"key": BotSettingKeyReasoningEnabled, "value": "true"})
+		map[string]any{"key": BotSettingKeyReasoningEnabled, "value": "true"})
 	assert.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
 
 	assert.NoError(t, json.Unmarshal(getSettings(t, handler, settingsRobotID).Body.Bytes(), &resp))
@@ -247,12 +247,14 @@ func TestBotSettings_WriteRejections(t *testing.T) {
 
 	cases := []struct {
 		name string
-		item map[string]string
+		item map[string]any
 	}{
-		{"unregistered key", map[string]string{"key": "bot.not_a_real_key", "value": "true"}},
-		{"derived key is read-only", map[string]string{"key": BotSettingKeyCardEnabled, "value": "true"}},
-		{"illegal bool literal", map[string]string{"key": BotSettingKeyDisplayEnabled, "value": "maybe"}},
-		{"empty value", map[string]string{"key": BotSettingKeyDisplayEnabled, "value": ""}},
+		{"unregistered key", map[string]any{"key": "bot.not_a_real_key", "value": "true"}},
+		{"derived key is read-only", map[string]any{"key": BotSettingKeyCardEnabled, "value": "true"}},
+		{"illegal bool literal", map[string]any{"key": BotSettingKeyDisplayEnabled, "value": "maybe"}},
+		{"empty value", map[string]any{"key": BotSettingKeyDisplayEnabled, "value": ""}},
+		{"null value", map[string]any{"key": BotSettingKeyDisplayEnabled, "value": nil}},
+		{"non-bool JSON", map[string]any{"key": BotSettingKeyDisplayEnabled, "value": 1}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -263,8 +265,8 @@ func TestBotSettings_WriteRejections(t *testing.T) {
 
 	// A batch containing one bad item must not half-apply the good ones.
 	w := putSettings(t, handler, settingsRobotID,
-		map[string]string{"key": BotSettingKeyDisplayEnabled, "value": "false"},
-		map[string]string{"key": "bot.not_a_real_key", "value": "true"})
+		map[string]any{"key": BotSettingKeyDisplayEnabled, "value": "false"},
+		map[string]any{"key": "bot.not_a_real_key", "value": "true"})
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 
 	var resp settingsListResp
@@ -285,7 +287,7 @@ func TestBotSettings_OwnershipGuard(t *testing.T) {
 	})
 	t.Run("write someone else's bot is forbidden", func(t *testing.T) {
 		w := putSettings(t, handler, settingsOtherRobotID,
-			map[string]string{"key": BotSettingKeyReasoningEnabled, "value": "false"})
+			map[string]any{"key": BotSettingKeyReasoningEnabled, "value": "false"})
 		assert.Equal(t, http.StatusForbidden, w.Code, "body=%s", w.Body.String())
 	})
 	t.Run("delete on someone else's bot is forbidden", func(t *testing.T) {
@@ -296,4 +298,71 @@ func TestBotSettings_OwnershipGuard(t *testing.T) {
 		w := getSettings(t, handler, "bot_does_not_exist")
 		assert.Equal(t, http.StatusNotFound, w.Code, "body=%s", w.Body.String())
 	})
+}
+
+// TestBotSettings_CatalogValueRoundTrips pins that what the read endpoint emits
+// can be written straight back.
+//
+// The catalog serves `value` as a JSON bool, and the obvious client flow is
+// "read the catalog, flip one entry, PUT the item back". If the write side only
+// accepted strings that round trip would 400 at BindJSON and every caller would
+// have to know to stringify — so the write side accepts both shapes.
+func TestBotSettings_CatalogValueRoundTrips(t *testing.T) {
+	handler, _ := setupBotSettings(t)
+
+	// Write with a real JSON bool, exactly as the read endpoint emits it.
+	w := putSettings(t, handler, settingsRobotID,
+		map[string]any{"key": BotSettingKeyDisplayEnabled, "value": false})
+	assert.Equal(t, http.StatusOK, w.Code, "a JSON bool must be accepted; body=%s", w.Body.String())
+
+	var resp settingsListResp
+	assert.NoError(t, json.Unmarshal(getSettings(t, handler, settingsRobotID).Body.Bytes(), &resp))
+	item := findSetting(t, resp, BotSettingKeyDisplayEnabled)
+	assert.NotNil(t, item.Value)
+	assert.False(t, *item.Value)
+	assert.Equal(t, botSettingSourceBot, item.Source)
+
+	// Feed the echoed value straight back — the round trip a UI performs.
+	w = putSettings(t, handler, settingsRobotID,
+		map[string]any{"key": item.Key, "value": *item.Value})
+	assert.Equal(t, http.StatusOK, w.Code, "echoed value must round trip; body=%s", w.Body.String())
+}
+
+// TestBotSettings_BatchWriteIsAtomic pins the all-or-nothing contract the
+// handler claims. A batch that fails partway must leave nothing behind:
+// otherwise the caller sees a 500 and believes nothing applied, while some
+// switches silently did — and the invalidation event never fires, so adapters
+// keep serving the stale profile.
+//
+// Driven through the validation failure (the only failure reachable without
+// breaking the DB): the invalid item is last, so any non-atomic implementation
+// would already have committed the first one.
+func TestBotSettings_BatchWriteIsAtomic(t *testing.T) {
+	handler, _ := setupBotSettings(t)
+
+	w := putSettings(t, handler, settingsRobotID,
+		map[string]any{"key": BotSettingKeyDisplayEnabled, "value": false},
+		map[string]any{"key": BotSettingKeyInteractionEnabled, "value": false},
+		map[string]any{"key": BotSettingKeyReasoningEnabled, "value": "not-a-bool"})
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+
+	var resp settingsListResp
+	assert.NoError(t, json.Unmarshal(getSettings(t, handler, settingsRobotID).Body.Bytes(), &resp))
+	for _, key := range []string{BotSettingKeyDisplayEnabled, BotSettingKeyInteractionEnabled} {
+		assert.Nil(t, findSetting(t, resp, key).Value,
+			"%s was written despite the batch failing", key)
+	}
+
+	// The same batch with every item valid applies completely.
+	w = putSettings(t, handler, settingsRobotID,
+		map[string]any{"key": BotSettingKeyDisplayEnabled, "value": false},
+		map[string]any{"key": BotSettingKeyInteractionEnabled, "value": false})
+	assert.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+
+	assert.NoError(t, json.Unmarshal(getSettings(t, handler, settingsRobotID).Body.Bytes(), &resp))
+	for _, key := range []string{BotSettingKeyDisplayEnabled, BotSettingKeyInteractionEnabled} {
+		item := findSetting(t, resp, key)
+		assert.NotNil(t, item.Value, "%s must be written when the whole batch is valid", key)
+		assert.False(t, *item.Value)
+	}
 }

--- a/modules/robot/bot_setting_integration_test.go
+++ b/modules/robot/bot_setting_integration_test.go
@@ -1,0 +1,294 @@
+package robot
+
+// task bot-setting-store —— owner 配置端点的集成测试（需要 MySQL + Redis）。
+// 纯函数层的解析优先级在 bot_setting_test.go；这里覆盖端点行为：目录回显、
+// 三层落点、删除即回落、属主守卫、派生键不可写。
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	commonmodule "github.com/Mininglamp-OSS/octo-server/modules/common"
+	"github.com/go-redis/redis"
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	settingsRobotID      = "bot_settings_owner"
+	settingsOtherRobotID = "bot_settings_other"
+)
+
+// resetSettingsUIDRateLimit clears the shared per-UID bucket.
+//
+// The settings routes mount SharedUIDRateLimiter, and that bucket lives in
+// Redis — CleanAllTables does not touch it, so without this a run of several
+// cases in one package would start tripping 429 partway through and the
+// failure would look like an assertion bug.
+func resetSettingsUIDRateLimit(t *testing.T, ctx *config.Context) {
+	t.Helper()
+	client := redis.NewClient(&redis.Options{
+		Addr:     ctx.GetConfig().DB.RedisAddr,
+		Password: ctx.GetConfig().DB.RedisPass,
+	})
+	defer client.Close()
+	keys, err := client.Keys("ratelimit:uid:*").Result()
+	if err == nil && len(keys) > 0 {
+		_ = client.Del(keys...).Err()
+	}
+}
+
+// setupBotSettings wires a bot owned by the test caller plus one owned by
+// somebody else, so the ownership guard has a real negative case.
+func setupBotSettings(t *testing.T) (http.Handler, *config.Context) {
+	t.Helper()
+	s, ctx := testutil.NewTestServer()
+	assert.NoError(t, testutil.CleanAllTables(ctx))
+	resetSettingsUIDRateLimit(t, ctx)
+	// SystemSettings is a process-wide singleton holding an in-memory snapshot
+	// that only refreshes on its own timer. CleanAllTables truncates the
+	// system_setting rows but leaves that snapshot alone, so without this a
+	// case that writes a deployment default leaks it into every later case in
+	// the binary — which surfaces as source="global" where "default" was
+	// expected, and only under -shuffle. Same family as the rate-limit bucket
+	// above: CleanAllTables clears tables, not in-process caches.
+	assert.NoError(t, commonmodule.EnsureSystemSettings(ctx).Reload())
+
+	_, err := ctx.DB().InsertBySql(
+		"INSERT INTO robot (robot_id, status, creator_uid) VALUES (?, 1, ?)",
+		settingsRobotID, testutil.UID,
+	).Exec()
+	assert.NoError(t, err)
+	_, err = ctx.DB().InsertBySql(
+		"INSERT INTO robot (robot_id, status, creator_uid) VALUES (?, 1, ?)",
+		settingsOtherRobotID, "someone_else",
+	).Exec()
+	assert.NoError(t, err)
+	return s.GetRoute(), ctx
+}
+
+// settingsItem mirrors one row of the owner catalog response. Value is a
+// pointer so the test can tell an explicit override apart from "unset" —
+// the same distinction the UI needs to render "restore default".
+type settingsItem struct {
+	Key       string `json:"key"`
+	Type      string `json:"type"`
+	Value     *bool  `json:"value"`
+	Effective bool   `json:"effective_value"`
+	Source    string `json:"source"`
+	Editable  bool   `json:"editable"`
+}
+
+type settingsListResp struct {
+	List []settingsItem `json:"list"`
+}
+
+func getSettings(t *testing.T, handler http.Handler, robotID string) *httptest.ResponseRecorder {
+	t.Helper()
+	w := httptest.NewRecorder()
+	req, err := http.NewRequest("GET", "/v1/robot/"+robotID+"/settings", nil)
+	assert.NoError(t, err)
+	req.Header.Set("token", token)
+	handler.ServeHTTP(w, req)
+	return w
+}
+
+func putSettings(t *testing.T, handler http.Handler, robotID string, items ...map[string]string) *httptest.ResponseRecorder {
+	t.Helper()
+	body, err := json.Marshal(map[string]interface{}{"items": items})
+	assert.NoError(t, err)
+	w := httptest.NewRecorder()
+	req, err := http.NewRequest("PUT", "/v1/robot/"+robotID+"/settings", bytes.NewReader(body))
+	assert.NoError(t, err)
+	req.Header.Set("token", token)
+	req.Header.Set("Content-Type", "application/json")
+	handler.ServeHTTP(w, req)
+	return w
+}
+
+func deleteSetting(t *testing.T, handler http.Handler, robotID, key string) *httptest.ResponseRecorder {
+	t.Helper()
+	w := httptest.NewRecorder()
+	req, err := http.NewRequest("DELETE", "/v1/robot/"+robotID+"/settings/"+key, nil)
+	assert.NoError(t, err)
+	req.Header.Set("token", token)
+	handler.ServeHTTP(w, req)
+	return w
+}
+
+func findSetting(t *testing.T, resp settingsListResp, key string) settingsItem {
+	t.Helper()
+	for _, item := range resp.List {
+		if item.Key == key {
+			return item
+		}
+	}
+	t.Fatalf("key %s missing from the settings catalog", key)
+	return settingsItem{}
+}
+
+// TestBotSettings_CatalogListsEveryRegisteredKey pins that the read endpoint is
+// a catalog, not just the rows that happen to exist: a client renders the Bot
+// management screen from this response, so a key with no override must still
+// appear (with value=null) rather than vanish.
+func TestBotSettings_CatalogListsEveryRegisteredKey(t *testing.T) {
+	handler, _ := setupBotSettings(t)
+
+	w := getSettings(t, handler, settingsRobotID)
+	assert.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+
+	var resp settingsListResp
+	assert.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Len(t, resp.List, len(botSettingDefs))
+
+	for _, key := range []string{
+		BotSettingKeyCardEnabled, BotSettingKeyDisplayEnabled,
+		BotSettingKeyInteractionEnabled, BotSettingKeyReasoningEnabled,
+	} {
+		item := findSetting(t, resp, key)
+		assert.Nil(t, item.Value, "%s has no override yet → value must be null", key)
+		assert.Equal(t, botSettingTypeBool, item.Type)
+	}
+
+	// card_enabled is derived from the deployment env, so it is reported as a
+	// read-only entry the UI can use to grey out the rest.
+	cardEnabled := findSetting(t, resp, BotSettingKeyCardEnabled)
+	assert.False(t, cardEnabled.Editable, "card_enabled must be read-only")
+	assert.Equal(t, botSettingSourceEnv, cardEnabled.Source)
+
+	// The three owner-editable switches start on the code default.
+	reasoning := findSetting(t, resp, BotSettingKeyReasoningEnabled)
+	assert.True(t, reasoning.Editable)
+	assert.Equal(t, botSettingSourceDefault, reasoning.Source)
+	assert.True(t, reasoning.Effective, "code default is true")
+}
+
+// TestBotSettings_OverrideThenDeleteFallsBack walks the full lifecycle the
+// "restore default" control depends on: an override reports source=bot, and
+// deleting it returns to the layer underneath rather than latching false.
+func TestBotSettings_OverrideThenDeleteFallsBack(t *testing.T) {
+	handler, _ := setupBotSettings(t)
+
+	w := putSettings(t, handler, settingsRobotID,
+		map[string]string{"key": BotSettingKeyReasoningEnabled, "value": "false"})
+	assert.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+
+	var resp settingsListResp
+	assert.NoError(t, json.Unmarshal(getSettings(t, handler, settingsRobotID).Body.Bytes(), &resp))
+	item := findSetting(t, resp, BotSettingKeyReasoningEnabled)
+	assert.NotNil(t, item.Value)
+	assert.False(t, *item.Value, "explicit override must be echoed back")
+	assert.False(t, item.Effective)
+	assert.Equal(t, botSettingSourceBot, item.Source)
+
+	// Deleting the override falls back to the layer below (here: code default),
+	// which is a different outcome from "set to false".
+	w = deleteSetting(t, handler, settingsRobotID, BotSettingKeyReasoningEnabled)
+	assert.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+
+	assert.NoError(t, json.Unmarshal(getSettings(t, handler, settingsRobotID).Body.Bytes(), &resp))
+	item = findSetting(t, resp, BotSettingKeyReasoningEnabled)
+	assert.Nil(t, item.Value, "override was deleted → value must be null again")
+	assert.True(t, item.Effective)
+	assert.Equal(t, botSettingSourceDefault, item.Source)
+
+	// Idempotent: deleting an override that no longer exists still succeeds.
+	w = deleteSetting(t, handler, settingsRobotID, BotSettingKeyReasoningEnabled)
+	assert.Equal(t, http.StatusOK, w.Code, "delete must be idempotent")
+}
+
+// TestBotSettings_GlobalDefaultLayer pins the middle tier: with no per-bot row,
+// the deployment default decides, and source says so — the distinction the UI
+// needs to render "following the server default".
+func TestBotSettings_GlobalDefaultLayer(t *testing.T) {
+	handler, ctx := setupBotSettings(t)
+
+	_, err := ctx.DB().InsertBySql(
+		"INSERT INTO system_setting (category, key_name, value, value_type) VALUES (?, ?, ?, 'bool')",
+		"botcard", "reasoning_enabled", "0",
+	).Exec()
+	assert.NoError(t, err)
+	// The snapshot is refreshed on a timer; force it so the test does not wait
+	// out defaultReloadTTL.
+	assert.NoError(t, commonmodule.EnsureSystemSettings(ctx).Reload())
+
+	var resp settingsListResp
+	assert.NoError(t, json.Unmarshal(getSettings(t, handler, settingsRobotID).Body.Bytes(), &resp))
+	item := findSetting(t, resp, BotSettingKeyReasoningEnabled)
+	assert.Nil(t, item.Value, "no per-bot override")
+	assert.False(t, item.Effective, "global default decides")
+	assert.Equal(t, botSettingSourceGlobal, item.Source)
+
+	// A per-bot override outranks the global default even when it disagrees.
+	w := putSettings(t, handler, settingsRobotID,
+		map[string]string{"key": BotSettingKeyReasoningEnabled, "value": "true"})
+	assert.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+
+	assert.NoError(t, json.Unmarshal(getSettings(t, handler, settingsRobotID).Body.Bytes(), &resp))
+	item = findSetting(t, resp, BotSettingKeyReasoningEnabled)
+	assert.True(t, item.Effective, "bot override wins over the global default")
+	assert.Equal(t, botSettingSourceBot, item.Source)
+}
+
+// TestBotSettings_WriteRejections covers every way a write must be refused.
+// The derived-key case is the load-bearing one: accepting it would let the DB
+// claim cards are on while the deployment env has them off.
+func TestBotSettings_WriteRejections(t *testing.T) {
+	handler, _ := setupBotSettings(t)
+
+	cases := []struct {
+		name string
+		item map[string]string
+	}{
+		{"unregistered key", map[string]string{"key": "bot.not_a_real_key", "value": "true"}},
+		{"derived key is read-only", map[string]string{"key": BotSettingKeyCardEnabled, "value": "true"}},
+		{"illegal bool literal", map[string]string{"key": BotSettingKeyDisplayEnabled, "value": "maybe"}},
+		{"empty value", map[string]string{"key": BotSettingKeyDisplayEnabled, "value": ""}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			w := putSettings(t, handler, settingsRobotID, tc.item)
+			assert.Equal(t, http.StatusBadRequest, w.Code, "body=%s", w.Body.String())
+		})
+	}
+
+	// A batch containing one bad item must not half-apply the good ones.
+	w := putSettings(t, handler, settingsRobotID,
+		map[string]string{"key": BotSettingKeyDisplayEnabled, "value": "false"},
+		map[string]string{"key": "bot.not_a_real_key", "value": "true"})
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+
+	var resp settingsListResp
+	assert.NoError(t, json.Unmarshal(getSettings(t, handler, settingsRobotID).Body.Bytes(), &resp))
+	assert.Nil(t, findSetting(t, resp, BotSettingKeyDisplayEnabled).Value,
+		"a rejected batch must not have written its valid items")
+}
+
+// TestBotSettings_OwnershipGuard pins that these endpoints are owner-only, and
+// that an unknown bot is 404 rather than 403 (the latter would confirm the id
+// exists).
+func TestBotSettings_OwnershipGuard(t *testing.T) {
+	handler, _ := setupBotSettings(t)
+
+	t.Run("read someone else's bot is forbidden", func(t *testing.T) {
+		w := getSettings(t, handler, settingsOtherRobotID)
+		assert.Equal(t, http.StatusForbidden, w.Code, "body=%s", w.Body.String())
+	})
+	t.Run("write someone else's bot is forbidden", func(t *testing.T) {
+		w := putSettings(t, handler, settingsOtherRobotID,
+			map[string]string{"key": BotSettingKeyReasoningEnabled, "value": "false"})
+		assert.Equal(t, http.StatusForbidden, w.Code, "body=%s", w.Body.String())
+	})
+	t.Run("delete on someone else's bot is forbidden", func(t *testing.T) {
+		w := deleteSetting(t, handler, settingsOtherRobotID, BotSettingKeyReasoningEnabled)
+		assert.Equal(t, http.StatusForbidden, w.Code, "body=%s", w.Body.String())
+	})
+	t.Run("unknown bot is not found", func(t *testing.T) {
+		w := getSettings(t, handler, "bot_does_not_exist")
+		assert.Equal(t, http.StatusNotFound, w.Code, "body=%s", w.Body.String())
+	})
+}

--- a/modules/robot/bot_setting_integration_test.go
+++ b/modules/robot/bot_setting_integration_test.go
@@ -167,10 +167,13 @@ func TestBotSettings_CatalogListsEveryRegisteredKey(t *testing.T) {
 	assert.Equal(t, botSettingSourceDefault, reasoning.Source)
 	assert.True(t, reasoning.Effective, "code default is true")
 
-	// Per-bot private config must never be held by a shared cache.
+	// Per-bot private config must never be held by a shared cache. Vary names
+	// the header this route actually authenticates with — user session is
+	// `token`, not Authorization (that is the bot-token profile endpoint).
 	cacheControl := w.Header().Get("Cache-Control")
 	assert.Contains(t, cacheControl, "private")
 	assert.Contains(t, cacheControl, "no-store")
+	assert.Equal(t, "token", w.Header().Get("Vary"))
 }
 
 // TestBotSettings_OverrideThenDeleteFallsBack walks the full lifecycle the
@@ -298,6 +301,26 @@ func TestBotSettings_OwnershipGuard(t *testing.T) {
 	t.Run("unknown bot is not found", func(t *testing.T) {
 		w := getSettings(t, handler, "bot_does_not_exist")
 		assert.Equal(t, http.StatusNotFound, w.Code, "body=%s", w.Body.String())
+	})
+
+	// Ownership is decided before per-item validation, so a malformed request
+	// against a bot you do not own answers 403/404 rather than 400. Two things
+	// depend on that ordering: the endpoint's documented ownership semantics,
+	// and not letting a non-owner tell "registered and writable" (403) apart
+	// from "unknown key" (400) — which would enumerate the server-side registry.
+	t.Run("a malformed write on someone else's bot is still forbidden", func(t *testing.T) {
+		w := putSettings(t, handler, settingsOtherRobotID,
+			map[string]any{"key": "bot.not_a_real_key", "value": "nonsense"})
+		assert.Equal(t, http.StatusForbidden, w.Code, "body=%s", w.Body.String())
+	})
+	t.Run("a malformed write on an unknown bot is still not found", func(t *testing.T) {
+		w := putSettings(t, handler, "bot_does_not_exist",
+			map[string]any{"key": "bot.not_a_real_key", "value": "nonsense"})
+		assert.Equal(t, http.StatusNotFound, w.Code, "body=%s", w.Body.String())
+	})
+	t.Run("an unknown key on someone else's bot is forbidden, not bad request", func(t *testing.T) {
+		w := deleteSetting(t, handler, settingsOtherRobotID, "bot.not_a_real_key")
+		assert.Equal(t, http.StatusForbidden, w.Code, "body=%s", w.Body.String())
 	})
 }
 

--- a/modules/robot/bot_setting_integration_test.go
+++ b/modules/robot/bot_setting_integration_test.go
@@ -165,6 +165,11 @@ func TestBotSettings_CatalogListsEveryRegisteredKey(t *testing.T) {
 	assert.True(t, reasoning.Editable)
 	assert.Equal(t, botSettingSourceDefault, reasoning.Source)
 	assert.True(t, reasoning.Effective, "code default is true")
+
+	// Per-bot private config must never be held by a shared cache.
+	cacheControl := w.Header().Get("Cache-Control")
+	assert.Contains(t, cacheControl, "private")
+	assert.Contains(t, cacheControl, "no-store")
 }
 
 // TestBotSettings_OverrideThenDeleteFallsBack walks the full lifecycle the

--- a/modules/robot/bot_setting_integration_test.go
+++ b/modules/robot/bot_setting_integration_test.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/Mininglamp-OSS/octo-lib/config"
@@ -328,16 +329,14 @@ func TestBotSettings_CatalogValueRoundTrips(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code, "echoed value must round trip; body=%s", w.Body.String())
 }
 
-// TestBotSettings_BatchWriteIsAtomic pins the all-or-nothing contract the
-// handler claims. A batch that fails partway must leave nothing behind:
-// otherwise the caller sees a 500 and believes nothing applied, while some
-// switches silently did — and the invalidation event never fires, so adapters
-// keep serving the stale profile.
+// TestBotSettings_BatchValidationRejectsAtomically covers the validation half of
+// the all-or-nothing contract: one bad item rejects the whole batch.
 //
-// Driven through the validation failure (the only failure reachable without
-// breaking the DB): the invalid item is last, so any non-atomic implementation
-// would already have committed the first one.
-func TestBotSettings_BatchWriteIsAtomic(t *testing.T) {
+// Named for what it actually covers. It does NOT exercise the transaction —
+// validation returns before Begin() is reached, so this case passes against the
+// pre-transaction code too. The rollback itself is covered by
+// TestWriteBotSettingOverrides_RollsBackOnMidBatchFailure.
+func TestBotSettings_BatchValidationRejectsAtomically(t *testing.T) {
 	handler, _ := setupBotSettings(t)
 
 	w := putSettings(t, handler, settingsRobotID,
@@ -365,4 +364,37 @@ func TestBotSettings_BatchWriteIsAtomic(t *testing.T) {
 		assert.NotNil(t, item.Value, "%s must be written when the whole batch is valid", key)
 		assert.False(t, *item.Value)
 	}
+}
+
+// TestWriteBotSettingOverrides_RollsBackOnMidBatchFailure exercises the
+// transaction for real: the second item's key exceeds key_name's column width,
+// so MySQL (strict mode) errors on it after the first has already been inserted
+// inside the transaction. Without the rollback the first would survive.
+//
+// It calls the writer directly rather than going through HTTP because the
+// registry whitelist makes an over-long key unreachable from the endpoint — which
+// is the point: the only failure the HTTP path can produce trips before Begin().
+func TestWriteBotSettingOverrides_RollsBackOnMidBatchFailure(t *testing.T) {
+	_, ctx := setupBotSettings(t)
+
+	overlong := strings.Repeat("k", 200) // key_name is VARCHAR(128)
+	err := writeBotSettingOverrides(ctx, settingsRobotID, testutil.UID, []botSettingWritePlan{
+		{key: BotSettingKeyDisplayEnabled, value: botSettingFalse},
+		{key: overlong, value: botSettingFalse},
+	})
+	assert.Error(t, err, "an over-long key must fail the write")
+
+	overrides, queryErr := queryBotSettingOverrides(ctx, settingsRobotID)
+	assert.NoError(t, queryErr)
+	assert.Empty(t, overrides,
+		"the first item survived a failed batch — the transaction did not roll back")
+
+	// The same batch without the poisoned item commits completely.
+	assert.NoError(t, writeBotSettingOverrides(ctx, settingsRobotID, testutil.UID, []botSettingWritePlan{
+		{key: BotSettingKeyDisplayEnabled, value: botSettingFalse},
+		{key: BotSettingKeyInteractionEnabled, value: botSettingFalse},
+	}))
+	overrides, queryErr = queryBotSettingOverrides(ctx, settingsRobotID)
+	assert.NoError(t, queryErr)
+	assert.Len(t, overrides, 2)
 }

--- a/modules/robot/bot_setting_test.go
+++ b/modules/robot/bot_setting_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/Mininglamp-OSS/octo-server/pkg/cardmsg"
+	"go.uber.org/zap"
 )
 
 func boolPtr(v bool) *bool { return &v }
@@ -239,4 +240,40 @@ func TestBuildBotSettingChangedEventData(t *testing.T) {
 			t.Errorf("event data carries %q; it must be a signal to re-fetch, not a value channel", key)
 		}
 	}
+}
+
+// TestWarnMalformedBotSetting_FiresOncePerRobotKey —— 脏值告警必须留痕，且只留一次。
+//
+// 两个要求互相拉扯，都得满足：脏值是**持久**状态（人工改库 / 迁移出错），而解析发生
+// 在每次发卡与每次 profile 读上；不去重就是拿一条运维告警把日志管道淹掉，最后没人看
+// 得见——和不打日志是同一个结果。所以按 (robot, key) 去重，而不是按调用去重。
+func TestWarnMalformedBotSetting_FiresOncePerRobotKey(t *testing.T) {
+	malformedBotSettingSeen.Delete("bot-warn-1\x00" + BotSettingKeyDisplayEnabled)
+	malformedBotSettingSeen.Delete("bot-warn-1\x00" + BotSettingKeyReasoningEnabled)
+	malformedBotSettingSeen.Delete("bot-warn-2\x00" + BotSettingKeyDisplayEnabled)
+	t.Cleanup(func() {
+		malformedBotSettingSeen.Delete("bot-warn-1\x00" + BotSettingKeyDisplayEnabled)
+		malformedBotSettingSeen.Delete("bot-warn-1\x00" + BotSettingKeyReasoningEnabled)
+		malformedBotSettingSeen.Delete("bot-warn-2\x00" + BotSettingKeyDisplayEnabled)
+	})
+
+	calls := 0
+	warn := func(string, ...zap.Field) { calls++ }
+
+	for i := 0; i < 5; i++ {
+		warnMalformedBotSetting(warn, "bot-warn-1", BotSettingKeyDisplayEnabled, "garbage")
+	}
+	if calls != 1 {
+		t.Fatalf("同一 (robot,key) 的脏值告警喊了 %d 次，应只喊一次", calls)
+	}
+
+	// 另一个键、另一个 Bot 都是独立的坏消息，不该被前一条压掉。
+	warnMalformedBotSetting(warn, "bot-warn-1", BotSettingKeyReasoningEnabled, "garbage")
+	warnMalformedBotSetting(warn, "bot-warn-2", BotSettingKeyDisplayEnabled, "garbage")
+	if calls != 3 {
+		t.Fatalf("calls = %d，不同 (robot,key) 的脏值被误并成一条", calls)
+	}
+
+	// 没有 logger 时静默返回而不是 panic：解析器在测试与后台任务里都可能无 logger。
+	warnMalformedBotSetting(nil, "bot-warn-3", BotSettingKeyDisplayEnabled, "garbage")
 }

--- a/modules/robot/bot_setting_test.go
+++ b/modules/robot/bot_setting_test.go
@@ -176,12 +176,12 @@ func TestFindBotSettingDef_RegistryShape(t *testing.T) {
 // false: a hand-edited row must fall through to the next layer, not silently
 // switch a capability off.
 func TestBotSettingBoolLiterals(t *testing.T) {
-	for _, raw := range []string{"1", "true", "TRUE", "True"} {
+	for _, raw := range []string{"1", "true", "TRUE", "True", " true ", "tRuE"} {
 		if got, ok := normalizeBotSettingBool(raw); !ok || got != botSettingTrue {
 			t.Errorf("normalize(%q) = %q,%v want %q,true", raw, got, ok, botSettingTrue)
 		}
 	}
-	for _, raw := range []string{"0", "false", "FALSE", "False", " false "} {
+	for _, raw := range []string{"0", "false", "FALSE", "False", " false ", "fAlSe"} {
 		if got, ok := normalizeBotSettingBool(raw); !ok || got != botSettingFalse {
 			t.Errorf("normalize(%q) = %q,%v want %q,true", raw, got, ok, botSettingFalse)
 		}
@@ -193,6 +193,34 @@ func TestBotSettingBoolLiterals(t *testing.T) {
 	}
 	if _, ok := parseBotSettingBool("garbage"); ok {
 		t.Error("parse accepted a garbage stored value; it must read as not-configured")
+	}
+}
+
+// TestBotSettingBoolLexing_WriteAndReadAgreeLiteralByLiteral 钉住这条链上**只有一套
+// 词法**：写侧接受的字面量集合，必须恒等于读侧认作已配置的集合。
+//
+// 这个不变量此前没有任何测试覆盖，于是两处各写各的能一路活到评审第六轮：写侧
+// trim 且认 `True`，读侧两样都不认。后果是手工写入 `value='True'` 被读成「覆盖值
+// 非法、已忽略」，而同一个字面量走写接口是被接受的——owner 以为设上了，实际在回落。
+//
+// 逐字面量比对，而不是断言「两者行为应当一致」：上一轮那条测试就是因为只钉了自己
+// 想到的那条轴（词表），漏了真正改动的那条轴（词法），才让分叉溜过去的。
+func TestBotSettingBoolLexing_WriteAndReadAgreeLiteralByLiteral(t *testing.T) {
+	for _, raw := range []string{
+		"1", "true", "TRUE", "True", " true ", "\ttrue\n", "tRuE",
+		"0", "false", "FALSE", "False", " false ", "\tfalse\n", "fAlSe",
+		"", " ", "yes", "no", "on", "off", "2", "null", "garbage", "T", "F",
+	} {
+		normalized, writeOK := normalizeBotSettingBool(raw)
+		readValue, readOK := parseBotSettingBool(raw)
+
+		if writeOK != readOK {
+			t.Errorf("%q：写侧接受=%v 读侧接受=%v —— 同一列出现了两套词法", raw, writeOK, readOK)
+			continue
+		}
+		if writeOK && readValue != (normalized == botSettingTrue) {
+			t.Errorf("%q：写侧归一化成 %q，读侧却解析成 %v", raw, normalized, readValue)
+		}
 	}
 }
 

--- a/modules/robot/bot_setting_test.go
+++ b/modules/robot/bot_setting_test.go
@@ -1,0 +1,242 @@
+package robot
+
+// task bot-setting-store —— 三层解析、总闸支配、写入校验的纯函数单测。
+// 这些用例刻意不碰 DB：解析优先级与来源标注是本任务的 load-bearing 语义，
+// 值得能在没有 MySQL 的环境里跑。端点级行为由集成测试覆盖。
+
+import (
+	"os"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardmsg"
+)
+
+func boolPtr(v bool) *bool { return &v }
+
+// TestResolveBotSettingBool_PriorityAndSource 钉住三层解析的优先级**和来源标注**。
+//
+// 来源标注和有效值一样重要：owner UI 靠 source 区分「我显式设成了 false」与
+// 「我没设、上层默认就是 false」，两者有效值相同但「恢复默认」的行为完全不同。
+// 只断言 effective 的测试会漏掉把 source 标错层的 bug。
+func TestResolveBotSettingBool_PriorityAndSource(t *testing.T) {
+	def := botSettingDef{
+		Key: "bot.test_switch", Type: botSettingTypeBool, Editable: true, CodeDefault: true,
+	}
+
+	cases := []struct {
+		name       string
+		override   *bool
+		globalVal  bool
+		globalOK   bool
+		wantEff    bool
+		wantSource string
+		wantValue  *bool
+	}{
+		{
+			name: "bot override wins over global", override: boolPtr(false),
+			globalVal: true, globalOK: true,
+			wantEff: false, wantSource: botSettingSourceBot, wantValue: boolPtr(false),
+		},
+		{
+			name: "bot override wins even when it agrees with global", override: boolPtr(true),
+			globalVal: true, globalOK: true,
+			wantEff: true, wantSource: botSettingSourceBot, wantValue: boolPtr(true),
+		},
+		{
+			name:      "global default applies when the bot has no override",
+			globalVal: false, globalOK: true,
+			wantEff: false, wantSource: botSettingSourceGlobal, wantValue: nil,
+		},
+		{
+			name:    "code default applies when neither layer has an opinion",
+			wantEff: true, wantSource: botSettingSourceDefault, wantValue: nil,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := resolveBotSettingBool(def, tc.override, tc.globalVal, tc.globalOK)
+			if got.Eff != tc.wantEff {
+				t.Errorf("effective = %v, want %v", got.Eff, tc.wantEff)
+			}
+			if got.Source != tc.wantSource {
+				t.Errorf("source = %q, want %q", got.Source, tc.wantSource)
+			}
+			switch {
+			case tc.wantValue == nil && got.Override != nil:
+				t.Errorf("value = %v, want null (no override)", *got.Override)
+			case tc.wantValue != nil && got.Override == nil:
+				t.Errorf("value = null, want %v", *tc.wantValue)
+			case tc.wantValue != nil && *got.Override != *tc.wantValue:
+				t.Errorf("value = %v, want %v", *got.Override, *tc.wantValue)
+			}
+		})
+	}
+}
+
+// TestResolveBotSettingBool_DerivedKeyIgnoresStoredLayers pins that a derived
+// key answers from the environment even if a row somehow exists for it. A
+// stored value that could outvote the env is exactly the "DB says cards are on
+// while the env has them off" state the read-only design exists to prevent.
+func TestResolveBotSettingBool_DerivedKeyIgnoresStoredLayers(t *testing.T) {
+	def := botSettingDef{
+		Key: BotSettingKeyCardEnabled, Type: botSettingTypeBool, Editable: false,
+		CodeDefault: true,
+		Derived:     func() bool { return false },
+	}
+	got := resolveBotSettingBool(def, boolPtr(true), true, true)
+	if got.Eff {
+		t.Error("derived key was overridden by a stored value")
+	}
+	if got.Source != botSettingSourceEnv {
+		t.Errorf("source = %q, want %q", got.Source, botSettingSourceEnv)
+	}
+	if got.Override != nil {
+		t.Error("derived key reported a stored override; it has no editable layer")
+	}
+}
+
+// TestApplyCardMasterSwitch_DominatesSubSwitches pins the invariant the manifest
+// depends on: with the deployment switch off, no sub-capability may report true.
+// Advertising one would break the "manifest agrees with the send gate" contract
+// pkg/cardmsg established — the send path refuses everything when BotEnabled()
+// is false.
+func TestApplyCardMasterSwitch_DominatesSubSwitches(t *testing.T) {
+	off := applyCardMasterSwitch(BotCardConfig{
+		CardEnabled: false, DisplayEnabled: true,
+		InteractionEnabled: true, ReasoningEnabled: true,
+	})
+	if off.DisplayEnabled || off.InteractionEnabled || off.ReasoningEnabled || off.CardEnabled {
+		t.Fatalf("master switch off must zero every sub-switch, got %#v", off)
+	}
+
+	on := BotCardConfig{
+		CardEnabled: true, DisplayEnabled: true,
+		InteractionEnabled: false, ReasoningEnabled: true,
+	}
+	if got := applyCardMasterSwitch(on); got != on {
+		t.Fatalf("master switch on must pass sub-switches through, got %#v want %#v", got, on)
+	}
+}
+
+// TestBotCardConfigFrom_ProjectsRegisteredKeys covers the projection from the
+// generic resolution list to the typed card config, including the master-switch
+// application that rides along with it.
+func TestBotCardConfigFrom_ProjectsRegisteredKeys(t *testing.T) {
+	resolutions := []botSettingResolution{
+		{Key: BotSettingKeyCardEnabled, Eff: true},
+		{Key: BotSettingKeyDisplayEnabled, Eff: false},
+		{Key: BotSettingKeyInteractionEnabled, Eff: true},
+		{Key: BotSettingKeyReasoningEnabled, Eff: true},
+		{Key: "bot.unrelated_future_key", Eff: true},
+	}
+	got := botCardConfigFrom(resolutions)
+	want := BotCardConfig{
+		CardEnabled: true, DisplayEnabled: false,
+		InteractionEnabled: true, ReasoningEnabled: true,
+	}
+	if got != want {
+		t.Fatalf("got %#v want %#v", got, want)
+	}
+}
+
+// TestFindBotSettingDef_RegistryShape guards the two properties the write path
+// relies on: an unregistered key is unknown (no wild keys), and card_enabled is
+// not editable (it is derived from the environment).
+func TestFindBotSettingDef_RegistryShape(t *testing.T) {
+	if findBotSettingDef("bot.not_a_real_key") != nil {
+		t.Error("an unregistered key resolved to a definition")
+	}
+	cardEnabled := findBotSettingDef(BotSettingKeyCardEnabled)
+	if cardEnabled == nil {
+		t.Fatal("bot.card_enabled is not registered")
+	}
+	if cardEnabled.Editable {
+		t.Error("bot.card_enabled must not be editable; it is derived from the deployment env")
+	}
+	for _, key := range []string{
+		BotSettingKeyDisplayEnabled, BotSettingKeyInteractionEnabled, BotSettingKeyReasoningEnabled,
+	} {
+		def := findBotSettingDef(key)
+		if def == nil {
+			t.Fatalf("%s is not registered", key)
+		}
+		if !def.Editable {
+			t.Errorf("%s must be owner-editable", key)
+		}
+		if !def.CodeDefault {
+			t.Errorf("%s code default = false, want true (the master switch carries the safe default)", key)
+		}
+	}
+}
+
+// TestBotSettingBoolLiterals covers both directions of the bool encoding.
+//
+// The read side deliberately treats garbage as "not configured" rather than
+// false: a hand-edited row must fall through to the next layer, not silently
+// switch a capability off.
+func TestBotSettingBoolLiterals(t *testing.T) {
+	for _, raw := range []string{"1", "true", "TRUE", "True"} {
+		if got, ok := normalizeBotSettingBool(raw); !ok || got != botSettingTrue {
+			t.Errorf("normalize(%q) = %q,%v want %q,true", raw, got, ok, botSettingTrue)
+		}
+	}
+	for _, raw := range []string{"0", "false", "FALSE", "False", " false "} {
+		if got, ok := normalizeBotSettingBool(raw); !ok || got != botSettingFalse {
+			t.Errorf("normalize(%q) = %q,%v want %q,true", raw, got, ok, botSettingFalse)
+		}
+	}
+	for _, raw := range []string{"", "yes", "on", "2", "null"} {
+		if _, ok := normalizeBotSettingBool(raw); ok {
+			t.Errorf("normalize(%q) accepted an illegal literal", raw)
+		}
+	}
+	if _, ok := parseBotSettingBool("garbage"); ok {
+		t.Error("parse accepted a garbage stored value; it must read as not-configured")
+	}
+}
+
+// TestBotSettingCardEnabledTracksDeploymentSwitch ties the registered derived
+// key to the real deployment gate rather than a copy of its logic — the whole
+// point of making it derived.
+func TestBotSettingCardEnabledTracksDeploymentSwitch(t *testing.T) {
+	def := findBotSettingDef(BotSettingKeyCardEnabled)
+	if def == nil || def.Derived == nil {
+		t.Fatal("bot.card_enabled must be a derived key")
+	}
+
+	t.Setenv(cardmsg.EnvEnabled, "true")
+	t.Setenv(cardmsg.EnvBotEnabled, "true")
+	if !def.Derived() {
+		t.Error("card_enabled = false with both deployment switches on")
+	}
+
+	t.Setenv(cardmsg.EnvBotEnabled, "false")
+	if def.Derived() {
+		t.Error("card_enabled = true while the bot sub-switch is off")
+	}
+
+	os.Unsetenv(cardmsg.EnvEnabled)
+	os.Unsetenv(cardmsg.EnvBotEnabled)
+	if def.Derived() {
+		t.Error("card_enabled = true with no deployment switch set; it must fail closed")
+	}
+}
+
+// TestBuildBotSettingChangedEventData pins that the invalidation event carries
+// no values. If it ever did, an adapter could apply a stale shape from the event
+// on top of the authoritative profile response.
+func TestBuildBotSettingChangedEventData(t *testing.T) {
+	data := buildBotSettingChangedEventData()
+	if data["scope"] != "bot_setting" {
+		t.Errorf("scope = %v, want bot_setting", data["scope"])
+	}
+	for _, key := range []string{
+		BotSettingKeyCardEnabled, BotSettingKeyDisplayEnabled,
+		BotSettingKeyInteractionEnabled, BotSettingKeyReasoningEnabled,
+		"value", "enabled",
+	} {
+		if _, present := data[key]; present {
+			t.Errorf("event data carries %q; it must be a signal to re-fetch, not a value channel", key)
+		}
+	}
+}

--- a/modules/robot/card_p1_test.go
+++ b/modules/robot/card_p1_test.go
@@ -52,3 +52,32 @@ func TestRobotCardIngress(t *testing.T) {
 	// octo/v2（P2 D2）已被接受：展示型 body 无交互元素时同样是合法 v2 卡。
 	assert.True(t, rb.payloadIsVail(maputil.Data(p1RobotCardPayload("octo/v2", ""))))
 }
+
+// TestRobotCardIngress_StringTypeIsNotACard 钉住路由谓词与校验谓词的同源性
+// （round-3 评审 P2-1）。
+//
+// 本 ingress 用 maputil.Data.Int("type") 分发，Int 会对字符串跑 strconv.Atoi；
+// cardmsg.IsCardPayload 只认 JSON 数字。两者不一致时 {"type":"17"} 会落进一条
+// 谁都不管的夹缝：Validate 因 IsCardPayload=false 直接 return nil（白名单、
+// 节点/深度上限、profile 协商全部不执行），rejectRobotCardBySetting 同样判 false
+// 而跳过全部 per-Bot 开关，Finalize 也 no-op。断言用的卡带 javascript: URL——
+// 上面那条同样的 URL 走数字 type 时是被拒的，这里若放行就等于**校验被绕过**，
+// 而不只是类型宽松。
+func TestRobotCardIngress_StringTypeIsNotACard(t *testing.T) {
+	_, ctx := testutil.NewTestServer()
+	defer func() { _ = testutil.CleanAllTables(ctx) }()
+	rb := New(ctx)
+	t.Setenv(cardmsg.EnvEnabled, "true")
+
+	payload := p1RobotCardPayload(cardmsg.ProfileV1, "javascript:alert(1)")
+	payload["type"] = "17" // 字符串而非数字
+
+	// 前提复核：分发确实把它当成 17（否则本测试没有守住任何东西）。
+	assert.Equal(t, cardmsg.InteractiveCard.Int(), maputil.Data(payload).Int("type"),
+		"maputil 不再强转字符串，本测试守护的夹缝已不存在，可以删除")
+	assert.False(t, cardmsg.IsCardPayload(payload),
+		"IsCardPayload 开始接受字符串 type，请改用它作为唯一谓词")
+
+	assert.False(t, rb.payloadIsVail(maputil.Data(payload)),
+		"字符串 type 的 payload 进了卡片分支却跳过校验——URL 白名单被绕过")
+}

--- a/modules/robot/sql/20260806000001_bot_setting.sql
+++ b/modules/robot/sql/20260806000001_bot_setting.sql
@@ -1,0 +1,28 @@
+-- +migrate Up
+-- bot_setting: Bot 级配置稀疏覆盖表。维度 (robot_id, key_name) → value。
+--
+-- 只存「偏离服务端全局默认」的覆盖项；无行或空串 value = 未配置，读取方回退
+-- system_setting 全局默认，再回退代码默认（与 bot_mention_pref 的稀疏语义同口径）。
+-- 因此「删除覆盖」== 回落上一层，而不是「设为 false」。
+--
+-- 存在的理由：本仓此前的一维 Bot 配置一律是给 `robot` 表加一列（inline_on /
+-- auto_approve / placeholder / bot_commands …），每加一个开关一次 ALTER，滚动发布
+-- 还要手写并发守卫。本表把后续 Bot 级配置收敛到 KV，新增配置项不再需要 DDL。
+--
+-- value 统一字符串存储（bool 用 "1"/"0"），与 system_setting 同口径；类型与合法
+-- 取值由服务端注册表（modules/robot/bot_setting.go 的 botSettingDefs）校验，DB 不做
+-- 类型约束——注册表是单一权威，DB 加 CHECK 只会与它漂移。
+CREATE TABLE IF NOT EXISTS `bot_setting` (
+  `id`         BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+  `robot_id`   VARCHAR(40)     NOT NULL DEFAULT '' COMMENT 'Bot UID',
+  `key_name`   VARCHAR(128)    NOT NULL DEFAULT '' COMMENT '注册表键名，如 bot.reasoning_enabled',
+  `value`      VARCHAR(1024)   NOT NULL DEFAULT '' COMMENT '统一字符串存储；bool 用 "1"/"0"；空串=未配置',
+  `created_at` TIMESTAMP       NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` TIMESTAMP       NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `updated_by` VARCHAR(40)     NOT NULL DEFAULT '' COMMENT '最后修改人 UID（审计）',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_robot_key` (`robot_id`, `key_name`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci COMMENT='Bot 级配置稀疏覆盖表';
+
+-- +migrate Down
+DROP TABLE IF EXISTS `bot_setting`;

--- a/modules/robot/stream_card_gate_test.go
+++ b/modules/robot/stream_card_gate_test.go
@@ -1,0 +1,228 @@
+package robot
+
+// task bot-setting-store round-7 —— 流式入口的卡片拒绝门。
+//
+// 打真实 handler 而不是抽一个纯函数来测：被守护的性质是「streamStart 这个 handler 里
+// 有这道门」，纯函数测试在有人把调用点删掉之后照样全绿——本分支已经出过两个「名字里的
+// 东西坏了它照样过」的测试（round-1 的原子性测试、round-7 评审指出的编辑门测试），
+// 不再添第三个。
+//
+// 不挂 robotAuth：`app` 表的迁移在 modules/base，不在 modules/robot 测试二进制的迁移
+// 集里（这也正是本包既有的 robot ingress 测试一律绕开该中间件的原因）。鉴权与本门正交
+// ——门在 BindJSON 之后、任何业务判断之前，鉴权通过与否不改变它的结论。
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	libconfig "github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	"github.com/Mininglamp-OSS/octo-server/modules/group"
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
+	"github.com/stretchr/testify/assert"
+)
+
+const streamGateRobotID = "streamgate_bot"
+
+// streamGateHarness mounts streamStart on its real route shape, minus the auth
+// middleware. The path keeps :robot_id so the handler's own c.Param read is
+// exercised rather than stubbed.
+//
+// **Constructs *Robot as a struct literal rather than calling New(ctx)**, and
+// that is load-bearing, not style. New() registers the module's event listeners
+// and background wiring — the doc comment on Service says it exists precisely so
+// callers can re-New *it* without duplicating them, which names *Robot as the
+// one you must not. An earlier draft of this file called New() per test and made
+// the bot_setting integration cases fail in 2 of 5 shuffled runs, always the
+// unrelated ones; dropping New() removed it. The handler needs only ctx (for
+// IMStreamStart) and the embedded logger, and the disband guards are skipped
+// entirely for ChannelTypePerson, which is what these cases use.
+//
+// Setup-time CleanAllTables only, never on exit: every sibling setup in this
+// package cleans before it runs, and cleaning afterwards instead puts the wipe
+// between some other test's setup and its assertions once the order shuffles.
+func streamGateHarness(t *testing.T) (*wkhttp.WKHttp, *stubGroupService) {
+	t.Helper()
+	_, ctx := testutil.NewTestServer()
+
+	gs := &stubGroupService{}
+	rb := &Robot{ctx: ctx, Log: log.NewTLog("RobotStreamGateTest"), groupService: gs}
+	r := wkhttp.New()
+	r.SetErrorRenderer(i18n.NewErrorRenderer(i18n.NewLocalizer(i18n.DefaultLanguage)))
+	r.POST("/v1/robots/:robot_id/:app_key/stream/start", rb.streamStart)
+	return r, gs
+}
+
+// stubGroupService records which uid allowSendToChannel asked about, which is
+// the only way to observe the FromUID pin from outside the handler: the pin is a
+// single assignment and IMStreamStart's response does not echo it back.
+//
+// The interface is embedded rather than fully implemented — every other method
+// is nil and would panic if reached, which is the point: if this stub ever needs
+// a second method, the handler started doing something this test does not model.
+type stubGroupService struct {
+	group.IService
+	askedUID string
+	member   bool
+}
+
+func (s *stubGroupService) ExistMember(groupNo string, uid string) (bool, error) {
+	s.askedUID = uid
+	return s.member, nil
+}
+
+// postStreamStart sends one stream/start carrying the given raw payload bytes.
+// MessageStreamStartReq.Payload is []byte, so encoding/json renders it base64 on
+// the wire — going through the real struct rather than a hand-written literal
+// keeps the test honest about the shape the handler actually receives.
+func postStreamStart(t *testing.T, handler http.Handler, payload []byte) *httptest.ResponseRecorder {
+	t.Helper()
+	body, err := json.Marshal(libconfig.MessageStreamStartReq{
+		ClientMsgNo: "streamgate-1",
+		FromUID:     streamGateRobotID,
+		ChannelID:   "streamgate_peer",
+		ChannelType: 1,
+		Payload:     payload,
+	})
+	assert.NoError(t, err)
+
+	w := httptest.NewRecorder()
+	req, err := http.NewRequest("POST",
+		"/v1/robots/"+streamGateRobotID+"/appkey/stream/start", bytes.NewReader(body))
+	assert.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	handler.ServeHTTP(w, req)
+	return w
+}
+
+func streamGateErrorCode(w *httptest.ResponseRecorder) string {
+	var envelope struct {
+		Error struct {
+			Code string `json:"code"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &envelope); err != nil {
+		return ""
+	}
+	return envelope.Error.Code
+}
+
+// TestStreamStart_RefusesCardPayload —— 流式入口不得成为第四条发卡路径。
+//
+// 本 handler 把 Payload 裸转给 WuKongIM：没有 payloadIsVail、没有 cardmsg.Validate、
+// 没有 BotEnabled() 总闸、也没有 per-Bot 门。没有这道拒绝，owner 关掉展示/交互卡之后，
+// 同一个 Bot 换这个端点仍能把 type:17 送出去——本任务承诺「每条已鉴权的发卡路径都按有效
+// 配置校验」，少一条这个承诺就是假的。
+func TestStreamStart_RefusesCardPayload(t *testing.T) {
+	handler, _ := streamGateHarness(t)
+
+	card := []byte(`{"type":17,"card_version":"1.0","profile":"octo/v1",` +
+		`"card":{"type":"AdaptiveCard","version":"1.5","body":[{"type":"TextBlock","text":"x"}]}}`)
+	w := postStreamStart(t, handler, card)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code, "body=%s", w.Body.String())
+	assert.Equal(t, "err.server.robot.content_invalid", streamGateErrorCode(w),
+		"卡片必须走本 ingress 既有的单一泛化码（防枚举），body=%s", w.Body.String())
+}
+
+// TestStreamStart_TextPayloadIsNotRefusedByTheCardGate —— 这道门只拦卡片。
+//
+// 断言「没有被**这道门**拒掉」，而不是「返回 200」：放行之后请求会一路走到 WuKongIM，
+// 其成败取决于 IM 侧状态，拿它当断言会把一条门禁测试变成环境测试。
+func TestStreamStart_TextPayloadIsNotRefusedByTheCardGate(t *testing.T) {
+	handler, _ := streamGateHarness(t)
+
+	w := postStreamStart(t, handler, []byte(`{"type":1,"content":"hello"}`))
+
+	assert.NotEqual(t, "err.server.robot.content_invalid", streamGateErrorCode(w),
+		"普通文本被卡片门拦下了，body=%s", w.Body.String())
+}
+
+// TestStreamStart_StringTypedPayloadIsNotACard —— 与 payloadIsVail 同一个谓词，
+// 且这里把它的**边界**钉成显式契约而不是留作默认。
+//
+// IsCardRawPayload 是 IsCardPayload 的 []byte 形态，同样只认 JSON 数字，所以
+// `{"type":"17"}` 在本门是放行的：它不被判作卡片，会当普通 payload 转给 IM。
+// legacy sendMessage 那条路上这个夹缝是被堵住的（round-3 P2-1），因为那里同时存在一个
+// 会强转字符串的分发谓词；本 handler 不做类型分发，没有那个夹缝可堵。
+//
+// 写下这条是为了让「本门覆盖到哪」有据可查：它的职责是不让**卡片**从流式路径出去，而
+// 字符串 type 能否被客户端渲染成卡片是仓外事实（见 journal known-gaps）。哪天答案是
+// 「能」，本用例会连同 sendMessage 侧一起改，而不是让人误以为这里已经覆盖了。
+func TestStreamStart_StringTypedPayloadIsNotACard(t *testing.T) {
+	handler, _ := streamGateHarness(t)
+
+	w := postStreamStart(t, handler, []byte(`{"type":"17","card":{}}`))
+
+	assert.NotEqual(t, "err.server.robot.content_invalid", streamGateErrorCode(w),
+		"字符串 type 目前不被 IsCardRawPayload 认作卡片；若这里开始拒绝，说明谓词已变，"+
+			"sendMessage 侧的同型判定需一并复核。body=%s", w.Body.String())
+}
+
+// TestStreamStart_PinsFromUIDToTheAuthenticatedRobot —— 身份取自路径，不信请求体。
+//
+// 这是 round-7 评审的**核心**阻塞项，评审明确说它「与客户端是否渲染卡片无关」：同一个
+// robotAuth 组里 sendMessage 与 typing 都把 FromUID 钉成 c.Param("robot_id")，只有
+// streamStart 直接用调用方传入的值——鉴权回答了「你是谁」，请求体却能改写「你说你是谁」，
+// 于是一个已鉴权的 Bot 能以任意 uid 开流。
+//
+// 请求体带一个与路径**不同**的 from_uid，再看频道校验实际按哪个身份去查群成员——
+// 这是从 handler 外部唯一能观察到该赋值的地方（IMStreamStart 的响应不回显 FromUID）。
+// 断言的是 stub 记下的 uid，而不是最终状态码：拿状态码当证据的话，「拒绝」既可能因为
+// 钉住生效、也可能因为 victim 恰好也不在群里，两种原因给出同一个绿灯。
+func TestStreamStart_PinsFromUIDToTheAuthenticatedRobot(t *testing.T) {
+	handler, gs := streamGateHarness(t)
+	gs.member = true // 成员判定放行，把频道门从断言里摘掉，只留身份这一个变量
+
+	body, err := json.Marshal(libconfig.MessageStreamStartReq{
+		ClientMsgNo: "streamgate-forge",
+		FromUID:     "victim_uid_not_this_bot", // 冒充：与路径里的 robot_id 不同
+		ChannelID:   "streamgate_group",
+		ChannelType: 2, // 群：allowSendToChannel 会真的按身份查成员
+		Payload:     []byte(`{"type":1,"content":"hello"}`),
+	})
+	assert.NoError(t, err)
+
+	w := httptest.NewRecorder()
+	req, err := http.NewRequest("POST",
+		"/v1/robots/"+streamGateRobotID+"/appkey/stream/start", bytes.NewReader(body))
+	assert.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, streamGateRobotID, gs.askedUID,
+		"频道校验按请求体里的 from_uid 做的——身份未被钉成已鉴权的 robot_id，冒充仍然成立")
+}
+
+// TestStreamStart_ChecksChannelPermission —— 频道校验存在，且拒绝走既有码。
+//
+// 与上一条分开：上一条问「按谁的身份查」，这条问「查不过时会不会拒」。合成一条的话，
+// 任何一半坏掉都被另一半的绿灯掩盖。
+func TestStreamStart_ChecksChannelPermission(t *testing.T) {
+	handler, gs := streamGateHarness(t)
+	gs.member = false // 非群成员
+
+	body, err := json.Marshal(libconfig.MessageStreamStartReq{
+		ClientMsgNo: "streamgate-nonmember",
+		FromUID:     streamGateRobotID,
+		ChannelID:   "streamgate_group",
+		ChannelType: 2,
+		Payload:     []byte(`{"type":1,"content":"hello"}`),
+	})
+	assert.NoError(t, err)
+
+	w := httptest.NewRecorder()
+	req, err := http.NewRequest("POST",
+		"/v1/robots/"+streamGateRobotID+"/appkey/stream/start", bytes.NewReader(body))
+	assert.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, "err.server.robot.channel_send_forbidden", streamGateErrorCode(w),
+		"非群成员必须被拒，且与 sendMessage 用同一个码，body=%s", w.Body.String())
+}

--- a/modules/robot/stream_card_gate_test.go
+++ b/modules/robot/stream_card_gate_test.go
@@ -67,12 +67,14 @@ func streamGateHarness(t *testing.T) (*wkhttp.WKHttp, *stubGroupService) {
 // a second method, the handler started doing something this test does not model.
 type stubGroupService struct {
 	group.IService
-	askedUID string
-	member   bool
+	askedUID   string
+	askedGroup string
+	member     bool
 }
 
 func (s *stubGroupService) ExistMember(groupNo string, uid string) (bool, error) {
 	s.askedUID = uid
+	s.askedGroup = groupNo
 	return s.member, nil
 }
 
@@ -261,4 +263,72 @@ func TestStreamStart_ChannelCheckPrecedesTheCardGate(t *testing.T) {
 	assert.Equal(t, "err.server.robot.channel_send_forbidden", streamGateErrorCode(w),
 		"卡片门抢在频道门前面答了：等于在鉴权之前就对内容表态，与 sendMessage 的顺序相反。"+
 			"body=%s", w.Body.String())
+}
+
+// TestAllowSendToChannel_CommunityTopicResolvesParentGroup —— 子区按父群判成员。
+//
+// 直接测这份共用判定，而不是只从 streamStart 打进去：三个 robot ingress
+// （sendMessage / typing / streamStart）都调它，这里少认一种频道类型，那种类型就在三条
+// 路上同时不可用。round-8 评审正是因为 streamStart 补了频道校验才让这个洞浮出水面——
+// 而它先前已经让 sendMessage 与 typing 的子区解散守卫永远不可达。
+//
+// 断言按父群查：子区 channelID 形如 `<parentGroupNo>____<topicNo>`，成员表挂在父群上，
+// 拿整个 channelID 去查成员会永远查不到，那是「看起来实现了、实际全拒」的失败形态。
+func TestAllowSendToChannel_CommunityTopicResolvesParentGroup(t *testing.T) {
+	_, ctx := testutil.NewTestServer()
+
+	gs := &stubGroupService{member: true}
+	rb := &Robot{ctx: ctx, Log: log.NewTLog("RobotAllowSendTest"), groupService: gs}
+
+	assert.True(t, rb.allowSendToChannel("bot_a", "parent_group_1____topic_9", 5),
+		"父群成员必须被允许向子区发送")
+	assert.Equal(t, "parent_group_1", gs.askedGroup,
+		"成员查询用的不是父群号——拿整个子区 channelID 去查会永远落空")
+
+	gs.member = false
+	assert.False(t, rb.allowSendToChannel("bot_a", "parent_group_1____topic_9", 5),
+		"非父群成员必须被拒")
+
+	// 形状不合法 → fail-closed，且不得把畸形串当群号去查。
+	gs.member = true
+	gs.askedGroup = ""
+	assert.False(t, rb.allowSendToChannel("bot_a", "no_separator_here", 5),
+		"子区 channelID 形状不合法时必须拒绝")
+	assert.Empty(t, gs.askedGroup, "形状不合法时不该发起成员查询")
+
+	// 未知类型仍然一律拒——放宽只针对 type 5。
+	assert.False(t, rb.allowSendToChannel("bot_a", "whatever", 99),
+		"未知频道类型必须继续拒绝")
+}
+
+// TestStreamStart_CommunityTopicIsNotRefusedByTheChannelGate —— round-8 评审的回归。
+//
+// 加频道校验之前，streamStart 是三条 robot 路里唯一子区能发的（因为它压根没校验）。
+// 补上校验后，allowSendToChannel 不认 type 5，子区流式立刻变成 403 —— 一个子区助手用
+// 流式增量回复正是最自然的用法。评审指出这一点时没有测试守着，因为原有用例只覆盖了
+// type 1 和 type 2。
+func TestStreamStart_CommunityTopicIsNotRefusedByTheChannelGate(t *testing.T) {
+	handler, gs := streamGateHarness(t)
+	gs.member = true // 父群成员
+
+	body, err := json.Marshal(libconfig.MessageStreamStartReq{
+		ClientMsgNo: "streamgate-topic",
+		FromUID:     streamGateRobotID,
+		ChannelID:   "streamgate_group____topic_1",
+		ChannelType: 5,
+		Payload:     []byte(`{"type":1,"content":"hello"}`),
+	})
+	assert.NoError(t, err)
+
+	w := httptest.NewRecorder()
+	req, err := http.NewRequest("POST",
+		"/v1/robots/"+streamGateRobotID+"/appkey/stream/start", bytes.NewReader(body))
+	assert.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	handler.ServeHTTP(w, req)
+
+	assert.NotEqual(t, "err.server.robot.channel_send_forbidden", streamGateErrorCode(w),
+		"父群成员的子区流式被频道门拒了，body=%s", w.Body.String())
+	assert.Equal(t, "streamgate_group", gs.askedGroup,
+		"子区成员判定必须落在父群上")
 }

--- a/modules/robot/stream_card_gate_test.go
+++ b/modules/robot/stream_card_gate_test.go
@@ -341,11 +341,25 @@ func TestAllowSendToChannel_CommunityTopicResolvesParentGroup(t *testing.T) {
 		"非父群成员必须被拒")
 
 	// 形状不合法 → fail-closed，且不得把畸形串当群号去查。
-	gs.activeMember = true
-	gs.askedGroup = ""
-	assert.False(t, rb.allowSendToChannel("bot_a", "no_separator_here", topicType),
-		"子区 channelID 形状不合法时必须拒绝")
-	assert.Empty(t, gs.askedGroup, "形状不合法时不该发起成员查询")
+	//
+	// 这几种形状全仓标准解析器 thread.ParseChannelID 都拒（恰好两段、两段非空），
+	// 而原来那版 SplitN(...,2) 只拒第一种：后两种会切出 parts[0]="groupA" 通过成员
+	// 校验，再把非规范 channelID 原样投出去——下游同样走 ParseChannelID，于是门按
+	// groupA 放行、消息却投不到任何订阅者。门与投递目标对「合法子区 ID」判断不一致，
+	// 正是 round-9 评审 P2-2（与刚修的 P1 同一族：本模块把全仓判定又实现了一遍且更松）。
+	for _, malformed := range []string{
+		"no_separator_here",        // 没有分隔符
+		"groupA____topic____extra", // 多一个分隔符：SplitN 会放行
+		"groupA____",               // 尾段为空：SplitN 会放行
+		"____topic_1",              // 群号为空：SplitN 会放行且把 "" 当群号
+	} {
+		gs.activeMember = true
+		gs.askedGroup = ""
+		assert.False(t, rb.allowSendToChannel("bot_a", malformed, topicType),
+			"子区 channelID %q 形状不合法时必须拒绝", malformed)
+		assert.Empty(t, gs.askedGroup,
+			"%q 形状不合法却发起了成员查询——说明解析器放行了一个下游会拒的 ID", malformed)
+	}
 
 	// 未知类型仍然一律拒——放宽只针对 type 5。
 	assert.False(t, rb.allowSendToChannel("bot_a", "whatever", 99),

--- a/modules/robot/stream_card_gate_test.go
+++ b/modules/robot/stream_card_gate_test.go
@@ -78,17 +78,31 @@ func seedGroup(t *testing.T, ctx *libconfig.Context, groupNo string, status int)
 // The interface is embedded rather than fully implemented — every other method
 // is nil and would panic if reached, which is the point: if this stub ever needs
 // a second method, the handler started doing something this test does not model.
+//
+// **The two membership predicates return separate fields on purpose.** They are
+// not interchangeable: ExistMember filters is_deleted=0 only, ExistMemberActive
+// also requires status=Normal, and the subarea gate must use the latter so a
+// blacklisted bot cannot post (round-8 review P1). A stub with one shared result
+// would answer both identically, so a test could not tell which one the handler
+// called and swapping them back would stay green. askedMethod records the choice
+// itself rather than only its outcome.
 type stubGroupService struct {
 	group.IService
-	askedUID   string
-	askedGroup string
-	member     bool
+	askedUID     string
+	askedGroup   string
+	askedMethod  string // "ExistMember" | "ExistMemberActive"
+	member       bool   // ExistMember result — is_deleted=0 only
+	activeMember bool   // ExistMemberActive result — also status=Normal
 }
 
 func (s *stubGroupService) ExistMember(groupNo string, uid string) (bool, error) {
-	s.askedUID = uid
-	s.askedGroup = groupNo
+	s.askedUID, s.askedGroup, s.askedMethod = uid, groupNo, "ExistMember"
 	return s.member, nil
+}
+
+func (s *stubGroupService) ExistMemberActive(groupNo string, uid string) (bool, error) {
+	s.askedUID, s.askedGroup, s.askedMethod = uid, groupNo, "ExistMemberActive"
+	return s.activeMember, nil
 }
 
 // postStreamStart sends one stream/start carrying the given raw payload bytes.
@@ -312,7 +326,7 @@ func TestStreamStart_ChannelCheckPrecedesTheCardGate(t *testing.T) {
 func TestAllowSendToChannel_CommunityTopicResolvesParentGroup(t *testing.T) {
 	_, ctx := testutil.NewTestServer()
 
-	gs := &stubGroupService{member: true}
+	gs := &stubGroupService{member: true, activeMember: true}
 	rb := &Robot{ctx: ctx, Log: log.NewTLog("RobotAllowSendTest"), groupService: gs}
 	// 用常量而非字面量 5：常量若改值，字面量会让这条测试静默改测另一种频道。
 	topicType := common.ChannelTypeCommunityTopic.Uint8()
@@ -322,12 +336,12 @@ func TestAllowSendToChannel_CommunityTopicResolvesParentGroup(t *testing.T) {
 	assert.Equal(t, "parent_group_1", gs.askedGroup,
 		"成员查询用的不是父群号——拿整个子区 channelID 去查会永远落空")
 
-	gs.member = false
+	gs.activeMember = false
 	assert.False(t, rb.allowSendToChannel("bot_a", "parent_group_1____topic_9", topicType),
 		"非父群成员必须被拒")
 
 	// 形状不合法 → fail-closed，且不得把畸形串当群号去查。
-	gs.member = true
+	gs.activeMember = true
 	gs.askedGroup = ""
 	assert.False(t, rb.allowSendToChannel("bot_a", "no_separator_here", topicType),
 		"子区 channelID 形状不合法时必须拒绝")
@@ -349,7 +363,7 @@ func TestAllowSendToChannel_CommunityTopicResolvesParentGroup(t *testing.T) {
 // 因为断言的是「没被频道门拒」而通过，但它证明的东西比名字承诺的少。第一版就是这样过的。
 func TestStreamStart_CommunityTopicFlowsThroughBothGates(t *testing.T) {
 	handler, gs, ctx := streamGateHarness(t)
-	gs.member = true // 父群成员
+	gs.activeMember = true // 父群活跃成员
 	seedGroup(t, ctx, "streamgate_group", 1)
 
 	w := postStreamStartTo(t, handler, "streamgate_group____topic_1",
@@ -377,7 +391,7 @@ func TestStreamStart_CommunityTopicFlowsThroughBothGates(t *testing.T) {
 // 「守卫存在」和「守卫永远放行」就分不出来。
 func TestStreamStart_CommunityTopicDisbandGuardIsLive(t *testing.T) {
 	handler, gs, ctx := streamGateHarness(t)
-	gs.member = true // 成员判定放行，只留解散这一个变量
+	gs.activeMember = true // 成员判定放行，只留解散这一个变量
 	seedGroup(t, ctx, "streamgate_dead", group.GroupStatusDisband)
 
 	w := postStreamStartTo(t, handler, "streamgate_dead____topic_1",
@@ -385,4 +399,32 @@ func TestStreamStart_CommunityTopicDisbandGuardIsLive(t *testing.T) {
 
 	assert.Equal(t, "err.server.robot.group_disbanded", streamGateErrorCode(w),
 		"父群已解散仍放行开流，body=%s", w.Body.String())
+}
+
+// TestAllowSendToChannel_CommunityTopicRefusesBlacklistedMember —— round-8 评审 P1。
+//
+// 这条用例把两个谓词的差别做成**唯一变量**：`member=true, activeMember=false` 正是被拉黑
+// 成员在库里的样子（`is_deleted=0` 通过、`status=Blacklist` 不通过）。用 ExistMember 判定
+// 会放行，用 ExistMemberActive 会拒绝——所以它守的不是「拒绝」这个结果，而是**选了哪个
+// 谓词**。只断言结果的话，把代码换回 ExistMember 而 stub 两个字段又恰好同值时，测试照绿。
+//
+// 为什么这条路必须用严格的那个：robot ingress 是服务端直发，不经过 IM datasource，拿不到
+// thread 模块的子区拉黑继承，本地这道门就是唯一防线。group/service.go 上 ExistMemberActive
+// 的注释点名了子区场景，thread / message / messages_search / bot_api 的每一处子区门禁也都
+// 用它——本函数曾是全仓唯一的例外。
+func TestAllowSendToChannel_CommunityTopicRefusesBlacklistedMember(t *testing.T) {
+	_, ctx := testutil.NewTestServer()
+
+	gs := &stubGroupService{member: true, activeMember: false} // 在群里，但被拉黑
+	rb := &Robot{ctx: ctx, Log: log.NewTLog("RobotBlacklistTest"), groupService: gs}
+
+	allowed := rb.allowSendToChannel("bot_a", "parent_group_1____topic_9",
+		common.ChannelTypeCommunityTopic.Uint8())
+
+	assert.False(t, allowed,
+		"被拉黑成员被放行进子区——说明走的是 ExistMember（只看 is_deleted）而非 ExistMemberActive")
+	assert.Equal(t, "ExistMemberActive", gs.askedMethod,
+		"子区门禁必须调 ExistMemberActive；调 ExistMember 会让被拉黑成员通过，"+
+			"且这条路绕过 IM 层的子区拉黑继承，本地判定是唯一防线")
+	assert.Equal(t, "parent_group_1", gs.askedGroup, "活跃成员判定必须落在父群上")
 }

--- a/modules/robot/stream_card_gate_test.go
+++ b/modules/robot/stream_card_gate_test.go
@@ -226,3 +226,39 @@ func TestStreamStart_ChecksChannelPermission(t *testing.T) {
 	assert.Equal(t, "err.server.robot.channel_send_forbidden", streamGateErrorCode(w),
 		"非群成员必须被拒，且与 sendMessage 用同一个码，body=%s", w.Body.String())
 }
+
+// TestStreamStart_ChannelCheckPrecedesTheCardGate —— 顺序也是契约。
+//
+// 一个**非群成员**发一张卡：两道门都会拒，但必须是频道门先答。sendMessage 的顺序就是
+// allowSendToChannel 在 payloadIsVail 之前——先确定有没有资格往这里发，再看发的是什么。
+// 本分支为同一条原则改过一次：settings 端点的属主校验被连提三轮后前移到形状校验之前，
+// 理由是「对无权资源先就内容表态，与端点自述的 403 语义矛盾」。
+//
+// 没有这条用例，两道门的相对位置就是无人防守的：任谁为了省一次 DB 查询把拒卡挪到前面，
+// 全部既有用例照样绿——因为每一条都只触发其中一道门。
+func TestStreamStart_ChannelCheckPrecedesTheCardGate(t *testing.T) {
+	handler, gs := streamGateHarness(t)
+	gs.member = false // 非群成员：频道门会拒
+
+	card := []byte(`{"type":17,"card_version":"1.0","profile":"octo/v1",` +
+		`"card":{"type":"AdaptiveCard","version":"1.5","body":[{"type":"TextBlock","text":"x"}]}}`)
+	body, err := json.Marshal(libconfig.MessageStreamStartReq{
+		ClientMsgNo: "streamgate-order",
+		FromUID:     streamGateRobotID,
+		ChannelID:   "streamgate_group",
+		ChannelType: 2,
+		Payload:     card, // 卡片门也会拒
+	})
+	assert.NoError(t, err)
+
+	w := httptest.NewRecorder()
+	req, err := http.NewRequest("POST",
+		"/v1/robots/"+streamGateRobotID+"/appkey/stream/start", bytes.NewReader(body))
+	assert.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, "err.server.robot.channel_send_forbidden", streamGateErrorCode(w),
+		"卡片门抢在频道门前面答了：等于在鉴权之前就对内容表态，与 sendMessage 的顺序相反。"+
+			"body=%s", w.Body.String())
+}

--- a/modules/robot/stream_card_gate_test.go
+++ b/modules/robot/stream_card_gate_test.go
@@ -18,6 +18,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/Mininglamp-OSS/octo-lib/common"
 	libconfig "github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
@@ -46,7 +47,7 @@ const streamGateRobotID = "streamgate_bot"
 // Setup-time CleanAllTables only, never on exit: every sibling setup in this
 // package cleans before it runs, and cleaning afterwards instead puts the wipe
 // between some other test's setup and its assertions once the order shuffles.
-func streamGateHarness(t *testing.T) (*wkhttp.WKHttp, *stubGroupService) {
+func streamGateHarness(t *testing.T) (*wkhttp.WKHttp, *stubGroupService, *libconfig.Context) {
 	t.Helper()
 	_, ctx := testutil.NewTestServer()
 
@@ -55,7 +56,19 @@ func streamGateHarness(t *testing.T) (*wkhttp.WKHttp, *stubGroupService) {
 	r := wkhttp.New()
 	r.SetErrorRenderer(i18n.NewErrorRenderer(i18n.NewLocalizer(i18n.DefaultLanguage)))
 	r.POST("/v1/robots/:robot_id/:app_key/stream/start", rb.streamStart)
-	return r, gs
+	return r, gs, ctx
+}
+
+// seedGroup inserts the parent group row the disband guard reads. Needed only by
+// the subarea cases: the guard is skipped for Person and, for Group, these cases
+// never get past the channel stub.
+func seedGroup(t *testing.T, ctx *libconfig.Context, groupNo string, status int) {
+	t.Helper()
+	_, err := ctx.DB().InsertBySql(
+		"INSERT INTO `group`(group_no, name, status, space_id) VALUES(?, ?, ?, '')",
+		groupNo, groupNo, status,
+	).Exec()
+	assert.NoError(t, err)
 }
 
 // stubGroupService records which uid allowSendToChannel asked about, which is
@@ -102,6 +115,28 @@ func postStreamStart(t *testing.T, handler http.Handler, payload []byte) *httpte
 	return w
 }
 
+// postStreamStartTo is postStreamStart with the channel under test's control,
+// for the subarea cases.
+func postStreamStartTo(t *testing.T, handler http.Handler, channelID string, channelType uint8, payload []byte) *httptest.ResponseRecorder {
+	t.Helper()
+	body, err := json.Marshal(libconfig.MessageStreamStartReq{
+		ClientMsgNo: "streamgate-topic",
+		FromUID:     streamGateRobotID,
+		ChannelID:   channelID,
+		ChannelType: channelType,
+		Payload:     payload,
+	})
+	assert.NoError(t, err)
+
+	w := httptest.NewRecorder()
+	req, err := http.NewRequest("POST",
+		"/v1/robots/"+streamGateRobotID+"/appkey/stream/start", bytes.NewReader(body))
+	assert.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	handler.ServeHTTP(w, req)
+	return w
+}
+
 func streamGateErrorCode(w *httptest.ResponseRecorder) string {
 	var envelope struct {
 		Error struct {
@@ -121,7 +156,7 @@ func streamGateErrorCode(w *httptest.ResponseRecorder) string {
 // 同一个 Bot 换这个端点仍能把 type:17 送出去——本任务承诺「每条已鉴权的发卡路径都按有效
 // 配置校验」，少一条这个承诺就是假的。
 func TestStreamStart_RefusesCardPayload(t *testing.T) {
-	handler, _ := streamGateHarness(t)
+	handler, _, _ := streamGateHarness(t)
 
 	card := []byte(`{"type":17,"card_version":"1.0","profile":"octo/v1",` +
 		`"card":{"type":"AdaptiveCard","version":"1.5","body":[{"type":"TextBlock","text":"x"}]}}`)
@@ -137,7 +172,7 @@ func TestStreamStart_RefusesCardPayload(t *testing.T) {
 // 断言「没有被**这道门**拒掉」，而不是「返回 200」：放行之后请求会一路走到 WuKongIM，
 // 其成败取决于 IM 侧状态，拿它当断言会把一条门禁测试变成环境测试。
 func TestStreamStart_TextPayloadIsNotRefusedByTheCardGate(t *testing.T) {
-	handler, _ := streamGateHarness(t)
+	handler, _, _ := streamGateHarness(t)
 
 	w := postStreamStart(t, handler, []byte(`{"type":1,"content":"hello"}`))
 
@@ -157,7 +192,7 @@ func TestStreamStart_TextPayloadIsNotRefusedByTheCardGate(t *testing.T) {
 // 字符串 type 能否被客户端渲染成卡片是仓外事实（见 journal known-gaps）。哪天答案是
 // 「能」，本用例会连同 sendMessage 侧一起改，而不是让人误以为这里已经覆盖了。
 func TestStreamStart_StringTypedPayloadIsNotACard(t *testing.T) {
-	handler, _ := streamGateHarness(t)
+	handler, _, _ := streamGateHarness(t)
 
 	w := postStreamStart(t, handler, []byte(`{"type":"17","card":{}}`))
 
@@ -178,7 +213,7 @@ func TestStreamStart_StringTypedPayloadIsNotACard(t *testing.T) {
 // 断言的是 stub 记下的 uid，而不是最终状态码：拿状态码当证据的话，「拒绝」既可能因为
 // 钉住生效、也可能因为 victim 恰好也不在群里，两种原因给出同一个绿灯。
 func TestStreamStart_PinsFromUIDToTheAuthenticatedRobot(t *testing.T) {
-	handler, gs := streamGateHarness(t)
+	handler, gs, _ := streamGateHarness(t)
 	gs.member = true // 成员判定放行，把频道门从断言里摘掉，只留身份这一个变量
 
 	body, err := json.Marshal(libconfig.MessageStreamStartReq{
@@ -206,7 +241,7 @@ func TestStreamStart_PinsFromUIDToTheAuthenticatedRobot(t *testing.T) {
 // 与上一条分开：上一条问「按谁的身份查」，这条问「查不过时会不会拒」。合成一条的话，
 // 任何一半坏掉都被另一半的绿灯掩盖。
 func TestStreamStart_ChecksChannelPermission(t *testing.T) {
-	handler, gs := streamGateHarness(t)
+	handler, gs, _ := streamGateHarness(t)
 	gs.member = false // 非群成员
 
 	body, err := json.Marshal(libconfig.MessageStreamStartReq{
@@ -239,7 +274,7 @@ func TestStreamStart_ChecksChannelPermission(t *testing.T) {
 // 没有这条用例，两道门的相对位置就是无人防守的：任谁为了省一次 DB 查询把拒卡挪到前面，
 // 全部既有用例照样绿——因为每一条都只触发其中一道门。
 func TestStreamStart_ChannelCheckPrecedesTheCardGate(t *testing.T) {
-	handler, gs := streamGateHarness(t)
+	handler, gs, _ := streamGateHarness(t)
 	gs.member = false // 非群成员：频道门会拒
 
 	card := []byte(`{"type":17,"card_version":"1.0","profile":"octo/v1",` +
@@ -279,20 +314,22 @@ func TestAllowSendToChannel_CommunityTopicResolvesParentGroup(t *testing.T) {
 
 	gs := &stubGroupService{member: true}
 	rb := &Robot{ctx: ctx, Log: log.NewTLog("RobotAllowSendTest"), groupService: gs}
+	// 用常量而非字面量 5：常量若改值，字面量会让这条测试静默改测另一种频道。
+	topicType := common.ChannelTypeCommunityTopic.Uint8()
 
-	assert.True(t, rb.allowSendToChannel("bot_a", "parent_group_1____topic_9", 5),
+	assert.True(t, rb.allowSendToChannel("bot_a", "parent_group_1____topic_9", topicType),
 		"父群成员必须被允许向子区发送")
 	assert.Equal(t, "parent_group_1", gs.askedGroup,
 		"成员查询用的不是父群号——拿整个子区 channelID 去查会永远落空")
 
 	gs.member = false
-	assert.False(t, rb.allowSendToChannel("bot_a", "parent_group_1____topic_9", 5),
+	assert.False(t, rb.allowSendToChannel("bot_a", "parent_group_1____topic_9", topicType),
 		"非父群成员必须被拒")
 
 	// 形状不合法 → fail-closed，且不得把畸形串当群号去查。
 	gs.member = true
 	gs.askedGroup = ""
-	assert.False(t, rb.allowSendToChannel("bot_a", "no_separator_here", 5),
+	assert.False(t, rb.allowSendToChannel("bot_a", "no_separator_here", topicType),
 		"子区 channelID 形状不合法时必须拒绝")
 	assert.Empty(t, gs.askedGroup, "形状不合法时不该发起成员查询")
 
@@ -301,34 +338,51 @@ func TestAllowSendToChannel_CommunityTopicResolvesParentGroup(t *testing.T) {
 		"未知频道类型必须继续拒绝")
 }
 
-// TestStreamStart_CommunityTopicIsNotRefusedByTheChannelGate —— round-8 评审的回归。
+// TestStreamStart_CommunityTopicFlowsThroughBothGates —— round-8 评审的回归。
 //
 // 加频道校验之前，streamStart 是三条 robot 路里唯一子区能发的（因为它压根没校验）。
-// 补上校验后，allowSendToChannel 不认 type 5，子区流式立刻变成 403 —— 一个子区助手用
-// 流式增量回复正是最自然的用法。评审指出这一点时没有测试守着，因为原有用例只覆盖了
-// type 1 和 type 2。
-func TestStreamStart_CommunityTopicIsNotRefusedByTheChannelGate(t *testing.T) {
-	handler, gs := streamGateHarness(t)
+// 补上校验后 allowSendToChannel 不认 type 5，子区流式立刻 403 —— 而子区助手用流式增量
+// 回复正是最自然的用法。原有用例只覆盖 type 1 和 2，所以没人拦住。
+//
+// **父群行必须先插进去**：修好频道门之后，那个此前不可达的子区解散守卫第一次被执行，
+// 它会去查 `group` 表。不插这一行的话，请求会在守卫里以 query_failed 结束——本用例仍会
+// 因为断言的是「没被频道门拒」而通过，但它证明的东西比名字承诺的少。第一版就是这样过的。
+func TestStreamStart_CommunityTopicFlowsThroughBothGates(t *testing.T) {
+	handler, gs, ctx := streamGateHarness(t)
 	gs.member = true // 父群成员
+	seedGroup(t, ctx, "streamgate_group", 1)
 
-	body, err := json.Marshal(libconfig.MessageStreamStartReq{
-		ClientMsgNo: "streamgate-topic",
-		FromUID:     streamGateRobotID,
-		ChannelID:   "streamgate_group____topic_1",
-		ChannelType: 5,
-		Payload:     []byte(`{"type":1,"content":"hello"}`),
-	})
-	assert.NoError(t, err)
+	w := postStreamStartTo(t, handler, "streamgate_group____topic_1",
+		common.ChannelTypeCommunityTopic.Uint8(), []byte(`{"type":1,"content":"hello"}`))
 
-	w := httptest.NewRecorder()
-	req, err := http.NewRequest("POST",
-		"/v1/robots/"+streamGateRobotID+"/appkey/stream/start", bytes.NewReader(body))
-	assert.NoError(t, err)
-	req.Header.Set("Content-Type", "application/json")
-	handler.ServeHTTP(w, req)
-
-	assert.NotEqual(t, "err.server.robot.channel_send_forbidden", streamGateErrorCode(w),
-		"父群成员的子区流式被频道门拒了，body=%s", w.Body.String())
 	assert.Equal(t, "streamgate_group", gs.askedGroup,
 		"子区成员判定必须落在父群上")
+	for _, refusal := range []string{
+		"err.server.robot.channel_send_forbidden",
+		"err.server.robot.group_disbanded",
+		"err.server.robot.query_failed",
+	} {
+		assert.NotEqual(t, refusal, streamGateErrorCode(w),
+			"父群成员向未解散子区开流被 %s 拦下了，body=%s", refusal, w.Body.String())
+	}
+}
+
+// TestStreamStart_CommunityTopicDisbandGuardIsLive —— 覆盖被本次改动**激活**的代码。
+//
+// 三个 handler 各有一个解析父群的子区解散守卫，在 allowSendToChannel 认识 type 5 之前
+// 全是死代码——一行都跑不到。修好频道门等于把它们同时启用了，而启用一段从未执行过的分支
+// 却不测它，正是「改动看起来没风险」最容易出事的地方。
+//
+// 与上一条配对：上一条证明未解散的子区能过，这一条证明已解散的过不去。少了任何一条，
+// 「守卫存在」和「守卫永远放行」就分不出来。
+func TestStreamStart_CommunityTopicDisbandGuardIsLive(t *testing.T) {
+	handler, gs, ctx := streamGateHarness(t)
+	gs.member = true // 成员判定放行，只留解散这一个变量
+	seedGroup(t, ctx, "streamgate_dead", group.GroupStatusDisband)
+
+	w := postStreamStartTo(t, handler, "streamgate_dead____topic_1",
+		common.ChannelTypeCommunityTopic.Uint8(), []byte(`{"type":1,"content":"hello"}`))
+
+	assert.Equal(t, "err.server.robot.group_disbanded", streamGateErrorCode(w),
+		"父群已解散仍放行开流，body=%s", w.Body.String())
 }


### PR DESCRIPTION
## Summary

Bot-level configuration in this repo has meant adding another column to `robot` — `inline_on`, `auto_approve`, `placeholder`, `bot_commands` and `app_bot.welcome_msg` are all that shape. That table started at 7 columns and has accumulated a dozen more, mixing identity, credentials, reported metadata and product config, and every new switch costs an `ALTER` that a rolling deploy needs a hand-written concurrency guard to survive.

This adds `bot_setting`, a sparse `(robot_id, key_name)` override table, plus a registry that is simultaneously the write whitelist, the owner-facing catalog, and the resolution chain — so a new config key is a registry entry, not a migration.

Resolution is **bot override → `system_setting` deployment default → code default**. Its first consumer is the four bot-level card switches, surfaced to producers through `GET /v1/bot/card/profile` and enforced independently on the send path.

**The diff also carries authorization work on `modules/robot` that the config store required and that review then extended** — see *Authorization changes* below. Those are the changes a reviewer should look at first; they are behaviour changes on pre-existing endpoints.

## Related Issue

Upstream request from `openclaw-channel-octo` (reasoning-progress card policy). No tracking issue in this repo.

## Linked Spec

`.octospec/tasks/bot-setting-store/brief.md` — with `context.yaml` recording the injected rules, and `.octospec/journal/shared/bot-setting-store.md` for the decisions and for what is deliberately deferred.

## Changes

### The config store

- **`bot_setting` table + registry** (`modules/robot/bot_setting.go`, `modules/robot/sql/20260806000001_bot_setting.sql`). Sparse override semantics: no row / empty value means "not configured", so **deleting an override falls back to the layer underneath rather than latching false**.
- **Owner endpoints** on `/v1/robot/:robot_id/settings` — `GET` (catalog + echo), `PUT` (batch write), `DELETE /:key` (drop one override, idempotent). Guarded by `assertRobotOwner`; `SharedUIDRateLimiter` mounted per route so the existing shared `auth` group is not altered.
- **Read returns `value` / `effective_value` / `source` separately.** Collapsing them would make "I chose off" indistinguishable from "I never set it", which is exactly what a restore-default control has to tell apart.
- **Four card switches.** `bot.card_enabled` is *derived* from `cardmsg.BotEnabled()` and rejects writes; `bot.display_enabled` / `bot.interaction_enabled` / `bot.reasoning_enabled` are owner-editable and default true.
- **`GET /v1/bot/card/profile`**: one additive `config` object carrying the already-AND-ed values. Every existing field untouched.
- **`Cache-Control: private, no-store`** on both reads, with `Vary` naming the header each route actually authenticates with (`token` for the user-session route, `Authorization` for the bot-token route). The profile body became per-bot while its URL stayed byte-identical for every caller.
- **`POST /v1/bot/sendMessage`** enforces the same config independently, collapsing every refusal into the existing generic `card_invalid`.
- **Deployment defaults** registered in `system_setting` under category `botcard`; `SettingBoolOK` added so a layered resolver can tell "explicitly false" from "unset".
- **Config writes enqueue a valueless typed bot event** so an adapter drops its cached profile immediately instead of waiting out a TTL.

### Authorization changes on `modules/robot` (behaviour changes on pre-existing endpoints)

These are outside what the title implies. The brief owns them explicitly (`brief.md`) and the journal records why each one landed here rather than in a follow-up.

- **`stream/start` pins `req.FromUID` to the authenticated `robot_id`.** It previously used the caller-supplied value, so an authenticated bot could open a stream as **any uid** — every sibling ingress (`sendMessage`, `typing`) already pinned it. Impersonation fix.
- **`stream/start` now calls `allowSendToChannel`.** It previously performed no channel authorization at all, so a bot could stream into a channel it is not a member of.
- **`stream/start` refuses card payloads** (`cardmsg.IsCardRawPayload`). It forwards `Payload []byte` verbatim to WuKongIM with no validation, so without this the per-bot card switches were bypassable through it. Refusing outright rather than rebuilding the `sendMessage` validation pipeline on a path whose purpose is incremental text — a second pipeline is a second thing to drift.
- **`allowSendToChannel` now accepts `ChannelTypeCommunityTopic`** (was refused as an unknown type), resolving the parent group and checking **`ExistMemberActive`** — the strict predicate every other subarea gate in the tree uses, which excludes blacklisted members. **Side effect: `sendMessage` and `typing` gain subarea support**, since all three share this predicate. The direction is permissive (type 5: always-refuse → active-parent-member), so nothing that sends today stops sending. It also makes three previously-unreachable subarea disband guards live.
- **`resolveParentGroupNo` delegates to `thread.ParseChannelID`** instead of a local `SplitN`. Now that it feeds an authorization decision, the gate and the delivery target must agree on what a subarea channel id is.
- **`payloadIsVail` routes the card branch on `cardmsg.IsCardPayload`** rather than the coercing `maputil.Data.Int("type")`. **Wire behaviour change:** a string-typed `{"type":"17"}` on the legacy robot ingress is now rejected where it was previously dispatched unvalidated (skipping the URL allowlist, node/depth caps, profile negotiation and these switches).

## Testing

Integration environment: MySQL 8 + Redis + WuKongIM v2.2.4, run per-package with the CI drop/create + `FLUSHALL` discipline at `utf8mb4_general_ci`.

- `go build ./...`, `go vet ./...` — clean
- `make i18n-extract-check`, `make i18n-lint` — clean (no new error codes; no raw error responses)
- `go test -race -shuffle=on` on `modules/robot`, `modules/bot_api`, `modules/common`, `modules/thread`, `modules/group` — ok
- `modules/robot`'s `NoLegacyResponseError` source guard extended with the new handler file and passing (`modules/bot_api` gained no new handler file, so its guard list is unchanged)

Every fix from review rounds 3 onward was verified by **reverting only that fix and confirming its test fails** — the discipline round 1 taught, when an atomicity test turned out to pass against the code it was written to catch.

New tests: resolution priority and source labelling, master-switch dominance, derived-key short-circuit, read/write bool-lexer identity literal by literal, registry shape, the manifest's two ref invariants, `AdvertisedRef` lookup, fail-closed-without-resolver, plus integration coverage of catalog/echo, override→delete→fallback, the global-default tier, every write rejection, the ownership guard (403/404), transaction rollback on a real mid-batch failure, and the empty-value-is-unconfigured case. For the authorization changes: `FromUID` pinning (asserted through which uid the channel check asks about), channel refusal, gate ordering, card refusal, the string-typed boundary, subarea parent-group resolution, the blacklisted-member refusal (asserting *which predicate was called*, not just the verdict), and the revived subarea disband guard in both directions.

- [x] Unit tests added/updated
- [x] Manually verified

## COMPREHENSION

**1. What does this change actually do to the load-bearing path?**

It inserts a per-bot policy lookup into two card paths that previously read only deployment constants. `GET /v1/bot/card/profile` gains a DB read and, with it, a failure mode it did not have: it was a pure constant after auth and could not fail, and it now returns `err.shared.internal` when the config cannot be resolved. That is deliberate — substituting defaults would re-open a capability the owner switched off, and would make the manifest disagree with the send gate for the duration of the blip — but **producers must retry rather than read an error as "capability off", and must branch on `error.code`, not the wire status**: `ResponseErrorL` pins the transport status to 400 with the real 500 in `error.http_status`.

`POST /v1/bot/sendMessage` gains a gate inside the existing `if cardIntent` block, so non-card sends are untouched. Both sides read `robot.IService.BotCardConfig`, so what the manifest advertises and what the send path accepts cannot drift.

On the robot module, `allowSendToChannel` becomes load-bearing for a channel type it previously refused outright, and `resolveParentGroupNo` becomes an authorization parser rather than an input to a disband guard.

Two invariants the code is responsible for: `card_enabled` is derived and unwritable, so the DB can never claim cards are on while the env has them off (that would break the manifest-agrees-with-the-send-gate contract `pkg/cardmsg` already established); and `reasoning_enabled=true` implies the advertised ref is one the send allowlist accepts, which holds by construction because both resolve through `AdvertisedRef` rather than naming a version.

**2. What could break because of it (dependents + failure mode)?**

- *Producers parsing the profile strictly.* The top-level field set grew by one. The existing `AdditiveContractFieldSet` guard caught this during development and was extended; `config`'s own five sub-fields are now frozen the same way `limits` is.
- *Producers treating a profile error as "off".* See above — this endpoint can now fail, and its transport status is 400 while the real status is 500.
- *Clients sending `type` as a JSON string to the legacy robot ingress.* `{"type":"17"}` now returns 400 instead of being delivered unvalidated. Blast radius is only observable from client telemetry.
- *Callers of `stream/start` that set a `from_uid` other than their own robot id* — it is now overwritten — *or that stream into channels they are not members of* — now 403 — *or that send card payloads through it* — now 400.
- *Malformed subarea channel ids* (`G____topic____extra`, `G____`, `____topic`) are now refused on type-5 paths rather than resolving a parent from a string the rest of the system considers invalid.
- *An operator expecting the deployment default to apply instantly.* Per-bot overrides are read from MySQL on every resolution, so they are immediately consistent across replicas. The middle tier inherits `system_setting`'s in-process snapshot with its 60s reload, so a **global** default takes up to a minute to reach every replica — and is best-effort by design (see the `SettingBoolOK` doc comment).
- *Existing bots.* None for the card switches: the three editable ones default true and the master switch is unchanged and still fail-closed, so a deployment that has not configured anything behaves exactly as before.
- *The one thing deliberately left ungated* is the **template branch** of `POST /v1/bot/message/edit`. Gating it would strand in-flight cards in a non-terminal state when the switch is turned off mid-stream. The **raw** branch of the same endpoint **is** gated — leaving it open was a privilege-escalation path (send `octo/v1`, then edit into an `octo/v2` frame carrying `Action.Submit`, which is the frame the action endpoint trusts).

**3. How do you know it works (specific test/repro/trace)?**

The priority chain, source labelling and master-switch dominance are pinned as pure functions (no DB), and the endpoint behaviour is covered end-to-end against a real MySQL/Redis/WuKongIM stack, including the negative cases — write to a derived key, unknown key, illegal literal, partially-invalid batch, and non-owner access.

Several defects were found and fixed during verification rather than assumed away:

- `-shuffle=on` failed on 2 of 4 seeds: `EnsureSystemSettings` is a process-wide singleton whose snapshot `CleanAllTables` does not touch, so a case writing a deployment default leaked it into later cases. Fixed in setup; staged as a learning because the `testing` rule already documents the same shape for Redis rate-limit buckets.
- Reviewing the hot path showed `EnsureSystemSettings` takes a process-wide mutex on **every** call, and it was being called per card send — defeating the lock-free `atomic.Pointer` read `SystemSettings` is built around. The singleton is now resolved once at construction and held on `Robot` / `Service`.
- Review found the same class of defect three times in a row — a shared rule re-implemented locally and more loosely than every other caller (the raw edit branch, the legacy robot ingress, then twice inside `allowSendToChannel`'s new subarea branch). Each was fixed by deleting the local implementation rather than tightening it. The journal records the generalisation.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] PR description is in English
- [x] Added tests for my changes
- [x] Updated documentation (octospec brief / journal / log)
- [x] Followed commit message conventions (Conventional Commits)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EpiuzpPoUjcWxsr9WjyCxH)_