### PR TITLE
feat: persist trusted server-authored card catalog provenance (E3 PR-C, ungated half)

### DIFF
--- a/.octospec/tasks/cardtmpl-provenance-markers/brief.md
+++ b/.octospec/tasks/cardtmpl-provenance-markers/brief.md
@@ -43,9 +43,10 @@ Three properties, each with a test that fails when its fix alone is reverted:
    reader rejects — permanently unclickable and uneditable.
    `TestSendRefusesToAuthorAMarkerItsReadersWouldReject`.
 2. **A marker cannot be forged.** No external input can carry the two keys in.
-   The four external entry points do not all achieve that the same way, and the
-   difference is worth stating because a single sentence hid a real gap for
-   three rounds: bot raw send and robot ingress **reject by key**; bot template
+   The entry points do not all achieve that the same way, and the difference is
+   worth stating because a single sentence hid a real gap for three rounds (the
+   normative per-ingress list is under Acceptance): bot raw send and robot
+   ingress **reject by key**; bot template
    mode has no such field in its request shape and the server authors the
    markers at the rendering boundary; the incoming webhook builds its envelope
    from a fixed field allowlist so caller keys never reach the top level; and
@@ -81,8 +82,30 @@ middleware, and the pilot. All of those stay in the parent task.
 
 ## Acceptance
 
-- Raw ingress carrying either key is rejected on every path (bot, robot,
-  incoming webhook, user edit).
+- **No external input can author or persist either marker.** That is the
+  invariant; "rejected by key" is only one of the ways it is met, and stating it
+  as if it were the only one is what hid a real gap for three rounds. Per
+  ingress:
+  - bot raw send / raw edit, and robot ingress — **reject the request** when
+    either key is present;
+  - bot template mode — the request shape has no such field, and the server
+    authors both markers itself at the rendering boundary;
+  - incoming webhook — builds its envelope from a fixed field allowlist
+    (`buildCardPayload`), so caller keys never reach the top level; a request
+    carrying them is **not rejected for that reason**, the keys are simply not
+    copied. The allowlist covers the two markers only: the caller still owns the
+    whole `card` node including `metadata.octo.template`. That is unchanged
+    legacy behaviour and not an impersonation — a webhook sends under its own
+    identity, and a markerless frame takes the static-`ActionContext` branch,
+    which authorizes no principal. It is the same in-body identity that made
+    key-stripping insufficient one bullet down, where the sender *is* someone
+    else's;
+  - thread source-message copy — **refuses type-17 payloads outright**, because
+    key-stripping does not reach the in-body identity
+    (`card.metadata.octo.template`) that the action route falls back to;
+  - user send / user edit — never reaches a marker question at all: cards are
+    refused as a message type (`modules/message/api.go`), both when the edit
+    body is one and when the target is.
 - Both authoring boundaries refuse to write a marker their readers reject.
 - A replacement frame cannot drop markers the stored frame carries, and the
   refusal is enforced at the mutation boundary rather than per call site.

--- a/.octospec/tasks/cardtmpl-provenance-markers/brief.md
+++ b/.octospec/tasks/cardtmpl-provenance-markers/brief.md
@@ -1,0 +1,70 @@
+---
+type: Task
+title: "Task: cardtmpl-provenance-markers"
+description: Server-authored catalog provenance markers on stored card frames — authored where they cannot be invalid, refused at raw ingress, and preserved across every replacement.
+tags: [card, cardmsg, cardtmpl, provenance, wire-contract, trust-boundary, notify, bot-api, testing]
+timestamp: 2026-08-06T00:00:00+08:00
+slug: cardtmpl-provenance-markers
+upstream: "split out of cardtmpl-runtime-catalog-grants-discovery (E3 PR-C); parent brief holds D3"
+source: self
+---
+
+# Task: cardtmpl-provenance-markers
+
+This is the **ungated** half of E3 PR-C, split out for review after round 7.
+
+The parent task —
+[`cardtmpl-runtime-catalog-grants-discovery`](../cardtmpl-runtime-catalog-grants-discovery/brief.md)
+— owns the contract of record, including **D3**, which this task implements.
+Nothing here is a scope change; the split exists because the two halves need
+different merge arguments:
+
+- **This task takes effect on merge.** It sits behind the pre-existing
+  `OCTO_CARD_MESSAGE_ENABLED` switch, not behind either runtime-catalog gate,
+  so wherever cards are already on, merging changes stored bytes and can make
+  one previously-succeeding send fail. That deserves line-by-line review.
+- **The parent's remaining half is inert on merge.** Grants, one-snapshot
+  authorization, discovery/export and the pilot are all behind
+  `OCTO_CARD_RUNTIME_CATALOG_CONTROL_ENABLED` / `_NEW_SEND_ENABLED`, both
+  default false. It can merge on that argument once this lands.
+
+## Scope
+
+A dynamic card frame carries two server-authored top-level markers,
+`template_ref` and `catalog_provenance`, so historical edit and action-context
+read the producer from the frame instead of inferring it from `msg.FromUID`.
+
+Three properties, each with a test that fails when its fix alone is reverted:
+
+1. **A marker cannot be authored invalid.** Both authoring boundaries validate
+   before stamping. `cardmsg.Validate`'s marker hook runs before the keys exist
+   and `Finalize` does not re-check, so the authoring site is the last point
+   that can refuse. An untrimmed target Space otherwise produced a frame every
+   reader rejects — permanently unclickable and uneditable.
+   `TestSendRefusesToAuthorAMarkerItsReadersWouldReject`.
+2. **A marker cannot be forged.** Every raw ingress — bot, robot, incoming
+   webhook, user edit — rejects both keys.
+3. **A marker cannot be dropped.** `CardMutator.Mutate` refuses a replacement
+   that loses markers the stored frame carries, so no call site can silently
+   downgrade a marked card into the legacy population and leave the identity
+   guards inert. `TestCardMutatorRefusesToDropStoredCatalogMarkers`,
+   `TestDocsActionFinalizerRoutesEveryStateThroughTheRegistry`,
+   `TestStandardActionFinalizerCannotSilentlyDowngradeAMarkedCard`.
+
+## Out of scope
+
+Grants, the grant table and its migration, one-snapshot authorization, the Bot
+capability manifest, B1/B2 discovery and export, the localized Space
+middleware, and the pilot. All of those stay in the parent task.
+
+## Acceptance
+
+- Raw ingress carrying either key is rejected on every path (bot, robot,
+  incoming webhook, user edit).
+- Both authoring boundaries refuse to write a marker their readers reject.
+- A replacement frame cannot drop markers the stored frame carries, and the
+  refusal is enforced at the mutation boundary rather than per call site.
+- Every docs finalizer state renders through the Registry, so the route cannot
+  be selected by a state allowlist that a later state would silently escape.
+- `docs.access-request@0.3.0` declares `cancelled` and `unavailable`, the two
+  outcomes the pre-Registry fallback used to render.

--- a/.octospec/tasks/cardtmpl-provenance-markers/brief.md
+++ b/.octospec/tasks/cardtmpl-provenance-markers/brief.md
@@ -74,6 +74,26 @@ Three properties, each with a test that fails when its fix alone is reverted:
   alternative is authorizing the copy through the same visibility gates a
   single-message read applies, which is a larger change than this slice.
 
+### Decision: `source_message_id` means "created from", the notification means "copied in"
+
+Raised in review because the `thread` row and the parent-group notification now
+disagree: `CreateThread` writes `req.SourceMessageID` to the row unconditionally,
+while the notification omits it when nothing was copied. Both readings are
+defensible, so the decision is recorded rather than left to the next reader.
+
+- **The row keeps the unconditional write.** It records provenance — which
+  message this thread was created from — and that is true whether or not the
+  copy happened. Dropping it would lose the only link back to the originating
+  message for exactly the threads created from cards.
+- **The notification keeps the conditional one.** It is a client-facing
+  description of the thread's contents, sitting beside `message_count` and the
+  preview, and a client that follows an announced `source_message_id` into an
+  empty thread has been lied to.
+
+They are the same key with two audiences, not one key with two meanings. Making
+them agree would require breaking one of the two; if a future reader wants one
+answer, the row's field should be renamed rather than the notification changed.
+
 ## Out of scope
 
 Grants, the grant table and its migration, one-snapshot authorization, the Bot
@@ -82,12 +102,24 @@ middleware, and the pilot. All of those stay in the parent task.
 
 ## Acceptance
 
-- **No external input can author or persist either marker.** That is the
-  invariant; "rejected by key" is only one of the ways it is met, and stating it
-  as if it were the only one is what hid a real gap for three rounds. Per
-  ingress:
-  - bot raw send / raw edit, and robot ingress — **reject the request** when
-    either key is present;
+- **No marker that any reader will honour can come from external input.** That
+  is the invariant. It is deliberately not the stronger "no external input can
+  persist either key": a frame typed `{"type":"17"}` (string, not number) is not
+  a card to `cardmsg.IsCardPayload`, so an ordinary caller can persist those
+  bytes — and the same predicate gates `CatalogFrameMarkers` and
+  `CardTemplateContext`, so no reader ever sees markers on it. Writer gate and
+  reader gate being one predicate is what makes that safe. "Rejected by key" is
+  likewise only one of the ways the invariant is met, and stating it as if it
+  were the only one is what hid a real gap for three rounds. Per ingress:
+  - bot raw send — **rejects `catalog_provenance` by key** on the raw branch. A
+    top-level `template_ref` is *not* rejected there: it selects template mode
+    (`send.go:97`), where the ref is checked against the bot's permitted refs
+    and the server re-authors both markers itself, and a raw `card` alongside it
+    is refused as a double-mode request. The two bullets are jointly complete;
+  - bot raw edit — rejects **both** keys in both directions
+    (`cardEnvelopeHasCatalogMarker`): a marked target is not raw-editable, and a
+    marked edit body is a forgery;
+  - robot ingress — rejects on presence of either key;
   - bot template mode — the request shape has no such field, and the server
     authors both markers itself at the rendering boundary;
   - incoming webhook — builds its envelope from a fixed field allowlist

--- a/.octospec/tasks/cardtmpl-provenance-markers/brief.md
+++ b/.octospec/tasks/cardtmpl-provenance-markers/brief.md
@@ -42,14 +42,36 @@ Three properties, each with a test that fails when its fix alone is reverted:
    that can refuse. An untrimmed target Space otherwise produced a frame every
    reader rejects — permanently unclickable and uneditable.
    `TestSendRefusesToAuthorAMarkerItsReadersWouldReject`.
-2. **A marker cannot be forged.** Every raw ingress — bot, robot, incoming
-   webhook, user edit — rejects both keys.
+2. **A marker cannot be forged.** No external input can carry the two keys in.
+   The four external entry points do not all achieve that the same way, and the
+   difference is worth stating because a single sentence hid a real gap for
+   three rounds: bot raw send and robot ingress **reject by key**; bot template
+   mode has no such field in its request shape and the server authors the
+   markers at the rendering boundary; the incoming webhook builds its envelope
+   from a fixed field allowlist so caller keys never reach the top level; and
+   the thread source-message copy **refuses type-17 payloads outright**, because
+   there the caller's bytes are persisted under another sender's identity and
+   the identity the action route trusts lives inside the card body, where
+   stripping the top-level keys does not reach.
 3. **A marker cannot be dropped.** `CardMutator.Mutate` refuses a replacement
    that loses markers the stored frame carries, so no call site can silently
    downgrade a marked card into the legacy population and leave the identity
    guards inert. `TestCardMutatorRefusesToDropStoredCatalogMarkers`,
    `TestDocsActionFinalizerRoutesEveryStateThroughTheRegistry`,
    `TestStandardActionFinalizerCannotSilentlyDowngradeAMarkedCard`.
+
+## Behaviour changes worth an owner's attention
+
+- **A thread created from a card message no longer copies a first message.**
+  The copy path persists caller-supplied bytes under the source message's
+  sender and never checks the id against the payload, so for a card that is a
+  way to send a card as another user — which the user ingress bans outright.
+  Refusing type-17 there matches that ban. The thread is still created and
+  `source_message_id` is simply not announced, so nothing claims a first
+  message that does not exist. Owner: whoever owns `modules/thread` should
+  confirm the product is willing to lose the card preview on that flow; the
+  alternative is authorizing the copy through the same visibility gates a
+  single-message read applies, which is a larger change than this slice.
 
 ## Out of scope
 

--- a/docs/card-protocol.md
+++ b/docs/card-protocol.md
@@ -31,6 +31,19 @@
 - `card_version` 当前固定 `"1.5"`；`profile` 见 §3。
 - 未知的**额外**顶层字段被容忍（前向兼容）。P2 起信封新增可选字段：
   `card_seq`（整数，乱序防护）、`transient`（bool，进度帧不入变更历史）。
+- E3 PR-C 起另有两个**服务端独占**的顶层标记，用于 Registry / dynamic catalog 帧：
+  `template_ref`（`{id, version}`，已存在）与 `catalog_provenance`
+  （`{version, principal_type, principal_id, space_id}`，新增）。两者都**只能由
+  服务端在渲染出口写入**：raw ingress（bot 原始发卡、robot、incoming webhook）
+  携带任一 key 一律拒绝，编辑路径也不能新增或改写它们。
+  - 兼容矩阵（`cardmsg.CatalogFrameMarkers`）：两者皆无 = pre-PR-C 旧帧，合法；
+    只有 `template_ref` = pre-PR-C 的 Bot Registry 帧，合法；两者皆有 = 严格校验，
+    `template_ref` 必须与 `card.metadata.octo.template` 完全一致；
+    **只有 `catalog_provenance` 而无 `template_ref` = 拒绝**（无法验证它在描述什么）。
+  - `principal_type` 只取 `bot` / `internal_producer`。`space_id` 是这次发送**被授权
+    针对的** Space：群/子区取目标群行的 Space，DM 取 bot 的权威 Space。
+  - 存在这两个标记的意义：历史编辑与 action-context 不再靠 `msg.FromUID` 猜
+    producer 身份，而是从服务端自己写下的帧里恢复。
 
 ## 2. octo/v1 profile（P1 展示白名单）
 
@@ -163,6 +176,11 @@ view/state/wire profile 以及每个 view 的 `submit_actions`；不能从
    ingress —— 渲染门禁是残余风险的最后防线。`from_uid` 由 IM 连接鉴权绑定，
    不可伪造。
 3. **P2 动作端点**再次服务端复验目标消息 sender 身份。
+4. **E3 PR-C：动作端点还复验存储 provenance**。帧带 `catalog_provenance` 时，
+   声明的 principal 必须与存储 `FromUID` 一致（bot），或经只读 producer binding
+   解析回同一个 `FromUID`（internal producer）；声明的 Space 与信封 Space 两者
+   都非空时必须相等。缺失即 pre-PR-C 帧，走既有兼容路径。这一层挡的是「拿到一个
+   合法帧、改掉里面的 principal 去冒充另一个 producer」。
 
 **服务端展示面的对应纪律**：推送 / 搜索命中 / 摘要 / 置顶 / 引用等由服务端
 产出文案的面，对 sender 非 bot/webhook 身份的 type-17 一律显示 `[卡片]`，

--- a/docs/card-protocol.md
+++ b/docs/card-protocol.md
@@ -34,8 +34,16 @@
 - E3 PR-C 起另有两个**服务端独占**的顶层标记，用于 Registry / dynamic catalog 帧：
   `template_ref`（`{id, version}`，已存在）与 `catalog_provenance`
   （`{version, principal_type, principal_id, space_id}`，新增）。两者都**只能由
-  服务端在渲染出口写入**：raw ingress（bot 原始发卡、robot、incoming webhook）
-  携带任一 key 一律拒绝，编辑路径也不能新增或改写它们。
+  服务端在渲染出口写入**，任何外部输入都不能带着它们进来。四条外部入口各自的
+  做法不同，写在这里以免读者以为它们同形：
+  - bot 原始发卡、robot ingress —— **按 key 拒绝**，出现任一即整条请求失败；
+  - bot 模板模式 —— 请求形状里根本没有这两个 key，服务端在渲染出口自己写；
+  - incoming webhook —— 信封由固定字段白名单从零构造，调用方的 key 到不了顶层；
+  - 子区源消息拷贝（`modules/thread`）—— 整条 type-17 payload **拒绝拷贝**：这条
+    路径把调用方的字节以源消息发送者的身份持久化，而 action 路由信任的模板身份在
+    卡体内部（`card.metadata.octo.template`），剥掉顶层 key 并不触及它。
+
+  编辑路径也不能新增或改写它们。
   - 兼容矩阵（`cardmsg.CatalogFrameMarkers`）：两者皆无 = pre-PR-C 旧帧，合法；
     只有 `template_ref` = pre-PR-C 的 Bot Registry 帧，合法；两者皆有 = 严格校验，
     `template_ref` 必须与 `card.metadata.octo.template` 完全一致；

--- a/internal/cardactiondispatch/contract.go
+++ b/internal/cardactiondispatch/contract.go
@@ -51,10 +51,19 @@ type Event struct {
 
 // CardContext is derived from the effective server-authored card frame before
 // enqueue. Zero value means a legacy card without registry metadata.
+//
+// PrincipalType/PrincipalID/SpaceID are additive PR-C D3 fields: the action
+// ingress copies them from the frame's validated `catalog_provenance` marker
+// after proving consistency with the stored sender and authoritative Space.
+// They are absent on frames sent before provenance existed; consumers must
+// not fall back to guessing a principal from sender/owner when they are set.
 type CardContext struct {
 	TemplateID      string `json:"template_id,omitempty"`
 	TemplateVersion string `json:"template_version,omitempty"`
 	View            string `json:"view,omitempty"`
+	PrincipalType   string `json:"principal_type,omitempty"`
+	PrincipalID     string `json:"principal_id,omitempty"`
+	SpaceID         string `json:"space_id,omitempty"`
 }
 
 type CallbackFormat string

--- a/internal/cardactiondispatch/contract_test.go
+++ b/internal/cardactiondispatch/contract_test.go
@@ -596,3 +596,60 @@ func sha256Hex(body []byte) string {
 	sum := sha256.Sum256(body)
 	return hex.EncodeToString(sum[:])
 }
+
+// ---- PR-C Slice 1 (D3): CardContext carries the validated stored principal
+// as additive durable fields. The cross-repo callback envelope is frozen and
+// must not grow the principal; only the internal event record does. ----
+
+func TestCardContextPrincipalFieldsAreDurableAndAdditive(t *testing.T) {
+	event := Event{
+		EventID: 7, ActionID: "docs-access-approve", OperatorUID: "user-1",
+		MessageID: "1001", ChannelID: "user-1", ChannelType: 1,
+		Card: CardContext{
+			TemplateID: "docs.access-request", TemplateVersion: "0.3.0", View: "pending",
+			PrincipalType: "internal_producer", PrincipalID: "docs-notify", SpaceID: "space-1",
+		},
+	}
+	raw, err := json.Marshal(event)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var decoded Event
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if decoded.Card != event.Card {
+		t.Fatalf("durable round trip = %+v, want %+v", decoded.Card, event.Card)
+	}
+
+	// Old durable events (no principal fields) keep decoding into the same shape.
+	var legacyDecoded Event
+	if err := json.Unmarshal([]byte(`{"event_id":7,"card":{"template_id":"docs.access-request","template_version":"0.3.0","view":"pending"}}`), &legacyDecoded); err != nil {
+		t.Fatal(err)
+	}
+	if legacyDecoded.Card.PrincipalID != "" || legacyDecoded.Card.TemplateVersion != "0.3.0" {
+		t.Fatalf("legacy durable decode = %+v", legacyDecoded.Card)
+	}
+
+	// The frozen octo-card-v1 callback envelope must not leak the principal.
+	body, err := MarshalCallbackRequest(event, CallbackFormatOctoCardV1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var envelope map[string]interface{}
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		t.Fatal(err)
+	}
+	card, _ := envelope["card"].(map[string]interface{})
+	for _, forbidden := range []string{"principal_type", "principal_id", "space_id"} {
+		if _, leaked := card[forbidden]; leaked {
+			t.Fatalf("callback envelope leaked %s: %s", forbidden, body)
+		}
+	}
+
+	// A partially-filled principal context is still a complete octo-card
+	// context for callback purposes (view/template drive the envelope).
+	if event.Card == (CardContext{}) {
+		t.Fatal("populated context compared equal to zero value")
+	}
+}

--- a/internal/carddispatch/context.go
+++ b/internal/carddispatch/context.go
@@ -22,6 +22,21 @@ func Install(ctx ValueStore, registry *Registry) error {
 	return nil
 }
 
+// ProducerBindingFromContext 解析已安装 Registry 的只读 producer 身份绑定
+// （PR-C D3）。Registry 未安装或 producer 未注册一律 (\"\", false)，调用方
+// 对 dynamic provenance fail-close。与 SenderFromContext 不同，它绝不返回
+// 发送能力 —— 业务 caller 无法借它构造 ProducerSpec 或拿到 Sender。
+func ProducerBindingFromContext(ctx ValueStore, id ProducerID) (string, bool) {
+	if ctx == nil {
+		return "", false
+	}
+	registry, ok := ctx.Value(registryContextKey).(*Registry)
+	if !ok || registry == nil {
+		return "", false
+	}
+	return registry.ProducerBinding(id)
+}
+
 func SenderFromContext(ctx ValueStore, id ProducerID) (Sender, error) {
 	if ctx == nil {
 		return nil, categorized(CategoryProducerDisabled, errors.New("application context unavailable"))

--- a/internal/carddispatch/dispatch.go
+++ b/internal/carddispatch/dispatch.go
@@ -116,6 +116,44 @@ func (s *producerSender) Send(ctx context.Context, target Target, card Card) (re
 		return nil, categorized(terminal, validateErr)
 	}
 
+	// PR-C D3：可信派发边界从「已通过 cardmsg.Validate 的 metadata.octo.template」
+	// 与「已注册 ProducerSpec.ID + 已授权 target Space」为 Registry 产出的卡
+	// 写入 server-authored 顶层 catalog 标记。业务调用方只掌握 Card.Document
+	// （裸 card 节点），够不到信封顶层，因此无法自报 principal；无模板元数据的
+	// legacy 文档不写标记（principal 只能靠猜，宁缺毋假）。
+	if refID, refVersion, ok := cardDocumentTemplateContext(cardDocument); ok {
+		provenance := cardmsg.CatalogProvenance{
+			Version:       cardmsg.CatalogProvenanceVersion,
+			PrincipalType: cardmsg.CatalogPrincipalWireInternalProducer,
+			PrincipalID:   string(s.spec.ID),
+			SpaceID:       target.SpaceID,
+		}
+		// Validate before stamping, because nothing downstream will. The
+		// cardmsg.Validate call above runs before these keys exist, and
+		// Finalize only builds `plain` and rechecks size — so this is the last
+		// point at which an invalid marker can be refused.
+		//
+		// Refusing here rather than trimming target.SpaceID is deliberate: this
+		// is the one boundary that authors an internal-producer marker, and it
+		// should be unable to author one the readers reject. The readers are
+		// strict (ParseCatalogProvenance requires a trimmed space_id) while the
+		// gate on the way in only tests emptiness, and whether an untrimmed
+		// Space survives the membership lookup is decided by a collation the
+		// application does not choose: space_member declares none and inherits
+		// the database default, and CI creates that database PAD SPACE
+		// (utf8mb4_general_ci), where 'space-a ' matches 'space-a'. A stamped
+		// frame that no reader accepts is unclickable and uneditable forever,
+		// so this refuses the send instead of delivering a broken card.
+		if err := provenance.Validate(); err != nil {
+			terminal = cardErrorCategory(err)
+			return nil, categorized(terminal, err)
+		}
+		payload[cardmsg.CatalogTemplateRefKey] = map[string]interface{}{
+			"id": refID, "version": refVersion,
+		}
+		payload[cardmsg.CatalogProvenanceKey] = provenance.MarshalMap()
+	}
+
 	// Authorization has already established this exact active Space. It is the
 	// only source allowed to enrich the wire envelope.
 	payload["space_id"] = target.SpaceID
@@ -200,6 +238,23 @@ func validateRequest(ctx context.Context, target Target, card Card) error {
 		return errors.New("unsupported render profile")
 	}
 	return nil
+}
+
+// cardDocumentTemplateContext 从裸 card 节点提取 Registry 模板身份，语义与
+// cardmsg.CardTemplateContext（信封形态）一致：协议必须是 octo-card@1.0，
+// id/version 非空且已 trim；任何偏差都按「非 Registry 文档」处理（不写标记）。
+func cardDocumentTemplateContext(card map[string]interface{}) (string, string, bool) {
+	metadata, _ := card["metadata"].(map[string]interface{})
+	octo, _ := metadata["octo"].(map[string]interface{})
+	template, _ := octo["template"].(map[string]interface{})
+	protocol, _ := octo["protocol"].(string)
+	id, _ := template["id"].(string)
+	version, _ := template["version"].(string)
+	if protocol != "octo-card@1.0" || id == "" || version == "" ||
+		strings.TrimSpace(id) != id || strings.TrimSpace(version) != version {
+		return "", "", false
+	}
+	return id, version, true
 }
 
 func cardErrorCategory(err error) Category {

--- a/internal/carddispatch/dispatch_test.go
+++ b/internal/carddispatch/dispatch_test.go
@@ -698,3 +698,162 @@ func metricHasLabels(pairs []*dto.LabelPair, want map[string]string) bool {
 	}
 	return true
 }
+
+// ---- PR-C Slice 1 (D3): the trusted dispatch boundary authors catalog
+// provenance from the registered ProducerSpec and the authorized target Space.
+// Business callers cannot self-report a principal. ----
+
+func registryCardDocument() json.RawMessage {
+	return json.RawMessage(`{
+		"type":"AdaptiveCard","version":"1.5",
+		"body":[{"type":"TextBlock","text":"pending"}],
+		"metadata":{"octo":{
+			"protocol":"octo-card@1.0",
+			"template":{"id":"docs.access-request","version":"0.3.0"}
+		}}
+	}`)
+}
+
+func TestSendAuthorsCatalogProvenanceForRegistryDocuments(t *testing.T) {
+	registry, _, _, transport, _ := newHarness(t, validSpec())
+	sender, err := registry.Sender("summary-notify")
+	require.NoError(t, err)
+
+	_, err = sender.Send(context.Background(), validTarget(), Card{
+		Profile: cardmsg.ProfileV1, Document: registryCardDocument(),
+	})
+	require.NoError(t, err)
+	_, req := transport.snapshot()
+	require.NotNil(t, req)
+	var wire map[string]interface{}
+	require.NoError(t, json.Unmarshal(req.Payload, &wire))
+
+	ref, _ := wire["template_ref"].(map[string]interface{})
+	require.NotNil(t, ref, "server-authored template_ref missing: %s", req.Payload)
+	assert.Equal(t, "docs.access-request", ref["id"])
+	assert.Equal(t, "0.3.0", ref["version"])
+
+	provenance, err := cardmsg.ParseCatalogProvenance(wire["catalog_provenance"])
+	require.NoError(t, err, "authored provenance must be canonical: %#v", wire["catalog_provenance"])
+	assert.Equal(t, cardmsg.CatalogPrincipalWireInternalProducer, provenance.PrincipalType)
+	assert.Equal(t, "summary-notify", provenance.PrincipalID, "principal is the registered ProducerSpec.ID")
+	assert.Equal(t, "space-a", provenance.SpaceID, "space is the authorized target Space")
+
+	// The outbound frame must satisfy the same strict marker contract the
+	// action ingress will later enforce.
+	markers, err := cardmsg.CatalogFrameMarkers(req.Payload)
+	require.NoError(t, err)
+	assert.True(t, markers.HasRef)
+	assert.True(t, markers.HasProvenance)
+}
+
+// PR-C review round 6 (yujiawei P1-1): the marker-authoring boundary must be
+// unable to author a marker its readers reject.
+//
+// cardmsg.Validate runs before these keys exist and Finalize does not
+// re-validate, so before this guard an untrimmed target Space produced a stored
+// frame that every reader refuses — ParseCatalogProvenance requires a trimmed
+// space_id. The card rendered and then nothing about it worked: every button
+// click and every edit failed permanently, with no way to repair the message.
+//
+// Reaching it needed only an untrimmed Space to survive the membership lookup,
+// and whether it does is decided by a collation the application does not
+// choose. space_member declares none and inherits the database default; CI
+// creates that database utf8mb4_general_ci, which is PAD SPACE, so 'space-a '
+// matches 'space-a'. Measured both ways: PAD SPACE matches, and the MySQL 8.0
+// default utf8mb4_0900_ai_ci (NO PAD) does not. Refusing the send here removes
+// the dependency on that fact entirely.
+func TestSendRefusesToAuthorAMarkerItsReadersWouldReject(t *testing.T) {
+	registry, _, _, transport, _ := newHarness(t, validSpec())
+	sender, err := registry.Sender("summary-notify")
+	require.NoError(t, err)
+
+	untrimmed := validTarget()
+	untrimmed.SpaceID = "space-a "
+
+	_, err = sender.Send(context.Background(), untrimmed, Card{
+		Profile: cardmsg.ProfileV1, Document: registryCardDocument(),
+	})
+	require.Error(t, err, "an untrimmed Space produced a card whose markers no reader accepts")
+	require.ErrorIs(t, err, cardmsg.ErrCatalogMarkerInvalid)
+
+	// Nothing was delivered: the send fails instead of storing a broken card.
+	_, req := transport.snapshot()
+	assert.Nil(t, req, "a frame with an unreadable marker reached the transport")
+}
+
+func TestSendLeavesLegacyDocumentsUnmarked(t *testing.T) {
+	registry, _, _, transport, _ := newHarness(t, validSpec())
+	sender, err := registry.Sender("summary-notify")
+	require.NoError(t, err)
+
+	_, err = sender.Send(context.Background(), validTarget(), Card{
+		Profile: cardmsg.ProfileV1, Document: validCardDocument(),
+	})
+	require.NoError(t, err)
+	_, req := transport.snapshot()
+	require.NotNil(t, req)
+	var wire map[string]interface{}
+	require.NoError(t, json.Unmarshal(req.Payload, &wire))
+	_, hasRef := wire["template_ref"]
+	_, hasProvenance := wire["catalog_provenance"]
+	assert.False(t, hasRef, "legacy document grew template_ref")
+	assert.False(t, hasProvenance, "legacy document grew catalog_provenance")
+}
+
+func TestProducerBindingExposesReadOnlySenderFacts(t *testing.T) {
+	enabled := validSpec()
+	disabled := validSpec()
+	disabled.ID = "docs-notify"
+	disabled.SenderUID = "notification"
+	disabled.Enabled = false
+	registry := NewRegistry(Dependencies{
+		IdentityResolver: &fakeIdentityResolver{identity: &botidentity.Identity{UID: "summary", Kind: botidentity.KindUserBot}},
+		Authorizer:       &fakeAuthorizer{},
+		Transport:        &fakeTransport{},
+		Metrics:          NewMetrics(prometheus.NewRegistry()),
+	}, []ProducerSpec{enabled, disabled})
+
+	sender, ok := registry.ProducerBinding("summary-notify")
+	require.True(t, ok)
+	assert.Equal(t, "summary", sender)
+
+	// A disabled producer cannot send, but its declared identity binding is
+	// still a fact the action ingress may verify historical frames against.
+	sender, ok = registry.ProducerBinding("docs-notify")
+	require.True(t, ok)
+	assert.Equal(t, "notification", sender)
+
+	_, ok = registry.ProducerBinding("never-registered")
+	assert.False(t, ok)
+
+	store := &fakeValueStore{}
+	require.NoError(t, Install(store, registry))
+	sender, ok = ProducerBindingFromContext(store, "summary-notify")
+	require.True(t, ok)
+	assert.Equal(t, "summary", sender)
+	_, ok = ProducerBindingFromContext(store, "never-registered")
+	assert.False(t, ok)
+	_, ok = ProducerBindingFromContext(&fakeValueStore{}, "summary-notify")
+	assert.False(t, ok, "missing registry must fail closed")
+}
+
+func TestProducerBindingRejectsAmbiguousOrInvalidSpecs(t *testing.T) {
+	duplicateA := validSpec()
+	duplicateB := validSpec()
+	invalid := validSpec()
+	invalid.ID = "docs-notify"
+	invalid.SenderUID = "iwh_webhook"
+	registry := NewRegistry(Dependencies{
+		IdentityResolver: &fakeIdentityResolver{identity: &botidentity.Identity{UID: "summary", Kind: botidentity.KindUserBot}},
+		Authorizer:       &fakeAuthorizer{},
+		Transport:        &fakeTransport{},
+		Metrics:          NewMetrics(prometheus.NewRegistry()),
+	}, []ProducerSpec{duplicateA, duplicateB, invalid})
+	if _, ok := registry.ProducerBinding("summary-notify"); ok {
+		t.Fatal("duplicate producer ID must not expose a binding")
+	}
+	if _, ok := registry.ProducerBinding("docs-notify"); ok {
+		t.Fatal("webhook-prefixed sender must not expose a binding")
+	}
+}

--- a/internal/carddispatch/mutation.go
+++ b/internal/carddispatch/mutation.go
@@ -187,6 +187,37 @@ func (m *CardMutator) Mutate(ctx context.Context, request CardMutationRequest) (
 	if revoked || deleted {
 		return CardMutationResult{}, ErrCardMutationNotFound
 	}
+	// The server-authored catalog markers are the card's identity, and identity
+	// does not change under an edit — pkg/cardtmpl/updater.go states exactly
+	// that, but stated it only for the path that happens to go through the
+	// updater. A caller that assembles a replacement frame from its own key set
+	// simply dropped them, and every guard keyed on their presence then went
+	// inert for that message: the stored-version pin and the cross-Space
+	// refusal both begin `if markers.Has…`. A user click was enough to trigger
+	// it, so this is enforced where every replacement passes rather than at
+	// each site that builds one.
+	//
+	// Absent on both sides is the legacy population and stays legal. Present on
+	// the stored frame and absent on the replacement is the erasure, and it is
+	// refused rather than repaired: re-attaching a template_ref would need the
+	// replacement's own card body to carry the matching metadata.octo.template,
+	// which a non-Registry render does not have, so "repair" would either fail
+	// validation anyway or stamp a Registry identity onto a body that is not
+	// one. The caller has to produce a frame that legitimately carries them.
+	stored, err := cardmsg.CatalogFrameMarkers(message.Payload)
+	if err != nil {
+		return CardMutationResult{}, fmt.Errorf("%w: stored frame markers: %v", ErrCardMutationInvalid, err)
+	}
+	if stored.HasRef || stored.HasProvenance {
+		next, markerErr := cardmsg.CatalogFrameMarkers([]byte(request.ContentEdit))
+		if markerErr != nil {
+			return CardMutationResult{}, fmt.Errorf("%w: replacement frame markers: %v", ErrCardMutationInvalid, markerErr)
+		}
+		if stored.HasRef != next.HasRef || stored.HasProvenance != next.HasProvenance {
+			return CardMutationResult{}, fmt.Errorf(
+				"%w: replacement drops the stored catalog markers", ErrCardMutationInvalid)
+		}
+	}
 	normalized, err := cardmsg.NormalizeContentEdit(request.ContentEdit)
 	if err != nil {
 		return CardMutationResult{}, fmt.Errorf("%w: %v", ErrCardMutationInvalid, err)

--- a/internal/carddispatch/mutation.go
+++ b/internal/carddispatch/mutation.go
@@ -205,18 +205,40 @@ func (m *CardMutator) Mutate(ctx context.Context, request CardMutationRequest) (
 	// acquire and so made every already-delivered Registry card permanently
 	// uneditable — the edit that would have added the marker was the operation
 	// being rejected.
-	stored, err := cardmsg.CatalogFrameMarkers(message.Payload)
+	//
+	// The comparison is against the *effective* frame, the same one Snapshot
+	// returns, not against message.Payload. Payload is the immutable original;
+	// edits live in message_extra.content_edit. Allowing the acquire above is
+	// exactly what makes those two diverge in markers, so reading the original
+	// here would have made the guard inert for the population the relaxation
+	// just created: a pre-PR-C frame is HasProvenance=false in the original
+	// forever, so from the second edit onward a replacement could drop the
+	// provenance the first edit added, or keep it and rewrite its values, and
+	// both clauses would compare against bytes that never change.
+	//
+	// The call is unconditional. Reading the effective frame already makes the
+	// old `if stored.HasRef || stored.HasProvenance` gate redundant rather than
+	// wrong — it is dropped because CatalogMarkersPreserved answers "nothing to
+	// preserve" for the both-absent case anyway, and a gate that skips the whole
+	// check is the shape that hid the previous defect.
+	effective, _, hasEffective, err := m.backend.EffectiveContent(request.MessageID)
+	if err != nil {
+		return CardMutationResult{}, fmt.Errorf("carddispatch: query effective card: %w", err)
+	}
+	storedFrame := message.Payload
+	if hasEffective {
+		storedFrame = []byte(effective)
+	}
+	stored, err := cardmsg.CatalogFrameMarkers(storedFrame)
 	if err != nil {
 		return CardMutationResult{}, fmt.Errorf("%w: stored frame markers: %v", ErrCardMutationInvalid, err)
 	}
-	if stored.HasRef || stored.HasProvenance {
-		next, markerErr := cardmsg.CatalogFrameMarkers([]byte(request.ContentEdit))
-		if markerErr != nil {
-			return CardMutationResult{}, fmt.Errorf("%w: replacement frame markers: %v", ErrCardMutationInvalid, markerErr)
-		}
-		if preserveErr := cardmsg.CatalogMarkersPreserved(stored, next); preserveErr != nil {
-			return CardMutationResult{}, fmt.Errorf("%w: %v", ErrCardMutationInvalid, preserveErr)
-		}
+	next, err := cardmsg.CatalogFrameMarkers([]byte(request.ContentEdit))
+	if err != nil {
+		return CardMutationResult{}, fmt.Errorf("%w: replacement frame markers: %v", ErrCardMutationInvalid, err)
+	}
+	if preserveErr := cardmsg.CatalogMarkersPreserved(stored, next); preserveErr != nil {
+		return CardMutationResult{}, fmt.Errorf("%w: %v", ErrCardMutationInvalid, preserveErr)
 	}
 	normalized, err := cardmsg.NormalizeContentEdit(request.ContentEdit)
 	if err != nil {

--- a/internal/carddispatch/mutation.go
+++ b/internal/carddispatch/mutation.go
@@ -197,13 +197,14 @@ func (m *CardMutator) Mutate(ctx context.Context, request CardMutationRequest) (
 	// it, so this is enforced where every replacement passes rather than at
 	// each site that builds one.
 	//
-	// Absent on both sides is the legacy population and stays legal. Present on
-	// the stored frame and absent on the replacement is the erasure, and it is
-	// refused rather than repaired: re-attaching a template_ref would need the
-	// replacement's own card body to carry the matching metadata.octo.template,
-	// which a non-Registry render does not have, so "repair" would either fail
-	// validation anyway or stamp a Registry identity onto a body that is not
-	// one. The caller has to produce a frame that legitimately carries them.
+	// Absent on both sides is the legacy population and stays legal. The rule
+	// itself lives in cardmsg.CatalogMarkersPreserved so there is one definition
+	// of it: erasure is refused, acquiring a marker on a pre-PR-C frame is
+	// allowed, and changing one where both sides carry it is refused. An earlier
+	// version compared presence for equality here, which also refused the
+	// acquire and so made every already-delivered Registry card permanently
+	// uneditable — the edit that would have added the marker was the operation
+	// being rejected.
 	stored, err := cardmsg.CatalogFrameMarkers(message.Payload)
 	if err != nil {
 		return CardMutationResult{}, fmt.Errorf("%w: stored frame markers: %v", ErrCardMutationInvalid, err)
@@ -213,9 +214,8 @@ func (m *CardMutator) Mutate(ctx context.Context, request CardMutationRequest) (
 		if markerErr != nil {
 			return CardMutationResult{}, fmt.Errorf("%w: replacement frame markers: %v", ErrCardMutationInvalid, markerErr)
 		}
-		if stored.HasRef != next.HasRef || stored.HasProvenance != next.HasProvenance {
-			return CardMutationResult{}, fmt.Errorf(
-				"%w: replacement drops the stored catalog markers", ErrCardMutationInvalid)
+		if preserveErr := cardmsg.CatalogMarkersPreserved(stored, next); preserveErr != nil {
+			return CardMutationResult{}, fmt.Errorf("%w: %v", ErrCardMutationInvalid, preserveErr)
 		}
 	}
 	normalized, err := cardmsg.NormalizeContentEdit(request.ContentEdit)

--- a/internal/carddispatch/mutation_test.go
+++ b/internal/carddispatch/mutation_test.go
@@ -463,3 +463,100 @@ func TestCardMutatorRefusesToRewriteStoredMarkerValues(t *testing.T) {
 		})
 	}
 }
+
+// PR-C review round 9 (Jerry-Xin and yujiawei, independently): the guard read
+// message.Payload, the immutable original, while edits persist to
+// message_extra.content_edit. Snapshot honours that distinction twelve lines
+// above; Mutate did not.
+//
+// The population this strands is the one the round-8 relaxation created. A
+// pre-PR-C card is HasProvenance=false in the original forever, so once the
+// first edit legitimately acquires provenance into content_edit, every later
+// edit was compared against bytes that no longer describe the card: the
+// provenance could be dropped outright, or kept and rewritten, and both clauses
+// were dead.
+//
+// The missing grid axis is not a case, it is the second dimension — the
+// effective frame differing from the original.
+func TestCardMutatorComparesAgainstTheEffectiveFrameNotTheOriginal(t *testing.T) {
+	for _, test := range []struct {
+		name      string
+		original  func(*testing.T, int64, bool) []byte
+		effective func(*testing.T, int64, bool) []byte
+		next      func(*testing.T, int64, bool) []byte
+		wantErr   bool
+	}{
+		{
+			// The exact sequence: pre-PR-C card, edit #1 acquires provenance,
+			// edit #2 drops it. Against the original this looked like no change.
+			name:     "provenance acquired by an earlier edit may not be dropped by a later one",
+			original: prePRCRegistryEnvelope, effective: markedTestCardEnvelope, next: prePRCRegistryEnvelope,
+			wantErr: true,
+		},
+		{
+			name:     "nor rewritten once the effective frame carries it",
+			original: prePRCRegistryEnvelope, effective: markedTestCardEnvelope,
+			next: func(t *testing.T, seq int64, act bool) []byte {
+				t.Helper()
+				var envelope map[string]interface{}
+				if err := json.Unmarshal(markedTestCardEnvelope(t, seq, act), &envelope); err != nil {
+					t.Fatal(err)
+				}
+				envelope[cardmsg.CatalogProvenanceKey] = cardmsg.CatalogProvenance{
+					Version:       cardmsg.CatalogProvenanceVersion,
+					PrincipalType: cardmsg.CatalogPrincipalWireInternalProducer,
+					PrincipalID:   "someone-else",
+					SpaceID:       "space-1",
+				}.MarshalMap()
+				raw, err := json.Marshal(envelope)
+				if err != nil {
+					t.Fatal(err)
+				}
+				return raw
+			},
+			wantErr: true,
+		},
+		{
+			name:     "carrying the acquired provenance through is applied",
+			original: prePRCRegistryEnvelope, effective: markedTestCardEnvelope, next: markedTestCardEnvelope,
+		},
+		{
+			// The gate that used to skip the whole check when the *original*
+			// carried nothing: a legacy original whose effective frame has since
+			// been marked still gets the protection.
+			name:     "an unmarked original does not disable the check",
+			original: testCardEnvelope, effective: markedTestCardEnvelope, next: testCardEnvelope,
+			wantErr: true,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			effective := test.effective(t, 41, false)
+			backend := &fakeMutationBackend{
+				message: storedCardMessage{
+					MessageID: "1001", MessageSeq: 7, FromUID: "notification",
+					Payload: test.original(t, 0, true),
+				},
+				effective: string(effective), effectiveSeq: 41, effectiveSet: true,
+			}
+			_, err := newCardMutator(backend).Mutate(context.Background(), CardMutationRequest{
+				SenderUID: "notification", MessageID: "1001", ChannelID: "user-b", ChannelType: 1,
+				ContentEdit: string(test.next(t, 42, false)),
+			})
+			if test.wantErr {
+				if !errors.Is(err, ErrCardMutationInvalid) {
+					t.Fatalf("Mutate() error = %v, want ErrCardMutationInvalid", err)
+				}
+				if len(backend.writes) != 0 {
+					t.Fatalf("a refused replacement was persisted: %+v", backend.writes)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Mutate() error = %v, want success", err)
+			}
+			if len(backend.writes) != 1 {
+				t.Fatalf("writes = %+v, want 1", backend.writes)
+			}
+		})
+	}
+}

--- a/internal/carddispatch/mutation_test.go
+++ b/internal/carddispatch/mutation_test.go
@@ -215,3 +215,94 @@ func testCardEnvelope(t *testing.T, cardSeq int64, withAction bool) []byte {
 	}
 	return raw
 }
+
+// markedTestCardEnvelope is testCardEnvelope plus the server-authored catalog
+// markers a Registry render carries: both top-level keys and the matching
+// metadata.octo.template they are validated against.
+func markedTestCardEnvelope(t *testing.T, cardSeq int64, withAction bool) []byte {
+	t.Helper()
+	var envelope map[string]interface{}
+	if err := json.Unmarshal(testCardEnvelope(t, cardSeq, withAction), &envelope); err != nil {
+		t.Fatal(err)
+	}
+	card := envelope["card"].(map[string]interface{})
+	card["metadata"] = map[string]interface{}{
+		"octo": map[string]interface{}{
+			"protocol": "octo-card@1.0",
+			"template": map[string]interface{}{"id": "docs.access-request", "version": "0.3.0"},
+		},
+	}
+	envelope[cardmsg.CatalogTemplateRefKey] = map[string]interface{}{
+		"id": "docs.access-request", "version": "0.3.0",
+	}
+	envelope[cardmsg.CatalogProvenanceKey] = cardmsg.CatalogProvenance{
+		Version:       cardmsg.CatalogProvenanceVersion,
+		PrincipalType: cardmsg.CatalogPrincipalWireInternalProducer,
+		PrincipalID:   "docs-notify",
+		SpaceID:       "space-1",
+	}.MarshalMap()
+	raw, err := json.Marshal(envelope)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return raw
+}
+
+// PR-C review round 6 (yujiawei P1-2), the structural half.
+//
+// The catalog markers are the card's identity and identity does not change
+// under an edit. pkg/cardtmpl/updater.go states that, but only the paths that
+// go through the updater honoured it: a caller assembling a replacement from
+// its own key set simply dropped them, and both identity guards — the
+// stored-version pin and the cross-Space refusal — begin `if markers.Has…`, so
+// they went inert for that message. Enforcing it here means no future call site
+// can silently downgrade a marked card, whatever frame it builds.
+func TestCardMutatorRefusesToDropStoredCatalogMarkers(t *testing.T) {
+	marked := markedTestCardEnvelope(t, 0, true)
+
+	t.Run("a replacement that drops the markers is refused", func(t *testing.T) {
+		backend := &fakeMutationBackend{message: storedCardMessage{
+			MessageID: "1001", MessageSeq: 7, FromUID: "notification", Payload: marked,
+		}}
+		_, err := newCardMutator(backend).Mutate(context.Background(), CardMutationRequest{
+			SenderUID: "notification", MessageID: "1001", ChannelID: "user-b", ChannelType: 1,
+			ContentEdit: string(testCardEnvelope(t, 42, false)), // legacy six-key rebuild
+		})
+		if !errors.Is(err, ErrCardMutationInvalid) {
+			t.Fatalf("Mutate() error = %v, want ErrCardMutationInvalid", err)
+		}
+		if len(backend.writes) != 0 {
+			t.Fatalf("a marker-erasing frame was persisted: %+v", backend.writes)
+		}
+	})
+
+	t.Run("a replacement that carries them through is applied", func(t *testing.T) {
+		backend := &fakeMutationBackend{message: storedCardMessage{
+			MessageID: "1001", MessageSeq: 7, FromUID: "notification", Payload: marked,
+		}}
+		result, err := newCardMutator(backend).Mutate(context.Background(), CardMutationRequest{
+			SenderUID: "notification", MessageID: "1001", ChannelID: "user-b", ChannelType: 1,
+			ContentEdit: string(markedTestCardEnvelope(t, 42, false)),
+		})
+		if err != nil {
+			t.Fatalf("Mutate() error = %v", err)
+		}
+		if !result.Applied || len(backend.writes) != 1 {
+			t.Fatalf("result = %+v writes = %+v", result, backend.writes)
+		}
+	})
+
+	t.Run("the legacy population is untouched", func(t *testing.T) {
+		backend := &fakeMutationBackend{message: storedCardMessage{
+			MessageID: "1001", MessageSeq: 7, FromUID: "notification",
+			Payload: testCardEnvelope(t, 0, true),
+		}}
+		result, err := newCardMutator(backend).Mutate(context.Background(), CardMutationRequest{
+			SenderUID: "notification", MessageID: "1001", ChannelID: "user-b", ChannelType: 1,
+			ContentEdit: string(testCardEnvelope(t, 42, false)),
+		})
+		if err != nil || !result.Applied {
+			t.Fatalf("an unmarked card must still be editable: result = %+v err = %v", result, err)
+		}
+	})
+}

--- a/internal/carddispatch/mutation_test.go
+++ b/internal/carddispatch/mutation_test.go
@@ -306,3 +306,160 @@ func TestCardMutatorRefusesToDropStoredCatalogMarkers(t *testing.T) {
 		}
 	})
 }
+
+// prePRCRegistryEnvelope is what a Bot Registry card already in storage looks
+// like: the merge-base renderPayload stamped `template_ref` only ("Retain only
+// the canonical ref as server-authored provenance"), so every such frame is
+// HasRef=true, HasProvenance=false.
+//
+// It is built here rather than reused from markedTestCardEnvelope because the
+// bug this covers was invisible to a fixture built from the *new* send path —
+// that path always writes both markers, so it can never produce the shape the
+// production population actually has.
+func prePRCRegistryEnvelope(t *testing.T, cardSeq int64, withAction bool) []byte {
+	t.Helper()
+	var envelope map[string]interface{}
+	if err := json.Unmarshal(markedTestCardEnvelope(t, cardSeq, withAction), &envelope); err != nil {
+		t.Fatal(err)
+	}
+	delete(envelope, cardmsg.CatalogProvenanceKey)
+	raw, err := json.Marshal(envelope)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return raw
+}
+
+// PR-C review round 8: one case per frame shape reachable in production today,
+// against the mutation boundary every replacement passes through.
+//
+// Both blockers found in review shared a shape — a guard moved to a boundary,
+// with the compatibility consequence for already-stored frames reasoned about
+// in a comment instead of pinned by a test that starts from pre-change bytes.
+// The grid is the answer to that: the axis that was missing is not a case, it
+// is the stored side.
+func TestCardMutatorMarkerRuleCoversEveryStoredFrameShape(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		stored  func(*testing.T, int64, bool) []byte
+		next    func(*testing.T, int64, bool) []byte
+		wantErr bool
+	}{
+		{
+			name:   "legacy stays legacy",
+			stored: testCardEnvelope, next: testCardEnvelope,
+		},
+		{
+			// The regression. Every Bot Registry card already in storage is this
+			// shape, and an edit is the only way it can ever acquire provenance —
+			// so refusing the acquire made those cards permanently uneditable,
+			// with the refusal reported as "drops the stored catalog markers".
+			name:   "a pre-PR-C ref-only frame may acquire provenance",
+			stored: prePRCRegistryEnvelope, next: markedTestCardEnvelope,
+		},
+		{
+			name:   "a marked frame may be replaced by the same markers",
+			stored: markedTestCardEnvelope, next: markedTestCardEnvelope,
+		},
+		{
+			name:   "a marked frame may not lose them",
+			stored: markedTestCardEnvelope, next: testCardEnvelope,
+			wantErr: true,
+		},
+		{
+			name:   "a ref-only frame may not lose its ref",
+			stored: prePRCRegistryEnvelope, next: testCardEnvelope,
+			wantErr: true,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			backend := &fakeMutationBackend{message: storedCardMessage{
+				MessageID: "1001", MessageSeq: 7, FromUID: "notification",
+				Payload: test.stored(t, 0, true),
+			}}
+			_, err := newCardMutator(backend).Mutate(context.Background(), CardMutationRequest{
+				SenderUID: "notification", MessageID: "1001", ChannelID: "user-b", ChannelType: 1,
+				ContentEdit: string(test.next(t, 42, false)),
+			})
+			if test.wantErr {
+				if !errors.Is(err, ErrCardMutationInvalid) {
+					t.Fatalf("Mutate() error = %v, want ErrCardMutationInvalid", err)
+				}
+				if len(backend.writes) != 0 {
+					t.Fatalf("a refused replacement was persisted: %+v", backend.writes)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Mutate() error = %v, want success", err)
+			}
+			if len(backend.writes) != 1 {
+				t.Fatalf("writes = %+v, want 1", backend.writes)
+			}
+		})
+	}
+}
+
+// Identity does not change under an edit, so a replacement that keeps both keys
+// and rewrites one of the values is refused too. Presence-only comparison let
+// that through; no in-tree caller reaches it, which is why it needs its own
+// test rather than waiting for one to appear.
+func TestCardMutatorRefusesToRewriteStoredMarkerValues(t *testing.T) {
+	rewrite := func(t *testing.T, mutate func(map[string]interface{})) []byte {
+		t.Helper()
+		var envelope map[string]interface{}
+		if err := json.Unmarshal(markedTestCardEnvelope(t, 42, false), &envelope); err != nil {
+			t.Fatal(err)
+		}
+		mutate(envelope)
+		raw, err := json.Marshal(envelope)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return raw
+	}
+	for _, test := range []struct {
+		name   string
+		mutate func(map[string]interface{})
+	}{
+		{
+			name: "a different producer",
+			mutate: func(envelope map[string]interface{}) {
+				envelope[cardmsg.CatalogProvenanceKey] = cardmsg.CatalogProvenance{
+					Version:       cardmsg.CatalogProvenanceVersion,
+					PrincipalType: cardmsg.CatalogPrincipalWireInternalProducer,
+					PrincipalID:   "someone-else",
+					SpaceID:       "space-1",
+				}.MarshalMap()
+			},
+		},
+		{
+			name: "a different Space",
+			mutate: func(envelope map[string]interface{}) {
+				envelope[cardmsg.CatalogProvenanceKey] = cardmsg.CatalogProvenance{
+					Version:       cardmsg.CatalogProvenanceVersion,
+					PrincipalType: cardmsg.CatalogPrincipalWireInternalProducer,
+					PrincipalID:   "docs-notify",
+					SpaceID:       "space-elsewhere",
+				}.MarshalMap()
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			backend := &fakeMutationBackend{message: storedCardMessage{
+				MessageID: "1001", MessageSeq: 7, FromUID: "notification",
+				Payload: markedTestCardEnvelope(t, 0, true),
+			}}
+			_, err := newCardMutator(backend).Mutate(context.Background(), CardMutationRequest{
+				SenderUID: "notification", MessageID: "1001", ChannelID: "user-b", ChannelType: 1,
+				ContentEdit: string(rewrite(t, test.mutate)),
+			})
+			if !errors.Is(err, ErrCardMutationInvalid) {
+				t.Fatalf("Mutate() error = %v, want ErrCardMutationInvalid", err)
+			}
+			if len(backend.writes) != 0 {
+				t.Fatalf("a rewritten marker was persisted: %+v", backend.writes)
+			}
+		})
+	}
+}

--- a/internal/carddispatch/registry.go
+++ b/internal/carddispatch/registry.go
@@ -18,12 +18,19 @@ var producerIDPattern = regexp.MustCompile(`^[a-z][a-z0-9-]{0,63}$`)
 type Registry struct {
 	senders map[ProducerID]*producerSender
 	invalid map[ProducerID]struct{}
+	// bindings 是 ProducerID → 权威 SenderUID 的只读事实表（PR-C D3）。
+	// action-context 用它校验 stored provenance：帧声明的 internal producer
+	// 是否真的绑定到该消息的 FromUID。disabled 的 spec 也登记 —— 停用只收回
+	// 发送能力，不抹掉身份事实（历史帧仍需校验）；duplicate/畸形 spec 身份
+	// 有歧义，不登记。
+	bindings map[ProducerID]string
 }
 
 func NewRegistry(deps Dependencies, specs []ProducerSpec) *Registry {
 	registry := &Registry{
-		senders: make(map[ProducerID]*producerSender),
-		invalid: make(map[ProducerID]struct{}),
+		senders:  make(map[ProducerID]*producerSender),
+		invalid:  make(map[ProducerID]struct{}),
+		bindings: make(map[ProducerID]string),
 	}
 	counts := make(map[ProducerID]int, len(specs))
 	for _, spec := range specs {
@@ -38,6 +45,7 @@ func NewRegistry(deps Dependencies, specs []ProducerSpec) *Registry {
 			}
 			continue
 		}
+		registry.recordBinding(input)
 		if !input.Enabled {
 			registry.invalid[input.ID] = struct{}{}
 			continue
@@ -76,9 +84,33 @@ func (r *Registry) Sender(id ProducerID) (Sender, error) {
 	return sender, nil
 }
 
+// recordBinding 登记一条身份事实。只接受形状合法的 (ID, SenderUID)：ID 走与
+// 发送侧相同的 pattern，sender 非空且非 incoming-webhook 前缀。
+func (r *Registry) recordBinding(spec ProducerSpec) {
+	if !producerIDPattern.MatchString(string(spec.ID)) {
+		return
+	}
+	sender := strings.TrimSpace(spec.SenderUID)
+	if sender == "" || strings.HasPrefix(sender, "iwh_") {
+		return
+	}
+	r.bindings[spec.ID] = sender
+}
+
+// ProducerBinding 返回 ProducerID 声明的权威 SenderUID。只读事实，不携带
+// 发送能力；调用方不能据此拿到 Sender。
+func (r *Registry) ProducerBinding(id ProducerID) (string, bool) {
+	if r == nil {
+		return "", false
+	}
+	sender, ok := r.bindings[id]
+	return sender, ok
+}
+
 func (r *Registry) reject(deps Dependencies, id ProducerID, reason string) {
 	r.invalid[id] = struct{}{}
 	delete(r.senders, id)
+	delete(r.bindings, id)
 	producer := metricProducerLabel(id)
 	deps.Metrics.configError(producer, reason)
 	if deps.Logger != nil {

--- a/modules/bot_api/card_template_catalog.go
+++ b/modules/bot_api/card_template_catalog.go
@@ -244,7 +244,7 @@ func (c *botCardTemplateCatalog) RenderPayload(
 		return nil, errBotTemplateCatalogUnavailable
 	}
 	return c.renderPayload(ctx, "bot-api-compat", cardtmpl.CatalogPurposeNewSend,
-		inbound, env, c.sendAllowed, "not Bot-callable for new send")
+		inbound, env, c.sendAllowed, "not Bot-callable for new send", false)
 }
 
 func (c *botCardTemplateCatalog) RenderPayloadForPrincipal(
@@ -257,7 +257,7 @@ func (c *botCardTemplateCatalog) RenderPayloadForPrincipal(
 		return nil, errBotTemplateCatalogUnavailable
 	}
 	return c.renderPayload(ctx, botID, cardtmpl.CatalogPurposeNewSend,
-		inbound, env, c.sendAllowed, "not Bot-callable for new send")
+		inbound, env, c.sendAllowed, "not Bot-callable for new send", true)
 }
 
 func (c *botCardTemplateCatalog) RenderEditPayload(
@@ -269,7 +269,7 @@ func (c *botCardTemplateCatalog) RenderEditPayload(
 		return nil, errBotTemplateCatalogUnavailable
 	}
 	return c.renderPayload(ctx, "bot-api-compat", cardtmpl.CatalogPurposeHistoricalEdit,
-		inbound, env, c.editAllowed, "not edit-compatible")
+		inbound, env, c.editAllowed, "not edit-compatible", false)
 }
 
 func (c *botCardTemplateCatalog) RenderEditPayloadForPrincipal(
@@ -282,7 +282,7 @@ func (c *botCardTemplateCatalog) RenderEditPayloadForPrincipal(
 		return nil, errBotTemplateCatalogUnavailable
 	}
 	return c.renderPayload(ctx, botID, cardtmpl.CatalogPurposeHistoricalEdit,
-		inbound, env, c.editAllowed, "not edit-compatible")
+		inbound, env, c.editAllowed, "not edit-compatible", true)
 }
 
 func (c *botCardTemplateCatalog) renderPayload(
@@ -293,6 +293,7 @@ func (c *botCardTemplateCatalog) renderPayload(
 	env cardtmpl.BuildEnv,
 	allowed map[botTemplateRef]struct{},
 	denialReason string,
+	authorProvenance bool,
 ) (map[string]any, error) {
 	if c == nil || c.catalog == nil {
 		return nil, errBotTemplateCatalogUnavailable
@@ -344,11 +345,33 @@ func (c *botCardTemplateCatalog) renderPayload(
 		}
 		return nil, fmt.Errorf("bot template render %s@%s: %w", ref.ID, ref.Version, err)
 	}
-	// Retain only the canonical ref as server-authored provenance. Raw Model B
-	// ingress rejects card+template_ref, so edit can distinguish a Registry frame
-	// from a caller-authored card that merely forged metadata.octo.template.
+	// Retain the canonical ref plus the authenticated-principal provenance as
+	// server-authored markers (PR-C D3). Raw Model B ingress rejects both keys,
+	// so edit/action ingress can trust a marked frame came from this boundary.
+	// env.SpaceID is server-resolved (send: resolveBotActiveSpaceID; edit: the
+	// Snapshot-pinned envelope Space) — callers never supply it.
 	rendered["template_ref"] = map[string]any{
 		"id": string(ref.ID), "version": ref.Version,
+	}
+	if authorProvenance {
+		provenance := cardmsg.CatalogProvenance{
+			Version:       cardmsg.CatalogProvenanceVersion,
+			PrincipalType: cardmsg.CatalogPrincipalWireBot,
+			PrincipalID:   botID,
+			SpaceID:       env.SpaceID,
+		}
+		// Same reason as the internal-producer boundary in
+		// internal/carddispatch: an authoring site must not be able to write a
+		// marker its readers reject, and no later stage re-validates —
+		// cardmsg.Validate runs before these keys exist and Finalize does not
+		// look at them. These inputs are server-resolved rather than
+		// caller-supplied, so no failure is constructible here today, which is
+		// exactly why it should be a checked invariant instead of a property of
+		// the current callers.
+		if err := provenance.Validate(); err != nil {
+			return nil, fmt.Errorf("%w: %v", errBotTemplateRequestInvalid, err)
+		}
+		rendered[cardmsg.CatalogProvenanceKey] = provenance.MarshalMap()
 	}
 	for _, key := range []string{"mention", "reply"} {
 		if value, ok := inbound[key]; ok {
@@ -440,7 +463,7 @@ func parseBotTemplateRef(value any) (botTemplateRef, error) {
 	return botTemplateRef{ID: cardtmpl.ID(id), Version: version}, nil
 }
 
-func requireEffectiveCardTemplate(envelope []byte, want botTemplateRef) error {
+func requireEffectiveCardTemplate(envelope []byte, want botTemplateRef, editorBotID string) error {
 	decoder := json.NewDecoder(bytes.NewReader(envelope))
 	decoder.UseNumber()
 	var payload map[string]any
@@ -459,6 +482,24 @@ func requireEffectiveCardTemplate(envelope []byte, want botTemplateRef) error {
 	version, _ := template["version"].(string)
 	if id != string(want.ID) || version != want.Version {
 		return fmt.Errorf("%w: effective template mismatch", errBotTemplateRequestInvalid)
+	}
+	// PR-C D3：stored catalog_provenance 存在时必须是本 bot 署名的 canonical
+	// 标记，且声明的 Space 与信封自身一致 —— internal producer 的帧、别的 bot
+	// 的帧或被篡改的标记都不能经 Bot 模板编辑路径改写。缺失即 pre-PR-C 帧，
+	// 走既有兼容路径（Snapshot ownership 已保证 FromUID == 编辑 bot）。
+	markers, err := cardmsg.CatalogFrameMarkers(envelope)
+	if err != nil {
+		return fmt.Errorf("%w: effective catalog markers: %v", errBotTemplateRequestInvalid, err)
+	}
+	if markers.HasProvenance {
+		if markers.Provenance.PrincipalType != cardmsg.CatalogPrincipalWireBot ||
+			markers.Provenance.PrincipalID != editorBotID {
+			return fmt.Errorf("%w: stored provenance does not match editing bot", errBotTemplateRequestInvalid)
+		}
+		envelopeSpace, _ := payload["space_id"].(string)
+		if markers.Provenance.SpaceID != "" && markers.Provenance.SpaceID != envelopeSpace {
+			return fmt.Errorf("%w: stored provenance space mismatch", errBotTemplateRequestInvalid)
+		}
 	}
 	return nil
 }

--- a/modules/bot_api/card_template_catalog_test.go
+++ b/modules/bot_api/card_template_catalog_test.go
@@ -423,18 +423,18 @@ func TestEffectiveCardTemplateIdentity(t *testing.T) {
 		t.Fatal(err)
 	}
 	want := botTemplateRef{ID: aireasoningprocess.TemplateID, Version: aireasoningprocess.TemplateVersion}
-	if err := requireEffectiveCardTemplate(raw, want); err != nil {
+	if err := requireEffectiveCardTemplate(raw, want, "bot-template"); err != nil {
 		t.Fatalf("requireEffectiveCardTemplate: %v", err)
 	}
 	delete(payload, "template_ref")
 	metadataOnly, _ := json.Marshal(payload)
-	if err := requireEffectiveCardTemplate(metadataOnly, want); !errors.Is(err, errBotTemplateRequestInvalid) {
+	if err := requireEffectiveCardTemplate(metadataOnly, want, "bot-template"); !errors.Is(err, errBotTemplateRequestInvalid) {
 		t.Fatalf("metadata-only target error = %v", err)
 	}
-	if err := requireEffectiveCardTemplate(raw, botTemplateRef{ID: want.ID, Version: "9.9.9"}); !errors.Is(err, errBotTemplateRequestInvalid) {
+	if err := requireEffectiveCardTemplate(raw, botTemplateRef{ID: want.ID, Version: "9.9.9"}, "bot-template"); !errors.Is(err, errBotTemplateRequestInvalid) {
 		t.Fatalf("mismatch error = %v", err)
 	}
-	if err := requireEffectiveCardTemplate([]byte(`{"type":17,"card":{}}`), want); !errors.Is(err, errBotTemplateRequestInvalid) {
+	if err := requireEffectiveCardTemplate([]byte(`{"type":17,"card":{}}`), want, "bot-template"); !errors.Is(err, errBotTemplateRequestInvalid) {
 		t.Fatalf("non-registry error = %v", err)
 	}
 }

--- a/modules/bot_api/card_template_edit_test.go
+++ b/modules/bot_api/card_template_edit_test.go
@@ -657,13 +657,13 @@ func TestBotRawEditRejectsCatalogProvenanceMarkers(t *testing.T) {
 	// The raw-edit guard treats either server-only marker as Registry
 	// authorship: a target carrying only catalog_provenance is still not
 	// raw-editable, and a raw content_edit carrying it is a forgery.
-	if !cardEnvelopeHasTemplateRef([]byte(`{"type":17,"catalog_provenance":{"version":1}}`)) {
+	if !cardEnvelopeHasCatalogMarker([]byte(`{"type":17,"catalog_provenance":{"version":1}}`)) {
 		t.Fatal("provenance-marked target not recognized as Registry-authored")
 	}
-	if !contentEditHasTemplateRef(`{"type":17,"catalog_provenance":{"version":1,"principal_type":"bot","principal_id":"x","space_id":""}}`) {
+	if !contentEditHasCatalogMarker(`{"type":17,"catalog_provenance":{"version":1,"principal_type":"bot","principal_id":"x","space_id":""}}`) {
 		t.Fatal("raw content_edit forging catalog_provenance not recognized")
 	}
-	if cardEnvelopeHasTemplateRef([]byte(`{"type":17,"card":{"body":[]}}`)) {
+	if cardEnvelopeHasCatalogMarker([]byte(`{"type":17,"card":{"body":[]}}`)) {
 		t.Fatal("legacy raw frame misclassified as Registry-authored")
 	}
 }

--- a/modules/bot_api/card_template_edit_test.go
+++ b/modules/bot_api/card_template_edit_test.go
@@ -80,7 +80,7 @@ func TestBotMessageEditRegistryTemplateRendersSameIdentity(t *testing.T) {
 	}
 	if err := requireEffectiveCardTemplate([]byte(request.ContentEdit), botTemplateRef{
 		ID: aireasoningprocess.TemplateID, Version: aireasoningprocess.TemplateVersion,
-	}); err != nil {
+	}, "bot-template"); err != nil {
 		t.Fatalf("replacement identity: %v", err)
 	}
 }
@@ -123,7 +123,7 @@ func TestBotMessageEditRegistryTemplateKeepsHistoricalVersionsEditable(t *testin
 			}
 			if err := requireEffectiveCardTemplate([]byte(mutator.mutateRequests[0].ContentEdit), botTemplateRef{
 				ID: aireasoningprocess.TemplateID, Version: historical.version,
-			}); err != nil {
+			}, "bot-template"); err != nil {
 				t.Fatalf("historical replacement identity: %v", err)
 			}
 		})
@@ -539,4 +539,107 @@ func invokeTemplateEdit(t *testing.T, ba *BotAPI, body map[string]any) *httptest
 
 func cardtmplBuildEnvForTest() cardtmpl.BuildEnv {
 	return cardtmpl.BuildEnv{Lang: "zh-CN", SpaceID: "space-1"}
+}
+
+// ---- PR-C Slice 1 (D3): Bot template edit re-authors the same-identity
+// provenance, rejects cross-principal stored frames, and raw edit cannot
+// forge or overwrite the server-only markers. ----
+
+func markedRegistryEnvelope(t *testing.T, catalog *botCardTemplateCatalog, botID string) []byte {
+	t.Helper()
+	env := cardtmplBuildEnvForTest()
+	payload, err := catalog.RenderPayloadForPrincipal(context.Background(), botID, registrySendBody(t,
+		"reasoning", testReasoningData(t, "reasoning"))["payload"].(map[string]any), env)
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload["space_id"] = env.SpaceID
+	payload["card_seq"] = int64(1)
+	if err := cardmsg.Finalize(payload); err != nil {
+		t.Fatal(err)
+	}
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return raw
+}
+
+func TestBotMessageEditRegistryTemplateReAuthorsSameProvenance(t *testing.T) {
+	t.Setenv(cardmsg.EnvEnabled, "true")
+	catalog, err := newBotCardTemplateCatalog(testBotTemplateRegistry(t), defaultBotTemplateRefs())
+	if err != nil {
+		t.Fatal(err)
+	}
+	mutator := &fakeBotCardMutator{
+		snapshot:     carddispatch.CardMutationSnapshot{Envelope: markedRegistryEnvelope(t, catalog, "bot-template"), CardSeq: 1},
+		mutateResult: carddispatch.CardMutationResult{Applied: true},
+	}
+	ba := &BotAPI{
+		Log:           log.NewTLog("BotAPI-template-edit-provenance"),
+		cardTemplates: catalog,
+		cardMutator:   mutator,
+	}
+	recorder := invokeTemplateEdit(t, ba, registryEditBody(t, "completed", testReasoningData(t, "completed"), 2, false))
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", recorder.Code, recorder.Body.String())
+	}
+	markers, err := cardmsg.CatalogFrameMarkers([]byte(mutator.mutateRequests[0].ContentEdit))
+	if err != nil {
+		t.Fatalf("replacement markers: %v", err)
+	}
+	if !markers.HasProvenance || markers.Provenance.PrincipalType != cardmsg.CatalogPrincipalWireBot ||
+		markers.Provenance.PrincipalID != "bot-template" {
+		t.Fatalf("replacement provenance = %+v", markers)
+	}
+	stored, err := cardmsg.CatalogFrameMarkers(mutator.snapshot.Envelope)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if markers.Provenance != stored.Provenance {
+		t.Fatalf("provenance changed across edit: stored=%+v replacement=%+v", stored.Provenance, markers.Provenance)
+	}
+}
+
+func TestBotMessageEditRegistryTemplateRejectsForeignStoredProvenance(t *testing.T) {
+	t.Setenv(cardmsg.EnvEnabled, "true")
+	catalog, err := newBotCardTemplateCatalog(testBotTemplateRegistry(t), defaultBotTemplateRefs())
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Same template, but the stored frame is signed by a different principal.
+	// Even if a Snapshot ownership gap ever let the lookup succeed, the stored
+	// provenance must fail the edit closed.
+	envelope := markedRegistryEnvelope(t, catalog, "another-bot")
+	mutator := &fakeBotCardMutator{
+		snapshot:     carddispatch.CardMutationSnapshot{Envelope: envelope, CardSeq: 1},
+		mutateResult: carddispatch.CardMutationResult{Applied: true},
+	}
+	ba := &BotAPI{
+		Log:           log.NewTLog("BotAPI-template-edit-foreign"),
+		cardTemplates: catalog,
+		cardMutator:   mutator,
+	}
+	recorder := invokeTemplateEdit(t, ba, registryEditBody(t, "completed", testReasoningData(t, "completed"), 2, false))
+	if recorder.Code != http.StatusBadRequest {
+		t.Fatalf("foreign provenance edit status=%d body=%s", recorder.Code, recorder.Body.String())
+	}
+	if len(mutator.mutateRequests) != 0 {
+		t.Fatal("foreign provenance edit reached mutation")
+	}
+}
+
+func TestBotRawEditRejectsCatalogProvenanceMarkers(t *testing.T) {
+	// The raw-edit guard treats either server-only marker as Registry
+	// authorship: a target carrying only catalog_provenance is still not
+	// raw-editable, and a raw content_edit carrying it is a forgery.
+	if !cardEnvelopeHasTemplateRef([]byte(`{"type":17,"catalog_provenance":{"version":1}}`)) {
+		t.Fatal("provenance-marked target not recognized as Registry-authored")
+	}
+	if !contentEditHasTemplateRef(`{"type":17,"catalog_provenance":{"version":1,"principal_type":"bot","principal_id":"x","space_id":""}}`) {
+		t.Fatal("raw content_edit forging catalog_provenance not recognized")
+	}
+	if cardEnvelopeHasTemplateRef([]byte(`{"type":17,"card":{"body":[]}}`)) {
+		t.Fatal("legacy raw frame misclassified as Registry-authored")
+	}
 }

--- a/modules/bot_api/card_template_edit_test.go
+++ b/modules/bot_api/card_template_edit_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -35,7 +36,30 @@ func (m *fakeBotCardMutator) Snapshot(_ context.Context, _ carddispatch.CardMuta
 	return m.snapshot, m.snapshotErr
 }
 
+// Mutate applies the production marker-preservation rule before recording the
+// request, through the same cardmsg.CatalogMarkersPreserved the real
+// CardMutator calls.
+//
+// PR-C review round 8: without this, the fake returned a canned result and the
+// real guard never ran, so an edit that the production boundary would refuse
+// looked like a pass here. Both blockers in that round lived in exactly this
+// seam — the handler suite stubbed the mutator, the mutator suite hand-built
+// replacements, and the interaction between a real render output and the real
+// guard was covered by neither.
 func (m *fakeBotCardMutator) Mutate(_ context.Context, request carddispatch.CardMutationRequest) (carddispatch.CardMutationResult, error) {
+	if len(m.snapshot.Envelope) > 0 {
+		stored, err := cardmsg.CatalogFrameMarkers(m.snapshot.Envelope)
+		if err != nil {
+			return carddispatch.CardMutationResult{}, err
+		}
+		next, err := cardmsg.CatalogFrameMarkers([]byte(request.ContentEdit))
+		if err != nil {
+			return carddispatch.CardMutationResult{}, err
+		}
+		if err := cardmsg.CatalogMarkersPreserved(stored, next); err != nil {
+			return carddispatch.CardMutationResult{}, fmt.Errorf("%w: %v", carddispatch.ErrCardMutationInvalid, err)
+		}
+	}
 	m.mutateRequests = append(m.mutateRequests, request)
 	return m.mutateResult, m.mutateErr
 }

--- a/modules/bot_api/card_template_send_test.go
+++ b/modules/bot_api/card_template_send_test.go
@@ -222,13 +222,13 @@ func TestRawContentEditCannotForgeRegistryProvenance(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !contentEditHasTemplateRef(string(encoded)) {
+	if !contentEditHasCatalogMarker(string(encoded)) {
 		t.Fatal("raw content_edit provenance marker was not detected")
 	}
-	if !cardEnvelopeHasTemplateRef(encoded) {
+	if !cardEnvelopeHasCatalogMarker(encoded) {
 		t.Fatal("Registry-authored target provenance marker was not detected")
 	}
-	if contentEditHasTemplateRef(string(mustJSON(t, imCardEnvelope("raw", 1)))) {
+	if contentEditHasCatalogMarker(string(mustJSON(t, imCardEnvelope("raw", 1)))) {
 		t.Fatal("ordinary raw content_edit falsely detected as Registry provenance")
 	}
 }

--- a/modules/bot_api/card_template_send_test.go
+++ b/modules/bot_api/card_template_send_test.go
@@ -387,9 +387,13 @@ func TestSendMessageRegistryTemplateAuthorsCatalogProvenance(t *testing.T) {
 		t.Fatal(err)
 	}
 	ba := &BotAPI{
-		Log:              log.NewTLog("BotAPI-template-provenance"),
-		cardTemplates:    catalog,
-		spaceQuerier:     &fakeSpaceQuerier{defaultSpace: "space-authoritative"},
+		Log:           log.NewTLog("BotAPI-template-provenance"),
+		cardTemplates: catalog,
+		spaceQuerier:  &fakeSpaceQuerier{defaultSpace: "space-authoritative"},
+		// The send path resolves the bot's card switches and fails closed when
+		// the resolver is unwired (#706), so a hand-built BotAPI has to supply
+		// one. This test is about provenance authoring, not per-bot policy.
+		cardConfig:       allCardCapabilitiesOn(),
 		dispatchOverride: dispatch.hook,
 	}
 	recorder := invokeTemplateSend(t, ba, registrySendBody(t, "reasoning", testReasoningData(t, "reasoning")), "")

--- a/modules/bot_api/card_template_send_test.go
+++ b/modules/bot_api/card_template_send_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/Mininglamp-OSS/octo-lib/common"
@@ -425,8 +426,12 @@ func TestSendMessageRawCardRejectsForgedCatalogProvenance(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	dispatch := &dispatchCapture{}
 	ba := &BotAPI{
-		Log:              log.NewTLog("BotAPI-raw-forge"),
-		spaceQuerier:     &fakeSpaceQuerier{defaultSpace: "space-authoritative"},
+		Log:          log.NewTLog("BotAPI-raw-forge"),
+		spaceQuerier: &fakeSpaceQuerier{defaultSpace: "space-authoritative"},
+		// Without a card config resolver the send fails closed before it ever
+		// reaches the forgery check, and ResponseErrorL pins every refusal to
+		// 400 — so a bare status assertion would pass for the wrong reason.
+		cardConfig:       allCardCapabilitiesOn(),
 		dispatchOverride: dispatch.hook,
 	}
 	// A fully self-consistent forgery: provenance + metadata agree. The raw
@@ -452,8 +457,10 @@ func TestSendMessageRawCardRejectsForgedCatalogProvenance(t *testing.T) {
 		"payload": payload,
 	}
 	recorder := invokeTemplateSend(t, ba, body, "")
-	if recorder.Code != http.StatusBadRequest {
-		t.Fatalf("forged provenance status=%d body=%s", recorder.Code, recorder.Body.String())
+	if recorder.Code != http.StatusBadRequest ||
+		!strings.Contains(recorder.Body.String(), "card") {
+		t.Fatalf("forged provenance status=%d body=%s (want the card-invalid refusal, "+
+			"not an unrelated 400)", recorder.Code, recorder.Body.String())
 	}
 	dispatch.mu.Lock()
 	defer dispatch.mu.Unlock()
@@ -473,13 +480,17 @@ func TestSendMessageRegistryModeRejectsCallerProvenanceKey(t *testing.T) {
 		Log:           log.NewTLog("BotAPI-registry-forge"),
 		cardTemplates: catalog,
 		spaceQuerier:  &fakeSpaceQuerier{defaultSpace: "space-authoritative"},
+		// See above: the resolver has to be wired or the refusal proves nothing.
+		cardConfig: allCardCapabilitiesOn(),
 	}
 	body := registrySendBody(t, "reasoning", testReasoningData(t, "reasoning"))
 	body["payload"].(map[string]any)["catalog_provenance"] = map[string]any{
 		"version": 1, "principal_type": "bot", "principal_id": "another-bot", "space_id": "space-x",
 	}
 	recorder := invokeTemplateSend(t, ba, body, "")
-	if recorder.Code != http.StatusBadRequest {
-		t.Fatalf("registry-mode caller provenance status=%d body=%s", recorder.Code, recorder.Body.String())
+	if recorder.Code != http.StatusBadRequest ||
+		!strings.Contains(recorder.Body.String(), "card") {
+		t.Fatalf("registry-mode caller provenance status=%d body=%s (want the card-invalid refusal, "+
+			"not an unrelated 400)", recorder.Code, recorder.Body.String())
 	}
 }

--- a/modules/bot_api/card_template_send_test.go
+++ b/modules/bot_api/card_template_send_test.go
@@ -368,3 +368,109 @@ func invokeTemplateSend(t *testing.T, ba *BotAPI, body map[string]any, onBehalfO
 	ba.sendMessage(ctx)
 	return recorder
 }
+
+// ---- PR-C Slice 1 (D3): the Bot Registry path authors catalog provenance
+// from the authenticated bot; raw callers cannot forge either server-only
+// marker through send. ----
+
+func TestSendMessageRegistryTemplateAuthorsCatalogProvenance(t *testing.T) {
+	t.Setenv(cardmsg.EnvEnabled, "true")
+	gin.SetMode(gin.TestMode)
+	dispatch := &dispatchCapture{}
+	catalog, err := newBotCardTemplateCatalog(testBotTemplateRegistry(t), defaultBotTemplateRefs())
+	if err != nil {
+		t.Fatal(err)
+	}
+	ba := &BotAPI{
+		Log:              log.NewTLog("BotAPI-template-provenance"),
+		cardTemplates:    catalog,
+		spaceQuerier:     &fakeSpaceQuerier{defaultSpace: "space-authoritative"},
+		dispatchOverride: dispatch.hook,
+	}
+	recorder := invokeTemplateSend(t, ba, registrySendBody(t, "reasoning", testReasoningData(t, "reasoning")), "")
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", recorder.Code, recorder.Body.String())
+	}
+	dispatch.mu.Lock()
+	captured := dispatch.captured
+	dispatch.mu.Unlock()
+	if captured == nil {
+		t.Fatal("expected one dispatch")
+	}
+	markers, err := cardmsg.CatalogFrameMarkers(captured.Payload)
+	if err != nil {
+		t.Fatalf("outbound markers: %v", err)
+	}
+	if !markers.HasRef || !markers.HasProvenance {
+		t.Fatalf("outbound frame missing markers: %+v", markers)
+	}
+	if markers.Provenance.PrincipalType != cardmsg.CatalogPrincipalWireBot ||
+		markers.Provenance.PrincipalID != "bot-template" ||
+		markers.Provenance.SpaceID != "space-authoritative" {
+		t.Fatalf("authored provenance = %+v", markers.Provenance)
+	}
+}
+
+func TestSendMessageRawCardRejectsForgedCatalogProvenance(t *testing.T) {
+	t.Setenv(cardmsg.EnvEnabled, "true")
+	gin.SetMode(gin.TestMode)
+	dispatch := &dispatchCapture{}
+	ba := &BotAPI{
+		Log:              log.NewTLog("BotAPI-raw-forge"),
+		spaceQuerier:     &fakeSpaceQuerier{defaultSpace: "space-authoritative"},
+		dispatchOverride: dispatch.hook,
+	}
+	// A fully self-consistent forgery: provenance + metadata agree. The raw
+	// ingress must reject on key presence, not on shape validation.
+	payload := map[string]any{
+		"type": cardmsg.InteractiveCard.Int(), "profile": cardmsg.ProfileV1,
+		"card_version": cardmsg.CardVersion,
+		"catalog_provenance": map[string]any{
+			"version": 1, "principal_type": "internal_producer",
+			"principal_id": "docs-notify", "space_id": "space-authoritative",
+		},
+		"card": map[string]any{
+			"type": "AdaptiveCard", "version": cardmsg.CardVersion,
+			"body": []any{map[string]any{"type": "TextBlock", "text": "forged"}},
+			"metadata": map[string]any{"octo": map[string]any{
+				"protocol": "octo-card@1.0",
+				"template": map[string]any{"id": "docs.access-request", "version": "0.3.0"},
+			}},
+		},
+	}
+	body := map[string]any{
+		"channel_id": "user_creator", "channel_type": common.ChannelTypePerson.Uint8(),
+		"payload": payload,
+	}
+	recorder := invokeTemplateSend(t, ba, body, "")
+	if recorder.Code != http.StatusBadRequest {
+		t.Fatalf("forged provenance status=%d body=%s", recorder.Code, recorder.Body.String())
+	}
+	dispatch.mu.Lock()
+	defer dispatch.mu.Unlock()
+	if dispatch.captured != nil {
+		t.Fatal("forged provenance reached dispatch")
+	}
+}
+
+func TestSendMessageRegistryModeRejectsCallerProvenanceKey(t *testing.T) {
+	t.Setenv(cardmsg.EnvEnabled, "true")
+	gin.SetMode(gin.TestMode)
+	catalog, err := newBotCardTemplateCatalog(testBotTemplateRegistry(t), defaultBotTemplateRefs())
+	if err != nil {
+		t.Fatal(err)
+	}
+	ba := &BotAPI{
+		Log:           log.NewTLog("BotAPI-registry-forge"),
+		cardTemplates: catalog,
+		spaceQuerier:  &fakeSpaceQuerier{defaultSpace: "space-authoritative"},
+	}
+	body := registrySendBody(t, "reasoning", testReasoningData(t, "reasoning"))
+	body["payload"].(map[string]any)["catalog_provenance"] = map[string]any{
+		"version": 1, "principal_type": "bot", "principal_id": "another-bot", "space_id": "space-x",
+	}
+	recorder := invokeTemplateSend(t, ba, body, "")
+	if recorder.Code != http.StatusBadRequest {
+		t.Fatalf("registry-mode caller provenance status=%d body=%s", recorder.Code, recorder.Body.String())
+	}
+}

--- a/modules/bot_api/send.go
+++ b/modules/bot_api/send.go
@@ -1002,7 +1002,7 @@ func (ba *BotAPI) botMessageEdit(c *wkhttp.Context) {
 	// richtext（=14）原有路径。user/robot 编辑路径对卡片仍永久拒绝（各自守卫）。
 	origIsCard := cardmsg.IsCardRawPayload(msgPayload)
 	editIsCard := cardmsg.IsCardContentEdit(req.ContentEdit)
-	if origIsCard && cardEnvelopeHasTemplateRef(msgPayload) {
+	if origIsCard && cardEnvelopeHasCatalogMarker(msgPayload) {
 		ba.Warn("raw card edit attempted to replace Registry-authored target", zap.String("messageID", req.MessageID))
 		httperr.ResponseErrorL(c, errcode.ErrBotAPICardInvalid, nil, nil)
 		return
@@ -1028,7 +1028,7 @@ func (ba *BotAPI) botMessageEdit(c *wkhttp.Context) {
 			httperr.ResponseErrorL(c, errcode.ErrBotAPICardDisabled, nil, nil)
 			return
 		}
-		if contentEditHasTemplateRef(req.ContentEdit) {
+		if contentEditHasCatalogMarker(req.ContentEdit) {
 			ba.Warn("raw card edit attempted to forge Registry provenance", zap.String("messageID", req.MessageID))
 			httperr.ResponseErrorL(c, errcode.ErrBotAPICardInvalid, nil, nil)
 			return
@@ -1354,15 +1354,15 @@ func effectiveEnvelopeSpaceID(raw json.RawMessage) string {
 	return spaceID
 }
 
-func contentEditHasTemplateRef(contentEdit string) bool {
-	return cardEnvelopeHasTemplateRef([]byte(contentEdit))
+func contentEditHasCatalogMarker(contentEdit string) bool {
+	return cardEnvelopeHasCatalogMarker([]byte(contentEdit))
 }
 
-// cardEnvelopeHasTemplateRef 报告一个信封是否携带任一 server-only catalog
+// cardEnvelopeHasCatalogMarker 报告一个信封是否携带任一 server-only catalog
 // 标记（template_ref / catalog_provenance，PR-C D3）。raw 编辑路径用它双向
 // 拒绝：目标是 Registry/internal 产出的帧 → raw 不能覆盖；编辑体携带标记 →
 // raw 不能伪造。
-func cardEnvelopeHasTemplateRef(raw []byte) bool {
+func cardEnvelopeHasCatalogMarker(raw []byte) bool {
 	var payload map[string]any
 	if err := json.Unmarshal(raw, &payload); err != nil {
 		return false

--- a/modules/bot_api/send.go
+++ b/modules/bot_api/send.go
@@ -127,6 +127,15 @@ func (ba *BotAPI) sendMessage(c *wkhttp.Context) {
 				return
 			}
 		} else {
+			// PR-C D3：catalog_provenance 是 server-only 顶层键，raw Bot 卡片按
+			// 键存在显式拒绝（不依赖形状校验，也不依赖客户端"不会传"）。
+			// template_ref 由上方 XOR 覆盖：出现即进 Registry 模式，raw card 共存
+			// 已被拒绝。
+			if _, forged := req.Payload[cardmsg.CatalogProvenanceKey]; forged {
+				ba.Warn("raw Bot 卡片试图伪造 catalog_provenance", zap.String("channelID", req.ChannelID))
+				httperr.ResponseErrorL(c, errcode.ErrBotAPICardInvalid, nil, nil)
+				return
+			}
 			if err := cardmsg.Validate(req.Payload); err != nil {
 				ba.Warn("InteractiveCard payload 校验失败", zap.Error(err), zap.String("channelID", req.ChannelID))
 				httperr.ResponseErrorL(c, errcode.ErrBotAPICardInvalid, nil, nil)
@@ -1203,7 +1212,7 @@ func (ba *BotAPI) botMessageEditViaRegistry(c *wkhttp.Context, req *botMessageEd
 		ba.respondBotTemplateSnapshotError(c, req.MessageID, err)
 		return
 	}
-	if err := requireEffectiveCardTemplate(snapshot.Envelope, ref); err != nil {
+	if err := requireEffectiveCardTemplate(snapshot.Envelope, ref, robotID); err != nil {
 		ba.Warn("Bot Registry edit 目标模板不匹配", zap.Error(err), zap.String("messageID", req.MessageID))
 		httperr.ResponseErrorL(c, errcode.ErrBotAPICardInvalid, nil, nil)
 		return
@@ -1330,12 +1339,19 @@ func contentEditHasTemplateRef(contentEdit string) bool {
 	return cardEnvelopeHasTemplateRef([]byte(contentEdit))
 }
 
+// cardEnvelopeHasTemplateRef 报告一个信封是否携带任一 server-only catalog
+// 标记（template_ref / catalog_provenance，PR-C D3）。raw 编辑路径用它双向
+// 拒绝：目标是 Registry/internal 产出的帧 → raw 不能覆盖；编辑体携带标记 →
+// raw 不能伪造。
 func cardEnvelopeHasTemplateRef(raw []byte) bool {
 	var payload map[string]any
 	if err := json.Unmarshal(raw, &payload); err != nil {
 		return false
 	}
-	_, exists := payload["template_ref"]
+	if _, exists := payload[cardmsg.CatalogTemplateRefKey]; exists {
+		return true
+	}
+	_, exists := payload[cardmsg.CatalogProvenanceKey]
 	return exists
 }
 

--- a/modules/incomingwebhook/card_test.go
+++ b/modules/incomingwebhook/card_test.go
@@ -87,3 +87,29 @@ func TestBuildCardPayload(t *testing.T) {
 	}, false)
 	assert.True(t, errors.Is(err, cardmsg.ErrCardPayloadTooLarge), "err=%v", err)
 }
+
+// PR-C Slice 1 (D3) regression: the webhook envelope is server-built from a
+// fixed key allowlist. A caller-forged Registry identity (metadata inside the
+// card doc) must not surface the server-only top-level catalog markers, and
+// no dynamic capability exists on this ingress.
+func TestBuildCardPayloadNeverEmitsCatalogMarkers(t *testing.T) {
+	t.Setenv(cardmsg.EnvEnabled, "true")
+	p, err := buildCardPayload(cardTestModel(), &pushPayloadReq{
+		MsgType: msgTypeCard,
+		Card: map[string]interface{}{
+			"type": "AdaptiveCard", "version": "1.5",
+			"body": []interface{}{
+				map[string]interface{}{"type": "TextBlock", "text": "forged registry lookalike"},
+			},
+			"metadata": map[string]interface{}{"octo": map[string]interface{}{
+				"protocol": "octo-card@1.0",
+				"template": map[string]interface{}{"id": "docs.access-request", "version": "0.3.0"},
+			}},
+		},
+	}, false)
+	assert.NoError(t, err)
+	_, hasRef := p[cardmsg.CatalogTemplateRefKey]
+	_, hasProvenance := p[cardmsg.CatalogProvenanceKey]
+	assert.False(t, hasRef, "webhook envelope grew template_ref")
+	assert.False(t, hasProvenance, "webhook envelope grew catalog_provenance")
+}

--- a/modules/message/api_card_action.go
+++ b/modules/message/api_card_action.go
@@ -26,6 +26,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"strings"
 	"time"
@@ -33,6 +34,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/common"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
 	"github.com/Mininglamp-OSS/octo-server/internal/cardactiondispatch"
+	"github.com/Mininglamp-OSS/octo-server/internal/carddispatch"
 	"github.com/Mininglamp-OSS/octo-server/modules/group"
 	"github.com/Mininglamp-OSS/octo-server/modules/thread"
 	"github.com/Mininglamp-OSS/octo-server/pkg/cardmsg"
@@ -220,15 +222,30 @@ func (m *Message) cardAction(c *wkhttp.Context) {
 		httperr.ResponseErrorL(c, errcode.ErrMessageCardActionInvalid, nil, nil)
 		return
 	}
-	cardSpaceID := m.resolveCardOriginSpaceID(msgM)
-	cardContext, err := resolveRegistryCardContext(c.Request.Context(), cardtmpl.CatalogAccess{
-		Purpose: cardtmpl.CatalogPurposeActionContext,
-		Principal: cardtmpl.CatalogPrincipal{
-			Kind: cardtmpl.CatalogPrincipalBot, ID: msgM.FromUID, SpaceID: cardSpaceID,
+	cardSpaceID, cardSpaceKnown := m.resolveCardOriginSpaceID(msgM)
+	// PR-C D3：principal 从生效帧的 stored provenance 恢复并校验（sender/
+	// producer 绑定/Space 一致性都在 resolveRegistryCardContext 内 fail-close）；
+	// 无标记的 legacy 帧沿用 sender 派生的 bot principal（static 兼容）。
+	cardContext, err := resolveRegistryCardContext(c.Request.Context(), cardActionFrameOrigin{
+		SenderUID:  msgM.FromUID,
+		SpaceID:    cardSpaceID,
+		SpaceKnown: cardSpaceKnown,
+		ProducerBinding: func(producerID string) (string, bool) {
+			return carddispatch.ProducerBindingFromContext(m.ctx, carddispatch.ProducerID(producerID))
 		},
 	}, effective, req.ActionID, actionData)
 	if err != nil {
 		m.releaseCardClaim(idemKey)
+		if errors.Is(err, errCardOriginSpaceUnavailable) {
+			// The click is well formed and the frame may be perfectly valid; we
+			// simply could not read the card's Space to check it against. That
+			// is an outage on our side, and answering 400 would both mislead
+			// the operator and tell the client not to retry.
+			m.Error("卡片来源 Space 不可用,无法校验 stored provenance",
+				zap.Error(err), zap.String("messageID", req.MessageID))
+			httperr.ResponseErrorL(c, errcode.ErrSharedInternal, nil, nil)
+			return
+		}
 		m.Warn("registry 卡片 action 与已发布交互契约不一致,拒绝",
 			zap.Error(err), zap.String("messageID", req.MessageID), zap.String("actionID", req.ActionID))
 		httperr.ResponseErrorL(c, errcode.ErrMessageCardActionInvalid, nil, nil)
@@ -300,12 +317,34 @@ func (m *Message) cardAction(c *wkhttp.Context) {
 	c.Response(map[string]interface{}{"accepted": true, "replay": false})
 }
 
+// cardActionFrameOrigin carries the server-side facts a stored frame's
+// provenance is validated against: the stored sender, the card's
+// authoritative origin Space, and the read-only producer-binding resolver.
+// None of these values comes from the click request.
+type cardActionFrameOrigin struct {
+	SenderUID string
+	SpaceID   string
+	// SpaceKnown reports that SpaceID is a determined fact. False means the
+	// origin lookup did not answer, which is not the same as "this card is in
+	// no Space" — see resolveCardOriginSpaceID. A frame's provenance can only
+	// be validated against a Space that was actually established.
+	SpaceKnown      bool
+	ProducerBinding func(producerID string) (senderUID string, ok bool)
+}
+
 // resolveRegistryCardContext binds callback context to metadata and interaction
 // reports from the effective server-authored frame. Cards without octo-card
 // template metadata retain the legacy zero context.
+//
+// PR-C D3：帧携带 catalog_provenance 时，它是 principal 的唯一来源 —— 先证明
+// 与 stored sender（bot：principal_id==FromUID；internal producer：注册的
+// binding SenderUID==FromUID）及权威 Space 一致，才进入 catalog access 与
+// durable CardContext；任何畸形/不一致 fail-close。无 provenance 的帧（含
+// pre-PR-C 的 template_ref-only Bot 帧）保留 sender 派生的 legacy bot
+// principal，且绝不给 CardContext 发明 validated principal 字段。
 func resolveRegistryCardContext(
 	ctx context.Context,
-	access cardtmpl.CatalogAccess,
+	origin cardActionFrameOrigin,
 	effective []byte,
 	actionID string,
 	actionData map[string]interface{},
@@ -316,6 +355,48 @@ func resolveRegistryCardContext(
 			return cardactiondispatch.CardContext{}, errors.New("message: card template metadata is incomplete")
 		}
 		return cardactiondispatch.CardContext{}, nil
+	}
+	markers, err := cardmsg.CatalogFrameMarkers(effective)
+	if err != nil {
+		return cardactiondispatch.CardContext{}, err
+	}
+	access := cardtmpl.CatalogAccess{
+		Purpose: cardtmpl.CatalogPurposeActionContext,
+		Principal: cardtmpl.CatalogPrincipal{
+			Kind: cardtmpl.CatalogPrincipalBot, ID: origin.SenderUID, SpaceID: origin.SpaceID,
+		},
+	}
+	var validated *cardactiondispatch.CardContext
+	if markers.HasProvenance {
+		principal, err := validatedFramePrincipal(origin, markers.Provenance)
+		if err != nil {
+			return cardactiondispatch.CardContext{}, err
+		}
+		access.Principal = principal
+		validated = &cardactiondispatch.CardContext{
+			PrincipalType: markers.Provenance.PrincipalType,
+			PrincipalID:   principal.ID,
+			SpaceID:       principal.SpaceID,
+		}
+	} else if !frozenRegistryKnows(cardtmpl.ID(ref.ID), ref.Version) {
+		// D3 fail-close for a markerless frame that names a *dynamic* version.
+		//
+		// The identity above comes from `card.metadata.octo.template`, which
+		// lives inside the card body a raw caller controls; raw ingress rejects
+		// the two server-only *top-level* keys, not this. Without this branch a
+		// frame carrying no server-authored provenance is authorized against
+		// the sender-derived Bot principal — which is the sending Bot's own
+		// grant identity — and `Allows(action_context)` reads `edit`. So a Bot
+		// holding only `discover+edit` could fabricate a frame naming an active
+		// dynamic version and drive its action route, with `edit` standing in
+		// for the `send` grant the frame never had.
+		//
+		// Markerless compatibility exists for one population: cards delivered
+		// before PR-C, every one of which names a version the frozen Registry
+		// knows. Scoping the fallback to exactly that population keeps invariant
+		// 7 intact and closes the substitution.
+		return cardactiondispatch.CardContext{}, fmt.Errorf(
+			"%w: %s@%s", errMarkerlessDynamicFrame, ref.ID, ref.Version)
 	}
 	catalog := cardtmpl.DefaultCatalog()
 	if catalog == nil {
@@ -342,9 +423,98 @@ func resolveRegistryCardContext(
 			return cardactiondispatch.CardContext{}, errors.New("message: card template owner does not match action route owner")
 		}
 	}
-	return cardactiondispatch.CardContext{
+	cardContext := cardactiondispatch.CardContext{
 		TemplateID: ref.ID, TemplateVersion: ref.Version, View: string(resolved.View),
-	}, nil
+	}
+	if validated != nil {
+		cardContext.PrincipalType = validated.PrincipalType
+		cardContext.PrincipalID = validated.PrincipalID
+		cardContext.SpaceID = validated.SpaceID
+	}
+	return cardContext, nil
+}
+
+// validatedFramePrincipal 证明 stored provenance 与服务端事实一致后，返回
+// catalog principal。失败即篡改/配置漂移信号，一律 fail-close：
+//   - bot principal 必须等于存储行 FromUID（IM 连接鉴权绑定，不可伪造）；
+//   - internal producer 必须在 carddispatch 注册表中绑定到 FromUID；
+//   - provenance 声明的 Space 非空且权威来源 Space 非空时必须一致。
+func validatedFramePrincipal(origin cardActionFrameOrigin, provenance cardmsg.CatalogProvenance) (cardtmpl.CatalogPrincipal, error) {
+	principal, err := cardtmpl.CatalogPrincipalFromProvenance(provenance)
+	if err != nil {
+		return cardtmpl.CatalogPrincipal{}, err
+	}
+	switch principal.Kind {
+	case cardtmpl.CatalogPrincipalBot:
+		if principal.ID != origin.SenderUID {
+			return cardtmpl.CatalogPrincipal{}, errors.New("message: stored bot provenance does not match message sender")
+		}
+	case cardtmpl.CatalogPrincipalInternalProducer:
+		if origin.ProducerBinding == nil {
+			return cardtmpl.CatalogPrincipal{}, errors.New("message: producer binding resolver unavailable")
+		}
+		boundSender, ok := origin.ProducerBinding(principal.ID)
+		if !ok || boundSender != origin.SenderUID {
+			return cardtmpl.CatalogPrincipal{}, errors.New("message: stored producer provenance does not match registered sender")
+		}
+	default:
+		return cardtmpl.CatalogPrincipal{}, errors.New("message: unsupported stored principal kind")
+	}
+	// A frame that names a Space is only trustworthy once that claim has been
+	// checked against the server's own answer. Skipping the check when the
+	// origin could not be determined would leave principal.SpaceID set to
+	// whatever the frame said, and that value becomes the grant scope for the
+	// action_context authorization — so a frame that reached storage without
+	// passing a trusted boundary could name any Space it liked. The bot branch
+	// above pins the principal *id* to the stored sender; nothing pins the
+	// Space but this.
+	// Refuse whenever the origin Space is unknown, whether or not the frame
+	// names one. The empty-Space branch looks harmless and is not: assigning an
+	// unknown origin leaves principal.SpaceID == "", which loadGrantDecision
+	// resolves against the *global* row alone. A principal holding an active
+	// global grant plus an exact tombstone for the card's real Space would then
+	// be allowed — defeating invariant 11, which exists precisely so an exact
+	// tombstone can shadow a live global grant. A transient group-row read is
+	// enough to reach it, so the unknown case has to fail closed on both sides.
+	if !origin.SpaceKnown {
+		return cardtmpl.CatalogPrincipal{}, fmt.Errorf(
+			"%w: card origin space is unavailable, cannot resolve the grant scope",
+			errCardOriginSpaceUnavailable)
+	}
+	if principal.SpaceID != "" && principal.SpaceID != origin.SpaceID {
+		return cardtmpl.CatalogPrincipal{}, errors.New("message: stored provenance space does not match card origin space")
+	}
+	if principal.SpaceID == "" {
+		principal.SpaceID = origin.SpaceID
+	}
+	return principal, nil
+}
+
+// errCardOriginSpaceUnavailable separates "the card's Space could not be read
+// right now" from "this click is malformed". Both refuse the action, but only
+// the first is worth retrying, and reporting it as a client error would tell an
+// operator to go looking at the payload instead of at the group table.
+var errCardOriginSpaceUnavailable = errors.New("message: card origin space unavailable")
+
+// errMarkerlessDynamicFrame is the refusal for a frame that names a template
+// the frozen Registry does not know and carries no server-authored provenance.
+// It is deliberately not merged into the generic invalid-action error class at
+// the source so the reason survives into the logs; the handler still collapses
+// it onto the one client-visible 400, because telling a caller *which* of the
+// action rejections it hit is an enumeration aid.
+var errMarkerlessDynamicFrame = errors.New("message: dynamic frame carries no server-authored provenance")
+
+// frozenRegistryKnows reports whether the process Registry holds this exact
+// version. It is the test for "this card predates the dynamic catalog", not a
+// permission check — a static template being known here says nothing about who
+// may act on it, which is still decided by the authorizer downstream.
+func frozenRegistryKnows(id cardtmpl.ID, version string) bool {
+	registry := cardtmpl.DefaultRegistry()
+	if registry == nil {
+		return false
+	}
+	_, err := registry.Lookup(id, version)
+	return err == nil
 }
 
 var errInternalCardActionRouteRejected = errors.New("internal card action route rejected")
@@ -499,14 +669,23 @@ func (m *Message) authorizeCardChannelMember(c *wkhttp.Context, loginUID, messag
 //
 // 任一步取不到 → 返回 ""(fail-closed:调用方省略 event_data.space_id,与 send 路径
 // 无权威值时 strip 客户端 space 的行为对齐;绝不回退到客户端可影响的上下文 Space)。
-func (m *Message) resolveCardOriginSpaceID(msgM *messageModel) string {
+//
+// The second return value separates two outcomes that used to share one empty
+// string. `known=true, spaceID=""` is a determined fact — a DM outside any
+// Space. `known=false` means the lookup itself did not answer: a group row that
+// could not be read, a malformed thread channel, an unparseable payload. The
+// distinction is load-bearing downstream: a frame's provenance can only be
+// checked against an origin Space that was actually established, and treating
+// "could not determine" as "there is none" both skips that check and turns
+// transient outages into permanent-looking rejections.
+func (m *Message) resolveCardOriginSpaceID(msgM *messageModel) (string, bool) {
 	switch msgM.ChannelType {
 	case common.ChannelTypeGroup.Uint8():
 		return m.groupSpaceIDOrEmpty(msgM.ChannelID)
 	case common.ChannelTypeCommunityTopic.Uint8():
 		parent, err := m.resolveParentGroupNo(msgM.ChannelID)
 		if err != nil || parent == "" {
-			return ""
+			return "", false
 		}
 		return m.groupSpaceIDOrEmpty(parent)
 	case common.ChannelTypePerson.Uint8():
@@ -514,21 +693,24 @@ func (m *Message) resolveCardOriginSpaceID(msgM *messageModel) string {
 			SpaceID string `json:"space_id"`
 		}
 		if err := json.Unmarshal(msgM.Payload, &env); err != nil {
-			return ""
+			return "", false
 		}
-		return env.SpaceID
+		// A DM payload legitimately carries no Space when the sender had none
+		// to stamp, so an absent value here is an answer rather than a failure.
+		return env.SpaceID, true
 	default:
-		return ""
+		return "", false
 	}
 }
 
-// groupSpaceIDOrEmpty 查群的权威 SpaceID;任何错误 / 空群 / 空 SpaceID → ""。
-func (m *Message) groupSpaceIDOrEmpty(groupNo string) string {
+// groupSpaceIDOrEmpty 查群的权威 SpaceID。查询失败 / 群不存在 → ("", false):
+// 未能判定。群存在但没有 SpaceID → ("", true):判定为「不属于任何 Space」。
+func (m *Message) groupSpaceIDOrEmpty(groupNo string) (string, bool) {
 	g, err := m.groupService.GetGroupWithGroupNo(groupNo)
 	if err != nil || g == nil {
-		return ""
+		return "", false
 	}
-	return g.SpaceID
+	return g.SpaceID, true
 }
 
 // cardCanonicalVisibleToViewer 复刻单条读 respondSingleMessage 的「内容可见性」层

--- a/modules/message/card_action_template_context_test.go
+++ b/modules/message/card_action_template_context_test.go
@@ -42,13 +42,8 @@ func TestResolveRegistryCardContextUsesEffectiveMetadataAndReport(t *testing.T) 
 	if !ok {
 		t.Fatal("approve action not found in rendered card")
 	}
-	access := cardtmpl.CatalogAccess{
-		Purpose: cardtmpl.CatalogPurposeActionContext,
-		Principal: cardtmpl.CatalogPrincipal{
-			Kind: cardtmpl.CatalogPrincipalBot, ID: "notification", SpaceID: "space-1",
-		},
-	}
-	got, err := resolveRegistryCardContext(context.Background(), access, raw, cardtmpl.DocsApproveActionID, actionData)
+	origin := cardActionFrameOrigin{SenderUID: "notification", SpaceID: "space-1", SpaceKnown: true}
+	got, err := resolveRegistryCardContext(context.Background(), origin, raw, cardtmpl.DocsApproveActionID, actionData)
 	if err != nil {
 		t.Fatalf("resolveRegistryCardContext: %v", err)
 	}
@@ -56,16 +51,22 @@ func TestResolveRegistryCardContextUsesEffectiveMetadataAndReport(t *testing.T) 
 	if got != want {
 		t.Fatalf("card context = %+v, want %+v", got, want)
 	}
-	if spy.lastRequest.Access != access {
-		t.Fatalf("action catalog access = %+v, want %+v", spy.lastRequest.Access, access)
+	wantAccess := cardtmpl.CatalogAccess{
+		Purpose: cardtmpl.CatalogPurposeActionContext,
+		Principal: cardtmpl.CatalogPrincipal{
+			Kind: cardtmpl.CatalogPrincipalBot, ID: "notification", SpaceID: "space-1",
+		},
 	}
-	if _, err := resolveRegistryCardContext(context.Background(), access, raw, "missing", nil); err == nil {
+	if spy.lastRequest.Access != wantAccess {
+		t.Fatalf("action catalog access = %+v, want %+v", spy.lastRequest.Access, wantAccess)
+	}
+	if _, err := resolveRegistryCardContext(context.Background(), origin, raw, "missing", nil); err == nil {
 		t.Fatal("undeclared action resolved without error")
 	}
 
 	// P2-b(PR#641 review):route owner(Action.data.owner)与 template owner 不一致
 	// 必须拒绝 —— 防止带 docs 身份的信封投递到别的路由。
-	if _, err := resolveRegistryCardContext(context.Background(), access, raw, cardtmpl.DocsApproveActionID,
+	if _, err := resolveRegistryCardContext(context.Background(), origin, raw, cardtmpl.DocsApproveActionID,
 		map[string]interface{}{"owner": "summary", "action_type": "access_request.decision"}); err == nil {
 		t.Fatal("owner mismatch resolved without error")
 	}
@@ -77,7 +78,7 @@ func TestResolveRegistryCardContextUsesEffectiveMetadataAndReport(t *testing.T) 
 	template := octo["template"].(map[string]any)
 	delete(template, "version")
 	partialRaw, _ := json.Marshal(payload)
-	if _, err := resolveRegistryCardContext(context.Background(), access, partialRaw, cardtmpl.DocsApproveActionID, actionData); err == nil {
+	if _, err := resolveRegistryCardContext(context.Background(), origin, partialRaw, cardtmpl.DocsApproveActionID, actionData); err == nil {
 		t.Fatal("partial registry metadata resolved as a legacy card")
 	}
 
@@ -87,11 +88,11 @@ func TestResolveRegistryCardContextUsesEffectiveMetadataAndReport(t *testing.T) 
 		"metadata": map[string]any{"octo": "corrupt"},
 	}}
 	corruptRaw, _ := json.Marshal(corrupt)
-	if _, err := resolveRegistryCardContext(context.Background(), access, corruptRaw, "any", nil); err == nil {
+	if _, err := resolveRegistryCardContext(context.Background(), origin, corruptRaw, "any", nil); err == nil {
 		t.Fatal("corrupt octo metadata resolved as a legacy card")
 	}
 
-	legacy, err := resolveRegistryCardContext(context.Background(), access, []byte(`{"type":17,"card":{"body":[]}}`), "legacy", nil)
+	legacy, err := resolveRegistryCardContext(context.Background(), origin, []byte(`{"type":17,"card":{"body":[]}}`), "legacy", nil)
 	if err != nil || legacy != (cardactiondispatch.CardContext{}) {
 		t.Fatalf("legacy context = (%+v, %v)", legacy, err)
 	}
@@ -107,14 +108,16 @@ func TestResolveRegistryCardContextRejectsV3LegacyControlIDs(t *testing.T) {
 	}
 	previousCatalog := cardtmpl.DefaultCatalog()
 	cardtmpl.SetDefaultCatalog(static)
-	t.Cleanup(func() { cardtmpl.SetDefaultCatalog(previousCatalog) })
+	// Install the Registry too: the markerless-frame guard consults it, and
+	// production always has one (DefaultCatalog itself falls back to it).
+	previousRegistry := cardtmpl.DefaultRegistry()
+	cardtmpl.SetDefaultRegistry(registry)
+	t.Cleanup(func() {
+		cardtmpl.SetDefaultCatalog(previousCatalog)
+		cardtmpl.SetDefaultRegistry(previousRegistry)
+	})
 
-	access := cardtmpl.CatalogAccess{
-		Purpose: cardtmpl.CatalogPurposeActionContext,
-		Principal: cardtmpl.CatalogPrincipal{
-			Kind: cardtmpl.CatalogPrincipalBot, ID: "bot-reasoning", SpaceID: "space-1",
-		},
-	}
+	origin := cardActionFrameOrigin{SenderUID: "bot-reasoning", SpaceID: "space-1", SpaceKnown: true}
 	for _, tc := range []struct {
 		state    cardtmpl.State
 		actionID string
@@ -138,7 +141,7 @@ func TestResolveRegistryCardContextRejectsV3LegacyControlIDs(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			_, err = resolveRegistryCardContext(context.Background(), access, raw, tc.actionID,
+			_, err = resolveRegistryCardContext(context.Background(), origin, raw, tc.actionID,
 				map[string]interface{}{"owner": "ai", "action_type": "reasoning.control"})
 			if !errors.Is(err, cardtmpl.ErrActionUnknown) {
 				t.Fatalf("resolve legacy action error = %v, want ErrActionUnknown", err)
@@ -158,4 +161,362 @@ func (s *actionContextCatalogSpy) ActionContext(
 ) (cardtmpl.CatalogActionContext, error) {
 	s.lastRequest = request
 	return s.Catalog.ActionContext(ctx, request)
+}
+
+// ---- PR-C Slice 1 (D3): the action ingress derives the catalog principal
+// from the frame's stored catalog_provenance after proving it consistent with
+// the stored sender and authoritative Space — never from raw guesses. ----
+
+func markedActionFrame(t *testing.T, registry *cardtmpl.Registry, provenance map[string]interface{}) ([]byte, map[string]interface{}) {
+	t.Helper()
+	sample, err := docsaccessrequest.Assets.ReadFile(docsaccessrequest.HandoffRoot + "/samples/pending.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload, err := registry.Render(context.Background(), docsaccessrequest.TemplateID, "",
+		docsaccessrequest.StatePending, sample,
+		cardtmpl.BuildEnv{WebLoginURL: "https://web.example.com", Lang: "en", SpaceID: "space-1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload["template_ref"] = map[string]interface{}{
+		"id": string(docsaccessrequest.TemplateID), "version": docsaccessrequest.TemplateVersion,
+	}
+	if provenance != nil {
+		payload["catalog_provenance"] = provenance
+	}
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	actionData, ok := cardmsg.SubmitAction(raw, cardtmpl.DocsApproveActionID)
+	if !ok {
+		t.Fatal("approve action not found")
+	}
+	return raw, actionData
+}
+
+func provenanceActionFixture(t *testing.T) (*cardtmpl.Registry, *actionContextCatalogSpy) {
+	t.Helper()
+	registry := cardtmpl.NewRegistry()
+	registry.Register(docsaccessrequest.New(), docsaccessrequest.Assets, docsaccessrequest.HandoffRoot)
+	registry.SetDefault(docsaccessrequest.TemplateID, docsaccessrequest.TemplateVersion)
+	registry.Freeze()
+	static, err := cardtmpl.NewStaticCatalog(registry)
+	if err != nil {
+		t.Fatal(err)
+	}
+	spy := &actionContextCatalogSpy{Catalog: static}
+	previousCatalog := cardtmpl.DefaultCatalog()
+	cardtmpl.SetDefaultCatalog(spy)
+	// The markerless-frame guard asks the frozen Registry whether it knows the
+	// version a frame names, so the fixture has to install one the way the
+	// composition root does. Without it the guard sees no Registry, answers
+	// "unknown" for everything, and every legacy frame is refused — fail-closed,
+	// but it would make this fixture disagree with production.
+	previousRegistry := cardtmpl.DefaultRegistry()
+	cardtmpl.SetDefaultRegistry(registry)
+	t.Cleanup(func() {
+		cardtmpl.SetDefaultCatalog(previousCatalog)
+		cardtmpl.SetDefaultRegistry(previousRegistry)
+	})
+	return registry, spy
+}
+
+func TestResolveRegistryCardContextUsesStoredProvenancePrincipal(t *testing.T) {
+	registry, spy := provenanceActionFixture(t)
+	raw, actionData := markedActionFrame(t, registry, map[string]interface{}{
+		"version": 1, "principal_type": "internal_producer",
+		"principal_id": "docs-notify", "space_id": "space-1",
+	})
+	origin := cardActionFrameOrigin{
+		SenderUID: "notification", SpaceID: "space-1", SpaceKnown: true,
+		ProducerBinding: func(producerID string) (string, bool) {
+			if producerID == "docs-notify" {
+				return "notification", true
+			}
+			return "", false
+		},
+	}
+	got, err := resolveRegistryCardContext(context.Background(), origin, raw, cardtmpl.DocsApproveActionID, actionData)
+	if err != nil {
+		t.Fatalf("resolveRegistryCardContext: %v", err)
+	}
+	want := cardactiondispatch.CardContext{
+		TemplateID: "docs.access-request", TemplateVersion: "0.2.0", View: "pending",
+		PrincipalType: "internal_producer", PrincipalID: "docs-notify", SpaceID: "space-1",
+	}
+	if got != want {
+		t.Fatalf("card context = %+v, want %+v", got, want)
+	}
+	wantPrincipal := cardtmpl.CatalogPrincipal{
+		Kind: cardtmpl.CatalogPrincipalInternalProducer, ID: "docs-notify", SpaceID: "space-1",
+	}
+	if spy.lastRequest.Access.Principal != wantPrincipal {
+		t.Fatalf("catalog access principal = %+v, want %+v", spy.lastRequest.Access.Principal, wantPrincipal)
+	}
+	if spy.lastRequest.Access.Purpose != cardtmpl.CatalogPurposeActionContext {
+		t.Fatalf("catalog access purpose = %v", spy.lastRequest.Access.Purpose)
+	}
+}
+
+func TestResolveRegistryCardContextRejectsInconsistentProvenance(t *testing.T) {
+	registry, _ := provenanceActionFixture(t)
+	binding := func(producerID string) (string, bool) {
+		if producerID == "docs-notify" {
+			return "notification", true
+		}
+		return "", false
+	}
+	cases := []struct {
+		name       string
+		provenance map[string]interface{}
+		origin     cardActionFrameOrigin
+	}{
+		{
+			name: "producer binding does not match stored sender",
+			provenance: map[string]interface{}{
+				"version": 1, "principal_type": "internal_producer",
+				"principal_id": "docs-notify", "space_id": "space-1",
+			},
+			origin: cardActionFrameOrigin{SenderUID: "other-bot", SpaceID: "space-1", SpaceKnown: true, ProducerBinding: binding},
+		},
+		{
+			name: "unregistered producer",
+			provenance: map[string]interface{}{
+				"version": 1, "principal_type": "internal_producer",
+				"principal_id": "rogue-producer", "space_id": "space-1",
+			},
+			origin: cardActionFrameOrigin{SenderUID: "notification", SpaceID: "space-1", SpaceKnown: true, ProducerBinding: binding},
+		},
+		{
+			name: "bot provenance names a different bot",
+			provenance: map[string]interface{}{
+				"version": 1, "principal_type": "bot",
+				"principal_id": "bot-a", "space_id": "space-1",
+			},
+			origin: cardActionFrameOrigin{SenderUID: "bot-b", SpaceID: "space-1", SpaceKnown: true, ProducerBinding: binding},
+		},
+		{
+			name: "cross-space provenance",
+			provenance: map[string]interface{}{
+				"version": 1, "principal_type": "internal_producer",
+				"principal_id": "docs-notify", "space_id": "space-2",
+			},
+			origin: cardActionFrameOrigin{SenderUID: "notification", SpaceID: "space-1", SpaceKnown: true, ProducerBinding: binding},
+		},
+		{
+			name: "malformed provenance",
+			provenance: map[string]interface{}{
+				"version": 1, "principal_type": "internal_producer",
+				"principal_id": "docs-notify", "space_id": "space-1", "extra": true,
+			},
+			origin: cardActionFrameOrigin{SenderUID: "notification", SpaceID: "space-1", SpaceKnown: true, ProducerBinding: binding},
+		},
+		{
+			name: "no binding resolver fails closed",
+			provenance: map[string]interface{}{
+				"version": 1, "principal_type": "internal_producer",
+				"principal_id": "docs-notify", "space_id": "space-1",
+			},
+			origin: cardActionFrameOrigin{SenderUID: "notification", SpaceID: "space-1", SpaceKnown: true},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			raw, actionData := markedActionFrame(t, registry, tc.provenance)
+			if _, err := resolveRegistryCardContext(context.Background(), tc.origin, raw, cardtmpl.DocsApproveActionID, actionData); err == nil {
+				t.Fatal("inconsistent stored provenance accepted")
+			}
+		})
+	}
+}
+
+func TestResolveRegistryCardContextBotProvenanceMatchesSender(t *testing.T) {
+	registry, _ := provenanceActionFixture(t)
+	raw, actionData := markedActionFrame(t, registry, map[string]interface{}{
+		"version": 1, "principal_type": "bot", "principal_id": "bot-a", "space_id": "space-1",
+	})
+	origin := cardActionFrameOrigin{SenderUID: "bot-a", SpaceID: "space-1", SpaceKnown: true}
+	got, err := resolveRegistryCardContext(context.Background(), origin, raw, cardtmpl.DocsApproveActionID, actionData)
+	if err != nil {
+		t.Fatalf("resolveRegistryCardContext: %v", err)
+	}
+	if got.PrincipalType != "bot" || got.PrincipalID != "bot-a" || got.SpaceID != "space-1" {
+		t.Fatalf("card context principal = %+v", got)
+	}
+}
+
+func TestResolveRegistryCardContextLegacyFrameKeepsSenderPrincipal(t *testing.T) {
+	registry, spy := provenanceActionFixture(t)
+	// Pre-PR-C Bot Registry frame: template_ref only, no provenance.
+	raw, actionData := markedActionFrame(t, registry, nil)
+	origin := cardActionFrameOrigin{SenderUID: "notification", SpaceID: "space-1", SpaceKnown: true}
+	got, err := resolveRegistryCardContext(context.Background(), origin, raw, cardtmpl.DocsApproveActionID, actionData)
+	if err != nil {
+		t.Fatalf("resolveRegistryCardContext: %v", err)
+	}
+	if got.PrincipalType != "" || got.PrincipalID != "" {
+		t.Fatalf("legacy frame invented a validated principal: %+v", got)
+	}
+	wantPrincipal := cardtmpl.CatalogPrincipal{
+		Kind: cardtmpl.CatalogPrincipalBot, ID: "notification", SpaceID: "space-1",
+	}
+	if spy.lastRequest.Access.Principal != wantPrincipal {
+		t.Fatalf("legacy catalog access = %+v, want %+v", spy.lastRequest.Access.Principal, wantPrincipal)
+	}
+}
+
+// A frame that names a Space is only as trustworthy as the check against the
+// server's own answer. When that answer is unavailable the click must be
+// refused — and refused as an outage, because the frame may be perfectly valid
+// and the caller has no way to fix a group-table read from its side.
+func TestValidatedFramePrincipalRefusesAFrameSpaceItCannotCheck(t *testing.T) {
+	registry, _ := provenanceActionFixture(t)
+	raw, actionData := markedActionFrame(t, registry, map[string]interface{}{
+		"version": 1, "principal_type": "internal_producer",
+		"principal_id": "docs-notify", "space_id": "space-1",
+	})
+	binding := func(producerID string) (string, bool) {
+		if producerID == "docs-notify" {
+			return "notification", true
+		}
+		return "", false
+	}
+	blind := cardActionFrameOrigin{
+		SenderUID: "notification", ProducerBinding: binding,
+		// SpaceKnown deliberately false: the group row would not load.
+	}
+	_, err := resolveRegistryCardContext(context.Background(), blind, raw,
+		cardtmpl.DocsApproveActionID, actionData)
+	if !errors.Is(err, errCardOriginSpaceUnavailable) {
+		t.Fatalf("err = %v, want errCardOriginSpaceUnavailable", err)
+	}
+
+	// A determined "this card is in no Space" is a different answer, and a
+	// frame claiming one then genuinely disagrees with the server.
+	determined := cardActionFrameOrigin{
+		SenderUID: "notification", SpaceKnown: true, ProducerBinding: binding,
+	}
+	_, err = resolveRegistryCardContext(context.Background(), determined, raw,
+		cardtmpl.DocsApproveActionID, actionData)
+	if err == nil || errors.Is(err, errCardOriginSpaceUnavailable) {
+		t.Fatalf("err = %v, want a plain mismatch rejection", err)
+	}
+
+	// An unmarked frame carries no Space claim, so an unavailable origin is
+	// nothing to verify and the legacy path stays open.
+	plain, plainData := markedActionFrame(t, registry, nil)
+	if _, err := resolveRegistryCardContext(context.Background(), blind, plain,
+		cardtmpl.DocsApproveActionID, plainData); errors.Is(err, errCardOriginSpaceUnavailable) {
+		t.Fatalf("an unmarked frame was refused for a Space it never claimed: %v", err)
+	}
+}
+
+// Review P1-1: the escalation this closes. A markerless frame's template
+// identity comes from `card.metadata.octo.template` — inside the card body a
+// raw caller controls — while raw ingress only rejects the two *top-level*
+// server-only keys. With no marker the principal fell back to the sending
+// Bot's own identity, and `Allows(action_context)` reads `edit`. So a Bot with
+// only `discover+edit` could fabricate a frame naming an active dynamic version
+// and drive its action route, with `edit` standing in for the `send` grant the
+// frame never had.
+//
+// Markerless compatibility exists for cards delivered before PR-C, every one of
+// which names a version the frozen Registry knows. Scoping the fallback to
+// exactly that population keeps invariant 7 and closes the substitution.
+func TestMarkerlessFrameNamingAnUnknownTemplateIsRefused(t *testing.T) {
+	registry, _ := provenanceActionFixture(t)
+	binding := func(string) (string, bool) { return "", false }
+	origin := cardActionFrameOrigin{
+		SenderUID: "notification", SpaceID: "space-1", SpaceKnown: true, ProducerBinding: binding,
+	}
+
+	// A markerless frame naming the frozen Registry's own version still works —
+	// that is the entire legacy population and it must not regress.
+	legacy, legacyData := markedActionFrame(t, registry, nil)
+	if _, err := resolveRegistryCardContext(context.Background(), origin, legacy,
+		cardtmpl.DocsApproveActionID, legacyData); err != nil {
+		t.Fatalf("a legacy markerless frame was refused: %v", err)
+	}
+
+	// The raw-forgery shape: no top-level marker at all (ingress rejects those
+	// by key presence), only the nested metadata a caller controls, pointed at
+	// a version the Registry does not know. Refused before any authorization.
+	forged := retargetFrameTemplateVersion(t, legacy, "9.9.9-dyn")
+	_, err := resolveRegistryCardContext(context.Background(), origin, forged,
+		cardtmpl.DocsApproveActionID, legacyData)
+	if !errors.Is(err, errMarkerlessDynamicFrame) {
+		t.Fatalf("err = %v, want errMarkerlessDynamicFrame", err)
+	}
+}
+
+// retargetFrameTemplateVersion rewrites metadata.octo.template.version, which is
+// the field a raw caller controls, leaving everything else intact.
+func retargetFrameTemplateVersion(t *testing.T, frame []byte, version string) []byte {
+	t.Helper()
+	var envelope map[string]any
+	if err := json.Unmarshal(frame, &envelope); err != nil {
+		t.Fatalf("decode frame: %v", err)
+	}
+	// A raw caller cannot set the top-level marker — ingress rejects it by key
+	// presence — so the forgery has to work without one.
+	delete(envelope, "template_ref")
+	card, _ := envelope["card"].(map[string]any)
+	metadata, _ := card["metadata"].(map[string]any)
+	octo, _ := metadata["octo"].(map[string]any)
+	template, _ := octo["template"].(map[string]any)
+	if template == nil {
+		t.Fatal("frame carries no metadata.octo.template")
+	}
+	template["version"] = version
+	retargeted, err := json.Marshal(envelope)
+	if err != nil {
+		t.Fatalf("encode frame: %v", err)
+	}
+	return retargeted
+}
+
+// Review P2-3: an unknown origin Space had to fail closed on *both* branches.
+// The empty-Space branch looks harmless and is not — assigning an unknown
+// origin leaves the principal's Space empty, which resolves against the global
+// grant row alone, so a principal holding an active global grant plus an exact
+// tombstone for the card's real Space would be allowed. That defeats invariant
+// 11, whose whole purpose is letting an exact tombstone shadow a live global
+// grant, and a transient group-row read failure is enough to reach it.
+func TestUnknownOriginSpaceIsRefusedWhateverTheFrameClaims(t *testing.T) {
+	registry, _ := provenanceActionFixture(t)
+	binding := func(producerID string) (string, bool) {
+		if producerID == "docs-notify" {
+			return "notification", true
+		}
+		return "", false
+	}
+	blind := cardActionFrameOrigin{SenderUID: "notification", ProducerBinding: binding}
+
+	for _, frameSpace := range []string{"space-1", ""} {
+		raw, actionData := markedActionFrame(t, registry, map[string]interface{}{
+			"version": 1, "principal_type": "internal_producer",
+			"principal_id": "docs-notify", "space_id": frameSpace,
+		})
+		_, err := resolveRegistryCardContext(context.Background(), blind, raw,
+			cardtmpl.DocsApproveActionID, actionData)
+		if !errors.Is(err, errCardOriginSpaceUnavailable) {
+			t.Fatalf("frame space %q: err = %v, want errCardOriginSpaceUnavailable", frameSpace, err)
+		}
+	}
+
+	// A determined origin still resolves, so the refusal is about not knowing
+	// rather than about the Space being absent.
+	known := blind
+	known.SpaceKnown = true
+	known.SpaceID = "space-1"
+	raw, actionData := markedActionFrame(t, registry, map[string]interface{}{
+		"version": 1, "principal_type": "internal_producer",
+		"principal_id": "docs-notify", "space_id": "space-1",
+	})
+	if _, err := resolveRegistryCardContext(context.Background(), known, raw,
+		cardtmpl.DocsApproveActionID, actionData); err != nil {
+		t.Fatalf("a determined origin Space was refused: %v", err)
+	}
 }

--- a/modules/notify/action_finalizer.go
+++ b/modules/notify/action_finalizer.go
@@ -98,7 +98,20 @@ func (f *DocsActionFinalizer) Finalize(ctx context.Context, event cardactiondisp
 		denyReason = strings.TrimSpace(v)
 	}
 	terminal := result.State == cardactiondispatch.StateApproved || result.State == cardactiondispatch.StateDenied
-	if terminal && f.updater != nil {
+	// Every state renders through the Registry when an updater is present, not
+	// just the decided ones. The pending card is a Registry render and so
+	// carries the server-authored catalog markers; the fallback below rebuilds
+	// the frame from a six-key allowlist that holds neither, so routing a
+	// marked card there erased both on an ordinary user click and left the
+	// identity guards in pkg/cardtmpl/updater.go inert for that message.
+	//
+	// Selecting the route by state was the bug's shape, so the state list is
+	// gone rather than extended: `cancelled` was the reported case, `pending`
+	// reaches the same branch, and a state added later would have inherited the
+	// defect silently. What remains is the distinction the fallback was written
+	// for — a deployment with no updater at all. `terminal` still means
+	// "decided", and still gates the notification below.
+	if f.updater != nil {
 		if err := f.replaceWithRegistryResult(ctx, event, result, channelID, lang, title, denyReason); err != nil {
 			return err
 		}
@@ -158,8 +171,19 @@ func truncRunes(s string, max int) string {
 	return s
 }
 
+// docsResultTemplateVersion resolves the click-driven result edit's target
+// version from the durable event's stored card context. The rules live in
+// docsResultVersion so the sibling mutate endpoint cannot drift from them.
+func docsResultTemplateVersion(event cardactiondispatch.Event) (string, error) {
+	return docsResultVersion(event.Card.TemplateID, event.Card.TemplateVersion)
+}
+
 func (f *DocsActionFinalizer) replaceWithRegistryResult(ctx context.Context, event cardactiondispatch.Event,
 	result cardactiondispatch.DecisionResult, channelID, lang, title, denyReason string) error {
+	version, err := docsResultTemplateVersion(event)
+	if err != nil {
+		return err
+	}
 	fields, state, err := buildDocsAccessResultFields(lang, docsResultRenderInput{
 		Data:             event.Data,
 		Title:            title,
@@ -167,6 +191,14 @@ func (f *DocsActionFinalizer) replaceWithRegistryResult(ctx context.Context, eve
 		DecidedAtDisplay: result.Display["decided_at"],
 		DenyReason:       denyReason,
 		Denied:           result.State == cardactiondispatch.StateDenied,
+		Cancelled:        result.State == cardactiondispatch.StateCancelled,
+		// Anything that is not a decision and not an explicit cancellation —
+		// `pending` today, whatever a later contract adds — renders as
+		// unavailable, which is what the pre-Registry fallback already showed
+		// for those states.
+		Unavailable: result.State != cardactiondispatch.StateApproved &&
+			result.State != cardactiondispatch.StateDenied &&
+			result.State != cardactiondispatch.StateCancelled,
 	})
 	if err != nil {
 		return err
@@ -180,7 +212,7 @@ func (f *DocsActionFinalizer) replaceWithRegistryResult(ctx context.Context, eve
 		// .octospec/learnings/pending/cardtmpl-interaction-closure.md)。若未来 event
 		// ID 生成器改为非单调,CAS 会静默丢弃合法更新——务必同步复核。
 		SenderUID: event.SenderUID, MessageID: event.MessageID, CardSeq: event.EventID,
-	}, docsaccessrequest.TemplateID, docsaccessrequest.TemplateVersionV3, state, fields, cardtmpl.BuildEnv{
+	}, docsaccessrequest.TemplateID, version, state, fields, cardtmpl.BuildEnv{
 		WebLoginURL: f.ctx.GetConfig().External.WebLoginURL, Lang: lang, SpaceID: event.SpaceID,
 	})
 }
@@ -196,6 +228,8 @@ type docsResultRenderInput struct {
 	DecidedAtDisplay string
 	DenyReason       string
 	Denied           bool
+	Cancelled        bool
+	Unavailable      bool
 }
 
 func buildDocsAccessResultFields(lang string, input docsResultRenderInput) (json.RawMessage, cardtmpl.State, error) {
@@ -223,9 +257,13 @@ func buildDocsAccessResultFields(lang string, input docsResultRenderInput) (json
 	}
 	state := docsaccessrequest.StateApproved
 	wireState := "approved"
-	if input.Denied {
-		state = docsaccessrequest.StateRejected
-		wireState = "rejected"
+	switch {
+	case input.Unavailable:
+		state, wireState = docsaccessrequest.StateUnavailable, "unavailable"
+	case input.Cancelled:
+		state, wireState = docsaccessrequest.StateCancelled, "cancelled"
+	case input.Denied:
+		state, wireState = docsaccessrequest.StateRejected, "rejected"
 	}
 	actor := stringEventData(input.Data, "actor")
 	document := map[string]any{
@@ -245,10 +283,16 @@ func buildDocsAccessResultFields(lang string, input docsResultRenderInput) (json
 		"state":     wireState,
 		"document":  document,
 		"requester": requester,
-		"decision": map[string]any{
+	}
+	// A cancelled request was never decided, so it has no operator and no
+	// decision time. The data contract requires `decision` only for
+	// approved/rejected; emitting one here would put the generic operator
+	// placeholder on a card nobody acted on.
+	if !input.Cancelled && !input.Unavailable {
+		fields["decision"] = map[string]any{
 			"operatorName":     truncRunes(operatorName, capResultName),
 			"decidedAtDisplay": truncRunes(strings.TrimSpace(input.DecidedAtDisplay), capResultShortLabel),
-		},
+		}
 	}
 	dataCaps := map[string]int{
 		"requestReason":      capResultReason,
@@ -311,7 +355,7 @@ func (f *DocsActionFinalizer) buildTerminalDocument(ctx context.Context, lang, d
 }
 
 // buildDocsDecisionTerminalDocument renders the legacy/no-updater fallback for
-// approved/denied outcomes. Production V3 result updates use CardUpdater.
+// approved/denied outcomes. Production result updates use CardUpdater at the card's stored version.
 func buildDocsDecisionTerminalDocument(ctx context.Context, webLoginURL, lang, docID, spaceID, title, denyReason string, denied bool) (json.RawMessage, error) {
 	labels := docsLabelsFor(lang)
 	if denied {

--- a/modules/notify/action_finalizer_v3_test.go
+++ b/modules/notify/action_finalizer_v3_test.go
@@ -272,67 +272,86 @@ func TestDocsActionFinalizerRejectsForeignStoredTemplate(t *testing.T) {
 	}
 }
 
-// PR-C review round 6 (yujiawei P1-2): a cancelled result must not downgrade a
-// marked card to the legacy rebuild.
+// PR-C review rounds 5 and 7 (yujiawei): the replacement route must not be
+// selected by state.
 //
-// The pending card is a Registry render, so it carries the server-authored
-// catalog markers. buildTerminalEnvelope assembles a replacement from a fixed
-// six-key allowlist that includes neither, and the marker-preserving branch was
-// taken only for approved/denied — so an ordinary user click on a route that
-// answers `cancelled` erased both markers. Both identity guards in
-// pkg/cardtmpl/updater.go begin `if markers.Has…`, so they went inert for that
-// message, and the frame silently rejoined the legacy population.
+// The pending card is a Registry render and carries the server-authored
+// catalog markers; the fallback rebuilds the frame from a six-key allowlist
+// that holds neither, so routing a marked card there erased both on an ordinary
+// user click and left the identity guards in pkg/cardtmpl/updater.go inert for
+// that message. `cancelled` was the reported case and `pending` reaches the
+// same branch, so an allowlist of "states that render through the Registry"
+// would have gone stale the next time the contract grew a state — silently, in
+// the direction of erasing markers. The route turns on whether an updater
+// exists instead, and this table is what holds that shape.
 //
-// The absence of any test for a non-terminal finalizer state is why this was
-// invisible for six rounds.
-func TestDocsActionFinalizerRoutesCancelledThroughTheRegistry(t *testing.T) {
-	wk := newWuKongServer()
-	defer wk.close()
-	ctx := newTestContext(t, wk)
-	ctx.GetConfig().External.WebLoginURL = "https://im.example.com/login"
-	updater := &captureViewUpdater{}
-	legacyMutator := &captureCardMutator{}
-	finalizer, err := NewDocsActionFinalizerWithUpdater(ctx, updater, legacyMutator, &capturingCardSender{})
-	if err != nil {
-		t.Fatalf("NewDocsActionFinalizerWithUpdater: %v", err)
-	}
-	event := cardactiondispatch.Event{
-		EventID: 43, SenderUID: NotifyBotUIDValue, Owner: "docs", ActionType: "access_request.decision",
-		MessageID: "1002", ChannelID: NotifyBotUIDValue, ChannelType: 1, SpaceID: "space-1", OperatorUID: "reviewer-1",
-		Data: map[string]any{
-			"doc_id": "doc-1", "request_id": "request-1", "doc_title": "Roadmap", "actor": "Alice",
-			"permission_label": "Access", "permission_role_label": "Editor", "source_name": "Docs",
-		},
-	}
-	result := cardactiondispatch.DecisionResult{
-		Disposition: cardactiondispatch.DispositionApplied,
-		State:       cardactiondispatch.StateCancelled,
-		Display:     map[string]string{"title": "Roadmap"},
-	}
-	if err := finalizer.Finalize(context.Background(), event, result); err != nil {
-		t.Fatalf("Finalize(cancelled): %v", err)
-	}
-	if len(legacyMutator.requests) != 0 {
-		t.Fatalf("cancelled took the marker-erasing legacy path: %+v", legacyMutator.requests)
-	}
-	if updater.calls != 1 {
-		t.Fatalf("registry replacement calls = %d, want 1", updater.calls)
-	}
-	if updater.id != docsaccessrequest.TemplateID || updater.version != docsaccessrequest.TemplateVersionV3 ||
-		updater.state != docsaccessrequest.StateCancelled {
-		t.Fatalf("update selection = %s@%s/%s", updater.id, updater.version, updater.state)
-	}
-	var fields map[string]any
-	if err := json.Unmarshal(updater.fields, &fields); err != nil {
-		t.Fatalf("decode fields: %v", err)
-	}
-	if fields["state"] != "cancelled" {
-		t.Fatalf("wire state = %v", fields["state"])
-	}
-	// Nobody decided a cancelled request, so it carries no operator: emitting
-	// one would put the generic approver placeholder on a card no one acted on.
-	if _, present := fields["decision"]; present {
-		t.Fatalf("cancelled result invented a decision: %+v", fields["decision"])
+// This test was written in round 7, reported as landed, and then removed by a
+// later whole-section edit in the same session. Nothing went red, because a
+// deleted test is not a failing test — which is the argument for the table
+// rather than for one more single-state case.
+func TestDocsActionFinalizerRoutesEveryStateThroughTheRegistry(t *testing.T) {
+	for _, test := range []struct {
+		name      string
+		state     cardactiondispatch.State
+		wantState cardtmpl.State
+		wantWire  string
+	}{
+		{"approved", cardactiondispatch.StateApproved, docsaccessrequest.StateApproved, "approved"},
+		{"denied", cardactiondispatch.StateDenied, docsaccessrequest.StateRejected, "rejected"},
+		{"cancelled", cardactiondispatch.StateCancelled, docsaccessrequest.StateCancelled, "cancelled"},
+		// The state that would have kept the defect alive after the cancelled
+		// fix: valid, decodable, and previously routed to the legacy rebuild.
+		{"pending", cardactiondispatch.StatePending, docsaccessrequest.StateUnavailable, "unavailable"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			wk := newWuKongServer()
+			defer wk.close()
+			ctx := newTestContext(t, wk)
+			ctx.GetConfig().External.WebLoginURL = "https://im.example.com/login"
+			updater := &captureViewUpdater{}
+			legacyMutator := &captureCardMutator{}
+			finalizer, err := NewDocsActionFinalizerWithUpdater(ctx, updater, legacyMutator, &capturingCardSender{})
+			if err != nil {
+				t.Fatalf("NewDocsActionFinalizerWithUpdater: %v", err)
+			}
+			event := cardactiondispatch.Event{
+				EventID: 44, SenderUID: NotifyBotUIDValue, Owner: "docs", ActionType: "access_request.decision",
+				MessageID: "1003", ChannelID: NotifyBotUIDValue, ChannelType: 1, SpaceID: "space-1",
+				OperatorUID: "reviewer-1",
+				Data: map[string]any{
+					"doc_id": "doc-1", "request_id": "request-1", "doc_title": "Roadmap", "actor": "Alice",
+				},
+			}
+			result := cardactiondispatch.DecisionResult{
+				Disposition: cardactiondispatch.DispositionApplied, State: test.state,
+				RequesterUID: "user-a", Display: map[string]string{"title": "Roadmap"},
+			}
+			if err := finalizer.Finalize(context.Background(), event, result); err != nil {
+				t.Fatalf("Finalize(%s): %v", test.state, err)
+			}
+			if len(legacyMutator.requests) != 0 {
+				t.Fatalf("%s took the marker-erasing legacy path", test.state)
+			}
+			if updater.state != test.wantState {
+				t.Fatalf("registry state = %q, want %q", updater.state, test.wantState)
+			}
+			var fields map[string]any
+			if err := json.Unmarshal(updater.fields, &fields); err != nil {
+				t.Fatalf("decode fields: %v", err)
+			}
+			if fields["state"] != test.wantWire {
+				t.Fatalf("wire state = %v, want %q", fields["state"], test.wantWire)
+			}
+			// Nobody decided cancelled or pending, so neither carries an
+			// operator: emitting one would put the generic approver placeholder
+			// on a card no one acted on.
+			_, hasDecision := fields["decision"]
+			wantDecision := test.state == cardactiondispatch.StateApproved ||
+				test.state == cardactiondispatch.StateDenied
+			if hasDecision != wantDecision {
+				t.Fatalf("decision present = %v, want %v for %s", hasDecision, wantDecision, test.state)
+			}
+		})
 	}
 }
 

--- a/modules/notify/action_finalizer_v3_test.go
+++ b/modules/notify/action_finalizer_v3_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/Mininglamp-OSS/octo-server/internal/cardactiondispatch"
 	"github.com/Mininglamp-OSS/octo-server/internal/carddispatch"
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardmsg"
 	"github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl"
 	docsaccessrequest "github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl/docs_access_request"
 )
@@ -19,10 +20,12 @@ type captureViewUpdater struct {
 	state   cardtmpl.State
 	fields  json.RawMessage
 	env     cardtmpl.BuildEnv
+	calls   int
 }
 
 func (u *captureViewUpdater) ReplaceView(_ context.Context, target cardtmpl.UpdateTarget, id cardtmpl.ID,
 	version string, state cardtmpl.State, fields json.RawMessage, env cardtmpl.BuildEnv) error {
+	u.calls++
 	u.target, u.id, u.version, u.state, u.fields, u.env = target, id, version, state, fields, env
 	return nil
 }
@@ -199,4 +202,341 @@ func TestDocsActionFinalizerV3TruncatesOversizedDisplayFields(t *testing.T) {
 	if !mut.mutated {
 		t.Fatal("mutator was never called — terminal update did not persist")
 	}
+}
+
+// ---- PR-C Slice 1 (D3/D7): the finalizer's result edit pins the version the
+// event's stored frame actually used — never a hardcoded constant, never a
+// foreign template identity. ----
+
+func storedVersionFinalizerFixture(t *testing.T) (*captureViewUpdater, *DocsActionFinalizer, cardactiondispatch.Event, cardactiondispatch.DecisionResult) {
+	t.Helper()
+	wk := newWuKongServer()
+	t.Cleanup(wk.close)
+	ctx := newTestContext(t, wk)
+	ctx.GetConfig().External.WebLoginURL = "https://im.example.com/login"
+	updater := &captureViewUpdater{}
+	finalizer, err := NewDocsActionFinalizerWithUpdater(ctx, updater, &captureCardMutator{}, &capturingCardSender{})
+	if err != nil {
+		t.Fatalf("NewDocsActionFinalizerWithUpdater: %v", err)
+	}
+	event := cardactiondispatch.Event{
+		EventID: 42, SenderUID: NotifyBotUIDValue, Owner: "docs", ActionType: "access_request.decision",
+		MessageID: "1001", ChannelID: NotifyBotUIDValue, ChannelType: 1, SpaceID: "space-1", OperatorUID: "reviewer-1",
+		Data: map[string]any{"doc_id": "doc-1", "request_id": "request-1", "doc_title": "Roadmap"},
+	}
+	result := cardactiondispatch.DecisionResult{
+		Disposition: cardactiondispatch.DispositionApplied, State: cardactiondispatch.StateApproved,
+		RequesterUID: "user-a", Display: map[string]string{"title": "Roadmap"},
+	}
+	return updater, finalizer, event, result
+}
+
+func TestDocsActionFinalizerUsesEventStoredTemplateVersion(t *testing.T) {
+	updater, finalizer, event, result := storedVersionFinalizerFixture(t)
+	// A dynamic pilot frame stores its own exact version in the durable event.
+	event.Card = cardactiondispatch.CardContext{
+		TemplateID: string(docsaccessrequest.TemplateID), TemplateVersion: "0.4.0-test.1", View: "pending",
+	}
+	if err := finalizer.Finalize(context.Background(), event, result); err != nil {
+		t.Fatalf("Finalize: %v", err)
+	}
+	if updater.version != "0.4.0-test.1" {
+		t.Fatalf("result edit version = %q, want the event's stored exact version", updater.version)
+	}
+	if updater.id != docsaccessrequest.TemplateID {
+		t.Fatalf("result edit template = %q", updater.id)
+	}
+}
+
+func TestDocsActionFinalizerLegacyEventKeepsStaticVersion(t *testing.T) {
+	updater, finalizer, event, result := storedVersionFinalizerFixture(t)
+	// Pre-registry durable events carry no card context.
+	if err := finalizer.Finalize(context.Background(), event, result); err != nil {
+		t.Fatalf("Finalize: %v", err)
+	}
+	if updater.version != docsaccessrequest.TemplateVersionV3 {
+		t.Fatalf("legacy result edit version = %q, want %q", updater.version, docsaccessrequest.TemplateVersionV3)
+	}
+}
+
+func TestDocsActionFinalizerRejectsForeignStoredTemplate(t *testing.T) {
+	updater, finalizer, event, result := storedVersionFinalizerFixture(t)
+	event.Card = cardactiondispatch.CardContext{
+		TemplateID: "summary.completed", TemplateVersion: "0.1.0", View: "default",
+	}
+	if err := finalizer.Finalize(context.Background(), event, result); err == nil {
+		t.Fatal("foreign stored template identity finalized")
+	}
+	if updater.calls != 0 {
+		t.Fatalf("foreign identity still edited the card: %d calls", updater.calls)
+	}
+}
+
+// PR-C review round 6 (yujiawei P1-2): a cancelled result must not downgrade a
+// marked card to the legacy rebuild.
+//
+// The pending card is a Registry render, so it carries the server-authored
+// catalog markers. buildTerminalEnvelope assembles a replacement from a fixed
+// six-key allowlist that includes neither, and the marker-preserving branch was
+// taken only for approved/denied — so an ordinary user click on a route that
+// answers `cancelled` erased both markers. Both identity guards in
+// pkg/cardtmpl/updater.go begin `if markers.Has…`, so they went inert for that
+// message, and the frame silently rejoined the legacy population.
+//
+// The absence of any test for a non-terminal finalizer state is why this was
+// invisible for six rounds.
+func TestDocsActionFinalizerRoutesCancelledThroughTheRegistry(t *testing.T) {
+	wk := newWuKongServer()
+	defer wk.close()
+	ctx := newTestContext(t, wk)
+	ctx.GetConfig().External.WebLoginURL = "https://im.example.com/login"
+	updater := &captureViewUpdater{}
+	legacyMutator := &captureCardMutator{}
+	finalizer, err := NewDocsActionFinalizerWithUpdater(ctx, updater, legacyMutator, &capturingCardSender{})
+	if err != nil {
+		t.Fatalf("NewDocsActionFinalizerWithUpdater: %v", err)
+	}
+	event := cardactiondispatch.Event{
+		EventID: 43, SenderUID: NotifyBotUIDValue, Owner: "docs", ActionType: "access_request.decision",
+		MessageID: "1002", ChannelID: NotifyBotUIDValue, ChannelType: 1, SpaceID: "space-1", OperatorUID: "reviewer-1",
+		Data: map[string]any{
+			"doc_id": "doc-1", "request_id": "request-1", "doc_title": "Roadmap", "actor": "Alice",
+			"permission_label": "Access", "permission_role_label": "Editor", "source_name": "Docs",
+		},
+	}
+	result := cardactiondispatch.DecisionResult{
+		Disposition: cardactiondispatch.DispositionApplied,
+		State:       cardactiondispatch.StateCancelled,
+		Display:     map[string]string{"title": "Roadmap"},
+	}
+	if err := finalizer.Finalize(context.Background(), event, result); err != nil {
+		t.Fatalf("Finalize(cancelled): %v", err)
+	}
+	if len(legacyMutator.requests) != 0 {
+		t.Fatalf("cancelled took the marker-erasing legacy path: %+v", legacyMutator.requests)
+	}
+	if updater.calls != 1 {
+		t.Fatalf("registry replacement calls = %d, want 1", updater.calls)
+	}
+	if updater.id != docsaccessrequest.TemplateID || updater.version != docsaccessrequest.TemplateVersionV3 ||
+		updater.state != docsaccessrequest.StateCancelled {
+		t.Fatalf("update selection = %s@%s/%s", updater.id, updater.version, updater.state)
+	}
+	var fields map[string]any
+	if err := json.Unmarshal(updater.fields, &fields); err != nil {
+		t.Fatalf("decode fields: %v", err)
+	}
+	if fields["state"] != "cancelled" {
+		t.Fatalf("wire state = %v", fields["state"])
+	}
+	// Nobody decided a cancelled request, so it carries no operator: emitting
+	// one would put the generic approver placeholder on a card no one acted on.
+	if _, present := fields["decision"]; present {
+		t.Fatalf("cancelled result invented a decision: %+v", fields["decision"])
+	}
+}
+
+// The template must actually be able to render what the finalizer now asks of
+// it — a state the manifest does not declare fails ViewFor with ErrStateUnknown,
+// which would turn the routing fix into a runtime error instead of a card. The
+// finalizer tests above drive a capturing fake and never reach ViewFor, so this
+// is the only thing that witnesses the manifest declaration.
+func TestDocsAccessRequestV3RendersTheNonDecisionStates(t *testing.T) {
+	registry := cardtmpl.NewRegistry()
+	registry.Register(docsaccessrequest.NewV3(), docsaccessrequest.Assets, docsaccessrequest.HandoffRootV3)
+	registry.Freeze()
+
+	for _, test := range []struct {
+		name        string
+		input       docsResultRenderInput
+		wantState   cardtmpl.State
+		wantVariant string
+	}{
+		{
+			name:        "cancelled",
+			input:       docsResultRenderInput{Cancelled: true},
+			wantState:   docsaccessrequest.StateCancelled,
+			wantVariant: docsaccessrequest.VariantCancelled,
+		},
+		{
+			name:        "unavailable",
+			input:       docsResultRenderInput{Unavailable: true},
+			wantState:   docsaccessrequest.StateUnavailable,
+			wantVariant: docsaccessrequest.VariantUnavailable,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			input := test.input
+			input.Data = map[string]any{"request_id": "request-1", "doc_id": "doc-1"}
+			input.Title = "Roadmap"
+			fields, state, err := buildDocsAccessResultFields("zh-CN", input)
+			if err != nil {
+				t.Fatalf("buildDocsAccessResultFields: %v", err)
+			}
+			if state != test.wantState {
+				t.Fatalf("state = %q, want %q", state, test.wantState)
+			}
+			payload, err := registry.Render(context.Background(),
+				docsaccessrequest.TemplateID, docsaccessrequest.TemplateVersionV3, state, fields,
+				cardtmpl.BuildEnv{Lang: "zh-CN", SpaceID: "space-1", WebLoginURL: "https://im.example.com/login"})
+			if err != nil {
+				t.Fatalf("render %s: %v", test.wantState, err)
+			}
+			raw, err := json.Marshal(payload)
+			if err != nil {
+				t.Fatal(err)
+			}
+			// The render is what makes the markers legal on the replacement
+			// frame: only a Registry render writes metadata.octo.template, which
+			// template_ref must agree with.
+			if tmplCtx, ok := cardmsg.CardTemplateContext(raw); !ok ||
+				tmplCtx.ID != string(docsaccessrequest.TemplateID) ||
+				tmplCtx.Version != docsaccessrequest.TemplateVersionV3 {
+				t.Fatalf("%s render lost its template identity: %+v ok=%v", test.wantState, tmplCtx, ok)
+			}
+			if variant, _ := cardmsg.CardVariant(raw); variant != test.wantVariant {
+				t.Fatalf("variant = %q, want %q", variant, test.wantVariant)
+			}
+			// Nobody decided these, so they carry no operator: emitting one
+			// would put the generic approver placeholder on an untouched card.
+			var decoded map[string]any
+			if err := json.Unmarshal(fields, &decoded); err != nil {
+				t.Fatal(err)
+			}
+			if _, present := decoded["decision"]; present {
+				t.Fatalf("%s invented a decision: %+v", test.wantState, decoded["decision"])
+			}
+		})
+	}
+}
+
+// markerEnforcingCardMutator applies the same rule production applies at
+// carddispatch.CardMutator.Mutate, through the same exported helper, against a
+// stored frame the test supplies. It exists because the notify package cannot
+// construct a real CardMutator (its constructor takes an unexported backend),
+// and the point of the test below is what StandardActionFinalizer's *output*
+// would do at that boundary — not what the fake does.
+type markerEnforcingCardMutator struct {
+	stored   []byte
+	requests []carddispatch.CardMutationRequest
+}
+
+func (m *markerEnforcingCardMutator) Mutate(_ context.Context,
+	request carddispatch.CardMutationRequest) (carddispatch.CardMutationResult, error) {
+	stored, err := cardmsg.CatalogFrameMarkers(m.stored)
+	if err != nil {
+		return carddispatch.CardMutationResult{}, err
+	}
+	next, err := cardmsg.CatalogFrameMarkers([]byte(request.ContentEdit))
+	if err != nil {
+		return carddispatch.CardMutationResult{}, err
+	}
+	if stored.HasRef != next.HasRef || stored.HasProvenance != next.HasProvenance {
+		return carddispatch.CardMutationResult{}, carddispatch.ErrCardMutationInvalid
+	}
+	m.requests = append(m.requests, request)
+	return carddispatch.CardMutationResult{Applied: true}, nil
+}
+
+// PR-C review round 7 (yujiawei): StandardActionFinalizer is the default
+// finalizer for every owner except docs, it has no updater, and it routes every
+// state — approved and denied included — through buildTerminalEnvelope.
+//
+// It is latent rather than live today, and the reason is worth pinning down
+// rather than assuming: BuildApprovalRequestCard hand-builds its document
+// without metadata.octo.protocol/template, so cardDocumentTemplateContext
+// returns false and those cards are never marked in the first place. The moment
+// any non-docs owner's card becomes a Registry render, it would be marked, and
+// this finalizer would erase the markers on every finalize.
+//
+// The mutation boundary is what stops that becoming a silent regression, so
+// this asserts the boundary refuses it — the finalizer fails loudly instead of
+// downgrading a marked card. Today's unmarked cards keep working unchanged.
+func TestStandardActionFinalizerCannotSilentlyDowngradeAMarkedCard(t *testing.T) {
+	newEvent := func() (cardactiondispatch.Event, cardactiondispatch.DecisionResult) {
+		return cardactiondispatch.Event{
+				EventID: 85, SenderUID: NotifyBotUIDValue, Owner: "tasks", ActionType: "task.decision",
+				MessageID: "2002", ChannelID: NotifyBotUIDValue, ChannelType: 1, SpaceID: "space-1",
+				OperatorUID: "user-b",
+			}, cardactiondispatch.DecisionResult{
+				Disposition: cardactiondispatch.DispositionApplied,
+				State:       cardactiondispatch.StateApproved, RequesterUID: "user-a",
+				Display: map[string]string{"title": "Deploy release"},
+			}
+	}
+
+	t.Run("a marked stored frame is refused, not erased", func(t *testing.T) {
+		mutator := &markerEnforcingCardMutator{stored: markedNotifyFrame(t)}
+		finalizer, err := NewStandardActionFinalizer(mutator, &capturingCardSender{})
+		if err != nil {
+			t.Fatalf("NewStandardActionFinalizer: %v", err)
+		}
+		event, result := newEvent()
+		if err := finalizer.Finalize(context.Background(), event, result); err == nil {
+			t.Fatal("a marked card was silently downgraded by the standard finalizer")
+		}
+		if len(mutator.requests) != 0 {
+			t.Fatalf("a marker-erasing frame was persisted: %+v", mutator.requests)
+		}
+	})
+
+	t.Run("today's unmarked cards are unaffected", func(t *testing.T) {
+		mutator := &markerEnforcingCardMutator{stored: unmarkedNotifyFrame(t)}
+		finalizer, err := NewStandardActionFinalizer(mutator, &capturingCardSender{})
+		if err != nil {
+			t.Fatalf("NewStandardActionFinalizer: %v", err)
+		}
+		event, result := newEvent()
+		if err := finalizer.Finalize(context.Background(), event, result); err != nil {
+			t.Fatalf("an unmarked card must still finalize: %v", err)
+		}
+		if len(mutator.requests) != 1 {
+			t.Fatalf("mutation count = %d, want 1", len(mutator.requests))
+		}
+	})
+}
+
+func unmarkedNotifyFrame(t *testing.T) []byte {
+	t.Helper()
+	raw, err := json.Marshal(map[string]any{
+		"type": cardmsg.InteractiveCard.Int(), "card_version": cardmsg.CardVersion,
+		"profile": cardmsg.ProfileV2, "space_id": "space-1", "card_seq": 1,
+		"card": map[string]any{
+			"type": "AdaptiveCard", "version": cardmsg.CardVersion,
+			"body": []any{map[string]any{"type": "TextBlock", "text": "Deploy release"}},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return raw
+}
+
+// markedNotifyFrame is what a Registry-rendered card of this family would look
+// like: the top-level markers plus the metadata.octo.template they are checked
+// against.
+func markedNotifyFrame(t *testing.T) []byte {
+	t.Helper()
+	var frame map[string]any
+	if err := json.Unmarshal(unmarkedNotifyFrame(t), &frame); err != nil {
+		t.Fatal(err)
+	}
+	frame["card"].(map[string]any)["metadata"] = map[string]any{
+		"octo": map[string]any{
+			"protocol": "octo-card@1.0",
+			"template": map[string]any{"id": "tasks.decision", "version": "1.0.0"},
+		},
+	}
+	frame[cardmsg.CatalogTemplateRefKey] = map[string]any{"id": "tasks.decision", "version": "1.0.0"}
+	frame[cardmsg.CatalogProvenanceKey] = cardmsg.CatalogProvenance{
+		Version:       cardmsg.CatalogProvenanceVersion,
+		PrincipalType: cardmsg.CatalogPrincipalWireInternalProducer,
+		PrincipalID:   "tasks-notify",
+		SpaceID:       "space-1",
+	}.MarshalMap()
+	raw, err := json.Marshal(frame)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return raw
 }

--- a/modules/notify/action_finalizer_v3_test.go
+++ b/modules/notify/action_finalizer_v3_test.go
@@ -410,12 +410,17 @@ func TestDocsAccessRequestV3RendersTheNonDecisionStates(t *testing.T) {
 	}
 }
 
-// markerEnforcingCardMutator applies the same rule production applies at
-// carddispatch.CardMutator.Mutate, through the same exported helper, against a
+// markerEnforcingCardMutator applies the production preservation rule against a
 // stored frame the test supplies. It exists because the notify package cannot
 // construct a real CardMutator (its constructor takes an unexported backend),
 // and the point of the test below is what StandardActionFinalizer's *output*
 // would do at that boundary — not what the fake does.
+//
+// It calls cardmsg.CatalogMarkersPreserved rather than restating the
+// comparison. An earlier version hand-copied the boolean logic and said it went
+// "through the same exported helper" when no such helper existed; the copy
+// inherited the original's presence-equality bug, so this fake reproduced the
+// defect instead of catching it.
 type markerEnforcingCardMutator struct {
 	stored   []byte
 	requests []carddispatch.CardMutationRequest
@@ -431,7 +436,7 @@ func (m *markerEnforcingCardMutator) Mutate(_ context.Context,
 	if err != nil {
 		return carddispatch.CardMutationResult{}, err
 	}
-	if stored.HasRef != next.HasRef || stored.HasProvenance != next.HasProvenance {
+	if err := cardmsg.CatalogMarkersPreserved(stored, next); err != nil {
 		return carddispatch.CardMutationResult{}, carddispatch.ErrCardMutationInvalid
 	}
 	m.requests = append(m.requests, request)

--- a/modules/notify/approval_card.go
+++ b/modules/notify/approval_card.go
@@ -21,7 +21,7 @@ func (n *Notify) deliverApprovalCardNotification(req *NotifyReq, capability card
 		return nil, errNotifyCardNotAllowed
 	}
 	card := req.ApprovalCard
-	if strings.TrimSpace(req.SpaceID) == "" || len(req.Targets) == 0 || len(req.Targets) > 200 ||
+	if !spaceIDAcceptable(req.SpaceID) || len(req.Targets) == 0 || len(req.Targets) > 200 ||
 		strings.TrimSpace(card.Title) == "" {
 		return nil, errNotifyCardInvalid
 	}

--- a/modules/notify/card.go
+++ b/modules/notify/card.go
@@ -66,7 +66,7 @@ func (n *Notify) deliverCardNotification(ctx context.Context, req *NotifyReq) (*
 	} else {
 		summaryTid = summaryfailed.TemplateID
 	}
-	if err := preflightSummarySchema(ctx, card, summaryTid); err != nil {
+	if err := preflightSummarySchema(ctx, req.SpaceID, card, summaryTid); err != nil {
 		if failure, ok := classifyNotifyCatalogRuntimeFailure(err); ok {
 			n.Error("summary card preflight rejected by runtime catalog",
 				zap.String("catalog_result", failure.result), zap.Error(err),
@@ -387,7 +387,7 @@ func (n *Notify) deliverDocsCardNotification(ctx context.Context, req *NotifyReq
 	// Only the access_requested + gate-on branch flows through Registry.Render;
 	// other kinds keep the historical validate-in-builder behavior.
 	if card.Kind == DocsCardKindAccessRequested && docsApprovalCardsEnabled() {
-		if err := preflightDocsAccessRequestSchema(ctx, card); err != nil {
+		if err := preflightDocsAccessRequestSchema(ctx, req.SpaceID, card); err != nil {
 			if failure, ok := classifyNotifyCatalogRuntimeFailure(err); ok {
 				n.Error("docs access-request card preflight rejected by runtime catalog",
 					zap.String("catalog_result", failure.result), zap.Error(err),
@@ -415,7 +415,7 @@ func (n *Notify) deliverDocsCardNotification(ctx context.Context, req *NotifyReq
 		} else {
 			tid = docsshared.TemplateID
 		}
-		if err := preflightDocsDisplaySchema(ctx, card, tid); err != nil {
+		if err := preflightDocsDisplaySchema(ctx, req.SpaceID, card, tid); err != nil {
 			if failure, ok := classifyNotifyCatalogRuntimeFailure(err); ok {
 				n.Error("docs display card preflight rejected by runtime catalog",
 					zap.String("catalog_result", failure.result), zap.Error(err),
@@ -535,7 +535,7 @@ func (n *Notify) deliverDocsCardNotification(ctx context.Context, req *NotifyReq
 	}
 	fallbackText := ""
 	if !canCard {
-		fallbackText = buildDocsFallbackText(card, lang)
+		fallbackText = buildDocsFallbackText(card, lang, req.SpaceID)
 	}
 
 	type sendResult struct {
@@ -762,9 +762,15 @@ func docsAttributionAndVariant(kind, actorName string, labels docsLabels) (strin
 // pilot Template. Other kinds keep the historical multi-line composition.
 // If Template.FallbackText is unavailable (Registry unwired / mapping fails),
 // fall back to the historical composition so callers never lose the text path.
-func buildDocsFallbackText(card *DocsCardFields, lang string) string {
+// spaceID is the Space the accompanying send is authorized against. It is not
+// decoration: template resolution became Space-aware in Slice 3, so resolving
+// the fallback with an empty Space would authorize a different principal than
+// the send this text belongs to — and the only visible symptom would be a card
+// rendered from the dynamic template whose plain-text twin came from the legacy
+// hardcoded labels.
+func buildDocsFallbackText(card *DocsCardFields, lang, spaceID string) string {
 	if card != nil && card.Kind == DocsCardKindAccessRequested && docsApprovalCardsEnabled() {
-		if text, ok := templateFallbackText(card, lang); ok {
+		if text, ok := templateFallbackText(card, lang, spaceID); ok {
 			return text
 		}
 	}

--- a/modules/notify/card.go
+++ b/modules/notify/card.go
@@ -33,6 +33,23 @@ import (
 // existing retry/dedup state machine handles them, exactly as the text path.
 // Ordinary card-build failures retain the legacy text fallback; runtime-catalog
 // safety rejections (blocked/disabled/auth/integrity/unavailable) fail closed.
+// spaceIDAcceptable rejects a Space the card boundary would later refuse.
+//
+// Blank was already rejected here; untrimmed was not, and after PR-C D3 that
+// difference is visible to callers. The marker-authoring boundary in
+// internal/carddispatch validates the Space before stamping it and fails the
+// send, so an untrimmed value used to fan out one goroutine per target and
+// come back as HTTP 200 with every target failed as `card_invalid`, N
+// identical warn lines, and nothing naming the cause. Catching it here turns
+// that into one accurate 400.
+//
+// This is validation, not normalisation: the value is still never rewritten.
+// Trimming it silently would put the caller's card in a Space they did not
+// name, which is the failure the strict reader exists to prevent.
+func spaceIDAcceptable(spaceID string) bool {
+	return spaceID != "" && strings.TrimSpace(spaceID) == spaceID
+}
+
 func (n *Notify) deliverCardNotification(ctx context.Context, req *NotifyReq) (*NotifyResp, error) {
 	if ctx == nil {
 		ctx = context.Background()
@@ -41,7 +58,7 @@ func (n *Notify) deliverCardNotification(ctx context.Context, req *NotifyReq) (*
 		return nil, errNotifyCardInvalid
 	}
 	card := req.Card
-	if strings.TrimSpace(req.SpaceID) == "" || len(req.Targets) == 0 || len(req.Targets) > 200 {
+	if !spaceIDAcceptable(req.SpaceID) || len(req.Targets) == 0 || len(req.Targets) > 200 {
 		return nil, errNotifyCardInvalid
 	}
 	if strings.TrimSpace(card.TaskNo) == "" || strings.TrimSpace(card.Title) == "" {
@@ -362,7 +379,7 @@ func (n *Notify) deliverDocsCardNotification(ctx context.Context, req *NotifyReq
 		return nil, errNotifyCardInvalid
 	}
 	card := req.DocsCard
-	if strings.TrimSpace(req.SpaceID) == "" || len(req.Targets) == 0 || len(req.Targets) > 200 {
+	if !spaceIDAcceptable(req.SpaceID) || len(req.Targets) == 0 || len(req.Targets) > 200 {
 		return nil, errNotifyCardInvalid
 	}
 	if strings.TrimSpace(card.DocID) == "" || strings.TrimSpace(card.Title) == "" {

--- a/modules/notify/card_action_test.go
+++ b/modules/notify/card_action_test.go
@@ -138,7 +138,7 @@ func TestDocsOutcomeCardsAreV1AndDeniedDoesNotLeakApproverOrReason(t *testing.T)
 		if kind == DocsCardKindAccessDenied {
 			assert.NotContains(t, string(document), "denial-reason-secret")
 			assert.Contains(t, string(document), "访问申请已拒绝")
-			fallback := buildDocsFallbackText(card, "zh-CN")
+			fallback := buildDocsFallbackText(card, "zh-CN", "")
 			assert.NotContains(t, fallback, "approver-secret")
 			assert.NotContains(t, fallback, "denial-reason-secret")
 		} else {

--- a/modules/notify/card_c1_regression_test.go
+++ b/modules/notify/card_c1_regression_test.go
@@ -137,7 +137,7 @@ func TestPreflightDocsAccessRequestSchema_AvatarSemantics(t *testing.T) {
 	for _, u := range bad {
 		card := validAccessRequestDocsCard()
 		card.ActorAvatarURL = u
-		if err := preflightDocsAccessRequestSchema(context.Background(), card); !errors.Is(err, cardtmpl.ErrFieldsInvalid) {
+		if err := preflightDocsAccessRequestSchema(context.Background(), "space-preflight", card); !errors.Is(err, cardtmpl.ErrFieldsInvalid) {
 			t.Errorf("avatar %q: want ErrFieldsInvalid, got %v", u, err)
 		}
 	}
@@ -146,7 +146,7 @@ func TestPreflightDocsAccessRequestSchema_AvatarSemantics(t *testing.T) {
 	for _, u := range ok {
 		card := validAccessRequestDocsCard()
 		card.ActorAvatarURL = u
-		if err := preflightDocsAccessRequestSchema(context.Background(), card); err != nil {
+		if err := preflightDocsAccessRequestSchema(context.Background(), "space-preflight", card); err != nil {
 			t.Errorf("avatar %q: want pass, got %v", u, err)
 		}
 	}
@@ -163,7 +163,7 @@ func TestPreflight_EmitsFieldsInvalidMetric(t *testing.T) {
 
 	card := validAccessRequestDocsCard()
 	card.Title = "" // schema violation: document.title minLength=1
-	if err := preflightDocsAccessRequestSchema(context.Background(), card); !errors.Is(err, cardtmpl.ErrFieldsInvalid) {
+	if err := preflightDocsAccessRequestSchema(context.Background(), "space-preflight", card); !errors.Is(err, cardtmpl.ErrFieldsInvalid) {
 		t.Fatalf("want ErrFieldsInvalid, got %v", err)
 	}
 

--- a/modules/notify/card_mutate_api.go
+++ b/modules/notify/card_mutate_api.go
@@ -99,7 +99,7 @@ type CardMutateResp struct {
 
 // mutateCard handles POST /v1/internal/cards/mutate. It drives one already-
 // delivered docs access card to its terminal (approved/denied) state in place,
-// reusing the same V3 Registry field mapping as the click-driven finalizer.
+// reusing the same Registry field mapping as the click-driven finalizer.
 // Docs capability only.
 func (n *Notify) mutateCard(c *wkhttp.Context) {
 	capability, _ := c.Get(notifyCapabilityContextKey)
@@ -243,6 +243,12 @@ func replaceSiblingWithRegistryResult(ctx context.Context, updater cardtmpl.Card
 	if storedDocID == "" || storedDocID != strings.TrimSpace(req.DocID) {
 		return fmt.Errorf("%w: document mismatch", errDocsSiblingContextInvalid)
 	}
+	// The version comes from the frame being replaced, exactly as the
+	// click-driven finalizer takes it from the stored card context.
+	version, err := docsResultVersionFromFrame(snapshot.Envelope)
+	if err != nil {
+		return fmt.Errorf("%w: %v", errDocsSiblingContextInvalid, err)
+	}
 	denied := req.Kind == DocsCardKindAccessDenied
 	fields, state, err := buildDocsAccessResultFields(env.Lang, docsResultRenderInput{
 		Data:             data,
@@ -260,5 +266,5 @@ func replaceSiblingWithRegistryResult(ctx context.Context, updater cardtmpl.Card
 			SpaceID: req.SpaceID, ChannelID: req.ChannelID, ChannelType: req.ChannelType,
 		},
 		SenderUID: NotifyBotUIDValue, MessageID: req.MessageID, CardSeq: cardSeq,
-	}, docsaccessrequest.TemplateID, docsaccessrequest.TemplateVersionV3, state, fields, env)
+	}, docsaccessrequest.TemplateID, version, state, fields, env)
 }

--- a/modules/notify/card_test.go
+++ b/modules/notify/card_test.go
@@ -313,7 +313,7 @@ func TestBuildDocsCard_RejectsNonHTTPSDeepLinkOrigin(t *testing.T) {
 }
 
 func TestBuildDocsFallbackText(t *testing.T) {
-	text := buildDocsFallbackText(validDocsCard(), "zh-CN")
+	text := buildDocsFallbackText(validDocsCard(), "zh-CN", "")
 	assert.Contains(t, text, "Alice 分享了文档")
 	assert.Contains(t, text, "文档：产品设计方案")
 	assert.Contains(t, text, "Q3 上线计划已确认")
@@ -331,7 +331,7 @@ func TestBuildDocsFallbackText_AccessRequestedPreservesExcerptAndTime(t *testing
 	card.Excerpt = "需要评审季度计划"
 	card.UpdatedAt = "2026-07-20 09:30"
 
-	text := buildDocsFallbackText(card, "zh-CN")
+	text := buildDocsFallbackText(card, "zh-CN", "")
 	assert.Contains(t, text, "需要评审季度计划", "access-request fallback dropped the excerpt")
 	assert.Contains(t, text, "2026-07-20 09:30", "access-request fallback dropped the time")
 	assert.Contains(t, text, "Alice", "actor should still appear")
@@ -385,7 +385,7 @@ func TestBuildDocsFallbackText_StripsNewlineInjection(t *testing.T) {
 	card := validDocsCard()
 	card.ActorName = "Alice\n系统管理员"
 	card.Title = "标题\n伪造：越权提示"
-	text := buildDocsFallbackText(card, "zh-CN")
+	text := buildDocsFallbackText(card, "zh-CN", "")
 	assert.NotContains(t, text, "\n伪造", "an embedded title newline must not start a new line")
 	assert.Contains(t, text, "Alice 系统管理员 分享了文档", "actor newline collapses to a space in the attribution")
 }

--- a/modules/notify/card_test.go
+++ b/modules/notify/card_test.go
@@ -455,3 +455,34 @@ func TestIntegration_NotifyBatchRejectsCardField(t *testing.T) {
 		})
 	}
 }
+
+// PR-C review round 7 (yujiawei P2-A): the three card ingresses rejected a
+// blank Space but not an untrimmed one, and after D3 that difference reaches
+// the caller. The marker-authoring boundary validates the Space before
+// stamping and fails the send, so an untrimmed value fanned out one goroutine
+// per target and returned HTTP 200 with every target failed as `card_invalid`
+// — N identical warn lines and nothing naming the cause.
+//
+// The value is still never rewritten. Trimming silently would deliver the
+// card into a Space the caller did not name, which is the failure the strict
+// reader exists to prevent; this only refuses earlier and says why.
+func TestCardIngressRejectsAnUntrimmedSpaceBeforeFanout(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		spaceID string
+		want    bool
+	}{
+		{"canonical", "space-1", true},
+		{"blank", "", false},
+		{"empty after trim", "   ", false},
+		{"trailing space", "space-1 ", false},
+		{"leading space", " space-1", false},
+		{"trailing newline", "space-1\n", false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if got := spaceIDAcceptable(test.spaceID); got != test.want {
+				t.Fatalf("spaceIDAcceptable(%q) = %v, want %v", test.spaceID, got, test.want)
+			}
+		})
+	}
+}

--- a/modules/notify/card_via_registry.go
+++ b/modules/notify/card_via_registry.go
@@ -83,7 +83,7 @@ const notifyCatalogCallTimeout = 10 * time.Second
 // buildDocsFallbackText 会先调本函数,让 fallback 文本走 pilot Template 的 L0
 // 定义。Registry 未注入 / Template 未注册 / mapping/unmarshal 失败 → 返 ok=false,
 // caller 兜回 legacy 多行组装。
-func templateFallbackText(card *DocsCardFields, lang string) (string, bool) {
+func templateFallbackText(card *DocsCardFields, lang, spaceID string) (string, bool) {
 	catalog := cardtmpl.DefaultCatalog()
 	if catalog == nil {
 		return "", false
@@ -95,7 +95,7 @@ func templateFallbackText(card *DocsCardFields, lang string) (string, bool) {
 	ctx, cancel := boundedNotifyCatalogContext(context.Background())
 	defer cancel()
 	text, err := catalog.FallbackText(ctx, cardtmpl.CatalogFallbackRequest{
-		Access: notifyCatalogAccess(docsNotifyProducerID, ""),
+		Access: notifyCatalogAccess(docsNotifyProducerID, spaceID),
 		ID:     docsaccessrequest.TemplateID, State: docsaccessrequest.StatePending,
 		Fields: fields, Lang: lang,
 	})
@@ -115,7 +115,13 @@ func templateFallbackText(card *DocsCardFields, lang string) (string, bool) {
 // R2-2 修正:前版当 registry nil 时返 nil 让 caller 继续走 v2 分支,后者最终降级
 // 文本 —— 那样"错请求"仍然会成功送达一条文本,与 §10 / A14 冲突。现在 preflight
 // 阶段就报 500,让 wiring bug 立刻可见。
-func preflightDocsAccessRequestSchema(parent context.Context, card *DocsCardFields) error {
+// preflightDocsAccessRequestSchema validates the caller's fields against the
+// template contract before anything is delivered (C1). It takes the Space
+// because PR-C made template resolution Space-aware: when the activation
+// pointer resolves to a dynamic version, the producer's grant is read for this
+// Space, and preflighting against an empty Space would authorize a different
+// decision than the send that follows it.
+func preflightDocsAccessRequestSchema(parent context.Context, spaceID string, card *DocsCardFields) error {
 	catalog := cardtmpl.DefaultCatalog()
 	if catalog == nil {
 		return fmt.Errorf("%w: default catalog not wired", errCardTmplUnavailable)
@@ -123,7 +129,7 @@ func preflightDocsAccessRequestSchema(parent context.Context, card *DocsCardFiel
 	ctx, cancel := boundedNotifyCatalogContext(parent)
 	defer cancel()
 	meta, err := catalog.MetaDefault(ctx, cardtmpl.CatalogDefaultRequest{
-		Access: notifyCatalogAccess(docsNotifyProducerID, ""), ID: docsaccessrequest.TemplateID,
+		Access: notifyCatalogAccess(docsNotifyProducerID, spaceID), ID: docsaccessrequest.TemplateID,
 	})
 	if err != nil {
 		return notifyCatalogLookupError(docsaccessrequest.TemplateID, err)
@@ -284,7 +290,12 @@ func (n *Notify) buildDocsDisplayCardViaRegistry(
 // preflightDocsDisplaySchema 与 preflightDocsAccessRequestSchema 同思路:在
 // memberCache/docsSender/gate 之前独立跑一次 InputSchema 校验(C1 不被绕过)。
 // docs.commented / docs.shared 无用户可控 URL 字段,不需要 avatar https 前置校验。
-func preflightDocsDisplaySchema(parent context.Context, card *DocsCardFields, templateID cardtmpl.ID) error {
+// spaceID is threaded for the same reason preflightDocsAccessRequestSchema
+// takes it: template resolution is Space-aware, so preflighting against an
+// empty Space would validate a different version than the send resolves.
+func preflightDocsDisplaySchema(
+	parent context.Context, spaceID string, card *DocsCardFields, templateID cardtmpl.ID,
+) error {
 	catalog := cardtmpl.DefaultCatalog()
 	if catalog == nil {
 		return fmt.Errorf("%w: default catalog not wired", errCardTmplUnavailable)
@@ -292,7 +303,7 @@ func preflightDocsDisplaySchema(parent context.Context, card *DocsCardFields, te
 	ctx, cancel := boundedNotifyCatalogContext(parent)
 	defer cancel()
 	meta, err := catalog.MetaDefault(ctx, cardtmpl.CatalogDefaultRequest{
-		Access: notifyCatalogAccess(docsNotifyProducerID, ""), ID: templateID,
+		Access: notifyCatalogAccess(docsNotifyProducerID, spaceID), ID: templateID,
 	})
 	if err != nil {
 		return notifyCatalogLookupError(templateID, err)
@@ -473,7 +484,10 @@ func (n *Notify) buildSummaryCardViaRegistry(
 // preflightSummarySchema 与 preflightDocsDisplaySchema 同思路:在 memberCache /
 // docsSender / gate 之前独立跑一次 InputSchema 校验(C1 不被绕过)。summary 卡
 // 无用户可控 URL 字段,不需要 https 前置校验。
-func preflightSummarySchema(parent context.Context, card *SummaryCardFields, templateID cardtmpl.ID) error {
+// spaceID is threaded for the same reason the docs preflights take it.
+func preflightSummarySchema(
+	parent context.Context, spaceID string, card *SummaryCardFields, templateID cardtmpl.ID,
+) error {
 	catalog := cardtmpl.DefaultCatalog()
 	if catalog == nil {
 		return fmt.Errorf("%w: default catalog not wired", errCardTmplUnavailable)
@@ -481,7 +495,7 @@ func preflightSummarySchema(parent context.Context, card *SummaryCardFields, tem
 	ctx, cancel := boundedNotifyCatalogContext(parent)
 	defer cancel()
 	meta, err := catalog.MetaDefault(ctx, cardtmpl.CatalogDefaultRequest{
-		Access: notifyCatalogAccess(summaryNotifyProducerID, ""), ID: templateID,
+		Access: notifyCatalogAccess(summaryNotifyProducerID, spaceID), ID: templateID,
 	})
 	if err != nil {
 		return notifyCatalogLookupError(templateID, err)

--- a/modules/notify/card_via_registry_display_baseline_test.go
+++ b/modules/notify/card_via_registry_display_baseline_test.go
@@ -44,7 +44,7 @@ func TestMapDocsDisplayFields_TruncatesDisplayFields(t *testing.T) {
 		Excerpt:   strings.Repeat("评", 1000), // cap 300
 		UpdatedAt: strings.Repeat("时", 300),  // cap 80
 	}
-	if err := preflightDocsDisplaySchema(context.Background(), huge, docscommented.TemplateID); err != nil {
+	if err := preflightDocsDisplaySchema(context.Background(), "space-preflight", huge, docscommented.TemplateID); err != nil {
 		t.Fatalf("preflight should PASS after truncation, got %v", err)
 	}
 	if _, _, err := n.buildDocsDisplayCardViaRegistry(context.Background(),
@@ -56,7 +56,7 @@ func TestMapDocsDisplayFields_TruncatesDisplayFields(t *testing.T) {
 	badDoc := &DocsCardFields{
 		DocID: strings.Repeat("x", 300), Title: "OK", Kind: DocsCardKindShared,
 	}
-	err := preflightDocsDisplaySchema(context.Background(), badDoc, docsshared.TemplateID)
+	err := preflightDocsDisplaySchema(context.Background(), "space-preflight", badDoc, docsshared.TemplateID)
 	if err == nil || !errorsIsFieldsInvalid(err) {
 		t.Fatalf("over-length docId must stay C1 400, got %v", err)
 	}
@@ -231,7 +231,7 @@ func TestPreflightDocsDisplaySchema_C1RejectsEmptyDocID(t *testing.T) {
 
 	// docId 空 → schema minLength=1 违规
 	card := &DocsCardFields{DocID: "", Title: "T", Kind: DocsCardKindCommented}
-	err := preflightDocsDisplaySchema(context.Background(), card, docscommented.TemplateID)
+	err := preflightDocsDisplaySchema(context.Background(), "space-preflight", card, docscommented.TemplateID)
 	if err == nil {
 		t.Fatal("expected ErrFieldsInvalid, got nil")
 	}

--- a/modules/notify/card_via_registry_summary_baseline_test.go
+++ b/modules/notify/card_via_registry_summary_baseline_test.go
@@ -47,7 +47,7 @@ func TestMapSummaryFields_TruncatesDisplayFields(t *testing.T) {
 		Members:     -5,
 		MsgCount:    -1,
 	}
-	if err := preflightSummarySchema(context.Background(), huge, summaryfailed.TemplateID); err != nil {
+	if err := preflightSummarySchema(context.Background(), "space-preflight", huge, summaryfailed.TemplateID); err != nil {
 		t.Fatalf("preflight should PASS after truncation, got %v", err)
 	}
 	if _, _, err := n.buildSummaryCardViaRegistry(context.Background(),
@@ -59,7 +59,7 @@ func TestMapSummaryFields_TruncatesDisplayFields(t *testing.T) {
 	badTask := &SummaryCardFields{
 		TaskNo: strings.Repeat("x", 300), Title: "OK", Kind: SummaryCardKindCompleted,
 	}
-	err := preflightSummarySchema(context.Background(), badTask, summarycompleted.TemplateID)
+	err := preflightSummarySchema(context.Background(), "space-preflight", badTask, summarycompleted.TemplateID)
 	if err == nil || !errorsIsFieldsInvalid(err) {
 		t.Fatalf("over-length taskNo must stay C1 400, got %v", err)
 	}
@@ -130,7 +130,7 @@ func TestMapSummaryFields_ClampsOverMaxCounts(t *testing.T) {
 			if s.kind == SummaryCardKindFailed {
 				card.Reason = "boom"
 			}
-			if err := preflightSummarySchema(context.Background(), card, s.templateID); err != nil {
+			if err := preflightSummarySchema(context.Background(), "space-preflight", card, s.templateID); err != nil {
 				t.Fatalf("preflight should PASS after count clamp, got %v", err)
 			}
 			if _, _, err := n.buildSummaryCardViaRegistry(context.Background(),
@@ -350,7 +350,7 @@ func TestPreflightSummarySchema_C1RejectsEmptyTaskNo(t *testing.T) {
 
 	// taskNo 空 → schema minLength=1 违规(completed 分支)
 	badCompleted := &SummaryCardFields{TaskNo: "", Title: "T", Kind: SummaryCardKindCompleted}
-	err := preflightSummarySchema(context.Background(), badCompleted, summarycompleted.TemplateID)
+	err := preflightSummarySchema(context.Background(), "space-preflight", badCompleted, summarycompleted.TemplateID)
 	if err == nil {
 		t.Fatal("expected ErrFieldsInvalid (completed), got nil")
 	}
@@ -360,7 +360,7 @@ func TestPreflightSummarySchema_C1RejectsEmptyTaskNo(t *testing.T) {
 
 	// 同样 taskNo 空 → schema minLength=1 违规(failed 分支)
 	badFailed := &SummaryCardFields{TaskNo: "", Title: "T", Kind: SummaryCardKindFailed, Reason: "r"}
-	err = preflightSummarySchema(context.Background(), badFailed, summaryfailed.TemplateID)
+	err = preflightSummarySchema(context.Background(), "space-preflight", badFailed, summaryfailed.TemplateID)
 	if err == nil {
 		t.Fatal("expected ErrFieldsInvalid (failed), got nil")
 	}
@@ -377,7 +377,7 @@ func TestPreflightSummarySchema_F7RegistryUnwired(t *testing.T) {
 	defer cardtmpl.SetDefaultRegistry(prev)
 
 	card := &SummaryCardFields{TaskNo: "t", Title: "T", Kind: SummaryCardKindCompleted}
-	err := preflightSummarySchema(context.Background(), card, summarycompleted.TemplateID)
+	err := preflightSummarySchema(context.Background(), "space-preflight", card, summarycompleted.TemplateID)
 	if err == nil {
 		t.Fatal("expected errCardTmplUnavailable, got nil")
 	}

--- a/modules/notify/card_via_registry_test.go
+++ b/modules/notify/card_via_registry_test.go
@@ -162,10 +162,10 @@ func TestNotifyCatalogOperationsUseBoundedContexts(t *testing.T) {
 
 	parent, cancel := context.WithCancel(context.Background())
 	cancel()
-	if err := preflightDocsAccessRequestSchema(parent, card); err != nil {
+	if err := preflightDocsAccessRequestSchema(parent, "space-preflight", card); err != nil {
 		t.Fatalf("preflight: %v", err)
 	}
-	if _, ok := templateFallbackText(card, "zh-CN"); !ok {
+	if _, ok := templateFallbackText(card, "zh-CN", ""); !ok {
 		t.Fatal("template fallback was unavailable")
 	}
 	n := newTestNotify(ctx, nil, nil, nil, "tk")
@@ -196,7 +196,7 @@ func TestPreflightDocsAccessRequestPreservesRuntimeCatalogFailures(t *testing.T)
 			cardtmpl.SetDefaultCatalog(&notifyFailureCatalog{Catalog: static, metaErr: cause})
 			t.Cleanup(func() { cardtmpl.SetDefaultCatalog(nil) })
 
-			err := preflightDocsAccessRequestSchema(context.Background(), validAccessRequestDocsCard())
+			err := preflightDocsAccessRequestSchema(context.Background(), "space-preflight", validAccessRequestDocsCard())
 			if !errors.Is(err, cause) {
 				t.Fatalf("preflight error = %v, want cause %v", err, cause)
 			}

--- a/modules/notify/docs_result_version.go
+++ b/modules/notify/docs_result_version.go
@@ -1,0 +1,88 @@
+package notify
+
+// PR-C review follow-up — one place decides which version a docs
+// access-request result edit renders at.
+//
+// There are two callers: the click-driven finalizer, which learns the version
+// from the durable event's stored card context, and the sibling mutate
+// endpoint, which learns it from the stored frame it is about to replace. They
+// used to disagree — the finalizer followed the stored version while the mutate
+// endpoint hardcoded V3 — which is fine only for as long as the registry
+// default happens to be V3. The moment it moves (as it already moved off
+// 0.2.0), one path renders the stored version, the other renders a constant,
+// and `CardUpdater.ReplaceView`'s stored-identity guard rejects whichever one
+// guessed wrong. A card half-finalized by whichever path the user happened to
+// trigger is not a failure mode worth keeping.
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardmsg"
+	docsaccessrequest "github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl/docs_access_request"
+)
+
+// errDocsResultVersion marks a result edit whose target version cannot be
+// determined, or which was routed to the wrong template entirely.
+var errDocsResultVersion = errors.New("notify: docs result edit has no usable template version")
+
+// docsResultVersion resolves the exact version for a result-view edit from the
+// template identity stored on the card.
+//
+// A card is always edited at the version it was sent as: the result view has to
+// exist in *that* contract, and following the activation pointer instead would
+// rewrite an existing card across versions. The three cases:
+//
+//   - No stored identity at all. The frame predates PR-C's provenance markers,
+//     so there is nothing to honour and the historical behaviour — render V3 —
+//     is preserved exactly.
+//   - A stored identity naming some other template. That is a routing mistake,
+//     not something to paper over by rendering the docs card anyway.
+//   - A stored identity naming 0.2.0. That version's manifest declares only the
+//     `pending` view, so it has no `result` to render into. Nothing sends 0.2.0
+//     today — new sends resolve through the registry default — so a *marked*
+//     0.2.0 frame is an impossible state rather than a case to upgrade. Say so
+//     here instead of failing several layers down inside ViewFor, where the
+//     error names a missing view and not the reason it is missing.
+func docsResultVersion(storedID, storedVersion string) (string, error) {
+	storedID, storedVersion = strings.TrimSpace(storedID), strings.TrimSpace(storedVersion)
+	if storedID == "" && storedVersion == "" {
+		return docsaccessrequest.TemplateVersionV3, nil
+	}
+	if storedID != string(docsaccessrequest.TemplateID) || storedVersion == "" {
+		return "", fmt.Errorf("%w: stored card context identifies %q@%q, not docs.access-request",
+			errDocsResultVersion, storedID, storedVersion)
+	}
+	if storedVersion == docsaccessrequest.TemplateVersion {
+		return "", fmt.Errorf("%w: %s@%s declares no result view; a marked frame at this version "+
+			"should not exist because new sends resolve through the registry default",
+			errDocsResultVersion, storedID, storedVersion)
+	}
+	return storedVersion, nil
+}
+
+// docsResultVersionFromFrame reads the stored identity off a persisted envelope
+// and resolves the result version from it.
+//
+// The identity comes from `card.metadata.octo.template`, which is where the
+// click path reads it too (`cardmsg.CardTemplateContext`, via
+// resolveRegistryCardContext). Keying off the top-level `template_ref` instead
+// would look equivalent but is not: that marker only exists on frames sent
+// since PR-C Slice 1, so every card already delivered carries the metadata and
+// no marker — and the two callers would answer differently for exactly the
+// population this helper was written to keep consistent.
+//
+// The marker check still runs first. It does not supply the identity; it
+// rejects a frame whose two identities disagree, which is a tampering signal
+// rather than a version question.
+func docsResultVersionFromFrame(envelope []byte) (string, error) {
+	if _, err := cardmsg.CatalogFrameMarkers(envelope); err != nil {
+		return "", fmt.Errorf("%w: %v", errDocsResultVersion, err)
+	}
+	stored, ok := cardmsg.CardTemplateContext(envelope)
+	if !ok {
+		return docsResultVersion("", "")
+	}
+	return docsResultVersion(stored.ID, stored.Version)
+}

--- a/modules/notify/docs_result_version.go
+++ b/modules/notify/docs_result_version.go
@@ -70,7 +70,12 @@ func docsResultVersion(storedID, storedVersion string) (string, error) {
 		return "", fmt.Errorf("%w: stored card context identifies %q@%q, not docs.access-request",
 			errDocsResultVersion, storedID, storedVersion)
 	}
-	if storedVersion == docsaccessrequest.TemplateVersion {
+	// TemplateVersionV2, not TemplateVersion: this branch names the specific
+	// version whose manifest has no `result` view, not whatever the registry
+	// default happens to be. Keyed off the moving pointer, a version bump turns
+	// this into a no-op and strands in-flight 0.2.0 cards pending forever —
+	// which is the exact failure this function was written to fix.
+	if storedVersion == docsaccessrequest.TemplateVersionV2 {
 		return docsaccessrequest.TemplateVersionV3, nil
 	}
 	return storedVersion, nil

--- a/modules/notify/docs_result_version.go
+++ b/modules/notify/docs_result_version.go
@@ -37,14 +37,30 @@ var errDocsResultVersion = errors.New("notify: docs result edit has no usable te
 //   - No stored identity at all. The frame predates PR-C's provenance markers,
 //     so there is nothing to honour and the historical behaviour — render V3 —
 //     is preserved exactly.
+//
 //   - A stored identity naming some other template. That is a routing mistake,
 //     not something to paper over by rendering the docs card anyway.
+//
 //   - A stored identity naming 0.2.0. That version's manifest declares only the
-//     `pending` view, so it has no `result` to render into. Nothing sends 0.2.0
-//     today — new sends resolve through the registry default — so a *marked*
-//     0.2.0 frame is an impossible state rather than a case to upgrade. Say so
-//     here instead of failing several layers down inside ViewFor, where the
-//     error names a missing view and not the reason it is missing.
+//     `pending` view, so there is no `result` to render into and the card is
+//     upgraded to the V3 result view — which is what main.go's registration
+//     comment promises ("旧 0.2.0 pending 消息仍可由 finalizer 升级成
+//     0.3.0/result") and what the pre-PR-C finalizer did by hardcoding V3.
+//
+//     An earlier revision refused this instead, on the reasoning that a
+//     *marked* 0.2.0 frame is an impossible state. That much is true — markers
+//     postdate 0.2.0 — but it is not what reaches here. The identity comes from
+//     `card.metadata.octo.template`, which unmarked pre-PR-C frames carry too,
+//     so the refusal landed on exactly the legacy population it argued was out
+//     of reach: 0.2.0 was the shipped registry default between #633 and #641,
+//     so those cards were delivered to production, and a reviewer clicking one
+//     got a failed finalization instead of the documented upgrade, leaving the
+//     card pending forever.
+//
+//     The upgrade needs no extra machinery. An unmarked frame has
+//     markers.HasRef false, so ReplaceView's stored-identity pin does not fire
+//     and rendering V3 over a stored 0.2.0 frame works exactly as it did before
+//     this package existed.
 func docsResultVersion(storedID, storedVersion string) (string, error) {
 	storedID, storedVersion = strings.TrimSpace(storedID), strings.TrimSpace(storedVersion)
 	if storedID == "" && storedVersion == "" {
@@ -55,9 +71,7 @@ func docsResultVersion(storedID, storedVersion string) (string, error) {
 			errDocsResultVersion, storedID, storedVersion)
 	}
 	if storedVersion == docsaccessrequest.TemplateVersion {
-		return "", fmt.Errorf("%w: %s@%s declares no result view; a marked frame at this version "+
-			"should not exist because new sends resolve through the registry default",
-			errDocsResultVersion, storedID, storedVersion)
+		return docsaccessrequest.TemplateVersionV3, nil
 	}
 	return storedVersion, nil
 }

--- a/modules/notify/docs_result_version_test.go
+++ b/modules/notify/docs_result_version_test.go
@@ -44,8 +44,14 @@ func TestDocsResultVersionRules(t *testing.T) {
 			// was the shipped registry default between #633 and #641, so those
 			// cards exist, and a click on one failed finalization and left it
 			// pending forever.
+			//
+			// The version is a literal here on purpose. Both this case and the
+			// branch it drives used to reach for docsaccessrequest.TemplateVersion,
+			// the *moving* default pointer — so a version bump would have moved
+			// them together, the branch would have quietly stopped matching real
+			// 0.2.0 frames, and this test would have kept passing while doing so.
 			name: "0.2.0 is upgraded to the V3 result view",
-			id:   string(docsaccessrequest.TemplateID), version: docsaccessrequest.TemplateVersion,
+			id:   string(docsaccessrequest.TemplateID), version: "0.2.0",
 			want: docsaccessrequest.TemplateVersionV3,
 		},
 		{

--- a/modules/notify/docs_result_version_test.go
+++ b/modules/notify/docs_result_version_test.go
@@ -1,0 +1,111 @@
+package notify
+
+// PR-C review follow-up evidence: the click path and the mutate path resolve
+// the result-edit version through one rule, and that rule refuses the two cases
+// that used to fail deep inside the renderer.
+
+import (
+	"errors"
+	"testing"
+
+	docsaccessrequest "github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl/docs_access_request"
+)
+
+func TestDocsResultVersionRules(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		id      string
+		version string
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "an unmarked legacy frame keeps rendering V3",
+			want: docsaccessrequest.TemplateVersionV3,
+		},
+		{
+			name: "a marked frame renders at its own stored version",
+			id:   string(docsaccessrequest.TemplateID), version: docsaccessrequest.TemplateVersionV3,
+			want: docsaccessrequest.TemplateVersionV3,
+		},
+		{
+			// A dynamic pilot version is not in the static registry, and that is
+			// fine: the stored version is authoritative and the catalog fails
+			// loudly on its own if it cannot render.
+			name: "a dynamic version is honoured verbatim",
+			id:   string(docsaccessrequest.TemplateID), version: "0.4.0-pilot.20260805",
+			want: "0.4.0-pilot.20260805",
+		},
+		{
+			name: "0.2.0 has no result view and is refused with the reason",
+			id:   string(docsaccessrequest.TemplateID), version: docsaccessrequest.TemplateVersion,
+			wantErr: true,
+		},
+		{
+			name: "another template is a routing mistake",
+			id:   "ai.reasoning-process", version: "0.3.0",
+			wantErr: true,
+		},
+		{
+			name:    "a marked frame with no version cannot be resolved",
+			id:      string(docsaccessrequest.TemplateID),
+			wantErr: true,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := docsResultVersion(test.id, test.version)
+			if test.wantErr {
+				if !errors.Is(err, errDocsResultVersion) {
+					t.Fatalf("error = %v, want errDocsResultVersion", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("docsResultVersion: %v", err)
+			}
+			if got != test.want {
+				t.Fatalf("version = %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
+// The two callers must not be able to drift apart again: both go through
+// docsResultVersion, so the same stored identity yields the same answer.
+func TestDocsResultVersionFromFrameMatchesTheStoredContext(t *testing.T) {
+	unmarked := []byte(`{"type":17,"card":{"type":"AdaptiveCard"}}`)
+	got, err := docsResultVersionFromFrame(unmarked)
+	if err != nil || got != docsaccessrequest.TemplateVersionV3 {
+		t.Fatalf("unmarked frame = %q err=%v, want the legacy V3 branch", got, err)
+	}
+
+	// The population that matters: a card delivered before PR-C Slice 1 has
+	// metadata.octo.template but no top-level template_ref. Reading only the
+	// marker would send this frame down the legacy V3 branch while the click
+	// path resolved 0.2.0 — the exact disagreement this helper exists to remove.
+	metadataOnly := []byte(`{"type":17,"card":{"metadata":{"octo":{"protocol":"octo-card@1.0",` +
+		`"template":{"id":"docs.access-request","version":"0.2.0"}}}}}`)
+	if _, err := docsResultVersionFromFrame(metadataOnly); !errors.Is(err, errDocsResultVersion) {
+		t.Fatalf("metadata-only 0.2.0 frame = %v, want the same refusal the click path gives", err)
+	}
+	metadataOnlyV3 := []byte(`{"type":17,"card":{"metadata":{"octo":{"protocol":"octo-card@1.0",` +
+		`"template":{"id":"docs.access-request","version":"0.3.0"}}}}}`)
+	if got, err := docsResultVersionFromFrame(metadataOnlyV3); err != nil || got != "0.3.0" {
+		t.Fatalf("metadata-only 0.3.0 frame = %q err=%v, want 0.3.0", got, err)
+	}
+
+	marked := []byte(`{"type":17,"template_ref":{"id":"docs.access-request","version":"0.3.0"},` +
+		`"card":{"metadata":{"octo":{"protocol":"octo-card@1.0",` +
+		`"template":{"id":"docs.access-request","version":"0.3.0"}}}}}`)
+	got, err = docsResultVersionFromFrame(marked)
+	if err != nil {
+		t.Fatalf("marked frame: %v", err)
+	}
+	want, err := docsResultVersion("docs.access-request", "0.3.0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != want {
+		t.Fatalf("frame path = %q, stored-context path = %q", got, want)
+	}
+}

--- a/modules/notify/docs_result_version_test.go
+++ b/modules/notify/docs_result_version_test.go
@@ -37,9 +37,16 @@ func TestDocsResultVersionRules(t *testing.T) {
 			want: "0.4.0-pilot.20260805",
 		},
 		{
-			name: "0.2.0 has no result view and is refused with the reason",
+			// 0.2.0 declares only the `pending` view, so it is upgraded to the
+			// V3 result view — the contract main.go's registration comment
+			// states, and what the pre-PR-C finalizer did by hardcoding V3.
+			// Refusing it instead stranded every in-flight 0.2.0 card: 0.2.0
+			// was the shipped registry default between #633 and #641, so those
+			// cards exist, and a click on one failed finalization and left it
+			// pending forever.
+			name: "0.2.0 is upgraded to the V3 result view",
 			id:   string(docsaccessrequest.TemplateID), version: docsaccessrequest.TemplateVersion,
-			wantErr: true,
+			want: docsaccessrequest.TemplateVersionV3,
 		},
 		{
 			name: "another template is a routing mistake",
@@ -79,14 +86,17 @@ func TestDocsResultVersionFromFrameMatchesTheStoredContext(t *testing.T) {
 		t.Fatalf("unmarked frame = %q err=%v, want the legacy V3 branch", got, err)
 	}
 
-	// The population that matters: a card delivered before PR-C Slice 1 has
-	// metadata.octo.template but no top-level template_ref. Reading only the
-	// marker would send this frame down the legacy V3 branch while the click
-	// path resolved 0.2.0 — the exact disagreement this helper exists to remove.
+	// The population that matters, and the one an earlier revision broke: a card
+	// delivered before PR-C Slice 1 has metadata.octo.template but no top-level
+	// template_ref. The reasoning for refusing 0.2.0 here was that a *marked*
+	// 0.2.0 frame cannot exist — true, but the identity is read from the
+	// metadata, which this frame has and every legacy card has, so the refusal
+	// landed on precisely the population it argued was unreachable.
 	metadataOnly := []byte(`{"type":17,"card":{"metadata":{"octo":{"protocol":"octo-card@1.0",` +
 		`"template":{"id":"docs.access-request","version":"0.2.0"}}}}}`)
-	if _, err := docsResultVersionFromFrame(metadataOnly); !errors.Is(err, errDocsResultVersion) {
-		t.Fatalf("metadata-only 0.2.0 frame = %v, want the same refusal the click path gives", err)
+	if got, err := docsResultVersionFromFrame(metadataOnly); err != nil ||
+		got != docsaccessrequest.TemplateVersionV3 {
+		t.Fatalf("metadata-only 0.2.0 frame = %q err=%v, want the documented upgrade to V3", got, err)
 	}
 	metadataOnlyV3 := []byte(`{"type":17,"card":{"metadata":{"octo":{"protocol":"octo-card@1.0",` +
 		`"template":{"id":"docs.access-request","version":"0.3.0"}}}}}`)

--- a/modules/robot/api.go
+++ b/modules/robot/api.go
@@ -867,6 +867,13 @@ func (rb *Robot) payloadIsVail(payloadResult maputil.Data) bool {
 			rb.Warn("卡片消息未启用,robot ingress 拒绝(部署总开关或 bot 子开关关闭)")
 			return false
 		}
+		// PR-C D3：server-only catalog 标记（template_ref / catalog_provenance）
+		// 只能由可信边界写入；robot ingress 按键存在显式拒绝（与 bot_api 的
+		// reject 口径对称，不走 __obo_* 的静默 strip —— 见 sanitize_robot_ingress.go）。
+		if robotCardPayloadForgesCatalogMarker(map[string]interface{}(payloadResult)) {
+			rb.Warn("robot 卡片试图伪造 server-only catalog 标记,拒绝")
+			return false
+		}
 		if err := cardmsg.Validate(map[string]interface{}(payloadResult)); err != nil {
 			rb.Warn("InteractiveCard payload 校验失败", zap.Error(err))
 			return false

--- a/modules/robot/sanitize_robot_ingress.go
+++ b/modules/robot/sanitize_robot_ingress.go
@@ -45,6 +45,7 @@
 package robot
 
 import (
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardmsg"
 	"github.com/Mininglamp-OSS/octo-server/pkg/obopayload"
 	"go.uber.org/zap"
 )
@@ -79,4 +80,24 @@ func sanitizeRobotIngressPayload(payload map[string]interface{}, channelID strin
 			zap.Int("stripped_count", stripped))
 	}
 	return stripped
+}
+
+// robotCardPayloadForgesCatalogMarker reports whether a robot-supplied
+// type-17 payload carries a server-only catalog marker (PR-C D3:
+// `template_ref` / `catalog_provenance`). These are authored exclusively by
+// the trusted Bot Registry and internal carddispatch boundaries; the legacy
+// robot ingress must REJECT them (loud 400-shaped false at the card gate),
+// deliberately diverging from the silent `__obo_*` strip above — the strip's
+// legacy-collision rationale does not apply to keys this PR introduces, and a
+// forged principal must never persist quietly. Presence alone rejects; shape
+// is irrelevant (a "well-formed" forgery is still a forgery).
+func robotCardPayloadForgesCatalogMarker(payload map[string]interface{}) bool {
+	if payload == nil {
+		return false
+	}
+	if _, exists := payload[cardmsg.CatalogTemplateRefKey]; exists {
+		return true
+	}
+	_, exists := payload[cardmsg.CatalogProvenanceKey]
+	return exists
 }

--- a/modules/robot/sanitize_robot_ingress_test.go
+++ b/modules/robot/sanitize_robot_ingress_test.go
@@ -263,3 +263,40 @@ func TestRobotMessage_R6FanoutKeysStripped(t *testing.T) {
 	assert.Equal(t, 1, payload["type"])
 	assert.Len(t, cl.calls, 1, "one warn log even for multiple reserved keys")
 }
+
+// ---- PR-C Slice 1 (D3): the legacy robot ingress explicitly rejects the
+// server-only catalog markers. Unlike the __obo_* strip above (a reserved
+// namespace legacy callers may collide with by accident), these keys are new
+// PR-C semantics with no legacy-caller precedent — forging them must be loud,
+// matching the bot API reject posture. ----
+
+func TestRobotCardPayloadForgesCatalogMarker(t *testing.T) {
+	cases := []struct {
+		name    string
+		payload map[string]interface{}
+		want    bool
+	}{
+		{name: "nil payload", payload: nil, want: false},
+		{name: "plain card", payload: map[string]interface{}{"type": 17, "card": map[string]interface{}{}}, want: false},
+		{name: "template_ref forge", payload: map[string]interface{}{
+			"type": 17, "card": map[string]interface{}{},
+			"template_ref": map[string]interface{}{"id": "docs.access-request", "version": "0.3.0"},
+		}, want: true},
+		{name: "catalog_provenance forge", payload: map[string]interface{}{
+			"type": 17, "card": map[string]interface{}{},
+			"catalog_provenance": map[string]interface{}{
+				"version": 1, "principal_type": "bot", "principal_id": "x", "space_id": "",
+			},
+		}, want: true},
+		{name: "null-valued marker still rejects", payload: map[string]interface{}{
+			"type": 17, "card": map[string]interface{}{}, "template_ref": nil,
+		}, want: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := robotCardPayloadForgesCatalogMarker(tc.payload); got != tc.want {
+				t.Fatalf("robotCardPayloadForgesCatalogMarker(%v) = %v, want %v", tc.payload, got, tc.want)
+			}
+		})
+	}
+}

--- a/modules/thread/db.go
+++ b/modules/thread/db.go
@@ -911,23 +911,21 @@ func (d *DB) DeleteThreadMd(groupNo, shortID, deletedBy string) (int64, error) {
 	return newVersion, tx.Commit()
 }
 
-// QueryMessageSource 根据 channelID 和 messageID 查询消息的发送者与原始 payload。
+// QueryMessageFromUID 根据 channelID 和 messageID 查询消息发送者。
 //
-// 两者都来自同一行，因为拷贝到子区的内容必须是服务端存下来的字节，而不是调用方
-// 回传的副本。此前只取 from_uid（"防止客户端伪造"），payload 仍由请求提供，于是
-// 任何群成员都能构造一条 from_uid 是真实 bot、内容自己写的持久化消息 —— 包括
-// PR-C 的 server-only 顶层标记 template_ref / catalog_provenance，而拷贝这条路径
-// 不经过 cardmsg.Validate。伪造出来的标记随后会被 action 路径当作可信身份读取。
-func (d *DB) QueryMessageSource(channelID string, messageID int64) (fromUID string, payload []byte, err error) {
+// 只取 from_uid：这是拷贝到子区时唯一需要向服务端求证的东西（防止客户端伪造发送
+// 者）。内容不从这里读 —— 单条消息读取要过 visibles 白名单、revoke/is_deleted、
+// message_user_extra 的按人删除、两个 offset 和 Expire 五道门，凭 message_id 直接
+// 取 payload 会绕过全部五道，等于让任何群成员凭 id 读回本群任意消息（包括已撤回
+// 的原文 —— 撤回脱敏发生在响应层，存储里原文还在）。拷贝内容改用调用方自己的字
+// 节并剥掉 server-only 标记，见 CreateThread。
+func (d *DB) QueryMessageFromUID(channelID string, messageID int64) (string, error) {
 	table := d.getMessageTable(channelID)
-	var row struct {
-		FromUID string `db:"from_uid"`
-		Payload []byte `db:"payload"`
-	}
-	_, err = d.session.Select("from_uid", "payload").From(table).
+	var fromUID string
+	_, err := d.session.Select("from_uid").From(table).
 		Where("message_id=? AND channel_id=?", messageID, channelID).
-		Load(&row)
-	return row.FromUID, row.Payload, err
+		Load(&fromUID)
+	return fromUID, err
 }
 
 // SettingModel 子区用户设置

--- a/modules/thread/db.go
+++ b/modules/thread/db.go
@@ -917,8 +917,10 @@ func (d *DB) DeleteThreadMd(groupNo, shortID, deletedBy string) (int64, error) {
 // 者）。内容不从这里读 —— 单条消息读取要过 visibles 白名单、revoke/is_deleted、
 // message_user_extra 的按人删除、两个 offset 和 Expire 五道门，凭 message_id 直接
 // 取 payload 会绕过全部五道，等于让任何群成员凭 id 读回本群任意消息（包括已撤回
-// 的原文 —— 撤回脱敏发生在响应层，存储里原文还在）。拷贝内容改用调用方自己的字
-// 节并剥掉 server-only 标记，见 CreateThread。
+// 的原文 —— 撤回脱敏发生在响应层，存储里原文还在）。拷贝内容用调用方自己的字节，
+// 原样持久化；卡片（type-17）则整体拒绝拷贝 —— 按 key 剥掉 server-only 标记曾是
+// 中间方案，但够不到卡体内部的 metadata.octo.template，只收窄了伪造面。见
+// CreateThread。
 func (d *DB) QueryMessageFromUID(channelID string, messageID int64) (string, error) {
 	table := d.getMessageTable(channelID)
 	var fromUID string

--- a/modules/thread/db.go
+++ b/modules/thread/db.go
@@ -911,14 +911,23 @@ func (d *DB) DeleteThreadMd(groupNo, shortID, deletedBy string) (int64, error) {
 	return newVersion, tx.Commit()
 }
 
-// QueryMessageFromUID 根据 channelID 和 messageID 查询消息发送者
-func (d *DB) QueryMessageFromUID(channelID string, messageID int64) (string, error) {
+// QueryMessageSource 根据 channelID 和 messageID 查询消息的发送者与原始 payload。
+//
+// 两者都来自同一行，因为拷贝到子区的内容必须是服务端存下来的字节，而不是调用方
+// 回传的副本。此前只取 from_uid（"防止客户端伪造"），payload 仍由请求提供，于是
+// 任何群成员都能构造一条 from_uid 是真实 bot、内容自己写的持久化消息 —— 包括
+// PR-C 的 server-only 顶层标记 template_ref / catalog_provenance，而拷贝这条路径
+// 不经过 cardmsg.Validate。伪造出来的标记随后会被 action 路径当作可信身份读取。
+func (d *DB) QueryMessageSource(channelID string, messageID int64) (fromUID string, payload []byte, err error) {
 	table := d.getMessageTable(channelID)
-	var fromUID string
-	_, err := d.session.Select("from_uid").From(table).
+	var row struct {
+		FromUID string `db:"from_uid"`
+		Payload []byte `db:"payload"`
+	}
+	_, err = d.session.Select("from_uid", "payload").From(table).
 		Where("message_id=? AND channel_id=?", messageID, channelID).
-		Load(&fromUID)
-	return fromUID, err
+		Load(&row)
+	return row.FromUID, row.Payload, err
 }
 
 // SettingModel 子区用户设置

--- a/modules/thread/service.go
+++ b/modules/thread/service.go
@@ -414,10 +414,10 @@ func (s *Service) CreateThread(req *CreateThreadReq) (*ThreadResp, error) {
 // 起点是创建者对父群的 effective space（GetMemberExternalFields 第 4 返回值）：
 //   - 外部成员                       -> 其 source_space_id
 //   - 现代（有 space）内部群的内部成员 -> 群自身 space_id
-//   - legacy（无 space）内部群的内部成员 -> ""（group.space_id==”）
+//   - legacy（无 space）内部群的内部成员 -> 空串（group.space_id 为空串）
 //
 // 只有最后一种 legacy 情况需要归一化：effective space 为空，但现代客户端读 legacy
-// 群时带的是**非空** default space（#484 口径），补行若落 space_id=” 会在 SQL 层被
+// 群时带的是**非空** default space（#484 口径），补行若落空串 space_id 会在 SQL 层被
 // 过滤掉，创建者永远看不到自己刚建的子区（issue #557 的 silent no-op）。因此**仅对
 // 这一路径**（内部成员 + 空 effective space）把 space 归一到创建者自己的 default
 // space——正是读侧（以及 auto_follow fanout 的 follower 行）所在的 space。外部成员、
@@ -425,7 +425,7 @@ func (s *Service) CreateThread(req *CreateThreadReq) (*ThreadResp, error) {
 //
 // 与 fanout 的关系：fanout（OnThreadCreated）的源数据来自群 ext 行，而群 ext 行只能
 // 由走 validateBase（拒空 space_id）的 follow 路径写入，所以 fanout 复制的必是非空
-// space，**永远不会**落 space_id=”。归一化到创建者 default space 后，创建者补行才
+// space，**永远不会**落空串 space_id。归一化到创建者 default space 后，创建者补行才
 // 与 fanout 的 follower 行落在同一非空 space。
 //
 // best-effort 降级：拿不到 default space（查询失败或用户无 default space）时，返回

--- a/modules/thread/service.go
+++ b/modules/thread/service.go
@@ -15,6 +15,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-server/modules/group"
 	"github.com/Mininglamp-OSS/octo-server/modules/space"
 	"github.com/Mininglamp-OSS/octo-server/modules/user"
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardmsg"
 	"github.com/Mininglamp-OSS/octo-server/pkg/pushcache"
 	"go.uber.org/zap"
 )
@@ -341,41 +342,46 @@ func (s *Service) CreateThread(req *CreateThreadReq) (*ThreadResp, error) {
 
 	// 拷贝源消息到子区作为首条消息（顺序：在 fanout 之后，客户端收到这条消息时
 	// thread ext 行已 commit）。
+	// copiedPayload 是实际拷进子区的字节：调用方给的 payload 剥掉两个 server-only
+	// 顶层标记之后的结果。为空表示这次没有拷贝。
 	//
-	// copiedPayload 是实际拷进子区的服务端字节；为空表示这次没有拷贝。父群通知的
-	// message_count 与 last_message 预览都由它派生，不能再用请求里的字段：自从内容
-	// 改从数据库读，「请求带了 payload」与「确实拷贝成功了」就是两个不同的判断，
-	// 源行缺失时父群会宣告一条子区里并不存在的首条消息，且之后没有事件纠正。
+	// 需要保证的属性是「template_ref / catalog_provenance 不能从外部到达」，剥离是
+	// 对它的最小实施。之前两版都没有做对：
+	//
+	//   - 直接用调用方 payload —— 任何群成员都能造出一条 from_uid 是真实 bot、自己
+	//     写标记的持久化消息，action 路径会把它当作可信 producer 身份读取。
+	//   - 改成从消息行读服务端字节 —— 封住了伪造，却让 message_id 成了免检读取凭证。
+	//     单条读要过 visibles、revoke/is_deleted、按人删除、两个 offset、Expire 五道
+	//     门，那个查询一道都不过，等于凭 id 就能把已撤回原文（脱敏只在响应层）重新
+	//     发布到全群订阅的子区频道里，还挂在原发送者名下。
+	//
+	// 剥离两者都避开：调用方只能提供他本来就持有的字节，所以不需要给这个模块引入
+	// 授权面；而拷贝出来的是一条合法的无标记帧 —— 拷贝本就是一条新消息，没有经过
+	// 授权原件的那个渲染边界，不该继承它的身份。
+	//
+	// 同时这也让拷贝内容回到调用方正在显示的那一帧。message.payload 是不可变原件，
+	// 编辑存在 message_extra.content_edit 里，从原件读会把编辑过的消息拷成旧正文，
+	// 把流式卡拷成第一个残帧。
 	var copiedPayload json.RawMessage
 	if req.SourceMessageID != nil && len(req.SourceMessagePayload) > 0 {
-		// 发送者和内容都从消息表取同一行，防止客户端伪造。
-		//
-		// 只固定 from_uid 是不够的：payload 之前直接用请求里的 source_message_payload，
-		// 所以任何群成员都能造出一条 from_uid 是真实 bot、内容自己写的持久化消息。
-		// PR-C 之后这尤其危险 —— 顶层 template_ref / catalog_provenance 是 server-only
-		// 标记，action 路径把它们当作可信的 producer 身份读取，而这条拷贝路径不经过
-		// cardmsg.Validate，也不在拒绝这两个 key 的四个 ingress 之列。
-		//
-		// 不改成「按 key 拒绝」（其余 ingress 的做法）是因为那会打断合法场景：客户端
-		// 手里的卡片本来就带标记（服务端发给它的），回传创建子区会被拒。用服务端
-		// 自己的字节则两全 —— 合法拷贝照常工作。
-		//
-		// req.SourceMessagePayload 因此只剩「要不要拷贝」这一个语义，内容一律以服务端
-		// 读到的为准；它不得再流向任何被持久化的字段。
-		sourceFromUID, sourcePayload, err := s.db.QueryMessageSource(req.GroupNo, *req.SourceMessageID)
+		stripped, err := cardmsg.StripCatalogMarkers(req.SourceMessagePayload)
 		if err != nil {
-			s.Warn("查询源消息失败，跳过拷贝",
+			s.Warn("剥离源消息 server-only 标记失败，跳过拷贝",
 				zap.Error(err),
 				zap.Int64("messageID", *req.SourceMessageID))
-		} else if len(sourcePayload) == 0 {
-			s.Warn("源消息不存在或无内容，跳过拷贝",
-				zap.Int64("messageID", *req.SourceMessageID))
 		} else {
-			if sourceFromUID == "" {
+			// 发送者仍从消息行求证，这是拷贝里唯一不能信调用方的部分。
+			sourceFromUID, queryErr := s.db.QueryMessageFromUID(req.GroupNo, *req.SourceMessageID)
+			if queryErr != nil {
+				s.Warn("查询源消息发送者失败，使用创建者作为发送者",
+					zap.Error(queryErr),
+					zap.Int64("messageID", *req.SourceMessageID))
+				sourceFromUID = req.CreatorUID
+			} else if sourceFromUID == "" {
 				sourceFromUID = req.CreatorUID
 			}
-			s.sendSourceMessage(channelID, sourceFromUID, sourcePayload)
-			copiedPayload = sourcePayload
+			s.sendSourceMessage(channelID, sourceFromUID, stripped)
+			copiedPayload = stripped
 		}
 	}
 

--- a/modules/thread/service.go
+++ b/modules/thread/service.go
@@ -342,35 +342,34 @@ func (s *Service) CreateThread(req *CreateThreadReq) (*ThreadResp, error) {
 
 	// 拷贝源消息到子区作为首条消息（顺序：在 fanout 之后，客户端收到这条消息时
 	// thread ext 行已 commit）。
-	// copiedPayload 是实际拷进子区的字节：调用方给的 payload 剥掉两个 server-only
-	// 顶层标记之后的结果。为空表示这次没有拷贝。
+	// copiedPayload 是实际拷进子区的字节；为空表示这次没有拷贝，父群通知的
+	// message_count 与 last_message 预览都由它派生。
 	//
-	// 需要保证的属性是「template_ref / catalog_provenance 不能从外部到达」，剥离是
-	// 对它的最小实施。之前两版都没有做对：
+	// 卡片（type-17）一律不拷贝。这条路径把调用方给的 JSON 以**源消息发送者的
+	// 身份**持久化，而 source_message_id 与 payload 之间从不校验对应关系，所以
+	// 任何群成员都能让一条自己写的消息挂在某个 bot 名下。对普通文本这只是内容
+	// 造假；对卡片则跨越了信任边界：
 	//
-	//   - 直接用调用方 payload —— 任何群成员都能造出一条 from_uid 是真实 bot、自己
-	//     写标记的持久化消息，action 路径会把它当作可信 producer 身份读取。
-	//   - 改成从消息行读服务端字节 —— 封住了伪造，却让 message_id 成了免检读取凭证。
-	//     单条读要过 visibles、revoke/is_deleted、按人删除、两个 offset、Expire 五道
-	//     门，那个查询一道都不过，等于凭 id 就能把已撤回原文（脱敏只在响应层）重新
-	//     发布到全群订阅的子区频道里，还挂在原发送者名下。
+	//   - action 路由信任的模板身份是 card.metadata.octo.template，它在卡体
+	//     **内部**，调用方完全控制。剥掉 template_ref / catalog_provenance 两个
+	//     顶层标记并不触及它。
+	//   - 无标记帧命中 legacy 兼容分支，而静态 ActionContext 不授权 principal
+	//     （pkg/cardtmpl/catalog.go），于是伪造帧连同自选的 Action.Submit 数据
+	//     被当作可信的 bot 卡片受理 —— 等于绕过「用户不能发卡」这条禁令。
 	//
-	// 剥离两者都避开：调用方只能提供他本来就持有的字节，所以不需要给这个模块引入
-	// 授权面；而拷贝出来的是一条合法的无标记帧 —— 拷贝本就是一条新消息，没有经过
-	// 授权原件的那个渲染边界，不该继承它的身份。
-	//
-	// 同时这也让拷贝内容回到调用方正在显示的那一帧。message.payload 是不可变原件，
-	// 编辑存在 message_extra.content_edit 里，从原件读会把编辑过的消息拷成旧正文，
-	// 把流式卡拷成第一个残帧。
+	// 所以按 key 剥离是把伪造面收窄，不是关闭。拒绝才是关闭，而且与用户 ingress
+	// 的既有策略同形（modules/message/api.go：卡片拒绝不依赖频道类型、好友关系，
+	// 也不触库）。代价是从卡片消息创建的子区没有首条消息 —— 这是有意的取舍。
 	var copiedPayload json.RawMessage
 	if req.SourceMessageID != nil && len(req.SourceMessagePayload) > 0 {
-		stripped, err := cardmsg.StripCatalogMarkers(req.SourceMessagePayload)
-		if err != nil {
-			s.Warn("剥离源消息 server-only 标记失败，跳过拷贝",
-				zap.Error(err),
+		if isCardSourcePayload(req.SourceMessagePayload) {
+			s.Warn("源消息是卡片，跳过拷贝",
+				zap.Bool("source_card_refused", true),
+				zap.String("groupNo", req.GroupNo),
+				zap.String("creatorUID", req.CreatorUID),
 				zap.Int64("messageID", *req.SourceMessageID))
 		} else {
-			// 发送者仍从消息行求证，这是拷贝里唯一不能信调用方的部分。
+			// 发送者从消息行求证，这是拷贝里唯一不能信调用方的部分。
 			sourceFromUID, queryErr := s.db.QueryMessageFromUID(req.GroupNo, *req.SourceMessageID)
 			if queryErr != nil {
 				s.Warn("查询源消息发送者失败，使用创建者作为发送者",
@@ -380,8 +379,14 @@ func (s *Service) CreateThread(req *CreateThreadReq) (*ThreadResp, error) {
 			} else if sourceFromUID == "" {
 				sourceFromUID = req.CreatorUID
 			}
-			s.sendSourceMessage(channelID, sourceFromUID, stripped)
-			copiedPayload = stripped
+			// 只有真正发出去了才算拷贝成功：父群宣告的首条消息必须确实存在。
+			if sendErr := s.sendSourceMessage(channelID, sourceFromUID, req.SourceMessagePayload); sendErr != nil {
+				s.Error("拷贝源消息到子区失败，父群不宣告首条消息",
+					zap.Error(sendErr),
+					zap.String("channelID", channelID))
+			} else {
+				copiedPayload = req.SourceMessagePayload
+			}
 		}
 	}
 
@@ -503,7 +508,10 @@ func (s *Service) sendThreadCreatedMessage(groupNo, shortID, name, creatorUID, c
 
 // sendSourceMessage 将源消息拷贝到子区频道作为首条消息
 // fromUID 应该是经过服务端验证的原始消息发送者
-func (s *Service) sendSourceMessage(channelID, fromUID string, payload json.RawMessage) {
+// sendSourceMessage returns the send error so the caller can tell whether the
+// copy actually happened. The parent-group notification advertises a first
+// message and a preview, and those must describe a message that exists.
+func (s *Service) sendSourceMessage(channelID, fromUID string, payload json.RawMessage) error {
 	err := s.ctx.SendMessage(&config.MsgSendReq{
 		Header: config.MsgHeader{
 			NoPersist: 0,
@@ -516,8 +524,9 @@ func (s *Service) sendSourceMessage(channelID, fromUID string, payload json.RawM
 		Payload:     payload,
 	})
 	if err != nil {
-		s.Error("拷贝源消息到子区失败", zap.Error(err), zap.String("channelID", channelID))
+		return fmt.Errorf("thread: copy source message: %w", err)
 	}
+	return nil
 }
 
 // UpdateName 修改子区名称
@@ -1322,4 +1331,12 @@ func sanitizeListStatuses(statuses []int) []int {
 		return []int{ThreadStatusActive}
 	}
 	return out
+}
+
+// isCardSourcePayload reports whether a caller-supplied source payload is a
+// card. It keys off the wire type rather than the marker keys: a frame whose
+// markers were removed is still a card, and still carries the in-body
+// metadata.octo.template that makes it actionable.
+func isCardSourcePayload(payload json.RawMessage) bool {
+	return cardmsg.IsCardRawPayload(payload)
 }

--- a/modules/thread/service.go
+++ b/modules/thread/service.go
@@ -397,14 +397,11 @@ func (s *Service) CreateThread(req *CreateThreadReq) (*ThreadResp, error) {
 	}
 
 	// 在父群发送子区创建消息（同样在 fanout 之后；与 sendSourceMessage 同序约束）。
-	// 拷贝被拒绝（卡片）或发送失败时不记录 source_message_id：父群通知不应声称
-	// 一个子区里并不存在的来源。子区本身照常创建 —— 用户的主要意图是建子区，
-	// 而不是拷贝那条消息。
-	announcedSourceID := req.SourceMessageID
-	if len(copiedPayload) == 0 {
-		announcedSourceID = nil
-	}
-	s.sendThreadCreatedMessage(req.GroupNo, shortID, req.Name, req.CreatorUID, req.CreatorName, announcedSourceID, copiedPayload)
+	// copiedPayload 为空（卡片被拒或发送失败）时，buildThreadCreatedPayload 会连
+	// 带丢掉 source_message_id：父群通知不应声称一个子区里并不存在的来源。这里
+	// 只管传「请求里的 id」和「实际拷了什么」，一致性由那一处判定，见该函数注释。
+	// 子区本身照常创建 —— 用户的主要意图是建子区，而不是拷贝那条消息。
+	s.sendThreadCreatedMessage(req.GroupNo, shortID, req.Name, req.CreatorUID, req.CreatorName, req.SourceMessageID, copiedPayload)
 
 	resp := s.toThreadRespWithID(thread)
 	resp.MemberCount = 1 // 创建者
@@ -460,7 +457,17 @@ func (s *Service) resolveCreatorBackfillSpaceID(groupNo, creatorUID string) (str
 	return creatorSpaceID, nil
 }
 
-// buildThreadCreatedPayload 构建子区创建通知消息的 payload
+// buildThreadCreatedPayload 构建子区创建通知消息的 payload。
+//
+// source_message_id、message_count、last_message 三者描述的是同一件事 —— 子区里
+// 到底有没有那条首条消息 —— 所以都由同一个事实派生：sourcePayload 是否非空。它是
+// **实际拷贝进子区的字节**，拷贝被拒（卡片）或发送失败时为空。
+//
+// 这个判断放在这里而不是调用方，是 PR-C review（lml2468）的直接结果。放在调用方
+// 时它只是一条约定：调用方忘了把 id 置空，父群就会宣告一条子区里并不存在的来源，
+// 而任何驱动本函数的测试都看不见这个错误 —— 当时那条测试正是传入已经为 nil 的 id
+// 去断言「没有 source_message_id」，删掉调用方的置空逻辑它照样绿。搬进来之后，
+// 「有 id 但没拷贝」这个不一致状态在本函数内被消解，调用方构造不出它。
 func buildThreadCreatedPayload(shortID, name, channelID, creatorUID, creatorName string, sourceMessageID *int64, sourcePayload json.RawMessage) map[string]interface{} {
 	participants := []map[string]string{
 		{"uid": creatorUID, "name": creatorName},
@@ -478,15 +485,15 @@ func buildThreadCreatedPayload(shortID, name, channelID, creatorUID, creatorName
 		"participants": participants,
 	}
 
-	if sourceMessageID != nil {
+	// 有拷贝才有来源。sourcePayload 来自请求，但只有在拷贝真正发出之后才会传到
+	// 这里：id、计数与预览必须描述子区里真实存在的东西，而不是调用方请求过什么。
+	copied := len(sourcePayload) > 0
+	if sourceMessageID != nil && copied {
 		payload["source_message_id"] = *sourceMessageID
 	}
 
-	// sourcePayload 是实际拷贝进子区的那段字节（未拷贝时为空）。它来自请求，
-	// 但只有在拷贝真正发出之后才会传到这里：计数与预览必须描述子区里真实存在
-	// 的东西，而不是调用方请求过什么。
 	var messageCount int64
-	if len(sourcePayload) > 0 {
+	if copied {
 		messageCount = 1
 		payload["last_message"] = map[string]interface{}{
 			"from_uid":  creatorUID,

--- a/modules/thread/service.go
+++ b/modules/thread/service.go
@@ -340,17 +340,32 @@ func (s *Service) CreateThread(req *CreateThreadReq) (*ThreadResp, error) {
 	// 拷贝源消息到子区作为首条消息（顺序：在 fanout 之后，客户端收到这条消息时
 	// thread ext 行已 commit）。
 	if req.SourceMessageID != nil && len(req.SourceMessagePayload) > 0 {
-		// 从消息表查询原始发送者，防止客户端伪造
-		sourceFromUID, err := s.db.QueryMessageFromUID(req.GroupNo, *req.SourceMessageID)
+		// 发送者和内容都从消息表取同一行，防止客户端伪造。
+		//
+		// 只固定 from_uid 是不够的：payload 之前直接用请求里的 source_message_payload，
+		// 所以任何群成员都能造出一条 from_uid 是真实 bot、内容自己写的持久化消息。
+		// PR-C 之后这尤其危险 —— 顶层 template_ref / catalog_provenance 是 server-only
+		// 标记，action 路径把它们当作可信的 producer 身份读取，而这条拷贝路径不经过
+		// cardmsg.Validate，也不在拒绝这两个 key 的四个 ingress 之列。
+		//
+		// 不改成"按 key 拒绝"（其余 ingress 的做法）是因为那会打断合法场景：客户端
+		// 手里的卡片本来就带标记（服务端发给它的），回传创建子区会被拒。用服务端
+		// 自己的字节则两全 —— 合法拷贝照常工作，且 source_message_payload 整个退出
+		// 信任边界，只剩"是否要拷贝"这一个语义。
+		sourceFromUID, sourcePayload, err := s.db.QueryMessageSource(req.GroupNo, *req.SourceMessageID)
 		if err != nil {
-			s.Warn("查询源消息发送者失败，使用创建者作为发送者",
+			s.Warn("查询源消息失败，跳过拷贝",
 				zap.Error(err),
 				zap.Int64("messageID", *req.SourceMessageID))
-			sourceFromUID = req.CreatorUID
-		} else if sourceFromUID == "" {
-			sourceFromUID = req.CreatorUID
+		} else if len(sourcePayload) == 0 {
+			s.Warn("源消息不存在或无内容，跳过拷贝",
+				zap.Int64("messageID", *req.SourceMessageID))
+		} else {
+			if sourceFromUID == "" {
+				sourceFromUID = req.CreatorUID
+			}
+			s.sendSourceMessage(channelID, sourceFromUID, sourcePayload)
 		}
-		s.sendSourceMessage(channelID, sourceFromUID, req.SourceMessagePayload)
 	}
 
 	// 在父群发送子区创建消息（同样在 fanout 之后；与 sendSourceMessage 同序约束）。
@@ -367,10 +382,10 @@ func (s *Service) CreateThread(req *CreateThreadReq) (*ThreadResp, error) {
 // 起点是创建者对父群的 effective space（GetMemberExternalFields 第 4 返回值）：
 //   - 外部成员                       -> 其 source_space_id
 //   - 现代（有 space）内部群的内部成员 -> 群自身 space_id
-//   - legacy（无 space）内部群的内部成员 -> ""（group.space_id==''）
+//   - legacy（无 space）内部群的内部成员 -> ""（group.space_id==”）
 //
 // 只有最后一种 legacy 情况需要归一化：effective space 为空，但现代客户端读 legacy
-// 群时带的是**非空** default space（#484 口径），补行若落 space_id='' 会在 SQL 层被
+// 群时带的是**非空** default space（#484 口径），补行若落 space_id=” 会在 SQL 层被
 // 过滤掉，创建者永远看不到自己刚建的子区（issue #557 的 silent no-op）。因此**仅对
 // 这一路径**（内部成员 + 空 effective space）把 space 归一到创建者自己的 default
 // space——正是读侧（以及 auto_follow fanout 的 follower 行）所在的 space。外部成员、
@@ -378,7 +393,7 @@ func (s *Service) CreateThread(req *CreateThreadReq) (*ThreadResp, error) {
 //
 // 与 fanout 的关系：fanout（OnThreadCreated）的源数据来自群 ext 行，而群 ext 行只能
 // 由走 validateBase（拒空 space_id）的 follow 路径写入，所以 fanout 复制的必是非空
-// space，**永远不会**落 space_id=''。归一化到创建者 default space 后，创建者补行才
+// space，**永远不会**落 space_id=”。归一化到创建者 default space 后，创建者补行才
 // 与 fanout 的 follower 行落在同一非空 space。
 //
 // best-effort 降级：拿不到 default space（查询失败或用户无 default space）时，返回

--- a/modules/thread/service.go
+++ b/modules/thread/service.go
@@ -112,8 +112,14 @@ type CreateThreadReq struct {
 	CreatorUID      string
 	CreatorName     string
 	SourceMessageID *int64
-	// SourceMessagePayload 只表达「要不要拷贝源消息」。内容一律以服务端从消息行
-	// 读到的字节为准（见 CreateThread），这个字段不得流向任何被持久化的字段。
+	// SourceMessagePayload 是调用方提供的源消息内容，**会被原样持久化**到子区，
+	// 并以 SourceMessageID 那一行的 from_uid 发出。服务端只核对发送者，从不校验
+	// 这段内容与 SourceMessageID 是否对应 —— 也就是说，任何有权在该群建子区的人
+	// 都能让一条自己写的消息挂在别人（含 bot）名下。
+	//
+	// 因此新增任何消费方之前先想清楚：这是**不可信输入**，只是恰好被记在可信的
+	// 发送者名下。卡片（type-17）已在 CreateThread 里整体拒绝，因为对卡片而言这
+	// 条性质会跨越 action 路由的信任边界；文本的内容造假是既有行为，本 PR 不改。
 	SourceMessagePayload json.RawMessage
 }
 
@@ -391,7 +397,14 @@ func (s *Service) CreateThread(req *CreateThreadReq) (*ThreadResp, error) {
 	}
 
 	// 在父群发送子区创建消息（同样在 fanout 之后；与 sendSourceMessage 同序约束）。
-	s.sendThreadCreatedMessage(req.GroupNo, shortID, req.Name, req.CreatorUID, req.CreatorName, req.SourceMessageID, copiedPayload)
+	// 拷贝被拒绝（卡片）或发送失败时不记录 source_message_id：父群通知不应声称
+	// 一个子区里并不存在的来源。子区本身照常创建 —— 用户的主要意图是建子区，
+	// 而不是拷贝那条消息。
+	announcedSourceID := req.SourceMessageID
+	if len(copiedPayload) == 0 {
+		announcedSourceID = nil
+	}
+	s.sendThreadCreatedMessage(req.GroupNo, shortID, req.Name, req.CreatorUID, req.CreatorName, announcedSourceID, copiedPayload)
 
 	resp := s.toThreadRespWithID(thread)
 	resp.MemberCount = 1 // 创建者
@@ -469,8 +482,9 @@ func buildThreadCreatedPayload(shortID, name, channelID, creatorUID, creatorName
 		payload["source_message_id"] = *sourceMessageID
 	}
 
-	// sourcePayload 是实际拷贝进子区的服务端字节（未拷贝时为空），不是请求字段：
-	// 计数与预览必须描述子区里真实存在的东西。
+	// sourcePayload 是实际拷贝进子区的那段字节（未拷贝时为空）。它来自请求，
+	// 但只有在拷贝真正发出之后才会传到这里：计数与预览必须描述子区里真实存在
+	// 的东西，而不是调用方请求过什么。
 	var messageCount int64
 	if len(sourcePayload) > 0 {
 		messageCount = 1

--- a/modules/thread/service.go
+++ b/modules/thread/service.go
@@ -106,12 +106,14 @@ func NewService(ctx *config.Context) IService {
 
 // CreateThreadReq 创建子区请求
 type CreateThreadReq struct {
-	GroupNo              string
-	Name                 string
-	CreatorUID           string
-	CreatorName          string
-	SourceMessageID      *int64
-	SourceMessagePayload json.RawMessage // 源消息原始 payload，用于拷贝到子区
+	GroupNo         string
+	Name            string
+	CreatorUID      string
+	CreatorName     string
+	SourceMessageID *int64
+	// SourceMessagePayload 只表达「要不要拷贝源消息」。内容一律以服务端从消息行
+	// 读到的字节为准（见 CreateThread），这个字段不得流向任何被持久化的字段。
+	SourceMessagePayload json.RawMessage
 }
 
 // ThreadResp 子区响应
@@ -339,6 +341,12 @@ func (s *Service) CreateThread(req *CreateThreadReq) (*ThreadResp, error) {
 
 	// 拷贝源消息到子区作为首条消息（顺序：在 fanout 之后，客户端收到这条消息时
 	// thread ext 行已 commit）。
+	//
+	// copiedPayload 是实际拷进子区的服务端字节；为空表示这次没有拷贝。父群通知的
+	// message_count 与 last_message 预览都由它派生，不能再用请求里的字段：自从内容
+	// 改从数据库读，「请求带了 payload」与「确实拷贝成功了」就是两个不同的判断，
+	// 源行缺失时父群会宣告一条子区里并不存在的首条消息，且之后没有事件纠正。
+	var copiedPayload json.RawMessage
 	if req.SourceMessageID != nil && len(req.SourceMessagePayload) > 0 {
 		// 发送者和内容都从消息表取同一行，防止客户端伪造。
 		//
@@ -348,10 +356,12 @@ func (s *Service) CreateThread(req *CreateThreadReq) (*ThreadResp, error) {
 		// 标记，action 路径把它们当作可信的 producer 身份读取，而这条拷贝路径不经过
 		// cardmsg.Validate，也不在拒绝这两个 key 的四个 ingress 之列。
 		//
-		// 不改成"按 key 拒绝"（其余 ingress 的做法）是因为那会打断合法场景：客户端
+		// 不改成「按 key 拒绝」（其余 ingress 的做法）是因为那会打断合法场景：客户端
 		// 手里的卡片本来就带标记（服务端发给它的），回传创建子区会被拒。用服务端
-		// 自己的字节则两全 —— 合法拷贝照常工作，且 source_message_payload 整个退出
-		// 信任边界，只剩"是否要拷贝"这一个语义。
+		// 自己的字节则两全 —— 合法拷贝照常工作。
+		//
+		// req.SourceMessagePayload 因此只剩「要不要拷贝」这一个语义，内容一律以服务端
+		// 读到的为准；它不得再流向任何被持久化的字段。
 		sourceFromUID, sourcePayload, err := s.db.QueryMessageSource(req.GroupNo, *req.SourceMessageID)
 		if err != nil {
 			s.Warn("查询源消息失败，跳过拷贝",
@@ -365,11 +375,12 @@ func (s *Service) CreateThread(req *CreateThreadReq) (*ThreadResp, error) {
 				sourceFromUID = req.CreatorUID
 			}
 			s.sendSourceMessage(channelID, sourceFromUID, sourcePayload)
+			copiedPayload = sourcePayload
 		}
 	}
 
 	// 在父群发送子区创建消息（同样在 fanout 之后；与 sendSourceMessage 同序约束）。
-	s.sendThreadCreatedMessage(req.GroupNo, shortID, req.Name, req.CreatorUID, req.CreatorName, req.SourceMessageID, req.SourceMessagePayload)
+	s.sendThreadCreatedMessage(req.GroupNo, shortID, req.Name, req.CreatorUID, req.CreatorName, req.SourceMessageID, copiedPayload)
 
 	resp := s.toThreadRespWithID(thread)
 	resp.MemberCount = 1 // 创建者
@@ -447,6 +458,8 @@ func buildThreadCreatedPayload(shortID, name, channelID, creatorUID, creatorName
 		payload["source_message_id"] = *sourceMessageID
 	}
 
+	// sourcePayload 是实际拷贝进子区的服务端字节（未拷贝时为空），不是请求字段：
+	// 计数与预览必须描述子区里真实存在的东西。
 	var messageCount int64
 	if len(sourcePayload) > 0 {
 		messageCount = 1

--- a/modules/thread/source_message_trust_test.go
+++ b/modules/thread/source_message_trust_test.go
@@ -141,12 +141,26 @@ func TestCardDetectionCoversMarkerlessFrames(t *testing.T) {
 // the thread does not have. source_message_id, message_count and the preview
 // all describe the same thing, so they are derived from the same fact: whether
 // bytes were actually copied.
+//
+// The input that matters is the *inconsistent* one — a request that named a
+// source paired with nothing copied — because that is the state CreateThread
+// hands over for a refused card or a failed send. An earlier revision of this
+// test passed an already-nil id, which asserted only that nil stays nil: the
+// decision it meant to guard lived at the call site and deleting it kept the
+// test green (lml2468, review round 13). The decision now lives in the builder,
+// so driving the builder drives the decision.
 func TestThreadCreatedNotificationOmitsTheSourceWhenNothingWasCopied(t *testing.T) {
 	sourceID := int64(9001)
-	payload := buildThreadCreatedPayload("t-1", "设计评审", "g-1@t-1", "u-1", "创建者", nil, nil)
-	if _, present := payload["source_message_id"]; present {
-		t.Fatalf("a source was announced with no copy: %+v", payload["source_message_id"])
+
+	refused := buildThreadCreatedPayload("t-1", "设计评审", "g-1@t-1", "u-1", "创建者", &sourceID, nil)
+	if got, present := refused["source_message_id"]; present {
+		t.Fatalf("the parent group announced source_message_id=%v for a message the thread "+
+			"does not contain; a client following that id finds an empty thread", got)
 	}
+	if got := refused["message_count"]; got != int64(0) {
+		t.Fatalf("message_count = %v, want 0 when the copy was refused", got)
+	}
+
 	withCopy := buildThreadCreatedPayload("t-1", "设计评审", "g-1@t-1", "u-1", "创建者",
 		&sourceID, []byte(`{"type":1,"content":"文本"}`))
 	if withCopy["source_message_id"] != sourceID {

--- a/modules/thread/source_message_trust_test.go
+++ b/modules/thread/source_message_trust_test.go
@@ -6,147 +6,65 @@ import (
 	"regexp"
 	"strings"
 	"testing"
-
-	"github.com/Mininglamp-OSS/octo-server/pkg/cardmsg"
 )
 
-// PR-C review rounds 9–11 (yujiawei): the thread source-message copy writes a
-// persisted message from bytes that arrived from outside, so it is a boundary
-// for the server-only catalog markers, and it took three attempts to place the
-// enforcement correctly. The two rejected shapes are recorded here because each
-// was defensible in isolation and wrong in consequence.
+// PR-C review rounds 9–12 (yujiawei, Jerry-Xin): the thread source-message copy
+// persists caller-supplied JSON under the *source message's* sender, and the id
+// and the payload are never checked against each other. Three enforcement
+// shapes were tried before this one, and the first two were each correct about
+// the property they targeted while the next consequence went un-enumerated.
 //
-//   - Copy the caller's payload verbatim (original). Any active group member
-//     could persist a message whose from_uid is a real bot's and whose
-//     top-level template_ref / catalog_provenance they wrote, which the action
-//     path then reads as trusted producer identity.
-//   - Substitute the server's stored bytes (round 10). That closed forgery and
-//     opened something worse: message_id became an unchecked read credential.
-//     A single-message read applies five gates — visibles, revoke/is_deleted,
-//     per-user deletion, both history offsets, Expire — and a bare
-//     SELECT payload applies none, so a member could have the server
-//     re-publish a revoked message's unredacted body (redaction happens in the
-//     response layer, not in storage) under its original sender, into a channel
-//     the whole group is subscribed to.
-//   - Strip the two keys from the caller's payload (now). The property needed
-//     is "these keys cannot arrive from outside", and stripping is the minimal
-//     enforcement of exactly that: the caller can only supply bytes they
-//     already hold, so no authorization surface is required, and the result is
-//     a legal unmarked frame — which is what a copy should be, since it never
-//     passed the rendering boundary that authored the original.
-func TestSourceMessageCopyStripsServerOnlyMarkers(t *testing.T) {
-	marked := []byte(`{"type":17,"card_version":"1.5","profile":"octo/v2",` +
-		`"template_ref":{"id":"docs.access-request","version":"0.3.0"},` +
-		`"catalog_provenance":{"version":1,"principal_type":"internal_producer",` +
-		`"principal_id":"docs-notify","space_id":"space-1"},` +
-		`"card":{"type":"AdaptiveCard","body":[]}}`)
-
-	stripped, err := cardmsg.StripCatalogMarkers(marked)
-	if err != nil {
-		t.Fatalf("StripCatalogMarkers: %v", err)
-	}
-	var decoded map[string]interface{}
-	if err := json.Unmarshal(stripped, &decoded); err != nil {
-		t.Fatalf("stripped payload is not valid JSON: %v", err)
-	}
-	if _, present := decoded[cardmsg.CatalogTemplateRefKey]; present {
-		t.Fatal("template_ref survived the strip")
-	}
-	if _, present := decoded[cardmsg.CatalogProvenanceKey]; present {
-		t.Fatal("catalog_provenance survived the strip")
-	}
-	// Everything else is the caller's own content and must be preserved — the
-	// legitimate case is a client echoing back a card it was really sent.
-	if decoded["type"] != float64(17) || decoded["profile"] != "octo/v2" {
-		t.Fatalf("the strip damaged the caller's frame: %+v", decoded)
-	}
-	if _, present := decoded["card"]; !present {
-		t.Fatal("the strip dropped the card body")
-	}
-
-	t.Run("an unmarked payload is returned byte-identical", func(t *testing.T) {
-		plain := []byte(`{"type":1,"content":"你好"}`)
-		out, err := cardmsg.StripCatalogMarkers(plain)
-		if err != nil {
-			t.Fatalf("StripCatalogMarkers: %v", err)
-		}
-		if string(out) != string(plain) {
-			t.Fatalf("an unmarked payload was rewritten: %s", out)
-		}
-	})
-
-	t.Run("a non-object payload is passed through", func(t *testing.T) {
-		for _, raw := range []string{`"just a string"`, `[1,2,3]`, `not json at all`} {
-			out, err := cardmsg.StripCatalogMarkers([]byte(raw))
-			if err != nil {
-				t.Fatalf("StripCatalogMarkers(%s): %v", raw, err)
-			}
-			if string(out) != raw {
-				t.Fatalf("payload %s was rewritten to %s", raw, out)
-			}
-		}
-	})
-}
-
-// The guard is over the boundary, not over one call site. Its first version
-// regexed sendSourceMessage only and was green while the same field still
-// reached sendThreadCreatedMessage and the persisted parent-group preview.
+//   - Copy the caller's bytes verbatim (original). Any group member could
+//     persist a message whose from_uid is a real bot's and whose top-level
+//     template_ref / catalog_provenance they wrote.
+//   - Substitute the server's stored bytes (round 10). Closed forgery, opened
+//     an unchecked read: a single-message read applies five gates — visibles,
+//     revoke/is_deleted, per-user deletion, both history offsets, Expire — and
+//     a bare SELECT payload by id applies none, so a member could have the
+//     server re-publish a revoked message's unredacted body under its original
+//     sender into a channel the whole group is subscribed to.
+//   - Strip the two top-level keys (round 11). Narrowed forgery without closing
+//     it. The identity the action route actually falls back to is
+//     card.metadata.octo.template, which lives *inside* the card body the
+//     caller controls. A markerless frame naming a frozen-known template takes
+//     the legacy-compatible branch, and static ActionContext does not authorize
+//     the principal — so a forged card plus chosen Action.Submit data is
+//     accepted as a trusted bot card, bypassing the "users cannot send cards"
+//     ban entirely.
 //
-// What must hold now: the copy path never passes req.SourceMessagePayload on
-// without stripping it, and it does not read message content out of the message
-// table by id.
-func TestSourceMessageCopyEnforcesTheBoundaryInSource(t *testing.T) {
+// Refusing type-17 outright is what closes it. It matches the user ingress in
+// modules/message/api.go, where card rejection is absolute — independent of
+// channel type and friendship, and taken before any DB work. The cost is that a
+// thread created from a card message has no first message; that is deliberate.
+func TestSourceMessageCopyRefusesCards(t *testing.T) {
 	raw, err := os.ReadFile("service.go")
 	if err != nil {
 		t.Fatalf("read service.go: %v", err)
 	}
 	code := stripGoComments(string(raw))
 
-	if !strings.Contains(code, "cardmsg.StripCatalogMarkers(req.SourceMessagePayload)") {
-		t.Fatal("the caller's payload is no longer stripped before it is copied")
+	if !strings.Contains(code, "isCardSourcePayload(req.SourceMessagePayload)") {
+		t.Fatal("the copy path no longer refuses card payloads; stripping keys is not sufficient, " +
+			"because the identity the action route trusts lives inside the card body")
 	}
 
 	// Reading stored content by message id would reintroduce the round-10
-	// bypass: that read applies none of the five gates a single-message read
-	// applies, so it hands back revoked, deleted, visibles-excluded and
-	// pre-offset content on the strength of an id alone.
-	//
-	// The query lives in db.go, so this half of the guard has to read that file
-	// — the first version checked service.go only and was blind to the very
-	// mutation it names.
+	// bypass, which applies none of the five gates a single-message read does.
 	dbRaw, err := os.ReadFile("db.go")
 	if err != nil {
 		t.Fatalf("read db.go: %v", err)
 	}
-	dbCode := stripGoComments(string(dbRaw))
 	payloadRead := regexp.MustCompile(`Select\([^)]*"payload"`)
-	for _, line := range strings.Split(dbCode, "\n") {
+	for _, line := range strings.Split(stripGoComments(string(dbRaw)), "\n") {
 		if payloadRead.MatchString(line) {
 			t.Fatalf("the copy path reads message content out of the message table by id:\n  %s\n"+
-				"That bypasses visibles / revoke / per-user deletion / both history offsets / Expire, "+
-				"so a member can have the server re-publish content they may not read.",
+				"That bypasses visibles / revoke / per-user deletion / both history offsets / Expire.",
 				strings.TrimSpace(line))
 		}
 	}
-
-	declaration := regexp.MustCompile(`SourceMessagePayload\s+json\.RawMessage`)
-	stripCall := regexp.MustCompile(`StripCatalogMarkers\(req\.SourceMessagePayload\)`)
-	decision := regexp.MustCompile(`len\(req\.SourceMessagePayload\)`)
-	for _, line := range strings.Split(code, "\n") {
-		if !strings.Contains(line, "SourceMessagePayload") {
-			continue
-		}
-		trimmed := strings.TrimSpace(line)
-		if declaration.MatchString(trimmed) || stripCall.MatchString(trimmed) || decision.MatchString(trimmed) {
-			continue
-		}
-		t.Fatalf("the caller's payload is used unstripped:\n  %s\n"+
-			"Every use must be the declaration, the len() test that decides whether to copy, "+
-			"or the strip itself.", trimmed)
-	}
 }
 
-// stripGoComments removes // and /* */ comments so the guard reads code rather
+// stripGoComments removes // and /* */ comments so the guards read code rather
 // than the prose describing it — the comments here necessarily name the field.
 func stripGoComments(source string) string {
 	source = regexp.MustCompile(`(?s)/\*.*?\*/`).ReplaceAllString(source, "")
@@ -160,12 +78,9 @@ func stripGoComments(source string) string {
 }
 
 // The parent-group notification must describe the thread that actually exists.
-//
-// message_count and the last_message preview are derived from the bytes
-// actually copied, not from the request field. Those were the same value before
-// round 10 and diverged when the content moved server-side; they are the same
-// value again now, and deriving from the copy keeps them correct if the copy is
-// ever skipped for another reason.
+// message_count and the last_message preview are derived from the bytes that
+// were actually copied — empty when the payload was a refused card, when the
+// send failed, or when no source was given.
 func TestThreadCreatedNotificationDescribesTheCopyThatHappened(t *testing.T) {
 	const shortID, name, channelID = "t-1", "设计评审", "g-1@t-1"
 	sourceID := int64(9001)
@@ -194,4 +109,30 @@ func TestThreadCreatedNotificationDescribesTheCopyThatHappened(t *testing.T) {
 			t.Fatalf("preview content = %v, want the copied bytes' content", last["content"])
 		}
 	})
+}
+
+// The refusal has to key off the wire type, not off the marker keys — a frame
+// with the markers already removed is still a card, and still carries the
+// in-body template identity that makes it actionable.
+func TestCardDetectionCoversMarkerlessFrames(t *testing.T) {
+	markerless := []byte(`{"type":17,"card_version":"1.5","profile":"octo/v2",` +
+		`"card":{"type":"AdaptiveCard","metadata":{"octo":{"protocol":"octo-card@1.0",` +
+		`"template":{"id":"docs.access-request","version":"0.3.0"}}}}}`)
+	var probe map[string]interface{}
+	if err := json.Unmarshal(markerless, &probe); err != nil {
+		t.Fatal(err)
+	}
+	if _, hasRef := probe["template_ref"]; hasRef {
+		t.Fatal("fixture is not markerless")
+	}
+	if _, hasProvenance := probe["catalog_provenance"]; hasProvenance {
+		t.Fatal("fixture is not markerless")
+	}
+	if !isCardSourcePayload(markerless) {
+		t.Fatal("a markerless type-17 frame was not recognised as a card; " +
+			"it still carries metadata.octo.template, which is the identity the action route trusts")
+	}
+	if isCardSourcePayload([]byte(`{"type":1,"content":"文本"}`)) {
+		t.Fatal("a plain text message was refused as a card")
+	}
 }

--- a/modules/thread/source_message_trust_test.go
+++ b/modules/thread/source_message_trust_test.go
@@ -1,62 +1,148 @@
 package thread
 
 import (
+	"encoding/json"
 	"os"
 	"regexp"
 	"strings"
 	"testing"
+
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardmsg"
 )
 
-// PR-C review rounds 9–10 (yujiawei): the thread source-message copy is a write
-// path to persisted messages, and it was outside the marker trust boundary.
+// PR-C review rounds 9–11 (yujiawei): the thread source-message copy writes a
+// persisted message from bytes that arrived from outside, so it is a boundary
+// for the server-only catalog markers, and it took three attempts to place the
+// enforcement correctly. The two rejected shapes are recorded here because each
+// was defensible in isolation and wrong in consequence.
 //
-// CreateThread fixes the copied message's from_uid by reading the source row
-// ("防止客户端伪造") but took the content from the request. So any active group
-// member could persist a message in a CommunityTopic channel whose from_uid is
-// a real bot's and whose content they wrote — including the server-only
-// top-level template_ref / catalog_provenance, which the action path then reads
-// as trusted producer identity. cardmsg.Validate never runs on this path, and
-// it is not one of the four ingresses that reject those keys by name.
+//   - Copy the caller's payload verbatim (original). Any active group member
+//     could persist a message whose from_uid is a real bot's and whose
+//     top-level template_ref / catalog_provenance they wrote, which the action
+//     path then reads as trusted producer identity.
+//   - Substitute the server's stored bytes (round 10). That closed forgery and
+//     opened something worse: message_id became an unchecked read credential.
+//     A single-message read applies five gates — visibles, revoke/is_deleted,
+//     per-user deletion, both history offsets, Expire — and a bare
+//     SELECT payload applies none, so a member could have the server
+//     re-publish a revoked message's unredacted body (redaction happens in the
+//     response layer, not in storage) under its original sender, into a channel
+//     the whole group is subscribed to.
+//   - Strip the two keys from the caller's payload (now). The property needed
+//     is "these keys cannot arrive from outside", and stripping is the minimal
+//     enforcement of exactly that: the caller can only supply bytes they
+//     already hold, so no authorization surface is required, and the result is
+//     a legal unmarked frame — which is what a copy should be, since it never
+//     passed the rendering boundary that authored the original.
+func TestSourceMessageCopyStripsServerOnlyMarkers(t *testing.T) {
+	marked := []byte(`{"type":17,"card_version":"1.5","profile":"octo/v2",` +
+		`"template_ref":{"id":"docs.access-request","version":"0.3.0"},` +
+		`"catalog_provenance":{"version":1,"principal_type":"internal_producer",` +
+		`"principal_id":"docs-notify","space_id":"space-1"},` +
+		`"card":{"type":"AdaptiveCard","body":[]}}`)
+
+	stripped, err := cardmsg.StripCatalogMarkers(marked)
+	if err != nil {
+		t.Fatalf("StripCatalogMarkers: %v", err)
+	}
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(stripped, &decoded); err != nil {
+		t.Fatalf("stripped payload is not valid JSON: %v", err)
+	}
+	if _, present := decoded[cardmsg.CatalogTemplateRefKey]; present {
+		t.Fatal("template_ref survived the strip")
+	}
+	if _, present := decoded[cardmsg.CatalogProvenanceKey]; present {
+		t.Fatal("catalog_provenance survived the strip")
+	}
+	// Everything else is the caller's own content and must be preserved — the
+	// legitimate case is a client echoing back a card it was really sent.
+	if decoded["type"] != float64(17) || decoded["profile"] != "octo/v2" {
+		t.Fatalf("the strip damaged the caller's frame: %+v", decoded)
+	}
+	if _, present := decoded["card"]; !present {
+		t.Fatal("the strip dropped the card body")
+	}
+
+	t.Run("an unmarked payload is returned byte-identical", func(t *testing.T) {
+		plain := []byte(`{"type":1,"content":"你好"}`)
+		out, err := cardmsg.StripCatalogMarkers(plain)
+		if err != nil {
+			t.Fatalf("StripCatalogMarkers: %v", err)
+		}
+		if string(out) != string(plain) {
+			t.Fatalf("an unmarked payload was rewritten: %s", out)
+		}
+	})
+
+	t.Run("a non-object payload is passed through", func(t *testing.T) {
+		for _, raw := range []string{`"just a string"`, `[1,2,3]`, `not json at all`} {
+			out, err := cardmsg.StripCatalogMarkers([]byte(raw))
+			if err != nil {
+				t.Fatalf("StripCatalogMarkers(%s): %v", raw, err)
+			}
+			if string(out) != raw {
+				t.Fatalf("payload %s was rewritten to %s", raw, out)
+			}
+		}
+	})
+}
+
+// The guard is over the boundary, not over one call site. Its first version
+// regexed sendSourceMessage only and was green while the same field still
+// reached sendThreadCreatedMessage and the persisted parent-group preview.
 //
-// The fix reads the content from the same row, which takes the request field
-// out of the trust boundary rather than adding a fifth key-rejection — a
-// rejection would break the legitimate case, since a client echoing back a card
-// it was legitimately sent carries real markers.
-//
-// This guard covers the *field*, not one call site. The first version regexed
-// `sendSourceMessage(...)` only, and was green while the same field still
-// reached sendThreadCreatedMessage and from there the persisted parent-group
-// notification's last_message preview — the exact "a later refactor
-// reintroduces it by accident" case the guard was written for, present at the
-// moment it was written.
-func TestSourceMessagePayloadNeverLeavesTheDecisionToCopy(t *testing.T) {
+// What must hold now: the copy path never passes req.SourceMessagePayload on
+// without stripping it, and it does not read message content out of the message
+// table by id.
+func TestSourceMessageCopyEnforcesTheBoundaryInSource(t *testing.T) {
 	raw, err := os.ReadFile("service.go")
 	if err != nil {
 		t.Fatalf("read service.go: %v", err)
 	}
 	code := stripGoComments(string(raw))
 
-	if !strings.Contains(code, "QueryMessageSource(") {
-		t.Fatal("the copy no longer reads the source row's payload via QueryMessageSource")
+	if !strings.Contains(code, "cardmsg.StripCatalogMarkers(req.SourceMessagePayload)") {
+		t.Fatal("the caller's payload is no longer stripped before it is copied")
 	}
 
-	// Every surviving use must be either the struct field declaration or the
-	// len() test that decides whether to copy at all. Anything else means the
-	// caller's bytes are being read for their content.
+	// Reading stored content by message id would reintroduce the round-10
+	// bypass: that read applies none of the five gates a single-message read
+	// applies, so it hands back revoked, deleted, visibles-excluded and
+	// pre-offset content on the strength of an id alone.
+	//
+	// The query lives in db.go, so this half of the guard has to read that file
+	// — the first version checked service.go only and was blind to the very
+	// mutation it names.
+	dbRaw, err := os.ReadFile("db.go")
+	if err != nil {
+		t.Fatalf("read db.go: %v", err)
+	}
+	dbCode := stripGoComments(string(dbRaw))
+	payloadRead := regexp.MustCompile(`Select\([^)]*"payload"`)
+	for _, line := range strings.Split(dbCode, "\n") {
+		if payloadRead.MatchString(line) {
+			t.Fatalf("the copy path reads message content out of the message table by id:\n  %s\n"+
+				"That bypasses visibles / revoke / per-user deletion / both history offsets / Expire, "+
+				"so a member can have the server re-publish content they may not read.",
+				strings.TrimSpace(line))
+		}
+	}
+
 	declaration := regexp.MustCompile(`SourceMessagePayload\s+json\.RawMessage`)
+	stripCall := regexp.MustCompile(`StripCatalogMarkers\(req\.SourceMessagePayload\)`)
 	decision := regexp.MustCompile(`len\(req\.SourceMessagePayload\)`)
 	for _, line := range strings.Split(code, "\n") {
 		if !strings.Contains(line, "SourceMessagePayload") {
 			continue
 		}
 		trimmed := strings.TrimSpace(line)
-		if declaration.MatchString(trimmed) || decision.MatchString(trimmed) {
+		if declaration.MatchString(trimmed) || stripCall.MatchString(trimmed) || decision.MatchString(trimmed) {
 			continue
 		}
-		t.Fatalf("the caller's source payload is used for its content, not just to decide whether to copy:\n  %s\n"+
-			"Content must come from QueryMessageSource. Otherwise a group member can put chosen bytes "+
-			"into a persisted message — under another sender's identity on the copy path, and into the "+
-			"parent group's last_message preview on the notification path.", trimmed)
+		t.Fatalf("the caller's payload is used unstripped:\n  %s\n"+
+			"Every use must be the declaration, the len() test that decides whether to copy, "+
+			"or the strip itself.", trimmed)
 	}
 }
 
@@ -75,11 +161,11 @@ func stripGoComments(source string) string {
 
 // The parent-group notification must describe the thread that actually exists.
 //
-// message_count and the last_message preview used to be computed from
-// len(req.SourceMessagePayload) while whether a copy happened came from the
-// database read — two different values since the content moved server-side. A
-// missing or empty source row produced a notification announcing a first
-// message the new thread does not contain, with no later event to correct it.
+// message_count and the last_message preview are derived from the bytes
+// actually copied, not from the request field. Those were the same value before
+// round 10 and diverged when the content moved server-side; they are the same
+// value again now, and deriving from the copy keeps them correct if the copy is
+// ever skipped for another reason.
 func TestThreadCreatedNotificationDescribesTheCopyThatHappened(t *testing.T) {
 	const shortID, name, channelID = "t-1", "设计评审", "g-1@t-1"
 	sourceID := int64(9001)
@@ -95,7 +181,7 @@ func TestThreadCreatedNotificationDescribesTheCopyThatHappened(t *testing.T) {
 	})
 
 	t.Run("a copy that happened is advertised from the copied bytes", func(t *testing.T) {
-		copied := []byte(`{"type":1,"content":"服务端存下来的内容"}`)
+		copied := []byte(`{"type":1,"content":"实际拷贝进去的内容"}`)
 		payload := buildThreadCreatedPayload(shortID, name, channelID, "u-1", "创建者", &sourceID, copied)
 		if got := payload["message_count"]; got != int64(1) {
 			t.Fatalf("message_count = %v, want 1", got)
@@ -104,7 +190,7 @@ func TestThreadCreatedNotificationDescribesTheCopyThatHappened(t *testing.T) {
 		if !ok {
 			t.Fatalf("last_message missing or wrong shape: %+v", payload["last_message"])
 		}
-		if last["content"] != "服务端存下来的内容" {
+		if last["content"] != "实际拷贝进去的内容" {
 			t.Fatalf("preview content = %v, want the copied bytes' content", last["content"])
 		}
 	})

--- a/modules/thread/source_message_trust_test.go
+++ b/modules/thread/source_message_trust_test.go
@@ -1,0 +1,55 @@
+package thread
+
+import (
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// PR-C review round 9 (yujiawei): the thread source-message copy is a write
+// path to a persisted card frame, and it was outside the marker trust boundary.
+//
+// CreateThread fixes the copied message's from_uid by reading the source row
+// ("防止客户端伪造") but took the payload from the request. So any active group
+// member could persist a message in a CommunityTopic channel whose from_uid is
+// a real bot's and whose content they wrote — including the server-only
+// top-level template_ref / catalog_provenance, which the action path then reads
+// as trusted producer identity. cardmsg.Validate never runs on this path, and
+// it is not one of the four ingresses that reject those keys by name.
+//
+// The fix is that the copy uses the server's own bytes, which takes
+// source_message_payload out of the trust boundary entirely rather than adding
+// a fifth key-rejection — a rejection would break the legitimate case, since a
+// client echoing a card it was legitimately sent would be carrying real
+// markers.
+//
+// This is a source guard rather than a behavioural test because the property is
+// "these bytes never reach that call", which is exactly the kind of thing a
+// later refactor reintroduces by accident.
+func TestSourceMessageCopyNeverUsesCallerPayload(t *testing.T) {
+	source, err := os.ReadFile("service.go")
+	if err != nil {
+		t.Fatalf("read service.go: %v", err)
+	}
+	text := string(source)
+
+	call := regexp.MustCompile(`sendSourceMessage\([^)]*\)`)
+	found := call.FindAllString(text, -1)
+	if len(found) == 0 {
+		t.Fatal("no sendSourceMessage call found; this guard has lost its subject")
+	}
+	for _, site := range found {
+		if strings.Contains(site, "SourceMessagePayload") {
+			t.Fatalf("the thread copy passes the caller's payload to the copied message: %s\n"+
+				"It must pass the payload read from the source row, or a group member can "+
+				"persist forged server-only card markers under another sender's identity.", site)
+		}
+	}
+
+	// The query the copy must read from has to return both halves of the source
+	// row; a from_uid-only query is what left the payload caller-controlled.
+	if !strings.Contains(text, "QueryMessageSource(") {
+		t.Fatal("the copy no longer reads the source row's payload via QueryMessageSource")
+	}
+}

--- a/modules/thread/source_message_trust_test.go
+++ b/modules/thread/source_message_trust_test.go
@@ -7,49 +7,105 @@ import (
 	"testing"
 )
 
-// PR-C review round 9 (yujiawei): the thread source-message copy is a write
-// path to a persisted card frame, and it was outside the marker trust boundary.
+// PR-C review rounds 9–10 (yujiawei): the thread source-message copy is a write
+// path to persisted messages, and it was outside the marker trust boundary.
 //
 // CreateThread fixes the copied message's from_uid by reading the source row
-// ("防止客户端伪造") but took the payload from the request. So any active group
+// ("防止客户端伪造") but took the content from the request. So any active group
 // member could persist a message in a CommunityTopic channel whose from_uid is
 // a real bot's and whose content they wrote — including the server-only
 // top-level template_ref / catalog_provenance, which the action path then reads
 // as trusted producer identity. cardmsg.Validate never runs on this path, and
 // it is not one of the four ingresses that reject those keys by name.
 //
-// The fix is that the copy uses the server's own bytes, which takes
-// source_message_payload out of the trust boundary entirely rather than adding
-// a fifth key-rejection — a rejection would break the legitimate case, since a
-// client echoing a card it was legitimately sent would be carrying real
-// markers.
+// The fix reads the content from the same row, which takes the request field
+// out of the trust boundary rather than adding a fifth key-rejection — a
+// rejection would break the legitimate case, since a client echoing back a card
+// it was legitimately sent carries real markers.
 //
-// This is a source guard rather than a behavioural test because the property is
-// "these bytes never reach that call", which is exactly the kind of thing a
-// later refactor reintroduces by accident.
-func TestSourceMessageCopyNeverUsesCallerPayload(t *testing.T) {
-	source, err := os.ReadFile("service.go")
+// This guard covers the *field*, not one call site. The first version regexed
+// `sendSourceMessage(...)` only, and was green while the same field still
+// reached sendThreadCreatedMessage and from there the persisted parent-group
+// notification's last_message preview — the exact "a later refactor
+// reintroduces it by accident" case the guard was written for, present at the
+// moment it was written.
+func TestSourceMessagePayloadNeverLeavesTheDecisionToCopy(t *testing.T) {
+	raw, err := os.ReadFile("service.go")
 	if err != nil {
 		t.Fatalf("read service.go: %v", err)
 	}
-	text := string(source)
+	code := stripGoComments(string(raw))
 
-	call := regexp.MustCompile(`sendSourceMessage\([^)]*\)`)
-	found := call.FindAllString(text, -1)
-	if len(found) == 0 {
-		t.Fatal("no sendSourceMessage call found; this guard has lost its subject")
-	}
-	for _, site := range found {
-		if strings.Contains(site, "SourceMessagePayload") {
-			t.Fatalf("the thread copy passes the caller's payload to the copied message: %s\n"+
-				"It must pass the payload read from the source row, or a group member can "+
-				"persist forged server-only card markers under another sender's identity.", site)
-		}
-	}
-
-	// The query the copy must read from has to return both halves of the source
-	// row; a from_uid-only query is what left the payload caller-controlled.
-	if !strings.Contains(text, "QueryMessageSource(") {
+	if !strings.Contains(code, "QueryMessageSource(") {
 		t.Fatal("the copy no longer reads the source row's payload via QueryMessageSource")
 	}
+
+	// Every surviving use must be either the struct field declaration or the
+	// len() test that decides whether to copy at all. Anything else means the
+	// caller's bytes are being read for their content.
+	declaration := regexp.MustCompile(`SourceMessagePayload\s+json\.RawMessage`)
+	decision := regexp.MustCompile(`len\(req\.SourceMessagePayload\)`)
+	for _, line := range strings.Split(code, "\n") {
+		if !strings.Contains(line, "SourceMessagePayload") {
+			continue
+		}
+		trimmed := strings.TrimSpace(line)
+		if declaration.MatchString(trimmed) || decision.MatchString(trimmed) {
+			continue
+		}
+		t.Fatalf("the caller's source payload is used for its content, not just to decide whether to copy:\n  %s\n"+
+			"Content must come from QueryMessageSource. Otherwise a group member can put chosen bytes "+
+			"into a persisted message — under another sender's identity on the copy path, and into the "+
+			"parent group's last_message preview on the notification path.", trimmed)
+	}
+}
+
+// stripGoComments removes // and /* */ comments so the guard reads code rather
+// than the prose describing it — the comments here necessarily name the field.
+func stripGoComments(source string) string {
+	source = regexp.MustCompile(`(?s)/\*.*?\*/`).ReplaceAllString(source, "")
+	lines := strings.Split(source, "\n")
+	for i, line := range lines {
+		if idx := strings.Index(line, "//"); idx >= 0 {
+			lines[i] = line[:idx]
+		}
+	}
+	return strings.Join(lines, "\n")
+}
+
+// The parent-group notification must describe the thread that actually exists.
+//
+// message_count and the last_message preview used to be computed from
+// len(req.SourceMessagePayload) while whether a copy happened came from the
+// database read — two different values since the content moved server-side. A
+// missing or empty source row produced a notification announcing a first
+// message the new thread does not contain, with no later event to correct it.
+func TestThreadCreatedNotificationDescribesTheCopyThatHappened(t *testing.T) {
+	const shortID, name, channelID = "t-1", "设计评审", "g-1@t-1"
+	sourceID := int64(9001)
+
+	t.Run("no copy issued means no first message is advertised", func(t *testing.T) {
+		payload := buildThreadCreatedPayload(shortID, name, channelID, "u-1", "创建者", &sourceID, nil)
+		if got := payload["message_count"]; got != int64(0) {
+			t.Fatalf("message_count = %v, want 0 when nothing was copied", got)
+		}
+		if _, present := payload["last_message"]; present {
+			t.Fatalf("a preview was advertised for a message the thread does not contain: %+v", payload["last_message"])
+		}
+	})
+
+	t.Run("a copy that happened is advertised from the copied bytes", func(t *testing.T) {
+		copied := []byte(`{"type":1,"content":"服务端存下来的内容"}`)
+		payload := buildThreadCreatedPayload(shortID, name, channelID, "u-1", "创建者", &sourceID, copied)
+		if got := payload["message_count"]; got != int64(1) {
+			t.Fatalf("message_count = %v, want 1", got)
+		}
+		last, ok := payload["last_message"].(map[string]interface{})
+		if !ok {
+			t.Fatalf("last_message missing or wrong shape: %+v", payload["last_message"])
+		}
+		if last["content"] != "服务端存下来的内容" {
+			t.Fatalf("preview content = %v, want the copied bytes' content", last["content"])
+		}
+	})
 }

--- a/modules/thread/source_message_trust_test.go
+++ b/modules/thread/source_message_trust_test.go
@@ -136,3 +136,55 @@ func TestCardDetectionCoversMarkerlessFrames(t *testing.T) {
 		t.Fatal("a plain text message was refused as a card")
 	}
 }
+
+// A refused or failed copy must not leave the parent group announcing a source
+// the thread does not have. source_message_id, message_count and the preview
+// all describe the same thing, so they are derived from the same fact: whether
+// bytes were actually copied.
+func TestThreadCreatedNotificationOmitsTheSourceWhenNothingWasCopied(t *testing.T) {
+	sourceID := int64(9001)
+	payload := buildThreadCreatedPayload("t-1", "设计评审", "g-1@t-1", "u-1", "创建者", nil, nil)
+	if _, present := payload["source_message_id"]; present {
+		t.Fatalf("a source was announced with no copy: %+v", payload["source_message_id"])
+	}
+	withCopy := buildThreadCreatedPayload("t-1", "设计评审", "g-1@t-1", "u-1", "创建者",
+		&sourceID, []byte(`{"type":1,"content":"文本"}`))
+	if withCopy["source_message_id"] != sourceID {
+		t.Fatalf("source_message_id = %v, want %d when the copy happened", withCopy["source_message_id"], sourceID)
+	}
+}
+
+// The caller-supplied payload is persisted, and the request contract has to say
+// so. An earlier revision read the content server-side, and when that was
+// reverted the comment stating "this field must never reach persisted data"
+// stayed behind — a false rule on the one exported field whose misuse is an
+// impersonation vector, which is the highest-value thing to get wrong.
+func TestSourceMessagePayloadContractCommentMatchesTheCode(t *testing.T) {
+	raw, err := os.ReadFile("service.go")
+	if err != nil {
+		t.Fatalf("read service.go: %v", err)
+	}
+	text := string(raw)
+	idx := strings.Index(text, "SourceMessagePayload json.RawMessage")
+	if idx < 0 {
+		t.Fatal("SourceMessagePayload field not found")
+	}
+	// The doc comment immediately above the field.
+	head := text[:idx]
+	blockStart := strings.LastIndex(head, "\n\n")
+	comment := head[blockStart:]
+
+	for _, stale := range []string{
+		"不得流向任何被持久化的字段",
+		"内容一律以服务端从消息行",
+	} {
+		if strings.Contains(comment, stale) {
+			t.Fatalf("the field's contract still claims %q, but the code persists the caller's bytes "+
+				"and verifies only from_uid", stale)
+		}
+	}
+	if !strings.Contains(comment, "会被原样持久化") {
+		t.Fatal("the field's contract no longer states that the caller's bytes are persisted; " +
+			"a consumer written against a softer claim reintroduces the impersonation path")
+	}
+}

--- a/pkg/cardmsg/provenance.go
+++ b/pkg/cardmsg/provenance.go
@@ -240,3 +240,43 @@ func validateCatalogMarkers(payload map[string]interface{}) error {
 	_, err := catalogMarkersFromPayload(payload, nil)
 	return err
 }
+
+// CatalogMarkersPreserved reports whether a replacement frame keeps the catalog
+// identity a stored frame carries. It is the single definition of that rule:
+// internal/carddispatch's mutation boundary enforces it on every replacement,
+// and tests that stand in for that boundary call this rather than restating the
+// comparison — an earlier version was hand-copied into a test fake, and the copy
+// reproduced a bug in the original instead of catching it.
+//
+// The rule is asymmetric on purpose, which is the part that was wrong when it
+// was written as an equality check:
+//
+//   - Losing a marker is refused. That is the erasure the boundary exists to
+//     stop; both identity guards in pkg/cardtmpl's updater begin `if
+//     markers.Has…`, so a dropped marker silently disables them for that
+//     message and returns the frame to the legacy population.
+//   - Gaining one is allowed. `template_ref` alone is a legal pre-PR-C Registry
+//     frame, and an edit is the only moment such a frame can acquire
+//     provenance. Refusing that made every already-delivered Registry card
+//     permanently uneditable, with no repair path, because the edit that would
+//     add the marker was the operation being refused. The gain is safe because
+//     only a server rendering boundary can author a marker and only the
+//     original sender can reach a mutation.
+//   - Changing one is refused. Identity does not change under an edit, so where
+//     both sides carry a marker the values must match. Presence alone would let
+//     a replacement keep both keys and rewrite principal_id or space_id.
+func CatalogMarkersPreserved(stored, next FrameCatalogMarkers) error {
+	if stored.HasRef && !next.HasRef {
+		return fmt.Errorf("%w: replacement drops the stored template_ref", ErrCatalogMarkerInvalid)
+	}
+	if stored.HasProvenance && !next.HasProvenance {
+		return fmt.Errorf("%w: replacement drops the stored catalog_provenance", ErrCatalogMarkerInvalid)
+	}
+	if stored.HasRef && next.HasRef && stored.Ref != next.Ref {
+		return fmt.Errorf("%w: replacement changes the stored template_ref", ErrCatalogMarkerInvalid)
+	}
+	if stored.HasProvenance && next.HasProvenance && stored.Provenance != next.Provenance {
+		return fmt.Errorf("%w: replacement changes the stored catalog_provenance", ErrCatalogMarkerInvalid)
+	}
+	return nil
+}

--- a/pkg/cardmsg/provenance.go
+++ b/pkg/cardmsg/provenance.go
@@ -280,39 +280,3 @@ func CatalogMarkersPreserved(stored, next FrameCatalogMarkers) error {
 	}
 	return nil
 }
-
-// StripCatalogMarkers removes the two server-only top-level markers from a
-// payload that arrived from outside, returning the input untouched when there
-// is nothing to remove.
-//
-// This is the enforcement for "these keys cannot arrive from outside" on a path
-// that copies caller-supplied bytes rather than authoring them. It strips
-// rather than rejects on purpose: a client echoing back a card it was
-// legitimately sent is carrying real markers, so refusing the request would
-// break the legitimate case, while removing them leaves a perfectly valid
-// unmarked frame — which is what the compatibility matrix calls a legacy frame
-// and what a copy should be anyway. A copy is a new message; it did not come
-// from the rendering boundary that authored the original, so it must not claim
-// that boundary's identity.
-//
-// Non-object and unparseable payloads are returned verbatim. There is nothing
-// to strip, and rewriting bytes this function does not understand would be a
-// worse outcome than passing them through.
-func StripCatalogMarkers(raw []byte) ([]byte, error) {
-	var payload map[string]interface{}
-	if err := json.Unmarshal(raw, &payload); err != nil {
-		return raw, nil
-	}
-	_, hasRef := payload[CatalogTemplateRefKey]
-	_, hasProvenance := payload[CatalogProvenanceKey]
-	if !hasRef && !hasProvenance {
-		return raw, nil
-	}
-	delete(payload, CatalogTemplateRefKey)
-	delete(payload, CatalogProvenanceKey)
-	stripped, err := json.Marshal(payload)
-	if err != nil {
-		return nil, fmt.Errorf("%w: re-encode stripped payload: %v", ErrCatalogMarkerInvalid, err)
-	}
-	return stripped, nil
-}

--- a/pkg/cardmsg/provenance.go
+++ b/pkg/cardmsg/provenance.go
@@ -280,3 +280,39 @@ func CatalogMarkersPreserved(stored, next FrameCatalogMarkers) error {
 	}
 	return nil
 }
+
+// StripCatalogMarkers removes the two server-only top-level markers from a
+// payload that arrived from outside, returning the input untouched when there
+// is nothing to remove.
+//
+// This is the enforcement for "these keys cannot arrive from outside" on a path
+// that copies caller-supplied bytes rather than authoring them. It strips
+// rather than rejects on purpose: a client echoing back a card it was
+// legitimately sent is carrying real markers, so refusing the request would
+// break the legitimate case, while removing them leaves a perfectly valid
+// unmarked frame — which is what the compatibility matrix calls a legacy frame
+// and what a copy should be anyway. A copy is a new message; it did not come
+// from the rendering boundary that authored the original, so it must not claim
+// that boundary's identity.
+//
+// Non-object and unparseable payloads are returned verbatim. There is nothing
+// to strip, and rewriting bytes this function does not understand would be a
+// worse outcome than passing them through.
+func StripCatalogMarkers(raw []byte) ([]byte, error) {
+	var payload map[string]interface{}
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		return raw, nil
+	}
+	_, hasRef := payload[CatalogTemplateRefKey]
+	_, hasProvenance := payload[CatalogProvenanceKey]
+	if !hasRef && !hasProvenance {
+		return raw, nil
+	}
+	delete(payload, CatalogTemplateRefKey)
+	delete(payload, CatalogProvenanceKey)
+	stripped, err := json.Marshal(payload)
+	if err != nil {
+		return nil, fmt.Errorf("%w: re-encode stripped payload: %v", ErrCatalogMarkerInvalid, err)
+	}
+	return stripped, nil
+}

--- a/pkg/cardmsg/provenance.go
+++ b/pkg/cardmsg/provenance.go
@@ -1,0 +1,242 @@
+package cardmsg
+
+// PR-C D3（spec: .octospec/tasks/cardtmpl-runtime-catalog-grants-discovery/
+// brief.md）：type-17 信封的 server-authored 顶层 catalog 标记。
+//
+// 两个标记都只能由可信边界写入 —— Bot Registry 路径（authBot 身份）与
+// internal carddispatch（已注册 ProducerSpec）；任何 raw ingress
+// （bot raw / robot legacy / user / incoming-webhook）必须显式拒绝携带它们。
+// 这里只定义 wire 形状与 strict parse：畸形标记是篡改信号，一律返回错误，
+// 绝不退化成 legacy 空标记（与 CardTemplateContext 的 PR#641 fail-close
+// 口径一致）。principal 与授权语义在 pkg/cardtmpl 层（cardmsg 不做授权）。
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+const (
+	// CatalogProvenanceKey / CatalogTemplateRefKey 是 type-17 信封的
+	// server-only 顶层键。raw ingress 检测/拒绝时统一引用这两个常量。
+	CatalogProvenanceKey  = "catalog_provenance"
+	CatalogTemplateRefKey = "template_ref"
+
+	// CatalogProvenanceVersion 是 v1 标记版本；未来演进 bump 该值并保持
+	// 旧版本可解析（额外形状仍然 strict）。
+	CatalogProvenanceVersion = 1
+
+	// Wire principal 类型。只有可认证的发送主体能成为 wire principal；
+	// space 是 discover-only grant principal（D2），system 是内部保留值，
+	// 二者都不会出现在存储帧里。
+	CatalogPrincipalWireBot              = "bot"
+	CatalogPrincipalWireInternalProducer = "internal_producer"
+)
+
+// ErrCatalogMarkerInvalid 标识畸形/不一致的 server-authored catalog 标记。
+var ErrCatalogMarkerInvalid = errors.New("cardmsg: invalid catalog marker")
+
+// CatalogProvenance 是 catalog_provenance 顶层标记的 typed 值对象。
+// 字段与 wire 形状一一对应；SpaceID 允许为空（发送边界没有权威 Space 的
+// 频道形态，如 Slice 3 之前的群聊 Bot 发送），非空值必须已 trim。
+type CatalogProvenance struct {
+	Version       int
+	PrincipalType string
+	PrincipalID   string
+	SpaceID       string
+}
+
+// Validate 校验 canonical v1 形状。
+func (p CatalogProvenance) Validate() error {
+	if p.Version != CatalogProvenanceVersion {
+		return fmt.Errorf("%w: unsupported provenance version %d", ErrCatalogMarkerInvalid, p.Version)
+	}
+	if p.PrincipalType != CatalogPrincipalWireBot && p.PrincipalType != CatalogPrincipalWireInternalProducer {
+		return fmt.Errorf("%w: unsupported principal_type %q", ErrCatalogMarkerInvalid, p.PrincipalType)
+	}
+	if p.PrincipalID == "" || strings.TrimSpace(p.PrincipalID) != p.PrincipalID {
+		return fmt.Errorf("%w: principal_id is required and must be trimmed", ErrCatalogMarkerInvalid)
+	}
+	if strings.TrimSpace(p.SpaceID) != p.SpaceID {
+		return fmt.Errorf("%w: space_id must be trimmed", ErrCatalogMarkerInvalid)
+	}
+	return nil
+}
+
+// MarshalMap 输出 canonical wire map。key 集合与 ParseCatalogProvenance 的
+// strict 校验互为镜像；新增字段必须同时改两处并 bump version 语义评审。
+func (p CatalogProvenance) MarshalMap() map[string]interface{} {
+	return map[string]interface{}{
+		"version":        p.Version,
+		"principal_type": p.PrincipalType,
+		"principal_id":   p.PrincipalID,
+		"space_id":       p.SpaceID,
+	}
+}
+
+// ParseCatalogProvenance strict 解析一个 catalog_provenance 值。未知键、
+// 缺键、类型错误、未知 principal、未 trim 值全部拒绝。
+func ParseCatalogProvenance(value interface{}) (CatalogProvenance, error) {
+	object, ok := value.(map[string]interface{})
+	if !ok || object == nil {
+		return CatalogProvenance{}, fmt.Errorf("%w: catalog_provenance must be an object", ErrCatalogMarkerInvalid)
+	}
+	allowed := map[string]struct{}{"version": {}, "principal_type": {}, "principal_id": {}, "space_id": {}}
+	for key := range object {
+		if _, known := allowed[key]; !known {
+			return CatalogProvenance{}, fmt.Errorf("%w: unknown catalog_provenance key %q", ErrCatalogMarkerInvalid, key)
+		}
+	}
+	for key := range allowed {
+		if _, present := object[key]; !present {
+			return CatalogProvenance{}, fmt.Errorf("%w: catalog_provenance missing key %q", ErrCatalogMarkerInvalid, key)
+		}
+	}
+	version, ok := provenanceVersion(object["version"])
+	if !ok {
+		return CatalogProvenance{}, fmt.Errorf("%w: catalog_provenance version is not an integer", ErrCatalogMarkerInvalid)
+	}
+	principalType, ok := object["principal_type"].(string)
+	if !ok {
+		return CatalogProvenance{}, fmt.Errorf("%w: principal_type must be a string", ErrCatalogMarkerInvalid)
+	}
+	principalID, ok := object["principal_id"].(string)
+	if !ok {
+		return CatalogProvenance{}, fmt.Errorf("%w: principal_id must be a string", ErrCatalogMarkerInvalid)
+	}
+	spaceID, ok := object["space_id"].(string)
+	if !ok {
+		return CatalogProvenance{}, fmt.Errorf("%w: space_id must be a string", ErrCatalogMarkerInvalid)
+	}
+	parsed := CatalogProvenance{Version: version, PrincipalType: principalType, PrincipalID: principalID, SpaceID: spaceID}
+	if err := parsed.Validate(); err != nil {
+		return CatalogProvenance{}, err
+	}
+	return parsed, nil
+}
+
+// provenanceVersion 接受 int / json.Number / 整数值 float64（三种解码路径），
+// 拒绝任何有小数部分或非数值的形状。
+func provenanceVersion(value interface{}) (int, bool) {
+	switch typed := value.(type) {
+	case int:
+		return typed, true
+	case int64:
+		return int(typed), true
+	case json.Number:
+		parsed, err := typed.Int64()
+		if err != nil {
+			return 0, false
+		}
+		return int(parsed), true
+	case float64:
+		if typed != float64(int64(typed)) {
+			return 0, false
+		}
+		return int(typed), true
+	default:
+		return 0, false
+	}
+}
+
+// CatalogTemplateRef 是顶层 template_ref 的 typed 值对象。
+type CatalogTemplateRef struct {
+	ID      string
+	Version string
+}
+
+// ParseCatalogTemplateRef strict 解析顶层 template_ref：恰好 {id, version}
+// 两个非空已 trim 字符串键（与 bot_api 的 caller-facing template_ref/v1
+// request 形状一致）。
+func ParseCatalogTemplateRef(value interface{}) (CatalogTemplateRef, error) {
+	object, ok := value.(map[string]interface{})
+	if !ok || len(object) != 2 {
+		return CatalogTemplateRef{}, fmt.Errorf("%w: template_ref must contain exactly id and version", ErrCatalogMarkerInvalid)
+	}
+	id, idOK := object["id"].(string)
+	version, versionOK := object["version"].(string)
+	if !idOK || !versionOK || id == "" || version == "" ||
+		strings.TrimSpace(id) != id || strings.TrimSpace(version) != version {
+		return CatalogTemplateRef{}, fmt.Errorf("%w: template_ref id/version are required", ErrCatalogMarkerInvalid)
+	}
+	return CatalogTemplateRef{ID: id, Version: version}, nil
+}
+
+// FrameCatalogMarkers 是一个有效帧的 server-authored catalog 身份快照。
+type FrameCatalogMarkers struct {
+	Ref           CatalogTemplateRef
+	Provenance    CatalogProvenance
+	HasRef        bool
+	HasProvenance bool
+}
+
+// CatalogFrameMarkers 从一个有效 type-17 帧提取并校验顶层 catalog 标记。
+//
+// 兼容矩阵（D3 + invariant 7 static 历史兼容）：
+//   - 两个标记都缺失 → legacy 帧，零值返回（不报错）；
+//   - 只有 template_ref → pre-PR-C Bot Registry 帧，合法；
+//   - 两个都有 → 都 strict 校验；
+//   - 只有 catalog_provenance → 服务端从不产出该形状，拒绝；
+//   - 任一存在时，template_ref 必须与 metadata.octo.template 完全一致
+//     （metadata 缺失/畸形同样拒绝 —— 标记只可能由 Registry 产出，而
+//     Registry 必然写 metadata）。
+//
+// 非 type-17 payload 返回零值（调用方对非卡片本就不该看标记）。
+func CatalogFrameMarkers(envelopeRaw []byte) (FrameCatalogMarkers, error) {
+	payload, err := decodeEnvelope(string(envelopeRaw))
+	if err != nil || !IsCardPayload(payload) {
+		return FrameCatalogMarkers{}, nil
+	}
+	return catalogMarkersFromPayload(payload, envelopeRaw)
+}
+
+func catalogMarkersFromPayload(payload map[string]interface{}, envelopeRaw []byte) (FrameCatalogMarkers, error) {
+	refValue, hasRef := payload[CatalogTemplateRefKey]
+	provenanceValue, hasProvenance := payload[CatalogProvenanceKey]
+	if !hasRef && !hasProvenance {
+		return FrameCatalogMarkers{}, nil
+	}
+	if !hasRef {
+		return FrameCatalogMarkers{}, fmt.Errorf("%w: catalog_provenance without template_ref", ErrCatalogMarkerInvalid)
+	}
+	markers := FrameCatalogMarkers{HasRef: true}
+	ref, err := ParseCatalogTemplateRef(refValue)
+	if err != nil {
+		return FrameCatalogMarkers{}, err
+	}
+	markers.Ref = ref
+	if envelopeRaw == nil {
+		encoded, marshalErr := json.Marshal(payload)
+		if marshalErr != nil {
+			return FrameCatalogMarkers{}, fmt.Errorf("%w: encode envelope: %v", ErrCatalogMarkerInvalid, marshalErr)
+		}
+		envelopeRaw = encoded
+	}
+	template, ok := CardTemplateContext(envelopeRaw)
+	if !ok || template.ID != ref.ID || template.Version != ref.Version {
+		return FrameCatalogMarkers{}, fmt.Errorf("%w: template_ref does not match metadata.octo.template", ErrCatalogMarkerInvalid)
+	}
+	if hasProvenance {
+		provenance, err := ParseCatalogProvenance(provenanceValue)
+		if err != nil {
+			return FrameCatalogMarkers{}, err
+		}
+		markers.Provenance = provenance
+		markers.HasProvenance = true
+	}
+	return markers, nil
+}
+
+// validateCatalogMarkers 是 Validate 的 defense-in-depth 钩子：任何携带
+// catalog 标记的信封（send 或 NormalizeContentEdit 路径）都必须是 canonical
+// 形状。raw ingress 的显式拒绝仍在各自边界；这里兜住遗漏的路径。
+func validateCatalogMarkers(payload map[string]interface{}) error {
+	_, hasRef := payload[CatalogTemplateRefKey]
+	_, hasProvenance := payload[CatalogProvenanceKey]
+	if !hasRef && !hasProvenance {
+		return nil
+	}
+	_, err := catalogMarkersFromPayload(payload, nil)
+	return err
+}

--- a/pkg/cardmsg/provenance_test.go
+++ b/pkg/cardmsg/provenance_test.go
@@ -1,0 +1,289 @@
+package cardmsg
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// Slice 1 RED (PR-C D3): the server-authored top-level catalog markers are a
+// strict wire value object. Anything that does not match the canonical v1
+// shape must fail parsing — a malformed marker is a tamper signal, never a
+// legacy fallback.
+
+func validProvenanceMap() map[string]interface{} {
+	return map[string]interface{}{
+		"version":        1,
+		"principal_type": "internal_producer",
+		"principal_id":   "docs-notify",
+		"space_id":       "space-1",
+	}
+}
+
+func TestParseCatalogProvenanceStrictShape(t *testing.T) {
+	cases := []struct {
+		name    string
+		mutate  func(map[string]interface{})
+		value   interface{}
+		wantErr bool
+	}{
+		{name: "canonical internal producer", mutate: func(m map[string]interface{}) {}},
+		{name: "canonical bot", mutate: func(m map[string]interface{}) {
+			m["principal_type"] = "bot"
+			m["principal_id"] = "bot-1"
+		}},
+		{name: "empty space is allowed pre target-space resolution", mutate: func(m map[string]interface{}) {
+			m["space_id"] = ""
+		}},
+		{name: "json.Number version from UseNumber decode", mutate: func(m map[string]interface{}) {
+			m["version"] = json.Number("1")
+		}},
+		{name: "float64 version from plain decode", mutate: func(m map[string]interface{}) {
+			m["version"] = float64(1)
+		}},
+		{name: "not a map", value: "forged", wantErr: true},
+		{name: "nil value", value: nil, wantErr: true},
+		{name: "unknown extra key", mutate: func(m map[string]interface{}) {
+			m["actor"] = "attacker"
+		}, wantErr: true},
+		{name: "missing version", mutate: func(m map[string]interface{}) {
+			delete(m, "version")
+		}, wantErr: true},
+		{name: "unsupported version", mutate: func(m map[string]interface{}) {
+			m["version"] = 2
+		}, wantErr: true},
+		{name: "missing principal_type", mutate: func(m map[string]interface{}) {
+			delete(m, "principal_type")
+		}, wantErr: true},
+		{name: "unknown principal_type", mutate: func(m map[string]interface{}) {
+			m["principal_type"] = "space"
+		}, wantErr: true},
+		{name: "system principal is not a wire principal", mutate: func(m map[string]interface{}) {
+			m["principal_type"] = "system"
+		}, wantErr: true},
+		{name: "missing principal_id", mutate: func(m map[string]interface{}) {
+			delete(m, "principal_id")
+		}, wantErr: true},
+		{name: "empty principal_id", mutate: func(m map[string]interface{}) {
+			m["principal_id"] = ""
+		}, wantErr: true},
+		{name: "untrimmed principal_id", mutate: func(m map[string]interface{}) {
+			m["principal_id"] = " docs-notify"
+		}, wantErr: true},
+		{name: "missing space_id key", mutate: func(m map[string]interface{}) {
+			delete(m, "space_id")
+		}, wantErr: true},
+		{name: "untrimmed space_id", mutate: func(m map[string]interface{}) {
+			m["space_id"] = "space-1 "
+		}, wantErr: true},
+		{name: "non-string principal_id", mutate: func(m map[string]interface{}) {
+			m["principal_id"] = 42
+		}, wantErr: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			value := tc.value
+			if tc.mutate != nil {
+				m := validProvenanceMap()
+				tc.mutate(m)
+				value = m
+			}
+			parsed, err := ParseCatalogProvenance(value)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("ParseCatalogProvenance(%#v) accepted a non-canonical marker: %+v", value, parsed)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ParseCatalogProvenance(%#v): %v", value, err)
+			}
+			if parsed.Version != CatalogProvenanceVersion {
+				t.Fatalf("version = %d", parsed.Version)
+			}
+		})
+	}
+}
+
+func TestCatalogProvenanceMarshalRoundTrip(t *testing.T) {
+	original := CatalogProvenance{
+		Version:       CatalogProvenanceVersion,
+		PrincipalType: CatalogPrincipalWireBot,
+		PrincipalID:   "bot-7",
+		SpaceID:       "space-9",
+	}
+	parsed, err := ParseCatalogProvenance(original.MarshalMap())
+	if err != nil {
+		t.Fatalf("round trip parse: %v", err)
+	}
+	if parsed != original {
+		t.Fatalf("round trip = %+v, want %+v", parsed, original)
+	}
+	// The map must survive a JSON encode/decode cycle (durable event storage).
+	raw, err := json.Marshal(original.MarshalMap())
+	if err != nil {
+		t.Fatal(err)
+	}
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	parsed, err = ParseCatalogProvenance(decoded)
+	if err != nil {
+		t.Fatalf("post-JSON parse: %v", err)
+	}
+	if parsed != original {
+		t.Fatalf("post-JSON round trip = %+v, want %+v", parsed, original)
+	}
+}
+
+func registryFrame(t *testing.T, mutate func(map[string]interface{})) []byte {
+	t.Helper()
+	frame := map[string]interface{}{
+		"type":         17,
+		"card_version": CardVersion,
+		"profile":      "octo/v1",
+		"template_ref": map[string]interface{}{"id": "docs.access-request", "version": "0.3.0"},
+		"catalog_provenance": map[string]interface{}{
+			"version": 1, "principal_type": "internal_producer",
+			"principal_id": "docs-notify", "space_id": "space-1",
+		},
+		"card": map[string]interface{}{
+			"type": "AdaptiveCard", "version": CardVersion,
+			"body": []interface{}{map[string]interface{}{"type": "TextBlock", "text": "hi"}},
+			"metadata": map[string]interface{}{"octo": map[string]interface{}{
+				"protocol": "octo-card@1.0",
+				"template": map[string]interface{}{"id": "docs.access-request", "version": "0.3.0"},
+			}},
+		},
+	}
+	if mutate != nil {
+		mutate(frame)
+	}
+	raw, err := json.Marshal(frame)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return raw
+}
+
+func TestCatalogFrameMarkersMatrix(t *testing.T) {
+	t.Run("both markers canonical", func(t *testing.T) {
+		markers, err := CatalogFrameMarkers(registryFrame(t, nil))
+		if err != nil {
+			t.Fatalf("CatalogFrameMarkers: %v", err)
+		}
+		if !markers.HasRef || !markers.HasProvenance {
+			t.Fatalf("markers presence = %+v", markers)
+		}
+		if markers.Ref.ID != "docs.access-request" || markers.Ref.Version != "0.3.0" {
+			t.Fatalf("ref = %+v", markers.Ref)
+		}
+		if markers.Provenance.PrincipalID != "docs-notify" || markers.Provenance.SpaceID != "space-1" {
+			t.Fatalf("provenance = %+v", markers.Provenance)
+		}
+	})
+	t.Run("legacy frame without markers", func(t *testing.T) {
+		markers, err := CatalogFrameMarkers(registryFrame(t, func(f map[string]interface{}) {
+			delete(f, "template_ref")
+			delete(f, "catalog_provenance")
+		}))
+		if err != nil {
+			t.Fatalf("legacy frame must stay compatible: %v", err)
+		}
+		if markers.HasRef || markers.HasProvenance {
+			t.Fatalf("legacy frame reported markers: %+v", markers)
+		}
+	})
+	t.Run("pre-PR-C bot frame keeps ref-only compatibility", func(t *testing.T) {
+		markers, err := CatalogFrameMarkers(registryFrame(t, func(f map[string]interface{}) {
+			delete(f, "catalog_provenance")
+		}))
+		if err != nil {
+			t.Fatalf("ref-only frame must stay compatible: %v", err)
+		}
+		if !markers.HasRef || markers.HasProvenance {
+			t.Fatalf("ref-only markers = %+v", markers)
+		}
+	})
+	t.Run("provenance without ref is never a server shape", func(t *testing.T) {
+		if _, err := CatalogFrameMarkers(registryFrame(t, func(f map[string]interface{}) {
+			delete(f, "template_ref")
+		})); err == nil {
+			t.Fatal("provenance without template_ref accepted")
+		}
+	})
+	t.Run("ref mismatching metadata is rejected", func(t *testing.T) {
+		if _, err := CatalogFrameMarkers(registryFrame(t, func(f map[string]interface{}) {
+			f["template_ref"] = map[string]interface{}{"id": "docs.access-request", "version": "0.2.0"}
+		})); err == nil {
+			t.Fatal("template_ref/metadata version mismatch accepted")
+		}
+	})
+	t.Run("ref without template metadata is rejected", func(t *testing.T) {
+		if _, err := CatalogFrameMarkers(registryFrame(t, func(f map[string]interface{}) {
+			card := f["card"].(map[string]interface{})
+			delete(card, "metadata")
+		})); err == nil {
+			t.Fatal("template_ref without metadata.octo.template accepted")
+		}
+	})
+	t.Run("malformed provenance is rejected", func(t *testing.T) {
+		if _, err := CatalogFrameMarkers(registryFrame(t, func(f map[string]interface{}) {
+			f["catalog_provenance"] = "forged"
+		})); err == nil {
+			t.Fatal("malformed catalog_provenance accepted")
+		}
+	})
+	t.Run("malformed ref is rejected", func(t *testing.T) {
+		if _, err := CatalogFrameMarkers(registryFrame(t, func(f map[string]interface{}) {
+			f["template_ref"] = map[string]interface{}{"id": "docs.access-request"}
+		})); err == nil {
+			t.Fatal("template_ref missing version accepted")
+		}
+	})
+	t.Run("non-card payload has no markers", func(t *testing.T) {
+		markers, err := CatalogFrameMarkers([]byte(`{"type":1,"content":"hello"}`))
+		if err != nil || markers.HasRef || markers.HasProvenance {
+			t.Fatalf("non-card = %+v err=%v", markers, err)
+		}
+	})
+}
+
+// Validate must reject malformed markers as defense in depth on every path
+// that funnels a full envelope through it (send + NormalizeContentEdit).
+func TestValidateRejectsMalformedCatalogMarkers(t *testing.T) {
+	decode := func(raw []byte) map[string]interface{} {
+		var payload map[string]interface{}
+		if err := json.Unmarshal(raw, &payload); err != nil {
+			t.Fatal(err)
+		}
+		return payload
+	}
+	if err := Validate(decode(registryFrame(t, nil))); err != nil {
+		t.Fatalf("canonical markers must pass Validate: %v", err)
+	}
+	for name, mutate := range map[string]func(map[string]interface{}){
+		"provenance not object": func(f map[string]interface{}) { f["catalog_provenance"] = 7 },
+		"provenance extra key": func(f map[string]interface{}) {
+			f["catalog_provenance"].(map[string]interface{})["grantor"] = "x"
+		},
+		"provenance without ref": func(f map[string]interface{}) { delete(f, "template_ref") },
+		"ref not object":         func(f map[string]interface{}) { f["template_ref"] = []interface{}{} },
+		"ref metadata mismatch": func(f map[string]interface{}) {
+			f["template_ref"].(map[string]interface{})["version"] = "9.9.9"
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			payload := decode(registryFrame(t, nil))
+			mutate(payload)
+			err := Validate(payload)
+			if err == nil {
+				t.Fatal("Validate accepted a malformed catalog marker")
+			}
+			if !strings.Contains(err.Error(), "catalog") {
+				t.Fatalf("error should identify the catalog marker: %v", err)
+			}
+		})
+	}
+}

--- a/pkg/cardmsg/validate.go
+++ b/pkg/cardmsg/validate.go
@@ -44,6 +44,12 @@ func Validate(payload map[string]interface{}) error {
 			return fmt.Errorf("%w: render_profile=%q", ErrCardProfileUnsupported, renderProfile)
 		}
 	}
+	// PR-C D3 defense in depth：携带 server-authored catalog 标记的信封必须是
+	// canonical 形状（strict parse + template_ref↔metadata 一致）。raw ingress
+	// 的显式拒绝在各自边界；这里兜住任何遗漏路径与编辑重写。
+	if err := validateCatalogMarkers(payload); err != nil {
+		return err
+	}
 	card, ok := payload["card"].(map[string]interface{})
 	if !ok || len(card) == 0 {
 		return ErrCardMissing

--- a/pkg/cardtmpl/docs_access_request/handoff/docs.access-request@0.3.0/contract/data.schema.json
+++ b/pkg/cardtmpl/docs_access_request/handoff/docs.access-request@0.3.0/contract/data.schema.json
@@ -3,134 +3,55 @@
   "title": "文档访问申请卡数据契约 0.3.0",
   "type": "object",
   "additionalProperties": false,
-  "required": [
-    "requestId",
-    "state",
-    "document"
-  ],
+  "required": ["requestId", "state", "document"],
   "properties": {
-    "requestId": {
-      "type": "string",
-      "minLength": 1,
-      "maxLength": 200
-    },
-    "state": {
-      "type": "string",
-      "enum": [
-        "pending",
-        "approved",
-        "rejected",
-        "cancelled",
-        "unavailable"
-      ]
-    },
+    "requestId": {"type": "string", "minLength": 1, "maxLength": 200},
+    "state": {"type": "string", "enum": ["pending", "approved", "rejected", "cancelled", "unavailable"]},
     "document": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "title"
-      ],
+      "required": ["title"],
       "properties": {
-        "docId": {
-          "type": "string",
-          "maxLength": 200
-        },
-        "title": {
-          "type": "string",
-          "minLength": 1,
-          "maxLength": 200
-        },
-        "url": {
-          "type": "string",
-          "maxLength": 2048
-        },
-        "sourceName": {
-          "type": "string",
-          "maxLength": 200
-        }
+        "docId": {"type": "string", "maxLength": 200},
+        "title": {"type": "string", "minLength": 1, "maxLength": 200},
+        "url": {"type": "string", "maxLength": 2048},
+        "sourceName": {"type": "string", "maxLength": 200}
       }
     },
     "requester": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "name": {
-          "type": "string",
-          "maxLength": 120
-        },
-        "avatarUrl": {
-          "type": "string",
-          "maxLength": 2048,
-          "pattern": "^(|https://[^/].*)$"
-        }
+        "name": {"type": "string", "maxLength": 120},
+        "avatarUrl": {"type": "string", "maxLength": 2048, "pattern": "^(|https://[^/].*)$"}
       }
     },
     "permission": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "type": "string",
-          "maxLength": 80
-        },
-        "roleLabel": {
-          "type": "string",
-          "maxLength": 80
-        }
+        "label": {"type": "string", "maxLength": 80},
+        "roleLabel": {"type": "string", "maxLength": 80}
       }
     },
-    "requestReason": {
-      "type": "string",
-      "maxLength": 300
-    },
-    "requestedAtDisplay": {
-      "type": "string",
-      "maxLength": 80
-    },
-    "messageTimeDisplay": {
-      "type": "string",
-      "maxLength": 80
-    },
+    "requestReason": {"type": "string", "maxLength": 300},
+    "requestedAtDisplay": {"type": "string", "maxLength": 80},
+    "messageTimeDisplay": {"type": "string", "maxLength": 80},
     "decision": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "operatorName"
-      ],
+      "required": ["operatorName"],
       "properties": {
-        "operatorName": {
-          "type": "string",
-          "minLength": 1,
-          "maxLength": 120
-        },
-        "decidedAtDisplay": {
-          "type": "string",
-          "maxLength": 80
-        },
-        "rejectionReason": {
-          "type": "string",
-          "maxLength": 300
-        }
+        "operatorName": {"type": "string", "minLength": 1, "maxLength": 120},
+        "decidedAtDisplay": {"type": "string", "maxLength": 80},
+        "rejectionReason": {"type": "string", "maxLength": 300}
       }
     }
   },
   "allOf": [
     {
-      "if": {
-        "properties": {
-          "state": {
-            "enum": [
-              "approved",
-              "rejected"
-            ]
-          }
-        }
-      },
-      "then": {
-        "required": [
-          "decision"
-        ]
-      }
+      "if": {"properties": {"state": {"enum": ["approved", "rejected"]}}},
+      "then": {"required": ["decision"]}
     }
   ]
 }

--- a/pkg/cardtmpl/docs_access_request/handoff/docs.access-request@0.3.0/contract/data.schema.json
+++ b/pkg/cardtmpl/docs_access_request/handoff/docs.access-request@0.3.0/contract/data.schema.json
@@ -3,55 +3,134 @@
   "title": "文档访问申请卡数据契约 0.3.0",
   "type": "object",
   "additionalProperties": false,
-  "required": ["requestId", "state", "document"],
+  "required": [
+    "requestId",
+    "state",
+    "document"
+  ],
   "properties": {
-    "requestId": {"type": "string", "minLength": 1, "maxLength": 200},
-    "state": {"type": "string", "enum": ["pending", "approved", "rejected"]},
+    "requestId": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 200
+    },
+    "state": {
+      "type": "string",
+      "enum": [
+        "pending",
+        "approved",
+        "rejected",
+        "cancelled",
+        "unavailable"
+      ]
+    },
     "document": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["title"],
+      "required": [
+        "title"
+      ],
       "properties": {
-        "docId": {"type": "string", "maxLength": 200},
-        "title": {"type": "string", "minLength": 1, "maxLength": 200},
-        "url": {"type": "string", "maxLength": 2048},
-        "sourceName": {"type": "string", "maxLength": 200}
+        "docId": {
+          "type": "string",
+          "maxLength": 200
+        },
+        "title": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 200
+        },
+        "url": {
+          "type": "string",
+          "maxLength": 2048
+        },
+        "sourceName": {
+          "type": "string",
+          "maxLength": 200
+        }
       }
     },
     "requester": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "name": {"type": "string", "maxLength": 120},
-        "avatarUrl": {"type": "string", "maxLength": 2048, "pattern": "^(|https://[^/].*)$"}
+        "name": {
+          "type": "string",
+          "maxLength": 120
+        },
+        "avatarUrl": {
+          "type": "string",
+          "maxLength": 2048,
+          "pattern": "^(|https://[^/].*)$"
+        }
       }
     },
     "permission": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {"type": "string", "maxLength": 80},
-        "roleLabel": {"type": "string", "maxLength": 80}
+        "label": {
+          "type": "string",
+          "maxLength": 80
+        },
+        "roleLabel": {
+          "type": "string",
+          "maxLength": 80
+        }
       }
     },
-    "requestReason": {"type": "string", "maxLength": 300},
-    "requestedAtDisplay": {"type": "string", "maxLength": 80},
-    "messageTimeDisplay": {"type": "string", "maxLength": 80},
+    "requestReason": {
+      "type": "string",
+      "maxLength": 300
+    },
+    "requestedAtDisplay": {
+      "type": "string",
+      "maxLength": 80
+    },
+    "messageTimeDisplay": {
+      "type": "string",
+      "maxLength": 80
+    },
     "decision": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["operatorName"],
+      "required": [
+        "operatorName"
+      ],
       "properties": {
-        "operatorName": {"type": "string", "minLength": 1, "maxLength": 120},
-        "decidedAtDisplay": {"type": "string", "maxLength": 80},
-        "rejectionReason": {"type": "string", "maxLength": 300}
+        "operatorName": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 120
+        },
+        "decidedAtDisplay": {
+          "type": "string",
+          "maxLength": 80
+        },
+        "rejectionReason": {
+          "type": "string",
+          "maxLength": 300
+        }
       }
     }
   },
   "allOf": [
     {
-      "if": {"properties": {"state": {"enum": ["approved", "rejected"]}}},
-      "then": {"required": ["decision"]}
+      "if": {
+        "properties": {
+          "state": {
+            "enum": [
+              "approved",
+              "rejected"
+            ]
+          }
+        }
+      },
+      "then": {
+        "required": [
+          "decision"
+        ]
+      }
     }
   ]
 }

--- a/pkg/cardtmpl/docs_access_request/handoff/docs.access-request@0.3.0/manifest.json
+++ b/pkg/cardtmpl/docs_access_request/handoff/docs.access-request@0.3.0/manifest.json
@@ -16,13 +16,27 @@
   "views": {
     "pending": {
       "wireProfile": "octo/v2",
-      "states": ["pending"],
-      "samples": ["samples/pending.json"]
+      "states": [
+        "pending"
+      ],
+      "samples": [
+        "samples/pending.json"
+      ]
     },
     "result": {
       "wireProfile": "octo/v1",
-      "states": ["approved", "rejected"],
-      "samples": ["samples/approved.json", "samples/rejected.json"]
+      "states": [
+        "approved",
+        "rejected",
+        "cancelled",
+        "unavailable"
+      ],
+      "samples": [
+        "samples/approved.json",
+        "samples/rejected.json",
+        "samples/cancelled.json",
+        "samples/unavailable.json"
+      ]
     }
   }
 }

--- a/pkg/cardtmpl/docs_access_request/handoff/docs.access-request@0.3.0/manifest.json
+++ b/pkg/cardtmpl/docs_access_request/handoff/docs.access-request@0.3.0/manifest.json
@@ -16,27 +16,13 @@
   "views": {
     "pending": {
       "wireProfile": "octo/v2",
-      "states": [
-        "pending"
-      ],
-      "samples": [
-        "samples/pending.json"
-      ]
+      "states": ["pending"],
+      "samples": ["samples/pending.json"]
     },
     "result": {
       "wireProfile": "octo/v1",
-      "states": [
-        "approved",
-        "rejected",
-        "cancelled",
-        "unavailable"
-      ],
-      "samples": [
-        "samples/approved.json",
-        "samples/rejected.json",
-        "samples/cancelled.json",
-        "samples/unavailable.json"
-      ]
+      "states": ["approved", "rejected", "cancelled", "unavailable"],
+      "samples": ["samples/approved.json", "samples/rejected.json", "samples/cancelled.json", "samples/unavailable.json"]
     }
   }
 }

--- a/pkg/cardtmpl/docs_access_request/handoff/docs.access-request@0.3.0/samples/cancelled.json
+++ b/pkg/cardtmpl/docs_access_request/handoff/docs.access-request@0.3.0/samples/cancelled.json
@@ -1,0 +1,10 @@
+{
+  "requestId": "DOC-REQ-025",
+  "state": "cancelled",
+  "document": {"docId": "d_2026-q3-okr", "title": "2026 Q3 OKR", "sourceName": "Q3 产品规划"},
+  "requester": {"name": "张三"},
+  "permission": {"label": "协作权限", "roleLabel": "协作者"},
+  "requestReason": "希望加入协作，以补充 KR3 数据。",
+  "requestedAtDisplay": "2026-07-16 11:00",
+  "messageTimeDisplay": "刚刚"
+}

--- a/pkg/cardtmpl/docs_access_request/handoff/docs.access-request@0.3.0/samples/unavailable.json
+++ b/pkg/cardtmpl/docs_access_request/handoff/docs.access-request@0.3.0/samples/unavailable.json
@@ -1,0 +1,10 @@
+{
+  "requestId": "DOC-REQ-026",
+  "state": "unavailable",
+  "document": {"docId": "d_2026-q3-okr", "title": "2026 Q3 OKR", "sourceName": "Q3 产品规划"},
+  "requester": {"name": "张三"},
+  "permission": {"label": "协作权限", "roleLabel": "协作者"},
+  "requestReason": "希望加入协作，以补充 KR3 数据。",
+  "requestedAtDisplay": "2026-07-16 11:00",
+  "messageTimeDisplay": "刚刚"
+}

--- a/pkg/cardtmpl/docs_access_request/template.go
+++ b/pkg/cardtmpl/docs_access_request/template.go
@@ -30,8 +30,15 @@ const (
 	HandoffRoot = "handoff/docs.access-request@0.2.0"
 	// TemplateID 稳定 ID 常量,供 composition root 引用。
 	TemplateID cardtmpl.ID = "docs.access-request"
-	// TemplateVersion 本模板当前版本。
-	TemplateVersion = "0.2.0"
+	// TemplateVersionV2 是 v2 交互档这一**具体版本**的稳定标识。需要指名 0.2.0
+	// 本身（而不是"当前版本"）的代码必须用它 —— 例如 notify.docsResultVersion 的
+	// 0.2.0→V3 result 升级分支：0.2.0 的 manifest 只声明 pending view，没有 result
+	// 可渲染，所以那条分支说的是 0.2.0 这个版本，不是"默认版本"。
+	TemplateVersionV2 = "0.2.0"
+	// TemplateVersion 本模板当前版本 —— 一个**会移动**的指针（它已经从 0.2.0 移到
+	// 过 0.3.0 又移回来）。只有真正想跟着默认版本走的代码才该用它；拿它去比较某个
+	// 历史版本，会在下次改版时静默变成永假分支。
+	TemplateVersion = TemplateVersionV2
 
 	// StatePending 是 v2 交互档视图 "pending" 承载的唯一状态。
 	// 本 PR 只注册 pending view;approved/rejected(result view)延后到 outcome PR。

--- a/pkg/cardtmpl/docs_access_request/v3.go
+++ b/pkg/cardtmpl/docs_access_request/v3.go
@@ -15,9 +15,23 @@ const (
 
 	StateApproved cardtmpl.State = "approved"
 	StateRejected cardtmpl.State = "rejected"
+	// StateCancelled is a request withdrawn or expired rather than decided, so
+	// it carries no `decision` block — the data contract requires one only for
+	// approved/rejected. It renders through the result view like the other two
+	// because a card that has been marked cannot be replaced by a frame built
+	// outside the Registry: the markers assert a template identity, and only a
+	// Registry render produces the metadata.octo.template they must agree with.
+	StateCancelled cardtmpl.State = "cancelled"
+	// StateUnavailable is the outcome for an action that reached no decision at
+	// all — the finalizer's catch-all, which previously rendered a plain
+	// resource card. It exists for the same reason StateCancelled does: the
+	// replacement for a marked card has to be a Registry render.
+	StateUnavailable cardtmpl.State = "unavailable"
 
-	VariantApproved = "docs.access_approved"
-	VariantRejected = "docs.access_denied"
+	VariantApproved    = "docs.access_approved"
+	VariantRejected    = "docs.access_denied"
+	VariantCancelled   = "docs.access_cancelled"
+	VariantUnavailable = "docs.access_unavailable"
 )
 
 type TemplateV3 struct {
@@ -90,7 +104,8 @@ func (t *TemplateV3) Build(ctx context.Context, state cardtmpl.State, fields jso
 			Body: body, Variant: Variant, DeepLink: deepLink, Source: &source,
 		}, nil
 	}
-	if state != StateApproved && state != StateRejected {
+	if state != StateApproved && state != StateRejected &&
+		state != StateCancelled && state != StateUnavailable {
 		return cardtmpl.BuildResult{}, fmt.Errorf("docs.access-request@0.3.0: unsupported state %q", state)
 	}
 	var input v3Fields
@@ -103,11 +118,22 @@ func (t *TemplateV3) Build(ctx context.Context, state cardtmpl.State, fields jso
 	}
 	labels := resultLabels(env.Lang, state == StateRejected)
 	variant := VariantApproved
-	if state == StateRejected {
+	switch state {
+	case StateRejected:
 		variant = VariantRejected
+	case StateCancelled:
+		labels, variant = cancelledLabels(env.Lang), VariantCancelled
+	case StateUnavailable:
+		labels, variant = unavailableLabels(env.Lang), VariantUnavailable
 	}
 	body, deepLink, err := cardtmpl.BuildDocsApprovalOutcomeV3BodyWithLang(env.Lang, env.WebLoginURL, docID, env.SpaceID, cardtmpl.DocsOutcomeContent{
-		Title: input.Document.Title, Variant: variant, Denied: state == StateRejected,
+		// Denied selects the L0 "not granted" treatment rather than the green
+		// approved one. Cancelled is not a denial, but the outcome builder
+		// carries a two-way flag and the honest half of it is that access was
+		// not granted; the wording comes from the labels above. Giving the base
+		// card a third treatment would change a shared L0 contract for a
+		// display nuance, which does not belong in this fix.
+		Title: input.Document.Title, Variant: variant, Denied: state != StateApproved,
 		HeaderLabel: labels.header, SourceName: input.Document.SourceName,
 		StatusLabel: labels.status, PermissionLabel: input.Permission.Label, ResultText: labels.result,
 		ReasonLabel: labels.reason, Reason: input.Decision.RejectionReason,
@@ -129,7 +155,8 @@ func (t *TemplateV3) FallbackText(state cardtmpl.State, fields json.RawMessage, 
 	if state == StatePending {
 		return New().FallbackText(state, fields, lang)
 	}
-	if state != StateApproved && state != StateRejected {
+	if state != StateApproved && state != StateRejected &&
+		state != StateCancelled && state != StateUnavailable {
 		return "", fmt.Errorf("docs.access-request@0.3.0: unsupported fallback state %q", state)
 	}
 	var input v3Fields
@@ -137,6 +164,12 @@ func (t *TemplateV3) FallbackText(state cardtmpl.State, fields json.RawMessage, 
 		return "", err
 	}
 	labels := resultLabels(lang, state == StateRejected)
+	switch state {
+	case StateCancelled:
+		labels = cancelledLabels(lang)
+	case StateUnavailable:
+		labels = unavailableLabels(lang)
+	}
 	return strings.TrimSpace(input.Document.Title) + " - " + labels.status, nil
 }
 
@@ -163,6 +196,37 @@ func (l resultLabelSet) banner(role string) string {
 		role = "viewer"
 	}
 	return "requested " + role + " access to this document."
+}
+
+// unavailableLabels describes an action that reached no decision at all — the
+// finalizer's catch-all when a route answers something other than a decision.
+func unavailableLabels(lang string) resultLabelSet {
+	if strings.EqualFold(lang, "zh-CN") || strings.HasPrefix(strings.ToLower(lang), "zh") {
+		return resultLabelSet{
+			header: "文档申请", status: "暂不可用", result: "本次访问申请暂时无法处理，权限未发生变更。",
+			reason: "拒绝原因", role: "申请人", requestReason: "申请原因", processedAt: "处理于", zh: true,
+		}
+	}
+	return resultLabelSet{
+		header: "Document access", status: "Unavailable", result: "The access request could not be processed; no permission changed.",
+		reason: "Reason", role: "Requester", requestReason: "Reason", processedAt: "Processed at",
+	}
+}
+
+// cancelledLabels describes a request that ended without a decision. It reuses
+// resultLabelSet so the outcome body needs no new shape; the reason row stays
+// empty because a cancelled request has no operator and no rejection reason.
+func cancelledLabels(lang string) resultLabelSet {
+	if strings.EqualFold(lang, "zh-CN") || strings.HasPrefix(strings.ToLower(lang), "zh") {
+		return resultLabelSet{
+			header: "文档申请", status: "已取消", result: "本次访问申请已取消，权限未发生变更。",
+			reason: "拒绝原因", role: "申请人", requestReason: "申请原因", processedAt: "处理于", zh: true,
+		}
+	}
+	return resultLabelSet{
+		header: "Document access", status: "Cancelled", result: "The access request was cancelled; no permission changed.",
+		reason: "Reason", role: "Requester", requestReason: "Reason", processedAt: "Processed at",
+	}
 }
 
 func resultLabels(lang string, denied bool) resultLabelSet {

--- a/pkg/cardtmpl/provenance.go
+++ b/pkg/cardtmpl/provenance.go
@@ -1,0 +1,35 @@
+package cardtmpl
+
+// PR-C D3（spec: .octospec/tasks/cardtmpl-runtime-catalog-grants-discovery/
+// brief.md）：stored server-authored provenance 与 catalog principal 的唯一
+// 桥接。wire 形状与 strict parse 在 pkg/cardmsg/provenance.go（信封权威层，
+// carddispatch 也要写标记而 cardtmpl 依赖 carddispatch，值对象放这里会成环）；
+// 本文件只做 typed principal 映射 —— historical_edit / action_context 的
+// principal 输入从此来自 stored marker，而不是 sender/owner 猜测。
+
+import (
+	"fmt"
+
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardmsg"
+)
+
+// CatalogPrincipalFromProvenance 把一个已存储的 wire marker 映射为 catalog
+// principal。marker 先过 strict Validate；wire principal 只有 bot 与
+// internal_producer 两种（space 是 discover-only grant principal、system 是
+// 内部保留值，都不可能出现在存储帧里），未知类型 fail-close。
+func CatalogPrincipalFromProvenance(provenance cardmsg.CatalogProvenance) (CatalogPrincipal, error) {
+	if err := provenance.Validate(); err != nil {
+		return CatalogPrincipal{}, err
+	}
+	var kind CatalogPrincipalKind
+	switch provenance.PrincipalType {
+	case cardmsg.CatalogPrincipalWireBot:
+		kind = CatalogPrincipalBot
+	case cardmsg.CatalogPrincipalWireInternalProducer:
+		kind = CatalogPrincipalInternalProducer
+	default:
+		return CatalogPrincipal{}, fmt.Errorf("%w: principal_type %q is not a catalog principal",
+			cardmsg.ErrCatalogMarkerInvalid, provenance.PrincipalType)
+	}
+	return CatalogPrincipal{Kind: kind, ID: provenance.PrincipalID, SpaceID: provenance.SpaceID}, nil
+}

--- a/pkg/cardtmpl/provenance_test.go
+++ b/pkg/cardtmpl/provenance_test.go
@@ -1,0 +1,80 @@
+package cardtmpl_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardmsg"
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl"
+)
+
+// Slice 1 RED (PR-C D3): the wire marker maps onto exactly one typed catalog
+// principal. Unknown or non-sendable wire principals must not become catalog
+// principals — the mapping is the only bridge between stored frames and
+// authorization input.
+func TestCatalogPrincipalFromProvenance(t *testing.T) {
+	cases := []struct {
+		name       string
+		provenance cardmsg.CatalogProvenance
+		want       cardtmpl.CatalogPrincipal
+		wantErr    bool
+	}{
+		{
+			name: "bot",
+			provenance: cardmsg.CatalogProvenance{
+				Version:       cardmsg.CatalogProvenanceVersion,
+				PrincipalType: cardmsg.CatalogPrincipalWireBot,
+				PrincipalID:   "bot-1", SpaceID: "space-1",
+			},
+			want: cardtmpl.CatalogPrincipal{
+				Kind: cardtmpl.CatalogPrincipalBot, ID: "bot-1", SpaceID: "space-1",
+			},
+		},
+		{
+			name: "internal producer with empty space",
+			provenance: cardmsg.CatalogProvenance{
+				Version:       cardmsg.CatalogProvenanceVersion,
+				PrincipalType: cardmsg.CatalogPrincipalWireInternalProducer,
+				PrincipalID:   "docs-notify",
+			},
+			want: cardtmpl.CatalogPrincipal{
+				Kind: cardtmpl.CatalogPrincipalInternalProducer, ID: "docs-notify",
+			},
+		},
+		{
+			name: "invalid marker never maps",
+			provenance: cardmsg.CatalogProvenance{
+				Version: 99, PrincipalType: cardmsg.CatalogPrincipalWireBot, PrincipalID: "bot-1",
+			},
+			wantErr: true,
+		},
+		{
+			name: "system is not a stored-frame principal",
+			provenance: cardmsg.CatalogProvenance{
+				Version:       cardmsg.CatalogProvenanceVersion,
+				PrincipalType: "system", PrincipalID: "readiness",
+			},
+			wantErr: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := cardtmpl.CatalogPrincipalFromProvenance(tc.provenance)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("mapped invalid provenance to %+v", got)
+				}
+				if !errors.Is(err, cardmsg.ErrCatalogMarkerInvalid) {
+					t.Fatalf("error = %v, want ErrCatalogMarkerInvalid", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("CatalogPrincipalFromProvenance: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("principal = %+v, want %+v", got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/cardtmpl/updater.go
+++ b/pkg/cardtmpl/updater.go
@@ -189,14 +189,24 @@ func storedMarkersForUpdate(envelope json.RawMessage, target UpdateTarget) (card
 	if err != nil {
 		return cardmsg.FrameCatalogMarkers{}, fmt.Errorf("%w: %v", ErrUpdateInvalid, err)
 	}
-	// An *empty* target Space never reaches here: validateUpdateTarget rejects
-	// one at the entry to both ReplaceView and Append, so by this point the
-	// caller has established a Space and a mismatch really is a mismatch. That
-	// is worth stating, because the neighbouring guards in bot_api and
-	// modules/message had to grow an explicit "unknown is not empty" state and
-	// this one looks like it is missing the same treatment. It is not — the
-	// distinction is enforced one layer up, and the click ingress refuses to
-	// create an event at all when the card's origin Space cannot be read.
+	// Two different Spaces are in play here and the guard only concerns one of
+	// them; an earlier version of this comment answered about the other, which
+	// is why it read as if the empty case were already handled.
+	//
+	//   - target.Target.SpaceID — never empty. validateUpdateTarget rejects an
+	//     empty one at the entry to both ReplaceView and Append, so by this
+	//     point the caller has established a Space and a mismatch really is a
+	//     mismatch. The neighbouring guards in bot_api and modules/message had
+	//     to grow an explicit "unknown is not empty" state; this one does not,
+	//     because the distinction is enforced one layer up and the click
+	//     ingress refuses to create an event at all when the card's origin
+	//     Space cannot be read.
+	//   - markers.Provenance.SpaceID — *can* be empty; it is a documented
+	//     reachable marker shape (pkg/cardmsg/provenance.go). The comparison
+	//     below deliberately skips that case rather than treating "" as a
+	//     mismatch against every target, because an unscoped marker is not a
+	//     cross-Space edit. updaterCatalogAccess is what resolves it, by
+	//     pinning the empty value to the target Space — see there.
 	if markers.HasProvenance && markers.Provenance.SpaceID != "" &&
 		markers.Provenance.SpaceID != target.Target.SpaceID {
 		return cardmsg.FrameCatalogMarkers{}, fmt.Errorf("%w: stored provenance space %q does not match target space %q",
@@ -229,6 +239,23 @@ func updaterCatalogAccess(target UpdateTarget, markers cardmsg.FrameCatalogMarke
 		principal, err := CatalogPrincipalFromProvenance(markers.Provenance)
 		if err != nil {
 			return CatalogAccess{}, fmt.Errorf("%w: %v", ErrUpdateInvalid, err)
+		}
+		// Pin an empty provenance Space to the authoritative target Space,
+		// exactly as the click ingress does (validatedFramePrincipal,
+		// modules/message/api_card_action.go). An empty space_id is a
+		// documented reachable marker shape, and storedMarkersForUpdate only
+		// compares the *non-empty* case — so without this the two readers of
+		// one marker derive two different principals from it.
+		//
+		// The difference is not cosmetic once grants exist: a principal with
+		// SpaceID "" resolves against the global grant row alone, so an active
+		// global grant plus an exact tombstone for the card's real Space would
+		// be allowed, which is the shadowing invariant 11 exists to prevent.
+		// Inert in this tree — nothing consumes Access on the static path — and
+		// it refuses more rather than less, so it is safe to land ahead of the
+		// grant machinery that makes it matter.
+		if principal.SpaceID == "" {
+			principal.SpaceID = target.Target.SpaceID
 		}
 		return CatalogAccess{Purpose: CatalogPurposeHistoricalEdit, Principal: principal}, nil
 	}

--- a/pkg/cardtmpl/updater.go
+++ b/pkg/cardtmpl/updater.go
@@ -57,8 +57,27 @@ func (u *updater) ReplaceView(ctx context.Context, target UpdateTarget, id ID, v
 	if id == "" || version == "" || env.SpaceID != target.Target.SpaceID {
 		return ErrUpdateInvalid
 	}
+	// PR-C D3/G13：先 Snapshot 生效帧，再做任何 authorization/render。stored
+	// server-authored 标记钉住 template identity / principal / Space —— 调用方
+	// 的 UpdateTarget 与 id@version 只有与 stored 一致才被接受，不能靠它们把
+	// 一张卡跨版本/跨身份/跨 Space 改写。
+	snapshot, err := u.mutator.Snapshot(ctx, mutationTarget(target))
+	if err != nil {
+		return err
+	}
+	markers, err := storedMarkersForUpdate(snapshot.Envelope, target)
+	if err != nil {
+		return err
+	}
+	if markers.HasRef && (markers.Ref.ID != string(id) || markers.Ref.Version != version) {
+		return fmt.Errorf("%w: stored template identity is %s@%s", ErrUpdateInvalid, markers.Ref.ID, markers.Ref.Version)
+	}
+	access, err := updaterCatalogAccess(target, markers)
+	if err != nil {
+		return err
+	}
 	meta, err := u.catalog.MetaExact(ctx, CatalogExactRequest{
-		Access: updaterCatalogAccess(target), ID: id, Version: version,
+		Access: access, ID: id, Version: version,
 	})
 	if err != nil {
 		return err
@@ -71,13 +90,13 @@ func (u *updater) ReplaceView(ctx context.Context, target UpdateTarget, id ID, v
 		recordUpdate(meta.ID, meta.Version, result)
 	}()
 	document, profile, renderProfile, err := RenderCatalogCardWithProfiles(ctx, u.catalog, CatalogRenderRequest{
-		Access: updaterCatalogAccess(target), ID: id, Version: version,
+		Access: access, ID: id, Version: version,
 		State: state, Fields: fields, Env: env,
 	})
 	if err != nil {
 		return err
 	}
-	contentEdit, err := updateEnvelope(document, profile, renderProfile, target.Target.SpaceID, target.CardSeq)
+	contentEdit, err := updateEnvelope(document, profile, renderProfile, target.Target.SpaceID, target.CardSeq, markers)
 	if err != nil {
 		return err
 	}
@@ -112,9 +131,19 @@ func (u *updater) Append(ctx context.Context, target UpdateTarget, element json.
 	if snapshot.CardSeq < 0 || target.CardSeq-1 != snapshot.CardSeq {
 		return carddispatch.ErrCardMutationConflict
 	}
+	// PR-C D3：stored 标记畸形即篡改信号 fail-close；provenance 存在时它是
+	// edit principal 的唯一来源（re-marshal 会原样保留两个顶层标记）。
+	markers, err := storedMarkersForUpdate(snapshot.Envelope, target)
+	if err != nil {
+		return err
+	}
+	access, err := updaterCatalogAccess(target, markers)
+	if err != nil {
+		return err
+	}
 	if template, ok := cardmsg.CardTemplateContext(snapshot.Envelope); ok {
 		meta, lookupErr := u.catalog.MetaExact(ctx, CatalogExactRequest{
-			Access: updaterCatalogAccess(target), ID: ID(template.ID), Version: template.Version,
+			Access: access, ID: ID(template.ID), Version: template.Version,
 		})
 		if lookupErr != nil && !errors.Is(lookupErr, ErrTemplateUnknown) {
 			return lookupErr
@@ -152,13 +181,63 @@ func (u *updater) Append(ctx context.Context, target UpdateTarget, element json.
 	return err
 }
 
-func updaterCatalogAccess(target UpdateTarget) CatalogAccess {
+// storedMarkersForUpdate 从生效帧提取 catalog 标记并做 update 边界校验：
+// 畸形标记 fail-close；stored provenance 声明的 Space 非空时必须与权威
+// UpdateTarget Space 一致 —— 跨 Space 的 mutation 在 render 前拒绝。
+func storedMarkersForUpdate(envelope json.RawMessage, target UpdateTarget) (cardmsg.FrameCatalogMarkers, error) {
+	markers, err := cardmsg.CatalogFrameMarkers(envelope)
+	if err != nil {
+		return cardmsg.FrameCatalogMarkers{}, fmt.Errorf("%w: %v", ErrUpdateInvalid, err)
+	}
+	// An *empty* target Space never reaches here: validateUpdateTarget rejects
+	// one at the entry to both ReplaceView and Append, so by this point the
+	// caller has established a Space and a mismatch really is a mismatch. That
+	// is worth stating, because the neighbouring guards in bot_api and
+	// modules/message had to grow an explicit "unknown is not empty" state and
+	// this one looks like it is missing the same treatment. It is not — the
+	// distinction is enforced one layer up, and the click ingress refuses to
+	// create an event at all when the card's origin Space cannot be read.
+	if markers.HasProvenance && markers.Provenance.SpaceID != "" &&
+		markers.Provenance.SpaceID != target.Target.SpaceID {
+		return cardmsg.FrameCatalogMarkers{}, fmt.Errorf("%w: stored provenance space %q does not match target space %q",
+			ErrUpdateInvalid, markers.Provenance.SpaceID, target.Target.SpaceID)
+	}
+	return markers, nil
+}
+
+// updaterCatalogAccess 构造 historical_edit 的 catalog access。stored
+// provenance 存在时它是 principal 的唯一来源（D3：不从 sender 反推）；
+// legacy 无标记帧保留既有 sender 派生口径（static 历史兼容，invariant 7）。
+//
+// Review asked whether this fallback needs the same scoping the action ingress
+// just grew — refuse a markerless frame that names a version only the runtime
+// catalog knows. It does not, and the difference is the threat model rather
+// than the shape. At the action ingress the template identity comes from
+// `card.metadata.octo`, inside a card body a raw caller controls, and the
+// derived principal is the *sending Bot's own* grant identity, so a fabricated
+// frame turns an `edit` grant into a substitute for `send`. Here the identity
+// is the caller's own `target.SenderUID`, every caller is an in-process
+// internal producer, and `Snapshot` has already proven that sender owns the
+// stored message. There is no path by which a request supplies it.
+//
+// Adding the check anyway would mean threading a Registry through
+// NewCardUpdater purely to guard a hole nothing can reach, and it would refuse
+// legitimate edits of pre-PR-C frames in any deployment whose default Registry
+// is not the one the updater was built over. Recorded rather than done.
+func updaterCatalogAccess(target UpdateTarget, markers cardmsg.FrameCatalogMarkers) (CatalogAccess, error) {
+	if markers.HasProvenance {
+		principal, err := CatalogPrincipalFromProvenance(markers.Provenance)
+		if err != nil {
+			return CatalogAccess{}, fmt.Errorf("%w: %v", ErrUpdateInvalid, err)
+		}
+		return CatalogAccess{Purpose: CatalogPurposeHistoricalEdit, Principal: principal}, nil
+	}
 	return CatalogAccess{
 		Purpose: CatalogPurposeHistoricalEdit,
 		Principal: CatalogPrincipal{
 			Kind: CatalogPrincipalInternalProducer, ID: target.SenderUID, SpaceID: target.Target.SpaceID,
 		},
-	}
+	}, nil
 }
 
 func validateUpdateTarget(ctx context.Context, target UpdateTarget) error {
@@ -183,7 +262,8 @@ func mutationRequest(target UpdateTarget, contentEdit string) carddispatch.CardM
 	}
 }
 
-func updateEnvelope(document json.RawMessage, profile, renderProfile, spaceID string, cardSeq int64) (string, error) {
+func updateEnvelope(document json.RawMessage, profile, renderProfile, spaceID string, cardSeq int64,
+	markers cardmsg.FrameCatalogMarkers) (string, error) {
 	var card map[string]interface{}
 	if err := json.Unmarshal(document, &card); err != nil || card == nil {
 		return "", fmt.Errorf("%w: decode rendered card", ErrUpdateInvalid)
@@ -194,6 +274,16 @@ func updateEnvelope(document json.RawMessage, profile, renderProfile, spaceID st
 	}
 	if renderProfile != "" {
 		envelope["render_profile"] = renderProfile
+	}
+	// PR-C D3：stored 标记原样保留到替换帧 —— identity/principal/Space 在
+	// mutation 中不可变；legacy 无标记帧不凭空长出标记（principal 会是猜测）。
+	if markers.HasRef {
+		envelope[cardmsg.CatalogTemplateRefKey] = map[string]interface{}{
+			"id": markers.Ref.ID, "version": markers.Ref.Version,
+		}
+	}
+	if markers.HasProvenance {
+		envelope[cardmsg.CatalogProvenanceKey] = markers.Provenance.MarshalMap()
 	}
 	raw, err := json.Marshal(envelope)
 	if err != nil {

--- a/pkg/cardtmpl/updater_test.go
+++ b/pkg/cardtmpl/updater_test.go
@@ -511,3 +511,41 @@ func TestCardUpdaterAppendValidatesStoredMarkers(t *testing.T) {
 		}
 	})
 }
+
+// An unscoped provenance marker (`space_id: ""`) is a documented reachable
+// shape, and the two readers of that marker have to derive the same principal
+// from it. The click ingress pins the empty value to the card's authoritative
+// origin Space (validatedFramePrincipal); this path pins it to the equally
+// authoritative UpdateTarget Space.
+//
+// The asymmetry it replaces was invisible in this tree — nothing consumes
+// Access on the static path — and becomes an authorization defect the moment
+// grants land: a principal carrying SpaceID "" resolves against the global
+// grant row alone, so an active global grant plus an exact tombstone for the
+// card's real Space would be allowed, which is precisely the shadowing that
+// invariant 11 exists to prevent.
+func TestCardUpdaterPinsAnUnscopedProvenanceToTheTargetSpace(t *testing.T) {
+	snapshot := markedV3Snapshot(t, func(frame map[string]any) {
+		provenance, _ := frame["catalog_provenance"].(map[string]any)
+		provenance["space_id"] = ""
+	})
+	catalog, _, updater := v3UpdaterFixture(t, snapshot)
+	target := v3UpdateTarget()
+
+	if err := updater.ReplaceView(context.Background(), target, docsaccessrequest.TemplateID,
+		docsaccessrequest.TemplateVersionV3, docsaccessrequest.StateApproved, approvedV3Fields(),
+		cardtmpl.BuildEnv{WebLoginURL: "https://web.example.com", Lang: "en", SpaceID: "space-1"}); err != nil {
+		t.Fatalf("ReplaceView refused an unscoped marker, which is a legitimate stored shape: %v", err)
+	}
+	if len(catalog.renderAccess) == 0 {
+		t.Fatal("render was never reached")
+	}
+	want := cardtmpl.CatalogPrincipal{
+		Kind: cardtmpl.CatalogPrincipalInternalProducer, ID: "docs-notify", SpaceID: target.Target.SpaceID,
+	}
+	if got := catalog.renderAccess[0].Principal; got != want {
+		t.Fatalf("edit principal = %+v, want %+v; an unscoped principal resolves against the global "+
+			"grant row alone, so an exact tombstone for %q could no longer shadow a live global grant",
+			got, want, target.Target.SpaceID)
+	}
+}

--- a/pkg/cardtmpl/updater_test.go
+++ b/pkg/cardtmpl/updater_test.go
@@ -276,3 +276,238 @@ func assertUpdateEnvelope(t *testing.T, raw string, seq int64, profile, renderPr
 		t.Fatalf("template.version = %v, want %q", template["version"], version)
 	}
 }
+
+// ---- PR-C Slice 1 (D3/G13): stored catalog markers pin identity, principal
+// and Space through every mutation. ----
+
+type accessCaptureCatalog struct {
+	cardtmpl.Catalog
+	metaAccess   []cardtmpl.CatalogAccess
+	renderAccess []cardtmpl.CatalogAccess
+}
+
+func (c *accessCaptureCatalog) MetaExact(ctx context.Context, request cardtmpl.CatalogExactRequest) (cardtmpl.TemplateMeta, error) {
+	c.metaAccess = append(c.metaAccess, request.Access)
+	return c.Catalog.MetaExact(ctx, request)
+}
+
+func (c *accessCaptureCatalog) Render(ctx context.Context, request cardtmpl.CatalogRenderRequest) (map[string]any, error) {
+	c.renderAccess = append(c.renderAccess, request.Access)
+	return c.Catalog.Render(ctx, request)
+}
+
+func markedV3Snapshot(t *testing.T, mutate func(map[string]any)) json.RawMessage {
+	t.Helper()
+	frame := map[string]any{
+		"type": 17, "card_version": cardmsg.CardVersion, "profile": cardmsg.ProfileV2,
+		"space_id": "space-1", "card_seq": 4,
+		"template_ref": map[string]any{
+			"id": string(docsaccessrequest.TemplateID), "version": docsaccessrequest.TemplateVersionV3,
+		},
+		"catalog_provenance": map[string]any{
+			"version": 1, "principal_type": "internal_producer",
+			"principal_id": "docs-notify", "space_id": "space-1",
+		},
+		"card": map[string]any{
+			"type": "AdaptiveCard", "version": cardmsg.CardVersion,
+			"body": []any{map[string]any{"type": "TextBlock", "text": "pending"}},
+			"metadata": map[string]any{"octo": map[string]any{
+				"protocol": cardtmpl.Protocol,
+				"template": map[string]any{
+					"id": string(docsaccessrequest.TemplateID), "version": docsaccessrequest.TemplateVersionV3,
+				},
+			}},
+		},
+	}
+	if mutate != nil {
+		mutate(frame)
+	}
+	raw, err := json.Marshal(frame)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return raw
+}
+
+func v3UpdaterFixture(t *testing.T, snapshot json.RawMessage) (*accessCaptureCatalog, *captureMutationGateway, cardtmpl.CardUpdater) {
+	t.Helper()
+	r := cardtmpl.NewRegistry()
+	r.Register(docsaccessrequest.NewV3(), docsaccessrequest.Assets, docsaccessrequest.HandoffRootV3)
+	r.SetDefault(docsaccessrequest.TemplateID, docsaccessrequest.TemplateVersionV3)
+	r.Freeze()
+	catalog := &accessCaptureCatalog{Catalog: staticCatalog(t, r)}
+	gateway := &captureMutationGateway{
+		snapshot: carddispatch.CardMutationSnapshot{Envelope: snapshot, CardSeq: 4},
+		result:   carddispatch.CardMutationResult{Applied: true},
+	}
+	updater, err := cardtmpl.NewCardUpdater(catalog, gateway)
+	if err != nil {
+		t.Fatalf("NewCardUpdater: %v", err)
+	}
+	return catalog, gateway, updater
+}
+
+func approvedV3Fields() json.RawMessage {
+	return json.RawMessage(`{
+		"requestId":"request-1","state":"approved",
+		"document":{"docId":"doc-1","title":"Roadmap"},
+		"requester":{"name":"Alice"},"decision":{"operatorName":"Bob"}
+	}`)
+}
+
+func v3UpdateTarget() cardtmpl.UpdateTarget {
+	return cardtmpl.UpdateTarget{
+		Target:    carddispatch.Target{SpaceID: "space-1", ChannelID: "user-b", ChannelType: 1},
+		SenderUID: "notification", MessageID: "1001", MessageSeq: 7, CardSeq: 42,
+	}
+}
+
+func TestCardUpdaterReplaceViewPreservesStoredCatalogMarkers(t *testing.T) {
+	catalog, gateway, updater := v3UpdaterFixture(t, markedV3Snapshot(t, nil))
+	if err := updater.ReplaceView(context.Background(), v3UpdateTarget(), docsaccessrequest.TemplateID,
+		docsaccessrequest.TemplateVersionV3, docsaccessrequest.StateApproved, approvedV3Fields(),
+		cardtmpl.BuildEnv{WebLoginURL: "https://web.example.com", Lang: "en", SpaceID: "space-1"}); err != nil {
+		t.Fatalf("ReplaceView: %v", err)
+	}
+	if len(gateway.requests) != 1 {
+		t.Fatalf("mutation count = %d", len(gateway.requests))
+	}
+	var envelope map[string]any
+	if err := json.Unmarshal([]byte(gateway.requests[0].ContentEdit), &envelope); err != nil {
+		t.Fatal(err)
+	}
+	ref, _ := envelope["template_ref"].(map[string]any)
+	if ref == nil || ref["id"] != string(docsaccessrequest.TemplateID) || ref["version"] != docsaccessrequest.TemplateVersionV3 {
+		t.Fatalf("replacement frame lost template_ref: %#v", envelope["template_ref"])
+	}
+	provenance, _ := envelope["catalog_provenance"].(map[string]any)
+	if provenance == nil || provenance["principal_type"] != "internal_producer" ||
+		provenance["principal_id"] != "docs-notify" || provenance["space_id"] != "space-1" {
+		t.Fatalf("replacement frame lost catalog_provenance: %#v", envelope["catalog_provenance"])
+	}
+	// The stored provenance — not the SenderUID guess — is the edit principal.
+	want := cardtmpl.CatalogPrincipal{
+		Kind: cardtmpl.CatalogPrincipalInternalProducer, ID: "docs-notify", SpaceID: "space-1",
+	}
+	if len(catalog.renderAccess) == 0 || catalog.renderAccess[0].Principal != want {
+		t.Fatalf("render access = %+v, want principal %+v", catalog.renderAccess, want)
+	}
+	if catalog.renderAccess[0].Purpose != cardtmpl.CatalogPurposeHistoricalEdit {
+		t.Fatalf("render purpose = %v", catalog.renderAccess[0].Purpose)
+	}
+}
+
+func TestCardUpdaterReplaceViewRejectsStoredIdentityMismatch(t *testing.T) {
+	_, gateway, updater := v3UpdaterFixture(t, markedV3Snapshot(t, nil))
+	err := updater.ReplaceView(context.Background(), v3UpdateTarget(), docsaccessrequest.TemplateID,
+		"9.9.9", docsaccessrequest.StateApproved, approvedV3Fields(),
+		cardtmpl.BuildEnv{WebLoginURL: "https://web.example.com", Lang: "en", SpaceID: "space-1"})
+	if !errors.Is(err, cardtmpl.ErrUpdateInvalid) {
+		t.Fatalf("ReplaceView(version drift) error = %v, want ErrUpdateInvalid", err)
+	}
+	if len(gateway.requests) != 0 {
+		t.Fatalf("identity drift still mutated: %+v", gateway.requests)
+	}
+}
+
+func TestCardUpdaterReplaceViewRejectsMalformedStoredMarkers(t *testing.T) {
+	snapshot := markedV3Snapshot(t, func(frame map[string]any) {
+		delete(frame, "template_ref") // provenance without ref is never a server shape
+	})
+	_, gateway, updater := v3UpdaterFixture(t, snapshot)
+	err := updater.ReplaceView(context.Background(), v3UpdateTarget(), docsaccessrequest.TemplateID,
+		docsaccessrequest.TemplateVersionV3, docsaccessrequest.StateApproved, approvedV3Fields(),
+		cardtmpl.BuildEnv{WebLoginURL: "https://web.example.com", Lang: "en", SpaceID: "space-1"})
+	if !errors.Is(err, cardtmpl.ErrUpdateInvalid) {
+		t.Fatalf("ReplaceView(malformed markers) error = %v, want ErrUpdateInvalid", err)
+	}
+	if len(gateway.requests) != 0 {
+		t.Fatalf("malformed markers still mutated: %+v", gateway.requests)
+	}
+}
+
+func TestCardUpdaterReplaceViewRejectsCrossSpaceStoredProvenance(t *testing.T) {
+	snapshot := markedV3Snapshot(t, func(frame map[string]any) {
+		frame["catalog_provenance"].(map[string]any)["space_id"] = "space-2"
+	})
+	_, gateway, updater := v3UpdaterFixture(t, snapshot)
+	err := updater.ReplaceView(context.Background(), v3UpdateTarget(), docsaccessrequest.TemplateID,
+		docsaccessrequest.TemplateVersionV3, docsaccessrequest.StateApproved, approvedV3Fields(),
+		cardtmpl.BuildEnv{WebLoginURL: "https://web.example.com", Lang: "en", SpaceID: "space-1"})
+	if !errors.Is(err, cardtmpl.ErrUpdateInvalid) {
+		t.Fatalf("ReplaceView(cross-space provenance) error = %v, want ErrUpdateInvalid", err)
+	}
+	if len(gateway.requests) != 0 {
+		t.Fatalf("cross-space provenance still mutated: %+v", gateway.requests)
+	}
+}
+
+func TestCardUpdaterReplaceViewLegacyFrameStaysUnmarked(t *testing.T) {
+	snapshot := markedV3Snapshot(t, func(frame map[string]any) {
+		delete(frame, "template_ref")
+		delete(frame, "catalog_provenance")
+	})
+	catalog, gateway, updater := v3UpdaterFixture(t, snapshot)
+	if err := updater.ReplaceView(context.Background(), v3UpdateTarget(), docsaccessrequest.TemplateID,
+		docsaccessrequest.TemplateVersionV3, docsaccessrequest.StateApproved, approvedV3Fields(),
+		cardtmpl.BuildEnv{WebLoginURL: "https://web.example.com", Lang: "en", SpaceID: "space-1"}); err != nil {
+		t.Fatalf("ReplaceView(legacy frame): %v", err)
+	}
+	var envelope map[string]any
+	if err := json.Unmarshal([]byte(gateway.requests[0].ContentEdit), &envelope); err != nil {
+		t.Fatal(err)
+	}
+	if _, forged := envelope["template_ref"]; forged {
+		t.Fatalf("legacy replacement grew template_ref: %#v", envelope["template_ref"])
+	}
+	if _, forged := envelope["catalog_provenance"]; forged {
+		t.Fatalf("legacy replacement grew catalog_provenance: %#v", envelope["catalog_provenance"])
+	}
+	// Without stored provenance the legacy sender-derived principal remains.
+	want := cardtmpl.CatalogPrincipal{
+		Kind: cardtmpl.CatalogPrincipalInternalProducer, ID: "notification", SpaceID: "space-1",
+	}
+	if len(catalog.renderAccess) == 0 || catalog.renderAccess[0].Principal != want {
+		t.Fatalf("legacy render access = %+v, want principal %+v", catalog.renderAccess, want)
+	}
+}
+
+func TestCardUpdaterAppendValidatesStoredMarkers(t *testing.T) {
+	t.Run("markers preserved and provenance principal used", func(t *testing.T) {
+		catalog, gateway, updater := v3UpdaterFixture(t, markedV3Snapshot(t, nil))
+		target := v3UpdateTarget()
+		target.CardSeq = 5
+		if err := updater.Append(context.Background(), target, json.RawMessage(`{"type":"TextBlock","text":"after"}`)); err != nil {
+			t.Fatalf("Append: %v", err)
+		}
+		var envelope map[string]any
+		if err := json.Unmarshal([]byte(gateway.requests[0].ContentEdit), &envelope); err != nil {
+			t.Fatal(err)
+		}
+		provenance, _ := envelope["catalog_provenance"].(map[string]any)
+		if provenance == nil || provenance["principal_id"] != "docs-notify" {
+			t.Fatalf("append frame lost catalog_provenance: %#v", envelope["catalog_provenance"])
+		}
+		want := cardtmpl.CatalogPrincipal{
+			Kind: cardtmpl.CatalogPrincipalInternalProducer, ID: "docs-notify", SpaceID: "space-1",
+		}
+		if len(catalog.metaAccess) == 0 || catalog.metaAccess[0].Principal != want {
+			t.Fatalf("append meta access = %+v, want principal %+v", catalog.metaAccess, want)
+		}
+	})
+	t.Run("malformed markers fail closed", func(t *testing.T) {
+		snapshot := markedV3Snapshot(t, func(frame map[string]any) {
+			frame["catalog_provenance"] = "forged"
+		})
+		_, gateway, updater := v3UpdaterFixture(t, snapshot)
+		target := v3UpdateTarget()
+		target.CardSeq = 5
+		err := updater.Append(context.Background(), target, json.RawMessage(`{"type":"TextBlock","text":"after"}`))
+		if !errors.Is(err, cardtmpl.ErrUpdateInvalid) {
+			t.Fatalf("Append(malformed markers) error = %v, want ErrUpdateInvalid", err)
+		}
+		if len(gateway.requests) != 0 {
+			t.Fatalf("malformed markers still mutated: %+v", gateway.requests)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

This is **the ungated half of #705**, split out for review. #705 is now a draft and will be rebased onto this branch once it lands.

The split is not a scope change. It exists because the two halves need different merge arguments, and mixing them meant #705 could not honestly make either one:

- **This PR takes effect on merge.** It sits behind the pre-existing `OCTO_CARD_MESSAGE_ENABLED` switch — *not* behind either runtime-catalog gate. Wherever cards are already on, merging changes stored bytes and changes behaviour on two historical-card paths, plus one thread-creation path. That deserves line-by-line review, and it is ~4k lines rather than 16k.
- **What stays in #705 is inert on merge.** Grants, one-snapshot authorization, discovery/export and the pilot are all behind `OCTO_CARD_RUNTIME_CATALOG_CONTROL_ENABLED` / `_NEW_SEND_ENABLED`, both default false.

A dynamic card frame carries two server-authored top-level markers, `template_ref` and `catalog_provenance`, so historical edit and action-context read the producer from the frame instead of inferring it from `msg.FromUID`.

## Related Issue

Roadmap E3 PR-C (D3). Split out of #705; no separate tracking issue.

## Linked Spec

- [`.octospec/tasks/cardtmpl-provenance-markers/brief.md`](.octospec/tasks/cardtmpl-provenance-markers/brief.md) — this slice's scope, out-of-scope and acceptance.
- Contract of record for D3: the parent [`cardtmpl-runtime-catalog-grants-discovery/brief.md`](.octospec/tasks/cardtmpl-runtime-catalog-grants-discovery/brief.md), which stays with #705.

## Changes

Three properties hold the trust boundary. Each is enforced where it cannot be bypassed, rather than at each site that could violate it.

- **A marker cannot be authored invalid.** Both authoring boundaries validate before stamping. `cardmsg.Validate`'s marker hook runs *before* the keys exist and `Finalize` does not re-check, so the authoring site is the last point that can refuse. The readers are strict where the writers were not — `ParseCatalogProvenance` requires a trimmed `space_id` while the ingress gate tested only emptiness — so an untrimmed target Space produced a stored frame every reader rejects: the card rendered, and then every click and every edit failed permanently, with no way to repair the message.
- **A marker cannot be forged.** The invariant is that *no marker any reader will honour can come from external input*. The five ingresses do not all achieve it the same way, and an earlier revision of this description said they did — which is what hid a real gap for three rounds. Bot **raw send** rejects `catalog_provenance` by key (a top-level `template_ref` there is not rejected; it selects template mode, where the ref is checked against the bot's permitted refs and the server re-authors both markers). Bot **raw edit** rejects both keys in both directions. **Robot ingress** rejects either key. The **incoming webhook** builds its envelope from a fixed field allowlist, so caller keys never reach the top level — it does not reject the request for carrying them. The **thread source-message copy** refuses type-17 payloads outright. **User send/edit** never reaches the question: cards are refused as a message type. The per-ingress enumeration is normative in the brief's Acceptance section.
- **A marker cannot be dropped, or silently rewritten.** The rule lives in one place, `cardmsg.CatalogMarkersPreserved`, and the mutation boundary applies it to every replacement: losing a marker is refused, *acquiring* one on a pre-PR-C frame is allowed, and changing a value where both sides carry one is refused. Deciding preservation per call site is what let an ordinary user click erase markers — the docs finalizer chose its replacement route by *state*, and any state outside the decided pair fell through to a six-key rebuild carrying neither. Both identity guards in `pkg/cardtmpl/updater.go` begin `if markers.Has…`, so they went inert for that message.
- The finalizer route now turns on whether an updater exists, so **every** state renders through the Registry. `docs.access-request@0.3.0` declares `cancelled` and `unavailable`, the two outcomes the pre-Registry fallback already displayed.
- The three card ingresses reject an untrimmed `space_id` up front instead of fanning out and returning HTTP 200 with every target failed as `card_invalid`. This is validation, not normalisation — the value is never rewritten, because trimming it silently would deliver the card into a Space the caller did not name.
- An **unscoped** provenance marker (`space_id: ""`, a documented reachable shape) is now pinned to the authoritative target Space at the historical-edit boundary, matching what the click ingress already did. One marker had two readers deriving two different principals from it; inert here, an authorization defect once #705's grants land.
- `docs/card-protocol.md` documents the marker compatibility matrix: both absent is a legacy frame; `template_ref` alone is a pre-PR-C Registry frame; both present are strictly validated against `card.metadata.octo.template`; `catalog_provenance` alone is refused.

## Behaviour change worth an owner's attention

**A thread created from a card message no longer copies a first message.** The copy path persists caller-supplied bytes under the *source message's* sender and never checks the id against the payload, so for a card it is a way to send a card as another user — which the user ingress bans outright. Stripping the two top-level keys narrows that without closing it, because the identity the action route falls back to is `card.metadata.octo.template`, inside the card body the caller controls. Refusing type-17 closes it. The thread is still created; `source_message_id` is simply not announced, so nothing claims a first message that does not exist.

Owner: whoever owns `modules/thread` should confirm the product is willing to lose the card preview on that flow. The alternative — authorizing the copy through the same five visibility gates a single-message read applies — is a larger change than this slice.

## Testing

```bash
go build ./...
go vet ./...
go test ./pkg/... ./internal/... -count=1
go test ./modules/notify/ ./modules/bot_api/ ./modules/message/ ./modules/incomingwebhook/ ./modules/thread/ -count=1
OCTO_MASTER_KEY=<32 bytes> go test ./modules/robot/ -count=1
go test -race -shuffle=on ./pkg/cardtmpl/... ./pkg/cardmsg/... ./internal/carddispatch/... ./internal/cardactiondispatch/...
golangci-lint run ./pkg/cardmsg/... ./pkg/cardtmpl/... ./internal/... ./modules/notify/... ./modules/message/... ./modules/robot/... ./modules/bot_api/... ./modules/thread/...
make i18n-extract-check && make i18n-lint
```

All green against MySQL 8.0 + Redis + WuKongIM; `golangci-lint` reports 0 issues.

Three notes for reviewers running this locally: each package needs a **fresh** `test` schema (module sets differ, so two packages sharing one make sql-migrate report "unknown migration in database" — and running two packages in a single `go test` invocation reproduces exactly that); create it with the collation CI uses — `CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci`, since the MySQL 8.0 default `utf8mb4_0900_ai_ci` differs in PAD behaviour and that is load-bearing for one of the changes below; and `modules/robot` needs a 32-byte `OCTO_MASTER_KEY`.

- [x] Unit tests added/updated
- [x] Manually verified

## COMPREHENSION

**1. What does this change actually do to the load-bearing path?**

It replaces a guess with a fact. A stored frame's producer identity used to be inferred from `msg.FromUID` at read time; it is now a server-authored marker written at the rendering boundary and validated against the stored sender before it becomes authorization input. Two guards in `pkg/cardtmpl/updater.go` — the stored-version pin and the cross-Space refusal — read that marker, which is why the marker's integrity, not its presence, is the load-bearing property.

The enforcement points moved deliberately. Authoring validates at the boundary rather than trusting callers to pass trimmed input; preservation is enforced at `CardMutator.Mutate` rather than in each helper that builds a replacement frame; and the thread notification's consistency is decided inside the payload builder rather than at its one call site. Every defect found in review was a call site that did not honour a rule stated somewhere else.

**2. What could break because of it (dependents + failure mode)?**

Everything here is live on merge wherever `OCTO_CARD_MESSAGE_ENABLED` is on. Five things change:

1. **Stored bytes change.** Every internal-producer card whose document carries `metadata.octo.template` gains the two top-level keys. The protocol tolerates unknown top-level fields, but the persisted frame is no longer byte-identical, and this reaches every client — worth one manual check against iOS / Android / web. The protocol tolerating unknown fields is a statement about the server, not about the clients.
2. **Historical Registry cards stay editable, but only because of an asymmetry that is easy to get wrong.** Every Bot Registry card already in storage carries `template_ref` alone, because the previous authoring boundary stamped only that. An edit authors provenance, so the replacement has one marker more than the stored frame. A preservation rule written as an equality check refuses exactly that, and since an edit is the only moment such a frame can gain a marker, the refusal is permanent with no repair path — `ai.reasoning-process` is a progressively edited streaming card, so a card sent shortly before a deploy and edited shortly after would freeze at its partial state. `CatalogMarkersPreserved` refuses only a loss. This shipped broken in an earlier revision of this branch and is fixed in `65d2782`.
3. **In-flight `docs.access-request@0.2.0` cards keep finalizing.** Resolving the result version from the stored card context rather than a hardcoded V3 initially refused 0.2.0, on the reasoning that a *marked* 0.2.0 frame cannot exist. True, but the identity is read from `card.metadata.octo.template`, which unmarked pre-PR-C frames carry too — so the refusal landed on the legacy population it argued was unreachable. 0.2.0 was the shipped registry default between #633 and #641, so those cards exist; a click on one failed finalization and left it pending forever. The documented upgrade to the V3 result view (`main.go:813`) is restored in `fdb6a8e`, and the branch now keys off `TemplateVersionV2` rather than the moving default pointer, so a future version bump cannot silently reopen it.
4. **A send that used to succeed can now fail.** A `space_id` with surrounding whitespace is rejected — now at the ingress with one accurate 400, and at the authoring boundary as the backstop. That is the intended trade: the alternative is delivering a card whose markers no reader accepts, which cannot be clicked or edited and cannot be repaired. Whether that input was ever reachable depends on a collation the application does not choose — `space_member` declares none and inherits the database default. Measured both ways on MySQL 8.0.46: `utf8mb4_general_ci` is PAD SPACE and `'space-a '` matches `'space-a'`; the server default `utf8mb4_0900_ai_ci` is NO PAD and does not. CI creates its database `general_ci`, and 40 of 188 migrations pin it explicitly, so the reachable case is the one that ships.
5. **A thread created from a card message loses its first message.** See the section above. `source_message_id` is still written to the `thread` row — that field records what the thread was created *from* — but the parent-group notification omits it when nothing was copied, so no client is told to follow an id into an empty thread. That split is deliberate and recorded in the brief.

One latent case is pinned rather than fixed: `StandardActionFinalizer` is the default finalizer for every non-docs owner and routes every state through the marker-less rebuild. It is harmless today only because `BuildApprovalRequestCard` writes no template metadata, so its cards are never marked. The day a non-docs owner's card becomes a Registry render, the mutation boundary refuses the finalize rather than silently downgrading it — a visible failure instead of an invisible one, and a test asserts that so it cannot change unnoticed.

**3. How do you know it works (specific test/repro/trace)?**

Each property has a test that reproduces the reported failure with its fix reverted, mutation-checked so it cannot pass for the wrong reason:

- `TestSendRefusesToAuthorAMarkerItsReadersWouldReject` — deleting the `provenance.Validate()` block makes it fail; the untrimmed Space then reaches the transport.
- `TestCardMutatorMarkerRuleCoversEveryStoredFrameShape` — one case per frame shape reachable in production (legacy, `template_ref`-only pre-PR-C, both-marker), from a fixture built to match pre-PR-C stored bytes rather than current-send-path bytes. Restoring the equality comparison fails the acquire case with the exact production error.
- `TestCardMutatorRefusesToRewriteStoredMarkerValues` — presence-only comparison lets a replacement keep both keys and rewrite `principal_id` or `space_id`; no in-tree caller reaches it, which is why it needs its own test.
- `TestDocsActionFinalizerRoutesEveryStateThroughTheRegistry` — restoring the state allowlist fails the `pending` row with the legacy frame in the output.
- `TestDocsAccessRequestV3RendersTheNonDecisionStates` — undeclaring either new state in the manifest fails it with `ErrStateUnknown`. It exists because mutation testing showed the finalizer tests drive a capturing fake that never reaches `ViewFor`.
- `TestDocsResultVersionRules` — restoring the 0.2.0 refusal fails both the upgrade case and the metadata-only legacy frame.
- `TestCardIngressRejectsAnUntrimmedSpaceBeforeFanout` — the ingress predicate, over six inputs.
- `TestCardUpdaterPinsAnUnscopedProvenanceToTheTargetSpace` — deleting the pin yields a principal with `SpaceID: ""`, which resolves against the global grant row alone.
- `TestSourceMessageCopyRefusesCards` and `TestThreadCreatedNotificationOmitsTheSourceWhenNothingWasCopied` — the second feeds the inconsistent state (a named source with nothing copied); dropping the builder guard fails it with the announced-but-absent id.

Two findings in review lived in the seam between two suites: the handler suite stubbed the mutator, the mutator suite hand-built replacements, and the interaction between a real render output and the real guard was covered by neither. `fakeBotCardMutator` now applies `CatalogMarkersPreserved` — the same function production calls — so with the old comparison restored, `TestBotMessageEditRegistryTemplate*` fails with the production symptom, HTTP 400 "Invalid card payload." on an ordinary historical edit.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] PR description is in English
- [x] Added tests for my changes
- [x] Updated documentation
- [x] Followed commit message conventions (Conventional Commits)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y1YA6kPCqbvC1ShXoMYMnq