### PR TITLE
feat(auth): harden token lifecycle with bounded v3 sessions

### DIFF
--- a/.octospec/journal/shared/token-lifecycle-hardening-pr2.md
+++ b/.octospec/journal/shared/token-lifecycle-hardening-pr2.md
@@ -74,4 +74,3 @@ matrix is complete or widen those operations without a stable device identity.
   management account able to log in again.
 - The rollout floor prevents phase rollback but cannot prove Kubernetes replica
   retirement or production capacity. Those remain explicit go/no-go checks.
-

--- a/.octospec/journal/shared/token-lifecycle-hardening-pr2.md
+++ b/.octospec/journal/shared/token-lifecycle-hardening-pr2.md
@@ -1,0 +1,77 @@
+---
+type: Journal
+title: "Journal: token-lifecycle-hardening PR 2"
+description: Record of the guarded v3 session rollout, durable revocation, and controlled legacy-token migration implementation.
+tags: ["auth", "security", "redis", "session", "migration", "observability"]
+timestamp: 2026-08-10T01:17:49+08:00
+# --- octospec extension fields ---
+task: token-lifecycle-hardening-pr2
+source: self
+---
+
+# Journal: token-lifecycle-hardening PR 2
+
+## What was done
+
+- Added a startup-fixed, default-`expand` rollout mode and an operator-only,
+  monotonic Redis floor. No deployment automatically enables v3, migration
+  apply, or legacy enforcement.
+- Added v3 payload absolute expiry, random session generations, issuance
+  fences, deadline-preserving reuse/snapshot updates, and a bounded session
+  index. Authentication reads the Token key and generation sequentially through
+  the existing shared Session Store pool and performs no steady-state write.
+- Scoped indexes by UID and generation. Revocation Lua records the generation
+  replaced by an event, so first application and exact replay clean only that
+  old index; a post-event login cannot be removed from the cap by an old event.
+- Added transactional MySQL revocation intents for active password changes and
+  resets, account disable/final destruction, and administrator deletion. API
+  paths apply synchronously; a leased, multi-replica worker retries pending
+  intents idempotently without logging credentials or raw UIDs.
+- Added a default-dry-run admin tool for monotonic floor changes and fixed-cutoff
+  legacy migration. Apply requires an explicit campaign, cutoff, batch size,
+  QPS, lease, and persisted revoke floor; it uses a separate two-connection
+  pool, owner lease, aggregate checkpoint, and single-key shorten-only Lua.
+- Revalidated passwords and authoritative account state after the issuance
+  fence across local, manager, external, OAuth, scan, and device-verification
+  paths. A review-found gap in manager status handling was fixed so disabled or
+  destroyed administrators cannot immediately obtain a new v3 bearer.
+
+## Security and rollout boundary
+
+The code remains inert in `expand`. Production closure still requires Redis
+topology/Lua/SCAN/lease and non-eviction checks, connection and two-read auth
+capacity budgets, an approved session cap and migration cutoff, old-replica
+retirement at every phase, apply plus two complete observations, enforce
+canarying, and security retest.
+
+`/v1/user/pc/quit`, device deletion, and OIDC sync `invalid_grant` still need a
+signed device-scope policy. The implementation deliberately does not claim that
+matrix is complete or widen those operations without a stable device identity.
+
+## Verification
+
+- `go test ./pkg/auth -count=1` and `go test -race ./pkg/auth/... -count=1` — pass.
+- `GIN_MODE=release go test ./modules/user -count=1` — pass against local
+  MySQL, Redis, and WuKongIM (31.781s final run).
+- `GIN_MODE=release go test ./modules/oidc -count=1` — pass against an isolated
+  temporary `test` schema; the original local schema was backed up and restored
+  automatically (13.038s final run).
+- `go test ./tools/token-session-admin ./pkg/metrics -count=1` — pass.
+- `go build ./...`, `go vet ./...`, `golangci-lint run ./...`,
+  `make i18n-extract-check`, and `make i18n-lint` — pass.
+- `go test ./... -count=1` — not green. Unchanged `internal/msgextraseq` held
+  the shared `test` database until the default 10-minute timeout; concurrent
+  integration packages then failed with MySQL 1205 lock waits. Relevant auth
+  packages passed in that run, and focused integration was rerun separately.
+
+## Learnings and follow-ups
+
+- A monotonic generation protects bearer validity but does not protect a shared
+  mutable index from stale cleanup. Cleanup ownership must carry the revoked
+  generation so retry and post-event issuance commute safely.
+- A credential fence must precede the authoritative credential/account read;
+  merely rereading a password while omitting status fields leaves a disabled
+  management account able to log in again.
+- The rollout floor prevents phase rollback but cannot prove Kubernetes replica
+  retirement or production capacity. Those remain explicit go/no-go checks.
+

--- a/.octospec/journal/shared/token-lifecycle-hardening-pr2.md
+++ b/.octospec/journal/shared/token-lifecycle-hardening-pr2.md
@@ -35,6 +35,36 @@ source: self
   fence across local, manager, external, OAuth, scan, and device-verification
   paths. A review-found gap in manager status handling was fixed so disabled or
   destroyed administrators cannot immediately obtain a new v3 bearer.
+- Closed the review fault paths without adding replica-local state: v3 issue
+  compensation removes only its owned generation-scoped index member; disabled
+  accounts cannot redeem an outstanding scan code; synchronous revocation uses
+  the same owner-lease invariant as workers; committed account destruction and
+  ordinary logout still attempt IM/device cleanup when Redis is degraded.
+- Namespaced migration state by campaign, made rate knobs resumable, required an
+  explicit `natural` or `cap` finite-token policy, and added persistent aggregate
+  evidence gates before bounded/enforce floor transitions. The repository writer
+  guard now covers all security-key families, and a command-count test pins v3
+  steady-state validation to two Redis reads and zero writes.
+- Hardened the local re-review findings without replica-local coordination. An
+  elapsed campaign cutoff now classifies dry-run `would_delete` separately from
+  apply `deleted` while preserving the approved absolute deadline; new
+  revocation intents reserve a five-second MySQL visibility window for the
+  synchronous by-ID claimant before workers take over; rollout control persists
+  an explicit minimum observation gap that later floor transitions must satisfy.
+- Made those rollout gates forward compatible without Redis surgery. Observation
+  gaps have a hard one-hour floor, may only increase between phases, and validate
+  evidence against the newly approved value. A legacy control record without the
+  gap remains readable and the next monotonic floor CAS backfills it. Applying an
+  elapsed migration cutoff now requires explicit confirmation in both the CLI
+  parser and Session Store API before any remaining records can be deleted.
+- Closed the remaining mid-run cutoff window. The single-key migration Lua now
+  refuses its first immediate deletion with a distinct action when an
+  unconfirmed apply crosses the immutable cutoff during a throttled scan. The
+  store returns a resumable error without completion evidence; an explicitly
+  confirmed rerun can then delete the remaining records under the same campaign.
+- Added `docs/token-session-rollout-runbook.md` with exact environment pairing,
+  Redis/non-eviction and connection preflight, phased commands, old-replica
+  checks, stop conditions, and the irreversible rollback boundary.
 
 ## Security and rollout boundary
 
@@ -44,25 +74,53 @@ capacity budgets, an approved session cap and migration cutoff, old-replica
 retirement at every phase, apply plus two complete observations, enforce
 canarying, and security retest.
 
+Finite legacy handling is now an explicit campaign decision: `natural` preserves
+already-bounded finite deadlines while still bounding persistent/over-max keys;
+`cap` also compresses finite deadlines to the cutoff and can force earlier
+re-login. The code supports both but does not approve either for production.
+
 `/v1/user/pc/quit`, device deletion, and OIDC sync `invalid_grant` still need a
 signed device-scope policy. The implementation deliberately does not claim that
 matrix is complete or widen those operations without a stable device identity.
 
 ## Verification
 
-- `go test ./pkg/auth -count=1` and `go test -race ./pkg/auth/... -count=1` — pass.
+- `go test -race ./pkg/auth/... -count=1` — pass (4.330s); the additional
+  finite-policy boundary test also passed after adding the over-max case. After
+  the local re-review hardening, the same command passed again (4.049s),
+  including elapsed-cutoff deletion and observation-gap regressions. After the
+  forward-compatibility fixes, it passed again (4.768s), including legacy
+  control backfill, monotonic gap increases, the one-hour floor, and elapsed
+  cutoff confirmation. After closing the mid-run cutoff window, it passed again
+  (4.533s); the new Redis regression also passed ten consecutive focused runs.
 - `GIN_MODE=release go test ./modules/user -count=1` — pass against local
-  MySQL, Redis, and WuKongIM (31.781s final run).
-- `GIN_MODE=release go test ./modules/oidc -count=1` — pass against an isolated
-  temporary `test` schema; the original local schema was backed up and restored
-  automatically (13.038s final run).
-- `go test ./tools/token-session-admin ./pkg/metrics -count=1` — pass.
+  MySQL, Redis, and WuKongIM (57.932s final re-review run), including the new
+  synchronous-claim priority-window integration test.
+- `GIN_MODE=release go test ./modules/oidc -count=1` — the shared `test` schema
+  first failed before assertions because of an unrelated stale migration ID;
+  the package passed against a fresh temporary `test` schema again after the
+  re-review changes (18.153s). The original schema was restored from a
+  checksum-verified dump with the same 118 tables and 190 migration records;
+  before/after dump SHA256 matched, then the temporary database and dumps were
+  removed.
+- `go test ./tools/token-session-admin ./tools/token-session-observe ./pkg/metrics
+  -count=1` — pass after the re-review changes (`token-session-observe` has no
+  test files; its shared store behavior is covered in `pkg/auth`). It passed
+  again after the forward-compatibility fixes (`token-session-admin` 0.418s,
+  `pkg/metrics` 0.699s), and after the mid-run cutoff fix
+  (`token-session-admin` 0.704s, `pkg/metrics` 0.447s).
 - `go build ./...`, `go vet ./...`, `golangci-lint run ./...`,
-  `make i18n-extract-check`, and `make i18n-lint` — pass.
-- `go test ./... -count=1` — not green. Unchanged `internal/msgextraseq` held
-  the shared `test` database until the default 10-minute timeout; concurrent
-  integration packages then failed with MySQL 1205 lock waits. Relevant auth
-  packages passed in that run, and focused integration was rerun separately.
+  `make i18n-extract-check`, and `make i18n-lint` — pass again at the
+  mid-run cutoff head; golangci-lint reported zero issues.
+- `go test -cover ./pkg/auth -count=1` — pass with 74.8% package statement
+  coverage. The repository has no 80% coverage gate; this journal does not
+  claim one, while the new destructive branch is directly exercised by the
+  RED-to-GREEN Redis regression above.
+- `go test ./... -count=1` was not rerun at the final documentation/policy head.
+  The earlier PR-head attempt was not green: unchanged `internal/msgextraseq`
+  held the shared `test` database until the default 10-minute timeout, then
+  concurrent packages failed with MySQL 1205 lock waits. Relevant packages were
+  rerun serially above; this journal does not claim an all-package pass.
 
 ## Learnings and follow-ups
 

--- a/.octospec/learnings/pending/token-lifecycle-hardening-pr2.md
+++ b/.octospec/learnings/pending/token-lifecycle-hardening-pr2.md
@@ -40,4 +40,3 @@ Checking only that the post-event bearer still authenticates misses the defect:
 the damage is to capacity and future revocation behavior. The pattern applies to
 distributed indexes, leases, caches, and outboxes whenever a primary monotonic
 state change is followed by non-transactional cleanup.
-

--- a/.octospec/learnings/pending/token-lifecycle-hardening-pr2.md
+++ b/.octospec/learnings/pending/token-lifecycle-hardening-pr2.md
@@ -1,0 +1,43 @@
+---
+type: Learning
+title: Scope revocation cleanup to the revoked generation
+description: Monotonic credential invalidation does not make a shared session index safe from stale-event cleanup; cleanup must carry generation ownership.
+tags: ["security", "redis", "concurrency", "revocation", "idempotency"]
+timestamp: 2026-08-10T01:17:49+08:00
+# --- octospec extension fields ---
+source: self
+origin_task: token-lifecycle-hardening-pr2
+status: pending
+candidate_rule: distributed-state
+---
+
+# Scope revocation cleanup to the revoked generation
+
+## Context
+
+Rotating a per-user generation immediately invalidates old bearers and makes an
+event replay idempotent for authentication. A separate per-user session index
+was still deleted unconditionally after rotation. An exact replay after a new
+login therefore left the new bearer valid but unindexed, bypassing the session
+cap; the first event also raced a new-generation issuer in the same way.
+
+## Rule of thumb
+
+When a monotonic event updates one security authority and later cleans an
+auxiliary shared collection:
+
+1. Record the exact old epoch/generation replaced by the event in the atomic
+   authority update.
+2. Partition or tag auxiliary state by that epoch.
+3. On exact replay, retry cleanup only for the recorded old epoch.
+4. On an older out-of-order event, do not clean current auxiliary state.
+5. Test both validity and secondary invariants such as caps, enumeration, and
+   device targeting after a post-event login.
+
+## Why worth a rule
+
+Checking only that the post-event bearer still authenticates misses the defect:
+the damage is to capacity and future revocation behavior. The pattern applies to
+distributed indexes, leases, caches, and outboxes whenever a primary monotonic
+state change is followed by non-transactional cleanup.
+

--- a/.octospec/log.md
+++ b/.octospec/log.md
@@ -9,10 +9,13 @@ change-log convention (§7). Newest first.
 - **Task** — `token-lifecycle-hardening-pr2`: added an inert-by-default,
   monotonic v3 session rollout; absolute deadlines, generation/fence validation,
   generation-scoped bounded indexes, durable high-risk revocation intents, and
-  a controlled legacy migration/admin tool. Review follow-up prevented stale
-  revocation replay from erasing post-event index entries and blocked disabled
-  administrators from reissuing sessions. Production activation, device-scope
-  completion, migration, enforce, and security retest remain explicit gates. See
+  a controlled legacy migration/admin tool. Review follow-up closed owned v3
+  compensation/index leaks, disabled scan-code redemption, campaign resume,
+  floor-evidence, lease and post-commit retry gaps; finite migration policy is
+  now explicit rather than hardcoded. The production runbook pins Redis,
+  connection, old-replica, required-floor and irreversible rollback gates.
+  Production activation, device-scope completion, migration, enforce, and
+  security retest remain explicit gates. See
   [journal](journal/shared/token-lifecycle-hardening-pr2.md).
 - **Learning (pending)** —
   [scope-revocation-cleanup-to-generation](learnings/pending/token-lifecycle-hardening-pr2.md):

--- a/.octospec/log.md
+++ b/.octospec/log.md
@@ -4,6 +4,22 @@ Change history for this repo's `.octospec/`, following the
 [OKF](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md)
 change-log convention (§7). Newest first.
 
+## 2026-08-10 (token-lifecycle-hardening PR 2)
+
+- **Task** — `token-lifecycle-hardening-pr2`: added an inert-by-default,
+  monotonic v3 session rollout; absolute deadlines, generation/fence validation,
+  generation-scoped bounded indexes, durable high-risk revocation intents, and
+  a controlled legacy migration/admin tool. Review follow-up prevented stale
+  revocation replay from erasing post-event index entries and blocked disabled
+  administrators from reissuing sessions. Production activation, device-scope
+  completion, migration, enforce, and security retest remain explicit gates. See
+  [journal](journal/shared/token-lifecycle-hardening-pr2.md).
+- **Learning (pending)** —
+  [scope-revocation-cleanup-to-generation](learnings/pending/token-lifecycle-hardening-pr2.md):
+  a monotonic authority update does not make later shared-index cleanup safe;
+  partition cleanup by the exact revoked generation and test secondary
+  invariants such as caps after event replay.
+
 ## 2026-08-09 (token-lifecycle-hardening PR 1)
 
 - **Task** — `token-lifecycle-hardening`: bounded all new and touched user HTTP

--- a/.octospec/tasks/token-lifecycle-hardening-pr2/brief.md
+++ b/.octospec/tasks/token-lifecycle-hardening-pr2/brief.md
@@ -79,8 +79,10 @@ source: self
   两次完整 aggregate observe；首次推进 floor 时还会持久化批准的最小观测间隔，后续推进必须
   使用至少 `1h` 且不低于已持久化值的间隔，两份证据必须达到本次批准的新值。旧版 control
   若没有该字段仍可读取，并在下一次单调推进时由 CAS 自动补齐，无需删除或手改 Redis key。
-  缺失、损坏、含读取歧义、间隔不足或计数不达标均 fail closed。上线命令、required-floor
-  配对、Redis/连接预算和回滚边界见 runbook。
+  observation 还带随机 scan ID 和由 Token/UIDToken prefix、`TokenExpire` 计算的作用域指纹；空
+  扫描、重复 scan ID、作用域不匹配、分类计数不守恒、缺失 v3 canary、损坏、含读取歧义、间隔
+  不足或计数不达标均 fail closed。旧版 observation evidence 因缺失新元数据自动失效，必须重扫。
+  上线命令、required-floor 配对、Redis/连接预算和回滚边界见 runbook。
 - 已把主动改密/重置、账号禁用/最终注销、管理员删除与 monotonic revocation intent 放入同一
   MySQL 事务；同步 Redis 应用失败后由带 owner lease 的多副本 worker 幂等重试。当前退出先撤
   HTTP bearer，再执行既有 IM 退出。新 intent 的 `next_attempt_at` 为同步 by-ID claim 保留 5 秒
@@ -283,7 +285,11 @@ legacy bearer 重新有效。
 - 默认 dry-run；apply 必须显式提供 campaign ID、不可变的绝对 `legacy_cutoff_at`、批准的处理策略、
   batch size 和 QPS。续跑时 campaign 参数不一致必须拒绝。
 - 使用带 owner token 和 lease 的单执行者锁；续约失败立即停止新批次，release compare-delete。
-  checkpoint 只保存 cursor/campaign/计数，不保存 Token、完整 key、payload 或 UID。
+  checkpoint 只保存 cursor/campaign/计数和 Redis `run_id` 的 SHA-256 实例指纹，不保存 Token、完整
+  key、payload、UID 或原始 `run_id`。apply 在每个 SCAN page 前后核对实例指纹；主节点重启、
+  failover 或恢复旧 checkpoint 时指纹变化必须在重新确认 lease 后从 cursor 0 幂等重扫，不能把
+  另一 Redis 进程的 cursor 继续解释。completion/checkpoint 必须同属当前 Redis 实例，否则
+  `bounded` 拒绝推进。
 - SCAN 不是快照。一次读失败、锁丢失、取消或游标未归零都必须输出 `complete=false`；不能把部分
   扫描的零计数当作迁移完成。key 在 SCAN 后自然过期计入 missing，不应让整次扫描伪装成功或
   无限失败。
@@ -432,7 +438,8 @@ grace 已经过期推断 v1/v2 已清零。
   v1/v2/v3/concurrent-change/lock-loss。cutoff 在入口已过期或 apply 运行中到期时都必须额外
   显式确认；否则入口校验或单 key Lua 会在删除前拒绝，本轮不能生成 completion evidence。
 - observe/apply 遇到读取错误、取消或未完成游标会输出 `complete=false`；只有两次完整扫描的
-  `persistent=0, over_max=0, v1/v2=0` 且跨过本次批准的间隔才允许 enforce。批准间隔不得低于
+  `total>0, persistent=0, over_max=0, v1/v2=0, v3>0` 且跨过本次批准的间隔才允许 enforce。
+  scan ID 必须不同、作用域指纹必须匹配当前 store、分类计数必须与 total 守恒；批准间隔不得低于
   `1h`，并且只能相对 rollout control 中已持久化的值增大、不能降低。
 - enforce 后 v1/v2、历史报告 Token、deny marker 命中的 legacy Token 全部失败；新 v1/v2 或
   permanent 异常触发告警。

--- a/.octospec/tasks/token-lifecycle-hardening-pr2/brief.md
+++ b/.octospec/tasks/token-lifecycle-hardening-pr2/brief.md
@@ -70,9 +70,21 @@ source: self
 - 已实现默认 `expand` 的单调 rollout mode、持久 floor、v3 绝对到期、generation/issuance
   fence、按 UID + generation 隔离的有界会话索引、legacy deny、默认 dry-run 的可续跑 migration
   apply，以及独立小连接池的 `token-session-admin`。合并或部署不会自动切到 v3、apply 或 enforce。
+- migration campaign/checkpoint 已按 campaign ID 隔离；batch/QPS 可在续跑时调整，固定 cutoff
+  过期后已有 campaign 仍可续跑，但命中的剩余记录会按既定绝对截止时间立即删除；dry-run 记为
+  `would_delete`，apply 记为 `deleted`，不再误报为 `shortened`。有限 legacy 策略不再硬编码，
+  工具要求显式选择 `natural` 或 `cap`，并把选择纳入不可变 campaign 安全身份；cutoff 已过期
+  或在 apply 运行中到期时，单 key Lua 都会在删除前要求显式确认立即删除影响。
+- `bounded` / `enforce` floor 会机器校验 migration completion/checkpoint 和同一当前 floor 下最近
+  两次完整 aggregate observe；首次推进 floor 时还会持久化批准的最小观测间隔，后续推进必须
+  使用至少 `1h` 且不低于已持久化值的间隔，两份证据必须达到本次批准的新值。旧版 control
+  若没有该字段仍可读取，并在下一次单调推进时由 CAS 自动补齐，无需删除或手改 Redis key。
+  缺失、损坏、含读取歧义、间隔不足或计数不达标均 fail closed。上线命令、required-floor
+  配对、Redis/连接预算和回滚边界见 runbook。
 - 已把主动改密/重置、账号禁用/最终注销、管理员删除与 monotonic revocation intent 放入同一
   MySQL 事务；同步 Redis 应用失败后由带 owner lease 的多副本 worker 幂等重试。当前退出先撤
-  HTTP bearer，再执行既有 IM 退出。
+  HTTP bearer，再执行既有 IM 退出。新 intent 的 `next_attempt_at` 为同步 by-ID claim 保留 5 秒
+  优先窗口；请求进程退出或失败后，共享 worker 再接管，不依赖副本本地锁或状态。
 - 登录 writer 已覆盖普通、username、email、manager、微信、GitHub、Gitee、OIDC/external、扫码、
   设备验证和注册；密码或账号状态在 issuance fence 后重新读取。管理端同时重查 `status` 与
   `is_destroy`，禁用/注销账号不能在撤销后重新登录。
@@ -128,6 +140,9 @@ source: self
 - 滚动升级允许 `expand` 与 `v3-write` 短暂混跑，因为所有 reader 已能安全识别 v3；此时不得
   进入 `revoke`、运行 apply 或创建 legacy deny marker。
 - 使用一个无 TTL、单 key 的 rollout control record 保存最小 writer version 和最小安全 mode；
+  同一 record 还保存显式批准的最小 observe 间隔。该值硬下界为 `1h`，后续阶段可经审批增大但
+  不得降低；证据必须满足本次写入的新值。旧版 record 缺失该字段时允许读取，下一次合法推进
+  以运维传入值原子补齐，不要求生产 Redis 手工删除或改写；
   只能由显式运维命令 CAS 向前推进，不能由公开 HTTP API 修改。所有副本进入 `v3-write` 后才把
   writer floor 设为 3；所有副本进入 `revoke` 后才允许创建 deny marker/运行 apply；apply 完成
   后才把安全 floor 推进到 `bounded`。运行时配置低于 floor 必须启动失败，迁移工具在前置 floor
@@ -271,12 +286,19 @@ legacy bearer 重新有效。
 - 每个 Token 由单 key Lua 重新读取当前 payload/version/PTTL 后决定，保证 TOCTOU 下仍满足：
   missing 或已变 v3 则 no-op；只缩短、不延长、不创建 key；短于目标的 TTL 保持不变；重复执行
   不以“本次运行时间 + grace”续期。
+- 已有 campaign 的绝对 cutoff 若在续跑前或本次限速扫描中已经过去，工具仍不得延长或替换该
+  安全 deadline；
+  命中的剩余目标记录必须删除，并在 dry-run/apply 中分别统计为 `would_delete` / `deleted`，使
+  运维能在 apply 前评估批量重新登录影响。此时 apply 必须额外显式确认 elapsed cutoff；仅传
+  `--apply` 时，每条记录的 Lua 都必须在 `DEL` 前 fail closed，本轮不得生成 completion evidence。
 - 永久 v1/v2 使用固定 `legacy_cutoff_at`；有限 v1/v2 按批准策略选择自然等待，或统一收敛到
   `min(当前 deadline, legacy_cutoff_at)`。超过 `TokenExpire` 的有限值至少压到上限。
 - v3 permanent/过期/generation 缺失本来就被 validator 拒绝；apply 不得把异常 v3“修复”为
   再次有效，只聚合告警并由单独清理动作删除。
-- 迁移使用独立小连接池和独立 latency/error 指标，不与在线 session pool 争抢连接；限速在
-  production 同拓扑压测后确定。
+- 迁移使用独立小连接池，不与在线 session pool 争抢连接；限速在 production 同拓扑压测后
+  确定。当前一次性工具以聚合 JSON、Job exit status/elapsed 和 Redis 平台指标作为运维证据，
+  尚未暴露独立 Prometheus latency/error endpoint；激活前必须把 Job 失败/超时接入告警，不能
+  仅依赖人工查看终端。
 
 进入 enforce 前至少完成两次 `complete=true` 的全前缀扫描，并同时满足
 `persistent=0, over_max=0, v1/v2=0`；两次扫描间隔和 campaign 证据写入 runbook。不能仅按
@@ -345,6 +367,9 @@ grace 已经过期推断 v1/v2 已清零。
 
 ## Rollout
 
+具体命令、配置配对、Kubernetes 旧副本清零证据、Redis 预检和 stop condition 见
+`docs/token-session-rollout-runbook.md`；以下状态机仍是放行依据：
+
 1. 在生产同拓扑预检配置、Redis Lua/SCAN/lease 兼容、non-evicting 安全状态、连接数和 v3/
    legacy 额外读取性能预算。
 2. 以 `expand` 部署 PR 2，清零所有 PR 2 之前副本；确认 v3 仍未签发。
@@ -366,8 +391,10 @@ grace 已经过期推断 v1/v2 已清零。
   PR 2 兼容制品；PR 1 没有运行时 generation resolver，不能作为可用回滚版本。
 - apply 可暂停/续跑，回滚不延长已经缩短的 TTL，不删除 legacy deny marker，也不清除 writer
   floor。已过期 Token 通过重新登录恢复，不能复活。
-- enforce 异常时最多退到 `bounded`，仍拒绝 permanent/over-max legacy、继续写 v3 并遵守 deny
-  marker；退回即意味着漏洞关闭条件暂时不成立，必须记录安全例外。禁止退到 `expand`。
+- enforce 灰度且 enforce floor 尚未建立时，异常最多退到 `bounded`，仍拒绝 permanent/over-max
+  legacy、继续写 v3 并遵守 deny marker；退回即意味着漏洞关闭条件暂时不成立，必须记录安全
+  例外。enforce floor 建立后不可再启动 bounded 实例，只能回滚到遵守 enforce floor 的兼容 v3
+  制品。禁止退到 `expand`。
 - generation/outbox 故障不得通过关闭 generation 校验或恢复 v2 writer 缓解；可暂停新登录/迁移、
   扩容 Redis、回滚到兼容 v3 制品并处理 backlog。
 
@@ -397,9 +424,12 @@ grace 已经过期推断 v1/v2 已清零。
 - 撤销矩阵中每个已签字事件都有 HTTP 集成测试；成功响应后旧 Token 返回统一未认证，IM 失败不
   恢复 bearer。密码 hash opportunistic rehash 不触发全量撤销。
 - migration dry-run 零写入且无秘密输出；apply 单执行者、可取消续跑、固定 cutoff、重复执行不
-  延期，覆盖 missing/persistent/finite-short/over-max/v1/v2/v3/concurrent-change/lock-loss。
+  延期，过期 cutoff 的删除与预删除单独统计；覆盖 missing/persistent/finite-short/over-max/
+  v1/v2/v3/concurrent-change/lock-loss。cutoff 在入口已过期或 apply 运行中到期时都必须额外
+  显式确认；否则入口校验或单 key Lua 会在删除前拒绝，本轮不能生成 completion evidence。
 - observe/apply 遇到读取错误、取消或未完成游标会输出 `complete=false`；只有两次完整扫描的
-  `persistent=0, over_max=0, v1/v2=0` 才允许 enforce。
+  `persistent=0, over_max=0, v1/v2=0` 且跨过本次批准的间隔才允许 enforce。批准间隔不得低于
+  `1h`，并且只能相对 rollout control 中已持久化的值增大、不能降低。
 - enforce 后 v1/v2、历史报告 Token、deny marker 命中的 legacy Token 全部失败；新 v1/v2 或
   permanent 异常触发告警。
 - 运行 focused `pkg/auth`、`modules/user`、`modules/oidc`、migration tests，`go test -race
@@ -413,6 +443,8 @@ grace 已经过期推断 v1/v2 已清零。
 包含当前设备在内的全部会话。以下环境参数和未接线路径不能由代码自行猜测：
 
 - legacy grace 与绝对 `legacy_cutoff_at`：原建议 7 天，需生产 observe 后签字。
+- 两次完整 observe 的最小间隔；工具要求每次 floor 推进时显式给出，硬下界为 `1h`，后续只可
+  经审批增大、不得降低。实际值需结合 Token QPS、Redis 压力和风险窗口签字。
 - finite v1/v2：自然等待最长 TTL，还是全部压到 cutoff；后者重新登录影响更大。
 - 单 UID 会话硬上限及超限策略；Web/PC 显式重登录继续复用剩余寿命，还是签发新 Token。
 - `/v1/user/quit`、`/v1/user/pc/quit`、设备删除的精确产品 scope；缺少稳定 device ID 时允许扩大

--- a/.octospec/tasks/token-lifecycle-hardening-pr2/brief.md
+++ b/.octospec/tasks/token-lifecycle-hardening-pr2/brief.md
@@ -1,0 +1,398 @@
+---
+type: Task
+title: "Task: token-lifecycle-hardening-pr2"
+description: Activate bounded v3 user sessions, complete high-risk revocation, and migrate legacy tokens without cross-replica or Redis safety regressions
+tags: [auth, security, redis, session, migration, observability]
+timestamp: 2026-08-09T21:06:24+08:00
+# --- octospec extension fields ---
+slug: token-lifecycle-hardening-pr2
+upstream: "follow-up to PR #723"
+source: self
+---
+
+# Task: token-lifecycle-hardening-pr2
+
+> 本 brief 是 `token-lifecycle-hardening` 的 PR 2 交付规格，只定义代码能力和受控启用流程，
+> 不代表生产迁移已经执行，也不因 PR 合并就关闭漏洞。
+
+## Goal
+
+在不改变客户端 opaque Token 协议的前提下完成第二阶段修复：
+
+1. 新签发或复用的用户 HTTP Token 使用 v3 payload，具有不可续期的绝对到期时间，并受
+   per-UID session generation 约束。
+2. 当前退出、设备退出、全部退出、密码变更/重置、账号禁用/注销等安全事件能够撤销对应
+   HTTP 会话，而不再把 WuKongIM 下线等同于 bearer 撤销。
+3. 历史 v1/v2 永久或超长 Token 通过单执行者、限速、可暂停续跑且只缩短寿命的迁移收敛，
+   最终进入拒绝全部 v1/v2 的 enforce 模式。
+4. 所有安全结论跨 API 副本成立；不依赖进程锁、本地缓存、单副本启动任务或 Redis 多 key
+   原子性假设。
+5. 认证热路径不做 Redis 写入；明确、压测并监控 v3 generation 校验带来的第二次 Redis 读取，
+   不以牺牲撤销正确性为代价使用副本本地 generation 缓存。
+
+漏洞关闭条件不是“PR 2 已合并”，而是生产完成 v3 writer 激活、历史迁移、`v1/v2=0`
+验证、enforce 灰度和报告历史 Token 场景复测。
+
+## Background
+
+### PR 1 基线（已验证）
+
+- 基线为 `origin/main@b46de7b9`，即 [#723](https://github.com/Mininglamp-OSS/octo-server/pull/723)
+  squash merge 后的 main。
+- PR 1 已收口生产 Token writer，阻止新 Token 或被资料更新/重复登录触达的 Token 变为永久，
+  并保持 Web/PC 复用 Token 的剩余 TTL，不再续满。
+- `pkg/auth` 已具备 v3 编解码和严格校验骨架；但 `auth.Encode` 仍写 v2，运行时没有接入真实
+  `SessionGenerationResolver`。当前若读到 v3 会因 generation validator 不可用而 fail closed。
+- 当前认证读取是单 Token key Lua，原子返回 payload 与 PTTL，稳态一次 Redis 往返且不写 Redis。
+  PR 2 为 v3 读取 UID 后还要查询 generation，通常增加第二次串行 Redis 往返。
+- 当前每个 `config.Context` 只有一个共享的有界 `session` Redis pool；PR 2 必须复用该 pool，
+  不能为 generation、索引或各业务模块再建连接池。
+- PR 1 的 `_octo_issue_owner` 与 compare-delete 补偿解决了多副本下“旧签发请求误删已被另一请求
+  接管的同一 Token”问题；PR 2 的 v3 writer 必须保留这一所有权语义。
+- `tools/token-session-observe` 目前只读并只输出聚合，没有 apply/enforce 能力。
+
+### 尚未闭环的风险
+
+- 历史永久 v1/v2 仍被兼容 validator 接受；v1/v2 payload 没有 `expires_at` 或 generation。
+- `uidtoken:<flag><uid>` 每个设备类型最多保存一个 Token，且历史路径可能没有该索引，不能作为
+  UID 全部会话的权威清单。
+- `/v1/user/quit`、`/v1/user/pc/quit`、设备删除、密码变更/重置、禁用和注销等路径仍存在只处理
+  IM/设备记录或只删除一个兼容索引 Token 的情况。
+- generation 是安全权威后，Redis generation 缺失、读取错误或 revocation 处理中都必须 fail
+  closed；否则会重新接受已撤销的 bearer。
+- 生产 Redis 是 standalone、sentinel、兼容单端点 proxy 还是 native Cluster 尚未核实。当前
+  go-redis `*redis.Client + redisAddr` 不提供 native Cluster discovery，因此 PR 2 不得靠跨 key
+  Lua 或 hash slot 假设声明兼容。
+
+## Security invariants
+
+以下不变量优先于可用性优化和兼容捷径：
+
+1. v3 的有效条件同时为：Token key 存在、`PTTL > 0`、`now < expires_at`、generation record
+   存在且为 active、payload generation 与当前值一致。任一读取失败或不匹配都拒绝。
+2. Redis TTL 负责回收，payload `expires_at` 与 generation 负责安全兜底；资料更新、重复登录、
+   补偿、迁移和回滚都不能延长原绝对 deadline。
+3. `RevokeAll` 先改变 generation；会话索引只用于枚举删除和容量治理。索引缺失或损坏不能让
+   全部撤销失效。
+4. 登录在验证密码/账号状态之前取得共享 issuance fence，并在返回 Token 前确认 fence 未变化。
+   安全事件开始前读取的旧凭据不能在事件后提交为有效会话。
+5. 新 credential 只有 Token、generation、会话索引和兼容索引达到可验证状态后才能返回。
+   任一步失败必须按 issue owner 精确补偿；复用既有 credential 失败时不得误删其他副本已接管
+   的会话。
+6. legacy deny marker 只有在所有在线副本都已停止写 v2 后才能启用；否则新 v2 登录会被 marker
+   立即拒绝。marker 在全局 enforce 前不得自动过期。
+7. 多副本一致性只依赖 Redis 单 key 原子操作和共享状态；不得用 Go mutex、本地 generation
+   cache 或“只有一个 pod 会执行”的假设作为安全边界。
+8. Token、完整 Redis key、payload、generation、索引成员和 UID 不得进入日志、指标 label、
+   migration checkpoint 或命令输出。
+
+## Recommended design
+
+### 1. 单调发布状态机
+
+新增一个严格解析、启动时固定、默认 `expand` 的 session rollout mode。建议状态为：
+
+| mode | writer | legacy reader | 安全能力 | 进入条件 |
+| --- | --- | --- | --- | --- |
+| `expand` | v2 | 兼容 v1/v2 | PR 2 代码已在位但不产生 v3 | PR 2 首次部署 |
+| `v3-write` | v3 | 兼容 v1/v2；已有 deny marker 仍拒绝 | generation/index 生效；deny marker 创建与批量迁移禁用 | 所有旧制品已清零 |
+| `revoke` | v3 | 兼容 v1/v2，并检查 per-UID deny marker | 完整撤销矩阵和 durable retry 生效 | 所有副本均为 `v3-write` 或更高 |
+| `bounded` | v3 | 只接受有限且未超过批准上限/截止时间的 v1/v2 | 永久、超上限 legacy fail closed | apply 完成且 `persistent=0, over_max=0` |
+| `enforce` | v3 | 拒绝全部 v1/v2 | 最终状态 | 完整扫描确认 `v1/v2=0` |
+
+- mode 使用一个枚举配置，避免 `writer_v3=false + enforce=true` 等非法布尔组合；显式空值、未知值
+  或低于持久 rollout floor 的配置必须启动失败。具体配置名在实现前定稿，并纳入启动日志和
+  低基数 gauge。
+- 滚动升级允许 `expand` 与 `v3-write` 短暂混跑，因为所有 reader 已能安全识别 v3；此时不得
+  进入 `revoke`、运行 apply 或创建 legacy deny marker。
+- 使用一个无 TTL、单 key 的 rollout control record 保存最小 writer version 和最小安全 mode；
+  只能由显式运维命令 CAS 向前推进，不能由公开 HTTP API 修改。所有副本进入 `v3-write` 后才把
+  writer floor 设为 3；所有副本进入 `revoke` 后才允许创建 deny marker/运行 apply；apply 完成
+  后才把安全 floor 推进到 `bounded`。运行时配置低于 floor 必须启动失败，迁移工具在前置 floor
+  缺失时拒绝执行。`v3-write` reader 即使尚未获准创建 marker，也必须尊重已存在的 marker，作为
+  混版/误配置的防御。writer floor 激活后，control record 缺失或不可读必须 fail closed，不能
+  被解释为尚未激活并恢复 v2 writer；部署配置仍须保持 v3 floor，control record 不能成为唯一
+  回滚防线。
+- 每个副本暴露 build SHA 与 rollout mode；进入下一阶段前必须同时核对 Deployment
+  `desired/current/ready`、旧 ReplicaSet 为 0 和应用 mode 指标，不能只看一次健康检查。
+
+### 2. 在首次激活前定稿 v3 payload
+
+PR 1 从未启用 v3 writer，PR 2 是调整 v3 schema 的最后安全窗口。新 payload 至少包含：
+
+- `uid`, `name`, `role`, `lang`
+- UTC Unix seconds 的 `issued_at`, `expires_at`
+- `device_flag` 与可获得时的稳定 `device_id`
+- 不可预测的 `session_generation`
+- issuance/revocation fence revision，用于阻止安全事件期间开始的登录在事件后提交
+
+要求：
+
+- `expires_at = issued_at + effective TokenExpire`，Redis TTL 以该绝对 deadline 计算并向下取整，
+  不能分别用两个 `now` 形成 Redis TTL 晚于 payload deadline。
+- 新 Token 使用可注入 clock 测试秒边界；generation 使用密码学安全随机值，不用可预测计数值
+  充当 credential fence。
+- v3 `UpdatePayloadKeepDeadline` 必须从当前 payload 复制 `issued_at/expires_at/device/generation/
+  revision`，只允许更新显示快照；不得继续调用 `auth.Encode` 生成 v2。当前昵称更新丢弃 `ok`
+  的路径也必须处理 missing/version-conflict，避免 DB 已更新却把安全更新错误呈现为成功或失败不明。
+- v3 复用保留原 `issued_at`、`expires_at`、generation 与剩余 TTL。将仍有效的 v1/v2 复用 Token
+  提升为 v3 时，以 `min(当前剩余 TTL, 配置上限)` 建立 deadline，绝不续期；提升失败时不得留下
+  “v3 已写但索引缺失”的 credential。
+- v3 一旦在线，任何 writer/update Lua 都必须拒绝 v3 降级为 v2；仓库级 reader/writer guard
+  继续覆盖全仓。
+
+### 3. Generation store 与登录 fence
+
+generation store 复用现有 session Redis client。每个 UID 的逻辑记录至少包含 current generation、
+issuance revision、active/revoking 状态和最后应用的撤销事件版本；具体序列化可实现时决定。
+
+- generation 缺失时，新登录通过单 key `SET NX` 初始化；并发初始化只有一个值获胜，其他请求
+  重新读取。已有 v3 的 generation 缺失时 validator 只拒绝，不能自动“修复”为 payload 值。
+- generation key 的 TTL 必须覆盖该 UID 最晚到期 v3 Token。每次成功签发延长到至少本次
+  `expires_at`，并用 generation 单 key 原子比较实现“只延长、不缩短”；较短会话的并发签发不能
+  把仍有长会话依赖的 generation 提前过期。延长失败则 credential 不得返回。若选择永久
+  generation key，必须说明删除/注销清理和容量预算，不能无评估地永久增长。
+- `BeginIssue` 在读取并验证密码、账号状态或外部身份结果之前取得 `(generation, revision)`；
+  `IssueNew/ReuseExisting` 在 Redis 写入前后确认 fence，变化时精确补偿本次新 credential 并返回
+  可观测失败。事件后开始的新登录取得新 fence，可按产品策略正常登录。
+- `RevokeAll` 原子切换到新的 generation 并推进 revision；即使 index 不存在也立即让全部 v3
+  失效。相同 durable event 的重试必须幂等，不能再次旋转 generation 而误撤用户事件后新建的
+  会话；乱序旧事件也不能覆盖较新的 generation。
+- device-scope 撤销要建立共享 issuance barrier，阻止同 scope 的并发登录穿过索引删除窗口。
+  若不能证明 device index 完整或 device identity 稳定，安全回退是扩大到 `RevokeAll`，不是返回
+  “撤销成功”。
+
+认证 v3 稳态明确允许且预计为两次串行 Redis 读取：一次单 Token key Lua，一次 generation
+record GET/单 key Lua；两次均不写 Redis。不采用跨 Token/generation key Lua，不把 generation
+缓存到副本内，也不为它新建连接池。
+
+### 4. 有界 per-UID 会话索引
+
+新增按 UID 枚举 v3 会话的可过期索引，`UIDToken` 仅在兼容期继续服务旧行为：
+
+- 索引成员至少能定位 Token，并带 device flag/device ID 与绝对到期信息；score 使用
+  `expires_at`，每次读写先清除过期成员，索引 key TTL 对齐当前最晚成员。并发新增只能延长 key
+  deadline；只有在单 key 原子重算仍存成员最大 deadline 后才能缩短，不能由较短会话覆盖。
+- 单用户会话数必须有硬上限。达到上限后的“拒绝新登录”或“原子淘汰最旧会话”由产品/安全
+  签字；不得静默无界增长，也不得随机删除仍在使用的会话。
+- 索引容量预留/清理使用索引自身的单 key Lua。Token key、generation key、索引和 UIDToken
+  分步写，按状态机补偿；不得把多个不同 key 放进 Lua 后假设生产一定不分 slot。
+- 新签发在索引失败时不能返回 credential。既有 Token 的复用/提升需要与新签发不同的补偿
+  语义，故障注入必须覆盖 Token/index/UIDToken/generation 每一步及两个副本交错执行。
+- `RevokeAll` 永远以 generation 为即时安全结果，再 best-effort 清索引。设备级撤销只有在索引
+  完整性可证明时才精确删除；否则扩大撤销并产生低基数告警。
+- Redis 中的索引仍属于 credential 数据，必须使用与 Token cache 相同的 ACL、备份和访问边界；
+  工具、日志、指标和 API 均不得枚举其成员。
+
+### 5. 撤销接口与 durable intent
+
+Session Store 暴露统一的 `RevokeCurrent`、`RevokeByDevice`、`RevokeAll`，业务 handler 不再直接
+拼接 Token/UIDToken key。HTTP Token 撤销与 WuKongIM device quit 是两个独立结果，前者成功
+不能由后者替代。
+
+对密码、账号状态、注销等 DB-backed 高风险事件：
+
+- DB 状态变更与 monotonic revocation intent 在同一事务提交；intent 包含随机 event ID、每 UID
+  单调版本、目标 scope/target generation 和重试状态，不包含 Token 或明文密码。
+- handler 在返回成功前同步应用 intent；应用失败不得伪装成功，pending intent 由有界退避、
+  可观测且支持多 worker 竞争的 worker 幂等重试。不能只记日志后丢失。
+- 相同 intent 重试不再次撤销事件完成后新建的会话；旧版本 intent 不能覆盖新版本。worker
+  claim/lease 和 release 必须比较 owner，进程崩溃后可接管。
+- 需要跨 DB/Redis 的精确状态机与故障注入，至少证明：事件成功响应后旧 bearer 已失效；DB
+  提交后 Redis 暂时失败时 intent 不丢；Redis 已推进而 DB 失败最多造成额外登出，不会恢复旧
+  bearer；并发旧凭据登录不能穿过 issuance fence。
+- APP/Web/PC 登录中的同密码 hash 算法升级不属于“用户改变凭据”，不得因 opportunistic rehash
+  撤销全部会话；主动改密、忘记密码和管理员重置才进入撤销矩阵。
+
+### 6. 撤销矩阵
+
+| 事件 | HTTP Token 目标 | WuKongIM | 必要约束 |
+| --- | --- | --- | --- |
+| 当前退出 | 当前请求 Token | 当前设备或保持接口既有范围 | 先使 bearer 无效并 compare-delete 兼容索引 |
+| `/v1/user/quit` | 待产品确认：当前 Token、Web/PC 还是全部 | 当前实现退出 Web+PC | 未确认前不得宣称“当前设备退出”已精确实现 |
+| `/v1/user/pc/quit` | 对应 device flag 的全部 v3 会话 | 对应设备 | 并发登录受 device issuance barrier 约束 |
+| 删除设备 | 相同稳定 `device_id` 的会话；无法证明时扩大到 flag/全部 | 对应设备 | 先撤 HTTP 会话，再删设备记录 |
+| 全部退出 | UID 全部 v3 + legacy deny marker | 全部设备 | generation 是即时权威，索引仅回收 |
+| 主动修改密码 | 建议撤销包含当前设备在内的全部会话 | 全部设备 | 产品签字；成功响应前完成同步撤销 |
+| 忘记密码/管理员重置 | 全部会话 | 全部设备 | 无条件 generation rotate + legacy deny |
+| 禁用/最终注销 | 全部会话 | 全部设备 | DB intent 可重试；解禁不恢复旧会话 |
+| 管理员降权/删除 | 至少全部管理会话；保留实时 RoleResolver 防线 | 按现状 | resolver 故障回退不能重新赋予旧权限 |
+| OIDC logout | 当前 HTTP Token；IdP RT 范围保持现状待签字 | 当前实现踢全部设备 | 保持 RP-Initiated Logout/best-effort wire contract |
+| OIDC sync 确认真实 `invalid_grant` | 建议 UID 全部本地会话 | 全部设备 | 作为 durable event，不只踢 IM |
+| 昵称/语言变化 | 不撤销 | 无 | 版本不降级，deadline 不变 |
+
+所有认证失败继续使用现有通用 i18n/anti-enumeration envelope；具体的 expired、generation
+mismatch、deny marker 或 Redis error 只进入低基数内部指标/日志，不泄露给客户端。
+
+### 7. Legacy deny 与迁移 apply
+
+`revoke` mode 起，对发生 `RevokeAll` 的 UID 写无 TTL legacy deny marker，所有 v1/v2 立即拒绝；
+v3 只看 generation。marker 在 enforce 后可清理，但不得在迁移窗口自动过期。
+
+legacy deny、generation 和 rollout control 都是认证安全状态，不能放在会静默驱逐这些 key 的
+缓存策略下。上线前必须确认相关 Redis DB/namespace 为 non-evicting，或提供等价的 durable ledger
+与 fail-closed 重建；仅依赖“无 TTL”不能防止 maxmemory eviction。deny marker 丢失不能让已撤销
+legacy bearer 重新有效。
+
+新增显式 migration apply 工具/Job，与 API 进程解耦：
+
+- 默认 dry-run；apply 必须显式提供 campaign ID、不可变的绝对 `legacy_cutoff_at`、批准的处理策略、
+  batch size 和 QPS。续跑时 campaign 参数不一致必须拒绝。
+- 使用带 owner token 和 lease 的单执行者锁；续约失败立即停止新批次，release compare-delete。
+  checkpoint 只保存 cursor/campaign/计数，不保存 Token、完整 key、payload 或 UID。
+- SCAN 不是快照。一次读失败、锁丢失、取消或游标未归零都必须输出 `complete=false`；不能把部分
+  扫描的零计数当作迁移完成。key 在 SCAN 后自然过期计入 missing，不应让整次扫描伪装成功或
+  无限失败。
+- 每个 Token 由单 key Lua 重新读取当前 payload/version/PTTL 后决定，保证 TOCTOU 下仍满足：
+  missing 或已变 v3 则 no-op；只缩短、不延长、不创建 key；短于目标的 TTL 保持不变；重复执行
+  不以“本次运行时间 + grace”续期。
+- 永久 v1/v2 使用固定 `legacy_cutoff_at`；有限 v1/v2 按批准策略选择自然等待，或统一收敛到
+  `min(当前 deadline, legacy_cutoff_at)`。超过 `TokenExpire` 的有限值至少压到上限。
+- v3 permanent/过期/generation 缺失本来就被 validator 拒绝；apply 不得把异常 v3“修复”为
+  再次有效，只聚合告警并由单独清理动作删除。
+- 迁移使用独立小连接池和独立 latency/error 指标，不与在线 session pool 争抢连接；限速在
+  production 同拓扑压测后确定。
+
+进入 enforce 前至少完成两次 `complete=true` 的全前缀扫描，并同时满足
+`persistent=0, over_max=0, v1/v2=0`；两次扫描间隔和 campaign 证据写入 runbook。不能仅按
+grace 已经过期推断 v1/v2 已清零。
+
+### 8. 多副本、Redis 拓扑与性能
+
+- 所有新脚本默认单 key。生产若是 native Redis Cluster，先解决当前 `*redis.Client` 的拓扑
+  不匹配；若是 proxy，则在同型号/版本/故障切换路径验证 `SCAN`、`EVALSHA`、`EVAL`、脚本缓存
+  与 lease 语义。不能用本地 standalone Redis 结果替代。
+- v3 每个认证请求预期两次串行 Redis 读取、零写入。基准测试必须断言命令数，生产容量评估按
+  峰值认证 QPS 至少翻倍估算 Redis command rate，并纳入 p95/p99 latency、pool wait/timeout、
+  Redis CPU/network 和 fail-closed 401 风险。
+- 迁移窗口内 v1/v2 在解码 UID 后还要检查 legacy deny marker；该额外读取同样复用 session
+  pool，并单独统计命令数/时延。进入 enforce 后直接拒绝 legacy，不再为其查询 marker。
+- 继续使用 `OCTO_AUTH_SESSION_REDIS_POOL_SIZE` / `...POOL_TIMEOUT` 控制唯一 session pool。
+  上线前按 `PoolSize ×（稳定副本数 + maxSurge）` 核算 `maxclients`；不得通过为 generation
+  新建 pool 绕过预算。
+- generation Redis 故障必须 fail closed，且触发独立告警；不得回退到“只检查 Token TTL”，
+  不得在本地缓存 generation 延迟撤销。为避免故障被误判成用户 Token 失效，客户端 wire
+  contract 是否仍固定 401 需沿用现状并在灰度中监控重新登录风暴。
+- session cap、索引 key 数、generation key 数和 outbox backlog 都必须有容量模型与告警；指标
+  只用 operation/outcome/reason/mode 等低基数 label。
+
+## Load-bearing list
+
+- `pkg/auth`：v3 schema、Session Store、TokenValidator、generation resolver、issue owner 补偿和
+  仓库级 reader/writer guard。
+- 所有签发/复用入口：普通/username/email、GitHub/Gitee/OIDC、扫码、设备验证、注册和 manager。
+- 所有显式 Token reader：AuthMiddleware、group 可选认证、message body Token、`/auth/verify`、
+  qrcode 二次读取等，必须继续走同一 validator。
+- Redis：Token/UIDToken 兼容 key、generation、会话索引、legacy deny、rollout floor、migration
+  lock/checkpoint 和脚本单 key 原子性。
+- MySQL：高风险状态变更与 durable revocation intent/outbox 的同事务语义、worker claim/retry。
+- 多设备/多副本：Web/PC 复用、APP 替换、并发登录/退出/改密、索引补偿和旧事件重试。
+- WuKongIM：HTTP bearer revoke 与 IM device quit 的顺序、独立结果和重试。
+- `wire-contract` / i18n：Token header、登录响应和通用未认证错误 envelope 不变。
+- 性能与容量：认证 Redis command rate、唯一 session pool、migration 独立 pool、Redis
+  `maxclients` 和 rollout `maxSurge`。
+- 运维：mode 单调推进、旧副本清零、migration campaign、enforce 与安全复测。
+
+## Out of scope
+
+- 不设计短 Access Token + 旋转 Refresh Token、静默续期或 refresh replay family；这是 Web/
+  iOS/Android 联合任务。
+- 不实现每次 API 活动都写 Redis 的滑动空闲超时。
+- 不改变客户端 Token header、登录响应字段、opaque Token 使用方式或现有错误 envelope。
+- 不处理 OIDC Provider 自己的 access/refresh/id_token 生命周期，也不处理 Bot token、App Bot
+  token、User API Key、Webhook secret、短信/扫码一次性凭据。
+- 不以 PR 2 自动启动生产 SCAN/apply/enforce，不在未核实前宣称生产 Token 数量、Redis 拓扑、
+  可接受 QPS 或影响用户数。
+- 不顺手重构无关登录/设备代码；只改为满足会话签发、验证、撤销和迁移不变量所必需的路径。
+
+## Observability and operations
+
+- Counter：issue/reuse/update/revoke/migrate 按 `operation,outcome`；validation reject 按
+  `reason`；outbox retry/dead-letter；device revoke fallback-to-all。
+- Gauge：当前 rollout mode、v2/v3 writer 副本数、session index/member 数量级、outbox backlog、
+  最近完整 observe 的 `persistent/over_max/v1/v2/v3` 和 `complete`。
+- Histogram：Token read、generation read、index operation、整体 validation、outbox apply、迁移
+  batch 时延；在线与 migration pool 分开。
+- 启动日志只记录生效 mode、TokenExpire、pool size/timeout、build SHA 和 rollout floor，禁止
+  credential/UID。审计日志只记录 event type、哈希化主体、scope、event version、结果和 trace ID。
+- 告警至少覆盖 generation 读取错误/缺失、session pool timeout、认证拒绝率突增、v3 persistent、
+  新增 v1/v2 writer、outbox 超龄、撤销失败、迁移 incomplete 和 enforce 后出现 legacy。
+
+## Rollout
+
+1. 在生产同拓扑预检配置、Redis Lua/SCAN/lease 兼容、non-evicting 安全状态、连接数和 v3/
+   legacy 额外读取性能预算。
+2. 以 `expand` 部署 PR 2，清零所有 PR 2 之前副本；确认 v3 仍未签发。
+3. 滚动到 `v3-write`，确认全部副本 mode/build 一致；设置单调 v3 writer floor。此阶段不得 apply。
+4. 滚动到 `revoke`；全部副本就绪后推进 revoke floor，再验证高风险事件、generation、legacy
+   deny 和 outbox 指标，随后启动限速 apply。
+5. apply 完成并两次完整 observe 证明 `persistent=0, over_max=0` 后进入 `bounded`；全部副本
+   就绪后再推进 bounded floor。
+6. 按批准策略等待/迁移到两次完整 observe 均为 `v1/v2=0`，再灰度 `enforce`。
+7. 使用报告历史 Token、退出、改密/重置、禁用/注销、多设备、多副本竞态和 Redis 故障场景复测。
+
+每一步有独立 go/no-go；自动化工具必须检查可验证前置条件，但不能伪造 Kubernetes 旧副本已
+清零或生产安全审批已经完成。
+
+## Rollback
+
+- `expand` 尚未产生 v3 前可回滚到 PR 1 制品。
+- 任一 v3 已签发或 writer floor 已设置后，只能回滚到能解析、校验 generation 且继续写 v3 的
+  PR 2 兼容制品；PR 1 没有运行时 generation resolver，不能作为可用回滚版本。
+- apply 可暂停/续跑，回滚不延长已经缩短的 TTL，不删除 legacy deny marker，也不清除 writer
+  floor。已过期 Token 通过重新登录恢复，不能复活。
+- enforce 异常时最多退到 `bounded`，仍拒绝 permanent/over-max legacy、继续写 v3 并遵守 deny
+  marker；退回即意味着漏洞关闭条件暂时不成立，必须记录安全例外。禁止退到 `expand`。
+- generation/outbox 故障不得通过关闭 generation 校验或恢复 v2 writer 缓解；可暂停新登录/迁移、
+  扩容 Redis、回滚到兼容 v3 制品并处理 backlog。
+
+## Acceptance
+
+- rollout mode 配置缺省为 `expand`；显式空/非法值启动失败。混版测试证明所有 PR 2 reader 可读
+  v2/v3，writer floor 设置后任何 v2 mode 实例拒绝启动，apply 在 floor 缺失时拒绝运行。
+- v3 新签发 Redis TTL `>0` 且不晚于 payload `expires_at`/配置上限；资料更新和 Web/PC/扫码复用
+  前后 `issued_at/expires_at/generation/revision` 不变，TTL 不增加，v3→v2 被原子拒绝。
+- 所有生产签发入口在 `v3-write` 后只产生 v3 并进入有界索引；源码守卫证明业务模块不能直接写
+  Token/UIDToken/generation/索引 key。
+- validator 对 v3 permanent、过期、generation missing/error/mismatch、revoking state 一律 fail
+  closed；AuthMiddleware 和所有显式 Token 入口结果一致，保持现有 i18n/anti-enumeration 响应。
+- 命令计数测试证明 v3 稳态认证为 Token 单 key Lua + generation 单 key read、零写入；每个
+  `config.Context` 仍只有一个 session pool。代表生产峰值及 `maxSurge` 的同拓扑负载验证满足
+  发布前签字的 p95/p99、pool timeout 和 Redis 余量 SLO。
+- 两个独立 Redis client/Session Store 模拟两个副本，覆盖 issue/reuse/logout/password reset
+  交错；安全事件前开始的登录不能在事件后产生有效 bearer，旧 durable event 重试不能撤销事件
+  后的新会话。
+- 故障注入逐步覆盖 generation/Token/index/UIDToken/DB commit/outbox/IM：新 credential 失败不
+  留可用孤儿；复用失败不误删已接管会话；DB 事件不丢；重复 worker 幂等。
+- session cap 在并发新签发下仍不超限；索引缺失时 `RevokeAll` 仍即时有效，设备撤销不能证明完整
+  时自动扩大范围并告警。
+- 多副本并发签发测试证明较短会话不能缩短 generation/index key 的 deadline；安全状态所在
+  Redis 发生 eviction、control/deny key 缺失或读取错误时不会恢复 v2 writer 或重新接受已撤销
+  legacy Token。
+- 撤销矩阵中每个已签字事件都有 HTTP 集成测试；成功响应后旧 Token 返回统一未认证，IM 失败不
+  恢复 bearer。密码 hash opportunistic rehash 不触发全量撤销。
+- migration dry-run 零写入且无秘密输出；apply 单执行者、可取消续跑、固定 cutoff、重复执行不
+  延期，覆盖 missing/persistent/finite-short/over-max/v1/v2/v3/concurrent-change/lock-loss。
+- observe/apply 遇到读取错误、取消或未完成游标会输出 `complete=false`；只有两次完整扫描的
+  `persistent=0, over_max=0, v1/v2=0` 才允许 enforce。
+- enforce 后 v1/v2、历史报告 Token、deny marker 命中的 legacy Token 全部失败；新 v1/v2 或
+  permanent 异常触发告警。
+- 运行 focused `pkg/auth`、`modules/user`、`modules/oidc`、migration tests，`go test -race
+  ./pkg/auth/...`、`go build ./...`、`go vet ./...`、`go test ./...`、`golangci-lint run ./...`、
+  `make i18n-extract-check` 和 `make i18n-lint`；若环境导致未完成，PR 必须明确列出未验证项，
+  不得宣称全绿。
+
+## Decisions required before implementation/activation
+
+- legacy grace 与绝对 `legacy_cutoff_at`：原建议 7 天，需生产 observe 后签字。
+- finite v1/v2：自然等待最长 TTL，还是全部压到 cutoff；后者重新登录影响更大。
+- 单 UID 会话硬上限及超限策略；Web/PC 显式重登录继续复用剩余寿命，还是签发新 Token。
+- `/v1/user/quit`、`/v1/user/pc/quit`、设备删除的精确产品 scope；缺少稳定 device ID 时允许扩大
+  到 device flag 还是全部会话。
+- 主动改密是否保留当前设备；本 brief 建议包含当前设备在内全部撤销。
+- 管理员降权/删除仅撤管理会话还是全部会话。
+- OIDC logout 是否继续“当前 HTTP Token + 全部 IdP RT + 全部 IM 设备”，以及 sync worker 的真实
+  `invalid_grant` 是否撤销 UID 全部本地会话；本 brief 默认保持/扩大安全语义，不擅自收窄。
+- 生产 Redis 拓扑、proxy/Cluster 命令兼容、迁移 QPS、session pool/`maxclients` 预算，以及 v3
+  两次读取可接受的 auth p95/p99 SLO。
+- durable intent 的表归属、重试期限/dead-letter/值班告警和数据保留；未确认前不能以日志代替。

--- a/.octospec/tasks/token-lifecycle-hardening-pr2/brief.md
+++ b/.octospec/tasks/token-lifecycle-hardening-pr2/brief.md
@@ -445,8 +445,10 @@ grace 已经过期推断 v1/v2 已清零。
 
 代码使用两个安全默认但仍需上线签字：单 UID cap 必须显式配置且超限时拒绝新登录；主动改密撤销
 包含当前设备在内的全部会话。主动改密/重置与禁用的兼容撤销和 WuKongIM 全设备退出在默认
-`expand` 部署即生效，不等待 floor 推进，因此相应产品签字是合并/部署门禁，不是后续 activation
-门禁。以下环境参数和未接线路径不能由代码自行猜测：
+`expand` 部署即生效，不等待 floor 推进；定时到期注销（`finalizeDestroy`）同样在默认 `expand`
+下撤销残留 bearer 并退出全部 IM 设备——该账号此刻已 `is_destroy=2` 且手机号已匿名化，bearer
+本就不应继续可用。因此相应产品签字是合并/部署门禁，不是后续 activation 门禁。以下环境参数和
+未接线路径不能由代码自行猜测：
 
 - legacy grace 与绝对 `legacy_cutoff_at`：原建议 7 天，需生产 observe 后签字。
 - 两次完整 observe 的最小间隔；工具要求每次 floor 推进时显式给出，硬下界为 `1h`，后续只可
@@ -457,6 +459,12 @@ grace 已经过期推断 v1/v2 已清零。
   到 device flag 还是全部会话。
 - 主动改密是否保留当前设备；本 brief 建议包含当前设备在内全部撤销。
 - 管理员降权/删除仅撤管理会话还是全部会话。
+- 用户主动即时注销（`destroyAccount`）在兼容模式下仍只做 WuKongIM 全设备退出，不撤 HTTP
+  bearer——与定时到期注销（已接入 `finishCommittedUserSecurityMutation`）不对称。该 gap 在
+  merge-base 即存在、非本 PR 引入，且合并当前错误码分流（`ErrUserDestroyFailed` /
+  `ErrUserStoreFailed`）会改变既有客户端可见语义，因此有意留待单独决策：要么接线该 helper 并
+  确认错误码收敛，要么在 `revoke` floor 推进时由 durable intent 覆盖。`Validate` 也始终不查
+  `is_destroy`。
 - OIDC logout 是否继续“当前 HTTP Token + 全部 IdP RT + 全部 IM 设备”，以及 sync worker 的真实
   `invalid_grant` 是否撤销 UID 全部本地会话；本 brief 默认保持/扩大安全语义，不擅自收窄。
 - 生产 Redis 拓扑、proxy/Cluster 命令兼容、迁移 QPS、session pool/`maxclients` 预算，以及 v3

--- a/.octospec/tasks/token-lifecycle-hardening-pr2/brief.md
+++ b/.octospec/tasks/token-lifecycle-hardening-pr2/brief.md
@@ -37,8 +37,9 @@ source: self
 
 ### PR 1 基线（已验证）
 
-- 基线为 `origin/main@b46de7b9`，即 [#723](https://github.com/Mininglamp-OSS/octo-server/pull/723)
-  squash merge 后的 main。
+- 实现基线为 `origin/main@d3daa912`；其中 PR 1 已由
+  [#723](https://github.com/Mininglamp-OSS/octo-server/pull/723) squash merge 为 `b46de7b9`，
+  后续主干提交也已纳入本分支。
 - PR 1 已收口生产 Token writer，阻止新 Token 或被资料更新/重复登录触达的 Token 变为永久，
   并保持 Web/PC 复用 Token 的剩余 TTL，不再续满。
 - `pkg/auth` 已具备 v3 编解码和严格校验骨架；但 `auth.Encode` 仍写 v2，运行时没有接入真实
@@ -63,6 +64,27 @@ source: self
 - 生产 Redis 是 standalone、sentinel、兼容单端点 proxy 还是 native Cluster 尚未核实。当前
   go-redis `*redis.Client + redisAddr` 不提供 native Cluster discovery，因此 PR 2 不得靠跨 key
   Lua 或 hash slot 假设声明兼容。
+
+### 当前实现状态（2026-08-10，仅代码分支）
+
+- 已实现默认 `expand` 的单调 rollout mode、持久 floor、v3 绝对到期、generation/issuance
+  fence、按 UID + generation 隔离的有界会话索引、legacy deny、默认 dry-run 的可续跑 migration
+  apply，以及独立小连接池的 `token-session-admin`。合并或部署不会自动切到 v3、apply 或 enforce。
+- 已把主动改密/重置、账号禁用/最终注销、管理员删除与 monotonic revocation intent 放入同一
+  MySQL 事务；同步 Redis 应用失败后由带 owner lease 的多副本 worker 幂等重试。当前退出先撤
+  HTTP bearer，再执行既有 IM 退出。
+- 登录 writer 已覆盖普通、username、email、manager、微信、GitHub、Gitee、OIDC/external、扫码、
+  设备验证和注册；密码或账号状态在 issuance fence 后重新读取。管理端同时重查 `status` 与
+  `is_destroy`，禁用/注销账号不能在撤销后重新登录。
+- 复核额外发现并修复了旧 revocation event 重放清空新会话索引的问题：索引按 generation 隔离，
+  Lua 返回本事件实际撤销的上一 generation，重试只清理该旧索引，不影响事件后新登录的 cap。
+- 本地 MySQL/Redis/WuKongIM 环境中，`pkg/auth`、`modules/user`、`modules/oidc` focused/integration、
+  auth race、build、vet、golangci-lint 和 i18n 均通过。`go test ./...` 未全绿：未改动的
+  `internal/msgextraseq` 持有共享 `test` 库直到 10 分钟超时，其他并发 package 随后报 MySQL 1205
+  lock wait；PR 不得把该次全仓运行写成通过。
+- `/v1/user/pc/quit`、设备删除和 OIDC sync `invalid_grant` 的精确撤销 scope 尚未获产品签字，当前
+  实现没有擅自扩大。它们与生产 Redis 拓扑/QPS/连接预算、session cap 值、cutoff 和迁移策略同为
+  激活前门禁；因此当前状态不是漏洞关闭。
 
 ## Security invariants
 
@@ -168,7 +190,9 @@ record GET/单 key Lua；两次均不写 Redis。不采用跨 Token/generation k
 
 ### 4. 有界 per-UID 会话索引
 
-新增按 UID 枚举 v3 会话的可过期索引，`UIDToken` 仅在兼容期继续服务旧行为：
+新增按 UID + generation 枚举 v3 会话的可过期索引，`UIDToken` 仅在兼容期继续服务旧行为。
+generation 隔离使撤销事件只清理自己淘汰的旧索引；事件后新登录写入新索引，不会被旧事件重放
+或首次撤销的并发尾部误删：
 
 - 索引成员至少能定位 Token，并带 device flag/device ID 与绝对到期信息；score 使用
   `expires_at`，每次读写先清除过期成员，索引 key TTL 对齐当前最晚成员。并发新增只能延长 key
@@ -179,8 +203,9 @@ record GET/单 key Lua；两次均不写 Redis。不采用跨 Token/generation k
   分步写，按状态机补偿；不得把多个不同 key 放进 Lua 后假设生产一定不分 slot。
 - 新签发在索引失败时不能返回 credential。既有 Token 的复用/提升需要与新签发不同的补偿
   语义，故障注入必须覆盖 Token/index/UIDToken/generation 每一步及两个副本交错执行。
-- `RevokeAll` 永远以 generation 为即时安全结果，再 best-effort 清索引。设备级撤销只有在索引
-  完整性可证明时才精确删除；否则扩大撤销并产生低基数告警。
+- `RevokeAll` 永远以 generation 为即时安全结果，再按 Lua 返回的上一 generation 精确清理旧索引；
+  重放相同事件不得删除当前 generation 的索引。设备级撤销只有在索引完整性可证明时才精确删除；
+  否则扩大撤销并产生低基数告警。
 - Redis 中的索引仍属于 credential 数据，必须使用与 Token cache 相同的 ACL、备份和访问边界；
   工具、日志、指标和 API 均不得枚举其成员。
 
@@ -361,7 +386,7 @@ grace 已经过期推断 v1/v2 已清零。
   发布前签字的 p95/p99、pool timeout 和 Redis 余量 SLO。
 - 两个独立 Redis client/Session Store 模拟两个副本，覆盖 issue/reuse/logout/password reset
   交错；安全事件前开始的登录不能在事件后产生有效 bearer，旧 durable event 重试不能撤销事件
-  后的新会话。
+  后的新会话，也不能从有界索引移除事件后会话而绕过 session cap。
 - 故障注入逐步覆盖 generation/Token/index/UIDToken/DB commit/outbox/IM：新 credential 失败不
   留可用孤儿；复用失败不误删已接管会话；DB 事件不丢；重复 worker 幂等。
 - session cap 在并发新签发下仍不超限；索引缺失时 `RevokeAll` 仍即时有效，设备撤销不能证明完整
@@ -382,7 +407,10 @@ grace 已经过期推断 v1/v2 已清零。
   `make i18n-extract-check` 和 `make i18n-lint`；若环境导致未完成，PR 必须明确列出未验证项，
   不得宣称全绿。
 
-## Decisions required before implementation/activation
+## Decisions required before activation / remaining scope
+
+代码使用两个安全默认但仍需上线签字：单 UID cap 必须显式配置且超限时拒绝新登录；主动改密撤销
+包含当前设备在内的全部会话。以下环境参数和未接线路径不能由代码自行猜测：
 
 - legacy grace 与绝对 `legacy_cutoff_at`：原建议 7 天，需生产 observe 后签字。
 - finite v1/v2：自然等待最长 TTL，还是全部压到 cutoff；后者重新登录影响更大。

--- a/.octospec/tasks/token-lifecycle-hardening-pr2/brief.md
+++ b/.octospec/tasks/token-lifecycle-hardening-pr2/brief.md
@@ -226,9 +226,9 @@ generation 隔离使撤销事件只清理自己淘汰的旧索引；事件后新
 
 ### 5. 撤销接口与 durable intent
 
-Session Store 暴露统一的 `RevokeCurrent`、`RevokeByDevice`、`RevokeAll`，业务 handler 不再直接
-拼接 Token/UIDToken key。HTTP Token 撤销与 WuKongIM device quit 是两个独立结果，前者成功
-不能由后者替代。
+Session Store 当前暴露统一的 `RevokeCurrent`、`RevokeAll`，业务 handler 不再直接拼接
+Token/UIDToken key。`RevokeByDevice` 仍属设备精确 scope 的待签字能力，本 PR 不宣称已交付。
+HTTP Token 撤销与 WuKongIM device quit 是两个独立结果，前者成功不能由后者替代。
 
 对密码、账号状态、注销等 DB-backed 高风险事件：
 
@@ -260,6 +260,10 @@ Session Store 暴露统一的 `RevokeCurrent`、`RevokeByDevice`、`RevokeAll`�
 | OIDC logout | 当前 HTTP Token；IdP RT 范围保持现状待签字 | 当前实现踢全部设备 | 保持 RP-Initiated Logout/best-effort wire contract |
 | OIDC sync 确认真实 `invalid_grant` | 建议 UID 全部本地会话 | 全部设备 | 作为 durable event，不只踢 IM |
 | 昵称/语言变化 | 不撤销 | 无 | 版本不降级，deadline 不变 |
+
+`expand`/`v3-write` 的兼容撤销只能通过 APP/Web/PC 的 UIDToken 反查各处理最新一条已知会话；
+只有进入 `revoke` floor 后，generation rotate 才保证“UID 全部会话”即时失效。因此生产不得把
+`v3-write` 阶段的兼容撤销描述为全部会话，也应尽量缩短该过渡窗口。
 
 所有认证失败继续使用现有通用 i18n/anti-enumeration envelope；具体的 expired、generation
 mismatch、deny marker 或 Redis error 只进入低基数内部指标/日志，不泄露给客户端。
@@ -440,7 +444,9 @@ grace 已经过期推断 v1/v2 已清零。
 ## Decisions required before activation / remaining scope
 
 代码使用两个安全默认但仍需上线签字：单 UID cap 必须显式配置且超限时拒绝新登录；主动改密撤销
-包含当前设备在内的全部会话。以下环境参数和未接线路径不能由代码自行猜测：
+包含当前设备在内的全部会话。主动改密/重置与禁用的兼容撤销和 WuKongIM 全设备退出在默认
+`expand` 部署即生效，不等待 floor 推进，因此相应产品签字是合并/部署门禁，不是后续 activation
+门禁。以下环境参数和未接线路径不能由代码自行猜测：
 
 - legacy grace 与绝对 `legacy_cutoff_at`：原建议 7 天，需生产 observe 后签字。
 - 两次完整 observe 的最小间隔；工具要求每次 floor 推进时显式给出，硬下界为 `1h`，后续只可

--- a/.octospec/tasks/token-lifecycle-hardening-pr2/context.yaml
+++ b/.octospec/tasks/token-lifecycle-hardening-pr2/context.yaml
@@ -1,0 +1,12 @@
+injected:
+  - id: space-isolation
+    source: repo
+  - id: error-handling
+    source: repo
+  - id: rate-limit
+    source: repo
+  - id: testing
+    source: repo
+  - id: commit-style
+    source: repo
+brief: .octospec/tasks/token-lifecycle-hardening-pr2/brief.md

--- a/docs/token-session-rollout-runbook.md
+++ b/docs/token-session-rollout-runbook.md
@@ -50,9 +50,12 @@ control key，也不能仅靠环境变量声明 floor。
    compare-delete。临时 key 必须有短 TTL，禁止对共享实例执行 `SCRIPT FLUSH`。
 3. 先在隔离前缀验证 `SCAN` cursor，再以获批的低 QPS 运行生产 observe。proxy 若不支持完整
    cursor 语义，不得开始 migration。
-4. 通过 `CONFIG GET maxmemory-policy` 或云厂商控制面确认 `noeviction`。若 proxy 禁止 `CONFIG`，
+4. 验证 migration 使用的账号可执行 `INFO server` 并返回稳定的 `run_id`；在受控主从切换中
+   `run_id` 必须变化。工具只保存其 SHA-256 指纹。若 proxy 禁止、伪造固定值或无法把命令路由到
+   实际执行 SCAN 的 Redis 实例，不得执行 apply，也不得推进 `bounded`。
+5. 通过 `CONFIG GET maxmemory-policy` 或云厂商控制面确认 `noeviction`。若 proxy 禁止 `CONFIG`，
    由 Redis 平台负责人提供可审计配置证据，不能把“命令被拒绝”当作通过。
-5. 验证主从切换后脚本缓存、lease owner 比较和无 TTL key 均保持预期；startup probe 只证明
+6. 验证主从切换后脚本缓存、lease owner 比较和无 TTL key 均保持预期；startup probe 只证明
    启动时刻，不证明 failover 路径。
 
 ### 3.2 连接数与性能
@@ -205,7 +208,11 @@ cleanup，后续清理必须走单独审核的聚合盘点和受控工具。
 ```
 
 若取消、锁丢失或失败，保留原 campaign/cutoff/policy，按 checkpoint 续跑；可降低 batch/QPS。
-只有输出 `complete=true` 才会生成 migration completion evidence。
+checkpoint 绑定 Redis `run_id` 的 SHA-256 指纹；恢复时或运行中检测到实例变化会重新确认 lease、
+把 cursor 归零并幂等重扫，累计统计可能包含重扫记录。只有稳定扫描到 cursor 0 且输出
+`complete=true` 才会生成同实例的 migration completion evidence；Redis 随后再次重启/failover，
+在推进 `bounded` 前必须用同一 campaign/cutoff/policy 重新完成 apply。旧 checkpoint/evidence
+缺失实例指纹时同样从 0 重扫，不得手工补字段。
 
 如果 apply 启动时 cutoff 尚未过期、但在限速扫描中到期，未带确认的任务会在第一条需要立即删除
 的记录上由 Lua 在 `DEL` 前停止，输出 `complete=false` 和明确错误；此前已经执行的 TTL 缩短不会
@@ -246,8 +253,15 @@ apply 完成后执行两次独立完整 observe。两次应跨过一个经批准
 /tmp/token-session-observe --config "$TOKEN_CONFIG" --batch-size 200 --qps 50 --record-rollout-evidence
 ```
 
-两次均须 `complete=true`、`read_errors=invalid_ttl=decode_invalid=0`、`persistent=0`、
-`over_max=0`。工具会在同一安全 key 中原子保留最近两份聚合证据，不保存 credential/UID。
+两次均须 `complete=true`、`total>0`、`read_errors=invalid_ttl=decode_invalid=0`、`persistent=0`、
+`over_max=0`，并核对每次输出的 `scan_id` 不同、`scope_fingerprint` 相同。指纹由
+Token/UIDToken prefix 与 `TokenExpire` 哈希生成，不泄露明文 prefix；同一次扫描结果重复提交会
+被拒绝。工具会在同一安全 key 中原子保留最近两份聚合证据，不保存 credential/UID。
+
+空 keyspace 不可作为“已迁移”的放行证据。若目标环境确实没有在线 Token，应在当前正常登录链路
+创建一个受控测试账号的 v3 canary，确认其 TTL/generation 正常后再执行两次 observe；禁止直接向
+Redis 伪造 token 或 evidence。升级到包含本门禁的工具后，旧 observation evidence 因缺少 scan ID/
+scope fingerprint 自动失效，必须重新扫描两次。
 
 先部署 `MODE=bounded`、`REQUIRED_FLOOR=revoke` 并灰度确认，再推进：
 
@@ -262,7 +276,7 @@ apply 完成后执行两次独立完整 observe。两次应跨过一个经批准
 ### Phase E：`enforce`
 
 等待或继续获批 campaign，直到在 `bounded` floor 下两次新的完整 observe 均满足 Phase D 条件，
-并额外满足 `v1=0`、`v2=0`。旧的 revoke-floor 证据不能复用。
+并额外满足 `v1=0`、`v2=0`、`v3>0`。旧的 revoke-floor 证据不能复用。
 
 以 `MODE=enforce`、`REQUIRED_FLOOR=bounded` 做小流量灰度，验证历史报告 Token、正常登录、退出、
 高风险撤销和 Redis 故障场景。灰度可回到 `bounded`，因为 enforce floor 尚未建立。

--- a/docs/token-session-rollout-runbook.md
+++ b/docs/token-session-rollout-runbook.md
@@ -125,7 +125,9 @@ OBSERVATION_MIN_GAP=1h
 
 ### Phase A：`expand`
 
-1. 部署 PR 2，显式或默认使用 `OCTO_AUTH_SESSION_MODE=expand`。
+1. 在产品确认改密/重置与账号禁用会触发全 IM 设备退出后，部署 PR 2，显式或默认使用
+   `OCTO_AUTH_SESSION_MODE=expand`。这项客户端可见行为随制品立即生效，不等待 v3 floor；此阶段
+   HTTP bearer 仅按 APP/Web/PC 兼容反查撤销各端最新一条已知会话，不能宣称 UID 全部会话已撤销。
 2. 等待 rollout 完成，确认 `desired=current=ready`，所有 PR 2 之前的 ReplicaSet 副本为 0。
 3. 核对每个 Pod 的 build、mode、floor、TTL 和 pool 日志；此时不得产生 v3、不得 apply。
 4. 运行一次限速 observe 做基线盘点，但不要记录 floor 证据：
@@ -166,6 +168,8 @@ OBSERVATION_MIN_GAP=1h
 ```
 
 部署 `REQUIRED_FLOOR=revoke` 后清零旧配置副本。只有完成这一步才允许 apply 和 rollout evidence。
+从该 floor 起，改密/重置和禁用事件才由 generation rotate 保证 UID 全部 HTTP 会话即时失效；
+`v3-write` 阶段只能保证兼容索引中每个 device flag 的最新会话。
 
 legacy deny marker 从本阶段开始按被全量撤销的 UID 写入且无 TTL。上线前按可能被撤销的唯一 UID
 数做容量预算；在所有 legacy reader 退出并进入最终 enforce 前禁止人工删除。本版本不提供自动

--- a/docs/token-session-rollout-runbook.md
+++ b/docs/token-session-rollout-runbook.md
@@ -1,0 +1,322 @@
+# Token session v3 rollout runbook
+
+本 runbook 只描述 PR 2 的受控启用。合并或以默认 `expand` 部署不会关闭历史 Token 漏洞；
+只有完成 migration、两次完整观察、`enforce` 灰度和安全复测后才能关闭漏洞。
+
+## 1. 安全边界
+
+- 运维工具必须使用与目标 API 制品相同的 commit 构建，并读取同一 Redis endpoint、DB、TLS
+  配置和 `tokenCachePrefix` / `uidTokenCachePrefix`。不要用本地 standalone Redis 结果替代生产
+  proxy/Cluster 结论。
+- 所有阶段按环境独立执行。命令中的配置路径、namespace、Deployment 和 selector 必须替换为
+  该环境的真实值。
+- 不得并行运行 migration apply。observe、apply 也应错峰，避免两个独立的两连接池同时给 Redis
+  增压。
+- 不得输出或采集 Token、完整 Redis key、payload、generation、索引成员或 UID。工具的标准输出
+  只保留聚合 JSON；原始 `SCAN` 结果不得进入工单或日志。
+- rollout floor、migration campaign/checkpoint/evidence 和 legacy deny marker 均为无 TTL 安全状态。
+  它们所在 Redis namespace 必须 `noeviction`；本版本没有可替代的 durable ledger。
+
+## 2. 配置清单
+
+| 配置 | 约束 |
+| --- | --- |
+| `TS_CACHE_TOKENEXPIRE` | 可缺失；显式配置必须是正数 Go duration，最大 `720h`。空值、`30d`、非正数或超过上限会启动失败。 |
+| `OCTO_AUTH_SESSION_MODE` | 缺失时为 `expand`；合法值依次为 `expand`、`v3-write`、`revoke`、`bounded`、`enforce`。显式空值非法。 |
+| `OCTO_AUTH_SESSION_MAX_PER_UID` | `v3-write` 及之后必须显式配置为 `1..10000`。数值和“满额拒绝新登录”行为须经产品/容量签字。 |
+| `OCTO_AUTH_SESSION_REQUIRED_FLOOR` | floor 建立后必须设置为当前已批准 floor。control key 缺失、损坏或低于该值时实例拒绝启动。 |
+| `OCTO_AUTH_SESSION_REDIS_POOL_SIZE` | 可选；默认 `10 * GOMAXPROCS`，最大通常为 4096。必须按副本数和 `maxSurge` 做连接预算。 |
+| `OCTO_AUTH_SESSION_REDIS_POOL_TIMEOUT` | 可选；默认 `3s`，必须为 `(0,30s]`。 |
+
+每次部署先检查最终渲染后的 Pod env，特别是 ConfigMap/Secret 中是否存在空字符串。启动日志必须
+包含且符合预期：
+
+```text
+Authentication session runtime: mode=... rollout_floor=... token_ttl=... redis_pool_size=... redis_pool_timeout=... build=...
+```
+
+从第一个 `v3-write` floor 建立后，Deployment 配置与 Redis control record 是双重防线：不能只保留
+control key，也不能仅靠环境变量声明 floor。
+
+## 3. 发布前预检
+
+### 3.1 Redis 命令与持久性
+
+在生产同型号、同版本、同 TLS/proxy/故障切换路径执行以下检查：
+
+1. 候选 API Pod 以 `expand` 启动并通过真实认证读取脚本的只读 startup probe。它验证
+   `EVALSHA`，脚本未缓存时由客户端回退 `EVAL`；失败会阻止 Pod 服务流量。
+2. 使用受控临时单 key 验证 lease 所需的 `SET NX PX`、`PTTL`、单 key `EVALSHA/EVAL` 续约和
+   compare-delete。临时 key 必须有短 TTL，禁止对共享实例执行 `SCRIPT FLUSH`。
+3. 先在隔离前缀验证 `SCAN` cursor，再以获批的低 QPS 运行生产 observe。proxy 若不支持完整
+   cursor 语义，不得开始 migration。
+4. 通过 `CONFIG GET maxmemory-policy` 或云厂商控制面确认 `noeviction`。若 proxy 禁止 `CONFIG`，
+   由 Redis 平台负责人提供可审计配置证据，不能把“命令被拒绝”当作通过。
+5. 验证主从切换后脚本缓存、lease owner 比较和无 TTL key 均保持预期；startup probe 只证明
+   启动时刻，不证明 failover 路径。
+
+### 3.2 连接数与性能
+
+最坏连接预算至少包含：
+
+```text
+session_pool_size * (stable_replicas + maxSurge)
++ 2 * concurrent_observe_jobs
++ 2 * concurrent_migration_jobs
++ 现有 API/worker/限流/运维客户端峰值
++ Redis 平台要求的保留余量
+```
+
+用 `INFO clients` / 平台监控核对 `connected_clients`、`maxclients` 和历史峰值。实际 Pod 的 pool
+size 以启动日志为准；只有 CPU request、没有 CPU limit 时，也要核实容器内 `GOMAXPROCS`，不能
+按 request 值猜默认池大小。
+
+在同拓扑压测中，v3 稳态认证为串行 `EVALSHA`（Token payload + PTTL）再 `GET` generation，零
+写入；legacy 在迁移窗口还会读取 deny marker。按生产峰值认证 QPS 评估 Redis command rate、
+CPU/network、auth p95/p99、pool wait/timeout 和 401 增幅，确认后再批准 pool 和 migration QPS。
+
+至少监控：
+
+- `dmwork_redis_pool_timeouts_total{client="session"}`、`total_connections`、`idle_connections`；
+- `dmwork_session_validation_rejected_total{reason=...}`；
+- `dmwork_session_operation_duration_seconds` / `operations_total`；
+- `dmwork_session_rollout_mode{mode=...}`；
+- `dmwork_session_revocation_backlog` / `revocation_retries_total`；
+- `dmwork_dependency_duration_seconds{dependency="redis",op=...,status=...}`；
+- HTTP 401、登录 QPS/失败率、Pod restart/readiness 和 Redis CPU/network/latency。
+
+## 4. 工具准备
+
+从已审核 commit 构建，记录二进制 SHA256；不要从开发机未提交工作区直接复制到生产：
+
+```bash
+go build -trimpath -o /tmp/token-session-admin ./tools/token-session-admin
+go build -trimpath -o /tmp/token-session-observe ./tools/token-session-observe
+shasum -a 256 /tmp/token-session-admin /tmp/token-session-observe
+```
+
+下文使用：
+
+```bash
+TOKEN_CONFIG=/etc/octo-server/tsdd.yaml
+MIGRATION_CAMPAIGN=legacy-token-YYYYMMDD
+MIGRATION_CUTOFF=YYYY-MM-DDTHH:MM:SSZ
+OBSERVATION_MIN_GAP=1h
+```
+
+`MIGRATION_CUTOFF` 是不可变的绝对 UTC deadline。`--finite-policy` 必须经批准后显式选择：
+
+- `natural`：已在 `TokenExpire` 内的有限 v1/v2 自然过期；永久和超过上限的记录仍被收敛。
+- `cap`：有限 v1/v2 也压到 cutoff，可能使更多在线用户提前重新登录。
+
+同一 campaign 的 cutoff、finite policy 和生效 `TokenExpire` 不可改变；续跑时可以下调
+`--batch-size` / `--qps`。新的 campaign 使用新的 ID，不会复用旧 checkpoint。
+
+`OBSERVATION_MIN_GAP` 必须由发布审批显式确定且不得低于 `1h`。首次推进 `v3-write` floor 时写入
+无 TTL rollout control；后续阶段可经审批增大，但不得低于已持久化值，两次 observe 必须达到
+本次传入的新间隔，否则命令 fail closed。若目标环境已有旧版 rollout control 且没有该字段，
+不要删除或手改 key；读取仍兼容，下一次合法 `advance-floor` 会用本次传入值原子补齐。
+
+完整演练要为证据窗口预留时间：进入 `bounded` 前的两次 observe 至少间隔 `1h`，进入
+`enforce` 前还需要 bounded floor 下两次新的 observe，最短约 `2h`，且不含扫描、部署和审批耗时。
+不要把这两段等待压进不足的生产变更窗口，也不要为缩短演练降低安全下界。
+
+## 5. 分阶段启用
+
+### Phase A：`expand`
+
+1. 部署 PR 2，显式或默认使用 `OCTO_AUTH_SESSION_MODE=expand`。
+2. 等待 rollout 完成，确认 `desired=current=ready`，所有 PR 2 之前的 ReplicaSet 副本为 0。
+3. 核对每个 Pod 的 build、mode、floor、TTL 和 pool 日志；此时不得产生 v3、不得 apply。
+4. 运行一次限速 observe 做基线盘点，但不要记录 floor 证据：
+
+```bash
+/tmp/token-session-observe --config "$TOKEN_CONFIG" --batch-size 200 --qps 50
+```
+
+结果必须检查 `complete`、`read_errors`、`invalid_ttl`、`decode_invalid`、`persistent`、
+`over_max`、`v1/v2/v3`。任何不完整或歧义统计都不是放行证据。
+
+### Phase B：`v3-write`
+
+1. 产品/容量签字 session cap；部署 `MODE=v3-write` + `MAX_PER_UID=<approved>`。此时 floor 尚未
+   建立，暂不设置 `REQUIRED_FLOOR`。
+2. 清零所有 `expand` 副本，确认所有 Pod 只写 v3，验证登录、复用、资料更新和 session cap。
+3. 推进不可逆 writer floor：
+
+```bash
+/tmp/token-session-admin advance-floor --config "$TOKEN_CONFIG" --to v3-write \
+  --observation-min-gap "$OBSERVATION_MIN_GAP"
+```
+
+4. 立即把 Deployment 增加 `OCTO_AUTH_SESSION_REQUIRED_FLOOR=v3-write` 并完成一次同制品滚动，
+   清零未带 required-floor 的副本。之后 control key 丢失会使新实例 fail closed。
+
+不得在仍有 `expand` writer 时提前建立 v3-write floor；已运行的旧进程不会动态重读 floor。
+
+### Phase C：`revoke`
+
+1. 部署 `MODE=revoke`、`REQUIRED_FLOOR=v3-write`，清零 `v3-write` 副本。
+2. 验证退出、改密/重置、禁用/注销、管理员删除的同步撤销和 durable retry；确认 backlog 收敛。
+3. 推进 floor，再滚动更新 required floor：
+
+```bash
+/tmp/token-session-admin advance-floor --config "$TOKEN_CONFIG" --to revoke \
+  --observation-min-gap "$OBSERVATION_MIN_GAP"
+```
+
+部署 `REQUIRED_FLOOR=revoke` 后清零旧配置副本。只有完成这一步才允许 apply 和 rollout evidence。
+
+legacy deny marker 从本阶段开始按被全量撤销的 UID 写入且无 TTL。上线前按可能被撤销的唯一 UID
+数做容量预算；在所有 legacy reader 退出并进入最终 enforce 前禁止人工删除。本版本不提供自动
+cleanup，后续清理必须走单独审核的聚合盘点和受控工具。
+
+### Phase D：migration 与 `bounded`
+
+先 dry-run，人工复核聚合结果和预计提前失效量：
+
+```bash
+/tmp/token-session-admin migrate \
+  --config "$TOKEN_CONFIG" \
+  --campaign "$MIGRATION_CAMPAIGN" \
+  --cutoff "$MIGRATION_CUTOFF" \
+  --finite-policy natural \
+  --batch-size 200 \
+  --qps 50 \
+  --lease 30s
+```
+
+批准后使用完全相同的 campaign/cutoff/policy 加 `--apply`：
+
+```bash
+/tmp/token-session-admin migrate \
+  --config "$TOKEN_CONFIG" \
+  --campaign "$MIGRATION_CAMPAIGN" \
+  --cutoff "$MIGRATION_CUTOFF" \
+  --finite-policy natural \
+  --batch-size 200 \
+  --qps 50 \
+  --lease 30s \
+  --apply
+```
+
+若取消、锁丢失或失败，保留原 campaign/cutoff/policy，按 checkpoint 续跑；可降低 batch/QPS。
+只有输出 `complete=true` 才会生成 migration completion evidence。
+
+如果 apply 启动时 cutoff 尚未过期、但在限速扫描中到期，未带确认的任务会在第一条需要立即删除
+的记录上由 Lua 在 `DEL` 前停止，输出 `complete=false` 和明确错误；此前已经执行的 TTL 缩短不会
+回滚，也不会生成 completion evidence。当前批次可能尚未写入 checkpoint，续跑会从最近已保存
+的 cursor（没有则从 0）幂等重放。此时先以同一 campaign/cutoff/policy 重新 dry-run 评估
+`would_delete`，获批后再加 `--confirm-elapsed-cutoff` 续跑；不得通过延后 cutoff 或更换 campaign
+绕过确认。
+
+若启动或恢复时 `MIGRATION_CUTOFF` 已经过期，不得改 cutoff 或换 campaign 来延长原安全
+deadline。先用相同 cutoff/policy 再跑 dry-run：命中的剩余记录会计入 `would_delete`；获批 apply
+后会立即删除并计入 `deleted`，可能触发批量重新登录。该行为是遵守已批准绝对截止时间，不得把
+它解释成普通
+`shortened`。过期 cutoff 的 apply 还必须显式传入 `--confirm-elapsed-cutoff`，仅传 `--apply` 会被
+工具和 store 双重拒绝：
+
+```bash
+/tmp/token-session-admin migrate \
+  --config "$TOKEN_CONFIG" \
+  --campaign "$MIGRATION_CAMPAIGN" \
+  --cutoff "$MIGRATION_CUTOFF" \
+  --finite-policy natural \
+  --batch-size 200 \
+  --qps 50 \
+  --lease 30s \
+  --apply \
+  --confirm-elapsed-cutoff
+```
+
+若影响不可接受，应停止 apply 并升级安全审批，不能由运维自行延后 deadline。
+
+每次 apply 结束都必须同时核对 exit status、`complete`、`deleted` 和 `shortened`；`deleted>0`
+表示本轮执行了经显式确认的立即删除，必须与审批中的预计重新登录影响一致。
+
+apply 完成后执行两次独立完整 observe。两次应跨过一个经批准的间隔，并分别保存聚合输出：
+
+```bash
+/tmp/token-session-observe --config "$TOKEN_CONFIG" --batch-size 200 --qps 50 --record-rollout-evidence
+/tmp/token-session-observe --config "$TOKEN_CONFIG" --batch-size 200 --qps 50 --record-rollout-evidence
+```
+
+两次均须 `complete=true`、`read_errors=invalid_ttl=decode_invalid=0`、`persistent=0`、
+`over_max=0`。工具会在同一安全 key 中原子保留最近两份聚合证据，不保存 credential/UID。
+
+先部署 `MODE=bounded`、`REQUIRED_FLOOR=revoke` 并灰度确认，再推进：
+
+```bash
+/tmp/token-session-admin advance-floor --config "$TOKEN_CONFIG" --to bounded \
+  --observation-min-gap "$OBSERVATION_MIN_GAP"
+```
+
+命令会机器校验 apply completion/checkpoint 和两次 observe；缺失、过期、损坏或不达标均拒绝。
+成功后部署 `REQUIRED_FLOOR=bounded` 并清零旧配置副本。
+
+### Phase E：`enforce`
+
+等待或继续获批 campaign，直到在 `bounded` floor 下两次新的完整 observe 均满足 Phase D 条件，
+并额外满足 `v1=0`、`v2=0`。旧的 revoke-floor 证据不能复用。
+
+以 `MODE=enforce`、`REQUIRED_FLOOR=bounded` 做小流量灰度，验证历史报告 Token、正常登录、退出、
+高风险撤销和 Redis 故障场景。灰度可回到 `bounded`，因为 enforce floor 尚未建立。
+
+所有副本稳定为 enforce、旧副本为 0 且复测通过后，才执行不可逆推进：
+
+```bash
+/tmp/token-session-admin advance-floor --config "$TOKEN_CONFIG" --to enforce \
+  --observation-min-gap "$OBSERVATION_MIN_GAP"
+```
+
+然后部署 `REQUIRED_FLOOR=enforce` 并清零旧配置副本。enforce floor 建立后不能再启动 bounded
+实例；只能回滚到仍支持 v3 generation 且遵守 enforce floor 的兼容制品。
+
+## 6. Kubernetes 核对模板
+
+不要只看一次 readiness。按实际 label 替换以下变量，并保存每阶段证据：
+
+```bash
+K8S_NAMESPACE=<namespace>
+K8S_DEPLOYMENT=<deployment>
+K8S_SELECTOR=<label-selector>
+
+kubectl -n "$K8S_NAMESPACE" rollout status deployment/"$K8S_DEPLOYMENT" --timeout=10m
+kubectl -n "$K8S_NAMESPACE" get deployment "$K8S_DEPLOYMENT" -o wide
+kubectl -n "$K8S_NAMESPACE" get rs -l "$K8S_SELECTOR" \
+  -o custom-columns='NAME:.metadata.name,DESIRED:.spec.replicas,CURRENT:.status.replicas,READY:.status.readyReplicas,IMAGE:.spec.template.spec.containers[*].image'
+kubectl -n "$K8S_NAMESPACE" get pods -l "$K8S_SELECTOR" -o wide
+```
+
+门禁是目标副本全部 ready、上一阶段/旧 build ReplicaSet 的 desired/current/ready 均为 0，并且每个
+新 Pod 的启动日志和 rollout-mode 指标一致。若 Pod 只有 CPU request 没有 limit，同时记录容器内
+实际 `GOMAXPROCS` 与启动日志 pool size。
+
+## 7. 中止与回滚
+
+- `expand` 尚未签发 v3 且未建立 v3-write floor：可回滚 PR 1 制品。
+- v3 已签发或 v3-write floor 已建立：不得回滚 PR 1，也不得恢复 v2 writer。回滚制品必须支持
+  v3、generation、deny marker 和当前 floor。
+- migration 可停止并按原 campaign 续跑；不得删除 campaign/checkpoint、延长已缩短 TTL、删除
+  deny marker，或通过更换 campaign 恢复已过期 Token。
+- rollout control 缺少 observation gap 的旧记录不需要 Redis 手术；保留原 key，由下一次合法
+  floor 推进补齐。已持久化的 gap 可提高但不得降低。
+- enforce 灰度期间、enforce floor 建立前可退到 bounded；enforce floor 建立后不可降级 floor。
+- generation/outbox/Redis 故障时暂停新阶段和 migration，扩容或回滚兼容 v3 制品；禁止关闭
+  generation 校验或临时恢复 v2 writer。
+
+任何阶段的 Redis error、pool timeout、认证拒绝突增、revocation backlog 不收敛、observe 不完整、
+旧副本未清零或客户端重登录风暴，均为 stop condition。中止不等于漏洞关闭。
+
+## 8. 最终关闭条件
+
+以下全部有证据后，才可把“认证 Token 生命周期过长”标记为已修复：
+
+1. enforce floor 与所有副本 mode/build 一致，旧副本为 0；
+2. migration apply 完成，最近两次完整 observe 为 `persistent=0, over_max=0, v1=0, v2=0`；
+3. Redis non-eviction、连接容量、两读性能和告警门禁已签字；
+4. 报告中的历史 Token 以及退出、改密/重置、禁用/注销、多设备、多副本竞态和 Redis 故障场景
+   已在目标环境复测；
+5. `/v1/user/pc/quit`、设备删除、OIDC sync `invalid_grant` 等未接线 scope 已有明确产品决定，
+   未完成项不得被 PR 合并状态掩盖。

--- a/main.go
+++ b/main.go
@@ -192,6 +192,16 @@ func runAPI(ctx *config.Context) {
 		panic(fmt.Errorf("verify authentication session Redis Lua support: %w", err))
 	}
 	probeCancel()
+	rolloutCtx, rolloutCancel := context.WithTimeout(context.Background(), 2*time.Second)
+	rolloutControl, err := tokenStore.RolloutControl(rolloutCtx)
+	rolloutCancel()
+	if err != nil {
+		panic(fmt.Errorf("read authentication session rollout floor: %w", err))
+	}
+	rolloutFloor := "none"
+	if rolloutControl != nil {
+		rolloutFloor = string(rolloutControl.ModeFloor)
+	}
 	route.SetTokenParser(auth.NewCacheTokenParser(
 		ctx.Cache(),
 		ctx.GetConfig().Cache.TokenCachePrefix,
@@ -278,6 +288,12 @@ func runAPI(ctx *config.Context) {
 	metrics.NewAvatarMetrics(prometheus.DefaultRegisterer)
 	metrics.NewSessionMetrics(prometheus.DefaultRegisterer)
 	metrics.SetSessionEffectiveTTL(ctx.GetConfig().Cache.TokenExpire)
+	metrics.SetSessionRolloutMode(string(tokenStore.Mode()))
+	fmt.Printf(
+		"Authentication session runtime: mode=%s rollout_floor=%s token_ttl=%s redis_pool_size=%d redis_pool_timeout=%s build=%s\n",
+		tokenStore.Mode(), rolloutFloor, ctx.GetConfig().Cache.TokenExpire,
+		sessionRedis.Options().PoolSize, sessionRedis.Options().PoolTimeout, ctx.GetConfig().Version,
+	)
 	// 自定义贴纸 handle 上线观测指标(P0: Sticker Handle Enforcement Rollout):上传签发
 	// handle 次数 / 注册结果分布 / 部署姿态 gauge。由 modules/file(签发) 与
 	// modules/sticker(注册) 经包级 Observe 函数灌入;此处注册即可,未注册前为 no-op。

--- a/modules/bot_provision/resolve.go
+++ b/modules/bot_provision/resolve.go
@@ -13,9 +13,9 @@ import (
 // bound to a disabled space would keep validating.
 //
 // v3.3.6 §P1 (yujiawei R2): also gate user.status=1 to close the
-// account-ban bypass. liftBanUser (modules/user/api_manager.go:909) sets
-// user.status=0 + QuitUserDevice clears redis token cache (handles
-// session-token path), but daemon api_key sits behind no such cache —
+// account-ban bypass. liftBanUser sets user.status=0, separately revokes known
+// HTTP sessions through Session Store, and calls QuitUserDevice for WuKongIM;
+// daemon api_key sits behind neither session mechanism —
 // without this join, a globally banned user's daemon keeps fully valid
 // credentials (verify-api-key 200, botToken mints live bot_token, mintBot
 // 200). execLogin already gates userInfo.Status (api.go:1418); v3 daemon

--- a/modules/oidc/api.go
+++ b/modules/oidc/api.go
@@ -1337,9 +1337,9 @@ func (r redisAuthcode) SetAuthcode(ctx context.Context, authcode, payload string
 	}
 }
 
-// ctxKiller 生产路径下的 sessionKiller 实现 —— 委托给 dmwork-lib 的
-// QuitUserDevice(uid, -1):内部统一删 token Redis + 用新 token 重签 IM,
-// WuKongIM 老连接的 transport 验证失败后自然断开,达成"踢全部设备"。
+// ctxKiller 生产路径下的 sessionKiller 实现 —— 委托给 octo-lib 的
+// QuitUserDevice(uid, -1) 退出 WuKongIM 全部设备。该调用不撤销 octo-server
+// HTTP bearer；OIDC sync invalid_grant 的本地会话 scope 仍是待签字能力。
 type ctxKiller struct{ ctx *config.Context }
 
 func (k ctxKiller) Kick(_ context.Context, uid string) error {

--- a/modules/oidc/api.go
+++ b/modules/oidc/api.go
@@ -19,6 +19,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
 	"github.com/Mininglamp-OSS/octo-server/modules/user"
+	"github.com/Mininglamp-OSS/octo-server/pkg/auth"
 	octoredis "github.com/Mininglamp-OSS/octo-server/pkg/redis"
 	rd "github.com/go-redis/redis"
 	mysql "github.com/go-sql-driver/mysql"
@@ -159,12 +160,7 @@ func New(ctx *config.Context) *OIDC {
 	o.audit = db
 	o.revoker = db
 	o.killer = ctxKiller{ctx: ctx}
-	o.tokenKill = cacheCurrentTokenInvalidator{
-		cache:          ctx.Cache(),
-		tokenPrefix:    ctx.GetConfig().Cache.TokenCachePrefix,
-		uidTokenPrefix: ctx.GetConfig().Cache.UIDTokenCachePrefix,
-		indexDel:       newRedisCompareDeleter(ctx),
-	}
+	o.tokenKill = auth.SessionStoreForContext(ctx)
 	o.cbGuard = NewCallbackGuard(
 		ctx.GetRedisConn(),
 		callbackGuardThresholdFromEnv(),

--- a/modules/oidc/api.go
+++ b/modules/oidc/api.go
@@ -37,6 +37,9 @@ const (
 	// thirdAuthcodeTTL 前端短码轮询拿 LoginRespJSON 的窗口。
 	// 登录响应仅在 callback 成功时落 Redis,容量影响可忽略。
 	thirdAuthcodeTTL = 5 * time.Minute
+	// logoutTokenInvalidationTimeout bounds the security-critical Redis work
+	// independently of the inbound request and the best-effort IM/IdP cleanup.
+	logoutTokenInvalidationTimeout = 3 * time.Second
 	// maxAuditDetail audit 表 reason 列写入的最大长度,防止 IdP 返回的
 	// 任意字段(如 ?error=...)灌爆审计字段或污染下游 dashboard。
 	maxAuditDetail    = 256
@@ -899,18 +902,24 @@ func (o *OIDC) logout(c *wkhttp.Context) {
 	kickFailed := false
 	revokeFailed := false
 	tokenFailed := false
-	if o.killer != nil {
-		if err := o.killer.Kick(ctx, uid); err != nil {
-			kickFailed = true
-			o.Error("OIDC logout 踢线失败",
+	if o.tokenKill != nil {
+		// The handler intentionally returns 200 even when cleanup is degraded, so
+		// a client disconnect must not cancel the only HTTP bearer revocation
+		// attempt. Keep its budget independent from IM kick and IdP cleanup.
+		tokenCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), logoutTokenInvalidationTimeout)
+		err := o.tokenKill.InvalidateCurrentToken(tokenCtx, uid, c.GetHeader("token"))
+		cancel()
+		if err != nil {
+			tokenFailed = true
+			o.Error("OIDC logout 作废当前 HTTP token 失败",
 				zap.String("trace_id", traceID),
 				zap.Error(err), zap.String("uid", uid))
 		}
 	}
-	if o.tokenKill != nil {
-		if err := o.tokenKill.InvalidateCurrentToken(ctx, uid, c.GetHeader("token")); err != nil {
-			tokenFailed = true
-			o.Error("OIDC logout 作废当前 HTTP token 失败",
+	if o.killer != nil {
+		if err := o.killer.Kick(ctx, uid); err != nil {
+			kickFailed = true
+			o.Error("OIDC logout 踢线失败",
 				zap.String("trace_id", traceID),
 				zap.Error(err), zap.String("uid", uid))
 		}

--- a/modules/oidc/api_test.go
+++ b/modules/oidc/api_test.go
@@ -560,6 +560,29 @@ func (r *fakeRevoker) RevokeRefreshByUID(uid string) (int64, error) {
 	return r.count, nil
 }
 
+type contextRecordingTokenInvalidator struct {
+	mu          sync.Mutex
+	called      bool
+	contextErr  error
+	deadline    time.Time
+	hasDeadline bool
+}
+
+func (i *contextRecordingTokenInvalidator) InvalidateCurrentToken(ctx context.Context, _, _ string) error {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	i.called = true
+	i.contextErr = ctx.Err()
+	i.deadline, i.hasDeadline = ctx.Deadline()
+	return i.contextErr
+}
+
+func (i *contextRecordingTokenInvalidator) snapshot() (bool, error, time.Time, bool) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	return i.called, i.contextErr, i.deadline, i.hasDeadline
+}
+
 // authorize 成功 → audit EventAuthorize 落库,带 IP/UA。
 // 用于风控数据面追溯 state 数 / 异常 IP 起步等指标。
 func TestAPI_Authorize_AuditsEventAuthorize(t *testing.T) {
@@ -688,6 +711,50 @@ func TestAPI_Logout_InvalidatesCurrentHTTPTokenOnly(t *testing.T) {
 	}
 	if got, _ := c.Get("uidtoken:1" + uid); got != otherToken {
 		t.Fatalf("other uidtoken index = %q, want %q", got, otherToken)
+	}
+}
+
+// A client disconnect must not cancel the security-critical bearer revocation.
+// OIDC logout is intentionally best-effort and still returns 200, so there is
+// no client retry or outbox path that could converge a skipped invalidation.
+func TestAPI_Logout_InvalidatesCurrentHTTPTokenAfterRequestCancellation(t *testing.T) {
+	mp := NewMockProvider(t)
+	o := newTestOIDC(t, mp, &fakeUserLookup{}, newFakeIdentityStore())
+	invalidator := &contextRecordingTokenInvalidator{}
+	o.tokenKill = invalidator
+	o.killer = &fakeKiller{}
+	o.revoker = &fakeRevoker{}
+
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.POST("/v1/auth/oidc/aegis/logout", func(gc *gin.Context) {
+		gc.Set("uid", "u-canceled-logout")
+		o.logout(wrapWk(gc))
+	})
+	canceled, cancel := context.WithCancel(context.Background())
+	cancel()
+	req := httptest.NewRequest(http.MethodPost, "/v1/auth/oidc/aegis/logout", nil).
+		WithContext(canceled)
+	req.Header.Set("token", "tok-canceled-logout")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+	called, contextErr, deadline, hasDeadline := invalidator.snapshot()
+	if !called {
+		t.Fatal("current HTTP token invalidator was not called")
+	}
+	if contextErr != nil {
+		t.Fatalf("bearer revocation inherited canceled request context: %v", contextErr)
+	}
+	if !hasDeadline {
+		t.Fatal("bearer revocation context must have a bounded deadline")
+	}
+	remaining := time.Until(deadline)
+	if remaining <= 0 || remaining > 4*time.Second {
+		t.Fatalf("bearer revocation deadline remaining = %s, want (0, 4s]", remaining)
 	}
 }
 

--- a/modules/oidc/sync_worker.go
+++ b/modules/oidc/sync_worker.go
@@ -14,10 +14,8 @@ import (
 	"golang.org/x/oauth2"
 )
 
-// sessionKiller 中止某个 UID 的所有会话(Web/PC/APP)并踢 WuKongIM 长连接。
-//
-// 生产实现包 *config.Context.QuitUserDevice(uid, -1):清 token Redis +
-// 重签 IM token 触发 WuKongIM 端 transport 失效。
+// sessionKiller 踢掉某个 UID 的 WuKongIM 全部设备连接。生产实现包装
+// *config.Context.QuitUserDevice(uid, -1)，它不撤销 octo-server HTTP bearer。
 type sessionKiller interface {
 	Kick(ctx context.Context, uid string) error
 }
@@ -94,10 +92,10 @@ type SyncWorkerConfig struct {
 
 // SyncWorker 周期性 refresh active RT,失败即吊销 + 踢线 + 审计。
 type SyncWorker struct {
-	cfg    SyncWorkerConfig
-	store  syncStore
-	enc    *Encryptor
-	rfsh   refresher
+	cfg   SyncWorkerConfig
+	store syncStore
+	enc   *Encryptor
+	rfsh  refresher
 	// ui / verif 都必须非 nil 才做实名同步。任一为 nil → sync_worker 保持
 	// YUJ-405 之前的原行为(纯 RT 轮转),向后兼容。生产路径在 OIDC.Init 中
 	// 同时注入(c.client + userSvc),只会一起 nil / 一起就位。

--- a/modules/user/api.go
+++ b/modules/user/api.go
@@ -1633,10 +1633,28 @@ func (u *User) login(c *wkhttp.Context) {
 		return
 	}
 	if userInfo != nil {
+		fencedUID := userInfo.UID
 		loginSpanCtx, err = withUserSessionIssueFence(loginSpanCtx, u.sessionStore, userInfo.UID)
 		if err != nil {
 			u.Error("初始化登录会话栅栏失败", zap.Error(err))
 			respondUserServiceError(c)
+			return
+		}
+		// BeginIssue must precede the authoritative credential read. If a
+		// password reset commits after the first lookup but before the fence,
+		// validating that stale in-memory hash would issue a session under the
+		// post-reset generation. Re-read the same login identity and require it
+		// to still resolve to the fenced UID; a later reset is stopped by the
+		// final fence CAS in IssueNewSession.
+		userInfo, err = u.db.QueryByUsernameCxt(loginSpanCtx, req.Username)
+		if err != nil {
+			u.Error("会话栅栏后复核用户信息失败", zap.String("username", req.Username), zap.Error(err))
+			respondUserError(c, errcode.ErrUserQueryFailed)
+			return
+		}
+		if userInfo == nil || userInfo.UID != fencedUID {
+			u.loginGuard.RecordFailureLogged(req.Username)
+			respondUserError(c, errcode.ErrUserInvalidCredentials)
 			return
 		}
 	}

--- a/modules/user/api.go
+++ b/modules/user/api.go
@@ -426,28 +426,29 @@ func (u *User) Route(r *wkhttp.WKHttp) {
 // app退出登录
 func (u *User) quit(c *wkhttp.Context) {
 	loginUID := c.GetLoginUID()
+	failed := false
 	if err := invalidateCurrentUserToken(c.Request.Context(), u.sessionStore, loginUID, c.GetHeader("token")); err != nil {
 		u.Error("撤销当前 HTTP token 失败", zap.Error(err))
-		respondUserError(c, errcode.ErrUserStoreFailed)
-		return
+		failed = true
 	}
 	err := u.ctx.QuitUserDevice(loginUID, int(config.Web)) // 退出web
 	if err != nil {
 		u.Error("退出web设备失败", zap.Error(err))
-		respondUserError(c, errcode.ErrUserStoreFailed)
-		return
+		failed = true
 	}
 
 	err = u.ctx.QuitUserDevice(loginUID, int(config.PC))
 	if err != nil {
 		u.Error("退出PC设备失败", zap.Error(err))
-		respondUserError(c, errcode.ErrUserStoreFailed)
-		return
+		failed = true
 	}
 
 	err = u.ctx.GetRedisConn().Del(fmt.Sprintf("%s%s", u.userDeviceTokenPrefix, loginUID))
 	if err != nil {
 		u.Error("删除设备token失败！", zap.Error(err))
+		failed = true
+	}
+	if failed {
 		respondUserError(c, errcode.ErrUserStoreFailed)
 		return
 	}
@@ -2629,9 +2630,15 @@ func (u *User) loginWithAuthCode(c *wkhttp.Context) {
 		respondUserError(c, errcode.ErrUserQueryFailed)
 		return
 	}
-	// 已注销账号拒绝授权登录；冷静期账号允许（与其他登录路径一致）
+	// 已禁用或已注销账号拒绝授权登录；冷静期账号允许（与其他登录路径一致）。
+	// issuance fence 只能阻止安全事件前开始的请求穿越撤销，事件后兑换仍需
+	// 以这里的权威账号状态拒绝，否则 live auth code 会签出新 generation bearer。
 	if userModel == nil || userModel.IsDestroy == IsDestroyDone {
 		respondUserError(c, errcode.ErrUserNotFound)
+		return
+	}
+	if userModel.Status == int(common.UserDisable) {
+		respondUserError(c, errcode.ErrUserAccountBanned)
 		return
 	}
 	// 获取缓存设备
@@ -3569,54 +3576,80 @@ func (u *User) destroyAccount(c *wkhttp.Context) {
 		respondUserError(c, errcode.ErrUserCurrentNotFound)
 		return
 	}
+	var retryIntent *sessionRevocationIntent
 	switch userInfo.IsDestroy {
 	case IsDestroyApplying:
 		respondUserError(c, errcode.ErrUserAccountDestroying)
 		return
 	case IsDestroyDone:
-		respondUserError(c, errcode.ErrUserAccountDestroyed)
-		return
-	}
-	//测试模式（仅非 release 生效）
-	if commonapi.IsTestCodeEnabled(u.ctx.GetConfig()) {
-		if !commonapi.MatchTestCode(u.ctx.GetConfig(), code) {
-			respondUserError(c, errcode.ErrUserCodeInvalid)
+		if sessionRevocationActive(u.sessionStore) {
+			retryIntent, err = u.db.pendingSessionRevocation(c.Request.Context(), loginUID, "account_destroy")
+			if err != nil {
+				u.Error("查询待重试的注销会话撤销任务失败", zap.Error(err))
+				respondUserError(c, errcode.ErrUserDestroyFailed)
+				return
+			}
+		}
+		if retryIntent == nil {
+			respondUserError(c, errcode.ErrUserAccountDestroyed)
 			return
 		}
-	} else {
-		//线上验证短信验证码
-		// 校验验证码
-		err = u.smsServie.Verify(c.Context, userInfo.Zone, userInfo.Phone, code, commonapi.CodeTypeDestroyAccount)
-		if err != nil {
-			u.Warn("注销验证码校验失败", zap.String("uid", loginUID), zap.Error(err))
-			respondUserError(c, errcode.ErrUserCodeInvalid)
-			return
+	}
+	if retryIntent == nil {
+		//测试模式（仅非 release 生效）
+		if commonapi.IsTestCodeEnabled(u.ctx.GetConfig()) {
+			if !commonapi.MatchTestCode(u.ctx.GetConfig(), code) {
+				respondUserError(c, errcode.ErrUserCodeInvalid)
+				return
+			}
+		} else {
+			//线上验证短信验证码
+			// 校验验证码
+			err = u.smsServie.Verify(c.Context, userInfo.Zone, userInfo.Phone, code, commonapi.CodeTypeDestroyAccount)
+			if err != nil {
+				u.Warn("注销验证码校验失败", zap.String("uid", loginUID), zap.Error(err))
+				respondUserError(c, errcode.ErrUserCodeInvalid)
+				return
+			}
 		}
 	}
 
-	// 毫秒时间戳：13 位足够保证唯一（UnixNano 19 位会撑爆 varchar(40)）。
-	// username 通过 anonymizeUsername 兜底防溢出（海外长手机号时回退 hash 形式）。
-	stamp := strconv.FormatInt(time.Now().UnixMilli(), 10)
-	phone := fmt.Sprintf("%s@%s@delete", userInfo.Phone, stamp)
-	username := anonymizeUsername(loginUID, userInfo.Zone, phone, stamp)
-	if sessionRevocationActive(u.sessionStore) {
-		intent, mutateErr := u.db.destroyAccountWithSessionRevocation(c.Request.Context(), loginUID, username, phone, IsDestroyNo)
-		if mutateErr == nil {
+	if retryIntent != nil {
+		err = u.applySessionRevocationIntent(c.Request.Context(), retryIntent)
+	} else {
+		// 毫秒时间戳：13 位足够保证唯一（UnixNano 19 位会撑爆 varchar(40)）。
+		// username 通过 anonymizeUsername 兜底防溢出（海外长手机号时回退 hash 形式）。
+		stamp := strconv.FormatInt(time.Now().UnixMilli(), 10)
+		phone := fmt.Sprintf("%s@%s@delete", userInfo.Phone, stamp)
+		username := anonymizeUsername(loginUID, userInfo.Zone, phone, stamp)
+		if sessionRevocationActive(u.sessionStore) {
+			intent, mutateErr := u.db.destroyAccountWithSessionRevocation(c.Request.Context(), loginUID, username, phone, IsDestroyNo)
+			if mutateErr != nil {
+				u.Error("注销账号错误", zap.Error(mutateErr))
+				respondUserError(c, errcode.ErrUserDestroyFailed)
+				return
+			}
 			err = u.applySessionRevocationIntent(c.Request.Context(), intent)
 		} else {
-			err = mutateErr
+			err = u.db.destroyAccount(loginUID, username, phone)
+			if err != nil {
+				u.Error("注销账号错误", zap.Error(err))
+				respondUserError(c, errcode.ErrUserDestroyFailed)
+				return
+			}
 		}
-	} else {
-		err = u.db.destroyAccount(loginUID, username, phone)
 	}
-	if err != nil {
-		u.Error("注销账号错误", zap.Error(err))
+	revocationErr := err
+	imErr := u.ctx.QuitUserDevice(c.GetLoginUID(), -1) // 退出全部登陆设备
+	if imErr != nil {
+		u.Error("退出登陆设备失败", zap.Error(imErr))
+	}
+	if revocationErr != nil {
+		u.Error("注销账号后的会话撤销尚未完成", zap.Error(revocationErr))
 		respondUserError(c, errcode.ErrUserDestroyFailed)
 		return
 	}
-	err = u.ctx.QuitUserDevice(c.GetLoginUID(), -1) // 退出全部登陆设备
-	if err != nil {
-		u.Error("退出登陆设备失败", zap.Error(err))
+	if imErr != nil {
 		respondUserError(c, errcode.ErrUserStoreFailed)
 		return
 	}

--- a/modules/user/api.go
+++ b/modules/user/api.go
@@ -3922,7 +3922,7 @@ func (u *User) pwdforget(c *wkhttp.Context) {
 		respondUserError(c, errcode.ErrUserPasswordProcessFailed)
 		return
 	}
-	err = updateUserFieldAndRevokeSessions(c.Request.Context(), u.db, u.sessionStore, userInfo.UID, "password", hashedPassword, "password_reset")
+	err = updatePasswordAndRevokeSessions(c.Request.Context(), u.db, u.sessionStore, u.ctx.QuitUserDevice, userInfo.UID, hashedPassword, "password_reset")
 	if err != nil {
 		u.Error("修改登录密码错误", zap.Error(err))
 		respondUserError(c, errcode.ErrUserLoginPwdUpdateFailed)

--- a/modules/user/api.go
+++ b/modules/user/api.go
@@ -1548,6 +1548,16 @@ func (u *User) wxLogin(c *wkhttp.Context) {
 			respondUserServiceError(c)
 			return
 		}
+		userInfo, err = u.reloadUserAfterIssueFence(loginSpanCtx, userInfo.UID)
+		if err != nil {
+			if errors.Is(err, ErrorUserNotExist) {
+				respondUserError(c, errcode.ErrUserNotFound)
+				return
+			}
+			u.Error("会话栅栏后复核微信登录用户失败", zap.Error(err))
+			respondUserError(c, errcode.ErrUserQueryFailed)
+			return
+		}
 		if userInfo.IsDestroy == IsDestroyDone {
 			respondUserError(c, errcode.ErrUserNotFound)
 			return
@@ -1926,6 +1936,17 @@ func userSessionIssueFenceFromContext(ctx context.Context, uid string) (auth.Iss
 		return auth.IssueFence{}, false
 	}
 	return value.fence, true
+}
+
+func (u *User) reloadUserAfterIssueFence(ctx context.Context, uid string) (*Model, error) {
+	user, err := u.db.QueryByUID(uid)
+	if err != nil {
+		return nil, fmt.Errorf("reload fenced user: %w", err)
+	}
+	if user == nil || user.UID != uid {
+		return nil, ErrorUserNotExist
+	}
+	return user, nil
 }
 
 func issueUserSession(ctx context.Context, store userSessionStore, token string, info auth.TokenInfo, fence auth.IssueFence) error {
@@ -3382,6 +3403,24 @@ func (u *User) loginCheckPhone(c *wkhttp.Context) {
 	if err != nil {
 		u.Error("初始化设备验证登录会话栅栏失败", zap.Error(err))
 		respondUserError(c, errcode.ErrUserStoreFailed)
+		return
+	}
+	userInfo, err = u.reloadUserAfterIssueFence(spanCtx, userInfo.UID)
+	if err != nil {
+		if errors.Is(err, ErrorUserNotExist) {
+			respondUserError(c, errcode.ErrUserNotFound)
+			return
+		}
+		u.Error("会话栅栏后复核设备验证用户失败", zap.Error(err))
+		respondUserError(c, errcode.ErrUserQueryFailed)
+		return
+	}
+	if userInfo.IsDestroy == IsDestroyDone {
+		respondUserError(c, errcode.ErrUserNotFound)
+		return
+	}
+	if userInfo.Status == int(common.UserDisable) {
+		respondUserError(c, errcode.ErrUserAccountUnavailable)
 		return
 	}
 	err = u.smsServie.Verify(spanCtx, userInfo.Zone, userInfo.Phone, req.Code, commonapi.CodeTypeCheckMobile)

--- a/modules/user/api.go
+++ b/modules/user/api.go
@@ -1976,6 +1976,9 @@ func revokeCurrentUserSession(ctx context.Context, store userSessionStore, token
 	if v3Store, ok := store.(v3UserSessionStore); ok && v3Store.Mode().WritesV3() {
 		return v3Store.RevokeCurrent(ctx, token, uid, deviceFlag)
 	}
+	if invalidator, ok := store.(currentUserTokenInvalidator); ok {
+		return invalidator.InvalidateCurrentToken(ctx, uid, token)
+	}
 	if err := store.DeleteToken(ctx, token); err != nil {
 		return err
 	}

--- a/modules/user/api.go
+++ b/modules/user/api.go
@@ -120,6 +120,7 @@ type User struct {
 	sessionStore             userSessionStore
 	tokenValidator           *auth.TokenValidator
 	scanLoginAuthorizations  *scanLoginAuthorizationStore
+	revocationWorkerOwner    string
 }
 
 type userSessionStore interface {
@@ -129,6 +130,27 @@ type userSessionStore interface {
 	DeviceToken(ctx context.Context, uid string, deviceFlag int) (string, error)
 	DeleteToken(ctx context.Context, token string) error
 	RevokeIssued(ctx context.Context, token, uid string, deviceFlag int) error
+}
+
+type v3UserSessionStore interface {
+	Mode() auth.SessionMode
+	BeginIssue(ctx context.Context, uid string) (auth.IssueFence, error)
+	IssueNewSession(ctx context.Context, token string, info auth.TokenInfo, fence auth.IssueFence) error
+	ReuseSession(ctx context.Context, token string, info auth.TokenInfo, fence auth.IssueFence) (bool, error)
+	UpdateSessionSnapshot(ctx context.Context, token string, info auth.TokenInfo) (bool, error)
+	RevokeCurrent(ctx context.Context, token, uid string, deviceFlag int) error
+	RevokeAll(ctx context.Context, uid string, event auth.RevocationEvent) error
+}
+
+type userSessionIssueContextKey struct{}
+
+type userSessionIssueContext struct {
+	uid   string
+	fence auth.IssueFence
+}
+
+type currentUserTokenInvalidator interface {
+	InvalidateCurrentToken(ctx context.Context, uid, token string) error
 }
 
 // New New
@@ -167,6 +189,7 @@ func New(ctx *config.Context) *User {
 		sessionStore:             sessionStore,
 		tokenValidator:           auth.NewTokenValidator(sessionStore, ctx.GetConfig().Cache.TokenCachePrefix),
 		scanLoginAuthorizations:  newScanLoginAuthorizationStore(loginRedisClient),
+		revocationWorkerOwner:    util.GenerUUID(),
 	}
 	// LanguageService 与 main.go 注入到 CacheTokenParser 的实例独立构造，但共享
 	// 底层 *DB session / Redis 连接，因此读写同一份 user.language 列与
@@ -392,16 +415,22 @@ func (u *User) Route(r *wkhttp.WKHttp) {
 		internal.POST("/verify-token", u.verifyTokenAegisRedirect)
 	}
 
-	u.ctx.AddOnlineStatusListener(u.onlineService.listenOnlineStatus) // 监听在线状态
-	u.ctx.AddOnlineStatusListener(u.handleOnlineStatus)               // 需要放在listenOnlineStatus之后
-	u.ctx.Schedule(time.Minute*5, u.onlineStatusCheck)                // 在线状态定时检查
-	u.ctx.Schedule(time.Minute*5, u.checkDestroyExpired)              // 注销冷静期到期扫描
+	u.ctx.AddOnlineStatusListener(u.onlineService.listenOnlineStatus)  // 监听在线状态
+	u.ctx.AddOnlineStatusListener(u.handleOnlineStatus)                // 需要放在listenOnlineStatus之后
+	u.ctx.Schedule(time.Minute*5, u.onlineStatusCheck)                 // 在线状态定时检查
+	u.ctx.Schedule(time.Minute*5, u.checkDestroyExpired)               // 注销冷静期到期扫描
+	u.ctx.Schedule(10*time.Second, u.processPendingSessionRevocations) // durable HTTP session revocation
 
 }
 
 // app退出登录
 func (u *User) quit(c *wkhttp.Context) {
 	loginUID := c.GetLoginUID()
+	if err := invalidateCurrentUserToken(c.Request.Context(), u.sessionStore, loginUID, c.GetHeader("token")); err != nil {
+		u.Error("撤销当前 HTTP token 失败", zap.Error(err))
+		respondUserError(c, errcode.ErrUserStoreFailed)
+		return
+	}
 	err := u.ctx.QuitUserDevice(loginUID, int(config.Web)) // 退出web
 	if err != nil {
 		u.Error("退出web设备失败", zap.Error(err))
@@ -1113,22 +1142,18 @@ func (u *User) userUpdateWithField(c *wkhttp.Context) {
 					preservedLang = ""
 				}
 			}
-			payload, encErr := auth.Encode(auth.TokenInfo{
+			snapshot := auth.TokenInfo{
 				UID:      loginUID,
 				Name:     fmt.Sprintf("%v", value),
 				Role:     c.GetLoginRole(),
 				Language: preservedLang,
-			})
-			if encErr != nil {
-				u.Error("编码token缓存失败！", zap.Error(encErr))
-				respondUserError(c, errcode.ErrUserStoreFailed)
-				return
 			}
-			_, err = u.sessionStore.UpdatePayloadKeepDeadline(c.Request.Context(), loginToken, payload)
+			_, err = updateUserSessionSnapshot(c.Request.Context(), u.sessionStore, loginToken, snapshot)
 			if err != nil {
-				u.Error("重新设置token缓存失败！", zap.Error(err))
-				respondUserError(c, errcode.ErrUserStoreFailed)
-				return
+				// The DB update above is already authoritative. A cache snapshot
+				// failure must not turn that committed mutation into a misleading
+				// API failure; the bearer keeps its old non-security display fields.
+				u.Warn("更新token展示快照失败", zap.Error(err))
 			}
 		}
 	}
@@ -1517,6 +1542,12 @@ func (u *User) wxLogin(c *wkhttp.Context) {
 		return
 	}
 	if userInfo != nil {
+		loginSpanCtx, err = withUserSessionIssueFence(loginSpanCtx, u.sessionStore, userInfo.UID)
+		if err != nil {
+			u.Error("初始化微信登录会话栅栏失败", zap.Error(err))
+			respondUserServiceError(c)
+			return
+		}
 		if userInfo.IsDestroy == IsDestroyDone {
 			respondUserError(c, errcode.ErrUserNotFound)
 			return
@@ -1601,6 +1632,14 @@ func (u *User) login(c *wkhttp.Context) {
 		respondUserError(c, errcode.ErrUserQueryFailed)
 		return
 	}
+	if userInfo != nil {
+		loginSpanCtx, err = withUserSessionIssueFence(loginSpanCtx, u.sessionStore, userInfo.UID)
+		if err != nil {
+			u.Error("初始化登录会话栅栏失败", zap.Error(err))
+			respondUserServiceError(c)
+			return
+		}
+	}
 	// 已注销 / 被禁用账号统一拒绝；与 emailLogin / usernameLogin 行为对齐
 	if userInfo == nil || userInfo.IsDestroy == IsDestroyDone || userInfo.Status == 0 {
 		u.loginGuard.RecordFailureLogged(req.Username)
@@ -1680,6 +1719,14 @@ func (u *User) respondExecLoginError(c *wkhttp.Context, err error, userInfo *Mod
 }
 
 func (u *User) execLogin(userInfo *Model, flag config.DeviceFlag, device *deviceReq, loginSpanCtx context.Context) (*loginUserDetailResp, error) {
+	issueFence, ok := userSessionIssueFenceFromContext(loginSpanCtx, userInfo.UID)
+	if !ok {
+		var err error
+		issueFence, err = beginUserSessionIssue(loginSpanCtx, u.sessionStore, userInfo.UID)
+		if err != nil {
+			return nil, fmt.Errorf("begin token issuance: %w", err)
+		}
+	}
 	if userInfo.Status == int(common.UserDisable) {
 		return nil, ErrUserDisabled
 	}
@@ -1745,7 +1792,7 @@ func (u *User) execLogin(userInfo *Model, flag config.DeviceFlag, device *device
 	reuseExistingToken := false
 	if flag == config.APP {
 		if oldToken != "" {
-			err = u.sessionStore.DeleteToken(loginSpanCtx, oldToken)
+			err = revokeCurrentUserSession(loginSpanCtx, u.sessionStore, oldToken, userInfo.UID, int(flag))
 			if err != nil {
 				u.Error("清除旧token数据错误", zap.Error(err))
 				tokenSpan.Finish()
@@ -1759,20 +1806,21 @@ func (u *User) execLogin(userInfo *Model, flag config.DeviceFlag, device *device
 		}
 	}
 
-	tokenPayload, err := auth.Encode(auth.TokenInfo{
-		UID:      userInfo.UID,
-		Name:     userInfo.Name,
-		Role:     userInfo.Role,
-		Language: userInfo.Language,
-	})
-	if err != nil {
-		u.Error("编码token缓存失败！", zap.Error(err))
-		tokenSpan.Finish()
-		return nil, errors.New("设置token缓存失败！")
+	deviceID := ""
+	if device != nil {
+		deviceID = device.DeviceID
+	}
+	sessionInfo := auth.TokenInfo{
+		UID:        userInfo.UID,
+		Name:       userInfo.Name,
+		Role:       userInfo.Role,
+		Language:   userInfo.Language,
+		DeviceFlag: int(flag),
+		DeviceID:   deviceID,
 	}
 	if reuseExistingToken {
 		var refreshed bool
-		refreshed, err = u.reuseExistingLoginToken(loginSpanCtx, token, tokenPayload, userInfo.UID, int(flag))
+		refreshed, err = reuseUserSession(loginSpanCtx, u.sessionStore, token, sessionInfo, issueFence)
 		if err != nil {
 			u.Error("刷新旧token缓存失败！", zap.Error(err))
 			tokenSpan.Finish()
@@ -1785,7 +1833,7 @@ func (u *User) execLogin(userInfo *Model, flag config.DeviceFlag, device *device
 	}
 	issuedNew := false
 	if !reuseExistingToken {
-		err = u.sessionStore.IssueNew(loginSpanCtx, token, tokenPayload, userInfo.UID, int(flag))
+		err = issueUserSession(loginSpanCtx, u.sessionStore, token, sessionInfo, issueFence)
 		if err != nil {
 			u.Error("设置token缓存失败！", zap.Error(err))
 			tokenSpan.Finish()
@@ -1838,6 +1886,80 @@ func (u *User) reuseExistingLoginToken(ctx context.Context, token, payload, uid 
 	return u.sessionStore.ReuseExisting(ctx, token, payload, uid, deviceFlag)
 }
 
+func beginUserSessionIssue(ctx context.Context, store userSessionStore, uid string) (auth.IssueFence, error) {
+	v3Store, ok := store.(v3UserSessionStore)
+	if !ok || !v3Store.Mode().WritesV3() {
+		return auth.IssueFence{}, nil
+	}
+	return v3Store.BeginIssue(ctx, uid)
+}
+
+func withUserSessionIssueFence(ctx context.Context, store userSessionStore, uid string) (context.Context, error) {
+	fence, err := beginUserSessionIssue(ctx, store, uid)
+	if err != nil {
+		return ctx, err
+	}
+	return context.WithValue(ctx, userSessionIssueContextKey{}, userSessionIssueContext{uid: uid, fence: fence}), nil
+}
+
+func userSessionIssueFenceFromContext(ctx context.Context, uid string) (auth.IssueFence, bool) {
+	value, ok := ctx.Value(userSessionIssueContextKey{}).(userSessionIssueContext)
+	if !ok || value.uid != uid {
+		return auth.IssueFence{}, false
+	}
+	return value.fence, true
+}
+
+func issueUserSession(ctx context.Context, store userSessionStore, token string, info auth.TokenInfo, fence auth.IssueFence) error {
+	if v3Store, ok := store.(v3UserSessionStore); ok && v3Store.Mode().WritesV3() {
+		return v3Store.IssueNewSession(ctx, token, info, fence)
+	}
+	payload, err := auth.Encode(info)
+	if err != nil {
+		return err
+	}
+	return store.IssueNew(ctx, token, payload, info.UID, info.DeviceFlag)
+}
+
+func reuseUserSession(ctx context.Context, store userSessionStore, token string, info auth.TokenInfo, fence auth.IssueFence) (bool, error) {
+	if v3Store, ok := store.(v3UserSessionStore); ok && v3Store.Mode().WritesV3() {
+		return v3Store.ReuseSession(ctx, token, info, fence)
+	}
+	payload, err := auth.Encode(info)
+	if err != nil {
+		return false, err
+	}
+	return store.ReuseExisting(ctx, token, payload, info.UID, info.DeviceFlag)
+}
+
+func revokeCurrentUserSession(ctx context.Context, store userSessionStore, token, uid string, deviceFlag int) error {
+	if v3Store, ok := store.(v3UserSessionStore); ok && v3Store.Mode().WritesV3() {
+		return v3Store.RevokeCurrent(ctx, token, uid, deviceFlag)
+	}
+	if err := store.DeleteToken(ctx, token); err != nil {
+		return err
+	}
+	return nil
+}
+
+func updateUserSessionSnapshot(ctx context.Context, store userSessionStore, token string, info auth.TokenInfo) (bool, error) {
+	if v3Store, ok := store.(v3UserSessionStore); ok {
+		return v3Store.UpdateSessionSnapshot(ctx, token, info)
+	}
+	payload, err := auth.Encode(info)
+	if err != nil {
+		return false, err
+	}
+	return store.UpdatePayloadKeepDeadline(ctx, token, payload)
+}
+
+func invalidateCurrentUserToken(ctx context.Context, store userSessionStore, uid, token string) error {
+	if invalidator, ok := store.(currentUserTokenInvalidator); ok {
+		return invalidator.InvalidateCurrentToken(ctx, uid, token)
+	}
+	return store.DeleteToken(ctx, token)
+}
+
 func (u *User) compensateIssuedToken(token, uid string, deviceFlag int) error {
 	// 请求取消不能跳过 credential 补偿；Redis client 自身另有严格超时，
 	// 这里再给整个清理动作一个总 deadline，避免失败路径无限占用 goroutine。
@@ -1863,6 +1985,22 @@ func (u *User) replaceAPPToken(ctx context.Context, token, payload, uid string) 
 		}
 	}
 	if err := u.sessionStore.IssueNew(ctx, token, payload, uid, int(config.APP)); err != nil {
+		return fmt.Errorf("issue APP token: %w", err)
+	}
+	return nil
+}
+
+func (u *User) replaceAPPTokenSession(ctx context.Context, token string, info auth.TokenInfo, fence auth.IssueFence) error {
+	oldToken, err := u.sessionStore.DeviceToken(ctx, info.UID, int(config.APP))
+	if err != nil {
+		return fmt.Errorf("load previous APP token: %w", err)
+	}
+	if strings.TrimSpace(oldToken) != "" {
+		if err := revokeCurrentUserSession(ctx, u.sessionStore, oldToken, info.UID, int(config.APP)); err != nil {
+			return fmt.Errorf("revoke previous APP token: %w", err)
+		}
+	}
+	if err := issueUserSession(ctx, u.sessionStore, token, info, fence); err != nil {
 		return fmt.Errorf("issue APP token: %w", err)
 	}
 	return nil
@@ -2410,6 +2548,12 @@ func (u *User) loginWithAuthCode(c *wkhttp.Context) {
 		respondUserError(c, errcode.ErrUserAuthCodeNotFound)
 		return
 	}
+	issueFence, err := beginUserSessionIssue(c.Request.Context(), u.sessionStore, scaner)
+	if err != nil {
+		u.Error("初始化扫码登录会话栅栏失败", zap.Error(err))
+		respondUserError(c, errcode.ErrUserStoreFailed)
+		return
+	}
 	consumed, err := u.scanLoginAuthorizations.Consume(authCode, authInfo)
 	if err != nil {
 		u.Error("原子消费扫码授权码失败！", zap.Error(err))
@@ -2452,6 +2596,7 @@ func (u *User) loginWithAuthCode(c *wkhttp.Context) {
 		return
 	}
 	// 获取缓存设备
+	sessionDeviceID := ""
 	if uuid != "" {
 		deviceCache, err := u.ctx.GetRedisConn().GetString(fmt.Sprintf("%s%s", common.DeviceCacheUUIDPrefix, uuid))
 		if err != nil {
@@ -2468,6 +2613,7 @@ func (u *User) loginWithAuthCode(c *wkhttp.Context) {
 				return
 			}
 			deviceId, _ := deviceInfoMap["device_id"].(string)
+			sessionDeviceID = deviceId
 			deviceName, _ := deviceInfoMap["device_name"].(string)
 			dmodel, _ := deviceInfoMap["device_model"].(string)
 			if deviceId != "" && deviceName != "" && dmodel != "" {
@@ -2496,18 +2642,16 @@ func (u *User) loginWithAuthCode(c *wkhttp.Context) {
 	// 在调用 IM 之前确定最终 token 并写入缓存。
 	// 复用旧 token 时用 SET XX(SetIfExists):仅当 token:<oldToken> 仍存在才刷新;
 	// 若已被并发 logout 删除,则回退到新 UUID,避免复活已登出的 token。
-	tokenPayload, err := auth.Encode(auth.TokenInfo{
-		UID:      userModel.UID,
-		Name:     userModel.Name,
-		Language: userModel.Language,
-	})
-	if err != nil {
-		u.Error("编码token缓存失败！", zap.Error(err))
-		respondUserError(c, errcode.ErrUserStoreFailed)
-		return
+	sessionInfo := auth.TokenInfo{
+		UID:        userModel.UID,
+		Name:       userModel.Name,
+		Role:       userModel.Role,
+		Language:   userModel.Language,
+		DeviceFlag: int(flag),
+		DeviceID:   sessionDeviceID,
 	}
 	if reuseExistingToken {
-		refreshed, err := u.reuseExistingLoginToken(c.Request.Context(), token, tokenPayload, userModel.UID, int(flag))
+		refreshed, err := reuseUserSession(c.Request.Context(), u.sessionStore, token, sessionInfo, issueFence)
 		if err != nil {
 			u.Error("刷新旧token缓存失败！", zap.Error(err))
 			respondUserError(c, errcode.ErrUserStoreFailed)
@@ -2520,7 +2664,7 @@ func (u *User) loginWithAuthCode(c *wkhttp.Context) {
 	}
 	issuedNew := false
 	if !reuseExistingToken {
-		err = u.sessionStore.IssueNew(c.Request.Context(), token, tokenPayload, userModel.UID, int(flag))
+		err = issueUserSession(c.Request.Context(), u.sessionStore, token, sessionInfo, issueFence)
 		if err != nil {
 			u.Error("设置token缓存失败！", zap.Error(err))
 			respondUserError(c, errcode.ErrUserStoreFailed)
@@ -3216,6 +3360,12 @@ func (u *User) loginCheckPhone(c *wkhttp.Context) {
 		respondUserError(c, errcode.ErrUserNotFound)
 		return
 	}
+	issueFence, err := beginUserSessionIssue(spanCtx, u.sessionStore, userInfo.UID)
+	if err != nil {
+		u.Error("初始化设备验证登录会话栅栏失败", zap.Error(err))
+		respondUserError(c, errcode.ErrUserStoreFailed)
+		return
+	}
 	err = u.smsServie.Verify(spanCtx, userInfo.Zone, userInfo.Phone, req.Code, commonapi.CodeTypeCheckMobile)
 	if err != nil {
 		u.Error("验证短信失败", zap.Error(err))
@@ -3253,18 +3403,15 @@ func (u *User) loginCheckPhone(c *wkhttp.Context) {
 		return
 	}
 	token := util.GenerUUID()
-	// 将token设置到缓存
-	tokenPayload, err := auth.Encode(auth.TokenInfo{
-		UID:      userInfo.UID,
-		Name:     userInfo.Name,
-		Language: userInfo.Language,
-	})
-	if err != nil {
-		u.Error("编码token缓存失败！", zap.Error(err))
-		respondUserError(c, errcode.ErrUserStoreFailed)
-		return
+	sessionInfo := auth.TokenInfo{
+		UID:        userInfo.UID,
+		Name:       userInfo.Name,
+		Role:       userInfo.Role,
+		Language:   userInfo.Language,
+		DeviceFlag: int(config.APP),
+		DeviceID:   loginDeivce.DeviceID,
 	}
-	err = u.replaceAPPToken(spanCtx, token, tokenPayload, userInfo.UID)
+	err = u.replaceAPPTokenSession(spanCtx, token, sessionInfo, issueFence)
 	if err != nil {
 		u.Error("设置token缓存失败！", zap.Error(err))
 		respondUserError(c, errcode.ErrUserStoreFailed)
@@ -3395,7 +3542,16 @@ func (u *User) destroyAccount(c *wkhttp.Context) {
 	stamp := strconv.FormatInt(time.Now().UnixMilli(), 10)
 	phone := fmt.Sprintf("%s@%s@delete", userInfo.Phone, stamp)
 	username := anonymizeUsername(loginUID, userInfo.Zone, phone, stamp)
-	err = u.db.destroyAccount(loginUID, username, phone)
+	if sessionRevocationActive(u.sessionStore) {
+		intent, mutateErr := u.db.destroyAccountWithSessionRevocation(c.Request.Context(), loginUID, username, phone, IsDestroyNo)
+		if mutateErr == nil {
+			err = u.applySessionRevocationIntent(c.Request.Context(), intent)
+		} else {
+			err = mutateErr
+		}
+	} else {
+		err = u.db.destroyAccount(loginUID, username, phone)
+	}
 	if err != nil {
 		u.Error("注销账号错误", zap.Error(err))
 		respondUserError(c, errcode.ErrUserDestroyFailed)
@@ -3673,7 +3829,7 @@ func (u *User) pwdforget(c *wkhttp.Context) {
 		respondUserError(c, errcode.ErrUserPasswordProcessFailed)
 		return
 	}
-	err = u.db.UpdateUsersWithField("password", hashedPassword, userInfo.UID)
+	err = updateUserFieldAndRevokeSessions(c.Request.Context(), u.db, u.sessionStore, userInfo.UID, "password", hashedPassword, "password_reset")
 	if err != nil {
 		u.Error("修改登录密码错误", zap.Error(err))
 		respondUserError(c, errcode.ErrUserLoginPwdUpdateFailed)
@@ -3909,18 +4065,24 @@ func (u *User) createUserWithRespAndTx(registerSpanCtx context.Context, createUs
 	}
 	u.ctx.EventCommit(eventID)
 	token := util.GenerUUID()
-	// 将token设置到缓存
-	tokenPayload, err := auth.Encode(auth.TokenInfo{
-		UID:      userModel.UID,
-		Name:     userModel.Name,
-		Role:     userModel.Role,
-		Language: userModel.Language,
-	})
+	issueFence, err := beginUserSessionIssue(registerSpanCtx, u.sessionStore, userModel.UID)
 	if err != nil {
-		u.Error("编码token缓存失败！", zap.Error(err))
+		u.Error("初始化注册登录会话栅栏失败", zap.Error(err))
 		return nil, err
 	}
-	err = u.sessionStore.IssueNew(registerSpanCtx, token, tokenPayload, userModel.UID, createUser.Flag)
+	deviceID := ""
+	if createUser.Device != nil {
+		deviceID = createUser.Device.DeviceID
+	}
+	sessionInfo := auth.TokenInfo{
+		UID:        userModel.UID,
+		Name:       userModel.Name,
+		Role:       userModel.Role,
+		Language:   userModel.Language,
+		DeviceFlag: createUser.Flag,
+		DeviceID:   deviceID,
+	}
+	err = issueUserSession(registerSpanCtx, u.sessionStore, token, sessionInfo, issueFence)
 	if err != nil {
 		u.Error("设置token缓存失败！", zap.Error(err))
 		return nil, err

--- a/modules/user/api.go
+++ b/modules/user/api.go
@@ -1997,10 +1997,12 @@ func updateUserSessionSnapshot(ctx context.Context, store userSessionStore, toke
 }
 
 func invalidateCurrentUserToken(ctx context.Context, store userSessionStore, uid, token string) error {
+	securityCtx, cancel := postCommitSecurityContext(ctx)
+	defer cancel()
 	if invalidator, ok := store.(currentUserTokenInvalidator); ok {
-		return invalidator.InvalidateCurrentToken(ctx, uid, token)
+		return invalidator.InvalidateCurrentToken(securityCtx, uid, token)
 	}
-	return store.DeleteToken(ctx, token)
+	return store.DeleteToken(securityCtx, token)
 }
 
 func (u *User) compensateIssuedToken(token, uid string, deviceFlag int) error {

--- a/modules/user/api_authcode_token_test.go
+++ b/modules/user/api_authcode_token_test.go
@@ -29,17 +29,17 @@ func TestLoginWithAuthCode_ReusedTokenGuardedBySetXX(t *testing.T) {
 	fnBody := body[fnStart : fnStart+len(fnSig)+fnEnd]
 
 	// 1. 复用旧 token 必须走 Session Store 的保 deadline 守卫。
-	assert.Contains(t, fnBody, "u.reuseExistingLoginToken(",
+	assert.Contains(t, fnBody, "reuseUserSession(",
 		"loginWithAuthCode 复用旧 token 必须经 Session Store 校验,避免复活或续期已登出 token")
 
 	// 2. 必须保留 reuseExistingToken 标记,IssueNew 只能在新签发分支执行。
 	assert.Contains(t, fnBody, "if !reuseExistingToken {",
 		"loginWithAuthCode 只能在 !reuseExistingToken 分支签发新 token")
-	assert.Contains(t, fnBody, "u.sessionStore.IssueNew(",
+	assert.Contains(t, fnBody, "issueUserSession(",
 		"loginWithAuthCode 新 token 必须通过 Session Store 签发")
 
 	// 3. token 缓存的最终决策必须在调用 IM 之前完成,否则 IM 会拿到回退前的旧 token。
-	guardIdx := strings.Index(fnBody, "u.reuseExistingLoginToken(")
+	guardIdx := strings.Index(fnBody, "reuseUserSession(")
 	imIdx := strings.Index(fnBody, "u.ctx.UpdateIMToken(")
 	require.NotEqual(t, -1, imIdx, "loginWithAuthCode 必须调用 UpdateIMToken")
 	assert.Less(t, guardIdx, imIdx,

--- a/modules/user/api_destroy.go
+++ b/modules/user/api_destroy.go
@@ -1,6 +1,7 @@
 package user
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
@@ -195,7 +196,18 @@ func (u *User) finalizeDestroy(m *Model) error {
 	stamp := strconv.FormatInt(time.Now().UnixMilli(), 10)
 	phone := fmt.Sprintf("%s@%s@delete", m.Phone, stamp)
 	username := anonymizeUsername(m.UID, m.Zone, phone, stamp)
-	switch err := u.db.finalizeDestroyAccount(m.UID, username, phone); err {
+	var destroyErr error
+	if sessionRevocationActive(u.sessionStore) {
+		intent, err := u.db.destroyAccountWithSessionRevocation(context.Background(), m.UID, username, phone, IsDestroyApplying)
+		if err == nil {
+			destroyErr = u.applySessionRevocationIntent(context.Background(), intent)
+		} else {
+			destroyErr = err
+		}
+	} else {
+		destroyErr = u.db.finalizeDestroyAccount(m.UID, username, phone)
+	}
+	switch destroyErr {
 	case nil:
 		// 写入成功
 	case ErrDestroyStateConflict:
@@ -203,7 +215,7 @@ func (u *User) finalizeDestroy(m *Model) error {
 		u.Info("用户已撤销注销，跳过 finalize", zap.String("uid", m.UID))
 		return nil
 	default:
-		return fmt.Errorf("update user destroy: %w", err)
+		return fmt.Errorf("update user destroy: %w", destroyErr)
 	}
 	if err := u.ctx.QuitUserDevice(m.UID, -1); err != nil {
 		// 设备踢出失败不阻塞 DB 状态更新——一旦写入 is_destroy=2，下次扫描不会再处理本账号。

--- a/modules/user/api_destroy.go
+++ b/modules/user/api_destroy.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"strconv"
 	"time"
@@ -196,31 +197,41 @@ func (u *User) finalizeDestroy(m *Model) error {
 	stamp := strconv.FormatInt(time.Now().UnixMilli(), 10)
 	phone := fmt.Sprintf("%s@%s@delete", m.Phone, stamp)
 	username := anonymizeUsername(m.UID, m.Zone, phone, stamp)
-	var destroyErr error
+	// DB 事务错误和提交后的 Redis 撤销错误必须分开：一旦事务提交（is_destroy=2），
+	// checkDestroyExpired 不会再选中本账号，提交后的 side effect 没有第二次机会。
+	// 把两者合成一个 error 会让 Redis 故障吞掉独立的 WuKongIM 全端登出——HTTP 撤销
+	// 有 outbox worker 兜底，IM 登出没有。
+	committed := false
+	var mutationErr, revocationErr error
 	if sessionRevocationActive(u.sessionStore) {
 		intent, err := u.db.destroyAccountWithSessionRevocation(context.Background(), m.UID, username, phone, IsDestroyApplying)
-		if err == nil {
-			destroyErr = u.applySessionRevocationIntent(context.Background(), intent)
+		if err != nil {
+			mutationErr = err
 		} else {
-			destroyErr = err
+			committed = true
+			revocationErr = u.applySessionRevocationIntent(context.Background(), intent)
 		}
 	} else {
-		destroyErr = u.db.finalizeDestroyAccount(m.UID, username, phone)
+		mutationErr = u.db.finalizeDestroyAccount(m.UID, username, phone)
+		committed = mutationErr == nil
 	}
-	switch destroyErr {
-	case nil:
-		// 写入成功
-	case ErrDestroyStateConflict:
-		// 用户在我们选中后、写入前撤销了注销。直接跳过，下一轮扫描不会再选中（is_destroy 已经回到 0）。
-		u.Info("用户已撤销注销，跳过 finalize", zap.String("uid", m.UID))
-		return nil
-	default:
-		return fmt.Errorf("update user destroy: %w", destroyErr)
+	if !committed {
+		if errors.Is(mutationErr, ErrDestroyStateConflict) {
+			// 用户在我们选中后、写入前撤销了注销。直接跳过，下一轮扫描不会再选中（is_destroy 已经回到 0）。
+			u.Info("用户已撤销注销，跳过 finalize", zap.String("uid", m.UID))
+			return nil
+		}
+		return fmt.Errorf("update user destroy: %w", mutationErr)
 	}
-	if err := u.ctx.QuitUserDevice(m.UID, -1); err != nil {
-		// 设备踢出失败不阻塞 DB 状态更新——一旦写入 is_destroy=2，下次扫描不会再处理本账号。
-		// 已知遗留风险：device 在 token 过期前仍能短暂访问；需要单独的 device-evict 重试任务（见 PR2）。
-		u.Error("踢出登录设备失败", zap.String("uid", m.UID), zap.Error(err))
+	// 已提交：撤销残留 bearer 并踢出全部 IM 设备，两者互不阻塞。
+	// 定时任务没有调用方可以重试，且 is_destroy=2 后本账号不会再被扫描到，
+	// 所以这里只记录错误而不上抛——否则批次日志会把「DB 已成功、撤销待收敛」
+	// 误报成 finalize 失败。HTTP 撤销由 revocation worker 收敛；IM 登出失败
+	// 仍是已知遗留风险（device 在 token 过期前仍能短暂访问）。
+	if err := finishCommittedUserSecurityMutation(
+		context.Background(), u.sessionStore, m.UID, true, revocationErr, u.ctx.QuitUserDevice,
+	); err != nil {
+		u.Error("到期注销后清理登录态未完成", zap.String("uid", m.UID), zap.Error(err))
 	}
 	u.Info("已执行到期注销", zap.String("uid", m.UID))
 	return nil

--- a/modules/user/api_emaillogin.go
+++ b/modules/user/api_emaillogin.go
@@ -288,6 +288,12 @@ func (u *User) emailLogin(c *wkhttp.Context) {
 		respondUserError(c, errcode.ErrUserNotFound)
 		return
 	}
+	loginSpanCtx, err = withUserSessionIssueFence(loginSpanCtx, u.sessionStore, userInfo.UID)
+	if err != nil {
+		u.Error("初始化邮箱登录会话栅栏失败", zap.Error(err))
+		respondUserServiceError(c)
+		return
+	}
 	if userInfo.IsDestroy == IsDestroyDone || userInfo.Status == 0 {
 		// 密码路径同样泄露账号状态，统一为通用错误 + 计入失败计数
 		if req.Password != "" {
@@ -385,7 +391,7 @@ func (u *User) emailForgetPwd(c *wkhttp.Context) {
 		respondUserError(c, errcode.ErrUserPasswordProcessFailed)
 		return
 	}
-	if err := u.db.updatePassword(newHash, userInfo.UID); err != nil {
+	if err := updateUserFieldAndRevokeSessions(c.Request.Context(), u.db, u.sessionStore, userInfo.UID, "password", newHash, "password_reset"); err != nil {
 		u.Error("更新密码失败", zap.Error(err))
 		respondUserError(c, errcode.ErrUserLoginPwdUpdateFailed)
 		return

--- a/modules/user/api_emaillogin.go
+++ b/modules/user/api_emaillogin.go
@@ -288,10 +288,26 @@ func (u *User) emailLogin(c *wkhttp.Context) {
 		respondUserError(c, errcode.ErrUserNotFound)
 		return
 	}
+	fencedUID := userInfo.UID
 	loginSpanCtx, err = withUserSessionIssueFence(loginSpanCtx, u.sessionStore, userInfo.UID)
 	if err != nil {
 		u.Error("初始化邮箱登录会话栅栏失败", zap.Error(err))
 		respondUserServiceError(c)
+		return
+	}
+	userInfo, err = u.db.QueryByEmail(req.Email)
+	if err != nil {
+		u.Error("会话栅栏后复核邮箱登录用户失败", zap.String("email", req.Email), zap.Error(err))
+		respondUserError(c, errcode.ErrUserQueryFailed)
+		return
+	}
+	if userInfo == nil || userInfo.UID != fencedUID {
+		if req.Password != "" {
+			u.loginGuard.RecordFailureLogged(req.Email)
+			respondUserError(c, errcode.ErrUserInvalidCredentials)
+			return
+		}
+		respondUserError(c, errcode.ErrUserNotFound)
 		return
 	}
 	if userInfo.IsDestroy == IsDestroyDone || userInfo.Status == 0 {

--- a/modules/user/api_emaillogin.go
+++ b/modules/user/api_emaillogin.go
@@ -407,7 +407,7 @@ func (u *User) emailForgetPwd(c *wkhttp.Context) {
 		respondUserError(c, errcode.ErrUserPasswordProcessFailed)
 		return
 	}
-	if err := updateUserFieldAndRevokeSessions(c.Request.Context(), u.db, u.sessionStore, userInfo.UID, "password", newHash, "password_reset"); err != nil {
+	if err := updatePasswordAndRevokeSessions(c.Request.Context(), u.db, u.sessionStore, u.ctx.QuitUserDevice, userInfo.UID, newHash, "password_reset"); err != nil {
 		u.Error("更新密码失败", zap.Error(err))
 		respondUserError(c, errcode.ErrUserLoginPwdUpdateFailed)
 		return

--- a/modules/user/api_gitee.go
+++ b/modules/user/api_gitee.go
@@ -137,6 +137,12 @@ func (u *User) giteeOAuth(c *wkhttp.Context) {
 
 	var loginResp *loginUserDetailResp
 	if userInfoM != nil { // 存在就登录
+		loginSpanCtx, err = withUserSessionIssueFence(loginSpanCtx, u.sessionStore, userInfoM.UID)
+		if err != nil {
+			u.Error("初始化 Gitee 登录会话栅栏失败", zap.Error(err))
+			respondUserServiceError(c)
+			return
+		}
 		if userInfoM.IsDestroy == IsDestroyDone {
 			respondUserError(c, errcode.ErrUserNotFound)
 			return

--- a/modules/user/api_gitee.go
+++ b/modules/user/api_gitee.go
@@ -143,6 +143,16 @@ func (u *User) giteeOAuth(c *wkhttp.Context) {
 			respondUserServiceError(c)
 			return
 		}
+		userInfoM, err = u.reloadUserAfterIssueFence(loginSpanCtx, userInfoM.UID)
+		if err != nil {
+			if errors.Is(err, ErrorUserNotExist) {
+				respondUserError(c, errcode.ErrUserNotFound)
+				return
+			}
+			u.Error("会话栅栏后复核 Gitee 登录用户失败", zap.Error(err))
+			respondUserError(c, errcode.ErrUserQueryFailed)
+			return
+		}
 		if userInfoM.IsDestroy == IsDestroyDone {
 			respondUserError(c, errcode.ErrUserNotFound)
 			return

--- a/modules/user/api_github.go
+++ b/modules/user/api_github.go
@@ -73,6 +73,12 @@ func (u *User) githubOAuth(c *wkhttp.Context) {
 
 	var loginResp *loginUserDetailResp
 	if userInfoM != nil { // 存在就登录
+		loginSpanCtx, err = withUserSessionIssueFence(loginSpanCtx, u.sessionStore, userInfoM.UID)
+		if err != nil {
+			u.Error("初始化 GitHub 登录会话栅栏失败", zap.Error(err))
+			respondUserServiceError(c)
+			return
+		}
 		if userInfoM.IsDestroy == IsDestroyDone {
 			respondUserError(c, errcode.ErrUserNotFound)
 			return

--- a/modules/user/api_github.go
+++ b/modules/user/api_github.go
@@ -79,6 +79,16 @@ func (u *User) githubOAuth(c *wkhttp.Context) {
 			respondUserServiceError(c)
 			return
 		}
+		userInfoM, err = u.reloadUserAfterIssueFence(loginSpanCtx, userInfoM.UID)
+		if err != nil {
+			if errors.Is(err, ErrorUserNotExist) {
+				respondUserError(c, errcode.ErrUserNotFound)
+				return
+			}
+			u.Error("会话栅栏后复核 GitHub 登录用户失败", zap.Error(err))
+			respondUserError(c, errcode.ErrUserQueryFailed)
+			return
+		}
 		if userInfoM.IsDestroy == IsDestroyDone {
 			respondUserError(c, errcode.ErrUserNotFound)
 			return

--- a/modules/user/api_login_token_test.go
+++ b/modules/user/api_login_token_test.go
@@ -137,7 +137,7 @@ func TestLoginCheckPhoneUsesAPPTokenReplacementBeforeIMUpdate(t *testing.T) {
 				return true
 			}
 			switch selector.Sel.Name {
-			case "replaceAPPToken":
+			case "replaceAPPToken", "replaceAPPTokenSession":
 				replacePos = call.Pos()
 			case "UpdateIMToken":
 				imPos = call.Pos()

--- a/modules/user/api_manager.go
+++ b/modules/user/api_manager.go
@@ -1085,19 +1085,36 @@ func (m *Manager) liftBanUser(c *wkhttp.Context) {
 		respondUserError(c, errcode.ErrUserNotFound)
 		return
 	}
-	if userInfo.Status == userStatus {
+	alreadyInState := userInfo.Status == userStatus
+	disabling := userStatus == int(common.UserDisable)
+	if alreadyInState && !disabling {
 		c.ResponseOK()
 		return
 	}
 	var securityErr error
-	if userStatus == int(common.UserDisable) {
-		committed, mutationErr := updateUserFieldAndRevokeSessionsWithResult(c.Request.Context(), m.userDB, m.sessionStore, uid, "status", status, "account_disable")
-		if !committed {
-			m.Error("修改用户状态错误", zap.Error(mutationErr))
-			respondUserError(c, errcode.ErrUserStoreFailed)
-			return
+	var mutationErr error
+	committed := false
+	if disabling {
+		if alreadyInState {
+			committed = true
+			if sessionRevocationActive(m.sessionStore) {
+				retryCtx, cancel := postCommitSecurityContext(c.Request.Context())
+				pending, pendingErr := m.userDB.pendingSessionRevocation(retryCtx, uid, "account_disable")
+				if pendingErr != nil {
+					mutationErr = pendingErr
+				} else if pending != nil {
+					mutationErr = applyAndMarkSessionRevocation(retryCtx, m.userDB, m.sessionStore, pending)
+				}
+				cancel()
+			}
+		} else {
+			committed, mutationErr = updateUserFieldAndRevokeSessionsWithResult(c.Request.Context(), m.userDB, m.sessionStore, uid, "status", status, "account_disable")
+			if !committed {
+				m.Error("修改用户状态错误", zap.Error(mutationErr))
+				respondUserError(c, errcode.ErrUserStoreFailed)
+				return
+			}
 		}
-		securityErr = finishCommittedUserSecurityMutation(c.Request.Context(), m.sessionStore, uid, committed, mutationErr, m.ctx.QuitUserDevice)
 	} else if err = m.userDB.UpdateUsersWithField("status", status, uid); err != nil {
 		m.Error("修改用户状态错误", zap.Error(err))
 		respondUserError(c, errcode.ErrUserStoreFailed)
@@ -1105,7 +1122,7 @@ func (m *Manager) liftBanUser(c *wkhttp.Context) {
 	}
 
 	ban := 0
-	if userStatus == int(common.UserDisable) {
+	if disabling {
 		ban = 1
 	}
 
@@ -1118,7 +1135,9 @@ func (m *Manager) liftBanUser(c *wkhttp.Context) {
 		m.Error("更新WebIM的token失败！", zap.Error(channelErr))
 	}
 	var quitErr error
-	if userStatus != int(common.UserDisable) {
+	if disabling {
+		securityErr = finishCommittedUserSecurityMutation(c.Request.Context(), m.sessionStore, uid, committed, mutationErr, m.ctx.QuitUserDevice)
+	} else {
 		quitErr = m.ctx.QuitUserDevice(userInfo.UID, -1)
 		if quitErr != nil {
 			m.Error("下线用户所有登录设备错误", zap.Error(quitErr), zap.String("uid", uid))

--- a/modules/user/api_manager.go
+++ b/modules/user/api_manager.go
@@ -283,7 +283,8 @@ func (m *Manager) login(c *wkhttp.Context) {
 		respondUserError(c, errcode.ErrUserQueryFailed)
 		return
 	}
-	if userInfo == nil || userInfo.UID != fencedUID {
+	if userInfo == nil || userInfo.UID != fencedUID ||
+		userInfo.Status == int(common.UserDisable) || userInfo.IsDestroy == IsDestroyDone {
 		respondUserError(c, errcode.ErrUserInvalidCredentials)
 		return
 	}

--- a/modules/user/api_manager.go
+++ b/modules/user/api_manager.go
@@ -1087,10 +1087,6 @@ func (m *Manager) liftBanUser(c *wkhttp.Context) {
 	}
 	alreadyInState := userInfo.Status == userStatus
 	disabling := userStatus == int(common.UserDisable)
-	if alreadyInState && !disabling {
-		c.ResponseOK()
-		return
-	}
 	var securityErr error
 	var mutationErr error
 	committed := false
@@ -1115,10 +1111,12 @@ func (m *Manager) liftBanUser(c *wkhttp.Context) {
 				return
 			}
 		}
-	} else if err = m.userDB.UpdateUsersWithField("status", status, uid); err != nil {
-		m.Error("修改用户状态错误", zap.Error(err))
-		respondUserError(c, errcode.ErrUserStoreFailed)
-		return
+	} else if !alreadyInState {
+		if err = m.userDB.UpdateUsersWithField("status", status, uid); err != nil {
+			m.Error("修改用户状态错误", zap.Error(err))
+			respondUserError(c, errcode.ErrUserStoreFailed)
+			return
+		}
 	}
 
 	ban := 0

--- a/modules/user/api_manager.go
+++ b/modules/user/api_manager.go
@@ -276,6 +276,17 @@ func (m *Manager) login(c *wkhttp.Context) {
 		respondUserError(c, errcode.ErrUserTokenCacheFailed)
 		return
 	}
+	fencedUID := userInfo.UID
+	userInfo, err = m.db.queryUserInfoWithNameAndPwd(req.Username)
+	if err != nil {
+		m.Error("会话栅栏后复核管理端用户失败", zap.Error(err))
+		respondUserError(c, errcode.ErrUserQueryFailed)
+		return
+	}
+	if userInfo == nil || userInfo.UID != fencedUID {
+		respondUserError(c, errcode.ErrUserInvalidCredentials)
+		return
+	}
 	matched, needsMigration := CheckPassword(req.Password, userInfo.Password)
 	if !matched {
 		respondUserError(c, errcode.ErrUserInvalidCredentials)

--- a/modules/user/api_manager.go
+++ b/modules/user/api_manager.go
@@ -270,6 +270,12 @@ func (m *Manager) login(c *wkhttp.Context) {
 		respondUserError(c, errcode.ErrUserInvalidCredentials)
 		return
 	}
+	issueFence, err := beginUserSessionIssue(c.Request.Context(), m.sessionStore, userInfo.UID)
+	if err != nil {
+		m.Error("初始化管理端登录会话栅栏失败", zap.Error(err))
+		respondUserError(c, errcode.ErrUserTokenCacheFailed)
+		return
+	}
 	matched, needsMigration := CheckPassword(req.Password, userInfo.Password)
 	if !matched {
 		respondUserError(c, errcode.ErrUserInvalidCredentials)
@@ -286,19 +292,14 @@ func (m *Manager) login(c *wkhttp.Context) {
 		return
 	}
 	token := util.GenerUUID()
-	// 将token设置到缓存
-	tokenPayload, err := auth.Encode(auth.TokenInfo{
-		UID:      userInfo.UID,
-		Name:     userInfo.Name,
-		Role:     userInfo.Role,
-		Language: userInfo.Language,
-	})
-	if err != nil {
-		m.Error("编码token缓存失败！", zap.Error(err))
-		respondUserError(c, errcode.ErrUserTokenCacheFailed)
-		return
+	sessionInfo := auth.TokenInfo{
+		UID:        userInfo.UID,
+		Name:       userInfo.Name,
+		Role:       userInfo.Role,
+		Language:   userInfo.Language,
+		DeviceFlag: int(config.Web),
 	}
-	err = m.sessionStore.IssueNew(c.Request.Context(), token, tokenPayload, userInfo.UID, int(config.Web))
+	err = issueUserSession(c.Request.Context(), m.sessionStore, token, sessionInfo, issueFence)
 	if err != nil {
 		m.Error("设置管理端token缓存失败！", zap.Error(err))
 		respondUserError(c, errcode.ErrUserTokenCacheFailed)
@@ -360,7 +361,7 @@ func (m *Manager) resetUserPassword(c *wkhttp.Context) {
 		respondUserError(c, errcode.ErrUserPasswordProcessFailed)
 		return
 	}
-	err = m.userDB.UpdateUsersWithField("password", newHash, req.Uid)
+	err = updateUserFieldAndRevokeSessions(c.Request.Context(), m.userDB, m.sessionStore, req.Uid, "password", newHash, "password_reset")
 	if err != nil {
 		m.Error("重置用户密码错误", zap.Error(err))
 		respondUserError(c, errcode.ErrUserLoginPwdUpdateFailed)
@@ -399,7 +400,16 @@ func (m *Manager) deleteAdminUsers(c *wkhttp.Context) {
 		respondUserError(c, errcode.ErrUserCannotDeleteSuperAdmin)
 		return
 	}
-	err = m.db.deleteUserWithUIDAndRole(uid, string(wkhttp.Admin))
+	if sessionRevocationActive(m.sessionStore) {
+		intent, mutateErr := m.userDB.deleteAdminWithSessionRevocation(c.Request.Context(), uid, string(wkhttp.Admin))
+		if mutateErr == nil {
+			err = applyAndMarkSessionRevocation(c.Request.Context(), m.userDB, m.sessionStore, intent)
+		} else {
+			err = mutateErr
+		}
+	} else {
+		err = m.db.deleteUserWithUIDAndRole(uid, string(wkhttp.Admin))
+	}
 	if err != nil {
 		m.Error("删除管理员错误", zap.Error(err))
 		respondUserError(c, errcode.ErrUserStoreFailed)
@@ -413,10 +423,12 @@ func (m *Manager) deleteAdminUsers(c *wkhttp.Context) {
 	m.roleService.Invalidate(user.UID)
 	// 撤销该管理员在所有设备端（APP/Web/PC）的登录态，而不只是 Web。尽力删除每个端
 	// （不在首个错误就中断），最大化吊销面；任一失败仍向调用方报错以便排查。
-	if err := m.revokeAllDeviceTokens(user.UID); err != nil {
-		m.Error("清除管理员token数据错误", zap.Error(err), zap.String("uid", user.UID))
-		respondUserError(c, errcode.ErrUserTokenCacheFailed)
-		return
+	if !sessionRevocationActive(m.sessionStore) {
+		if err := m.revokeAllDeviceTokens(user.UID); err != nil {
+			m.Error("清除管理员token数据错误", zap.Error(err), zap.String("uid", user.UID))
+			respondUserError(c, errcode.ErrUserTokenCacheFailed)
+			return
+		}
 	}
 	c.ResponseOK()
 }
@@ -1069,7 +1081,11 @@ func (m *Manager) liftBanUser(c *wkhttp.Context) {
 		c.ResponseOK()
 		return
 	}
-	err = m.userDB.UpdateUsersWithField("status", status, uid)
+	if userStatus == int(common.UserDisable) {
+		err = updateUserFieldAndRevokeSessions(c.Request.Context(), m.userDB, m.sessionStore, uid, "status", status, "account_disable")
+	} else {
+		err = m.userDB.UpdateUsersWithField("status", status, uid)
+	}
 	if err != nil {
 		m.Error("修改用户状态错误", zap.Error(err))
 		respondUserError(c, errcode.ErrUserStoreFailed)
@@ -1150,25 +1166,28 @@ func (m *Manager) updatePwd(c *wkhttp.Context) {
 		respondUserError(c, errcode.ErrUserPasswordProcessFailed)
 		return
 	}
-	err = m.userDB.UpdateUsersWithField("password", newHashedPassword, loginUID)
+	err = updateUserFieldAndRevokeSessions(c.Request.Context(), m.userDB, m.sessionStore, loginUID, "password", newHashedPassword, "password_change")
 	if err != nil {
 		m.Error("修改用户密码错误", zap.Error(err))
 		respondUserError(c, errcode.ErrUserLoginPwdUpdateFailed)
 		return
 	}
-	// 清除token缓存
-	oldToken, err := m.ctx.Cache().Get(fmt.Sprintf("%s%d%s", m.ctx.GetConfig().Cache.UIDTokenCachePrefix, config.Web, user.UID))
-	if err != nil {
-		m.Error("获取旧token错误", zap.Error(err))
-		respondUserError(c, errcode.ErrUserTokenCacheFailed)
-		return
-	}
-	if oldToken != "" {
-		err = m.ctx.Cache().Delete(m.ctx.GetConfig().Cache.TokenCachePrefix + oldToken)
+	if !sessionRevocationActive(m.sessionStore) {
+		// expand/v3-write compatibility path; revoke mode already rotated the
+		// generation and persisted a legacy deny marker above.
+		oldToken, err := m.ctx.Cache().Get(fmt.Sprintf("%s%d%s", m.ctx.GetConfig().Cache.UIDTokenCachePrefix, config.Web, user.UID))
 		if err != nil {
-			m.Error("清除旧token数据错误", zap.Error(err))
+			m.Error("获取旧token错误", zap.Error(err))
 			respondUserError(c, errcode.ErrUserTokenCacheFailed)
 			return
+		}
+		if oldToken != "" {
+			err = m.ctx.Cache().Delete(m.ctx.GetConfig().Cache.TokenCachePrefix + oldToken)
+			if err != nil {
+				m.Error("清除旧token数据错误", zap.Error(err))
+				respondUserError(c, errcode.ErrUserTokenCacheFailed)
+				return
+			}
 		}
 	}
 	c.ResponseOK()

--- a/modules/user/api_manager.go
+++ b/modules/user/api_manager.go
@@ -421,7 +421,12 @@ func (m *Manager) deleteAdminUsers(c *wkhttp.Context) {
 	// 撤销该管理员在所有设备端（APP/Web/PC）的登录态，而不只是 Web。尽力删除每个端
 	// （不在首个错误就中断），最大化吊销面；任一失败仍向调用方报错以便排查。
 	if !sessionRevocationActive(m.sessionStore) {
-		if err := m.revokeAllDeviceTokens(c.Request.Context(), user.UID); err != nil {
+		// user 行已被硬删除，且兼容模式下没有持久化的 revocation intent 兜底：
+		// 这是唯一一次撤销机会。必须脱离请求 context，否则客户端断开即永久跳过，
+		// 运维和 runtime 都没有收敛路径。
+		securityCtx, cancel := postCommitSecurityContext(c.Request.Context())
+		defer cancel()
+		if err := m.revokeAllDeviceTokens(securityCtx, user.UID); err != nil {
 			m.Error("清除管理员token数据错误", zap.Error(err), zap.String("uid", user.UID))
 			respondUserError(c, errcode.ErrUserTokenCacheFailed)
 			return

--- a/modules/user/api_manager.go
+++ b/modules/user/api_manager.go
@@ -1,6 +1,7 @@
 package user
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"runtime/debug"
@@ -10,7 +11,6 @@ import (
 
 	"github.com/Mininglamp-OSS/octo-lib/common"
 	"github.com/Mininglamp-OSS/octo-lib/config"
-	"github.com/Mininglamp-OSS/octo-lib/pkg/cache"
 	"github.com/Mininglamp-OSS/octo-server/modules/base/event"
 	common2 "github.com/Mininglamp-OSS/octo-server/modules/common"
 	"github.com/Mininglamp-OSS/octo-server/pkg/auth"
@@ -412,37 +412,41 @@ func (m *Manager) deleteAdminUsers(c *wkhttp.Context) {
 		respondUserError(c, errcode.ErrUserCannotDeleteSuperAdmin)
 		return
 	}
-	if sessionRevocationActive(m.sessionStore) {
-		intent, mutateErr := m.userDB.deleteAdminWithSessionRevocation(c.Request.Context(), uid, string(wkhttp.Admin))
-		if mutateErr == nil {
-			err = applyAndMarkSessionRevocation(c.Request.Context(), m.userDB, m.sessionStore, intent)
-		} else {
-			err = mutateErr
-		}
-	} else {
-		err = m.db.deleteUserWithUIDAndRole(uid, string(wkhttp.Admin))
-	}
+	err = m.deleteAdminUser(c.Request.Context(), user.UID)
 	if err != nil {
 		m.Error("删除管理员错误", zap.Error(err))
 		respondUserError(c, errcode.ErrUserStoreFailed)
 		return
 	}
-	// 先失效角色热缓存，再撤销 token。DB 里该 uid 已删（权威源 role 已为空），所以
-	// 只要这里清掉 user_role:{uid} 热缓存，即便下面的 token 撤销失败、某个 token 残
-	// 留，下一请求经 RoleResolver 也会从 DB 解析出"无系统角色"而被拒。顺序反过来
-	// （先撤 token，失败就 return）会跳过 Invalidate，让旧 role 缓存存活到 TTL，
-	// 与残留 token 叠加成提权窗口——正是本 PR 要消除的（PR #364 review）。
-	m.roleService.Invalidate(user.UID)
 	// 撤销该管理员在所有设备端（APP/Web/PC）的登录态，而不只是 Web。尽力删除每个端
 	// （不在首个错误就中断），最大化吊销面；任一失败仍向调用方报错以便排查。
 	if !sessionRevocationActive(m.sessionStore) {
-		if err := m.revokeAllDeviceTokens(user.UID); err != nil {
+		if err := m.revokeAllDeviceTokens(c.Request.Context(), user.UID); err != nil {
 			m.Error("清除管理员token数据错误", zap.Error(err), zap.String("uid", user.UID))
 			respondUserError(c, errcode.ErrUserTokenCacheFailed)
 			return
 		}
 	}
 	c.ResponseOK()
+}
+
+func (m *Manager) deleteAdminUser(ctx context.Context, uid string) error {
+	if sessionRevocationActive(m.sessionStore) {
+		intent, err := m.userDB.deleteAdminWithSessionRevocation(ctx, uid, string(wkhttp.Admin))
+		if err != nil {
+			return err
+		}
+		// The transaction has committed: invalidate authorization state before
+		// attempting Redis revocation so an apply failure cannot preserve an
+		// admin role cache alongside a residual bearer.
+		m.roleService.Invalidate(uid)
+		return applyAndMarkSessionRevocation(ctx, m.userDB, m.sessionStore, intent)
+	}
+	if err := m.db.deleteUserWithUIDAndRole(uid, string(wkhttp.Admin)); err != nil {
+		return err
+	}
+	m.roleService.Invalidate(uid)
+	return nil
 }
 
 // deviceTokenRevokeFailure pairs a device flag with the error from trying to
@@ -452,17 +456,14 @@ type deviceTokenRevokeFailure struct {
 	err  error
 }
 
-// revokeDeviceTokensInCache is the cache-only, injectable core of
-// revokeAllDeviceTokens (factored out so it can be unit-tested with a fake
-// cache). It removes uid's token payload + UIDToken reverse mapping for every
-// device flag. best-effort: it does NOT abort on the first error — it attempts
-// every flag and returns one failure entry per error, so a Redis hiccup on one
-// device cannot strand the others.
-func revokeDeviceTokensInCache(c cache.Cache, uidTokenPrefix, tokenPrefix, uid string) []deviceTokenRevokeFailure {
+// revokeDeviceTokens routes every credential mutation through Session Store,
+// which owns compare-delete and v3 bounded-index cleanup. It remains
+// best-effort across device flags so one Redis error does not strand all other
+// known sessions.
+func revokeDeviceTokens(ctx context.Context, store userSessionStore, uid string) []deviceTokenRevokeFailure {
 	var failures []deviceTokenRevokeFailure
 	for _, flag := range []config.DeviceFlag{config.APP, config.Web, config.PC} {
-		uidKey := fmt.Sprintf("%s%d%s", uidTokenPrefix, flag, uid)
-		token, err := c.Get(uidKey)
+		token, err := store.DeviceToken(ctx, uid, int(flag))
 		if err != nil {
 			failures = append(failures, deviceTokenRevokeFailure{flag, err})
 			continue
@@ -470,11 +471,7 @@ func revokeDeviceTokensInCache(c cache.Cache, uidTokenPrefix, tokenPrefix, uid s
 		if token == "" {
 			continue
 		}
-		if err := c.Delete(tokenPrefix + token); err != nil {
-			failures = append(failures, deviceTokenRevokeFailure{flag, err})
-			continue
-		}
-		if err := c.Delete(uidKey); err != nil {
+		if err := revokeCurrentUserSession(ctx, store, token, uid, int(flag)); err != nil {
 			failures = append(failures, deviceTokenRevokeFailure{flag, err})
 		}
 	}
@@ -483,10 +480,9 @@ func revokeDeviceTokensInCache(c cache.Cache, uidTokenPrefix, tokenPrefix, uid s
 
 // revokeAllDeviceTokens 清除某 uid 在所有设备端（APP/Web/PC）的登录态：既删
 // token:{token} 让旧 token 立即失效，也删 UIDToken:{flag}{uid} 反查映射。
-// best-effort（见 revokeDeviceTokensInCache），逐端记日志，返回首个错误供调用方报错。
-func (m *Manager) revokeAllDeviceTokens(uid string) error {
-	cacheCfg := m.ctx.GetConfig().Cache
-	failures := revokeDeviceTokensInCache(m.ctx.Cache(), cacheCfg.UIDTokenCachePrefix, cacheCfg.TokenCachePrefix, uid)
+// best-effort（见 revokeDeviceTokens），逐端记日志，返回首个错误供调用方报错。
+func (m *Manager) revokeAllDeviceTokens(ctx context.Context, uid string) error {
+	failures := revokeDeviceTokens(ctx, m.sessionStore, uid)
 	var firstErr error
 	for _, f := range failures {
 		m.Error("撤销设备token失败", zap.Error(f.err), zap.String("uid", uid), zap.Uint8("device_flag", f.flag.Uint8()))
@@ -1187,19 +1183,10 @@ func (m *Manager) updatePwd(c *wkhttp.Context) {
 	if !sessionRevocationActive(m.sessionStore) {
 		// expand/v3-write compatibility path; revoke mode already rotated the
 		// generation and persisted a legacy deny marker above.
-		oldToken, err := m.ctx.Cache().Get(fmt.Sprintf("%s%d%s", m.ctx.GetConfig().Cache.UIDTokenCachePrefix, config.Web, user.UID))
-		if err != nil {
-			m.Error("获取旧token错误", zap.Error(err))
+		if err := m.revokeAllDeviceTokens(c.Request.Context(), user.UID); err != nil {
+			m.Error("清除旧token数据错误", zap.Error(err))
 			respondUserError(c, errcode.ErrUserTokenCacheFailed)
 			return
-		}
-		if oldToken != "" {
-			err = m.ctx.Cache().Delete(m.ctx.GetConfig().Cache.TokenCachePrefix + oldToken)
-			if err != nil {
-				m.Error("清除旧token数据错误", zap.Error(err))
-				respondUserError(c, errcode.ErrUserTokenCacheFailed)
-				return
-			}
 		}
 	}
 	c.ResponseOK()

--- a/modules/user/api_manager.go
+++ b/modules/user/api_manager.go
@@ -373,7 +373,7 @@ func (m *Manager) resetUserPassword(c *wkhttp.Context) {
 		respondUserError(c, errcode.ErrUserPasswordProcessFailed)
 		return
 	}
-	err = updateUserFieldAndRevokeSessions(c.Request.Context(), m.userDB, m.sessionStore, req.Uid, "password", newHash, "password_reset")
+	err = updatePasswordAndRevokeSessions(c.Request.Context(), m.userDB, m.sessionStore, m.ctx.QuitUserDevice, req.Uid, newHash, "password_reset")
 	if err != nil {
 		m.Error("重置用户密码错误", zap.Error(err))
 		respondUserError(c, errcode.ErrUserLoginPwdUpdateFailed)
@@ -1089,12 +1089,16 @@ func (m *Manager) liftBanUser(c *wkhttp.Context) {
 		c.ResponseOK()
 		return
 	}
+	var securityErr error
 	if userStatus == int(common.UserDisable) {
-		err = updateUserFieldAndRevokeSessions(c.Request.Context(), m.userDB, m.sessionStore, uid, "status", status, "account_disable")
-	} else {
-		err = m.userDB.UpdateUsersWithField("status", status, uid)
-	}
-	if err != nil {
+		committed, mutationErr := updateUserFieldAndRevokeSessionsWithResult(c.Request.Context(), m.userDB, m.sessionStore, uid, "status", status, "account_disable")
+		if !committed {
+			m.Error("修改用户状态错误", zap.Error(mutationErr))
+			respondUserError(c, errcode.ErrUserStoreFailed)
+			return
+		}
+		securityErr = finishCommittedUserSecurityMutation(c.Request.Context(), m.sessionStore, uid, committed, mutationErr, m.ctx.QuitUserDevice)
+	} else if err = m.userDB.UpdateUsersWithField("status", status, uid); err != nil {
 		m.Error("修改用户状态错误", zap.Error(err))
 		respondUserError(c, errcode.ErrUserStoreFailed)
 		return
@@ -1105,19 +1109,27 @@ func (m *Manager) liftBanUser(c *wkhttp.Context) {
 		ban = 1
 	}
 
-	err = m.ctx.IMCreateOrUpdateChannelInfo(&config.ChannelInfoCreateReq{
+	channelErr := m.ctx.IMCreateOrUpdateChannelInfo(&config.ChannelInfoCreateReq{
 		ChannelID:   uid,
 		ChannelType: common.ChannelTypePerson.Uint8(),
 		Ban:         ban,
 	})
-	if err != nil {
-		m.Error("更新WebIM的token失败！", zap.Error(err))
-		respondUserError(c, errcode.ErrUserIMCallFailed)
+	if channelErr != nil {
+		m.Error("更新WebIM的token失败！", zap.Error(channelErr))
+	}
+	var quitErr error
+	if userStatus != int(common.UserDisable) {
+		quitErr = m.ctx.QuitUserDevice(userInfo.UID, -1)
+		if quitErr != nil {
+			m.Error("下线用户所有登录设备错误", zap.Error(quitErr), zap.String("uid", uid))
+		}
+	}
+	if securityErr != nil {
+		m.Error("封禁用户会话撤销未同步完成", zap.Error(securityErr), zap.String("uid", uid))
+		respondUserError(c, errcode.ErrUserStoreFailed)
 		return
 	}
-	err = m.ctx.QuitUserDevice(userInfo.UID, -1)
-	if err != nil {
-		m.Error("下线用户所有登录设备错误", zap.Error(err), zap.String("uid", uid))
+	if channelErr != nil || quitErr != nil {
 		respondUserError(c, errcode.ErrUserIMCallFailed)
 		return
 	}
@@ -1174,20 +1186,11 @@ func (m *Manager) updatePwd(c *wkhttp.Context) {
 		respondUserError(c, errcode.ErrUserPasswordProcessFailed)
 		return
 	}
-	err = updateUserFieldAndRevokeSessions(c.Request.Context(), m.userDB, m.sessionStore, loginUID, "password", newHashedPassword, "password_change")
+	err = updatePasswordAndRevokeSessions(c.Request.Context(), m.userDB, m.sessionStore, m.ctx.QuitUserDevice, loginUID, newHashedPassword, "password_change")
 	if err != nil {
 		m.Error("修改用户密码错误", zap.Error(err))
 		respondUserError(c, errcode.ErrUserLoginPwdUpdateFailed)
 		return
-	}
-	if !sessionRevocationActive(m.sessionStore) {
-		// expand/v3-write compatibility path; revoke mode already rotated the
-		// generation and persisted a legacy deny marker above.
-		if err := m.revokeAllDeviceTokens(c.Request.Context(), user.UID); err != nil {
-			m.Error("清除旧token数据错误", zap.Error(err))
-			respondUserError(c, errcode.ErrUserTokenCacheFailed)
-			return
-		}
 	}
 	c.ResponseOK()
 }

--- a/modules/user/api_manager_test.go
+++ b/modules/user/api_manager_test.go
@@ -755,10 +755,8 @@ func TestManager_DeleteAdminUser_RevokesSessionsAndRoleCache(t *testing.T) {
 }
 
 func TestDeleteAdminUserInvalidatesRoleAfterCommittedRevocationFailure(t *testing.T) {
-	_, ctx := testutil.NewTestServer()
-	require.NoError(t, testutil.CleanAllTables(ctx))
-	uid := "admin-revoke-failure-" + util.GenerUUID()
-	m := NewManager(ctx)
+	_, ctx, _, m := newTokenHTTPTestServer(t)
+	uid := "arf-" + util.GenerUUID()
 	m.sessionStore = &flakyRevokeAllSessionStore{}
 	require.NoError(t, m.userDB.Insert(&Model{
 		UID: uid, Name: "admin", Role: string(wkhttp.Admin), Username: "admin_" + uid[len(uid)-12:],

--- a/modules/user/api_manager_test.go
+++ b/modules/user/api_manager_test.go
@@ -2,6 +2,7 @@ package user
 
 import (
 	"bytes"
+	"context"
 	"database/sql"
 	"encoding/json"
 	"errors"
@@ -17,6 +18,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
 	"github.com/Mininglamp-OSS/octo-lib/testutil"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAddUser(t *testing.T) {
@@ -752,27 +754,71 @@ func TestManager_DeleteAdminUser_RevokesSessionsAndRoleCache(t *testing.T) {
 	}
 }
 
+func TestDeleteAdminUserInvalidatesRoleAfterCommittedRevocationFailure(t *testing.T) {
+	_, ctx := testutil.NewTestServer()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+	uid := "admin-revoke-failure-" + util.GenerUUID()
+	m := NewManager(ctx)
+	m.sessionStore = &flakyRevokeAllSessionStore{}
+	require.NoError(t, m.userDB.Insert(&Model{
+		UID: uid, Name: "admin", Role: string(wkhttp.Admin), Username: "admin_" + uid[len(uid)-12:],
+	}))
+	require.NoError(t, ctx.Cache().Set(RoleCacheKeyPrefix+uid, string(wkhttp.Admin)))
+	t.Cleanup(func() {
+		_, _ = ctx.DB().DeleteFrom("user_session_revocation_intent").Where("uid=?", uid).Exec()
+		_, _ = ctx.DB().DeleteFrom("user_session_revocation_version").Where("uid=?", uid).Exec()
+		_, _ = ctx.DB().DeleteFrom("user").Where("uid=?", uid).Exec()
+		_ = ctx.Cache().Delete(RoleCacheKeyPrefix + uid)
+	})
+
+	err := m.deleteAdminUser(context.Background(), uid)
+	require.ErrorContains(t, err, "redis unavailable")
+	deleted, queryErr := m.userDB.QueryByUID(uid)
+	require.NoError(t, queryErr)
+	require.Nil(t, deleted, "the database mutation must already be committed")
+	cachedRole, cacheErr := ctx.Cache().Get(RoleCacheKeyPrefix + uid)
+	require.NoError(t, cacheErr)
+	require.Empty(t, cachedRole, "a committed delete must invalidate the role cache even when Redis revocation fails")
+}
+
 // TestRevokeDeviceTokensInCache_BestEffort pins that a Redis error on one device
 // flag does not abort revocation of the others (PR #364 review F2): the loop
 // attempts all three flags and reports a failure per error rather than bailing
 // on the first. Uses the shared fakeLangCache (implements cache.Cache).
-func TestRevokeDeviceTokensInCache_BestEffort(t *testing.T) {
-	c := newFakeLangCache()
-	const uidTokenPrefix, tokenPrefix, uid = "UIDTOKEN:", "TOKEN:", "u1"
+type recordingDeviceRevokeStore struct {
+	fakeUserSessionStore
+	tokens   map[int]string
+	failures map[string]error
+	revoked  []string
+}
+
+func (s *recordingDeviceRevokeStore) DeviceToken(_ context.Context, _ string, deviceFlag int) (string, error) {
+	return s.tokens[deviceFlag], nil
+}
+
+func (s *recordingDeviceRevokeStore) InvalidateCurrentToken(_ context.Context, _ string, token string) error {
+	s.revoked = append(s.revoked, token)
+	return s.failures[token]
+}
+
+func TestRevokeDeviceTokens_BestEffort(t *testing.T) {
+	const uid = "u1"
+	store := &recordingDeviceRevokeStore{
+		tokens:   make(map[int]string),
+		failures: make(map[string]error),
+	}
 	for _, fl := range []config.DeviceFlag{config.APP, config.Web, config.PC} {
 		tok := fmt.Sprintf("tok-%d", fl)
-		c.store[fmt.Sprintf("%s%d%s", uidTokenPrefix, fl, uid)] = tok
-		c.store[tokenPrefix+tok] = uid + "@x@admin"
+		store.tokens[int(fl)] = tok
+		store.failures[tok] = errors.New("redis down")
 	}
-	// Every Delete fails: a fail-fast loop would stop after flag 0; best-effort
+	// Every revocation fails: a fail-fast loop would stop after flag 0; best-effort
 	// must still attempt all three.
-	c.delErr = errors.New("redis down")
-
-	failures := revokeDeviceTokensInCache(c, uidTokenPrefix, tokenPrefix, uid)
+	failures := revokeDeviceTokens(context.Background(), store, uid)
 	if len(failures) != 3 {
 		t.Fatalf("best-effort revoke must attempt all 3 device flags despite errors, got %d failures", len(failures))
 	}
-	if len(c.deletes) < 3 {
-		t.Fatalf("expected a Delete attempt per device flag, got %d", len(c.deletes))
+	if len(store.revoked) != 3 {
+		t.Fatalf("expected a Session Store revoke attempt per device flag, got %d", len(store.revoked))
 	}
 }

--- a/modules/user/api_manager_test.go
+++ b/modules/user/api_manager_test.go
@@ -790,11 +790,17 @@ type recordingDeviceRevokeStore struct {
 	revoked  []string
 }
 
-func (s *recordingDeviceRevokeStore) DeviceToken(_ context.Context, _ string, deviceFlag int) (string, error) {
+func (s *recordingDeviceRevokeStore) DeviceToken(ctx context.Context, _ string, deviceFlag int) (string, error) {
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
 	return s.tokens[deviceFlag], nil
 }
 
-func (s *recordingDeviceRevokeStore) InvalidateCurrentToken(_ context.Context, _ string, token string) error {
+func (s *recordingDeviceRevokeStore) InvalidateCurrentToken(ctx context.Context, _ string, token string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	s.revoked = append(s.revoked, token)
 	return s.failures[token]
 }

--- a/modules/user/api_usernamelogin.go
+++ b/modules/user/api_usernamelogin.go
@@ -116,10 +116,22 @@ func (u *User) usernameLogin(c *wkhttp.Context) {
 		respondUserError(c, errcode.ErrUserInvalidCredentials)
 		return
 	}
+	fencedUID := userInfo.UID
 	loginSpanCtx, err = withUserSessionIssueFence(loginSpanCtx, u.sessionStore, userInfo.UID)
 	if err != nil {
 		u.Error("初始化用户名登录会话栅栏失败", zap.Error(err))
 		respondUserServiceError(c)
+		return
+	}
+	userInfo, err = u.db.QueryByUsernameCxt(loginSpanCtx, req.Username)
+	if err != nil {
+		u.Error("会话栅栏后复核用户名登录用户失败", zap.String("username", req.Username), zap.Error(err))
+		respondUserError(c, errcode.ErrUserQueryFailed)
+		return
+	}
+	if userInfo == nil || userInfo.UID != fencedUID {
+		u.loginGuard.RecordFailureLogged(req.Username)
+		respondUserError(c, errcode.ErrUserInvalidCredentials)
 		return
 	}
 	// 已注销账号拒绝登录；冷静期账号允许登录（响应中附带注销状态提示）

--- a/modules/user/api_usernamelogin.go
+++ b/modules/user/api_usernamelogin.go
@@ -299,9 +299,7 @@ func (u *User) resetPwdWithWeb3PublicKey(c *wkhttp.Context) {
 		respondUserError(c, errcode.ErrUserPasswordProcessFailed)
 		return
 	}
-	updateMap := map[string]interface{}{}
-	updateMap["password"] = newHash
-	err = u.db.updateUser(updateMap, user.UID)
+	err = updatePasswordAndRevokeSessions(c.Request.Context(), u.db, u.sessionStore, u.ctx.QuitUserDevice, user.UID, newHash, "password_reset")
 	if err != nil {
 		u.Error("修改用户密码错误", zap.Error(err))
 		respondUserError(c, errcode.ErrUserStoreFailed)

--- a/modules/user/api_usernamelogin.go
+++ b/modules/user/api_usernamelogin.go
@@ -542,7 +542,7 @@ func (u *User) updatePwd(c *wkhttp.Context) {
 		respondUserError(c, errcode.ErrUserPasswordProcessFailed)
 		return
 	}
-	err = updateUserFieldAndRevokeSessions(c.Request.Context(), u.db, u.sessionStore, userInfo.UID, "password", newHash, "password_change")
+	err = updatePasswordAndRevokeSessions(c.Request.Context(), u.db, u.sessionStore, u.ctx.QuitUserDevice, userInfo.UID, newHash, "password_change")
 	if err != nil {
 		u.Error("修改登录密码错误", zap.Error(err))
 		respondUserError(c, errcode.ErrUserLoginPwdUpdateFailed)

--- a/modules/user/api_usernamelogin.go
+++ b/modules/user/api_usernamelogin.go
@@ -116,6 +116,12 @@ func (u *User) usernameLogin(c *wkhttp.Context) {
 		respondUserError(c, errcode.ErrUserInvalidCredentials)
 		return
 	}
+	loginSpanCtx, err = withUserSessionIssueFence(loginSpanCtx, u.sessionStore, userInfo.UID)
+	if err != nil {
+		u.Error("初始化用户名登录会话栅栏失败", zap.Error(err))
+		respondUserServiceError(c)
+		return
+	}
 	// 已注销账号拒绝登录；冷静期账号允许登录（响应中附带注销状态提示）
 	if userInfo.IsDestroy == IsDestroyDone || userInfo.Status == 0 {
 		u.loginGuard.RecordFailureLogged(req.Username)
@@ -524,7 +530,7 @@ func (u *User) updatePwd(c *wkhttp.Context) {
 		respondUserError(c, errcode.ErrUserPasswordProcessFailed)
 		return
 	}
-	err = u.db.UpdateUsersWithField("password", newHash, userInfo.UID)
+	err = updateUserFieldAndRevokeSessions(c.Request.Context(), u.db, u.sessionStore, userInfo.UID, "password", newHash, "password_change")
 	if err != nil {
 		u.Error("修改登录密码错误", zap.Error(err))
 		respondUserError(c, errcode.ErrUserLoginPwdUpdateFailed)

--- a/modules/user/db.go
+++ b/modules/user/db.go
@@ -206,7 +206,7 @@ var allowedUpdateFields = map[string]bool{
 	"msg_show_detail": true, "voice_on": true, "shock_on": true,
 	"msg_expire_second": true, "is_upload_avatar": true,
 	"chat_pwd": true, "lock_after_minute": true, "lock_screen_pwd": true,
-	"password": true,
+	"password": true, "status": true,
 }
 
 // UpdateUsersWithField 修改用户基本资料

--- a/modules/user/db_manager.go
+++ b/modules/user/db_manager.go
@@ -160,12 +160,14 @@ func (m *managerDB) deleteUserWithUIDAndRole(uid, role string) error {
 }
 
 type managerLoginModel struct {
-	Username string
-	UID      string
-	Name     string
-	Password string
-	Role     string
-	Language string // 偏好语言快照——AuthMiddleware 上的 LanguageResolver 在 Parse 时会刷新成最新值
+	Username  string
+	UID       string
+	Name      string
+	Password  string
+	Role      string
+	Language  string // 偏好语言快照——AuthMiddleware 上的 LanguageResolver 在 Parse 时会刷新成最新值
+	Status    int
+	IsDestroy int
 }
 
 type managerUserModel struct {

--- a/modules/user/external_login.go
+++ b/modules/user/external_login.go
@@ -108,6 +108,10 @@ func (u *User) externalLoginExisting(ctx context.Context, req ExternalLoginReq) 
 	if err != nil {
 		return nil, fmt.Errorf("user: initialize external login session fence: %w", err)
 	}
+	userInfoM, err = u.reloadUserAfterIssueFence(ctx, userInfoM.UID)
+	if err != nil {
+		return nil, err
+	}
 	// IsDestroy 三态(db.go:15):0=正常 1=冷静期(可撤销) 2=已注销(终态)。
 	// 冷静期用户允许登录,登录动作即撤销注销;已注销用户拒绝。
 	// 与 api_emaillogin.go:245 / api.go:1012 等其他登录入口对齐。

--- a/modules/user/external_login.go
+++ b/modules/user/external_login.go
@@ -104,6 +104,10 @@ func (u *User) externalLoginExisting(ctx context.Context, req ExternalLoginReq) 
 	if userInfoM == nil {
 		return nil, errors.New("用户不存在")
 	}
+	ctx, err = withUserSessionIssueFence(ctx, u.sessionStore, userInfoM.UID)
+	if err != nil {
+		return nil, fmt.Errorf("user: initialize external login session fence: %w", err)
+	}
 	// IsDestroy 三态(db.go:15):0=正常 1=冷静期(可撤销) 2=已注销(终态)。
 	// 冷静期用户允许登录,登录动作即撤销注销;已注销用户拒绝。
 	// 与 api_emaillogin.go:245 / api.go:1012 等其他登录入口对齐。

--- a/modules/user/scanlogin_policy_test.go
+++ b/modules/user/scanlogin_policy_test.go
@@ -234,6 +234,46 @@ func TestScanLoginAuthorization_RequiresConfirmationAndRedeemsOnce(t *testing.T)
 	assert.Contains(t, w.Body.String(), "err.server.user.auth_code_not_found")
 }
 
+func TestScanLoginAuthorization_DisabledAccountCannotRedeemLiveCode(t *testing.T) {
+	s, ctx := testutil.NewTestServer()
+	wireI18nRendererForUserTest(s)
+	require.NoError(t, testutil.CleanAllTables(ctx))
+	enableScanLoginForUserTest(t, ctx)
+
+	db := NewDB(ctx)
+	model, err := db.QueryByUID(testutil.UID)
+	require.NoError(t, err)
+	if model == nil {
+		require.NoError(t, db.Insert(&Model{
+			UID:      testutil.UID,
+			Name:     "disabled scan login user",
+			Username: "disabled_scan_login_user",
+			ShortNo:  "scan003",
+			Status:   int(libcommon.UserAvailable),
+		}))
+	}
+
+	authCode := util.GenerUUID()
+	uuid := util.GenerUUID()
+	authInfo, err := encodeScanLoginAuthorization(testutil.UID, uuid)
+	require.NoError(t, err)
+	require.NoError(t, ctx.GetRedisConn().SetAndExpire(scanLoginReadyAuthorizationKey(authCode), authInfo, time.Minute))
+	require.NoError(t, ctx.GetRedisConn().SetAndExpire(scanLoginUUIDClaimKey(uuid), authCode, time.Minute))
+	pollSecret, err := mintScanLoginPollSecret(ctx.GetRedisConn(), uuid)
+	require.NoError(t, err)
+	_, err = db.session.Update("user").Set("status", int(libcommon.UserDisable)).Where("uid=?", testutil.UID).Exec()
+	require.NoError(t, err)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost,
+		"/v1/user/login_authcode/"+authCode+"?poll_secret="+pollSecret, nil)
+	setPublicIPForUserTest(req, "9.9.8.43")
+	s.GetRoute().ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusBadRequest, w.Code, w.Body.String())
+	assert.Contains(t, w.Body.String(), "err.server.user.account_banned")
+}
+
 func TestScanLoginAuthorization_MultipleReplicasRedeemOnce(t *testing.T) {
 	s1, ctx := testutil.NewTestServer()
 	s2, _ := testutil.NewTestServer()

--- a/modules/user/scanlogin_poll_test.go
+++ b/modules/user/scanlogin_poll_test.go
@@ -348,8 +348,8 @@ func TestLoginWithAuthCode_ConsumesBeforeIssuingSession(t *testing.T) {
 
 	assert.Contains(t, fn, "u.scanLoginPollSecretMatches(uuid, strings.TrimSpace(c.Query(scanLoginPollSecretQuery)))")
 	consume := strings.Index(fn, "u.scanLoginAuthorizations.Consume(authCode, authInfo)")
-	reuseExisting := strings.Index(fn, "u.reuseExistingLoginToken(")
-	issueNew := strings.Index(fn, "u.sessionStore.IssueNew(")
+	reuseExisting := strings.Index(fn, "reuseUserSession(")
+	issueNew := strings.Index(fn, "issueUserSession(")
 	imUpdate := strings.Index(fn, "u.ctx.UpdateIMToken")
 	require.NotEqual(t, -1, consume)
 	require.NotEqual(t, -1, reuseExisting)

--- a/modules/user/service.go
+++ b/modules/user/service.go
@@ -1234,7 +1234,7 @@ func (s *Service) UpdateLoginPassword(req UpdateLoginPasswordReq) error {
 	if hashErr != nil {
 		return hashErr
 	}
-	err = updateUserFieldAndRevokeSessions(context.Background(), s.db, s.sessionStore, req.UID, "password", newHash, "password_change")
+	err = updatePasswordAndRevokeSessions(context.Background(), s.db, s.sessionStore, s.ctx.QuitUserDevice, req.UID, newHash, "password_change")
 	if err != nil {
 		return errors.New("更新密码失败！")
 	}

--- a/modules/user/service.go
+++ b/modules/user/service.go
@@ -15,6 +15,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-server/modules/botfather/cmdmenu"
 	"github.com/Mininglamp-OSS/octo-server/modules/source"
 	"github.com/Mininglamp-OSS/octo-server/modules/space"
+	"github.com/Mininglamp-OSS/octo-server/pkg/auth"
 	octoi18n "github.com/Mininglamp-OSS/octo-server/pkg/i18n"
 	"go.uber.org/zap"
 )
@@ -237,8 +238,9 @@ type oidcBindHandler interface {
 
 // Service Service
 type Service struct {
-	ctx *config.Context
-	db  *DB
+	ctx          *config.Context
+	db           *DB
+	sessionStore userSessionStore
 	log.Log
 	friendDB         *friendDB
 	onlineDB         *onlineDB
@@ -399,6 +401,7 @@ func NewService(ctx *config.Context) IService {
 	return &Service{
 		ctx:              ctx,
 		db:               NewDB(ctx),
+		sessionStore:     auth.SessionStoreForContext(ctx),
 		friendDB:         newFriendDB(ctx),
 		settingDB:        NewSettingDB(ctx.DB()),
 		onetimePrekeysDB: newOnetimePrekeysDB(ctx),
@@ -1231,7 +1234,7 @@ func (s *Service) UpdateLoginPassword(req UpdateLoginPasswordReq) error {
 	if hashErr != nil {
 		return hashErr
 	}
-	err = s.db.updatePassword(newHash, req.UID)
+	err = updateUserFieldAndRevokeSessions(context.Background(), s.db, s.sessionStore, req.UID, "password", newHash, "password_change")
 	if err != nil {
 		return errors.New("更新密码失败！")
 	}

--- a/modules/user/session_revocation.go
+++ b/modules/user/session_revocation.go
@@ -309,9 +309,29 @@ func (d *DB) claimSessionRevocationByID(ctx context.Context, intent *sessionRevo
 		intent.LeaseUntil = &leaseUntil
 		return true, nil
 	}
-	var status uint8
-	_, loadErr := d.session.Select("status").From("user_session_revocation_intent").Where("id=?", intent.ID).LoadContext(ctx, &status)
-	if loadErr == nil && status == sessionRevocationApplied {
+	// Losing the claim is not the same as losing the revocation. Distinguish the
+	// two benign outcomes — already applied, or currently owned by someone else
+	// (normally the shared worker, which reserves the intent after the sync
+	// priority window) — from a genuine fault. Reporting a live foreign lease as
+	// an error would tell the caller their committed mutation failed and invite a
+	// second one. The lease comparison runs in SQL so it matches the claim
+	// predicate above exactly and cannot drift on driver time zones.
+	var claimState struct {
+		Status     uint8 `db:"status"`
+		LeaseAlive bool  `db:"lease_alive"`
+	}
+	loadErr := d.session.SelectBySql(
+		"SELECT status, (lease_until IS NOT NULL AND lease_until>?) AS lease_alive "+
+			"FROM user_session_revocation_intent WHERE id=?",
+		now, intent.ID,
+	).LoadOneContext(ctx, &claimState)
+	if loadErr != nil {
+		return false, fmt.Errorf("user: read synchronous revocation claim state: %w", loadErr)
+	}
+	if claimState.Status == sessionRevocationApplied {
+		return false, nil
+	}
+	if claimState.LeaseAlive {
 		return false, nil
 	}
 	return false, errors.New("user: session revocation lease ownership lost")

--- a/modules/user/session_revocation.go
+++ b/modules/user/session_revocation.go
@@ -1,0 +1,332 @@
+package user
+
+import (
+	"context"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
+	"github.com/Mininglamp-OSS/octo-server/pkg/auth"
+	"github.com/gocraft/dbr/v2"
+	"go.uber.org/zap"
+)
+
+const (
+	sessionRevocationPending = 0
+	sessionRevocationApplied = 1
+
+	sessionRevocationLease     = 30 * time.Second
+	sessionRevocationBatchSize = 20
+)
+
+var allowedSessionRevocationReasons = map[string]bool{
+	"password_change": true,
+	"password_reset":  true,
+	"account_disable": true,
+	"account_destroy": true,
+	"admin_delete":    true,
+}
+
+type sessionRevocationIntent struct {
+	ID           uint64     `db:"id"`
+	EventID      string     `db:"event_id"`
+	UID          string     `db:"uid"`
+	EventVersion uint64     `db:"event_version"`
+	Reason       string     `db:"reason"`
+	Attempts     uint32     `db:"attempts"`
+	LeaseOwner   string     `db:"lease_owner"`
+	LeaseUntil   *time.Time `db:"lease_until"`
+}
+
+type sessionRevocationMutation func(context.Context, *dbr.Tx) error
+
+func sessionRevocationActive(store userSessionStore) bool {
+	v3Store, ok := store.(v3UserSessionStore)
+	return ok && v3Store.Mode().RevokesSessions()
+}
+
+func (d *DB) updateUserFieldWithSessionRevocation(ctx context.Context, uid, field string, value interface{}, reason string) (*sessionRevocationIntent, error) {
+	if !allowedUpdateFields[field] {
+		return nil, fmt.Errorf("field %q is not allowed for update", field)
+	}
+	return d.mutateWithSessionRevocation(ctx, uid, reason, func(ctx context.Context, tx *dbr.Tx) error {
+		result, err := tx.Update("user").Set(field, value).Where("uid=?", uid).ExecContext(ctx)
+		if err != nil {
+			return fmt.Errorf("user: update %s with session revocation: %w", field, err)
+		}
+		affected, err := result.RowsAffected()
+		if err != nil {
+			return fmt.Errorf("user: read %s update result: %w", field, err)
+		}
+		if affected == 0 {
+			return errors.New("user: revocation mutation target not found or unchanged")
+		}
+		return nil
+	})
+}
+
+func (d *DB) destroyAccountWithSessionRevocation(ctx context.Context, uid, username, phone string, expectedState int) (*sessionRevocationIntent, error) {
+	return d.mutateWithSessionRevocation(ctx, uid, "account_destroy", func(ctx context.Context, tx *dbr.Tx) error {
+		result, err := tx.Update("user").SetMap(map[string]interface{}{
+			"phone":             phone,
+			"username":          username,
+			"is_destroy":        IsDestroyDone,
+			"destroy_apply_at":  nil,
+			"destroy_expire_at": nil,
+		}).Where("uid=? AND is_destroy=?", uid, expectedState).ExecContext(ctx)
+		if err != nil {
+			return fmt.Errorf("destroy account with session revocation: %w", err)
+		}
+		affected, err := result.RowsAffected()
+		if err != nil {
+			return fmt.Errorf("destroy account with session revocation rows: %w", err)
+		}
+		if affected == 0 {
+			return ErrDestroyStateConflict
+		}
+		return nil
+	})
+}
+
+func (d *DB) deleteAdminWithSessionRevocation(ctx context.Context, uid, role string) (*sessionRevocationIntent, error) {
+	return d.mutateWithSessionRevocation(ctx, uid, "admin_delete", func(ctx context.Context, tx *dbr.Tx) error {
+		result, err := tx.DeleteFrom("user").Where("uid=? AND role=?", uid, role).ExecContext(ctx)
+		if err != nil {
+			return fmt.Errorf("delete admin with session revocation: %w", err)
+		}
+		affected, err := result.RowsAffected()
+		if err != nil {
+			return fmt.Errorf("delete admin with session revocation rows: %w", err)
+		}
+		if affected == 0 {
+			return errors.New("user: admin revocation target not found")
+		}
+		return nil
+	})
+}
+
+func updateUserFieldAndRevokeSessions(ctx context.Context, db *DB, store userSessionStore, uid, field string, value interface{}, reason string) error {
+	if !sessionRevocationActive(store) {
+		return db.UpdateUsersWithField(field, fmt.Sprintf("%v", value), uid)
+	}
+	intent, err := db.updateUserFieldWithSessionRevocation(ctx, uid, field, value, reason)
+	if err != nil {
+		return err
+	}
+	return applyAndMarkSessionRevocation(ctx, db, store, intent)
+}
+
+func (d *DB) mutateWithSessionRevocation(ctx context.Context, uid, reason string, mutation sessionRevocationMutation) (*sessionRevocationIntent, error) {
+	if uid == "" || !allowedSessionRevocationReasons[reason] || mutation == nil {
+		return nil, errors.New("user: invalid session revocation mutation")
+	}
+	tx, err := d.session.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("user: begin revocation transaction: %w", err)
+	}
+	defer tx.RollbackUnlessCommitted()
+
+	if err := mutation(ctx, tx); err != nil {
+		return nil, err
+	}
+	if _, err := tx.InsertBySql(
+		"INSERT INTO user_session_revocation_version (uid, version) VALUES (?, 0) ON DUPLICATE KEY UPDATE uid=VALUES(uid)",
+		uid,
+	).ExecContext(ctx); err != nil {
+		return nil, fmt.Errorf("user: initialize revocation version: %w", err)
+	}
+	var current uint64
+	if _, err := tx.Select("version").From("user_session_revocation_version").Where("uid=?", uid).Suffix("FOR UPDATE").LoadContext(ctx, &current); err != nil {
+		return nil, fmt.Errorf("user: lock revocation version: %w", err)
+	}
+	next := current + 1
+	if next == 0 {
+		return nil, errors.New("user: session revocation version exhausted")
+	}
+	if _, err := tx.UpdateBySql(
+		"UPDATE user_session_revocation_version SET version=?, updated_at=? WHERE uid=? AND version=?",
+		next, time.Now().UTC(), uid, current,
+	).ExecContext(ctx); err != nil {
+		return nil, fmt.Errorf("user: advance revocation version: %w", err)
+	}
+	intent := &sessionRevocationIntent{
+		EventID:      util.GenerUUID(),
+		UID:          uid,
+		EventVersion: next,
+		Reason:       reason,
+	}
+	result, err := tx.InsertInto("user_session_revocation_intent").
+		Columns("event_id", "uid", "event_version", "reason", "status", "next_attempt_at").
+		Values(intent.EventID, uid, next, reason, sessionRevocationPending, time.Now().UTC()).
+		ExecContext(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("user: insert session revocation intent: %w", err)
+	}
+	lastID, err := result.LastInsertId()
+	if err != nil {
+		return nil, fmt.Errorf("user: read session revocation intent id: %w", err)
+	}
+	intent.ID = uint64(lastID)
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("user: commit revocation transaction: %w", err)
+	}
+	return intent, nil
+}
+
+func (d *DB) claimSessionRevocation(ctx context.Context, owner string, now time.Time) (*sessionRevocationIntent, error) {
+	if owner == "" {
+		return nil, errors.New("user: revocation claim owner required")
+	}
+	tx, err := d.session.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("user: begin revocation claim: %w", err)
+	}
+	defer tx.RollbackUnlessCommitted()
+
+	var intent sessionRevocationIntent
+	err = tx.SelectBySql(
+		"SELECT id,event_id,uid,event_version,reason,attempts,lease_owner,lease_until "+
+			"FROM user_session_revocation_intent "+
+			"WHERE status=? AND next_attempt_at<=? AND (lease_until IS NULL OR lease_until<=?) "+
+			"ORDER BY id LIMIT 1 FOR UPDATE SKIP LOCKED",
+		sessionRevocationPending, now, now,
+	).LoadOneContext(ctx, &intent)
+	if err != nil {
+		if errors.Is(err, dbr.ErrNotFound) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("user: select session revocation intent: %w", err)
+	}
+	result, err := tx.UpdateBySql(
+		"UPDATE user_session_revocation_intent SET lease_owner=?,lease_until=? WHERE id=? AND status=?",
+		owner, now.Add(sessionRevocationLease), intent.ID, sessionRevocationPending,
+	).ExecContext(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("user: claim session revocation intent: %w", err)
+	}
+	affected, err := result.RowsAffected()
+	if err != nil || affected != 1 {
+		return nil, fmt.Errorf("user: invalid session revocation claim result")
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("user: commit session revocation claim: %w", err)
+	}
+	intent.LeaseOwner = owner
+	leaseUntil := now.Add(sessionRevocationLease)
+	intent.LeaseUntil = &leaseUntil
+	return &intent, nil
+}
+
+func (d *DB) markSessionRevocationApplied(ctx context.Context, intent *sessionRevocationIntent, owner string) error {
+	query := "UPDATE user_session_revocation_intent SET status=?,applied_at=?,lease_owner='',lease_until=NULL,last_error_code='' WHERE id=? AND status=?"
+	args := []interface{}{sessionRevocationApplied, time.Now().UTC(), intent.ID, sessionRevocationPending}
+	if owner != "" {
+		query += " AND lease_owner=?"
+		args = append(args, owner)
+	}
+	result, err := d.session.UpdateBySql(query, args...).ExecContext(ctx)
+	if err != nil {
+		return fmt.Errorf("user: mark session revocation applied: %w", err)
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("user: read revocation applied result: %w", err)
+	}
+	if affected == 0 {
+		var status uint8
+		_, loadErr := d.session.Select("status").From("user_session_revocation_intent").Where("id=?", intent.ID).LoadContext(ctx, &status)
+		if loadErr == nil && status == sessionRevocationApplied {
+			return nil
+		}
+		return errors.New("user: session revocation lease ownership lost")
+	}
+	return nil
+}
+
+func (d *DB) releaseSessionRevocation(ctx context.Context, intent *sessionRevocationIntent, owner string) error {
+	delay := sessionRevocationRetryDelay(intent.Attempts + 1)
+	result, err := d.session.UpdateBySql(
+		"UPDATE user_session_revocation_intent SET attempts=attempts+1,next_attempt_at=?,lease_owner='',lease_until=NULL,last_error_code=? "+
+			"WHERE id=? AND status=? AND lease_owner=?",
+		time.Now().UTC().Add(delay), "redis_apply_failed", intent.ID, sessionRevocationPending, owner,
+	).ExecContext(ctx)
+	if err != nil {
+		return fmt.Errorf("user: release session revocation intent: %w", err)
+	}
+	affected, err := result.RowsAffected()
+	if err != nil || affected != 1 {
+		return errors.New("user: session revocation lease ownership lost on release")
+	}
+	return nil
+}
+
+func sessionRevocationRetryDelay(attempt uint32) time.Duration {
+	if attempt > 8 {
+		attempt = 8
+	}
+	delay := time.Second * time.Duration(1<<attempt)
+	if delay > 5*time.Minute {
+		return 5 * time.Minute
+	}
+	return delay
+}
+
+func applySessionRevocation(ctx context.Context, store userSessionStore, intent *sessionRevocationIntent) error {
+	v3Store, ok := store.(v3UserSessionStore)
+	if !ok || !v3Store.Mode().RevokesSessions() {
+		return errors.New("user: session revocation rollout mode is not active")
+	}
+	err := v3Store.RevokeAll(ctx, intent.UID, auth.RevocationEvent{Version: intent.EventVersion, ID: intent.EventID})
+	if errors.Is(err, auth.ErrRevocationAlreadyApplied) {
+		return nil
+	}
+	return err
+}
+
+func (u *User) applySessionRevocationIntent(ctx context.Context, intent *sessionRevocationIntent) error {
+	return applyAndMarkSessionRevocation(ctx, u.db, u.sessionStore, intent)
+}
+
+func applyAndMarkSessionRevocation(ctx context.Context, db *DB, store userSessionStore, intent *sessionRevocationIntent) error {
+	if err := applySessionRevocation(ctx, store, intent); err != nil {
+		return err
+	}
+	return db.markSessionRevocationApplied(ctx, intent, "")
+}
+
+func (u *User) processPendingSessionRevocations() {
+	v3Store, ok := u.sessionStore.(v3UserSessionStore)
+	if !ok || !v3Store.Mode().RevokesSessions() {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	for processed := 0; processed < sessionRevocationBatchSize; processed++ {
+		intent, err := u.db.claimSessionRevocation(ctx, u.revocationWorkerOwner, time.Now().UTC())
+		if err != nil {
+			u.Error("领取会话撤销任务失败", zap.Error(err))
+			return
+		}
+		if intent == nil {
+			return
+		}
+		if err := applySessionRevocation(ctx, u.sessionStore, intent); err != nil {
+			if releaseErr := u.db.releaseSessionRevocation(ctx, intent, u.revocationWorkerOwner); releaseErr != nil {
+				u.Error("释放会话撤销任务失败", zap.String("subject", sessionRevocationSubject(intent.UID)), zap.Error(releaseErr))
+			}
+			u.Warn("应用会话撤销任务失败", zap.String("subject", sessionRevocationSubject(intent.UID)), zap.String("reason", intent.Reason))
+			continue
+		}
+		if err := u.db.markSessionRevocationApplied(ctx, intent, u.revocationWorkerOwner); err != nil {
+			u.Error("完成会话撤销任务失败", zap.String("subject", sessionRevocationSubject(intent.UID)), zap.Error(err))
+			return
+		}
+	}
+}
+
+func sessionRevocationSubject(uid string) string {
+	sum := sha256.Sum256([]byte(uid))
+	return fmt.Sprintf("%x", sum[:8])
+}

--- a/modules/user/session_revocation.go
+++ b/modules/user/session_revocation.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
 	"github.com/Mininglamp-OSS/octo-server/pkg/auth"
+	"github.com/Mininglamp-OSS/octo-server/pkg/metrics"
 	"github.com/gocraft/dbr/v2"
 	"go.uber.org/zap"
 )
@@ -303,9 +304,16 @@ func (u *User) processPendingSessionRevocations() {
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 	defer cancel()
+	u.observeSessionRevocationBacklog(ctx)
+	defer func() {
+		observeCtx, observeCancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer observeCancel()
+		u.observeSessionRevocationBacklog(observeCtx)
+	}()
 	for processed := 0; processed < sessionRevocationBatchSize; processed++ {
 		intent, err := u.db.claimSessionRevocation(ctx, u.revocationWorkerOwner, time.Now().UTC())
 		if err != nil {
+			metrics.ObserveSessionRevocationRetry("claim")
 			u.Error("领取会话撤销任务失败", zap.Error(err))
 			return
 		}
@@ -313,17 +321,30 @@ func (u *User) processPendingSessionRevocations() {
 			return
 		}
 		if err := applySessionRevocation(ctx, u.sessionStore, intent); err != nil {
+			metrics.ObserveSessionRevocationRetry("redis_apply")
 			if releaseErr := u.db.releaseSessionRevocation(ctx, intent, u.revocationWorkerOwner); releaseErr != nil {
+				metrics.ObserveSessionRevocationRetry("release")
 				u.Error("释放会话撤销任务失败", zap.String("subject", sessionRevocationSubject(intent.UID)), zap.Error(releaseErr))
 			}
 			u.Warn("应用会话撤销任务失败", zap.String("subject", sessionRevocationSubject(intent.UID)), zap.String("reason", intent.Reason))
 			continue
 		}
 		if err := u.db.markSessionRevocationApplied(ctx, intent, u.revocationWorkerOwner); err != nil {
+			metrics.ObserveSessionRevocationRetry("mark_applied")
 			u.Error("完成会话撤销任务失败", zap.String("subject", sessionRevocationSubject(intent.UID)), zap.Error(err))
 			return
 		}
 	}
+}
+
+func (u *User) observeSessionRevocationBacklog(ctx context.Context) {
+	var backlog int64
+	_, err := u.db.session.Select("COUNT(*)").From("user_session_revocation_intent").Where("status=?", sessionRevocationPending).LoadContext(ctx, &backlog)
+	if err != nil {
+		u.Warn("查询会话撤销积压失败", zap.Error(err))
+		return
+	}
+	metrics.SetSessionRevocationBacklog(backlog)
 }
 
 func sessionRevocationSubject(uid string) string {

--- a/modules/user/session_revocation.go
+++ b/modules/user/session_revocation.go
@@ -20,6 +20,10 @@ const (
 
 	sessionRevocationLease     = 30 * time.Second
 	sessionRevocationBatchSize = 20
+	// Newly committed intents are reserved briefly for their synchronous
+	// by-ID claimant. Shared workers take over after the window if the request
+	// process exits or cannot complete the Redis revocation.
+	sessionRevocationSyncPriorityWindow = 5 * time.Second
 )
 
 var allowedSessionRevocationReasons = map[string]bool{
@@ -158,9 +162,10 @@ func (d *DB) mutateWithSessionRevocation(ctx context.Context, uid, reason string
 		EventVersion: next,
 		Reason:       reason,
 	}
+	workerVisibleAt := time.Now().UTC().Add(sessionRevocationSyncPriorityWindow)
 	result, err := tx.InsertInto("user_session_revocation_intent").
 		Columns("event_id", "uid", "event_version", "reason", "status", "next_attempt_at").
-		Values(intent.EventID, uid, next, reason, sessionRevocationPending, time.Now().UTC()).
+		Values(intent.EventID, uid, next, reason, sessionRevocationPending, workerVisibleAt).
 		ExecContext(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("user: insert session revocation intent: %w", err)
@@ -218,6 +223,56 @@ func (d *DB) claimSessionRevocation(ctx context.Context, owner string, now time.
 	leaseUntil := now.Add(sessionRevocationLease)
 	intent.LeaseUntil = &leaseUntil
 	return &intent, nil
+}
+
+func (d *DB) pendingSessionRevocation(ctx context.Context, uid, reason string) (*sessionRevocationIntent, error) {
+	if uid == "" || !allowedSessionRevocationReasons[reason] {
+		return nil, errors.New("user: invalid pending session revocation query")
+	}
+	var intent sessionRevocationIntent
+	err := d.session.SelectBySql(
+		"SELECT id,event_id,uid,event_version,reason,attempts,lease_owner,lease_until "+
+			"FROM user_session_revocation_intent WHERE uid=? AND reason=? AND status=? "+
+			"ORDER BY event_version DESC LIMIT 1",
+		uid, reason, sessionRevocationPending,
+	).LoadOneContext(ctx, &intent)
+	if errors.Is(err, dbr.ErrNotFound) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("user: load pending session revocation intent: %w", err)
+	}
+	return &intent, nil
+}
+
+func (d *DB) claimSessionRevocationByID(ctx context.Context, intent *sessionRevocationIntent, owner string, now time.Time) (bool, error) {
+	if intent == nil || intent.ID == 0 || owner == "" {
+		return false, errors.New("user: synchronous revocation claim requires intent and owner")
+	}
+	result, err := d.session.UpdateBySql(
+		"UPDATE user_session_revocation_intent SET lease_owner=?,lease_until=? "+
+			"WHERE id=? AND status=? AND (lease_until IS NULL OR lease_until<=?)",
+		owner, now.Add(sessionRevocationLease), intent.ID, sessionRevocationPending, now,
+	).ExecContext(ctx)
+	if err != nil {
+		return false, fmt.Errorf("user: claim synchronous session revocation intent: %w", err)
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return false, fmt.Errorf("user: read synchronous revocation claim result: %w", err)
+	}
+	if affected == 1 {
+		intent.LeaseOwner = owner
+		leaseUntil := now.Add(sessionRevocationLease)
+		intent.LeaseUntil = &leaseUntil
+		return true, nil
+	}
+	var status uint8
+	_, loadErr := d.session.Select("status").From("user_session_revocation_intent").Where("id=?", intent.ID).LoadContext(ctx, &status)
+	if loadErr == nil && status == sessionRevocationApplied {
+		return false, nil
+	}
+	return false, errors.New("user: session revocation lease ownership lost")
 }
 
 func (d *DB) markSessionRevocationApplied(ctx context.Context, intent *sessionRevocationIntent, owner string) error {
@@ -291,10 +346,21 @@ func (u *User) applySessionRevocationIntent(ctx context.Context, intent *session
 }
 
 func applyAndMarkSessionRevocation(ctx context.Context, db *DB, store userSessionStore, intent *sessionRevocationIntent) error {
-	if err := applySessionRevocation(ctx, store, intent); err != nil {
+	owner := "sync-" + util.GenerUUID()
+	claimed, err := db.claimSessionRevocationByID(ctx, intent, owner, time.Now().UTC())
+	if err != nil {
 		return err
 	}
-	return db.markSessionRevocationApplied(ctx, intent, "")
+	if !claimed {
+		return nil
+	}
+	if err := applySessionRevocation(ctx, store, intent); err != nil {
+		if releaseErr := db.releaseSessionRevocation(ctx, intent, owner); releaseErr != nil {
+			return errors.Join(err, releaseErr)
+		}
+		return err
+	}
+	return db.markSessionRevocationApplied(ctx, intent, owner)
 }
 
 func (u *User) processPendingSessionRevocations() {

--- a/modules/user/session_revocation.go
+++ b/modules/user/session_revocation.go
@@ -25,6 +25,17 @@ const (
 	// by-ID claimant. Shared workers take over after the window if the request
 	// process exits or cannot complete the Redis revocation.
 	sessionRevocationSyncPriorityWindow = 5 * time.Second
+
+	sessionRevocationWaitInitial = 100 * time.Millisecond
+	sessionRevocationWaitMaximum = 500 * time.Millisecond
+)
+
+type sessionRevocationClaim uint8
+
+const (
+	sessionRevocationClaimAcquired sessionRevocationClaim = iota + 1
+	sessionRevocationClaimApplied
+	sessionRevocationClaimLeasedElsewhere
 )
 
 var allowedSessionRevocationReasons = map[string]bool{
@@ -34,6 +45,8 @@ var allowedSessionRevocationReasons = map[string]bool{
 	"account_destroy": true,
 	"admin_delete":    true,
 }
+
+var errSessionRevocationPending = errors.New("user: session revocation remains pending under another owner")
 
 type sessionRevocationIntent struct {
 	ID           uint64     `db:"id"`
@@ -287,9 +300,9 @@ func (d *DB) pendingSessionRevocation(ctx context.Context, uid, reason string) (
 	return &intent, nil
 }
 
-func (d *DB) claimSessionRevocationByID(ctx context.Context, intent *sessionRevocationIntent, owner string, now time.Time) (bool, error) {
+func (d *DB) claimSessionRevocationByID(ctx context.Context, intent *sessionRevocationIntent, owner string, now time.Time) (sessionRevocationClaim, error) {
 	if intent == nil || intent.ID == 0 || owner == "" {
-		return false, errors.New("user: synchronous revocation claim requires intent and owner")
+		return 0, errors.New("user: synchronous revocation claim requires intent and owner")
 	}
 	result, err := d.session.UpdateBySql(
 		"UPDATE user_session_revocation_intent SET lease_owner=?,lease_until=? "+
@@ -297,25 +310,24 @@ func (d *DB) claimSessionRevocationByID(ctx context.Context, intent *sessionRevo
 		owner, now.Add(sessionRevocationLease), intent.ID, sessionRevocationPending, now,
 	).ExecContext(ctx)
 	if err != nil {
-		return false, fmt.Errorf("user: claim synchronous session revocation intent: %w", err)
+		return 0, fmt.Errorf("user: claim synchronous session revocation intent: %w", err)
 	}
 	affected, err := result.RowsAffected()
 	if err != nil {
-		return false, fmt.Errorf("user: read synchronous revocation claim result: %w", err)
+		return 0, fmt.Errorf("user: read synchronous revocation claim result: %w", err)
 	}
 	if affected == 1 {
 		intent.LeaseOwner = owner
 		leaseUntil := now.Add(sessionRevocationLease)
 		intent.LeaseUntil = &leaseUntil
-		return true, nil
+		return sessionRevocationClaimAcquired, nil
 	}
-	// Losing the claim is not the same as losing the revocation. Distinguish the
-	// two benign outcomes — already applied, or currently owned by someone else
-	// (normally the shared worker, which reserves the intent after the sync
-	// priority window) — from a genuine fault. Reporting a live foreign lease as
-	// an error would tell the caller their committed mutation failed and invite a
-	// second one. The lease comparison runs in SQL so it matches the claim
-	// predicate above exactly and cannot drift on driver time zones.
+	// Losing the claim is not the same as completing the revocation. Distinguish
+	// already-applied from a pending intent currently owned by another replica,
+	// so the caller can wait within its bounded post-commit budget without
+	// stealing the lease or repeating the Redis mutation. The lease comparison
+	// runs in SQL so it matches the claim predicate above exactly and cannot
+	// drift on driver time zones.
 	var claimState struct {
 		Status     uint8 `db:"status"`
 		LeaseAlive bool  `db:"lease_alive"`
@@ -326,15 +338,58 @@ func (d *DB) claimSessionRevocationByID(ctx context.Context, intent *sessionRevo
 		now, intent.ID,
 	).LoadOneContext(ctx, &claimState)
 	if loadErr != nil {
-		return false, fmt.Errorf("user: read synchronous revocation claim state: %w", loadErr)
+		return 0, fmt.Errorf("user: read synchronous revocation claim state: %w", loadErr)
 	}
 	if claimState.Status == sessionRevocationApplied {
-		return false, nil
+		return sessionRevocationClaimApplied, nil
 	}
-	if claimState.LeaseAlive {
-		return false, nil
+	if claimState.Status == sessionRevocationPending && claimState.LeaseAlive {
+		return sessionRevocationClaimLeasedElsewhere, nil
 	}
-	return false, errors.New("user: session revocation lease ownership lost")
+	return 0, errors.New("user: session revocation lease ownership lost")
+}
+
+func (d *DB) sessionRevocationAppliedByID(ctx context.Context, id uint64) (bool, error) {
+	var status uint8
+	err := d.session.Select("status").From("user_session_revocation_intent").Where("id=?", id).LoadOneContext(ctx, &status)
+	if err != nil {
+		return false, fmt.Errorf("user: read session revocation completion: %w", err)
+	}
+	switch status {
+	case sessionRevocationPending:
+		return false, nil
+	case sessionRevocationApplied:
+		return true, nil
+	default:
+		return false, fmt.Errorf("user: invalid session revocation status %d", status)
+	}
+}
+
+func waitForSessionRevocationApplied(ctx context.Context, db *DB, intent *sessionRevocationIntent) error {
+	delay := sessionRevocationWaitInitial
+	for {
+		timer := time.NewTimer(delay)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return fmt.Errorf("%w: %w", errSessionRevocationPending, ctx.Err())
+		case <-timer.C:
+		}
+
+		applied, err := db.sessionRevocationAppliedByID(ctx, intent.ID)
+		if err != nil {
+			return err
+		}
+		if applied {
+			return nil
+		}
+		if delay < sessionRevocationWaitMaximum {
+			delay *= 2
+			if delay > sessionRevocationWaitMaximum {
+				delay = sessionRevocationWaitMaximum
+			}
+		}
+	}
 }
 
 func (d *DB) markSessionRevocationApplied(ctx context.Context, intent *sessionRevocationIntent, owner string) error {
@@ -411,12 +466,19 @@ func applyAndMarkSessionRevocation(ctx context.Context, db *DB, store userSessio
 	securityCtx, cancel := postCommitSecurityContext(ctx)
 	defer cancel()
 	owner := "sync-" + util.GenerUUID()
-	claimed, err := db.claimSessionRevocationByID(securityCtx, intent, owner, time.Now().UTC())
+	claim, err := db.claimSessionRevocationByID(securityCtx, intent, owner, time.Now().UTC())
 	if err != nil {
 		return err
 	}
-	if !claimed {
+	switch claim {
+	case sessionRevocationClaimApplied:
 		return nil
+	case sessionRevocationClaimLeasedElsewhere:
+		return waitForSessionRevocationApplied(securityCtx, db, intent)
+	case sessionRevocationClaimAcquired:
+		// Continue below: this request owns the lease and must apply it.
+	default:
+		return fmt.Errorf("user: invalid session revocation claim %d", claim)
 	}
 	if err := applySessionRevocation(securityCtx, store, intent); err != nil {
 		if releaseErr := db.releaseSessionRevocation(securityCtx, intent, owner); releaseErr != nil {

--- a/modules/user/session_revocation.go
+++ b/modules/user/session_revocation.go
@@ -112,15 +112,47 @@ func (d *DB) deleteAdminWithSessionRevocation(ctx context.Context, uid, role str
 	})
 }
 
-func updateUserFieldAndRevokeSessions(ctx context.Context, db *DB, store userSessionStore, uid, field string, value interface{}, reason string) error {
+func updateUserFieldAndRevokeSessionsWithResult(ctx context.Context, db *DB, store userSessionStore, uid, field string, value interface{}, reason string) (bool, error) {
 	if !sessionRevocationActive(store) {
-		return db.UpdateUsersWithField(field, fmt.Sprintf("%v", value), uid)
+		err := db.UpdateUsersWithField(field, fmt.Sprintf("%v", value), uid)
+		return err == nil, err
 	}
 	intent, err := db.updateUserFieldWithSessionRevocation(ctx, uid, field, value, reason)
 	if err != nil {
-		return err
+		return false, err
 	}
-	return applyAndMarkSessionRevocation(ctx, db, store, intent)
+	return true, applyAndMarkSessionRevocation(ctx, db, store, intent)
+}
+
+type quitUserDevicesFunc func(uid string, deviceFlag int) error
+
+// finishCommittedUserSecurityMutation preserves the database commit boundary:
+// a rolled-back mutation has no external effects, while a committed mutation
+// always attempts HTTP bearer revocation and the independent WuKongIM logout.
+// In revoke/enforce modes the durable intent already owns bearer revocation;
+// earlier rollout modes use the compatibility indexes through Session Store.
+func finishCommittedUserSecurityMutation(ctx context.Context, store userSessionStore, uid string, committed bool, mutationErr error, quit quitUserDevicesFunc) error {
+	if !committed {
+		return mutationErr
+	}
+	result := mutationErr
+	if !sessionRevocationActive(store) {
+		for _, failure := range revokeDeviceTokens(ctx, store, uid) {
+			result = errors.Join(result, fmt.Errorf("user: revoke device %d session: %w", failure.flag, failure.err))
+		}
+	}
+	if quit == nil {
+		return errors.Join(result, errors.New("user: quit user devices callback is required"))
+	}
+	if err := quit(uid, -1); err != nil {
+		result = errors.Join(result, fmt.Errorf("user: quit all IM devices: %w", err))
+	}
+	return result
+}
+
+func updatePasswordAndRevokeSessions(ctx context.Context, db *DB, store userSessionStore, quit quitUserDevicesFunc, uid string, password interface{}, reason string) error {
+	committed, err := updateUserFieldAndRevokeSessionsWithResult(ctx, db, store, uid, "password", password, reason)
+	return finishCommittedUserSecurityMutation(ctx, store, uid, committed, err, quit)
 }
 
 func (d *DB) mutateWithSessionRevocation(ctx context.Context, uid, reason string, mutation sessionRevocationMutation) (*sessionRevocationIntent, error) {

--- a/modules/user/session_revocation.go
+++ b/modules/user/session_revocation.go
@@ -20,6 +20,7 @@ const (
 
 	sessionRevocationLease     = 30 * time.Second
 	sessionRevocationBatchSize = 20
+	postCommitSecurityTimeout  = 3 * time.Second
 	// Newly committed intents are reserved briefly for their synchronous
 	// by-ID claimant. Shared workers take over after the window if the request
 	// process exits or cannot complete the Redis revocation.
@@ -126,6 +127,13 @@ func updateUserFieldAndRevokeSessionsWithResult(ctx context.Context, db *DB, sto
 
 type quitUserDevicesFunc func(uid string, deviceFlag int) error
 
+func postCommitSecurityContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return context.WithTimeout(context.WithoutCancel(ctx), postCommitSecurityTimeout)
+}
+
 // finishCommittedUserSecurityMutation preserves the database commit boundary:
 // a rolled-back mutation has no external effects, while a committed mutation
 // always attempts HTTP bearer revocation and the independent WuKongIM logout.
@@ -135,9 +143,11 @@ func finishCommittedUserSecurityMutation(ctx context.Context, store userSessionS
 	if !committed {
 		return mutationErr
 	}
+	securityCtx, cancel := postCommitSecurityContext(ctx)
+	defer cancel()
 	result := mutationErr
 	if !sessionRevocationActive(store) {
-		for _, failure := range revokeDeviceTokens(ctx, store, uid) {
+		for _, failure := range revokeDeviceTokens(securityCtx, store, uid) {
 			result = errors.Join(result, fmt.Errorf("user: revoke device %d session: %w", failure.flag, failure.err))
 		}
 	}
@@ -378,21 +388,23 @@ func (u *User) applySessionRevocationIntent(ctx context.Context, intent *session
 }
 
 func applyAndMarkSessionRevocation(ctx context.Context, db *DB, store userSessionStore, intent *sessionRevocationIntent) error {
+	securityCtx, cancel := postCommitSecurityContext(ctx)
+	defer cancel()
 	owner := "sync-" + util.GenerUUID()
-	claimed, err := db.claimSessionRevocationByID(ctx, intent, owner, time.Now().UTC())
+	claimed, err := db.claimSessionRevocationByID(securityCtx, intent, owner, time.Now().UTC())
 	if err != nil {
 		return err
 	}
 	if !claimed {
 		return nil
 	}
-	if err := applySessionRevocation(ctx, store, intent); err != nil {
-		if releaseErr := db.releaseSessionRevocation(ctx, intent, owner); releaseErr != nil {
+	if err := applySessionRevocation(securityCtx, store, intent); err != nil {
+		if releaseErr := db.releaseSessionRevocation(securityCtx, intent, owner); releaseErr != nil {
 			return errors.Join(err, releaseErr)
 		}
 		return err
 	}
-	return db.markSessionRevocationApplied(ctx, intent, owner)
+	return db.markSessionRevocationApplied(securityCtx, intent, owner)
 }
 
 func (u *User) processPendingSessionRevocations() {

--- a/modules/user/session_revocation_post_commit_test.go
+++ b/modules/user/session_revocation_post_commit_test.go
@@ -267,6 +267,8 @@ func TestApplyRevocationWaitsForForeignOwnerAndFailsIfItNeverApplies(t *testing.
 		err := applyAndMarkSessionRevocation(context.Background(), userAPI.db, store, intent)
 		require.Error(t, err,
 			"an intent still pending under another owner must not be acknowledged as revoked")
+		require.ErrorIs(t, err, errSessionRevocationPending,
+			"the caller must be able to distinguish a retryable pending revocation")
 		var pending int
 		_, loadErr := ctx.DB().Select("COUNT(*)").From("user_session_revocation_intent").
 			Where("id=? AND status=?", intent.ID, sessionRevocationPending).Load(&pending)

--- a/modules/user/session_revocation_post_commit_test.go
+++ b/modules/user/session_revocation_post_commit_test.go
@@ -180,11 +180,11 @@ func TestDeleteAdminUserRevokesEveryBearerDespiteCanceledRequestContext(t *testi
 		"a committed administrator deletion must revoke every device bearer even if the client disconnected")
 }
 
-// A committed mutation whose revocation intent is already leased by the shared
-// worker has succeeded — the intent is applied within the lease. Reporting that
-// as a failure tells the user their password change failed after it committed,
-// which invites a second change.
-func TestClaimSessionRevocationTreatsForeignLeaseAsDeferredApply(t *testing.T) {
+// A claim that cannot be taken has two very different meanings, and collapsing
+// them is unsafe in both directions: reporting a live foreign lease as a failure
+// tells the user their committed password change failed, while reporting it as
+// success acknowledges a high-risk mutation whose bearer may still be valid.
+func TestClaimSessionRevocationDistinguishesAppliedFromForeignLease(t *testing.T) {
 	_, _, userAPI, _ := newTokenHTTPTestServer(t)
 	uid := "lease-" + util.GenerUUID()[:10]
 	require.NoError(t, userAPI.db.Insert(&Model{
@@ -196,43 +196,45 @@ func TestClaimSessionRevocationTreatsForeignLeaseAsDeferredApply(t *testing.T) {
 	require.NoError(t, err)
 
 	now := time.Now().UTC()
-	claimed, err := userAPI.db.claimSessionRevocationByID(context.Background(), intent, "worker-owner", now)
+	claim, err := userAPI.db.claimSessionRevocationByID(context.Background(), intent, "worker-owner", now)
 	require.NoError(t, err)
-	require.True(t, claimed, "the worker takes the lease first")
+	require.Equal(t, sessionRevocationClaimAcquired, claim, "the worker takes the lease first")
 
-	// The synchronous request path arrives second. It cannot take the lease, but
-	// the revocation is not lost: the current owner applies it within the lease.
+	// The synchronous request path arrives second. The revocation is neither lost
+	// nor complete — it is owned by someone else and still pending.
 	contender := *intent
-	claimed, err = userAPI.db.claimSessionRevocationByID(context.Background(), &contender, "sync-owner", now)
-	require.NoError(t, err,
-		"another owner holding a live lease is deferred apply, not a failed revocation")
-	require.False(t, claimed)
+	claim, err = userAPI.db.claimSessionRevocationByID(context.Background(), &contender, "sync-owner", now)
+	require.NoError(t, err, "a live foreign lease is a distinct state, not a fault")
+	require.Equal(t, sessionRevocationClaimLeasedElsewhere, claim,
+		"a pending intent held by another owner must never be reported as applied")
 
 	// The lease must still be reclaimable once it expires, or a crashed owner
 	// would strand the intent.
-	claimed, err = userAPI.db.claimSessionRevocationByID(
+	claim, err = userAPI.db.claimSessionRevocationByID(
 		context.Background(), &contender, "sync-later", now.Add(sessionRevocationLease+time.Second))
 	require.NoError(t, err)
-	require.True(t, claimed, "an expired lease must be reclaimable")
+	require.Equal(t, sessionRevocationClaimAcquired, claim, "an expired lease must be reclaimable")
+
+	require.NoError(t, userAPI.db.markSessionRevocationApplied(context.Background(), &contender, "sync-later"))
+	claim, err = userAPI.db.claimSessionRevocationByID(
+		context.Background(), &contender, "sync-after-applied", time.Now().UTC())
+	require.NoError(t, err)
+	require.Equal(t, sessionRevocationClaimApplied, claim, "an applied intent is complete")
 
 	// A genuinely missing intent must still be an error: this must not become a
 	// blanket "any claim failure is fine".
 	missing := *intent
 	missing.ID = intent.ID + 1_000_000
-	_, err = userAPI.db.claimSessionRevocationByID(context.Background(), &missing, "sync-missing", now)
-	require.Error(t, err, "a vanished intent row is a real fault, not deferred apply")
+	_, err = userAPI.db.claimSessionRevocationByID(context.Background(), &missing, "sync-missing", time.Now().UTC())
+	require.Error(t, err, "a vanished intent row is a real fault, not a lease state")
 }
 
-// End-to-end shape of the same failure: the caller gets 200 and the password is
-// changed even though the worker owns the pending intent.
-func TestPasswordChangeSucceedsWhileWorkerOwnsRevocationIntent(t *testing.T) {
+// The synchronous path must not acknowledge a high-risk mutation while the
+// bearer revocation is still only promised. It waits inside the post-commit
+// budget for the current owner to finish, and reports a retryable failure if
+// that owner never does.
+func TestApplyRevocationWaitsForForeignOwnerAndFailsIfItNeverApplies(t *testing.T) {
 	_, ctx, userAPI, _ := newTokenHTTPTestServer(t)
-	uid := "wlease-" + util.GenerUUID()[:9]
-	require.NoError(t, userAPI.db.Insert(&Model{
-		UID: uid, Name: "worker lease user", Username: "wl_" + uid, ShortNo: "wl_" + uid,
-		Password: "before", Status: int(libcommon.UserAvailable),
-	}))
-
 	client := octoredis.NewInstrumentedClient(ctx.GetConfig())
 	store := auth.NewRedisSessionStore(
 		client,
@@ -243,27 +245,47 @@ func TestPasswordChangeSucceedsWhileWorkerOwnsRevocationIntent(t *testing.T) {
 		auth.WithSessionMaxPerUID(4),
 	)
 
-	// Reproduce the race deterministically: commit the intent, let the worker
-	// take its lease, then run the request path's apply step.
-	intent, err := userAPI.db.updateUserFieldWithSessionRevocation(
-		context.Background(), uid, "password", "after", "password_change")
-	require.NoError(t, err)
-	claimed, err := userAPI.db.claimSessionRevocationByID(
-		context.Background(), intent, "worker-owner", time.Now().UTC())
-	require.NoError(t, err)
-	require.True(t, claimed)
+	newLeasedIntent := func(t *testing.T, tag string) *sessionRevocationIntent {
+		t.Helper()
+		uid := tag + util.GenerUUID()[:8]
+		require.NoError(t, userAPI.db.Insert(&Model{
+			UID: uid, Name: "worker lease user", Username: "wl_" + uid, ShortNo: "wl_" + uid,
+			Password: "before", Status: int(libcommon.UserAvailable),
+		}))
+		intent, err := userAPI.db.updateUserFieldWithSessionRevocation(
+			context.Background(), uid, "password", "after", "password_change")
+		require.NoError(t, err)
+		claim, err := userAPI.db.claimSessionRevocationByID(
+			context.Background(), intent, "worker-owner", time.Now().UTC())
+		require.NoError(t, err)
+		require.Equal(t, sessionRevocationClaimAcquired, claim)
+		return intent
+	}
 
-	require.NoError(t, applyAndMarkSessionRevocation(context.Background(), userAPI.db, store, intent),
-		"a committed change whose intent is being applied by the worker must not report failure")
+	t.Run("owner never applies", func(t *testing.T) {
+		intent := newLeasedIntent(t, "stuck-")
+		err := applyAndMarkSessionRevocation(context.Background(), userAPI.db, store, intent)
+		require.Error(t, err,
+			"an intent still pending under another owner must not be acknowledged as revoked")
+		var pending int
+		_, loadErr := ctx.DB().Select("COUNT(*)").From("user_session_revocation_intent").
+			Where("id=? AND status=?", intent.ID, sessionRevocationPending).Load(&pending)
+		require.NoError(t, loadErr)
+		require.Equal(t, 1, pending, "the intent stays pending for its current owner to retry")
+	})
 
-	changed, err := userAPI.db.QueryByUID(uid)
-	require.NoError(t, err)
-	require.Equal(t, "after", changed.Password)
-	var pending int
-	_, err = ctx.DB().Select("COUNT(*)").From("user_session_revocation_intent").
-		Where("uid=? AND status=?", uid, sessionRevocationPending).Load(&pending)
-	require.NoError(t, err)
-	require.Equal(t, 1, pending, "the intent stays pending for its current owner")
+	t.Run("owner applies within the post-commit budget", func(t *testing.T) {
+		intent := newLeasedIntent(t, "conv-")
+		applied := make(chan struct{})
+		go func() {
+			defer close(applied)
+			time.Sleep(200 * time.Millisecond)
+			_ = userAPI.db.markSessionRevocationApplied(context.Background(), intent, "worker-owner")
+		}()
+		require.NoError(t, applyAndMarkSessionRevocation(context.Background(), userAPI.db, store, intent),
+			"a revocation that converges inside the budget is a success, not a failure")
+		<-applied
+	})
 }
 
 // Class guard for the defect above: this is the fourth call site where a

--- a/modules/user/session_revocation_post_commit_test.go
+++ b/modules/user/session_revocation_post_commit_test.go
@@ -1,0 +1,329 @@
+package user
+
+import (
+	"context"
+	"go/ast"
+	"go/parser"
+	gotoken "go/token"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"sort"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	libcommon "github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/stretchr/testify/require"
+)
+
+// The scheduled finalizer has no compensation path for WuKongIM: once the
+// destroy transaction commits, `checkDestroyExpired` never selects the account
+// again (is_destroy advanced past 1). A post-commit Redis revocation failure is
+// retried by the outbox worker, so it must not suppress the independent IM
+// logout.
+func TestFinalizeDestroyStillQuitsIMDevicesAfterCommittedRevocationFailure(t *testing.T) {
+	_, ctx, userAPI, _ := newTokenHTTPTestServer(t)
+	uid := "fin-" + util.GenerUUID()[:12]
+	require.NoError(t, userAPI.db.Insert(&Model{
+		UID: uid, Name: "finalize user", Username: "fin_" + uid,
+		ShortNo: "fin_" + uid, Phone: "13800000001", Zone: "0086",
+		Status: int(libcommon.UserAvailable),
+	}))
+	require.NoError(t, userAPI.db.applyDestroy(uid, time.Now().Add(-30*24*time.Hour), time.Now().Add(-time.Hour)))
+
+	var imMu sync.Mutex
+	deviceQuitCalls := 0
+	im := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/user/device_quit" {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"status":0}`))
+			return
+		}
+		imMu.Lock()
+		deviceQuitCalls++
+		imMu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(im.Close)
+	ctx.GetConfig().WuKongIM.APIURL = im.URL
+
+	store := &flakyRevokeAllSessionStore{}
+	userAPI.sessionStore = store
+
+	expired, err := userAPI.db.queryDestroyExpired(time.Now(), 10)
+	require.NoError(t, err)
+	require.Len(t, expired, 1)
+
+	require.NoError(t, userAPI.finalizeDestroy(expired[0]),
+		"a committed finalization is terminal: a deferred Redis apply is not a finalizer failure")
+
+	finalized, err := userAPI.db.QueryByUID(uid)
+	require.NoError(t, err)
+	require.Equal(t, IsDestroyDone, finalized.IsDestroy, "the destroy transaction must remain committed")
+	require.Equal(t, 1, store.callCount())
+	imMu.Lock()
+	require.Equal(t, 1, deviceQuitCalls,
+		"post-commit Redis failure must not skip the independent WuKongIM logout")
+	imMu.Unlock()
+
+	var pending int
+	_, err = ctx.DB().Select("COUNT(*)").From("user_session_revocation_intent").
+		Where("uid=? AND status=?", uid, sessionRevocationPending).Load(&pending)
+	require.NoError(t, err)
+	require.Equal(t, 1, pending, "the failed apply must stay pending for the outbox worker")
+}
+
+// The other side of the same boundary: a mutation that never committed emits no
+// external side effects at all.
+func TestFinalizeDestroyEmitsNoSideEffectsWhenTransactionDidNotCommit(t *testing.T) {
+	_, ctx, userAPI, _ := newTokenHTTPTestServer(t)
+	uid := "cnl-" + util.GenerUUID()[:12]
+	require.NoError(t, userAPI.db.Insert(&Model{
+		UID: uid, Name: "cancel racer", Username: "cnl_" + uid,
+		ShortNo: "cnl_" + uid, Phone: "13800000002", Zone: "0086",
+		Status: int(libcommon.UserAvailable),
+	}))
+	require.NoError(t, userAPI.db.applyDestroy(uid, time.Now().Add(-30*24*time.Hour), time.Now().Add(-time.Hour)))
+
+	var imMu sync.Mutex
+	deviceQuitCalls := 0
+	im := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/user/device_quit" {
+			imMu.Lock()
+			deviceQuitCalls++
+			imMu.Unlock()
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status":0}`))
+	}))
+	t.Cleanup(im.Close)
+	ctx.GetConfig().WuKongIM.APIURL = im.URL
+
+	revokeStore := &recordingDeviceRevokeStore{
+		tokens:   map[int]string{int(config.APP): "conflict-app-token"},
+		failures: make(map[string]error),
+	}
+	userAPI.sessionStore = revokeStore
+
+	expired, err := userAPI.db.queryDestroyExpired(time.Now(), 10)
+	require.NoError(t, err)
+	require.Len(t, expired, 1)
+	// The user cancels between selection and the finalizing write.
+	require.NoError(t, userAPI.db.cancelDestroy(uid))
+
+	require.NoError(t, userAPI.finalizeDestroy(expired[0]),
+		"a state conflict must be skipped silently, not reported as a finalizer failure")
+
+	unchanged, err := userAPI.db.QueryByUID(uid)
+	require.NoError(t, err)
+	require.Equal(t, IsDestroyNo, unchanged.IsDestroy)
+	require.NotContains(t, unchanged.Phone, "@delete")
+	require.Empty(t, revokeStore.revoked, "an uncommitted finalization must not revoke bearers")
+	imMu.Lock()
+	require.Zero(t, deviceQuitCalls, "an uncommitted finalization must not log devices out")
+	imMu.Unlock()
+}
+
+// deleteAdminUsers hard-deletes the user row and then, in the shipped `expand`
+// default, revokes bearers through Session Store. That revocation is the only
+// one there is: no revocation intent exists in this mode and the row is gone, so
+// neither the runtime nor an operator can retry it. A disconnected client must
+// therefore not be able to cancel it.
+func TestDeleteAdminUserRevokesEveryBearerDespiteCanceledRequestContext(t *testing.T) {
+	server, _, _, managerAPI := newTokenHTTPTestServer(t)
+	wireI18nRendererForUserTest(server)
+	uid := "adm-" + util.GenerUUID()[:12]
+	require.NoError(t, managerAPI.userDB.Insert(&Model{
+		UID: uid, Name: "deleted admin", Username: "adm_" + uid,
+		ShortNo: "adm_" + uid, Role: string(wkhttp.Admin),
+		Status: int(libcommon.UserAvailable),
+	}))
+
+	store := &recordingDeviceRevokeStore{
+		tokens: map[int]string{
+			int(config.APP): "admin-app-token",
+			int(config.Web): "admin-web-token",
+			int(config.PC):  "admin-pc-token",
+		},
+		failures: make(map[string]error),
+	}
+	managerAPI.sessionStore = store
+	require.False(t, sessionRevocationActive(managerAPI.sessionStore),
+		"this regression covers the shipped compatibility mode")
+
+	server.GetRoute().Any("/test/manager/admin/delete", func(c *wkhttp.Context) {
+		c.Set("uid", "root")
+		c.Set("role", string(wkhttp.SuperAdmin))
+		managerAPI.deleteAdminUsers(c)
+	})
+
+	canceled, cancel := context.WithCancel(context.Background())
+	cancel()
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodDelete, "/test/manager/admin/delete?uid="+uid, nil)
+	server.GetRoute().ServeHTTP(recorder, request.WithContext(canceled))
+
+	require.Equal(t, http.StatusOK, recorder.Code, recorder.Body.String())
+	deleted, err := managerAPI.userDB.QueryByUID(uid)
+	require.NoError(t, err)
+	require.Nil(t, deleted, "the administrator row must be deleted")
+	require.ElementsMatch(t,
+		[]string{"admin-app-token", "admin-web-token", "admin-pc-token"},
+		store.revoked,
+		"a committed administrator deletion must revoke every device bearer even if the client disconnected")
+}
+
+// Class guard for the defect above: this is the fourth call site where a
+// post-commit Session Store revocation was handed a cancelable request context,
+// so assert the property instead of the individual call sites.
+//
+// A function is "cancel-bound" when it reaches a revocation primitive without
+// detaching from its caller's cancellation (postCommitSecurityContext /
+// context.WithoutCancel / context.Background). Handing a request-derived context
+// to such a function makes the revocation abortable by the client.
+func TestCommittedRevocationNeverReceivesRequestDerivedContext(t *testing.T) {
+	// Session Store methods (and package helpers) that delete or rotate
+	// credentials. Reaching any of these is what makes a function security
+	// critical rather than merely context-taking.
+	revocationPrimitives := map[string]bool{
+		"RevokeAll":              true,
+		"RevokeCurrent":          true,
+		"RevokeIssued":           true,
+		"DeleteToken":            true,
+		"DeleteUIDToken":         true,
+		"InvalidateCurrentToken": true,
+		"revokeDeviceTokens":     true,
+	}
+	detachers := map[string]bool{
+		"postCommitSecurityContext": true,
+		"WithoutCancel":             true,
+		"Background":                true,
+		"TODO":                      true,
+	}
+
+	type function struct {
+		file    string
+		name    string
+		body    *ast.BlockStmt
+		calls   map[string]bool
+		detach  bool
+		reaches bool
+	}
+
+	entries, err := os.ReadDir(".")
+	require.NoError(t, err)
+	functions := make([]*function, 0, 256)
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".go") || strings.HasSuffix(entry.Name(), "_test.go") {
+			continue
+		}
+		fset := gotoken.NewFileSet()
+		parsed, err := parser.ParseFile(fset, entry.Name(), nil, 0)
+		require.NoError(t, err)
+		for _, declaration := range parsed.Decls {
+			declared, ok := declaration.(*ast.FuncDecl)
+			if !ok || declared.Body == nil {
+				continue
+			}
+			current := &function{
+				file:  entry.Name(),
+				name:  declared.Name.Name,
+				body:  declared.Body,
+				calls: make(map[string]bool),
+			}
+			ast.Inspect(declared.Body, func(node ast.Node) bool {
+				call, ok := node.(*ast.CallExpr)
+				if !ok {
+					return true
+				}
+				name := calledFunctionName(call.Fun)
+				current.calls[name] = true
+				if detachers[name] {
+					current.detach = true
+				}
+				if revocationPrimitives[name] {
+					current.reaches = true
+				}
+				return true
+			})
+			functions = append(functions, current)
+		}
+	}
+	require.NotEmpty(t, functions)
+
+	// A cancel-bound function reaches a primitive without detaching. Propagate
+	// through the call graph until it settles: a caller inherits the property
+	// unless it detaches first.
+	cancelBound := make(map[string]bool)
+	for name := range revocationPrimitives {
+		cancelBound[name] = true
+	}
+	for changed := true; changed; {
+		changed = false
+		for _, current := range functions {
+			if current.detach || cancelBound[current.name] {
+				continue
+			}
+			for callee := range current.calls {
+				if cancelBound[callee] {
+					cancelBound[current.name] = true
+					changed = true
+					break
+				}
+			}
+		}
+	}
+	// Sanity-check the detector itself: the compatibility revocation helper is
+	// cancel-bound by construction, and the detaching wrappers are not.
+	require.True(t, cancelBound["revokeAllDeviceTokens"],
+		"revokeAllDeviceTokens reaches Session Store without detaching; the detector must see it")
+	require.False(t, cancelBound["finishCommittedUserSecurityMutation"],
+		"finishCommittedUserSecurityMutation detaches, so callers may pass a request context")
+	require.False(t, cancelBound["invalidateCurrentUserToken"],
+		"invalidateCurrentUserToken detaches, so callers may pass a request context")
+
+	var violations []string
+	for _, current := range functions {
+		ast.Inspect(current.body, func(node ast.Node) bool {
+			call, ok := node.(*ast.CallExpr)
+			if !ok || !cancelBound[calledFunctionName(call.Fun)] {
+				return true
+			}
+			for _, argument := range call.Args {
+				if !isRequestDerivedContext(argument) {
+					continue
+				}
+				violations = append(violations, current.file+"/"+current.name+" -> "+calledFunctionName(call.Fun))
+			}
+			return true
+		})
+	}
+	sort.Strings(violations)
+	require.Empty(t, violations,
+		"a Session Store revocation that follows a committed write must run on a context detached "+
+			"from the request (postCommitSecurityContext); client disconnect would otherwise skip it "+
+			"with no retry path: %v", violations)
+}
+
+// isRequestDerivedContext reports whether the expression yields a context tied
+// to the inbound HTTP request — `c.Request.Context()` or a bare `c.Context`.
+func isRequestDerivedContext(expression ast.Expr) bool {
+	switch typed := expression.(type) {
+	case *ast.CallExpr:
+		selector, ok := typed.Fun.(*ast.SelectorExpr)
+		if !ok || selector.Sel.Name != "Context" {
+			return false
+		}
+		inner, ok := selector.X.(*ast.SelectorExpr)
+		return ok && inner.Sel.Name == "Request"
+	case *ast.SelectorExpr:
+		return typed.Sel.Name == "Context"
+	default:
+		return false
+	}
+}

--- a/modules/user/session_revocation_post_commit_test.go
+++ b/modules/user/session_revocation_post_commit_test.go
@@ -18,6 +18,8 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/pkg/auth"
+	octoredis "github.com/Mininglamp-OSS/octo-server/pkg/redis"
 	"github.com/stretchr/testify/require"
 )
 
@@ -176,6 +178,92 @@ func TestDeleteAdminUserRevokesEveryBearerDespiteCanceledRequestContext(t *testi
 		[]string{"admin-app-token", "admin-web-token", "admin-pc-token"},
 		store.revoked,
 		"a committed administrator deletion must revoke every device bearer even if the client disconnected")
+}
+
+// A committed mutation whose revocation intent is already leased by the shared
+// worker has succeeded — the intent is applied within the lease. Reporting that
+// as a failure tells the user their password change failed after it committed,
+// which invites a second change.
+func TestClaimSessionRevocationTreatsForeignLeaseAsDeferredApply(t *testing.T) {
+	_, _, userAPI, _ := newTokenHTTPTestServer(t)
+	uid := "lease-" + util.GenerUUID()[:10]
+	require.NoError(t, userAPI.db.Insert(&Model{
+		UID: uid, Name: "lease user", Username: "ls_" + uid, ShortNo: "ls_" + uid,
+		Password: "before", Status: int(libcommon.UserAvailable),
+	}))
+	intent, err := userAPI.db.updateUserFieldWithSessionRevocation(
+		context.Background(), uid, "password", "after", "password_change")
+	require.NoError(t, err)
+
+	now := time.Now().UTC()
+	claimed, err := userAPI.db.claimSessionRevocationByID(context.Background(), intent, "worker-owner", now)
+	require.NoError(t, err)
+	require.True(t, claimed, "the worker takes the lease first")
+
+	// The synchronous request path arrives second. It cannot take the lease, but
+	// the revocation is not lost: the current owner applies it within the lease.
+	contender := *intent
+	claimed, err = userAPI.db.claimSessionRevocationByID(context.Background(), &contender, "sync-owner", now)
+	require.NoError(t, err,
+		"another owner holding a live lease is deferred apply, not a failed revocation")
+	require.False(t, claimed)
+
+	// The lease must still be reclaimable once it expires, or a crashed owner
+	// would strand the intent.
+	claimed, err = userAPI.db.claimSessionRevocationByID(
+		context.Background(), &contender, "sync-later", now.Add(sessionRevocationLease+time.Second))
+	require.NoError(t, err)
+	require.True(t, claimed, "an expired lease must be reclaimable")
+
+	// A genuinely missing intent must still be an error: this must not become a
+	// blanket "any claim failure is fine".
+	missing := *intent
+	missing.ID = intent.ID + 1_000_000
+	_, err = userAPI.db.claimSessionRevocationByID(context.Background(), &missing, "sync-missing", now)
+	require.Error(t, err, "a vanished intent row is a real fault, not deferred apply")
+}
+
+// End-to-end shape of the same failure: the caller gets 200 and the password is
+// changed even though the worker owns the pending intent.
+func TestPasswordChangeSucceedsWhileWorkerOwnsRevocationIntent(t *testing.T) {
+	_, ctx, userAPI, _ := newTokenHTTPTestServer(t)
+	uid := "wlease-" + util.GenerUUID()[:9]
+	require.NoError(t, userAPI.db.Insert(&Model{
+		UID: uid, Name: "worker lease user", Username: "wl_" + uid, ShortNo: "wl_" + uid,
+		Password: "before", Status: int(libcommon.UserAvailable),
+	}))
+
+	client := octoredis.NewInstrumentedClient(ctx.GetConfig())
+	store := auth.NewRedisSessionStore(
+		client,
+		"post-commit-token:"+util.GenerUUID()+":",
+		"post-commit-uid:"+util.GenerUUID()+":",
+		time.Hour,
+		auth.WithSessionMode(auth.SessionModeRevoke),
+		auth.WithSessionMaxPerUID(4),
+	)
+
+	// Reproduce the race deterministically: commit the intent, let the worker
+	// take its lease, then run the request path's apply step.
+	intent, err := userAPI.db.updateUserFieldWithSessionRevocation(
+		context.Background(), uid, "password", "after", "password_change")
+	require.NoError(t, err)
+	claimed, err := userAPI.db.claimSessionRevocationByID(
+		context.Background(), intent, "worker-owner", time.Now().UTC())
+	require.NoError(t, err)
+	require.True(t, claimed)
+
+	require.NoError(t, applyAndMarkSessionRevocation(context.Background(), userAPI.db, store, intent),
+		"a committed change whose intent is being applied by the worker must not report failure")
+
+	changed, err := userAPI.db.QueryByUID(uid)
+	require.NoError(t, err)
+	require.Equal(t, "after", changed.Password)
+	var pending int
+	_, err = ctx.DB().Select("COUNT(*)").From("user_session_revocation_intent").
+		Where("uid=? AND status=?", uid, sessionRevocationPending).Load(&pending)
+	require.NoError(t, err)
+	require.Equal(t, 1, pending, "the intent stays pending for its current owner")
 }
 
 // Class guard for the defect above: this is the fourth call site where a

--- a/modules/user/session_revocation_test.go
+++ b/modules/user/session_revocation_test.go
@@ -96,7 +96,7 @@ func TestAccountDisableAndRevocationIntentCommitTogether(t *testing.T) {
 	require.Equal(t, 1, pending)
 }
 
-func TestSessionRevocationWorkerAppliesPendingIntentAndStops(t *testing.T) {
+func TestSessionRevocationWorkerAppliesPendingIntent(t *testing.T) {
 	_, ctx := testutil.NewTestServer()
 	db := NewDB(ctx)
 	client := octoredis.NewInstrumentedClient(ctx.GetConfig())
@@ -121,24 +121,11 @@ func TestSessionRevocationWorkerAppliesPendingIntentAndStops(t *testing.T) {
 	require.NoError(t, err)
 
 	worker := &User{db: db, sessionStore: store, revocationWorkerOwner: "test-worker"}
-	workerCtx, cancel := context.WithCancel(context.Background())
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
-		worker.runSessionRevocationWorker(workerCtx, 10*time.Millisecond)
-	}()
-	require.Eventually(t, func() bool {
-		var applied int
-		_, queryErr := ctx.DB().Select("COUNT(*)").From("user_session_revocation_intent").Where("id=? AND status=?", intent.ID, sessionRevocationApplied).Load(&applied)
-		return queryErr == nil && applied == 1
-	}, 2*time.Second, 20*time.Millisecond)
+	worker.processPendingSessionRevocations()
+	var applied int
+	_, err = ctx.DB().Select("COUNT(*)").From("user_session_revocation_intent").Where("id=? AND status=?", intent.ID, sessionRevocationApplied).Load(&applied)
+	require.NoError(t, err)
+	require.Equal(t, 1, applied)
 	_, err = auth.NewTokenValidator(store, prefix).Validate(context.Background(), token)
 	require.Error(t, err)
-
-	cancel()
-	select {
-	case <-done:
-	case <-time.After(time.Second):
-		t.Fatal("session revocation worker did not stop after cancellation")
-	}
 }

--- a/modules/user/session_revocation_test.go
+++ b/modules/user/session_revocation_test.go
@@ -2,12 +2,20 @@ package user
 
 import (
 	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
 	"testing"
 	"time"
 
+	libcommon "github.com/Mininglamp-OSS/octo-lib/common"
 	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
 	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	commonapi "github.com/Mininglamp-OSS/octo-server/modules/base/common"
 	"github.com/Mininglamp-OSS/octo-server/pkg/auth"
 	octoredis "github.com/Mininglamp-OSS/octo-server/pkg/redis"
 	"github.com/stretchr/testify/require"
@@ -96,6 +104,30 @@ func TestAccountDisableAndRevocationIntentCommitTogether(t *testing.T) {
 	require.Equal(t, 1, pending)
 }
 
+func TestNewSessionRevocationIntentReservesSynchronousClaimWindow(t *testing.T) {
+	_, ctx := testutil.NewTestServer()
+	db := NewDB(ctx)
+	uid := util.GenerUUID()
+	require.NoError(t, db.Insert(&Model{UID: uid, Name: "sync-priority-user", ShortNo: uid, Password: "before", Status: 1}))
+	t.Cleanup(func() {
+		_, _ = ctx.DB().DeleteFrom("user_session_revocation_intent").Where("uid=?", uid).Exec()
+		_, _ = ctx.DB().DeleteFrom("user_session_revocation_version").Where("uid=?", uid).Exec()
+		_, _ = ctx.DB().DeleteFrom("user").Where("uid=?", uid).Exec()
+	})
+
+	intent, err := db.updateUserFieldWithSessionRevocation(context.Background(), uid, "password", "after", "password_reset")
+	require.NoError(t, err)
+	now := time.Now().UTC()
+
+	workerIntent, err := db.claimSessionRevocation(context.Background(), "worker", now)
+	require.NoError(t, err)
+	require.Nil(t, workerIntent, "a normal worker must not race the synchronous apply immediately after commit")
+
+	claimed, err := db.claimSessionRevocationByID(context.Background(), intent, "sync", now)
+	require.NoError(t, err)
+	require.True(t, claimed, "the synchronous by-ID path must ignore its own worker visibility delay")
+}
+
 func TestSessionRevocationWorkerAppliesPendingIntent(t *testing.T) {
 	_, ctx := testutil.NewTestServer()
 	db := NewDB(ctx)
@@ -119,6 +151,11 @@ func TestSessionRevocationWorkerAppliesPendingIntent(t *testing.T) {
 	require.NoError(t, store.IssueNewSession(context.Background(), token, auth.TokenInfo{UID: uid, DeviceFlag: int(config.Web)}, fence))
 	intent, err := db.updateUserFieldWithSessionRevocation(context.Background(), uid, "password", "after", "password_reset")
 	require.NoError(t, err)
+	_, err = ctx.DB().Update("user_session_revocation_intent").
+		Set("next_attempt_at", time.Now().UTC().Add(-time.Second)).
+		Where("id=?", intent.ID).
+		Exec()
+	require.NoError(t, err, "simulate a synchronous caller that exited before claiming its intent")
 
 	worker := &User{db: db, sessionStore: store, revocationWorkerOwner: "test-worker"}
 	worker.processPendingSessionRevocations()
@@ -128,4 +165,197 @@ func TestSessionRevocationWorkerAppliesPendingIntent(t *testing.T) {
 	require.Equal(t, 1, applied)
 	_, err = auth.NewTokenValidator(store, prefix).Validate(context.Background(), token)
 	require.Error(t, err)
+}
+
+type logoutFailingSessionStore struct {
+	fakeUserSessionStore
+	err error
+}
+
+func (s *logoutFailingSessionStore) InvalidateCurrentToken(context.Context, string, string) error {
+	return s.err
+}
+
+func TestLogoutStillQuitsIMAndCleansDeviceStateWhenBearerRevokeFails(t *testing.T) {
+	server, ctx := testutil.NewTestServer()
+	wireI18nRendererForUserTest(server)
+	uid := "logout-converge-" + util.GenerUUID()
+	deviceKey := "logout-device:" + uid
+	require.NoError(t, ctx.GetRedisConn().SetAndExpire(deviceKey, "present", time.Minute))
+
+	var flagsMu sync.Mutex
+	var flags []int
+	im := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/user/device_quit" {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"status":0}`))
+			return
+		}
+		var request struct {
+			DeviceFlag int `json:"device_flag"`
+		}
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		require.NoError(t, util.ReadJsonByByte(body, &request))
+		flagsMu.Lock()
+		flags = append(flags, request.DeviceFlag)
+		flagsMu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(im.Close)
+	ctx.GetConfig().WuKongIM.APIURL = im.URL
+
+	u := New(ctx)
+	u.sessionStore = &logoutFailingSessionStore{err: errors.New("redis unavailable")}
+	u.userDeviceTokenPrefix = "logout-device:"
+	server.GetRoute().POST("/test/session/logout", func(c *wkhttp.Context) {
+		c.Set("uid", uid)
+		u.quit(c)
+	})
+
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodPost, "/test/session/logout", nil)
+	request.Header.Set("token", "current-token")
+	server.GetRoute().ServeHTTP(recorder, request)
+
+	require.Equal(t, http.StatusBadRequest, recorder.Code, recorder.Body.String())
+	flagsMu.Lock()
+	require.ElementsMatch(t, []int{int(config.Web), int(config.PC)}, flags,
+		"HTTP bearer failure must not skip independent IM logout attempts")
+	flagsMu.Unlock()
+	deviceState, err := ctx.GetRedisConn().GetString(deviceKey)
+	require.NoError(t, err)
+	require.Empty(t, deviceState, "a retryable bearer failure must not skip local device-state cleanup")
+}
+
+type flakyRevokeAllSessionStore struct {
+	fakeUserSessionStore
+	mu    sync.Mutex
+	calls int
+}
+
+func (s *flakyRevokeAllSessionStore) Mode() auth.SessionMode { return auth.SessionModeRevoke }
+
+func (s *flakyRevokeAllSessionStore) BeginIssue(context.Context, string) (auth.IssueFence, error) {
+	return auth.IssueFence{}, nil
+}
+
+func (s *flakyRevokeAllSessionStore) IssueNewSession(context.Context, string, auth.TokenInfo, auth.IssueFence) error {
+	return nil
+}
+
+func (s *flakyRevokeAllSessionStore) ReuseSession(context.Context, string, auth.TokenInfo, auth.IssueFence) (bool, error) {
+	return false, nil
+}
+
+func (s *flakyRevokeAllSessionStore) UpdateSessionSnapshot(context.Context, string, auth.TokenInfo) (bool, error) {
+	return false, nil
+}
+
+func (s *flakyRevokeAllSessionStore) RevokeCurrent(context.Context, string, string, int) error {
+	return nil
+}
+
+func (s *flakyRevokeAllSessionStore) RevokeAll(context.Context, string, auth.RevocationEvent) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.calls++
+	if s.calls == 1 {
+		return errors.New("redis unavailable")
+	}
+	return nil
+}
+
+func (s *flakyRevokeAllSessionStore) callCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.calls
+}
+
+type allowDestroySMSService struct{}
+
+func (allowDestroySMSService) SendVerifyCode(context.Context, string, string, commonapi.CodeType) error {
+	return nil
+}
+
+func (allowDestroySMSService) Verify(context.Context, string, string, string, commonapi.CodeType) error {
+	return nil
+}
+
+func TestDestroyAccountRetryConvergesCommittedRevocationAndAlwaysQuitsIM(t *testing.T) {
+	server, ctx := testutil.NewTestServer()
+	wireI18nRendererForUserTest(server)
+	require.NoError(t, testutil.CleanAllTables(ctx))
+	ctx.GetConfig().SMSCode = "123456"
+	uid := "d-" + util.GenerUUID()
+	db := NewDB(ctx)
+	require.NoError(t, db.Insert(&Model{
+		UID:       uid,
+		Name:      "destroy converge user",
+		Username:  "destroy_" + uid[len(uid)-12:],
+		ShortNo:   "destroy_" + uid[len(uid)-10:],
+		Phone:     "13800000000",
+		Zone:      "0086",
+		Status:    int(libcommon.UserAvailable),
+		IsDestroy: IsDestroyNo,
+	}))
+	t.Cleanup(func() {
+		_, _ = ctx.DB().DeleteFrom("user_session_revocation_intent").Where("uid=?", uid).Exec()
+		_, _ = ctx.DB().DeleteFrom("user_session_revocation_version").Where("uid=?", uid).Exec()
+		_, _ = ctx.DB().DeleteFrom("user").Where("uid=?", uid).Exec()
+	})
+
+	var imMu sync.Mutex
+	imCalls := 0
+	im := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/user/device_quit" {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"status":0}`))
+			return
+		}
+		imMu.Lock()
+		imCalls++
+		imMu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(im.Close)
+	ctx.GetConfig().WuKongIM.APIURL = im.URL
+
+	store := &flakyRevokeAllSessionStore{}
+	u := New(ctx)
+	u.sessionStore = store
+	u.smsServie = allowDestroySMSService{}
+	server.GetRoute().Any("/test/session/destroy/:code", func(c *wkhttp.Context) {
+		c.Set("uid", uid)
+		u.destroyAccount(c)
+	})
+
+	requestDestroy := func() *httptest.ResponseRecorder {
+		t.Helper()
+		recorder := httptest.NewRecorder()
+		request := httptest.NewRequest(http.MethodDelete, "/test/session/destroy/123456", nil)
+		server.GetRoute().ServeHTTP(recorder, request)
+		return recorder
+	}
+
+	first := requestDestroy()
+	require.Equal(t, http.StatusBadRequest, first.Code, first.Body.String())
+	model, err := db.QueryByUID(uid)
+	require.NoError(t, err)
+	require.Equal(t, IsDestroyDone, model.IsDestroy, "the first response failed after the DB transaction committed")
+	imMu.Lock()
+	require.Equal(t, 1, imCalls, "post-commit Redis failure must not skip the independent IM quit")
+	imMu.Unlock()
+
+	second := requestDestroy()
+	require.Equal(t, http.StatusOK, second.Code, second.Body.String())
+	require.Equal(t, 2, store.callCount(), "retry must apply the existing pending revocation intent")
+	imMu.Lock()
+	require.Equal(t, 2, imCalls, "retry must keep IM quit idempotent")
+	imMu.Unlock()
+	var applied int
+	_, err = ctx.DB().Select("COUNT(*)").From("user_session_revocation_intent").
+		Where("uid=? AND status=?", uid, sessionRevocationApplied).Load(&applied)
+	require.NoError(t, err)
+	require.Equal(t, 1, applied)
 }

--- a/modules/user/session_revocation_test.go
+++ b/modules/user/session_revocation_test.go
@@ -172,6 +172,53 @@ type logoutFailingSessionStore struct {
 	err error
 }
 
+func TestFinishCommittedUserSecurityMutationPreservesCommitBoundary(t *testing.T) {
+	t.Run("uncommitted mutation has no external side effects", func(t *testing.T) {
+		store := &recordingDeviceRevokeStore{
+			tokens: map[int]string{int(config.APP): "app-token"}, failures: make(map[string]error),
+		}
+		quitCalls := 0
+		mutationErr := errors.New("database rollback")
+		err := finishCommittedUserSecurityMutation(context.Background(), store, "u1", false, mutationErr, func(string, int) error {
+			quitCalls++
+			return nil
+		})
+		require.ErrorIs(t, err, mutationErr)
+		require.Empty(t, store.revoked)
+		require.Zero(t, quitCalls)
+	})
+
+	t.Run("committed compatibility mutation revokes bearers and always quits IM", func(t *testing.T) {
+		store := &recordingDeviceRevokeStore{
+			tokens: map[int]string{
+				int(config.APP): "app-token", int(config.Web): "web-token", int(config.PC): "pc-token",
+			},
+			failures: map[string]error{"web-token": errors.New("redis unavailable")},
+		}
+		var quitFlags []int
+		err := finishCommittedUserSecurityMutation(context.Background(), store, "u1", true, nil, func(_ string, flag int) error {
+			quitFlags = append(quitFlags, flag)
+			return nil
+		})
+		require.ErrorContains(t, err, "redis unavailable")
+		require.ElementsMatch(t, []string{"app-token", "web-token", "pc-token"}, store.revoked)
+		require.Equal(t, []int{-1}, quitFlags, "a bearer revocation error must not skip independent IM logout")
+	})
+
+	t.Run("committed durable mutation still quits IM when synchronous apply fails", func(t *testing.T) {
+		store := &flakyRevokeAllSessionStore{}
+		applyErr := errors.New("redis unavailable")
+		quitCalls := 0
+		err := finishCommittedUserSecurityMutation(context.Background(), store, "u1", true, applyErr, func(_ string, flag int) error {
+			quitCalls++
+			require.Equal(t, -1, flag)
+			return nil
+		})
+		require.ErrorIs(t, err, applyErr)
+		require.Equal(t, 1, quitCalls)
+	})
+}
+
 func (s *logoutFailingSessionStore) InvalidateCurrentToken(context.Context, string, string) error {
 	return s.err
 }

--- a/modules/user/session_revocation_test.go
+++ b/modules/user/session_revocation_test.go
@@ -321,6 +321,54 @@ func TestPasswordMutationRevokesKnownBearersAndQuitsAllIMDevices(t *testing.T) {
 	quitFlagsMu.Unlock()
 }
 
+func TestDisableUserStillAppliesIMSideEffectsAfterCommittedRevocationFailure(t *testing.T) {
+	server, ctx, _, managerAPI := newTokenHTTPTestServer(t)
+	wireI18nRendererForUserTest(server)
+	uid := "disable-" + util.GenerUUID()
+	require.NoError(t, managerAPI.userDB.Insert(&Model{
+		UID: uid, Name: "disable user", ShortNo: uid, Status: int(libcommon.UserAvailable),
+	}))
+
+	var imMu sync.Mutex
+	deviceQuitCalls := 0
+	channelCalls := 0
+	im := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		imMu.Lock()
+		switch r.URL.Path {
+		case "/user/device_quit":
+			deviceQuitCalls++
+		default:
+			channelCalls++
+		}
+		imMu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status":0}`))
+	}))
+	t.Cleanup(im.Close)
+	ctx.GetConfig().WuKongIM.APIURL = im.URL
+
+	store := &flakyRevokeAllSessionStore{}
+	managerAPI.sessionStore = store
+	server.GetRoute().Any("/test/manager/liftban/:uid/:status", func(c *wkhttp.Context) {
+		c.Set("uid", "root")
+		c.Set("role", string(wkhttp.SuperAdmin))
+		managerAPI.liftBanUser(c)
+	})
+
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodPut, "/test/manager/liftban/"+uid+"/0", nil)
+	server.GetRoute().ServeHTTP(recorder, request)
+	require.Equal(t, http.StatusBadRequest, recorder.Code, recorder.Body.String())
+	updated, err := managerAPI.userDB.QueryByUID(uid)
+	require.NoError(t, err)
+	require.Zero(t, updated.Status, "the account disable transaction must remain committed")
+	require.Equal(t, 1, store.callCount())
+	imMu.Lock()
+	require.Equal(t, 1, deviceQuitCalls, "post-commit Redis failure must not skip independent IM logout")
+	require.Equal(t, 1, channelCalls, "post-commit Redis failure must not skip the IM channel ban")
+	imMu.Unlock()
+}
+
 func (s *logoutFailingSessionStore) InvalidateCurrentToken(context.Context, string, string) error {
 	return s.err
 }

--- a/modules/user/session_revocation_test.go
+++ b/modules/user/session_revocation_test.go
@@ -95,3 +95,50 @@ func TestAccountDisableAndRevocationIntentCommitTogether(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 1, pending)
 }
+
+func TestSessionRevocationWorkerAppliesPendingIntentAndStops(t *testing.T) {
+	_, ctx := testutil.NewTestServer()
+	db := NewDB(ctx)
+	client := octoredis.NewInstrumentedClient(ctx.GetConfig())
+	prefix := "user-revocation-worker-token:" + util.GenerUUID() + ":"
+	uidPrefix := "user-revocation-worker-uid:" + util.GenerUUID() + ":"
+	store := auth.NewRedisSessionStore(client, prefix, uidPrefix, time.Hour, auth.WithSessionMode(auth.SessionModeRevoke), auth.WithSessionMaxPerUID(4))
+	uid := util.GenerUUID()
+	token := "token-" + util.GenerUUID()
+	require.NoError(t, db.Insert(&Model{UID: uid, Name: "worker-user", ShortNo: uid, Password: "before", Status: 1}))
+	t.Cleanup(func() {
+		_, _ = ctx.DB().DeleteFrom("user_session_revocation_intent").Where("uid=?", uid).Exec()
+		_, _ = ctx.DB().DeleteFrom("user_session_revocation_version").Where("uid=?", uid).Exec()
+		_, _ = ctx.DB().DeleteFrom("user").Where("uid=?", uid).Exec()
+		_ = store.DeleteToken(context.Background(), token)
+		_ = client.Close()
+	})
+
+	fence, err := store.BeginIssue(context.Background(), uid)
+	require.NoError(t, err)
+	require.NoError(t, store.IssueNewSession(context.Background(), token, auth.TokenInfo{UID: uid, DeviceFlag: int(config.Web)}, fence))
+	intent, err := db.updateUserFieldWithSessionRevocation(context.Background(), uid, "password", "after", "password_reset")
+	require.NoError(t, err)
+
+	worker := &User{db: db, sessionStore: store, revocationWorkerOwner: "test-worker"}
+	workerCtx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		worker.runSessionRevocationWorker(workerCtx, 10*time.Millisecond)
+	}()
+	require.Eventually(t, func() bool {
+		var applied int
+		_, queryErr := ctx.DB().Select("COUNT(*)").From("user_session_revocation_intent").Where("id=? AND status=?", intent.ID, sessionRevocationApplied).Load(&applied)
+		return queryErr == nil && applied == 1
+	}, 2*time.Second, 20*time.Millisecond)
+	_, err = auth.NewTokenValidator(store, prefix).Validate(context.Background(), token)
+	require.Error(t, err)
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("session revocation worker did not stop after cancellation")
+	}
+}

--- a/modules/user/session_revocation_test.go
+++ b/modules/user/session_revocation_test.go
@@ -3,6 +3,9 @@ package user
 import (
 	"context"
 	"errors"
+	"go/ast"
+	"go/parser"
+	gotoken "go/token"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -217,6 +220,50 @@ func TestFinishCommittedUserSecurityMutationPreservesCommitBoundary(t *testing.T
 		require.ErrorIs(t, err, applyErr)
 		require.Equal(t, 1, quitCalls)
 	})
+}
+
+func TestPasswordAndDisablePathsUseCommittedSecurityMutationHelper(t *testing.T) {
+	tests := []struct {
+		file     string
+		function string
+		calls    []string
+	}{
+		{file: "api.go", function: "pwdforget", calls: []string{"updatePasswordAndRevokeSessions"}},
+		{file: "api_emaillogin.go", function: "emailForgetPwd", calls: []string{"updatePasswordAndRevokeSessions"}},
+		{file: "api_manager.go", function: "resetUserPassword", calls: []string{"updatePasswordAndRevokeSessions"}},
+		{file: "api_manager.go", function: "updatePwd", calls: []string{"updatePasswordAndRevokeSessions"}},
+		{file: "api_usernamelogin.go", function: "updatePwd", calls: []string{"updatePasswordAndRevokeSessions"}},
+		{file: "service.go", function: "UpdateLoginPassword", calls: []string{"updatePasswordAndRevokeSessions"}},
+		{file: "api_manager.go", function: "liftBanUser", calls: []string{"updateUserFieldAndRevokeSessionsWithResult", "finishCommittedUserSecurityMutation"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.file+"/"+tt.function, func(t *testing.T) {
+			fset := gotoken.NewFileSet()
+			file, err := parser.ParseFile(fset, tt.file, nil, 0)
+			require.NoError(t, err)
+			found := make(map[string]bool)
+			for _, declaration := range file.Decls {
+				function, ok := declaration.(*ast.FuncDecl)
+				if !ok || function.Name.Name != tt.function {
+					continue
+				}
+				ast.Inspect(function.Body, func(node ast.Node) bool {
+					call, ok := node.(*ast.CallExpr)
+					if !ok {
+						return true
+					}
+					if name, ok := call.Fun.(*ast.Ident); ok {
+						found[name.Name] = true
+					}
+					return true
+				})
+			}
+			for _, call := range tt.calls {
+				require.True(t, found[call], "%s must call %s", tt.function, call)
+			}
+		})
+	}
 }
 
 func (s *logoutFailingSessionStore) InvalidateCurrentToken(context.Context, string, string) error {

--- a/modules/user/session_revocation_test.go
+++ b/modules/user/session_revocation_test.go
@@ -1,6 +1,7 @@
 package user
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"go/ast"
@@ -443,6 +444,73 @@ func TestPasswordMutationRevokesKnownBearersAndQuitsAllIMDevices(t *testing.T) {
 		indexed, err := userAPI.sessionStore.DeviceToken(context.Background(), uid, int(flag))
 		require.NoError(t, err)
 		require.Empty(t, indexed)
+		record, err := auth.SessionStoreForContext(ctx).ReadToken(context.Background(), ctx.GetConfig().Cache.TokenCachePrefix+token)
+		require.NoError(t, err)
+		require.Equal(t, time.Duration(-2), record.TTL)
+	}
+	quitFlagsMu.Lock()
+	require.Equal(t, []int{-1}, quitFlags)
+	quitFlagsMu.Unlock()
+}
+
+func TestWeb3PasswordResetRevokesKnownBearersAndQuitsAllIMDevices(t *testing.T) {
+	server, ctx, userAPI, _ := newTokenHTTPTestServer(t)
+	uid := "w3-" + util.GenerUUID()
+	username := "web3_" + uid[len(uid)-12:]
+	const (
+		verifyText = "hello123"
+		publicKey  = "03af80b90d25145da28c583359beb47b21796b2fe1a23c1511e443e7a64dfdb27d"
+		signature  = "44459fd9146290dcd913350bae6fe79fd48050d39b3c1c315e8f032af3b555d41af6f2c07d4d0f1d8d5dd041af8175e657ae981cf47e58aa5547ab08fc7066e401"
+	)
+	require.NoError(t, userAPI.db.Insert(&Model{
+		UID: uid, Username: username, Name: "web3 user", ShortNo: username,
+		Password: "before", Status: int(libcommon.UserAvailable), Web3PublicKey: publicKey,
+	}))
+	require.NoError(t, ctx.GetRedisConn().SetAndExpire("web3_verify:"+uid+"_"+Web3VerifyPassword, verifyText, time.Minute))
+
+	tokens := map[config.DeviceFlag]string{
+		config.APP: "web3-app-" + util.GenerUUID(),
+		config.Web: "web3-web-" + util.GenerUUID(),
+		config.PC:  "web3-pc-" + util.GenerUUID(),
+	}
+	for flag, token := range tokens {
+		payload, err := auth.Encode(auth.TokenInfo{UID: uid, DeviceFlag: int(flag)})
+		require.NoError(t, err)
+		require.NoError(t, userAPI.sessionStore.IssueNew(context.Background(), token, payload, uid, int(flag)))
+	}
+
+	var quitFlagsMu sync.Mutex
+	var quitFlags []int
+	im := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/user/device_quit", r.URL.Path)
+		var request struct {
+			DeviceFlag int `json:"device_flag"`
+		}
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		require.NoError(t, util.ReadJsonByByte(body, &request))
+		quitFlagsMu.Lock()
+		quitFlags = append(quitFlags, request.DeviceFlag)
+		quitFlagsMu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(im.Close)
+	ctx.GetConfig().WuKongIM.APIURL = im.URL
+	server.GetRoute().POST("/v1/user/pwdforget_web3", userAPI.resetPwdWithWeb3PublicKey)
+
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodPost, "/v1/user/pwdforget_web3", bytes.NewReader([]byte(util.ToJson(map[string]interface{}{
+		"username": username, "password": "after", "verify_text": verifyText, "sign_text": signature,
+	}))))
+	request.Header.Set("Content-Type", "application/json")
+	server.GetRoute().ServeHTTP(recorder, request)
+	require.Equal(t, http.StatusOK, recorder.Code, recorder.Body.String())
+
+	updated, err := userAPI.db.QueryByUID(uid)
+	require.NoError(t, err)
+	matched, _ := CheckPassword("after", updated.Password)
+	require.True(t, matched)
+	for _, token := range tokens {
 		record, err := auth.SessionStoreForContext(ctx).ReadToken(context.Background(), ctx.GetConfig().Cache.TokenCachePrefix+token)
 		require.NoError(t, err)
 		require.Equal(t, time.Duration(-2), record.TTL)

--- a/modules/user/session_revocation_test.go
+++ b/modules/user/session_revocation_test.go
@@ -1,0 +1,73 @@
+package user
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	"github.com/Mininglamp-OSS/octo-server/pkg/auth"
+	octoredis "github.com/Mininglamp-OSS/octo-server/pkg/redis"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPasswordMutationAndSessionRevocationIntentAreDurableAndApplied(t *testing.T) {
+	_, ctx := testutil.NewTestServer()
+	db := NewDB(ctx)
+	client := octoredis.NewInstrumentedClient(ctx.GetConfig())
+	prefix := "user-revocation-token:" + util.GenerUUID() + ":"
+	uidPrefix := "user-revocation-uid:" + util.GenerUUID() + ":"
+	store := auth.NewRedisSessionStore(client, prefix, uidPrefix, time.Hour, auth.WithSessionMode(auth.SessionModeRevoke), auth.WithSessionMaxPerUID(4))
+	uid := util.GenerUUID()
+	token := "token-" + util.GenerUUID()
+	password := "hash-before"
+	require.NoError(t, db.Insert(&Model{UID: uid, Name: "revocation-user", ShortNo: uid, Password: password, Status: 1}))
+	t.Cleanup(func() {
+		_, _ = ctx.DB().DeleteFrom("user_session_revocation_intent").Where("uid=?", uid).Exec()
+		_, _ = ctx.DB().DeleteFrom("user_session_revocation_version").Where("uid=?", uid).Exec()
+		_, _ = ctx.DB().DeleteFrom("user").Where("uid=?", uid).Exec()
+		_ = store.DeleteToken(context.Background(), token)
+		_ = client.Close()
+	})
+
+	fence, err := store.BeginIssue(context.Background(), uid)
+	require.NoError(t, err)
+	require.NoError(t, store.IssueNewSession(context.Background(), token, auth.TokenInfo{UID: uid, DeviceFlag: int(config.Web)}, fence))
+	_, err = auth.NewTokenValidator(store, prefix).Validate(context.Background(), token)
+	require.NoError(t, err)
+
+	intent, err := db.updateUserFieldWithSessionRevocation(context.Background(), uid, "password", "hash-after", "password_reset")
+	require.NoError(t, err)
+	require.NotZero(t, intent.ID)
+	require.NotEmpty(t, intent.EventID)
+	require.EqualValues(t, 1, intent.EventVersion)
+
+	updated, err := db.QueryByUID(uid)
+	require.NoError(t, err)
+	require.Equal(t, "hash-after", updated.Password)
+	var pending int
+	_, err = ctx.DB().Select("COUNT(*)").From("user_session_revocation_intent").Where("id=? AND status=?", intent.ID, sessionRevocationPending).Load(&pending)
+	require.NoError(t, err)
+	require.Equal(t, 1, pending)
+
+	require.NoError(t, applyAndMarkSessionRevocation(context.Background(), db, store, intent))
+	_, err = auth.NewTokenValidator(store, prefix).Validate(context.Background(), token)
+	require.Error(t, err)
+	var applied int
+	_, err = ctx.DB().Select("COUNT(*)").From("user_session_revocation_intent").Where("id=? AND status=?", intent.ID, sessionRevocationApplied).Load(&applied)
+	require.NoError(t, err)
+	require.Equal(t, 1, applied)
+
+	// An idempotent replay must not rotate away sessions created after the
+	// original security event.
+	postFence, err := store.BeginIssue(context.Background(), uid)
+	require.NoError(t, err)
+	postToken := "post-" + util.GenerUUID()
+	require.NoError(t, store.IssueNewSession(context.Background(), postToken, auth.TokenInfo{UID: uid, DeviceFlag: int(config.PC)}, postFence))
+	t.Cleanup(func() { _ = store.DeleteToken(context.Background(), postToken) })
+	require.NoError(t, applyAndMarkSessionRevocation(context.Background(), db, store, intent))
+	_, err = auth.NewTokenValidator(store, prefix, auth.WithValidatorClock(func() time.Time { return time.Now() })).Validate(context.Background(), postToken)
+	require.NoError(t, err)
+}

--- a/modules/user/session_revocation_test.go
+++ b/modules/user/session_revocation_test.go
@@ -621,6 +621,81 @@ func TestDisableUserStillAppliesIMSideEffectsAfterCommittedRevocationFailure(t *
 	imMu.Unlock()
 }
 
+func TestEnableUserRetryConvergesIMSideEffectsAfterCommittedStatusChange(t *testing.T) {
+	tests := []struct {
+		name         string
+		failEndpoint string
+	}{
+		{name: "channel unban fails", failEndpoint: "/channel/info"},
+		{name: "device quit fails", failEndpoint: "/user/device_quit"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server, ctx, _, managerAPI := newTokenHTTPTestServer(t)
+			wireI18nRendererForUserTest(server)
+			uid := "enable-" + util.GenerUUID()
+			require.NoError(t, managerAPI.userDB.Insert(&Model{
+				UID: uid, Name: "enable user", ShortNo: uid, Status: int(libcommon.UserDisable),
+			}))
+
+			var imMu sync.Mutex
+			calls := map[string]int{
+				"/channel/info":     0,
+				"/user/device_quit": 0,
+			}
+			var sideEffectOrder []string
+			im := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				imMu.Lock()
+				calls[r.URL.Path]++
+				call := calls[r.URL.Path]
+				sideEffectOrder = append(sideEffectOrder, r.URL.Path)
+				imMu.Unlock()
+				if r.URL.Path == tt.failEndpoint && call == 1 {
+					w.WriteHeader(http.StatusInternalServerError)
+					return
+				}
+				w.WriteHeader(http.StatusOK)
+			}))
+			t.Cleanup(im.Close)
+			ctx.GetConfig().WuKongIM.APIURL = im.URL
+
+			server.GetRoute().Any("/test/manager/liftban/:uid/:status", func(c *wkhttp.Context) {
+				c.Set("uid", "root")
+				c.Set("role", string(wkhttp.SuperAdmin))
+				managerAPI.liftBanUser(c)
+			})
+			requestEnable := func() *httptest.ResponseRecorder {
+				t.Helper()
+				recorder := httptest.NewRecorder()
+				request := httptest.NewRequest(http.MethodPut, "/test/manager/liftban/"+uid+"/1", nil)
+				server.GetRoute().ServeHTTP(recorder, request)
+				return recorder
+			}
+
+			first := requestEnable()
+			require.Equal(t, http.StatusBadRequest, first.Code, first.Body.String())
+			updated, err := managerAPI.userDB.QueryByUID(uid)
+			require.NoError(t, err)
+			require.Equal(t, int(libcommon.UserAvailable), updated.Status,
+				"the account enable status change must remain committed")
+
+			second := requestEnable()
+			require.Equal(t, http.StatusOK, second.Code, second.Body.String())
+			imMu.Lock()
+			require.Equal(t, map[string]int{
+				"/channel/info":     2,
+				"/user/device_quit": 2,
+			}, calls, "an already-enabled retry must replay both idempotent IM side effects")
+			require.Equal(t, []string{
+				"/channel/info", "/user/device_quit",
+				"/channel/info", "/user/device_quit",
+			}, sideEffectOrder)
+			imMu.Unlock()
+		})
+	}
+}
+
 func (s *logoutFailingSessionStore) InvalidateCurrentToken(context.Context, string, string) error {
 	return s.err
 }

--- a/modules/user/session_revocation_test.go
+++ b/modules/user/session_revocation_test.go
@@ -181,7 +181,7 @@ func TestCommittedSessionRevocationIgnoresCanceledRequestContext(t *testing.T) {
 	prefix := "user-revocation-canceled-token:" + util.GenerUUID() + ":"
 	uidPrefix := "user-revocation-canceled-uid:" + util.GenerUUID() + ":"
 	store := auth.NewRedisSessionStore(client, prefix, uidPrefix, time.Hour, auth.WithSessionMode(auth.SessionModeRevoke), auth.WithSessionMaxPerUID(2))
-	uid := "canceled-" + util.GenerUUID()
+	uid := "c-" + util.GenerUUID()
 	token := "token-" + util.GenerUUID()
 	require.NoError(t, db.Insert(&Model{UID: uid, Name: "canceled user", ShortNo: uid, Password: "before", Status: 1}))
 	t.Cleanup(func() {
@@ -293,6 +293,13 @@ func TestInvalidateCurrentUserTokenIgnoresCanceledRequestContext(t *testing.T) {
 }
 
 func TestPasswordMutationPathsUseCommittedSecurityMutationHelper(t *testing.T) {
+	legacyHashMigrations := map[string]bool{
+		"api.go/login":                       true,
+		"api_emaillogin.go/emailLogin":       true,
+		"api_manager.go/login":               true,
+		"api_usernamelogin.go/usernameLogin": true,
+		"oidc_bind.go/VerifyPasswordByUID":   true,
+	}
 	entries, err := os.ReadDir(".")
 	require.NoError(t, err)
 	var mutationPaths []string
@@ -308,12 +315,15 @@ func TestPasswordMutationPathsUseCommittedSecurityMutationHelper(t *testing.T) {
 			if !ok || function.Body == nil || function.Name.Name == "updatePasswordAndRevokeSessions" {
 				continue
 			}
-			mutatesPassword, usesHelper := passwordMutationCalls(function.Body)
+			mutatesPassword, usesHelper, legacyHashMigration := passwordMutationCalls(function.Body)
 			if !mutatesPassword {
 				continue
 			}
 			path := entry.Name() + "/" + function.Name.Name
 			mutationPaths = append(mutationPaths, path)
+			if legacyHashMigration && legacyHashMigrations[path] {
+				continue
+			}
 			require.True(t, usesHelper, "%s writes the password credential without updatePasswordAndRevokeSessions", path)
 		}
 	}
@@ -322,9 +332,10 @@ func TestPasswordMutationPathsUseCommittedSecurityMutationHelper(t *testing.T) {
 	require.NotEmpty(t, mutationPaths)
 }
 
-func passwordMutationCalls(body *ast.BlockStmt) (mutatesPassword bool, usesHelper bool) {
+func passwordMutationCalls(body *ast.BlockStmt) (mutatesPassword bool, usesHelper bool, legacyHashMigration bool) {
 	var hasPasswordLiteral bool
 	var callsGenericUserWriter bool
+	var callsDirectPasswordWriter bool
 	ast.Inspect(body, func(node ast.Node) bool {
 		switch typed := node.(type) {
 		case *ast.BasicLit:
@@ -342,10 +353,15 @@ func passwordMutationCalls(body *ast.BlockStmt) (mutatesPassword bool, usesHelpe
 			if name == "updateUser" || name == "UpdateUsersWithField" {
 				callsGenericUserWriter = true
 			}
+			if name == "updatePassword" {
+				callsDirectPasswordWriter = true
+			}
 		}
 		return true
 	})
-	return usesHelper || (hasPasswordLiteral && callsGenericUserWriter), usesHelper
+	mutatesPassword = usesHelper || callsDirectPasswordWriter || (hasPasswordLiteral && callsGenericUserWriter)
+	legacyHashMigration = callsDirectPasswordWriter && !callsGenericUserWriter && !usesHelper
+	return mutatesPassword, usesHelper, legacyHashMigration
 }
 
 func calledFunctionName(expression ast.Expr) string {

--- a/modules/user/session_revocation_test.go
+++ b/modules/user/session_revocation_test.go
@@ -71,3 +71,27 @@ func TestPasswordMutationAndSessionRevocationIntentAreDurableAndApplied(t *testi
 	_, err = auth.NewTokenValidator(store, prefix, auth.WithValidatorClock(func() time.Time { return time.Now() })).Validate(context.Background(), postToken)
 	require.NoError(t, err)
 }
+
+func TestAccountDisableAndRevocationIntentCommitTogether(t *testing.T) {
+	_, ctx := testutil.NewTestServer()
+	db := NewDB(ctx)
+	uid := util.GenerUUID()
+	require.NoError(t, db.Insert(&Model{UID: uid, Name: "disable-user", ShortNo: uid, Status: 1}))
+	t.Cleanup(func() {
+		_, _ = ctx.DB().DeleteFrom("user_session_revocation_intent").Where("uid=?", uid).Exec()
+		_, _ = ctx.DB().DeleteFrom("user_session_revocation_version").Where("uid=?", uid).Exec()
+		_, _ = ctx.DB().DeleteFrom("user").Where("uid=?", uid).Exec()
+	})
+
+	intent, err := db.updateUserFieldWithSessionRevocation(context.Background(), uid, "status", "0", "account_disable")
+	require.NoError(t, err)
+	require.NotNil(t, intent)
+	updated, err := db.QueryByUID(uid)
+	require.NoError(t, err)
+	require.Zero(t, updated.Status)
+
+	var pending int
+	_, err = ctx.DB().Select("COUNT(*)").From("user_session_revocation_intent").Where("id=? AND status=?", intent.ID, sessionRevocationPending).Load(&pending)
+	require.NoError(t, err)
+	require.Equal(t, 1, pending)
+}

--- a/modules/user/session_revocation_test.go
+++ b/modules/user/session_revocation_test.go
@@ -131,9 +131,10 @@ func TestNewSessionRevocationIntentReservesSynchronousClaimWindow(t *testing.T) 
 	require.NoError(t, err)
 	require.Nil(t, workerIntent, "a normal worker must not race the synchronous apply immediately after commit")
 
-	claimed, err := db.claimSessionRevocationByID(context.Background(), intent, "sync", now)
+	claim, err := db.claimSessionRevocationByID(context.Background(), intent, "sync", now)
 	require.NoError(t, err)
-	require.True(t, claimed, "the synchronous by-ID path must ignore its own worker visibility delay")
+	require.Equal(t, sessionRevocationClaimAcquired, claim,
+		"the synchronous by-ID path must ignore its own worker visibility delay")
 }
 
 func TestSessionRevocationWorkerAppliesPendingIntent(t *testing.T) {

--- a/modules/user/session_revocation_test.go
+++ b/modules/user/session_revocation_test.go
@@ -9,6 +9,10 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -170,6 +174,45 @@ func TestSessionRevocationWorkerAppliesPendingIntent(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestCommittedSessionRevocationIgnoresCanceledRequestContext(t *testing.T) {
+	_, ctx, userAPI, _ := newTokenHTTPTestServer(t)
+	db := userAPI.db
+	client := octoredis.NewInstrumentedClient(ctx.GetConfig())
+	prefix := "user-revocation-canceled-token:" + util.GenerUUID() + ":"
+	uidPrefix := "user-revocation-canceled-uid:" + util.GenerUUID() + ":"
+	store := auth.NewRedisSessionStore(client, prefix, uidPrefix, time.Hour, auth.WithSessionMode(auth.SessionModeRevoke), auth.WithSessionMaxPerUID(2))
+	uid := "canceled-" + util.GenerUUID()
+	token := "token-" + util.GenerUUID()
+	require.NoError(t, db.Insert(&Model{UID: uid, Name: "canceled user", ShortNo: uid, Password: "before", Status: 1}))
+	t.Cleanup(func() {
+		_, _ = ctx.DB().DeleteFrom("user_session_revocation_intent").Where("uid=?", uid).Exec()
+		_, _ = ctx.DB().DeleteFrom("user_session_revocation_version").Where("uid=?", uid).Exec()
+		_, _ = ctx.DB().DeleteFrom("user").Where("uid=?", uid).Exec()
+		keys, _ := client.Keys(prefix + "*").Result()
+		metadata, _ := client.Keys(uidPrefix + "*").Result()
+		keys = append(keys, metadata...)
+		if len(keys) > 0 {
+			_ = client.Del(keys...).Err()
+		}
+		_ = client.Close()
+	})
+
+	fence, err := store.BeginIssue(context.Background(), uid)
+	require.NoError(t, err)
+	require.NoError(t, store.IssueNewSession(context.Background(), token, auth.TokenInfo{
+		UID: uid, DeviceFlag: int(config.Web), DeviceID: "web-device",
+	}, fence))
+	intent, err := db.updateUserFieldWithSessionRevocation(context.Background(), uid, "password", "after", "password_reset")
+	require.NoError(t, err)
+
+	requestCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+	require.NoError(t, applyAndMarkSessionRevocation(requestCtx, db, store, intent),
+		"a committed intent must use a bounded context detached from the canceled request")
+	_, err = auth.NewTokenValidator(store, prefix).Validate(context.Background(), token)
+	require.Error(t, err)
+}
+
 type logoutFailingSessionStore struct {
 	fakeUserSessionStore
 	err error
@@ -208,6 +251,23 @@ func TestFinishCommittedUserSecurityMutationPreservesCommitBoundary(t *testing.T
 		require.Equal(t, []int{-1}, quitFlags, "a bearer revocation error must not skip independent IM logout")
 	})
 
+	t.Run("committed compatibility mutation ignores request cancellation", func(t *testing.T) {
+		store := &recordingDeviceRevokeStore{
+			tokens: map[int]string{int(config.APP): "app-token"}, failures: make(map[string]error),
+		}
+		requestCtx, cancel := context.WithCancel(context.Background())
+		cancel()
+		quitCalls := 0
+		err := finishCommittedUserSecurityMutation(requestCtx, store, "u1", true, nil, func(_ string, flag int) error {
+			quitCalls++
+			require.Equal(t, -1, flag)
+			return nil
+		})
+		require.NoError(t, err)
+		require.Equal(t, []string{"app-token"}, store.revoked)
+		require.Equal(t, 1, quitCalls)
+	})
+
 	t.Run("committed durable mutation still quits IM when synchronous apply fails", func(t *testing.T) {
 		store := &flakyRevokeAllSessionStore{}
 		applyErr := errors.New("redis unavailable")
@@ -222,48 +282,103 @@ func TestFinishCommittedUserSecurityMutationPreservesCommitBoundary(t *testing.T
 	})
 }
 
-func TestPasswordAndDisablePathsUseCommittedSecurityMutationHelper(t *testing.T) {
-	tests := []struct {
-		file     string
-		function string
-		calls    []string
-	}{
-		{file: "api.go", function: "pwdforget", calls: []string{"updatePasswordAndRevokeSessions"}},
-		{file: "api_emaillogin.go", function: "emailForgetPwd", calls: []string{"updatePasswordAndRevokeSessions"}},
-		{file: "api_manager.go", function: "resetUserPassword", calls: []string{"updatePasswordAndRevokeSessions"}},
-		{file: "api_manager.go", function: "updatePwd", calls: []string{"updatePasswordAndRevokeSessions"}},
-		{file: "api_usernamelogin.go", function: "updatePwd", calls: []string{"updatePasswordAndRevokeSessions"}},
-		{file: "service.go", function: "UpdateLoginPassword", calls: []string{"updatePasswordAndRevokeSessions"}},
-		{file: "api_manager.go", function: "liftBanUser", calls: []string{"updateUserFieldAndRevokeSessionsWithResult", "finishCommittedUserSecurityMutation"}},
+func TestInvalidateCurrentUserTokenIgnoresCanceledRequestContext(t *testing.T) {
+	store := &recordingDeviceRevokeStore{
+		tokens: map[int]string{int(config.APP): "app-token"}, failures: make(map[string]error),
 	}
+	requestCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+	require.NoError(t, invalidateCurrentUserToken(requestCtx, store, "u1", "app-token"))
+	require.Equal(t, []string{"app-token"}, store.revoked)
+}
 
-	for _, tt := range tests {
-		t.Run(tt.file+"/"+tt.function, func(t *testing.T) {
-			fset := gotoken.NewFileSet()
-			file, err := parser.ParseFile(fset, tt.file, nil, 0)
-			require.NoError(t, err)
-			found := make(map[string]bool)
-			for _, declaration := range file.Decls {
-				function, ok := declaration.(*ast.FuncDecl)
-				if !ok || function.Name.Name != tt.function {
-					continue
+func TestPasswordMutationPathsUseCommittedSecurityMutationHelper(t *testing.T) {
+	entries, err := os.ReadDir(".")
+	require.NoError(t, err)
+	var mutationPaths []string
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".go") || strings.HasSuffix(entry.Name(), "_test.go") {
+			continue
+		}
+		fset := gotoken.NewFileSet()
+		file, err := parser.ParseFile(fset, entry.Name(), nil, 0)
+		require.NoError(t, err)
+		for _, declaration := range file.Decls {
+			function, ok := declaration.(*ast.FuncDecl)
+			if !ok || function.Body == nil || function.Name.Name == "updatePasswordAndRevokeSessions" {
+				continue
+			}
+			mutatesPassword, usesHelper := passwordMutationCalls(function.Body)
+			if !mutatesPassword {
+				continue
+			}
+			path := entry.Name() + "/" + function.Name.Name
+			mutationPaths = append(mutationPaths, path)
+			require.True(t, usesHelper, "%s writes the password credential without updatePasswordAndRevokeSessions", path)
+		}
+	}
+	sort.Strings(mutationPaths)
+	require.Contains(t, mutationPaths, "api_usernamelogin.go/resetPwdWithWeb3PublicKey")
+	require.NotEmpty(t, mutationPaths)
+}
+
+func passwordMutationCalls(body *ast.BlockStmt) (mutatesPassword bool, usesHelper bool) {
+	var hasPasswordLiteral bool
+	var callsGenericUserWriter bool
+	ast.Inspect(body, func(node ast.Node) bool {
+		switch typed := node.(type) {
+		case *ast.BasicLit:
+			if typed.Kind == gotoken.STRING {
+				value, err := strconv.Unquote(typed.Value)
+				if err == nil && value == "password" {
+					hasPasswordLiteral = true
 				}
-				ast.Inspect(function.Body, func(node ast.Node) bool {
-					call, ok := node.(*ast.CallExpr)
-					if !ok {
-						return true
-					}
-					if name, ok := call.Fun.(*ast.Ident); ok {
-						found[name.Name] = true
-					}
-					return true
-				})
 			}
-			for _, call := range tt.calls {
-				require.True(t, found[call], "%s must call %s", tt.function, call)
+		case *ast.CallExpr:
+			name := calledFunctionName(typed.Fun)
+			if name == "updatePasswordAndRevokeSessions" {
+				usesHelper = true
 			}
+			if name == "updateUser" || name == "UpdateUsersWithField" {
+				callsGenericUserWriter = true
+			}
+		}
+		return true
+	})
+	return usesHelper || (hasPasswordLiteral && callsGenericUserWriter), usesHelper
+}
+
+func calledFunctionName(expression ast.Expr) string {
+	switch typed := expression.(type) {
+	case *ast.Ident:
+		return typed.Name
+	case *ast.SelectorExpr:
+		return typed.Sel.Name
+	default:
+		return ""
+	}
+}
+
+func TestDisablePathUsesCommittedSecurityMutationHelper(t *testing.T) {
+	fset := gotoken.NewFileSet()
+	file, err := parser.ParseFile(fset, "api_manager.go", nil, 0)
+	require.NoError(t, err)
+	found := make(map[string]bool)
+	for _, declaration := range file.Decls {
+		function, ok := declaration.(*ast.FuncDecl)
+		if !ok || function.Name.Name != "liftBanUser" {
+			continue
+		}
+		ast.Inspect(function.Body, func(node ast.Node) bool {
+			call, ok := node.(*ast.CallExpr)
+			if ok {
+				found[calledFunctionName(call.Fun)] = true
+			}
+			return true
 		})
 	}
+	require.True(t, found["updateUserFieldAndRevokeSessionsWithResult"])
+	require.True(t, found["finishCommittedUserSecurityMutation"])
 }
 
 func TestPasswordMutationRevokesKnownBearersAndQuitsAllIMDevices(t *testing.T) {
@@ -321,6 +436,44 @@ func TestPasswordMutationRevokesKnownBearersAndQuitsAllIMDevices(t *testing.T) {
 	quitFlagsMu.Unlock()
 }
 
+func TestV3WriteCompatibilityRevocationFreesBoundedIndex(t *testing.T) {
+	cfg := config.New()
+	client := octoredis.NewInstrumentedClient(cfg)
+	prefix := "user-v3-index-token:" + util.GenerUUID() + ":"
+	uidPrefix := "user-v3-index-uid:" + util.GenerUUID() + ":"
+	store := auth.NewRedisSessionStore(client, prefix, uidPrefix, time.Hour,
+		auth.WithSessionMode(auth.SessionModeV3Write), auth.WithSessionMaxPerUID(3))
+	uid := "v3-index-" + util.GenerUUID()
+	t.Cleanup(func() {
+		keys, _ := client.Keys(prefix + "*").Result()
+		metadata, _ := client.Keys(uidPrefix + "*").Result()
+		keys = append(keys, metadata...)
+		if len(keys) > 0 {
+			_ = client.Del(keys...).Err()
+		}
+		_ = client.Close()
+	})
+
+	fence, err := store.BeginIssue(context.Background(), uid)
+	require.NoError(t, err)
+	for _, flag := range []config.DeviceFlag{config.APP, config.Web, config.PC} {
+		flagName := strconv.Itoa(int(flag))
+		token := "before-" + flagName + "-" + util.GenerUUID()
+		require.NoError(t, store.IssueNewSession(context.Background(), token, auth.TokenInfo{
+			UID: uid, DeviceFlag: int(flag), DeviceID: "device-" + flagName,
+		}, fence))
+	}
+	require.Empty(t, revokeDeviceTokens(context.Background(), store, uid))
+
+	for _, flag := range []config.DeviceFlag{config.APP, config.Web, config.PC} {
+		flagName := strconv.Itoa(int(flag))
+		token := "after-" + flagName + "-" + util.GenerUUID()
+		require.NoError(t, store.IssueNewSession(context.Background(), token, auth.TokenInfo{
+			UID: uid, DeviceFlag: int(flag), DeviceID: "replacement-" + flagName,
+		}, fence), "all bounded-index slots must be reusable after compatibility revocation")
+	}
+}
+
 func TestDisableUserStillAppliesIMSideEffectsAfterCommittedRevocationFailure(t *testing.T) {
 	server, ctx, _, managerAPI := newTokenHTTPTestServer(t)
 	wireI18nRendererForUserTest(server)
@@ -332,13 +485,16 @@ func TestDisableUserStillAppliesIMSideEffectsAfterCommittedRevocationFailure(t *
 	var imMu sync.Mutex
 	deviceQuitCalls := 0
 	channelCalls := 0
+	var sideEffectOrder []string
 	im := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		imMu.Lock()
 		switch r.URL.Path {
 		case "/user/device_quit":
 			deviceQuitCalls++
+			sideEffectOrder = append(sideEffectOrder, "quit")
 		default:
 			channelCalls++
+			sideEffectOrder = append(sideEffectOrder, "channel")
 		}
 		imMu.Unlock()
 		w.Header().Set("Content-Type", "application/json")
@@ -366,6 +522,18 @@ func TestDisableUserStillAppliesIMSideEffectsAfterCommittedRevocationFailure(t *
 	imMu.Lock()
 	require.Equal(t, 1, deviceQuitCalls, "post-commit Redis failure must not skip independent IM logout")
 	require.Equal(t, 1, channelCalls, "post-commit Redis failure must not skip the IM channel ban")
+	require.Equal(t, []string{"channel", "quit"}, sideEffectOrder, "the channel ban must be visible before disconnecting devices")
+	imMu.Unlock()
+
+	retryRecorder := httptest.NewRecorder()
+	retryRequest := httptest.NewRequest(http.MethodPut, "/test/manager/liftban/"+uid+"/0", nil)
+	server.GetRoute().ServeHTTP(retryRecorder, retryRequest)
+	require.Equal(t, http.StatusOK, retryRecorder.Code, retryRecorder.Body.String())
+	require.Equal(t, 2, store.callCount(), "an already-disabled retry must re-apply the pending revocation intent")
+	imMu.Lock()
+	require.Equal(t, 2, deviceQuitCalls)
+	require.Equal(t, 2, channelCalls)
+	require.Equal(t, []string{"channel", "quit", "channel", "quit"}, sideEffectOrder)
 	imMu.Unlock()
 }
 

--- a/modules/user/session_revocation_test.go
+++ b/modules/user/session_revocation_test.go
@@ -266,6 +266,61 @@ func TestPasswordAndDisablePathsUseCommittedSecurityMutationHelper(t *testing.T)
 	}
 }
 
+func TestPasswordMutationRevokesKnownBearersAndQuitsAllIMDevices(t *testing.T) {
+	_, ctx, userAPI, _ := newTokenHTTPTestServer(t)
+	uid := "pwd-" + util.GenerUUID()
+	require.NoError(t, userAPI.db.Insert(&Model{
+		UID: uid, Name: "password user", ShortNo: uid, Password: "before", Status: int(libcommon.UserAvailable),
+	}))
+
+	tokens := map[config.DeviceFlag]string{
+		config.APP: "pwd-app-" + util.GenerUUID(),
+		config.Web: "pwd-web-" + util.GenerUUID(),
+		config.PC:  "pwd-pc-" + util.GenerUUID(),
+	}
+	for flag, token := range tokens {
+		payload, err := auth.Encode(auth.TokenInfo{UID: uid, DeviceFlag: int(flag)})
+		require.NoError(t, err)
+		require.NoError(t, userAPI.sessionStore.IssueNew(context.Background(), token, payload, uid, int(flag)))
+	}
+
+	var quitFlagsMu sync.Mutex
+	var quitFlags []int
+	im := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/user/device_quit", r.URL.Path)
+		var request struct {
+			DeviceFlag int `json:"device_flag"`
+		}
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		require.NoError(t, util.ReadJsonByByte(body, &request))
+		quitFlagsMu.Lock()
+		quitFlags = append(quitFlags, request.DeviceFlag)
+		quitFlagsMu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(im.Close)
+	ctx.GetConfig().WuKongIM.APIURL = im.URL
+
+	require.NoError(t, updatePasswordAndRevokeSessions(
+		context.Background(), userAPI.db, userAPI.sessionStore, ctx.QuitUserDevice, uid, "after", "password_reset",
+	))
+	updated, err := userAPI.db.QueryByUID(uid)
+	require.NoError(t, err)
+	require.Equal(t, "after", updated.Password)
+	for flag, token := range tokens {
+		indexed, err := userAPI.sessionStore.DeviceToken(context.Background(), uid, int(flag))
+		require.NoError(t, err)
+		require.Empty(t, indexed)
+		record, err := auth.SessionStoreForContext(ctx).ReadToken(context.Background(), ctx.GetConfig().Cache.TokenCachePrefix+token)
+		require.NoError(t, err)
+		require.Equal(t, time.Duration(-2), record.TTL)
+	}
+	quitFlagsMu.Lock()
+	require.Equal(t, []int{-1}, quitFlags)
+	quitFlagsMu.Unlock()
+}
+
 func (s *logoutFailingSessionStore) InvalidateCurrentToken(context.Context, string, string) error {
 	return s.err
 }

--- a/modules/user/sql/20260809000001_user_session_revocation_intent.sql
+++ b/modules/user/sql/20260809000001_user_session_revocation_intent.sql
@@ -1,0 +1,34 @@
+-- +migrate Up
+-- Per-user monotonic event source for durable HTTP-session revocation.
+CREATE TABLE IF NOT EXISTS `user_session_revocation_version` (
+  `uid` VARCHAR(64) NOT NULL,
+  `version` BIGINT UNSIGNED NOT NULL DEFAULT 0,
+  `updated_at` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
+  PRIMARY KEY (`uid`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- Transactional outbox. It intentionally contains no bearer, Redis key,
+-- password, generation, or session-index member.
+CREATE TABLE IF NOT EXISTS `user_session_revocation_intent` (
+  `id` BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+  `event_id` CHAR(36) NOT NULL,
+  `uid` VARCHAR(64) NOT NULL,
+  `event_version` BIGINT UNSIGNED NOT NULL,
+  `reason` VARCHAR(32) NOT NULL,
+  `status` TINYINT UNSIGNED NOT NULL DEFAULT 0,
+  `attempts` INT UNSIGNED NOT NULL DEFAULT 0,
+  `next_attempt_at` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+  `lease_owner` VARCHAR(64) NOT NULL DEFAULT '',
+  `lease_until` DATETIME(3) NULL,
+  `last_error_code` VARCHAR(64) NOT NULL DEFAULT '',
+  `created_at` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+  `applied_at` DATETIME(3) NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_user_session_revocation_event_id` (`event_id`),
+  UNIQUE KEY `uk_user_session_revocation_uid_version` (`uid`, `event_version`),
+  KEY `idx_user_session_revocation_pending` (`status`, `next_attempt_at`, `lease_until`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- +migrate Down
+DROP TABLE IF EXISTS `user_session_revocation_intent`;
+DROP TABLE IF EXISTS `user_session_revocation_version`;

--- a/modules/user/token_http_ttl_test.go
+++ b/modules/user/token_http_ttl_test.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/Mininglamp-OSS/octo-lib/common"
 	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-lib/module"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
@@ -125,6 +126,37 @@ func TestLocalCredentialCannotCrossPasswordChangeBeforeIssueFence(t *testing.T) 
 		fresh, err := managerAPI.userDB.QueryByUID(uid)
 		require.NoError(t, err)
 		require.Equal(t, newHash, fresh.Password)
+	})
+
+	t.Run("external login rechecks account state after fence", func(t *testing.T) {
+		uid := util.GenerUUID()
+		require.NoError(t, userAPI.db.Insert(&Model{
+			UID:      uid,
+			Username: "external" + uid[:8],
+			Name:     "Fenced External User",
+			ShortNo:  "ext_" + uid[:12],
+			Status:   1,
+		}))
+		mutationCalled := false
+		userAPI.sessionStore = &passwordChangeOnBeginIssueStore{
+			RedisSessionStore: realStore,
+			mutate: func() error {
+				mutationCalled = true
+				_, err := userAPI.db.session.Update("user").Set("status", int(common.UserDisable)).Where("uid=?", uid).Exec()
+				return err
+			},
+		}
+
+		result, err := userAPI.externalLoginExisting(context.Background(), ExternalLoginReq{
+			ExistingUID: uid,
+			DeviceFlag:  config.Web,
+		})
+		require.Error(t, err)
+		require.True(t, mutationCalled, "test must mutate status inside BeginIssue; err=%v", err)
+		require.Nil(t, result)
+		fresh, queryErr := userAPI.db.QueryByUID(uid)
+		require.NoError(t, queryErr)
+		require.Equal(t, int(common.UserDisable), fresh.Status)
 	})
 
 	_, client := auth.SessionStoreAndClientForContext(ctx)

--- a/modules/user/token_http_ttl_test.go
+++ b/modules/user/token_http_ttl_test.go
@@ -128,6 +128,45 @@ func TestLocalCredentialCannotCrossPasswordChangeBeforeIssueFence(t *testing.T) 
 		require.Equal(t, newHash, fresh.Password)
 	})
 
+	t.Run("manager login rechecks account state after fence", func(t *testing.T) {
+		uid := util.GenerUUID()
+		username := "disabled-manager-" + uid[:12]
+		password := "manager-password"
+		hash, err := HashPassword(password)
+		require.NoError(t, err)
+		require.NoError(t, managerAPI.userDB.Insert(&Model{
+			UID:      uid,
+			Username: username,
+			Name:     "Disabled Manager",
+			ShortNo:  "mgr_" + uid[:12],
+			Password: hash,
+			Role:     string(wkhttp.SuperAdmin),
+			Status:   int(common.UserAvailable),
+		}))
+		managerAPI.sessionStore = &passwordChangeOnBeginIssueStore{
+			RedisSessionStore: realStore,
+			mutate: func() error {
+				_, err := managerAPI.userDB.session.Update("user").
+					Set("status", int(common.UserDisable)).
+					Where("uid=?", uid).
+					Exec()
+				return err
+			},
+		}
+
+		recorder := httptest.NewRecorder()
+		request := httptest.NewRequest(http.MethodPost, "/v1/manager/login", bytes.NewReader([]byte(util.ToJson(map[string]interface{}{
+			"username": username,
+			"password": password,
+		}))))
+		request.Header.Set("Content-Type", "application/json")
+		server.GetRoute().ServeHTTP(recorder, request)
+		require.Equal(t, http.StatusBadRequest, recorder.Code, "body=%s", recorder.Body.String())
+		fresh, err := managerAPI.userDB.QueryByUID(uid)
+		require.NoError(t, err)
+		require.Equal(t, int(common.UserDisable), fresh.Status)
+	})
+
 	t.Run("external login rechecks account state after fence", func(t *testing.T) {
 		uid := util.GenerUUID()
 		require.NoError(t, userAPI.db.Insert(&Model{

--- a/modules/user/token_http_ttl_test.go
+++ b/modules/user/token_http_ttl_test.go
@@ -25,13 +25,131 @@ var tokenHTTPTestDatabases struct {
 }
 
 func TestTokenDeadlineOverHTTP(t *testing.T) {
-	server, ctx := newTokenHTTPTestServer(t)
+	server, ctx, _, _ := newTokenHTTPTestServer(t)
 	t.Run("manager login issues a finite token", func(t *testing.T) {
 		testManagerLoginIssuesFiniteTokenOverHTTP(t, server, ctx)
 	})
 	t.Run("nickname update preserves the deadline", func(t *testing.T) {
 		testNicknameUpdatePreservesFiniteTokenDeadlineOverHTTP(t, server, ctx)
 	})
+}
+
+func TestLocalCredentialCannotCrossPasswordChangeBeforeIssueFence(t *testing.T) {
+	t.Setenv("OCTO_AUTH_SESSION_MODE", string(auth.SessionModeV3Write))
+	t.Setenv("OCTO_AUTH_SESSION_MAX_PER_UID", "10")
+	server, ctx, userAPI, managerAPI := newTokenHTTPTestServer(t)
+	realStore, ok := userAPI.sessionStore.(*auth.RedisSessionStore)
+	require.True(t, ok)
+
+	t.Run("user login rechecks password after fence", func(t *testing.T) {
+		uid := util.GenerUUID()
+		username := "fenceduser" + uid[:8]
+		oldPassword := "old-user-password"
+		newPassword := "new-user-password"
+		oldHash, err := HashPassword(oldPassword)
+		require.NoError(t, err)
+		newHash, err := HashPassword(newPassword)
+		require.NoError(t, err)
+		require.NoError(t, userAPI.db.Insert(&Model{
+			UID:      uid,
+			Username: username,
+			Name:     "Fenced User",
+			ShortNo:  "usr_" + uid[:12],
+			Password: oldHash,
+			Status:   1,
+		}))
+		loaded, err := userAPI.db.QueryByUsername(username)
+		require.NoError(t, err)
+		require.NotNil(t, loaded)
+		matched, _ := CheckPassword(oldPassword, loaded.Password)
+		require.True(t, matched)
+		require.Equal(t, auth.SessionModeV3Write, realStore.Mode())
+		mutationCalled := false
+		userAPI.sessionStore = &passwordChangeOnBeginIssueStore{
+			RedisSessionStore: realStore,
+			mutate: func() error {
+				mutationCalled = true
+				return userAPI.db.UpdateUsersWithField("password", newHash, uid)
+			},
+		}
+
+		recorder := httptest.NewRecorder()
+		request := httptest.NewRequest(http.MethodPost, "/v1/user/login", bytes.NewReader([]byte(util.ToJson(map[string]interface{}{
+			"username": username,
+			"password": oldPassword,
+			"flag":     int(config.Web),
+		}))))
+		request.Header.Set("Content-Type", "application/json")
+		server.GetRoute().ServeHTTP(recorder, request)
+		require.Equal(t, http.StatusBadRequest, recorder.Code, "body=%s", recorder.Body.String())
+		fresh, err := userAPI.db.QueryByUID(uid)
+		require.NoError(t, err)
+		require.True(t, mutationCalled, "test must mutate the password inside BeginIssue; body=%s", recorder.Body.String())
+		matched, _ = CheckPassword(newPassword, fresh.Password)
+		require.True(t, matched, "the committed password change must remain authoritative")
+	})
+
+	t.Run("manager login rechecks password after fence", func(t *testing.T) {
+		uid := util.GenerUUID()
+		username := "fenced-manager-" + uid[:12]
+		oldPassword := "old-manager-password"
+		newPassword := "new-manager-password"
+		oldHash, err := HashPassword(oldPassword)
+		require.NoError(t, err)
+		newHash, err := HashPassword(newPassword)
+		require.NoError(t, err)
+		require.NoError(t, managerAPI.userDB.Insert(&Model{
+			UID:      uid,
+			Username: username,
+			Name:     "Fenced Manager",
+			ShortNo:  "mgr_" + uid[:12],
+			Password: oldHash,
+			Role:     string(wkhttp.SuperAdmin),
+			Status:   1,
+		}))
+		managerAPI.sessionStore = &passwordChangeOnBeginIssueStore{
+			RedisSessionStore: realStore,
+			mutate: func() error {
+				return managerAPI.userDB.UpdateUsersWithField("password", newHash, uid)
+			},
+		}
+
+		recorder := httptest.NewRecorder()
+		request := httptest.NewRequest(http.MethodPost, "/v1/manager/login", bytes.NewReader([]byte(util.ToJson(map[string]interface{}{
+			"username": username,
+			"password": oldPassword,
+		}))))
+		request.Header.Set("Content-Type", "application/json")
+		server.GetRoute().ServeHTTP(recorder, request)
+		require.Equal(t, http.StatusBadRequest, recorder.Code, "body=%s", recorder.Body.String())
+		fresh, err := managerAPI.userDB.QueryByUID(uid)
+		require.NoError(t, err)
+		require.Equal(t, newHash, fresh.Password)
+	})
+
+	_, client := auth.SessionStoreAndClientForContext(ctx)
+	keys, err := client.Keys(ctx.GetConfig().Cache.TokenCachePrefix + "*").Result()
+	require.NoError(t, err)
+	require.Empty(t, keys, "stale credentials must not produce bearer keys")
+}
+
+type passwordChangeOnBeginIssueStore struct {
+	*auth.RedisSessionStore
+	once   sync.Once
+	mutate func() error
+	err    error
+}
+
+func (s *passwordChangeOnBeginIssueStore) BeginIssue(ctx context.Context, uid string) (auth.IssueFence, error) {
+	s.once.Do(func() {
+		if s.mutate != nil {
+			s.err = s.mutate()
+		}
+	})
+	if s.err != nil {
+		return auth.IssueFence{}, s.err
+	}
+	return s.RedisSessionStore.BeginIssue(ctx, uid)
 }
 
 func testManagerLoginIssuesFiniteTokenOverHTTP(t *testing.T, server *libserver.Server, ctx *config.Context) {
@@ -111,7 +229,7 @@ func testNicknameUpdatePreservesFiniteTokenDeadlineOverHTTP(t *testing.T, server
 	require.LessOrEqual(t, after, before, "profile updates must not extend the bearer deadline")
 }
 
-func newTokenHTTPTestServer(t *testing.T) (*libserver.Server, *config.Context) {
+func newTokenHTTPTestServer(t *testing.T) (*libserver.Server, *config.Context, *User, *Manager) {
 	t.Helper()
 	databaseName := "octo_user_token_ttl_" + util.GenerUUID()[:12]
 	bootstrapConfig := config.New()
@@ -128,6 +246,8 @@ func newTokenHTTPTestServer(t *testing.T) (*libserver.Server, *config.Context) {
 	cfg := config.New()
 	cfg.Test = true
 	cfg.DB.MySQLAddr = fmt.Sprintf("root:demo@tcp(127.0.0.1:3306)/%s?charset=utf8mb4&parseTime=true", databaseName)
+	cfg.Cache.TokenCachePrefix = "token-http:" + util.GenerUUID() + ":"
+	cfg.Cache.UIDTokenCachePrefix = "token-http-uid:" + util.GenerUUID() + ":"
 	ctx := config.NewContext(cfg)
 
 	// module.Setup must run the complete migration set, but octo-lib caches its
@@ -146,7 +266,7 @@ func newTokenHTTPTestServer(t *testing.T) (*libserver.Server, *config.Context) {
 	server := libserver.New(ctx)
 	server.GetRoute().UseGin(ctx.Tracer().GinMiddle())
 	ctx.SetHttpRoute(server.GetRoute())
-	store := auth.SessionStoreForContext(ctx)
+	store, client := auth.SessionStoreAndClientForContext(ctx)
 	server.GetRoute().SetTokenParser(auth.NewCacheTokenParser(
 		ctx.Cache(),
 		cfg.Cache.TokenCachePrefix,
@@ -155,8 +275,17 @@ func newTokenHTTPTestServer(t *testing.T) (*libserver.Server, *config.Context) {
 	userAPI := New(ctx)
 	managerAPI := NewManager(ctx)
 	server.GetRoute().POST("/v1/manager/login", managerAPI.login)
+	server.GetRoute().POST("/v1/user/login", userAPI.login)
 	server.GetRoute().Group("/v1/user", ctx.AuthMiddleware(server.GetRoute())).PUT("/current", userAPI.userUpdateWithField)
-	return server, ctx
+	t.Cleanup(func() {
+		keys, _ := client.Keys(cfg.Cache.TokenCachePrefix + "*").Result()
+		metadata, _ := client.Keys(cfg.Cache.UIDTokenCachePrefix + "*").Result()
+		keys = append(keys, metadata...)
+		if len(keys) > 0 {
+			_ = client.Del(keys...).Err()
+		}
+	})
+	return server, ctx, userAPI, managerAPI
 }
 
 func cleanupTokenHTTPTestDatabases() error {

--- a/modules/user/token_writer_guard_test.go
+++ b/modules/user/token_writer_guard_test.go
@@ -77,6 +77,22 @@ func write(ctx Context, renamed string) {
 	}
 }
 
+func TestDirectTokenWriterGuardRejectsCredentialDeletionMethods(t *testing.T) {
+	for _, method := range []string{"Del", "Delete", "Unlink"} {
+		t.Run(method, func(t *testing.T) {
+			source := fmt.Sprintf(`package fixture
+func remove(ctx Context, renamed string) {
+	ctx.Cache().%s(ctx.GetConfig().Cache.TokenCachePrefix + renamed)
+	ctx.Cache().%s(ctx.GetConfig().Cache.UIDTokenCachePrefix + renamed)
+}`, method, method)
+			fset := gotoken.NewFileSet()
+			file, err := parser.ParseFile(fset, "fixture.go", source, 0)
+			require.NoError(t, err)
+			require.Len(t, tokenWriterViolations(fset, file, "fixture.go"), 2)
+		})
+	}
+}
+
 func TestDirectTokenWriterGuardRejectsSessionSecurityNamespaceMutations(t *testing.T) {
 	tests := []struct {
 		method string

--- a/modules/user/token_writer_guard_test.go
+++ b/modules/user/token_writer_guard_test.go
@@ -153,7 +153,7 @@ func tokenWriterViolations(fset *gotoken.FileSet, file *ast.File, path string) [
 
 func isCredentialWriteMethod(method string) bool {
 	switch method {
-	case "Set", "SetAndExpire", "SetNX", "Persist", "Expire", "ExpireAt":
+	case "Set", "SetAndExpire", "SetNX", "Persist", "Expire", "ExpireAt", "Del", "Delete", "Unlink":
 		return true
 	default:
 		return false

--- a/modules/user/token_writer_guard_test.go
+++ b/modules/user/token_writer_guard_test.go
@@ -8,6 +8,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -76,6 +77,31 @@ func write(ctx Context, renamed string) {
 	}
 }
 
+func TestDirectTokenWriterGuardRejectsSessionSecurityNamespaceMutations(t *testing.T) {
+	tests := []struct {
+		method string
+		key    string
+	}{
+		{method: "Set", key: `"opaque-prefix:auth:generation:" + subject`},
+		{method: "ZAdd", key: `"opaque-prefix:auth:sessions:" + subject`},
+		{method: "Del", key: `"opaque-prefix:auth:legacy-deny:" + subject`},
+		{method: "Expire", key: `"opaque-prefix:auth:rollout-control"`},
+		{method: "SetNX", key: `"opaque-prefix:auth:migration:lock"`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.method+"_"+tt.key, func(t *testing.T) {
+			source := fmt.Sprintf(`package fixture
+func mutate(client Client, subject string) {
+	client.%s(%s, value)
+}`, tt.method, tt.key)
+			fset := gotoken.NewFileSet()
+			file, err := parser.ParseFile(fset, "fixture.go", source, 0)
+			require.NoError(t, err)
+			require.Len(t, tokenWriterViolations(fset, file, "fixture.go"), 1)
+		})
+	}
+}
+
 func directTokenWriterViolations(path string) ([]string, error) {
 	fset := gotoken.NewFileSet()
 	file, err := parser.ParseFile(fset, path, nil, 0)
@@ -96,18 +122,37 @@ func tokenWriterViolations(fset *gotoken.FileSet, file *ast.File, path string) [
 		if !ok {
 			return true
 		}
-		switch selector.Sel.Name {
-		case "Set", "SetAndExpire", "SetNX", "Persist", "Expire", "ExpireAt":
-		default:
+		method := selector.Sel.Name
+		credentialWrite := isCredentialWriteMethod(method) && expressionContainsTokenPrefix(call.Args[0])
+		securityStateMutation := isSecurityStateMutationMethod(method) && expressionContainsSessionSecurityNamespace(call.Args[0])
+		if !credentialWrite && !securityStateMutation {
 			return true
 		}
-		if expressionContainsTokenPrefix(call.Args[0]) {
-			position := fset.Position(call.Pos())
-			violations = append(violations, fmt.Sprintf("%s:%d calls %s with a token cache prefix", path, position.Line, selector.Sel.Name))
-		}
+		position := fset.Position(call.Pos())
+		violations = append(violations, fmt.Sprintf("%s:%d calls %s with a token session security key", path, position.Line, method))
 		return true
 	})
 	return violations
+}
+
+func isCredentialWriteMethod(method string) bool {
+	switch method {
+	case "Set", "SetAndExpire", "SetNX", "Persist", "Expire", "ExpireAt":
+		return true
+	default:
+		return false
+	}
+}
+
+func isSecurityStateMutationMethod(method string) bool {
+	switch method {
+	case "Set", "SetAndExpire", "SetNX", "Persist", "Expire", "ExpireAt",
+		"Del", "Delete", "Unlink", "Rename", "Move", "Copy",
+		"ZAdd", "ZRem", "ZRemRangeByScore", "HSet", "HDel":
+		return true
+	default:
+		return false
+	}
 }
 
 func tokenWriterRepoRoot(t *testing.T) string {
@@ -133,6 +178,34 @@ func expressionContainsTokenPrefix(expression ast.Expr) bool {
 		if ok && (selector.Sel.Name == "TokenCachePrefix" || selector.Sel.Name == "UIDTokenCachePrefix") {
 			found = true
 			return false
+		}
+		return !found
+	})
+	return found
+}
+
+func expressionContainsSessionSecurityNamespace(expression ast.Expr) bool {
+	found := false
+	ast.Inspect(expression, func(node ast.Node) bool {
+		literal, ok := node.(*ast.BasicLit)
+		if !ok || literal.Kind != gotoken.STRING {
+			return !found
+		}
+		value, err := strconv.Unquote(literal.Value)
+		if err != nil {
+			return !found
+		}
+		for _, namespace := range []string{
+			"auth:generation:",
+			"auth:sessions:",
+			"auth:legacy-deny:",
+			"auth:rollout-control",
+			"auth:migration:",
+		} {
+			if strings.Contains(value, namespace) {
+				found = true
+				return false
+			}
 		}
 		return !found
 	})

--- a/pkg/auth/parser_test.go
+++ b/pkg/auth/parser_test.go
@@ -348,6 +348,7 @@ func TestTokenValidatorV3LifetimeAndRedisTTL(t *testing.T) {
 		IssuedAt:          now.Add(-time.Hour).Unix(),
 		ExpiresAt:         now.Add(time.Hour).Unix(),
 		SessionGeneration: "g1",
+		SessionRevision:   1,
 	})
 	if err != nil {
 		t.Fatalf("EncodeV3: %v", err)
@@ -357,6 +358,7 @@ func TestTokenValidatorV3LifetimeAndRedisTTL(t *testing.T) {
 		IssuedAt:          now.Add(-2 * time.Hour).Unix(),
 		ExpiresAt:         now.Unix(),
 		SessionGeneration: "g1",
+		SessionRevision:   1,
 	})
 	if err != nil {
 		t.Fatalf("EncodeV3 expired: %v", err)
@@ -420,6 +422,7 @@ func TestCacheTokenParserUsesTokenValidator(t *testing.T) {
 		IssuedAt:          now.Add(-2 * time.Hour).Unix(),
 		ExpiresAt:         now.Unix(),
 		SessionGeneration: "g1",
+		SessionRevision:   1,
 	})
 	if err != nil {
 		t.Fatalf("EncodeV3: %v", err)

--- a/pkg/auth/runtime.go
+++ b/pkg/auth/runtime.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"runtime"
@@ -64,6 +65,10 @@ func SessionStoreAndClientForContext(ctx *config.Context) (*RedisSessionStore, *
 	if err != nil {
 		panic(err)
 	}
+	policy, err := sessionPolicyFromEnv()
+	if err != nil {
+		panic(err)
+	}
 	client := octoredis.NewInstrumentedClient(ctx.GetConfig(), func(o *rd.Options) {
 		o.MaxRetries = 1
 		o.PoolSize = options.poolSize
@@ -77,7 +82,15 @@ func SessionStoreAndClientForContext(ctx *config.Context) (*RedisSessionStore, *
 		ctx.GetConfig().Cache.TokenCachePrefix,
 		ctx.GetConfig().Cache.UIDTokenCachePrefix,
 		ctx.GetConfig().Cache.TokenExpire,
+		WithSessionMode(policy.mode),
+		WithSessionMaxPerUID(policy.maxPerUID),
 	)
+	validationCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := store.ValidateRolloutControl(validationCtx, policy.requiredFloor); err != nil {
+		_ = client.Close()
+		panic(err)
+	}
 	ctx.SetValue(&sessionRuntime{store: store, client: client}, sessionRuntimeContextKey)
 	return store, client
 }

--- a/pkg/auth/runtime_test.go
+++ b/pkg/auth/runtime_test.go
@@ -74,6 +74,9 @@ func unsetSessionRuntimeEnv(t *testing.T) {
 	for _, key := range []string{
 		"OCTO_AUTH_SESSION_REDIS_POOL_SIZE",
 		"OCTO_AUTH_SESSION_REDIS_POOL_TIMEOUT",
+		sessionModeEnv,
+		sessionMaxPerUIDEnv,
+		sessionRequiredFloorEnv,
 	} {
 		old, existed := os.LookupEnv(key)
 		require.NoError(t, os.Unsetenv(key))

--- a/pkg/auth/session_hardening_test.go
+++ b/pkg/auth/session_hardening_test.go
@@ -209,6 +209,7 @@ func TestTokenValidatorFailsClosedAcrossStoreAndGenerationErrors(t *testing.T) {
 		IssuedAt:          now.Add(-time.Minute).Unix(),
 		ExpiresAt:         now.Add(time.Minute).Unix(),
 		SessionGeneration: "g1",
+		SessionRevision:   1,
 	})
 	require.NoError(t, err)
 	v2, err := Encode(TokenInfo{UID: "u1"})

--- a/pkg/auth/session_migration.go
+++ b/pkg/auth/session_migration.go
@@ -36,13 +36,25 @@ end
 if ttl ~= -1 and ttl <= 0 then
   return {version, ttl, 2}
 end
-local target = tonumber(ARGV[1])
-local cap_target = tonumber(ARGV[2]) + tonumber(ARGV[3])
-if cap_target < target then
-  target = cap_target
+local max_target = tonumber(ARGV[2]) + tonumber(ARGV[3])
+local target = max_target
+if ttl == -1 or ARGV[5] == "cap" then
+  target = tonumber(ARGV[1])
+  if max_target < target then
+    target = max_target
+  end
 end
 local target_ttl = target - tonumber(ARGV[2])
-local shorten = ttl == -1 or target_ttl <= 0 or ttl > target_ttl
+if target_ttl <= 0 then
+  if ARGV[4] == "1" and ARGV[6] ~= "1" then
+    return {version, ttl, 4}
+  end
+  if ARGV[4] == "1" then
+    redis.call("DEL", KEYS[1])
+  end
+  return {version, ttl, 3}
+end
+local shorten = ttl == -1 or ttl > target_ttl
 if not shorten then
   return {version, ttl, 0}
 end
@@ -60,18 +72,32 @@ return redis.call("PEXPIRE", KEYS[1], ARGV[2])
 )
 
 var (
-	ErrMigrationLockHeld = errors.New("auth: token migration lock is held")
-	ErrMigrationLockLost = errors.New("auth: token migration lock was lost")
+	ErrMigrationLockHeld                          = errors.New("auth: token migration lock is held")
+	ErrMigrationLockLost                          = errors.New("auth: token migration lock was lost")
+	ErrMigrationElapsedCutoffConfirmationRequired = errors.New("auth: migration apply requires confirm elapsed cutoff")
 )
 
 type LegacyMigrationOptions struct {
-	CampaignID string
-	CutoffAt   time.Time
-	BatchSize  int64
-	Interval   time.Duration
-	Apply      bool
-	Lease      time.Duration
+	CampaignID           string
+	CutoffAt             time.Time
+	FinitePolicy         LegacyFinitePolicy
+	BatchSize            int64
+	Interval             time.Duration
+	Apply                bool
+	ConfirmElapsedCutoff bool
+	Lease                time.Duration
 }
+
+type LegacyFinitePolicy string
+
+const (
+	// LegacyFinitePolicyNatural preserves finite legacy deadlines that already
+	// fit within maxTTL. Persistent and over-max records are still bounded.
+	LegacyFinitePolicyNatural LegacyFinitePolicy = "natural"
+	// LegacyFinitePolicyCap also compresses finite legacy deadlines to the
+	// campaign cutoff. This may log users out earlier and requires approval.
+	LegacyFinitePolicyCap LegacyFinitePolicy = "cap"
+)
 
 type LegacyMigrationResult struct {
 	Complete    bool   `json:"complete"`
@@ -82,6 +108,8 @@ type LegacyMigrationResult struct {
 	V2          int64  `json:"v2"`
 	V3          int64  `json:"v3"`
 	Shortened   int64  `json:"shortened"`
+	WouldDelete int64  `json:"would_delete"`
+	Deleted     int64  `json:"deleted"`
 	Unchanged   int64  `json:"unchanged"`
 	Invalid     int64  `json:"invalid"`
 	V3NonFinite int64  `json:"v3_non_finite"`
@@ -93,8 +121,6 @@ type legacyMigrationCampaign struct {
 	CampaignID   string `json:"campaign_id"`
 	CutoffAtMS   int64  `json:"cutoff_at_unix_ms"`
 	MaxTTLMS     int64  `json:"max_ttl_ms"`
-	BatchSize    int64  `json:"batch_size"`
-	IntervalMS   int64  `json:"interval_ms"`
 	FinitePolicy string `json:"finite_policy"`
 }
 
@@ -200,7 +226,7 @@ func (s *RedisSessionStore) MigrateLegacySessions(ctx context.Context, options L
 					return result, err
 				}
 			}
-			if err := s.migrateLegacyToken(key, campaign, options.Apply, &result); err != nil {
+			if err := s.migrateLegacyToken(key, campaign, options.Apply, options.ConfirmElapsedCutoff, &result); err != nil {
 				return result, err
 			}
 		}
@@ -221,6 +247,9 @@ func (s *RedisSessionStore) MigrateLegacySessions(ctx context.Context, options L
 				if err := s.saveMigrationCheckpoint(campaign.CampaignID, 0, result); err != nil {
 					return result, err
 				}
+				if err := s.recordMigrationCompletion(campaign.CampaignID, result); err != nil {
+					return result, err
+				}
 			}
 			return result, nil
 		}
@@ -235,6 +264,9 @@ func (s *RedisSessionStore) validateMigrationOptions(options LegacyMigrationOpti
 	if options.CutoffAt.IsZero() {
 		return legacyMigrationCampaign{}, errors.New("auth: migration cutoff is required")
 	}
+	if options.FinitePolicy != LegacyFinitePolicyNatural && options.FinitePolicy != LegacyFinitePolicyCap {
+		return legacyMigrationCampaign{}, errors.New("auth: migration finite policy must be natural or cap")
+	}
 	if options.BatchSize <= 0 || options.BatchSize > 10_000 {
 		return legacyMigrationCampaign{}, errors.New("auth: migration batch size must be between 1 and 10000")
 	}
@@ -242,28 +274,30 @@ func (s *RedisSessionStore) validateMigrationOptions(options LegacyMigrationOpti
 		return legacyMigrationCampaign{}, errors.New("auth: migration interval must not be negative")
 	}
 	if options.Apply {
+		if options.CutoffAt.UTC().UnixMilli() <= s.now().UTC().UnixMilli() && !options.ConfirmElapsedCutoff {
+			return legacyMigrationCampaign{}, ErrMigrationElapsedCutoffConfirmationRequired
+		}
 		if options.Lease < 5*time.Second || options.Lease > 5*time.Minute {
 			return legacyMigrationCampaign{}, errors.New("auth: migration lease must be between 5s and 5m")
-		}
-		if !options.CutoffAt.After(time.Now()) {
-			return legacyMigrationCampaign{}, errors.New("auth: migration cutoff must be in the future when apply is enabled")
 		}
 	}
 	return legacyMigrationCampaign{
 		CampaignID:   campaignID,
 		CutoffAtMS:   options.CutoffAt.UTC().UnixMilli(),
 		MaxTTLMS:     s.maxTTL.Milliseconds(),
-		BatchSize:    options.BatchSize,
-		IntervalMS:   options.Interval.Milliseconds(),
-		FinitePolicy: "cap",
+		FinitePolicy: string(options.FinitePolicy),
 	}, nil
 }
 
-func (s *RedisSessionStore) migrateLegacyToken(key string, campaign legacyMigrationCampaign, apply bool, result *LegacyMigrationResult) error {
-	nowMS := time.Now().UTC().UnixMilli()
+func (s *RedisSessionStore) migrateLegacyToken(key string, campaign legacyMigrationCampaign, apply, confirmElapsedCutoff bool, result *LegacyMigrationResult) error {
+	nowMS := s.now().UTC().UnixMilli()
 	applyArg := "0"
 	if apply {
 		applyArg = "1"
+	}
+	confirmElapsedCutoffArg := "0"
+	if confirmElapsedCutoff {
+		confirmElapsedCutoffArg = "1"
 	}
 	raw, err := migrateLegacyTokenScript.Run(
 		s.client,
@@ -272,6 +306,8 @@ func (s *RedisSessionStore) migrateLegacyToken(key string, campaign legacyMigrat
 		nowMS,
 		campaign.MaxTTLMS,
 		applyArg,
+		campaign.FinitePolicy,
+		confirmElapsedCutoffArg,
 	).Result()
 	if err != nil {
 		return fmt.Errorf("auth: migrate token record: %w", err)
@@ -315,6 +351,14 @@ func (s *RedisSessionStore) migrateLegacyToken(key string, campaign legacyMigrat
 		result.Shortened++
 	case 2:
 		result.Invalid++
+	case 3:
+		if apply {
+			result.Deleted++
+		} else {
+			result.WouldDelete++
+		}
+	case 4:
+		return ErrMigrationElapsedCutoffConfirmationRequired
 	default:
 		return fmt.Errorf("auth: invalid migration action %d", action)
 	}
@@ -326,28 +370,43 @@ func (s *RedisSessionStore) ensureMigrationCampaign(campaign legacyMigrationCamp
 	if err != nil {
 		return err
 	}
-	created, err := s.client.SetNX(s.migrationCampaignKey(), string(encoded), 0).Result()
+	key := s.migrationCampaignKey(campaign.CampaignID)
+	current, err := s.client.Get(key).Result()
+	if err == nil {
+		return s.validatePersistedMigrationCampaign(key, current, string(encoded))
+	}
+	if err != rd.Nil {
+		return fmt.Errorf("auth: load migration campaign: %w", err)
+	}
+	if campaign.CutoffAtMS <= s.now().UTC().UnixMilli() {
+		return errors.New("auth: a new migration campaign cutoff must be in the future")
+	}
+	created, err := s.client.SetNX(key, string(encoded), 0).Result()
 	if err != nil {
 		return fmt.Errorf("auth: initialize migration campaign: %w", err)
 	}
 	if created {
 		return nil
 	}
-	current, err := s.client.Get(s.migrationCampaignKey()).Result()
+	current, err = s.client.Get(key).Result()
 	if err != nil {
 		return fmt.Errorf("auth: load migration campaign: %w", err)
 	}
-	if current != string(encoded) {
+	return s.validatePersistedMigrationCampaign(key, current, string(encoded))
+}
+
+func (s *RedisSessionStore) validatePersistedMigrationCampaign(key, current, expected string) error {
+	if current != expected {
 		return errors.New("auth: migration campaign parameters do not match persisted campaign")
 	}
-	if ttl, err := s.client.PTTL(s.migrationCampaignKey()).Result(); err != nil || ttl != -time.Millisecond {
+	if ttl, err := s.client.PTTL(key).Result(); err != nil || ttl != -time.Millisecond {
 		return errors.New("auth: migration campaign record must not expire")
 	}
 	return nil
 }
 
 func (s *RedisSessionStore) loadMigrationCheckpoint(campaignID string) (*legacyMigrationCheckpoint, error) {
-	raw, err := s.client.Get(s.migrationCheckpointKey()).Result()
+	raw, err := s.client.Get(s.migrationCheckpointKey(campaignID)).Result()
 	if err == rd.Nil {
 		return nil, nil
 	}
@@ -369,7 +428,7 @@ func (s *RedisSessionStore) saveMigrationCheckpoint(campaignID string, cursor ui
 	if err != nil {
 		return err
 	}
-	if err := s.client.Set(s.migrationCheckpointKey(), string(encoded), 0).Err(); err != nil {
+	if err := s.client.Set(s.migrationCheckpointKey(campaignID), string(encoded), 0).Err(); err != nil {
 		return fmt.Errorf("auth: save migration checkpoint: %w", err)
 	}
 	return nil
@@ -435,12 +494,12 @@ func migrationLockError(errorsCh <-chan error) error {
 	}
 }
 
-func (s *RedisSessionStore) migrationCampaignKey() string {
-	return s.uidTokenPrefix + "auth:migration:campaign"
+func (s *RedisSessionStore) migrationCampaignKey(campaignID string) string {
+	return s.uidTokenPrefix + "auth:migration:campaign:" + sessionSubject(campaignID)
 }
 
-func (s *RedisSessionStore) migrationCheckpointKey() string {
-	return s.uidTokenPrefix + "auth:migration:checkpoint"
+func (s *RedisSessionStore) migrationCheckpointKey(campaignID string) string {
+	return s.uidTokenPrefix + "auth:migration:checkpoint:" + sessionSubject(campaignID)
 }
 
 func (s *RedisSessionStore) migrationLockKey() string {

--- a/pkg/auth/session_migration.go
+++ b/pkg/auth/session_migration.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -125,9 +126,10 @@ type legacyMigrationCampaign struct {
 }
 
 type legacyMigrationCheckpoint struct {
-	CampaignID string                `json:"campaign_id"`
-	Cursor     uint64                `json:"cursor"`
-	Result     LegacyMigrationResult `json:"result"`
+	CampaignID      string                `json:"campaign_id"`
+	RedisInstanceID string                `json:"redis_instance_id"`
+	Cursor          uint64                `json:"cursor"`
+	Result          LegacyMigrationResult `json:"result"`
 }
 
 func (s *RedisSessionStore) MigrateLegacySessions(ctx context.Context, options LegacyMigrationOptions) (result LegacyMigrationResult, err error) {
@@ -147,6 +149,7 @@ func (s *RedisSessionStore) MigrateLegacySessions(ctx context.Context, options L
 	}
 
 	owner := ""
+	redisInstanceID := ""
 	var lockErrors <-chan error
 	if options.Apply {
 		if err := s.ensureMigrationCampaign(campaign); err != nil {
@@ -169,6 +172,10 @@ func (s *RedisSessionStore) MigrateLegacySessions(ctx context.Context, options L
 		keepaliveCtx, stopKeepalive := context.WithCancel(ctx)
 		defer stopKeepalive()
 		lockErrors = s.keepMigrationLockAlive(keepaliveCtx, owner, options.Lease)
+		redisInstanceID, err = s.currentRedisInstanceID()
+		if err != nil {
+			return result, fmt.Errorf("auth: identify migration Redis instance: %w", err)
+		}
 		checkpoint, loadErr := s.loadMigrationCheckpoint(campaign.CampaignID)
 		if loadErr != nil {
 			return result, loadErr
@@ -177,6 +184,9 @@ func (s *RedisSessionStore) MigrateLegacySessions(ctx context.Context, options L
 			result = checkpoint.Result
 			result.Complete = false
 			result.LockLost = false
+			if checkpoint.RedisInstanceID != redisInstanceID {
+				result.LastCursor = 0
+			}
 		}
 	}
 
@@ -200,6 +210,19 @@ func (s *RedisSessionStore) MigrateLegacySessions(ctx context.Context, options L
 			if err := s.confirmMigrationLock(owner, options.Lease); err != nil {
 				result.LockLost = errors.Is(err, ErrMigrationLockLost)
 				return result, err
+			}
+			currentRedisInstanceID, err := s.currentRedisInstanceID()
+			if err != nil {
+				return result, fmt.Errorf("auth: identify migration Redis instance before scan: %w", err)
+			}
+			if currentRedisInstanceID != redisInstanceID {
+				redisInstanceID = currentRedisInstanceID
+				cursor = 0
+				result.LastCursor = 0
+				if err := s.confirmMigrationLock(owner, options.Lease); err != nil {
+					result.LockLost = errors.Is(err, ErrMigrationLockLost)
+					return result, err
+				}
 			}
 		}
 		keys, next, err := s.client.Scan(cursor, s.tokenPrefix+"*", options.BatchSize).Result()
@@ -233,21 +256,56 @@ func (s *RedisSessionStore) MigrateLegacySessions(ctx context.Context, options L
 		cursor = next
 		result.LastCursor = cursor
 		if options.Apply {
+			currentRedisInstanceID, err := s.currentRedisInstanceID()
+			if err != nil {
+				return result, fmt.Errorf("auth: identify migration Redis instance after scan: %w", err)
+			}
+			if currentRedisInstanceID != redisInstanceID {
+				redisInstanceID = currentRedisInstanceID
+				cursor = 0
+				result.LastCursor = 0
+				if err := s.confirmMigrationLock(owner, options.Lease); err != nil {
+					result.LockLost = errors.Is(err, ErrMigrationLockLost)
+					return result, err
+				}
+				if err := s.saveMigrationCheckpoint(campaign.CampaignID, redisInstanceID, 0, result); err != nil {
+					return result, err
+				}
+				continue
+			}
 			if err := s.confirmMigrationLock(owner, options.Lease); err != nil {
 				result.LockLost = errors.Is(err, ErrMigrationLockLost)
 				return result, err
 			}
-			if err := s.saveMigrationCheckpoint(campaign.CampaignID, cursor, result); err != nil {
+			if err := s.saveMigrationCheckpoint(campaign.CampaignID, redisInstanceID, cursor, result); err != nil {
 				return result, err
 			}
 		}
 		if cursor == 0 {
+			if options.Apply {
+				currentRedisInstanceID, err := s.currentRedisInstanceID()
+				if err != nil {
+					return result, fmt.Errorf("auth: identify migration Redis instance before completion: %w", err)
+				}
+				if currentRedisInstanceID != redisInstanceID {
+					redisInstanceID = currentRedisInstanceID
+					result.LastCursor = 0
+					if err := s.confirmMigrationLock(owner, options.Lease); err != nil {
+						result.LockLost = errors.Is(err, ErrMigrationLockLost)
+						return result, err
+					}
+					if err := s.saveMigrationCheckpoint(campaign.CampaignID, redisInstanceID, 0, result); err != nil {
+						return result, err
+					}
+					continue
+				}
+			}
 			result.Complete = true
 			if options.Apply {
-				if err := s.saveMigrationCheckpoint(campaign.CampaignID, 0, result); err != nil {
+				if err := s.saveMigrationCheckpoint(campaign.CampaignID, redisInstanceID, 0, result); err != nil {
 					return result, err
 				}
-				if err := s.recordMigrationCompletion(campaign.CampaignID, result); err != nil {
+				if err := s.recordMigrationCompletion(campaign.CampaignID, redisInstanceID, result); err != nil {
 					return result, err
 				}
 			}
@@ -420,11 +478,19 @@ func (s *RedisSessionStore) loadMigrationCheckpoint(campaignID string) (*legacyM
 	if checkpoint.CampaignID != campaignID {
 		return nil, errors.New("auth: migration checkpoint belongs to another campaign")
 	}
+	if checkpoint.Result.CampaignID != campaignID || checkpoint.Cursor != checkpoint.Result.LastCursor {
+		return nil, errors.New("auth: migration checkpoint is internally inconsistent")
+	}
 	return &checkpoint, nil
 }
 
-func (s *RedisSessionStore) saveMigrationCheckpoint(campaignID string, cursor uint64, result LegacyMigrationResult) error {
-	encoded, err := json.Marshal(legacyMigrationCheckpoint{CampaignID: campaignID, Cursor: cursor, Result: result})
+func (s *RedisSessionStore) saveMigrationCheckpoint(campaignID, redisInstanceID string, cursor uint64, result LegacyMigrationResult) error {
+	encoded, err := json.Marshal(legacyMigrationCheckpoint{
+		CampaignID:      campaignID,
+		RedisInstanceID: redisInstanceID,
+		Cursor:          cursor,
+		Result:          result,
+	})
 	if err != nil {
 		return err
 	}
@@ -432,6 +498,36 @@ func (s *RedisSessionStore) saveMigrationCheckpoint(campaignID string, cursor ui
 		return fmt.Errorf("auth: save migration checkpoint: %w", err)
 	}
 	return nil
+}
+
+func (s *RedisSessionStore) currentRedisInstanceID() (string, error) {
+	if s.redisInstanceIDFn != nil {
+		instanceID, err := s.redisInstanceIDFn()
+		if err != nil {
+			return "", err
+		}
+		if strings.TrimSpace(instanceID) == "" {
+			return "", errors.New("Redis instance identity must not be empty")
+		}
+		return instanceID, nil
+	}
+	info, err := s.client.Info("server").Result()
+	if err != nil {
+		return "", fmt.Errorf("read Redis INFO server: %w", err)
+	}
+	var runID string
+	for _, line := range strings.Split(info, "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "run_id:") {
+			runID = strings.TrimSpace(strings.TrimPrefix(line, "run_id:"))
+			break
+		}
+	}
+	if runID == "" {
+		return "", errors.New("Redis INFO server did not return run_id")
+	}
+	sum := sha256.Sum256([]byte("token-session-migration/v1:" + runID))
+	return fmt.Sprintf("%x", sum[:]), nil
 }
 
 func (s *RedisSessionStore) renewMigrationLock(owner string, lease time.Duration) (bool, error) {

--- a/pkg/auth/session_migration.go
+++ b/pkg/auth/session_migration.go
@@ -1,0 +1,448 @@
+package auth
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	rd "github.com/go-redis/redis"
+)
+
+var (
+	migrateLegacyTokenScript = rd.NewScript(`
+local value = redis.call("GET", KEYS[1])
+if not value then
+  return {0, -2, 0}
+end
+local ttl = redis.call("PTTL", KEYS[1])
+local version = 1
+if string.sub(value, 1, 3) == "v3:" then
+  version = 3
+elseif string.sub(value, 1, 3) == "v2:" then
+  version = 2
+end
+if version == 3 then
+  if ttl <= 0 then
+    return {version, ttl, 2}
+  end
+  return {version, ttl, 0}
+end
+if ttl == -2 then
+  return {0, ttl, 0}
+end
+if ttl ~= -1 and ttl <= 0 then
+  return {version, ttl, 2}
+end
+local target = tonumber(ARGV[1])
+local cap_target = tonumber(ARGV[2]) + tonumber(ARGV[3])
+if cap_target < target then
+  target = cap_target
+end
+local target_ttl = target - tonumber(ARGV[2])
+local shorten = ttl == -1 or target_ttl <= 0 or ttl > target_ttl
+if not shorten then
+  return {version, ttl, 0}
+end
+if ARGV[4] == "1" then
+  redis.call("PEXPIREAT", KEYS[1], target)
+end
+return {version, ttl, 1}
+`)
+	renewMigrationLockScript = rd.NewScript(`
+if redis.call("GET", KEYS[1]) ~= ARGV[1] then
+  return 0
+end
+return redis.call("PEXPIRE", KEYS[1], ARGV[2])
+`)
+)
+
+var (
+	ErrMigrationLockHeld = errors.New("auth: token migration lock is held")
+	ErrMigrationLockLost = errors.New("auth: token migration lock was lost")
+)
+
+type LegacyMigrationOptions struct {
+	CampaignID string
+	CutoffAt   time.Time
+	BatchSize  int64
+	Interval   time.Duration
+	Apply      bool
+	Lease      time.Duration
+}
+
+type LegacyMigrationResult struct {
+	Complete    bool   `json:"complete"`
+	CampaignID  string `json:"campaign_id"`
+	Scanned     int64  `json:"scanned"`
+	Missing     int64  `json:"missing"`
+	V1          int64  `json:"v1"`
+	V2          int64  `json:"v2"`
+	V3          int64  `json:"v3"`
+	Shortened   int64  `json:"shortened"`
+	Unchanged   int64  `json:"unchanged"`
+	Invalid     int64  `json:"invalid"`
+	V3NonFinite int64  `json:"v3_non_finite"`
+	LastCursor  uint64 `json:"last_cursor"`
+	LockLost    bool   `json:"lock_lost"`
+}
+
+type legacyMigrationCampaign struct {
+	CampaignID   string `json:"campaign_id"`
+	CutoffAtMS   int64  `json:"cutoff_at_unix_ms"`
+	MaxTTLMS     int64  `json:"max_ttl_ms"`
+	BatchSize    int64  `json:"batch_size"`
+	IntervalMS   int64  `json:"interval_ms"`
+	FinitePolicy string `json:"finite_policy"`
+}
+
+type legacyMigrationCheckpoint struct {
+	CampaignID string                `json:"campaign_id"`
+	Cursor     uint64                `json:"cursor"`
+	Result     LegacyMigrationResult `json:"result"`
+}
+
+func (s *RedisSessionStore) MigrateLegacySessions(ctx context.Context, options LegacyMigrationOptions) (result LegacyMigrationResult, err error) {
+	campaign, err := s.validateMigrationOptions(options)
+	if err != nil {
+		return LegacyMigrationResult{}, err
+	}
+	result.CampaignID = campaign.CampaignID
+	if options.Apply {
+		control, err := s.RolloutControl(ctx)
+		if err != nil {
+			return result, err
+		}
+		if control == nil || control.ModeFloor.rank() < SessionModeRevoke.rank() {
+			return result, errors.New("auth: migration apply requires persisted revoke rollout floor")
+		}
+	}
+
+	owner := ""
+	var lockErrors <-chan error
+	if options.Apply {
+		if err := s.ensureMigrationCampaign(campaign); err != nil {
+			return result, err
+		}
+		owner, err = newSessionGeneration()
+		if err != nil {
+			return result, err
+		}
+		acquired, err := s.client.SetNX(s.migrationLockKey(), owner, options.Lease).Result()
+		if err != nil {
+			return result, fmt.Errorf("auth: acquire migration lock: %w", err)
+		}
+		if !acquired {
+			return result, ErrMigrationLockHeld
+		}
+		defer func() {
+			_, _ = compareDeleteScript.Run(s.client, []string{s.migrationLockKey()}, owner).Result()
+		}()
+		keepaliveCtx, stopKeepalive := context.WithCancel(ctx)
+		defer stopKeepalive()
+		lockErrors = s.keepMigrationLockAlive(keepaliveCtx, owner, options.Lease)
+		checkpoint, loadErr := s.loadMigrationCheckpoint(campaign.CampaignID)
+		if loadErr != nil {
+			return result, loadErr
+		}
+		if checkpoint != nil && !checkpoint.Result.Complete {
+			result = checkpoint.Result
+			result.Complete = false
+			result.LockLost = false
+		}
+	}
+
+	var throttle <-chan time.Time
+	var ticker *time.Ticker
+	if options.Interval > 0 {
+		ticker = time.NewTicker(options.Interval)
+		defer ticker.Stop()
+		throttle = ticker.C
+	}
+	cursor := result.LastCursor
+	for {
+		if err := ctx.Err(); err != nil {
+			return result, err
+		}
+		if options.Apply {
+			if err := migrationLockError(lockErrors); err != nil {
+				result.LockLost = errors.Is(err, ErrMigrationLockLost)
+				return result, err
+			}
+			if err := s.confirmMigrationLock(owner, options.Lease); err != nil {
+				result.LockLost = errors.Is(err, ErrMigrationLockLost)
+				return result, err
+			}
+		}
+		keys, next, err := s.client.Scan(cursor, s.tokenPrefix+"*", options.BatchSize).Result()
+		if err != nil {
+			return result, fmt.Errorf("auth: migration scan: %w", err)
+		}
+		for _, key := range keys {
+			if options.Apply {
+				if err := migrationLockError(lockErrors); err != nil {
+					result.LockLost = errors.Is(err, ErrMigrationLockLost)
+					return result, err
+				}
+			}
+			if throttle != nil {
+				select {
+				case <-ctx.Done():
+					return result, ctx.Err()
+				case <-throttle:
+				}
+			}
+			if options.Apply {
+				if err := migrationLockError(lockErrors); err != nil {
+					result.LockLost = errors.Is(err, ErrMigrationLockLost)
+					return result, err
+				}
+			}
+			if err := s.migrateLegacyToken(key, campaign, options.Apply, &result); err != nil {
+				return result, err
+			}
+		}
+		cursor = next
+		result.LastCursor = cursor
+		if options.Apply {
+			if err := s.confirmMigrationLock(owner, options.Lease); err != nil {
+				result.LockLost = errors.Is(err, ErrMigrationLockLost)
+				return result, err
+			}
+			if err := s.saveMigrationCheckpoint(campaign.CampaignID, cursor, result); err != nil {
+				return result, err
+			}
+		}
+		if cursor == 0 {
+			result.Complete = true
+			if options.Apply {
+				if err := s.saveMigrationCheckpoint(campaign.CampaignID, 0, result); err != nil {
+					return result, err
+				}
+			}
+			return result, nil
+		}
+	}
+}
+
+func (s *RedisSessionStore) validateMigrationOptions(options LegacyMigrationOptions) (legacyMigrationCampaign, error) {
+	campaignID := strings.TrimSpace(options.CampaignID)
+	if campaignID == "" || len(campaignID) > 64 {
+		return legacyMigrationCampaign{}, errors.New("auth: migration campaign id must contain 1-64 characters")
+	}
+	if options.CutoffAt.IsZero() {
+		return legacyMigrationCampaign{}, errors.New("auth: migration cutoff is required")
+	}
+	if options.BatchSize <= 0 || options.BatchSize > 10_000 {
+		return legacyMigrationCampaign{}, errors.New("auth: migration batch size must be between 1 and 10000")
+	}
+	if options.Interval < 0 {
+		return legacyMigrationCampaign{}, errors.New("auth: migration interval must not be negative")
+	}
+	if options.Apply {
+		if options.Lease < 5*time.Second || options.Lease > 5*time.Minute {
+			return legacyMigrationCampaign{}, errors.New("auth: migration lease must be between 5s and 5m")
+		}
+		if !options.CutoffAt.After(time.Now()) {
+			return legacyMigrationCampaign{}, errors.New("auth: migration cutoff must be in the future when apply is enabled")
+		}
+	}
+	return legacyMigrationCampaign{
+		CampaignID:   campaignID,
+		CutoffAtMS:   options.CutoffAt.UTC().UnixMilli(),
+		MaxTTLMS:     s.maxTTL.Milliseconds(),
+		BatchSize:    options.BatchSize,
+		IntervalMS:   options.Interval.Milliseconds(),
+		FinitePolicy: "cap",
+	}, nil
+}
+
+func (s *RedisSessionStore) migrateLegacyToken(key string, campaign legacyMigrationCampaign, apply bool, result *LegacyMigrationResult) error {
+	nowMS := time.Now().UTC().UnixMilli()
+	applyArg := "0"
+	if apply {
+		applyArg = "1"
+	}
+	raw, err := migrateLegacyTokenScript.Run(
+		s.client,
+		[]string{key},
+		campaign.CutoffAtMS,
+		nowMS,
+		campaign.MaxTTLMS,
+		applyArg,
+	).Result()
+	if err != nil {
+		return fmt.Errorf("auth: migrate token record: %w", err)
+	}
+	parts, ok := raw.([]interface{})
+	if !ok || len(parts) != 3 {
+		return fmt.Errorf("auth: invalid migration result %T", raw)
+	}
+	version, err := redisInteger(parts[0])
+	if err != nil {
+		return err
+	}
+	ttl, err := redisInteger(parts[1])
+	if err != nil {
+		return err
+	}
+	action, err := redisInteger(parts[2])
+	if err != nil {
+		return err
+	}
+	result.Scanned++
+	switch version {
+	case 0:
+		result.Missing++
+	case 1:
+		result.V1++
+	case 2:
+		result.V2++
+	case 3:
+		result.V3++
+		if ttl <= 0 {
+			result.V3NonFinite++
+		}
+	default:
+		result.Invalid++
+	}
+	switch action {
+	case 0:
+		result.Unchanged++
+	case 1:
+		result.Shortened++
+	case 2:
+		result.Invalid++
+	default:
+		return fmt.Errorf("auth: invalid migration action %d", action)
+	}
+	return nil
+}
+
+func (s *RedisSessionStore) ensureMigrationCampaign(campaign legacyMigrationCampaign) error {
+	encoded, err := json.Marshal(campaign)
+	if err != nil {
+		return err
+	}
+	created, err := s.client.SetNX(s.migrationCampaignKey(), string(encoded), 0).Result()
+	if err != nil {
+		return fmt.Errorf("auth: initialize migration campaign: %w", err)
+	}
+	if created {
+		return nil
+	}
+	current, err := s.client.Get(s.migrationCampaignKey()).Result()
+	if err != nil {
+		return fmt.Errorf("auth: load migration campaign: %w", err)
+	}
+	if current != string(encoded) {
+		return errors.New("auth: migration campaign parameters do not match persisted campaign")
+	}
+	if ttl, err := s.client.PTTL(s.migrationCampaignKey()).Result(); err != nil || ttl != -time.Millisecond {
+		return errors.New("auth: migration campaign record must not expire")
+	}
+	return nil
+}
+
+func (s *RedisSessionStore) loadMigrationCheckpoint(campaignID string) (*legacyMigrationCheckpoint, error) {
+	raw, err := s.client.Get(s.migrationCheckpointKey()).Result()
+	if err == rd.Nil {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("auth: load migration checkpoint: %w", err)
+	}
+	var checkpoint legacyMigrationCheckpoint
+	if err := json.Unmarshal([]byte(raw), &checkpoint); err != nil {
+		return nil, fmt.Errorf("auth: decode migration checkpoint: %w", err)
+	}
+	if checkpoint.CampaignID != campaignID {
+		return nil, errors.New("auth: migration checkpoint belongs to another campaign")
+	}
+	return &checkpoint, nil
+}
+
+func (s *RedisSessionStore) saveMigrationCheckpoint(campaignID string, cursor uint64, result LegacyMigrationResult) error {
+	encoded, err := json.Marshal(legacyMigrationCheckpoint{CampaignID: campaignID, Cursor: cursor, Result: result})
+	if err != nil {
+		return err
+	}
+	if err := s.client.Set(s.migrationCheckpointKey(), string(encoded), 0).Err(); err != nil {
+		return fmt.Errorf("auth: save migration checkpoint: %w", err)
+	}
+	return nil
+}
+
+func (s *RedisSessionStore) renewMigrationLock(owner string, lease time.Duration) (bool, error) {
+	result, err := renewMigrationLockScript.Run(s.client, []string{s.migrationLockKey()}, owner, lease.Milliseconds()).Result()
+	if err != nil {
+		return false, fmt.Errorf("auth: renew migration lock: %w", err)
+	}
+	value, err := redisInteger(result)
+	return value == 1, err
+}
+
+func (s *RedisSessionStore) confirmMigrationLock(owner string, lease time.Duration) error {
+	ok, err := s.renewMigrationLock(owner, lease)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return ErrMigrationLockLost
+	}
+	return nil
+}
+
+func (s *RedisSessionStore) keepMigrationLockAlive(ctx context.Context, owner string, lease time.Duration) <-chan error {
+	errorsCh := make(chan error, 1)
+	interval := lease / 3
+	if interval > time.Second {
+		interval = time.Second
+	}
+	go func() {
+		defer close(errorsCh)
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				if err := s.confirmMigrationLock(owner, lease); err != nil {
+					errorsCh <- err
+					return
+				}
+			}
+		}
+	}()
+	return errorsCh
+}
+
+func migrationLockError(errorsCh <-chan error) error {
+	if errorsCh == nil {
+		return nil
+	}
+	select {
+	case err, ok := <-errorsCh:
+		if !ok {
+			return nil
+		}
+		return err
+	default:
+		return nil
+	}
+}
+
+func (s *RedisSessionStore) migrationCampaignKey() string {
+	return s.uidTokenPrefix + "auth:migration:campaign"
+}
+
+func (s *RedisSessionStore) migrationCheckpointKey() string {
+	return s.uidTokenPrefix + "auth:migration:checkpoint"
+}
+
+func (s *RedisSessionStore) migrationLockKey() string {
+	return s.uidTokenPrefix + "auth:migration:lock"
+}

--- a/pkg/auth/session_migration_test.go
+++ b/pkg/auth/session_migration_test.go
@@ -2,7 +2,9 @@ package auth
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -12,6 +14,8 @@ import (
 	rd "github.com/go-redis/redis"
 	"github.com/stretchr/testify/require"
 )
+
+const rolloutObservationGapForTest = time.Hour
 
 func TestLegacyMigrationDryRunIsZeroWriteAndClassifiesRecords(t *testing.T) {
 	store, client := newLegacyMigrationTestStore(t, SessionModeExpand)
@@ -32,10 +36,11 @@ func TestLegacyMigrationDryRunIsZeroWriteAndClassifiesRecords(t *testing.T) {
 
 	before := legacyMigrationSnapshot(t, client, store, keys)
 	result, err := store.MigrateLegacySessions(ctx, LegacyMigrationOptions{
-		CampaignID: "dry-run",
-		CutoffAt:   cutoff,
-		BatchSize:  100,
-		Apply:      false,
+		CampaignID:   "dry-run",
+		CutoffAt:     cutoff,
+		FinitePolicy: LegacyFinitePolicyCap,
+		BatchSize:    100,
+		Apply:        false,
 	})
 	require.NoError(t, err)
 	require.True(t, result.Complete)
@@ -57,7 +62,71 @@ func TestLegacyMigrationDryRunIsZeroWriteAndClassifiesRecords(t *testing.T) {
 		require.Positive(t, after[token].TTL)
 		require.LessOrEqual(t, after[token].TTL, expected.TTL)
 	}
-	require.Equal(t, int64(0), mustExists(t, client, store.migrationCampaignKey(), store.migrationCheckpointKey(), store.migrationLockKey()))
+	require.Equal(t, int64(0), mustExists(t, client, store.migrationCampaignKey("dry-run"), store.migrationCheckpointKey("dry-run"), store.migrationLockKey()))
+}
+
+func TestLegacyMigrationRequiresExplicitFinitePolicy(t *testing.T) {
+	store, _ := newLegacyMigrationTestStore(t, SessionModeExpand)
+
+	_, err := store.MigrateLegacySessions(context.Background(), LegacyMigrationOptions{
+		CampaignID: "missing-policy",
+		CutoffAt:   time.Now().UTC().Add(time.Hour),
+		BatchSize:  100,
+	})
+	require.ErrorContains(t, err, "finite policy")
+}
+
+func TestLegacyMigrationFinitePolicyControlsOnlyFiniteLegacyDeadlines(t *testing.T) {
+	tests := []struct {
+		name             string
+		policy           LegacyFinitePolicy
+		wantFiniteCapped bool
+	}{
+		{name: "natural keeps an already bounded finite deadline", policy: LegacyFinitePolicyNatural},
+		{name: "cap compresses a finite deadline to the cutoff", policy: LegacyFinitePolicyCap, wantFiniteCapped: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store, client := newLegacyMigrationTestStore(t, SessionModeRevoke)
+			ctx := context.Background()
+			require.NoError(t, store.AdvanceRolloutControl(ctx, SessionModeV3Write, rolloutObservationGapForTest))
+			require.NoError(t, store.AdvanceRolloutControl(ctx, SessionModeRevoke, rolloutObservationGapForTest))
+			cutoff := time.Now().UTC().Add(15 * time.Minute)
+			require.NoError(t, client.Set(store.tokenKey("finite"), "v2:finite", 30*time.Minute).Err())
+			require.NoError(t, client.Set(store.tokenKey("over-max"), "v2:over-max", 2*time.Hour).Err())
+			require.NoError(t, client.Set(store.tokenKey("persistent"), "v2:persistent", 0).Err())
+			finiteBefore := mustPTTL(t, client, store.tokenKey("finite"))
+
+			result, err := store.MigrateLegacySessions(ctx, LegacyMigrationOptions{
+				CampaignID:   "policy-" + string(tt.policy),
+				CutoffAt:     cutoff,
+				FinitePolicy: tt.policy,
+				BatchSize:    100,
+				Apply:        true,
+				Lease:        5 * time.Second,
+			})
+			require.NoError(t, err)
+			require.True(t, result.Complete)
+
+			persistentAfter := mustPTTL(t, client, store.tokenKey("persistent"))
+			require.Positive(t, persistentAfter)
+			require.LessOrEqual(t, persistentAfter, time.Until(cutoff)+time.Second)
+
+			finiteAfter := mustPTTL(t, client, store.tokenKey("finite"))
+			overMaxAfter := mustPTTL(t, client, store.tokenKey("over-max"))
+			require.Positive(t, finiteAfter)
+			require.Positive(t, overMaxAfter)
+			require.LessOrEqual(t, overMaxAfter, store.maxTTL+time.Second)
+			if tt.wantFiniteCapped {
+				require.LessOrEqual(t, finiteAfter, time.Until(cutoff)+time.Second)
+				require.LessOrEqual(t, overMaxAfter, time.Until(cutoff)+time.Second)
+				return
+			}
+			require.Greater(t, finiteAfter, 25*time.Minute)
+			require.LessOrEqual(t, finiteAfter, finiteBefore)
+			require.Greater(t, overMaxAfter, 50*time.Minute)
+		})
+	}
 }
 
 func TestLegacyMigrationApplyRequiresFloorAndOnlyShortensLegacy(t *testing.T) {
@@ -65,21 +134,22 @@ func TestLegacyMigrationApplyRequiresFloorAndOnlyShortensLegacy(t *testing.T) {
 	ctx := context.Background()
 	cutoff := time.Now().UTC().Add(30 * time.Minute)
 	options := LegacyMigrationOptions{
-		CampaignID: "apply",
-		CutoffAt:   cutoff,
-		BatchSize:  100,
-		Apply:      true,
-		Lease:      5 * time.Second,
+		CampaignID:   "apply",
+		CutoffAt:     cutoff,
+		FinitePolicy: LegacyFinitePolicyCap,
+		BatchSize:    100,
+		Apply:        true,
+		Lease:        5 * time.Second,
 	}
 	require.NoError(t, client.Set(store.tokenKey("persistent-v1"), `{"uid":"legacy"}`, 0).Err())
 
 	_, err := store.MigrateLegacySessions(ctx, options)
 	require.ErrorContains(t, err, "persisted revoke rollout floor")
 	require.Equal(t, -time.Millisecond, mustPTTL(t, client, store.tokenKey("persistent-v1")))
-	require.Equal(t, int64(0), mustExists(t, client, store.migrationCampaignKey(), store.migrationCheckpointKey(), store.migrationLockKey()))
+	require.Equal(t, int64(0), mustExists(t, client, store.migrationCampaignKey("apply"), store.migrationCheckpointKey("apply"), store.migrationLockKey()))
 
-	require.NoError(t, store.AdvanceRolloutControl(ctx, SessionModeV3Write))
-	require.NoError(t, store.AdvanceRolloutControl(ctx, SessionModeRevoke))
+	require.NoError(t, store.AdvanceRolloutControl(ctx, SessionModeV3Write, rolloutObservationGapForTest))
+	require.NoError(t, store.AdvanceRolloutControl(ctx, SessionModeRevoke, rolloutObservationGapForTest))
 	require.NoError(t, client.Set(store.tokenKey("long-v2"), "v2:long", 2*time.Hour).Err())
 	require.NoError(t, client.Set(store.tokenKey("short-v2"), "v2:short", 5*time.Minute).Err())
 	require.NoError(t, client.Set(store.tokenKey("persistent-v3"), "v3:invalid", 0).Err())
@@ -102,8 +172,8 @@ func TestLegacyMigrationApplyRequiresFloorAndOnlyShortensLegacy(t *testing.T) {
 	require.Positive(t, shortAfter)
 	require.LessOrEqual(t, shortAfter, shortBefore)
 	require.Equal(t, -time.Millisecond, mustPTTL(t, client, store.tokenKey("persistent-v3")))
-	require.Equal(t, -time.Millisecond, mustPTTL(t, client, store.migrationCampaignKey()))
-	require.Equal(t, -time.Millisecond, mustPTTL(t, client, store.migrationCheckpointKey()))
+	require.Equal(t, -time.Millisecond, mustPTTL(t, client, store.migrationCampaignKey("apply")))
+	require.Equal(t, -time.Millisecond, mustPTTL(t, client, store.migrationCheckpointKey("apply")))
 
 	beforeRepeat := mustPTTL(t, client, store.tokenKey("long-v2"))
 	_, err = store.MigrateLegacySessions(ctx, options)
@@ -119,18 +189,19 @@ func TestLegacyMigrationApplyRequiresFloorAndOnlyShortensLegacy(t *testing.T) {
 func TestLegacyMigrationApplyIsSingleOwnerAndDetectsLockLossWithinBatch(t *testing.T) {
 	store, client := newLegacyMigrationTestStore(t, SessionModeRevoke)
 	ctx := context.Background()
-	require.NoError(t, store.AdvanceRolloutControl(ctx, SessionModeV3Write))
-	require.NoError(t, store.AdvanceRolloutControl(ctx, SessionModeRevoke))
+	require.NoError(t, store.AdvanceRolloutControl(ctx, SessionModeV3Write, rolloutObservationGapForTest))
+	require.NoError(t, store.AdvanceRolloutControl(ctx, SessionModeRevoke, rolloutObservationGapForTest))
 	for i := 0; i < 8; i++ {
 		require.NoError(t, client.Set(store.tokenKey(fmt.Sprintf("legacy-%02d", i)), "v2:legacy", 0).Err())
 	}
 	options := LegacyMigrationOptions{
-		CampaignID: "lock-loss",
-		CutoffAt:   time.Now().UTC().Add(time.Hour),
-		BatchSize:  1000,
-		Interval:   500 * time.Millisecond,
-		Apply:      true,
-		Lease:      5 * time.Second,
+		CampaignID:   "lock-loss",
+		CutoffAt:     time.Now().UTC().Add(time.Hour),
+		FinitePolicy: LegacyFinitePolicyCap,
+		BatchSize:    1000,
+		Interval:     500 * time.Millisecond,
+		Apply:        true,
+		Lease:        5 * time.Second,
 	}
 
 	type outcome struct {
@@ -169,18 +240,19 @@ func TestLegacyMigrationApplyIsSingleOwnerAndDetectsLockLossWithinBatch(t *testi
 func TestLegacyMigrationCancellationReportsIncompleteAndCanResume(t *testing.T) {
 	store, client := newLegacyMigrationTestStore(t, SessionModeRevoke)
 	ctx := context.Background()
-	require.NoError(t, store.AdvanceRolloutControl(ctx, SessionModeV3Write))
-	require.NoError(t, store.AdvanceRolloutControl(ctx, SessionModeRevoke))
+	require.NoError(t, store.AdvanceRolloutControl(ctx, SessionModeV3Write, rolloutObservationGapForTest))
+	require.NoError(t, store.AdvanceRolloutControl(ctx, SessionModeRevoke, rolloutObservationGapForTest))
 	for i := 0; i < 40; i++ {
 		require.NoError(t, client.Set(store.tokenKey(fmt.Sprintf("resume-%02d", i)), "v2:legacy", 0).Err())
 	}
 	options := LegacyMigrationOptions{
-		CampaignID: "resume",
-		CutoffAt:   time.Now().UTC().Add(time.Hour),
-		BatchSize:  1,
-		Interval:   20 * time.Millisecond,
-		Apply:      true,
-		Lease:      5 * time.Second,
+		CampaignID:   "resume",
+		CutoffAt:     time.Now().UTC().Add(time.Hour),
+		FinitePolicy: LegacyFinitePolicyCap,
+		BatchSize:    1,
+		Interval:     20 * time.Millisecond,
+		Apply:        true,
+		Lease:        5 * time.Second,
 	}
 	cancelled, cancel := context.WithCancel(ctx)
 	done := make(chan struct {
@@ -195,7 +267,7 @@ func TestLegacyMigrationCancellationReportsIncompleteAndCanResume(t *testing.T) 
 		}{result: result, err: err}
 	}()
 	require.Eventually(t, func() bool {
-		raw, err := client.Get(store.migrationCheckpointKey()).Result()
+		raw, err := client.Get(store.migrationCheckpointKey("resume")).Result()
 		return err == nil && raw != ""
 	}, 2*time.Second, 20*time.Millisecond)
 	cancel()
@@ -212,12 +284,240 @@ func TestLegacyMigrationCancellationReportsIncompleteAndCanResume(t *testing.T) 
 	}
 }
 
+func TestLegacyMigrationCampaignCanRetuneRuntimeRateAndStartAnotherCampaign(t *testing.T) {
+	t.Run("resume with retuned batch and interval", func(t *testing.T) {
+		store, _ := newLegacyMigrationTestStore(t, SessionModeRevoke)
+		ctx := context.Background()
+		require.NoError(t, store.AdvanceRolloutControl(ctx, SessionModeV3Write, rolloutObservationGapForTest))
+		require.NoError(t, store.AdvanceRolloutControl(ctx, SessionModeRevoke, rolloutObservationGapForTest))
+		options := LegacyMigrationOptions{
+			CampaignID:   "retunable",
+			CutoffAt:     time.Now().UTC().Add(time.Hour),
+			FinitePolicy: LegacyFinitePolicyCap,
+			BatchSize:    100,
+			Apply:        true,
+			Lease:        5 * time.Second,
+		}
+		result, err := store.MigrateLegacySessions(ctx, options)
+		require.NoError(t, err)
+		require.True(t, result.Complete)
+
+		options.BatchSize = 1
+		options.Interval = time.Millisecond
+		result, err = store.MigrateLegacySessions(ctx, options)
+		require.NoError(t, err, "batch size and QPS are resumable runtime controls, not campaign safety identity")
+		require.True(t, result.Complete)
+	})
+
+	t.Run("a completed campaign does not permanently block the next campaign", func(t *testing.T) {
+		store, _ := newLegacyMigrationTestStore(t, SessionModeRevoke)
+		ctx := context.Background()
+		require.NoError(t, store.AdvanceRolloutControl(ctx, SessionModeV3Write, rolloutObservationGapForTest))
+		require.NoError(t, store.AdvanceRolloutControl(ctx, SessionModeRevoke, rolloutObservationGapForTest))
+		first := LegacyMigrationOptions{
+			CampaignID:   "first",
+			CutoffAt:     time.Now().UTC().Add(time.Hour),
+			FinitePolicy: LegacyFinitePolicyCap,
+			BatchSize:    100,
+			Apply:        true,
+			Lease:        5 * time.Second,
+		}
+		result, err := store.MigrateLegacySessions(ctx, first)
+		require.NoError(t, err)
+		require.True(t, result.Complete)
+
+		second := first
+		second.CampaignID = "second"
+		second.CutoffAt = first.CutoffAt.Add(time.Hour)
+		result, err = store.MigrateLegacySessions(ctx, second)
+		require.NoError(t, err, "campaign/checkpoint records must be isolated by campaign ID")
+		require.True(t, result.Complete)
+	})
+}
+
+func TestLegacyMigrationElapsedCutoffClassifiesDeletionWithoutExtendingDeadline(t *testing.T) {
+	tests := []struct {
+		name            string
+		policy          LegacyFinitePolicy
+		apply           bool
+		confirmElapsed  bool
+		wantErr         string
+		wantDeleted     int64
+		wantWouldDelete int64
+		wantExists      int64
+		wantUnchanged   int64
+	}{
+		{name: "cap dry-run reports both records", policy: LegacyFinitePolicyCap, wantWouldDelete: 2, wantExists: 2},
+		{name: "cap apply requires explicit confirmation", policy: LegacyFinitePolicyCap, apply: true, wantErr: "confirm elapsed cutoff", wantExists: 2},
+		{name: "cap confirmed apply deletes both records", policy: LegacyFinitePolicyCap, apply: true, confirmElapsed: true, wantDeleted: 2},
+		{name: "natural dry-run reports only persistent record", policy: LegacyFinitePolicyNatural, wantWouldDelete: 1, wantExists: 2, wantUnchanged: 1},
+		{name: "natural confirmed apply deletes only persistent record", policy: LegacyFinitePolicyNatural, apply: true, confirmElapsed: true, wantDeleted: 1, wantExists: 1, wantUnchanged: 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			now := time.Now().UTC()
+			store, client := newLegacyMigrationTestStore(t, SessionModeRevoke, WithSessionClock(func() time.Time { return now }))
+			ctx := context.Background()
+			require.NoError(t, store.AdvanceRolloutControl(ctx, SessionModeV3Write, rolloutObservationGapForTest))
+			require.NoError(t, store.AdvanceRolloutControl(ctx, SessionModeRevoke, rolloutObservationGapForTest))
+			options := LegacyMigrationOptions{
+				CampaignID:           "elapsed-cutoff-" + string(tt.policy),
+				CutoffAt:             now.Add(-time.Hour),
+				FinitePolicy:         tt.policy,
+				BatchSize:            100,
+				Apply:                tt.apply,
+				ConfirmElapsedCutoff: tt.confirmElapsed,
+				Lease:                5 * time.Second,
+			}
+			if tt.apply {
+				persisted := legacyMigrationCampaign{
+					CampaignID:   options.CampaignID,
+					CutoffAtMS:   options.CutoffAt.UnixMilli(),
+					MaxTTLMS:     store.maxTTL.Milliseconds(),
+					FinitePolicy: string(tt.policy),
+				}
+				raw, err := json.Marshal(persisted)
+				require.NoError(t, err)
+				require.NoError(t, client.Set(store.migrationCampaignKey(options.CampaignID), string(raw), 0).Err(), "simulate a campaign created before its cutoff elapsed")
+			}
+			require.NoError(t, client.Set(store.tokenKey("finite"), "v2:finite", 30*time.Minute).Err())
+			require.NoError(t, client.Set(store.tokenKey("persistent"), "v2:persistent", 0).Err())
+
+			result, err := store.MigrateLegacySessions(ctx, options)
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				require.Equal(t, tt.wantExists, mustExists(t, client, store.tokenKey("finite"), store.tokenKey("persistent")))
+				return
+			}
+			require.NoError(t, err, "an interrupted campaign must remain resumable after its immutable cutoff passes")
+			require.True(t, result.Complete)
+			require.Equal(t, int64(2), result.Scanned)
+			require.Equal(t, tt.wantDeleted, result.Deleted)
+			require.Equal(t, tt.wantWouldDelete, result.WouldDelete)
+			require.Zero(t, result.Shortened, "elapsed cutoffs must not report immediate deletion as TTL shortening")
+			require.Equal(t, tt.wantUnchanged, result.Unchanged)
+			require.Equal(t, tt.wantExists, mustExists(t, client, store.tokenKey("finite"), store.tokenKey("persistent")))
+		})
+	}
+}
+
+func TestLegacyMigrationStopsBeforeUnconfirmedCutoffDeletionDuringApply(t *testing.T) {
+	base := time.Now().UTC()
+	cutoff := base.Add(time.Minute)
+	var clockCalls atomic.Int64
+	store, client := newLegacyMigrationTestStore(t, SessionModeRevoke, WithSessionClock(func() time.Time {
+		// validateMigrationOptions, campaign creation, and the first record run
+		// before cutoff. The second record observes the same run after cutoff.
+		if clockCalls.Add(1) <= 3 {
+			return base
+		}
+		return cutoff.Add(time.Minute)
+	}))
+	ctx := context.Background()
+	require.NoError(t, store.AdvanceRolloutControl(ctx, SessionModeV3Write, rolloutObservationGapForTest))
+	require.NoError(t, store.AdvanceRolloutControl(ctx, SessionModeRevoke, rolloutObservationGapForTest))
+	keys := []string{store.tokenKey("first"), store.tokenKey("second")}
+	for _, key := range keys {
+		require.NoError(t, client.Set(key, "v2:persistent", 0).Err())
+	}
+	options := LegacyMigrationOptions{
+		CampaignID:   "cutoff-elapses-during-apply",
+		CutoffAt:     cutoff,
+		FinitePolicy: LegacyFinitePolicyCap,
+		BatchSize:    100,
+		Apply:        true,
+		Lease:        5 * time.Second,
+	}
+
+	result, err := store.MigrateLegacySessions(ctx, options)
+	require.ErrorIs(t, err, ErrMigrationElapsedCutoffConfirmationRequired)
+	require.False(t, result.Complete)
+	require.Zero(t, result.Deleted)
+	require.Equal(t, int64(2), mustExists(t, client, keys...))
+	require.Equal(t, int64(0), mustExists(t, client, store.latestMigrationCompletionKey()))
+
+	options.ConfirmElapsedCutoff = true
+	result, err = store.MigrateLegacySessions(ctx, options)
+	require.NoError(t, err)
+	require.True(t, result.Complete)
+	require.Equal(t, int64(2), result.Deleted)
+	require.Equal(t, int64(0), mustExists(t, client, keys...))
+}
+
+func TestAdvanceBoundedFloorRequiresMigrationAndObservationEvidence(t *testing.T) {
+	store, _ := newLegacyMigrationTestStore(t, SessionModeRevoke)
+	ctx := context.Background()
+	require.NoError(t, store.AdvanceRolloutControl(ctx, SessionModeV3Write, rolloutObservationGapForTest))
+	require.NoError(t, store.AdvanceRolloutControl(ctx, SessionModeRevoke, rolloutObservationGapForTest))
+
+	err := store.AdvanceRolloutControl(ctx, SessionModeBounded, rolloutObservationGapForTest)
+	require.ErrorContains(t, err, "evidence")
+}
+
+func TestRolloutFloorAdvancesOnlyWithRecordedMigrationAndSpacedObservationEvidence(t *testing.T) {
+	now := time.Now().UTC()
+	store, _ := newLegacyMigrationTestStore(t, SessionModeRevoke, WithSessionClock(func() time.Time { return now }))
+	ctx := context.Background()
+	require.NoError(t, store.AdvanceRolloutControl(ctx, SessionModeV3Write, rolloutObservationGapForTest))
+	increasedGap := 2 * rolloutObservationGapForTest
+	require.NoError(t, store.AdvanceRolloutControl(ctx, SessionModeRevoke, increasedGap))
+
+	result, err := store.MigrateLegacySessions(ctx, LegacyMigrationOptions{
+		CampaignID:   "floor-evidence",
+		CutoffAt:     now.Add(time.Hour),
+		FinitePolicy: LegacyFinitePolicyCap,
+		BatchSize:    100,
+		Apply:        true,
+		Lease:        5 * time.Second,
+	})
+	require.NoError(t, err)
+	require.True(t, result.Complete)
+
+	boundedObservation := SessionObservation{Complete: true, Finite: 2, V1: 1, V2: 1}
+	require.NoError(t, store.RecordRolloutObservation(ctx, boundedObservation))
+	require.ErrorContains(t, store.AdvanceRolloutControl(ctx, SessionModeBounded, increasedGap), "two complete")
+	now = now.Add(increasedGap - time.Millisecond)
+	require.NoError(t, store.RecordRolloutObservation(ctx, boundedObservation))
+	require.ErrorContains(t, store.AdvanceRolloutControl(ctx, SessionModeBounded, increasedGap), "minimum gap")
+	now = now.Add(increasedGap)
+	require.NoError(t, store.RecordRolloutObservation(ctx, boundedObservation))
+	require.NoError(t, store.AdvanceRolloutControl(ctx, SessionModeBounded, increasedGap))
+
+	require.ErrorContains(t, store.AdvanceRolloutControl(ctx, SessionModeEnforce, increasedGap), "two complete")
+	enforceObservation := SessionObservation{Complete: true, Finite: 2, V3: 2}
+	now = now.Add(time.Millisecond)
+	require.NoError(t, store.RecordRolloutObservation(ctx, enforceObservation))
+	require.ErrorContains(t, store.AdvanceRolloutControl(ctx, SessionModeEnforce, increasedGap), "two complete")
+	now = now.Add(increasedGap - time.Millisecond)
+	require.NoError(t, store.RecordRolloutObservation(ctx, enforceObservation))
+	require.ErrorContains(t, store.AdvanceRolloutControl(ctx, SessionModeEnforce, increasedGap), "minimum gap")
+	now = now.Add(increasedGap)
+	require.NoError(t, store.RecordRolloutObservation(ctx, enforceObservation))
+	require.NoError(t, store.AdvanceRolloutControl(ctx, SessionModeEnforce, increasedGap))
+}
+
+func TestRecordRolloutObservationRejectsIncompleteOrAmbiguousEvidence(t *testing.T) {
+	store, _ := newLegacyMigrationTestStore(t, SessionModeRevoke)
+	ctx := context.Background()
+	require.NoError(t, store.AdvanceRolloutControl(ctx, SessionModeV3Write, rolloutObservationGapForTest))
+	require.NoError(t, store.AdvanceRolloutControl(ctx, SessionModeRevoke, rolloutObservationGapForTest))
+
+	for _, observation := range []SessionObservation{
+		{},
+		{Complete: true, ReadErrors: 1},
+		{Complete: true, InvalidTTL: 1},
+		{Complete: true, DecodeInvalid: 1},
+	} {
+		require.Error(t, store.RecordRolloutObservation(ctx, observation))
+	}
+}
+
 type legacyTokenSnapshot struct {
 	Value string
 	TTL   time.Duration
 }
 
-func newLegacyMigrationTestStore(t *testing.T, mode SessionMode) (*RedisSessionStore, *rd.Client) {
+func newLegacyMigrationTestStore(t *testing.T, mode SessionMode, extraOptions ...SessionStoreOption) (*RedisSessionStore, *rd.Client) {
 	t.Helper()
 	cfg := config.New()
 	client := octoredis.NewInstrumentedClient(cfg)
@@ -227,6 +527,7 @@ func newLegacyMigrationTestStore(t *testing.T, mode SessionMode) (*RedisSessionS
 	if mode.writesV3() {
 		options = append(options, WithSessionMaxPerUID(10))
 	}
+	options = append(options, extraOptions...)
 	store := NewRedisSessionStore(client, prefix, uidPrefix, time.Hour, options...)
 	t.Cleanup(func() {
 		keys, _ := client.Keys(prefix + "*").Result()

--- a/pkg/auth/session_migration_test.go
+++ b/pkg/auth/session_migration_test.go
@@ -293,8 +293,19 @@ func TestLegacyMigrationRestartsSavedCursorAfterRedisInstanceChange(t *testing.T
 	for i := 0; i < 128; i++ {
 		require.NoError(t, client.Set(store.tokenKey(fmt.Sprintf("redis-restart-%03d", i)), "v2:legacy", 0).Err())
 	}
-	skippedKeys, savedCursor, err := client.Scan(0, store.tokenPrefix+"*", 1).Result()
-	require.NoError(t, err)
+	var skippedKeys []string
+	var savedCursor uint64
+	for cursor := uint64(0); ; {
+		keys, next, err := client.Scan(cursor, store.tokenPrefix+"*", 1).Result()
+		require.NoError(t, err)
+		if len(keys) > 0 && next != 0 {
+			skippedKeys = keys
+			savedCursor = next
+			break
+		}
+		require.NotZero(t, next, "fixture requires a non-empty page before SCAN completion")
+		cursor = next
+	}
 	require.NotEmpty(t, skippedKeys)
 	require.NotZero(t, savedCursor, "fixture requires a resumable non-zero SCAN cursor")
 
@@ -331,6 +342,44 @@ func TestLegacyMigrationRestartsSavedCursorAfterRedisInstanceChange(t *testing.T
 	loaded, err := store.loadMigrationCheckpoint(campaignID)
 	require.NoError(t, err)
 	require.Equal(t, "new-redis-instance", loaded.RedisInstanceID)
+}
+
+func TestLegacyMigrationRestartsWhenRedisInstanceChangesDuringScan(t *testing.T) {
+	store, client := newLegacyMigrationTestStore(t, SessionModeRevoke)
+	ctx := context.Background()
+	require.NoError(t, store.AdvanceRolloutControl(ctx, SessionModeV3Write, rolloutObservationGapForTest))
+	require.NoError(t, store.AdvanceRolloutControl(ctx, SessionModeRevoke, rolloutObservationGapForTest))
+	for i := 0; i < 128; i++ {
+		require.NoError(t, client.Set(store.tokenKey(fmt.Sprintf("in-flight-restart-%03d", i)), "v2:legacy", 0).Err())
+	}
+
+	var identityReads atomic.Int64
+	store.redisInstanceIDFn = func() (string, error) {
+		if identityReads.Add(1) <= 2 {
+			return "redis-before-failover", nil
+		}
+		return "redis-after-failover", nil
+	}
+	result, err := store.MigrateLegacySessions(ctx, LegacyMigrationOptions{
+		CampaignID:   "redis-change-during-scan",
+		CutoffAt:     time.Now().UTC().Add(time.Hour),
+		FinitePolicy: LegacyFinitePolicyCap,
+		BatchSize:    100,
+		Apply:        true,
+		Lease:        5 * time.Second,
+	})
+	require.NoError(t, err)
+	require.True(t, result.Complete)
+	require.Greater(t, identityReads.Load(), int64(3))
+	for i := 0; i < 128; i++ {
+		require.Positive(t, mustPTTL(t, client, store.tokenKey(fmt.Sprintf("in-flight-restart-%03d", i))))
+	}
+	checkpoint, err := store.loadMigrationCheckpoint("redis-change-during-scan")
+	require.NoError(t, err)
+	require.Equal(t, "redis-after-failover", checkpoint.RedisInstanceID)
+	completion, err := store.loadMigrationCompletionEvidence()
+	require.NoError(t, err)
+	require.Equal(t, checkpoint.RedisInstanceID, completion.RedisInstanceID)
 }
 
 func TestLegacyMigrationCampaignCanRetuneRuntimeRateAndStartAnotherCampaign(t *testing.T) {
@@ -539,25 +588,44 @@ func TestRolloutFloorAdvancesOnlyWithRecordedMigrationAndSpacedObservationEviden
 	require.NoError(t, err)
 	require.True(t, result.Complete)
 
-	boundedObservation := SessionObservation{Complete: true, Finite: 2, V1: 1, V2: 1}
+	boundedObservation := SessionObservation{
+		ScanID:           "bounded-observation-1",
+		ScopeFingerprint: store.rolloutObservationScopeFingerprint(),
+		Complete:         true,
+		Total:            2,
+		Finite:           2,
+		V1:               1,
+		V2:               1,
+	}
 	require.NoError(t, store.RecordRolloutObservation(ctx, boundedObservation))
 	require.ErrorContains(t, store.AdvanceRolloutControl(ctx, SessionModeBounded, increasedGap), "two complete")
 	now = now.Add(increasedGap - time.Millisecond)
+	boundedObservation.ScanID = "bounded-observation-2"
 	require.NoError(t, store.RecordRolloutObservation(ctx, boundedObservation))
 	require.ErrorContains(t, store.AdvanceRolloutControl(ctx, SessionModeBounded, increasedGap), "minimum gap")
 	now = now.Add(increasedGap)
+	boundedObservation.ScanID = "bounded-observation-3"
 	require.NoError(t, store.RecordRolloutObservation(ctx, boundedObservation))
 	require.NoError(t, store.AdvanceRolloutControl(ctx, SessionModeBounded, increasedGap))
 
 	require.ErrorContains(t, store.AdvanceRolloutControl(ctx, SessionModeEnforce, increasedGap), "two complete")
-	enforceObservation := SessionObservation{Complete: true, Finite: 2, V3: 2}
+	enforceObservation := SessionObservation{
+		ScanID:           "enforce-observation-1",
+		ScopeFingerprint: store.rolloutObservationScopeFingerprint(),
+		Complete:         true,
+		Total:            2,
+		Finite:           2,
+		V3:               2,
+	}
 	now = now.Add(time.Millisecond)
 	require.NoError(t, store.RecordRolloutObservation(ctx, enforceObservation))
 	require.ErrorContains(t, store.AdvanceRolloutControl(ctx, SessionModeEnforce, increasedGap), "two complete")
 	now = now.Add(increasedGap - time.Millisecond)
+	enforceObservation.ScanID = "enforce-observation-2"
 	require.NoError(t, store.RecordRolloutObservation(ctx, enforceObservation))
 	require.ErrorContains(t, store.AdvanceRolloutControl(ctx, SessionModeEnforce, increasedGap), "minimum gap")
 	now = now.Add(increasedGap)
+	enforceObservation.ScanID = "enforce-observation-3"
 	require.NoError(t, store.RecordRolloutObservation(ctx, enforceObservation))
 	require.NoError(t, store.AdvanceRolloutControl(ctx, SessionModeEnforce, increasedGap))
 }

--- a/pkg/auth/session_migration_test.go
+++ b/pkg/auth/session_migration_test.go
@@ -284,6 +284,55 @@ func TestLegacyMigrationCancellationReportsIncompleteAndCanResume(t *testing.T) 
 	}
 }
 
+func TestLegacyMigrationRestartsSavedCursorAfterRedisInstanceChange(t *testing.T) {
+	store, client := newLegacyMigrationTestStore(t, SessionModeRevoke)
+	ctx := context.Background()
+	require.NoError(t, store.AdvanceRolloutControl(ctx, SessionModeV3Write, rolloutObservationGapForTest))
+	require.NoError(t, store.AdvanceRolloutControl(ctx, SessionModeRevoke, rolloutObservationGapForTest))
+
+	for i := 0; i < 128; i++ {
+		require.NoError(t, client.Set(store.tokenKey(fmt.Sprintf("redis-restart-%03d", i)), "v2:legacy", 0).Err())
+	}
+	skippedKeys, savedCursor, err := client.Scan(0, store.tokenPrefix+"*", 1).Result()
+	require.NoError(t, err)
+	require.NotEmpty(t, skippedKeys)
+	require.NotZero(t, savedCursor, "fixture requires a resumable non-zero SCAN cursor")
+
+	campaignID := "redis-instance-change"
+	checkpoint := legacyMigrationCheckpoint{
+		CampaignID:      campaignID,
+		RedisInstanceID: "old-redis-instance",
+		Cursor:          savedCursor,
+		Result: LegacyMigrationResult{
+			CampaignID: campaignID,
+			Scanned:    int64(len(skippedKeys)),
+			LastCursor: savedCursor,
+		},
+	}
+	raw, err := json.Marshal(checkpoint)
+	require.NoError(t, err)
+	require.NoError(t, client.Set(store.migrationCheckpointKey(campaignID), string(raw), 0).Err())
+	store.redisInstanceIDFn = func() (string, error) { return "new-redis-instance", nil }
+
+	result, err := store.MigrateLegacySessions(ctx, LegacyMigrationOptions{
+		CampaignID:   campaignID,
+		CutoffAt:     time.Now().UTC().Add(time.Hour),
+		FinitePolicy: LegacyFinitePolicyCap,
+		BatchSize:    1,
+		Apply:        true,
+		Lease:        5 * time.Second,
+	})
+	require.NoError(t, err)
+	require.True(t, result.Complete)
+	for _, key := range skippedKeys {
+		require.Positive(t, mustPTTL(t, client, key), "a cursor from another Redis process must not skip its earlier page")
+	}
+
+	loaded, err := store.loadMigrationCheckpoint(campaignID)
+	require.NoError(t, err)
+	require.Equal(t, "new-redis-instance", loaded.RedisInstanceID)
+}
+
 func TestLegacyMigrationCampaignCanRetuneRuntimeRateAndStartAnotherCampaign(t *testing.T) {
 	t.Run("resume with retuned batch and interval", func(t *testing.T) {
 		store, _ := newLegacyMigrationTestStore(t, SessionModeRevoke)
@@ -521,12 +570,151 @@ func TestRecordRolloutObservationRejectsIncompleteOrAmbiguousEvidence(t *testing
 
 	for _, observation := range []SessionObservation{
 		{},
+		{Complete: true},
 		{Complete: true, ReadErrors: 1},
 		{Complete: true, InvalidTTL: 1},
 		{Complete: true, DecodeInvalid: 1},
 	} {
 		require.Error(t, store.RecordRolloutObservation(ctx, observation))
 	}
+}
+
+func TestRecordRolloutObservationRejectsDuplicateScanAndInconsistentCounts(t *testing.T) {
+	store, client := newLegacyMigrationTestStore(t, SessionModeRevoke)
+	ctx := context.Background()
+	require.NoError(t, store.AdvanceRolloutControl(ctx, SessionModeV3Write, rolloutObservationGapForTest))
+	require.NoError(t, store.AdvanceRolloutControl(ctx, SessionModeRevoke, rolloutObservationGapForTest))
+	require.NoError(t, client.Set(store.tokenKey("observed"), "v2:{\"uid\":\"u1\"}", time.Minute).Err())
+
+	observation, err := store.Observe(ctx, 100)
+	require.NoError(t, err)
+	require.NotEmpty(t, observation.ScanID)
+	require.NotEmpty(t, observation.ScopeFingerprint)
+	require.NoError(t, store.RecordRolloutObservation(ctx, observation))
+	require.ErrorContains(t, store.RecordRolloutObservation(ctx, observation), "already recorded")
+
+	inconsistent := observation
+	inconsistent.ScanID = "different-scan"
+	inconsistent.Total++
+	require.ErrorContains(t, store.RecordRolloutObservation(ctx, inconsistent), "counts")
+}
+
+func TestRolloutAdvanceRejectsVacuousLegacyObservationEvidence(t *testing.T) {
+	tests := []struct {
+		name    string
+		current SessionMode
+		next    SessionMode
+	}{
+		{name: "bounded", current: SessionModeRevoke, next: SessionModeBounded},
+		{name: "enforce", current: SessionModeBounded, next: SessionModeEnforce},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			now := time.Now().UTC()
+			store, client := newLegacyMigrationTestStore(t, tt.current, WithSessionClock(func() time.Time { return now }))
+			ctx := context.Background()
+			require.NoError(t, store.AdvanceRolloutControl(ctx, SessionModeV3Write, rolloutObservationGapForTest))
+			require.NoError(t, store.AdvanceRolloutControl(ctx, SessionModeRevoke, rolloutObservationGapForTest))
+			if tt.current == SessionModeBounded {
+				control := SessionRolloutControl{
+					ModeFloor:           SessionModeBounded,
+					WriterVersion:       3,
+					ObservationMinGapMS: rolloutObservationGapForTest.Milliseconds(),
+				}
+				raw, err := json.Marshal(control)
+				require.NoError(t, err)
+				require.NoError(t, client.Set(store.rolloutControlKey(), string(raw), 0).Err())
+			} else {
+				result, err := store.MigrateLegacySessions(ctx, LegacyMigrationOptions{
+					CampaignID:   "empty-observation-gate",
+					CutoffAt:     now.Add(time.Hour),
+					FinitePolicy: LegacyFinitePolicyCap,
+					BatchSize:    100,
+					Apply:        true,
+					Lease:        5 * time.Second,
+				})
+				require.NoError(t, err)
+				require.True(t, result.Complete)
+			}
+
+			history := []rolloutObservationEvidence{
+				{ID: "legacy-empty-1", RecordedAtMS: now.Add(time.Millisecond).UnixMilli(), ModeFloor: tt.current, Observation: SessionObservation{Complete: true}},
+				{ID: "legacy-empty-2", RecordedAtMS: now.Add(rolloutObservationGapForTest + time.Millisecond).UnixMilli(), ModeFloor: tt.current, Observation: SessionObservation{Complete: true}},
+			}
+			raw, err := json.Marshal(history)
+			require.NoError(t, err)
+			require.NoError(t, client.Set(store.rolloutObservationEvidenceKey(), string(raw), 0).Err())
+
+			err = store.AdvanceRolloutControl(ctx, tt.next, rolloutObservationGapForTest)
+			require.ErrorContains(t, err, "non-empty")
+		})
+	}
+}
+
+func TestRolloutObservationEvidenceCannotCrossTokenScopes(t *testing.T) {
+	now := time.Now().UTC()
+	store, client := newLegacyMigrationTestStore(t, SessionModeBounded, WithSessionClock(func() time.Time { return now }))
+	ctx := context.Background()
+	control := SessionRolloutControl{
+		ModeFloor:           SessionModeBounded,
+		WriterVersion:       3,
+		ObservationMinGapMS: rolloutObservationGapForTest.Milliseconds(),
+	}
+	raw, err := json.Marshal(control)
+	require.NoError(t, err)
+	require.NoError(t, client.Set(store.rolloutControlKey(), string(raw), 0).Err())
+
+	payload, err := EncodeV3(TokenInfo{
+		UID:               "scope-user",
+		IssuedAt:          now.Add(-time.Minute).Unix(),
+		ExpiresAt:         now.Add(time.Hour).Unix(),
+		SessionGeneration: "scope-generation",
+		SessionRevision:   1,
+	})
+	require.NoError(t, err)
+	require.NoError(t, client.Set(store.tokenKey("scope-token"), payload, time.Hour).Err())
+	for i := 0; i < 2; i++ {
+		observation, err := store.Observe(ctx, 100)
+		require.NoError(t, err)
+		require.NoError(t, store.RecordRolloutObservation(ctx, observation))
+		now = now.Add(rolloutObservationGapForTest)
+	}
+
+	otherStore := NewRedisSessionStore(
+		client,
+		"another-token-scope:"+util.GenerUUID()+":",
+		store.uidTokenPrefix,
+		store.maxTTL,
+		WithSessionMode(SessionModeBounded),
+		WithSessionMaxPerUID(10),
+		WithSessionClock(func() time.Time { return now }),
+	)
+	err = otherStore.AdvanceRolloutControl(ctx, SessionModeEnforce, rolloutObservationGapForTest)
+	require.ErrorContains(t, err, "scope")
+}
+
+func TestEnforceFloorRequiresObservedV3Session(t *testing.T) {
+	now := time.Now().UTC()
+	store, client := newLegacyMigrationTestStore(t, SessionModeBounded, WithSessionClock(func() time.Time { return now }))
+	ctx := context.Background()
+	control := SessionRolloutControl{
+		ModeFloor:           SessionModeBounded,
+		WriterVersion:       3,
+		ObservationMinGapMS: rolloutObservationGapForTest.Milliseconds(),
+	}
+	raw, err := json.Marshal(control)
+	require.NoError(t, err)
+	require.NoError(t, client.Set(store.rolloutControlKey(), string(raw), 0).Err())
+	require.NoError(t, client.Set(store.tokenKey("legacy-only"), "v2:{\"uid\":\"u1\"}", time.Minute).Err())
+
+	for i := 0; i < 2; i++ {
+		observation, err := store.Observe(ctx, 100)
+		require.NoError(t, err)
+		require.NoError(t, store.RecordRolloutObservation(ctx, observation))
+		now = now.Add(rolloutObservationGapForTest)
+	}
+	err = store.AdvanceRolloutControl(ctx, SessionModeEnforce, rolloutObservationGapForTest)
+	require.ErrorContains(t, err, "v3 > 0")
 }
 
 type legacyTokenSnapshot struct {

--- a/pkg/auth/session_migration_test.go
+++ b/pkg/auth/session_migration_test.go
@@ -436,11 +436,28 @@ func TestLegacyMigrationStopsBeforeUnconfirmedCutoffDeletionDuringApply(t *testi
 	require.Equal(t, int64(2), mustExists(t, client, keys...))
 	require.Equal(t, int64(0), mustExists(t, client, store.latestMigrationCompletionKey()))
 
+	// SCAN may return the two records in one page or separate pages. When the
+	// first page completes, its checkpoint records the key already shortened to
+	// the campaign cutoff; a confirmed resume correctly starts at the saved
+	// cursor instead of rescanning that key. Make the shortened key reach its
+	// Redis deadline so both pagination shapes converge on the production state:
+	// one naturally expired key and one remaining key that requires confirmed
+	// deletion.
+	var shortenedKey string
+	for _, key := range keys {
+		if ttl := mustPTTL(t, client, key); ttl > 0 {
+			shortenedKey = key
+		}
+	}
+	require.NotEmpty(t, shortenedKey)
+	require.NoError(t, client.PExpire(shortenedKey, time.Millisecond).Err())
+	require.Eventually(t, func() bool { return mustExists(t, client, shortenedKey) == 0 }, time.Second, 10*time.Millisecond)
+
 	options.ConfirmElapsedCutoff = true
 	result, err = store.MigrateLegacySessions(ctx, options)
 	require.NoError(t, err)
 	require.True(t, result.Complete)
-	require.Equal(t, int64(2), result.Deleted)
+	require.Equal(t, int64(1), result.Deleted)
 	require.Equal(t, int64(0), mustExists(t, client, keys...))
 }
 

--- a/pkg/auth/session_migration_test.go
+++ b/pkg/auth/session_migration_test.go
@@ -1,0 +1,267 @@
+package auth
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
+	octoredis "github.com/Mininglamp-OSS/octo-server/pkg/redis"
+	rd "github.com/go-redis/redis"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLegacyMigrationDryRunIsZeroWriteAndClassifiesRecords(t *testing.T) {
+	store, client := newLegacyMigrationTestStore(t, SessionModeExpand)
+	ctx := context.Background()
+	now := time.Now().UTC()
+	cutoff := now.Add(30 * time.Minute)
+
+	keys := map[string]string{
+		"persistent-v1": `{"uid":"legacy"}`,
+		"long-v2":       "v2:long",
+		"short-v2":      "v2:short",
+		"persistent-v3": "v3:invalid-but-must-not-be-repaired",
+	}
+	require.NoError(t, client.Set(store.tokenKey("persistent-v1"), keys["persistent-v1"], 0).Err())
+	require.NoError(t, client.Set(store.tokenKey("long-v2"), keys["long-v2"], 2*time.Hour).Err())
+	require.NoError(t, client.Set(store.tokenKey("short-v2"), keys["short-v2"], 5*time.Minute).Err())
+	require.NoError(t, client.Set(store.tokenKey("persistent-v3"), keys["persistent-v3"], 0).Err())
+
+	before := legacyMigrationSnapshot(t, client, store, keys)
+	result, err := store.MigrateLegacySessions(ctx, LegacyMigrationOptions{
+		CampaignID: "dry-run",
+		CutoffAt:   cutoff,
+		BatchSize:  100,
+		Apply:      false,
+	})
+	require.NoError(t, err)
+	require.True(t, result.Complete)
+	require.Equal(t, int64(4), result.Scanned)
+	require.Equal(t, int64(1), result.V1)
+	require.Equal(t, int64(2), result.V2)
+	require.Equal(t, int64(1), result.V3)
+	require.Equal(t, int64(2), result.Shortened)
+	require.Equal(t, int64(1), result.Unchanged)
+	require.Equal(t, int64(1), result.Invalid)
+	require.Equal(t, int64(1), result.V3NonFinite)
+	after := legacyMigrationSnapshot(t, client, store, keys)
+	for token, expected := range before {
+		require.Equal(t, expected.Value, after[token].Value)
+		if expected.TTL == -time.Millisecond {
+			require.Equal(t, expected.TTL, after[token].TTL)
+			continue
+		}
+		require.Positive(t, after[token].TTL)
+		require.LessOrEqual(t, after[token].TTL, expected.TTL)
+	}
+	require.Equal(t, int64(0), mustExists(t, client, store.migrationCampaignKey(), store.migrationCheckpointKey(), store.migrationLockKey()))
+}
+
+func TestLegacyMigrationApplyRequiresFloorAndOnlyShortensLegacy(t *testing.T) {
+	store, client := newLegacyMigrationTestStore(t, SessionModeRevoke)
+	ctx := context.Background()
+	cutoff := time.Now().UTC().Add(30 * time.Minute)
+	options := LegacyMigrationOptions{
+		CampaignID: "apply",
+		CutoffAt:   cutoff,
+		BatchSize:  100,
+		Apply:      true,
+		Lease:      5 * time.Second,
+	}
+	require.NoError(t, client.Set(store.tokenKey("persistent-v1"), `{"uid":"legacy"}`, 0).Err())
+
+	_, err := store.MigrateLegacySessions(ctx, options)
+	require.ErrorContains(t, err, "persisted revoke rollout floor")
+	require.Equal(t, -time.Millisecond, mustPTTL(t, client, store.tokenKey("persistent-v1")))
+	require.Equal(t, int64(0), mustExists(t, client, store.migrationCampaignKey(), store.migrationCheckpointKey(), store.migrationLockKey()))
+
+	require.NoError(t, store.AdvanceRolloutControl(ctx, SessionModeV3Write))
+	require.NoError(t, store.AdvanceRolloutControl(ctx, SessionModeRevoke))
+	require.NoError(t, client.Set(store.tokenKey("long-v2"), "v2:long", 2*time.Hour).Err())
+	require.NoError(t, client.Set(store.tokenKey("short-v2"), "v2:short", 5*time.Minute).Err())
+	require.NoError(t, client.Set(store.tokenKey("persistent-v3"), "v3:invalid", 0).Err())
+	shortBefore := mustPTTL(t, client, store.tokenKey("short-v2"))
+
+	result, err := store.MigrateLegacySessions(ctx, options)
+	require.NoError(t, err)
+	require.True(t, result.Complete)
+	require.Equal(t, int64(1), result.V1)
+	require.Equal(t, int64(2), result.V2)
+	require.Equal(t, int64(1), result.V3)
+	require.Equal(t, int64(2), result.Shortened)
+	require.Equal(t, int64(1), result.V3NonFinite)
+	for _, token := range []string{"persistent-v1", "long-v2"} {
+		ttl := mustPTTL(t, client, store.tokenKey(token))
+		require.Positive(t, ttl)
+		require.LessOrEqual(t, ttl, time.Until(cutoff)+time.Second)
+	}
+	shortAfter := mustPTTL(t, client, store.tokenKey("short-v2"))
+	require.Positive(t, shortAfter)
+	require.LessOrEqual(t, shortAfter, shortBefore)
+	require.Equal(t, -time.Millisecond, mustPTTL(t, client, store.tokenKey("persistent-v3")))
+	require.Equal(t, -time.Millisecond, mustPTTL(t, client, store.migrationCampaignKey()))
+	require.Equal(t, -time.Millisecond, mustPTTL(t, client, store.migrationCheckpointKey()))
+
+	beforeRepeat := mustPTTL(t, client, store.tokenKey("long-v2"))
+	_, err = store.MigrateLegacySessions(ctx, options)
+	require.NoError(t, err)
+	require.LessOrEqual(t, mustPTTL(t, client, store.tokenKey("long-v2")), beforeRepeat)
+
+	drifted := options
+	drifted.CutoffAt = cutoff.Add(time.Minute)
+	_, err = store.MigrateLegacySessions(ctx, drifted)
+	require.ErrorContains(t, err, "parameters do not match")
+}
+
+func TestLegacyMigrationApplyIsSingleOwnerAndDetectsLockLossWithinBatch(t *testing.T) {
+	store, client := newLegacyMigrationTestStore(t, SessionModeRevoke)
+	ctx := context.Background()
+	require.NoError(t, store.AdvanceRolloutControl(ctx, SessionModeV3Write))
+	require.NoError(t, store.AdvanceRolloutControl(ctx, SessionModeRevoke))
+	for i := 0; i < 8; i++ {
+		require.NoError(t, client.Set(store.tokenKey(fmt.Sprintf("legacy-%02d", i)), "v2:legacy", 0).Err())
+	}
+	options := LegacyMigrationOptions{
+		CampaignID: "lock-loss",
+		CutoffAt:   time.Now().UTC().Add(time.Hour),
+		BatchSize:  1000,
+		Interval:   500 * time.Millisecond,
+		Apply:      true,
+		Lease:      5 * time.Second,
+	}
+
+	type outcome struct {
+		result LegacyMigrationResult
+		err    error
+	}
+	done := make(chan outcome, 1)
+	go func() {
+		result, err := store.MigrateLegacySessions(ctx, options)
+		done <- outcome{result: result, err: err}
+	}()
+
+	require.Eventually(t, func() bool {
+		return mustExists(t, client, store.migrationLockKey()) == 1
+	}, 2*time.Second, 20*time.Millisecond)
+	require.Eventually(t, func() bool {
+		for i := 0; i < 8; i++ {
+			if mustPTTL(t, client, store.tokenKey(fmt.Sprintf("legacy-%02d", i))) > 0 {
+				return true
+			}
+		}
+		return false
+	}, 2*time.Second, 20*time.Millisecond)
+	require.NoError(t, client.Del(store.migrationLockKey()).Err())
+
+	got := <-done
+	require.ErrorIs(t, got.err, ErrMigrationLockLost)
+	require.False(t, got.result.Complete)
+	require.True(t, got.result.LockLost)
+
+	require.NoError(t, client.Set(store.migrationLockKey(), "another-owner", 10*time.Second).Err())
+	_, err := store.MigrateLegacySessions(ctx, options)
+	require.ErrorIs(t, err, ErrMigrationLockHeld)
+}
+
+func TestLegacyMigrationCancellationReportsIncompleteAndCanResume(t *testing.T) {
+	store, client := newLegacyMigrationTestStore(t, SessionModeRevoke)
+	ctx := context.Background()
+	require.NoError(t, store.AdvanceRolloutControl(ctx, SessionModeV3Write))
+	require.NoError(t, store.AdvanceRolloutControl(ctx, SessionModeRevoke))
+	for i := 0; i < 40; i++ {
+		require.NoError(t, client.Set(store.tokenKey(fmt.Sprintf("resume-%02d", i)), "v2:legacy", 0).Err())
+	}
+	options := LegacyMigrationOptions{
+		CampaignID: "resume",
+		CutoffAt:   time.Now().UTC().Add(time.Hour),
+		BatchSize:  1,
+		Interval:   20 * time.Millisecond,
+		Apply:      true,
+		Lease:      5 * time.Second,
+	}
+	cancelled, cancel := context.WithCancel(ctx)
+	done := make(chan struct {
+		result LegacyMigrationResult
+		err    error
+	}, 1)
+	go func() {
+		result, err := store.MigrateLegacySessions(cancelled, options)
+		done <- struct {
+			result LegacyMigrationResult
+			err    error
+		}{result: result, err: err}
+	}()
+	require.Eventually(t, func() bool {
+		raw, err := client.Get(store.migrationCheckpointKey()).Result()
+		return err == nil && raw != ""
+	}, 2*time.Second, 20*time.Millisecond)
+	cancel()
+	first := <-done
+	require.ErrorIs(t, first.err, context.Canceled)
+	require.False(t, first.result.Complete)
+
+	result, err := store.MigrateLegacySessions(ctx, options)
+	require.NoError(t, err)
+	require.True(t, result.Complete)
+	require.Zero(t, result.LastCursor)
+	for i := 0; i < 40; i++ {
+		require.Positive(t, mustPTTL(t, client, store.tokenKey(fmt.Sprintf("resume-%02d", i))))
+	}
+}
+
+type legacyTokenSnapshot struct {
+	Value string
+	TTL   time.Duration
+}
+
+func newLegacyMigrationTestStore(t *testing.T, mode SessionMode) (*RedisSessionStore, *rd.Client) {
+	t.Helper()
+	cfg := config.New()
+	client := octoredis.NewInstrumentedClient(cfg)
+	prefix := "session-migration:" + util.GenerUUID() + ":"
+	uidPrefix := "session-migration-uid:" + util.GenerUUID() + ":"
+	options := []SessionStoreOption{WithSessionMode(mode)}
+	if mode.writesV3() {
+		options = append(options, WithSessionMaxPerUID(10))
+	}
+	store := NewRedisSessionStore(client, prefix, uidPrefix, time.Hour, options...)
+	t.Cleanup(func() {
+		keys, _ := client.Keys(prefix + "*").Result()
+		metadata, _ := client.Keys(uidPrefix + "*").Result()
+		keys = append(keys, metadata...)
+		if len(keys) > 0 {
+			_ = client.Del(keys...).Err()
+		}
+		_ = client.Close()
+	})
+	return store, client
+}
+
+func legacyMigrationSnapshot(t *testing.T, client *rd.Client, store *RedisSessionStore, tokens map[string]string) map[string]legacyTokenSnapshot {
+	t.Helper()
+	result := make(map[string]legacyTokenSnapshot, len(tokens))
+	for token := range tokens {
+		key := store.tokenKey(token)
+		value, err := client.Get(key).Result()
+		require.NoError(t, err)
+		result[token] = legacyTokenSnapshot{Value: value, TTL: mustPTTL(t, client, key)}
+	}
+	return result
+}
+
+func mustPTTL(t *testing.T, client *rd.Client, key string) time.Duration {
+	t.Helper()
+	ttl, err := client.PTTL(key).Result()
+	require.NoError(t, err)
+	return ttl
+}
+
+func mustExists(t *testing.T, client *rd.Client, keys ...string) int64 {
+	t.Helper()
+	value, err := client.Exists(keys...).Result()
+	require.NoError(t, err)
+	return value
+}

--- a/pkg/auth/session_policy.go
+++ b/pkg/auth/session_policy.go
@@ -1,0 +1,120 @@
+package auth
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
+
+const (
+	sessionModeEnv          = "OCTO_AUTH_SESSION_MODE"
+	sessionMaxPerUIDEnv     = "OCTO_AUTH_SESSION_MAX_PER_UID"
+	sessionRequiredFloorEnv = "OCTO_AUTH_SESSION_REQUIRED_FLOOR"
+
+	sessionMaxPerUIDLimit = 10_000
+)
+
+// SessionMode is the monotonic deployment phase for user HTTP sessions.
+// Its zero value is deliberately invalid; runtime configuration defaults to
+// expand only when the environment variable is absent.
+type SessionMode string
+
+const (
+	SessionModeExpand  SessionMode = "expand"
+	SessionModeV3Write SessionMode = "v3-write"
+	SessionModeRevoke  SessionMode = "revoke"
+	SessionModeBounded SessionMode = "bounded"
+	SessionModeEnforce SessionMode = "enforce"
+)
+
+type sessionPolicy struct {
+	mode          SessionMode
+	maxPerUID     int
+	requiredFloor SessionMode
+}
+
+func sessionPolicyFromEnv() (sessionPolicy, error) {
+	mode := SessionModeExpand
+	if raw, ok := os.LookupEnv(sessionModeEnv); ok {
+		value := strings.TrimSpace(raw)
+		mode = SessionMode(value)
+		if !mode.valid() {
+			return sessionPolicy{}, fmt.Errorf("invalid %s %q", sessionModeEnv, value)
+		}
+	}
+
+	maxPerUID := 0
+	if raw, ok := os.LookupEnv(sessionMaxPerUIDEnv); ok {
+		value := strings.TrimSpace(raw)
+		parsed, err := strconv.ParseInt(value, 10, 32)
+		if err != nil || parsed <= 0 {
+			return sessionPolicy{}, fmt.Errorf("%s must be a positive integer", sessionMaxPerUIDEnv)
+		}
+		if parsed > sessionMaxPerUIDLimit {
+			return sessionPolicy{}, fmt.Errorf("%s must not exceed %d", sessionMaxPerUIDEnv, sessionMaxPerUIDLimit)
+		}
+		maxPerUID = int(parsed)
+	}
+	if mode.writesV3() && maxPerUID == 0 {
+		return sessionPolicy{}, fmt.Errorf("%s must be explicitly configured when %s=%s", sessionMaxPerUIDEnv, sessionModeEnv, mode)
+	}
+	var requiredFloor SessionMode
+	if raw, ok := os.LookupEnv(sessionRequiredFloorEnv); ok {
+		value := strings.TrimSpace(raw)
+		requiredFloor = SessionMode(value)
+		if !requiredFloor.valid() {
+			return sessionPolicy{}, fmt.Errorf("invalid %s %q", sessionRequiredFloorEnv, value)
+		}
+		if mode.rank() < requiredFloor.rank() {
+			return sessionPolicy{}, fmt.Errorf("%s=%s is below %s=%s", sessionModeEnv, mode, sessionRequiredFloorEnv, requiredFloor)
+		}
+	}
+	return sessionPolicy{mode: mode, maxPerUID: maxPerUID, requiredFloor: requiredFloor}, nil
+}
+
+func (m SessionMode) valid() bool {
+	switch m {
+	case SessionModeExpand, SessionModeV3Write, SessionModeRevoke, SessionModeBounded, SessionModeEnforce:
+		return true
+	default:
+		return false
+	}
+}
+
+func (m SessionMode) writesV3() bool {
+	return m.rank() >= SessionModeV3Write.rank()
+}
+
+// WritesV3 reports whether the rollout phase permits creating or promoting
+// user HTTP sessions with the v3 envelope.
+func (m SessionMode) WritesV3() bool {
+	return m.writesV3()
+}
+
+// RevokesSessions reports whether durable security events may rotate
+// generations and create legacy deny markers in this rollout phase.
+func (m SessionMode) RevokesSessions() bool {
+	return m.rank() >= SessionModeRevoke.rank()
+}
+
+func (m SessionMode) checksLegacyDeny() bool {
+	return m.rank() >= SessionModeV3Write.rank() && m != SessionModeEnforce
+}
+
+func (m SessionMode) rank() int {
+	switch m {
+	case SessionModeExpand:
+		return 1
+	case SessionModeV3Write:
+		return 2
+	case SessionModeRevoke:
+		return 3
+	case SessionModeBounded:
+		return 4
+	case SessionModeEnforce:
+		return 5
+	default:
+		return 0
+	}
+}

--- a/pkg/auth/session_rollout.go
+++ b/pkg/auth/session_rollout.go
@@ -1,0 +1,154 @@
+package auth
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	rd "github.com/go-redis/redis"
+)
+
+var (
+	readRolloutControlScript = rd.NewScript(`
+local value = redis.call("GET", KEYS[1])
+if not value then
+  return {false, -2}
+end
+return {value, redis.call("PTTL", KEYS[1])}
+`)
+	advanceRolloutControlScript = rd.NewScript(`
+local current = redis.call("GET", KEYS[1])
+if ARGV[1] == "" then
+  if current then
+    return 0
+  end
+  redis.call("SET", KEYS[1], ARGV[2], "NX")
+  return 1
+end
+if current ~= ARGV[1] then
+  return 0
+end
+redis.call("SET", KEYS[1], ARGV[2], "XX")
+return 1
+`)
+)
+
+var ErrRolloutControlChanged = errors.New("auth: session rollout control changed concurrently")
+
+type SessionRolloutControl struct {
+	ModeFloor     SessionMode `json:"mode_floor"`
+	WriterVersion int         `json:"writer_version"`
+}
+
+func (s *RedisSessionStore) ValidateRolloutControl(ctx context.Context, requiredFloor SessionMode) error {
+	control, _, err := s.loadRolloutControl(ctx)
+	if err != nil {
+		return err
+	}
+	if control == nil {
+		if requiredFloor.valid() {
+			return fmt.Errorf("auth: session rollout control is required at floor %s", requiredFloor)
+		}
+		if s.mode.rank() >= SessionModeRevoke.rank() {
+			return fmt.Errorf("auth: session rollout control is required for mode %s", s.mode)
+		}
+		return nil
+	}
+	if s.mode.rank() < control.ModeFloor.rank() {
+		return fmt.Errorf("auth: configured session mode %s is below persisted floor %s", s.mode, control.ModeFloor)
+	}
+	if requiredFloor.valid() && control.ModeFloor.rank() < requiredFloor.rank() {
+		return fmt.Errorf("auth: persisted session floor %s is below required floor %s", control.ModeFloor, requiredFloor)
+	}
+	return nil
+}
+
+func (s *RedisSessionStore) RolloutControl(ctx context.Context) (*SessionRolloutControl, error) {
+	control, _, err := s.loadRolloutControl(ctx)
+	return control, err
+}
+
+// AdvanceRolloutControl performs one monotonic CAS transition. It is intended
+// for an explicit operator tool, never an API process startup hook.
+func (s *RedisSessionStore) AdvanceRolloutControl(ctx context.Context, next SessionMode) error {
+	if !next.valid() || next == SessionModeExpand {
+		return errors.New("auth: rollout floor must advance to v3-write or later")
+	}
+	current, raw, err := s.loadRolloutControl(ctx)
+	if err != nil {
+		return err
+	}
+	if current == nil {
+		if next != SessionModeV3Write {
+			return fmt.Errorf("auth: first rollout floor must be %s", SessionModeV3Write)
+		}
+	} else {
+		if next.rank() != current.ModeFloor.rank()+1 {
+			return fmt.Errorf("auth: rollout floor must advance exactly one phase from %s", current.ModeFloor)
+		}
+	}
+	nextControl := SessionRolloutControl{ModeFloor: next, WriterVersion: 3}
+	encoded, err := json.Marshal(nextControl)
+	if err != nil {
+		return fmt.Errorf("auth: encode rollout control: %w", err)
+	}
+	result, err := advanceRolloutControlScript.Run(s.client, []string{s.rolloutControlKey()}, raw, string(encoded)).Result()
+	if err != nil {
+		return fmt.Errorf("auth: advance rollout control: %w", err)
+	}
+	changed, err := redisInteger(result)
+	if err != nil {
+		return err
+	}
+	if changed != 1 {
+		return ErrRolloutControlChanged
+	}
+	return nil
+}
+
+func (s *RedisSessionStore) loadRolloutControl(ctx context.Context) (*SessionRolloutControl, string, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, "", err
+	}
+	result, err := readRolloutControlScript.Run(s.client, []string{s.rolloutControlKey()}).Result()
+	if err != nil {
+		return nil, "", fmt.Errorf("auth: read rollout control: %w", err)
+	}
+	parts, ok := result.([]interface{})
+	if !ok || len(parts) != 2 {
+		return nil, "", fmt.Errorf("auth: invalid rollout control result %T", result)
+	}
+	ttl, err := redisInteger(parts[1])
+	if err != nil {
+		return nil, "", err
+	}
+	if ttl == -2 {
+		return nil, "", nil
+	}
+	if ttl != -1 {
+		return nil, "", errors.New("auth: rollout control must not expire")
+	}
+	var raw string
+	switch value := parts[0].(type) {
+	case string:
+		raw = value
+	case []byte:
+		raw = string(value)
+	default:
+		return nil, "", fmt.Errorf("auth: invalid rollout control payload %T", parts[0])
+	}
+	var control SessionRolloutControl
+	if err := json.Unmarshal([]byte(raw), &control); err != nil {
+		return nil, "", fmt.Errorf("auth: decode rollout control: %w", err)
+	}
+	if !control.ModeFloor.valid() || control.ModeFloor == SessionModeExpand || control.WriterVersion != 3 || strings.TrimSpace(string(control.ModeFloor)) == "" {
+		return nil, "", errors.New("auth: invalid rollout control record")
+	}
+	return &control, raw, nil
+}
+
+func (s *RedisSessionStore) rolloutControlKey() string {
+	return s.uidTokenPrefix + "auth:rollout-control"
+}

--- a/pkg/auth/session_rollout.go
+++ b/pkg/auth/session_rollout.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	rd "github.com/go-redis/redis"
 )
@@ -37,9 +38,15 @@ return 1
 
 var ErrRolloutControlChanged = errors.New("auth: session rollout control changed concurrently")
 
+// MinimumRolloutObservationGap is the hard safety floor for independent
+// rollout observations. Operators may raise it between phases but cannot
+// lower it once persisted.
+const MinimumRolloutObservationGap = time.Hour
+
 type SessionRolloutControl struct {
-	ModeFloor     SessionMode `json:"mode_floor"`
-	WriterVersion int         `json:"writer_version"`
+	ModeFloor           SessionMode `json:"mode_floor"`
+	WriterVersion       int         `json:"writer_version"`
+	ObservationMinGapMS int64       `json:"observation_min_gap_ms"`
 }
 
 func (s *RedisSessionStore) ValidateRolloutControl(ctx context.Context, requiredFloor SessionMode) error {
@@ -72,9 +79,13 @@ func (s *RedisSessionStore) RolloutControl(ctx context.Context) (*SessionRollout
 
 // AdvanceRolloutControl performs one monotonic CAS transition. It is intended
 // for an explicit operator tool, never an API process startup hook.
-func (s *RedisSessionStore) AdvanceRolloutControl(ctx context.Context, next SessionMode) error {
+func (s *RedisSessionStore) AdvanceRolloutControl(ctx context.Context, next SessionMode, observationMinGap time.Duration) error {
 	if !next.valid() || next == SessionModeExpand {
 		return errors.New("auth: rollout floor must advance to v3-write or later")
+	}
+	observationMinGapMS := observationMinGap.Milliseconds()
+	if observationMinGap < MinimumRolloutObservationGap {
+		return fmt.Errorf("auth: rollout observation minimum gap must be at least %s", MinimumRolloutObservationGap)
 	}
 	current, raw, err := s.loadRolloutControl(ctx)
 	if err != nil {
@@ -85,11 +96,21 @@ func (s *RedisSessionStore) AdvanceRolloutControl(ctx context.Context, next Sess
 			return fmt.Errorf("auth: first rollout floor must be %s", SessionModeV3Write)
 		}
 	} else {
+		if current.ObservationMinGapMS > observationMinGapMS {
+			return fmt.Errorf("auth: rollout observation minimum gap cannot decrease below persisted %dms", current.ObservationMinGapMS)
+		}
 		if next.rank() != current.ModeFloor.rank()+1 {
 			return fmt.Errorf("auth: rollout floor must advance exactly one phase from %s", current.ModeFloor)
 		}
+		if err := s.validateRolloutAdvanceEvidence(ctx, current.ModeFloor, next, observationMinGapMS); err != nil {
+			return err
+		}
 	}
-	nextControl := SessionRolloutControl{ModeFloor: next, WriterVersion: 3}
+	nextControl := SessionRolloutControl{
+		ModeFloor:           next,
+		WriterVersion:       3,
+		ObservationMinGapMS: observationMinGapMS,
+	}
 	encoded, err := json.Marshal(nextControl)
 	if err != nil {
 		return fmt.Errorf("auth: encode rollout control: %w", err)
@@ -143,7 +164,7 @@ func (s *RedisSessionStore) loadRolloutControl(ctx context.Context) (*SessionRol
 	if err := json.Unmarshal([]byte(raw), &control); err != nil {
 		return nil, "", fmt.Errorf("auth: decode rollout control: %w", err)
 	}
-	if !control.ModeFloor.valid() || control.ModeFloor == SessionModeExpand || control.WriterVersion != 3 || strings.TrimSpace(string(control.ModeFloor)) == "" {
+	if !control.ModeFloor.valid() || control.ModeFloor == SessionModeExpand || control.WriterVersion != 3 || control.ObservationMinGapMS < 0 || strings.TrimSpace(string(control.ModeFloor)) == "" {
 		return nil, "", errors.New("auth: invalid rollout control record")
 	}
 	return &control, raw, nil

--- a/pkg/auth/session_rollout.go
+++ b/pkg/auth/session_rollout.go
@@ -66,6 +66,9 @@ func (s *RedisSessionStore) ValidateRolloutControl(ctx context.Context, required
 	if s.mode.rank() < control.ModeFloor.rank() {
 		return fmt.Errorf("auth: configured session mode %s is below persisted floor %s", s.mode, control.ModeFloor)
 	}
+	if s.mode.rank() > control.ModeFloor.rank()+1 {
+		return fmt.Errorf("auth: configured session mode %s is more than one phase above persisted floor %s", s.mode, control.ModeFloor)
+	}
 	if requiredFloor.valid() && control.ModeFloor.rank() < requiredFloor.rank() {
 		return fmt.Errorf("auth: persisted session floor %s is below required floor %s", control.ModeFloor, requiredFloor)
 	}

--- a/pkg/auth/session_rollout_evidence.go
+++ b/pkg/auth/session_rollout_evidence.go
@@ -1,0 +1,201 @@
+package auth
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	rd "github.com/go-redis/redis"
+)
+
+var appendRolloutObservationScript = rd.NewScript(`
+local history = {}
+local current = redis.call("GET", KEYS[1])
+if current then
+  history = cjson.decode(current)
+end
+table.insert(history, cjson.decode(ARGV[1]))
+while #history > 2 do
+  table.remove(history, 1)
+end
+redis.call("SET", KEYS[1], cjson.encode(history))
+return #history
+`)
+
+type rolloutObservationEvidence struct {
+	ID           string             `json:"id"`
+	RecordedAtMS int64              `json:"recorded_at_unix_ms"`
+	ModeFloor    SessionMode        `json:"mode_floor"`
+	Observation  SessionObservation `json:"observation"`
+}
+
+type migrationCompletionEvidence struct {
+	CampaignID    string `json:"campaign_id"`
+	CompletedAtMS int64  `json:"completed_at_unix_ms"`
+}
+
+// RecordRolloutObservation persists only aggregate, low-cardinality evidence
+// for a later floor transition. It never stores a token, Redis key, UID, or
+// payload. The last two observations share one non-expiring key and are
+// appended atomically so concurrent operators cannot lose an evidence record.
+func (s *RedisSessionStore) RecordRolloutObservation(ctx context.Context, observation SessionObservation) error {
+	if err := validateRecordableRolloutObservation(observation); err != nil {
+		return err
+	}
+	control, err := s.RolloutControl(ctx)
+	if err != nil {
+		return err
+	}
+	if control == nil || control.ModeFloor.rank() < SessionModeRevoke.rank() {
+		return errors.New("auth: rollout observation evidence requires persisted revoke floor")
+	}
+	id, err := newSessionGeneration()
+	if err != nil {
+		return err
+	}
+	evidence := rolloutObservationEvidence{
+		ID:           id,
+		RecordedAtMS: s.now().UTC().UnixMilli(),
+		ModeFloor:    control.ModeFloor,
+		Observation:  observation,
+	}
+	encoded, err := json.Marshal(evidence)
+	if err != nil {
+		return fmt.Errorf("auth: encode rollout observation evidence: %w", err)
+	}
+	if _, err := appendRolloutObservationScript.Run(
+		s.client,
+		[]string{s.rolloutObservationEvidenceKey()},
+		string(encoded),
+	).Result(); err != nil {
+		return fmt.Errorf("auth: record rollout observation evidence: %w", err)
+	}
+	return nil
+}
+
+func validateRecordableRolloutObservation(observation SessionObservation) error {
+	if !observation.Complete {
+		return errors.New("auth: rollout observation evidence must be complete")
+	}
+	if observation.ReadErrors != 0 || observation.InvalidTTL != 0 || observation.DecodeInvalid != 0 {
+		return errors.New("auth: rollout observation evidence contains ambiguous token records")
+	}
+	return nil
+}
+
+func (s *RedisSessionStore) recordMigrationCompletion(campaignID string, result LegacyMigrationResult) error {
+	if !result.Complete || result.LockLost || result.CampaignID != campaignID {
+		return errors.New("auth: cannot record incomplete migration evidence")
+	}
+	evidence := migrationCompletionEvidence{
+		CampaignID:    campaignID,
+		CompletedAtMS: s.now().UTC().UnixMilli(),
+	}
+	encoded, err := json.Marshal(evidence)
+	if err != nil {
+		return fmt.Errorf("auth: encode migration completion evidence: %w", err)
+	}
+	if err := s.client.Set(s.latestMigrationCompletionKey(), string(encoded), 0).Err(); err != nil {
+		return fmt.Errorf("auth: record migration completion evidence: %w", err)
+	}
+	return nil
+}
+
+func (s *RedisSessionStore) validateRolloutAdvanceEvidence(ctx context.Context, current, next SessionMode, observationMinGapMS int64) error {
+	if next != SessionModeBounded && next != SessionModeEnforce {
+		return nil
+	}
+	if next == SessionModeBounded {
+		completion, err := s.loadMigrationCompletionEvidence()
+		if err != nil {
+			return err
+		}
+		checkpoint, err := s.loadMigrationCheckpoint(completion.CampaignID)
+		if err != nil {
+			return err
+		}
+		if checkpoint == nil || !checkpoint.Result.Complete || checkpoint.Result.LockLost || checkpoint.CampaignID != completion.CampaignID {
+			return errors.New("auth: bounded floor requires complete migration checkpoint evidence")
+		}
+		if err := s.validateObservationEvidence(current, next, completion.CompletedAtMS, observationMinGapMS); err != nil {
+			return err
+		}
+		return nil
+	}
+	return s.validateObservationEvidence(current, next, 0, observationMinGapMS)
+}
+
+func (s *RedisSessionStore) loadMigrationCompletionEvidence() (migrationCompletionEvidence, error) {
+	var evidence migrationCompletionEvidence
+	if err := s.loadPersistentEvidence(s.latestMigrationCompletionKey(), &evidence); err != nil {
+		return migrationCompletionEvidence{}, fmt.Errorf("auth: bounded floor migration evidence: %w", err)
+	}
+	if evidence.CampaignID == "" || evidence.CompletedAtMS <= 0 {
+		return migrationCompletionEvidence{}, errors.New("auth: bounded floor migration evidence is invalid")
+	}
+	return evidence, nil
+}
+
+func (s *RedisSessionStore) validateObservationEvidence(current, next SessionMode, notBeforeMS, observationMinGapMS int64) error {
+	var history []rolloutObservationEvidence
+	if err := s.loadPersistentEvidence(s.rolloutObservationEvidenceKey(), &history); err != nil {
+		return fmt.Errorf("auth: %s floor observation evidence: %w", next, err)
+	}
+	if len(history) != 2 {
+		return fmt.Errorf("auth: %s floor requires two complete observation evidence records", next)
+	}
+	seen := make(map[string]struct{}, len(history))
+	for _, evidence := range history {
+		if evidence.ID == "" || evidence.ModeFloor != current || evidence.RecordedAtMS < notBeforeMS {
+			return fmt.Errorf("auth: %s floor requires two complete observations from current floor %s after migration", next, current)
+		}
+		if _, duplicate := seen[evidence.ID]; duplicate {
+			return fmt.Errorf("auth: %s floor requires two distinct complete observations", next)
+		}
+		seen[evidence.ID] = struct{}{}
+		if err := validateRecordableRolloutObservation(evidence.Observation); err != nil {
+			return fmt.Errorf("auth: %s floor observation evidence is invalid: %w", next, err)
+		}
+		if evidence.Observation.Persistent != 0 || evidence.Observation.OverMax != 0 {
+			return fmt.Errorf("auth: %s floor requires persistent=0 and over_max=0 evidence", next)
+		}
+		if next == SessionModeEnforce && (evidence.Observation.V1 != 0 || evidence.Observation.V2 != 0) {
+			return errors.New("auth: enforce floor requires v1=0 and v2=0 evidence")
+		}
+	}
+	if observationMinGapMS <= 0 || history[1].RecordedAtMS-history[0].RecordedAtMS < observationMinGapMS {
+		return fmt.Errorf("auth: %s floor observations must have the persisted minimum gap of %dms", next, observationMinGapMS)
+	}
+	return nil
+}
+
+func (s *RedisSessionStore) loadPersistentEvidence(key string, target interface{}) error {
+	raw, err := s.client.Get(key).Result()
+	if err == rd.Nil {
+		return errors.New("required evidence is missing")
+	}
+	if err != nil {
+		return fmt.Errorf("load evidence: %w", err)
+	}
+	ttl, err := s.client.PTTL(key).Result()
+	if err != nil {
+		return fmt.Errorf("read evidence ttl: %w", err)
+	}
+	if ttl != -time.Millisecond {
+		return errors.New("required evidence must not expire")
+	}
+	if err := json.Unmarshal([]byte(raw), target); err != nil {
+		return fmt.Errorf("decode evidence: %w", err)
+	}
+	return nil
+}
+
+func (s *RedisSessionStore) latestMigrationCompletionKey() string {
+	return s.uidTokenPrefix + "auth:migration:latest-complete"
+}
+
+func (s *RedisSessionStore) rolloutObservationEvidenceKey() string {
+	return s.uidTokenPrefix + "auth:rollout-observations"
+}

--- a/pkg/auth/session_rollout_evidence.go
+++ b/pkg/auth/session_rollout_evidence.go
@@ -2,9 +2,12 @@ package auth
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strconv"
+	"strings"
 	"time"
 
 	rd "github.com/go-redis/redis"
@@ -16,12 +19,18 @@ local current = redis.call("GET", KEYS[1])
 if current then
   history = cjson.decode(current)
 end
-table.insert(history, cjson.decode(ARGV[1]))
+local next = cjson.decode(ARGV[1])
+for _, evidence in ipairs(history) do
+  if evidence.id == next.id then
+    return 0
+  end
+end
+table.insert(history, next)
 while #history > 2 do
   table.remove(history, 1)
 end
 redis.call("SET", KEYS[1], cjson.encode(history))
-return #history
+return 1
 `)
 
 type rolloutObservationEvidence struct {
@@ -32,8 +41,9 @@ type rolloutObservationEvidence struct {
 }
 
 type migrationCompletionEvidence struct {
-	CampaignID    string `json:"campaign_id"`
-	CompletedAtMS int64  `json:"completed_at_unix_ms"`
+	CampaignID      string `json:"campaign_id"`
+	CompletedAtMS   int64  `json:"completed_at_unix_ms"`
+	RedisInstanceID string `json:"redis_instance_id"`
 }
 
 // RecordRolloutObservation persists only aggregate, low-cardinality evidence
@@ -44,6 +54,9 @@ func (s *RedisSessionStore) RecordRolloutObservation(ctx context.Context, observ
 	if err := validateRecordableRolloutObservation(observation); err != nil {
 		return err
 	}
+	if observation.ScopeFingerprint != s.rolloutObservationScopeFingerprint() {
+		return errors.New("auth: rollout observation evidence scope does not match this session store")
+	}
 	control, err := s.RolloutControl(ctx)
 	if err != nil {
 		return err
@@ -51,12 +64,8 @@ func (s *RedisSessionStore) RecordRolloutObservation(ctx context.Context, observ
 	if control == nil || control.ModeFloor.rank() < SessionModeRevoke.rank() {
 		return errors.New("auth: rollout observation evidence requires persisted revoke floor")
 	}
-	id, err := newSessionGeneration()
-	if err != nil {
-		return err
-	}
 	evidence := rolloutObservationEvidence{
-		ID:           id,
+		ID:           observation.ScanID,
 		RecordedAtMS: s.now().UTC().UnixMilli(),
 		ModeFloor:    control.ModeFloor,
 		Observation:  observation,
@@ -65,12 +74,20 @@ func (s *RedisSessionStore) RecordRolloutObservation(ctx context.Context, observ
 	if err != nil {
 		return fmt.Errorf("auth: encode rollout observation evidence: %w", err)
 	}
-	if _, err := appendRolloutObservationScript.Run(
+	result, err := appendRolloutObservationScript.Run(
 		s.client,
 		[]string{s.rolloutObservationEvidenceKey()},
 		string(encoded),
-	).Result(); err != nil {
+	).Result()
+	if err != nil {
 		return fmt.Errorf("auth: record rollout observation evidence: %w", err)
+	}
+	appended, err := redisInteger(result)
+	if err != nil {
+		return fmt.Errorf("auth: record rollout observation evidence: %w", err)
+	}
+	if appended != 1 {
+		return errors.New("auth: rollout observation scan was already recorded")
 	}
 	return nil
 }
@@ -79,19 +96,48 @@ func validateRecordableRolloutObservation(observation SessionObservation) error 
 	if !observation.Complete {
 		return errors.New("auth: rollout observation evidence must be complete")
 	}
+	if observation.Total <= 0 {
+		return errors.New("auth: rollout observation evidence must cover a non-empty token scope")
+	}
+	counts := []int64{
+		observation.Missing,
+		observation.Persistent,
+		observation.Finite,
+		observation.OverMax,
+		observation.InvalidTTL,
+		observation.DecodeInvalid,
+		observation.ReadErrors,
+		observation.V1,
+		observation.V2,
+		observation.V3,
+	}
+	for _, count := range counts {
+		if count < 0 {
+			return errors.New("auth: rollout observation evidence counts must not be negative")
+		}
+	}
+	if observation.Missing+observation.Persistent+observation.Finite+observation.InvalidTTL != observation.Total ||
+		observation.V1+observation.V2+observation.V3+observation.DecodeInvalid != observation.Total-observation.Missing ||
+		observation.OverMax > observation.Finite {
+		return errors.New("auth: rollout observation evidence counts do not match total")
+	}
 	if observation.ReadErrors != 0 || observation.InvalidTTL != 0 || observation.DecodeInvalid != 0 {
 		return errors.New("auth: rollout observation evidence contains ambiguous token records")
+	}
+	if strings.TrimSpace(observation.ScanID) == "" || strings.TrimSpace(observation.ScopeFingerprint) == "" {
+		return errors.New("auth: rollout observation evidence requires scan identity and scope fingerprint")
 	}
 	return nil
 }
 
-func (s *RedisSessionStore) recordMigrationCompletion(campaignID string, result LegacyMigrationResult) error {
-	if !result.Complete || result.LockLost || result.CampaignID != campaignID {
+func (s *RedisSessionStore) recordMigrationCompletion(campaignID, redisInstanceID string, result LegacyMigrationResult) error {
+	if !result.Complete || result.LockLost || result.CampaignID != campaignID || strings.TrimSpace(redisInstanceID) == "" {
 		return errors.New("auth: cannot record incomplete migration evidence")
 	}
 	evidence := migrationCompletionEvidence{
-		CampaignID:    campaignID,
-		CompletedAtMS: s.now().UTC().UnixMilli(),
+		CampaignID:      campaignID,
+		CompletedAtMS:   s.now().UTC().UnixMilli(),
+		RedisInstanceID: redisInstanceID,
 	}
 	encoded, err := json.Marshal(evidence)
 	if err != nil {
@@ -119,6 +165,13 @@ func (s *RedisSessionStore) validateRolloutAdvanceEvidence(ctx context.Context, 
 		if checkpoint == nil || !checkpoint.Result.Complete || checkpoint.Result.LockLost || checkpoint.CampaignID != completion.CampaignID {
 			return errors.New("auth: bounded floor requires complete migration checkpoint evidence")
 		}
+		redisInstanceID, err := s.currentRedisInstanceID()
+		if err != nil {
+			return fmt.Errorf("auth: bounded floor verify Redis instance: %w", err)
+		}
+		if completion.RedisInstanceID == "" || checkpoint.RedisInstanceID != completion.RedisInstanceID || redisInstanceID != completion.RedisInstanceID {
+			return errors.New("auth: bounded floor requires migration evidence from the current Redis instance")
+		}
 		if err := s.validateObservationEvidence(current, next, completion.CompletedAtMS, observationMinGapMS); err != nil {
 			return err
 		}
@@ -132,7 +185,7 @@ func (s *RedisSessionStore) loadMigrationCompletionEvidence() (migrationCompleti
 	if err := s.loadPersistentEvidence(s.latestMigrationCompletionKey(), &evidence); err != nil {
 		return migrationCompletionEvidence{}, fmt.Errorf("auth: bounded floor migration evidence: %w", err)
 	}
-	if evidence.CampaignID == "" || evidence.CompletedAtMS <= 0 {
+	if evidence.CampaignID == "" || evidence.CompletedAtMS <= 0 || evidence.RedisInstanceID == "" {
 		return migrationCompletionEvidence{}, errors.New("auth: bounded floor migration evidence is invalid")
 	}
 	return evidence, nil
@@ -158,17 +211,40 @@ func (s *RedisSessionStore) validateObservationEvidence(current, next SessionMod
 		if err := validateRecordableRolloutObservation(evidence.Observation); err != nil {
 			return fmt.Errorf("auth: %s floor observation evidence is invalid: %w", next, err)
 		}
+		if evidence.ID != evidence.Observation.ScanID {
+			return fmt.Errorf("auth: %s floor observation evidence scan identity does not match its record", next)
+		}
+		if evidence.Observation.ScopeFingerprint != s.rolloutObservationScopeFingerprint() {
+			return fmt.Errorf("auth: %s floor observation evidence scope does not match this session store", next)
+		}
 		if evidence.Observation.Persistent != 0 || evidence.Observation.OverMax != 0 {
 			return fmt.Errorf("auth: %s floor requires persistent=0 and over_max=0 evidence", next)
 		}
-		if next == SessionModeEnforce && (evidence.Observation.V1 != 0 || evidence.Observation.V2 != 0) {
-			return errors.New("auth: enforce floor requires v1=0 and v2=0 evidence")
+		if next == SessionModeEnforce {
+			if evidence.Observation.V3 <= 0 {
+				return errors.New("auth: enforce floor requires v3 > 0 evidence")
+			}
+			if evidence.Observation.V1 != 0 || evidence.Observation.V2 != 0 {
+				return errors.New("auth: enforce floor requires v1=0 and v2=0 evidence")
+			}
 		}
 	}
 	if observationMinGapMS <= 0 || history[1].RecordedAtMS-history[0].RecordedAtMS < observationMinGapMS {
 		return fmt.Errorf("auth: %s floor observations must have the persisted minimum gap of %dms", next, observationMinGapMS)
 	}
 	return nil
+}
+
+func (s *RedisSessionStore) rolloutObservationScopeFingerprint() string {
+	encoded := strconv.AppendQuote(nil, "token-session-observation/v1")
+	encoded = append(encoded, '\n')
+	encoded = strconv.AppendQuote(encoded, s.tokenPrefix)
+	encoded = append(encoded, '\n')
+	encoded = strconv.AppendQuote(encoded, s.uidTokenPrefix)
+	encoded = append(encoded, '\n')
+	encoded = strconv.AppendInt(encoded, s.maxTTL.Milliseconds(), 10)
+	sum := sha256.Sum256(encoded)
+	return fmt.Sprintf("%x", sum[:])
 }
 
 func (s *RedisSessionStore) loadPersistentEvidence(key string, target interface{}) error {

--- a/pkg/auth/session_store.go
+++ b/pkg/auth/session_store.go
@@ -64,18 +64,20 @@ var (
 // SessionObservation contains low-cardinality migration facts only. It never
 // includes a token, Redis key, UID, or payload.
 type SessionObservation struct {
-	Complete      bool  `json:"complete"`
-	Total         int64 `json:"total"`
-	Missing       int64 `json:"missing"`
-	Persistent    int64 `json:"persistent"`
-	Finite        int64 `json:"finite"`
-	OverMax       int64 `json:"over_max"`
-	InvalidTTL    int64 `json:"invalid_ttl"`
-	DecodeInvalid int64 `json:"decode_invalid"`
-	ReadErrors    int64 `json:"read_errors"`
-	V1            int64 `json:"v1"`
-	V2            int64 `json:"v2"`
-	V3            int64 `json:"v3"`
+	ScanID           string `json:"scan_id"`
+	ScopeFingerprint string `json:"scope_fingerprint"`
+	Complete         bool   `json:"complete"`
+	Total            int64  `json:"total"`
+	Missing          int64  `json:"missing"`
+	Persistent       int64  `json:"persistent"`
+	Finite           int64  `json:"finite"`
+	OverMax          int64  `json:"over_max"`
+	InvalidTTL       int64  `json:"invalid_ttl"`
+	DecodeInvalid    int64  `json:"decode_invalid"`
+	ReadErrors       int64  `json:"read_errors"`
+	V1               int64  `json:"v1"`
+	V2               int64  `json:"v2"`
+	V3               int64  `json:"v3"`
 }
 
 // RedisSessionStore is the sole v2 credential writer in Release A. It owns
@@ -89,6 +91,9 @@ type RedisSessionStore struct {
 	mode           SessionMode
 	maxPerUID      int
 	now            func() time.Time
+	// redisInstanceIDFn resolves the opaque process identity used to keep a
+	// resumable SCAN cursor bound to one Redis process.
+	redisInstanceIDFn func() (string, error)
 }
 
 type SessionStoreOption func(*RedisSessionStore)
@@ -500,6 +505,12 @@ func (s *RedisSessionStore) ObserveRateLimited(ctx context.Context, batchSize in
 	if interval < 0 {
 		return SessionObservation{}, fmt.Errorf("auth: observe interval must not be negative")
 	}
+	scanID, err := newSessionGeneration()
+	if err != nil {
+		return SessionObservation{}, fmt.Errorf("auth: create observation scan id: %w", err)
+	}
+	stats.ScanID = scanID
+	stats.ScopeFingerprint = s.rolloutObservationScopeFingerprint()
 	var throttle <-chan time.Time
 	var ticker *time.Ticker
 	if interval > 0 {

--- a/pkg/auth/session_store.go
+++ b/pkg/auth/session_store.go
@@ -64,6 +64,7 @@ var (
 // SessionObservation contains low-cardinality migration facts only. It never
 // includes a token, Redis key, UID, or payload.
 type SessionObservation struct {
+	Complete      bool  `json:"complete"`
 	Total         int64 `json:"total"`
 	Missing       int64 `json:"missing"`
 	Persistent    int64 `json:"persistent"`
@@ -71,6 +72,7 @@ type SessionObservation struct {
 	OverMax       int64 `json:"over_max"`
 	InvalidTTL    int64 `json:"invalid_ttl"`
 	DecodeInvalid int64 `json:"decode_invalid"`
+	ReadErrors    int64 `json:"read_errors"`
 	V1            int64 `json:"v1"`
 	V2            int64 `json:"v2"`
 	V3            int64 `json:"v3"`
@@ -84,21 +86,65 @@ type RedisSessionStore struct {
 	tokenPrefix    string
 	uidTokenPrefix string
 	maxTTL         time.Duration
+	mode           SessionMode
+	maxPerUID      int
+	now            func() time.Time
 }
 
-func NewRedisSessionStore(client *rd.Client, tokenPrefix, uidTokenPrefix string, maxTTL time.Duration) *RedisSessionStore {
+type SessionStoreOption func(*RedisSessionStore)
+
+func WithSessionMode(mode SessionMode) SessionStoreOption {
+	return func(store *RedisSessionStore) {
+		store.mode = mode
+	}
+}
+
+func WithSessionMaxPerUID(max int) SessionStoreOption {
+	return func(store *RedisSessionStore) {
+		store.maxPerUID = max
+	}
+}
+
+func WithSessionClock(now func() time.Time) SessionStoreOption {
+	return func(store *RedisSessionStore) {
+		if now != nil {
+			store.now = now
+		}
+	}
+}
+
+func NewRedisSessionStore(client *rd.Client, tokenPrefix, uidTokenPrefix string, maxTTL time.Duration, opts ...SessionStoreOption) *RedisSessionStore {
 	if client == nil {
 		panic("auth: NewRedisSessionStore requires non-nil redis client")
 	}
 	if maxTTL <= 0 {
 		panic("auth: NewRedisSessionStore requires positive max TTL")
 	}
-	return &RedisSessionStore{
+	store := &RedisSessionStore{
 		client:         client,
 		tokenPrefix:    tokenPrefix,
 		uidTokenPrefix: uidTokenPrefix,
 		maxTTL:         maxTTL,
+		mode:           SessionModeExpand,
+		now:            time.Now,
 	}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(store)
+		}
+	}
+	if !store.mode.valid() {
+		panic("auth: NewRedisSessionStore requires a valid session mode")
+	}
+	if store.mode.writesV3() {
+		if store.maxPerUID <= 0 || store.maxPerUID > sessionMaxPerUIDLimit {
+			panic("auth: NewRedisSessionStore requires a bounded max sessions per UID in v3 modes")
+		}
+		if store.maxTTL < time.Second {
+			panic("auth: NewRedisSessionStore requires at least one second max TTL in v3 modes")
+		}
+	}
+	return store
 }
 
 func (s *RedisSessionStore) tokenKey(token string) string {
@@ -442,27 +488,28 @@ func (s *RedisSessionStore) ObserveRateLimited(ctx context.Context, batchSize in
 	pattern := s.tokenPrefix + "*"
 	for {
 		if err := ctx.Err(); err != nil {
-			return SessionObservation{}, err
+			return stats, err
 		}
 		keys, next, err := s.client.Scan(cursor, pattern, batchSize).Result()
 		if err != nil {
-			return SessionObservation{}, fmt.Errorf("auth: observe scan: %w", err)
+			return stats, fmt.Errorf("auth: observe scan: %w", err)
 		}
 		for _, key := range keys {
 			if throttle != nil {
 				select {
 				case <-ctx.Done():
-					return SessionObservation{}, ctx.Err()
+					return stats, ctx.Err()
 				case <-throttle:
 				}
 			}
 			if err := ctx.Err(); err != nil {
-				return SessionObservation{}, err
+				return stats, err
 			}
 			stats.Total++
 			record, err := s.ReadToken(ctx, key)
 			if err != nil {
-				return SessionObservation{}, fmt.Errorf("auth: observe token record: %w", err)
+				stats.ReadErrors++
+				return stats, fmt.Errorf("auth: observe token record: %w", err)
 			}
 			switch {
 			case record.TTL == -2:
@@ -494,6 +541,7 @@ func (s *RedisSessionStore) ObserveRateLimited(ctx context.Context, batchSize in
 		}
 		cursor = next
 		if cursor == 0 {
+			stats.Complete = true
 			return stats, nil
 		}
 	}

--- a/pkg/auth/session_store.go
+++ b/pkg/auth/session_store.go
@@ -327,6 +327,22 @@ func (s *RedisSessionStore) RevokeIssued(ctx context.Context, token, uid string,
 		// owns the live credential and the original issuer must not revoke it.
 		return nil
 	}
+	var v3IndexKey string
+	var v3IndexMember string
+	if strings.HasPrefix(currentPayload, v3Prefix) {
+		info, err := Decode(currentPayload)
+		if err != nil {
+			return fmt.Errorf("auth: decode issued v3 token for revoke: %w", err)
+		}
+		if info.UID != uid || info.DeviceFlag != deviceFlag {
+			return errors.New("auth: issued v3 token revoke metadata mismatch")
+		}
+		v3IndexMember, err = encodeSessionIndexMember(token, info.DeviceFlag, info.DeviceID)
+		if err != nil {
+			return err
+		}
+		v3IndexKey = s.sessionIndexKey(info.UID, info.SessionGeneration)
+	}
 	result, err := compareDeleteScript.Run(
 		s.client,
 		[]string{s.tokenKey(token)},
@@ -344,7 +360,14 @@ func (s *RedisSessionStore) RevokeIssued(ctx context.Context, token, uid string,
 		// concurrent writer may have adopted this credential.
 		return nil
 	}
-	return s.compareDeleteDeviceIndex(token, uid, deviceFlag)
+	deviceErr := s.compareDeleteDeviceIndex(token, uid, deviceFlag)
+	var indexErr error
+	if v3IndexKey != "" {
+		if err := s.client.ZRem(v3IndexKey, v3IndexMember).Err(); err != nil {
+			indexErr = fmt.Errorf("auth: delete issued v3 session index: %w", err)
+		}
+	}
+	return errors.Join(deviceErr, indexErr)
 }
 
 func (s *RedisSessionStore) compareDeleteDeviceIndex(token, uid string, deviceFlag int) error {

--- a/pkg/auth/session_store_test.go
+++ b/pkg/auth/session_store_test.go
@@ -65,6 +65,7 @@ func TestRedisSessionStoreRejectsV3PayloadDowngrade(t *testing.T) {
 		IssuedAt:          now.Add(-time.Minute).Unix(),
 		ExpiresAt:         now.Add(time.Minute).Unix(),
 		SessionGeneration: "generation-v3",
+		SessionRevision:   1,
 	})
 	require.NoError(t, err)
 	v2, err := Encode(TokenInfo{UID: "u-v3", Name: "renamed"})
@@ -267,6 +268,7 @@ func TestRedisSessionStoreObserveAggregatesOnly(t *testing.T) {
 		IssuedAt:          now.Add(-time.Minute).Unix(),
 		ExpiresAt:         now.Add(time.Minute).Unix(),
 		SessionGeneration: "g3",
+		SessionRevision:   1,
 	})
 	require.NoError(t, err)
 	require.NoError(t, client.Set(keys[0], "u1@legacy", 0).Err())

--- a/pkg/auth/session_v3.go
+++ b/pkg/auth/session_v3.go
@@ -1,0 +1,890 @@
+package auth
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-server/pkg/metrics"
+	rd "github.com/go-redis/redis"
+)
+
+var (
+	ensureGenerationScript = rd.NewScript(`
+local current = redis.call("GET", KEYS[1])
+if not current then
+  redis.call("SET", KEYS[1], ARGV[1], "PX", ARGV[2], "NX")
+  current = redis.call("GET", KEYS[1])
+end
+if not current then
+  return redis.error_reply("generation initialization lost")
+end
+local ttl = redis.call("PTTL", KEYS[1])
+if ttl >= 0 and ttl < tonumber(ARGV[2]) then
+  redis.call("PEXPIRE", KEYS[1], ARGV[2])
+end
+return current
+`)
+	addSessionIndexScript = rd.NewScript(`
+redis.call("ZREMRANGEBYSCORE", KEYS[1], "-inf", ARGV[1])
+local existing = redis.call("ZSCORE", KEYS[1], ARGV[2])
+if not existing and redis.call("ZCARD", KEYS[1]) >= tonumber(ARGV[4]) then
+  return -1
+end
+redis.call("ZADD", KEYS[1], ARGV[3], ARGV[2])
+local ttl = redis.call("PTTL", KEYS[1])
+if ttl >= 0 and ttl < tonumber(ARGV[5]) then
+  redis.call("PEXPIRE", KEYS[1], ARGV[5])
+elseif ttl == -1 then
+  redis.call("PEXPIRE", KEYS[1], ARGV[5])
+end
+return 1
+`)
+	rotateGenerationScript = rd.NewScript(`
+local current = redis.call("GET", KEYS[1])
+local revision = 0
+local last_version = 0
+local ttl = -2
+if current then
+  local decoded = cjson.decode(current)
+  revision = tonumber(decoded.revision) or 0
+  last_version = tonumber(decoded.last_event_version) or 0
+  if last_version >= tonumber(ARGV[2]) then
+    if last_version == tonumber(ARGV[2]) and decoded.last_event_id == ARGV[3] then
+      return 0
+    end
+    return -1
+  end
+  ttl = redis.call("PTTL", KEYS[1])
+end
+local next = cjson.encode({
+  generation = ARGV[1],
+  revision = revision + 1,
+  state = "active",
+  last_event_version = tonumber(ARGV[2]),
+  last_event_id = ARGV[3]
+})
+if ttl == -1 then
+  redis.call("SET", KEYS[1], next)
+else
+  local next_ttl = tonumber(ARGV[4])
+  if ttl > next_ttl then
+    next_ttl = ttl
+  end
+  redis.call("SET", KEYS[1], next, "PX", next_ttl)
+end
+return 1
+`)
+	extendGenerationDeadlineScript = rd.NewScript(`
+local current = redis.call("GET", KEYS[1])
+if not current then
+  return 0
+end
+local decoded = cjson.decode(current)
+if decoded.generation ~= ARGV[1] or tonumber(decoded.revision) ~= tonumber(ARGV[2]) or decoded.state ~= "active" then
+  return 0
+end
+local ttl = redis.call("PTTL", KEYS[1])
+if ttl >= 0 and ttl < tonumber(ARGV[3]) then
+  redis.call("PEXPIRE", KEYS[1], ARGV[3])
+end
+return 1
+`)
+	casReplacePayloadKeepDeadlineScript = rd.NewScript(`
+local current = redis.call("GET", KEYS[1])
+if not current then
+  return {-2, 0, 0}
+end
+if current ~= ARGV[1] then
+  return {-4, 0, 0}
+end
+local ttl = redis.call("PTTL", KEYS[1])
+local persistent = 0
+if ttl == -1 then
+  ttl = tonumber(ARGV[3])
+  persistent = 1
+elseif ttl <= 0 then
+  return {-2, 0, 0}
+elseif ttl > tonumber(ARGV[3]) then
+  ttl = tonumber(ARGV[3])
+end
+redis.call("SET", KEYS[1], ARGV[2], "PX", ttl, "XX")
+return {1, ttl, persistent}
+`)
+)
+
+var (
+	ErrV3SessionsDisabled        = errors.New("auth: v3 session writer is disabled")
+	ErrSessionLimitReached       = errors.New("auth: session limit reached")
+	ErrIssueFenceChanged         = errors.New("auth: session issue fence changed")
+	ErrRevocationAlreadyApplied  = errors.New("auth: revocation event already applied")
+	ErrSessionGenerationInactive = errors.New("auth: session generation is not active")
+	ErrLegacySessionDenied       = errors.New("auth: legacy session denied")
+)
+
+const sessionGenerationActive = "active"
+
+type IssueFence struct {
+	Generation string
+	Revision   uint64
+}
+
+type RevocationEvent struct {
+	Version uint64
+	ID      string
+}
+
+type sessionGenerationRecord struct {
+	Generation       string `json:"generation"`
+	Revision         uint64 `json:"revision"`
+	State            string `json:"state"`
+	LastEventVersion uint64 `json:"last_event_version,omitempty"`
+	LastEventID      string `json:"last_event_id,omitempty"`
+}
+
+type sessionIndexMember struct {
+	Token      string `json:"token"`
+	DeviceFlag int    `json:"device_flag"`
+	DeviceID   string `json:"device_id,omitempty"`
+}
+
+func (s *RedisSessionStore) Mode() SessionMode {
+	return s.mode
+}
+
+func (s *RedisSessionStore) BeginIssue(ctx context.Context, uid string) (fence IssueFence, err error) {
+	started := time.Now()
+	defer func() { metrics.ObserveSessionOperation("begin_issue", started, err) }()
+	if !s.mode.writesV3() {
+		return IssueFence{}, ErrV3SessionsDisabled
+	}
+	if strings.TrimSpace(uid) == "" {
+		return IssueFence{}, errors.New("auth: begin issue requires uid")
+	}
+	if err := ctx.Err(); err != nil {
+		return IssueFence{}, err
+	}
+
+	generation, err := newSessionGeneration()
+	if err != nil {
+		return IssueFence{}, err
+	}
+	candidate, err := json.Marshal(sessionGenerationRecord{
+		Generation: generation,
+		Revision:   1,
+		State:      sessionGenerationActive,
+	})
+	if err != nil {
+		return IssueFence{}, fmt.Errorf("auth: encode initial session generation: %w", err)
+	}
+	result, err := ensureGenerationScript.Run(
+		s.client,
+		[]string{s.generationKey(uid)},
+		string(candidate),
+		s.maxTTL.Milliseconds(),
+	).Result()
+	if err != nil {
+		return IssueFence{}, fmt.Errorf("auth: initialize session generation: %w", err)
+	}
+	record, err := decodeSessionGeneration(result)
+	if err != nil {
+		return IssueFence{}, err
+	}
+	if record.State != sessionGenerationActive {
+		return IssueFence{}, ErrSessionGenerationInactive
+	}
+	return IssueFence{Generation: record.Generation, Revision: record.Revision}, nil
+}
+
+func (s *RedisSessionStore) CurrentGeneration(ctx context.Context, uid string) (string, error) {
+	if strings.TrimSpace(uid) == "" {
+		return "", errors.New("auth: current generation requires uid")
+	}
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+	raw, err := s.client.Get(s.generationKey(uid)).Result()
+	if err == rd.Nil {
+		return "", nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("auth: load session generation: %w", err)
+	}
+	record, err := decodeSessionGeneration(raw)
+	if err != nil {
+		return "", err
+	}
+	if record.State != sessionGenerationActive {
+		return "", ErrSessionGenerationInactive
+	}
+	return record.Generation, nil
+}
+
+func (s *RedisSessionStore) ValidateLegacySession(ctx context.Context, info TokenInfo, record TokenRecord) error {
+	if s.mode == SessionModeEnforce {
+		return ErrLegacySessionDenied
+	}
+	if s.mode == SessionModeBounded && (record.TTL <= 0 || record.TTL > s.maxTTL) {
+		return ErrLegacySessionDenied
+	}
+	if !s.mode.checksLegacyDeny() {
+		return nil
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	exists, err := s.client.Exists(s.legacyDenyKey(info.UID)).Result()
+	if err != nil {
+		return fmt.Errorf("auth: load legacy session deny marker: %w", err)
+	}
+	if exists != 0 {
+		return ErrLegacySessionDenied
+	}
+	return nil
+}
+
+// ReuseSession refreshes an existing credential without extending its
+// deadline. In v3 writer modes it also promotes a finite legacy credential to
+// v3 under the supplied issuance fence; a missing credential returns false so
+// the caller can issue a new random token.
+func (s *RedisSessionStore) ReuseSession(ctx context.Context, token string, snapshot TokenInfo, fence IssueFence) (ok bool, err error) {
+	started := time.Now()
+	defer func() { metrics.ObserveSessionOperation("reuse_session", started, err) }()
+	if strings.TrimSpace(token) == "" || strings.TrimSpace(snapshot.UID) == "" || snapshot.DeviceFlag < 0 {
+		return false, errors.New("auth: reuse session requires token, uid, and non-negative device flag")
+	}
+	if !s.mode.writesV3() {
+		payload, err := Encode(snapshot)
+		if err != nil {
+			return false, err
+		}
+		return s.ReuseExisting(ctx, token, payload, snapshot.UID, snapshot.DeviceFlag)
+	}
+	if strings.TrimSpace(fence.Generation) == "" || fence.Revision == 0 {
+		return false, errors.New("auth: reuse v3 session requires a valid issue fence")
+	}
+	if err := s.requireFence(ctx, snapshot.UID, fence); err != nil {
+		return false, err
+	}
+
+	for attempt := 0; attempt < 4; attempt++ {
+		record, err := s.ReadToken(ctx, s.tokenKey(token))
+		if err != nil {
+			return false, err
+		}
+		if record.TTL == -2 || strings.TrimSpace(record.Payload) == "" {
+			return false, nil
+		}
+		current, err := Decode(record.Payload)
+		if err != nil {
+			return false, fmt.Errorf("auth: decode reused token payload: %w", err)
+		}
+		if current.UID != snapshot.UID {
+			return false, errors.New("auth: reused token uid mismatch")
+		}
+		if current.IsV3() {
+			ok, conflict, err := s.reuseExistingV3(ctx, token, record.Payload, current, snapshot, fence)
+			if err != nil || ok || !conflict {
+				return ok, err
+			}
+			continue
+		}
+		ok, conflict, err := s.promoteLegacySession(ctx, token, record, snapshot, fence)
+		if err != nil || ok || !conflict {
+			return ok, err
+		}
+	}
+	s.cleanupIndexReservationIfLegacy(token, snapshot.UID, snapshot.DeviceFlag, snapshot.DeviceID)
+	return false, errors.New("auth: reused token changed too frequently")
+}
+
+// UpdateSessionSnapshot changes only display and authorization snapshot
+// fields. v3 security claims are copied from the current payload and the CAS
+// prevents a concurrent writer from being overwritten with stale claims.
+func (s *RedisSessionStore) UpdateSessionSnapshot(ctx context.Context, token string, snapshot TokenInfo) (ok bool, err error) {
+	started := time.Now()
+	defer func() { metrics.ObserveSessionOperation("update_snapshot", started, err) }()
+	if strings.TrimSpace(token) == "" {
+		return false, errors.New("auth: update session snapshot requires token")
+	}
+	for attempt := 0; attempt < 4; attempt++ {
+		record, err := s.ReadToken(ctx, s.tokenKey(token))
+		if err != nil {
+			return false, err
+		}
+		if record.TTL == -2 || strings.TrimSpace(record.Payload) == "" {
+			return false, nil
+		}
+		current, err := Decode(record.Payload)
+		if err != nil {
+			return false, fmt.Errorf("auth: decode token snapshot: %w", err)
+		}
+		if snapshot.UID != "" && snapshot.UID != current.UID {
+			return false, errors.New("auth: token snapshot uid mismatch")
+		}
+		current.Name = snapshot.Name
+		current.Role = snapshot.Role
+		current.Language = snapshot.Language
+
+		var next string
+		capTTL := s.maxTTL
+		if current.IsV3() {
+			next, err = EncodeV3(current)
+			capTTL = time.Unix(current.ExpiresAt, 0).Sub(s.now().UTC())
+		} else {
+			next, err = Encode(current)
+		}
+		if err != nil {
+			return false, err
+		}
+		if capTTL <= 0 {
+			return false, nil
+		}
+		_, replaced, conflict, err := s.casReplacePayloadKeepDeadline(ctx, token, record.Payload, next, capTTL)
+		if err != nil {
+			return false, err
+		}
+		if conflict {
+			continue
+		}
+		return replaced, nil
+	}
+	return false, errors.New("auth: token snapshot changed too frequently")
+}
+
+func (s *RedisSessionStore) reuseExistingV3(ctx context.Context, token, currentPayload string, current, snapshot TokenInfo, fence IssueFence) (ok bool, conflict bool, err error) {
+	if current.SessionGeneration != fence.Generation || current.SessionRevision != fence.Revision {
+		return false, false, nil
+	}
+	if current.DeviceFlag != snapshot.DeviceFlag {
+		return false, false, errors.New("auth: reused v3 token device flag mismatch")
+	}
+	current.Name = snapshot.Name
+	current.Role = snapshot.Role
+	current.Language = snapshot.Language
+	next, err := EncodeV3(current)
+	if err != nil {
+		return false, false, err
+	}
+	deadline := time.Unix(current.ExpiresAt, 0)
+	capTTL := deadline.Sub(s.now().UTC())
+	if capTTL <= 0 {
+		return false, false, nil
+	}
+	ttl, replaced, conflict, err := s.casReplacePayloadKeepDeadline(ctx, token, currentPayload, next, capTTL)
+	if err != nil {
+		return false, false, err
+	}
+	if conflict {
+		return false, true, nil
+	}
+	if !replaced {
+		return false, false, nil
+	}
+	member, err := encodeSessionIndexMember(token, current.DeviceFlag, current.DeviceID)
+	if err != nil {
+		return false, false, err
+	}
+	if err := s.addSessionIndex(current.UID, member, current.ExpiresAt, ttl); err != nil {
+		return false, false, err
+	}
+	if err := s.client.Set(s.uidTokenKey(current.UID, current.DeviceFlag), token, ttl).Err(); err != nil {
+		return false, false, fmt.Errorf("auth: refresh v3 token device index: %w", err)
+	}
+	if err := s.extendFenceDeadline(ctx, current.UID, fence, deadline); err != nil {
+		return false, false, err
+	}
+	if err := s.requireFence(ctx, current.UID, fence); err != nil {
+		return false, false, err
+	}
+	return true, false, nil
+}
+
+func (s *RedisSessionStore) promoteLegacySession(ctx context.Context, token string, record TokenRecord, snapshot TokenInfo, fence IssueFence) (ok bool, conflict bool, err error) {
+	capTTL := record.TTL
+	if capTTL == -1 || capTTL > s.maxTTL {
+		capTTL = s.maxTTL
+	}
+	if capTTL <= 0 {
+		return false, false, nil
+	}
+	now := s.now().UTC()
+	expiresAt := now.Add(capTTL).Unix()
+	deadline := time.Unix(expiresAt, 0)
+	capTTL = deadline.Sub(now)
+	if capTTL <= 0 {
+		return false, false, nil
+	}
+	snapshot.IssuedAt = now.Unix()
+	snapshot.ExpiresAt = expiresAt
+	snapshot.SessionGeneration = fence.Generation
+	snapshot.SessionRevision = fence.Revision
+	payload, err := EncodeV3(snapshot)
+	if err != nil {
+		return false, false, err
+	}
+	ownedPayload, err := markIssuedPayload(payload, token)
+	if err != nil {
+		return false, false, err
+	}
+	member, err := encodeSessionIndexMember(token, snapshot.DeviceFlag, snapshot.DeviceID)
+	if err != nil {
+		return false, false, err
+	}
+	if err := s.addSessionIndex(snapshot.UID, member, expiresAt, capTTL); err != nil {
+		return false, false, err
+	}
+	ttl, replaced, conflict, err := s.casReplacePayloadKeepDeadline(ctx, token, record.Payload, ownedPayload, capTTL)
+	if err != nil {
+		_ = s.client.ZRem(s.sessionIndexKey(snapshot.UID), member).Err()
+		return false, false, err
+	}
+	if conflict {
+		return false, true, nil
+	}
+	if !replaced {
+		_ = s.client.ZRem(s.sessionIndexKey(snapshot.UID), member).Err()
+		return false, false, nil
+	}
+	cleanup := func(primary error) error {
+		cleanupErr := s.cleanupIssuedV3(token, ownedPayload, snapshot.UID, snapshot.DeviceFlag, member)
+		if cleanupErr != nil {
+			return fmt.Errorf("%w (promoted credential cleanup failed: %v)", primary, cleanupErr)
+		}
+		return primary
+	}
+	if err := s.client.Set(s.uidTokenKey(snapshot.UID, snapshot.DeviceFlag), token, ttl).Err(); err != nil {
+		return false, false, cleanup(fmt.Errorf("auth: bind promoted token device: %w", err))
+	}
+	if err := s.extendFenceDeadline(ctx, snapshot.UID, fence, deadline); err != nil {
+		return false, false, cleanup(err)
+	}
+	if err := s.requireFence(ctx, snapshot.UID, fence); err != nil {
+		return false, false, cleanup(err)
+	}
+	return true, false, nil
+}
+
+func (s *RedisSessionStore) casReplacePayloadKeepDeadline(ctx context.Context, token, expected, next string, capTTL time.Duration) (ttl time.Duration, replaced bool, conflict bool, err error) {
+	if err := ctx.Err(); err != nil {
+		return 0, false, false, err
+	}
+	if capTTL <= 0 {
+		return 0, false, false, errors.New("auth: replacement ttl must be positive")
+	}
+	result, err := casReplacePayloadKeepDeadlineScript.Run(
+		s.client,
+		[]string{s.tokenKey(token)},
+		expected,
+		next,
+		capTTL.Milliseconds(),
+	).Result()
+	if err != nil {
+		return 0, false, false, fmt.Errorf("auth: replace token payload: %w", err)
+	}
+	parts, ok := result.([]interface{})
+	if !ok || len(parts) != 3 {
+		return 0, false, false, fmt.Errorf("auth: invalid token replacement result %T", result)
+	}
+	code, err := redisInteger(parts[0])
+	if err != nil {
+		return 0, false, false, err
+	}
+	if code == -2 {
+		return 0, false, false, nil
+	}
+	if code == -4 {
+		return 0, false, true, nil
+	}
+	if code != 1 {
+		return 0, false, false, fmt.Errorf("auth: unexpected token replacement result %d", code)
+	}
+	ttlMS, err := redisInteger(parts[1])
+	if err != nil {
+		return 0, false, false, err
+	}
+	if ttlMS <= 0 {
+		return 0, false, false, fmt.Errorf("auth: invalid token replacement ttl %d", ttlMS)
+	}
+	persistent, err := redisInteger(parts[2])
+	if err != nil {
+		return 0, false, false, err
+	}
+	if persistent == 1 {
+		metrics.ObservePersistentSession()
+	}
+	return time.Duration(ttlMS) * time.Millisecond, true, false, nil
+}
+
+func (s *RedisSessionStore) cleanupIndexReservationIfLegacy(token, uid string, deviceFlag int, deviceID string) {
+	raw, err := s.client.Get(s.tokenKey(token)).Result()
+	if err == nil {
+		if info, decodeErr := Decode(raw); decodeErr == nil && info.IsV3() {
+			return
+		}
+	}
+	member, err := encodeSessionIndexMember(token, deviceFlag, deviceID)
+	if err == nil {
+		_ = s.client.ZRem(s.sessionIndexKey(uid), member).Err()
+	}
+}
+
+func (s *RedisSessionStore) IssueNewSession(ctx context.Context, token string, info TokenInfo, fence IssueFence) (err error) {
+	started := time.Now()
+	defer func() { metrics.ObserveSessionOperation("issue_v3", started, err) }()
+	if !s.mode.writesV3() {
+		return ErrV3SessionsDisabled
+	}
+	if strings.TrimSpace(token) == "" || strings.TrimSpace(info.UID) == "" || info.DeviceFlag < 0 {
+		return errors.New("auth: issue v3 token requires token, uid, and non-negative device flag")
+	}
+	if strings.TrimSpace(fence.Generation) == "" || fence.Revision == 0 {
+		return errors.New("auth: issue v3 token requires a valid issue fence")
+	}
+	if err := s.requireFence(ctx, info.UID, fence); err != nil {
+		return err
+	}
+
+	now := s.now().UTC()
+	issuedAt := now.Unix()
+	expiresAt := now.Add(s.maxTTL).Unix()
+	deadline := time.Unix(expiresAt, 0)
+	ttl := deadline.Sub(now)
+	if ttl <= 0 {
+		return errors.New("auth: configured session lifetime does not reach the next UTC second")
+	}
+	info.IssuedAt = issuedAt
+	info.ExpiresAt = expiresAt
+	info.SessionGeneration = fence.Generation
+	info.SessionRevision = fence.Revision
+	payload, err := EncodeV3(info)
+	if err != nil {
+		return err
+	}
+	ownedPayload, err := markIssuedPayload(payload, token)
+	if err != nil {
+		return fmt.Errorf("auth: mark issued v3 token payload: %w", err)
+	}
+	member, err := encodeSessionIndexMember(token, info.DeviceFlag, info.DeviceID)
+	if err != nil {
+		return err
+	}
+
+	created, err := s.client.SetNX(s.tokenKey(token), ownedPayload, ttl).Result()
+	if err != nil {
+		return fmt.Errorf("auth: issue v3 token: %w", err)
+	}
+	if !created {
+		return ErrTokenCollision
+	}
+	cleanup := func(primary error) error {
+		cleanupErr := s.cleanupIssuedV3(token, ownedPayload, info.UID, info.DeviceFlag, member)
+		if cleanupErr != nil {
+			return fmt.Errorf("%w (credential cleanup failed: %v)", primary, cleanupErr)
+		}
+		return primary
+	}
+
+	if err := s.addSessionIndex(info.UID, member, expiresAt, ttl); err != nil {
+		return cleanup(err)
+	}
+	if err := ctx.Err(); err != nil {
+		return cleanup(err)
+	}
+	if err := s.client.Set(s.uidTokenKey(info.UID, info.DeviceFlag), token, ttl).Err(); err != nil {
+		return cleanup(fmt.Errorf("auth: bind v3 token device: %w", err))
+	}
+	if err := s.extendFenceDeadline(ctx, info.UID, fence, deadline); err != nil {
+		return cleanup(err)
+	}
+	if err := s.requireFence(ctx, info.UID, fence); err != nil {
+		return cleanup(err)
+	}
+	return nil
+}
+
+func (s *RedisSessionStore) extendFenceDeadline(ctx context.Context, uid string, fence IssueFence, deadline time.Time) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	ttl := deadline.Sub(s.now().UTC())
+	if ttl <= 0 {
+		return ErrIssueFenceChanged
+	}
+	result, err := extendGenerationDeadlineScript.Run(
+		s.client,
+		[]string{s.generationKey(uid)},
+		fence.Generation,
+		fence.Revision,
+		ttl.Milliseconds(),
+	).Result()
+	if err != nil {
+		return fmt.Errorf("auth: extend session generation deadline: %w", err)
+	}
+	code, err := redisInteger(result)
+	if err != nil {
+		return err
+	}
+	if code != 1 {
+		return ErrIssueFenceChanged
+	}
+	return nil
+}
+
+func (s *RedisSessionStore) RevokeAll(ctx context.Context, uid string, event RevocationEvent) (err error) {
+	started := time.Now()
+	defer func() { metrics.ObserveSessionOperation("revoke_all", started, err) }()
+	if !s.mode.writesV3() {
+		return ErrV3SessionsDisabled
+	}
+	if strings.TrimSpace(uid) == "" || event.Version == 0 || strings.TrimSpace(event.ID) == "" {
+		return errors.New("auth: revoke all requires uid and a versioned event")
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	nextGeneration, err := newSessionGeneration()
+	if err != nil {
+		return err
+	}
+	result, err := rotateGenerationScript.Run(
+		s.client,
+		[]string{s.generationKey(uid)},
+		nextGeneration,
+		event.Version,
+		event.ID,
+		s.maxTTL.Milliseconds(),
+	).Result()
+	if err != nil {
+		return fmt.Errorf("auth: rotate session generation: %w", err)
+	}
+	code, err := redisInteger(result)
+	if err != nil {
+		return err
+	}
+	alreadyApplied := code <= 0
+	if s.mode.rank() >= SessionModeRevoke.rank() {
+		if err := s.client.Set(s.legacyDenyKey(uid), strconv.FormatUint(event.Version, 10), 0).Err(); err != nil {
+			return fmt.Errorf("auth: persist legacy session deny marker: %w", err)
+		}
+	}
+	if err := s.client.Del(s.sessionIndexKey(uid)).Err(); err != nil {
+		return fmt.Errorf("auth: session generation revoked but index cleanup failed: %w", err)
+	}
+	if alreadyApplied {
+		return ErrRevocationAlreadyApplied
+	}
+	return nil
+}
+
+// RevokeCurrent removes one bearer with compare-delete semantics and cleans
+// both compatibility and v3 indexes only after that exact payload was
+// removed. A concurrent payload adoption is retried instead of being deleted
+// based on a stale read.
+func (s *RedisSessionStore) RevokeCurrent(ctx context.Context, token, uid string, deviceFlag int) (err error) {
+	started := time.Now()
+	defer func() { metrics.ObserveSessionOperation("revoke_current", started, err) }()
+	if strings.TrimSpace(token) == "" || strings.TrimSpace(uid) == "" || deviceFlag < 0 {
+		return errors.New("auth: revoke current requires token, uid, and non-negative device flag")
+	}
+	for attempt := 0; attempt < 4; attempt++ {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		currentPayload, err := s.client.Get(s.tokenKey(token)).Result()
+		if err == rd.Nil {
+			return s.compareDeleteDeviceIndex(token, uid, deviceFlag)
+		}
+		if err != nil {
+			return fmt.Errorf("auth: load current token for revoke: %w", err)
+		}
+		info, err := Decode(currentPayload)
+		if err != nil {
+			return fmt.Errorf("auth: decode current token for revoke: %w", err)
+		}
+		if info.UID != uid {
+			return errors.New("auth: current token uid mismatch")
+		}
+		result, err := compareDeleteScript.Run(s.client, []string{s.tokenKey(token)}, currentPayload).Result()
+		if err != nil {
+			return fmt.Errorf("auth: delete current token: %w", err)
+		}
+		deleted, err := redisInteger(result)
+		if err != nil {
+			return err
+		}
+		if deleted == 0 {
+			continue
+		}
+		if err := s.compareDeleteDeviceIndex(token, uid, deviceFlag); err != nil {
+			return err
+		}
+		if info.IsV3() {
+			member, err := encodeSessionIndexMember(token, info.DeviceFlag, info.DeviceID)
+			if err != nil {
+				return err
+			}
+			if err := s.client.ZRem(s.sessionIndexKey(uid), member).Err(); err != nil {
+				return fmt.Errorf("auth: delete current v3 session index: %w", err)
+			}
+		}
+		return nil
+	}
+	return errors.New("auth: current token changed too frequently during revoke")
+}
+
+// InvalidateCurrentToken is the module-facing current-logout primitive. It
+// uses v3 metadata to clean the bounded index; legacy credentials are deleted
+// directly because their payload has no trustworthy device scope.
+func (s *RedisSessionStore) InvalidateCurrentToken(ctx context.Context, uid, token string) error {
+	if strings.TrimSpace(uid) == "" || strings.TrimSpace(token) == "" {
+		return errors.New("auth: invalidate current token requires uid and token")
+	}
+	record, err := s.ReadToken(ctx, s.tokenKey(token))
+	if err != nil {
+		return err
+	}
+	if record.TTL == -2 || strings.TrimSpace(record.Payload) == "" {
+		return nil
+	}
+	info, err := Decode(record.Payload)
+	if err != nil {
+		return fmt.Errorf("auth: decode current token: %w", err)
+	}
+	if info.UID != uid {
+		return errors.New("auth: current token uid mismatch")
+	}
+	if info.IsV3() {
+		return s.RevokeCurrent(ctx, token, uid, info.DeviceFlag)
+	}
+	return s.DeleteToken(ctx, token)
+}
+
+func (s *RedisSessionStore) requireFence(ctx context.Context, uid string, fence IssueFence) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	raw, err := s.client.Get(s.generationKey(uid)).Result()
+	if err == rd.Nil {
+		return ErrIssueFenceChanged
+	}
+	if err != nil {
+		return fmt.Errorf("auth: verify issue fence: %w", err)
+	}
+	record, err := decodeSessionGeneration(raw)
+	if err != nil {
+		return err
+	}
+	if record.State != sessionGenerationActive || record.Generation != fence.Generation || record.Revision != fence.Revision {
+		return ErrIssueFenceChanged
+	}
+	return nil
+}
+
+func (s *RedisSessionStore) addSessionIndex(uid, member string, expiresAt int64, ttl time.Duration) error {
+	result, err := addSessionIndexScript.Run(
+		s.client,
+		[]string{s.sessionIndexKey(uid)},
+		s.now().UTC().Unix(),
+		member,
+		expiresAt,
+		s.maxPerUID,
+		ttl.Milliseconds(),
+	).Result()
+	if err != nil {
+		return fmt.Errorf("auth: add v3 session index: %w", err)
+	}
+	code, err := redisInteger(result)
+	if err != nil {
+		return err
+	}
+	if code == -1 {
+		return ErrSessionLimitReached
+	}
+	if code != 1 {
+		return fmt.Errorf("auth: unexpected session index result %d", code)
+	}
+	return nil
+}
+
+func (s *RedisSessionStore) cleanupIssuedV3(token, ownedPayload, uid string, deviceFlag int, member string) error {
+	result, err := compareDeleteScript.Run(s.client, []string{s.tokenKey(token)}, ownedPayload).Result()
+	if err != nil {
+		return fmt.Errorf("auth: delete issued v3 token: %w", err)
+	}
+	deleted, err := redisInteger(result)
+	if err != nil {
+		return err
+	}
+	if deleted == 0 {
+		return nil
+	}
+	if err := s.compareDeleteDeviceIndex(token, uid, deviceFlag); err != nil {
+		return err
+	}
+	if err := s.client.ZRem(s.sessionIndexKey(uid), member).Err(); err != nil {
+		return fmt.Errorf("auth: delete issued v3 session index: %w", err)
+	}
+	return nil
+}
+
+func (s *RedisSessionStore) generationKey(uid string) string {
+	return s.uidTokenPrefix + "auth:generation:" + sessionSubject(uid)
+}
+
+func (s *RedisSessionStore) sessionIndexKey(uid string) string {
+	return s.uidTokenPrefix + "auth:sessions:" + sessionSubject(uid)
+}
+
+func (s *RedisSessionStore) legacyDenyKey(uid string) string {
+	return s.uidTokenPrefix + "auth:legacy-deny:" + sessionSubject(uid)
+}
+
+func sessionSubject(uid string) string {
+	sum := sha256.Sum256([]byte(uid))
+	return hex.EncodeToString(sum[:])
+}
+
+func newSessionGeneration() (string, error) {
+	raw := make([]byte, 32)
+	if _, err := rand.Read(raw); err != nil {
+		return "", fmt.Errorf("auth: generate session generation: %w", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(raw), nil
+}
+
+func decodeSessionGeneration(value interface{}) (sessionGenerationRecord, error) {
+	var raw []byte
+	switch typed := value.(type) {
+	case string:
+		raw = []byte(typed)
+	case []byte:
+		raw = typed
+	default:
+		return sessionGenerationRecord{}, fmt.Errorf("auth: invalid session generation result %T", value)
+	}
+	var record sessionGenerationRecord
+	if err := json.Unmarshal(raw, &record); err != nil {
+		return sessionGenerationRecord{}, fmt.Errorf("auth: decode session generation: %w", err)
+	}
+	if strings.TrimSpace(record.Generation) == "" || record.Revision == 0 || strings.TrimSpace(record.State) == "" {
+		return sessionGenerationRecord{}, errors.New("auth: invalid session generation record")
+	}
+	return record, nil
+}
+
+func encodeSessionIndexMember(token string, deviceFlag int, deviceID string) (string, error) {
+	encoded, err := json.Marshal(sessionIndexMember{Token: token, DeviceFlag: deviceFlag, DeviceID: deviceID})
+	if err != nil {
+		return "", fmt.Errorf("auth: encode session index member: %w", err)
+	}
+	return string(encoded), nil
+}

--- a/pkg/auth/session_v3.go
+++ b/pkg/auth/session_v3.go
@@ -53,16 +53,18 @@ local current = redis.call("GET", KEYS[1])
 local revision = 0
 local last_version = 0
 local ttl = -2
+local previous_generation = ""
 if current then
   local decoded = cjson.decode(current)
   revision = tonumber(decoded.revision) or 0
   last_version = tonumber(decoded.last_event_version) or 0
   if last_version >= tonumber(ARGV[2]) then
     if last_version == tonumber(ARGV[2]) and decoded.last_event_id == ARGV[3] then
-      return 0
+      return {0, decoded.last_revoked_generation or ""}
     end
-    return -1
+    return {-1, ""}
   end
+  previous_generation = decoded.generation or ""
   ttl = redis.call("PTTL", KEYS[1])
 end
 local next = cjson.encode({
@@ -70,7 +72,8 @@ local next = cjson.encode({
   revision = revision + 1,
   state = "active",
   last_event_version = tonumber(ARGV[2]),
-  last_event_id = ARGV[3]
+  last_event_id = ARGV[3],
+  last_revoked_generation = previous_generation
 })
 if ttl == -1 then
   redis.call("SET", KEYS[1], next)
@@ -81,7 +84,7 @@ else
   end
   redis.call("SET", KEYS[1], next, "PX", next_ttl)
 end
-return 1
+return {1, previous_generation}
 `)
 	extendGenerationDeadlineScript = rd.NewScript(`
 local current = redis.call("GET", KEYS[1])
@@ -143,11 +146,12 @@ type RevocationEvent struct {
 }
 
 type sessionGenerationRecord struct {
-	Generation       string `json:"generation"`
-	Revision         uint64 `json:"revision"`
-	State            string `json:"state"`
-	LastEventVersion uint64 `json:"last_event_version,omitempty"`
-	LastEventID      string `json:"last_event_id,omitempty"`
+	Generation            string `json:"generation"`
+	Revision              uint64 `json:"revision"`
+	State                 string `json:"state"`
+	LastEventVersion      uint64 `json:"last_event_version,omitempty"`
+	LastEventID           string `json:"last_event_id,omitempty"`
+	LastRevokedGeneration string `json:"last_revoked_generation,omitempty"`
 }
 
 type sessionIndexMember struct {
@@ -302,7 +306,7 @@ func (s *RedisSessionStore) ReuseSession(ctx context.Context, token string, snap
 			return ok, err
 		}
 	}
-	s.cleanupIndexReservationIfLegacy(token, snapshot.UID, snapshot.DeviceFlag, snapshot.DeviceID)
+	s.cleanupIndexReservationIfLegacy(token, snapshot.UID, snapshot.DeviceFlag, snapshot.DeviceID, fence.Generation)
 	return false, errors.New("auth: reused token changed too frequently")
 }
 
@@ -393,7 +397,7 @@ func (s *RedisSessionStore) reuseExistingV3(ctx context.Context, token, currentP
 	if err != nil {
 		return false, false, err
 	}
-	if err := s.addSessionIndex(current.UID, member, current.ExpiresAt, ttl); err != nil {
+	if err := s.addSessionIndex(current.UID, current.SessionGeneration, member, current.ExpiresAt, ttl); err != nil {
 		return false, false, err
 	}
 	if err := s.client.Set(s.uidTokenKey(current.UID, current.DeviceFlag), token, ttl).Err(); err != nil {
@@ -439,23 +443,23 @@ func (s *RedisSessionStore) promoteLegacySession(ctx context.Context, token stri
 	if err != nil {
 		return false, false, err
 	}
-	if err := s.addSessionIndex(snapshot.UID, member, expiresAt, capTTL); err != nil {
+	if err := s.addSessionIndex(snapshot.UID, fence.Generation, member, expiresAt, capTTL); err != nil {
 		return false, false, err
 	}
 	ttl, replaced, conflict, err := s.casReplacePayloadKeepDeadline(ctx, token, record.Payload, ownedPayload, capTTL)
 	if err != nil {
-		_ = s.client.ZRem(s.sessionIndexKey(snapshot.UID), member).Err()
+		_ = s.client.ZRem(s.sessionIndexKey(snapshot.UID, fence.Generation), member).Err()
 		return false, false, err
 	}
 	if conflict {
 		return false, true, nil
 	}
 	if !replaced {
-		_ = s.client.ZRem(s.sessionIndexKey(snapshot.UID), member).Err()
+		_ = s.client.ZRem(s.sessionIndexKey(snapshot.UID, fence.Generation), member).Err()
 		return false, false, nil
 	}
 	cleanup := func(primary error) error {
-		cleanupErr := s.cleanupIssuedV3(token, ownedPayload, snapshot.UID, snapshot.DeviceFlag, member)
+		cleanupErr := s.cleanupIssuedV3(token, ownedPayload, snapshot.UID, snapshot.DeviceFlag, fence.Generation, member)
 		if cleanupErr != nil {
 			return fmt.Errorf("%w (promoted credential cleanup failed: %v)", primary, cleanupErr)
 		}
@@ -524,7 +528,7 @@ func (s *RedisSessionStore) casReplacePayloadKeepDeadline(ctx context.Context, t
 	return time.Duration(ttlMS) * time.Millisecond, true, false, nil
 }
 
-func (s *RedisSessionStore) cleanupIndexReservationIfLegacy(token, uid string, deviceFlag int, deviceID string) {
+func (s *RedisSessionStore) cleanupIndexReservationIfLegacy(token, uid string, deviceFlag int, deviceID, generation string) {
 	raw, err := s.client.Get(s.tokenKey(token)).Result()
 	if err == nil {
 		if info, decodeErr := Decode(raw); decodeErr == nil && info.IsV3() {
@@ -533,7 +537,7 @@ func (s *RedisSessionStore) cleanupIndexReservationIfLegacy(token, uid string, d
 	}
 	member, err := encodeSessionIndexMember(token, deviceFlag, deviceID)
 	if err == nil {
-		_ = s.client.ZRem(s.sessionIndexKey(uid), member).Err()
+		_ = s.client.ZRem(s.sessionIndexKey(uid, generation), member).Err()
 	}
 }
 
@@ -586,14 +590,14 @@ func (s *RedisSessionStore) IssueNewSession(ctx context.Context, token string, i
 		return ErrTokenCollision
 	}
 	cleanup := func(primary error) error {
-		cleanupErr := s.cleanupIssuedV3(token, ownedPayload, info.UID, info.DeviceFlag, member)
+		cleanupErr := s.cleanupIssuedV3(token, ownedPayload, info.UID, info.DeviceFlag, fence.Generation, member)
 		if cleanupErr != nil {
 			return fmt.Errorf("%w (credential cleanup failed: %v)", primary, cleanupErr)
 		}
 		return primary
 	}
 
-	if err := s.addSessionIndex(info.UID, member, expiresAt, ttl); err != nil {
+	if err := s.addSessionIndex(info.UID, fence.Generation, member, expiresAt, ttl); err != nil {
 		return cleanup(err)
 	}
 	if err := ctx.Err(); err != nil {
@@ -666,20 +670,35 @@ func (s *RedisSessionStore) RevokeAll(ctx context.Context, uid string, event Rev
 	if err != nil {
 		return fmt.Errorf("auth: rotate session generation: %w", err)
 	}
-	code, err := redisInteger(result)
+	parts, ok := result.([]interface{})
+	if !ok || len(parts) != 2 {
+		return fmt.Errorf("auth: invalid session generation rotation result %T", result)
+	}
+	code, err := redisInteger(parts[0])
 	if err != nil {
 		return err
 	}
-	alreadyApplied := code <= 0
+	previousGeneration, err := redisString(parts[1])
+	if err != nil {
+		return err
+	}
+	if code == -1 {
+		return ErrRevocationAlreadyApplied
+	}
+	if code != 0 && code != 1 {
+		return fmt.Errorf("auth: unexpected session generation rotation result %d", code)
+	}
 	if s.mode.rank() >= SessionModeRevoke.rank() {
 		if err := s.client.Set(s.legacyDenyKey(uid), strconv.FormatUint(event.Version, 10), 0).Err(); err != nil {
 			return fmt.Errorf("auth: persist legacy session deny marker: %w", err)
 		}
 	}
-	if err := s.client.Del(s.sessionIndexKey(uid)).Err(); err != nil {
-		return fmt.Errorf("auth: session generation revoked but index cleanup failed: %w", err)
+	if previousGeneration != "" {
+		if err := s.client.Del(s.sessionIndexKey(uid, previousGeneration)).Err(); err != nil {
+			return fmt.Errorf("auth: session generation revoked but index cleanup failed: %w", err)
+		}
 	}
-	if alreadyApplied {
+	if code == 0 {
 		return ErrRevocationAlreadyApplied
 	}
 	return nil
@@ -732,7 +751,7 @@ func (s *RedisSessionStore) RevokeCurrent(ctx context.Context, token, uid string
 			if err != nil {
 				return err
 			}
-			if err := s.client.ZRem(s.sessionIndexKey(uid), member).Err(); err != nil {
+			if err := s.client.ZRem(s.sessionIndexKey(uid, info.SessionGeneration), member).Err(); err != nil {
 				return fmt.Errorf("auth: delete current v3 session index: %w", err)
 			}
 		}
@@ -789,10 +808,13 @@ func (s *RedisSessionStore) requireFence(ctx context.Context, uid string, fence 
 	return nil
 }
 
-func (s *RedisSessionStore) addSessionIndex(uid, member string, expiresAt int64, ttl time.Duration) error {
+func (s *RedisSessionStore) addSessionIndex(uid, generation, member string, expiresAt int64, ttl time.Duration) error {
+	if strings.TrimSpace(generation) == "" {
+		return errors.New("auth: add v3 session index requires generation")
+	}
 	result, err := addSessionIndexScript.Run(
 		s.client,
-		[]string{s.sessionIndexKey(uid)},
+		[]string{s.sessionIndexKey(uid, generation)},
 		s.now().UTC().Unix(),
 		member,
 		expiresAt,
@@ -815,7 +837,7 @@ func (s *RedisSessionStore) addSessionIndex(uid, member string, expiresAt int64,
 	return nil
 }
 
-func (s *RedisSessionStore) cleanupIssuedV3(token, ownedPayload, uid string, deviceFlag int, member string) error {
+func (s *RedisSessionStore) cleanupIssuedV3(token, ownedPayload, uid string, deviceFlag int, generation, member string) error {
 	result, err := compareDeleteScript.Run(s.client, []string{s.tokenKey(token)}, ownedPayload).Result()
 	if err != nil {
 		return fmt.Errorf("auth: delete issued v3 token: %w", err)
@@ -830,7 +852,7 @@ func (s *RedisSessionStore) cleanupIssuedV3(token, ownedPayload, uid string, dev
 	if err := s.compareDeleteDeviceIndex(token, uid, deviceFlag); err != nil {
 		return err
 	}
-	if err := s.client.ZRem(s.sessionIndexKey(uid), member).Err(); err != nil {
+	if err := s.client.ZRem(s.sessionIndexKey(uid, generation), member).Err(); err != nil {
 		return fmt.Errorf("auth: delete issued v3 session index: %w", err)
 	}
 	return nil
@@ -840,8 +862,8 @@ func (s *RedisSessionStore) generationKey(uid string) string {
 	return s.uidTokenPrefix + "auth:generation:" + sessionSubject(uid)
 }
 
-func (s *RedisSessionStore) sessionIndexKey(uid string) string {
-	return s.uidTokenPrefix + "auth:sessions:" + sessionSubject(uid)
+func (s *RedisSessionStore) sessionIndexKey(uid, generation string) string {
+	return s.uidTokenPrefix + "auth:sessions:" + sessionSubject(uid) + ":" + sessionSubject(generation)
 }
 
 func (s *RedisSessionStore) legacyDenyKey(uid string) string {
@@ -879,6 +901,17 @@ func decodeSessionGeneration(value interface{}) (sessionGenerationRecord, error)
 		return sessionGenerationRecord{}, errors.New("auth: invalid session generation record")
 	}
 	return record, nil
+}
+
+func redisString(value interface{}) (string, error) {
+	switch typed := value.(type) {
+	case string:
+		return typed, nil
+	case []byte:
+		return string(typed), nil
+	default:
+		return "", fmt.Errorf("auth: invalid redis string result %T", value)
+	}
 }
 
 func encodeSessionIndexMember(token string, deviceFlag int, deviceID string) (string, error) {

--- a/pkg/auth/session_v3.go
+++ b/pkg/auth/session_v3.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-server/pkg/metrics"
 	rd "github.com/go-redis/redis"
 )
@@ -784,7 +785,16 @@ func (s *RedisSessionStore) InvalidateCurrentToken(ctx context.Context, uid, tok
 	if info.IsV3() {
 		return s.RevokeCurrent(ctx, token, uid, info.DeviceFlag)
 	}
-	return s.DeleteToken(ctx, token)
+	if err := s.DeleteToken(ctx, token); err != nil {
+		return err
+	}
+	var cleanupErr error
+	for _, flag := range []config.DeviceFlag{config.APP, config.Web, config.PC} {
+		if err := s.compareDeleteDeviceIndex(token, uid, int(flag)); err != nil {
+			cleanupErr = errors.Join(cleanupErr, err)
+		}
+	}
+	return cleanupErr
 }
 
 func (s *RedisSessionStore) requireFence(ctx context.Context, uid string, fence IssueFence) error {

--- a/pkg/auth/session_v3.go
+++ b/pkg/auth/session_v3.go
@@ -307,7 +307,7 @@ func (s *RedisSessionStore) ReuseSession(ctx context.Context, token string, snap
 			return ok, err
 		}
 	}
-	s.cleanupIndexReservationIfLegacy(token, snapshot.UID, snapshot.DeviceFlag, snapshot.DeviceID, fence.Generation)
+	_ = s.cleanupIndexReservation(token, snapshot.UID, snapshot.DeviceFlag, snapshot.DeviceID, fence.Generation)
 	return false, errors.New("auth: reused token changed too frequently")
 }
 
@@ -449,14 +449,21 @@ func (s *RedisSessionStore) promoteLegacySession(ctx context.Context, token stri
 	}
 	ttl, replaced, conflict, err := s.casReplacePayloadKeepDeadline(ctx, token, record.Payload, ownedPayload, capTTL)
 	if err != nil {
-		_ = s.client.ZRem(s.sessionIndexKey(snapshot.UID, fence.Generation), member).Err()
+		if cleanupErr := s.cleanupIndexReservation(token, snapshot.UID, snapshot.DeviceFlag, snapshot.DeviceID, fence.Generation); cleanupErr != nil {
+			return false, false, fmt.Errorf("%w (promotion index cleanup failed: %v)", err, cleanupErr)
+		}
 		return false, false, err
 	}
 	if conflict {
+		if err := s.cleanupIndexReservation(token, snapshot.UID, snapshot.DeviceFlag, snapshot.DeviceID, fence.Generation); err != nil {
+			return false, false, err
+		}
 		return false, true, nil
 	}
 	if !replaced {
-		_ = s.client.ZRem(s.sessionIndexKey(snapshot.UID, fence.Generation), member).Err()
+		if err := s.cleanupIndexReservation(token, snapshot.UID, snapshot.DeviceFlag, snapshot.DeviceID, fence.Generation); err != nil {
+			return false, false, err
+		}
 		return false, false, nil
 	}
 	cleanup := func(primary error) error {
@@ -529,17 +536,37 @@ func (s *RedisSessionStore) casReplacePayloadKeepDeadline(ctx context.Context, t
 	return time.Duration(ttlMS) * time.Millisecond, true, false, nil
 }
 
-func (s *RedisSessionStore) cleanupIndexReservationIfLegacy(token, uid string, deviceFlag int, deviceID, generation string) {
+// cleanupIndexReservation removes only the caller's speculative bounded-index
+// member. A CAS error is ambiguous: the payload write may have succeeded even
+// though the client saw an error. Re-reading the token prevents compensation
+// from deleting the member currently owned by a successful v3 payload.
+func (s *RedisSessionStore) cleanupIndexReservation(token, uid string, deviceFlag int, deviceID, generation string) error {
+	member, err := encodeSessionIndexMember(token, deviceFlag, deviceID)
+	if err != nil {
+		return err
+	}
 	raw, err := s.client.Get(s.tokenKey(token)).Result()
 	if err == nil {
-		if info, decodeErr := Decode(raw); decodeErr == nil && info.IsV3() {
-			return
+		info, decodeErr := Decode(raw)
+		if decodeErr != nil {
+			return fmt.Errorf("auth: inspect promotion payload for index cleanup: %w", decodeErr)
 		}
+		if info.IsV3() {
+			currentMember, encodeErr := encodeSessionIndexMember(token, info.DeviceFlag, info.DeviceID)
+			if encodeErr != nil {
+				return encodeErr
+			}
+			if currentMember == member {
+				return nil
+			}
+		}
+	} else if err != rd.Nil {
+		return fmt.Errorf("auth: inspect promotion payload for index cleanup: %w", err)
 	}
-	member, err := encodeSessionIndexMember(token, deviceFlag, deviceID)
-	if err == nil {
-		_ = s.client.ZRem(s.sessionIndexKey(uid, generation), member).Err()
+	if err := s.client.ZRem(s.sessionIndexKey(uid, generation), member).Err(); err != nil {
+		return fmt.Errorf("auth: remove promotion index reservation: %w", err)
 	}
+	return nil
 }
 
 func (s *RedisSessionStore) IssueNewSession(ctx context.Context, token string, info TokenInfo, fence IssueFence) (err error) {

--- a/pkg/auth/session_v3_test.go
+++ b/pkg/auth/session_v3_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
 	octoredis "github.com/Mininglamp-OSS/octo-server/pkg/redis"
+	rd "github.com/go-redis/redis"
 	"github.com/stretchr/testify/require"
 )
 
@@ -72,14 +73,42 @@ func TestSessionRolloutControlIsMonotonicAndFailClosed(t *testing.T) {
 
 	require.NoError(t, v3Store.ValidateRolloutControl(context.Background(), ""))
 	require.Error(t, v3Store.ValidateRolloutControl(context.Background(), SessionModeV3Write))
-	require.NoError(t, v3Store.AdvanceRolloutControl(context.Background(), SessionModeV3Write))
+	require.ErrorContains(t, v3Store.AdvanceRolloutControl(context.Background(), SessionModeV3Write, 0), "at least 1h")
+	require.ErrorContains(t, v3Store.AdvanceRolloutControl(context.Background(), SessionModeV3Write, rolloutObservationGapForTest-time.Millisecond), "at least 1h")
+	require.NoError(t, v3Store.AdvanceRolloutControl(context.Background(), SessionModeV3Write, rolloutObservationGapForTest))
 	require.Error(t, expandStore.ValidateRolloutControl(context.Background(), ""))
 	require.NoError(t, v3Store.ValidateRolloutControl(context.Background(), SessionModeV3Write))
-	require.Error(t, v3Store.AdvanceRolloutControl(context.Background(), SessionModeBounded))
-	require.NoError(t, v3Store.AdvanceRolloutControl(context.Background(), SessionModeRevoke))
+	require.Error(t, v3Store.AdvanceRolloutControl(context.Background(), SessionModeBounded, rolloutObservationGapForTest))
+	require.NoError(t, v3Store.AdvanceRolloutControl(context.Background(), SessionModeRevoke, 2*rolloutObservationGapForTest))
 	control, err := v3Store.RolloutControl(context.Background())
 	require.NoError(t, err)
 	require.Equal(t, SessionModeRevoke, control.ModeFloor)
+	require.Equal(t, (2 * rolloutObservationGapForTest).Milliseconds(), control.ObservationMinGapMS)
+	require.ErrorContains(t, v3Store.AdvanceRolloutControl(context.Background(), SessionModeBounded, rolloutObservationGapForTest), "cannot decrease")
+}
+
+func TestSessionRolloutControlBackfillsLegacyObservationGapOnNextAdvance(t *testing.T) {
+	cfg := config.New()
+	client := octoredis.NewInstrumentedClient(cfg)
+	prefix := "session-rollout-legacy:" + util.GenerUUID() + ":"
+	uidPrefix := "session-rollout-legacy-uid:" + util.GenerUUID() + ":"
+	store := NewRedisSessionStore(client, prefix, uidPrefix, time.Hour, WithSessionMode(SessionModeV3Write), WithSessionMaxPerUID(2))
+	t.Cleanup(func() {
+		_ = client.Del(store.rolloutControlKey()).Err()
+		_ = client.Close()
+	})
+
+	require.NoError(t, client.Set(store.rolloutControlKey(), `{"mode_floor":"v3-write","writer_version":3}`, 0).Err())
+	control, err := store.RolloutControl(context.Background())
+	require.NoError(t, err)
+	require.Zero(t, control.ObservationMinGapMS)
+	require.NoError(t, store.ValidateRolloutControl(context.Background(), SessionModeV3Write))
+
+	require.NoError(t, store.AdvanceRolloutControl(context.Background(), SessionModeRevoke, rolloutObservationGapForTest))
+	control, err = store.RolloutControl(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, SessionModeRevoke, control.ModeFloor)
+	require.Equal(t, rolloutObservationGapForTest.Milliseconds(), control.ObservationMinGapMS)
 }
 
 func TestRedisSessionStoreIssuesBoundedV3AndValidatorUsesGeneration(t *testing.T) {
@@ -138,6 +167,125 @@ func TestRedisSessionStoreIssuesBoundedV3AndValidatorUsesGeneration(t *testing.T
 	got, err := validator.Validate(context.Background(), token)
 	require.NoError(t, err)
 	require.Equal(t, uid, got.UID)
+}
+
+func TestTokenValidatorV3SteadyStateUsesExactlyTwoReadsAndNoWrites(t *testing.T) {
+	cfg := config.New()
+	client := octoredis.NewInstrumentedClient(cfg)
+	prefix := "session-v3-command-count:" + util.GenerUUID() + ":"
+	uidPrefix := "session-v3-command-count-uid:" + util.GenerUUID() + ":"
+	store := NewRedisSessionStore(client, prefix, uidPrefix, time.Hour, WithSessionMode(SessionModeV3Write), WithSessionMaxPerUID(2))
+	uid := "u-" + util.GenerUUID()
+	token := "t-" + util.GenerUUID()
+	t.Cleanup(func() {
+		keys, _ := client.Keys(prefix + "*").Result()
+		metadata, _ := client.Keys(uidPrefix + "*").Result()
+		keys = append(keys, metadata...)
+		if len(keys) > 0 {
+			_ = client.Del(keys...).Err()
+		}
+		_ = client.Close()
+	})
+
+	fence, err := store.BeginIssue(context.Background(), uid)
+	require.NoError(t, err)
+	require.NoError(t, store.IssueNewSession(context.Background(), token, TokenInfo{UID: uid, DeviceFlag: 1}, fence))
+	require.NoError(t, readTokenScript.Load(client).Err(), "preload the read script so NOSCRIPT fallback is outside the steady-state count")
+
+	var commands []string
+	client.WrapProcess(func(old func(rd.Cmder) error) func(rd.Cmder) error {
+		return func(cmd rd.Cmder) error {
+			commands = append(commands, cmd.Name())
+			return old(cmd)
+		}
+	})
+
+	_, err = NewTokenValidator(store, prefix).Validate(context.Background(), token)
+	require.NoError(t, err)
+	require.Equal(t, []string{"evalsha", "get"}, commands,
+		"steady-state v3 validation must remain token single-key Lua plus generation GET, with no Redis write")
+}
+
+func TestRedisSessionStoreRevokeIssuedRemovesV3IndexReservation(t *testing.T) {
+	cfg := config.New()
+	client := octoredis.NewInstrumentedClient(cfg)
+	prefix := "session-v3-compensation:" + util.GenerUUID() + ":"
+	uidPrefix := "session-v3-compensation-uid:" + util.GenerUUID() + ":"
+	store := NewRedisSessionStore(client, prefix, uidPrefix, time.Hour, WithSessionMode(SessionModeV3Write), WithSessionMaxPerUID(2))
+	uid := "u-" + util.GenerUUID()
+	t.Cleanup(func() {
+		keys, _ := client.Keys(prefix + "*").Result()
+		metadata, _ := client.Keys(uidPrefix + "*").Result()
+		keys = append(keys, metadata...)
+		if len(keys) > 0 {
+			_ = client.Del(keys...).Err()
+		}
+		_ = client.Close()
+	})
+
+	fence, err := store.BeginIssue(context.Background(), uid)
+	require.NoError(t, err)
+	for i := 0; i < 2; i++ {
+		token := "failed-" + util.GenerUUID()
+		require.NoError(t, store.IssueNewSession(context.Background(), token, TokenInfo{
+			UID:        uid,
+			DeviceFlag: i,
+			DeviceID:   "failed-device-" + string(rune('a'+i)),
+		}, fence))
+		require.NoError(t, store.RevokeIssued(context.Background(), token, uid, i))
+	}
+
+	count, err := client.ZCard(store.sessionIndexKey(uid, fence.Generation)).Result()
+	require.NoError(t, err)
+	require.Zero(t, count, "downstream login compensation must not consume bounded-session capacity")
+	require.NoError(t, store.IssueNewSession(context.Background(), "recovered-"+util.GenerUUID(), TokenInfo{
+		UID:        uid,
+		DeviceFlag: 1,
+		DeviceID:   "recovered-device",
+	}, fence), "a recovered dependency must be able to issue immediately after compensated failures")
+}
+
+func TestRedisSessionStoreRevokeIssuedPreservesV3SessionAdoptedByAnotherReplica(t *testing.T) {
+	cfg := config.New()
+	clientA := octoredis.NewInstrumentedClient(cfg)
+	clientB := octoredis.NewInstrumentedClient(cfg)
+	prefix := "session-v3-adopted:" + util.GenerUUID() + ":"
+	uidPrefix := "session-v3-adopted-uid:" + util.GenerUUID() + ":"
+	storeA := NewRedisSessionStore(clientA, prefix, uidPrefix, time.Hour, WithSessionMode(SessionModeV3Write), WithSessionMaxPerUID(2))
+	storeB := NewRedisSessionStore(clientB, prefix, uidPrefix, time.Hour, WithSessionMode(SessionModeV3Write), WithSessionMaxPerUID(2))
+	uid := "u-" + util.GenerUUID()
+	token := "t-" + util.GenerUUID()
+	t.Cleanup(func() {
+		keys, _ := clientA.Keys(prefix + "*").Result()
+		metadata, _ := clientA.Keys(uidPrefix + "*").Result()
+		keys = append(keys, metadata...)
+		if len(keys) > 0 {
+			_ = clientA.Del(keys...).Err()
+		}
+		_ = clientA.Close()
+		_ = clientB.Close()
+	})
+
+	fence, err := storeA.BeginIssue(context.Background(), uid)
+	require.NoError(t, err)
+	info := TokenInfo{UID: uid, Name: "first", DeviceFlag: 1, DeviceID: "shared-device"}
+	require.NoError(t, storeA.IssueNewSession(context.Background(), token, info, fence))
+	adopted, err := storeB.ReuseSession(context.Background(), token, TokenInfo{
+		UID:        uid,
+		Name:       "adopted",
+		DeviceFlag: 1,
+		DeviceID:   "shared-device",
+	}, fence)
+	require.NoError(t, err)
+	require.True(t, adopted)
+
+	require.NoError(t, storeA.RevokeIssued(context.Background(), token, uid, 1))
+	validated, err := NewTokenValidator(storeB, prefix).Validate(context.Background(), token)
+	require.NoError(t, err)
+	require.Equal(t, "adopted", validated.Name)
+	count, err := clientA.ZCard(storeA.sessionIndexKey(uid, fence.Generation)).Result()
+	require.NoError(t, err)
+	require.EqualValues(t, 1, count, "an old issuer must not erase the adopted replica's bounded-index membership")
 }
 
 func TestRedisSessionStoreV3IndexIsBounded(t *testing.T) {
@@ -386,6 +534,34 @@ func TestTokenValidatorAppliesLegacyRolloutPolicy(t *testing.T) {
 		_, err := NewTokenValidator(store, prefix).Validate(context.Background(), token)
 		require.ErrorIs(t, err, wkhttp.ErrTokenInvalid)
 	})
+}
+
+func TestInvalidateCurrentLegacyTokenCompareDeletesCompatibilityIndex(t *testing.T) {
+	cfg := config.New()
+	client := octoredis.NewInstrumentedClient(cfg)
+	prefix := "session-legacy-logout:" + util.GenerUUID() + ":"
+	uidPrefix := "session-legacy-logout-uid:" + util.GenerUUID() + ":"
+	store := NewRedisSessionStore(client, prefix, uidPrefix, time.Hour)
+	uid := "u-" + util.GenerUUID()
+	token := "t-" + util.GenerUUID()
+	t.Cleanup(func() {
+		keys, _ := client.Keys(prefix + "*").Result()
+		metadata, _ := client.Keys(uidPrefix + "*").Result()
+		keys = append(keys, metadata...)
+		if len(keys) > 0 {
+			_ = client.Del(keys...).Err()
+		}
+		_ = client.Close()
+	})
+
+	payload, err := Encode(TokenInfo{UID: uid, Name: "legacy"})
+	require.NoError(t, err)
+	require.NoError(t, store.IssueNew(context.Background(), token, payload, uid, 1))
+	require.NoError(t, store.InvalidateCurrentToken(context.Background(), uid, token))
+
+	indexed, err := store.DeviceToken(context.Background(), uid, 1)
+	require.NoError(t, err)
+	require.Empty(t, indexed, "legacy logout must not leave uidtoken pointing at a revoked bearer")
 }
 
 func TestRedisSessionStorePromotesLegacyReuseWithoutExtendingDeadline(t *testing.T) {

--- a/pkg/auth/session_v3_test.go
+++ b/pkg/auth/session_v3_test.go
@@ -1,0 +1,473 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	octoredis "github.com/Mininglamp-OSS/octo-server/pkg/redis"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSessionPolicyFromEnvDefaultsClosedAndValidatesActivation(t *testing.T) {
+	t.Run("expand default", func(t *testing.T) {
+		unsetSessionRuntimeEnv(t)
+		policy, err := sessionPolicyFromEnv()
+		require.NoError(t, err)
+		require.Equal(t, SessionModeExpand, policy.mode)
+		require.Zero(t, policy.maxPerUID)
+	})
+
+	t.Run("v3 requires explicit bound", func(t *testing.T) {
+		unsetSessionRuntimeEnv(t)
+		t.Setenv(sessionModeEnv, string(SessionModeV3Write))
+		_, err := sessionPolicyFromEnv()
+		require.ErrorContains(t, err, sessionMaxPerUIDEnv)
+	})
+
+	t.Run("v3 accepts explicit bound", func(t *testing.T) {
+		unsetSessionRuntimeEnv(t)
+		t.Setenv(sessionModeEnv, string(SessionModeV3Write))
+		t.Setenv(sessionMaxPerUIDEnv, "2")
+		policy, err := sessionPolicyFromEnv()
+		require.NoError(t, err)
+		require.Equal(t, SessionModeV3Write, policy.mode)
+		require.Equal(t, 2, policy.maxPerUID)
+	})
+
+	t.Run("required floor rejects lower configured mode", func(t *testing.T) {
+		unsetSessionRuntimeEnv(t)
+		t.Setenv(sessionRequiredFloorEnv, string(SessionModeV3Write))
+		_, err := sessionPolicyFromEnv()
+		require.ErrorContains(t, err, sessionRequiredFloorEnv)
+	})
+
+	for _, value := range []string{"", "unknown", "V3-WRITE"} {
+		t.Run("invalid mode "+value, func(t *testing.T) {
+			unsetSessionRuntimeEnv(t)
+			t.Setenv(sessionModeEnv, value)
+			_, err := sessionPolicyFromEnv()
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestSessionRolloutControlIsMonotonicAndFailClosed(t *testing.T) {
+	cfg := config.New()
+	client := octoredis.NewInstrumentedClient(cfg)
+	prefix := "session-rollout:" + util.GenerUUID() + ":"
+	uidPrefix := "session-rollout-uid:" + util.GenerUUID() + ":"
+	v3Store := NewRedisSessionStore(client, prefix, uidPrefix, time.Hour, WithSessionMode(SessionModeV3Write), WithSessionMaxPerUID(2))
+	expandStore := NewRedisSessionStore(client, prefix, uidPrefix, time.Hour)
+	t.Cleanup(func() {
+		_ = client.Del(v3Store.rolloutControlKey()).Err()
+		_ = client.Close()
+	})
+
+	require.NoError(t, v3Store.ValidateRolloutControl(context.Background(), ""))
+	require.Error(t, v3Store.ValidateRolloutControl(context.Background(), SessionModeV3Write))
+	require.NoError(t, v3Store.AdvanceRolloutControl(context.Background(), SessionModeV3Write))
+	require.Error(t, expandStore.ValidateRolloutControl(context.Background(), ""))
+	require.NoError(t, v3Store.ValidateRolloutControl(context.Background(), SessionModeV3Write))
+	require.Error(t, v3Store.AdvanceRolloutControl(context.Background(), SessionModeBounded))
+	require.NoError(t, v3Store.AdvanceRolloutControl(context.Background(), SessionModeRevoke))
+	control, err := v3Store.RolloutControl(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, SessionModeRevoke, control.ModeFloor)
+}
+
+func TestRedisSessionStoreIssuesBoundedV3AndValidatorUsesGeneration(t *testing.T) {
+	cfg := config.New()
+	client := octoredis.NewInstrumentedClient(cfg)
+	prefix := "session-v3:" + util.GenerUUID() + ":"
+	uidPrefix := "session-v3-uid:" + util.GenerUUID() + ":"
+	now := time.Date(2026, time.August, 9, 13, 0, 0, 0, time.UTC)
+	store := NewRedisSessionStore(
+		client,
+		prefix,
+		uidPrefix,
+		time.Hour,
+		WithSessionMode(SessionModeV3Write),
+		WithSessionMaxPerUID(2),
+		WithSessionClock(func() time.Time { return now }),
+	)
+	uid := "u-" + util.GenerUUID()
+	token := "t-" + util.GenerUUID()
+	t.Cleanup(func() {
+		keys, _ := client.Keys(prefix + "*").Result()
+		meta, _ := client.Keys(uidPrefix + "*").Result()
+		keys = append(keys, meta...)
+		if len(keys) > 0 {
+			_ = client.Del(keys...).Err()
+		}
+		_ = client.Close()
+	})
+
+	fence, err := store.BeginIssue(context.Background(), uid)
+	require.NoError(t, err)
+	require.NotEmpty(t, fence.Generation)
+	require.Positive(t, fence.Revision)
+
+	err = store.IssueNewSession(context.Background(), token, TokenInfo{
+		UID:        uid,
+		Name:       "alice",
+		DeviceFlag: 1,
+		DeviceID:   "device-1",
+	}, fence)
+	require.NoError(t, err)
+
+	record, err := store.ReadToken(context.Background(), prefix+token)
+	require.NoError(t, err)
+	require.Positive(t, record.TTL)
+	require.LessOrEqual(t, record.TTL, time.Hour)
+	info, err := Decode(record.Payload)
+	require.NoError(t, err)
+	require.True(t, info.IsV3())
+	require.Equal(t, fence.Generation, info.SessionGeneration)
+	require.Equal(t, fence.Revision, info.SessionRevision)
+	require.Equal(t, now.Unix(), info.IssuedAt)
+	require.Equal(t, now.Add(time.Hour).Unix(), info.ExpiresAt)
+
+	validator := NewTokenValidator(store, prefix, WithValidatorClock(func() time.Time { return now }))
+	got, err := validator.Validate(context.Background(), token)
+	require.NoError(t, err)
+	require.Equal(t, uid, got.UID)
+}
+
+func TestRedisSessionStoreV3IndexIsBounded(t *testing.T) {
+	cfg := config.New()
+	client := octoredis.NewInstrumentedClient(cfg)
+	prefix := "session-v3-cap:" + util.GenerUUID() + ":"
+	uidPrefix := "session-v3-cap-uid:" + util.GenerUUID() + ":"
+	store := NewRedisSessionStore(
+		client,
+		prefix,
+		uidPrefix,
+		time.Hour,
+		WithSessionMode(SessionModeV3Write),
+		WithSessionMaxPerUID(2),
+	)
+	uid := "u-" + util.GenerUUID()
+	t.Cleanup(func() {
+		keys, _ := client.Keys(prefix + "*").Result()
+		meta, _ := client.Keys(uidPrefix + "*").Result()
+		keys = append(keys, meta...)
+		if len(keys) > 0 {
+			_ = client.Del(keys...).Err()
+		}
+		_ = client.Close()
+	})
+
+	fence, err := store.BeginIssue(context.Background(), uid)
+	require.NoError(t, err)
+	for i := 0; i < 2; i++ {
+		err = store.IssueNewSession(context.Background(), "token-"+util.GenerUUID(), TokenInfo{
+			UID:        uid,
+			DeviceFlag: i,
+		}, fence)
+		require.NoError(t, err)
+	}
+	err = store.IssueNewSession(context.Background(), "token-"+util.GenerUUID(), TokenInfo{
+		UID:        uid,
+		DeviceFlag: 2,
+	}, fence)
+	require.ErrorIs(t, err, ErrSessionLimitReached)
+}
+
+func TestRedisSessionStoreGenerationDeadlineNeverShrinks(t *testing.T) {
+	cfg := config.New()
+	clientA := octoredis.NewInstrumentedClient(cfg)
+	clientB := octoredis.NewInstrumentedClient(cfg)
+	prefix := "session-generation:" + util.GenerUUID() + ":"
+	uidPrefix := "session-generation-uid:" + util.GenerUUID() + ":"
+	longStore := NewRedisSessionStore(clientA, prefix, uidPrefix, 2*time.Hour, WithSessionMode(SessionModeV3Write), WithSessionMaxPerUID(2))
+	shortStore := NewRedisSessionStore(clientB, prefix, uidPrefix, time.Minute, WithSessionMode(SessionModeV3Write), WithSessionMaxPerUID(2))
+	uid := "u-" + util.GenerUUID()
+	t.Cleanup(func() {
+		keys, _ := clientA.Keys(uidPrefix + "*").Result()
+		if len(keys) > 0 {
+			_ = clientA.Del(keys...).Err()
+		}
+		_ = clientA.Close()
+		_ = clientB.Close()
+	})
+
+	first, err := longStore.BeginIssue(context.Background(), uid)
+	require.NoError(t, err)
+	key := longStore.generationKey(uid)
+	before, err := clientA.PTTL(key).Result()
+	require.NoError(t, err)
+	require.Greater(t, before, time.Hour)
+
+	second, err := shortStore.BeginIssue(context.Background(), uid)
+	require.NoError(t, err)
+	require.Equal(t, first, second)
+	after, err := clientA.PTTL(key).Result()
+	require.NoError(t, err)
+	require.Greater(t, after, time.Hour)
+	require.LessOrEqual(t, after, before)
+}
+
+func TestRedisSessionStoreRejectsStaleIssueFence(t *testing.T) {
+	cfg := config.New()
+	client := octoredis.NewInstrumentedClient(cfg)
+	prefix := "session-fence:" + util.GenerUUID() + ":"
+	uidPrefix := "session-fence-uid:" + util.GenerUUID() + ":"
+	store := NewRedisSessionStore(client, prefix, uidPrefix, time.Hour, WithSessionMode(SessionModeV3Write), WithSessionMaxPerUID(2))
+	uid := "u-" + util.GenerUUID()
+	token := "t-" + util.GenerUUID()
+	t.Cleanup(func() {
+		keys, _ := client.Keys(prefix + "*").Result()
+		meta, _ := client.Keys(uidPrefix + "*").Result()
+		keys = append(keys, meta...)
+		if len(keys) > 0 {
+			_ = client.Del(keys...).Err()
+		}
+		_ = client.Close()
+	})
+
+	fence, err := store.BeginIssue(context.Background(), uid)
+	require.NoError(t, err)
+	require.NoError(t, store.RevokeAll(context.Background(), uid, RevocationEvent{Version: 1, ID: "password-reset"}))
+	err = store.IssueNewSession(context.Background(), token, TokenInfo{UID: uid, DeviceFlag: 1}, fence)
+	require.ErrorIs(t, err, ErrIssueFenceChanged)
+	exists, existsErr := client.Exists(prefix + token).Result()
+	require.NoError(t, existsErr)
+	require.Zero(t, exists)
+
+	err = store.RevokeAll(context.Background(), uid, RevocationEvent{Version: 1, ID: "password-reset"})
+	require.True(t, err == nil || errors.Is(err, ErrRevocationAlreadyApplied))
+}
+
+func TestRedisSessionStoreConcurrentIndexNeverExceedsBound(t *testing.T) {
+	cfg := config.New()
+	clientA := octoredis.NewInstrumentedClient(cfg)
+	clientB := octoredis.NewInstrumentedClient(cfg)
+	prefix := "session-v3-concurrent:" + util.GenerUUID() + ":"
+	uidPrefix := "session-v3-concurrent-uid:" + util.GenerUUID() + ":"
+	storeA := NewRedisSessionStore(clientA, prefix, uidPrefix, time.Hour, WithSessionMode(SessionModeV3Write), WithSessionMaxPerUID(2))
+	storeB := NewRedisSessionStore(clientB, prefix, uidPrefix, time.Hour, WithSessionMode(SessionModeV3Write), WithSessionMaxPerUID(2))
+	uid := "u-" + util.GenerUUID()
+	t.Cleanup(func() {
+		keys, _ := clientA.Keys(prefix + "*").Result()
+		meta, _ := clientA.Keys(uidPrefix + "*").Result()
+		keys = append(keys, meta...)
+		if len(keys) > 0 {
+			_ = clientA.Del(keys...).Err()
+		}
+		_ = clientA.Close()
+		_ = clientB.Close()
+	})
+
+	fence, err := storeA.BeginIssue(context.Background(), uid)
+	require.NoError(t, err)
+	otherFence, err := storeB.BeginIssue(context.Background(), uid)
+	require.NoError(t, err)
+	require.Equal(t, fence, otherFence)
+
+	var successes atomic.Int64
+	var wg sync.WaitGroup
+	errs := make(chan error, 8)
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			store := storeA
+			if i%2 == 1 {
+				store = storeB
+			}
+			err := store.IssueNewSession(context.Background(), "token-"+util.GenerUUID(), TokenInfo{UID: uid, DeviceFlag: i}, fence)
+			if err == nil {
+				successes.Add(1)
+				return
+			}
+			errs <- err
+		}(i)
+	}
+	wg.Wait()
+	close(errs)
+	require.EqualValues(t, 2, successes.Load())
+	for err := range errs {
+		require.ErrorIs(t, err, ErrSessionLimitReached)
+	}
+	count, err := clientA.ZCard(storeA.sessionIndexKey(uid)).Result()
+	require.NoError(t, err)
+	require.EqualValues(t, 2, count)
+}
+
+func TestRedisSessionStoreRevocationRetryDoesNotRevokePostEventSession(t *testing.T) {
+	cfg := config.New()
+	clientA := octoredis.NewInstrumentedClient(cfg)
+	clientB := octoredis.NewInstrumentedClient(cfg)
+	prefix := "session-v3-retry:" + util.GenerUUID() + ":"
+	uidPrefix := "session-v3-retry-uid:" + util.GenerUUID() + ":"
+	storeA := NewRedisSessionStore(clientA, prefix, uidPrefix, time.Hour, WithSessionMode(SessionModeRevoke), WithSessionMaxPerUID(2))
+	storeB := NewRedisSessionStore(clientB, prefix, uidPrefix, time.Hour, WithSessionMode(SessionModeRevoke), WithSessionMaxPerUID(2))
+	uid := "u-" + util.GenerUUID()
+	token := "t-" + util.GenerUUID()
+	event := RevocationEvent{Version: 1, ID: "event-" + util.GenerUUID()}
+	t.Cleanup(func() {
+		keys, _ := clientA.Keys(prefix + "*").Result()
+		meta, _ := clientA.Keys(uidPrefix + "*").Result()
+		keys = append(keys, meta...)
+		if len(keys) > 0 {
+			_ = clientA.Del(keys...).Err()
+		}
+		_ = clientA.Close()
+		_ = clientB.Close()
+	})
+
+	_, err := storeA.BeginIssue(context.Background(), uid)
+	require.NoError(t, err)
+	require.NoError(t, storeA.RevokeAll(context.Background(), uid, event))
+	postEventFence, err := storeB.BeginIssue(context.Background(), uid)
+	require.NoError(t, err)
+	require.NoError(t, storeB.IssueNewSession(context.Background(), token, TokenInfo{UID: uid, DeviceFlag: 1}, postEventFence))
+	require.ErrorIs(t, storeA.RevokeAll(context.Background(), uid, event), ErrRevocationAlreadyApplied)
+
+	validator := NewTokenValidator(storeA, prefix)
+	_, err = validator.Validate(context.Background(), token)
+	require.NoError(t, err)
+}
+
+func TestTokenValidatorAppliesLegacyRolloutPolicy(t *testing.T) {
+	cfg := config.New()
+	client := octoredis.NewInstrumentedClient(cfg)
+	prefix := "session-legacy-policy:" + util.GenerUUID() + ":"
+	uidPrefix := "session-legacy-policy-uid:" + util.GenerUUID() + ":"
+	uid := "u-" + util.GenerUUID()
+	payload, err := Encode(TokenInfo{UID: uid, Name: "legacy"})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		keys, _ := client.Keys(prefix + "*").Result()
+		meta, _ := client.Keys(uidPrefix + "*").Result()
+		keys = append(keys, meta...)
+		if len(keys) > 0 {
+			_ = client.Del(keys...).Err()
+		}
+		_ = client.Close()
+	})
+
+	t.Run("v3 writer honors an existing deny marker", func(t *testing.T) {
+		store := NewRedisSessionStore(client, prefix, uidPrefix, time.Hour, WithSessionMode(SessionModeV3Write), WithSessionMaxPerUID(2))
+		token := "denied-" + util.GenerUUID()
+		require.NoError(t, client.Set(prefix+token, payload, time.Minute).Err())
+		require.NoError(t, client.Set(store.legacyDenyKey(uid), "1", 0).Err())
+		_, err := NewTokenValidator(store, prefix).Validate(context.Background(), token)
+		require.ErrorIs(t, err, wkhttp.ErrTokenInvalid)
+		require.NoError(t, client.Del(store.legacyDenyKey(uid)).Err())
+	})
+
+	t.Run("bounded rejects persistent legacy", func(t *testing.T) {
+		store := NewRedisSessionStore(client, prefix, uidPrefix, time.Hour, WithSessionMode(SessionModeBounded), WithSessionMaxPerUID(2))
+		token := "persistent-" + util.GenerUUID()
+		require.NoError(t, client.Set(prefix+token, payload, 0).Err())
+		_, err := NewTokenValidator(store, prefix).Validate(context.Background(), token)
+		require.ErrorIs(t, err, wkhttp.ErrTokenInvalid)
+	})
+
+	t.Run("enforce rejects finite legacy without a marker lookup", func(t *testing.T) {
+		store := NewRedisSessionStore(client, prefix, uidPrefix, time.Hour, WithSessionMode(SessionModeEnforce), WithSessionMaxPerUID(2))
+		token := "enforce-" + util.GenerUUID()
+		require.NoError(t, client.Set(prefix+token, payload, time.Minute).Err())
+		_, err := NewTokenValidator(store, prefix).Validate(context.Background(), token)
+		require.ErrorIs(t, err, wkhttp.ErrTokenInvalid)
+	})
+}
+
+func TestRedisSessionStorePromotesLegacyReuseWithoutExtendingDeadline(t *testing.T) {
+	cfg := config.New()
+	client := octoredis.NewInstrumentedClient(cfg)
+	prefix := "session-promote:" + util.GenerUUID() + ":"
+	uidPrefix := "session-promote-uid:" + util.GenerUUID() + ":"
+	now := time.Date(2026, time.August, 9, 15, 0, 0, 0, time.UTC)
+	store := NewRedisSessionStore(client, prefix, uidPrefix, time.Hour, WithSessionMode(SessionModeV3Write), WithSessionMaxPerUID(2), WithSessionClock(func() time.Time { return now }))
+	uid := "u-" + util.GenerUUID()
+	token := "t-" + util.GenerUUID()
+	legacy, err := Encode(TokenInfo{UID: uid, Name: "old"})
+	require.NoError(t, err)
+	require.NoError(t, client.Set(prefix+token, legacy, 20*time.Minute).Err())
+	before, err := client.PTTL(prefix + token).Result()
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		keys, _ := client.Keys(prefix + "*").Result()
+		meta, _ := client.Keys(uidPrefix + "*").Result()
+		keys = append(keys, meta...)
+		if len(keys) > 0 {
+			_ = client.Del(keys...).Err()
+		}
+		_ = client.Close()
+	})
+
+	fence, err := store.BeginIssue(context.Background(), uid)
+	require.NoError(t, err)
+	ok, err := store.ReuseSession(context.Background(), token, TokenInfo{UID: uid, Name: "new", DeviceFlag: 1, DeviceID: "device-1"}, fence)
+	require.NoError(t, err)
+	require.True(t, ok)
+	after, err := client.PTTL(prefix + token).Result()
+	require.NoError(t, err)
+	require.Positive(t, after)
+	require.LessOrEqual(t, after, before)
+	record, err := store.ReadToken(context.Background(), prefix+token)
+	require.NoError(t, err)
+	info, err := Decode(record.Payload)
+	require.NoError(t, err)
+	require.True(t, info.IsV3())
+	require.Equal(t, "new", info.Name)
+	require.Equal(t, fence.Generation, info.SessionGeneration)
+	require.Equal(t, fence.Revision, info.SessionRevision)
+	require.Equal(t, now.Unix(), info.IssuedAt)
+	require.LessOrEqual(t, info.ExpiresAt, now.Add(20*time.Minute).Unix())
+}
+
+func TestRedisSessionStoreSnapshotUpdatePreservesV3SecurityClaims(t *testing.T) {
+	cfg := config.New()
+	client := octoredis.NewInstrumentedClient(cfg)
+	prefix := "session-snapshot:" + util.GenerUUID() + ":"
+	uidPrefix := "session-snapshot-uid:" + util.GenerUUID() + ":"
+	now := time.Date(2026, time.August, 9, 16, 0, 0, 0, time.UTC)
+	store := NewRedisSessionStore(client, prefix, uidPrefix, time.Hour, WithSessionMode(SessionModeV3Write), WithSessionMaxPerUID(2), WithSessionClock(func() time.Time { return now }))
+	uid := "u-" + util.GenerUUID()
+	token := "t-" + util.GenerUUID()
+	t.Cleanup(func() {
+		keys, _ := client.Keys(prefix + "*").Result()
+		meta, _ := client.Keys(uidPrefix + "*").Result()
+		keys = append(keys, meta...)
+		if len(keys) > 0 {
+			_ = client.Del(keys...).Err()
+		}
+		_ = client.Close()
+	})
+
+	fence, err := store.BeginIssue(context.Background(), uid)
+	require.NoError(t, err)
+	require.NoError(t, store.IssueNewSession(context.Background(), token, TokenInfo{UID: uid, Name: "old", Role: "user", Language: "en-US", DeviceFlag: 1, DeviceID: "device-1"}, fence))
+	beforeRecord, err := store.ReadToken(context.Background(), prefix+token)
+	require.NoError(t, err)
+	beforeInfo, err := Decode(beforeRecord.Payload)
+	require.NoError(t, err)
+
+	ok, err := store.UpdateSessionSnapshot(context.Background(), token, TokenInfo{UID: uid, Name: "new", Role: "admin", Language: "zh-CN"})
+	require.NoError(t, err)
+	require.True(t, ok)
+	afterRecord, err := store.ReadToken(context.Background(), prefix+token)
+	require.NoError(t, err)
+	afterInfo, err := Decode(afterRecord.Payload)
+	require.NoError(t, err)
+	require.Equal(t, "new", afterInfo.Name)
+	require.Equal(t, "admin", afterInfo.Role)
+	require.Equal(t, "zh-CN", afterInfo.Language)
+	require.Equal(t, beforeInfo.IssuedAt, afterInfo.IssuedAt)
+	require.Equal(t, beforeInfo.ExpiresAt, afterInfo.ExpiresAt)
+	require.Equal(t, beforeInfo.DeviceFlag, afterInfo.DeviceFlag)
+	require.Equal(t, beforeInfo.DeviceID, afterInfo.DeviceID)
+	require.Equal(t, beforeInfo.SessionGeneration, afterInfo.SessionGeneration)
+	require.Equal(t, beforeInfo.SessionRevision, afterInfo.SessionRevision)
+	require.LessOrEqual(t, afterRecord.TTL, beforeRecord.TTL)
+}

--- a/pkg/auth/session_v3_test.go
+++ b/pkg/auth/session_v3_test.go
@@ -310,7 +310,8 @@ func TestRedisSessionStoreRevocationRetryDoesNotRevokePostEventSession(t *testin
 	storeA := NewRedisSessionStore(clientA, prefix, uidPrefix, time.Hour, WithSessionMode(SessionModeRevoke), WithSessionMaxPerUID(2))
 	storeB := NewRedisSessionStore(clientB, prefix, uidPrefix, time.Hour, WithSessionMode(SessionModeRevoke), WithSessionMaxPerUID(2))
 	uid := "u-" + util.GenerUUID()
-	token := "t-" + util.GenerUUID()
+	tokenA := "t-" + util.GenerUUID()
+	tokenB := "t-" + util.GenerUUID()
 	event := RevocationEvent{Version: 1, ID: "event-" + util.GenerUUID()}
 	t.Cleanup(func() {
 		keys, _ := clientA.Keys(prefix + "*").Result()
@@ -328,12 +329,18 @@ func TestRedisSessionStoreRevocationRetryDoesNotRevokePostEventSession(t *testin
 	require.NoError(t, storeA.RevokeAll(context.Background(), uid, event))
 	postEventFence, err := storeB.BeginIssue(context.Background(), uid)
 	require.NoError(t, err)
-	require.NoError(t, storeB.IssueNewSession(context.Background(), token, TokenInfo{UID: uid, DeviceFlag: 1}, postEventFence))
+	require.NoError(t, storeB.IssueNewSession(context.Background(), tokenA, TokenInfo{UID: uid, DeviceFlag: 1}, postEventFence))
+	require.NoError(t, storeB.IssueNewSession(context.Background(), tokenB, TokenInfo{UID: uid, DeviceFlag: 2}, postEventFence))
 	require.ErrorIs(t, storeA.RevokeAll(context.Background(), uid, event), ErrRevocationAlreadyApplied)
 
 	validator := NewTokenValidator(storeA, prefix)
-	_, err = validator.Validate(context.Background(), token)
+	_, err = validator.Validate(context.Background(), tokenA)
 	require.NoError(t, err)
+	_, err = validator.Validate(context.Background(), tokenB)
+	require.NoError(t, err)
+	err = storeA.IssueNewSession(context.Background(), "t-"+util.GenerUUID(), TokenInfo{UID: uid, DeviceFlag: 3}, postEventFence)
+	require.ErrorIs(t, err, ErrSessionLimitReached,
+		"replaying an old revocation event must not erase post-event sessions from the bounded index")
 }
 
 func TestTokenValidatorAppliesLegacyRolloutPolicy(t *testing.T) {

--- a/pkg/auth/session_v3_test.go
+++ b/pkg/auth/session_v3_test.go
@@ -296,7 +296,7 @@ func TestRedisSessionStoreConcurrentIndexNeverExceedsBound(t *testing.T) {
 	for err := range errs {
 		require.ErrorIs(t, err, ErrSessionLimitReached)
 	}
-	count, err := clientA.ZCard(storeA.sessionIndexKey(uid)).Result()
+	count, err := clientA.ZCard(storeA.sessionIndexKey(uid, fence.Generation)).Result()
 	require.NoError(t, err)
 	require.EqualValues(t, 2, count)
 }

--- a/pkg/auth/session_v3_test.go
+++ b/pkg/auth/session_v3_test.go
@@ -111,6 +111,24 @@ func TestSessionRolloutControlBackfillsLegacyObservationGapOnNextAdvance(t *test
 	require.Equal(t, rolloutObservationGapForTest.Milliseconds(), control.ObservationMinGapMS)
 }
 
+func TestSessionRolloutControlRejectsSkippingPastPersistedFloor(t *testing.T) {
+	cfg := config.New()
+	client := octoredis.NewInstrumentedClient(cfg)
+	prefix := "session-rollout-skip:" + util.GenerUUID() + ":"
+	uidPrefix := "session-rollout-skip-uid:" + util.GenerUUID() + ":"
+	v3Store := NewRedisSessionStore(client, prefix, uidPrefix, time.Hour, WithSessionMode(SessionModeV3Write), WithSessionMaxPerUID(2))
+	revokeStore := NewRedisSessionStore(client, prefix, uidPrefix, time.Hour, WithSessionMode(SessionModeRevoke), WithSessionMaxPerUID(2))
+	enforceStore := NewRedisSessionStore(client, prefix, uidPrefix, time.Hour, WithSessionMode(SessionModeEnforce), WithSessionMaxPerUID(2))
+	t.Cleanup(func() {
+		_ = client.Del(v3Store.rolloutControlKey()).Err()
+		_ = client.Close()
+	})
+
+	require.NoError(t, v3Store.AdvanceRolloutControl(context.Background(), SessionModeV3Write, rolloutObservationGapForTest))
+	require.NoError(t, revokeStore.ValidateRolloutControl(context.Background(), SessionModeV3Write))
+	require.ErrorContains(t, enforceStore.ValidateRolloutControl(context.Background(), SessionModeV3Write), "more than one phase")
+}
+
 func TestRedisSessionStoreIssuesBoundedV3AndValidatorUsesGeneration(t *testing.T) {
 	cfg := config.New()
 	client := octoredis.NewInstrumentedClient(cfg)
@@ -607,6 +625,54 @@ func TestRedisSessionStorePromotesLegacyReuseWithoutExtendingDeadline(t *testing
 	require.Equal(t, fence.Revision, info.SessionRevision)
 	require.Equal(t, now.Unix(), info.IssuedAt)
 	require.LessOrEqual(t, info.ExpiresAt, now.Add(20*time.Minute).Unix())
+}
+
+func TestPromoteLegacySessionConflictCleansOwnIndexReservation(t *testing.T) {
+	cfg := config.New()
+	client := octoredis.NewInstrumentedClient(cfg)
+	prefix := "session-promote-conflict:" + util.GenerUUID() + ":"
+	uidPrefix := "session-promote-conflict-uid:" + util.GenerUUID() + ":"
+	now := time.Date(2026, time.August, 10, 10, 0, 0, 0, time.UTC)
+	store := NewRedisSessionStore(client, prefix, uidPrefix, time.Hour, WithSessionMode(SessionModeV3Write), WithSessionMaxPerUID(2), WithSessionClock(func() time.Time { return now }))
+	uid := "u-" + util.GenerUUID()
+	token := "t-" + util.GenerUUID()
+	legacy, err := Encode(TokenInfo{UID: uid, Name: "old"})
+	require.NoError(t, err)
+	require.NoError(t, client.Set(prefix+token, legacy, 20*time.Minute).Err())
+	t.Cleanup(func() {
+		keys, _ := client.Keys(prefix + "*").Result()
+		meta, _ := client.Keys(uidPrefix + "*").Result()
+		keys = append(keys, meta...)
+		if len(keys) > 0 {
+			_ = client.Del(keys...).Err()
+		}
+		_ = client.Close()
+	})
+
+	fence, err := store.BeginIssue(context.Background(), uid)
+	require.NoError(t, err)
+	staleRecord, err := store.ReadToken(context.Background(), prefix+token)
+	require.NoError(t, err)
+
+	ok, conflict, err := store.promoteLegacySession(context.Background(), token, staleRecord, TokenInfo{
+		UID: uid, Name: "winner", DeviceFlag: 1, DeviceID: "winner-device",
+	}, fence)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.False(t, conflict)
+
+	ok, conflict, err = store.promoteLegacySession(context.Background(), token, staleRecord, TokenInfo{
+		UID: uid, Name: "loser", DeviceFlag: 1, DeviceID: "loser-device",
+	}, fence)
+	require.NoError(t, err)
+	require.False(t, ok)
+	require.True(t, conflict)
+
+	members, err := client.ZRange(store.sessionIndexKey(uid, fence.Generation), 0, -1).Result()
+	require.NoError(t, err)
+	winnerMember, err := encodeSessionIndexMember(token, 1, "winner-device")
+	require.NoError(t, err)
+	require.Equal(t, []string{winnerMember}, members, "losing promotion must not consume a bounded-session slot")
 }
 
 func TestRedisSessionStoreSnapshotUpdatePreservesV3SecurityClaims(t *testing.T) {

--- a/pkg/auth/tokeninfo.go
+++ b/pkg/auth/tokeninfo.go
@@ -33,6 +33,7 @@ type TokenInfo struct {
 	DeviceFlag        int
 	DeviceID          string
 	SessionGeneration string
+	SessionRevision   uint64
 }
 
 // ErrEmptyToken indicates an empty cache value (missing or evicted token).
@@ -59,6 +60,7 @@ type tokenInfoV3 struct {
 	DeviceFlag        int    `json:"device_flag"`
 	DeviceID          string `json:"device_id,omitempty"`
 	SessionGeneration string `json:"session_generation"`
+	SessionRevision   uint64 `json:"session_revision"`
 }
 
 // Encode serializes a TokenInfo as the versioned JSON envelope. The UID is
@@ -96,6 +98,9 @@ func EncodeV3(info TokenInfo) (string, error) {
 	if strings.TrimSpace(info.SessionGeneration) == "" {
 		return "", fmt.Errorf("%w: session_generation required", ErrInvalidToken)
 	}
+	if info.SessionRevision == 0 {
+		return "", fmt.Errorf("%w: session_revision required", ErrInvalidToken)
+	}
 	payload, err := json.Marshal(tokenInfoV3{
 		UID:               info.UID,
 		Name:              info.Name,
@@ -106,6 +111,7 @@ func EncodeV3(info TokenInfo) (string, error) {
 		DeviceFlag:        info.DeviceFlag,
 		DeviceID:          info.DeviceID,
 		SessionGeneration: info.SessionGeneration,
+		SessionRevision:   info.SessionRevision,
 	})
 	if err != nil {
 		return "", fmt.Errorf("auth: marshal v3 token payload: %w", err)
@@ -157,6 +163,7 @@ func decodeV3(payload string) (TokenInfo, error) {
 		DeviceFlag:        v.DeviceFlag,
 		DeviceID:          v.DeviceID,
 		SessionGeneration: v.SessionGeneration,
+		SessionRevision:   v.SessionRevision,
 	}
 	if info.UID == "" {
 		return TokenInfo{}, fmt.Errorf("%w: uid missing", ErrInvalidToken)
@@ -170,12 +177,15 @@ func decodeV3(payload string) (TokenInfo, error) {
 	if strings.TrimSpace(info.SessionGeneration) == "" {
 		return TokenInfo{}, fmt.Errorf("%w: session_generation missing", ErrInvalidToken)
 	}
+	if info.SessionRevision == 0 {
+		return TokenInfo{}, fmt.Errorf("%w: session_revision missing", ErrInvalidToken)
+	}
 	return info, nil
 }
 
 // IsV3 reports whether Decode returned the v3 envelope.
 func (i TokenInfo) IsV3() bool {
-	return i.IssuedAt > 0 && i.ExpiresAt > 0 && i.SessionGeneration != ""
+	return i.IssuedAt > 0 && i.ExpiresAt > 0 && i.SessionGeneration != "" && i.SessionRevision > 0
 }
 
 func decodeLegacy(raw string) (TokenInfo, error) {

--- a/pkg/auth/tokeninfo_test.go
+++ b/pkg/auth/tokeninfo_test.go
@@ -20,6 +20,7 @@ func TestEncodeV3RoundTrip(t *testing.T) {
 		DeviceFlag:        1,
 		DeviceID:          "device-1",
 		SessionGeneration: "generation-1",
+		SessionRevision:   7,
 	}
 
 	encoded, err := EncodeV3(in)
@@ -61,7 +62,11 @@ func TestEncodeV3RejectsIncompleteSecurityClaims(t *testing.T) {
 		},
 		{
 			name: "blank generation",
-			info: TokenInfo{UID: "u1", IssuedAt: 1, ExpiresAt: 2, SessionGeneration: "  "},
+			info: TokenInfo{UID: "u1", IssuedAt: 1, ExpiresAt: 2, SessionGeneration: "  ", SessionRevision: 1},
+		},
+		{
+			name: "missing revision",
+			info: TokenInfo{UID: "u1", IssuedAt: 1, ExpiresAt: 2, SessionGeneration: "g1"},
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
@@ -80,11 +85,12 @@ func TestDecodeV3RejectsInvalidLifetime(t *testing.T) {
 		name string
 		raw  string
 	}{
-		{name: "missing issued at", raw: "v3:{\"uid\":\"u1\",\"expires_at\":2,\"session_generation\":\"g\"}"},
-		{name: "missing expires at", raw: "v3:{\"uid\":\"u1\",\"issued_at\":1,\"session_generation\":\"g\"}"},
-		{name: "deadline not after issue", raw: "v3:{\"uid\":\"u1\",\"issued_at\":2,\"expires_at\":2,\"session_generation\":\"g\"}"},
-		{name: "missing generation", raw: "v3:{\"uid\":\"u1\",\"issued_at\":1,\"expires_at\":2}"},
-		{name: "missing uid", raw: "v3:{\"issued_at\":1,\"expires_at\":2,\"session_generation\":\"g\"}"},
+		{name: "missing issued at", raw: "v3:{\"uid\":\"u1\",\"expires_at\":2,\"session_generation\":\"g\",\"session_revision\":1}"},
+		{name: "missing expires at", raw: "v3:{\"uid\":\"u1\",\"issued_at\":1,\"session_generation\":\"g\",\"session_revision\":1}"},
+		{name: "deadline not after issue", raw: "v3:{\"uid\":\"u1\",\"issued_at\":2,\"expires_at\":2,\"session_generation\":\"g\",\"session_revision\":1}"},
+		{name: "missing generation", raw: "v3:{\"uid\":\"u1\",\"issued_at\":1,\"expires_at\":2,\"session_revision\":1}"},
+		{name: "missing revision", raw: "v3:{\"uid\":\"u1\",\"issued_at\":1,\"expires_at\":2,\"session_generation\":\"g\"}"},
+		{name: "missing uid", raw: "v3:{\"issued_at\":1,\"expires_at\":2,\"session_generation\":\"g\",\"session_revision\":1}"},
 		{name: "bad json", raw: "v3:{not-json}"},
 	}
 	for _, tt := range tests {

--- a/pkg/auth/validator.go
+++ b/pkg/auth/validator.go
@@ -26,11 +26,16 @@ type SessionGenerationResolver interface {
 	CurrentGeneration(ctx context.Context, uid string) (string, error)
 }
 
+type LegacySessionPolicy interface {
+	ValidateLegacySession(ctx context.Context, info TokenInfo, record TokenRecord) error
+}
+
 type TokenValidator struct {
 	reader             TokenRecordReader
 	prefix             string
 	now                func() time.Time
 	generationResolver SessionGenerationResolver
+	legacyPolicy       LegacySessionPolicy
 }
 
 func WithSessionGenerationResolver(resolver SessionGenerationResolver) ValidatorOption {
@@ -56,6 +61,12 @@ func NewTokenValidator(reader TokenRecordReader, prefix string, opts ...Validato
 		panic("auth: NewTokenValidator requires non-nil reader")
 	}
 	v := &TokenValidator{reader: reader, prefix: prefix, now: time.Now}
+	if resolver, ok := reader.(SessionGenerationResolver); ok {
+		v.generationResolver = resolver
+	}
+	if policy, ok := reader.(LegacySessionPolicy); ok {
+		v.legacyPolicy = policy
+	}
 	for _, opt := range opts {
 		opt(v)
 	}
@@ -117,6 +128,16 @@ func (v *TokenValidator) Validate(ctx context.Context, token string) (TokenInfo,
 	}
 	if record.TTL == -1 {
 		metrics.ObservePersistentSession()
+	}
+	if v.legacyPolicy != nil {
+		if err := v.legacyPolicy.ValidateLegacySession(ctx, info, record); err != nil {
+			if errors.Is(err, ErrLegacySessionDenied) {
+				metrics.ObserveSessionValidationReject("legacy_policy")
+				return TokenInfo{}, fmt.Errorf("%w: legacy session rejected by rollout policy", wkhttp.ErrTokenInvalid)
+			}
+			metrics.ObserveSessionValidationReject("legacy_policy_store_error")
+			return TokenInfo{}, fmt.Errorf("auth: validate legacy session policy: %w", err)
+		}
 	}
 	return info, nil
 }

--- a/pkg/metrics/session.go
+++ b/pkg/metrics/session.go
@@ -8,14 +8,17 @@ import (
 )
 
 type SessionMetrics struct {
-	Operations       *prometheus.CounterVec
-	OperationLatency *prometheus.HistogramVec
-	ValidationReject *prometheus.CounterVec
-	PersistentSeen   prometheus.Counter
-	EffectiveTTL     prometheus.Gauge
-	operationOK      map[string]prometheus.Counter
-	operationError   map[string]prometheus.Counter
-	operationLatency map[string]prometheus.Observer
+	Operations        *prometheus.CounterVec
+	OperationLatency  *prometheus.HistogramVec
+	ValidationReject  *prometheus.CounterVec
+	PersistentSeen    prometheus.Counter
+	EffectiveTTL      prometheus.Gauge
+	RolloutMode       *prometheus.GaugeVec
+	RevocationBacklog prometheus.Gauge
+	RevocationRetries *prometheus.CounterVec
+	operationOK       map[string]prometheus.Counter
+	operationError    map[string]prometheus.Counter
+	operationLatency  map[string]prometheus.Observer
 }
 
 var defaultSessionMetrics atomic.Pointer[SessionMetrics]
@@ -53,8 +56,29 @@ func NewSessionMetrics(reg prometheus.Registerer) *SessionMetrics {
 			Name:      "effective_ttl_seconds",
 			Help:      "Configured access-token TTL effective in this process.",
 		}),
+		RolloutMode: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: metricNamespace,
+			Subsystem: "session",
+			Name:      "rollout_mode",
+			Help:      "Current session rollout mode; exactly one known mode is 1 per process.",
+		}, []string{"mode"}),
+		RevocationBacklog: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: metricNamespace,
+			Subsystem: "session",
+			Name:      "revocation_backlog",
+			Help:      "Pending durable session revocation intents visible to this process.",
+		}),
+		RevocationRetries: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: metricNamespace,
+			Subsystem: "session",
+			Name:      "revocation_retries_total",
+			Help:      "Durable session revocation retry failures by bounded reason.",
+		}, []string{"reason"}),
 	}
-	reg.MustRegister(m.Operations, m.OperationLatency, m.ValidationReject, m.PersistentSeen, m.EffectiveTTL)
+	reg.MustRegister(m.Operations, m.OperationLatency, m.ValidationReject, m.PersistentSeen, m.EffectiveTTL, m.RolloutMode, m.RevocationBacklog, m.RevocationRetries)
+	for _, mode := range sessionRolloutModes {
+		m.RolloutMode.WithLabelValues(mode).Set(0)
+	}
 	m.operationOK = make(map[string]prometheus.Counter, 5)
 	m.operationError = make(map[string]prometheus.Counter, 5)
 	m.operationLatency = make(map[string]prometheus.Observer, 5)
@@ -104,5 +128,39 @@ func ObservePersistentSession() {
 func SetSessionEffectiveTTL(ttl time.Duration) {
 	if m := defaultSessionMetrics.Load(); m != nil {
 		m.EffectiveTTL.Set(ttl.Seconds())
+	}
+}
+
+var sessionRolloutModes = []string{"expand", "v3-write", "revoke", "bounded", "enforce"}
+
+func SetSessionRolloutMode(current string) {
+	if m := defaultSessionMetrics.Load(); m != nil {
+		for _, mode := range sessionRolloutModes {
+			value := float64(0)
+			if mode == current {
+				value = 1
+			}
+			m.RolloutMode.WithLabelValues(mode).Set(value)
+		}
+	}
+}
+
+func SetSessionRevocationBacklog(count int64) {
+	if m := defaultSessionMetrics.Load(); m != nil {
+		if count < 0 {
+			count = 0
+		}
+		m.RevocationBacklog.Set(float64(count))
+	}
+}
+
+func ObserveSessionRevocationRetry(reason string) {
+	switch reason {
+	case "claim", "redis_apply", "mark_applied", "release":
+	default:
+		reason = "other"
+	}
+	if m := defaultSessionMetrics.Load(); m != nil {
+		m.RevocationRetries.WithLabelValues(reason).Inc()
 	}
 }

--- a/pkg/metrics/session_test.go
+++ b/pkg/metrics/session_test.go
@@ -19,6 +19,9 @@ func TestSessionMetricsRegisterAndObserveLowCardinalitySignals(t *testing.T) {
 	ObserveSessionValidationReject("v3_expired")
 	ObservePersistentSession()
 	SetSessionEffectiveTTL(48 * time.Hour)
+	SetSessionRolloutMode("revoke")
+	SetSessionRevocationBacklog(7)
+	ObserveSessionRevocationRetry("redis_apply")
 
 	if got := counterWithLabels(t, reg, "dmwork_session_operations_total", map[string]string{"operation": "issue", "outcome": "ok"}); got != 1 {
 		t.Fatalf("issue ok = %v, want 1", got)
@@ -35,6 +38,18 @@ func TestSessionMetricsRegisterAndObserveLowCardinalitySignals(t *testing.T) {
 	if got := gaugeWithoutLabels(t, reg, "dmwork_session_effective_ttl_seconds"); got != (48 * time.Hour).Seconds() {
 		t.Fatalf("effective ttl = %v, want %v", got, (48 * time.Hour).Seconds())
 	}
+	if got := gaugeWithLabels(t, reg, "dmwork_session_rollout_mode", map[string]string{"mode": "revoke"}); got != 1 {
+		t.Fatalf("revoke rollout mode = %v, want 1", got)
+	}
+	if got := gaugeWithLabels(t, reg, "dmwork_session_rollout_mode", map[string]string{"mode": "expand"}); got != 0 {
+		t.Fatalf("expand rollout mode = %v, want 0", got)
+	}
+	if got := gaugeWithoutLabels(t, reg, "dmwork_session_revocation_backlog"); got != 7 {
+		t.Fatalf("revocation backlog = %v, want 7", got)
+	}
+	if got := counterWithLabels(t, reg, "dmwork_session_revocation_retries_total", map[string]string{"reason": "redis_apply"}); got != 1 {
+		t.Fatalf("revocation retry = %v, want 1", got)
+	}
 }
 
 func TestSessionMetricsNoDefaultIsNoop(t *testing.T) {
@@ -46,6 +61,9 @@ func TestSessionMetricsNoDefaultIsNoop(t *testing.T) {
 	ObserveSessionValidationReject("missing")
 	ObservePersistentSession()
 	SetSessionEffectiveTTL(time.Hour)
+	SetSessionRolloutMode("expand")
+	SetSessionRevocationBacklog(1)
+	ObserveSessionRevocationRetry("redis_apply")
 }
 
 func counterWithLabels(t *testing.T, reg *prometheus.Registry, name string, want map[string]string) float64 {
@@ -90,6 +108,39 @@ func gaugeWithoutLabels(t *testing.T, reg *prometheus.Registry, name string) flo
 	for _, mf := range mfs {
 		if mf.GetName() == name && len(mf.GetMetric()) == 1 {
 			return mf.GetMetric()[0].GetGauge().GetValue()
+		}
+	}
+	return 0
+}
+
+func gaugeWithLabels(t *testing.T, reg *prometheus.Registry, name string, want map[string]string) float64 {
+	t.Helper()
+	mfs, err := reg.Gather()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, mf := range mfs {
+		if mf.GetName() != name {
+			continue
+		}
+		for _, metric := range mf.GetMetric() {
+			matched := true
+			for labelName, labelValue := range want {
+				found := false
+				for _, label := range metric.GetLabel() {
+					if label.GetName() == labelName && label.GetValue() == labelValue {
+						found = true
+						break
+					}
+				}
+				if !found {
+					matched = false
+					break
+				}
+			}
+			if matched {
+				return metric.GetGauge().GetValue()
+			}
 		}
 	}
 	return 0

--- a/tools/token-session-admin/main.go
+++ b/tools/token-session-admin/main.go
@@ -1,0 +1,215 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-server/internal/tokenlifecycle"
+	"github.com/Mininglamp-OSS/octo-server/pkg/auth"
+	octoredis "github.com/Mininglamp-OSS/octo-server/pkg/redis"
+	rd "github.com/go-redis/redis"
+	"github.com/spf13/viper"
+)
+
+type adminCommandKind string
+
+const (
+	adminCommandAdvanceFloor adminCommandKind = "advance-floor"
+	adminCommandMigrate      adminCommandKind = "migrate"
+)
+
+type adminCommand struct {
+	kind       adminCommandKind
+	configPath string
+	floor      auth.SessionMode
+	migration  auth.LegacyMigrationOptions
+}
+
+func main() {
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	if err := run(ctx, os.Args[1:], os.Stdout); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func run(ctx context.Context, args []string, output io.Writer) error {
+	command, err := parseAdminCommand(args, time.Now)
+	if err != nil {
+		return err
+	}
+	cfg, err := loadAdminConfig(command.configPath)
+	if err != nil {
+		return err
+	}
+	client := octoredis.NewInstrumentedClient(cfg, func(options *rd.Options) {
+		options.MaxRetries = 1
+		options.PoolSize = 2
+		options.DialTimeout = 2 * time.Second
+		options.ReadTimeout = 2 * time.Second
+		options.WriteTimeout = 2 * time.Second
+		options.PoolTimeout = time.Second
+	})
+	defer client.Close()
+	store := auth.NewRedisSessionStore(
+		client,
+		cfg.Cache.TokenCachePrefix,
+		cfg.Cache.UIDTokenCachePrefix,
+		cfg.Cache.TokenExpire,
+	)
+
+	switch command.kind {
+	case adminCommandAdvanceFloor:
+		if err := store.AdvanceRolloutControl(ctx, command.floor); err != nil {
+			return fmt.Errorf("advance session rollout floor: %w", err)
+		}
+		control, err := store.RolloutControl(ctx)
+		if err != nil {
+			return fmt.Errorf("read advanced session rollout floor: %w", err)
+		}
+		if err := json.NewEncoder(output).Encode(control); err != nil {
+			return fmt.Errorf("encode rollout control: %w", err)
+		}
+		return nil
+	case adminCommandMigrate:
+		result, migrationErr := store.MigrateLegacySessions(ctx, command.migration)
+		if err := json.NewEncoder(output).Encode(result); err != nil {
+			return fmt.Errorf("encode migration result: %w", err)
+		}
+		if migrationErr != nil {
+			return fmt.Errorf("migrate legacy token sessions: %w", migrationErr)
+		}
+		return nil
+	default:
+		return errors.New("unsupported token session admin command")
+	}
+}
+
+func parseAdminCommand(args []string, now func() time.Time) (adminCommand, error) {
+	if len(args) == 0 {
+		return adminCommand{}, errors.New("usage: token-session-admin <advance-floor|migrate> [flags]")
+	}
+	if now == nil {
+		now = time.Now
+	}
+	switch args[0] {
+	case string(adminCommandAdvanceFloor):
+		return parseAdvanceFloorCommand(args[1:])
+	case string(adminCommandMigrate):
+		return parseMigrateCommand(args[1:], now)
+	default:
+		return adminCommand{}, fmt.Errorf("unknown token session admin command %q", args[0])
+	}
+}
+
+func parseAdvanceFloorCommand(args []string) (adminCommand, error) {
+	flags := flag.NewFlagSet(string(adminCommandAdvanceFloor), flag.ContinueOnError)
+	flags.SetOutput(io.Discard)
+	configPath := flags.String("config", "", "octo-server config file")
+	target := flags.String("to", "", "next rollout floor")
+	if err := flags.Parse(args); err != nil {
+		return adminCommand{}, err
+	}
+	if flags.NArg() != 0 {
+		return adminCommand{}, errors.New("advance-floor does not accept positional arguments")
+	}
+	if strings.TrimSpace(*configPath) == "" {
+		return adminCommand{}, errors.New("advance-floor requires --config")
+	}
+	floor := auth.SessionMode(strings.TrimSpace(*target))
+	switch floor {
+	case auth.SessionModeV3Write, auth.SessionModeRevoke, auth.SessionModeBounded, auth.SessionModeEnforce:
+	default:
+		return adminCommand{}, errors.New("advance-floor --to must be one of v3-write, revoke, bounded, enforce")
+	}
+	return adminCommand{kind: adminCommandAdvanceFloor, configPath: *configPath, floor: floor}, nil
+}
+
+func parseMigrateCommand(args []string, now func() time.Time) (adminCommand, error) {
+	flags := flag.NewFlagSet(string(adminCommandMigrate), flag.ContinueOnError)
+	flags.SetOutput(io.Discard)
+	configPath := flags.String("config", "", "octo-server config file")
+	campaignID := flags.String("campaign", "", "immutable migration campaign identifier")
+	cutoffRaw := flags.String("cutoff", "", "absolute RFC3339 legacy deadline")
+	batchSize := flags.Int64("batch-size", 0, "Redis SCAN count hint")
+	qps := flags.Float64("qps", 0, "maximum token records processed per second")
+	lease := flags.Duration("lease", 0, "single-owner migration lease")
+	apply := flags.Bool("apply", false, "apply TTL shortening; omitted means dry-run")
+	if err := flags.Parse(args); err != nil {
+		return adminCommand{}, err
+	}
+	if flags.NArg() != 0 {
+		return adminCommand{}, errors.New("migrate does not accept positional arguments")
+	}
+	if strings.TrimSpace(*configPath) == "" {
+		return adminCommand{}, errors.New("migrate requires --config")
+	}
+	if strings.TrimSpace(*campaignID) == "" {
+		return adminCommand{}, errors.New("migrate requires --campaign")
+	}
+	if strings.TrimSpace(*cutoffRaw) == "" {
+		return adminCommand{}, errors.New("migrate requires --cutoff")
+	}
+	cutoff, err := time.Parse(time.RFC3339Nano, *cutoffRaw)
+	if err != nil {
+		return adminCommand{}, fmt.Errorf("invalid --cutoff %q: %w", *cutoffRaw, err)
+	}
+	if *batchSize <= 0 || *batchSize > 10_000 {
+		return adminCommand{}, errors.New("--batch-size must be between 1 and 10000")
+	}
+	if *qps <= 0 || *qps > 10_000 {
+		return adminCommand{}, errors.New("--qps must be greater than zero and no more than 10000")
+	}
+	interval := time.Duration(float64(time.Second) / *qps)
+	if interval <= 0 {
+		return adminCommand{}, errors.New("--qps produces an invalid processing interval")
+	}
+	if *lease < 5*time.Second || *lease > 5*time.Minute {
+		return adminCommand{}, errors.New("--lease must be between 5s and 5m")
+	}
+	if *apply && !cutoff.After(now()) {
+		return adminCommand{}, errors.New("--cutoff must be in the future when --apply is enabled")
+	}
+	return adminCommand{
+		kind:       adminCommandMigrate,
+		configPath: *configPath,
+		migration: auth.LegacyMigrationOptions{
+			CampaignID: strings.TrimSpace(*campaignID),
+			CutoffAt:   cutoff.UTC(),
+			BatchSize:  *batchSize,
+			Interval:   interval,
+			Apply:      *apply,
+			Lease:      *lease,
+		},
+	}, nil
+}
+
+func loadAdminConfig(path string) (*config.Config, error) {
+	vp := viper.New()
+	vp.SetConfigFile(path)
+	if err := vp.ReadInConfig(); err != nil {
+		return nil, fmt.Errorf("load config %s: %w", path, err)
+	}
+	vp.SetEnvPrefix("TS")
+	vp.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
+	vp.AutomaticEnv()
+	tokenExpire, err := tokenlifecycle.ValidateTokenExpire(vp)
+	if err != nil {
+		return nil, err
+	}
+	cfg := config.New()
+	cfg.ConfigureWithViper(vp)
+	cfg.Cache.TokenExpire = tokenExpire
+	return cfg, nil
+}

--- a/tools/token-session-admin/main.go
+++ b/tools/token-session-admin/main.go
@@ -29,10 +29,11 @@ const (
 )
 
 type adminCommand struct {
-	kind       adminCommandKind
-	configPath string
-	floor      auth.SessionMode
-	migration  auth.LegacyMigrationOptions
+	kind              adminCommandKind
+	configPath        string
+	floor             auth.SessionMode
+	observationMinGap time.Duration
+	migration         auth.LegacyMigrationOptions
 }
 
 func main() {
@@ -71,7 +72,7 @@ func run(ctx context.Context, args []string, output io.Writer) error {
 
 	switch command.kind {
 	case adminCommandAdvanceFloor:
-		if err := store.AdvanceRolloutControl(ctx, command.floor); err != nil {
+		if err := store.AdvanceRolloutControl(ctx, command.floor, command.observationMinGap); err != nil {
 			return fmt.Errorf("advance session rollout floor: %w", err)
 		}
 		control, err := store.RolloutControl(ctx)
@@ -118,6 +119,7 @@ func parseAdvanceFloorCommand(args []string) (adminCommand, error) {
 	flags.SetOutput(io.Discard)
 	configPath := flags.String("config", "", "octo-server config file")
 	target := flags.String("to", "", "next rollout floor")
+	observationMinGap := flags.Duration("observation-min-gap", 0, "approved minimum duration between rollout observations")
 	if err := flags.Parse(args); err != nil {
 		return adminCommand{}, err
 	}
@@ -133,7 +135,15 @@ func parseAdvanceFloorCommand(args []string) (adminCommand, error) {
 	default:
 		return adminCommand{}, errors.New("advance-floor --to must be one of v3-write, revoke, bounded, enforce")
 	}
-	return adminCommand{kind: adminCommandAdvanceFloor, configPath: *configPath, floor: floor}, nil
+	if *observationMinGap < auth.MinimumRolloutObservationGap {
+		return adminCommand{}, fmt.Errorf("advance-floor requires --observation-min-gap of at least %s", auth.MinimumRolloutObservationGap)
+	}
+	return adminCommand{
+		kind:              adminCommandAdvanceFloor,
+		configPath:        *configPath,
+		floor:             floor,
+		observationMinGap: *observationMinGap,
+	}, nil
 }
 
 func parseMigrateCommand(args []string, now func() time.Time) (adminCommand, error) {
@@ -142,10 +152,12 @@ func parseMigrateCommand(args []string, now func() time.Time) (adminCommand, err
 	configPath := flags.String("config", "", "octo-server config file")
 	campaignID := flags.String("campaign", "", "immutable migration campaign identifier")
 	cutoffRaw := flags.String("cutoff", "", "absolute RFC3339 legacy deadline")
+	finitePolicyRaw := flags.String("finite-policy", "", "finite legacy policy: natural or cap")
 	batchSize := flags.Int64("batch-size", 0, "Redis SCAN count hint")
 	qps := flags.Float64("qps", 0, "maximum token records processed per second")
 	lease := flags.Duration("lease", 0, "single-owner migration lease")
 	apply := flags.Bool("apply", false, "apply TTL shortening; omitted means dry-run")
+	confirmElapsedCutoff := flags.Bool("confirm-elapsed-cutoff", false, "confirm immediate deletion when the immutable cutoff has elapsed")
 	if err := flags.Parse(args); err != nil {
 		return adminCommand{}, err
 	}
@@ -165,6 +177,10 @@ func parseMigrateCommand(args []string, now func() time.Time) (adminCommand, err
 	if err != nil {
 		return adminCommand{}, fmt.Errorf("invalid --cutoff %q: %w", *cutoffRaw, err)
 	}
+	finitePolicy := auth.LegacyFinitePolicy(strings.TrimSpace(*finitePolicyRaw))
+	if finitePolicy != auth.LegacyFinitePolicyNatural && finitePolicy != auth.LegacyFinitePolicyCap {
+		return adminCommand{}, errors.New("migrate --finite-policy must be natural or cap")
+	}
 	if *batchSize <= 0 || *batchSize > 10_000 {
 		return adminCommand{}, errors.New("--batch-size must be between 1 and 10000")
 	}
@@ -178,19 +194,21 @@ func parseMigrateCommand(args []string, now func() time.Time) (adminCommand, err
 	if *lease < 5*time.Second || *lease > 5*time.Minute {
 		return adminCommand{}, errors.New("--lease must be between 5s and 5m")
 	}
-	if *apply && !cutoff.After(now()) {
-		return adminCommand{}, errors.New("--cutoff must be in the future when --apply is enabled")
+	if *apply && cutoff.UTC().UnixMilli() <= now().UTC().UnixMilli() && !*confirmElapsedCutoff {
+		return adminCommand{}, errors.New("migrate --apply with elapsed --cutoff requires --confirm-elapsed-cutoff")
 	}
 	return adminCommand{
 		kind:       adminCommandMigrate,
 		configPath: *configPath,
 		migration: auth.LegacyMigrationOptions{
-			CampaignID: strings.TrimSpace(*campaignID),
-			CutoffAt:   cutoff.UTC(),
-			BatchSize:  *batchSize,
-			Interval:   interval,
-			Apply:      *apply,
-			Lease:      *lease,
+			CampaignID:           strings.TrimSpace(*campaignID),
+			CutoffAt:             cutoff.UTC(),
+			FinitePolicy:         finitePolicy,
+			BatchSize:            *batchSize,
+			Interval:             interval,
+			Apply:                *apply,
+			ConfirmElapsedCutoff: *confirmElapsedCutoff,
+			Lease:                *lease,
 		},
 	}, nil
 }

--- a/tools/token-session-admin/main_test.go
+++ b/tools/token-session-admin/main_test.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-server/pkg/auth"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseAdminCommandRequiresExplicitSafeMigrationParameters(t *testing.T) {
+	now := time.Date(2026, time.August, 9, 16, 0, 0, 0, time.UTC)
+	args := []string{
+		"migrate",
+		"--config", "configs/prod.yaml",
+		"--campaign", "legacy-2026-08",
+		"--cutoff", "2026-08-16T16:00:00Z",
+		"--batch-size", "200",
+		"--qps", "50",
+		"--lease", "30s",
+	}
+
+	command, err := parseAdminCommand(args, func() time.Time { return now })
+	require.NoError(t, err)
+	require.Equal(t, adminCommandMigrate, command.kind)
+	require.Equal(t, "configs/prod.yaml", command.configPath)
+	require.False(t, command.migration.Apply)
+	require.Equal(t, "legacy-2026-08", command.migration.CampaignID)
+	require.Equal(t, time.Date(2026, time.August, 16, 16, 0, 0, 0, time.UTC), command.migration.CutoffAt)
+	require.Equal(t, int64(200), command.migration.BatchSize)
+	require.Equal(t, 20*time.Millisecond, command.migration.Interval)
+	require.Equal(t, 30*time.Second, command.migration.Lease)
+
+	args = append(args, "--apply")
+	command, err = parseAdminCommand(args, func() time.Time { return now })
+	require.NoError(t, err)
+	require.True(t, command.migration.Apply)
+}
+
+func TestParseAdminCommandRejectsUnsafeOrAmbiguousMigrationInput(t *testing.T) {
+	now := time.Date(2026, time.August, 9, 16, 0, 0, 0, time.UTC)
+	valid := []string{
+		"migrate",
+		"--config", "configs/prod.yaml",
+		"--campaign", "legacy-2026-08",
+		"--cutoff", "2026-08-16T16:00:00Z",
+		"--batch-size", "200",
+		"--qps", "50",
+		"--lease", "30s",
+	}
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{name: "missing campaign", args: withoutFlag(valid, "--campaign")},
+		{name: "missing cutoff", args: withoutFlag(valid, "--cutoff")},
+		{name: "missing batch", args: withoutFlag(valid, "--batch-size")},
+		{name: "missing qps", args: withoutFlag(valid, "--qps")},
+		{name: "missing lease", args: withoutFlag(valid, "--lease")},
+		{name: "malformed cutoff", args: replaceFlag(valid, "--cutoff", "next-week")},
+		{name: "zero batch", args: replaceFlag(valid, "--batch-size", "0")},
+		{name: "oversized batch", args: replaceFlag(valid, "--batch-size", "10001")},
+		{name: "zero qps", args: replaceFlag(valid, "--qps", "0")},
+		{name: "oversized qps", args: replaceFlag(valid, "--qps", "10001")},
+		{name: "short lease", args: replaceFlag(valid, "--lease", "4s")},
+		{name: "long lease", args: replaceFlag(valid, "--lease", "6m")},
+		{name: "unexpected positional", args: append(append([]string{}, valid...), "extra")},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := parseAdminCommand(tt.args, func() time.Time { return now })
+			require.Error(t, err)
+		})
+	}
+
+	pastApply := append(replaceFlag(valid, "--cutoff", "2026-08-09T15:59:59Z"), "--apply")
+	_, err := parseAdminCommand(pastApply, func() time.Time { return now })
+	require.ErrorContains(t, err, "future")
+}
+
+func TestParseAdminCommandAcceptsOnlyOneStepRolloutTargets(t *testing.T) {
+	for _, target := range []auth.SessionMode{
+		auth.SessionModeV3Write,
+		auth.SessionModeRevoke,
+		auth.SessionModeBounded,
+		auth.SessionModeEnforce,
+	} {
+		command, err := parseAdminCommand([]string{
+			"advance-floor", "--config", "configs/prod.yaml", "--to", string(target),
+		}, time.Now)
+		require.NoError(t, err)
+		require.Equal(t, adminCommandAdvanceFloor, command.kind)
+		require.Equal(t, target, command.floor)
+	}
+
+	for _, target := range []string{"", "expand", "V3-WRITE", "unknown"} {
+		_, err := parseAdminCommand([]string{
+			"advance-floor", "--config", "configs/prod.yaml", "--to", target,
+		}, time.Now)
+		require.Error(t, err)
+	}
+}
+
+func TestParseAdminCommandRejectsUnknownOrMissingSubcommand(t *testing.T) {
+	for _, args := range [][]string{nil, {}, {"unknown"}} {
+		_, err := parseAdminCommand(args, time.Now)
+		require.Error(t, err)
+	}
+}
+
+func withoutFlag(args []string, name string) []string {
+	result := make([]string, 0, len(args)-2)
+	for i := 0; i < len(args); i++ {
+		if args[i] == name {
+			i++
+			continue
+		}
+		result = append(result, args[i])
+	}
+	return result
+}
+
+func replaceFlag(args []string, name, value string) []string {
+	result := append([]string(nil), args...)
+	for i := 0; i+1 < len(result); i++ {
+		if result[i] == name {
+			result[i+1] = value
+			return result
+		}
+	}
+	return result
+}

--- a/tools/token-session-admin/main_test.go
+++ b/tools/token-session-admin/main_test.go
@@ -15,6 +15,7 @@ func TestParseAdminCommandRequiresExplicitSafeMigrationParameters(t *testing.T) 
 		"--config", "configs/prod.yaml",
 		"--campaign", "legacy-2026-08",
 		"--cutoff", "2026-08-16T16:00:00Z",
+		"--finite-policy", "natural",
 		"--batch-size", "200",
 		"--qps", "50",
 		"--lease", "30s",
@@ -27,6 +28,7 @@ func TestParseAdminCommandRequiresExplicitSafeMigrationParameters(t *testing.T) 
 	require.False(t, command.migration.Apply)
 	require.Equal(t, "legacy-2026-08", command.migration.CampaignID)
 	require.Equal(t, time.Date(2026, time.August, 16, 16, 0, 0, 0, time.UTC), command.migration.CutoffAt)
+	require.Equal(t, auth.LegacyFinitePolicyNatural, command.migration.FinitePolicy)
 	require.Equal(t, int64(200), command.migration.BatchSize)
 	require.Equal(t, 20*time.Millisecond, command.migration.Interval)
 	require.Equal(t, 30*time.Second, command.migration.Lease)
@@ -44,6 +46,7 @@ func TestParseAdminCommandRejectsUnsafeOrAmbiguousMigrationInput(t *testing.T) {
 		"--config", "configs/prod.yaml",
 		"--campaign", "legacy-2026-08",
 		"--cutoff", "2026-08-16T16:00:00Z",
+		"--finite-policy", "natural",
 		"--batch-size", "200",
 		"--qps", "50",
 		"--lease", "30s",
@@ -54,6 +57,8 @@ func TestParseAdminCommandRejectsUnsafeOrAmbiguousMigrationInput(t *testing.T) {
 	}{
 		{name: "missing campaign", args: withoutFlag(valid, "--campaign")},
 		{name: "missing cutoff", args: withoutFlag(valid, "--cutoff")},
+		{name: "missing finite policy", args: withoutFlag(valid, "--finite-policy")},
+		{name: "unknown finite policy", args: replaceFlag(valid, "--finite-policy", "guess")},
 		{name: "missing batch", args: withoutFlag(valid, "--batch-size")},
 		{name: "missing qps", args: withoutFlag(valid, "--qps")},
 		{name: "missing lease", args: withoutFlag(valid, "--lease")},
@@ -75,7 +80,13 @@ func TestParseAdminCommandRejectsUnsafeOrAmbiguousMigrationInput(t *testing.T) {
 
 	pastApply := append(replaceFlag(valid, "--cutoff", "2026-08-09T15:59:59Z"), "--apply")
 	_, err := parseAdminCommand(pastApply, func() time.Time { return now })
-	require.ErrorContains(t, err, "future")
+	require.ErrorContains(t, err, "--confirm-elapsed-cutoff")
+
+	confirmedPastApply := append(pastApply, "--confirm-elapsed-cutoff")
+	command, err := parseAdminCommand(confirmedPastApply, func() time.Time { return now })
+	require.NoError(t, err, "an elapsed resumable campaign must require explicit destructive confirmation")
+	require.True(t, command.migration.Apply)
+	require.True(t, command.migration.ConfirmElapsedCutoff)
 }
 
 func TestParseAdminCommandAcceptsOnlyOneStepRolloutTargets(t *testing.T) {
@@ -87,16 +98,33 @@ func TestParseAdminCommandAcceptsOnlyOneStepRolloutTargets(t *testing.T) {
 	} {
 		command, err := parseAdminCommand([]string{
 			"advance-floor", "--config", "configs/prod.yaml", "--to", string(target),
+			"--observation-min-gap", "1h",
 		}, time.Now)
 		require.NoError(t, err)
 		require.Equal(t, adminCommandAdvanceFloor, command.kind)
 		require.Equal(t, target, command.floor)
+		require.Equal(t, time.Hour, command.observationMinGap)
 	}
 
 	for _, target := range []string{"", "expand", "V3-WRITE", "unknown"} {
 		_, err := parseAdminCommand([]string{
 			"advance-floor", "--config", "configs/prod.yaml", "--to", target,
+			"--observation-min-gap", "1h",
 		}, time.Now)
+		require.Error(t, err)
+	}
+
+	valid := []string{
+		"advance-floor", "--config", "configs/prod.yaml", "--to", "v3-write",
+		"--observation-min-gap", "1h",
+	}
+	for _, args := range [][]string{
+		withoutFlag(valid, "--observation-min-gap"),
+		replaceFlag(valid, "--observation-min-gap", "0s"),
+		replaceFlag(valid, "--observation-min-gap", "-1s"),
+		replaceFlag(valid, "--observation-min-gap", "59m59s"),
+	} {
+		_, err := parseAdminCommand(args, time.Now)
 		require.Error(t, err)
 	}
 }

--- a/tools/token-session-observe/main.go
+++ b/tools/token-session-observe/main.go
@@ -59,11 +59,11 @@ func run() error {
 	}
 	interval := time.Duration(float64(time.Second) / *qps)
 	stats, err := store.ObserveRateLimited(ctx, *batchSize, interval)
-	if err != nil {
-		return fmt.Errorf("observe token sessions: %w", err)
-	}
 	if err := json.NewEncoder(os.Stdout).Encode(stats); err != nil {
 		return fmt.Errorf("encode aggregate observation: %w", err)
+	}
+	if err != nil {
+		return fmt.Errorf("observe token sessions: %w", err)
 	}
 	return nil
 }

--- a/tools/token-session-observe/main.go
+++ b/tools/token-session-observe/main.go
@@ -30,6 +30,7 @@ func run() error {
 	configPath := flag.String("config", "configs/tsdd.yaml", "octo-server config file")
 	batchSize := flag.Int64("batch-size", 200, "Redis SCAN count hint (1-10000)")
 	qps := flag.Float64("qps", 100, "maximum token records read per second")
+	recordRolloutEvidence := flag.Bool("record-rollout-evidence", false, "persist this complete aggregate scan as rollout evidence")
 	flag.Parse()
 
 	cfg, err := loadConfig(*configPath)
@@ -59,11 +60,18 @@ func run() error {
 	}
 	interval := time.Duration(float64(time.Second) / *qps)
 	stats, err := store.ObserveRateLimited(ctx, *batchSize, interval)
+	var evidenceErr error
+	if err == nil && *recordRolloutEvidence {
+		evidenceErr = store.RecordRolloutObservation(ctx, stats)
+	}
 	if err := json.NewEncoder(os.Stdout).Encode(stats); err != nil {
 		return fmt.Errorf("encode aggregate observation: %w", err)
 	}
 	if err != nil {
 		return fmt.Errorf("observe token sessions: %w", err)
+	}
+	if evidenceErr != nil {
+		return fmt.Errorf("record rollout observation evidence: %w", evidenceErr)
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

This is the activation and migration follow-up to #723. It adds bounded v3 user sessions, durable high-risk revocation, and a controlled legacy-token migration path without changing the client-facing opaque token contract.

The runtime default remains `expand`: merging or deploying this PR does not automatically enable v3 writers, create legacy deny markers, run migration apply, or reject legacy sessions.

## Related Issue

- Follow-up to #723

## Linked Spec

- [`.octospec/tasks/token-lifecycle-hardening-pr2/brief.md`](.octospec/tasks/token-lifecycle-hardening-pr2/brief.md)

## Changes

- Add the monotonic `expand -> v3-write -> revoke -> bounded -> enforce` rollout policy and persistent safety floors. Runtime startup may be at most one phase above the persisted floor, preventing unsafe phase skipping.
- Add v3 session payloads with absolute expiry, per-UID generation, issuance fences, and UID-plus-generation bounded indexes.
- Keep v3 validation fail closed on missing, stale, revoking, or unreadable generation state while reusing the existing session Redis pool.
- Route login/reuse writers and credential deletion through the session store across local, manager, external, OIDC, social, scan-login, registration, and device-verification paths. The repository guard also rejects direct Token/UIDToken deletion methods.
- Clean speculative legacy-promotion index reservations by payload ownership after CAS conflicts or ambiguous errors, so a losing replica cannot consume a bounded-session slot or delete the winning member.
- Persist password/account-state revocation intents in the same MySQL transaction and retry Redis application through an owner-leased, idempotent worker.
- Invalidate the role cache immediately after a committed administrator deletion, before synchronous Redis revocation application, so an apply failure cannot preserve both a stale admin role and a residual bearer.
- Finalize password change/reset and account-disable events across the DB commit boundary, HTTP session revocation, and WuKongIM all-device logout. A rolled-back DB mutation emits no external side effects; after commit, a Redis failure does not suppress the independent IM operations.
- Add dry-run-by-default observe/apply/admin tooling with fixed cutoffs, resumable checkpoints, single-owner leases, and secret-free output.
- Add rollout, validation, migration, index, and revocation backlog metrics.

## Testing

- [x] Unit and integration tests added/updated
- [x] Manually verified against local MySQL 8, Redis 7, and WuKongIM containers

Passed on HEAD `8056e9d2`:

- `go test -race ./pkg/auth/... -count=1`
- Focused `modules/user` source/unit guards for committed side effects, Session Store deletion, and the repository-wide credential-writer policy
- Isolated-MySQL/Redis integration tests for password revocation plus all-device IM logout, account-disable convergence after Redis failure, and role-cache invalidation after a committed administrator deletion
- `go test ./pkg/metrics/... ./tools/... -count=1`
- `go build ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `make i18n-extract-check`
- `make i18n-lint`
- A real local WuKongIM `/user/device_quit` probe with `device_flag=-1` returned HTTP 200

The latest head is not reported as a green full `modules/user`, `modules/oidc`, or `go test ./...` run. The shared local `test.gorp_migrations` currently contains `20260810000001_user_phone_encrypted_columns.sql`, which is absent from this checkout, so octo-lib rejects that shared schema before those suites start. The affected user paths above passed against isolated `utf8mb4_general_ci` databases; the shared schema was not rewritten to manufacture a green result.

## Activation gates

- Confirm the production Redis topology supports the required single-key Lua, SCAN, script-cache fallback, and lease semantics, and that authentication safety keys cannot be silently evicted.
- Budget v3's second serial Redis read and `session_pool_size x (replicas + maxSurge)` connections against production peak QPS, latency SLOs, and `maxclients`.
- Confirm session cap, legacy cutoff, finite-legacy policy, and the exact product scope for `/v1/user/pc/quit`, device deletion, and OIDC sync `invalid_grant`; those paths are intentionally not guessed in this PR.
- Clear old replicas and verify one mode/build across all replicas before advancing each floor. Migration apply is allowed only after the revoke floor; enforce requires two complete scans with `persistent=0`, `over_max=0`, and `v1/v2=0`.
- Once v3 has been issued or the writer floor is advanced, rollback must stay on a v3-capable build; PR #723 alone is no longer a safe rollback target.

## COMPREHENSION

1. **What does this change actually do** to the load-bearing path?

   It changes user HTTP session issuance from legacy v2 to bounded v3 only after an explicit rollout transition. A v3 bearer is valid only when the token key and absolute deadline are valid and its Redis generation matches the current active per-UID generation. High-risk DB mutations persist a revocation intent transactionally, then rotate generation and retry cleanup durably. Session indexes are bounded cleanup/cap structures, not the authority for revoke-all.

2. **What could break** because of it (dependents + failure mode)?

   In v3 modes, authentication normally performs two serial Redis reads instead of one and intentionally fails closed if generation/control state is unavailable. Incorrect Redis capacity, eviction policy, topology compatibility, rollout ordering, or session-cap values can cause login rejection or broad 401s. Advancing a safety floor also narrows rollback options. These risks are why the default is `expand` and every activation step is externally gated.

3. **How do you know it works** (specific test/repro/trace)?

   Tests cover two independent Redis clients as separate replicas, stale issuance fences, generation mismatch/missing/error states, concurrent cap enforcement, deadline preservation, legacy promotion conflicts, replay of old revocation events after a new login, outbox retry/lease behavior, fixed-cutoff migration idempotency, rollout phase-skip rejection, administrator role-cache ordering, Session Store-only credential deletion, and post-commit password/disable IM convergence. The focused race, integration, build, vet, lint, and i18n commands listed above passed against local container dependencies.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] PR description is in English
- [x] Added tests for my changes
- [x] Updated documentation
- [x] Followed commit message conventions (Conventional Commits)
