### PR TITLE
feat(cardtmpl): publish ai.reasoning-process@0.4.1

### DIFF
--- a/.octospec/tasks/cardtmpl-reasoning-bleed-successor/brief.md
+++ b/.octospec/tasks/cardtmpl-reasoning-bleed-successor/brief.md
@@ -1,0 +1,86 @@
+---
+type: Task
+title: "Task: cardtmpl-reasoning-bleed-successor"
+description: Publish ai.reasoning-process@0.4.1 as the immutable successor to 0.4.0, adopting the incoming full-bleed presentation while preserving the server-owned bounded contract and Bot cutover rules.
+tags: [card, cardtmpl, ai-reasoning-process, json-template, bot-api, wire-contract, test, testing, rollback]
+timestamp: 2026-08-10T14:30:00+08:00
+# --- octospec extension fields ---
+slug: cardtmpl-reasoning-bleed-successor
+upstream: "front-end handoff attachment ai.reasoning-process@0.3.1.handoff.zip sha256 c708905b18198b266479d5c7e4e2904d7c70a99fdd47f7c0117fcfc573c09433; supersedes no published artifact"
+source: user
+---
+
+# Task: cardtmpl-reasoning-bleed-successor
+
+## Goal
+
+Publish the immutable built-in artifact `ai.reasoning-process@0.4.1` from the
+attached front-end handoff. `0.4.0` is already published, so the handoff's
+internal `0.3.1` identity must not be used to overwrite any historical card.
+
+The release adopts the front-end's full-bleed root container (`bleed: true`) in
+all three templates and records its `octo-chat@1.2.0-rc.3` render-profile
+provenance. It registers V5 with the static registry, makes V5 the default and
+the sole Bot new-send advertisement, while retaining V1–V4 for exact-version
+historical edits.
+
+## Load-bearing decisions
+
+1. Start from the shipped `0.4.0` artifact, not from the attachment as a whole.
+   Its V4 data schema, aggregate cap, thought truncation, reports, samples, and
+   vetted percent-encoded SVG icon bytes remain authoritative.
+2. Apply only the presentation delta that changes the card: `bleed: true` on
+   the root `Container` of `active`, `result`, and `error`. Regenerate all five
+   goldens from the server-owned templates and samples.
+3. Use `renderProfile: octo-chat@1.2.0-rc.3` as manifest provenance only;
+   `renderProfileCompatibility` remains `octo-chat/v1`. The server does not
+   ship or validate front-end `render-profile/` resources.
+4. Keep `owner=ai`, `protocol=octo-card@1.0`, the five-state/view/wire mapping,
+   no manifest `submit_actions`, and no `actionType`.
+5. Do not import the handoff's unbounded schema, optional unused `phaseState`,
+   `reports/result.interaction.json`, or render-profile directory. Preserve the
+   V4 `statusGlyph` binding; hardcoding `•` would erase the producer's per-tool
+   success/failure signal. Preserve the existing vetted percent-encoded SVG
+   bytes rather than broadening the inline-image allowlist for base64 variants.
+6. This is an image-release cutover only. Do not use runtime activation or
+   rollback pointers to switch the built-in exact version.
+
+## In scope
+
+- Add the V5 artifact and exact-version constants.
+- Register V5, move the default and Bot `AdvertisedSend` to V5, and extend
+  edit compatibility through V5.
+- Update focused artifact, registry, composition-root, catalog, and Bot-profile
+  assertions so a regression cannot advertise an unregistered version.
+
+## Out of scope
+
+- Changing V1–V4 artifacts or stored historical cards.
+- Relaxing schema, node, payload, persistence, or inline-image security limits.
+- Adding new producer fields, client controls, routes, migrations, error codes,
+  runtime-catalog activation, or a consumer-plugin release.
+
+## Acceptance
+
+- [ ] V5 manifest has exact identity `ai.reasoning-process@0.4.1`, owner and
+  protocol, contract `1.2.0`, render profile `octo-chat@1.2.0-rc.3`, and the
+  unchanged five-state/view/wire shape with no Submit capability.
+- [ ] All V5 root template containers carry `bleed: true`; no V5 template
+  hardcodes a tool status glyph or changes the V4 toggle surface.
+- [ ] The V5 schema is byte-identical to V4; it retains all bounds and
+  `x-octo-constraints`, excludes `phaseState`, and V5 ships neither a
+  render-profile directory nor a result interaction report.
+- [ ] Goldens match server rendering for all five samples and the rendered V5
+  frames remain valid through the production persistence normalization path.
+- [ ] V1–V4 remain unchanged; registry contains V1–V5 and defaults to V5;
+  Bot new sends advertise only V5 while exact-version edits accept V1–V5.
+- [ ] Focused `pkg/cardtmpl/ai_reasoning_process`, `modules/bot_api`,
+  `modules/card_template_catalog`, and composition-root tests pass, followed by
+  `go build ./...`, `go vet ./...`, and `git diff --check`.
+
+## Rollback
+
+Roll back by deploying the previous image, whose static catalog advertises V4.
+Do not mutate V5 or activate a runtime-catalog pointer: already-created V5
+cards retain their exact artifact identity and must remain renderable on images
+that keep V5 registered.

--- a/main.go
+++ b/main.go
@@ -865,16 +865,17 @@ func installCardTmplRegistry() *cardtmpl.Registry {
 	registry.SetDefault(summarycompleted.TemplateID, summarycompleted.TemplateVersion)
 	registry.Register(summaryfailed.New(), summaryfailed.Assets, summaryfailed.HandoffRoot)
 	registry.SetDefault(summaryfailed.TemplateID, summaryfailed.TemplateVersion)
-	// roadmap E1/E1c safety successor:保留冻结的 0.1.0/0.2.0/0.3.0 供历史消息按
-	// 原契约编辑且不跨版本迁移，同时注册精简版式的 0.4.0 并设为新默认。0.4.0 与
-	// 0.3.0 的动作面完全一致（只有客户端本地 toggle），差异全在展示层。
+	// roadmap E1/E1c safety successor:保留冻结的 0.1.0–0.4.0 供历史消息按
+	// 原契约编辑且不跨版本迁移，同时注册 full-bleed 版 0.4.1 并设为新默认。0.4.1 与
+	// 0.4.0 的动作面与数据契约完全一致（只有客户端本地 toggle），差异只在根容器展示层。
 	// Bot 新发/历史 edit 的授权集合由 bot_api catalog 独立收口；Registry 多版本
 	// 只提供精确版本渲染能力，不隐式开放 Bot 权限。
 	registry.RegisterJSON(aireasoningprocess.Assets, aireasoningprocess.HandoffRootV1)
 	registry.RegisterJSON(aireasoningprocess.Assets, aireasoningprocess.HandoffRootV2)
 	registry.RegisterJSON(aireasoningprocess.Assets, aireasoningprocess.HandoffRootV3)
 	registry.RegisterJSON(aireasoningprocess.Assets, aireasoningprocess.HandoffRootV4)
-	registry.SetDefault(aireasoningprocess.TemplateID, aireasoningprocess.TemplateVersionV4)
+	registry.RegisterJSON(aireasoningprocess.Assets, aireasoningprocess.HandoffRootV5)
+	registry.SetDefault(aireasoningprocess.TemplateID, aireasoningprocess.TemplateVersionV5)
 	registry.Freeze()
 	cardtmpl.SetGlobalMetrics(cardtmpl.NewMetrics(prometheus.DefaultRegisterer))
 	cardtmpl.SetDefaultRegistry(registry)

--- a/main_test.go
+++ b/main_test.go
@@ -319,7 +319,7 @@ func TestAccessLogIgnorePathsIncludesProbeEndpoints(t *testing.T) {
 	require.Contains(t, paths, "/v1/ready")
 }
 
-func TestInstallCardTmplRegistryRegistersReasoningHistoryAndV4Default(t *testing.T) {
+func TestInstallCardTmplRegistryRegistersReasoningHistoryAndV5Default(t *testing.T) {
 	previousRegistry := cardtmpl.DefaultRegistry()
 	previousRegisterer := prometheus.DefaultRegisterer
 	previousGatherer := prometheus.DefaultGatherer
@@ -346,11 +346,12 @@ func TestInstallCardTmplRegistryRegistersReasoningHistoryAndV4Default(t *testing
 		aireasoningprocess.TemplateVersionV2,
 		aireasoningprocess.TemplateVersionV3,
 		aireasoningprocess.TemplateVersionV4,
+		aireasoningprocess.TemplateVersionV5,
 	}, versions)
 
 	current, err := registry.Lookup(aireasoningprocess.TemplateID, "")
 	require.NoError(t, err)
-	require.Equal(t, aireasoningprocess.TemplateVersionV4, current.Meta().Version)
+	require.Equal(t, aireasoningprocess.TemplateVersionV5, current.Meta().Version)
 	for _, version := range versions {
 		_, err := registry.Lookup(aireasoningprocess.TemplateID, version)
 		require.NoError(t, err)

--- a/modules/bot_api/bot_setting_card_test.go
+++ b/modules/bot_api/bot_setting_card_test.go
@@ -134,7 +134,7 @@ func TestAdvertisedRef_UnknownTemplateIsNotAdvertised(t *testing.T) {
 		t.Fatal("AdvertisedRef returned a ref for a template that is not advertised to bots")
 	}
 	if ref, ok := catalog.AdvertisedRef(aireasoningprocess.TemplateID); !ok ||
-		ref.Version != aireasoningprocess.TemplateVersionV4 {
+		ref.Version != aireasoningprocess.TemplateVersionV5 {
 		t.Fatalf("AdvertisedRef(%s) = %#v ok=%v", aireasoningprocess.TemplateID, ref, ok)
 	}
 }

--- a/modules/bot_api/card_profile_test.go
+++ b/modules/bot_api/card_profile_test.go
@@ -290,7 +290,7 @@ func assertReasoningCurrentCapability(t *testing.T, capability botTemplatingCapa
 	}
 	template := capability.Templates[0]
 	assert.Equal(t, string(aireasoningprocess.TemplateID), template.ID)
-	assert.Equal(t, aireasoningprocess.TemplateVersionV4, template.Version)
+	assert.Equal(t, aireasoningprocess.TemplateVersionV5, template.Version)
 	assert.Len(t, template.Views, 3)
 	for _, view := range template.Views {
 		assert.Empty(t, view.SubmitActions, "view %s must not advertise server callbacks", view.Name)

--- a/modules/bot_api/card_template_catalog.go
+++ b/modules/bot_api/card_template_catalog.go
@@ -64,7 +64,7 @@ type botCardTemplateCatalog struct {
 func defaultBotTemplateRefs() []botTemplateRef {
 	return []botTemplateRef{{
 		ID:      aireasoningprocess.TemplateID,
-		Version: aireasoningprocess.TemplateVersionV4,
+		Version: aireasoningprocess.TemplateVersionV5,
 	}}
 }
 
@@ -76,6 +76,7 @@ func defaultBotTemplatePolicy() botTemplatePolicy {
 			{ID: aireasoningprocess.TemplateID, Version: aireasoningprocess.TemplateVersionV2},
 			{ID: aireasoningprocess.TemplateID, Version: aireasoningprocess.TemplateVersionV3},
 			{ID: aireasoningprocess.TemplateID, Version: aireasoningprocess.TemplateVersionV4},
+			{ID: aireasoningprocess.TemplateID, Version: aireasoningprocess.TemplateVersionV5},
 		},
 	}
 }

--- a/modules/bot_api/card_template_catalog_test.go
+++ b/modules/bot_api/card_template_catalog_test.go
@@ -15,8 +15,8 @@ import (
 // The advertised/new-send version, tracked in one place so a successor bump
 // touches this constant rather than every assertion below.
 const (
-	testReasoningVersionCurrent = aireasoningprocess.TemplateVersionV4
-	testReasoningRootCurrent    = aireasoningprocess.HandoffRootV4
+	testReasoningVersionCurrent = aireasoningprocess.TemplateVersionV5
+	testReasoningRootCurrent    = aireasoningprocess.HandoffRootV5
 )
 
 func testBotTemplateRegistry(t *testing.T) *cardtmpl.Registry {
@@ -25,6 +25,7 @@ func testBotTemplateRegistry(t *testing.T) *cardtmpl.Registry {
 	r.RegisterJSON(aireasoningprocess.Assets, aireasoningprocess.HandoffRootV1)
 	r.RegisterJSON(aireasoningprocess.Assets, aireasoningprocess.HandoffRootV2)
 	r.RegisterJSON(aireasoningprocess.Assets, aireasoningprocess.HandoffRootV3)
+	r.RegisterJSON(aireasoningprocess.Assets, aireasoningprocess.HandoffRootV4)
 	r.RegisterJSON(aireasoningprocess.Assets, testReasoningRootCurrent)
 	r.SetDefault(aireasoningprocess.TemplateID, testReasoningVersionCurrent)
 	r.Register(docsaccessrequest.NewV3(), docsaccessrequest.Assets, docsaccessrequest.HandoffRootV3)
@@ -66,6 +67,7 @@ func TestBotCardTemplateCatalogSeparatesNewSendFromLegacyEdit(t *testing.T) {
 		{aireasoningprocess.TemplateVersionV1, aireasoningprocess.HandoffRootV1},
 		{aireasoningprocess.TemplateVersionV2, aireasoningprocess.HandoffRootV2},
 		{aireasoningprocess.TemplateVersionV3, aireasoningprocess.HandoffRootV3},
+		{aireasoningprocess.TemplateVersionV4, aireasoningprocess.HandoffRootV4},
 	} {
 		t.Run(historical.version, func(t *testing.T) {
 			legacyRef := map[string]any{

--- a/modules/card_template_catalog/runtime_startup_test.go
+++ b/modules/card_template_catalog/runtime_startup_test.go
@@ -126,11 +126,13 @@ func TestInitializeRuntimeCatalogAcceptsRegisteredStaticReasoningTargets(t *test
 	registry.RegisterJSON(aireasoningprocess.Assets, aireasoningprocess.HandoffRootV2)
 	registry.RegisterJSON(aireasoningprocess.Assets, aireasoningprocess.HandoffRootV3)
 	registry.RegisterJSON(aireasoningprocess.Assets, aireasoningprocess.HandoffRootV4)
+	registry.RegisterJSON(aireasoningprocess.Assets, aireasoningprocess.HandoffRootV5)
 	registry.Freeze()
 	store := &startupStoreStub{targets: []startupActivationTarget{
 		{ID: aireasoningprocess.TemplateID, Version: aireasoningprocess.TemplateVersionV2},
 		{ID: aireasoningprocess.TemplateID, Version: aireasoningprocess.TemplateVersionV3},
 		{ID: aireasoningprocess.TemplateID, Version: aireasoningprocess.TemplateVersionV4},
+		{ID: aireasoningprocess.TemplateID, Version: aireasoningprocess.TemplateVersionV5},
 	}}
 	api := &API{store: store, registry: registry}
 	api.validateStateTarget = api.validateTarget

--- a/pkg/cardtmpl/ai_reasoning_process/card.go
+++ b/pkg/cardtmpl/ai_reasoning_process/card.go
@@ -11,7 +11,8 @@
 //	registry.RegisterJSON(aireasoningprocess.Assets, aireasoningprocess.HandoffRootV2)
 //	registry.RegisterJSON(aireasoningprocess.Assets, aireasoningprocess.HandoffRootV3)
 //	registry.RegisterJSON(aireasoningprocess.Assets, aireasoningprocess.HandoffRootV4)
-//	registry.SetDefault(aireasoningprocess.TemplateID, aireasoningprocess.TemplateVersionV4)
+//	registry.RegisterJSON(aireasoningprocess.Assets, aireasoningprocess.HandoffRootV5)
+//	registry.SetDefault(aireasoningprocess.TemplateID, aireasoningprocess.TemplateVersionV5)
 //
 // Layering: L1 JSON artifacts live under handoff/. Frozen V1/V2 retain their
 // historical reasoning_stop/reasoning_retry Submit contracts. V3 removes those
@@ -19,6 +20,8 @@
 // V4 keeps V3's action surface and adds the simplified presentation: a slimmed
 // header with chevron toggles and per-phase collapsible tool panels. Across all
 // versions active/error remain octo/v2 and result remains octo/v1.
+// V5 keeps the V4 contract and interaction surface byte-for-byte while allowing
+// that simplified root container to bleed to the chat edge.
 package aireasoningprocess
 
 import (
@@ -54,9 +57,14 @@ const (
 	// 13 is load-bearing rather than incidental.
 	HandoffRootV4     = "handoff/ai.reasoning-process@0.4.0"
 	TemplateVersionV4 = "0.4.0"
+	// HandoffRootV5 and TemplateVersionV5 identify the full-bleed presentation
+	// successor. It intentionally preserves V4's bounded data contract and
+	// client-local action surface; only the root-container presentation changes.
+	HandoffRootV5     = "handoff/ai.reasoning-process@0.4.1"
+	TemplateVersionV5 = "0.4.1"
 
 	// HandoffRoot and TemplateVersion retain the package's current-version
 	// aliases for callers that do not need an explicit historical version.
-	HandoffRoot     = HandoffRootV4
-	TemplateVersion = TemplateVersionV4
+	HandoffRoot     = HandoffRootV5
+	TemplateVersion = TemplateVersionV5
 )

--- a/pkg/cardtmpl/ai_reasoning_process/card_test.go
+++ b/pkg/cardtmpl/ai_reasoning_process/card_test.go
@@ -30,6 +30,8 @@ const (
 	reasoningRootV3    = aireasoningprocess.HandoffRootV3
 	reasoningVersionV4 = aireasoningprocess.TemplateVersionV4
 	reasoningRootV4    = aireasoningprocess.HandoffRootV4
+	reasoningVersionV5 = aireasoningprocess.TemplateVersionV5
+	reasoningRootV5    = aireasoningprocess.HandoffRootV5
 )
 
 var reasoningVersions = []struct {
@@ -40,6 +42,7 @@ var reasoningVersions = []struct {
 	{aireasoningprocess.TemplateVersionV2, aireasoningprocess.HandoffRootV2},
 	{reasoningVersionV3, reasoningRootV3},
 	{reasoningVersionV4, reasoningRootV4},
+	{reasoningVersionV5, reasoningRootV5},
 }
 
 // boundedReasoningVersions skips the pre-#667 V1, which has no bounds to assert.
@@ -56,7 +59,8 @@ func newRegistry(t *testing.T) *cardtmpl.Registry {
 	reg.RegisterJSON(aireasoningprocess.Assets, aireasoningprocess.HandoffRootV2)
 	reg.RegisterJSON(aireasoningprocess.Assets, reasoningRootV3)
 	reg.RegisterJSON(aireasoningprocess.Assets, reasoningRootV4)
-	reg.SetDefault(aireasoningprocess.TemplateID, reasoningVersionV4)
+	reg.RegisterJSON(aireasoningprocess.Assets, reasoningRootV5)
+	reg.SetDefault(aireasoningprocess.TemplateID, reasoningVersionV5)
 	reg.Freeze()
 	return reg
 }
@@ -90,21 +94,22 @@ func TestRegistersAllVersionsAndDefaultsToSimplifiedSuccessor(t *testing.T) {
 		aireasoningprocess.TemplateVersionV2,
 		reasoningVersionV3,
 		reasoningVersionV4,
+		reasoningVersionV5,
 	}
 	if !equalStrings(versions, wantVersions) {
 		t.Fatalf("registered versions = %v, want %v", versions, wantVersions)
 	}
-	if aireasoningprocess.TemplateVersion != reasoningVersionV4 || aireasoningprocess.HandoffRoot != reasoningRootV4 {
+	if aireasoningprocess.TemplateVersion != reasoningVersionV5 || aireasoningprocess.HandoffRoot != reasoningRootV5 {
 		t.Fatalf("current aliases = %s / %s, want %s / %s",
-			aireasoningprocess.TemplateVersion, aireasoningprocess.HandoffRoot, reasoningVersionV4, reasoningRootV4)
+			aireasoningprocess.TemplateVersion, aireasoningprocess.HandoffRoot, reasoningVersionV5, reasoningRootV5)
 	}
 
 	tmpl, err := reg.Lookup(aireasoningprocess.TemplateID, "")
 	if err != nil {
 		t.Fatalf("Lookup(default): %v", err)
 	}
-	if got := tmpl.Meta().Version; got != reasoningVersionV4 {
-		t.Fatalf("default version = %q, want %q", got, reasoningVersionV4)
+	if got := tmpl.Meta().Version; got != reasoningVersionV5 {
+		t.Fatalf("default version = %q, want %q", got, reasoningVersionV5)
 	}
 }
 
@@ -531,7 +536,7 @@ func worstCasePhases(thoughtMax int) []any {
 // reasoningThoughtMax is the per-version `phases[].thought` *accept* ceiling —
 // the schema maxLength above which a payload is rejected outright. V2/V3 pinned it
 // to the producer's observed output (280 + `…` = 281) and have no truncation, so
-// for them accept == display. V4 separates the two: it accepts up to 4001 and
+// for them accept == display. V4 and V5 separate the two: they accept up to 4001 and
 // clamps to reasoningThoughtDisplayMax at render time, so an over-long summary
 // degrades to truncated text instead of failing the card.
 //
@@ -543,7 +548,7 @@ func reasoningThoughtMax(t *testing.T, version string) int {
 	switch version {
 	case aireasoningprocess.TemplateVersionV2, reasoningVersionV3:
 		return 281
-	case reasoningVersionV4:
+	case reasoningVersionV4, reasoningVersionV5:
 		return 4001
 	default:
 		t.Fatalf("reasoningThoughtMax: unhandled version %q — add its ceiling explicitly", version)
@@ -551,14 +556,16 @@ func reasoningThoughtMax(t *testing.T, version string) int {
 	}
 }
 
-// reasoningThoughtDisplayMax is V4's rendered ceiling, declared in the schema as
+// reasoningThoughtDisplayMax is V4/V5's rendered ceiling, declared in the schema as
 // x-octo-constraints.truncateStrings. It is what actually bounds the frame, so it
 // — not the accept ceiling — is the number the persistence budget is sized against.
 const reasoningThoughtDisplayMax = 400
 
 // reasoningThoughtTruncates reports whether a version clamps instead of rejecting
-// above its display ceiling. Only V4 does.
-func reasoningThoughtTruncates(version string) bool { return version == reasoningVersionV4 }
+// above its display ceiling. Only V4/V5 do.
+func reasoningThoughtTruncates(version string) bool {
+	return version == reasoningVersionV4 || version == reasoningVersionV5
+}
 
 func renderData(reg *cardtmpl.Registry, version string, state cardtmpl.State, data map[string]any) error {
 	raw, err := json.Marshal(data)

--- a/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.4.1/contract/data.schema.json
+++ b/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.4.1/contract/data.schema.json
@@ -1,0 +1,269 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "推理过程卡数据契约",
+  "description": "AI 推理过程附件的展示型 ViewModel。消息作者、头像、时间与最终 Markdown 回答由消息容器负责，不进入卡片契约。",
+  "x-octo-constraints": {
+    "aggregateArrayLimits": [
+      {
+        "parentArray": "phases",
+        "childArray": "actions",
+        "maxTotalItems": 13
+      }
+    ],
+    "truncateStrings": [
+      {
+        "arrayField": "phases",
+        "field": "thought",
+        "maxRunes": 400,
+        "ellipsis": "…"
+      }
+    ]
+  },
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "reasoningId",
+    "state",
+    "title",
+    "statusLabel",
+    "statusTone",
+    "traceExpanded",
+    "traceCollapsed",
+    "collapsedSummary",
+    "phases"
+  ],
+  "properties": {
+    "reasoningId": {
+      "type": "string",
+      "minLength": 1,
+      "description": "本轮推理的稳定标识。",
+      "examples": [
+        "reasoning-channel-b-001"
+      ],
+      "maxLength": 512
+    },
+    "state": {
+      "type": "string",
+      "enum": [
+        "reasoning",
+        "answering",
+        "completed",
+        "stopped",
+        "error"
+      ],
+      "description": "卡片当前状态；宿主据此选择 active、result 或 error View。"
+    },
+    "title": {
+      "type": "string",
+      "minLength": 1,
+      "description": "推理卡标题。",
+      "examples": [
+        "深度思考"
+      ],
+      "maxLength": 64
+    },
+    "statusLabel": {
+      "type": "string",
+      "minLength": 1,
+      "description": "面向用户的状态文案。",
+      "maxLength": 32
+    },
+    "statusTone": {
+      "type": "string",
+      "enum": [
+        "Accent",
+        "Good",
+        "Warning",
+        "Attention"
+      ],
+      "description": "Adaptive Cards 标准语义色。"
+    },
+    "timerText": {
+      "type": "string",
+      "minLength": 1,
+      "description": "兼容旧版数据的耗时与阶段摘要；精简版不展示此字段。",
+      "maxLength": 128
+    },
+    "traceExpanded": {
+      "type": "boolean",
+      "description": "初始是否展示推理明细。"
+    },
+    "traceCollapsed": {
+      "type": "boolean",
+      "description": "初始是否展示收起摘要；应与 traceExpanded 互斥。"
+    },
+    "collapsedSummary": {
+      "type": "string",
+      "minLength": 1,
+      "description": "推理明细收起时的摘要。",
+      "maxLength": 160
+    },
+    "progressText": {
+      "type": "string",
+      "minLength": 1,
+      "description": "活动态底部的实时进度提示。",
+      "maxLength": 160
+    },
+    "phases": {
+      "type": "array",
+      "minItems": 1,
+      "description": "按发生顺序排列的推理阶段。仅包含可向用户展示的过程摘要，不承载隐藏的模型内部思维。",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "thought",
+          "actions"
+        ],
+        "properties": {
+          "thought": {
+            "type": "string",
+            "minLength": 1,
+            "description": "该阶段面向用户的推理摘要。展示上限 400 码点（见 x-octo-constraints.truncateStrings）；超出部分由服务端截断并追加省略号，不报错。此处的 maxLength 是受理上限，仅用于拒绝病态超长载荷。",
+            "maxLength": 4001
+          },
+          "actions": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "tool",
+                "detail",
+                "statusGlyph",
+                "statusTone"
+              ],
+              "properties": {
+                "tool": {
+                  "type": "string",
+                  "minLength": 1,
+                  "description": "工具或步骤名称。",
+                  "maxLength": 81
+                },
+                "detail": {
+                  "type": "string",
+                  "minLength": 1,
+                  "description": "已脱敏的调用摘要。",
+                  "maxLength": 192
+                },
+                "statusGlyph": {
+                  "type": "string",
+                  "minLength": 1,
+                  "maxLength": 2,
+                  "description": "调用状态符号，例如 ●。"
+                },
+                "statusTone": {
+                  "type": "string",
+                  "enum": [
+                    "Accent",
+                    "Good",
+                    "Attention"
+                  ],
+                  "description": "工具调用状态的标准语义色。"
+                }
+              }
+            },
+            "maxItems": 12
+          }
+        }
+      },
+      "maxItems": 6
+    },
+    "errorTitle": {
+      "type": "string",
+      "minLength": 1,
+      "description": "失败态标题。",
+      "maxLength": 64
+    },
+    "errorMessage": {
+      "type": "string",
+      "minLength": 1,
+      "description": "失败原因与用户可采取动作。",
+      "maxLength": 121
+    }
+  },
+  "allOf": [
+    {
+      "oneOf": [
+        {
+          "properties": {
+            "traceExpanded": {
+              "const": true
+            },
+            "traceCollapsed": {
+              "const": false
+            }
+          }
+        },
+        {
+          "properties": {
+            "traceExpanded": {
+              "const": false
+            },
+            "traceCollapsed": {
+              "const": true
+            }
+          }
+        }
+      ]
+    },
+    {
+      "if": {
+        "properties": {
+          "state": {
+            "enum": [
+              "reasoning",
+              "answering"
+            ]
+          }
+        }
+      },
+      "then": {
+        "required": [
+          "progressText"
+        ]
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "state": {
+            "const": "error"
+          }
+        }
+      },
+      "then": {
+        "required": [
+          "errorTitle",
+          "errorMessage"
+        ]
+      }
+    }
+  ],
+  "examples": [
+    {
+      "reasoningId": "reasoning-channel-b-001",
+      "state": "completed",
+      "title": "深度思考",
+      "statusLabel": "已完成",
+      "statusTone": "Good",
+      "traceExpanded": false,
+      "traceCollapsed": true,
+      "collapsedSummary": "已思考 12 秒",
+      "phases": [
+        {
+          "thought": "先拆解漏斗并核对近 90 天数据。",
+          "actions": [
+            {
+              "tool": "query_metrics",
+              "detail": "channel=B · range=90d",
+              "statusGlyph": "●",
+              "statusTone": "Good"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.4.1/goldens/answering.card.json
+++ b/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.4.1/goldens/answering.card.json
@@ -1,0 +1,935 @@
+{
+  "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+  "body": [
+    {
+      "bleed": true,
+      "items": [
+        {
+          "columns": [
+            {
+              "items": [
+                {
+                  "columns": [
+                    {
+                      "items": [
+                        {
+                          "size": "Small",
+                          "spacing": "None",
+                          "text": "深度思考",
+                          "type": "TextBlock",
+                          "weight": "Bolder",
+                          "wrap": true
+                        }
+                      ],
+                      "type": "Column",
+                      "width": "auto"
+                    },
+                    {
+                      "items": [
+                        {
+                          "altText": "展开",
+                          "id": "reasoning_toggle_collapsed",
+                          "isVisible": false,
+                          "selectAction": {
+                            "id": "reasoning_toggle",
+                            "targetElements": [
+                              "trace_panel",
+                              "collapsed_panel",
+                              "reasoning_toggle_collapsed",
+                              "reasoning_toggle_expanded"
+                            ],
+                            "type": "Action.ToggleVisibility"
+                          },
+                          "size": "Small",
+                          "spacing": "None",
+                          "type": "Image",
+                          "url": "data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%221em%22%20height%3D%221em%22%20viewBox%3D%220%200%2024%2024%22%3E%3Cpath%20fill%3D%22none%22%20stroke%3D%22%23a1a6ab%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20stroke-width%3D%222%22%20d%3D%22m6%209l6%206l6-6%22%2F%3E%3C%2Fsvg%3E",
+                          "width": "14px"
+                        },
+                        {
+                          "altText": "收起",
+                          "id": "reasoning_toggle_expanded",
+                          "isVisible": true,
+                          "selectAction": {
+                            "id": "reasoning_toggle_expanded_action",
+                            "targetElements": [
+                              "trace_panel",
+                              "collapsed_panel",
+                              "reasoning_toggle_collapsed",
+                              "reasoning_toggle_expanded"
+                            ],
+                            "type": "Action.ToggleVisibility"
+                          },
+                          "size": "Small",
+                          "spacing": "None",
+                          "type": "Image",
+                          "url": "data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%221em%22%20height%3D%221em%22%20viewBox%3D%220%200%2024%2024%22%3E%3Cpath%20fill%3D%22none%22%20stroke%3D%22%23a1a6ab%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20stroke-width%3D%222%22%20d%3D%22m18%2015l-6-6l-6%206%22%2F%3E%3C%2Fsvg%3E",
+                          "width": "14px"
+                        }
+                      ],
+                      "type": "Column",
+                      "verticalContentAlignment": "Center",
+                      "width": "auto"
+                    }
+                  ],
+                  "spacing": "None",
+                  "type": "ColumnSet"
+                },
+                {
+                  "color": "Accent",
+                  "size": "Small",
+                  "spacing": "None",
+                  "text": "回答中",
+                  "type": "TextBlock",
+                  "wrap": true
+                }
+              ],
+              "type": "Column",
+              "width": "stretch"
+            }
+          ],
+          "id": "reasoning_header",
+          "spacing": "None",
+          "type": "ColumnSet"
+        },
+        {
+          "id": "trace_panel",
+          "isVisible": true,
+          "items": [
+            {
+              "id": "reasoning_phase_0",
+              "items": [
+                {
+                  "columns": [
+                    {
+                      "items": [
+                        {
+                          "size": "Small",
+                          "spacing": "None",
+                          "text": "先拆分线索、试用激活与付费三段漏斗，核对近 90 天数据。",
+                          "type": "TextBlock",
+                          "wrap": true
+                        }
+                      ],
+                      "type": "Column",
+                      "verticalContentAlignment": "Center",
+                      "width": "stretch"
+                    },
+                    {
+                      "items": [
+                        {
+                          "altText": "展开工具",
+                          "id": "reasoning_tools_toggle_collapsed_0",
+                          "isVisible": true,
+                          "selectAction": {
+                            "id": "reasoning_tools_toggle_action_0",
+                            "targetElements": [
+                              "reasoning_tools_panel_0",
+                              "reasoning_tools_toggle_collapsed_0",
+                              "reasoning_tools_toggle_expanded_0"
+                            ],
+                            "type": "Action.ToggleVisibility"
+                          },
+                          "size": "Small",
+                          "spacing": "None",
+                          "type": "Image",
+                          "url": "data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%221em%22%20height%3D%221em%22%20viewBox%3D%220%200%2024%2024%22%3E%3Cpath%20fill%3D%22none%22%20stroke%3D%22%23a1a6ab%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20stroke-width%3D%222%22%20d%3D%22m6%209l6%206l6-6%22%2F%3E%3C%2Fsvg%3E",
+                          "width": "14px"
+                        },
+                        {
+                          "altText": "收起工具",
+                          "id": "reasoning_tools_toggle_expanded_0",
+                          "isVisible": false,
+                          "selectAction": {
+                            "id": "reasoning_tools_toggle_expanded_action_0",
+                            "targetElements": [
+                              "reasoning_tools_panel_0",
+                              "reasoning_tools_toggle_collapsed_0",
+                              "reasoning_tools_toggle_expanded_0"
+                            ],
+                            "type": "Action.ToggleVisibility"
+                          },
+                          "size": "Small",
+                          "spacing": "None",
+                          "type": "Image",
+                          "url": "data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%221em%22%20height%3D%221em%22%20viewBox%3D%220%200%2024%2024%22%3E%3Cpath%20fill%3D%22none%22%20stroke%3D%22%23a1a6ab%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20stroke-width%3D%222%22%20d%3D%22m18%2015l-6-6l-6%206%22%2F%3E%3C%2Fsvg%3E",
+                          "width": "14px"
+                        }
+                      ],
+                      "type": "Column",
+                      "verticalContentAlignment": "Center",
+                      "width": "auto"
+                    }
+                  ],
+                  "spacing": "None",
+                  "type": "ColumnSet"
+                },
+                {
+                  "id": "reasoning_tools_panel_0",
+                  "isVisible": false,
+                  "items": [
+                    {
+                      "columns": [
+                        {
+                          "items": [],
+                          "type": "Column",
+                          "width": "8px"
+                        },
+                        {
+                          "items": [
+                            {
+                              "color": "Good",
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "●",
+                              "type": "TextBlock"
+                            }
+                          ],
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "query_metrics",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "isSubtle": true,
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "channel=B · range=90d · group=stage",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "stretch"
+                        }
+                      ],
+                      "spacing": "None",
+                      "type": "ColumnSet"
+                    },
+                    {
+                      "columns": [
+                        {
+                          "items": [],
+                          "type": "Column",
+                          "width": "8px"
+                        },
+                        {
+                          "items": [
+                            {
+                              "color": "Good",
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "●",
+                              "type": "TextBlock"
+                            }
+                          ],
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "read_file",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "isSubtle": true,
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "~/analytics/funnel_definition.sql · ×2",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "stretch"
+                        }
+                      ],
+                      "spacing": "Small",
+                      "type": "ColumnSet"
+                    },
+                    {
+                      "columns": [
+                        {
+                          "items": [],
+                          "type": "Column",
+                          "width": "8px"
+                        },
+                        {
+                          "items": [
+                            {
+                              "color": "Good",
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "●",
+                              "type": "TextBlock"
+                            }
+                          ],
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "run_sql",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "isSubtle": true,
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "按漏斗阶段汇总数量与转化率",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "stretch"
+                        }
+                      ],
+                      "spacing": "Small",
+                      "type": "ColumnSet"
+                    }
+                  ],
+                  "spacing": "Small",
+                  "type": "Container"
+                }
+              ],
+              "spacing": "None",
+              "type": "Container"
+            },
+            {
+              "id": "reasoning_phase_1",
+              "items": [
+                {
+                  "columns": [
+                    {
+                      "items": [
+                        {
+                          "size": "Small",
+                          "spacing": "None",
+                          "text": "激活率的降幅高于线索量，交叉核验行业结构、客服工单、NPS 与季节性。",
+                          "type": "TextBlock",
+                          "wrap": true
+                        }
+                      ],
+                      "type": "Column",
+                      "verticalContentAlignment": "Center",
+                      "width": "stretch"
+                    },
+                    {
+                      "items": [
+                        {
+                          "altText": "展开工具",
+                          "id": "reasoning_tools_toggle_collapsed_1",
+                          "isVisible": true,
+                          "selectAction": {
+                            "id": "reasoning_tools_toggle_action_1",
+                            "targetElements": [
+                              "reasoning_tools_panel_1",
+                              "reasoning_tools_toggle_collapsed_1",
+                              "reasoning_tools_toggle_expanded_1"
+                            ],
+                            "type": "Action.ToggleVisibility"
+                          },
+                          "size": "Small",
+                          "spacing": "None",
+                          "type": "Image",
+                          "url": "data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%221em%22%20height%3D%221em%22%20viewBox%3D%220%200%2024%2024%22%3E%3Cpath%20fill%3D%22none%22%20stroke%3D%22%23a1a6ab%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20stroke-width%3D%222%22%20d%3D%22m6%209l6%206l6-6%22%2F%3E%3C%2Fsvg%3E",
+                          "width": "14px"
+                        },
+                        {
+                          "altText": "收起工具",
+                          "id": "reasoning_tools_toggle_expanded_1",
+                          "isVisible": false,
+                          "selectAction": {
+                            "id": "reasoning_tools_toggle_expanded_action_1",
+                            "targetElements": [
+                              "reasoning_tools_panel_1",
+                              "reasoning_tools_toggle_collapsed_1",
+                              "reasoning_tools_toggle_expanded_1"
+                            ],
+                            "type": "Action.ToggleVisibility"
+                          },
+                          "size": "Small",
+                          "spacing": "None",
+                          "type": "Image",
+                          "url": "data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%221em%22%20height%3D%221em%22%20viewBox%3D%220%200%2024%2024%22%3E%3Cpath%20fill%3D%22none%22%20stroke%3D%22%23a1a6ab%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20stroke-width%3D%222%22%20d%3D%22m18%2015l-6-6l-6%206%22%2F%3E%3C%2Fsvg%3E",
+                          "width": "14px"
+                        }
+                      ],
+                      "type": "Column",
+                      "verticalContentAlignment": "Center",
+                      "width": "auto"
+                    }
+                  ],
+                  "spacing": "None",
+                  "type": "ColumnSet"
+                },
+                {
+                  "id": "reasoning_tools_panel_1",
+                  "isVisible": false,
+                  "items": [
+                    {
+                      "columns": [
+                        {
+                          "items": [],
+                          "type": "Column",
+                          "width": "8px"
+                        },
+                        {
+                          "items": [
+                            {
+                              "color": "Good",
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "●",
+                              "type": "TextBlock"
+                            }
+                          ],
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "query_metrics",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "isSubtle": true,
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "按行业拆分激活率",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "stretch"
+                        }
+                      ],
+                      "spacing": "None",
+                      "type": "ColumnSet"
+                    },
+                    {
+                      "columns": [
+                        {
+                          "items": [],
+                          "type": "Column",
+                          "width": "8px"
+                        },
+                        {
+                          "items": [
+                            {
+                              "color": "Good",
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "●",
+                              "type": "TextBlock"
+                            }
+                          ],
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "search_tickets",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "isSubtle": true,
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "渠道 B · 试用 / 激活失败 · 近 60 天",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "stretch"
+                        }
+                      ],
+                      "spacing": "Small",
+                      "type": "ColumnSet"
+                    },
+                    {
+                      "columns": [
+                        {
+                          "items": [],
+                          "type": "Column",
+                          "width": "8px"
+                        },
+                        {
+                          "items": [
+                            {
+                              "color": "Good",
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "●",
+                              "type": "TextBlock"
+                            }
+                          ],
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "read_file",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "isSubtle": true,
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "~/nps/2026Q2_channelB.csv",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "stretch"
+                        }
+                      ],
+                      "spacing": "Small",
+                      "type": "ColumnSet"
+                    },
+                    {
+                      "columns": [
+                        {
+                          "items": [],
+                          "type": "Column",
+                          "width": "8px"
+                        },
+                        {
+                          "items": [
+                            {
+                              "color": "Good",
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "●",
+                              "type": "TextBlock"
+                            }
+                          ],
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "query_metrics",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "isSubtle": true,
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "叠加节假日与季节性校正",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "stretch"
+                        }
+                      ],
+                      "spacing": "Small",
+                      "type": "ColumnSet"
+                    }
+                  ],
+                  "spacing": "Small",
+                  "type": "Container"
+                }
+              ],
+              "spacing": "Small",
+              "type": "Container"
+            },
+            {
+              "id": "reasoning_phase_2",
+              "items": [
+                {
+                  "columns": [
+                    {
+                      "items": [
+                        {
+                          "size": "Small",
+                          "spacing": "None",
+                          "text": "主因确认：教育与专业服务合计贡献 63% 降幅，激活断点集中在试用权益触达。",
+                          "type": "TextBlock",
+                          "wrap": true
+                        }
+                      ],
+                      "type": "Column",
+                      "verticalContentAlignment": "Center",
+                      "width": "stretch"
+                    },
+                    {
+                      "items": [
+                        {
+                          "altText": "展开工具",
+                          "id": "reasoning_tools_toggle_collapsed_2",
+                          "isVisible": true,
+                          "selectAction": {
+                            "id": "reasoning_tools_toggle_action_2",
+                            "targetElements": [
+                              "reasoning_tools_panel_2",
+                              "reasoning_tools_toggle_collapsed_2",
+                              "reasoning_tools_toggle_expanded_2"
+                            ],
+                            "type": "Action.ToggleVisibility"
+                          },
+                          "size": "Small",
+                          "spacing": "None",
+                          "type": "Image",
+                          "url": "data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%221em%22%20height%3D%221em%22%20viewBox%3D%220%200%2024%2024%22%3E%3Cpath%20fill%3D%22none%22%20stroke%3D%22%23a1a6ab%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20stroke-width%3D%222%22%20d%3D%22m6%209l6%206l6-6%22%2F%3E%3C%2Fsvg%3E",
+                          "width": "14px"
+                        },
+                        {
+                          "altText": "收起工具",
+                          "id": "reasoning_tools_toggle_expanded_2",
+                          "isVisible": false,
+                          "selectAction": {
+                            "id": "reasoning_tools_toggle_expanded_action_2",
+                            "targetElements": [
+                              "reasoning_tools_panel_2",
+                              "reasoning_tools_toggle_collapsed_2",
+                              "reasoning_tools_toggle_expanded_2"
+                            ],
+                            "type": "Action.ToggleVisibility"
+                          },
+                          "size": "Small",
+                          "spacing": "None",
+                          "type": "Image",
+                          "url": "data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%221em%22%20height%3D%221em%22%20viewBox%3D%220%200%2024%2024%22%3E%3Cpath%20fill%3D%22none%22%20stroke%3D%22%23a1a6ab%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20stroke-width%3D%222%22%20d%3D%22m18%2015l-6-6l-6%206%22%2F%3E%3C%2Fsvg%3E",
+                          "width": "14px"
+                        }
+                      ],
+                      "type": "Column",
+                      "verticalContentAlignment": "Center",
+                      "width": "auto"
+                    }
+                  ],
+                  "spacing": "None",
+                  "type": "ColumnSet"
+                },
+                {
+                  "id": "reasoning_tools_panel_2",
+                  "isVisible": false,
+                  "items": [
+                    {
+                      "columns": [
+                        {
+                          "items": [],
+                          "type": "Column",
+                          "width": "8px"
+                        },
+                        {
+                          "items": [
+                            {
+                              "color": "Good",
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "●",
+                              "type": "TextBlock"
+                            }
+                          ],
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "run_sql",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "isSubtle": true,
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "按行业汇总转化降幅贡献",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "stretch"
+                        }
+                      ],
+                      "spacing": "None",
+                      "type": "ColumnSet"
+                    },
+                    {
+                      "columns": [
+                        {
+                          "items": [],
+                          "type": "Column",
+                          "width": "8px"
+                        },
+                        {
+                          "items": [
+                            {
+                              "color": "Good",
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "●",
+                              "type": "TextBlock"
+                            }
+                          ],
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "edit_file",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "isSubtle": true,
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "~/reports/channelB_rootcause.md · 已编辑",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "stretch"
+                        }
+                      ],
+                      "spacing": "Small",
+                      "type": "ColumnSet"
+                    },
+                    {
+                      "columns": [
+                        {
+                          "items": [],
+                          "type": "Column",
+                          "width": "8px"
+                        },
+                        {
+                          "items": [
+                            {
+                              "color": "Accent",
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "●",
+                              "type": "TextBlock"
+                            }
+                          ],
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "think",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "isSubtle": true,
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "正在组织结论、证据与下周建议…",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "stretch"
+                        }
+                      ],
+                      "spacing": "Small",
+                      "type": "ColumnSet"
+                    }
+                  ],
+                  "spacing": "Small",
+                  "type": "Container"
+                }
+              ],
+              "spacing": "Small",
+              "type": "Container"
+            },
+            {
+              "color": "Accent",
+              "size": "Small",
+              "spacing": "Medium",
+              "text": "◌  推理已完成，正在生成回答…",
+              "type": "TextBlock",
+              "wrap": true
+            }
+          ],
+          "spacing": "Medium",
+          "type": "Container"
+        },
+        {
+          "id": "collapsed_panel",
+          "isVisible": false,
+          "items": [
+            {
+              "isSubtle": true,
+              "size": "Small",
+              "spacing": "None",
+              "text": "正在生成回答",
+              "type": "TextBlock",
+              "wrap": true
+            }
+          ],
+          "spacing": "Small",
+          "type": "Container"
+        }
+      ],
+      "spacing": "None",
+      "style": "emphasis",
+      "type": "Container"
+    }
+  ],
+  "type": "AdaptiveCard",
+  "version": "1.5"
+}

--- a/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.4.1/goldens/completed.card.json
+++ b/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.4.1/goldens/completed.card.json
@@ -1,0 +1,1095 @@
+{
+  "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+  "body": [
+    {
+      "bleed": true,
+      "items": [
+        {
+          "columns": [
+            {
+              "items": [
+                {
+                  "columns": [
+                    {
+                      "items": [
+                        {
+                          "size": "Small",
+                          "spacing": "None",
+                          "text": "深度思考",
+                          "type": "TextBlock",
+                          "weight": "Bolder",
+                          "wrap": true
+                        }
+                      ],
+                      "type": "Column",
+                      "width": "auto"
+                    },
+                    {
+                      "items": [
+                        {
+                          "altText": "展开",
+                          "id": "reasoning_toggle_collapsed",
+                          "isVisible": true,
+                          "selectAction": {
+                            "id": "reasoning_toggle",
+                            "targetElements": [
+                              "trace_panel",
+                              "collapsed_panel",
+                              "reasoning_toggle_collapsed",
+                              "reasoning_toggle_expanded"
+                            ],
+                            "type": "Action.ToggleVisibility"
+                          },
+                          "size": "Small",
+                          "spacing": "None",
+                          "type": "Image",
+                          "url": "data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%221em%22%20height%3D%221em%22%20viewBox%3D%220%200%2024%2024%22%3E%3Cpath%20fill%3D%22none%22%20stroke%3D%22%23a1a6ab%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20stroke-width%3D%222%22%20d%3D%22m6%209l6%206l6-6%22%2F%3E%3C%2Fsvg%3E",
+                          "width": "14px"
+                        },
+                        {
+                          "altText": "收起",
+                          "id": "reasoning_toggle_expanded",
+                          "isVisible": false,
+                          "selectAction": {
+                            "id": "reasoning_toggle_expanded_action",
+                            "targetElements": [
+                              "trace_panel",
+                              "collapsed_panel",
+                              "reasoning_toggle_collapsed",
+                              "reasoning_toggle_expanded"
+                            ],
+                            "type": "Action.ToggleVisibility"
+                          },
+                          "size": "Small",
+                          "spacing": "None",
+                          "type": "Image",
+                          "url": "data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%221em%22%20height%3D%221em%22%20viewBox%3D%220%200%2024%2024%22%3E%3Cpath%20fill%3D%22none%22%20stroke%3D%22%23a1a6ab%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20stroke-width%3D%222%22%20d%3D%22m18%2015l-6-6l-6%206%22%2F%3E%3C%2Fsvg%3E",
+                          "width": "14px"
+                        }
+                      ],
+                      "type": "Column",
+                      "verticalContentAlignment": "Center",
+                      "width": "auto"
+                    }
+                  ],
+                  "spacing": "None",
+                  "type": "ColumnSet"
+                },
+                {
+                  "color": "Good",
+                  "size": "Small",
+                  "spacing": "None",
+                  "text": "已完成",
+                  "type": "TextBlock",
+                  "wrap": true
+                }
+              ],
+              "type": "Column",
+              "width": "stretch"
+            }
+          ],
+          "id": "reasoning_header",
+          "spacing": "None",
+          "type": "ColumnSet"
+        },
+        {
+          "id": "trace_panel",
+          "isVisible": false,
+          "items": [
+            {
+              "id": "reasoning_phase_0",
+              "items": [
+                {
+                  "columns": [
+                    {
+                      "items": [
+                        {
+                          "size": "Small",
+                          "spacing": "None",
+                          "text": "先把渠道 B 转化下降的范围圈出来：拆成线索、试用激活、付费三段漏斗，取近 90 天数据。",
+                          "type": "TextBlock",
+                          "wrap": true
+                        }
+                      ],
+                      "type": "Column",
+                      "verticalContentAlignment": "Center",
+                      "width": "stretch"
+                    },
+                    {
+                      "items": [
+                        {
+                          "altText": "展开工具",
+                          "id": "reasoning_tools_toggle_collapsed_0",
+                          "isVisible": true,
+                          "selectAction": {
+                            "id": "reasoning_tools_toggle_action_0",
+                            "targetElements": [
+                              "reasoning_tools_panel_0",
+                              "reasoning_tools_toggle_collapsed_0",
+                              "reasoning_tools_toggle_expanded_0"
+                            ],
+                            "type": "Action.ToggleVisibility"
+                          },
+                          "size": "Small",
+                          "spacing": "None",
+                          "type": "Image",
+                          "url": "data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%221em%22%20height%3D%221em%22%20viewBox%3D%220%200%2024%2024%22%3E%3Cpath%20fill%3D%22none%22%20stroke%3D%22%23a1a6ab%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20stroke-width%3D%222%22%20d%3D%22m6%209l6%206l6-6%22%2F%3E%3C%2Fsvg%3E",
+                          "width": "14px"
+                        },
+                        {
+                          "altText": "收起工具",
+                          "id": "reasoning_tools_toggle_expanded_0",
+                          "isVisible": false,
+                          "selectAction": {
+                            "id": "reasoning_tools_toggle_expanded_action_0",
+                            "targetElements": [
+                              "reasoning_tools_panel_0",
+                              "reasoning_tools_toggle_collapsed_0",
+                              "reasoning_tools_toggle_expanded_0"
+                            ],
+                            "type": "Action.ToggleVisibility"
+                          },
+                          "size": "Small",
+                          "spacing": "None",
+                          "type": "Image",
+                          "url": "data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%221em%22%20height%3D%221em%22%20viewBox%3D%220%200%2024%2024%22%3E%3Cpath%20fill%3D%22none%22%20stroke%3D%22%23a1a6ab%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20stroke-width%3D%222%22%20d%3D%22m18%2015l-6-6l-6%206%22%2F%3E%3C%2Fsvg%3E",
+                          "width": "14px"
+                        }
+                      ],
+                      "type": "Column",
+                      "verticalContentAlignment": "Center",
+                      "width": "auto"
+                    }
+                  ],
+                  "spacing": "None",
+                  "type": "ColumnSet"
+                },
+                {
+                  "id": "reasoning_tools_panel_0",
+                  "isVisible": false,
+                  "items": [
+                    {
+                      "columns": [
+                        {
+                          "items": [],
+                          "type": "Column",
+                          "width": "8px"
+                        },
+                        {
+                          "items": [
+                            {
+                              "color": "Good",
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "●",
+                              "type": "TextBlock"
+                            }
+                          ],
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "query_metrics",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "isSubtle": true,
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "channel=B · range=90d · group=stage",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "stretch"
+                        }
+                      ],
+                      "spacing": "None",
+                      "type": "ColumnSet"
+                    },
+                    {
+                      "columns": [
+                        {
+                          "items": [],
+                          "type": "Column",
+                          "width": "8px"
+                        },
+                        {
+                          "items": [
+                            {
+                              "color": "Good",
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "●",
+                              "type": "TextBlock"
+                            }
+                          ],
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "read_file",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "isSubtle": true,
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "~/analytics/funnel_definition.sql · ×2",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "stretch"
+                        }
+                      ],
+                      "spacing": "Small",
+                      "type": "ColumnSet"
+                    },
+                    {
+                      "columns": [
+                        {
+                          "items": [],
+                          "type": "Column",
+                          "width": "8px"
+                        },
+                        {
+                          "items": [
+                            {
+                              "color": "Good",
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "●",
+                              "type": "TextBlock"
+                            }
+                          ],
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "run_sql",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "isSubtle": true,
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "按漏斗阶段汇总数量与转化率",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "stretch"
+                        }
+                      ],
+                      "spacing": "Small",
+                      "type": "ColumnSet"
+                    }
+                  ],
+                  "spacing": "Small",
+                  "type": "Container"
+                }
+              ],
+              "spacing": "None",
+              "type": "Container"
+            },
+            {
+              "id": "reasoning_phase_1",
+              "items": [
+                {
+                  "columns": [
+                    {
+                      "items": [
+                        {
+                          "size": "Small",
+                          "spacing": "None",
+                          "text": "激活率的降幅高于线索量，交叉核验行业结构、客服工单、NPS 与季节性。",
+                          "type": "TextBlock",
+                          "wrap": true
+                        }
+                      ],
+                      "type": "Column",
+                      "verticalContentAlignment": "Center",
+                      "width": "stretch"
+                    },
+                    {
+                      "items": [
+                        {
+                          "altText": "展开工具",
+                          "id": "reasoning_tools_toggle_collapsed_1",
+                          "isVisible": true,
+                          "selectAction": {
+                            "id": "reasoning_tools_toggle_action_1",
+                            "targetElements": [
+                              "reasoning_tools_panel_1",
+                              "reasoning_tools_toggle_collapsed_1",
+                              "reasoning_tools_toggle_expanded_1"
+                            ],
+                            "type": "Action.ToggleVisibility"
+                          },
+                          "size": "Small",
+                          "spacing": "None",
+                          "type": "Image",
+                          "url": "data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%221em%22%20height%3D%221em%22%20viewBox%3D%220%200%2024%2024%22%3E%3Cpath%20fill%3D%22none%22%20stroke%3D%22%23a1a6ab%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20stroke-width%3D%222%22%20d%3D%22m6%209l6%206l6-6%22%2F%3E%3C%2Fsvg%3E",
+                          "width": "14px"
+                        },
+                        {
+                          "altText": "收起工具",
+                          "id": "reasoning_tools_toggle_expanded_1",
+                          "isVisible": false,
+                          "selectAction": {
+                            "id": "reasoning_tools_toggle_expanded_action_1",
+                            "targetElements": [
+                              "reasoning_tools_panel_1",
+                              "reasoning_tools_toggle_collapsed_1",
+                              "reasoning_tools_toggle_expanded_1"
+                            ],
+                            "type": "Action.ToggleVisibility"
+                          },
+                          "size": "Small",
+                          "spacing": "None",
+                          "type": "Image",
+                          "url": "data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%221em%22%20height%3D%221em%22%20viewBox%3D%220%200%2024%2024%22%3E%3Cpath%20fill%3D%22none%22%20stroke%3D%22%23a1a6ab%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20stroke-width%3D%222%22%20d%3D%22m18%2015l-6-6l-6%206%22%2F%3E%3C%2Fsvg%3E",
+                          "width": "14px"
+                        }
+                      ],
+                      "type": "Column",
+                      "verticalContentAlignment": "Center",
+                      "width": "auto"
+                    }
+                  ],
+                  "spacing": "None",
+                  "type": "ColumnSet"
+                },
+                {
+                  "id": "reasoning_tools_panel_1",
+                  "isVisible": false,
+                  "items": [
+                    {
+                      "columns": [
+                        {
+                          "items": [],
+                          "type": "Column",
+                          "width": "8px"
+                        },
+                        {
+                          "items": [
+                            {
+                              "color": "Good",
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "●",
+                              "type": "TextBlock"
+                            }
+                          ],
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "query_metrics",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "isSubtle": true,
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "按行业拆分激活率",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "stretch"
+                        }
+                      ],
+                      "spacing": "None",
+                      "type": "ColumnSet"
+                    },
+                    {
+                      "columns": [
+                        {
+                          "items": [],
+                          "type": "Column",
+                          "width": "8px"
+                        },
+                        {
+                          "items": [
+                            {
+                              "color": "Good",
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "●",
+                              "type": "TextBlock"
+                            }
+                          ],
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "run_sql",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "isSubtle": true,
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "对比各行业激活与付费转化",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "stretch"
+                        }
+                      ],
+                      "spacing": "Small",
+                      "type": "ColumnSet"
+                    },
+                    {
+                      "columns": [
+                        {
+                          "items": [],
+                          "type": "Column",
+                          "width": "8px"
+                        },
+                        {
+                          "items": [
+                            {
+                              "color": "Good",
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "●",
+                              "type": "TextBlock"
+                            }
+                          ],
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "search_tickets",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "isSubtle": true,
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "渠道 B · 试用 / 激活失败 · 近 60 天",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "stretch"
+                        }
+                      ],
+                      "spacing": "Small",
+                      "type": "ColumnSet"
+                    },
+                    {
+                      "columns": [
+                        {
+                          "items": [],
+                          "type": "Column",
+                          "width": "8px"
+                        },
+                        {
+                          "items": [
+                            {
+                              "color": "Good",
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "●",
+                              "type": "TextBlock"
+                            }
+                          ],
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "read_file",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "isSubtle": true,
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "~/nps/2026Q2_channelB.csv",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "stretch"
+                        }
+                      ],
+                      "spacing": "Small",
+                      "type": "ColumnSet"
+                    },
+                    {
+                      "columns": [
+                        {
+                          "items": [],
+                          "type": "Column",
+                          "width": "8px"
+                        },
+                        {
+                          "items": [
+                            {
+                              "color": "Good",
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "●",
+                              "type": "TextBlock"
+                            }
+                          ],
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "query_metrics",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "isSubtle": true,
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "叠加节假日与季节性校正",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "stretch"
+                        }
+                      ],
+                      "spacing": "Small",
+                      "type": "ColumnSet"
+                    },
+                    {
+                      "columns": [
+                        {
+                          "items": [],
+                          "type": "Column",
+                          "width": "8px"
+                        },
+                        {
+                          "items": [
+                            {
+                              "color": "Good",
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "●",
+                              "type": "TextBlock"
+                            }
+                          ],
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "run_sql",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "isSubtle": true,
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "逐周复核线索与激活数量",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "stretch"
+                        }
+                      ],
+                      "spacing": "Small",
+                      "type": "ColumnSet"
+                    },
+                    {
+                      "columns": [
+                        {
+                          "items": [],
+                          "type": "Column",
+                          "width": "8px"
+                        },
+                        {
+                          "items": [
+                            {
+                              "color": "Good",
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "●",
+                              "type": "TextBlock"
+                            }
+                          ],
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "web_search",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "isSubtle": true,
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "SaaS 行业 2026 试用政策调整",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "stretch"
+                        }
+                      ],
+                      "spacing": "Small",
+                      "type": "ColumnSet"
+                    }
+                  ],
+                  "spacing": "Small",
+                  "type": "Container"
+                }
+              ],
+              "spacing": "Small",
+              "type": "Container"
+            },
+            {
+              "id": "reasoning_phase_2",
+              "items": [
+                {
+                  "columns": [
+                    {
+                      "items": [
+                        {
+                          "size": "Small",
+                          "spacing": "None",
+                          "text": "主因确认：教育与专业服务合计贡献 63% 降幅，激活断点集中在试用权益触达。",
+                          "type": "TextBlock",
+                          "wrap": true
+                        }
+                      ],
+                      "type": "Column",
+                      "verticalContentAlignment": "Center",
+                      "width": "stretch"
+                    },
+                    {
+                      "items": [
+                        {
+                          "altText": "展开工具",
+                          "id": "reasoning_tools_toggle_collapsed_2",
+                          "isVisible": true,
+                          "selectAction": {
+                            "id": "reasoning_tools_toggle_action_2",
+                            "targetElements": [
+                              "reasoning_tools_panel_2",
+                              "reasoning_tools_toggle_collapsed_2",
+                              "reasoning_tools_toggle_expanded_2"
+                            ],
+                            "type": "Action.ToggleVisibility"
+                          },
+                          "size": "Small",
+                          "spacing": "None",
+                          "type": "Image",
+                          "url": "data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%221em%22%20height%3D%221em%22%20viewBox%3D%220%200%2024%2024%22%3E%3Cpath%20fill%3D%22none%22%20stroke%3D%22%23a1a6ab%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20stroke-width%3D%222%22%20d%3D%22m6%209l6%206l6-6%22%2F%3E%3C%2Fsvg%3E",
+                          "width": "14px"
+                        },
+                        {
+                          "altText": "收起工具",
+                          "id": "reasoning_tools_toggle_expanded_2",
+                          "isVisible": false,
+                          "selectAction": {
+                            "id": "reasoning_tools_toggle_expanded_action_2",
+                            "targetElements": [
+                              "reasoning_tools_panel_2",
+                              "reasoning_tools_toggle_collapsed_2",
+                              "reasoning_tools_toggle_expanded_2"
+                            ],
+                            "type": "Action.ToggleVisibility"
+                          },
+                          "size": "Small",
+                          "spacing": "None",
+                          "type": "Image",
+                          "url": "data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%221em%22%20height%3D%221em%22%20viewBox%3D%220%200%2024%2024%22%3E%3Cpath%20fill%3D%22none%22%20stroke%3D%22%23a1a6ab%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20stroke-width%3D%222%22%20d%3D%22m18%2015l-6-6l-6%206%22%2F%3E%3C%2Fsvg%3E",
+                          "width": "14px"
+                        }
+                      ],
+                      "type": "Column",
+                      "verticalContentAlignment": "Center",
+                      "width": "auto"
+                    }
+                  ],
+                  "spacing": "None",
+                  "type": "ColumnSet"
+                },
+                {
+                  "id": "reasoning_tools_panel_2",
+                  "isVisible": false,
+                  "items": [
+                    {
+                      "columns": [
+                        {
+                          "items": [],
+                          "type": "Column",
+                          "width": "8px"
+                        },
+                        {
+                          "items": [
+                            {
+                              "color": "Good",
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "●",
+                              "type": "TextBlock"
+                            }
+                          ],
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "run_sql",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "isSubtle": true,
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "按行业汇总转化降幅贡献",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "stretch"
+                        }
+                      ],
+                      "spacing": "None",
+                      "type": "ColumnSet"
+                    },
+                    {
+                      "columns": [
+                        {
+                          "items": [],
+                          "type": "Column",
+                          "width": "8px"
+                        },
+                        {
+                          "items": [
+                            {
+                              "color": "Good",
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "●",
+                              "type": "TextBlock"
+                            }
+                          ],
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "edit_file",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "isSubtle": true,
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "~/reports/channelB_rootcause.md · 已编辑",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "stretch"
+                        }
+                      ],
+                      "spacing": "Small",
+                      "type": "ColumnSet"
+                    },
+                    {
+                      "columns": [
+                        {
+                          "items": [],
+                          "type": "Column",
+                          "width": "8px"
+                        },
+                        {
+                          "items": [
+                            {
+                              "color": "Good",
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "●",
+                              "type": "TextBlock"
+                            }
+                          ],
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "think",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "isSubtle": true,
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "拆分行业漏斗深挖与权益触达复盘",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "stretch"
+                        }
+                      ],
+                      "spacing": "Small",
+                      "type": "ColumnSet"
+                    }
+                  ],
+                  "spacing": "Small",
+                  "type": "Container"
+                }
+              ],
+              "spacing": "Small",
+              "type": "Container"
+            }
+          ],
+          "spacing": "Medium",
+          "type": "Container"
+        },
+        {
+          "id": "collapsed_panel",
+          "isVisible": true,
+          "items": [
+            {
+              "isSubtle": true,
+              "size": "Small",
+              "spacing": "None",
+              "text": "已思考 12 秒",
+              "type": "TextBlock",
+              "wrap": true
+            }
+          ],
+          "spacing": "Small",
+          "type": "Container"
+        }
+      ],
+      "spacing": "None",
+      "style": "emphasis",
+      "type": "Container"
+    }
+  ],
+  "type": "AdaptiveCard",
+  "version": "1.5"
+}

--- a/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.4.1/goldens/error.card.json
+++ b/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.4.1/goldens/error.card.json
@@ -1,0 +1,588 @@
+{
+  "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+  "body": [
+    {
+      "bleed": true,
+      "items": [
+        {
+          "columns": [
+            {
+              "items": [
+                {
+                  "columns": [
+                    {
+                      "items": [
+                        {
+                          "size": "Small",
+                          "spacing": "None",
+                          "text": "深度思考",
+                          "type": "TextBlock",
+                          "weight": "Bolder",
+                          "wrap": true
+                        }
+                      ],
+                      "type": "Column",
+                      "width": "auto"
+                    },
+                    {
+                      "items": [
+                        {
+                          "altText": "展开",
+                          "id": "reasoning_toggle_collapsed",
+                          "isVisible": false,
+                          "selectAction": {
+                            "id": "reasoning_toggle",
+                            "targetElements": [
+                              "trace_panel",
+                              "collapsed_panel",
+                              "reasoning_toggle_collapsed",
+                              "reasoning_toggle_expanded"
+                            ],
+                            "type": "Action.ToggleVisibility"
+                          },
+                          "size": "Small",
+                          "spacing": "None",
+                          "type": "Image",
+                          "url": "data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%221em%22%20height%3D%221em%22%20viewBox%3D%220%200%2024%2024%22%3E%3Cpath%20fill%3D%22none%22%20stroke%3D%22%23a1a6ab%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20stroke-width%3D%222%22%20d%3D%22m6%209l6%206l6-6%22%2F%3E%3C%2Fsvg%3E",
+                          "width": "14px"
+                        },
+                        {
+                          "altText": "收起",
+                          "id": "reasoning_toggle_expanded",
+                          "isVisible": true,
+                          "selectAction": {
+                            "id": "reasoning_toggle_expanded_action",
+                            "targetElements": [
+                              "trace_panel",
+                              "collapsed_panel",
+                              "reasoning_toggle_collapsed",
+                              "reasoning_toggle_expanded"
+                            ],
+                            "type": "Action.ToggleVisibility"
+                          },
+                          "size": "Small",
+                          "spacing": "None",
+                          "type": "Image",
+                          "url": "data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%221em%22%20height%3D%221em%22%20viewBox%3D%220%200%2024%2024%22%3E%3Cpath%20fill%3D%22none%22%20stroke%3D%22%23a1a6ab%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20stroke-width%3D%222%22%20d%3D%22m18%2015l-6-6l-6%206%22%2F%3E%3C%2Fsvg%3E",
+                          "width": "14px"
+                        }
+                      ],
+                      "type": "Column",
+                      "verticalContentAlignment": "Center",
+                      "width": "auto"
+                    }
+                  ],
+                  "spacing": "None",
+                  "type": "ColumnSet"
+                },
+                {
+                  "color": "Attention",
+                  "size": "Small",
+                  "spacing": "None",
+                  "text": "生成失败",
+                  "type": "TextBlock",
+                  "wrap": true
+                }
+              ],
+              "type": "Column",
+              "width": "stretch"
+            }
+          ],
+          "id": "reasoning_header",
+          "spacing": "None",
+          "type": "ColumnSet"
+        },
+        {
+          "id": "trace_panel",
+          "isVisible": true,
+          "items": [
+            {
+              "id": "reasoning_phase_0",
+              "items": [
+                {
+                  "columns": [
+                    {
+                      "items": [
+                        {
+                          "size": "Small",
+                          "spacing": "None",
+                          "text": "先拆分线索、试用激活与付费三段漏斗，核对近 90 天数据。",
+                          "type": "TextBlock",
+                          "wrap": true
+                        }
+                      ],
+                      "type": "Column",
+                      "verticalContentAlignment": "Center",
+                      "width": "stretch"
+                    },
+                    {
+                      "items": [
+                        {
+                          "altText": "展开工具",
+                          "id": "reasoning_tools_toggle_collapsed_0",
+                          "isVisible": true,
+                          "selectAction": {
+                            "id": "reasoning_tools_toggle_action_0",
+                            "targetElements": [
+                              "reasoning_tools_panel_0",
+                              "reasoning_tools_toggle_collapsed_0",
+                              "reasoning_tools_toggle_expanded_0"
+                            ],
+                            "type": "Action.ToggleVisibility"
+                          },
+                          "size": "Small",
+                          "spacing": "None",
+                          "type": "Image",
+                          "url": "data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%221em%22%20height%3D%221em%22%20viewBox%3D%220%200%2024%2024%22%3E%3Cpath%20fill%3D%22none%22%20stroke%3D%22%23a1a6ab%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20stroke-width%3D%222%22%20d%3D%22m6%209l6%206l6-6%22%2F%3E%3C%2Fsvg%3E",
+                          "width": "14px"
+                        },
+                        {
+                          "altText": "收起工具",
+                          "id": "reasoning_tools_toggle_expanded_0",
+                          "isVisible": false,
+                          "selectAction": {
+                            "id": "reasoning_tools_toggle_expanded_action_0",
+                            "targetElements": [
+                              "reasoning_tools_panel_0",
+                              "reasoning_tools_toggle_collapsed_0",
+                              "reasoning_tools_toggle_expanded_0"
+                            ],
+                            "type": "Action.ToggleVisibility"
+                          },
+                          "size": "Small",
+                          "spacing": "None",
+                          "type": "Image",
+                          "url": "data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%221em%22%20height%3D%221em%22%20viewBox%3D%220%200%2024%2024%22%3E%3Cpath%20fill%3D%22none%22%20stroke%3D%22%23a1a6ab%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20stroke-width%3D%222%22%20d%3D%22m18%2015l-6-6l-6%206%22%2F%3E%3C%2Fsvg%3E",
+                          "width": "14px"
+                        }
+                      ],
+                      "type": "Column",
+                      "verticalContentAlignment": "Center",
+                      "width": "auto"
+                    }
+                  ],
+                  "spacing": "None",
+                  "type": "ColumnSet"
+                },
+                {
+                  "id": "reasoning_tools_panel_0",
+                  "isVisible": false,
+                  "items": [
+                    {
+                      "columns": [
+                        {
+                          "items": [],
+                          "type": "Column",
+                          "width": "8px"
+                        },
+                        {
+                          "items": [
+                            {
+                              "color": "Good",
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "●",
+                              "type": "TextBlock"
+                            }
+                          ],
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "query_metrics",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "isSubtle": true,
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "channel=B · range=90d · group=stage",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "stretch"
+                        }
+                      ],
+                      "spacing": "None",
+                      "type": "ColumnSet"
+                    },
+                    {
+                      "columns": [
+                        {
+                          "items": [],
+                          "type": "Column",
+                          "width": "8px"
+                        },
+                        {
+                          "items": [
+                            {
+                              "color": "Good",
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "●",
+                              "type": "TextBlock"
+                            }
+                          ],
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "read_file",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "isSubtle": true,
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "~/analytics/funnel_definition.sql · ×2",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "stretch"
+                        }
+                      ],
+                      "spacing": "Small",
+                      "type": "ColumnSet"
+                    },
+                    {
+                      "columns": [
+                        {
+                          "items": [],
+                          "type": "Column",
+                          "width": "8px"
+                        },
+                        {
+                          "items": [
+                            {
+                              "color": "Good",
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "●",
+                              "type": "TextBlock"
+                            }
+                          ],
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "run_sql",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "isSubtle": true,
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "按漏斗阶段汇总数量与转化率",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "stretch"
+                        }
+                      ],
+                      "spacing": "Small",
+                      "type": "ColumnSet"
+                    }
+                  ],
+                  "spacing": "Small",
+                  "type": "Container"
+                }
+              ],
+              "spacing": "None",
+              "type": "Container"
+            },
+            {
+              "id": "reasoning_phase_1",
+              "items": [
+                {
+                  "columns": [
+                    {
+                      "items": [
+                        {
+                          "size": "Small",
+                          "spacing": "None",
+                          "text": "准备交叉核验行业结构、客服工单与 NPS 时，推理服务连接中断。",
+                          "type": "TextBlock",
+                          "wrap": true
+                        }
+                      ],
+                      "type": "Column",
+                      "verticalContentAlignment": "Center",
+                      "width": "stretch"
+                    },
+                    {
+                      "items": [
+                        {
+                          "altText": "展开工具",
+                          "id": "reasoning_tools_toggle_collapsed_1",
+                          "isVisible": true,
+                          "selectAction": {
+                            "id": "reasoning_tools_toggle_action_1",
+                            "targetElements": [
+                              "reasoning_tools_panel_1",
+                              "reasoning_tools_toggle_collapsed_1",
+                              "reasoning_tools_toggle_expanded_1"
+                            ],
+                            "type": "Action.ToggleVisibility"
+                          },
+                          "size": "Small",
+                          "spacing": "None",
+                          "type": "Image",
+                          "url": "data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%221em%22%20height%3D%221em%22%20viewBox%3D%220%200%2024%2024%22%3E%3Cpath%20fill%3D%22none%22%20stroke%3D%22%23a1a6ab%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20stroke-width%3D%222%22%20d%3D%22m6%209l6%206l6-6%22%2F%3E%3C%2Fsvg%3E",
+                          "width": "14px"
+                        },
+                        {
+                          "altText": "收起工具",
+                          "id": "reasoning_tools_toggle_expanded_1",
+                          "isVisible": false,
+                          "selectAction": {
+                            "id": "reasoning_tools_toggle_expanded_action_1",
+                            "targetElements": [
+                              "reasoning_tools_panel_1",
+                              "reasoning_tools_toggle_collapsed_1",
+                              "reasoning_tools_toggle_expanded_1"
+                            ],
+                            "type": "Action.ToggleVisibility"
+                          },
+                          "size": "Small",
+                          "spacing": "None",
+                          "type": "Image",
+                          "url": "data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%221em%22%20height%3D%221em%22%20viewBox%3D%220%200%2024%2024%22%3E%3Cpath%20fill%3D%22none%22%20stroke%3D%22%23a1a6ab%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20stroke-width%3D%222%22%20d%3D%22m18%2015l-6-6l-6%206%22%2F%3E%3C%2Fsvg%3E",
+                          "width": "14px"
+                        }
+                      ],
+                      "type": "Column",
+                      "verticalContentAlignment": "Center",
+                      "width": "auto"
+                    }
+                  ],
+                  "spacing": "None",
+                  "type": "ColumnSet"
+                },
+                {
+                  "id": "reasoning_tools_panel_1",
+                  "isVisible": false,
+                  "items": [
+                    {
+                      "columns": [
+                        {
+                          "items": [],
+                          "type": "Column",
+                          "width": "8px"
+                        },
+                        {
+                          "items": [
+                            {
+                              "color": "Good",
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "●",
+                              "type": "TextBlock"
+                            }
+                          ],
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "query_metrics",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "isSubtle": true,
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "按行业拆分激活率",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "stretch"
+                        }
+                      ],
+                      "spacing": "None",
+                      "type": "ColumnSet"
+                    },
+                    {
+                      "columns": [
+                        {
+                          "items": [],
+                          "type": "Column",
+                          "width": "8px"
+                        },
+                        {
+                          "items": [
+                            {
+                              "color": "Attention",
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "●",
+                              "type": "TextBlock"
+                            }
+                          ],
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "search_tickets",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "isSubtle": true,
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "连接超时，调用未完成",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "stretch"
+                        }
+                      ],
+                      "spacing": "Small",
+                      "type": "ColumnSet"
+                    }
+                  ],
+                  "spacing": "Small",
+                  "type": "Container"
+                }
+              ],
+              "spacing": "Small",
+              "type": "Container"
+            }
+          ],
+          "spacing": "Medium",
+          "type": "Container"
+        },
+        {
+          "id": "collapsed_panel",
+          "isVisible": false,
+          "items": [
+            {
+              "isSubtle": true,
+              "size": "Small",
+              "spacing": "None",
+              "text": "生成已中断",
+              "type": "TextBlock",
+              "wrap": true
+            }
+          ],
+          "spacing": "Small",
+          "type": "Container"
+        },
+        {
+          "items": [
+            {
+              "color": "Attention",
+              "spacing": "None",
+              "text": "生成失败",
+              "type": "TextBlock",
+              "weight": "Bolder",
+              "wrap": true
+            },
+            {
+              "spacing": "Small",
+              "text": "推理服务连接超时，本次生成已结束。已完成的过程会保留。",
+              "type": "TextBlock",
+              "wrap": true
+            }
+          ],
+          "spacing": "Medium",
+          "style": "attention",
+          "type": "Container"
+        }
+      ],
+      "spacing": "None",
+      "style": "emphasis",
+      "type": "Container"
+    }
+  ],
+  "type": "AdaptiveCard",
+  "version": "1.5"
+}

--- a/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.4.1/goldens/reasoning.card.json
+++ b/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.4.1/goldens/reasoning.card.json
@@ -1,0 +1,687 @@
+{
+  "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+  "body": [
+    {
+      "bleed": true,
+      "items": [
+        {
+          "columns": [
+            {
+              "items": [
+                {
+                  "columns": [
+                    {
+                      "items": [
+                        {
+                          "size": "Small",
+                          "spacing": "None",
+                          "text": "深度思考",
+                          "type": "TextBlock",
+                          "weight": "Bolder",
+                          "wrap": true
+                        }
+                      ],
+                      "type": "Column",
+                      "width": "auto"
+                    },
+                    {
+                      "items": [
+                        {
+                          "altText": "展开",
+                          "id": "reasoning_toggle_collapsed",
+                          "isVisible": false,
+                          "selectAction": {
+                            "id": "reasoning_toggle",
+                            "targetElements": [
+                              "trace_panel",
+                              "collapsed_panel",
+                              "reasoning_toggle_collapsed",
+                              "reasoning_toggle_expanded"
+                            ],
+                            "type": "Action.ToggleVisibility"
+                          },
+                          "size": "Small",
+                          "spacing": "None",
+                          "type": "Image",
+                          "url": "data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%221em%22%20height%3D%221em%22%20viewBox%3D%220%200%2024%2024%22%3E%3Cpath%20fill%3D%22none%22%20stroke%3D%22%23a1a6ab%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20stroke-width%3D%222%22%20d%3D%22m6%209l6%206l6-6%22%2F%3E%3C%2Fsvg%3E",
+                          "width": "14px"
+                        },
+                        {
+                          "altText": "收起",
+                          "id": "reasoning_toggle_expanded",
+                          "isVisible": true,
+                          "selectAction": {
+                            "id": "reasoning_toggle_expanded_action",
+                            "targetElements": [
+                              "trace_panel",
+                              "collapsed_panel",
+                              "reasoning_toggle_collapsed",
+                              "reasoning_toggle_expanded"
+                            ],
+                            "type": "Action.ToggleVisibility"
+                          },
+                          "size": "Small",
+                          "spacing": "None",
+                          "type": "Image",
+                          "url": "data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%221em%22%20height%3D%221em%22%20viewBox%3D%220%200%2024%2024%22%3E%3Cpath%20fill%3D%22none%22%20stroke%3D%22%23a1a6ab%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20stroke-width%3D%222%22%20d%3D%22m18%2015l-6-6l-6%206%22%2F%3E%3C%2Fsvg%3E",
+                          "width": "14px"
+                        }
+                      ],
+                      "type": "Column",
+                      "verticalContentAlignment": "Center",
+                      "width": "auto"
+                    }
+                  ],
+                  "spacing": "None",
+                  "type": "ColumnSet"
+                },
+                {
+                  "color": "Accent",
+                  "size": "Small",
+                  "spacing": "None",
+                  "text": "思考中",
+                  "type": "TextBlock",
+                  "wrap": true
+                }
+              ],
+              "type": "Column",
+              "width": "stretch"
+            }
+          ],
+          "id": "reasoning_header",
+          "spacing": "None",
+          "type": "ColumnSet"
+        },
+        {
+          "id": "trace_panel",
+          "isVisible": true,
+          "items": [
+            {
+              "id": "reasoning_phase_0",
+              "items": [
+                {
+                  "columns": [
+                    {
+                      "items": [
+                        {
+                          "size": "Small",
+                          "spacing": "None",
+                          "text": "先把渠道 B 转化下降的范围圈出来：拆成线索、试用激活、付费三段漏斗，取近 90 天数据。",
+                          "type": "TextBlock",
+                          "wrap": true
+                        }
+                      ],
+                      "type": "Column",
+                      "verticalContentAlignment": "Center",
+                      "width": "stretch"
+                    },
+                    {
+                      "items": [
+                        {
+                          "altText": "展开工具",
+                          "id": "reasoning_tools_toggle_collapsed_0",
+                          "isVisible": true,
+                          "selectAction": {
+                            "id": "reasoning_tools_toggle_action_0",
+                            "targetElements": [
+                              "reasoning_tools_panel_0",
+                              "reasoning_tools_toggle_collapsed_0",
+                              "reasoning_tools_toggle_expanded_0"
+                            ],
+                            "type": "Action.ToggleVisibility"
+                          },
+                          "size": "Small",
+                          "spacing": "None",
+                          "type": "Image",
+                          "url": "data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%221em%22%20height%3D%221em%22%20viewBox%3D%220%200%2024%2024%22%3E%3Cpath%20fill%3D%22none%22%20stroke%3D%22%23a1a6ab%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20stroke-width%3D%222%22%20d%3D%22m6%209l6%206l6-6%22%2F%3E%3C%2Fsvg%3E",
+                          "width": "14px"
+                        },
+                        {
+                          "altText": "收起工具",
+                          "id": "reasoning_tools_toggle_expanded_0",
+                          "isVisible": false,
+                          "selectAction": {
+                            "id": "reasoning_tools_toggle_expanded_action_0",
+                            "targetElements": [
+                              "reasoning_tools_panel_0",
+                              "reasoning_tools_toggle_collapsed_0",
+                              "reasoning_tools_toggle_expanded_0"
+                            ],
+                            "type": "Action.ToggleVisibility"
+                          },
+                          "size": "Small",
+                          "spacing": "None",
+                          "type": "Image",
+                          "url": "data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%221em%22%20height%3D%221em%22%20viewBox%3D%220%200%2024%2024%22%3E%3Cpath%20fill%3D%22none%22%20stroke%3D%22%23a1a6ab%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20stroke-width%3D%222%22%20d%3D%22m18%2015l-6-6l-6%206%22%2F%3E%3C%2Fsvg%3E",
+                          "width": "14px"
+                        }
+                      ],
+                      "type": "Column",
+                      "verticalContentAlignment": "Center",
+                      "width": "auto"
+                    }
+                  ],
+                  "spacing": "None",
+                  "type": "ColumnSet"
+                },
+                {
+                  "id": "reasoning_tools_panel_0",
+                  "isVisible": false,
+                  "items": [
+                    {
+                      "columns": [
+                        {
+                          "items": [],
+                          "type": "Column",
+                          "width": "8px"
+                        },
+                        {
+                          "items": [
+                            {
+                              "color": "Good",
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "●",
+                              "type": "TextBlock"
+                            }
+                          ],
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "query_metrics",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "isSubtle": true,
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "channel=B · range=90d · group=stage",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "stretch"
+                        }
+                      ],
+                      "spacing": "None",
+                      "type": "ColumnSet"
+                    },
+                    {
+                      "columns": [
+                        {
+                          "items": [],
+                          "type": "Column",
+                          "width": "8px"
+                        },
+                        {
+                          "items": [
+                            {
+                              "color": "Good",
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "●",
+                              "type": "TextBlock"
+                            }
+                          ],
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "read_file",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "isSubtle": true,
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "~/analytics/funnel_definition.sql · ×2",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "stretch"
+                        }
+                      ],
+                      "spacing": "Small",
+                      "type": "ColumnSet"
+                    },
+                    {
+                      "columns": [
+                        {
+                          "items": [],
+                          "type": "Column",
+                          "width": "8px"
+                        },
+                        {
+                          "items": [
+                            {
+                              "color": "Good",
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "●",
+                              "type": "TextBlock"
+                            }
+                          ],
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "run_sql",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "isSubtle": true,
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "按漏斗阶段汇总数量与转化率",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "stretch"
+                        }
+                      ],
+                      "spacing": "Small",
+                      "type": "ColumnSet"
+                    }
+                  ],
+                  "spacing": "Small",
+                  "type": "Container"
+                }
+              ],
+              "spacing": "None",
+              "type": "Container"
+            },
+            {
+              "id": "reasoning_phase_1",
+              "items": [
+                {
+                  "columns": [
+                    {
+                      "items": [
+                        {
+                          "size": "Small",
+                          "spacing": "None",
+                          "text": "口径正常，但激活率掉得比线索量快；继续拉行业标签、客服工单和 NPS 交叉验证。",
+                          "type": "TextBlock",
+                          "wrap": true
+                        }
+                      ],
+                      "type": "Column",
+                      "verticalContentAlignment": "Center",
+                      "width": "stretch"
+                    },
+                    {
+                      "items": [
+                        {
+                          "altText": "展开工具",
+                          "id": "reasoning_tools_toggle_collapsed_1",
+                          "isVisible": true,
+                          "selectAction": {
+                            "id": "reasoning_tools_toggle_action_1",
+                            "targetElements": [
+                              "reasoning_tools_panel_1",
+                              "reasoning_tools_toggle_collapsed_1",
+                              "reasoning_tools_toggle_expanded_1"
+                            ],
+                            "type": "Action.ToggleVisibility"
+                          },
+                          "size": "Small",
+                          "spacing": "None",
+                          "type": "Image",
+                          "url": "data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%221em%22%20height%3D%221em%22%20viewBox%3D%220%200%2024%2024%22%3E%3Cpath%20fill%3D%22none%22%20stroke%3D%22%23a1a6ab%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20stroke-width%3D%222%22%20d%3D%22m6%209l6%206l6-6%22%2F%3E%3C%2Fsvg%3E",
+                          "width": "14px"
+                        },
+                        {
+                          "altText": "收起工具",
+                          "id": "reasoning_tools_toggle_expanded_1",
+                          "isVisible": false,
+                          "selectAction": {
+                            "id": "reasoning_tools_toggle_expanded_action_1",
+                            "targetElements": [
+                              "reasoning_tools_panel_1",
+                              "reasoning_tools_toggle_collapsed_1",
+                              "reasoning_tools_toggle_expanded_1"
+                            ],
+                            "type": "Action.ToggleVisibility"
+                          },
+                          "size": "Small",
+                          "spacing": "None",
+                          "type": "Image",
+                          "url": "data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%221em%22%20height%3D%221em%22%20viewBox%3D%220%200%2024%2024%22%3E%3Cpath%20fill%3D%22none%22%20stroke%3D%22%23a1a6ab%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20stroke-width%3D%222%22%20d%3D%22m18%2015l-6-6l-6%206%22%2F%3E%3C%2Fsvg%3E",
+                          "width": "14px"
+                        }
+                      ],
+                      "type": "Column",
+                      "verticalContentAlignment": "Center",
+                      "width": "auto"
+                    }
+                  ],
+                  "spacing": "None",
+                  "type": "ColumnSet"
+                },
+                {
+                  "id": "reasoning_tools_panel_1",
+                  "isVisible": false,
+                  "items": [
+                    {
+                      "columns": [
+                        {
+                          "items": [],
+                          "type": "Column",
+                          "width": "8px"
+                        },
+                        {
+                          "items": [
+                            {
+                              "color": "Good",
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "●",
+                              "type": "TextBlock"
+                            }
+                          ],
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "query_metrics",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "isSubtle": true,
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "channel=B · dims=industry · metric=activation_rate",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "stretch"
+                        }
+                      ],
+                      "spacing": "None",
+                      "type": "ColumnSet"
+                    },
+                    {
+                      "columns": [
+                        {
+                          "items": [],
+                          "type": "Column",
+                          "width": "8px"
+                        },
+                        {
+                          "items": [
+                            {
+                              "color": "Good",
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "●",
+                              "type": "TextBlock"
+                            }
+                          ],
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "search_tickets",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "isSubtle": true,
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "渠道 B · 试用 / 激活失败 · 近 60 天",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "stretch"
+                        }
+                      ],
+                      "spacing": "Small",
+                      "type": "ColumnSet"
+                    },
+                    {
+                      "columns": [
+                        {
+                          "items": [],
+                          "type": "Column",
+                          "width": "8px"
+                        },
+                        {
+                          "items": [
+                            {
+                              "color": "Good",
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "●",
+                              "type": "TextBlock"
+                            }
+                          ],
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "read_file",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "isSubtle": true,
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "~/nps/2026Q2_channelB.csv",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "stretch"
+                        }
+                      ],
+                      "spacing": "Small",
+                      "type": "ColumnSet"
+                    },
+                    {
+                      "columns": [
+                        {
+                          "items": [],
+                          "type": "Column",
+                          "width": "8px"
+                        },
+                        {
+                          "items": [
+                            {
+                              "color": "Accent",
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "●",
+                              "type": "TextBlock"
+                            }
+                          ],
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "query_metrics",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "isSubtle": true,
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "正在叠加季节性校正…",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "stretch"
+                        }
+                      ],
+                      "spacing": "Small",
+                      "type": "ColumnSet"
+                    }
+                  ],
+                  "spacing": "Small",
+                  "type": "Container"
+                }
+              ],
+              "spacing": "Small",
+              "type": "Container"
+            },
+            {
+              "color": "Accent",
+              "size": "Small",
+              "spacing": "Medium",
+              "text": "◌  正在执行下一步…",
+              "type": "TextBlock",
+              "wrap": true
+            }
+          ],
+          "spacing": "Medium",
+          "type": "Container"
+        },
+        {
+          "id": "collapsed_panel",
+          "isVisible": false,
+          "items": [
+            {
+              "isSubtle": true,
+              "size": "Small",
+              "spacing": "None",
+              "text": "正在思考",
+              "type": "TextBlock",
+              "wrap": true
+            }
+          ],
+          "spacing": "Small",
+          "type": "Container"
+        }
+      ],
+      "spacing": "None",
+      "style": "emphasis",
+      "type": "Container"
+    }
+  ],
+  "type": "AdaptiveCard",
+  "version": "1.5"
+}

--- a/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.4.1/goldens/stopped.card.json
+++ b/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.4.1/goldens/stopped.card.json
@@ -1,0 +1,567 @@
+{
+  "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+  "body": [
+    {
+      "bleed": true,
+      "items": [
+        {
+          "columns": [
+            {
+              "items": [
+                {
+                  "columns": [
+                    {
+                      "items": [
+                        {
+                          "size": "Small",
+                          "spacing": "None",
+                          "text": "深度思考",
+                          "type": "TextBlock",
+                          "weight": "Bolder",
+                          "wrap": true
+                        }
+                      ],
+                      "type": "Column",
+                      "width": "auto"
+                    },
+                    {
+                      "items": [
+                        {
+                          "altText": "展开",
+                          "id": "reasoning_toggle_collapsed",
+                          "isVisible": true,
+                          "selectAction": {
+                            "id": "reasoning_toggle",
+                            "targetElements": [
+                              "trace_panel",
+                              "collapsed_panel",
+                              "reasoning_toggle_collapsed",
+                              "reasoning_toggle_expanded"
+                            ],
+                            "type": "Action.ToggleVisibility"
+                          },
+                          "size": "Small",
+                          "spacing": "None",
+                          "type": "Image",
+                          "url": "data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%221em%22%20height%3D%221em%22%20viewBox%3D%220%200%2024%2024%22%3E%3Cpath%20fill%3D%22none%22%20stroke%3D%22%23a1a6ab%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20stroke-width%3D%222%22%20d%3D%22m6%209l6%206l6-6%22%2F%3E%3C%2Fsvg%3E",
+                          "width": "14px"
+                        },
+                        {
+                          "altText": "收起",
+                          "id": "reasoning_toggle_expanded",
+                          "isVisible": false,
+                          "selectAction": {
+                            "id": "reasoning_toggle_expanded_action",
+                            "targetElements": [
+                              "trace_panel",
+                              "collapsed_panel",
+                              "reasoning_toggle_collapsed",
+                              "reasoning_toggle_expanded"
+                            ],
+                            "type": "Action.ToggleVisibility"
+                          },
+                          "size": "Small",
+                          "spacing": "None",
+                          "type": "Image",
+                          "url": "data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%221em%22%20height%3D%221em%22%20viewBox%3D%220%200%2024%2024%22%3E%3Cpath%20fill%3D%22none%22%20stroke%3D%22%23a1a6ab%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20stroke-width%3D%222%22%20d%3D%22m18%2015l-6-6l-6%206%22%2F%3E%3C%2Fsvg%3E",
+                          "width": "14px"
+                        }
+                      ],
+                      "type": "Column",
+                      "verticalContentAlignment": "Center",
+                      "width": "auto"
+                    }
+                  ],
+                  "spacing": "None",
+                  "type": "ColumnSet"
+                },
+                {
+                  "color": "Warning",
+                  "size": "Small",
+                  "spacing": "None",
+                  "text": "已停止",
+                  "type": "TextBlock",
+                  "wrap": true
+                }
+              ],
+              "type": "Column",
+              "width": "stretch"
+            }
+          ],
+          "id": "reasoning_header",
+          "spacing": "None",
+          "type": "ColumnSet"
+        },
+        {
+          "id": "trace_panel",
+          "isVisible": false,
+          "items": [
+            {
+              "id": "reasoning_phase_0",
+              "items": [
+                {
+                  "columns": [
+                    {
+                      "items": [
+                        {
+                          "size": "Small",
+                          "spacing": "None",
+                          "text": "先拆分线索、试用激活与付费三段漏斗，核对近 90 天数据。",
+                          "type": "TextBlock",
+                          "wrap": true
+                        }
+                      ],
+                      "type": "Column",
+                      "verticalContentAlignment": "Center",
+                      "width": "stretch"
+                    },
+                    {
+                      "items": [
+                        {
+                          "altText": "展开工具",
+                          "id": "reasoning_tools_toggle_collapsed_0",
+                          "isVisible": true,
+                          "selectAction": {
+                            "id": "reasoning_tools_toggle_action_0",
+                            "targetElements": [
+                              "reasoning_tools_panel_0",
+                              "reasoning_tools_toggle_collapsed_0",
+                              "reasoning_tools_toggle_expanded_0"
+                            ],
+                            "type": "Action.ToggleVisibility"
+                          },
+                          "size": "Small",
+                          "spacing": "None",
+                          "type": "Image",
+                          "url": "data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%221em%22%20height%3D%221em%22%20viewBox%3D%220%200%2024%2024%22%3E%3Cpath%20fill%3D%22none%22%20stroke%3D%22%23a1a6ab%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20stroke-width%3D%222%22%20d%3D%22m6%209l6%206l6-6%22%2F%3E%3C%2Fsvg%3E",
+                          "width": "14px"
+                        },
+                        {
+                          "altText": "收起工具",
+                          "id": "reasoning_tools_toggle_expanded_0",
+                          "isVisible": false,
+                          "selectAction": {
+                            "id": "reasoning_tools_toggle_expanded_action_0",
+                            "targetElements": [
+                              "reasoning_tools_panel_0",
+                              "reasoning_tools_toggle_collapsed_0",
+                              "reasoning_tools_toggle_expanded_0"
+                            ],
+                            "type": "Action.ToggleVisibility"
+                          },
+                          "size": "Small",
+                          "spacing": "None",
+                          "type": "Image",
+                          "url": "data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%221em%22%20height%3D%221em%22%20viewBox%3D%220%200%2024%2024%22%3E%3Cpath%20fill%3D%22none%22%20stroke%3D%22%23a1a6ab%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20stroke-width%3D%222%22%20d%3D%22m18%2015l-6-6l-6%206%22%2F%3E%3C%2Fsvg%3E",
+                          "width": "14px"
+                        }
+                      ],
+                      "type": "Column",
+                      "verticalContentAlignment": "Center",
+                      "width": "auto"
+                    }
+                  ],
+                  "spacing": "None",
+                  "type": "ColumnSet"
+                },
+                {
+                  "id": "reasoning_tools_panel_0",
+                  "isVisible": false,
+                  "items": [
+                    {
+                      "columns": [
+                        {
+                          "items": [],
+                          "type": "Column",
+                          "width": "8px"
+                        },
+                        {
+                          "items": [
+                            {
+                              "color": "Good",
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "●",
+                              "type": "TextBlock"
+                            }
+                          ],
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "query_metrics",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "isSubtle": true,
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "channel=B · range=90d · group=stage",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "stretch"
+                        }
+                      ],
+                      "spacing": "None",
+                      "type": "ColumnSet"
+                    },
+                    {
+                      "columns": [
+                        {
+                          "items": [],
+                          "type": "Column",
+                          "width": "8px"
+                        },
+                        {
+                          "items": [
+                            {
+                              "color": "Good",
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "●",
+                              "type": "TextBlock"
+                            }
+                          ],
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "read_file",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "isSubtle": true,
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "~/analytics/funnel_definition.sql · ×2",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "stretch"
+                        }
+                      ],
+                      "spacing": "Small",
+                      "type": "ColumnSet"
+                    },
+                    {
+                      "columns": [
+                        {
+                          "items": [],
+                          "type": "Column",
+                          "width": "8px"
+                        },
+                        {
+                          "items": [
+                            {
+                              "color": "Good",
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "●",
+                              "type": "TextBlock"
+                            }
+                          ],
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "run_sql",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "isSubtle": true,
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "按漏斗阶段汇总数量与转化率",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "stretch"
+                        }
+                      ],
+                      "spacing": "Small",
+                      "type": "ColumnSet"
+                    }
+                  ],
+                  "spacing": "Small",
+                  "type": "Container"
+                }
+              ],
+              "spacing": "None",
+              "type": "Container"
+            },
+            {
+              "id": "reasoning_phase_1",
+              "items": [
+                {
+                  "columns": [
+                    {
+                      "items": [
+                        {
+                          "size": "Small",
+                          "spacing": "None",
+                          "text": "激活率降幅高于线索量，开始按行业与试用权益触达交叉核验。",
+                          "type": "TextBlock",
+                          "wrap": true
+                        }
+                      ],
+                      "type": "Column",
+                      "verticalContentAlignment": "Center",
+                      "width": "stretch"
+                    },
+                    {
+                      "items": [
+                        {
+                          "altText": "展开工具",
+                          "id": "reasoning_tools_toggle_collapsed_1",
+                          "isVisible": true,
+                          "selectAction": {
+                            "id": "reasoning_tools_toggle_action_1",
+                            "targetElements": [
+                              "reasoning_tools_panel_1",
+                              "reasoning_tools_toggle_collapsed_1",
+                              "reasoning_tools_toggle_expanded_1"
+                            ],
+                            "type": "Action.ToggleVisibility"
+                          },
+                          "size": "Small",
+                          "spacing": "None",
+                          "type": "Image",
+                          "url": "data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%221em%22%20height%3D%221em%22%20viewBox%3D%220%200%2024%2024%22%3E%3Cpath%20fill%3D%22none%22%20stroke%3D%22%23a1a6ab%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20stroke-width%3D%222%22%20d%3D%22m6%209l6%206l6-6%22%2F%3E%3C%2Fsvg%3E",
+                          "width": "14px"
+                        },
+                        {
+                          "altText": "收起工具",
+                          "id": "reasoning_tools_toggle_expanded_1",
+                          "isVisible": false,
+                          "selectAction": {
+                            "id": "reasoning_tools_toggle_expanded_action_1",
+                            "targetElements": [
+                              "reasoning_tools_panel_1",
+                              "reasoning_tools_toggle_collapsed_1",
+                              "reasoning_tools_toggle_expanded_1"
+                            ],
+                            "type": "Action.ToggleVisibility"
+                          },
+                          "size": "Small",
+                          "spacing": "None",
+                          "type": "Image",
+                          "url": "data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%221em%22%20height%3D%221em%22%20viewBox%3D%220%200%2024%2024%22%3E%3Cpath%20fill%3D%22none%22%20stroke%3D%22%23a1a6ab%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20stroke-width%3D%222%22%20d%3D%22m18%2015l-6-6l-6%206%22%2F%3E%3C%2Fsvg%3E",
+                          "width": "14px"
+                        }
+                      ],
+                      "type": "Column",
+                      "verticalContentAlignment": "Center",
+                      "width": "auto"
+                    }
+                  ],
+                  "spacing": "None",
+                  "type": "ColumnSet"
+                },
+                {
+                  "id": "reasoning_tools_panel_1",
+                  "isVisible": false,
+                  "items": [
+                    {
+                      "columns": [
+                        {
+                          "items": [],
+                          "type": "Column",
+                          "width": "8px"
+                        },
+                        {
+                          "items": [
+                            {
+                              "color": "Good",
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "●",
+                              "type": "TextBlock"
+                            }
+                          ],
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "query_metrics",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "isSubtle": true,
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "按行业拆分激活率",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "stretch"
+                        }
+                      ],
+                      "spacing": "None",
+                      "type": "ColumnSet"
+                    },
+                    {
+                      "columns": [
+                        {
+                          "items": [],
+                          "type": "Column",
+                          "width": "8px"
+                        },
+                        {
+                          "items": [
+                            {
+                              "color": "Accent",
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "●",
+                              "type": "TextBlock"
+                            }
+                          ],
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "search_tickets",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "isSubtle": true,
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "调用已由用户停止",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "stretch"
+                        }
+                      ],
+                      "spacing": "Small",
+                      "type": "ColumnSet"
+                    }
+                  ],
+                  "spacing": "Small",
+                  "type": "Container"
+                }
+              ],
+              "spacing": "Small",
+              "type": "Container"
+            }
+          ],
+          "spacing": "Medium",
+          "type": "Container"
+        },
+        {
+          "id": "collapsed_panel",
+          "isVisible": true,
+          "items": [
+            {
+              "isSubtle": true,
+              "size": "Small",
+              "spacing": "None",
+              "text": "已停止 · 保留 2 段思考",
+              "type": "TextBlock",
+              "wrap": true
+            }
+          ],
+          "spacing": "Small",
+          "type": "Container"
+        }
+      ],
+      "spacing": "None",
+      "style": "emphasis",
+      "type": "Container"
+    }
+  ],
+  "type": "AdaptiveCard",
+  "version": "1.5"
+}

--- a/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.4.1/manifest.json
+++ b/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.4.1/manifest.json
@@ -1,0 +1,50 @@
+{
+  "schemaVersion": 2,
+  "id": "ai.reasoning-process",
+  "name": "推理过程卡",
+  "version": "0.4.1",
+  "contractVersion": "1.2.0",
+  "protocol": "octo-card@1.0",
+  "adaptiveCardVersion": "1.5",
+  "renderProfile": "octo-chat@1.2.0-rc.3",
+  "renderProfileCompatibility": "octo-chat/v1",
+  "defaultLocale": "zh-CN",
+  "owner": "ai",
+  "dataSchema": "contract/data.schema.json",
+  "views": {
+    "active": {
+      "wireProfile": "octo/v2",
+      "states": [
+        "reasoning",
+        "answering"
+      ],
+      "template": "templates/active.template.json",
+      "samples": [
+        "samples/reasoning.json",
+        "samples/answering.json"
+      ]
+    },
+    "result": {
+      "wireProfile": "octo/v1",
+      "states": [
+        "completed",
+        "stopped"
+      ],
+      "template": "templates/result.template.json",
+      "samples": [
+        "samples/completed.json",
+        "samples/stopped.json"
+      ]
+    },
+    "error": {
+      "wireProfile": "octo/v2",
+      "states": [
+        "error"
+      ],
+      "template": "templates/error.template.json",
+      "samples": [
+        "samples/error.json"
+      ]
+    }
+  }
+}

--- a/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.4.1/reports/active.interaction.json
+++ b/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.4.1/reports/active.interaction.json
@@ -1,0 +1,13 @@
+{
+  "actions": [
+    {
+      "id": "reasoning_toggle",
+      "type": "Action.ToggleVisibility"
+    },
+    {
+      "id": "reasoning_toggle_expanded_action",
+      "type": "Action.ToggleVisibility"
+    }
+  ],
+  "inputs": []
+}

--- a/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.4.1/reports/error.interaction.json
+++ b/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.4.1/reports/error.interaction.json
@@ -1,0 +1,13 @@
+{
+  "actions": [
+    {
+      "id": "reasoning_toggle",
+      "type": "Action.ToggleVisibility"
+    },
+    {
+      "id": "reasoning_toggle_expanded_action",
+      "type": "Action.ToggleVisibility"
+    }
+  ],
+  "inputs": []
+}

--- a/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.4.1/samples/answering.json
+++ b/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.4.1/samples/answering.json
@@ -1,0 +1,89 @@
+{
+  "reasoningId": "reasoning-channel-b-001",
+  "state": "answering",
+  "title": "深度思考",
+  "statusLabel": "回答中",
+  "statusTone": "Accent",
+  "timerText": "正在生成回答…",
+  "traceExpanded": true,
+  "traceCollapsed": false,
+  "collapsedSummary": "正在生成回答",
+  "progressText": "推理已完成，正在生成回答…",
+  "phases": [
+    {
+      "thought": "先拆分线索、试用激活与付费三段漏斗，核对近 90 天数据。",
+      "actions": [
+        {
+          "tool": "query_metrics",
+          "detail": "channel=B · range=90d · group=stage",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "read_file",
+          "detail": "~/analytics/funnel_definition.sql · ×2",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "run_sql",
+          "detail": "按漏斗阶段汇总数量与转化率",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        }
+      ]
+    },
+    {
+      "thought": "激活率的降幅高于线索量，交叉核验行业结构、客服工单、NPS 与季节性。",
+      "actions": [
+        {
+          "tool": "query_metrics",
+          "detail": "按行业拆分激活率",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "search_tickets",
+          "detail": "渠道 B · 试用 / 激活失败 · 近 60 天",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "read_file",
+          "detail": "~/nps/2026Q2_channelB.csv",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "query_metrics",
+          "detail": "叠加节假日与季节性校正",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        }
+      ]
+    },
+    {
+      "thought": "主因确认：教育与专业服务合计贡献 63% 降幅，激活断点集中在试用权益触达。",
+      "actions": [
+        {
+          "tool": "run_sql",
+          "detail": "按行业汇总转化降幅贡献",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "edit_file",
+          "detail": "~/reports/channelB_rootcause.md · 已编辑",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "think",
+          "detail": "正在组织结论、证据与下周建议…",
+          "statusGlyph": "●",
+          "statusTone": "Accent"
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.4.1/samples/completed.json
+++ b/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.4.1/samples/completed.json
@@ -1,0 +1,106 @@
+{
+  "reasoningId": "reasoning-channel-b-001",
+  "state": "completed",
+  "title": "深度思考",
+  "statusLabel": "已完成",
+  "statusTone": "Good",
+  "timerText": "用时 12 秒 · 3 段推理 · 13 次工具调用",
+  "traceExpanded": false,
+  "traceCollapsed": true,
+  "collapsedSummary": "已思考 12 秒",
+  "phases": [
+    {
+      "thought": "先把渠道 B 转化下降的范围圈出来：拆成线索、试用激活、付费三段漏斗，取近 90 天数据。",
+      "actions": [
+        {
+          "tool": "query_metrics",
+          "detail": "channel=B · range=90d · group=stage",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "read_file",
+          "detail": "~/analytics/funnel_definition.sql · ×2",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "run_sql",
+          "detail": "按漏斗阶段汇总数量与转化率",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        }
+      ]
+    },
+    {
+      "thought": "激活率的降幅高于线索量，交叉核验行业结构、客服工单、NPS 与季节性。",
+      "actions": [
+        {
+          "tool": "query_metrics",
+          "detail": "按行业拆分激活率",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "run_sql",
+          "detail": "对比各行业激活与付费转化",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "search_tickets",
+          "detail": "渠道 B · 试用 / 激活失败 · 近 60 天",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "read_file",
+          "detail": "~/nps/2026Q2_channelB.csv",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "query_metrics",
+          "detail": "叠加节假日与季节性校正",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "run_sql",
+          "detail": "逐周复核线索与激活数量",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "web_search",
+          "detail": "SaaS 行业 2026 试用政策调整",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        }
+      ]
+    },
+    {
+      "thought": "主因确认：教育与专业服务合计贡献 63% 降幅，激活断点集中在试用权益触达。",
+      "actions": [
+        {
+          "tool": "run_sql",
+          "detail": "按行业汇总转化降幅贡献",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "edit_file",
+          "detail": "~/reports/channelB_rootcause.md · 已编辑",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "think",
+          "detail": "拆分行业漏斗深挖与权益触达复盘",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.4.1/samples/error.json
+++ b/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.4.1/samples/error.json
@@ -1,0 +1,55 @@
+{
+  "reasoningId": "reasoning-channel-b-003",
+  "state": "error",
+  "title": "深度思考",
+  "statusLabel": "生成失败",
+  "statusTone": "Attention",
+  "timerText": "已中断",
+  "traceExpanded": true,
+  "traceCollapsed": false,
+  "collapsedSummary": "生成已中断",
+  "errorTitle": "生成失败",
+  "errorMessage": "推理服务连接超时，本次生成已结束。已完成的过程会保留。",
+  "phases": [
+    {
+      "thought": "先拆分线索、试用激活与付费三段漏斗，核对近 90 天数据。",
+      "actions": [
+        {
+          "tool": "query_metrics",
+          "detail": "channel=B · range=90d · group=stage",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "read_file",
+          "detail": "~/analytics/funnel_definition.sql · ×2",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "run_sql",
+          "detail": "按漏斗阶段汇总数量与转化率",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        }
+      ]
+    },
+    {
+      "thought": "准备交叉核验行业结构、客服工单与 NPS 时，推理服务连接中断。",
+      "actions": [
+        {
+          "tool": "query_metrics",
+          "detail": "按行业拆分激活率",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "search_tickets",
+          "detail": "连接超时，调用未完成",
+          "statusGlyph": "●",
+          "statusTone": "Attention"
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.4.1/samples/reasoning.json
+++ b/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.4.1/samples/reasoning.json
@@ -1,0 +1,66 @@
+{
+  "reasoningId": "reasoning-channel-b-001",
+  "state": "reasoning",
+  "title": "深度思考",
+  "statusLabel": "思考中",
+  "statusTone": "Accent",
+  "timerText": "正在深度思考…",
+  "traceExpanded": true,
+  "traceCollapsed": false,
+  "collapsedSummary": "正在思考",
+  "progressText": "正在执行下一步…",
+  "phases": [
+    {
+      "thought": "先把渠道 B 转化下降的范围圈出来：拆成线索、试用激活、付费三段漏斗，取近 90 天数据。",
+      "actions": [
+        {
+          "tool": "query_metrics",
+          "detail": "channel=B · range=90d · group=stage",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "read_file",
+          "detail": "~/analytics/funnel_definition.sql · ×2",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "run_sql",
+          "detail": "按漏斗阶段汇总数量与转化率",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        }
+      ]
+    },
+    {
+      "thought": "口径正常，但激活率掉得比线索量快；继续拉行业标签、客服工单和 NPS 交叉验证。",
+      "actions": [
+        {
+          "tool": "query_metrics",
+          "detail": "channel=B · dims=industry · metric=activation_rate",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "search_tickets",
+          "detail": "渠道 B · 试用 / 激活失败 · 近 60 天",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "read_file",
+          "detail": "~/nps/2026Q2_channelB.csv",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "query_metrics",
+          "detail": "正在叠加季节性校正…",
+          "statusGlyph": "●",
+          "statusTone": "Accent"
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.4.1/samples/stopped.json
+++ b/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.4.1/samples/stopped.json
@@ -1,0 +1,53 @@
+{
+  "reasoningId": "reasoning-channel-b-002",
+  "state": "stopped",
+  "title": "深度思考",
+  "statusLabel": "已停止",
+  "statusTone": "Warning",
+  "timerText": "已思考 6 秒 · 已停止于第 2 段",
+  "traceExpanded": false,
+  "traceCollapsed": true,
+  "collapsedSummary": "已停止 · 保留 2 段思考",
+  "phases": [
+    {
+      "thought": "先拆分线索、试用激活与付费三段漏斗，核对近 90 天数据。",
+      "actions": [
+        {
+          "tool": "query_metrics",
+          "detail": "channel=B · range=90d · group=stage",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "read_file",
+          "detail": "~/analytics/funnel_definition.sql · ×2",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "run_sql",
+          "detail": "按漏斗阶段汇总数量与转化率",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        }
+      ]
+    },
+    {
+      "thought": "激活率降幅高于线索量，开始按行业与试用权益触达交叉核验。",
+      "actions": [
+        {
+          "tool": "query_metrics",
+          "detail": "按行业拆分激活率",
+          "statusGlyph": "●",
+          "statusTone": "Good"
+        },
+        {
+          "tool": "search_tickets",
+          "detail": "调用已由用户停止",
+          "statusGlyph": "●",
+          "statusTone": "Accent"
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.4.1/templates/active.template.json
+++ b/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.4.1/templates/active.template.json
@@ -1,0 +1,273 @@
+{
+  "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+  "type": "AdaptiveCard",
+  "version": "1.5",
+  "body": [
+    {
+      "type": "Container",
+      "style": "emphasis",
+      "spacing": "None",
+      "bleed": true,
+      "items": [
+        {
+          "type": "ColumnSet",
+          "id": "reasoning_header",
+          "spacing": "None",
+          "columns": [
+            {
+              "type": "Column",
+              "width": "stretch",
+              "items": [
+                {
+                  "type": "ColumnSet",
+                  "spacing": "None",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "${title}",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "Image",
+                          "id": "reasoning_toggle_collapsed",
+                          "isVisible": "${traceCollapsed}",
+                          "url": "data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%221em%22%20height%3D%221em%22%20viewBox%3D%220%200%2024%2024%22%3E%3Cpath%20fill%3D%22none%22%20stroke%3D%22%23a1a6ab%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20stroke-width%3D%222%22%20d%3D%22m6%209l6%206l6-6%22%2F%3E%3C%2Fsvg%3E",
+                          "altText": "展开",
+                          "size": "Small",
+                          "width": "14px",
+                          "spacing": "None",
+                          "selectAction": {
+                            "type": "Action.ToggleVisibility",
+                            "id": "reasoning_toggle",
+                            "targetElements": [
+                              "trace_panel",
+                              "collapsed_panel",
+                              "reasoning_toggle_collapsed",
+                              "reasoning_toggle_expanded"
+                            ]
+                          }
+                        },
+                        {
+                          "type": "Image",
+                          "id": "reasoning_toggle_expanded",
+                          "isVisible": "${traceExpanded}",
+                          "url": "data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%221em%22%20height%3D%221em%22%20viewBox%3D%220%200%2024%2024%22%3E%3Cpath%20fill%3D%22none%22%20stroke%3D%22%23a1a6ab%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20stroke-width%3D%222%22%20d%3D%22m18%2015l-6-6l-6%206%22%2F%3E%3C%2Fsvg%3E",
+                          "altText": "收起",
+                          "size": "Small",
+                          "width": "14px",
+                          "spacing": "None",
+                          "selectAction": {
+                            "type": "Action.ToggleVisibility",
+                            "id": "reasoning_toggle_expanded_action",
+                            "targetElements": [
+                              "trace_panel",
+                              "collapsed_panel",
+                              "reasoning_toggle_collapsed",
+                              "reasoning_toggle_expanded"
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "TextBlock",
+                  "text": "${statusLabel}",
+                  "color": "${statusTone}",
+                  "size": "Small",
+                  "wrap": true,
+                  "spacing": "None"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "Container",
+          "id": "trace_panel",
+          "isVisible": "${traceExpanded}",
+          "spacing": "Medium",
+          "items": [
+            {
+              "$data": "${phases}",
+              "type": "Container",
+              "id": "reasoning_phase_${$index}",
+              "spacing": "${if($index == 0, 'None', 'Small')}",
+              "items": [
+                {
+                  "type": "ColumnSet",
+                  "spacing": "None",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "${thought}",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "Image",
+                          "id": "reasoning_tools_toggle_collapsed_${$index}",
+                          "isVisible": true,
+                          "url": "data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%221em%22%20height%3D%221em%22%20viewBox%3D%220%200%2024%2024%22%3E%3Cpath%20fill%3D%22none%22%20stroke%3D%22%23a1a6ab%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20stroke-width%3D%222%22%20d%3D%22m6%209l6%206l6-6%22%2F%3E%3C%2Fsvg%3E",
+                          "altText": "展开工具",
+                          "size": "Small",
+                          "width": "14px",
+                          "spacing": "None",
+                          "selectAction": {
+                            "type": "Action.ToggleVisibility",
+                            "id": "reasoning_tools_toggle_action_${$index}",
+                            "targetElements": [
+                              "reasoning_tools_panel_${$index}",
+                              "reasoning_tools_toggle_collapsed_${$index}",
+                              "reasoning_tools_toggle_expanded_${$index}"
+                            ]
+                          }
+                        },
+                        {
+                          "type": "Image",
+                          "id": "reasoning_tools_toggle_expanded_${$index}",
+                          "isVisible": false,
+                          "url": "data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%221em%22%20height%3D%221em%22%20viewBox%3D%220%200%2024%2024%22%3E%3Cpath%20fill%3D%22none%22%20stroke%3D%22%23a1a6ab%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20stroke-width%3D%222%22%20d%3D%22m18%2015l-6-6l-6%206%22%2F%3E%3C%2Fsvg%3E",
+                          "altText": "收起工具",
+                          "size": "Small",
+                          "width": "14px",
+                          "spacing": "None",
+                          "selectAction": {
+                            "type": "Action.ToggleVisibility",
+                            "id": "reasoning_tools_toggle_expanded_action_${$index}",
+                            "targetElements": [
+                              "reasoning_tools_panel_${$index}",
+                              "reasoning_tools_toggle_collapsed_${$index}",
+                              "reasoning_tools_toggle_expanded_${$index}"
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "Container",
+                  "id": "reasoning_tools_panel_${$index}",
+                  "isVisible": false,
+                  "spacing": "Small",
+                  "items": [
+                    {
+                      "$data": "${actions}",
+                      "type": "ColumnSet",
+                      "spacing": "${if($index == 0, 'None', 'Small')}",
+                      "columns": [
+                        {
+                          "type": "Column",
+                          "width": "8px",
+                          "items": []
+                        },
+                        {
+                          "type": "Column",
+                          "width": "auto",
+                          "verticalContentAlignment": "Center",
+                          "items": [
+                            {
+                              "type": "TextBlock",
+                              "text": "${statusGlyph}",
+                              "color": "${statusTone}",
+                              "size": "Small",
+                              "spacing": "None"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "Column",
+                          "width": "auto",
+                          "spacing": "Small",
+                          "verticalContentAlignment": "Center",
+                          "items": [
+                            {
+                              "type": "TextBlock",
+                              "text": "${tool}",
+                              "size": "Small",
+                              "wrap": true,
+                              "spacing": "None"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "Column",
+                          "width": "stretch",
+                          "spacing": "Small",
+                          "verticalContentAlignment": "Center",
+                          "items": [
+                            {
+                              "type": "TextBlock",
+                              "text": "${detail}",
+                              "isSubtle": true,
+                              "size": "Small",
+                              "wrap": true,
+                              "spacing": "None"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "TextBlock",
+              "text": "◌  ${progressText}",
+              "color": "Accent",
+              "size": "Small",
+              "wrap": true,
+              "spacing": "Medium"
+            }
+          ]
+        },
+        {
+          "type": "Container",
+          "id": "collapsed_panel",
+          "isVisible": "${traceCollapsed}",
+          "spacing": "Small",
+          "items": [
+            {
+              "type": "TextBlock",
+              "text": "${collapsedSummary}",
+              "size": "Small",
+              "isSubtle": true,
+              "wrap": true,
+              "spacing": "None"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.4.1/templates/error.template.json
+++ b/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.4.1/templates/error.template.json
@@ -1,0 +1,286 @@
+{
+  "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+  "type": "AdaptiveCard",
+  "version": "1.5",
+  "body": [
+    {
+      "type": "Container",
+      "style": "emphasis",
+      "spacing": "None",
+      "bleed": true,
+      "items": [
+        {
+          "type": "ColumnSet",
+          "id": "reasoning_header",
+          "spacing": "None",
+          "columns": [
+            {
+              "type": "Column",
+              "width": "stretch",
+              "items": [
+                {
+                  "type": "ColumnSet",
+                  "spacing": "None",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "${title}",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "Image",
+                          "id": "reasoning_toggle_collapsed",
+                          "isVisible": "${traceCollapsed}",
+                          "url": "data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%221em%22%20height%3D%221em%22%20viewBox%3D%220%200%2024%2024%22%3E%3Cpath%20fill%3D%22none%22%20stroke%3D%22%23a1a6ab%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20stroke-width%3D%222%22%20d%3D%22m6%209l6%206l6-6%22%2F%3E%3C%2Fsvg%3E",
+                          "altText": "展开",
+                          "size": "Small",
+                          "width": "14px",
+                          "spacing": "None",
+                          "selectAction": {
+                            "type": "Action.ToggleVisibility",
+                            "id": "reasoning_toggle",
+                            "targetElements": [
+                              "trace_panel",
+                              "collapsed_panel",
+                              "reasoning_toggle_collapsed",
+                              "reasoning_toggle_expanded"
+                            ]
+                          }
+                        },
+                        {
+                          "type": "Image",
+                          "id": "reasoning_toggle_expanded",
+                          "isVisible": "${traceExpanded}",
+                          "url": "data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%221em%22%20height%3D%221em%22%20viewBox%3D%220%200%2024%2024%22%3E%3Cpath%20fill%3D%22none%22%20stroke%3D%22%23a1a6ab%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20stroke-width%3D%222%22%20d%3D%22m18%2015l-6-6l-6%206%22%2F%3E%3C%2Fsvg%3E",
+                          "altText": "收起",
+                          "size": "Small",
+                          "width": "14px",
+                          "spacing": "None",
+                          "selectAction": {
+                            "type": "Action.ToggleVisibility",
+                            "id": "reasoning_toggle_expanded_action",
+                            "targetElements": [
+                              "trace_panel",
+                              "collapsed_panel",
+                              "reasoning_toggle_collapsed",
+                              "reasoning_toggle_expanded"
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "TextBlock",
+                  "text": "${statusLabel}",
+                  "color": "${statusTone}",
+                  "size": "Small",
+                  "wrap": true,
+                  "spacing": "None"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "Container",
+          "id": "trace_panel",
+          "isVisible": "${traceExpanded}",
+          "spacing": "Medium",
+          "items": [
+            {
+              "$data": "${phases}",
+              "type": "Container",
+              "id": "reasoning_phase_${$index}",
+              "spacing": "${if($index == 0, 'None', 'Small')}",
+              "items": [
+                {
+                  "type": "ColumnSet",
+                  "spacing": "None",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "${thought}",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "Image",
+                          "id": "reasoning_tools_toggle_collapsed_${$index}",
+                          "isVisible": true,
+                          "url": "data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%221em%22%20height%3D%221em%22%20viewBox%3D%220%200%2024%2024%22%3E%3Cpath%20fill%3D%22none%22%20stroke%3D%22%23a1a6ab%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20stroke-width%3D%222%22%20d%3D%22m6%209l6%206l6-6%22%2F%3E%3C%2Fsvg%3E",
+                          "altText": "展开工具",
+                          "size": "Small",
+                          "width": "14px",
+                          "spacing": "None",
+                          "selectAction": {
+                            "type": "Action.ToggleVisibility",
+                            "id": "reasoning_tools_toggle_action_${$index}",
+                            "targetElements": [
+                              "reasoning_tools_panel_${$index}",
+                              "reasoning_tools_toggle_collapsed_${$index}",
+                              "reasoning_tools_toggle_expanded_${$index}"
+                            ]
+                          }
+                        },
+                        {
+                          "type": "Image",
+                          "id": "reasoning_tools_toggle_expanded_${$index}",
+                          "isVisible": false,
+                          "url": "data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%221em%22%20height%3D%221em%22%20viewBox%3D%220%200%2024%2024%22%3E%3Cpath%20fill%3D%22none%22%20stroke%3D%22%23a1a6ab%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20stroke-width%3D%222%22%20d%3D%22m18%2015l-6-6l-6%206%22%2F%3E%3C%2Fsvg%3E",
+                          "altText": "收起工具",
+                          "size": "Small",
+                          "width": "14px",
+                          "spacing": "None",
+                          "selectAction": {
+                            "type": "Action.ToggleVisibility",
+                            "id": "reasoning_tools_toggle_expanded_action_${$index}",
+                            "targetElements": [
+                              "reasoning_tools_panel_${$index}",
+                              "reasoning_tools_toggle_collapsed_${$index}",
+                              "reasoning_tools_toggle_expanded_${$index}"
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "Container",
+                  "id": "reasoning_tools_panel_${$index}",
+                  "isVisible": false,
+                  "spacing": "Small",
+                  "items": [
+                    {
+                      "$data": "${actions}",
+                      "type": "ColumnSet",
+                      "spacing": "${if($index == 0, 'None', 'Small')}",
+                      "columns": [
+                        {
+                          "type": "Column",
+                          "width": "8px",
+                          "items": []
+                        },
+                        {
+                          "type": "Column",
+                          "width": "auto",
+                          "verticalContentAlignment": "Center",
+                          "items": [
+                            {
+                              "type": "TextBlock",
+                              "text": "${statusGlyph}",
+                              "color": "${statusTone}",
+                              "size": "Small",
+                              "spacing": "None"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "Column",
+                          "width": "auto",
+                          "spacing": "Small",
+                          "verticalContentAlignment": "Center",
+                          "items": [
+                            {
+                              "type": "TextBlock",
+                              "text": "${tool}",
+                              "size": "Small",
+                              "wrap": true,
+                              "spacing": "None"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "Column",
+                          "width": "stretch",
+                          "spacing": "Small",
+                          "verticalContentAlignment": "Center",
+                          "items": [
+                            {
+                              "type": "TextBlock",
+                              "text": "${detail}",
+                              "isSubtle": true,
+                              "size": "Small",
+                              "wrap": true,
+                              "spacing": "None"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "Container",
+          "id": "collapsed_panel",
+          "isVisible": "${traceCollapsed}",
+          "spacing": "Small",
+          "items": [
+            {
+              "type": "TextBlock",
+              "text": "${collapsedSummary}",
+              "size": "Small",
+              "isSubtle": true,
+              "wrap": true,
+              "spacing": "None"
+            }
+          ]
+        },
+        {
+          "type": "Container",
+          "style": "attention",
+          "spacing": "Medium",
+          "items": [
+            {
+              "type": "TextBlock",
+              "text": "${errorTitle}",
+              "color": "Attention",
+              "weight": "Bolder",
+              "wrap": true,
+              "spacing": "None"
+            },
+            {
+              "type": "TextBlock",
+              "text": "${errorMessage}",
+              "wrap": true,
+              "spacing": "Small"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.4.1/templates/result.template.json
+++ b/pkg/cardtmpl/ai_reasoning_process/handoff/ai.reasoning-process@0.4.1/templates/result.template.json
@@ -1,0 +1,265 @@
+{
+  "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+  "type": "AdaptiveCard",
+  "version": "1.5",
+  "body": [
+    {
+      "type": "Container",
+      "style": "emphasis",
+      "spacing": "None",
+      "bleed": true,
+      "items": [
+        {
+          "type": "ColumnSet",
+          "id": "reasoning_header",
+          "spacing": "None",
+          "columns": [
+            {
+              "type": "Column",
+              "width": "stretch",
+              "items": [
+                {
+                  "type": "ColumnSet",
+                  "spacing": "None",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "${title}",
+                          "weight": "Bolder",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "Image",
+                          "id": "reasoning_toggle_collapsed",
+                          "isVisible": "${traceCollapsed}",
+                          "url": "data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%221em%22%20height%3D%221em%22%20viewBox%3D%220%200%2024%2024%22%3E%3Cpath%20fill%3D%22none%22%20stroke%3D%22%23a1a6ab%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20stroke-width%3D%222%22%20d%3D%22m6%209l6%206l6-6%22%2F%3E%3C%2Fsvg%3E",
+                          "altText": "展开",
+                          "size": "Small",
+                          "width": "14px",
+                          "spacing": "None",
+                          "selectAction": {
+                            "type": "Action.ToggleVisibility",
+                            "id": "reasoning_toggle",
+                            "targetElements": [
+                              "trace_panel",
+                              "collapsed_panel",
+                              "reasoning_toggle_collapsed",
+                              "reasoning_toggle_expanded"
+                            ]
+                          }
+                        },
+                        {
+                          "type": "Image",
+                          "id": "reasoning_toggle_expanded",
+                          "isVisible": "${traceExpanded}",
+                          "url": "data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%221em%22%20height%3D%221em%22%20viewBox%3D%220%200%2024%2024%22%3E%3Cpath%20fill%3D%22none%22%20stroke%3D%22%23a1a6ab%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20stroke-width%3D%222%22%20d%3D%22m18%2015l-6-6l-6%206%22%2F%3E%3C%2Fsvg%3E",
+                          "altText": "收起",
+                          "size": "Small",
+                          "width": "14px",
+                          "spacing": "None",
+                          "selectAction": {
+                            "type": "Action.ToggleVisibility",
+                            "id": "reasoning_toggle_expanded_action",
+                            "targetElements": [
+                              "trace_panel",
+                              "collapsed_panel",
+                              "reasoning_toggle_collapsed",
+                              "reasoning_toggle_expanded"
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "TextBlock",
+                  "text": "${statusLabel}",
+                  "color": "${statusTone}",
+                  "size": "Small",
+                  "wrap": true,
+                  "spacing": "None"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "Container",
+          "id": "trace_panel",
+          "isVisible": "${traceExpanded}",
+          "spacing": "Medium",
+          "items": [
+            {
+              "$data": "${phases}",
+              "type": "Container",
+              "id": "reasoning_phase_${$index}",
+              "spacing": "${if($index == 0, 'None', 'Small')}",
+              "items": [
+                {
+                  "type": "ColumnSet",
+                  "spacing": "None",
+                  "columns": [
+                    {
+                      "type": "Column",
+                      "width": "stretch",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "TextBlock",
+                          "text": "${thought}",
+                          "size": "Small",
+                          "wrap": true,
+                          "spacing": "None"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Column",
+                      "width": "auto",
+                      "verticalContentAlignment": "Center",
+                      "items": [
+                        {
+                          "type": "Image",
+                          "id": "reasoning_tools_toggle_collapsed_${$index}",
+                          "isVisible": true,
+                          "url": "data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%221em%22%20height%3D%221em%22%20viewBox%3D%220%200%2024%2024%22%3E%3Cpath%20fill%3D%22none%22%20stroke%3D%22%23a1a6ab%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20stroke-width%3D%222%22%20d%3D%22m6%209l6%206l6-6%22%2F%3E%3C%2Fsvg%3E",
+                          "altText": "展开工具",
+                          "size": "Small",
+                          "width": "14px",
+                          "spacing": "None",
+                          "selectAction": {
+                            "type": "Action.ToggleVisibility",
+                            "id": "reasoning_tools_toggle_action_${$index}",
+                            "targetElements": [
+                              "reasoning_tools_panel_${$index}",
+                              "reasoning_tools_toggle_collapsed_${$index}",
+                              "reasoning_tools_toggle_expanded_${$index}"
+                            ]
+                          }
+                        },
+                        {
+                          "type": "Image",
+                          "id": "reasoning_tools_toggle_expanded_${$index}",
+                          "isVisible": false,
+                          "url": "data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%221em%22%20height%3D%221em%22%20viewBox%3D%220%200%2024%2024%22%3E%3Cpath%20fill%3D%22none%22%20stroke%3D%22%23a1a6ab%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20stroke-width%3D%222%22%20d%3D%22m18%2015l-6-6l-6%206%22%2F%3E%3C%2Fsvg%3E",
+                          "altText": "收起工具",
+                          "size": "Small",
+                          "width": "14px",
+                          "spacing": "None",
+                          "selectAction": {
+                            "type": "Action.ToggleVisibility",
+                            "id": "reasoning_tools_toggle_expanded_action_${$index}",
+                            "targetElements": [
+                              "reasoning_tools_panel_${$index}",
+                              "reasoning_tools_toggle_collapsed_${$index}",
+                              "reasoning_tools_toggle_expanded_${$index}"
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "Container",
+                  "id": "reasoning_tools_panel_${$index}",
+                  "isVisible": false,
+                  "spacing": "Small",
+                  "items": [
+                    {
+                      "$data": "${actions}",
+                      "type": "ColumnSet",
+                      "spacing": "${if($index == 0, 'None', 'Small')}",
+                      "columns": [
+                        {
+                          "type": "Column",
+                          "width": "8px",
+                          "items": []
+                        },
+                        {
+                          "type": "Column",
+                          "width": "auto",
+                          "verticalContentAlignment": "Center",
+                          "items": [
+                            {
+                              "type": "TextBlock",
+                              "text": "${statusGlyph}",
+                              "color": "${statusTone}",
+                              "size": "Small",
+                              "spacing": "None"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "Column",
+                          "width": "auto",
+                          "spacing": "Small",
+                          "verticalContentAlignment": "Center",
+                          "items": [
+                            {
+                              "type": "TextBlock",
+                              "text": "${tool}",
+                              "size": "Small",
+                              "wrap": true,
+                              "spacing": "None"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "Column",
+                          "width": "stretch",
+                          "spacing": "Small",
+                          "verticalContentAlignment": "Center",
+                          "items": [
+                            {
+                              "type": "TextBlock",
+                              "text": "${detail}",
+                              "isSubtle": true,
+                              "size": "Small",
+                              "wrap": true,
+                              "spacing": "None"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "Container",
+          "id": "collapsed_panel",
+          "isVisible": "${traceCollapsed}",
+          "spacing": "Small",
+          "items": [
+            {
+              "type": "TextBlock",
+              "text": "${collapsedSummary}",
+              "size": "Small",
+              "isSubtle": true,
+              "wrap": true,
+              "spacing": "None"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/cardtmpl/ai_reasoning_process/v5_test.go
+++ b/pkg/cardtmpl/ai_reasoning_process/v5_test.go
@@ -1,0 +1,126 @@
+package aireasoningprocess_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io/fs"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-server/internal/carddispatch"
+	"github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl"
+	aireasoningprocess "github.com/Mininglamp-OSS/octo-server/pkg/cardtmpl/ai_reasoning_process"
+)
+
+func TestFullBleedSuccessorContractAndAssets(t *testing.T) {
+	manifest := readAssetMap(t, reasoningRootV5+"/manifest.json")
+	for key, want := range map[string]string{
+		"id":                         string(aireasoningprocess.TemplateID),
+		"version":                    reasoningVersionV5,
+		"contractVersion":            "1.2.0",
+		"protocol":                   "octo-card@1.0",
+		"adaptiveCardVersion":        "1.5",
+		"renderProfile":              "octo-chat@1.2.0-rc.3",
+		"renderProfileCompatibility": "octo-chat/v1",
+		"owner":                      "ai",
+	} {
+		if got, _ := manifest[key].(string); got != want {
+			t.Fatalf("manifest.%s = %q, want %q", key, got, want)
+		}
+	}
+	if _, exists := manifest["actionType"]; exists {
+		t.Fatal("0.4.1 manifest must not advertise actionType")
+	}
+	views, _ := manifest["views"].(map[string]any)
+	if len(views) != 3 {
+		t.Fatalf("views = %d, want 3", len(views))
+	}
+	for name, raw := range views {
+		view, _ := raw.(map[string]any)
+		if _, exists := view["submit_actions"]; exists {
+			t.Fatalf("view %q declares submit_actions; capability must stay derived", name)
+		}
+	}
+
+	for _, relative := range []string{
+		"contract/data.schema.json",
+		"reports/active.interaction.json",
+		"reports/error.interaction.json",
+		"samples/reasoning.json",
+		"samples/answering.json",
+		"samples/completed.json",
+		"samples/stopped.json",
+		"samples/error.json",
+	} {
+		if got, want := readAsset(t, reasoningRootV5+"/"+relative), readAsset(t, reasoningRootV4+"/"+relative); !bytes.Equal(got, want) {
+			t.Fatalf("0.4.1 %s drifted from 0.4.0", relative)
+		}
+	}
+
+	for _, view := range []string{"active", "result", "error"} {
+		v4 := readAssetMap(t, reasoningRootV4+"/templates/"+view+".template.json")
+		v5 := readAssetMap(t, reasoningRootV5+"/templates/"+view+".template.json")
+		root := fullBleedRoot(t, v5, "template "+view)
+		delete(root, "bleed")
+		if got, want := canon(t, v5), canon(t, v4); got != want {
+			t.Fatalf("0.4.1 %s template changed beyond root bleed\ngot=%s\nwant=%s", view, got, want)
+		}
+	}
+
+	for _, state := range []string{"reasoning", "answering", "completed", "stopped", "error"} {
+		v4 := readGolden(t, reasoningRootV4, state)
+		v5 := readGolden(t, reasoningRootV5, state)
+		root := fullBleedRoot(t, v5, "golden "+state)
+		delete(root, "bleed")
+		if got, want := canon(t, v5), canon(t, v4); got != want {
+			t.Fatalf("0.4.1 %s golden changed beyond root bleed\ngot=%s\nwant=%s", state, got, want)
+		}
+	}
+
+	for _, forbidden := range []string{
+		reasoningRootV5 + "/reports/result.interaction.json",
+		reasoningRootV5 + "/render-profile/manifest.json",
+	} {
+		if _, err := aireasoningprocess.Assets.Open(forbidden); !errors.Is(err, fs.ErrNotExist) {
+			t.Fatalf("%s must not be shipped (err = %v)", forbidden, err)
+		}
+	}
+}
+
+func TestFullBleedSuccessorSurvivesProductionPersistence(t *testing.T) {
+	reg := newRegistry(t)
+	for _, tc := range reasoningStates {
+		payload, err := reg.Render(context.Background(), aireasoningprocess.TemplateID,
+			reasoningVersionV5, tc.state, readSample(t, reasoningRootV5, string(tc.state)),
+			cardtmpl.BuildEnv{Lang: "zh-CN", SpaceID: "space-x"})
+		if err != nil {
+			t.Fatalf("render %s: %v", tc.state, err)
+		}
+		payload["card_seq"] = 2
+		payload["space_id"] = "space-x"
+		raw, err := json.Marshal(payload)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := carddispatch.NormalizeFrameForPersistence(string(raw)); err != nil {
+			t.Fatalf("%s V5 frame rejected by persistence normalization: %v", tc.state, err)
+		}
+	}
+}
+
+func fullBleedRoot(t *testing.T, card map[string]any, label string) map[string]any {
+	t.Helper()
+	body, _ := card["body"].([]any)
+	if len(body) == 0 {
+		t.Fatalf("%s has no body", label)
+	}
+	root, _ := body[0].(map[string]any)
+	if root == nil {
+		t.Fatalf("%s root body element is %T, want object", label, body[0])
+	}
+	if bleed, _ := root["bleed"].(bool); !bleed {
+		t.Fatalf("%s root bleed = %v, want true", label, root["bleed"])
+	}
+	return root
+}


### PR DESCRIPTION
## Summary

Publish ai.reasoning-process@0.4.1 as the immutable full-bleed successor to 0.4.0 while retaining V1-V4 for exact-version historical edits.

## Related Issue

N/A

## Linked Spec

.octospec/tasks/cardtmpl-reasoning-bleed-successor/brief.md

## Changes

- Add the 0.4.1 artifact derived from the shipped 0.4.0 contract; the card delta is root Container bleed=true, plus the new manifest identity and render-profile provenance.
- Register V5 as the static default and sole Bot new-send advertisement while keeping V1-V5 edit-compatible.
- Add artifact, golden, persistence, registry, catalog, and Bot capability regression coverage.

## Testing

- [x] Unit tests added/updated
- [x] Manually verified

Passed:

- go test ./modules/bot_api -count=1
- go test ./pkg/cardtmpl/ai_reasoning_process with the focused V5 test set
- go test ./modules/card_template_catalog -run TestInitializeRuntimeCatalogAcceptsRegisteredStaticReasoningTargets
- go test . -run TestInstallCardTmplRegistryRegistersReasoningHistoryAndV5Default
- git diff --check origin/main...HEAD

## COMPREHENSION

1. **What does this change actually do** to the load-bearing path?

   It registers an immutable 0.4.1 template, makes it the default and advertised Bot send version, and preserves all older exact versions for historical edits. Rendering differs from 0.4.0 only by enabling bleed on the root container.

2. **What could break** because of it (dependents + failure mode)?

   A producer attempting a new send with a stale 0.4.0 ref is rejected and must refresh the Bot card profile. Existing V1-V4 cards remain editable, and the schema, wire profiles, actions, limits, samples, and interaction reports are unchanged.

3. **How do you know it works** (specific test/repro/trace)?

   V5 tests compare the schema and supporting assets byte-for-byte with V4, compare templates and goldens after removing only root bleed, render all five states through production persistence normalization, and verify registry, Bot advertisement, and historical edit compatibility.

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] PR description is in English
- [x] Added tests for my changes
- [x] Updated documentation
- [x] Followed commit message conventions (Conventional Commits)