### PR TITLE
feat(notification): add account notification pause service

### DIFF
--- a/.octospec/tasks/notification-pause/brief.md
+++ b/.octospec/tasks/notification-pause/brief.md
@@ -1,0 +1,38 @@
+---
+type: Task
+title: "Task: notification-pause"
+description: Add account-level notification pause state with cross-device synchronization and offline-push filtering.
+tags: ["wire-contract", "reliability", "test"]
+timestamp: 2026-08-12T10:15:00Z
+slug: notification-pause
+upstream: octo-web settings-center T19
+source: self
+---
+
+# Task: notification-pause
+
+## Goal
+
+Provide an account-level notification pause API and synchronize the authoritative
+state to all online devices. A valid pause suppresses message offline Push for
+paused recipients while RTC/call Push remains unaffected.
+
+## Reliability and contract
+
+- GET/PUT/DELETE operate only on the authenticated UID and return revisioned state.
+- Successful mutations send `user.notification_pause.changed` after the database write.
+- Known paused UIDs are excluded from message offline Push; duplicates and order are preserved.
+- A pause lookup failure logs an observable error and preserves the original offline-Push batch.
+- UID lookups are bounded in batches; `paused_until` is limited to 30 days.
+- RTC/call Push behavior remains unchanged.
+
+## Out of scope
+
+- RTC/call Push suppression.
+- Independent sync channels, outbox, ACK protocol, or device-level pause state.
+- Client-side scheduling UX beyond server-side validation.
+
+## Verification
+
+- Focused Go tests for notification state, webhook filtering, and lookup failure.
+- `make i18n-extract-check` and `make i18n-lint`.

--- a/internal/modules.go
+++ b/internal/modules.go
@@ -43,6 +43,7 @@ import (
 	_ "github.com/Mininglamp-OSS/octo-server/modules/internal_resolve"
 	_ "github.com/Mininglamp-OSS/octo-server/modules/message"
 	_ "github.com/Mininglamp-OSS/octo-server/modules/messages_search"
+	_ "github.com/Mininglamp-OSS/octo-server/modules/notification"
 	_ "github.com/Mininglamp-OSS/octo-server/modules/notify"
 	_ "github.com/Mininglamp-OSS/octo-server/modules/oidc"
 	_ "github.com/Mininglamp-OSS/octo-server/modules/opanalytics"

--- a/modules/notification/1module.go
+++ b/modules/notification/1module.go
@@ -1,0 +1,29 @@
+package notification
+
+import (
+	"embed"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/register"
+)
+
+//go:embed sql
+var sqlFS embed.FS
+
+//go:embed swagger/api.yaml
+var swaggerContent string
+
+func init() {
+	register.AddModule(func(ctx interface{}) register.Module {
+		api := New(ctx.(*config.Context))
+		return register.Module{
+			Name: "notification",
+			SetupAPI: func() register.APIRouter {
+				return api
+			},
+			Service: api,
+			Swagger: swaggerContent,
+			SQLDir:  register.NewSQLFS(sqlFS),
+		}
+	})
+}

--- a/modules/notification/api.go
+++ b/modules/notification/api.go
@@ -17,6 +17,12 @@ type Service struct {
 	log.Log
 }
 
+const maxPauseDuration = 30 * 24 * time.Hour
+
+func validPauseUntil(now, pausedUntil time.Time) bool {
+	return pausedUntil.After(now) && !pausedUntil.After(now.Add(maxPauseDuration))
+}
+
 func New(ctx *config.Context) *Service {
 	return &Service{ctx: ctx, db: newDBStore(ctx), Log: log.NewTLog("Notification")}
 }
@@ -48,7 +54,7 @@ func (s *Service) putPause(c *wkhttp.Context) {
 	}
 	now := time.Now().UTC()
 	pausedUntil := req.PausedUntil.UTC()
-	if !pausedUntil.After(now) {
+	if !validPauseUntil(now, pausedUntil) {
 		s.writeInvalidTime(c)
 		return
 	}

--- a/modules/notification/api.go
+++ b/modules/notification/api.go
@@ -1,0 +1,123 @@
+package notification
+
+import (
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	appwkhttp "github.com/Mininglamp-OSS/octo-server/pkg/wkhttp"
+	"go.uber.org/zap"
+)
+
+type Service struct {
+	ctx *config.Context
+	db  *dbStore
+	log.Log
+}
+
+func New(ctx *config.Context) *Service {
+	return &Service{ctx: ctx, db: newDBStore(ctx), Log: log.NewTLog("Notification")}
+}
+
+func (s *Service) Route(r *wkhttp.WKHttp) {
+	user := r.Group("/v1/user", s.ctx.AuthMiddleware(r), appwkhttp.SharedUIDRateLimiter(r, s.ctx))
+	{
+		user.GET("/notification-pause", s.getPause)
+		user.PUT("/notification-pause", s.putPause)
+		user.DELETE("/notification-pause", s.deletePause)
+	}
+}
+
+func (s *Service) getPause(c *wkhttp.Context) {
+	now := time.Now().UTC()
+	record, err := s.db.get(c.GetLoginUID())
+	if err != nil {
+		s.writeStoreError(c, err)
+		return
+	}
+	c.Response(s.response(record, now))
+}
+
+func (s *Service) putPause(c *wkhttp.Context) {
+	var req updatePauseRequest
+	if err := c.BindJSON(&req); err != nil {
+		s.writeInvalidTime(c)
+		return
+	}
+	now := time.Now().UTC()
+	pausedUntil := req.PausedUntil.UTC()
+	if !pausedUntil.After(now) {
+		s.writeInvalidTime(c)
+		return
+	}
+	record, err := s.db.upsert(c.GetLoginUID(), pausedUntil, now)
+	if err != nil {
+		s.writeStoreError(c, err)
+		return
+	}
+	response := s.response(record, time.Now().UTC())
+	if err := s.sendChangedCMD(c.GetLoginUID(), response); err != nil {
+		s.Warn("发送通知暂停状态 CMD 失败", zap.String("uid", c.GetLoginUID()), zap.Error(err))
+	}
+	c.Response(response)
+}
+
+func (s *Service) deletePause(c *wkhttp.Context) {
+	now := time.Now().UTC()
+	record, err := s.db.clear(c.GetLoginUID(), now)
+	if err != nil {
+		s.writeStoreError(c, err)
+		return
+	}
+	response := s.response(record, time.Now().UTC())
+	if err := s.sendChangedCMD(c.GetLoginUID(), response); err != nil {
+		s.Warn("发送通知暂停状态 CMD 失败", zap.String("uid", c.GetLoginUID()), zap.Error(err))
+	}
+	c.Response(response)
+}
+
+func (s *Service) response(record *pauseRecord, now time.Time) pauseResponse {
+	response := pauseResponse{ServerTime: now.UTC()}
+	if record == nil {
+		return response
+	}
+	response.Revision = record.Revision
+	if record.PausedUntil != nil && record.PausedUntil.After(now) {
+		response.Paused = true
+		until := record.PausedUntil.UTC()
+		response.PausedUntil = &until
+	}
+	return response
+}
+
+func (s *Service) sendChangedCMD(uid string, response pauseResponse) error {
+	return s.ctx.SendCMD(config.MsgCMDReq{
+		NoPersist:   true,
+		ChannelID:   uid,
+		ChannelType: common.ChannelTypePerson.Uint8(),
+		CMD:         notificationPauseCMD,
+		Param: map[string]interface{}{
+			"paused":       response.Paused,
+			"paused_until": response.PausedUntil,
+			"revision":     response.Revision,
+			"server_time":  response.ServerTime,
+		},
+	})
+}
+
+func (s *Service) writeInvalidTime(c *wkhttp.Context) {
+	respondInvalidPauseTime(c)
+}
+
+func (s *Service) writeStoreError(c *wkhttp.Context, err error) {
+	s.Error("通知暂停状态存储失败", zap.String("uid", c.GetLoginUID()), zap.Error(err))
+	respondPauseUpdateFailed(c)
+}
+
+// ActiveUIDs returns the account-level pause state for a batch of recipients.
+// It is intentionally read-only so webhook can fail closed without sharing API concerns.
+func (s *Service) ActiveUIDs(uids []string, now time.Time) (map[string]struct{}, error) {
+	return s.db.getActiveByUIDs(uids, now)
+}

--- a/modules/notification/api_i18n.go
+++ b/modules/notification/api_i18n.go
@@ -1,0 +1,15 @@
+package notification
+
+import (
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
+	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
+)
+
+func respondInvalidPauseTime(c *wkhttp.Context) {
+	httperr.ResponseErrorLWithStatus(c, errcode.ErrNotificationPauseInvalidTime, nil, nil)
+}
+
+func respondPauseUpdateFailed(c *wkhttp.Context) {
+	httperr.ResponseErrorLWithStatus(c, errcode.ErrNotificationPauseUpdateFailed, nil, nil)
+}

--- a/modules/notification/api_i18n_test.go
+++ b/modules/notification/api_i18n_test.go
@@ -1,0 +1,35 @@
+package notification
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestNotificationNoLegacyResponseError keeps notification handlers on the
+// localized response envelope and prevents a future raw error response from
+// bypassing the registered notification error codes.
+func TestNotificationNoLegacyResponseError(t *testing.T) {
+	for _, file := range []string{"api.go", "api_i18n.go"} {
+		data, err := os.ReadFile(file)
+		if err != nil {
+			t.Fatalf("read %s: %v", file, err)
+		}
+		cleaned := strings.Builder{}
+		for _, line := range strings.Split(string(data), "\n") {
+			if index := strings.Index(line, "//"); index >= 0 {
+				line = line[:index]
+			}
+			cleaned.WriteString(line)
+			cleaned.WriteByte('\n')
+		}
+		for _, banned := range []string{
+			".ResponseError(", ".ResponseErrorf(", ".ResponseErrorWithStatus(",
+			".AbortWithStatusJSON(", ".AbortWithStatus(", "c.Response(\"",
+		} {
+			if strings.Contains(cleaned.String(), banned) {
+				t.Fatalf("modules/notification/%s must use httperr.ResponseErrorL* instead of legacy %s", file, banned)
+			}
+		}
+	}
+}

--- a/modules/notification/api_test.go
+++ b/modules/notification/api_test.go
@@ -1,0 +1,42 @@
+package notification
+
+import (
+	"testing"
+	"time"
+)
+
+func TestResponseNormalizesMissingAndExpiredPause(t *testing.T) {
+	now := time.Date(2026, 8, 12, 11, 30, 0, 125000000, time.UTC)
+	service := &Service{}
+
+	missing := service.response(nil, now)
+	if missing.Paused || missing.PausedUntil != nil || missing.Revision != 0 {
+		t.Fatalf("missing record should be inactive: %+v", missing)
+	}
+
+	expiredAt := now.Add(-time.Millisecond)
+	expired := service.response(&pauseRecord{PausedUntil: &expiredAt, Revision: 7}, now)
+	if expired.Paused || expired.PausedUntil != nil || expired.Revision != 7 {
+		t.Fatalf("expired record should be normalized to inactive: %+v", expired)
+	}
+}
+
+func TestResponseUsesUTCAbsolutePauseTime(t *testing.T) {
+	now := time.Date(2026, 8, 12, 11, 30, 0, 125000000, time.FixedZone("CST", 8*60*60))
+	until := now.Add(30 * time.Minute)
+	service := &Service{}
+
+	response := service.response(&pauseRecord{PausedUntil: &until, Revision: 42}, now)
+	if !response.Paused || response.PausedUntil == nil {
+		t.Fatalf("future record should be active: %+v", response)
+	}
+	if response.PausedUntil.Location() != time.UTC {
+		t.Fatalf("paused_until should be normalized to UTC, got %s", response.PausedUntil.Location())
+	}
+	if response.PausedUntil.Equal(until) == false || response.Revision != 42 {
+		t.Fatalf("unexpected authoritative response: %+v", response)
+	}
+	if response.ServerTime.Location() != time.UTC {
+		t.Fatalf("server_time should be UTC, got %s", response.ServerTime.Location())
+	}
+}

--- a/modules/notification/api_test.go
+++ b/modules/notification/api_test.go
@@ -40,3 +40,16 @@ func TestResponseUsesUTCAbsolutePauseTime(t *testing.T) {
 		t.Fatalf("server_time should be UTC, got %s", response.ServerTime.Location())
 	}
 }
+
+func TestValidPauseUntilCapsThePauseWindow(t *testing.T) {
+	now := time.Date(2026, 8, 12, 11, 30, 0, 0, time.UTC)
+	if !validPauseUntil(now, now.Add(time.Minute)) {
+		t.Fatal("future pause should be accepted")
+	}
+	if validPauseUntil(now, now) || validPauseUntil(now, now.Add(-time.Minute)) {
+		t.Fatal("current and past pause times should be rejected")
+	}
+	if validPauseUntil(now, now.Add(maxPauseDuration+time.Nanosecond)) {
+		t.Fatal("pause window beyond the cap should be rejected")
+	}
+}

--- a/modules/notification/db.go
+++ b/modules/notification/db.go
@@ -1,0 +1,86 @@
+package notification
+
+import (
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/gocraft/dbr/v2"
+)
+
+type dbStore struct {
+	session *dbr.Session
+}
+
+func newDBStore(ctx *config.Context) *dbStore {
+	return &dbStore{session: ctx.DB()}
+}
+
+func (s *dbStore) get(uid string) (*pauseRecord, error) {
+	var record *pauseRecord
+	_, err := s.session.Select("uid", "paused_until", "revision", "updated_at").
+		From("user_notification_pause").
+		Where("uid=?", uid).
+		Load(&record)
+	return record, err
+}
+
+func (s *dbStore) upsert(uid string, pausedUntil time.Time, now time.Time) (*pauseRecord, error) {
+	tx, err := s.session.Begin()
+	if err != nil {
+		return nil, err
+	}
+	_, err = tx.InsertBySql(
+		"INSERT INTO user_notification_pause (uid, paused_until, revision, updated_at) VALUES (?, ?, 1, ?) "+
+			"ON DUPLICATE KEY UPDATE paused_until=VALUES(paused_until), revision=revision+1, updated_at=VALUES(updated_at)",
+		uid, pausedUntil.UTC(), now.UTC(),
+	).Exec()
+	if err != nil {
+		_ = tx.Rollback()
+		return nil, err
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, err
+	}
+	return s.get(uid)
+}
+
+func (s *dbStore) clear(uid string, now time.Time) (*pauseRecord, error) {
+	tx, err := s.session.Begin()
+	if err != nil {
+		return nil, err
+	}
+	_, err = tx.InsertBySql(
+		"INSERT INTO user_notification_pause (uid, paused_until, revision, updated_at) VALUES (?, NULL, 1, ?) "+
+			"ON DUPLICATE KEY UPDATE paused_until=NULL, revision=revision+1, updated_at=VALUES(updated_at)",
+		uid, now.UTC(),
+	).Exec()
+	if err != nil {
+		_ = tx.Rollback()
+		return nil, err
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, err
+	}
+	return s.get(uid)
+}
+
+func (s *dbStore) getActiveByUIDs(uids []string, now time.Time) (map[string]struct{}, error) {
+	active := make(map[string]struct{})
+	if len(uids) == 0 {
+		return active, nil
+	}
+	var records []*pauseRecord
+	_, err := s.session.Select("uid", "paused_until", "revision", "updated_at").
+		From("user_notification_pause").
+		Where("uid IN ? AND paused_until IS NOT NULL AND paused_until > ?", uids, now.UTC()).
+		Load(&records)
+	if err != nil {
+		return nil, err
+	}
+	for _, record := range records {
+		if record != nil {
+			active[record.UID] = struct{}{}
+		}
+	}
+	return active, nil
+}

--- a/modules/notification/db.go
+++ b/modules/notification/db.go
@@ -38,22 +38,12 @@ func (s *dbStore) upsert(uid string, pausedUntil time.Time, now time.Time) (*pau
 		_ = tx.Rollback()
 		return nil, err
 	}
-	if err := tx.Commit(); err != nil {
-		return nil, err
-	}
-	return s.get(uid)
-}
-
-func (s *dbStore) clear(uid string, now time.Time) (*pauseRecord, error) {
-	tx, err := s.session.Begin()
-	if err != nil {
-		return nil, err
-	}
-	_, err = tx.InsertBySql(
-		"INSERT INTO user_notification_pause (uid, paused_until, revision, updated_at) VALUES (?, NULL, 1, ?) "+
-			"ON DUPLICATE KEY UPDATE paused_until=NULL, revision=revision+1, updated_at=VALUES(updated_at)",
-		uid, now.UTC(),
-	).Exec()
+	var record *pauseRecord
+	_, err = tx.Select("uid", "paused_until", "revision", "updated_at").
+		From("user_notification_pause").
+		Where("uid=?", uid).
+		Suffix("FOR UPDATE").
+		Load(&record)
 	if err != nil {
 		_ = tx.Rollback()
 		return nil, err
@@ -61,7 +51,38 @@ func (s *dbStore) clear(uid string, now time.Time) (*pauseRecord, error) {
 	if err := tx.Commit(); err != nil {
 		return nil, err
 	}
-	return s.get(uid)
+	return record, nil
+}
+
+func (s *dbStore) clear(uid string, now time.Time) (*pauseRecord, error) {
+	tx, err := s.session.Begin()
+	if err != nil {
+		return nil, err
+	}
+	_, err = tx.Update("user_notification_pause").
+		Set("paused_until", nil).
+		Set("updated_at", now.UTC()).
+		Set("revision", dbr.Expr("revision+1")).
+		Where("uid=? AND paused_until IS NOT NULL", uid).
+		Exec()
+	if err != nil {
+		_ = tx.Rollback()
+		return nil, err
+	}
+	var record *pauseRecord
+	_, err = tx.Select("uid", "paused_until", "revision", "updated_at").
+		From("user_notification_pause").
+		Where("uid=?", uid).
+		Suffix("FOR UPDATE").
+		Load(&record)
+	if err != nil {
+		_ = tx.Rollback()
+		return nil, err
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, err
+	}
+	return record, nil
 }
 
 func (s *dbStore) getActiveByUIDs(uids []string, now time.Time) (map[string]struct{}, error) {
@@ -69,17 +90,24 @@ func (s *dbStore) getActiveByUIDs(uids []string, now time.Time) (map[string]stru
 	if len(uids) == 0 {
 		return active, nil
 	}
-	var records []*pauseRecord
-	_, err := s.session.Select("uid", "paused_until", "revision", "updated_at").
-		From("user_notification_pause").
-		Where("uid IN ? AND paused_until IS NOT NULL AND paused_until > ?", uids, now.UTC()).
-		Load(&records)
-	if err != nil {
-		return nil, err
-	}
-	for _, record := range records {
-		if record != nil {
-			active[record.UID] = struct{}{}
+	const batchSize = 1000
+	for start := 0; start < len(uids); start += batchSize {
+		end := start + batchSize
+		if end > len(uids) {
+			end = len(uids)
+		}
+		var records []*pauseRecord
+		_, err := s.session.Select("uid", "paused_until", "revision", "updated_at").
+			From("user_notification_pause").
+			Where("uid IN ? AND paused_until IS NOT NULL AND paused_until > ?", uids[start:end], now.UTC()).
+			Load(&records)
+		if err != nil {
+			return nil, err
+		}
+		for _, record := range records {
+			if record != nil {
+				active[record.UID] = struct{}{}
+			}
 		}
 	}
 	return active, nil

--- a/modules/notification/model.go
+++ b/modules/notification/model.go
@@ -1,0 +1,23 @@
+package notification
+
+import "time"
+
+const notificationPauseCMD = "user.notification_pause.changed"
+
+type pauseRecord struct {
+	UID         string     `db:"uid"`
+	PausedUntil *time.Time `db:"paused_until"`
+	Revision    uint64     `db:"revision"`
+	UpdatedAt   time.Time  `db:"updated_at"`
+}
+
+type pauseResponse struct {
+	Paused      bool       `json:"paused"`
+	PausedUntil *time.Time `json:"paused_until"`
+	Revision    uint64     `json:"revision"`
+	ServerTime  time.Time  `json:"server_time"`
+}
+
+type updatePauseRequest struct {
+	PausedUntil time.Time `json:"paused_until"`
+}

--- a/modules/notification/sql/20260812000001_notification_pause.sql
+++ b/modules/notification/sql/20260812000001_notification_pause.sql
@@ -6,7 +6,6 @@ CREATE TABLE IF NOT EXISTS `user_notification_pause` (
   `revision` BIGINT UNSIGNED NOT NULL DEFAULT 0,
   `updated_at` DATETIME(3) NOT NULL,
   PRIMARY KEY (`uid`),
-  KEY `idx_user_notification_pause_until` (`paused_until`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 -- +migrate Down

--- a/modules/notification/sql/20260812000001_notification_pause.sql
+++ b/modules/notification/sql/20260812000001_notification_pause.sql
@@ -6,7 +6,7 @@ CREATE TABLE IF NOT EXISTS `user_notification_pause` (
   `revision` BIGINT UNSIGNED NOT NULL DEFAULT 0,
   `updated_at` DATETIME(3) NOT NULL,
   PRIMARY KEY (`uid`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
 -- +migrate Down
 

--- a/modules/notification/sql/20260812000001_notification_pause.sql
+++ b/modules/notification/sql/20260812000001_notification_pause.sql
@@ -5,7 +5,7 @@ CREATE TABLE IF NOT EXISTS `user_notification_pause` (
   `paused_until` DATETIME(3) NULL,
   `revision` BIGINT UNSIGNED NOT NULL DEFAULT 0,
   `updated_at` DATETIME(3) NOT NULL,
-  PRIMARY KEY (`uid`),
+  PRIMARY KEY (`uid`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 -- +migrate Down

--- a/modules/notification/sql/20260812000001_notification_pause.sql
+++ b/modules/notification/sql/20260812000001_notification_pause.sql
@@ -1,0 +1,14 @@
+-- +migrate Up
+
+CREATE TABLE IF NOT EXISTS `user_notification_pause` (
+  `uid` VARCHAR(40) NOT NULL,
+  `paused_until` DATETIME(3) NULL,
+  `revision` BIGINT UNSIGNED NOT NULL DEFAULT 0,
+  `updated_at` DATETIME(3) NOT NULL,
+  PRIMARY KEY (`uid`),
+  KEY `idx_user_notification_pause_until` (`paused_until`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- +migrate Down
+
+DROP TABLE IF EXISTS `user_notification_pause`;

--- a/modules/notification/swagger/api.yaml
+++ b/modules/notification/swagger/api.yaml
@@ -1,0 +1,126 @@
+openapi: 3.0.3
+info:
+  title: Octo Notification Pause API
+  version: 1.0.0
+paths:
+  /v1/user/notification-pause:
+    get:
+      operationId: getNotificationPause
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Current account notification pause state
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotificationPause'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '500':
+          $ref: '#/components/responses/UpdateFailed'
+    put:
+      operationId: setNotificationPause
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SetNotificationPause'
+      responses:
+        '200':
+          description: Saved authoritative state
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotificationPause'
+        '400':
+          $ref: '#/components/responses/InvalidTime'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '500':
+          $ref: '#/components/responses/UpdateFailed'
+    delete:
+      operationId: clearNotificationPause
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Restored authoritative state
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotificationPause'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '500':
+          $ref: '#/components/responses/UpdateFailed'
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+  schemas:
+    SetNotificationPause:
+      type: object
+      required: [paused_until]
+      properties:
+        paused_until:
+          type: string
+          format: date-time
+          description: UTC absolute time later than server time
+    NotificationPause:
+      type: object
+      required: [paused, paused_until, revision, server_time]
+      properties:
+        paused:
+          type: boolean
+        paused_until:
+          type: string
+          format: date-time
+          nullable: true
+        revision:
+          type: integer
+          format: int64
+          minimum: 0
+        server_time:
+          type: string
+          format: date-time
+      example:
+        paused: true
+        paused_until: '2026-08-12T12:30:00.000Z'
+        revision: 42
+        server_time: '2026-08-12T11:30:00.125Z'
+    Error:
+      type: object
+      required: [code]
+      properties:
+        code:
+          type: string
+  responses:
+    Unauthorized:
+      description: Authentication required
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+          example:
+            code: unauthorized
+    InvalidTime:
+      description: Invalid or non-future pause time
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+          example:
+            code: err.server.notification.pause.invalid_time
+    UpdateFailed:
+      description: Database update failed
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+          example:
+            code: err.server.notification.pause.update_failed

--- a/modules/notification/swagger/api.yaml
+++ b/modules/notification/swagger/api.yaml
@@ -93,34 +93,71 @@ components:
         paused_until: '2026-08-12T12:30:00.000Z'
         revision: 42
         server_time: '2026-08-12T11:30:00.125Z'
-    Error:
+    ErrorDetail:
       type: object
-      required: [code]
+      required: [code, message, details, http_status]
       properties:
         code:
           type: string
+        message:
+          type: string
+        details:
+          type: object
+          additionalProperties: true
+        http_status:
+          type: integer
+          format: int32
+    ErrorEnvelope:
+      type: object
+      required: [error, msg, status]
+      properties:
+        error:
+          $ref: '#/components/schemas/ErrorDetail'
+        msg:
+          type: string
+        status:
+          type: integer
+          format: int32
   responses:
     Unauthorized:
       description: Authentication required
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/Error'
+            $ref: '#/components/schemas/ErrorEnvelope'
           example:
-            code: unauthorized
+            error:
+              code: unauthorized
+              message: Authentication required
+              details: {}
+              http_status: 401
+            msg: Authentication required
+            status: 401
     InvalidTime:
       description: Invalid or non-future pause time
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/Error'
+            $ref: '#/components/schemas/ErrorEnvelope'
           example:
-            code: err.server.notification.pause.invalid_time
+            error:
+              code: err.server.notification.pause.invalid_time
+              message: invalid pause time
+              details: {}
+              http_status: 400
+            msg: invalid pause time
+            status: 400
     UpdateFailed:
       description: Database update failed
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/Error'
+            $ref: '#/components/schemas/ErrorEnvelope'
           example:
-            code: err.server.notification.pause.update_failed
+            error:
+              code: err.server.notification.pause.update_failed
+              message: update failed
+              details: {}
+              http_status: 500
+            msg: update failed
+            status: 500

--- a/modules/notification/swagger/api.yaml
+++ b/modules/notification/swagger/api.yaml
@@ -17,6 +17,8 @@ paths:
                 $ref: '#/components/schemas/NotificationPause'
         '401':
           $ref: '#/components/responses/Unauthorized'
+        '429':
+          $ref: '#/components/responses/RateLimited'
         '500':
           $ref: '#/components/responses/UpdateFailed'
     put:
@@ -40,6 +42,8 @@ paths:
           $ref: '#/components/responses/InvalidTime'
         '401':
           $ref: '#/components/responses/Unauthorized'
+        '429':
+          $ref: '#/components/responses/RateLimited'
         '500':
           $ref: '#/components/responses/UpdateFailed'
     delete:
@@ -55,6 +59,8 @@ paths:
                 $ref: '#/components/schemas/NotificationPause'
         '401':
           $ref: '#/components/responses/Unauthorized'
+        '429':
+          $ref: '#/components/responses/RateLimited'
         '500':
           $ref: '#/components/responses/UpdateFailed'
 components:
@@ -125,14 +131,6 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/ErrorEnvelope'
-          example:
-            error:
-              code: unauthorized
-              message: Authentication required
-              details: {}
-              http_status: 401
-            msg: Authentication required
-            status: 401
     InvalidTime:
       description: Invalid or non-future pause time
       content:
@@ -147,6 +145,25 @@ components:
               http_status: 400
             msg: invalid pause time
             status: 400
+    RateLimited:
+      description: Too many requests for this account
+      headers:
+        Retry-After:
+          schema:
+            type: integer
+          description: Seconds to wait before retrying
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorEnvelope'
+          example:
+            error:
+              code: err.shared.rate.limited
+              message: Too many requests
+              details: {}
+              http_status: 429
+            msg: Too many requests
+            status: 429
     UpdateFailed:
       description: Database update failed
       content:

--- a/modules/webhook/api.go
+++ b/modules/webhook/api.go
@@ -13,6 +13,7 @@ import (
 	"runtime/debug"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/Mininglamp-OSS/octo-lib/common"
 	"github.com/Mininglamp-OSS/octo-lib/config"
@@ -22,6 +23,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhook"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
 	"github.com/Mininglamp-OSS/octo-server/modules/group"
+	"github.com/Mininglamp-OSS/octo-server/modules/notification"
 	"github.com/Mininglamp-OSS/octo-server/modules/user"
 	"github.com/Mininglamp-OSS/octo-server/pkg/cardmsg"
 	"github.com/Mininglamp-OSS/octo-server/pkg/i18n"
@@ -36,14 +38,15 @@ import (
 // Webhook Webhook
 type Webhook struct {
 	log.Log
-	ctx          *config.Context
-	supportTypes []common.ContentType
-	db           *DB
-	messageDB    *messageDB
-	pushMap      map[common.DeviceType]map[string]Push
-	groupService group.IService
-	userService  user.IService
-	secretKey    string // Webhook HMAC-SHA256 签名密钥
+	ctx                 *config.Context
+	supportTypes        []common.ContentType
+	db                  *DB
+	messageDB           *messageDB
+	pushMap             map[common.DeviceType]map[string]Push
+	groupService        group.IService
+	userService         user.IService
+	notificationService *notification.Service
+	secretKey           string // Webhook HMAC-SHA256 签名密钥
 	wkhook.UnimplementedWebhookServiceServer
 	grpcServer *grpc.Server
 }
@@ -117,15 +120,16 @@ func New(ctx *config.Context) *Webhook {
 		}
 	}
 	return &Webhook{
-		db:           NewDB(ctx.DB()),
-		supportTypes: supportTypes,
-		ctx:          ctx,
-		Log:          log.NewTLog("Webhook"),
-		pushMap:      pushMap,
-		messageDB:    newMessageDB(ctx),
-		groupService: group.NewService(ctx),
-		userService:  user.NewService(ctx),
-		secretKey:    os.Getenv("TS_WEBHOOK_SECRET_KEY"),
+		db:                  NewDB(ctx.DB()),
+		supportTypes:        supportTypes,
+		ctx:                 ctx,
+		Log:                 log.NewTLog("Webhook"),
+		pushMap:             pushMap,
+		messageDB:           newMessageDB(ctx),
+		groupService:        group.NewService(ctx),
+		userService:         user.NewService(ctx),
+		notificationService: notification.New(ctx),
+		secretKey:           os.Getenv("TS_WEBHOOK_SECRET_KEY"),
 	}
 }
 func getSupportTypes() []common.ContentType {
@@ -533,6 +537,28 @@ func (w *Webhook) pushTo(msgResp msgOfflineNotify, toUids []string) error {
 	if !w.containSupportType(common.ContentType(msgResp.ContentType)) && !isVideoCall {
 		w.Debug("不推送：不支持的消息类型！", zap.Int("contentType", msgResp.ContentType), zap.Bool("signal", setting.Signal))
 		return nil
+	}
+
+	// 账号级快捷静音只抑制消息离线 Push，不影响 RTC/来电推送。
+	// 在进入 PushPool 前一次性查询全部接收 UID，避免每个设备任务产生 N+1 查询。
+	if !isVideoCall && w.notificationService != nil {
+		pausedUIDs, err := w.notificationService.ActiveUIDs(toUids, time.Now().UTC())
+		if err != nil {
+			// 静音状态查询失败时 fail closed，避免在用户已选择静音时发送本次 Push。
+			w.Error("查询账号级通知暂停状态失败，本次 Push 跳过", zap.Error(err), zap.Int("toUidsCount", len(toUids)))
+			return nil
+		}
+		if len(pausedUIDs) > 0 {
+			for _, uid := range toUids {
+				if _, paused := pausedUIDs[uid]; paused {
+					w.Debug("因账号级通知暂停抑制 Push", zap.String("uid", uid))
+				}
+			}
+			toUids = excludePausedUIDs(toUids, pausedUIDs)
+			if len(toUids) == 0 {
+				return nil
+			}
+		}
 	}
 
 	// 解析消息来源的 space_id

--- a/modules/webhook/api.go
+++ b/modules/webhook/api.go
@@ -547,12 +547,6 @@ func (w *Webhook) pushTo(msgResp msgOfflineNotify, toUids []string) error {
 			// 快捷静音是 best-effort 的通知偏好，不是安全边界。查询失败时
 			// 必须继续原有 Push，避免一次 DB 故障静默丢弃整批离线通知。
 			w.Error("查询账号级通知暂停状态失败，继续发送原始 Push", zap.Error(err), zap.Int("toUidsCount", len(toUids)))
-		} else if len(pausedUIDs) > 0 {
-			for _, uid := range toUids {
-				if _, paused := pausedUIDs[uid]; paused {
-					w.Debug("因账号级通知暂停抑制 Push", zap.String("uid", uid))
-				}
-			}
 		}
 		toUids = filterPausedUIDs(toUids, pausedUIDs, err)
 		if err == nil && len(toUids) == 0 {

--- a/modules/webhook/api.go
+++ b/modules/webhook/api.go
@@ -544,20 +544,19 @@ func (w *Webhook) pushTo(msgResp msgOfflineNotify, toUids []string) error {
 	if !isVideoCall && w.notificationService != nil {
 		pausedUIDs, err := w.notificationService.ActiveUIDs(toUids, time.Now().UTC())
 		if err != nil {
-			// 静音状态查询失败时 fail closed，避免在用户已选择静音时发送本次 Push。
-			w.Error("查询账号级通知暂停状态失败，本次 Push 跳过", zap.Error(err), zap.Int("toUidsCount", len(toUids)))
-			return nil
-		}
-		if len(pausedUIDs) > 0 {
+			// 快捷静音是 best-effort 的通知偏好，不是安全边界。查询失败时
+			// 必须继续原有 Push，避免一次 DB 故障静默丢弃整批离线通知。
+			w.Error("查询账号级通知暂停状态失败，继续发送原始 Push", zap.Error(err), zap.Int("toUidsCount", len(toUids)))
+		} else if len(pausedUIDs) > 0 {
 			for _, uid := range toUids {
 				if _, paused := pausedUIDs[uid]; paused {
 					w.Debug("因账号级通知暂停抑制 Push", zap.String("uid", uid))
 				}
 			}
-			toUids = excludePausedUIDs(toUids, pausedUIDs)
-			if len(toUids) == 0 {
-				return nil
-			}
+		}
+		toUids = filterPausedUIDs(toUids, pausedUIDs, err)
+		if err == nil && len(toUids) == 0 {
+			return nil
 		}
 	}
 

--- a/modules/webhook/notification_pause.go
+++ b/modules/webhook/notification_pause.go
@@ -1,0 +1,15 @@
+package webhook
+
+func excludePausedUIDs(uids []string, paused map[string]struct{}) []string {
+	if len(paused) == 0 {
+		return uids
+	}
+	filtered := make([]string, 0, len(uids))
+	for _, uid := range uids {
+		if _, ok := paused[uid]; ok {
+			continue
+		}
+		filtered = append(filtered, uid)
+	}
+	return filtered
+}

--- a/modules/webhook/notification_pause.go
+++ b/modules/webhook/notification_pause.go
@@ -12,7 +12,7 @@ func filterPausedUIDs(uids []string, paused map[string]struct{}, lookupErr error
 
 func excludePausedUIDs(uids []string, paused map[string]struct{}) []string {
 	if len(paused) == 0 {
-		return uids
+		return append([]string(nil), uids...)
 	}
 	filtered := make([]string, 0, len(uids))
 	for _, uid := range uids {

--- a/modules/webhook/notification_pause.go
+++ b/modules/webhook/notification_pause.go
@@ -1,5 +1,15 @@
 package webhook
 
+// filterPausedUIDs applies the account-level pause only when the lookup
+// succeeded. A lookup error must not turn a best-effort notification feature
+// into a silent drop of the entire offline-push batch.
+func filterPausedUIDs(uids []string, paused map[string]struct{}, lookupErr error) []string {
+	if lookupErr != nil {
+		return uids
+	}
+	return excludePausedUIDs(uids, paused)
+}
+
 func excludePausedUIDs(uids []string, paused map[string]struct{}) []string {
 	if len(paused) == 0 {
 		return uids

--- a/modules/webhook/notification_pause_test.go
+++ b/modules/webhook/notification_pause_test.go
@@ -22,8 +22,11 @@ func TestExcludePausedUIDs(t *testing.T) {
 func TestExcludePausedUIDsKeepsInputWhenNoPausedUID(t *testing.T) {
 	uids := []string{"u1", "u2"}
 	got := excludePausedUIDs(uids, nil)
-	if len(got) != len(uids) || &got[0] != &uids[0] {
-		t.Fatalf("no-op filtering should preserve the input slice")
+	if len(got) != len(uids) || got[0] != uids[0] || got[1] != uids[1] {
+		t.Fatalf("no-op filtering should preserve the recipients, got %v", got)
+	}
+	if &got[0] == &uids[0] {
+		t.Fatalf("no-op filtering should not alias the input slice")
 	}
 }
 

--- a/modules/webhook/notification_pause_test.go
+++ b/modules/webhook/notification_pause_test.go
@@ -1,0 +1,25 @@
+package webhook
+
+import "testing"
+
+func TestExcludePausedUIDs(t *testing.T) {
+	uids := []string{"u1", "u2", "u3", "u2"}
+	got := excludePausedUIDs(uids, map[string]struct{}{"u2": {}})
+	want := []string{"u1", "u3"}
+	if len(got) != len(want) {
+		t.Fatalf("expected %v, got %v", want, got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("expected %v, got %v", want, got)
+		}
+	}
+}
+
+func TestExcludePausedUIDsKeepsInputWhenNoPausedUID(t *testing.T) {
+	uids := []string{"u1", "u2"}
+	got := excludePausedUIDs(uids, nil)
+	if len(got) != len(uids) || &got[0] != &uids[0] {
+		t.Fatalf("no-op filtering should preserve the input slice")
+	}
+}

--- a/modules/webhook/notification_pause_test.go
+++ b/modules/webhook/notification_pause_test.go
@@ -1,6 +1,9 @@
 package webhook
 
-import "testing"
+import (
+	"context"
+	"testing"
+)
 
 func TestExcludePausedUIDs(t *testing.T) {
 	uids := []string{"u1", "u2", "u3", "u2"}
@@ -21,5 +24,20 @@ func TestExcludePausedUIDsKeepsInputWhenNoPausedUID(t *testing.T) {
 	got := excludePausedUIDs(uids, nil)
 	if len(got) != len(uids) || &got[0] != &uids[0] {
 		t.Fatalf("no-op filtering should preserve the input slice")
+	}
+}
+
+func TestFilterPausedUIDsFailsOpenWhenLookupFails(t *testing.T) {
+	uids := []string{"u1", "u2"}
+	got := filterPausedUIDs(uids, map[string]struct{}{"u1": {}}, context.DeadlineExceeded)
+	if len(got) != len(uids) || got[0] != "u1" || got[1] != "u2" {
+		t.Fatalf("lookup failure must preserve the original recipients, got %v", got)
+	}
+}
+
+func TestFilterPausedUIDsExcludesOnlyKnownPausedUIDs(t *testing.T) {
+	got := filterPausedUIDs([]string{"u1", "u2"}, map[string]struct{}{"u1": {}}, nil)
+	if len(got) != 1 || got[0] != "u2" {
+		t.Fatalf("expected only paused uid to be removed, got %v", got)
 	}
 }

--- a/pkg/errcode/notification.go
+++ b/pkg/errcode/notification.go
@@ -1,0 +1,21 @@
+package errcode
+
+import (
+	"net/http"
+
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n/codes"
+)
+
+var (
+	ErrNotificationPauseInvalidTime = register(codes.Code{
+		ID:             "err.server.notification.pause.invalid_time",
+		HTTPStatus:     http.StatusBadRequest,
+		DefaultMessage: "Notification pause time is invalid.",
+	})
+	ErrNotificationPauseUpdateFailed = register(codes.Code{
+		ID:             "err.server.notification.pause.update_failed",
+		HTTPStatus:     http.StatusInternalServerError,
+		DefaultMessage: "Failed to update notification pause state.",
+		Internal:       true,
+	})
+)

--- a/pkg/httperr/respond.go
+++ b/pkg/httperr/respond.go
@@ -34,6 +34,9 @@ func ResponseErrorL(c *wkhttp.Context, code codes.Code, params i18n.Params, deta
 //   - the Octo-link Bot bind/unbind endpoints (modules/botfather/api_user.go,
 //     POST/DELETE /v1/user/bots/:bot_id/bind) — new endpoints that must return
 //     real REST status (404/409/…) so external Agents branch on the wire code.
+//   - The account notification-pause endpoints (modules/notification/api.go)
+//     — new settings-center endpoints whose invalid-time and storage errors
+//     expose their canonical 400/500 statuses to the client.
 //   - the document-comment Bot mention ingress (modules/bot_mention/api.go,
 //     POST /v1/internal/bot-mentions) — a new service-to-service endpoint whose
 //     docs-backend caller branches on 401/404/409/500 retry semantics.

--- a/pkg/i18n/locales/active.zh-CN.toml
+++ b/pkg/i18n/locales/active.zh-CN.toml
@@ -1345,3 +1345,11 @@ other = "该幂等键已用于不同的请求。"
 
 ["err.server.bot_mention.store_failed"]
 other = "文档评论机器人事件处理失败。"
+
+# ---- modules/notification：账号级快捷静音 ----
+
+["err.server.notification.pause.invalid_time"]
+other = "通知暂停时间无效。"
+
+["err.server.notification.pause.update_failed"]
+other = "更新通知暂停状态失败。"

--- a/pkg/i18n/locales/active.zh-CN.toml
+++ b/pkg/i18n/locales/active.zh-CN.toml
@@ -1245,13 +1245,6 @@ other = "运营看板 ETL 正在运行，请稍后再试。"
 ["err.server.opanalytics.etl_trigger_failed"]
 other = "触发运营看板 ETL 失败。"
 
-# ---- modules/notification：账号级快捷静音 ----
-
-["err.server.notification.pause.invalid_time"]
-other = "通知暂停时间无效。"
-
-["err.server.notification.pause.update_failed"]
-other = "更新通知暂停状态失败。"
 
 # ---- modules/messages_search：消息搜索（直查 OpenSearch） ----
 

--- a/pkg/i18n/locales/active.zh-CN.toml
+++ b/pkg/i18n/locales/active.zh-CN.toml
@@ -1245,6 +1245,14 @@ other = "运营看板 ETL 正在运行，请稍后再试。"
 ["err.server.opanalytics.etl_trigger_failed"]
 other = "触发运营看板 ETL 失败。"
 
+# ---- modules/notification：账号级快捷静音 ----
+
+["err.server.notification.pause.invalid_time"]
+other = "通知暂停时间无效。"
+
+["err.server.notification.pause.update_failed"]
+other = "更新通知暂停状态失败。"
+
 # ---- modules/messages_search：消息搜索（直查 OpenSearch） ----
 
 ["err.server.messages_search.validation_failed"]

--- a/tools/i18nmarkers/server/active.en-US.toml
+++ b/tools/i18nmarkers/server/active.en-US.toml
@@ -684,6 +684,12 @@ other = "The binding session has expired or is invalid. Please start over."
 ["err.server.oidc.bind_verify_required"]
 other = "Please complete verification before confirming."
 
+["err.server.notification.pause.invalid_time"]
+other = "Notification pause time is invalid."
+
+["err.server.notification.pause.update_failed"]
+other = "Failed to update notification pause state."
+
 ["err.server.opanalytics.etl_already_running"]
 other = "Analytics ETL is already running."
 
@@ -1286,9 +1292,3 @@ other = "Invalid request."
 
 ["err.server.workplace.store_failed"]
 other = "Failed to update workplace data."
-
-["err.server.notification.pause.invalid_time"]
-other = "Notification pause time is invalid."
-
-["err.server.notification.pause.update_failed"]
-other = "Failed to update notification pause state."

--- a/tools/i18nmarkers/server/active.en-US.toml
+++ b/tools/i18nmarkers/server/active.en-US.toml
@@ -1286,3 +1286,9 @@ other = "Invalid request."
 
 ["err.server.workplace.store_failed"]
 other = "Failed to update workplace data."
+
+["err.server.notification.pause.invalid_time"]
+other = "Notification pause time is invalid."
+
+["err.server.notification.pause.update_failed"]
+other = "Failed to update notification pause state."

--- a/tools/i18nmarkers/server/active.en-US.toml
+++ b/tools/i18nmarkers/server/active.en-US.toml
@@ -612,6 +612,12 @@ other = "Message search failed."
 ["err.server.message.store_failed"]
 other = "Failed to persist message data."
 
+["err.server.notification.pause.invalid_time"]
+other = "Notification pause time is invalid."
+
+["err.server.notification.pause.update_failed"]
+other = "Failed to update notification pause state."
+
 ["err.server.messages_search.depth_exceeded"]
 other = "Search pagination depth limit reached; narrow your query."
 

--- a/tools/i18nmarkers/server/active.en-US.toml
+++ b/tools/i18nmarkers/server/active.en-US.toml
@@ -612,7 +612,6 @@ other = "Message search failed."
 ["err.server.message.store_failed"]
 other = "Failed to persist message data."
 
-
 ["err.server.messages_search.depth_exceeded"]
 other = "Search pagination depth limit reached; narrow your query."
 

--- a/tools/i18nmarkers/server/active.en-US.toml
+++ b/tools/i18nmarkers/server/active.en-US.toml
@@ -633,6 +633,12 @@ other = "Search service is temporarily unavailable."
 ["err.server.messages_search.validation_failed"]
 other = "Invalid search request."
 
+["err.server.notification.pause.invalid_time"]
+other = "Notification pause time is invalid."
+
+["err.server.notification.pause.update_failed"]
+other = "Failed to update notification pause state."
+
 ["err.server.notify.card_invalid"]
 other = "The card notification request is invalid."
 
@@ -683,12 +689,6 @@ other = "The binding session has expired or is invalid. Please start over."
 
 ["err.server.oidc.bind_verify_required"]
 other = "Please complete verification before confirming."
-
-["err.server.notification.pause.invalid_time"]
-other = "Notification pause time is invalid."
-
-["err.server.notification.pause.update_failed"]
-other = "Failed to update notification pause state."
 
 ["err.server.opanalytics.etl_already_running"]
 other = "Analytics ETL is already running."

--- a/tools/i18nmarkers/server/active.en-US.toml
+++ b/tools/i18nmarkers/server/active.en-US.toml
@@ -612,11 +612,6 @@ other = "Message search failed."
 ["err.server.message.store_failed"]
 other = "Failed to persist message data."
 
-["err.server.notification.pause.invalid_time"]
-other = "Notification pause time is invalid."
-
-["err.server.notification.pause.update_failed"]
-other = "Failed to update notification pause state."
 
 ["err.server.messages_search.depth_exceeded"]
 other = "Search pagination depth limit reached; narrow your query."


### PR DESCRIPTION


## Summary

- 新增账号级快捷静音状态表及 migration
- 新增 GET/PUT/DELETE notification pause API
- 增加 UTC 绝对时间、revision 和跨设备 CMD 同步
- 在 webhook 离线 Push 入口按 UID 批量拦截有效静音账号
- RTC/来电 Push 不受快捷静音影响
- 补齐 OpenAPI 3.0.3、i18n 错误码和 UID 限流
- 本 PR 基于最新 upstream `main` 提交 `2c98180d`

## Verification

- `go test -count=1 ./modules/notification ./modules/webhook ./pkg/errcode`
- `make i18n-extract-check`
- `make i18n-lint`
- `gofmt`、OpenAPI YAML 解析、`git diff --check`

## Octospec

- Linked Spec: `.octospec/tasks/notification-pause/brief.md` (upstream: octo-web settings-center T19)
- COMPREHENSION: account-level server-authoritative pause state, revisioned cross-device CMD sync, offline message Push filtering, and fail-open behavior on lookup failure.
- Review follow-ups: transaction-consistent read-back, idempotent DELETE, 30-day upper bound, and batched UID lookup.

## Review follow-up status

- Fixed: fail-open lookup, transaction-consistent read-back, idempotent DELETE, 30-day cap, UID batching, Swagger envelope/429, i18n duplicate markers, and notification legacy-response guard.
- Documented: notification consumer of ResponseErrorLWithStatus.
- Non-blocking pending confirmation: Signal-encrypted RTC/call invite detection.