### PR TITLE
feat(common): deliver tracking_enabled in appconfig

### DIFF
--- a/modules/common/api.go
+++ b/modules/common/api.go
@@ -401,6 +401,7 @@ func (cn *Common) appConfig(c *wkhttp.Context) {
 			DriveOn:                cn.systemSettings.DriveEnabled(),
 			DmloopOn:               cn.systemSettings.DmloopEnabled(),
 			DmpersonalOn:           cn.systemSettings.DmpersonalEnabled(),
+			TrackingEnabled:        cn.systemSettings.TrackingEnabled(),
 			MessageReaction:        messageReaction,
 			// Sticker 上限:短路分支同样下发,让老客户端在管理台放宽/收窄后
 			// 也能立刻拿到最新值。
@@ -453,6 +454,7 @@ func (cn *Common) appConfig(c *wkhttp.Context) {
 		DriveOn:                cn.systemSettings.DriveEnabled(),
 		DmloopOn:               cn.systemSettings.DmloopEnabled(),
 		DmpersonalOn:           cn.systemSettings.DmpersonalEnabled(),
+		TrackingEnabled:        cn.systemSettings.TrackingEnabled(),
 		MessageReaction:        messageReaction,
 		// Sticker 上限:客户端本地预校验用,兜底仍在服务端 modules/file 侧。
 		StickerUploadLimits: buildStickerUploadLimitsResp(cn.systemSettings),
@@ -856,6 +858,14 @@ type appConfigResp struct {
 	// 解耦(同 DocsOn):运维切策略后老客户端命中 version 短路分支也须拿到最新值,故两分支都下发。
 	DmloopOn     bool `json:"dmloop_on"`
 	DmpersonalOn bool `json:"dmpersonal_on"`
+
+	// TrackingEnabled 告知客户端是否开启前端埋点(octo-dap)采集。值来源于 system_setting
+	// tracking.enabled；默认 false —— 埋点层随发布上线但静默(fail-closed)，octo-web 只有拿到
+	// 此字段为真才开始采集。collector 与 TRACK_API_URL egress 在集群内验证通过前运维保持关闭。
+	// 只表达采集策略，不承担服务端鉴权(collector 自身鉴权)。与 app_config.version 解耦的原因
+	// 同 DocsOn：运维切策略后老客户端命中 version 短路分支也须拿到最新值，故两分支都下发。
+	TrackingEnabled bool `json:"tracking_enabled"`
+
 
 	// MessageReaction is the deployment-wide default capability for ordinary
 	// Web/iOS/Android clients. It is intentionally identity-agnostic because

--- a/modules/common/api_test.go
+++ b/modules/common/api_test.go
@@ -1022,7 +1022,56 @@ func TestGetAppConfig_LoopFlags_OnVersionShortCircuit(t *testing.T) {
 	assert.Contains(t, w.Body.String(), `"dmpersonal_on":true`)
 }
 
-// appconfig 必须下发 drive_on：值来源于 system_setting drive.enabled。默认 false，
+// appconfig 必须下发 tracking_enabled:值来源于 system_setting tracking.enabled。默认 false,
+// 埋点层随发布上线但静默(fail-closed),octo-web 只有拿到此字段为真才开始采集。
+func TestGetAppConfig_TrackingEnabled_DefaultFalse(t *testing.T) {
+	s, ctx := testutil.NewTestServer()
+	f := New(ctx)
+	cleanAllTablesAndReloadSettings(t, ctx)
+	err := f.appConfigDB.insert(&appConfigModel{})
+	assert.NoError(t, err)
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/v1/common/appconfig", nil)
+	req.Header.Set("token", testutil.Token)
+	s.GetRoute().ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), `"tracking_enabled":false`)
+}
+
+// system_setting tracking.enabled=true → appconfig 下发 true,客户端开始埋点采集。
+func TestGetAppConfig_TrackingEnabled_True(t *testing.T) {
+	s, ctx := testutil.NewTestServer()
+	f := New(ctx)
+	cleanAllTablesAndReloadSettings(t, ctx)
+	setModuleEnabledSetting(t, ctx, "tracking", true)
+	err := f.appConfigDB.insert(&appConfigModel{})
+	assert.NoError(t, err)
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/v1/common/appconfig", nil)
+	req.Header.Set("token", testutil.Token)
+	s.GetRoute().ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), `"tracking_enabled":true`)
+}
+
+// version 短路分支同样要下发 tracking_enabled:采集开关须与 app_config.version 解耦,
+// 避免运维切换后老客户端命中版本短路而继续用旧值(同 docs_on)。
+func TestGetAppConfig_TrackingEnabled_OnVersionShortCircuit(t *testing.T) {
+	s, ctx := testutil.NewTestServer()
+	f := New(ctx)
+	cleanAllTablesAndReloadSettings(t, ctx)
+	setModuleEnabledSetting(t, ctx, "tracking", true)
+	err := f.appConfigDB.insert(&appConfigModel{})
+	assert.NoError(t, err)
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/v1/common/appconfig?version=99999999", nil)
+	req.Header.Set("token", testutil.Token)
+	s.GetRoute().ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), `"tracking_enabled":true`)
+}
+
+
 // 客户端据此隐藏网盘(drive)模块入口（独立部署的 octo-drive 上线前）。
 func TestGetAppConfig_DriveOn_DefaultFalse(t *testing.T) {
 	s, ctx := testutil.NewTestServer()

--- a/modules/common/system_setting_schema.go
+++ b/modules/common/system_setting_schema.go
@@ -297,6 +297,13 @@ var systemSettingSchema = []settingDef{
 	{Category: "dmpersonal", Key: "enabled", Type: settingTypeBool, Description: "是否向客户端展示「我的/运行时」模块入口（默认关闭；与 dmloop 分开以便独立放量）",
 		Effective: func(s *SystemSettings) string { return boolToCanonical(s.DmpersonalEnabled()) }},
 
+	// 前端埋点(octo-dap)采集总开关。默认关闭，埋点层随发布上线但静默(fail-closed)：
+	// octo-web 只有在 appconfig 下发 tracking_enabled 为真时才开始采集。采集器 collector
+	// 与 TRACK_API_URL egress 在集群内验证通过前，运维保持此开关为关。仅表达采集策略，
+	// 不承担服务端鉴权(collector 自身鉴权)。经 GET /v1/common/appconfig 的 tracking_enabled 下发给客户端。
+	{Category: "tracking", Key: "enabled", Type: settingTypeBool, Description: "是否开启前端埋点(octo-dap)采集（collector 与 egress 在集群内验证通过前默认关闭）",
+		Effective: func(s *SystemSettings) string { return boolToCanonical(s.TrackingEnabled()) }},
+
 	// 自定义贴纸上传限制（sticker-upload-compression 任务）。原先硬编码在
 	// modules/file/const.go；挪进 system_setting 后可灰度/回滚，且每键都有
 	// 服务端硬上限（stickerUpload*HardCap / stickerCompress*HardCap），误配也不会

--- a/modules/common/system_settings.go
+++ b/modules/common/system_settings.go
@@ -1373,6 +1373,18 @@ func (s *SystemSettings) DmpersonalEnabled() bool {
 	return s.getBool("dmpersonal", "enabled", false)
 }
 
+// TrackingEnabled reports whether the frontend event-tracking layer (octo-dap)
+// should collect. Default false — the tracker ships dark (fail-closed): octo-web
+// only starts collecting when appconfig delivers tracking_enabled truthy, so ops
+// keeps this off until the octo-dap collector is deployed and the TRACK_API_URL
+// egress is verified in-cluster. Display/behaviour policy only; the collector
+// enforces its own auth. Value source: system_setting tracking.enabled
+// (DB, hot-reloaded — flip in the admin console, 60s multi-instance converge,
+// no restart). Delivered via GET /v1/common/appconfig as tracking_enabled.
+func (s *SystemSettings) TrackingEnabled() bool {
+	return s.getBool("tracking", "enabled", false)
+}
+
 // ---------------------------------------------------------------------------
 // Custom-sticker upload constraints + optional server-side compression
 // (sticker-upload-compression task).


### PR DESCRIPTION
## What

Add a `tracking.enabled` system_setting and surface it as `tracking_enabled` in `GET /v1/common/appconfig`, so the octo-web event-tracking layer (octo-dap) can be switched on/off from the admin console without a deploy.

- `SystemSettings.TrackingEnabled()` reads `system_setting` `tracking.enabled`, default `false`.
- Registered in the setting schema (typed bool, `effective_value` queryable), grouped with the module-display toggles.
- New `TrackingEnabled bool \`json:"tracking_enabled"\`` on `appConfigResp`, assigned in **both** handler branches (version-shortcut and full-refresh).

## Why

The frontend tracker is fail-closed: it ships dark and only collects once appconfig delivers `tracking_enabled` truthy (octo-web#1330). octo-server never emitted such a field, so ops could not enable tracking at all. This closes that gap, mirroring `docs_on` / `dmloop_on`.

## Behaviour

- Default `false` — no behaviour change on existing deployments until ops flips it.
- Hot-reloaded (no restart; 60s multi-instance convergence).
- Delivered in both branches so old clients hitting the version short-circuit still get the current value.

## Operational preconditions (keep off until met)

1. The octo-dap collector is deployed and the `TRACK_API_URL` egress is verified in-cluster (same-origin `/v1/e/b` → collector).
2. The collector must **not** log the business `token` header.

Display/collection policy only; the collector enforces its own auth.

## Tests

`TestGetAppConfig_TrackingEnabled_DefaultFalse` / `_True` / `_OnVersionShortCircuit` (mirror the docs/dmloop tests). Build + the appconfig/schema test suite pass on a clean DB.


Fixes #750
