### PR TITLE
fix: harden BotFather Space binding

### DIFF
--- a/.octospec/journal/shared/botfather-space-binding-hardening.md
+++ b/.octospec/journal/shared/botfather-space-binding-hardening.md
@@ -1,0 +1,65 @@
+---
+type: Journal
+title: "Journal: botfather-space-binding-hardening"
+description: Record of making BotFather conversational Bot creation validate and commit Space binding from server-authoritative membership state.
+tags: ["botfather", "space", "isolation", "auth", "data-integrity", "testing"]
+timestamp: 2026-08-11T16:56:17Z
+# --- octospec extension fields ---
+task: botfather-space-binding-hardening
+upstream: none
+source: user
+---
+
+# Journal: botfather-space-binding-hardening
+
+## What was done
+
+- Treat the WuKongIM payload or legacy channel Space ID only as a selector.
+  Before creating durable Bot artifacts, require an active creator, active
+  Space, and active creator membership from the database.
+- When no selector is present, derive a target only when exactly one active
+  creator Space exists. Zero or multiple candidates fail closed.
+- Recheck the creator, Space, and membership under row locks and insert the Bot
+  membership in the same transaction. The insert must affect exactly one row;
+  no best-effort `INSERT IGNORE` remains in this path.
+- On core-creation or binding failure, compensate newly created App, robot,
+  user, friendship, and membership artifacts. If hard deletion cannot complete,
+  disable the Bot and blank credential-bearing fields as a fail-closed fallback.
+- Keep the existing generic localized creation-failure reply. New security logs
+  contain only bounded reason values and no identifiers, payloads, or tokens.
+
+## Verification
+
+- `go test ./modules/botfather/... -count=1 -coverprofile=...`: PASS with a
+  synthetic test-only master key. The BotFather package reports 40.4% statement
+  coverage (legacy package-wide baseline); the changed authorization/binding
+  functions report 88.6% (`createBot`), 100.0%
+  (`resolveAuthorizedCreationSpace`), 80.6% (`bindCreatedBotToSpace`), and 96.2%
+  (`deleteCreatedBotArtifacts`).
+- The regression suite includes real MySQL persistence tests for forged,
+  missing, inactive, removed, ambiguous, authorized, concurrent-change, query
+  failure, insert failure, compensation, and core-creation failure paths.
+- The end-to-end test drives the actual BotFather message state machine for a
+  rejected forged selector and an authorized creation, then verifies `/mybots`
+  Space isolation from persisted rows.
+- Focused `go test -race`, `go vet ./modules/botfather/...`,
+  `golangci-lint run ./modules/botfather/...`, `make i18n-extract-check`, and
+  `make i18n-lint`: PASS.
+- Local MySQL, Redis, and WuKongIM checks passed. Cleanup verification found no
+  residual test trigger, synthetic Bot/user rows, or BotFather state keys.
+- Diff scan found no incident identifiers, production domains, message bodies,
+  or credentials. Standalone `octospec-lint` is not installed; the task YAML
+  parses and the brief/context/diff were checked manually against injected
+  rules.
+
+## Structural learning and rollout
+
+- A tenant selector is not authorization evidence. The decisive check must be
+  repeated at the write linearization point, not only before a multi-step
+  provisioning flow.
+- A success reply is not persistence evidence; tests assert the committed
+  membership row and its isolation from another Space.
+- Any mixed-version deployment remains vulnerable while an old replica can
+  process `/newbot`. Drain old replicas or temporarily disable conversational
+  creation during rollout. Rollback must likewise block this flow until a
+  corrected build is active.

--- a/.octospec/journal/shared/botfather-space-binding-hardening.md
+++ b/.octospec/journal/shared/botfather-space-binding-hardening.md
@@ -28,13 +28,27 @@ source: user
 - Keep the existing generic localized creation-failure reply. New security logs
   contain only bounded reason values and no identifiers, payloads, or tokens.
 
+## Review hardening
+
+- Scoped friendship compensation to the two creator/Bot directions instead of
+  scanning every row that mentions the newly-created Bot. The predicate uses
+  the existing paired friendship index; a local `EXPLAIN` confirmed indexed
+  range access rather than a full-table scan.
+- Made the final binding transaction use the normal deferred rollback guard,
+  documented its `user -> space -> space_member` lock order, and keep
+  membership timestamps database-authoritative with `NOW()`.
+- Added focused SQL-mock coverage for a zero-row membership insert and for a
+  failed transaction begin. Both outcomes return failure and do not reach a
+  success commit.
+
 ## Verification
 
 - `go test ./modules/botfather/... -count=1 -coverprofile=...`: PASS with a
-  synthetic test-only master key. The BotFather package reports 40.4% statement
+  synthetic test-only master key and branch-isolated MySQL/Redis. The BotFather
+  package reports 40.4% statement
   coverage (legacy package-wide baseline); the changed authorization/binding
   functions report 88.6% (`createBot`), 100.0%
-  (`resolveAuthorizedCreationSpace`), 80.6% (`bindCreatedBotToSpace`), and 96.2%
+  (`resolveAuthorizedCreationSpace`), 84.8% (`bindCreatedBotToSpace`), and 96.2%
   (`deleteCreatedBotArtifacts`).
 - The regression suite includes real MySQL persistence tests for forged,
   missing, inactive, removed, ambiguous, authorized, concurrent-change, query
@@ -42,11 +56,16 @@ source: user
 - The end-to-end test drives the actual BotFather message state machine for a
   rejected forged selector and an authorized creation, then verifies `/mybots`
   Space isolation from persisted rows.
-- Focused `go test -race`, `go vet ./modules/botfather/...`,
-  `golangci-lint run ./modules/botfather/...`, `make i18n-extract-check`, and
-  `make i18n-lint`: PASS.
-- Local MySQL, Redis, and WuKongIM checks passed. Cleanup verification found no
-  residual test trigger, synthetic Bot/user rows, or BotFather state keys.
+- Focused real-message-flow E2E re-ran in the branch-isolated MySQL/Redis and
+  WuKongIM environment: a forged selector was rejected; an authorized
+  selector created exactly one persisted membership and remained isolated in
+  `/mybots`. The relevant `go test -race` target, `go build`, `go vet
+  ./modules/botfather/...`, `golangci-lint run ./modules/botfather/...`,
+  `make i18n-extract-check`, and `make i18n-lint`: PASS.
+- Local MySQL, Redis, and WuKongIM checks passed. The branch-isolated schema
+  had no residual synthetic rows or triggers after validation; that schema and
+  its dedicated Redis container were then removed without touching shared test
+  infrastructure.
 - Diff scan found no incident identifiers, production domains, message bodies,
   or credentials. Standalone `octospec-lint` is not installed; the task YAML
   parses and the brief/context/diff were checked manually against injected

--- a/.octospec/log.md
+++ b/.octospec/log.md
@@ -4,6 +4,19 @@ Change history for this repo's `.octospec/`, following the
 [OKF](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md)
 change-log convention (§7). Newest first.
 
+## 2026-08-12 (botfather-space-binding-hardening)
+
+- **Task** — `botfather-space-binding-hardening`: made the server authoritative
+  for conversational Bot-to-Space binding. Payload/channel Space IDs are now
+  selectors only; active creator, Space, and membership are checked fail-closed
+  before creation and again under row locks in the membership transaction.
+  Missing selectors require exactly one active creator Space. Binding or core
+  persistence failures compensate created artifacts and revoke credentials,
+  while external failures remain generic and logs remain identifier-free.
+  MySQL-backed regression, end-to-end Space-isolation, race, coverage, vet,
+  lint, i18n, cleanup, and redaction checks passed. See
+  [journal](journal/shared/botfather-space-binding-hardening.md).
+
 ## 2026-08-10 (token-lifecycle-hardening PR 2)
 
 - **Task** — `token-lifecycle-hardening-pr2`: added an inert-by-default,

--- a/.octospec/log.md
+++ b/.octospec/log.md
@@ -13,6 +13,9 @@ change-log convention (§7). Newest first.
   Missing selectors require exactly one active creator Space. Binding or core
   persistence failures compensate created artifacts and revoke credentials,
   while external failures remain generic and logs remain identifier-free.
+  Review hardening scopes friendship compensation to the newly-created
+  creator/Bot pair (indexed range access, not a full-table scan), documents the
+  binding lock order, and covers zero-row insert and begin-failure paths.
   MySQL-backed regression, end-to-end Space-isolation, race, coverage, vet,
   lint, i18n, cleanup, and redaction checks passed. See
   [journal](journal/shared/botfather-space-binding-hardening.md).

--- a/.octospec/tasks/botfather-space-binding-hardening/brief.md
+++ b/.octospec/tasks/botfather-space-binding-hardening/brief.md
@@ -1,0 +1,174 @@
+---
+type: Task
+title: "Task: botfather-space-binding-hardening"
+description: Make the server authoritative for BotFather Bot-to-Space binding and reject untrusted cross-Space selectors before Bot creation.
+tags: [space, isolation, auth, acl, bot-api, trust-boundary, wire-contract, i18n, testing, commit, security, data-integrity]
+timestamp: 2026-08-12T00:23:48+08:00
+# --- octospec extension fields ---
+slug: botfather-space-binding-hardening
+upstream: none (P0 production incident hardening; incident identifiers are intentionally omitted)
+source: user
+---
+
+# Task: botfather-space-binding-hardening
+
+> One task = one `.octospec/tasks/<slug>/` directory. This brief is the spec for
+> the work. Production identifiers, credentials, domains, and message bodies are
+> deliberately excluded; tests and examples must use synthetic values only.
+
+## Goal
+
+Make octo-server the sole policy authority for the Space assigned to a Bot
+created through the conversational BotFather `/newbot` flow.
+
+The `space_id` received from a WuKongIM message payload, or derived from a
+legacy channel prefix, is an untrusted selector. Before creating any durable
+Bot artifact, the server must prove that:
+
+1. the creator account is active;
+2. the selected Space is active; and
+3. the creator is an active member of that Space.
+
+An explicit selector that fails any check, or a database error while checking,
+must fail closed. A missing selector may use a server-derived fallback only
+when the creator belongs to exactly one active Space; zero or multiple active
+Spaces are ambiguous and must fail closed. The implementation must not choose
+an arbitrary "first Space".
+
+The authorization decision and Bot membership write must remain valid under a
+concurrent membership or Space-status change. A rejected or failed binding must
+not return a success message, expose whether a foreign Space exists, or leave a
+usable active Bot without an active Space binding.
+
+## Background
+
+- `modules/botfather/api.go::messagesListen` reads `space_id` directly from the
+  inbound IM payload and installs it as message-processing context.
+- `modules/botfather/command.go::createBot` currently creates the App, `robot`,
+  and `user` first, then uses `resolveSpaceID(fromUID)` directly in an
+  `INSERT IGNORE INTO space_member` statement.
+- The command path does not verify creator membership or Space/account status.
+  A client-controlled selector can therefore create a cross-Space membership
+  row. The insertion is also best-effort: an empty selector or insert failure
+  can still produce an active orphan Bot and a success reply.
+- `/mybots` and Space Bot listings correctly filter by `space_member`; after a
+  wrong binding, the Bot disappears from the creator's intended Space and is
+  visible to members of the incorrectly selected Space.
+- Other provisioning code already demonstrates stronger server-side
+  membership checks, but this task must not copy their best-effort partial
+  creation behavior. The conversational path must fail closed before reporting
+  success.
+- The repo `space-isolation` rule classifies a missing or fail-open cross-Space
+  boundary as P0.
+
+## Security and consistency contract
+
+- Payload `space_id` and channel-prefix Space IDs are never authorization
+  evidence; they only select the Space against which the server checks current
+  database state.
+- The canonical authorization query includes active `user`, active `space`,
+  and active `space_member` rows.
+- Authorization query errors are denials, not legacy fallbacks.
+- The final authorization check and `space_member` write must be atomic or use
+  equivalent locking/conditional-write semantics so a stale preflight check
+  cannot authorize the commit.
+- `INSERT IGNORE` must not hide a zero-row or conflicting membership outcome.
+  Success requires a verified active Bot membership in the selected Space.
+- Any post-validation persistence failure must return an error and compensate
+  newly created App/robot/user artifacts sufficiently that no active usable Bot
+  or exposed Bot token remains.
+- User-visible rejection continues through the existing localized generic
+  BotFather creation-failure message. It must not echo a submitted Space ID or
+  distinguish nonexistent, inactive, and unauthorized foreign Spaces.
+- New security logs use low-cardinality reason values and must not contain Bot
+  tokens, raw message payloads, production UIDs, production Space IDs, or
+  production domains.
+
+## Load-bearing list
+
+- **space**, **isolation**, **auth**, **acl**, **bot-api** — this change repairs
+  a cross-tenant write boundary. Membership and parent Space/account status are
+  required at the moment the Bot binding is committed. (rule:
+  `space-isolation`)
+- **trust-boundary**, **wire-contract** — WuKongIM message payload fields are
+  attacker-controlled input. Existing clients may keep sending `space_id`, but
+  it becomes a selector rather than policy authority. No payload shape changes.
+  (rule: `trust-boundary`)
+- **i18n**, **error-response** — the IM command flow keeps the existing
+  localized generic failure response; no raw database or authorization error is
+  sent to the user. (rule: `error-handling`)
+- **data-integrity** — App, `robot`, `user`, and `space_member` persistence spans
+  more than one existing service operation. Failure and compensation semantics
+  must prevent a new active orphan or cross-Space Bot.
+- **multi-instance**, **concurrency** — authorization correctness must not
+  depend on process-local state or a race-prone check-then-write window.
+- **testing** — the P0 boundary requires behavior-level negative tests for
+  forged, missing, inactive, removed, ambiguous, and query-failure cases, plus
+  the authorized happy path. Test fixtures are synthetic and isolated. (rule:
+  `testing`)
+- **secret-handling**, **redaction** — Bot tokens and incident identifiers must
+  not enter tests, fixtures, logs, the brief, journal, commits, or PR text.
+- **commit** — implementation follows English Conventional Commits and records
+  RED/GREEN evidence without sensitive data. (rule: `commit-style`)
+
+## Out of scope
+
+- Fixing octo-web `currentSpaceId` caching, account namespacing, `SpaceGate`, or
+  other client-side Space selection behavior.
+- Repairing existing production Bot/Space rows, bulk classifying orphan or
+  multi-Space Bots, migrating Bot ownership, or changing WuKongIM whitelists.
+- Changing `POST /v1/user/bots`, OBO minting, App Bot provisioning, Bot deletion,
+  or other Bot creation/removal paths except where a narrowly shared helper is
+  required for this command-path fix.
+- Fixing duplicate welcome-message delivery.
+- Replacing the existing per-UID `sync.Map` message context. Same-UID concurrent
+  context isolation is a separate correctness task; this task's server-side
+  membership authorization must remain safe even if the selector is wrong.
+- Adding database migrations, feature flags, new HTTP endpoints, or a Bot
+  migration API.
+- Returning detailed Space authorization failures to clients.
+
+## Acceptance
+
+- An explicit synthetic Space selector succeeds only when the synthetic creator
+  account, Space, and membership are all active.
+- A selector for a Space where the creator has no active membership is rejected
+  before any App, robot, user, friend, or Bot `space_member` artifact is created.
+- Nonexistent Space, inactive Space, inactive creator, removed membership, and
+  membership-query failure all fail closed with the same external behavior.
+- A missing selector succeeds only for exactly one active creator Space. It is
+  rejected for zero active Spaces and for two or more active Spaces; no query
+  ordering is used to guess intent.
+- A concurrent creator-membership removal or Space disable cannot produce a
+  successful Bot binding based solely on a stale preflight result.
+- A Bot membership insert/commit failure does not produce the creation-success
+  reply and leaves no newly created active usable Bot or exposed Bot token.
+- The authorized happy path creates exactly one active Bot membership in the
+  authorized Space and preserves the existing BotFather success-message shape.
+- `/mybots` continues to return the new Bot in its authorized Space and not in a
+  different synthetic Space.
+- Tests exercise the actual `createBot` persistence boundary, not only a copied
+  predicate. Critical authorization-decision branches reach 100% coverage; new
+  code meets at least 80% line and branch coverage.
+- Focused tests pass, including the new regression target and existing
+  BotFather tests. Run the relevant race target where the environment permits.
+- `gofmt`, `go vet` for the touched package, `make i18n-extract-check`,
+  `make i18n-lint`, and octospec lint/check pass, or an infrastructure-only
+  blocker is recorded with its exact command and sanitized error.
+- A repository scan of the new diff finds no production UID, Space ID, Bot ID,
+  Bot token, domain, or unredacted message body from the incident evidence.
+
+## Rollout and rollback
+
+- Ship the server fix before relying on any client correction. Client fixes are
+  defense in depth and cannot authorize a weaker server path.
+- A rolling deployment remains vulnerable while any old replica can process
+  BotFather messages. Prefer blue/green or drain all old replicas before
+  declaring the P0 closed; otherwise temporarily disable conversational Bot
+  creation during the mixed-version window.
+- Observe only low-cardinality accepted/rejected/failure outcomes. Do not add
+  UID, Space ID, Bot ID, payload, or token labels.
+- Rolling back to the current behavior reopens the cross-Space write. Prefer a
+  forward fix; if emergency rollback is unavoidable, disable or block the
+  conversational `/newbot` processing path until a corrected build is active.
+- No schema rollback is required.

--- a/.octospec/tasks/botfather-space-binding-hardening/context.yaml
+++ b/.octospec/tasks/botfather-space-binding-hardening/context.yaml
@@ -1,0 +1,50 @@
+schema_version: 1
+task: botfather-space-binding-hardening
+brief: .octospec/tasks/botfather-space-binding-hardening/brief.md
+resolved_at: 2026-08-12T00:40:00+08:00
+
+injected_rules:
+  - id: space-isolation
+    source: repo
+    load_bearing: true
+    why: >
+      BotFather creation writes a Bot membership into space_member. The inbound
+      Space ID is only an untrusted selector; active creator, Space, and creator
+      membership must be checked fail-closed again at the binding commit.
+  - id: trust-boundary
+    source: repo
+    load_bearing: true
+    why: >
+      space_id originates in a WuKongIM payload or legacy channel prefix and
+      cannot authorize a cross-Space write. Missing selectors may be derived
+      only from exactly one server-verified active creator Space.
+  - id: error-handling
+    source: repo
+    load_bearing: true
+    why: >
+      Rejections retain the existing localized generic BotFather creation
+      failure and must not reveal whether a submitted Space exists or why the
+      authorization check failed.
+  - id: rate-limit
+    source: repo
+    load_bearing: false
+    why: >
+      No HTTP route or request-frequency policy changes. The existing message
+      ingestion limits remain unchanged and no custom Redis limiter is added.
+  - id: testing
+    source: repo
+    load_bearing: true
+    why: >
+      The P0 regression tests exercise the real createBot persistence boundary
+      with synthetic users and Spaces, including negative authorization,
+      ambiguous fallback, compensation, and authorized creation paths.
+  - id: commit-style
+    source: repo
+    load_bearing: false
+    why: >
+      Implement records sanitized RED and GREEN evidence but creates no commit;
+      a later Finish phase will use an English Conventional Commit subject.
+
+security_notes:
+  - Production identifiers, domains, Bot tokens, and message bodies are excluded.
+  - Logs and tests use bounded reason values or synthetic identifiers only.

--- a/modules/botfather/command.go
+++ b/modules/botfather/command.go
@@ -3,6 +3,7 @@ package botfather
 import (
 	"crypto/rand"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -799,7 +800,8 @@ func (h *commandHandler) disconnectBot(fromUID string, bot *robotModel) {
 // ========== 辅助方法 ==========
 
 // createBotCoreWithRetry 生成 Bot ID 并创建 App + robot + user，碰撞时自动重试。
-// 返回 (robotID, error)。
+// 非碰撞错误会返回本次生成的 robotID，供调用方补偿 commit 结果不确定的
+// App/robot/user；碰撞重试耗尽时不返回 ID，避免误删已有 Bot。
 func (h *commandHandler) createBotCoreWithRetry(creatorUID, name, botToken string) (string, error) {
 	const maxRetries = 3
 	var robotID string
@@ -818,14 +820,27 @@ func (h *commandHandler) createBotCoreWithRetry(creatorUID, name, botToken strin
 				zap.String("robotID", robotID), zap.Int("attempt", attempt+1))
 			continue
 		}
-		return "", lastErr
+		return robotID, lastErr
 	}
 	return "", lastErr
 }
 
 func (h *commandHandler) createBot(creatorUID, fromUID, name, username, botToken string) (retErr error) {
+	// The payload/channel Space ID is only a selector. Resolve it against
+	// authoritative active user, Space, and membership rows before creating any
+	// durable Bot artifact. A missing selector is accepted only when the server
+	// can derive exactly one active creator Space.
+	targetSpaceID, err := h.db.resolveAuthorizedCreationSpace(creatorUID, h.resolveSpaceID(fromUID))
+	if err != nil {
+		reason := "space_authorization_lookup_failed"
+		if errors.Is(err, errCreateBotSpaceDenied) {
+			reason = "space_authorization_denied"
+		}
+		h.Warn("Bot Space授权失败", zap.String("reason", reason))
+		return errCreateBotSpaceBindingFailed
+	}
+
 	var robotID string
-	var err error
 	if username == "" {
 		robotID, err = h.createBotCoreWithRetry(creatorUID, name, botToken)
 	} else {
@@ -833,32 +848,37 @@ func (h *commandHandler) createBot(creatorUID, fromUID, name, username, botToken
 		robotID = username
 	}
 	if err != nil {
-		return err
+		// Conversational creation always uses a server-generated ID, so it is
+		// safe to compensate even when the core transaction's Commit result was
+		// ambiguous. Explicit usernames are used only by non-conversational
+		// callers and are intentionally not cleaned here.
+		if username == "" && robotID != "" {
+			if cleanupErr := h.db.deleteCreatedBotArtifacts(robotID); cleanupErr != nil {
+				h.Error("Bot核心创建补偿失败",
+					zap.String("reason", "core_creation_cleanup_failed"))
+			}
+		}
+		return errCreateBotPersistenceFailed
 	}
 
-	// 后续步骤：加入 Space、好友关系等
-	targetSpaceID := h.resolveSpaceID(fromUID)
-	if targetSpaceID == "" {
-		// 无 Space 信息（legacy），回退到创建者的第一个 Space
-		h.Warn("createBot: no space_id from client, falling back to creator's first Space",
-			zap.String("fromUID", fromUID), zap.String("creatorUID", creatorUID))
-		creatorSpaces, err := h.getCreatorSpaceIDs(creatorUID)
-		if err != nil {
-			h.Warn("查询创建者Space失败", zap.Error(err))
+	// Re-check under row locks and write the Bot membership in the same
+	// transaction. This is the authorization linearization point: a concurrent
+	// disable/removal that commits first is observed and denied; one that waits
+	// for these locks occurs after a valid binding commit.
+	if err = h.db.bindCreatedBotToSpace(creatorUID, robotID, targetSpaceID); err != nil {
+		reason := "space_binding_persistence_failed"
+		if errors.Is(err, errCreateBotSpaceDenied) {
+			reason = "space_authorization_changed"
 		}
-		if len(creatorSpaces) > 0 {
-			targetSpaceID = creatorSpaces[0]
+		h.Warn("Bot Space绑定失败", zap.String("reason", reason))
+		cleanupErr := h.db.deleteCreatedBotArtifacts(robotID)
+		if cleanupErr != nil {
+			h.Error("Bot创建补偿失败",
+				zap.String("reason", "space_binding_cleanup_failed"))
 		}
+		return errCreateBotSpaceBindingFailed
 	}
-	if targetSpaceID != "" {
-		_, err = h.ctx.DB().InsertBySql(
-			"INSERT IGNORE INTO space_member (space_id, uid, role, status, created_at, updated_at) VALUES (?, ?, 0, 1, NOW(), NOW())",
-			targetSpaceID, robotID,
-		).Exec()
-		if err != nil {
-			h.Warn("Bot加入Space失败", zap.Error(err), zap.String("space_id", targetSpaceID))
-		}
-	}
+
 	// 兼容：仍添加好友关系（过渡期）
 	err = h.userService.AddFriend(creatorUID, &user.FriendReq{
 		UID:   creatorUID,
@@ -1051,15 +1071,6 @@ func (h *commandHandler) resolveSpaceID(fromUID string) string {
 }
 
 // fixFriendVersion 修复好友 version=0 的问题（WKSDK 增量同步需要 version > 0）
-// getCreatorSpaceIDs returns all active Space IDs the creator belongs to
-func (h *commandHandler) getCreatorSpaceIDs(uid string) ([]string, error) {
-	var ids []string
-	_, err := h.db.session.SelectBySql(
-		"SELECT space_id FROM space_member WHERE uid=? AND status=1", uid,
-	).Load(&ids)
-	return ids, err
-}
-
 func (h *commandHandler) fixFriendVersion(uid, toUID string) {
 	var maxVer int64
 	err := h.db.session.SelectBySql("SELECT IFNULL(MAX(version),0) FROM friend WHERE uid=?", uid).LoadOne(&maxVer)

--- a/modules/botfather/command.go
+++ b/modules/botfather/command.go
@@ -848,12 +848,13 @@ func (h *commandHandler) createBot(creatorUID, fromUID, name, username, botToken
 		robotID = username
 	}
 	if err != nil {
-		// Conversational creation always uses a server-generated ID, so it is
-		// safe to compensate even when the core transaction's Commit result was
-		// ambiguous. Explicit usernames are used only by non-conversational
-		// callers and are intentionally not cleaned here.
+		// Production conversational creation always uses a server-generated ID,
+		// so it is safe to compensate even when the core transaction's Commit
+		// result was ambiguous. The non-empty username branch is retained only as
+		// a deterministic internal test seam: its ID might pre-exist after an
+		// ambiguous or collision-like core failure, so do not delete it here.
 		if username == "" && robotID != "" {
-			if cleanupErr := h.db.deleteCreatedBotArtifacts(robotID); cleanupErr != nil {
+			if cleanupErr := h.db.deleteCreatedBotArtifacts(creatorUID, robotID); cleanupErr != nil {
 				h.Error("Bot核心创建补偿失败",
 					zap.String("reason", "core_creation_cleanup_failed"))
 			}
@@ -871,7 +872,7 @@ func (h *commandHandler) createBot(creatorUID, fromUID, name, username, botToken
 			reason = "space_authorization_changed"
 		}
 		h.Warn("Bot Space绑定失败", zap.String("reason", reason))
-		cleanupErr := h.db.deleteCreatedBotArtifacts(robotID)
+		cleanupErr := h.db.deleteCreatedBotArtifacts(creatorUID, robotID)
 		if cleanupErr != nil {
 			h.Error("Bot创建补偿失败",
 				zap.String("reason", "space_binding_cleanup_failed"))

--- a/modules/botfather/command_createbot_e2e_test.go
+++ b/modules/botfather/command_createbot_e2e_test.go
@@ -1,0 +1,109 @@
+package botfather
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBotFatherNewBotSpaceBindingE2E(t *testing.T) {
+	ctx := newCreateBotTestContext(t)
+	defer func() { require.NoError(t, testutil.CleanAllTables(ctx)) }()
+
+	tests := []struct {
+		name       string
+		creatorUID string
+		spaceID    string
+		seed       func(t *testing.T, ctx *config.Context, creatorUID, spaceID string)
+		wantBot    bool
+	}{
+		{
+			name:       "forged payload Space is rejected",
+			creatorUID: "user_e2e_rejected",
+			spaceID:    "space_synthetic_e2e_foreign",
+			seed: func(t *testing.T, ctx *config.Context, creatorUID, spaceID string) {
+				seedCreateBotSpace(t, ctx, "space_synthetic_e2e_owned", 1)
+				seedCreateBotMembership(t, ctx, "space_synthetic_e2e_owned", creatorUID, 1)
+				seedCreateBotSpace(t, ctx, spaceID, 1)
+			},
+			wantBot: false,
+		},
+		{
+			name:       "authorized payload Space creates bound Bot",
+			creatorUID: "user_e2e_authorized",
+			spaceID:    "space_synthetic_e2e_target",
+			seed: func(t *testing.T, ctx *config.Context, creatorUID, spaceID string) {
+				seedCreateBotSpace(t, ctx, spaceID, 1)
+				seedCreateBotMembership(t, ctx, spaceID, creatorUID, 1)
+				seedCreateBotSpace(t, ctx, "space_synthetic_e2e_other", 1)
+				seedCreateBotMembership(t, ctx, "space_synthetic_e2e_other", creatorUID, 1)
+			},
+			wantBot: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.NoError(t, testutil.CleanAllTables(ctx))
+			seedCreateBotUser(t, ctx, tt.creatorUID, 1)
+			tt.seed(t, ctx, tt.creatorUID, tt.spaceID)
+
+			bf := New(ctx)
+			require.NoError(t, bf.cmdHandler.sm.Clear(tt.creatorUID, tt.spaceID))
+			bf.messagesListen([]*config.MessageResp{
+				newCreateBotMessage(tt.creatorUID, tt.spaceID, CmdNewBot),
+			})
+			require.Eventually(t, func() bool {
+				state, err := bf.cmdHandler.sm.GetState(tt.creatorUID, tt.spaceID)
+				return err == nil && state == StateWaitingBotName
+			}, 5*time.Second, 20*time.Millisecond)
+
+			bf.messagesListen([]*config.MessageResp{
+				newCreateBotMessage(tt.creatorUID, tt.spaceID, "Synthetic E2E Bot"),
+			})
+			require.Eventually(t, func() bool {
+				return len(bf.msgSem) == 0
+			}, 10*time.Second, 20*time.Millisecond)
+
+			bots, err := bf.db.queryRobotsByCreatorUID(tt.creatorUID)
+			require.NoError(t, err)
+			if !tt.wantBot {
+				require.Empty(t, bots)
+				return
+			}
+
+			require.Len(t, bots, 1)
+			assertCreateBotMembershipCount(t, ctx, bots[0].RobotID, tt.spaceID, 1)
+
+			cleanupTarget := setSpaceIDFromPayload(tt.creatorUID, tt.spaceID)
+			visibleInTarget, queryErr := bf.cmdHandler.queryBotsForUser(tt.creatorUID)
+			cleanupTarget()
+			require.NoError(t, queryErr)
+			require.Len(t, visibleInTarget, 1)
+
+			cleanupOther := setSpaceIDFromPayload(tt.creatorUID, "space_synthetic_e2e_other")
+			visibleInOther, queryErr := bf.cmdHandler.queryBotsForUser(tt.creatorUID)
+			cleanupOther()
+			require.NoError(t, queryErr)
+			require.Empty(t, visibleInOther)
+		})
+	}
+}
+
+func newCreateBotMessage(fromUID, spaceID, content string) *config.MessageResp {
+	return &config.MessageResp{
+		FromUID:     fromUID,
+		ChannelID:   common.GetFakeChannelIDWith(fromUID, BotFatherUID),
+		ChannelType: common.ChannelTypePerson.Uint8(),
+		Payload: []byte(util.ToJson(map[string]interface{}{
+			"type":     common.Text,
+			"content":  content,
+			"space_id": spaceID,
+		})),
+	}
+}

--- a/modules/botfather/command_createbot_space_test.go
+++ b/modules/botfather/command_createbot_space_test.go
@@ -468,6 +468,61 @@ func TestDeleteCreatedBotArtifactsDeletesOnlyCreatorFriendPairs(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
+func TestBindCreatedBotToSpaceRejectsUnexpectedInsertRows(t *testing.T) {
+	rawDB, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer rawDB.Close()
+	conn := &dbr.Connection{
+		DB:            rawDB,
+		EventReceiver: &dbr.NullEventReceiver{},
+		Dialect:       dialect.MySQL,
+	}
+	db := &botfatherDB{session: conn.NewSession(nil)}
+
+	mock.ExpectBegin()
+	mock.ExpectQuery("SELECT status, is_destroy FROM user.*FOR UPDATE").
+		WillReturnRows(sqlmock.NewRows([]string{"status", "is_destroy"}).AddRow(1, 0))
+	mock.ExpectQuery("SELECT status FROM space.*FOR UPDATE").
+		WillReturnRows(sqlmock.NewRows([]string{"status"}).AddRow(1))
+	mock.ExpectQuery("SELECT status FROM space_member.*FOR UPDATE").
+		WillReturnRows(sqlmock.NewRows([]string{"status"}).AddRow(1))
+	mock.ExpectExec("INSERT INTO space_member.*NOW\\(\\), NOW\\(\\)").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectRollback()
+
+	err = db.bindCreatedBotToSpace(
+		"user_synthetic_bind",
+		"bot_synthetic_bind",
+		"space_synthetic_bind",
+	)
+
+	require.EqualError(t, err, "insert Bot Space membership: unexpected affected rows")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestBindCreatedBotToSpaceReturnsBeginFailure(t *testing.T) {
+	rawDB, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer rawDB.Close()
+	conn := &dbr.Connection{
+		DB:            rawDB,
+		EventReceiver: &dbr.NullEventReceiver{},
+		Dialect:       dialect.MySQL,
+	}
+	db := &botfatherDB{session: conn.NewSession(nil)}
+	beginErr := errors.New("synthetic transaction begin failure")
+	mock.ExpectBegin().WillReturnError(beginErr)
+
+	err = db.bindCreatedBotToSpace(
+		"user_synthetic_bind",
+		"bot_synthetic_bind",
+		"space_synthetic_bind",
+	)
+
+	assert.ErrorIs(t, err, beginErr)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
 type blockingCreateAppService struct {
 	app.IService
 	created chan struct{}

--- a/modules/botfather/command_createbot_space_test.go
+++ b/modules/botfather/command_createbot_space_test.go
@@ -3,6 +3,7 @@ package botfather
 import (
 	"errors"
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
@@ -417,18 +418,57 @@ func TestDeleteCreatedBotArtifactsFallsBackToCredentialRevocation(t *testing.T) 
 	}
 	db := &botfatherDB{session: conn.NewSession(nil)}
 	deleteErr := errors.New("synthetic cleanup delete failure")
+	const (
+		creatorUID = "user_synthetic_cleanup_creator"
+		botID      = "bot_synthetic_cleanup"
+	)
 
 	mock.ExpectBegin()
-	mock.ExpectExec("DELETE FROM .*friend.*").WillReturnError(deleteErr)
+	mock.ExpectExec(regexp.QuoteMeta(
+		"DELETE FROM friend WHERE (uid=? AND to_uid=?) OR (uid=? AND to_uid=?)",
+	)).
+		WithArgs(creatorUID, botID, botID, creatorUID).
+		WillReturnError(deleteErr)
 	mock.ExpectRollback()
 	mock.ExpectExec("UPDATE robot SET status=0").WillReturnResult(sqlmock.NewResult(0, 1))
 	mock.ExpectExec("UPDATE user SET status=0").WillReturnResult(sqlmock.NewResult(0, 1))
 	mock.ExpectExec("UPDATE space_member SET status=0").WillReturnResult(sqlmock.NewResult(0, 1))
 	mock.ExpectExec("UPDATE app SET status=0").WillReturnResult(sqlmock.NewResult(0, 1))
 
-	cleanupErr := db.deleteCreatedBotArtifacts("bot_synthetic_cleanup")
+	cleanupErr := db.deleteCreatedBotArtifacts(creatorUID, botID)
 
 	assert.ErrorIs(t, cleanupErr, deleteErr)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestDeleteCreatedBotArtifactsDeletesOnlyCreatorFriendPairs(t *testing.T) {
+	rawDB, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer rawDB.Close()
+	conn := &dbr.Connection{
+		DB:            rawDB,
+		EventReceiver: &dbr.NullEventReceiver{},
+		Dialect:       dialect.MySQL,
+	}
+	db := &botfatherDB{session: conn.NewSession(nil)}
+	const (
+		creatorUID = "user_synthetic_cleanup_creator"
+		botID      = "bot_synthetic_cleanup"
+	)
+
+	mock.ExpectBegin()
+	mock.ExpectExec(regexp.QuoteMeta(
+		"DELETE FROM friend WHERE (uid=? AND to_uid=?) OR (uid=? AND to_uid=?)",
+	)).
+		WithArgs(creatorUID, botID, botID, creatorUID).
+		WillReturnResult(sqlmock.NewResult(0, 2))
+	mock.ExpectExec("DELETE FROM .*space_member.*").WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec("DELETE FROM .*user.*").WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec("DELETE FROM .*robot.*").WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec("DELETE FROM .*app.*").WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectCommit()
+
+	require.NoError(t, db.deleteCreatedBotArtifacts(creatorUID, botID))
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 

--- a/modules/botfather/command_createbot_space_test.go
+++ b/modules/botfather/command_createbot_space_test.go
@@ -425,10 +425,8 @@ func TestDeleteCreatedBotArtifactsFallsBackToCredentialRevocation(t *testing.T) 
 
 	mock.ExpectBegin()
 	mock.ExpectExec(regexp.QuoteMeta(
-		"DELETE FROM friend WHERE (uid=? AND to_uid=?) OR (uid=? AND to_uid=?)",
-	)).
-		WithArgs(creatorUID, botID, botID, creatorUID).
-		WillReturnError(deleteErr)
+		"DELETE FROM `friend` WHERE ((uid='user_synthetic_cleanup_creator' AND to_uid='bot_synthetic_cleanup') OR (uid='bot_synthetic_cleanup' AND to_uid='user_synthetic_cleanup_creator'))",
+	)).WillReturnError(deleteErr)
 	mock.ExpectRollback()
 	mock.ExpectExec("UPDATE robot SET status=0").WillReturnResult(sqlmock.NewResult(0, 1))
 	mock.ExpectExec("UPDATE user SET status=0").WillReturnResult(sqlmock.NewResult(0, 1))
@@ -458,10 +456,8 @@ func TestDeleteCreatedBotArtifactsDeletesOnlyCreatorFriendPairs(t *testing.T) {
 
 	mock.ExpectBegin()
 	mock.ExpectExec(regexp.QuoteMeta(
-		"DELETE FROM friend WHERE (uid=? AND to_uid=?) OR (uid=? AND to_uid=?)",
-	)).
-		WithArgs(creatorUID, botID, botID, creatorUID).
-		WillReturnResult(sqlmock.NewResult(0, 2))
+		"DELETE FROM `friend` WHERE ((uid='user_synthetic_cleanup_creator' AND to_uid='bot_synthetic_cleanup') OR (uid='bot_synthetic_cleanup' AND to_uid='user_synthetic_cleanup_creator'))",
+	)).WillReturnResult(sqlmock.NewResult(0, 2))
 	mock.ExpectExec("DELETE FROM .*space_member.*").WillReturnResult(sqlmock.NewResult(0, 1))
 	mock.ExpectExec("DELETE FROM .*user.*").WillReturnResult(sqlmock.NewResult(0, 1))
 	mock.ExpectExec("DELETE FROM .*robot.*").WillReturnResult(sqlmock.NewResult(0, 1))

--- a/modules/botfather/command_createbot_space_test.go
+++ b/modules/botfather/command_createbot_space_test.go
@@ -1,0 +1,537 @@
+package botfather
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	"github.com/Mininglamp-OSS/octo-server/modules/base/app"
+	"github.com/gocraft/dbr/v2"
+	"github.com/gocraft/dbr/v2/dialect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateBotSpaceBindingRejectsUntrustedSelector(t *testing.T) {
+	ctx := newCreateBotTestContext(t)
+	defer func() { require.NoError(t, testutil.CleanAllTables(ctx)) }()
+
+	tests := []struct {
+		name     string
+		selector string
+		seed     func(t *testing.T, ctx *config.Context, creatorUID string)
+	}{
+		{
+			name:     "foreign Space",
+			selector: "space_synthetic_foreign",
+			seed: func(t *testing.T, ctx *config.Context, creatorUID string) {
+				seedCreateBotSpace(t, ctx, "space_synthetic_owned", 1)
+				seedCreateBotMembership(t, ctx, "space_synthetic_owned", creatorUID, 1)
+				seedCreateBotSpace(t, ctx, "space_synthetic_foreign", 1)
+			},
+		},
+		{
+			name:     "nonexistent Space",
+			selector: "space_synthetic_missing",
+		},
+		{
+			name:     "inactive Space",
+			selector: "space_synthetic_inactive",
+			seed: func(t *testing.T, ctx *config.Context, creatorUID string) {
+				seedCreateBotSpace(t, ctx, "space_synthetic_inactive", 0)
+				seedCreateBotMembership(t, ctx, "space_synthetic_inactive", creatorUID, 1)
+			},
+		},
+		{
+			name:     "inactive creator",
+			selector: "space_synthetic_creator_disabled",
+			seed: func(t *testing.T, ctx *config.Context, creatorUID string) {
+				_, err := ctx.DB().Update("user").Set("status", 0).Where("uid=?", creatorUID).Exec()
+				require.NoError(t, err)
+				seedCreateBotSpace(t, ctx, "space_synthetic_creator_disabled", 1)
+				seedCreateBotMembership(t, ctx, "space_synthetic_creator_disabled", creatorUID, 1)
+			},
+		},
+		{
+			name:     "removed membership",
+			selector: "space_synthetic_removed",
+			seed: func(t *testing.T, ctx *config.Context, creatorUID string) {
+				seedCreateBotSpace(t, ctx, "space_synthetic_removed", 1)
+				seedCreateBotMembership(t, ctx, "space_synthetic_removed", creatorUID, 0)
+			},
+		},
+	}
+
+	for i, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.NoError(t, testutil.CleanAllTables(ctx))
+			creatorUID := fmt.Sprintf("user_space_guard_%d", i)
+			botID := fmt.Sprintf("bot_space_guard_%d", i)
+			seedCreateBotUser(t, ctx, creatorUID, 1)
+			if tt.seed != nil {
+				tt.seed(t, ctx, creatorUID)
+			}
+
+			cleanup := setSpaceIDFromPayload(creatorUID, tt.selector)
+			err := newCommandHandler(ctx).createBot(
+				creatorUID,
+				creatorUID,
+				"Synthetic Bot",
+				botID,
+				"bf_test_space_guard",
+			)
+			cleanup()
+
+			assert.Error(t, err)
+			assertNoCreateBotArtifacts(t, ctx, botID)
+		})
+	}
+}
+
+func TestCreateBotSpaceBindingMissingSelector(t *testing.T) {
+	ctx := newCreateBotTestContext(t)
+	defer func() { require.NoError(t, testutil.CleanAllTables(ctx)) }()
+
+	tests := []struct {
+		name       string
+		spaceCount int
+		wantErr    bool
+	}{
+		{name: "zero active Spaces", spaceCount: 0, wantErr: true},
+		{name: "exactly one active Space", spaceCount: 1, wantErr: false},
+		{name: "multiple active Spaces", spaceCount: 2, wantErr: true},
+	}
+
+	for i, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.NoError(t, testutil.CleanAllTables(ctx))
+			creatorUID := fmt.Sprintf("user_space_fallback_%d", i)
+			botID := fmt.Sprintf("bot_space_fallback_%d", i)
+			seedCreateBotUser(t, ctx, creatorUID, 1)
+			for spaceIndex := 0; spaceIndex < tt.spaceCount; spaceIndex++ {
+				spaceID := fmt.Sprintf("space_synthetic_%d_%d", i, spaceIndex)
+				seedCreateBotSpace(t, ctx, spaceID, 1)
+				seedCreateBotMembership(t, ctx, spaceID, creatorUID, 1)
+			}
+
+			err := newCommandHandler(ctx).createBot(
+				creatorUID,
+				creatorUID,
+				"Synthetic Bot",
+				botID,
+				"bf_test_space_fallback",
+			)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				assertNoCreateBotArtifacts(t, ctx, botID)
+				return
+			}
+			require.NoError(t, err)
+			assertCreateBotArtifacts(t, ctx, botID, "space_synthetic_1_0")
+		})
+	}
+}
+
+func TestCreateBotSpaceBindingAuthorizedSelector(t *testing.T) {
+	ctx := newCreateBotTestContext(t)
+	defer func() { require.NoError(t, testutil.CleanAllTables(ctx)) }()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+
+	const (
+		creatorUID  = "user_space_authorized"
+		botID       = "bot_space_authorized"
+		targetSpace = "space_synthetic_target"
+		otherSpace  = "space_synthetic_other"
+	)
+	seedCreateBotUser(t, ctx, creatorUID, 1)
+	seedCreateBotSpace(t, ctx, targetSpace, 1)
+	seedCreateBotMembership(t, ctx, targetSpace, creatorUID, 1)
+	seedCreateBotSpace(t, ctx, otherSpace, 1)
+	seedCreateBotMembership(t, ctx, otherSpace, creatorUID, 1)
+
+	cleanup := setSpaceIDFromPayload(creatorUID, targetSpace)
+	err := newCommandHandler(ctx).createBot(
+		creatorUID,
+		creatorUID,
+		"Synthetic Bot",
+		botID,
+		"bf_test_space_authorized",
+	)
+	cleanup()
+
+	require.NoError(t, err)
+	assertCreateBotArtifacts(t, ctx, botID, targetSpace)
+	assertCreateBotMembershipCount(t, ctx, botID, otherSpace, 0)
+}
+
+func TestCreateBotSpaceBindingRechecksAuthorityBeforeCommit(t *testing.T) {
+	ctx := newCreateBotTestContext(t)
+	defer func() { require.NoError(t, testutil.CleanAllTables(ctx)) }()
+
+	tests := []struct {
+		name   string
+		mutate func(t *testing.T, ctx *config.Context, creatorUID, spaceID string)
+	}{
+		{
+			name: "creator disabled after preflight",
+			mutate: func(t *testing.T, ctx *config.Context, creatorUID, _ string) {
+				_, err := ctx.DB().Update("user").Set("status", 0).
+					Where("uid=?", creatorUID).Exec()
+				require.NoError(t, err)
+			},
+		},
+		{
+			name: "creator destroyed after preflight",
+			mutate: func(t *testing.T, ctx *config.Context, creatorUID, _ string) {
+				_, err := ctx.DB().Update("user").Set("is_destroy", 2).
+					Where("uid=?", creatorUID).Exec()
+				require.NoError(t, err)
+			},
+		},
+		{
+			name: "creator deleted after preflight",
+			mutate: func(t *testing.T, ctx *config.Context, creatorUID, _ string) {
+				_, err := ctx.DB().DeleteFrom("user").Where("uid=?", creatorUID).Exec()
+				require.NoError(t, err)
+			},
+		},
+		{
+			name: "membership removed after preflight",
+			mutate: func(t *testing.T, ctx *config.Context, creatorUID, spaceID string) {
+				_, err := ctx.DB().Update("space_member").Set("status", 0).
+					Where("space_id=? AND uid=?", spaceID, creatorUID).Exec()
+				require.NoError(t, err)
+			},
+		},
+		{
+			name: "membership deleted after preflight",
+			mutate: func(t *testing.T, ctx *config.Context, creatorUID, spaceID string) {
+				_, err := ctx.DB().DeleteFrom("space_member").
+					Where("space_id=? AND uid=?", spaceID, creatorUID).Exec()
+				require.NoError(t, err)
+			},
+		},
+		{
+			name: "Space disabled after preflight",
+			mutate: func(t *testing.T, ctx *config.Context, _, spaceID string) {
+				_, err := ctx.DB().Update("space").Set("status", 0).
+					Where("space_id=?", spaceID).Exec()
+				require.NoError(t, err)
+			},
+		},
+		{
+			name: "Space deleted after preflight",
+			mutate: func(t *testing.T, ctx *config.Context, _, spaceID string) {
+				_, err := ctx.DB().DeleteFrom("space").Where("space_id=?", spaceID).Exec()
+				require.NoError(t, err)
+			},
+		},
+	}
+
+	for i, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.NoError(t, testutil.CleanAllTables(ctx))
+			creatorUID := fmt.Sprintf("user_space_race_%d", i)
+			botID := fmt.Sprintf("bot_space_race_%d", i)
+			spaceID := fmt.Sprintf("space_synthetic_race_%d", i)
+			seedCreateBotUser(t, ctx, creatorUID, 1)
+			seedCreateBotSpace(t, ctx, spaceID, 1)
+			seedCreateBotMembership(t, ctx, spaceID, creatorUID, 1)
+
+			handler := newCommandHandler(ctx)
+			created := make(chan struct{})
+			resume := make(chan struct{})
+			handler.appService = &blockingCreateAppService{
+				IService: handler.appService,
+				created:  created,
+				resume:   resume,
+			}
+			cleanupSelector := setSpaceIDFromPayload(creatorUID, spaceID)
+			result := make(chan error, 1)
+			go func() {
+				result <- handler.createBot(
+					creatorUID,
+					creatorUID,
+					"Synthetic Bot",
+					botID,
+					"bf_test_space_race",
+				)
+			}()
+
+			<-created
+			tt.mutate(t, ctx, creatorUID, spaceID)
+			close(resume)
+			err := <-result
+			cleanupSelector()
+
+			assert.Error(t, err)
+			assertNoCreateBotArtifacts(t, ctx, botID)
+		})
+	}
+}
+
+func TestCreateBotSpaceBindingInsertFailureCompensatesCoreArtifacts(t *testing.T) {
+	ctx := newCreateBotTestContext(t)
+	defer func() { require.NoError(t, testutil.CleanAllTables(ctx)) }()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+
+	const (
+		creatorUID = "user_space_insert_failure"
+		botID      = "bot_space_insert_failure"
+		spaceID    = "space_synthetic_insert_failure"
+		trigger    = "botfather_test_reject_bot_membership"
+	)
+	seedCreateBotUser(t, ctx, creatorUID, 1)
+	seedCreateBotSpace(t, ctx, spaceID, 1)
+	seedCreateBotMembership(t, ctx, spaceID, creatorUID, 1)
+
+	_, err := ctx.DB().Exec("DROP TRIGGER IF EXISTS " + trigger)
+	require.NoError(t, err)
+	_, err = ctx.DB().Exec(`
+		CREATE TRIGGER ` + trigger + `
+		BEFORE INSERT ON space_member
+		FOR EACH ROW
+		BEGIN
+			IF NEW.uid = '` + botID + `' THEN
+				SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = 'synthetic Bot membership insert failure';
+			END IF;
+		END`)
+	require.NoError(t, err)
+	defer func() {
+		_, dropErr := ctx.DB().Exec("DROP TRIGGER IF EXISTS " + trigger)
+		require.NoError(t, dropErr)
+	}()
+
+	cleanupSelector := setSpaceIDFromPayload(creatorUID, spaceID)
+	err = newCommandHandler(ctx).createBot(
+		creatorUID,
+		creatorUID,
+		"Synthetic Bot",
+		botID,
+		"bf_test_space_insert_failure",
+	)
+	cleanupSelector()
+
+	assert.Error(t, err)
+	assertNoCreateBotArtifacts(t, ctx, botID)
+}
+
+func TestCreateBotCoreFailureLeavesNoGeneratedArtifacts(t *testing.T) {
+	ctx := newCreateBotTestContext(t)
+	defer func() { require.NoError(t, testutil.CleanAllTables(ctx)) }()
+	require.NoError(t, testutil.CleanAllTables(ctx))
+
+	const (
+		creatorUID = "user_core_insert_failure"
+		spaceID    = "space_synthetic_core_failure"
+		trigger    = "botfather_test_reject_robot_insert"
+	)
+	seedCreateBotUser(t, ctx, creatorUID, 1)
+	seedCreateBotSpace(t, ctx, spaceID, 1)
+	seedCreateBotMembership(t, ctx, spaceID, creatorUID, 1)
+
+	_, err := ctx.DB().Exec("DROP TRIGGER IF EXISTS " + trigger)
+	require.NoError(t, err)
+	_, err = ctx.DB().Exec(`
+		CREATE TRIGGER ` + trigger + `
+		BEFORE INSERT ON robot
+		FOR EACH ROW
+		SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = 'synthetic robot insert failure'`)
+	require.NoError(t, err)
+	defer func() {
+		_, dropErr := ctx.DB().Exec("DROP TRIGGER IF EXISTS " + trigger)
+		require.NoError(t, dropErr)
+	}()
+
+	cleanupSelector := setSpaceIDFromPayload(creatorUID, spaceID)
+	err = newCommandHandler(ctx).createBot(
+		creatorUID,
+		creatorUID,
+		"Synthetic Bot",
+		"",
+		"bf_test_core_insert_failure",
+	)
+	cleanupSelector()
+
+	assert.ErrorIs(t, err, errCreateBotPersistenceFailed)
+	assertCreateBotCount(t, ctx, "SELECT COUNT(*) FROM app WHERE app_id<>?", "synthetic_nonexistent", 0)
+	assertCreateBotCount(t, ctx, "SELECT COUNT(*) FROM robot WHERE creator_uid=?", creatorUID, 0)
+	assertCreateBotCount(t, ctx, "SELECT COUNT(*) FROM user WHERE robot=1 AND uid<>?", creatorUID, 0)
+	assertCreateBotCount(t, ctx, "SELECT COUNT(*) FROM friend WHERE uid=? OR to_uid=?", creatorUID, 0, creatorUID)
+	assertCreateBotCount(t, ctx, "SELECT COUNT(*) FROM space_member WHERE uid<>?", creatorUID, 0)
+}
+
+func TestResolveAuthorizedCreationSpaceQueryFailureFailsClosed(t *testing.T) {
+	tests := []struct {
+		name       string
+		selector   string
+		queryMatch string
+	}{
+		{
+			name:       "explicit selector",
+			selector:   "space_synthetic_query_error",
+			queryMatch: `(?s)SELECT sm\.space_id.*AND sm\.space_id = 'space_synthetic_query_error'`,
+		},
+		{
+			name:       "missing selector",
+			queryMatch: `(?s)SELECT sm\.space_id.*LIMIT 2`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rawDB, mock, err := sqlmock.New()
+			require.NoError(t, err)
+			defer rawDB.Close()
+			conn := &dbr.Connection{
+				DB:            rawDB,
+				EventReceiver: &dbr.NullEventReceiver{},
+				Dialect:       dialect.MySQL,
+			}
+			db := &botfatherDB{session: conn.NewSession(nil)}
+			mock.ExpectQuery(tt.queryMatch).WillReturnError(errors.New("synthetic database failure"))
+
+			spaceID, resolveErr := db.resolveAuthorizedCreationSpace("user_synthetic_query_error", tt.selector)
+
+			assert.Empty(t, spaceID)
+			assert.Error(t, resolveErr)
+			assert.NotErrorIs(t, resolveErr, errCreateBotSpaceDenied)
+			require.NoError(t, mock.ExpectationsWereMet())
+		})
+	}
+}
+
+func TestDeleteCreatedBotArtifactsFallsBackToCredentialRevocation(t *testing.T) {
+	rawDB, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer rawDB.Close()
+	conn := &dbr.Connection{
+		DB:            rawDB,
+		EventReceiver: &dbr.NullEventReceiver{},
+		Dialect:       dialect.MySQL,
+	}
+	db := &botfatherDB{session: conn.NewSession(nil)}
+	deleteErr := errors.New("synthetic cleanup delete failure")
+
+	mock.ExpectBegin()
+	mock.ExpectExec("DELETE FROM .*friend.*").WillReturnError(deleteErr)
+	mock.ExpectRollback()
+	mock.ExpectExec("UPDATE robot SET status=0").WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec("UPDATE user SET status=0").WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec("UPDATE space_member SET status=0").WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec("UPDATE app SET status=0").WillReturnResult(sqlmock.NewResult(0, 1))
+
+	cleanupErr := db.deleteCreatedBotArtifacts("bot_synthetic_cleanup")
+
+	assert.ErrorIs(t, cleanupErr, deleteErr)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+type blockingCreateAppService struct {
+	app.IService
+	created chan struct{}
+	resume  chan struct{}
+}
+
+func (s *blockingCreateAppService) CreateApp(req app.Req) (*app.Resp, error) {
+	resp, err := s.IService.CreateApp(req)
+	if err != nil {
+		return nil, err
+	}
+	close(s.created)
+	<-s.resume
+	return resp, nil
+}
+
+func newCreateBotTestContext(t *testing.T) *config.Context {
+	t.Helper()
+	t.Setenv("OCTO_MASTER_KEY", "0123456789abcdef0123456789abcdef")
+	_, ctx := testutil.NewTestServer()
+	return ctx
+}
+
+func seedCreateBotUser(t *testing.T, ctx *config.Context, uid string, status int) {
+	t.Helper()
+	_, err := ctx.DB().InsertBySql(
+		"INSERT INTO user (uid, name, username, short_no, status) VALUES (?, ?, ?, ?, ?)",
+		uid,
+		"Synthetic User",
+		uid,
+		"sn_"+util.GenerUUID()[:12],
+		status,
+	).Exec()
+	require.NoError(t, err)
+}
+
+func seedCreateBotSpace(t *testing.T, ctx *config.Context, spaceID string, status int) {
+	t.Helper()
+	_, err := ctx.DB().InsertBySql(
+		"INSERT INTO space (space_id, name, status) VALUES (?, ?, ?)",
+		spaceID,
+		"Synthetic Space",
+		status,
+	).Exec()
+	require.NoError(t, err)
+}
+
+func seedCreateBotMembership(t *testing.T, ctx *config.Context, spaceID, uid string, status int) {
+	t.Helper()
+	_, err := ctx.DB().InsertBySql(
+		"INSERT INTO space_member (space_id, uid, role, status) VALUES (?, ?, 0, ?)",
+		spaceID,
+		uid,
+		status,
+	).Exec()
+	require.NoError(t, err)
+}
+
+func assertNoCreateBotArtifacts(t *testing.T, ctx *config.Context, botID string) {
+	t.Helper()
+	assertCreateBotCount(t, ctx, "SELECT COUNT(*) FROM app WHERE app_id=?", botID, 0)
+	assertCreateBotCount(t, ctx, "SELECT COUNT(*) FROM robot WHERE robot_id=?", botID, 0)
+	assertCreateBotCount(t, ctx, "SELECT COUNT(*) FROM user WHERE uid=?", botID, 0)
+	assertCreateBotCount(t, ctx, "SELECT COUNT(*) FROM friend WHERE uid=? OR to_uid=?", botID, 0, botID)
+	assertCreateBotCount(t, ctx, "SELECT COUNT(*) FROM space_member WHERE uid=?", botID, 0)
+}
+
+func assertCreateBotArtifacts(t *testing.T, ctx *config.Context, botID, spaceID string) {
+	t.Helper()
+	assertCreateBotCount(t, ctx, "SELECT COUNT(*) FROM app WHERE app_id=? AND status=1", botID, 1)
+	assertCreateBotCount(t, ctx, "SELECT COUNT(*) FROM robot WHERE robot_id=? AND status=1", botID, 1)
+	assertCreateBotCount(t, ctx, "SELECT COUNT(*) FROM user WHERE uid=? AND status=1 AND robot=1", botID, 1)
+	assertCreateBotCount(t, ctx, "SELECT COUNT(*) FROM friend WHERE (uid=? OR to_uid=?) AND is_deleted=0", botID, 2, botID)
+	assertCreateBotMembershipCount(t, ctx, botID, spaceID, 1)
+	assertCreateBotCount(t, ctx, "SELECT COUNT(*) FROM space_member WHERE uid=?", botID, 1)
+}
+
+func assertCreateBotMembershipCount(t *testing.T, ctx *config.Context, botID, spaceID string, want int) {
+	t.Helper()
+	assertCreateBotCount(
+		t,
+		ctx,
+		"SELECT COUNT(*) FROM space_member WHERE uid=? AND space_id=? AND status=1",
+		botID,
+		want,
+		spaceID,
+	)
+}
+
+func assertCreateBotCount(
+	t *testing.T,
+	ctx *config.Context,
+	query string,
+	firstArg interface{},
+	want int,
+	rest ...interface{},
+) {
+	t.Helper()
+	args := append([]interface{}{firstArg}, rest...)
+	var got int
+	require.NoError(t, ctx.DB().SelectBySql(query, args...).LoadOne(&got))
+	assert.Equal(t, want, got)
+}

--- a/modules/botfather/db.go
+++ b/modules/botfather/db.go
@@ -1,7 +1,10 @@
 package botfather
 
 import (
+	"errors"
+	"fmt"
 	"strings"
+	"time"
 
 	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/db"
@@ -12,6 +15,10 @@ type botfatherDB struct {
 	session *dbr.Session
 	ctx     *config.Context
 }
+
+var errCreateBotSpaceDenied = errors.New("bot creation Space authorization denied")
+var errCreateBotSpaceBindingFailed = errors.New("bot creation Space binding failed")
+var errCreateBotPersistenceFailed = errors.New("bot creation persistence failed")
 
 func newBotfatherDB(ctx *config.Context) *botfatherDB {
 	return &botfatherDB{
@@ -79,6 +86,185 @@ func (d *botfatherDB) queryRobotsByCreatorUIDAndSpaceID(creatorUID, spaceID stri
 		spaceID, creatorUID,
 	).Load(&list)
 	return list, err
+}
+
+// resolveAuthorizedCreationSpace treats selectedSpaceID as an untrusted
+// selector. An explicit selector must identify an active Space in which the
+// active creator is an active member. Without a selector, exactly one such
+// Space must exist; LIMIT 2 distinguishes unique from ambiguous without
+// relying on row order.
+func (d *botfatherDB) resolveAuthorizedCreationSpace(creatorUID, selectedSpaceID string) (string, error) {
+	const activeMembershipSQL = `
+		SELECT sm.space_id
+		FROM user u
+		INNER JOIN space_member sm ON sm.uid = u.uid
+		INNER JOIN space s ON s.space_id = sm.space_id
+		WHERE u.uid = ? AND u.status = 1 AND u.is_destroy = 0
+		  AND sm.status = 1 AND s.status = 1`
+
+	if selectedSpaceID != "" {
+		var authorizedSpaceID string
+		err := d.session.SelectBySql(
+			activeMembershipSQL+" AND sm.space_id = ?",
+			creatorUID,
+			selectedSpaceID,
+		).LoadOne(&authorizedSpaceID)
+		if errors.Is(err, dbr.ErrNotFound) {
+			return "", errCreateBotSpaceDenied
+		}
+		if err != nil {
+			return "", fmt.Errorf("resolve Bot creation Space: %w", err)
+		}
+		return authorizedSpaceID, nil
+	}
+
+	var activeSpaceIDs []string
+	_, err := d.session.SelectBySql(activeMembershipSQL+" LIMIT 2", creatorUID).Load(&activeSpaceIDs)
+	if err != nil {
+		return "", fmt.Errorf("derive Bot creation Space: %w", err)
+	}
+	if len(activeSpaceIDs) != 1 {
+		return "", errCreateBotSpaceDenied
+	}
+	return activeSpaceIDs[0], nil
+}
+
+// bindCreatedBotToSpace is the final authorization check and membership write.
+// Locking the three authority rows before the INSERT prevents a stale preflight
+// decision from authorizing the commit after a concurrent disable/removal.
+func (d *botfatherDB) bindCreatedBotToSpace(creatorUID, robotID, spaceID string) (retErr error) {
+	tx, err := d.session.Begin()
+	if err != nil {
+		return fmt.Errorf("begin Bot Space binding: %w", err)
+	}
+	defer func() {
+		if retErr != nil {
+			_ = tx.Rollback()
+		}
+	}()
+
+	var creator struct {
+		Status    int
+		IsDestroy int
+	}
+	err = tx.SelectBySql(
+		"SELECT status, is_destroy FROM user WHERE uid=? FOR UPDATE",
+		creatorUID,
+	).LoadOne(&creator)
+	if errors.Is(err, dbr.ErrNotFound) || (err == nil && (creator.Status != 1 || creator.IsDestroy != 0)) {
+		return errCreateBotSpaceDenied
+	}
+	if err != nil {
+		return fmt.Errorf("lock Bot creator: %w", err)
+	}
+
+	var spaceStatus int
+	err = tx.SelectBySql(
+		"SELECT status FROM space WHERE space_id=? FOR UPDATE",
+		spaceID,
+	).LoadOne(&spaceStatus)
+	if errors.Is(err, dbr.ErrNotFound) || (err == nil && spaceStatus != 1) {
+		return errCreateBotSpaceDenied
+	}
+	if err != nil {
+		return fmt.Errorf("lock Bot target Space: %w", err)
+	}
+
+	var membershipStatus int
+	err = tx.SelectBySql(
+		"SELECT status FROM space_member WHERE space_id=? AND uid=? FOR UPDATE",
+		spaceID,
+		creatorUID,
+	).LoadOne(&membershipStatus)
+	if errors.Is(err, dbr.ErrNotFound) || (err == nil && membershipStatus != 1) {
+		return errCreateBotSpaceDenied
+	}
+	if err != nil {
+		return fmt.Errorf("lock Bot creator membership: %w", err)
+	}
+
+	now := time.Now()
+	result, err := tx.InsertInto("space_member").
+		Columns("space_id", "uid", "role", "status", "created_at", "updated_at").
+		Values(spaceID, robotID, 0, 1, now, now).
+		Exec()
+	if err != nil {
+		return fmt.Errorf("insert Bot Space membership: %w", err)
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("check Bot Space membership insert: %w", err)
+	}
+	if affected != 1 {
+		return errors.New("insert Bot Space membership: unexpected affected rows")
+	}
+	if err = tx.Commit(); err != nil {
+		return fmt.Errorf("commit Bot Space binding: %w", err)
+	}
+	return nil
+}
+
+// deleteCreatedBotArtifacts compensates a failed post-core Space binding. The
+// hard delete clears every newly-created credential-bearing row atomically.
+// If that transaction fails, best-effort fail-closed updates disable the Bot
+// and blank credentials so cleanup failure cannot leave a usable active Bot.
+func (d *botfatherDB) deleteCreatedBotArtifacts(robotID string) error {
+	tx, err := d.session.Begin()
+	if err == nil {
+		steps := []func() error{
+			func() error {
+				_, stepErr := tx.DeleteFrom("friend").Where("uid=? OR to_uid=?", robotID, robotID).Exec()
+				return stepErr
+			},
+			func() error {
+				_, stepErr := tx.DeleteFrom("space_member").Where("uid=?", robotID).Exec()
+				return stepErr
+			},
+			func() error {
+				_, stepErr := tx.DeleteFrom("user").Where("uid=? AND robot=1", robotID).Exec()
+				return stepErr
+			},
+			func() error {
+				_, stepErr := tx.DeleteFrom("robot").Where("robot_id=?", robotID).Exec()
+				return stepErr
+			},
+			func() error {
+				_, stepErr := tx.DeleteFrom("app").Where("app_id=?", robotID).Exec()
+				return stepErr
+			},
+		}
+		for _, step := range steps {
+			if err = step(); err != nil {
+				_ = tx.Rollback()
+				break
+			}
+		}
+		if err == nil {
+			if err = tx.Commit(); err == nil {
+				return nil
+			}
+		}
+	}
+
+	cleanupErr := err
+	failClosedStatements := []struct {
+		query string
+		args  []interface{}
+	}{
+		{
+			query: "UPDATE robot SET status=0, username='', token='', bot_token='' WHERE robot_id=?",
+			args:  []interface{}{robotID},
+		},
+		{query: "UPDATE user SET status=0 WHERE uid=? AND robot=1", args: []interface{}{robotID}},
+		{query: "UPDATE space_member SET status=0 WHERE uid=?", args: []interface{}{robotID}},
+		{query: "UPDATE app SET status=0, app_key='' WHERE app_id=?", args: []interface{}{robotID}},
+	}
+	for _, statement := range failClosedStatements {
+		if _, updateErr := d.session.UpdateBySql(statement.query, statement.args...).Exec(); updateErr != nil {
+			cleanupErr = errors.Join(cleanupErr, updateErr)
+		}
+	}
+	return cleanupErr
 }
 
 func (d *botfatherDB) queryUserNamesByUsernames(usernames []string) (map[string]string, error) {

--- a/modules/botfather/db.go
+++ b/modules/botfather/db.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/db"
@@ -94,6 +93,8 @@ func (d *botfatherDB) queryRobotsByCreatorUIDAndSpaceID(creatorUID, spaceID stri
 // Space must exist; LIMIT 2 distinguishes unique from ambiguous without
 // relying on row order.
 func (d *botfatherDB) resolveAuthorizedCreationSpace(creatorUID, selectedSpaceID string) (string, error) {
+	// Bot provisioning intentionally treats an account in the deletion cooling-off
+	// period as inactive, even though ordinary messaging remains available.
 	const activeMembershipSQL = `
 		SELECT sm.space_id
 		FROM user u
@@ -130,18 +131,16 @@ func (d *botfatherDB) resolveAuthorizedCreationSpace(creatorUID, selectedSpaceID
 }
 
 // bindCreatedBotToSpace is the final authorization check and membership write.
-// Locking the three authority rows before the INSERT prevents a stale preflight
-// decision from authorizing the commit after a concurrent disable/removal.
-func (d *botfatherDB) bindCreatedBotToSpace(creatorUID, robotID, spaceID string) (retErr error) {
+// Lock in user -> space -> space_member order; future transactions must not lock
+// a Space member before its parent Space. Locking the authority rows before the
+// INSERT prevents a stale preflight decision from authorizing the commit after a
+// concurrent disable/removal.
+func (d *botfatherDB) bindCreatedBotToSpace(creatorUID, robotID, spaceID string) error {
 	tx, err := d.session.Begin()
 	if err != nil {
 		return fmt.Errorf("begin Bot Space binding: %w", err)
 	}
-	defer func() {
-		if retErr != nil {
-			_ = tx.Rollback()
-		}
-	}()
+	defer tx.RollbackUnlessCommitted()
 
 	var creator struct {
 		Status    int
@@ -183,11 +182,11 @@ func (d *botfatherDB) bindCreatedBotToSpace(creatorUID, robotID, spaceID string)
 		return fmt.Errorf("lock Bot creator membership: %w", err)
 	}
 
-	now := time.Now()
-	result, err := tx.InsertInto("space_member").
-		Columns("space_id", "uid", "role", "status", "created_at", "updated_at").
-		Values(spaceID, robotID, 0, 1, now, now).
-		Exec()
+	result, err := tx.InsertBySql(
+		"INSERT INTO space_member (space_id, uid, role, status, created_at, updated_at) VALUES (?, ?, 0, 1, NOW(), NOW())",
+		spaceID,
+		robotID,
+	).Exec()
 	if err != nil {
 		return fmt.Errorf("insert Bot Space membership: %w", err)
 	}
@@ -205,15 +204,19 @@ func (d *botfatherDB) bindCreatedBotToSpace(creatorUID, robotID, spaceID string)
 }
 
 // deleteCreatedBotArtifacts compensates a failed post-core Space binding. The
-// hard delete clears every newly-created credential-bearing row atomically.
+// hard delete clears every newly-created credential-bearing row atomically. The
+// creator UID confines friendship cleanup to the two newly-created pair rows,
+// preserving the friend table's (uid, to_uid) index access path.
 // If that transaction fails, best-effort fail-closed updates disable the Bot
 // and blank credentials so cleanup failure cannot leave a usable active Bot.
-func (d *botfatherDB) deleteCreatedBotArtifacts(robotID string) error {
+func (d *botfatherDB) deleteCreatedBotArtifacts(creatorUID, robotID string) error {
 	tx, err := d.session.Begin()
 	if err == nil {
 		steps := []func() error{
 			func() error {
-				_, stepErr := tx.DeleteFrom("friend").Where("uid=? OR to_uid=?", robotID, robotID).Exec()
+				_, stepErr := tx.DeleteFrom("friend").
+					Where("(uid=? AND to_uid=?) OR (uid=? AND to_uid=?)", creatorUID, robotID, robotID, creatorUID).
+					Exec()
 				return stepErr
 			},
 			func() error {


### PR DESCRIPTION
## Summary

Harden the conversational BotFather `/newbot` flow so the server, rather than
the WuKongIM payload, is authoritative for Bot-to-Space binding. This closes a
P0 cross-Space object-level authorization gap and makes creation fail closed
when binding cannot be proven or committed.

## Related Issue

N/A — production incident identifiers are intentionally omitted.

## Linked Spec

`.octospec/tasks/botfather-space-binding-hardening/brief.md`

## Changes

- Treat payload/channel `space_id` as an untrusted selector and require an
  active creator, active Space, and active creator membership before creating
  durable Bot artifacts.
- Allow selector fallback only when the creator has exactly one active Space;
  reject zero or multiple candidates instead of choosing an arbitrary row.
- Revalidate authority under row locks and insert the Bot membership in the
  same transaction, requiring exactly one inserted row.
- Compensate failed core creation or Space binding by deleting newly created
  artifacts; if deletion fails, disable the Bot and blank credential-bearing
  fields as a fail-closed fallback.
- Keep the existing generic localized failure reply and low-cardinality,
  identifier-free security logs.
- Add MySQL-backed regression coverage, a BotFather message-flow E2E test,
  OctoSpec task context, journal, and changelog entry.

## Testing

- [x] Unit/integration/E2E tests added and updated
- [x] Manually verified with local MySQL, Redis, and WuKongIM containers
- `go test ./modules/botfather/... -count=1 -coverprofile=...` — PASS with a
  synthetic test-only master key. Package coverage: 40.4% statements; changed
  load-bearing functions: 88.6%, 100.0%, 80.6%, and 96.2%.
- Focused `go test -race` for the new authorization, compensation, and E2E
  targets — PASS.
- `go vet ./modules/botfather/...` — PASS.
- `golangci-lint run ./modules/botfather/...` — PASS, 0 issues.
- `make i18n-extract-check && make i18n-lint` — PASS.
- Verified no residual test trigger, synthetic Bot/user rows, or BotFather
  Redis state; redaction scan found no production identifier or credential.

## COMPREHENSION

1. **What does this change actually do** to the load-bearing path?

   The creation path now uses the inbound Space ID only to select a candidate.
   It first checks current database authority, creates the core Bot artifacts,
   then locks the creator, Space, and creator membership rows and repeats the
   authorization decision in the membership transaction. A successful command
   therefore requires a committed active Bot membership in an authorized Space;
   a failed write is no longer logged and ignored.

2. **What could break** because of it (dependents + failure mode)?

   Legacy clients that omit `space_id` while the creator belongs to multiple
   active Spaces will now receive the existing generic creation failure instead
   of an arbitrary binding; clients should send the selected Space ID. Mixed
   old/new replicas remain vulnerable because an old replica can still process
   `/newbot`, so rollout must drain old replicas or temporarily disable the flow.
   An emergency binary rollback reopens the write boundary and must also block
   conversational Bot creation until a corrected build is active.

3. **How do you know it works** (specific test/repro/trace)?

   Regression tests exercise forged, nonexistent, inactive, removed, missing,
   ambiguous, authorized, query-failure, concurrent-authority-change, core
   persistence failure, membership insertion failure, and compensation paths
   against real MySQL rows. The E2E test drives the BotFather message state
   machine for both rejected and authorized selectors, then verifies the
   persisted membership and `/mybots` query-path isolation from another Space.
   Focused race detection and all BotFather package tests pass.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] PR description is in English
- [x] Added tests for my changes
- [x] Updated documentation
- [x] Followed commit message conventions (Conventional Commits)
