### PR TITLE
fix(auth): harden user token lifecycle (PR 1)

### DIFF
--- a/.octospec/journal/shared/token-lifecycle-hardening.md
+++ b/.octospec/journal/shared/token-lifecycle-hardening.md
@@ -1,0 +1,85 @@
+---
+type: Journal
+title: "Journal: token-lifecycle-hardening (PR 1)"
+description: Record of bounding new and touched user HTTP-token lifetimes while preserving mixed-version rollout safety.
+tags: ["auth", "security", "redis", "session", "migration", "observability"]
+timestamp: 2026-08-09T18:42:28+08:00
+# --- octospec extension fields ---
+task: token-lifecycle-hardening
+source: self
+---
+# Journal: token-lifecycle-hardening (PR 1)
+
+## What was done
+
+This first delivery stops the server from creating or accidentally restoring an
+unbounded user HTTP bearer while retaining the existing opaque-token client
+contract:
+
+- Kept the existing `cache.tokenExpire` / `TS_CACHE_TOKENEXPIRE` entry point,
+  made explicit values fail loudly unless they are valid positive Go durations,
+  and capped them at 720h. Empty-value detection is scoped to the one env key and
+  does not mutate shared Viper semantics.
+- Added one process-wide Session Store and bounded Redis pool for authentication.
+  Writers issue finite credentials, preserve the existing deadline on reuse or
+  profile updates, compensate failed new issuance, and never recreate a bearer
+  deleted by a concurrent replica.
+- Replaced split `GET`/TTL assumptions with one single-key Lua read. API replicas
+  execute the real read script as a read-only startup probe and refuse to serve
+  if the configured Redis path cannot execute it.
+- Routed explicit token readers through the canonical validator. Release A keeps
+  legacy v1/v2 compatibility, while any v3 value is immediately subject to a
+  finite Redis TTL, absolute expiry, and session-generation validation.
+- Added low-cardinality session metrics and a separate, rate-limited, read-only
+  observation tool. It reports aggregate migration facts without emitting
+  bearer values, Redis keys, or UIDs.
+- Added repository-wide AST guards so production token reads/writes cannot
+  bypass `pkg/auth`; direct `Set`, `SetAndExpire`, `SetNX`, `Persist`, `Expire`,
+  and `ExpireAt` calls using token prefixes are rejected outside the store.
+
+## Security and rollout boundary
+
+PR 1 is a stop-the-bleeding release, not final vulnerability closure. Historical
+persistent v1/v2 sessions remain readable until an approved migration handles
+them, and v2 has no payload-level absolute deadline. PR 2 must add guarded v3
+issuance, generation/session indexes, the high-risk-event revocation matrix, and
+migration apply/enforce. The finding can close only after production observation,
+controlled migration, old-replica removal, and security retest.
+
+The change does not alter the token header, login response shape, or database
+schema and does not run a bulk expiry during deployment. Intentional operational
+changes are fail-loud configuration validation, fail-closed Lua startup probing,
+non-sliding Web/PC token reuse, APP bearer replacement, and an additional bounded
+Redis pool whose capacity must be budgeted across replicas.
+
+## Verification
+
+- `go build ./...` — pass.
+- `go vet ./...` — pass.
+- `golangci-lint run ./...` — 0 issues.
+- `go test . ./pkg/auth ./pkg/metrics -count=1` — pass.
+- Focused `modules/user` writer, login, Redis, and HTTP TTL tests — pass.
+- `make i18n-extract-check` and `make i18n-lint` — pass.
+- `pkg/auth` race and coverage checks were run during implementation; auth
+  coverage was above the task threshold.
+
+A broad user-package regex initially selected an unrelated scan-login test and
+hit the shared MySQL migration drift (`group` table already present without the
+matching migration state). Re-running the exact token-lifecycle targets passed.
+The shared database was not cleaned or modified to hide that environment issue.
+
+## Learnings and follow-ups
+
+- Detecting an explicitly empty env override must not change global configuration
+  semantics. Read the one security-sensitive env key directly and test unrelated
+  empty and non-empty overrides before and after validation.
+- Authentication Lua remains one Redis round-trip in steady state and does not
+  write on every request. Before rollout, verify `EVALSHA`/`EVAL` through the
+  production endpoint and budget Session Store `PoolSize x replica count`
+  against Redis `maxclients`.
+- Web/PC explicit login currently reuses the bearer without extending its
+  deadline. Product approval is required because a near-expiry bearer can still
+  expire shortly after a successful login.
+- PR 2 must preserve v3 security claims when updating display snapshots and must
+  expose incomplete migration scans explicitly rather than silently treating
+  Redis read failures as complete data.

--- a/.octospec/journal/shared/token-lifecycle-hardening.md
+++ b/.octospec/journal/shared/token-lifecycle-hardening.md
@@ -24,6 +24,12 @@ contract:
   Writers issue finite credentials, preserve the existing deadline on reuse or
   profile updates, compensate failed new issuance, and never recreate a bearer
   deleted by a concurrent replica.
+- Added a per-issue ownership marker inside the versioned Token payload. Reuse
+  atomically removes that marker on the existing single Token key, while failed
+  issuance compensation compare-deletes only the still-owned payload. A stalled
+  replica therefore cannot revoke the same Token after another replica has
+  successfully adopted it; no process lock, extra Redis key, or auth-hot-path
+  write was introduced.
 - Replaced split `GET`/TTL assumptions with one single-key Lua read. API replicas
   execute the real read script as a read-only startup probe and refuse to serve
   if the configured Redis path cannot execute it.
@@ -60,8 +66,9 @@ Redis pool whose capacity must be budgeted across replicas.
 - `go test . ./pkg/auth ./pkg/metrics -count=1` — pass.
 - Focused `modules/user` writer, login, Redis, and HTTP TTL tests — pass.
 - `make i18n-extract-check` and `make i18n-lint` — pass.
-- `pkg/auth` race and coverage checks were run during implementation; auth
-  coverage was above the task threshold.
+- Two independent Redis clients/Session Stores reproduce the issue-adopt-fail
+  ordering and prove compensation preserves the adopted Token and device index.
+- `go test -race -count=1 ./pkg/auth/...` — pass; auth coverage 87.2%.
 
 A broad user-package regex initially selected an unrelated scan-login test and
 hit the shared MySQL migration drift (`group` table already present without the
@@ -77,6 +84,10 @@ The shared database was not cleaned or modified to hide that environment issue.
   write on every request. Before rollout, verify `EVALSHA`/`EVAL` through the
   production endpoint and budget Session Store `PoolSize x replica count`
   against Redis `maxclients`.
+- A Token string or payload equality is not sufficient issue-attempt ownership:
+  Web/PC login intentionally reuses the same Token. Ownership must be represented
+  in shared Redis state and removed atomically when another request adopts it;
+  compensation then uses exact compare-delete rather than unconditional `DEL`.
 - Web/PC explicit login currently reuses the bearer without extending its
   deadline. Product approval is required because a near-expiry bearer can still
   expire shortly after a successful login.

--- a/.octospec/learnings/pending/token-lifecycle-hardening.md
+++ b/.octospec/learnings/pending/token-lifecycle-hardening.md
@@ -1,0 +1,45 @@
+---
+type: Learning
+title: Scope explicit-empty environment validation to one key
+description: Detecting an explicitly empty security configuration must not mutate the shared configuration object's semantics for unrelated keys.
+tags: ["configuration", "security", "viper", "environment"]
+timestamp: 2026-08-09T18:42:28+08:00
+# --- octospec extension fields ---
+source: self
+origin_task: token-lifecycle-hardening
+status: pending
+candidate_rule: configuration
+---
+
+# Scope explicit-empty environment validation to one key
+
+## Context
+
+The token TTL must distinguish an absent environment variable (use the bounded
+default or YAML) from an explicitly empty variable (configuration error). A first
+implementation enabled Viper's `AllowEmptyEnv` on the shared instance before the
+rest of the application loaded configuration. That instance-wide switch made
+unrelated empty `TS_*` variables override YAML as well, including database and
+Redis TLS settings.
+
+## Rule of thumb
+
+When one security-sensitive setting needs absent-versus-empty detection:
+
+1. Use `os.LookupEnv` for the documented env key and strictly parse it when
+   present, including the empty string.
+2. Read the YAML/default path only when that env key is absent.
+3. Do not toggle an instance-wide or process-wide empty-env policy as a local
+   validation shortcut.
+4. Add a regression that loads unrelated security/connection values from YAML,
+   sets their env counterparts empty, and proves validation leaves them intact.
+5. Also prove a non-empty unrelated env override still wins, so the fix does not
+   disable legitimate configuration precedence.
+
+## Why worth a rule
+
+Configuration validation runs before most dependencies are initialized, so a
+silent precedence change can redirect a service to the wrong database or disable
+transport security while startup still appears successful. The safe pattern is
+small, deterministic, and applies to every fail-loud security knob, not only
+token TTL.

--- a/.octospec/log.md
+++ b/.octospec/log.md
@@ -4,6 +4,23 @@ Change history for this repo's `.octospec/`, following the
 [OKF](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md)
 change-log convention (§7). Newest first.
 
+## 2026-08-09 (token-lifecycle-hardening PR 1)
+
+- **Task** — `token-lifecycle-hardening`: bounded all new and touched user HTTP
+  bearers with the existing Token TTL, centralized readers/writers in a shared
+  Redis Session Store, preserved deadlines atomically across replicas, added
+  strict v3 forward validation, startup Lua compatibility probing, bounded pool
+  metrics, and a rate-limited aggregate-only migration observer. This PR does
+  not bulk-expire historical persistent v1/v2 sessions; v3 activation,
+  generation/indexed revocation, migration apply/enforce, and final security
+  closure remain PR 2 plus controlled operations. See
+  [journal](journal/shared/token-lifecycle-hardening.md).
+- **Learning (pending)** —
+  [scope-explicit-empty-env-validation](learnings/pending/token-lifecycle-hardening.md):
+  distinguish absent from explicitly empty security env values by reading the
+  one documented key; never mutate shared configuration semantics as a local
+  validation shortcut.
+
 ## 2026-08-09 (scan-login-authorization)
 
 - **Task** — `scan-login-authorization`: added a deployment-wide

--- a/.octospec/tasks/token-lifecycle-hardening/brief.md
+++ b/.octospec/tasks/token-lifecycle-hardening/brief.md
@@ -19,6 +19,8 @@ source: self
 
 当前依赖的 Viper v1.16 / cast v1.5.1 最终使用 Go `time.ParseDuration`，不支持 `30d` 这种 day 后缀。仓库示例中的 `tokenExpire: 30d` 会解析为零，再被 octo-lib 静默替换成默认 30 天，容易造成“覆盖已生效”的误判；实现时必须把示例改为 `720h`，并在 octo-server 启动层对 Viper 已完成 env 覆盖后的原始值做显式解析和校验。
 
+显式空值 env 的校验只能用 `os.LookupEnv("TS_CACHE_TOKENEXPIRE")` 收敛到该唯一配置项；不得调用 `AllowEmptyEnv` 改变共享 Viper 实例的全局语义，否则其他空 `TS_*` env 可能覆盖 YAML 中的数据库地址或 Redis TLS 配置。校验前后，非 Token 配置的 env/YAML 优先级必须保持不变。
+
 ## Goal
 
 让所有用户 Access Token 同时满足以下约束：

--- a/.octospec/tasks/token-lifecycle-hardening/brief.md
+++ b/.octospec/tasks/token-lifecycle-hardening/brief.md
@@ -98,7 +98,7 @@ Redis 原子更新优先使用 Lua `PTTL + SET PX`，兼容当前 go-redis 版�
 
 - `PTTL > 0`：以原剩余毫秒数重写 value。
 - `PTTL == -2`：返回 missing，调用方不得重建相同 Token。
-- `PTTL == -1`：记录 `persistent_detected`，在兼容迁移阶段只赋予一次固定 legacy grace TTL；不得继续保持永久。
+- `PTTL == -1`：记录 `persistent_detected` 且不得继续保持永久。Release A 的在线资料更新/重复登录只把被触达 key 收敛到当前 `TokenExpire` 上限（默认最多 720h），不冒充尚未批准的 7 天迁移；显式 migration apply 在生产盘点和 go/no-go 后才使用一次固定 legacy grace，且重复执行不得延长已有 TTL。因此进入 enforce 仍必须以 observe 的实际 `v1/v2=0` 为准，不能按“已过 7 天”推断。
 
 多 key Lua 前必须核对生产 Redis 是否为 Cluster。若为 Cluster，key 设计必须使用同一 hash tag，或拆成单 key 原子操作并明确补偿；不能假设 standalone。
 当前仓库的 `*redis.Client + 单 redisAddr` 没有原生 Cluster 拓扑发现能力；若生产是 native Redis Cluster 而不是兼容单端点 proxy，应先把客户端/slot 设计作为阻塞前置项，不能只调整 Lua key 名后宣称支持。

--- a/.octospec/tasks/token-lifecycle-hardening/brief.md
+++ b/.octospec/tasks/token-lifecycle-hardening/brief.md
@@ -105,6 +105,13 @@ Redis 原子更新优先使用 Lua `PTTL + SET PX`，兼容当前 go-redis 版�
 
 新签发和复用旧 Token 必须使用不同补偿语义：`IssueNew` 在索引或 IM 更新失败时删除本次新建的 credential；`ReuseExisting` 失败时不得把登录前已有效的旧 Token 当作“新 Token”删除。APP 替换旧 Token、Redis 部分成功、IM 成功/失败的每个组合都要有明确状态机和故障注入测试，避免孤儿 credential 或误踢已有会话。
 
+#### 多副本与性能约束
+
+- 同一进程的所有 Token reader/writer 必须复用 `config.Context` 内唯一的 Session Store 和唯一的有界 go-redis 连接池，不能由 group/message/user 等模块各自建池。PR 1 当前每副本池大小为 10，带有限 dial/read/write/pool timeout 和一次重试；上线前需按副本数核算 Redis `maxclients`，并通过 session latency/error 指标确认没有 pool wait 饱和。若需扩容连接池，应基于压测或生产证据单独调整，不能靠每个模块复制 client 绕过。
+- 认证热路径的 payload 与 PTTL 读取必须由一个单-key Lua 原子完成；脚本缓存命中后的稳态为一次 Redis 往返，新 Redis 节点首次 `EVALSHA` 遇到 `NOSCRIPT` 时允许由客户端回退一次 `EVAL`。不得先 `GET` 再 `PTTL` 形成 TOCTOU，也不得在每个已认证请求上写 TTL、索引或 generation。资料更新、登录和撤销才允许写 Redis，避免把本次安全修复变成按请求写放大。
+- 未确认生产 Cluster 拓扑前，PR 1 的 Lua 只能操作一个 key；Token key 与兼容 `UIDToken` 索引分步写，并以“新 credential 可补偿、旧 credential 不误删”的状态机处理部分失败。不同副本必须只通过 Redis 中的原子条件协调，不能依赖进程锁或本地缓存保证安全。
+- migration observe/apply 不得随每个副本启动；显式运维进程默认限速、连接池独立且更小，可取消并只输出聚合。在线请求与迁移流量的 Redis 延迟、错误率必须分别可观测，避免扫描挤占认证连接。
+
 ### 2. Token payload v3 绝对到期
 
 新增可向后解码的 v3 payload，至少包含：
@@ -243,11 +250,13 @@ v3 是新的 cache value 格式，当前旧二进制不能解码。必须采用 
 - 故障注入覆盖 Token/index/UIDToken/IM 每一步失败：新签发失败无可用孤儿 credential，复用失败不误删登录前已有效的旧 Token。
 - 当前退出、全部退出、密码修改、各类密码重置、禁用和注销按撤销矩阵测试；旧 Token 随后访问返回统一未认证响应。
 - 并发测试证明旧密码校验与密码修改/重置竞态时，安全事件前开始、事件后才提交的会话不能存活；v3 索引缺失时 `RevokeAll` 仍通过 generation 立即失效 Token，legacy 孤儿则由 deny marker 阻断。
+- 两个独立 Redis client/Session Store 实例模拟不同副本时，并发复用与 logout 不得复活 bearer；补偿撤销只能 compare-delete 自己的兼容索引，不能删除其他副本刚写入的新 Token 索引。
 - OIDC logout 继续撤当前 HTTP Token、吊销该 UID 全部未吊销 IdP RT、踢全部 IM 设备，并保持现有 best-effort/RP-Initiated Logout 响应行为。
 - legacy 迁移工具 dry-run 不写 Redis、不输出秘密；apply 可中断续跑、幂等且不延长 TTL；测试覆盖 `TTL=-2/-1/>max/normal`。
 - 混版测试证明 Release A 能读取 v2/v3，Release B 写 v3；发布检查能阻止旧副本存活时进入 enforce。
 - 迁移完成后按配置的 Token 前缀扫描：`persistent=0`、`over_max=0`、`v1/v2=0`；enforce 期间新增这些类型会触发告警。
 - Redis 不可用或 payload/TTL 不合法时认证 fail closed，且保持现有 i18n/anti-enumeration wire contract。
+- 认证 validator 稳态每次请求执行一次单-key Redis 脚本且不写 Redis（允许新节点首次 `NOSCRIPT` 回退）；每副本只创建一个 Session Store 连接池，池大小、timeout、retry 和操作时延均有测试或指标证据，迁移扫描不与在线池混用。
 - 相关测试至少覆盖 `pkg/auth`、`modules/user`、`modules/oidc`；运行 focused tests、`go test ./...`、`make i18n-extract-check`、`make i18n-lint` 和 lint。
 
 ## Decisions required before implementation

--- a/.octospec/tasks/token-lifecycle-hardening/brief.md
+++ b/.octospec/tasks/token-lifecycle-hardening/brief.md
@@ -107,8 +107,9 @@ Redis 原子更新优先使用 Lua `PTTL + SET PX`，兼容当前 go-redis 版�
 
 #### 多副本与性能约束
 
-- 同一进程的所有 Token reader/writer 必须复用 `config.Context` 内唯一的 Session Store 和唯一的有界 go-redis 连接池，不能由 group/message/user 等模块各自建池。PR 1 当前每副本池大小为 10，带有限 dial/read/write/pool timeout 和一次重试；上线前需按副本数核算 Redis `maxclients`，并通过 session latency/error 指标确认没有 pool wait 饱和。若需扩容连接池，应基于压测或生产证据单独调整，不能靠每个模块复制 client 绕过。
+- 同一进程的所有 Token reader/writer 必须复用 `config.Context` 内唯一的 Session Store 和唯一的有界 go-redis 连接池，不能由 group/message/user 等模块各自建池。PR 1 默认 `PoolSize=10*GOMAXPROCS`、`PoolTimeout=3s`、`MaxRetries=1`，可分别用严格校验的 `OCTO_AUTH_SESSION_REDIS_POOL_SIZE`（正整数，上限为 `max(4096, 默认 PoolSize)`）和 `OCTO_AUTH_SESSION_REDIS_POOL_TIMEOUT`（Go duration，`>0` 且 `<=30s`）覆盖；显式空值或非法值启动失败。该池纳入现有 Redis pool collector，label 固定为 `session`。上线前必须按 `pool size × 副本数` 核算 Redis `maxclients`，并通过 session latency/error 与 pool timeout 指标确认没有排队饱和；不能靠每个模块复制 client 绕过。
 - 认证热路径的 payload 与 PTTL 读取必须由一个单-key Lua 原子完成；脚本缓存命中后的稳态为一次 Redis 往返，新 Redis 节点首次 `EVALSHA` 遇到 `NOSCRIPT` 时允许由客户端回退一次 `EVAL`。不得先 `GET` 再 `PTTL` 形成 TOCTOU，也不得在每个已认证请求上写 TTL、索引或 generation。资料更新、登录和撤销才允许写 Redis，避免把本次安全修复变成按请求写放大。
+- API 副本开始服务前必须用真实的认证读取脚本执行一次只读 missing-key probe；失败直接阻止启动。不得提供回退旧 `GET` 认证语义的 kill-switch，因为那会绕过 payload+PTTL 原子校验。生产仍需在发布前确认 proxy/Cluster 对 `EVALSHA`/`EVAL` 的兼容性，启动 probe 不是压测替代品。
 - 未确认生产 Cluster 拓扑前，PR 1 的 Lua 只能操作一个 key；Token key 与兼容 `UIDToken` 索引分步写，并以“新 credential 可补偿、旧 credential 不误删”的状态机处理部分失败。不同副本必须只通过 Redis 中的原子条件协调，不能依赖进程锁或本地缓存保证安全。
 - migration observe/apply 不得随每个副本启动；显式运维进程默认限速、连接池独立且更小，可取消并只输出聚合。在线请求与迁移流量的 Redis 延迟、错误率必须分别可观测，避免扫描挤占认证连接。
 
@@ -126,13 +127,14 @@ Redis 原子更新优先使用 Lua `PTTL + SET PX`，兼容当前 go-redis 版�
 
 generation key 的生命周期至少覆盖该 UID 最晚到期的 v3 Token；validator 发现 generation 缺失必须 fail closed，不能把缺失解释为默认值而重新接受旧 Token。`RevokeAll` 即使索引缺失也必须创建新的 generation。
 
-阶段一的推荐策略为：沿用现有 `Cache.TokenExpire`（YAML `cache.tokenExpire` / env `TS_CACHE_TOKENEXPIRE`），但在 `ConfigureWithViper` 吞掉解析错误之前，对 env 覆盖后的原始值显式校验：缺省才使用 720h；显式值必须是带单位的合法 Go duration、`> 0` 且不超过经安全/产品确认的硬上限。建议暂定最大 720h。生产配置若非法或超过上限，预检必须先处理，不能在发布时静默回退、截断或带错配置启动。启动日志和低基数指标应暴露最终生效的 TTL，便于确认配置覆盖结果。
+阶段一的推荐策略为：沿用现有 `Cache.TokenExpire`（YAML `cache.tokenExpire` / env `TS_CACHE_TOKENEXPIRE`），但在 `ConfigureWithViper` 吞掉解析错误之前，对 env 覆盖后的原始值显式校验：缺省才使用 720h；显式值（包括显式空字符串）必须是带单位的合法 Go duration、`> 0` 且不超过经安全/产品确认的硬上限。建议暂定最大 720h。生产配置若非法或超过上限，预检必须先处理，不能在发布时静默回退、截断或带错配置启动。启动日志和低基数指标应暴露最终生效的 TTL，便于确认配置覆盖结果。
 
 所有直接读取 Token cache 后调用 `auth.Decode` 的验证入口也必须走同一个 validator，特别是公开邀请可选认证、`message.sendMsg` 的 body Token、`/auth/verify` 和二维码入口，避免主 AuthMiddleware 已收紧但辅助入口仍接受过期 payload。
 
 ### 3. 绝对寿命与重复登录
 
 - 资料更新永远保留原 deadline。
+- Session Store 必须原子拒绝把现有 `v3:` payload 重写成 v2/legacy；Release A 即锁住该不变量，避免 Release B 激活后资料更新绕过 `expires_at` 与 generation 撤销。
 - Web/PC 显式重复登录若继续复用旧 Token，只保留剩余寿命，不续满 30 天。
 - 若产品要求“重新输入凭据后获得新的完整寿命”，必须签发新 Token；不能通过延长旧 Token 模拟。新 Token 对已有多端会话的影响需由会话索引和设备策略显式处理。
 - APP 当前替换旧 Token 的行为可保留，但签发与删除必须由 Session Store 完成。
@@ -242,7 +244,7 @@ v3 是新的 cache value 格式，当前旧二进制不能解码。必须采用 
 ## Acceptance
 
 - 真实 Redis 集成测试证明：新登录 Token TTL `> 0` 且 `<= configured max`；改昵称前后 TTL 不增加，绝不会从有限值变为 `-1`。
-- 配置测试证明合法的 `cache.tokenExpire` 和 `TS_CACHE_TOKENEXPIRE`（例如 `48h`）能覆盖默认 720h，且 env 优先；`30d`、无单位数字、其他 malformed 值、零值、负值或超过硬上限配置均在启动期 fail loudly，不能静默回退默认值。
+- 配置测试证明合法的 `cache.tokenExpire` 和 `TS_CACHE_TOKENEXPIRE`（例如 `48h`）能覆盖默认 720h，且 env 优先；显式空 env、`30d`、无单位数字、其他 malformed 值、零值、负值或超过硬上限配置均在启动期 fail loudly，不能静默回退默认值。
 - payload v3 被人工放入永久 Redis key 时，无论 `expires_at` 是否仍有效都因 `PTTL=-1` 被拒；有限 TTL key 中 `expires_at <= now` 或 generation 不匹配的 v3 仍被所有认证/verify/辅助入口拒绝。
 - Web/PC/扫码复用旧 Token 时以 `PTTL + SET PX` 保留原 deadline；并发 logout 后不得复活 Token。
 - 所有生产 Token writer 通过 Session Store；源码守卫禁止业务代码直接对 `TokenCachePrefix` / `UIDTokenCachePrefix` 执行 `Set` / `SetAndExpire`。
@@ -256,6 +258,7 @@ v3 是新的 cache value 格式，当前旧二进制不能解码。必须采用 
 - 混版测试证明 Release A 能读取 v2/v3，Release B 写 v3；发布检查能阻止旧副本存活时进入 enforce。
 - 迁移完成后按配置的 Token 前缀扫描：`persistent=0`、`over_max=0`、`v1/v2=0`；enforce 期间新增这些类型会触发告警。
 - Redis 不可用或 payload/TTL 不合法时认证 fail closed，且保持现有 i18n/anti-enumeration wire contract。
+- API 启动在接受流量前执行认证读取 Lua 的只读 probe；脚本不兼容或 Redis 失败时阻止启动，不回退旧认证语义。
 - 认证 validator 稳态每次请求执行一次单-key Redis 脚本且不写 Redis（允许新节点首次 `NOSCRIPT` 回退）；每副本只创建一个 Session Store 连接池，池大小、timeout、retry 和操作时延均有测试或指标证据，迁移扫描不与在线池混用。
 - 相关测试至少覆盖 `pkg/auth`、`modules/user`、`modules/oidc`；运行 focused tests、`go test ./...`、`make i18n-extract-check`、`make i18n-lint` 和 lint。
 

--- a/.octospec/tasks/token-lifecycle-hardening/brief.md
+++ b/.octospec/tasks/token-lifecycle-hardening/brief.md
@@ -1,0 +1,264 @@
+---
+type: Task
+title: "Task: token-lifecycle-hardening"
+description: Enforce a bounded user access-token lifetime, migrate legacy persistent sessions safely, and make security-event revocation complete
+tags: [auth, security, redis, session, migration, observability]
+timestamp: 2026-08-09T15:44:02+08:00
+# --- octospec extension fields ---
+slug: token-lifecycle-hardening
+upstream: TBD
+source: self
+---
+
+# Task: token-lifecycle-hardening
+
+> 本 brief 只定义服务端修复边界和上线顺序，不包含生产环境现状结论。
+> 生产 `cache.tokenExpire`、Redis 拓扑和历史 Token 数量仍需只读核查。
+
+现有 TTL 配置入口继续作为唯一来源：配置文件使用 `cache.tokenExpire`，环境变量覆盖使用 `TS_CACHE_TOKENEXPIRE`，代码默认值为 `time.Hour * 24 * 30`（720h，即 30 天）。该配置由 Viper 在进程启动时读取，不做运行时热更新；本任务不增加第二个同义配置项。
+
+当前依赖的 Viper v1.16 / cast v1.5.1 最终使用 Go `time.ParseDuration`，不支持 `30d` 这种 day 后缀。仓库示例中的 `tokenExpire: 30d` 会解析为零，再被 octo-lib 静默替换成默认 30 天，容易造成“覆盖已生效”的误判；实现时必须把示例改为 `720h`，并在 octo-server 启动层对 Viper 已完成 env 覆盖后的原始值做显式解析和校验。
+
+## Goal
+
+让所有用户 Access Token 同时满足以下约束：
+
+1. 从签发开始具有服务端可验证的绝对最大寿命；任何资料更新、重复登录或扫码登录都不能把绝对到期时间向后延长。
+2. Redis 中的 Token key 必须有有限 TTL；即使未来某次写操作意外丢失 TTL，Token payload 的绝对到期时间仍会让认证失败。
+3. 当前设备退出、全部设备退出、密码变更/重置、账号禁用/注销等高风险事件能够按矩阵撤销对应 HTTP 会话，而不只是踢 WuKongIM 连接。
+4. 历史永久 Token 通过可观测、可限速、可中断的迁移逐步收敛，避免一次性清空导致全量用户异常登出。
+5. 不改变客户端当前携带 opaque Token 的请求协议；Access/Refresh Token 双 Token 协议另立跨端任务。
+
+## Background
+
+### 已验证事实
+
+- 基线：`origin/main@8e2e66a84d1f`。
+- 本地使用真实 MySQL、Redis、WuKongIM 链路完成：`POST /v1/user/login` → `PUT /v1/user/current` 修改昵称。
+- 登录后 `TTL token:<token>` 为 `720h`；修改昵称后变为 `-1s`，即 Redis 永久 key。
+- 直接原因是 `modules/user/api.go` 的昵称更新使用 `Cache.Set` 重写 Token payload；底层 `pkg/redis.Conn.Set` 使用 Redis expiration `0`，会移除原 TTL。
+- `pkg/auth.CacheTokenParser` 当前只读取并解码 Redis value；payload v2 没有 `issued_at` / `expires_at`，因此 Redis TTL 丢失后没有第二道绝对过期校验。
+- 当前 Redis 客户端配置只有单个 `db.redisAddr`，实现使用 go-redis `*redis.Client` 而非 `ClusterClient`；这只能证明代码按单端点工作，不能据此推断生产后端一定是 standalone，生产仍可能位于 Redis proxy 后。
+
+### Token 写入路径盘点
+
+下列路径会签发或重写用户 HTTP Token，必须统一收口，不能逐点修补：
+
+- `/v1/user/login`、username/email 登录以及已有用户的 GitHub/Gitee/OIDC 登录最终进入 `user.execLogin`。
+- 扫码登录 `loginWithAuthCode` 自行复用或签发 Token。
+- 设备验证二阶段 `loginCheckPhone` 自行签发 APP Token。
+- 手机号/username/email 注册以及 GitHub/Gitee/OIDC 新建用户通过 `createUserWithRespAndTx` 自行签发 Token。
+- 管理后台 `manager.login` 自行签发 Token。
+- 昵称更新会重写当前 Token payload。
+- `execLogin` / 扫码登录在复用 Web/PC Token 时使用 `SET XX` 加完整 `TokenExpire`，会把剩余 TTL 重新续满；这实现的是滑动续期，不是绝对最大寿命。
+- `loginCheckPhone` 和 `createUserWithRespAndTx` 只写 Token key，没有写 `UIDToken` 反向索引；多个路径还会先写 Redis Token、再调用 WuKongIM，后续失败时没有统一补偿。
+
+### Token 读取路径盘点
+
+- 主 AuthMiddleware 使用 `pkg/auth.CacheTokenParser`；`modules/report` 虽沿用带 cache/prefix 参数的旧调用形式，但同一个 `WKHttp` 已注入自定义 parser，不构成旁路。
+- `modules/group` 的公开邀请详情可选读取 header Token，`modules/message.sendMsg` 会读取 body 中的 Token，`/v1/auth/verify` 会验证请求体 Token；它们都直接 `Cache.Get + auth.Decode`，不会自动继承主 parser 后续新增的 TTL/绝对到期校验。
+- `modules/qrcode` 在 AuthMiddleware 之后又直接读取并解码同一 header Token；当前不是认证旁路，但应消除重复解析或改走同一 validator，避免两套语义漂移。
+- `updateSystemUserToken` 只给 System/FileHelper/Admin 调 WuKongIM `/user/token` 更新 IM transport Token，不写 octo-server 的 HTTP Token cache，不属于本任务的用户 Access Token writer。
+
+### 当前撤销边界
+
+- OIDC logout 已显式删除当前 HTTP Token，并用 compare-delete 清理恰好指向该 Token 的 `UIDToken` 索引；同时 `RevokeRefreshByUID` 会吊销该 UID 名下全部未吊销 IdP refresh token，`QuitUserDevice(uid, -1)` 会踢全部 WuKongIM 设备。三者均为 best-effort，失败仍返回现有 logout 响应并通过指标区分；该现状不能简写成“只吊销当前设备的 IdP RT”。
+- `/v1/user/quit`、`/v1/user/pc/quit`、设备删除目前主要操作 WuKongIM/设备表，没有完整删除 HTTP Token。
+- 多条修改/重置密码路径只更新密码，或最多删除 Web 反向索引指向的单个 Token；不能覆盖 APP、PC、历史孤儿 Token。
+- 账号禁用/注销调用 `QuitUserDevice` 只会请求 WuKongIM `/user/device_quit`；它不会删除 octo-server Redis Token。
+- 删除管理员时已有逻辑会清角色缓存，并尝试删除 APP/Web/PC 三个 `UIDToken` 当前指向的 Token；RoleResolver 正常读取 DB 时能及时阻断旧管理权限，但 resolver 故障会回退到 Token 中的角色快照，该枚举也覆盖不了历史孤儿 Token，因此不能把 RoleResolver 当作完整撤销的替代品。
+- 默认 `uidtoken:<flag><uid>`（实际前缀可配置）每个设备类型只保存一个值，不是所有历史 Token 的权威清单；`loginCheckPhone`、注册签发及历史版本还可能产生无反向索引的 Token。
+- OIDC sync worker 在确认某条 refresh token 为真实 `invalid_grant` 后，会标记该 RT 吊销并调用 `QuitUserDevice(uid, -1)`；当前仍只踢 IM，不会撤销该 UID 的 HTTP Token。
+
+## Options evaluated
+
+| 方案 | 优点 | 缺口 | 结论 |
+| --- | --- | --- | --- |
+| 昵称处改成 `SetAndExpire(TokenExpire)` | 改动最小 | 每次昵称更新把寿命续满；未覆盖其他写入、历史永久 Token 和撤销事件 | 不采用 |
+| 昵称处使用 `KEEPTTL` | 能修复本次稳定复现 | 重复登录仍会续满；Redis TTL 再次丢失时无 payload 兜底；撤销仍不完整 | 只作为止血原语，不是完整方案 |
+| 统一 Session Store + 有绝对过期的 payload + 历史迁移 + 会话索引 | 服务端可闭环，客户端协议不变；能覆盖签发、更新、撤销和迁移 | 改动面较大，必须分阶段兼容上线 | 推荐 |
+| 立即改成短 Access Token + 旋转 Refresh Token | 长期安全模型最好 | 需要 Web/iOS/Android 同步升级、重放检测和混版兼容；不能作为本次服务端止血前提 | 单独跨端任务 |
+
+## Recommended design
+
+### 1. 收口 Session Store
+
+在 user/auth 边界引入唯一的用户 Session Store；业务 handler 不再直接拼接
+`TokenCachePrefix` / `UIDTokenCachePrefix` 写 Redis。至少提供：
+
+- `BeginIssue` / `IssueNew`：签发随机 opaque Token，写 Token payload、兼容设备反向索引和 per-UID 会话索引。对本地密码登录，`BeginIssue` 必须在读取并验证密码/账号状态之前取得预期 generation，`IssueNew` 再以 CAS 提交；高风险事件推进 generation 后，事件前读取的旧凭据不能落成新会话。
+- `UpdatePayloadKeepDeadline`：仅更新昵称/语言等快照，原子保留剩余 TTL 和原 `expires_at`。
+- `ReuseExisting`：仅在 key 仍存在时更新 payload，不增加剩余 TTL；缺失时走 `IssueNew`，不能复活已登出 Token。
+- `RevokeCurrent`：删除请求携带的 Token，并 compare-delete 匹配的设备反向索引。
+- `RevokeByDevice`：按设备信息和会话索引删除所有匹配 Token。
+- `RevokeAll`：先推进该 UID 的 session generation，使所有 v3 Token 立即因 generation 不匹配而失败，再尽力删除索引成员；索引删除是回收手段，不是完整撤销的唯一安全依据。
+- `Validate`：统一完成读取、TTL 状态、payload 版本、绝对到期和 session generation 校验，供 AuthMiddleware 与所有显式 Token 入口复用。
+
+Redis 原子更新优先使用 Lua `PTTL + SET PX`，兼容当前 go-redis 版本：
+
+- `PTTL > 0`：以原剩余毫秒数重写 value。
+- `PTTL == -2`：返回 missing，调用方不得重建相同 Token。
+- `PTTL == -1`：记录 `persistent_detected`，在兼容迁移阶段只赋予一次固定 legacy grace TTL；不得继续保持永久。
+
+多 key Lua 前必须核对生产 Redis 是否为 Cluster。若为 Cluster，key 设计必须使用同一 hash tag，或拆成单 key 原子操作并明确补偿；不能假设 standalone。
+当前仓库的 `*redis.Client + 单 redisAddr` 没有原生 Cluster 拓扑发现能力；若生产是 native Redis Cluster 而不是兼容单端点 proxy，应先把客户端/slot 设计作为阻塞前置项，不能只调整 Lua key 名后宣称支持。
+
+新签发和复用旧 Token 必须使用不同补偿语义：`IssueNew` 在索引或 IM 更新失败时删除本次新建的 credential；`ReuseExisting` 失败时不得把登录前已有效的旧 Token 当作“新 Token”删除。APP 替换旧 Token、Redis 部分成功、IM 成功/失败的每个组合都要有明确状态机和故障注入测试，避免孤儿 credential 或误踢已有会话。
+
+### 2. Token payload v3 绝对到期
+
+新增可向后解码的 v3 payload，至少包含：
+
+- `uid`, `name`, `role`, `lang`
+- `issued_at`
+- `expires_at`
+- `device_flag`，以及设备级撤销需要的稳定 `device_id`（无设备信息时显式为空）
+- `session_generation`（不可预测的 per-UID generation 标识，供 `RevokeAll` O(1) 失效所有 v3 会话）
+
+时间字段固定为 UTC Unix seconds，并通过可注入 clock 测试边界。对 v3，认证同时检查 Redis key 存在、`PTTL > 0`、`now < expires_at` 且 payload generation 等于当前 UID generation。Redis TTL 是回收机制，`expires_at` 和 generation 是安全兜底；任一不满足都拒绝。observe/apply 期间的 v1/v2 不具备这些字段，必须走下文单独的 legacy 兼容策略，不能伪造字段。
+
+generation key 的生命周期至少覆盖该 UID 最晚到期的 v3 Token；validator 发现 generation 缺失必须 fail closed，不能把缺失解释为默认值而重新接受旧 Token。`RevokeAll` 即使索引缺失也必须创建新的 generation。
+
+阶段一的推荐策略为：沿用现有 `Cache.TokenExpire`（YAML `cache.tokenExpire` / env `TS_CACHE_TOKENEXPIRE`），但在 `ConfigureWithViper` 吞掉解析错误之前，对 env 覆盖后的原始值显式校验：缺省才使用 720h；显式值必须是带单位的合法 Go duration、`> 0` 且不超过经安全/产品确认的硬上限。建议暂定最大 720h。生产配置若非法或超过上限，预检必须先处理，不能在发布时静默回退、截断或带错配置启动。启动日志和低基数指标应暴露最终生效的 TTL，便于确认配置覆盖结果。
+
+所有直接读取 Token cache 后调用 `auth.Decode` 的验证入口也必须走同一个 validator，特别是公开邀请可选认证、`message.sendMsg` 的 body Token、`/auth/verify` 和二维码入口，避免主 AuthMiddleware 已收紧但辅助入口仍接受过期 payload。
+
+### 3. 绝对寿命与重复登录
+
+- 资料更新永远保留原 deadline。
+- Web/PC 显式重复登录若继续复用旧 Token，只保留剩余寿命，不续满 30 天。
+- 若产品要求“重新输入凭据后获得新的完整寿命”，必须签发新 Token；不能通过延长旧 Token 模拟。新 Token 对已有多端会话的影响需由会话索引和设备策略显式处理。
+- APP 当前替换旧 Token 的行为可保留，但签发与删除必须由 Session Store 完成。
+
+### 4. 新 Token 的会话索引
+
+为每个 UID 维护可过期的会话索引，覆盖所有新签发路径，而不再把三个
+`UIDToken:<flag><uid>` 当作完整清单。索引要求：
+
+- 不写日志、指标或迁移输出中的 Token 明文。
+- 成员随 Token 到期清理；读取时清除过期成员。
+- 有明确的单用户会话上限，防止索引无界增长。
+- 索引可使用按 `expires_at` 排序的集合，key 自身到期时间对齐最晚成员；任何读取/写入都先清理过期成员。具体 key/hash-tag 方案必须在生产拓扑确认后定稿。
+- 新 Token key 成功但索引/IM 更新失败时执行针对新 credential 的补偿；复用旧 Token 走前述不同的补偿语义。
+- `UIDToken` 在兼容期保留给旧逻辑；最终是否移除另行决定。
+
+会话索引只保证新 writer 产生的 Token 可枚举，不能让历史孤儿 Token 自动可撤销。兼容期 `RevokeAll` 还必须写 per-UID legacy deny marker；在全局 `v1/v2=0` 并进入 enforce 前不得自动过期，validator 对该 UID 的 v1/v2 一律拒绝。该 marker 不是 credential，可以在 enforce 后安全清理。否则密码重置或账号禁用发生在迁移窗口时，未被 `UIDToken` 索引覆盖的旧 Token 会在 marker 过期后重新有效。
+
+### 5. 撤销矩阵
+
+| 事件 | HTTP Token 目标 | WuKongIM | 备注 |
+| --- | --- | --- | --- |
+| 当前设备退出 | 当前 Token | 当前设备 | 先撤 HTTP Token；IM 失败不能让 bearer 继续有效 |
+| OIDC logout（保持现状） | 当前 Token | 当前实现踢全部设备 | 同时吊销该 UID 全部未吊销 IdP RT；保持 RP-Initiated Logout 响应契约 |
+| PC/Web 退出 | 对应 device flag 的全部会话 | 对应设备 | 不能只发 CMD |
+| 全部设备退出 | UID 全部会话 | `device_flag=-1` | Redis 与 IM 分别计结果 |
+| 用户主动修改密码 | 默认撤销全部会话 | 全部设备 | 客户端收到成功后重新登录；若要保留当前会话需产品明确批准 |
+| 忘记密码/管理员重置密码 | 撤销全部会话 | 全部设备 | 无条件执行 |
+| 账号禁用/最终注销 | 撤销全部会话 | 全部设备 | 状态落库与撤销失败要有可重试任务/告警 |
+| 账号解禁 | 不恢复旧会话 | 无 | 必须重新登录 |
+| 管理员降权/删除 | 角色缓存立即失效；必要时撤销管理会话 | 按现状 | 保留 RoleResolver 的实时降权防线 |
+| OIDC sync 确认真实 `invalid_grant` | 默认撤销 UID 全部会话 | 全部设备 | 延续当前“踢全部 IM”的安全意图；是否收窄需产品/安全明确批准 |
+| 昵称/语言变化 | 不撤销，仅更新 payload 且保留 deadline | 无 | 不得续期 |
+
+设备删除在 v3 payload/索引具备 `device_id` 后才能精确撤销；在此之前宁可撤销该设备类型或全部会话，不得声称已完成设备级吊销。
+
+高风险事件与登录签发必须覆盖并发竞态：事件开始前已经通过旧密码校验、但事件后才提交的 Token 不能存活。若不采用 generation/CAS，就必须给出等价的 per-UID 串行化方案及 Redis 故障时的 fail-closed 语义。涉及 DB 状态变更（密码、禁用、注销）时，撤销失败不能只写日志后丢失；需要持久化重试事件/告警，并明确“安全优先导致额外登出”可接受，“状态已变更但旧 bearer 无界有效”不可接受。
+
+### 6. 历史 Token 迁移
+
+提供显式运维工具/Job，不在每个副本启动时无锁全量 `SCAN`。扫描必须读取运行时配置的 `TokenCachePrefix` / `UIDTokenCachePrefix`，默认示例分别为 `token:*` / `uidtoken:*`，不能硬编码大小写或假设生产未改前缀：
+
+1. `observe`：只读扫描配置前缀，仅输出总数、`missing / persistent / finite / over_max / decode_invalid / v1 / v2 / v3` 聚合，不输出 key、Token 或 payload。`UIDToken` 只用于一致性统计，不能据此推导完整会话数。
+2. `apply`：游标可续跑、批量限速、分布式单执行者；对永久 key 设置一次 legacy grace TTL（建议 7 天），对超过最大寿命的有限 TTL 做上限收敛；重复执行幂等且绝不延长现有 TTL。
+3. `enforce`：确认旧副本已全部退出、writer 已全部切 v3、`persistent=0` 且实际 `v1/v2=0` 后，认证拒绝所有 legacy payload；v3 的永久 key和过期/generation 不匹配 payload 从 v3 validator 上线起即拒绝。
+
+无法从 v1/v2 payload 推导真实签发时间，因此不能伪造 `issued_at`。legacy grace 只用于平滑退出，不能被刷新、资料更新或重复迁移延长。
+
+只给永久 legacy key 设置 7 天 grace 时，原本具有正常有限 TTL 的 v1/v2 最长仍可能存活一个 `TokenExpire` 窗口，因此不能仅观察 7 天就 enforce。若业务要求 7 天后统一拒绝 legacy，`apply` 必须显式把**所有** v1/v2 TTL 收敛到 `min(current_ttl, 7d)`，并在执行前评估重新登录影响；否则应等待 observe 证明 v1/v2 自然清零。
+
+### 7. 混版兼容与发布顺序
+
+v3 是新的 cache value 格式，当前旧二进制不能解码。必须采用 expand/activate 两阶段发布；Release A/B 是运行模式，不强行等同于 PR 1/PR 2：
+
+1. Release A（expand）：所有 parser/显式 Token 入口统一走 validator；validator 能解码 v3，并对任何读到的 v3 强制校验 `PTTL`、`expires_at` 和 generation。完整 v3 writer/index/generation 能力随制品上线但由开关保持关闭，线上 writer 继续写 v2；TTL 保留、原始配置校验、指标和 migration observe 生效，legacy 暂按兼容模式读取。
+2. 淘汰全部 Release A 之前的副本，确认回滚制品能解码/校验 v3，并能在回滚时继续以 v3 模式写入。
+3. Release B：writer 切 v3，启用新会话索引、generation/CAS 和完整撤销；随后执行 legacy apply。
+4. 确认 `persistent=0`，并按选定策略等待 v1/v2 实际清零（自然等待最长有限 TTL，或事先批准后统一压到 grace），同时观察错误率和重新登录率，再进入 enforce。
+
+旧副本仍存活时不得执行 apply/enforce：它仍可能通过昵称更新重新制造永久 key。Release B 不能回滚到不识别 v3 的旧制品，只能回滚到 Release A。
+
+### 8. 建议交付拆分
+
+- PR 1（立即止血）：原始 TTL 配置校验及错误示例修正、Session Store 的 v2 writer、昵称/重复登录保留 deadline、所有签发路径收口、统一 validator（含 v3 前向解码和 v3 时间校验）、指标及 migration observe。该 PR 不改变客户端协议，也不开始批量过期历史 Token。
+- PR 2（expand 能力）：实现受开关保护的 v3 writer、generation/CAS、per-UID/device 会话索引、撤销矩阵及 migration apply/enforce 能力；先以 Release A 模式部署并清零旧副本，再通过配置进入 Release B，不能在代码首次出现时同时切 writer。
+- 运维变更：旧副本清零确认、生产只读盘点、限速 apply、grace 观察和 enforce；每一步有独立 go/no-go 与回滚检查。
+- 跨端后续：若 30 天仍不满足目标，再设计短 Access Token + 单次旋转 Refresh Token；不阻塞前两项服务端整改。
+
+## Load-bearing list
+
+- `auth`：opaque Token cache 格式、AuthMiddleware parser、直接 Token 验证入口和反枚举错误语义。
+- `wire-contract`：客户端仍使用现有 `token` header；过期/撤销继续呈现统一的未认证响应，不泄露具体原因。
+- Redis：Token payload、TTL、`UIDToken` 兼容索引、新 per-UID 会话索引、Lua 原子性和 Cluster key-slot 约束。
+- 所有签发入口：普通/username/email 登录、GitHub/Gitee/OIDC、扫码、设备验证、注册和 manager 登录。
+- 多设备行为：APP 替换、Web/PC 复用、扫码登录复用以及并发 logout/login 的“不复活”保证。
+- 高风险账号事件：当前/全部退出、密码修改/重置、账号禁用/注销、管理员降权。
+- WuKongIM：HTTP Token 撤销与 IM device quit 是两个独立结果，不能互相替代。
+- 生产迁移：历史永久 Token、旧 v1/v2 cache value、混版副本、灰度、回滚和限速。
+- 可观测性：不得记录 bearer/token key/value；指标 label 不含 uid/token。
+
+## Out of scope
+
+- 本任务不设计新的客户端 Refresh Token 协议、Access Token 静默刷新或 Refresh Token 重放族检测；这需要 Web/iOS/Android 联合 brief。
+- 本任务不实现按“每次 API 活动”滑动的空闲超时；绝对到期先落地，避免每请求写 Redis。
+- 不改变 OIDC Provider 自己的 access/refresh/id_token 生命周期；这里只处理 octo-server 用户会话。OIDC logout 现有 IdP RT 吊销继续保留。
+- 不处理 Bot token、App Bot token、User API Key、Webhook secret、短信/扫码一次性凭据等其他 credential 类型。
+- 不修改客户端 Token header、登录响应字段或错误 envelope。
+- 未完成生产只读核查前，不在文档中宣称生产 TTL、永久 Token 数量或影响用户数。
+
+## Observability and operations
+
+- Counter：签发/更新/撤销按 `operation,outcome`；认证拒绝按低基数 `reason`；legacy permanent 检测与修复数量。
+- Gauge：迁移最近一次扫描的 `persistent / over_max / legacy` 剩余量；不得以 token/uid 为 label。
+- Histogram：Redis Session Store 操作时延、迁移批次时延；不记录 key。
+- Alert：enforce 后仍检测到 permanent Token、新签发出现无 TTL、撤销连续失败、认证错误率/重新登录率突增。
+- 审计日志只记录事件类型、匿名/哈希化主体标识、device flag、结果和 trace id；禁止 Token 明文及完整 Redis key。
+- 运维 Runbook 必须包含 dry-run、批大小/速率、暂停/续跑、验证查询、混版检查、回滚制品和用户沟通门槛。
+
+## Rollback
+
+- Release B 只允许回滚到能解码并校验 v3、且保留 v3 writer 能力的 Release A 制品；禁止回滚到当前 main 版本。
+- 回滚代码不回滚已收紧的 TTL，不把 key 恢复为永久；已过期 Token 通过重新登录恢复，不能“复活”。
+- legacy apply 可暂停/续跑，但回滚不延长已经设置的 TTL；需要改变 grace 时只能对尚未处理的 key 使用新策略，不能按重试时间给已处理 key 续期。
+- enforce 如引发异常，可退回“接受具有有限 TTL 且未命中 legacy deny marker 的 v1/v2”兼容模式；永久 key和 `expires_at` 已过期/generation 不匹配的 v3 在任何回滚模式下仍拒绝。Release B 激活后即使回滚到 Release A 制品也必须保持 v3 writer 开关开启，不能重新制造 v2；若 v3 签发本身故障，应暂停新签发并修复，不能用恢复 legacy writer 绕过。
+- Redis/IM/DB 任一撤销链路失败必须保留可重试记录和告警；不得仅返回成功后丢失失败事件。
+
+## Acceptance
+
+- 真实 Redis 集成测试证明：新登录 Token TTL `> 0` 且 `<= configured max`；改昵称前后 TTL 不增加，绝不会从有限值变为 `-1`。
+- 配置测试证明合法的 `cache.tokenExpire` 和 `TS_CACHE_TOKENEXPIRE`（例如 `48h`）能覆盖默认 720h，且 env 优先；`30d`、无单位数字、其他 malformed 值、零值、负值或超过硬上限配置均在启动期 fail loudly，不能静默回退默认值。
+- payload v3 被人工放入永久 Redis key 时，无论 `expires_at` 是否仍有效都因 `PTTL=-1` 被拒；有限 TTL key 中 `expires_at <= now` 或 generation 不匹配的 v3 仍被所有认证/verify/辅助入口拒绝。
+- Web/PC/扫码复用旧 Token 时以 `PTTL + SET PX` 保留原 deadline；并发 logout 后不得复活 Token。
+- 所有生产 Token writer 通过 Session Store；源码守卫禁止业务代码直接对 `TokenCachePrefix` / `UIDTokenCachePrefix` 执行 `Set` / `SetAndExpire`。
+- 普通、username/email、GitHub/Gitee/OIDC、扫码、设备验证、注册、manager 登录均有测试证明签发有限 TTL，并正确进入会话索引。
+- 故障注入覆盖 Token/index/UIDToken/IM 每一步失败：新签发失败无可用孤儿 credential，复用失败不误删登录前已有效的旧 Token。
+- 当前退出、全部退出、密码修改、各类密码重置、禁用和注销按撤销矩阵测试；旧 Token 随后访问返回统一未认证响应。
+- 并发测试证明旧密码校验与密码修改/重置竞态时，安全事件前开始、事件后才提交的会话不能存活；v3 索引缺失时 `RevokeAll` 仍通过 generation 立即失效 Token，legacy 孤儿则由 deny marker 阻断。
+- OIDC logout 继续撤当前 HTTP Token、吊销该 UID 全部未吊销 IdP RT、踢全部 IM 设备，并保持现有 best-effort/RP-Initiated Logout 响应行为。
+- legacy 迁移工具 dry-run 不写 Redis、不输出秘密；apply 可中断续跑、幂等且不延长 TTL；测试覆盖 `TTL=-2/-1/>max/normal`。
+- 混版测试证明 Release A 能读取 v2/v3，Release B 写 v3；发布检查能阻止旧副本存活时进入 enforce。
+- 迁移完成后按配置的 Token 前缀扫描：`persistent=0`、`over_max=0`、`v1/v2=0`；enforce 期间新增这些类型会触发告警。
+- Redis 不可用或 payload/TTL 不合法时认证 fail closed，且保持现有 i18n/anti-enumeration wire contract。
+- 相关测试至少覆盖 `pkg/auth`、`modules/user`、`modules/oidc`；运行 focused tests、`go test ./...`、`make i18n-extract-check`、`make i18n-lint` 和 lint。
+
+## Decisions required before implementation
+
+- Access Token 服务端硬上限：复用现有 `cache.tokenExpire` / `TS_CACHE_TOKENEXPIRE`，建议最大 30 天；若要更短，需要同步确认客户端重新登录体验。
+- legacy grace：建议 7 天；生产 permanent 数量和活跃率核查后再定。
+- legacy finite 策略：等待最长有限 TTL 自然清零，还是把全部 v1/v2 一次性压到 grace；后者会扩大重新登录影响，必须单独 go/no-go。
+- 用户主动修改密码后：建议撤销包含当前设备在内的全部会话。
+- 设备级会话上限及 Web/PC 多登策略。
+- 生产 Redis 拓扑（standalone/sentinel/cluster）与可接受的迁移 QPS。
+- OIDC logout 当前“当前 HTTP + 全部 IdP RT + 全部 IM 设备”的既有语义是否原样保留；本 brief 默认保留，不擅自收窄。
+- `/v1/user/quit`、`/v1/user/pc/quit` 与设备删除分别对应“当前 Token、设备类型还是全部会话”；在接口语义确认前按更安全的扩大撤销处理，不能声称已实现精确设备撤销。
+- OIDC sync 的真实 `invalid_grant` 是否继续按当前安全意图撤销该 UID 全部本地会话；本 brief 默认撤销全部。
+- Refresh Token/空闲超时是否另开跨端任务；不得用无限滑动 TTL 替代正式决定。

--- a/.octospec/tasks/token-lifecycle-hardening/context.yaml
+++ b/.octospec/tasks/token-lifecycle-hardening/context.yaml
@@ -1,0 +1,62 @@
+# Rules resolved for this task (octospec Implement phase).
+slug: token-lifecycle-hardening
+resolved_at: 2026-08-09T18:42:28+08:00
+
+rules_injected:
+  - id: space-isolation
+    tier: repo
+    load_bearing: true
+    why: >
+      Authentication validity is a tenant boundary. All HTTP-token readers now
+      share one validator and fail closed for malformed or invalid v3 session
+      state without changing the existing unauthenticated wire response.
+    applied:
+      - Explicit token readers in group, message, qrcode, user, and auth routes
+        use the canonical validator instead of decoding Redis values directly.
+      - Session state is shared through Redis and coordinated atomically rather
+        than through process-local locks, so replicas cannot resurrect a bearer
+        deleted by a concurrent logout.
+  - id: error-handling
+    tier: repo
+    load_bearing: true
+    why: >
+      Token expiry and Redis failures are authentication failures whose public
+      response must retain the existing anti-enumeration and i18n contract.
+    applied:
+      - No new raw error responses or reason-specific authentication details
+        were exposed to clients.
+      - Infrastructure and validation reasons remain bounded internal metrics;
+        i18n extraction and direct-response lint stay clean.
+  - id: rate-limit
+    tier: repo
+    load_bearing: true
+    why: >
+      Internal and module files are touched, but this task does not add or move
+      routes or request-frequency policies.
+    applied:
+      - Existing global, strict-IP, and shared-UID middleware placement is
+        unchanged.
+      - Migration observation is an explicit rate-limited operator process and
+        does not run inside API replicas.
+  - id: testing
+    tier: repo
+    load_bearing: false
+    applied:
+      - Real Redis tests cover finite TTL, atomic read/update, concurrent logout,
+        failure compensation, v3 downgrade prevention, and read-only observation.
+      - HTTP tests use isolated temporary databases and verify login TTL plus
+        nickname-update deadline preservation.
+      - Source guards prevent production readers/writers from bypassing the
+        canonical auth boundary.
+  - id: commit-style
+    tier: repo
+    load_bearing: false
+    applied:
+      - Commits use English Conventional Commit subjects; PR content is English.
+
+notes:
+  - This is PR 1 of 2. It stops new or touched credentials from becoming
+    unbounded but intentionally does not bulk-expire historical persistent v1/v2
+    sessions.
+  - PR 2 owns v3 activation, generation/session indexes, the revocation matrix,
+    migration apply/enforce, and the associated go/no-go gates.

--- a/configs/tsdd.yaml
+++ b/configs/tsdd.yaml
@@ -250,7 +250,7 @@ smsCode: "123456" # 测试短信验证码， 如果不为空，则短信验证�
 # #################### 缓存配置 ####################
 #cache:
 #  tokenCachePrefix: "token:" # token缓存前缀
-#  tokenExpire: 30d # token过期时间
+#  tokenExpire: 720h # token过期时间；Go duration 不支持 30d
 #  loginDeviceCachePrefix: "login_device:" # 登录设备缓存前缀
 #  loginDeviceCacheExpire: 5m # 登录设备缓存过期时间
 #  uidTokenCachePrefix: "uidtoken:" # uid和token的缓存前缀

--- a/internal/tokenlifecycle/config.go
+++ b/internal/tokenlifecycle/config.go
@@ -2,6 +2,7 @@ package tokenlifecycle
 
 import (
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -15,9 +16,10 @@ const MaxTokenExpire = 720 * time.Hour
 // default. Only an actually absent key receives the 720h default.
 func ValidateTokenExpire(vp *viper.Viper) (time.Duration, error) {
 	const key = "cache.tokenExpire"
-	// An explicitly present but empty TS_CACHE_TOKENEXPIRE must not be treated
-	// as absent and silently fall back to 720h.
-	vp.AllowEmptyEnv(true)
+	const envKey = "TS_CACHE_TOKENEXPIRE"
+	if value, ok := os.LookupEnv(envKey); ok {
+		return parseTokenExpire(strings.TrimSpace(value), envKey)
+	}
 	if !vp.IsSet(key) {
 		return MaxTokenExpire, nil
 	}
@@ -26,16 +28,19 @@ func ValidateTokenExpire(vp *viper.Viper) (time.Duration, error) {
 	if !ok {
 		return 0, fmt.Errorf("%s must be a duration string with a Go unit, got %T", key, raw)
 	}
-	value = strings.TrimSpace(value)
+	return parseTokenExpire(strings.TrimSpace(value), key)
+}
+
+func parseTokenExpire(value, source string) (time.Duration, error) {
 	duration, err := time.ParseDuration(value)
 	if err != nil {
-		return 0, fmt.Errorf("invalid %s %q: %w", key, value, err)
+		return 0, fmt.Errorf("invalid %s %q: %w", source, value, err)
 	}
 	if duration <= 0 {
-		return 0, fmt.Errorf("%s must be greater than zero", key)
+		return 0, fmt.Errorf("%s must be greater than zero", source)
 	}
 	if duration > MaxTokenExpire {
-		return 0, fmt.Errorf("%s must not exceed %s", key, MaxTokenExpire)
+		return 0, fmt.Errorf("%s must not exceed %s", source, MaxTokenExpire)
 	}
 	return duration, nil
 }

--- a/internal/tokenlifecycle/config.go
+++ b/internal/tokenlifecycle/config.go
@@ -39,6 +39,12 @@ func parseTokenExpire(value, source string) (time.Duration, error) {
 	if duration <= 0 {
 		return 0, fmt.Errorf("%s must be greater than zero", source)
 	}
+	// Redis PX and the Session Store Lua contract represent deadlines in whole
+	// milliseconds. Accepting a smaller duration would pass startup validation
+	// but become PX 0 at write time, making every token write fail at runtime.
+	if duration < time.Millisecond {
+		return 0, fmt.Errorf("%s must be at least %s", source, time.Millisecond)
+	}
 	if duration > MaxTokenExpire {
 		return 0, fmt.Errorf("%s must not exceed %s", source, MaxTokenExpire)
 	}

--- a/internal/tokenlifecycle/config.go
+++ b/internal/tokenlifecycle/config.go
@@ -1,0 +1,38 @@
+package tokenlifecycle
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/spf13/viper"
+)
+
+const MaxTokenExpire = 720 * time.Hour
+
+// ValidateTokenExpire validates Viper's raw post-env-override value before
+// octo-lib GetDuration can silently replace an invalid explicit value with its
+// default. Only an actually absent key receives the 720h default.
+func ValidateTokenExpire(vp *viper.Viper) (time.Duration, error) {
+	const key = "cache.tokenExpire"
+	if !vp.IsSet(key) {
+		return MaxTokenExpire, nil
+	}
+	raw := vp.Get(key)
+	value, ok := raw.(string)
+	if !ok {
+		return 0, fmt.Errorf("%s must be a duration string with a Go unit, got %T", key, raw)
+	}
+	value = strings.TrimSpace(value)
+	duration, err := time.ParseDuration(value)
+	if err != nil {
+		return 0, fmt.Errorf("invalid %s %q: %w", key, value, err)
+	}
+	if duration <= 0 {
+		return 0, fmt.Errorf("%s must be greater than zero", key)
+	}
+	if duration > MaxTokenExpire {
+		return 0, fmt.Errorf("%s must not exceed %s", key, MaxTokenExpire)
+	}
+	return duration, nil
+}

--- a/internal/tokenlifecycle/config.go
+++ b/internal/tokenlifecycle/config.go
@@ -15,6 +15,9 @@ const MaxTokenExpire = 720 * time.Hour
 // default. Only an actually absent key receives the 720h default.
 func ValidateTokenExpire(vp *viper.Viper) (time.Duration, error) {
 	const key = "cache.tokenExpire"
+	// An explicitly present but empty TS_CACHE_TOKENEXPIRE must not be treated
+	// as absent and silently fall back to 720h.
+	vp.AllowEmptyEnv(true)
 	if !vp.IsSet(key) {
 		return MaxTokenExpire, nil
 	}

--- a/main.go
+++ b/main.go
@@ -23,6 +23,7 @@ import (
 	_ "github.com/Mininglamp-OSS/octo-server/internal"
 	"github.com/Mininglamp-OSS/octo-server/internal/cardactiondispatch"
 	"github.com/Mininglamp-OSS/octo-server/internal/carddispatch"
+	"github.com/Mininglamp-OSS/octo-server/internal/tokenlifecycle"
 	commonapi "github.com/Mininglamp-OSS/octo-server/modules/base/common"
 	"github.com/Mininglamp-OSS/octo-server/modules/base/event"
 	"github.com/Mininglamp-OSS/octo-server/modules/bot_api"
@@ -103,6 +104,10 @@ func loadConfigFromFile(cfgFile string) *viper.Viper {
 	return vp
 }
 
+func validateTokenExpireConfig(vp *viper.Viper) (time.Duration, error) {
+	return tokenlifecycle.ValidateTokenExpire(vp)
+}
+
 func main() {
 	var CfgFile string //config file
 	flag.StringVar(&CfgFile, "config", "configs/tsdd.yaml", "config file")
@@ -111,12 +116,18 @@ func main() {
 	vp.SetEnvPrefix("TS")
 	vp.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
 	vp.AutomaticEnv()
+	tokenExpire, err := validateTokenExpireConfig(vp)
+	if err != nil {
+		panic(err)
+	}
 
 	gin.SetMode(gin.ReleaseMode)
 
 	cfg := config.New()
 	cfg.Version = Version
 	cfg.ConfigureWithViper(vp)
+	cfg.Cache.TokenExpire = tokenExpire
+	fmt.Println("Effective access token TTL:", cfg.Cache.TokenExpire)
 
 	// 安全校验：release 模式下禁止配置 smsCode（万能验证码后门）
 	if err := commonapi.ValidateTestCodeConfig(cfg); err != nil {
@@ -174,9 +185,11 @@ func runAPI(ctx *config.Context) {
 	// 角色（user_role:{uid} 热缓存 → DB），把降权生效窗口收敛到缓存 TTL。
 	userLangSvc := user.NewLanguageService(user.NewDB(ctx), ctx.Cache())
 	userRoleSvc := user.NewRoleService(user.NewDB(ctx), ctx.Cache())
+	tokenStore := auth.SessionStoreForContext(ctx)
 	route.SetTokenParser(auth.NewCacheTokenParser(
 		ctx.Cache(),
 		ctx.GetConfig().Cache.TokenCachePrefix,
+		auth.WithTokenValidator(auth.NewTokenValidator(tokenStore, ctx.GetConfig().Cache.TokenCachePrefix)),
 		auth.WithLanguageResolver(userLangSvc),
 		auth.WithRoleResolver(userRoleSvc),
 	))
@@ -257,6 +270,8 @@ func runAPI(ctx *config.Context) {
 	// singleflight 合并 / 304。由 modules/user 的 avatarCache 经包级 Observe 函数灌入;
 	// 此处注册即可,未注册前这些 Observe 为 no-op,不影响已构造的 cache。
 	metrics.NewAvatarMetrics(prometheus.DefaultRegisterer)
+	metrics.NewSessionMetrics(prometheus.DefaultRegisterer)
+	metrics.SetSessionEffectiveTTL(ctx.GetConfig().Cache.TokenExpire)
 	// 自定义贴纸 handle 上线观测指标(P0: Sticker Handle Enforcement Rollout):上传签发
 	// handle 次数 / 注册结果分布 / 部署姿态 gauge。由 modules/file(签发) 与
 	// modules/sticker(注册) 经包级 Observe 函数灌入;此处注册即可,未注册前为 no-op。

--- a/main.go
+++ b/main.go
@@ -185,7 +185,13 @@ func runAPI(ctx *config.Context) {
 	// 角色（user_role:{uid} 热缓存 → DB），把降权生效窗口收敛到缓存 TTL。
 	userLangSvc := user.NewLanguageService(user.NewDB(ctx), ctx.Cache())
 	userRoleSvc := user.NewRoleService(user.NewDB(ctx), ctx.Cache())
-	tokenStore := auth.SessionStoreForContext(ctx)
+	tokenStore, sessionRedis := auth.SessionStoreAndClientForContext(ctx)
+	probeCtx, probeCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	if err := tokenStore.Probe(probeCtx); err != nil {
+		probeCancel()
+		panic(fmt.Errorf("verify authentication session Redis Lua support: %w", err))
+	}
+	probeCancel()
 	route.SetTokenParser(auth.NewCacheTokenParser(
 		ctx.Cache(),
 		ctx.GetConfig().Cache.TokenCachePrefix,
@@ -391,6 +397,7 @@ func runAPI(ctx *config.Context) {
 	libredis.SetRedisObserver(metrics.ObserveRedisCmd)
 	metrics.RegisterPoolCollectors(prometheus.DefaultRegisterer, ctx.DB().DB, map[string]*rd.Client{
 		"ratelimit":            rlRedis,
+		"session":              sessionRedis,
 		"card_action_dispatch": cardActionRuntime.redisClient,
 	})
 	// 在所有指标族注册完成后再起 scrape 端点,避免启动窗口内的 scrape 漏掉

--- a/main_test.go
+++ b/main_test.go
@@ -2,6 +2,9 @@ package main
 
 import (
 	"bytes"
+	"go/ast"
+	"go/parser"
+	"go/token"
 	"os"
 	"regexp"
 	"sort"
@@ -21,13 +24,15 @@ func TestValidateTokenExpireConfig(t *testing.T) {
 		name    string
 		yaml    string
 		env     string
+		envSet  bool
 		want    time.Duration
 		wantErr bool
 	}{
 		{name: "default", want: 720 * time.Hour},
 		{name: "yaml override", yaml: "cache:\n  tokenExpire: 48h\n", want: 48 * time.Hour},
-		{name: "env overrides yaml", yaml: "cache:\n  tokenExpire: 48h\n", env: "24h", want: 24 * time.Hour},
-		{name: "invalid env does not fall back to yaml", yaml: "cache:\n  tokenExpire: 48h\n", env: "30d", wantErr: true},
+		{name: "env overrides yaml", yaml: "cache:\n  tokenExpire: 48h\n", env: "24h", envSet: true, want: 24 * time.Hour},
+		{name: "empty env does not fall back to yaml", yaml: "cache:\n  tokenExpire: 48h\n", envSet: true, wantErr: true},
+		{name: "invalid env does not fall back to yaml", yaml: "cache:\n  tokenExpire: 48h\n", env: "30d", envSet: true, wantErr: true},
 		{name: "day suffix unsupported", yaml: "cache:\n  tokenExpire: 30d\n", wantErr: true},
 		{name: "bare number unsupported", yaml: "cache:\n  tokenExpire: 24\n", wantErr: true},
 		{name: "malformed", yaml: "cache:\n  tokenExpire: tomorrow\n", wantErr: true},
@@ -38,6 +43,15 @@ func TestValidateTokenExpireConfig(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			old, existed := os.LookupEnv("TS_CACHE_TOKENEXPIRE")
+			require.NoError(t, os.Unsetenv("TS_CACHE_TOKENEXPIRE"))
+			t.Cleanup(func() {
+				if existed {
+					_ = os.Setenv("TS_CACHE_TOKENEXPIRE", old)
+					return
+				}
+				_ = os.Unsetenv("TS_CACHE_TOKENEXPIRE")
+			})
 			vp := viper.New()
 			if tt.yaml != "" {
 				vp.SetConfigType("yaml")
@@ -46,7 +60,9 @@ func TestValidateTokenExpireConfig(t *testing.T) {
 			vp.SetEnvPrefix("TS")
 			vp.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
 			vp.AutomaticEnv()
-			t.Setenv("TS_CACHE_TOKENEXPIRE", tt.env)
+			if tt.envSet {
+				t.Setenv("TS_CACHE_TOKENEXPIRE", tt.env)
+			}
 
 			got, err := validateTokenExpireConfig(vp)
 			if tt.wantErr {
@@ -57,6 +73,44 @@ func TestValidateTokenExpireConfig(t *testing.T) {
 			require.Equal(t, tt.want, got)
 		})
 	}
+}
+
+func TestRunAPIRegistersSessionRedisPool(t *testing.T) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "main.go", nil, 0)
+	require.NoError(t, err)
+
+	foundRegistration := false
+	foundSession := false
+	ast.Inspect(file, func(node ast.Node) bool {
+		call, ok := node.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		selector, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok || selector.Sel.Name != "RegisterPoolCollectors" || len(call.Args) < 3 {
+			return true
+		}
+		foundRegistration = true
+		clients, ok := call.Args[2].(*ast.CompositeLit)
+		if !ok {
+			return true
+		}
+		for _, element := range clients.Elts {
+			pair, ok := element.(*ast.KeyValueExpr)
+			if !ok {
+				continue
+			}
+			key, ok := pair.Key.(*ast.BasicLit)
+			if ok && key.Value == `"session"` {
+				foundSession = true
+			}
+		}
+		return true
+	})
+
+	require.True(t, foundRegistration, "main must register Redis pool collectors")
+	require.True(t, foundSession, "the shared authentication session pool must be observable")
 }
 
 func TestGlobalRateLimitExcludePathsIncludesProbeEndpoints(t *testing.T) {

--- a/main_test.go
+++ b/main_test.go
@@ -39,6 +39,8 @@ func TestValidateTokenExpireConfig(t *testing.T) {
 		{name: "malformed", yaml: "cache:\n  tokenExpire: tomorrow\n", wantErr: true},
 		{name: "zero", yaml: "cache:\n  tokenExpire: 0s\n", wantErr: true},
 		{name: "negative", yaml: "cache:\n  tokenExpire: -1h\n", wantErr: true},
+		{name: "sub-millisecond", yaml: "cache:\n  tokenExpire: 1us\n", wantErr: true},
+		{name: "one millisecond", yaml: "cache:\n  tokenExpire: 1ms\n", want: time.Millisecond},
 		{name: "over hard limit", yaml: "cache:\n  tokenExpire: 721h\n", wantErr: true},
 	}
 

--- a/main_test.go
+++ b/main_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl"
 	aireasoningprocess "github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl/ai_reasoning_process"
 	"github.com/prometheus/client_golang/prometheus"
@@ -73,6 +74,31 @@ func TestValidateTokenExpireConfig(t *testing.T) {
 			require.Equal(t, tt.want, got)
 		})
 	}
+}
+
+func TestValidateTokenExpireConfigDoesNotChangeOtherEmptyEnvSemantics(t *testing.T) {
+	const yamlConfig = `
+db:
+  mysqlAddr: produser:prodpass@tcp(prod-mysql:3306)/prod
+  redisTLS: true
+`
+
+	vp := viper.New()
+	vp.SetConfigType("yaml")
+	require.NoError(t, vp.ReadConfig(bytes.NewBufferString(yamlConfig)))
+	vp.SetEnvPrefix("TS")
+	vp.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
+	vp.AutomaticEnv()
+	t.Setenv("TS_DB_MYSQLADDR", "")
+	t.Setenv("TS_DB_REDISTLS", "")
+
+	_, err := validateTokenExpireConfig(vp)
+	require.NoError(t, err)
+
+	cfg := config.New()
+	cfg.ConfigureWithViper(vp)
+	require.Equal(t, "produser:prodpass@tcp(prod-mysql:3306)/prod", cfg.DB.MySQLAddr)
+	require.True(t, cfg.DB.RedisTLS)
 }
 
 func TestRunAPIRegistersSessionRedisPool(t *testing.T) {

--- a/main_test.go
+++ b/main_test.go
@@ -27,6 +27,7 @@ func TestValidateTokenExpireConfig(t *testing.T) {
 		{name: "default", want: 720 * time.Hour},
 		{name: "yaml override", yaml: "cache:\n  tokenExpire: 48h\n", want: 48 * time.Hour},
 		{name: "env overrides yaml", yaml: "cache:\n  tokenExpire: 48h\n", env: "24h", want: 24 * time.Hour},
+		{name: "invalid env does not fall back to yaml", yaml: "cache:\n  tokenExpire: 48h\n", env: "30d", wantErr: true},
 		{name: "day suffix unsupported", yaml: "cache:\n  tokenExpire: 30d\n", wantErr: true},
 		{name: "bare number unsupported", yaml: "cache:\n  tokenExpire: 24\n", wantErr: true},
 		{name: "malformed", yaml: "cache:\n  tokenExpire: tomorrow\n", wantErr: true},
@@ -45,9 +46,7 @@ func TestValidateTokenExpireConfig(t *testing.T) {
 			vp.SetEnvPrefix("TS")
 			vp.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
 			vp.AutomaticEnv()
-			if tt.env != "" {
-				t.Setenv("TS_CACHE_TOKENEXPIRE", tt.env)
-			}
+			t.Setenv("TS_CACHE_TOKENEXPIRE", tt.env)
 
 			got, err := validateTokenExpireConfig(vp)
 			if tt.wantErr {

--- a/main_test.go
+++ b/main_test.go
@@ -113,6 +113,41 @@ func TestRunAPIRegistersSessionRedisPool(t *testing.T) {
 	require.True(t, foundSession, "the shared authentication session pool must be observable")
 }
 
+func TestRunAPIProbesSessionLuaBeforeInstallingTokenParser(t *testing.T) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "main.go", nil, 0)
+	require.NoError(t, err)
+
+	var probePosition, parserPosition token.Pos
+	for _, declaration := range file.Decls {
+		function, ok := declaration.(*ast.FuncDecl)
+		if !ok || function.Name.Name != "runAPI" {
+			continue
+		}
+		ast.Inspect(function.Body, func(node ast.Node) bool {
+			call, ok := node.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			selector, ok := call.Fun.(*ast.SelectorExpr)
+			if !ok {
+				return true
+			}
+			switch selector.Sel.Name {
+			case "Probe":
+				probePosition = call.Pos()
+			case "SetTokenParser":
+				parserPosition = call.Pos()
+			}
+			return true
+		})
+	}
+
+	require.NotZero(t, probePosition, "API startup must exercise the real session read Lua")
+	require.NotZero(t, parserPosition, "API startup must install the canonical token parser")
+	require.Less(t, probePosition, parserPosition, "Lua compatibility must be proven before authentication is installed")
+}
+
 func TestGlobalRateLimitExcludePathsIncludesProbeEndpoints(t *testing.T) {
 	paths := globalRateLimitExcludePaths()
 

--- a/main_test.go
+++ b/main_test.go
@@ -1,17 +1,64 @@
 package main
 
 import (
+	"bytes"
 	"os"
 	"regexp"
 	"sort"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl"
 	aireasoningprocess "github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl/ai_reasoning_process"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/require"
 )
+
+func TestValidateTokenExpireConfig(t *testing.T) {
+	tests := []struct {
+		name    string
+		yaml    string
+		env     string
+		want    time.Duration
+		wantErr bool
+	}{
+		{name: "default", want: 720 * time.Hour},
+		{name: "yaml override", yaml: "cache:\n  tokenExpire: 48h\n", want: 48 * time.Hour},
+		{name: "env overrides yaml", yaml: "cache:\n  tokenExpire: 48h\n", env: "24h", want: 24 * time.Hour},
+		{name: "day suffix unsupported", yaml: "cache:\n  tokenExpire: 30d\n", wantErr: true},
+		{name: "bare number unsupported", yaml: "cache:\n  tokenExpire: 24\n", wantErr: true},
+		{name: "malformed", yaml: "cache:\n  tokenExpire: tomorrow\n", wantErr: true},
+		{name: "zero", yaml: "cache:\n  tokenExpire: 0s\n", wantErr: true},
+		{name: "negative", yaml: "cache:\n  tokenExpire: -1h\n", wantErr: true},
+		{name: "over hard limit", yaml: "cache:\n  tokenExpire: 721h\n", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			vp := viper.New()
+			if tt.yaml != "" {
+				vp.SetConfigType("yaml")
+				require.NoError(t, vp.ReadConfig(bytes.NewBufferString(tt.yaml)))
+			}
+			vp.SetEnvPrefix("TS")
+			vp.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
+			vp.AutomaticEnv()
+			if tt.env != "" {
+				t.Setenv("TS_CACHE_TOKENEXPIRE", tt.env)
+			}
+
+			got, err := validateTokenExpireConfig(vp)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
 
 func TestGlobalRateLimitExcludePathsIncludesProbeEndpoints(t *testing.T) {
 	paths := globalRateLimitExcludePaths()

--- a/modules/group/api.go
+++ b/modules/group/api.go
@@ -48,12 +48,13 @@ import (
 type Group struct {
 	ctx *config.Context
 	log.Log
-	db            *DB
-	settingDB     *settingDB
-	userDB        *user.DB
-	groupService  IService
-	fileService   file.IService
-	commonService common2.IService
+	db             *DB
+	settingDB      *settingDB
+	userDB         *user.DB
+	groupService   IService
+	fileService    file.IService
+	commonService  common2.IService
+	tokenValidator *auth.TokenValidator
 	// welcomeStore backs the per-group 入群欢迎语 CRUD (task group-welcome-message).
 	welcomeStore *common2.GroupWelcomeConfigStore
 }
@@ -70,7 +71,11 @@ func New(ctx *config.Context) *Group {
 		groupService:  NewService(ctx),
 		fileService:   file.NewService(ctx),
 		commonService: common2.NewService(ctx),
-		welcomeStore:  common2.NewGroupWelcomeConfigStore(ctx.DB()),
+		tokenValidator: auth.NewTokenValidator(
+			auth.SessionStoreForContext(ctx),
+			ctx.GetConfig().Cache.TokenCachePrefix,
+		),
+		welcomeStore: common2.NewGroupWelcomeConfigStore(ctx.DB()),
 	}
 	g.ctx.AddEventListener(event.GroupDisband, g.handleGroupDisbandEvent)
 	g.ctx.AddEventListener(event.EventUserRegister, g.handleRegisterUserEvent)
@@ -4673,14 +4678,10 @@ func (g *Group) groupInviteDetail(c *wkhttp.Context) {
 	// 预览路径，不破坏未登录访问者的 external_blocked 硬拦截语义。
 	var loginUID string
 	if token := strings.TrimSpace(c.GetHeader("token")); token != "" {
-		raw, cacheErr := g.ctx.Cache().Get(g.ctx.GetConfig().Cache.TokenCachePrefix + token)
-		if cacheErr == nil && strings.TrimSpace(raw) != "" {
-			// AuthMiddleware 的 token value 由 pkg/auth 收口编解码：v2 JSON 或
-			// 灰度期残留的 "uid@name[@role]"。auth.Decode 返回 ErrInvalidToken
-			// 时安全降级为未登录访问者，沿用 external_blocked 硬拦截语义。
-			if info, decodeErr := auth.Decode(raw); decodeErr == nil {
-				loginUID = info.UID
-			}
+		// 可选鉴权失败安全降级为匿名访问者；唯一 validator 同时执行
+		// payload 版本、Redis PTTL 与 v3 绝对到期检查。
+		if info, validateErr := g.tokenValidator.Validate(c.Request.Context(), token); validateErr == nil {
+			loginUID = info.UID
 		}
 	}
 

--- a/modules/message/api.go
+++ b/modules/message/api.go
@@ -305,6 +305,7 @@ type Message struct {
 	// exercised by the matrix suite, so widening the seam there is
 	// deliberately deferred to keep the diff minimal.
 	reminderSeqOverride func() (int64, error)
+	tokenValidator      *auth.TokenValidator
 }
 
 // New New
@@ -339,6 +340,10 @@ func New(ctx *config.Context) *Message {
 		cardRevisions:  cardrevision.NewStore(ctx.DB()),
 		seqStore:       msgextraseq.New(ctx),
 		stopChan:       make(chan struct{}),
+		tokenValidator: auth.NewTokenValidator(
+			auth.SessionStoreForContext(ctx),
+			ctx.GetConfig().Cache.TokenCachePrefix,
+		),
 	}
 	m.ctx.AddEventListener(event.GroupMemberAdd, m.handleGroupMemberAddEvent)
 	m.ctx.AddEventListener(event.GroupMemberScanJoin, m.handleGroupMemberScanJoinEvent)
@@ -524,18 +529,13 @@ func (m *Message) sendMsg(c *wkhttp.Context) {
 		respondMessageRequestInvalid(c, "payload")
 		return
 	}
-	raw, err := m.ctx.Cache().Get(m.ctx.GetConfig().Cache.TokenCachePrefix + req.Token)
+	info, err := m.tokenValidator.Validate(c.Request.Context(), req.Token)
 	if err != nil {
 		m.Error("解析token错误", zap.Error(err))
-		respondMessageTokenInvalid(c)
-		return
-	}
-	if strings.TrimSpace(raw) == "" {
-		respondMessageNotLoggedIn(c)
-		return
-	}
-	info, decodeErr := auth.Decode(raw)
-	if decodeErr != nil {
+		if errors.Is(err, wkhttp.ErrTokenNotFound) {
+			respondMessageNotLoggedIn(c)
+			return
+		}
 		respondMessageTokenInvalid(c)
 		return
 	}

--- a/modules/qrcode/api.go
+++ b/modules/qrcode/api.go
@@ -15,7 +15,6 @@ import (
 	"github.com/Mininglamp-OSS/octo-server/modules/group"
 	spacemod "github.com/Mininglamp-OSS/octo-server/modules/space"
 	"github.com/Mininglamp-OSS/octo-server/modules/user"
-	"github.com/Mininglamp-OSS/octo-server/pkg/auth"
 	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
 	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
 	spacepkg "github.com/Mininglamp-OSS/octo-server/pkg/space"
@@ -69,22 +68,9 @@ func (q *QRCode) handleQRCodeInfo(c *wkhttp.Context) {
 		respondQRCodeTokenRequired(c)
 		return
 	}
-	raw, err := q.ctx.Cache().Get(q.ctx.GetConfig().Cache.TokenCachePrefix + token)
-	if err != nil {
-		q.Error("获取登录信息失败！", zap.Error(err))
-		httperr.ResponseErrorL(c, errcode.ErrQRCodeQueryFailed, nil, nil)
-		return
-	}
-	if strings.TrimSpace(raw) == "" {
-		c.String(http.StatusOK, fmt.Sprintf("请下载“%s”APP扫码！", q.ctx.GetConfig().AppName))
-		return
-	}
-	info, decodeErr := auth.Decode(raw)
-	if decodeErr != nil {
-		httperr.ResponseErrorL(c, errcode.ErrQRCodeTokenInvalid, nil, nil)
-		return
-	}
-	loginUID := info.UID
+	// Route 已经过统一 AuthMiddleware；直接复用中间件身份，避免再次走一套
+	// Cache.Get+Decode 而绕过 PTTL/绝对到期校验。
+	loginUID := c.GetLoginUID()
 	code := c.Param("code")
 
 	if strings.HasPrefix(code, "user_") { // 用户资料二维码 格式： user_xxxx

--- a/modules/user/api.go
+++ b/modules/user/api.go
@@ -115,30 +115,23 @@ type User struct {
 	loginGuard               *LoginGuard
 	verificationDB           *verificationDB
 	languageService          *LanguageService
-	existingTokenSetter      existingTokenSetter
+	sessionStore             userSessionStore
+	tokenValidator           *auth.TokenValidator
 	scanLoginAuthorizations  *scanLoginAuthorizationStore
 }
 
-type existingTokenSetter interface {
-	SetIfExists(key string, value string, expire time.Duration) (bool, error)
-}
-
-type redisExistingTokenSetter struct {
-	client *rd.Client
-}
-
-func (s redisExistingTokenSetter) SetIfExists(key string, value string, expire time.Duration) (bool, error) {
-	if s.client == nil {
-		return false, nil
-	}
-	return s.client.SetXX(key, value, expire).Result()
+type userSessionStore interface {
+	IssueNew(ctx context.Context, token, payload, uid string, deviceFlag int) error
+	ReuseExisting(ctx context.Context, token, payload, uid string, deviceFlag int) (bool, error)
+	UpdatePayloadKeepDeadline(ctx context.Context, token, payload string) (bool, error)
+	DeviceToken(ctx context.Context, uid string, deviceFlag int) (string, error)
+	DeleteToken(ctx context.Context, token string) error
+	RevokeIssued(ctx context.Context, token, uid string, deviceFlag int) error
 }
 
 // New New
 func New(ctx *config.Context) *User {
-	loginRedisClient := octoredis.NewInstrumentedClient(ctx.GetConfig(), func(o *rd.Options) {
-		o.PoolSize = 10
-	})
+	sessionStore, loginRedisClient := auth.SessionStoreAndClientForContext(ctx)
 	u := &User{
 		ctx:                      ctx,
 		db:                       NewDB(ctx),
@@ -169,10 +162,9 @@ func New(ctx *config.Context) *User {
 		pinnedDB:                 NewPinnedDB(ctx),
 		spaceSettingDB:           NewSpaceSettingDB(ctx.DB()),
 		verificationDB:           newVerificationDB(ctx),
-		existingTokenSetter: redisExistingTokenSetter{
-			client: loginRedisClient,
-		},
-		scanLoginAuthorizations: newScanLoginAuthorizationStore(loginRedisClient),
+		sessionStore:             sessionStore,
+		tokenValidator:           auth.NewTokenValidator(sessionStore, ctx.GetConfig().Cache.TokenCachePrefix),
+		scanLoginAuthorizations:  newScanLoginAuthorizationStore(loginRedisClient),
 	}
 	// LanguageService 与 main.go 注入到 CacheTokenParser 的实例独立构造，但共享
 	// 底层 *DB session / Redis 连接，因此读写同一份 user.language 列与
@@ -1100,15 +1092,20 @@ func (u *User) userUpdateWithField(c *wkhttp.Context) {
 			return
 		}
 		if key == "name" {
-			// 将重新设置token设置到缓存（这里主要是更新登录者的name）。
-			// 保留原有 Language 快照：从既存 cache value 解码后只换 Name，
-			// 避免 rename 把语言偏好抹空；Redis miss 时回退到无快照（由
-			// AuthMiddleware 上的 LanguageResolver 在下次请求重建）。
+			// 只更新当前 bearer 的展示快照，原子保留它的剩余 TTL。并发
+			// logout 已删除 key 时不重建；历史永久 key 被 Session Store
+			// 首次触达后收敛到配置的有限 TokenExpire。
 			loginToken := c.GetHeader("token")
-			preservedLang := ""
-			if oldRaw, getErr := u.ctx.Cache().Get(u.ctx.GetConfig().Cache.TokenCachePrefix + loginToken); getErr == nil && oldRaw != "" {
-				if oldInfo, decErr := auth.Decode(oldRaw); decErr == nil {
+			preservedLang, resolveErr := u.languageService.Resolve(c.Request.Context(), loginUID)
+			if resolveErr != nil {
+				// Resolver 故障时保留旧快照；只有权威读取和旧 token 读取都失败
+				// 才留空，避免一次资料更新扩大依赖故障影响。
+				oldInfo, validateErr := u.tokenValidator.Validate(c.Request.Context(), loginToken)
+				if validateErr == nil {
 					preservedLang = oldInfo.Language
+				} else {
+					u.Warn("解析用户语言及旧token快照均失败", zap.String("uid", loginUID), zap.Error(resolveErr))
+					preservedLang = ""
 				}
 			}
 			payload, encErr := auth.Encode(auth.TokenInfo{
@@ -1122,7 +1119,7 @@ func (u *User) userUpdateWithField(c *wkhttp.Context) {
 				respondUserError(c, errcode.ErrUserStoreFailed)
 				return
 			}
-			err = u.ctx.Cache().Set(u.ctx.GetConfig().Cache.TokenCachePrefix+loginToken, payload)
+			_, err = u.sessionStore.UpdatePayloadKeepDeadline(c.Request.Context(), loginToken, payload)
 			if err != nil {
 				u.Error("重新设置token缓存失败！", zap.Error(err))
 				respondUserError(c, errcode.ErrUserStoreFailed)
@@ -1668,7 +1665,7 @@ func (u *User) execLogin(userInfo *Model, flag config.DeviceFlag, device *device
 	tokenSpan, _ := u.ctx.Tracer().StartSpanFromContext(loginSpanCtx, "SetAndExpire")
 	tokenSpan.SetTag("key", "token")
 	// 获取老的token并清除老token数据
-	oldToken, err := u.ctx.Cache().Get(fmt.Sprintf("%s%d%s", u.ctx.GetConfig().Cache.UIDTokenCachePrefix, flag, userInfo.UID))
+	oldToken, err := u.sessionStore.DeviceToken(loginSpanCtx, userInfo.UID, int(flag))
 	if err != nil {
 		u.Error("获取旧token错误", zap.Error(err))
 		tokenSpan.Finish()
@@ -1677,7 +1674,7 @@ func (u *User) execLogin(userInfo *Model, flag config.DeviceFlag, device *device
 	reuseExistingToken := false
 	if flag == config.APP {
 		if oldToken != "" {
-			err = u.ctx.Cache().Delete(u.ctx.GetConfig().Cache.TokenCachePrefix + oldToken)
+			err = u.sessionStore.DeleteToken(loginSpanCtx, oldToken)
 			if err != nil {
 				u.Error("清除旧token数据错误", zap.Error(err))
 				tokenSpan.Finish()
@@ -1704,11 +1701,7 @@ func (u *User) execLogin(userInfo *Model, flag config.DeviceFlag, device *device
 	}
 	if reuseExistingToken {
 		var refreshed bool
-		refreshed, err = u.refreshExistingLoginToken(
-			u.ctx.GetConfig().Cache.TokenCachePrefix+token,
-			tokenPayload,
-			u.ctx.GetConfig().Cache.TokenExpire,
-		)
+		refreshed, err = u.reuseExistingLoginToken(loginSpanCtx, token, tokenPayload, userInfo.UID, int(flag))
 		if err != nil {
 			u.Error("刷新旧token缓存失败！", zap.Error(err))
 			tokenSpan.Finish()
@@ -1719,19 +1712,15 @@ func (u *User) execLogin(userInfo *Model, flag config.DeviceFlag, device *device
 			reuseExistingToken = false
 		}
 	}
+	issuedNew := false
 	if !reuseExistingToken {
-		err = u.ctx.Cache().SetAndExpire(u.ctx.GetConfig().Cache.TokenCachePrefix+token, tokenPayload, u.ctx.GetConfig().Cache.TokenExpire)
+		err = u.sessionStore.IssueNew(loginSpanCtx, token, tokenPayload, userInfo.UID, int(flag))
 		if err != nil {
 			u.Error("设置token缓存失败！", zap.Error(err))
 			tokenSpan.Finish()
 			return nil, errors.New("设置token缓存失败！")
 		}
-	}
-	err = u.ctx.Cache().SetAndExpire(fmt.Sprintf("%s%d%s", u.ctx.GetConfig().Cache.UIDTokenCachePrefix, flag, userInfo.UID), token, u.ctx.GetConfig().Cache.TokenExpire)
-	if err != nil {
-		u.Error("设置uidtoken缓存失败！", zap.Error(err))
-		tokenSpan.Finish()
-		return nil, errors.New("设置uidtoken缓存失败！")
+		issuedNew = true
 	}
 	tokenSpan.Finish()
 
@@ -1746,6 +1735,11 @@ func (u *User) execLogin(userInfo *Model, flag config.DeviceFlag, device *device
 	imResp, err := u.ctx.UpdateIMToken(imTokenReq)
 	if err != nil {
 		u.Error("更新IM的token失败！", zap.Error(err))
+		if issuedNew {
+			if revokeErr := u.compensateIssuedToken(token, userInfo.UID, int(flag)); revokeErr != nil {
+				u.Error("补偿撤销新签发token失败！", zap.Error(revokeErr))
+			}
+		}
 		updateTokenSpan.SetTag("err", err)
 		updateTokenSpan.Finish()
 		return nil, errors.New("更新IM的token失败！")
@@ -1753,6 +1747,11 @@ func (u *User) execLogin(userInfo *Model, flag config.DeviceFlag, device *device
 	updateTokenSpan.Finish()
 
 	if imResp.Status == config.UpdateTokenStatusBan {
+		if issuedNew {
+			if revokeErr := u.compensateIssuedToken(token, userInfo.UID, int(flag)); revokeErr != nil {
+				u.Error("封禁响应后补偿撤销新签发token失败！", zap.Error(revokeErr))
+			}
+		}
 		return nil, errors.New("此账号已经被封禁！")
 	}
 
@@ -1761,11 +1760,19 @@ func (u *User) execLogin(userInfo *Model, flag config.DeviceFlag, device *device
 	return resp, nil
 }
 
-func (u *User) refreshExistingLoginToken(key string, payload string, expire time.Duration) (bool, error) {
-	if u.existingTokenSetter == nil {
+func (u *User) reuseExistingLoginToken(ctx context.Context, token, payload, uid string, deviceFlag int) (bool, error) {
+	if u.sessionStore == nil {
 		return false, nil
 	}
-	return u.existingTokenSetter.SetIfExists(key, payload, expire)
+	return u.sessionStore.ReuseExisting(ctx, token, payload, uid, deviceFlag)
+}
+
+func (u *User) compensateIssuedToken(token, uid string, deviceFlag int) error {
+	// 请求取消不能跳过 credential 补偿；Redis client 自身另有严格超时，
+	// 这里再给整个清理动作一个总 deadline，避免失败路径无限占用 goroutine。
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	return u.sessionStore.RevokeIssued(ctx, token, uid, deviceFlag)
 }
 
 // sendWelcomeMsg 发送欢迎语
@@ -2326,7 +2333,7 @@ func (u *User) loginWithAuthCode(c *wkhttp.Context) {
 	// burns this authorization and requires a fresh scan; fail-closed behavior
 	// is preferable to making a credential replayable across replicas.
 	// 获取老的token
-	token, err := u.ctx.Cache().Get(fmt.Sprintf("%s%d%s", u.ctx.GetConfig().Cache.UIDTokenCachePrefix, flag, scaner))
+	token, err := u.sessionStore.DeviceToken(c.Request.Context(), scaner, int(flag))
 	if err != nil {
 		u.Error("获取旧token错误", zap.Error(err))
 		respondUserError(c, errcode.ErrUserIMCallFailed)
@@ -2407,11 +2414,7 @@ func (u *User) loginWithAuthCode(c *wkhttp.Context) {
 		return
 	}
 	if reuseExistingToken {
-		refreshed, err := u.refreshExistingLoginToken(
-			u.ctx.GetConfig().Cache.TokenCachePrefix+token,
-			tokenPayload,
-			u.ctx.GetConfig().Cache.TokenExpire,
-		)
+		refreshed, err := u.reuseExistingLoginToken(c.Request.Context(), token, tokenPayload, userModel.UID, int(flag))
 		if err != nil {
 			u.Error("刷新旧token缓存失败！", zap.Error(err))
 			respondUserError(c, errcode.ErrUserStoreFailed)
@@ -2422,13 +2425,15 @@ func (u *User) loginWithAuthCode(c *wkhttp.Context) {
 			reuseExistingToken = false
 		}
 	}
+	issuedNew := false
 	if !reuseExistingToken {
-		err = u.ctx.Cache().SetAndExpire(u.ctx.GetConfig().Cache.TokenCachePrefix+token, tokenPayload, u.ctx.GetConfig().Cache.TokenExpire)
+		err = u.sessionStore.IssueNew(c.Request.Context(), token, tokenPayload, userModel.UID, int(flag))
 		if err != nil {
 			u.Error("设置token缓存失败！", zap.Error(err))
 			respondUserError(c, errcode.ErrUserStoreFailed)
 			return
 		}
+		issuedNew = true
 	}
 
 	imResp, err := u.ctx.UpdateIMToken(config.UpdateIMTokenReq{
@@ -2439,10 +2444,20 @@ func (u *User) loginWithAuthCode(c *wkhttp.Context) {
 	})
 	if err != nil {
 		u.Error("更新IM的token失败！", zap.Error(err))
+		if issuedNew {
+			if revokeErr := u.compensateIssuedToken(token, userModel.UID, int(flag)); revokeErr != nil {
+				u.Error("补偿撤销扫码登录新token失败！", zap.Error(revokeErr))
+			}
+		}
 		respondUserError(c, errcode.ErrUserIMCallFailed)
 		return
 	}
 	if imResp.Status == config.UpdateTokenStatusBan {
+		if issuedNew {
+			if revokeErr := u.compensateIssuedToken(token, userModel.UID, int(flag)); revokeErr != nil {
+				u.Error("封禁响应后补偿撤销扫码登录新token失败！", zap.Error(revokeErr))
+			}
+		}
 		respondUserError(c, errcode.ErrUserAccountBanned)
 		return
 	}
@@ -2457,13 +2472,6 @@ func (u *User) loginWithAuthCode(c *wkhttp.Context) {
 		if delErr := u.ctx.GetRedisConn().Del(fmt.Sprintf("%s%s", common.QRCodeCachePrefix, uuid)); delErr != nil {
 			u.Warn("清理扫码二维码状态失败", zap.String("uuid", uuid), zap.Error(delErr))
 		}
-	}
-
-	err = u.ctx.Cache().SetAndExpire(fmt.Sprintf("%s%d%s", u.ctx.GetConfig().Cache.UIDTokenCachePrefix, flag, userModel.UID), token, u.ctx.GetConfig().Cache.TokenExpire)
-	if err != nil {
-		u.Error("设置uidtoken缓存失败！", zap.Error(err))
-		respondUserError(c, errcode.ErrUserStoreFailed)
-		return
 	}
 
 	resp := map[string]interface{}{
@@ -3163,7 +3171,7 @@ func (u *User) loginCheckPhone(c *wkhttp.Context) {
 		respondUserError(c, errcode.ErrUserStoreFailed)
 		return
 	}
-	err = u.ctx.Cache().SetAndExpire(u.ctx.GetConfig().Cache.TokenCachePrefix+token, tokenPayload, u.ctx.GetConfig().Cache.TokenExpire)
+	err = u.sessionStore.IssueNew(spanCtx, token, tokenPayload, userInfo.UID, int(config.APP))
 	if err != nil {
 		u.Error("设置token缓存失败！", zap.Error(err))
 		respondUserError(c, errcode.ErrUserStoreFailed)
@@ -3178,10 +3186,16 @@ func (u *User) loginCheckPhone(c *wkhttp.Context) {
 	})
 	if err != nil {
 		u.Error("更新IM的token失败！", zap.Error(err))
+		if revokeErr := u.compensateIssuedToken(token, userInfo.UID, int(config.APP)); revokeErr != nil {
+			u.Error("补偿撤销设备验证新token失败！", zap.Error(revokeErr))
+		}
 		respondUserError(c, errcode.ErrUserIMCallFailed)
 		return
 	}
 	if imResp.Status == config.UpdateTokenStatusBan {
+		if revokeErr := u.compensateIssuedToken(token, userInfo.UID, int(config.APP)); revokeErr != nil {
+			u.Error("封禁响应后补偿撤销设备验证新token失败！", zap.Error(revokeErr))
+		}
 		respondUserError(c, errcode.ErrUserAccountBanned)
 		return
 	}
@@ -3813,7 +3827,7 @@ func (u *User) createUserWithRespAndTx(registerSpanCtx context.Context, createUs
 		u.Error("编码token缓存失败！", zap.Error(err))
 		return nil, err
 	}
-	err = u.ctx.Cache().SetAndExpire(u.ctx.GetConfig().Cache.TokenCachePrefix+token, tokenPayload, u.ctx.GetConfig().Cache.TokenExpire)
+	err = u.sessionStore.IssueNew(registerSpanCtx, token, tokenPayload, userModel.UID, createUser.Flag)
 	if err != nil {
 		u.Error("设置token缓存失败！", zap.Error(err))
 		return nil, err
@@ -3826,6 +3840,9 @@ func (u *User) createUserWithRespAndTx(registerSpanCtx context.Context, createUs
 	})
 	if err != nil {
 		u.Error("更新IM的token失败！", zap.Error(err))
+		if revokeErr := u.compensateIssuedToken(token, userModel.UID, createUser.Flag); revokeErr != nil {
+			u.Error("补偿撤销注册新token失败！", zap.Error(revokeErr))
+		}
 		return nil, err
 	}
 	go u.sentWelcomeMsg(publicIP, createUser.UID)
@@ -4263,16 +4280,9 @@ func (u *User) authVerifyToken(c *wkhttp.Context) {
 		return
 	}
 
-	// Same Redis lookup as AuthMiddleware: "token:<value>" → versioned envelope
-	// (v2 JSON) 或 legacy "uid@name[@role]"。auth.Decode 兼容两者。
-	raw, cacheErr := u.ctx.Cache().Get(u.ctx.GetConfig().Cache.TokenCachePrefix + req.Token)
-	if cacheErr != nil || strings.TrimSpace(raw) == "" {
+	info, validateErr := u.tokenValidator.Validate(c.Request.Context(), req.Token)
+	if validateErr != nil {
 		c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"msg": "invalid or expired token"})
-		return
-	}
-	info, decodeErr := auth.Decode(raw)
-	if decodeErr != nil {
-		c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"msg": "malformed token data"})
 		return
 	}
 

--- a/modules/user/api.go
+++ b/modules/user/api.go
@@ -1775,6 +1775,28 @@ func (u *User) compensateIssuedToken(token, uid string, deviceFlag int) error {
 	return u.sessionStore.RevokeIssued(ctx, token, uid, deviceFlag)
 }
 
+// replaceAPPToken keeps device-verification login aligned with the existing
+// APP single-session policy: revoke the currently indexed HTTP bearer before
+// publishing a new credential. Every step uses the shared Redis-backed Session
+// Store rather than a process-local lock; a Redis failure stops issuance. Full
+// concurrent-issuance serialization remains part of the v3 generation/CAS
+// release described by the task brief.
+func (u *User) replaceAPPToken(ctx context.Context, token, payload, uid string) error {
+	oldToken, err := u.sessionStore.DeviceToken(ctx, uid, int(config.APP))
+	if err != nil {
+		return fmt.Errorf("load previous APP token: %w", err)
+	}
+	if strings.TrimSpace(oldToken) != "" {
+		if err := u.sessionStore.DeleteToken(ctx, oldToken); err != nil {
+			return fmt.Errorf("revoke previous APP token: %w", err)
+		}
+	}
+	if err := u.sessionStore.IssueNew(ctx, token, payload, uid, int(config.APP)); err != nil {
+		return fmt.Errorf("issue APP token: %w", err)
+	}
+	return nil
+}
+
 // sendWelcomeMsg 发送欢迎语
 func (u *User) sentWelcomeMsg(publicIP, uid string) {
 	appconfig, err := u.commonService.GetAppConfig()
@@ -3171,7 +3193,7 @@ func (u *User) loginCheckPhone(c *wkhttp.Context) {
 		respondUserError(c, errcode.ErrUserStoreFailed)
 		return
 	}
-	err = u.sessionStore.IssueNew(spanCtx, token, tokenPayload, userInfo.UID, int(config.APP))
+	err = u.replaceAPPToken(spanCtx, token, tokenPayload, userInfo.UID)
 	if err != nil {
 		u.Error("设置token缓存失败！", zap.Error(err))
 		respondUserError(c, errcode.ErrUserStoreFailed)

--- a/modules/user/api_authcode_token_redis_test.go
+++ b/modules/user/api_authcode_token_redis_test.go
@@ -1,11 +1,13 @@
 package user
 
 import (
+	"context"
 	"testing"
 	"time"
 
+	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
-	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	"github.com/Mininglamp-OSS/octo-server/pkg/auth"
 	octoredis "github.com/Mininglamp-OSS/octo-server/pkg/redis"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -22,32 +24,40 @@ import (
 // 只依赖 Redis(CI 必备),不碰 WuKongIM —— 完整 HTTP e2e 因 CI 的 IM 不接受给未注册 uid
 // 发 token(UpdateIMToken 返回 im_call_failed)而不可移植,故下沉到 race 真正发生的
 // Redis 层。配套 fake 实现的纯单测见 TestRefreshExistingLoginToken_DoesNotRecreateDeletedToken。
-func TestRedisExistingTokenSetter_SetXX_RealRedis(t *testing.T) {
-	_, ctx := testutil.NewTestServer()
-	setter := redisExistingTokenSetter{
-		client: octoredis.NewInstrumentedClient(ctx.GetConfig()),
-	}
-	prefix := ctx.GetConfig().Cache.TokenCachePrefix
+func TestRedisSessionStore_ReuseExisting_RealRedis(t *testing.T) {
+	cfg := config.New()
+	client := octoredis.NewInstrumentedClient(cfg)
+	t.Cleanup(func() { _ = client.Close() })
+	store := auth.NewRedisSessionStore(client, cfg.Cache.TokenCachePrefix, cfg.Cache.UIDTokenCachePrefix, time.Minute)
+	prefix := cfg.Cache.TokenCachePrefix
 
 	t.Run("key不存在_不创建_模拟logout已删除", func(t *testing.T) {
-		key := prefix + "pr225-missing-" + util.GenerUUID()
-		require.NoError(t, ctx.GetRedisConn().Del(key)) // 前置:token:<old> 已被 logout 删除
-		ok, err := setter.SetIfExists(key, "payload", time.Minute)
+		token := "pr225-missing-" + util.GenerUUID()
+		key := prefix + token
+		require.NoError(t, client.Del(key).Err())
+		ok, err := store.ReuseExisting(context.Background(), token, "payload", "u1", 1)
 		require.NoError(t, err)
 		assert.False(t, ok, "SET XX 对不存在的 key 必须返回 false,不能复活已登出 token")
-		got, err := ctx.Cache().Get(key)
+		exists, err := client.Exists(key).Result()
 		require.NoError(t, err)
-		assert.Empty(t, got, "已登出的 token key 不得被重新创建")
+		assert.Zero(t, exists, "已登出的 token key 不得被重新创建")
 	})
 
 	t.Run("key存在_刷新payload_保证Web多端复用", func(t *testing.T) {
-		key := prefix + "pr225-exists-" + util.GenerUUID()
-		require.NoError(t, ctx.Cache().SetAndExpire(key, "old-payload", time.Minute))
-		ok, err := setter.SetIfExists(key, "new-payload", time.Minute)
+		token := "pr225-exists-" + util.GenerUUID()
+		key := prefix + token
+		require.NoError(t, client.Set(key, "old-payload", time.Minute).Err())
+		before, err := client.PTTL(key).Result()
+		require.NoError(t, err)
+		ok, err := store.ReuseExisting(context.Background(), token, "new-payload", "u1", 1)
 		require.NoError(t, err)
 		assert.True(t, ok, "SET XX 对存在的 key 必须返回 true(正常 Web 多端复用)")
-		got, err := ctx.Cache().Get(key)
+		got, err := client.Get(key).Result()
 		require.NoError(t, err)
 		assert.Equal(t, "new-payload", got, "SET XX 必须刷新已存在 key 的 payload")
+		after, err := client.PTTL(key).Result()
+		require.NoError(t, err)
+		assert.LessOrEqual(t, after, before, "复用旧 token 不得延长 deadline")
+		require.NoError(t, client.Del(key, cfg.Cache.UIDTokenCachePrefix+"1u1").Err())
 	})
 }

--- a/modules/user/api_authcode_token_test.go
+++ b/modules/user/api_authcode_token_test.go
@@ -28,17 +28,18 @@ func TestLoginWithAuthCode_ReusedTokenGuardedBySetXX(t *testing.T) {
 	require.NotEqual(t, -1, fnEnd)
 	fnBody := body[fnStart : fnStart+len(fnSig)+fnEnd]
 
-	// 1. 复用旧 token 必须走 SET XX 守卫(refreshExistingLoginToken),
-	//    不能再无条件 SetAndExpire 复活 token key。
-	assert.Contains(t, fnBody, "u.refreshExistingLoginToken(",
-		"loginWithAuthCode 复用旧 token 必须经 refreshExistingLoginToken(SET XX)校验,避免复活已登出 token")
+	// 1. 复用旧 token 必须走 Session Store 的保 deadline 守卫。
+	assert.Contains(t, fnBody, "u.reuseExistingLoginToken(",
+		"loginWithAuthCode 复用旧 token 必须经 Session Store 校验,避免复活或续期已登出 token")
 
-	// 2. 必须保留 reuseExistingToken 标记,SetAndExpire 只能在 !reuseExistingToken 分支兜底。
+	// 2. 必须保留 reuseExistingToken 标记,IssueNew 只能在新签发分支执行。
 	assert.Contains(t, fnBody, "if !reuseExistingToken {",
-		"loginWithAuthCode 只能在 !reuseExistingToken 分支无条件写 token 缓存")
+		"loginWithAuthCode 只能在 !reuseExistingToken 分支签发新 token")
+	assert.Contains(t, fnBody, "u.sessionStore.IssueNew(",
+		"loginWithAuthCode 新 token 必须通过 Session Store 签发")
 
 	// 3. token 缓存的最终决策必须在调用 IM 之前完成,否则 IM 会拿到回退前的旧 token。
-	guardIdx := strings.Index(fnBody, "u.refreshExistingLoginToken(")
+	guardIdx := strings.Index(fnBody, "u.reuseExistingLoginToken(")
 	imIdx := strings.Index(fnBody, "u.ctx.UpdateIMToken(")
 	require.NotEqual(t, -1, imIdx, "loginWithAuthCode 必须调用 UpdateIMToken")
 	assert.Less(t, guardIdx, imIdx,

--- a/modules/user/api_login_token_test.go
+++ b/modules/user/api_login_token_test.go
@@ -1,6 +1,7 @@
 package user
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -8,11 +9,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-type fakeExistingTokenSetter struct {
+type fakeUserSessionStore struct {
 	cache *common.MemoryCache
 }
 
-func (f fakeExistingTokenSetter) SetIfExists(key string, value string, expire time.Duration) (bool, error) {
+func (f fakeUserSessionStore) ReuseExisting(_ context.Context, token, value, _ string, _ int) (bool, error) {
+	key := "token:" + token
 	got, err := f.cache.Get(key)
 	if err != nil {
 		return false, err
@@ -20,7 +22,21 @@ func (f fakeExistingTokenSetter) SetIfExists(key string, value string, expire ti
 	if got == "" {
 		return false, nil
 	}
-	return true, f.cache.SetAndExpire(key, value, expire)
+	return true, f.cache.SetAndExpire(key, value, time.Minute)
+}
+
+func (f fakeUserSessionStore) IssueNew(context.Context, string, string, string, int) error {
+	return nil
+}
+func (f fakeUserSessionStore) UpdatePayloadKeepDeadline(context.Context, string, string) (bool, error) {
+	return false, nil
+}
+func (f fakeUserSessionStore) DeviceToken(context.Context, string, int) (string, error) {
+	return "", nil
+}
+func (f fakeUserSessionStore) DeleteToken(context.Context, string) error { return nil }
+func (f fakeUserSessionStore) RevokeIssued(context.Context, string, string, int) error {
+	return nil
 }
 
 // Web/PC 登录复用 uidtoken 里的旧 token 时,必须使用 "SET XX" 语义刷新 token。
@@ -28,9 +44,9 @@ func (f fakeExistingTokenSetter) SetIfExists(key string, value string, expire ti
 // 重新创建出来,否则刚 logout 的 HTTP token 会被并发登录复活。
 func TestRefreshExistingLoginToken_DoesNotRecreateDeletedToken(t *testing.T) {
 	c := common.NewMemoryCache()
-	u := &User{existingTokenSetter: fakeExistingTokenSetter{cache: c}}
+	u := &User{sessionStore: fakeUserSessionStore{cache: c}}
 
-	ok, err := u.refreshExistingLoginToken("token:logged-out", "payload", time.Minute)
+	ok, err := u.reuseExistingLoginToken(context.Background(), "logged-out", "payload", "u1", 1)
 	require.NoError(t, err)
 	require.False(t, ok, "missing token key must not be recreated")
 

--- a/modules/user/api_login_token_test.go
+++ b/modules/user/api_login_token_test.go
@@ -2,10 +2,15 @@ package user
 
 import (
 	"context"
+	"errors"
+	"go/ast"
+	"go/parser"
+	gotoken "go/token"
 	"testing"
 	"time"
 
 	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/stretchr/testify/require"
 )
 
@@ -53,4 +58,95 @@ func TestRefreshExistingLoginToken_DoesNotRecreateDeletedToken(t *testing.T) {
 	got, err := c.Get("token:logged-out")
 	require.NoError(t, err)
 	require.Empty(t, got)
+}
+
+type recordingAPPSessionStore struct {
+	oldToken string
+	calls    []string
+}
+
+func (s *recordingAPPSessionStore) IssueNew(_ context.Context, token, _ string, _ string, deviceFlag int) error {
+	s.calls = append(s.calls, "issue:"+token)
+	if deviceFlag != int(config.APP) {
+		return errors.New("unexpected device flag")
+	}
+	return nil
+}
+
+func (s *recordingAPPSessionStore) DeviceToken(_ context.Context, _ string, deviceFlag int) (string, error) {
+	s.calls = append(s.calls, "device_token")
+	if deviceFlag != int(config.APP) {
+		return "", errors.New("unexpected device flag")
+	}
+	return s.oldToken, nil
+}
+
+func (s *recordingAPPSessionStore) DeleteToken(_ context.Context, token string) error {
+	s.calls = append(s.calls, "delete:"+token)
+	return nil
+}
+
+func (s *recordingAPPSessionStore) ReuseExisting(context.Context, string, string, string, int) (bool, error) {
+	return false, nil
+}
+
+func (s *recordingAPPSessionStore) UpdatePayloadKeepDeadline(context.Context, string, string) (bool, error) {
+	return false, nil
+}
+
+func (s *recordingAPPSessionStore) RevokeIssued(context.Context, string, string, int) error {
+	return nil
+}
+
+type appTokenReplacer interface {
+	replaceAPPToken(context.Context, string, string, string) error
+}
+
+func TestReplaceAPPTokenRevokesPreviousBearerBeforeIssue(t *testing.T) {
+	store := &recordingAPPSessionStore{oldToken: "old-app-token"}
+	u := &User{sessionStore: store}
+	replacer, ok := interface{}(u).(appTokenReplacer)
+	require.True(t, ok, "device verification login must share the APP replacement policy")
+
+	require.NoError(t, replacer.replaceAPPToken(context.Background(), "new-app-token", "payload", "u1"))
+	require.Equal(t, []string{
+		"device_token",
+		"delete:old-app-token",
+		"issue:new-app-token",
+	}, store.calls)
+}
+
+func TestLoginCheckPhoneUsesAPPTokenReplacementBeforeIMUpdate(t *testing.T) {
+	fset := gotoken.NewFileSet()
+	file, err := parser.ParseFile(fset, "api.go", nil, 0)
+	require.NoError(t, err)
+
+	var replacePos, imPos gotoken.Pos
+	for _, declaration := range file.Decls {
+		fn, ok := declaration.(*ast.FuncDecl)
+		if !ok || fn.Name.Name != "loginCheckPhone" {
+			continue
+		}
+		ast.Inspect(fn.Body, func(node ast.Node) bool {
+			call, ok := node.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			selector, ok := call.Fun.(*ast.SelectorExpr)
+			if !ok {
+				return true
+			}
+			switch selector.Sel.Name {
+			case "replaceAPPToken":
+				replacePos = call.Pos()
+			case "UpdateIMToken":
+				imPos = call.Pos()
+			}
+			return true
+		})
+	}
+
+	require.NotZero(t, replacePos, "loginCheckPhone must revoke the previous APP bearer before issuing a new one")
+	require.NotZero(t, imPos, "loginCheckPhone must still update the IM credential")
+	require.Less(t, replacePos, imPos, "HTTP bearer replacement must finish before the IM token is published")
 }

--- a/modules/user/api_manager.go
+++ b/modules/user/api_manager.go
@@ -38,6 +38,7 @@ type Manager struct {
 	onlineService IOnlineService
 	commonService common2.IService
 	roleService   *RoleService
+	sessionStore  userSessionStore
 }
 
 // NewManager NewManager
@@ -53,6 +54,7 @@ func NewManager(ctx *config.Context) *Manager {
 		onlineService: NewOnlineService(ctx),
 		commonService: common2.NewService(ctx),
 		roleService:   NewRoleService(NewDB(ctx), ctx.Cache()),
+		sessionStore:  auth.SessionStoreForContext(ctx),
 	}
 	m.createManagerAccount()
 	return m
@@ -296,16 +298,9 @@ func (m *Manager) login(c *wkhttp.Context) {
 		respondUserError(c, errcode.ErrUserTokenCacheFailed)
 		return
 	}
-	err = m.ctx.Cache().SetAndExpire(m.ctx.GetConfig().Cache.TokenCachePrefix+token, tokenPayload, m.ctx.GetConfig().Cache.TokenExpire)
+	err = m.sessionStore.IssueNew(c.Request.Context(), token, tokenPayload, userInfo.UID, int(config.Web))
 	if err != nil {
-		m.Error("设置token缓存失败！", zap.Error(err))
-		respondUserError(c, errcode.ErrUserTokenCacheFailed)
-		return
-	}
-
-	err = m.ctx.Cache().SetAndExpire(fmt.Sprintf("%s%d%s", m.ctx.GetConfig().Cache.UIDTokenCachePrefix, config.Web, userInfo.UID), token, m.ctx.GetConfig().Cache.TokenExpire)
-	if err != nil {
-		m.Error("设置uidtoken缓存失败！", zap.Error(err))
+		m.Error("设置管理端token缓存失败！", zap.Error(err))
 		respondUserError(c, errcode.ErrUserTokenCacheFailed)
 		return
 	}

--- a/modules/user/main_test.go
+++ b/modules/user/main_test.go
@@ -3,6 +3,7 @@ package user
 import (
 	"crypto/rand"
 	"encoding/hex"
+	"fmt"
 	"os"
 	"testing"
 )
@@ -23,5 +24,10 @@ func TestMain(m *testing.M) {
 		_, _ = rand.Read(key)
 		_ = os.Setenv("OCTO_MASTER_KEY", hex.EncodeToString(key))
 	}
-	os.Exit(m.Run())
+	code := m.Run()
+	if err := cleanupTokenHTTPTestDatabases(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		code = 1
+	}
+	os.Exit(code)
 }

--- a/modules/user/scanlogin_poll_test.go
+++ b/modules/user/scanlogin_poll_test.go
@@ -348,13 +348,18 @@ func TestLoginWithAuthCode_ConsumesBeforeIssuingSession(t *testing.T) {
 
 	assert.Contains(t, fn, "u.scanLoginPollSecretMatches(uuid, strings.TrimSpace(c.Query(scanLoginPollSecretQuery)))")
 	consume := strings.Index(fn, "u.scanLoginAuthorizations.Consume(authCode, authInfo)")
-	cacheWrite := strings.Index(fn, "u.ctx.Cache().SetAndExpire")
+	reuseExisting := strings.Index(fn, "u.reuseExistingLoginToken(")
+	issueNew := strings.Index(fn, "u.sessionStore.IssueNew(")
 	imUpdate := strings.Index(fn, "u.ctx.UpdateIMToken")
 	require.NotEqual(t, -1, consume)
-	require.NotEqual(t, -1, cacheWrite)
+	require.NotEqual(t, -1, reuseExisting)
+	require.NotEqual(t, -1, issueNew)
 	require.NotEqual(t, -1, imUpdate)
-	assert.Less(t, consume, cacheWrite, "授权必须先原子消费，再写登录 token")
+	assert.Less(t, consume, reuseExisting, "授权必须先原子消费，再复用已有登录 token")
+	assert.Less(t, consume, issueNew, "授权必须先原子消费，再签发新登录 token")
 	assert.Less(t, consume, imUpdate, "授权必须先原子消费，再产生 IM 登录副作用")
+	assert.NotContains(t, fn, "u.ctx.Cache().SetAndExpire",
+		"扫码登录不得绕过 Session Store 直接写 token cache")
 }
 
 // TestLoginWithAuthCode_ClearsScanLoginState 锁住 P2-3：登录完成后本轮扫码的所有状态

--- a/modules/user/token_http_ttl_test.go
+++ b/modules/user/token_http_ttl_test.go
@@ -1,0 +1,160 @@
+package user
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/module"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	libserver "github.com/Mininglamp-OSS/octo-lib/server"
+	"github.com/Mininglamp-OSS/octo-server/pkg/auth"
+	"github.com/stretchr/testify/require"
+)
+
+var tokenHTTPTestDatabases struct {
+	sync.Mutex
+	names []string
+}
+
+func TestTokenDeadlineOverHTTP(t *testing.T) {
+	server, ctx := newTokenHTTPTestServer(t)
+	t.Run("manager login issues a finite token", func(t *testing.T) {
+		testManagerLoginIssuesFiniteTokenOverHTTP(t, server, ctx)
+	})
+	t.Run("nickname update preserves the deadline", func(t *testing.T) {
+		testNicknameUpdatePreservesFiniteTokenDeadlineOverHTTP(t, server, ctx)
+	})
+}
+
+func testManagerLoginIssuesFiniteTokenOverHTTP(t *testing.T, server *libserver.Server, ctx *config.Context) {
+	t.Helper()
+	manager := NewManager(ctx)
+	uid := util.GenerUUID()
+	username := "manager-ttl-" + uid[:12]
+	password := "manager-ttl-password"
+	hash, err := HashPassword(password)
+	require.NoError(t, err)
+	require.NoError(t, manager.userDB.Insert(&Model{
+		UID:      uid,
+		Username: username,
+		Name:     "TTL Manager",
+		ShortNo:  "mgr_" + uid[:12],
+		Password: hash,
+		Role:     string(wkhttp.SuperAdmin),
+		Status:   1,
+	}))
+
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodPost, "/v1/manager/login", bytes.NewReader([]byte(util.ToJson(map[string]interface{}{
+		"username": username,
+		"password": password,
+	}))))
+	request.Header.Set("Content-Type", "application/json")
+	server.GetRoute().ServeHTTP(recorder, request)
+	require.Equal(t, http.StatusOK, recorder.Code, "body=%s", recorder.Body.String())
+	var response struct {
+		Token string `json:"token"`
+	}
+	require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &response))
+	require.NotEmpty(t, response.Token)
+
+	_, client := auth.SessionStoreAndClientForContext(ctx)
+	tokenKey := ctx.GetConfig().Cache.TokenCachePrefix + response.Token
+	uidKey := ctx.GetConfig().Cache.UIDTokenCachePrefix + "1" + uid
+	t.Cleanup(func() { _ = client.Del(tokenKey, uidKey).Err() })
+	ttl, err := client.PTTL(tokenKey).Result()
+	require.NoError(t, err)
+	require.Positive(t, ttl)
+	require.LessOrEqual(t, ttl, ctx.GetConfig().Cache.TokenExpire)
+}
+
+func testNicknameUpdatePreservesFiniteTokenDeadlineOverHTTP(t *testing.T, server *libserver.Server, ctx *config.Context) {
+	t.Helper()
+	user := New(ctx)
+	uid := util.GenerUUID()
+	require.NoError(t, user.db.Insert(&Model{
+		UID:      uid,
+		Username: uid,
+		Name:     "Before",
+		ShortNo:  "usr_" + uid[:12],
+		Status:   1,
+	}))
+
+	store, client := auth.SessionStoreAndClientForContext(ctx)
+	tokenValue := "nickname-token-" + util.GenerUUID()
+	require.NoError(t, store.IssueNew(context.Background(), tokenValue, uid+"@Before", uid, int(config.APP)))
+	tokenKey := ctx.GetConfig().Cache.TokenCachePrefix + tokenValue
+	uidKey := ctx.GetConfig().Cache.UIDTokenCachePrefix + "0" + uid
+	t.Cleanup(func() { _ = client.Del(tokenKey, uidKey).Err() })
+	before, err := client.PTTL(tokenKey).Result()
+	require.NoError(t, err)
+	require.Positive(t, before)
+
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodPut, "/v1/user/current", bytes.NewReader([]byte(`{"name":"After"}`)))
+	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("token", tokenValue)
+	server.GetRoute().ServeHTTP(recorder, request)
+	require.Equal(t, http.StatusOK, recorder.Code, "body=%s", recorder.Body.String())
+
+	after, err := client.PTTL(tokenKey).Result()
+	require.NoError(t, err)
+	require.Positive(t, after)
+	require.LessOrEqual(t, after, before, "profile updates must not extend the bearer deadline")
+}
+
+func newTokenHTTPTestServer(t *testing.T) (*libserver.Server, *config.Context) {
+	t.Helper()
+	databaseName := "octo_user_token_ttl_" + util.GenerUUID()[:12]
+	bootstrapConfig := config.New()
+	bootstrapConfig.Test = true
+	bootstrapConfig.DB.MySQLAddr = "root:demo@tcp(127.0.0.1:3306)/information_schema?charset=utf8mb4&parseTime=true"
+	bootstrap := config.NewContext(bootstrapConfig)
+	_, err := bootstrap.DB().Exec("CREATE DATABASE `" + databaseName + "` CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci")
+	require.NoError(t, err, "create isolated token TTL test database")
+	require.NoError(t, bootstrap.DB().DB.Close())
+	tokenHTTPTestDatabases.Lock()
+	tokenHTTPTestDatabases.names = append(tokenHTTPTestDatabases.names, databaseName)
+	tokenHTTPTestDatabases.Unlock()
+
+	cfg := config.New()
+	cfg.Test = true
+	cfg.DB.MySQLAddr = fmt.Sprintf("root:demo@tcp(127.0.0.1:3306)/%s?charset=utf8mb4&parseTime=true", databaseName)
+	ctx := config.NewContext(cfg)
+
+	server := libserver.New(ctx)
+	server.GetRoute().UseGin(ctx.Tracer().GinMiddle())
+	ctx.SetHttpRoute(server.GetRoute())
+	require.NoError(t, module.Setup(ctx), "set up modules in isolated token TTL database")
+	return server, ctx
+}
+
+func cleanupTokenHTTPTestDatabases() error {
+	tokenHTTPTestDatabases.Lock()
+	names := append([]string(nil), tokenHTTPTestDatabases.names...)
+	tokenHTTPTestDatabases.names = nil
+	tokenHTTPTestDatabases.Unlock()
+	if len(names) == 0 {
+		return nil
+	}
+
+	cfg := config.New()
+	cfg.Test = true
+	cfg.DB.MySQLAddr = "root:demo@tcp(127.0.0.1:3306)/information_schema?charset=utf8mb4&parseTime=true"
+	bootstrap := config.NewContext(cfg)
+	defer bootstrap.DB().DB.Close()
+	for _, name := range names {
+		if _, err := bootstrap.DB().Exec("DROP DATABASE IF EXISTS `" + name + "`"); err != nil {
+			return fmt.Errorf("drop isolated token TTL database %s: %w", name, err)
+		}
+	}
+	return nil
+}

--- a/modules/user/token_http_ttl_test.go
+++ b/modules/user/token_http_ttl_test.go
@@ -130,10 +130,32 @@ func newTokenHTTPTestServer(t *testing.T) (*libserver.Server, *config.Context) {
 	cfg.DB.MySQLAddr = fmt.Sprintf("root:demo@tcp(127.0.0.1:3306)/%s?charset=utf8mb4&parseTime=true", databaseName)
 	ctx := config.NewContext(cfg)
 
+	// module.Setup must run the complete migration set, but octo-lib caches its
+	// module instances behind a process-wide sync.Once. Under CI's shuffled
+	// package tests those instances may belong to an earlier `test` database
+	// context, so routes registered by Setup must not serve this isolated DB.
+	migrationServer := libserver.New(ctx)
+	migrationServer.GetRoute().UseGin(ctx.Tracer().GinMiddle())
+	ctx.SetHttpRoute(migrationServer.GetRoute())
+	require.NoError(t, module.Setup(ctx), "set up modules in isolated token TTL database")
+
+	// Register only the handlers exercised here from objects constructed with
+	// this test's context. This keeps handler reads and fixture writes on the
+	// same isolated database regardless of which package test initialized the
+	// global module registry first.
 	server := libserver.New(ctx)
 	server.GetRoute().UseGin(ctx.Tracer().GinMiddle())
 	ctx.SetHttpRoute(server.GetRoute())
-	require.NoError(t, module.Setup(ctx), "set up modules in isolated token TTL database")
+	store := auth.SessionStoreForContext(ctx)
+	server.GetRoute().SetTokenParser(auth.NewCacheTokenParser(
+		ctx.Cache(),
+		cfg.Cache.TokenCachePrefix,
+		auth.WithTokenValidator(auth.NewTokenValidator(store, cfg.Cache.TokenCachePrefix)),
+	))
+	userAPI := New(ctx)
+	managerAPI := NewManager(ctx)
+	server.GetRoute().POST("/v1/manager/login", managerAPI.login)
+	server.GetRoute().Group("/v1/user", ctx.AuthMiddleware(server.GetRoute())).PUT("/current", userAPI.userUpdateWithField)
 	return server, ctx
 }
 

--- a/modules/user/token_writer_guard_test.go
+++ b/modules/user/token_writer_guard_test.go
@@ -1,0 +1,26 @@
+package user
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestProductionTokenWritersUseSessionStore(t *testing.T) {
+	for _, path := range []string{"api.go", "api_manager.go"} {
+		src, err := os.ReadFile(path)
+		require.NoError(t, err)
+		body := string(src)
+		for _, forbidden := range []string{
+			"Cache.TokenCachePrefix+loginToken, payload)",
+			"Cache.TokenCachePrefix+token, tokenPayload",
+			"Cache.UIDTokenCachePrefix, flag, userInfo.UID), token",
+			"Cache.UIDTokenCachePrefix, flag, userModel.UID), token",
+			"Cache.UIDTokenCachePrefix, config.Web, userInfo.UID), token",
+		} {
+			require.False(t, strings.Contains(body, forbidden), "%s still bypasses Session Store with %q", path, forbidden)
+		}
+	}
+}

--- a/modules/user/token_writer_guard_test.go
+++ b/modules/user/token_writer_guard_test.go
@@ -1,26 +1,93 @@
 package user
 
 import (
-	"os"
-	"strings"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	gotoken "go/token"
+	"io/fs"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
 func TestProductionTokenWritersUseSessionStore(t *testing.T) {
-	for _, path := range []string{"api.go", "api_manager.go"} {
-		src, err := os.ReadFile(path)
-		require.NoError(t, err)
-		body := string(src)
-		for _, forbidden := range []string{
-			"Cache.TokenCachePrefix+loginToken, payload)",
-			"Cache.TokenCachePrefix+token, tokenPayload",
-			"Cache.UIDTokenCachePrefix, flag, userInfo.UID), token",
-			"Cache.UIDTokenCachePrefix, flag, userModel.UID), token",
-			"Cache.UIDTokenCachePrefix, config.Web, userInfo.UID), token",
-		} {
-			require.False(t, strings.Contains(body, forbidden), "%s still bypasses Session Store with %q", path, forbidden)
+	var violations []string
+	err := filepath.WalkDir("..", func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
 		}
+		if entry.IsDir() || filepath.Ext(path) != ".go" || filepath.Ext(path) == ".test" || filepath.Base(path) == "token_writer_guard_test.go" {
+			return nil
+		}
+		if len(path) >= len("_test.go") && path[len(path)-len("_test.go"):] == "_test.go" {
+			return nil
+		}
+		found, err := directTokenWriterViolations(path)
+		if err != nil {
+			return err
+		}
+		violations = append(violations, found...)
+		return nil
+	})
+	require.NoError(t, err)
+	require.Empty(t, violations, "production token cache writes must go through pkg/auth Session Store")
+}
+
+func TestDirectTokenWriterGuardHandlesFormattingAndRenames(t *testing.T) {
+	source := `package fixture
+func write(ctx Context, renamed string) {
+	ctx.Cache().SetAndExpire(
+		ctx.GetConfig().Cache.TokenCachePrefix + renamed,
+		"payload",
+		minute,
+	)
+}`
+	fset := gotoken.NewFileSet()
+	file, err := parser.ParseFile(fset, "fixture.go", source, 0)
+	require.NoError(t, err)
+	require.Len(t, tokenWriterViolations(fset, file, "fixture.go"), 1)
+}
+
+func directTokenWriterViolations(path string) ([]string, error) {
+	fset := gotoken.NewFileSet()
+	file, err := parser.ParseFile(fset, path, nil, 0)
+	if err != nil {
+		return nil, err
 	}
+	return tokenWriterViolations(fset, file, path), nil
+}
+
+func tokenWriterViolations(fset *gotoken.FileSet, file *ast.File, path string) []string {
+	var violations []string
+	ast.Inspect(file, func(node ast.Node) bool {
+		call, ok := node.(*ast.CallExpr)
+		if !ok || len(call.Args) == 0 {
+			return true
+		}
+		selector, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok || (selector.Sel.Name != "Set" && selector.Sel.Name != "SetAndExpire" && selector.Sel.Name != "SetNX") {
+			return true
+		}
+		if expressionContainsTokenPrefix(call.Args[0]) {
+			position := fset.Position(call.Pos())
+			violations = append(violations, fmt.Sprintf("%s:%d calls %s with a token cache prefix", path, position.Line, selector.Sel.Name))
+		}
+		return true
+	})
+	return violations
+}
+
+func expressionContainsTokenPrefix(expression ast.Expr) bool {
+	found := false
+	ast.Inspect(expression, func(node ast.Node) bool {
+		selector, ok := node.(*ast.SelectorExpr)
+		if ok && (selector.Sel.Name == "TokenCachePrefix" || selector.Sel.Name == "UIDTokenCachePrefix") {
+			found = true
+			return false
+		}
+		return !found
+	})
+	return found
 }

--- a/modules/user/token_writer_guard_test.go
+++ b/modules/user/token_writer_guard_test.go
@@ -50,6 +50,21 @@ func write(ctx Context, renamed string) {
 	require.Len(t, tokenWriterViolations(fset, file, "fixture.go"), 1)
 }
 
+func TestDirectTokenWriterGuardRejectsDeadlineMutationMethods(t *testing.T) {
+	for _, method := range []string{"Persist", "Expire", "ExpireAt"} {
+		t.Run(method, func(t *testing.T) {
+			source := fmt.Sprintf(`package fixture
+func write(ctx Context, renamed string) {
+	ctx.Cache().%s(ctx.GetConfig().Cache.TokenCachePrefix + renamed, deadline)
+}`, method)
+			fset := gotoken.NewFileSet()
+			file, err := parser.ParseFile(fset, "fixture.go", source, 0)
+			require.NoError(t, err)
+			require.Len(t, tokenWriterViolations(fset, file, "fixture.go"), 1)
+		})
+	}
+}
+
 func directTokenWriterViolations(path string) ([]string, error) {
 	fset := gotoken.NewFileSet()
 	file, err := parser.ParseFile(fset, path, nil, 0)

--- a/modules/user/token_writer_guard_test.go
+++ b/modules/user/token_writer_guard_test.go
@@ -6,22 +6,33 @@ import (
 	"go/parser"
 	gotoken "go/token"
 	"io/fs"
+	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
 func TestProductionTokenWritersUseSessionStore(t *testing.T) {
+	root := tokenWriterRepoRoot(t)
+	authPackage := filepath.Join(root, "pkg", "auth")
 	var violations []string
-	err := filepath.WalkDir("..", func(path string, entry fs.DirEntry, walkErr error) error {
+	err := filepath.WalkDir(root, func(path string, entry fs.DirEntry, walkErr error) error {
 		if walkErr != nil {
 			return walkErr
 		}
-		if entry.IsDir() || filepath.Ext(path) != ".go" || filepath.Ext(path) == ".test" || filepath.Base(path) == "token_writer_guard_test.go" {
+		if entry.IsDir() {
+			switch entry.Name() {
+			case ".git", ".context", "vendor", "node_modules":
+				return filepath.SkipDir
+			}
+			if path == authPackage {
+				return filepath.SkipDir
+			}
 			return nil
 		}
-		if len(path) >= len("_test.go") && path[len(path)-len("_test.go"):] == "_test.go" {
+		if filepath.Ext(path) != ".go" || strings.HasSuffix(path, "_test.go") {
 			return nil
 		}
 		found, err := directTokenWriterViolations(path)
@@ -82,7 +93,12 @@ func tokenWriterViolations(fset *gotoken.FileSet, file *ast.File, path string) [
 			return true
 		}
 		selector, ok := call.Fun.(*ast.SelectorExpr)
-		if !ok || (selector.Sel.Name != "Set" && selector.Sel.Name != "SetAndExpire" && selector.Sel.Name != "SetNX") {
+		if !ok {
+			return true
+		}
+		switch selector.Sel.Name {
+		case "Set", "SetAndExpire", "SetNX", "Persist", "Expire", "ExpireAt":
+		default:
 			return true
 		}
 		if expressionContainsTokenPrefix(call.Args[0]) {
@@ -92,6 +108,22 @@ func tokenWriterViolations(fset *gotoken.FileSet, file *ast.File, path string) [
 		return true
 	})
 	return violations
+}
+
+func tokenWriterRepoRoot(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	require.NoError(t, err)
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatal("go.mod not found walking up from test directory")
+		}
+		dir = parent
+	}
 }
 
 func expressionContainsTokenPrefix(expression ast.Expr) bool {

--- a/pkg/auth/parser.go
+++ b/pkg/auth/parser.go
@@ -75,10 +75,20 @@ type CacheTokenParser struct {
 	Prefix       string
 	resolver     LanguageResolver
 	roleResolver RoleResolver
+	validator    *TokenValidator
 }
 
 // ParserOption configures optional CacheTokenParser behaviour.
 type ParserOption func(*CacheTokenParser)
+
+// WithTokenValidator makes Parse use the canonical payload+PTTL validator.
+func WithTokenValidator(v *TokenValidator) ParserOption {
+	return func(p *CacheTokenParser) {
+		if v != nil {
+			p.validator = v
+		}
+	}
+}
 
 // WithLanguageResolver wires a LanguageResolver into the parser; nil resolver
 // is a no-op so callers can pass an interface value that may be unset in test
@@ -127,20 +137,31 @@ func (p *CacheTokenParser) Parse(ctx context.Context, token string) (wkhttp.User
 	parseStart := time.Now()
 	var tokenMs, langMs, roleMs int64
 	tokenStart := time.Now()
-	raw, err := p.Cache.Get(p.Prefix + token)
+	var info TokenInfo
+	var err error
+	if p.validator != nil {
+		info, err = p.validator.Validate(ctx, token)
+	} else {
+		var raw string
+		raw, err = p.Cache.Get(p.Prefix + token)
+		if err != nil {
+			err = fmt.Errorf("auth: load token from cache: %w", err)
+		} else if strings.TrimSpace(raw) == "" {
+			err = wkhttp.ErrTokenNotFound
+		} else {
+			info, err = Decode(raw)
+			if errors.Is(err, ErrEmptyToken) {
+				err = wkhttp.ErrTokenNotFound
+			} else if err != nil {
+				err = fmt.Errorf("%w: %v", wkhttp.ErrTokenInvalid, err)
+			} else if info.IsV3() {
+				err = fmt.Errorf("%w: v3 token requires ttl-aware validator", wkhttp.ErrTokenInvalid)
+			}
+		}
+	}
 	tokenMs = time.Since(tokenStart).Milliseconds()
 	if err != nil {
-		return wkhttp.UserInfo{}, fmt.Errorf("auth: load token from cache: %w", err)
-	}
-	if strings.TrimSpace(raw) == "" {
-		return wkhttp.UserInfo{}, wkhttp.ErrTokenNotFound
-	}
-	info, err := Decode(raw)
-	if err != nil {
-		if errors.Is(err, ErrEmptyToken) {
-			return wkhttp.UserInfo{}, wkhttp.ErrTokenNotFound
-		}
-		return wkhttp.UserInfo{}, fmt.Errorf("%w: %v", wkhttp.ErrTokenInvalid, err)
+		return wkhttp.UserInfo{}, err
 	}
 	language := info.Language
 	if p.resolver != nil {

--- a/pkg/auth/parser_test.go
+++ b/pkg/auth/parser_test.go
@@ -21,6 +21,15 @@ type fakeTokenRecordReader struct {
 	err     error
 }
 
+type fakeSessionGenerationResolver struct {
+	generation string
+	err        error
+}
+
+func (r fakeSessionGenerationResolver) CurrentGeneration(context.Context, string) (string, error) {
+	return r.generation, r.err
+}
+
 func (r *fakeTokenRecordReader) ReadToken(_ context.Context, key string) (TokenRecord, error) {
 	if r.err != nil {
 		return TokenRecord{}, r.err
@@ -354,19 +363,26 @@ func TestTokenValidatorV3LifetimeAndRedisTTL(t *testing.T) {
 	}
 
 	tests := []struct {
-		name   string
-		record TokenRecord
-		wantOK bool
+		name       string
+		record     TokenRecord
+		generation string
+		wantOK     bool
 	}{
-		{name: "finite and before absolute deadline", record: TokenRecord{Payload: valid, TTL: time.Minute}, wantOK: true},
-		{name: "persistent redis key", record: TokenRecord{Payload: valid, TTL: -1}},
-		{name: "expired payload", record: TokenRecord{Payload: expired, TTL: time.Minute}},
-		{name: "missing key", record: TokenRecord{TTL: -2}},
+		{name: "finite and before absolute deadline", record: TokenRecord{Payload: valid, TTL: time.Minute}, generation: "g1", wantOK: true},
+		{name: "persistent redis key", record: TokenRecord{Payload: valid, TTL: -1}, generation: "g1"},
+		{name: "expired payload", record: TokenRecord{Payload: expired, TTL: time.Minute}, generation: "g1"},
+		{name: "generation mismatch", record: TokenRecord{Payload: valid, TTL: time.Minute}, generation: "g2"},
+		{name: "missing key", record: TokenRecord{TTL: -2}, generation: "g1"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			reader := &fakeTokenRecordReader{records: map[string]TokenRecord{testPrefix + "tok": tt.record}}
-			validator := NewTokenValidator(reader, testPrefix, WithValidatorClock(func() time.Time { return now }))
+			validator := NewTokenValidator(
+				reader,
+				testPrefix,
+				WithValidatorClock(func() time.Time { return now }),
+				WithSessionGenerationResolver(fakeSessionGenerationResolver{generation: tt.generation}),
+			)
 			_, validateErr := validator.Validate(context.Background(), "tok")
 			if tt.wantOK && validateErr != nil {
 				t.Fatalf("Validate: %v", validateErr)

--- a/pkg/auth/parser_test.go
+++ b/pkg/auth/parser_test.go
@@ -16,6 +16,18 @@ type fakeCache struct {
 	getErr error
 }
 
+type fakeTokenRecordReader struct {
+	records map[string]TokenRecord
+	err     error
+}
+
+func (r *fakeTokenRecordReader) ReadToken(_ context.Context, key string) (TokenRecord, error) {
+	if r.err != nil {
+		return TokenRecord{}, r.err
+	}
+	return r.records[key], nil
+}
+
 func newFakeCache() *fakeCache { return &fakeCache{store: map[string]string{}} }
 
 func (c *fakeCache) Set(key, value string) error { c.store[key] = value; return nil }
@@ -128,8 +140,8 @@ func TestCacheTokenParserPropagatesCacheError(t *testing.T) {
 // stubResolver is used to exercise the LanguageResolver hook without pulling
 // modules/user into pkg/auth's test deps.
 type stubResolver struct {
-	lang string
-	err  error
+	lang   string
+	err    error
 	gotUID string
 }
 
@@ -316,5 +328,94 @@ func TestWithRoleResolverNilIsNoOp(t *testing.T) {
 	}
 	if got.Role != "admin" {
 		t.Fatalf("without a resolver the token snapshot role must pass through, got %q", got.Role)
+	}
+}
+
+func TestTokenValidatorV3LifetimeAndRedisTTL(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, time.August, 9, 8, 0, 0, 0, time.UTC)
+	valid, err := EncodeV3(TokenInfo{
+		UID:               "u1",
+		IssuedAt:          now.Add(-time.Hour).Unix(),
+		ExpiresAt:         now.Add(time.Hour).Unix(),
+		SessionGeneration: "g1",
+	})
+	if err != nil {
+		t.Fatalf("EncodeV3: %v", err)
+	}
+	expired, err := EncodeV3(TokenInfo{
+		UID:               "u1",
+		IssuedAt:          now.Add(-2 * time.Hour).Unix(),
+		ExpiresAt:         now.Unix(),
+		SessionGeneration: "g1",
+	})
+	if err != nil {
+		t.Fatalf("EncodeV3 expired: %v", err)
+	}
+
+	tests := []struct {
+		name   string
+		record TokenRecord
+		wantOK bool
+	}{
+		{name: "finite and before absolute deadline", record: TokenRecord{Payload: valid, TTL: time.Minute}, wantOK: true},
+		{name: "persistent redis key", record: TokenRecord{Payload: valid, TTL: -1}},
+		{name: "expired payload", record: TokenRecord{Payload: expired, TTL: time.Minute}},
+		{name: "missing key", record: TokenRecord{TTL: -2}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reader := &fakeTokenRecordReader{records: map[string]TokenRecord{testPrefix + "tok": tt.record}}
+			validator := NewTokenValidator(reader, testPrefix, WithValidatorClock(func() time.Time { return now }))
+			_, validateErr := validator.Validate(context.Background(), "tok")
+			if tt.wantOK && validateErr != nil {
+				t.Fatalf("Validate: %v", validateErr)
+			}
+			if !tt.wantOK && !errors.Is(validateErr, wkhttp.ErrTokenInvalid) && !errors.Is(validateErr, wkhttp.ErrTokenNotFound) {
+				t.Fatalf("Validate: want auth sentinel, got %v", validateErr)
+			}
+		})
+	}
+}
+
+func TestTokenValidatorKeepsLegacyCompatibility(t *testing.T) {
+	t.Parallel()
+	v2, err := Encode(TokenInfo{UID: "u1", Name: "alice"})
+	if err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+	reader := &fakeTokenRecordReader{records: map[string]TokenRecord{
+		testPrefix + "v2":     {Payload: v2, TTL: time.Minute},
+		testPrefix + "legacy": {Payload: "u1@alice", TTL: -1},
+	}}
+	validator := NewTokenValidator(reader, testPrefix)
+	for _, token := range []string{"v2", "legacy"} {
+		if _, err := validator.Validate(context.Background(), token); err != nil {
+			t.Fatalf("Validate(%q): legacy compatibility must remain enabled, got %v", token, err)
+		}
+	}
+}
+
+func TestCacheTokenParserUsesTokenValidator(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, time.August, 9, 8, 0, 0, 0, time.UTC)
+	raw, err := EncodeV3(TokenInfo{
+		UID:               "u1",
+		IssuedAt:          now.Add(-2 * time.Hour).Unix(),
+		ExpiresAt:         now.Unix(),
+		SessionGeneration: "g1",
+	})
+	if err != nil {
+		t.Fatalf("EncodeV3: %v", err)
+	}
+	reader := &fakeTokenRecordReader{records: map[string]TokenRecord{
+		testPrefix + "tok": {Payload: raw, TTL: time.Minute},
+	}}
+	validator := NewTokenValidator(reader, testPrefix, WithValidatorClock(func() time.Time { return now }))
+	p := NewCacheTokenParser(newFakeCache(), testPrefix, WithTokenValidator(validator))
+
+	_, err = p.Parse(context.Background(), "tok")
+	if !errors.Is(err, wkhttp.ErrTokenInvalid) {
+		t.Fatalf("Parse: expired v3 must be rejected, got %v", err)
 	}
 }

--- a/pkg/auth/reader_guard_test.go
+++ b/pkg/auth/reader_guard_test.go
@@ -1,0 +1,29 @@
+package auth
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestExplicitTokenReadersDoNotBypassValidator(t *testing.T) {
+	for _, path := range []string{
+		"../../modules/group/api.go",
+		"../../modules/message/api.go",
+		"../../modules/qrcode/api.go",
+		"../../modules/user/api.go",
+	} {
+		src, err := os.ReadFile(path)
+		require.NoError(t, err)
+		body := string(src)
+		require.False(t, strings.Contains(body, "auth.Decode("), "%s contains an ad-hoc token decoder", path)
+		for lineNo, line := range strings.Split(body, "\n") {
+			require.False(t,
+				strings.Contains(line, "Cache().Get(") && strings.Contains(line, "TokenCachePrefix"),
+				"%s:%d contains a direct token-cache reader", path, lineNo+1,
+			)
+		}
+	}
+}

--- a/pkg/auth/runtime.go
+++ b/pkg/auth/runtime.go
@@ -1,6 +1,11 @@
 package auth
 
 import (
+	"fmt"
+	"os"
+	"runtime"
+	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -10,6 +15,19 @@ import (
 )
 
 const sessionRuntimeContextKey = "octo-server/auth/session-runtime/v1"
+
+const (
+	sessionRedisPoolSizeEnv        = "OCTO_AUTH_SESSION_REDIS_POOL_SIZE"
+	sessionRedisPoolTimeoutEnv     = "OCTO_AUTH_SESSION_REDIS_POOL_TIMEOUT"
+	sessionRedisPoolSizeMax        = 4096
+	sessionRedisPoolTimeoutMax     = 30 * time.Second
+	sessionRedisPoolTimeoutDefault = 3 * time.Second
+)
+
+type sessionRedisOptions struct {
+	poolSize    int
+	poolTimeout time.Duration
+}
 
 type sessionRuntime struct {
 	store  *RedisSessionStore
@@ -42,13 +60,17 @@ func SessionStoreAndClientForContext(ctx *config.Context) (*RedisSessionStore, *
 	if existing, ok := ctx.Value(sessionRuntimeContextKey).(*sessionRuntime); ok {
 		return existing.store, existing.client
 	}
+	options, err := sessionRedisOptionsFromEnv()
+	if err != nil {
+		panic(err)
+	}
 	client := octoredis.NewInstrumentedClient(ctx.GetConfig(), func(o *rd.Options) {
 		o.MaxRetries = 1
-		o.PoolSize = 10
+		o.PoolSize = options.poolSize
 		o.DialTimeout = 2 * time.Second
 		o.ReadTimeout = 2 * time.Second
 		o.WriteTimeout = 2 * time.Second
-		o.PoolTimeout = time.Second
+		o.PoolTimeout = options.poolTimeout
 	})
 	store := NewRedisSessionStore(
 		client,
@@ -58,4 +80,41 @@ func SessionStoreAndClientForContext(ctx *config.Context) (*RedisSessionStore, *
 	)
 	ctx.SetValue(&sessionRuntime{store: store, client: client}, sessionRuntimeContextKey)
 	return store, client
+}
+
+func sessionRedisOptionsFromEnv() (sessionRedisOptions, error) {
+	options := sessionRedisOptions{
+		poolSize:    10 * runtime.GOMAXPROCS(0),
+		poolTimeout: sessionRedisPoolTimeoutDefault,
+	}
+	if raw, ok := os.LookupEnv(sessionRedisPoolSizeEnv); ok {
+		value := strings.TrimSpace(raw)
+		parsed, err := strconv.ParseInt(value, 10, 32)
+		if err != nil || parsed <= 0 {
+			return sessionRedisOptions{}, fmt.Errorf("%s must be a positive integer", sessionRedisPoolSizeEnv)
+		}
+		maxPoolSize := sessionRedisPoolSizeMax
+		if options.poolSize > maxPoolSize {
+			maxPoolSize = options.poolSize
+		}
+		if parsed > int64(maxPoolSize) {
+			return sessionRedisOptions{}, fmt.Errorf("%s must not exceed %d", sessionRedisPoolSizeEnv, maxPoolSize)
+		}
+		options.poolSize = int(parsed)
+	}
+	if raw, ok := os.LookupEnv(sessionRedisPoolTimeoutEnv); ok {
+		value := strings.TrimSpace(raw)
+		parsed, err := time.ParseDuration(value)
+		if err != nil {
+			return sessionRedisOptions{}, fmt.Errorf("invalid %s %q: %w", sessionRedisPoolTimeoutEnv, value, err)
+		}
+		if parsed <= 0 {
+			return sessionRedisOptions{}, fmt.Errorf("%s must be greater than zero", sessionRedisPoolTimeoutEnv)
+		}
+		if parsed > sessionRedisPoolTimeoutMax {
+			return sessionRedisOptions{}, fmt.Errorf("%s must not exceed %s", sessionRedisPoolTimeoutEnv, sessionRedisPoolTimeoutMax)
+		}
+		options.poolTimeout = parsed
+	}
+	return options, nil
 }

--- a/pkg/auth/runtime.go
+++ b/pkg/auth/runtime.go
@@ -1,0 +1,61 @@
+package auth
+
+import (
+	"sync"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	octoredis "github.com/Mininglamp-OSS/octo-server/pkg/redis"
+	rd "github.com/go-redis/redis"
+)
+
+const sessionRuntimeContextKey = "octo-server/auth/session-runtime/v1"
+
+type sessionRuntime struct {
+	store  *RedisSessionStore
+	client *rd.Client
+}
+
+var sessionRuntimeMu sync.Mutex
+
+// SessionStoreForContext returns one bounded Redis pool per server context.
+// All modules in a replica share it; security hardening must not multiply
+// connection pools with the number of token-consuming modules.
+func SessionStoreForContext(ctx *config.Context) *RedisSessionStore {
+	store, _ := SessionStoreAndClientForContext(ctx)
+	return store
+}
+
+// SessionStoreAndClientForContext also exposes the shared client to adjacent
+// auth stores that require Lua. Callers must not close it independently; its
+// lifetime is the same as the config.Context, matching existing Redis pools.
+func SessionStoreAndClientForContext(ctx *config.Context) (*RedisSessionStore, *rd.Client) {
+	if ctx == nil {
+		panic("auth: session store requires non-nil context")
+	}
+	if existing, ok := ctx.Value(sessionRuntimeContextKey).(*sessionRuntime); ok {
+		return existing.store, existing.client
+	}
+
+	sessionRuntimeMu.Lock()
+	defer sessionRuntimeMu.Unlock()
+	if existing, ok := ctx.Value(sessionRuntimeContextKey).(*sessionRuntime); ok {
+		return existing.store, existing.client
+	}
+	client := octoredis.NewInstrumentedClient(ctx.GetConfig(), func(o *rd.Options) {
+		o.MaxRetries = 1
+		o.PoolSize = 10
+		o.DialTimeout = 2 * time.Second
+		o.ReadTimeout = 2 * time.Second
+		o.WriteTimeout = 2 * time.Second
+		o.PoolTimeout = time.Second
+	})
+	store := NewRedisSessionStore(
+		client,
+		ctx.GetConfig().Cache.TokenCachePrefix,
+		ctx.GetConfig().Cache.UIDTokenCachePrefix,
+		ctx.GetConfig().Cache.TokenExpire,
+	)
+	ctx.SetValue(&sessionRuntime{store: store, client: client}, sessionRuntimeContextKey)
+	return store, client
+}

--- a/pkg/auth/runtime_test.go
+++ b/pkg/auth/runtime_test.go
@@ -1,6 +1,8 @@
 package auth
 
 import (
+	"os"
+	"runtime"
 	"testing"
 	"time"
 
@@ -9,6 +11,7 @@ import (
 )
 
 func TestSessionStoreForContextSharesOneBoundedPool(t *testing.T) {
+	unsetSessionRuntimeEnv(t)
 	ctx := config.NewContext(config.New())
 	store1, client1 := SessionStoreAndClientForContext(ctx)
 	store2, client2 := SessionStoreAndClientForContext(ctx)
@@ -16,7 +19,70 @@ func TestSessionStoreForContextSharesOneBoundedPool(t *testing.T) {
 
 	require.Same(t, store1, store2)
 	require.Same(t, client1, client2)
-	require.Equal(t, 10, client1.Options().PoolSize)
-	require.Equal(t, time.Second, client1.Options().PoolTimeout)
+	require.Equal(t, 10*runtime.GOMAXPROCS(0), client1.Options().PoolSize)
+	require.Equal(t, 3*time.Second, client1.Options().PoolTimeout)
 	require.Equal(t, 1, client1.Options().MaxRetries)
+}
+
+func TestSessionStoreForContextHonorsPoolOverrides(t *testing.T) {
+	unsetSessionRuntimeEnv(t)
+	t.Setenv("OCTO_AUTH_SESSION_REDIS_POOL_SIZE", "37")
+	t.Setenv("OCTO_AUTH_SESSION_REDIS_POOL_TIMEOUT", "1500ms")
+
+	ctx := config.NewContext(config.New())
+	_, client := SessionStoreAndClientForContext(ctx)
+	t.Cleanup(func() { _ = client.Close() })
+
+	require.Equal(t, 37, client.Options().PoolSize)
+	require.Equal(t, 1500*time.Millisecond, client.Options().PoolTimeout)
+}
+
+func TestSessionStoreForContextRejectsInvalidPoolOverrides(t *testing.T) {
+	tests := []struct {
+		name  string
+		key   string
+		value string
+	}{
+		{name: "empty size", key: "OCTO_AUTH_SESSION_REDIS_POOL_SIZE", value: ""},
+		{name: "zero size", key: "OCTO_AUTH_SESSION_REDIS_POOL_SIZE", value: "0"},
+		{name: "negative size", key: "OCTO_AUTH_SESSION_REDIS_POOL_SIZE", value: "-1"},
+		{name: "malformed size", key: "OCTO_AUTH_SESSION_REDIS_POOL_SIZE", value: "many"},
+		{name: "oversized pool", key: "OCTO_AUTH_SESSION_REDIS_POOL_SIZE", value: "4097"},
+		{name: "empty timeout", key: "OCTO_AUTH_SESSION_REDIS_POOL_TIMEOUT", value: ""},
+		{name: "zero timeout", key: "OCTO_AUTH_SESSION_REDIS_POOL_TIMEOUT", value: "0s"},
+		{name: "negative timeout", key: "OCTO_AUTH_SESSION_REDIS_POOL_TIMEOUT", value: "-1s"},
+		{name: "malformed timeout", key: "OCTO_AUTH_SESSION_REDIS_POOL_TIMEOUT", value: "soon"},
+		{name: "oversized timeout", key: "OCTO_AUTH_SESSION_REDIS_POOL_TIMEOUT", value: "31s"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			unsetSessionRuntimeEnv(t)
+			t.Setenv(tt.key, tt.value)
+			ctx := config.NewContext(config.New())
+
+			require.Panics(t, func() {
+				_, client := SessionStoreAndClientForContext(ctx)
+				t.Cleanup(func() { _ = client.Close() })
+			})
+		})
+	}
+}
+
+func unsetSessionRuntimeEnv(t *testing.T) {
+	t.Helper()
+	for _, key := range []string{
+		"OCTO_AUTH_SESSION_REDIS_POOL_SIZE",
+		"OCTO_AUTH_SESSION_REDIS_POOL_TIMEOUT",
+	} {
+		old, existed := os.LookupEnv(key)
+		require.NoError(t, os.Unsetenv(key))
+		t.Cleanup(func() {
+			if existed {
+				_ = os.Setenv(key, old)
+				return
+			}
+			_ = os.Unsetenv(key)
+		})
+	}
 }

--- a/pkg/auth/runtime_test.go
+++ b/pkg/auth/runtime_test.go
@@ -1,0 +1,22 @@
+package auth
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSessionStoreForContextSharesOneBoundedPool(t *testing.T) {
+	ctx := config.NewContext(config.New())
+	store1, client1 := SessionStoreAndClientForContext(ctx)
+	store2, client2 := SessionStoreAndClientForContext(ctx)
+	t.Cleanup(func() { _ = client1.Close() })
+
+	require.Same(t, store1, store2)
+	require.Same(t, client1, client2)
+	require.Equal(t, 10, client1.Options().PoolSize)
+	require.Equal(t, time.Second, client1.Options().PoolTimeout)
+	require.Equal(t, 1, client1.Options().MaxRetries)
+}

--- a/pkg/auth/session_hardening_test.go
+++ b/pkg/auth/session_hardening_test.go
@@ -1,0 +1,221 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	octoredis "github.com/Mininglamp-OSS/octo-server/pkg/redis"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRedisSessionStoreDeviceLookupAndCompensation(t *testing.T) {
+	cfg := config.New()
+	client := octoredis.NewInstrumentedClient(cfg)
+	store := NewRedisSessionStore(client, cfg.Cache.TokenCachePrefix, cfg.Cache.UIDTokenCachePrefix, time.Minute)
+	uid := "session-compensation-" + util.GenerUUID()
+	uidKey := cfg.Cache.UIDTokenCachePrefix + "1" + uid
+	token := "session-issued-" + util.GenerUUID()
+	replacement := "session-replacement-" + util.GenerUUID()
+	t.Cleanup(func() {
+		_ = client.Del(cfg.Cache.TokenCachePrefix+token, uidKey).Err()
+		_ = client.Close()
+	})
+
+	require.NoError(t, store.IssueNew(context.Background(), token, "payload", uid, 1))
+	got, err := store.DeviceToken(context.Background(), uid, 1)
+	require.NoError(t, err)
+	require.Equal(t, token, got)
+
+	// A newer replica may have replaced the compatibility index before an
+	// older issue attempt compensates. RevokeIssued must never erase the newer
+	// index; compare-delete limits cleanup to the credential it owns.
+	require.NoError(t, client.Set(uidKey, replacement, time.Minute).Err())
+	require.NoError(t, store.RevokeIssued(context.Background(), token, uid, 1))
+	got, err = store.DeviceToken(context.Background(), uid, 1)
+	require.NoError(t, err)
+	require.Equal(t, replacement, got)
+	exists, err := client.Exists(cfg.Cache.TokenCachePrefix + token).Result()
+	require.NoError(t, err)
+	require.Zero(t, exists)
+
+	require.NoError(t, client.Del(uidKey).Err())
+	got, err = store.DeviceToken(context.Background(), uid, 1)
+	require.NoError(t, err)
+	require.Empty(t, got)
+}
+
+func TestRedisSessionStoreReadsAtomicPayloadAndTTLStates(t *testing.T) {
+	cfg := config.New()
+	client := octoredis.NewInstrumentedClient(cfg)
+	prefix := "session-read-" + util.GenerUUID() + ":"
+	store := NewRedisSessionStore(client, prefix, "session-read-uid:", time.Minute)
+	finiteKey := prefix + "finite"
+	persistentKey := prefix + "persistent"
+	t.Cleanup(func() {
+		_ = client.Del(finiteKey, persistentKey).Err()
+		_ = client.Close()
+	})
+
+	require.NoError(t, client.Set(finiteKey, "finite-payload", time.Minute).Err())
+	require.NoError(t, client.Set(persistentKey, "persistent-payload", 0).Err())
+
+	finite, err := store.ReadToken(context.Background(), finiteKey)
+	require.NoError(t, err)
+	require.Equal(t, "finite-payload", finite.Payload)
+	require.Positive(t, finite.TTL)
+
+	persistent, err := store.ReadToken(context.Background(), persistentKey)
+	require.NoError(t, err)
+	require.Equal(t, "persistent-payload", persistent.Payload)
+	require.Equal(t, time.Duration(-1), persistent.TTL)
+
+	missing, err := store.ReadToken(context.Background(), prefix+"missing")
+	require.NoError(t, err)
+	require.Equal(t, time.Duration(-2), missing.TTL)
+}
+
+func TestRedisSessionStoreRejectsInvalidInputsAndCancelledWork(t *testing.T) {
+	cfg := config.New()
+	client := octoredis.NewInstrumentedClient(cfg)
+	store := NewRedisSessionStore(client, cfg.Cache.TokenCachePrefix, cfg.Cache.UIDTokenCachePrefix, time.Minute)
+	t.Cleanup(func() { _ = client.Close() })
+
+	require.Error(t, store.IssueNew(context.Background(), "", "payload", "u1", 1))
+	_, err := store.ReuseExisting(context.Background(), "", "payload", "u1", 1)
+	require.Error(t, err)
+	_, err = store.UpdatePayloadKeepDeadline(context.Background(), "", "payload")
+	require.Error(t, err)
+	_, err = store.DeviceToken(context.Background(), "", 1)
+	require.Error(t, err)
+	require.Error(t, store.DeleteToken(context.Background(), ""))
+	require.Error(t, store.RevokeIssued(context.Background(), "token", "", 1))
+	_, err = store.ReadToken(context.Background(), "")
+	require.Error(t, err)
+
+	cancelled, cancel := context.WithCancel(context.Background())
+	cancel()
+	require.ErrorIs(t, store.IssueNew(cancelled, "token", "payload", "u1", 1), context.Canceled)
+	_, err = store.ReuseExisting(cancelled, "token", "payload", "u1", 1)
+	require.ErrorIs(t, err, context.Canceled)
+	_, err = store.DeviceToken(cancelled, "u1", 1)
+	require.ErrorIs(t, err, context.Canceled)
+	require.ErrorIs(t, store.DeleteToken(cancelled, "token"), context.Canceled)
+	require.ErrorIs(t, store.RevokeIssued(cancelled, "token", "u1", 1), context.Canceled)
+	_, err = store.ReadToken(cancelled, "token:key")
+	require.ErrorIs(t, err, context.Canceled)
+	_, err = store.ObserveRateLimited(cancelled, 1, 0)
+	require.ErrorIs(t, err, context.Canceled)
+
+	_, err = store.ObserveRateLimited(context.Background(), 0, 0)
+	require.Error(t, err)
+	_, err = store.ObserveRateLimited(context.Background(), 1, -time.Millisecond)
+	require.Error(t, err)
+}
+
+func TestSessionStoreConstructorsRejectUnsafeConfiguration(t *testing.T) {
+	require.Panics(t, func() { NewRedisSessionStore(nil, "token:", "uidtoken:", time.Minute) })
+
+	cfg := config.New()
+	client := octoredis.NewInstrumentedClient(cfg)
+	t.Cleanup(func() { _ = client.Close() })
+	require.Panics(t, func() { NewRedisSessionStore(client, "token:", "uidtoken:", 0) })
+	require.Panics(t, func() { SessionStoreForContext(nil) })
+
+	ctx := config.NewContext(cfg)
+	store, runtimeClient := SessionStoreAndClientForContext(ctx)
+	t.Cleanup(func() { _ = runtimeClient.Close() })
+	require.Same(t, store, SessionStoreForContext(ctx))
+}
+
+func TestRedisIntegerAcceptsRedisRepresentations(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		value   interface{}
+		want    int64
+		wantErr bool
+	}{
+		{name: "integer", value: int64(7), want: 7},
+		{name: "string", value: "-2", want: -2},
+		{name: "bytes", value: []byte("42"), want: 42},
+		{name: "malformed", value: "nope", wantErr: true},
+		{name: "unexpected type", value: 7, wantErr: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := redisInteger(tt.value)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestTokenValidatorFailsClosedAcrossStoreAndGenerationErrors(t *testing.T) {
+	now := time.Date(2026, time.August, 9, 8, 0, 0, 0, time.UTC)
+	v3, err := EncodeV3(TokenInfo{
+		UID:               "u1",
+		IssuedAt:          now.Add(-time.Minute).Unix(),
+		ExpiresAt:         now.Add(time.Minute).Unix(),
+		SessionGeneration: "g1",
+	})
+	require.NoError(t, err)
+	v2, err := Encode(TokenInfo{UID: "u1"})
+	require.NoError(t, err)
+	storeErr := errors.New("redis unavailable")
+	generationErr := errors.New("generation unavailable")
+
+	tests := []struct {
+		name       string
+		token      string
+		reader     *fakeTokenRecordReader
+		resolver   SessionGenerationResolver
+		want       error
+		wrappedErr error
+	}{
+		{name: "missing token input", token: " ", reader: &fakeTokenRecordReader{}, want: wkhttp.ErrTokenMissing},
+		{name: "store failure", token: "tok", reader: &fakeTokenRecordReader{err: storeErr}, wrappedErr: storeErr},
+		{name: "empty payload", token: "tok", reader: &fakeTokenRecordReader{records: map[string]TokenRecord{testPrefix + "tok": {TTL: time.Minute}}}, want: wkhttp.ErrTokenNotFound},
+		{name: "decode failure", token: "tok", reader: &fakeTokenRecordReader{records: map[string]TokenRecord{testPrefix + "tok": {Payload: "invalid", TTL: time.Minute}}}, want: wkhttp.ErrTokenInvalid},
+		{name: "v3 zero ttl", token: "tok", reader: &fakeTokenRecordReader{records: map[string]TokenRecord{testPrefix + "tok": {Payload: v3, TTL: 0}}}, want: wkhttp.ErrTokenInvalid},
+		{name: "v3 resolver missing", token: "tok", reader: &fakeTokenRecordReader{records: map[string]TokenRecord{testPrefix + "tok": {Payload: v3, TTL: time.Minute}}}, want: wkhttp.ErrTokenInvalid},
+		{name: "v3 resolver failure", token: "tok", reader: &fakeTokenRecordReader{records: map[string]TokenRecord{testPrefix + "tok": {Payload: v3, TTL: time.Minute}}}, resolver: fakeSessionGenerationResolver{err: generationErr}, wrappedErr: generationErr},
+		{name: "v3 empty generation", token: "tok", reader: &fakeTokenRecordReader{records: map[string]TokenRecord{testPrefix + "tok": {Payload: v3, TTL: time.Minute}}}, resolver: fakeSessionGenerationResolver{}, want: wkhttp.ErrTokenInvalid},
+		{name: "legacy zero ttl", token: "tok", reader: &fakeTokenRecordReader{records: map[string]TokenRecord{testPrefix + "tok": {Payload: v2, TTL: 0}}}, want: wkhttp.ErrTokenInvalid},
+		{name: "legacy invalid negative ttl", token: "tok", reader: &fakeTokenRecordReader{records: map[string]TokenRecord{testPrefix + "tok": {Payload: v2, TTL: -3}}}, want: wkhttp.ErrTokenInvalid},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			validator := NewTokenValidator(
+				tt.reader,
+				testPrefix,
+				WithValidatorClock(func() time.Time { return now }),
+				WithSessionGenerationResolver(tt.resolver),
+			)
+			_, err := validator.Validate(context.Background(), tt.token)
+			if tt.wrappedErr != nil {
+				require.ErrorIs(t, err, tt.wrappedErr)
+				return
+			}
+			require.ErrorIs(t, err, tt.want)
+		})
+	}
+}
+
+func TestTokenValidatorConstructorAndNilOptions(t *testing.T) {
+	require.Panics(t, func() { NewTokenValidator(nil, testPrefix) })
+	reader := &fakeTokenRecordReader{records: map[string]TokenRecord{}}
+	validator := NewTokenValidator(
+		reader,
+		testPrefix,
+		WithValidatorClock(nil),
+		WithSessionGenerationResolver(nil),
+	)
+	require.NotNil(t, validator.now)
+}

--- a/pkg/auth/session_hardening_test.go
+++ b/pkg/auth/session_hardening_test.go
@@ -26,7 +26,9 @@ func TestRedisSessionStoreDeviceLookupAndCompensation(t *testing.T) {
 		_ = client.Close()
 	})
 
-	require.NoError(t, store.IssueNew(context.Background(), token, "payload", uid, 1))
+	payload, err := Encode(TokenInfo{UID: uid, Name: "issued"})
+	require.NoError(t, err)
+	require.NoError(t, store.IssueNew(context.Background(), token, payload, uid, 1))
 	got, err := store.DeviceToken(context.Background(), uid, 1)
 	require.NoError(t, err)
 	require.Equal(t, token, got)

--- a/pkg/auth/session_hardening_test.go
+++ b/pkg/auth/session_hardening_test.go
@@ -49,6 +49,49 @@ func TestRedisSessionStoreDeviceLookupAndCompensation(t *testing.T) {
 	require.Empty(t, got)
 }
 
+func TestRedisSessionStoreCompensationPreservesTokenAdoptedByAnotherReplica(t *testing.T) {
+	cfg := config.New()
+	clientA := octoredis.NewInstrumentedClient(cfg)
+	clientB := octoredis.NewInstrumentedClient(cfg)
+	storeA := NewRedisSessionStore(clientA, cfg.Cache.TokenCachePrefix, cfg.Cache.UIDTokenCachePrefix, time.Minute)
+	storeB := NewRedisSessionStore(clientB, cfg.Cache.TokenCachePrefix, cfg.Cache.UIDTokenCachePrefix, time.Minute)
+	uid := "session-adopted-" + util.GenerUUID()
+	token := "session-adopted-token-" + util.GenerUUID()
+	tokenKey := cfg.Cache.TokenCachePrefix + token
+	uidKey := cfg.Cache.UIDTokenCachePrefix + "1" + uid
+	t.Cleanup(func() {
+		_ = clientA.Del(tokenKey, uidKey).Err()
+		_ = clientA.Close()
+		_ = clientB.Close()
+	})
+	payload, err := Encode(TokenInfo{UID: uid, Name: "same-payload"})
+	require.NoError(t, err)
+
+	// Replica A publishes a new credential, then stalls while updating IM.
+	require.NoError(t, storeA.IssueNew(context.Background(), token, payload, uid, 1))
+
+	// Replica B observes the compatibility index, adopts the same token, and
+	// completes its login. The payload is deliberately byte-identical so the
+	// store cannot mistake payload equality for issue-attempt ownership.
+	indexedToken, err := storeB.DeviceToken(context.Background(), uid, 1)
+	require.NoError(t, err)
+	require.Equal(t, token, indexedToken)
+	adopted, err := storeB.ReuseExisting(context.Background(), token, payload, uid, 1)
+	require.NoError(t, err)
+	require.True(t, adopted)
+
+	// Replica A's IM call now fails. Its compensation must not revoke the
+	// credential that replica B has already adopted and returned to a client.
+	require.NoError(t, storeA.RevokeIssued(context.Background(), token, uid, 1))
+	record, err := storeB.ReadToken(context.Background(), tokenKey)
+	require.NoError(t, err)
+	require.Equal(t, payload, record.Payload)
+	require.Positive(t, record.TTL)
+	indexedToken, err = storeB.DeviceToken(context.Background(), uid, 1)
+	require.NoError(t, err)
+	require.Equal(t, token, indexedToken)
+}
+
 func TestRedisSessionStoreReadsAtomicPayloadAndTTLStates(t *testing.T) {
 	cfg := config.New()
 	client := octoredis.NewInstrumentedClient(cfg)

--- a/pkg/auth/session_store.go
+++ b/pkg/auth/session_store.go
@@ -21,9 +21,16 @@ end
 return {value, redis.call("PTTL", KEYS[1])}
 `)
 	updatePayloadKeepDeadlineScript = rd.NewScript(`
+local current = redis.call("GET", KEYS[1])
+if not current then
+  return {-2, 0}
+end
 local ttl = redis.call("PTTL", KEYS[1])
 if ttl == -2 then
   return {-2, 0}
+end
+if string.sub(current, 1, 3) == "v3:" and string.sub(ARGV[1], 1, 3) ~= "v3:" then
+  return {-3, 0}
 end
 local persistent = 0
 if ttl == -1 then
@@ -45,7 +52,10 @@ return 0
 `)
 )
 
-var ErrTokenCollision = errors.New("auth: generated token already exists")
+var (
+	ErrTokenCollision        = errors.New("auth: generated token already exists")
+	ErrTokenVersionDowngrade = errors.New("auth: token payload version downgrade rejected")
+)
 
 // SessionObservation contains low-cardinality migration facts only. It never
 // includes a token, Redis key, UID, or payload.
@@ -180,6 +190,9 @@ func (s *RedisSessionStore) updatePayloadKeepDeadline(ctx context.Context, token
 	if ttlMS == -2 {
 		return 0, false, nil
 	}
+	if ttlMS == -3 {
+		return 0, false, ErrTokenVersionDowngrade
+	}
 	if ttlMS <= 0 {
 		return 0, false, fmt.Errorf("auth: update token payload returned invalid ttl %d", ttlMS)
 	}
@@ -187,6 +200,17 @@ func (s *RedisSessionStore) updatePayloadKeepDeadline(ctx context.Context, token
 		metrics.ObservePersistentSession()
 	}
 	return time.Duration(ttlMS) * time.Millisecond, true, nil
+}
+
+// Probe executes the same read-only, single-key Lua used by the authentication
+// hot path. It is intended for startup compatibility checks before accepting
+// traffic; it never creates or mutates a Redis key.
+func (s *RedisSessionStore) Probe(ctx context.Context) error {
+	const probeToken = "__octo_auth_session_lua_probe__"
+	if _, err := s.ReadToken(ctx, s.tokenKey(probeToken)); err != nil {
+		return fmt.Errorf("auth: probe session read script: %w", err)
+	}
+	return nil
 }
 
 func (s *RedisSessionStore) DeviceToken(ctx context.Context, uid string, deviceFlag int) (string, error) {
@@ -333,7 +357,7 @@ func (s *RedisSessionStore) ObserveRateLimited(ctx context.Context, batchSize in
 				continue
 			case record.TTL == -1:
 				stats.Persistent++
-			case record.TTL >= 0:
+			case record.TTL > 0:
 				stats.Finite++
 				if record.TTL > s.maxTTL {
 					stats.OverMax++

--- a/pkg/auth/session_store.go
+++ b/pkg/auth/session_store.go
@@ -2,6 +2,8 @@ package auth
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strconv"
@@ -51,6 +53,8 @@ end
 return 0
 `)
 )
+
+const issuedOwnerField = "_octo_issue_owner"
 
 var (
 	ErrTokenCollision        = errors.New("auth: generated token already exists")
@@ -105,8 +109,10 @@ func (s *RedisSessionStore) uidTokenKey(uid string, deviceFlag int) string {
 	return s.uidTokenPrefix + strconv.Itoa(deviceFlag) + uid
 }
 
-// IssueNew creates a finite bearer and compatibility device index. If the
-// index write fails, the new credential is deleted as compensation.
+// IssueNew creates a finite bearer and compatibility device index. The stored
+// payload carries an internal ownership marker until another request rewrites
+// it through ReuseExisting or UpdatePayloadKeepDeadline. If the index write
+// fails, only the still-owned credential is deleted as compensation.
 func (s *RedisSessionStore) IssueNew(ctx context.Context, token, payload, uid string, deviceFlag int) (err error) {
 	started := time.Now()
 	defer func() { metrics.ObserveSessionOperation("issue", started, err) }()
@@ -116,7 +122,11 @@ func (s *RedisSessionStore) IssueNew(ctx context.Context, token, payload, uid st
 	if err := ctx.Err(); err != nil {
 		return err
 	}
-	created, err := s.client.SetNX(s.tokenKey(token), payload, s.maxTTL).Result()
+	ownedPayload, err := markIssuedPayload(payload, token)
+	if err != nil {
+		return fmt.Errorf("auth: mark issued token payload: %w", err)
+	}
+	created, err := s.client.SetNX(s.tokenKey(token), ownedPayload, s.maxTTL).Result()
 	if err != nil {
 		return fmt.Errorf("auth: issue token: %w", err)
 	}
@@ -124,7 +134,11 @@ func (s *RedisSessionStore) IssueNew(ctx context.Context, token, payload, uid st
 		return ErrTokenCollision
 	}
 	if err := s.client.Set(s.uidTokenKey(uid, deviceFlag), token, s.maxTTL).Err(); err != nil {
-		cleanupErr := s.client.Del(s.tokenKey(token)).Err()
+		_, cleanupErr := compareDeleteScript.Run(
+			s.client,
+			[]string{s.tokenKey(token)},
+			ownedPayload,
+		).Result()
 		if cleanupErr != nil {
 			return fmt.Errorf("auth: bind token device: %w (credential cleanup failed: %v)", err, cleanupErr)
 		}
@@ -243,14 +257,51 @@ func (s *RedisSessionStore) DeleteToken(ctx context.Context, token string) error
 	return nil
 }
 
-// RevokeIssued compensates a new credential. Never use it for a reused token.
+// RevokeIssued compensates a credential only while it is still owned by its
+// original issue attempt. Adoption by another request removes the ownership
+// marker atomically with its payload update, making this method a no-op.
 func (s *RedisSessionStore) RevokeIssued(ctx context.Context, token, uid string, deviceFlag int) error {
-	if strings.TrimSpace(uid) == "" || deviceFlag < 0 {
-		return errors.New("auth: revoke token requires uid and non-negative device flag")
+	if strings.TrimSpace(token) == "" || strings.TrimSpace(uid) == "" || deviceFlag < 0 {
+		return errors.New("auth: revoke token requires token, uid, and non-negative device flag")
 	}
-	if err := s.DeleteToken(ctx, token); err != nil {
+	if err := ctx.Err(); err != nil {
 		return err
 	}
+	currentPayload, err := s.client.Get(s.tokenKey(token)).Result()
+	if err == rd.Nil {
+		return s.compareDeleteDeviceIndex(token, uid, deviceFlag)
+	}
+	if err != nil {
+		return fmt.Errorf("auth: load issued token for revoke: %w", err)
+	}
+	owner, ok := issuedPayloadOwner(currentPayload)
+	if !ok || owner != issueOwner(token) {
+		// ReuseExisting and UpdatePayloadKeepDeadline rewrite the canonical
+		// payload without the issue marker. Once that happens, another request
+		// owns the live credential and the original issuer must not revoke it.
+		return nil
+	}
+	result, err := compareDeleteScript.Run(
+		s.client,
+		[]string{s.tokenKey(token)},
+		currentPayload,
+	).Result()
+	if err != nil {
+		return fmt.Errorf("auth: delete issued token: %w", err)
+	}
+	deleted, err := redisInteger(result)
+	if err != nil {
+		return fmt.Errorf("auth: decode issued token delete result: %w", err)
+	}
+	if deleted == 0 {
+		// The token changed after the ownership read. Preserve both keys: the
+		// concurrent writer may have adopted this credential.
+		return nil
+	}
+	return s.compareDeleteDeviceIndex(token, uid, deviceFlag)
+}
+
+func (s *RedisSessionStore) compareDeleteDeviceIndex(token, uid string, deviceFlag int) error {
 	if _, err := compareDeleteScript.Run(
 		s.client,
 		[]string{s.uidTokenKey(uid, deviceFlag)},
@@ -259,6 +310,68 @@ func (s *RedisSessionStore) RevokeIssued(ctx context.Context, token, uid string,
 		return fmt.Errorf("auth: delete token device index: %w", err)
 	}
 	return nil
+}
+
+func markIssuedPayload(payload, token string) (string, error) {
+	prefix, body, err := versionedPayloadJSON(payload)
+	if err != nil {
+		return "", err
+	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(body), &fields); err != nil {
+		return "", fmt.Errorf("decode token payload: %w", err)
+	}
+	if fields == nil {
+		return "", errors.New("decode token payload: expected JSON object")
+	}
+	owner, err := json.Marshal(issueOwner(token))
+	if err != nil {
+		return "", fmt.Errorf("encode issue owner: %w", err)
+	}
+	fields[issuedOwnerField] = owner
+	marked, err := json.Marshal(fields)
+	if err != nil {
+		return "", fmt.Errorf("encode issued token payload: %w", err)
+	}
+	return prefix + string(marked), nil
+}
+
+func issuedPayloadOwner(payload string) (string, bool) {
+	_, body, err := versionedPayloadJSON(payload)
+	if err != nil {
+		return "", false
+	}
+	var marker struct {
+		Owner string `json:"_octo_issue_owner"`
+	}
+	if err := json.Unmarshal([]byte(body), &marker); err != nil || marker.Owner == "" {
+		return "", false
+	}
+	return marker.Owner, true
+}
+
+func versionedPayloadJSON(payload string) (string, string, error) {
+	switch {
+	case strings.HasPrefix(payload, v2Prefix):
+		return v2Prefix, strings.TrimPrefix(payload, v2Prefix), nil
+	case strings.HasPrefix(payload, v3Prefix):
+		return v3Prefix, strings.TrimPrefix(payload, v3Prefix), nil
+	default:
+		info, err := Decode(payload)
+		if err != nil {
+			return "", "", fmt.Errorf("decode token payload: %w", err)
+		}
+		encoded, err := Encode(info)
+		if err != nil {
+			return "", "", err
+		}
+		return v2Prefix, strings.TrimPrefix(encoded, v2Prefix), nil
+	}
+}
+
+func issueOwner(token string) string {
+	sum := sha256.Sum256([]byte(token))
+	return fmt.Sprintf("%x", sum[:])
 }
 
 func (s *RedisSessionStore) ReadToken(ctx context.Context, key string) (record TokenRecord, err error) {

--- a/pkg/auth/session_store.go
+++ b/pkg/auth/session_store.go
@@ -1,0 +1,380 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-server/pkg/metrics"
+	rd "github.com/go-redis/redis"
+)
+
+var (
+	readTokenScript = rd.NewScript(`
+local value = redis.call("GET", KEYS[1])
+if not value then
+  return {false, -2}
+end
+return {value, redis.call("PTTL", KEYS[1])}
+`)
+	updatePayloadKeepDeadlineScript = rd.NewScript(`
+local ttl = redis.call("PTTL", KEYS[1])
+if ttl == -2 then
+  return {-2, 0}
+end
+local persistent = 0
+if ttl == -1 then
+  ttl = tonumber(ARGV[2])
+  persistent = 1
+elseif ttl <= 0 then
+  return {-2, 0}
+elseif ttl > tonumber(ARGV[2]) then
+  ttl = tonumber(ARGV[2])
+end
+redis.call("SET", KEYS[1], ARGV[1], "PX", ttl, "XX")
+return {ttl, persistent}
+`)
+	compareDeleteScript = rd.NewScript(`
+if redis.call("GET", KEYS[1]) == ARGV[1] then
+  return redis.call("DEL", KEYS[1])
+end
+return 0
+`)
+)
+
+var ErrTokenCollision = errors.New("auth: generated token already exists")
+
+// SessionObservation contains low-cardinality migration facts only. It never
+// includes a token, Redis key, UID, or payload.
+type SessionObservation struct {
+	Total         int64 `json:"total"`
+	Missing       int64 `json:"missing"`
+	Persistent    int64 `json:"persistent"`
+	Finite        int64 `json:"finite"`
+	OverMax       int64 `json:"over_max"`
+	InvalidTTL    int64 `json:"invalid_ttl"`
+	DecodeInvalid int64 `json:"decode_invalid"`
+	V1            int64 `json:"v1"`
+	V2            int64 `json:"v2"`
+	V3            int64 `json:"v3"`
+}
+
+// RedisSessionStore is the sole v2 credential writer in Release A. It owns
+// token and compatibility UIDToken key construction so handlers cannot
+// accidentally drop or extend a bearer deadline.
+type RedisSessionStore struct {
+	client         *rd.Client
+	tokenPrefix    string
+	uidTokenPrefix string
+	maxTTL         time.Duration
+}
+
+func NewRedisSessionStore(client *rd.Client, tokenPrefix, uidTokenPrefix string, maxTTL time.Duration) *RedisSessionStore {
+	if client == nil {
+		panic("auth: NewRedisSessionStore requires non-nil redis client")
+	}
+	if maxTTL <= 0 {
+		panic("auth: NewRedisSessionStore requires positive max TTL")
+	}
+	return &RedisSessionStore{
+		client:         client,
+		tokenPrefix:    tokenPrefix,
+		uidTokenPrefix: uidTokenPrefix,
+		maxTTL:         maxTTL,
+	}
+}
+
+func (s *RedisSessionStore) tokenKey(token string) string {
+	return s.tokenPrefix + token
+}
+
+func (s *RedisSessionStore) uidTokenKey(uid string, deviceFlag int) string {
+	return s.uidTokenPrefix + strconv.Itoa(deviceFlag) + uid
+}
+
+// IssueNew creates a finite bearer and compatibility device index. If the
+// index write fails, the new credential is deleted as compensation.
+func (s *RedisSessionStore) IssueNew(ctx context.Context, token, payload, uid string, deviceFlag int) (err error) {
+	started := time.Now()
+	defer func() { metrics.ObserveSessionOperation("issue", started, err) }()
+	if strings.TrimSpace(token) == "" || strings.TrimSpace(payload) == "" || strings.TrimSpace(uid) == "" || deviceFlag < 0 {
+		return errors.New("auth: issue token requires token, payload, uid, and non-negative device flag")
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	created, err := s.client.SetNX(s.tokenKey(token), payload, s.maxTTL).Result()
+	if err != nil {
+		return fmt.Errorf("auth: issue token: %w", err)
+	}
+	if !created {
+		return ErrTokenCollision
+	}
+	if err := s.client.Set(s.uidTokenKey(uid, deviceFlag), token, s.maxTTL).Err(); err != nil {
+		cleanupErr := s.client.Del(s.tokenKey(token)).Err()
+		if cleanupErr != nil {
+			return fmt.Errorf("auth: bind token device: %w (credential cleanup failed: %v)", err, cleanupErr)
+		}
+		return fmt.Errorf("auth: bind token device: %w", err)
+	}
+	return nil
+}
+
+// ReuseExisting updates a bearer without extending its deadline and aligns
+// the compatibility index to the same TTL. A missing bearer is never recreated.
+func (s *RedisSessionStore) ReuseExisting(ctx context.Context, token, payload, uid string, deviceFlag int) (ok bool, err error) {
+	started := time.Now()
+	defer func() { metrics.ObserveSessionOperation("reuse", started, err) }()
+	if strings.TrimSpace(token) == "" || strings.TrimSpace(payload) == "" || strings.TrimSpace(uid) == "" || deviceFlag < 0 {
+		return false, errors.New("auth: reuse token requires token, payload, uid, and non-negative device flag")
+	}
+	ttl, ok, err := s.updatePayloadKeepDeadline(ctx, token, payload)
+	if err != nil || !ok {
+		return ok, err
+	}
+	if err := s.client.Set(s.uidTokenKey(uid, deviceFlag), token, ttl).Err(); err != nil {
+		// This was a pre-existing credential, so failure must not delete it.
+		return true, fmt.Errorf("auth: refresh token device index: %w", err)
+	}
+	return true, nil
+}
+
+func (s *RedisSessionStore) UpdatePayloadKeepDeadline(ctx context.Context, token, payload string) (ok bool, err error) {
+	started := time.Now()
+	defer func() { metrics.ObserveSessionOperation("update_payload", started, err) }()
+	if strings.TrimSpace(token) == "" || strings.TrimSpace(payload) == "" {
+		return false, errors.New("auth: update token requires token and payload")
+	}
+	_, ok, err = s.updatePayloadKeepDeadline(ctx, token, payload)
+	return ok, err
+}
+
+func (s *RedisSessionStore) updatePayloadKeepDeadline(ctx context.Context, token, payload string) (time.Duration, bool, error) {
+	if err := ctx.Err(); err != nil {
+		return 0, false, err
+	}
+	result, err := updatePayloadKeepDeadlineScript.Run(
+		s.client,
+		[]string{s.tokenKey(token)},
+		payload,
+		s.maxTTL.Milliseconds(),
+	).Result()
+	if err != nil {
+		return 0, false, fmt.Errorf("auth: update token payload: %w", err)
+	}
+	parts, ok := result.([]interface{})
+	if !ok || len(parts) != 2 {
+		return 0, false, fmt.Errorf("auth: invalid token update result %T", result)
+	}
+	ttlMS, err := redisInteger(parts[0])
+	if err != nil {
+		return 0, false, err
+	}
+	persistent, err := redisInteger(parts[1])
+	if err != nil {
+		return 0, false, err
+	}
+	if ttlMS == -2 {
+		return 0, false, nil
+	}
+	if ttlMS <= 0 {
+		return 0, false, fmt.Errorf("auth: update token payload returned invalid ttl %d", ttlMS)
+	}
+	if persistent == 1 {
+		metrics.ObservePersistentSession()
+	}
+	return time.Duration(ttlMS) * time.Millisecond, true, nil
+}
+
+func (s *RedisSessionStore) DeviceToken(ctx context.Context, uid string, deviceFlag int) (string, error) {
+	if strings.TrimSpace(uid) == "" || deviceFlag < 0 {
+		return "", errors.New("auth: load device token requires uid and non-negative device flag")
+	}
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+	token, err := s.client.Get(s.uidTokenKey(uid, deviceFlag)).Result()
+	if err == rd.Nil {
+		return "", nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("auth: load device token: %w", err)
+	}
+	return token, nil
+}
+
+func (s *RedisSessionStore) DeleteToken(ctx context.Context, token string) error {
+	if strings.TrimSpace(token) == "" {
+		return errors.New("auth: delete token requires token")
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if err := s.client.Del(s.tokenKey(token)).Err(); err != nil {
+		return fmt.Errorf("auth: delete token: %w", err)
+	}
+	return nil
+}
+
+// RevokeIssued compensates a new credential. Never use it for a reused token.
+func (s *RedisSessionStore) RevokeIssued(ctx context.Context, token, uid string, deviceFlag int) error {
+	if strings.TrimSpace(uid) == "" || deviceFlag < 0 {
+		return errors.New("auth: revoke token requires uid and non-negative device flag")
+	}
+	if err := s.DeleteToken(ctx, token); err != nil {
+		return err
+	}
+	if _, err := compareDeleteScript.Run(
+		s.client,
+		[]string{s.uidTokenKey(uid, deviceFlag)},
+		token,
+	).Result(); err != nil {
+		return fmt.Errorf("auth: delete token device index: %w", err)
+	}
+	return nil
+}
+
+func (s *RedisSessionStore) ReadToken(ctx context.Context, key string) (record TokenRecord, err error) {
+	started := time.Now()
+	defer func() { metrics.ObserveSessionOperation("read", started, err) }()
+	if strings.TrimSpace(key) == "" {
+		return TokenRecord{}, errors.New("auth: read token requires key")
+	}
+	if err := ctx.Err(); err != nil {
+		return TokenRecord{}, err
+	}
+	result, err := readTokenScript.Run(s.client, []string{key}).Result()
+	if err != nil {
+		return TokenRecord{}, fmt.Errorf("auth: read token: %w", err)
+	}
+	parts, ok := result.([]interface{})
+	if !ok || len(parts) != 2 {
+		return TokenRecord{}, fmt.Errorf("auth: invalid token read result %T", result)
+	}
+	ttlMS, err := redisInteger(parts[1])
+	if err != nil {
+		return TokenRecord{}, err
+	}
+	if ttlMS == -2 {
+		return TokenRecord{TTL: -2}, nil
+	}
+	payload, ok := parts[0].(string)
+	if !ok {
+		if bytes, bytesOK := parts[0].([]byte); bytesOK {
+			payload = string(bytes)
+		} else {
+			return TokenRecord{}, fmt.Errorf("auth: invalid token payload result %T", parts[0])
+		}
+	}
+	if ttlMS == -1 {
+		return TokenRecord{Payload: payload, TTL: -1}, nil
+	}
+	return TokenRecord{Payload: payload, TTL: time.Duration(ttlMS) * time.Millisecond}, nil
+}
+
+// Observe performs an explicit, read-only cursor scan for migration planning.
+// It is never called at process startup. The result is aggregate-only, and
+// each batch checks context cancellation so operators can stop it safely.
+func (s *RedisSessionStore) Observe(ctx context.Context, batchSize int64) (stats SessionObservation, err error) {
+	return s.ObserveRateLimited(ctx, batchSize, 0)
+}
+
+// ObserveRateLimited is Observe with an optional minimum interval between
+// token reads. Production tooling must pass a positive interval to cap Redis
+// load; zero is intended for bounded tests and offline environments.
+func (s *RedisSessionStore) ObserveRateLimited(ctx context.Context, batchSize int64, interval time.Duration) (stats SessionObservation, err error) {
+	started := time.Now()
+	defer func() { metrics.ObserveSessionOperation("observe", started, err) }()
+	if batchSize <= 0 || batchSize > 10_000 {
+		return SessionObservation{}, fmt.Errorf("auth: observe batch size must be between 1 and 10000")
+	}
+	if interval < 0 {
+		return SessionObservation{}, fmt.Errorf("auth: observe interval must not be negative")
+	}
+	var throttle <-chan time.Time
+	var ticker *time.Ticker
+	if interval > 0 {
+		ticker = time.NewTicker(interval)
+		defer ticker.Stop()
+		throttle = ticker.C
+	}
+	var cursor uint64
+	pattern := s.tokenPrefix + "*"
+	for {
+		if err := ctx.Err(); err != nil {
+			return SessionObservation{}, err
+		}
+		keys, next, err := s.client.Scan(cursor, pattern, batchSize).Result()
+		if err != nil {
+			return SessionObservation{}, fmt.Errorf("auth: observe scan: %w", err)
+		}
+		for _, key := range keys {
+			if throttle != nil {
+				select {
+				case <-ctx.Done():
+					return SessionObservation{}, ctx.Err()
+				case <-throttle:
+				}
+			}
+			if err := ctx.Err(); err != nil {
+				return SessionObservation{}, err
+			}
+			stats.Total++
+			record, err := s.ReadToken(ctx, key)
+			if err != nil {
+				return SessionObservation{}, fmt.Errorf("auth: observe token record: %w", err)
+			}
+			switch {
+			case record.TTL == -2:
+				stats.Missing++
+				continue
+			case record.TTL == -1:
+				stats.Persistent++
+			case record.TTL >= 0:
+				stats.Finite++
+				if record.TTL > s.maxTTL {
+					stats.OverMax++
+				}
+			default:
+				stats.InvalidTTL++
+			}
+
+			if _, err := Decode(record.Payload); err != nil {
+				stats.DecodeInvalid++
+				continue
+			}
+			switch {
+			case strings.HasPrefix(record.Payload, v3Prefix):
+				stats.V3++
+			case strings.HasPrefix(record.Payload, v2Prefix):
+				stats.V2++
+			default:
+				stats.V1++
+			}
+		}
+		cursor = next
+		if cursor == 0 {
+			return stats, nil
+		}
+	}
+}
+
+func redisInteger(value interface{}) (int64, error) {
+	switch v := value.(type) {
+	case int64:
+		return v, nil
+	case string:
+		result, err := strconv.ParseInt(v, 10, 64)
+		if err != nil {
+			return 0, fmt.Errorf("auth: invalid redis integer %q: %w", v, err)
+		}
+		return result, nil
+	case []byte:
+		return redisInteger(string(v))
+	default:
+		return 0, fmt.Errorf("auth: invalid redis integer result %T", value)
+	}
+}

--- a/pkg/auth/session_store_test.go
+++ b/pkg/auth/session_store_test.go
@@ -29,7 +29,9 @@ func TestRedisSessionStoreKeepsTokenDeadline(t *testing.T) {
 		_ = client.Close()
 	})
 
-	require.NoError(t, store.IssueNew(context.Background(), token, "old", "u1", 1))
+	oldPayload, err := Encode(TokenInfo{UID: "u1", Name: "old"})
+	require.NoError(t, err)
+	require.NoError(t, store.IssueNew(context.Background(), token, oldPayload, "u1", 1))
 	before, err := client.PTTL(cfg.Cache.TokenCachePrefix + token).Result()
 	require.NoError(t, err)
 	require.Positive(t, before)
@@ -135,7 +137,9 @@ func TestRedisSessionStoreConcurrentLogoutCannotBeResurrected(t *testing.T) {
 		_ = clientA.Close()
 		_ = clientB.Close()
 	})
-	require.NoError(t, storeA.IssueNew(context.Background(), token, "old", "u-race", 1))
+	oldPayload, err := Encode(TokenInfo{UID: "u-race", Name: "old"})
+	require.NoError(t, err)
+	require.NoError(t, storeA.IssueNew(context.Background(), token, oldPayload, "u-race", 1))
 
 	start := make(chan struct{})
 	errCh := make(chan error, 33)
@@ -191,8 +195,10 @@ func TestRedisSessionStoreIssueFailureCompensatesNewCredential(t *testing.T) {
 		}
 	})
 
-	err := store.IssueNew(context.Background(), token, "payload", "u-compensate", 1)
-	require.Error(t, err)
+	payload, err := Encode(TokenInfo{UID: "u-compensate", Name: "issued"})
+	require.NoError(t, err)
+	issueErr := store.IssueNew(context.Background(), token, payload, "u-compensate", 1)
+	require.Error(t, issueErr)
 	exists, existsErr := client.Exists(tokenKey).Result()
 	require.NoError(t, existsErr)
 	require.Zero(t, exists, "partial issue must not leave an orphan bearer")

--- a/pkg/auth/session_store_test.go
+++ b/pkg/auth/session_store_test.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"testing"
@@ -45,6 +46,80 @@ func TestRedisSessionStoreKeepsTokenDeadline(t *testing.T) {
 	got, err := client.Get(cfg.Cache.TokenCachePrefix + token).Result()
 	require.NoError(t, err)
 	require.Equal(t, "new", got)
+}
+
+func TestRedisSessionStoreRejectsV3PayloadDowngrade(t *testing.T) {
+	cfg := config.New()
+	client := octoredis.NewInstrumentedClient(cfg)
+	store := NewRedisSessionStore(client, cfg.Cache.TokenCachePrefix, cfg.Cache.UIDTokenCachePrefix, time.Minute)
+	token := "session-store-v3-downgrade-" + util.GenerUUID()
+	key := cfg.Cache.TokenCachePrefix + token
+	t.Cleanup(func() {
+		_ = client.Del(key).Err()
+		_ = client.Close()
+	})
+	now := time.Now().UTC()
+	v3, err := EncodeV3(TokenInfo{
+		UID:               "u-v3",
+		IssuedAt:          now.Add(-time.Minute).Unix(),
+		ExpiresAt:         now.Add(time.Minute).Unix(),
+		SessionGeneration: "generation-v3",
+	})
+	require.NoError(t, err)
+	v2, err := Encode(TokenInfo{UID: "u-v3", Name: "renamed"})
+	require.NoError(t, err)
+	require.NoError(t, client.Set(key, v3, time.Minute).Err())
+	before, err := client.PTTL(key).Result()
+	require.NoError(t, err)
+
+	ok, err := store.UpdatePayloadKeepDeadline(context.Background(), token, v2)
+	require.False(t, ok)
+	require.ErrorContains(t, err, "version downgrade")
+	after, ttlErr := client.PTTL(key).Result()
+	require.NoError(t, ttlErr)
+	require.Positive(t, after)
+	require.LessOrEqual(t, after, before)
+	got, getErr := client.Get(key).Result()
+	require.NoError(t, getErr)
+	require.Equal(t, v3, got, "a rejected update must leave the v3 payload unchanged")
+}
+
+type sessionStoreProber interface {
+	Probe(context.Context) error
+}
+
+func TestRedisSessionStoreProbeExecutesReadOnlyLua(t *testing.T) {
+	cfg := config.New()
+	client := octoredis.NewInstrumentedClient(cfg)
+	prefix := "session-probe:" + util.GenerUUID() + ":"
+	store := NewRedisSessionStore(client, prefix, "session-probe-uid:", time.Minute)
+	t.Cleanup(func() { _ = client.Close() })
+
+	prober, ok := interface{}(store).(sessionStoreProber)
+	require.True(t, ok, "RedisSessionStore must expose a startup Lua compatibility probe")
+	require.NoError(t, prober.Probe(context.Background()))
+	keys, err := client.Keys(prefix + "*").Result()
+	require.NoError(t, err)
+	require.Empty(t, keys, "the startup probe must not write Redis")
+}
+
+func TestRedisSessionStoreProbeFailsClosed(t *testing.T) {
+	cfg := config.New()
+	client := octoredis.NewInstrumentedClient(cfg)
+	store := NewRedisSessionStore(client, "session-probe-fail:", "session-probe-fail-uid:", time.Minute)
+	t.Cleanup(func() { _ = client.Close() })
+	client.WrapProcess(func(old func(rd.Cmder) error) func(rd.Cmder) error {
+		return func(cmd rd.Cmder) error {
+			if cmd.Name() == "evalsha" || cmd.Name() == "eval" {
+				return errors.New("injected lua rejection")
+			}
+			return old(cmd)
+		}
+	})
+
+	prober, ok := interface{}(store).(sessionStoreProber)
+	require.True(t, ok, "RedisSessionStore must expose a startup Lua compatibility probe")
+	require.ErrorContains(t, prober.Probe(context.Background()), "injected lua rejection")
 }
 
 func TestRedisSessionStoreConcurrentLogoutCannotBeResurrected(t *testing.T) {
@@ -205,6 +280,36 @@ func TestRedisSessionStoreObserveAggregatesOnly(t *testing.T) {
 	require.Equal(t, int64(1), stats.V1)
 	require.Equal(t, int64(2), stats.V2)
 	require.Equal(t, int64(1), stats.V3)
+}
+
+func TestRedisSessionStoreObserveCountsZeroTTLAsInvalid(t *testing.T) {
+	cfg := config.New()
+	client := octoredis.NewInstrumentedClient(cfg)
+	prefix := "observe-zero-ttl:" + util.GenerUUID() + ":"
+	key := prefix + "token"
+	store := NewRedisSessionStore(client, prefix, "observe-zero-ttl-uid:", time.Minute)
+	require.NoError(t, client.Set(key, "u1@legacy", time.Minute).Err())
+	t.Cleanup(func() {
+		_ = client.Del(key).Err()
+		_ = client.Close()
+	})
+	client.WrapProcess(func(old func(rd.Cmder) error) func(rd.Cmder) error {
+		return func(cmd rd.Cmder) error {
+			if cmd.Name() == "evalsha" {
+				args := cmd.Args()
+				args[0] = "eval"
+				args[1] = `return {"u1@legacy", 0}`
+				args[2] = 0
+			}
+			return old(cmd)
+		}
+	})
+
+	stats, err := store.Observe(context.Background(), 10)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), stats.Total)
+	require.Equal(t, int64(1), stats.InvalidTTL)
+	require.Zero(t, stats.Finite)
 }
 
 func TestRedisSessionStoreMissingTokenIsNotRecreated(t *testing.T) {

--- a/pkg/auth/session_store_test.go
+++ b/pkg/auth/session_store_test.go
@@ -2,7 +2,7 @@ package auth
 
 import (
 	"context"
-	"errors"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -49,34 +49,41 @@ func TestRedisSessionStoreKeepsTokenDeadline(t *testing.T) {
 
 func TestRedisSessionStoreConcurrentLogoutCannotBeResurrected(t *testing.T) {
 	cfg := config.New()
-	client := octoredis.NewInstrumentedClient(cfg)
-	store := NewRedisSessionStore(client, cfg.Cache.TokenCachePrefix, cfg.Cache.UIDTokenCachePrefix, time.Minute)
+	clientA := octoredis.NewInstrumentedClient(cfg)
+	clientB := octoredis.NewInstrumentedClient(cfg)
+	storeA := NewRedisSessionStore(clientA, cfg.Cache.TokenCachePrefix, cfg.Cache.UIDTokenCachePrefix, time.Minute)
+	storeB := NewRedisSessionStore(clientB, cfg.Cache.TokenCachePrefix, cfg.Cache.UIDTokenCachePrefix, time.Minute)
 	token := "session-store-race-" + util.GenerUUID()
 	tokenKey := cfg.Cache.TokenCachePrefix + token
 	uidKey := cfg.Cache.UIDTokenCachePrefix + "1u-race"
 	t.Cleanup(func() {
-		_ = client.Del(tokenKey, uidKey).Err()
-		_ = client.Close()
+		_ = clientA.Del(tokenKey, uidKey).Err()
+		_ = clientA.Close()
+		_ = clientB.Close()
 	})
-	require.NoError(t, store.IssueNew(context.Background(), token, "old", "u-race", 1))
+	require.NoError(t, storeA.IssueNew(context.Background(), token, "old", "u-race", 1))
 
 	start := make(chan struct{})
 	errCh := make(chan error, 33)
 	var wg sync.WaitGroup
 	for i := 0; i < 32; i++ {
+		store := storeA
+		if i%2 == 1 {
+			store = storeB
+		}
 		wg.Add(1)
-		go func() {
+		go func(store *RedisSessionStore) {
 			defer wg.Done()
 			<-start
 			_, err := store.ReuseExisting(context.Background(), token, "new", "u-race", 1)
 			errCh <- err
-		}()
+		}(store)
 	}
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
 		<-start
-		errCh <- store.DeleteToken(context.Background(), token)
+		errCh <- storeB.DeleteToken(context.Background(), token)
 	}()
 	close(start)
 	wg.Wait()
@@ -84,7 +91,7 @@ func TestRedisSessionStoreConcurrentLogoutCannotBeResurrected(t *testing.T) {
 	for err := range errCh {
 		require.NoError(t, err)
 	}
-	exists, err := client.Exists(tokenKey).Result()
+	exists, err := clientA.Exists(tokenKey).Result()
 	require.NoError(t, err)
 	require.Zero(t, exists, "SET XX Lua serialized with DEL must never recreate a logged-out bearer")
 }
@@ -100,19 +107,18 @@ func TestRedisSessionStoreIssueFailureCompensatesNewCredential(t *testing.T) {
 		_ = client.Del(tokenKey, uidKey).Err()
 		_ = client.Close()
 	})
-	injected := errors.New("injected uid index failure")
 	client.WrapProcess(func(old func(rd.Cmder) error) func(rd.Cmder) error {
 		return func(cmd rd.Cmder) error {
 			args := cmd.Args()
-			if cmd.Name() == "set" && len(args) > 1 && args[1] == uidKey {
-				return injected
+			if cmd.Name() == "set" && !redisArgsContain(args, "nx") {
+				args[0] = "injected-uid-index-failure"
 			}
 			return old(cmd)
 		}
 	})
 
 	err := store.IssueNew(context.Background(), token, "payload", "u-compensate", 1)
-	require.ErrorIs(t, err, injected)
+	require.Error(t, err)
 	exists, existsErr := client.Exists(tokenKey).Result()
 	require.NoError(t, existsErr)
 	require.Zero(t, exists, "partial issue must not leave an orphan bearer")
@@ -130,12 +136,11 @@ func TestRedisSessionStoreReuseFailureKeepsExistingCredential(t *testing.T) {
 		_ = client.Close()
 	})
 	require.NoError(t, client.Set(tokenKey, "old", time.Minute).Err())
-	injected := errors.New("injected uid index failure")
 	client.WrapProcess(func(old func(rd.Cmder) error) func(rd.Cmder) error {
 		return func(cmd rd.Cmder) error {
 			args := cmd.Args()
-			if cmd.Name() == "set" && len(args) > 1 && args[1] == uidKey {
-				return injected
+			if cmd.Name() == "set" && !redisArgsContain(args, "nx") {
+				args[0] = "injected-uid-index-failure"
 			}
 			return old(cmd)
 		}
@@ -143,10 +148,19 @@ func TestRedisSessionStoreReuseFailureKeepsExistingCredential(t *testing.T) {
 
 	ok, err := store.ReuseExisting(context.Background(), token, "new", "u-reuse", 1)
 	require.True(t, ok)
-	require.ErrorIs(t, err, injected)
+	require.Error(t, err)
 	got, getErr := client.Get(tokenKey).Result()
 	require.NoError(t, getErr)
 	require.Equal(t, "new", got, "reuse failure must not delete a credential that predated the attempt")
+}
+
+func redisArgsContain(args []interface{}, want string) bool {
+	for _, arg := range args {
+		if fmt.Sprint(arg) == want {
+			return true
+		}
+	}
+	return false
 }
 
 func TestRedisSessionStoreObserveAggregatesOnly(t *testing.T) {
@@ -208,7 +222,7 @@ func TestRedisSessionStoreMissingTokenIsNotRecreated(t *testing.T) {
 	require.Zero(t, exists)
 }
 
-func TestRedisSessionStoreBoundsTouchedPersistentToken(t *testing.T) {
+func TestRedisSessionStoreBoundsTouchedLegacyToken(t *testing.T) {
 	cfg := config.New()
 	client := octoredis.NewInstrumentedClient(cfg)
 	store := NewRedisSessionStore(client, cfg.Cache.TokenCachePrefix, cfg.Cache.UIDTokenCachePrefix, time.Minute)
@@ -227,4 +241,16 @@ func TestRedisSessionStoreBoundsTouchedPersistentToken(t *testing.T) {
 	require.NoError(t, err)
 	require.Positive(t, ttl)
 	require.LessOrEqual(t, ttl, time.Minute)
+
+	overMaxToken := "session-store-over-max-" + util.GenerUUID()
+	overMaxKey := cfg.Cache.TokenCachePrefix + overMaxToken
+	t.Cleanup(func() { _ = client.Del(overMaxKey).Err() })
+	require.NoError(t, client.Set(overMaxKey, "old", 2*time.Minute).Err())
+	ok, err = store.UpdatePayloadKeepDeadline(context.Background(), overMaxToken, "new")
+	require.NoError(t, err)
+	require.True(t, ok)
+	ttl, err = client.PTTL(overMaxKey).Result()
+	require.NoError(t, err)
+	require.Positive(t, ttl)
+	require.LessOrEqual(t, ttl, time.Minute, "touched over-max token must be clamped, never preserved beyond policy")
 }

--- a/pkg/auth/session_store_test.go
+++ b/pkg/auth/session_store_test.go
@@ -1,0 +1,81 @@
+package auth
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	octoredis "github.com/Mininglamp-OSS/octo-server/pkg/redis"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRedisSessionStoreKeepsTokenDeadline(t *testing.T) {
+	_, ctx := testutil.NewTestServer()
+	client := octoredis.NewInstrumentedClient(ctx.GetConfig())
+	store := NewRedisSessionStore(
+		client,
+		ctx.GetConfig().Cache.TokenCachePrefix,
+		ctx.GetConfig().Cache.UIDTokenCachePrefix,
+		2*time.Minute,
+	)
+	token := "session-store-" + util.GenerUUID()
+	t.Cleanup(func() {
+		_ = client.Del(ctx.GetConfig().Cache.TokenCachePrefix + token).Err()
+		_ = client.Close()
+	})
+
+	require.NoError(t, store.IssueNew(context.Background(), token, "old", "u1", 1))
+	before, err := client.PTTL(ctx.GetConfig().Cache.TokenCachePrefix + token).Result()
+	require.NoError(t, err)
+	require.Positive(t, before)
+
+	time.Sleep(20 * time.Millisecond)
+	ok, err := store.UpdatePayloadKeepDeadline(context.Background(), token, "new")
+	require.NoError(t, err)
+	require.True(t, ok)
+	after, err := client.PTTL(ctx.GetConfig().Cache.TokenCachePrefix + token).Result()
+	require.NoError(t, err)
+	require.Positive(t, after)
+	require.LessOrEqual(t, after, before, "payload update must never extend the bearer deadline")
+	got, err := client.Get(ctx.GetConfig().Cache.TokenCachePrefix + token).Result()
+	require.NoError(t, err)
+	require.Equal(t, "new", got)
+}
+
+func TestRedisSessionStoreMissingTokenIsNotRecreated(t *testing.T) {
+	_, ctx := testutil.NewTestServer()
+	client := octoredis.NewInstrumentedClient(ctx.GetConfig())
+	store := NewRedisSessionStore(client, ctx.GetConfig().Cache.TokenCachePrefix, ctx.GetConfig().Cache.UIDTokenCachePrefix, time.Minute)
+	t.Cleanup(func() { _ = client.Close() })
+	token := "session-store-missing-" + util.GenerUUID()
+
+	ok, err := store.ReuseExisting(context.Background(), token, "payload", "u1", 1)
+	require.NoError(t, err)
+	require.False(t, ok)
+	exists, err := client.Exists(ctx.GetConfig().Cache.TokenCachePrefix + token).Result()
+	require.NoError(t, err)
+	require.Zero(t, exists)
+}
+
+func TestRedisSessionStoreBoundsTouchedPersistentToken(t *testing.T) {
+	_, ctx := testutil.NewTestServer()
+	client := octoredis.NewInstrumentedClient(ctx.GetConfig())
+	store := NewRedisSessionStore(client, ctx.GetConfig().Cache.TokenCachePrefix, ctx.GetConfig().Cache.UIDTokenCachePrefix, time.Minute)
+	token := "session-store-persistent-" + util.GenerUUID()
+	key := ctx.GetConfig().Cache.TokenCachePrefix + token
+	t.Cleanup(func() {
+		_ = client.Del(key).Err()
+		_ = client.Close()
+	})
+	require.NoError(t, client.Set(key, "old", 0).Err())
+
+	ok, err := store.UpdatePayloadKeepDeadline(context.Background(), token, "new")
+	require.NoError(t, err)
+	require.True(t, ok)
+	ttl, err := client.PTTL(key).Result()
+	require.NoError(t, err)
+	require.Positive(t, ttl)
+	require.LessOrEqual(t, ttl, time.Minute)
+}

--- a/pkg/auth/session_store_test.go
+++ b/pkg/auth/session_store_test.go
@@ -2,32 +2,35 @@ package auth
 
 import (
 	"context"
+	"errors"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
-	"github.com/Mininglamp-OSS/octo-lib/testutil"
 	octoredis "github.com/Mininglamp-OSS/octo-server/pkg/redis"
+	rd "github.com/go-redis/redis"
 	"github.com/stretchr/testify/require"
 )
 
 func TestRedisSessionStoreKeepsTokenDeadline(t *testing.T) {
-	_, ctx := testutil.NewTestServer()
-	client := octoredis.NewInstrumentedClient(ctx.GetConfig())
+	cfg := config.New()
+	client := octoredis.NewInstrumentedClient(cfg)
 	store := NewRedisSessionStore(
 		client,
-		ctx.GetConfig().Cache.TokenCachePrefix,
-		ctx.GetConfig().Cache.UIDTokenCachePrefix,
+		cfg.Cache.TokenCachePrefix,
+		cfg.Cache.UIDTokenCachePrefix,
 		2*time.Minute,
 	)
 	token := "session-store-" + util.GenerUUID()
 	t.Cleanup(func() {
-		_ = client.Del(ctx.GetConfig().Cache.TokenCachePrefix + token).Err()
+		_ = client.Del(cfg.Cache.TokenCachePrefix+token, cfg.Cache.UIDTokenCachePrefix+"1u1").Err()
 		_ = client.Close()
 	})
 
 	require.NoError(t, store.IssueNew(context.Background(), token, "old", "u1", 1))
-	before, err := client.PTTL(ctx.GetConfig().Cache.TokenCachePrefix + token).Result()
+	before, err := client.PTTL(cfg.Cache.TokenCachePrefix + token).Result()
 	require.NoError(t, err)
 	require.Positive(t, before)
 
@@ -35,36 +38,182 @@ func TestRedisSessionStoreKeepsTokenDeadline(t *testing.T) {
 	ok, err := store.UpdatePayloadKeepDeadline(context.Background(), token, "new")
 	require.NoError(t, err)
 	require.True(t, ok)
-	after, err := client.PTTL(ctx.GetConfig().Cache.TokenCachePrefix + token).Result()
+	after, err := client.PTTL(cfg.Cache.TokenCachePrefix + token).Result()
 	require.NoError(t, err)
 	require.Positive(t, after)
 	require.LessOrEqual(t, after, before, "payload update must never extend the bearer deadline")
-	got, err := client.Get(ctx.GetConfig().Cache.TokenCachePrefix + token).Result()
+	got, err := client.Get(cfg.Cache.TokenCachePrefix + token).Result()
 	require.NoError(t, err)
 	require.Equal(t, "new", got)
 }
 
+func TestRedisSessionStoreConcurrentLogoutCannotBeResurrected(t *testing.T) {
+	cfg := config.New()
+	client := octoredis.NewInstrumentedClient(cfg)
+	store := NewRedisSessionStore(client, cfg.Cache.TokenCachePrefix, cfg.Cache.UIDTokenCachePrefix, time.Minute)
+	token := "session-store-race-" + util.GenerUUID()
+	tokenKey := cfg.Cache.TokenCachePrefix + token
+	uidKey := cfg.Cache.UIDTokenCachePrefix + "1u-race"
+	t.Cleanup(func() {
+		_ = client.Del(tokenKey, uidKey).Err()
+		_ = client.Close()
+	})
+	require.NoError(t, store.IssueNew(context.Background(), token, "old", "u-race", 1))
+
+	start := make(chan struct{})
+	errCh := make(chan error, 33)
+	var wg sync.WaitGroup
+	for i := 0; i < 32; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			_, err := store.ReuseExisting(context.Background(), token, "new", "u-race", 1)
+			errCh <- err
+		}()
+	}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		<-start
+		errCh <- store.DeleteToken(context.Background(), token)
+	}()
+	close(start)
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		require.NoError(t, err)
+	}
+	exists, err := client.Exists(tokenKey).Result()
+	require.NoError(t, err)
+	require.Zero(t, exists, "SET XX Lua serialized with DEL must never recreate a logged-out bearer")
+}
+
+func TestRedisSessionStoreIssueFailureCompensatesNewCredential(t *testing.T) {
+	cfg := config.New()
+	client := octoredis.NewInstrumentedClient(cfg)
+	store := NewRedisSessionStore(client, cfg.Cache.TokenCachePrefix, cfg.Cache.UIDTokenCachePrefix, time.Minute)
+	token := "session-store-compensate-" + util.GenerUUID()
+	tokenKey := cfg.Cache.TokenCachePrefix + token
+	uidKey := cfg.Cache.UIDTokenCachePrefix + "1u-compensate"
+	t.Cleanup(func() {
+		_ = client.Del(tokenKey, uidKey).Err()
+		_ = client.Close()
+	})
+	injected := errors.New("injected uid index failure")
+	client.WrapProcess(func(old func(rd.Cmder) error) func(rd.Cmder) error {
+		return func(cmd rd.Cmder) error {
+			args := cmd.Args()
+			if cmd.Name() == "set" && len(args) > 1 && args[1] == uidKey {
+				return injected
+			}
+			return old(cmd)
+		}
+	})
+
+	err := store.IssueNew(context.Background(), token, "payload", "u-compensate", 1)
+	require.ErrorIs(t, err, injected)
+	exists, existsErr := client.Exists(tokenKey).Result()
+	require.NoError(t, existsErr)
+	require.Zero(t, exists, "partial issue must not leave an orphan bearer")
+}
+
+func TestRedisSessionStoreReuseFailureKeepsExistingCredential(t *testing.T) {
+	cfg := config.New()
+	client := octoredis.NewInstrumentedClient(cfg)
+	store := NewRedisSessionStore(client, cfg.Cache.TokenCachePrefix, cfg.Cache.UIDTokenCachePrefix, time.Minute)
+	token := "session-store-reuse-failure-" + util.GenerUUID()
+	tokenKey := cfg.Cache.TokenCachePrefix + token
+	uidKey := cfg.Cache.UIDTokenCachePrefix + "1u-reuse"
+	t.Cleanup(func() {
+		_ = client.Del(tokenKey, uidKey).Err()
+		_ = client.Close()
+	})
+	require.NoError(t, client.Set(tokenKey, "old", time.Minute).Err())
+	injected := errors.New("injected uid index failure")
+	client.WrapProcess(func(old func(rd.Cmder) error) func(rd.Cmder) error {
+		return func(cmd rd.Cmder) error {
+			args := cmd.Args()
+			if cmd.Name() == "set" && len(args) > 1 && args[1] == uidKey {
+				return injected
+			}
+			return old(cmd)
+		}
+	})
+
+	ok, err := store.ReuseExisting(context.Background(), token, "new", "u-reuse", 1)
+	require.True(t, ok)
+	require.ErrorIs(t, err, injected)
+	got, getErr := client.Get(tokenKey).Result()
+	require.NoError(t, getErr)
+	require.Equal(t, "new", got, "reuse failure must not delete a credential that predated the attempt")
+}
+
+func TestRedisSessionStoreObserveAggregatesOnly(t *testing.T) {
+	cfg := config.New()
+	client := octoredis.NewInstrumentedClient(cfg)
+	prefix := "observe:" + util.GenerUUID() + ":"
+	store := NewRedisSessionStore(client, prefix, "observe-uid:", time.Minute)
+	keys := []string{
+		prefix + "legacy",
+		prefix + "v2",
+		prefix + "v3",
+		prefix + "invalid",
+		prefix + "over-max",
+	}
+	t.Cleanup(func() {
+		_ = client.Del(keys...).Err()
+		_ = client.Close()
+	})
+	v2, err := Encode(TokenInfo{UID: "u2", Name: "v2"})
+	require.NoError(t, err)
+	now := time.Now().UTC()
+	v3, err := EncodeV3(TokenInfo{
+		UID:               "u3",
+		IssuedAt:          now.Add(-time.Minute).Unix(),
+		ExpiresAt:         now.Add(time.Minute).Unix(),
+		SessionGeneration: "g3",
+	})
+	require.NoError(t, err)
+	require.NoError(t, client.Set(keys[0], "u1@legacy", 0).Err())
+	require.NoError(t, client.Set(keys[1], v2, 30*time.Second).Err())
+	require.NoError(t, client.Set(keys[2], v3, 30*time.Second).Err())
+	require.NoError(t, client.Set(keys[3], "not-a-token", 30*time.Second).Err())
+	require.NoError(t, client.Set(keys[4], v2, 2*time.Minute).Err())
+
+	stats, err := store.Observe(context.Background(), 2)
+	require.NoError(t, err)
+	require.Equal(t, int64(5), stats.Total)
+	require.Equal(t, int64(1), stats.Persistent)
+	require.Equal(t, int64(4), stats.Finite)
+	require.Equal(t, int64(1), stats.OverMax)
+	require.Equal(t, int64(1), stats.DecodeInvalid)
+	require.Equal(t, int64(1), stats.V1)
+	require.Equal(t, int64(2), stats.V2)
+	require.Equal(t, int64(1), stats.V3)
+}
+
 func TestRedisSessionStoreMissingTokenIsNotRecreated(t *testing.T) {
-	_, ctx := testutil.NewTestServer()
-	client := octoredis.NewInstrumentedClient(ctx.GetConfig())
-	store := NewRedisSessionStore(client, ctx.GetConfig().Cache.TokenCachePrefix, ctx.GetConfig().Cache.UIDTokenCachePrefix, time.Minute)
+	cfg := config.New()
+	client := octoredis.NewInstrumentedClient(cfg)
+	store := NewRedisSessionStore(client, cfg.Cache.TokenCachePrefix, cfg.Cache.UIDTokenCachePrefix, time.Minute)
 	t.Cleanup(func() { _ = client.Close() })
 	token := "session-store-missing-" + util.GenerUUID()
 
 	ok, err := store.ReuseExisting(context.Background(), token, "payload", "u1", 1)
 	require.NoError(t, err)
 	require.False(t, ok)
-	exists, err := client.Exists(ctx.GetConfig().Cache.TokenCachePrefix + token).Result()
+	exists, err := client.Exists(cfg.Cache.TokenCachePrefix + token).Result()
 	require.NoError(t, err)
 	require.Zero(t, exists)
 }
 
 func TestRedisSessionStoreBoundsTouchedPersistentToken(t *testing.T) {
-	_, ctx := testutil.NewTestServer()
-	client := octoredis.NewInstrumentedClient(ctx.GetConfig())
-	store := NewRedisSessionStore(client, ctx.GetConfig().Cache.TokenCachePrefix, ctx.GetConfig().Cache.UIDTokenCachePrefix, time.Minute)
+	cfg := config.New()
+	client := octoredis.NewInstrumentedClient(cfg)
+	store := NewRedisSessionStore(client, cfg.Cache.TokenCachePrefix, cfg.Cache.UIDTokenCachePrefix, time.Minute)
 	token := "session-store-persistent-" + util.GenerUUID()
-	key := ctx.GetConfig().Cache.TokenCachePrefix + token
+	key := cfg.Cache.TokenCachePrefix + token
 	t.Cleanup(func() {
 		_ = client.Del(key).Err()
 		_ = client.Close()

--- a/pkg/auth/session_store_test.go
+++ b/pkg/auth/session_store_test.go
@@ -2,7 +2,6 @@ package auth
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"sync"
 	"testing"
@@ -111,7 +110,7 @@ func TestRedisSessionStoreProbeFailsClosed(t *testing.T) {
 	client.WrapProcess(func(old func(rd.Cmder) error) func(rd.Cmder) error {
 		return func(cmd rd.Cmder) error {
 			if cmd.Name() == "evalsha" || cmd.Name() == "eval" {
-				return errors.New("injected lua rejection")
+				cmd.Args()[0] = "eval-disabled-by-proxy"
 			}
 			return old(cmd)
 		}
@@ -119,7 +118,7 @@ func TestRedisSessionStoreProbeFailsClosed(t *testing.T) {
 
 	prober, ok := interface{}(store).(sessionStoreProber)
 	require.True(t, ok, "RedisSessionStore must expose a startup Lua compatibility probe")
-	require.ErrorContains(t, prober.Probe(context.Background()), "injected lua rejection")
+	require.ErrorContains(t, prober.Probe(context.Background()), "unknown command")
 }
 
 func TestRedisSessionStoreConcurrentLogoutCannotBeResurrected(t *testing.T) {

--- a/pkg/auth/tokeninfo.go
+++ b/pkg/auth/tokeninfo.go
@@ -5,8 +5,8 @@
 // Historically the cache value was a `@`-joined string ("uid@name" or
 // "uid@name@role") split ad-hoc at every call site. i18n 主方案 D10/D21 要求把
 // token cache 真相源收口，并在 payload 中带上用户语言偏好（D20 UserInfo），
-// 因此引入 versioned JSON envelope（v2:）；v1 字符串格式保留为解码 fallback，
-// 灰度期老 token 不会因为升级失效。
+// Encode 在 expand 阶段继续写 v2；Decode 提前兼容 v3，让所有 reader 先于
+// v3 writer 升级。灰度期老 token 不会因为升级失效。
 package auth
 
 import (
@@ -16,18 +16,23 @@ import (
 	"strings"
 )
 
-// v2Prefix marks the versioned JSON envelope. Bumping the version means a new
-// prefix (e.g. "v3:") — decoder must keep tolerating older prefixes during the
-// rollout window.
-const v2Prefix = "v2:"
+const (
+	v2Prefix = "v2:"
+	v3Prefix = "v3:"
+)
 
 // TokenInfo is the structured payload stored under TokenCachePrefix+token.
 // UID is required; Role/Language may be empty.
 type TokenInfo struct {
-	UID      string
-	Name     string
-	Role     string
-	Language string
+	UID               string
+	Name              string
+	Role              string
+	Language          string
+	IssuedAt          int64
+	ExpiresAt         int64
+	DeviceFlag        int
+	DeviceID          string
+	SessionGeneration string
 }
 
 // ErrEmptyToken indicates an empty cache value (missing or evicted token).
@@ -42,6 +47,18 @@ type tokenInfoV2 struct {
 	Name     string `json:"name,omitempty"`
 	Role     string `json:"role,omitempty"`
 	Language string `json:"lang,omitempty"`
+}
+
+type tokenInfoV3 struct {
+	UID               string `json:"uid"`
+	Name              string `json:"name,omitempty"`
+	Role              string `json:"role,omitempty"`
+	Language          string `json:"lang,omitempty"`
+	IssuedAt          int64  `json:"issued_at"`
+	ExpiresAt         int64  `json:"expires_at"`
+	DeviceFlag        int    `json:"device_flag"`
+	DeviceID          string `json:"device_id,omitempty"`
+	SessionGeneration string `json:"session_generation"`
 }
 
 // Encode serializes a TokenInfo as the versioned JSON envelope. The UID is
@@ -64,6 +81,38 @@ func Encode(info TokenInfo) (string, error) {
 	return v2Prefix + string(payload), nil
 }
 
+// EncodeV3 is intentionally separate from Encode. Release A readers can
+// decode and validate v3 while production writers still emit v2.
+func EncodeV3(info TokenInfo) (string, error) {
+	if info.UID == "" {
+		return "", fmt.Errorf("%w: uid required", ErrInvalidToken)
+	}
+	if info.IssuedAt <= 0 {
+		return "", fmt.Errorf("%w: issued_at required", ErrInvalidToken)
+	}
+	if info.ExpiresAt <= info.IssuedAt {
+		return "", fmt.Errorf("%w: expires_at must be after issued_at", ErrInvalidToken)
+	}
+	if strings.TrimSpace(info.SessionGeneration) == "" {
+		return "", fmt.Errorf("%w: session_generation required", ErrInvalidToken)
+	}
+	payload, err := json.Marshal(tokenInfoV3{
+		UID:               info.UID,
+		Name:              info.Name,
+		Role:              info.Role,
+		Language:          info.Language,
+		IssuedAt:          info.IssuedAt,
+		ExpiresAt:         info.ExpiresAt,
+		DeviceFlag:        info.DeviceFlag,
+		DeviceID:          info.DeviceID,
+		SessionGeneration: info.SessionGeneration,
+	})
+	if err != nil {
+		return "", fmt.Errorf("auth: marshal v3 token payload: %w", err)
+	}
+	return v3Prefix + string(payload), nil
+}
+
 // Decode reverses Encode and tolerates the legacy "uid@name[@role]" string so
 // that tokens written by older binaries (and cached before the upgrade) keep
 // working until they expire. UID emptiness is the only structural check
@@ -75,6 +124,9 @@ func Decode(raw string) (TokenInfo, error) {
 	}
 	if strings.HasPrefix(raw, v2Prefix) {
 		return decodeV2(raw[len(v2Prefix):])
+	}
+	if strings.HasPrefix(raw, v3Prefix) {
+		return decodeV3(raw[len(v3Prefix):])
 	}
 	return decodeLegacy(raw)
 }
@@ -88,6 +140,42 @@ func decodeV2(payload string) (TokenInfo, error) {
 		return TokenInfo{}, fmt.Errorf("%w: uid missing", ErrInvalidToken)
 	}
 	return TokenInfo{UID: v.UID, Name: v.Name, Role: v.Role, Language: v.Language}, nil
+}
+
+func decodeV3(payload string) (TokenInfo, error) {
+	var v tokenInfoV3
+	if err := json.Unmarshal([]byte(payload), &v); err != nil {
+		return TokenInfo{}, fmt.Errorf("%w: %v", ErrInvalidToken, err)
+	}
+	info := TokenInfo{
+		UID:               v.UID,
+		Name:              v.Name,
+		Role:              v.Role,
+		Language:          v.Language,
+		IssuedAt:          v.IssuedAt,
+		ExpiresAt:         v.ExpiresAt,
+		DeviceFlag:        v.DeviceFlag,
+		DeviceID:          v.DeviceID,
+		SessionGeneration: v.SessionGeneration,
+	}
+	if info.UID == "" {
+		return TokenInfo{}, fmt.Errorf("%w: uid missing", ErrInvalidToken)
+	}
+	if info.IssuedAt <= 0 {
+		return TokenInfo{}, fmt.Errorf("%w: issued_at missing", ErrInvalidToken)
+	}
+	if info.ExpiresAt <= info.IssuedAt {
+		return TokenInfo{}, fmt.Errorf("%w: invalid absolute lifetime", ErrInvalidToken)
+	}
+	if strings.TrimSpace(info.SessionGeneration) == "" {
+		return TokenInfo{}, fmt.Errorf("%w: session_generation missing", ErrInvalidToken)
+	}
+	return info, nil
+}
+
+// IsV3 reports whether Decode returned the v3 envelope.
+func (i TokenInfo) IsV3() bool {
+	return i.IssuedAt > 0 && i.ExpiresAt > 0 && i.SessionGeneration != ""
 }
 
 func decodeLegacy(raw string) (TokenInfo, error) {

--- a/pkg/auth/tokeninfo_test.go
+++ b/pkg/auth/tokeninfo_test.go
@@ -41,6 +41,39 @@ func TestEncodeV3RoundTrip(t *testing.T) {
 	}
 }
 
+func TestEncodeV3RejectsIncompleteSecurityClaims(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		name string
+		info TokenInfo
+	}{
+		{
+			name: "missing uid",
+			info: TokenInfo{IssuedAt: 1, ExpiresAt: 2, SessionGeneration: "g1"},
+		},
+		{
+			name: "missing issued at",
+			info: TokenInfo{UID: "u1", ExpiresAt: 2, SessionGeneration: "g1"},
+		},
+		{
+			name: "deadline not after issue",
+			info: TokenInfo{UID: "u1", IssuedAt: 2, ExpiresAt: 2, SessionGeneration: "g1"},
+		},
+		{
+			name: "blank generation",
+			info: TokenInfo{UID: "u1", IssuedAt: 1, ExpiresAt: 2, SessionGeneration: "  "},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := EncodeV3(tt.info)
+			if !errors.Is(err, ErrInvalidToken) {
+				t.Fatalf("EncodeV3: want ErrInvalidToken, got %v", err)
+			}
+		})
+	}
+}
+
 func TestDecodeV3RejectsInvalidLifetime(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
@@ -51,6 +84,8 @@ func TestDecodeV3RejectsInvalidLifetime(t *testing.T) {
 		{name: "missing expires at", raw: "v3:{\"uid\":\"u1\",\"issued_at\":1,\"session_generation\":\"g\"}"},
 		{name: "deadline not after issue", raw: "v3:{\"uid\":\"u1\",\"issued_at\":2,\"expires_at\":2,\"session_generation\":\"g\"}"},
 		{name: "missing generation", raw: "v3:{\"uid\":\"u1\",\"issued_at\":1,\"expires_at\":2}"},
+		{name: "missing uid", raw: "v3:{\"issued_at\":1,\"expires_at\":2,\"session_generation\":\"g\"}"},
+		{name: "bad json", raw: "v3:{not-json}"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/auth/tokeninfo_test.go
+++ b/pkg/auth/tokeninfo_test.go
@@ -4,7 +4,63 @@ import (
 	"errors"
 	"strings"
 	"testing"
+	"time"
 )
+
+func TestEncodeV3RoundTrip(t *testing.T) {
+	t.Parallel()
+	issuedAt := time.Date(2026, time.August, 9, 8, 0, 0, 0, time.UTC)
+	in := TokenInfo{
+		UID:               "u1",
+		Name:              "alice",
+		Role:              "admin",
+		Language:          "zh-CN",
+		IssuedAt:          issuedAt.Unix(),
+		ExpiresAt:         issuedAt.Add(24 * time.Hour).Unix(),
+		DeviceFlag:        1,
+		DeviceID:          "device-1",
+		SessionGeneration: "generation-1",
+	}
+
+	encoded, err := EncodeV3(in)
+	if err != nil {
+		t.Fatalf("EncodeV3: %v", err)
+	}
+	if !strings.HasPrefix(encoded, v3Prefix) {
+		t.Fatalf("encoded value missing v3 prefix: %q", encoded)
+	}
+	got, err := Decode(encoded)
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	if got != in {
+		t.Fatalf("round trip mismatch: got %+v want %+v", got, in)
+	}
+	if !got.IsV3() {
+		t.Fatal("decoded v3 payload must report IsV3")
+	}
+}
+
+func TestDecodeV3RejectsInvalidLifetime(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		raw  string
+	}{
+		{name: "missing issued at", raw: "v3:{\"uid\":\"u1\",\"expires_at\":2,\"session_generation\":\"g\"}"},
+		{name: "missing expires at", raw: "v3:{\"uid\":\"u1\",\"issued_at\":1,\"session_generation\":\"g\"}"},
+		{name: "deadline not after issue", raw: "v3:{\"uid\":\"u1\",\"issued_at\":2,\"expires_at\":2,\"session_generation\":\"g\"}"},
+		{name: "missing generation", raw: "v3:{\"uid\":\"u1\",\"issued_at\":1,\"expires_at\":2}"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := Decode(tt.raw)
+			if !errors.Is(err, ErrInvalidToken) {
+				t.Fatalf("Decode(%q): want ErrInvalidToken, got %v", tt.raw, err)
+			}
+		})
+	}
+}
 
 func TestEncodeRoundTrip(t *testing.T) {
 	t.Parallel()

--- a/pkg/auth/validator.go
+++ b/pkg/auth/validator.go
@@ -1,0 +1,122 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/pkg/metrics"
+)
+
+// TokenRecord is an atomic snapshot of a token payload and its Redis PTTL.
+// TTL follows Redis semantics: -2 means missing and -1 means persistent.
+type TokenRecord struct {
+	Payload string
+	TTL     time.Duration
+}
+
+type TokenRecordReader interface {
+	ReadToken(ctx context.Context, key string) (TokenRecord, error)
+}
+
+type SessionGenerationResolver interface {
+	CurrentGeneration(ctx context.Context, uid string) (string, error)
+}
+
+type TokenValidator struct {
+	reader             TokenRecordReader
+	prefix             string
+	now                func() time.Time
+	generationResolver SessionGenerationResolver
+}
+
+func WithSessionGenerationResolver(resolver SessionGenerationResolver) ValidatorOption {
+	return func(v *TokenValidator) {
+		if resolver != nil {
+			v.generationResolver = resolver
+		}
+	}
+}
+
+type ValidatorOption func(*TokenValidator)
+
+func WithValidatorClock(now func() time.Time) ValidatorOption {
+	return func(v *TokenValidator) {
+		if now != nil {
+			v.now = now
+		}
+	}
+}
+
+func NewTokenValidator(reader TokenRecordReader, prefix string, opts ...ValidatorOption) *TokenValidator {
+	if reader == nil {
+		panic("auth: NewTokenValidator requires non-nil reader")
+	}
+	v := &TokenValidator{reader: reader, prefix: prefix, now: time.Now}
+	for _, opt := range opts {
+		opt(v)
+	}
+	return v
+}
+
+// Validate is the canonical token-read policy. Legacy v1/v2 persistent keys
+// remain readable in Release A so migration can be observed before apply. Any
+// v3 key is strict immediately: finite Redis TTL plus absolute payload expiry.
+func (v *TokenValidator) Validate(ctx context.Context, token string) (TokenInfo, error) {
+	if strings.TrimSpace(token) == "" {
+		return TokenInfo{}, wkhttp.ErrTokenMissing
+	}
+	record, err := v.reader.ReadToken(ctx, v.prefix+token)
+	if err != nil {
+		metrics.ObserveSessionValidationReject("store_error")
+		return TokenInfo{}, fmt.Errorf("auth: load token record: %w", err)
+	}
+	if record.TTL == -2 || strings.TrimSpace(record.Payload) == "" {
+		metrics.ObserveSessionValidationReject("missing")
+		return TokenInfo{}, wkhttp.ErrTokenNotFound
+	}
+	info, err := Decode(record.Payload)
+	if err != nil {
+		if errors.Is(err, ErrEmptyToken) {
+			metrics.ObserveSessionValidationReject("missing")
+			return TokenInfo{}, wkhttp.ErrTokenNotFound
+		}
+		metrics.ObserveSessionValidationReject("decode_invalid")
+		return TokenInfo{}, fmt.Errorf("%w: %v", wkhttp.ErrTokenInvalid, err)
+	}
+	if info.IsV3() {
+		if record.TTL <= 0 {
+			metrics.ObserveSessionValidationReject("v3_non_finite_ttl")
+			return TokenInfo{}, fmt.Errorf("%w: v3 token has non-finite redis ttl", wkhttp.ErrTokenInvalid)
+		}
+		if v.now().Unix() >= info.ExpiresAt {
+			metrics.ObserveSessionValidationReject("v3_expired")
+			return TokenInfo{}, fmt.Errorf("%w: v3 token absolute deadline reached", wkhttp.ErrTokenInvalid)
+		}
+		if v.generationResolver == nil {
+			metrics.ObserveSessionValidationReject("v3_generation_unavailable")
+			return TokenInfo{}, fmt.Errorf("%w: v3 generation validator unavailable", wkhttp.ErrTokenInvalid)
+		}
+		generation, err := v.generationResolver.CurrentGeneration(ctx, info.UID)
+		if err != nil {
+			metrics.ObserveSessionValidationReject("generation_store_error")
+			return TokenInfo{}, fmt.Errorf("auth: load session generation: %w", err)
+		}
+		if generation == "" || generation != info.SessionGeneration {
+			metrics.ObserveSessionValidationReject("generation_mismatch")
+			return TokenInfo{}, fmt.Errorf("%w: v3 session generation mismatch", wkhttp.ErrTokenInvalid)
+		}
+		return info, nil
+	}
+	if record.TTL == 0 || record.TTL < -2 {
+		metrics.ObserveSessionValidationReject("invalid_ttl")
+		return TokenInfo{}, fmt.Errorf("%w: invalid redis ttl", wkhttp.ErrTokenInvalid)
+	}
+	if record.TTL == -1 {
+		metrics.ObservePersistentSession()
+	}
+	return info, nil
+}

--- a/pkg/metrics/session.go
+++ b/pkg/metrics/session.go
@@ -1,0 +1,108 @@
+package metrics
+
+import (
+	"sync/atomic"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type SessionMetrics struct {
+	Operations       *prometheus.CounterVec
+	OperationLatency *prometheus.HistogramVec
+	ValidationReject *prometheus.CounterVec
+	PersistentSeen   prometheus.Counter
+	EffectiveTTL     prometheus.Gauge
+	operationOK      map[string]prometheus.Counter
+	operationError   map[string]prometheus.Counter
+	operationLatency map[string]prometheus.Observer
+}
+
+var defaultSessionMetrics atomic.Pointer[SessionMetrics]
+
+func NewSessionMetrics(reg prometheus.Registerer) *SessionMetrics {
+	m := &SessionMetrics{
+		Operations: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: metricNamespace,
+			Subsystem: "session",
+			Name:      "operations_total",
+			Help:      "Token session store operations by low-cardinality operation and outcome.",
+		}, []string{"operation", "outcome"}),
+		OperationLatency: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Namespace: metricNamespace,
+			Subsystem: "session",
+			Name:      "operation_duration_seconds",
+			Help:      "Token session store operation latency by operation.",
+			Buckets:   []float64{.001, .0025, .005, .01, .025, .05, .1, .25, .5, 1, 2.5},
+		}, []string{"operation"}),
+		ValidationReject: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: metricNamespace,
+			Subsystem: "session",
+			Name:      "validation_rejected_total",
+			Help:      "Token validation rejections by low-cardinality reason.",
+		}, []string{"reason"}),
+		PersistentSeen: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: metricNamespace,
+			Subsystem: "session",
+			Name:      "persistent_detected_total",
+			Help:      "Legacy persistent token records observed by validation or bounded on update.",
+		}),
+		EffectiveTTL: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: metricNamespace,
+			Subsystem: "session",
+			Name:      "effective_ttl_seconds",
+			Help:      "Configured access-token TTL effective in this process.",
+		}),
+	}
+	reg.MustRegister(m.Operations, m.OperationLatency, m.ValidationReject, m.PersistentSeen, m.EffectiveTTL)
+	m.operationOK = make(map[string]prometheus.Counter, 5)
+	m.operationError = make(map[string]prometheus.Counter, 5)
+	m.operationLatency = make(map[string]prometheus.Observer, 5)
+	for _, operation := range []string{"issue", "reuse", "update_payload", "read", "observe"} {
+		m.operationOK[operation] = m.Operations.WithLabelValues(operation, "ok")
+		m.operationError[operation] = m.Operations.WithLabelValues(operation, "error")
+		m.operationLatency[operation] = m.OperationLatency.WithLabelValues(operation)
+	}
+	defaultSessionMetrics.Store(m)
+	return m
+}
+
+func ObserveSessionOperation(operation string, started time.Time, err error) {
+	if m := defaultSessionMetrics.Load(); m != nil {
+		counter := m.operationOK[operation]
+		if err != nil {
+			counter = m.operationError[operation]
+		}
+		if counter == nil {
+			outcome := "ok"
+			if err != nil {
+				outcome = "error"
+			}
+			counter = m.Operations.WithLabelValues(operation, outcome)
+		}
+		counter.Inc()
+		observer := m.operationLatency[operation]
+		if observer == nil {
+			observer = m.OperationLatency.WithLabelValues(operation)
+		}
+		observer.Observe(time.Since(started).Seconds())
+	}
+}
+
+func ObserveSessionValidationReject(reason string) {
+	if m := defaultSessionMetrics.Load(); m != nil {
+		m.ValidationReject.WithLabelValues(reason).Inc()
+	}
+}
+
+func ObservePersistentSession() {
+	if m := defaultSessionMetrics.Load(); m != nil {
+		m.PersistentSeen.Inc()
+	}
+}
+
+func SetSessionEffectiveTTL(ttl time.Duration) {
+	if m := defaultSessionMetrics.Load(); m != nil {
+		m.EffectiveTTL.Set(ttl.Seconds())
+	}
+}

--- a/pkg/metrics/session_test.go
+++ b/pkg/metrics/session_test.go
@@ -1,0 +1,96 @@
+package metrics
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+func TestSessionMetricsRegisterAndObserveLowCardinalitySignals(t *testing.T) {
+	prev := defaultSessionMetrics.Load()
+	t.Cleanup(func() { defaultSessionMetrics.Store(prev) })
+
+	reg := prometheus.NewRegistry()
+	NewSessionMetrics(reg)
+	ObserveSessionOperation("issue", time.Now().Add(-time.Millisecond), nil)
+	ObserveSessionOperation("issue", time.Now().Add(-time.Millisecond), errors.New("redis unavailable"))
+	ObserveSessionValidationReject("v3_expired")
+	ObservePersistentSession()
+	SetSessionEffectiveTTL(48 * time.Hour)
+
+	if got := counterWithLabels(t, reg, "dmwork_session_operations_total", map[string]string{"operation": "issue", "outcome": "ok"}); got != 1 {
+		t.Fatalf("issue ok = %v, want 1", got)
+	}
+	if got := counterWithLabels(t, reg, "dmwork_session_operations_total", map[string]string{"operation": "issue", "outcome": "error"}); got != 1 {
+		t.Fatalf("issue error = %v, want 1", got)
+	}
+	if got := counterWithLabels(t, reg, "dmwork_session_validation_rejected_total", map[string]string{"reason": "v3_expired"}); got != 1 {
+		t.Fatalf("v3_expired = %v, want 1", got)
+	}
+	if got := counterWithLabels(t, reg, "dmwork_session_persistent_detected_total", nil); got != 1 {
+		t.Fatalf("persistent detected = %v, want 1", got)
+	}
+	if got := gaugeWithoutLabels(t, reg, "dmwork_session_effective_ttl_seconds"); got != (48 * time.Hour).Seconds() {
+		t.Fatalf("effective ttl = %v, want %v", got, (48 * time.Hour).Seconds())
+	}
+}
+
+func TestSessionMetricsNoDefaultIsNoop(t *testing.T) {
+	prev := defaultSessionMetrics.Load()
+	t.Cleanup(func() { defaultSessionMetrics.Store(prev) })
+	defaultSessionMetrics.Store(nil)
+
+	ObserveSessionOperation("read", time.Now(), nil)
+	ObserveSessionValidationReject("missing")
+	ObservePersistentSession()
+	SetSessionEffectiveTTL(time.Hour)
+}
+
+func counterWithLabels(t *testing.T, reg *prometheus.Registry, name string, want map[string]string) float64 {
+	t.Helper()
+	mfs, err := reg.Gather()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, mf := range mfs {
+		if mf.GetName() != name {
+			continue
+		}
+		for _, metric := range mf.GetMetric() {
+			matched := true
+			for labelName, labelValue := range want {
+				found := false
+				for _, label := range metric.GetLabel() {
+					if label.GetName() == labelName && label.GetValue() == labelValue {
+						found = true
+						break
+					}
+				}
+				if !found {
+					matched = false
+					break
+				}
+			}
+			if matched {
+				return metric.GetCounter().GetValue()
+			}
+		}
+	}
+	return 0
+}
+
+func gaugeWithoutLabels(t *testing.T, reg *prometheus.Registry, name string) float64 {
+	t.Helper()
+	mfs, err := reg.Gather()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, mf := range mfs {
+		if mf.GetName() == name && len(mf.GetMetric()) == 1 {
+			return mf.GetMetric()[0].GetGauge().GetValue()
+		}
+	}
+	return 0
+}

--- a/tools/lint-direct-error-response/baseline.txt
+++ b/tools/lint-direct-error-response/baseline.txt
@@ -27,6 +27,6 @@
 14 modules/oidc/api.go  # EXEMPT: OAuth2/OIDC protocol endpoints (authorize/callback/logout) — browser-facing redirect flow, not the dmwork front-end; raw errMsg() kept by design (#220). The err.Error() leaks were closed in #220.
 0 modules/oidc/api_bind.go  # migrated to httperr.ResponseErrorLWithStatus (#220)
 0 modules/robot/api.go  # migrated to httperr.ResponseErrorL / ResponseErrorLWithStatus (#267)
-8 modules/user/api.go
+7 modules/user/api.go
 4 modules/webhook/github.go  # EXEMPT: GitHub webhook signature errors — external GH never reads the localized envelope
 4 pkg/space/middleware.go

--- a/tools/token-session-observe/main.go
+++ b/tools/token-session-observe/main.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-server/internal/tokenlifecycle"
+	"github.com/Mininglamp-OSS/octo-server/pkg/auth"
+	octoredis "github.com/Mininglamp-OSS/octo-server/pkg/redis"
+	rd "github.com/go-redis/redis"
+	"github.com/spf13/viper"
+)
+
+func main() {
+	if err := run(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	configPath := flag.String("config", "configs/tsdd.yaml", "octo-server config file")
+	batchSize := flag.Int64("batch-size", 200, "Redis SCAN count hint (1-10000)")
+	qps := flag.Float64("qps", 100, "maximum token records read per second")
+	flag.Parse()
+
+	cfg, err := loadConfig(*configPath)
+	if err != nil {
+		return err
+	}
+	client := octoredis.NewInstrumentedClient(cfg, func(o *rd.Options) {
+		o.MaxRetries = 1
+		o.PoolSize = 2
+		o.DialTimeout = 2 * time.Second
+		o.ReadTimeout = 2 * time.Second
+		o.WriteTimeout = 2 * time.Second
+		o.PoolTimeout = time.Second
+	})
+	defer client.Close()
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	store := auth.NewRedisSessionStore(
+		client,
+		cfg.Cache.TokenCachePrefix,
+		cfg.Cache.UIDTokenCachePrefix,
+		cfg.Cache.TokenExpire,
+	)
+	if *qps <= 0 || *qps > 10_000 {
+		return fmt.Errorf("qps must be greater than zero and no more than 10000")
+	}
+	interval := time.Duration(float64(time.Second) / *qps)
+	stats, err := store.ObserveRateLimited(ctx, *batchSize, interval)
+	if err != nil {
+		return fmt.Errorf("observe token sessions: %w", err)
+	}
+	if err := json.NewEncoder(os.Stdout).Encode(stats); err != nil {
+		return fmt.Errorf("encode aggregate observation: %w", err)
+	}
+	return nil
+}
+
+func loadConfig(path string) (*config.Config, error) {
+	vp := viper.New()
+	vp.SetConfigFile(path)
+	if err := vp.ReadInConfig(); err != nil {
+		return nil, fmt.Errorf("load config %s: %w", path, err)
+	}
+	vp.SetEnvPrefix("TS")
+	vp.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
+	vp.AutomaticEnv()
+	tokenExpire, err := tokenlifecycle.ValidateTokenExpire(vp)
+	if err != nil {
+		return nil, err
+	}
+	cfg := config.New()
+	cfg.ConfigureWithViper(vp)
+	cfg.Cache.TokenExpire = tokenExpire
+	return cfg, nil
+}


### PR DESCRIPTION
## Summary

PR 1 of 2 for user HTTP-token lifecycle hardening. It stops new or touched
credentials from becoming unbounded, preserves bearer deadlines across profile
updates and repeated login, and prepares a safe mixed-version migration without
changing the client token contract.

This PR intentionally does not bulk-expire historical persistent v1/v2 tokens.
Final closure requires PR 2 plus controlled production migration and retest.

## Related Issue

No public issue is linked; this security-hardening work is tracked by the linked
repository spec.

## Linked Spec

[`.octospec/tasks/token-lifecycle-hardening/brief.md`](.octospec/tasks/token-lifecycle-hardening/brief.md)

## Changes

- Strictly validate the existing `cache.tokenExpire` /
  `TS_CACHE_TOKENEXPIRE` setting, keep the 720h maximum, and fail startup for
  explicit empty, malformed, non-positive, or over-limit values without
  mutating shared Viper semantics.
- Route all production user-token writers through one Session Store. New
  credentials receive finite TTLs; reuse and profile updates preserve the
  existing deadline; concurrent logout cannot be undone by another replica.
- Make authentication read payload and PTTL atomically with one single-key Lua
  script, and execute the real read script as a read-only API startup probe.
- Centralize explicit token readers on the canonical validator. Legacy v1/v2
  remains compatible in PR 1; v3 values already fail closed on non-finite TTL,
  absolute expiry, or session-generation mismatch.
- Add bounded Session Store pool configuration and metrics, aggregate-only
  migration observation, failure-compensation tests, HTTP TTL coverage, and
  repository-wide reader/writer source guards.
- Record the PR 1 rollout boundary, verification, and reusable configuration
  learning in OctoSpec journal/context files.

## Testing

- [x] Unit tests added/updated
- [x] Manually verified with local MySQL, Redis, and WuKongIM containers
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `golangci-lint run ./...` (0 issues)
- [x] `go test . ./pkg/auth ./pkg/metrics -count=1`
- [x] Focused `modules/user` login, Redis, source-guard, and HTTP TTL tests
- [x] `go test -race ./pkg/auth ./pkg/metrics`
- [x] `make i18n-extract-check`
- [x] `make i18n-lint`

The broad all-package integration suite is not claimed as green: the shared
local MySQL schema has unrelated migration-state drift. Exact changed targets
pass, and the database was not cleaned to conceal that environment failure.

## COMPREHENSION

1. **What does this change actually do** to the load-bearing path?

   Every user HTTP bearer read now resolves through one validator backed by an
   atomic payload+PTTL Redis read. Every production writer issues a finite
   credential or updates an existing credential without extending its deadline.
   New-credential compensation, compare-safe index cleanup, and Redis-only
   coordination preserve the invariant across replicas. API startup proves the
   configured Redis path can execute the authentication Lua before serving.

2. **What could break** because of it (dependents + failure mode)?

   Invalid TTL config or a Redis endpoint without `EVALSHA`/`EVAL` now prevents
   startup instead of silently degrading. Web/PC repeated login preserves the
   old deadline, so a near-expiry session can still expire shortly after login;
   APP replacement revokes the previous bearer. The dedicated pool adds up to
   `PoolSize x replicas` Redis connections and must fit `maxclients`. Historical
   persistent v1/v2 sessions remain valid until PR 2 migration, by design.

3. **How do you know it works** (specific test/repro/trace)?

   A real HTTP login test proves `0 < PTTL <= TokenExpire`; nickname update
   proves PTTL never increases. Two Session Store instances prove concurrent
   logout cannot resurrect a credential. Failure injection covers issue/index
   compensation and startup Lua rejection. v3 downgrade, permanent/non-finite
   TTL, absolute-expiry, generation, writer/reader guard, pool-bound, and
   empty-env/Viper-isolation regressions are all pinned by tests. The final
   build, vet, lint, focused integration, race, and i18n gates are listed above.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] PR description is in English
- [x] Added tests for my changes
- [x] Updated documentation
- [x] Followed commit message conventions (Conventional Commits)
