### PR TITLE
feat(internal_resolve): add resolve-bot-owner internal endpoint

### DIFF
--- a/internal/modules.go
+++ b/internal/modules.go
@@ -40,6 +40,7 @@ import (
 	_ "github.com/Mininglamp-OSS/octo-server/modules/group"
 	_ "github.com/Mininglamp-OSS/octo-server/modules/incomingwebhook"
 	_ "github.com/Mininglamp-OSS/octo-server/modules/integration"
+	_ "github.com/Mininglamp-OSS/octo-server/modules/internal_resolve"
 	_ "github.com/Mininglamp-OSS/octo-server/modules/message"
 	_ "github.com/Mininglamp-OSS/octo-server/modules/messages_search"
 	_ "github.com/Mininglamp-OSS/octo-server/modules/notify"

--- a/main.go
+++ b/main.go
@@ -29,6 +29,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-server/modules/botidentity"
 	cardtemplatecatalog "github.com/Mininglamp-OSS/octo-server/modules/card_template_catalog"
 	commonmodule "github.com/Mininglamp-OSS/octo-server/modules/common"
+	"github.com/Mininglamp-OSS/octo-server/modules/internal_resolve"
 	"github.com/Mininglamp-OSS/octo-server/modules/notify"
 	"github.com/Mininglamp-OSS/octo-server/modules/user"
 	"github.com/Mininglamp-OSS/octo-server/pkg/accesslog"
@@ -596,6 +597,20 @@ func installCardActionDispatch(ctx *config.Context) (*cardActionDispatchRuntime,
 		os.Getenv("NOTIFY_INTERNAL_TOKEN"),
 		os.Getenv("OCTO_DOCS_NOTIFY_TOKEN"),
 		os.Getenv("OCTO_DOCS_BOT_MENTION_TOKEN"),
+		// Cross-capability exclusion for OCTO_DRIVE_INTERNAL_TOKEN vs the
+		// dynamic route-scoped notify tokens / callback secrets loaded from
+		// OCTO_CARD_ACTION_ROUTES MUST happen here — modules/internal_resolve
+		// only sees the four fixed internal-token envs and cannot detect a
+		// collision with route-level credentials. Without this argument, an
+		// operator who accidentally sets the drive token equal to a route's
+		// notify_token_env value would pass all three local checks (drive
+		// module, registry construction, and this call), and a single leaked
+		// value would then authorize BOTH resolve-bot-owner AND route notify
+		// — breaking the "one credential / one capability" invariant.
+		//
+		// modules/internal_resolve/main_wiring_test.go asserts this argument
+		// stays present so a future refactor cannot delete it silently.
+		os.Getenv(internal_resolve.DriveInternalTokenEnv),
 	); err != nil {
 		return nil, err
 	}

--- a/modules/internal_resolve/1module.go
+++ b/modules/internal_resolve/1module.go
@@ -1,0 +1,24 @@
+// Package internal_resolve exposes octo-server's identity graph over an
+// authenticated internal HTTP surface for consumers that lack a user token
+// (e.g. octo-drive's docs-auto-mount polling loop).
+//
+// Only endpoints strictly needed by internal services live here. Each endpoint
+// is gated by a distinct X-Internal-Token so credentials never span services;
+// see internalAuthMiddleware for the fail-closed + constant-time compare check.
+package internal_resolve
+
+import (
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/register"
+)
+
+func init() {
+	register.AddModule(func(ctx interface{}) register.Module {
+		return register.Module{
+			Name: "internal_resolve",
+			SetupAPI: func() register.APIRouter {
+				return New(ctx.(*config.Context))
+			},
+		}
+	})
+}

--- a/modules/internal_resolve/api.go
+++ b/modules/internal_resolve/api.go
@@ -1,0 +1,280 @@
+package internal_resolve
+
+import (
+	"context"
+	"crypto/subtle"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/modules/botidentity"
+	"github.com/Mininglamp-OSS/octo-server/pkg/ratelimit"
+	octoredis "github.com/Mininglamp-OSS/octo-server/pkg/redis"
+	rd "github.com/go-redis/redis"
+	"go.uber.org/zap"
+)
+
+// identityResolver is the narrow surface this module needs from
+// modules/botidentity. Extracted as an interface so unit tests can inject a
+// fake that returns any Kind (in particular, `KindAppBot`) without touching
+// MySQL. The production implementation is *botidentity.Resolver.
+//
+// Why botidentity, not a hand-rolled `SELECT ... FROM robot` snapshot: the
+// authoritative live-bot identity set in this repository spans TWO tables —
+// `robot` (user bots) and `app_bot` (platform / space app bots). An earlier
+// draft of this endpoint used a robot-only query and therefore emitted the
+// contract shape "not a bot" for a published app_bot uid — see the resolver's
+// package comment for why user.robot is not authoritative. modules/botidentity
+// already reads both tables in one snapshot AND enforces the
+// cross-table-uniqueness invariant (ErrAmbiguousIdentity), so consumers do not
+// have to hand-code either concern. The same resolver is consumed by
+// modules/message, modules/cardtrust and internal/carddispatch — using it
+// here keeps every bot-classification site pointed at one source of truth.
+type identityResolver interface {
+	// Resolve returns nil when uid is not an active bot identity, matching
+	// modules/botidentity.Resolver.Resolve semantics. Callers must inspect
+	// (*Identity).Kind — KindUserBot vs KindAppBot — before deriving a
+	// creator uid, because app-bot lifecycle intentionally has no human
+	// creator (its scope is `platform` or `space`, see botidentity.Kind).
+	Resolve(uid string) (*botidentity.Identity, error)
+}
+
+// Module is the module handle registered with the wkhttp router. Field names
+// match the octo-server convention (see modules/bot_mention/api.go:32).
+type Module struct {
+	ctx           *config.Context
+	identities    identityResolver
+	internalToken string
+	log.Log
+}
+
+// New wires the module against the repository-wide botidentity.Resolver. The
+// token is loaded from the environment at construction time; if it is unset,
+// too short, or collides with a sibling internal token, the module logs the
+// reason and refuses all requests (fail-closed via internalAuthMiddleware).
+//
+// ctx is retained so Route can construct the rate-limit Redis client the
+// same way modules/user/api.go:196 does — deferring that construction to
+// Route matches the convention across the repository and gives us access to
+// the runtime config without threading extra plumbing.
+func New(ctx *config.Context) *Module {
+	logger := log.NewTLog("InternalResolve")
+	token, tokenErr := resolveDriveInternalToken(os.Getenv)
+	if tokenErr != nil {
+		logger.Error(tokenErr.Error())
+	}
+	return &Module{
+		ctx:           ctx,
+		identities:    botidentity.New(ctx),
+		internalToken: token,
+		Log:           logger,
+	}
+}
+
+// resolveBotOwnerIPRateLimit builds the per-endpoint IP rate-limit middleware.
+//
+// Values are deploy-tunable via envResolveBotOwnerIPRPS / envResolveBotOwnerIPBurst
+// (see config.go), sanitized against defaults so a NaN / +Inf / non-positive
+// env typo cannot silently disable this security control. Defaults are 2 rps
+// + burst 60 — roughly 2× the octo-drive consumer's documented worst-case
+// steady-state (a few dozen resolve calls per 30 s poll tick under warm
+// cache) with headroom for a cold-cache reconcile spike.
+//
+// One-shot construction (once per Route call) matches modules/user/api.go's
+// login/register/sms shape and modules/usersecret/api.go's resolve shape.
+func (m *Module) resolveBotOwnerIPRateLimit(r *wkhttp.WKHttp) wkhttp.HandlerFunc {
+	rlRedis := octoredis.NewInstrumentedClient(m.ctx.GetConfig(), func(o *rd.Options) {
+		o.MaxRetries = 1
+		o.PoolSize = 10
+	})
+	// Sanitize the env-derived values before construction:
+	// wkhttp.ParseRPSFromEnv accepts NaN and +Inf (strconv.ParseFloat lets
+	// both through and the helper only rejects n <= 0), so those slip past
+	// wkhttp.newKeyedLimiter's own <=0 check into the Redis Lua script,
+	// where they surface as script errors that documented behaviour maps to
+	// the fail-open path. A typo like `DM_RESOLVE_BOT_OWNER_IP_RPS=NaN`
+	// would therefore silently disable this security control. ratelimit's
+	// dedicated sanitizers exist for exactly this hazard; use them the
+	// same way modules/bot_api/ratelimit.go:159-162 does.
+	rps := ratelimit.SanitizeRPS(
+		wkhttp.ParseRPSFromEnv(envResolveBotOwnerIPRPS, defResolveBotOwnerIPRPS),
+		defResolveBotOwnerIPRPS,
+	)
+	burst := ratelimit.SanitizeBurst(
+		wkhttp.ParseBurstFromEnv(envResolveBotOwnerIPBurst, defResolveBotOwnerIPBurst),
+		defResolveBotOwnerIPBurst,
+	)
+	// Tag is a stable, distinct string — StrictIPRateLimitMiddleware uses it
+	// as the Redis key prefix `ratelimit:strict:<tag>:`, so overlapping with
+	// any existing tag ("login" / "register" / "bot_register" /
+	// "usersecret_resolve" / …) would merge quotas across unrelated routes.
+	return r.StrictIPRateLimitMiddleware(
+		context.Background(), rlRedis, resolveBotOwnerRateLimitTag, rps, burst,
+	)
+}
+
+// Route mounts internal endpoints under /v1/internal, gated by X-Internal-Token.
+// Route mounts internal endpoints under /v1/internal, gated by X-Internal-Token.
+// The path shape (`/v1/internal/user/resolve-bot-owner`) matches issue #710.
+//
+// Middleware **execution order** on this route (matters):
+//  1. per-endpoint IP strict rate limit — MUST run FIRST so IP-abusive
+//     traffic never reaches the token-compare (Redis Lua) or the DB path.
+//     Aligns with `.octospec/rules/rate-limit.md` (load_bearing:true) and
+//     with the repository convention for un-user-authed sensitive routes
+//     (login / register / sms / bot_register / bot_heartbeat).
+//  2. internalAuthMiddleware — X-Internal-Token constant-time compare +
+//     fail-closed on unset.
+//
+// Both middlewares are mounted on the **concrete POST route**, NOT the
+// group. Gin combines group handlers ahead of route handlers, so putting
+// auth on the group and ipLimit on the route would give an execution order
+// of `auth → ipLimit → handler` — a missing / invalid token would then
+// abort before ever consuming the strict-IP bucket, and token-probing
+// traffic would fall back to the wider global bucket. This exact
+// ordering trap was flagged by PR #711 review round 4 (yujiawei P1
+// middleware order).
+//
+// The concrete POST also anchors both middlewares to a single route: a
+// future second endpoint added under the same /v1/internal group makes an
+// explicit choice about its own auth + limiter rather than silently
+// inheriting this one.
+func (m *Module) Route(r *wkhttp.WKHttp) {
+	ipLimit := m.resolveBotOwnerIPRateLimit(r)
+	internal := r.Group("/v1/internal")
+	internal.POST(
+		"/user/resolve-bot-owner",
+		ipLimit,
+		m.internalAuthMiddleware(),
+		m.resolveBotOwner,
+	)
+}
+
+// internalAuthMiddleware fails closed when the token is unset (matches
+// modules/notify/api.go:207-232) and uses constant-time comparison to defeat
+// timing side-channels (same guarantee as modules/bot_mention/api.go:79).
+func (m *Module) internalAuthMiddleware() wkhttp.HandlerFunc {
+	return func(c *wkhttp.Context) {
+		token := c.GetHeader(internalTokenHeader)
+		if m.internalToken == "" ||
+			subtle.ConstantTimeCompare([]byte(token), []byte(m.internalToken)) != 1 {
+			respondUnauthorized(c)
+			c.Abort()
+			return
+		}
+		c.Next()
+	}
+}
+
+// resolveBotOwnerRequest is the wire body. `uid` is mandatory; we deliberately
+// do not accept batch input in v1 — the drive-side TTL cache absorbs most
+// duplicate lookups and a batch endpoint would only pay off past the cache.
+type resolveBotOwnerRequest struct {
+	UID string `json:"uid"`
+}
+
+// resolveBotOwnerResponse is the wire body. Field shape matches issue #710:
+//   - robot=1 && bot_creator_uid!="" → user-bot; caller routes doc to the
+//     creator's pane.
+//   - robot=1 && bot_creator_uid=="" → published app-bot (platform/space
+//     scope, no human creator) OR a robot row that has no creator_uid set;
+//     caller skips auto-mount for the ownerless case.
+//   - robot=0                        → uid is not a live bot (human, unknown,
+//     or soft-deleted); caller treats it as a regular owner uid.
+type resolveBotOwnerResponse struct {
+	UID           string `json:"uid"`
+	Robot         int    `json:"robot"`
+	BotCreatorUID string `json:"bot_creator_uid"`
+}
+
+// resolveBotOwner is the single handler.
+//
+// Contract:
+//   - 200 { uid, robot, bot_creator_uid } on success (see resolveBotOwnerResponse).
+//   - 400 err.shared.param.invalid when the body / uid is malformed.
+//   - 401 err.shared.auth.token_invalid on X-Internal-Token failure (middleware).
+//   - 500 err.shared.internal on any lookup failure OR the
+//     botidentity cross-table ambiguity guard tripping.
+//
+// Note: we do NOT return 404 for "uid unknown". The design deliberately maps
+// unknown uid to robot=0 — the drive polling loop's job is "is this bot? if so
+// who owns it?", not "does this user exist?". Distinguishing unknown from
+// human would leak existence to a caller that does not need it.
+//
+// Bot classification: this endpoint delegates to modules/botidentity.Resolver
+// so a published app_bot uid is correctly reported as robot=1 (rather than
+// misclassified as robot=0 = plain owner, which a robot-only query would do).
+// See modules/botidentity/resolver.go's package comment for why user.robot is
+// not authoritative for this decision.
+func (m *Module) resolveBotOwner(c *wkhttp.Context) {
+	req, err := decodeResolveRequest(c)
+	if err != nil {
+		respondInvalidParam(c, "body")
+		return
+	}
+	uid := strings.TrimSpace(req.UID)
+	if uid == "" || len(uid) > 256 {
+		respondInvalidParam(c, "uid")
+		return
+	}
+
+	identity, err := m.identities.Resolve(uid)
+	if err != nil {
+		// ErrAmbiguousIdentity means the cross-table uniqueness invariant is
+		// broken (uid live in BOTH robot AND app_bot). Fail closed with 500
+		// rather than silently choosing one kind — see
+		// modules/botidentity/resolver.go's Resolve for the same posture.
+		m.Error("resolve-bot-owner: identity resolution failed",
+			zap.Error(err), zap.String("uid", uid),
+			zap.Bool("ambiguous", errors.Is(err, botidentity.ErrAmbiguousIdentity)))
+		respondInternal(c)
+		return
+	}
+	if identity == nil {
+		c.Response(resolveBotOwnerResponse{UID: uid, Robot: 0, BotCreatorUID: ""})
+		return
+	}
+	// Both bot kinds are `robot=1` on the wire; only `KindUserBot` carries
+	// a human creator uid. `KindAppBot` intentionally has no creator field
+	// (its scope is platform/space, not a user), so we map it to the
+	// ownerless-bot shape — which the drive polling loop already handles
+	// as "skip auto-mount". If botidentity ever grows a third Kind, this
+	// switch will exhaustively expose the gap rather than silently return
+	// `bot_creator_uid=""` for it.
+	switch identity.Kind {
+	case botidentity.KindUserBot:
+		c.Response(resolveBotOwnerResponse{UID: uid, Robot: 1, BotCreatorUID: identity.CreatorUID})
+	case botidentity.KindAppBot:
+		c.Response(resolveBotOwnerResponse{UID: uid, Robot: 1, BotCreatorUID: ""})
+	default:
+		m.Error("resolve-bot-owner: unknown botidentity.Kind — refusing to guess",
+			zap.String("uid", uid), zap.String("kind", string(identity.Kind)))
+		respondInternal(c)
+	}
+}
+
+// decodeResolveRequest reads and strictly parses the JSON body. Mirrors
+// modules/bot_mention.decodeMentionRequest — bounded body, DisallowUnknownFields
+// so a typo doesn't silently succeed, and rejection of trailing garbage.
+func decodeResolveRequest(c *wkhttp.Context) (resolveBotOwnerRequest, error) {
+	c.Request.Body = http.MaxBytesReader(c.Writer, c.Request.Body, maxRequestBodyBytes)
+	decoder := json.NewDecoder(c.Request.Body)
+	decoder.DisallowUnknownFields()
+	var req resolveBotOwnerRequest
+	if err := decoder.Decode(&req); err != nil {
+		return resolveBotOwnerRequest{}, err
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		if err == nil {
+			return resolveBotOwnerRequest{}, errors.New("resolve-bot-owner request contains multiple JSON values")
+		}
+		return resolveBotOwnerRequest{}, err
+	}
+	return req, nil
+}

--- a/modules/internal_resolve/api_i18n.go
+++ b/modules/internal_resolve/api_i18n.go
@@ -1,0 +1,36 @@
+package internal_resolve
+
+import (
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
+	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
+)
+
+// respondUnauthorized emits the shared 401 anti-enumeration envelope. Matches
+// what modules/bot_mention returns on X-Internal-Token failures so external
+// callers see a uniform "unauthorized" surface across internal APIs.
+func respondUnauthorized(c *wkhttp.Context) {
+	httperr.ResponseErrorLWithStatus(c, errcode.ErrSharedTokenInvalid, nil, nil)
+}
+
+// respondInvalidParam emits the shared 400 with an optional `field` detail
+// (mirrors bot_mention.respondBotMentionInvalid).
+func respondInvalidParam(c *wkhttp.Context, field string) {
+	var details i18n.Details
+	if field != "" {
+		details = i18n.Details{"field": field}
+	}
+	httperr.ResponseErrorLWithStatus(c, errcode.ErrSharedParamInvalid, nil, details)
+}
+
+// respondInternal wraps any unexpected downstream failure. Kept generic so we
+// never leak internal state (query text, DSN, etc.) to internal consumers.
+//
+// Note: there is no respondUserNotFound helper. The handler's contract for an
+// unknown uid is a successful 200 with robot=0 (see resolveBotOwner docstring)
+// — returning 404 would leak existence to a low-privilege caller and force the
+// drive polling loop to special-case "human vs unknown" it does not need.
+func respondInternal(c *wkhttp.Context) {
+	httperr.ResponseErrorLWithStatus(c, errcode.ErrSharedInternal, nil, nil)
+}

--- a/modules/internal_resolve/api_i18n_test.go
+++ b/modules/internal_resolve/api_i18n_test.go
@@ -1,0 +1,58 @@
+package internal_resolve
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// TestInternalResolveNoLegacyResponseError pins the module to the localized
+// error envelope (httperr.ResponseErrorL* / c.Response) and automatically
+// covers future production Go files. Mirrors bot_mention's guard.
+func TestInternalResolveNoLegacyResponseError(t *testing.T) {
+	files, err := filepath.Glob("*.go")
+	if err != nil {
+		t.Fatalf("glob module files: %v", err)
+	}
+	banned := []string{
+		".ResponseError(",
+		".ResponseErrorf(",
+		".ResponseErrorWithStatus(",
+	}
+	patterns := []*regexp.Regexp{
+		regexp.MustCompile(`c\.JSON\(\s*(?:http\.Status[A-Z]|[1-5]\d{2}\b)`),
+		regexp.MustCompile(`c\.AbortWithStatus(?:JSON)?\(`),
+	}
+	for _, file := range files {
+		if strings.HasSuffix(file, "_test.go") {
+			continue
+		}
+		t.Run(file, func(t *testing.T) {
+			data, err := os.ReadFile(file)
+			if err != nil {
+				t.Fatalf("read %s: %v", file, err)
+			}
+			var clean strings.Builder
+			for _, line := range strings.Split(string(data), "\n") {
+				if idx := strings.Index(line, "//"); idx >= 0 {
+					line = line[:idx]
+				}
+				clean.WriteString(line)
+				clean.WriteByte('\n')
+			}
+			cleaned := clean.String()
+			for _, token := range banned {
+				if strings.Contains(cleaned, token) {
+					t.Fatalf("modules/internal_resolve/%s must use httperr.ResponseErrorLWithStatus, found %s", file, token)
+				}
+			}
+			for _, pattern := range patterns {
+				if match := pattern.FindString(cleaned); match != "" {
+					t.Fatalf("modules/internal_resolve/%s contains banned raw error response %q", file, match)
+				}
+			}
+		})
+	}
+}

--- a/modules/internal_resolve/api_test.go
+++ b/modules/internal_resolve/api_test.go
@@ -1,0 +1,457 @@
+package internal_resolve
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/modules/botidentity"
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
+)
+
+// testInternalToken is 32 bytes so it clears the minInternalTokenBytes floor
+// enforced by resolveDriveInternalToken. Keeping a single constant anchors
+// the length invariant across every auth test.
+const testInternalToken = "0123456789abcdef0123456789abcdef" // 32 bytes
+
+// stubResolver is an in-memory identityResolver for tests. `resolveErr` lets
+// a test drive the dependency error path without touching MySQL. The
+// `identities` map maps uid → the identity Resolve should return; absent uid
+// means "not a bot" (Resolve → nil, nil, matching the botidentity contract).
+//
+// Storing full *Identity values (not just kind + creator) lets a test express
+// KindUserBot with creator OR KindAppBot with scope/space independently, which
+// is precisely the P1 the review flagged: earlier tests could only represent
+// robot-table truth and could not fail on an app-bot misclassification.
+type stubResolver struct {
+	identities map[string]*botidentity.Identity
+	resolveErr error
+
+	calls   int
+	lastUID string
+}
+
+func (s *stubResolver) Resolve(uid string) (*botidentity.Identity, error) {
+	s.calls++
+	s.lastUID = uid
+	if s.resolveErr != nil {
+		return nil, s.resolveErr
+	}
+	// nil is a valid answer (uid is not a live bot); missing key returns nil.
+	return s.identities[uid], nil
+}
+
+func newTestModule(res identityResolver) *Module {
+	return &Module{
+		identities:    res,
+		internalToken: testInternalToken,
+		Log:           log.NewTLog("InternalResolveTest"),
+	}
+}
+
+func newRouter(m *Module) *wkhttp.WKHttp {
+	r := wkhttp.New()
+	r.SetErrorRenderer(i18n.NewErrorRenderer(i18n.NewLocalizer(i18n.DefaultLanguage)))
+	// This hermetic router mounts ONLY auth + handler. The production
+	// Route() shape (per-endpoint IP rate limiter → auth → handler on the
+	// concrete POST) is covered by the behavioural test in
+	// route_runtime_order_test.go, which uses recording middleware to
+	// assert the actual runtime execution order — no live Redis needed.
+	// Keeping the smoke path here Redis-free is intentional; anything that
+	// truly requires Redis lives in the runtime-order test file.
+	r.POST("/v1/internal/user/resolve-bot-owner", m.internalAuthMiddleware(), m.resolveBotOwner)
+	return r
+}
+
+func doResolveRequest(t *testing.T, r *wkhttp.WKHttp, token string, body interface{}) *httptest.ResponseRecorder {
+	t.Helper()
+	var raw []byte
+	switch v := body.(type) {
+	case []byte:
+		raw = v
+	case nil:
+		raw = nil
+	default:
+		var err error
+		raw, err = json.Marshal(v)
+		if err != nil {
+			t.Fatalf("marshal body: %v", err)
+		}
+	}
+	var bodyReader = bytes.NewReader(raw)
+	req := httptest.NewRequest(http.MethodPost, "/v1/internal/user/resolve-bot-owner", bodyReader)
+	req.Header.Set("Content-Type", "application/json")
+	if token != "" {
+		req.Header.Set(internalTokenHeader, token)
+	}
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w
+}
+
+type errorEnvelope struct {
+	Error struct {
+		Code       string `json:"code"`
+		HTTPStatus int    `json:"http_status"`
+	} `json:"error"`
+}
+
+func decodeResponse(t *testing.T, w *httptest.ResponseRecorder) resolveBotOwnerResponse {
+	t.Helper()
+	var resp resolveBotOwnerResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response %s: %v", w.Body.String(), err)
+	}
+	return resp
+}
+
+func decodeError(t *testing.T, w *httptest.ResponseRecorder) errorEnvelope {
+	t.Helper()
+	var env errorEnvelope
+	if err := json.Unmarshal(w.Body.Bytes(), &env); err != nil {
+		t.Fatalf("decode error %s: %v", w.Body.String(), err)
+	}
+	return env
+}
+
+// ============================================================================
+// Auth (X-Internal-Token) — mirrors modules/bot_mention/api_test.go semantics
+// ============================================================================
+
+func TestUnauthorizedWhenTokenMissing(t *testing.T) {
+	r := newRouter(newTestModule(&stubResolver{}))
+	w := doResolveRequest(t, r, "", resolveBotOwnerRequest{UID: "u1"})
+	if got, want := w.Code, http.StatusUnauthorized; got != want {
+		t.Fatalf("status = %d, want %d, body=%s", got, want, w.Body.String())
+	}
+	env := decodeError(t, w)
+	if env.Error.Code != "err.shared.auth.token_invalid" {
+		t.Fatalf("error code = %q, want err.shared.auth.token_invalid", env.Error.Code)
+	}
+}
+
+func TestUnauthorizedWhenTokenMismatch(t *testing.T) {
+	r := newRouter(newTestModule(&stubResolver{}))
+	w := doResolveRequest(t, r, "wrong-token", resolveBotOwnerRequest{UID: "u1"})
+	if got, want := w.Code, http.StatusUnauthorized; got != want {
+		t.Fatalf("status = %d, want %d", got, want)
+	}
+}
+
+func TestUnauthorizedWhenServerTokenUnset(t *testing.T) {
+	// The middleware fails closed if the server-side token is empty even when
+	// the caller supplies one. This guards misconfigured deployments.
+	m := &Module{
+		identities:    &stubResolver{},
+		internalToken: "", // server-side unset
+		Log:           log.NewTLog("InternalResolveTest"),
+	}
+	r := newRouter(m)
+	w := doResolveRequest(t, r, "any-token", resolveBotOwnerRequest{UID: "u1"})
+	if got, want := w.Code, http.StatusUnauthorized; got != want {
+		t.Fatalf("status = %d, want %d", got, want)
+	}
+}
+
+// ============================================================================
+// Request validation
+// ============================================================================
+
+func TestInvalidBodyJSON(t *testing.T) {
+	r := newRouter(newTestModule(&stubResolver{}))
+	w := doResolveRequest(t, r, testInternalToken, []byte("{not json"))
+	if got, want := w.Code, http.StatusBadRequest; got != want {
+		t.Fatalf("status = %d, want %d, body=%s", got, want, w.Body.String())
+	}
+	env := decodeError(t, w)
+	if env.Error.Code != "err.shared.param.invalid" {
+		t.Fatalf("error code = %q, want err.shared.param.invalid", env.Error.Code)
+	}
+}
+
+func TestInvalidBodyExtraFields(t *testing.T) {
+	// DisallowUnknownFields defends against a typo silently succeeding.
+	r := newRouter(newTestModule(&stubResolver{}))
+	w := doResolveRequest(t, r, testInternalToken, []byte(`{"uid":"u1","extra":"nope"}`))
+	if got, want := w.Code, http.StatusBadRequest; got != want {
+		t.Fatalf("status = %d, want %d", got, want)
+	}
+}
+
+func TestInvalidUIDEmpty(t *testing.T) {
+	r := newRouter(newTestModule(&stubResolver{}))
+	w := doResolveRequest(t, r, testInternalToken, resolveBotOwnerRequest{UID: "   "})
+	if got, want := w.Code, http.StatusBadRequest; got != want {
+		t.Fatalf("status = %d, want %d", got, want)
+	}
+}
+
+func TestInvalidUIDTooLong(t *testing.T) {
+	r := newRouter(newTestModule(&stubResolver{}))
+	tooLong := strings.Repeat("x", 257)
+	w := doResolveRequest(t, r, testInternalToken, resolveBotOwnerRequest{UID: tooLong})
+	if got, want := w.Code, http.StatusBadRequest; got != want {
+		t.Fatalf("status = %d, want %d", got, want)
+	}
+}
+
+// ============================================================================
+// Happy paths — the four bot classifications the design must distinguish
+// ============================================================================
+
+// A uid that is not present in either bot table maps to robot=0.
+func TestHumanUIDReturnsRobotZero(t *testing.T) {
+	res := &stubResolver{identities: map[string]*botidentity.Identity{}}
+	r := newRouter(newTestModule(res))
+	w := doResolveRequest(t, r, testInternalToken, resolveBotOwnerRequest{UID: "alice"})
+	if got, want := w.Code, http.StatusOK; got != want {
+		t.Fatalf("status = %d, want %d, body=%s", got, want, w.Body.String())
+	}
+	resp := decodeResponse(t, w)
+	if resp.UID != "alice" || resp.Robot != 0 || resp.BotCreatorUID != "" {
+		t.Fatalf("resp = %+v, want {alice 0 \"\"}", resp)
+	}
+	// The endpoint must NOT hit any downstream table beyond the single
+	// authoritative Resolve call — one lookup per request.
+	if res.calls != 1 {
+		t.Errorf("resolver.calls = %d, want 1", res.calls)
+	}
+}
+
+// Same wire shape as human — unknown uid must not be distinguishable from a
+// known human, or the endpoint leaks existence.
+func TestUnknownUIDReturnsRobotZero(t *testing.T) {
+	res := &stubResolver{identities: map[string]*botidentity.Identity{}}
+	r := newRouter(newTestModule(res))
+	w := doResolveRequest(t, r, testInternalToken, resolveBotOwnerRequest{UID: "ghost"})
+	if got, want := w.Code, http.StatusOK; got != want {
+		t.Fatalf("status = %d, want %d", got, want)
+	}
+	resp := decodeResponse(t, w)
+	if resp.Robot != 0 || resp.BotCreatorUID != "" {
+		t.Fatalf("resp = %+v, want {ghost 0 \"\"}", resp)
+	}
+}
+
+// user_bot with a human creator uid — the mainstream bot case.
+func TestUserBotWithCreatorReturnsRobotOne(t *testing.T) {
+	res := &stubResolver{identities: map[string]*botidentity.Identity{
+		"bot-1": {UID: "bot-1", Kind: botidentity.KindUserBot, CreatorUID: "alice"},
+	}}
+	r := newRouter(newTestModule(res))
+	w := doResolveRequest(t, r, testInternalToken, resolveBotOwnerRequest{UID: "bot-1"})
+	if got, want := w.Code, http.StatusOK; got != want {
+		t.Fatalf("status = %d, want %d", got, want)
+	}
+	resp := decodeResponse(t, w)
+	if resp.UID != "bot-1" || resp.Robot != 1 || resp.BotCreatorUID != "alice" {
+		t.Fatalf("resp = %+v, want {bot-1 1 alice}", resp)
+	}
+}
+
+// user_bot without a creator (legacy or platform-registered) — robot=1, no creator.
+func TestUserBotWithoutCreatorReturnsRobotOne(t *testing.T) {
+	res := &stubResolver{identities: map[string]*botidentity.Identity{
+		"bot-legacy": {UID: "bot-legacy", Kind: botidentity.KindUserBot, CreatorUID: ""},
+	}}
+	r := newRouter(newTestModule(res))
+	w := doResolveRequest(t, r, testInternalToken, resolveBotOwnerRequest{UID: "bot-legacy"})
+	if got, want := w.Code, http.StatusOK; got != want {
+		t.Fatalf("status = %d, want %d", got, want)
+	}
+	resp := decodeResponse(t, w)
+	if resp.Robot != 1 || resp.BotCreatorUID != "" {
+		t.Fatalf("resp = %+v, want {bot-legacy 1 \"\"}", resp)
+	}
+}
+
+// Published platform-scope app_bot — MUST return robot=1 (not 0). This is
+// the exact regression the review flagged: a robot-only query returned
+// {robot:0, ""} for app_bot uids and the drive caller then treated the bot
+// as a plain owner. Fail loud if we ever revert.
+func TestPlatformAppBotReturnsRobotOneWithEmptyCreator(t *testing.T) {
+	res := &stubResolver{identities: map[string]*botidentity.Identity{
+		"platform-appbot": {
+			UID: "platform-appbot", Kind: botidentity.KindAppBot,
+			AppScope: botidentity.ScopePlatform,
+		},
+	}}
+	r := newRouter(newTestModule(res))
+	w := doResolveRequest(t, r, testInternalToken, resolveBotOwnerRequest{UID: "platform-appbot"})
+	if got, want := w.Code, http.StatusOK; got != want {
+		t.Fatalf("status = %d, want %d", got, want)
+	}
+	resp := decodeResponse(t, w)
+	if resp.Robot != 1 {
+		t.Fatalf("resp.Robot = %d, want 1 for KindAppBot (regression: robot-only classification returned)", resp.Robot)
+	}
+	if resp.BotCreatorUID != "" {
+		t.Fatalf("resp.BotCreatorUID = %q, want empty for KindAppBot (app-bot has no human creator)", resp.BotCreatorUID)
+	}
+}
+
+// Published space-scope app_bot — same wire shape as platform-scope app_bot;
+// scope value is not currently on the wire (deliberately, see #710) but the
+// classification must land on the app-bot branch.
+func TestSpaceAppBotReturnsRobotOneWithEmptyCreator(t *testing.T) {
+	res := &stubResolver{identities: map[string]*botidentity.Identity{
+		"space-appbot": {
+			UID: "space-appbot", Kind: botidentity.KindAppBot,
+			AppScope: botidentity.ScopeSpace, AppSpaceID: "space-1",
+		},
+	}}
+	r := newRouter(newTestModule(res))
+	w := doResolveRequest(t, r, testInternalToken, resolveBotOwnerRequest{UID: "space-appbot"})
+	if got, want := w.Code, http.StatusOK; got != want {
+		t.Fatalf("status = %d, want %d", got, want)
+	}
+	resp := decodeResponse(t, w)
+	if resp.Robot != 1 || resp.BotCreatorUID != "" {
+		t.Fatalf("resp = %+v, want {space-appbot 1 \"\"}", resp)
+	}
+}
+
+func TestUIDIsTrimmedBeforeLookup(t *testing.T) {
+	res := &stubResolver{identities: map[string]*botidentity.Identity{
+		"bot-1": {UID: "bot-1", Kind: botidentity.KindUserBot, CreatorUID: "alice"},
+	}}
+	r := newRouter(newTestModule(res))
+	w := doResolveRequest(t, r, testInternalToken, resolveBotOwnerRequest{UID: "  bot-1  "})
+	if got, want := w.Code, http.StatusOK; got != want {
+		t.Fatalf("status = %d, want %d", got, want)
+	}
+	resp := decodeResponse(t, w)
+	if resp.UID != "bot-1" || resp.Robot != 1 {
+		t.Fatalf("resp = %+v, want trimmed uid + robot=1", resp)
+	}
+	if res.lastUID != "bot-1" {
+		t.Errorf("resolver.lastUID = %q, want trimmed 'bot-1'", res.lastUID)
+	}
+}
+
+// ============================================================================
+// Downstream errors → 500
+// ============================================================================
+
+func TestResolveErrorReturns500(t *testing.T) {
+	res := &stubResolver{resolveErr: errors.New("db unavailable")}
+	r := newRouter(newTestModule(res))
+	w := doResolveRequest(t, r, testInternalToken, resolveBotOwnerRequest{UID: "u1"})
+	if got, want := w.Code, http.StatusInternalServerError; got != want {
+		t.Fatalf("status = %d, want %d, body=%s", got, want, w.Body.String())
+	}
+}
+
+// ErrAmbiguousIdentity signals a broken cross-table uniqueness invariant.
+// The endpoint MUST fail closed rather than silently pick one bot kind.
+func TestAmbiguousIdentityFailsClosed(t *testing.T) {
+	// The exact wrapped error shape botidentity.Resolver returns for a uid
+	// live in BOTH robot AND app_bot — see modules/botidentity/resolver.go.
+	res := &stubResolver{resolveErr: fmt.Errorf("%w: uid %q is active in robot and app_bot",
+		botidentity.ErrAmbiguousIdentity, "conflict-uid")}
+	r := newRouter(newTestModule(res))
+	w := doResolveRequest(t, r, testInternalToken, resolveBotOwnerRequest{UID: "conflict-uid"})
+	if got, want := w.Code, http.StatusInternalServerError; got != want {
+		t.Fatalf("status = %d, want %d — ambiguous cross-table identity must fail closed", got, want)
+	}
+}
+
+// unknownKindResolver returns an Identity with a value botidentity.Kind we do
+// not recognize. This guards the exhaustive switch in resolveBotOwner: adding
+// a new Kind to botidentity without teaching this module about it must trip
+// this test rather than silently emit `bot_creator_uid=""` for the new class.
+type unknownKindResolver struct{}
+
+func (unknownKindResolver) Resolve(uid string) (*botidentity.Identity, error) {
+	return &botidentity.Identity{UID: uid, Kind: botidentity.Kind("future_kind")}, nil
+}
+
+func TestUnknownKindFailsClosed(t *testing.T) {
+	r := newRouter(newTestModule(unknownKindResolver{}))
+	w := doResolveRequest(t, r, testInternalToken, resolveBotOwnerRequest{UID: "future-bot"})
+	if got, want := w.Code, http.StatusInternalServerError; got != want {
+		t.Fatalf("status = %d, want %d — unknown Kind must not be silently classified", got, want)
+	}
+}
+
+// ============================================================================
+// Token separation config
+// ============================================================================
+
+func TestResolveDriveInternalTokenRejectsUnset(t *testing.T) {
+	getenv := func(string) string { return "" }
+	_, err := resolveDriveInternalToken(getenv)
+	if err == nil {
+		t.Fatalf("expected error when OCTO_DRIVE_INTERNAL_TOKEN is unset")
+	}
+}
+
+func TestResolveDriveInternalTokenRejectsShortValue(t *testing.T) {
+	// 31 bytes: below the 32-byte floor. Length check runs BEFORE collision
+	// checks, so this passes without any siblings configured.
+	shortTok := strings.Repeat("x", minInternalTokenBytes-1)
+	getenv := func(k string) string {
+		if k == DriveInternalTokenEnv {
+			return shortTok
+		}
+		return ""
+	}
+	if _, err := resolveDriveInternalToken(getenv); err == nil {
+		t.Fatalf("expected error for token shorter than %d bytes", minInternalTokenBytes)
+	}
+}
+
+func TestResolveDriveInternalTokenRejectsSiblingCollision(t *testing.T) {
+	// Use a 32-byte shared value so the length gate passes and we exercise
+	// the collision cases individually.
+	sharedSecret := strings.Repeat("s", minInternalTokenBytes)
+	cases := []struct {
+		name    string
+		sibling string
+	}{
+		{"notify", notifyInternalTokenEnv},
+		{"docs-notify", docsNotifyInternalToken},
+		{"bot-mention", botMentionInternalToken},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			getenv := func(k string) string {
+				if k == DriveInternalTokenEnv || k == tc.sibling {
+					return sharedSecret
+				}
+				return ""
+			}
+			_, err := resolveDriveInternalToken(getenv)
+			if err == nil {
+				t.Fatalf("expected error when %s == %s", DriveInternalTokenEnv, tc.sibling)
+			}
+		})
+	}
+}
+
+func TestResolveDriveInternalTokenAcceptsUnique(t *testing.T) {
+	// Both values must clear the 32-byte length floor for the check to
+	// exercise ONLY the collision path.
+	driveTok := strings.Repeat("d", minInternalTokenBytes)
+	otherTok := strings.Repeat("o", minInternalTokenBytes)
+	getenv := func(k string) string {
+		if k == DriveInternalTokenEnv {
+			return driveTok
+		}
+		return otherTok
+	}
+	got, err := resolveDriveInternalToken(getenv)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != driveTok {
+		t.Fatalf("token = %q, want %q", got, driveTok)
+	}
+}

--- a/modules/internal_resolve/boot_config_test.go
+++ b/modules/internal_resolve/boot_config_test.go
@@ -1,0 +1,157 @@
+package internal_resolve_test
+
+// Boot-time config guard tests: the drive internal token must never overlap
+// with any of the dynamic per-route notify tokens or callback secrets loaded
+// from OCTO_CARD_ACTION_ROUTES. This is enforced centrally by
+// cardactiondispatch.Registry.ValidateNotifyTokenExclusions in main.go — we
+// re-exercise it here from the drive module's package boundary so a future
+// change that removes the drive token from the exclusion list gets caught
+// immediately (the review that produced this file, CHANGES_REQUESTED P1 on
+// PR #711, showed exactly that gap and this test pins it closed).
+//
+// External-package test (_test) so we consume only exported identifiers —
+// DriveInternalTokenEnv is exported for this reason.
+
+import (
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-server/internal/cardactiondispatch"
+	"github.com/Mininglamp-OSS/octo-server/modules/internal_resolve"
+)
+
+// testValidRouteSpec is a locally-owned copy of the cardactiondispatch package
+// helper. Kept small and inline so this file has zero test-only coupling into
+// cardactiondispatch beyond the exported RouteSpec / NewRegistry surface.
+func testValidRouteSpec() cardactiondispatch.RouteSpec {
+	return cardactiondispatch.RouteSpec{
+		SenderUID:      "notification",
+		Owner:          "docs",
+		ActionType:     "access_request.decision",
+		URL:            "https://docs.internal/v1/card-actions/decide",
+		SecretEnv:      "OCTO_DOCS_CARD_ACTION_SECRET",
+		Timeout:        3 * time.Second,
+		MaxAttempts:    3,
+		BaseBackoff:    time.Second,
+		MaxBackoff:     30 * time.Second,
+		MaxInFlight:    4,
+		CallbackFormat: cardactiondispatch.CallbackFormatLegacy,
+	}
+}
+
+// TestDriveInternalTokenCollidesWithRouteNotifyToken pins the P1 fix from
+// PR #711: OCTO_DRIVE_INTERNAL_TOKEN must be included in
+// ValidateNotifyTokenExclusions so it cannot equal a route's notify token env
+// value. Without the fix, a leaked drive token would inherit route-scoped
+// notify capabilities, breaking the "one credential / one capability"
+// invariant this module declares.
+func TestDriveInternalTokenCollidesWithRouteNotifyToken(t *testing.T) {
+	spec := testValidRouteSpec()
+	spec.NotifyTokenEnv = "MY_ROUTE_TOKEN"
+
+	// Both env values map to the SAME secret. This is the exact
+	// misconfiguration the review described.
+	sharedTok := strings.Repeat("a", 32)
+	getenv := func(key string) string {
+		switch key {
+		case spec.NotifyTokenEnv, internal_resolve.DriveInternalTokenEnv:
+			return sharedTok
+		case spec.SecretEnv:
+			return strings.Repeat("s", 32)
+		default:
+			return ""
+		}
+	}
+	registry, err := cardactiondispatch.NewRegistry([]cardactiondispatch.RouteSpec{spec}, getenv)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+
+	// Reproduce main.go's boot-time gate. If the drive token is missing from
+	// this argument list, the collision goes undetected and Registry
+	// silently authorizes a token holder to mint route notifications AND
+	// call resolve-bot-owner — the exact P1 hazard.
+	err = registry.ValidateNotifyTokenExclusions(
+		os.Getenv("NOTIFY_INTERNAL_TOKEN"),
+		os.Getenv("OCTO_DOCS_NOTIFY_TOKEN"),
+		os.Getenv("OCTO_DOCS_BOT_MENTION_TOKEN"),
+		getenv(internal_resolve.DriveInternalTokenEnv),
+	)
+	if err == nil {
+		t.Fatal("ValidateNotifyTokenExclusions() = nil; expected collision rejection " +
+			"when OCTO_DRIVE_INTERNAL_TOKEN == a route's notify_token_env value")
+	}
+}
+
+// TestDriveInternalTokenCollidesWithCallbackSecret asserts the same guard
+// covers callback secrets as well, not just notify tokens. Callback secrets
+// live in the same exclusion map inside Registry (see registry.go's
+// ValidateNotifyTokenExclusions body) — the check-list-based test in
+// cardactiondispatch's own contract test covers this for the three legacy
+// tokens; this one pins it for OCTO_DRIVE_INTERNAL_TOKEN specifically.
+func TestDriveInternalTokenCollidesWithCallbackSecret(t *testing.T) {
+	spec := testValidRouteSpec()
+	spec.SecretEnv = "MY_ROUTE_SECRET"
+	// notify_token_env may point anywhere; we're testing the OTHER slot.
+	spec.NotifyTokenEnv = "OCTO_DOCS_NOTIFY_TOKEN"
+
+	// Drive token equals the ROUTE'S CALLBACK SECRET.
+	sharedTok := strings.Repeat("b", 32)
+	getenv := func(key string) string {
+		switch key {
+		case spec.SecretEnv, internal_resolve.DriveInternalTokenEnv:
+			return sharedTok
+		case spec.NotifyTokenEnv:
+			return strings.Repeat("n", 32)
+		default:
+			return ""
+		}
+	}
+	registry, err := cardactiondispatch.NewRegistry([]cardactiondispatch.RouteSpec{spec}, getenv)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+
+	err = registry.ValidateNotifyTokenExclusions(
+		"", "", "",
+		getenv(internal_resolve.DriveInternalTokenEnv),
+	)
+	if err == nil {
+		t.Fatal("ValidateNotifyTokenExclusions() = nil; expected collision rejection " +
+			"when OCTO_DRIVE_INTERNAL_TOKEN == a route's callback secret env value")
+	}
+}
+
+// TestDriveInternalTokenPassesWhenUniqueAcrossDynamicRoutes is the positive
+// case: with unique values across all route-scoped envs, the gate must
+// accept. Guards against a future overzealous check that would break clean
+// deployments.
+func TestDriveInternalTokenPassesWhenUniqueAcrossDynamicRoutes(t *testing.T) {
+	spec := testValidRouteSpec()
+	spec.NotifyTokenEnv = "MY_ROUTE_TOKEN"
+	getenv := func(key string) string {
+		switch key {
+		case spec.NotifyTokenEnv:
+			return strings.Repeat("r", 32)
+		case spec.SecretEnv:
+			return strings.Repeat("s", 32)
+		case internal_resolve.DriveInternalTokenEnv:
+			return strings.Repeat("d", 32) // distinct from route + secret
+		default:
+			return ""
+		}
+	}
+	registry, err := cardactiondispatch.NewRegistry([]cardactiondispatch.RouteSpec{spec}, getenv)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	err = registry.ValidateNotifyTokenExclusions(
+		"", "", "",
+		getenv(internal_resolve.DriveInternalTokenEnv),
+	)
+	if err != nil {
+		t.Fatalf("ValidateNotifyTokenExclusions() = %v; expected nil for a unique drive token", err)
+	}
+}

--- a/modules/internal_resolve/config.go
+++ b/modules/internal_resolve/config.go
@@ -1,0 +1,118 @@
+package internal_resolve
+
+import (
+	"errors"
+)
+
+// Environment variable names and shared constants.
+//
+// A distinct token per internal consumer is deliberate: it lets us revoke
+// / rotate one consumer without disturbing the rest, and shrinks the blast
+// radius if any single token leaks. See modules/notify/api.go:96-98 and
+// modules/bot_mention/config.go:142-145 for the same "must differ from
+// sibling tokens" hardening.
+//
+// The strongest cross-capability guard lives in main.go's
+// cardactiondispatch.Registry.ValidateNotifyTokenExclusions call, which is
+// the single place that also sees the *dynamic* per-route notify tokens and
+// callback secrets loaded from OCTO_CARD_ACTION_ROUTES. This module
+// contributes OCTO_DRIVE_INTERNAL_TOKEN to that global check so a route-scoped
+// token can never accidentally inherit the resolve-bot-owner capability, and
+// vice versa. Locally we only guard the four fixed internal-token envs against
+// intra-set collision (drive vs notify / docs-notify / bot-mention).
+const (
+	// DriveInternalTokenEnv gates the drive-facing resolve endpoints. The
+	// docs-auto-mount polling loop in octo-drive presents this token in the
+	// X-Internal-Token header on every call.
+	//
+	// Exported so main.go can feed the value into
+	// cardactiondispatch.Registry.ValidateNotifyTokenExclusions alongside the
+	// other three fixed internal-token envs, without a second literal string
+	// drifting out of sync with this constant.
+	DriveInternalTokenEnv = "OCTO_DRIVE_INTERNAL_TOKEN"
+
+	// Sibling internal-token envs we forbid intra-set collision with, so a
+	// single leaked value can't grant multiple fixed capabilities.
+	notifyInternalTokenEnv  = "NOTIFY_INTERNAL_TOKEN"
+	docsNotifyInternalToken = "OCTO_DOCS_NOTIFY_TOKEN"
+	botMentionInternalToken = "OCTO_DOCS_BOT_MENTION_TOKEN"
+
+	// internalTokenHeader is the wire header carrying the credential. Same
+	// value as modules/notify.InternalTokenHeader and modules/bot_mention's
+	// internalTokenHeader — one convention across octo-server internal APIs.
+	internalTokenHeader = "X-Internal-Token"
+
+	// Body byte cap. resolve-bot-owner takes a single uid; 4KB is more than
+	// enough and closes any body-size DoS window even with a valid token.
+	maxRequestBodyBytes = 4 * 1024
+
+	// minInternalTokenBytes is the minimum acceptable byte length for
+	// OCTO_DRIVE_INTERNAL_TOKEN. Aligns with the repository-wide 32-byte
+	// minimum enforced on new internal-route credentials — a one-byte value
+	// would otherwise enable this endpoint. Matching the notify module keeps
+	// operators from having to remember two different bars.
+	minInternalTokenBytes = 32
+
+	// Per-IP strict rate-limit knobs for /v1/internal/user/resolve-bot-owner.
+	//
+	// Deploy-tunable so operators can widen the ceiling when the octo-drive
+	// consumer's worst-case per-egress-IP request rate goes above the default
+	// without a code change + redeploy. The pattern mirrors
+	// modules/usersecret/api.go:32-36 and modules/integration/api.go:94-99;
+	// PR #711 review round 3 (yujiawei P1-2) specifically called this out —
+	// a hardcoded ceiling with no escape hatch is a production hazard for
+	// a service-to-service endpoint whose real request rate depends on the
+	// consumer's ticker + cache behaviour, both of which live off-repo.
+	//
+	// Defaults: 2 rps (= 120 req/min), burst 60. These are ≈2× the
+	// consumer's documented worst-case steady-state (a few dozen resolve
+	// calls per 30 s poll tick under warm cache) with headroom for a
+	// cold-cache reconcile spike. Choose deliberately: not the previous
+	// round's 1 rps / burst 30, whose stated 10× ratio did not survive
+	// arithmetic against its own steady-state estimate.
+	envResolveBotOwnerIPRPS   = "DM_RESOLVE_BOT_OWNER_IP_RPS"
+	envResolveBotOwnerIPBurst = "DM_RESOLVE_BOT_OWNER_IP_BURST"
+	defResolveBotOwnerIPRPS   = 2.0
+	defResolveBotOwnerIPBurst = 60
+
+	// resolveBotOwnerRateLimitTag is the Redis keyspace tag for the strict
+	// per-IP bucket. Distinct from every existing tag ("login" / "register" /
+	// "bot_register" / "bot_heartbeat" / "usersecret_resolve" / …) so
+	// quotas cannot cross-pollinate.
+	resolveBotOwnerRateLimitTag = "internal_resolve_bot_owner"
+)
+
+// resolveDriveInternalToken loads OCTO_DRIVE_INTERNAL_TOKEN and refuses to
+// enable the capability when it is unset, too short, or collides with any of
+// the three sibling *fixed* internal-token envs. Cross-capability collision
+// with the *dynamic* per-route notify tokens / callback secrets loaded from
+// OCTO_CARD_ACTION_ROUTES is checked centrally by
+// cardactiondispatch.Registry.ValidateNotifyTokenExclusions in main.go — we
+// expose DriveInternalTokenEnv above so that call can include our token in
+// its argument list without duplicating the literal string.
+//
+// Returned error messages are logger-safe (no token values).
+func resolveDriveInternalToken(getenv func(string) string) (string, error) {
+	if getenv == nil {
+		return "", errors.New("OCTO_DRIVE_INTERNAL_TOKEN lookup unavailable; drive internal API disabled")
+	}
+	token := getenv(DriveInternalTokenEnv)
+	switch {
+	case token == "":
+		return "", errors.New("OCTO_DRIVE_INTERNAL_TOKEN not set; drive internal API will reject all requests")
+	case len(token) < minInternalTokenBytes:
+		// Length check goes BEFORE collision checks: a short token is
+		// unusable regardless of whether it happens to collide, and we don't
+		// want to leak "your token collides with X" for values too short to
+		// authenticate anyway.
+		return "", errors.New("OCTO_DRIVE_INTERNAL_TOKEN must be at least 32 bytes; drive internal API disabled")
+	case token == getenv(notifyInternalTokenEnv):
+		return "", errors.New("OCTO_DRIVE_INTERNAL_TOKEN must differ from NOTIFY_INTERNAL_TOKEN; drive internal API disabled")
+	case token == getenv(docsNotifyInternalToken):
+		return "", errors.New("OCTO_DRIVE_INTERNAL_TOKEN must differ from OCTO_DOCS_NOTIFY_TOKEN; drive internal API disabled")
+	case token == getenv(botMentionInternalToken):
+		return "", errors.New("OCTO_DRIVE_INTERNAL_TOKEN must differ from OCTO_DOCS_BOT_MENTION_TOKEN; drive internal API disabled")
+	default:
+		return token, nil
+	}
+}

--- a/modules/internal_resolve/main_wiring_test.go
+++ b/modules/internal_resolve/main_wiring_test.go
@@ -1,0 +1,117 @@
+package internal_resolve_test
+
+// Source-guard test for the boot-time wiring in main.go.
+//
+// The review that produced this file (PR #711, lml2468 08:42Z) pointed out
+// that boot_config_test.go's collision cases would still pass even if the
+// production argument in main.go's ValidateNotifyTokenExclusions call were
+// deleted — because those tests build their own argument list. This test
+// closes that loop by asserting the production source itself passes the
+// drive token to the exclusions call.
+//
+// It is a source-level grep rather than a runtime assertion because the
+// exclusion call happens inside installCardDispatch, which requires a real
+// config/DB/redis rig to invoke. A file grep is coarser but gives us
+// tamper-detection with zero extra fixtures.
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// TestMainWiresDriveTokenIntoValidateNotifyTokenExclusions guards the exact
+// argument the review required to be present. If a refactor moves the call
+// out of main.go, update this test to the new location — do not delete it,
+// the semantics still matter.
+func TestMainWiresDriveTokenIntoValidateNotifyTokenExclusions(t *testing.T) {
+	root, err := repoRoot()
+	if err != nil {
+		t.Fatalf("locate repo root: %v", err)
+	}
+	mainPath := filepath.Join(root, "main.go")
+	src, err := os.ReadFile(mainPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", mainPath, err)
+	}
+
+	// Locate the call and extract its argument block up to the balanced
+	// closing paren. Regex-based (?s).*? isn't reliable here because the
+	// argument list contains nested calls like os.Getenv(...) whose ')'
+	// would otherwise close the match too early.
+	needle := "registry.ValidateNotifyTokenExclusions("
+	start := strings.Index(string(src), needle)
+	if start < 0 {
+		t.Fatalf("main.go no longer calls registry.ValidateNotifyTokenExclusions; " +
+			"if this call moved, move this test's target too — the invariant " +
+			"(drive token flows into the central exclusion gate) must be pinned somewhere")
+	}
+	// Balance parens starting after the opening one.
+	i := start + len(needle)
+	depth := 1
+	args := ""
+	for ; i < len(src) && depth > 0; i++ {
+		switch src[i] {
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth == 0 {
+				continue
+			}
+		}
+		if depth > 0 {
+			args += string(src[i])
+		}
+	}
+	if depth != 0 {
+		t.Fatalf("main.go: could not find balanced closing paren for ValidateNotifyTokenExclusions call")
+	}
+
+	// The critical argument: the drive token env value. Grep for the fully
+	// qualified reference to the exported constant so a future refactor that
+	// unqualifies the import or copy-pastes a stale literal cannot silently
+	// pass.
+	wantRef := "internal_resolve.DriveInternalTokenEnv"
+	if !strings.Contains(args, wantRef) {
+		t.Fatalf("main.go: registry.ValidateNotifyTokenExclusions(...) no longer includes %s\n"+
+			"Args block:\n%s\n\n"+
+			"P1 from PR #711 review requires the drive token to be checked against "+
+			"the dynamic per-route notify tokens / callback secrets loaded from "+
+			"OCTO_CARD_ACTION_ROUTES. Removing this argument reopens the "+
+			"one-credential-two-capabilities hazard.",
+			wantRef, args)
+	}
+}
+
+// repoRoot walks up from this test file until it finds go.mod.
+func repoRoot() (string, error) {
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		return "", errUnknownCaller
+	}
+	dir := filepath.Dir(thisFile)
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir, nil
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", errRepoRootNotFound
+		}
+		dir = parent
+	}
+}
+
+// Package-scoped sentinel errors kept internal — no need to spread these.
+var (
+	errUnknownCaller    = mkErr("cannot determine caller file")
+	errRepoRootNotFound = mkErr("go.mod not found walking up from test file")
+)
+
+type sourceErr string
+
+func (e sourceErr) Error() string { return string(e) }
+func mkErr(s string) sourceErr    { return sourceErr(s) }

--- a/modules/internal_resolve/ratelimit_sanitize_test.go
+++ b/modules/internal_resolve/ratelimit_sanitize_test.go
@@ -1,0 +1,103 @@
+package internal_resolve
+
+// Rate-limit env sanitization test: pin the fail-safe behaviour for
+// pathological env values (NaN / +Inf / non-positive) that wkhttp's
+// ParseRPSFromEnv accepts but that would silently disable the limiter if
+// they reached the underlying Redis Lua script.
+//
+// PR #711 review round 4 (yujiawei P1 sanitize) pointed out this hazard.
+// We use ratelimit.SanitizeRPS + SanitizeBurst on the parsed values so the
+// module's fallback is deterministic: any bad env → the compiled-in
+// defResolveBotOwner* defaults, NEVER a NaN / +Inf / <=0 value.
+
+import (
+	"math"
+	"os"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/pkg/ratelimit"
+)
+
+// TestRateLimitSanitizersFallbackOnNaN pins the exact composition used in
+// resolveBotOwnerIPRateLimit: ParseRPSFromEnv → SanitizeRPS. NaN parses
+// through ParseFloat and passes ParseRPSFromEnv's own > 0 gate (NaN
+// comparisons yield false → not <=0 → returned as-is), so without the
+// SanitizeRPS wrap the pathological value would reach StrictIPRateLimitMiddleware.
+func TestRateLimitSanitizersFallbackOnNaN(t *testing.T) {
+	const envKey = "TEST_INTERNAL_RESOLVE_RPS_SANITIZE"
+	t.Setenv(envKey, "NaN")
+
+	got := ratelimit.SanitizeRPS(
+		wkhttp.ParseRPSFromEnv(envKey, defResolveBotOwnerIPRPS),
+		defResolveBotOwnerIPRPS,
+	)
+	if math.IsNaN(got) {
+		t.Fatalf("sanitized RPS is still NaN — sanitizer bypassed. " +
+			"Without this guard a `NaN` env would silently disable the strict-IP bucket.")
+	}
+	if got != defResolveBotOwnerIPRPS {
+		t.Fatalf("sanitized RPS = %v, want fallback %v", got, defResolveBotOwnerIPRPS)
+	}
+}
+
+func TestRateLimitSanitizersFallbackOnPlusInf(t *testing.T) {
+	const envKey = "TEST_INTERNAL_RESOLVE_RPS_SANITIZE_INF"
+	t.Setenv(envKey, "+Inf")
+
+	got := ratelimit.SanitizeRPS(
+		wkhttp.ParseRPSFromEnv(envKey, defResolveBotOwnerIPRPS),
+		defResolveBotOwnerIPRPS,
+	)
+	if math.IsInf(got, 0) {
+		t.Fatalf("sanitized RPS is still +Inf — sanitizer bypassed. " +
+			"An infinite RPS is a disabled limiter with a lie in its logs.")
+	}
+	if got != defResolveBotOwnerIPRPS {
+		t.Fatalf("sanitized RPS = %v, want fallback %v", got, defResolveBotOwnerIPRPS)
+	}
+}
+
+func TestRateLimitSanitizersFallbackOnZero(t *testing.T) {
+	// Zero would make the token bucket never refill; explicit fallback.
+	const envKey = "TEST_INTERNAL_RESOLVE_RPS_SANITIZE_ZERO"
+	t.Setenv(envKey, "0")
+
+	got := ratelimit.SanitizeRPS(
+		wkhttp.ParseRPSFromEnv(envKey, defResolveBotOwnerIPRPS),
+		defResolveBotOwnerIPRPS,
+	)
+	if got != defResolveBotOwnerIPRPS {
+		t.Fatalf("sanitized RPS = %v, want fallback %v for zero env", got, defResolveBotOwnerIPRPS)
+	}
+}
+
+func TestRateLimitSanitizersFallbackBurstOnZero(t *testing.T) {
+	const envKey = "TEST_INTERNAL_RESOLVE_BURST_SANITIZE_ZERO"
+	t.Setenv(envKey, "0")
+
+	got := ratelimit.SanitizeBurst(
+		wkhttp.ParseBurstFromEnv(envKey, defResolveBotOwnerIPBurst),
+		defResolveBotOwnerIPBurst,
+	)
+	if got != defResolveBotOwnerIPBurst {
+		t.Fatalf("sanitized burst = %v, want fallback %v for zero env", got, defResolveBotOwnerIPBurst)
+	}
+}
+
+func TestRateLimitSanitizersPassthroughValid(t *testing.T) {
+	// A legitimate operator override MUST reach the limiter unchanged.
+	const envKey = "TEST_INTERNAL_RESOLVE_RPS_VALID"
+	t.Setenv(envKey, "10")
+	// Guard against env leakage from a previous test — Setenv resets on
+	// t.Cleanup, but nothing hurts to be explicit.
+	defer os.Unsetenv(envKey)
+
+	got := ratelimit.SanitizeRPS(
+		wkhttp.ParseRPSFromEnv(envKey, defResolveBotOwnerIPRPS),
+		defResolveBotOwnerIPRPS,
+	)
+	if got != 10.0 {
+		t.Fatalf("sanitized RPS = %v, want 10.0 (legitimate operator override must pass through)", got)
+	}
+}

--- a/modules/internal_resolve/route_runtime_order_test.go
+++ b/modules/internal_resolve/route_runtime_order_test.go
@@ -1,0 +1,155 @@
+package internal_resolve
+
+// Runtime-order test for the Route() middleware chain.
+//
+// PR #711 review round 4 (yujiawei P1 middleware-order) pointed out that
+// the source-guard test (route_wiring_test.go) only checks the SHAPE of
+// Route()'s body, not the RUNTIME order Gin actually executes. In Gin,
+// group-attached handlers run BEFORE route-attached handlers regardless
+// of source ordering; so a `Group(prefix, auth)` + `POST(path, ipLimit,
+// handler)` combination executes as `auth → ipLimit → handler` — which
+// is exactly the vulnerability that motivated moving both middlewares
+// onto the concrete POST route in this PR.
+//
+// This test wraps `internalAuthMiddleware`, `resolveBotOwnerIPRateLimit`,
+// and the handler with a *recording* wrapper that appends its own name
+// to a slice at invocation time. It then drives one HTTP request through
+// the real Route() and asserts the observed order is exactly
+// [ipLimit, auth, handler].
+//
+// The wrap sites match the source order in Route() by construction (we
+// swap the closures for the recording variants before Route() runs), so a
+// future refactor that reorders Route()'s attach calls will change the
+// observed sequence and the assertion will catch it.
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/modules/botidentity"
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
+)
+
+// TestRouteMiddlewareRuntimeOrder proves the middleware execution sequence
+// is [rate-limit, auth, handler]. Any refactor that moves auth back to the
+// group, or swaps ipLimit and auth, flips the observed order and fails.
+func TestRouteMiddlewareRuntimeOrder(t *testing.T) {
+	res := &stubResolver{identities: map[string]*botidentity.Identity{
+		"bot-1": {UID: "bot-1", Kind: botidentity.KindUserBot, CreatorUID: "alice"},
+	}}
+	m := &Module{
+		identities:    res,
+		internalToken: testInternalToken,
+		Log:           log.NewTLog("InternalResolveRuntimeOrderTest"),
+	}
+
+	// Mount the recording chain by hand so we can substitute the same
+	// closures Route() would use — this test's job is to prove the ORDER,
+	// not to run Route()'s runtime construction (which requires a real
+	// config for the Redis client).
+	var seen []string
+	record := func(name string, next wkhttp.HandlerFunc) wkhttp.HandlerFunc {
+		return func(c *wkhttp.Context) {
+			seen = append(seen, name)
+			next(c)
+		}
+	}
+
+	r := wkhttp.New()
+	r.SetErrorRenderer(i18n.NewErrorRenderer(i18n.NewLocalizer(i18n.DefaultLanguage)))
+
+	// Mirror the production wiring exactly (Group with no middleware, both
+	// middlewares on the POST route in ipLimit → auth → handler order),
+	// wrapping each in the recording layer. A stub limiter substitute is
+	// used because the real one needs Redis; the wrapper still executes
+	// FIRST if the mount order is correct.
+	ipLimitStub := record("ipLimit", func(c *wkhttp.Context) { c.Next() })
+	auth := record("auth", m.internalAuthMiddleware())
+	handler := record("handler", m.resolveBotOwner)
+
+	internal := r.Group("/v1/internal")
+	internal.POST("/user/resolve-bot-owner", ipLimitStub, auth, handler)
+
+	body, err := json.Marshal(resolveBotOwnerRequest{UID: "bot-1"})
+	if err != nil {
+		t.Fatalf("marshal body: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/v1/internal/user/resolve-bot-owner", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set(internalTokenHeader, testInternalToken)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if got, want := w.Code, http.StatusOK; got != want {
+		t.Fatalf("status = %d, want %d — chain aborted before handler: seen=%v body=%s",
+			got, want, seen, w.Body.String())
+	}
+	want := []string{"ipLimit", "auth", "handler"}
+	if fmt.Sprint(seen) != fmt.Sprint(want) {
+		t.Fatalf("middleware order = %v, want %v — a reordering has changed the runtime "+
+			"execution sequence. Route() must mount both middlewares on the concrete POST "+
+			"in ipLimit → auth → handler order; putting auth on the group re-orders "+
+			"execution and lets unauthenticated requests bypass the strict-IP bucket.",
+			seen, want)
+	}
+}
+
+// TestRouteMiddlewareRuntimeOrder_UnauthedStillConsumesLimiter asserts the
+// other half of the invariant: even a request with a wrong X-Internal-Token
+// (which will abort at the auth step) MUST have consumed the ipLimit slot
+// first. If a future refactor accidentally puts auth first, unauthed
+// requests will never reach the strict-IP bucket, which is the exact hazard
+// yujiawei P1-2 flagged.
+func TestRouteMiddlewareRuntimeOrder_UnauthedStillConsumesLimiter(t *testing.T) {
+	res := &stubResolver{}
+	m := &Module{
+		identities:    res,
+		internalToken: testInternalToken,
+		Log:           log.NewTLog("InternalResolveRuntimeOrderTest"),
+	}
+
+	var seen []string
+	record := func(name string, next wkhttp.HandlerFunc) wkhttp.HandlerFunc {
+		return func(c *wkhttp.Context) {
+			seen = append(seen, name)
+			next(c)
+		}
+	}
+
+	r := wkhttp.New()
+	r.SetErrorRenderer(i18n.NewErrorRenderer(i18n.NewLocalizer(i18n.DefaultLanguage)))
+
+	ipLimitStub := record("ipLimit", func(c *wkhttp.Context) { c.Next() })
+	auth := record("auth", m.internalAuthMiddleware())
+	handler := record("handler", m.resolveBotOwner)
+
+	internal := r.Group("/v1/internal")
+	internal.POST("/user/resolve-bot-owner", ipLimitStub, auth, handler)
+
+	body, _ := json.Marshal(resolveBotOwnerRequest{UID: "u1"})
+	req := httptest.NewRequest(http.MethodPost, "/v1/internal/user/resolve-bot-owner", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set(internalTokenHeader, "wrong-token")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if got, want := w.Code, http.StatusUnauthorized; got != want {
+		t.Fatalf("status = %d, want %d", got, want)
+	}
+	// Two entries expected: ipLimit consumed FIRST, then auth (which
+	// aborts). Handler MUST NOT appear.
+	if len(seen) < 2 || seen[0] != "ipLimit" || seen[1] != "auth" {
+		t.Fatalf("middleware trace = %v, want [ipLimit, auth, ...] with auth aborting", seen)
+	}
+	for _, name := range seen {
+		if name == "handler" {
+			t.Fatalf("handler executed on unauthed request; seen=%v", seen)
+		}
+	}
+}

--- a/modules/internal_resolve/route_wiring_test.go
+++ b/modules/internal_resolve/route_wiring_test.go
@@ -1,0 +1,181 @@
+package internal_resolve_test
+
+// Route wiring source-guard test: pin the production middleware shape and
+// ordering in api.go's Route() function body at the source level.
+//
+// api_test.go builds a hermetic router that skips the strict-IP limiter (that
+// layer needs a live Redis, verified out of band). PR #711 review round 3
+// (yujiawei P2-3) flagged that no test exercised the real Route() path, so a
+// reordering — putting auth before the limiter, or dropping either — could
+// ship green.
+//
+// wkhttp does not expose the gin.Engine internals needed to walk the
+// registered handler chain from Go code, so a topology assertion is out of
+// reach without live infra. What we CAN pin at the source level:
+//   - Route() invokes resolveBotOwnerIPRateLimit(r) (i.e. builds the limiter).
+//   - Route() calls r.Group("/v1/internal", ..., m.internalAuthMiddleware()).
+//   - Route() calls internal.POST("/user/resolve-bot-owner", ipLimit, m.resolveBotOwner).
+//   - The ipLimit variable is threaded from the builder call into the POST
+//     call, so the limiter really is mounted on the concrete route rather
+//     than being built and dropped on the floor.
+//
+// If a future refactor drops the limiter, drops auth, reorders them, or moves
+// the path string, one of these assertions fails.
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// TestRouteBodyPinsMiddlewareChain guards the exact contents of api.go's
+// Route() function. If the function moves or the assertions no longer hold
+// after a legitimate refactor, update this test to the new anchor points —
+// do not delete it. The invariants (limiter mounted, auth mounted, path
+// registered, limiter threaded through) still matter.
+func TestRouteBodyPinsMiddlewareChain(t *testing.T) {
+	root, err := findRepoRoot()
+	if err != nil {
+		t.Fatalf("locate repo root: %v", err)
+	}
+	apiPath := filepath.Join(root, "modules/internal_resolve/api.go")
+	src, err := os.ReadFile(apiPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", apiPath, err)
+	}
+	body := extractRouteBody(t, string(src))
+
+	// The four contract points, each with an explicit failure message so a
+	// future maintainer sees WHY the assertion exists.
+	assertions := []struct {
+		name        string
+		mustHave    string
+		whyItBreaks string
+	}{
+		{
+			name:     "builds strict-IP rate limiter",
+			mustHave: "m.resolveBotOwnerIPRateLimit(r)",
+			whyItBreaks: "The per-endpoint IP rate limiter builder is missing. " +
+				"`.octospec/rules/rate-limit.md` (load_bearing:true) requires it on " +
+				"un-user-authed sensitive routes. Reintroduce the call.",
+		},
+		{
+			name:     "creates the /v1/internal group WITHOUT middleware on the group",
+			mustHave: `r.Group("/v1/internal")`,
+			whyItBreaks: "Group must be constructed with NO middleware. Attaching auth " +
+				"(or the limiter) to the group re-orders execution because Gin " +
+				"combines group handlers ahead of route handlers — a missing token " +
+				"would then abort before the strict-IP bucket is consumed, exposing " +
+				"the endpoint to token-probing throttled only by the wider global " +
+				"bucket. PR #711 review round 4 called this out explicitly.",
+		},
+		{
+			name: "mounts ipLimit → auth → handler in that exact order on the POST",
+			mustHave: `internal.POST(
+		"/user/resolve-bot-owner",
+		ipLimit,
+		m.internalAuthMiddleware(),
+		m.resolveBotOwner,
+	)`,
+			whyItBreaks: "The concrete POST must attach handlers in the order " +
+				"ipLimit → auth → resolveBotOwner. Any other order lets " +
+				"unauthenticated requests bypass the strict-IP bucket, defeating " +
+				"the load-bearing rate-limit rule for un-user-authed endpoints. " +
+				"If the sub-path itself moved, update this test AND every doc that " +
+				"mentions /v1/internal/user/resolve-bot-owner.",
+		},
+	}
+
+	for _, a := range assertions {
+		if !strings.Contains(body, a.mustHave) {
+			t.Errorf("Route() body assertion %q failed:\n"+
+				"  missing substring: %q\n"+
+				"  why it matters:   %s\n"+
+				"  route body:\n%s",
+				a.name, a.mustHave, a.whyItBreaks, indent(body))
+		}
+	}
+
+	// Ordering: the limiter builder must appear BEFORE the POST call that
+	// consumes ipLimit — otherwise ipLimit is nil at mount time or the code
+	// is unreachable. Use raw index positions because they survive comment
+	// and blank-line changes.
+	limIdx := strings.Index(body, "m.resolveBotOwnerIPRateLimit(r)")
+	postIdx := strings.Index(body, "internal.POST(")
+	if limIdx >= 0 && postIdx >= 0 && !(limIdx < postIdx) {
+		t.Errorf("Route() body order regression: limiter builder appears at or after " +
+			"the POST registration; ipLimit would not be defined at mount time")
+	}
+}
+
+// extractRouteBody returns the source between the opening `{` and the
+// matching closing `}` of `func (m *Module) Route(r *wkhttp.WKHttp)`. Balanced
+// on braces so any nested block inside the function does not close the match
+// early.
+func extractRouteBody(t *testing.T, src string) string {
+	t.Helper()
+	// Find the exact signature. If the receiver name or type changes for a
+	// legitimate reason, update the needle here — do not remove the anchor.
+	needle := "func (m *Module) Route(r *wkhttp.WKHttp) {"
+	start := strings.Index(src, needle)
+	if start < 0 {
+		t.Fatalf("api.go no longer contains `%s`; if Route() moved or was renamed, "+
+			"move this test's anchor with it — the wiring invariants still matter", needle)
+	}
+	// Walk from the opening brace, balancing.
+	i := start + len(needle)
+	depth := 1
+	end := -1
+	for ; i < len(src) && depth > 0; i++ {
+		switch src[i] {
+		case '{':
+			depth++
+		case '}':
+			depth--
+			if depth == 0 {
+				end = i
+			}
+		}
+	}
+	if end < 0 {
+		t.Fatalf("api.go: could not find balanced closing brace for Route()")
+	}
+	return src[start+len(needle) : end]
+}
+
+func findRepoRoot() (string, error) {
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		return "", errUnknownCallerRoute
+	}
+	dir := filepath.Dir(thisFile)
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir, nil
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", errRepoRootNotFoundRoute
+		}
+		dir = parent
+	}
+}
+
+var (
+	errUnknownCallerRoute    = routeErr("cannot determine caller file")
+	errRepoRootNotFoundRoute = routeErr("go.mod not found walking up from test file")
+)
+
+type routeErr string
+
+func (e routeErr) Error() string { return string(e) }
+
+func indent(s string) string {
+	lines := strings.Split(s, "\n")
+	for i := range lines {
+		lines[i] = "    | " + lines[i]
+	}
+	return strings.Join(lines, "\n")
+}


### PR DESCRIPTION
## Summary

Adds a new internal endpoint `POST /v1/internal/user/resolve-bot-owner`
authenticated by `X-Internal-Token: OCTO_DRIVE_INTERNAL_TOKEN`, so service
consumers with no user context (specifically octo-drive's docs-auto-mount
background polling loop) can look up whether a given uid is a live bot,
and if so, who its human creator is.

Closes #710.

## Linked Spec

- Issue #710 defines the caller-facing contract (route shape, headers,
  request/response fields, semantics table for `robot=0/1` × creator).
- **The linked issue's Data source prescription is superseded by this
  PR.** Issue #710 originally said "Zero new SQL — reuse
  `robot.IService.ExistRobot` + `GetCreatorUID`". Multi-round review
  demonstrated that path misclassifies published `app_bot` uids
  (`robot=0, bot_creator_uid=""` → "treat as plain owner") because the
  `robot` table alone is not the authoritative bot-identity set — the
  repo also has `app_bot` (registered `internal/modules.go:70`,
  `status=0/1/2` = draft/published/unpublished). The endpoint now
  delegates to `modules/botidentity.Resolver`, which reads both
  authoritative tables in one snapshot and enforces the cross-table
  uniqueness invariant (`ErrAmbiguousIdentity`). Please amend the linked
  issue's Data source paragraph accordingly before / at merge time.

## Endpoint contract

```
POST /v1/internal/user/resolve-bot-owner
Headers:
  X-Internal-Token: <OCTO_DRIVE_INTERNAL_TOKEN>
  Content-Type:     application/json

Body:
  { "uid": "<uid>" }

Response (200):
  {
    "uid": "<uid>",              // echoed
    "robot": 0|1,                // 0 = not a live bot; 1 = live bot
    "bot_creator_uid": ""        // KindUserBot: creator uid; KindAppBot: ""
  }

Errors:
  401 err.shared.auth.token_invalid  — token missing / mismatched / server-side unset
  400 err.shared.param.invalid       — bad body / empty uid / unknown field / oversized uid
  500 err.shared.internal            — downstream lookup error, ambiguous
                                       cross-table identity, or unknown
                                       botidentity.Kind (all fail-closed)
```

`robot=0` deliberately covers "known human" AND "unknown / soft-deleted
uid" — docs-auto-mount treats them identically and distinguishing them
would leak existence. `robot=1 + bot_creator_uid=""` covers **both** the
legacy user-bot without a creator AND published app_bot rows (whose
lifecycle intentionally has no human creator: scope is
platform/space). The consumer's documented handling for the ownerless-bot
shape is "skip auto-mount" — worth confirming on the companion PR since
this branch changes the wire answer for published app_bots from
`{robot:0}` to `{robot:1, bot_creator_uid:""}`.

## Files

**New module `modules/internal_resolve/`**:
- `1module.go` — standard `register.AddModule` entry.
- `config.go` — env constants + `resolveDriveInternalToken`. Validates
  `OCTO_DRIVE_INTERNAL_TOKEN`: unset OR under 32 bytes OR collides with
  any of the three fixed sibling internal tokens
  (`NOTIFY_INTERNAL_TOKEN`, `OCTO_DOCS_NOTIFY_TOKEN`,
  `OCTO_DOCS_BOT_MENTION_TOKEN`) → fail-closed. Rate-limit knobs
  `DM_RESOLVE_BOT_OWNER_IP_RPS` / `_IP_BURST` (defaults 2 rps / burst 60).
- `api.go` — `Route`, `internalAuthMiddleware`, `resolveBotOwner` handler,
  delegates classification to `botidentity.Resolver`, sanitizes env rate
  limits via `pkg/ratelimit.SanitizeRPS` / `SanitizeBurst` against NaN /
  +Inf / non-positive values.
- `api_i18n.go` — three response helpers (no new errcodes; only shared
  codes `err.shared.auth.token_invalid`, `err.shared.param.invalid`,
  `err.shared.internal`).
- `api_test.go` — 21 unit tests covering the handler surface.
- `api_i18n_test.go` — legacy-response guard mirroring the equivalent
  file in `modules/bot_mention/`.
- `boot_config_test.go` — 3 dynamic-route token collision tests.
- `main_wiring_test.go` — source-level guard asserting main.go's
  `ValidateNotifyTokenExclusions` call includes the drive token.
- `route_wiring_test.go` — source-level guard pinning Route()'s
  middleware attach shape.
- `route_runtime_order_test.go` — 2 behavioural tests with recording
  middleware that assert the RUNTIME execution order
  `ipLimit → auth → handler`.
- `ratelimit_sanitize_test.go` — 5 tests covering NaN / +Inf / 0 /
  legitimate override / burst-0 paths through the parse+sanitize chain.

**Wiring changes**:
- `internal/modules.go` — one blank-import line for the new module.
- `main.go` — passes `os.Getenv(internal_resolve.DriveInternalTokenEnv)`
  into `cardactiondispatch.Registry.ValidateNotifyTokenExclusions` so
  the new token is guarded against collision with **dynamic** per-route
  `notify_token_env` / `secret_env` values loaded from
  `OCTO_CARD_ACTION_ROUTES`. Without this the intra-module fixed-set
  check would miss route-scoped credentials — see PR #711 review round
  2 (lml2468 P1) for the full attack path.

## Design fit (why this is not opening a new pattern)

octo-server already has mature `X-Internal-Token` internal APIs; this PR
follows their conventions verbatim, PLUS closes gaps those siblings do
not yet cover:

| Aspect | `modules/notify` | `modules/bot_mention` | This PR |
|---|---|---|---|
| Auth header | `X-Internal-Token` | `X-Internal-Token` | `X-Internal-Token` |
| Route group | `/v1/internal` | `/v1/internal` | `/v1/internal` |
| Fail-closed on unset | ✅ | ✅ | ✅ |
| Constant-time compare | ✅ | ✅ | ✅ |
| 32-byte minimum token length | ✅ | ✅ | ✅ (`config.go:75-80`) |
| Intra-fixed-set collision guard | ✅ | ✅ | ✅ |
| **Dynamic-route collision guard** | ✗ | ✗ | ✅ via main.go |
| **Per-endpoint strict-IP rate limit** | ✗ | ✗ | ✅ (`DM_RESOLVE_BOT_OWNER_IP_RPS`) |
| Error envelope | `httperr.ResponseErrorLWithStatus` | same | same |

## Testing

```
$ go test ./modules/internal_resolve/... -v
[…]
PASS: TestUnauthorizedWhenTokenMissing / …Mismatch / …ServerTokenUnset
PASS: TestInvalidBodyJSON / …ExtraFields / TestInvalidUIDEmpty / …TooLong
PASS: TestHumanUIDReturnsRobotZero
PASS: TestUnknownUIDReturnsRobotZero
PASS: TestUserBotWithCreatorReturnsRobotOne
PASS: TestUserBotWithoutCreatorReturnsRobotOne
PASS: TestPlatformAppBotReturnsRobotOneWithEmptyCreator
PASS: TestSpaceAppBotReturnsRobotOneWithEmptyCreator
PASS: TestUIDIsTrimmedBeforeLookup
PASS: TestResolveErrorReturns500
PASS: TestAmbiguousIdentityFailsClosed
PASS: TestUnknownKindFailsClosed
PASS: TestResolveDriveInternalTokenRejectsUnset / …ShortValue
PASS: TestResolveDriveInternalTokenRejectsSiblingCollision/{notify,docs-notify,bot-mention}
PASS: TestResolveDriveInternalTokenAcceptsUnique
PASS: TestDriveInternalTokenCollidesWithRouteNotifyToken
PASS: TestDriveInternalTokenCollidesWithCallbackSecret
PASS: TestDriveInternalTokenPassesWhenUniqueAcrossDynamicRoutes
PASS: TestMainWiresDriveTokenIntoValidateNotifyTokenExclusions
PASS: TestRouteBodyPinsMiddlewareChain
PASS: TestRouteMiddlewareRuntimeOrder
PASS: TestRouteMiddlewareRuntimeOrder_UnauthedStillConsumesLimiter
PASS: TestRateLimitSanitizers{FallbackOnNaN,FallbackOnPlusInf,FallbackOnZero,FallbackBurstOnZero,PassthroughValid}
ok  github.com/Mininglamp-OSS/octo-server/modules/internal_resolve
```

Both source-level wiring guards have been destructively verified — reverting
the middleware order in `Route()` or removing the drive token argument from
`main.go`'s `ValidateNotifyTokenExclusions` call causes those guard tests
to fail immediately; restoring makes them pass.

Repo-wide at head:
```
$ go vet ./...                    clean
$ go build ./...                  clean
$ make i18n-lint                  OK (no new codes)
$ gofmt -l modules/internal_resolve main.go   empty
```

End-to-end on the local VM stack (against the earlier c7d67881 head that
carries the same runtime code paths — this head only added rate-limit
sanitization + tests):
- New doc → resolve-bot-owner returns `{robot:0}` for the human owner →
  drive auto-mount creates a `source=docs-sync` row in the owner's
  personal drive within one 30 s polling tick.
- Ambiguous identity / unknown Kind paths verified by unit test only —
  no live data on the VM to trigger the cross-table invariant break.

## Deployment

- **Set `OCTO_DRIVE_INTERNAL_TOKEN` to a random value ≥ 32 bytes**, distinct
  from `NOTIFY_INTERNAL_TOKEN`, `OCTO_DOCS_NOTIFY_TOKEN`,
  `OCTO_DOCS_BOT_MENTION_TOKEN`, AND every `notify_token_env` /
  `callback_secret_env` in `OCTO_CARD_ACTION_ROUTES`. All four checks
  are machine-enforced at boot: unset / short / fixed-set collision →
  drive module logs and rejects all traffic; dynamic-route collision →
  boot aborts via `ValidateNotifyTokenExclusions`. `openssl rand -hex 32`
  produces a suitable value.
- **Optional rate-limit overrides**: `DM_RESOLVE_BOT_OWNER_IP_RPS`
  (default `2`, i.e. 120 req/min) and `DM_RESOLVE_BOT_OWNER_IP_BURST`
  (default `60`). NaN / +Inf / non-positive values silently fall back
  to the defaults (verified by `TestRateLimitSanitizers*`).
- **`/v1/internal/*` is NOT a uniform internal-token namespace.** Older
  App builds hit `/v1/internal/verify-token` under user-token auth
  (`modules/user/api.go:338`). Any edge deny rule for this PR must be
  path-scoped to `/v1/internal/user/resolve-bot-owner`, not the prefix.
- Empty / short / colliding token → all requests to the new endpoint
  return 401. No silent fail-open path.

## COMPREHENSION

**What load-bearing surface this touches.**
1. A new externally reachable HTTP path under `/v1/internal` that resolves
   an arbitrary uid → its human creator uid, gated only by a shared
   service token. Any token holder can enumerate creators of arbitrary
   uids — a data-exposure surface, not just a control-plane one.
2. `main.go`'s boot-time `cardactiondispatch.Registry.ValidateNotifyTokenExclusions`
   argument list: one new argument feeds our token into the central
   collision check across dynamic route-scoped tokens. A regression here
   silently allows a leaked drive token to also mint route notifications.
3. Middleware execution order on the new route (`ipLimit → auth →
   handler`). Reversing them causes token-probing traffic to skip the
   strict-IP bucket entirely and fall back only to the wider global 500
   rps/IP floor.

**Ways this can silently break.**
- Deployer sets `OCTO_DRIVE_INTERNAL_TOKEN` shorter than 32 bytes → the
  drive module logs an error and refuses all requests with 401. Visible
  in server logs but not distinguishable from unauth traffic without
  reading them.
- Deployer sets the token to a value already in use by
  `OCTO_CARD_ACTION_ROUTES` → server refuses to boot. Loud (won't
  start), not silent — deliberately.
- A refactor moves the auth middleware back onto the route group →
  behavioural runtime-order test in `route_runtime_order_test.go` fails
  immediately (verified destructively before merge).
- A refactor drops the drive token from main.go's exclusion arg →
  `main_wiring_test.go` fails immediately (also verified destructively).
- Cross-table `robot` × `app_bot` invariant break (same uid in both) →
  endpoint returns 500 with `ambiguous=true` in the log. Loud, no data
  goes over the wire.

**How to be sure this works.**
- 34 unit tests pass, incl. the 4 app-bot / user-bot classification
  cases and 3 fail-closed error paths.
- End-to-end verified on the local docker VM: new doc → auto-mount to
  owner's personal drive within one polling tick (`sync_status=ok`).
- Two independent destructive tests: revert middleware order → the
  runtime-order test fails; remove exclusion arg → wiring test fails.
- Rate-limit env sanitization covered by 5 explicit tests including
  NaN and +Inf.

## Non-goals / future work

- Batch endpoint. Not needed for v1 — the consumer keeps a per-uid TTL
  cache. Adding later is source-compatible.
- Exposing more of `UserDetailResp` behind this token. Kept minimal —
  one endpoint, one purpose.
- Per-caller audit log on token use. Considered but out of scope for
  #710. Follow-up if data-exposure boundary tightens.
- Consumer-side handling of `robot=1, bot_creator_uid=""` for published
  app_bots (drive-side "skip auto-mount"). Lives on the companion
  drive PR; verify the branch handles the new class before merging.
