### PR TITLE
fix(auth): use proxy-aware IPs for login audits

### DIFF
--- a/.octospec/journal/shared/login-audit-ip-spoofing.md
+++ b/.octospec/journal/shared/login-audit-ip-spoofing.md
@@ -1,0 +1,60 @@
+---
+type: Journal
+title: "Journal: login-audit-ip-spoofing"
+description: Login and OIDC audit attribution now share octo-lib's validated proxy-aware client-IP selector with rate limiting, while preserving the audit, response, and quota contracts.
+tags: ["user", "oidc", "auth", "login-audit", "rate-limit", "trust-boundary", "security", "dependency"]
+timestamp: 2026-08-12T00:04:11+08:00
+task: login-audit-ip-spoofing
+upstream: Mininglamp-OSS/octo-lib#119
+source: self
+---
+
+# login-audit-ip-spoofing
+
+## What was done
+
+- octo-lib PR #119 exports `wkhttp.ClientIP`, makes both shared IP limiters use
+  it, selects the proxy-appended rightmost XFF entry, validates and canonicalizes
+  candidates, fails malformed or ambiguous input into the existing unknown-IP
+  bucket, and bounds suffix parsing without splitting an attacker-sized header.
+- octo-server replaces all 15 user-module and four OIDC security-sensitive
+  `util.GetClientPublicIP(c.Request)` sources with `wkhttp.ClientIP`. This covers
+  successful and failed login audit, account creation, logout, OIDC state and
+  session propagation, bind audit, and the OIDC callback failure-counter key.
+- `normalizeLoginIP` remains at the user audit insertion boundary as defense in
+  depth. No route, response, error envelope, schema, quota, or welcome-message
+  ordering changed; non-security `util.GetClientPublicIP` callers are untouched.
+
+## Load-bearing decisions
+
+- The immediate contract is the current single-CLB topology: the trusted proxy
+  must own the final XFF entry and overwrite or strip `X-Real-Ip`; public clients
+  must not reach the service directly. `wkhttp.ClientIP` is one parser shared by
+  rate limiting and audit, so those paths cannot disagree on the source key.
+- Parsing a syntactically valid IP is not a proxy trust decision. The retained
+  database normalizer protects field integrity, while CLB header ownership and
+  network reachability remain deployment gates.
+- This is a stacked change. The server PR may be reviewed while octo-lib #119 is
+  open, but it must not merge until the library is squash-merged and `go.mod` is
+  updated from the temporary PR-head pseudo-version to the final merge revision.
+
+## Verification
+
+- TDD RED: server commit `1274394a` fails in a detached worktree because the old
+  octo-lib has no `wkhttp.ClientIP`; GREEN: `e68a52d7` passes the same focused
+  user/OIDC targets and the user audit database integration case.
+- The complete OIDC package passes against octo-lib head `d1184f6` in an isolated
+  schema. Focused user/OIDC tests also pass with the race detector; full-repo
+  `go vet ./...`, `golangci-lint run ./...`, `go mod verify`, and diff checks pass.
+- The complete user-package run is not claimed green: its filtered failures are
+  pre-existing dashboard-reader tests whose isolated schema lacks legacy column
+  `user.app_id`. A clean CI run remains the pre-merge full-suite gate.
+
+## Rollout and rollback
+
+- Before production, verify the actual CLB header bytes and direct-connect
+  controls. Monitor audit-IP cardinality/empties, OIDC callback rejection and
+  HTTP 429 rates; a shift to proxy addresses or the unknown bucket indicates a
+  broken topology assumption.
+- Roll back the octo-server binary/dependency set. No schema rollback or
+  historical audit rewrite is required or safe.

--- a/.octospec/journal/shared/login-audit-ip-spoofing.md
+++ b/.octospec/journal/shared/login-audit-ip-spoofing.md
@@ -25,6 +25,17 @@ source: self
 - `normalizeLoginIP` remains at the user audit insertion boundary as defense in
   depth. No route, response, error envelope, schema, quota, or welcome-message
   ordering changed; non-security `util.GetClientPublicIP` callers are untouched.
+- Review follow-up closes the malformed-header bypass: when `wkhttp.ClientIP`
+  deliberately returns empty for an invalid or ambiguous final header,
+  `CallbackGuard` now uses its stable `__unknown_ip__` bucket for check,
+  failure-recording, and reset instead of silently treating the request as
+  unidentifiable. Its existing threshold/window/prefix and Redis fail-open
+  contract remain intact.
+- User and OIDC source guards now scan all production Go files in each package
+  with AST import-alias handling, preserve the 15/4 `wkhttp.ClientIP` inventory,
+  and reserve named exemptions for any intentional legacy use. A real
+  `/v1/user/login` `ServeHTTP` test now verifies the persisted failed-login
+  audit IP is the proxy-appended rightmost XFF value.
 
 ## Load-bearing decisions
 
@@ -51,6 +62,16 @@ source: self
 - The complete user-package run is not claimed green: its filtered failures are
   pre-existing dashboard-reader tests whose isolated schema lacks legacy column
   `user.app_id`. A clean CI run remains the pre-merge full-suite gate.
+- Review TDD evidence: `662383a5` is RED — three malformed-final-XFF callback
+  failures did not consume the callback budget and a fourth request still got
+  400. `0cc82cf9` is GREEN — the fourth request receives the established 429
+  path. The focused user route/source-guard target passes, and the complete
+  OIDC package passes in its independent isolated schema. The equivalent
+  default-database OIDC run remains blocked before assertions by stale shared
+  migration state (`unknown migration ... 20191106000001_event_legacy01.sql`).
+- Focused race runs for the new user and OIDC coverage pass, as do
+  `GOWORK=off go vet ./...`, `GOWORK=off golangci-lint run ./...` (0 issues),
+  `GOWORK=off go mod verify`, and `git diff --check`.
 
 ## Rollout and rollback
 
@@ -60,3 +81,7 @@ source: self
   broken topology assumption.
 - Roll back the octo-server binary/dependency set. No schema rollback or
   historical audit rewrite is required or safe.
+- The independent incoming-webhook IP parser, global Gin trusted-proxy wiring,
+  empty-IP welcome-message formatting, and the QR-code commentary remain
+  explicitly out of scope for this PR and are documented as follow-ups in the
+  task brief.

--- a/.octospec/journal/shared/login-audit-ip-spoofing.md
+++ b/.octospec/journal/shared/login-audit-ip-spoofing.md
@@ -13,10 +13,11 @@ source: self
 
 ## What was done
 
-- octo-lib PR #119 exports `wkhttp.ClientIP`, makes both shared IP limiters use
-  it, selects the proxy-appended rightmost XFF entry, validates and canonicalizes
-  candidates, fails malformed or ambiguous input into the existing unknown-IP
-  bucket, and bounds suffix parsing without splitting an attacker-sized header.
+- octo-lib PR #119, squash-merged as `233dd6f`, exports `wkhttp.ClientIP`, makes
+  both shared IP limiters use it, selects the proxy-appended rightmost XFF entry,
+  validates and canonicalizes candidates, fails malformed or ambiguous input
+  into the existing unknown-IP bucket, and bounds suffix parsing without
+  splitting an attacker-sized header.
 - octo-server replaces all 15 user-module and four OIDC security-sensitive
   `util.GetClientPublicIP(c.Request)` sources with `wkhttp.ClientIP`. This covers
   successful and failed login audit, account creation, logout, OIDC state and
@@ -34,18 +35,19 @@ source: self
 - Parsing a syntactically valid IP is not a proxy trust decision. The retained
   database normalizer protects field integrity, while CLB header ownership and
   network reachability remain deployment gates.
-- This is a stacked change. The server PR may be reviewed while octo-lib #119 is
-  open, but it must not merge until the library is squash-merged and `go.mod` is
-  updated from the temporary PR-head pseudo-version to the final merge revision.
+- This was developed as a stacked change. The server PR opened while octo-lib
+  #119 was under review; after the library squash merge, `go.mod` was updated to
+  final merge revision `233dd6f` and the focused gates were rerun.
 
 ## Verification
 
 - TDD RED: server commit `1274394a` fails in a detached worktree because the old
   octo-lib has no `wkhttp.ClientIP`; GREEN: `e68a52d7` passes the same focused
   user/OIDC targets and the user audit database integration case.
-- The complete OIDC package passes against octo-lib head `d1184f6` in an isolated
-  schema. Focused user/OIDC tests also pass with the race detector; full-repo
-  `go vet ./...`, `golangci-lint run ./...`, `go mod verify`, and diff checks pass.
+- The complete OIDC package passes against octo-lib merge commit `233dd6f` in an
+  isolated schema. Focused user/OIDC tests also pass with the race detector;
+  full-repo `go vet ./...`, `golangci-lint run ./...`, `go mod verify`, and diff
+  checks pass.
 - The complete user-package run is not claimed green: its filtered failures are
   pre-existing dashboard-reader tests whose isolated schema lacks legacy column
   `user.app_id`. A clean CI run remains the pre-merge full-suite gate.

--- a/.octospec/log.md
+++ b/.octospec/log.md
@@ -9,9 +9,9 @@ change-log convention (§7). Newest first.
 - **Fix** — Task `login-audit-ip-spoofing`: login, account-creation, logout, and
   OIDC audit/guard paths now use the same validated proxy-aware client-IP source
   as shared rate limiting. The stacked server change covers all 15 user and four
-  OIDC sources, preserves the audit/wire/quota contracts, and depends on approved
-  octo-lib PR #119. The final library squash SHA and production CLB/direct-access
-  checks remain merge and rollout gates. See
+  OIDC sources, preserves the audit/wire/quota contracts, and now pins merged
+  octo-lib #119 commit `233dd6f`. Production CLB/direct-access checks remain
+  rollout gates. See
   [journal](journal/shared/login-audit-ip-spoofing.md).
 
 ## 2026-08-10 (token-lifecycle-hardening PR 2)

--- a/.octospec/log.md
+++ b/.octospec/log.md
@@ -10,8 +10,10 @@ change-log convention (§7). Newest first.
   OIDC audit/guard paths now use the same validated proxy-aware client-IP source
   as shared rate limiting. The stacked server change covers all 15 user and four
   OIDC sources, preserves the audit/wire/quota contracts, and now pins merged
-  octo-lib #119 commit `233dd6f`. Production CLB/direct-access checks remain
-  rollout gates. See
+  octo-lib #119 commit `233dd6f`. Review follow-up closes empty-IP callback
+  guard bypasses with a stable unknown bucket, directory-wide source guards,
+  and a routed user audit assertion. Production CLB/direct-access checks remain
+  rollout gates; independent incoming-webhook parsing is a follow-up. See
   [journal](journal/shared/login-audit-ip-spoofing.md).
 
 ## 2026-08-10 (token-lifecycle-hardening PR 2)

--- a/.octospec/log.md
+++ b/.octospec/log.md
@@ -4,6 +4,16 @@ Change history for this repo's `.octospec/`, following the
 [OKF](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md)
 change-log convention (§7). Newest first.
 
+## 2026-08-12 (login-audit-ip-spoofing)
+
+- **Fix** — Task `login-audit-ip-spoofing`: login, account-creation, logout, and
+  OIDC audit/guard paths now use the same validated proxy-aware client-IP source
+  as shared rate limiting. The stacked server change covers all 15 user and four
+  OIDC sources, preserves the audit/wire/quota contracts, and depends on approved
+  octo-lib PR #119. The final library squash SHA and production CLB/direct-access
+  checks remain merge and rollout gates. See
+  [journal](journal/shared/login-audit-ip-spoofing.md).
+
 ## 2026-08-10 (token-lifecycle-hardening PR 2)
 
 - **Task** — `token-lifecycle-hardening-pr2`: added an inert-by-default,

--- a/.octospec/tasks/login-audit-ip-spoofing/brief.md
+++ b/.octospec/tasks/login-audit-ip-spoofing/brief.md
@@ -1,0 +1,273 @@
+---
+type: Task
+title: "Task: login-audit-ip-spoofing"
+description: Make login and OIDC audit IP attribution use the same proxy-aware source as shared rate limiting
+tags: [user, oidc, auth, login-audit, rate-limit, trust-boundary, security, dependency]
+timestamp: 2026-08-11T17:22:57+08:00
+slug: login-audit-ip-spoofing
+source: self
+upstream: Mininglamp-OSS/octo-lib#119
+---
+
+# Task: login-audit-ip-spoofing
+
+## Goal
+
+Prevent a client-supplied leftmost `X-Forwarded-For` value from becoming the
+recorded source IP for account creation, login, logout, or OIDC bind events, and
+from splitting the OIDC callback failure counter across attacker-selected keys.
+
+Use one proxy-aware client-IP implementation from octo-lib `pkg/wkhttp` for both
+shared rate limiting and security-sensitive audit paths. Preserve the current
+login response, audit schema, welcome-message ordering, and rate-limit quota
+semantics.
+
+## Background
+
+Before this task, octo-server pinned octo-lib at
+`v0.0.0-20260629040702-79f78844bfab`. In that version:
+
+- `util.GetClientPublicIP` returns the first non-empty value in
+  `X-Forwarded-For`, then `X-Real-Ip`, then `RemoteAddr`.
+- wkhttp's private `getClientIP` returns `X-Real-Ip`, otherwise the rightmost
+  `X-Forwarded-For` value, otherwise `RemoteAddr`.
+
+The octo-lib export and selector hardening are tracked by
+[`Mininglamp-OSS/octo-lib#119`](https://github.com/Mininglamp-OSS/octo-lib/pull/119).
+Its current PR head is `d1184f63703cb88b9a863e77adcb176c69f19b87` and may be
+used as a temporary pseudo-version while the two repositories are developed and
+tested together. octo-lib uses squash merge, so before octo-server merges, its
+dependency must be updated from this temporary PR-head revision to the final
+octo-lib merge commit and the focused tests must be rerun with that revision.
+
+The exported selector deliberately tightens the former private helper. The
+rightmost XFF entry is authoritative even when the proxy appends a separate
+header field line; `X-Real-Ip` is a fallback only, ambiguous duplicates fail
+closed, and every candidate is parsed and canonicalized before it can become a
+rate-limit key or audit value. Invalid candidates enter the existing shared
+unknown-IP bucket rather than creating attacker-selected Redis keys.
+
+With the current single-proxy CLB model, an attacker can send a forged XFF value
+and the proxy can append the real source on the right:
+
+```text
+X-Forwarded-For: 203.0.113.10, 198.51.100.24
+                 attacker value  actual source appended by CLB
+```
+
+`GetClientPublicIP` records `203.0.113.10`; wkhttp's rate-limit helper selects
+`198.51.100.24`. `normalizeLoginIP` only parses and canonicalizes an IP string,
+so it rejects malformed header text but correctly cannot distinguish a valid
+forged IP from a valid trusted value.
+
+Gin `Context.ClientIP()` is not an acceptable replacement in the current
+deployment. `wkhttp.New()` creates a Gin engine with the default trust-all proxy
+configuration, and neither octo-lib nor octo-server calls
+`SetTrustedProxies`. With all proxy addresses trusted, Gin can select the
+attacker-controlled leftmost XFF entry.
+
+The user module contains 15 direct security-sensitive
+`util.GetClientPublicIP(c.Request)` calls, not 14:
+
+- `modules/user/api.go`: 6
+- `modules/user/api_emaillogin.go`: 2
+- `modules/user/api_gitee.go`: 2
+- `modules/user/api_github.go`: 2
+- `modules/user/api_manager.go`: 1
+- `modules/user/api_usernamelogin.go`: 2
+
+OIDC contains four more direct calls. They cover the IP stored in `StateData`,
+the callback failure guard key, logout audit, and the shared bind-audit helper.
+`StateData.IP` also flows through `IssueSessionReq.PublicIP` and
+`user.ExternalLoginReq.PublicIP` into the same user `login_log`, so replacing
+only the 15 user call sites would leave OIDC login audit spoofable.
+
+## Load-bearing list
+
+- `trust-boundary` — forwarded headers are untrusted unless the direct peer is
+  the expected proxy and that proxy owns the header contract. For the immediate
+  single-CLB fix, the actual source must be the final XFF entry, whether the CLB
+  comma-appends or adds a final field line. `X-Real-Ip` is fallback-only and
+  must be overwritten or stripped. Pods must not be reachable through a public
+  path that bypasses the proxy.
+- `single-client-ip-source` — octo-lib `pkg/wkhttp` exports `ClientIP` from the
+  shared rate-limit implementation, validates and canonicalizes its output, and
+  the shared rate-limit middleware and audit callers use that same function.
+  octo-server must not add another local copy of the header parsing algorithm.
+- `user-login-audit` — all 15 direct user-module sources feeding successful or
+  failed login audit, account creation audit, scan login, phone verification,
+  manager login, and GitHub/Gitee login must use `wkhttp.ClientIP`.
+- `oidc-audit` — authorize/callback, logout, and bind audit must use the same IP
+  source. The IP propagated from OIDC into user session issuance must therefore
+  match the OIDC audit IP for the same request stage.
+- `oidc-callback-guard` — the existing failure-only callback guard keeps its
+  thresholds, reset behavior, Redis key prefix, and error contract; source-IP
+  key derivation changes from spoofable leftmost XFF to the validated,
+  canonical value returned by `wkhttp.ClientIP`.
+- `audit-data-contract` — `login_log.login_ip` and `oidc_audit_log.ip` schemas
+  do not change. `normalizeLoginIP` remains at the user audit insertion boundary
+  to enforce valid, canonical IP text and protect the `VARCHAR(40)` field.
+- `welcome-message-ordering` — `finishSuccessfulLogin` must continue reading the
+  previous successful login before inserting the current row, and the same IP
+  selected for the current audit event continues to feed the welcome-message
+  path.
+- `rate-limit` — the global and strict shared IP middleware must retain their
+  quota thresholds, key prefixes, fail-closed unknown-IP bucket, and fail-open
+  Redis-error behavior. Valid IPs become canonical bucket keys; malformed,
+  ambiguous, or oversized candidates use the existing unknown-IP bucket. This
+  task does not introduce a new generic limiter.
+- `dependency-rollout` — stacked development may temporarily pin octo-lib PR
+  #119 head `d1184f63703cb88b9a863e77adcb176c69f19b87`. The octo-lib
+  export must be merged and resolvable before octo-server merges, and
+  `go.mod`/`go.sum` must then point to the final squash-merge commit rather than
+  the superseded PR-head commit.
+- `wire-contract` — no HTTP route, response body, status code, localized error,
+  authentication decision, or client-visible field changes.
+
+## Out of scope
+
+- Globally changing either octo-lib or octo-server
+  `util.GetClientPublicIP`; non-security display and geolocation consumers keep
+  their existing behavior.
+- Configuring Gin `SetTrustedProxies`. A complete implementation first requires
+  octo-lib to expose the private Gin engine's proxy configuration and operations
+  to provide the actual direct-proxy CIDRs. This remains a follow-up hardening
+  item.
+- Supporting an unverified CDN or multi-proxy topology. The rightmost-XFF rule
+  is deliberately tied to the current single-CLB deployment contract.
+- Changing the QR login confirmation UI to display IP/device evidence. The
+  current qrcode code only documents why this evidence is not shown.
+- Fixing the separate live `c.ClientIP()` uses in `modules/messages_search` and
+  `modules/usersecret`; track and assess those independently.
+- Changing OIDC callback guard quotas, introducing a new rate-limit middleware,
+  or altering login/account lockout policy.
+- Database migrations, historical audit-row repair, IP geolocation changes, or
+  retroactive attribution of already-spoofed rows.
+
+## Acceptance
+
+### octo-lib
+
+- Export `wkhttp.ClientIP(r *http.Request) string` with Go documentation that
+  states the header priority, single-proxy assumption, and the required
+  `X-Real-Ip`/XFF ownership and direct-connect controls.
+- Shared global and strict IP rate-limit middleware call the exported function;
+  no second implementation remains inside wkhttp.
+- Unit tests prove all of the following:
+  - The final XFF entry has priority over `X-Real-Ip` when both are present.
+  - For `X-Forwarded-For: <forged>, <actual>`, the returned value is `<actual>`.
+  - A proxy-added second XFF field line is treated as the final entry.
+  - Duplicate fallback `X-Real-Ip` fields fail closed.
+  - Invalid, oversized, sentinel-colliding, or zoned values fail closed.
+  - Valid IPv4 and IPv6 values are canonicalized and IPv4-mapped IPv6 is
+    unmapped.
+  - a missing forwarded header falls back to IPv4 and IPv6 `RemoteAddr` values.
+  - an unusable or non-IP request address returns the empty-string fallback.
+- Existing wkhttp rate-limit tests continue to pass without quota, key-prefix,
+  fail-open/fail-closed, or error-envelope changes.
+
+### octo-server
+
+- During stacked development, `go.mod` and `go.sum` may point to octo-lib PR
+  #119 head `d1184f63703cb88b9a863e77adcb176c69f19b87`. Before the
+  octo-server PR merges, they point to the final octo-lib squash-merge revision
+  containing `wkhttp.ClientIP`, and focused tests have passed against it.
+- All 15 user-module and four OIDC direct
+  `util.GetClientPublicIP(c.Request)` calls in scope use `wkhttp.ClientIP`.
+- A source guard fails if `util.GetClientPublicIP(c.Request)` is reintroduced
+  under `modules/user` or `modules/oidc` without an explicit test exemption.
+- `normalizeLoginIP` remains in both `recordSuccess` and `recordFailure`; its
+  tests continue to cover canonical IPv4/IPv6 and rejection of malformed or
+  overlong text. Its comments describe validation as defense in depth rather
+  than as a proxy trust decision.
+- A representative successful login and failed login test send a forged
+  leftmost XFF plus an actual rightmost value and assert that `login_log` stores
+  only the actual rightmost IP.
+- OIDC tests prove that the same header shape supplies the actual rightmost IP
+  to `StateData`/audit/session issuance and to the callback failure guard key.
+- No user/OIDC error response, login response, route, database schema, or i18n
+  catalog changes.
+- Focused tests pass in each repository:
+
+  ```bash
+  # octo-lib
+  go test ./pkg/wkhttp/...
+
+  # octo-server; integration cases require MySQL, Redis, and WuKongIM
+  go test ./modules/user/... ./modules/oidc/...
+  ```
+
+- Broader `go test ./...` and lint results are recorded before merge, or an
+  infrastructure-only blocker is documented with its exact error.
+
+### Deployment gate
+
+- Before production rollout, operations verifies with a request observed at
+  the application that the CLB behavior matches both conditions:
+  - a client-supplied XFF entry cannot replace the actual rightmost source;
+  - a client-supplied `X-Real-Ip` is overwritten or stripped rather than passed
+    through unchanged.
+- Network policy/security-group evidence confirms that public clients cannot
+  connect directly to the Pod/service endpoint and supply trusted headers
+  without traversing the CLB.
+- If either condition is false, this task is not considered production-complete;
+  fix the proxy/header contract or implement explicit trusted-proxy processing
+  before relying on the audit IP.
+
+## Deployment and rollback
+
+1. Merge and publish octo-lib PR #119 first. It exports and hardens the shared
+   selector; existing rate-limit thresholds, key prefixes, and Redis failure
+   behavior remain unchanged, while inconsistent or invalid header values now
+   fail into the shared unknown-IP bucket. Replace the temporary PR-head pin
+   with the final squash-merge revision before merging octo-server.
+2. Complete the CLB header and direct-connect deployment gate before deploying
+   the octo-server dependency bump.
+3. Deploy octo-server as a normal rolling release. Monitor login-event IP
+   cardinality, empty/invalid audit IP rates, OIDC callback rejection counts,
+   HTTP 429 rates, and audit insert errors. A sharp shift to CLB/private proxy
+   addresses indicates that the assumed header contract is wrong.
+4. Roll back by deploying the previous octo-server binary and dependency set.
+   No schema or persisted contract rollback is required. The octo-lib commit can
+   remain published because dependency consumers opt into it by revision.
+5. Do not repair historical audit IPs automatically: the original source cannot
+   be reconstructed reliably after attribution was poisoned. Preserve affected
+   rows and annotate the incident window operationally if needed.
+
+## Validation record (2026-08-12)
+
+- octo-lib PR #119 is open at head
+  `d1184f63703cb88b9a863e77adcb176c69f19b87`, approved, and all required CI
+  checks are green while it awaits squash merge. The latest blocking review
+  finding was reproduced RED: a 64 KiB comma-dense XFF allocated 1,056,788
+  bytes per `ClientIP` call before rate limiting. Commit `0878bb2` pins the
+  allocation bound and rightmost-IP behavior; commit `d1184f6` replaces the
+  full `strings.Split` with suffix-only `strings.LastIndexByte` parsing and is
+  GREEN. Both commits are pushed and rereview is approved; no explanatory
+  review comment was added.
+- octo-lib passes `go test ./...`, the focused `TestClientIP` race run,
+  `go vet ./...`, `golangci-lint run ./...`, and `git diff --check` at
+  `d1184f6`.
+- The octo-server stacked branch temporarily pins the resolvable pseudo-version
+  `v0.0.0-20260811154526-d1184f63703c`. Commit `1274394a` is the RED checkpoint:
+  in a detached worktree at that commit, the focused user target fails to build
+  because the old octo-lib has no `wkhttp.ClientIP`. Commit `e68a52d7` is the
+  GREEN production change. With `GOWORK=off`, focused user and OIDC client-IP
+  tests pass, including source guards, OIDC state storage, session issuance,
+  audit attribution, callback failure limiting, and bind context attribution.
+  The focused race run, `go mod verify`, full-repo `go vet ./...`, full-repo
+  `golangci-lint run ./...`, and `git diff --check` also pass.
+- In isolated schema `octo_login_audit_ip_lusaka_20260811`,
+  `TestLoginLog_RecordSuccessAndFailure_Integration` passes against octo-lib
+  `d1184f6` and proves successful and failed login rows retain the rightmost XFF
+  value. In independent schema `octo_login_audit_oidc_lusaka_20260811`, the
+  complete `go test ./modules/oidc/... -count=1` run passes against the same
+  octo-lib head.
+- The complete user package run is not counted as green. Its filtered failure
+  list contains only pre-existing dashboard-reader manager tests; a focused
+  rerun fails at test setup with `Error 1054 (42S22): Unknown column 'app_id'
+  in 'field list'` while inserting `user.Model`. The isolated schema is missing
+  the legacy `user.app_id` column declared by
+  `modules/user/sql/20210204000001_user_legacy01.sql`. This is an isolated-schema
+  fixture gap, not a login-audit assertion failure; a clean full user/repo run
+  remains a pre-merge CI gate.

--- a/.octospec/tasks/login-audit-ip-spoofing/brief.md
+++ b/.octospec/tasks/login-audit-ip-spoofing/brief.md
@@ -34,11 +34,11 @@ Before this task, octo-server pinned octo-lib at
 
 The octo-lib export and selector hardening are tracked by
 [`Mininglamp-OSS/octo-lib#119`](https://github.com/Mininglamp-OSS/octo-lib/pull/119).
-Its current PR head is `d1184f63703cb88b9a863e77adcb176c69f19b87` and may be
-used as a temporary pseudo-version while the two repositories are developed and
-tested together. octo-lib uses squash merge, so before octo-server merges, its
-dependency must be updated from this temporary PR-head revision to the final
-octo-lib merge commit and the focused tests must be rerun with that revision.
+It was squash-merged as `233dd6fcdda60ccf347811d1e7a069f1e9703bf8` after stacked
+development against PR head `d1184f63703cb88b9a863e77adcb176c69f19b87`.
+octo-server now pins the final merge revision through pseudo-version
+`v0.0.0-20260811160929-233dd6fcdda6`, and the focused tests have been rerun
+against that revision.
 
 The exported selector deliberately tightens the former private helper. The
 rightmost XFF entry is authoritative even when the proxy appends a separate
@@ -116,11 +116,10 @@ only the 15 user call sites would leave OIDC login audit spoofable.
   Redis-error behavior. Valid IPs become canonical bucket keys; malformed,
   ambiguous, or oversized candidates use the existing unknown-IP bucket. This
   task does not introduce a new generic limiter.
-- `dependency-rollout` — stacked development may temporarily pin octo-lib PR
-  #119 head `d1184f63703cb88b9a863e77adcb176c69f19b87`. The octo-lib
-  export must be merged and resolvable before octo-server merges, and
-  `go.mod`/`go.sum` must then point to the final squash-merge commit rather than
-  the superseded PR-head commit.
+- `dependency-rollout` — stacked development used octo-lib PR #119 head
+  `d1184f63703cb88b9a863e77adcb176c69f19b87`; the final server dependency must
+  resolve to squash-merge commit `233dd6fcdda60ccf347811d1e7a069f1e9703bf8`,
+  not the superseded PR-head commit.
 - `wire-contract` — no HTTP route, response body, status code, localized error,
   authentication decision, or client-visible field changes.
 
@@ -168,10 +167,9 @@ only the 15 user call sites would leave OIDC login audit spoofable.
 
 ### octo-server
 
-- During stacked development, `go.mod` and `go.sum` may point to octo-lib PR
-  #119 head `d1184f63703cb88b9a863e77adcb176c69f19b87`. Before the
-  octo-server PR merges, they point to the final octo-lib squash-merge revision
-  containing `wkhttp.ClientIP`, and focused tests have passed against it.
+- `go.mod` and `go.sum` point to octo-lib squash-merge revision
+  `233dd6fcdda60ccf347811d1e7a069f1e9703bf8` containing `wkhttp.ClientIP`, and
+  focused tests have passed against it.
 - All 15 user-module and four OIDC direct
   `util.GetClientPublicIP(c.Request)` calls in scope use `wkhttp.ClientIP`.
 - A source guard fails if `util.GetClientPublicIP(c.Request)` is reintroduced
@@ -236,33 +234,32 @@ only the 15 user call sites would leave OIDC login audit spoofable.
 
 ## Validation record (2026-08-12)
 
-- octo-lib PR #119 is open at head
-  `d1184f63703cb88b9a863e77adcb176c69f19b87`, approved, and all required CI
-  checks are green while it awaits squash merge. The latest blocking review
-  finding was reproduced RED: a 64 KiB comma-dense XFF allocated 1,056,788
-  bytes per `ClientIP` call before rate limiting. Commit `0878bb2` pins the
-  allocation bound and rightmost-IP behavior; commit `d1184f6` replaces the
-  full `strings.Split` with suffix-only `strings.LastIndexByte` parsing and is
-  GREEN. Both commits are pushed and rereview is approved; no explanatory
-  review comment was added.
+- octo-lib PR #119 was approved with all required CI green and squash-merged as
+  `233dd6fcdda60ccf347811d1e7a069f1e9703bf8`. Its latest blocking review finding
+  was reproduced RED: a 64 KiB comma-dense XFF allocated 1,056,788 bytes per
+  `ClientIP` call before rate limiting. Commit `0878bb2` pins the allocation
+  bound and rightmost-IP behavior; commit `d1184f6` replaces the full
+  `strings.Split` with suffix-only `strings.LastIndexByte` parsing and is GREEN.
+  No explanatory review comment was added.
 - octo-lib passes `go test ./...`, the focused `TestClientIP` race run,
   `go vet ./...`, `golangci-lint run ./...`, and `git diff --check` at
   `d1184f6`.
-- The octo-server stacked branch temporarily pins the resolvable pseudo-version
-  `v0.0.0-20260811154526-d1184f63703c`. Commit `1274394a` is the RED checkpoint:
+- The octo-server branch pins final pseudo-version
+  `v0.0.0-20260811160929-233dd6fcdda6`. Commit `1274394a` is the RED checkpoint:
   in a detached worktree at that commit, the focused user target fails to build
   because the old octo-lib has no `wkhttp.ClientIP`. Commit `e68a52d7` is the
   GREEN production change. With `GOWORK=off`, focused user and OIDC client-IP
   tests pass, including source guards, OIDC state storage, session issuance,
   audit attribution, callback failure limiting, and bind context attribution.
   The focused race run, `go mod verify`, full-repo `go vet ./...`, full-repo
-  `golangci-lint run ./...`, and `git diff --check` also pass.
+  `golangci-lint run ./...`, and `git diff --check` also pass after switching to
+  final merge commit `233dd6f`.
 - In isolated schema `octo_login_audit_ip_lusaka_20260811`,
   `TestLoginLog_RecordSuccessAndFailure_Integration` passes against octo-lib
-  `d1184f6` and proves successful and failed login rows retain the rightmost XFF
+  `233dd6f` and proves successful and failed login rows retain the rightmost XFF
   value. In independent schema `octo_login_audit_oidc_lusaka_20260811`, the
   complete `go test ./modules/oidc/... -count=1` run passes against the same
-  octo-lib head.
+  octo-lib merge commit.
 - The complete user package run is not counted as green. Its filtered failure
   list contains only pre-existing dashboard-reader manager tests; a focused
   rerun fails at test setup with `Error 1054 (42S22): Unknown column 'app_id'

--- a/.octospec/tasks/login-audit-ip-spoofing/brief.md
+++ b/.octospec/tasks/login-audit-ip-spoofing/brief.md
@@ -103,7 +103,9 @@ only the 15 user call sites would leave OIDC login audit spoofable.
 - `oidc-callback-guard` — the existing failure-only callback guard keeps its
   thresholds, reset behavior, Redis key prefix, and error contract; source-IP
   key derivation changes from spoofable leftmost XFF to the validated,
-  canonical value returned by `wkhttp.ClientIP`.
+  canonical value returned by `wkhttp.ClientIP`. A malformed or ambiguous
+  header returns an empty value from that selector and must use the guard's
+  stable unknown-IP bucket, never bypass the failure counter.
 - `audit-data-contract` — `login_log.login_ip` and `oidc_audit_log.ip` schemas
   do not change. `normalizeLoginIP` remains at the user audit insertion boundary
   to enforce valid, canonical IP text and protect the `VARCHAR(40)` field.
@@ -128,18 +130,25 @@ only the 15 user call sites would leave OIDC login audit spoofable.
 - Globally changing either octo-lib or octo-server
   `util.GetClientPublicIP`; non-security display and geolocation consumers keep
   their existing behavior.
-- Configuring Gin `SetTrustedProxies`. A complete implementation first requires
-  octo-lib to expose the private Gin engine's proxy configuration and operations
-  to provide the actual direct-proxy CIDRs. This remains a follow-up hardening
-  item.
+- Configuring Gin `SetTrustedProxies` or consolidating every local client-IP
+  parser. The repository already has `OCTO_TRUSTED_PROXY_CIDRS` for i18n caller
+  resolution, but wiring that policy into wkhttp/Gin and reconciling all parser
+  consumers is a separate rollout with its own topology validation.
 - Supporting an unverified CDN or multi-proxy topology. The rightmost-XFF rule
   is deliberately tied to the current single-CLB deployment contract.
 - Changing the QR login confirmation UI to display IP/device evidence. The
   current qrcode code only documents why this evidence is not shown.
 - Fixing the separate live `c.ClientIP()` uses in `modules/messages_search` and
   `modules/usersecret`; track and assess those independently.
+- Replacing the independent `modules/incomingwebhook/ratelimit.go` client-IP
+  parser. It has different XFF/X-Real-IP precedence and multi-header handling;
+  move it to `wkhttp.ClientIP` with dedicated delivery-rate-limit tests in a
+  follow-up rather than expanding this login-audit PR.
 - Changing OIDC callback guard quotas, introducing a new rate-limit middleware,
   or altering login/account lockout policy.
+- Changing empty-IP welcome-message rendering or the stale QR-code IP
+  commentary. They are user-experience/documentation follow-ups, not part of
+  audit attribution or callback-guard enforcement.
 - Database migrations, historical audit-row repair, IP geolocation changes, or
   retroactive attribution of already-spoofed rows.
 
@@ -172,8 +181,11 @@ only the 15 user call sites would leave OIDC login audit spoofable.
   focused tests have passed against it.
 - All 15 user-module and four OIDC direct
   `util.GetClientPublicIP(c.Request)` calls in scope use `wkhttp.ClientIP`.
-- A source guard fails if `util.GetClientPublicIP(c.Request)` is reintroduced
-  under `modules/user` or `modules/oidc` without an explicit test exemption.
+- Directory-level source guards scan every production `.go` file under
+  `modules/user` and `modules/oidc` (excluding `_test.go`), detect
+  `util.GetClientPublicIP` even when imported with an alias, retain the 15/4
+  `wkhttp.ClientIP` call inventory, and require a named, justified exemption
+  for any intentional legacy use.
 - `normalizeLoginIP` remains in both `recordSuccess` and `recordFailure`; its
   tests continue to cover canonical IPv4/IPv6 and rejection of malformed or
   overlong text. Its comments describe validation as defense in depth rather
@@ -181,8 +193,13 @@ only the 15 user call sites would leave OIDC login audit spoofable.
 - A representative successful login and failed login test send a forged
   leftmost XFF plus an actual rightmost value and assert that `login_log` stores
   only the actual rightmost IP.
+- At least one user `/v1/user/login` router test drives `ServeHTTP` and queries
+  `login_log`, proving handler wiring (rather than only the audit DB boundary)
+  stores the rightmost XFF value.
 - OIDC tests prove that the same header shape supplies the actual rightmost IP
   to `StateData`/audit/session issuance and to the callback failure guard key.
+- OIDC callback tests prove an invalid final XFF value still increments the
+  stable unknown-IP bucket and reaches the existing callback threshold.
 - No user/OIDC error response, login response, route, database schema, or i18n
   catalog changes.
 - Focused tests pass in each repository:
@@ -268,3 +285,19 @@ only the 15 user call sites would leave OIDC login audit spoofable.
   `modules/user/sql/20210204000001_user_legacy01.sql`. This is an isolated-schema
   fixture gap, not a login-audit assertion failure; a clean full user/repo run
   remains a pre-merge CI gate.
+- Review follow-up RED checkpoint `662383a5` demonstrates the newly reachable
+  empty-IP path: three invalid-final-XFF callback failures returned 400 and the
+  fourth was incorrectly still 400 instead of 429. It also adds AST-backed
+  directory source guards and a real `/v1/user/login` failure-route audit test.
+  GREEN checkpoint `0cc82cf9` maps empty selector output to the guard's stable
+  `__unknown_ip__` bucket without changing thresholds, window, Redis prefix, or
+  reset semantics. The focused OIDC reproducer and user route/source-guard test
+  pass; the complete OIDC package passes in
+  `octo_login_audit_oidc_lusaka_20260811`.
+- The review follow-up also passes focused `-race` runs for those OIDC and user
+  targets, `GOWORK=off go vet ./...`, `GOWORK=off golangci-lint run ./...`
+  (0 issues), `GOWORK=off go mod verify`, and `git diff --check`.
+- The same complete OIDC command against the shared default `test` database is
+  not counted green: setup panics at `unknown migration in database` for
+  `20191106000001_event_legacy01.sql`. The isolated-schema pass above is the
+  relevant package evidence; a clean CI database remains the merge gate.

--- a/.octospec/tasks/login-audit-ip-spoofing/context.yaml
+++ b/.octospec/tasks/login-audit-ip-spoofing/context.yaml
@@ -1,0 +1,14 @@
+injected:
+  - id: error-handling
+    source: repo
+  - id: rate-limit
+    source: repo
+  - id: space-isolation
+    source: repo
+  - id: trust-boundary
+    source: repo
+  - id: testing
+    source: repo
+  - id: commit-style
+    source: repo
+brief: .octospec/tasks/login-audit-ip-spoofing/brief.md

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	firebase.google.com/go/v4 v4.13.0
 	github.com/BurntSushi/toml v1.6.0
 	github.com/DATA-DOG/go-sqlmock v1.5.0
-	github.com/Mininglamp-OSS/octo-lib v0.0.0-20260629040702-79f78844bfab
+	github.com/Mininglamp-OSS/octo-lib v0.0.0-20260811154526-d1184f63703c
 	github.com/alibabacloud-go/darabonba-openapi v0.2.1
 	github.com/alibabacloud-go/sms-intl-20180501 v1.0.1
 	github.com/alibabacloud-go/tea v1.2.1

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	firebase.google.com/go/v4 v4.13.0
 	github.com/BurntSushi/toml v1.6.0
 	github.com/DATA-DOG/go-sqlmock v1.5.0
-	github.com/Mininglamp-OSS/octo-lib v0.0.0-20260811154526-d1184f63703c
+	github.com/Mininglamp-OSS/octo-lib v0.0.0-20260811160929-233dd6fcdda6
 	github.com/alibabacloud-go/darabonba-openapi v0.2.1
 	github.com/alibabacloud-go/sms-intl-20180501 v1.0.1
 	github.com/alibabacloud-go/tea v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -65,8 +65,8 @@ github.com/HdrHistogram/hdrhistogram-go v1.1.2 h1:5IcZpTvzydCQeHzK4Ef/D5rrSqwxob
 github.com/HdrHistogram/hdrhistogram-go v1.1.2/go.mod h1:yDgFjdqOqDEKOvasDdhWNXYg9BVp4O+o5f6V/ehm6Oo=
 github.com/MicahParks/keyfunc v1.9.0 h1:lhKd5xrFHLNOWrDc4Tyb/Q1AJ4LCzQ48GVJyVIID3+o=
 github.com/MicahParks/keyfunc v1.9.0/go.mod h1:IdnCilugA0O/99dW+/MkvlyrsX8+L8+x95xuVNtM5jw=
-github.com/Mininglamp-OSS/octo-lib v0.0.0-20260811154526-d1184f63703c h1:cPW5kpcT1ekhuRaV6Hkrl0nNEzCbYOPVcMhGv5JKLUo=
-github.com/Mininglamp-OSS/octo-lib v0.0.0-20260811154526-d1184f63703c/go.mod h1:uOCTTI3QdG0ETKZ6uluRWUZgKexee/pY1pQYWyIEvZ0=
+github.com/Mininglamp-OSS/octo-lib v0.0.0-20260811160929-233dd6fcdda6 h1:yQpfOy/A0sGpuHrCrg9HYZBgYiMEKSZkpGgwWHmMT3o=
+github.com/Mininglamp-OSS/octo-lib v0.0.0-20260811160929-233dd6fcdda6/go.mod h1:uOCTTI3QdG0ETKZ6uluRWUZgKexee/pY1pQYWyIEvZ0=
 github.com/RichardKnop/logging v0.0.0-20190827224416-1a693bdd4fae h1:DcFpTQBYQ9Ct2d6sC7ol0/ynxc2pO1cpGUM+f4t5adg=
 github.com/RichardKnop/logging v0.0.0-20190827224416-1a693bdd4fae/go.mod h1:rJJ84PyA/Wlmw1hO+xTzV2wsSUon6J5ktg0g8BF2PuU=
 github.com/RichardKnop/machinery/v2 v2.0.11 h1:BTfLGOmOju3W/OtlZmLX26OjYNZsU4PJo04pQReycdc=

--- a/go.sum
+++ b/go.sum
@@ -65,8 +65,8 @@ github.com/HdrHistogram/hdrhistogram-go v1.1.2 h1:5IcZpTvzydCQeHzK4Ef/D5rrSqwxob
 github.com/HdrHistogram/hdrhistogram-go v1.1.2/go.mod h1:yDgFjdqOqDEKOvasDdhWNXYg9BVp4O+o5f6V/ehm6Oo=
 github.com/MicahParks/keyfunc v1.9.0 h1:lhKd5xrFHLNOWrDc4Tyb/Q1AJ4LCzQ48GVJyVIID3+o=
 github.com/MicahParks/keyfunc v1.9.0/go.mod h1:IdnCilugA0O/99dW+/MkvlyrsX8+L8+x95xuVNtM5jw=
-github.com/Mininglamp-OSS/octo-lib v0.0.0-20260629040702-79f78844bfab h1:pPc175QRTu8j2EbQY3fSSQZEThfO2Qs5Fe1UomawOLY=
-github.com/Mininglamp-OSS/octo-lib v0.0.0-20260629040702-79f78844bfab/go.mod h1:uOCTTI3QdG0ETKZ6uluRWUZgKexee/pY1pQYWyIEvZ0=
+github.com/Mininglamp-OSS/octo-lib v0.0.0-20260811154526-d1184f63703c h1:cPW5kpcT1ekhuRaV6Hkrl0nNEzCbYOPVcMhGv5JKLUo=
+github.com/Mininglamp-OSS/octo-lib v0.0.0-20260811154526-d1184f63703c/go.mod h1:uOCTTI3QdG0ETKZ6uluRWUZgKexee/pY1pQYWyIEvZ0=
 github.com/RichardKnop/logging v0.0.0-20190827224416-1a693bdd4fae h1:DcFpTQBYQ9Ct2d6sC7ol0/ynxc2pO1cpGUM+f4t5adg=
 github.com/RichardKnop/logging v0.0.0-20190827224416-1a693bdd4fae/go.mod h1:rJJ84PyA/Wlmw1hO+xTzV2wsSUon6J5ktg0g8BF2PuU=
 github.com/RichardKnop/machinery/v2 v2.0.11 h1:BTfLGOmOju3W/OtlZmLX26OjYNZsU4PJo04pQReycdc=

--- a/modules/oidc/api.go
+++ b/modules/oidc/api.go
@@ -16,7 +16,6 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/pkg/cache"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/register"
-	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
 	"github.com/Mininglamp-OSS/octo-server/modules/user"
 	"github.com/Mininglamp-OSS/octo-server/pkg/auth"
@@ -380,7 +379,7 @@ func (o *OIDC) authorize(c *wkhttp.Context) {
 		Provider:       o.cfg.Provider.ID,
 		CodeVerifier:   verifier,
 		Nonce:          nonce,
-		IP:             util.GetClientPublicIP(c.Request),
+		IP:             wkhttp.ClientIP(c.Request),
 		UserAgent:      c.Request.UserAgent(),
 		ReturnTo:       cleanReturnTo,
 		ClientAuthcode: authcode,
@@ -410,7 +409,7 @@ func (o *OIDC) authorize(c *wkhttp.Context) {
 // 与 api_github.go:161 保持一致,前端无需新代码。
 func (o *OIDC) callback(c *wkhttp.Context) {
 	traceID := newTraceID()
-	clientIP := util.GetClientPublicIP(c.Request)
+	clientIP := wkhttp.ClientIP(c.Request)
 	start := time.Now()
 
 	// result 在每个分支显式置位,defer 集中上报 callback 计数 + duration。
@@ -950,7 +949,7 @@ func (o *OIDC) logout(c *wkhttp.Context) {
 		metricLogoutTotal.WithLabelValues("ok").Inc()
 	}
 	o.writeAudit(uid, EventLogout, &StateData{
-		IP:        util.GetClientPublicIP(c.Request),
+		IP:        wkhttp.ClientIP(c.Request),
 		UserAgent: c.Request.UserAgent(),
 	}, "")
 

--- a/modules/oidc/api_bind.go
+++ b/modules/oidc/api_bind.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
 	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
 	"go.uber.org/zap"
@@ -409,13 +408,10 @@ func stateFromCtx(c *wkhttp.Context) *StateData {
 	}
 }
 
-// clientIP 抽出来避免对 util 包的多余依赖;直接读 Request.RemoteAddr 兜底。
-// 生产路径前置代理时由 util.GetClientPublicIP 透 X-Forwarded-For,这里测试
-// 走 httptest 不会有代理,RemoteAddr 即真实 IP。
+// clientIP 与共享限流复用同一代理感知取值路径，避免审计和限流对同一请求记录
+// 不同来源。测试走 httptest 时没有代理，wkhttp.ClientIP 会回退到 RemoteAddr。
 func clientIP(c *wkhttp.Context) string {
-	// 透 util 而非 net.SplitHostPort:与 callback 路径行为对齐,避免反向代理头
-	// 解析差异引入审计字段不一致。
-	return util.GetClientPublicIP(c.Request)
+	return wkhttp.ClientIP(c.Request)
 }
 
 // bindResultFromErr 把 BindService 返回的 error 翻译成 metric result label。

--- a/modules/oidc/api_bind_test.go
+++ b/modules/oidc/api_bind_test.go
@@ -101,6 +101,19 @@ func newTestBindRouter(o *OIDC) *gin.Engine {
 	return r
 }
 
+func TestStateFromCtxUsesProxyAwareClientIP(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/auth/oidc/aegis/bind/confirm", nil)
+	c.Request.Header.Set("X-Forwarded-For", "203.0.113.10, 198.51.100.24")
+
+	sd := stateFromCtx(wrapWk(c))
+	if sd.IP != "198.51.100.24" {
+		t.Fatalf("StateData.IP = %q, want trusted rightmost XFF", sd.IP)
+	}
+}
+
 func defaultBindCfg() BindConfig {
 	return BindConfig{
 		Enabled:        true,

--- a/modules/oidc/api_test.go
+++ b/modules/oidc/api_test.go
@@ -482,6 +482,42 @@ func TestAPI_Callback_RateLimited(t *testing.T) {
 	}
 }
 
+// ClientIP 对畸形最终 XFF 返回空串；callback guard 必须把这种请求归入稳定的
+// unknown-IP 桶，而不是因为没有可用 IP 就跳过失败计数。
+func TestAPI_Callback_InvalidFinalXFFUsesUnknownBucket(t *testing.T) {
+	mp := NewMockProvider(t)
+	o := newTestOIDC(t, mp, &fakeUserLookup{}, newFakeIdentityStore())
+	o.cbGuard = NewCallbackGuard(newCallbackGuardRedis(t), 3, 5*time.Minute)
+
+	const unknownIP = "__unknown_ip__"
+	unknownKey := o.cbGuard.key(unknownIP)
+	if err := o.cbGuard.redis.Del(unknownKey); err != nil {
+		t.Fatalf("clear unknown-IP callback bucket: %v", err)
+	}
+	t.Cleanup(func() { _ = o.cbGuard.redis.Del(unknownKey) })
+
+	r := newTestRouter(o)
+	for i := 0; i < 3; i++ {
+		req := httptest.NewRequest("GET",
+			"/v1/auth/oidc/aegis/callback?state=never-saved&code=x", nil)
+		req.Header.Set("X-Forwarded-For", "203.0.113.10, not-an-ip")
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("attempt %d status = %d, want 400; body=%s", i+1, w.Code, w.Body.String())
+		}
+	}
+
+	req := httptest.NewRequest("GET",
+		"/v1/auth/oidc/aegis/callback?state=never-saved&code=x", nil)
+	req.Header.Set("X-Forwarded-For", "203.0.113.10, not-an-ip")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusTooManyRequests {
+		t.Fatalf("status after unknown-IP threshold = %d, want 429; body=%s", w.Code, w.Body.String())
+	}
+}
+
 // 成功 callback 应落 EventCallbackOK 审计;IdP 错误应落 EventCallbackFail。
 func TestAPI_Callback_AuditTrail(t *testing.T) {
 	mp := NewMockProvider(t)

--- a/modules/oidc/api_test.go
+++ b/modules/oidc/api_test.go
@@ -49,6 +49,17 @@ func (f *fakeAudit) events() []AuditEvent {
 	return out
 }
 
+func (f *fakeAudit) ipForEvent(event AuditEvent) string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for _, entry := range f.entries {
+		if entry.Event == event {
+			return entry.IP
+		}
+	}
+	return ""
+}
+
 // fakeAuthcode 内存版 ThirdAuthcode 写入,用于 handler 测试。
 // failNext > 0 时下一次 Set 调用会返错(模拟 Redis 抖动),用完自减。
 type fakeAuthcode struct {
@@ -172,6 +183,33 @@ func TestAPI_Authorize_RedirectsToIdP(t *testing.T) {
 	}
 }
 
+func TestAPI_Authorize_StoresProxyAwareClientIP(t *testing.T) {
+	mp := NewMockProvider(t)
+	o := newTestOIDC(t, mp, &fakeUserLookup{}, newFakeIdentityStore())
+	r := newTestRouter(o)
+
+	req := httptest.NewRequest("GET", "/v1/auth/oidc/aegis/authorize?authcode=ac-ip", nil)
+	req.Header.Set("X-Forwarded-For", "203.0.113.10, 198.51.100.24")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	loc, err := url.Parse(w.Header().Get("Location"))
+	if err != nil {
+		t.Fatalf("parse location: %v", err)
+	}
+	state := loc.Query().Get("state")
+	if state == "" {
+		t.Fatal("missing state in authorize redirect")
+	}
+	sd, err := o.stateStore.Consume(context.Background(), state)
+	if err != nil {
+		t.Fatalf("consume state: %v", err)
+	}
+	if sd.IP != "198.51.100.24" {
+		t.Fatalf("StateData.IP = %q, want trusted rightmost XFF", sd.IP)
+	}
+}
+
 // authorize 缺 authcode 应 400。
 func TestAPI_Authorize_MissingAuthcode(t *testing.T) {
 	mp := NewMockProvider(t)
@@ -254,6 +292,7 @@ func TestAPI_Callback_E2E_ExistingUser(t *testing.T) {
 
 	// Step 1: authorize → 拿到 state
 	req := httptest.NewRequest("GET", "/v1/auth/oidc/aegis/authorize?authcode=front-ac&return_to=/home", nil)
+	req.Header.Set("X-Forwarded-For", "203.0.113.10, 198.51.100.24")
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
 	if w.Code != http.StatusFound {
@@ -284,7 +323,7 @@ func TestAPI_Callback_E2E_ExistingUser(t *testing.T) {
 	if len(users.loginCalls) != 1 {
 		t.Fatalf("expected 1 IssueSession call, got %d", len(users.loginCalls))
 	}
-	if c := users.loginCalls[0]; c.UID != "u-existing" || c.CreateUser {
+	if c := users.loginCalls[0]; c.UID != "u-existing" || c.CreateUser || c.PublicIP != "198.51.100.24" {
 		t.Errorf("IssueSession call wrong: %+v", c)
 	}
 }
@@ -420,9 +459,9 @@ func TestAPI_Callback_RateLimited(t *testing.T) {
 	o := newTestOIDC(t, mp, &fakeUserLookup{}, newFakeIdentityStore())
 	o.cbGuard = NewCallbackGuard(newCallbackGuardRedis(t), 3, 5*time.Minute)
 
-	// 直接把计数顶到阈值。GetClientPublicIP 在无 X-Forwarded-For 时
-	// 会返回 RemoteAddr 的 IP,httptest 默认 192.0.2.1。
-	const testIP = "192.0.2.1"
+	// 直接把真实来源计数顶到阈值。请求随后携带一个伪造的最左 XFF；callback
+	// 必须仍命中最右侧真实来源的桶，而不是让攻击者靠改最左项绕过阈值。
+	const testIP = "198.51.100.24"
 	o.cbGuard.Reset(testIP)
 	t.Cleanup(func() { o.cbGuard.Reset(testIP) })
 	for i := 0; i < 3; i++ {
@@ -434,6 +473,7 @@ func TestAPI_Callback_RateLimited(t *testing.T) {
 	r := newTestRouter(o)
 	req := httptest.NewRequest("GET",
 		"/v1/auth/oidc/aegis/callback?state=any&code=x", nil)
+	req.Header.Set("X-Forwarded-For", "203.0.113.10, "+testIP)
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
 
@@ -462,6 +502,7 @@ func TestAPI_Callback_AuditTrail(t *testing.T) {
 
 	// 成功路径
 	req := httptest.NewRequest("GET", "/v1/auth/oidc/aegis/authorize?authcode=ac-ok&return_to=/", nil)
+	req.Header.Set("X-Forwarded-For", "203.0.113.10, 198.51.100.24")
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
 	authURL, _ := url.Parse(w.Header().Get("Location"))
@@ -482,6 +523,9 @@ func TestAPI_Callback_AuditTrail(t *testing.T) {
 	}
 	if !foundOK {
 		t.Errorf("expected EventCallbackOK in audit, got %v", events)
+	}
+	if got := audit.ipForEvent(EventCallbackOK); got != "198.51.100.24" {
+		t.Errorf("EventCallbackOK IP = %q, want trusted rightmost XFF", got)
 	}
 }
 

--- a/modules/oidc/callback_guard.go
+++ b/modules/oidc/callback_guard.go
@@ -17,6 +17,7 @@ const (
 	defaultCallbackFailThreshold = 10
 	defaultCallbackFailWindow    = 5 * time.Minute
 	callbackFailKeyPrefix        = "oidc:cb:fail:"
+	callbackUnknownIPKey         = "__unknown_ip__"
 )
 
 // ErrCallbackBlocked /callback 同 IP 失败次数过多,临时锁定。
@@ -50,11 +51,20 @@ func NewCallbackGuard(r *redis.Conn, threshold int64, window time.Duration) *Cal
 	return &CallbackGuard{redis: r, threshold: threshold, window: window}
 }
 
-func normalizeIP(ip string) string { return strings.TrimSpace(ip) }
+func normalizeIP(ip string) string {
+	ip = strings.TrimSpace(ip)
+	if ip == "" {
+		// wkhttp.ClientIP 对畸形或歧义的代理头 fail-closed 返回空串。与共享
+		// IP limiter 保持同一语义：归入稳定的 unknown-IP 桶，不能跳过保护。
+		return callbackUnknownIPKey
+	}
+	return ip
+}
 
 func (g *CallbackGuard) key(ip string) string { return callbackFailKeyPrefix + ip }
 
-// Check 失败计数已达阈值返回 ErrCallbackBlocked,否则放行。空 IP 视为无效标识直接放行。
+// Check 失败计数已达阈值返回 ErrCallbackBlocked,否则放行。空 IP 归入共享的
+// unknown-IP 桶，避免畸形代理头绕过保护。
 //
 // fail-open:Redis 抖动时不锁,与 LoginGuard 一致。基础设施层网关 cap 兜底 DoS。
 //
@@ -64,9 +74,6 @@ func (g *CallbackGuard) Check(ip string) error {
 		return nil
 	}
 	ip = normalizeIP(ip)
-	if ip == "" {
-		return nil
-	}
 	s, err := g.redis.GetString(g.key(ip))
 	if err != nil {
 		log.Warn("CallbackGuard Check 读取失败,fail-open", zap.String("ip", ip), zap.Error(err))
@@ -92,9 +99,6 @@ func (g *CallbackGuard) RecordFailure(ip string) error {
 		return nil
 	}
 	ip = normalizeIP(ip)
-	if ip == "" {
-		return nil
-	}
 	key := g.key(ip)
 	if _, err := g.redis.Incr(key); err != nil {
 		return fmt.Errorf("incr callback failure: %w", err)
@@ -112,9 +116,6 @@ func (g *CallbackGuard) Reset(ip string) error {
 		return nil
 	}
 	ip = normalizeIP(ip)
-	if ip == "" {
-		return nil
-	}
 	if err := g.redis.Del(g.key(ip)); err != nil {
 		return fmt.Errorf("del callback failure: %w", err)
 	}

--- a/modules/oidc/callback_guard_test.go
+++ b/modules/oidc/callback_guard_test.go
@@ -60,12 +60,18 @@ func TestCallbackGuard_Reset_ClearsCounter(t *testing.T) {
 	assert.NoError(t, g.Check(ip))
 }
 
-func TestCallbackGuard_EmptyIPIsNoop(t *testing.T) {
+func TestCallbackGuard_EmptyIPUsesUnknownBucket(t *testing.T) {
 	g := NewCallbackGuard(newCallbackGuardRedis(t), 3, 5*time.Minute)
-	assert.NoError(t, g.RecordFailure(""))
-	assert.NoError(t, g.RecordFailure("   "))
-	assert.NoError(t, g.Check(""))
+	const unknownIP = "__unknown_ip__"
+	assert.NoError(t, g.redis.Del(g.key(unknownIP)))
+	t.Cleanup(func() { _ = g.redis.Del(g.key(unknownIP)) })
+
+	for i := 0; i < 3; i++ {
+		assert.NoError(t, g.RecordFailure(""))
+	}
+	assert.ErrorIs(t, g.Check("   "), ErrCallbackBlocked)
 	assert.NoError(t, g.Reset(""))
+	assert.NoError(t, g.Check(""))
 }
 
 func TestCallbackGuard_DefaultThresholdAndWindow(t *testing.T) {

--- a/modules/oidc/client_ip_source_test.go
+++ b/modules/oidc/client_ip_source_test.go
@@ -1,0 +1,33 @@
+package oidc
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestSecuritySensitivePathsUseWKHTTPClientIP(t *testing.T) {
+	tests := []struct {
+		file      string
+		wantCalls int
+	}{
+		{file: "api.go", wantCalls: 3},
+		{file: "api_bind.go", wantCalls: 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.file, func(t *testing.T) {
+			data, err := os.ReadFile(tt.file)
+			if err != nil {
+				t.Fatalf("read %s: %v", tt.file, err)
+			}
+			source := string(data)
+			if strings.Contains(source, "util.GetClientPublicIP(c.Request)") {
+				t.Fatalf("%s still uses spoofable util.GetClientPublicIP", tt.file)
+			}
+			if got := strings.Count(source, "wkhttp.ClientIP(c.Request)"); got != tt.wantCalls {
+				t.Fatalf("%s wkhttp.ClientIP calls = %d, want %d", tt.file, got, tt.wantCalls)
+			}
+		})
+	}
+}

--- a/modules/oidc/client_ip_source_test.go
+++ b/modules/oidc/client_ip_source_test.go
@@ -1,33 +1,98 @@
 package oidc
 
 import (
+	"go/ast"
+	"go/parser"
+	gotoken "go/token"
 	"os"
+	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 )
 
 func TestSecuritySensitivePathsUseWKHTTPClientIP(t *testing.T) {
-	tests := []struct {
-		file      string
-		wantCalls int
-	}{
-		{file: "api.go", wantCalls: 3},
-		{file: "api_bind.go", wantCalls: 1},
+	files, err := filepath.Glob("*.go")
+	if err != nil {
+		t.Fatalf("list OIDC Go files: %v", err)
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.file, func(t *testing.T) {
-			data, err := os.ReadFile(tt.file)
-			if err != nil {
-				t.Fatalf("read %s: %v", tt.file, err)
+	// Any exception must name the production file and explain why it is safe.
+	exemptions := map[string]string{}
+	safeCalls := 0
+	for _, file := range files {
+		if strings.HasSuffix(file, "_test.go") {
+			continue
+		}
+		if reason, exempt := exemptions[file]; exempt {
+			if strings.TrimSpace(reason) == "" {
+				t.Fatalf("%s has an empty client-IP source exemption", file)
 			}
-			source := string(data)
-			if strings.Contains(source, "util.GetClientPublicIP(c.Request)") {
-				t.Fatalf("%s still uses spoofable util.GetClientPublicIP", tt.file)
-			}
-			if got := strings.Count(source, "wkhttp.ClientIP(c.Request)"); got != tt.wantCalls {
-				t.Fatalf("%s wkhttp.ClientIP calls = %d, want %d", tt.file, got, tt.wantCalls)
-			}
-		})
+			continue
+		}
+		legacy, safe := oidcClientIPCallCounts(t, file)
+		if legacy > 0 {
+			t.Fatalf("%s contains %d util.GetClientPublicIP call(s); add a justified exemption or use wkhttp.ClientIP", file, legacy)
+		}
+		safeCalls += safe
 	}
+	if safeCalls != 4 {
+		t.Fatalf("OIDC production wkhttp.ClientIP calls = %d, want 4", safeCalls)
+	}
+}
+
+func oidcClientIPCallCounts(t *testing.T, file string) (legacy, safe int) {
+	t.Helper()
+	source, err := os.ReadFile(file)
+	if err != nil {
+		t.Fatalf("read %s: %v", file, err)
+	}
+	parsed, err := parser.ParseFile(gotoken.NewFileSet(), file, source, 0)
+	if err != nil {
+		t.Fatalf("parse %s: %v", file, err)
+	}
+
+	aliases := map[string]string{}
+	for _, spec := range parsed.Imports {
+		importPath, err := strconv.Unquote(spec.Path.Value)
+		if err != nil {
+			t.Fatalf("parse import in %s: %v", file, err)
+		}
+		if importPath != "github.com/Mininglamp-OSS/octo-lib/pkg/util" &&
+			importPath != "github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp" {
+			continue
+		}
+		alias := filepath.Base(importPath)
+		if spec.Name != nil {
+			alias = spec.Name.Name
+		}
+		aliases[alias] = importPath
+	}
+
+	ast.Inspect(parsed, func(node ast.Node) bool {
+		call, ok := node.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		selector, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+		ident, ok := selector.X.(*ast.Ident)
+		if !ok {
+			return true
+		}
+		switch aliases[ident.Name] {
+		case "github.com/Mininglamp-OSS/octo-lib/pkg/util":
+			if selector.Sel.Name == "GetClientPublicIP" {
+				legacy++
+			}
+		case "github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp":
+			if selector.Sel.Name == "ClientIP" {
+				safe++
+			}
+		}
+		return true
+	})
+	return legacy, safe
 }

--- a/modules/user/api.go
+++ b/modules/user/api.go
@@ -1643,7 +1643,7 @@ func (u *User) login(c *wkhttp.Context) {
 		respondUserError(c, errcode.ErrUserLoginLocked)
 		return
 	}
-	publicIP := util.GetClientPublicIP(c.Request)
+	publicIP := wkhttp.ClientIP(c.Request)
 	loginSpan := u.ctx.Tracer().StartSpan(
 		"login",
 		opentracing.ChildOf(c.GetSpanContext()),
@@ -1728,7 +1728,7 @@ func (u *User) execLoginAndRespose(userInfo *Model, flag config.DeviceFlag, devi
 
 	c.Response(result)
 
-	publicIP := util.GetClientPublicIP(c.Request)
+	publicIP := wkhttp.ClientIP(c.Request)
 	u.finishSuccessfulLogin(userInfo.UID, userInfo.Username, publicIP, loginType)
 }
 
@@ -2835,7 +2835,7 @@ func (u *User) loginWithAuthCode(c *wkhttp.Context) {
 	u.applyRealnameToAuthCodeMap(resp, userModel.UID)
 	redemptionAudit.MarkCompleted()
 	c.Response(resp)
-	u.finishSuccessfulLogin(userModel.UID, userModel.Username, util.GetClientPublicIP(c.Request), "scan_login")
+	u.finishSuccessfulLogin(userModel.UID, userModel.Username, wkhttp.ClientIP(c.Request), "scan_login")
 }
 
 // 获取二维码数据的管道
@@ -3569,7 +3569,7 @@ func (u *User) loginCheckPhone(c *wkhttp.Context) {
 	resp := newLoginUserDetailResp(userInfo, token, u.ctx)
 	u.applyRealnameToLoginResp(resp, userInfo.UID)
 	c.Response(resp)
-	u.finishSuccessfulLogin(userInfo.UID, userInfo.Username, util.GetClientPublicIP(c.Request), "phone_verify")
+	u.finishSuccessfulLogin(userInfo.UID, userInfo.Username, wkhttp.ClientIP(c.Request), "phone_verify")
 }
 
 // customerservices 客服列表
@@ -4062,7 +4062,7 @@ func (u *User) createUser(registerSpanCtx context.Context, createUser *createUse
 			fmt.Fprintf(os.Stderr, "recovered panic in goroutine: %v\n%s\n", err, debug.Stack())
 		}
 	}()
-	publicIP := util.GetClientPublicIP(c.Request)
+	publicIP := wkhttp.ClientIP(c.Request)
 	resp, err := u.createUserWithRespAndTx(registerSpanCtx, createUser, publicIP, invite, tx, func() error {
 		err := tx.Commit()
 		if err != nil {
@@ -4082,7 +4082,7 @@ func (u *User) createUser(registerSpanCtx context.Context, createUser *createUse
 }
 
 func (u *User) createUserTx(registerSpanCtx context.Context, createUser *createUserModel, c *wkhttp.Context, commitCallback func() error, invite *model.Invite, tx *dbr.Tx) {
-	publicIP := util.GetClientPublicIP(c.Request)
+	publicIP := wkhttp.ClientIP(c.Request)
 	resp, err := u.createUserWithRespAndTx(registerSpanCtx, createUser, publicIP, invite, tx, commitCallback)
 	if err != nil {
 		respondUserError(c, errcode.ErrUserRegisterFailed)

--- a/modules/user/api_emaillogin.go
+++ b/modules/user/api_emaillogin.go
@@ -195,7 +195,7 @@ func (u *User) emailRegister(c *wkhttp.Context) {
 		}
 	}()
 
-	publicIP := util.GetClientPublicIP(c.Request)
+	publicIP := wkhttp.ClientIP(c.Request)
 	registerSpan := u.ctx.Tracer().StartSpan(
 		"user.emailRegister",
 		opentracing.ChildOf(c.GetSpanContext()),
@@ -256,7 +256,7 @@ func (u *User) emailLogin(c *wkhttp.Context) {
 		respondUserRequestInvalid(c, "")
 		return
 	}
-	publicIP := util.GetClientPublicIP(c.Request)
+	publicIP := wkhttp.ClientIP(c.Request)
 	// 仅密码登录走 guard；验证码登录有独立的发送频控 + 验证次数限制，不纳入 guard 计数。
 	if req.Password != "" {
 		if err := u.loginGuard.Check(req.Email); err != nil {

--- a/modules/user/api_gitee.go
+++ b/modules/user/api_gitee.go
@@ -163,7 +163,7 @@ func (u *User) giteeOAuth(c *wkhttp.Context) {
 			return
 		}
 		// 发送登录消息
-		publicIP := util.GetClientPublicIP(c.Request)
+		publicIP := wkhttp.ClientIP(c.Request)
 		u.finishSuccessfulLogin(userInfoM.UID, userInfoM.Username, publicIP, "gitee")
 	} else {
 		if common.EnsureSystemSettings(u.ctx).RegisterOff() {
@@ -235,7 +235,7 @@ func (u *User) giteeOAuth(c *wkhttp.Context) {
 			return
 		}
 		// 发送登录消息
-		publicIP := util.GetClientPublicIP(c.Request)
+		publicIP := wkhttp.ClientIP(c.Request)
 		loginResp, err = u.createUserWithRespAndTx(loginSpanCtx, model, publicIP, nil, tx, func() error {
 			err := tx.Commit()
 			if err != nil {

--- a/modules/user/api_github.go
+++ b/modules/user/api_github.go
@@ -99,7 +99,7 @@ func (u *User) githubOAuth(c *wkhttp.Context) {
 			return
 		}
 		// 发送登录消息
-		publicIP := util.GetClientPublicIP(c.Request)
+		publicIP := wkhttp.ClientIP(c.Request)
 		u.finishSuccessfulLogin(userInfoM.UID, userInfoM.Username, publicIP, "github")
 	} else {
 		if common.EnsureSystemSettings(u.ctx).RegisterOff() {
@@ -170,7 +170,7 @@ func (u *User) githubOAuth(c *wkhttp.Context) {
 			return
 		}
 		// 发送登录消息
-		publicIP := util.GetClientPublicIP(c.Request)
+		publicIP := wkhttp.ClientIP(c.Request)
 		loginResp, err = u.createUserWithRespAndTx(loginSpanCtx, model, publicIP, nil, tx, func() error {
 			err := tx.Commit()
 			if err != nil {

--- a/modules/user/api_login_ip_source_test.go
+++ b/modules/user/api_login_ip_source_test.go
@@ -1,0 +1,37 @@
+package user
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestLoginAuditUsesWKHTTPClientIP(t *testing.T) {
+	tests := []struct {
+		file      string
+		wantCalls int
+	}{
+		{file: "api.go", wantCalls: 6},
+		{file: "api_emaillogin.go", wantCalls: 2},
+		{file: "api_gitee.go", wantCalls: 2},
+		{file: "api_github.go", wantCalls: 2},
+		{file: "api_manager.go", wantCalls: 1},
+		{file: "api_usernamelogin.go", wantCalls: 2},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.file, func(t *testing.T) {
+			data, err := os.ReadFile(tt.file)
+			if err != nil {
+				t.Fatalf("read %s: %v", tt.file, err)
+			}
+			source := string(data)
+			if strings.Contains(source, "util.GetClientPublicIP(c.Request)") {
+				t.Fatalf("%s still uses spoofable util.GetClientPublicIP", tt.file)
+			}
+			if got := strings.Count(source, "wkhttp.ClientIP(c.Request)"); got != tt.wantCalls {
+				t.Fatalf("%s wkhttp.ClientIP calls = %d, want %d", tt.file, got, tt.wantCalls)
+			}
+		})
+	}
+}

--- a/modules/user/api_login_ip_source_test.go
+++ b/modules/user/api_login_ip_source_test.go
@@ -1,37 +1,98 @@
 package user
 
 import (
+	"go/ast"
+	"go/parser"
+	gotoken "go/token"
 	"os"
+	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 )
 
 func TestLoginAuditUsesWKHTTPClientIP(t *testing.T) {
-	tests := []struct {
-		file      string
-		wantCalls int
-	}{
-		{file: "api.go", wantCalls: 6},
-		{file: "api_emaillogin.go", wantCalls: 2},
-		{file: "api_gitee.go", wantCalls: 2},
-		{file: "api_github.go", wantCalls: 2},
-		{file: "api_manager.go", wantCalls: 1},
-		{file: "api_usernamelogin.go", wantCalls: 2},
+	files, err := filepath.Glob("*.go")
+	if err != nil {
+		t.Fatalf("list user Go files: %v", err)
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.file, func(t *testing.T) {
-			data, err := os.ReadFile(tt.file)
-			if err != nil {
-				t.Fatalf("read %s: %v", tt.file, err)
+	// Any exception must name the production file and explain why it is safe.
+	exemptions := map[string]string{}
+	safeCalls := 0
+	for _, file := range files {
+		if strings.HasSuffix(file, "_test.go") {
+			continue
+		}
+		if reason, exempt := exemptions[file]; exempt {
+			if strings.TrimSpace(reason) == "" {
+				t.Fatalf("%s has an empty client-IP source exemption", file)
 			}
-			source := string(data)
-			if strings.Contains(source, "util.GetClientPublicIP(c.Request)") {
-				t.Fatalf("%s still uses spoofable util.GetClientPublicIP", tt.file)
-			}
-			if got := strings.Count(source, "wkhttp.ClientIP(c.Request)"); got != tt.wantCalls {
-				t.Fatalf("%s wkhttp.ClientIP calls = %d, want %d", tt.file, got, tt.wantCalls)
-			}
-		})
+			continue
+		}
+		legacy, safe := clientIPCallCounts(t, file)
+		if legacy > 0 {
+			t.Fatalf("%s contains %d util.GetClientPublicIP call(s); add a justified exemption or use wkhttp.ClientIP", file, legacy)
+		}
+		safeCalls += safe
 	}
+	if safeCalls != 15 {
+		t.Fatalf("user production wkhttp.ClientIP calls = %d, want 15", safeCalls)
+	}
+}
+
+func clientIPCallCounts(t *testing.T, file string) (legacy, safe int) {
+	t.Helper()
+	source, err := os.ReadFile(file)
+	if err != nil {
+		t.Fatalf("read %s: %v", file, err)
+	}
+	parsed, err := parser.ParseFile(gotoken.NewFileSet(), file, source, 0)
+	if err != nil {
+		t.Fatalf("parse %s: %v", file, err)
+	}
+
+	aliases := map[string]string{}
+	for _, spec := range parsed.Imports {
+		importPath, err := strconv.Unquote(spec.Path.Value)
+		if err != nil {
+			t.Fatalf("parse import in %s: %v", file, err)
+		}
+		if importPath != "github.com/Mininglamp-OSS/octo-lib/pkg/util" &&
+			importPath != "github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp" {
+			continue
+		}
+		alias := filepath.Base(importPath)
+		if spec.Name != nil {
+			alias = spec.Name.Name
+		}
+		aliases[alias] = importPath
+	}
+
+	ast.Inspect(parsed, func(node ast.Node) bool {
+		call, ok := node.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		selector, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+		ident, ok := selector.X.(*ast.Ident)
+		if !ok {
+			return true
+		}
+		switch aliases[ident.Name] {
+		case "github.com/Mininglamp-OSS/octo-lib/pkg/util":
+			if selector.Sel.Name == "GetClientPublicIP" {
+				legacy++
+			}
+		case "github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp":
+			if selector.Sel.Name == "ClientIP" {
+				safe++
+			}
+		}
+		return true
+	})
+	return legacy, safe
 }

--- a/modules/user/api_login_log.go
+++ b/modules/user/api_login_log.go
@@ -27,10 +27,10 @@ func NewLoginLog(ctx *config.Context) *LoginLog {
 // 信息"，审计侧也需要可 SQL 检索的登录历史。
 const loginEventLogMsg = "login_event"
 
-// normalizeLoginIP 把代理头中的候选值收窄为规范 IP 文本。
-// GetClientPublicIP 为兼容现有反向代理会优先返回 X-Forwarded-For，该值在
-// 代理信任边界配错时可由客户端控制。审计入库边界必须再校验：非 IP 存空串，
-// 而不是让超长值撑爆 login_log.login_ip VARCHAR(40) 并丢失整条记录。
+// normalizeLoginIP 把代理层选出的候选值收窄为规范 IP 文本。
+// 代理信任边界由 wkhttp.ClientIP 与部署配置负责；这里保留入库前的纵深校验：
+// 非 IP 存空串，而不是让异常或超长值撑爆 login_log.login_ip VARCHAR(40)
+// 并丢失整条记录。
 func normalizeLoginIP(value string) string {
 	ip := net.ParseIP(strings.TrimSpace(value))
 	if ip == nil {

--- a/modules/user/api_manager.go
+++ b/modules/user/api_manager.go
@@ -311,7 +311,7 @@ func (m *Manager) login(c *wkhttp.Context) {
 		respondUserError(c, errcode.ErrUserQueryFailed)
 		return
 	}
-	publicIP := util.GetClientPublicIP(c.Request)
+	publicIP := wkhttp.ClientIP(c.Request)
 	// 登录失败统一返回 ErrUserInvalidCredentials，避免攻击者通过"用户不存在"
 	// 与"密码错误"的响应差异枚举有效管理账号（与 /v1/user login 反枚举一致）。
 	if userInfo == nil || userInfo.UID == "" {

--- a/modules/user/api_usernamelogin.go
+++ b/modules/user/api_usernamelogin.go
@@ -96,7 +96,7 @@ func (u *User) usernameLogin(c *wkhttp.Context) {
 		respondUserError(c, errcode.ErrUserLoginLocked)
 		return
 	}
-	publicIP := util.GetClientPublicIP(c.Request)
+	publicIP := wkhttp.ClientIP(c.Request)
 	loginSpan := u.ctx.Tracer().StartSpan(
 		"login",
 		opentracing.ChildOf(c.GetSpanContext()),
@@ -209,7 +209,7 @@ func (u *User) registerWithUsername(username string, name string, password strin
 			fmt.Fprintf(os.Stderr, "recovered panic in goroutine: %v\n%s\n", err, debug.Stack())
 		}
 	}()
-	publicIP := util.GetClientPublicIP(c.Request)
+	publicIP := wkhttp.ClientIP(c.Request)
 	result, err := u.createUserWithRespAndTx(registerSpanCtx, model, publicIP, nil, tx, func() error {
 		err := tx.Commit()
 		if err != nil {

--- a/modules/user/db_login_log_test.go
+++ b/modules/user/db_login_log_test.go
@@ -1,10 +1,13 @@
 package user
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 	"unicode/utf8"
 
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
 	"github.com/Mininglamp-OSS/octo-lib/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -22,12 +25,16 @@ func TestLoginLog_RecordSuccessAndFailure_Integration(t *testing.T) {
 
 	l := NewLoginLog(ctx)
 	logDB := NewLoginLogDB(ctx.DB())
+	successReq := httptest.NewRequest(http.MethodPost, "/v1/user/login", nil)
+	successReq.Header.Set("X-Forwarded-For", "203.0.113.10, 198.51.100.24")
+	failureReq := httptest.NewRequest(http.MethodPost, "/v1/user/login", nil)
+	failureReq.Header.Set("X-Forwarded-For", "203.0.113.11, 198.51.100.25")
 
 	// 手机号注册用户的 username 就是 zone+phone，正是不能落明文的那种输入
 	const phoneAccount = "008613800001234"
-	l.recordSuccess("u-1", phoneAccount, "1.2.3.4", "username")
-	l.recordFailure("bob@example.com", "5.6.7.8", "email")
-	l.recordFailure("bob@example.com", "5.6.7.8", "email")
+	l.recordSuccess("u-1", phoneAccount, wkhttp.ClientIP(successReq), "username")
+	l.recordFailure("bob@example.com", wkhttp.ClientIP(failureReq), "email")
+	l.recordFailure("bob@example.com", wkhttp.ClientIP(failureReq), "email")
 	l.recordFailure("x@13800001234", strings.Repeat("9", 41), "username")
 
 	var rows []*LoginLogModel
@@ -38,11 +45,14 @@ func TestLoginLog_RecordSuccessAndFailure_Integration(t *testing.T) {
 	assert.Equal(t, "u-1", rows[0].UID)
 	assert.Equal(t, loginStatusSuccess, rows[0].Status)
 	assert.Equal(t, "username", rows[0].LoginType)
+	assert.Equal(t, "198.51.100.24", rows[0].LoginIP, "success audit must ignore forged leftmost XFF")
 
 	assert.Equal(t, "", rows[1].UID, "failed attempts must not carry a uid")
 	assert.Equal(t, loginStatusFailure, rows[1].Status)
 	assert.Equal(t, loginStatusFailure, rows[2].Status)
 	assert.Equal(t, loginStatusFailure, rows[3].Status)
+	assert.Equal(t, "198.51.100.25", rows[1].LoginIP, "failure audit must ignore forged leftmost XFF")
+	assert.Equal(t, "198.51.100.25", rows[2].LoginIP, "repeated failure must retain the trusted source")
 	assert.Empty(t, rows[3].LoginIP, "invalid attacker-controlled XFF must not drop the audit row")
 
 	// 关键契约：整张表不得出现账号明文
@@ -71,7 +81,7 @@ func TestLoginLog_RecordSuccessAndFailure_Integration(t *testing.T) {
 	last, err := logDB.queryLastLoginIP("u-1")
 	require.NoError(t, err)
 	require.NotNil(t, last)
-	assert.Equal(t, "1.2.3.4", last.LoginIP)
+	assert.Equal(t, "198.51.100.24", last.LoginIP)
 }
 
 func TestMaskLoginAccount(t *testing.T) {

--- a/modules/user/token_http_ttl_test.go
+++ b/modules/user/token_http_ttl_test.go
@@ -35,6 +35,30 @@ func TestTokenDeadlineOverHTTP(t *testing.T) {
 	})
 }
 
+func TestLoginFailureAuditUsesProxyAwareIPOverHTTP(t *testing.T) {
+	server, ctx, _, _ := newTokenHTTPTestServer(t)
+	username := "missing-login-" + util.GenerUUID()
+
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodPost, "/v1/user/login", bytes.NewReader([]byte(util.ToJson(map[string]interface{}{
+		"username": username,
+		"password": "wrong-password",
+		"flag":     int(config.Web),
+	}))))
+	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("X-Forwarded-For", "203.0.113.10, 198.51.100.24")
+	server.GetRoute().ServeHTTP(recorder, request)
+	require.Equal(t, http.StatusBadRequest, recorder.Code, "body=%s", recorder.Body.String())
+
+	var rows []*LoginLogModel
+	_, err := ctx.DB().Select("*").From("login_log").
+		Where("login_type=?", "username").OrderAsc("id").Load(&rows)
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	require.Equal(t, loginStatusFailure, rows[0].Status)
+	require.Equal(t, "198.51.100.24", rows[0].LoginIP)
+}
+
 func TestLocalCredentialCannotCrossPasswordChangeBeforeIssueFence(t *testing.T) {
 	t.Setenv("OCTO_AUTH_SESSION_MODE", string(auth.SessionModeV3Write))
 	t.Setenv("OCTO_AUTH_SESSION_MAX_PER_UID", "10")


### PR DESCRIPTION
## Summary

Harden security-sensitive login and OIDC audit IP attribution so a client-supplied leftmost `X-Forwarded-For` value cannot poison audit rows or split the OIDC callback failure counter.

This was opened as a stacked draft on [Mininglamp-OSS/octo-lib#119](https://github.com/Mininglamp-OSS/octo-lib/pull/119). The upstream PR is squash-merged as `233dd6fcdda60ccf347811d1e7a069f1e9703bf8`, and this branch pins that final merge revision.

## Related Issue

No octo-server issue was created for the reported security finding. Upstream dependency: [Mininglamp-OSS/octo-lib#119](https://github.com/Mininglamp-OSS/octo-lib/pull/119).

## Linked Spec

[`.octospec/tasks/login-audit-ip-spoofing/brief.md`](.octospec/tasks/login-audit-ip-spoofing/brief.md)

## Changes

- Replace all 15 user-module and four OIDC security-sensitive `util.GetClientPublicIP` sources with the shared validated `wkhttp.ClientIP` selector.
- Keep `normalizeLoginIP` as defense-in-depth at the audit database boundary and preserve routes, responses, schemas, quotas, and welcome-message ordering.
- Map malformed/ambiguous selector output to the OIDC callback guard's stable unknown-IP bucket; it no longer bypasses failure accounting.
- Add AST-backed package-wide source guards (including aliased imports), a routed `/v1/user/login` audit assertion, and malformed-final-XFF callback coverage.
- Record trust assumptions, dependency rollout, review evidence, and follow-ups in OctoSpec.

## Testing

- [x] Unit/integration tests added or updated
- [ ] Manually verified in production (CLB and direct-access deployment gates remain open)

Passed locally against octo-lib merge commit `233dd6f`:

- TDD RED `662383a5`: malformed final XFF bypassed callback failures; the fourth request incorrectly returned 400.
- TDD GREEN `0cc82cf9`: the same fourth request returns 429 from the existing callback guard.
- Focused user router/source-guard and OIDC guard/router/source-guard tests, including `-race`.
- Complete `go test ./modules/oidc/... -count=1` in independent schema `octo_login_audit_oidc_lusaka_20260811`.
- `GOWORK=off go vet ./...`, `GOWORK=off golangci-lint run ./...` (0 issues), `GOWORK=off go mod verify`, and `git diff --check`.

The complete OIDC run against the shared default `test` database is not claimed green: setup is blocked by pre-existing stale migration state (`unknown migration ... 20191106000001_event_legacy01.sql`). The complete user-package run likewise remains a clean-CI gate because its isolated schema is missing legacy `user.app_id`.

## COMPREHENSION

1. **What does this change actually do to the load-bearing path?**

   Login, account-creation, logout, OIDC state/session propagation, bind audit, and the OIDC callback failure guard now derive their IP from the same validated proxy-aware selector as shared rate limiting. Invalid or ambiguous header output enters a stable unknown callback bucket rather than silently disabling the guard. Audit storage still independently validates the selected IP.

2. **What could break because of it (dependents + failure mode)?**

   If production CLB output does not match the documented bare-IP/rightmost-entry contract, valid traffic could collapse into the unknown bucket or be attributed to a proxy address, producing broad 429s or empty/wrong audit IPs. Direct service access would also bypass the trust model.

3. **How do you know it works (specific test/repro/trace)?**

   The review reproducer sends an invalid final XFF through the real OIDC callback route: it was RED after three failures and becomes 429 on the fourth request after the fix. The user handler is exercised through `ServeHTTP` and the resulting `login_log.login_ip` is the rightmost XFF value. Package-wide AST guards preserve the complete 15/4 inventory; focused race tests, the isolated full OIDC package, vet, lint, module verification, and diff checks pass.

## Merge and rollout gates

- [x] Squash-merge octo-lib #119.
- [x] Pin final pseudo-version `v0.0.0-20260811160929-233dd6fcdda6` and rerun focused tests.
- [x] Close the two review blockers on the previous head (`4ba3ab4`).
- [ ] Obtain a clean full user/repository CI result and latest-head review approval.
- [ ] Verify CLB XFF/X-Real-IP behavior and block public direct access before rollout.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] PR description is in English
- [x] Added tests for my changes
- [x] Updated documentation
- [x] Followed commit message conventions (Conventional Commits)
