### PR TITLE
feat(agent-mail): add browser identity gateway

### DIFF
--- a/.octospec/journal/shared/agent-mail-identity-gateway.md
+++ b/.octospec/journal/shared/agent-mail-identity-gateway.md
@@ -1,0 +1,68 @@
+---
+type: Journal
+title: "Learning: Agent Mail identity gateway"
+description: "Human mailbox ownership and Agent mailbox credentials need separate HTTP trust boundaries even when they share one public base URL."
+tags: ["octospec-learning", "auth", "space", "agent-mail", "isolation"]
+timestamp: 2026-07-29T13:50:00Z
+source: self
+---
+
+# Learning: Agent Mail identity gateway
+
+## What changed
+
+Browser mail requests now derive identity from the authenticated OCTO user and
+validated Space, then use a short-lived request-bound assertion to resolve an
+explicitly provisioned octo-mail owner. Shared Basic/API-key owner injection was
+removed.
+
+## What we learned
+
+The human owner path and the Agent `omb_` path cannot share one proxy behavior:
+the human path must replace caller credentials, while the Agent path must
+preserve only its mailbox-scoped credential. They can still use one public OCTO
+base URL by using separate paths. Mixing them either breaks CLI authorization or
+risks reintroducing a shared/over-privileged credential.
+
+An Agent mailbox credential must also never receive a general send capability.
+Manual Draft delivery does not need a second Bot bridge in octo-server: the
+Mail Plugin can consume the host's trusted-owner signal and ask octo-mail to
+apply a narrowly scoped, idempotent owner-confirmed Draft operation using the
+existing mailbox credential. Keeping that flow out of this gateway avoids a
+second cross-service identity translation and leaves octo-server responsible
+only for browser identity proxying.
+
+Buffered gateways must bound time as well as bytes. A concurrency slot or byte
+reservation is not a real resource bound if a peer can stop making progress and
+hold it forever. The browser body, upstream upload/header phase, upstream
+response body, and downstream browser write therefore use progress timeouts,
+while small bodies bypass the large-body weighted budget.
+
+The upload byte reservation must follow the lifetime of the actual buffered
+bytes, not the whole downstream handler and not merely the return of
+`http.Client.Do`. A Go `RoundTripper` may close a request body asynchronously
+after returning the response, so a close-aware request body drops its buffered
+reader and only then releases the reservation. This keeps the accounting
+truthful without allowing a slow browser response to consume all upload budget.
+
+An identity-replacing proxy also needs an explicit cache boundary. Authenticated
+users, Spaces, and mailboxes share the same URL shape, so upstream cache headers
+cannot be trusted to express the gateway's identity dimensions. Gateway
+responses are therefore always private and non-storable and name all three
+selector headers in `Vary`.
+
+Rejecting an unknown-length body also requires expiring the server read
+deadline before closing it. `net/http` may otherwise drain an unread chunked
+body to reuse the connection; a client that stops immediately after the first
+over-limit byte can block that drain forever after the progress watchdog has
+already stopped, retaining both the handler and its resource reservations.
+
+Space must be part of the persisted owner mapping, not only request metadata.
+The same OCTO UID in two Spaces can otherwise see one shared mailbox and violate
+Space isolation even though middleware membership checks pass.
+
+## Rule impact
+
+No new general repository rule. The browser assertion contract, progress
+bounds, and the decision not to expose a Bot Draft-send route are recorded in
+the linked task brief, module README, and focused tests.

--- a/.octospec/tasks/agent-mail-identity-gateway/brief.md
+++ b/.octospec/tasks/agent-mail-identity-gateway/brief.md
@@ -1,0 +1,83 @@
+---
+type: Task
+title: "Task: agent-mail-identity-gateway"
+description: "Bind Agent Mail requests to the authenticated OCTO user and validated Space instead of a shared mailbox credential."
+tags: ["agent-mail", "auth", "space", "isolation", "proxy", "wire-contract", "testing"]
+timestamp: 2026-07-29T10:15:00Z
+slug: agent-mail-identity-gateway
+source: self
+upstream: "https://github.com/Mininglamp-OSS/octo-server/issues/735"
+---
+
+# Task: agent-mail-identity-gateway
+
+## Goal
+
+Route browser Agent Mail requests through an authenticated OCTO gateway. The
+gateway derives the actor from the OCTO session and the Space from validated
+middleware state, then presents a short-lived signed identity assertion to
+octo-mail. Different users and Spaces must never inherit one shared mailbox
+credential.
+
+## Background
+
+The current local `/mail-api` proxy injects one server-side Basic/API-key
+credential. It is useful for single-mailbox UI development but makes every OCTO
+user appear as the same mail owner. V1 requires user, mailbox, and Space
+isolation before additional product expansion.
+
+## Load-bearing list
+
+- OCTO authentication: the actor is always `GetLoginUID()` and never comes from
+  a request field or caller-controlled header.
+- Space isolation: the route requires a non-empty Space validated by
+  `SpaceMiddleware`; missing or non-member Spaces fail closed.
+- Gateway assertion: method, upstream request URI, body digest, actor, Space,
+  selected mailbox, issue time, expiry, and nonce are HMAC-bound with a managed
+  shared secret; octo-mail consumes each nonce once.
+- Proxy boundary: browser Authorization headers are never forwarded as
+  octo-mail owner credentials; hop-by-hop headers and secrets are not logged;
+  private mail responses cannot be reused across authenticated identities by a
+  shared cache.
+- octo-mail mapping: a signed `(issuer, subject, space)` resolves to one
+  provisioned owner principal and a mailbox owned by that principal.
+- Rule mutations retain the human-owner requirement; an Agent credential is not
+  upgraded by the gateway.
+- Streaming bounds: request buffering, upstream upload, response headers,
+  upstream response reads, and downstream response writes have explicit
+  size/concurrency/progress limits.
+
+## Out of scope
+
+- Public-domain reputation, SPF/DKIM/DMARC/PTR, or external mailbox hosting.
+- A general Channel gateway or shared IM/Mail protocol.
+- Automatic Agent task execution or Runtime processing state.
+- Silently choosing among multiple sender identities without an explicit,
+  ownership-checked mailbox selection.
+- Owner confirmation and Agent Draft delivery. Those remain inside the Mail
+  Plugin and octo-mail credential boundary; octo-server exposes no Bot
+  Draft-send endpoint.
+
+## Acceptance
+
+- Requests without a valid OCTO session or validated Space never reach
+  octo-mail.
+- User A and user B in the same Space resolve to different provisioned mail
+  owners and cannot list, read, send as, or mutate each other's mailbox.
+- The same UID in two Spaces resolves only through the exact provisioned Space
+  binding; no fallback to another Space exists.
+- Tampered, expired, wrong-method, wrong-path, or wrong-body gateway assertions
+  are rejected uniformly.
+- The mailbox selector is signed and a gateway assertion is single-use.
+- Browser requests no longer depend on a global `MAIL_API_AUTHORIZATION` or
+  `MAIL_API_TOKEN` for owner identity.
+- Stalled request bodies, upstream uploads, response-header waits, upstream
+  response bodies, and downstream response writes release their gateway
+  resources within the configured progress timeout; small requests do not wait
+  behind the large-body budget.
+- Oversized, stalled, malformed, and truncated transfers fail explicitly and
+  release their concurrency slots and byte-budget reservations.
+- Proxied mail responses are non-storable and vary on every request header that
+  selects the authenticated user, Space, or mailbox.
+- Focused gateway/auth/isolation tests, formatting, vet, and relevant builds
+  pass before Docker integration is declared complete.

--- a/.octospec/tasks/agent-mail-identity-gateway/context.yaml
+++ b/.octospec/tasks/agent-mail-identity-gateway/context.yaml
@@ -1,0 +1,31 @@
+brief: .octospec/tasks/agent-mail-identity-gateway/brief.md
+injected:
+  - id: space-isolation
+    source: repo
+    reason: "The gateway handles user mailbox data and must bind every request to an authenticated UID and validated Space."
+  - id: trust-boundary
+    source: repo
+    reason: "The browser proxy replaces caller credentials with a request-bound identity assertion at the OCTO/octo-mail boundary."
+  - id: error-handling
+    source: repo
+    reason: "The new authenticated API must preserve the localized OCTO error envelope."
+  - id: rate-limit
+    source: repo
+    reason: "The authenticated proxy route must use the shared per-UID limiter."
+  - id: testing
+    source: repo
+    reason: "Identity and proxy trust-boundary changes require negative tests."
+  - id: commit-style
+    source: repo
+    reason: "Repository convention; no commit is created in this local phase."
+files_expected:
+  - modules/agentmailgateway/**
+  - internal/modules.go
+  - pkg/errcode/agent_mail_gateway.go
+  - pkg/i18n/response_writer.go
+  - pkg/i18n/locales/active.zh-CN.toml
+  - pkg/metrics/http.go
+  - tools/i18nmarkers/server/active.en-US.toml
+  - .octospec/journal/shared/agent-mail-identity-gateway.md
+  - .octospec/tasks/agent-mail-identity-gateway/verification.md
+updated_at: 2026-08-13T06:34:59Z

--- a/.octospec/tasks/agent-mail-identity-gateway/verification.md
+++ b/.octospec/tasks/agent-mail-identity-gateway/verification.md
@@ -1,0 +1,37 @@
+# Verification
+
+- Rules checked: `space-isolation`, `trust-boundary`, `error-handling`,
+  `rate-limit`, `testing`, `commit-style`.
+- Commands run:
+  - `go test ./modules/agentmailgateway/... -count=1` -> pass.
+  - `go test -race ./modules/agentmailgateway/... -count=1` -> pass.
+  - `go vet ./modules/agentmailgateway/... ./pkg/i18n ./pkg/metrics` -> pass.
+  - `go build ./...` -> pass.
+  - `make i18n-extract-check && make i18n-lint` -> pass.
+  - `gofmt -l` on the touched Go files -> clean.
+  - `git diff --check` -> pass.
+- Acceptance:
+  - Browser gateway assertions bind UID, Space, mailbox, method, URI, body,
+    lifetime, and nonce.
+  - octo-server exposes no Bot Draft-send bridge; owner confirmation and scoped
+    delivery remain in the Mail Plugin and octo-mail boundary.
+  - Known-length and self-delimiting unknown-length responses stream with
+    client-visible truncation on HTTP/1.1; ambiguous close-delimited and
+    non-HTTP/1.1 unknown-length responses fail before status commit.
+  - Upstream compression negotiation is fixed to `identity`, so a gzip response
+    retains its known wire length and succeeds over an HTTP/2 downstream while
+    genuinely unknown-length HTTP/2 responses remain fail-closed.
+  - Request buffering has per-request, concurrent-buffering, aggregate
+    accounted-byte, and progress-time bounds. Real stalled and over-limit
+    unknown-length network bodies produce explicit errors and release the
+    large-body slot and byte reservation; the upstream request body drops its
+    buffered reader before releasing the reservation; upstream upload/response
+    and downstream write stalls terminate; and slow browser reads do not retain
+    request-body budget after the upstream upload closes.
+  - Every proxied response overrides upstream cache policy with `private,
+    no-store` and varies on `token`, `X-Space-ID`, and `X-Octo-Mailbox-ID`.
+  - Conditional attachment resume forwards `If-Range`, the signed assertion
+    test pins the mailbox claim, and `HEAD` metadata is not rejected merely
+    because the represented body is larger than the response-body limit.
+- Out of scope check: no general Bot mail-send endpoint, new approval UI, or
+  automatic-send behavior was added.

--- a/internal/modules.go
+++ b/internal/modules.go
@@ -21,6 +21,7 @@ package modules
 
 // 引入模块
 import (
+	_ "github.com/Mininglamp-OSS/octo-server/modules/agentmailgateway"
 	_ "github.com/Mininglamp-OSS/octo-server/modules/backup"
 	_ "github.com/Mininglamp-OSS/octo-server/modules/base"
 

--- a/modules/agentmailgateway/1module.go
+++ b/modules/agentmailgateway/1module.go
@@ -1,0 +1,17 @@
+package agentmailgateway
+
+import (
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/register"
+)
+
+func init() {
+	register.AddModule(func(ctx interface{}) register.Module {
+		return register.Module{
+			Name: "agentmailgateway",
+			SetupAPI: func() register.APIRouter {
+				return New(ctx.(*config.Context))
+			},
+		}
+	})
+}

--- a/modules/agentmailgateway/README.md
+++ b/modules/agentmailgateway/README.md
@@ -1,0 +1,77 @@
+# Agent Mail identity gateway
+
+This module exposes the authenticated OCTO route:
+
+```text
+/v1/mail-gateway/webapi/v0/*
+```
+
+It derives the subject from the OCTO login session and the Space from
+`SpaceMiddleware`, then replaces caller credentials with a one-minute HMAC
+assertion bound to the exact upstream method, URI, and body.
+
+## Configuration
+
+Both variables are required to enable the gateway:
+
+```text
+OCTO_MAIL_GATEWAY_URL=http://octo-mail:8090
+OCTO_MAIL_GATEWAY_SECRET=<at least 32 bytes>
+```
+
+The optional `OCTO_MAIL_GATEWAY_TIMEOUT` is a Go duration and defaults to
+`30s`. The value must not exceed `2m`. It bounds each no-progress phase rather
+than the whole browser request:
+
+- reading the browser request body;
+- connecting to octo-mail and completing the TLS handshake;
+- uploading the buffered request body and waiting for response headers;
+- reading the upstream response body; and
+- writing each response chunk to the browser.
+
+Each successful body read resets the relevant progress timer, so a large
+transfer that continues making progress is not cut off by a whole-request
+deadline. The browser request context remains the outer cancellation boundary.
+
+The same secret must be configured as `OCTO_MAIL_GATEWAY_SECRET` in
+octo-mail. The secret is an internal service credential and must not be sent to
+the browser or used as an account API key.
+
+Only the octo-mail `/webapi/v0` surface is reachable. Browser `Authorization`,
+`token`, cookies, caller identity headers, and hop-by-hop headers are not
+forwarded. `X-Octo-Mailbox-ID` is the only mailbox selection header and is
+validated again by octo-mail against the mapped owner.
+
+Every proxied response is marked `Cache-Control: private, no-store` and varies
+on the session token, validated Space, and selected mailbox headers. This
+prevents a shared cache from reusing one caller's mail response for another
+caller even though their gateway URLs are otherwise identical.
+
+## Streaming and memory bounds
+
+- Known-length responses retain the upstream `Content-Length`; a short transfer
+  is therefore visible to the client.
+- The gateway requests `Accept-Encoding: identity` from octo-mail instead of
+  forwarding browser compression preferences. This prevents Go's transport
+  from transparently turning a known-length gzip response into an
+  unknown-length response that HTTP/2 cannot safely truncate. If an upstream
+  still returns a compressed representation, its encoding and known length are
+  preserved for the browser.
+- HTTP/1.1 chunked responses stream immediately. A read failure, progress
+  timeout, or the 64 MiB response limit aborts the HTTP/1.1 client connection so
+  it cannot end as a clean chunked success.
+- HTTP/1.x close-delimited responses are rejected before their status is
+  committed because EOF cannot distinguish completion from truncation.
+  Unknown-length responses are also rejected for HTTP/1.0 and HTTP/2 downstream
+  clients, where this handler cannot reliably surface a mid-stream failure.
+- Request and response bodies each have a 64 MiB per-request limit. Four slots
+  bound concurrent large-body buffering. Bodies over 1 MiB additionally use a
+  256 MiB weighted budget until the upstream transport closes its request body.
+  Closing that body drops the transport-visible reference to the buffered bytes
+  before releasing the reservation, so a slow browser response cannot retain
+  unrelated upload capacity. Smaller bodies bypass that large-body budget.
+  Requests without a declared length reserve the full 64 MiB allowance and are
+  still bounded by the four slots and progress timeout. An over-limit
+  unknown-length request is rejected with `413` and its connection is made
+  non-reusable before the unread body is closed, preventing `net/http`'s
+  connection-reuse drain from retaining those reservations.

--- a/modules/agentmailgateway/api_i18n.go
+++ b/modules/agentmailgateway/api_i18n.go
@@ -1,0 +1,11 @@
+package agentmailgateway
+
+import (
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n/codes"
+)
+
+func respondGatewayError(c *wkhttp.Context, code codes.Code) {
+	httperr.ResponseErrorLWithStatus(c, code, nil, nil)
+}

--- a/modules/agentmailgateway/api_i18n_test.go
+++ b/modules/agentmailgateway/api_i18n_test.go
@@ -1,0 +1,38 @@
+package agentmailgateway
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestAgentMailGatewayNoLegacyErrorResponse keeps locally generated errors on
+// the i18n envelope. The transparent proxy deliberately writes the upstream
+// status and body through c.Status/c.Writer, so those success/error passthrough
+// primitives are not banned here.
+func TestAgentMailGatewayNoLegacyErrorResponse(t *testing.T) {
+	data, err := os.ReadFile("gateway.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var clean strings.Builder
+	for _, line := range strings.Split(string(data), "\n") {
+		if idx := strings.Index(line, "//"); idx >= 0 {
+			line = line[:idx]
+		}
+		clean.WriteString(line)
+		clean.WriteByte('\n')
+	}
+	for _, banned := range []string{
+		".ResponseError(",
+		".ResponseErrorf(",
+		".ResponseErrorWithStatus(",
+		".AbortWithStatusJSON(",
+		".AbortWithStatus(",
+		"c.JSON(",
+	} {
+		if strings.Contains(clean.String(), banned) {
+			t.Fatalf("gateway.go must render local errors through respondGatewayError instead of %s", banned)
+		}
+	}
+}

--- a/modules/agentmailgateway/assertion.go
+++ b/modules/agentmailgateway/assertion.go
@@ -1,0 +1,83 @@
+package agentmailgateway
+
+import (
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+)
+
+const (
+	assertionPrefix  = "omg_"
+	assertionVersion = 1
+	assertionIssuer  = "octo-server"
+)
+
+var errInvalidAssertionInput = errors.New("invalid gateway assertion input")
+
+// assertionClaims is the wire contract shared with octo-mail. It binds the
+// authenticated OCTO identity to one exact upstream HTTP request.
+type assertionClaims struct {
+	Version    int    `json:"v"`
+	Issuer     string `json:"iss"`
+	Subject    string `json:"sub"`
+	SpaceID    string `json:"space"`
+	MailboxID  string `json:"mailbox,omitempty"`
+	Method     string `json:"method"`
+	RequestURI string `json:"uri"`
+	BodySHA256 string `json:"body_sha256"`
+	IssuedAt   int64  `json:"iat"`
+	ExpiresAt  int64  `json:"exp"`
+	Nonce      string `json:"nonce"`
+}
+
+func signAssertion(secret []byte, subject, spaceID, method, requestURI string, body []byte, now time.Time, nonceSource io.Reader) (string, error) {
+	return signAssertionForMailbox(secret, subject, spaceID, "", method, requestURI, body, now, nonceSource)
+}
+
+func signAssertionForMailbox(secret []byte, subject, spaceID, mailboxID, method, requestURI string, body []byte, now time.Time, nonceSource io.Reader) (string, error) {
+	if len(secret) < 32 || strings.TrimSpace(subject) == "" || strings.TrimSpace(spaceID) == "" ||
+		strings.TrimSpace(method) == "" || requestURI == "" || nonceSource == nil {
+		return "", errInvalidAssertionInput
+	}
+
+	nonce := make([]byte, 16)
+	if _, err := io.ReadFull(nonceSource, nonce); err != nil {
+		return "", fmt.Errorf("generate assertion nonce: %w", err)
+	}
+	bodySum := sha256.Sum256(body)
+	now = now.UTC()
+	claims := assertionClaims{
+		Version:    assertionVersion,
+		Issuer:     assertionIssuer,
+		Subject:    strings.TrimSpace(subject),
+		SpaceID:    strings.TrimSpace(spaceID),
+		MailboxID:  strings.TrimSpace(mailboxID),
+		Method:     strings.ToUpper(strings.TrimSpace(method)),
+		RequestURI: requestURI,
+		BodySHA256: hex.EncodeToString(bodySum[:]),
+		IssuedAt:   now.Unix(),
+		ExpiresAt:  now.Add(time.Minute).Unix(),
+		Nonce:      base64.RawURLEncoding.EncodeToString(nonce),
+	}
+	payload, err := json.Marshal(claims)
+	if err != nil {
+		return "", fmt.Errorf("marshal assertion claims: %w", err)
+	}
+	payloadText := base64.RawURLEncoding.EncodeToString(payload)
+	mac := hmac.New(sha256.New, secret)
+	_, _ = mac.Write([]byte(payloadText))
+	signature := base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
+	return assertionPrefix + payloadText + "." + signature, nil
+}
+
+func randomNonceSource() io.Reader {
+	return rand.Reader
+}

--- a/modules/agentmailgateway/assertion_test.go
+++ b/modules/agentmailgateway/assertion_test.go
@@ -1,0 +1,51 @@
+package agentmailgateway
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+)
+
+const fixedAssertionVector = "omg_eyJ2IjoxLCJpc3MiOiJvY3RvLXNlcnZlciIsInN1YiI6InVzZXItYSIsInNwYWNlIjoic3BhY2UtYSIsIm1ldGhvZCI6IlBPU1QiLCJ1cmkiOiIvd2ViYXBpL3YwL21lc3NhZ2VzP3g9MSIsImJvZHlfc2hhMjU2IjoiMjMwZDgzNThkYzhlODg5MGI0YzU4ZGVlYjYyOTEyZWUyZjIwMzU3YWU5MmE1Y2M4NjFiOThlNjhmZTMxYWNiNSIsImlhdCI6MTc4NTMxOTIwMCwiZXhwIjoxNzg1MzE5MjYwLCJub25jZSI6IkFBRUNBd1FGQmdjSUNRb0xEQTBPRHcifQ.djWC9k17lq-g2zuKORkSnQUuEKZK9dIYl8ktFBHSqIc"
+
+func TestSignAssertionMatchesOctoMailWireVector(t *testing.T) {
+	secret := []byte(strings.Repeat("s", 32))
+	nonce := make([]byte, 16)
+	for i := range nonce {
+		nonce[i] = byte(i)
+	}
+	now := time.Date(2026, 7, 29, 10, 0, 0, 0, time.UTC)
+
+	token, err := signAssertion(
+		secret,
+		"user-a",
+		"space-a",
+		"post",
+		"/webapi/v0/messages?x=1",
+		[]byte("body"),
+		now,
+		bytes.NewReader(nonce),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if token != fixedAssertionVector {
+		t.Fatalf("wire token mismatch\n got: %s\nwant: %s", token, fixedAssertionVector)
+	}
+}
+
+func TestSignAssertionRejectsIncompleteIdentity(t *testing.T) {
+	secret := []byte(strings.Repeat("s", 32))
+	for name, identity := range map[string][2]string{
+		"subject": {"", "space-a"},
+		"space":   {"user-a", ""},
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, err := signAssertion(secret, identity[0], identity[1], "GET", "/webapi/v0/mailboxes", nil, time.Now(), bytes.NewReader(make([]byte, 16)))
+			if err == nil {
+				t.Fatal("incomplete identity was accepted")
+			}
+		})
+	}
+}

--- a/modules/agentmailgateway/gateway.go
+++ b/modules/agentmailgateway/gateway.go
@@ -1,0 +1,858 @@
+package agentmailgateway
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"path"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
+	spacepkg "github.com/Mininglamp-OSS/octo-server/pkg/space"
+	appwkhttp "github.com/Mininglamp-OSS/octo-server/pkg/wkhttp"
+	"go.uber.org/zap"
+	"golang.org/x/sync/semaphore"
+)
+
+const (
+	envGatewayURL     = "OCTO_MAIL_GATEWAY_URL"
+	envGatewaySecret  = "OCTO_MAIL_GATEWAY_SECRET"
+	envGatewayTimeout = "OCTO_MAIL_GATEWAY_TIMEOUT"
+
+	gatewayRoutePrefix          = "/v1/mail-gateway"
+	mailAPIPrefix               = "/webapi/v0"
+	maxRequestBytes             = int64(64 << 20)
+	maxResponseBytes            = int64(64 << 20)
+	largeRequestThreshold       = int64(1 << 20)
+	maxConcurrentLargeRequests  = 4
+	maxInFlightRequestBodyBytes = maxConcurrentLargeRequests * maxRequestBytes
+	defaultLargeRequestSlotWait = 5 * time.Second
+	defaultTimeout              = 30 * time.Second
+)
+
+var allowedMethods = map[string]struct{}{
+	http.MethodGet: {}, http.MethodHead: {}, http.MethodPost: {},
+	http.MethodPut: {}, http.MethodPatch: {}, http.MethodDelete: {},
+	http.MethodOptions: {},
+}
+
+var (
+	errGatewayNotConfigured  = errors.New("Agent Mail gateway is not configured")
+	errBodyTooLarge          = errors.New("body exceeds gateway limit")
+	errLargeRequestSlotWait  = errors.New("timed out waiting for a large request slot")
+	errRequestBodyBudgetWait = errors.New("timed out waiting for request body budget")
+)
+
+type gatewayConfig struct {
+	upstream *url.URL
+	secret   []byte
+	timeout  time.Duration
+}
+
+// Gateway authenticates browser mail requests through OCTO and proxies only
+// the octo-mail WebAPI surface using a short-lived request-bound assertion.
+type Gateway struct {
+	ctx *config.Context
+	log.Log
+	cfg         gatewayConfig
+	client      *http.Client
+	now         func() time.Time
+	nonceSource io.Reader
+	// largeRequestSlots bounds the number of request bodies large enough to
+	// create material memory pressure while they are buffered for signing. The
+	// weighted budget separately bounds bodies retained by upstream uploads.
+	largeRequestSlots    chan struct{}
+	largeRequestSlotWait time.Duration
+	requestBodyBudget    *semaphore.Weighted
+}
+
+func New(ctx *config.Context) *Gateway {
+	cfg, err := loadGatewayConfig()
+	g := &Gateway{
+		ctx:                  ctx,
+		Log:                  log.NewTLog("AgentMailGateway"),
+		cfg:                  cfg,
+		now:                  time.Now,
+		nonceSource:          randomNonceSource(),
+		largeRequestSlots:    make(chan struct{}, maxConcurrentLargeRequests),
+		largeRequestSlotWait: defaultLargeRequestSlotWait,
+		requestBodyBudget:    semaphore.NewWeighted(maxInFlightRequestBodyBytes),
+	}
+	if err != nil {
+		if errors.Is(err, errGatewayNotConfigured) {
+			g.Warn("Agent Mail gateway is disabled because it is not configured")
+		} else {
+			g.Error("Agent Mail gateway is disabled because its configuration is invalid", zap.Error(err))
+		}
+	}
+	g.client = newGatewayHTTPClient(cfg.timeout)
+	return g
+}
+
+func loadGatewayConfig() (gatewayConfig, error) {
+	cfg := gatewayConfig{timeout: defaultTimeout}
+	rawURL := strings.TrimSpace(os.Getenv(envGatewayURL))
+	secret := os.Getenv(envGatewaySecret)
+	if rawURL == "" && secret == "" {
+		return cfg, errGatewayNotConfigured
+	}
+	if rawURL == "" || secret == "" {
+		return cfg, fmt.Errorf("%s and %s must be configured together", envGatewayURL, envGatewaySecret)
+	}
+	if len([]byte(secret)) < 32 {
+		return cfg, fmt.Errorf("%s must contain at least 32 bytes", envGatewaySecret)
+	}
+	upstream, err := url.Parse(rawURL)
+	if err != nil || (upstream.Scheme != "http" && upstream.Scheme != "https") || upstream.Host == "" ||
+		upstream.User != nil || upstream.RawQuery != "" || upstream.Fragment != "" {
+		return cfg, fmt.Errorf("%s must be an http(s) origin with an optional path", envGatewayURL)
+	}
+	upstream.Path = strings.TrimRight(upstream.Path, "/")
+	upstream.RawPath = strings.TrimRight(upstream.RawPath, "/")
+
+	if rawTimeout := strings.TrimSpace(os.Getenv(envGatewayTimeout)); rawTimeout != "" {
+		parsed, err := time.ParseDuration(rawTimeout)
+		if err != nil || parsed <= 0 || parsed > 2*time.Minute {
+			return cfg, fmt.Errorf("%s must be between 1ns and 2m", envGatewayTimeout)
+		}
+		cfg.timeout = parsed
+	}
+	cfg.upstream = upstream
+	cfg.secret = []byte(secret)
+	return cfg, nil
+}
+
+func newGatewayHTTPClient(timeout time.Duration) *http.Client {
+	timeout = normalizedGatewayTimeout(timeout)
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.DialContext = (&net.Dialer{
+		Timeout:   timeout,
+		KeepAlive: 30 * time.Second,
+	}).DialContext
+	transport.TLSHandshakeTimeout = timeout
+	transport.ResponseHeaderTimeout = timeout
+	return &http.Client{
+		Transport: transport,
+		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+}
+
+func normalizedGatewayTimeout(timeout time.Duration) time.Duration {
+	if timeout <= 0 {
+		return defaultTimeout
+	}
+	return timeout
+}
+
+// Route requires the standard authenticated UID and validated Space before the
+// request can reach the proxy trust boundary.
+func (g *Gateway) Route(r *wkhttp.WKHttp) {
+	group := r.Group(
+		gatewayRoutePrefix,
+		g.ctx.AuthMiddleware(r),
+		appwkhttp.SharedUIDRateLimiter(r, g.ctx),
+		spacepkg.SpaceMiddleware(g.ctx),
+	)
+	group.RouterGroup.Any("/*path", r.WKHttpHandler(g.proxy))
+}
+
+func (g *Gateway) proxy(c *wkhttp.Context) {
+	uid := strings.TrimSpace(c.GetLoginUID())
+	spaceID := strings.TrimSpace(spacepkg.GetSpaceID(c))
+	if uid == "" {
+		respondGatewayError(c, errcode.ErrAgentMailGatewayUnauthorized)
+		return
+	}
+	if spaceID == "" {
+		respondGatewayError(c, errcode.ErrAgentMailGatewaySpaceRequired)
+		return
+	}
+	if g.cfg.upstream == nil || len(g.cfg.secret) < 32 || g.client == nil {
+		respondGatewayError(c, errcode.ErrAgentMailGatewayUnavailable)
+		return
+	}
+	if _, ok := allowedMethods[c.Request.Method]; !ok {
+		respondGatewayError(c, errcode.ErrAgentMailGatewayRequestInvalid)
+		return
+	}
+
+	target, err := g.upstreamURL(c.Request.URL)
+	if err != nil {
+		respondGatewayError(c, errcode.ErrAgentMailGatewayRequestInvalid)
+		return
+	}
+	if c.Request.ContentLength > maxRequestBytes {
+		respondGatewayError(c, errcode.ErrAgentMailGatewayPayloadTooLarge)
+		return
+	}
+	releaseLargeRequest, err := g.acquireLargeRequestSlot(c.Request)
+	if err != nil {
+		respondGatewayError(c, errcode.ErrAgentMailGatewayUnavailable)
+		return
+	}
+	defer releaseLargeRequest()
+	releaseRequestBodyBudget, err := g.acquireRequestBodyBudget(c.Request)
+	if err != nil {
+		respondGatewayError(c, errcode.ErrAgentMailGatewayUnavailable)
+		return
+	}
+	releaseBudgetOnReturn := true
+	defer func() {
+		if releaseBudgetOnReturn {
+			releaseRequestBodyBudget()
+		}
+	}()
+	timeout := normalizedGatewayTimeout(g.cfg.timeout)
+	responseController := http.NewResponseController(c.Writer)
+	requestBody := newIdleTimeoutReadCloser(c.Request.Body, timeout, func() {
+		// A real net/http request body holds its own mutex while blocked in Read,
+		// so Close alone cannot reliably interrupt a slow client. Expiring the
+		// connection read deadline first makes that Read return; Close remains a
+		// fallback for test/custom bodies and non-standard servers.
+		if err := responseController.SetReadDeadline(time.Now()); err != nil {
+			g.Warn("Failed to expire stalled Agent Mail request body", zap.Error(err))
+		}
+	})
+	requestBodyClosed := false
+	defer func() {
+		if requestBodyClosed {
+			return
+		}
+		// A panic must not leave the watchdog holding a writer that Gin may
+		// reuse. Expire the connection first so closing an unread chunked body
+		// cannot block in net/http's connection-reuse drain.
+		_ = responseController.SetReadDeadline(time.Now())
+		c.Writer.Header().Set("Connection", "close")
+		_ = requestBody.Close()
+	}()
+	body, err := readBoundedBody(requestBody, maxRequestBytes)
+	if err != nil {
+		// An unknown-length body may still have bytes pending after LimitReader
+		// detects overflow. net/http otherwise tries to drain up to 256 KiB in
+		// Body.Close, which can block forever once the watchdog is stopped.
+		// Expire the read side before Close and make the connection non-reusable;
+		// the response side remains available for the explicit 4xx envelope.
+		if deadlineErr := responseController.SetReadDeadline(time.Now()); deadlineErr != nil {
+			g.Warn("Failed to expire rejected Agent Mail request body", zap.Error(deadlineErr))
+		}
+		c.Writer.Header().Set("Connection", "close")
+		_ = requestBody.Close()
+		requestBodyClosed = true
+		releaseLargeRequest()
+		if errors.Is(err, errBodyTooLarge) {
+			respondGatewayError(c, errcode.ErrAgentMailGatewayPayloadTooLarge)
+		} else {
+			respondGatewayError(c, errcode.ErrAgentMailGatewayRequestInvalid)
+		}
+		return
+	}
+	_ = requestBody.Close()
+	requestBodyClosed = true
+	if deadlineErr := responseController.SetReadDeadline(time.Time{}); deadlineErr != nil {
+		g.Warn("Failed to clear Agent Mail request body deadline", zap.Error(deadlineErr))
+	}
+	releaseLargeRequest()
+	mailboxID := strings.TrimSpace(c.GetHeader("X-Octo-Mailbox-ID"))
+	token, err := signAssertionForMailbox(g.cfg.secret, uid, spaceID, mailboxID, c.Request.Method, target.RequestURI(), body, g.now(), g.nonceSource)
+	if err != nil {
+		g.Error("Failed to sign Agent Mail gateway assertion", zap.Error(err))
+		respondGatewayError(c, errcode.ErrAgentMailGatewayUnavailable)
+		return
+	}
+
+	upstreamContext, cancelUpstream := context.WithCancel(c.Request.Context())
+	defer cancelUpstream()
+	uploadWatchdog := newProgressWatchdog(timeout, cancelUpstream)
+	defer uploadWatchdog.Stop()
+	var uploadBody *releasingRequestBody
+	var upstreamRequestBody io.Reader
+	if len(body) > 0 {
+		uploadBody = newReleasingRequestBody(body, uploadWatchdog, releaseRequestBodyBudget)
+		upstreamRequestBody = uploadBody
+	}
+	request, err := http.NewRequestWithContext(upstreamContext, c.Request.Method, target.String(), upstreamRequestBody)
+	if err != nil {
+		g.Error("Failed to construct Agent Mail upstream request", zap.Error(err))
+		respondGatewayError(c, errcode.ErrAgentMailGatewayUnavailable)
+		return
+	}
+	if len(body) > 0 {
+		request.ContentLength = int64(len(body))
+		// The RoundTripper owns request.Body after Do starts. Its Close method
+		// drops the final request-held reference to body before releasing the
+		// corresponding byte reservation. Do not mutate request.Body here: a
+		// RoundTripper may still access it asynchronously after Do returns.
+		releaseBudgetOnReturn = false
+		body = nil
+	} else {
+		releaseRequestBodyBudget()
+		releaseBudgetOnReturn = false
+	}
+	copyRequestHeaders(request.Header, c.Request.Header)
+	// Browser compression preferences are intentionally not forwarded. Asking
+	// for the identity representation also prevents net/http from transparently
+	// decompressing gzip into an unknown-length response that HTTP/2 cannot
+	// safely truncate on a later upstream failure.
+	request.Header.Set("Accept-Encoding", "identity")
+	request.Header.Set("Authorization", "Bearer "+token)
+	// Reconstruct the mailbox selector from the exact value covered by the
+	// assertion. A caller-controlled Connection header must not be able to make
+	// the signed claim and the downstream request disagree.
+	if mailboxID != "" {
+		request.Header.Set("X-Octo-Mailbox-ID", mailboxID)
+	}
+
+	response, err := g.client.Do(request)
+	uploadWatchdog.Stop()
+	if err != nil {
+		g.Warn("Agent Mail upstream request failed", zap.Error(upstreamErrorCause(err)))
+		respondGatewayError(c, errcode.ErrAgentMailGatewayUnavailable)
+		return
+	}
+	response.Body = newIdleTimeoutReadCloser(response.Body, timeout, nil)
+	defer response.Body.Close()
+	hasResponseBody := responseHasBody(c.Request.Method, response.StatusCode)
+	if hasResponseBody && response.ContentLength > maxResponseBytes {
+		g.Error("Agent Mail upstream response exceeded the gateway limit",
+			zap.Int64("contentLength", response.ContentLength), zap.Int64("limit", maxResponseBytes))
+		respondGatewayError(c, errcode.ErrAgentMailGatewayBadResponse)
+		return
+	}
+
+	unknownLength := hasResponseBody && response.ContentLength < 0
+	if hasResponseBody && isCloseDelimitedResponse(response) {
+		g.Error("Agent Mail upstream returned an unsafe close-delimited response")
+		respondGatewayError(c, errcode.ErrAgentMailGatewayBadResponse)
+		return
+	}
+	if unknownLength && !(c.Request.ProtoMajor == 1 && c.Request.ProtoMinor >= 1) {
+		g.Error("Agent Mail response stream cannot expose truncation to a non-HTTP/1.1 client")
+		respondGatewayError(c, errcode.ErrAgentMailGatewayBadResponse)
+		return
+	}
+
+	responseWriter, err := newProgressDeadlineWriter(c.Writer, responseController, timeout)
+	if err != nil {
+		g.Error("Failed to bound Agent Mail downstream response write", zap.Error(err))
+		respondGatewayError(c, errcode.ErrAgentMailGatewayBadResponse)
+		return
+	}
+	defer func() {
+		if err := responseWriter.Close(); err != nil {
+			g.Warn("Failed to clear Agent Mail downstream response deadline", zap.Error(err))
+		}
+	}()
+	copyResponseHeaders(c.Writer.Header(), response.Header)
+	// Every response varies by authenticated user, validated Space, and selected
+	// mailbox even though those identities are absent from the URL. Never allow
+	// an upstream cache directive to make private mail reusable across callers.
+	c.Writer.Header().Set("Cache-Control", "private, no-store")
+	c.Writer.Header().Set("Vary", "token, X-Space-ID, X-Octo-Mailbox-ID")
+	if response.ContentLength > 0 {
+		c.Writer.Header().Set("Content-Length", strconv.FormatInt(response.ContentLength, 10))
+	}
+	c.Status(response.StatusCode)
+	if hasResponseBody {
+		var downstreamWriter io.Writer = responseWriter
+		if unknownLength {
+			// Commit headers immediately and flush each copied chunk. These responses
+			// must remain streaming rather than becoming a temp-file dependency.
+			c.Writer.Flush()
+			downstreamWriter = flushingResponseWriter{ResponseWriter: responseWriter, Flusher: c.Writer}
+		}
+		if err := copyBoundedBody(downstreamWriter, response.Body, maxResponseBytes); err != nil {
+			g.Error("Agent Mail upstream response stream failed", zap.Error(err))
+			if unknownLength {
+				// gin.Recovery intercepts http.ErrAbortHandler, so explicitly close
+				// the current HTTP/1.1 connection. Without a terminating chunk the
+				// client observes a transport error instead of a clean truncated 2xx.
+				if abortErr := abortResponseStream(c.Writer); abortErr != nil {
+					g.Error("Failed to abort Agent Mail response stream", zap.Error(abortErr))
+				}
+			}
+		}
+	}
+}
+
+func (g *Gateway) upstreamURL(incoming *url.URL) (*url.URL, error) {
+	if incoming == nil || g.cfg.upstream == nil {
+		return nil, fmt.Errorf("missing URL")
+	}
+	escapedPath := incoming.EscapedPath()
+	if !strings.HasPrefix(escapedPath, gatewayRoutePrefix+"/") {
+		return nil, fmt.Errorf("path is outside gateway route")
+	}
+	relativeEscaped := strings.TrimPrefix(escapedPath, gatewayRoutePrefix)
+	relative, err := url.ParseRequestURI(relativeEscaped)
+	if err != nil || (relative.Path != mailAPIPrefix && !strings.HasPrefix(relative.Path, mailAPIPrefix+"/")) || hasUnsafePathSegment(relative.Path) {
+		return nil, fmt.Errorf("path is outside mail WebAPI")
+	}
+
+	target := *g.cfg.upstream
+	target.Path = strings.TrimRight(g.cfg.upstream.Path, "/") + relative.Path
+	baseEscaped := strings.TrimRight(g.cfg.upstream.EscapedPath(), "/")
+	target.RawPath = baseEscaped + relative.EscapedPath()
+	if target.RawPath == target.Path {
+		target.RawPath = ""
+	}
+	target.RawQuery = incoming.RawQuery
+	return &target, nil
+}
+
+func hasUnsafePathSegment(value string) bool {
+	if strings.Contains(value, `\`) || path.Clean(value) != value {
+		return true
+	}
+	for _, segment := range strings.Split(value, "/") {
+		if segment == "." || segment == ".." {
+			return true
+		}
+	}
+	return false
+}
+
+func readBoundedBody(reader io.Reader, limit int64) ([]byte, error) {
+	if reader == nil {
+		return nil, nil
+	}
+	body, err := io.ReadAll(io.LimitReader(reader, limit+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(body)) > limit {
+		return nil, errBodyTooLarge
+	}
+	return body, nil
+}
+
+func copyBoundedBody(dst io.Writer, src io.Reader, limit int64) error {
+	if src == nil {
+		return nil
+	}
+	written, err := io.Copy(dst, io.LimitReader(src, limit))
+	if err != nil {
+		return err
+	}
+	if written < limit {
+		return nil
+	}
+	var probe [1]byte
+	_, err = io.ReadFull(src, probe[:])
+	switch {
+	case err == nil:
+		return errBodyTooLarge
+	case errors.Is(err, io.EOF), errors.Is(err, io.ErrUnexpectedEOF):
+		return nil
+	default:
+		return err
+	}
+}
+
+func responseHasBody(method string, status int) bool {
+	return method != http.MethodHead && status >= http.StatusOK &&
+		status != http.StatusNoContent && status != http.StatusNotModified
+}
+
+func isCloseDelimitedResponse(response *http.Response) bool {
+	return response != nil && response.ContentLength < 0 && response.ProtoMajor == 1 &&
+		len(response.TransferEncoding) == 0 && !response.Uncompressed
+}
+
+type flushingResponseWriter struct {
+	ResponseWriter io.Writer
+	Flusher        http.Flusher
+}
+
+// progressWatchdog invokes cancel after one timeout interval without a Touch.
+// It is used around client.Do so request upload and response-header waits both
+// have a bound even when a custom or stalled transport never returns.
+type progressWatchdog struct {
+	mu       sync.Mutex
+	timer    *time.Timer
+	timeout  time.Duration
+	deadline time.Time
+	stopped  bool
+	cancel   func()
+	done     chan struct{}
+	doneOnce sync.Once
+}
+
+func newProgressWatchdog(timeout time.Duration, cancel func()) *progressWatchdog {
+	w := &progressWatchdog{
+		timeout: normalizedGatewayTimeout(timeout),
+		cancel:  cancel,
+		done:    make(chan struct{}),
+	}
+	w.deadline = time.Now().Add(w.timeout)
+	w.timer = time.AfterFunc(w.timeout, w.expire)
+	return w
+}
+
+func (w *progressWatchdog) expire() {
+	w.mu.Lock()
+	if w.stopped {
+		w.mu.Unlock()
+		w.finish()
+		return
+	}
+	if remaining := time.Until(w.deadline); remaining > 0 {
+		w.timer.Reset(remaining)
+		w.mu.Unlock()
+		return
+	}
+	w.stopped = true
+	cancel := w.cancel
+	w.mu.Unlock()
+	if cancel != nil {
+		cancel()
+	}
+	w.finish()
+}
+
+func (w *progressWatchdog) Touch() {
+	if w == nil {
+		return
+	}
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if !w.stopped {
+		w.deadline = time.Now().Add(w.timeout)
+		w.timer.Reset(w.timeout)
+	}
+}
+
+func (w *progressWatchdog) Stop() {
+	if w == nil {
+		return
+	}
+	w.mu.Lock()
+	stoppedTimer := false
+	if !w.stopped {
+		w.stopped = true
+		stoppedTimer = w.timer.Stop()
+	}
+	done := w.done
+	w.mu.Unlock()
+	if stoppedTimer {
+		w.finish()
+	}
+	<-done
+}
+
+func (w *progressWatchdog) finish() {
+	w.doneOnce.Do(func() { close(w.done) })
+}
+
+type progressReader struct {
+	io.Reader
+	watchdog *progressWatchdog
+}
+
+func (r *progressReader) Read(body []byte) (int, error) {
+	n, err := r.Reader.Read(body)
+	if n > 0 {
+		r.watchdog.Touch()
+	}
+	return n, err
+}
+
+// releasingRequestBody retains the buffered request only until the upstream
+// RoundTripper closes the request body. RoundTrip is allowed to close Body
+// asynchronously after returning a response, so the handler must not clear the
+// request fields or release the byte reservation based only on Do returning.
+type releasingRequestBody struct {
+	mu        sync.Mutex
+	reader    io.Reader
+	release   func()
+	closeOnce sync.Once
+}
+
+func newReleasingRequestBody(body []byte, watchdog *progressWatchdog, release func()) *releasingRequestBody {
+	return &releasingRequestBody{
+		reader:  &progressReader{Reader: bytes.NewReader(body), watchdog: watchdog},
+		release: release,
+	}
+}
+
+func (r *releasingRequestBody) Read(body []byte) (int, error) {
+	if r == nil {
+		return 0, io.EOF
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.reader == nil {
+		return 0, io.EOF
+	}
+	return r.reader.Read(body)
+}
+
+func (r *releasingRequestBody) Close() error {
+	if r == nil {
+		return nil
+	}
+	r.closeOnce.Do(func() {
+		r.mu.Lock()
+		r.reader = nil
+		release := r.release
+		r.release = nil
+		r.mu.Unlock()
+		if release != nil {
+			release()
+		}
+	})
+	return nil
+}
+
+// idleTimeoutReadCloser closes a body after one timeout interval without a
+// successful read. Closing the upstream response body interrupts the transport;
+// the optional callback lets request-body reads first expire the server-side
+// connection deadline.
+type idleTimeoutReadCloser struct {
+	body      io.ReadCloser
+	watchdog  *progressWatchdog
+	closeOnce sync.Once
+}
+
+func newIdleTimeoutReadCloser(body io.ReadCloser, timeout time.Duration, beforeClose func()) *idleTimeoutReadCloser {
+	r := &idleTimeoutReadCloser{body: body}
+	r.watchdog = newProgressWatchdog(timeout, func() {
+		if beforeClose != nil {
+			beforeClose()
+		}
+		r.closeBody()
+	})
+	return r
+}
+
+func (r *idleTimeoutReadCloser) Read(body []byte) (int, error) {
+	if r == nil || r.body == nil {
+		return 0, io.EOF
+	}
+	n, err := r.body.Read(body)
+	if n > 0 {
+		r.watchdog.Touch()
+	}
+	if err != nil {
+		r.watchdog.Stop()
+	}
+	return n, err
+}
+
+func (r *idleTimeoutReadCloser) Close() error {
+	if r == nil {
+		return nil
+	}
+	r.watchdog.Stop()
+	return r.closeBody()
+}
+
+func (r *idleTimeoutReadCloser) closeBody() error {
+	var closeErr error
+	r.closeOnce.Do(func() {
+		if r.body != nil {
+			closeErr = r.body.Close()
+		}
+	})
+	return closeErr
+}
+
+func (w flushingResponseWriter) Write(body []byte) (int, error) {
+	written, err := w.ResponseWriter.Write(body)
+	if written > 0 {
+		w.Flusher.Flush()
+	}
+	return written, err
+}
+
+// progressDeadlineWriter bounds each downstream response write independently.
+// A successful write refreshes the deadline for the next chunk. Test/custom
+// writers may not expose connection deadlines; production net/http writers do
+// through the response-writer Unwrap chain.
+type progressDeadlineWriter struct {
+	writer     io.Writer
+	controller *http.ResponseController
+	timeout    time.Duration
+	enabled    bool
+}
+
+func newProgressDeadlineWriter(
+	writer io.Writer,
+	controller *http.ResponseController,
+	timeout time.Duration,
+) (*progressDeadlineWriter, error) {
+	w := &progressDeadlineWriter{
+		writer:     writer,
+		controller: controller,
+		timeout:    normalizedGatewayTimeout(timeout),
+		enabled:    true,
+	}
+	if err := w.refresh(); err != nil {
+		if errors.Is(err, http.ErrNotSupported) {
+			w.enabled = false
+			return w, nil
+		}
+		return nil, err
+	}
+	return w, nil
+}
+
+func (w *progressDeadlineWriter) Write(body []byte) (int, error) {
+	if err := w.refresh(); err != nil {
+		return 0, err
+	}
+	written, err := w.writer.Write(body)
+	if written > 0 {
+		if refreshErr := w.refresh(); err == nil && refreshErr != nil {
+			err = refreshErr
+		}
+	}
+	return written, err
+}
+
+func (w *progressDeadlineWriter) Close() error {
+	if w == nil || !w.enabled {
+		return nil
+	}
+	return w.controller.SetWriteDeadline(time.Time{})
+}
+
+func (w *progressDeadlineWriter) refresh() error {
+	if w == nil || !w.enabled {
+		return nil
+	}
+	return w.controller.SetWriteDeadline(time.Now().Add(w.timeout))
+}
+
+func abortResponseStream(writer http.ResponseWriter) error {
+	hijacker, ok := writer.(http.Hijacker)
+	if !ok {
+		return errors.New("response writer does not support connection hijacking")
+	}
+	connection, _, err := hijacker.Hijack()
+	if err != nil {
+		return err
+	}
+	return connection.Close()
+}
+
+func (g *Gateway) acquireLargeRequestSlot(request *http.Request) (func(), error) {
+	if request == nil || request.Body == nil || request.ContentLength == 0 ||
+		(request.ContentLength > 0 && request.ContentLength <= largeRequestThreshold) || g.largeRequestSlots == nil {
+		return func() {}, nil
+	}
+	wait := g.largeRequestSlotWait
+	if wait <= 0 {
+		wait = defaultLargeRequestSlotWait
+	}
+	timer := time.NewTimer(wait)
+	defer timer.Stop()
+	select {
+	case g.largeRequestSlots <- struct{}{}:
+		var once sync.Once
+		return func() { once.Do(func() { <-g.largeRequestSlots }) }, nil
+	case <-request.Context().Done():
+		return func() {}, request.Context().Err()
+	case <-timer.C:
+		return func() {}, errLargeRequestSlotWait
+	}
+}
+
+func (g *Gateway) acquireRequestBodyBudget(request *http.Request) (func(), error) {
+	if request == nil || request.Body == nil || request.ContentLength == 0 ||
+		(request.ContentLength > 0 && request.ContentLength <= largeRequestThreshold) || g.requestBodyBudget == nil {
+		return func() {}, nil
+	}
+	reservation := request.ContentLength
+	if reservation < 0 {
+		reservation = maxRequestBytes
+	}
+	wait := g.largeRequestSlotWait
+	if wait <= 0 {
+		wait = defaultLargeRequestSlotWait
+	}
+	waitCtx, cancel := context.WithTimeout(request.Context(), wait)
+	defer cancel()
+	if err := g.requestBodyBudget.Acquire(waitCtx, reservation); err != nil {
+		if request.Context().Err() != nil {
+			return func() {}, request.Context().Err()
+		}
+		return func() {}, errRequestBodyBudgetWait
+	}
+	var once sync.Once
+	return func() {
+		once.Do(func() { g.requestBodyBudget.Release(reservation) })
+	}, nil
+}
+
+func copyRequestHeaders(dst, src http.Header) {
+	connectionHeaders := connectionHeaderNames(src)
+	for _, name := range []string{
+		"Accept", "Accept-Language", "Cache-Control", "Content-Type", "If-Match",
+		"If-Modified-Since", "If-None-Match", "If-Range", "If-Unmodified-Since", "Range", "User-Agent",
+	} {
+		if _, nominated := connectionHeaders[http.CanonicalHeaderKey(name)]; nominated {
+			continue
+		}
+		for _, value := range src.Values(name) {
+			dst.Add(name, value)
+		}
+	}
+}
+
+func copyResponseHeaders(dst, src http.Header) {
+	connectionHeaders := connectionHeaderNames(src)
+	for name, values := range src {
+		canonical := http.CanonicalHeaderKey(name)
+		_, nominated := connectionHeaders[canonical]
+		if nominated || isHopByHopHeader(canonical) || canonical == "Content-Length" || canonical == "Set-Cookie" {
+			continue
+		}
+		for _, value := range values {
+			dst.Add(canonical, value)
+		}
+	}
+}
+
+func connectionHeaderNames(headers http.Header) map[string]struct{} {
+	names := make(map[string]struct{})
+	for _, value := range headers.Values("Connection") {
+		for _, token := range strings.Split(value, ",") {
+			if name := http.CanonicalHeaderKey(strings.TrimSpace(token)); name != "" {
+				names[name] = struct{}{}
+			}
+		}
+	}
+	return names
+}
+
+func isHopByHopHeader(name string) bool {
+	switch http.CanonicalHeaderKey(name) {
+	case "Connection", "Keep-Alive", "Proxy-Authenticate", "Proxy-Authorization",
+		"Proxy-Connection", "Te", "Trailer", "Transfer-Encoding", "Upgrade":
+		return true
+	default:
+		return false
+	}
+}
+
+func upstreamErrorCause(err error) error {
+	var urlErr *url.Error
+	if errors.As(err, &urlErr) && urlErr.Err != nil {
+		return urlErr.Err
+	}
+	return err
+}

--- a/modules/agentmailgateway/gateway_test.go
+++ b/modules/agentmailgateway/gateway_test.go
@@ -1,0 +1,1436 @@
+package agentmailgateway
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
+	appmetrics "github.com/Mininglamp-OSS/octo-server/pkg/metrics"
+	"github.com/prometheus/client_golang/prometheus"
+	"golang.org/x/sync/semaphore"
+)
+
+func TestProxyBindsAuthenticatedIdentityAndExactRequest(t *testing.T) {
+	secret := []byte(strings.Repeat("g", 32))
+	fixedNow := time.Date(2026, 7, 29, 11, 0, 0, 0, time.UTC)
+	requestBody := []byte(`{"to":["b@demo.octo.test"],"text":"hello"}`)
+
+	gateway := newTestGateway(t, "http://octo-mail.test", secret, fixedNow)
+	gateway.client = &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		if r.URL.RequestURI() != "/webapi/v0/messages?folder=sent&limit=10" {
+			t.Errorf("upstream URI = %q", r.URL.RequestURI())
+		}
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("read upstream body: %v", err)
+		}
+		if !bytes.Equal(body, requestBody) {
+			t.Errorf("upstream body = %q", body)
+		}
+		claims := verifyAssertionForTest(t, secret, strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer "))
+		if claims.Subject != "octo-user-a" || claims.SpaceID != "space-a" || claims.Method != http.MethodPost {
+			t.Errorf("assertion identity = %#v", claims)
+		}
+		if claims.MailboxID != "42" {
+			t.Errorf("assertion mailbox = %q", claims.MailboxID)
+		}
+		if claims.RequestURI != r.URL.RequestURI() {
+			t.Errorf("assertion URI = %q, request URI = %q", claims.RequestURI, r.URL.RequestURI())
+		}
+		sum := sha256.Sum256(body)
+		if claims.BodySHA256 != strings.ToLower(strings.TrimSpace(fmtHex(sum[:]))) {
+			t.Errorf("assertion body digest = %q", claims.BodySHA256)
+		}
+		if r.Header.Get("X-Octo-Mailbox-ID") != "42" {
+			t.Errorf("mailbox selection = %q", r.Header.Get("X-Octo-Mailbox-ID"))
+		}
+		if r.Header.Get("If-Range") != `"revision-1"` {
+			t.Errorf("If-Range = %q", r.Header.Get("If-Range"))
+		}
+		for _, forbidden := range []string{"Token", "X-Space-ID", "Cookie", "X-Octo-UID"} {
+			if value := r.Header.Get(forbidden); value != "" {
+				t.Errorf("untrusted header %s was forwarded", forbidden)
+			}
+		}
+		return &http.Response{
+			StatusCode: http.StatusCreated,
+			Header: http.Header{
+				"Content-Type":      []string{"application/json"},
+				"X-Upstream-Result": []string{"kept"},
+			},
+			Body: io.NopCloser(strings.NewReader(`{"id":"message-1"}`)),
+		}, nil
+	})}
+	router := newProxyRouter(gateway, "octo-user-a", "space-a")
+	req := httptest.NewRequest(http.MethodPost, "/v1/mail-gateway/webapi/v0/messages?folder=sent&limit=10", bytes.NewReader(requestBody))
+	req.Header.Set("Authorization", "Basic attacker-controlled")
+	req.Header.Set("Token", "browser-session")
+	req.Header.Set("X-Space-ID", "space-a")
+	req.Header.Set("Cookie", "session=private")
+	req.Header.Set("X-Octo-UID", "forged-user")
+	req.Header.Set("X-Octo-Mailbox-ID", "42")
+	req.Header.Set("If-Range", `"revision-1"`)
+	req.Header.Set("Connection", "X-Octo-Mailbox-ID")
+	req.Header.Set("Content-Type", "application/json")
+	recorder := httptest.NewRecorder()
+	router.ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusCreated {
+		t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
+	}
+	if recorder.Body.String() != `{"id":"message-1"}` {
+		t.Fatalf("body = %s", recorder.Body.String())
+	}
+	if recorder.Header().Get("X-Upstream-Result") != "kept" {
+		t.Fatalf("upstream response header was not preserved")
+	}
+}
+
+func TestProxyFailsClosedWithoutIdentityOrSpace(t *testing.T) {
+	for name, test := range map[string]struct {
+		uid, spaceID string
+		wantStatus   int
+		wantCode     string
+	}{
+		"identity": {"", "space-a", http.StatusUnauthorized, "err.server.agent_mail_gateway.unauthorized"},
+		"space":    {"user-a", "", http.StatusBadRequest, "err.server.agent_mail_gateway.space_required"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			gateway := &Gateway{}
+			router := newProxyRouter(gateway, test.uid, test.spaceID)
+			recorder := httptest.NewRecorder()
+			router.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/v1/mail-gateway/webapi/v0/mailboxes", nil))
+			if recorder.Code != test.wantStatus {
+				t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
+			}
+			assertErrorCode(t, recorder.Body.Bytes(), test.wantCode)
+		})
+	}
+}
+
+func TestProxyPreservesOctoMailBusinessError(t *testing.T) {
+	secret := []byte(strings.Repeat("g", 32))
+	gateway := newTestGateway(t, "http://octo-mail.test", secret, time.Now())
+	wantBody := `{"error":{"code":"unauthorized","message":"authentication failed"}}`
+	gateway.client = &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusUnauthorized,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(wantBody)),
+		}, nil
+	})}
+	router := newProxyRouter(gateway, "user-a", "space-a")
+	recorder := httptest.NewRecorder()
+	router.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/v1/mail-gateway/webapi/v0/mailboxes", nil))
+
+	if recorder.Code != http.StatusUnauthorized || recorder.Body.String() != wantBody {
+		t.Fatalf("proxied error = status %d body %s", recorder.Code, recorder.Body.String())
+	}
+}
+
+func TestProxyRejectsPathsOutsideWebAPI(t *testing.T) {
+	secret := []byte(strings.Repeat("g", 32))
+	var upstreamCalls atomic.Int32
+	gateway := newTestGateway(t, "http://octo-mail.test", secret, time.Now())
+	gateway.client = &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		upstreamCalls.Add(1)
+		return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader("ok"))}, nil
+	})}
+	router := newProxyRouter(gateway, "user-a", "space-a")
+	recorder := httptest.NewRecorder()
+	router.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/v1/mail-gateway/admin/tenants", nil))
+	if recorder.Code != http.StatusBadRequest {
+		t.Fatalf("outside path status = %d, body = %s", recorder.Code, recorder.Body.String())
+	}
+	traversal := &url.URL{
+		Path:    "/v1/mail-gateway/webapi/v0/../admin",
+		RawPath: "/v1/mail-gateway/webapi/v0/%2e%2e/admin",
+	}
+	if _, err := gateway.upstreamURL(traversal); err == nil {
+		t.Fatal("encoded path traversal was accepted")
+	}
+	if upstreamCalls.Load() != 0 {
+		t.Fatalf("invalid paths reached upstream %d times", upstreamCalls.Load())
+	}
+}
+
+func TestLoadGatewayConfigRequiresPairedStrongConfiguration(t *testing.T) {
+	t.Setenv(envGatewayURL, "http://octo-mail:8090")
+	t.Setenv(envGatewaySecret, "short")
+	if _, err := loadGatewayConfig(); err == nil {
+		t.Fatal("weak gateway secret was accepted")
+	}
+
+	t.Setenv(envGatewaySecret, strings.Repeat("s", 32))
+	t.Setenv(envGatewayTimeout, "10s")
+	cfg, err := loadGatewayConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.upstream.String() != "http://octo-mail:8090" || cfg.timeout != 10*time.Second {
+		t.Fatalf("config = %#v", cfg)
+	}
+}
+
+func TestGatewayHTTPClientBoundsHeadersButNotResponseBodyConsumption(t *testing.T) {
+	t.Run("response headers", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+			time.Sleep(150 * time.Millisecond)
+			_, _ = writer.Write([]byte("late"))
+		}))
+		defer server.Close()
+
+		_, err := newGatewayHTTPClient(30 * time.Millisecond).Get(server.URL)
+		if err == nil {
+			t.Fatal("response header timeout was not enforced")
+		}
+	})
+
+	t.Run("response body", func(t *testing.T) {
+		releaseBody := make(chan struct{})
+		server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+			writer.WriteHeader(http.StatusOK)
+			_, _ = writer.Write([]byte("A"))
+			writer.(http.Flusher).Flush()
+			<-releaseBody
+			_, _ = writer.Write([]byte("B"))
+		}))
+		defer server.Close()
+
+		response, err := newGatewayHTTPClient(30 * time.Millisecond).Get(server.URL)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer response.Body.Close()
+		first := make([]byte, 1)
+		if _, err := io.ReadFull(response.Body, first); err != nil || string(first) != "A" {
+			t.Fatalf("first body byte=%q err=%v", first, err)
+		}
+		time.Sleep(60 * time.Millisecond)
+		close(releaseBody)
+		rest, err := io.ReadAll(response.Body)
+		if err != nil || string(rest) != "B" {
+			t.Fatalf("remaining body=%q err=%v", rest, err)
+		}
+	})
+}
+
+func TestReadBoundedBodyRejectsOverflow(t *testing.T) {
+	if _, err := readBoundedBody(strings.NewReader("1234"), 3); err == nil {
+		t.Fatal("overflow body was accepted")
+	}
+}
+
+func TestCopyBoundedBodyStreamsWithoutExceedingLimit(t *testing.T) {
+	var dst bytes.Buffer
+	if err := copyBoundedBody(&dst, strings.NewReader("123"), 3); err != nil {
+		t.Fatalf("exact-limit response failed: %v", err)
+	}
+	if dst.String() != "123" {
+		t.Fatalf("body=%q", dst.String())
+	}
+
+	dst.Reset()
+	err := copyBoundedBody(&dst, strings.NewReader("1234"), 3)
+	if !errors.Is(err, errBodyTooLarge) {
+		t.Fatalf("overflow error=%v", err)
+	}
+	if dst.String() != "123" {
+		t.Fatalf("forwarded body exceeded limit: %q", dst.String())
+	}
+}
+
+func TestProxyRejectsKnownOversizedResponseBeforeWritingUpstreamStatus(t *testing.T) {
+	gateway := newTestGateway(t, "http://octo-mail.test", []byte(strings.Repeat("g", 32)), time.Now())
+	gateway.client = &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode:    http.StatusOK,
+			ContentLength: maxResponseBytes + 1,
+			Body:          failingReadCloser{err: errors.New("body must not be read")},
+		}, nil
+	})}
+	recorder := httptest.NewRecorder()
+	newProxyRouter(gateway, "user-a", "space-a").ServeHTTP(
+		recorder, httptest.NewRequest(http.MethodGet, "/v1/mail-gateway/webapi/v0/mailboxes", nil),
+	)
+	if recorder.Code != http.StatusBadGateway {
+		t.Fatalf("status=%d body=%s", recorder.Code, recorder.Body.String())
+	}
+	assertErrorCode(t, recorder.Body.Bytes(), "err.server.agent_mail_gateway.bad_response")
+}
+
+func TestProxyStreamsSelfDelimitedUnknownLengthResponses(t *testing.T) {
+	tests := map[string]struct {
+		protoMajor       int
+		transferEncoding []string
+		uncompressed     bool
+	}{
+		"HTTP/1.1 chunked":           {protoMajor: 1, transferEncoding: []string{"chunked"}},
+		"HTTP/1.1 decompressed gzip": {protoMajor: 1, uncompressed: true},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			gateway := newTestGateway(t, "http://octo-mail.test", []byte(strings.Repeat("g", 32)), time.Now())
+			gateway.client = &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode:       http.StatusOK,
+					ProtoMajor:       test.protoMajor,
+					ContentLength:    -1,
+					TransferEncoding: test.transferEncoding,
+					Uncompressed:     test.uncompressed,
+					Body:             io.NopCloser(strings.NewReader("complete")),
+				}, nil
+			})}
+			server := httptest.NewServer(newProxyRouter(gateway, "user-a", "space-a"))
+			defer server.Close()
+
+			response, err := server.Client().Get(server.URL + "/v1/mail-gateway/webapi/v0/mailboxes")
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer response.Body.Close()
+			body, err := io.ReadAll(response.Body)
+			if err != nil || response.StatusCode != http.StatusOK || string(body) != "complete" {
+				t.Fatalf("status=%d body=%q err=%v", response.StatusCode, body, err)
+			}
+		})
+	}
+}
+
+func TestProxyRejectsUnknownLengthResponseForRealHTTP2Client(t *testing.T) {
+	gateway := newTestGateway(t, "http://octo-mail.test", []byte(strings.Repeat("g", 32)), time.Now())
+	gateway.client = &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode:       http.StatusOK,
+			ProtoMajor:       2,
+			ContentLength:    -1,
+			TransferEncoding: nil,
+			Body:             io.NopCloser(strings.NewReader("complete")),
+		}, nil
+	})}
+	server := httptest.NewUnstartedServer(newProxyRouter(gateway, "user-a", "space-a"))
+	server.EnableHTTP2 = true
+	server.StartTLS()
+	defer server.Close()
+
+	response, err := server.Client().Get(server.URL + "/v1/mail-gateway/webapi/v0/mailboxes")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if response.ProtoMajor != 2 || response.StatusCode != http.StatusBadGateway {
+		t.Fatalf("proto=%s status=%d body=%s", response.Proto, response.StatusCode, body)
+	}
+	assertErrorCode(t, body, "err.server.agent_mail_gateway.bad_response")
+}
+
+func TestProxyForwardsGzipResponseToHTTP2WithoutTransparentDecompression(t *testing.T) {
+	payload := []byte(`{"messages":[]}`)
+	var compressed bytes.Buffer
+	gzipWriter := gzip.NewWriter(&compressed)
+	if _, err := gzipWriter.Write(payload); err != nil {
+		t.Fatal(err)
+	}
+	if err := gzipWriter.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	upstreamEncoding := make(chan string, 1)
+	upstream := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		upstreamEncoding <- request.Header.Get("Accept-Encoding")
+		writer.Header().Set("Content-Encoding", "gzip")
+		writer.Header().Set("Content-Type", "application/json")
+		writer.Header().Set("Content-Length", strconv.Itoa(compressed.Len()))
+		writer.WriteHeader(http.StatusOK)
+		_, _ = writer.Write(compressed.Bytes())
+	}))
+	defer upstream.Close()
+
+	gateway := newTestGateway(t, upstream.URL, []byte(strings.Repeat("g", 32)), time.Now())
+	server := httptest.NewUnstartedServer(newProxyRouter(gateway, "user-a", "space-a"))
+	server.EnableHTTP2 = true
+	server.StartTLS()
+	defer server.Close()
+
+	transport := server.Client().Transport.(*http.Transport).Clone()
+	transport.DisableCompression = true
+	client := &http.Client{Transport: transport}
+	request, err := http.NewRequest(http.MethodGet, server.URL+"/v1/mail-gateway/webapi/v0/messages", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request.Header.Set("Accept-Encoding", "gzip")
+	response, err := client.Do(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+	if response.ProtoMajor != 2 || response.StatusCode != http.StatusOK {
+		t.Fatalf("proto=%s status=%d", response.Proto, response.StatusCode)
+	}
+	if response.Header.Get("Content-Encoding") != "gzip" || response.ContentLength != int64(compressed.Len()) {
+		t.Fatalf("encoding=%q contentLength=%d", response.Header.Get("Content-Encoding"), response.ContentLength)
+	}
+	reader, err := gzip.NewReader(response.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	decoded, err := io.ReadAll(reader)
+	if closeErr := reader.Close(); err == nil {
+		err = closeErr
+	}
+	if err != nil || !bytes.Equal(decoded, payload) {
+		t.Fatalf("decoded=%q err=%v", decoded, err)
+	}
+	if got := <-upstreamEncoding; got != "identity" {
+		t.Fatalf("upstream Accept-Encoding=%q, want identity", got)
+	}
+}
+
+func TestProxyRejectsCloseDelimitedUpstreamBeforeCommittingStatus(t *testing.T) {
+	gateway := newTestGateway(t, "http://octo-mail.test", []byte(strings.Repeat("g", 32)), time.Now())
+	gateway.client = &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode:    http.StatusOK,
+			ProtoMajor:    1,
+			ContentLength: -1,
+			Close:         true,
+			Body:          io.NopCloser(strings.NewReader(`{"mailboxes":[`)),
+		}, nil
+	})}
+	recorder := httptest.NewRecorder()
+	newProxyRouter(gateway, "user-a", "space-a").ServeHTTP(
+		recorder, httptest.NewRequest(http.MethodGet, "/v1/mail-gateway/webapi/v0/mailboxes", nil),
+	)
+	if recorder.Code != http.StatusBadGateway {
+		t.Fatalf("status=%d body=%s", recorder.Code, recorder.Body.String())
+	}
+	assertErrorCode(t, recorder.Body.Bytes(), "err.server.agent_mail_gateway.bad_response")
+}
+
+func TestProxyRejectsUnknownLengthResponseForHTTP10Client(t *testing.T) {
+	gateway := newTestGateway(t, "http://octo-mail.test", []byte(strings.Repeat("g", 32)), time.Now())
+	gateway.client = &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode:       http.StatusOK,
+			ProtoMajor:       1,
+			ContentLength:    -1,
+			TransferEncoding: []string{"chunked"},
+			Body:             io.NopCloser(strings.NewReader("complete")),
+		}, nil
+	})}
+	request := httptest.NewRequest(http.MethodGet, "/v1/mail-gateway/webapi/v0/mailboxes", nil)
+	request.Proto = "HTTP/1.0"
+	request.ProtoMajor = 1
+	request.ProtoMinor = 0
+	recorder := httptest.NewRecorder()
+	newProxyRouter(gateway, "user-a", "space-a").ServeHTTP(recorder, request)
+	if recorder.Code != http.StatusBadGateway {
+		t.Fatalf("status=%d body=%s", recorder.Code, recorder.Body.String())
+	}
+	assertErrorCode(t, recorder.Body.Bytes(), "err.server.agent_mail_gateway.bad_response")
+}
+
+func TestProxyStreamsUnknownLengthResponseBeforeUpstreamCompletes(t *testing.T) {
+	releaseUpstream := make(chan struct{})
+	released := false
+	defer func() {
+		if !released {
+			close(releaseUpstream)
+		}
+	}()
+	gateway := newTestGateway(t, "http://octo-mail.test", []byte(strings.Repeat("g", 32)), time.Now())
+	gateway.client = &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode:    http.StatusOK,
+			ContentLength: -1,
+			Body: &stagedReadCloser{
+				first:   []byte("A"),
+				rest:    []byte("B"),
+				release: releaseUpstream,
+			},
+		}, nil
+	})}
+	server := httptest.NewServer(newProductionWrappedProxyRouter(gateway, "user-a", "space-a"))
+	defer server.Close()
+
+	type responseResult struct {
+		response *http.Response
+		err      error
+	}
+	responseCh := make(chan responseResult, 1)
+	go func() {
+		response, err := server.Client().Get(server.URL + "/v1/mail-gateway/webapi/v0/attachments/E1")
+		responseCh <- responseResult{response: response, err: err}
+	}()
+	var result responseResult
+	select {
+	case result = <-responseCh:
+	case <-time.After(time.Second):
+		t.Fatal("response headers waited for the complete unknown-length upstream body")
+	}
+	if result.err != nil {
+		t.Fatal(result.err)
+	}
+	defer result.response.Body.Close()
+	first := make([]byte, 1)
+	if _, err := io.ReadFull(result.response.Body, first); err != nil || string(first) != "A" {
+		t.Fatalf("first body byte=%q err=%v", first, err)
+	}
+	close(releaseUpstream)
+	released = true
+	rest, err := io.ReadAll(result.response.Body)
+	if err != nil || string(rest) != "B" {
+		t.Fatalf("remaining body=%q err=%v", rest, err)
+	}
+}
+
+func TestProxyAbortsUnknownLengthResponseOnStreamFailure(t *testing.T) {
+	tests := map[string]struct {
+		body      io.ReadCloser
+		wantBytes int64
+	}{
+		"overflow": {
+			body:      io.NopCloser(io.LimitReader(zeroReader{}, maxResponseBytes+1)),
+			wantBytes: maxResponseBytes,
+		},
+		"read failure": {
+			body:      &partialFailingReadCloser{data: []byte("AAA"), err: errors.New("truncated response")},
+			wantBytes: 3,
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			gateway := newTestGateway(t, "http://octo-mail.test", []byte(strings.Repeat("g", 32)), time.Now())
+			gateway.client = &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+				return &http.Response{StatusCode: http.StatusOK, ContentLength: -1, Body: test.body}, nil
+			})}
+			server := httptest.NewServer(newProxyRouter(gateway, "user-a", "space-a"))
+			defer server.Close()
+
+			response, err := server.Client().Get(server.URL + "/v1/mail-gateway/webapi/v0/attachments/E1")
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer response.Body.Close()
+			written, readErr := io.Copy(io.Discard, response.Body)
+			if response.StatusCode != http.StatusOK || written != test.wantBytes || readErr == nil {
+				t.Fatalf("status=%d bytes=%d readErr=%v", response.StatusCode, written, readErr)
+			}
+		})
+	}
+}
+
+func TestProxyPreservesKnownLengthSoMidstreamFailureIsVisible(t *testing.T) {
+	gateway := newTestGateway(t, "http://octo-mail.test", []byte(strings.Repeat("g", 32)), time.Now())
+	gateway.client = &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode:    http.StatusOK,
+			ContentLength: 1000,
+			Body:          &partialFailingReadCloser{data: []byte("AAA"), err: errors.New("upstream reset")},
+		}, nil
+	})}
+	server := httptest.NewServer(newProxyRouter(gateway, "user-a", "space-a"))
+	defer server.Close()
+
+	response, err := server.Client().Get(server.URL + "/v1/mail-gateway/webapi/v0/attachments/E1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+	body, readErr := io.ReadAll(response.Body)
+	if string(body) != "AAA" || !errors.Is(readErr, io.ErrUnexpectedEOF) {
+		t.Fatalf("body=%q readErr=%v, want a visible truncated-response error", body, readErr)
+	}
+}
+
+func TestProxyAllowsHeadMetadataAboveResponseBodyLimit(t *testing.T) {
+	gateway := newTestGateway(t, "http://octo-mail.test", []byte(strings.Repeat("g", 32)), time.Now())
+	gateway.client = &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode:    http.StatusOK,
+			ContentLength: maxResponseBytes + 1,
+			Body:          http.NoBody,
+		}, nil
+	})}
+	recorder := httptest.NewRecorder()
+	newProxyRouter(gateway, "user-a", "space-a").ServeHTTP(
+		recorder,
+		httptest.NewRequest(http.MethodHead, "/v1/mail-gateway/webapi/v0/attachments/E1", nil),
+	)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("HEAD status=%d body=%s", recorder.Code, recorder.Body.String())
+	}
+	if got := recorder.Header().Get("Content-Length"); got != strconv.FormatInt(maxResponseBytes+1, 10) {
+		t.Fatalf("HEAD Content-Length=%q", got)
+	}
+}
+
+func TestLargeRequestBufferingHasConcurrencyBound(t *testing.T) {
+	gateway := &Gateway{largeRequestSlots: make(chan struct{}, 1), largeRequestSlotWait: 10 * time.Millisecond}
+	first := httptest.NewRequest(http.MethodPost, "/", strings.NewReader("body"))
+	first.ContentLength = largeRequestThreshold + 1
+	release, err := gateway.acquireLargeRequestSlot(first)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer release()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	second := httptest.NewRequest(http.MethodPost, "/", strings.NewReader("body")).WithContext(ctx)
+	second.ContentLength = -1
+	if _, err := gateway.acquireLargeRequestSlot(second); !errors.Is(err, context.Canceled) {
+		t.Fatalf("second acquire error=%v, want context.Canceled", err)
+	}
+
+	third := httptest.NewRequest(http.MethodPost, "/", strings.NewReader("body"))
+	third.ContentLength = -1
+	started := time.Now()
+	if _, err := gateway.acquireLargeRequestSlot(third); !errors.Is(err, errLargeRequestSlotWait) {
+		t.Fatalf("third acquire error=%v, want errLargeRequestSlotWait", err)
+	}
+	if elapsed := time.Since(started); elapsed > time.Second {
+		t.Fatalf("bounded slot wait took %v", elapsed)
+	}
+}
+
+func TestProxyRejectsKnownOversizedRequestBeforeWaitingForSlot(t *testing.T) {
+	var upstreamCalls atomic.Int32
+	gateway := newTestGateway(t, "http://octo-mail.test", []byte(strings.Repeat("g", 32)), time.Now())
+	gateway.largeRequestSlots = make(chan struct{}, 1)
+	gateway.largeRequestSlots <- struct{}{}
+	gateway.largeRequestSlotWait = time.Second
+	gateway.client = &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		upstreamCalls.Add(1)
+		return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody}, nil
+	})}
+	request := httptest.NewRequest(http.MethodPost, "/v1/mail-gateway/webapi/v0/messages", strings.NewReader("body"))
+	request.ContentLength = maxRequestBytes + 1
+	recorder := httptest.NewRecorder()
+	started := time.Now()
+	newProxyRouter(gateway, "user-a", "space-a").ServeHTTP(recorder, request)
+
+	if recorder.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("status=%d body=%s", recorder.Code, recorder.Body.String())
+	}
+	if time.Since(started) > 250*time.Millisecond {
+		t.Fatal("known oversized request waited for a buffering slot")
+	}
+	if upstreamCalls.Load() != 0 {
+		t.Fatalf("oversized request reached upstream %d times", upstreamCalls.Load())
+	}
+}
+
+func TestProxyReleasesLargeRequestSlotAfterBuffering(t *testing.T) {
+	gateway := newTestGateway(t, "http://octo-mail.test", []byte(strings.Repeat("g", 32)), time.Now())
+	gateway.nonceSource = zeroReader{}
+	gateway.largeRequestSlots = make(chan struct{}, 1)
+	gateway.largeRequestSlotWait = 100 * time.Millisecond
+	firstAtUpstream := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	var upstreamCalls atomic.Int32
+	gateway.client = &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		if upstreamCalls.Add(1) == 1 {
+			close(firstAtUpstream)
+			<-releaseFirst
+		}
+		return &http.Response{
+			StatusCode:    http.StatusOK,
+			ContentLength: 2,
+			Body:          io.NopCloser(strings.NewReader("ok")),
+		}, nil
+	})}
+	router := newProxyRouter(gateway, "user-a", "space-a")
+	firstDone := make(chan *httptest.ResponseRecorder, 1)
+	go func() {
+		request := httptest.NewRequest(http.MethodPost, "/v1/mail-gateway/webapi/v0/messages", strings.NewReader("first"))
+		request.ContentLength = largeRequestThreshold + 1
+		recorder := httptest.NewRecorder()
+		router.ServeHTTP(recorder, request)
+		firstDone <- recorder
+	}()
+	<-firstAtUpstream
+
+	secondRequest := httptest.NewRequest(http.MethodPost, "/v1/mail-gateway/webapi/v0/messages", strings.NewReader("second"))
+	secondRequest.ContentLength = largeRequestThreshold + 1
+	secondRecorder := httptest.NewRecorder()
+	router.ServeHTTP(secondRecorder, secondRequest)
+	if secondRecorder.Code != http.StatusOK || secondRecorder.Body.String() != "ok" {
+		t.Fatalf("second response status=%d body=%q", secondRecorder.Code, secondRecorder.Body.String())
+	}
+
+	close(releaseFirst)
+	firstRecorder := <-firstDone
+	if firstRecorder.Code != http.StatusOK || firstRecorder.Body.String() != "ok" {
+		t.Fatalf("first response status=%d body=%q", firstRecorder.Code, firstRecorder.Body.String())
+	}
+}
+
+func TestProxyStalledRequestBodyReleasesLargeRequestSlot(t *testing.T) {
+	gateway := newTestGateway(t, "http://octo-mail.test", []byte(strings.Repeat("g", 32)), time.Now())
+	gateway.cfg.timeout = 20 * time.Millisecond
+	gateway.largeRequestSlots = make(chan struct{}, 1)
+	gateway.largeRequestSlotWait = 100 * time.Millisecond
+	gateway.client = &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: http.StatusOK, ContentLength: 2, Body: io.NopCloser(strings.NewReader("ok"))}, nil
+	})}
+	router := newProxyRouter(gateway, "user-a", "space-a")
+	stalled := newBlockingReadCloser()
+	request := httptest.NewRequest(http.MethodPost, "/v1/mail-gateway/webapi/v0/messages", stalled)
+	request.ContentLength = largeRequestThreshold + 1
+	done := make(chan *httptest.ResponseRecorder, 1)
+	go func() {
+		recorder := httptest.NewRecorder()
+		router.ServeHTTP(recorder, request)
+		done <- recorder
+	}()
+
+	select {
+	case recorder := <-done:
+		if recorder.Code != http.StatusBadRequest {
+			t.Fatalf("stalled request status=%d body=%s", recorder.Code, recorder.Body.String())
+		}
+	case <-time.After(250 * time.Millisecond):
+		_ = stalled.Close()
+		<-done
+		t.Fatal("stalled request body held the large-request slot past the gateway timeout")
+	}
+
+	second := httptest.NewRequest(http.MethodPost, "/v1/mail-gateway/webapi/v0/messages", strings.NewReader("next"))
+	second.ContentLength = largeRequestThreshold + 1
+	recorder := httptest.NewRecorder()
+	router.ServeHTTP(recorder, second)
+	if recorder.Code != http.StatusOK || recorder.Body.String() != "ok" {
+		t.Fatalf("released slot status=%d body=%q", recorder.Code, recorder.Body.String())
+	}
+}
+
+func TestProxyStalledNetworkRequestBodyReleasesLargeRequestSlot(t *testing.T) {
+	gateway := newTestGateway(t, "http://octo-mail.test", []byte(strings.Repeat("g", 32)), time.Now())
+	gateway.cfg.timeout = 50 * time.Millisecond
+	gateway.largeRequestSlots = make(chan struct{}, 1)
+	gateway.largeRequestSlotWait = 250 * time.Millisecond
+	gateway.client = &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: http.StatusOK, ContentLength: 2, Body: io.NopCloser(strings.NewReader("ok"))}, nil
+	})}
+	server := httptest.NewServer(newProductionWrappedProxyRouter(gateway, "user-a", "space-a"))
+	defer server.Close()
+
+	reader, writer := io.Pipe()
+	request, err := http.NewRequest(http.MethodPost, server.URL+"/v1/mail-gateway/webapi/v0/messages", reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request.ContentLength = largeRequestThreshold + 1
+	done := make(chan *http.Response, 1)
+	errCh := make(chan error, 1)
+	go func() {
+		response, requestErr := server.Client().Do(request)
+		if requestErr != nil {
+			errCh <- requestErr
+			return
+		}
+		done <- response
+	}()
+	if _, err := writer.Write([]byte("x")); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case response := <-done:
+		defer response.Body.Close()
+		if response.StatusCode != http.StatusBadRequest {
+			body, _ := io.ReadAll(response.Body)
+			t.Fatalf("stalled network request status=%d body=%s", response.StatusCode, body)
+		}
+	case err := <-errCh:
+		t.Fatalf("stalled network request failed before the gateway response: %v", err)
+	case <-time.After(time.Second):
+		_ = writer.Close()
+		t.Fatal("real network request body outlived the gateway progress timeout")
+	}
+	_ = writer.Close()
+
+	body := bytes.Repeat([]byte("a"), int(largeRequestThreshold+1))
+	response, err := server.Client().Post(
+		server.URL+"/v1/mail-gateway/webapi/v0/messages",
+		"application/octet-stream",
+		bytes.NewReader(body),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+	responseBody, err := io.ReadAll(response.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if response.StatusCode != http.StatusOK || string(responseBody) != "ok" {
+		t.Fatalf("released network slot status=%d body=%q", response.StatusCode, responseBody)
+	}
+}
+
+func TestProxyUnknownLengthOverflowReturns413AndReleasesLargeRequestSlot(t *testing.T) {
+	gateway := newTestGateway(t, "http://octo-mail.test", []byte(strings.Repeat("g", 32)), time.Now())
+	gateway.cfg.timeout = time.Second
+	gateway.largeRequestSlots = make(chan struct{}, 1)
+	gateway.largeRequestSlotWait = time.Second
+	gateway.requestBodyBudget = semaphore.NewWeighted(maxRequestBytes)
+	gateway.client = &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: http.StatusOK, ContentLength: 2, Body: io.NopCloser(strings.NewReader("ok"))}, nil
+	})}
+	server := httptest.NewServer(newProductionWrappedProxyRouter(gateway, "user-a", "space-a"))
+	defer server.Close()
+
+	reader, writer := io.Pipe()
+	defer writer.Close()
+	request, err := http.NewRequest(http.MethodPost, server.URL+"/v1/mail-gateway/webapi/v0/messages", reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request.ContentLength = -1
+	if request.ContentLength != -1 {
+		t.Fatalf("request ContentLength=%d, want unknown", request.ContentLength)
+	}
+	type responseResult struct {
+		response *http.Response
+		err      error
+	}
+	responseCh := make(chan responseResult, 1)
+	go func() {
+		response, requestErr := server.Client().Do(request)
+		responseCh <- responseResult{response: response, err: requestErr}
+	}()
+	uploadCh := make(chan error, 1)
+	go func() {
+		_, uploadErr := io.CopyN(writer, zeroReader{}, maxRequestBytes+1)
+		uploadCh <- uploadErr
+	}()
+
+	select {
+	case uploadErr := <-uploadCh:
+		if uploadErr != nil {
+			t.Fatalf("upload overflow probe: %v", uploadErr)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("unknown-length overflow upload did not reach the gateway limit")
+	}
+
+	var result responseResult
+	select {
+	case result = <-responseCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("unknown-length overflow did not produce a response")
+	}
+	if result.err != nil {
+		t.Fatalf("unknown-length overflow request: %v", result.err)
+	}
+	defer result.response.Body.Close()
+	responseBody, err := io.ReadAll(result.response.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.response.StatusCode != http.StatusRequestEntityTooLarge {
+		t.Fatalf("overflow status=%d body=%s", result.response.StatusCode, responseBody)
+	}
+	assertErrorCode(t, responseBody, "err.server.agent_mail_gateway.payload_too_large")
+
+	// The rejected chunked body must not retain either the only concurrency
+	// slot or its full 64 MiB budget reservation.
+	nextBody := bytes.Repeat([]byte("a"), int(largeRequestThreshold+1))
+	nextResponse, err := server.Client().Post(
+		server.URL+"/v1/mail-gateway/webapi/v0/messages",
+		"application/octet-stream",
+		bytes.NewReader(nextBody),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer nextResponse.Body.Close()
+	nextResponseBody, err := io.ReadAll(nextResponse.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if nextResponse.StatusCode != http.StatusOK || string(nextResponseBody) != "ok" {
+		t.Fatalf("request after overflow status=%d body=%q", nextResponse.StatusCode, nextResponseBody)
+	}
+}
+
+func TestProxyBoundsStalledUpstreamUpload(t *testing.T) {
+	gateway := newTestGateway(t, "http://octo-mail.test", []byte(strings.Repeat("g", 32)), time.Now())
+	gateway.cfg.timeout = 20 * time.Millisecond
+	gateway.client = &http.Client{Transport: roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		<-request.Context().Done()
+		return nil, request.Context().Err()
+	})}
+	requestContext, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	request := httptest.NewRequest(http.MethodPost, "/v1/mail-gateway/webapi/v0/messages", strings.NewReader("body")).WithContext(requestContext)
+	done := make(chan *httptest.ResponseRecorder, 1)
+	go func() {
+		recorder := httptest.NewRecorder()
+		newProxyRouter(gateway, "user-a", "space-a").ServeHTTP(recorder, request)
+		done <- recorder
+	}()
+	select {
+	case recorder := <-done:
+		if recorder.Code != http.StatusServiceUnavailable {
+			t.Fatalf("stalled upstream status=%d body=%s", recorder.Code, recorder.Body.String())
+		}
+	case <-time.After(250 * time.Millisecond):
+		cancel()
+		<-done
+		t.Fatal("stalled upstream upload outlived the gateway progress timeout")
+	}
+}
+
+func TestProxyBoundsStalledUpstreamResponseBody(t *testing.T) {
+	gateway := newTestGateway(t, "http://octo-mail.test", []byte(strings.Repeat("g", 32)), time.Now())
+	gateway.cfg.timeout = 20 * time.Millisecond
+	stalled := newBlockingReadCloser()
+	gateway.client = &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: http.StatusOK, ContentLength: 1, Body: stalled}, nil
+	})}
+	done := make(chan *httptest.ResponseRecorder, 1)
+	go func() {
+		recorder := httptest.NewRecorder()
+		newProxyRouter(gateway, "user-a", "space-a").ServeHTTP(
+			recorder,
+			httptest.NewRequest(http.MethodGet, "/v1/mail-gateway/webapi/v0/messages", nil),
+		)
+		done <- recorder
+	}()
+	select {
+	case recorder := <-done:
+		if recorder.Code != http.StatusOK {
+			t.Fatalf("stalled response status=%d body=%s", recorder.Code, recorder.Body.String())
+		}
+	case <-time.After(250 * time.Millisecond):
+		_ = stalled.Close()
+		<-done
+		t.Fatal("stalled upstream response body outlived the gateway progress timeout")
+	}
+}
+
+func TestProxyBoundsStalledDownstreamWriteAndReleasesRequestBudget(t *testing.T) {
+	const requestSize = largeRequestThreshold + 1
+	gateway := newTestGateway(t, "http://octo-mail.test", []byte(strings.Repeat("g", 32)), time.Now())
+	gateway.cfg.timeout = 100 * time.Millisecond
+	gateway.requestBodyBudget = semaphore.NewWeighted(requestSize)
+	gateway.largeRequestSlotWait = 100 * time.Millisecond
+	upstreamBody := newCloseTrackingReadCloser(strings.NewReader("response"))
+	gateway.client = &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode:    http.StatusOK,
+			ContentLength: int64(len("response")),
+			Body:          upstreamBody,
+		}, nil
+	})}
+
+	request := httptest.NewRequest(
+		http.MethodPost,
+		"/v1/mail-gateway/webapi/v0/messages",
+		bytes.NewReader(make([]byte, requestSize)),
+	)
+	writer := newDeadlineBlockingResponseWriter()
+	done := make(chan struct{})
+	go func() {
+		newProxyRouter(gateway, "user-a", "space-a").ServeHTTP(writer, request)
+		close(done)
+	}()
+
+	select {
+	case <-writer.writeStarted:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("downstream response write did not start")
+	}
+	if !gateway.requestBodyBudget.TryAcquire(requestSize) {
+		t.Fatal("request body budget remained held after the upstream request body closed")
+	}
+	gateway.requestBodyBudget.Release(requestSize)
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("stalled downstream write outlived the gateway progress timeout")
+	}
+	select {
+	case <-upstreamBody.closed:
+	default:
+		t.Fatal("stalled downstream write did not close the upstream response body")
+	}
+	if !writer.sawWriteDeadline() {
+		t.Fatal("downstream response write was not given a progress deadline")
+	}
+	if !writer.deadlineCleared() {
+		t.Fatal("downstream response deadline was not cleared after the handler returned")
+	}
+	if !gateway.requestBodyBudget.TryAcquire(requestSize) {
+		t.Fatal("request body budget remained held after the stalled handler returned")
+	}
+	gateway.requestBodyBudget.Release(requestSize)
+}
+
+func TestRequestBodyBudgetReleasesOnlyAfterUpstreamRequestBodyCloses(t *testing.T) {
+	const requestSize = largeRequestThreshold + 1
+	gateway := newTestGateway(t, "http://octo-mail.test", []byte(strings.Repeat("g", 32)), time.Now())
+	gateway.nonceSource = zeroReader{}
+	gateway.requestBodyBudget = semaphore.NewWeighted(requestSize)
+	gateway.largeRequestSlotWait = 100 * time.Millisecond
+	firstAtUpstream := make(chan struct{})
+	closeUpstreamRequestBody := make(chan struct{})
+	upstreamRequestBodyClosed := make(chan struct{})
+	upstreamResponseBody := newBlockingReadCloser()
+	gateway.client = &http.Client{Transport: rawRoundTripFunc(func(request *http.Request) (*http.Response, error) {
+		close(firstAtUpstream)
+		go func() {
+			<-closeUpstreamRequestBody
+			_ = request.Body.Close()
+			close(upstreamRequestBodyClosed)
+		}()
+		return &http.Response{
+			StatusCode:    http.StatusOK,
+			ContentLength: 1,
+			Body:          upstreamResponseBody,
+		}, nil
+	})}
+	router := newProxyRouter(gateway, "user-a", "space-a")
+	firstDone := make(chan *httptest.ResponseRecorder, 1)
+	go func() {
+		recorder := httptest.NewRecorder()
+		request := httptest.NewRequest(http.MethodPost, "/v1/mail-gateway/webapi/v0/messages", strings.NewReader("1234"))
+		request.ContentLength = requestSize
+		router.ServeHTTP(recorder, request)
+		firstDone <- recorder
+	}()
+	<-firstAtUpstream
+
+	if gateway.requestBodyBudget.TryAcquire(requestSize) {
+		gateway.requestBodyBudget.Release(requestSize)
+		t.Fatal("request body budget was released before the upstream request body closed")
+	}
+
+	close(closeUpstreamRequestBody)
+	select {
+	case <-upstreamRequestBodyClosed:
+	case <-time.After(time.Second):
+		t.Fatal("upstream request body did not close")
+	}
+	if !gateway.requestBodyBudget.TryAcquire(requestSize) {
+		t.Fatal("request body budget remained held after the upstream request body closed")
+	}
+	gateway.requestBodyBudget.Release(requestSize)
+	select {
+	case <-firstDone:
+		t.Fatal("handler completed before its upstream response body was released")
+	default:
+	}
+
+	_ = upstreamResponseBody.Close()
+	select {
+	case first := <-firstDone:
+		if first.Code != http.StatusOK {
+			t.Fatalf("first status=%d body=%q", first.Code, first.Body.String())
+		}
+	case <-time.After(time.Second):
+		t.Fatal("handler did not finish after the upstream response body closed")
+	}
+}
+
+func TestReleasingRequestBodyDropsBufferedReaderBeforeReleasingBudget(t *testing.T) {
+	releaseCalls := 0
+	var requestBody *releasingRequestBody
+	requestBody = newReleasingRequestBody([]byte("buffered"), nil, func() {
+		requestBody.mu.Lock()
+		defer requestBody.mu.Unlock()
+		if requestBody.reader != nil {
+			t.Error("buffered reader was still reachable when the budget was released")
+		}
+		releaseCalls++
+	})
+	if err := requestBody.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := requestBody.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if releaseCalls != 1 {
+		t.Fatalf("release calls=%d, want 1", releaseCalls)
+	}
+	var probe [1]byte
+	if n, err := requestBody.Read(probe[:]); n != 0 || !errors.Is(err, io.EOF) {
+		t.Fatalf("read after close = (%d, %v), want EOF", n, err)
+	}
+}
+
+func TestProxyOverridesUpstreamCachePolicyForPrivateMail(t *testing.T) {
+	gateway := newTestGateway(t, "http://octo-mail.test", []byte(strings.Repeat("g", 32)), time.Now())
+	gateway.client = &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode:    http.StatusOK,
+			ContentLength: 2,
+			Header: http.Header{
+				"Cache-Control": []string{"public, max-age=3600"},
+				"Vary":          []string{"Accept-Encoding"},
+			},
+			Body: io.NopCloser(strings.NewReader("ok")),
+		}, nil
+	})}
+	recorder := httptest.NewRecorder()
+	newProxyRouter(gateway, "user-a", "space-a").ServeHTTP(
+		recorder,
+		httptest.NewRequest(http.MethodGet, "/v1/mail-gateway/webapi/v0/messages", nil),
+	)
+	if recorder.Code != http.StatusOK || recorder.Body.String() != "ok" {
+		t.Fatalf("status=%d body=%q", recorder.Code, recorder.Body.String())
+	}
+	if got := recorder.Header().Get("Cache-Control"); got != "private, no-store" {
+		t.Fatalf("Cache-Control=%q", got)
+	}
+	if got := recorder.Header().Get("Vary"); got != "token, X-Space-ID, X-Octo-Mailbox-ID" {
+		t.Fatalf("Vary=%q", got)
+	}
+}
+
+func TestUnknownLengthRequestReservesMaximumBodyBudget(t *testing.T) {
+	gateway := &Gateway{
+		requestBodyBudget:    semaphore.NewWeighted(maxRequestBytes),
+		largeRequestSlotWait: 10 * time.Millisecond,
+	}
+	unknown := httptest.NewRequest(http.MethodPost, "/", strings.NewReader("body"))
+	unknown.ContentLength = -1
+	release, err := gateway.acquireRequestBodyBudget(unknown)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer release()
+
+	small := httptest.NewRequest(http.MethodPost, "/", strings.NewReader("x"))
+	small.ContentLength = 1
+	releaseSmall, err := gateway.acquireRequestBodyBudget(small)
+	if err != nil {
+		t.Fatalf("small request became collateral damage of the large-body budget: %v", err)
+	}
+	releaseSmall()
+
+	large := httptest.NewRequest(http.MethodPost, "/", strings.NewReader("large"))
+	large.ContentLength = largeRequestThreshold + 1
+	if _, err := gateway.acquireRequestBodyBudget(large); !errors.Is(err, errRequestBodyBudgetWait) {
+		t.Fatalf("large request error=%v, want unknown request to reserve the full limit", err)
+	}
+}
+
+func TestConnectionNominatedHeadersAreNotForwarded(t *testing.T) {
+	requestSource := http.Header{
+		"Connection":        []string{"Content-Type, X-Octo-Mailbox-ID"},
+		"Content-Type":      []string{"application/json"},
+		"X-Octo-Mailbox-ID": []string{"42"},
+	}
+	requestDestination := make(http.Header)
+	copyRequestHeaders(requestDestination, requestSource)
+	if requestDestination.Get("Content-Type") != "" || requestDestination.Get("X-Octo-Mailbox-ID") != "" {
+		t.Fatalf("connection-nominated request headers forwarded: %#v", requestDestination)
+	}
+
+	responseSource := http.Header{
+		"Connection":        []string{"X-Upstream-Result"},
+		"X-Upstream-Result": []string{"private"},
+		"Content-Type":      []string{"application/json"},
+	}
+	responseDestination := make(http.Header)
+	copyResponseHeaders(responseDestination, responseSource)
+	if responseDestination.Get("X-Upstream-Result") != "" {
+		t.Fatalf("connection-nominated response header forwarded: %#v", responseDestination)
+	}
+	if responseDestination.Get("Content-Type") != "application/json" {
+		t.Fatalf("end-to-end response header was dropped: %#v", responseDestination)
+	}
+}
+
+func newTestGateway(t *testing.T, upstreamURL string, secret []byte, now time.Time) *Gateway {
+	t.Helper()
+	parsed, err := url.Parse(upstreamURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return &Gateway{
+		Log:                  log.NewTLog("AgentMailGatewayTest"),
+		cfg:                  gatewayConfig{upstream: parsed, secret: secret, timeout: 5 * time.Second},
+		client:               newGatewayHTTPClient(5 * time.Second),
+		now:                  func() time.Time { return now },
+		nonceSource:          bytes.NewReader(make([]byte, 16)),
+		largeRequestSlots:    make(chan struct{}, maxConcurrentLargeRequests),
+		largeRequestSlotWait: defaultLargeRequestSlotWait,
+		requestBodyBudget:    semaphore.NewWeighted(maxInFlightRequestBodyBytes),
+	}
+}
+
+func newProxyRouter(gateway *Gateway, uid, spaceID string) *wkhttp.WKHttp {
+	router := wkhttp.New()
+	router.SetErrorRenderer(i18n.NewErrorRenderer(i18n.NewLocalizer(i18n.SourceLanguage)))
+	registerProxyRoute(router, gateway, uid, spaceID)
+	return router
+}
+
+func newProductionWrappedProxyRouter(gateway *Gateway, uid, spaceID string) *wkhttp.WKHttp {
+	router := wkhttp.New()
+	router.SetErrorRenderer(i18n.NewErrorRenderer(i18n.NewLocalizer(i18n.SourceLanguage)))
+	router.UseGin(i18n.EarlyMiddleware(i18n.MiddlewareOptions{DefaultLanguage: i18n.SourceLanguage}))
+	router.UseGin(appmetrics.NewHTTPMetrics(prometheus.NewRegistry()).GinMiddleware())
+	registerProxyRoute(router, gateway, uid, spaceID)
+	return router
+}
+
+func registerProxyRoute(router *wkhttp.WKHttp, gateway *Gateway, uid, spaceID string) {
+	router.Any(gatewayRoutePrefix+"/*path", func(c *wkhttp.Context) {
+		if uid != "" {
+			c.Set("uid", uid)
+		}
+		if spaceID != "" {
+			c.Set("space_id", spaceID)
+		}
+		gateway.proxy(c)
+	})
+}
+
+func verifyAssertionForTest(t *testing.T, secret []byte, token string) assertionClaims {
+	t.Helper()
+	if !strings.HasPrefix(token, assertionPrefix) {
+		t.Fatalf("missing assertion prefix: %q", token)
+	}
+	payloadText, signatureText, ok := strings.Cut(strings.TrimPrefix(token, assertionPrefix), ".")
+	if !ok {
+		t.Fatalf("invalid assertion shape")
+	}
+	signature, err := base64.RawURLEncoding.DecodeString(signatureText)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mac := hmac.New(sha256.New, secret)
+	_, _ = mac.Write([]byte(payloadText))
+	if !hmac.Equal(signature, mac.Sum(nil)) {
+		t.Fatal("invalid assertion signature")
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(payloadText)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var claims assertionClaims
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		t.Fatal(err)
+	}
+	return claims
+}
+
+func fmtHex(value []byte) string {
+	const digits = "0123456789abcdef"
+	result := make([]byte, len(value)*2)
+	for i, b := range value {
+		result[i*2] = digits[b>>4]
+		result[i*2+1] = digits[b&0x0f]
+	}
+	return string(result)
+}
+
+func assertErrorCode(t *testing.T, body []byte, want string) {
+	t.Helper()
+	var envelope struct {
+		Error struct {
+			Code string `json:"code"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		t.Fatalf("decode error envelope: %v; body=%s", err, body)
+	}
+	if envelope.Error.Code != want {
+		t.Fatalf("error code = %q, want %q", envelope.Error.Code, want)
+	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(request *http.Request) (response *http.Response, err error) {
+	if request.Body != nil {
+		defer request.Body.Close()
+	}
+	return f(request)
+}
+
+// rawRoundTripFunc is reserved for tests that exercise the RoundTripper
+// contract allowing Request.Body to close asynchronously after RoundTrip
+// returns. Most test transports use roundTripFunc so they close bodies just as
+// production net/http transports must.
+type rawRoundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f rawRoundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) {
+	return f(request)
+}
+
+type failingReadCloser struct {
+	err error
+}
+
+func (r failingReadCloser) Read([]byte) (int, error) { return 0, r.err }
+func (failingReadCloser) Close() error               { return nil }
+
+type partialFailingReadCloser struct {
+	data []byte
+	err  error
+}
+
+func (r *partialFailingReadCloser) Read(dst []byte) (int, error) {
+	if len(r.data) == 0 {
+		return 0, r.err
+	}
+	n := copy(dst, r.data)
+	r.data = r.data[n:]
+	return n, nil
+}
+
+func (*partialFailingReadCloser) Close() error { return nil }
+
+type stagedReadCloser struct {
+	first   []byte
+	rest    []byte
+	release <-chan struct{}
+	stage   int
+}
+
+func (r *stagedReadCloser) Read(dst []byte) (int, error) {
+	switch r.stage {
+	case 0:
+		r.stage = 1
+		return copy(dst, r.first), nil
+	case 1:
+		<-r.release
+		r.stage = 2
+		return copy(dst, r.rest), nil
+	default:
+		return 0, io.EOF
+	}
+}
+
+func (*stagedReadCloser) Close() error { return nil }
+
+type blockingReadCloser struct {
+	closed chan struct{}
+	once   sync.Once
+}
+
+func newBlockingReadCloser() *blockingReadCloser {
+	return &blockingReadCloser{closed: make(chan struct{})}
+}
+
+func (r *blockingReadCloser) Read([]byte) (int, error) {
+	<-r.closed
+	return 0, errors.New("body closed")
+}
+
+func (r *blockingReadCloser) Close() error {
+	r.once.Do(func() { close(r.closed) })
+	return nil
+}
+
+type closeTrackingReadCloser struct {
+	io.Reader
+	closed chan struct{}
+	once   sync.Once
+}
+
+func newCloseTrackingReadCloser(reader io.Reader) *closeTrackingReadCloser {
+	return &closeTrackingReadCloser{Reader: reader, closed: make(chan struct{})}
+}
+
+func (r *closeTrackingReadCloser) Close() error {
+	r.once.Do(func() { close(r.closed) })
+	return nil
+}
+
+type deadlineBlockingResponseWriter struct {
+	header       http.Header
+	mu           sync.Mutex
+	deadlines    []time.Time
+	writeStarted chan struct{}
+	writeOnce    sync.Once
+}
+
+func newDeadlineBlockingResponseWriter() *deadlineBlockingResponseWriter {
+	return &deadlineBlockingResponseWriter{
+		header:       make(http.Header),
+		writeStarted: make(chan struct{}),
+	}
+}
+
+func (w *deadlineBlockingResponseWriter) Header() http.Header { return w.header }
+
+func (*deadlineBlockingResponseWriter) WriteHeader(int) {}
+
+func (w *deadlineBlockingResponseWriter) Write([]byte) (int, error) {
+	w.writeOnce.Do(func() { close(w.writeStarted) })
+	w.mu.Lock()
+	deadline := w.deadlines[len(w.deadlines)-1]
+	w.mu.Unlock()
+	if wait := time.Until(deadline); wait > 0 {
+		timer := time.NewTimer(wait)
+		defer timer.Stop()
+		<-timer.C
+	}
+	return 0, context.DeadlineExceeded
+}
+
+func (*deadlineBlockingResponseWriter) Flush() {}
+
+func (w *deadlineBlockingResponseWriter) SetWriteDeadline(deadline time.Time) error {
+	w.mu.Lock()
+	w.deadlines = append(w.deadlines, deadline)
+	w.mu.Unlock()
+	return nil
+}
+
+func (w *deadlineBlockingResponseWriter) sawWriteDeadline() bool {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	for _, deadline := range w.deadlines {
+		if !deadline.IsZero() {
+			return true
+		}
+	}
+	return false
+}
+
+func (w *deadlineBlockingResponseWriter) deadlineCleared() bool {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return len(w.deadlines) > 0 && w.deadlines[len(w.deadlines)-1].IsZero()
+}
+
+type zeroReader struct{}
+
+func (zeroReader) Read(p []byte) (int, error) {
+	for i := range p {
+		p[i] = 0
+	}
+	return len(p), nil
+}

--- a/pkg/errcode/agent_mail_gateway.go
+++ b/pkg/errcode/agent_mail_gateway.go
@@ -1,0 +1,42 @@
+package errcode
+
+import (
+	"net/http"
+
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n/codes"
+)
+
+var (
+	ErrAgentMailGatewayUnauthorized = register(codes.Code{
+		ID:             "err.server.agent_mail_gateway.unauthorized",
+		HTTPStatus:     http.StatusUnauthorized,
+		DefaultMessage: "Authentication is required.",
+	})
+	ErrAgentMailGatewaySpaceRequired = register(codes.Code{
+		ID:             "err.server.agent_mail_gateway.space_required",
+		HTTPStatus:     http.StatusBadRequest,
+		DefaultMessage: "Select a Space before opening Agent Mail.",
+	})
+	ErrAgentMailGatewayRequestInvalid = register(codes.Code{
+		ID:             "err.server.agent_mail_gateway.request_invalid",
+		HTTPStatus:     http.StatusBadRequest,
+		DefaultMessage: "Invalid Agent Mail request.",
+	})
+	ErrAgentMailGatewayPayloadTooLarge = register(codes.Code{
+		ID:             "err.server.agent_mail_gateway.payload_too_large",
+		HTTPStatus:     http.StatusRequestEntityTooLarge,
+		DefaultMessage: "The Agent Mail request is too large.",
+	})
+	ErrAgentMailGatewayUnavailable = register(codes.Code{
+		ID:             "err.server.agent_mail_gateway.unavailable",
+		HTTPStatus:     http.StatusServiceUnavailable,
+		DefaultMessage: "Agent Mail is temporarily unavailable.",
+		Internal:       true,
+	})
+	ErrAgentMailGatewayBadResponse = register(codes.Code{
+		ID:             "err.server.agent_mail_gateway.bad_response",
+		HTTPStatus:     http.StatusBadGateway,
+		DefaultMessage: "Agent Mail returned an invalid response.",
+		Internal:       true,
+	})
+)

--- a/pkg/i18n/locales/active.zh-CN.toml
+++ b/pkg/i18n/locales/active.zh-CN.toml
@@ -746,6 +746,26 @@ other = "Webhook 消息投递失败。"
 ["err.server.incomingwebhook.push_disabled"]
 other = "未找到。"
 
+# ---- err.server.agent_mail_gateway.* ----
+
+["err.server.agent_mail_gateway.unauthorized"]
+other = "请先登录。"
+
+["err.server.agent_mail_gateway.space_required"]
+other = "请先选择 Space，再打开 Agent Mail。"
+
+["err.server.agent_mail_gateway.request_invalid"]
+other = "Agent Mail 请求无效。"
+
+["err.server.agent_mail_gateway.payload_too_large"]
+other = "Agent Mail 请求内容过大。"
+
+["err.server.agent_mail_gateway.unavailable"]
+other = "Agent Mail 暂时不可用。"
+
+["err.server.agent_mail_gateway.bad_response"]
+other = "Agent Mail 返回了无效响应。"
+
 # ---- err.server.incomingwebhook.mgmt_* (management endpoints, #246 follow-up) ----
 
 ["err.server.incomingwebhook.mgmt_forbidden"]

--- a/pkg/i18n/response_writer.go
+++ b/pkg/i18n/response_writer.go
@@ -1,6 +1,10 @@
 package i18n
 
-import "github.com/gin-gonic/gin"
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
 
 // contentLanguageWriter is a gin.ResponseWriter shim that refreshes the
 // Content-Language header right before the response is committed.
@@ -33,6 +37,11 @@ type contentLanguageWriter struct {
 
 func newContentLanguageWriter(c *gin.Context, earlyLang string) *contentLanguageWriter {
 	return &contentLanguageWriter{ResponseWriter: c.Writer, c: c, earlyLang: earlyLang}
+}
+
+// Unwrap keeps optional net/http capabilities reachable through this shim.
+func (w *contentLanguageWriter) Unwrap() http.ResponseWriter {
+	return w.ResponseWriter
 }
 
 // applyLanguage stamps the late-merged Content-Language onto the response.

--- a/pkg/metrics/http.go
+++ b/pkg/metrics/http.go
@@ -175,6 +175,11 @@ type bodyCapture struct {
 	limit int
 }
 
+// Unwrap keeps optional net/http capabilities reachable through this shim.
+func (b *bodyCapture) Unwrap() http.ResponseWriter {
+	return b.ResponseWriter
+}
+
 func (b *bodyCapture) Write(p []byte) (int, error) {
 	if remain := b.limit - b.buf.Len(); remain > 0 {
 		take := len(p)

--- a/tools/i18nmarkers/server/active.en-US.toml
+++ b/tools/i18nmarkers/server/active.en-US.toml
@@ -6,6 +6,24 @@
 #
 # CI rejects PRs that change codes.Register input without re-running extract.
 
+["err.server.agent_mail_gateway.bad_response"]
+other = "Agent Mail returned an invalid response."
+
+["err.server.agent_mail_gateway.payload_too_large"]
+other = "The Agent Mail request is too large."
+
+["err.server.agent_mail_gateway.request_invalid"]
+other = "Invalid Agent Mail request."
+
+["err.server.agent_mail_gateway.space_required"]
+other = "Select a Space before opening Agent Mail."
+
+["err.server.agent_mail_gateway.unauthorized"]
+other = "Authentication is required."
+
+["err.server.agent_mail_gateway.unavailable"]
+other = "Agent Mail is temporarily unavailable."
+
 ["err.server.app_bot.id_conflict"]
 other = "The bot id is already in use."
 


### PR DESCRIPTION
## Summary

Adds an authenticated browser Mail identity gateway that binds each downstream request to the logged-in OCTO user, active Space, selected mailbox, method, URI, body digest, expiry, and nonce.

Owner-confirmed Agent Draft delivery is intentionally outside octo-server: the trusted Mail Plugin performs the OpenClaw Owner check and uses octo-mail's scoped, versioned Draft-send path. This PR does not add a Bot Draft-send endpoint.

## Related Issue

Fixes #735

## Linked Spec

`.octospec/tasks/agent-mail-identity-gateway/brief.md`

## Changes

- Add short-lived Gateway assertions bound to user UID, Space, mailbox, method, URI, body digest, lifetime, and nonce.
- Add authenticated browser Mail Gateway routing without forwarding caller-controlled authorization or hop-by-hop headers.
- Keep requests fail-closed when Gateway configuration, identity, Space membership, mailbox selection, path validation, or assertion signing fails.
- Enforce a 64 MiB per-request body limit and a 256 MiB aggregate accounted-byte budget while allowing small bodies to avoid large-upload contention.
- Bound stalled client request bodies, upstream request writes, response headers, and response-body progress without penalizing slow but progressing transfers.
- Reject over-limit unknown-length request bodies without blocking in `net/http` connection-reuse draining, and release their slot and byte reservation.
- Stream supported self-delimiting responses; reject ambiguous close-delimited and unsupported downstream protocol combinations before status commit.
- Add real HTTP/2 downstream, stalled-body, unknown-length overflow, upload-stall, response-stall, framing, response-overflow, and aggregate-budget regression tests.

## Testing

- [x] Unit tests added/updated
- [x] Manually verified

```bash
go test ./modules/agentmailgateway/... -count=1
go test -race ./modules/agentmailgateway/... -count=1
go vet ./modules/agentmailgateway/... ./pkg/i18n ./pkg/metrics
go build ./...
make i18n-extract-check
make i18n-lint
git diff --check
```

All commands above pass.

## COMPREHENSION

1. **What does this change actually do** to the load-bearing path?

   Browser Mail calls enter octo-server with the user's login session and Space context. The gateway resolves that server-side identity, validates the constrained upstream route, signs the exact request, and forwards only an allowlisted header set. Large bodies and streaming responses are bounded by size, aggregate accounted-byte limits, and phase-specific progress deadlines. Rejected unknown-length bodies make the browser connection non-reusable before cleanup so unread bytes cannot wedge the handler in the server request-body drain.

2. **What could break** because of it (dependents + failure mode)?

   Browser Mail depends on matching Gateway configuration and octo-mail assertion verification. Invalid identity, Space, mailbox, route, framing, an oversized body, or a stalled transfer fails closed as a localized Gateway error or transport failure. Agent Draft confirmation does not depend on this browser gateway or a new Bot endpoint.

3. **How do you know it works** (specific test/repro/trace)?

   Tests cover assertion binding and tampering, path confinement, header filtering, request-size and aggregate-budget enforcement, slow/stalled and over-limit unknown-length request bodies, stalled upstream writes and reads, known-length truncation, chunked response overflow/failure, real HTTP/2 downstream behavior, and timeout layering. The unknown-length overflow regression also proves a following large upload succeeds after the rejection. Package race tests, vet, repository build, and i18n checks pass.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] PR description is in English
- [x] Added tests for my changes
- [x] Updated documentation
- [x] Followed commit message conventions (Conventional Commits)
