### PR TITLE
fix(group): expose avatar custom fields in channel extra

### DIFF
--- a/modules/group/1module.go
+++ b/modules/group/1module.go
@@ -208,6 +208,9 @@ func newChannelRespWithGroupResp(groupResp *GroupResp) *model.ChannelResp {
 	extraMap["allow_view_history_msg"] = groupResp.AllowViewHistoryMsg
 	extraMap["group_type"] = groupResp.GroupType
 	extraMap["allow_member_pinned_message"] = groupResp.AllowMemberPinnedMessage
+	extraMap["is_named"] = groupResp.IsNamed
+	extraMap["avatar_text"] = groupResp.AvatarText
+	extraMap["avatar_color"] = groupResp.AvatarColor
 	// 群级「允许免@回答」总开关：前端 channelInfo.orgData.allow_no_mention 据此回读
 	// 真实 0/1 值，否则开关永远显示「开」且关不掉（refresh 弹回）。默认 1=允许，零回归。
 	extraMap["allow_no_mention"] = groupResp.AllowNoMention

--- a/modules/group/api_allow_no_mention_test.go
+++ b/modules/group/api_allow_no_mention_test.go
@@ -122,6 +122,21 @@ func TestNewChannelResp_CarriesAllowNoMention(t *testing.T) {
 	}
 }
 
+func TestNewChannelResp_CarriesAvatarCustomFields(t *testing.T) {
+	avatarColor := 5
+	resp := newChannelRespWithGroupResp(&GroupResp{
+		GroupNo:     "g-avatar-extra",
+		Name:        "avatar group",
+		IsNamed:     1,
+		AvatarText:  "研发",
+		AvatarColor: &avatarColor,
+	})
+
+	assert.Equal(t, 1, resp.Extra["is_named"], "extra 必须透出 is_named，前端据此判断默认头像是否取群名")
+	assert.Equal(t, "研发", resp.Extra["avatar_text"], "extra 必须透出 avatar_text，前端据此预填文字头像弹窗")
+	assert.Equal(t, &avatarColor, resp.Extra["avatar_color"], "extra 必须透出 avatar_color，前端据此预填色板")
+}
+
 // TestGroupSettingUpdate_AllowNoMention_SilentToggleSucceeds pins YUJ-3153 Bug
 // 3: toggling the switch as creator now goes through the silent
 // SendChannelUpdateToGroup path (like mute / allow_view_history_msg) instead of


### PR DESCRIPTION
## Summary
- Expose `is_named`, `avatar_text`, and `avatar_color` in group channel `extraMap` so clients can prefill existing group avatar text/color settings from `/v1/channels/:id/:type`.
- Add a focused regression test for the channel response extra fields.

## Companion PR
- Frontend existing-group avatar editor: https://github.com/Mininglamp-OSS/octo-web/pull/1311
- Rollout note: this is additive response data; web can soft-degrade before this ships, but both PRs should be reviewed and shipped together when possible.

## Test plan
- Not run locally: Go toolchain (`go` / `gofmt`) is not available in this runtime PATH.
- GitHub CI is running server tests; build/vet/lint/i18n/title/security checks are passing at the time of update, `Test` is still in progress.

## Risks
- Low: response-only additive fields in `extraMap`, aligned with existing `GroupResp` JSON names and group detail fields.

Multica Issue: OCT-8


Closes #730
