### PR TITLE
fix(authz): gate public profile reads on the system-bot whitelist

### DIFF
--- a/.octospec/journal/shared/profile-visibility-system-bot-whitelist.md
+++ b/.octospec/journal/shared/profile-visibility-system-bot-whitelist.md
@@ -1,0 +1,131 @@
+---
+type: Journal
+title: "Journal: profile-visibility-system-bot-whitelist"
+description: The shared person-profile visibility decision now takes its public-bot exemption from the pkg/space.SystemBots whitelist instead of the writable user.category column, so a category=system row that is not a system bot no longer bypasses the relationship check.
+tags: ["user", "channel", "auth", "acl", "space", "isolation", "trust-boundary", "security", "wire-contract", "test"]
+timestamp: 2026-08-12T12:10:00+08:00
+task: profile-visibility-system-bot-whitelist
+upstream: internal follow-up to channel-get-object-authz (PR #722)
+source: self
+---
+
+# profile-visibility-system-bot-whitelist
+
+## What was done
+
+- `PersonProfileInput.SystemAccount` became `SystemBot`, and the two call sites
+  (`modules/user/api.go` `u.get`, `modules/channel/api.go`
+  `personProfileVisible`) now populate it with `spacepkg.IsSystemBot(uid)`
+  instead of `Category == CategorySystem || Category == CategoryCustomerService`.
+- The field documentation states the constraint directly: the caller must use
+  the whitelist and must not use `category`. The rename exists because the old
+  name invited exactly the wiring that caused the defect.
+- The decision itself stays in `modules/channel/service` (zero-dependency leaf
+  package), so `GET /v1/users/:uid` and the PERSON branch of
+  `GET /v1/channels/:id/:type` cannot drift apart.
+- Two tests inherited from `channel-get-object-authz` had asserted the defective
+  behavior (`category=system` implies a full profile). They were rewritten to the
+  whitelist contract, and a reverse regression was added on both endpoints.
+
+## Load-bearing decisions
+
+- `user.category` has exactly two values, `system` and `customerService`
+  (`modules/user/const.go`). The prior predicate covered both, so the defect was
+  purely over-broad; an earlier claim during review that it also missed
+  `service`/`service_notice` categories was wrong and is corrected in the brief.
+- The account that made this reachable is the superuser seeded by
+  `newManagerSeedModel`: `category=system`, `role=superAdmin`, `robot=0`, and a
+  fixed guessable UID. Its build entry is intentionally unchanged, because
+  `category` remains legitimate as a display and classification attribute; only
+  its use as an authorization input is removed.
+- No material disclosure was reproduced, and the change is recorded as a
+  narrowing of the authorization input rather than an incident fix. The two
+  endpoints do **not** share the same exposure surface, and conflating them was
+  the main error in the first drafts of this record, so they are stated
+  separately here.
+- `GET /v1/users/:uid`: a stranger saw `category=system` as the only populated
+  field beyond the minimal set. The reason is not that the row is empty —
+  `newManagerSeedModel` writes `Name: "超级管理员"` and `ShortNo: "30000"` — it is
+  that `modules/user/api.go:1431-1436` blanks `ShortNo` and `Vercode` unless
+  `Follow == 1` or the caller is the target.
+- `GET /v1/channels/:id/:type` (PERSON) has **no such blanking**. The response is
+  built by `newChannelRespWithUserDetailResp` (`modules/user/1module.go:189-217`),
+  where `extraMap["short_no"] = user.ShortNo` is unconditional and nothing in
+  `modules/channel/api.go` clears it afterwards. So before this change, a caller
+  with no relationship did receive the superuser's `extra.short_no = "30000"`
+  along with `online` / `last_offline` / `device_flag` / `sex` / `source_desc` /
+  `category`. That surface was missing from the first drafts, which cited the
+  `u.get` blanking as if it covered both endpoints.
+- Two further claims raised in review were checked and **disproved**, recorded so
+  they are not carried forward: `username = "superAdmin"` never reached the wire,
+  because `NewUserDetailResp` (`modules/user/service.go:1554-1556`) gates it on
+  `m.Robot == 1` and the superuser is `robot=0`, with
+  `model.ChannelResp.Username` being `omitempty`; and `extra.vercode` was never
+  disclosed to a stranger, because `service.go:509-524` assigns it only when
+  `friend != nil && friend.IsDeleted == 0` — and where a friend relation exists,
+  the `Followed` leg already granted visibility independently of this predicate.
+- The conclusion therefore stands with a corrected basis: phone, email, and zone
+  are self-only on both paths via `self := loginUID == m.UID`; the extra field the
+  channel endpoint did hand out is a short number hardcoded as a public seed
+  value in this open-source repository (`modules/user/api_manager.go:1606`),
+  carrying neither PII nor a capability.
+- The assertions in the new tests use the JSON-key form (`"short_no":`) rather
+  than a bare substring, so they match what the record claims they are: `short_no`
+  carries no `omitempty` (`modules/user/service.go:1467`), the channel full path
+  inserts the key unconditionally, and neither `minimalUserDetailResp` nor
+  `MinimalChannelResp` declares it — the assertion is about response *shape*. The
+  looser bare-substring form inherited from `channel-get-object-authz` is left
+  untouched in that task's own cases.
+- The residual value is defense in depth: the moment anyone seeds a populated
+  `category=system` display account, or `customerService` starts being used, the
+  old predicate would have silently become a real disclosure surface.
+- `fileHelper` is whitelisted but carries `robot=0`
+  (`modules/user/sql/20191106000003_user_legacy01.sql`), so it is the correct
+  fixture for proving the whitelist leg rather than the robot leg. `u_10000`
+  would have passed through the pre-existing `Robot` branch and proven nothing.
+- `customerService` rows now fall back to the relationship check. If such an
+  account must stay publicly readable, the supported route is the whitelist or
+  `robot=1`, not another category shortcut.
+- `SystemBots` stays a four-entry hardcoded map. Making it configuration- or
+  DB-driven is deliberately deferred; the existing comment in
+  `pkg/space/query.go` already reserves that path.
+
+## Verification
+
+- `go build ./...` and `go vet ./modules/channel/service/ ./modules/channel/
+  ./modules/user/` pass, the latter compiling the integration test files and so
+  confirming no stale references to the renamed field.
+- Focused integration runs pass against local MySQL, Redis, and WuKongIM:
+  `TestUserGet_SystemBot_Viewable`,
+  `TestUserGet_SystemCategoryNotWhitelisted_Minimal`,
+  `TestChannelGet_Person_SystemBot_Viewable`, and
+  `TestChannelGet_Person_SystemCategoryNotWhitelisted_Minimal`.
+- No regression in the authorization matrix established by the prior task:
+  `go test ./modules/user/ -run TestUserGet` and `go test ./modules/channel/
+  ./modules/channel/service/ -run 'TestChannelGet|TestMinimalChannelResp|TestPersonProfileVisible|TestNewMinimalChannelResp'`
+  are green, covering the no-relation, common-group, bot, same-Space,
+  cross-Space, and topic branches.
+- All focused runs were repeated after rebasing onto `origin/main`, which had
+  advanced by `#741` and `#742`; `#741` touches the same file
+  (`modules/user/api.go`) in the login-audit region and the rebase was clean.
+- Two environment prerequisites surfaced and are not caused by this change: the
+  shared `test` schema retains migration rows written by other workspaces and
+  needs a drop and recreate with an explicit `utf8mb4_general_ci` collation per
+  test package, and the `modules/channel` package requires a 32-byte
+  `OCTO_MASTER_KEY` when it mounts `modules/common`.
+- `make i18n-extract-check` and `make i18n-lint` were not rerun. No error code,
+  `httperr` call site, or locale file is touched, so no new marker or
+  translation is expected; CI remains the gate for that claim.
+
+## Rollout and rollback
+
+- No schema change, migration, configuration flag, or environment variable. The
+  change is behavioral only and takes effect on deploy.
+- The only observable wire change is for callers with no relationship to a
+  non-whitelisted `category=system` account: the response narrows from the full
+  shape to the established minimal set. That account is not a conversation peer
+  and carries no client-rendered business data, so no client impact is expected.
+- Rollback is a plain revert of the commit; nothing persists that would need
+  repair afterwards.
+- Worth watching after deploy: any client error concentrated on profile reads of
+  the superuser UID would indicate an unexpected consumer of that full shape.

--- a/.octospec/log.md
+++ b/.octospec/log.md
@@ -4,6 +4,32 @@ Change history for this repo's `.octospec/`, following the
 [OKF](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md)
 change-log convention (§7). Newest first.
 
+## 2026-08-12 (profile-visibility-system-bot-whitelist)
+
+- **Task** — `profile-visibility-system-bot-whitelist`: took the public-bot
+  exemption in the shared person-profile visibility decision off the writable
+  `user.category` column and put it on the `pkg/space.SystemBots` whitelist, so a
+  `category=system` row that is not a system bot — the superuser account, which
+  has a fixed guessable UID — no longer skips the Space, friend, and common-group
+  legs. The input field was renamed `SystemAccount` to `SystemBot` to close the
+  wiring that caused the defect, and both endpoints moved together. Recorded as a
+  narrowing of the authorization input, not an incident fix: no material
+  disclosure was reproduced. The two endpoints differ, and the record states them
+  separately — `/v1/users/:uid` withheld the short number via the `Follow` gate at
+  `modules/user/api.go:1431-1436`, while `/v1/channels/:id/:type` has no such gate
+  and did hand a stranger the superuser's `extra.short_no` plus online state. That
+  value is a public seed constant in this repository and carries no PII and no
+  capability; `username` and `vercode` were checked and never reached a stranger.
+  Two inherited tests had asserted the defective behavior and were rewritten, with
+  reverse regressions added on both endpoints for `system` and `customerService`.
+  **Operators upgrading**: any human support account sitting on
+  `category=customerService` with `robot=0` degrades to the minimal profile set on
+  deploy; `SystemBots` is a compile-time literal, so the supported remedies are
+  adding the UID to that whitelist, marking the account `robot=1`, or relying on a
+  normal relationship path. Focused MySQL-backed runs and the prior authorization
+  matrix pass, before and after rebase. See
+  [journal](journal/shared/profile-visibility-system-bot-whitelist.md).
+
 ## 2026-08-12 (botfather-space-binding-hardening)
 
 - **Task** — `botfather-space-binding-hardening`: made the server authoritative

--- a/.octospec/tasks/profile-visibility-system-bot-whitelist/brief.md
+++ b/.octospec/tasks/profile-visibility-system-bot-whitelist/brief.md
@@ -1,0 +1,179 @@
+---
+type: Task
+title: "Task: profile-visibility-system-bot-whitelist"
+description: Narrow the person-profile "system account" fast-path from the writable user.category column to the explicit pkg/space.SystemBots whitelist, so a category=system row that is not a system bot (the admin superuser) no longer bypasses the relationship check.
+tags: ["auth", "acl", "isolation", "wire-contract", "test"]
+timestamp: 2026-08-12T04:03:02Z
+# --- octospec extension fields ---
+slug: profile-visibility-system-bot-whitelist
+upstream: internal follow-up to channel-get-object-authz (PR #722); reported as "任意用户资料批量泄露" on GET /v1/users/admin
+source: self
+---
+
+# Task: profile-visibility-system-bot-whitelist
+
+## Goal
+
+`channel-get-object-authz`（PR #722）给 `GET /v1/users/:uid` 与
+`GET /v1/channels/:id/:type`(PERSON) 补齐了对象级授权，其中"系统账号恒可见"这条
+身份放行用的是**用户表的 `category` 字段**：
+
+```go
+SystemAccount: userDetailResp.Category == CategorySystem || userDetailResp.Category == CategoryCustomerService,
+```
+
+该字段与"是否公开系统 Bot"并不等价。`pkg/space.SystemBots` 才是仓库里"所有 Space
+可见的系统级 Bot"的权威定义（`botfather` / `u_10000` / `fileHelper` /
+`notification`），而 `category` 是一个可被建号代码与运维写入的普通列——
+`newManagerSeedModel`（`modules/user/api_manager.go:1602`）给**超管 admin 账号**
+写的就是 `Category: "system"`，且 `Role: superAdmin`、`robot=0`、不在白名单。
+
+后果：`admin` 是固定可猜 UID，任意登录用户拿它即可命中 `SystemAccount` 短路，
+**跳过 Space / 好友 / 共同群三腿关系检查**，拿到完整资料形状而非最小集。
+
+本次把两端的判定输入从 `category` 换成 `spacepkg.IsSystemBot(uid)` 白名单，并把
+共享判定结构体的字段 `SystemAccount` 改名为 `SystemBot`，在契约文档里写明「必须用
+白名单、禁止用 category 回填」。
+
+## Background
+
+### 实际影响（如实评估，未夸大；**逐端点**分开陈述）
+
+两个端点的暴露面**不同**，早前把它们混为一谈是本 brief 的主要错误来源，故按端点拆开。
+
+**`GET /v1/users/:uid`（admin 实测 200，32 字段）**
+
+- 陌生人视角下超出最小资料集的字段里只有 `category=system` 有值。成因**不是**该行为空
+  ——`newManagerSeedModel`（`modules/user/api_manager.go:1602`）写了
+  `Name: "超级管理员"` 与 `ShortNo: "30000"`。真正的原因是 `modules/user/api.go:1431-1436`
+  在 `Follow != 1 && 非本人` 时把 `ShortNo` 与 `Vercode` 清空。
+
+**`GET /v1/channels/:id/:type`（PERSON，同一预置，本次一并修复的第二个出口）**
+
+- 该端点**没有**上面那道清空。响应经 `newChannelRespWithUserDetailResp`
+  （`modules/user/1module.go:189-217`）构造，`extraMap["short_no"] = user.ShortNo`
+  无条件写入，`grep short_no modules/channel/api.go` 无任何后置清空。
+- 因此修复前，任意登录用户对无关系目标 `GET /v1/channels/admin/1` **确实拿到了**
+  `extra.short_no="30000"`，以及 `online` / `last_offline` / `device_flag` / `sex` /
+  `source_desc` / `category`。**这是原 brief 漏掉的暴露面。**
+
+**两项经核实**否证**的指控**（review 曾提出，实测不成立，记录在此避免后人沿用）：
+
+- `username="superAdmin"` **未**上 wire：`NewUserDetailResp`（`modules/user/service.go:1554-1556`）
+  有门禁 `if m.Robot == 1 { username = m.Username }`，而 admin 是 `robot=0`，故
+  `UserDetailResp.Username` 为空；`model.ChannelResp.Username` 又是 `omitempty`。
+- `extra.vercode` **未**泄露给陌生人：`service.go:509-524` 仅在
+  `friend != nil && friend.IsDeleted == 0` 时才赋 `vercode`，陌生人恒为空；种子 admin
+  本身也没有 `Vercode`。故不存在"加好友能力被泄露"这一腿——真要有好友关系，
+  `Followed` 腿本来就放行，与本次收紧无关。
+
+**结论（维持"无实质数据泄露"，但理由据上修正）**
+
+- 手机 / 邮箱 / 区号**不在暴露面内**——`NewUserDetailResp` 的 `self := loginUID == m.UID`
+  两端一致挡住。
+- channel 端点确实多给了超管的 `short_no="30000"` 与在线态，但该短号是**公开仓库里
+  写死的默认种子值**（`api_manager.go:1606`），读源码即知，泄露价值近似为零；且不含
+  PII、不含能力（vercode）。
+- 枚举价值极低：`admin` 可猜，但"存在 admin 超管"本身是公开常识。
+
+因此定位仍是 **P2 口径一致性加固 / 纵深防御**，不触发披露流程；但"陌生人拿不到短号"
+这句话**只对 `/v1/users/:uid` 成立**，不能用来描述本 PR 修的第二个端点。
+
+之所以仍要做：
+
+1. `category` 是可写、语义宽泛的展示字段，把它当授权输入违背"公开可见=显式白名单"
+   原则。今天 admin 的字段恰好没有敏感值所以无害；将来只要有人建一个 `category=system` 的
+   非白名单展示号、或 `customerService` 号被启用并填上资料，这个宽口径就会**无声
+   变成**真实泄露面。
+2. 白名单让"公开可见"成为必须显式声明的动作，可枚举、可 review。
+
+**一处需要纠正的先前说法**：本人曾在讨论中称"原判定漏掉了 `service` /
+`service_notice` 等类别"。核实 `modules/user/const.go` 后确认**该说法不成立**：
+category 只有 `system` 与 `customerService`（camelCase）两个取值，原判定覆盖了全部
+取值。问题**只是过宽，不存在过窄**。
+
+### 为什么改字段名而不只换判定
+
+`SystemAccount` 这个名字本身就在诱导"用 category 填它"——这正是本 bug 的复发入口。
+改名为 `SystemBot` + 在字段注释里写死「必须由调用方用 `spacepkg.IsSystemBot(uid)`
+判定」，让下一个改这里的人无法自然地把 category 塞回来。多出的 diff 只是几行，
+换来的是防复发。
+
+### 行为不回退的依据
+
+- 白名单内 `robot=0` 的成员（`fileHelper`，见
+  `modules/user/sql/20191106000003_user_legacy01.sql:55`）仍由 `SystemBot` 分支放行，
+  不依赖 `Robot` 分支——这是本次专门用 `fileHelper` 而非 `u_10000`（`robot=1`）
+  写测试的原因：确保命中的是白名单腿。
+- 普通 bot（`robot==1`）仍走既有 `Robot` 分支，与"查看资料 ≠ 已可交互"的既定产品
+  事实一致。
+- `customerService` 账号随之回落到关系检查。这是本次**有意的**收紧：若产品确需客服号
+  对所有人公开资料，正道是把该号纳入白名单或设 `robot=1`，而不是再加一条 category
+  短路。当前库中未发现启用中的 `customerService` 账号。
+
+## Load-bearing list
+
+- `auth` / `acl` / `isolation` — 单聊资料的对象级可见性判定本身。判定收口在
+  `modules/channel/service`（零依赖叶子包）供两端共用，本次两个调用方必须同步改，
+  否则一边放宽即静默重开同一越权面。
+- `wire-contract` — 对**无关系调用方**而言，非白名单 `category=system` 账号
+  （即 admin）的响应从完整形状收窄为最小集。该账号不承载任何客户端业务渲染
+  （空号、非会话对端），故判定为无客户端影响；白名单系统 Bot 与普通 bot 的响应形状
+  不变。
+- `test` — `channel-get-object-authz` 留下的两个用例
+  （`TestUserGet_SystemAccount_Viewable` /
+  `TestChannelGet_Person_SystemAccount_Viewable`）把**有缺陷的行为**编码进了断言
+  （断言 `category=system` 即可见完整资料），修复后必然失败，必须改写为正确契约并
+  补反向回归。
+
+## Out of scope
+
+- **不**把 `SystemBots` 改成配置 / DB 驱动。当前 4 个硬编码够用，`pkg/space/query.go`
+  注释已留future 口子；现在做属过度设计。
+- **不**改动最小资料集的字段策略（`newMinimalUserDetailResp` /
+  `NewMinimalChannelResp` 白名单不动），也不改 `real_name` 对外可见性——沿用 #722 的
+  既定政策。
+- **不**改成 403/404：保留最小集（`uid`/`name`/`follow` + 调用方自身状态）以免客户端
+  渲染裂图，与 #722 的分级降级设计一致。
+- **不**动其它 `GetUserDetail` 复用点（群邀请人富化 `modules/user/api.go:1384`、
+  `modules/user/1module.go:65` 的 datasource）——它们不经过本短路。
+- **不**改超管账号的建号逻辑（`newManagerSeedModel` 仍写 `category=system`）：
+  category 作为**展示/分类**字段的用途正当，本次只是不再拿它做授权。
+
+## Acceptance
+
+- [x] 两端判定输入改为 `spacepkg.IsSystemBot(uid)`；共享字段更名为 `SystemBot`，
+      注释写明禁止用 category 回填。
+- [x] 白名单系统 Bot（`fileHelper`，`robot=0`）无任何关系时仍返回完整资料
+      （断言含 `short_no`）——两端各一例：
+      `TestUserGet_SystemBot_Viewable`、`TestChannelGet_Person_SystemBot_Viewable`。
+- [x] **反向回归**：`category=system` 但非白名单账号（admin 同类）无关系时降级为
+      最小集（断言**不含** `short_no`）——两端各一例：
+      `TestUserGet_SystemCategoryNotWhitelisted_Minimal`、
+      `TestChannelGet_Person_SystemCategoryNotWhitelisted_Minimal`。
+- [x] 被移除判定的另一半 `customerService` 同样上锁（两端各一例：
+      `TestUserGet_CustomerServiceCategoryNotWhitelisted_Minimal`、
+      `TestChannelGet_Person_CustomerServiceCategoryNotWhitelisted_Minimal`）。
+      仓库无任何代码路径写该 category，故无种子可依赖，这两条断言是防止它被悄悄加回
+      放行集的唯一保险。
+- [x] 共享判定单测的身份放行子用例由 `system_account` 更名为 `system_bot`
+      （`modules/channel/service/profile_visibility_test.go`）。
+- [x] 无回归：`go test ./modules/user/ -run TestUserGet` 与
+      `go test ./modules/channel/ -run 'TestChannelGet|TestMinimalChannelResp'` 全绿
+      （含 NoRelation / CommonGroup / Bot / SameSpace / CrossSpace / Topic 等
+      #722 建立的授权矩阵）。
+- [x] `go build ./...`、`go vet ./modules/channel/service/ ./modules/channel/ ./modules/user/` 通过。
+- [ ] 不涉及新增错误码 / 响应信封改动，故 `make i18n-extract-check` /
+      `make i18n-lint` 无新增项（未重跑，本次未触碰 `pkg/errcode` 与
+      `httperr` 调用点）。
+
+### 本地验证记录（2026-08-12）
+
+在本地容器环境（MySQL 3306 / Redis 6379 / WuKongIM 5001）实跑，上述集成用例全绿。
+过程中两处**环境**前置（非本改动引入）：
+
+- 共享 `test` 库残留其它 workspace 的迁移记录 → `unknown migration` panic，需
+  drop & recreate（显式 `COLLATE utf8mb4_general_ci`）；且包间迁移集不同，
+  每个测试包前需重建。
+- `modules/channel` 测试包启动挂载 `modules/common` 时要求
+  `OCTO_MASTER_KEY`（恰好 32 字节），测试时注入。

--- a/.octospec/tasks/profile-visibility-system-bot-whitelist/context.yaml
+++ b/.octospec/tasks/profile-visibility-system-bot-whitelist/context.yaml
@@ -1,0 +1,57 @@
+schema_version: 1
+task: profile-visibility-system-bot-whitelist
+brief: .octospec/tasks/profile-visibility-system-bot-whitelist/brief.md
+resolved_at: 2026-08-12T12:10:00+08:00
+
+injected_rules:
+  - id: space-isolation
+    source: repo
+    load_bearing: true
+    why: >
+      The change is the object-level read boundary itself. The person-profile
+      fast path decided visibility from a writable user column, letting a
+      guessable UID bypass the Space, friend, and common-group legs. Both
+      endpoints now derive the public-bot exemption from an explicit whitelist.
+  - id: error-handling
+    source: repo
+    load_bearing: false
+    why: >
+      No new error code, envelope, or status. Unrelated callers keep receiving a
+      200 with the established minimal profile set rather than a rejection, so
+      client rendering of historical senders does not break.
+  - id: trust-boundary
+    source: repo
+    load_bearing: true
+    why: >
+      user.category is an operator- and seed-writable display attribute. Treating
+      it as an authorization signal made the superuser row publicly readable;
+      pkg/space.SystemBots is the only enumerable definition of a publicly
+      visible bot.
+  - id: rate-limit
+    source: repo
+    load_bearing: false
+    why: >
+      No route or limiter change. Both endpoints keep the SharedUIDRateLimiter
+      mounted by the prior object-authz task; tests reset ratelimit:uid:* in
+      setup as that task established.
+  - id: testing
+    source: repo
+    load_bearing: true
+    why: >
+      Two existing cases had encoded the defective behavior as assertions and had
+      to be rewritten rather than kept green. The reverse regression pins the
+      narrowing: a category=system row outside the whitelist degrades to the
+      minimal set on both endpoints.
+  - id: commit-style
+    source: repo
+    load_bearing: false
+    why: >
+      Single English Conventional Commit subject with a prose body, matching the
+      surrounding history.
+
+security_notes:
+  - No production identifier, hostname, credential, or token appears in the
+    brief, journal, tests, or commit message.
+  - The superuser account is referred to by its fixed public UID only; no
+    password, role grant, or session material is described.
+  - Tests use synthetic UIDs plus the migration-seeded fileHelper bot.

--- a/modules/channel/api.go
+++ b/modules/channel/api.go
@@ -317,13 +317,14 @@ func (ch *Channel) channelGet(c *wkhttp.Context) {
 // modules/channel/service（与 /v1/users/:uid 共用，避免两端口径漂移）；这里只负责把
 // 本模块能看到的目标属性翻译成该函数的输入。
 func (ch *Channel) personProfileVisible(loginUID string, peerID string, resp *model.ChannelResp) (bool, error) {
-	// 身份类放行（本人 / webhook / bot / 系统账号）不需要查关系，先判定；只有都不命中
-	// 才付出 HasAuthzRelation 的查询代价。
+	// 身份类放行（本人 / webhook / bot / 系统 Bot）不需要查关系，先判定；只有都不命中
+	// 才付出 HasAuthzRelation 的查询代价。系统 Bot 走 pkg/space.SystemBots 白名单，不看
+	// category 字段——category=system 的非白名单账号必须回落到关系检查，避免整份身份泄露。
 	fastPath := chservice.PersonProfileInput{
 		LoginUID:          loginUID,
 		PeerUID:           peerID,
 		SyntheticIdentity: strings.HasPrefix(peerID, user.WebhookUIDPrefix),
-		SystemAccount:     resp.Category == user.CategorySystem || resp.Category == user.CategoryCustomerService,
+		SystemBot:         spacepkg.IsSystemBot(peerID),
 		Robot:             resp.Robot == 1,
 	}
 	if visible, err := chservice.PersonProfileVisible(fastPath, nil); err != nil || visible {

--- a/modules/channel/channel_get_authz_test.go
+++ b/modules/channel/channel_get_authz_test.go
@@ -346,8 +346,27 @@ func TestChannelGet_Person_SameSpace_Full(t *testing.T) {
 	assert.Contains(t, w.Body.String(), "short_no", "同 Space 可直接聊天，资料应完整下发")
 }
 
-// PERSON 系统账号：无需任何关系即可查看（category=system / customerService）。
-func TestChannelGet_Person_SystemAccount_Viewable(t *testing.T) {
+// PERSON 系统 Bot：pkg/space.SystemBots 白名单里的账号无需任何关系即可查看完整资料。
+// 用 robot=0 的 fileHelper（而非 robot=1 的 u_10000），确保命中 SystemBot 分支而非 Robot
+// 分支——CleanAllTables 已清掉迁移预置的 fileHelper，这里重新建号无冲突。
+func TestChannelGet_Person_SystemBot_Viewable(t *testing.T) {
+	s, ctx := newChannelAuthzServer(t)
+	defer testutil.CleanAllTables(ctx)
+
+	assert.NoError(t, user.NewService(ctx).AddUser(&user.AddUserReq{
+		UID: "fileHelper", Name: "SystemBot", ShortNo: "SNSYSBOT",
+	}))
+
+	w := getChannel(s, "fileHelper", common.ChannelTypePerson.Uint8())
+
+	assert.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+	assert.Contains(t, w.Body.String(), "SystemBot")
+	assert.Contains(t, w.Body.String(), `"short_no":`, "白名单系统 Bot 资料应完整可查，不被降级为最小集")
+}
+
+// 回归（本次收紧的核心）：category=system 但**不在** SystemBots 白名单的账号（如 admin
+// 超管号）不再享受系统放行，无可见关系时必须降级为最小集，不得整份下发身份字段。
+func TestChannelGet_Person_SystemCategoryNotWhitelisted_Minimal(t *testing.T) {
 	s, ctx := newChannelAuthzServer(t)
 	defer testutil.CleanAllTables(ctx)
 
@@ -359,8 +378,26 @@ func TestChannelGet_Person_SystemAccount_Viewable(t *testing.T) {
 	w := getChannel(s, "t_sysacct", common.ChannelTypePerson.Uint8())
 
 	assert.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
-	assert.Contains(t, w.Body.String(), "SystemAccount")
-	assert.Contains(t, w.Body.String(), "short_no", "系统账号资料应完整可查，不被降级为最小集")
+	assert.NotContains(t, w.Body.String(), `"short_no":`,
+		"非白名单的 category=system 账号无关系时必须降级为最小集，不得泄露身份字段")
+}
+
+// 同上，锁住被移除判定的另一半：`customerService` 也不再享受身份放行（两端对称，
+// 一边漏掉就会静默重开同一越权面）。
+func TestChannelGet_Person_CustomerServiceCategoryNotWhitelisted_Minimal(t *testing.T) {
+	s, ctx := newChannelAuthzServer(t)
+	defer testutil.CleanAllTables(ctx)
+
+	assert.NoError(t, user.NewService(ctx).AddUser(&user.AddUserReq{
+		UID: "t_csacct", Name: "CustomerServiceAcct", ShortNo: "SNCSACCT",
+	}))
+	setUserCategory(t, ctx, "t_csacct", user.CategoryCustomerService)
+
+	w := getChannel(s, "t_csacct", common.ChannelTypePerson.Uint8())
+
+	assert.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+	assert.NotContains(t, w.Body.String(), `"short_no":`,
+		"customerService 账号无关系时同样必须降级为最小集")
 }
 
 // 最小集的 JSON 线上形状（判定与构造已收口到 modules/channel/service，纯逻辑分支在

--- a/modules/channel/service/profile_visibility.go
+++ b/modules/channel/service/profile_visibility.go
@@ -12,8 +12,12 @@ import "github.com/Mininglamp-OSS/octo-lib/model"
 // 静默重开同一个越权面。
 //
 // 本包是**零依赖叶子包**（modules/user 反向引用它，见 modules/user/api_friend.go），
-// 因此这里不 import modules/user / modules/incomingwebhook：合成身份前缀（iwh_）与
-// 系统/客服分类常量归那些上层模块所有，由调用方判定后以布尔传入。
+// 因此这里不 import modules/user / modules/incomingwebhook / pkg/space：合成身份前缀
+// （iwh_）与系统 Bot 白名单归那些包所有，由调用方判定后以布尔传入。
+//
+// 注意「系统账号」的判定来源：调用方必须传 pkg/space.SystemBots 的白名单结果，
+// **不是** user 表的 category 分类常量（后者曾是本判定的输入，正是被收紧掉的越权面，
+// 详见 SystemBot 字段注释）。
 
 // CommonGroupChecker 判定两个用户是否至少同属一个未解散的群。
 // 由 group 模块提供实现（channel 直接注入 groupService，user 走注册钩子）。
@@ -26,8 +30,14 @@ type PersonProfileInput struct {
 	// SyntheticIdentity：目标是展示专用合成身份（如 incoming webhook 的 iwh_ 前缀）。
 	// 这类身份没有隐私字段，保持完整以免展示层裂图。
 	SyntheticIdentity bool
-	// SystemAccount：系统 / 客服账号。
-	SystemAccount bool
+	// SystemBot：目标是 pkg/space.SystemBots 白名单里的系统 Bot（botfather / u_10000 /
+	// fileHelper / notification）——这些账号与 Space 无关，须对所有登录用户公开可见。
+	//
+	// 必须由调用方用**白名单**判定（spacepkg.IsSystemBot(uid)），**不要**用 user 表的
+	// category 字段（== "system" / "customerService"）：category 是可被运维/迁移写入的
+	// 普通字段（如固定可猜 UID 的 admin 超管号就是 category=system），用它放行会把非系统
+	// Bot 的账号整份身份泄露给任意登录用户——这正是本字段收紧前的越权面。
+	SystemBot bool
 	// Robot：目标是 bot。资料公开可查——用户要先看到 bot 才能决定是否添加；
 	// "查看资料" != "已可交互"，未加好友仍不能与 bot 对话。
 	Robot bool
@@ -41,7 +51,7 @@ type PersonProfileInput struct {
 }
 
 // PersonProfileVisible 判定调用方是否可见目标的完整资料。可见关系：
-// 本人 / 合成身份 / bot / 系统账号 / 已关注（好友或同 Space） / 共同群。
+// 本人 / 合成身份 / bot / 系统 Bot / 已关注（好友或同 Space） / 共同群。
 //
 // 共同群是最后一道判定，因为它是唯一需要查库的一项——外部群里跨 Space 的非好友成员
 // 既非好友也无共同 Space，仅靠共同群可达；不放行会让群内成员名/头像裂图。
@@ -55,7 +65,7 @@ func PersonProfileVisible(in PersonProfileInput, hasCommonGroup CommonGroupCheck
 	if in.LoginUID != "" && in.LoginUID == in.PeerUID {
 		return true, nil
 	}
-	if in.SyntheticIdentity || in.Robot || in.SystemAccount || in.Followed {
+	if in.SyntheticIdentity || in.Robot || in.SystemBot || in.Followed {
 		return true, nil
 	}
 	if hasCommonGroup == nil || in.LoginUID == "" {

--- a/modules/channel/service/profile_visibility_test.go
+++ b/modules/channel/service/profile_visibility_test.go
@@ -27,7 +27,7 @@ func TestPersonProfileVisible_EarlyAllowIdentities(t *testing.T) {
 		{"self", PersonProfileInput{LoginUID: "u1", PeerUID: "u1"}},
 		{"synthetic_identity", PersonProfileInput{LoginUID: "u1", PeerUID: "iwh_abc", SyntheticIdentity: true}},
 		{"bot", PersonProfileInput{LoginUID: "u1", PeerUID: "u2", Robot: true}},
-		{"system_account", PersonProfileInput{LoginUID: "u1", PeerUID: "u2", SystemAccount: true}},
+		{"system_bot", PersonProfileInput{LoginUID: "u1", PeerUID: "u2", SystemBot: true}},
 		{"followed", PersonProfileInput{LoginUID: "u1", PeerUID: "u2", Followed: true}},
 	}
 	for _, c := range cases {

--- a/modules/user/api.go
+++ b/modules/user/api.go
@@ -1299,13 +1299,15 @@ func (u *User) get(c *wkhttp.Context) {
 	// 判定与 /v1/channels/:id/:type 共用 channel/service，两端口径不会漂移。
 	// 与 channelGet 最小集的差异：这里**保留** follow —— 资料页要靠它渲染加好友入口，
 	// 省略会让"陌生人可加好友"这个正常入口消失（channelGet 是发送者渲染，不需要）。
-	// 身份类放行（本人 / bot / 系统账号）先判定，不命中才付关系查询的代价。
+	// 身份类放行（本人 / bot / 系统 Bot）先判定，不命中才付关系查询的代价。
 	// SyntheticIdentity 恒为 false：iwh_ 前缀在上方已提前 return，走不到这里。
+	// SystemBot 走 pkg/space.SystemBots 白名单，不看 category 字段——category=system 的
+	// 非白名单账号（如 admin 超管号）必须回落到关系检查，否则整份身份被任意用户读走。
 	fastPath := chservice.PersonProfileInput{
-		LoginUID:      loginUID,
-		PeerUID:       uid,
-		SystemAccount: userDetailResp.Category == CategorySystem || userDetailResp.Category == CategoryCustomerService,
-		Robot:         userDetailResp.Robot == 1,
+		LoginUID:  loginUID,
+		PeerUID:   uid,
+		SystemBot: spacepkg.IsSystemBot(uid),
+		Robot:     userDetailResp.Robot == 1,
 	}
 	visible, err := chservice.PersonProfileVisible(fastPath, nil)
 	if err == nil && !visible {

--- a/modules/user/user_get_authz_test.go
+++ b/modules/user/user_get_authz_test.go
@@ -221,8 +221,26 @@ func TestUserGet_Bot_Viewable(t *testing.T) {
 	assert.Contains(t, w.Body.String(), "short_no", "bot 资料应完整可查")
 }
 
-// 系统账号：同上。
-func TestUserGet_SystemAccount_Viewable(t *testing.T) {
+// 系统 Bot：pkg/space.SystemBots 白名单里的账号无需任何关系即可查看完整资料。
+// 用 robot=0 的 fileHelper（而非 robot=1 的 u_10000），确保命中的是 SystemBot 分支而
+// 不是 Robot 分支——CleanAllTables 已清掉迁移预置的 fileHelper，这里重新建号无冲突。
+func TestUserGet_SystemBot_Viewable(t *testing.T) {
+	s, ctx := newUserAuthzServer(t)
+	defer testutil.CleanAllTables(ctx)
+
+	assert.NoError(t, NewService(ctx).AddUser(&AddUserReq{
+		UID: "fileHelper", Name: "SystemBotU", ShortNo: "SNSYSBOTU",
+	}))
+
+	w := getUser(s, "fileHelper")
+	assert.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+	assert.Contains(t, w.Body.String(), `"short_no":`, "白名单系统 Bot 资料应完整可查")
+}
+
+// 回归（本次收紧的核心）：category=system 但**不在** SystemBots 白名单的账号——例如固定
+// 可猜 UID 的 admin 超管号——不再享受系统放行。无可见关系时必须降级为最小集，不得把短号、
+// 在线态等身份字段整份下发给任意登录用户。
+func TestUserGet_SystemCategoryNotWhitelisted_Minimal(t *testing.T) {
 	s, ctx := newUserAuthzServer(t)
 	defer testutil.CleanAllTables(ctx)
 
@@ -234,7 +252,28 @@ func TestUserGet_SystemAccount_Viewable(t *testing.T) {
 
 	w := getUser(s, "ut_sys")
 	assert.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
-	assert.Contains(t, w.Body.String(), "short_no", "系统账号资料应完整可查")
+	assert.NotContains(t, w.Body.String(), `"short_no":`,
+		"非白名单的 category=system 账号无关系时必须降级为最小集，不得泄露身份字段")
+}
+
+// 同上，锁住被移除判定的另一半：`customerService` 也不再享受身份放行。仓库里没有任何
+// 代码路径写这个 category（只有 QueryByCategory / GetUsersWithCategories 读它），所以
+// 这类账号只可能来自人工改库或遗留系统——正因为没有种子可依赖，这条断言是唯一能防止
+// 它被悄悄加回放行集的保险。
+func TestUserGet_CustomerServiceCategoryNotWhitelisted_Minimal(t *testing.T) {
+	s, ctx := newUserAuthzServer(t)
+	defer testutil.CleanAllTables(ctx)
+
+	assert.NoError(t, NewService(ctx).AddUser(&AddUserReq{
+		UID: "ut_cs", Name: "CustomerServiceU", ShortNo: "SNCSU",
+	}))
+	_, err := ctx.DB().UpdateBySql("UPDATE `user` SET category=? WHERE uid=?", CategoryCustomerService, "ut_cs").Exec()
+	assert.NoError(t, err)
+
+	w := getUser(s, "ut_cs")
+	assert.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+	assert.NotContains(t, w.Body.String(), `"short_no":`,
+		"customerService 账号无关系时同样必须降级为最小集")
 }
 
 // 本人：完整资料（含仅自己可见的手机号字段路径）。


### PR DESCRIPTION
## Summary

Take the "system account" exemption in the shared person-profile visibility
decision off the writable `user.category` column and put it on the explicit
`pkg/space.SystemBots` whitelist.

`channel-get-object-authz` (#722) added object-level authorization to
`GET /v1/users/:uid` and the PERSON branch of `GET /v1/channels/:id/:type`, and
exempted "system accounts" by testing `category == system || category ==
customerService`. That column is a writable display attribute, not an
authorization signal. The superuser account seeded by `newManagerSeedModel`
carries `category=system` with `role=superAdmin` and `robot=0`, and its UID is a
fixed, guessable `admin`, so any logged-in caller reached the full profile shape
instead of the minimal set without holding any relationship to it.

Please read this as a narrowing of the authorization input, not an incident fix.
**No material disclosure was reproduced.** The two endpoints do not share the same
exposure surface, though, and earlier revisions of this description wrongly
described both with one mechanism, so they are stated separately:

- `GET /v1/users/:uid` — a stranger saw `category=system` as the only populated
  field beyond the minimal set. Not because the row is empty (the seed writes
  `Name: "超级管理员"` and `ShortNo: "30000"`) but because
  `modules/user/api.go:1431-1436` blanks `ShortNo` and `Vercode` unless
  `Follow == 1` or the caller is the target.
- `GET /v1/channels/:id/:type` (PERSON) — **no such gate**. The response is built
  by `newChannelRespWithUserDetailResp` (`modules/user/1module.go:189-217`) where
  `extraMap["short_no"] = user.ShortNo` is unconditional, and nothing in
  `modules/channel/api.go` clears it. A caller with no relationship therefore did
  receive the superuser's `extra.short_no = "30000"` plus `online` /
  `last_offline` / `device_flag` / `sex` / `source_desc` / `category`.

Two adjacent claims were checked and do **not** hold, recorded here so they are not
carried forward: `username = "superAdmin"` never reached the wire, because
`NewUserDetailResp` (`modules/user/service.go:1554-1556`) gates it on
`m.Robot == 1` and the superuser is `robot=0`, with `model.ChannelResp.Username`
being `omitempty`; and `extra.vercode` was never disclosed to a stranger, because
`service.go:509-524` assigns it only when `friend != nil && friend.IsDeleted == 0`
— and where a friend relation exists, the `Followed` leg already granted
visibility independently of the predicate being removed.

So the conclusion holds on a corrected basis: phone, email, and zone are self-only
on both paths via `self := loginUID == m.UID`, and the one extra field the channel
endpoint handed out is a short number hardcoded as a public seed value in this
repository (`modules/user/api_manager.go:1606`) — no PII, no capability. The
residual value of the fix is defense in depth: the moment anyone seeds a populated
`category=system` account, or `customerService` starts being used, the old
predicate would silently have become a real disclosure surface.

## Related Issue

No octo-server issue was created for the reported finding. This is an internal
follow-up to #722, which introduced the predicate being narrowed here.

Since there is no scoped issue to carry it, the Sprint is set on this PR directly
(`Sprint W33` on the Octo Board), which is the PR-level fallback the sprint gate
accepts.

Review raised three non-blocking follow-ups that are deliberately out of scope
here — the config/whitelist/`category` split, the case-sensitivity asymmetry, and
`IMDatasource.SystemUIDs` still keying off `category`. They are tracked in #745.
Deliberately not phrased as a closing reference: that issue outlives this PR.

## Linked Spec

[`.octospec/tasks/profile-visibility-system-bot-whitelist/brief.md`](.octospec/tasks/profile-visibility-system-bot-whitelist/brief.md)

## Changes

- Rename `PersonProfileInput.SystemAccount` to `SystemBot` and document the
  constraint on the field: the caller must use `spacepkg.IsSystemBot(uid)` and
  must not use `category`. The rename is deliberate — the old name invited
  exactly the wiring that caused the defect.
- Populate it from the whitelist at both call sites, `modules/user/api.go`
  (`u.get`) and `modules/channel/api.go` (`personProfileVisible`). The decision
  stays collapsed in `modules/channel/service` so the two endpoints cannot drift
  apart.
- Rewrite the two tests inherited from #722 that had encoded the defective
  behavior as assertions (`category=system` implies a full profile), and add the
  reverse regression on both endpoints: a `category=system` row outside the
  whitelist degrades to the minimal set, and so does a `customerService` row.
  Nothing in the tree writes that second category — it is only ever read — so no
  seed can carry it and the assertion is the only thing preventing it from being
  quietly returned to the exempt set.
- Fix the constant spelling in the new guardrail comment (`customerService`, not
  `customer_service`), and reword the package doc, which still named the
  `category` constants as the intended source of the exemption twenty lines above
  the field doc that forbids exactly that.
- Record the task brief, resolved rule context, journal, and change-log entry
  under `.octospec/`. The change-log entry carries the operator note for
  `customerService` accounts (see Changes above).

The new assertions use the JSON-key form (`"short_no":`) rather than a bare
substring, so they are the response-*shape* assertions the record claims they are:
`short_no` carries no `omitempty` (`modules/user/service.go:1467`), the channel full
path inserts the key unconditionally, and neither `minimalUserDetailResp` nor
`MinimalChannelResp` declares it. The looser bare-substring form inherited from
#722 is left untouched in that task's own cases.

Behavior that intentionally does not change:

- Whitelisted bots that are not flagged `robot` (`fileHelper`) keep their public
  profile through the whitelist leg rather than the robot leg.
- Ordinary bots (`robot == 1`) keep theirs through the pre-existing robot leg.
- `customerService` rows now fall back to the relationship check. Nothing in the
  tree writes that category — it is only ever read — so a default deployment has
  none. **Operators upgrading**: if a deployment does carry human support accounts
  on `category=customerService` with `robot=0`, they degrade to the minimal profile
  set on deploy, and because `SystemBots` is a compile-time literal there is no
  configuration lever. The supported remedies are adding the UID to that
  whitelist, marking the account `robot=1`, or relying on a normal relationship
  path. This note is also in the `.octospec/log.md` entry so it is discoverable
  without reading this PR.
- `newManagerSeedModel` still writes `category=system`. The column remains
  legitimate for display and classification; only its use as an authorization
  input is removed.

## Testing

- [x] Unit tests added/updated
- [x] Manually verified

Focused integration runs against local MySQL, Redis, and WuKongIM:

```
go test ./modules/user/    -run 'TestUserGet'
go test ./modules/channel/ ./modules/channel/service/ \
  -run 'TestChannelGet|TestMinimalChannelResp|TestPersonProfileVisible|TestNewMinimalChannelResp'
```

Both green, covering the four new cases plus the whole authorization matrix
established by #722 (no-relation, common-group, bot, same-Space, cross-Space,
topic). `go build ./...` and `go vet ./modules/channel/service/
./modules/channel/ ./modules/user/` pass; the vet targets compile the integration
test files, which is what confirms no stale references to the renamed field. All
of it was rerun after rebasing onto `main` — `#741` touches the same file
(`modules/user/api.go`) in the login-audit region and the rebase was clean.

Not claimed: `make i18n-extract-check` and `make i18n-lint` were not rerun. No
error code, `httperr` call site, or locale file is touched, so no new marker or
translation is expected, but CI remains the gate for that claim.

Two environment prerequisites surfaced during the runs and are not caused by this
change: the shared `test` schema retains migration rows written by other
workspaces and needs a drop and recreate with an explicit `utf8mb4_general_ci`
collation per test package, and `modules/channel` requires a 32-byte
`OCTO_MASTER_KEY` when it mounts `modules/common`.

## COMPREHENSION

1. **What does this change actually do** to the load-bearing path?

   It changes one boolean input to the object-level read decision for single-chat
   profiles. Previously the decision short-circuited to "visible" for any row
   whose `category` was `system` or `customerService`, before any relationship
   query ran. Now it short-circuits only for the four UIDs in
   `pkg/space.SystemBots`. Everything else — self, synthetic `iwh_` identities,
   `robot == 1`, friend or active-Space relation, common group, and the
   fail-closed default — is untouched. Concretely, the superuser account and any
   `customerService` account now fall through to `HasAuthzRelation` and the
   common-group check like any other user.

2. **What could break** because of it (dependents + failure mode)?

   The observable wire change is limited to callers with no relationship to a
   non-whitelisted `category=system` account: the response narrows from the full
   shape to the established minimal set (`uid`, `name`, `follow`, `robot`, plus
   all of the caller's own conversation state). Today that is the superuser
   account, which is not a conversation peer and carries no client-rendered
   business data, so no client impact is expected. The failure mode to watch for
   is an unknown consumer that reads the full shape of that specific UID.

   The genuine risk was regressing a public bot into the minimal set and breaking
   sender rendering. `fileHelper` is whitelisted but carries `robot=0`, so it
   would have been the casualty of getting the whitelist leg wrong — which is
   exactly why it, and not `robot=1` `u_10000`, is the fixture in both new
   viewable tests. Using `u_10000` would have passed through the robot leg and
   proven nothing.

3. **How do you know it works** (specific test/repro/trace)?

   The two rewritten tests are the evidence that matters, because the two cases
   they replace passed on the defective code. `TestUserGet_SystemBot_Viewable` and
   `TestChannelGet_Person_SystemBot_Viewable` assert `short_no` is still present
   for whitelisted `fileHelper` with no relationship, pinning the whitelist leg.
   `TestUserGet_SystemCategoryNotWhitelisted_Minimal` and
   `TestChannelGet_Person_SystemCategoryNotWhitelisted_Minimal` seed a row,
   set `category=system`, and assert `short_no` is absent — these fail on the
   pre-change predicate, which is what makes them a regression test rather than a
   restatement. Both endpoints are covered separately on purpose, since the whole
   point of collapsing the decision into one leaf package is that a one-sided fix
   silently reopens the same surface.

   One correction worth recording: during review I claimed the old predicate also
   missed `service` / `service_notice` categories. That was wrong.
   `modules/user/const.go` defines exactly two values, `system` and
   `customerService`, so the predicate covered all of them and the defect was
   purely over-broad. The brief and journal carry the same correction.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] PR description is in English
- [x] Added tests for my changes
- [x] Updated documentation
- [x] Followed commit message conventions (Conventional Commits)
