### PR TITLE
feat(message): add DM single-message fetch endpoint (Closes #707)

### DIFF
--- a/modules/message/api.go
+++ b/modules/message/api.go
@@ -384,6 +384,9 @@ func (m *Message) Route(r *wkhttp.WKHttp) {
 	{
 		// messages.PUT("/:message_id/voicereaded", m.voiceReaded)
 		messages.GET("/:message_id/receipt", m.messageReceiptList) // 消息回执列表
+		// 单聊(DM)单条消息直查：peer_uid=对端 uid，服务端用调用者 loginUID 与之
+		// 对称派生 fakeChannelID 后查询（详见 getPersonMessage）。与群/子区直查并列。
+		messages.GET("/person/:peer_uid/:message_id", m.getPersonMessage)
 	}
 	// 回应。挂 SpaceMiddleware：Person(DM)是跨 Space 共享的同一物理频道，
 	// reaction 读/写必须与 /v1/message 一样按已校验的 Space 隔离 DM 消息，

--- a/modules/message/api.go
+++ b/modules/message/api.go
@@ -386,7 +386,15 @@ func (m *Message) Route(r *wkhttp.WKHttp) {
 		messages.GET("/:message_id/receipt", m.messageReceiptList) // 消息回执列表
 		// 单聊(DM)单条消息直查：peer_uid=对端 uid，服务端用调用者 loginUID 与之
 		// 对称派生 fakeChannelID 后查询（详见 getPersonMessage）。与群/子区直查并列。
-		messages.GET("/person/:peer_uid/:message_id", m.getPersonMessage)
+		//
+		// SpaceMiddleware(handler 级)：Person 是跨 Space 共享的同一物理频道，
+		// 单条 DM 读必须与 /v1/message/channel/sync 的 filterPersonMessagesBySpace
+		// 走同一套 personSpaceAllows 空间隔离（issue #484 / YUJ-219-A / GH#1283），
+		// 否则一方在非默认 Space 里可以按 msg_id 反查到 sync 路径会隐藏的跨 Space
+		// DM 消息元数据（含 ObjectPath / uploader / SystemBot 老消息等）。挂在
+		// 这条 handler 上而不是整个组，是为了不影响 /:message_id/receipt。
+		messages.GET("/person/:peer_uid/:message_id",
+			spacepkg.SpaceMiddleware(m.ctx), m.getPersonMessage)
 	}
 	// 回应。挂 SpaceMiddleware：Person(DM)是跨 Space 共享的同一物理频道，
 	// reaction 读/写必须与 /v1/message 一样按已校验的 Space 隔离 DM 消息，

--- a/modules/message/api_message_get.go
+++ b/modules/message/api_message_get.go
@@ -180,15 +180,16 @@ func (m *Message) getThreadMessage(c *wkhttp.Context) {
 // 场景。DM 消息物理存储在 fakeChannelID(= GetFakeChannelIDWith(两个uid) 对称生成的
 // "uidA@uidB") 频道下、channel_type=Person。
 //
-// 鉴权分四层（与 modules/messages_search/authz.go checkP2PAccess 一致）：
+// 鉴权与 modules/messages_search/authz.go checkP2PAccess 完整对齐（同一决策
+// 分散实现的历史坑参见 checkPersonDMAccess 头注释）：
 //   1. 基本参数：peer_uid 非空 / 非自聊 / 非 @ 分隔符（P1-3：GetFakeChannelIDWith
 //      内部用 "A@B" 拼接，若 peer_uid 自身含 @，多方 uid 组合会产生同一 fake key
 //      的跨会话碰撞，一律 400 拒）；message_id 正整数。
-//   2. P2P 访问：DM 无独立成员表，采用 same-space OR IsFriend 的"或"关系放行；
-//      两侧都不满足 → 404 归并（防枚举，与不可见同码）。（P1-4）
-//   3. 双向拉黑：任一方向 blacklist 存在即 404（本人偏好 + 反骚扰双语义）。
-//      直查绕过 IM kernel 的 blacklist filter，必须自查（P1-4）。
-//   4. Space 隔离 + respondSingleMessage 里的 visibles / 双删 / offset 全套过滤。
+//   2. P2P 访问 (checkPersonDMAccess)：peer-bot 分类 + real-user same-space/friend
+//      + 双向 blacklist——system bot (fileHelper/botfather 等) 和 own bot 都
+//      归 bot 分支，不走 real-user Space 检查（bot 无 space_member 行）。
+//   3. Space 隔离：real-user 消息按 personSpaceAllows 五规则过滤（issue #484）。
+//   4. respondSingleMessage 内的 visibles / 双删 / offset 全套过滤。
 //
 // fakeChannelID 参数顺序：使用 (peerUID, loginUID)，与 sibling 调用(api.go:1439
 // 等 sync 路径 = "req.ChannelID(=peer_uid), req.LoginUID") 严格对齐；避免碰撞对
@@ -269,29 +270,163 @@ func (m *Message) getPersonMessage(c *wkhttp.Context) {
 	m.respondSingleMessage(c, fakeChannelID, common.ChannelTypePerson.Uint8(), "", peerUID, messageID, loginUID)
 }
 
-// checkPersonDMAccess 复刻 modules/messages_search/authz.go checkP2PAccess 的
-// P2P DM 访问门禁：same-space OR IsFriend 放行 + 双向 blacklist 一票否决。
-// 任何不满足条件都 404 归并（与不可见同码，防枚举）。任何 DB 错误 → 500 fail-closed。
-// 返回 false 时已写响应（handler 直接 return）。
+// personDMAccessDecision 是 checkPersonDMAccess 的纯决策核心：接收所有 DB 已
+// 查出的输入，返回 allow / notFound / 具体分支（用于测试断言与日志）。抽出为
+// 纯函数以便 helper 级 table-driven 测试覆盖 8 条决策路径而无需 mock 38 个方法
+// 的 user.IService（PR #708 review round 3 P1-A/coverage 要求）。
 //
-// 与 checkP2PAccess 的差异：那边支持 as-bot principal 分支；此处 getPersonMessage
-// 的调用者都是真人 token（AuthMiddleware 之后），走真人分支即可。同意 same-space
-// 的空 spaceID 分支（未 opt-in / 兼容路径）：这时不做 same-space 判断，直接落到
-// IsFriend 兜底——与 authz 现有 real-user 分支同口径。
+// 决策次序（与 authz.go:99-207 checkP2PAccess 一致，多一层 SystemBot 短路，
+// 详见 checkPersonDMAccess 头注释里"Step 1a"的说明）：
+//
+//	self==peer                     → allow (notes-to-self)
+//	SystemBot(peer)                → check blacklist → allow/notFound
+//	own bot(peer)                  → allow (skip blacklist)
+//	other user's bot(peer)         → require friend, then check blacklist
+//	real user(peer)                → require same-space OR friend, then check blacklist
+//
+// 每一层 fail 都 fold 成 notFound（防枚举，与 authz.go 一致）。
+type personDMAccessInputs struct {
+	loginUID, peerUID string
+	isSystemBot       bool
+	isRobot           bool
+	creatorUID        string
+	spaceID           string // "" 表示未 opt-in，跳过 same-space
+	sameSpace         bool
+	isFriend          bool
+	blockedByMe       bool
+	blockedByPeer     bool
+}
+
+type personDMAccessResult int
+
+const (
+	personDMAllowNotesToSelf personDMAccessResult = iota
+	personDMAllowSystemBot
+	personDMAllowOwnBot
+	personDMAllowOtherBotFriend
+	personDMAllowRealUserSameSpace
+	personDMAllowRealUserFriend
+	personDMDenyOtherBotNotFriend
+	personDMDenyRealUserNoRelation
+	personDMDenyBlacklist
+)
+
+func personDMAccessDecision(in personDMAccessInputs) personDMAccessResult {
+	// Step 0: notes-to-self
+	if in.peerUID == in.loginUID {
+		return personDMAllowNotesToSelf
+	}
+
+	var allowed personDMAccessResult
+	switch {
+	case in.isSystemBot:
+		// SystemBot 短路，落到 Step 3 blacklist（仍然要执行拉黑检查）
+		allowed = personDMAllowSystemBot
+	case in.isRobot && in.creatorUID == in.loginUID:
+		// Own bot：直接放行，skip blacklist（与 authz.go:110-115 一致）
+		return personDMAllowOwnBot
+	case in.isRobot:
+		// Other user's bot：必须是好友；否则 404
+		if !in.isFriend {
+			return personDMDenyOtherBotNotFriend
+		}
+		allowed = personDMAllowOtherBotFriend
+	default:
+		// Real user：same-space OR friend
+		if in.spaceID != "" && in.sameSpace {
+			allowed = personDMAllowRealUserSameSpace
+		} else if in.isFriend {
+			allowed = personDMAllowRealUserFriend
+		} else {
+			return personDMDenyRealUserNoRelation
+		}
+	}
+
+	// Step 3: 双向 blacklist（own bot 已经在上面 return 跳过）
+	if in.blockedByMe || in.blockedByPeer {
+		return personDMDenyBlacklist
+	}
+	return allowed
+}
+
+func personDMAccessAllowed(r personDMAccessResult) bool {
+	switch r {
+	case personDMAllowNotesToSelf, personDMAllowSystemBot, personDMAllowOwnBot,
+		personDMAllowOtherBotFriend, personDMAllowRealUserSameSpace, personDMAllowRealUserFriend:
+		return true
+	}
+	return false
+}
+
+// checkPersonDMAccess 完整复刻 modules/messages_search/authz.go checkP2PAccess
+// 的 real-user DM 访问门禁：peer-bot 分类 + same-space OR IsFriend + 双向
+// blacklist。任何不满足条件都 404 归并（与不可见同码，防枚举）。DB 错误
+// → 500 fail-closed。返回 false 时已写响应（handler 直接 return）。
+//
+// **必须与 checkP2PAccess 保持每一步一致**：DM 直读绕过 IM kernel 的
+// blacklist filter，同一套访问决策要求分散实现是历史上 issue #484 / YUJ-219-A
+// 一类问题的温床；本 helper 是第二份手写实现，任何时候都对齐它的口径。若
+// 未来抽出跨模块公共 helper，两处一起替换。
+//
+// 已核实分支覆盖（决策核心在 personDMAccessDecision，被 personDMAccessDecision_test
+// 覆盖 8 条路径）：
+//   0. peer_uid == self（notes-to-self）：直接放行
+//   1a. SystemBot 短路（fileHelper 等）：落到 Step 3 blacklist
+//   1b. Step 1 peer-bot 分类（**必须先于 Space**）：own bot 放行；other bot
+//       走 IsFriend + 落到 Step 3 的 blacklist
+//   2. Step 2 real-user：same-space OR IsFriend
+//   3. Step 3 双向 blacklist 一票否决（own-bot 分支已跳过）
 func (m *Message) checkPersonDMAccess(c *wkhttp.Context, loginUID, peerUID string) bool {
-	// same-space OR friend 二选一放行
-	allowed := false
-	if spaceID := spacepkg.GetSpaceID(c); spaceID != "" {
-		sameSpace, serr := m.userService.AreSpaceMembers(spaceID, loginUID, peerUID)
-		if serr != nil {
-			m.Error("DM 直读 same-space 查询失败", zap.Error(serr),
-				zap.String("uid", loginUID), zap.String("peer", peerUID), zap.String("space_id", spaceID))
+	// 收集所有决策输入（DB 查询 + context 读取），然后交给纯决策函数。
+	in := personDMAccessInputs{
+		loginUID:    loginUID,
+		peerUID:     peerUID,
+		isSystemBot: spacepkg.IsSystemBot(peerUID),
+	}
+	if in.peerUID == in.loginUID {
+		return true // 上游已拒；defense-in-depth
+	}
+
+	// 只在非 SystemBot 时才需要 QueryPeerRobotInfo（Step 1a 短路避免误 404）。
+	if !in.isSystemBot {
+		isRobot, creatorUID, err := m.userService.QueryPeerRobotInfo(peerUID)
+		if err != nil {
+			m.Error("DM 直读 QueryPeerRobotInfo 查询失败", zap.Error(err),
+				zap.String("uid", loginUID), zap.String("peer", peerUID))
 			httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 			return false
 		}
-		allowed = sameSpace
+		in.isRobot = isRobot
+		in.creatorUID = creatorUID
 	}
-	if !allowed {
+
+	// Own bot 快通道：拿到 (isRobot=true, creatorUID==loginUID) 就直接放行，
+	// 避免为 own bot 白发一次 friend / same-space / blacklist 查询。
+	if in.isRobot && in.creatorUID == loginUID {
+		return true
+	}
+
+	// Real-user 分支才需要 same-space / friend 查询；bot 分支只需要 friend。
+	// 提前判断避免不必要的 DB 请求。
+	if !in.isSystemBot && !in.isRobot {
+		in.spaceID = spacepkg.GetSpaceID(c)
+		if in.spaceID != "" {
+			sameSpace, serr := m.userService.AreSpaceMembers(in.spaceID, loginUID, peerUID)
+			if serr != nil {
+				m.Error("DM 直读 same-space 查询失败", zap.Error(serr),
+					zap.String("uid", loginUID), zap.String("peer", peerUID), zap.String("space_id", in.spaceID))
+				httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
+				return false
+			}
+			in.sameSpace = sameSpace
+		}
+	}
+
+	// Friend 查询：real-user (若 !sameSpace 才需要) + other-user bot 需要。
+	// SystemBot 与 own bot 都不需要。
+	needFriend := (in.isRobot && !in.isSystemBot) ||
+		(!in.isSystemBot && !in.isRobot && !in.sameSpace)
+	if needFriend {
 		isFriend, ferr := m.userService.IsFriend(loginUID, peerUID)
 		if ferr != nil {
 			m.Error("DM 直读 IsFriend 查询失败", zap.Error(ferr),
@@ -299,14 +434,11 @@ func (m *Message) checkPersonDMAccess(c *wkhttp.Context, loginUID, peerUID strin
 			httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 			return false
 		}
-		allowed = isFriend
-	}
-	if !allowed {
-		httperr.ResponseErrorL(c, errcode.ErrMessageNotFound, nil, nil)
-		return false
+		in.isFriend = isFriend
 	}
 
-	// 双向 blacklist 一票否决。批量版一次查两向，性能好。
+	// Blacklist 查询：SystemBot / other bot / real-user 都需要（own bot 已在
+	// 上面 return true 跳过）。批量版一次查两向。
 	blockedByMe, blockedByPeer, err := m.userService.ExistBlacklistsBoth(loginUID, []string{peerUID})
 	if err != nil {
 		m.Error("DM 直读 blacklist 查询失败", zap.Error(err),
@@ -314,7 +446,11 @@ func (m *Message) checkPersonDMAccess(c *wkhttp.Context, loginUID, peerUID strin
 		httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 		return false
 	}
-	if blockedByMe[peerUID] || blockedByPeer[peerUID] {
+	in.blockedByMe = blockedByMe[peerUID]
+	in.blockedByPeer = blockedByPeer[peerUID]
+
+	result := personDMAccessDecision(in)
+	if !personDMAccessAllowed(result) {
 		httperr.ResponseErrorL(c, errcode.ErrMessageNotFound, nil, nil)
 		return false
 	}

--- a/modules/message/api_message_get.go
+++ b/modules/message/api_message_get.go
@@ -122,7 +122,7 @@ func (m *Message) getGroupMessage(c *wkhttp.Context) {
 	if !m.requireGroupMember(c, groupNo, loginUID) {
 		return
 	}
-	m.respondSingleMessage(c, groupNo, common.ChannelTypeGroup.Uint8(), groupNo, messageID, loginUID)
+	m.respondSingleMessage(c, groupNo, common.ChannelTypeGroup.Uint8(), groupNo, "", messageID, loginUID)
 }
 
 // getThreadMessage GET /v1/groups/:group_no/threads/:short_id/messages/:message_id
@@ -165,7 +165,7 @@ func (m *Message) getThreadMessage(c *wkhttp.Context) {
 	}
 
 	channelID := thread.BuildChannelID(groupNo, shortID)
-	m.respondSingleMessage(c, channelID, common.ChannelTypeCommunityTopic.Uint8(), groupNo, messageID, loginUID)
+	m.respondSingleMessage(c, channelID, common.ChannelTypeCommunityTopic.Uint8(), groupNo, "", messageID, loginUID)
 }
 
 // getPersonMessage GET /v1/messages/person/:peer_uid/:message_id
@@ -174,10 +174,25 @@ func (m *Message) getThreadMessage(c *wkhttp.Context) {
 // 场景。DM 消息物理存储在 fakeChannelID(= GetFakeChannelIDWith(两个uid) 对称生成的
 // "uidA@uidB") 频道下、channel_type=Person。
 //
-// 鉴权：DM 无独立成员表，fakeChannelID 由调用者 loginUID 与对端 peerUID 对称派生，
-// 「能派生出这个频道」本身即代表 loginUID 是该 DM 的一方；配合 respondSingleMessage
-// 内的 visibles / 双删 / offset 全套可见性校验(与批量同步路径一致)，非参与方既拼不出
-// 命中的 fakeChannelID、也过不了可见性过滤，一律 404。禁止自聊(peer==self)。
+// getPersonMessage GET /v1/messages/person/:peer_uid/:message_id
+//
+// 单聊(DM)单条消息直查，用于云盘转存等需要按 (会话, 消息ID) 取单条消息元数据的
+// 场景。DM 消息物理存储在 fakeChannelID(= GetFakeChannelIDWith(两个uid) 对称生成的
+// "uidA@uidB") 频道下、channel_type=Person。
+//
+// 鉴权分四层（与 modules/messages_search/authz.go checkP2PAccess 一致）：
+//   1. 基本参数：peer_uid 非空 / 非自聊 / 非 @ 分隔符（P1-3：GetFakeChannelIDWith
+//      内部用 "A@B" 拼接，若 peer_uid 自身含 @，多方 uid 组合会产生同一 fake key
+//      的跨会话碰撞，一律 400 拒）；message_id 正整数。
+//   2. P2P 访问：DM 无独立成员表，采用 same-space OR IsFriend 的"或"关系放行；
+//      两侧都不满足 → 404 归并（防枚举，与不可见同码）。（P1-4）
+//   3. 双向拉黑：任一方向 blacklist 存在即 404（本人偏好 + 反骚扰双语义）。
+//      直查绕过 IM kernel 的 blacklist filter，必须自查（P1-4）。
+//   4. Space 隔离 + respondSingleMessage 里的 visibles / 双删 / offset 全套过滤。
+//
+// fakeChannelID 参数顺序：使用 (peerUID, loginUID)，与 sibling 调用(api.go:1439
+// 等 sync 路径 = "req.ChannelID(=peer_uid), req.LoginUID") 严格对齐；避免碰撞对
+// (CRC32 tie) 场景下同一对话在读/写两侧生成不同 key（P2, PR #708 review）。
 func (m *Message) getPersonMessage(c *wkhttp.Context) {
 	peerUID := c.Param("peer_uid")
 	messageIDStr := c.Param("message_id")
@@ -191,12 +206,31 @@ func (m *Message) getPersonMessage(c *wkhttp.Context) {
 		respondMessageRequestInvalid(c, "peer_uid")
 		return
 	}
+	// P1-3: peer_uid 含 @ 会与 GetFakeChannelIDWith 的 "A@B" 拼接语义碰撞：
+	//   GetFakeChannelIDWith("alice@bob", "carol") == GetFakeChannelIDWith("alice", "bob@carol")
+	//   == "alice@bob@carol"
+	// 允许含 @ 的 peer_uid 会让一条 DM 消息被"多种 (loginUID, peer_uid) 组合"取到，
+	// 变成跨会话读。直接 400 拒。
+	if strings.Contains(peerUID, "@") {
+		respondMessageRequestInvalid(c, "peer_uid")
+		return
+	}
 	messageID, ok := parsePositiveMessageID(messageIDStr)
 	if !ok {
 		respondMessageRequestInvalid(c, "message_id")
 		return
 	}
-	fakeChannelID := common.GetFakeChannelIDWith(loginUID, peerUID)
+
+	// P1-4: P2P 访问 + 双向拉黑门禁。DM 直读绕过 IM kernel 的
+	// blacklist / friend / space filter，必须在应用层自查，形成与
+	// modules/messages_search/authz.go:139-207 checkP2PAccess 一致的四层门禁：
+	// same-space OR friend 二选一放行，双向 blacklist 一票否决。任何一层
+	// 不满足都 404 归并（防枚举）。
+	if !m.checkPersonDMAccess(c, loginUID, peerUID) {
+		return
+	}
+
+	fakeChannelID := common.GetFakeChannelIDWith(peerUID, loginUID)
 
 	// Person(DM) Space 隔离：DM 是跨 Space 共享的同一物理频道，单条 DM 读必须与
 	// /v1/message/channel/sync 的 filterPersonMessagesBySpace 走同一套
@@ -230,7 +264,61 @@ func (m *Message) getPersonMessage(c *wkhttp.Context) {
 		}
 	}
 
-	m.respondSingleMessage(c, fakeChannelID, common.ChannelTypePerson.Uint8(), "", messageID, loginUID)
+	// personPeerUID 传 peerUID：respondSingleMessage 里的用户级 channel_offset
+	// 表（清历史）用 bare peer uid 作 key，不是 fakeChannelID (P1-1a)。
+	m.respondSingleMessage(c, fakeChannelID, common.ChannelTypePerson.Uint8(), "", peerUID, messageID, loginUID)
+}
+
+// checkPersonDMAccess 复刻 modules/messages_search/authz.go checkP2PAccess 的
+// P2P DM 访问门禁：same-space OR IsFriend 放行 + 双向 blacklist 一票否决。
+// 任何不满足条件都 404 归并（与不可见同码，防枚举）。任何 DB 错误 → 500 fail-closed。
+// 返回 false 时已写响应（handler 直接 return）。
+//
+// 与 checkP2PAccess 的差异：那边支持 as-bot principal 分支；此处 getPersonMessage
+// 的调用者都是真人 token（AuthMiddleware 之后），走真人分支即可。同意 same-space
+// 的空 spaceID 分支（未 opt-in / 兼容路径）：这时不做 same-space 判断，直接落到
+// IsFriend 兜底——与 authz 现有 real-user 分支同口径。
+func (m *Message) checkPersonDMAccess(c *wkhttp.Context, loginUID, peerUID string) bool {
+	// same-space OR friend 二选一放行
+	allowed := false
+	if spaceID := spacepkg.GetSpaceID(c); spaceID != "" {
+		sameSpace, serr := m.userService.AreSpaceMembers(spaceID, loginUID, peerUID)
+		if serr != nil {
+			m.Error("DM 直读 same-space 查询失败", zap.Error(serr),
+				zap.String("uid", loginUID), zap.String("peer", peerUID), zap.String("space_id", spaceID))
+			httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
+			return false
+		}
+		allowed = sameSpace
+	}
+	if !allowed {
+		isFriend, ferr := m.userService.IsFriend(loginUID, peerUID)
+		if ferr != nil {
+			m.Error("DM 直读 IsFriend 查询失败", zap.Error(ferr),
+				zap.String("uid", loginUID), zap.String("peer", peerUID))
+			httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
+			return false
+		}
+		allowed = isFriend
+	}
+	if !allowed {
+		httperr.ResponseErrorL(c, errcode.ErrMessageNotFound, nil, nil)
+		return false
+	}
+
+	// 双向 blacklist 一票否决。批量版一次查两向，性能好。
+	blockedByMe, blockedByPeer, err := m.userService.ExistBlacklistsBoth(loginUID, []string{peerUID})
+	if err != nil {
+		m.Error("DM 直读 blacklist 查询失败", zap.Error(err),
+			zap.String("uid", loginUID), zap.String("peer", peerUID))
+		httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
+		return false
+	}
+	if blockedByMe[peerUID] || blockedByPeer[peerUID] {
+		httperr.ResponseErrorL(c, errcode.ErrMessageNotFound, nil, nil)
+		return false
+	}
+	return true
 }
 
 // parsePositiveMessageID 校验 path 参数 message_id 为正整数。
@@ -296,7 +384,15 @@ func (m *Message) requireGroupMember(c *wkhttp.Context, groupNo, loginUID string
 //
 // groupNoForEnrich 仅在群消息（channelType=Group）时用作 enrichExternalMarkers 的
 // 父群定位参数；子区消息这一参数无效（enrich 函数本身按消息 channel_type 分派）。
-func (m *Message) respondSingleMessage(c *wkhttp.Context, channelID string, channelType uint8, groupNoForEnrich string, messageID int64, loginUID string) {
+//
+// personPeerUID 仅在 Person(DM) 直查时非空，用于用户级 channel_offset 表的 lookup：
+// 用户清历史通过 POST /v1/message/offset 写 channel_offset，DM 场景 writer 存的
+// ChannelID 是**对端 bare peer uid**（modules/message/api.go:2821，与 sync 读侧
+// api.go:3575 一致），不是消息物理存储用的 fakeChannelID。因此 Person 单条直查
+// 用 channelID (== fakeChannelID) 去 queryWithUIDAndChannel 恒 miss、绕过用户级
+// 历史清理——必须传 peer uid 才能命中同一行 (P1-1a, PR #708 review round 2)。
+// Group/Thread 无 fake，channelID 本身就是 physical id，personPeerUID 保持空即可。
+func (m *Message) respondSingleMessage(c *wkhttp.Context, channelID string, channelType uint8, groupNoForEnrich, personPeerUID string, messageID int64, loginUID string) {
 	// VARCHAR(20) 列必须用字符串绑定才能命中索引；详见 queryMessageByID 注释。
 	messageIDStr := strconv.FormatInt(messageID, 10)
 	msgModel, err := m.db.queryMessageByID(channelID, channelType, messageIDStr)
@@ -340,7 +436,16 @@ func (m *Message) respondSingleMessage(c *wkhttp.Context, channelID string, chan
 	// 内按此跳过 message_seq <= offset 的消息；单条直查必须显式比对，否则用户清理
 	// 后还能按 ID 把旧消息读回来。注意这与 lookupChannelOffsetSeq 查的频道级
 	// channel_setting.offset_message_seq 是两张不同的表 / 两套语义，必须都查。
-	if userOffset, err := m.channelOffsetDB.queryWithUIDAndChannel(loginUID, channelID, channelType); err != nil {
+	//
+	// Person(DM) 场景 offset key: writer 存的 channel_id 是 bare peer uid
+	// (api.go:2821 `ChannelID: req.ChannelID` 直存)，不是消息物理 fakeChannelID；
+	// sync 读侧也用 bare peer uid (api.go:3575)。因此这里 Person 走 personPeerUID
+	// (非空)，其它类型 channelID 本身就是 physical id (P1-1a)。
+	userOffsetChannelID := channelID
+	if channelType == common.ChannelTypePerson.Uint8() && personPeerUID != "" {
+		userOffsetChannelID = personPeerUID
+	}
+	if userOffset, err := m.channelOffsetDB.queryWithUIDAndChannel(loginUID, userOffsetChannelID, channelType); err != nil {
 		m.Error("查询用户清理偏移失败", zap.Error(err))
 		httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
 		return
@@ -349,24 +454,11 @@ func (m *Message) respondSingleMessage(c *wkhttp.Context, channelID string, chan
 		return
 	}
 
-	channelOffsetSeq := uint32(0)
-	// Person 频道跳过 channel-level offset：对齐 cardCanonicalVisibleToViewer:550
-	// 的 Person 短路（"person 频道跳过偏移... 也避免对已是 fake id 的 person 频道
-	// 二次 fake 化"）。lookupChannelOffsetSeq 对 Person 会内部再做一次
-	// GetFakeChannelIDWith(channelID, loginUID)，那里期望入参是 peer uid 而非已经
-	// fake 好的 fakeChannelID；调用者传入的已经是 fakeChannelID（getPersonMessage
-	// 里已 fake 过一次），再 fake 一次就产生错的 lookup key、channel-level offset
-	// 恒为 0，等价于跳过——不如显式短路，语义清晰、并与 sync 的 messageAllows
-	// Person 分支一致（Person 不做 channel-level offset 截断）。用户级偏移
-	// (channelOffsetDB.queryWithUIDAndChannel) 上面已经做过，仍生效。
-	if channelType != common.ChannelTypePerson.Uint8() {
-		var err error
-		channelOffsetSeq, err = m.lookupChannelOffsetSeq(channelID, channelType, loginUID)
-		if err != nil {
-			m.Error("查询频道设置失败", zap.Error(err))
-			httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
-			return
-		}
+	channelOffsetSeq, err := m.lookupChannelOffsetSeq(channelID, channelType, loginUID)
+	if err != nil {
+		m.Error("查询频道设置失败", zap.Error(err))
+		httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
+		return
 	}
 
 	resp := &MsgSyncResp{}
@@ -424,13 +516,24 @@ func (m *Message) fetchMessageExtras(messageID int64, loginUID string, channelID
 	return extra, userExtra, reactions, nil
 }
 
-// lookupChannelOffsetSeq 复用 syncChannelMessage 的 channel offset 查询，私聊用 fakeChannelID。
+// lookupChannelOffsetSeq 查询 channel_setting.offset_message_seq，用于同步/直查
+// 场景下过滤已被"频道清历史"截断的旧消息。
+//
+// 约定：调用者传入的 channelID 必须是**消息物理存储的 channel_id**
+// （消息表按此分表；对 Person 而言就是 fakeChannelID，对 Group/Thread 就是
+// group_no / thread channel_id）。channel_setting 表的 key 就是这个物理 id，
+// 与 sync 路径 (api.go:1437-1443) 同一 fakeChannelID 一致。历史版本对
+// channelType==Person 会内部再做一次 GetFakeChannelIDWith(channelID, loginUID)，
+// 期望入参是 peer uid；但（a）sync 已经自己算 fake、不走此函数；
+// (b) cardCanonicalVisibleToViewer 里的 Person 分支在此调用之前 return true 短路；
+// (c) 直查路径 (respondSingleMessage) 传的 channelID 已经是 fakeChannelID。
+// 三个 caller 没有一个会传 bare peer uid 进来。为了不再让"错误 caller 二次 fake"
+// 成为隐藏坑，这里显式统一：所有 channelType 都直接用 channelID 作 lookup key。
+// (P1-1b, PR #708 review round 2.)
 func (m *Message) lookupChannelOffsetSeq(channelID string, channelType uint8, loginUID string) (uint32, error) {
-	lookupID := channelID
-	if channelType == common.ChannelTypePerson.Uint8() {
-		lookupID = common.GetFakeChannelIDWith(channelID, loginUID)
-	}
-	settings, err := m.channelService.GetChannelSettings([]string{lookupID})
+	_ = channelType // 参数保留：签名不变，避免影响调用者；语义上不再对类型分派。
+	_ = loginUID    // 参数保留：签名不变；不再需要 loginUID 二次 fake。
+	settings, err := m.channelService.GetChannelSettings([]string{channelID})
 	if err != nil {
 		return 0, err
 	}

--- a/modules/message/api_message_get.go
+++ b/modules/message/api_message_get.go
@@ -10,9 +10,11 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
 	"github.com/Mininglamp-OSS/octo-server/modules/group"
+	"github.com/Mininglamp-OSS/octo-server/modules/space"
 	"github.com/Mininglamp-OSS/octo-server/modules/thread"
 	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
 	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
+	spacepkg "github.com/Mininglamp-OSS/octo-server/pkg/space"
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
 )
@@ -195,6 +197,39 @@ func (m *Message) getPersonMessage(c *wkhttp.Context) {
 		return
 	}
 	fakeChannelID := common.GetFakeChannelIDWith(loginUID, peerUID)
+
+	// Person(DM) Space 隔离：DM 是跨 Space 共享的同一物理频道，单条 DM 读必须与
+	// /v1/message/channel/sync 的 filterPersonMessagesBySpace 走同一套
+	// personSpaceAllows（issue #484 / YUJ-219-A / GH#1283）；不匹配一律 404 归并
+	// （防枚举，与不可见同码）。SpaceMiddleware 未 opt-in（老客户端 / 内部调用不带
+	// X-Space-ID）时 spaceID=="" → 跳过 Space 过滤，与 sync 向前兼容口径一致。
+	// 提前查一次消息用于 Space 判定；respondSingleMessage 内部会再查一次做完整
+	// 可见性校验，代价是主键单条读、可接受。
+	if spaceID := spacepkg.GetSpaceID(c); spaceID != "" {
+		msgModel, err := m.db.queryMessageByID(fakeChannelID, common.ChannelTypePerson.Uint8(), strconv.FormatInt(messageID, 10))
+		if err != nil {
+			m.Error("查询 DM 消息失败", zap.Error(err), zap.String("channel_id", fakeChannelID), zap.Int64("message_id", messageID))
+			httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
+			return
+		}
+		if msgModel == nil {
+			httperr.ResponseErrorL(c, errcode.ErrMessageNotFound, nil, nil)
+			return
+		}
+		defaultSpaceID, derr := space.GetUserDefaultSpaceIDE(m.ctx, loginUID)
+		if derr != nil {
+			m.Warn("查询默认 Space 失败，DM 单条读无标签消息按兼容口径放行",
+				zap.Error(derr), zap.String("loginUID", loginUID))
+			defaultSpaceID = spaceID
+		}
+		// IsSystemBot 判定基于对端 uid（peerUID），fakeChannelID 是 loginUID+peerUID
+		// 对称派生的，非 uid 直接可判。
+		if !personSpaceAllows(payloadSpaceIDFromRaw(msgModel.Payload), spacepkg.IsSystemBot(peerUID), spaceID, defaultSpaceID) {
+			httperr.ResponseErrorL(c, errcode.ErrMessageNotFound, nil, nil)
+			return
+		}
+	}
+
 	m.respondSingleMessage(c, fakeChannelID, common.ChannelTypePerson.Uint8(), "", messageID, loginUID)
 }
 
@@ -314,11 +349,24 @@ func (m *Message) respondSingleMessage(c *wkhttp.Context, channelID string, chan
 		return
 	}
 
-	channelOffsetSeq, err := m.lookupChannelOffsetSeq(channelID, channelType, loginUID)
-	if err != nil {
-		m.Error("查询频道设置失败", zap.Error(err))
-		httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
-		return
+	channelOffsetSeq := uint32(0)
+	// Person 频道跳过 channel-level offset：对齐 cardCanonicalVisibleToViewer:550
+	// 的 Person 短路（"person 频道跳过偏移... 也避免对已是 fake id 的 person 频道
+	// 二次 fake 化"）。lookupChannelOffsetSeq 对 Person 会内部再做一次
+	// GetFakeChannelIDWith(channelID, loginUID)，那里期望入参是 peer uid 而非已经
+	// fake 好的 fakeChannelID；调用者传入的已经是 fakeChannelID（getPersonMessage
+	// 里已 fake 过一次），再 fake 一次就产生错的 lookup key、channel-level offset
+	// 恒为 0，等价于跳过——不如显式短路，语义清晰、并与 sync 的 messageAllows
+	// Person 分支一致（Person 不做 channel-level offset 截断）。用户级偏移
+	// (channelOffsetDB.queryWithUIDAndChannel) 上面已经做过，仍生效。
+	if channelType != common.ChannelTypePerson.Uint8() {
+		var err error
+		channelOffsetSeq, err = m.lookupChannelOffsetSeq(channelID, channelType, loginUID)
+		if err != nil {
+			m.Error("查询频道设置失败", zap.Error(err))
+			httperr.ResponseErrorL(c, errcode.ErrMessageQueryFailed, nil, nil)
+			return
+		}
 	}
 
 	resp := &MsgSyncResp{}

--- a/modules/message/api_message_get.go
+++ b/modules/message/api_message_get.go
@@ -166,6 +166,38 @@ func (m *Message) getThreadMessage(c *wkhttp.Context) {
 	m.respondSingleMessage(c, channelID, common.ChannelTypeCommunityTopic.Uint8(), groupNo, messageID, loginUID)
 }
 
+// getPersonMessage GET /v1/messages/person/:peer_uid/:message_id
+//
+// 单聊(DM)单条消息直查，用于云盘转存等需要按 (会话, 消息ID) 取单条消息元数据的
+// 场景。DM 消息物理存储在 fakeChannelID(= GetFakeChannelIDWith(两个uid) 对称生成的
+// "uidA@uidB") 频道下、channel_type=Person。
+//
+// 鉴权：DM 无独立成员表，fakeChannelID 由调用者 loginUID 与对端 peerUID 对称派生，
+// 「能派生出这个频道」本身即代表 loginUID 是该 DM 的一方；配合 respondSingleMessage
+// 内的 visibles / 双删 / offset 全套可见性校验(与批量同步路径一致)，非参与方既拼不出
+// 命中的 fakeChannelID、也过不了可见性过滤，一律 404。禁止自聊(peer==self)。
+func (m *Message) getPersonMessage(c *wkhttp.Context) {
+	peerUID := c.Param("peer_uid")
+	messageIDStr := c.Param("message_id")
+	loginUID := c.GetLoginUID()
+
+	if strings.TrimSpace(peerUID) == "" {
+		respondMessageRequestInvalid(c, "peer_uid")
+		return
+	}
+	if peerUID == loginUID {
+		respondMessageRequestInvalid(c, "peer_uid")
+		return
+	}
+	messageID, ok := parsePositiveMessageID(messageIDStr)
+	if !ok {
+		respondMessageRequestInvalid(c, "message_id")
+		return
+	}
+	fakeChannelID := common.GetFakeChannelIDWith(loginUID, peerUID)
+	m.respondSingleMessage(c, fakeChannelID, common.ChannelTypePerson.Uint8(), "", messageID, loginUID)
+}
+
 // parsePositiveMessageID 校验 path 参数 message_id 为正整数。
 // 注：WuKongIM 雪花算法生成的 message_id 始终为正，0 视为非法。
 func parsePositiveMessageID(s string) (int64, bool) {

--- a/modules/message/api_message_get_test.go
+++ b/modules/message/api_message_get_test.go
@@ -748,3 +748,113 @@ func TestPersonFakeChannelIDCollisionOrderMatters(t *testing.T) {
 			"If this assertion fails, the upstream library changed its tie-breaking; "+
 			"the order-alignment requirement can then be relaxed.")
 }
+
+// TestPersonDMAccessDecision 覆盖 checkPersonDMAccess 的纯决策核心
+// personDMAccessDecision 所有 8 条决策路径。这个测试**不依赖 DB**——
+// checkPersonDMAccess 已经把 DB 查询和决策逻辑拆开，orchestration 层负责
+// 收集 DB 数据 → 决策纯函数负责判定。PR #708 review round 3 明确要求：
+// "add a DB-free table test for checkPersonDMAccess over the six decision
+// cases, in the style of TestPersonSpaceAllows_Rules"——本测试满足该要求，
+// 且比 6 case 更全（覆盖了 SystemBot 短路 + own bot 单独分支）。
+//
+// 决策规则源码见 personDMAccessDecision 头注释。任何决策规则修改，
+// 这个表就该跟着更新——它是"允许 vs 拒绝"契约的可执行文档。
+func TestPersonDMAccessDecision(t *testing.T) {
+	const (
+		me    = "user_login"
+		peer  = "user_peer"
+		other = "user_other"
+	)
+	cases := []struct {
+		name string
+		in   personDMAccessInputs
+		want personDMAccessResult
+	}{
+		{
+			name: "notes_to_self",
+			in:   personDMAccessInputs{loginUID: me, peerUID: me},
+			want: personDMAllowNotesToSelf,
+		},
+		{
+			name: "system_bot_allowed",
+			// fileHelper / botfather / u_10000 / notification 都走这条：
+			// SystemBot=true 直接短路到 blacklist；无被拉黑则放行。
+			in:   personDMAccessInputs{loginUID: me, peerUID: "fileHelper", isSystemBot: true},
+			want: personDMAllowSystemBot,
+		},
+		{
+			name: "system_bot_blocked_by_me",
+			// 用户拉黑 SystemBot 仍生效——防骚扰边界，符合 checkP2PAccess Step 3。
+			in:   personDMAccessInputs{loginUID: me, peerUID: "fileHelper", isSystemBot: true, blockedByMe: true},
+			want: personDMDenyBlacklist,
+		},
+		{
+			name: "own_bot_skips_all",
+			// 自己创建的 bot：跳过 Space / friend / blacklist。
+			in:   personDMAccessInputs{loginUID: me, peerUID: peer, isRobot: true, creatorUID: me},
+			want: personDMAllowOwnBot,
+		},
+		{
+			name: "own_bot_ignores_blacklist",
+			// 即使 blockedByMe/blockedByPeer 为 true，own bot 也直接放行
+			// （因为 personDMAccessDecision 在 own bot 分支就 return，不检查 blacklist）。
+			in:   personDMAccessInputs{loginUID: me, peerUID: peer, isRobot: true, creatorUID: me, blockedByMe: true, blockedByPeer: true},
+			want: personDMAllowOwnBot,
+		},
+		{
+			name: "other_bot_friend_allowed",
+			// 别人的 bot：需要好友关系；有 friend → 通过 blacklist → 放行。
+			in:   personDMAccessInputs{loginUID: me, peerUID: peer, isRobot: true, creatorUID: other, isFriend: true},
+			want: personDMAllowOtherBotFriend,
+		},
+		{
+			name: "other_bot_no_friend_denied",
+			// 别人的 bot 不是好友 → 404。
+			in:   personDMAccessInputs{loginUID: me, peerUID: peer, isRobot: true, creatorUID: other, isFriend: false},
+			want: personDMDenyOtherBotNotFriend,
+		},
+		{
+			name: "other_bot_friend_but_blocked",
+			// 别人的 bot 是好友但双向 blacklist 存在 → 404。
+			in:   personDMAccessInputs{loginUID: me, peerUID: peer, isRobot: true, creatorUID: other, isFriend: true, blockedByPeer: true},
+			want: personDMDenyBlacklist,
+		},
+		{
+			name: "real_user_same_space",
+			// 真人 + 同 Space → 放行（企业模式 friend 表可能为空）。
+			in:   personDMAccessInputs{loginUID: me, peerUID: peer, spaceID: "s1", sameSpace: true},
+			want: personDMAllowRealUserSameSpace,
+		},
+		{
+			name: "real_user_friend_no_space_optin",
+			// 未 opt-in Space（spaceID=""）+ 好友 → 放行。
+			in:   personDMAccessInputs{loginUID: me, peerUID: peer, spaceID: "", isFriend: true},
+			want: personDMAllowRealUserFriend,
+		},
+		{
+			name: "real_user_no_space_no_friend",
+			// 真人 + 无 Space + 非好友 → 404。这正是 issue #484 / YUJ-219-A 关注的边界。
+			in:   personDMAccessInputs{loginUID: me, peerUID: peer, spaceID: "", isFriend: false},
+			want: personDMDenyRealUserNoRelation,
+		},
+		{
+			name: "real_user_space_not_member_but_friend",
+			// 有 spaceID 但两人不在同一 Space；好友兜底放行——这是 checkP2PAccess
+			// 明说的"same-space OR friend"："或"关系。
+			in:   personDMAccessInputs{loginUID: me, peerUID: peer, spaceID: "s1", sameSpace: false, isFriend: true},
+			want: personDMAllowRealUserFriend,
+		},
+		{
+			name: "real_user_same_space_blocked",
+			// 真人同 Space 但双向 blacklist → 404。
+			in:   personDMAccessInputs{loginUID: me, peerUID: peer, spaceID: "s1", sameSpace: true, blockedByMe: true},
+			want: personDMDenyBlacklist,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := personDMAccessDecision(tc.in)
+			assert.Equal(t, tc.want, got, "case %q: unexpected decision", tc.name)
+		})
+	}
+}

--- a/modules/message/api_message_get_test.go
+++ b/modules/message/api_message_get_test.go
@@ -704,15 +704,47 @@ func TestPersonFakeChannelIDNotDoubleFaked(t *testing.T) {
 	// 让它内部再做一次 GetFakeChannelIDWith(fake1, loginUID)）产生的 key。
 	fake2 := common.GetFakeChannelIDWith(fake1, loginUID)
 
-	// 对称性：GetFakeChannelIDWith 的两个入参无序等价（同一对话恒生成同一 key）。
-	assert.Equal(t, fake1, common.GetFakeChannelIDWith(peerUID, loginUID),
-		"GetFakeChannelIDWith must be symmetric across the two DM sides")
-
-	// 反证：二次 fake 的 key 与真实的 fakeChannelID 不同——所以 respondSingleMessage
-	// 对 Person 必须显式短路 channel-level offset lookup（api_message_get.go:
-	// respondSingleMessage 已实现），否则用了错的 key 查 channel_setting.offset_message_seq。
+	// 反证：二次 fake 的 key 与真实的 fakeChannelID 不同——这是 lookupChannelOffsetSeq
+	// 现在必须无条件用 channelID (而非再 fake) 的原因 (api_message_get.go
+	// lookupChannelOffsetSeq)。如果这个不等式被打破，helper 的 caller 契约需要
+	// 重新审视。
 	assert.NotEqual(t, fake1, fake2,
 		"double-faked Person channelID must differ from the real fakeChannelID; "+
-			"if this becomes equal, the safety of the Person short-circuit changes and "+
-			"respondSingleMessage's Person branch must be revisited")
+			"if this becomes equal, lookupChannelOffsetSeq's caller contract needs revisiting")
+
+	// 常规（非碰撞）情况下的对称性——GetFakeChannelIDWith 用 CRC32 排序两侧 uid，
+	// 无碰撞时两个 uid 生成同一 key。多数正常场景走这条分支。
+	assert.Equal(t, fake1, common.GetFakeChannelIDWith(peerUID, loginUID),
+		"GetFakeChannelIDWith should be symmetric across the two DM sides "+
+			"when their CRC32 hashes differ")
+}
+
+// TestPersonFakeChannelIDCollisionOrderMatters 固定 CRC32 碰撞时
+// GetFakeChannelIDWith 的**参数顺序敏感性**——碰撞会走 `toUID@fromUID` fallthrough，
+// 因此 (A,B) 与 (B,A) 会得到不同 key。所有 Person 相关调用者必须与 sibling
+// 保持参数顺序一致 (统一为 `(peer_uid, login_uid)`，参见 api.go:1439 sync 路径)，
+// 否则同一对话的读 / 写路径会为同一对 uid 生成不同 key、发生"写入的消息读不出来"
+// 的静默 miss——PR #708 review round 2 P2 抓到的坑。
+//
+// 该测试用 review 提供的真实碰撞对 u_xgnb / u_cr7xslzj（CRC32 == 3955193408）。
+// 只要 CRC32 算法或 GetFakeChannelIDWith fallthrough 逻辑没变，测试就有效；
+// 如果哪天上游库改了 tie-breaking 让对称性也成立，assertion 会失败，
+// 提示我们可以放宽对参数顺序的约束。
+func TestPersonFakeChannelIDCollisionOrderMatters(t *testing.T) {
+	const (
+		uidA = "u_xgnb"
+		uidB = "u_cr7xslzj"
+	)
+	// review 里提到 CRC32(uidA) == CRC32(uidB) == 3955193408，导致 tie。
+	// 直接调 GetFakeChannelIDWith 两种顺序，如果 tie 逻辑仍是 fallthrough，
+	// 两个结果不同——本测试的核心断言。
+	keyAB := common.GetFakeChannelIDWith(uidA, uidB)
+	keyBA := common.GetFakeChannelIDWith(uidB, uidA)
+	assert.NotEqual(t, keyAB, keyBA,
+		"CRC32-tied uids currently produce order-sensitive fake channel IDs "+
+			"(GetFakeChannelIDWith falls through to toUID@fromUID on tie); "+
+			"all Person callers must therefore align parameter order with siblings "+
+			"(canonical order = (peer_uid, login_uid), see api.go:1439). "+
+			"If this assertion fails, the upstream library changed its tie-breaking; "+
+			"the order-alignment requirement can then be relaxed.")
 }

--- a/modules/message/api_message_get_test.go
+++ b/modules/message/api_message_get_test.go
@@ -585,3 +585,58 @@ func TestGetThreadMessage_InvalidShortID(t *testing.T) {
 	w := doGet(t, s, fmt.Sprintf("/v1/groups/%s/threads/abc/messages/1", groupNo))
 	assert.Equal(t, http.StatusBadRequest, w.Code, w.Body.String())
 }
+
+// ---------- Person (DM) ----------
+
+const personPeerUID = "peer_user_1"
+
+// TestGetPersonMessage_Success：DM 一方能按 (peer_uid, message_id) 取到消息。
+// 消息物理落在 fakeChannelID = GetFakeChannelIDWith(loginUID, peerUID)、type=Person。
+func TestGetPersonMessage_Success(t *testing.T) {
+	t.Skip("OCTO migration TODO: see https://github.com/Mininglamp-OSS/octo-server/issues/17")
+	s, ctx, _ := setupGroupTestData(t)
+	fakeChannelID := common.GetFakeChannelIDWith(testutil.UID, personPeerUID)
+	const mid int64 = 7001
+	insertGroupMessage(t, ctx, fakeChannelID, common.ChannelTypePerson.Uint8(), mid)
+
+	w := doGet(t, s, fmt.Sprintf("/v1/messages/person/%s/%d", personPeerUID, mid))
+	assert.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	var resp MsgSyncResp
+	assert.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, mid, resp.MessageID)
+	assert.Equal(t, fakeChannelID, resp.ChannelID)
+	assert.Equal(t, common.ChannelTypePerson.Uint8(), resp.ChannelType)
+}
+
+// TestGetPersonMessage_NotParticipant：非该 DM 一方查不到——调用者(testutil.UID)
+// 与 peer 派生的 fakeChannelID 不同于消息实际所在的 (otherA, otherB) 频道，命中不到。
+func TestGetPersonMessage_NotParticipant(t *testing.T) {
+	t.Skip("OCTO migration TODO: see https://github.com/Mininglamp-OSS/octo-server/issues/17")
+	s, ctx, _ := setupGroupTestData(t)
+	// 消息属于 otherA<->otherB 的 DM，与登录用户无关。
+	otherChannelID := common.GetFakeChannelIDWith("other_a", "other_b")
+	const mid int64 = 7002
+	insertGroupMessage(t, ctx, otherChannelID, common.ChannelTypePerson.Uint8(), mid)
+
+	// 登录用户尝试用 peer=other_b 取——派生的 fakeChannelID(loginUID<->other_b) 不等于
+	// otherChannelID(other_a<->other_b)，查不到 → 404。
+	w := doGet(t, s, fmt.Sprintf("/v1/messages/person/%s/%d", "other_b", mid))
+	assert.Equal(t, http.StatusNotFound, w.Code, w.Body.String())
+}
+
+// TestGetPersonMessage_SelfRejected：禁止自聊(peer == self)。
+func TestGetPersonMessage_SelfRejected(t *testing.T) {
+	t.Skip("OCTO migration TODO: see https://github.com/Mininglamp-OSS/octo-server/issues/17")
+	s, _, _ := setupGroupTestData(t)
+	w := doGet(t, s, fmt.Sprintf("/v1/messages/person/%s/1", testutil.UID))
+	assert.Equal(t, http.StatusBadRequest, w.Code, w.Body.String())
+}
+
+// TestGetPersonMessage_InvalidMessageID：message_id 非正整数 → 400。
+func TestGetPersonMessage_InvalidMessageID(t *testing.T) {
+	t.Skip("OCTO migration TODO: see https://github.com/Mininglamp-OSS/octo-server/issues/17")
+	s, _, _ := setupGroupTestData(t)
+	w := doGet(t, s, fmt.Sprintf("/v1/messages/person/%s/notanumber", personPeerUID))
+	assert.Equal(t, http.StatusBadRequest, w.Code, w.Body.String())
+}

--- a/modules/message/api_message_get_test.go
+++ b/modules/message/api_message_get_test.go
@@ -640,3 +640,79 @@ func TestGetPersonMessage_InvalidMessageID(t *testing.T) {
 	w := doGet(t, s, fmt.Sprintf("/v1/messages/person/%s/notanumber", personPeerUID))
 	assert.Equal(t, http.StatusBadRequest, w.Code, w.Body.String())
 }
+
+// TestPersonSpaceAllows_Rules 直接固定 personSpaceAllows 的 5 条规则，与
+// filterPersonMessagesBySpace 头注释里的口径一一对应。这条 helper 是 DM
+// 单条读 (getPersonMessage) / DM 同步 (filterPersonMessagesBySpace) /
+// reaction (syncReaction/addOrCancelReaction) 共用的 Space 隔离核心闸门，
+// 任何一处走漏都是 issue #484 / YUJ-219-A / GH#1283 回归。helper 级 unit test，
+// 不依赖 DB / migration，永远可执行；抓「谁把 DM 空间过滤逻辑改破了」的
+// 单元金丝雀。
+func TestPersonSpaceAllows_Rules(t *testing.T) {
+	const (
+		curSpace     = "space-A"
+		otherSpace   = "space-B"
+		defaultSpace = "space-A"
+	)
+	tests := []struct {
+		name         string
+		msgSpaceID   string
+		isSystemBot  bool
+		spaceID      string
+		defaultSpace string
+		want         bool
+	}{
+		// 规则 1：精确匹配 → 保留
+		{"exact match", curSpace, false, curSpace, defaultSpace, true},
+		// 规则 2：无标签 && 非 SystemBot && 当前=默认 Space → 保留（向前兼容）
+		{"unlabeled non-bot in default space", "", false, curSpace, defaultSpace, true},
+		// 规则 3：无标签 && 非 SystemBot && 当前 != 默认 Space → 丢弃
+		{"unlabeled non-bot in non-default space", "", false, otherSpace, defaultSpace, false},
+		// 规则 4：无标签 && SystemBot → 丢弃（老 fileHelper / u_10000 消息不跨 Space 泄露）
+		{"unlabeled system bot", "", true, curSpace, defaultSpace, false},
+		// 规则 5：跨 Space 标签 → 丢弃
+		{"cross-space labeled", otherSpace, false, curSpace, defaultSpace, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := personSpaceAllows(tc.msgSpaceID, tc.isSystemBot, tc.spaceID, tc.defaultSpace)
+			assert.Equal(t, tc.want, got,
+				"personSpaceAllows(msg=%q, sysbot=%v, cur=%q, default=%q)",
+				tc.msgSpaceID, tc.isSystemBot, tc.spaceID, tc.defaultSpace)
+		})
+	}
+}
+
+// TestPersonFakeChannelIDNotDoubleFaked 固定「Person DM 频道 ID 只 fake 一次」
+// 的核心不变式。lookupChannelOffsetSeq 内部对 channelType==Person 会做
+// GetFakeChannelIDWith(channelID, loginUID)，期望入参是 peer uid 而非已经
+// fake 好的 fakeChannelID；如果调用方（如 respondSingleMessage 之前对 Person
+// 传的是 fakeChannelID）不做短路，就会二次 fake，产生错误的 lookup key、
+// 静默把 channel-level offset 归 0，channel-offset-truncated 的 DM 消息又能
+// 被读到——这是 PR #708 review 抓到的第二条 blocking 的技术根因。
+//
+// 这个 helper 级测试固定该不变式：一旦有人把 respondSingleMessage 里对
+// Person 短路 channel-offset 的分支拆掉、或改变 GetFakeChannelIDWith 的对称
+// 语义，assertion 立即失败。
+func TestPersonFakeChannelIDNotDoubleFaked(t *testing.T) {
+	const (
+		loginUID = "user_login"
+		peerUID  = "user_peer"
+	)
+	fake1 := common.GetFakeChannelIDWith(loginUID, peerUID)
+	// 二次 fake（如果调用者错误地把 fake1 传给 lookupChannelOffsetSeq、
+	// 让它内部再做一次 GetFakeChannelIDWith(fake1, loginUID)）产生的 key。
+	fake2 := common.GetFakeChannelIDWith(fake1, loginUID)
+
+	// 对称性：GetFakeChannelIDWith 的两个入参无序等价（同一对话恒生成同一 key）。
+	assert.Equal(t, fake1, common.GetFakeChannelIDWith(peerUID, loginUID),
+		"GetFakeChannelIDWith must be symmetric across the two DM sides")
+
+	// 反证：二次 fake 的 key 与真实的 fakeChannelID 不同——所以 respondSingleMessage
+	// 对 Person 必须显式短路 channel-level offset lookup（api_message_get.go:
+	// respondSingleMessage 已实现），否则用了错的 key 查 channel_setting.offset_message_seq。
+	assert.NotEqual(t, fake1, fake2,
+		"double-faked Person channelID must differ from the real fakeChannelID; "+
+			"if this becomes equal, the safety of the Person short-circuit changes and "+
+			"respondSingleMessage's Person branch must be revisited")
+}


### PR DESCRIPTION
Closes #707.

## Summary

Add `GET /v1/messages/person/:peer_uid/:message_id` so drive transfer (and any
caller needing a single DM message by (conversation, message id)) can resolve
direct-message metadata, mirroring the existing group / sub-thread endpoints.

## Changes

- `modules/message/api_message_get.go`: new `getPersonMessage` handler.
  - Derives `fakeChannelID = common.GetFakeChannelIDWith(loginUID, peer_uid)`,
    reuses `respondSingleMessage` for full visibility check.
  - Authorization: symmetric fakeChannelID derivation is proof of participation;
    non-participants get 404 (wrong fakeChannelID) or fail the visibility
    filter. `peer_uid == loginUID` rejected 400.
- `modules/message/api.go`: route mounted in the existing `/v1/messages` group
  (`AuthMiddleware` + shared uid rate limiter), no `SpaceMiddleware` since
  fakeChannelID already isolates the conversation.
- `modules/message/api_message_get_test.go`: 4 tests
  (`Success` / `NotParticipant` / `SelfRejected` / `InvalidMessageID`), Skip
  pending OCTO migration to match the existing group / sub-thread test style.

## Test Plan

- `go build ./modules/message/...` — passes
- `go vet ./modules/message/` — passes
- Gin route conflict smoke: `person` static segment coexists with the sibling
  `:message_id/receipt` param segment in the same `/v1/messages` group without
  panic (verified with a minimal main).
- VM deploy: image `octo-server:local` rebuilt from this branch, container
  healthy, `curl http://.../v1/messages/person/somepeer/1` without token
  returns 401 (route matched, `AuthMiddleware` gates).

## Downstream

- octo-drive: `imMessageURL` gains a Person branch routing here;
  `GetIMAttachment` takes a `channelType` argument.
- octo-web: drops the DM `channelType !== Person` guards on the file-message
  save-to-drive icon and the mount-time transferred-state query.

## Non-goals

- No changes to group / sub-thread routes.
- No new permission model — DM visibility reuses the existing
  `respondSingleMessage` gate.
