### PR TITLE
fix(cardtmpl): close the x-octo-constraints fail-open and wire the bot_api persistence gates

### DIFF
--- a/.octospec/tasks/card-gate-hardening/brief.md
+++ b/.octospec/tasks/card-gate-hardening/brief.md
@@ -1,0 +1,108 @@
+---
+type: Task
+title: "Task: card-gate-hardening"
+description: Close three gaps left by PR #712's persistence and truncation gates — a fail-open in the x-octo-constraints parser, zero test coverage for the two modules/bot_api guards, and a doc comment that under-counts the write paths the persistence judge covers.
+tags: [card, cardtmpl, cardmsg, carddispatch, bot-api, trust-boundary, test, testing]
+timestamp: 2026-08-08T09:30:00+08:00
+# --- octospec extension fields ---
+slug: card-gate-hardening
+upstream: "follow-up to Mininglamp-OSS/octo-server#712 (review P2-1 / P2-2 / P2-4)"
+source: review
+---
+
+# Task: card-gate-hardening
+
+## Goal
+
+Three findings from the approving reviews on #712, none of which blocked that merge and all
+of which are in mutable engine code. No artifact bytes change; no published card version is
+touched.
+
+1. **A fail-open in the `x-octo-constraints` parser.** Optional string fields were read with
+   `v, _ := entry[k].(string)`, which maps "present but wrong type" onto the same `""` the
+   absent case produces — so a declaration silently changes meaning instead of failing to
+   compile.
+2. **Both guards added to `modules/bot_api` had zero test coverage in that package.** All
+   coverage sat in `internal/carddispatch`, behind that layer's fakes.
+3. **The persistence judge's doc comment listed three write paths; there are five.**
+
+## Background
+
+### Why (1) is a fail-open and not a style nit
+
+`truncateStrings` has two genuinely optional fields, and that is exactly what makes the
+`v, _ :=` idiom unsafe for them:
+
+- a non-string `arrayField` becomes `""`, which re-scopes the clamp from `phases[].thought`
+  to a top-level `thought` that does not exist — the declared display ceiling then simply
+  **stops applying**, with no error at compile time and no signal at render time. Since
+  applying that ceiling is the entire purpose of the declaration, this is a silent, total
+  failure of the feature.
+- a non-string `ellipsis` becomes `""`, silently dropping the ellipsis so a truncated value
+  becomes indistinguishable from a short one.
+
+Measured before the fix: both cases **compile successfully**. The three *required* string
+fields (`field`, `parentArray`, `childArray`) were already caught downstream by a `== ""`
+comparison — so they fail closed, but by accident, and they report `is required` for what is
+actually a type error. Fixing the diagnosis is worth the same change.
+
+Not reachable today: the runtime-publish path is not enabled, and no shipped artifact has a
+wrong-typed constraint. It is reachable the moment either changes.
+
+### Why (2) is the same shape as #712's P0
+
+The P0 that took three review rounds to find was a guard applied in one package and tested
+through another package's fake: `fakeBotCardMutator` records the request and never
+re-validates, so the entire second validation pass was uncovered. After #712 the same shape
+existed again — the raw-card-edit column gate and the template-send precheck both live in
+`modules/bot_api`, and `grep` for their identifiers across `modules/bot_api/*_test.go`
+returned nothing.
+
+### Why (3) matters more than a stale comment usually would
+
+`NormalizeFrameForPersistence`'s comment asserted that *all* pre-write revalidation paths go
+through it. That assertion being false is precisely what caused rounds 5 and 6: the raw edit
+branch and `WriteCAS` did not. The comment was corrected when those were wired in, but the
+enumeration itself will drift again.
+
+## Load-bearing list
+
+- `pkg/cardtmpl/json_artifact.go` — `parseStringTruncations` / `parseAggregateArrayLimits`.
+  Optionality must be preserved: omitting `arrayField` (top-level scope) and `ellipsis`
+  (no ellipsis) stays legal. Only *present-but-wrong-typed* becomes an error.
+- `internal/carddispatch/mutation.go` — the doc comment is the only change; no behaviour.
+- `modules/bot_api` — tests only; no production change.
+
+## Out of scope
+
+- The 92.6%-of-column margin on an all-fields-at-maximum CJK frame, and its two durable
+  fixes (`MEDIUMTEXT` widening, or display ceilings on `tool`/`detail` — the latter needs
+  nested-path support in `truncateStrings` first). Recorded in #712's D3a.
+- The `[图片]` placeholder lines `BuildPlain` emits for every `Image` regardless of
+  `isVisible`, which land in push previews. Needs a product decision and touches either the
+  push text surface (`altText` is unvalidated) or search indexing.
+- A distinguishable error code for "too large" versus "invalid card".
+- Promoting the two pending learnings into `rules/`.
+
+## Acceptance
+
+- [ ] A present-but-wrong-typed `arrayField` / `ellipsis` / `field` / `parentArray` /
+      `childArray` fails compilation with a message naming the field **and** saying it must
+      be a string. Proven to be a change: the same cases compile successfully with the
+      production fix reverted.
+- [ ] Omitting `arrayField` and omitting `ellipsis` both still compile, and truncation still
+      clamps — the tightening must not remove the optionality.
+- [ ] `modules/bot_api` drives the raw-card-edit column gate through the **real** HTTP
+      handler, with a positive control first (a normal-sized edit succeeds on the same setup)
+      so the subsequent rejection is attributable to width rather than to auth, lookup or
+      policy. Asserted: HTTP 400, the `card_invalid` code's message, and that the stored
+      `content_edit` still holds the control frame.
+- [ ] Removing the gate makes that test fail — and fail with the store error, showing the
+      frame reached MySQL.
+- [ ] `modules/bot_api` proves the template-send precheck is not dead code: a schema-valid
+      worst-case payload renders to a frame that passes `cardmsg.MaxPayloadBytes` and exceeds
+      the column.
+- [ ] A source guard counts the persistence judge's write paths and fails when the count
+      diverges from the number the doc comment claims. Proven to fire by removing one.
+- [ ] `go build ./...`, `go vet ./...`, gofmt, `git diff --check`, `golangci-lint`, `-race`
+      on the three touched packages, and the DB-backed `modules/bot_api` suite all pass.

--- a/.octospec/tasks/card-gate-hardening/brief.md
+++ b/.octospec/tasks/card-gate-hardening/brief.md
@@ -25,6 +25,10 @@ touched.
 2. **Both guards added to `modules/bot_api` had zero test coverage in that package.** All
    coverage sat in `internal/carddispatch`, behind that layer's fakes.
 3. **The persistence judge's doc comment listed three write paths; there are five.**
+4. **The template-send precheck measured the send frame, not the first-edit envelope.** The edit
+   path always appends `card_seq` and, for progress frames, `transient` — so sizing the precheck
+   on the send frame leaves a window as wide as that overhead in which a card sends successfully
+   and then fails its very first edit, which is the exact failure the precheck exists to prevent.
 
 ## Background
 
@@ -70,8 +74,20 @@ enumeration itself will drift again.
 - `pkg/cardtmpl/json_artifact.go` — `parseStringTruncations` / `parseAggregateArrayLimits`.
   Optionality must be preserved: omitting `arrayField` (top-level scope) and `ellipsis`
   (no ellipsis) stays legal. Only *present-but-wrong-typed* becomes an error.
+  **`ellipsis` must also keep accepting untrimmed values.** The first revision of this change
+  read it through the same helper as `arrayField` and so gave it a trim requirement it never
+  had — a correctly-typed `" …"` went from accepted to rejected, which is exactly the class of
+  tightening this list rules out (caught in review). The two kinds of field now use separate
+  readers: fields naming a schema path are trimmed (an untrimmed one can never match a property
+  name), display text is taken verbatim. Reachability matters here — `POST
+  /v1/manager/card-templates/validate` reaches the compiler with **no** `requireRuntimeReady`
+  gate, unlike `/publish`, so "the runtime path is disabled" is not a sufficient argument.
 - `internal/carddispatch/mutation.go` — the doc comment is the only change; no behaviour.
-- `modules/bot_api` — tests only; no production change.
+- `modules/bot_api` — the template-send precheck now measures a worst-case first-edit envelope
+  (`card_seq` at the int64 ceiling, `transient` true) through
+  `carddispatch.NormalizeFrameForPersistence` rather than comparing the send frame's length to a
+  constant, so the width judge stays single-sourced and a future envelope key cannot reopen the
+  window. The probe runs on a copy — the outbound payload must not gain those keys.
 
 ## Out of scope
 
@@ -99,10 +115,36 @@ enumeration itself will drift again.
       `content_edit` still holds the control frame.
 - [ ] Removing the gate makes that test fail — and fail with the store error, showing the
       frame reached MySQL.
-- [ ] `modules/bot_api` proves the template-send precheck is not dead code: a schema-valid
-      worst-case payload renders to a frame that passes `cardmsg.MaxPayloadBytes` and exceeds
-      the column.
-- [ ] A source guard counts the persistence judge's write paths and fails when the count
-      diverges from the number the doc comment claims. Proven to fire by removing one.
+- [ ] The template-send precheck is exercised **through the real `sendMessage` handler**, not by
+      re-implementing its arithmetic: `POST /v1/bot/sendMessage` in template mode, positive
+      control first, then 400 + the `card_invalid` message + **no dispatch**. Deleting the
+      guard's rejection must turn it red — the first revision asserted only the judgment, so the
+      whole `if templateMode` block could be removed with the suite still green (caught in
+      review; the same shape as the #712 P0 this brief diagnoses, one level up).
+- [ ] A separate liveness test keeps proving the target is reachable from schema-valid input (the
+      worst case renders to 151% of the column while passing `cardmsg.MaxPayloadBytes`), since
+      that fact is what makes the guard non-dead — but it is explicitly not the guard's test.
+- [ ] An untrimmed `ellipsis` is asserted **accepted**, and an untrimmed `arrayField` / `field`
+      asserted rejected, so the contract split is pinned in both directions.
+- [ ] `requiredStringField` reports `must not be empty` and `must be trimmed` separately — an
+      empty string is trimmed, so one message cannot stand for both rules.
+- [ ] The DB-backed await fails rather than skips once IM health has been confirmed, so the one
+      guard this change actually wires cannot pass by skipping.
+- [ ] The precheck is sized on the first-edit envelope: a test measures the overhead the edit
+      path adds, asserts it is positive, and asserts the window it opens is non-empty — so if a
+      future change makes the two frames identical the test says so instead of passing quietly.
+      The measured overhead is printed rather than written into a comment as a magic number.
+- [ ] A source guard counts the persistence judge's use sites and fails when the count diverges
+      from the number the doc comment claims. It scans the **whole module recursively** (an
+      earlier revision read three hardcoded directories non-recursively, making a fourth package
+      invisible), skips the judge's own body so its internal width check is not miscounted as a
+      second gate, and accepts either constant name so renaming to the exported alias does not
+      produce a misleading failure. Its message states what it does **not** prove: counting call
+      sites can never detect a write path that bypasses the judge — that class (#712's P0) is out
+      of reach by construction and only a human enumeration of write entry points covers it.
+      Proven to fire three times: deliberately (a `CardUpdater` path pointed back at
+      `cardmsg.NormalizeContentEdit`), for real (the first-edit-envelope probe took the count 5→6,
+      forcing the comment to separate write paths from the non-writing precheck), and on the
+      widened scan (a probe file in a fourth package was seen).
 - [ ] `go build ./...`, `go vet ./...`, gofmt, `git diff --check`, `golangci-lint`, `-race`
       on the three touched packages, and the DB-backed `modules/bot_api` suite all pass.

--- a/internal/carddispatch/mutation.go
+++ b/internal/carddispatch/mutation.go
@@ -57,16 +57,24 @@ const MaxPersistedFrameBytes = maxContentEditBytes
 // NormalizeFrameForPersistence 是「一帧卡片能否落库」的唯一判据。返回 canonical 字节
 // （cardmsg 已重算权威 plain），可直接写库。
 //
-// 覆盖面是**五条**写路径，不是三条（此前这段注释只列了前三条，而 #712 后续轮次又接进来
-// 两条 —— 一段断言了不成立的不变量的注释，正是那两轮 blocker 的成因，所以这里逐条列全）：
+// 覆盖面是**六处**，其中五处是写路径、一处是发送侧预检（此前这段注释只列了前三条，而
+// #712 后续轮次又接进来三处 —— 一段断言了不成立的不变量的注释，正是那两轮 blocker 的成因，
+// 所以这里逐条列全，并由 TestPersistenceJudgeCallSitesMatchItsDocumentedCount 钉住计数）：
 //
-//  1. CardMutator.Mutate（本文件）——  bot 模板编辑与内部生产者编辑
+// 写路径（帧确实要落库）：
+//
+//  1. CardMutator.Mutate（本文件）—— bot 模板编辑与内部生产者编辑
 //  2. pkg/cardtmpl CardUpdater.Append
 //  3. pkg/cardtmpl CardUpdater.ReplaceView
 //  4. modules/bot_api raw 卡片编辑分支 —— 一处调用覆盖它下游的三个写动作
 //     （card_seq CAS / 非 card_seq LWW / 修订历史追加，三者消费同一份字节）
 //  5. CardMutator.WriteCAS 自己再查一次宽度（见那里的注释）—— 不是重复，而是让
 //     旁路对未来的调用方也不可得，而非仅对今天的调用方关闭
+//
+// 非写路径（**不**落库，只借判据做判断）：
+//
+//  6. modules/bot_api 模板发送预检 —— 拿「最坏的首次编辑信封」问一次「这张卡将来编辑得动
+//     吗」。它不写任何东西；走这个函数是为了让宽度判据只有一份，而不是在发送侧抄一个魔数。
 //
 // 不在覆盖面内、且**刻意**不在的：modules/robot 与 modules/message 的 content_edit 写入
 // 载不了卡片帧（两者都在 cardmsg.RejectsCardEdit 之后，type-17 双向都拒），非卡片的

--- a/internal/carddispatch/mutation.go
+++ b/internal/carddispatch/mutation.go
@@ -54,9 +54,23 @@ const maxContentEditBytes = 65535
 // 等于发出即报废，所以它需要拿到同一个数而不是自己抄一份 —— 抄的那份会漂移。
 const MaxPersistedFrameBytes = maxContentEditBytes
 
-// NormalizeFrameForPersistence 是「一帧卡片能否落库」的唯一判据，所有在写入前重新校验
-// 帧的路径都必须走它：CardMutator.Mutate、以及 pkg/cardtmpl 的 CardUpdater.Append /
-// ReplaceView。返回的是 canonical 字节（cardmsg 已重算权威 plain），可直接写库。
+// NormalizeFrameForPersistence 是「一帧卡片能否落库」的唯一判据。返回 canonical 字节
+// （cardmsg 已重算权威 plain），可直接写库。
+//
+// 覆盖面是**五条**写路径，不是三条（此前这段注释只列了前三条，而 #712 后续轮次又接进来
+// 两条 —— 一段断言了不成立的不变量的注释，正是那两轮 blocker 的成因，所以这里逐条列全）：
+//
+//  1. CardMutator.Mutate（本文件）——  bot 模板编辑与内部生产者编辑
+//  2. pkg/cardtmpl CardUpdater.Append
+//  3. pkg/cardtmpl CardUpdater.ReplaceView
+//  4. modules/bot_api raw 卡片编辑分支 —— 一处调用覆盖它下游的三个写动作
+//     （card_seq CAS / 非 card_seq LWW / 修订历史追加，三者消费同一份字节）
+//  5. CardMutator.WriteCAS 自己再查一次宽度（见那里的注释）—— 不是重复，而是让
+//     旁路对未来的调用方也不可得，而非仅对今天的调用方关闭
+//
+// 不在覆盖面内、且**刻意**不在的：modules/robot 与 modules/message 的 content_edit 写入
+// 载不了卡片帧（两者都在 cardmsg.RejectsCardEdit 之后，type-17 双向都拒），非卡片的
+// richtext content_edit 仍未对列宽设限（既有债，不在本函数职责内）。
 //
 // 为什么要有这个函数而不是各调用点自己拼：PR#712 的 P0 就是各点自己拼出来的 ——
 // 渲染侧和回写侧对「同一帧是否合法」给出了不同答案，于是卡片发得出去、编辑必失败。

--- a/internal/carddispatch/mutation_column_test.go
+++ b/internal/carddispatch/mutation_column_test.go
@@ -244,60 +244,92 @@ func TestMaxPersistedFrameBytesTracksTheGate(t *testing.T) {
 	}
 }
 
-// NormalizeFrameForPersistence 的文档注释逐条列出了它覆盖的五条写路径。这类枚举会漂移，
+// NormalizeFrameForPersistence 的文档注释逐条列出了它的全部使用点（五条写路径 + 一处发送侧
+// 预检）。这类枚举会漂移，
 // 而一段断言了不成立的不变量的注释正是 #712 里两轮 blocker 的成因（注释说「所有回写路径
 // 都走这个判据」，而 raw 编辑分支和 WriteCAS 都不走）。所以这里用源码守卫钉住计数：调用点
 // 增减时测试失败，逼着改注释，而不是等下一个人相信一段过时的断言。
+//
+// **这条守卫证明的是什么、不是什么**（review of #716 要求写清）：它只保证那段注释里的计数与
+// 源码里判据的使用点数量一致 —— 也就是「注释别撒谎」。它**无法**发现一条绕过判据直接写库的
+// 路径，那种缺陷按构造就在「数调用点」这个手段的射程之外，无论扫多少目录。#712 的 P0 正是那
+// 一类，只能靠人枚举写入口（见 NormalizeFrameForPersistence 注释里的「刻意不在覆盖面内」段）。
+//
+// 扫描范围是整个 module（递归），所以在第四个包或子包里新增调用也会被看见 —— 早先的版本只扫
+// 三个硬编码目录且非递归，那时新包是隐形的。
 func TestPersistenceJudgeCallSitesMatchItsDocumentedCount(t *testing.T) {
-	// 注释里声明的条数。改这个数就必须同步改上面那段枚举。
-	const documented = 5
+	// 注释里声明的条数。改这个数就必须同步改那段枚举 —— 反过来也一样：这条守卫在本次
+	// follow-up 里真的响过一次（新增模板发送预检后实测 6 条 vs 声明 5 条），逼着把第 6 条
+	// 补进注释并说明它是「不落库、只借判据」的那一类。守卫有效性由此自证。
+	const documented = 6
 
-	roots := map[string]string{
-		"internal/carddispatch": ".",
-		"modules/bot_api":       "../../modules/bot_api",
-		"pkg/cardtmpl":          "../../pkg/cardtmpl",
-	}
+	// 递归扫整个 module，而不是三个硬编码目录 —— 第四个包/子包里的调用不能是隐形的。
+	const repoRoot = "../.."
 	callRE := regexp.MustCompile(`NormalizeFrameForPersistence\(`)
-	// WriteCAS 自己查宽度，不经过那个函数，所以按注释第 5 条单独计。
-	standaloneRE := regexp.MustCompile(`len\(request\.ContentEdit\) > maxContentEditBytes`)
+	// WriteCAS 自己查宽度、不经过那个函数，所以按注释里的「独立设闸」单独计。两个常量名
+	// 都接受：写死一个会让改用导出别名时报出「你增删了写路径」这种误导性失败。
+	standaloneRE := regexp.MustCompile(`>\s*(maxContentEditBytes|MaxPersistedFrameBytes)\b`)
 
 	sites := 0
 	standalone := 0
-	for label, dir := range roots {
-		entries, err := os.ReadDir(dir)
-		if err != nil {
-			t.Fatalf("read %s: %v", label, err)
+	if err := filepath.WalkDir(repoRoot, func(path string, d os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
 		}
-		for _, entry := range entries {
-			name := entry.Name()
-			if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+		if d.IsDir() {
+			switch d.Name() {
+			case ".git", "node_modules", "vendor", "assets", "docs", ".octospec":
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		name := d.Name()
+		if !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			return nil
+		}
+		body, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return readErr
+		}
+		// 判据**自己**函数体内的那次宽度检查不算「另一处设闸」—— 它就是判据本身。用
+		// 「见到声明起、见到列首 } 止」跳过它；靠变量名区分（len(normalized) vs
+		// len(request.ContentEdit)）会让重命名接收者变量就误报「你增删了写路径」。
+		inJudgeBody := false
+		for _, line := range strings.Split(string(body), "\n") {
+			trimmed := strings.TrimSpace(line)
+			if strings.HasPrefix(trimmed, "func NormalizeFrameForPersistence") {
+				inJudgeBody = true
 				continue
 			}
-			body, err := os.ReadFile(filepath.Join(dir, name))
-			if err != nil {
-				t.Fatalf("read %s/%s: %v", label, name, err)
+			if inJudgeBody {
+				if line == "}" {
+					inJudgeBody = false
+				}
+				continue
 			}
-			text := string(body)
-			// 函数自身的声明与注释里的提及不算调用点。
-			for _, line := range strings.Split(text, "\n") {
-				trimmed := strings.TrimSpace(line)
-				if strings.HasPrefix(trimmed, "//") || strings.HasPrefix(trimmed, "func NormalizeFrameForPersistence") {
-					continue
-				}
-				if callRE.MatchString(line) {
-					sites++
-				}
-				if standaloneRE.MatchString(line) {
-					standalone++
-				}
+			// 行注释不算使用点。块注释 / 字符串字面量里的同名文本仍会被算进来 —— 这是已知
+			// 的粗糙处，彻底解决要用 go/ast；当前树里没有这种写法，且方向是 fail-closed
+			// （多算只会让计数不符而报错，不会漏算）。
+			if strings.HasPrefix(trimmed, "//") {
+				continue
+			}
+			if callRE.MatchString(line) {
+				sites++
+			}
+			if standaloneRE.MatchString(line) {
+				standalone++
 			}
 		}
+		return nil
+	}); err != nil {
+		t.Fatalf("walk %s: %v", repoRoot, err)
 	}
 
 	if got := sites + standalone; got != documented {
-		t.Fatalf("持久化判据的写路径实测 %d 条（%d 处调用 + %d 处独立设闸），注释声明 %d 条。\n"+
-			"增删了写路径就要同步 NormalizeFrameForPersistence 的注释枚举 —— 一段过时的\n"+
-			"「所有路径都走这里」正是 #712 两轮 blocker 的成因。",
+		t.Fatalf("持久化判据的使用点实测 %d 处（%d 处调用 + %d 处独立设闸），注释声明 %d 处。\n"+
+			"增删使用点就要同步 NormalizeFrameForPersistence 的注释枚举，并标明新增那处是\n"+
+			"「写路径」还是「不落库的预检」。注意本守卫的射程：它只保证注释里的计数不撒谎，\n"+
+			"发现不了绕过判据直接写库的路径 —— 那种缺陷（#712 的 P0）只能靠人枚举写入口。",
 			got, sites, standalone, documented)
 	}
 }

--- a/internal/carddispatch/mutation_column_test.go
+++ b/internal/carddispatch/mutation_column_test.go
@@ -243,3 +243,61 @@ func TestMaxPersistedFrameBytesTracksTheGate(t *testing.T) {
 		t.Fatalf("MaxPersistedFrameBytes+1 个字节应被拒，得到 %v", err)
 	}
 }
+
+// NormalizeFrameForPersistence 的文档注释逐条列出了它覆盖的五条写路径。这类枚举会漂移，
+// 而一段断言了不成立的不变量的注释正是 #712 里两轮 blocker 的成因（注释说「所有回写路径
+// 都走这个判据」，而 raw 编辑分支和 WriteCAS 都不走）。所以这里用源码守卫钉住计数：调用点
+// 增减时测试失败，逼着改注释，而不是等下一个人相信一段过时的断言。
+func TestPersistenceJudgeCallSitesMatchItsDocumentedCount(t *testing.T) {
+	// 注释里声明的条数。改这个数就必须同步改上面那段枚举。
+	const documented = 5
+
+	roots := map[string]string{
+		"internal/carddispatch": ".",
+		"modules/bot_api":       "../../modules/bot_api",
+		"pkg/cardtmpl":          "../../pkg/cardtmpl",
+	}
+	callRE := regexp.MustCompile(`NormalizeFrameForPersistence\(`)
+	// WriteCAS 自己查宽度，不经过那个函数，所以按注释第 5 条单独计。
+	standaloneRE := regexp.MustCompile(`len\(request\.ContentEdit\) > maxContentEditBytes`)
+
+	sites := 0
+	standalone := 0
+	for label, dir := range roots {
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			t.Fatalf("read %s: %v", label, err)
+		}
+		for _, entry := range entries {
+			name := entry.Name()
+			if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+				continue
+			}
+			body, err := os.ReadFile(filepath.Join(dir, name))
+			if err != nil {
+				t.Fatalf("read %s/%s: %v", label, name, err)
+			}
+			text := string(body)
+			// 函数自身的声明与注释里的提及不算调用点。
+			for _, line := range strings.Split(text, "\n") {
+				trimmed := strings.TrimSpace(line)
+				if strings.HasPrefix(trimmed, "//") || strings.HasPrefix(trimmed, "func NormalizeFrameForPersistence") {
+					continue
+				}
+				if callRE.MatchString(line) {
+					sites++
+				}
+				if standaloneRE.MatchString(line) {
+					standalone++
+				}
+			}
+		}
+	}
+
+	if got := sites + standalone; got != documented {
+		t.Fatalf("持久化判据的写路径实测 %d 条（%d 处调用 + %d 处独立设闸），注释声明 %d 条。\n"+
+			"增删了写路径就要同步 NormalizeFrameForPersistence 的注释枚举 —— 一段过时的\n"+
+			"「所有路径都走这里」正是 #712 两轮 blocker 的成因。",
+			got, sites, standalone, documented)
+	}
+}

--- a/modules/bot_api/card_persistence_gate_test.go
+++ b/modules/bot_api/card_persistence_gate_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -13,12 +14,14 @@ import (
 
 	"github.com/Mininglamp-OSS/octo-lib/common"
 	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
 	"github.com/Mininglamp-OSS/octo-lib/testutil"
 	"github.com/Mininglamp-OSS/octo-server/internal/carddispatch"
 	"github.com/Mininglamp-OSS/octo-server/pkg/cardmsg"
 	"github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl"
 	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
+	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -135,10 +138,15 @@ func TestBotRawCardEditRejectsFrameWiderThanTheColumn(t *testing.T) {
 }
 
 // awaitP1CardStored 等 IM 异步持久化完成，返回可用于编辑的 messageSeq。
+//
+// 超时**判失败、不 skip**（review of #716）：调用方在此之前已经用 skipWithoutIMBot 确认过
+// :5001 健康，所以到这里还等不到就是真问题。原来写 t.Skip 会让本 PR 唯一真正接线 guard 的
+// 那条用例在负载高的 runner 上变成 pass-by-skip —— 与真通过在结果里分不出来，正是「测试
+// 存在但什么都没保证」的那一类。预算也从 6s 抬到 15s，减少误判。
 func awaitP1CardStored(t *testing.T, ctx *config.Context, clientMsgID int64) uint32 {
 	t.Helper()
 	var msgSeq uint32
-	for i := 0; i < 20; i++ {
+	for i := 0; i < 50; i++ {
 		sr, err := ctx.IMSearchMessages(&config.MsgSearchReq{
 			ChannelID:   testutil.UID,
 			ChannelType: common.ChannelTypePerson.Uint8(),
@@ -152,30 +160,81 @@ func awaitP1CardStored(t *testing.T, ctx *config.Context, clientMsgID int64) uin
 		time.Sleep(300 * time.Millisecond)
 	}
 	if msgSeq == 0 {
-		t.Skip("消息未在预期时间内完成 IM 异步持久化，跳过（非本用例断言的对象）")
+		t.Fatalf("消息未在 15s 内完成 IM 异步持久化（clientMsgID=%d）。IM 健康检查已通过，"+
+			"所以这是真失败而不是环境缺失 —— 不能 skip，否则本 PR 唯一接线 guard 的用例"+
+			"会以「通过」的形式静默失效", clientMsgID)
 	}
 	return msgSeq
 }
 
-// 模板发送预检（sendMessage 的模板分支）：send 侧原本只查 512 KiB、编辑侧查 TEXT 列宽，
-// 两者不一致就能造出「发得出去、第一次编辑就被拒」的卡。这条用例证明**schema 合法**的
-// 输入确实能渲染出超列宽的帧（所以预检不是死代码），并且预检用的常量与写入侧闸同源。
+// 模板发送预检（sendMessage 的模板分支）**必须驱动真 handler**。
 //
-// 刻意不打 HTTP：这里要钉的是「渲染结果 vs 列宽」这个判断，用真实 catalog 渲染 + 真实
-// 常量即可，不必拖上 DB/IM。raw 编辑那条闸的接线才需要真实 handler（见上）。
-func TestTemplateSendPrecheckCatchesSchemaValidButUnstorableFrame(t *testing.T) {
+// 这条用例的第一版只是渲染出最坏帧、然后自己比一次长度 —— 那是重新实现了预检的算术，
+// 根本没走到预检：review 把 send.go 里整个 `if templateMode { … }` 块删掉，测试照样绿。
+// 那正是本 PR 自己诊断的 #712 P0 的形状（断言判断、不断言接线），只是高了一层，所以必须
+// 修成打 POST /v1/bot/sendMessage。不需要 DB —— dispatchOverride 就能截住派发。
+func TestTemplateSendPrecheckRejectsUnstorableFrameThroughHandler(t *testing.T) {
 	t.Setenv(cardmsg.EnvEnabled, "true")
-	catalog, err := newBotCardTemplateCatalog(testBotTemplateRegistry(t), defaultBotTemplateRefs())
-	if err != nil {
-		t.Fatal(err)
+	gin.SetMode(gin.TestMode)
+
+	newAPI := func(dispatch *dispatchCapture) *BotAPI {
+		catalog, err := newBotCardTemplateCatalog(testBotTemplateRegistry(t), defaultBotTemplateRefs())
+		if err != nil {
+			t.Fatal(err)
+		}
+		return &BotAPI{
+			Log:              log.NewTLog("BotAPI-precheck"),
+			cardTemplates:    catalog,
+			cardConfig:       allCardCapabilitiesOn(),
+			spaceQuerier:     &fakeSpaceQuerier{defaultSpace: "space-authoritative"},
+			dispatchOverride: dispatch.hook,
+		}
 	}
 
-	// 最坏形状：6 阶段 / 13 条聚合 action（schema 的聚合上限）/ 每个自由字符串顶到上限，
-	// 且全部用会被 Go 转义成 6 字节的 `<`。thought 给到受理上限，由引擎截到展示上限。
+	// **正向对照，先跑**：出厂样本必须发得出去。没有它，下面那条「被拒」可能是任何原因
+	// （模板未注册、策略门、Space 解析）造成的，归因不到列宽。
+	control := &dispatchCapture{}
+	recorder := invokeTemplateSend(t, newAPI(control),
+		registrySendBody(t, "reasoning", testReasoningData(t, "reasoning")), "")
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("出厂样本的模板发送应成功；这条不过说明 harness 有问题，后面无法归因: status=%d body=%s",
+			recorder.Code, recorder.Body.String())
+	}
+	control.mu.Lock()
+	controlDispatched := control.captured != nil
+	control.mu.Unlock()
+	if !controlDispatched {
+		t.Fatal("正向对照应产生一次派发")
+	}
+
+	// 同一套 harness，只把 data 换成 schema 合法的最坏形状（实测首次编辑信封 151% 列宽）。
+	blocked := &dispatchCapture{}
+	recorder = invokeTemplateSend(t, newAPI(blocked),
+		registrySendBody(t, "error", worstCaseReasoningData(t)), "")
+	if recorder.Code != http.StatusBadRequest {
+		t.Fatalf("超列宽的模板发送应被预检拒绝（否则卡片发出后第一次编辑就动不了）: status=%d body=%s",
+			recorder.Code, recorder.Body.String())
+	}
+	if !strings.Contains(recorder.Body.String(), errcode.ErrBotAPICardInvalid.DefaultMessage) {
+		t.Fatalf("应映射到 card-invalid: %s", recorder.Body.String())
+	}
+	// 关键：不得派发。预检必须挡在出站之前，而不是发出去再说。
+	blocked.mu.Lock()
+	dispatched := blocked.captured
+	blocked.mu.Unlock()
+	if dispatched != nil {
+		t.Fatal("超列宽帧被派发了 —— 预检没有挡在出站之前，这张卡会发出去且永远编辑不动")
+	}
+}
+
+// worstCaseReasoningData 构造 schema 允许的最坏形状：6 阶段 / 13 条聚合 action（聚合上限）/
+// 每个自由字符串顶到上限，且全用会被 Go 转义成 6 字节的 `<`。thought 给到受理上限，由引擎
+// 截到展示上限。实测渲染后的首次编辑信封是列宽的 151%。
+func worstCaseReasoningData(t *testing.T) json.RawMessage {
+	t.Helper()
 	filler := func(n int) string { return strings.Repeat("<", n) }
 	phases := make([]any, 0, 6)
-	actionCounts := []int{3, 2, 2, 2, 2, 2}
-	for _, count := range actionCounts {
+	for _, count := range []int{3, 2, 2, 2, 2, 2} {
 		actions := make([]any, 0, count)
 		for i := 0; i < count; i++ {
 			actions = append(actions, map[string]any{
@@ -185,31 +244,40 @@ func TestTemplateSendPrecheckCatchesSchemaValidButUnstorableFrame(t *testing.T) 
 		}
 		phases = append(phases, map[string]any{"thought": filler(4001), "actions": actions})
 	}
-	fields := map[string]any{
+	raw, err := json.Marshal(map[string]any{
 		"reasoningId": strings.Repeat("r", 512), "state": "error",
 		"title": filler(64), "statusLabel": filler(32), "statusTone": "Attention",
 		"traceExpanded": true, "traceCollapsed": false,
 		"collapsedSummary": filler(160), "progressText": filler(160),
 		"errorTitle": filler(64), "errorMessage": filler(121),
 		"phases": phases,
-	}
-	raw, err := json.Marshal(fields)
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
+	return raw
+}
 
+// 保留这条只量字节的用例作为**活性事实**：证明 schema 合法的输入确实能渲染出超列宽的帧，
+// 所以上面那条 handler 用例测的不是死代码。它单独不足以守住 guard（review P1 已证），
+// 两条一起才完整。
+func TestTemplateSendPrecheckTargetIsReachableFromSchemaValidInput(t *testing.T) {
+	t.Setenv(cardmsg.EnvEnabled, "true")
+	catalog, err := newBotCardTemplateCatalog(testBotTemplateRegistry(t), defaultBotTemplateRefs())
+	if err != nil {
+		t.Fatal(err)
+	}
 	rendered, err := catalog.RenderPayload(context.Background(), map[string]any{
 		"type": float64(17),
 		"template_ref": map[string]any{
 			"id": "ai.reasoning-process", "version": testReasoningVersionCurrent,
 		},
 		"state": "error",
-		"data":  rawJSONToMap(t, raw),
+		"data":  rawJSONToMap(t, worstCaseReasoningData(t)),
 	}, cardtmpl.BuildEnv{Lang: "zh-CN", SpaceID: "space-x"})
 	if err != nil {
-		t.Fatalf("最坏形状必须 schema 合法、渲染得出来（否则测不到预检）: %v", err)
+		t.Fatalf("最坏形状必须 schema 合法、渲染得出来: %v", err)
 	}
-	// 与 sendMessage 同口径：预检量的是 Finalize 之后的出站帧。
 	if err := cardmsg.Finalize(rendered); err != nil {
 		t.Fatal(err)
 	}
@@ -217,16 +285,76 @@ func TestTemplateSendPrecheckCatchesSchemaValidButUnstorableFrame(t *testing.T) 
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	// ① 这一帧过得了 cardmsg 的 512 KiB 上限 —— 所以 send 侧靠 cardmsg 是拦不住的。
+	// ① 过得了 cardmsg 的 512 KiB 上限 —— 所以 send 侧靠 cardmsg 拦不住。
 	assert.NoError(t, cardmsg.RecheckPayloadSize(rendered),
 		"最坏帧应仍在 cardmsg.MaxPayloadBytes 内，否则它在渲染阶段就挂了，预检永远走不到")
-	// ② 但它存不下 —— 预检必须拦住，否则卡片发出后第一次编辑就被写入侧的闸拒掉。
+	// ② 但存不下。
 	assert.Greater(t, len(frame), carddispatch.MaxPersistedFrameBytes,
-		"schema 允许的最坏帧竟然装得下列宽 —— 若模板收窄到这个程度，预检可以移除；"+
-			"在那之前它是活的，不能当死代码删掉")
-
+		"schema 允许的最坏帧竟然装得下列宽 —— 若模板收窄到这个程度，预检可以移除；在那之前它是活的")
 	t.Logf("最坏帧 %d B = 列宽 %d B 的 %.0f%%（cardmsg 上限 %d B 拦不住它）",
 		len(frame), carddispatch.MaxPersistedFrameBytes,
 		100*float64(len(frame))/float64(carddispatch.MaxPersistedFrameBytes), cardmsg.MaxPayloadBytes)
+}
+
+// 预检必须按**首次编辑信封**量，而不是按发送帧量。编辑路径必然追加 card_seq、进度帧还会
+// 追加 transient（send.go 的 registry edit 分支）。所以按发送帧长度
+// 放行会留下一个与该开销同宽的窗口：落在其中的帧发得出去、第一次编辑就被写入侧的
+// 闸拒掉 —— 正是这道预检存在的理由（follow-up review）。字段长度连续可变，区间可达。
+func TestTemplateSendPrecheckAccountsForTheFirstEditEnvelope(t *testing.T) {
+	t.Setenv(cardmsg.EnvEnabled, "true")
+	catalog, err := newBotCardTemplateCatalog(testBotTemplateRegistry(t), defaultBotTemplateRefs())
+	if err != nil {
+		t.Fatal(err)
+	}
+	rendered, err := catalog.RenderPayload(context.Background(), map[string]any{
+		"type": float64(17),
+		"template_ref": map[string]any{
+			"id": "ai.reasoning-process", "version": testReasoningVersionCurrent,
+		},
+		"state": "reasoning",
+		"data":  rawJSONToMap(t, testReasoningData(t, "reasoning")),
+	}, cardtmpl.BuildEnv{Lang: "zh-CN", SpaceID: "space-x"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := cardmsg.Finalize(rendered); err != nil {
+		t.Fatal(err)
+	}
+	sendFrame, err := json.Marshal(rendered)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// 复刻编辑路径的信封改写，取最坏值（int64 上界的 card_seq + transient）。
+	probe := make(map[string]interface{}, len(rendered)+2)
+	for k, v := range rendered {
+		probe[k] = v
+	}
+	probe["card_seq"] = int64(math.MaxInt64)
+	probe["transient"] = true
+	editFrame, err := json.Marshal(probe)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	overhead := len(editFrame) - len(sendFrame)
+	assert.Positive(t, overhead,
+		"首次编辑信封必须比发送帧大，否则这条用例测的东西不存在")
+	t.Logf("发送帧 %d B → 首次编辑信封 %d B，开销 %d B（这就是按发送帧量会漏掉的窗口宽度）",
+		len(sendFrame), len(editFrame), overhead)
+
+	// 关键断言：一个恰好落在窗口里的帧 —— 发送帧装得下、编辑信封装不下 —— 必须被预检
+	// 用的那个判据拒掉。这里直接对判据下手，不必构造一张真到 65,491 B 的卡。
+	windowSend := strings.Repeat("x", carddispatch.MaxPersistedFrameBytes-overhead/2)
+	assert.LessOrEqual(t, len(windowSend), carddispatch.MaxPersistedFrameBytes,
+		"窗口内的发送帧按定义应装得下列宽")
+	assert.Greater(t, len(windowSend)+overhead, carddispatch.MaxPersistedFrameBytes,
+		"窗口内的帧加上编辑信封开销后应超出列宽 —— 否则窗口是空的，这条用例无意义")
+
+	// 同一份渲染结果，两种量法给出不同答案，这就是修复前后的差别。
+	assert.LessOrEqual(t, len(sendFrame), carddispatch.MaxPersistedFrameBytes,
+		"出厂样本的发送帧本来就远在列宽内（此处只是钉住前提）")
+	if _, err := carddispatch.NormalizeFrameForPersistence(string(editFrame)); err != nil {
+		t.Fatalf("出厂样本的首次编辑信封应通过判据: %v", err)
+	}
 }

--- a/modules/bot_api/card_persistence_gate_test.go
+++ b/modules/bot_api/card_persistence_gate_test.go
@@ -1,0 +1,232 @@
+package bot_api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	"github.com/Mininglamp-OSS/octo-server/internal/carddispatch"
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardmsg"
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
+	"github.com/stretchr/testify/assert"
+)
+
+// 这两条闸都实现在 modules/bot_api 里，而在此之前**本包内零测试覆盖** —— 覆盖全在
+// internal/carddispatch，靠的是那一层的 fake。这正是 #712 里那个 P0 之所以能溜过去的
+// 形状：guard 在 A 包，测试用 B 包的替身（fakeBotCardMutator 只记请求、从不复校验），
+// 于是 A 包这层接线没人守。所以这里刻意走真实 HTTP handler，不用 fake。
+//
+// ① raw 卡片编辑的列宽闸（send.go 的 raw 分支）：一处调用覆盖它下游三个写动作
+//    （card_seq CAS / 非 card_seq LWW / 修订历史追加），三者消费同一份字节。
+// ② 模板发送的列宽预检（sendMessage 的模板分支）。
+
+// oversizedRawCard 造一个 cardmsg 完全合法、但比 TEXT 列宽的卡：单个 TextBlock 撑大。
+// cardmsg 只有 512 KiB 的 payload 上限，是列宽的 8 倍，所以这个帧过得了 Validate。
+func oversizedRawCard() map[string]interface{} {
+	return map[string]interface{}{
+		"type":         cardmsg.InteractiveCard.Int(),
+		"card_version": cardmsg.CardVersion,
+		"profile":      cardmsg.ProfileV1,
+		"card": map[string]interface{}{
+			"type": "AdaptiveCard", "version": "1.5",
+			"body": []interface{}{
+				map[string]interface{}{
+					"type": "TextBlock",
+					// 每个 CJK 字符 3 字节，取列宽的一半个字符 → 稳过列宽。
+					"text": strings.Repeat("塞", carddispatch.MaxPersistedFrameBytes/2),
+				},
+			},
+		},
+	}
+}
+
+func TestBotRawCardEditRejectsFrameWiderThanTheColumn(t *testing.T) {
+	skipWithoutIMBot(t)
+	t.Setenv(cardmsg.EnvEnabled, "true")
+	s, ctx := testutil.NewTestServer()
+	defer func() { _ = testutil.CleanAllTables(ctx) }()
+	seedP1CardBot(t, ctx)
+
+	do := func(path string, body map[string]interface{}) *httptest.ResponseRecorder {
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("POST", path, bytes.NewReader([]byte(util.ToJson(body))))
+		req.Header.Set("Authorization", "Bearer "+p1CardBotToken)
+		s.GetRoute().ServeHTTP(w, req)
+		return w
+	}
+
+	// 先正常发一张卡，拿到可编辑的目标。
+	w := do("/v1/bot/sendMessage", map[string]interface{}{
+		"channel_id":   testutil.UID,
+		"channel_type": common.ChannelTypePerson.Uint8(),
+		"payload":      p1CardEnvelope(),
+	})
+	assert.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	var sendResp struct {
+		MessageID int64 `json:"message_id"`
+	}
+	assert.NoError(t, json.Unmarshal(w.Body.Bytes(), &sendResp))
+	assert.NotZero(t, sendResp.MessageID)
+
+	msgSeq := awaitP1CardStored(t, ctx, sendResp.MessageID)
+	messageID := fmt.Sprintf("%d", sendResp.MessageID)
+
+	// 自证前提：这个超宽帧在 cardmsg 眼里是合法的，被拒只能是因为列宽。
+	oversized := util.ToJson(oversizedRawCard())
+	if _, err := cardmsg.NormalizeContentEdit(oversized); err != nil {
+		t.Fatalf("测试前提不成立：帧本身就非法 (%v)，那它测不到列宽闸", err)
+	}
+	assert.Greater(t, len(oversized), carddispatch.MaxPersistedFrameBytes)
+
+	editBody := func(contentEdit string) map[string]interface{} {
+		return map[string]interface{}{
+			"message_id":   messageID,
+			"message_seq":  msgSeq,
+			"channel_id":   testutil.UID,
+			"channel_type": common.ChannelTypePerson.Uint8(),
+			"content_edit": contentEdit,
+		}
+	}
+
+	// **正向对照，先跑**。没有它，下面那条「被拒」什么也证明不了 —— token 错、消息查不到、
+	// 策略门关着，任何一个都能让编辑失败。先证明这套 setup 下正常尺寸的编辑确实能成功，
+	// 才能把随后的拒绝归因到列宽。
+	w = do("/v1/bot/message/edit", editBody(util.ToJson(p1CardEnvelope())))
+	assert.Equal(t, http.StatusOK, w.Code,
+		"正常尺寸的 raw 卡片编辑应成功；这条不过说明 setup 有问题，后面的断言无法归因: %s", w.Body.String())
+
+	var storedAfterControl int
+	_, err := ctx.DB().SelectBySql(
+		"select count(*) from message_extra where message_id=? and content_edit is not null and content_edit<>''",
+		messageID).Load(&storedAfterControl)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, storedAfterControl, "正向对照应留下一行 content_edit")
+
+	// 现在同一条消息、同一套 setup，只把帧换成超宽的 —— 必须被拒。
+	w = do("/v1/bot/message/edit", editBody(oversized))
+	assert.Equal(t, http.StatusBadRequest, w.Code,
+		"超宽 raw 卡片编辑被接受了 —— 列宽闸没生效，这一帧会直达 MySQL 的 TEXT 列: %s", w.Body.String())
+	// 断言 DefaultMessage 而不是 error.code：testutil.NewTestServer 不装 i18n
+	// ErrorRenderer，响应体里没有 error.code 字段。DefaultMessage 取自 errcode 的注册处，
+	// 所以这条仍然把拒绝归因到**这个**码，而不是任意一个 400。
+	assert.Contains(t, w.Body.String(), errcode.ErrBotAPICardInvalid.DefaultMessage,
+		"应映射到 card-invalid（ErrCardMutationTooLarge wrap 了 ErrCardMutationInvalid）: %s", w.Body.String())
+
+	// 且不得覆盖已落库的那一行：闸挡在写之前，不是让 MySQL 去拒。
+	var storedEdit string
+	_, err = ctx.DB().SelectBySql(
+		"select content_edit from message_extra where message_id=?", messageID).Load(&storedEdit)
+	assert.NoError(t, err)
+	assert.NotContains(t, storedEdit, strings.Repeat("塞", 64),
+		"超宽帧不得触达写路径，落库内容应仍是正向对照那一帧")
+	assert.LessOrEqual(t, len(storedEdit), carddispatch.MaxPersistedFrameBytes,
+		"落库的 content_edit 不得超过列宽")
+}
+
+// awaitP1CardStored 等 IM 异步持久化完成，返回可用于编辑的 messageSeq。
+func awaitP1CardStored(t *testing.T, ctx *config.Context, clientMsgID int64) uint32 {
+	t.Helper()
+	var msgSeq uint32
+	for i := 0; i < 20; i++ {
+		sr, err := ctx.IMSearchMessages(&config.MsgSearchReq{
+			ChannelID:   testutil.UID,
+			ChannelType: common.ChannelTypePerson.Uint8(),
+			MessageIds:  []int64{clientMsgID},
+			LoginUID:    p1CardBotID,
+		})
+		if err == nil && sr != nil && len(sr.Messages) > 0 && sr.Messages[0].MessageSeq > 0 {
+			msgSeq = sr.Messages[0].MessageSeq
+			break
+		}
+		time.Sleep(300 * time.Millisecond)
+	}
+	if msgSeq == 0 {
+		t.Skip("消息未在预期时间内完成 IM 异步持久化，跳过（非本用例断言的对象）")
+	}
+	return msgSeq
+}
+
+// 模板发送预检（sendMessage 的模板分支）：send 侧原本只查 512 KiB、编辑侧查 TEXT 列宽，
+// 两者不一致就能造出「发得出去、第一次编辑就被拒」的卡。这条用例证明**schema 合法**的
+// 输入确实能渲染出超列宽的帧（所以预检不是死代码），并且预检用的常量与写入侧闸同源。
+//
+// 刻意不打 HTTP：这里要钉的是「渲染结果 vs 列宽」这个判断，用真实 catalog 渲染 + 真实
+// 常量即可，不必拖上 DB/IM。raw 编辑那条闸的接线才需要真实 handler（见上）。
+func TestTemplateSendPrecheckCatchesSchemaValidButUnstorableFrame(t *testing.T) {
+	t.Setenv(cardmsg.EnvEnabled, "true")
+	catalog, err := newBotCardTemplateCatalog(testBotTemplateRegistry(t), defaultBotTemplateRefs())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// 最坏形状：6 阶段 / 13 条聚合 action（schema 的聚合上限）/ 每个自由字符串顶到上限，
+	// 且全部用会被 Go 转义成 6 字节的 `<`。thought 给到受理上限，由引擎截到展示上限。
+	filler := func(n int) string { return strings.Repeat("<", n) }
+	phases := make([]any, 0, 6)
+	actionCounts := []int{3, 2, 2, 2, 2, 2}
+	for _, count := range actionCounts {
+		actions := make([]any, 0, count)
+		for i := 0; i < count; i++ {
+			actions = append(actions, map[string]any{
+				"tool": filler(81), "detail": filler(192),
+				"statusGlyph": "●", "statusTone": "Good",
+			})
+		}
+		phases = append(phases, map[string]any{"thought": filler(4001), "actions": actions})
+	}
+	fields := map[string]any{
+		"reasoningId": strings.Repeat("r", 512), "state": "error",
+		"title": filler(64), "statusLabel": filler(32), "statusTone": "Attention",
+		"traceExpanded": true, "traceCollapsed": false,
+		"collapsedSummary": filler(160), "progressText": filler(160),
+		"errorTitle": filler(64), "errorMessage": filler(121),
+		"phases": phases,
+	}
+	raw, err := json.Marshal(fields)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rendered, err := catalog.RenderPayload(context.Background(), map[string]any{
+		"type": float64(17),
+		"template_ref": map[string]any{
+			"id": "ai.reasoning-process", "version": testReasoningVersionCurrent,
+		},
+		"state": "error",
+		"data":  rawJSONToMap(t, raw),
+	}, cardtmpl.BuildEnv{Lang: "zh-CN", SpaceID: "space-x"})
+	if err != nil {
+		t.Fatalf("最坏形状必须 schema 合法、渲染得出来（否则测不到预检）: %v", err)
+	}
+	// 与 sendMessage 同口径：预检量的是 Finalize 之后的出站帧。
+	if err := cardmsg.Finalize(rendered); err != nil {
+		t.Fatal(err)
+	}
+	frame, err := json.Marshal(rendered)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// ① 这一帧过得了 cardmsg 的 512 KiB 上限 —— 所以 send 侧靠 cardmsg 是拦不住的。
+	assert.NoError(t, cardmsg.RecheckPayloadSize(rendered),
+		"最坏帧应仍在 cardmsg.MaxPayloadBytes 内，否则它在渲染阶段就挂了，预检永远走不到")
+	// ② 但它存不下 —— 预检必须拦住，否则卡片发出后第一次编辑就被写入侧的闸拒掉。
+	assert.Greater(t, len(frame), carddispatch.MaxPersistedFrameBytes,
+		"schema 允许的最坏帧竟然装得下列宽 —— 若模板收窄到这个程度，预检可以移除；"+
+			"在那之前它是活的，不能当死代码删掉")
+
+	t.Logf("最坏帧 %d B = 列宽 %d B 的 %.0f%%（cardmsg 上限 %d B 拦不住它）",
+		len(frame), carddispatch.MaxPersistedFrameBytes,
+		100*float64(len(frame))/float64(carddispatch.MaxPersistedFrameBytes), cardmsg.MaxPayloadBytes)
+}

--- a/modules/bot_api/send.go
+++ b/modules/bot_api/send.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
 	"net/http"
 	"runtime/debug"
 	"strconv"
@@ -316,29 +317,48 @@ func (ba *BotAPI) sendMessage(c *wkhttp.Context) {
 	// 模板发送的列宽预检（PR#712 review lml2468 P1-2）。send 侧原本只查 512 KiB，而编辑
 	// 侧查 TEXT 列宽 65,535 B，两者不一致就能造出「发得出去、第一次编辑就被拒」的卡。
 	//
-	// 这道检查**只覆盖第一帧**，不是那个不一致的通解（review P2-3）：编辑信封会多出
-	// card_seq / transient，而且推理卡的后续帧数据更多（phases 从 1 累积到 6），所以首帧
-	// 装得下推不出第 N 帧装得下。它能挡住的是病态的首帧 —— 那种发出去就注定动不了的卡。
-	// 真正的通解是迁 MEDIUMTEXT 或给 tool/detail 上截断，见 brief D3a 的 open 项。
+	// 量的是**最坏的首次编辑信封**，不是发送帧本身：编辑路径会在渲染结果上追加 card_seq
+	// （必然）和 transient（进度帧）。card_seq 取 int64 上界、transient 取 true，两者都是最坏
+	// 取值，实测合计 48 字节。按发送帧长度放行会留下一个同宽的窗口 —— 落在其中的帧发得出去、
+	// 第一次编辑就被写入侧的闸拒掉，而字段长度是连续可变的，所以这个区间可达
+	// （follow-up review；具体字节数由 TestTemplateSendPrecheckAccountsForTheFirstEditEnvelope
+	// 实测并打印，不写死在这里当魔数）。
+	//
+	// 用 carddispatch.NormalizeFrameForPersistence 而不是自己比长度：宽度判据只有一份，
+	// 编辑路径以后再多加一个信封键，这里不会因为漏改一个魔数而重新裂开。代价是每次模板
+	// 发送多跑一次 Validate+Finalize+marshal —— 一张卡只在首帧付一次，后续帧走编辑路径。
+	//
+	// 这道检查**只覆盖第一帧**，仍不是那个不一致的通解（review P2-3）：推理卡的后续帧数据
+	// 更多（phases 从 1 累积到 6），首帧装得下推不出第 N 帧装得下。它能挡住的是那种发出去
+	// 就注定动不了的卡。真正的通解是迁 MEDIUMTEXT 或给 tool/detail 上截断，见 brief D3a。
 	//
 	// 只作用于**模板**分支，刻意不管 raw 发送：模板帧的尺寸由服务端产物 + schema 有界输入
 	// 决定（实测出厂样本 10.3–18.3 KB，占列宽 15.7%–27.9%），所以这道检查只会在病态输入上
 	// 触发；而 raw 卡片是调用方自己作者的一次性内容，对外承诺的就是 512 KiB，收紧它会拒掉
 	// 今天能发、且从不被编辑因而永远不碰 content_edit 的卡。
 	if templateMode {
+		// 浅拷贝：只往顶层加键，card 子树不动，且**不能**污染真正出站的 payload。
+		probe := make(map[string]interface{}, len(payload)+2)
+		for k, v := range payload {
+			probe[k] = v
+		}
+		probe["card_seq"] = int64(math.MaxInt64)
+		probe["transient"] = true
+
 		// fail-closed：marshal 失败必须拒绝，不能跳过尺寸检查。实践上不可达
 		// （payload 是 JSON 解出来的 map，上面 cardmsg.Finalize 刚 marshal 过一次），
 		// 但一个 fail-open 的条件不该出现在这个位置（review P2-4）。
-		frame, mErr := json.Marshal(payload)
+		probeFrame, mErr := json.Marshal(probe)
 		if mErr != nil {
 			ba.Error("模板渲染帧 marshal 失败,无法做列宽预检", zap.Error(mErr),
 				zap.String("channelID", channelID))
 			httperr.ResponseErrorL(c, errcode.ErrBotAPICardInvalid, nil, nil)
 			return
 		}
-		if len(frame) > carddispatch.MaxPersistedFrameBytes {
-			ba.Warn("模板渲染帧超出持久化列宽,拒绝发送(否则卡片发出后无法编辑)",
-				zap.String("channelID", channelID), zap.Int("frameBytes", len(frame)),
+		if _, pErr := carddispatch.NormalizeFrameForPersistence(string(probeFrame)); pErr != nil {
+			ba.Warn("模板渲染帧的首次编辑信封超出持久化列宽,拒绝发送(否则卡片发出后无法编辑)",
+				zap.Error(pErr), zap.String("channelID", channelID),
+				zap.Int("sendFrameBytes", len(probeFrame)),
 				zap.Int("columnBytes", carddispatch.MaxPersistedFrameBytes))
 			httperr.ResponseErrorL(c, errcode.ErrBotAPICardInvalid, nil, nil)
 			return

--- a/pkg/cardtmpl/json_artifact.go
+++ b/pkg/cardtmpl/json_artifact.go
@@ -1149,13 +1149,13 @@ func parseAggregateArrayLimits(schema map[string]any) ([]jsonTemplateAggregateAr
 		if err := rejectUnknownKeys(entry, "parentArray", "childArray", "maxTotalItems"); err != nil {
 			return nil, fmt.Errorf("aggregateArrayLimits[%d]: %w", index, err)
 		}
-		parent, _ := entry["parentArray"].(string)
-		child, _ := entry["childArray"].(string)
-		if parent == "" || parent != strings.TrimSpace(parent) {
-			return nil, fmt.Errorf("aggregateArrayLimits[%d].parentArray is required and must be trimmed", index)
+		parent, err := requiredStringField(entry, "parentArray")
+		if err != nil {
+			return nil, fmt.Errorf("aggregateArrayLimits[%d].%w", index, err)
 		}
-		if child == "" || child != strings.TrimSpace(child) {
-			return nil, fmt.Errorf("aggregateArrayLimits[%d].childArray is required and must be trimmed", index)
+		child, err := requiredStringField(entry, "childArray")
+		if err != nil {
+			return nil, fmt.Errorf("aggregateArrayLimits[%d].%w", index, err)
 		}
 		maxItems, err := positiveJSONInt(entry["maxTotalItems"])
 		if err != nil {
@@ -1203,14 +1203,21 @@ func parseStringTruncations(schema map[string]any) ([]jsonTemplateStringTruncati
 		if err := rejectUnknownKeys(entry, "arrayField", "field", "maxRunes", "ellipsis"); err != nil {
 			return nil, fmt.Errorf("truncateStrings[%d]: %w", index, err)
 		}
-		arrayField, _ := entry["arrayField"].(string)
-		field, _ := entry["field"].(string)
-		ellipsis, _ := entry["ellipsis"].(string)
-		if field == "" || field != strings.TrimSpace(field) {
-			return nil, fmt.Errorf("truncateStrings[%d].field is required and must be trimmed", index)
+		// arrayField and ellipsis are genuinely optional, which is exactly why they
+		// must not be read with `v, _ := ...`: for an optional field that idiom maps
+		// a wrong-typed value onto the same "" the absent case produces, so the
+		// declaration silently changes meaning. See optionalStringField.
+		arrayField, err := optionalStringField(entry, "arrayField")
+		if err != nil {
+			return nil, fmt.Errorf("truncateStrings[%d].%w", index, err)
 		}
-		if arrayField != strings.TrimSpace(arrayField) {
-			return nil, fmt.Errorf("truncateStrings[%d].arrayField must be trimmed", index)
+		field, err := requiredStringField(entry, "field")
+		if err != nil {
+			return nil, fmt.Errorf("truncateStrings[%d].%w", index, err)
+		}
+		ellipsis, err := optionalStringField(entry, "ellipsis")
+		if err != nil {
+			return nil, fmt.Errorf("truncateStrings[%d].%w", index, err)
 		}
 		maxRunes, err := positiveJSONInt(entry["maxRunes"])
 		if err != nil {
@@ -1291,6 +1298,54 @@ func validateTruncationTarget(schema map[string]any, tr jsonTemplateStringTrunca
 			truncationTarget(tr), tr.MaxRunes, maxLength)
 	}
 	return nil
+}
+
+// optionalStringField reads a string-valued key that may legitimately be absent.
+// Absent yields "" with no error; a key that is *present* with a non-string value
+// is an error rather than "".
+//
+// Why this exists instead of `v, _ := m[k].(string)`: for an **optional** field
+// that idiom collapses "wrong type" onto the same "" the absent case produces, so
+// the declaration silently changes meaning instead of failing to compile. Two live
+// cases in truncateStrings (found reviewing #712): a non-string `arrayField`
+// becomes "", which re-scopes the clamp from `phases[].thought` to a top-level
+// `thought` that does not exist — the declared display ceiling then simply stops
+// applying, with no error at compile time and no signal at render time. A
+// non-string `ellipsis` becomes "", silently dropping the ellipsis so a truncated
+// value is indistinguishable from a short one.
+func optionalStringField(entry map[string]any, key string) (string, error) {
+	raw, present := entry[key]
+	if !present {
+		return "", nil
+	}
+	value, ok := raw.(string)
+	if !ok {
+		return "", fmt.Errorf("%s must be a string", key)
+	}
+	if value != strings.TrimSpace(value) {
+		return "", fmt.Errorf("%s must be trimmed", key)
+	}
+	return value, nil
+}
+
+// requiredStringField is optionalStringField plus presence and non-emptiness.
+// The callers previously leaned on a downstream `== ""` comparison to catch a
+// wrong-typed value: that happens to fail closed, but it fails closed by accident
+// and reports "is required" for what is actually a type error. Making the check
+// explicit keeps the outcome and fixes the diagnosis.
+func requiredStringField(entry map[string]any, key string) (string, error) {
+	raw, present := entry[key]
+	if !present {
+		return "", fmt.Errorf("%s is required", key)
+	}
+	value, ok := raw.(string)
+	if !ok {
+		return "", fmt.Errorf("%s must be a string", key)
+	}
+	if value == "" || value != strings.TrimSpace(value) {
+		return "", fmt.Errorf("%s is required and must be trimmed", key)
+	}
+	return value, nil
 }
 
 func positiveJSONInt(value any) (int, error) {

--- a/pkg/cardtmpl/json_artifact.go
+++ b/pkg/cardtmpl/json_artifact.go
@@ -1207,7 +1207,7 @@ func parseStringTruncations(schema map[string]any) ([]jsonTemplateStringTruncati
 		// must not be read with `v, _ := ...`: for an optional field that idiom maps
 		// a wrong-typed value onto the same "" the absent case produces, so the
 		// declaration silently changes meaning. See optionalStringField.
-		arrayField, err := optionalStringField(entry, "arrayField")
+		arrayField, err := optionalTrimmedStringField(entry, "arrayField")
 		if err != nil {
 			return nil, fmt.Errorf("truncateStrings[%d].%w", index, err)
 		}
@@ -1322,6 +1322,25 @@ func optionalStringField(entry map[string]any, key string) (string, error) {
 	if !ok {
 		return "", fmt.Errorf("%s must be a string", key)
 	}
+	return value, nil
+}
+
+// optionalTrimmedStringField is optionalStringField plus a trim requirement, for the
+// fields that name a schema path — an untrimmed one can never match a property name,
+// so accepting it would only defer the failure.
+//
+// Deliberately NOT applied to `ellipsis` (review of #716): that field is display text,
+// not a path, and the pre-#716 parser used it verbatim. A leading-space suffix like
+// " …" is a legitimate typographic choice, so trimming it would turn a
+// correctly-typed value from accepted into rejected — a tightening beyond "only
+// present-but-wrong-typed becomes an error", which is the contract this change
+// declared. Sharing one helper across both kinds of field is what introduced that
+// over-reach; keeping them separate is what prevents it.
+func optionalTrimmedStringField(entry map[string]any, key string) (string, error) {
+	value, err := optionalStringField(entry, key)
+	if err != nil {
+		return "", err
+	}
 	if value != strings.TrimSpace(value) {
 		return "", fmt.Errorf("%s must be trimmed", key)
 	}
@@ -1342,8 +1361,13 @@ func requiredStringField(entry map[string]any, key string) (string, error) {
 	if !ok {
 		return "", fmt.Errorf("%s must be a string", key)
 	}
-	if value == "" || value != strings.TrimSpace(value) {
-		return "", fmt.Errorf("%s is required and must be trimmed", key)
+	// 空串与「有前后空白」是两条不同的规则，分开报 —— 本次改动的目标就是修这类
+	// 「消息指控了一条值没违反的规则」（review of #716）。空串本身是 trimmed 的。
+	if value == "" {
+		return "", fmt.Errorf("%s must not be empty", key)
+	}
+	if value != strings.TrimSpace(value) {
+		return "", fmt.Errorf("%s must be trimmed", key)
 	}
 	return value, nil
 }

--- a/pkg/cardtmpl/json_artifact_compiler_test.go
+++ b/pkg/cardtmpl/json_artifact_compiler_test.go
@@ -799,6 +799,23 @@ func TestCompileJSONArtifactRejectsWrongTypedConstraintFields(t *testing.T) {
 			constraints: `{"truncateStrings":[{"maxRunes":8,"ellipsis":"…"}]}`,
 			want:        "field is required",
 		},
+		// 空串与未 trim 是两条不同的规则，消息不能互相指控（review of #716）。
+		{
+			name:        "field 是空串",
+			constraints: `{"truncateStrings":[{"field":"","maxRunes":8,"ellipsis":"…"}]}`,
+			want:        "field must not be empty",
+		},
+		{
+			name:        "field 前后有空白",
+			constraints: `{"truncateStrings":[{"field":" title","maxRunes":8,"ellipsis":"…"}]}`,
+			want:        "field must be trimmed",
+		},
+		// arrayField 是 schema 路径，未 trim 永远匹配不上属性名，所以照旧要求 trim。
+		{
+			name:        "arrayField 前后有空白",
+			constraints: `{"truncateStrings":[{"arrayField":"groups ","field":"title","maxRunes":8,"ellipsis":"…"}]}`,
+			want:        "arrayField must be trimmed",
+		},
 		{
 			name:        "parentArray 是数字",
 			constraints: `{"aggregateArrayLimits":[{"parentArray":1,"childArray":"items","maxTotalItems":2}]}`,
@@ -827,9 +844,17 @@ func TestCompileJSONArtifactRejectsWrongTypedConstraintFields(t *testing.T) {
 	}
 
 	// 反向：合法的省略 arrayField / ellipsis 必须继续通过，否则这次收紧就把可选性也一起收掉了。
+	//
+	// **ellipsis 不做 trim 要求**：它是展示文本而非 schema 路径，#716 之前的解析器逐字使用它，
+	// 而 " …"（前导空格的省略号）是合法的排版选择。给它加 trim 会把一个**类型正确**的值从
+	// 接受变成拒绝 —— 超出「只有 present-but-wrong-typed 才报错」这个本次改动自己声明的
+	// 契约（review of #716 抓到这处过度收紧）。所以这里正面钉住它仍被接受。
 	for _, tc := range []struct{ name, constraints string }{
 		{"省略 arrayField（顶层字段）", `{` + aggregate + `,"truncateStrings":[{"field":"title","maxRunes":8,"ellipsis":"…"}]}`},
 		{"省略 ellipsis（无省略号截断）", `{` + aggregate + `,"truncateStrings":[{"field":"title","maxRunes":8}]}`},
+		{"ellipsis 前导空格", `{` + aggregate + `,"truncateStrings":[{"field":"title","maxRunes":8,"ellipsis":" …"}]}`},
+		{"ellipsis 尾随空格", `{` + aggregate + `,"truncateStrings":[{"field":"title","maxRunes":8,"ellipsis":"… "}]}`},
+		{"ellipsis 含换行", `{` + aggregate + `,"truncateStrings":[{"field":"title","maxRunes":8,"ellipsis":"...\n"}]}`},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			if err := compile(t, tc.constraints); err != nil {

--- a/pkg/cardtmpl/json_artifact_compiler_test.go
+++ b/pkg/cardtmpl/json_artifact_compiler_test.go
@@ -747,3 +747,94 @@ func TestCompileJSONArtifactGoldensSeeTheTruncatedRender(t *testing.T) {
 		t.Fatalf("error = %q, want a golden mismatch", err.Error())
 	}
 }
+
+// x-octo-constraints 里的字符串字段必须**显式**按类型读。可选字段（arrayField /
+// ellipsis）尤其如此：用 `v, _ := entry[k].(string)` 会把「类型不对」映射到与「键不存在」
+// 相同的 ""，于是声明的语义被静默改写，编译期无错、渲染期无信号。
+//
+// 具体后果（#712 follow-up）：非字符串 arrayField 变 "" 后，截断从 phases[].thought
+// 重定向到一个不存在的顶层 thought —— **声明的展示上限彻底停止生效**，而这正是
+// truncateStrings 存在的唯一目的。非字符串 ellipsis 变 "" 则静默丢掉省略号，截断过的值
+// 与本来就短的值再也分不出来。
+func TestCompileJSONArtifactRejectsWrongTypedConstraintFields(t *testing.T) {
+	compile := func(t *testing.T, constraints string) error {
+		t.Helper()
+		bundle := validJSONArtifactBundle()
+		bundle.Schema = json.RawMessage(fmt.Sprintf(
+			`{"$schema":"http://json-schema.org/draft-07/schema#","type":"object",`+
+				`"additionalProperties":false,"required":["title"],"properties":%s,"x-octo-constraints":%s}`,
+			validArtifactProperties, constraints,
+		))
+		_, err := CompileJSONArtifact(context.Background(), bundle, DefaultCompileLimits())
+		return err
+	}
+
+	const aggregate = `"aggregateArrayLimits":[{"parentArray":"groups","childArray":"items","maxTotalItems":2}]`
+
+	for _, tc := range []struct{ name, constraints, want string }{
+		// 两个可选字段：这两条是真正的 fail-open，修复前**编译通过**。
+		{
+			name:        "arrayField 是数字",
+			constraints: `{"truncateStrings":[{"arrayField":7,"field":"title","maxRunes":8,"ellipsis":"…"}]}`,
+			want:        "arrayField must be a string",
+		},
+		{
+			name:        "arrayField 是布尔",
+			constraints: `{"truncateStrings":[{"arrayField":false,"field":"title","maxRunes":8,"ellipsis":"…"}]}`,
+			want:        "arrayField must be a string",
+		},
+		{
+			name:        "ellipsis 是数字",
+			constraints: `{"truncateStrings":[{"field":"title","maxRunes":8,"ellipsis":3}]}`,
+			want:        "ellipsis must be a string",
+		},
+		// 必填字段：修复前靠下游 `== ""` 偶然挡住，但把类型错误报成「is required」。
+		{
+			name:        "field 是数字",
+			constraints: `{"truncateStrings":[{"field":9,"maxRunes":8,"ellipsis":"…"}]}`,
+			want:        "field must be a string",
+		},
+		{
+			name:        "field 缺失",
+			constraints: `{"truncateStrings":[{"maxRunes":8,"ellipsis":"…"}]}`,
+			want:        "field is required",
+		},
+		{
+			name:        "parentArray 是数字",
+			constraints: `{"aggregateArrayLimits":[{"parentArray":1,"childArray":"items","maxTotalItems":2}]}`,
+			want:        "parentArray must be a string",
+		},
+		{
+			name:        "childArray 是对象",
+			constraints: `{"aggregateArrayLimits":[{"parentArray":"groups","childArray":{},"maxTotalItems":2}]}`,
+			want:        "childArray must be a string",
+		},
+		{
+			name:        "childArray 缺失",
+			constraints: `{"aggregateArrayLimits":[{"parentArray":"groups","maxTotalItems":2}]}`,
+			want:        "childArray is required",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := compile(t, tc.constraints)
+			if err == nil {
+				t.Fatalf("类型错误的 %s 编译通过了 —— 声明会被静默改写语义", tc.name)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error = %q, want it to mention %q", err.Error(), tc.want)
+			}
+		})
+	}
+
+	// 反向：合法的省略 arrayField / ellipsis 必须继续通过，否则这次收紧就把可选性也一起收掉了。
+	for _, tc := range []struct{ name, constraints string }{
+		{"省略 arrayField（顶层字段）", `{` + aggregate + `,"truncateStrings":[{"field":"title","maxRunes":8,"ellipsis":"…"}]}`},
+		{"省略 ellipsis（无省略号截断）", `{` + aggregate + `,"truncateStrings":[{"field":"title","maxRunes":8}]}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := compile(t, tc.constraints); err != nil {
+				t.Fatalf("合法的省略应通过：%v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Three findings from the approving reviews on #712 (P2-1, P2-2, P2-4). None blocked that merge; all sit in **mutable engine code**, and no artifact bytes change — no published card version is touched.

**1. A fail-open in the `x-octo-constraints` parser.** Optional string fields were read with `v, _ := entry[k].(string)`, which maps *present-but-wrong-type* onto the same `""` the absent case produces. For `truncateStrings` that is a silent, total failure of the feature rather than a style nit: a non-string `arrayField` becomes `""`, which re-scopes the clamp from `phases[].thought` to a top-level `thought` that does not exist, so the declared display ceiling **stops applying** — no compile error, no render-time signal. A non-string `ellipsis` becomes `""`, silently dropping it so a truncated value is indistinguishable from a short one.

The three *required* string fields (`field`, `parentArray`, `childArray`) were already caught downstream by a `== ""` comparison — they fail closed, but by accident, and they report `is required` for what is actually a type error. They now go through the same explicit reader: same outcome, correct diagnosis.

**2. Both guards #712 added to `modules/bot_api` had zero coverage in that package.** All coverage sat in `internal/carddispatch`, behind that layer's fakes. This is the same shape as the P0 that took three rounds to find — a guard applied in one package and tested through another package's fake, where `fakeBotCardMutator` records the request and never re-validates.

**3. The persistence judge's doc comment listed three write paths; there are five.** That assertion being false is exactly what caused rounds 5 and 6 (the raw-edit branch and `WriteCAS` did not go through it). Beyond correcting the enumeration, a source guard now counts the call sites and fails when they diverge from the documented number.

## Related Issue

Follow-up to #712. No issue.

## Linked Spec

`.octospec/tasks/card-gate-hardening/brief.md`

## Changes

**`pkg/cardtmpl/json_artifact.go`** — `optionalStringField` / `requiredStringField` replace five `v, _ := ...` reads across `parseStringTruncations` and `parseAggregateArrayLimits`. Optionality is preserved: omitting `arrayField` (top-level scope) and `ellipsis` (no ellipsis) stays legal and is asserted; only *present-but-wrong-typed* becomes an error.

**`internal/carddispatch/mutation.go`** — doc comment only, no behaviour. The enumeration is now five entries, and it also records what is deliberately *not* covered: `modules/robot` and `modules/message` cannot carry a card frame (both sit behind `cardmsg.RejectsCardEdit`, which refuses type-17 in either direction), and non-card richtext `content_edit` remains unbounded against the column as pre-existing debt.

**`modules/bot_api/card_persistence_gate_test.go`** (new) — tests only.

- The raw-card-edit column gate is driven through the **real HTTP handler**, not a fake, with a **positive control first**: a normal-sized edit must succeed on the same setup, so the subsequent rejection is attributable to width rather than to auth, lookup or the per-bot policy gate. Then asserts HTTP 400, the `card_invalid` code's message, and that the stored `content_edit` still holds the control frame.
- The template-send precheck is proven not to be dead code: a schema-valid worst case (6 phases / 13 aggregate actions / every free string at its ceiling, escape-heavy) renders to a frame that passes `cardmsg.MaxPayloadBytes` **and** exceeds the column.

**`internal/carddispatch/mutation_column_test.go`** — the call-site count guard.

**`pkg/cardtmpl/json_artifact_compiler_test.go`** — 8 rejection cases plus 2 still-legal-omission cases.

## Testing

- [x] Unit tests added/updated
- [x] Manually verified

Host Go 1.26.5 + `golangci-lint` 2.12.2 (the version CI pins); MySQL + Redis + WuKongIM containers up, test DB recreated before each DB-backed package.

- `go build ./...`, `go vet ./...`, gofmt on every changed file, `git diff --check` — clean
- `golangci-lint run ./pkg/cardtmpl/... ./pkg/cardmsg/... ./internal/carddispatch/... ./modules/bot_api/...` — **0 issues**
- `-race`: `./pkg/cardtmpl/...` (8 packages), `./pkg/cardmsg/`, `./internal/carddispatch/` — green
- `go test`: `./modules/bot_api/` (52s), `./modules/card_template_catalog/`, `./modules/notify/`, `.` — green

**Each new test was proven to be a change, not a restatement of existing behaviour**, by reverting the production fix and re-running:

The parser fail-open — with `json_artifact.go` reverted and the new test kept:

```
--- FAIL  arrayField 是数字     类型错误的 arrayField 是数字 编译通过了 —— 声明会被静默改写语义
--- FAIL  arrayField 是布尔     同上
--- FAIL  ellipsis 是数字       同上
--- FAIL  field 是数字          error = "...field is required and must be trimmed", want "field must be a string"
--- FAIL  parentArray 是数字    error = "...parentArray is required and must be trimmed", want "parentArray must be a string"
```

So the two optional fields were genuinely accepted (fail-open), and the three required ones were mis-diagnosed rather than unguarded. That distinction is sharper than the review's "three `, ok :=`" and is recorded in the brief.

The raw-edit gate — with the `NormalizeFrameForPersistence` call at the raw branch removed:

```
--- FAIL: TestBotRawCardEditRejectsFrameWiderThanTheColumn
    Error: "{\"msg\":\"Failed to update data.\",\"status\":400}" does not contain "Invalid card payload."
```

`Failed to update data.` is `ErrBotAPIStoreFailed` — the frame reached MySQL and MySQL rejected it, which is precisely the outcome the gate exists to prevent. The test distinguishes the two 400s.

The call-site guard — with one `CardUpdater` path pointed back at `cardmsg.NormalizeContentEdit`:

```
--- FAIL  持久化判据的写路径实测 4 条（3 处调用 + 1 处独立设闸），注释声明 5 条。
```

Measured, for the record: the schema-valid worst-case template frame is **98,994 B = 151%** of the 65,535 B column, against `cardmsg.MaxPayloadBytes` of 524,288 B — independently reproduced at 98,998 B from `pkg/cardtmpl` (the 4-byte delta is envelope fields).

## COMPREHENSION

**1. What does this change actually do to the load-bearing path?**

- **Compile-time constraint parsing** gains a fail-closed reader. The behaviour change is narrow and one-directional: declarations that previously compiled with a silently reinterpreted meaning now fail. Nothing that compiled *and behaved as written* is affected — verified by compiling every shipped artifact plus the whole test corpus.
- **The persistence gate is untouched.** Item 3 is a comment; items 2 is tests only. The only production edit outside the parser is that comment.
- **Optionality is load-bearing and preserved.** `arrayField` absent means "top-level property" and `ellipsis` absent means "no ellipsis" — both remain legal and are asserted, so the tightening cannot be read as making them required.

**2. What could break because of it (dependents + failure mode)?**

- **An artifact with a wrong-typed constraint field now fails to compile.** For static built-ins that is a startup panic rather than a silent misbehaviour — which is the intended trade, and no shipped artifact has one (checked). For the runtime-publish path it is a 400 at validate time; that path is not enabled.
- **Error message text changed** for the three required fields (`is required and must be trimmed` → `must be a string` when the type is wrong). Existing tests assert on field-name substrings only, so none depended on the old wording; checked before changing it.
- **The new source guard is a maintenance obligation.** Adding or removing a persistence write path now fails a test until the doc comment's count is updated. That is the point, but it will surprise whoever hits it first — the failure message says exactly what to do.
- **The raw-edit test needs MySQL + WuKongIM**, so it skips in environments without them (`skipWithoutIMBot`, and it skips if IM has not persisted the message in time rather than failing on infrastructure). The template-precheck test needs neither.

**3. How do you know it works (specific test/repro/trace)?**

Each of the three items was proven to be a real change by reverting the production side and observing failure — output quoted under Testing above. Beyond that:

- `TestCompileJSONArtifactRejectsWrongTypedConstraintFields` — 8 rejection cases (2 real fail-opens, 3 mis-diagnoses, 3 missing-field) + 2 still-legal omissions, one of which also asserts truncation still clamps.
- `TestBotRawCardEditRejectsFrameWiderThanTheColumn` — real handler, positive control first, then 400 + code message + stored-row unchanged. Also self-proves its premise: the oversized frame passes `cardmsg.NormalizeContentEdit`, so width is the only possible cause of rejection.
- `TestTemplateSendPrecheckCatchesSchemaValidButUnstorableFrame` — asserts both directions (inside `MaxPayloadBytes`, over the column), so if a future template narrowing makes the precheck unreachable the test says so instead of silently passing.
- `TestPersistenceJudgeCallSitesMatchItsDocumentedCount` — its own path handling was wrong on the first run (`".."` from `internal/carddispatch` resolves to `internal/`, so `mutation.go` was never scanned and it counted 3); fixed and then verified to fire.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] PR description is in English
- [x] Added tests for my changes
- [x] Updated documentation
- [x] Followed commit message conventions (Conventional Commits)
