### PR TITLE
fix(authz): enforce object-level authorization on channel and profile reads

### DIFF
--- a/.octospec/journal/shared/channel-get-object-authz.md
+++ b/.octospec/journal/shared/channel-get-object-authz.md
@@ -1,0 +1,139 @@
+---
+type: Journal
+title: "Journal: channel-get-object-authz"
+description: Added object-level authorization to the channel-detail and user-profile endpoints, and the traps found along the way — display-layer datasources are not an authz layer, membership rows outlive disbanded groups, and a not-found branch that a datasource error kept unreachable.
+tags: ["space", "isolation", "auth", "acl", "thread", "wire-contract", "sql"]
+timestamp: 2026-08-09T05:45:39Z
+slug: channel-get-object-authz
+---
+
+# channel-get-object-authz
+
+## What was wrong
+
+`GET /v1/channels/:channel_id/:channel_type` (`channelGet`) had **no
+object-level authorization**. `loginUID` was passed to the datasource purely as
+a render parameter and never used as an authorization subject. Any authenticated
+caller could swap `channel_id` and read:
+
+- **GROUP**: name / notice / member count / `space_id` / external-group flag of
+  any group they had never joined — the sibling `GET /v1/groups/:group_no`
+  (`groupGet`) gated the *same* `GetGroupDetail` behind `ExistMember`, this one
+  did not.
+- **COMMUNITY_TOPIC**: sub-channel metadata with no parent-group membership
+  check (violating the repo's own "thread must verify parent channel access").
+- **PERSON**: `short_no` / device flags / last-offline / realname of any user.
+
+Confirmed live against a test environment via a leave-group closure: after
+leaving a group, `groups/{gno}` returned 403 while `channels/{gno}/2` still
+returned 200 + full detail (`quit:1` — the server knew the caller had left).
+Origin: a pentest finding; the report conflated it with a token-revocation
+issue, but the evidence was a plain object-level (IDOR) read.
+
+## The fix
+
+Per-`channel_type` authorization in the handler (the datasources stay a pure
+display layer):
+
+- GROUP: `ExistMember` up front — non-member *and* missing group both map to one
+  `ErrGroupViewForbidden` (no existence oracle).
+- COMMUNITY_TOPIC: `ExistMemberActive` on the parent group (read from the
+  display payload's `extra.group_no`, so `channel` need not import `thread`).
+- PERSON: relationship-graded. Related (self / friend / same-Space / common
+  group / bot / system / webhook) → full detail; unrelated → a minimal DTO. Not
+  a 403: this endpoint is the sole data source for rendering arbitrary message
+  senders, so a hard reject would break avatar/name rendering for external-group
+  members from other Spaces.
+
+`GET /v1/users/:uid` is the same root cause reached through a second door — same
+login-only gate, same `GetUserDetail` call with no relationship check — so it is
+fixed here too rather than left as a documented-but-open sibling. The decision
+lives in `modules/channel/service` (a dependency-free leaf package that
+`modules/user` already imports), so the two endpoints cannot drift apart; if they
+had each kept their own copy, relaxing one would silently reopen the other. The
+profile endpoint's minimal set deliberately **keeps** `follow` where the channel
+one omits it: a profile page needs `follow == 0` to render the add-friend entry,
+while a sender-rendering endpoint must not hand out a relationship verdict at
+all. `modules/user` cannot import `modules/group` (group imports user), so the
+common-group lookup arrives via a registration hook, mirroring the existing
+`RegisterGroupMemberChecker`; an unregistered hook fails closed.
+
+Also: mounted `SharedUIDRateLimiter`, routed all rejections through the
+`httperr` envelope, and fixed a nil-panic (missing group → 500 empty body) that
+was itself an existence oracle.
+
+## Structural learnings & gotchas
+
+- **A display-layer datasource is not an authz layer.** `BussDataSource.
+  ChannelGet` is shared by push-title fallback, webhook identity, etc.; it
+  renders, it must not gate. Authorization belongs in the handler, per type.
+- **A membership row outlives its parent.** `disband` only flips
+  `group.status`; member cleanup is an async event, so rows linger with
+  `is_deleted=0`. A relationship check that queries only `group_member`
+  fail-opens on disbanded groups — `ExistCommonGroup` must `JOIN group` and
+  exclude the dissolved state. Do not let an async cleanup be an authorization
+  precondition. Same shape as the reminder-sync leak: an association table needs
+  the parent's predicate. But exclude *only* what the rationale covers — see the
+  review follow-up below on why a `status = Normal` whitelist was too strict.
+- **A datasource error can strand a handler's not-found branch.**
+  `GetUserDetail` returned a plain error for a missing user, so the datasource
+  loop hit the legacy `c.ResponseError` and the handler's `ErrUserNotFound`
+  branch was dead. Fix: return a sentinel (`ErrorUserNotExist`) and have the
+  datasource translate it to `ErrDatasourceNotProcess` so the chain falls
+  through to the unified not-found. There was already a zombie
+  `ErrorUserNotExist` (defined, never used) — reused it instead of adding a
+  second near-identical sentinel.
+- **A minimal response needs its own DTO.** `model.ChannelResp` has no
+  `omitempty`, so copying four fields still serializes `follow:0` / `status:0` /
+  `extra:null` — and `follow:0` reads to clients as "definitely not a friend".
+  Use a dedicated whitelist DTO and assert at the JSON key level.
+- **PERSON existence can't be unified the way GROUP can.** GROUP folds
+  missing+forbidden into one response; PERSON can't, because an
+  unrelated-but-existing user must still return name/logo for sender rendering.
+  A high-entropy 32-hex uid makes the residual oracle a non-threat; the real
+  enumeration surface (`short_no`) never reaches this endpoint.
+
+## Review follow-ups worth keeping
+
+- **A brief is a published artifact.** The first cut of this task's brief named
+  the still-unpatched sibling endpoint with its handler and `file:line`, in a
+  public repo. That is a precise pointer to a live hole. Either redact, or — as
+  here — land the sibling fix so there is nothing to point at. `.octospec/`
+  briefs read as internal notes but ship publicly.
+- **A whitelist status check is not automatically the safe one.** The first cut
+  required `status = Normal`, which also excluded admin-**disabled** groups — a
+  distinct, reversible state that every other liveness check in the module
+  treats as live (16 call sites test `== GroupStatusDisband`). Matching the
+  module's blacklist convention (`<> Disband`) satisfies the same
+  disbanded-group rationale without silently dropping mutual visibility for two
+  users whose only shared group is temporarily disabled.
+- **Copying a constant across a layer you already import is drift for free.**
+  The channel-side `iwh_` copy was justified as avoiding a cross-module import,
+  but the file already imports `modules/user` and uses two of its constants
+  fourteen lines away; `user.WebhookUIDPrefix` exists for exactly this.
+
+## Test notes
+
+Both endpoints had zero authorization coverage before. Added an authorization matrix
+(`modules/channel/channel_get_authz_test.go`): group non-member / member /
+missing; person no-relation minimal / common-group full / bot viewable /
+not-found / disbanded-common-group minimal; plus a JSON-key-level minimal-DTO
+assertion, plus a `/v1/users/:uid` matrix (no-relation minimal keeping `follow`,
+same-Space, common-group-only, bot, system account, self, not-found) and pure
+decision tests in the service package (early-allow identities must not even
+reach the common-group query; nil hook and query errors fail closed).
+
+The COMMUNITY_TOPIC route test needs the thread module's datasource registered,
+which means `DM_THREAD_ON` must be set **before** the first
+`register.GetModules` call (the flag is read inside the module factory, and
+factories run once under `once.Do`) — hence a package-level `TestMain` plus a
+blank import of `modules/thread` (channel and thread do not import each other).
+The positive case asserts a 200 carrying the topic name, so it also pins the
+cross-module `Extra["group_no"]` contract the parent-group check depends on; a
+forbidden-only test would pass even if the datasource were never registered.
+
+Route now carries `SharedUIDRateLimiter`, so setup deletes this user's
+`ratelimit:uid:{uid}` key (the bucket survives `CleanAllTables`; a
+`KEYS ratelimit:uid:*` sweep would delete buckets of packages running
+concurrently). Test DB needs a drop&recreate between differing module sets
+(`unknown migration`).

--- a/.octospec/journal/shared/channel-get-object-authz.md
+++ b/.octospec/journal/shared/channel-get-object-authz.md
@@ -94,11 +94,16 @@ was itself an existence oracle.
   gets banned, or the only shared group is disbanded — i.e. precisely the
   transitions this change made load-bearing. Ask, for every field you drop from
   a response the client caches: what does the client's zero value mean, and does
-  it get persisted?
-- **A minimal response needs its own DTO.** `model.ChannelResp` has no
-  `omitempty`, so copying four fields still serializes `follow:0` / `status:0` /
-  `extra:null` — and `follow:0` reads to clients as "definitely not a friend".
-  Use a dedicated whitelist DTO and assert at the JSON key level.
+  it get persisted? The rule that fell out of it: emit everything that is the
+  caller's own state (settings, per-conversation flags, their own blacklist
+  flag), omit only the peer's identity and presence.
+- **A minimal response needs its own DTO, and the whitelist is not "as few
+  fields as possible".** `model.ChannelResp` has no `omitempty`, so assigning a
+  subset of its fields still serializes the rest as zeros — `follow:0` reads to
+  clients as "definitely not a friend". A dedicated DTO fixes that, but the
+  first cut then over-corrected: the right line is **caller's own state in,
+  peer's identity out**, not "smallest possible object". Assert the serialized
+  key set, so both directions are pinned.
 - **PERSON existence can't be unified the way GROUP can.** GROUP folds
   missing+forbidden into one response; PERSON can't, because an
   unrelated-but-existing user must still return name/logo for sender rendering.

--- a/.octospec/journal/shared/channel-get-object-authz.md
+++ b/.octospec/journal/shared/channel-get-object-authz.md
@@ -83,6 +83,18 @@ was itself an existence oracle.
   through to the unified not-found. There was already a zombie
   `ErrorUserNotExist` (defined, never used) — reused it instead of adding a
   second near-identical sentinel.
+- **"Absent" is not a neutral default — decide it per field, per client.** The
+  minimal sets omit `follow` because a `0` reads as "definitely not a friend",
+  but they must **emit** `status`, because all three clients decode an absent
+  `status` as `0`, which is their disabled/banned sentinel, and write it back
+  over the cached row (Android hides the message composer; iOS had already
+  hard-coded a guard for exactly this on `mute`). Same reasoning, opposite
+  conclusion, one field apart. The trigger is not the stranger case but a peer
+  you are currently in a 1:1 with who leaves the visible set — a shared Space
+  gets banned, or the only shared group is disbanded — i.e. precisely the
+  transitions this change made load-bearing. Ask, for every field you drop from
+  a response the client caches: what does the client's zero value mean, and does
+  it get persisted?
 - **A minimal response needs its own DTO.** `model.ChannelResp` has no
   `omitempty`, so copying four fields still serializes `follow:0` / `status:0` /
   `extra:null` — and `follow:0` reads to clients as "definitely not a friend".

--- a/.octospec/learnings/pending/membership-row-outlives-its-parent.md
+++ b/.octospec/learnings/pending/membership-row-outlives-its-parent.md
@@ -1,0 +1,66 @@
+---
+type: Learning
+title: "A membership row outlives its parent — join the parent's status, don't trust the association table alone"
+description: Relationship/authorization checks that query only an association table (group_member, space_member, …) fail-open when the parent is soft-disabled and rows are cleaned up asynchronously. Join the parent and require its active status; never let an async cleanup be an authorization precondition.
+tags: [auth, acl, sql, soft-delete, async-cleanup, fail-closed, isolation, security]
+timestamp: 2026-08-09T00:00:00Z
+status: pending
+---
+
+# A membership row outlives its parent
+
+## Context
+
+`channelGet` graded a caller's access to a peer's profile partly on "do they
+share a group". The first cut, `ExistCommonGroup`, self-joined `group_member`
+on `is_deleted=0` and nothing else.
+
+But `disband` (group dissolution) only flips `group.status = 2` in its main
+transaction; member cleanup is an **async event**. So two users who share only a
+*dissolved* group still have live `group_member` rows (`is_deleted=0`) during
+the cleanup window — or forever, if the async job fails. The check returned
+"common group = true" and handed over full profile detail.
+
+The same shape had already bitten `reminder-sync`: a channel-level reminder
+query over an association table with no parent-membership predicate leaked
+cross-tenant rows.
+
+## The rule
+
+When an authorization or relationship decision reads an **association table**
+(`group_member`, `space_member`, subscription, share, …), the parent entity's
+lifecycle state is part of the predicate. Join the parent and require its active
+status:
+
+```sql
+INNER JOIN `group` g ON g.group_no = m.group_no
+WHERE ... AND g.status <> <Dissolved>
+```
+
+**Exclude only the state your rationale covers.** The first cut of this used a
+`status = Normal` whitelist, which also excluded an admin-**disabled** group — a
+distinct, reversible state that every other liveness check in that module treats
+as live. A whitelist silently widens the exclusion every time someone adds a new
+status value; a blacklist on the state you actually reasoned about does not.
+Match the module's existing convention rather than inventing a stricter one in
+one query.
+
+Corollary: **an async cleanup is never an authorization precondition.** If
+"the rows will be gone soon" is what keeps a check correct, the check is
+fail-open for the whole window (and permanently if the job dies). Encode the
+invariant in the query, not in a worker's eventual success.
+
+Ask, for every association-table check: *what happens to this row when the
+parent is soft-deleted / disabled / dissolved?* If the answer is "a background
+job removes it later", your `WHERE` clause is missing a parent-status predicate.
+
+## Applies to
+
+Any read/authz keyed on membership or linkage where the parent can be
+soft-disabled: group/space membership, channel subscriptions, resource shares,
+bot/app bindings, invitation validity. Prefer an existing "active" helper over
+the bare `is_deleted=0` variant when the check is load-bearing for access — but
+check what that helper's status predicate actually excludes before reusing it.
+
+Reference: `modules/group/db.go` `ExistCommonGroup`;
+sibling case `modules/message/db_reminders.go` (reminder-sync-membership-scope).

--- a/.octospec/log.md
+++ b/.octospec/log.md
@@ -27,6 +27,40 @@ change-log convention (§7). Newest first.
   clients must tolerate the committed-write/error-response branch without
   reopening an authentication credential.
 
+## 2026-08-09 (channel-get-object-authz)
+
+- **Task** — `channel-get-object-authz`: `GET /v1/channels/:channel_id/:channel_type`
+  (`channelGet`) had no object-level authorization — `loginUID` was a render
+  param, never an authz subject, so any authenticated caller could swap
+  `channel_id` and read group detail (name/notice/member count/`space_id`) of
+  groups they'd left or never joined, sub-channel metadata with no parent
+  membership check, and any user's `short_no`/device flags/realname. Added
+  per-type gating: GROUP/COMMUNITY_TOPIC require (parent) membership
+  (non-member + missing → one `ErrGroupViewForbidden`, no existence oracle);
+  PERSON is relationship-graded (self/friend/same-Space/common-group/bot/system/
+  webhook → full; unrelated → a minimal whitelist DTO, *not* a 403, since this
+  is the sole datasource for rendering arbitrary message senders). Mounted
+  `SharedUIDRateLimiter`; fixed a missing-group nil-panic (500 empty body) that
+  was itself an existence oracle. Traps: display-layer datasources are not an
+  authz layer; a `group_member` row outlives a disbanded group (async cleanup)
+  so `ExistCommonGroup` must `JOIN group` and exclude dissolved ones; a datasource
+  error had stranded the handler's not-found branch (fixed via the
+  `ErrorUserNotExist` sentinel → `ErrDatasourceNotProcess`); a minimal response
+  needs its own DTO because `model.ChannelResp` has no `omitempty`. Origin: an
+  internal security review (object-level read). `GET /v1/users/:uid` is the same
+  root cause through a second door and is fixed in the same change: the decision
+  now lives in `modules/channel/service` (dependency-free leaf that
+  `modules/user` already imports) so the two endpoints cannot drift, with the
+  common-group lookup injected via a registration hook because `modules/user`
+  cannot import `modules/group`. The profile endpoint's minimal set keeps
+  `follow` (the add-friend entry needs it) where the channel one omits it.
+  Review follow-ups: a public brief must not point at an unpatched sibling
+  (fixed by landing both); `status = Normal` was too strict — admin-disabled
+  groups are live everywhere else in the module, so the check is
+  `<> GroupStatusDisband`; existence checks use `SELECT 1 ... LIMIT 1`. See
+  [journal](journal/shared/channel-get-object-authz.md);
+  learning [membership-row-outlives-its-parent](learnings/pending/membership-row-outlives-its-parent.md).
+
 ## 2026-08-07 (reminder-sync-membership-scope)
 
 - **Task** — `reminder-sync-membership-scope`: `POST /v1/message/reminder/sync`

--- a/.octospec/log.md
+++ b/.octospec/log.md
@@ -53,7 +53,10 @@ change-log convention (§7). Newest first.
   `modules/user` already imports) so the two endpoints cannot drift, with the
   common-group lookup injected via a registration hook because `modules/user`
   cannot import `modules/group`. The profile endpoint's minimal set keeps
-  `follow` (the add-friend entry needs it) where the channel one omits it.
+  `follow` (the add-friend entry needs it) where the channel one omits it; both
+  emit `status`, because clients read an absent `status` as their banned
+  sentinel and persist it, so "absent" had to be decided per field rather than
+  applied as a blanket rule.
   Review follow-ups: a public brief must not point at an unpatched sibling
   (fixed by landing both); `status = Normal` was too strict — admin-disabled
   groups are live everywhere else in the module, so the check is

--- a/.octospec/tasks/channel-get-object-authz/brief.md
+++ b/.octospec/tasks/channel-get-object-authz/brief.md
@@ -29,7 +29,7 @@ source: self
     见 Background）/ 系统账号 / `iwh_` webhook —— 返回完整详情，字段与今天完全
     一致（含 `real_name`，保持对外可见，不改动）。
   - **完全无关系** —— 只回渲染历史消息发送者所需的最小集
-    （`channel_id` / `name` / `logo` / `robot`），不下发 `short_no` / `sex` /
+    （`channel_id` / `name` / `logo` / `robot` / `status`），不下发 `short_no` / `sex` /
     `device_flag` / `last_offline` / `source_desc` / `vercode` 等身份细节
     （`real_name` 等 `extra` 字段随整个 `extra` 一并不下发，是"最小集不含"而非
     "对 real_name 单独剥离"）。
@@ -41,6 +41,16 @@ source: self
 「加好友」入口的依据，省略会让陌生人加好友这个正常入口消失（channelGet 是发送者渲染，
 不需要 follow，故刻意省略）。加好友流程不依赖本响应其它字段——`vercode` 由 search /
 扫码路径铸造并校验，且该端点对非好友本来就返回空 `vercode`。
+
+最小集的"省略 vs 给值"按**客户端如何解读缺失**逐字段决定，两个方向都出现：
+- `follow`：channelGet 省略（给 0 会被读成"明确非好友"），users/:uid 保留（资料页靠
+  `follow==0` 渲染加好友入口）；
+- `status`：**两端都必须下发**。三端客户端把缺失时的零值 0 当作"已禁用/封禁"哨兵并
+  写回本地缓存（Android `WKChannelStatus.statusDisabled = 0` → 隐藏输入框并显示封禁
+  视图；iOS 整行覆盖，历史上已为 `mute` 单独硬编码过同类保护）。该字段在本响应里是
+  **调用方自己**是否拉黑对方（1/2，永不为 0），非对方身份信息，下发不削弱隐私收窄。
+  触发路径不是陌生人，而是"当前正在 1:1 的对端离开可见集"——同 Space 对端所在 Space
+  被封禁、或唯一共同群解散/自己退群，下次频道信息刷新即命中。
 
 同时消除两个放大风险：群不存在触发的 nil-panic（500，构成存在性枚举
 oracle），以及该路由缺少 per-UID 限流（批量枚举无成本）。
@@ -162,7 +172,7 @@ helper**，需新建（外部群跨 Space 成员既非好友也非共同 Space�
       一致，均不下发 `name`/`notice`/`member_count`/`space_id`。
 - [ ] COMMUNITY_TOPIC：非父群成员调用 `GET /v1/channels/{topicID}/5` 被拒，
       不下发子区名 / `group_no` / `creator_uid` / `message_count`。
-- [ ] PERSON 无关系目标：仅返回 `channel_id` / `name` / `logo` / `robot`；
+- [ ] PERSON 无关系目标：仅返回 `channel_id` / `name` / `logo` / `robot` / `status`；
       断言响应不下发 `short_no` / `sex` / `device_flag` / `last_offline` /
       `source_desc` / `vercode`（即 `extra` 不下发身份细节）。
 - [ ] PERSON 有关系目标（本人 / 好友 / 共同 Space / 共同群 / Bot / 系统账号）：
@@ -177,7 +187,7 @@ helper**，需新建（外部群跨 Space 成员既非好友也非共同 Space�
 
 ### A2. `GET /v1/users/:uid`（同根因，一并修复）
 
-- [ ] 无关系目标：降级为最小集（`uid`/`name`/`follow`/`robot`），不下发 `short_no` /
+- [ ] 无关系目标：降级为最小集（`uid`/`name`/`follow`/`robot`/`status`），不下发 `short_no` /
       `sex` / `online` / `last_offline` / `device_flag` / `source_desc` / `vercode` /
       实名字段。
 - [ ] 最小集**保留 `follow`**：陌生人资料页仍能渲染「加好友」入口（与 channelGet

--- a/.octospec/tasks/channel-get-object-authz/brief.md
+++ b/.octospec/tasks/channel-get-object-authz/brief.md
@@ -1,0 +1,216 @@
+---
+type: Task
+title: "Task: channel-get-object-authz"
+description: Add object-level authorization to the channel-detail and user-profile endpoints so callers can no longer read details for channels/users they have no relationship with.
+tags: ["space", "isolation", "auth", "acl", "thread", "wire-contract", "error-response", "i18n", "rate-limit", "test"]
+timestamp: 2026-08-09T05:45:39Z
+# --- octospec extension fields ---
+slug: channel-get-object-authz
+upstream: internal security review (object-level read on the channel detail endpoint)
+source: self
+---
+
+# Task: channel-get-object-authz
+
+## Goal
+
+`GET /v1/channels/:channel_id/:channel_type`（`modules/channel/api.go:158`
+`channelGet`）**完全没有对象级授权**：`loginUID` 只被当作渲染参数传给
+`BussDataSource.ChannelGet`，从不用于鉴权。任意已登录用户替换 `channel_id`
+即可读取自己无权访问的频道详情。
+
+本次给 `channelGet` 补齐对象级授权，按 `channel_type` 分治：
+
+- **GROUP（2）/ COMMUNITY_TOPIC（5）**：校验调用方是（父）群有效成员，非成员
+  按与 `GET /v1/groups/:group_no`（`groupGet`）一致的方式拒绝，不再回群名 /
+  公告 / 成员数 / `space_id` / 外部群标识。
+- **PERSON（1）**：不做二元拒绝，改为**按关系分级返回**。
+  - **有关系** —— 本人 / 好友 / 共同 Space / 共同群 / Bot（`robot==1`，恒可查，
+    见 Background）/ 系统账号 / `iwh_` webhook —— 返回完整详情，字段与今天完全
+    一致（含 `real_name`，保持对外可见，不改动）。
+  - **完全无关系** —— 只回渲染历史消息发送者所需的最小集
+    （`channel_id` / `name` / `logo` / `robot`），不下发 `short_no` / `sex` /
+    `device_flag` / `last_offline` / `source_desc` / `vercode` 等身份细节
+    （`real_name` 等 `extra` 字段随整个 `extra` 一并不下发，是"最小集不含"而非
+    "对 real_name 单独剥离"）。
+
+`GET /v1/users/:uid`（`u.get`）是**同一根因的第二个出口**：同样只有登录鉴权、同样
+直调 `GetUserDetail` 不校验关系，任意登录用户拿任意 UID 即可读到完整身份。本次一并
+修复——判定收口到 `modules/channel/service`（零依赖叶子包），两端共用同一函数，避免
+一边放宽另一边静默重开同一越权面。该端点的最小集**保留 `follow`**：它是资料页渲染
+「加好友」入口的依据，省略会让陌生人加好友这个正常入口消失（channelGet 是发送者渲染，
+不需要 follow，故刻意省略）。加好友流程不依赖本响应其它字段——`vercode` 由 search /
+扫码路径铸造并校验，且该端点对非好友本来就返回空 `vercode`。
+
+同时消除两个放大风险：群不存在触发的 nil-panic（500，构成存在性枚举
+oracle），以及该路由缺少 per-UID 限流（批量枚举无成本）。
+
+## Background
+
+### 复现（测试环境，2026-08-09，退群闭环，凭据不入库）
+
+建一临时群（我为创建者）→ 退群（群主自动转让给第二老成员，群继续存在）→ 以
+**非成员**身份复测同一群号：
+
+- `GET /v1/groups/{gno}` → **403** `err.server.group.view_forbidden`（正确）
+- `GET /v1/channels/{gno}/2` → **200 + 完整群详情**，响应 `quit:1` 表明服务端
+  明知调用方已退群，仍下发 `name` / `notice` / `member_count` / `space_id` /
+  `is_external_group` / `allow_view_history_msg`。
+
+两端点调用的是**同一个** `group.Service.GetGroupDetail`
+（`modules/group/service.go:304`），差异只在 `groupGet`（`modules/group/api.go:847`）
+调用前有 `ExistMember` 门禁，`channelGet` 没有。
+
+Space 头对该端点完全无效：非成员态下删除 `X-Space-Id` 或伪造成任意值，
+`channelGet` 一律 200（`groupGet` 删头仍 403，因它查 `ExistMember` 与头无关）。
+`channelGet` 对 `s{spaceID}_{uid}` 前缀只做剥离取 `peerID`
+（`modules/channel/api.go:165-170`），解析出的 `spaceID` 直接丢弃，且该路由未挂
+`SpaceMiddleware`（`api.go:42-49` 只有 `AuthMiddleware`）。
+
+顺带证实的存在性 oracle：群不存在 → **500 空 body**
+（`newChannelRespWithGroupResp`（`modules/group/1module.go:171`）对
+`GetGroupDetail` 返回的 `nil` 不判空即解引用，panic 被 gin Recovery 兜成 500）；
+用户不存在 → **400**「用户信息不存在！」。两种响应可零成本区分频道/用户是否存在。
+
+### 数据源链现状（四个 `ChannelGet` 实现均不鉴权）
+
+`channelGet` 通过 `register.GetModules` 链式分发到各模块的
+`BussDataSource.ChannelGet`。这些是**展示层**数据源，设计上不负责鉴权：
+
+- PERSON：`modules/user/1module.go:56` → `GetUserDetail(uid, loginUID)`
+  （`modules/user/service.go:420`）。`phone` / `email` / `zone` 已被
+  `NewUserDetailResp`（`service.go:1499`）的 `self := loginUID == m.UID` 挡住，
+  未泄露；但 `short_no` / `device_flag` / `last_offline` 无条件下发，`real_name`
+  按 `service.go:1460` 注释是**有意对外可见（含非自己）**。
+- GROUP：`modules/group/1module.go:97` → `GetGroupDetail`。
+- COMMUNITY_TOPIC：`modules/thread/1module.go:200`，**完全不校验父群成员关系**，
+  与 CLAUDE.md「thread 必须 verify parent channel access」相违。
+- `iwh_` 前缀单聊：`modules/incomingwebhook/display.go:83`，仅合成展示名/头像，
+  刻意不下发 `group_no`；本 brief 不改其逻辑。
+
+### 为什么 PERSON 不能简单 403（关键约束）
+
+`modules/user/1module.go:239` 的注释（YUJ-411 根因报告）明确：
+`/v1/channels/:id/:type → newChannelRespWithUserDetailResp` 是 Android WKSDK
+单用户 Channel 的**唯一数据源**，客户端渲染**任意消息发送者**名字/头像都打这个
+端点。若对非好友硬 403，**外部群里来自其它 Space 的非好友成员**（`IsFriend` 与
+`GetCommonSpaceID` 都判否）会渲染裂名/裂图。因此 PERSON 分支必须分级降级而非
+拒绝。仓库现有关系素材只有 `userService.IsFriend` 和
+`space.GetCommonSpaceID`（`modules/space/db.go:438`），**缺"共同群"关系判定
+helper**，需新建（外部群跨 Space 成员既非好友也非共同 Space，仅靠共同群可达）。
+
+产品事实（本 task 的关系模型依据，已确认）：
+
+- **同一 Space 内的用户可直接聊天，无需好友关系**——这是最主要的可达关系，对齐现有
+  `GetUserDetail`（`service.go:518`）对共同 Space 自动补 `follow=1` 的写法。跨 Space
+  才依赖好友或共同群可达。因此对绝大多数目标"有关系"成立；"完全无关系"（不同
+  Space、非好友、无共同群）只出现在历史消息残留的发送者渲染或枚举探测。
+- **Bot 需先加好友才能交互**，但其**资料必须可查看**（用户要先看到 bot 才能决定
+  是否添加）。故 Bot（`robot==1`）在本分支**恒归入"可查"**，与"未加好友不能和
+  bot 聊天"不冲突（查看资料 ≠ 已可交互）。这也对齐现有 `GetUserDetail`
+  （`service.go:518`）里 `follow==0 && robot==0` 才用共同 Space 补 `follow` 的
+  写法——Bot 被单独排除在该补位逻辑之外。
+- **`real_name` 保持对外可见**（`service.go:1460` 现状不变）；它只在"有关系"路径
+  进入响应，无关系走最小集时随整个 `extra` 不下发。
+
+### 合法非成员场景不受影响（已核对）
+
+- 加群预览走**独立公开端点** `/v1/group/invite/detail`（`groupInviteDetail`，
+  `modules/group/api.go:4613`，`QueryWithGroupNo` + `QueryMemberCount`，需持有效
+  邀请码），扫码入群走 `scanjoin`，均不经 `channelGet`。
+- 退群后 `conversation/sync` 已把该群移出会话列表（实测），正常客户端不会再对
+  退群的群调 `channelGet`。
+
+## Load-bearing list
+
+- `space` / `isolation` / `auth` / `acl` — 对象级读边界；本改动即该边界本身。
+  GROUP/TOPIC 的成员校验、PERSON 的关系分级、以及 Space 前缀解析后 `spaceID`
+  被丢弃的现状都在此范围。
+- `thread` — COMMUNITY_TOPIC 频道详情继承父群 ACL；新增父群成员校验。
+- `wire-contract` — `channelGet` 响应形状收窄：PERSON 无关系时字段裁剪，
+  GROUP/TOPIC 非成员从 200+详情 变为拒绝。需核对客户端字段依赖不回归。**已知
+  影响**：历史消息里的群引用（群名片转发、"你已被移出群"通知、搜索历史点入）若
+  客户端**实时**调 `channelGet /2` 渲染群名，非成员将拿到拒绝而非群名——需与
+  客户端确认这些位置是否已用本地缓存的群名而非实时拉取。
+- `error-response` / `i18n` — `modules/channel/` 尚未做 i18n 迁移（现全是 legacy
+  `c.ResponseError`）。新增拒绝分支必须走 `httperr.ResponseErrorL` + 注册
+  `pkg/errcode` 码；`incomingwebhook`（`webhook_render_test.go`）与 `user` 侧有
+  跨模块测试断言 `channelGet` 响应文本/行为，改响应体要同步。
+- `rate-limit` — 该路由组（`api.go:42`）仅 `AuthMiddleware`，需在 `AuthMiddleware`
+  之后挂 `SharedUIDRateLimiter`（默认 2rps/burst60），与其它认证路由一致。
+- `test` — 跨用户 / 跨 Space / 退群后 / 非父群成员子区 / `iwh_` webhook /
+  不存在目标 的回归测试，两个端点各一套；限流测试 setup 需重置本用户的
+  `ratelimit:uid:{uid}`（只删自己那把 key，KEYS 全量扫会删掉并发包的桶）。
+
+## Out of scope
+
+- 用户资料的**字段策略本身**（哪些字段属于"完整"）不变：手机号 / 邮箱 / 区号仍只
+  对本人下发，`real_name` 在有关系视角下的可见性保持现状。本 task 只加"无关系时
+  降级"这一层。
+- `iwh_` webhook 展示分支（`incomingwebhook/display.go`）逻辑不变。
+- 加群预览 / 扫码入群端点（`groupInviteDetail` / `scanjoin`）不改。
+- todo 中其它条目（扫码登录 4.1、预签名下载、HTML 内联、Token 生命周期、公共配置
+  收敛）不在本 task。
+
+## Acceptance
+
+### A. 对象级授权（核心）
+
+- [ ] GROUP：非成员调用 `GET /v1/channels/{gno}/2` 不再返回群详情，其拒绝行为与
+      `GET /v1/groups/{gno}` 对齐（复用 `errcode.ErrGroupViewForbidden` 或等价
+      语义码）。退群闭环复测：退群后 `channels/{gno}/2` 与 `groups/{gno}` 响应
+      一致，均不下发 `name`/`notice`/`member_count`/`space_id`。
+- [ ] COMMUNITY_TOPIC：非父群成员调用 `GET /v1/channels/{topicID}/5` 被拒，
+      不下发子区名 / `group_no` / `creator_uid` / `message_count`。
+- [ ] PERSON 无关系目标：仅返回 `channel_id` / `name` / `logo` / `robot`；
+      断言响应不下发 `short_no` / `sex` / `device_flag` / `last_offline` /
+      `source_desc` / `vercode`（即 `extra` 不下发身份细节）。
+- [ ] PERSON 有关系目标（本人 / 好友 / 共同 Space / 共同群 / Bot / 系统账号）：
+      现有字段齐全无回归，`real_name` / `realname_verified` 等在已实名好友视角
+      下仍正常下发（保持现状）。
+- [ ] Bot 目标（`robot==1`）即使调用方未加其好友也可查看资料（`name` / `logo` /
+      `bot_description` / `bot_commands` 等），不被降级为最小集。
+- [ ] 外部群跨 Space 非好友成员：`GET /v1/channels/{uid}/1` 仍成功返回 `name` /
+      `logo`（不 403、不裂名），由新建的"共同群"关系判定覆盖。
+- [ ] Space 头不再是授权依据也不再被静默忽略造成越权：删除/伪造 `X-Space-Id`
+      不能读取调用方无权访问的频道（与新增的成员/关系校验一致即可）。
+
+### A2. `GET /v1/users/:uid`（同根因，一并修复）
+
+- [ ] 无关系目标：降级为最小集（`uid`/`name`/`follow`/`robot`），不下发 `short_no` /
+      `sex` / `online` / `last_offline` / `device_flag` / `source_desc` / `vercode` /
+      实名字段。
+- [ ] 最小集**保留 `follow`**：陌生人资料页仍能渲染「加好友」入口（与 channelGet
+      最小集的刻意差异，理由见 Goal）。
+- [ ] 有关系目标（本人 / 好友 / 同 Space / 共同群 / bot / 系统账号）：字段无回归。
+- [ ] 不存在的 UID 返回 `err.server.user.not_found`，不再返回"查询失败"（后者会误导
+      客户端重试，也混淆了故障与不存在）。
+- [ ] 可见性判定与 channelGet **共用** `modules/channel/service` 的同一函数；判定
+      依赖未注入时 fail closed（降级而非放开）。
+
+### B. 健壮性与响应一致性
+
+- [ ] 群不存在不再返回 500：`channelGet` 对 `GetGroupDetail` 返回 `nil` 的分支
+      判空处理（同时修 `newChannelRespWithGroupResp` 的 nil 解引用）。
+- [ ] 存在性枚举收敛（分类型，避免自相矛盾）：
+      - GROUP/TOPIC：不存在的（父）群与非成员返回**同一** forbidden 响应（码+状态
+        一致），对齐 `groupGet` 先 `ExistMember` 的行为，天然不泄露群是否存在。
+      - PERSON：不存在目标不再 500，返回稳定的 not_found；"无关系但存在"仍需返回
+        最小集（`name`/`logo`，供历史发送者渲染），故与 not_found **有意可区分**。
+        这是"发送者渲染必须成功"与"防 uid 枚举"的固有张力；因 uid 为 32-hex 高熵、
+        非现实枚举面（真正的枚举面 `short_no` 不经此端点），此处取"消除 5xx +
+        渲染优先"，不强行统一。
+- [ ] 新增拒绝/降级分支全部走 `httperr.ResponseErrorL` + 已注册 `pkg/errcode`
+      码；`make i18n-extract-check` 与 `make i18n-lint` 通过；对应 zh-CN 翻译
+      入 `active.zh-CN.toml`。
+- [ ] 该路由组在 `AuthMiddleware` 之后挂 `SharedUIDRateLimiter`。
+- [ ] `go test ./modules/channel/... ./modules/user/... ./modules/group/... ./modules/thread/... ./modules/incomingwebhook/...` 通过；
+      新增 `channelGet` 授权矩阵单测（当前 `channelGet` 零测试覆盖）；限流相关
+      测试在 setup reset `ratelimit:uid:*`。
+- [ ] `Test<Module>NoLegacyResponseError` 源码守卫与 D23 lint baseline 不因新增
+      handler 文件而破。
+
+### 交付方式
+
+- 单个 PR 交付以上全部 Acceptance（授权分级 + 健壮性 + 限流 + 测试）。`real_name`
+  可见性已定（保持现状），无外部阻塞项。

--- a/.octospec/tasks/channel-get-object-authz/brief.md
+++ b/.octospec/tasks/channel-get-object-authz/brief.md
@@ -28,11 +28,15 @@ source: self
   - **有关系** —— 本人 / 好友 / 共同 Space / 共同群 / Bot（`robot==1`，恒可查，
     见 Background）/ 系统账号 / `iwh_` webhook —— 返回完整详情，字段与今天完全
     一致（含 `real_name`，保持对外可见，不改动）。
-  - **完全无关系** —— 只回渲染历史消息发送者所需的最小集
-    （`channel_id` / `name` / `logo` / `robot` / `status`），不下发 `short_no` / `sex` /
-    `device_flag` / `last_offline` / `source_desc` / `vercode` 等身份细节
-    （`real_name` 等 `extra` 字段随整个 `extra` 一并不下发，是"最小集不含"而非
-    "对 real_name 单独剥离"）。
+  - **完全无关系** —— 降级为最小集，规则是**下发全部「调用方自己的状态」、只省略
+    「对方的身份」**：保留 `channel_id` / `name` / `logo` / `robot` 以供渲染，保留
+    `status` / `stick` / `mute` / `show_nick` / `receipt` / `remark` / `flame` /
+    `flame_second` / `parent_channel`，以及 `extra` 中调用方自己的键
+    （`chat_pwd_on` / `screenshot` / `revoke_remind` / `msg_auto_delete`）；
+    省略对方身份与在线态：`username` / `short_no` / `sex` / `category` /
+    `source_desc` / `vercode` / `online` / `last_offline` / `device_flag` /
+    实名字段 / `bot_*`，以及 `be_deleted` / `be_blacklist`（对方对调用方的动作）
+    和 `follow`（关系判决，发送者渲染不需要）。
 
 `GET /v1/users/:uid`（`u.get`）是**同一根因的第二个出口**：同样只有登录鉴权、同样
 直调 `GetUserDetail` 不校验关系，任意登录用户拿任意 UID 即可读到完整身份。本次一并
@@ -42,15 +46,28 @@ source: self
 不需要 follow，故刻意省略）。加好友流程不依赖本响应其它字段——`vercode` 由 search /
 扫码路径铸造并校验，且该端点对非好友本来就返回空 `vercode`。
 
-最小集的"省略 vs 给值"按**客户端如何解读缺失**逐字段决定，两个方向都出现：
-- `follow`：channelGet 省略（给 0 会被读成"明确非好友"），users/:uid 保留（资料页靠
-  `follow==0` 渲染加好友入口）；
-- `status`：**两端都必须下发**。三端客户端把缺失时的零值 0 当作"已禁用/封禁"哨兵并
-  写回本地缓存（Android `WKChannelStatus.statusDisabled = 0` → 隐藏输入框并显示封禁
-  视图；iOS 整行覆盖，历史上已为 `mute` 单独硬编码过同类保护）。该字段在本响应里是
-  **调用方自己**是否拉黑对方（1/2，永不为 0），非对方身份信息，下发不削弱隐私收窄。
-  触发路径不是陌生人，而是"当前正在 1:1 的对端离开可见集"——同 Space 对端所在 Space
-  被封禁、或唯一共同群解散/自己退群，下次频道信息刷新即命中。
+最小集的"省略 vs 给值"按**客户端如何解读缺失**逐字段决定，统一到一条规则：
+
+> **下发所有「调用方自己的状态」，只省略「对方的身份」。**
+
+依据：三端客户端**整行写回本地缓存且不做字段存在性检查**——用新分配的对象接收响应，
+缺失键取零值，再无条件覆盖 SDK 缓存里正确的值。所以省略"调用方自己的设置"买不到任何
+隐私，只会把用户自己开启的功能悄悄关掉。已被追证的后果：
+
+- 缺 `status` → 零值 0 撞上"已禁用/封禁"哨兵（Android `WKChannelStatus.statusDisabled
+  = 0`）→ 隐藏输入框并显示封禁视图；
+- 缺 `extra.chat_pwd_on` → **聊天密码锁静默失效**，加锁会话直接打开且不提示、会话列表
+  预览不再打码（Android 内存态、iOS 落盘）；
+- 缺 `extra.msg_auto_delete` → iOS 新发消息不再按期自动删除（该键全端只由本接口注入）；
+- 缺 `mute` / `stick` / `remark` → 免打扰、置顶、备注被重置（iOS 历史上已为 `mute`
+  单独硬编码过兜底，说明这是已复发过的 bug class）。
+
+唯一例外是 `follow`：channelGet 省略它（给 0 会被读成"明确非好友"，且发送者渲染不需要
+关系判决），users/:uid 保留它（资料页靠 `follow==0` 渲染加好友入口，且走到最小集必然
+是 0）。
+
+触发路径不是陌生人，而是"当前正在 1:1 的对端离开可见集"——删好友、同 Space 对端所在
+Space 被封禁、或唯一共同群解散/自己退群，下次频道信息刷新即命中。
 
 同时消除两个放大风险：群不存在触发的 nil-panic（500，构成存在性枚举
 oracle），以及该路由缺少 per-UID 限流（批量枚举无成本）。
@@ -172,9 +189,11 @@ helper**，需新建（外部群跨 Space 成员既非好友也非共同 Space�
       一致，均不下发 `name`/`notice`/`member_count`/`space_id`。
 - [ ] COMMUNITY_TOPIC：非父群成员调用 `GET /v1/channels/{topicID}/5` 被拒，
       不下发子区名 / `group_no` / `creator_uid` / `message_count`。
-- [ ] PERSON 无关系目标：仅返回 `channel_id` / `name` / `logo` / `robot` / `status`；
-      断言响应不下发 `short_no` / `sex` / `device_flag` / `last_offline` /
-      `source_desc` / `vercode`（即 `extra` 不下发身份细节）。
+- [ ] PERSON 无关系目标：按「调用方自身状态全留、对方身份全剥」降级——断言响应**保留**
+      `status` / `stick` / `mute` / `remark` / `extra.chat_pwd_on` /
+      `extra.msg_auto_delete` 等调用方自身设置（缺失会让用户自己开启的功能被清零），
+      且**不下发** `short_no` / `sex` / `device_flag` / `last_offline` /
+      `source_desc` / `vercode` / 实名字段 / `follow`。
 - [ ] PERSON 有关系目标（本人 / 好友 / 共同 Space / 共同群 / Bot / 系统账号）：
       现有字段齐全无回归，`real_name` / `realname_verified` 等在已实名好友视角
       下仍正常下发（保持现状）。
@@ -187,9 +206,11 @@ helper**，需新建（外部群跨 Space 成员既非好友也非共同 Space�
 
 ### A2. `GET /v1/users/:uid`（同根因，一并修复）
 
-- [ ] 无关系目标：降级为最小集（`uid`/`name`/`follow`/`robot`/`status`），不下发 `short_no` /
-      `sex` / `online` / `last_offline` / `device_flag` / `source_desc` / `vercode` /
-      实名字段。
+- [ ] 无关系目标：降级为最小集，同样遵循「调用方自身状态全留、对方身份全剥」——保留
+      `uid`/`name`/`robot`/`follow`（恒 0）以及 `status`/`mute`/`top`/`chat_pwd_on`/
+      `screenshot`/`revoke_remind`/`receipt`/`flame`/`flame_second`/`remark`；
+      不下发 `short_no` / `sex` / `online` / `last_offline` / `device_flag` /
+      `source_desc` / `vercode` / 实名字段 / `be_deleted` / `be_blacklist`。
 - [ ] 最小集**保留 `follow`**：陌生人资料页仍能渲染「加好友」入口（与 channelGet
       最小集的刻意差异，理由见 Goal）。
 - [ ] 有关系目标（本人 / 好友 / 同 Space / 共同群 / bot / 系统账号）：字段无回归。

--- a/.octospec/tasks/channel-get-object-authz/context.yaml
+++ b/.octospec/tasks/channel-get-object-authz/context.yaml
@@ -1,0 +1,12 @@
+injected:
+  - id: space-isolation
+    source: repo
+  - id: error-handling
+    source: repo
+  - id: rate-limit
+    source: repo
+  - id: trust-boundary
+    source: repo
+  - id: testing
+    source: repo
+brief: .octospec/tasks/channel-get-object-authz/brief.md

--- a/modules/channel/api.go
+++ b/modules/channel/api.go
@@ -255,8 +255,9 @@ func (ch *Channel) channelGet(c *wkhttp.Context) {
 	if channelType == common.ChannelTypePerson.Uint8() {
 		visible, err := ch.personProfileVisible(loginUID, channelID, channelResp)
 		if err != nil {
+			// 用 user 域错误码：这是单聊（人）资料读取失败，客户端不该看到群错误。
 			ch.Error("查询单聊资料可见关系失败", zap.Error(err))
-			httperr.ResponseErrorL(c, errcode.ErrGroupQueryFailed, nil, nil)
+			httperr.ResponseErrorL(c, errcode.ErrUserQueryFailed, nil, nil)
 			return
 		}
 		if !visible {

--- a/modules/channel/api.go
+++ b/modules/channel/api.go
@@ -308,14 +308,26 @@ func (ch *Channel) channelGet(c *wkhttp.Context) {
 // modules/channel/service（与 /v1/users/:uid 共用，避免两端口径漂移）；这里只负责把
 // 本模块能看到的目标属性翻译成该函数的输入。
 func (ch *Channel) personProfileVisible(loginUID string, peerID string, resp *model.ChannelResp) (bool, error) {
-	return chservice.PersonProfileVisible(chservice.PersonProfileInput{
+	// 身份类放行（本人 / webhook / bot / 系统账号）不需要查关系，先判定；只有都不命中
+	// 才付出 HasAuthzRelation 的查询代价。
+	fastPath := chservice.PersonProfileInput{
 		LoginUID:          loginUID,
 		PeerUID:           peerID,
 		SyntheticIdentity: strings.HasPrefix(peerID, user.WebhookUIDPrefix),
 		SystemAccount:     resp.Category == user.CategorySystem || resp.Category == user.CategoryCustomerService,
 		Robot:             resp.Robot == 1,
-		Followed:          resp.Follow == 1,
-	}, ch.groupService.ExistCommonGroup)
+	}
+	if visible, err := chservice.PersonProfileVisible(fastPath, nil); err != nil || visible {
+		return visible, err
+	}
+	// 关系腿走授权口径：不能用 resp.Follow（展示字段，同 Space 来源不校验 Space 活性）。
+	related, err := ch.userService.HasAuthzRelation(loginUID, peerID)
+	if err != nil {
+		return false, err
+	}
+	in := fastPath
+	in.Followed = related
+	return chservice.PersonProfileVisible(in, ch.groupService.ExistCommonGroup)
 }
 
 func (ch *Channel) state(c *wkhttp.Context) {

--- a/modules/channel/api.go
+++ b/modules/channel/api.go
@@ -252,6 +252,10 @@ func (ch *Channel) channelGet(c *wkhttp.Context) {
 	// 对象级授权（PERSON 分级降级）：无可见关系时只返回渲染历史发送者所需的最小集，
 	// 不下发短号/在线状态/设备指纹/实名等身份细节。不做二元 403——渲染任意消息发送者
 	// 名/头像是本端点的既有职责（YUJ-411），硬拒会让外部群跨 Space 成员裂图。
+	// 只在这里**判定**，降级响应推迟到 channelSettingDB 富化之后再构造：
+	// msg_auto_delete / parent_channel 是那一步才附到 channelResp 上的，而它们属于
+	// 调用方自己的会话设置，必须进最小集（缺失会让 iOS 新消息不再自动删除）。
+	personMinimal := false
 	if channelType == common.ChannelTypePerson.Uint8() {
 		visible, err := ch.personProfileVisible(loginUID, channelID, channelResp)
 		if err != nil {
@@ -260,10 +264,7 @@ func (ch *Channel) channelGet(c *wkhttp.Context) {
 			httperr.ResponseErrorL(c, errcode.ErrUserQueryFailed, nil, nil)
 			return
 		}
-		if !visible {
-			c.JSON(http.StatusOK, chservice.NewMinimalChannelResp(channelResp))
-			return
-		}
+		personMinimal = !visible
 	}
 
 	fakeChannelID := channelID
@@ -290,6 +291,14 @@ func (ch *Channel) channelGet(c *wkhttp.Context) {
 		if channelSettingM.MsgAutoDelete > 0 {
 			channelResp.Extra["msg_auto_delete"] = channelSettingM.MsgAutoDelete
 		}
+	}
+
+	// 无可见关系：剥掉对方身份、保留调用方自身会话设置后返回（见
+	// chservice.NewMinimalChannelResp 的取舍规则）。放在设置富化之后、BotFather 文案
+	// 重渲染之前——后者只对 bot 生效，而 bot 恒可见，走不到这里。
+	if personMinimal {
+		c.JSON(http.StatusOK, chservice.NewMinimalChannelResp(channelResp))
+		return
 	}
 
 	// BotFather 的命令菜单是服务端自有文案：库里只存部署默认语言的兜底，这里按

--- a/modules/channel/api.go
+++ b/modules/channel/api.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/Mininglamp-OSS/octo-lib/common"
 	"github.com/Mininglamp-OSS/octo-lib/config"
@@ -12,11 +13,15 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/pkg/register"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
 	"github.com/Mininglamp-OSS/octo-server/modules/botfather/cmdmenu"
+	chservice "github.com/Mininglamp-OSS/octo-server/modules/channel/service"
 	"github.com/Mininglamp-OSS/octo-server/modules/group"
 	"github.com/Mininglamp-OSS/octo-server/modules/user"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
+	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
 	octoi18n "github.com/Mininglamp-OSS/octo-server/pkg/i18n"
 	spacepkg "github.com/Mininglamp-OSS/octo-server/pkg/space"
 	"github.com/Mininglamp-OSS/octo-server/pkg/util"
+	appwkhttp "github.com/Mininglamp-OSS/octo-server/pkg/wkhttp"
 	"go.uber.org/zap"
 )
 
@@ -43,9 +48,11 @@ func (ch *Channel) Route(r *wkhttp.WKHttp) {
 	auth := r.Group("/v1", ch.ctx.AuthMiddleware(r))
 	{
 		auth.GET("/channel/state", ch.state)
-		auth.GET("/channels/:channel_id/:channel_type", ch.channelGet)                          // 获取频道信息
-		auth.POST("/channels/:channel_id/:channel_type/message/clear", ch.clearChannelMessages) // 清空频道消息
-		auth.GET("/channels/:channel_id/:channel_type/storyline", ch.getStoryline)              // 获取群聊个人故事线
+		// channelGet 是跨用户读频道详情的入口，单独挂 SharedUIDRateLimiter（须在
+		// AuthMiddleware 之后才能读到 uid），封顶批量枚举频道/用户的速率。
+		auth.GET("/channels/:channel_id/:channel_type", appwkhttp.SharedUIDRateLimiter(r, ch.ctx), ch.channelGet) // 获取频道信息
+		auth.POST("/channels/:channel_id/:channel_type/message/clear", ch.clearChannelMessages)                   // 清空频道消息
+		auth.GET("/channels/:channel_id/:channel_type/storyline", ch.getStoryline)                                // 获取群聊个人故事线
 	}
 
 	// Routes that build PERSONAL MsgSendReq need SpaceMiddleware so the
@@ -169,6 +176,23 @@ func (ch *Channel) channelGet(c *wkhttp.Context) {
 		}
 	}
 
+	// 对象级授权（GROUP 前置）：非成员——含群不存在（ExistMember 对不存在群同样返回
+	// false）——统一 forbidden。既堵越权（历史上任意登录用户替换 channel_id 即可读
+	// 群名/公告/成员数/space_id），也不泄露群是否存在，口径与 GET /v1/groups/:group_no
+	// （groupGet）一致。
+	if channelType == common.ChannelTypeGroup.Uint8() {
+		isMember, err := ch.groupService.ExistMember(channelID, loginUID)
+		if err != nil {
+			ch.Error("查询群成员关系失败", zap.Error(err))
+			httperr.ResponseErrorL(c, errcode.ErrGroupQueryFailed, nil, nil)
+			return
+		}
+		if !isMember {
+			httperr.ResponseErrorL(c, errcode.ErrGroupViewForbidden, nil, nil)
+			return
+		}
+	}
+
 	modules := register.GetModules(ch.ctx)
 	var err error
 	var channelResp *model.ChannelResp
@@ -187,10 +211,60 @@ func (ch *Channel) channelGet(c *wkhttp.Context) {
 		}
 	}
 	if channelResp == nil {
-		ch.Error("频道不存在！", zap.String("channel_id", channelID), zap.Uint8("channelType", channelType))
-		c.ResponseError(errors.New("频道不存在！"))
+		// 目标不存在：按类型分流，避免存在性枚举 oracle。
+		//   - COMMUNITY_TOPIC：与"非父群成员"统一 forbidden，不泄露子区是否存在。
+		//   - PERSON：统一 not_found（"无关系但存在"的用户仍需返回名/头像供历史发送者
+		//     渲染，故无法与 not_found 合并，见 task brief）。
+		//   - 其它类型：保持原有"频道不存在"。
+		switch channelType {
+		case common.ChannelTypeCommunityTopic.Uint8():
+			httperr.ResponseErrorL(c, errcode.ErrGroupViewForbidden, nil, nil)
+		case common.ChannelTypePerson.Uint8():
+			httperr.ResponseErrorL(c, errcode.ErrUserNotFound, nil, nil)
+		default:
+			ch.Error("频道不存在！", zap.String("channel_id", channelID), zap.Uint8("channelType", channelType))
+			c.ResponseError(errors.New("频道不存在！"))
+		}
 		return
 	}
+
+	// 对象级授权（COMMUNITY_TOPIC 后置）：子区详情继承父群 ACL。父群号从展示数据
+	// 的 extra 取（channel 模块不直接依赖 thread 的 channel_id 解析），用活跃成员
+	// 校验（排除黑名单，语义同 ExistMemberActive 关于 CommunityTopic 的说明）。
+	if channelType == common.ChannelTypeCommunityTopic.Uint8() {
+		parentGroupNo, _ := channelResp.Extra["group_no"].(string)
+		if parentGroupNo == "" {
+			httperr.ResponseErrorL(c, errcode.ErrGroupViewForbidden, nil, nil)
+			return
+		}
+		isMember, err := ch.groupService.ExistMemberActive(parentGroupNo, loginUID)
+		if err != nil {
+			ch.Error("查询子区父群成员关系失败", zap.Error(err))
+			httperr.ResponseErrorL(c, errcode.ErrGroupQueryFailed, nil, nil)
+			return
+		}
+		if !isMember {
+			httperr.ResponseErrorL(c, errcode.ErrGroupViewForbidden, nil, nil)
+			return
+		}
+	}
+
+	// 对象级授权（PERSON 分级降级）：无可见关系时只返回渲染历史发送者所需的最小集，
+	// 不下发短号/在线状态/设备指纹/实名等身份细节。不做二元 403——渲染任意消息发送者
+	// 名/头像是本端点的既有职责（YUJ-411），硬拒会让外部群跨 Space 成员裂图。
+	if channelType == common.ChannelTypePerson.Uint8() {
+		visible, err := ch.personProfileVisible(loginUID, channelID, channelResp)
+		if err != nil {
+			ch.Error("查询单聊资料可见关系失败", zap.Error(err))
+			httperr.ResponseErrorL(c, errcode.ErrGroupQueryFailed, nil, nil)
+			return
+		}
+		if !visible {
+			c.JSON(http.StatusOK, chservice.NewMinimalChannelResp(channelResp))
+			return
+		}
+	}
+
 	fakeChannelID := channelID
 	if channelType == common.ChannelTypePerson.Uint8() {
 		fakeChannelID = common.GetFakeChannelIDWith(loginUID, channelID)
@@ -227,6 +301,20 @@ func (ch *Channel) channelGet(c *wkhttp.Context) {
 
 	c.JSON(http.StatusOK, channelResp)
 
+}
+
+// personProfileVisible 判定 loginUID 是否可见 peerID 的完整单聊资料。判定本身收口在
+// modules/channel/service（与 /v1/users/:uid 共用，避免两端口径漂移）；这里只负责把
+// 本模块能看到的目标属性翻译成该函数的输入。
+func (ch *Channel) personProfileVisible(loginUID string, peerID string, resp *model.ChannelResp) (bool, error) {
+	return chservice.PersonProfileVisible(chservice.PersonProfileInput{
+		LoginUID:          loginUID,
+		PeerUID:           peerID,
+		SyntheticIdentity: strings.HasPrefix(peerID, user.WebhookUIDPrefix),
+		SystemAccount:     resp.Category == user.CategorySystem || resp.Category == user.CategoryCustomerService,
+		Robot:             resp.Robot == 1,
+		Followed:          resp.Follow == 1,
+	}, ch.groupService.ExistCommonGroup)
 }
 
 func (ch *Channel) state(c *wkhttp.Context) {

--- a/modules/channel/channel_get_authz_test.go
+++ b/modules/channel/channel_get_authz_test.go
@@ -82,8 +82,19 @@ func seedMemberDeleted(t *testing.T, ctx *config.Context, groupNo, uid string, r
 	assert.NoError(t, err)
 }
 
-// seedSpaceMember 把 uid 加入某 Space（status=1 在籍）。GetCommonSpaceID 只查
-// space_member，不需要 space 表行。
+// seedSpace 建 Space 父行（status: 1=正常 / 2=封禁 / 0=已解散）。
+// 授权口径的"同 Space"判定会 JOIN space 校验活性（space.HasActiveCommonSpace），
+// 所以只插 space_member 不建父行 = 不可达——这正是封禁冻结生效的机制。
+func seedSpace(t *testing.T, ctx *config.Context, spaceID string, status int) {
+	t.Helper()
+	_, err := ctx.DB().InsertBySql(
+		"INSERT INTO space (space_id, name, creator, status, version) VALUES (?,?,?,?,1)",
+		spaceID, "sp-"+spaceID, testutil.UID, status,
+	).Exec()
+	assert.NoError(t, err)
+}
+
+// seedSpaceMember 把 uid 加入某 Space（成员行 status=1 在籍）。
 func seedSpaceMember(t *testing.T, ctx *config.Context, spaceID, uid string) {
 	t.Helper()
 	_, err := ctx.DB().InsertBySql(
@@ -282,6 +293,8 @@ func TestChannelGet_Person_CrossSpace_Minimal_SpaceHeaderIrrelevant(t *testing.T
 	assert.NoError(t, user.NewService(ctx).AddUser(&user.AddUserReq{
 		UID: "t_otherspace", Name: "OtherSpaceUser", ShortNo: "SNOTHERSP",
 	}))
+	seedSpace(t, ctx, "space_a", 1)
+	seedSpace(t, ctx, "space_b", 1)
 	seedSpaceMember(t, ctx, "space_a", testutil.UID)   // 调用方在 A
 	seedSpaceMember(t, ctx, "space_b", "t_otherspace") // 目标在 B
 
@@ -312,6 +325,7 @@ func TestChannelGet_Person_SameSpace_Full(t *testing.T) {
 	assert.NoError(t, user.NewService(ctx).AddUser(&user.AddUserReq{
 		UID: "t_samespace", Name: "SameSpaceUser", ShortNo: "SNSAMESP",
 	}))
+	seedSpace(t, ctx, "space_a", 1) // 正常 Space
 	seedSpaceMember(t, ctx, "space_a", testutil.UID)
 	seedSpaceMember(t, ctx, "space_a", "t_samespace")
 

--- a/modules/channel/channel_get_authz_test.go
+++ b/modules/channel/channel_get_authz_test.go
@@ -187,7 +187,11 @@ func TestChannelGet_Person_NoRelation_Minimal(t *testing.T) {
 	assert.NotContains(t, w.Body.String(), "SNSTRANGER", "无关系不得下发短号值")
 	// 最小集是专用 DTO：零值字段也不得出现（follow:0 会被客户端误判为"明确非好友"）。
 	assert.NotContains(t, w.Body.String(), "\"follow\"", "最小集不得含 follow 字段, body=%s", w.Body.String())
-	assert.NotContains(t, w.Body.String(), "\"status\"", "最小集不得含 status 字段")
+	// status 与 follow 取舍相反：必须下发。缺失会被三端当成 0="已禁用/封禁"哨兵并写回
+	// 本地缓存（Android 隐藏输入框）。值来自调用方自己的拉黑状态，永不为 0。
+	assert.Contains(t, w.Body.String(), "\"status\":1",
+		"最小集必须下发 status 且为正常值, body=%s", w.Body.String())
+	assert.NotContains(t, w.Body.String(), "\"status\":0", "status 绝不能是 0（客户端封禁哨兵）")
 	assert.NotContains(t, w.Body.String(), "\"extra\"", "最小集不得含 extra 字段")
 	assert.NotContains(t, w.Body.String(), "\"device_flag\"", "最小集不得含 device_flag 字段")
 }
@@ -376,9 +380,10 @@ func TestMinimalChannelResp_JSONShape(t *testing.T) {
 		keys = append(keys, k)
 	}
 	sort.Strings(keys)
-	assert.Equal(t, []string{"channel", "logo", "name", "robot"}, keys,
-		"最小集只能有这四个顶层字段, got=%s", string(b))
-	for _, leaked := range []string{"short_no", "SNX", "follow", "status", "notice", "extra"} {
+	assert.Equal(t, []string{"channel", "logo", "name", "robot", "status"}, keys,
+		"最小集只能有这五个顶层字段, got=%s", string(b))
+	assert.Contains(t, string(b), "\"status\":2", "status 必须原样透传（此处入参为 2）")
+	for _, leaked := range []string{"short_no", "SNX", "follow", "notice", "extra"} {
 		assert.NotContains(t, string(b), leaked)
 	}
 }

--- a/modules/channel/channel_get_authz_test.go
+++ b/modules/channel/channel_get_authz_test.go
@@ -1,0 +1,370 @@
+package channel
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sort"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/model"
+	"github.com/Mininglamp-OSS/octo-lib/server"
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	chservice "github.com/Mininglamp-OSS/octo-server/modules/channel/service"
+	"github.com/Mininglamp-OSS/octo-server/modules/user"
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
+	"github.com/go-redis/redis"
+	"github.com/stretchr/testify/assert"
+)
+
+// channel_get_authz_test.go —— GET /v1/channels/:channel_id/:channel_type 的对象级
+// 授权矩阵（task channel-get-object-authz）。该端点历史上无任何鉴权：任意登录用户
+// 替换 channel_id 即可读取无权访问的频道详情。
+
+// resetChannelUIDRateLimit 清掉 SharedUIDRateLimiter 为本测试用户建的 per-uid 桶。
+// channelGet 现挂了 SharedUIDRateLimiter，桶持久且不被 CleanAllTables 清除，
+// 连续用例会累积把 loginUID 限流掉——须在每个用例 setup 时显式重置。
+//
+// 只删 testutil.UID 这一个 key：限流器是进程级单例、共享同一 Redis keyspace，而
+// testutil.UID 跨包通用；用 KEYS ratelimit:uid:* + DEL 全量会删掉并发运行的其它包的
+// 桶（KEYS 本身也是 O(keyspace) 阻塞命令）。
+func resetChannelUIDRateLimit(t *testing.T, ctx *config.Context) {
+	t.Helper()
+	rds := redis.NewClient(&redis.Options{
+		Addr:     ctx.GetConfig().DB.RedisAddr,
+		Password: ctx.GetConfig().DB.RedisPass,
+	})
+	defer rds.Close()
+	_ = rds.Del("ratelimit:uid:" + testutil.UID).Err()
+}
+
+func newChannelAuthzServer(t *testing.T) (*server.Server, *config.Context) {
+	t.Helper()
+	s, ctx := testutil.NewTestServer()
+	assert.NoError(t, testutil.CleanAllTables(ctx))
+	// 不注入 renderer 时错误信封拿不到 error.code；forbidden/not_found 断言依赖它。
+	s.GetRoute().SetErrorRenderer(i18n.NewErrorRenderer(i18n.NewLocalizer(i18n.DefaultLanguage)))
+	resetChannelUIDRateLimit(t, ctx)
+	// 登录用户
+	assert.NoError(t, user.NewService(ctx).AddUser(&user.AddUserReq{UID: testutil.UID, Name: "login-user", ShortNo: "SNLOGIN"}))
+	return s, ctx
+}
+
+func seedGroup(t *testing.T, ctx *config.Context, groupNo, name, notice, creator string) {
+	seedGroupStatus(t, ctx, groupNo, name, notice, creator, 1) // 1 = GroupStatusNormal
+}
+
+// seedGroupStatus 建群并显式指定 group.status（1=正常, 2=已解散）。
+func seedGroupStatus(t *testing.T, ctx *config.Context, groupNo, name, notice, creator string, status int) {
+	t.Helper()
+	// 反引号：group 是 MySQL 保留字（见 dbr 表名反引号约定）。
+	_, err := ctx.DB().InsertBySql(
+		"INSERT INTO `group` (group_no, name, notice, creator, status, version) VALUES (?,?,?,?,?,1)",
+		groupNo, name, notice, creator, status,
+	).Exec()
+	assert.NoError(t, err)
+}
+
+func seedMember(t *testing.T, ctx *config.Context, groupNo, uid string, role int) {
+	seedMemberDeleted(t, ctx, groupNo, uid, role, 0)
+}
+
+// seedMemberDeleted 建群成员并显式指定 is_deleted（1 = 已退群/已移除，行仍保留）。
+func seedMemberDeleted(t *testing.T, ctx *config.Context, groupNo, uid string, role, isDeleted int) {
+	t.Helper()
+	_, err := ctx.DB().InsertBySql(
+		"INSERT INTO group_member (group_no, uid, role, status, version, vercode, is_deleted) VALUES (?,?,?,1,1,?,?)",
+		groupNo, uid, role, fmt.Sprintf("vc-%s-%s", groupNo, uid), isDeleted,
+	).Exec()
+	assert.NoError(t, err)
+}
+
+// seedSpaceMember 把 uid 加入某 Space（status=1 在籍）。GetCommonSpaceID 只查
+// space_member，不需要 space 表行。
+func seedSpaceMember(t *testing.T, ctx *config.Context, spaceID, uid string) {
+	t.Helper()
+	_, err := ctx.DB().InsertBySql(
+		"INSERT INTO space_member (space_id, uid, role, status, version) VALUES (?,?,0,1,1)",
+		spaceID, uid,
+	).Exec()
+	assert.NoError(t, err)
+}
+
+// setUserCategory 把用户标记为系统/客服账号（AddUserReq 没有 Category 字段）。
+func setUserCategory(t *testing.T, ctx *config.Context, uid, category string) {
+	t.Helper()
+	_, err := ctx.DB().UpdateBySql("UPDATE `user` SET category=? WHERE uid=?", category, uid).Exec()
+	assert.NoError(t, err)
+}
+
+func getChannel(s *server.Server, channelID string, channelType uint8) *httptest.ResponseRecorder {
+	return getChannelWithSpace(s, channelID, channelType, "")
+}
+
+// getChannelWithSpace 允许指定（或省略）X-Space-Id，用于验证 Space 头不是授权输入。
+func getChannelWithSpace(s *server.Server, channelID string, channelType uint8, spaceID string) *httptest.ResponseRecorder {
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", fmt.Sprintf("/v1/channels/%s/%d", channelID, channelType), nil)
+	req.Header.Set("token", testutil.Token)
+	if spaceID != "" {
+		req.Header.Set("X-Space-Id", spaceID)
+	}
+	s.GetRoute().ServeHTTP(w, req)
+	return w
+}
+
+// GROUP 非成员：不再回群详情，返回 view_forbidden，且不泄露群名/公告。
+func TestChannelGet_Group_NonMember_Forbidden(t *testing.T) {
+	s, ctx := newChannelAuthzServer(t)
+	defer testutil.CleanAllTables(ctx)
+
+	seedGroup(t, ctx, "g_authz_nm", "SECRET_GROUP_NAME", "SECRET_NOTICE", "creator_x")
+	seedMember(t, ctx, "g_authz_nm", "creator_x", 1) // 仅 creator_x，loginUID 非成员
+
+	w := getChannel(s, "g_authz_nm", common.ChannelTypeGroup.Uint8())
+
+	assert.Equal(t, http.StatusBadRequest, w.Code, "body=%s", w.Body.String()) // D14 兼容期固定 400
+	assert.Contains(t, w.Body.String(), "err.server.group.view_forbidden", "body=%s", w.Body.String())
+	assert.NotContains(t, w.Body.String(), "SECRET_GROUP_NAME", "非成员不得读到群名")
+	assert.NotContains(t, w.Body.String(), "SECRET_NOTICE", "非成员不得读到群公告")
+}
+
+// GROUP 成员：正常返回群详情。
+func TestChannelGet_Group_Member_OK(t *testing.T) {
+	s, ctx := newChannelAuthzServer(t)
+	defer testutil.CleanAllTables(ctx)
+
+	seedGroup(t, ctx, "g_authz_m", "MEMBER_GROUP_NAME", "", "creator_x")
+	seedMember(t, ctx, "g_authz_m", "creator_x", 1)
+	seedMember(t, ctx, "g_authz_m", testutil.UID, 0) // loginUID 是成员
+
+	w := getChannel(s, "g_authz_m", common.ChannelTypeGroup.Uint8())
+
+	assert.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+	assert.Contains(t, w.Body.String(), "MEMBER_GROUP_NAME")
+}
+
+// GROUP 不存在：不再 500（nil-panic 修复），且与非成员统一为 forbidden（不泄露存在性）。
+func TestChannelGet_Group_NotFound_NoPanicUnified(t *testing.T) {
+	s, ctx := newChannelAuthzServer(t)
+	defer testutil.CleanAllTables(ctx)
+
+	w := getChannel(s, "g_does_not_exist", common.ChannelTypeGroup.Uint8())
+
+	assert.NotEqual(t, http.StatusInternalServerError, w.Code, "群不存在不应再 panic 成 500, body=%s", w.Body.String())
+	assert.Contains(t, w.Body.String(), "err.server.group.view_forbidden",
+		"不存在与非成员应返回同一 forbidden 响应, body=%s", w.Body.String())
+}
+
+// PERSON 无关系：只回最小集（name/logo/robot），不下发 short_no 等身份细节。
+func TestChannelGet_Person_NoRelation_Minimal(t *testing.T) {
+	s, ctx := newChannelAuthzServer(t)
+	defer testutil.CleanAllTables(ctx)
+
+	assert.NoError(t, user.NewService(ctx).AddUser(&user.AddUserReq{
+		UID: "t_stranger", Name: "StrangerName", ShortNo: "SNSTRANGER",
+	}))
+
+	w := getChannel(s, "t_stranger", common.ChannelTypePerson.Uint8())
+
+	assert.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+	assert.Contains(t, w.Body.String(), "StrangerName", "最小集仍需返回 name 供发送者渲染")
+	assert.NotContains(t, w.Body.String(), "short_no", "无关系不得下发 short_no")
+	assert.NotContains(t, w.Body.String(), "SNSTRANGER", "无关系不得下发短号值")
+	// 最小集是专用 DTO：零值字段也不得出现（follow:0 会被客户端误判为"明确非好友"）。
+	assert.NotContains(t, w.Body.String(), "\"follow\"", "最小集不得含 follow 字段, body=%s", w.Body.String())
+	assert.NotContains(t, w.Body.String(), "\"status\"", "最小集不得含 status 字段")
+	assert.NotContains(t, w.Body.String(), "\"extra\"", "最小集不得含 extra 字段")
+	assert.NotContains(t, w.Body.String(), "\"device_flag\"", "最小集不得含 device_flag 字段")
+}
+
+// PERSON 仅共同群（非好友、无共同 Space）：视为可见，返回完整资料（含 short_no）。
+// 覆盖 Acceptance「外部群跨 Space 非好友成员 name/logo 仍可渲染」。
+func TestChannelGet_Person_CommonGroupOnly_Full(t *testing.T) {
+	s, ctx := newChannelAuthzServer(t)
+	defer testutil.CleanAllTables(ctx)
+
+	assert.NoError(t, user.NewService(ctx).AddUser(&user.AddUserReq{
+		UID: "t_cofellow", Name: "CoGroupMate", ShortNo: "SNCOFELLOW",
+	}))
+	// 两人同属一群，但不是好友、无共同 Space。
+	seedGroup(t, ctx, "g_common", "co-group", "", testutil.UID)
+	seedMember(t, ctx, "g_common", testutil.UID, 1)
+	seedMember(t, ctx, "g_common", "t_cofellow", 0)
+
+	w := getChannel(s, "t_cofellow", common.ChannelTypePerson.Uint8())
+
+	assert.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+	assert.Contains(t, w.Body.String(), "CoGroupMate")
+	assert.Contains(t, w.Body.String(), "short_no", "共同群可达应返回完整资料（含 extra）")
+}
+
+// PERSON Bot：即使调用方未加好友也可查看 bot 资料（不降级）。
+func TestChannelGet_Person_Bot_Viewable(t *testing.T) {
+	s, ctx := newChannelAuthzServer(t)
+	defer testutil.CleanAllTables(ctx)
+
+	assert.NoError(t, user.NewService(ctx).AddUser(&user.AddUserReq{
+		UID: "t_bot", Name: "SomeBot", ShortNo: "SNBOT", Robot: 1,
+	}))
+
+	w := getChannel(s, "t_bot", common.ChannelTypePerson.Uint8())
+
+	assert.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+	assert.Contains(t, w.Body.String(), "SomeBot")
+	assert.Contains(t, w.Body.String(), "short_no", "bot 资料应完整可查，不被降级为最小集")
+}
+
+// PERSON 真实不存在用户：走统一 i18n not_found，不再是旧 raw error，也不 500。
+func TestChannelGet_Person_NotExist_NotFound(t *testing.T) {
+	s, ctx := newChannelAuthzServer(t)
+	defer testutil.CleanAllTables(ctx)
+
+	// 不建该用户。
+	w := getChannel(s, "no_such_user_zzz", common.ChannelTypePerson.Uint8())
+
+	assert.NotEqual(t, http.StatusInternalServerError, w.Code, "body=%s", w.Body.String())
+	assert.Contains(t, w.Body.String(), "err.server.user.not_found",
+		"不存在用户应走统一 not_found i18n 信封, body=%s", w.Body.String())
+}
+
+// PERSON 仅共同「已解散」群：不构成有效共同群关系，降级最小集（P1-1 修复）。
+func TestChannelGet_Person_CommonGroupDisbanded_Minimal(t *testing.T) {
+	s, ctx := newChannelAuthzServer(t)
+	defer testutil.CleanAllTables(ctx)
+
+	assert.NoError(t, user.NewService(ctx).AddUser(&user.AddUserReq{
+		UID: "t_disband", Name: "DisbandMate", ShortNo: "SNDISBAND",
+	}))
+	// 唯一共同群已解散（status=2）；成员行仍在（disband 只改群状态、成员异步清理）。
+	seedGroupStatus(t, ctx, "g_disband", "dg", "", testutil.UID, 2)
+	seedMember(t, ctx, "g_disband", testutil.UID, 1)
+	seedMember(t, ctx, "g_disband", "t_disband", 0)
+
+	w := getChannel(s, "t_disband", common.ChannelTypePerson.Uint8())
+
+	assert.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+	assert.Contains(t, w.Body.String(), "DisbandMate")
+	assert.NotContains(t, w.Body.String(), "short_no", "已解散群不构成共同群关系，应降级为最小集")
+	assert.NotContains(t, w.Body.String(), "SNDISBAND")
+}
+
+// GROUP 已退群成员（group_member 行仍在，is_deleted=1）：不得再读群详情。
+// 这是线上复现用的退群闭环场景——修复前 groups/{gno} 返回 403 而 channels/{gno}/2
+// 仍返回 200 + 完整详情（响应里 quit:1 已表明服务端知道调用方退群了）。
+func TestChannelGet_Group_LeftMember_Forbidden(t *testing.T) {
+	s, ctx := newChannelAuthzServer(t)
+	defer testutil.CleanAllTables(ctx)
+
+	seedGroup(t, ctx, "g_left", "LEFT_GROUP_NAME", "LEFT_NOTICE", "creator_x")
+	seedMember(t, ctx, "g_left", "creator_x", 1)
+	seedMemberDeleted(t, ctx, "g_left", testutil.UID, 0, 1) // 已退群
+
+	w := getChannel(s, "g_left", common.ChannelTypeGroup.Uint8())
+
+	assert.Equal(t, http.StatusBadRequest, w.Code, "body=%s", w.Body.String())
+	assert.Contains(t, w.Body.String(), "err.server.group.view_forbidden", "body=%s", w.Body.String())
+	assert.NotContains(t, w.Body.String(), "LEFT_GROUP_NAME", "退群后不得再读到群名")
+	assert.NotContains(t, w.Body.String(), "LEFT_NOTICE", "退群后不得再读到群公告")
+	// quit 标记也不该出现——整个详情都不下发，而不是"带 quit:1 的详情"。
+	assert.NotContains(t, w.Body.String(), "\"quit\"", "退群后不得下发任何群详情字段")
+}
+
+// PERSON 跨 Space（双方各在不同 Space、非好友、无共同群）：只回最小集；
+// 且 X-Space-Id 缺失 / 伪造 / 指向自己的 Space 结果完全一致——证明 Space 头不是授权输入。
+func TestChannelGet_Person_CrossSpace_Minimal_SpaceHeaderIrrelevant(t *testing.T) {
+	s, ctx := newChannelAuthzServer(t)
+	defer testutil.CleanAllTables(ctx)
+
+	assert.NoError(t, user.NewService(ctx).AddUser(&user.AddUserReq{
+		UID: "t_otherspace", Name: "OtherSpaceUser", ShortNo: "SNOTHERSP",
+	}))
+	seedSpaceMember(t, ctx, "space_a", testutil.UID)   // 调用方在 A
+	seedSpaceMember(t, ctx, "space_b", "t_otherspace") // 目标在 B
+
+	for _, spaceHeader := range []string{"", "space_a", "space_b", "bogus_space_xyz"} {
+		name := spaceHeader
+		if name == "" {
+			name = "(无头)"
+		}
+		t.Run(name, func(t *testing.T) {
+			resetChannelUIDRateLimit(t, ctx)
+			w := getChannelWithSpace(s, "t_otherspace", common.ChannelTypePerson.Uint8(), spaceHeader)
+
+			assert.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+			assert.Contains(t, w.Body.String(), "OtherSpaceUser", "最小集仍需回 name")
+			assert.NotContains(t, w.Body.String(), "short_no", "跨 Space 不得下发 short_no（Space 头无论如何都不能提权）")
+			assert.NotContains(t, w.Body.String(), "SNOTHERSP")
+			assert.NotContains(t, w.Body.String(), "\"extra\"")
+		})
+	}
+}
+
+// PERSON 同 Space（无好友关系）：可直接聊天，故资料完整可见——锁住"同 Space 即可达"，
+// 防止把跨 Space 的收紧误伤成同 Space 也降级。
+func TestChannelGet_Person_SameSpace_Full(t *testing.T) {
+	s, ctx := newChannelAuthzServer(t)
+	defer testutil.CleanAllTables(ctx)
+
+	assert.NoError(t, user.NewService(ctx).AddUser(&user.AddUserReq{
+		UID: "t_samespace", Name: "SameSpaceUser", ShortNo: "SNSAMESP",
+	}))
+	seedSpaceMember(t, ctx, "space_a", testutil.UID)
+	seedSpaceMember(t, ctx, "space_a", "t_samespace")
+
+	w := getChannel(s, "t_samespace", common.ChannelTypePerson.Uint8())
+
+	assert.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+	assert.Contains(t, w.Body.String(), "SameSpaceUser")
+	assert.Contains(t, w.Body.String(), "short_no", "同 Space 可直接聊天，资料应完整下发")
+}
+
+// PERSON 系统账号：无需任何关系即可查看（category=system / customerService）。
+func TestChannelGet_Person_SystemAccount_Viewable(t *testing.T) {
+	s, ctx := newChannelAuthzServer(t)
+	defer testutil.CleanAllTables(ctx)
+
+	assert.NoError(t, user.NewService(ctx).AddUser(&user.AddUserReq{
+		UID: "t_sysacct", Name: "SystemAccount", ShortNo: "SNSYSACCT",
+	}))
+	setUserCategory(t, ctx, "t_sysacct", user.CategorySystem)
+
+	w := getChannel(s, "t_sysacct", common.ChannelTypePerson.Uint8())
+
+	assert.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+	assert.Contains(t, w.Body.String(), "SystemAccount")
+	assert.Contains(t, w.Body.String(), "short_no", "系统账号资料应完整可查，不被降级为最小集")
+}
+
+// 最小集的 JSON 线上形状（判定与构造已收口到 modules/channel/service，纯逻辑分支在
+// 那里的 profile_visibility_test.go 里锁；这里只钉序列化后的字段集合）。
+func TestMinimalChannelResp_JSONShape(t *testing.T) {
+	full := &model.ChannelResp{}
+	full.Channel.ChannelID = "u1"
+	full.Channel.ChannelType = common.ChannelTypePerson.Uint8()
+	full.Name = "N"
+	full.Logo = "users/u1/avatar"
+	full.Follow = 1
+	full.Status = 2
+	full.Notice = "secret-notice"
+	full.Extra = map[string]interface{}{"short_no": "SNX"}
+
+	b, err := json.Marshal(chservice.NewMinimalChannelResp(full))
+	assert.NoError(t, err)
+
+	var m map[string]json.RawMessage
+	assert.NoError(t, json.Unmarshal(b, &m))
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	assert.Equal(t, []string{"channel", "logo", "name", "robot"}, keys,
+		"最小集只能有这四个顶层字段, got=%s", string(b))
+	for _, leaked := range []string{"short_no", "SNX", "follow", "status", "notice", "extra"} {
+		assert.NotContains(t, string(b), leaked)
+	}
+}

--- a/modules/channel/channel_get_authz_test.go
+++ b/modules/channel/channel_get_authz_test.go
@@ -192,8 +192,12 @@ func TestChannelGet_Person_NoRelation_Minimal(t *testing.T) {
 	assert.Contains(t, w.Body.String(), "\"status\":1",
 		"最小集必须下发 status 且为正常值, body=%s", w.Body.String())
 	assert.NotContains(t, w.Body.String(), "\"status\":0", "status 绝不能是 0（客户端封禁哨兵）")
-	assert.NotContains(t, w.Body.String(), "\"extra\"", "最小集不得含 extra 字段")
 	assert.NotContains(t, w.Body.String(), "\"device_flag\"", "最小集不得含 device_flag 字段")
+	// 调用方自己的会话设置必须保留：客户端整行写回缓存，省略会把用户自己开的功能关掉。
+	for _, kept := range []string{"\"mute\"", "\"stick\"", "\"remark\"", "\"extra\"", "\"chat_pwd_on\""} {
+		assert.Contains(t, w.Body.String(), kept,
+			"最小集必须保留调用方自身设置 %s, body=%s", kept, w.Body.String())
+	}
 }
 
 // PERSON 仅共同群（非好友、无共同 Space）：视为可见，返回完整资料（含 short_no）。
@@ -315,7 +319,9 @@ func TestChannelGet_Person_CrossSpace_Minimal_SpaceHeaderIrrelevant(t *testing.T
 			assert.Contains(t, w.Body.String(), "OtherSpaceUser", "最小集仍需回 name")
 			assert.NotContains(t, w.Body.String(), "short_no", "跨 Space 不得下发 short_no（Space 头无论如何都不能提权）")
 			assert.NotContains(t, w.Body.String(), "SNOTHERSP")
-			assert.NotContains(t, w.Body.String(), "\"extra\"")
+			// extra 存在但只含调用方自己的会话设置，不含对方身份键。
+			assert.Contains(t, w.Body.String(), "\"chat_pwd_on\"")
+			assert.NotContains(t, w.Body.String(), "real_name")
 		})
 	}
 }
@@ -368,7 +374,17 @@ func TestMinimalChannelResp_JSONShape(t *testing.T) {
 	full.Follow = 1
 	full.Status = 2
 	full.Notice = "secret-notice"
-	full.Extra = map[string]interface{}{"short_no": "SNX"}
+	full.Mute = 1
+	full.Stick = 1
+	full.ShowNick = 1
+	full.Receipt = 1
+	full.Remark = "my-remark"
+	full.Flame = 1
+	full.FlameSecond = 30
+	full.Extra = map[string]interface{}{
+		"short_no": "SNX", "real_name": "张三", "sex": 1,
+		"chat_pwd_on": 1, "screenshot": 1, "revoke_remind": 1, "msg_auto_delete": 60,
+	}
 
 	b, err := json.Marshal(chservice.NewMinimalChannelResp(full))
 	assert.NoError(t, err)
@@ -380,10 +396,20 @@ func TestMinimalChannelResp_JSONShape(t *testing.T) {
 		keys = append(keys, k)
 	}
 	sort.Strings(keys)
-	assert.Equal(t, []string{"channel", "logo", "name", "robot", "status"}, keys,
-		"最小集只能有这五个顶层字段, got=%s", string(b))
+	// 规则：调用方自身状态全留、对方身份全剥。
+	assert.Equal(t, []string{
+		"channel", "extra", "flame", "flame_second", "logo", "mute", "name",
+		"receipt", "remark", "robot", "show_nick", "status", "stick",
+	}, keys, "最小集字段集合已固定, got=%s", string(b))
 	assert.Contains(t, string(b), "\"status\":2", "status 必须原样透传（此处入参为 2）")
-	for _, leaked := range []string{"short_no", "SNX", "follow", "notice", "extra"} {
+	assert.Contains(t, string(b), "\"mute\":1", "调用方的免打扰设置必须透传")
+	assert.Contains(t, string(b), "\"chat_pwd_on\":1",
+		"聊天密码锁必须透传：缺失会让加锁会话直接打开且不提示, got=%s", string(b))
+	assert.Contains(t, string(b), "\"msg_auto_delete\":60",
+		"消息定时删除必须透传：缺失会让 iOS 新消息不再自动删除, got=%s", string(b))
+	// 对方身份/在线态一律不下发；follow 是关系判决，同样不下发。
+	for _, leaked := range []string{"short_no", "SNX", "\"follow\"", "notice",
+		"real_name", "device_flag", "last_offline", "\"sex\"", "vercode", "\"online\""} {
 		assert.NotContains(t, string(b), leaked)
 	}
 }

--- a/modules/channel/channel_get_topic_authz_test.go
+++ b/modules/channel/channel_get_topic_authz_test.go
@@ -1,0 +1,110 @@
+package channel
+
+import (
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	"github.com/stretchr/testify/assert"
+
+	// thread 的 ChannelGet datasource 必须注册，COMMUNITY_TOPIC 分支才可达；
+	// channel 与 thread 互不依赖（已确认无 import cycle），故可在测试里 blank-import。
+	_ "github.com/Mininglamp-OSS/octo-server/modules/thread"
+)
+
+// channel_get_topic_authz_test.go —— COMMUNITY_TOPIC(5) 分支的路由级授权测试。
+//
+// 单列一个文件的原因：thread 模块的 datasource 只在 DM_THREAD_ON 为真时注册，而该
+// 开关在模块 factory 内读取、factory 由 register.GetModules 的 once.Do 只跑一次，
+// 所以必须在**首次** GetModules 之前设好 env —— 用包级 TestMain 统一设置，避免与
+// channel_get_authz_test.go 里的用例产生顺序耦合。
+//
+// 这条分支还依赖一个跨模块数据契约：channelGet 从 Extra["group_no"] 取父群号，该值由
+// modules/thread 的 newChannelRespWithThread 生成。这里的测试同时钉住那个契约——若
+// 将来 thread 改了 key 名或类型，父群成员校验会静默失效（正是本次要堵的洞）。
+func TestMain(m *testing.M) {
+	_ = os.Setenv("DM_THREAD_ON", "true")
+	code := m.Run()
+	_ = os.Unsetenv("DM_THREAD_ON")
+	os.Exit(code)
+}
+
+// seedThread 建子区行。表名/列名与 modules/thread 的 schema 对齐。
+func seedThread(t *testing.T, ctx *config.Context, groupNo, shortID, name, creator string) {
+	t.Helper()
+	_, err := ctx.DB().InsertBySql(
+		"INSERT INTO thread (group_no, short_id, name, creator_uid, status, version) VALUES (?,?,?,?,1,1)",
+		groupNo, shortID, name, creator,
+	).Exec()
+	assert.NoError(t, err)
+}
+
+// 父群成员：可读子区详情。同时验证 Extra["group_no"] 契约成立（否则会被判 forbidden）。
+func TestChannelGet_Topic_ParentGroupMember_OK(t *testing.T) {
+	s, ctx := newChannelAuthzServer(t)
+	defer testutil.CleanAllTables(ctx)
+
+	seedGroup(t, ctx, "g_topic_ok", "topic-parent", "", "creator_x")
+	seedMember(t, ctx, "g_topic_ok", "creator_x", 1)
+	seedMember(t, ctx, "g_topic_ok", testutil.UID, 0) // 调用方是父群成员
+	seedThread(t, ctx, "g_topic_ok", "t1", "TOPIC_VISIBLE_NAME", "creator_x")
+
+	w := getChannel(s, "g_topic_ok____t1", common.ChannelTypeCommunityTopic.Uint8())
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("父群成员应能读子区详情, code=%d body=%s", w.Code, w.Body.String())
+	}
+	assert.Contains(t, w.Body.String(), "TOPIC_VISIBLE_NAME")
+}
+
+// 非父群成员：不得读子区详情，且不泄露子区名 / 父群号 / 创建者。
+func TestChannelGet_Topic_NonParentMember_Forbidden(t *testing.T) {
+	s, ctx := newChannelAuthzServer(t)
+	defer testutil.CleanAllTables(ctx)
+
+	seedGroup(t, ctx, "g_topic_nm", "topic-parent", "", "creator_x")
+	seedMember(t, ctx, "g_topic_nm", "creator_x", 1) // 调用方不是成员
+	seedThread(t, ctx, "g_topic_nm", "t1", "TOPIC_SECRET_NAME", "creator_x")
+
+	w := getChannel(s, "g_topic_nm____t1", common.ChannelTypeCommunityTopic.Uint8())
+
+	assert.Equal(t, http.StatusBadRequest, w.Code, "body=%s", w.Body.String())
+	assert.Contains(t, w.Body.String(), "err.server.group.view_forbidden", "body=%s", w.Body.String())
+	assert.NotContains(t, w.Body.String(), "TOPIC_SECRET_NAME", "非父群成员不得读到子区名")
+	assert.NotContains(t, w.Body.String(), "creator_x", "非父群成员不得读到创建者")
+}
+
+// 已退出父群：与非成员同样被拒（成员行保留 is_deleted=1）。
+func TestChannelGet_Topic_LeftParentGroup_Forbidden(t *testing.T) {
+	s, ctx := newChannelAuthzServer(t)
+	defer testutil.CleanAllTables(ctx)
+
+	seedGroup(t, ctx, "g_topic_left", "topic-parent", "", "creator_x")
+	seedMember(t, ctx, "g_topic_left", "creator_x", 1)
+	seedMemberDeleted(t, ctx, "g_topic_left", testutil.UID, 0, 1) // 已退群
+	seedThread(t, ctx, "g_topic_left", "t1", "TOPIC_LEFT_NAME", "creator_x")
+
+	w := getChannel(s, "g_topic_left____t1", common.ChannelTypeCommunityTopic.Uint8())
+
+	assert.Equal(t, http.StatusBadRequest, w.Code, "body=%s", w.Body.String())
+	assert.Contains(t, w.Body.String(), "err.server.group.view_forbidden")
+	assert.NotContains(t, w.Body.String(), "TOPIC_LEFT_NAME")
+}
+
+// 子区不存在：与"非父群成员"返回同一 forbidden，不泄露子区是否存在。
+func TestChannelGet_Topic_NotFound_UnifiedForbidden(t *testing.T) {
+	s, ctx := newChannelAuthzServer(t)
+	defer testutil.CleanAllTables(ctx)
+
+	seedGroup(t, ctx, "g_topic_nf", "topic-parent", "", "creator_x")
+	seedMember(t, ctx, "g_topic_nf", testutil.UID, 0) // 即便是父群成员，子区不存在也不给存在性信号
+
+	w := getChannel(s, "g_topic_nf____nosuch", common.ChannelTypeCommunityTopic.Uint8())
+
+	assert.NotEqual(t, http.StatusInternalServerError, w.Code, "body=%s", w.Body.String())
+	assert.Contains(t, w.Body.String(), "err.server.group.view_forbidden",
+		"子区不存在应与非成员同码, body=%s", w.Body.String())
+}

--- a/modules/channel/service/profile_visibility.go
+++ b/modules/channel/service/profile_visibility.go
@@ -73,23 +73,36 @@ func PersonProfileVisible(in PersonProfileInput, hasCommonGroup CommonGroupCheck
 //
 // 刻意省略 follow：本端点用于渲染任意发送者，不是关系页，客户端不应据此判断关系。
 // （/v1/users/:uid 的最小集相反**保留** follow —— 那是资料页，要靠它渲染加好友入口。）
+//
+// 但 status **必须下发**，这与 follow 的取舍方向相反，原因是两者的"缺失"被客户端解读
+// 得不一样：
+//   - follow 缺失 → 客户端当作未知（给 0 反而会被读成"明确非好友"），故省略更安全；
+//   - status 缺失 → 三端都把零值 0 当作"已禁用/封禁"哨兵并**写回本地缓存**
+//     （Android WKChannelStatus.statusDisabled = 0 → 隐藏输入框并显示封禁视图；
+//     iOS 会整行覆盖，且历史上已为 mute 单独硬编码过同类保护），故省略更危险。
+//
+// 且 status 在本响应里是**调用方自己**是否拉黑对方（1=未拉黑 / 2=已拉黑，见
+// user.GetUserDetail 的 blacklist 计算），既非对方身份信息，也永不为 0，下发它不削弱
+// 本次的隐私收窄目标——真正买到隐私的是 short_no / 在线状态 / 设备指纹等的省略。
 type MinimalChannelResp struct {
 	Channel struct {
 		ChannelID   string `json:"channel_id"`
 		ChannelType uint8  `json:"channel_type"`
 	} `json:"channel"`
-	Name  string `json:"name"`
-	Logo  string `json:"logo"`
-	Robot int    `json:"robot"`
+	Name   string `json:"name"`
+	Logo   string `json:"logo"`
+	Robot  int    `json:"robot"`
+	Status int    `json:"status"`
 }
 
 // NewMinimalChannelResp 从完整详情里挑出白名单四项。白名单式构造——将来给
 // model.ChannelResp 新增字段时默认不泄露。
 func NewMinimalChannelResp(full *model.ChannelResp) MinimalChannelResp {
 	m := MinimalChannelResp{
-		Name:  full.Name,
-		Logo:  full.Logo,
-		Robot: full.Robot,
+		Name:   full.Name,
+		Logo:   full.Logo,
+		Robot:  full.Robot,
+		Status: full.Status,
 	}
 	m.Channel.ChannelID = full.Channel.ChannelID
 	m.Channel.ChannelType = full.Channel.ChannelType

--- a/modules/channel/service/profile_visibility.go
+++ b/modules/channel/service/profile_visibility.go
@@ -31,8 +31,12 @@ type PersonProfileInput struct {
 	// Robot：目标是 bot。资料公开可查——用户要先看到 bot 才能决定是否添加；
 	// "查看资料" != "已可交互"，未加好友仍不能与 bot 对话。
 	Robot bool
-	// Followed：已关注。user.GetUserDetail 已把「好友」与「同 Space 可直接聊天」
-	// 两种可达关系合并进 Follow，故这里一个布尔即覆盖两者。
+	// Followed：调用方与目标存在可达关系（好友，或同属一个**正常状态**的 Space）。
+	//
+	// 必须由调用方用**授权口径**计算（user.IService.HasAuthzRelation），
+	// **不要**直接传 UserDetailResp.Follow / ChannelResp.Follow：那是展示字段，
+	// 其"同 Space"来源不校验 Space 活性（封禁 Space 只翻父行、成员行仍在），
+	// 用它做授权会让封禁冻结失效。
 	Followed bool
 }
 

--- a/modules/channel/service/profile_visibility.go
+++ b/modules/channel/service/profile_visibility.go
@@ -1,0 +1,93 @@
+package service
+
+import "github.com/Mininglamp-OSS/octo-lib/model"
+
+// profile_visibility.go —— 单聊/用户资料的**对象级可见性判定**，两个端点共用：
+//
+//	GET /v1/channels/:channel_id/:channel_type  （channel_type=PERSON）
+//	GET /v1/users/:uid
+//
+// 两者历史上都只有登录鉴权、没有对象级关系校验，且共用 user.GetUserDetail 作为数据源。
+// 判定收口在本包而不是各自的 handler，是为了让两端口径不可能漂移——一边放宽另一边就
+// 静默重开同一个越权面。
+//
+// 本包是**零依赖叶子包**（modules/user 反向引用它，见 modules/user/api_friend.go），
+// 因此这里不 import modules/user / modules/incomingwebhook：合成身份前缀（iwh_）与
+// 系统/客服分类常量归那些上层模块所有，由调用方判定后以布尔传入。
+
+// CommonGroupChecker 判定两个用户是否至少同属一个未解散的群。
+// 由 group 模块提供实现（channel 直接注入 groupService，user 走注册钩子）。
+type CommonGroupChecker func(uidA string, uidB string) (bool, error)
+
+// PersonProfileInput 描述判定所需的调用方与目标属性。
+type PersonProfileInput struct {
+	LoginUID string
+	PeerUID  string
+	// SyntheticIdentity：目标是展示专用合成身份（如 incoming webhook 的 iwh_ 前缀）。
+	// 这类身份没有隐私字段，保持完整以免展示层裂图。
+	SyntheticIdentity bool
+	// SystemAccount：系统 / 客服账号。
+	SystemAccount bool
+	// Robot：目标是 bot。资料公开可查——用户要先看到 bot 才能决定是否添加；
+	// "查看资料" != "已可交互"，未加好友仍不能与 bot 对话。
+	Robot bool
+	// Followed：已关注。user.GetUserDetail 已把「好友」与「同 Space 可直接聊天」
+	// 两种可达关系合并进 Follow，故这里一个布尔即覆盖两者。
+	Followed bool
+}
+
+// PersonProfileVisible 判定调用方是否可见目标的完整资料。可见关系：
+// 本人 / 合成身份 / bot / 系统账号 / 已关注（好友或同 Space） / 共同群。
+//
+// 共同群是最后一道判定，因为它是唯一需要查库的一项——外部群里跨 Space 的非好友成员
+// 既非好友也无共同 Space，仅靠共同群可达；不放行会让群内成员名/头像裂图。
+//
+// hasCommonGroup 为 nil 时 fail closed（返回 false），调用方降级为最小集：宁可少给
+// 字段，也不能因为依赖未注入就放开完整资料。
+func PersonProfileVisible(in PersonProfileInput, hasCommonGroup CommonGroupChecker) (bool, error) {
+	if in.PeerUID == "" {
+		return false, nil
+	}
+	if in.LoginUID != "" && in.LoginUID == in.PeerUID {
+		return true, nil
+	}
+	if in.SyntheticIdentity || in.Robot || in.SystemAccount || in.Followed {
+		return true, nil
+	}
+	if hasCommonGroup == nil || in.LoginUID == "" {
+		return false, nil
+	}
+	return hasCommonGroup(in.LoginUID, in.PeerUID)
+}
+
+// MinimalChannelResp 是 channelGet 在无可见关系时的最小响应契约：只序列化频道标识 /
+// 名称 / 头像 / 是否机器人，供客户端渲染历史消息发送者。
+//
+// 不复用 model.ChannelResp——它绝大多数字段无 omitempty，即便只赋值四项，序列化仍会
+// 带出 follow:0 / status:0 / notice:"" / extra:null，其中 follow:0 会被客户端读成
+// 「明确非好友」。用独立 DTO 从字节层面保证「仅这四项」。
+//
+// 刻意省略 follow：本端点用于渲染任意发送者，不是关系页，客户端不应据此判断关系。
+// （/v1/users/:uid 的最小集相反**保留** follow —— 那是资料页，要靠它渲染加好友入口。）
+type MinimalChannelResp struct {
+	Channel struct {
+		ChannelID   string `json:"channel_id"`
+		ChannelType uint8  `json:"channel_type"`
+	} `json:"channel"`
+	Name  string `json:"name"`
+	Logo  string `json:"logo"`
+	Robot int    `json:"robot"`
+}
+
+// NewMinimalChannelResp 从完整详情里挑出白名单四项。白名单式构造——将来给
+// model.ChannelResp 新增字段时默认不泄露。
+func NewMinimalChannelResp(full *model.ChannelResp) MinimalChannelResp {
+	m := MinimalChannelResp{
+		Name:  full.Name,
+		Logo:  full.Logo,
+		Robot: full.Robot,
+	}
+	m.Channel.ChannelID = full.Channel.ChannelID
+	m.Channel.ChannelType = full.Channel.ChannelType
+	return m
+}

--- a/modules/channel/service/profile_visibility.go
+++ b/modules/channel/service/profile_visibility.go
@@ -64,47 +64,92 @@ func PersonProfileVisible(in PersonProfileInput, hasCommonGroup CommonGroupCheck
 	return hasCommonGroup(in.LoginUID, in.PeerUID)
 }
 
-// MinimalChannelResp 是 channelGet 在无可见关系时的最小响应契约：只序列化频道标识 /
-// 名称 / 头像 / 是否机器人，供客户端渲染历史消息发送者。
+// MinimalChannelResp 是 channelGet 在无可见关系时的最小响应契约。
 //
-// 不复用 model.ChannelResp——它绝大多数字段无 omitempty，即便只赋值四项，序列化仍会
-// 带出 follow:0 / status:0 / notice:"" / extra:null，其中 follow:0 会被客户端读成
-// 「明确非好友」。用独立 DTO 从字节层面保证「仅这四项」。
+// 取舍规则（本次的核心政策，逐字段判断而非一刀切白名单）：
 //
-// 刻意省略 follow：本端点用于渲染任意发送者，不是关系页，客户端不应据此判断关系。
-// （/v1/users/:uid 的最小集相反**保留** follow —— 那是资料页，要靠它渲染加好友入口。）
+//	下发所有「调用方自己的状态」，只省略「对方的身份」。
 //
-// 但 status **必须下发**，这与 follow 的取舍方向相反，原因是两者的"缺失"被客户端解读
-// 得不一样：
-//   - follow 缺失 → 客户端当作未知（给 0 反而会被读成"明确非好友"），故省略更安全；
-//   - status 缺失 → 三端都把零值 0 当作"已禁用/封禁"哨兵并**写回本地缓存**
-//     （Android WKChannelStatus.statusDisabled = 0 → 隐藏输入框并显示封禁视图；
-//     iOS 会整行覆盖，且历史上已为 mute 单独硬编码过同类保护），故省略更危险。
+// 理由是客户端**整行写回缓存**且不做字段存在性检查：三端都用一个新分配的对象接收本
+// 响应，缺失键取零值，再无条件覆盖 SDK 缓存里正确的值。所以省略一个"调用方自己的
+// 设置"不会买到任何隐私，只会把用户自己开启的功能悄悄关掉——已实测的后果包括：
+//   - 缺 status → 零值 0 撞上"已禁用/封禁"哨兵，Android 隐藏输入框、显示封禁视图；
+//   - 缺 extra.chat_pwd_on → 聊天密码锁失效，加锁会话直接打开且不提示、列表预览
+//     不再打码（Android 内存态、iOS 落盘）；
+//   - 缺 extra.msg_auto_delete → iOS 新发消息不再按期自动删除（该 key 全端只由本
+//     接口注入）；
+//   - 缺 mute/stick/save/remark → 免打扰、置顶、备注被重置（iOS 历史上已为 mute
+//     单独硬编码过兜底，说明这是已知且已复发过的 bug class）。
 //
-// 且 status 在本响应里是**调用方自己**是否拉黑对方（1=未拉黑 / 2=已拉黑，见
-// user.GetUserDetail 的 blacklist 计算），既非对方身份信息，也永不为 0，下发它不削弱
-// 本次的隐私收窄目标——真正买到隐私的是 short_no / 在线状态 / 设备指纹等的省略。
+// 真正买到隐私的是对方身份/在线态的省略：username、short_no、sex、category、
+// source_desc、vercode、online、last_offline、device_flag、实名字段、bot_* 等。
+// follow 与 be_deleted / be_blacklist 也不下发：前者是关系判决（发送者渲染不需要，
+// 给 0 会被读成"明确非好友"），后两者是**对方**对调用方的动作，属对方信息。
 type MinimalChannelResp struct {
 	Channel struct {
 		ChannelID   string `json:"channel_id"`
 		ChannelType uint8  `json:"channel_type"`
 	} `json:"channel"`
-	Name   string `json:"name"`
-	Logo   string `json:"logo"`
-	Robot  int    `json:"robot"`
-	Status int    `json:"status"`
+	ParentChannel *struct {
+		ChannelID   string `json:"channel_id"`
+		ChannelType uint8  `json:"channel_type"`
+	} `json:"parent_channel,omitempty"`
+
+	// 渲染必需（对方的可公开展示信息）
+	Name  string `json:"name"`
+	Logo  string `json:"logo"`
+	Robot int    `json:"robot"`
+
+	// 以下全部是**调用方自己**的状态，必须原样透传
+	Status      int `json:"status"`       // 调用方是否拉黑对方（1/2，永不为 0）
+	Receipt     int `json:"receipt"`      // 消息回执设置
+	Stick       int `json:"stick"`        // 置顶
+	Mute        int `json:"mute"`         // 免打扰
+	ShowNick    int `json:"show_nick"`    // 显示昵称
+	Flame       int `json:"flame"`        // 阅后即焚
+	FlameSecond int `json:"flame_second"` // 阅后即焚秒数
+
+	Remark string `json:"remark"` // 调用方给对方设置的备注
+
+	// Extra 只保留调用方自己的会话设置键，不含对方身份（实名、bot_* 等一律不进）。
+	Extra map[string]interface{} `json:"extra"`
 }
 
-// NewMinimalChannelResp 从完整详情里挑出白名单四项。白名单式构造——将来给
-// model.ChannelResp 新增字段时默认不泄露。
+// callerOwnedExtraKeys 是 Extra 中属于**调用方自己**的键；其余（realname_verified /
+// real_name / short_no / sex / source_desc / vercode / bot_* 等）是对方身份，不下发。
+var callerOwnedExtraKeys = []string{
+	"chat_pwd_on",     // 聊天密码锁——缺失会让锁静默失效
+	"screenshot",      // 截屏通知
+	"revoke_remind",   // 撤回提醒
+	"msg_auto_delete", // 消息定时删除——缺失会让 iOS 新消息不再自动删除
+}
+
+// NewMinimalChannelResp 按「调用方自身状态全留、对方身份全剥」构造最小集。
+//
+// 必须在 channelSettingDB 富化**之后**调用：msg_auto_delete 与 parent_channel 是那一
+// 步才附到 full 上的，提前返回会让它们永远缺失。
 func NewMinimalChannelResp(full *model.ChannelResp) MinimalChannelResp {
 	m := MinimalChannelResp{
-		Name:   full.Name,
-		Logo:   full.Logo,
-		Robot:  full.Robot,
-		Status: full.Status,
+		ParentChannel: full.ParentChannel,
+		Name:          full.Name,
+		Logo:          full.Logo,
+		Robot:         full.Robot,
+		Status:        full.Status,
+		Receipt:       full.Receipt,
+		Stick:         full.Stick,
+		Mute:          full.Mute,
+		ShowNick:      full.ShowNick,
+		Flame:         full.Flame,
+		FlameSecond:   full.FlameSecond,
+		Remark:        full.Remark,
+		Extra:         map[string]interface{}{},
 	}
 	m.Channel.ChannelID = full.Channel.ChannelID
 	m.Channel.ChannelType = full.Channel.ChannelType
+	for _, k := range callerOwnedExtraKeys {
+		if v, ok := full.Extra[k]; ok {
+			m.Extra[k] = v
+		}
+	}
 	return m
 }

--- a/modules/channel/service/profile_visibility_test.go
+++ b/modules/channel/service/profile_visibility_test.go
@@ -1,0 +1,112 @@
+package service
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/model"
+	"github.com/stretchr/testify/assert"
+)
+
+// profile_visibility_test.go —— 共享可见性判定的契约测试。判定被 channelGet 与
+// /v1/users/:uid 共用，任一分支放宽都会同时重开两个端点的越权面，故在此集中锁死。
+
+func TestPersonProfileVisible_EarlyAllowIdentities(t *testing.T) {
+	// checker 一旦被调用即 fail 测试：以下身份必须在触及共同群查询前就放行。
+	mustNotCall := func(t *testing.T) CommonGroupChecker {
+		return func(string, string) (bool, error) {
+			t.Fatal("这些身份应在查询共同群之前就判定可见")
+			return false, nil
+		}
+	}
+
+	cases := []struct {
+		name string
+		in   PersonProfileInput
+	}{
+		{"self", PersonProfileInput{LoginUID: "u1", PeerUID: "u1"}},
+		{"synthetic_identity", PersonProfileInput{LoginUID: "u1", PeerUID: "iwh_abc", SyntheticIdentity: true}},
+		{"bot", PersonProfileInput{LoginUID: "u1", PeerUID: "u2", Robot: true}},
+		{"system_account", PersonProfileInput{LoginUID: "u1", PeerUID: "u2", SystemAccount: true}},
+		{"followed", PersonProfileInput{LoginUID: "u1", PeerUID: "u2", Followed: true}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			ok, err := PersonProfileVisible(c.in, mustNotCall(t))
+			assert.NoError(t, err)
+			assert.True(t, ok)
+		})
+	}
+}
+
+// 无任何身份特权时才落到共同群查询，并如实透传其结果。
+func TestPersonProfileVisible_FallsBackToCommonGroup(t *testing.T) {
+	in := PersonProfileInput{LoginUID: "u1", PeerUID: "u2"}
+
+	ok, err := PersonProfileVisible(in, func(a, b string) (bool, error) {
+		assert.Equal(t, "u1", a)
+		assert.Equal(t, "u2", b)
+		return true, nil
+	})
+	assert.NoError(t, err)
+	assert.True(t, ok, "有共同群 → 可见")
+
+	ok, err = PersonProfileVisible(in, func(string, string) (bool, error) { return false, nil })
+	assert.NoError(t, err)
+	assert.False(t, ok, "无共同群 → 不可见（降级最小集）")
+}
+
+// 依赖缺失 / 查询出错必须 fail closed —— 不能因为拿不到关系就放开完整资料。
+func TestPersonProfileVisible_FailsClosed(t *testing.T) {
+	in := PersonProfileInput{LoginUID: "u1", PeerUID: "u2"}
+
+	ok, err := PersonProfileVisible(in, nil)
+	assert.NoError(t, err)
+	assert.False(t, ok, "checker 未注入 → 不可见")
+
+	ok, err = PersonProfileVisible(PersonProfileInput{LoginUID: "", PeerUID: "u2"},
+		func(string, string) (bool, error) { return true, nil })
+	assert.NoError(t, err)
+	assert.False(t, ok, "调用方 uid 为空 → 不可见")
+
+	ok, err = PersonProfileVisible(PersonProfileInput{LoginUID: "u1", PeerUID: ""},
+		func(string, string) (bool, error) { return true, nil })
+	assert.NoError(t, err)
+	assert.False(t, ok, "目标 uid 为空 → 不可见")
+
+	wantErr := errors.New("db down")
+	ok, err = PersonProfileVisible(in, func(string, string) (bool, error) { return false, wantErr })
+	assert.ErrorIs(t, err, wantErr, "查询错误必须上抛，由调用方决定 5xx，不可静默放行")
+	assert.False(t, ok)
+}
+
+// 空 LoginUID 不得因 LoginUID == PeerUID 的字符串相等而被误判为"本人"。
+func TestPersonProfileVisible_EmptyUIDsNotSelf(t *testing.T) {
+	ok, err := PersonProfileVisible(PersonProfileInput{LoginUID: "", PeerUID: ""}, nil)
+	assert.NoError(t, err)
+	assert.False(t, ok)
+}
+
+// NewMinimalChannelResp 是白名单式构造：序列化后只有 channel/name/logo/robot 四个顶层
+// 字段——零值字段（follow/status/notice/extra）也不得出现。
+func TestNewMinimalChannelResp_WhitelistOnly(t *testing.T) {
+	full := &model.ChannelResp{}
+	full.Channel.ChannelID = "u1"
+	full.Channel.ChannelType = 1
+	full.Name = "N"
+	full.Logo = "users/u1/avatar"
+	full.Robot = 1
+	full.LastOffline = 123
+	full.DeviceFlag = 3
+	full.Follow = 1
+	full.Status = 2
+	full.Notice = "secret-notice"
+	full.Extra = map[string]interface{}{"short_no": "SNX"}
+
+	m := NewMinimalChannelResp(full)
+	assert.Equal(t, "u1", m.Channel.ChannelID)
+	assert.Equal(t, uint8(1), m.Channel.ChannelType)
+	assert.Equal(t, "N", m.Name)
+	assert.Equal(t, "users/u1/avatar", m.Logo)
+	assert.Equal(t, 1, m.Robot)
+}

--- a/modules/group/1module.go
+++ b/modules/group/1module.go
@@ -5,12 +5,12 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/Mininglamp-OSS/octo-server/modules/user"
-	"github.com/Mininglamp-OSS/octo-server/pkg/util"
 	"github.com/Mininglamp-OSS/octo-lib/common"
 	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-lib/model"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/register"
+	"github.com/Mininglamp-OSS/octo-server/modules/user"
+	"github.com/Mininglamp-OSS/octo-server/pkg/util"
 )
 
 //go:embed sql
@@ -30,6 +30,9 @@ func init() {
 		// source_space_* / home_space_* 字段，让 Web/Android/iOS UserInfo 能区分
 		// "同 Space 非好友 → 直接发消息" vs "跨 Space 外部成员 → 仅可在群内交流"。
 		user.RegisterGroupMemberExternalProvider(api.groupService.GetMemberExternalFields)
+		// 注册共同群判定，供 user 模块的 /v1/users/:uid 做对象级资料可见性判定
+		// （与 /v1/channels/:id/:type 共用 channel/service 的判定函数）。
+		user.RegisterCommonGroupChecker(api.groupService.ExistCommonGroup)
 		return register.Module{
 			Name: "group",
 			SetupAPI: func() register.APIRouter {
@@ -101,6 +104,12 @@ func init() {
 					groupResp, err := api.groupService.GetGroupDetail(channelID, loginUID)
 					if err != nil {
 						return nil, err
+					}
+					if groupResp == nil {
+						// 群不存在：交还链路，由上层优雅回落（频道不存在 / forbidden），
+						// 不把 nil 传给 newChannelRespWithGroupResp 解引用 panic（历史上
+						// 群不存在返回 500 空 body，构成存在性枚举 oracle）。
+						return nil, register.ErrDatasourceNotProcess
 					}
 					return newChannelRespWithGroupResp(groupResp), nil
 				},

--- a/modules/group/1module.go
+++ b/modules/group/1module.go
@@ -33,6 +33,10 @@ func init() {
 		// 注册共同群判定，供 user 模块的 /v1/users/:uid 做对象级资料可见性判定
 		// （与 /v1/channels/:id/:type 共用 channel/service 的判定函数）。
 		user.RegisterCommonGroupChecker(api.groupService.ExistCommonGroup)
+		// 活跃成员口径（排该群黑名单），供 /v1/users/:uid 的 ?group_no= 富化门禁使用；
+		// 与 RegisterGroupMemberChecker（ExistMember，服务置顶等既有路径）分开，避免
+		// 收紧一处波及另一处。
+		user.RegisterActiveGroupMemberChecker(api.groupService.ExistMemberActive)
 		return register.Module{
 			Name: "group",
 			SetupAPI: func() register.APIRouter {

--- a/modules/group/db.go
+++ b/modules/group/db.go
@@ -207,7 +207,11 @@ func (d *DB) ExistMemberActiveInternal(uid string, groupNo string) (bool, error)
 // 管理员可设的独立状态（api_manager.go 的 groupStatusUpdate 只翻 status、保留成员），
 // 全模块 liveness 检查一律只排除 Disband，禁用群仍是"活着的群"。若这里用白名单，
 // 两人唯一共同群被管理员禁用就会静默丢失互相可见性，正是 PERSON 分级要避免的裂图。
-// 可见口径与 ExistMember 一致（不额外排黑名单）——共同群关系不因一方被禁言而消失。
+//
+// 成员侧要求**双方** status=Normal：群黑名单（GroupMemberStatusBlacklist）只置
+// status、保留 is_deleted=0，若不排除，被某群拉黑的人仍能凭该群拿到对方完整资料。
+// 与子区门禁 ExistMemberActive 的口径一致（同一 PR 内两个新谓词不应互相矛盾）。
+// 降级后对方的名字/头像仍可渲染（最小集含 name/logo），不会裂图。
 //
 // SELECT 1 ... LIMIT 1 而非 COUNT(*)：这是存在性判断，且是本端点最热的读路径
 // （每次对无关系 peer 的 channelGet 都会走），让 MySQL 命中首行即停，不必枚举
@@ -222,8 +226,8 @@ func (d *DB) ExistCommonGroup(uidA string, uidB string) (bool, error) {
 			"INNER JOIN group_member m2 ON m1.group_no = m2.group_no "+
 			"INNER JOIN `group` g ON g.group_no = m1.group_no "+
 			"WHERE m1.uid = ? AND m2.uid = ? AND m1.is_deleted = 0 AND m2.is_deleted = 0 "+
-			"AND g.status <> ? LIMIT 1",
-		uidA, uidB, GroupStatusDisband,
+			"AND m1.status = ? AND m2.status = ? AND g.status <> ? LIMIT 1",
+		uidA, uidB, common.GroupMemberStatusNormal, common.GroupMemberStatusNormal, GroupStatusDisband,
 	).Load(&exists)
 	return exists > 0, err
 }

--- a/modules/group/db.go
+++ b/modules/group/db.go
@@ -193,6 +193,41 @@ func (d *DB) ExistMemberActiveInternal(uid string, groupNo string) (bool, error)
 	return count > 0, err
 }
 
+// ExistCommonGroup 判定两个用户是否至少同属一个「未解散」的未退出群（两侧
+// is_deleted=0 且群 status<>GroupStatusDisband）。用于单聊频道详情的关系可见性判定：
+// 外部群里跨 Space 的非好友成员，既非好友也无共同 Space，仅靠共同群可达；不据此
+// 开放展示资料，群内成员名/头像会裂图。
+//
+// 必须关联 group 排除已解散群：解散（disband）只 UpdateStatusTx 改 group.status=2，
+// 成员清理是异步事件，成员行会在窗口期（或异步失败时）残留 is_deleted=0。若只查
+// group_member，两人仅共同属于已解散群也会被误判为「有共同群」，从而拿到完整个人
+// 资料——授权判定不能 fail-open 依赖异步清理。
+//
+// 用 status<>Disband 黑名单而非 status=Normal 白名单：GroupStatusDisabled(0) 是
+// 管理员可设的独立状态（api_manager.go 的 groupStatusUpdate 只翻 status、保留成员），
+// 全模块 liveness 检查一律只排除 Disband，禁用群仍是"活着的群"。若这里用白名单，
+// 两人唯一共同群被管理员禁用就会静默丢失互相可见性，正是 PERSON 分级要避免的裂图。
+// 可见口径与 ExistMember 一致（不额外排黑名单）——共同群关系不因一方被禁言而消失。
+//
+// SELECT 1 ... LIMIT 1 而非 COUNT(*)：这是存在性判断，且是本端点最热的读路径
+// （每次对无关系 peer 的 channelGet 都会走），让 MySQL 命中首行即停，不必枚举
+// 整个交集。
+func (d *DB) ExistCommonGroup(uidA string, uidB string) (bool, error) {
+	if uidA == "" || uidB == "" {
+		return false, nil
+	}
+	var exists int
+	_, err := d.session.SelectBySql(
+		"SELECT 1 FROM group_member m1 "+
+			"INNER JOIN group_member m2 ON m1.group_no = m2.group_no "+
+			"INNER JOIN `group` g ON g.group_no = m1.group_no "+
+			"WHERE m1.uid = ? AND m2.uid = ? AND m1.is_deleted = 0 AND m2.is_deleted = 0 "+
+			"AND g.status <> ? LIMIT 1",
+		uidA, uidB, GroupStatusDisband,
+	).Load(&exists)
+	return exists > 0, err
+}
+
 func (d *DB) existMembers(groupNos []string, uid string) ([]string, error) {
 	var results []string
 	_, err := d.session.Select("group_no").From("group_member").Where("group_no in ? and uid=? and is_deleted=0", groupNos, uid).Load(&results)

--- a/modules/group/db_common_group_test.go
+++ b/modules/group/db_common_group_test.go
@@ -1,0 +1,104 @@
+package group
+
+import (
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	"github.com/stretchr/testify/assert"
+)
+
+// db_common_group_test.go —— ExistCommonGroup 谓词的直接单测。
+//
+// 为什么单列在 group 包：该谓词是对象级资料可见性判定的一条腿
+// （见 modules/channel/service/profile_visibility.go）。channel 侧的路由测试直接注入
+// 生产实现 ch.groupService.ExistCommonGroup，能覆盖"群已解散"；但 modules/user 侧走
+// 注册钩子，且其测试为消除全局状态污染注册了自写替身，**无法**覆盖生产谓词。谓词的
+// 语义必须在它自己的包里钉住，否则改 SQL 不会有任何测试变红。
+//
+// 每条断言都做过变异验证：删掉对应谓词，对应用例必须失败。
+
+func newCommonGroupDB(t *testing.T) *DB {
+	t.Helper()
+	_, ctx := testutil.NewTestServer()
+	assert.NoError(t, testutil.CleanAllTables(ctx))
+	return NewDB(ctx)
+}
+
+func seedCG(t *testing.T, d *DB, groupNo string, groupStatus int, members map[string]int) {
+	t.Helper()
+	_, err := d.session.InsertBySql(
+		"INSERT INTO `group` (group_no, name, creator, status, version) VALUES (?,?,'cg_creator',?,1)",
+		groupNo, "cg-"+groupNo, groupStatus,
+	).Exec()
+	assert.NoError(t, err)
+	for uid, memberStatus := range members {
+		_, err := d.session.InsertBySql(
+			"INSERT INTO group_member (group_no, uid, role, status, version, vercode, is_deleted) VALUES (?,?,0,?,1,?,0)",
+			groupNo, uid, memberStatus, "vc-"+groupNo+"-"+uid,
+		).Exec()
+		assert.NoError(t, err)
+	}
+}
+
+func TestExistCommonGroup(t *testing.T) {
+	d := newCommonGroupDB(t)
+
+	// 正常群 + 双方 status=Normal → 构成共同群
+	seedCG(t, d, "cg_ok", GroupStatusNormal, map[string]int{"cg_a": 1, "cg_b": 1})
+	// 已解散群（status=Disband，成员行仍在——disband 只翻父行、成员异步清理）
+	seedCG(t, d, "cg_disband", GroupStatusDisband, map[string]int{"cg_a": 1, "cg_dis": 1})
+	// 管理员禁用群（status=Disabled）——**仍应算共同群**：全模块 liveness 检查只排除
+	// Disband，禁用是可逆的独立状态，用白名单会静默丢失互相可见性。
+	seedCG(t, d, "cg_disabled", GroupStatusDisabled, map[string]int{"cg_a": 1, "cg_dsb": 1})
+	// 调用方在群内被拉黑（status=Blacklist，is_deleted 仍为 0）
+	seedCG(t, d, "cg_blk_self", GroupStatusNormal, map[string]int{"cg_a": 2, "cg_blk1": 1})
+	// 目标在群内被拉黑
+	seedCG(t, d, "cg_blk_peer", GroupStatusNormal, map[string]int{"cg_a": 1, "cg_blk2": 2})
+
+	cases := []struct {
+		name string
+		a, b string
+		want bool
+		why  string
+	}{
+		{"normal_group_both_active", "cg_a", "cg_b", true, "正常群 + 双方正常"},
+		{"disbanded_group", "cg_a", "cg_dis", false,
+			"已解散群不构成关系：成员行会在异步清理窗口期残留，授权不能 fail-open 依赖清理"},
+		{"disabled_group_still_counts", "cg_a", "cg_dsb", true,
+			"管理员禁用群仍是活着的群（全模块只排除 Disband）；用 status=Normal 白名单会误伤"},
+		{"caller_blacklisted", "cg_a", "cg_blk1", false, "调用方被该群拉黑 → 该群不再赋予可达关系"},
+		{"peer_blacklisted", "cg_a", "cg_blk2", false, "目标被该群拉黑 → 同上（口径对称）"},
+		{"no_shared_group", "cg_b", "cg_dis", false, "无共同群"},
+		{"empty_uid", "", "cg_b", false, "空 uid 直接判否，不查库"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, err := d.ExistCommonGroup(c.a, c.b)
+			assert.NoError(t, err)
+			assert.Equal(t, c.want, got, c.why)
+		})
+	}
+}
+
+// 已退群（is_deleted=1，成员行保留）不构成共同群。
+func TestExistCommonGroup_LeftMemberExcluded(t *testing.T) {
+	d := newCommonGroupDB(t)
+
+	_, err := d.session.InsertBySql(
+		"INSERT INTO `group` (group_no, name, creator, status, version) VALUES ('cg_left','cg-left','cg_creator',?,1)",
+		GroupStatusNormal,
+	).Exec()
+	assert.NoError(t, err)
+	_, err = d.session.InsertBySql(
+		"INSERT INTO group_member (group_no, uid, role, status, version, vercode, is_deleted) VALUES ('cg_left','cg_x',0,1,1,'vc1',1)",
+	).Exec()
+	assert.NoError(t, err)
+	_, err = d.session.InsertBySql(
+		"INSERT INTO group_member (group_no, uid, role, status, version, vercode, is_deleted) VALUES ('cg_left','cg_y',0,1,1,'vc2',0)",
+	).Exec()
+	assert.NoError(t, err)
+
+	got, err := d.ExistCommonGroup("cg_x", "cg_y")
+	assert.NoError(t, err)
+	assert.False(t, got, "已退群成员不构成共同群")
+}

--- a/modules/group/service.go
+++ b/modules/group/service.go
@@ -81,6 +81,10 @@ type IService interface {
 	GetMemberTotalAndOnlineCount(groupNo string) (int, int, error)
 	// 是否存在群成员
 	ExistMember(groupNo string, uid string) (bool, error)
+	// ExistCommonGroup 判定两个用户是否至少同属一个未解散的群。用于单聊频道详情与
+	// 用户资料的关系可见性判定（外部群跨 Space 非好友成员仅靠共同群可达）。
+	// 命名与 db 层同名，保持两层一致（同 ExistMember / ExistMemberActive）。
+	ExistCommonGroup(uidA string, uidB string) (bool, error)
 	// ExistMemberActive 是否存在「活跃」群成员（is_deleted=0 AND status=Normal，
 	// 白名单语义、fail-closed），排除被拉黑成员。供绕过 IM 直查本地分表的读/发门禁，
 	// 以及子区(CommunityTopic)解析父群后的读/写门禁使用，防止被拉黑用户越权读子区内容。
@@ -606,6 +610,11 @@ func (s *Service) GetMemberTotalAndOnlineCount(groupNo string) (int, int, error)
 
 func (s *Service) ExistMember(groupNo string, uid string) (bool, error) {
 	return s.db.ExistMember(uid, groupNo)
+}
+
+// ExistCommonGroup 判定两个用户是否至少同属一个未解散的群。
+func (s *Service) ExistCommonGroup(uidA string, uidB string) (bool, error) {
+	return s.db.ExistCommonGroup(uidA, uidB)
 }
 
 // ExistMemberActive 是 ExistMember 的白名单（fail closed）变体：除 is_deleted=0 外还

--- a/modules/space/db.go
+++ b/modules/space/db.go
@@ -433,8 +433,41 @@ func (d *DB) updateInvitation(code string, maxUses *int, expiresAt *time.Time) e
 	return err
 }
 
+// HasActiveCommonSpace 判定两个用户是否同属一个**正常状态**的 Space（双方在籍
+// status=1，且 space.status=SpaceStatusNormal）。
+//
+// 与 GetCommonSpaceID 的关键差别是 JOIN 了 space 表校验父实体活性：封禁 / 解散
+// Space 走的是 updateSpaceStatus（db_manager.go），它**只翻 space.status、不清
+// space_member 行**（与 forceDisbandSpace 不同）。因此只查关联表的判定会让封禁
+// Space 的两个成员仍被视为"同 Space 可达"，绕过封禁冻结——与
+// api_member_search.go 里已经处理过的同一类问题。
+//
+// 授权判定必须用本函数；GetCommonSpaceID 保留给展示/兼容用途（它有十余个调用方，
+// 语义不在本次范围内变更）。
+func HasActiveCommonSpace(ctx *config.Context, uid1, uid2 string) (bool, error) {
+	if uid1 == "" || uid2 == "" {
+		return false, nil
+	}
+	var exists int
+	_, err := ctx.DB().SelectBySql(`
+		SELECT 1 FROM space_member sm1
+		INNER JOIN space_member sm2 ON sm1.space_id = sm2.space_id
+		INNER JOIN space s ON s.space_id = sm1.space_id
+		WHERE sm1.uid=? AND sm2.uid=? AND sm1.status=1 AND sm2.status=1
+		  AND s.status=?
+		LIMIT 1
+	`, uid1, uid2, SpaceStatusNormal).Load(&exists)
+	if err != nil {
+		return false, err
+	}
+	return exists > 0, nil
+}
+
 // GetCommonSpaceID 查找两个用户共同所在的第一个 Space
 // 返回 space_id 或空字符串（无共同 Space）
+//
+// 注意：本函数**不校验 Space 活性**（不 JOIN space 表），仅供展示用途。
+// 授权判定请用 HasActiveCommonSpace。
 func GetCommonSpaceID(ctx *config.Context, uid1, uid2 string) string {
 	var spaceID string
 	_, err := ctx.DB().SelectBySql(`

--- a/modules/user/1module.go
+++ b/modules/user/1module.go
@@ -64,11 +64,16 @@ func init() {
 					}
 					userDetailResp, err := api.userService.GetUserDetail(channelID, loginUID)
 					if err != nil {
+						// 用户不存在（哨兵）→ 交还链路，让上层（channelGet）走统一的
+						// not_found 响应；真实查询故障才向上传播（不可降级为 not-found）。
+						if errors.Is(err, ErrorUserNotExist) {
+							return nil, register.ErrDatasourceNotProcess
+						}
 						return nil, err
 					}
 					if userDetailResp == nil {
 						api.Error("用户不存在！", zap.String("channel_id", channelID))
-						return nil, errors.New("用户不存在！")
+						return nil, register.ErrDatasourceNotProcess
 					}
 					return newChannelRespWithUserDetailResp(userDetailResp), nil
 				},

--- a/modules/user/api.go
+++ b/modules/user/api.go
@@ -29,6 +29,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-server/pkg/ratelimit"
 	octoredis "github.com/Mininglamp-OSS/octo-server/pkg/redis"
 	spacepkg "github.com/Mininglamp-OSS/octo-server/pkg/space"
+	appwkhttp "github.com/Mininglamp-OSS/octo-server/pkg/wkhttp"
 	rd "github.com/go-redis/redis"
 	"github.com/gocraft/dbr/v2"
 	"github.com/opentracing/opentracing-go"
@@ -235,7 +236,10 @@ func (u *User) Route(r *wkhttp.WKHttp) {
 	auth := r.Group("/v1", u.ctx.AuthMiddleware(r))
 	{
 
-		auth.GET("/users/:uid", u.get) // 根据uid查询用户信息
+		// 挂 SharedUIDRateLimiter（须在 AuthMiddleware 之后才能读到 uid）：该端点是
+		// 对象级资料读取面，UID 虽是 32 位 hex 高熵，但认证用户批量探测不应只受全局
+		// per-IP 桶约束。与 channelGet 对齐（modules/channel/api.go）。
+		auth.GET("/users/:uid", appwkhttp.SharedUIDRateLimiter(r, u.ctx), u.get) // 根据uid查询用户信息
 		// 获取用户的会话信息
 		// auth.GET("/users/:uid/conversation", u.userConversationInfoGet)
 
@@ -1260,12 +1264,13 @@ func (u *User) get(c *wkhttp.Context) {
 	// 与 channelGet 最小集的差异：这里**保留** follow —— 资料页要靠它渲染加好友入口，
 	// 省略会让"陌生人可加好友"这个正常入口消失（channelGet 是发送者渲染，不需要）。
 	visible, err := chservice.PersonProfileVisible(chservice.PersonProfileInput{
-		LoginUID:          loginUID,
-		PeerUID:           uid,
-		SyntheticIdentity: strings.HasPrefix(uid, webhookUIDPrefix),
-		SystemAccount:     userDetailResp.Category == CategorySystem || userDetailResp.Category == CategoryCustomerService,
-		Robot:             userDetailResp.Robot == 1,
-		Followed:          userDetailResp.Follow == 1,
+		LoginUID: loginUID,
+		PeerUID:  uid,
+		// SyntheticIdentity 恒为 false：iwh_ 前缀在上方已提前 return，走不到这里。
+		// 显式留空而不是重复前缀判断，避免读起来像 load-bearing 的死条件。
+		SystemAccount: userDetailResp.Category == CategorySystem || userDetailResp.Category == CategoryCustomerService,
+		Robot:         userDetailResp.Robot == 1,
+		Followed:      userDetailResp.Follow == 1,
 	}, chservice.CommonGroupChecker(getCommonGroupChecker()))
 	if err != nil {
 		u.Error("查询用户资料可见关系失败", zap.Error(err), zap.String("uid", uid))
@@ -1284,6 +1289,29 @@ func (u *User) get(c *wkhttp.Context) {
 	isShowShortNo := false
 	vercode := ""
 	var groupMember *model.GroupMemberResp
+	// group_no 是**调用方传入**的，其富化会下发该群维度的数据：IsShowShortNo 在群
+	// ForbiddenAddFriend==0 时返回目标的 vercode，GetGroupMember 返回目标的成员行
+	// （role / status / 邀请人 / 入群时间）以及外部成员来源 Space 字段。两个 datasource
+	// 都只校验**目标**在该群的可见性规则，完全不接收调用方 uid ——所以必须在这里先确认
+	// 调用方自己是该群成员，否则任何能看到目标的人都可以拿一个自己不在的群号，反查该群
+	// 维度的元数据。
+	//
+	// 非成员（含 checker 未注入 → fail closed）时**静默忽略** group_no，等价于没传：
+	// 比报错更保守，不会打断持有过期/无效 group_no 的客户端，同时该群维度的字段一律不
+	// 下发。
+	if groupNo != "" {
+		callerInGroup := false
+		if checker := getGroupMemberChecker(); checker != nil {
+			ok, err := checker(groupNo, loginUID)
+			if err != nil {
+				u.Error("查询调用方群成员关系失败", zap.Error(err), zap.String("group_no", groupNo))
+			}
+			callerInGroup = ok
+		}
+		if !callerInGroup {
+			groupNo = ""
+		}
+	}
 	if groupNo != "" {
 		modules := register.GetModules(u.ctx)
 		for _, m := range modules {

--- a/modules/user/api.go
+++ b/modules/user/api.go
@@ -1263,15 +1263,25 @@ func (u *User) get(c *wkhttp.Context) {
 	// 判定与 /v1/channels/:id/:type 共用 channel/service，两端口径不会漂移。
 	// 与 channelGet 最小集的差异：这里**保留** follow —— 资料页要靠它渲染加好友入口，
 	// 省略会让"陌生人可加好友"这个正常入口消失（channelGet 是发送者渲染，不需要）。
-	visible, err := chservice.PersonProfileVisible(chservice.PersonProfileInput{
-		LoginUID: loginUID,
-		PeerUID:  uid,
-		// SyntheticIdentity 恒为 false：iwh_ 前缀在上方已提前 return，走不到这里。
-		// 显式留空而不是重复前缀判断，避免读起来像 load-bearing 的死条件。
+	// 身份类放行（本人 / bot / 系统账号）先判定，不命中才付关系查询的代价。
+	// SyntheticIdentity 恒为 false：iwh_ 前缀在上方已提前 return，走不到这里。
+	fastPath := chservice.PersonProfileInput{
+		LoginUID:      loginUID,
+		PeerUID:       uid,
 		SystemAccount: userDetailResp.Category == CategorySystem || userDetailResp.Category == CategoryCustomerService,
 		Robot:         userDetailResp.Robot == 1,
-		Followed:      userDetailResp.Follow == 1,
-	}, chservice.CommonGroupChecker(getCommonGroupChecker()))
+	}
+	visible, err := chservice.PersonProfileVisible(fastPath, nil)
+	if err == nil && !visible {
+		// 关系腿走授权口径：不能用 userDetailResp.Follow（展示字段，其同 Space 来源
+		// 不校验 Space 活性，封禁 Space 的成员行仍在）。
+		var related bool
+		if related, err = u.userService.HasAuthzRelation(loginUID, uid); err == nil {
+			in := fastPath
+			in.Followed = related
+			visible, err = chservice.PersonProfileVisible(in, chservice.CommonGroupChecker(getCommonGroupChecker()))
+		}
+	}
 	if err != nil {
 		u.Error("查询用户资料可见关系失败", zap.Error(err), zap.String("uid", uid))
 		respondUserError(c, errcode.ErrUserQueryFailed)

--- a/modules/user/api.go
+++ b/modules/user/api.go
@@ -1311,7 +1311,11 @@ func (u *User) get(c *wkhttp.Context) {
 	// 下发。
 	if groupNo != "" {
 		callerInGroup := false
-		if checker := getGroupMemberChecker(); checker != nil {
+		// 用**活跃成员**口径（排该群黑名单），与子区门禁 ExistMemberActive、共同群判定
+		// 保持一致：被该群拉黑的人不应还能凭该群号反查群维度元数据。不复用
+		// getGroupMemberChecker（ExistMember，只看 is_deleted），那个钩子还服务着置顶
+		// 频道校验等既有路径。
+		if checker := getActiveGroupMemberChecker(); checker != nil {
 			ok, err := checker(groupNo, loginUID)
 			if err != nil {
 				u.Error("查询调用方群成员关系失败", zap.Error(err), zap.String("group_no", groupNo))

--- a/modules/user/api.go
+++ b/modules/user/api.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-lib/model"
+	chservice "github.com/Mininglamp-OSS/octo-server/modules/channel/service"
 	"github.com/Mininglamp-OSS/octo-server/modules/file"
 	"github.com/Mininglamp-OSS/octo-server/modules/source"
 	"github.com/Mininglamp-OSS/octo-server/pkg/authtree"
@@ -1239,12 +1240,40 @@ func (u *User) get(c *wkhttp.Context) {
 
 	userDetailResp, err := u.userService.GetUserDetail(uid, loginUID)
 	if err != nil {
+		// 目标不存在与查询故障必须分开：前者是稳定的 not_found（不能报"查询失败"误导
+		// 客户端重试），后者才是 5xx 语义的查询故障。
+		if errors.Is(err, ErrorUserNotExist) {
+			respondUserError(c, errcode.ErrUserNotFound)
+			return
+		}
 		u.Error("获取用户详情失败！", zap.Error(err))
 		respondUserError(c, errcode.ErrUserQueryFailed)
 		return
 	}
 	if userDetailResp == nil {
 		respondUserError(c, errcode.ErrUserNotFound)
+		return
+	}
+
+	// 对象级授权：无可见关系时降级为最小资料集，不再仅凭目标 UID 返回完整身份。
+	// 判定与 /v1/channels/:id/:type 共用 channel/service，两端口径不会漂移。
+	// 与 channelGet 最小集的差异：这里**保留** follow —— 资料页要靠它渲染加好友入口，
+	// 省略会让"陌生人可加好友"这个正常入口消失（channelGet 是发送者渲染，不需要）。
+	visible, err := chservice.PersonProfileVisible(chservice.PersonProfileInput{
+		LoginUID:          loginUID,
+		PeerUID:           uid,
+		SyntheticIdentity: strings.HasPrefix(uid, webhookUIDPrefix),
+		SystemAccount:     userDetailResp.Category == CategorySystem || userDetailResp.Category == CategoryCustomerService,
+		Robot:             userDetailResp.Robot == 1,
+		Followed:          userDetailResp.Follow == 1,
+	}, chservice.CommonGroupChecker(getCommonGroupChecker()))
+	if err != nil {
+		u.Error("查询用户资料可见关系失败", zap.Error(err), zap.String("uid", uid))
+		respondUserError(c, errcode.ErrUserQueryFailed)
+		return
+	}
+	if !visible {
+		c.Response(newMinimalUserDetailResp(userDetailResp))
 		return
 	}
 	// BotFather 的命令菜单是服务端自有文案，按请求协商语言重渲染（#335）；

--- a/modules/user/api_pinned.go
+++ b/modules/user/api_pinned.go
@@ -22,8 +22,10 @@ const pinnedMaxPerSpace = 7
 type GroupMemberCheckFunc func(groupNo string, uid string) (bool, error)
 
 // CommonGroupCheckFunc 检查两个用户是否至少同属一个未解散的群。
-// 由 group 模块在 init 阶段注册（modules/user 不能 import modules/group——反向依赖，
-// group/1module.go 引用 user），同 GroupMemberCheckFunc 的注入方向。
+// 由 group 模块的 register.AddModule factory 注册（modules/user 不能 import
+// modules/group——反向依赖，group/1module.go 引用 user），同 GroupMemberCheckFunc 的
+// 注入方向。factory 在首次 register.GetModules 时执行——不是包 init——但路由也由
+// GetModules 挂载，所以端点能对外服务时 hook 必然已就位；nil 路径本身也 fail closed。
 type CommonGroupCheckFunc func(uidA string, uidB string) (bool, error)
 
 var (

--- a/modules/user/api_pinned.go
+++ b/modules/user/api_pinned.go
@@ -21,6 +21,31 @@ const pinnedMaxPerSpace = 7
 // GroupMemberCheckFunc 检查用户是否为群成员的函数类型
 type GroupMemberCheckFunc func(groupNo string, uid string) (bool, error)
 
+// CommonGroupCheckFunc 检查两个用户是否至少同属一个未解散的群。
+// 由 group 模块在 init 阶段注册（modules/user 不能 import modules/group——反向依赖，
+// group/1module.go 引用 user），同 GroupMemberCheckFunc 的注入方向。
+type CommonGroupCheckFunc func(uidA string, uidB string) (bool, error)
+
+var (
+	commonGroupCheckerMu sync.RWMutex
+	commonGroupChecker   CommonGroupCheckFunc
+)
+
+// RegisterCommonGroupChecker 注册共同群检查函数（供 group 模块调用）。
+func RegisterCommonGroupChecker(fn CommonGroupCheckFunc) {
+	commonGroupCheckerMu.Lock()
+	commonGroupChecker = fn
+	commonGroupCheckerMu.Unlock()
+}
+
+// getCommonGroupChecker 返回已注册的共同群检查函数；未注册返回 nil，调用方据此
+// fail closed（资料降级为最小集），不得因依赖缺失而放开完整资料。
+func getCommonGroupChecker() CommonGroupCheckFunc {
+	commonGroupCheckerMu.RLock()
+	defer commonGroupCheckerMu.RUnlock()
+	return commonGroupChecker
+}
+
 var (
 	groupMemberCheckerMu sync.RWMutex
 	groupMemberChecker   GroupMemberCheckFunc

--- a/modules/user/api_pinned.go
+++ b/modules/user/api_pinned.go
@@ -28,6 +28,35 @@ type GroupMemberCheckFunc func(groupNo string, uid string) (bool, error)
 // GetModules 挂载，所以端点能对外服务时 hook 必然已就位；nil 路径本身也 fail closed。
 type CommonGroupCheckFunc func(uidA string, uidB string) (bool, error)
 
+// ActiveGroupMemberCheckFunc 检查用户是否为群的**活跃**成员（is_deleted=0 且
+// status=Normal，即排除被该群拉黑者）。
+//
+// 与 GroupMemberCheckFunc 分开注册、不复用：后者绑定的是 group.ExistMember（只看
+// is_deleted），且同时服务置顶频道访问校验等既有路径，收紧它会改变那些路径的语义。
+// 需要"活跃成员"口径的新门禁（如 /v1/users/:uid 的 ?group_no= 富化）用本函数，与
+// 子区门禁 ExistMemberActive、共同群判定 ExistCommonGroup 的口径保持一致。
+type ActiveGroupMemberCheckFunc func(groupNo string, uid string) (bool, error)
+
+var (
+	activeGroupMemberCheckerMu sync.RWMutex
+	activeGroupMemberChecker   ActiveGroupMemberCheckFunc
+)
+
+// RegisterActiveGroupMemberChecker 注册活跃群成员检查函数（供 group 模块调用）。
+func RegisterActiveGroupMemberChecker(fn ActiveGroupMemberCheckFunc) {
+	activeGroupMemberCheckerMu.Lock()
+	activeGroupMemberChecker = fn
+	activeGroupMemberCheckerMu.Unlock()
+}
+
+// getActiveGroupMemberChecker 返回已注册的活跃群成员检查函数；未注册返回 nil，
+// 调用方据此 fail closed（不做群维度富化）。
+func getActiveGroupMemberChecker() ActiveGroupMemberCheckFunc {
+	activeGroupMemberCheckerMu.RLock()
+	defer activeGroupMemberCheckerMu.RUnlock()
+	return activeGroupMemberChecker
+}
+
 var (
 	commonGroupCheckerMu sync.RWMutex
 	commonGroupChecker   CommonGroupCheckFunc

--- a/modules/user/service.go
+++ b/modules/user/service.go
@@ -64,6 +64,13 @@ type IService interface {
 	GetRegisterCountWithDateSpace(startDate, endDate string) (map[string]int64, error)
 	// IsFriend 查询两个用户是否为好友关系
 	IsFriend(uid string, toUID string) (bool, error)
+	// HasAuthzRelation 判定 loginUID 与 peerUID 之间是否存在**授权口径**的可达关系：
+	// 好友，或同属一个正常状态的 Space。
+	//
+	// 不要用 UserDetailResp.Follow 代替它：Follow 是展示字段，其"同 Space"来源
+	// （space.GetCommonSpaceID）不校验 Space 活性，封禁 Space 的成员行仍在，会让
+	// 冻结失效。对象级资料可见性判定必须走本方法。
+	HasAuthzRelation(loginUID string, peerUID string) (bool, error)
 	// 获取在线用户
 	GetUserOnlineStatus([]string) ([]*OnLineUserResp, error)
 	// 更新用户信息
@@ -1154,6 +1161,25 @@ func (s *Service) GetRegisterCountWithDateSpace(startDate, endDate string) (map[
 }
 
 // IsFriend 查询两个用户是否为好友关系
+// HasAuthzRelation 见 IService 的说明。两条腿按代价升序判定：先好友（单表查询），
+// 再同 Space（两表 JOIN + space 活性）。任一成立即返回，避免无谓的第二次查询。
+func (s *Service) HasAuthzRelation(loginUID string, peerUID string) (bool, error) {
+	if loginUID == "" || peerUID == "" {
+		return false, nil
+	}
+	if loginUID == peerUID {
+		return true, nil
+	}
+	isFriend, err := s.IsFriend(loginUID, peerUID)
+	if err != nil {
+		return false, err
+	}
+	if isFriend {
+		return true, nil
+	}
+	return space.HasActiveCommonSpace(s.ctx, loginUID, peerUID)
+}
+
 func (s *Service) IsFriend(uid string, toUID string) (bool, error) {
 	if uid == "" || toUID == "" {
 		return false, errors.New("用户ID不能为空")

--- a/modules/user/service.go
+++ b/modules/user/service.go
@@ -19,6 +19,10 @@ import (
 	"go.uber.org/zap"
 )
 
+// ErrorUserNotExist 是「用户不存在」的哨兵错误。GetUserDetail 命中空行时返回它，
+// 供调用方用 errors.Is 与「真实查询故障」区分（真实故障不可降级为 not-found，见
+// webhook_identity 的 (nil,nil)/(nil,err) 语义）：channelGet 的数据源据此把不存在的
+// 用户交还链路，最终走统一的 not_found 响应，而非旧的 raw error。
 var ErrorUserNotExist = errors.New("用户不存在！")
 
 // IService 用户服务接口
@@ -417,6 +421,7 @@ func (s *Service) GetAllUsers() ([]*Resp, error) {
 	}
 	return list, nil
 }
+
 func (s *Service) GetUserDetail(uid string, loginUID string) (*UserDetailResp, error) {
 	model, err := s.db.QueryDetailByUID(uid, loginUID)
 	if err != nil {
@@ -424,7 +429,7 @@ func (s *Service) GetUserDetail(uid string, loginUID string) (*UserDetailResp, e
 		return nil, err
 	}
 	if model == nil {
-		return nil, errors.New("用户信息不存在！")
+		return nil, ErrorUserNotExist
 	}
 	onlineM, err := s.onlineDB.queryLastOnlineDeviceWithUID(uid)
 	if err != nil {

--- a/modules/user/user_get_authz_test.go
+++ b/modules/user/user_get_authz_test.go
@@ -74,6 +74,26 @@ func getUser(s *server.Server, uid string) *httptest.ResponseRecorder {
 // seedUserGroupMemberInvited 带 invite_uid 建成员行。u.get 只有在成员行 InviteUID
 // 非空时才把 group_member 塞进响应，所以验证"群维度富化是否被抑制"必须用这个 seeder
 // ——否则负向断言恒成立（空断言），证明不了门禁起作用。
+// seedSpace 建 Space 父行并指定 status（1=正常, 2=封禁, 0=已解散）。
+// 授权判定要 JOIN space 校验活性，所以测试必须建父行——只插 space_member 会让
+// "同 Space" 判定为假（这正是 P2-1 修复后的预期行为）。
+func seedSpace(t *testing.T, ctx *config.Context, spaceID string, status int) {
+	t.Helper()
+	_, err := ctx.DB().InsertBySql(
+		"INSERT INTO space (space_id, name, creator, status, version) VALUES (?,?,?,?,1)",
+		spaceID, "sp-"+spaceID, testutil.UID, status,
+	).Exec()
+	assert.NoError(t, err)
+}
+
+func seedSpaceMemberRow(t *testing.T, ctx *config.Context, spaceID, uid string) {
+	t.Helper()
+	_, err := ctx.DB().InsertBySql(
+		"INSERT INTO space_member (space_id, uid, role, status, version) VALUES (?,?,0,1,1)", spaceID, uid,
+	).Exec()
+	assert.NoError(t, err)
+}
+
 func seedUserGroupMemberInvited(t *testing.T, ctx *config.Context, groupNo, uid, inviteUID string) {
 	t.Helper()
 	_, err := ctx.DB().InsertBySql(
@@ -121,11 +141,9 @@ func TestUserGet_SameSpace_Full(t *testing.T) {
 	assert.NoError(t, NewService(ctx).AddUser(&AddUserReq{
 		UID: "ut_same", Name: "SameSpaceU", ShortNo: "SNSAMEU",
 	}))
+	seedSpace(t, ctx, "sp_a", 1) // 1 = SpaceStatusNormal
 	for _, uid := range []string{testutil.UID, "ut_same"} {
-		_, err := ctx.DB().InsertBySql(
-			"INSERT INTO space_member (space_id, uid, role, status, version) VALUES ('sp_a',?,0,1,1)", uid,
-		).Exec()
-		assert.NoError(t, err)
+		seedSpaceMemberRow(t, ctx, "sp_a", uid)
 	}
 
 	w := getUser(s, "ut_same")
@@ -318,4 +336,43 @@ func TestUserGet_CommonGroupButBlacklisted_Minimal(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code, "body=%s", body)
 	assert.Contains(t, body, "BlacklistedPeer", "名字仍可渲染，不裂图")
 	assert.NotContains(t, body, "short_no", "被该群拉黑后不应再凭该群拿到完整资料, body=%s", body)
+}
+
+// 同属一个**已封禁** Space：不构成授权口径的可达关系 → 降级最小集（P2-1）。
+// 封禁只翻 space.status、不清 space_member 行，若判定只查关联表，封禁冻结会失效。
+func TestUserGet_BannedCommonSpace_Minimal(t *testing.T) {
+	s, ctx := newUserAuthzServer(t)
+	defer testutil.CleanAllTables(ctx)
+
+	assert.NoError(t, NewService(ctx).AddUser(&AddUserReq{
+		UID: "ut_banned", Name: "BannedSpacePeer", ShortNo: "SNBANNED",
+	}))
+	seedSpace(t, ctx, "sp_banned", 2) // 2 = SpaceStatusBanned
+	seedSpaceMemberRow(t, ctx, "sp_banned", testutil.UID)
+	seedSpaceMemberRow(t, ctx, "sp_banned", "ut_banned")
+
+	w := getUser(s, "ut_banned")
+	body := w.Body.String()
+
+	assert.Equal(t, http.StatusOK, w.Code, "body=%s", body)
+	assert.Contains(t, body, "BannedSpacePeer", "名字仍可渲染")
+	assert.NotContains(t, body, "short_no", "封禁 Space 不应再构成可达关系, body=%s", body)
+	assert.NotContains(t, body, "SNBANNED")
+}
+
+// 同属一个**已解散** Space（status=0）同样不构成可达关系。
+func TestUserGet_DisbandedCommonSpace_Minimal(t *testing.T) {
+	s, ctx := newUserAuthzServer(t)
+	defer testutil.CleanAllTables(ctx)
+
+	assert.NoError(t, NewService(ctx).AddUser(&AddUserReq{
+		UID: "ut_dis", Name: "DisbandedSpacePeer", ShortNo: "SNDIS",
+	}))
+	seedSpace(t, ctx, "sp_dis", 0) // 0 = SpaceStatusDisbanded
+	seedSpaceMemberRow(t, ctx, "sp_dis", testutil.UID)
+	seedSpaceMemberRow(t, ctx, "sp_dis", "ut_dis")
+
+	w := getUser(s, "ut_dis")
+	assert.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+	assert.NotContains(t, w.Body.String(), "short_no", "已解散 Space 不应构成可达关系")
 }

--- a/modules/user/user_get_authz_test.go
+++ b/modules/user/user_get_authz_test.go
@@ -129,6 +129,9 @@ func TestUserGet_NoRelation_MinimalKeepsFollow(t *testing.T) {
 	assert.Contains(t, body, "\"follow\":0",
 		"资料页需要 follow 渲染加好友入口，且走到最小集必然是 0（不能从展示字段复制）, body=%s", body)
 	assert.NotContains(t, body, "\"follow\":1", "最小集不得声称已关注")
+	assert.Contains(t, body, "\"status\":1",
+		"status 必须下发：缺失会被三端当成 0=已封禁并写回缓存（Android 隐藏输入框）, body=%s", body)
+	assert.NotContains(t, body, "\"status\":0", "status 绝不能是 0")
 	// 身份细节必须剥离
 	for _, leaked := range []string{"SNSTRU", "short_no", "device_flag", "last_offline", "source_desc", "sex", "vercode"} {
 		assert.NotContains(t, body, leaked, "无关系不得下发 %s", leaked)
@@ -231,7 +234,7 @@ func TestUserGet_NotExist_NotFound(t *testing.T) {
 func TestNewMinimalUserDetailResp_WhitelistOnly(t *testing.T) {
 	full := &UserDetailResp{
 		// Follow 刻意给 1：最小集必须按授权决策输出 0，而不是复制这个展示字段。
-		UID: "u1", Name: "N", Follow: 1, Robot: 0,
+		UID: "u1", Name: "N", Follow: 1, Robot: 0, Status: 1,
 		ShortNo: "SN", Sex: 1, Online: 1, LastOffline: 123, Vercode: "vc",
 		SourceDesc: "src", RealName: "张三", RealnameVerified: true, Phone: "13000000000",
 	}
@@ -246,8 +249,10 @@ func TestNewMinimalUserDetailResp_WhitelistOnly(t *testing.T) {
 		keys = append(keys, k)
 	}
 	sort.Strings(keys)
-	assert.Equal(t, []string{"follow", "name", "robot", "uid"}, keys,
-		"最小集只能有这四个顶层字段, got=%s", string(b))
+	assert.Equal(t, []string{"follow", "name", "robot", "status", "uid"}, keys,
+		"最小集只能有这五个顶层字段, got=%s", string(b))
+	assert.Contains(t, string(b), "\"status\":1",
+		"status 必须原样透传：缺失会被客户端当成 0=已封禁并写回缓存")
 	assert.Contains(t, string(b), "\"follow\":0", "入参 Follow=1 时输出仍须为 0, got=%s", string(b))
 	for _, leaked := range []string{"SN", "short_no", "sex", "online", "last_offline", "vercode", "source_desc", "real_name", "张三", "13000000000"} {
 		assert.NotContains(t, string(b), leaked)

--- a/modules/user/user_get_authz_test.go
+++ b/modules/user/user_get_authz_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/server"
 	"github.com/Mininglamp-OSS/octo-lib/testutil"
 	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
+	"github.com/go-redis/redis"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -20,12 +21,30 @@ import (
 // 该端点与 /v1/channels/:id/:type 同根因：都只有登录鉴权、共用 GetUserDetail，任意
 // 登录用户拿任意 UID 就能读到完整身份（短号 / 性别 / 在线状态 / 设备指纹 / 实名）。
 // 可见性判定收口在 modules/channel/service，两端共用，故这里主要钉本端点特有的部分：
-// 最小集**保留 follow**（资料页要靠它渲染加好友入口），以及不存在目标的响应码。
+// 最小集的字段取舍（保留 follow 与全部「调用方自身状态」，见 user_profile_minimal.go）
+// 以及不存在目标的响应码。
+
+// resetUserUIDRateLimit 清掉本测试用户的 per-uid 令牌桶。
+//
+// /v1/users/:uid 现在挂了 SharedUIDRateLimiter，桶在 Redis 持久且**不被
+// CleanAllTables 清除**；本文件十余个用例共用 testutil.UID，重复执行（-count=N）或与
+// 其它包并行跑会把桶耗尽而收到限流响应。只删自己这一把 key —— KEYS 全量扫是 O(keyspace)
+// 阻塞命令，且会删掉并发包的桶（与 channel 侧同款做法）。
+func resetUserUIDRateLimit(t *testing.T, ctx *config.Context) {
+	t.Helper()
+	rds := redis.NewClient(&redis.Options{
+		Addr:     ctx.GetConfig().DB.RedisAddr,
+		Password: ctx.GetConfig().DB.RedisPass,
+	})
+	defer rds.Close()
+	_ = rds.Del("ratelimit:uid:" + testutil.UID).Err()
+}
 
 func newUserAuthzServer(t *testing.T) (*server.Server, *config.Context) {
 	t.Helper()
 	s, ctx := testutil.NewTestServer()
 	assert.NoError(t, testutil.CleanAllTables(ctx))
+	resetUserUIDRateLimit(t, ctx)
 	// 显式注册两个 group 侧 hook，并在用例结束后复原。
 	//
 	// 不能依赖模块 bootstrap 注册的全局值：同包的 pinned_test.go 会把
@@ -43,6 +62,18 @@ func newUserAuthzServer(t *testing.T) (*server.Server, *config.Context) {
 		var cnt int
 		_, err := ctx.DB().SelectBySql(
 			"SELECT 1 FROM group_member WHERE group_no=? AND uid=? AND is_deleted=0 LIMIT 1", groupNo, uid,
+		).Load(&cnt)
+		return cnt > 0, err
+	})
+	// ?group_no= 富化门禁用的是**活跃成员**口径（排该群黑名单），与 group.ExistMemberActive
+	// 一致。谓词本身由 modules/group 的单测钉在生产实现上；这里只需等价替身。
+	prevActive := getActiveGroupMemberChecker()
+	t.Cleanup(func() { RegisterActiveGroupMemberChecker(prevActive) })
+	RegisterActiveGroupMemberChecker(func(groupNo, uid string) (bool, error) {
+		var cnt int
+		_, err := ctx.DB().SelectBySql(
+			"SELECT 1 FROM group_member WHERE group_no=? AND uid=? AND is_deleted=0 AND status=1 LIMIT 1",
+			groupNo, uid,
 		).Load(&cnt)
 		return cnt > 0, err
 	})
@@ -229,12 +260,15 @@ func TestUserGet_NotExist_NotFound(t *testing.T) {
 	assert.NotContains(t, body, "err.server.user.query_failed", "不得再报查询失败")
 }
 
-// newMinimalUserDetailResp 是白名单构造：**序列化后**只有 uid/name/follow/robot 四个
-// 顶层字段。断言 key 集合而非逐字段取值——后者在给 DTO 新增第五个字段时仍会通过。
+// newMinimalUserDetailResp 是白名单构造：序列化后的字段集合固定为「渲染必需 + 调用方
+// 自身全部会话状态」，不含对方身份。断言 key 集合而非逐字段取值——后者在给 DTO 新增
+// 字段时仍会通过，而新增字段若属对方身份就是一次泄露。
 func TestNewMinimalUserDetailResp_WhitelistOnly(t *testing.T) {
 	full := &UserDetailResp{
 		// Follow 刻意给 1：最小集必须按授权决策输出 0，而不是复制这个展示字段。
 		UID: "u1", Name: "N", Follow: 1, Robot: 0, Status: 1,
+		Mute: 1, Top: 1, ChatPwdOn: 1, Screenshot: 1, RevokeRemind: 1, Receipt: 1,
+		Flame: 1, FlameSecond: 30, Remark: "my-remark",
 		ShortNo: "SN", Sex: 1, Online: 1, LastOffline: 123, Vercode: "vc",
 		SourceDesc: "src", RealName: "张三", RealnameVerified: true, Phone: "13000000000",
 	}
@@ -249,10 +283,16 @@ func TestNewMinimalUserDetailResp_WhitelistOnly(t *testing.T) {
 		keys = append(keys, k)
 	}
 	sort.Strings(keys)
-	assert.Equal(t, []string{"follow", "name", "robot", "status", "uid"}, keys,
-		"最小集只能有这五个顶层字段, got=%s", string(b))
+	assert.Equal(t, []string{
+		"chat_pwd_on", "flame", "flame_second", "follow", "mute", "name", "receipt",
+		"remark", "revoke_remind", "robot", "screenshot", "status", "top", "uid",
+	}, keys, "最小集字段集合已固定（调用方自身状态全留、对方身份全剥）, got=%s", string(b))
 	assert.Contains(t, string(b), "\"status\":1",
 		"status 必须原样透传：缺失会被客户端当成 0=已封禁并写回缓存")
+	assert.Contains(t, string(b), "\"chat_pwd_on\":1",
+		"聊天密码锁必须透传：缺失会让加锁会话直接打开且不提示")
+	assert.Contains(t, string(b), "\"mute\":1")
+	assert.Contains(t, string(b), "\"remark\":\"my-remark\"")
 	assert.Contains(t, string(b), "\"follow\":0", "入参 Follow=1 时输出仍须为 0, got=%s", string(b))
 	for _, leaked := range []string{"SN", "short_no", "sex", "online", "last_offline", "vercode", "source_desc", "real_name", "张三", "13000000000"} {
 		assert.NotContains(t, string(b), leaked)
@@ -396,4 +436,44 @@ func TestUserGet_DisbandedCommonSpace_Minimal(t *testing.T) {
 	assert.NotContains(t, w.Body.String(), "short_no", "已解散 Space 不应构成可达关系")
 	assert.Contains(t, w.Body.String(), "\"follow\":0", "body=%s", w.Body.String())
 	assert.NotContains(t, w.Body.String(), "\"follow\":1")
+}
+
+// 调用方**被该群拉黑**（group_member.status=Blacklist，is_deleted 仍为 0）时，
+// ?group_no= 富化必须被抑制：门禁用活跃成员口径，与子区门禁 / 共同群判定一致。
+// 否则被拉黑的人仍能凭该群号反查该群维度的成员元数据与 vercode。
+func TestUserGet_GroupNoEnrichment_CallerBlacklistedInGroup_Suppressed(t *testing.T) {
+	s, ctx := newUserAuthzServer(t)
+	defer testutil.CleanAllTables(ctx)
+
+	// 目标可见（同一正常 Space），但调用方在 ug_blkgate 群里被拉黑。
+	assert.NoError(t, NewService(ctx).AddUser(&AddUserReq{
+		UID: "ut_blkgate", Name: "BlkGateTarget", ShortNo: "SNBLKGATE",
+	}))
+	seedSpace(t, ctx, "sp_blkgate", 1)
+	seedSpaceMemberRow(t, ctx, "sp_blkgate", testutil.UID)
+	seedSpaceMemberRow(t, ctx, "sp_blkgate", "ut_blkgate")
+
+	_, err := ctx.DB().InsertBySql(
+		"INSERT INTO `group` (group_no, name, creator, status, version) VALUES ('ug_blkgate','blkgate','ut_blkgate',1,1)",
+	).Exec()
+	assert.NoError(t, err)
+	// 调用方成员行存在但 status=2（被拉黑）
+	_, err = ctx.DB().InsertBySql(
+		"INSERT INTO group_member (group_no, uid, role, status, version, vercode, is_deleted) VALUES ('ug_blkgate',?,0,2,1,'vc-blkgate-self',0)",
+		testutil.UID,
+	).Exec()
+	assert.NoError(t, err)
+	seedUserGroupMemberInvited(t, ctx, "ug_blkgate", "ut_blkgate", "ut_inviter2")
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/v1/users/ut_blkgate?group_no=ug_blkgate", nil)
+	req.Header.Set("token", testutil.Token)
+	s.GetRoute().ServeHTTP(w, req)
+	body := w.Body.String()
+
+	assert.Equal(t, http.StatusOK, w.Code, "body=%s", body)
+	assert.Contains(t, body, "BlkGateTarget", "目标本身可见，主响应不受影响")
+	assert.NotContains(t, body, "\"group_member\":{",
+		"被该群拉黑的调用方不得拿到群成员元数据, body=%s", body)
+	assert.NotContains(t, body, "vc-ug_blkgate", "不得泄露该群维度的 vercode")
 }

--- a/modules/user/user_get_authz_test.go
+++ b/modules/user/user_get_authz_test.go
@@ -126,7 +126,9 @@ func TestUserGet_NoRelation_MinimalKeepsFollow(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, w.Code, "body=%s", body)
 	assert.Contains(t, body, "StrangerU", "最小集仍需返回 name")
-	assert.Contains(t, body, "\"follow\"", "资料页需要 follow 渲染加好友入口, body=%s", body)
+	assert.Contains(t, body, "\"follow\":0",
+		"资料页需要 follow 渲染加好友入口，且走到最小集必然是 0（不能从展示字段复制）, body=%s", body)
+	assert.NotContains(t, body, "\"follow\":1", "最小集不得声称已关注")
 	// 身份细节必须剥离
 	for _, leaked := range []string{"SNSTRU", "short_no", "device_flag", "last_offline", "source_desc", "sex", "vercode"} {
 		assert.NotContains(t, body, leaked, "无关系不得下发 %s", leaked)
@@ -228,7 +230,8 @@ func TestUserGet_NotExist_NotFound(t *testing.T) {
 // 顶层字段。断言 key 集合而非逐字段取值——后者在给 DTO 新增第五个字段时仍会通过。
 func TestNewMinimalUserDetailResp_WhitelistOnly(t *testing.T) {
 	full := &UserDetailResp{
-		UID: "u1", Name: "N", Follow: 0, Robot: 0,
+		// Follow 刻意给 1：最小集必须按授权决策输出 0，而不是复制这个展示字段。
+		UID: "u1", Name: "N", Follow: 1, Robot: 0,
 		ShortNo: "SN", Sex: 1, Online: 1, LastOffline: 123, Vercode: "vc",
 		SourceDesc: "src", RealName: "张三", RealnameVerified: true, Phone: "13000000000",
 	}
@@ -245,6 +248,7 @@ func TestNewMinimalUserDetailResp_WhitelistOnly(t *testing.T) {
 	sort.Strings(keys)
 	assert.Equal(t, []string{"follow", "name", "robot", "uid"}, keys,
 		"最小集只能有这四个顶层字段, got=%s", string(b))
+	assert.Contains(t, string(b), "\"follow\":0", "入参 Follow=1 时输出仍须为 0, got=%s", string(b))
 	for _, leaked := range []string{"SN", "short_no", "sex", "online", "last_offline", "vercode", "source_desc", "real_name", "张三", "13000000000"} {
 		assert.NotContains(t, string(b), leaked)
 	}
@@ -261,11 +265,12 @@ func TestUserGet_GroupNoEnrichment_CallerNotMember_Suppressed(t *testing.T) {
 	assert.NoError(t, NewService(ctx).AddUser(&AddUserReq{
 		UID: "ut_target", Name: "TargetU", ShortNo: "SNTGT",
 	}))
+	// 必须建 space 父行：授权判定 JOIN space 校验活性，只插 space_member 会让目标
+	// 判为不可见 → 请求直接走最小集、到不了群维度富化块，本用例的负向断言就恒成立
+	// （空断言）。这里踩过一次，见 PR #722 review。
+	seedSpace(t, ctx, "sp_x", 1)
 	for _, uid := range []string{testutil.UID, "ut_target"} {
-		_, err := ctx.DB().InsertBySql(
-			"INSERT INTO space_member (space_id, uid, role, status, version) VALUES ('sp_x',?,0,1,1)", uid,
-		).Exec()
-		assert.NoError(t, err)
+		seedSpaceMemberRow(t, ctx, "sp_x", uid)
 	}
 	_, err := ctx.DB().InsertBySql(
 		"INSERT INTO `group` (group_no, name, creator, status, version) VALUES ('ug_outsider','outsider-grp','ut_target',1,1)",
@@ -311,7 +316,13 @@ func TestUserGet_GroupNoEnrichment_CallerIsMember_Works(t *testing.T) {
 }
 
 // 被该群拉黑（status=Blacklist，is_deleted 仍为 0）后，该群不再构成"有共同群"关系
-// → 降级为最小集。与子区门禁 ExistMemberActive 口径一致。
+// → 降级为最小集。
+//
+// 注意本用例的**有效范围**：newUserAuthzServer 为消除全局状态污染注册了自写的 checker
+// 替身（modules/user 不能 import modules/group），所以这里验证的是「checker 判否时
+// handler 正确降级」这条接线，**不是** ExistCommonGroup 谓词本身。谓词语义（黑名单 /
+// 已解散 / 禁用群仍算 / 已退群）由 modules/group/db_common_group_test.go 直接钉在生产
+// 实现上，并逐条做过变异验证——曾经在这里误以为覆盖了谓词，见 PR #722 review。
 func TestUserGet_CommonGroupButBlacklisted_Minimal(t *testing.T) {
 	s, ctx := newUserAuthzServer(t)
 	defer testutil.CleanAllTables(ctx)
@@ -356,6 +367,9 @@ func TestUserGet_BannedCommonSpace_Minimal(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, w.Code, "body=%s", body)
 	assert.Contains(t, body, "BannedSpacePeer", "名字仍可渲染")
+	assert.Contains(t, body, "\"follow\":0", "授权判定认定无关系，最小集必须回 follow:0, body=%s", body)
+	assert.NotContains(t, body, "\"follow\":1",
+		"不得复制展示字段：封禁 Space 会让 full.Follow 仍为 1，照抄即泄露该共属事实")
 	assert.NotContains(t, body, "short_no", "封禁 Space 不应再构成可达关系, body=%s", body)
 	assert.NotContains(t, body, "SNBANNED")
 }
@@ -375,4 +389,6 @@ func TestUserGet_DisbandedCommonSpace_Minimal(t *testing.T) {
 	w := getUser(s, "ut_dis")
 	assert.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
 	assert.NotContains(t, w.Body.String(), "short_no", "已解散 Space 不应构成可达关系")
+	assert.Contains(t, w.Body.String(), "\"follow\":0", "body=%s", w.Body.String())
+	assert.NotContains(t, w.Body.String(), "\"follow\":1")
 }

--- a/modules/user/user_get_authz_test.go
+++ b/modules/user/user_get_authz_test.go
@@ -1,0 +1,176 @@
+package user
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/server"
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
+	"github.com/stretchr/testify/assert"
+)
+
+// user_get_authz_test.go —— GET /v1/users/:uid 的对象级授权矩阵。
+//
+// 该端点与 /v1/channels/:id/:type 同根因：都只有登录鉴权、共用 GetUserDetail，任意
+// 登录用户拿任意 UID 就能读到完整身份（短号 / 性别 / 在线状态 / 设备指纹 / 实名）。
+// 可见性判定收口在 modules/channel/service，两端共用，故这里主要钉本端点特有的部分：
+// 最小集**保留 follow**（资料页要靠它渲染加好友入口），以及不存在目标的响应码。
+
+func newUserAuthzServer(t *testing.T) (*server.Server, *config.Context) {
+	t.Helper()
+	s, ctx := testutil.NewTestServer()
+	assert.NoError(t, testutil.CleanAllTables(ctx))
+	// 不注入 renderer 拿不到 error.code
+	s.GetRoute().SetErrorRenderer(i18n.NewErrorRenderer(i18n.NewLocalizer(i18n.DefaultLanguage)))
+	assert.NoError(t, NewService(ctx).AddUser(&AddUserReq{UID: testutil.UID, Name: "login-user", ShortNo: "SNLOGINU"}))
+	return s, ctx
+}
+
+func getUser(s *server.Server, uid string) *httptest.ResponseRecorder {
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/v1/users/"+uid, nil)
+	req.Header.Set("token", testutil.Token)
+	s.GetRoute().ServeHTTP(w, req)
+	return w
+}
+
+func seedUserGroupMember(t *testing.T, ctx *config.Context, groupNo, uid string) {
+	t.Helper()
+	_, err := ctx.DB().InsertBySql(
+		"INSERT INTO group_member (group_no, uid, role, status, version, vercode, is_deleted) VALUES (?,?,0,1,1,?,0)",
+		groupNo, uid, fmt.Sprintf("vc-%s-%s", groupNo, uid),
+	).Exec()
+	assert.NoError(t, err)
+}
+
+// 无关系：降级为最小集——剥掉身份细节，但**保留 follow**（加好友入口靠它）。
+func TestUserGet_NoRelation_MinimalKeepsFollow(t *testing.T) {
+	s, ctx := newUserAuthzServer(t)
+	defer testutil.CleanAllTables(ctx)
+
+	assert.NoError(t, NewService(ctx).AddUser(&AddUserReq{
+		UID: "ut_stranger", Name: "StrangerU", ShortNo: "SNSTRU",
+	}))
+
+	w := getUser(s, "ut_stranger")
+	body := w.Body.String()
+
+	assert.Equal(t, http.StatusOK, w.Code, "body=%s", body)
+	assert.Contains(t, body, "StrangerU", "最小集仍需返回 name")
+	assert.Contains(t, body, "\"follow\"", "资料页需要 follow 渲染加好友入口, body=%s", body)
+	// 身份细节必须剥离
+	for _, leaked := range []string{"SNSTRU", "short_no", "device_flag", "last_offline", "source_desc", "sex", "vercode"} {
+		assert.NotContains(t, body, leaked, "无关系不得下发 %s", leaked)
+	}
+}
+
+// 同 Space（无好友关系，可直接聊天）：完整资料。
+func TestUserGet_SameSpace_Full(t *testing.T) {
+	s, ctx := newUserAuthzServer(t)
+	defer testutil.CleanAllTables(ctx)
+
+	assert.NoError(t, NewService(ctx).AddUser(&AddUserReq{
+		UID: "ut_same", Name: "SameSpaceU", ShortNo: "SNSAMEU",
+	}))
+	for _, uid := range []string{testutil.UID, "ut_same"} {
+		_, err := ctx.DB().InsertBySql(
+			"INSERT INTO space_member (space_id, uid, role, status, version) VALUES ('sp_a',?,0,1,1)", uid,
+		).Exec()
+		assert.NoError(t, err)
+	}
+
+	w := getUser(s, "ut_same")
+	assert.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+	assert.Contains(t, w.Body.String(), "short_no", "同 Space 可直接聊天，资料应完整")
+}
+
+// 仅共同群（跨 Space、非好友）：完整资料。走的是 group 模块注册进来的共同群 checker。
+func TestUserGet_CommonGroupOnly_Full(t *testing.T) {
+	s, ctx := newUserAuthzServer(t)
+	defer testutil.CleanAllTables(ctx)
+
+	assert.NoError(t, NewService(ctx).AddUser(&AddUserReq{
+		UID: "ut_cofellow", Name: "CoGroupU", ShortNo: "SNCOU",
+	}))
+	_, err := ctx.DB().InsertBySql(
+		"INSERT INTO `group` (group_no, name, creator, status, version) VALUES ('ug_common','co',?,1,1)", testutil.UID,
+	).Exec()
+	assert.NoError(t, err)
+	seedUserGroupMember(t, ctx, "ug_common", testutil.UID)
+	seedUserGroupMember(t, ctx, "ug_common", "ut_cofellow")
+
+	w := getUser(s, "ut_cofellow")
+	assert.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+	assert.Contains(t, w.Body.String(), "short_no", "共同群可达应返回完整资料")
+}
+
+// bot：无需任何关系即可查看完整资料（用户要先看到 bot 才能决定是否添加）。
+func TestUserGet_Bot_Viewable(t *testing.T) {
+	s, ctx := newUserAuthzServer(t)
+	defer testutil.CleanAllTables(ctx)
+
+	assert.NoError(t, NewService(ctx).AddUser(&AddUserReq{
+		UID: "ut_bot", Name: "SomeBotU", ShortNo: "SNBOTU", Robot: 1,
+	}))
+
+	w := getUser(s, "ut_bot")
+	assert.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+	assert.Contains(t, w.Body.String(), "short_no", "bot 资料应完整可查")
+}
+
+// 系统账号：同上。
+func TestUserGet_SystemAccount_Viewable(t *testing.T) {
+	s, ctx := newUserAuthzServer(t)
+	defer testutil.CleanAllTables(ctx)
+
+	assert.NoError(t, NewService(ctx).AddUser(&AddUserReq{
+		UID: "ut_sys", Name: "SystemU", ShortNo: "SNSYSU",
+	}))
+	_, err := ctx.DB().UpdateBySql("UPDATE `user` SET category=? WHERE uid=?", CategorySystem, "ut_sys").Exec()
+	assert.NoError(t, err)
+
+	w := getUser(s, "ut_sys")
+	assert.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+	assert.Contains(t, w.Body.String(), "short_no", "系统账号资料应完整可查")
+}
+
+// 本人：完整资料（含仅自己可见的手机号字段路径）。
+func TestUserGet_Self_Full(t *testing.T) {
+	s, ctx := newUserAuthzServer(t)
+	defer testutil.CleanAllTables(ctx)
+
+	w := getUser(s, testutil.UID)
+	assert.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+	assert.Contains(t, w.Body.String(), "SNLOGINU", "本人应看到自己的短号")
+}
+
+// 不存在的用户：走 not_found，而不是此前的"查询失败"（后者会误导客户端重试）。
+func TestUserGet_NotExist_NotFound(t *testing.T) {
+	s, ctx := newUserAuthzServer(t)
+	defer testutil.CleanAllTables(ctx)
+
+	w := getUser(s, "ut_no_such_user")
+	body := w.Body.String()
+
+	assert.NotEqual(t, http.StatusInternalServerError, w.Code, "body=%s", body)
+	assert.Contains(t, body, "err.server.user.not_found", "不存在用户应走 not_found, body=%s", body)
+	assert.NotContains(t, body, "err.server.user.query_failed", "不得再报查询失败")
+}
+
+// newMinimalUserDetailResp 是白名单构造：只有 uid/name/follow/robot 四个字段。
+func TestNewMinimalUserDetailResp_WhitelistOnly(t *testing.T) {
+	full := &UserDetailResp{
+		UID: "u1", Name: "N", Follow: 0, Robot: 0,
+		ShortNo: "SN", Sex: 1, Online: 1, LastOffline: 123, Vercode: "vc",
+		SourceDesc: "src", RealName: "张三", RealnameVerified: true, Phone: "13000000000",
+	}
+	m := newMinimalUserDetailResp(full)
+	assert.Equal(t, "u1", m.UID)
+	assert.Equal(t, "N", m.Name)
+	assert.Equal(t, 0, m.Follow)
+	assert.Equal(t, 0, m.Robot)
+}

--- a/modules/user/user_get_authz_test.go
+++ b/modules/user/user_get_authz_test.go
@@ -1,9 +1,11 @@
 package user
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"sort"
 	"testing"
 
 	"github.com/Mininglamp-OSS/octo-lib/config"
@@ -24,6 +26,37 @@ func newUserAuthzServer(t *testing.T) (*server.Server, *config.Context) {
 	t.Helper()
 	s, ctx := testutil.NewTestServer()
 	assert.NoError(t, testutil.CleanAllTables(ctx))
+	// 显式注册两个 group 侧 hook，并在用例结束后复原。
+	//
+	// 不能依赖模块 bootstrap 注册的全局值：同包的 pinned_test.go 会把
+	// groupMemberChecker 置为 nil，整包跑时会污染这些用例（单独跑通过、整包跑失败）。
+	// 这里直连 group 的 db 语义显然不可能（modules/user 不能 import modules/group，
+	// 反向依赖），所以用等价的最小实现——判定口径与 group.ExistMember /
+	// ExistCommonGroup 一致：group_member 行未删且（共同群还要求）双方 status 正常、
+	// 群未解散。
+	prevMember, prevCommon := getGroupMemberChecker(), getCommonGroupChecker()
+	t.Cleanup(func() {
+		setGroupMemberChecker(prevMember)
+		RegisterCommonGroupChecker(prevCommon)
+	})
+	setGroupMemberChecker(func(groupNo, uid string) (bool, error) {
+		var cnt int
+		_, err := ctx.DB().SelectBySql(
+			"SELECT 1 FROM group_member WHERE group_no=? AND uid=? AND is_deleted=0 LIMIT 1", groupNo, uid,
+		).Load(&cnt)
+		return cnt > 0, err
+	})
+	RegisterCommonGroupChecker(func(a, b string) (bool, error) {
+		var cnt int
+		_, err := ctx.DB().SelectBySql(
+			"SELECT 1 FROM group_member m1 "+
+				"INNER JOIN group_member m2 ON m1.group_no=m2.group_no "+
+				"INNER JOIN `group` g ON g.group_no=m1.group_no "+
+				"WHERE m1.uid=? AND m2.uid=? AND m1.is_deleted=0 AND m2.is_deleted=0 "+
+				"AND m1.status=1 AND m2.status=1 AND g.status<>2 LIMIT 1", a, b,
+		).Load(&cnt)
+		return cnt > 0, err
+	})
 	// 不注入 renderer 拿不到 error.code
 	s.GetRoute().SetErrorRenderer(i18n.NewErrorRenderer(i18n.NewLocalizer(i18n.DefaultLanguage)))
 	assert.NoError(t, NewService(ctx).AddUser(&AddUserReq{UID: testutil.UID, Name: "login-user", ShortNo: "SNLOGINU"}))
@@ -36,6 +69,18 @@ func getUser(s *server.Server, uid string) *httptest.ResponseRecorder {
 	req.Header.Set("token", testutil.Token)
 	s.GetRoute().ServeHTTP(w, req)
 	return w
+}
+
+// seedUserGroupMemberInvited 带 invite_uid 建成员行。u.get 只有在成员行 InviteUID
+// 非空时才把 group_member 塞进响应，所以验证"群维度富化是否被抑制"必须用这个 seeder
+// ——否则负向断言恒成立（空断言），证明不了门禁起作用。
+func seedUserGroupMemberInvited(t *testing.T, ctx *config.Context, groupNo, uid, inviteUID string) {
+	t.Helper()
+	_, err := ctx.DB().InsertBySql(
+		"INSERT INTO group_member (group_no, uid, role, status, version, vercode, is_deleted, invite_uid) VALUES (?,?,0,1,1,?,0,?)",
+		groupNo, uid, fmt.Sprintf("vc-%s-%s", groupNo, uid), inviteUID,
+	).Exec()
+	assert.NoError(t, err)
 }
 
 func seedUserGroupMember(t *testing.T, ctx *config.Context, groupNo, uid string) {
@@ -161,16 +206,116 @@ func TestUserGet_NotExist_NotFound(t *testing.T) {
 	assert.NotContains(t, body, "err.server.user.query_failed", "不得再报查询失败")
 }
 
-// newMinimalUserDetailResp 是白名单构造：只有 uid/name/follow/robot 四个字段。
+// newMinimalUserDetailResp 是白名单构造：**序列化后**只有 uid/name/follow/robot 四个
+// 顶层字段。断言 key 集合而非逐字段取值——后者在给 DTO 新增第五个字段时仍会通过。
 func TestNewMinimalUserDetailResp_WhitelistOnly(t *testing.T) {
 	full := &UserDetailResp{
 		UID: "u1", Name: "N", Follow: 0, Robot: 0,
 		ShortNo: "SN", Sex: 1, Online: 1, LastOffline: 123, Vercode: "vc",
 		SourceDesc: "src", RealName: "张三", RealnameVerified: true, Phone: "13000000000",
 	}
-	m := newMinimalUserDetailResp(full)
-	assert.Equal(t, "u1", m.UID)
-	assert.Equal(t, "N", m.Name)
-	assert.Equal(t, 0, m.Follow)
-	assert.Equal(t, 0, m.Robot)
+
+	b, err := json.Marshal(newMinimalUserDetailResp(full))
+	assert.NoError(t, err)
+
+	var m map[string]json.RawMessage
+	assert.NoError(t, json.Unmarshal(b, &m))
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	assert.Equal(t, []string{"follow", "name", "robot", "uid"}, keys,
+		"最小集只能有这四个顶层字段, got=%s", string(b))
+	for _, leaked := range []string{"SN", "short_no", "sex", "online", "last_offline", "vercode", "source_desc", "real_name", "张三", "13000000000"} {
+		assert.NotContains(t, string(b), leaked)
+	}
+}
+
+// group_no 是调用方传入的：调用方**不在**该群时，群维度富化必须整体不下发
+// （group_member / 外部来源 Space 字段 / 该群的 vercode）。否则任何能看到目标的人
+// 都能拿一个自己不在的群号反查该群维度元数据。
+func TestUserGet_GroupNoEnrichment_CallerNotMember_Suppressed(t *testing.T) {
+	s, ctx := newUserAuthzServer(t)
+	defer testutil.CleanAllTables(ctx)
+
+	// 目标可见（同 Space），但调用方不在 ug_outsider 群里。
+	assert.NoError(t, NewService(ctx).AddUser(&AddUserReq{
+		UID: "ut_target", Name: "TargetU", ShortNo: "SNTGT",
+	}))
+	for _, uid := range []string{testutil.UID, "ut_target"} {
+		_, err := ctx.DB().InsertBySql(
+			"INSERT INTO space_member (space_id, uid, role, status, version) VALUES ('sp_x',?,0,1,1)", uid,
+		).Exec()
+		assert.NoError(t, err)
+	}
+	_, err := ctx.DB().InsertBySql(
+		"INSERT INTO `group` (group_no, name, creator, status, version) VALUES ('ug_outsider','outsider-grp','ut_target',1,1)",
+	).Exec()
+	assert.NoError(t, err)
+	seedUserGroupMemberInvited(t, ctx, "ug_outsider", "ut_target", "ut_inviter") // 只有目标在群里
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/v1/users/ut_target?group_no=ug_outsider", nil)
+	req.Header.Set("token", testutil.Token)
+	s.GetRoute().ServeHTTP(w, req)
+	body := w.Body.String()
+
+	assert.Equal(t, http.StatusOK, w.Code, "body=%s", body)
+	assert.Contains(t, body, "TargetU", "目标本身可见，主响应不受影响")
+	assert.NotContains(t, body, "\"group_member\":{", "调用方非群成员不得拿到群成员元数据, body=%s", body)
+	assert.NotContains(t, body, "vc-ug_outsider", "不得泄露该群维度的 vercode")
+}
+
+// 调用方确实在该群时，群维度富化正常工作（确保上面的门禁不是把功能整体关掉）。
+func TestUserGet_GroupNoEnrichment_CallerIsMember_Works(t *testing.T) {
+	s, ctx := newUserAuthzServer(t)
+	defer testutil.CleanAllTables(ctx)
+
+	assert.NoError(t, NewService(ctx).AddUser(&AddUserReq{
+		UID: "ut_mate", Name: "MateU", ShortNo: "SNMATE",
+	}))
+	_, err := ctx.DB().InsertBySql(
+		"INSERT INTO `group` (group_no, name, creator, status, version) VALUES ('ug_shared','shared-grp',?,1,1)", testutil.UID,
+	).Exec()
+	assert.NoError(t, err)
+	seedUserGroupMember(t, ctx, "ug_shared", testutil.UID)
+	seedUserGroupMemberInvited(t, ctx, "ug_shared", "ut_mate", testutil.UID)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/v1/users/ut_mate?group_no=ug_shared", nil)
+	req.Header.Set("token", testutil.Token)
+	s.GetRoute().ServeHTTP(w, req)
+	body := w.Body.String()
+
+	assert.Equal(t, http.StatusOK, w.Code, "body=%s", body)
+	assert.Contains(t, body, "group_member", "同群调用方应能拿到群成员信息, body=%s", body)
+}
+
+// 被该群拉黑（status=Blacklist，is_deleted 仍为 0）后，该群不再构成"有共同群"关系
+// → 降级为最小集。与子区门禁 ExistMemberActive 口径一致。
+func TestUserGet_CommonGroupButBlacklisted_Minimal(t *testing.T) {
+	s, ctx := newUserAuthzServer(t)
+	defer testutil.CleanAllTables(ctx)
+
+	assert.NoError(t, NewService(ctx).AddUser(&AddUserReq{
+		UID: "ut_blk", Name: "BlacklistedPeer", ShortNo: "SNBLK",
+	}))
+	_, err := ctx.DB().InsertBySql(
+		"INSERT INTO `group` (group_no, name, creator, status, version) VALUES ('ug_blk','blk-grp','ut_blk',1,1)",
+	).Exec()
+	assert.NoError(t, err)
+	// 调用方在群里但被拉黑（status=2），目标正常。
+	_, err = ctx.DB().InsertBySql(
+		"INSERT INTO group_member (group_no, uid, role, status, version, vercode, is_deleted) VALUES ('ug_blk',?,0,2,1,'vc-blk-self',0)", testutil.UID,
+	).Exec()
+	assert.NoError(t, err)
+	seedUserGroupMember(t, ctx, "ug_blk", "ut_blk")
+
+	w := getUser(s, "ut_blk")
+	body := w.Body.String()
+
+	assert.Equal(t, http.StatusOK, w.Code, "body=%s", body)
+	assert.Contains(t, body, "BlacklistedPeer", "名字仍可渲染，不裂图")
+	assert.NotContains(t, body, "short_no", "被该群拉黑后不应再凭该群拿到完整资料, body=%s", body)
 }

--- a/modules/user/user_profile_minimal.go
+++ b/modules/user/user_profile_minimal.go
@@ -1,0 +1,40 @@
+package user
+
+// user_profile_minimal.go —— `GET /v1/users/:uid` 在**无可见关系**时的最小资料契约。
+//
+// 该端点历史上只有登录鉴权：任意登录用户拿任意 UID 就能读到完整身份（短号、性别、
+// 在线状态、设备指纹、来源描述、实名等），既是任意资料读取也是用户存在性枚举面。
+// 可见关系判定与 `/v1/channels/:id/:type` 共用 modules/channel/service。
+//
+// 与 channelGet 最小集的**刻意差异**：这里保留 `follow`。
+//   - channelGet 用于渲染任意消息发送者，不是关系页，给 follow:0 会被读成"明确非好友"；
+//   - 本端点是资料页，客户端要靠 follow==0 渲染「加好友」入口，省略它会让陌生人
+//     加好友这个正常入口消失。
+//
+// 加好友流程不依赖本响应的其它字段：vercode 由 search / 扫码路径铸造并校验
+// （见 modules/user/api_friend.go 的 source.CheckRequestAddFriendCode），且本端点对
+// 非好友本来就返回空 vercode。
+type minimalUserDetailResp struct {
+	UID  string `json:"uid"`
+	Name string `json:"name"`
+	// Follow 0=未关注（陌生人）1=已关注。见文件头：资料页据此渲染加好友入口。
+	Follow int `json:"follow"`
+	// Robot 供客户端区分 bot 与真人的渲染分支。注意 bot 恒可见完整资料，故走到最小集
+	// 时它必为 0；保留该字段只为让契约形状稳定，客户端无需按分支解析。
+	Robot int `json:"robot"`
+}
+
+// newMinimalUserDetailResp 白名单式构造最小资料集：剥离 short_no / sex / online /
+// last_offline / device_flag / source_desc / vercode / remark / 实名 等全部身份与关系
+// 细节。手机号 / 邮箱 / 区号本就只对本人下发（见 NewUserDetailResp 的 self 判定），
+// 不在此重复。
+//
+// 白名单而非黑名单——将来给 UserDetailResp 新增字段时默认不泄露。
+func newMinimalUserDetailResp(full *UserDetailResp) minimalUserDetailResp {
+	return minimalUserDetailResp{
+		UID:    full.UID,
+		Name:   full.Name,
+		Follow: full.Follow,
+		Robot:  full.Robot,
+	}
+}

--- a/modules/user/user_profile_minimal.go
+++ b/modules/user/user_profile_minimal.go
@@ -32,9 +32,15 @@ type minimalUserDetailResp struct {
 // 白名单而非黑名单——将来给 UserDetailResp 新增字段时默认不泄露。
 func newMinimalUserDetailResp(full *UserDetailResp) minimalUserDetailResp {
 	return minimalUserDetailResp{
-		UID:    full.UID,
-		Name:   full.Name,
-		Follow: full.Follow,
+		UID:  full.UID,
+		Name: full.Name,
+		// Follow 恒为 0，**不能**从 full.Follow 复制。走到最小集意味着授权判定已认定
+		// 无可达关系（非好友、无**活跃**共同 Space、无共同有效群）；而 full.Follow 是
+		// 展示字段，它的同 Space 来源（GetCommonSpaceID）不校验 Space 活性，封禁 / 解散
+		// Space 会让它仍为 1。照抄会让响应自相矛盾——一边剥掉身份字段说"无关系"，一边
+		// 告诉客户端"已关注"，并且恰好泄露了本要隐去的那条"你们同属某个（已封禁）
+		// Space"的事实。这正是本次要消除的展示/授权混淆。
+		Follow: 0,
 		Robot:  full.Robot,
 	}
 }

--- a/modules/user/user_profile_minimal.go
+++ b/modules/user/user_profile_minimal.go
@@ -17,36 +17,52 @@ package user
 type minimalUserDetailResp struct {
 	UID  string `json:"uid"`
 	Name string `json:"name"`
-	// Follow 0=未关注（陌生人）1=已关注。见文件头：资料页据此渲染加好友入口。
+	// Follow 0=未关注（陌生人）。走到最小集意味着授权判定已认定无可达关系，故恒为 0，
+	// **不能**从 full.Follow 复制（那是展示字段，其同 Space 来源不校验 Space 活性）。
+	// 资料页据此渲染加好友入口。
 	Follow int `json:"follow"`
-	// Robot 供客户端区分 bot 与真人的渲染分支。注意 bot 恒可见完整资料，故走到最小集
-	// 时它必为 0；保留该字段只为让契约形状稳定，客户端无需按分支解析。
+	// Robot 供客户端区分 bot 与真人的渲染分支。
 	Robot int `json:"robot"`
-	// Status **必须下发**（与省略 follow 的方向相反）：三端都把缺失时的零值 0 当作
-	// "已禁用/封禁"哨兵并写回本地缓存（Android 会隐藏输入框），所以对 status 而言
-	// 省略比给值更危险。它在本响应里是**调用方自己**是否拉黑对方（1=未拉黑 /
-	// 2=已拉黑），是调用方自身状态、永不为 0，下发不削弱隐私收窄。
-	Status int `json:"status"`
+
+	// ── 以下全部是**调用方自己**的状态，必须原样透传 ──
+	// 规则见 chservice.MinimalChannelResp 的文档：客户端整行写回缓存且不做字段存在性
+	// 检查，省略"调用方自己的设置"买不到任何隐私，只会把用户自己开启的功能悄悄关掉。
+	Status       int    `json:"status"`        // 调用方是否拉黑对方（1/2，永不为 0）
+	Mute         int    `json:"mute"`          // 免打扰
+	Top          int    `json:"top"`           // 置顶
+	ChatPwdOn    int    `json:"chat_pwd_on"`   // 聊天密码锁——缺失会让锁静默失效
+	Screenshot   int    `json:"screenshot"`    // 截屏通知
+	RevokeRemind int    `json:"revoke_remind"` // 撤回提醒
+	Receipt      int    `json:"receipt"`       // 消息回执
+	Flame        int    `json:"flame"`         // 阅后即焚
+	FlameSecond  int    `json:"flame_second"`  // 阅后即焚秒数
+	Remark       string `json:"remark"`        // 调用方给对方设置的备注
 }
 
-// newMinimalUserDetailResp 白名单式构造最小资料集：剥离 short_no / sex / online /
-// last_offline / device_flag / source_desc / vercode / remark / 实名 等全部身份与关系
-// 细节。手机号 / 邮箱 / 区号本就只对本人下发（见 NewUserDetailResp 的 self 判定），
-// 不在此重复。
+// newMinimalUserDetailResp 按「调用方自身状态全留、对方身份全剥」构造最小资料集。
 //
-// 白名单而非黑名单——将来给 UserDetailResp 新增字段时默认不泄露。
+// 剥掉的是对方身份/在线态：username / short_no / sex / category / source_desc /
+// vercode / online / last_offline / device_flag / 实名字段 / bot_* / be_deleted /
+// be_blacklist（后两者是**对方**对调用方的动作，属对方信息）。
+// 手机号 / 邮箱 / 区号本就只对本人下发（见 NewUserDetailResp 的 self 判定）。
+//
+// 白名单而非黑名单——将来给 UserDetailResp 新增字段时默认不泄露；新增的若属"调用方
+// 自己的状态"，须显式加进来，否则客户端写回时会把它清零。
 func newMinimalUserDetailResp(full *UserDetailResp) minimalUserDetailResp {
 	return minimalUserDetailResp{
-		UID:  full.UID,
-		Name: full.Name,
-		// Follow 恒为 0，**不能**从 full.Follow 复制。走到最小集意味着授权判定已认定
-		// 无可达关系（非好友、无**活跃**共同 Space、无共同有效群）；而 full.Follow 是
-		// 展示字段，它的同 Space 来源（GetCommonSpaceID）不校验 Space 活性，封禁 / 解散
-		// Space 会让它仍为 1。照抄会让响应自相矛盾——一边剥掉身份字段说"无关系"，一边
-		// 告诉客户端"已关注"，并且恰好泄露了本要隐去的那条"你们同属某个（已封禁）
-		// Space"的事实。这正是本次要消除的展示/授权混淆。
-		Follow: 0,
-		Robot:  full.Robot,
-		Status: full.Status,
+		UID:          full.UID,
+		Name:         full.Name,
+		Follow:       0,
+		Robot:        full.Robot,
+		Status:       full.Status,
+		Mute:         full.Mute,
+		Top:          full.Top,
+		ChatPwdOn:    full.ChatPwdOn,
+		Screenshot:   full.Screenshot,
+		RevokeRemind: full.RevokeRemind,
+		Receipt:      full.Receipt,
+		Flame:        full.Flame,
+		FlameSecond:  full.FlameSecond,
+		Remark:       full.Remark,
 	}
 }

--- a/modules/user/user_profile_minimal.go
+++ b/modules/user/user_profile_minimal.go
@@ -22,6 +22,11 @@ type minimalUserDetailResp struct {
 	// Robot 供客户端区分 bot 与真人的渲染分支。注意 bot 恒可见完整资料，故走到最小集
 	// 时它必为 0；保留该字段只为让契约形状稳定，客户端无需按分支解析。
 	Robot int `json:"robot"`
+	// Status **必须下发**（与省略 follow 的方向相反）：三端都把缺失时的零值 0 当作
+	// "已禁用/封禁"哨兵并写回本地缓存（Android 会隐藏输入框），所以对 status 而言
+	// 省略比给值更危险。它在本响应里是**调用方自己**是否拉黑对方（1=未拉黑 /
+	// 2=已拉黑），是调用方自身状态、永不为 0，下发不削弱隐私收窄。
+	Status int `json:"status"`
 }
 
 // newMinimalUserDetailResp 白名单式构造最小资料集：剥离 short_no / sex / online /
@@ -42,5 +47,6 @@ func newMinimalUserDetailResp(full *UserDetailResp) minimalUserDetailResp {
 		// Space"的事实。这正是本次要消除的展示/授权混淆。
 		Follow: 0,
 		Robot:  full.Robot,
+		Status: full.Status,
 	}
 }


### PR DESCRIPTION
## Summary

`GET /v1/channels/:channel_id/:channel_type` (`channelGet`) performed **no
object-level authorization**. `loginUID` was passed to the display datasource
purely as a render parameter and was never used as an authorization subject, so
any authenticated caller could swap `channel_id` and read channel/user detail
they have no relationship with.

`GET /v1/users/:uid` (`u.get`) is the same root cause reached through a second
door — same login-only gate, same `GetUserDetail` call with no relationship
check — and is fixed in the same PR rather than left open. The decision is shared
between them, so they cannot drift apart.

Authorization lives in the handlers; the `BussDataSource.ChannelGet` chain stays
a pure display layer.

## Related Issue

None filed upstream; captured as an octospec task.

## Linked Spec

`.octospec/tasks/channel-get-object-authz/brief.md`

## Changes

- **Shared decision** — `modules/channel/service` (a dependency-free leaf package
  that `modules/user` already imports) owns `PersonProfileVisible` and the
  minimal channel DTO. `modules/user` cannot import `modules/group` (group
  imports user), so the common-group lookup arrives via
  `RegisterCommonGroupChecker`, mirroring the existing
  `RegisterGroupMemberChecker`; an unregistered hook fails closed.
- **`GET /v1/users/:uid`** — relationship-graded the same way. Unrelated callers
  get a minimal whitelist DTO; a missing user now reaches the localized
  not-found instead of a query-failure code. Its minimal set deliberately
  **keeps** `follow` (a stranger's profile needs `follow == 0` to render the
  add-friend entry) where the channel endpoint omits it. The add-friend flow does
  not depend on any other field of this response: `vercode` is minted and
  verified through the search / QR path, and this endpoint already returned an
  empty `vercode` for non-friends.

- **GROUP / COMMUNITY_TOPIC** — require (parent) group membership. GROUP checks
  `ExistMember` before dispatch; COMMUNITY_TOPIC resolves the parent via the
  display payload's `extra.group_no` and checks `ExistMemberActive`. Non-member
  and missing group both map to a single `ErrGroupViewForbidden`, so the
  response does not reveal whether the group exists. This matches the gating
  `GET /v1/groups/:group_no` already had over the same `GetGroupDetail`.
- **PERSON** — relationship-graded rather than a binary reject. self / friend /
  same-Space / common group / bot / system account / webhook identity get the
  existing full detail; unrelated callers get a minimal whitelist DTO
  (`channel` / `name` / `logo` / `robot`) instead of `short_no`, device flags,
  last-offline and realname fields. A hard 403 is not viable here: this endpoint
  is the sole data source for rendering arbitrary message senders, so rejecting
  would break name/avatar rendering for external-group members from other
  Spaces.
- `group.ExistCommonGroup` joins `` `group` `` and excludes **dissolved** groups
  (`status <> GroupStatusDisband`) — dissolution only flips the status and cleans
  members asynchronously, so a membership-only query would treat a disbanded
  group as a live relationship. Admin-**disabled** groups stay live, matching
  every other liveness check in the module. Shaped as `SELECT 1 ... LIMIT 1`
  since it answers a boolean on a hot path.
- Fixed a nil dereference in the group datasource: a missing group reached
  `newChannelRespWithGroupResp(nil)` and returned a 500 with an empty body,
  which was itself an existence oracle.
- `GetUserDetail` now returns the pre-existing `ErrorUserNotExist` sentinel and
  the user datasource translates it to `ErrDatasourceNotProcess`, so a missing
  user reaches the unified localized not-found instead of a raw error response.
- All new rejection paths go through the `httperr` envelope with already
  registered `pkg/errcode` codes (no new codes, no new translations needed).
- Mounted `SharedUIDRateLimiter` on the route (after `AuthMiddleware`), per the
  repo's authenticated-route convention.

## Testing

Neither endpoint had any authorization coverage. Added:

- `modules/channel/channel_get_authz_test.go` — group non-member / member /
  missing / left-the-group; person no-relation minimal / same-Space full /
  common-group-only full / common-group-**disbanded** minimal / bot / system
  account / not-found; cross-Space with the `X-Space-Id` header absent, correct,
  wrong and forged (all identical, pinning that the header is not an
  authorization input); plus a JSON-key-level assertion on the minimal DTO.
- `modules/channel/channel_get_topic_authz_test.go` — the COMMUNITY_TOPIC branch
  at route level: parent-group member / non-member / left-parent / missing topic.
  The positive case asserts a 200 carrying the topic name, so it also pins the
  cross-module `Extra["group_no"]` contract the parent check depends on (a
  forbidden-only test would pass even if the datasource were never registered).
  Needs `DM_THREAD_ON` set before the first `register.GetModules` call, hence a
  package-level `TestMain` and a blank import of `modules/thread`.
- `modules/user/user_get_authz_test.go` — the profile matrix: no-relation
  minimal (asserting `follow` is present and identity fields are not),
  same-Space, common-group-only, bot, system account, self, not-found.
- `modules/channel/service/profile_visibility_test.go` — the shared decision:
  early-allow identities must not even reach the common-group query; nil hook,
  empty uids and query errors all fail closed.

```
# 26 packages: every package that depends on modules/group or modules/user,
# each with the test DB recreated first (differing module sets otherwise trip
# sql-migrate's unknown-migration check)
go test ./modules/{channel,channel/service,user,group,thread,incomingwebhook,\
botfather,bot_api,messages_search,message,notify,robot,space,qrcode,statistics,\
webhook,integration,app_bot,bot_mention,bot_provision,card_template_catalog,\
oidc,conversation_ext,report,search}/ ./pkg/cardtmpl/... ./internal/...   # all ok
go test -tags=integration ./modules/{messages_search,botidentity}/                # ok
make i18n-extract-check && make i18n-lint                                        # ok
go vet ./... && gofmt -l <touched files>                                         # clean
```

Three `-tags=integration` suites do not pass, all verified pre-existing against
the merge base in a clean worktree: `modules/message` (test-only import cycle),
`modules/conversation_ext` (122 failures on base and on this branch — needs a
separate database), `modules/base/event` (`Table 'test.event' doesn't exist`).

- [x] Unit tests added/updated
- [x] Manually verified

## COMPREHENSION

1. **What does this change actually do to the load-bearing path?**

   It moves the read boundary for both endpoints from "any authenticated caller"
   to "caller with a verified relationship to the object", inside the handlers
   rather than in the datasources. GROUP/TOPIC become membership-gated; PERSON
   keeps returning a renderable identity for everyone but stops emitting
   identity detail to unrelated callers. Note the Space header was never an
   authorization input on this route (the `s{spaceID}_` prefix is parsed and the
   space id discarded, and no `SpaceMiddleware` is mounted) — authorization now
   rests on membership/relationship facts, which is header-independent by
   construction.

2. **What could break because of it (dependents + failure mode)?**

   - Clients that resolve a *group* name from a group they are not in will now
     get a rejection instead of the name. Concretely: group cards forwarded into
     other conversations, "you were removed from group" notices, and search
     results pointing at historical groups — if any of those fetch the name live
     rather than from a cached conversation entry, they render without a title.
     Left-group conversations are already dropped from `conversation/sync`, and
     join preview/scan-join use their own invite-code-gated endpoints
     (`/v1/group/invite/detail`, `scanjoin`), so the common paths are unaffected.
   - Clients reading identity fields for *unrelated* users get a shorter object.
     The minimal DTO deliberately omits `follow` rather than sending `follow: 0`,
     since a zero value would read as "definitely not a friend"; consumers must
     treat an absent field as unknown.
   - `GetUserDetail`'s missing-user error is now a sentinel. Its only other
     caller logs and ignores it, and no test asserts the old text. `/v1/users/:uid`
     changes a missing user from a query-failure code to not-found — clients that
     branched on the old code will see the new one.
   - A stranger's profile page loses `short_no` / online state / realname. The
     add-friend entry still renders (`follow` is retained) and the add-friend
     call itself is unaffected.
   - **Open item, not resolved here:** `SharedUIDRateLimiter` is a per-UID bucket
     shared across every mounted endpoint (2 rps / burst 60 by default). A cold
     start that resolves many distinct senders now competes with
     conversation/message reads for the same tokens, and the failure mode is a
     rate-limit response where a name or avatar should be. Worth one measurement
     against a busy account before this ships; `DM_API_UID_RATELIMIT_RPS` /
     `_BURST` are the escape hatch.

3. **How do you know it works (specific test/repro/trace)?**

   The original defect was reproduced end to end against a running deployment
   with a leave-group closure: create a group, leave it (ownership transfers to
   the next-oldest member, group survives), then re-query as a non-member —
   `GET /v1/groups/{gno}` returned 403 while `GET /v1/channels/{gno}/2` still
   returned 200 with the full detail and `quit:1`, proving the server knew the
   caller had left. Removing or forging the Space header changed nothing, and a
   nonexistent group returned a 500 empty body versus 200 for a real one.

   The profile endpoint was verified by reading the call graph rather than by a
   live repro; its regression matrix is the evidence for it.

   That exact asymmetry is now locked down by tests:
   `TestChannelGet_Group_NonMember_Forbidden` asserts the forbidden code and that
   the group name and notice are absent from the body;
   `TestChannelGet_Group_NotFound_NoPanicUnified` asserts no 500 and the same
   forbidden code as the non-member case;
   `TestChannelGet_Person_CommonGroupDisbanded_Minimal` asserts a dissolved
   shared group does not unlock full detail.
