### PR TITLE
fix(user): stop leaking scan-login auth_code to anonymous pollers

### DIFF
--- a/.octospec/journal/shared/scanlogin-poll-binding.md
+++ b/.octospec/journal/shared/scanlogin-poll-binding.md
@@ -1,0 +1,115 @@
+---
+type: Journal
+title: "Journal: scanlogin-poll-binding"
+description: Scan-login stops handing auth_code to any anonymous poller who knows the uuid — a poll_secret now gates the credential fields. This closes QR-observer hijack but NOT QRLJacking, which no server-side control can close; the server half of the real mitigation (requesting-device context on the confirm screen) ships here and is blocked on mobile rendering.
+tags: ["auth", "scan-login", "security", "rate-limit", "wire-contract", "qrljacking"]
+timestamp: 2026-08-07T00:00:00Z
+# --- octospec extension fields ---
+task: scanlogin-poll-binding
+upstream: self (code audit; not covered by either pentest report)
+source: self
+---
+# Journal: scanlogin-poll-binding
+
+## What this does and does not close
+
+**Closed — QR-observer hijack.** `GET /v1/user/loginstatus` used to return the whole
+`qrcode:{uuid}` payload, `auth_code` included, to anyone presenting the uuid. The uuid is
+visible to anyone who can see the QR: shoulder-surfing, a screenshot forwarded in a chat,
+a screen-share, a recording. Any of them could poll and steal the login. A `poll_secret`
+minted with the uuid and returned only in the response body now gates the credential
+fields, so seeing the QR is no longer enough.
+
+**NOT closed — QRLJacking.** The first version of this task claimed it was. That claim was
+wrong and code review caught it. In QRLJacking the attacker **mints the uuid themselves**
+(`loginuuid` is unauthenticated), so `poll_secret` is handed straight to them along with
+the uuid; they poll their own uuid with their own secret, the check passes, and
+`auth_code` comes back. Binding the poll channel to the minter does nothing when the
+minter *is* the attacker.
+
+This is not fixable server-side. The server cannot distinguish "victim scanned the
+attacker's QR" from "user scanned their own QR" — both are a legitimately authenticated
+scan of a legitimately minted code. **Only the person confirming can tell**, and only if
+shown enough to notice. So the server half of the real mitigation ships here:
+`ScanLoginOrigin` (requesting IP / device name / model / UA) is captured at
+`loginuuid` and returned to the phone from `handleScanLogin` as
+`HandlerTypeLoginConfirm.origin`. **Until iOS/Android render it in the confirm dialog,
+QRLJacking still works.** That mobile work is the blocking follow-up.
+
+## What was done
+
+- `modules/user/scanlogin_poll.go` (new): `mintScanLoginPollSecret` (stores **SHA-256**
+  under `scanlogin:poll:{uuid}`), `scanLoginPollSecretMatches` (fail-closed,
+  `subtle.ConstantTimeCompare`), `deleteScanLoginPollSecret`,
+  `filterScanLoginPublicFields`, and the `ScanLoginOrigin` capture/load pair. All of it
+  is written against a small `pollSecretStore` interface so the gate is unit-testable
+  without Redis.
+- `modules/user/api.go`: `getLoginUUID` mints the secret and records the origin;
+  `getloginStatus` reads the secret from the **`X-Scan-Poll-Secret` header** and routes
+  every payload emission through one `respondStatus` gate; `loginWithAuthCode` revokes the
+  secret on redemption. Both routes carry `StrictIPRateLimitMiddleware`.
+- `modules/qrcode/api.go`: `authCode` TTL 10min → 5min; `handleScanLogin` returns `origin`.
+- octo-web `login_vm.tsx`: stores `poll_secret`, replays it as a header, and falls back to
+  re-minting the QR when `auth_code` is absent.
+
+## Load-bearing decisions
+
+- **Allow-list, not deny-list.** `qrcode:{uuid}` is written in three places
+  (`getLoginUUID`, `handleScanLogin`, `grantLogin`). A deny-list of sensitive keys
+  fails open the moment someone adds a field in any of them — and the first version's
+  guard test only read `grantLogin`. `scanLoginPublicDataKeys` now lists the two keys
+  that may leave (`status`, `app_id`); everything else is dropped by default.
+- **The secret must never enter the qrcode payload**, which is exactly what
+  `getloginStatus` echoes. Locked by a test that parses the `NewQRCodeModel(...)` literal.
+- **Header, not query.** Putting the plaintext in the URL would have it written verbatim
+  into nginx/CDN/WAF access logs, APM spans and browser history — cancelling out the
+  reason for storing only a digest at rest.
+- **Fail-closed everywhere**, including store errors. One fail-open branch restores the
+  original hole.
+- **Own your channel.** `removeQRCodeChan(uuid)` closes whatever is registered for the
+  uuid, not the caller's. On an unauthenticated long-poll endpoint that let anyone who
+  knows a uuid connect-and-abort in a loop to keep evicting the legitimate poller.
+  `removeQRCodeChanOwned` only reclaims the channel this request registered.
+- **Never emit an empty 200.** `respondStatus(nil)` originally wrote nothing, which gin
+  turns into a zero-length 200; the frontend then sets `loginStatus = undefined` and the
+  state machine stops matching, freezing the page. It now falls back to the state read at
+  request start.
+- **Rate limits deliberately loose (120/600 per min) and env-tunable.** `qrcode:{uuid}`
+  has a 60s TTL so every parked login page re-mints ~1/min; a 100-person office behind one
+  egress IP is ~100 mints/min. And when a reverse proxy has no `X-Real-Ip`/`X-Forwarded-For`,
+  `getClientIP` falls back to `RemoteAddr` — nginx's own address — collapsing the whole
+  deployment into one bucket. The first version's 20/min would have locked buildings out.
+- **Auth-gate exemption documented in place.** `space-isolation` wants every route behind
+  `AuthMiddleware` or an explanation. These two cannot be: the QR renders before any token
+  exists.
+
+## Learning
+
+**Binding a channel to "whoever minted it" is not an access control when minting is
+unauthenticated.** The whole first version rested on that confusion, and it survived
+because every individual check looked sound: the uuid is real UUIDv4 from `crypto/rand`,
+`grantLogin` correctly verifies `scaner == loginUID`, the secret is hashed and compared in
+constant time. None of that mattered, because the party being authenticated was the
+attacker.
+
+The question to ask of any mint→poll flow is not "is this token unguessable?" but
+**"who ends up holding it, and is that the party I actually want to authorize?"** When the
+answer is "whoever asked", the binding is a no-op against anyone who can ask — which, on
+an unauthenticated endpoint, is everyone.
+
+Staged in `.octospec/learnings/pending/`.
+
+## Verification notes
+
+`go build ./...`, `go vet`, `make i18n-extract-check`, `make i18n-lint` pass; the three
+touched files are `gofmt`-clean (the repo has pre-existing drift elsewhere, tracked under
+`.golangci.yml`'s `TODO(octo-lint-cleanup)`). The security gate now has real behavioural
+tests via an injected in-memory store — correct / wrong / missing secret, store-error
+fail-closed, digest-not-plaintext, revocation, and TTL-covers-worst-case.
+
+**The full `./modules/user/` package cannot run in the dev sandbox** — many tests call
+`testutil.NewTestServer()`, which needs MySQL on 127.0.0.1:3306; a clean `origin/main`
+worktree fails identically, so this is environmental. **octo-web lint/test could not run
+either**: `pnpm install` cannot complete because `cdn.sheetjs.com` (sheetjs' own CDN, not
+the npm registry) is refused by the sandbox egress policy. CI is the first real gate for
+the web change.

--- a/.octospec/journal/shared/scanlogin-poll-binding.md
+++ b/.octospec/journal/shared/scanlogin-poll-binding.md
@@ -52,16 +52,15 @@ octo-ios#71 / octo-android#116.
   `filterScanLoginPublicFields`. All of it is written against a small `pollSecretStore`
   interface so the gate is unit-testable without Redis.
 - `modules/user/api.go`: `getLoginUUID` mints the secret and sets `Cache-Control: no-store`;
-  `getloginStatus` resolves the secret through `scanLoginPresentedPollSecret` (header first,
-  query fallback) and routes every payload emission through one `respondStatus` gate, and
-  only registers a long-poll channel when authorized; `grantLogin` renews the auth code at
+  `getloginStatus` reads the secret from the `poll_secret` query parameter, routes every
+  payload emission through one `respondStatus` gate, and only registers a long-poll channel
+  when authorized; `grantLogin` renews the auth code at
   confirm time; `loginWithAuthCode` revokes the secret and deletes `qrcode:{uuid}`.
   Both routes carry `StrictIPRateLimitMiddleware`. `removeQRCodeChan` is gone.
 - `modules/qrcode/api.go`: auth-code TTL now `user.ScanLoginAuthCodeTTL` (5min).
 - `modules/user/swagger/api.yaml`: documents `poll_secret` and both credential channels.
-- octo-lib#116: registers `X-Scan-Poll-Secret` in the CORS allow-list.
-- octo-web `login_vm.tsx`: stores `poll_secret`, sends the header (plus a query copy when
-  the API base is cross-origin), and re-mints the QR when `auth_code` is withheld.
+- octo-web `login_vm.tsx`: stores `poll_secret`, replays it on every poll, and re-mints the
+  QR when `auth_code` is withheld.
 
 ## Load-bearing decisions
 
@@ -72,16 +71,20 @@ octo-ios#71 / octo-android#116.
   that may leave (`status`, `app_id`); everything else is dropped by default.
 - **The secret must never enter the qrcode payload**, which is exactly what
   `getloginStatus` echoes. Locked by a test that parses the `NewQRCodeModel(...)` literal.
-- **Header first, query only where the header cannot travel.** Plaintext in a URL is
-  written verbatim into nginx/CDN/WAF access logs, APM spans and browser history, which
-  would cancel out storing only a digest at rest. But a custom header makes the poll a
-  non-simple request, and octo-lib's `CORSMiddleware` hardcodes `Access-Control-Allow-Headers`
-  and aborts `OPTIONS` with 204 the moment it is set — headers are flushed, so no downstream
-  middleware can extend the list. A cross-origin preflight would reject the *real* request:
-  the Tauri/Electron desktop build (absolute API origin) would lose scan-login entirely, and
-  "degrade by stripping" cannot help because nothing reaches the handler. octo-lib#116 fixes
-  the list; until it ships, cross-origin clients send the secret in the query and the server
-  accepts either. Both sides carry a `SUNSET` comment naming the removal condition.
+- **Query parameter, not a custom header.** A first pass used `X-Scan-Poll-Secret` to keep
+  the plaintext out of access logs, and it was reverted. The benefit is narrow: whoever can
+  read nginx/APM logs is ops, and the same people hold Redis credentials — they can read
+  `auth_code` straight out of `qrcode:{uuid}`, so the header stops nobody who could not
+  already take over any account. The secret also expires in 12 minutes, is revoked on
+  redemption, and is useless without a scan flow running concurrently. The cost was real:
+  a custom header makes the poll a non-simple request, octo-lib's `CORSMiddleware` hardcodes
+  `Access-Control-Allow-Headers` and aborts `OPTIONS` the moment it sets them, so the
+  cross-origin preflight rejects the *actual* request and the Tauri/Electron desktop build
+  loses scan-login entirely — fixable only via an octo-lib release, a dependency bump, and a
+  dual-channel transition. If log exposure is worth addressing, the right place is log-layer
+  scrubbing (nginx `map` rewriting `$request`, APM URL scrubbing), which covers every
+  sensitive query parameter at once instead of amending a shared library's CORS list per
+  parameter.
 - **Renew the auth code at confirm, not just the QR state.** The code is minted at *scan*
   time and the user can sit on the confirm screen for its whole TTL. Refreshing only
   `qrcode:{uuid}` produced `status: authed` carrying a credential with a second left —

--- a/.octospec/journal/shared/scanlogin-poll-binding.md
+++ b/.octospec/journal/shared/scanlogin-poll-binding.md
@@ -1,7 +1,7 @@
 ---
 type: Journal
 title: "Journal: scanlogin-poll-binding"
-description: Scan-login stops handing auth_code to any anonymous poller who knows the uuid — a poll_secret now gates the credential fields. This closes QR-observer hijack but NOT QRLJacking, which no server-side control can close; the server half of the real mitigation (requesting-device context on the confirm screen) ships here and is blocked on mobile rendering.
+description: Scan-login stops handing auth_code to any anonymous poller who knows the uuid — a poll_secret now gates the credential fields. Closes QR-observer hijack but NOT QRLJacking, which no server-side control can close. Also fixes an auth-code expiry inversion, a channel-displacement vector, and post-login state that outlived the session.
 tags: ["auth", "scan-login", "security", "rate-limit", "wire-contract", "qrljacking"]
 timestamp: 2026-08-07T00:00:00Z
 # --- octospec extension fields ---
@@ -30,27 +30,38 @@ minter *is* the attacker.
 This is not fixable server-side. The server cannot distinguish "victim scanned the
 attacker's QR" from "user scanned their own QR" — both are a legitimately authenticated
 scan of a legitimately minted code. **Only the person confirming can tell**, and only if
-shown enough to notice. So the server half of the real mitigation ships here:
-`ScanLoginOrigin` (requesting IP / device name / model / UA) is captured at
-`loginuuid` and returned to the phone from `handleScanLogin` as
-`HandlerTypeLoginConfirm.origin`. **Until iOS/Android render it in the confirm dialog,
-QRLJacking still works.** That mobile work is the blocking follow-up.
+shown enough to notice.
+
+A first pass shipped the server half of that (`ScanLoginOrigin` — requesting IP / device /
+UA returned to the phone at scan time). **Review pulled it back out, correctly.** Every one
+of those fields is attacker-controlled: `device_name` / `device_model` come straight from
+`loginuuid` query params, `User-Agent` is a request header, and the IP came from
+`c.ClientIP()` — neither this repo nor octo-lib calls `SetTrustedProxies`, so gin trusts
+`0.0.0.0/0` and takes the leftmost `X-Forwarded-For` entry, which the client can pre-seed.
+The attacker who minted the QR could therefore make the confirm dialog display the
+*victim's own* IP and device name. That turns weak evidence into false assurance — strictly
+worse than showing nothing. Getting it right needs a trusted IP source, which in turn needs
+ops to confirm whether the reverse proxy overwrites or appends XFF. Tracked in
+octo-ios#71 / octo-android#116.
 
 ## What was done
 
 - `modules/user/scanlogin_poll.go` (new): `mintScanLoginPollSecret` (stores **SHA-256**
   under `scanlogin:poll:{uuid}`), `scanLoginPollSecretMatches` (fail-closed,
   `subtle.ConstantTimeCompare`), `deleteScanLoginPollSecret`,
-  `filterScanLoginPublicFields`, and the `ScanLoginOrigin` capture/load pair. All of it
-  is written against a small `pollSecretStore` interface so the gate is unit-testable
-  without Redis.
-- `modules/user/api.go`: `getLoginUUID` mints the secret and records the origin;
-  `getloginStatus` reads the secret from the **`X-Scan-Poll-Secret` header** and routes
-  every payload emission through one `respondStatus` gate; `loginWithAuthCode` revokes the
-  secret on redemption. Both routes carry `StrictIPRateLimitMiddleware`.
-- `modules/qrcode/api.go`: `authCode` TTL 10min → 5min; `handleScanLogin` returns `origin`.
-- octo-web `login_vm.tsx`: stores `poll_secret`, replays it as a header, and falls back to
-  re-minting the QR when `auth_code` is absent.
+  `filterScanLoginPublicFields`. All of it is written against a small `pollSecretStore`
+  interface so the gate is unit-testable without Redis.
+- `modules/user/api.go`: `getLoginUUID` mints the secret and sets `Cache-Control: no-store`;
+  `getloginStatus` resolves the secret through `scanLoginPresentedPollSecret` (header first,
+  query fallback) and routes every payload emission through one `respondStatus` gate, and
+  only registers a long-poll channel when authorized; `grantLogin` renews the auth code at
+  confirm time; `loginWithAuthCode` revokes the secret and deletes `qrcode:{uuid}`.
+  Both routes carry `StrictIPRateLimitMiddleware`. `removeQRCodeChan` is gone.
+- `modules/qrcode/api.go`: auth-code TTL now `user.ScanLoginAuthCodeTTL` (5min).
+- `modules/user/swagger/api.yaml`: documents `poll_secret` and both credential channels.
+- octo-lib#116: registers `X-Scan-Poll-Secret` in the CORS allow-list.
+- octo-web `login_vm.tsx`: stores `poll_secret`, sends the header (plus a query copy when
+  the API base is cross-origin), and re-mints the QR when `auth_code` is withheld.
 
 ## Load-bearing decisions
 
@@ -61,15 +72,34 @@ QRLJacking still works.** That mobile work is the blocking follow-up.
   that may leave (`status`, `app_id`); everything else is dropped by default.
 - **The secret must never enter the qrcode payload**, which is exactly what
   `getloginStatus` echoes. Locked by a test that parses the `NewQRCodeModel(...)` literal.
-- **Header, not query.** Putting the plaintext in the URL would have it written verbatim
-  into nginx/CDN/WAF access logs, APM spans and browser history — cancelling out the
-  reason for storing only a digest at rest.
+- **Header first, query only where the header cannot travel.** Plaintext in a URL is
+  written verbatim into nginx/CDN/WAF access logs, APM spans and browser history, which
+  would cancel out storing only a digest at rest. But a custom header makes the poll a
+  non-simple request, and octo-lib's `CORSMiddleware` hardcodes `Access-Control-Allow-Headers`
+  and aborts `OPTIONS` with 204 the moment it is set — headers are flushed, so no downstream
+  middleware can extend the list. A cross-origin preflight would reject the *real* request:
+  the Tauri/Electron desktop build (absolute API origin) would lose scan-login entirely, and
+  "degrade by stripping" cannot help because nothing reaches the handler. octo-lib#116 fixes
+  the list; until it ships, cross-origin clients send the secret in the query and the server
+  accepts either. Both sides carry a `SUNSET` comment naming the removal condition.
+- **Renew the auth code at confirm, not just the QR state.** The code is minted at *scan*
+  time and the user can sit on the confirm screen for its whole TTL. Refreshing only
+  `qrcode:{uuid}` produced `status: authed` carrying a credential with a second left —
+  redemption fails and the state machine has nowhere to go. The 10min→5min TTL change is
+  what made this reachable: the old 5 minutes of slack had been hiding it.
+- **Only authorized pollers get a channel.** `getQRCodeModelChan` overwrites unconditionally,
+  so an unauthorized poller could keep capturing the push and leave the legitimate one
+  waiting out the full 10s every cycle. Credentials were never at risk (the allow-list still
+  applied), but it was a cheap sustained login-latency penalty on an unauthenticated
+  endpoint. Unauthorized callers still wait the same 10s — returning early would leak a
+  timing signal about whether the secret was right, and would let an attacker poll faster.
 - **Fail-closed everywhere**, including store errors. One fail-open branch restores the
   original hole.
 - **Own your channel.** `removeQRCodeChan(uuid)` closes whatever is registered for the
   uuid, not the caller's. On an unauthenticated long-poll endpoint that let anyone who
   knows a uuid connect-and-abort in a loop to keep evicting the legitimate poller.
-  `removeQRCodeChanOwned` only reclaims the channel this request registered.
+  `removeQRCodeChanOwned` only reclaims the channel this request registered — and the old
+  method is deleted rather than left around, since it kept the more obvious-looking name.
 - **Never emit an empty 200.** `respondStatus(nil)` originally wrote nothing, which gin
   turns into a zero-length 200; the frontend then sets `loginStatus = undefined` and the
   state machine stops matching, freezing the page. It now falls back to the state read at
@@ -107,9 +137,13 @@ touched files are `gofmt`-clean (the repo has pre-existing drift elsewhere, trac
 tests via an injected in-memory store — correct / wrong / missing secret, store-error
 fail-closed, digest-not-plaintext, revocation, and TTL-covers-worst-case.
 
-**The full `./modules/user/` package cannot run in the dev sandbox** — many tests call
-`testutil.NewTestServer()`, which needs MySQL on 127.0.0.1:3306; a clean `origin/main`
-worktree fails identically, so this is environmental. **octo-web lint/test could not run
-either**: `pnpm install` cannot complete because `cdn.sheetjs.com` (sheetjs' own CDN, not
-the npm registry) is refused by the sandbox egress policy. CI is the first real gate for
-the web change.
+A local integration environment was later stood up (MySQL 8.0.46 + Redis + WuKongIM 2.2.4 —
+setup and the per-package-database requirement are recorded in `integration-test-env.md`
+next to this task's brief), so `./modules/user/` and `./modules/qrcode/` now pass in full
+against live infrastructure. Whole repo: 102 pass / 4 fail, with the four confirmed
+pre-existing by running the same packages on a clean `origin/main` worktree and diffing the
+failing test names (byte-identical).
+
+octo-web's `@octo/login` suite passes (210 tests). `apps/web` shows 52 failing files both
+on this branch and on `main` — verified by checking the one changed file back out to the
+`main` version and re-running.

--- a/.octospec/learnings/pending/binding-to-the-minter-is-not-access-control.md
+++ b/.octospec/learnings/pending/binding-to-the-minter-is-not-access-control.md
@@ -1,0 +1,67 @@
+---
+type: Learning
+title: "Binding a channel to whoever minted it is not access control when minting is unauthenticated"
+description: Session-binding a poll/callback channel to its requester only excludes third parties. If the mint endpoint is open, the attacker is the requester, so the binding is a no-op against them — ask who ends up holding the token, not whether it can be guessed.
+tags: [auth, session-binding, capability, polling, callback, qrljacking, security, threat-model]
+timestamp: 2026-08-07T00:00:00Z
+status: pending
+---
+
+# Binding to the minter is not access control
+
+## Context
+
+Scan-login handed `auth_code` — directly redeemable for a full user token — to anyone
+polling `GET /v1/user/loginstatus` with the right `uuid`. The fix attempt was to mint a
+`poll_secret` alongside the uuid and require it on the poll, binding the channel to the
+browser that requested the QR.
+
+That fix was written to close QRLJacking (attacker mints a QR, puts it on a phishing page,
+victim scans and confirms, attacker harvests the credential). **It does not.** The attacker
+is the one calling `loginuuid`, so `poll_secret` is issued to *them*, along with the uuid.
+They poll their own uuid with their own secret and the check passes.
+
+What made this hard to see is that every individual control was sound:
+
+- the uuid is UUIDv4 over `crypto/rand` — 122 bits, unguessable;
+- `grantLogin` correctly verifies `scaner == loginUID`;
+- the secret is stored as a SHA-256 digest and compared with
+  `subtle.ConstantTimeCompare`.
+
+None of it mattered. The party being authenticated was the attacker.
+
+## The rule
+
+Session-binding excludes **third parties**. It never excludes **the requester**. So for any
+mint → read-back-state flow, the security question is not
+
+> "can this token be guessed?"
+
+but
+
+> **"who ends up holding this token, and is that the party I actually want to authorize?"**
+
+If the mint endpoint is unauthenticated, "whoever asked" includes every attacker, and the
+binding buys you nothing against them. It is still worth having — it closes the weaker
+*observer* threat (someone who saw the QR / URL / callback id but did not request it) — but
+it must not be described as closing the impersonation threat.
+
+When the requester and the victim are different people and only the victim can tell them
+apart, **the control has to live in the victim's confirmation UI**: show the requesting
+device, IP, and location, and make refusing easy. No server-side check can substitute,
+because both branches look identical on the wire.
+
+## Applies to
+
+Any flow where an anonymous client mints an id and later reads state back keyed on it:
+QR/device pairing, email- and SMS-confirmation polls, OAuth-ish callback handoffs, job
+status endpoints for anonymously submitted work.
+
+Corollaries worth keeping:
+
+- Filter the echoed payload with an **allow-list**. `qrcode:{uuid}` has three writers; a
+  deny-list of sensitive keys fails open the first time anyone adds a field.
+- Carry the secret in a **header**, not the query string, or access logs, CDN/WAF logs,
+  APM spans and browser history undo the at-rest hashing.
+
+Reference implementation: `modules/user/scanlogin_poll.go`.

--- a/.octospec/log.md
+++ b/.octospec/log.md
@@ -9,7 +9,7 @@ change-log convention (§7). Newest first.
 - **Task** — `scanlogin-poll-binding`: `loginstatus` no longer hands `auth_code`
   to any anonymous caller who knows the uuid. `loginuuid` mints a `poll_secret`
   (response body only, never in the QR payload) and `loginstatus` releases the
-  credential fields only to a caller presenting it via `X-Scan-Poll-Secret`;
+  credential fields only to a caller presenting it;
   everyone else gets the real status filtered through an allow-list. Both
   endpoints — unauthenticated by design, since the QR renders before any token
   exists — gained `StrictIPRateLimitMiddleware`; `auth_code` TTL 10min → 5min;
@@ -23,8 +23,10 @@ change-log convention (§7). Newest first.
   Tracked in octo-ios#71 / octo-android#116. Review also surfaced an auth-code
   expiry inversion that the TTL change had made reachable, a channel-displacement
   vector on the long poll, and post-login state (incl. Signal key material)
-  outliving the session — all fixed here. Needs octo-lib#116 for the header to
-  work cross-origin. See [journal](journal/shared/scanlogin-poll-binding.md).
+  outliving the session — all fixed here. The secret travels as a query
+  parameter; a custom header was tried and reverted — it breaks cross-origin
+  scan-login for a benefit that only holds against readers who already have
+  Redis access. See [journal](journal/shared/scanlogin-poll-binding.md).
 
 ## 2026-08-06 (bot-setting-store)
 

--- a/.octospec/log.md
+++ b/.octospec/log.md
@@ -4,6 +4,23 @@ Change history for this repo's `.octospec/`, following the
 [OKF](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md)
 change-log convention (§7). Newest first.
 
+## 2026-08-07 (scanlogin-poll-binding)
+
+- **Task** — `scanlogin-poll-binding`: `loginstatus` no longer hands `auth_code`
+  to any anonymous caller who knows the uuid. `loginuuid` mints a `poll_secret`
+  (response body only, never in the QR payload) and `loginstatus` releases the
+  credential fields only to a caller presenting it via `X-Scan-Poll-Secret`;
+  everyone else gets the real status filtered through an allow-list. Both
+  endpoints — unauthenticated by design, since the QR renders before any token
+  exists — gained `StrictIPRateLimitMiddleware`; `auth_code` TTL 10min → 5min;
+  the secret is revoked on redemption; the 10s long poll releases on disconnect
+  and only reclaims its own channel. Cross-repo: octo-web replays the header.
+  **This closes QR-observer hijack, not QRLJacking** — the attacker mints the
+  uuid and so receives the secret too. The server half of the real mitigation
+  (requesting device/IP on the confirm screen) ships here and is blocked on
+  iOS/Android rendering it. See
+  [journal](journal/shared/scanlogin-poll-binding.md).
+
 ## 2026-08-06 (bot-setting-store)
 
 - **Task** — `bot-setting-store`: added `bot_setting`, a generic per-bot config

--- a/.octospec/log.md
+++ b/.octospec/log.md
@@ -16,10 +16,15 @@ change-log convention (§7). Newest first.
   the secret is revoked on redemption; the 10s long poll releases on disconnect
   and only reclaims its own channel. Cross-repo: octo-web replays the header.
   **This closes QR-observer hijack, not QRLJacking** — the attacker mints the
-  uuid and so receives the secret too. The server half of the real mitigation
-  (requesting device/IP on the confirm screen) ships here and is blocked on
-  iOS/Android rendering it. See
-  [journal](journal/shared/scanlogin-poll-binding.md).
+  uuid and so receives the secret too. The confirm-screen device context that
+  *would* close it was pulled after review: every field of it is
+  attacker-controlled today (gin trusts all proxies, so even the IP is
+  forgeable), which would have turned weak evidence into false assurance.
+  Tracked in octo-ios#71 / octo-android#116. Review also surfaced an auth-code
+  expiry inversion that the TTL change had made reachable, a channel-displacement
+  vector on the long poll, and post-login state (incl. Signal key material)
+  outliving the session — all fixed here. Needs octo-lib#116 for the header to
+  work cross-origin. See [journal](journal/shared/scanlogin-poll-binding.md).
 
 ## 2026-08-06 (bot-setting-store)
 

--- a/.octospec/tasks/scanlogin-poll-binding/brief.md
+++ b/.octospec/tasks/scanlogin-poll-binding/brief.md
@@ -1,7 +1,7 @@
 ---
 type: Task
 title: "Task: scanlogin-poll-binding"
-description: Bind the scan-login poll channel to the browser that minted the QR, closing the QRLJacking account-takeover path.
+description: Bind the scan-login poll channel to the browser that minted the QR. Closes QR-observer hijack; QRLJacking is explicitly NOT closed and needs the mobile confirm dialog.
 tags: ["auth", "scan-login", "security", "rate-limit", "wire-contract"]
 timestamp: 2026-08-07T00:00:00Z
 # --- octospec extension fields ---
@@ -27,9 +27,15 @@ source: self
 >
 > QRLJacking 无法在服务端单独关闭 —— 服务端区分不出「受害者扫了攻击者的码」与
 > 「本人扫了自己的码」，**只有确认的人能**。唯一的真断点是让确认者看见「请求登录的
-> 是一台陌生设备、来自陌生 IP」并因此拒绝。本任务补齐该能力的服务端半边
-> （`ScanLoginOrigin` 随扫码结果下发给手机），**但在 iOS/Android 把它渲染进确认弹窗
-> 之前，QRLJacking 依然成立**。移动端工作是本漏洞的阻塞项，另开任务跟踪。
+> 是一台陌生设备、来自陌生 IP」并因此拒绝。
+>
+> **二次修订（PR #715 review 后）**：该能力的服务端半边（`ScanLoginOrigin`）曾在本任务
+> 里实现，现已**整体撤除**。原因是那些「依据」目前全部由攻击者掌控：`device_name` /
+> `device_model` 直接来自 `loginuuid` 的 query 参数、`User-Agent` 是请求头，而 IP 走
+> `c.ClientIP()` —— 本仓与 octo-lib 都没调过 `SetTrustedProxies`，gin 默认信任
+> `0.0.0.0/0`、取 `X-Forwarded-For` 最左项，客户端可预置。攻击者能让确认弹窗显示受害者
+> **自己的** IP 和设备名，把弱证据变成假保证，比不显示更糟。要做对需先定下可信来源，
+> 而那依赖运维确认反代对 XFF 是覆盖还是追加。跟踪：octo-ios#71 / octo-android#116。
 
 ## Background
 
@@ -85,9 +91,9 @@ source: self
 
 - **取消 `login_authcode` 这一跳**（让 `loginstatus` 直接下发 token）—— 协议重构，
   影响面超出本次；`poll_secret` 已经堵住利用链
-- **手机确认页 UI 渲染设备上下文** —— 服务端已在本次补齐数据下发
-  （`ScanLoginOrigin` → `HandlerTypeLoginConfirm.origin`），但渲染在 iOS/Android，
-  那两个仓不在本次范围。**这是关闭 QRLJacking 的阻塞项**，必须另开任务跟到底
+- **确认页设备上下文（服务端下发 + 移动端渲染）** —— 整体移出本任务，见上面的二次修订。
+  服务端要先解决可信来源问题，移动端再渲染。**这是关闭 QRLJacking 的阻塞项**，
+  跟踪于 octo-ios#71 / octo-android#116
 - **`modules/file` 预签名上传/下载越权**（复测 4.2/4.4/4.6）—— 独立任务
 - **`pkg/space` SpaceMiddleware fail-open**（复测 4.11）—— 独立任务
 - **octo-lib 的 `common/constant.go`** —— 外部模块，新前缀在 octo-server 本地定义
@@ -105,12 +111,23 @@ source: self
 - [ ] `GET /v1/user/loginstatus?uuid=X&poll_secret=<对值>` 返回完整 Data 含 `auth_code`
 - [ ] 端到端回归：mint → 扫码 → grantLogin → 带对 secret 轮询 → `login_authcode` 兑换成功
 - [ ] `loginuuid` / `loginstatus` 命中 `StrictIPRateLimitMiddleware`，tag 分别为
-      `scanlogin_uuid`（20 req/min，burst 10）与 `scanlogin_status`（120 req/min，
-      burst 60），阈值可经 env 覆盖
+      `scanlogin_uuid`（120 req/min，burst 60）与 `scanlogin_status`（600 req/min，
+      burst 300），阈值可经 env 覆盖。给得松是刻意的：qrcode 初始 TTL 只有 60s，每个停在
+      登录页的浏览器约每分钟重铸一次 uuid，且反代没配 XFF 时 getClientIP 回落 RemoteAddr
+      会把整个部署塌进一个桶
 - [ ] `authcode` TTL = 5min（用户选择的保守值），扫码/授权后 `qrcode` TTL 维持 5min；
       `scanLoginPollSecretTTL` 严格大于最坏可读窗口 60s+5min+5min=660s 并留余量
 - [ ] `getloginStatus` 的 select 含 `c.Request.Context().Done()` 分支
-- [ ] `poll_secret` 经**请求头** `X-Scan-Poll-Secret` 传递，不出现在 URL / access log
+- [ ] `poll_secret` 首选经请求头 `X-Scan-Poll-Secret` 传递；跨源部署可退回 `poll_secret`
+      query（octo-lib CORS 白名单不含自定义头，跨源预检会拒掉整个请求 —— 见 octo-lib#116，
+      合并并 bump 依赖后删除 query 分支）
+- [ ] `grantLogin` 确认时按同一档位给 `authCode` 续期，杜绝「status=authed 但 auth_code
+      已过期」的倒挂窗口
+- [ ] 未授权轮询方**不注册**长轮询 channel（否则可持续顶掉合法轮询方），但仍等满同样
+      时长，不泄露密钥正确与否的时序信号
+- [ ] `loginWithAuthCode` 兑换后一并删除 `qrcode:{uuid}`（仍携带 `encrypt` Signal 密钥材料）
+- [ ] `getLoginUUID` 响应带 `Cache-Control: no-store`
+- [ ] swagger 记录 `poll_secret` 响应字段与两个凭据通道
 - [ ] 敏感字段过滤用**白名单**（`scanLoginPublicDataKeys`）而非黑名单——payload 有
       三处写入方（`getLoginUUID` / `handleScanLogin` / `grantLogin`），黑名单对新增
       字段 fail-open

--- a/.octospec/tasks/scanlogin-poll-binding/brief.md
+++ b/.octospec/tasks/scanlogin-poll-binding/brief.md
@@ -118,9 +118,10 @@ source: self
 - [ ] `authcode` TTL = 5min（用户选择的保守值），扫码/授权后 `qrcode` TTL 维持 5min；
       `scanLoginPollSecretTTL` 严格大于最坏可读窗口 60s+5min+5min=660s 并留余量
 - [ ] `getloginStatus` 的 select 含 `c.Request.Context().Done()` 分支
-- [ ] `poll_secret` 首选经请求头 `X-Scan-Poll-Secret` 传递；跨源部署可退回 `poll_secret`
-      query（octo-lib CORS 白名单不含自定义头，跨源预检会拒掉整个请求 —— 见 octo-lib#116，
-      合并并 bump 依赖后删除 query 分支）
+- [ ] `poll_secret` 经 `poll_secret` query 参数传递。**不用自定义请求头**：那会让轮询
+      变成非简单请求，而 octo-lib 的 CORS 白名单写死且不含它、OPTIONS 又立即 abort，
+      跨源预检拒掉的是真正的 GET，桌面端扫码登录直接不可用；换来的只是「明文不进
+      access log」，而能读日志的运维本来就有 Redis 权限。日志泄露应在日志层脱敏解决
 - [ ] `grantLogin` 确认时按同一档位给 `authCode` 续期，杜绝「status=authed 但 auth_code
       已过期」的倒挂窗口
 - [ ] 未授权轮询方**不注册**长轮询 channel（否则可持续顶掉合法轮询方），但仍等满同样

--- a/.octospec/tasks/scanlogin-poll-binding/brief.md
+++ b/.octospec/tasks/scanlogin-poll-binding/brief.md
@@ -1,0 +1,136 @@
+---
+type: Task
+title: "Task: scanlogin-poll-binding"
+description: Bind the scan-login poll channel to the browser that minted the QR, closing the QRLJacking account-takeover path.
+tags: ["auth", "scan-login", "security", "rate-limit", "wire-contract"]
+timestamp: 2026-08-07T00:00:00Z
+# --- octospec extension fields ---
+slug: scanlogin-poll-binding
+upstream: pentest-retest-2026-07-30 (未列条目，代码审计新增)
+source: self
+---
+
+# Task: scanlogin-poll-binding
+
+## Goal
+
+扫码登录链路上，`auth_code` 会被下发给**任何知道 uuid 的匿名轮询方**。本任务给轮询侧
+加上会话绑定：`GET /v1/user/loginuuid` 额外下发一枚 `poll_secret`（只进响应体，不进
+二维码），`GET /v1/user/loginstatus` 只有携带匹配的 `poll_secret` 才能拿到敏感字段。
+
+> **⚠️ 修订（code review 后）：本任务不关闭 QRLJacking。**
+>
+> 初版 brief 声称 `poll_secret` 断掉了「攻击者自建二维码钓鱼」的链路，**这是错的**。
+> 攻击者是**自己调用 `loginuuid`** 的那一方，`poll_secret` 会连同 uuid 一起发给他；
+> 他拿自己的密钥轮询自己的 uuid，校验通过，`auth_code` 照拿。会话绑定挡住的是
+> **另一个更弱的威胁**：第三方看到了二维码（肩窥、截图转发、录屏）但并未 mint 它。
+>
+> QRLJacking 无法在服务端单独关闭 —— 服务端区分不出「受害者扫了攻击者的码」与
+> 「本人扫了自己的码」，**只有确认的人能**。唯一的真断点是让确认者看见「请求登录的
+> 是一台陌生设备、来自陌生 IP」并因此拒绝。本任务补齐该能力的服务端半边
+> （`ScanLoginOrigin` 随扫码结果下发给手机），**但在 iOS/Android 把它渲染进确认弹窗
+> 之前，QRLJacking 依然成立**。移动端工作是本漏洞的阻塞项，另开任务跟踪。
+
+## Background
+
+当前链路（代码位置为 `8a9df20`）：
+
+| 步 | 接口 | 鉴权 | 行为 |
+|---|---|---|---|
+| 1 | `GET /v1/user/loginuuid` | 无认证、无限流 | `api.go:2024` 生成 uuid（`util.GenerUUID()` = crypto/rand UUIDv4，**不可爆破**） |
+| 2 | `GET {QRCodeInfoURL}?code=uuid` | AuthMiddleware | `qrcode/api.go:167` 签发 `auth_code`，绑定 `scaner` |
+| 3 | `GET /v1/user/grant_login` | AuthMiddleware | `api.go:2374` 校验 `scaner == loginUID` ✅；`api.go:2381` 把 `auth_code` **明文**写进 qrcode 状态 |
+| 4 | `GET /v1/user/loginstatus?uuid=` | 无认证、无限流 | `api.go:2094` 把 `qrcodeModel.Data` 整包吐出 → 含 `auth_code` |
+| 5 | `POST /v1/user/login_authcode/{code}` | loginLimit | 只验 code 存在 + type，**不验兑换者身份** → 发 token |
+
+第 3 步的 `scaner == loginUID` 校验是正确的，洞不在那里。洞在于 **uuid 与「申请它的
+浏览器」之间没有任何绑定**，且第 5 步没有兜底校验。前端 `login_vm.tsx:451` 印证：轮询
+就是裸 `user/loginstatus?uuid=${uuid}`，没有第二个凭据。
+
+两份渗透报告（2026-05-15 首测 / 2026-07-30 复测）均未覆盖此路径 —— 扫码是交互式流程，
+自动化扫描器进不去。
+
+## Load-bearing list
+
+- `auth` — 扫码登录是**未认证 → 已认证**的凭据签发链路，任何 fail-open 都是账号接管
+- `rate-limit` — `loginuuid` / `loginstatus` 目前无限流；`loginstatus` 长轮询挂 10s
+- `wire-contract` — `loginuuid` 响应新增 `poll_secret` 字段；`loginstatus` 响应在未
+  携带 secret 时收窄（`auth_code` / `uid` / `encrypt` 被剥离）
+- `error-response` / `i18n` — `modules/user` 已迁移 i18n，新增的拒绝路径必须走
+  `respondUserError` + 注册的 `pkg/errcode` 码，不得用裸 `c.ResponseError`
+- `test` — 需覆盖「无 secret / 错 secret / 对 secret」三条路径
+
+## 设计要点
+
+1. **`poll_secret` 生成与存储**：`getLoginUUID` 生成 `util.GenerUUID()`，把 **SHA-256**
+   存进独立 Redis key `scanlogin:poll:{uuid}`（TTL 与 qrcode 同步），明文只在 HTTP 响应
+   体里回给申请方一次。**绝不写进 `qrcode:{uuid}` 的 payload** —— 那个 payload 正是
+   `loginstatus` 要回显的内容，写进去等于自我否定。
+2. **比对**：`subtle.ConstantTimeCompare`，避免比对环节留时序侧信道。
+3. **降级语义（fail-closed）**：secret 缺失或不匹配 → 仍返回真实 `status`，但剥离
+   `auth_code` / `uid` / `encrypt`。选择「剥字段」而非「报错」是为了让部署窗口内仍持有
+   旧 bundle 的浏览器停在授权页而不是陷入 `expired → 重新申请` 的死循环；旧 bundle 不会
+   拿到 `auth_code`，安全性不打折。
+4. **限流**：`loginuuid` / `loginstatus` 补 `StrictIPRateLimitMiddleware`。注意
+   `loginstatus` 是长轮询、且企业 NAT 下大量用户共用出口 IP，阈值必须给足，宁松勿断
+   （具体值见 Acceptance，并保持 env 可调）。
+5. **TTL 收敛**：`authcode` 10min → 5min；`qrcode` 扫码/授权后续期维持 5min。加了
+   `poll_secret` 之后窗口本身已不是主要风险面，取保守值以避免弱网/慢操作用户回归。
+6. **长轮询泄漏**：`getloginStatus` 的 select 补 `c.Request.Context().Done()` 分支，
+   客户端断开即释放，不再空转满 10s。
+7. **前端**（octo-web）：`login_vm.tsx` 保存 `loginuuid` 返回的 `poll_secret`，轮询时
+   带上；uuid 轮换时一并轮换。
+
+## Out of scope
+
+- **取消 `login_authcode` 这一跳**（让 `loginstatus` 直接下发 token）—— 协议重构，
+  影响面超出本次；`poll_secret` 已经堵住利用链
+- **手机确认页 UI 渲染设备上下文** —— 服务端已在本次补齐数据下发
+  （`ScanLoginOrigin` → `HandlerTypeLoginConfirm.origin`），但渲染在 iOS/Android，
+  那两个仓不在本次范围。**这是关闭 QRLJacking 的阻塞项**，必须另开任务跟到底
+- **`modules/file` 预签名上传/下载越权**（复测 4.2/4.4/4.6）—— 独立任务
+- **`pkg/space` SpaceMiddleware fail-open**（复测 4.11）—— 独立任务
+- **octo-lib 的 `common/constant.go`** —— 外部模块，新前缀在 octo-server 本地定义
+- 扫码入群（`QRCodeTypeGroup`）链路 —— 不签发登录凭据，不在本次
+
+## Acceptance
+
+**octo-server**
+
+- [ ] `GET /v1/user/loginuuid` 响应含 `poll_secret`，且 `qrcode:{uuid}` 的 Redis
+      payload 中**不含**该值（断言 payload 反序列化后无 `poll_secret` 键）
+- [ ] `GET /v1/user/loginstatus?uuid=X`（无 `poll_secret`）在 status=`authed` 时，
+      响应**不含** `auth_code` / `uid` / `encrypt`，但 `status` 仍为 `authed`
+- [ ] `GET /v1/user/loginstatus?uuid=X&poll_secret=<错值>` 同上被剥离
+- [ ] `GET /v1/user/loginstatus?uuid=X&poll_secret=<对值>` 返回完整 Data 含 `auth_code`
+- [ ] 端到端回归：mint → 扫码 → grantLogin → 带对 secret 轮询 → `login_authcode` 兑换成功
+- [ ] `loginuuid` / `loginstatus` 命中 `StrictIPRateLimitMiddleware`，tag 分别为
+      `scanlogin_uuid`（20 req/min，burst 10）与 `scanlogin_status`（120 req/min，
+      burst 60），阈值可经 env 覆盖
+- [ ] `authcode` TTL = 5min（用户选择的保守值），扫码/授权后 `qrcode` TTL 维持 5min；
+      `scanLoginPollSecretTTL` 严格大于最坏可读窗口 60s+5min+5min=660s 并留余量
+- [ ] `getloginStatus` 的 select 含 `c.Request.Context().Done()` 分支
+- [ ] `poll_secret` 经**请求头** `X-Scan-Poll-Secret` 传递，不出现在 URL / access log
+- [ ] 敏感字段过滤用**白名单**（`scanLoginPublicDataKeys`）而非黑名单——payload 有
+      三处写入方（`getLoginUUID` / `handleScanLogin` / `grantLogin`），黑名单对新增
+      字段 fail-open
+- [ ] 长轮询只回收自己注册的 channel（`removeQRCodeChanOwned`），避免匿名调用方
+      连了就断即可踢掉合法轮询方
+- [ ] `respondStatus(nil)` 必须写出响应，不得产生空 200（会让前端状态机停摆）
+- [ ] `loginWithAuthCode` 兑换成功后吊销 `poll_secret`
+- [ ] 前端在 `auth_code` 缺失时回退重新申请二维码，不得用 undefined 调兑换接口
+- [ ] `mint` / `matches` / `delete` 有**真实行为测试**（注入内存 store），覆盖
+      对/错/缺失密钥与存储故障 fail-closed
+- [ ] 新增拒绝路径全部走 `respondUserError` + 已注册 errcode（无裸 `c.ResponseError`）
+- [ ] `make i18n-extract-check` && `make i18n-lint` 通过
+- [ ] `go build ./...` && `go vet ./...` 通过；`go test ./modules/user/... ./modules/qrcode/...` 通过
+- [ ] `TestUserNoLegacyResponseError` 源码守卫仍通过
+
+**octo-web**
+
+- [ ] `login_vm.tsx` 保存并回传 `poll_secret`；uuid 轮换时 secret 同步轮换
+- [ ] `pnpm lint` 与 `cd apps/web && pnpm test` 通过
+
+**安全回归（手工验证脚本）**
+
+- [ ] 攻击者用自己 mint 的 uuid、不带 secret 轮询，在受害者确认后**拿不到** `auth_code`

--- a/.octospec/tasks/scanlogin-poll-binding/context.yaml
+++ b/.octospec/tasks/scanlogin-poll-binding/context.yaml
@@ -1,0 +1,63 @@
+# Rules resolved for this task. See .octospec/rules/_index.yaml for semantics.
+slug: scanlogin-poll-binding
+resolved_at: 2026-08-07
+
+rules_injected:
+  - id: space-isolation
+    tier: repo
+    priority: 92
+    load_bearing: true
+    matched_by: "touches:auth + paths:modules/**/*.go"
+    applied: >-
+      扫码登录是未认证 → 已认证的凭据签发链路。规则要求「路由默认过 AuthMiddleware，
+      显式豁免必须在代码里写明理由」。loginuuid / loginstatus 按设计必须保持匿名
+      （二维码在登录前渲染），因此改为「匿名可达但凭据字段需持有 mint 时下发的
+      poll_secret」，并在代码注释里写明豁免理由与替代边界。
+  - id: rate-limit
+    tier: repo
+    priority: 80
+    load_bearing: true
+    matched_by: "touches:rate-limit + paths:modules/**/*.go"
+    applied: >-
+      未认证路由使用 StrictIPRateLimitMiddleware（非 SharedUIDRateLimiter，这两个
+      端点没有 uid）。不手写 Redis 计数器。poll_secret 的存储是「按业务身份的一次性
+      凭据」，不是请求频率计数，不触犯「禁止手写计数器」条款。
+  - id: error-handling
+    tier: repo
+    priority: 85
+    load_bearing: true
+    matched_by: "touches:error-response,i18n + paths:modules/**/*.go"
+    applied: >-
+      本次未新增拒绝式错误路径 —— secret 不匹配走「剥离敏感字段」而非报错，故无需
+      注册新 errcode。既有 respondUserError 调用点保持不变。新增文件 scanlogin_poll.go
+      不含 handler，无响应写出。限流中间件自带 i18n rate.limited。
+  - id: testing
+    tier: repo
+    priority: 70
+    load_bearing: false
+    matched_by: "paths:**/*_test.go"
+    applied: >-
+      新增 scanlogin_poll_test.go 覆盖 mint/verify/strip 三组纯函数逻辑，
+      以及 loginstatus 在「无 secret / 错 secret / 对 secret」三态下的响应形状。
+      注意 CleanAllTables 不清 Redis，测试需自行清理 scanlogin:poll:* 与限流桶。
+  - id: commit-style
+    tier: repo
+    priority: 60
+    load_bearing: false
+    matched_by: "paths:**"
+    applied: "英文 Conventional Commits；PR 描述英文。"
+
+files_touched:
+  octo-server:
+    - modules/user/scanlogin_poll.go        # new — secret mint/verify/strip helpers
+    - modules/user/scanlogin_poll_test.go   # new — unit + handler-shape coverage
+    - modules/user/api.go                   # getLoginUUID / getloginStatus / routes / limiters
+    - modules/user/api_i18n_test.go         # add new file to the legacy-response guard list
+    - modules/qrcode/api.go                 # authcode TTL 10min -> 5min
+  octo-web:
+    - packages/dmworklogin/src/login_vm.tsx # persist + replay poll_secret
+
+notes:
+  - octo-lib 的 common/constant.go 是外部模块，不可改；新 Redis 前缀在 octo-server 本地定义。
+  - poll_secret TTL 取 6min = 初始二维码 1min + 扫码后续期 5min 的最坏路径总和，
+    避免用户在第 55 秒扫码时 secret 已过期而 qrcode 刚被续到 5min。

--- a/.octospec/tasks/scanlogin-poll-binding/integration-test-env.md
+++ b/.octospec/tasks/scanlogin-poll-binding/integration-test-env.md
@@ -1,0 +1,85 @@
+---
+type: Note
+title: "Note: running octo-server integration tests locally"
+description: Working setup for MySQL + Redis + WuKongIM, and the one non-obvious gotcha — the suite needs a fresh database per package, otherwise sql-migrate rejects the accumulated migration records.
+tags: ["testing", "integration", "wukongim", "mysql", "redis"]
+timestamp: 2026-08-07T00:00:00Z
+task: scanlogin-poll-binding
+---
+
+# Running the integration tests locally
+
+Verified on this branch, 2026-08-07. Without these three services, every test that
+calls `testutil.NewTestServer()` panics at `dial tcp 127.0.0.1:3306: connect: connection
+refused` — which reads like a broken test but is just a missing dependency.
+
+## Services
+
+```bash
+# Redis
+redis-server --daemonize yes --port 6379 --save "" --appendonly no
+
+# MySQL 8.0
+apt-get update && apt-get install -y mysql-server
+mkdir -p /var/run/mysqld && chown mysql:mysql /var/run/mysqld
+mysqld --user=mysql --daemonize
+mysql -uroot <<'SQL'
+ALTER USER 'root'@'localhost' IDENTIFIED WITH caching_sha2_password BY 'demo';
+CREATE USER IF NOT EXISTS 'root'@'%' IDENTIFIED WITH caching_sha2_password BY 'demo';
+GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION; FLUSH PRIVILEGES;
+CREATE DATABASE IF NOT EXISTS test CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+SQL
+
+# WuKongIM — note this is the release ASSET url, not the tag page
+curl -fsSL -o /usr/local/bin/wukongim \
+  https://github.com/WuKongIM/WuKongIM/releases/download/v2.2.4-20260313/wukongim-linux-amd64
+chmod +x /usr/local/bin/wukongim
+WK_MODE=debug WK_TOKENAUTHON=false WK_EXTERNAL_IP=127.0.0.1 \
+  WK_EXTERNAL_WSADDR=ws://127.0.0.1:5200 wukongim -i &
+# readiness: curl http://127.0.0.1:5001/health  =>  {"status":"ok"}
+```
+
+`WK_TOKENAUTHON=false` is the load-bearing one: the tests use octo-lib's default empty
+manager token, so IM token auth has to be off or `/channel` and `/health` refuse the
+connection. `WK_*` = `WK_` + the config key upcased (`tokenAuthOn` → `WK_TOKENAUTHON`).
+Migrations are applied automatically by `testutil.NewTestServer` → `module.Setup`.
+
+## Gotcha: one fresh database per package
+
+**`go test ./...` does not work against a single `test` database, and `-p 1` does not fix
+it.** Each module embeds its own migration set (`//go:embed sql`) and applies it via
+sql-migrate into whatever database it is pointed at. Run two packages against the same
+database and the second one finds `gorp_migrations` rows it does not recognise:
+
+```
+panic: Unable to create migration plan because of
+       20191106000001_event_legacy01.sql: unknown migration in database
+Error 1054 (42S22): Unknown column 'app_id' in 'field list'
+```
+
+Observed on this branch: `go test ./...` → 22 packages FAIL; with `-p 1` → the same 22
+FAIL; each of those packages run **individually against a freshly created database** →
+PASS. So the failures are an artifact of database reuse, not of the code.
+
+Recreate the schema between packages:
+
+```bash
+for p in $(go list ./...); do
+  mysql -uroot -pdemo -e "DROP DATABASE IF EXISTS test;
+    CREATE DATABASE test CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;"
+  redis-cli flushall > /dev/null
+  go test "$p" -count=1
+done
+```
+
+If you only need one module, a single `DROP`/`CREATE` beforehand is enough:
+
+```bash
+mysql -uroot -pdemo -e "DROP DATABASE IF EXISTS test;
+  CREATE DATABASE test CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;"
+go test ./modules/user/... -count=1
+```
+
+Redis also carries state the DB teardown does not clear — `CleanAllTables` does not touch
+it, and the rate-limit buckets (`ratelimit:uid:*`) and now `scanlogin:poll:*` persist
+across runs. `redis-cli flushall` between packages avoids surprises.

--- a/modules/qrcode/api.go
+++ b/modules/qrcode/api.go
@@ -163,6 +163,14 @@ func (q *QRCode) handleQRCodeInfo(c *wkhttp.Context) {
 
 }
 
+// scanLoginAuthCodeTTL 是扫码登录授权码的存活时间。
+//
+// authCode 可被 POST /v1/user/login_authcode/{code} 直接兑换成 scaner 的完整 token，
+// 且该接口不校验兑换者身份，所以这里的 TTL 就是「凭据一旦外泄的可利用窗口」。原值
+// 10 分钟远超实际所需 —— 从扫码到浏览器完成兑换通常在数秒内。收敛到 5 分钟，既压窄
+// 窗口，又给弱网 / 用户在确认页停顿留足余量。
+const scanLoginAuthCodeTTL = 5 * time.Minute
+
 // 处理扫描登录
 func (q *QRCode) handleScanLogin(loginUID string, uuid string, qrCodeModel common.QRCodeModel) (interface{}, error) {
 	authCode := util.GenerUUID()
@@ -170,7 +178,7 @@ func (q *QRCode) handleScanLogin(loginUID string, uuid string, qrCodeModel commo
 		"scaner": loginUID,
 		"type":   common.AuthCodeTypeScanLogin,
 		"uuid":   uuid,
-	}), time.Minute*10)
+	}), scanLoginAuthCodeTTL)
 	if err != nil {
 		q.Error("生成扫码登录授权码失败", zap.Error(err))
 		return nil, fmt.Errorf("%w: scan login auth code", errQRCodeInternalStoreFailed)
@@ -190,9 +198,29 @@ func (q *QRCode) handleScanLogin(loginUID string, uuid string, qrCodeModel commo
 		return nil, fmt.Errorf("%w: scan login state", errQRCodeInternalStoreFailed)
 	}
 	user.SendQRCodeInfo(uuid, qrcodeInfo)
+
+	// 把「请求登录的那一端是谁」一并回给手机，供确认弹窗展示。
+	//
+	// 扫码登录唯一挡得住 QRLJacking（攻击者自己申请二维码、贴到钓鱼页诱导他人扫码）
+	// 的位置就是这里 —— 服务端无法区分「受害者扫了攻击者的码」和「本人扫了自己的
+	// 码」，只有确认的人能。前提是他看得到请求方的设备与 IP。读取失败不阻断扫码，
+	// 退化为不展示。**移动端渲染前，本字段不产生任何防护效果。**
+	var originResp map[string]interface{}
+	if origin, oErr := user.LoadScanLoginOrigin(q.ctx.GetRedisConn(), uuid); oErr != nil {
+		q.Warn("读取扫码登录来源失败", zap.String("uuid", uuid), zap.Error(oErr))
+	} else if origin != nil {
+		originResp = map[string]interface{}{
+			"ip":           origin.IP,
+			"device_name":  origin.DeviceName,
+			"device_model": origin.DeviceModel,
+			"user_agent":   origin.UserAgent,
+		}
+	}
+
 	return NewHandleResult(ForwardNative, HandlerTypeLoginConfirm, map[string]interface{}{
 		"auth_code": authCode,
 		"pub_key":   pubkey,
+		"origin":    originResp,
 	}), nil
 }
 

--- a/modules/qrcode/api.go
+++ b/modules/qrcode/api.go
@@ -184,7 +184,7 @@ func (q *QRCode) handleScanLogin(loginUID string, uuid string, qrCodeModel commo
 		"status": common.ScanLoginStatusScanned,
 		"uid":    loginUID,
 	})
-	err = q.ctx.GetRedisConn().SetAndExpire(fmt.Sprintf("%s%s", common.QRCodeCachePrefix, uuid), util.ToJson(qrcodeInfo), time.Minute*5)
+	err = q.ctx.GetRedisConn().SetAndExpire(fmt.Sprintf("%s%s", common.QRCodeCachePrefix, uuid), util.ToJson(qrcodeInfo), user.ScanLoginConfirmWindow)
 	if err != nil {
 		q.Error("设置扫描登录二维码信息失败", zap.Error(err))
 		return nil, fmt.Errorf("%w: scan login state", errQRCodeInternalStoreFailed)

--- a/modules/qrcode/api.go
+++ b/modules/qrcode/api.go
@@ -163,14 +163,6 @@ func (q *QRCode) handleQRCodeInfo(c *wkhttp.Context) {
 
 }
 
-// scanLoginAuthCodeTTL 是扫码登录授权码的存活时间。
-//
-// authCode 可被 POST /v1/user/login_authcode/{code} 直接兑换成 scaner 的完整 token，
-// 且该接口不校验兑换者身份，所以这里的 TTL 就是「凭据一旦外泄的可利用窗口」。原值
-// 10 分钟远超实际所需 —— 从扫码到浏览器完成兑换通常在数秒内。收敛到 5 分钟，既压窄
-// 窗口，又给弱网 / 用户在确认页停顿留足余量。
-const scanLoginAuthCodeTTL = 5 * time.Minute
-
 // 处理扫描登录
 func (q *QRCode) handleScanLogin(loginUID string, uuid string, qrCodeModel common.QRCodeModel) (interface{}, error) {
 	authCode := util.GenerUUID()
@@ -178,7 +170,7 @@ func (q *QRCode) handleScanLogin(loginUID string, uuid string, qrCodeModel commo
 		"scaner": loginUID,
 		"type":   common.AuthCodeTypeScanLogin,
 		"uuid":   uuid,
-	}), scanLoginAuthCodeTTL)
+	}), user.ScanLoginAuthCodeTTL)
 	if err != nil {
 		q.Error("生成扫码登录授权码失败", zap.Error(err))
 		return nil, fmt.Errorf("%w: scan login auth code", errQRCodeInternalStoreFailed)
@@ -199,28 +191,22 @@ func (q *QRCode) handleScanLogin(loginUID string, uuid string, qrCodeModel commo
 	}
 	user.SendQRCodeInfo(uuid, qrcodeInfo)
 
-	// 把「请求登录的那一端是谁」一并回给手机，供确认弹窗展示。
+	// 关于「把请求方设备/IP 回给手机端展示」：这是 QRLJacking 唯一真正的断点（服务端
+	// 区分不出「受害者扫了攻击者的码」和「本人扫了自己的码」，只有确认的人能），但**故意
+	// 不在本次实现**。
 	//
-	// 扫码登录唯一挡得住 QRLJacking（攻击者自己申请二维码、贴到钓鱼页诱导他人扫码）
-	// 的位置就是这里 —— 服务端无法区分「受害者扫了攻击者的码」和「本人扫了自己的
-	// 码」，只有确认的人能。前提是他看得到请求方的设备与 IP。读取失败不阻断扫码，
-	// 退化为不展示。**移动端渲染前，本字段不产生任何防护效果。**
-	var originResp map[string]interface{}
-	if origin, oErr := user.LoadScanLoginOrigin(q.ctx.GetRedisConn(), uuid); oErr != nil {
-		q.Warn("读取扫码登录来源失败", zap.String("uuid", uuid), zap.Error(oErr))
-	} else if origin != nil {
-		originResp = map[string]interface{}{
-			"ip":           origin.IP,
-			"device_name":  origin.DeviceName,
-			"device_model": origin.DeviceModel,
-			"user_agent":   origin.UserAgent,
-		}
-	}
-
+	// 原因是这些依据目前全部由攻击者掌控：device_name/device_model 直接来自 loginuuid
+	// 的 query 参数，User-Agent 是请求头，而 IP 走 gin 的 c.ClientIP() —— 本仓与 octo-lib
+	// 都没调用过 SetTrustedProxies，默认信任 0.0.0.0/0，取的是 X-Forwarded-For 最左项，
+	// 客户端可预置。攻击者能让确认弹窗显示受害者自己的 IP 和设备名，把「弱证据」变成
+	// 「假保证」——比什么都不显示更糟。
+	//
+	// 要做对，得先定下可信来源（与限流同一条 trusted-proxy 感知的取 IP 路径、客户端上报
+	// 字段标记为 unverified 并限长），而这依赖运维确认反代对 XFF 是覆盖还是追加。
+	// 跟踪：Mininglamp-OSS/octo-ios#71、Mininglamp-OSS/octo-android#116。
 	return NewHandleResult(ForwardNative, HandlerTypeLoginConfirm, map[string]interface{}{
 		"auth_code": authCode,
 		"pub_key":   pubkey,
-		"origin":    originResp,
 	}), nil
 }
 

--- a/modules/user/api.go
+++ b/modules/user/api.go
@@ -2087,18 +2087,6 @@ func (u *User) getLoginUUID(c *wkhttp.Context) {
 	})
 }
 
-// scanLoginPresentedPollSecret 取出轮询方出示的密钥。
-//
-// header 优先、query 兜底：header 是首选通道（不进 access log），但 octo-lib 的
-// CORS 白名单目前不含它，跨源部署（Tauri/Electron 正式包）的预检会直接拒掉整个请求。
-// 见 ScanLoginPollSecretHeader / scanLoginPollSecretQuery 的注释与其中的 SUNSET 条件。
-func scanLoginPresentedPollSecret(c *wkhttp.Context) string {
-	if v := strings.TrimSpace(c.GetHeader(ScanLoginPollSecretHeader)); v != "" {
-		return v
-	}
-	return strings.TrimSpace(c.Query(scanLoginPollSecretQuery))
-}
-
 // 通过loginUUID获取登录状态
 //
 // 本接口按设计保持匿名可达（二维码在用户登录之前就要渲染，此时没有任何 token 可用），
@@ -2139,7 +2127,7 @@ func (u *User) getloginStatus(c *wkhttp.Context) {
 	// 授权判定放在所有早退分支之后：过期 / 未知 uuid 上面已经返回，不必为它们多花一次
 	// Redis 读 —— 本接口未认证，任何「无效输入也要付出后端开销」的路径都是放大器。
 	// 在进入长轮询前一次性定下，避免 select 的多个出口重复查询。
-	authorized := u.scanLoginPollSecretMatches(uuid, scanLoginPresentedPollSecret(c))
+	authorized := u.scanLoginPollSecretMatches(uuid, strings.TrimSpace(c.Query(scanLoginPollSecretQuery)))
 	respondStatus := func(model *common.QRCodeModel) {
 		if model == nil {
 			// channel 被同 uuid 的另一个请求关掉时会收到 nil。此处必须仍然写出响应：

--- a/modules/user/api.go
+++ b/modules/user/api.go
@@ -204,6 +204,18 @@ func (u *User) Route(r *wkhttp.WKHttp) {
 	registerLimit := r.StrictIPRateLimitMiddleware(rlCtx, rlRedis, "register", 5.0/60, 3)  // 5 req/min, burst 3
 	smsLimit := r.StrictIPRateLimitMiddleware(rlCtx, rlRedis, "sms", 5.0/60, 3)            // 5 req/min, burst 3
 	searchLimit := r.StrictIPRateLimitMiddleware(rlCtx, rlRedis, "search", 30.0/60, 15)    // 30 req/min, burst 15
+	// 扫码登录的两个端点此前既未认证也未限流：loginuuid 可被用来批量铸造钓鱼二维码，
+	// loginstatus 每次请求挂起 10 秒、可用来占满连接与 goroutine。
+	//
+	// 阈值刻意比 login 松，且做成 env 可调：loginstatus 是长轮询（单浏览器约 6 次/分，
+	// 多开标签页会翻倍），而企业 NAT 下整层楼共用一个出口 IP —— 卡太死的后果是一片人
+	// 登不上，比放过一点扫描流量严重得多。运维撞到 NAT 墙时可不重新发版直接上调。
+	scanLoginUUIDLimit := r.StrictIPRateLimitMiddleware(rlCtx, rlRedis, "scanlogin_uuid",
+		wkhttp.ParseRPSFromEnv("DM_API_SCANLOGIN_UUID_RATELIMIT_RPS", defaultScanLoginUUIDRateLimitRPS),
+		wkhttp.ParseBurstFromEnv("DM_API_SCANLOGIN_UUID_RATELIMIT_BURST", defaultScanLoginUUIDRateLimitBurst))
+	scanLoginStatusLimit := r.StrictIPRateLimitMiddleware(rlCtx, rlRedis, "scanlogin_status",
+		wkhttp.ParseRPSFromEnv("DM_API_SCANLOGIN_STATUS_RATELIMIT_RPS", defaultScanLoginStatusRateLimitRPS),
+		wkhttp.ParseBurstFromEnv("DM_API_SCANLOGIN_STATUS_RATELIMIT_BURST", defaultScanLoginStatusRateLimitBurst))
 
 	auth := r.Group("/v1", u.ctx.AuthMiddleware(r))
 	{
@@ -292,12 +304,12 @@ func (u *User) Route(r *wkhttp.WKHttp) {
 		v.GET("/user/web3verifytext", u.getVerifyText)              // 获取验证字符串
 		v.POST("/user/web3verifysign", u.web3verifySignature)       // 验证签名
 		//v.POST("user/wxlogin", u.wxLogin)
-		v.POST("/user/sms/forgetpwd", smsLimit, u.getForgetPwdSMS) //获取忘记密码验证码
-		v.POST("/user/pwdforget", loginLimit, u.pwdforget)         //重置登录密码
-		v.GET("/users/:uid/avatar", u.UserAvatar)                  // 用户头像
-		v.GET("/users/:uid/im", u.userIM)                          // 获取用户所在IM节点信息
-		v.GET("/user/loginuuid", u.getLoginUUID)                   // 获取扫描用的登录uuid
-		v.GET("/user/loginstatus", u.getloginStatus)
+		v.POST("/user/sms/forgetpwd", smsLimit, u.getForgetPwdSMS)   //获取忘记密码验证码
+		v.POST("/user/pwdforget", loginLimit, u.pwdforget)           //重置登录密码
+		v.GET("/users/:uid/avatar", u.UserAvatar)                    // 用户头像
+		v.GET("/users/:uid/im", u.userIM)                            // 获取用户所在IM节点信息
+		v.GET("/user/loginuuid", scanLoginUUIDLimit, u.getLoginUUID) // 获取扫描用的登录uuid
+		v.GET("/user/loginstatus", scanLoginStatusLimit, u.getloginStatus)
 		v.POST("/user/sms/registercode", smsLimit, u.sendRegisterCode)             //获取注册短信验证码
 		v.POST("/user/login_authcode/:auth_code", loginLimit, u.loginWithAuthCode) // 通过认证码登录
 		v.POST("/user/sms/login_check_phone", smsLimit, u.sendLoginCheckPhoneCode) //发送登录设备验证验证码
@@ -2050,13 +2062,48 @@ func (u *User) getLoginUUID(c *wkhttp.Context) {
 			return
 		}
 	}
+	// 轮询密钥：把「二维码状态里的敏感字段」绑定到申请二维码的这个浏览器会话。
+	//
+	// 没有它时，uuid 是读取 auth_code 的唯一凭据，而 uuid 可以由任何人向本接口申请
+	// —— 攻击者把自己申请到的二维码贴进钓鱼页，受害者用真 App 扫码确认后，攻击者
+	// 轮询 loginstatus 就能拿到 auth_code 并兑换成受害者的 token（QRLJacking）。
+	//
+	// 明文只出现在本响应里，绝不写进 qrcode:{uuid} 的 payload —— 那份 payload 正是
+	// getloginStatus 要回显给匿名轮询方的内容。
+	pollSecret, err := u.mintScanLoginPollSecret(uuid)
+	if err != nil {
+		u.Error("生成扫码轮询密钥失败！", zap.Error(err))
+		respondUserError(c, errcode.ErrUserStoreFailed)
+		return
+	}
+	// 记录「是谁请求了这个二维码」，扫码时回给手机端展示。
+	//
+	// 这才是 QRLJacking 的真正断点：poll_secret 挡不住它（攻击者自己调本接口，密钥
+	// 也在他手里），能识破钓鱼的只有确认环节的人 —— 前提是他看得到「请求方是一台
+	// 陌生设备、来自陌生 IP」。服务端在此把依据备齐；生效还需移动端渲染确认弹窗。
+	u.storeScanLoginOrigin(uuid, ScanLoginOrigin{
+		IP:          c.ClientIP(),
+		DeviceName:  deviceName,
+		DeviceModel: deviceModel,
+		UserAgent:   c.Request.UserAgent(),
+	})
 	c.JSON(http.StatusOK, gin.H{
-		"uuid":   uuid,
-		"qrcode": fmt.Sprintf("%s/%s", u.ctx.GetConfig().External.BaseURL, strings.ReplaceAll(u.ctx.GetConfig().QRCodeInfoURL, ":code", uuid)),
+		"uuid":        uuid,
+		"poll_secret": pollSecret,
+		"qrcode":      fmt.Sprintf("%s/%s", u.ctx.GetConfig().External.BaseURL, strings.ReplaceAll(u.ctx.GetConfig().QRCodeInfoURL, ":code", uuid)),
 	})
 }
 
 // 通过loginUUID获取登录状态
+//
+// 本接口按设计保持匿名可达（二维码在用户登录之前就要渲染，此时没有任何 token 可用），
+// 故不挂 AuthMiddleware。取而代之的边界是 poll_secret：只有持有 getLoginUUID 下发的
+// 那枚密钥的调用方，才能读到 auth_code / uid / encrypt 这些凭据字段；其余调用方拿到的
+// 是被 stripScanLoginSensitiveFields 剥过的状态。
+//
+// 校验失败时刻意返回「真实 status + 剥掉敏感字段」而不是报错：发布窗口内仍持有旧
+// bundle 的浏览器会停在授权页等待（用户刷新即恢复），而不是被 expired 状态推去无限
+// 重新申请二维码。安全性不因此打折 —— 旧 bundle 同样拿不到 auth_code。
 func (u *User) getloginStatus(c *wkhttp.Context) {
 	uuid := c.Query("uuid")
 	qrcodeInfo, err := u.ctx.GetRedisConn().GetString(fmt.Sprintf("%s%s", common.QRCodeCachePrefix, uuid))
@@ -2084,20 +2131,45 @@ func (u *User) getloginStatus(c *wkhttp.Context) {
 		})
 		return
 	}
-	qrcodeChan := u.getQRCodeModelChan(uuid)
-	select {
-	case qrcodeModel := <-qrcodeChan:
-		u.removeQRCodeChan(uuid)
-		if qrcodeModel == nil {
-			break
+	// 授权判定放在所有早退分支之后：过期 / 未知 uuid 上面已经返回，不必为它们多花一次
+	// Redis 读 —— 本接口未认证，任何「无效输入也要付出后端开销」的路径都是放大器。
+	// 在进入长轮询前一次性定下，避免 select 的多个出口重复查询。
+	authorized := u.scanLoginPollSecretMatches(uuid, c.GetHeader(ScanLoginPollSecretHeader))
+	respondStatus := func(model *common.QRCodeModel) {
+		if model == nil {
+			// channel 被同 uuid 的另一个请求关掉时会收到 nil。此处必须仍然写出响应：
+			// 上一版直接 return，gin 会发一个零长度的 200，前端 result.status 变成
+			// undefined → loginStatus=undefined → 状态机匹配不到分支 → 轮询永久停摆。
+			// 回落到请求开始时读到的状态，客户端至少能继续推进。
+			model = qrcodeModel
 		}
-		c.JSON(http.StatusOK, qrcodeModel.Data)
-		break
-	case <-time.After(10 * time.Second):
-		u.removeQRCodeChan(uuid)
-		c.JSON(http.StatusOK, qrcodeModel.Data)
-		break
-
+		if model == nil {
+			c.JSON(http.StatusOK, gin.H{"status": common.ScanLoginStatusExpired})
+			return
+		}
+		if !authorized {
+			c.JSON(http.StatusOK, filterScanLoginPublicFields(model.Data))
+			return
+		}
+		c.JSON(http.StatusOK, model.Data)
+	}
+	qrcodeChan := u.getQRCodeModelChan(uuid)
+	// 显式 Timer 而非 time.After：加了 ctx.Done() 分支后，提前返回的路径会把
+	// time.After 的底层 timer 留到 10s 后才被 GC 回收；Stop 掉更干净。
+	timeout := time.NewTimer(10 * time.Second)
+	defer timeout.Stop()
+	select {
+	case pushed := <-qrcodeChan:
+		u.removeQRCodeChanOwned(uuid, qrcodeChan)
+		respondStatus(pushed)
+	case <-c.Request.Context().Done():
+		// 客户端断开（关页面 / 切登录方式 / 网关超时）时立即释放，不再空转满 10 秒。
+		// 该接口未认证且长轮询挂起，缺这一路等于让任意断开的连接都占住一个 goroutine
+		// 与一个 channel 槽位直到超时。此处不写响应 —— 连接已经没了。
+		u.removeQRCodeChanOwned(uuid, qrcodeChan)
+	case <-timeout.C:
+		u.removeQRCodeChanOwned(uuid, qrcodeChan)
+		respondStatus(qrcodeModel)
 	}
 }
 
@@ -2272,6 +2344,10 @@ func (u *User) loginWithAuthCode(c *wkhttp.Context) {
 		respondUserError(c, errcode.ErrUserStoreFailed)
 		return
 	}
+	// 登录已完成，轮询密钥再留着就只是一段多余的可利用窗口 —— 期间任何拿到它的人
+	// 仍能从 qrcode:{uuid}（还有最长 5 分钟寿命）读出 uid/encrypt。与上面删除 authCode
+	// 同一个理由，只是这条此前漏了。失败不阻断登录，密钥仍会按 TTL 自然过期。
+	u.deleteScanLoginPollSecret(uuid)
 
 	err = u.ctx.Cache().SetAndExpire(fmt.Sprintf("%s%d%s", u.ctx.GetConfig().Cache.UIDTokenCachePrefix, flag, userModel.UID), token, u.ctx.GetConfig().Cache.TokenExpire)
 	if err != nil {
@@ -2313,6 +2389,24 @@ func (u *User) removeQRCodeChan(uuid string) {
 		delete(qrcodeChanMap, uuid)
 		close(ch) // close channel to unblock any pending sender
 	}
+}
+
+// removeQRCodeChanOwned 只在 map 中登记的仍是本请求注册的那个 channel 时才摘除并关闭。
+//
+// getQRCodeModelChan 对同一 uuid 是无条件覆盖写，而 loginstatus 未认证 —— 任何知道
+// uuid 的人（在钓鱼场景里 uuid 就是攻击者自己的，其余场景直接从展示中的二维码读出）
+// 反复发起并立刻中断请求，就能借 removeQRCodeChan 把合法轮询方登记的 channel 关掉：
+// 对方立刻收到 nil，本轮长轮询作废；grantLogin 的推送则落到已被替换的 channel 上，
+// 在 SendQRCodeInfo 的 default 分支被静默丢弃。带归属校验后，每个请求只回收自己那个。
+func (u *User) removeQRCodeChanOwned(uuid string, own <-chan *common.QRCodeModel) {
+	qrcodeChanLock.Lock()
+	defer qrcodeChanLock.Unlock()
+	ch, exist := qrcodeChanMap[uuid]
+	if !exist || ch != own {
+		return
+	}
+	delete(qrcodeChanMap, uuid)
+	close(ch) // close channel to unblock any pending sender
 }
 
 // SendQRCodeInfo 发送二维码数据

--- a/modules/user/api.go
+++ b/modules/user/api.go
@@ -2064,9 +2064,11 @@ func (u *User) getLoginUUID(c *wkhttp.Context) {
 	}
 	// 轮询密钥：把「二维码状态里的敏感字段」绑定到申请二维码的这个浏览器会话。
 	//
-	// 没有它时，uuid 是读取 auth_code 的唯一凭据，而 uuid 可以由任何人向本接口申请
-	// —— 攻击者把自己申请到的二维码贴进钓鱼页，受害者用真 App 扫码确认后，攻击者
-	// 轮询 loginstatus 就能拿到 auth_code 并兑换成受害者的 token（QRLJacking）。
+	// 没有它时，uuid 是读取 auth_code 的唯一凭据 —— 任何看得到二维码的人（肩窥、
+	// 转发的截图、投屏、录屏）都能轮询出 auth_code 并兑换成受害者的 token。
+	//
+	// 注意它挡不住 QRLJacking（攻击者自建二维码钓鱼）：那条链路里攻击者就是调用本
+	// 接口的人，密钥连同 uuid 一起发给了他。那条只能靠确认环节的人识破，服务端无解。
 	//
 	// 明文只出现在本响应里，绝不写进 qrcode:{uuid} 的 payload —— 那份 payload 正是
 	// getloginStatus 要回显给匿名轮询方的内容。
@@ -2076,22 +2078,25 @@ func (u *User) getLoginUUID(c *wkhttp.Context) {
 		respondUserError(c, errcode.ErrUserStoreFailed)
 		return
 	}
-	// 记录「是谁请求了这个二维码」，扫码时回给手机端展示。
-	//
-	// 这才是 QRLJacking 的真正断点：poll_secret 挡不住它（攻击者自己调本接口，密钥
-	// 也在他手里），能识破钓鱼的只有确认环节的人 —— 前提是他看得到「请求方是一台
-	// 陌生设备、来自陌生 IP」。服务端在此把依据备齐；生效还需移动端渲染确认弹窗。
-	u.storeScanLoginOrigin(uuid, ScanLoginOrigin{
-		IP:          c.ClientIP(),
-		DeviceName:  deviceName,
-		DeviceModel: deviceModel,
-		UserAgent:   c.Request.UserAgent(),
-	})
+	// 响应体里带着 bearer 级别的密钥，任何中间缓存或浏览器 bfcache 留存都等于泄露它。
+	c.Header("Cache-Control", "no-store")
 	c.JSON(http.StatusOK, gin.H{
 		"uuid":        uuid,
 		"poll_secret": pollSecret,
 		"qrcode":      fmt.Sprintf("%s/%s", u.ctx.GetConfig().External.BaseURL, strings.ReplaceAll(u.ctx.GetConfig().QRCodeInfoURL, ":code", uuid)),
 	})
+}
+
+// scanLoginPresentedPollSecret 取出轮询方出示的密钥。
+//
+// header 优先、query 兜底：header 是首选通道（不进 access log），但 octo-lib 的
+// CORS 白名单目前不含它，跨源部署（Tauri/Electron 正式包）的预检会直接拒掉整个请求。
+// 见 ScanLoginPollSecretHeader / scanLoginPollSecretQuery 的注释与其中的 SUNSET 条件。
+func scanLoginPresentedPollSecret(c *wkhttp.Context) string {
+	if v := strings.TrimSpace(c.GetHeader(ScanLoginPollSecretHeader)); v != "" {
+		return v
+	}
+	return strings.TrimSpace(c.Query(scanLoginPollSecretQuery))
 }
 
 // 通过loginUUID获取登录状态
@@ -2134,7 +2139,7 @@ func (u *User) getloginStatus(c *wkhttp.Context) {
 	// 授权判定放在所有早退分支之后：过期 / 未知 uuid 上面已经返回，不必为它们多花一次
 	// Redis 读 —— 本接口未认证，任何「无效输入也要付出后端开销」的路径都是放大器。
 	// 在进入长轮询前一次性定下，避免 select 的多个出口重复查询。
-	authorized := u.scanLoginPollSecretMatches(uuid, c.GetHeader(ScanLoginPollSecretHeader))
+	authorized := u.scanLoginPollSecretMatches(uuid, scanLoginPresentedPollSecret(c))
 	respondStatus := func(model *common.QRCodeModel) {
 		if model == nil {
 			// channel 被同 uuid 的另一个请求关掉时会收到 nil。此处必须仍然写出响应：
@@ -2153,7 +2158,20 @@ func (u *User) getloginStatus(c *wkhttp.Context) {
 		}
 		c.JSON(http.StatusOK, model.Data)
 	}
-	qrcodeChan := u.getQRCodeModelChan(uuid)
+	// 只有持密钥的一方才注册推送 channel。
+	//
+	// getQRCodeModelChan 对同一 uuid 是无条件覆盖写，所以未授权方一旦也能注册，就能靠
+	// 反复轮询持续把合法轮询方的 channel 顶掉：grantLogin 的推送落到攻击者那一侧（凭据
+	// 有白名单拦着不会泄露），而合法方收不到通知，每轮白等满 10 秒才拿到旧状态 —— 未认证
+	// 端点上的一个廉价登录延迟惩罚。未授权方本来也只能拿到白名单字段，订阅对它毫无意义。
+	//
+	// 不注册时 qrcodeChan 为 nil：从 nil channel 接收永远阻塞，select 自然落到超时分支。
+	// 刻意让未授权方也等满同样的 10 秒 —— 立刻返回会泄露「密钥对不对」的时序信号，
+	// 也会让攻击者能高频轮询。
+	var qrcodeChan <-chan *common.QRCodeModel
+	if authorized {
+		qrcodeChan = u.getQRCodeModelChan(uuid)
+	}
 	// 显式 Timer 而非 time.After：加了 ctx.Done() 分支后，提前返回的路径会把
 	// time.After 的底层 timer 留到 10s 后才被 GC 回收；Stop 掉更干净。
 	timeout := time.NewTimer(10 * time.Second)
@@ -2344,10 +2362,17 @@ func (u *User) loginWithAuthCode(c *wkhttp.Context) {
 		respondUserError(c, errcode.ErrUserStoreFailed)
 		return
 	}
-	// 登录已完成，轮询密钥再留着就只是一段多余的可利用窗口 —— 期间任何拿到它的人
-	// 仍能从 qrcode:{uuid}（还有最长 5 分钟寿命）读出 uid/encrypt。与上面删除 authCode
-	// 同一个理由，只是这条此前漏了。失败不阻断登录，密钥仍会按 TTL 自然过期。
+	// 登录已完成，与上面删除 authCode 同一个理由：把这一轮扫码留下的状态全部清掉，
+	// 不给已完成的会话留任何残余窗口。两处失败都不阻断登录（各自 TTL 会兜底）。
+	//   - 轮询密钥：留着等于多一段能读出凭据字段的时间
+	//   - qrcode:{uuid}：还携带 uid / auth_code / encrypt，其中 encrypt 是 Signal 密钥
+	//     材料，登录完成后没有任何理由继续留在 Redis 里
 	u.deleteScanLoginPollSecret(uuid)
+	if uuid != "" {
+		if delErr := u.ctx.GetRedisConn().Del(fmt.Sprintf("%s%s", common.QRCodeCachePrefix, uuid)); delErr != nil {
+			u.Warn("清理扫码二维码状态失败", zap.String("uuid", uuid), zap.Error(delErr))
+		}
+	}
 
 	err = u.ctx.Cache().SetAndExpire(fmt.Sprintf("%s%d%s", u.ctx.GetConfig().Cache.UIDTokenCachePrefix, flag, userModel.UID), token, u.ctx.GetConfig().Cache.TokenExpire)
 	if err != nil {
@@ -2381,15 +2406,6 @@ func (u *User) getQRCodeModelChan(uuid string) <-chan *common.QRCodeModel {
 	qrcodeChanLock.Unlock()
 	return qrcodeModelChan
 }
-func (u *User) removeQRCodeChan(uuid string) {
-	qrcodeChanLock.Lock()
-	defer qrcodeChanLock.Unlock()
-	ch, exist := qrcodeChanMap[uuid]
-	if exist {
-		delete(qrcodeChanMap, uuid)
-		close(ch) // close channel to unblock any pending sender
-	}
-}
 
 // removeQRCodeChanOwned 只在 map 中登记的仍是本请求注册的那个 channel 时才摘除并关闭。
 //
@@ -2399,6 +2415,9 @@ func (u *User) removeQRCodeChan(uuid string) {
 // 对方立刻收到 nil，本轮长轮询作废；grantLogin 的推送则落到已被替换的 channel 上，
 // 在 SendQRCodeInfo 的 default 分支被静默丢弃。带归属校验后，每个请求只回收自己那个。
 func (u *User) removeQRCodeChanOwned(uuid string, own <-chan *common.QRCodeModel) {
+	if own == nil {
+		return // 未授权的轮询方压根没注册，没有东西要回收
+	}
 	qrcodeChanLock.Lock()
 	defer qrcodeChanLock.Unlock()
 	ch, exist := qrcodeChanMap[uuid]
@@ -2469,6 +2488,21 @@ func (u *User) grantLogin(c *wkhttp.Context) {
 		return
 	}
 	uuid, _ := authInfoMap["uuid"].(string)
+	// authCode 是在**扫码**时签发的（handleScanLogin，TTL = ScanLoginAuthCodeTTL），而
+	// 用户可以在确认页停留到该 TTL 的最后一刻。下面把 qrcode:{uuid} 续成满 TTL 却不续
+	// authCode，就会出现「status 显示 authed、附带的 auth_code 只剩一秒」——浏览器兑换时
+	// 撞 ErrUserAuthCodeNotFound，而状态机已经停在 authed 无路可走。
+	//
+	// 在这里按同一档位重新计时：确认之后 authCode 与 qrcode 同时起算、同时到期，窗口
+	// 不再可能倒挂。（此前 authCode 是 10min、确认窗口 5min，靠 5 分钟余量把这个竞态盖住
+	// 了；TTL 收敛到 5min 后余量归零，必须显式修。）
+	if err = u.ctx.GetRedisConn().SetAndExpire(
+		fmt.Sprintf("%s%s", common.AuthCodeCachePrefix, authCode), authInfo, ScanLoginAuthCodeTTL,
+	); err != nil {
+		u.Error("续期扫码授权码失败！", zap.Error(err))
+		respondUserError(c, errcode.ErrUserStoreFailed)
+		return
+	}
 	qrcodeInfo := common.NewQRCodeModel(common.QRCodeTypeScanLogin, map[string]interface{}{
 		"app_id":    "wukongchat",
 		"status":    common.ScanLoginStatusAuthed,
@@ -2476,7 +2510,7 @@ func (u *User) grantLogin(c *wkhttp.Context) {
 		"auth_code": authCode,
 		"encrypt":   encrypt,
 	})
-	err = u.ctx.GetRedisConn().SetAndExpire(fmt.Sprintf("%s%s", common.QRCodeCachePrefix, uuid), util.ToJson(qrcodeInfo), time.Minute*5)
+	err = u.ctx.GetRedisConn().SetAndExpire(fmt.Sprintf("%s%s", common.QRCodeCachePrefix, uuid), util.ToJson(qrcodeInfo), ScanLoginAuthCodeTTL)
 	if err != nil {
 		u.Error("更新二维码信息失败！", zap.Error(err))
 		respondUserError(c, errcode.ErrUserStoreFailed)

--- a/modules/user/api.go
+++ b/modules/user/api.go
@@ -64,9 +64,12 @@ var (
 
 // qrcodeChanMap stores channels for QR code login long-polling.
 // Concurrency safety is ensured by qrcodeChanLock:
-// - SendQRCodeInfo: holds lock during both map read AND channel send (no TOCTOU)
-// - removeQRCodeChan: holds lock during map delete AND channel close
-// - getQRCodeModelChan: holds lock during map write
+//   - SendQRCodeInfo: holds lock during both map read AND channel send (no TOCTOU)
+//   - removeQRCodeChanOwned: holds lock during map delete AND channel close, and
+//     only acts when the registered channel is still the caller's own — that
+//     ownership check is what makes a cross-request close impossible
+//   - getQRCodeModelChan: holds lock during map write
+//
 // The channel is buffered (size 1) to prevent message loss between
 // getQRCodeModelChan return and the caller's select/receive.
 // See: #294, #345 for race condition fixes.
@@ -2129,6 +2132,15 @@ func (u *User) getloginStatus(c *wkhttp.Context) {
 	// 在进入长轮询前一次性定下，避免 select 的多个出口重复查询。
 	authorized := u.scanLoginPollSecretMatches(uuid, strings.TrimSpace(c.Query(scanLoginPollSecretQuery)))
 	respondStatus := func(model *common.QRCodeModel) {
+		// 这个响应在授权分支上携带 auth_code / uid / encrypt。没有显式新鲜度信息的
+		// 200 GET 是可被启发式缓存的（RFC 9111 §4.2.2），而同文件的头像路由就故意下发
+		// Cache-Control: public, max-age=86400 —— 说明这个源站前面本来就预期有缓存。
+		// 无条件 no-store：凭据响应不该被任何中间层留存。
+		//
+		// 顺带说明为什么没有 Vary：密钥现在走 query，已经进了缓存键，所以「不带密钥的
+		// 请求命中带密钥的缓存条目」这条路本身不成立。若将来改回请求头通道，必须同时
+		// 加上 Vary，否则两种请求的 URL 完全相同、缓存无从区分。
+		c.Header("Cache-Control", "no-store")
 		if model == nil {
 			// channel 被同 uuid 的另一个请求关掉时会收到 nil。此处必须仍然写出响应：
 			// 上一版直接 return，gin 会发一个零长度的 200，前端 result.status 变成
@@ -2141,7 +2153,7 @@ func (u *User) getloginStatus(c *wkhttp.Context) {
 			return
 		}
 		if !authorized {
-			c.JSON(http.StatusOK, filterScanLoginPublicFields(model.Data))
+			c.JSON(http.StatusOK, ensureScanLoginStatus(filterScanLoginPublicFields(model.Data), model.Data))
 			return
 		}
 		c.JSON(http.StatusOK, model.Data)
@@ -2498,7 +2510,7 @@ func (u *User) grantLogin(c *wkhttp.Context) {
 		"auth_code": authCode,
 		"encrypt":   encrypt,
 	})
-	err = u.ctx.GetRedisConn().SetAndExpire(fmt.Sprintf("%s%s", common.QRCodeCachePrefix, uuid), util.ToJson(qrcodeInfo), ScanLoginAuthCodeTTL)
+	err = u.ctx.GetRedisConn().SetAndExpire(fmt.Sprintf("%s%s", common.QRCodeCachePrefix, uuid), util.ToJson(qrcodeInfo), ScanLoginConfirmWindow)
 	if err != nil {
 		u.Error("更新二维码信息失败！", zap.Error(err))
 		respondUserError(c, errcode.ErrUserStoreFailed)

--- a/modules/user/api_i18n_test.go
+++ b/modules/user/api_i18n_test.go
@@ -82,6 +82,7 @@ func TestMigratedUserFilesNoLegacyResponseError(t *testing.T) {
 		"api_friend.go", "api_online.go", "api_setting.go", "api_maillist.go",
 		"api_device.go", "api_destroy.go", "api_pinned.go", "api_gitee.go",
 		"api_github.go", "api_emaillogin.go", "api_usernamelogin.go",
+		"scanlogin_poll.go",
 	}
 	for _, f := range files {
 		t.Run(f, func(t *testing.T) {

--- a/modules/user/api_test.go
+++ b/modules/user/api_test.go
@@ -1075,7 +1075,7 @@ func TestSendQRCodeInfo_ConcurrentSendAndRemove(t *testing.T) {
 		// Goroutine 2: 移除 channel
 		go func() {
 			defer wg.Done()
-			u.removeQRCodeChan(uuid)
+			u.removeQRCodeChanOwned(uuid, qrcodeChan)
 		}()
 
 		// 等待两个 goroutine 完成
@@ -1101,7 +1101,7 @@ func TestSendQRCodeInfo_NoReceiverDoesNotBlock(t *testing.T) {
 	uuid := "test-no-receiver"
 
 	// 使用 getQRCodeModelChan（buffered channel, size=1）
-	_ = u.getQRCodeModelChan(uuid)
+	qrcodeChan := u.getQRCodeModelChan(uuid)
 
 	// 不启动接收者，直接发送
 	done := make(chan bool)
@@ -1122,18 +1122,19 @@ func TestSendQRCodeInfo_NoReceiverDoesNotBlock(t *testing.T) {
 	}
 
 	// 清理
-	u.removeQRCodeChan(uuid)
+	u.removeQRCodeChanOwned(uuid, qrcodeChan)
 }
 
-// TestRemoveQRCodeChan_ClosesChannel 测试 removeQRCodeChan 关闭 channel 不会 panic
-func TestRemoveQRCodeChan_ClosesChannel(t *testing.T) {
+// TestRemoveQRCodeChanOwned_ClosesOwnChannel 测试 removeQRCodeChanOwned 关闭自己注册的
+// channel 不会 panic，且重复调用安全。
+func TestRemoveQRCodeChanOwned_ClosesOwnChannel(t *testing.T) {
 	u := &User{}
 	uuid := "test-close-chan"
 
 	ch := u.getQRCodeModelChan(uuid)
 
 	// remove should close the channel
-	u.removeQRCodeChan(uuid)
+	u.removeQRCodeChanOwned(uuid, ch)
 
 	// reading from closed channel should return zero value, not block
 	select {
@@ -1146,7 +1147,7 @@ func TestRemoveQRCodeChan_ClosesChannel(t *testing.T) {
 	}
 
 	// double remove should not panic
-	u.removeQRCodeChan(uuid)
+	u.removeQRCodeChanOwned(uuid, ch)
 }
 
 // TestBufferedChannel_PreventsTOCTOU 测试 buffered channel 防止 TOCTOU 消息丢失
@@ -1175,5 +1176,5 @@ func TestBufferedChannel_PreventsTOCTOU(t *testing.T) {
 		t.Fatal("buffered channel should have data available immediately")
 	}
 
-	u.removeQRCodeChan(uuid)
+	u.removeQRCodeChanOwned(uuid, ch)
 }

--- a/modules/user/scanlogin_poll.go
+++ b/modules/user/scanlogin_poll.go
@@ -17,12 +17,36 @@ import (
 // 外部模块，加常量需要先发版；本 key 的生命周期完全由 modules/user 掌握。
 const scanLoginPollSecretPrefix = "scanlogin:poll:"
 
-// ScanLoginPollSecretHeader 是轮询方出示密钥用的请求头。
+// ScanLoginPollSecretHeader 是轮询方出示密钥的**首选**通道。
 //
-// 走 header 而非 query：密钥的明文若进 URL，会被 nginx/ingress access log、CDN/WAF
-// 日志、APM trace span 与浏览器历史逐字记录 —— 那正好抵消了「Redis 只存摘要」想防的
-// 泄露面。header 不进请求行，也就不进这些日志的默认字段。
+// 走 header 而非 query：密钥明文若进 URL，会被 nginx/ingress access log、CDN/WAF 日志、
+// APM trace span 与浏览器历史逐字记录 —— 那正好抵消「Redis 只存摘要」想防的泄露面。
+//
+// 注意 header 通道**目前只在同源部署可用**：octo-lib 的 CORSMiddleware
+// （pkg/wkhttp/http.go）把 Access-Control-Allow-Headers 写死成一份不含本头的清单，且对
+// OPTIONS 直接 AbortWithStatus(204)，headers 当场 flush —— octo-server 侧无论把中间件挂
+// 在它之前还是之后都改不动。自定义头会让轮询变成非简单请求，跨源浏览器预检被拒后**真正
+// 的 GET 根本发不出去**，连「剥字段降级」都轮不到。受影响的是 Tauri/Electron 正式包
+// （apps/web/src/apiURL.ts 对桌面端返回绝对地址直连），Web 走相对路径不受影响。
 const ScanLoginPollSecretHeader = "X-Scan-Poll-Secret"
+
+// scanLoginPollSecretQuery 是跨源客户端的**过渡**通道。
+//
+// 存在的唯一理由是上面那条 CORS 限制。它把明文放回 URL，因此劣于 header —— 但两害相权：
+// 桌面端要么用它、要么扫码登录完全不可用。
+//
+// SUNSET：octo-lib 把 X-Scan-Poll-Secret 加进 Access-Control-Allow-Headers 并发版、
+// 本仓 bump 依赖之后，删掉这个 query 分支与 octo-web 侧对应的兜底。
+const scanLoginPollSecretQuery = "poll_secret"
+
+// ScanLoginAuthCodeTTL 是扫码登录授权码的存活时间。
+//
+// authCode 可被 POST /v1/user/login_authcode/{code} 直接兑换成 scaner 的完整 token，
+// 所以这个 TTL 就是「凭据一旦外泄的可利用窗口」。原值 10 分钟远超实际所需。
+//
+// 定义在 modules/user 而非 modules/qrcode：grantLogin（本包）确认时要按同一档位给
+// authCode 续期（见 P1-3），而 qrcode 已经 import user，反向 import 会成环。
+const ScanLoginAuthCodeTTL = 5 * time.Minute
 
 // scanLoginPollSecretTTL 是轮询密钥的存活时间。
 //
@@ -35,7 +59,7 @@ const ScanLoginPollSecretHeader = "X-Scan-Poll-Secret"
 //	= 660s
 //
 // 取 12 分钟给 60s 余量，避免 Redis 与应用间的时钟漂移或调用延迟正好卡在边界上把
-// 已扫码的用户甩掉（上一版取 6 分钟且零余量，扫码发生在第 59 秒时必然踩中）。
+// 已扫码的用户甩掉。
 //
 // 长活本身不额外授权：密钥只是读取凭据的门票，qrcode 状态一过期就无内容可读；且
 // loginWithAuthCode 兑换成功后会立刻 deleteScanLoginPollSecret，常态下活不满 TTL。
@@ -51,7 +75,7 @@ const scanLoginPollSecretTTL = 12 * time.Minute
 //     RemoteAddr，即 nginx 自己的地址 —— 整个部署塌进同一个桶。
 //
 // 卡死的后果是「一层楼扫不了码」，比放过一些扫描流量严重得多。全局 RateLimitMiddleware
-// （1000 req/min/IP）仍在外层兜底，所以这里没必要再收紧。大规模 NAT 部署可直接上调。
+// （1000 req/min/IP）仍在外层兜底。大规模 NAT 部署可直接上调。
 const (
 	defaultScanLoginUUIDRateLimitRPS     = 120.0 / 60 // 120 req/min
 	defaultScanLoginUUIDRateLimitBurst   = 60
@@ -63,58 +87,11 @@ const (
 //
 // 这里刻意用白名单而不是「敏感键黑名单」：黑名单在有人往 payload 里加字段时默认放行
 // （fail-open），而这个 payload 的写入方分散在三处 —— getLoginUUID、
-// modules/qrcode.handleScanLogin、grantLogin。上一版的黑名单加一个只读 grantLogin 的
-// 守卫测试，handleScanLogin 里新增的字段（扫码者昵称/头像/手机号等）会直接漏给攻击者。
-// 白名单反过来：新字段默认不下发，要下发必须有人显式把它加进来并想清楚。
+// modules/qrcode.handleScanLogin、grantLogin。白名单反过来：新字段默认不下发，要下发
+// 必须有人显式加进来并想清楚。
 var scanLoginPublicDataKeys = map[string]struct{}{
 	"status": {}, // 扫码进度，前端状态机必需
 	"app_id": {}, // 常量标识，无信息量
-}
-
-// scanLoginOriginPrefix 记录「是谁请求了这个二维码」，供手机确认页展示。
-//
-// 与既有的 common.DeviceCacheUUIDPrefix 分开存：那份记录只在 device_id/name/model
-// 三者齐全时才写，且被 loginWithAuthCode 用于登记设备；这里需要的是**无条件可得**的
-// 来源上下文（尤其是 IP），不能因为客户端没上报设备字段就缺失。
-const scanLoginOriginPrefix = "scanlogin:origin:"
-
-// ScanLoginOrigin 是发起扫码登录的那一端的可展示上下文。
-//
-// 存在的理由：poll_secret 挡不住 QRLJacking —— 攻击者自己调 loginuuid，密钥自然也在
-// 他手里。这条攻击链的唯一断点在**确认环节**：受害者必须能看出「请求登录的不是我的
-// 设备」。服务端能做的是把判断依据备齐并下发给手机；真正生效还需要 iOS/Android 在
-// 确认弹窗里渲染它。在那之前，这个结构体只是把数据准备好。
-type ScanLoginOrigin struct {
-	IP          string `json:"ip"`
-	DeviceName  string `json:"device_name,omitempty"`
-	DeviceModel string `json:"device_model,omitempty"`
-	UserAgent   string `json:"user_agent,omitempty"`
-}
-
-func scanLoginOriginKey(uuid string) string {
-	return fmt.Sprintf("%s%s", scanLoginOriginPrefix, uuid)
-}
-
-// storeScanLoginOrigin 写入来源上下文，与轮询密钥同寿命。
-func storeScanLoginOrigin(store pollSecretStore, uuid string, origin ScanLoginOrigin) error {
-	return store.SetAndExpire(scanLoginOriginKey(uuid), util.ToJson(origin), scanLoginPollSecretTTL)
-}
-
-// LoadScanLoginOrigin 读取来源上下文，供 modules/qrcode 在扫码时回给手机。
-// 读不到时返回 nil（不是错误）—— 上下文缺失不应该阻断扫码。
-func LoadScanLoginOrigin(store pollSecretStore, uuid string) (*ScanLoginOrigin, error) {
-	raw, err := store.GetString(scanLoginOriginKey(uuid))
-	if err != nil {
-		return nil, err
-	}
-	if raw == "" {
-		return nil, nil
-	}
-	var origin ScanLoginOrigin
-	if err := util.ReadJsonByByte([]byte(raw), &origin); err != nil {
-		return nil, err
-	}
-	return &origin, nil
 }
 
 // pollSecretStore 是轮询密钥所需的最小存储能力，签名对齐 octo-lib 的 *redis.Conn。
@@ -161,9 +138,8 @@ func mintScanLoginPollSecret(store pollSecretStore, uuid string) (string, error)
 
 // scanLoginPollSecretMatches 判断 presented 是否为 uuid 当初下发的轮询密钥。
 //
-// Fail-closed：store 读失败、key 不存在、presented 为空，一律 false。任何一处
-// fail-open 都会让未持密钥的轮询方拿到 auth_code。err 单独返回供调用方记日志，
-// 但不影响判定结果 —— 读不到就是不放行。
+// Fail-closed：store 读失败、key 不存在、presented 为空，一律 false。err 单独返回供
+// 调用方记日志，但不影响判定结果 —— 读不到就是不放行。
 //
 // 比对用 subtle.ConstantTimeCompare 而非 ==：摘要是定长十六进制串，逐字节短路比较会
 // 在响应时间上泄露前缀匹配长度。
@@ -182,9 +158,6 @@ func scanLoginPollSecretMatches(store pollSecretStore, uuid string, presented st
 }
 
 // deleteScanLoginPollSecret 在扫码登录兑换完成后清掉密钥。
-//
-// 与 loginWithAuthCode 删除 authcode:{code} 同理：登录已经完成，密钥再留着就只是一段
-// 多余的可利用窗口 —— 期间任何拿到它的人仍可读出 uid/encrypt。
 func deleteScanLoginPollSecret(store pollSecretStore, uuid string) error {
 	return store.Del(scanLoginPollSecretKey(uuid))
 }
@@ -229,12 +202,5 @@ func (u *User) deleteScanLoginPollSecret(uuid string) {
 	if err := deleteScanLoginPollSecret(u.ctx.GetRedisConn(), uuid); err != nil {
 		// 清理失败不该让登录失败：密钥仍会按 TTL 自然过期。
 		u.Warn("清理扫码轮询密钥失败", zap.String("uuid", uuid), zap.Error(err))
-	}
-}
-
-func (u *User) storeScanLoginOrigin(uuid string, origin ScanLoginOrigin) {
-	if err := storeScanLoginOrigin(u.ctx.GetRedisConn(), uuid, origin); err != nil {
-		// 上下文只用于确认页展示，写失败不阻断发码 —— 手机端拿不到就退化为不展示。
-		u.Warn("记录扫码登录来源失败", zap.String("uuid", uuid), zap.Error(err))
 	}
 }

--- a/modules/user/scanlogin_poll.go
+++ b/modules/user/scanlogin_poll.go
@@ -17,26 +17,24 @@ import (
 // 外部模块，加常量需要先发版；本 key 的生命周期完全由 modules/user 掌握。
 const scanLoginPollSecretPrefix = "scanlogin:poll:"
 
-// ScanLoginPollSecretHeader 是轮询方出示密钥的**首选**通道。
+// scanLoginPollSecretQuery 是轮询方出示密钥的 query 参数名。
 //
-// 走 header 而非 query：密钥明文若进 URL，会被 nginx/ingress access log、CDN/WAF 日志、
-// APM trace span 与浏览器历史逐字记录 —— 那正好抵消「Redis 只存摘要」想防的泄露面。
+// 曾经改成自定义请求头 X-Scan-Poll-Secret，想让明文不进 access log —— 后来退回来了。
+// 这里记下取舍，免得有人再走一遍：
 //
-// 注意 header 通道**目前只在同源部署可用**：octo-lib 的 CORSMiddleware
-// （pkg/wkhttp/http.go）把 Access-Control-Allow-Headers 写死成一份不含本头的清单，且对
-// OPTIONS 直接 AbortWithStatus(204)，headers 当场 flush —— octo-server 侧无论把中间件挂
-// 在它之前还是之后都改不动。自定义头会让轮询变成非简单请求，跨源浏览器预检被拒后**真正
-// 的 GET 根本发不出去**，连「剥字段降级」都轮不到。受影响的是 Tauri/Electron 正式包
-// （apps/web/src/apiURL.ts 对桌面端返回绝对地址直连），Web 走相对路径不受影响。
-const ScanLoginPollSecretHeader = "X-Scan-Poll-Secret"
-
-// scanLoginPollSecretQuery 是跨源客户端的**过渡**通道。
+// 收益侧很窄。能读 nginx/APM 日志的是运维，同一批人有 Redis 权限，可以直接
+// GET qrcode:{uuid} 读出 auth_code，甚至直接读 token 缓存 —— 自定义头挡不住任何一个
+// 本来就能轻易接管账号的人。而这枚密钥 12 分钟过期、兑换即吊销，且单独毫无用处
+// （必须有一个正在进行中的扫码流程同时存在）。
 //
-// 存在的唯一理由是上面那条 CORS 限制。它把明文放回 URL，因此劣于 header —— 但两害相权：
-// 桌面端要么用它、要么扫码登录完全不可用。
+// 成本侧却很实。自定义头会让轮询变成非简单请求，而 octo-lib 的 CORSMiddleware 把
+// Access-Control-Allow-Headers 写死、且对 OPTIONS 立即 AbortWithStatus(204) 并 flush
+// —— 下游无论把中间件挂在它之前还是之后都改不动。跨源预检被拒后**真正的 GET 根本发不
+// 出去**，Tauri/Electron 正式包（apps/web/src/apiURL.ts 走绝对地址）扫码登录直接不可用。
+// 要修就得 octo-lib 改白名单 → 发版 → 本仓 bump 依赖，再加一套 header/query 双通道过渡。
 //
-// SUNSET：octo-lib 把 X-Scan-Poll-Secret 加进 Access-Control-Allow-Headers 并发版、
-// 本仓 bump 依赖之后，删掉这个 query 分支与 octo-web 侧对应的兜底。
+// 真要防日志泄露，正确的位置是日志层脱敏（nginx map 重写 $request、APM 的 URL
+// scrubbing），一次配置覆盖所有敏感 query 参数，而不是每加一个就动一次共享库的 CORS。
 const scanLoginPollSecretQuery = "poll_secret"
 
 // ScanLoginAuthCodeTTL 是扫码登录授权码的存活时间。

--- a/modules/user/scanlogin_poll.go
+++ b/modules/user/scanlogin_poll.go
@@ -1,0 +1,240 @@
+package user
+
+import (
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/hex"
+	"fmt"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
+	"go.uber.org/zap"
+)
+
+// scanLoginPollSecretPrefix 是扫码登录轮询密钥的 Redis 前缀。
+//
+// 该前缀在 octo-server 本地定义（而非 octo-lib common.*CachePrefix）：octo-lib 是
+// 外部模块，加常量需要先发版；本 key 的生命周期完全由 modules/user 掌握。
+const scanLoginPollSecretPrefix = "scanlogin:poll:"
+
+// ScanLoginPollSecretHeader 是轮询方出示密钥用的请求头。
+//
+// 走 header 而非 query：密钥的明文若进 URL，会被 nginx/ingress access log、CDN/WAF
+// 日志、APM trace span 与浏览器历史逐字记录 —— 那正好抵消了「Redis 只存摘要」想防的
+// 泄露面。header 不进请求行，也就不进这些日志的默认字段。
+const ScanLoginPollSecretHeader = "X-Scan-Poll-Secret"
+
+// scanLoginPollSecretTTL 是轮询密钥的存活时间。
+//
+// 必须覆盖「二维码状态还可能被读到」的最坏路径，否则用户扫得晚一点就会拿不到
+// auth_code。该路径是三段累加：
+//
+//	mint 后 60s 内扫码（getLoginUUID 写 qrcode:{uuid} 的初始 TTL）
+//	+ 300s   （handleScanLogin 把 qrcode 续到 5min，用户在确认页停顿的上限）
+//	+ 300s   （grantLogin 确认后再续 5min，浏览器兑换前的窗口）
+//	= 660s
+//
+// 取 12 分钟给 60s 余量，避免 Redis 与应用间的时钟漂移或调用延迟正好卡在边界上把
+// 已扫码的用户甩掉（上一版取 6 分钟且零余量，扫码发生在第 59 秒时必然踩中）。
+//
+// 长活本身不额外授权：密钥只是读取凭据的门票，qrcode 状态一过期就无内容可读；且
+// loginWithAuthCode 兑换成功后会立刻 deleteScanLoginPollSecret，常态下活不满 TTL。
+const scanLoginPollSecretTTL = 12 * time.Minute
+
+// 扫码登录两个未认证端点的默认限流档位（可经 DM_API_SCANLOGIN_*_RATELIMIT_{RPS,BURST}
+// 覆盖，见 api.go 的挂载点）。
+//
+// 这两个值是「防批量滥用的地板」，不是精细控制，所以给得很松。定档依据：
+//   - qrcode:{uuid} 初始 TTL 只有 60s，所以每个停在登录页的浏览器约每分钟重铸一次
+//     uuid —— 一个 100 人的办公室就是 ~100 次/分，全部来自同一个出口 IP。
+//   - 反向代理若没配 X-Real-Ip / X-Forwarded-For，octo-lib 的 getClientIP 会回落到
+//     RemoteAddr，即 nginx 自己的地址 —— 整个部署塌进同一个桶。
+//
+// 卡死的后果是「一层楼扫不了码」，比放过一些扫描流量严重得多。全局 RateLimitMiddleware
+// （1000 req/min/IP）仍在外层兜底，所以这里没必要再收紧。大规模 NAT 部署可直接上调。
+const (
+	defaultScanLoginUUIDRateLimitRPS     = 120.0 / 60 // 120 req/min
+	defaultScanLoginUUIDRateLimitBurst   = 60
+	defaultScanLoginStatusRateLimitRPS   = 600.0 / 60 // 600 req/min
+	defaultScanLoginStatusRateLimitBurst = 300
+)
+
+// scanLoginPublicDataKeys 是 qrcode:{uuid} 状态里允许回给**任意**匿名轮询方的键。
+//
+// 这里刻意用白名单而不是「敏感键黑名单」：黑名单在有人往 payload 里加字段时默认放行
+// （fail-open），而这个 payload 的写入方分散在三处 —— getLoginUUID、
+// modules/qrcode.handleScanLogin、grantLogin。上一版的黑名单加一个只读 grantLogin 的
+// 守卫测试，handleScanLogin 里新增的字段（扫码者昵称/头像/手机号等）会直接漏给攻击者。
+// 白名单反过来：新字段默认不下发，要下发必须有人显式把它加进来并想清楚。
+var scanLoginPublicDataKeys = map[string]struct{}{
+	"status": {}, // 扫码进度，前端状态机必需
+	"app_id": {}, // 常量标识，无信息量
+}
+
+// scanLoginOriginPrefix 记录「是谁请求了这个二维码」，供手机确认页展示。
+//
+// 与既有的 common.DeviceCacheUUIDPrefix 分开存：那份记录只在 device_id/name/model
+// 三者齐全时才写，且被 loginWithAuthCode 用于登记设备；这里需要的是**无条件可得**的
+// 来源上下文（尤其是 IP），不能因为客户端没上报设备字段就缺失。
+const scanLoginOriginPrefix = "scanlogin:origin:"
+
+// ScanLoginOrigin 是发起扫码登录的那一端的可展示上下文。
+//
+// 存在的理由：poll_secret 挡不住 QRLJacking —— 攻击者自己调 loginuuid，密钥自然也在
+// 他手里。这条攻击链的唯一断点在**确认环节**：受害者必须能看出「请求登录的不是我的
+// 设备」。服务端能做的是把判断依据备齐并下发给手机；真正生效还需要 iOS/Android 在
+// 确认弹窗里渲染它。在那之前，这个结构体只是把数据准备好。
+type ScanLoginOrigin struct {
+	IP          string `json:"ip"`
+	DeviceName  string `json:"device_name,omitempty"`
+	DeviceModel string `json:"device_model,omitempty"`
+	UserAgent   string `json:"user_agent,omitempty"`
+}
+
+func scanLoginOriginKey(uuid string) string {
+	return fmt.Sprintf("%s%s", scanLoginOriginPrefix, uuid)
+}
+
+// storeScanLoginOrigin 写入来源上下文，与轮询密钥同寿命。
+func storeScanLoginOrigin(store pollSecretStore, uuid string, origin ScanLoginOrigin) error {
+	return store.SetAndExpire(scanLoginOriginKey(uuid), util.ToJson(origin), scanLoginPollSecretTTL)
+}
+
+// LoadScanLoginOrigin 读取来源上下文，供 modules/qrcode 在扫码时回给手机。
+// 读不到时返回 nil（不是错误）—— 上下文缺失不应该阻断扫码。
+func LoadScanLoginOrigin(store pollSecretStore, uuid string) (*ScanLoginOrigin, error) {
+	raw, err := store.GetString(scanLoginOriginKey(uuid))
+	if err != nil {
+		return nil, err
+	}
+	if raw == "" {
+		return nil, nil
+	}
+	var origin ScanLoginOrigin
+	if err := util.ReadJsonByByte([]byte(raw), &origin); err != nil {
+		return nil, err
+	}
+	return &origin, nil
+}
+
+// pollSecretStore 是轮询密钥所需的最小存储能力，签名对齐 octo-lib 的 *redis.Conn。
+//
+// 抽成接口是为了让密钥的写入/比对/删除能在没有 Redis 的环境下做真实行为测试 ——
+// 这是本模块唯一的安全闸门，只用源码字符串断言覆盖它是不够的（key 拼错、存了明文、
+// 写读两侧 key 不一致这类错误都能一路绿灯上线）。
+type pollSecretStore interface {
+	SetAndExpire(key string, value interface{}, expire time.Duration) error
+	GetString(key string) (string, error)
+	Del(key string) error
+}
+
+// scanLoginPollSecretKey 拼装轮询密钥的 Redis key。
+func scanLoginPollSecretKey(uuid string) string {
+	return fmt.Sprintf("%s%s", scanLoginPollSecretPrefix, uuid)
+}
+
+// hashScanLoginPollSecret 返回密钥的 SHA-256 十六进制摘要。
+//
+// 存摘要而非明文：Redis 快照 / 慢查询日志 / 运维 KEYS 扫描都可能让明文外泄，而该
+// 明文等价于「读取 auth_code 的权限」。摘要不可逆，泄露也无法用于轮询。
+func hashScanLoginPollSecret(secret string) string {
+	sum := sha256.Sum256([]byte(secret))
+	return hex.EncodeToString(sum[:])
+}
+
+// mintScanLoginPollSecret 为 uuid 生成一枚轮询密钥，把摘要写入 store，返回明文。
+//
+// 明文只在 getLoginUUID 的 HTTP 响应体里回给申请方一次。**绝不能写进
+// qrcode:{uuid} 的 payload** —— 那个 payload 正是 getloginStatus 要回显给匿名轮询方
+// 的内容，把密钥放进去等于把门钥匙挂在门上。
+func mintScanLoginPollSecret(store pollSecretStore, uuid string) (string, error) {
+	secret := util.GenerUUID() // crypto/rand UUIDv4，122 bit
+	if err := store.SetAndExpire(
+		scanLoginPollSecretKey(uuid),
+		hashScanLoginPollSecret(secret),
+		scanLoginPollSecretTTL,
+	); err != nil {
+		return "", err
+	}
+	return secret, nil
+}
+
+// scanLoginPollSecretMatches 判断 presented 是否为 uuid 当初下发的轮询密钥。
+//
+// Fail-closed：store 读失败、key 不存在、presented 为空，一律 false。任何一处
+// fail-open 都会让未持密钥的轮询方拿到 auth_code。err 单独返回供调用方记日志，
+// 但不影响判定结果 —— 读不到就是不放行。
+//
+// 比对用 subtle.ConstantTimeCompare 而非 ==：摘要是定长十六进制串，逐字节短路比较会
+// 在响应时间上泄露前缀匹配长度。
+func scanLoginPollSecretMatches(store pollSecretStore, uuid string, presented string) (bool, error) {
+	if uuid == "" || presented == "" {
+		return false, nil
+	}
+	stored, err := store.GetString(scanLoginPollSecretKey(uuid))
+	if err != nil {
+		return false, err
+	}
+	if stored == "" {
+		return false, nil
+	}
+	return subtle.ConstantTimeCompare([]byte(stored), []byte(hashScanLoginPollSecret(presented))) == 1, nil
+}
+
+// deleteScanLoginPollSecret 在扫码登录兑换完成后清掉密钥。
+//
+// 与 loginWithAuthCode 删除 authcode:{code} 同理：登录已经完成，密钥再留着就只是一段
+// 多余的可利用窗口 —— 期间任何拿到它的人仍可读出 uid/encrypt。
+func deleteScanLoginPollSecret(store pollSecretStore, uuid string) error {
+	return store.Del(scanLoginPollSecretKey(uuid))
+}
+
+// filterScanLoginPublicFields 返回 data 中仅保留 scanLoginPublicDataKeys 的浅拷贝。
+//
+// 返回拷贝而非原地删除：同一个 *common.QRCodeModel 会经长轮询 channel 广播，原地改会
+// 污染持有正确密钥那一方的视图。
+func filterScanLoginPublicFields(data map[string]interface{}) map[string]interface{} {
+	if data == nil {
+		return nil
+	}
+	out := make(map[string]interface{}, len(scanLoginPublicDataKeys))
+	for k, v := range data {
+		if _, ok := scanLoginPublicDataKeys[k]; ok {
+			out[k] = v
+		}
+	}
+	return out
+}
+
+// --- *User 上的薄封装：注入生产用的 Redis 连接并统一记日志 ---------------------
+
+func (u *User) mintScanLoginPollSecret(uuid string) (string, error) {
+	return mintScanLoginPollSecret(u.ctx.GetRedisConn(), uuid)
+}
+
+func (u *User) scanLoginPollSecretMatches(uuid string, presented string) bool {
+	ok, err := scanLoginPollSecretMatches(u.ctx.GetRedisConn(), uuid, presented)
+	if err != nil {
+		// 读不到就当没有 —— 宁可让合法用户停在授权页重试，也不能放行匿名轮询。
+		u.Error("读取扫码轮询密钥失败", zap.String("uuid", uuid), zap.Error(err))
+		return false
+	}
+	return ok
+}
+
+func (u *User) deleteScanLoginPollSecret(uuid string) {
+	if uuid == "" {
+		return
+	}
+	if err := deleteScanLoginPollSecret(u.ctx.GetRedisConn(), uuid); err != nil {
+		// 清理失败不该让登录失败：密钥仍会按 TTL 自然过期。
+		u.Warn("清理扫码轮询密钥失败", zap.String("uuid", uuid), zap.Error(err))
+	}
+}
+
+func (u *User) storeScanLoginOrigin(uuid string, origin ScanLoginOrigin) {
+	if err := storeScanLoginOrigin(u.ctx.GetRedisConn(), uuid, origin); err != nil {
+		// 上下文只用于确认页展示，写失败不阻断发码 —— 手机端拿不到就退化为不展示。
+		u.Warn("记录扫码登录来源失败", zap.String("uuid", uuid), zap.Error(err))
+	}
+}

--- a/modules/user/scanlogin_poll.go
+++ b/modules/user/scanlogin_poll.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/Mininglamp-OSS/octo-lib/common"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
 	"go.uber.org/zap"
 )
@@ -46,15 +47,24 @@ const scanLoginPollSecretQuery = "poll_secret"
 // authCode 续期（见 P1-3），而 qrcode 已经 import user，反向 import 会成环。
 const ScanLoginAuthCodeTTL = 5 * time.Minute
 
+// ScanLoginConfirmWindow 是「二维码已被扫描 / 已授权」状态的存活时间，也就是用户可以
+// 停在确认页、以及浏览器完成兑换的时间上限。
+//
+// 单独命名而不是继续散落 time.Minute*5：scanLoginPollSecretTTL 的推导把这个量当作
+// 一个三项累加里的两项在用，写成字面量就意味着注释里的算术、守卫测试里的建模、以及
+// 代码实际行为是三份互不相干的东西。两个写入方（modules/qrcode.handleScanLogin 与
+// grantLogin）现在都引用它。
+const ScanLoginConfirmWindow = 5 * time.Minute
+
 // scanLoginPollSecretTTL 是轮询密钥的存活时间。
 //
 // 必须覆盖「二维码状态还可能被读到」的最坏路径，否则用户扫得晚一点就会拿不到
 // auth_code。该路径是三段累加：
 //
 //	mint 后 60s 内扫码（getLoginUUID 写 qrcode:{uuid} 的初始 TTL）
-//	+ 300s   （handleScanLogin 把 qrcode 续到 5min，用户在确认页停顿的上限）
-//	+ 300s   （grantLogin 确认后再续 5min，浏览器兑换前的窗口）
-//	= 660s
+//	+ ScanLoginConfirmWindow（handleScanLogin 续期，用户停在确认页的上限）
+//	+ ScanLoginConfirmWindow（grantLogin 确认后再续，浏览器兑换前的窗口）
+//	= 60s + 2×5min = 660s
 //
 // 取 12 分钟给 60s 余量，避免 Redis 与应用间的时钟漂移或调用延迟正好卡在边界上把
 // 已扫码的用户甩掉。
@@ -74,11 +84,18 @@ const scanLoginPollSecretTTL = 12 * time.Minute
 //
 // 卡死的后果是「一层楼扫不了码」，比放过一些扫描流量严重得多。全局 RateLimitMiddleware
 // （1000 req/min/IP）仍在外层兜底。大规模 NAT 部署可直接上调。
+//
+// 档位刻意留一个数量级的余量，而不是贴着上面那笔估算走：初版取 120/600，正好是估算值
+// 的 83%/100% —— 讲着「要留余量」却没留。100 人同时打开登录页（重启后、上班高峰）会
+// 直接吃满 burst，而失败面是通用的 i18n rate.limited，运维根本归因不到这两个桶。
+//
+// 更贴切的建模其实是并发上限而非请求速率（loginstatus 是 10s 长轮询，一个请求占的是
+// 连接而不是一次调用），但那要换一套中间件；在此之前用宽档位换「绝不误伤」。
 const (
-	defaultScanLoginUUIDRateLimitRPS     = 120.0 / 60 // 120 req/min
-	defaultScanLoginUUIDRateLimitBurst   = 60
-	defaultScanLoginStatusRateLimitRPS   = 600.0 / 60 // 600 req/min
-	defaultScanLoginStatusRateLimitBurst = 300
+	defaultScanLoginUUIDRateLimitRPS     = 1200.0 / 60 // 1200 req/min
+	defaultScanLoginUUIDRateLimitBurst   = 600
+	defaultScanLoginStatusRateLimitRPS   = 6000.0 / 60 // 6000 req/min
+	defaultScanLoginStatusRateLimitBurst = 3000
 )
 
 // scanLoginPublicDataKeys 是 qrcode:{uuid} 状态里允许回给**任意**匿名轮询方的键。
@@ -201,4 +218,27 @@ func (u *User) deleteScanLoginPollSecret(uuid string) {
 		// 清理失败不该让登录失败：密钥仍会按 TTL 自然过期。
 		u.Warn("清理扫码轮询密钥失败", zap.String("uuid", uuid), zap.Error(err))
 	}
+}
+
+// ensureScanLoginStatus 保证下发给未授权轮询方的 payload 里一定有 status。
+//
+// 白名单的默认行为是「新字段不下发」，这对凭据是对的、对 status 是错的：一旦过滤后
+// 的 map 里没有 status（Data 为 nil，或将来某个写入方构造出一份键全被丢掉的 payload），
+// 前端拿到的 result.status 是 undefined → loginStatus 变 undefined → 状态机匹配不到
+// 任何分支 → 轮询永久停摆。这正是 respondStatus 当初要消除的故障。
+//
+// 回落顺序：过滤结果里的 status → 原始 Data 里的 status → expired。
+func ensureScanLoginStatus(filtered map[string]interface{}, original map[string]interface{}) map[string]interface{} {
+	if filtered == nil {
+		filtered = map[string]interface{}{}
+	}
+	if _, ok := filtered["status"]; ok {
+		return filtered
+	}
+	if v, ok := original["status"]; ok {
+		filtered["status"] = v
+		return filtered
+	}
+	filtered["status"] = common.ScanLoginStatusExpired
+	return filtered
 }

--- a/modules/user/scanlogin_poll_test.go
+++ b/modules/user/scanlogin_poll_test.go
@@ -4,11 +4,15 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -136,14 +140,10 @@ func TestScanLoginPollSecret_TTLCoversWorstCaseFlow(t *testing.T) {
 	// 最坏路径：mint 后 60s 扫码（qrcode 初始 TTL）→ handleScanLogin 续 5min →
 	// grantLogin 再续 5min = 660s。密钥必须活得比这久，否则扫得晚的用户拿不到
 	// auth_code。上一版取 6min（=360s）零余量，扫码发生在第 59 秒时必然踩中。
-	worstCase := 60*time.Second + scanLoginAuthCodeTTLMirror + scanLoginAuthCodeTTLMirror
+	worstCase := 60*time.Second + ScanLoginAuthCodeTTL + ScanLoginAuthCodeTTL
 	assert.Greater(t, scanLoginPollSecretTTL, worstCase,
 		"轮询密钥 TTL 必须严格覆盖二维码状态的最长可读窗口并留余量")
 }
-
-// scanLoginAuthCodeTTLMirror 镜像 modules/qrcode.scanLoginAuthCodeTTL（跨包不可见）。
-// 两者漂移时上面的 TTL 断言会失效，故在此显式标注依赖。
-const scanLoginAuthCodeTTLMirror = 5 * time.Minute
 
 // ---------------------------------------------------------------------------
 // 行为测试：字段白名单
@@ -197,30 +197,6 @@ func TestHashScanLoginPollSecret_IsDeterministicSHA256Hex(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// 行为测试：来源上下文
-// ---------------------------------------------------------------------------
-
-func TestScanLoginOrigin_RoundTrip(t *testing.T) {
-	store := newFakePollSecretStore()
-	const uuid = "uuid-1"
-	want := ScanLoginOrigin{IP: "203.0.113.9", DeviceName: "Chrome", DeviceModel: "Windows", UserAgent: "UA/1"}
-
-	require.NoError(t, storeScanLoginOrigin(store, uuid, want))
-
-	got, err := LoadScanLoginOrigin(store, uuid)
-	require.NoError(t, err)
-	require.NotNil(t, got)
-	assert.Equal(t, want, *got)
-}
-
-func TestScanLoginOrigin_MissingIsNotAnError(t *testing.T) {
-	// 上下文缺失只该退化为「确认页不展示」，不能阻断扫码。
-	got, err := LoadScanLoginOrigin(newFakePollSecretStore(), "absent")
-	require.NoError(t, err)
-	assert.Nil(t, got)
-}
-
-// ---------------------------------------------------------------------------
 // 源码契约锁：只锁「无法在无 Redis 环境端到端跑」的 handler 结构不变量
 // ---------------------------------------------------------------------------
 
@@ -264,8 +240,8 @@ func TestGetLoginUUID_KeepsPollSecretOutOfQRCodePayload(t *testing.T) {
 func TestGetLoginStatus_DataOnlyLeavesThroughTheGate(t *testing.T) {
 	fn := readFuncBody(t, "api.go", "func (u *User) getloginStatus(")
 
-	assert.Contains(t, fn, "u.scanLoginPollSecretMatches(uuid, c.GetHeader(ScanLoginPollSecretHeader))",
-		"轮询密钥必须从请求头读取，不能走 query（会被 access log 记录）")
+	assert.Contains(t, fn, "u.scanLoginPollSecretMatches(uuid, scanLoginPresentedPollSecret(c))",
+		"轮询密钥必须经 scanLoginPresentedPollSecret 读取（请求头优先、query 兜底）")
 	assert.Contains(t, fn, "filterScanLoginPublicFields(model.Data)")
 
 	closureStart := strings.Index(fn, "respondStatus := func(")
@@ -284,8 +260,8 @@ func TestGetLoginStatus_ReleasesOnDisconnectAndOwnsItsChannel(t *testing.T) {
 	assert.Contains(t, fn, "case <-c.Request.Context().Done():",
 		"长轮询必须在客户端断开时立即释放")
 	assert.Contains(t, fn, "defer timeout.Stop()")
-	// 必须只回收自己注册的 channel：removeQRCodeChan(uuid) 会关掉 map 里当前那个，
-	// 而该接口未认证 —— 任何知道 uuid 的人反复连了就断即可踢掉合法轮询方。
+	// 必须只回收自己注册的 channel。无归属校验的 removeQRCodeChan 已删除，这里锁住
+	// 它不会被重新引入 —— 那会把跨请求关闭别人 channel 的洞放回来。
 	assert.NotContains(t, fn, "u.removeQRCodeChan(uuid)",
 		"必须用带归属校验的 removeQRCodeChanOwned")
 	assert.Contains(t, fn, "u.removeQRCodeChanOwned(uuid, qrcodeChan)")
@@ -306,4 +282,82 @@ func TestScanLoginRoutesCarryStrictIPRateLimit(t *testing.T) {
 	assert.Contains(t, body, `v.GET("/user/loginstatus", scanLoginStatusLimit, u.getloginStatus)`)
 	assert.Contains(t, body, `"scanlogin_uuid"`)
 	assert.Contains(t, body, `"scanlogin_status"`)
+}
+
+// TestScanLoginPresentedPollSecret_PrefersHeaderFallsBackToQuery 锁住双通道取值：
+// 请求头优先（不进 access log），query 仅为跨源部署的过渡兜底 —— octo-lib 的 CORS
+// 白名单不含自定义头，跨源预检会把整个请求拒掉，连降级都轮不到。
+func TestScanLoginPresentedPollSecret_PrefersHeaderFallsBackToQuery(t *testing.T) {
+	newCtx := func(header string, query string) *wkhttp.Context {
+		u := "/v1/user/loginstatus?uuid=x"
+		if query != "" {
+			u += "&" + scanLoginPollSecretQuery + "=" + query
+		}
+		req := httptest.NewRequest(http.MethodGet, u, nil)
+		if header != "" {
+			req.Header.Set(ScanLoginPollSecretHeader, header)
+		}
+		gc, _ := gin.CreateTestContext(httptest.NewRecorder())
+		gc.Request = req
+		return &wkhttp.Context{Context: gc}
+	}
+
+	assert.Equal(t, "h", scanLoginPresentedPollSecret(newCtx("h", "")), "只有头时取头")
+	assert.Equal(t, "q", scanLoginPresentedPollSecret(newCtx("", "q")), "只有 query 时回落")
+	assert.Equal(t, "h", scanLoginPresentedPollSecret(newCtx("h", "q")), "两者都有时头优先")
+	assert.Equal(t, "", scanLoginPresentedPollSecret(newCtx("", "")), "都没有时为空 → fail-closed")
+	assert.Equal(t, "h", scanLoginPresentedPollSecret(newCtx("  h  ", "")), "两端空白要裁掉")
+}
+
+// TestGetLoginStatus_OnlyAuthorizedPollersRegisterAChannel 锁住 P2-1 的修复：
+// getQRCodeModelChan 对同一 uuid 是无条件覆盖写，未授权方一旦也能注册，就能靠反复轮询
+// 持续顶掉合法轮询方的 channel，让对方每轮白等满 10 秒。
+func TestGetLoginStatus_OnlyAuthorizedPollersRegisterAChannel(t *testing.T) {
+	fn := readFuncBody(t, "api.go", "func (u *User) getloginStatus(")
+
+	assert.Contains(t, fn, "if authorized {",
+		"channel 注册必须以 authorized 为前提")
+	regIdx := strings.Index(fn, "u.getQRCodeModelChan(uuid)")
+	gateIdx := strings.Index(fn, "if authorized {")
+	require.NotEqual(t, -1, regIdx)
+	require.NotEqual(t, -1, gateIdx)
+	assert.Less(t, gateIdx, regIdx, "授权判断必须在注册之前")
+}
+
+// TestGrantLogin_RenewsAuthCodeTTL 锁住 P1-3 的修复。authCode 在**扫码**时签发，用户
+// 可以在确认页停到该 TTL 的最后一刻；若这里只续 qrcode 不续 authCode，就会出现
+// 「status=authed、附带的 auth_code 只剩一秒」，浏览器兑换必然失败且状态机无路可走。
+func TestGrantLogin_RenewsAuthCodeTTL(t *testing.T) {
+	fn := readFuncBody(t, "api.go", "func (u *User) grantLogin(")
+
+	assert.Contains(t, fn, "common.AuthCodeCachePrefix, authCode), authInfo, ScanLoginAuthCodeTTL",
+		"确认时必须按同一档位给 authCode 重新计时")
+
+	renewIdx := strings.Index(fn, "common.AuthCodeCachePrefix, authCode), authInfo, ScanLoginAuthCodeTTL")
+	qrIdx := strings.Index(fn, "common.QRCodeCachePrefix, uuid)")
+	require.NotEqual(t, -1, renewIdx)
+	require.NotEqual(t, -1, qrIdx)
+	assert.Less(t, renewIdx, qrIdx,
+		"先续 authCode 再写 qrcode —— 续期失败就不该对外宣告 authed")
+
+	// 两者必须用同一个常量，否则窗口又会倒挂。
+	assert.NotContains(t, fn, "time.Minute*5",
+		"TTL 必须走 ScanLoginAuthCodeTTL 常量，不要再散落字面量")
+}
+
+// TestLoginWithAuthCode_ClearsScanLoginState 锁住 P2-3：登录完成后本轮扫码的所有状态
+// 都要清掉。qrcode:{uuid} 里还带着 encrypt（Signal 密钥材料），没有理由留在 Redis。
+func TestLoginWithAuthCode_ClearsScanLoginState(t *testing.T) {
+	fn := readFuncBody(t, "api.go", "func (u *User) loginWithAuthCode(")
+
+	assert.Contains(t, fn, "u.deleteScanLoginPollSecret(uuid)", "必须吊销轮询密钥")
+	assert.Contains(t, fn, "common.QRCodeCachePrefix, uuid)",
+		"必须一并删除 qrcode:{uuid}，它仍携带 uid / auth_code / encrypt")
+}
+
+// TestGetLoginUUID_SetsNoStore 锁住 P2-5：响应体带着 bearer 级密钥，任何中间缓存或
+// 浏览器 bfcache 留存都等于泄露它。
+func TestGetLoginUUID_SetsNoStore(t *testing.T) {
+	fn := readFuncBody(t, "api.go", "func (u *User) getLoginUUID(")
+	assert.Contains(t, fn, `c.Header("Cache-Control", "no-store")`)
 }

--- a/modules/user/scanlogin_poll_test.go
+++ b/modules/user/scanlogin_poll_test.go
@@ -1,0 +1,309 @@
+package user
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakePollSecretStore 是 pollSecretStore 的内存实现，用于在没有 Redis 的环境下对
+// 安全闸门做真实行为测试（key 拼装、存摘要而非明文、写读一致、删除生效、TTL）。
+type fakePollSecretStore struct {
+	values map[string]string
+	ttls   map[string]time.Duration
+	getErr error
+	setErr error
+}
+
+func newFakePollSecretStore() *fakePollSecretStore {
+	return &fakePollSecretStore{values: map[string]string{}, ttls: map[string]time.Duration{}}
+}
+
+func (f *fakePollSecretStore) SetAndExpire(key string, value interface{}, expire time.Duration) error {
+	if f.setErr != nil {
+		return f.setErr
+	}
+	f.values[key] = value.(string)
+	f.ttls[key] = expire
+	return nil
+}
+
+func (f *fakePollSecretStore) GetString(key string) (string, error) {
+	if f.getErr != nil {
+		return "", f.getErr
+	}
+	return f.values[key], nil
+}
+
+func (f *fakePollSecretStore) Del(key string) error {
+	delete(f.values, key)
+	delete(f.ttls, key)
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// 行为测试：mint / matches / delete 全链路
+// ---------------------------------------------------------------------------
+
+func TestScanLoginPollSecret_MintThenMatch(t *testing.T) {
+	store := newFakePollSecretStore()
+	const uuid = "uuid-1"
+
+	secret, err := mintScanLoginPollSecret(store, uuid)
+	require.NoError(t, err)
+	require.NotEmpty(t, secret)
+
+	ok, err := scanLoginPollSecretMatches(store, uuid, secret)
+	require.NoError(t, err)
+	assert.True(t, ok, "刚铸造的密钥必须能通过校验")
+}
+
+func TestScanLoginPollSecret_StoresDigestNotPlaintext(t *testing.T) {
+	store := newFakePollSecretStore()
+	const uuid = "uuid-1"
+
+	secret, err := mintScanLoginPollSecret(store, uuid)
+	require.NoError(t, err)
+
+	stored, ok := store.values[scanLoginPollSecretKey(uuid)]
+	require.True(t, ok, "必须写在 scanlogin:poll:{uuid} 这个 key 上")
+	assert.NotEqual(t, secret, stored, "Redis 里不得出现明文密钥")
+
+	want := sha256.Sum256([]byte(secret))
+	assert.Equal(t, hex.EncodeToString(want[:]), stored)
+	assert.Equal(t, scanLoginPollSecretTTL, store.ttls[scanLoginPollSecretKey(uuid)])
+}
+
+func TestScanLoginPollSecret_RejectsWrongAbsentAndEmpty(t *testing.T) {
+	store := newFakePollSecretStore()
+	const uuid = "uuid-1"
+	secret, err := mintScanLoginPollSecret(store, uuid)
+	require.NoError(t, err)
+
+	cases := []struct {
+		name      string
+		uuid      string
+		presented string
+	}{
+		{"错误密钥", uuid, "not-the-secret"},
+		{"空密钥（未升级的旧客户端）", uuid, ""},
+		{"密钥对但 uuid 不对", "uuid-other", secret},
+		{"uuid 与密钥都为空", "", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ok, err := scanLoginPollSecretMatches(store, tc.uuid, tc.presented)
+			require.NoError(t, err)
+			assert.False(t, ok)
+		})
+	}
+}
+
+func TestScanLoginPollSecret_FailsClosedOnStoreError(t *testing.T) {
+	store := newFakePollSecretStore()
+	const uuid = "uuid-1"
+	secret, err := mintScanLoginPollSecret(store, uuid)
+	require.NoError(t, err)
+
+	store.getErr = errors.New("redis down")
+	ok, err := scanLoginPollSecretMatches(store, uuid, secret)
+	// 读失败必须判为「不通过」。任何 fail-open 都会把 auth_code 交给匿名轮询方。
+	assert.False(t, ok, "存储故障时必须 fail-closed")
+	assert.Error(t, err, "错误要回传给调用方记日志")
+}
+
+func TestScanLoginPollSecret_DeleteRevokes(t *testing.T) {
+	store := newFakePollSecretStore()
+	const uuid = "uuid-1"
+	secret, err := mintScanLoginPollSecret(store, uuid)
+	require.NoError(t, err)
+
+	require.NoError(t, deleteScanLoginPollSecret(store, uuid))
+
+	ok, err := scanLoginPollSecretMatches(store, uuid, secret)
+	require.NoError(t, err)
+	assert.False(t, ok, "兑换后密钥必须立即失效，不留残余窗口")
+}
+
+func TestScanLoginPollSecret_TTLCoversWorstCaseFlow(t *testing.T) {
+	// 最坏路径：mint 后 60s 扫码（qrcode 初始 TTL）→ handleScanLogin 续 5min →
+	// grantLogin 再续 5min = 660s。密钥必须活得比这久，否则扫得晚的用户拿不到
+	// auth_code。上一版取 6min（=360s）零余量，扫码发生在第 59 秒时必然踩中。
+	worstCase := 60*time.Second + scanLoginAuthCodeTTLMirror + scanLoginAuthCodeTTLMirror
+	assert.Greater(t, scanLoginPollSecretTTL, worstCase,
+		"轮询密钥 TTL 必须严格覆盖二维码状态的最长可读窗口并留余量")
+}
+
+// scanLoginAuthCodeTTLMirror 镜像 modules/qrcode.scanLoginAuthCodeTTL（跨包不可见）。
+// 两者漂移时上面的 TTL 断言会失效，故在此显式标注依赖。
+const scanLoginAuthCodeTTLMirror = 5 * time.Minute
+
+// ---------------------------------------------------------------------------
+// 行为测试：字段白名单
+// ---------------------------------------------------------------------------
+
+func TestFilterScanLoginPublicFields_DropsEverythingNotAllowlisted(t *testing.T) {
+	out := filterScanLoginPublicFields(map[string]interface{}{
+		"app_id":    "wukongchat",
+		"status":    "authed",
+		"uid":       "victim-uid",
+		"auth_code": "the-golden-ticket",
+		"encrypt":   "signal-key-material",
+		// 白名单的意义：未来任何人往 payload 里加字段，默认不下发。
+		"scanner_phone": "13800000000",
+		"someNewField":  "whatever",
+	})
+
+	assert.Equal(t, map[string]interface{}{
+		"app_id": "wukongchat",
+		"status": "authed",
+	}, out, "只有显式列入白名单的键可以回给未授权轮询方")
+}
+
+func TestFilterScanLoginPublicFields_AllowlistExcludesCredentials(t *testing.T) {
+	for _, k := range []string{"auth_code", "uid", "encrypt"} {
+		_, ok := scanLoginPublicDataKeys[k]
+		assert.False(t, ok, "%q 是凭据/身份字段，绝不可进白名单", k)
+	}
+}
+
+func TestFilterScanLoginPublicFields_DoesNotMutateInput(t *testing.T) {
+	in := map[string]interface{}{"status": "authed", "auth_code": "abc"}
+	_ = filterScanLoginPublicFields(in)
+	// 同一个 *common.QRCodeModel 会被长轮询 channel 广播给多个等待者，
+	// 原地删除会污染持有正确密钥那一方的视图。
+	assert.Equal(t, "abc", in["auth_code"], "过滤必须返回拷贝，不得修改入参")
+}
+
+func TestFilterScanLoginPublicFields_NilPassthrough(t *testing.T) {
+	assert.Nil(t, filterScanLoginPublicFields(nil))
+}
+
+func TestHashScanLoginPollSecret_IsDeterministicSHA256Hex(t *testing.T) {
+	const secret = "a-poll-secret"
+	want := sha256.Sum256([]byte(secret))
+	got := hashScanLoginPollSecret(secret)
+
+	assert.Equal(t, hex.EncodeToString(want[:]), got)
+	assert.Equal(t, got, hashScanLoginPollSecret(secret), "同一输入必须稳定")
+	assert.NotEqual(t, got, hashScanLoginPollSecret(secret+"x"))
+}
+
+// ---------------------------------------------------------------------------
+// 行为测试：来源上下文
+// ---------------------------------------------------------------------------
+
+func TestScanLoginOrigin_RoundTrip(t *testing.T) {
+	store := newFakePollSecretStore()
+	const uuid = "uuid-1"
+	want := ScanLoginOrigin{IP: "203.0.113.9", DeviceName: "Chrome", DeviceModel: "Windows", UserAgent: "UA/1"}
+
+	require.NoError(t, storeScanLoginOrigin(store, uuid, want))
+
+	got, err := LoadScanLoginOrigin(store, uuid)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, want, *got)
+}
+
+func TestScanLoginOrigin_MissingIsNotAnError(t *testing.T) {
+	// 上下文缺失只该退化为「确认页不展示」，不能阻断扫码。
+	got, err := LoadScanLoginOrigin(newFakePollSecretStore(), "absent")
+	require.NoError(t, err)
+	assert.Nil(t, got)
+}
+
+// ---------------------------------------------------------------------------
+// 源码契约锁：只锁「无法在无 Redis 环境端到端跑」的 handler 结构不变量
+// ---------------------------------------------------------------------------
+
+func readFuncBody(t *testing.T, path string, sig string) string {
+	t.Helper()
+	src, err := os.ReadFile(path)
+	require.NoError(t, err)
+	body := string(src)
+	start := strings.Index(body, sig)
+	require.NotEqual(t, -1, start, "%s 必须存在于 %s", sig, path)
+	rest := body[start+len(sig):]
+	end := strings.Index(rest, "\nfunc ")
+	if end == -1 {
+		return body[start:]
+	}
+	return body[start : start+len(sig)+end]
+}
+
+func TestGetLoginUUID_KeepsPollSecretOutOfQRCodePayload(t *testing.T) {
+	fn := readFuncBody(t, "api.go", "func (u *User) getLoginUUID(")
+
+	assert.Contains(t, fn, "u.mintScanLoginPollSecret(uuid)")
+	assert.Contains(t, fn, `"poll_secret": pollSecret`)
+
+	// 核心不变量：密钥绝不能进 qrcode:{uuid} 的 payload —— 那份 payload 正是
+	// getloginStatus 要回显给匿名轮询方的内容。
+	modelStart := strings.Index(fn, "common.NewQRCodeModel(")
+	require.NotEqual(t, -1, modelStart)
+	modelEnd := strings.Index(fn[modelStart:], "}))")
+	require.NotEqual(t, -1, modelEnd)
+	payload := fn[modelStart : modelStart+modelEnd]
+	for _, banned := range []string{"poll_secret", "pollSecret", "Secret"} {
+		assert.NotContains(t, payload, banned,
+			"密钥不得写入 qrcode payload —— 会被 getloginStatus 原样回显")
+	}
+}
+
+// TestGetLoginStatus_DataOnlyLeavesThroughTheGate 锁住「所有 Data 出口都经过
+// respondStatus」。用「respondStatus 闭包之外不得出现 .Data」来表达，而不是禁止某几个
+// 具体变量名的字符串 —— 后者改个变量名就能绕过，等于没锁。
+func TestGetLoginStatus_DataOnlyLeavesThroughTheGate(t *testing.T) {
+	fn := readFuncBody(t, "api.go", "func (u *User) getloginStatus(")
+
+	assert.Contains(t, fn, "u.scanLoginPollSecretMatches(uuid, c.GetHeader(ScanLoginPollSecretHeader))",
+		"轮询密钥必须从请求头读取，不能走 query（会被 access log 记录）")
+	assert.Contains(t, fn, "filterScanLoginPublicFields(model.Data)")
+
+	closureStart := strings.Index(fn, "respondStatus := func(")
+	require.NotEqual(t, -1, closureStart, "必须存在 respondStatus 闭包")
+	closureEnd := strings.Index(fn[closureStart:], "\n\t}\n")
+	require.NotEqual(t, -1, closureEnd)
+	outside := fn[:closureStart] + fn[closureStart+closureEnd:]
+
+	assert.NotContains(t, outside, ".Data",
+		"二维码状态只能经 respondStatus 下发；闭包之外出现 .Data 意味着绕过了密钥校验")
+}
+
+func TestGetLoginStatus_ReleasesOnDisconnectAndOwnsItsChannel(t *testing.T) {
+	fn := readFuncBody(t, "api.go", "func (u *User) getloginStatus(")
+
+	assert.Contains(t, fn, "case <-c.Request.Context().Done():",
+		"长轮询必须在客户端断开时立即释放")
+	assert.Contains(t, fn, "defer timeout.Stop()")
+	// 必须只回收自己注册的 channel：removeQRCodeChan(uuid) 会关掉 map 里当前那个，
+	// 而该接口未认证 —— 任何知道 uuid 的人反复连了就断即可踢掉合法轮询方。
+	assert.NotContains(t, fn, "u.removeQRCodeChan(uuid)",
+		"必须用带归属校验的 removeQRCodeChanOwned")
+	assert.Contains(t, fn, "u.removeQRCodeChanOwned(uuid, qrcodeChan)")
+}
+
+func TestLoginWithAuthCode_RevokesPollSecret(t *testing.T) {
+	fn := readFuncBody(t, "api.go", "func (u *User) loginWithAuthCode(")
+	assert.Contains(t, fn, "u.deleteScanLoginPollSecret(uuid)",
+		"兑换完成后必须吊销轮询密钥，与删除 authCode 同理")
+}
+
+func TestScanLoginRoutesCarryStrictIPRateLimit(t *testing.T) {
+	src, err := os.ReadFile("api.go")
+	require.NoError(t, err)
+	body := string(src)
+
+	assert.Contains(t, body, `v.GET("/user/loginuuid", scanLoginUUIDLimit, u.getLoginUUID)`)
+	assert.Contains(t, body, `v.GET("/user/loginstatus", scanLoginStatusLimit, u.getloginStatus)`)
+	assert.Contains(t, body, `"scanlogin_uuid"`)
+	assert.Contains(t, body, `"scanlogin_status"`)
+}

--- a/modules/user/scanlogin_poll_test.go
+++ b/modules/user/scanlogin_poll_test.go
@@ -3,12 +3,18 @@ package user
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -348,4 +354,114 @@ func TestLoginWithAuthCode_ClearsScanLoginState(t *testing.T) {
 func TestGetLoginUUID_SetsNoStore(t *testing.T) {
 	fn := readFuncBody(t, "api.go", "func (u *User) getLoginUUID(")
 	assert.Contains(t, fn, `c.Header("Cache-Control", "no-store")`)
+}
+
+// ---------------------------------------------------------------------------
+// 行为测试：闸门本身（httptest 级）
+// ---------------------------------------------------------------------------
+
+// buildScanLoginStatusPayload 复刻 grantLogin 写进 qrcode:{uuid} 的 authed 状态。
+func buildScanLoginStatusPayload() *common.QRCodeModel {
+	return common.NewQRCodeModel(common.QRCodeTypeScanLogin, map[string]interface{}{
+		"app_id":    "wukongchat",
+		"status":    string(common.ScanLoginStatusAuthed),
+		"uid":       "victim-uid",
+		"auth_code": "the-golden-ticket",
+		"encrypt":   "signal-key-material",
+	})
+}
+
+// serveScanLoginStatus 跑 getloginStatus 的下发逻辑（授权判定 + respondStatus），
+// 返回真实的 HTTP 响应。
+//
+// 这是对 P2-5 的回应：此前所有 handler 级不变量都只由「源码里包含某字符串」的断言锁着，
+// 而那类断言挡不住真实的回归 —— 比如把 c.JSON(200, model.Data) 写成 c.JSON(200, model)
+// 会把整个 model（含 Data）序列化出去，字符串里却找不到 ".Data"，断言照样绿。这里断言的
+// 是性质本身：没有密钥就拿不到 auth_code。
+func serveScanLoginStatus(t *testing.T, store pollSecretStore, uuid string, presented string) *httptest.ResponseRecorder {
+	t.Helper()
+	model := buildScanLoginStatusPayload()
+
+	w := httptest.NewRecorder()
+	gc, _ := gin.CreateTestContext(w)
+	target := "/v1/user/loginstatus?uuid=" + uuid
+	if presented != "" {
+		target += "&" + scanLoginPollSecretQuery + "=" + presented
+	}
+	gc.Request = httptest.NewRequest(http.MethodGet, target, nil)
+	c := &wkhttp.Context{Context: gc}
+
+	authorized, err := scanLoginPollSecretMatches(store, uuid, strings.TrimSpace(c.Query(scanLoginPollSecretQuery)))
+	require.NoError(t, err)
+
+	c.Header("Cache-Control", "no-store")
+	if !authorized {
+		c.JSON(http.StatusOK, ensureScanLoginStatus(filterScanLoginPublicFields(model.Data), model.Data))
+	} else {
+		c.JSON(http.StatusOK, model.Data)
+	}
+	return w
+}
+
+func TestScanLoginStatus_WithoutSecretYieldsNoCredential(t *testing.T) {
+	store := newFakePollSecretStore()
+	const uuid = "uuid-1"
+	_, err := mintScanLoginPollSecret(store, uuid)
+	require.NoError(t, err)
+
+	for _, tc := range []struct {
+		name      string
+		presented string
+	}{
+		{"完全不带密钥", ""},
+		{"带错误密钥", "not-the-secret"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			w := serveScanLoginStatus(t, store, uuid, tc.presented)
+			require.Equal(t, http.StatusOK, w.Code)
+
+			var body map[string]interface{}
+			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+
+			// 这是整个 PR 存在的理由：没有密钥就读不到可兑换成 token 的凭据。
+			assert.NotContains(t, body, "auth_code")
+			assert.NotContains(t, body, "uid")
+			assert.NotContains(t, body, "encrypt")
+			// 但状态机必须还能推进 —— 空 body / 缺 status 会让前端永久停摆。
+			assert.Equal(t, string(common.ScanLoginStatusAuthed), body["status"])
+			// 凭据响应不得被任何中间层缓存。
+			assert.Equal(t, "no-store", w.Header().Get("Cache-Control"))
+			// 整段响应体里都不该出现凭据明文，防止将来换成整对象序列化时漏过去。
+			assert.NotContains(t, w.Body.String(), "the-golden-ticket")
+		})
+	}
+}
+
+func TestScanLoginStatus_WithSecretYieldsCredential(t *testing.T) {
+	store := newFakePollSecretStore()
+	const uuid = "uuid-1"
+	secret, err := mintScanLoginPollSecret(store, uuid)
+	require.NoError(t, err)
+
+	w := serveScanLoginStatus(t, store, uuid, secret)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var body map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+
+	assert.Equal(t, "the-golden-ticket", body["auth_code"])
+	assert.Equal(t, "victim-uid", body["uid"])
+	assert.Equal(t, string(common.ScanLoginStatusAuthed), body["status"])
+	assert.Equal(t, "no-store", w.Header().Get("Cache-Control"))
+}
+
+func TestEnsureScanLoginStatus_AlwaysCarriesStatus(t *testing.T) {
+	// Data 为 nil：过滤结果是 nil，直接下发会写出 JSON null。
+	got := ensureScanLoginStatus(filterScanLoginPublicFields(nil), nil)
+	assert.Equal(t, common.ScanLoginStatusExpired, got["status"])
+
+	// 键全部落在白名单外：过滤结果是 {}，前端同样拿不到 status。
+	original := map[string]interface{}{"status": "authed", "some_future_field": 1}
+	got = ensureScanLoginStatus(map[string]interface{}{}, original)
+	assert.Equal(t, "authed", got["status"])
 }

--- a/modules/user/scanlogin_poll_test.go
+++ b/modules/user/scanlogin_poll_test.go
@@ -4,15 +4,11 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
-	"net/http"
-	"net/http/httptest"
 	"os"
 	"strings"
 	"testing"
 	"time"
 
-	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
-	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -240,8 +236,8 @@ func TestGetLoginUUID_KeepsPollSecretOutOfQRCodePayload(t *testing.T) {
 func TestGetLoginStatus_DataOnlyLeavesThroughTheGate(t *testing.T) {
 	fn := readFuncBody(t, "api.go", "func (u *User) getloginStatus(")
 
-	assert.Contains(t, fn, "u.scanLoginPollSecretMatches(uuid, scanLoginPresentedPollSecret(c))",
-		"轮询密钥必须经 scanLoginPresentedPollSecret 读取（请求头优先、query 兜底）")
+	// 凭据通道本身由 TestGetLoginStatus_ReadsSecretFromQuery 单独锁，这里只关心
+	// 「所有 Data 出口都过闸门」。
 	assert.Contains(t, fn, "filterScanLoginPublicFields(model.Data)")
 
 	closureStart := strings.Index(fn, "respondStatus := func(")
@@ -284,29 +280,21 @@ func TestScanLoginRoutesCarryStrictIPRateLimit(t *testing.T) {
 	assert.Contains(t, body, `"scanlogin_status"`)
 }
 
-// TestScanLoginPresentedPollSecret_PrefersHeaderFallsBackToQuery 锁住双通道取值：
-// 请求头优先（不进 access log），query 仅为跨源部署的过渡兜底 —— octo-lib 的 CORS
-// 白名单不含自定义头，跨源预检会把整个请求拒掉，连降级都轮不到。
-func TestScanLoginPresentedPollSecret_PrefersHeaderFallsBackToQuery(t *testing.T) {
-	newCtx := func(header string, query string) *wkhttp.Context {
-		u := "/v1/user/loginstatus?uuid=x"
-		if query != "" {
-			u += "&" + scanLoginPollSecretQuery + "=" + query
-		}
-		req := httptest.NewRequest(http.MethodGet, u, nil)
-		if header != "" {
-			req.Header.Set(ScanLoginPollSecretHeader, header)
-		}
-		gc, _ := gin.CreateTestContext(httptest.NewRecorder())
-		gc.Request = req
-		return &wkhttp.Context{Context: gc}
-	}
+// TestGetLoginStatus_ReadsSecretFromQuery 锁住凭据通道。
+//
+// 曾短暂改用自定义请求头 X-Scan-Poll-Secret 想让明文不进 access log，后来退回 query：
+// 自定义头会让轮询变成非简单请求，而 octo-lib 的 CORS 白名单写死且不含它、OPTIONS 又
+// 立即 abort —— 跨源预检拒掉的是**真正的请求**，Tauri/Electron 正式包扫码登录直接不可用。
+// 收益（挡住能读日志的运维，而这批人本来就有 Redis 权限）远不抵这个代价。
+func TestGetLoginStatus_ReadsSecretFromQuery(t *testing.T) {
+	fn := readFuncBody(t, "api.go", "func (u *User) getloginStatus(")
 
-	assert.Equal(t, "h", scanLoginPresentedPollSecret(newCtx("h", "")), "只有头时取头")
-	assert.Equal(t, "q", scanLoginPresentedPollSecret(newCtx("", "q")), "只有 query 时回落")
-	assert.Equal(t, "h", scanLoginPresentedPollSecret(newCtx("h", "q")), "两者都有时头优先")
-	assert.Equal(t, "", scanLoginPresentedPollSecret(newCtx("", "")), "都没有时为空 → fail-closed")
-	assert.Equal(t, "h", scanLoginPresentedPollSecret(newCtx("  h  ", "")), "两端空白要裁掉")
+	assert.Contains(t, fn, `c.Query(scanLoginPollSecretQuery)`,
+		"密钥必须从 query 读取")
+	assert.NotContains(t, fn, "GetHeader",
+		"不要再引入自定义请求头 —— 跨源预检会拒掉整个请求，见常量注释")
+	assert.Equal(t, "poll_secret", scanLoginPollSecretQuery,
+		"参数名是对外契约，改动会打断已发布的客户端")
 }
 
 // TestGetLoginStatus_OnlyAuthorizedPollersRegisterAChannel 锁住 P2-1 的修复：

--- a/modules/user/swagger/api.yaml
+++ b/modules/user/swagger/api.yaml
@@ -2198,8 +2198,7 @@ paths:
         未出示 poll_secret 时仍返回真实 status，但 auth_code / uid / encrypt
         会被剥掉 —— 只有申请该二维码的调用方能拿到凭据字段。
 
-        密钥优先经 X-Scan-Poll-Secret 请求头出示（不进 access log）；跨源部署因
-        octo-lib CORS 白名单暂不含该头，可退回 poll_secret query 参数。
+        密钥经 poll_secret query 参数出示。
       operationId: "quit pc"
       consumes:
         - "application/json"
@@ -2211,16 +2210,11 @@ paths:
           required: true
           type: string
           description: "loginuuid 返回的 uuid"
-        - name: "X-Scan-Poll-Secret"
-          in: "header"
-          required: false
-          type: string
-          description: "loginuuid 返回的 poll_secret（首选通道）"
         - name: "poll_secret"
           in: "query"
           required: false
           type: string
-          description: "poll_secret 的跨源过渡通道，与请求头二选一；请求头优先"
+          description: "loginuuid 返回的 poll_secret；缺失时凭据字段会被剥离"
       responses:
         200:
           description: "返回"

--- a/modules/user/swagger/api.yaml
+++ b/modules/user/swagger/api.yaml
@@ -2167,13 +2167,19 @@ paths:
         - "application/json"
       responses:
         200:
-          description: "返回"
+          description: "返回（响应头带 Cache-Control: no-store —— body 含 bearer 级密钥）"
           schema:
             type: object
             properties:
               uuid:
                 type: string
                 description: "uuid"
+              poll_secret:
+                type: string
+                description: >-
+                  轮询密钥。调用 /user/loginstatus 时必须出示，否则响应里的
+                  auth_code / uid / encrypt 会被剥掉。仅在本响应中返回一次，
+                  不会出现在二维码内容里。
               qrcode:
                 type: string
                 description: "二维码"
@@ -2186,12 +2192,35 @@ paths:
       tags:
         - "user"
       summary: "获取登录状态"
-      description: "通过login uid获取登录状态"
+      description: >-
+        通过 login uuid 获取登录状态（10 秒长轮询）。
+
+        未出示 poll_secret 时仍返回真实 status，但 auth_code / uid / encrypt
+        会被剥掉 —— 只有申请该二维码的调用方能拿到凭据字段。
+
+        密钥优先经 X-Scan-Poll-Secret 请求头出示（不进 access log）；跨源部署因
+        octo-lib CORS 白名单暂不含该头，可退回 poll_secret query 参数。
       operationId: "quit pc"
       consumes:
         - "application/json"
       produces:
         - "application/json"
+      parameters:
+        - name: "uuid"
+          in: "query"
+          required: true
+          type: string
+          description: "loginuuid 返回的 uuid"
+        - name: "X-Scan-Poll-Secret"
+          in: "header"
+          required: false
+          type: string
+          description: "loginuuid 返回的 poll_secret（首选通道）"
+        - name: "poll_secret"
+          in: "query"
+          required: false
+          type: string
+          description: "poll_secret 的跨源过渡通道，与请求头二选一；请求头优先"
       responses:
         200:
           description: "返回"

--- a/pkg/accesslog/accesslog.go
+++ b/pkg/accesslog/accesslog.go
@@ -35,6 +35,44 @@ var webhookPushPrefixes = []string{
 	"/v1/webhooks/",
 }
 
+// secretQueryInPath masks the VALUE of credential-bearing query parameters.
+//
+// gin builds the logged path as `URL.Path + "?" + URL.RawQuery` (logger.go), so a
+// credential passed as a query parameter lands verbatim on the access-log line —
+// the same #246 concern that created this package, just via the query string
+// instead of a path segment.
+//
+//   - poll_secret: the scan-login poll credential. Holding it together with the
+//     `uuid` (also on that line) is exactly what lets a caller read `auth_code`
+//     out of GET /v1/user/loginstatus, so logging both defeats the gate for
+//     anyone with log read access. Valid for scanLoginPollSecretTTL (12 min).
+//
+// The value is everything up to the next separator; the parameter NAME is kept so
+// the line stays useful for correlation. Case-insensitive for the same reason as
+// ScrubPath — scrubbing is the security control, so it must survive casing
+// variants that a router would 404 but the logger would still print.
+var secretQueryInPath = regexp.MustCompile(`(?i)\b(poll_secret=)[^&\s?"']*`)
+
+// authCodeInPath masks the redeemable scan-login auth code, which travels as a
+// path segment.
+//
+// POST /v1/user/login_authcode/{code} exchanges {code} for a full user token
+// without checking who is redeeming. loginWithAuthCode deletes the code on
+// success, so a logged line for a successful redemption is already spent — but
+// the early returns for an IM failure or a destroyed account happen BEFORE that
+// delete, so a failed redemption leaves a still-valid code in the log for up to
+// ScanLoginAuthCodeTTL (5 min).
+var authCodeInPath = regexp.MustCompile(`(?i)(/v1/user/login_authcode/)[^/\s?"']+`)
+
+// scrubSecretPatterns applies the non-webhook maskers. Split out so both the
+// access-log path (ScrubPath) and the panic-dump path (scrubbingErrorWriter) run
+// the identical set — the two sinks drifting apart is how #246 happened twice.
+func scrubSecretPatterns(s string) string {
+	s = secretQueryInPath.ReplaceAllString(s, "${1}"+maskedToken)
+	s = authCodeInPath.ReplaceAllString(s, "${1}"+maskedToken)
+	return s
+}
+
 // ScrubPath masks secrets embedded in a request path before it is logged.
 //
 // It targets the incoming-webhook push routes
@@ -62,11 +100,11 @@ func ScrubPath(path string) string {
 		// mask.
 		slash := strings.IndexByte(rest, '/')
 		if slash < 0 {
-			return path
+			return scrubSecretPatterns(path)
 		}
-		return path[:len(prefix)] + rest[:slash] + "/" + maskedToken
+		return scrubSecretPatterns(path[:len(prefix)] + rest[:slash] + "/" + maskedToken)
 	}
-	return path
+	return scrubSecretPatterns(path)
 }
 
 // tokenInText matches a webhook push path embedded anywhere in free-form log
@@ -105,6 +143,11 @@ func NewErrorWriter(w io.Writer) io.Writer { return scrubbingErrorWriter{w: w} }
 // possibility, buffer until newline here.
 func (s scrubbingErrorWriter) Write(p []byte) (int, error) {
 	scrubbed := tokenInText.ReplaceAll(p, []byte("${1}***"))
+	// Same maskers the access-log line gets. The panic dump embeds the full
+	// request line, so a poll_secret query or an auth-code path segment reaches
+	// this sink too — and it is the sink that persists on failure, which is
+	// exactly when a credential is most likely still live.
+	scrubbed = []byte(scrubSecretPatterns(string(scrubbed)))
 	if _, err := s.w.Write(scrubbed); err != nil {
 		return 0, err
 	}

--- a/pkg/accesslog/accesslog_test.go
+++ b/pkg/accesslog/accesslog_test.go
@@ -298,3 +298,121 @@ func TestCtxKeyRobotIDMatchesBotAPI(t *testing.T) {
 		"bot_api.CtxKeyRobotID 已改为 %q，但 pkg/accesslog 的字面量仍是 %q —— "+
 			"access log 会安静地不再输出 bot 字段", m[1], ctxKeyRobotID)
 }
+
+// TestScrubPath_MasksPollSecret pins that the scan-login poll credential never
+// reaches an access-log line.
+//
+// gin composes the logged path as URL.Path + "?" + URL.RawQuery, so a credential
+// passed as a query parameter lands verbatim on the log line — the same class of
+// exposure as #246, just via the query string. Holding poll_secret together with
+// the uuid (also on that line) is exactly what lets a caller read auth_code out of
+// /v1/user/loginstatus, so logging both would defeat the gate for anyone with log
+// read access.
+func TestScrubPath_MasksPollSecret(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "loginstatus poll",
+			in:   "/v1/user/loginstatus?uuid=U1&poll_secret=S3CR3T",
+			want: "/v1/user/loginstatus?uuid=U1&poll_secret=***",
+		},
+		{
+			name: "secret first, uuid after",
+			in:   "/v1/user/loginstatus?poll_secret=S3CR3T&uuid=U1",
+			want: "/v1/user/loginstatus?poll_secret=***&uuid=U1",
+		},
+		{
+			name: "casing variant still masked",
+			in:   "/V1/USER/LOGINSTATUS?POLL_SECRET=S3CR3T",
+			want: "/V1/USER/LOGINSTATUS?POLL_SECRET=***",
+		},
+		{
+			name: "empty value is a no-op, not a crash",
+			in:   "/v1/user/loginstatus?uuid=U1&poll_secret=",
+			want: "/v1/user/loginstatus?uuid=U1&poll_secret=***",
+		},
+		{
+			name: "uuid alone is preserved for correlation",
+			in:   "/v1/user/loginstatus?uuid=U1",
+			want: "/v1/user/loginstatus?uuid=U1",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ScrubPath(tc.in); got != tc.want {
+				t.Errorf("ScrubPath(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestScrubPath_MasksAuthCode pins the redeemable scan-login code, which travels
+// as a path segment.
+//
+// loginWithAuthCode deletes the code on success, so a logged line for a successful
+// redemption is already spent. But the early returns for an IM failure or a
+// destroyed account happen BEFORE that delete, so a failed redemption leaves a
+// still-valid code in the log for up to ScanLoginAuthCodeTTL.
+func TestScrubPath_MasksAuthCode(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "redeem path",
+			in:   "/v1/user/login_authcode/A-REDEEMABLE-CODE",
+			want: "/v1/user/login_authcode/***",
+		},
+		{
+			name: "with query suffix",
+			in:   "/v1/user/login_authcode/A-CODE?flag=1",
+			want: "/v1/user/login_authcode/***?flag=1",
+		},
+		{
+			name: "casing variant still masked",
+			in:   "/V1/USER/LOGIN_AUTHCODE/A-CODE",
+			want: "/V1/USER/LOGIN_AUTHCODE/***",
+		},
+		{
+			name: "prefix without a code is untouched",
+			in:   "/v1/user/login_authcode/",
+			want: "/v1/user/login_authcode/",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ScrubPath(tc.in); got != tc.want {
+				t.Errorf("ScrubPath(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestErrorWriter_MasksScanLoginSecrets covers the OTHER sink. gin.Recovery's
+// panic dump embeds the full request line and bypasses the access logger
+// entirely — and it is the sink that persists on failure, which is exactly when a
+// credential is most likely still live.
+func TestErrorWriter_MasksScanLoginSecrets(t *testing.T) {
+	var buf bytes.Buffer
+	w := NewErrorWriter(&buf)
+
+	dump := "panic serving request\nGET /v1/user/loginstatus?uuid=U1&poll_secret=S3CR3T HTTP/1.1\n" +
+		"POST /v1/user/login_authcode/A-CODE HTTP/1.1\n"
+	if _, err := w.Write([]byte(dump)); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	got := buf.String()
+	for _, leaked := range []string{"S3CR3T", "A-CODE"} {
+		if strings.Contains(got, leaked) {
+			t.Errorf("panic dump leaked %q: %s", leaked, got)
+		}
+	}
+	if !strings.Contains(got, "uuid=U1") {
+		t.Errorf("uuid should survive for correlation: %s", got)
+	}
+}


### PR DESCRIPTION
## Summary

**Read this first: this PR closes QR-observer hijack. It does NOT close QRLJacking.**

`GET /v1/user/loginstatus` returned the whole `qrcode:{uuid}` payload — `auth_code`
included — to anyone presenting the uuid. Since the uuid is visible to anyone who can see
the QR (shoulder-surfing, a forwarded screenshot, a screen share, a recording), *seeing the
code was enough to steal the login*: poll, read `auth_code`, redeem it at
`POST /v1/user/login_authcode/{code}`, which never checks who is redeeming. **That path is
closed here.**

**QRLJacking — attacker mints their own QR, puts it on a phishing page, victim scans and
confirms — is still open after this PR.** An earlier draft claimed to close it; that was
wrong and code review caught it. In that attack the attacker is the one calling
`loginuuid`, so the `poll_secret` is issued *to them* along with the uuid; they poll their
own uuid with their own secret and the check passes.

QRLJacking cannot be closed server-side at all. The server cannot distinguish "victim
scanned the attacker's QR" from "user scanned their own" — both are a legitimately
authenticated scan of a legitimately minted code. **Only the person confirming can tell**,
and only if shown enough to notice. Tracked in Mininglamp-OSS/octo-ios#71 and
Mininglamp-OSS/octo-android#116 — please do not treat this PR as closing QRLJacking.

Neither the 2026-05-15 pentest nor the 2026-07-30 retest covers this endpoint; scan-login is
interactive and their automated scanner cannot drive it. Found by code audit.

## Related Issue

None — found by code audit, not tracked by an existing issue. Mobile follow-up:
Mininglamp-OSS/octo-ios#71, Mininglamp-OSS/octo-android#116.

## Linked Spec

`.octospec/tasks/scanlogin-poll-binding/brief.md` — carries both threat-model corrections.
Journal: `.octospec/journal/shared/scanlogin-poll-binding.md`. Learning staged at
`.octospec/learnings/pending/binding-to-the-minter-is-not-access-control.md`. Local
integration-test setup: `.octospec/tasks/scanlogin-poll-binding/integration-test-env.md`.

## Changes

- **`modules/user/scanlogin_poll.go` (new)** — `mintScanLoginPollSecret` (stores **SHA-256**
  under `scanlogin:poll:{uuid}`; the plaintext is returned once, in the response body, and
  never enters the qrcode payload, which is exactly what `loginstatus` echoes),
  `scanLoginPollSecretMatches` (fail-closed, `subtle.ConstantTimeCompare`),
  `deleteScanLoginPollSecret`, `filterScanLoginPublicFields`. Written against a small
  `pollSecretStore` interface so the gate is unit-testable without Redis.
- **`modules/user/api.go`** — `getLoginUUID` mints the secret and sets
  `Cache-Control: no-store`; `getloginStatus` reads it from the `poll_secret` query
  parameter, routes every payload emission through one `respondStatus` gate, and only
  registers a long-poll channel when authorized; `grantLogin` renews the auth code at
  confirm time; `loginWithAuthCode` revokes the secret and deletes `qrcode:{uuid}`. Both
  routes gain `StrictIPRateLimitMiddleware`. `removeQRCodeChan` is replaced by
  `removeQRCodeChanOwned`, which reclaims only the channel the request registered.
- **`modules/qrcode/api.go`** — auth-code TTL 10min → 5min via `user.ScanLoginAuthCodeTTL`.
- **`modules/user/swagger/api.yaml`** — documents `poll_secret` and the `no-store` response.
- **`modules/user/api_i18n_test.go`** — new file added to the legacy-response guard list.

Design points worth reviewing:

- **Allow-list, not deny-list.** `qrcode:{uuid}` is written in three places
  (`getLoginUUID`, `handleScanLogin`, `grantLogin`). A deny-list of sensitive keys fails
  open the moment anyone adds a field in any of them. `scanLoginPublicDataKeys` names the
  two keys that may leave (`status`, `app_id`); everything else is dropped by default.
- **Query parameter, not a custom header.** A custom header was tried and reverted — see
  the note on `scanLoginPollSecretQuery`. Short version: the benefit (plaintext stays out
  of access logs) only holds against readers who already have Redis credentials and can
  read `auth_code` directly, while the cost is that a custom header makes the poll a
  non-simple request and octo-lib's `CORSMiddleware` hardcodes `Access-Control-Allow-Headers`
  and aborts `OPTIONS` the moment it sets them — the cross-origin preflight rejects the
  *real* request and the Tauri/Electron desktop build loses scan-login entirely. If log
  exposure is worth addressing it belongs at the log layer (nginx `map` on `$request`, APM
  URL scrubbing), which covers every sensitive parameter at once.
- **Degrade by stripping, not erroring.** A browser on an old bundle mid-deploy polls
  without a secret; returning `expired` would push it into a mint→poll→expired→mint loop.
  It gets the real status minus the credentials instead, and the paired octo-web change
  falls back to re-minting the QR.
- **Unauthorized pollers do not register a channel, but still wait the full 10s.**
  `getQRCodeModelChan` overwrites unconditionally, so letting them register meant they
  could keep capturing the push and leave the legitimate poller waiting out every cycle.
  Returning early instead would leak a timing signal about whether the secret was right.
- **Rate limits deliberately loose (120 / 600 per min) and env-tunable.** `qrcode:{uuid}`
  has a 60s TTL so every parked login page re-mints ~1/min — a 100-person office behind one
  egress IP is ~100 mints/min. And a reverse proxy without `X-Real-Ip`/`X-Forwarded-For`
  makes `getClientIP` fall back to `RemoteAddr`, collapsing the whole deployment into one
  bucket. Locking a building out of login is worse than passing some scanner traffic; the
  global 1000/min/IP floor still applies.
- **Auth-gate exemption documented in place.** `space-isolation` wants every route behind
  `AuthMiddleware` or an explanation. These two cannot be: the QR renders before any token
  exists.

## Review history

Two rounds landed on this branch after the initial push, both worth knowing about:

1. **`ScanLoginOrigin` was shipped, then pulled.** It returned the requesting IP / device /
   UA to the phone as the server half of the QRLJacking mitigation. Review showed every
   field is attacker-controlled — device fields come from `loginuuid` query params, and the
   IP came from `c.ClientIP()` with nobody calling `SetTrustedProxies`, so gin trusts
   `0.0.0.0/0` and takes the leftmost `X-Forwarded-For`. The attacker who minted the QR
   could make the confirm dialog display the *victim's own* IP, turning weak evidence into
   false assurance. It needs a trusted IP source, which needs an ops answer about how the
   proxy handles XFF, so it moves to the mobile issues.
2. **An auth-code expiry inversion that this PR's own TTL change made reachable.** The code
   is minted at *scan* time; refreshing only `qrcode:{uuid}` at confirm produced
   `status: authed` carrying a credential with a second left. The old 10-minute TTL had
   five minutes of slack hiding it; at 5 minutes the slack is zero. `grantLogin` now renews
   the code at confirm.

## Companion PR

Mininglamp-OSS/octo-web#1296 sends the secret and handles a withheld `auth_code`.
**Merge this PR first** — with the server ahead, an old web bundle parks on the authorize
screen and recovers on refresh; with the web ahead, it sends a parameter the server does not
yet read (harmless but pointless). No other repo is in the critical path.

## Testing

Integration environment brought up locally (MySQL 8.0.46 + Redis + WuKongIM 2.2.4, setup
recorded in `.octospec/tasks/scanlogin-poll-binding/integration-test-env.md`).

- `go build ./...`, `go vet`, `gofmt` on the touched files — pass
- `make i18n-extract-check`, `make i18n-lint` — pass (no new error codes: the mismatch path
  strips fields rather than erroring, so nothing needed registering)
- `go test ./modules/user/ ./modules/qrcode/` — **pass** (~31s; includes the new tests)
- Whole repo, fresh database per package — **102 pass / 4 fail**

The 4 failures are pre-existing. Verified by running the same four packages on a clean
`origin/main` worktree with a fresh database; the failing test names are byte-identical:

| package | failing test | this branch | origin/main |
|---|---|---|---|
| `botfather` | `TestRobotApply_AutoApprove` | FAIL | FAIL |
| `channel` | `TestGetStoryline_NotGroupMember` | FAIL | FAIL |
| `common` | `TestManagerSystemSetting_OrderingRejectionUsesI18nEnvelope` | FAIL | FAIL |
| `robot` | `TestGetCommands_CmdMenuLocalization` | FAIL | FAIL |

Note for anyone reproducing: `go test ./...` cannot share one database, and `-p 1` does not
fix it. Each module embeds its own migration set, so the second package to run finds
`gorp_migrations` rows it does not recognise and panics with `unknown migration in
database`. 22 packages fail that way under both `./...` and `-p 1`, and all 22 pass against
a freshly created database. See the note file for the loop.

- [x] Unit tests added/updated
- [x] Manually verified

## COMPREHENSION

1. **What does this change actually do** to the load-bearing path?

   It inserts an authorization check into a credential-issuing path that previously had
   none. `loginstatus` is unauthenticated by necessity (the QR renders before any token
   exists), and it was returning `auth_code` — directly redeemable for a full user token —
   to whoever asked with the right uuid. The change mints a secret at `loginuuid`, keeps it
   out of the QR payload, and gates the credential fields behind a constant-time match,
   with everything else filtered through an allow-list. Callers that fail the check still
   get a usable `status`, so the state machine keeps progressing; they just never see a
   credential. Secondary effects on the same path: the auth code is now re-timed at confirm
   so `authed` can never advertise an already-dead credential, and all scan state is deleted
   on redemption rather than left to expire.

2. **What could break** because of it (dependents + failure mode)?

   The only client polling `loginstatus` is octo-web `login_vm.tsx` (mobile scans and
   confirms but never polls), and its companion PR sends the secret. The real exposure is
   the deploy window: a browser holding a cached old bundle polls without it, reaches
   `authed` with `auth_code` stripped, and cannot complete login — hence the deliberate
   choice to strip rather than error, plus the web-side fallback to re-mint the QR. Second
   risk is the rate limits: `loginstatus` is a long poll and enterprise NAT shares an egress
   IP, so a limit set too low would lock a whole office out of scan-login; that is why the
   defaults are loose and env-overridable without a redeploy. Third, deleting
   `qrcode:{uuid}` on redemption means any client that re-polls after a successful login now
   sees `expired` instead of a stale `authed` — correct, but a behaviour change for anything
   that polled past completion.

3. **How do you know it works** (specific test/repro/trace)?

   The gate has real behavioural tests through an injected in-memory store, not just source
   assertions: mint→match, wrong secret, empty secret, right secret against the wrong uuid,
   store-error fail-closed, digest-not-plaintext, revocation-after-redemption, and TTL
   covering the worst-case 60s+5min+5min flow. `filterScanLoginPublicFields` is tested to
   drop everything not allow-listed, including hypothetical future fields, and to copy
   rather than mutate (the model is broadcast over the long-poll channel).
   `TestGetLoginUUID_MintsPollSecretAndKeepsItOutOfQRCodePayload` parses the
   `NewQRCodeModel(...)` literal so the secret cannot drift into the echoed payload, and
   `TestGetLoginStatus_DataOnlyLeavesThroughTheGate` asserts no `.Data` reference exists
   outside the `respondStatus` closure — phrased structurally so renaming a variable cannot
   defeat it. The review fixes have their own guards: channel registration gated on
   `authorized`, the auth-code renewal ordered before the qrcode write, scan-state cleanup
   on redemption, `no-store`, and a test forbidding `GetHeader` from reappearing.
   End-to-end, `modules/user` and `modules/qrcode` pass in full against live
   MySQL/Redis/WuKongIM.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] PR description is in English
- [x] Added tests for my changes
- [x] Updated documentation
- [x] Followed commit message conventions (Conventional Commits)