### PR TITLE
fix(group): clear uploaded avatar on generated save

### DIFF
--- a/modules/group/1module.go
+++ b/modules/group/1module.go
@@ -211,6 +211,7 @@ func newChannelRespWithGroupResp(groupResp *GroupResp) *model.ChannelResp {
 	extraMap["is_named"] = groupResp.IsNamed
 	extraMap["avatar_text"] = groupResp.AvatarText
 	extraMap["avatar_color"] = groupResp.AvatarColor
+	extraMap["is_upload_avatar"] = groupResp.IsUploadAvatar
 	// 群级「允许免@回答」总开关：前端 channelInfo.orgData.allow_no_mention 据此回读
 	// 真实 0/1 值，否则开关永远显示「开」且关不掉（refresh 弹回）。默认 1=允许，零回归。
 	extraMap["allow_no_mention"] = groupResp.AllowNoMention

--- a/modules/group/api.go
+++ b/modules/group/api.go
@@ -1168,8 +1168,7 @@ func (g *Group) groupUpdate(c *wkhttp.Context) {
 	}
 	// 群存在性 + 状态检查（不缓存整行：下方 invite 分支改用列级写，避免用旧快照全列回写
 	// 覆盖掉 name 分支刚提交的 name/is_named，见 DB.UpdateInviteTx 注释）。
-	groupInfo, err := g.getGroupInfo(groupNo)
-	if err != nil {
+	if _, err := g.getGroupInfo(groupNo); err != nil {
 		respondGroupInfoError(c, err)
 		return
 	}

--- a/modules/group/api.go
+++ b/modules/group/api.go
@@ -1179,12 +1179,13 @@ func (g *Group) groupUpdate(c *wkhttp.Context) {
 	noticeValue, hasNotice := groupMap[common.GroupAttrKeyNotice]
 	avatarTextValue, hasAvatarText := groupMap[attrKeyAvatarText]
 	avatarColorValue, hasAvatarColor := groupMap[attrKeyAvatarColor]
+	clearUploadedAvatarValue, hasClearUploadedAvatar := groupMap[attrKeyClearUploadedAvatar]
 
 	// 权限分档：
-	//   高级字段（notice/invite/avatar_text/avatar_color）——仍需管理员/群主。
+	//   高级字段（notice/invite/avatar_text/avatar_color/clear_uploaded_avatar）——仍需管理员/群主。
 	//   仅改名（只含 name、不含任何高级字段）——任何活跃人类成员即可，龙虾除外。
 	//   其它（既无 name 也无高级字段）——保守走管理员校验兜底。
-	hasAdvanced := hasNotice || hasInvite || hasAvatarText || hasAvatarColor
+	hasAdvanced := hasNotice || hasInvite || hasAvatarText || hasAvatarColor || hasClearUploadedAvatar
 	if hasAdvanced || !hasName {
 		isManager, err := g.db.QueryIsGroupManagerOrCreator(groupNo, loginUID)
 		if err != nil {
@@ -1229,11 +1230,23 @@ func (g *Group) groupUpdate(c *wkhttp.Context) {
 	// 「返回 400 却已部分写入群名」的非原子部分写入。avatar_text 空串清除自定义文字（回退
 	// is_named 规则:老群群名/新群双人图标），avatar_color "" / "-1" 清除自定义色（回退派生）。超限直接拒绝，不静默截断。
 	var avatarReq *UpdateGroupAvatarCustomServiceReq
-	if hasAvatarText || hasAvatarColor {
+	if hasAvatarText || hasAvatarColor || hasClearUploadedAvatar {
 		avatarReq = &UpdateGroupAvatarCustomServiceReq{
 			GroupNo:      groupNo,
 			OperatorUID:  loginUID,
 			OperatorName: loginName,
+		}
+		if hasClearUploadedAvatar {
+			raw := strings.TrimSpace(strings.ToLower(clearUploadedAvatarValue))
+			if raw != "1" && raw != "true" {
+				respondGroupRequestInvalid(c, attrKeyClearUploadedAvatar)
+				return
+			}
+			if !hasAvatarText && !hasAvatarColor {
+				respondGroupRequestInvalid(c, attrKeyClearUploadedAvatar)
+				return
+			}
+			avatarReq.ClearUploadedAvatar = true
 		}
 		if hasAvatarText {
 			if avatarrender.VisibleRuneCount(avatarTextValue) > 4 {

--- a/modules/group/api.go
+++ b/modules/group/api.go
@@ -1168,7 +1168,8 @@ func (g *Group) groupUpdate(c *wkhttp.Context) {
 	}
 	// 群存在性 + 状态检查（不缓存整行：下方 invite 分支改用列级写，避免用旧快照全列回写
 	// 覆盖掉 name 分支刚提交的 name/is_named，见 DB.UpdateInviteTx 注释）。
-	if _, err := g.getGroupInfo(groupNo); err != nil {
+	groupInfo, err := g.getGroupInfo(groupNo)
+	if err != nil {
 		respondGroupInfoError(c, err)
 		return
 	}
@@ -1180,6 +1181,19 @@ func (g *Group) groupUpdate(c *wkhttp.Context) {
 	avatarTextValue, hasAvatarText := groupMap[attrKeyAvatarText]
 	avatarColorValue, hasAvatarColor := groupMap[attrKeyAvatarColor]
 	clearUploadedAvatarValue, hasClearUploadedAvatar := groupMap[attrKeyClearUploadedAvatar]
+	clearUploadedAvatar := false
+	if hasClearUploadedAvatar {
+		raw := strings.TrimSpace(strings.ToLower(clearUploadedAvatarValue))
+		switch raw {
+		case "", "0", "false":
+			hasClearUploadedAvatar = false
+		case "1", "true":
+			clearUploadedAvatar = true
+		default:
+			respondGroupRequestInvalid(c, attrKeyClearUploadedAvatar)
+			return
+		}
+	}
 
 	// 权限分档：
 	//   高级字段（notice/invite/avatar_text/avatar_color/clear_uploaded_avatar）——仍需管理员/群主。
@@ -1196,6 +1210,18 @@ func (g *Group) groupUpdate(c *wkhttp.Context) {
 		if !isManager {
 			httperr.ResponseErrorL(c, errcode.ErrGroupManagerOnly, nil, nil)
 			return
+		}
+		if clearUploadedAvatar && groupInfo.IsUploadAvatar == 1 {
+			isCreator, err := g.db.QueryIsGroupCreator(groupNo, loginUID)
+			if err != nil {
+				g.Error("查询群创建者失败！", zap.Error(err))
+				httperr.ResponseErrorL(c, errcode.ErrGroupQueryFailed, nil, nil)
+				return
+			}
+			if !isCreator {
+				httperr.ResponseErrorL(c, errcode.ErrGroupCreatorOnly, nil, nil)
+				return
+			}
 		}
 	} else {
 		// 仅改名：低风险写，内部活跃人类成员即可，龙虾(robot)不是普通成员，禁止其改名。
@@ -1237,16 +1263,7 @@ func (g *Group) groupUpdate(c *wkhttp.Context) {
 			OperatorName: loginName,
 		}
 		if hasClearUploadedAvatar {
-			raw := strings.TrimSpace(strings.ToLower(clearUploadedAvatarValue))
-			if raw != "1" && raw != "true" {
-				respondGroupRequestInvalid(c, attrKeyClearUploadedAvatar)
-				return
-			}
-			if !hasAvatarText && !hasAvatarColor {
-				respondGroupRequestInvalid(c, attrKeyClearUploadedAvatar)
-				return
-			}
-			avatarReq.ClearUploadedAvatar = true
+			avatarReq.ClearUploadedAvatar = clearUploadedAvatar
 		}
 		if hasAvatarText {
 			if avatarrender.VisibleRuneCount(avatarTextValue) > 4 {

--- a/modules/group/api.go
+++ b/modules/group/api.go
@@ -1211,7 +1211,7 @@ func (g *Group) groupUpdate(c *wkhttp.Context) {
 			httperr.ResponseErrorL(c, errcode.ErrGroupManagerOnly, nil, nil)
 			return
 		}
-		if clearUploadedAvatar && groupInfo.IsUploadAvatar == 1 {
+		if clearUploadedAvatar {
 			isCreator, err := g.db.QueryIsGroupCreator(groupNo, loginUID)
 			if err != nil {
 				g.Error("查询群创建者失败！", zap.Error(err))

--- a/modules/group/avatar_custom_test.go
+++ b/modules/group/avatar_custom_test.go
@@ -13,15 +13,23 @@ func intPtr(v int) *int { return &v }
 // TestGroupRespExposesAvatarFields 回归 Fix4:GroupResp 暴露 avatar_text/avatar_color,
 // 客户端 reload 后能读回已存的自定义值。
 func TestGroupRespExposesAvatarFields(t *testing.T) {
-	resp := (&GroupResp{}).fromModel(&Model{GroupNo: "g1", Name: "n", AvatarText: "研发", AvatarColor: intPtr(3)})
+	resp := (&GroupResp{}).fromModel(&Model{
+		GroupNo:        "g1",
+		Name:           "n",
+		IsUploadAvatar: 1,
+		AvatarText:     "研发",
+		AvatarColor:    intPtr(3),
+	})
 	require.Equal(t, "研发", resp.AvatarText)
 	require.NotNil(t, resp.AvatarColor)
 	require.Equal(t, 3, *resp.AvatarColor)
+	require.Equal(t, 1, resp.IsUploadAvatar)
 
 	// 未自定义 → 空串 / nil。
 	plain := (&GroupResp{}).fromModel(&Model{GroupNo: "g2", Name: "n"})
 	require.Equal(t, "", plain.AvatarText)
 	require.Nil(t, plain.AvatarColor)
+	require.Equal(t, 0, plain.IsUploadAvatar)
 }
 
 // TestGroupReqCheckAvatar 覆盖二次弹窗自定义头像参数的纯校验：avatar_text 去不可见

--- a/modules/group/avatar_update_test.go
+++ b/modules/group/avatar_update_test.go
@@ -91,6 +91,8 @@ func TestGroupUpdateAvatarCustomValidation(t *testing.T) {
 		{"text over 4 visible runes", map[string]string{attrKeyAvatarText: "一二三四五"}},
 		{"color out of range", map[string]string{attrKeyAvatarColor: "99"}},
 		{"color non-numeric", map[string]string{attrKeyAvatarColor: "abc"}},
+		{"clear uploaded invalid", map[string]string{attrKeyAvatarText: "研发", attrKeyClearUploadedAvatar: "yes"}},
+		{"clear uploaded alone", map[string]string{attrKeyClearUploadedAvatar: "1"}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -105,6 +107,67 @@ func TestGroupUpdateAvatarCustomValidation(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "", got.AvatarText)
 	require.Nil(t, got.AvatarColor)
+}
+
+// TestGroupUpdateAvatarCustomClearsUploadedAvatar 覆盖从上传图片头像切回服务端生成
+// 文字/颜色头像的原子切换语义：同一次 PUT 写 avatar_text/avatar_color 并清除上传图优先级。
+func TestGroupUpdateAvatarCustomClearsUploadedAvatar(t *testing.T) {
+	s, ctx := newTestServer(t)
+	require.NoError(t, testutil.CleanAllTables(ctx))
+	g := New(ctx)
+
+	const groupNo = "avatar_upd_clear_upload_1"
+	oldColor := 2
+	require.NoError(t, g.db.Insert(&Model{
+		GroupNo: groupNo, Name: "上传头像群", Creator: testutil.UID, Status: 1,
+		Version: 100, IsUploadAvatar: 1, AvatarText: "旧字", AvatarColor: &oldColor,
+	}))
+	require.NoError(t, g.db.InsertMember(&MemberModel{
+		GroupNo: groupNo, UID: testutil.UID, Role: MemberRoleCreator, Status: 1,
+	}))
+
+	w := putGroupUpdate(t, s.GetRoute(), groupNo, map[string]string{
+		attrKeyAvatarText:          "研发",
+		attrKeyAvatarColor:         "5",
+		attrKeyClearUploadedAvatar: "1",
+	})
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	got, err := g.db.QueryWithGroupNo(groupNo)
+	require.NoError(t, err)
+	require.Equal(t, "研发", got.AvatarText)
+	require.NotNil(t, got.AvatarColor)
+	require.Equal(t, 5, *got.AvatarColor)
+	require.Equal(t, 0, got.IsUploadAvatar, "clear_uploaded_avatar=1 应清除上传图优先级")
+	require.NotEqual(t, int64(100), got.Version, "切换头像来源应 bump version")
+
+	// 只改文字 + clear：颜色保持；clear_uploaded_avatar 也接受 true。
+	require.NoError(t, g.db.updateAvatar("uploaded/path-1.png", 1, groupNo))
+	w = putGroupUpdate(t, s.GetRoute(), groupNo, map[string]string{
+		attrKeyAvatarText:          "产品",
+		attrKeyClearUploadedAvatar: "true",
+	})
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	got, err = g.db.QueryWithGroupNo(groupNo)
+	require.NoError(t, err)
+	require.Equal(t, "产品", got.AvatarText)
+	require.NotNil(t, got.AvatarColor)
+	require.Equal(t, 5, *got.AvatarColor, "只改文字 + clear 时颜色保持")
+	require.Equal(t, 0, got.IsUploadAvatar)
+
+	// 只改颜色 + clear：文字保持。
+	require.NoError(t, g.db.updateAvatar("uploaded/path-2.png", 2, groupNo))
+	w = putGroupUpdate(t, s.GetRoute(), groupNo, map[string]string{
+		attrKeyAvatarColor:         "7",
+		attrKeyClearUploadedAvatar: "1",
+	})
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	got, err = g.db.QueryWithGroupNo(groupNo)
+	require.NoError(t, err)
+	require.Equal(t, "产品", got.AvatarText, "只改颜色 + clear 时文字保持")
+	require.NotNil(t, got.AvatarColor)
+	require.Equal(t, 7, *got.AvatarColor)
+	require.Equal(t, 0, got.IsUploadAvatar)
 }
 
 // TestGroupUpdatePartialWriteRejected 回归:混合 payload(合法 name + 非法 avatar)
@@ -188,7 +251,7 @@ func TestGroupUpdateAvatarCustomSkipsDisbanded(t *testing.T) {
 	}))
 
 	text := "研发"
-	affected, err := g.db.updateAvatarCustom(groupNo, &text, true, intPtr(3), 200)
+	affected, err := g.db.updateAvatarCustom(groupNo, &text, true, intPtr(3), false, 200)
 	require.NoError(t, err)
 	require.Equal(t, int64(0), affected, "已解散群必须命中 0 行")
 
@@ -206,7 +269,7 @@ func TestGroupUpdateAvatarCustomSkipsDisbanded(t *testing.T) {
 		GroupNo: liveNo, Name: "正常群", Creator: "c1",
 		Status: GroupStatusNormal, Version: 100,
 	}))
-	affected, err = g.db.updateAvatarCustom(liveNo, &text, true, intPtr(3), 200)
+	affected, err = g.db.updateAvatarCustom(liveNo, &text, true, intPtr(3), false, 200)
 	require.NoError(t, err)
 	require.Equal(t, int64(1), affected, "未解散群应命中 1 行")
 	got, err = g.db.QueryWithGroupNo(liveNo)

--- a/modules/group/avatar_update_test.go
+++ b/modules/group/avatar_update_test.go
@@ -92,7 +92,6 @@ func TestGroupUpdateAvatarCustomValidation(t *testing.T) {
 		{"color out of range", map[string]string{attrKeyAvatarColor: "99"}},
 		{"color non-numeric", map[string]string{attrKeyAvatarColor: "abc"}},
 		{"clear uploaded invalid", map[string]string{attrKeyAvatarText: "研发", attrKeyClearUploadedAvatar: "yes"}},
-		{"clear uploaded alone", map[string]string{attrKeyClearUploadedAvatar: "1"}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -107,6 +106,45 @@ func TestGroupUpdateAvatarCustomValidation(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "", got.AvatarText)
 	require.Nil(t, got.AvatarColor)
+}
+
+func TestGroupUpdateAvatarCustomClearUploadedAvatarCreatorOnly(t *testing.T) {
+	s, ctx := newTestServer(t)
+	require.NoError(t, testutil.CleanAllTables(ctx))
+	g := New(ctx)
+
+	const groupNo = "avatar_upd_clear_creator_only_1"
+	require.NoError(t, g.db.Insert(&Model{
+		GroupNo: groupNo, Name: "上传头像权限群", Creator: testutil.UID, Status: 1,
+		Version: 100, IsUploadAvatar: 1, AvatarText: "旧字",
+	}))
+	require.NoError(t, g.db.InsertMember(&MemberModel{
+		GroupNo: groupNo, UID: testutil.UID, Role: MemberRoleManager, Status: 1,
+	}))
+
+	w := putGroupUpdate(t, s.GetRoute(), groupNo, map[string]string{
+		attrKeyAvatarText:          "研发",
+		attrKeyClearUploadedAvatar: "1",
+	})
+	require.Equal(t, http.StatusBadRequest, w.Code, w.Body.String())
+
+	got, err := g.db.QueryWithGroupNo(groupNo)
+	require.NoError(t, err)
+	require.Equal(t, 1, got.IsUploadAvatar, "非群主不得清除上传图优先级")
+	require.Equal(t, "旧字", got.AvatarText, "权限失败不得部分写入文字")
+
+	_, err = g.db.session.Update("group_member").Set("role", MemberRoleCreator).
+		Where("group_no=? AND uid=?", groupNo, testutil.UID).Exec()
+	require.NoError(t, err)
+	w = putGroupUpdate(t, s.GetRoute(), groupNo, map[string]string{
+		attrKeyAvatarText:          "研发",
+		attrKeyClearUploadedAvatar: "1",
+	})
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	got, err = g.db.QueryWithGroupNo(groupNo)
+	require.NoError(t, err)
+	require.Equal(t, 0, got.IsUploadAvatar)
+	require.Equal(t, "研发", got.AvatarText)
 }
 
 // TestGroupUpdateAvatarCustomClearsUploadedAvatar 覆盖从上传图片头像切回服务端生成
@@ -168,6 +206,34 @@ func TestGroupUpdateAvatarCustomClearsUploadedAvatar(t *testing.T) {
 	require.NotNil(t, got.AvatarColor)
 	require.Equal(t, 7, *got.AvatarColor)
 	require.Equal(t, 0, got.IsUploadAvatar)
+
+	// 单独 clear：确认切回已保存的生成头像字段，不强制客户端制造无意义 text/color diff。
+	require.NoError(t, g.db.updateAvatar("uploaded/path-standalone.png", 4, groupNo))
+	w = putGroupUpdate(t, s.GetRoute(), groupNo, map[string]string{
+		attrKeyClearUploadedAvatar: "1",
+	})
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	got, err = g.db.QueryWithGroupNo(groupNo)
+	require.NoError(t, err)
+	require.Equal(t, "产品", got.AvatarText)
+	require.NotNil(t, got.AvatarColor)
+	require.Equal(t, 7, *got.AvatarColor)
+	require.Equal(t, 0, got.IsUploadAvatar)
+
+	// false / 0 视为未设置 clear_uploaded_avatar：普通文字更新仍可由管理员执行，且不清上传图。
+	require.NoError(t, g.db.updateAvatar("uploaded/path-3.png", 3, groupNo))
+	_, err = g.db.session.Update("group_member").Set("role", MemberRoleManager).
+		Where("group_no=? AND uid=?", groupNo, testutil.UID).Exec()
+	require.NoError(t, err)
+	w = putGroupUpdate(t, s.GetRoute(), groupNo, map[string]string{
+		attrKeyAvatarText:          "设计",
+		attrKeyClearUploadedAvatar: "false",
+	})
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	got, err = g.db.QueryWithGroupNo(groupNo)
+	require.NoError(t, err)
+	require.Equal(t, "设计", got.AvatarText)
+	require.Equal(t, 1, got.IsUploadAvatar, "clear_uploaded_avatar=false 不应清除上传图优先级")
 }
 
 // TestGroupUpdatePartialWriteRejected 回归:混合 payload(合法 name + 非法 avatar)

--- a/modules/group/const.go
+++ b/modules/group/const.go
@@ -49,6 +49,7 @@ const (
 // 表示清除自定义色（回退按 group_no 派生）；avatar_text 为空字符串表示清除自定义
 // 文字（回退：老群取群名前 2 字，新群双人图标）。
 const (
-	attrKeyAvatarText  = "avatar_text"
-	attrKeyAvatarColor = "avatar_color"
+	attrKeyAvatarText          = "avatar_text"
+	attrKeyAvatarColor         = "avatar_color"
+	attrKeyClearUploadedAvatar = "clear_uploaded_avatar"
 )

--- a/modules/group/db.go
+++ b/modules/group/db.go
@@ -414,12 +414,10 @@ func (d *DB) updateAvatar(avatar string, avatarVersion int64, groupNo string) er
 	return err
 }
 
-// updateAvatarCustom 更新自定义群头像文字/颜色与群版本（不触碰 is_upload_avatar：
-// 自定义文字/色仍是「默认头像」范畴，渲染时实时出图，不同于上传图片）。color 为
-// *int，nil → NULL（清除自定义色，回退按 group_no 派生）。text 为空串表示清除自定义
-// 文字（回退：老群取群名前 2 字，新群双人图标）。
-// updateAvatarCustom 只更新本次实际提供的列：text 非 nil 时写 avatar_text，setColor
-// 为 true 时写 avatar_color（*int，nil → NULL 清除自定义色）；始终 bump version。
+// updateAvatarCustom 更新自定义群头像文字/颜色与群版本：text 非 nil 时写
+// avatar_text（空串表示清除自定义文字），setColor 为 true 时写 avatar_color（*int，
+// nil → NULL 清除自定义色），clearUploadedAvatar 为 true 时同一条 UPDATE 清除上传图
+// 优先级（is_upload_avatar=0）；始终 bump version。
 // 列级更新避免「读-改-写」竞态——并发只改文字 / 只改色不会互相覆盖对方的列。
 func (d *DB) updateAvatarCustom(groupNo string, text *string, setColor bool, color *int, clearUploadedAvatar bool, version int64) (int64, error) {
 	// updated_at 列是 DEFAULT CURRENT_TIMESTAMP 但**无** ON UPDATE，列级 UPDATE 不会自动

--- a/modules/group/db.go
+++ b/modules/group/db.go
@@ -421,7 +421,7 @@ func (d *DB) updateAvatar(avatar string, avatarVersion int64, groupNo string) er
 // updateAvatarCustom 只更新本次实际提供的列：text 非 nil 时写 avatar_text，setColor
 // 为 true 时写 avatar_color（*int，nil → NULL 清除自定义色）；始终 bump version。
 // 列级更新避免「读-改-写」竞态——并发只改文字 / 只改色不会互相覆盖对方的列。
-func (d *DB) updateAvatarCustom(groupNo string, text *string, setColor bool, color *int, version int64) (int64, error) {
+func (d *DB) updateAvatarCustom(groupNo string, text *string, setColor bool, color *int, clearUploadedAvatar bool, version int64) (int64, error) {
 	// updated_at 列是 DEFAULT CURRENT_TIMESTAMP 但**无** ON UPDATE，列级 UPDATE 不会自动
 	// 刷新，故显式写入，保证 GroupResp.updated_at 反映本次自定义头像变更。
 	setMap := map[string]interface{}{
@@ -433,6 +433,9 @@ func (d *DB) updateAvatarCustom(groupNo string, text *string, setColor bool, col
 	}
 	if setColor {
 		setMap["avatar_color"] = color
+	}
+	if clearUploadedAvatar {
+		setMap["is_upload_avatar"] = 0
 	}
 	// status 入 WHERE，与服务层读取时的 disband 守卫对称：读到「未解散」之后、写入之前群
 	// 被并发解散时，这里命中 0 行而非把自定义头像写到已解散的死行上（关闭 TOCTOU）。

--- a/modules/group/service.go
+++ b/modules/group/service.go
@@ -847,6 +847,7 @@ type GroupResp struct {
 	IsNamed                  int       `json:"is_named"`                    // 1=改版前老群(默认渲染群名文字)/0=新群(默认双人图标)；由 #500 迁移回填，新群恒为 0；客户端可据此本地预判默认头像取群名文字 vs 双人图标
 	AvatarText               string    `json:"avatar_text"`                 // 自定义群头像文字（空=按 is_named 回退：老群渲染群名/新群双人图标）
 	AvatarColor              *int      `json:"avatar_color"`                // 自定义群头像色板下标（null=按 group_no 派生）
+	IsUploadAvatar           int       `json:"is_upload_avatar"`            // 1=当前群头像使用上传图片；0=使用文字/颜色/默认合成头像
 	Remark                   string    `json:"remark"`                      // 群备注
 	Notice                   string    `json:"notice"`                      // 群公告
 	Mute                     int       `json:"mute"`                        // 免打扰
@@ -894,6 +895,7 @@ func (g *GroupResp) from(model *DetailModel) *GroupResp {
 		IsNamed:                  model.IsNamed,
 		AvatarText:               model.AvatarText,
 		AvatarColor:              model.AvatarColor,
+		IsUploadAvatar:           model.IsUploadAvatar,
 		Notice:                   model.Notice,
 		Mute:                     model.Mute,
 		Top:                      model.Top,
@@ -939,6 +941,7 @@ func (g *GroupResp) fromModel(model *Model) *GroupResp {
 		IsNamed:                  model.IsNamed,
 		AvatarText:               model.AvatarText,
 		AvatarColor:              model.AvatarColor,
+		IsUploadAvatar:           model.IsUploadAvatar,
 		Notice:                   model.Notice,
 		Forbidden:                model.Forbidden,
 		Invite:                   model.Invite,

--- a/modules/group/service.go
+++ b/modules/group/service.go
@@ -1066,6 +1066,8 @@ type UpdateGroupAvatarCustomServiceReq struct {
 	// 非 nil 为色板下标。为 false 时不动颜色。
 	SetAvatarColor bool
 	AvatarColor    *int
+	// ClearUploadedAvatar：同一次保存确认使用生成头像，清除上传图片头像优先级。
+	ClearUploadedAvatar bool
 }
 
 // ---------- Service method implementations ----------
@@ -1993,8 +1995,11 @@ func (s *Service) UpdateGroupAvatarCustom(req *UpdateGroupAvatarCustomServiceReq
 	if req.GroupNo == "" {
 		return errors.New("group_no is required")
 	}
-	if req.AvatarText == nil && !req.SetAvatarColor {
+	if req.AvatarText == nil && !req.SetAvatarColor && !req.ClearUploadedAvatar {
 		return errors.New("nothing to update")
+	}
+	if req.ClearUploadedAvatar && req.AvatarText == nil && !req.SetAvatarColor {
+		return errors.New("clear_uploaded_avatar requires avatar_text or avatar_color")
 	}
 
 	groupModel, err := s.db.QueryWithGroupNo(req.GroupNo)
@@ -2016,7 +2021,7 @@ func (s *Service) UpdateGroupAvatarCustom(req *UpdateGroupAvatarCustomServiceReq
 	// updateAvatarCustom 的 WHERE 带 status<>disband：若读到未解散之后、写入之前群被并发
 	// 解散，则命中 0 行——据此返回 not-found/disbanded，不把 version/通知误发到死行（关闭
 	// 上面 read-check 与本次 write 之间的 TOCTOU）。
-	affected, err := s.db.updateAvatarCustom(req.GroupNo, req.AvatarText, req.SetAvatarColor, req.AvatarColor, version)
+	affected, err := s.db.updateAvatarCustom(req.GroupNo, req.AvatarText, req.SetAvatarColor, req.AvatarColor, req.ClearUploadedAvatar, version)
 	if err != nil {
 		s.Error("update group avatar custom failed", zap.Error(err))
 		return errors.New("failed to update group avatar")

--- a/modules/group/service.go
+++ b/modules/group/service.go
@@ -1998,9 +1998,6 @@ func (s *Service) UpdateGroupAvatarCustom(req *UpdateGroupAvatarCustomServiceReq
 	if req.AvatarText == nil && !req.SetAvatarColor && !req.ClearUploadedAvatar {
 		return errors.New("nothing to update")
 	}
-	if req.ClearUploadedAvatar && req.AvatarText == nil && !req.SetAvatarColor {
-		return errors.New("clear_uploaded_avatar requires avatar_text or avatar_color")
-	}
 
 	groupModel, err := s.db.QueryWithGroupNo(req.GroupNo)
 	if err != nil {
@@ -2032,6 +2029,18 @@ func (s *Service) UpdateGroupAvatarCustom(req *UpdateGroupAvatarCustomServiceReq
 
 	// 通知客户端刷新频道信息 → 重新拉取头像。
 	s.ctx.SendChannelUpdateToGroup(req.GroupNo)
+	if req.ClearUploadedAvatar {
+		if err := s.ctx.SendCMD(config.MsgCMDReq{
+			ChannelID:   req.GroupNo,
+			ChannelType: common.ChannelTypeGroup.Uint8(),
+			CMD:         common.CMDGroupAvatarUpdate,
+			Param: map[string]interface{}{
+				"group_no": req.GroupNo,
+			},
+		}); err != nil {
+			s.Error("send group avatar update cmd failed", zap.String("group_no", req.GroupNo), zap.Error(err))
+		}
+	}
 
 	return nil
 }

--- a/modules/group/swagger/api.yaml
+++ b/modules/group/swagger/api.yaml
@@ -532,6 +532,9 @@ paths:
               avatar_color:
                 type: integer
                 description: "自定义群头像色板下标 [0, 调色板大小)；空串或 -1 清除→回退按 group_no 派生"
+              clear_uploaded_avatar:
+                type: string
+                description: "确认切回服务端生成头像并清除上传图优先级；仅接受字符串 '1'/'true'（'0'/'false'/空串视为未设置）；当当前头像来源为上传图时仅群主可用"
 
       responses:
         200:

--- a/modules/group/swagger/api.yaml
+++ b/modules/group/swagger/api.yaml
@@ -534,7 +534,7 @@ paths:
                 description: "自定义群头像色板下标 [0, 调色板大小)；空串或 -1 清除→回退按 group_no 派生"
               clear_uploaded_avatar:
                 type: string
-                description: "确认切回服务端生成头像并清除上传图优先级；仅接受字符串 '1'/'true'（'0'/'false'/空串视为未设置）；当当前头像来源为上传图时仅群主可用"
+                description: "确认切回服务端生成头像并清除上传图优先级；仅接受字符串 '1'/'true'（'0'/'false'/空串视为未设置）；仅群主可用"
 
       responses:
         200:


### PR DESCRIPTION
## Summary
- Add a controlled `clear_uploaded_avatar` field to `PUT /v1/groups/:group_no` for generated-avatar saves.
- Accept `"1"` / `"true"` as clear intent and treat `"0"` / `"false"` / empty as unset.
- Clear `is_upload_avatar` in the same avatar custom UPDATE so switching from uploaded image to generated text/color avatar is atomic.
- Gate all `clear_uploaded_avatar=true` requests to the group creator, matching the creator-only upload path and closing stale-snapshot upload/clear races.
- Emit `CMDGroupAvatarUpdate` when clearing upload priority so all clients invalidate cached avatar images.
- Cover invalid values, creator-only clear, standalone clear, false/no-op parsing, and uploaded → generated transitions in group avatar update tests.

## Dependency / Rollout
- Required by web PR: https://github.com/Mininglamp-OSS/octo-web/pull/1311
- Ship this server PR before or with the web PR. If web ships first, uploaded-image groups can save generated fields but will keep rendering the old uploaded avatar until this backend field is deployed.
- Prior field exposure PR is already merged: https://github.com/Mininglamp-OSS/octo-server/pull/728

## Test plan
- `git diff --check` ✅
- Local `go test` / `gofmt` not run in this runtime: `go` and `gofmt` are not on PATH. GitHub CI should validate.

## Risks
- Existing uploaded avatar object/path is intentionally preserved; only `is_upload_avatar` priority is cleared.
- Standalone clear is intentional so web can confirm switching to already-saved generated fields without manufacturing a text/color diff.

Closes #730
Multica Issue: OCT-8
