### PR TITLE
feat(incomingwebhook): align VCS cards with Forge

### DIFF
--- a/.octospec/tasks/vcs-webhook-card-forge-align/brief.md
+++ b/.octospec/tasks/vcs-webhook-card-forge-align/brief.md
@@ -185,9 +185,11 @@ Event builders supply only event-specific content and safe semantic literals.
   remains absolute HTTP(S).
 - **Image security:** only reviewed exact bytes may bypass the general HTTP(S)
   image URL rule. Client sanitization is defense in depth, not server authority.
-- **Authoritative plain:** `Finalize` must still derive a non-placeholder,
-  readable `plain` containing the meaningful event content after the body is
-  rearranged.
+- **Authoritative plain:** the final VCS envelope must derive `plain` from the
+  already-validated semantic `vcs-content` projection, not from the decorative
+  Forge header. The event headline remains the first line used by notifications,
+  conversation previews, search, summaries, and pins. Native cards and non-VCS
+  card producers retain the existing whole-card `Finalize` behavior.
 - **Degrade and delivery:** flag-off text bytes, card-build failure to text,
   ping/skip/no_event, audit, auth, mention expansion, and final payload-size
   checks remain unchanged.
@@ -221,6 +223,10 @@ Event builders supply only event-specific content and safe semantic literals.
 - Every one of the 11 current GitHub/GitLab card builders returns a non-nil
   card for its valid fixture, uses the same header/content/action anatomy,
   passes `cardmsg.Validate`, and derives a non-placeholder `plain`.
+- A production VCS envelope derives `plain` from `vcs-content`: its first line is
+  the event headline and it has no leading `[图片]`, source label, repository/
+  project context, or badge. The projection is package-internal and cannot be
+  selected by native `msg_type:"card"` JSON.
 - Header tests assert the exact vetted icon URI, visible `GitHub`/`GitLab`
   label, repository/project context, and appropriate event/status badge.
 - Pipeline headline has no semantic `color`; its status badge carries the

--- a/.octospec/tasks/vcs-webhook-card-forge-align/brief.md
+++ b/.octospec/tasks/vcs-webhook-card-forge-align/brief.md
@@ -79,14 +79,16 @@ platform-owned.
   was found in current octo-web/main.
 - Use the neutral Lucide `git-branch` icon for both sources; visible source text
   differentiates GitHub from GitLab. The reviewed source is Lucide
-  `0.577.0`, official repository `lucide-icons/lucide`, licensed under ISC.
+  `0.577.0`, official repository `lucide-icons/lucide`. Its upstream license
+  file carries ISC terms plus the MIT notice for Feather-derived portions.
 - Vendor one compact, URL-encoded `data:image/svg+xml,...` constant with a
   fixed neutral stroke suitable for the Forge card header. Do not use base64,
   runtime Iconify/CDN fetches, arbitrary SVG registration, or caller-supplied
   icon bytes.
-- Add the Lucide copyright, source/version, and ISC license notice to the
-  repository's third-party notice material. The icon constant must document
-  the upstream file and any byte-level modifications (size/color/minification).
+- Add the Lucide copyright, source/version, ISC terms, and Feather MIT notice
+  to the repository's third-party notice material. The icon constant must
+  document the upstream file and any byte-level modifications
+  (size/color/minification).
 
 ## Proposed design
 
@@ -242,7 +244,8 @@ Event builders supply only event-specific content and safe semantic literals.
   markdown cannot create links/emphasis/lists, non-HTTP(S) destinations cannot
   become actions, and malformed icon/navigation data degrades safely.
 - `NOTICE` (or the repository's canonical third-party notice location)
-  contains the Lucide 0.577.0 source, copyright, and ISC license notice.
+  contains the Lucide 0.577.0 source, copyright, ISC terms, and Feather MIT
+  notice from that release's upstream license file.
 
 ### Compatibility and visual verification
 

--- a/.octospec/tasks/vcs-webhook-card-forge-align/brief.md
+++ b/.octospec/tasks/vcs-webhook-card-forge-align/brief.md
@@ -1,0 +1,293 @@
+---
+type: Task
+title: "Task: vcs-webhook-card-forge-align"
+description: Align every server-authored GitHub/GitLab incoming-webhook card with octo-web's Forge visual profile and docs-card layout language, using one reviewed neutral inline icon and preserving event, trust, URL, fallback, and delivery contracts.
+tags: ["incomingwebhook", "adapter", "webhook", "card", "wire-contract", "render-profile", "trust-boundary", "external-content", "url-destination", "testing"]
+timestamp: 2026-08-08T12:00:49+08:00
+# --- octospec extension fields ---
+slug: vcs-webhook-card-forge-align
+upstream: self
+source: self
+---
+
+# Task: vcs-webhook-card-forge-align
+
+> This brief is based on `octo-server` main at
+> `75edcf3869a0f06e0521c0d8d8d27bb9cd4296dc` and a fresh checkout of
+> `Mininglamp-OSS/octo-web` main at
+> `5269665bc904e54ca3b89d08c5d2258f916f9a26`. Re-check both heads before
+> implementation because the client render-profile and width contracts are
+> cross-repository dependencies.
+
+## Goal
+
+Refresh all existing **server-authored GitHub and GitLab incoming-webhook
+InteractiveCards** so they use octo-web's Forge visual profile and the same
+compact header / semantic badge / accent surface hierarchy as the current docs
+cards.
+
+The user-visible result is one coherent VCS card family:
+
+- a compact header with a reviewed neutral VCS icon, visible `GitHub` or
+  `GitLab` source text, repository/project context, and an event/status badge;
+- a neutral headline and structured content surface instead of coloring the
+  whole Pipeline title;
+- readable facts and long values, including English Pipeline labels and one
+  job name per line;
+- the existing localized `Action.OpenUrl` navigation, text fallback, event
+  semantics, and trust boundary unchanged.
+
+This is a presentation change to the existing VCS producer. It is **not** a
+`cardtmpl` migration and does not make externally supplied webhook cards
+platform-owned.
+
+## Verified background
+
+### octo-web rendering contract
+
+- Current octo-web fixes every InteractiveCard outer width at
+  `width: min(480px, 100%)` and makes both legacy/Forge mount roots fill that
+  width (`InteractiveCard/index.css`). Equal desktop width and narrow-screen
+  shrink are therefore client-container behavior; the server must not add an
+  empty stretch column solely to simulate a fixed outer width.
+- `render_profile` is active, not reserved. Missing/empty permanently selects
+  `legacy`; explicit `octo-chat/v1` selects the packaged Forge HostConfig
+  (`renderProfile.ts`, `renderOctoCard.ts`, and `renderDecision.test.tsx`).
+- Incoming-webhook senders (`iwh_*`) are trusted for display but remain
+  submit-read-only. This task adds no interactive actions or inputs.
+
+### Inline-image validation contract
+
+- `pkg/cardmsg` does **not** generically allow `data:image/svg+xml`.
+  `checkImageURL` accepts only an exact match from `vettedInlineImages`; every
+  other image URI falls back to the absolute HTTP(S) allowlist.
+- Existing tests explicitly reject an arbitrary harmless SVG, a one-byte
+  mutation, surrounding whitespace, appended content, and a base64-encoded SVG.
+  Therefore an embedded VCS icon must be deliberately added to the exact-byte
+  allowlist; merely copying a `data:` URI into `adapter_card.go` would make every
+  VCS card fail validation and degrade to text.
+- The current docs v3 cards use HTTPS Iconify/Lucide URLs; they do not prove
+  that arbitrary or base64 SVG data URIs pass server validation.
+- octo-web can safely render bounded SVG data URIs after its own sanitizer, but
+  the server's stricter exact-byte gate remains authoritative and must not be
+  weakened to the client's broader policy.
+
+### Icon source and license decision
+
+- Do not ship GitHub or GitLab logo artwork in this task. Those marks carry
+  separate brand/trademark usage conditions and no approved repository asset
+  was found in current octo-web/main.
+- Use the neutral Lucide `git-branch` icon for both sources; visible source text
+  differentiates GitHub from GitLab. The reviewed source is Lucide
+  `0.577.0`, official repository `lucide-icons/lucide`, licensed under ISC.
+- Vendor one compact, URL-encoded `data:image/svg+xml,...` constant with a
+  fixed neutral stroke suitable for the Forge card header. Do not use base64,
+  runtime Iconify/CDN fetches, arbitrary SVG registration, or caller-supplied
+  icon bytes.
+- Add the Lucide copyright, source/version, and ISC license notice to the
+  repository's third-party notice material. The icon constant must document
+  the upstream file and any byte-level modifications (size/color/minification).
+
+## Proposed design
+
+### 1. Shared VCS card anatomy
+
+Keep `vcsCardData.card` as the single GitHub/GitLab assembler and evolve it to
+produce one shared structure:
+
+1. **Header `ColumnSet`**
+   - auto column: 16px reviewed neutral `git-branch` Image;
+   - stretch column: small/bolder visible source label plus subtle repository or
+     project context, with wrapping/truncation bounded by existing helpers;
+   - optional auto column: small/bolder event or status badge.
+2. **Accent content `Container`**
+   - `style: "accent"`, `bleed: true`, separator and explicit spacing;
+   - neutral bolder headline (never status-colored as a whole);
+   - existing title/commit/comment lines, FactSet, and quote content using the
+     current escaped and rune-bounded leaves.
+3. **Navigation footer**
+   - when a valid destination exists, render a full-bleed `emphasis` Container
+     with separator and one `ActionSet` carrying the existing localized
+     `Action.OpenUrl`;
+   - remove the duplicate top-level `actions` form so each card still exposes
+     exactly one navigation action;
+   - the current destination must still pass `httpURLForCard` and
+     `cardmsg.Validate`; an invalid/missing URL omits the whole footer rather
+     than rejecting delivery.
+
+The shared assembler must keep both sibling adapters structurally identical.
+Event builders supply only event-specific content and safe semantic literals.
+
+### 2. Event and status presentation
+
+- Cover all current builders, not only the screenshot's Pipeline card:
+  - GitHub: push/tag-via-push, pull request, issue, issue comment, release;
+  - GitLab: push, tag push, merge request, issue, note, pipeline.
+- Pipeline maps known statuses to semantic badge colors (`Good`, `Attention`,
+  `Warning`, `Accent`) while the headline remains neutral. Unknown statuses use
+  the default badge color and remain visible as escaped text.
+- Pipeline fact titles are always the English literals `Branch`, `Status`,
+  `Duration`, and `Jobs (N)`, independent of outbound language.
+- Pipeline jobs retain current ordering, non-blank count, per-item rune cap,
+  maximum rendered count, and overflow marker, but render one job per line.
+  Do not change the shared slash-joined representation used by MR/PR/Issue
+  `Labels (N)`.
+- Existing user-visible action localization remains unchanged.
+
+### 3. Server-owned Forge selection
+
+- VCS adapter cards explicitly emit top-level
+  `render_profile: "octo-chat/v1"` so octo-web selects the Forge HostConfig.
+  This field is a sibling of `profile`, not part of the Adaptive Card document
+  or `metadata.octo`.
+- Author the value through a package-internal, non-JSON field on the internal
+  `pushPayloadReq` (or an equivalently closed server-only path). `vcsPushReq`
+  sets the constant; `buildCardPayload` copies it before
+  `cardmsg.Validate`/`Finalize`.
+- Native callers sending `msg_type:"card"` cannot provide or override this
+  internal value and continue to omit `render_profile` unless a separate
+  contract explicitly changes them. Do not default every incoming card to
+  Forge based only on message type.
+- `profile` remains `octo/v1`; no `card_profile` field and no Submit/Input
+  capability is introduced.
+
+### 4. Exact vetted inline icon
+
+- Add one exported, immutable VCS icon constant to `pkg/cardmsg` and include
+  that exact string in `vettedInlineImages`; the shared card assembler reuses
+  the same constant instead of duplicating bytes.
+- Keep `checkImageURL`'s model unchanged: exact vetted bytes or absolute
+  HTTP(S). Do not add a registration API, caller trust mode, SVG parser, broad
+  MIME allowlist, or adapter-specific bypass.
+- The icon stays below the existing 1 KiB icon limit. A one-byte mutation,
+  whitespace variant, base64 re-encoding, or any other SVG remains rejected.
+- `httpURLForCard` remains the gate for navigation destinations. It is not the
+  image gate and must not be relaxed to accept `data:`.
+
+## Load-bearing list
+
+- **Shared card producer:** `modules/incomingwebhook/adapter_card.go` owns the
+  common structure, leaf escaping, URL preflight, size/count limits, status
+  colors, metadata, and card self-validation.
+- **GitHub/GitLab event builders:** `adapter_github.go` and
+  `adapter_gitlab.go` retain every current event/action/status decision and
+  supply only the existing bounded data to the shared assembler.
+- **Server-owned envelope:** `pushPayloadReq`, `vcsPushReq`, and
+  `buildCardPayload` must distinguish server-authored VCS cards from external
+  native `msg_type:"card"` requests before adding `render_profile`.
+- **Trust boundary:** actor, repository/project, ref, title, commit, job,
+  label, action/status, and comment text remain attacker-influenced. Every leaf
+  continues through the existing clamp/escape helpers; every actionable URL
+  remains absolute HTTP(S).
+- **Image security:** only reviewed exact bytes may bypass the general HTTP(S)
+  image URL rule. Client sanitization is defense in depth, not server authority.
+- **Authoritative plain:** `Finalize` must still derive a non-placeholder,
+  readable `plain` containing the meaningful event content after the body is
+  rearranged.
+- **Degrade and delivery:** flag-off text bytes, card-build failure to text,
+  ping/skip/no_event, audit, auth, mention expansion, and final payload-size
+  checks remain unchanged.
+- **Client compatibility:** explicit `octo-chat/v1` is required for the Forge
+  layout; current octo-web main is the verified client baseline.
+- **Third-party attribution:** vendoring the Lucide-derived icon requires the
+  upstream copyright and ISC notice to ship with this repository.
+
+## Out of scope
+
+- No GitHub mark, GitLab tanuki, Simple Icons brand asset, or other trademarked
+  platform artwork without a separately approved asset and brand review.
+- No arbitrary SVG ingestion, general `data:` URL support, base64 exception,
+  remote icon configuration, CDN dependency, or new SVG sanitizer.
+- No change to supported GitHub/GitLab event types, action/status acceptance,
+  token/signature authentication, audit outcomes, rate limits, or input caps.
+- No change to markdown text fallback bytes or to
+  `OCTO_CARD_MESSAGE_ENABLED` behavior/default.
+- No `cardtmpl` migration, template/version registry entry, persistence
+  migration, card revision history, callback route, Input.*, or Action.Submit.
+- No octo-web implementation change: current main already owns width,
+  render-profile selection, Forge CSS/HostConfig, sender trust, and client-side
+  SVG sanitization.
+- No redesign of WeCom, Feishu, Multica, native webhook cards, bot cards, or
+  platform docs/AI templates.
+
+## Acceptance
+
+### Structural and wire assertions
+
+- Every one of the 11 current GitHub/GitLab card builders returns a non-nil
+  card for its valid fixture, uses the same header/content/action anatomy,
+  passes `cardmsg.Validate`, and derives a non-placeholder `plain`.
+- Header tests assert the exact vetted icon URI, visible `GitHub`/`GitLab`
+  label, repository/project context, and appropriate event/status badge.
+- Pipeline headline has no semantic `color`; its status badge carries the
+  mapped semantic color. Known, in-progress, unknown, and missing statuses keep
+  their current render/skip semantics.
+- Both `en-US` and `zh-CN` Pipeline cards contain English `Branch`, `Status`,
+  `Duration`, and `Jobs (N)`. Job values use newline separators while MR/PR/
+  Issue label values remain slash-joined.
+- A production envelope built from a valid VCS adapter request contains exactly
+  `profile:"octo/v1"` and `render_profile:"octo-chat/v1"`; the value is present
+  before validation/finalization and survives transport serialization.
+- A native external `msg_type:"card"` JSON body cannot set the package-internal
+  render profile and does not gain `render_profile` by default.
+
+### Image and trust-boundary assertions
+
+- The new Lucide-derived VCS URI passes `pkg/cardmsg.Validate` only at
+  `Image.url` / `ImageSet.images[].url` and stays below 1 KiB.
+- Arbitrary SVG, a one-byte icon mutation, whitespace/appended-content variants,
+  and base64 re-encoding still fail with `ErrCardBadURLScheme`; the vetted URI
+  remains forbidden in action URL/iconUrl and background-image fields.
+- Existing hostile GitHub/GitLab fixture coverage remains green: external
+  markdown cannot create links/emphasis/lists, non-HTTP(S) destinations cannot
+  become actions, and malformed icon/navigation data degrades safely.
+- `NOTICE` (or the repository's canonical third-party notice location)
+  contains the Lucide 0.577.0 source, copyright, and ISC license notice.
+
+### Compatibility and visual verification
+
+- With `OCTO_CARD_MESSAGE_ENABLED` off, representative GitHub and GitLab events
+  produce the historical text payload byte-for-byte.
+- With it on, invalid server-built cards still log and degrade to text rather
+  than turning a valid webhook delivery into a new 4xx.
+- Render representative GitHub Push/PR/Issue and GitLab Push/MR/Pipeline cards
+  against current octo-web/main in both light and dark themes. Capture PR
+  evidence showing:
+  - equal 480px desktop outer width and responsive shrink below 480px;
+  - no horizontal overflow for long repository, branch, title, labels, jobs,
+    or comment values;
+  - Forge header/accent/badge hierarchy and neutral Pipeline headline;
+  - readable missing-optional-field states and a visible OpenUrl action when a
+    valid destination exists.
+- The visual check must use a final type-17 envelope containing
+  `render_profile:"octo-chat/v1"`; rendering the card document alone is not
+  sufficient evidence.
+
+### Verification commands
+
+```bash
+go test ./pkg/cardmsg -run 'TestInlineImage|Test.*Image' -count=1
+go test ./modules/incomingwebhook/... -count=1
+go test ./pkg/cardmsg/... -count=1
+golangci-lint run ./pkg/cardmsg/... ./modules/incomingwebhook/...
+git diff --check origin/main...
+```
+
+If implementation adds a new handler-bearing Go file, update
+`TestIncomingWebhookNoLegacyResponseError`'s source list. No i18n extraction is
+required unless user-facing error codes or localized error behavior change.
+
+## Rollout and rollback
+
+- Use the existing `OCTO_CARD_MESSAGE_ENABLED` gate; add no second rollout flag.
+- Before rollout, verify the deployed octo-web version supports
+  `octo-chat/v1` and the 480px wrapper contract. Older clients that do not
+  accept the explicit render profile may show their existing update/fallback
+  behavior, so client-version readiness is a release gate.
+- Monitor the existing “built VCS card failed self-validation; degrading to
+  text” warning and card-render fallback/client error telemetry. A rise after
+  deployment indicates icon/profile/layout incompatibility.
+- Roll back the octo-server image (or disable the existing card-message gate)
+  to restore the prior card/text behavior. No database or historical-message
+  rollback is required because these cards are fire-and-forget and this task
+  adds no persistence schema.

--- a/.octospec/tasks/vcs-webhook-card-forge-align/brief.md
+++ b/.octospec/tasks/vcs-webhook-card-forge-align/brief.md
@@ -188,8 +188,10 @@ Event builders supply only event-specific content and safe semantic literals.
 - **Authoritative plain:** the final VCS envelope must derive `plain` from the
   already-validated semantic `vcs-content` projection, not from the decorative
   Forge header. The event headline remains the first line used by notifications,
-  conversation previews, search, summaries, and pins. Native cards and non-VCS
-  card producers retain the existing whole-card `Finalize` behavior.
+  conversation previews, search, summaries, and pins; the existing repository/
+  project context follows it so those surfaces retain source identity. Native
+  cards and non-VCS card producers retain the existing whole-card `Finalize`
+  behavior.
 - **Degrade and delivery:** flag-off text bytes, card-build failure to text,
   ping/skip/no_event, audit, auth, mention expansion, and final payload-size
   checks remain unchanged.
@@ -224,9 +226,9 @@ Event builders supply only event-specific content and safe semantic literals.
   card for its valid fixture, uses the same header/content/action anatomy,
   passes `cardmsg.Validate`, and derives a non-placeholder `plain`.
 - A production VCS envelope derives `plain` from `vcs-content`: its first line is
-  the event headline and it has no leading `[图片]`, source label, repository/
-  project context, or badge. The projection is package-internal and cannot be
-  selected by native `msg_type:"card"` JSON.
+  the event headline, repository/project context follows immediately when present,
+  and it has no leading `[图片]`, source label, or badge. The projection is
+  package-internal and cannot be selected by native `msg_type:"card"` JSON.
 - Header tests assert the exact vetted icon URI, visible `GitHub`/`GitLab`
   label, repository/project context, and appropriate event/status badge.
 - Pipeline headline has no semantic `color`; its status badge carries the

--- a/.octospec/tasks/vcs-webhook-card-forge-align/brief.md
+++ b/.octospec/tasks/vcs-webhook-card-forge-align/brief.md
@@ -132,6 +132,8 @@ Event builders supply only event-specific content and safe semantic literals.
   `Duration`, and `Jobs (N)`, independent of outbound language.
 - Pipeline jobs retain current ordering, non-blank count, per-item rune cap,
   maximum rendered count, and overflow marker, but render one job per line.
+  Encode separators as CommonMark hard breaks (`"  \n"`), because octo-web's
+  card markdown renderer collapses bare soft-break newlines to spaces.
   Do not change the shared slash-joined representation used by MR/PR/Issue
   `Labels (N)`.
 - Existing user-visible action localization remains unchanged.

--- a/NOTICE
+++ b/NOTICE
@@ -53,5 +53,56 @@ For the exhaustive module-by-module license inventory, run
 `go-licenses csv ./...` or inspect each upstream's LICENSE file
 via `go.sum`.
 
+--------------------------------------------------------------------
+Lucide git-branch icon
+--------------------------------------------------------------------
+
+OCTO Server includes a modified copy of the git-branch SVG from Lucide
+0.577.0:
+  https://github.com/lucide-icons/lucide/blob/0.577.0/icons/git-branch.svg
+
+The copy is minified and URL-encoded, changes width and height from 24px to
+16px, and replaces currentColor with the fixed neutral stroke #6b7075.
+
+ISC License
+
+Copyright (c) for portions of Lucide are held by Cole Bemis 2013-2026 as part of Feather (MIT). All other copyright (c) for Lucide are held by Lucide Contributors 2026.
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+---
+
+The MIT License (MIT) (for portions derived from Feather)
+
+Copyright (c) 2013-2026 Cole Bemis
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
 Frontend clients (octo-web) bundle
 additional UI and platform SDKs; see each client repository's NOTICE.

--- a/modules/incomingwebhook/adapter_card.go
+++ b/modules/incomingwebhook/adapter_card.go
@@ -300,10 +300,36 @@ func validateVCSCard(card map[string]interface{}) error {
 	})
 }
 
+// vcsPlainProjection returns the semantic content area as a standalone card-shaped
+// projection for authoritative plain derivation. The Forge header is visual chrome:
+// its icon, source/context labels, and badge must not displace the event headline in
+// push notifications, conversation previews, search, or summaries.
+//
+// The projection is package-internal and is extracted from the already validated
+// server-authored card. Native msg_type:"card" callers cannot select or forge it.
+func vcsPlainProjection(card map[string]interface{}) map[string]interface{} {
+	body, ok := card["body"].([]interface{})
+	if !ok {
+		return nil
+	}
+	for _, raw := range body {
+		element, ok := raw.(map[string]interface{})
+		if !ok || element["id"] != "vcs-content" {
+			continue
+		}
+		items, ok := element["items"].([]interface{})
+		if !ok {
+			return nil
+		}
+		return map[string]interface{}{"body": items}
+	}
+	return nil
+}
+
 // vcsPushReq picks the pushPayloadReq for a rendered VCS event: a card request when a
 // card was built (flag on) AND it self-validates, else the text request (the degrade
-// path — flag off OR card build/validate failure). Card plain is derived by Finalize
-// from the card body, so no text seed is needed.
+// path — flag off OR card build/validate failure). Card plain is derived from the
+// server-owned semantic content projection, so no caller-controlled text seed is used.
 func vcsPushReq(text string, card map[string]interface{}) *pushPayloadReq {
 	if card != nil {
 		if err := validateVCSCard(card); err != nil {
@@ -315,10 +341,16 @@ func vcsPushReq(text string, card map[string]interface{}) *pushPayloadReq {
 			zap.L().Warn("incomingwebhook: built VCS card failed self-validation; degrading to text",
 				zap.Error(err))
 		} else {
+			plainProjection := vcsPlainProjection(card)
+			if plainProjection == nil {
+				zap.L().Warn("incomingwebhook: built VCS card is missing its semantic content projection; degrading to text")
+				return &pushPayloadReq{Content: clipRunes(text, maxContentRunes())}
+			}
 			return &pushPayloadReq{
-				MsgType:       msgTypeCard,
-				Card:          card,
-				renderProfile: cardmsg.RenderProfileOctoChatV1,
+				MsgType:         msgTypeCard,
+				Card:            card,
+				renderProfile:   cardmsg.RenderProfileOctoChatV1,
+				plainProjection: plainProjection,
 			}
 		}
 	}

--- a/modules/incomingwebhook/adapter_card.go
+++ b/modules/incomingwebhook/adapter_card.go
@@ -352,9 +352,12 @@ func cappedFactValue(rawNames []string, max int) (value string, count int) {
 
 // cappedPipelineJobsValue preserves the same filtering, escaping, ordering, cap,
 // count, and overflow semantics as Labels, but gives every rendered job its own
-// line. It is intentionally pipeline-only so Labels retain their slash separator.
+// line. The two spaces before each newline are CommonMark's hard-break syntax;
+// bare newlines are soft breaks and octo-web's markdown renderer collapses them
+// to spaces. It is intentionally pipeline-only so Labels retain their slash
+// separator.
 func cappedPipelineJobsValue(rawNames []string, max int) (value string, count int) {
-	return cappedFactValueWithSeparator(rawNames, max, "\n", "\n…")
+	return cappedFactValueWithSeparator(rawNames, max, "  \n", "  \n…")
 }
 
 func cappedFactValueWithSeparator(rawNames []string, max int, separator, overflowSuffix string) (value string, count int) {

--- a/modules/incomingwebhook/adapter_card.go
+++ b/modules/incomingwebhook/adapter_card.go
@@ -141,15 +141,16 @@ func httpURLForCard(raw string) string {
 // already-safe markdown (composed with escapeCardText / cardCodeSpan); the assembler
 // does not re-escape.
 type vcsCardData struct {
-	source   string    // "GitHub" / "GitLab": metadata.octo.source.label + button label
-	variant  string    // metadata.octo.variant, e.g. "vcs.github.push"
-	headline string    // bold title line (whole TextBlock is Bolder)
-	status   string    // "", "Attention", "Good", "Warning" — headline color (pipeline status)
-	subtitle string    // subtle repo/context line; "" omits it
-	lines    []string  // body lines (commit list / "#N · title"); each its own TextBlock
-	facts    []vcsFact // labeled metadata rows (pipeline Branch/Status/Duration/Jobs); "" omits the FactSet
-	quote    string    // comment snippet; "" omits it; rendered in an emphasis Container
-	url      string    // Action.OpenUrl target (already http(s)-validated); "" omits the button
+	source     string    // "GitHub" / "GitLab": metadata.octo.source.label + button label
+	variant    string    // metadata.octo.variant, e.g. "vcs.github.push"
+	badge      string    // fixed event label, or an escaped pipeline status
+	badgeColor string    // optional semantic color for the pipeline status badge
+	headline   string    // bold title line in the neutral content surface
+	subtitle   string    // subtle repository/project context in the header; "" omits it
+	lines      []string  // body lines (commit list / "#N · title"); each its own TextBlock
+	facts      []vcsFact // labeled metadata rows (pipeline Branch/Status/Duration/Jobs); "" omits the FactSet
+	quote      string    // comment snippet; "" omits it; rendered in an emphasis Container
+	url        string    // Action.OpenUrl target (already http(s)-validated); "" omits the footer
 }
 
 // vcsFact is one FactSet row (title/value already-safe markdown; the assembler does
@@ -165,22 +166,15 @@ type vcsFact struct {
 // ActionSet(Action.OpenUrl).
 func (d vcsCardData) card(lang string) map[string]interface{} {
 	headline := map[string]interface{}{
-		"type": "TextBlock", "text": d.headline, "weight": "Bolder", "wrap": true,
+		"type": "TextBlock", "id": "vcs-headline", "text": d.headline,
+		"weight": "Bolder", "wrap": true,
 	}
-	if d.status != "" {
-		headline["color"] = d.status
-	}
-	body := []interface{}{headline}
-	if d.subtitle != "" {
-		body = append(body, map[string]interface{}{
-			"type": "TextBlock", "text": d.subtitle, "isSubtle": true, "spacing": "None", "wrap": true,
-		})
-	}
+	contentItems := []interface{}{headline}
 	for _, ln := range d.lines {
 		if ln == "" {
 			continue
 		}
-		body = append(body, map[string]interface{}{
+		contentItems = append(contentItems, map[string]interface{}{
 			"type": "TextBlock", "text": ln, "wrap": true, "spacing": "Small",
 		})
 	}
@@ -189,14 +183,66 @@ func (d vcsCardData) card(lang string) map[string]interface{} {
 		for _, f := range d.facts {
 			facts = append(facts, map[string]interface{}{"title": f.title, "value": f.value})
 		}
-		body = append(body, map[string]interface{}{"type": "FactSet", "facts": facts})
+		contentItems = append(contentItems, map[string]interface{}{"type": "FactSet", "facts": facts})
 	}
 	if d.quote != "" {
-		body = append(body, map[string]interface{}{
+		contentItems = append(contentItems, map[string]interface{}{
 			"type": "Container", "style": "emphasis",
 			"items": []interface{}{
 				map[string]interface{}{"type": "TextBlock", "text": d.quote, "wrap": true, "isSubtle": true},
 			},
+		})
+	}
+
+	headerColumns := []interface{}{
+		map[string]interface{}{
+			"type": "Column", "width": "auto",
+			"items": []interface{}{map[string]interface{}{
+				"type": "Image", "id": "vcs-source-icon", "url": cardmsg.VCSGitBranchIcon,
+				"width": "16px", "height": "16px", "spacing": "None",
+			}},
+		},
+		map[string]interface{}{
+			"type": "Column", "width": "stretch", "spacing": "Small",
+			"items": vcsHeaderTextItems(d.source, d.subtitle),
+		},
+	}
+	if d.badge != "" {
+		badge := map[string]interface{}{
+			"type": "TextBlock", "id": "vcs-event-badge", "text": d.badge,
+			"size": "Small", "weight": "Bolder", "spacing": "None", "wrap": false,
+		}
+		if d.badgeColor != "" {
+			badge["color"] = d.badgeColor
+		}
+		headerColumns = append(headerColumns, map[string]interface{}{
+			"type": "Column", "width": "auto", "spacing": "Small",
+			"items": []interface{}{badge},
+		})
+	}
+	body := []interface{}{
+		map[string]interface{}{
+			"type": "ColumnSet", "id": "vcs-header", "spacing": "None",
+			"verticalContentAlignment": "Center", "columns": headerColumns,
+		},
+		map[string]interface{}{
+			"type": "Container", "id": "vcs-content", "style": "accent", "bleed": true,
+			"separator": true, "spacing": "Small", "items": contentItems,
+		},
+	}
+	if d.url != "" {
+		// Navigation remains one structured Action.OpenUrl. The destination was
+		// preflighted by httpURLForCard and is checked again by cardmsg.Validate;
+		// it is not duplicated into unvalidated metadata or card.actions.
+		body = append(body, map[string]interface{}{
+			"type": "Container", "id": "vcs-footer", "style": "emphasis", "bleed": true,
+			"separator": true, "spacing": "None",
+			"items": []interface{}{map[string]interface{}{
+				"type": "ActionSet", "spacing": "None",
+				"actions": []interface{}{map[string]interface{}{
+					"type": "Action.OpenUrl", "title": vcsViewLabel(d.source, lang), "url": d.url,
+				}},
+			}},
 		})
 	}
 	metaOcto := map[string]interface{}{"source": map[string]interface{}{"label": d.source}}
@@ -209,19 +255,21 @@ func (d vcsCardData) card(lang string) map[string]interface{} {
 		"metadata": map[string]interface{}{"octo": metaOcto},
 		"body":     body,
 	}
-	// Navigation is the single structured Action.OpenUrl (allowlisted by both
-	// httpURLForCard and cardmsg.Validate). We deliberately do NOT also mirror the URL
-	// into metadata.webUrl: cardmsg's validator does not walk the metadata subtree, so
-	// carrying a URL there would rely on incidental coupling for the "every rendered URL
-	// was allowlisted" invariant (PR #596 review, yujiawei P2).
-	if d.url != "" {
-		card["actions"] = []interface{}{
-			map[string]interface{}{
-				"type": "Action.OpenUrl", "title": vcsViewLabel(d.source, lang), "url": d.url,
-			},
-		}
-	}
 	return card
+}
+
+func vcsHeaderTextItems(source, context string) []interface{} {
+	items := []interface{}{map[string]interface{}{
+		"type": "TextBlock", "id": "vcs-source-label", "text": source,
+		"size": "Small", "weight": "Bolder", "spacing": "None", "wrap": false,
+	}}
+	if context != "" {
+		items = append(items, map[string]interface{}{
+			"type": "TextBlock", "id": "vcs-source-context", "text": context,
+			"size": "Small", "isSubtle": true, "spacing": "None", "wrap": true,
+		})
+	}
+	return items
 }
 
 // vcsViewLabel localizes the "View on {GitHub|GitLab}" action title via the
@@ -244,10 +292,11 @@ func isZhLang(lang string) bool {
 // (from / space_id) are not needed by Validate (it checks structure / URL / size).
 func validateVCSCard(card map[string]interface{}) error {
 	return cardmsg.Validate(map[string]interface{}{
-		"type":         cardmsg.InteractiveCard.Int(),
-		"card":         card,
-		"card_version": cardmsg.CardVersion,
-		"profile":      cardmsg.ProfileV1,
+		"type":           cardmsg.InteractiveCard.Int(),
+		"card":           card,
+		"card_version":   cardmsg.CardVersion,
+		"profile":        cardmsg.ProfileV1,
+		"render_profile": cardmsg.RenderProfileOctoChatV1,
 	})
 }
 
@@ -266,7 +315,11 @@ func vcsPushReq(text string, card map[string]interface{}) *pushPayloadReq {
 			zap.L().Warn("incomingwebhook: built VCS card failed self-validation; degrading to text",
 				zap.Error(err))
 		} else {
-			return &pushPayloadReq{MsgType: msgTypeCard, Card: card}
+			return &pushPayloadReq{
+				MsgType:       msgTypeCard,
+				Card:          card,
+				renderProfile: cardmsg.RenderProfileOctoChatV1,
+			}
 		}
 	}
 	return &pushPayloadReq{Content: clipRunes(text, maxContentRunes())}
@@ -288,14 +341,23 @@ const maxRenderedLabels = 10
 const cardFactItemMax = 64
 
 // cappedFactValue builds a capped, "/"-joined FactSet value from raw external name
-// strings — shared by the pipeline card's Jobs fact and the GitLab MR/Issue Labels
-// fact (previously duplicated inline at each call site, which could let their
-// escaping/capping decisions silently drift apart). Each name is escaped via
+// strings for GitHub/GitLab PR/MR/Issue Labels. Each name is escaped via
 // escapeCardText; blank names (e.g. an empty label title) are dropped before capping
 // and counting, so the fact never shows an empty slot or an inflated (N). Returns
 // ("", 0) when there is nothing left to show — the caller omits the FactSet row
 // entirely in that case.
 func cappedFactValue(rawNames []string, max int) (value string, count int) {
+	return cappedFactValueWithSeparator(rawNames, max, " / ", " …")
+}
+
+// cappedPipelineJobsValue preserves the same filtering, escaping, ordering, cap,
+// count, and overflow semantics as Labels, but gives every rendered job its own
+// line. It is intentionally pipeline-only so Labels retain their slash separator.
+func cappedPipelineJobsValue(rawNames []string, max int) (value string, count int) {
+	return cappedFactValueWithSeparator(rawNames, max, "\n", "\n…")
+}
+
+func cappedFactValueWithSeparator(rawNames []string, max int, separator, overflowSuffix string) (value string, count int) {
 	names := make([]string, 0, len(rawNames))
 	for _, n := range rawNames {
 		if v := escapeCardText(n, cardFactItemMax); v != "" {
@@ -310,9 +372,9 @@ func cappedFactValue(rawNames []string, max int) (value string, count int) {
 	if overflow {
 		shown = names[:max]
 	}
-	value = strings.Join(shown, " / ")
+	value = strings.Join(shown, separator)
 	if overflow {
-		value += " …"
+		value += overflowSuffix
 	}
 	return value, len(names)
 }
@@ -331,15 +393,13 @@ func vcsCardLabelsFor(lang string) vcsCardLabels {
 	return vcsCardLabels{source: "Source", target: "Target", labels: "Labels"}
 }
 
-// pipelineLabels are the localized FactSet titles for the pipeline card.
+// pipelineLabels are deliberately language-neutral: product terminology for the
+// pipeline card remains English even when the surrounding action title is localized.
 type pipelineLabels struct {
 	branch, status, duration, jobs string
 }
 
-func pipelineLabelsFor(lang string) pipelineLabels {
-	if isZhLang(lang) {
-		return pipelineLabels{branch: "分支", status: "状态", duration: "耗时", jobs: "任务"}
-	}
+func pipelineLabelsFor(_ string) pipelineLabels {
 	return pipelineLabels{branch: "Branch", status: "Status", duration: "Duration", jobs: "Jobs"}
 }
 
@@ -376,9 +436,8 @@ func formatPipelineDuration(sec int) string {
 	}
 }
 
-// pipelineStatusColor maps a GitLab terminal pipeline status to an AC TextBlock
-// color so the headline reads at a glance (success green / failed red / canceled
-// amber). Unknown → "" (default color).
+// pipelineStatusColor maps a GitLab pipeline status to the compact badge color.
+// The headline stays neutral. Unknown → "" (default badge color).
 func pipelineStatusColor(status string) string {
 	switch status {
 	case "success":

--- a/modules/incomingwebhook/adapter_card.go
+++ b/modules/incomingwebhook/adapter_card.go
@@ -301,9 +301,10 @@ func validateVCSCard(card map[string]interface{}) error {
 }
 
 // vcsPlainProjection returns the semantic content area as a standalone card-shaped
-// projection for authoritative plain derivation. The Forge header is visual chrome:
-// its icon, source/context labels, and badge must not displace the event headline in
-// push notifications, conversation previews, search, or summaries.
+// projection for authoritative plain derivation. The Forge icon, source label, and
+// badge are visual chrome and stay excluded. Repository/project context is retained
+// immediately after the event headline so notifications and search results remain
+// attributable without letting header chrome displace the headline.
 //
 // The projection is package-internal and is extracted from the already validated
 // server-authored card. Native msg_type:"card" callers cannot select or forge it.
@@ -321,7 +322,45 @@ func vcsPlainProjection(card map[string]interface{}) map[string]interface{} {
 		if !ok {
 			return nil
 		}
-		return map[string]interface{}{"body": items}
+		context := vcsHeaderContextForPlain(body)
+		if context == nil || len(items) == 0 {
+			return map[string]interface{}{"body": items}
+		}
+		projectionItems := make([]interface{}, 0, len(items)+1)
+		projectionItems = append(projectionItems, items[0], context)
+		projectionItems = append(projectionItems, items[1:]...)
+		return map[string]interface{}{"body": projectionItems}
+	}
+	return nil
+}
+
+func vcsHeaderContextForPlain(body []interface{}) map[string]interface{} {
+	for _, raw := range body {
+		header, ok := raw.(map[string]interface{})
+		if !ok || header["id"] != "vcs-header" {
+			continue
+		}
+		columns, ok := header["columns"].([]interface{})
+		if !ok {
+			return nil
+		}
+		for _, rawColumn := range columns {
+			column, ok := rawColumn.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			items, ok := column["items"].([]interface{})
+			if !ok {
+				continue
+			}
+			for _, rawItem := range items {
+				item, ok := rawItem.(map[string]interface{})
+				if ok && item["id"] == "vcs-source-context" {
+					return item
+				}
+			}
+		}
+		return nil
 	}
 	return nil
 }

--- a/modules/incomingwebhook/adapter_card_test.go
+++ b/modules/incomingwebhook/adapter_card_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const expectedVCSGitBranchIcon = "data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20viewBox%3D%220%200%2024%2024%22%20fill%3D%22none%22%20stroke%3D%22%236b7075%22%20stroke-width%3D%222%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%3E%3Cpath%20d%3D%22M15%206a9%209%200%200%200-9%209V3%22%2F%3E%3Ccircle%20cx%3D%2218%22%20cy%3D%226%22%20r%3D%223%22%2F%3E%3Ccircle%20cx%3D%226%22%20cy%3D%2218%22%20r%3D%223%22%2F%3E%3C%2Fsvg%3E"
+
 // The card builders take the already-parsed *ev (parse unmarshals once); these
 // helpers unmarshal a JSON fixture and build, keeping the tests fixture-driven.
 func ghPushCardFrom(t *testing.T, body string) map[string]interface{} {
@@ -122,21 +124,136 @@ func cardBodyText(card map[string]interface{}) string {
 	return b.String()
 }
 
-// cardOpenURL returns the first Action.OpenUrl (url, title) on the card, or "","".
-func cardOpenURL(card map[string]interface{}) (url, title string) {
-	acts, _ := card["actions"].([]interface{})
-	for _, a := range acts {
-		act, _ := a.(map[string]interface{})
-		if act != nil && act["type"] == "Action.OpenUrl" {
-			u, _ := act["url"].(string)
-			t, _ := act["title"].(string)
-			return u, t
+func walkCardValue(value interface{}, visit func(map[string]interface{})) {
+	switch v := value.(type) {
+	case map[string]interface{}:
+		visit(v)
+		for _, child := range v {
+			walkCardValue(child, visit)
+		}
+	case []interface{}:
+		for _, child := range v {
+			walkCardValue(child, visit)
 		}
 	}
-	return "", ""
+}
+
+func cardNodeByID(card map[string]interface{}, id string) map[string]interface{} {
+	var found map[string]interface{}
+	walkCardValue(card, func(node map[string]interface{}) {
+		if found == nil && node["id"] == id {
+			found = node
+		}
+	})
+	return found
+}
+
+func cardFactValue(card map[string]interface{}, title string) string {
+	var value string
+	walkCardValue(card, func(node map[string]interface{}) {
+		if value != "" || node["type"] != "FactSet" {
+			return
+		}
+		facts, _ := node["facts"].([]interface{})
+		for _, raw := range facts {
+			fact, _ := raw.(map[string]interface{})
+			if fact != nil && fact["title"] == title {
+				value, _ = fact["value"].(string)
+				return
+			}
+		}
+	})
+	return value
+}
+
+// cardOpenURL returns the first Action.OpenUrl (url, title) on the card, or "","".
+func cardOpenURL(card map[string]interface{}) (url, title string) {
+	walkCardValue(card, func(node map[string]interface{}) {
+		if url == "" && node["type"] == "Action.OpenUrl" {
+			url, _ = node["url"].(string)
+			title, _ = node["title"].(string)
+		}
+	})
+	return url, title
 }
 
 func cardActionURL(card map[string]interface{}) string { u, _ := cardOpenURL(card); return u }
+
+func TestVCSCardForgeAnatomy(t *testing.T) {
+	tests := []struct {
+		name      string
+		card      map[string]interface{}
+		source    string
+		context   string
+		badge     string
+		actionURL string
+	}{
+		{
+			name: "github push",
+			card: ghPushCardFrom(t, `{
+				"ref":"refs/heads/main",
+				"compare":"https://github.com/o/r/compare/a...b",
+				"commits":[{"id":"abc1234","message":"ship"}],
+				"repository":{"full_name":"o/r","html_url":"https://github.com/o/r"},
+				"sender":{"login":"alice"}}`),
+			source: "GitHub", context: "o/r", badge: "Push",
+			actionURL: "https://github.com/o/r/compare/a...b",
+		},
+		{
+			name: "gitlab pipeline",
+			card: glPipelineCardFrom(t, `{
+				"object_attributes":{"id":42,"status":"success","ref":"main"},
+				"project":{"path_with_namespace":"g/r","web_url":"https://gitlab.com/g/r"}}`),
+			source: "GitLab", context: "g/r", badge: "success",
+			actionURL: "https://gitlab.com/g/r/-/pipelines/42",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.NotNil(t, tt.card)
+			require.NoError(t, validateVCSCard(tt.card))
+
+			header := cardNodeByID(tt.card, "vcs-header")
+			require.NotNil(t, header)
+			assert.Equal(t, "ColumnSet", header["type"])
+
+			icon := cardNodeByID(tt.card, "vcs-source-icon")
+			require.NotNil(t, icon)
+			assert.Equal(t, expectedVCSGitBranchIcon, icon["url"])
+			assert.Equal(t, "16px", icon["width"])
+			assert.Equal(t, "16px", icon["height"])
+
+			source := cardNodeByID(tt.card, "vcs-source-label")
+			require.NotNil(t, source)
+			assert.Equal(t, tt.source, source["text"])
+			context := cardNodeByID(tt.card, "vcs-source-context")
+			require.NotNil(t, context)
+			assert.Equal(t, tt.context, context["text"])
+
+			badge := cardNodeByID(tt.card, "vcs-event-badge")
+			require.NotNil(t, badge)
+			assert.Equal(t, tt.badge, badge["text"])
+
+			content := cardNodeByID(tt.card, "vcs-content")
+			require.NotNil(t, content)
+			assert.Equal(t, "Container", content["type"])
+			assert.Equal(t, "accent", content["style"])
+			assert.Equal(t, true, content["bleed"])
+
+			headline := cardNodeByID(tt.card, "vcs-headline")
+			require.NotNil(t, headline)
+			assert.NotContains(t, headline, "color", "headline stays neutral; semantic color belongs to the badge")
+
+			footer := cardNodeByID(tt.card, "vcs-footer")
+			require.NotNil(t, footer)
+			assert.Equal(t, "emphasis", footer["style"])
+			assert.Equal(t, true, footer["bleed"])
+			assert.NotContains(t, tt.card, "actions", "navigation is rendered once inside the footer")
+			assert.Equal(t, tt.actionURL, cardActionURL(tt.card))
+		})
+	}
+}
 
 func TestBuildGitHubPushCard(t *testing.T) {
 	card := ghPushCardFrom(t, `{
@@ -300,15 +417,20 @@ func TestBuildGitLabPipelineCard_StatusColor(t *testing.T) {
 	require.NotNil(t, card)
 	require.NoError(t, validateVCSCard(card))
 
-	// success → headline TextBlock carries color=Good; status word lives in the FactSet.
-	body0 := card["body"].([]interface{})[0].(map[string]interface{})
-	assert.Equal(t, "Good", body0["color"])
+	// success → semantic color lives only on the compact status badge.
+	headline := cardNodeByID(card, "vcs-headline")
+	require.NotNil(t, headline)
+	assert.NotContains(t, headline, "color")
+	badge := cardNodeByID(card, "vcs-event-badge")
+	require.NotNil(t, badge)
+	assert.Equal(t, "success", badge["text"])
+	assert.Equal(t, "Good", badge["color"])
 	plain := cardmsg.BuildPlain(card)
 	assert.Contains(t, plain, "Pipeline #4567")
 	assert.Contains(t, plain, "Branch: test")
 	assert.Contains(t, plain, "Status: success")
 	assert.Contains(t, plain, "Duration: 7m 26s", "446s → 7m 26s")
-	assert.Contains(t, plain, "Jobs (5): build / unit / lint / e2e / deploy")
+	assert.Equal(t, "build\nunit\nlint\ne2e\ndeploy", cardFactValue(card, "Jobs (5)"))
 	assert.Equal(t, "https://gitlab.com/grp/app/-/pipelines/4567", cardActionURL(card))
 
 	// Non-terminal statuses are rendered too (no longer filtered to success/failed/canceled).
@@ -319,8 +441,9 @@ func TestBuildGitLabPipelineCard_StatusColor(t *testing.T) {
 			card := glPipelineCardFrom(t, fmt.Sprintf(`{"object_attributes":{"id":1,"status":%q}}`, status))
 			require.NotNil(t, card)
 			require.NoError(t, validateVCSCard(card))
-			body0 := card["body"].([]interface{})[0].(map[string]interface{})
-			assert.Equal(t, "Accent", body0["color"])
+			badge := cardNodeByID(card, "vcs-event-badge")
+			require.NotNil(t, badge)
+			assert.Equal(t, "Accent", badge["color"])
 			// `_` is escaped by escapeCardText (`_` → `\_`); BuildPlain's stripMarkdown
 			// (a real markdown parser) does not fold that back to a bare `_`, so the
 			// plain rendering keeps the backslash — confirmed empirically here.
@@ -334,11 +457,46 @@ func TestBuildGitLabPipelineCard_StatusColor(t *testing.T) {
 	unknown := glPipelineCardFrom(t, `{"object_attributes":{"id":1,"status":"some_future_gitlab_status"}}`)
 	require.NotNil(t, unknown)
 	require.NoError(t, validateVCSCard(unknown))
-	unknownBody0 := unknown["body"].([]interface{})[0].(map[string]interface{})
-	assert.NotContains(t, unknownBody0, "color", "unmapped status keeps the default headline color")
+	unknownBadge := cardNodeByID(unknown, "vcs-event-badge")
+	require.NotNil(t, unknownBadge)
+	assert.NotContains(t, unknownBadge, "color", "unmapped status keeps the default badge color")
 
 	// Missing status (malformed payload, nothing to render) → no card.
 	assert.Nil(t, glPipelineCardFrom(t, `{"object_attributes":{"id":1}}`))
+}
+
+func TestBuildGitLabPipelineCard_UsesEnglishLabelsAndJobLinesForAllLanguages(t *testing.T) {
+	var ev glPipelineEvent
+	require.NoError(t, json.Unmarshal([]byte(`{
+		"object_attributes":{"id":7,"status":"success","ref":"main","duration":42},
+		"project":{"path_with_namespace":"o/r","web_url":"https://gitlab.com/o/r"},
+		"builds":[{"name":"build"},{"name":"unit"},{"name":"deploy"}]
+	}`), &ev))
+
+	for _, lang := range []string{"en-US", "zh-CN"} {
+		t.Run(lang, func(t *testing.T) {
+			card := buildGitLabPipelineCard(&ev, lang)
+			require.NotNil(t, card)
+			require.NoError(t, validateVCSCard(card))
+			assert.Equal(t, "main", cardFactValue(card, "Branch"))
+			assert.Equal(t, "success", cardFactValue(card, "Status"))
+			assert.Equal(t, "42s", cardFactValue(card, "Duration"))
+			assert.Equal(t, "build\nunit\ndeploy", cardFactValue(card, "Jobs (3)"))
+			assert.Empty(t, cardFactValue(card, "分支"))
+			assert.Empty(t, cardFactValue(card, "任务 (3)"))
+		})
+	}
+
+	t.Run("labels keep slash separator", func(t *testing.T) {
+		card := glIssueCardFrom(t, `{
+			"user":{"username":"alice"},
+			"object_attributes":{"iid":1,"title":"bug","url":"https://gitlab.com/o/r/-/issues/1","action":"open"},
+			"labels":[{"title":"backend"},{"title":"needs-review"}],
+			"project":{"path_with_namespace":"o/r"}
+		}`)
+		require.NotNil(t, card)
+		assert.Equal(t, "backend / needs-review", cardFactValue(card, "Labels (2)"))
+	})
 }
 
 func TestFormatPipelineDuration(t *testing.T) {
@@ -500,41 +658,72 @@ func TestGlLabelsFact_OverflowAndEscaping(t *testing.T) {
 	})
 }
 
-// TestAllVCSCardBuilders_Smoke exercises every event-specific builder (the ones only
-// indirectly covered elsewhere: GitHub PR/issues/release, GitLab tag/note) so a
-// regression in any one is caught: card is non-nil, passes the authoritative
-// validator, derives non-empty plain, and carries the expected headline.
+// TestAllVCSCardBuilders_Smoke exercises every event-specific builder so a regression
+// in any one is caught: card is non-nil, passes the authoritative validator, derives
+// non-empty plain, carries the expected headline, and uses the shared Forge anatomy.
 func TestAllVCSCardBuilders_Smoke(t *testing.T) {
 	cases := []struct {
 		name     string
 		build    func(t *testing.T) map[string]interface{}
 		headline string
+		source   string
+		badge    string
 	}{
+		{"gh push", func(t *testing.T) map[string]interface{} {
+			var ev ghPushEvent
+			require.NoError(t, json.Unmarshal([]byte(`{"ref":"refs/heads/main","commits":[{"id":"abc1234","message":"ship"}],"repository":{"full_name":"o/r","html_url":"https://github.com/o/r"},"sender":{"login":"amy"}}`), &ev))
+			return buildGitHubPushCard(&ev, "en-US")
+		}, "amy pushed 1 commit(s)", "GitHub", "Push"},
 		{"gh pull_request opened", func(t *testing.T) map[string]interface{} {
 			var ev ghPullRequestEvent
 			require.NoError(t, json.Unmarshal([]byte(`{"action":"opened","pull_request":{"number":9,"title":"Add cards","html_url":"https://github.com/o/r/pull/9"},"repository":{"full_name":"o/r"},"sender":{"login":"alice"}}`), &ev))
 			return buildGitHubPullRequestCard(&ev, "en-US")
-		}, "alice opened a pull request"},
+		}, "alice opened a pull request", "GitHub", "Pull Request"},
 		{"gh issues closed", func(t *testing.T) map[string]interface{} {
 			var ev ghIssuesEvent
 			require.NoError(t, json.Unmarshal([]byte(`{"action":"closed","issue":{"number":3,"title":"Bug","html_url":"https://github.com/o/r/issues/3"},"repository":{"full_name":"o/r"},"sender":{"login":"bob"}}`), &ev))
 			return buildGitHubIssuesCard(&ev, "en-US")
-		}, "bob closed an issue"},
+		}, "bob closed an issue", "GitHub", "Issue"},
+		{"gh issue comment", func(t *testing.T) map[string]interface{} {
+			var ev ghIssueCommentEvent
+			require.NoError(t, json.Unmarshal([]byte(`{"action":"created","issue":{"number":4,"title":"Bug"},"comment":{"body":"lgtm","html_url":"https://github.com/o/r/issues/4#issuecomment-1"},"repository":{"full_name":"o/r"},"sender":{"login":"bea"}}`), &ev))
+			return buildGitHubIssueCommentCard(&ev, "en-US")
+		}, "bea commented on an issue", "GitHub", "Comment"},
 		{"gh release published", func(t *testing.T) map[string]interface{} {
 			var ev ghReleaseEvent
 			require.NoError(t, json.Unmarshal([]byte(`{"action":"published","release":{"tag_name":"v1.2.0","name":"v1.2.0","html_url":"https://github.com/o/r/releases/v1.2.0"},"repository":{"full_name":"o/r"},"sender":{"login":"carol"}}`), &ev))
 			return buildGitHubReleaseCard(&ev, "en-US")
-		}, "carol published a release"},
+		}, "carol published a release", "GitHub", "Release"},
+		{"gl push", func(t *testing.T) map[string]interface{} {
+			var ev glPushEvent
+			require.NoError(t, json.Unmarshal([]byte(`{"ref":"refs/heads/main","commits":[{"id":"abc123","message":"ship"}],"user_username":"dana","project":{"path_with_namespace":"o/r","web_url":"https://gitlab.com/o/r"}}`), &ev))
+			return buildGitLabPushCard(&ev, "en-US")
+		}, "dana pushed 1 commit(s)", "GitLab", "Push"},
 		{"gl tag push", func(t *testing.T) map[string]interface{} {
 			var ev glPushEvent
 			require.NoError(t, json.Unmarshal([]byte(`{"ref":"refs/tags/v2.0.0","after":"abc123","user_username":"dave","project":{"path_with_namespace":"o/r","web_url":"https://gitlab.com/o/r"}}`), &ev))
 			return buildGitLabTagPushCard(&ev, "en-US")
-		}, "dave pushed tag"},
+		}, "dave pushed tag", "GitLab", "Tag"},
+		{"gl merge request", func(t *testing.T) map[string]interface{} {
+			var ev glMergeRequestEvent
+			require.NoError(t, json.Unmarshal([]byte(`{"user":{"username":"erin"},"object_attributes":{"iid":5,"title":"Refactor","action":"open","url":"https://gitlab.com/o/r/-/merge_requests/5"},"project":{"path_with_namespace":"o/r"}}`), &ev))
+			return buildGitLabMergeRequestCard(&ev, "en-US")
+		}, "erin opened a merge request", "GitLab", "Merge Request"},
+		{"gl issue", func(t *testing.T) map[string]interface{} {
+			var ev glIssueEvent
+			require.NoError(t, json.Unmarshal([]byte(`{"user":{"username":"finn"},"object_attributes":{"iid":6,"title":"Bug","action":"open","url":"https://gitlab.com/o/r/-/issues/6"},"project":{"path_with_namespace":"o/r"}}`), &ev))
+			return buildGitLabIssueCard(&ev, "en-US")
+		}, "finn opened an issue", "GitLab", "Issue"},
 		{"gl note on MR", func(t *testing.T) map[string]interface{} {
 			var ev glNoteEvent
 			require.NoError(t, json.Unmarshal([]byte(`{"user":{"username":"erin"},"object_attributes":{"note":"lgtm","noteable_type":"MergeRequest","url":"https://gitlab.com/o/r/-/merge_requests/5#note_1"},"merge_request":{"iid":5,"title":"Refactor"},"project":{"path_with_namespace":"o/r","web_url":"https://gitlab.com/o/r"}}`), &ev))
 			return buildGitLabNoteCard(&ev, "en-US")
-		}, "erin commented"},
+		}, "erin commented", "GitLab", "Comment"},
+		{"gl pipeline", func(t *testing.T) map[string]interface{} {
+			var ev glPipelineEvent
+			require.NoError(t, json.Unmarshal([]byte(`{"object_attributes":{"id":7,"status":"success","ref":"main"},"project":{"path_with_namespace":"o/r","web_url":"https://gitlab.com/o/r"}}`), &ev))
+			return buildGitLabPipelineCard(&ev, "en-US")
+		}, "Pipeline #7", "GitLab", "success"},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -543,6 +732,8 @@ func TestAllVCSCardBuilders_Smoke(t *testing.T) {
 			require.NoError(t, validateVCSCard(card), "server-built card must pass cardmsg.Validate")
 			assert.NotEmpty(t, cardmsg.BuildPlain(card))
 			assert.Contains(t, cardBodyText(card), c.headline)
+			assert.Equal(t, c.source, cardNodeByID(card, "vcs-source-label")["text"])
+			assert.Equal(t, c.badge, cardNodeByID(card, "vcs-event-badge")["text"])
 		})
 	}
 }
@@ -740,6 +931,7 @@ func TestBuildCardPayload_AdapterEnvelope(t *testing.T) {
 	assert.Equal(t, cardmsg.InteractiveCard.Int(), payload["type"])
 	assert.Equal(t, cardmsg.CardVersion, payload["card_version"])
 	assert.Equal(t, cardmsg.ProfileV1, payload["profile"])
+	assert.NotContains(t, payload, "render_profile", "generic native card requests retain legacy rendering unless their own contract opts in")
 	assert.Equal(t, "sp_1", payload["space_id"], "space_id is server-derived from the webhook row")
 
 	from, _ := payload["from"].(map[string]interface{})
@@ -752,6 +944,41 @@ func TestBuildCardPayload_AdapterEnvelope(t *testing.T) {
 	assert.NotEmpty(t, plain, "Finalize derives an authoritative plain")
 	assert.NotEqual(t, cardmsg.PlaceholderCard, plain, "plain comes from the card body, not the [卡片] fallback")
 	assert.Contains(t, plain, "pushed")
+}
+
+func TestVCSCardEnvelopeSelectsForgeWithoutExposingCallerOverride(t *testing.T) {
+	t.Setenv(cardmsg.EnvEnabled, "1")
+	body := []byte(`{
+		"ref":"refs/heads/main",
+		"commits":[{"id":"abc1234","message":"ship"}],
+		"repository":{"full_name":"o/r","html_url":"https://github.com/o/r"},
+		"sender":{"login":"alice"}
+	}`)
+	req, skip, invalid := parseGitHubPush(ghHeader("push"), body)
+	require.NotNil(t, req, "skip=%q invalid=%q", skip, invalid)
+	require.Equal(t, msgTypeCard, req.MsgType)
+
+	m := &incomingWebhookModel{WebhookID: "iwh_vcs", SpaceID: "sp_1", Name: "VCS"}
+	payload, err := buildCardPayload(m, req, false)
+	require.NoError(t, err)
+	assert.Equal(t, cardmsg.ProfileV1, payload["profile"])
+	assert.Equal(t, cardmsg.RenderProfileOctoChatV1, payload["render_profile"])
+	require.NoError(t, cardmsg.Validate(payload))
+	encoded, err := json.Marshal(payload)
+	require.NoError(t, err)
+	assert.Contains(t, string(encoded), `"render_profile":"octo-chat/v1"`)
+
+	t.Run("native JSON cannot author render profile", func(t *testing.T) {
+		cardJSON, err := json.Marshal(req.Card)
+		require.NoError(t, err)
+		var native pushPayloadReq
+		require.NoError(t, json.Unmarshal([]byte(fmt.Sprintf(
+			`{"msg_type":"card","render_profile":"octo-chat/v1","card":%s}`, cardJSON,
+		)), &native))
+		nativePayload, err := buildCardPayload(m, &native, false)
+		require.NoError(t, err)
+		assert.NotContains(t, nativePayload, "render_profile")
+	})
 }
 
 func TestVCSViewLabel(t *testing.T) {

--- a/modules/incomingwebhook/adapter_card_test.go
+++ b/modules/incomingwebhook/adapter_card_test.go
@@ -872,6 +872,17 @@ func TestVCSPushReq_Degrade(t *testing.T) {
 		assert.NotNil(t, req.Card)
 		assert.Empty(t, req.Content, "card path does not set text content")
 	})
+
+	t.Run("missing semantic content projection → text", func(t *testing.T) {
+		card := map[string]interface{}{
+			"type": "AdaptiveCard", "version": cardmsg.CardVersion,
+			"body": []interface{}{map[string]interface{}{"type": "TextBlock", "text": "headline"}},
+		}
+		require.NoError(t, validateVCSCard(card), "precondition: the generic card shape is valid")
+		req := vcsPushReq("fallback text", card)
+		assert.Empty(t, req.MsgType, "a malformed server-authored VCS anatomy must not reach the card path")
+		assert.Equal(t, "fallback text", req.Content)
+	})
 }
 
 // TestVCSParse_FlagGate covers the top-level dispatch: with the flag off the adapter

--- a/modules/incomingwebhook/adapter_card_test.go
+++ b/modules/incomingwebhook/adapter_card_test.go
@@ -430,7 +430,8 @@ func TestBuildGitLabPipelineCard_StatusColor(t *testing.T) {
 	assert.Contains(t, plain, "Branch: test")
 	assert.Contains(t, plain, "Status: success")
 	assert.Contains(t, plain, "Duration: 7m 26s", "446s → 7m 26s")
-	assert.Equal(t, "build\nunit\nlint\ne2e\ndeploy", cardFactValue(card, "Jobs (5)"))
+	assert.Equal(t, "build  \nunit  \nlint  \ne2e  \ndeploy", cardFactValue(card, "Jobs (5)"),
+		"two spaces before each newline produce CommonMark hard breaks in octo-web")
 	assert.Equal(t, "https://gitlab.com/grp/app/-/pipelines/4567", cardActionURL(card))
 
 	// Non-terminal statuses are rendered too (no longer filtered to success/failed/canceled).
@@ -481,7 +482,8 @@ func TestBuildGitLabPipelineCard_UsesEnglishLabelsAndJobLinesForAllLanguages(t *
 			assert.Equal(t, "main", cardFactValue(card, "Branch"))
 			assert.Equal(t, "success", cardFactValue(card, "Status"))
 			assert.Equal(t, "42s", cardFactValue(card, "Duration"))
-			assert.Equal(t, "build\nunit\ndeploy", cardFactValue(card, "Jobs (3)"))
+			assert.Equal(t, "build  \nunit  \ndeploy", cardFactValue(card, "Jobs (3)"),
+				"raw newlines are CommonMark soft breaks and collapse in browser layout")
 			assert.Empty(t, cardFactValue(card, "分支"))
 			assert.Empty(t, cardFactValue(card, "任务 (3)"))
 		})

--- a/modules/incomingwebhook/adapter_card_test.go
+++ b/modules/incomingwebhook/adapter_card_test.go
@@ -832,7 +832,9 @@ func TestVCSCard_ListMarkerNeutralized(t *testing.T) {
 			"project":{"path_with_namespace":"o/r","web_url":"https://gitlab.com/o/r"}}`)
 		require.NotNil(t, card)
 		require.NoError(t, validateVCSCard(card))
-		headline := card["body"].([]interface{})[0].(map[string]interface{})["text"].(string)
+		headlineNode := cardNodeByID(card, "vcs-headline")
+		require.NotNil(t, headlineNode)
+		headline, _ := headlineNode["text"].(string)
 		assert.True(t, strings.HasPrefix(headline, `\- Security Team`),
 			"a display name starting with '- ' must not open a bullet list in the headline; got %q", headline)
 	})

--- a/modules/incomingwebhook/adapter_card_test.go
+++ b/modules/incomingwebhook/adapter_card_test.go
@@ -985,6 +985,26 @@ func TestVCSCardEnvelopeSelectsForgeWithoutExposingCallerOverride(t *testing.T) 
 	})
 }
 
+func TestVCSCardEnvelopePlainStartsWithEventHeadline(t *testing.T) {
+	t.Setenv(cardmsg.EnvEnabled, "1")
+	body := []byte(`{
+		"object_attributes":{"id":21511,"status":"success","ref":"develop"},
+		"project":{"path_with_namespace":"dmwork/octo-server","web_url":"https://gitlab.com/dmwork/octo-server"}
+	}`)
+	req, skip, invalid := parseGitLabPush(glHeader("Pipeline Hook"), body)
+	require.NotNil(t, req, "skip=%q invalid=%q", skip, invalid)
+	require.Equal(t, msgTypeCard, req.MsgType)
+
+	payload, err := buildCardPayload(
+		&incomingWebhookModel{WebhookID: "iwh_vcs", SpaceID: "sp_1", Name: "VCS"},
+		req,
+		false,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "Pipeline #21511\nBranch: develop\nStatus: success", payload["plain"],
+		"decorative VCS header content must not displace the event headline in notifications and previews")
+}
+
 func TestVCSViewLabel(t *testing.T) {
 	assert.Equal(t, "View on GitHub", vcsViewLabel(cardSourceGitHub, "en-US"))
 	assert.Equal(t, "在 GitHub 查看", vcsViewLabel(cardSourceGitHub, "zh-CN"))

--- a/modules/incomingwebhook/adapter_card_test.go
+++ b/modules/incomingwebhook/adapter_card_test.go
@@ -999,7 +999,7 @@ func TestVCSCardEnvelopeSelectsForgeWithoutExposingCallerOverride(t *testing.T) 
 	})
 }
 
-func TestVCSCardEnvelopePlainStartsWithEventHeadline(t *testing.T) {
+func TestVCSCardEnvelopePlainStartsWithEventHeadlineAndKeepsContext(t *testing.T) {
 	t.Setenv(cardmsg.EnvEnabled, "1")
 	body := []byte(`{
 		"object_attributes":{"id":21511,"status":"success","ref":"develop"},
@@ -1015,8 +1015,8 @@ func TestVCSCardEnvelopePlainStartsWithEventHeadline(t *testing.T) {
 		false,
 	)
 	require.NoError(t, err)
-	assert.Equal(t, "Pipeline #21511\nBranch: develop\nStatus: success", payload["plain"],
-		"decorative VCS header content must not displace the event headline in notifications and previews")
+	assert.Equal(t, "Pipeline #21511\ndmwork/octo-server\nBranch: develop\nStatus: success", payload["plain"],
+		"plain must start with the event headline, retain repository context, and exclude decorative header content")
 }
 
 func TestVCSViewLabel(t *testing.T) {

--- a/modules/incomingwebhook/adapter_card_test.go
+++ b/modules/incomingwebhook/adapter_card_test.go
@@ -988,11 +988,14 @@ func TestVCSCardEnvelopeSelectsForgeWithoutExposingCallerOverride(t *testing.T) 
 		require.NoError(t, err)
 		var native pushPayloadReq
 		require.NoError(t, json.Unmarshal([]byte(fmt.Sprintf(
-			`{"msg_type":"card","render_profile":"octo-chat/v1","card":%s}`, cardJSON,
+			`{"msg_type":"card","render_profile":"octo-chat/v1","plain_projection":{"body":[{"type":"TextBlock","text":"forged"}]},"card":%s}`,
+			cardJSON,
 		)), &native))
+		assert.Nil(t, native.plainProjection, "native JSON cannot select a server-owned plain projection")
 		nativePayload, err := buildCardPayload(m, &native, false)
 		require.NoError(t, err)
 		assert.NotContains(t, nativePayload, "render_profile")
+		assert.NotEqual(t, "forged", nativePayload["plain"])
 	})
 }
 

--- a/modules/incomingwebhook/adapter_github.go
+++ b/modules/incomingwebhook/adapter_github.go
@@ -552,11 +552,13 @@ func buildGitHubPushCard(ev *ghPushEvent, lang string) map[string]interface{} {
 	d := vcsCardData{
 		source:   cardSourceGitHub,
 		variant:  "vcs.github.push",
+		badge:    "Push",
 		subtitle: escapeCardText(ev.Repository.FullName, cardTitleMax),
 		url:      ghRepoURLCard(ev.Compare, ev.Repository),
 	}
 	switch {
 	case strings.HasPrefix(ev.Ref, "refs/tags/"):
+		d.badge = "Tag"
 		if ev.Deleted {
 			d.headline = fmt.Sprintf("%s deleted tag %s", who, ref)
 		} else {
@@ -618,6 +620,7 @@ func buildGitHubPullRequestCard(ev *ghPullRequestEvent, lang string) map[string]
 	return vcsCardData{
 		source:   cardSourceGitHub,
 		variant:  "vcs.github.pull_request",
+		badge:    "Pull Request",
 		headline: headline,
 		subtitle: escapeCardText(ev.Repository.FullName, cardTitleMax),
 		lines:    []string{numberedTitle("#", ev.PullRequest.Number, ev.PullRequest.Title)},
@@ -638,6 +641,7 @@ func buildGitHubIssuesCard(ev *ghIssuesEvent, lang string) map[string]interface{
 	return vcsCardData{
 		source:   cardSourceGitHub,
 		variant:  "vcs.github.issues",
+		badge:    "Issue",
 		headline: fmt.Sprintf("%s %s an issue", ghActorCard(ev.Sender), escapeCardText(verb, cardActorMax)),
 		subtitle: escapeCardText(ev.Repository.FullName, cardTitleMax),
 		lines:    []string{numberedTitle("#", ev.Issue.Number, ev.Issue.Title)},
@@ -669,6 +673,7 @@ func buildGitHubIssueCommentCard(ev *ghIssueCommentEvent, lang string) map[strin
 	d := vcsCardData{
 		source:   cardSourceGitHub,
 		variant:  "vcs.github.issue_comment",
+		badge:    "Comment",
 		headline: fmt.Sprintf("%s %s an issue", ghActorCard(ev.Sender), escapeCardText(verb, cardActorMax)),
 		subtitle: escapeCardText(ev.Repository.FullName, cardTitleMax),
 		lines:    []string{numberedTitle("#", ev.Issue.Number, ev.Issue.Title)},
@@ -692,6 +697,7 @@ func buildGitHubReleaseCard(ev *ghReleaseEvent, lang string) map[string]interfac
 	return vcsCardData{
 		source:   cardSourceGitHub,
 		variant:  "vcs.github.release",
+		badge:    "Release",
 		headline: fmt.Sprintf("%s %s a release", ghActorCard(ev.Sender), escapeCardText(verb, cardActorMax)),
 		subtitle: escapeCardText(ev.Repository.FullName, cardTitleMax),
 		lines:    []string{escapeCardText(title, cardTitleMax)},

--- a/modules/incomingwebhook/adapter_gitlab.go
+++ b/modules/incomingwebhook/adapter_gitlab.go
@@ -525,6 +525,7 @@ func buildGitLabPushCard(ev *glPushEvent, lang string) map[string]interface{} {
 	d := vcsCardData{
 		source:   cardSourceGitLab,
 		variant:  "vcs.gitlab.push",
+		badge:    "Push",
 		subtitle: escapeCardText(ev.Project.PathWithNamespace, cardTitleMax),
 		url:      httpURLForCard(ev.Project.WebURL),
 	}
@@ -561,6 +562,7 @@ func buildGitLabTagPushCard(ev *glPushEvent, lang string) map[string]interface{}
 	return vcsCardData{
 		source:   cardSourceGitLab,
 		variant:  "vcs.gitlab.tag_push",
+		badge:    "Tag",
 		headline: headline,
 		subtitle: escapeCardText(ev.Project.PathWithNamespace, cardTitleMax),
 		url:      httpURLForCard(ev.Project.WebURL),
@@ -588,6 +590,7 @@ func buildGitLabMergeRequestCard(ev *glMergeRequestEvent, lang string) map[strin
 	return vcsCardData{
 		source:   cardSourceGitLab,
 		variant:  "vcs.gitlab.merge_request",
+		badge:    "Merge Request",
 		headline: fmt.Sprintf("%s %s a merge request", glActorCard(ev.User.Username, ev.User.Name), escapeCardText(verb, cardActorMax)),
 		subtitle: escapeCardText(ev.Project.PathWithNamespace, cardTitleMax),
 		lines:    []string{numberedTitle("!", ev.ObjectAttributes.IID, ev.ObjectAttributes.Title)},
@@ -608,6 +611,7 @@ func buildGitLabIssueCard(ev *glIssueEvent, lang string) map[string]interface{} 
 	return vcsCardData{
 		source:   cardSourceGitLab,
 		variant:  "vcs.gitlab.issue",
+		badge:    "Issue",
 		headline: fmt.Sprintf("%s %s an issue", glActorCard(ev.User.Username, ev.User.Name), escapeCardText(verb, cardActorMax)),
 		subtitle: escapeCardText(ev.Project.PathWithNamespace, cardTitleMax),
 		lines:    []string{numberedTitle("#", ev.ObjectAttributes.IID, ev.ObjectAttributes.Title)},
@@ -652,6 +656,7 @@ func buildGitLabNoteCard(ev *glNoteEvent, lang string) map[string]interface{} {
 	return vcsCardData{
 		source:   cardSourceGitLab,
 		variant:  "vcs.gitlab.note",
+		badge:    "Comment",
 		headline: fmt.Sprintf("%s commented", glActorCard(ev.User.Username, ev.User.Name)),
 		subtitle: escapeCardText(ev.Project.PathWithNamespace, cardTitleMax),
 		lines:    []string{target},
@@ -679,7 +684,7 @@ func buildGitLabPipelineCard(ev *glPipelineEvent, lang string) map[string]interf
 		for i, b := range ev.Builds {
 			names[i] = b.Name
 		}
-		if value, n := cappedFactValue(names, maxRenderedJobs); n > 0 {
+		if value, n := cappedPipelineJobsValue(names, maxRenderedJobs); n > 0 {
 			facts = append(facts, vcsFact{title: fmt.Sprintf("%s (%d)", labels.jobs, n), value: value})
 		}
 	}
@@ -688,12 +693,13 @@ func buildGitLabPipelineCard(ev *glPipelineEvent, lang string) map[string]interf
 		url = fmt.Sprintf("%s/-/pipelines/%d", strings.TrimRight(p, "/"), ev.ObjectAttributes.ID)
 	}
 	return vcsCardData{
-		source:   cardSourceGitLab,
-		variant:  "vcs.gitlab.pipeline",
-		headline: fmt.Sprintf("Pipeline #%d", ev.ObjectAttributes.ID),
-		status:   pipelineStatusColor(ev.ObjectAttributes.Status),
-		subtitle: escapeCardText(ev.Project.PathWithNamespace, cardTitleMax),
-		facts:    facts,
-		url:      url,
+		source:     cardSourceGitLab,
+		variant:    "vcs.gitlab.pipeline",
+		badge:      escapeCardText(ev.ObjectAttributes.Status, cardActorMax),
+		badgeColor: pipelineStatusColor(ev.ObjectAttributes.Status),
+		headline:   fmt.Sprintf("Pipeline #%d", ev.ObjectAttributes.ID),
+		subtitle:   escapeCardText(ev.Project.PathWithNamespace, cardTitleMax),
+		facts:      facts,
+		url:        url,
 	}.card(lang)
 }

--- a/modules/incomingwebhook/card.go
+++ b/modules/incomingwebhook/card.go
@@ -55,6 +55,12 @@ func buildCardPayload(m *incomingWebhookModel, req *pushPayloadReq, allowOverrid
 		// space_id 由服务端从 group 派生，不接受调用方覆盖（与 buildPayload 一致）。
 		"space_id": m.SpaceID,
 	}
+	// renderProfile is intentionally package-internal: server-authored producers
+	// may opt into a renderer contract, while native request JSON cannot forge or
+	// override it. Add it before both authoritative validation passes.
+	if req.renderProfile != "" {
+		payload["render_profile"] = req.renderProfile
+	}
 	if err := cardmsg.Validate(payload); err != nil {
 		return nil, err
 	}

--- a/modules/incomingwebhook/card.go
+++ b/modules/incomingwebhook/card.go
@@ -26,7 +26,9 @@ var errCardDisabled = errors.New("incomingwebhook: card messages disabled")
 //     card_version/profile（服务端钉 octo/v1，不接受调用方覆盖 —— 与丢弃
 //     req.Extra 的安全基线一致）、from.kind=webhook、服务端派生 space_id；
 //   - cardmsg.Validate：白名单/大小/URL/树上限 write-strict（与 bot ingress
-//     同一权威）；cardmsg.Finalize：重算权威 plain + 完整出站 payload 复检；
+//     同一权威）；cardmsg.Finalize：重算默认权威 plain + 完整出站 payload 复检；
+//     服务端 VCS 生产者可通过不可由 JSON 构造的 plainProjection，把 plain 收口到
+//     已校验卡片的语义内容区，排除纯视觉 header；投影覆盖后再次复检出站大小；
 //   - Decision 8 `text` 种子语义：仅当派生 plain 为空（= [卡片] 兜底）且调用方
 //     给了 text 时，用 text 作 plain（rune 上限与纯文本路径一致）；卡片 body
 //     产出文本时 text 被忽略 —— 派生始终权威。种子覆盖发生在 Finalize 复检之后、
@@ -66,6 +68,12 @@ func buildCardPayload(m *incomingWebhookModel, req *pushPayloadReq, allowOverrid
 	}
 	if err := cardmsg.Finalize(payload); err != nil {
 		return nil, err
+	}
+	if req.plainProjection != nil {
+		payload["plain"] = cardmsg.BuildPlain(req.plainProjection)
+		if err := cardmsg.RecheckPayloadSize(payload); err != nil {
+			return nil, err
+		}
 	}
 	if payload["plain"] == cardmsg.PlaceholderCard {
 		seed := req.Text

--- a/modules/incomingwebhook/model.go
+++ b/modules/incomingwebhook/model.go
@@ -122,6 +122,10 @@ type pushPayloadReq struct {
 	// 目前只有通过 vcsPushReq 构造的 GitHub/GitLab 卡片会设置它；原生
 	// msg_type:"card" 调用方即使提交同名 JSON 字段也无法写入。
 	renderProfile string
+	// plainProjection 是服务端 VCS 生产者从已校验卡片的语义内容区提取的
+	// plain 投影，不对请求 JSON 开放。它排除新 Forge header 的装饰图标、来源和
+	// badge，避免这些视觉元素取代事件 headline 成为推送/会话预览首行。
+	plainProjection map[string]interface{}
 
 	Username  string                 `json:"username,omitempty"`
 	AvatarURL string                 `json:"avatar_url,omitempty"`

--- a/modules/incomingwebhook/model.go
+++ b/modules/incomingwebhook/model.go
@@ -117,7 +117,12 @@ type pushPayloadReq struct {
 	// Card 是 msg_type:"card" 的标准 Adaptive Cards 1.5 JSON（octo/v1 白名单
 	// 子集，card-message-protocol P1）。Text 在 card 形态下是可选 plain 种子
 	// （仅当卡片派生 plain 为空时使用，Decision 8）。
-	Card      map[string]interface{} `json:"card,omitempty"`
+	Card map[string]interface{} `json:"card,omitempty"`
+	// renderProfile 是服务端生产者专用的视觉契约选择，不对请求 JSON 开放。
+	// 目前只有通过 vcsPushReq 构造的 GitHub/GitLab 卡片会设置它；原生
+	// msg_type:"card" 调用方即使提交同名 JSON 字段也无法写入。
+	renderProfile string
+
 	Username  string                 `json:"username,omitempty"`
 	AvatarURL string                 `json:"avatar_url,omitempty"`
 	Extra     map[string]interface{} `json:"extra,omitempty"`

--- a/pkg/cardmsg/inline_image.go
+++ b/pkg/cardmsg/inline_image.go
@@ -39,13 +39,19 @@ package cardmsg
 const (
 	chevronDownIcon = "data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%221em%22%20height%3D%221em%22%20viewBox%3D%220%200%2024%2024%22%3E%3Cpath%20fill%3D%22none%22%20stroke%3D%22%23a1a6ab%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20stroke-width%3D%222%22%20d%3D%22m6%209l6%206l6-6%22%2F%3E%3C%2Fsvg%3E"
 	chevronUpIcon   = "data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%221em%22%20height%3D%221em%22%20viewBox%3D%220%200%2024%2024%22%3E%3Cpath%20fill%3D%22none%22%20stroke%3D%22%23a1a6ab%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20stroke-width%3D%222%22%20d%3D%22m18%2015l-6-6l-6%206%22%2F%3E%3C%2Fsvg%3E"
+
+	// VCSGitBranchIcon is Lucide git-branch@0.577.0, minified and URL-encoded
+	// after changing its 24px size to 16px and currentColor to the fixed neutral
+	// Forge header stroke #6b7075. NOTICE carries the upstream license text.
+	VCSGitBranchIcon = "data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20viewBox%3D%220%200%2024%2024%22%20fill%3D%22none%22%20stroke%3D%22%236b7075%22%20stroke-width%3D%222%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%3E%3Cpath%20d%3D%22M15%206a9%209%200%200%200-9%209V3%22%2F%3E%3Ccircle%20cx%3D%2218%22%20cy%3D%226%22%20r%3D%223%22%2F%3E%3Ccircle%20cx%3D%226%22%20cy%3D%2218%22%20r%3D%223%22%2F%3E%3C%2Fsvg%3E"
 )
 
 // vettedInlineImages 是允许出现在图片类 URL 字段上的内联图，按完整字节索引。
 // 只读，进程生命周期内不变 —— 没有注册接口，加图标必须改这份源码。
 var vettedInlineImages = map[string]struct{}{
-	chevronDownIcon: {},
-	chevronUpIcon:   {},
+	chevronDownIcon:  {},
+	chevronUpIcon:    {},
+	VCSGitBranchIcon: {},
 }
 
 // isVettedInlineImage 报告 raw 是否与某个审过的内联图逐字节相同。

--- a/pkg/cardmsg/inline_image_test.go
+++ b/pkg/cardmsg/inline_image_test.go
@@ -8,6 +8,10 @@ import (
 	"testing"
 )
 
+// Lucide git-branch@0.577.0，缩到 16px 并把 currentColor 固定为 Forge
+// header 使用的中性色。生产常量必须与这串审过的字节逐字节一致。
+const vcsGitBranchIconForTest = "data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20viewBox%3D%220%200%2024%2024%22%20fill%3D%22none%22%20stroke%3D%22%236b7075%22%20stroke-width%3D%222%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%3E%3Cpath%20d%3D%22M15%206a9%209%200%200%200-9%209V3%22%2F%3E%3Ccircle%20cx%3D%2218%22%20cy%3D%226%22%20r%3D%223%22%2F%3E%3Ccircle%20cx%3D%226%22%20cy%3D%2218%22%20r%3D%223%22%2F%3E%3C%2Fsvg%3E"
+
 func inlineSVG(svg string) string {
 	return "data:image/svg+xml," + url.QueryEscape(svg)
 }
@@ -61,6 +65,30 @@ func TestInlineImageAllowlistIsExactBytes(t *testing.T) {
 			card := cardWithBody(map[string]interface{}{"type": "Image", "url": tc.raw})
 			if err := Validate(envelope(card)); !errors.Is(err, ErrCardBadURLScheme) {
 				t.Fatalf("未审过的字节应被拒 (%s), err=%v", tc.name, err)
+			}
+		})
+	}
+}
+
+func TestVCSGitBranchIconIsExactVettedImage(t *testing.T) {
+	card := cardWithBody(map[string]interface{}{"type": "Image", "url": vcsGitBranchIconForTest})
+	if err := Validate(envelope(card)); err != nil {
+		t.Fatalf("reviewed VCS git-branch icon should pass Image.url validation: %v", err)
+	}
+
+	for _, tc := range []struct {
+		name string
+		uri  string
+	}{
+		{name: "one byte mutation", uri: strings.Replace(vcsGitBranchIconForTest, "%236b7075", "%236b7076", 1)},
+		{name: "leading whitespace", uri: " " + vcsGitBranchIconForTest},
+		{name: "appended content", uri: vcsGitBranchIconForTest + "%3Cscript%3E"},
+		{name: "base64 re-encoding", uri: "data:image/svg+xml;base64," + base64.StdEncoding.EncodeToString([]byte(`<svg viewBox="0 0 24 24"/>`))},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			card := cardWithBody(map[string]interface{}{"type": "Image", "url": tc.uri})
+			if err := Validate(envelope(card)); !errors.Is(err, ErrCardBadURLScheme) {
+				t.Fatalf("non-vetted VCS icon bytes should be rejected, err=%v", err)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

Align server-authored GitHub and GitLab incoming-webhook cards with octo-web's Forge visual language while preserving the existing event, trust, URL, fallback, and delivery contracts.

The cards now use a compact source header, neutral Lucide VCS icon, semantic badge, accent content surface, and inline navigation footer. VCS envelopes opt into `octo-chat/v1`, and their authoritative `plain` is projected from semantic content so notifications and conversation previews still start with the event headline.

Rollout and rollback continue to use the existing `OCTO_CARD_MESSAGE_ENABLED` gate; no schema or historical-message migration is required.

## Related Issue

N/A

## Linked Spec

[`.octospec/tasks/vcs-webhook-card-forge-align/brief.md`](.octospec/tasks/vcs-webhook-card-forge-align/brief.md)

## Changes

- Apply one shared Forge header/content/footer anatomy to all current GitHub and GitLab card builders, including neutral Pipeline headlines, semantic badges, English Pipeline fact labels, and one job per rendered line.
- Add the reviewed Lucide `git-branch` SVG to the exact-byte inline-image allowlist and ship the required ISC/Feather MIT attribution without broadening `data:` URI acceptance.
- Keep `render_profile` and the VCS `plain` projection server-owned and non-JSON; native `msg_type:"card"` callers cannot select either behavior.
- Preserve HTTP(S) URL validation, hostile-input escaping, card-to-text degradation, flag-off text bytes, and payload-size rechecks.

## Testing

- [x] Unit tests added/updated
- [x] Manually verified — the requester reviewed the octo-web rendering and confirmed the final result
- `go test ./modules/incomingwebhook/... ./pkg/cardmsg/... -count=1`
- `go test -race ./modules/incomingwebhook/... ./pkg/cardmsg/... -count=1`
- `golangci-lint run ./pkg/cardmsg/... ./modules/incomingwebhook/...`
- Coverage: `modules/incomingwebhook` 85.3%, `pkg/cardmsg` 84.4%
- `git diff --check origin/main...HEAD`

Local `go test ./...` was attempted but is not claimed as passing evidence: package-level integration tests share a hard-coded MySQL `test` schema and raced migrations locally (`unknown migration` / `table already exists`). The affected packages above passed independently against the local MySQL, Redis, and WuKongIM test services; CI will run the repository suite with isolated services.

## COMPREHENSION

1. **What does this change actually do** to the load-bearing path?

   GitHub/GitLab webhook payloads still pass through the same bounded escaping and HTTP(S) URL gates, but the server-owned VCS card assembler now emits the Forge anatomy and selects `render_profile:"octo-chat/v1"`. The exact vetted icon is accepted only as an `Image.url`. After normal card validation/finalization, the outgoing VCS `plain` is re-derived from the already-validated `vcs-content` projection and size-checked again, preventing decorative header content from replacing the event headline in previews.

2. **What could break** because of it (dependents + failure mode)?

   An older client without `octo-chat/v1` support could show its existing unsupported/fallback behavior. Any byte drift in the inline SVG or invalid card anatomy will fail closed and degrade that webhook delivery to the historical text payload. If the server-owned `vcs-content` marker is accidentally removed, VCS construction also degrades to text. Native cards, docs/AI templates, callback actions, persistence, and non-VCS webhook adapters do not opt into these paths.

3. **How do you know it works** (specific test/repro/trace)?

   Tests cover all 11 VCS builders, the shared Forge anatomy, exact/mutated SVG acceptance, hostile markdown and URL cases, `render_profile` ownership, flag-off and invalid-card degradation, Pipeline hard breaks, and the final production envelope plain (`Pipeline #21511` is the first line with no `[图片]`/source/badge prefix). Relevant full package tests, race tests, coverage, lint, and diff checks pass after rebasing onto current `origin/main`.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] PR description is in English
- [x] Added tests for my changes
- [x] Updated documentation
- [x] Followed commit message conventions (Conventional Commits)
