### PR TITLE
feat(manager): grant expert-market admin capabilities to superAdmin

### DIFF
--- a/modules/user/api_manager.go
+++ b/modules/user/api_manager.go
@@ -180,6 +180,8 @@ func (m *Manager) me(c *wkhttp.Context) {
 //   - skill.write       = 系统 Skill 创建/编辑/删除/分类管理（requireSuperAdmin）
 //   - mcp.read          = 系统 MCP 列表/详情查看（requireSuperAdmin）
 //   - mcp.write         = 系统 MCP 创建/编辑/删除（requireSuperAdmin）
+//   - expert.read       = 专家市场 专家/专家团 列表/详情查看（requireSuperAdmin）
+//   - expert.write      = 专家市场 上传新建/编辑/删除 + 分类管理（requireSuperAdmin）
 //
 // TODO(#366 Part 2): 目前这张表按各端点当前档位手工维护；集中式 authz 策略表落地
 // 后，应改为由同一份 route→role 真源派生，彻底消除前后端漂移。
@@ -200,6 +202,8 @@ func managerCapabilities(role string) map[string]bool {
 		"skill.write":        isSuper, // 系统 Skill 创建/编辑/删除/分类管理（marketplace admin surface）
 		"mcp.read":           isSuper, // 系统 MCP 列表/详情（marketplace admin surface 只认共享 X-Admin-Token 不分 role，此处收窄到超管以缩小页面暴露面）
 		"mcp.write":          isSuper, // 系统 MCP 创建/编辑/删除（同上）
+		"expert.read":        isSuper, // 专家市场 专家/专家团 列表/详情（marketplace admin surface 收窄到超管）
+		"expert.write":       isSuper, // 专家市场 创建(上传)/编辑/删除 + 分类管理（同上）
 		// admin ∪ superAdmin；dashboardReader 仅有 dashboard.read。
 		"appversion.read": isAdmin,                            // 版本列表
 		"dashboard.read":  auth.CanReadManagerDashboard(role), // 运营看板查看

--- a/modules/user/api_manager_me_test.go
+++ b/modules/user/api_manager_me_test.go
@@ -25,6 +25,7 @@ func TestManagerCapabilities(t *testing.T) {
 	superOnly := []string{
 		"system_setting", "backup", "appversion.write", "dashboard.trigger", "space.destructive",
 		"users.write", "users.manage_admin", "groups.write", "skill.write", "skill.read", "mcp.write", "mcp.read",
+		"expert.write", "expert.read",
 	}
 	adminTier := []string{
 		"appversion.read", "dashboard.read", "users.read", "groups.read", "space.read", "space.write",


### PR DESCRIPTION
## What

Add `expert.read` / `expert.write` to the `/v1/manager/me` capability map (superAdmin tier), mirroring the existing `mcp.read` / `mcp.write` and `skill.read` / `skill.write` entries.

## Why

The octo-admin console is gaining an **Expert Market** admin surface (专家市场) that manages platform-provided (`visibility=system`) experts and squads via octo-marketplace's new `/api/v1/admin/experts | squads | expert_categories` admin API. The console gates that page/menu on the `expert.read` / `expert.write` manager capabilities, so `manager/me` must advertise them. Without this, a superAdmin sees no Expert Market entry.

Scoped to superAdmin only (`isSuper`), consistent with the other marketplace admin surfaces.

## Changes

- `managerCapabilities`: add `expert.read` / `expert.write` = `isSuper`, plus the contract comment block.
- `TestManagerCapabilities`: add both keys to the `superOnly` list (the count guard enforces the contract).

## Testing

- `go build ./modules/user/` and `go vet ./modules/user/` pass.
- The pure `TestManagerCapabilities` covers the change (superAdmin has the keys, admin does not, count guard). Note: the full `modules/user` test package requires a live MySQL via the upstream `TestMain` harness, which isn't available in my local env — the DB-backed cases were not run here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)