### PR TITLE
fix(user): harden scan login authorization

### DIFF
--- a/.octospec/journal/shared/scan-login-authorization.md
+++ b/.octospec/journal/shared/scan-login-authorization.md
@@ -29,11 +29,23 @@ source: self
   push latency, ambiguous Redis outcomes, consume-first response loss, mixed
   versions, the System Settings reload window, and the OIDC-only production
   requirement to keep scan login disabled.
+- Review follow-up changed the absent-setting default to disabled. An
+  uninitialized System Settings snapshot is represented by nil and fails closed;
+  a successful empty snapshot also stays disabled, while explicit `1` enables
+  the flow. This permits the server to ship before the Web redemption call sends
+  `poll_secret`.
+- Added `scanlogin:claim:{uuid}` to promotion, rollback, and consumption. Lua
+  scripts now allow only one auth code to claim a browser QR session and retain
+  a consumed marker for five minutes. Sequential scans after `waitScan` are
+  rejected; concurrent scans may mint pending codes, but only one can promote.
+- Extended application access/recovery-log scrubbing to the `grant_login`
+  `auth_code` and Signal `encrypt` query values.
 
 ## Verification
 
 - `go test ./modules/user -run 'Test(ScanLogin|LoginWithAuthCode|GrantLogin|GetLogin)' -count=1`
-- `go test -race ./modules/user -run 'Test(ScanLoginRedemptionAuditWarnsOnlyWhenLoginIsIncomplete|ScanLoginAuthorization_(PromoteAndConsumeAreAtomic|RollbackPromotionRestoresPending|MultipleReplicasRedeemOnce)|ScanLoginRateLimitsRejectNonFiniteRPSConfig)$' -count=1`
+- `go test ./modules/user -count=1`
+- `go test -race ./modules/user -run 'TestScanLoginAuthorization_(PromoteAndConsumeAreAtomic|UUIDClaimAllowsOnlyOneAuthorization|RollbackPromotionRestoresPending|MultipleReplicasRedeemOnce|MultipleAuthCodesForOneUUIDRedeemOnce)$' -count=1`
 - `go test ./modules/qrcode -count=1`
 - `go test ./modules/common -run 'Test(GetAppConfig_ScanLogin|SystemSettings_ScanLogin)' -count=1`
 - `go test ./pkg/accesslog -count=1`
@@ -52,6 +64,13 @@ full-package run.
 - Correctness must live in shared Redis state; process-local QR push channels
   are latency optimizations only. An in-flight poll on another replica can still
   wait for its 10-second timeout.
+- Atomicity per auth code is not atomicity per browser session. When multiple
+  credentials share one UUID and one browser secret, the UUID itself must have
+  a shared claim and consumed state.
+- A required client parameter makes a default-on server rollout incompatible
+  even if the server API is additive. Default the gate off until the last
+  consumer is verified; do not add a fail-open compatibility branch to an auth
+  credential check.
 - Consume-first is the safe replay posture, but a downstream failure burns the
   authorization. Clients must restart the complete scan flow rather than retry
   the same credential.
@@ -67,6 +86,7 @@ full-package run.
   ingress, CDN, and APM URL logs must redact it.
 - Other `ParseRPSFromEnv` call sites still need a repository-wide finite-number
   hardening change; this task sanitizes only the two scan-login endpoints.
-- OIDC-only production must pre-create `login.scan_enabled=false`. Old binaries
-  ignore the key, so mixed-version deployment and rollback require an ingress
-  block or blue/green cutover.
+- Scan login now defaults to disabled. OIDC-only production should still
+  explicitly persist `login.scan_enabled=false` for operational clarity. Old
+  binaries ignore the key, so mixed-version deployment and rollback require an
+  ingress block or blue/green cutover.

--- a/.octospec/journal/shared/scan-login-authorization.md
+++ b/.octospec/journal/shared/scan-login-authorization.md
@@ -1,0 +1,72 @@
+---
+type: Journal
+title: "Journal: scan-login-authorization"
+description: Record of the deployment-wide scan-login policy gate and explicit, browser-bound, one-shot authorization flow.
+tags: [auth, security, qrcode, wire-contract, multi-instance, redis, rate-limit]
+timestamp: 2026-08-09T13:25:48+08:00
+task: scan-login-authorization
+source: self
+---
+
+# Journal: scan-login-authorization
+
+## What was done
+
+- Added DB-backed System Setting `login.scan_enabled`, exposed it as
+  `scan_login_enabled`, and enforced it at QR creation, scan, confirmation,
+  polling, and redemption.
+- Split scan from authorization: scan creates a non-redeemable pending record;
+  authenticated `grant_login` atomically promotes it only after the scanner is
+  verified. Redemption atomically consumes the exact ready record before login
+  side effects, so concurrent replicas cannot issue two sessions.
+- Bound polling and redemption to a browser-only `poll_secret`, stored as a
+  digest and redacted from application access/recovery logs. Unauthorized
+  pollers receive only allow-listed public state.
+- Added finite-value sanitization to the two scan-login limiter configurations,
+  rollback of failed QR-state publication, and an audit warning when a consumed
+  authorization does not complete login.
+- Documented the client and rollout contract, including process-local status
+  push latency, ambiguous Redis outcomes, consume-first response loss, mixed
+  versions, the System Settings reload window, and the OIDC-only production
+  requirement to keep scan login disabled.
+
+## Verification
+
+- `go test ./modules/user -run 'Test(ScanLogin|LoginWithAuthCode|GrantLogin|GetLogin)' -count=1`
+- `go test -race ./modules/user -run 'Test(ScanLoginRedemptionAuditWarnsOnlyWhenLoginIsIncomplete|ScanLoginAuthorization_(PromoteAndConsumeAreAtomic|RollbackPromotionRestoresPending|MultipleReplicasRedeemOnce)|ScanLoginRateLimitsRejectNonFiniteRPSConfig)$' -count=1`
+- `go test ./modules/qrcode -count=1`
+- `go test ./modules/common -run 'Test(GetAppConfig_ScanLogin|SystemSettings_ScanLogin)' -count=1`
+- `go test ./pkg/accesslog -count=1`
+- `go build ./...`
+- `go vet ./modules/user ./modules/qrcode ./modules/common ./pkg/accesslog`
+- `make i18n-extract-check` and `make i18n-lint`
+
+The full `modules/common` package reached MySQL's existing 151-connection limit
+in `TestManagerSystemSetting_OrderingRejectsFromThreadSide`. The focused
+scan-login common tests pass against a freshly created `test` database using
+`utf8mb4_general_ci`; this infrastructure limitation is not reported as a green
+full-package run.
+
+## Learnings and gotchas
+
+- Correctness must live in shared Redis state; process-local QR push channels
+  are latency optimizations only. An in-flight poll on another replica can still
+  wait for its 10-second timeout.
+- Consume-first is the safe replay posture, but a downstream failure burns the
+  authorization. Clients must restart the complete scan flow rather than retry
+  the same credential.
+- Redis write errors are outcome-ambiguous. Compensation must handle the case
+  where the server committed the QR state before the caller observed an error.
+- Test packages with different embedded migration sets must not share one
+  concurrently mutated test database. Recreate the `test` schema with
+  `utf8mb4_general_ci` between incompatible package runs.
+
+## Residuals and rollout
+
+- `poll_secret` remains in the query string for current CORS compatibility;
+  ingress, CDN, and APM URL logs must redact it.
+- Other `ParseRPSFromEnv` call sites still need a repository-wide finite-number
+  hardening change; this task sanitizes only the two scan-login endpoints.
+- OIDC-only production must pre-create `login.scan_enabled=false`. Old binaries
+  ignore the key, so mixed-version deployment and rollback require an ingress
+  block or blue/green cutover.

--- a/.octospec/learnings/pending/scan-login-authorization.md
+++ b/.octospec/learnings/pending/scan-login-authorization.md
@@ -1,0 +1,49 @@
+---
+type: Learning
+title: "Redis write errors have ambiguous outcomes"
+description: A client-observed Redis error does not prove the write was absent, so compensation must preserve safety under both committed and uncommitted outcomes.
+tags: [redis, auth, compensation, distributed-systems, client-contract]
+timestamp: 2026-08-09T13:25:48+08:00
+source: self
+origin_task: scan-login-authorization
+status: pending
+candidate_rule: error-handling
+---
+
+# Redis write errors have ambiguous outcomes
+
+## Context
+
+Scan-login confirmation first promotes a pending authorization into a
+redeemable record, then publishes the `authed` QR state. If the QR-state Redis
+write reports an error, the server rolls the authorization back to pending.
+
+The error does not prove that Redis rejected the write. A connection reset or
+timeout can happen after Redis committed it, leaving the QR state as `authed`
+while the authorization is pending again. Treating the error as proof of
+non-commit would make the compensation model and client state machine incorrect.
+
+## Rule of thumb
+
+For a remote write followed by compensation:
+
+1. Model both outcomes behind an error: not committed and committed but the
+   response was lost.
+2. Choose compensation that preserves the security invariant in both outcomes.
+   Here, non-redeemability wins even if the visible QR state is temporarily stale.
+3. Do not let a displayed terminal state be the authority for credential
+   issuance; re-check the shared authorization record at redemption.
+4. Document the recovery contract. A client receiving a failed or ambiguous
+   confirmation/redemption must restart the complete flow rather than replaying
+   a possibly consumed credential.
+5. Add observability for partial completion without logging credentials or
+   turning the safe denial into a fail-open retry path.
+
+## Why worth a rule
+
+The pattern is not Redis-specific: any networked store can commit a request and
+lose its response. Authentication, payment, and job-claim flows are especially
+likely to add compensation that is safe only under the uncommitted branch unless
+this ambiguity is made explicit during design and review.
+
+Promotion into `.octospec/rules/` requires a separate reviewed change.

--- a/.octospec/log.md
+++ b/.octospec/log.md
@@ -4,6 +4,25 @@ Change history for this repo's `.octospec/`, following the
 [OKF](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md)
 change-log convention (§7). Newest first.
 
+## 2026-08-09 (scan-login-authorization)
+
+- **Task** — `scan-login-authorization`: added a deployment-wide
+  `login.scan_enabled` policy gate, split scan from explicit confirmation, bound
+  redemption to the browser-issued `poll_secret`, and made confirmation and
+  redemption atomic across replicas. Anonymous polling exposes credential fields
+  only to the matching browser and keeps strict per-IP limits; non-finite scan
+  limiter values fall back to finite defaults. Incomplete post-consume login work
+  emits a bounded warning, while failed QR-state publication restores the pending
+  confirmation without overwriting a newer attempt. The OIDC-only production
+  rollout keeps scan login disabled before new binaries start and blocks the
+  routes during any old/new mixed-version or rollback window. See
+  [journal](journal/shared/scan-login-authorization.md).
+- **Learning (pending)** —
+  [redis-write-errors-have-ambiguous-outcomes](learnings/pending/scan-login-authorization.md):
+  a Redis write error does not prove the write was absent; compensation and
+  clients must tolerate the committed-write/error-response branch without
+  reopening an authentication credential.
+
 ## 2026-08-07 (reminder-sync-membership-scope)
 
 - **Task** — `reminder-sync-membership-scope`: `POST /v1/message/reminder/sync`

--- a/.octospec/log.md
+++ b/.octospec/log.md
@@ -9,7 +9,11 @@ change-log convention (§7). Newest first.
 - **Task** — `scan-login-authorization`: added a deployment-wide
   `login.scan_enabled` policy gate, split scan from explicit confirmation, bound
   redemption to the browser-issued `poll_secret`, and made confirmation and
-  redemption atomic across replicas. Anonymous polling exposes credential fields
+  redemption atomic across replicas. Review follow-up added a per-UUID claim so
+  different auth codes for one displayed QR cannot both become redeemable,
+  made the rollout gate default disabled and fail closed before the first
+  successful settings load, and scrubbed confirmation credentials from logs.
+  Anonymous polling exposes credential fields
   only to the matching browser and keeps strict per-IP limits; non-finite scan
   limiter values fall back to finite defaults. Incomplete post-consume login work
   emits a bounded warning, while failed QR-state publication restores the pending

--- a/.octospec/tasks/scan-login-authorization/brief.md
+++ b/.octospec/tasks/scan-login-authorization/brief.md
@@ -14,8 +14,8 @@ source: self
 
 Make the server the policy authority for scan login.
 
-Add the DB-backed System Setting `login.scan_enabled`, defaulting to `true` for
-backward compatibility, and expose it as `scan_login_enabled` from both
+Add the DB-backed System Setting `login.scan_enabled`, defaulting to `false` for
+a safe server-first rollout, and expose it as `scan_login_enabled` from both
 `GET /v1/common/appconfig` response branches. When the setting is `false`, the
 server must reject creation, scanning, confirmation, and redemption of scan-login
 sessions; status polling must return an explicit `disabled` state.
@@ -35,11 +35,14 @@ session's existing `poll_secret` and must be atomic and one-shot.
 - `error-response` — disabled entry points use the localized error envelope and
   one registered user error code.
 - `system-settings` — `login.scan_enabled` is hot-reloaded from the shared
-  snapshot and defaults to enabled when absent.
+  snapshot, fails closed before the first successful load, and defaults to
+  disabled when absent. Later reload failures retain the last good snapshot.
 - `multi-instance` — pending promotion and final consumption use shared Redis;
-  atomicity must hold across replicas and concurrent requests.
+  atomicity must hold across replicas, concurrent requests, and different auth
+  codes minted for the same QR UUID.
 - `secret-handling` — `poll_secret` remains hashed at rest, is required for
-  redemption, and must stay redacted from access and recovery logs.
+  redemption, and must stay redacted from access and recovery logs. The
+  `grant_login` query parameters `auth_code` and `encrypt` are redacted too.
 - `rate-limit` — existing strict per-IP limits on anonymous scan-login endpoints
   remain in place, and non-finite RPS environment values fall back to safe
   defaults instead of degrading the Redis limiter into fail-open behavior.
@@ -47,13 +50,15 @@ session's existing `poll_secret` and must be atomic and one-shot.
 ## State model
 
 1. `loginuuid` creates the QR state and a browser-only `poll_secret`.
-2. Scanning creates a pending authorization tied to scanner UID and QR UUID. The
-   QR state becomes `scanned` and contains no UID or redeemable credential.
+2. Scanning a `waitScan` QR creates a pending authorization tied to scanner UID
+   and QR UUID. The QR state becomes `scanned` and contains no UID or redeemable
+   credential; sequential re-scans are rejected.
 3. `grant_login` verifies the authenticated scanner and atomically promotes the
-   pending record into a redeemable authorization. The QR state becomes `authed`.
+   pending record into a redeemable authorization while claiming the QR UUID.
+   At most one auth code can hold that claim. The QR state becomes `authed`.
 4. `login_authcode` validates the authorization type and UUID, validates the
-   matching `poll_secret`, then atomically consumes the authorization before
-   issuing login side effects.
+   matching `poll_secret`, then atomically consumes the authorization and marks
+   the UUID claim consumed before issuing login side effects.
 
 ## Out of scope
 
@@ -66,8 +71,10 @@ session's existing `poll_secret` and must be atomic and one-shot.
 
 ## Acceptance
 
-- `login.scan_enabled` defaults to `true`, accepts a DB override, and is returned
+- `login.scan_enabled` defaults to `false`, accepts a DB override, and is returned
   as `scan_login_enabled` from both appconfig branches.
+- Before the first successful System Settings load, scan login is disabled. A
+  failed later reload keeps the last successfully loaded value.
 - With the switch disabled, `loginuuid`, scan-login QR handling, `grant_login`,
   and `login_authcode` are rejected; `loginstatus` returns `disabled` immediately.
 - Non-login QR codes are unaffected.
@@ -77,6 +84,9 @@ session's existing `poll_secret` and must be atomic and one-shot.
 - Missing or wrong `poll_secret` does not consume a ready authorization.
 - Correct `poll_secret` permits exactly one atomic consume; concurrent or replayed
   redemption cannot issue a second login.
+- Two different auth codes tied to one QR UUID cannot both become ready or issue
+  sessions, including when confirmations arrive concurrently on different
+  replicas. A consumed UUID remains claimed for the confirmation window.
 - Two independently constructed server instances sharing the same Redis permit
   exactly one pending promotion and one session issuance. Every replica can read
   the confirmed state. A new poll that reads an already `authed` state returns
@@ -93,9 +103,13 @@ session's existing `poll_secret` and must be atomic and one-shot.
 ## Client and rollout contract
 
 - Production currently disables local login and registration and uses OIDC as
-  the unified authentication flow. Pre-create `login.scan_enabled=false` before
-  starting the new binaries so Web does not expose scan login and mobile exits
-  the flow on `err.server.user.scan_login_disabled` or polling state `disabled`.
+  the unified authentication flow. Keep `login.scan_enabled=false` so Web does
+  not expose scan login and mobile exits the flow on
+  `err.server.user.scan_login_disabled` or polling state `disabled`.
+- The shipped Web client sends `poll_secret` while polling but not when calling
+  `POST /v1/user/login_authcode/{code}`. Therefore every deployment, not only
+  OIDC-only production, must keep scan login disabled until a client release
+  sends the secret on redemption. There is no legacy compatibility bypass.
 - `POST /v1/user/login_authcode/{code}` now requires the `poll_secret` returned
   by `GET /v1/user/loginuuid`. The `scanned` polling state no longer includes a
   scanner UID; clients must not depend on that field before confirmation.
@@ -134,11 +148,12 @@ session's existing `poll_secret` and must be atomic and one-shot.
   may already be updated while the client received no credentials. This remains
   fail-closed against replay; the client must restart the complete scan flow
   instead of retrying the consumed authorization code.
-- Other deployments keep the backward-compatible default
-  `login.scan_enabled=true` while clients adopt `scan_login_enabled`, `disabled`,
-  and `poll_secret`.
+- An absent setting defaults to disabled. Enabling is an explicit rollout action
+  performed only after Web and mobile clients have passed the contract tests for
+  `scan_login_enabled`, `disabled`, explicit confirmation, and redemption with
+  `poll_secret`.
 - Rollback requires no schema migration. Deployments that intentionally use scan
-  login can restore `login.scan_enabled=true` when reverting this behavior. The
+  login can set `login.scan_enabled=true` only with compatible clients. The
   OIDC-only production deployment must keep the setting `false`; before rolling
   back to an older binary that ignores the key, block scan-login routes at the
   ingress so rollback does not re-expose the historical enabled behavior.

--- a/.octospec/tasks/scan-login-authorization/brief.md
+++ b/.octospec/tasks/scan-login-authorization/brief.md
@@ -92,8 +92,8 @@ session's existing `poll_secret` and must be atomic and one-shot.
 ## Client and rollout contract
 
 - Production currently disables local login and registration and uses OIDC as
-  the unified authentication flow. Set `login.scan_enabled=false` explicitly
-  after deploying the server so Web does not expose scan login and mobile exits
+  the unified authentication flow. Pre-create `login.scan_enabled=false` before
+  starting the new binaries so Web does not expose scan login and mobile exits
   the flow on `err.server.user.scan_login_disabled` or polling state `disabled`.
 - `POST /v1/user/login_authcode/{code}` now requires the `poll_secret` returned
   by `GET /v1/user/loginuuid`. The `scanned` polling state no longer includes a
@@ -108,9 +108,8 @@ session's existing `poll_secret` and must be atomic and one-shot.
 - `poll_secret` remains a query parameter for current CORS compatibility. It is
   scrubbed by application access/recovery logs; ingress, CDN, and APM URL logs
   must also redact it.
-- For the OIDC-only production deployment, pre-create
-  `login.scan_enabled=false` in `system_setting` before starting the new
-  binaries. Old binaries ignore this key, so use a blue/green cutover or
+- Old binaries ignore the pre-created `login.scan_enabled` key, so use a
+  blue/green cutover or
   temporarily block the anonymous scan-login entry points until old replicas
   have drained; do not expose a mixed-version scan-login window.
 - Runtime setting changes are immediate only on the replica handling the admin

--- a/.octospec/tasks/scan-login-authorization/brief.md
+++ b/.octospec/tasks/scan-login-authorization/brief.md
@@ -137,6 +137,8 @@ session's existing `poll_secret` and must be atomic and one-shot.
 - Other deployments keep the backward-compatible default
   `login.scan_enabled=true` while clients adopt `scan_login_enabled`, `disabled`,
   and `poll_secret`.
-- Roll back operationally by restoring `login.scan_enabled=true`; no schema
-  migration is required. Code rollback is safe because the default remains the
-  historical enabled behavior.
+- Rollback requires no schema migration. Deployments that intentionally use scan
+  login can restore `login.scan_enabled=true` when reverting this behavior. The
+  OIDC-only production deployment must keep the setting `false`; before rolling
+  back to an older binary that ignores the key, block scan-login routes at the
+  ingress so rollback does not re-expose the historical enabled behavior.

--- a/.octospec/tasks/scan-login-authorization/brief.md
+++ b/.octospec/tasks/scan-login-authorization/brief.md
@@ -1,0 +1,94 @@
+---
+type: Task
+title: "Task: scan-login-authorization"
+description: Add a deployment-wide scan-login switch and require explicit confirmation before one-shot redemption
+tags: [auth, security, qrcode, wire-contract, error-response, system-settings, test]
+timestamp: 2026-08-09T00:00:00+08:00
+slug: scan-login-authorization
+source: self
+---
+
+# Task: scan-login-authorization
+
+## Goal
+
+Make the server the policy authority for scan login.
+
+Add the DB-backed System Setting `login.scan_enabled`, defaulting to `true` for
+backward compatibility, and expose it as `scan_login_enabled` from both
+`GET /v1/common/appconfig` response branches. When the setting is `false`, the
+server must reject creation, scanning, confirmation, and redemption of scan-login
+sessions; status polling must return an explicit `disabled` state.
+
+Harden the authorization flow so scanning a QR code creates only a pending
+confirmation. A redeemable authorization is created only after the scanner calls
+the authenticated confirmation endpoint. Redemption must be bound to the browser
+session's existing `poll_secret` and must be atomic and one-shot.
+
+## Load-bearing list
+
+- `auth` — scan login issues a full user session token; pending, confirmed, and
+  consumed states are authentication boundaries.
+- `wire-contract` — keep the existing mobile confirmation response field
+  `auth_code`; add `scan_login_enabled` and the polling state `disabled` without
+  changing unrelated QR-code response shapes.
+- `error-response` — disabled entry points use the localized error envelope and
+  one registered user error code.
+- `system-settings` — `login.scan_enabled` is hot-reloaded from the shared
+  snapshot and defaults to enabled when absent.
+- `multi-instance` — pending promotion and final consumption use shared Redis;
+  atomicity must hold across replicas and concurrent requests.
+- `secret-handling` — `poll_secret` remains hashed at rest, is required for
+  redemption, and must stay redacted from access and recovery logs.
+- `rate-limit` — existing strict per-IP limits on anonymous scan-login endpoints
+  remain in place.
+
+## State model
+
+1. `loginuuid` creates the QR state and a browser-only `poll_secret`.
+2. Scanning creates a pending authorization tied to scanner UID and QR UUID. The
+   QR state becomes `scanned` and contains no UID or redeemable credential.
+3. `grant_login` verifies the authenticated scanner and atomically promotes the
+   pending record into a redeemable authorization. The QR state becomes `authed`.
+4. `login_authcode` validates the authorization type and UUID, validates the
+   matching `poll_secret`, then atomically consumes the authorization before
+   issuing login side effects.
+
+## Out of scope
+
+- Client-side hiding and disabled-state UX; the server contract is delivered
+  first for later web and mobile adoption.
+- Changes to user-profile, group, or other QR-code types.
+- Device/IP display in the mobile confirmation view.
+- Local-account login and OIDC policy changes.
+- Changes to unrelated authentication-code consumers.
+
+## Acceptance
+
+- `login.scan_enabled` defaults to `true`, accepts a DB override, and is returned
+  as `scan_login_enabled` from both appconfig branches.
+- With the switch disabled, `loginuuid`, scan-login QR handling, `grant_login`,
+  and `login_authcode` are rejected; `loginstatus` returns `disabled` immediately.
+- Non-login QR codes are unaffected.
+- Scanning alone cannot create or redeem a ready authorization and does not put
+  UID or credential material in the scanned polling state.
+- Explicit confirmation atomically promotes exactly one matching pending record.
+- Missing or wrong `poll_secret` does not consume a ready authorization.
+- Correct `poll_secret` permits exactly one atomic consume; concurrent or replayed
+  redemption cannot issue a second login.
+- Disabling the switch blocks sessions created before the setting changed while
+  it remains disabled.
+- Focused Go tests, race tests for the authorization store, i18n extraction/lint,
+  formatting, and vet pass, or any infrastructure-only blocker is recorded with
+  the exact command and error.
+
+## Rollout and rollback
+
+- Deploy server code with the default enabled; this preserves existing behavior
+  while clients adopt `scan_login_enabled` and `disabled`.
+- In deployments that use only external identity login, set
+  `login.scan_enabled=false` through the System Setting management API. Replicas
+  converge through the existing snapshot reload mechanism.
+- Roll back operationally by restoring `login.scan_enabled=true`; no schema
+  migration is required. Code rollback is safe because the default remains the
+  historical enabled behavior.

--- a/.octospec/tasks/scan-login-authorization/brief.md
+++ b/.octospec/tasks/scan-login-authorization/brief.md
@@ -41,7 +41,8 @@ session's existing `poll_secret` and must be atomic and one-shot.
 - `secret-handling` — `poll_secret` remains hashed at rest, is required for
   redemption, and must stay redacted from access and recovery logs.
 - `rate-limit` — existing strict per-IP limits on anonymous scan-login endpoints
-  remain in place.
+  remain in place, and non-finite RPS environment values fall back to safe
+  defaults instead of degrading the Redis limiter into fail-open behavior.
 
 ## State model
 
@@ -76,19 +77,36 @@ session's existing `poll_secret` and must be atomic and one-shot.
 - Missing or wrong `poll_secret` does not consume a ready authorization.
 - Correct `poll_secret` permits exactly one atomic consume; concurrent or replayed
   redemption cannot issue a second login.
+- Non-finite `DM_API_SCANLOGIN_*_RATELIMIT_RPS` values such as `NaN` and `+Inf`
+  are replaced with the corresponding finite default before limiter creation.
 - Disabling the switch blocks sessions created before the setting changed while
   it remains disabled.
 - Focused Go tests, race tests for the authorization store, i18n extraction/lint,
   formatting, and vet pass, or any infrastructure-only blocker is recorded with
   the exact command and error.
 
-## Rollout and rollback
+## Client and rollout contract
 
-- Deploy server code with the default enabled; this preserves existing behavior
-  while clients adopt `scan_login_enabled` and `disabled`.
-- In deployments that use only external identity login, set
-  `login.scan_enabled=false` through the System Setting management API. Replicas
-  converge through the existing snapshot reload mechanism.
+- Production currently disables local login and registration and uses OIDC as
+  the unified authentication flow. Set `login.scan_enabled=false` explicitly
+  after deploying the server so Web does not expose scan login and mobile exits
+  the flow on `err.server.user.scan_login_disabled` or polling state `disabled`.
+- `POST /v1/user/login_authcode/{code}` now requires the `poll_secret` returned
+  by `GET /v1/user/loginuuid`. The `scanned` polling state no longer includes a
+  scanner UID; clients must not depend on that field before confirmation.
+- The mobile client must present a real user confirmation step before calling
+  `grant_login`. The server closes scan-alone redemption and binds redemption to
+  the browser session, but does not by itself guarantee protection when a client
+  automatically confirms a scan.
+- Rolling deployment can invalidate in-flight scan sessions when old and new
+  replicas handle different steps. Users should restart the scan flow after the
+  deployment window; do not treat old sessions as backward-compatible.
+- `poll_secret` remains a query parameter for current CORS compatibility. It is
+  scrubbed by application access/recovery logs; ingress, CDN, and APM URL logs
+  must also redact it.
+- Deploy server code first, then apply the production setting above. Other
+  deployments keep the backward-compatible default `login.scan_enabled=true`
+  while clients adopt `scan_login_enabled`, `disabled`, and `poll_secret`.
 - Roll back operationally by restoring `login.scan_enabled=true`; no schema
   migration is required. Code rollback is safe because the default remains the
   historical enabled behavior.

--- a/.octospec/tasks/scan-login-authorization/brief.md
+++ b/.octospec/tasks/scan-login-authorization/brief.md
@@ -77,6 +77,10 @@ session's existing `poll_secret` and must be atomic and one-shot.
 - Missing or wrong `poll_secret` does not consume a ready authorization.
 - Correct `poll_secret` permits exactly one atomic consume; concurrent or replayed
   redemption cannot issue a second login.
+- Two independently constructed server instances sharing the same Redis permit
+  exactly one pending promotion and one session issuance. Every replica can read
+  the confirmed state, and an already `authed` state returns immediately instead
+  of retaining a 10-second long-poll goroutine.
 - Non-finite `DM_API_SCANLOGIN_*_RATELIMIT_RPS` values such as `NaN` and `+Inf`
   are replaced with the corresponding finite default before limiter creation.
 - Disabling the switch blocks sessions created before the setting changed while
@@ -104,9 +108,23 @@ session's existing `poll_secret` and must be atomic and one-shot.
 - `poll_secret` remains a query parameter for current CORS compatibility. It is
   scrubbed by application access/recovery logs; ingress, CDN, and APM URL logs
   must also redact it.
-- Deploy server code first, then apply the production setting above. Other
-  deployments keep the backward-compatible default `login.scan_enabled=true`
-  while clients adopt `scan_login_enabled`, `disabled`, and `poll_secret`.
+- For the OIDC-only production deployment, pre-create
+  `login.scan_enabled=false` in `system_setting` before starting the new
+  binaries. Old binaries ignore this key, so use a blue/green cutover or
+  temporarily block the anonymous scan-login entry points until old replicas
+  have drained; do not expose a mixed-version scan-login window.
+- Runtime setting changes are immediate only on the replica handling the admin
+  write. Peer replicas inherit the existing System Settings auto-reload budget
+  of up to 60 seconds. Incident response that requires an immediate global stop
+  must also block the scan-login routes at the ingress or restart all replicas.
+- QR status push channels remain process-local. A poll already waiting on a
+  different replica can wait until the existing 10-second timeout before its
+  next shared-Redis read; this affects latency only and does not bypass the
+  `poll_secret`, confirmation, or one-shot consume gates. Sticky routing can
+  reduce this bounded delay but is not required for correctness.
+- Other deployments keep the backward-compatible default
+  `login.scan_enabled=true` while clients adopt `scan_login_enabled`, `disabled`,
+  and `poll_secret`.
 - Roll back operationally by restoring `login.scan_enabled=true`; no schema
   migration is required. Code rollback is safe because the default remains the
   historical enabled behavior.

--- a/.octospec/tasks/scan-login-authorization/brief.md
+++ b/.octospec/tasks/scan-login-authorization/brief.md
@@ -79,8 +79,9 @@ session's existing `poll_secret` and must be atomic and one-shot.
   redemption cannot issue a second login.
 - Two independently constructed server instances sharing the same Redis permit
   exactly one pending promotion and one session issuance. Every replica can read
-  the confirmed state, and an already `authed` state returns immediately instead
-  of retaining a 10-second long-poll goroutine.
+  the confirmed state. A new poll that reads an already `authed` state returns
+  immediately instead of retaining a 10-second long-poll goroutine; a poll that
+  was already waiting on another replica can still take up to 10 seconds.
 - Non-finite `DM_API_SCANLOGIN_*_RATELIMIT_RPS` values such as `NaN` and `+Inf`
   are replaced with the corresponding finite default before limiter creation.
 - Disabling the switch blocks sessions created before the setting changed while
@@ -120,7 +121,19 @@ session's existing `poll_secret` and must be atomic and one-shot.
   different replica can wait until the existing 10-second timeout before its
   next shared-Redis read; this affects latency only and does not bypass the
   `poll_secret`, confirmation, or one-shot consume gates. Sticky routing can
-  reduce this bounded delay but is not required for correctness.
+  reduce this bounded delay but is not required for correctness. A new poll that
+  initially reads `authed` returns immediately; `scanned` has no equivalent
+  shared-state short circuit and can still take up to 10 seconds to surface.
+- A failed QR-state publish is rolled back to pending. Because a Redis write can
+  succeed server-side before the caller observes an error, the QR can briefly
+  report `authed` while redemption is unavailable. Confirmation or redemption
+  failures and ambiguous outcomes must restart the complete scan flow; clients
+  must not treat the displayed QR state as proof of a completed login.
+- Redemption consumes the authorization before issuing the session. If session
+  issuance succeeds but the HTTP response is lost, the token cache and IM state
+  may already be updated while the client received no credentials. This remains
+  fail-closed against replay; the client must restart the complete scan flow
+  instead of retrying the consumed authorization code.
 - Other deployments keep the backward-compatible default
   `login.scan_enabled=true` while clients adopt `scan_login_enabled`, `disabled`,
   and `poll_secret`.

--- a/modules/common/api.go
+++ b/modules/common/api.go
@@ -390,6 +390,7 @@ func (cn *Common) appConfig(c *wkhttp.Context) {
 			Version:                appConfigM.Version,
 			SystemBotUIDs:          spacepkg.SystemBotList(),
 			LocalLoginOff:          boolToFlag(cn.systemSettings.LocalLoginOff()),
+			ScanLoginEnabled:       cn.systemSettings.ScanLoginEnabled(),
 			DisableUserCreateSpace: boolToFlag(cn.systemSettings.SpaceDisableUserCreate()),
 			SearchEnabled:          searchEnabled,
 			MessagesSearchOn:       searchEnabled,
@@ -441,6 +442,7 @@ func (cn *Common) appConfig(c *wkhttp.Context) {
 		// YUJ-219-A / GH#1283：单一真源下发系统 Bot UID 列表，替代三端硬编码。
 		SystemBotUIDs:          spacepkg.SystemBotList(),
 		LocalLoginOff:          boolToFlag(cn.systemSettings.LocalLoginOff()),
+		ScanLoginEnabled:       cn.systemSettings.ScanLoginEnabled(),
 		DisableUserCreateSpace: boolToFlag(cn.systemSettings.SpaceDisableUserCreate()),
 		SearchEnabled:          searchEnabled,
 		MessagesSearchOn:       searchEnabled,
@@ -774,6 +776,12 @@ type appConfigResp struct {
 	// 与 app_config.version 解耦：即使客户端命中 version 短路分支，也必须能拿到
 	// 最新值，否则 admin 切换开关后老客户端会被本地缓存住。和 SystemBotUIDs 同理。
 	LocalLoginOff int `json:"local_login_off"`
+
+	// ScanLoginEnabled is the client-facing view of login.scan_enabled. Unlike
+	// a display-only toggle, the same setting is enforced by every server-side
+	// scan-login entry point. It is deliberately present in both appconfig
+	// branches so an app_config version cache cannot hide a live policy change.
+	ScanLoginEnabled bool `json:"scan_login_enabled"`
 
 	// DisableUserCreateSpace 控制客户端是否隐藏「创建空间」入口。
 	// 来源 system_setting space.disable_user_create,回退到 env

--- a/modules/common/api_scan_login_test.go
+++ b/modules/common/api_scan_login_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestGetAppConfig_ScanLoginEnabledDefaultsTrue(t *testing.T) {
+func TestGetAppConfig_ScanLoginEnabledDefaultsFalse(t *testing.T) {
 	s, ctx := testutil.NewTestServer()
 	cn := New(ctx)
 	cleanAllTablesAndReloadSettings(t, ctx)
@@ -21,7 +21,7 @@ func TestGetAppConfig_ScanLoginEnabledDefaultsTrue(t *testing.T) {
 	s.GetRoute().ServeHTTP(w, req)
 
 	require.Equal(t, http.StatusOK, w.Code)
-	assert.Contains(t, w.Body.String(), `"scan_login_enabled":true`)
+	assert.Contains(t, w.Body.String(), `"scan_login_enabled":false`)
 }
 
 func TestGetAppConfig_ScanLoginDisabledInEveryResponseBranch(t *testing.T) {

--- a/modules/common/api_scan_login_test.go
+++ b/modules/common/api_scan_login_test.go
@@ -1,0 +1,50 @@
+package common
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetAppConfig_ScanLoginEnabledDefaultsTrue(t *testing.T) {
+	s, ctx := testutil.NewTestServer()
+	cn := New(ctx)
+	cleanAllTablesAndReloadSettings(t, ctx)
+	require.NoError(t, cn.appConfigDB.insert(&appConfigModel{}))
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/v1/common/appconfig", nil)
+	s.GetRoute().ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), `"scan_login_enabled":true`)
+}
+
+func TestGetAppConfig_ScanLoginDisabledInEveryResponseBranch(t *testing.T) {
+	for _, path := range []string{
+		"/v1/common/appconfig",
+		"/v1/common/appconfig?version=99999999",
+	} {
+		t.Run(path, func(t *testing.T) {
+			s, ctx := testutil.NewTestServer()
+			cn := New(ctx)
+			cleanAllTablesAndReloadSettings(t, ctx)
+			require.NoError(t, cn.appConfigDB.insert(&appConfigModel{Version: 1}))
+
+			settings := EnsureSystemSettings(ctx)
+			require.NoError(t, settings.db.upsert("login", "scan_enabled", "0", settingTypeBool, ""))
+			require.NoError(t, settings.Reload())
+
+			w := httptest.NewRecorder()
+			req, _ := http.NewRequest(http.MethodGet, path, nil)
+			s.GetRoute().ServeHTTP(w, req)
+
+			require.Equal(t, http.StatusOK, w.Code)
+			assert.Contains(t, w.Body.String(), `"scan_login_enabled":false`)
+		})
+	}
+}

--- a/modules/common/swagger/api.yaml
+++ b/modules/common/swagger/api.yaml
@@ -562,6 +562,9 @@ paths:
                 items:
                   type: string
                 description: "系统级 Bot UID 列表（跨 Space 可见），单一真源 pkg/space.SystemBots = {botfather, u_10000, fileHelper}。客户端据此替换硬编码 botfather 判定，避免 SYSTEM_BOTS 跨端漂移 (YUJ-219 / GH#1283)"
+              scan_login_enabled:
+                type: boolean
+                description: "是否启用扫码登录。值来自 system_setting login.scan_enabled；默认 true，关闭时服务端同步拒绝扫码登录全链路"
               message_reaction:
                 type: object
                 description: "普通 Web/iOS/Android 客户端的全局消息 Reaction 能力；由 system_setting message_reaction.read/write 独立控制，默认可读不可写，Bot 身份覆盖不在此公共接口处理"

--- a/modules/common/swagger/api.yaml
+++ b/modules/common/swagger/api.yaml
@@ -564,7 +564,7 @@ paths:
                 description: "系统级 Bot UID 列表（跨 Space 可见），单一真源 pkg/space.SystemBots = {botfather, u_10000, fileHelper}。客户端据此替换硬编码 botfather 判定，避免 SYSTEM_BOTS 跨端漂移 (YUJ-219 / GH#1283)"
               scan_login_enabled:
                 type: boolean
-                description: "是否启用扫码登录。值来自 system_setting login.scan_enabled；默认 true，关闭时服务端同步拒绝扫码登录全链路"
+                description: "是否启用扫码登录。值来自 system_setting login.scan_enabled；默认 false，客户端完成 poll_secret 兑换适配后方可显式开启"
               message_reaction:
                 type: object
                 description: "普通 Web/iOS/Android 客户端的全局消息 Reaction 能力；由 system_setting message_reaction.read/write 独立控制，默认可读不可写，Bot 身份覆盖不在此公共接口处理"

--- a/modules/common/system_setting_schema.go
+++ b/modules/common/system_setting_schema.go
@@ -117,7 +117,7 @@ var systemSettingSchema = []settingDef{
 	// SSO-only deployments can route all users through OIDC/GitHub/Gitee.
 	{Category: "login", Key: "local_off", Type: settingTypeBool, Description: "是否关闭本地账号登录入口",
 		Effective: func(s *SystemSettings) string { return boolToCanonical(s.LocalLoginOff()) }},
-	{Category: "login", Key: "scan_enabled", Type: settingTypeBool, Description: "是否开启扫码登录",
+	{Category: "login", Key: "scan_enabled", Type: settingTypeBool, Description: "是否开启扫码登录（默认关闭，客户端适配后显式开启）",
 		Effective: func(s *SystemSettings) string { return boolToCanonical(s.ScanLoginEnabled()) }},
 
 	// Space user-facing creation toggle — admin 关闭后客户端隐藏创建入口,

--- a/modules/common/system_setting_schema.go
+++ b/modules/common/system_setting_schema.go
@@ -117,6 +117,8 @@ var systemSettingSchema = []settingDef{
 	// SSO-only deployments can route all users through OIDC/GitHub/Gitee.
 	{Category: "login", Key: "local_off", Type: settingTypeBool, Description: "是否关闭本地账号登录入口",
 		Effective: func(s *SystemSettings) string { return boolToCanonical(s.LocalLoginOff()) }},
+	{Category: "login", Key: "scan_enabled", Type: settingTypeBool, Description: "是否开启扫码登录",
+		Effective: func(s *SystemSettings) string { return boolToCanonical(s.ScanLoginEnabled()) }},
 
 	// Space user-facing creation toggle — admin 关闭后客户端隐藏创建入口,
 	// 后端 POST /v1/space/create 直接 403。env DM_SPACE_DISABLE_USER_CREATE

--- a/modules/common/system_settings.go
+++ b/modules/common/system_settings.go
@@ -369,6 +369,16 @@ func (s *SystemSettings) LocalLoginOff() bool {
 	return anyThirdPartyLoginConfigured(s.ctx.GetConfig())
 }
 
+// ScanLoginEnabled returns whether QR-code login is enabled deployment-wide.
+//
+// Default true preserves the historical behavior for deployments that have not
+// configured the setting. Unlike LocalLoginOff, this switch is itself the
+// server-side security boundary: every scan-login entry point reads the same
+// hot-reloaded snapshot, while unrelated QR-code types remain available.
+func (s *SystemSettings) ScanLoginEnabled() bool {
+	return s.getBool("login", "scan_enabled", true)
+}
+
 // anyThirdPartyLoginConfigured reports whether at least one external login
 // provider has the credentials it needs to handle a real auth round-trip.
 // LocalLoginOff guards on this so flipping the master switch without wiring

--- a/modules/common/system_settings.go
+++ b/modules/common/system_settings.go
@@ -33,10 +33,10 @@ var (
 // EnsureSystemSettings returns the process-wide SystemSettings instance,
 // constructing it on first call. Safe to call from any goroutine.
 //
-// Failed initial Load is non-fatal: an empty-snapshot instance is stored
-// and the background auto-reload (started here) will retry every
-// reloadTTL. Until then all getters fall back to yaml — degraded mode,
-// not a hard failure. A successful subsequent reload self-heals.
+// Failed initial Load is non-fatal: the background auto-reload (started here)
+// retries every reloadTTL. Ordinary getters fall back to yaml while the
+// snapshot is nil; security gates such as ScanLoginEnabled fail closed until a
+// successful load publishes the first snapshot. A subsequent reload self-heals.
 func EnsureSystemSettings(ctx *config.Context) *SystemSettings {
 	sharedMu.Lock()
 	defer sharedMu.Unlock()
@@ -98,19 +98,17 @@ type SystemSettings struct {
 	log.Log
 }
 
-// NewSystemSettings builds a helper with an empty initial snapshot.
-// Callers must invoke Load() once at startup before serving traffic;
-// Reload() is safe to call at any time (admin write path uses it).
+// NewSystemSettings builds a helper with an uninitialized snapshot. A nil
+// snapshot distinguishes "the DB successfully returned no rows" from "the DB
+// has never been read successfully". Callers must invoke Load() once at startup
+// before serving traffic; Reload() is safe at any time.
 func NewSystemSettings(ctx *config.Context, db *systemSettingDB) *SystemSettings {
-	s := &SystemSettings{
+	return &SystemSettings{
 		ctx:       ctx,
 		db:        db,
 		reloadTTL: defaultReloadTTL,
 		Log:       log.NewTLog("SystemSettings"),
 	}
-	empty := map[string]string{}
-	s.snapshot.Store(&empty)
-	return s
 }
 
 // Load reads every row from system_setting and atomically replaces the
@@ -371,12 +369,16 @@ func (s *SystemSettings) LocalLoginOff() bool {
 
 // ScanLoginEnabled returns whether QR-code login is enabled deployment-wide.
 //
-// Default true preserves the historical behavior for deployments that have not
-// configured the setting. Unlike LocalLoginOff, this switch is itself the
-// server-side security boundary: every scan-login entry point reads the same
-// hot-reloaded snapshot, while unrelated QR-code types remain available.
+// Default false permits a server-first rollout without breaking clients that do
+// not yet send poll_secret on redemption. Operators must explicitly enable scan
+// login only after every client in the flow supports the hardened contract.
+// Before the first successful settings load the snapshot is nil and this gate
+// also fails closed; later reload failures retain the last successful snapshot.
 func (s *SystemSettings) ScanLoginEnabled() bool {
-	return s.getBool("login", "scan_enabled", true)
+	if s.snapshot.Load() == nil {
+		return false
+	}
+	return s.getBool("login", "scan_enabled", false)
 }
 
 // anyThirdPartyLoginConfigured reports whether at least one external login

--- a/modules/common/system_settings_scan_login_test.go
+++ b/modules/common/system_settings_scan_login_test.go
@@ -1,0 +1,37 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
+	"github.com/stretchr/testify/assert"
+)
+
+func scanLoginSettings(snapshot map[string]string) *SystemSettings {
+	s := &SystemSettings{Log: log.NewTLog("SystemSettingsTest")}
+	m := map[string]string{}
+	for key, value := range snapshot {
+		m[key] = value
+	}
+	s.snapshot.Store(&m)
+	return s
+}
+
+func TestSystemSettings_ScanLoginEnabledDefaultsTrue(t *testing.T) {
+	assert.True(t, scanLoginSettings(nil).ScanLoginEnabled())
+}
+
+func TestSystemSettings_ScanLoginEnabledHonoursDBSnapshot(t *testing.T) {
+	for _, tc := range []struct {
+		value string
+		want  bool
+	}{
+		{value: "0", want: false},
+		{value: "1", want: true},
+	} {
+		s := scanLoginSettings(map[string]string{
+			schemaKey("login", "scan_enabled"): tc.value,
+		})
+		assert.Equal(t, tc.want, s.ScanLoginEnabled(), "value=%s", tc.value)
+	}
+}

--- a/modules/common/system_settings_scan_login_test.go
+++ b/modules/common/system_settings_scan_login_test.go
@@ -17,8 +17,16 @@ func scanLoginSettings(snapshot map[string]string) *SystemSettings {
 	return s
 }
 
-func TestSystemSettings_ScanLoginEnabledDefaultsTrue(t *testing.T) {
-	assert.True(t, scanLoginSettings(nil).ScanLoginEnabled())
+func TestSystemSettings_ScanLoginEnabledDefaultsFalse(t *testing.T) {
+	assert.False(t, scanLoginSettings(nil).ScanLoginEnabled(),
+		"server-first rollout must stay gated until clients send poll_secret on redemption")
+}
+
+func TestSystemSettings_ScanLoginEnabledFailsClosedBeforeFirstSuccessfulLoad(t *testing.T) {
+	s := &SystemSettings{Log: log.NewTLog("SystemSettingsTest")}
+
+	assert.False(t, s.ScanLoginEnabled(),
+		"an uninitialized settings snapshot must not enable the scan-login security boundary")
 }
 
 func TestSystemSettings_ScanLoginEnabledHonoursDBSnapshot(t *testing.T) {

--- a/modules/qrcode/api.go
+++ b/modules/qrcode/api.go
@@ -170,6 +170,10 @@ func (q *QRCode) handleQRCodeInfo(c *wkhttp.Context) {
 
 // 处理扫描登录
 func (q *QRCode) handleScanLogin(loginUID string, uuid string, qrCodeModel common.QRCodeModel) (interface{}, error) {
+	if qrCodeModel.Data == nil ||
+		fmt.Sprint(qrCodeModel.Data["status"]) != string(common.ScanLoginStatusWaitScan) {
+		return nil, errQRCodeNotFound
+	}
 	authCode := util.GenerUUID()
 	err := user.SavePendingScanLoginAuthorization(q.ctx.GetRedisConn(), authCode, loginUID, uuid)
 	if err != nil {

--- a/modules/qrcode/api.go
+++ b/modules/qrcode/api.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	commonsettings "github.com/Mininglamp-OSS/octo-server/modules/common"
 	"github.com/Mininglamp-OSS/octo-server/modules/group"
 	spacemod "github.com/Mininglamp-OSS/octo-server/modules/space"
 	"github.com/Mininglamp-OSS/octo-server/modules/user"
@@ -150,7 +151,11 @@ func (q *QRCode) handleQRCodeInfo(c *wkhttp.Context) {
 	case common.QRCodeTypeGroup: // 扫描入群
 		result, err = q.handleJoinGroup(loginUID, qrCodeModel)
 	case common.QRCodeTypeScanLogin: // 扫描登录
-		result, err = q.handleScanLogin(loginUID, code, qrCodeModel)
+		if !commonsettings.EnsureSystemSettings(q.ctx).ScanLoginEnabled() {
+			err = errQRCodeScanLoginDisabled
+		} else {
+			result, err = q.handleScanLogin(loginUID, code, qrCodeModel)
+		}
 	default:
 		err = errQRCodeUnsupportedType
 	}
@@ -166,14 +171,10 @@ func (q *QRCode) handleQRCodeInfo(c *wkhttp.Context) {
 // 处理扫描登录
 func (q *QRCode) handleScanLogin(loginUID string, uuid string, qrCodeModel common.QRCodeModel) (interface{}, error) {
 	authCode := util.GenerUUID()
-	err := q.ctx.GetRedisConn().SetAndExpire(fmt.Sprintf("%s%s", common.AuthCodeCachePrefix, authCode), util.ToJson(map[string]interface{}{
-		"scaner": loginUID,
-		"type":   common.AuthCodeTypeScanLogin,
-		"uuid":   uuid,
-	}), user.ScanLoginAuthCodeTTL)
+	err := user.SavePendingScanLoginAuthorization(q.ctx.GetRedisConn(), authCode, loginUID, uuid)
 	if err != nil {
-		q.Error("生成扫码登录授权码失败", zap.Error(err))
-		return nil, fmt.Errorf("%w: scan login auth code", errQRCodeInternalStoreFailed)
+		q.Error("生成扫码登录待确认记录失败", zap.Error(err))
+		return nil, fmt.Errorf("%w: scan login pending authorization", errQRCodeInternalStoreFailed)
 	}
 	var pubkey string
 	if qrCodeModel.Data != nil && qrCodeModel.Data["pub_key"] != nil {
@@ -182,11 +183,13 @@ func (q *QRCode) handleScanLogin(loginUID string, uuid string, qrCodeModel commo
 	qrcodeInfo := common.NewQRCodeModel(common.QRCodeTypeScanLogin, map[string]interface{}{
 		"app_id": "wukongchat",
 		"status": common.ScanLoginStatusScanned,
-		"uid":    loginUID,
 	})
 	err = q.ctx.GetRedisConn().SetAndExpire(fmt.Sprintf("%s%s", common.QRCodeCachePrefix, uuid), util.ToJson(qrcodeInfo), user.ScanLoginConfirmWindow)
 	if err != nil {
 		q.Error("设置扫描登录二维码信息失败", zap.Error(err))
+		if cleanupErr := user.DeletePendingScanLoginAuthorization(q.ctx.GetRedisConn(), authCode); cleanupErr != nil {
+			q.Warn("清理扫码登录待确认记录失败", zap.String("uuid", uuid), zap.Error(cleanupErr))
+		}
 		return nil, fmt.Errorf("%w: scan login state", errQRCodeInternalStoreFailed)
 	}
 	user.SendQRCodeInfo(uuid, qrcodeInfo)

--- a/modules/qrcode/api_i18n.go
+++ b/modules/qrcode/api_i18n.go
@@ -14,6 +14,7 @@ var (
 	errQRCodeGroupDataInvalid    = errors.New("qrcode: group data invalid")
 	errQRCodeGroupNotFound       = errors.New("qrcode: group not found")
 	errQRCodeGroupSpaceForbidden = errors.New("qrcode: group space forbidden")
+	errQRCodeScanLoginDisabled   = errors.New("qrcode: scan login disabled")
 	errQRCodeInternalQueryFailed = errors.New("qrcode: internal query failed")
 	errQRCodeInternalStoreFailed = errors.New("qrcode: internal store failed")
 )
@@ -38,6 +39,8 @@ func respondQRCodeHandleError(c *wkhttp.Context, err error) {
 		httperr.ResponseErrorL(c, errcode.ErrQRCodeGroupNotFound, nil, nil)
 	case errors.Is(err, errQRCodeGroupSpaceForbidden):
 		httperr.ResponseErrorL(c, errcode.ErrQRCodeGroupSpaceForbidden, nil, nil)
+	case errors.Is(err, errQRCodeScanLoginDisabled):
+		httperr.ResponseErrorL(c, errcode.ErrUserScanLoginDisabled, nil, nil)
 	case errors.Is(err, errQRCodeInternalStoreFailed):
 		httperr.ResponseErrorL(c, errcode.ErrQRCodeStoreFailed, nil, nil)
 	default:

--- a/modules/qrcode/api_i18n.go
+++ b/modules/qrcode/api_i18n.go
@@ -11,6 +11,7 @@ import (
 
 var (
 	errQRCodeUnsupportedType     = errors.New("qrcode: unsupported type")
+	errQRCodeNotFound            = errors.New("qrcode: not found")
 	errQRCodeGroupDataInvalid    = errors.New("qrcode: group data invalid")
 	errQRCodeGroupNotFound       = errors.New("qrcode: group not found")
 	errQRCodeGroupSpaceForbidden = errors.New("qrcode: group space forbidden")
@@ -37,6 +38,8 @@ func respondQRCodeHandleError(c *wkhttp.Context, err error) {
 		respondQRCodeRequestInvalid(c, "code")
 	case errors.Is(err, errQRCodeGroupNotFound):
 		httperr.ResponseErrorL(c, errcode.ErrQRCodeGroupNotFound, nil, nil)
+	case errors.Is(err, errQRCodeNotFound):
+		httperr.ResponseErrorL(c, errcode.ErrQRCodeNotFound, nil, nil)
 	case errors.Is(err, errQRCodeGroupSpaceForbidden):
 		httperr.ResponseErrorL(c, errcode.ErrQRCodeGroupSpaceForbidden, nil, nil)
 	case errors.Is(err, errQRCodeScanLoginDisabled):

--- a/modules/qrcode/scanlogin_policy_test.go
+++ b/modules/qrcode/scanlogin_policy_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
 	"github.com/Mininglamp-OSS/octo-lib/testutil"
 	commonsettings "github.com/Mininglamp-OSS/octo-server/modules/common"
+	"github.com/Mininglamp-OSS/octo-server/modules/user"
 	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -98,6 +99,13 @@ func TestScanLoginQRCodeCreatesPendingStateOnly(t *testing.T) {
 func TestNonLoginQRCodeRemainsAvailableWhenScanLoginDisabled(t *testing.T) {
 	s, ctx := testutil.NewTestServer()
 	require.NoError(t, testutil.CleanAllTables(ctx))
+	require.NoError(t, user.NewDB(ctx).Insert(&user.Model{
+		UID:      testutil.UID,
+		Name:     "QR user",
+		Username: "qr_user",
+		ShortNo:  "qr001",
+		Status:   1,
+	}))
 	_, err := ctx.DB().InsertInto("system_setting").
 		Columns("category", "key_name", "value", "value_type").
 		Values("login", "scan_enabled", "0", "bool").Exec()
@@ -109,5 +117,6 @@ func TestNonLoginQRCodeRemainsAvailableWhenScanLoginDisabled(t *testing.T) {
 	req.Header.Set("token", testutil.Token)
 	s.GetRoute().ServeHTTP(w, req)
 
+	require.Equal(t, http.StatusOK, w.Code)
 	assert.NotContains(t, w.Body.String(), "err.server.user.scan_login_disabled")
 }

--- a/modules/qrcode/scanlogin_policy_test.go
+++ b/modules/qrcode/scanlogin_policy_test.go
@@ -1,0 +1,113 @@
+package qrcode
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	libcommon "github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	commonsettings "github.com/Mininglamp-OSS/octo-server/modules/common"
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func setScanLoginEnabledForQRCodeTest(t *testing.T, enabled bool) (*httptest.ResponseRecorder, string) {
+	t.Helper()
+	s, ctx := testutil.NewTestServer()
+	s.GetRoute().SetErrorRenderer(i18n.NewErrorRenderer(i18n.NewLocalizer(i18n.DefaultLanguage)))
+	require.NoError(t, testutil.CleanAllTables(ctx))
+	value := "0"
+	if enabled {
+		value = "1"
+	}
+	_, err := ctx.DB().InsertInto("system_setting").
+		Columns("category", "key_name", "value", "value_type").
+		Values("login", "scan_enabled", value, "bool").Exec()
+	require.NoError(t, err)
+	require.NoError(t, commonsettings.EnsureSystemSettings(ctx).Reload())
+
+	code := util.GenerUUID()
+	require.NoError(t, ctx.GetRedisConn().SetAndExpire(
+		fmt.Sprintf("%s%s", libcommon.QRCodeCachePrefix, code),
+		util.ToJson(libcommon.NewQRCodeModel(libcommon.QRCodeTypeScanLogin, map[string]interface{}{
+			"app_id": "wukongchat",
+			"status": libcommon.ScanLoginStatusWaitScan,
+		})),
+		time.Minute,
+	))
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/v1/qrcode/"+code, nil)
+	req.Header.Set("token", testutil.Token)
+	s.GetRoute().ServeHTTP(w, req)
+	return w, code
+}
+
+func TestScanLoginQRCodeRejectedWhenDisabled(t *testing.T) {
+	w, _ := setScanLoginEnabledForQRCodeTest(t, false)
+	assert.Contains(t, w.Body.String(), "err.server.user.scan_login_disabled")
+}
+
+func TestScanLoginQRCodeCreatesPendingStateOnly(t *testing.T) {
+	s, ctx := testutil.NewTestServer()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+	require.NoError(t, commonsettings.EnsureSystemSettings(ctx).Reload())
+
+	code := util.GenerUUID()
+	require.NoError(t, ctx.GetRedisConn().SetAndExpire(
+		fmt.Sprintf("%s%s", libcommon.QRCodeCachePrefix, code),
+		util.ToJson(libcommon.NewQRCodeModel(libcommon.QRCodeTypeScanLogin, map[string]interface{}{
+			"app_id": "wukongchat",
+			"status": libcommon.ScanLoginStatusWaitScan,
+		})),
+		time.Minute,
+	))
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/v1/qrcode/"+code, nil)
+	req.Header.Set("token", testutil.Token)
+	s.GetRoute().ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var body struct {
+		Data map[string]interface{} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	authCode, _ := body.Data["auth_code"].(string)
+	require.NotEmpty(t, authCode)
+
+	ready, err := ctx.GetRedisConn().GetString(fmt.Sprintf("%s%s", libcommon.AuthCodeCachePrefix, authCode))
+	require.NoError(t, err)
+	assert.Empty(t, ready, "scanning must not create a redeemable authorization")
+
+	stored, err := ctx.GetRedisConn().GetString(fmt.Sprintf("%s%s", libcommon.QRCodeCachePrefix, code))
+	require.NoError(t, err)
+	var state libcommon.QRCodeModel
+	require.NoError(t, json.Unmarshal([]byte(stored), &state))
+	assert.Equal(t, string(libcommon.ScanLoginStatusScanned), fmt.Sprint(state.Data["status"]))
+	assert.NotContains(t, state.Data, "uid")
+	assert.NotContains(t, state.Data, "auth_code")
+}
+
+func TestNonLoginQRCodeRemainsAvailableWhenScanLoginDisabled(t *testing.T) {
+	s, ctx := testutil.NewTestServer()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+	_, err := ctx.DB().InsertInto("system_setting").
+		Columns("category", "key_name", "value", "value_type").
+		Values("login", "scan_enabled", "0", "bool").Exec()
+	require.NoError(t, err)
+	require.NoError(t, commonsettings.EnsureSystemSettings(ctx).Reload())
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/v1/qrcode/user_"+testutil.UID, nil)
+	req.Header.Set("token", testutil.Token)
+	s.GetRoute().ServeHTTP(w, req)
+
+	assert.NotContains(t, w.Body.String(), "err.server.user.scan_login_disabled")
+}

--- a/modules/qrcode/scanlogin_policy_test.go
+++ b/modules/qrcode/scanlogin_policy_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	libcommon "github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
 	"github.com/Mininglamp-OSS/octo-lib/testutil"
 	commonsettings "github.com/Mininglamp-OSS/octo-server/modules/common"
@@ -17,6 +18,15 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func enableScanLoginForQRCodeTest(t *testing.T, ctx *config.Context) {
+	t.Helper()
+	_, err := ctx.DB().InsertInto("system_setting").
+		Columns("category", "key_name", "value", "value_type").
+		Values("login", "scan_enabled", "1", "bool").Exec()
+	require.NoError(t, err)
+	require.NoError(t, commonsettings.EnsureSystemSettings(ctx).Reload())
+}
 
 func setScanLoginEnabledForQRCodeTest(t *testing.T, enabled bool) (*httptest.ResponseRecorder, string) {
 	t.Helper()
@@ -58,7 +68,7 @@ func TestScanLoginQRCodeRejectedWhenDisabled(t *testing.T) {
 func TestScanLoginQRCodeCreatesPendingStateOnly(t *testing.T) {
 	s, ctx := testutil.NewTestServer()
 	require.NoError(t, testutil.CleanAllTables(ctx))
-	require.NoError(t, commonsettings.EnsureSystemSettings(ctx).Reload())
+	enableScanLoginForQRCodeTest(t, ctx)
 
 	code := util.GenerUUID()
 	require.NoError(t, ctx.GetRedisConn().SetAndExpire(
@@ -94,6 +104,97 @@ func TestScanLoginQRCodeCreatesPendingStateOnly(t *testing.T) {
 	assert.Equal(t, string(libcommon.ScanLoginStatusScanned), fmt.Sprint(state.Data["status"]))
 	assert.NotContains(t, state.Data, "uid")
 	assert.NotContains(t, state.Data, "auth_code")
+}
+
+func TestScanLoginQRCodeRejectsRescanAfterStateLeavesWaitScan(t *testing.T) {
+	s, ctx := testutil.NewTestServer()
+	s.GetRoute().SetErrorRenderer(i18n.NewErrorRenderer(i18n.NewLocalizer(i18n.DefaultLanguage)))
+	require.NoError(t, testutil.CleanAllTables(ctx))
+	enableScanLoginForQRCodeTest(t, ctx)
+
+	code := util.GenerUUID()
+	require.NoError(t, ctx.GetRedisConn().SetAndExpire(
+		fmt.Sprintf("%s%s", libcommon.QRCodeCachePrefix, code),
+		util.ToJson(libcommon.NewQRCodeModel(libcommon.QRCodeTypeScanLogin, map[string]interface{}{
+			"app_id": "wukongchat",
+			"status": libcommon.ScanLoginStatusWaitScan,
+		})),
+		time.Minute,
+	))
+
+	first := httptest.NewRecorder()
+	firstReq := httptest.NewRequest(http.MethodGet, "/v1/qrcode/"+code, nil)
+	firstReq.Header.Set("token", testutil.Token)
+	s.GetRoute().ServeHTTP(first, firstReq)
+	require.Equal(t, http.StatusOK, first.Code, first.Body.String())
+
+	second := httptest.NewRecorder()
+	secondReq := httptest.NewRequest(http.MethodGet, "/v1/qrcode/"+code, nil)
+	secondReq.Header.Set("token", testutil.Token)
+	s.GetRoute().ServeHTTP(second, secondReq)
+	assert.NotEqual(t, http.StatusOK, second.Code, second.Body.String())
+	assert.Contains(t, second.Body.String(), "err.server.qrcode.not_found")
+}
+
+func TestScanLoginQRCodePendingFlowsThroughConfirmationAndRedemption(t *testing.T) {
+	s, ctx := testutil.NewTestServer()
+	s.GetRoute().SetErrorRenderer(i18n.NewErrorRenderer(i18n.NewLocalizer(i18n.DefaultLanguage)))
+	require.NoError(t, testutil.CleanAllTables(ctx))
+	enableScanLoginForQRCodeTest(t, ctx)
+
+	db := user.NewDB(ctx)
+	model, err := db.QueryByUID(testutil.UID)
+	require.NoError(t, err)
+	if model == nil {
+		require.NoError(t, db.Insert(&user.Model{
+			UID:      testutil.UID,
+			Name:     "scan login cross module user",
+			Username: "scan_login_cross_module",
+			ShortNo:  "scan003",
+			Status:   1,
+		}))
+	}
+
+	create := httptest.NewRecorder()
+	createReq := httptest.NewRequest(http.MethodGet, "/v1/user/loginuuid", nil)
+	createReq.Header.Set("X-Forwarded-For", "9.9.10.1")
+	createReq.RemoteAddr = "9.9.10.1:12345"
+	s.GetRoute().ServeHTTP(create, createReq)
+	require.Equal(t, http.StatusOK, create.Code, create.Body.String())
+	var created struct {
+		UUID       string `json:"uuid"`
+		PollSecret string `json:"poll_secret"`
+	}
+	require.NoError(t, json.Unmarshal(create.Body.Bytes(), &created))
+	require.NotEmpty(t, created.UUID)
+	require.NotEmpty(t, created.PollSecret)
+
+	scan := httptest.NewRecorder()
+	scanReq := httptest.NewRequest(http.MethodGet, "/v1/qrcode/"+created.UUID, nil)
+	scanReq.Header.Set("token", testutil.Token)
+	s.GetRoute().ServeHTTP(scan, scanReq)
+	require.Equal(t, http.StatusOK, scan.Code, scan.Body.String())
+	var scanned struct {
+		Data map[string]interface{} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(scan.Body.Bytes(), &scanned))
+	authCode, _ := scanned.Data["auth_code"].(string)
+	require.NotEmpty(t, authCode)
+
+	confirm := httptest.NewRecorder()
+	confirmReq := httptest.NewRequest(http.MethodGet, "/v1/user/grant_login?auth_code="+authCode, nil)
+	confirmReq.Header.Set("token", testutil.Token)
+	s.GetRoute().ServeHTTP(confirm, confirmReq)
+	require.Equal(t, http.StatusOK, confirm.Code, confirm.Body.String())
+
+	redeem := httptest.NewRecorder()
+	redeemReq := httptest.NewRequest(http.MethodPost,
+		"/v1/user/login_authcode/"+authCode+"?poll_secret="+created.PollSecret, nil)
+	redeemReq.Header.Set("X-Forwarded-For", "9.9.10.2")
+	redeemReq.RemoteAddr = "9.9.10.2:12345"
+	s.GetRoute().ServeHTTP(redeem, redeemReq)
+	require.Equal(t, http.StatusOK, redeem.Code, redeem.Body.String())
+	assert.Contains(t, redeem.Body.String(), `"token"`)
 }
 
 func TestNonLoginQRCodeRemainsAvailableWhenScanLoginDisabled(t *testing.T) {

--- a/modules/user/api.go
+++ b/modules/user/api.go
@@ -2146,7 +2146,7 @@ func (u *User) getLoginUUID(c *wkhttp.Context) {
 func (u *User) getloginStatus(c *wkhttp.Context) {
 	if !common2.EnsureSystemSettings(u.ctx).ScanLoginEnabled() {
 		c.Header("Cache-Control", "no-store")
-		c.JSON(http.StatusOK, gin.H{"status": "disabled"})
+		c.JSON(http.StatusOK, gin.H{"status": scanLoginStatusDisabled})
 		return
 	}
 	uuid := c.Query("uuid")

--- a/modules/user/api.go
+++ b/modules/user/api.go
@@ -2585,10 +2585,12 @@ func (u *User) grantLogin(c *wkhttp.Context) {
 	err = u.ctx.GetRedisConn().SetAndExpire(fmt.Sprintf("%s%s", common.QRCodeCachePrefix, uuid), util.ToJson(qrcodeInfo), ScanLoginConfirmWindow)
 	if err != nil {
 		u.Error("更新二维码信息失败！", zap.Error(err))
-		if revoked, revokeErr := u.scanLoginAuthorizations.Consume(authCode, authInfo); revokeErr != nil {
-			u.Warn("回滚扫码授权码失败！", zap.Error(revokeErr))
-		} else if !revoked {
-			u.Warn("扫码授权码在状态写入失败后已不再可回滚", zap.String("uuid", uuid))
+		if restored, rollbackErr := u.scanLoginAuthorizations.RollbackPromotion(
+			authCode, authInfo, ScanLoginConfirmWindow,
+		); rollbackErr != nil {
+			u.Warn("恢复扫码待确认授权失败！", zap.String("uuid", uuid), zap.Error(rollbackErr))
+		} else if !restored {
+			u.Warn("扫码授权码在状态写入失败后已无法恢复", zap.String("uuid", uuid))
 		}
 		respondUserError(c, errcode.ErrUserStoreFailed)
 		return

--- a/modules/user/api.go
+++ b/modules/user/api.go
@@ -2306,6 +2306,8 @@ func (u *User) loginWithAuthCode(c *wkhttp.Context) {
 		respondUserError(c, errcode.ErrUserAuthCodeNotFound)
 		return
 	}
+	redemptionAudit := newScanLoginRedemptionAudit(u.Log, uuid, scaner)
+	defer redemptionAudit.WarnIfIncomplete()
 	// Consumption happens before any login side effect. A downstream failure
 	// burns this authorization and requires a fresh scan; fail-closed behavior
 	// is preferable to making a credential replayable across replicas.
@@ -2464,6 +2466,7 @@ func (u *User) loginWithAuthCode(c *wkhttp.Context) {
 	// newLoginUserDetailResp,必须单独补三个实名字段 —— 否则扫码登录的客户端
 	// 永远拿不到 self 实名态,和 POST /v1/user/login 契约不一致。
 	u.applyRealnameToAuthCodeMap(resp, userModel.UID)
+	redemptionAudit.MarkCompleted()
 	c.Response(resp)
 }
 

--- a/modules/user/api.go
+++ b/modules/user/api.go
@@ -2211,6 +2211,10 @@ func (u *User) getloginStatus(c *wkhttp.Context) {
 	// process cannot receive its in-memory channel notification. Once the shared
 	// Redis read already shows authed, entering the 10-second long poll only adds
 	// latency and retains a goroutine without waiting for any useful transition.
+	// Authorized and unauthorized callers take the same early return, so it does
+	// not reveal whether poll_secret matched. respondStatus still strips credential
+	// fields for unauthorized callers, and the strict per-IP limiter remains the
+	// abuse-control fallback for repeated terminal-state polling.
 	if scanLoginStatusIs(qrcodeModel, string(common.ScanLoginStatusAuthed)) {
 		respondStatus(qrcodeModel)
 		return
@@ -2223,8 +2227,9 @@ func (u *User) getloginStatus(c *wkhttp.Context) {
 	// 端点上的一个廉价登录延迟惩罚。未授权方本来也只能拿到白名单字段，订阅对它毫无意义。
 	//
 	// 不注册时 qrcodeChan 为 nil：从 nil channel 接收永远阻塞，select 自然落到超时分支。
-	// 刻意让未授权方也等满同样的 10 秒 —— 立刻返回会泄露「密钥对不对」的时序信号，
-	// 也会让攻击者能高频轮询。
+	// 对尚未 authed 的状态，刻意让未授权方等满 10 秒 —— 此时立刻返回会泄露「密钥
+	// 对不对」的时序信号，也会让攻击者能高频轮询。上面的 authed 终态短路对授权与
+	// 未授权方一致，因此不携带这类密钥判定信号。
 	var qrcodeChan <-chan *common.QRCodeModel
 	if authorized {
 		qrcodeChan = u.getQRCodeModelChan(uuid)

--- a/modules/user/api.go
+++ b/modules/user/api.go
@@ -2206,6 +2206,15 @@ func (u *User) getloginStatus(c *wkhttp.Context) {
 		}
 		c.JSON(http.StatusOK, model.Data)
 	}
+	// authed is terminal for this polling cycle. In a multi-replica deployment,
+	// grant_login may have published the state through another process, so this
+	// process cannot receive its in-memory channel notification. Once the shared
+	// Redis read already shows authed, entering the 10-second long poll only adds
+	// latency and retains a goroutine without waiting for any useful transition.
+	if fmt.Sprint(qrcodeModel.Data["status"]) == string(common.ScanLoginStatusAuthed) {
+		respondStatus(qrcodeModel)
+		return
+	}
 	// 只有持密钥的一方才注册推送 channel。
 	//
 	// getQRCodeModelChan 对同一 uuid 是无条件覆盖写，所以未授权方一旦也能注册，就能靠

--- a/modules/user/api.go
+++ b/modules/user/api.go
@@ -25,6 +25,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-server/pkg/avatarrender"
 	"github.com/Mininglamp-OSS/octo-server/pkg/avatarversion"
 	"github.com/Mininglamp-OSS/octo-server/pkg/metrics"
+	"github.com/Mininglamp-OSS/octo-server/pkg/ratelimit"
 	octoredis "github.com/Mininglamp-OSS/octo-server/pkg/redis"
 	spacepkg "github.com/Mininglamp-OSS/octo-server/pkg/space"
 	rd "github.com/go-redis/redis"
@@ -218,10 +219,16 @@ func (u *User) Route(r *wkhttp.WKHttp) {
 	// 多开标签页会翻倍），而企业 NAT 下整层楼共用一个出口 IP —— 卡太死的后果是一片人
 	// 登不上，比放过一点扫描流量严重得多。运维撞到 NAT 墙时可不重新发版直接上调。
 	scanLoginUUIDLimit := r.StrictIPRateLimitMiddleware(rlCtx, rlRedis, "scanlogin_uuid",
-		wkhttp.ParseRPSFromEnv("DM_API_SCANLOGIN_UUID_RATELIMIT_RPS", defaultScanLoginUUIDRateLimitRPS),
+		ratelimit.SanitizeRPS(
+			wkhttp.ParseRPSFromEnv("DM_API_SCANLOGIN_UUID_RATELIMIT_RPS", defaultScanLoginUUIDRateLimitRPS),
+			defaultScanLoginUUIDRateLimitRPS,
+		),
 		wkhttp.ParseBurstFromEnv("DM_API_SCANLOGIN_UUID_RATELIMIT_BURST", defaultScanLoginUUIDRateLimitBurst))
 	scanLoginStatusLimit := r.StrictIPRateLimitMiddleware(rlCtx, rlRedis, "scanlogin_status",
-		wkhttp.ParseRPSFromEnv("DM_API_SCANLOGIN_STATUS_RATELIMIT_RPS", defaultScanLoginStatusRateLimitRPS),
+		ratelimit.SanitizeRPS(
+			wkhttp.ParseRPSFromEnv("DM_API_SCANLOGIN_STATUS_RATELIMIT_RPS", defaultScanLoginStatusRateLimitRPS),
+			defaultScanLoginStatusRateLimitRPS,
+		),
 		wkhttp.ParseBurstFromEnv("DM_API_SCANLOGIN_STATUS_RATELIMIT_BURST", defaultScanLoginStatusRateLimitBurst))
 
 	auth := r.Group("/v1", u.ctx.AuthMiddleware(r))

--- a/modules/user/api.go
+++ b/modules/user/api.go
@@ -2211,7 +2211,7 @@ func (u *User) getloginStatus(c *wkhttp.Context) {
 	// process cannot receive its in-memory channel notification. Once the shared
 	// Redis read already shows authed, entering the 10-second long poll only adds
 	// latency and retains a goroutine without waiting for any useful transition.
-	if fmt.Sprint(qrcodeModel.Data["status"]) == string(common.ScanLoginStatusAuthed) {
+	if scanLoginStatusIs(qrcodeModel, string(common.ScanLoginStatusAuthed)) {
 		respondStatus(qrcodeModel)
 		return
 	}

--- a/modules/user/api.go
+++ b/modules/user/api.go
@@ -115,6 +115,7 @@ type User struct {
 	verificationDB           *verificationDB
 	languageService          *LanguageService
 	existingTokenSetter      existingTokenSetter
+	scanLoginAuthorizations  *scanLoginAuthorizationStore
 }
 
 type existingTokenSetter interface {
@@ -134,6 +135,9 @@ func (s redisExistingTokenSetter) SetIfExists(key string, value string, expire t
 
 // New New
 func New(ctx *config.Context) *User {
+	loginRedisClient := octoredis.NewInstrumentedClient(ctx.GetConfig(), func(o *rd.Options) {
+		o.PoolSize = 10
+	})
 	u := &User{
 		ctx:                      ctx,
 		db:                       NewDB(ctx),
@@ -165,10 +169,9 @@ func New(ctx *config.Context) *User {
 		spaceSettingDB:           NewSpaceSettingDB(ctx.DB()),
 		verificationDB:           newVerificationDB(ctx),
 		existingTokenSetter: redisExistingTokenSetter{
-			client: octoredis.NewInstrumentedClient(ctx.GetConfig(), func(o *rd.Options) {
-				o.PoolSize = 10
-			}),
+			client: loginRedisClient,
 		},
+		scanLoginAuthorizations: newScanLoginAuthorizationStore(loginRedisClient),
 	}
 	// LanguageService 与 main.go 注入到 CacheTokenParser 的实例独立构造，但共享
 	// 底层 *DB session / Redis 连接，因此读写同一份 user.language 列与
@@ -2067,6 +2070,10 @@ func (u *User) unregisterUserDeviceToken(c *wkhttp.Context) {
 
 // 获取登录的uuid（web登录）
 func (u *User) getLoginUUID(c *wkhttp.Context) {
+	if !common2.EnsureSystemSettings(u.ctx).ScanLoginEnabled() {
+		respondUserError(c, errcode.ErrUserScanLoginDisabled)
+		return
+	}
 	uuid := util.GenerUUID()
 	deviceId := c.Query("device_id")
 	deviceName := c.Query("device_name")
@@ -2130,6 +2137,11 @@ func (u *User) getLoginUUID(c *wkhttp.Context) {
 // bundle 的浏览器会停在授权页等待（用户刷新即恢复），而不是被 expired 状态推去无限
 // 重新申请二维码。安全性不因此打折 —— 旧 bundle 同样拿不到 auth_code。
 func (u *User) getloginStatus(c *wkhttp.Context) {
+	if !common2.EnsureSystemSettings(u.ctx).ScanLoginEnabled() {
+		c.Header("Cache-Control", "no-store")
+		c.JSON(http.StatusOK, gin.H{"status": "disabled"})
+		return
+	}
 	uuid := c.Query("uuid")
 	qrcodeInfo, err := u.ctx.GetRedisConn().GetString(fmt.Sprintf("%s%s", common.QRCodeCachePrefix, uuid))
 	if err != nil {
@@ -2222,8 +2234,12 @@ func (u *User) getloginStatus(c *wkhttp.Context) {
 
 // 通过authCode登录
 func (u *User) loginWithAuthCode(c *wkhttp.Context) {
+	if !common2.EnsureSystemSettings(u.ctx).ScanLoginEnabled() {
+		respondUserError(c, errcode.ErrUserScanLoginDisabled)
+		return
+	}
 	authCode := c.Param("auth_code")
-	authCodeKey := fmt.Sprintf("%s%s", common.AuthCodeCachePrefix, authCode)
+	authCodeKey := scanLoginReadyAuthorizationKey(authCode)
 	flagI64, _ := strconv.ParseInt(c.Query("flag"), 10, 64)
 	var flag config.DeviceFlag
 	if flagI64 == 0 {
@@ -2262,6 +2278,30 @@ func (u *User) loginWithAuthCode(c *wkhttp.Context) {
 		respondUserAuthInfoInvalid(c, "scaner")
 		return
 	}
+	uuid, ok := authInfoMap["uuid"].(string)
+	if !ok || uuid == "" {
+		respondUserAuthInfoInvalid(c, "uuid")
+		return
+	}
+	if !u.scanLoginPollSecretMatches(uuid, strings.TrimSpace(c.Query(scanLoginPollSecretQuery))) {
+		// Missing and wrong browser credentials intentionally collapse to the
+		// same response as an unknown authorization code.
+		respondUserError(c, errcode.ErrUserAuthCodeNotFound)
+		return
+	}
+	consumed, err := u.scanLoginAuthorizations.Consume(authCode, authInfo)
+	if err != nil {
+		u.Error("原子消费扫码授权码失败！", zap.Error(err))
+		respondUserError(c, errcode.ErrUserStoreFailed)
+		return
+	}
+	if !consumed {
+		respondUserError(c, errcode.ErrUserAuthCodeNotFound)
+		return
+	}
+	// Consumption happens before any login side effect. A downstream failure
+	// burns this authorization and requires a fresh scan; fail-closed behavior
+	// is preferable to making a credential replayable across replicas.
 	// 获取老的token
 	token, err := u.ctx.Cache().Get(fmt.Sprintf("%s%d%s", u.ctx.GetConfig().Cache.UIDTokenCachePrefix, flag, scaner))
 	if err != nil {
@@ -2289,7 +2329,6 @@ func (u *User) loginWithAuthCode(c *wkhttp.Context) {
 		return
 	}
 	// 获取缓存设备
-	uuid, _ := authInfoMap["uuid"].(string)
 	if uuid != "" {
 		deviceCache, err := u.ctx.GetRedisConn().GetString(fmt.Sprintf("%s%s", common.DeviceCacheUUIDPrefix, uuid))
 		if err != nil {
@@ -2385,13 +2424,7 @@ func (u *User) loginWithAuthCode(c *wkhttp.Context) {
 		return
 	}
 
-	err = u.ctx.GetRedisConn().Del(authCodeKey)
-	if err != nil {
-		u.Error("删除授权码失败！", zap.Error(err))
-		respondUserError(c, errcode.ErrUserStoreFailed)
-		return
-	}
-	// 登录已完成，与上面删除 authCode 同一个理由：把这一轮扫码留下的状态全部清掉，
+	// 登录已完成，把这一轮扫码留下的状态全部清掉，
 	// 不给已完成的会话留任何残余窗口。两处失败都不阻断登录（各自 TTL 会兜底）。
 	//   - 轮询密钥：留着等于多一段能读出凭据字段的时间
 	//   - qrcode:{uuid}：还携带 uid / auth_code / encrypt，其中 encrypt 是 Signal 密钥
@@ -2474,6 +2507,10 @@ func SendQRCodeInfo(uuid string, qrcode *common.QRCodeModel) {
 
 // 授权登录
 func (u *User) grantLogin(c *wkhttp.Context) {
+	if !common2.EnsureSystemSettings(u.ctx).ScanLoginEnabled() {
+		respondUserError(c, errcode.ErrUserScanLoginDisabled)
+		return
+	}
 	authCode := c.Query("auth_code")
 	loginUID := c.MustGet("uid").(string)
 	encrypt := c.Query("encrypt") // signal相关密钥
@@ -2481,7 +2518,7 @@ func (u *User) grantLogin(c *wkhttp.Context) {
 		respondUserRequestInvalid(c, "auth_code")
 		return
 	}
-	authInfo, err := u.ctx.GetRedisConn().GetString(fmt.Sprintf("%s%s", common.AuthCodeCachePrefix, authCode))
+	authInfo, err := u.ctx.GetRedisConn().GetString(scanLoginPendingAuthorizationKey(authCode))
 	if err != nil {
 		u.Error("获取授权信息失败！", zap.Error(err))
 		respondUserError(c, errcode.ErrUserQueryFailed)
@@ -2516,20 +2553,19 @@ func (u *User) grantLogin(c *wkhttp.Context) {
 		respondUserError(c, errcode.ErrUserAuthScannerMismatch)
 		return
 	}
-	uuid, _ := authInfoMap["uuid"].(string)
-	// authCode 是在**扫码**时签发的（handleScanLogin，TTL = ScanLoginAuthCodeTTL），而
-	// 用户可以在确认页停留到该 TTL 的最后一刻。下面把 qrcode:{uuid} 续成满 TTL 却不续
-	// authCode，就会出现「status 显示 authed、附带的 auth_code 只剩一秒」——浏览器兑换时
-	// 撞 ErrUserAuthCodeNotFound，而状态机已经停在 authed 无路可走。
-	//
-	// 在这里按同一档位重新计时：确认之后 authCode 与 qrcode 同时起算、同时到期，窗口
-	// 不再可能倒挂。（此前 authCode 是 10min、确认窗口 5min，靠 5 分钟余量把这个竞态盖住
-	// 了；TTL 收敛到 5min 后余量归零，必须显式修。）
-	if err = u.ctx.GetRedisConn().SetAndExpire(
-		fmt.Sprintf("%s%s", common.AuthCodeCachePrefix, authCode), authInfo, ScanLoginAuthCodeTTL,
-	); err != nil {
-		u.Error("续期扫码授权码失败！", zap.Error(err))
+	uuid, ok := authInfoMap["uuid"].(string)
+	if !ok || uuid == "" {
+		respondUserAuthInfoInvalid(c, "uuid")
+		return
+	}
+	promoted, err := u.scanLoginAuthorizations.Promote(authCode, authInfo, ScanLoginAuthCodeTTL)
+	if err != nil {
+		u.Error("提升扫码授权码失败！", zap.Error(err))
 		respondUserError(c, errcode.ErrUserStoreFailed)
+		return
+	}
+	if !promoted {
+		respondUserError(c, errcode.ErrUserAuthCodeNotFound)
 		return
 	}
 	qrcodeInfo := common.NewQRCodeModel(common.QRCodeTypeScanLogin, map[string]interface{}{
@@ -2542,6 +2578,11 @@ func (u *User) grantLogin(c *wkhttp.Context) {
 	err = u.ctx.GetRedisConn().SetAndExpire(fmt.Sprintf("%s%s", common.QRCodeCachePrefix, uuid), util.ToJson(qrcodeInfo), ScanLoginConfirmWindow)
 	if err != nil {
 		u.Error("更新二维码信息失败！", zap.Error(err))
+		if revoked, revokeErr := u.scanLoginAuthorizations.Consume(authCode, authInfo); revokeErr != nil {
+			u.Warn("回滚扫码授权码失败！", zap.Error(revokeErr))
+		} else if !revoked {
+			u.Warn("扫码授权码在状态写入失败后已不再可回滚", zap.String("uuid", uuid))
+		}
 		respondUserError(c, errcode.ErrUserStoreFailed)
 		return
 	}

--- a/modules/user/scanlogin_audit.go
+++ b/modules/user/scanlogin_audit.go
@@ -1,0 +1,43 @@
+package user
+
+import "go.uber.org/zap"
+
+type scanLoginWarningLogger interface {
+	Warn(message string, fields ...zap.Field)
+}
+
+type scanLoginRedemptionAudit struct {
+	logger     scanLoginWarningLogger
+	uuid       string
+	scannerUID string
+	completed  bool
+}
+
+func newScanLoginRedemptionAudit(
+	logger scanLoginWarningLogger,
+	uuid string,
+	scannerUID string,
+) *scanLoginRedemptionAudit {
+	return &scanLoginRedemptionAudit{
+		logger:     logger,
+		uuid:       uuid,
+		scannerUID: scannerUID,
+	}
+}
+
+func (a *scanLoginRedemptionAudit) MarkCompleted() {
+	if a != nil {
+		a.completed = true
+	}
+}
+
+func (a *scanLoginRedemptionAudit) WarnIfIncomplete() {
+	if a == nil || a.completed || a.logger == nil {
+		return
+	}
+	a.logger.Warn(
+		"扫码授权已消费但登录未完成",
+		zap.String("uuid", a.uuid),
+		zap.String("scanner_uid", a.scannerUID),
+	)
+}

--- a/modules/user/scanlogin_audit_test.go
+++ b/modules/user/scanlogin_audit_test.go
@@ -1,0 +1,57 @@
+package user
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+type capturedScanLoginWarning struct {
+	message string
+	fields  []zap.Field
+}
+
+type scanLoginAuditTestLogger struct {
+	warnings []capturedScanLoginWarning
+}
+
+func (l *scanLoginAuditTestLogger) Warn(message string, fields ...zap.Field) {
+	l.warnings = append(l.warnings, capturedScanLoginWarning{message: message, fields: fields})
+}
+
+func TestScanLoginRedemptionAuditWarnsOnlyWhenLoginIsIncomplete(t *testing.T) {
+	tests := []struct {
+		name         string
+		completed    bool
+		wantWarnings int
+	}{
+		{name: "consumed authorization without login completion", wantWarnings: 1},
+		{name: "successful login", completed: true, wantWarnings: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger := &scanLoginAuditTestLogger{}
+			audit := newScanLoginRedemptionAudit(logger, "qr-uuid", "scanner-uid")
+			if tt.completed {
+				audit.MarkCompleted()
+			}
+
+			audit.WarnIfIncomplete()
+
+			require.Len(t, logger.warnings, tt.wantWarnings)
+			if tt.wantWarnings == 0 {
+				return
+			}
+			warning := logger.warnings[0]
+			assert.Equal(t, "扫码授权已消费但登录未完成", warning.message)
+			require.Len(t, warning.fields, 2)
+			assert.Equal(t, "uuid", warning.fields[0].Key)
+			assert.Equal(t, "qr-uuid", warning.fields[0].String)
+			assert.Equal(t, "scanner_uid", warning.fields[1].Key)
+			assert.Equal(t, "scanner-uid", warning.fields[1].String)
+		})
+	}
+}

--- a/modules/user/scanlogin_authorization.go
+++ b/modules/user/scanlogin_authorization.go
@@ -140,6 +140,12 @@ return 1
 // RollbackPromotion atomically restores a ready authorization to pending when
 // publishing the authed QR state fails. It never overwrites an existing pending
 // record, so a stale rollback cannot replace a newer confirmation attempt.
+//
+// A Redis write error can be outcome-ambiguous: the authed QR state may have
+// reached Redis before its caller observed an error. Rolling back still favors
+// non-redeemability, so the QR may temporarily say authed while this record is
+// pending again. Clients must treat a failed redemption as retryable by starting
+// a fresh scan flow instead of treating the displayed QR state as final success.
 func (s *scanLoginAuthorizationStore) RollbackPromotion(authCode, expected string, ttl time.Duration) (bool, error) {
 	if s == nil || s.client == nil || authCode == "" || expected == "" || ttl <= 0 {
 		return false, errScanLoginAuthorizationInvalid

--- a/modules/user/scanlogin_authorization.go
+++ b/modules/user/scanlogin_authorization.go
@@ -101,6 +101,10 @@ return 1
 // Promote atomically moves the exact pending payload into the redeemable
 // namespace. Comparing the value prevents a stale reader from promoting a
 // record that changed between GET and the script.
+//
+// The script spans pending and ready keys without Redis hash tags. This service
+// currently uses a single-node *redis.Client; migrating this path to Redis
+// Cluster requires colocating both keys in one hash slot before rollout.
 func (s *scanLoginAuthorizationStore) Promote(authCode, expected string, ttl time.Duration) (bool, error) {
 	if s == nil || s.client == nil || authCode == "" || expected == "" || ttl <= 0 {
 		return false, errScanLoginAuthorizationInvalid
@@ -116,6 +120,41 @@ func (s *scanLoginAuthorizationStore) Promote(authCode, expected string, ttl tim
 	).Int64()
 	if err != nil {
 		return false, fmt.Errorf("promote scan login authorization: %w", err)
+	}
+	return result == 1, nil
+}
+
+var rollbackScanLoginAuthorizationScript = rd.NewScript(`
+local ready = redis.call("GET", KEYS[1])
+if not ready or ready ~= ARGV[1] then
+  return 0
+end
+if redis.call("EXISTS", KEYS[2]) == 1 then
+  return 0
+end
+redis.call("SET", KEYS[2], ready, "PX", ARGV[2])
+redis.call("DEL", KEYS[1])
+return 1
+`)
+
+// RollbackPromotion atomically restores a ready authorization to pending when
+// publishing the authed QR state fails. It never overwrites an existing pending
+// record, so a stale rollback cannot replace a newer confirmation attempt.
+func (s *scanLoginAuthorizationStore) RollbackPromotion(authCode, expected string, ttl time.Duration) (bool, error) {
+	if s == nil || s.client == nil || authCode == "" || expected == "" || ttl <= 0 {
+		return false, errScanLoginAuthorizationInvalid
+	}
+	result, err := rollbackScanLoginAuthorizationScript.Run(
+		s.client,
+		[]string{
+			scanLoginReadyAuthorizationKey(authCode),
+			scanLoginPendingAuthorizationKey(authCode),
+		},
+		expected,
+		strconv.FormatInt(ttl.Milliseconds(), 10),
+	).Int64()
+	if err != nil {
+		return false, fmt.Errorf("rollback scan login authorization: %w", err)
 	}
 	return result == 1, nil
 }

--- a/modules/user/scanlogin_authorization.go
+++ b/modules/user/scanlogin_authorization.go
@@ -1,0 +1,148 @@
+package user
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+	"time"
+
+	libcommon "github.com/Mininglamp-OSS/octo-lib/common"
+	rd "github.com/go-redis/redis"
+)
+
+const scanLoginPendingAuthorizationPrefix = "scanlogin:pending:"
+
+var errScanLoginAuthorizationInvalid = errors.New("scan login authorization is invalid")
+
+type scanLoginAuthorization struct {
+	ScannerUID string `json:"scaner"`
+	Type       string `json:"type"`
+	UUID       string `json:"uuid"`
+}
+
+// ScanLoginPendingStore is the minimal Redis capability needed by the QR-code
+// module to create and clean up a pending confirmation. The redeemable
+// AuthCodeCachePrefix is intentionally not written through this interface.
+type ScanLoginPendingStore interface {
+	SetAndExpire(key string, value interface{}, expire time.Duration) error
+	Del(key string) error
+}
+
+func scanLoginPendingAuthorizationKey(authCode string) string {
+	return scanLoginPendingAuthorizationPrefix + authCode
+}
+
+func scanLoginReadyAuthorizationKey(authCode string) string {
+	return fmt.Sprintf("%s%s", libcommon.AuthCodeCachePrefix, authCode)
+}
+
+func encodeScanLoginAuthorization(scannerUID, uuid string) (string, error) {
+	if scannerUID == "" || uuid == "" {
+		return "", errScanLoginAuthorizationInvalid
+	}
+	payload, err := json.Marshal(scanLoginAuthorization{
+		ScannerUID: scannerUID,
+		Type:       string(libcommon.AuthCodeTypeScanLogin),
+		UUID:       uuid,
+	})
+	if err != nil {
+		return "", fmt.Errorf("encode scan login authorization: %w", err)
+	}
+	return string(payload), nil
+}
+
+// SavePendingScanLoginAuthorization creates a confirmation record that cannot
+// be redeemed by login_authcode. Only grant_login can promote it into the
+// established AuthCodeCachePrefix namespace.
+func SavePendingScanLoginAuthorization(store ScanLoginPendingStore, authCode, scannerUID, uuid string) error {
+	if store == nil || authCode == "" {
+		return errScanLoginAuthorizationInvalid
+	}
+	encoded, err := encodeScanLoginAuthorization(scannerUID, uuid)
+	if err != nil {
+		return err
+	}
+	return store.SetAndExpire(
+		scanLoginPendingAuthorizationKey(authCode),
+		encoded,
+		ScanLoginConfirmWindow,
+	)
+}
+
+// DeletePendingScanLoginAuthorization compensates a QR-state write failure.
+// The pending record is not redeemable, but retaining an orphan needlessly
+// extends the scanner's confirmation surface until TTL expiry.
+func DeletePendingScanLoginAuthorization(store ScanLoginPendingStore, authCode string) error {
+	if store == nil || authCode == "" {
+		return nil
+	}
+	return store.Del(scanLoginPendingAuthorizationKey(authCode))
+}
+
+type scanLoginAuthorizationStore struct {
+	client *rd.Client
+}
+
+func newScanLoginAuthorizationStore(client *rd.Client) *scanLoginAuthorizationStore {
+	return &scanLoginAuthorizationStore{client: client}
+}
+
+var promoteScanLoginAuthorizationScript = rd.NewScript(`
+local pending = redis.call("GET", KEYS[1])
+if not pending or pending ~= ARGV[1] then
+  return 0
+end
+redis.call("SET", KEYS[2], pending, "PX", ARGV[2])
+redis.call("DEL", KEYS[1])
+return 1
+`)
+
+// Promote atomically moves the exact pending payload into the redeemable
+// namespace. Comparing the value prevents a stale reader from promoting a
+// record that changed between GET and the script.
+func (s *scanLoginAuthorizationStore) Promote(authCode, expected string, ttl time.Duration) (bool, error) {
+	if s == nil || s.client == nil || authCode == "" || expected == "" || ttl <= 0 {
+		return false, errScanLoginAuthorizationInvalid
+	}
+	result, err := promoteScanLoginAuthorizationScript.Run(
+		s.client,
+		[]string{
+			scanLoginPendingAuthorizationKey(authCode),
+			scanLoginReadyAuthorizationKey(authCode),
+		},
+		expected,
+		strconv.FormatInt(ttl.Milliseconds(), 10),
+	).Int64()
+	if err != nil {
+		return false, fmt.Errorf("promote scan login authorization: %w", err)
+	}
+	return result == 1, nil
+}
+
+var consumeScanLoginAuthorizationScript = rd.NewScript(`
+local ready = redis.call("GET", KEYS[1])
+if not ready or ready ~= ARGV[1] then
+  return 0
+end
+redis.call("DEL", KEYS[1])
+return 1
+`)
+
+// Consume atomically deletes the exact ready authorization. At most one
+// request across all replicas can return true, closing the GET-then-DEL replay
+// window in the former handler implementation.
+func (s *scanLoginAuthorizationStore) Consume(authCode, expected string) (bool, error) {
+	if s == nil || s.client == nil || authCode == "" || expected == "" {
+		return false, errScanLoginAuthorizationInvalid
+	}
+	result, err := consumeScanLoginAuthorizationScript.Run(
+		s.client,
+		[]string{scanLoginReadyAuthorizationKey(authCode)},
+		expected,
+	).Int64()
+	if err != nil {
+		return false, fmt.Errorf("consume scan login authorization: %w", err)
+	}
+	return result == 1, nil
+}

--- a/modules/user/scanlogin_authorization.go
+++ b/modules/user/scanlogin_authorization.go
@@ -11,7 +11,11 @@ import (
 	rd "github.com/go-redis/redis"
 )
 
-const scanLoginPendingAuthorizationPrefix = "scanlogin:pending:"
+const (
+	scanLoginPendingAuthorizationPrefix = "scanlogin:pending:"
+	scanLoginUUIDClaimPrefix            = "scanlogin:claim:"
+	scanLoginConsumedClaimPrefix        = "consumed:"
+)
 
 var errScanLoginAuthorizationInvalid = errors.New("scan login authorization is invalid")
 
@@ -35,6 +39,22 @@ func scanLoginPendingAuthorizationKey(authCode string) string {
 
 func scanLoginReadyAuthorizationKey(authCode string) string {
 	return fmt.Sprintf("%s%s", libcommon.AuthCodeCachePrefix, authCode)
+}
+
+func scanLoginUUIDClaimKey(uuid string) string {
+	return scanLoginUUIDClaimPrefix + uuid
+}
+
+func scanLoginAuthorizationUUID(encoded string) (string, error) {
+	var authorization scanLoginAuthorization
+	if err := json.Unmarshal([]byte(encoded), &authorization); err != nil {
+		return "", fmt.Errorf("decode scan login authorization: %w", err)
+	}
+	if authorization.ScannerUID == "" || authorization.UUID == "" ||
+		authorization.Type != string(libcommon.AuthCodeTypeScanLogin) {
+		return "", errScanLoginAuthorizationInvalid
+	}
+	return authorization.UUID, nil
 }
 
 func encodeScanLoginAuthorization(scannerUID, uuid string) (string, error) {
@@ -93,6 +113,12 @@ local pending = redis.call("GET", KEYS[1])
 if not pending or pending ~= ARGV[1] then
   return 0
 end
+local claim = redis.call("GET", KEYS[3])
+if claim and claim ~= ARGV[3] then
+  redis.call("DEL", KEYS[1])
+  return 0
+end
+redis.call("SET", KEYS[3], ARGV[3], "PX", ARGV[2])
 redis.call("SET", KEYS[2], pending, "PX", ARGV[2])
 redis.call("DEL", KEYS[1])
 return 1
@@ -102,21 +128,27 @@ return 1
 // namespace. Comparing the value prevents a stale reader from promoting a
 // record that changed between GET and the script.
 //
-// The script spans pending and ready keys without Redis hash tags. This service
-// currently uses a single-node *redis.Client; migrating this path to Redis
-// Cluster requires colocating both keys in one hash slot before rollout.
+// The script spans pending, ready, and per-UUID claim keys without Redis hash
+// tags. This service currently uses a single-node *redis.Client; migrating this
+// path to Redis Cluster requires colocating all keys in one hash slot first.
 func (s *scanLoginAuthorizationStore) Promote(authCode, expected string, ttl time.Duration) (bool, error) {
 	if s == nil || s.client == nil || authCode == "" || expected == "" || ttl <= 0 {
 		return false, errScanLoginAuthorizationInvalid
+	}
+	uuid, err := scanLoginAuthorizationUUID(expected)
+	if err != nil {
+		return false, err
 	}
 	result, err := promoteScanLoginAuthorizationScript.Run(
 		s.client,
 		[]string{
 			scanLoginPendingAuthorizationKey(authCode),
 			scanLoginReadyAuthorizationKey(authCode),
+			scanLoginUUIDClaimKey(uuid),
 		},
 		expected,
 		strconv.FormatInt(ttl.Milliseconds(), 10),
+		authCode,
 	).Int64()
 	if err != nil {
 		return false, fmt.Errorf("promote scan login authorization: %w", err)
@@ -129,17 +161,23 @@ local ready = redis.call("GET", KEYS[1])
 if not ready or ready ~= ARGV[1] then
   return 0
 end
+local claim = redis.call("GET", KEYS[3])
+if not claim or claim ~= ARGV[3] then
+  return 0
+end
 if redis.call("EXISTS", KEYS[2]) == 1 then
   return 0
 end
 redis.call("SET", KEYS[2], ready, "PX", ARGV[2])
+redis.call("SET", KEYS[3], ARGV[3], "PX", ARGV[2])
 redis.call("DEL", KEYS[1])
 return 1
 `)
 
 // RollbackPromotion atomically restores a ready authorization to pending when
 // publishing the authed QR state fails. It never overwrites an existing pending
-// record, so a stale rollback cannot replace a newer confirmation attempt.
+// record and preserves the UUID claim for this auth code, so only the same
+// confirmation can be retried after rollback.
 //
 // A Redis write error can be outcome-ambiguous: the authed QR state may have
 // reached Redis before its caller observed an error. Rolling back still favors
@@ -150,14 +188,20 @@ func (s *scanLoginAuthorizationStore) RollbackPromotion(authCode, expected strin
 	if s == nil || s.client == nil || authCode == "" || expected == "" || ttl <= 0 {
 		return false, errScanLoginAuthorizationInvalid
 	}
+	uuid, err := scanLoginAuthorizationUUID(expected)
+	if err != nil {
+		return false, err
+	}
 	result, err := rollbackScanLoginAuthorizationScript.Run(
 		s.client,
 		[]string{
 			scanLoginReadyAuthorizationKey(authCode),
 			scanLoginPendingAuthorizationKey(authCode),
+			scanLoginUUIDClaimKey(uuid),
 		},
 		expected,
 		strconv.FormatInt(ttl.Milliseconds(), 10),
+		authCode,
 	).Int64()
 	if err != nil {
 		return false, fmt.Errorf("rollback scan login authorization: %w", err)
@@ -170,21 +214,36 @@ local ready = redis.call("GET", KEYS[1])
 if not ready or ready ~= ARGV[1] then
   return 0
 end
+local claim = redis.call("GET", KEYS[2])
+if not claim or claim ~= ARGV[2] then
+  return 0
+end
 redis.call("DEL", KEYS[1])
+redis.call("SET", KEYS[2], ARGV[3] .. ARGV[2], "PX", ARGV[4])
 return 1
 `)
 
-// Consume atomically deletes the exact ready authorization. At most one
-// request across all replicas can return true, closing the GET-then-DEL replay
-// window in the former handler implementation.
+// Consume atomically deletes the exact ready authorization and marks its UUID
+// claim consumed. At most one request across all auth codes and replicas can
+// return true for a browser QR session.
 func (s *scanLoginAuthorizationStore) Consume(authCode, expected string) (bool, error) {
 	if s == nil || s.client == nil || authCode == "" || expected == "" {
 		return false, errScanLoginAuthorizationInvalid
 	}
+	uuid, err := scanLoginAuthorizationUUID(expected)
+	if err != nil {
+		return false, err
+	}
 	result, err := consumeScanLoginAuthorizationScript.Run(
 		s.client,
-		[]string{scanLoginReadyAuthorizationKey(authCode)},
+		[]string{
+			scanLoginReadyAuthorizationKey(authCode),
+			scanLoginUUIDClaimKey(uuid),
+		},
 		expected,
+		authCode,
+		scanLoginConsumedClaimPrefix,
+		strconv.FormatInt(ScanLoginConfirmWindow.Milliseconds(), 10),
 	).Int64()
 	if err != nil {
 		return false, fmt.Errorf("consume scan login authorization: %w", err)

--- a/modules/user/scanlogin_authorization_test.go
+++ b/modules/user/scanlogin_authorization_test.go
@@ -1,6 +1,7 @@
 package user
 
 import (
+	"fmt"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -10,6 +11,37 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+type fakeScanLoginPendingStore struct {
+	key     string
+	value   string
+	expire  time.Duration
+	deleted string
+}
+
+func (s *fakeScanLoginPendingStore) SetAndExpire(key string, value interface{}, expire time.Duration) error {
+	s.key = key
+	s.value = fmt.Sprint(value)
+	s.expire = expire
+	return nil
+}
+
+func (s *fakeScanLoginPendingStore) Del(key string) error {
+	s.deleted = key
+	return nil
+}
+
+func TestSavePendingScanLoginAuthorization_UsesNonRedeemableNamespace(t *testing.T) {
+	store := &fakeScanLoginPendingStore{}
+	require.NoError(t, SavePendingScanLoginAuthorization(store, "code-1", "scanner-1", "uuid-1"))
+
+	assert.Equal(t, scanLoginPendingAuthorizationKey("code-1"), store.key)
+	assert.NotEqual(t, scanLoginReadyAuthorizationKey("code-1"), store.key)
+	assert.Equal(t, ScanLoginConfirmWindow, store.expire)
+	want, err := encodeScanLoginAuthorization("scanner-1", "uuid-1")
+	require.NoError(t, err)
+	assert.Equal(t, want, store.value)
+}
 
 func newScanLoginAuthorizationStoreForTest(t *testing.T) *scanLoginAuthorizationStore {
 	t.Helper()

--- a/modules/user/scanlogin_authorization_test.go
+++ b/modules/user/scanlogin_authorization_test.go
@@ -43,6 +43,57 @@ func TestSavePendingScanLoginAuthorization_UsesNonRedeemableNamespace(t *testing
 	assert.Equal(t, want, store.value)
 }
 
+func TestScanLoginAuthorization_RejectsInvalidPayloadsAndArguments(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		encoded string
+	}{
+		{name: "invalid JSON", encoded: "not-json"},
+		{name: "missing scanner", encoded: `{"type":"scan_login","uuid":"uuid-1"}`},
+		{name: "missing UUID", encoded: `{"scaner":"scanner-1","type":"scan_login"}`},
+		{name: "wrong type", encoded: `{"scaner":"scanner-1","type":"group","uuid":"uuid-1"}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := scanLoginAuthorizationUUID(tc.encoded)
+			require.Error(t, err)
+		})
+	}
+
+	_, err := encodeScanLoginAuthorization("", "uuid-1")
+	require.ErrorIs(t, err, errScanLoginAuthorizationInvalid)
+	_, err = encodeScanLoginAuthorization("scanner-1", "")
+	require.ErrorIs(t, err, errScanLoginAuthorizationInvalid)
+
+	fake := &fakeScanLoginPendingStore{}
+	require.ErrorIs(t,
+		SavePendingScanLoginAuthorization(nil, "code", "scanner-1", "uuid-1"),
+		errScanLoginAuthorizationInvalid)
+	require.ErrorIs(t,
+		SavePendingScanLoginAuthorization(fake, "", "scanner-1", "uuid-1"),
+		errScanLoginAuthorizationInvalid)
+	require.NoError(t, DeletePendingScanLoginAuthorization(nil, "code"))
+	require.NoError(t, DeletePendingScanLoginAuthorization(fake, ""))
+	require.NoError(t, DeletePendingScanLoginAuthorization(fake, "code"))
+	assert.Equal(t, scanLoginPendingAuthorizationKey("code"), fake.deleted)
+
+	invalidStore := &scanLoginAuthorizationStore{}
+	_, err = invalidStore.Promote("code", "payload", time.Minute)
+	require.ErrorIs(t, err, errScanLoginAuthorizationInvalid)
+	_, err = invalidStore.RollbackPromotion("code", "payload", time.Minute)
+	require.ErrorIs(t, err, errScanLoginAuthorizationInvalid)
+	_, err = invalidStore.Consume("code", "payload")
+	require.ErrorIs(t, err, errScanLoginAuthorizationInvalid)
+
+	decodingStore := &scanLoginAuthorizationStore{client: rd.NewClient(&rd.Options{Addr: "127.0.0.1:0"})}
+	t.Cleanup(func() { _ = decodingStore.client.Close() })
+	_, err = decodingStore.Promote("code", "not-json", time.Minute)
+	require.Error(t, err)
+	_, err = decodingStore.RollbackPromotion("code", "not-json", time.Minute)
+	require.Error(t, err)
+	_, err = decodingStore.Consume("code", "not-json")
+	require.Error(t, err)
+}
+
 func newScanLoginAuthorizationStoreForTest(t *testing.T) *scanLoginAuthorizationStore {
 	t.Helper()
 	client := rd.NewClient(&rd.Options{
@@ -65,15 +116,19 @@ func TestScanLoginAuthorization_PromoteAndConsumeAreAtomic(t *testing.T) {
 	authCode := "scan-auth-" + time.Now().Format("150405.000000000")
 	pendingKey := scanLoginPendingAuthorizationKey(authCode)
 	readyKey := scanLoginReadyAuthorizationKey(authCode)
+	claimKey := scanLoginUUIDClaimKey("uuid-1")
 	t.Cleanup(func() {
-		_ = store.client.Del(pendingKey, readyKey).Err()
+		_ = store.client.Del(pendingKey, readyKey, claimKey).Err()
 	})
+	require.NoError(t, store.client.Del(claimKey).Err())
 
 	expected, err := encodeScanLoginAuthorization("scanner-1", "uuid-1")
 	require.NoError(t, err)
+	wrongExpected, err := encodeScanLoginAuthorization("scanner-wrong", "uuid-1")
+	require.NoError(t, err)
 	require.NoError(t, store.client.Set(pendingKey, expected, time.Minute).Err())
 
-	wrong, err := store.Promote(authCode, expected+"-wrong", time.Minute)
+	wrong, err := store.Promote(authCode, wrongExpected, time.Minute)
 	require.NoError(t, err)
 	assert.False(t, wrong)
 	assert.Equal(t, expected, store.client.Get(pendingKey).Val())
@@ -101,7 +156,7 @@ func TestScanLoginAuthorization_PromoteAndConsumeAreAtomic(t *testing.T) {
 	assert.Equal(t, rd.Nil, store.client.Get(pendingKey).Err())
 	assert.Equal(t, expected, store.client.Get(readyKey).Val())
 
-	consumedWrong, err := store.Consume(authCode, expected+"-wrong")
+	consumedWrong, err := store.Consume(authCode, wrongExpected)
 	require.NoError(t, err)
 	assert.False(t, consumedWrong)
 	assert.Equal(t, expected, store.client.Get(readyKey).Val())
@@ -130,7 +185,7 @@ func TestScanLoginAuthorization_UUIDClaimAllowsOnlyOneAuthorization(t *testing.T
 	store := newScanLoginAuthorizationStoreForTest(t)
 	uuid := "scan-uuid-claim-" + time.Now().Format("150405.000000000")
 	authCodes := []string{uuid + "-a", uuid + "-b"}
-	claimKey := "scanlogin:claim:" + uuid
+	claimKey := scanLoginUUIDClaimKey(uuid)
 	expected, err := encodeScanLoginAuthorization("scanner-1", uuid)
 	require.NoError(t, err)
 
@@ -196,15 +251,20 @@ func TestScanLoginAuthorization_RollbackPromotionRestoresPending(t *testing.T) {
 	authCode := "scan-rollback-" + time.Now().Format("150405.000000000")
 	pendingKey := scanLoginPendingAuthorizationKey(authCode)
 	readyKey := scanLoginReadyAuthorizationKey(authCode)
+	uuid := "uuid-" + authCode
+	claimKey := scanLoginUUIDClaimKey(uuid)
 	t.Cleanup(func() {
-		_ = store.client.Del(pendingKey, readyKey).Err()
+		_ = store.client.Del(pendingKey, readyKey, claimKey).Err()
 	})
 
-	expected, err := encodeScanLoginAuthorization("scanner-1", "uuid-1")
+	expected, err := encodeScanLoginAuthorization("scanner-1", uuid)
+	require.NoError(t, err)
+	wrongExpected, err := encodeScanLoginAuthorization("scanner-wrong", uuid)
 	require.NoError(t, err)
 	require.NoError(t, store.client.Set(readyKey, expected, time.Minute).Err())
+	require.NoError(t, store.client.Set(claimKey, authCode, time.Minute).Err())
 
-	wrong, err := store.RollbackPromotion(authCode, expected+"-wrong", time.Minute)
+	wrong, err := store.RollbackPromotion(authCode, wrongExpected, time.Minute)
 	require.NoError(t, err)
 	assert.False(t, wrong)
 	assert.Equal(t, expected, store.client.Get(readyKey).Val())
@@ -223,7 +283,9 @@ func TestScanLoginAuthorization_RollbackPromotionRestoresPending(t *testing.T) {
 	assert.True(t, restored)
 	assert.Equal(t, rd.Nil, store.client.Get(readyKey).Err())
 	assert.Equal(t, expected, store.client.Get(pendingKey).Val())
+	assert.Equal(t, authCode, store.client.Get(claimKey).Val())
 	assert.Greater(t, store.client.PTTL(pendingKey).Val(), time.Duration(0))
+	assert.Greater(t, store.client.PTTL(claimKey).Val(), time.Duration(0))
 
 	replayed, err := store.RollbackPromotion(authCode, expected, time.Minute)
 	require.NoError(t, err)

--- a/modules/user/scanlogin_authorization_test.go
+++ b/modules/user/scanlogin_authorization_test.go
@@ -125,3 +125,42 @@ func TestScanLoginAuthorization_PromoteAndConsumeAreAtomic(t *testing.T) {
 	assert.Equal(t, int32(1), consumed)
 	assert.Equal(t, rd.Nil, store.client.Get(readyKey).Err())
 }
+
+func TestScanLoginAuthorization_RollbackPromotionRestoresPending(t *testing.T) {
+	store := newScanLoginAuthorizationStoreForTest(t)
+	authCode := "scan-rollback-" + time.Now().Format("150405.000000000")
+	pendingKey := scanLoginPendingAuthorizationKey(authCode)
+	readyKey := scanLoginReadyAuthorizationKey(authCode)
+	t.Cleanup(func() {
+		_ = store.client.Del(pendingKey, readyKey).Err()
+	})
+
+	expected, err := encodeScanLoginAuthorization("scanner-1", "uuid-1")
+	require.NoError(t, err)
+	require.NoError(t, store.client.Set(readyKey, expected, time.Minute).Err())
+
+	wrong, err := store.RollbackPromotion(authCode, expected+"-wrong", time.Minute)
+	require.NoError(t, err)
+	assert.False(t, wrong)
+	assert.Equal(t, expected, store.client.Get(readyKey).Val())
+	assert.Equal(t, rd.Nil, store.client.Get(pendingKey).Err())
+
+	require.NoError(t, store.client.Set(pendingKey, "newer-pending", time.Minute).Err())
+	conflict, err := store.RollbackPromotion(authCode, expected, time.Minute)
+	require.NoError(t, err)
+	assert.False(t, conflict, "rollback must not overwrite an existing pending authorization")
+	assert.Equal(t, expected, store.client.Get(readyKey).Val())
+	assert.Equal(t, "newer-pending", store.client.Get(pendingKey).Val())
+	require.NoError(t, store.client.Del(pendingKey).Err())
+
+	restored, err := store.RollbackPromotion(authCode, expected, time.Minute)
+	require.NoError(t, err)
+	assert.True(t, restored)
+	assert.Equal(t, rd.Nil, store.client.Get(readyKey).Err())
+	assert.Equal(t, expected, store.client.Get(pendingKey).Val())
+	assert.Greater(t, store.client.PTTL(pendingKey).Val(), time.Duration(0))
+
+	replayed, err := store.RollbackPromotion(authCode, expected, time.Minute)
+	require.NoError(t, err)
+	assert.False(t, replayed)
+}

--- a/modules/user/scanlogin_authorization_test.go
+++ b/modules/user/scanlogin_authorization_test.go
@@ -126,6 +126,71 @@ func TestScanLoginAuthorization_PromoteAndConsumeAreAtomic(t *testing.T) {
 	assert.Equal(t, rd.Nil, store.client.Get(readyKey).Err())
 }
 
+func TestScanLoginAuthorization_UUIDClaimAllowsOnlyOneAuthorization(t *testing.T) {
+	store := newScanLoginAuthorizationStoreForTest(t)
+	uuid := "scan-uuid-claim-" + time.Now().Format("150405.000000000")
+	authCodes := []string{uuid + "-a", uuid + "-b"}
+	claimKey := "scanlogin:claim:" + uuid
+	expected, err := encodeScanLoginAuthorization("scanner-1", uuid)
+	require.NoError(t, err)
+
+	keys := []string{claimKey}
+	for _, authCode := range authCodes {
+		pendingKey := scanLoginPendingAuthorizationKey(authCode)
+		readyKey := scanLoginReadyAuthorizationKey(authCode)
+		keys = append(keys, pendingKey, readyKey)
+		require.NoError(t, store.client.Set(pendingKey, expected, time.Minute).Err())
+	}
+	t.Cleanup(func() { _ = store.client.Del(keys...).Err() })
+
+	start := make(chan struct{})
+	results := make([]bool, len(authCodes))
+	errs := make([]error, len(authCodes))
+	var wg sync.WaitGroup
+	wg.Add(len(authCodes))
+	for i, authCode := range authCodes {
+		go func(i int, authCode string) {
+			defer wg.Done()
+			<-start
+			results[i], errs[i] = store.Promote(authCode, expected, time.Minute)
+		}(i, authCode)
+	}
+	close(start)
+	wg.Wait()
+
+	winner := -1
+	for i := range authCodes {
+		require.NoError(t, errs[i])
+		if results[i] {
+			require.Equal(t, -1, winner, "only one auth code may claim a QR session")
+			winner = i
+		}
+	}
+	require.NotEqual(t, -1, winner)
+	loser := 1 - winner
+	assert.Equal(t, authCodes[winner], store.client.Get(claimKey).Val())
+	assert.Equal(t, expected, store.client.Get(scanLoginReadyAuthorizationKey(authCodes[winner])).Val())
+	assert.Equal(t, rd.Nil, store.client.Get(scanLoginPendingAuthorizationKey(authCodes[loser])).Err(),
+		"the losing pending authorization must be removed")
+	assert.Equal(t, rd.Nil, store.client.Get(scanLoginReadyAuthorizationKey(authCodes[loser])).Err())
+
+	consumed, err := store.Consume(authCodes[winner], expected)
+	require.NoError(t, err)
+	require.True(t, consumed)
+	assert.Equal(t, "consumed:"+authCodes[winner], store.client.Get(claimKey).Val())
+
+	lateAuthCode := uuid + "-late"
+	latePendingKey := scanLoginPendingAuthorizationKey(lateAuthCode)
+	lateReadyKey := scanLoginReadyAuthorizationKey(lateAuthCode)
+	keys = append(keys, latePendingKey, lateReadyKey)
+	require.NoError(t, store.client.Set(latePendingKey, expected, time.Minute).Err())
+	promoted, err := store.Promote(lateAuthCode, expected, time.Minute)
+	require.NoError(t, err)
+	assert.False(t, promoted, "a consumed QR session must reject later authorizations")
+	assert.Equal(t, rd.Nil, store.client.Get(latePendingKey).Err())
+	assert.Equal(t, rd.Nil, store.client.Get(lateReadyKey).Err())
+}
+
 func TestScanLoginAuthorization_RollbackPromotionRestoresPending(t *testing.T) {
 	store := newScanLoginAuthorizationStoreForTest(t)
 	authCode := "scan-rollback-" + time.Now().Format("150405.000000000")

--- a/modules/user/scanlogin_authorization_test.go
+++ b/modules/user/scanlogin_authorization_test.go
@@ -1,0 +1,95 @@
+package user
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	rd "github.com/go-redis/redis"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newScanLoginAuthorizationStoreForTest(t *testing.T) *scanLoginAuthorizationStore {
+	t.Helper()
+	client := rd.NewClient(&rd.Options{
+		Addr:         "127.0.0.1:6399",
+		MaxRetries:   1,
+		DialTimeout:  2 * time.Second,
+		ReadTimeout:  2 * time.Second,
+		WriteTimeout: 2 * time.Second,
+	})
+	if err := client.Ping().Err(); err != nil {
+		_ = client.Close()
+		t.Skipf("test Redis unavailable: %v", err)
+	}
+	t.Cleanup(func() { _ = client.Close() })
+	return newScanLoginAuthorizationStore(client)
+}
+
+func TestScanLoginAuthorization_PromoteAndConsumeAreAtomic(t *testing.T) {
+	store := newScanLoginAuthorizationStoreForTest(t)
+	authCode := "scan-auth-" + time.Now().Format("150405.000000000")
+	pendingKey := scanLoginPendingAuthorizationKey(authCode)
+	readyKey := scanLoginReadyAuthorizationKey(authCode)
+	t.Cleanup(func() {
+		_ = store.client.Del(pendingKey, readyKey).Err()
+	})
+
+	expected, err := encodeScanLoginAuthorization("scanner-1", "uuid-1")
+	require.NoError(t, err)
+	require.NoError(t, store.client.Set(pendingKey, expected, time.Minute).Err())
+
+	wrong, err := store.Promote(authCode, expected+"-wrong", time.Minute)
+	require.NoError(t, err)
+	assert.False(t, wrong)
+	assert.Equal(t, expected, store.client.Get(pendingKey).Val())
+	assert.Equal(t, rd.Nil, store.client.Get(readyKey).Err())
+
+	const workers = 32
+	var promoted int32
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for i := 0; i < workers; i++ {
+		go func() {
+			defer wg.Done()
+			ok, promoteErr := store.Promote(authCode, expected, time.Minute)
+			if promoteErr != nil {
+				t.Errorf("promote: %v", promoteErr)
+				return
+			}
+			if ok {
+				atomic.AddInt32(&promoted, 1)
+			}
+		}()
+	}
+	wg.Wait()
+	assert.Equal(t, int32(1), promoted)
+	assert.Equal(t, rd.Nil, store.client.Get(pendingKey).Err())
+	assert.Equal(t, expected, store.client.Get(readyKey).Val())
+
+	consumedWrong, err := store.Consume(authCode, expected+"-wrong")
+	require.NoError(t, err)
+	assert.False(t, consumedWrong)
+	assert.Equal(t, expected, store.client.Get(readyKey).Val())
+
+	var consumed int32
+	wg.Add(workers)
+	for i := 0; i < workers; i++ {
+		go func() {
+			defer wg.Done()
+			ok, consumeErr := store.Consume(authCode, expected)
+			if consumeErr != nil {
+				t.Errorf("consume: %v", consumeErr)
+				return
+			}
+			if ok {
+				atomic.AddInt32(&consumed, 1)
+			}
+		}()
+	}
+	wg.Wait()
+	assert.Equal(t, int32(1), consumed)
+	assert.Equal(t, rd.Nil, store.client.Get(readyKey).Err())
+}

--- a/modules/user/scanlogin_policy_test.go
+++ b/modules/user/scanlogin_policy_test.go
@@ -1,6 +1,7 @@
 package user
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -19,6 +20,12 @@ func TestScanLoginDisabledBlocksUserEntryPoints(t *testing.T) {
 	s, ctx := testutil.NewTestServer()
 	wireI18nRendererForUserTest(s)
 	require.NoError(t, testutil.CleanAllTables(ctx))
+	authInfo, err := encodeScanLoginAuthorization(testutil.UID, "disabled-existing-uuid")
+	require.NoError(t, err)
+	require.NoError(t, ctx.GetRedisConn().SetAndExpire(
+		scanLoginPendingAuthorizationKey("code"), authInfo, time.Minute))
+	require.NoError(t, ctx.GetRedisConn().SetAndExpire(
+		scanLoginReadyAuthorizationKey("code"), authInfo, time.Minute))
 	setSystemSettingForUserTest(t, ctx, "login", "scan_enabled", "0", "bool")
 	require.NoError(t, commonsettings.EnsureSystemSettings(ctx).Reload())
 
@@ -45,6 +52,12 @@ func TestScanLoginDisabledBlocksUserEntryPoints(t *testing.T) {
 			assert.Contains(t, w.Body.String(), "err.server.user.scan_login_disabled")
 		})
 	}
+	pending, err := ctx.GetRedisConn().GetString(scanLoginPendingAuthorizationKey("code"))
+	require.NoError(t, err)
+	ready, err := ctx.GetRedisConn().GetString(scanLoginReadyAuthorizationKey("code"))
+	require.NoError(t, err)
+	assert.Equal(t, authInfo, pending, "disabled confirmation must not promote or delete an existing pending record")
+	assert.Equal(t, authInfo, ready, "disabled redemption must not consume an existing ready record")
 }
 
 func TestScanLoginStatusReturnsDisabledStateImmediately(t *testing.T) {
@@ -56,10 +69,12 @@ func TestScanLoginStatusReturnsDisabledStateImmediately(t *testing.T) {
 	w := httptest.NewRecorder()
 	req, _ := http.NewRequest(http.MethodGet, "/v1/user/loginstatus?uuid=existing-or-new", nil)
 	setPublicIPForUserTest(req, "9.9.8.20")
+	started := time.Now()
 	s.GetRoute().ServeHTTP(w, req)
 
 	require.Equal(t, http.StatusOK, w.Code)
 	assert.JSONEq(t, `{"status":"disabled"}`, w.Body.String())
+	assert.Less(t, time.Since(started), time.Second, "disabled status must bypass the 10-second long poll")
 }
 
 func TestLoginWithAuthCode_WrongPollSecretDoesNotConsumeAuthorization(t *testing.T) {
@@ -87,4 +102,80 @@ func TestLoginWithAuthCode_WrongPollSecretDoesNotConsumeAuthorization(t *testing
 	stillReady, err := ctx.GetRedisConn().GetString(authKey)
 	require.NoError(t, err)
 	assert.Equal(t, authInfo, stillReady, "wrong browser secret must not burn a valid confirmation")
+}
+
+func TestScanLoginAuthorization_RequiresConfirmationAndRedeemsOnce(t *testing.T) {
+	s, ctx := testutil.NewTestServer()
+	wireI18nRendererForUserTest(s)
+	require.NoError(t, testutil.CleanAllTables(ctx))
+	require.NoError(t, commonsettings.EnsureSystemSettings(ctx).Reload())
+
+	db := NewDB(ctx)
+	model, err := db.QueryByUID(testutil.UID)
+	require.NoError(t, err)
+	if model == nil {
+		require.NoError(t, db.Insert(&Model{
+			UID:      testutil.UID,
+			Name:     "scan login user",
+			Username: "scan_login_user",
+			ShortNo:  "scan001",
+			Status:   1,
+		}))
+	}
+
+	authCode := util.GenerUUID()
+	uuid := util.GenerUUID()
+	require.NoError(t, SavePendingScanLoginAuthorization(ctx.GetRedisConn(), authCode, testutil.UID, uuid))
+	pollSecret, err := mintScanLoginPollSecret(ctx.GetRedisConn(), uuid)
+	require.NoError(t, err)
+
+	// Scanning alone creates no ready authorization, even for the browser that
+	// owns the correct poll secret.
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodPost,
+		"/v1/user/login_authcode/"+authCode+"?poll_secret="+pollSecret, nil)
+	setPublicIPForUserTest(req, "9.9.8.40")
+	s.GetRoute().ServeHTTP(w, req)
+	assert.Contains(t, w.Body.String(), "err.server.user.auth_code_not_found")
+	pendingBeforeConfirm, err := ctx.GetRedisConn().GetString(scanLoginPendingAuthorizationKey(authCode))
+	require.NoError(t, err)
+	assert.NotEmpty(t, pendingBeforeConfirm)
+
+	// The authenticated scanner explicitly confirms, atomically promoting the
+	// pending record and publishing authed state to the browser.
+	w = httptest.NewRecorder()
+	req, _ = http.NewRequest(http.MethodGet, "/v1/user/grant_login?auth_code="+authCode, nil)
+	req.Header.Set("token", testutil.Token)
+	s.GetRoute().ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	pendingAfterConfirm, err := ctx.GetRedisConn().GetString(scanLoginPendingAuthorizationKey(authCode))
+	require.NoError(t, err)
+	ready, err := ctx.GetRedisConn().GetString(scanLoginReadyAuthorizationKey(authCode))
+	require.NoError(t, err)
+	assert.Empty(t, pendingAfterConfirm)
+	assert.Equal(t, pendingBeforeConfirm, ready)
+
+	qrcodeRaw, err := ctx.GetRedisConn().GetString(fmt.Sprintf("%s%s", libcommon.QRCodeCachePrefix, uuid))
+	require.NoError(t, err)
+	var qrcodeState libcommon.QRCodeModel
+	require.NoError(t, json.Unmarshal([]byte(qrcodeRaw), &qrcodeState))
+	assert.Equal(t, string(libcommon.ScanLoginStatusAuthed), fmt.Sprint(qrcodeState.Data["status"]))
+
+	// Exactly one redemption can issue a session. The second request observes
+	// the atomic consume and cannot replay the same authorization.
+	w = httptest.NewRecorder()
+	req, _ = http.NewRequest(http.MethodPost,
+		"/v1/user/login_authcode/"+authCode+"?poll_secret="+pollSecret, nil)
+	setPublicIPForUserTest(req, "9.9.8.41")
+	s.GetRoute().ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	assert.Contains(t, w.Body.String(), `"token"`)
+
+	w = httptest.NewRecorder()
+	req, _ = http.NewRequest(http.MethodPost,
+		"/v1/user/login_authcode/"+authCode+"?poll_secret="+pollSecret, nil)
+	setPublicIPForUserTest(req, "9.9.8.42")
+	s.GetRoute().ServeHTTP(w, req)
+	assert.Contains(t, w.Body.String(), "err.server.user.auth_code_not_found")
 }

--- a/modules/user/scanlogin_policy_test.go
+++ b/modules/user/scanlogin_policy_test.go
@@ -77,6 +77,50 @@ func TestScanLoginStatusReturnsDisabledStateImmediately(t *testing.T) {
 	assert.Less(t, time.Since(started), time.Second, "disabled status must bypass the 10-second long poll")
 }
 
+func TestScanLoginRateLimitsRejectNonFiniteRPSConfig(t *testing.T) {
+	t.Setenv("DM_API_SCANLOGIN_UUID_RATELIMIT_RPS", "NaN")
+	t.Setenv("DM_API_SCANLOGIN_UUID_RATELIMIT_BURST", "1")
+	t.Setenv("DM_API_SCANLOGIN_STATUS_RATELIMIT_RPS", "+Inf")
+	t.Setenv("DM_API_SCANLOGIN_STATUS_RATELIMIT_BURST", "1")
+
+	s, ctx := testutil.NewTestServer()
+	wireI18nRendererForUserTest(s)
+	require.NoError(t, testutil.CleanAllTables(ctx))
+	require.NoError(t, commonsettings.EnsureSystemSettings(ctx).Reload())
+
+	const ip = "9.9.8.21"
+	for _, key := range []string{
+		"ratelimit:strict:scanlogin_uuid:" + ip,
+		"ratelimit:strict:scanlogin_status:" + ip,
+	} {
+		require.NoError(t, ctx.GetRedisConn().Del(key))
+	}
+
+	for _, tc := range []struct {
+		name string
+		path string
+	}{
+		{name: "uuid NaN", path: "/v1/user/loginuuid"},
+		{name: "status positive infinity", path: "/v1/user/loginstatus?uuid=missing"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			for attempt := 1; attempt <= 2; attempt++ {
+				w := httptest.NewRecorder()
+				req, _ := http.NewRequest(http.MethodGet, tc.path, nil)
+				setPublicIPForUserTest(req, ip)
+				s.GetRoute().ServeHTTP(w, req)
+
+				if attempt == 1 {
+					require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+					continue
+				}
+				require.Equal(t, http.StatusTooManyRequests, w.Code, w.Body.String())
+				assert.Contains(t, w.Body.String(), "err.shared.rate.limited")
+			}
+		})
+	}
+}
+
 func TestLoginWithAuthCode_WrongPollSecretDoesNotConsumeAuthorization(t *testing.T) {
 	s, ctx := testutil.NewTestServer()
 	wireI18nRendererForUserTest(s)

--- a/modules/user/scanlogin_policy_test.go
+++ b/modules/user/scanlogin_policy_test.go
@@ -11,12 +11,19 @@ import (
 	"time"
 
 	libcommon "github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
 	"github.com/Mininglamp-OSS/octo-lib/testutil"
 	commonsettings "github.com/Mininglamp-OSS/octo-server/modules/common"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func enableScanLoginForUserTest(t *testing.T, ctx *config.Context) {
+	t.Helper()
+	setSystemSettingForUserTest(t, ctx, "login", "scan_enabled", "1", "bool")
+	require.NoError(t, commonsettings.EnsureSystemSettings(ctx).Reload())
+}
 
 func TestScanLoginDisabledBlocksUserEntryPoints(t *testing.T) {
 	s, ctx := testutil.NewTestServer()
@@ -89,7 +96,7 @@ func TestScanLoginRateLimitsRejectNonFiniteRPSConfig(t *testing.T) {
 	s, ctx := testutil.NewTestServer()
 	wireI18nRendererForUserTest(s)
 	require.NoError(t, testutil.CleanAllTables(ctx))
-	require.NoError(t, commonsettings.EnsureSystemSettings(ctx).Reload())
+	enableScanLoginForUserTest(t, ctx)
 
 	const ip = "9.9.8.21"
 	for _, key := range []string{
@@ -128,7 +135,7 @@ func TestLoginWithAuthCode_WrongPollSecretDoesNotConsumeAuthorization(t *testing
 	s, ctx := testutil.NewTestServer()
 	wireI18nRendererForUserTest(s)
 	require.NoError(t, testutil.CleanAllTables(ctx))
-	require.NoError(t, commonsettings.EnsureSystemSettings(ctx).Reload())
+	enableScanLoginForUserTest(t, ctx)
 
 	authCode := util.GenerUUID()
 	uuid := util.GenerUUID()
@@ -155,7 +162,7 @@ func TestScanLoginAuthorization_RequiresConfirmationAndRedeemsOnce(t *testing.T)
 	s, ctx := testutil.NewTestServer()
 	wireI18nRendererForUserTest(s)
 	require.NoError(t, testutil.CleanAllTables(ctx))
-	require.NoError(t, commonsettings.EnsureSystemSettings(ctx).Reload())
+	enableScanLoginForUserTest(t, ctx)
 
 	db := NewDB(ctx)
 	model, err := db.QueryByUID(testutil.UID)
@@ -233,7 +240,7 @@ func TestScanLoginAuthorization_MultipleReplicasRedeemOnce(t *testing.T) {
 	wireI18nRendererForUserTest(s1)
 	wireI18nRendererForUserTest(s2)
 	require.NoError(t, testutil.CleanAllTables(ctx))
-	require.NoError(t, commonsettings.EnsureSystemSettings(ctx).Reload())
+	enableScanLoginForUserTest(t, ctx)
 
 	db := NewDB(ctx)
 	model, err := db.QueryByUID(testutil.UID)
@@ -313,4 +320,93 @@ func TestScanLoginAuthorization_MultipleReplicasRedeemOnce(t *testing.T) {
 		assert.Contains(t, response.Body.String(), "err.server.user.auth_code_not_found")
 	}
 	require.Equal(t, 1, redeemSuccesses, "only one replica may consume and issue a session")
+}
+
+func TestScanLoginAuthorization_MultipleAuthCodesForOneUUIDRedeemOnce(t *testing.T) {
+	s1, ctx := testutil.NewTestServer()
+	s2, _ := testutil.NewTestServer()
+	wireI18nRendererForUserTest(s1)
+	wireI18nRendererForUserTest(s2)
+	require.NoError(t, testutil.CleanAllTables(ctx))
+	enableScanLoginForUserTest(t, ctx)
+
+	db := NewDB(ctx)
+	model, err := db.QueryByUID(testutil.UID)
+	require.NoError(t, err)
+	if model == nil {
+		require.NoError(t, db.Insert(&Model{
+			UID:      testutil.UID,
+			Name:     "single QR claim user",
+			Username: "single_qr_claim_user",
+			ShortNo:  "scan004",
+			Status:   1,
+		}))
+	}
+
+	uuid := util.GenerUUID()
+	authCodes := []string{util.GenerUUID(), util.GenerUUID()}
+	for _, authCode := range authCodes {
+		require.NoError(t, SavePendingScanLoginAuthorization(ctx.GetRedisConn(), authCode, testutil.UID, uuid))
+	}
+	pollSecret, err := mintScanLoginPollSecret(ctx.GetRedisConn(), uuid)
+	require.NoError(t, err)
+
+	routes := []http.Handler{s1.GetRoute(), s2.GetRoute()}
+	callBoth := func(method string, paths []string, token bool) []*httptest.ResponseRecorder {
+		t.Helper()
+		responses := make([]*httptest.ResponseRecorder, len(routes))
+		start := make(chan struct{})
+		var wg sync.WaitGroup
+		wg.Add(len(routes))
+		for i, route := range routes {
+			go func(i int, route http.Handler) {
+				defer wg.Done()
+				<-start
+				w := httptest.NewRecorder()
+				req := httptest.NewRequest(method, paths[i], nil)
+				setPublicIPForUserTest(req, "9.9.11."+strconv.Itoa(i+1))
+				if token {
+					req.Header.Set("token", testutil.Token)
+				}
+				route.ServeHTTP(w, req)
+				responses[i] = w
+			}(i, route)
+		}
+		close(start)
+		wg.Wait()
+		return responses
+	}
+
+	confirmPaths := []string{
+		"/v1/user/grant_login?auth_code=" + authCodes[0],
+		"/v1/user/grant_login?auth_code=" + authCodes[1],
+	}
+	confirmResponses := callBoth(http.MethodGet, confirmPaths, true)
+	confirmSuccesses := 0
+	for _, response := range confirmResponses {
+		if response.Code == http.StatusOK {
+			confirmSuccesses++
+			continue
+		}
+		assert.Contains(t, response.Body.String(), "err.server.user.auth_code_not_found")
+	}
+	require.Equal(t, 1, confirmSuccesses,
+		"two auth codes for one QR session must not both become redeemable")
+
+	redeemPaths := []string{
+		"/v1/user/login_authcode/" + authCodes[0] + "?poll_secret=" + pollSecret,
+		"/v1/user/login_authcode/" + authCodes[1] + "?poll_secret=" + pollSecret,
+	}
+	redeemResponses := callBoth(http.MethodPost, redeemPaths, false)
+	redeemSuccesses := 0
+	for _, response := range redeemResponses {
+		if response.Code == http.StatusOK {
+			redeemSuccesses++
+			assert.Contains(t, response.Body.String(), `"token"`)
+			continue
+		}
+		assert.Contains(t, response.Body.String(), "err.server.user.auth_code_not_found")
+	}
+	require.Equal(t, 1, redeemSuccesses,
+		"one displayed QR session must issue at most one login session")
 }

--- a/modules/user/scanlogin_policy_test.go
+++ b/modules/user/scanlogin_policy_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"testing"
 	"time"
 
@@ -43,12 +44,13 @@ func TestScanLoginDisabledBlocksUserEntryPoints(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			w := httptest.NewRecorder()
 			req, _ := http.NewRequest(tc.method, tc.path, nil)
-			setPublicIPForUserTest(req, "9.9.8."+string(rune('1'+i)))
+			setPublicIPForUserTest(req, "9.9.8."+strconv.Itoa(i+1))
 			if tc.token {
 				req.Header.Set("token", testutil.Token)
 			}
 			s.GetRoute().ServeHTTP(w, req)
 
+			require.Equal(t, http.StatusBadRequest, w.Code, w.Body.String())
 			assert.Contains(t, w.Body.String(), "err.server.user.scan_login_disabled")
 		})
 	}
@@ -73,7 +75,7 @@ func TestScanLoginStatusReturnsDisabledStateImmediately(t *testing.T) {
 	s.GetRoute().ServeHTTP(w, req)
 
 	require.Equal(t, http.StatusOK, w.Code)
-	assert.JSONEq(t, `{"status":"disabled"}`, w.Body.String())
+	assert.JSONEq(t, `{"status":"`+scanLoginStatusDisabled+`"}`, w.Body.String())
 	assert.Less(t, time.Since(started), time.Second, "disabled status must bypass the 10-second long poll")
 }
 

--- a/modules/user/scanlogin_policy_test.go
+++ b/modules/user/scanlogin_policy_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strconv"
+	"sync"
 	"testing"
 	"time"
 
@@ -224,4 +225,92 @@ func TestScanLoginAuthorization_RequiresConfirmationAndRedeemsOnce(t *testing.T)
 	setPublicIPForUserTest(req, "9.9.8.42")
 	s.GetRoute().ServeHTTP(w, req)
 	assert.Contains(t, w.Body.String(), "err.server.user.auth_code_not_found")
+}
+
+func TestScanLoginAuthorization_MultipleReplicasRedeemOnce(t *testing.T) {
+	s1, ctx := testutil.NewTestServer()
+	s2, _ := testutil.NewTestServer()
+	wireI18nRendererForUserTest(s1)
+	wireI18nRendererForUserTest(s2)
+	require.NoError(t, testutil.CleanAllTables(ctx))
+	require.NoError(t, commonsettings.EnsureSystemSettings(ctx).Reload())
+
+	db := NewDB(ctx)
+	model, err := db.QueryByUID(testutil.UID)
+	require.NoError(t, err)
+	if model == nil {
+		require.NoError(t, db.Insert(&Model{
+			UID:      testutil.UID,
+			Name:     "multi replica scan login user",
+			Username: "multi_replica_scan_login_user",
+			ShortNo:  "scan002",
+			Status:   1,
+		}))
+	}
+
+	authCode := util.GenerUUID()
+	uuid := util.GenerUUID()
+	require.NoError(t, SavePendingScanLoginAuthorization(ctx.GetRedisConn(), authCode, testutil.UID, uuid))
+	pollSecret, err := mintScanLoginPollSecret(ctx.GetRedisConn(), uuid)
+	require.NoError(t, err)
+
+	routes := []http.Handler{s1.GetRoute(), s2.GetRoute()}
+	callBoth := func(method string, path string, token bool) []*httptest.ResponseRecorder {
+		t.Helper()
+		responses := make([]*httptest.ResponseRecorder, len(routes))
+		start := make(chan struct{})
+		var wg sync.WaitGroup
+		wg.Add(len(routes))
+		for i, route := range routes {
+			go func(i int, route http.Handler) {
+				defer wg.Done()
+				<-start
+				w := httptest.NewRecorder()
+				req := httptest.NewRequest(method, path, nil)
+				setPublicIPForUserTest(req, "9.9.9."+strconv.Itoa(i+1))
+				if token {
+					req.Header.Set("token", testutil.Token)
+				}
+				route.ServeHTTP(w, req)
+				responses[i] = w
+			}(i, route)
+		}
+		close(start)
+		wg.Wait()
+		return responses
+	}
+
+	confirmResponses := callBoth(http.MethodGet, "/v1/user/grant_login?auth_code="+authCode, true)
+	confirmSuccesses := 0
+	for _, response := range confirmResponses {
+		if response.Code == http.StatusOK {
+			confirmSuccesses++
+			continue
+		}
+		assert.Contains(t, response.Body.String(), "err.server.user.auth_code_not_found")
+	}
+	require.Equal(t, 1, confirmSuccesses, "only one replica may promote the pending authorization")
+	statusStarted := time.Now()
+	statusResponses := callBoth(http.MethodGet,
+		"/v1/user/loginstatus?uuid="+uuid+"&poll_secret="+pollSecret, false)
+	assert.Less(t, time.Since(statusStarted), time.Second,
+		"a replica that reads an already confirmed shared state must not enter the long poll")
+	for _, response := range statusResponses {
+		require.Equal(t, http.StatusOK, response.Code, response.Body.String())
+		assert.Contains(t, response.Body.String(), authCode,
+			"every replica must read the confirmed state from shared Redis")
+	}
+
+	redeemResponses := callBoth(http.MethodPost,
+		"/v1/user/login_authcode/"+authCode+"?poll_secret="+pollSecret, false)
+	redeemSuccesses := 0
+	for _, response := range redeemResponses {
+		if response.Code == http.StatusOK {
+			redeemSuccesses++
+			assert.Contains(t, response.Body.String(), `"token"`)
+			continue
+		}
+		assert.Contains(t, response.Body.String(), "err.server.user.auth_code_not_found")
+	}
+	require.Equal(t, 1, redeemSuccesses, "only one replica may consume and issue a session")
 }

--- a/modules/user/scanlogin_policy_test.go
+++ b/modules/user/scanlogin_policy_test.go
@@ -1,0 +1,90 @@
+package user
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	libcommon "github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	commonsettings "github.com/Mininglamp-OSS/octo-server/modules/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestScanLoginDisabledBlocksUserEntryPoints(t *testing.T) {
+	s, ctx := testutil.NewTestServer()
+	wireI18nRendererForUserTest(s)
+	require.NoError(t, testutil.CleanAllTables(ctx))
+	setSystemSettingForUserTest(t, ctx, "login", "scan_enabled", "0", "bool")
+	require.NoError(t, commonsettings.EnsureSystemSettings(ctx).Reload())
+
+	cases := []struct {
+		name   string
+		method string
+		path   string
+		token  bool
+	}{
+		{name: "create uuid", method: http.MethodGet, path: "/v1/user/loginuuid"},
+		{name: "confirm", method: http.MethodGet, path: "/v1/user/grant_login?auth_code=code", token: true},
+		{name: "redeem", method: http.MethodPost, path: "/v1/user/login_authcode/code?poll_secret=secret"},
+	}
+	for i, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			req, _ := http.NewRequest(tc.method, tc.path, nil)
+			setPublicIPForUserTest(req, "9.9.8."+string(rune('1'+i)))
+			if tc.token {
+				req.Header.Set("token", testutil.Token)
+			}
+			s.GetRoute().ServeHTTP(w, req)
+
+			assert.Contains(t, w.Body.String(), "err.server.user.scan_login_disabled")
+		})
+	}
+}
+
+func TestScanLoginStatusReturnsDisabledStateImmediately(t *testing.T) {
+	s, ctx := testutil.NewTestServer()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+	setSystemSettingForUserTest(t, ctx, "login", "scan_enabled", "0", "bool")
+	require.NoError(t, commonsettings.EnsureSystemSettings(ctx).Reload())
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/v1/user/loginstatus?uuid=existing-or-new", nil)
+	setPublicIPForUserTest(req, "9.9.8.20")
+	s.GetRoute().ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.JSONEq(t, `{"status":"disabled"}`, w.Body.String())
+}
+
+func TestLoginWithAuthCode_WrongPollSecretDoesNotConsumeAuthorization(t *testing.T) {
+	s, ctx := testutil.NewTestServer()
+	wireI18nRendererForUserTest(s)
+	require.NoError(t, testutil.CleanAllTables(ctx))
+	require.NoError(t, commonsettings.EnsureSystemSettings(ctx).Reload())
+
+	authCode := util.GenerUUID()
+	uuid := util.GenerUUID()
+	authInfo, err := encodeScanLoginAuthorization(testutil.UID, uuid)
+	require.NoError(t, err)
+	authKey := fmt.Sprintf("%s%s", libcommon.AuthCodeCachePrefix, authCode)
+	require.NoError(t, ctx.GetRedisConn().SetAndExpire(authKey, authInfo, time.Minute))
+	_, err = mintScanLoginPollSecret(ctx.GetRedisConn(), uuid)
+	require.NoError(t, err)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodPost,
+		"/v1/user/login_authcode/"+authCode+"?poll_secret=wrong", nil)
+	setPublicIPForUserTest(req, "9.9.8.30")
+	s.GetRoute().ServeHTTP(w, req)
+
+	assert.Contains(t, w.Body.String(), "err.server.user.auth_code_not_found")
+	stillReady, err := ctx.GetRedisConn().GetString(authKey)
+	require.NoError(t, err)
+	assert.Equal(t, authInfo, stillReady, "wrong browser secret must not burn a valid confirmation")
+}

--- a/modules/user/scanlogin_poll.go
+++ b/modules/user/scanlogin_poll.go
@@ -40,11 +40,12 @@ const scanLoginPollSecretQuery = "poll_secret"
 
 // ScanLoginAuthCodeTTL 是扫码登录授权码的存活时间。
 //
-// authCode 可被 POST /v1/user/login_authcode/{code} 直接兑换成 scaner 的完整 token，
-// 所以这个 TTL 就是「凭据一旦外泄的可利用窗口」。原值 10 分钟远超实际所需。
+// authCode 在 grantLogin 明确确认后才会进入可兑换命名空间，并可被 POST
+// /v1/user/login_authcode/{code} 兑换成 scanner 的完整 token，所以这个 TTL 就是
+// 「已确认凭据一旦外泄的可利用窗口」。原值 10 分钟远超实际所需。
 //
-// 定义在 modules/user 而非 modules/qrcode：grantLogin（本包）确认时要按同一档位给
-// authCode 续期（见 P1-3），而 qrcode 已经 import user，反向 import 会成环。
+// 定义在 modules/user 而非 modules/qrcode：grantLogin（本包）确认时用它设置 ready
+// authorization 的完整窗口，而 qrcode 已经 import user，反向 import 会成环。
 const ScanLoginAuthCodeTTL = 5 * time.Minute
 
 // ScanLoginConfirmWindow 是「二维码已被扫描 / 已授权」状态的存活时间，也就是用户可以
@@ -69,8 +70,9 @@ const ScanLoginConfirmWindow = 5 * time.Minute
 // 取 12 分钟给 60s 余量，避免 Redis 与应用间的时钟漂移或调用延迟正好卡在边界上把
 // 已扫码的用户甩掉。
 //
-// 长活本身不额外授权：密钥只是读取凭据的门票，qrcode 状态一过期就无内容可读；且
-// loginWithAuthCode 兑换成功后会立刻 deleteScanLoginPollSecret，常态下活不满 TTL。
+// 长活本身不额外授权：密钥必须与已确认 auth_code 配对才能兑换，qrcode 状态一过期
+// 也无内容可读；loginWithAuthCode 兑换成功后会立刻 deleteScanLoginPollSecret，常态下
+// 活不满 TTL。
 const scanLoginPollSecretTTL = 12 * time.Minute
 
 // 扫码登录两个未认证端点的默认限流档位（可经 DM_API_SCANLOGIN_*_RATELIMIT_{RPS,BURST}

--- a/modules/user/scanlogin_poll.go
+++ b/modules/user/scanlogin_poll.go
@@ -16,7 +16,10 @@ import (
 //
 // 该前缀在 octo-server 本地定义（而非 octo-lib common.*CachePrefix）：octo-lib 是
 // 外部模块，加常量需要先发版；本 key 的生命周期完全由 modules/user 掌握。
-const scanLoginPollSecretPrefix = "scanlogin:poll:"
+const (
+	scanLoginPollSecretPrefix = "scanlogin:poll:"
+	scanLoginStatusDisabled   = "disabled"
+)
 
 // scanLoginPollSecretQuery 是轮询方出示密钥的 query 参数名。
 //

--- a/modules/user/scanlogin_poll.go
+++ b/modules/user/scanlogin_poll.go
@@ -114,6 +114,13 @@ var scanLoginPublicDataKeys = map[string]struct{}{
 	"app_id": {}, // 常量标识，无信息量
 }
 
+func scanLoginStatusIs(model *common.QRCodeModel, status string) bool {
+	if model == nil {
+		return false
+	}
+	return fmt.Sprint(model.Data["status"]) == status
+}
+
 // pollSecretStore 是轮询密钥所需的最小存储能力，签名对齐 octo-lib 的 *redis.Conn。
 //
 // 抽成接口是为了让密钥的写入/比对/删除能在没有 Redis 的环境下做真实行为测试 ——

--- a/modules/user/scanlogin_poll_test.go
+++ b/modules/user/scanlogin_poll_test.go
@@ -335,6 +335,9 @@ func TestGrantLogin_PromotesPendingAuthorizationBeforePublishingAuthed(t *testin
 	require.NotEqual(t, -1, qrIdx)
 	assert.Less(t, renewIdx, qrIdx,
 		"先提升授权再写 qrcode —— 提升失败就不该对外宣告 authed")
+	assert.Contains(t, fn,
+		"u.scanLoginAuthorizations.RollbackPromotion(authCode, authInfo, ScanLoginConfirmWindow)",
+		"qrcode 状态写失败时必须原子恢复 pending，让移动端可以重试确认")
 
 	assert.NotContains(t, fn, "time.Minute*5",
 		"TTL 必须走 ScanLoginAuthCodeTTL 常量，不要再散落字面量")

--- a/modules/user/scanlogin_poll_test.go
+++ b/modules/user/scanlogin_poll_test.go
@@ -321,22 +321,37 @@ func TestGetLoginStatus_OnlyAuthorizedPollersRegisterAChannel(t *testing.T) {
 // TestGrantLogin_RenewsAuthCodeTTL 锁住 P1-3 的修复。authCode 在**扫码**时签发，用户
 // 可以在确认页停到该 TTL 的最后一刻；若这里只续 qrcode 不续 authCode，就会出现
 // 「status=authed、附带的 auth_code 只剩一秒」，浏览器兑换必然失败且状态机无路可走。
-func TestGrantLogin_RenewsAuthCodeTTL(t *testing.T) {
+func TestGrantLogin_PromotesPendingAuthorizationBeforePublishingAuthed(t *testing.T) {
 	fn := readFuncBody(t, "api.go", "func (u *User) grantLogin(")
 
-	assert.Contains(t, fn, "common.AuthCodeCachePrefix, authCode), authInfo, ScanLoginAuthCodeTTL",
-		"确认时必须按同一档位给 authCode 重新计时")
+	assert.Contains(t, fn, "u.scanLoginAuthorizations.Promote(authCode, authInfo, ScanLoginAuthCodeTTL)",
+		"确认时必须原子地把 pending 授权提升为可兑换授权")
+	assert.NotContains(t, fn, "SetAndExpire(\n\t\tfmt.Sprintf(\"%s%s\", common.AuthCodeCachePrefix",
+		"确认流程不得绕过原子 promote 直接覆盖可兑换授权")
 
-	renewIdx := strings.Index(fn, "common.AuthCodeCachePrefix, authCode), authInfo, ScanLoginAuthCodeTTL")
+	renewIdx := strings.Index(fn, "u.scanLoginAuthorizations.Promote(authCode, authInfo, ScanLoginAuthCodeTTL)")
 	qrIdx := strings.Index(fn, "common.QRCodeCachePrefix, uuid)")
 	require.NotEqual(t, -1, renewIdx)
 	require.NotEqual(t, -1, qrIdx)
 	assert.Less(t, renewIdx, qrIdx,
-		"先续 authCode 再写 qrcode —— 续期失败就不该对外宣告 authed")
+		"先提升授权再写 qrcode —— 提升失败就不该对外宣告 authed")
 
-	// 两者必须用同一个常量，否则窗口又会倒挂。
 	assert.NotContains(t, fn, "time.Minute*5",
 		"TTL 必须走 ScanLoginAuthCodeTTL 常量，不要再散落字面量")
+}
+
+func TestLoginWithAuthCode_ConsumesBeforeIssuingSession(t *testing.T) {
+	fn := readFuncBody(t, "api.go", "func (u *User) loginWithAuthCode(")
+
+	assert.Contains(t, fn, "u.scanLoginPollSecretMatches(uuid, strings.TrimSpace(c.Query(scanLoginPollSecretQuery)))")
+	consume := strings.Index(fn, "u.scanLoginAuthorizations.Consume(authCode, authInfo)")
+	cacheWrite := strings.Index(fn, "u.ctx.Cache().SetAndExpire")
+	imUpdate := strings.Index(fn, "u.ctx.UpdateIMToken")
+	require.NotEqual(t, -1, consume)
+	require.NotEqual(t, -1, cacheWrite)
+	require.NotEqual(t, -1, imUpdate)
+	assert.Less(t, consume, cacheWrite, "授权必须先原子消费，再写登录 token")
+	assert.Less(t, consume, imUpdate, "授权必须先原子消费，再产生 IM 登录副作用")
 }
 
 // TestLoginWithAuthCode_ClearsScanLoginState 锁住 P2-3：登录完成后本轮扫码的所有状态

--- a/modules/user/scanlogin_poll_test.go
+++ b/modules/user/scanlogin_poll_test.go
@@ -335,8 +335,7 @@ func TestGrantLogin_PromotesPendingAuthorizationBeforePublishingAuthed(t *testin
 	require.NotEqual(t, -1, qrIdx)
 	assert.Less(t, renewIdx, qrIdx,
 		"先提升授权再写 qrcode —— 提升失败就不该对外宣告 authed")
-	assert.Contains(t, fn,
-		"u.scanLoginAuthorizations.RollbackPromotion(authCode, authInfo, ScanLoginConfirmWindow)",
+	assert.Contains(t, fn, "u.scanLoginAuthorizations.RollbackPromotion(",
 		"qrcode 状态写失败时必须原子恢复 pending，让移动端可以重试确认")
 
 	assert.NotContains(t, fn, "time.Minute*5",

--- a/modules/user/scanlogin_poll_test.go
+++ b/modules/user/scanlogin_poll_test.go
@@ -323,10 +323,11 @@ func TestGetLoginStatus_OnlyAuthorizedPollersRegisterAChannel(t *testing.T) {
 // 「status=authed、附带的 auth_code 只剩一秒」，浏览器兑换必然失败且状态机无路可走。
 func TestGrantLogin_PromotesPendingAuthorizationBeforePublishingAuthed(t *testing.T) {
 	fn := readFuncBody(t, "api.go", "func (u *User) grantLogin(")
+	compact := strings.Join(strings.Fields(fn), "")
 
 	assert.Contains(t, fn, "u.scanLoginAuthorizations.Promote(authCode, authInfo, ScanLoginAuthCodeTTL)",
 		"确认时必须原子地把 pending 授权提升为可兑换授权")
-	assert.NotContains(t, fn, "SetAndExpire(\n\t\tfmt.Sprintf(\"%s%s\", common.AuthCodeCachePrefix",
+	assert.NotContains(t, compact, "SetAndExpire(fmt.Sprintf(\"%s%s\",common.AuthCodeCachePrefix",
 		"确认流程不得绕过原子 promote 直接覆盖可兑换授权")
 
 	renewIdx := strings.Index(fn, "u.scanLoginAuthorizations.Promote(authCode, authInfo, ScanLoginAuthCodeTTL)")

--- a/modules/user/swagger/api.yaml
+++ b/modules/user/swagger/api.yaml
@@ -957,7 +957,7 @@ paths:
       tags:
         - "user"
       summary: "通过认证码登录"
-      description: "通过认证码登录"
+      description: "通过已确认的扫码认证码登录；认证码必须与 loginuuid 返回的 poll_secret 配对且只能消费一次"
       operationId: "login_authcode"
       consumes:
         - "application/json"
@@ -968,6 +968,11 @@ paths:
           name: "auth_code"
           type: string
           description: "授权码"
+          required: true
+        - in: "query"
+          name: "poll_secret"
+          type: string
+          description: "loginuuid 返回的浏览器会话密钥；错误或缺失不会消费 auth_code"
           required: true
       responses:
         200:
@@ -2194,6 +2199,8 @@ paths:
       summary: "获取登录状态"
       description: >-
         通过 login uuid 获取登录状态（10 秒长轮询）。
+
+        login.scan_enabled=false 时立即返回 status=disabled。
 
         未出示 poll_secret 时仍返回真实 status，但 auth_code / uid / encrypt
         会被剥掉 —— 只有申请该二维码的调用方能拿到凭据字段。

--- a/pkg/accesslog/accesslog.go
+++ b/pkg/accesslog/accesslog.go
@@ -56,12 +56,10 @@ var secretQueryInPath = regexp.MustCompile(`(?i)\b(poll_secret=)[^&\s?"']*`)
 // authCodeInPath masks the redeemable scan-login auth code, which travels as a
 // path segment.
 //
-// POST /v1/user/login_authcode/{code} exchanges {code} for a full user token
-// without checking who is redeeming. loginWithAuthCode deletes the code on
-// success, so a logged line for a successful redemption is already spent — but
-// the early returns for an IM failure or a destroyed account happen BEFORE that
-// delete, so a failed redemption leaves a still-valid code in the log for up to
-// ScanLoginAuthCodeTTL (5 min).
+// POST /v1/user/login_authcode/{code} treats {code} as one half of the login
+// credential: the matching browser poll_secret is also required, and a valid
+// code is atomically consumed before login side effects. Rejected requests can
+// still contain an unspent code, so the path segment must always be masked.
 var authCodeInPath = regexp.MustCompile(`(?i)(/v1/user/login_authcode/)[^/\s?"']+`)
 
 // scrubSecretPatterns applies the non-webhook maskers. Split out so both the

--- a/pkg/accesslog/accesslog.go
+++ b/pkg/accesslog/accesslog.go
@@ -46,12 +46,15 @@ var webhookPushPrefixes = []string{
 //     `uuid` (also on that line) is exactly what lets a caller read `auth_code`
 //     out of GET /v1/user/loginstatus, so logging both defeats the gate for
 //     anyone with log read access. Valid for scanLoginPollSecretTTL (12 min).
+//   - auth_code: grant_login promotes this one-time authorization into a full
+//     login credential after the authenticated scanner confirms.
+//   - encrypt: Signal key material supplied by the scanner at confirmation.
 //
 // The value is everything up to the next separator; the parameter NAME is kept so
 // the line stays useful for correlation. Case-insensitive for the same reason as
 // ScrubPath — scrubbing is the security control, so it must survive casing
 // variants that a router would 404 but the logger would still print.
-var secretQueryInPath = regexp.MustCompile(`(?i)\b(poll_secret=)[^&\s?"']*`)
+var secretQueryInPath = regexp.MustCompile(`(?i)\b((?:poll_secret|auth_code|encrypt)=)[^&\s?"']*`)
 
 // authCodeInPath masks the redeemable scan-login auth code, which travels as a
 // path segment.

--- a/pkg/accesslog/accesslog_test.go
+++ b/pkg/accesslog/accesslog_test.go
@@ -373,6 +373,11 @@ func TestScrubPath_MasksAuthCode(t *testing.T) {
 			want: "/v1/user/login_authcode/***?flag=1",
 		},
 		{
+			name: "redeem path and browser secret",
+			in:   "/v1/user/login_authcode/A-CODE?flag=1&poll_secret=S3CR3T",
+			want: "/v1/user/login_authcode/***?flag=1&poll_secret=***",
+		},
+		{
 			name: "casing variant still masked",
 			in:   "/V1/USER/LOGIN_AUTHCODE/A-CODE",
 			want: "/V1/USER/LOGIN_AUTHCODE/***",

--- a/pkg/accesslog/accesslog_test.go
+++ b/pkg/accesslog/accesslog_test.go
@@ -2,7 +2,6 @@ package accesslog
 
 import (
 	"bytes"
-	"github.com/stretchr/testify/require"
 	"os"
 	"regexp"
 	"strings"
@@ -10,6 +9,8 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestScrubPath(t *testing.T) {
@@ -349,6 +350,30 @@ func TestScrubPath_MasksPollSecret(t *testing.T) {
 	}
 }
 
+func TestScrubPath_MasksGrantLoginSecrets(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "auth code and signal material",
+			in:   "/v1/user/grant_login?auth_code=A-CODE&encrypt=SIGNAL-KEY",
+			want: "/v1/user/grant_login?auth_code=***&encrypt=***",
+		},
+		{
+			name: "mixed case parameters",
+			in:   "/v1/user/grant_login?AUTH_CODE=A-CODE&ENCRYPT=SIGNAL-KEY&keep=value",
+			want: "/v1/user/grant_login?AUTH_CODE=***&ENCRYPT=***&keep=value",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, ScrubPath(tc.in))
+		})
+	}
+}
+
 // TestScrubPath_MasksAuthCode pins the redeemable scan-login code, which travels
 // as a path segment.
 //
@@ -406,13 +431,14 @@ func TestErrorWriter_MasksScanLoginSecrets(t *testing.T) {
 	w := NewErrorWriter(&buf)
 
 	dump := "panic serving request\nGET /v1/user/loginstatus?uuid=U1&poll_secret=S3CR3T HTTP/1.1\n" +
-		"POST /v1/user/login_authcode/A-CODE HTTP/1.1\n"
+		"POST /v1/user/login_authcode/A-CODE HTTP/1.1\n" +
+		"GET /v1/user/grant_login?auth_code=GRANT-CODE&encrypt=SIGNAL-KEY HTTP/1.1\n"
 	if _, err := w.Write([]byte(dump)); err != nil {
 		t.Fatalf("write: %v", err)
 	}
 
 	got := buf.String()
-	for _, leaked := range []string{"S3CR3T", "A-CODE"} {
+	for _, leaked := range []string{"S3CR3T", "A-CODE", "GRANT-CODE", "SIGNAL-KEY"} {
 		if strings.Contains(got, leaked) {
 			t.Errorf("panic dump leaked %q: %s", leaked, got)
 		}

--- a/pkg/errcode/user.go
+++ b/pkg/errcode/user.go
@@ -126,6 +126,11 @@ var (
 		HTTPStatus:     http.StatusForbidden,
 		DefaultMessage: "Local login is disabled.",
 	})
+	ErrUserScanLoginDisabled = register(codes.Code{
+		ID:             "err.server.user.scan_login_disabled",
+		HTTPStatus:     http.StatusForbidden,
+		DefaultMessage: "Scan login is disabled.",
+	})
 	ErrUserPhoneRegionUnsupported = register(codes.Code{
 		ID:             "err.server.user.phone_region_unsupported",
 		HTTPStatus:     http.StatusBadRequest,

--- a/pkg/i18n/locales/active.zh-CN.toml
+++ b/pkg/i18n/locales/active.zh-CN.toml
@@ -167,6 +167,9 @@ other = "注册通道暂未开放。"
 ["err.server.user.local_login_disabled"]
 other = "本地登录已关闭。"
 
+["err.server.user.scan_login_disabled"]
+other = "扫码登录已关闭。"
+
 ["err.server.user.phone_region_unsupported"]
 other = "仅支持中国大陆手机号。"
 

--- a/tools/i18nmarkers/server/active.en-US.toml
+++ b/tools/i18nmarkers/server/active.en-US.toml
@@ -1182,6 +1182,9 @@ other = "Registration is currently closed."
 ["err.server.user.request_invalid"]
 other = "Invalid request."
 
+["err.server.user.scan_login_disabled"]
+other = "Scan login is disabled."
+
 ["err.server.user.short_no_already_changed"]
 other = "Short ID can only be changed once."
 


### PR DESCRIPTION
## Summary

Harden scan login so the server is the policy authority and scanning alone can no longer create a redeemable login.

## Related Issue

N/A — no server issue has been assigned to this security hardening task.

## Linked Spec

`.octospec/tasks/scan-login-authorization/brief.md`

## Changes

- Add the DB-backed `login.scan_enabled` switch, expose `scan_login_enabled`, and enforce the switch across QR creation, scan, confirmation, polling, and redemption.
- Split scan from explicit mobile confirmation; keep pending and ready authorizations in separate Redis namespaces and promote/consume them atomically across replicas.
- Bind polling and one-shot redemption to the browser-issued `poll_secret`; filter credential fields for unauthorized pollers and scrub secrets from application logs.
- Preserve strict per-IP limits on anonymous scan endpoints and replace non-finite scan limiter values with finite defaults.
- Roll back a failed QR-state publication to pending and warn when a consumed authorization does not complete login.
- Document the client, mixed-version rollout, OIDC-only deployment, rollback, and failure-recovery contracts.

## Testing

- [x] `go test ./modules/user -run 'Test(ScanLogin|LoginWithAuthCode|GrantLogin|GetLogin)' -count=1`
- [x] `go test -race ./modules/user -run 'Test(ScanLoginRedemptionAuditWarnsOnlyWhenLoginIsIncomplete|ScanLoginAuthorization_(PromoteAndConsumeAreAtomic|RollbackPromotionRestoresPending|MultipleReplicasRedeemOnce)|ScanLoginRateLimitsRejectNonFiniteRPSConfig)$' -count=1`
- [x] `go test ./modules/qrcode -count=1`
- [x] `go test ./modules/common -run 'Test(GetAppConfig_ScanLogin|SystemSettings_ScanLogin)' -count=1`
- [x] `go test ./pkg/accesslog -count=1`
- [x] `go build ./...`
- [x] `go vet ./modules/user ./modules/qrcode ./modules/common ./pkg/accesslog`
- [x] `golangci-lint run ./...`
- [x] `make i18n-extract-check && make i18n-lint`

The full `modules/common` package is not reported as green: its existing test setup reached MySQL's 151-connection limit in `TestManagerSystemSetting_OrderingRejectsFromThreadSide`. The focused scan-login common tests pass against a fresh `utf8mb4_general_ci` test database.

## COMPREHENSION

1. **What does this change actually do to the load-bearing path?**

   Scan login now has a server-controlled kill switch. A scan creates only a pending record; the authenticated scanner must explicitly confirm it before the server atomically creates a redeemable record. The browser must present its own `poll_secret`, and redemption consumes the authorization before any session side effect, so another browser or replica cannot replay it.

2. **What could break because of it (dependents + failure mode)?**

   Old Web clients do not send `poll_secret`, old mobile clients may assume scan implies authorization, and old server replicas ignore the new switch. Mixed versions can invalidate in-flight sessions or expose the historical flow. Production therefore pre-creates `login.scan_enabled=false`, drains old replicas through blue/green or ingress blocking, and keeps the switch disabled for the current OIDC-only deployment. In-flight cross-replica status updates can still take up to the existing 10-second poll timeout.

3. **How do you know it works (specific test/repro/trace)?**

   The integration suite proves that scan alone cannot redeem, wrong or missing browser secrets cannot consume, confirmation and redemption succeed once, and two independently constructed servers sharing Redis still issue only one session. Race tests cover promotion, rollback, consumption, and incomplete-login audit behavior. Dedicated tests cover the switch at user, QR, and app-config boundaries plus non-finite limiter configuration.

## Checklist

- [x] I have read `CONTRIBUTING.md`
- [x] PR description is in English
- [x] Added tests for my changes
- [x] Updated documentation
- [x] Followed commit message conventions
