### PR TITLE
fix: build full server package in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,9 +10,8 @@
 
 FROM golang:1.25 AS build
 
-ENV GOPROXY=https://goproxy.cn,direct \
-    GOSUMDB=sum.golang.google.cn \
-    GO111MODULE=on
+ENV GOPROXY https://goproxy.cn,direct
+ENV GO111MODULE on
 
 WORKDIR /go/cache
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN GIT_COMMIT=$(git rev-parse HEAD 2>/dev/null || echo unknown) && \
     GIT_TREE_STATE=$(test -n "`git status --porcelain 2>/dev/null`" && echo "dirty" || echo "clean") && \
     CGO_ENABLED=0 GOOS=linux go build \
       -ldflags="-w -extldflags '-static' -X main.Commit=$GIT_COMMIT -X main.CommitDate=$GIT_COMMIT_DATE -X main.Version=$GIT_VERSION -X main.TreeState=$GIT_TREE_STATE" \
-      -installsuffix cgo -o app ./main.go
+      -installsuffix cgo -o app .
 
 
 FROM alpine:3.21 AS prod

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,9 @@
 
 FROM golang:1.25 AS build
 
-ENV GOPROXY https://goproxy.cn,direct
-ENV GO111MODULE on
+ENV GOPROXY=https://goproxy.cn,direct \
+    GOSUMDB=sum.golang.google.cn \
+    GO111MODULE=on
 
 WORKDIR /go/cache
 


### PR DESCRIPTION
## Summary

Fixes the container build failure exposed by the session rollout command added in #733. The Dockerfile previously compiled only `main.go`, which excludes other files in package `main`.

## Related Issue

Related: #733

## Linked Spec

[Token session rollout simplify](.octospec/tasks/token-session-rollout-simplify/brief.md) — the image must include `/home/app session-rollout`.

## Changes

- Build the complete root Go package with `go build ... .` instead of compiling only `./main.go`.

## Testing

- [x] `go test .`
- [x] `CGO_ENABLED=0 GOOS=linux go build` with the Dockerfile build flags and package target `.` produced a static Linux executable.
- [ ] Full `docker build` for the final Dockerfile configuration.

## COMPREHENSION

1. **What does this change actually do** to the load-bearing path?

   It makes the image build compile every non-test file in package `main`, including `session_rollout_cmd.go`, so the runtime binary contains the `session-rollout` operator surface. The entrypoint and normal server startup arguments are unchanged.

2. **What could break** because of it (dependents + failure mode)?

   A package-level initialization side effect in an additional root-package file would now execute during normal startup. `session_rollout_cmd.go` has no `init()` function, and its relevant dependencies are already imported by `main.go`; normal server startup therefore follows the existing path unless invoked explicitly as `app session-rollout ...`.

3. **How do you know it works** (specific test/repro/trace)?

   The old `go build ./main.go` reproducibly failed with undefined `sessionRolloutCommand` and `runSessionRolloutCommand`. Building the root package with the Dockerfile cross-compilation flags succeeded, and `go test .` passed.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] PR description is in English
- [ ] Added tests for my changes
- [ ] Updated documentation
- [x] Followed commit message conventions (Conventional Commits)