### PR TITLE
feat(notification): add account notification pause service

### DIFF
--- a/internal/modules.go
+++ b/internal/modules.go
@@ -39,6 +39,7 @@ import (
 	_ "github.com/Mininglamp-OSS/octo-server/modules/incomingwebhook"
 	_ "github.com/Mininglamp-OSS/octo-server/modules/integration"
 	_ "github.com/Mininglamp-OSS/octo-server/modules/message"
+	_ "github.com/Mininglamp-OSS/octo-server/modules/notification"
 	_ "github.com/Mininglamp-OSS/octo-server/modules/notify"
 	_ "github.com/Mininglamp-OSS/octo-server/modules/oidc"
 	_ "github.com/Mininglamp-OSS/octo-server/modules/opanalytics"

--- a/modules/notification/1module.go
+++ b/modules/notification/1module.go
@@ -1,0 +1,29 @@
+package notification
+
+import (
+	"embed"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/register"
+)
+
+//go:embed sql
+var sqlFS embed.FS
+
+//go:embed swagger/api.yaml
+var swaggerContent string
+
+func init() {
+	register.AddModule(func(ctx interface{}) register.Module {
+		api := New(ctx.(*config.Context))
+		return register.Module{
+			Name: "notification",
+			SetupAPI: func() register.APIRouter {
+				return api
+			},
+			Service: api,
+			Swagger: swaggerContent,
+			SQLDir:  register.NewSQLFS(sqlFS),
+		}
+	})
+}

--- a/modules/notification/api.go
+++ b/modules/notification/api.go
@@ -1,0 +1,123 @@
+package notification
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"go.uber.org/zap"
+)
+
+type Service struct {
+	ctx *config.Context
+	db  *dbStore
+	log.Log
+}
+
+func New(ctx *config.Context) *Service {
+	return &Service{ctx: ctx, db: newDBStore(ctx), Log: log.NewTLog("Notification")}
+}
+
+func (s *Service) Route(r *wkhttp.WKHttp) {
+	user := r.Group("/v1/user", s.ctx.AuthMiddleware(r))
+	{
+		user.GET("/notification-pause", s.getPause)
+		user.PUT("/notification-pause", s.putPause)
+		user.DELETE("/notification-pause", s.deletePause)
+	}
+}
+
+func (s *Service) getPause(c *wkhttp.Context) {
+	now := time.Now().UTC()
+	record, err := s.db.get(c.GetLoginUID())
+	if err != nil {
+		s.writeStoreError(c, err)
+		return
+	}
+	c.Response(s.response(record, now))
+}
+
+func (s *Service) putPause(c *wkhttp.Context) {
+	var req updatePauseRequest
+	if err := c.BindJSON(&req); err != nil {
+		s.writeInvalidTime(c)
+		return
+	}
+	now := time.Now().UTC()
+	pausedUntil := req.PausedUntil.UTC()
+	if !pausedUntil.After(now) {
+		s.writeInvalidTime(c)
+		return
+	}
+	record, err := s.db.upsert(c.GetLoginUID(), pausedUntil, now)
+	if err != nil {
+		s.writeStoreError(c, err)
+		return
+	}
+	response := s.response(record, time.Now().UTC())
+	if err := s.sendChangedCMD(c.GetLoginUID(), response); err != nil {
+		s.Warn("发送通知暂停状态 CMD 失败", zap.String("uid", c.GetLoginUID()), zap.Error(err))
+	}
+	c.Response(response)
+}
+
+func (s *Service) deletePause(c *wkhttp.Context) {
+	now := time.Now().UTC()
+	record, err := s.db.clear(c.GetLoginUID(), now)
+	if err != nil {
+		s.writeStoreError(c, err)
+		return
+	}
+	response := s.response(record, time.Now().UTC())
+	if err := s.sendChangedCMD(c.GetLoginUID(), response); err != nil {
+		s.Warn("发送通知暂停状态 CMD 失败", zap.String("uid", c.GetLoginUID()), zap.Error(err))
+	}
+	c.Response(response)
+}
+
+func (s *Service) response(record *pauseRecord, now time.Time) pauseResponse {
+	response := pauseResponse{ServerTime: now.UTC()}
+	if record == nil {
+		return response
+	}
+	response.Revision = record.Revision
+	if record.PausedUntil != nil && record.PausedUntil.After(now) {
+		response.Paused = true
+		until := record.PausedUntil.UTC()
+		response.PausedUntil = &until
+	}
+	return response
+}
+
+func (s *Service) sendChangedCMD(uid string, response pauseResponse) error {
+	return s.ctx.SendCMD(config.MsgCMDReq{
+		NoPersist:   true,
+		ChannelID:   uid,
+		ChannelType: common.ChannelTypePerson.Uint8(),
+		CMD:         notificationPauseCMD,
+		Param: map[string]interface{}{
+			"paused":       response.Paused,
+			"paused_until": response.PausedUntil,
+			"revision":     response.Revision,
+			"server_time":  response.ServerTime,
+		},
+	})
+}
+
+func (s *Service) writeInvalidTime(c *wkhttp.Context) {
+	c.JSON(http.StatusBadRequest, errorResponse{Code: "notification_pause_invalid_time"})
+}
+
+func (s *Service) writeStoreError(c *wkhttp.Context, err error) {
+	s.Error("通知暂停状态存储失败", zap.String("uid", c.GetLoginUID()), zap.Error(err))
+	c.JSON(http.StatusInternalServerError, errorResponse{Code: "notification_pause_update_failed"})
+}
+
+// ActiveUIDs returns the account-level pause state for a batch of recipients.
+// It is intentionally read-only so webhook can fail closed without sharing API concerns.
+func (s *Service) ActiveUIDs(uids []string, now time.Time) (map[string]struct{}, error) {
+	return s.db.getActiveByUIDs(uids, now)
+}

--- a/modules/notification/api.go
+++ b/modules/notification/api.go
@@ -1,13 +1,13 @@
 package notification
 
 import (
-	"net/http"
 	"time"
 
 	"github.com/Mininglamp-OSS/octo-lib/common"
 	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	appwkhttp "github.com/Mininglamp-OSS/octo-server/pkg/wkhttp"
 	"go.uber.org/zap"
 )
 
@@ -22,7 +22,7 @@ func New(ctx *config.Context) *Service {
 }
 
 func (s *Service) Route(r *wkhttp.WKHttp) {
-	user := r.Group("/v1/user", s.ctx.AuthMiddleware(r))
+	user := r.Group("/v1/user", s.ctx.AuthMiddleware(r), appwkhttp.SharedUIDRateLimiter(r, s.ctx))
 	{
 		user.GET("/notification-pause", s.getPause)
 		user.PUT("/notification-pause", s.putPause)
@@ -108,12 +108,12 @@ func (s *Service) sendChangedCMD(uid string, response pauseResponse) error {
 }
 
 func (s *Service) writeInvalidTime(c *wkhttp.Context) {
-	c.JSON(http.StatusBadRequest, errorResponse{Code: "notification_pause_invalid_time"})
+	respondInvalidPauseTime(c)
 }
 
 func (s *Service) writeStoreError(c *wkhttp.Context, err error) {
 	s.Error("通知暂停状态存储失败", zap.String("uid", c.GetLoginUID()), zap.Error(err))
-	c.JSON(http.StatusInternalServerError, errorResponse{Code: "notification_pause_update_failed"})
+	respondPauseUpdateFailed(c)
 }
 
 // ActiveUIDs returns the account-level pause state for a batch of recipients.

--- a/modules/notification/api_i18n.go
+++ b/modules/notification/api_i18n.go
@@ -1,0 +1,15 @@
+package notification
+
+import (
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
+	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
+)
+
+func respondInvalidPauseTime(c *wkhttp.Context) {
+	httperr.ResponseErrorLWithStatus(c, errcode.ErrNotificationPauseInvalidTime, nil, nil)
+}
+
+func respondPauseUpdateFailed(c *wkhttp.Context) {
+	httperr.ResponseErrorLWithStatus(c, errcode.ErrNotificationPauseUpdateFailed, nil, nil)
+}

--- a/modules/notification/api_test.go
+++ b/modules/notification/api_test.go
@@ -1,0 +1,42 @@
+package notification
+
+import (
+	"testing"
+	"time"
+)
+
+func TestResponseNormalizesMissingAndExpiredPause(t *testing.T) {
+	now := time.Date(2026, 8, 12, 11, 30, 0, 125000000, time.UTC)
+	service := &Service{}
+
+	missing := service.response(nil, now)
+	if missing.Paused || missing.PausedUntil != nil || missing.Revision != 0 {
+		t.Fatalf("missing record should be inactive: %+v", missing)
+	}
+
+	expiredAt := now.Add(-time.Millisecond)
+	expired := service.response(&pauseRecord{PausedUntil: &expiredAt, Revision: 7}, now)
+	if expired.Paused || expired.PausedUntil != nil || expired.Revision != 7 {
+		t.Fatalf("expired record should be normalized to inactive: %+v", expired)
+	}
+}
+
+func TestResponseUsesUTCAbsolutePauseTime(t *testing.T) {
+	now := time.Date(2026, 8, 12, 11, 30, 0, 125000000, time.FixedZone("CST", 8*60*60))
+	until := now.Add(30 * time.Minute)
+	service := &Service{}
+
+	response := service.response(&pauseRecord{PausedUntil: &until, Revision: 42}, now)
+	if !response.Paused || response.PausedUntil == nil {
+		t.Fatalf("future record should be active: %+v", response)
+	}
+	if response.PausedUntil.Location() != time.UTC {
+		t.Fatalf("paused_until should be normalized to UTC, got %s", response.PausedUntil.Location())
+	}
+	if response.PausedUntil.Equal(until) == false || response.Revision != 42 {
+		t.Fatalf("unexpected authoritative response: %+v", response)
+	}
+	if response.ServerTime.Location() != time.UTC {
+		t.Fatalf("server_time should be UTC, got %s", response.ServerTime.Location())
+	}
+}

--- a/modules/notification/db.go
+++ b/modules/notification/db.go
@@ -1,0 +1,86 @@
+package notification
+
+import (
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/gocraft/dbr/v2"
+)
+
+type dbStore struct {
+	session *dbr.Session
+}
+
+func newDBStore(ctx *config.Context) *dbStore {
+	return &dbStore{session: ctx.DB()}
+}
+
+func (s *dbStore) get(uid string) (*pauseRecord, error) {
+	var record *pauseRecord
+	_, err := s.session.Select("uid", "paused_until", "revision", "updated_at").
+		From("user_notification_pause").
+		Where("uid=?", uid).
+		Load(&record)
+	return record, err
+}
+
+func (s *dbStore) upsert(uid string, pausedUntil time.Time, now time.Time) (*pauseRecord, error) {
+	tx, err := s.session.Begin()
+	if err != nil {
+		return nil, err
+	}
+	_, err = tx.InsertBySql(
+		"INSERT INTO user_notification_pause (uid, paused_until, revision, updated_at) VALUES (?, ?, 1, ?) "+
+			"ON DUPLICATE KEY UPDATE paused_until=VALUES(paused_until), revision=revision+1, updated_at=VALUES(updated_at)",
+		uid, pausedUntil.UTC(), now.UTC(),
+	).Exec()
+	if err != nil {
+		_ = tx.Rollback()
+		return nil, err
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, err
+	}
+	return s.get(uid)
+}
+
+func (s *dbStore) clear(uid string, now time.Time) (*pauseRecord, error) {
+	tx, err := s.session.Begin()
+	if err != nil {
+		return nil, err
+	}
+	_, err = tx.InsertBySql(
+		"INSERT INTO user_notification_pause (uid, paused_until, revision, updated_at) VALUES (?, NULL, 1, ?) "+
+			"ON DUPLICATE KEY UPDATE paused_until=NULL, revision=revision+1, updated_at=VALUES(updated_at)",
+		uid, now.UTC(),
+	).Exec()
+	if err != nil {
+		_ = tx.Rollback()
+		return nil, err
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, err
+	}
+	return s.get(uid)
+}
+
+func (s *dbStore) getActiveByUIDs(uids []string, now time.Time) (map[string]struct{}, error) {
+	active := make(map[string]struct{})
+	if len(uids) == 0 {
+		return active, nil
+	}
+	var records []*pauseRecord
+	_, err := s.session.Select("uid", "paused_until", "revision", "updated_at").
+		From("user_notification_pause").
+		Where("uid IN ? AND paused_until IS NOT NULL AND paused_until > ?", uids, now.UTC()).
+		Load(&records)
+	if err != nil {
+		return nil, err
+	}
+	for _, record := range records {
+		if record != nil {
+			active[record.UID] = struct{}{}
+		}
+	}
+	return active, nil
+}

--- a/modules/notification/model.go
+++ b/modules/notification/model.go
@@ -1,0 +1,27 @@
+package notification
+
+import "time"
+
+const notificationPauseCMD = "user.notification_pause.changed"
+
+type pauseRecord struct {
+	UID         string     `db:"uid"`
+	PausedUntil *time.Time `db:"paused_until"`
+	Revision    uint64     `db:"revision"`
+	UpdatedAt   time.Time  `db:"updated_at"`
+}
+
+type pauseResponse struct {
+	Paused      bool       `json:"paused"`
+	PausedUntil *time.Time `json:"paused_until"`
+	Revision    uint64     `json:"revision"`
+	ServerTime  time.Time  `json:"server_time"`
+}
+
+type updatePauseRequest struct {
+	PausedUntil time.Time `json:"paused_until"`
+}
+
+type errorResponse struct {
+	Code string `json:"code"`
+}

--- a/modules/notification/model.go
+++ b/modules/notification/model.go
@@ -21,7 +21,3 @@ type pauseResponse struct {
 type updatePauseRequest struct {
 	PausedUntil time.Time `json:"paused_until"`
 }
-
-type errorResponse struct {
-	Code string `json:"code"`
-}

--- a/modules/notification/sql/20260812000001_notification_pause.sql
+++ b/modules/notification/sql/20260812000001_notification_pause.sql
@@ -1,0 +1,14 @@
+-- +migrate Up
+
+CREATE TABLE IF NOT EXISTS `user_notification_pause` (
+  `uid` VARCHAR(40) NOT NULL,
+  `paused_until` DATETIME(3) NULL,
+  `revision` BIGINT UNSIGNED NOT NULL DEFAULT 0,
+  `updated_at` DATETIME(3) NOT NULL,
+  PRIMARY KEY (`uid`),
+  KEY `idx_user_notification_pause_until` (`paused_until`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- +migrate Down
+
+DROP TABLE IF EXISTS `user_notification_pause`;

--- a/modules/notification/swagger/api.yaml
+++ b/modules/notification/swagger/api.yaml
@@ -1,0 +1,126 @@
+openapi: 3.0.3
+info:
+  title: Octo Notification Pause API
+  version: 1.0.0
+paths:
+  /v1/user/notification-pause:
+    get:
+      operationId: getNotificationPause
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Current account notification pause state
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotificationPause'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '500':
+          $ref: '#/components/responses/UpdateFailed'
+    put:
+      operationId: setNotificationPause
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SetNotificationPause'
+      responses:
+        '200':
+          description: Saved authoritative state
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotificationPause'
+        '400':
+          $ref: '#/components/responses/InvalidTime'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '500':
+          $ref: '#/components/responses/UpdateFailed'
+    delete:
+      operationId: clearNotificationPause
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Restored authoritative state
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotificationPause'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '500':
+          $ref: '#/components/responses/UpdateFailed'
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+  schemas:
+    SetNotificationPause:
+      type: object
+      required: [paused_until]
+      properties:
+        paused_until:
+          type: string
+          format: date-time
+          description: UTC absolute time later than server time
+    NotificationPause:
+      type: object
+      required: [paused, paused_until, revision, server_time]
+      properties:
+        paused:
+          type: boolean
+        paused_until:
+          type: string
+          format: date-time
+          nullable: true
+        revision:
+          type: integer
+          format: int64
+          minimum: 0
+        server_time:
+          type: string
+          format: date-time
+      example:
+        paused: true
+        paused_until: '2026-08-12T12:30:00.000Z'
+        revision: 42
+        server_time: '2026-08-12T11:30:00.125Z'
+    Error:
+      type: object
+      required: [code]
+      properties:
+        code:
+          type: string
+  responses:
+    Unauthorized:
+      description: Authentication required
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+          example:
+            code: unauthorized
+    InvalidTime:
+      description: Invalid or non-future pause time
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+          example:
+            code: notification_pause_invalid_time
+    UpdateFailed:
+      description: Database update failed
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+          example:
+            code: notification_pause_update_failed

--- a/modules/notification/swagger/api.yaml
+++ b/modules/notification/swagger/api.yaml
@@ -115,7 +115,7 @@ components:
           schema:
             $ref: '#/components/schemas/Error'
           example:
-            code: notification_pause_invalid_time
+            code: err.server.notification.pause.invalid_time
     UpdateFailed:
       description: Database update failed
       content:
@@ -123,4 +123,4 @@ components:
           schema:
             $ref: '#/components/schemas/Error'
           example:
-            code: notification_pause_update_failed
+            code: err.server.notification.pause.update_failed

--- a/modules/webhook/api.go
+++ b/modules/webhook/api.go
@@ -13,6 +13,7 @@ import (
 	"runtime/debug"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/Mininglamp-OSS/octo-lib/common"
 	"github.com/Mininglamp-OSS/octo-lib/config"
@@ -22,6 +23,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhook"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
 	"github.com/Mininglamp-OSS/octo-server/modules/group"
+	"github.com/Mininglamp-OSS/octo-server/modules/notification"
 	"github.com/Mininglamp-OSS/octo-server/modules/user"
 	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
 	spacepkg "github.com/Mininglamp-OSS/octo-server/pkg/space"
@@ -35,14 +37,15 @@ import (
 // Webhook Webhook
 type Webhook struct {
 	log.Log
-	ctx          *config.Context
-	supportTypes []common.ContentType
-	db           *DB
-	messageDB    *messageDB
-	pushMap      map[common.DeviceType]map[string]Push
-	groupService group.IService
-	userService  user.IService
-	secretKey    string // Webhook HMAC-SHA256 签名密钥
+	ctx                 *config.Context
+	supportTypes        []common.ContentType
+	db                  *DB
+	messageDB           *messageDB
+	pushMap             map[common.DeviceType]map[string]Push
+	groupService        group.IService
+	userService         user.IService
+	notificationService *notification.Service
+	secretKey           string // Webhook HMAC-SHA256 签名密钥
 	wkhook.UnimplementedWebhookServiceServer
 	grpcServer *grpc.Server
 }
@@ -116,15 +119,16 @@ func New(ctx *config.Context) *Webhook {
 		}
 	}
 	return &Webhook{
-		db:           NewDB(ctx.DB()),
-		supportTypes: supportTypes,
-		ctx:          ctx,
-		Log:          log.NewTLog("Webhook"),
-		pushMap:      pushMap,
-		messageDB:    newMessageDB(ctx),
-		groupService: group.NewService(ctx),
-		userService:  user.NewService(ctx),
-		secretKey:    os.Getenv("TS_WEBHOOK_SECRET_KEY"),
+		db:                  NewDB(ctx.DB()),
+		supportTypes:        supportTypes,
+		ctx:                 ctx,
+		Log:                 log.NewTLog("Webhook"),
+		pushMap:             pushMap,
+		messageDB:           newMessageDB(ctx),
+		groupService:        group.NewService(ctx),
+		userService:         user.NewService(ctx),
+		notificationService: notification.New(ctx),
+		secretKey:           os.Getenv("TS_WEBHOOK_SECRET_KEY"),
 	}
 }
 func getSupportTypes() []common.ContentType {
@@ -479,6 +483,28 @@ func (w *Webhook) pushTo(msgResp msgOfflineNotify, toUids []string) error {
 	if !w.containSupportType(common.ContentType(msgResp.ContentType)) && !isVideoCall {
 		w.Debug("不推送：不支持的消息类型！", zap.Int("contentType", msgResp.ContentType), zap.Bool("signal", setting.Signal))
 		return nil
+	}
+
+	// 账号级快捷静音只抑制消息离线 Push，不影响 RTC/来电推送。
+	// 在进入 PushPool 前一次性查询全部接收 UID，避免每个设备任务产生 N+1 查询。
+	if !isVideoCall && w.notificationService != nil {
+		pausedUIDs, err := w.notificationService.ActiveUIDs(toUids, time.Now().UTC())
+		if err != nil {
+			// 静音状态查询失败时 fail closed，避免在用户已选择静音时发送本次 Push。
+			w.Error("查询账号级通知暂停状态失败，本次 Push 跳过", zap.Error(err), zap.Int("toUidsCount", len(toUids)))
+			return nil
+		}
+		if len(pausedUIDs) > 0 {
+			for _, uid := range toUids {
+				if _, paused := pausedUIDs[uid]; paused {
+					w.Debug("因账号级通知暂停抑制 Push", zap.String("uid", uid))
+				}
+			}
+			toUids = excludePausedUIDs(toUids, pausedUIDs)
+			if len(toUids) == 0 {
+				return nil
+			}
+		}
 	}
 
 	// 解析消息来源的 space_id

--- a/modules/webhook/notification_pause.go
+++ b/modules/webhook/notification_pause.go
@@ -1,0 +1,15 @@
+package webhook
+
+func excludePausedUIDs(uids []string, paused map[string]struct{}) []string {
+	if len(paused) == 0 {
+		return uids
+	}
+	filtered := make([]string, 0, len(uids))
+	for _, uid := range uids {
+		if _, ok := paused[uid]; ok {
+			continue
+		}
+		filtered = append(filtered, uid)
+	}
+	return filtered
+}

--- a/modules/webhook/notification_pause_test.go
+++ b/modules/webhook/notification_pause_test.go
@@ -1,0 +1,25 @@
+package webhook
+
+import "testing"
+
+func TestExcludePausedUIDs(t *testing.T) {
+	uids := []string{"u1", "u2", "u3", "u2"}
+	got := excludePausedUIDs(uids, map[string]struct{}{"u2": {}})
+	want := []string{"u1", "u3"}
+	if len(got) != len(want) {
+		t.Fatalf("expected %v, got %v", want, got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("expected %v, got %v", want, got)
+		}
+	}
+}
+
+func TestExcludePausedUIDsKeepsInputWhenNoPausedUID(t *testing.T) {
+	uids := []string{"u1", "u2"}
+	got := excludePausedUIDs(uids, nil)
+	if len(got) != len(uids) || &got[0] != &uids[0] {
+		t.Fatalf("no-op filtering should preserve the input slice")
+	}
+}

--- a/pkg/errcode/notification.go
+++ b/pkg/errcode/notification.go
@@ -1,0 +1,21 @@
+package errcode
+
+import (
+	"net/http"
+
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n/codes"
+)
+
+var (
+	ErrNotificationPauseInvalidTime = register(codes.Code{
+		ID:             "err.server.notification.pause.invalid_time",
+		HTTPStatus:     http.StatusBadRequest,
+		DefaultMessage: "Notification pause time is invalid.",
+	})
+	ErrNotificationPauseUpdateFailed = register(codes.Code{
+		ID:             "err.server.notification.pause.update_failed",
+		HTTPStatus:     http.StatusInternalServerError,
+		DefaultMessage: "Failed to update notification pause state.",
+		Internal:       true,
+	})
+)

--- a/pkg/i18n/locales/active.zh-CN.toml
+++ b/pkg/i18n/locales/active.zh-CN.toml
@@ -1090,3 +1090,11 @@ other = "运营看板 ETL 正在运行，请稍后再试。"
 
 ["err.server.opanalytics.etl_trigger_failed"]
 other = "触发运营看板 ETL 失败。"
+
+# ---- modules/notification：账号级快捷静音 ----
+
+["err.server.notification.pause.invalid_time"]
+other = "通知暂停时间无效。"
+
+["err.server.notification.pause.update_failed"]
+other = "更新通知暂停状态失败。"

--- a/tools/i18nmarkers/server/active.en-US.toml
+++ b/tools/i18nmarkers/server/active.en-US.toml
@@ -450,6 +450,12 @@ other = "Message search failed."
 ["err.server.message.store_failed"]
 other = "Failed to persist message data."
 
+["err.server.notification.pause.invalid_time"]
+other = "Notification pause time is invalid."
+
+["err.server.notification.pause.update_failed"]
+other = "Failed to update notification pause state."
+
 ["err.server.oidc.bind_already_bound"]
 other = "This identity is already bound. Please sign in via OIDC to continue."
 


### PR DESCRIPTION
## Summary

- 新增账号级快捷静音状态表及 migration
- 新增 GET/PUT/DELETE notification pause API
- 增加 UTC 绝对时间、revision 和跨设备 CMD 同步
- 在 webhook 离线 Push 入口按 UID 批量拦截有效静音账号
- RTC/来电 Push 不受快捷静音影响
- 补齐 OpenAPI 3.0.3、i18n 错误码和 UID 限流

## Verification

- `go test -count=1 ./modules/notification ./modules/webhook ./pkg/errcode`
- `make i18n-extract-check`
- `make i18n-lint`
- `gofmt`、OpenAPI YAML 解析、`git diff --check`