### PR TITLE
fix(group): resolve the invite page download entry from the updater endpoint

### DIFF
--- a/.octospec/tasks/invite-page-download-entry/brief.md
+++ b/.octospec/tasks/invite-page-download-entry/brief.md
@@ -38,9 +38,14 @@ so no new configuration is required:
 the updater endpoint (`common/updater/android/1.0`, `common/updater/ios/1.0.0`).
 The invite page was simply never wired to it.
 
-Deliberately **not** used: `appconfig.web_url`. With both platform buttons
-rendering everywhere, there is no case left that needs a "go to the web app"
-fallback.
+`appconfig.web_url` is used as a last resort, but only when **neither** platform
+yields a usable installer. That case is reachable in practice — both platforms
+lacking a version record, the updater returning 5xx, the network failing, or every
+address failing validation — and without a fallback the page renders a group card
+above an unexplained blank, with the invite-detail request succeeding so nothing
+looks wrong. An earlier revision ruled `web_url` out on the grounds that both
+buttons render everywhere; that reasoning assumed at least one row resolves, which
+is exactly the assumption this case violates.
 
 Prior art constraining the design: `octo-server#1246` removed the `dmwork://`
 deep link because neither mobile client registers the scheme; a grep test pins
@@ -86,7 +91,19 @@ that. No "open in app" button may be reintroduced.
       itself as Macintosh, so a wrong guess hands over the wrong platform's installer.
 - [x] A platform with no version record (updater 204), a malformed address, or a
       failed request hides only its own row. Nothing falls back to `API_BASE`.
-- [x] The address passes a scheme allowlist (http/https) before reaching `a.href`.
+- [x] Installer addresses must be absolute http/https **and carry a file suffix**.
+      Relative values are rejected rather than resolved: this page and the web login
+      page would resolve them against different bases (`API_BASE` vs
+      `location.origin`), so at most one could be right. A suffix-less address is a
+      landing page, not a package — a download button that opens a web page is the
+      same broken promise this task exists to remove.
+- [x] When neither platform yields an installer, fall back to `appconfig.web_url`
+      (absolute http/https, no suffix requirement — a portal is not a package).
+      If that is unavailable too, still show nothing; never `API_BASE`.
+- [x] Copying chains the `execCommand` fallback onto a **rejected** `writeText`,
+      not merely onto the Clipboard API being absent. Embedded IM webviews commonly
+      expose `navigator.clipboard` under HTTPS and then deny the write, which is
+      precisely the environment the fallback exists for.
 - [x] Zero external resources: no CDN script, external stylesheet, `@import`,
       `url(http…)` or remote image; icons are inline SVG
       (`TestGroupInvitePage_NoExternalResources`).

--- a/.octospec/tasks/invite-page-download-entry/brief.md
+++ b/.octospec/tasks/invite-page-download-entry/brief.md
@@ -91,12 +91,11 @@ that. No "open in app" button may be reintroduced.
       itself as Macintosh, so a wrong guess hands over the wrong platform's installer.
 - [x] A platform with no version record (updater 204), a malformed address, or a
       failed request hides only its own row. Nothing falls back to `API_BASE`.
-- [x] Installer addresses must be absolute http/https **and carry a file suffix**.
-      Relative values are rejected rather than resolved: this page and the web login
-      page would resolve them against different bases (`API_BASE` vs
-      `location.origin`), so at most one could be right. A suffix-less address is a
-      landing page, not a package — a download button that opens a web page is the
-      same broken promise this task exists to remove.
+- [x] Installer addresses must be absolute http/https. Relative values are rejected
+      rather than resolved: this page and the web login page would resolve them
+      against different bases (`API_BASE` vs `location.origin`), so at most one could
+      be right. **No further local rule is added on top of the scheme allowlist** —
+      see the rejected-alternative note below.
 - [x] When neither platform yields an installer, fall back to `appconfig.web_url`
       (absolute http/https, no suffix requirement — a portal is not a package).
       If that is unavailable too, still show nothing; never `API_BASE`.
@@ -109,6 +108,33 @@ that. No "open in app" button may be reintroduced.
       (`TestGroupInvitePage_NoExternalResources`).
 - [x] `modules/group` passes under the CI recipe (fresh database, `-race`,
       `-shuffle=on`).
+
+## Rejected alternative: requiring a file suffix on installer addresses
+
+A revision of this task briefly required the installer address's last path segment
+to carry a file extension, on the theory that a suffix-less address is a landing
+page rather than a package. Review rejected it and the rejection is correct:
+
+- **It does not discriminate.** It accepts `…/download/ios.html` — exactly the
+  landing page it was meant to exclude — while rejecting App Store and TestFlight
+  addresses and any signed download URL that carries its filename in the query.
+- **It is unsatisfiable for iOS.** Installing an iOS app from a browser requires the
+  `itms-services:` scheme, which the (correct) scheme allowlist rejects. Every
+  address that actually installs the app from a mobile browser is therefore a store
+  or TestFlight page, and every one of those is suffix-less. No iOS value could both
+  pass validation and work.
+- **It contradicts this task's own reasoning.** Relative addresses are rejected here
+  precisely because this page and the web login page would disagree about the same
+  stored value. A suffix rule creates that same disagreement — `octo-web`'s
+  `resolveSafeDownloadUrl` validates only the scheme, and `addAppVersion` imposes no
+  format constraint at all — so one page would show a working button where the other
+  hides it.
+- **The `web_url` fallback does not cover it.** The fallback requires *both*
+  platforms to fail, so a deployment with a suffixed Android APK and an App Store
+  iOS address would leave an iPhone visitor with an Android-only page.
+
+A download address pointing at a web page is a data-quality problem whose owner is
+the admin console's validation. A landing page cannot detect it from a URL string.
 
 ## Known verification gap
 

--- a/.octospec/tasks/invite-page-download-entry/brief.md
+++ b/.octospec/tasks/invite-page-download-entry/brief.md
@@ -70,8 +70,11 @@ that. No "open in app" button may be reintroduced.
 
 - `octo-web`: no shared download component, no download entry in the logged-in
   shell. The invite page is self-contained instead.
-- `appconfig.web_url` as a desktop fallback — unnecessary once both buttons render
-  on desktop.
+- A **desktop-triggered** `web_url` entry. Both platform rows render on desktop, so
+  nothing needs to key off the platform. Note this is not a blanket exclusion of
+  `web_url`: a fallback gated on *neither platform resolving* is in scope and
+  implemented — see Background. Do not read this line as permission to delete
+  `setupWebFallback`.
 - The other landing pages (`space_email_invite.html`, `space_join_approve.html`) —
   they have no download button and are unaffected.
 - The pre-existing `t.Skip` on `TestGroupInvitePage_NoDmworkScheme` (OCTO migration

--- a/.octospec/tasks/invite-page-download-entry/brief.md
+++ b/.octospec/tasks/invite-page-download-entry/brief.md
@@ -1,0 +1,104 @@
+---
+type: Task
+title: "Task: invite-page-download-entry"
+description: Resolve the group invite landing page's app-download entry from the public updater endpoint instead of the API base URL.
+tags: ["group", "invite", "h5", "download"]
+timestamp: 2026-08-13T00:00:00Z
+# --- octospec extension fields ---
+slug: invite-page-download-entry
+upstream: Mininglamp-OSS/octo-server (regression from 10cff2da "feat(group): public H5 invite landing page")
+source: self
+---
+
+# Task: invite-page-download-entry
+
+## Goal
+
+Make the group invite landing page's app-download entry actually lead to an
+installer.
+
+The page bound its single "download app" button to the injected `API_BASE`. In
+production `External.BaseURL` is the API prefix (`https://<host>/api`), so the
+only download entry point on the page was a guaranteed 404 — verified live
+against the deployed host. The code comment said "fall back to the product
+site", but the implementation reused the API base; semantics and implementation
+had diverged.
+
+## Background
+
+Two public, unauthenticated endpoints already serve exactly what the page needs,
+so no new configuration is required:
+
+| Endpoint | Returns | Existing consumer |
+|---|---|---|
+| `GET /v1/common/updater/{os}/{version}` | `{"url": "<installer>"}` | web login page download popover |
+| `GET /v1/common/appconfig` | `web_url` (= `External.WebLoginURL`) | clients |
+
+`octo-web`'s `dmworklogin` package already resolves installer addresses through
+the updater endpoint (`common/updater/android/1.0`, `common/updater/ios/1.0.0`).
+The invite page was simply never wired to it.
+
+Deliberately **not** used: `appconfig.web_url`. With both platform buttons
+rendering everywhere, there is no case left that needs a "go to the web app"
+fallback.
+
+Prior art constraining the design: `octo-server#1246` removed the `dmwork://`
+deep link because neither mobile client registers the scheme; a grep test pins
+that. No "open in app" button may be reintroduced.
+
+## Load-bearing list
+
+- **Public invite landing page** (`assets/web/group_invite.html`) — unauthenticated,
+  rate-limited, the first product surface many users see. Rendered by
+  `groupInvitePage` (`modules/group/api.go`) via `{{API_BASE_URL}}` substitution.
+- **`External.BaseURL` injection contract** — still injected as `API_BASE` and
+  still used for API calls. Only its misuse as a *download page* address is removed.
+- **Cross-module route dependency** — the page hardcodes `modules/common`'s
+  `/v1/common/updater/:os/:version` as a string with no symbolic reference from Go.
+- **URL destination handling** (`.octospec/rules/trust-boundary.md`) — the updater
+  returns the raw `download_url` column, which ends up in `a.href`.
+- **Existing landing-page behavior** — join button, `need_space` / `external_blocked` /
+  expired / rate-limited / server-error / network-error states, `findTokenAndSid`
+  session discovery. None of it changes.
+
+## Out of scope
+
+- `octo-web`: no shared download component, no download entry in the logged-in
+  shell. The invite page is self-contained instead.
+- `appconfig.web_url` as a desktop fallback — unnecessary once both buttons render
+  on desktop.
+- The other landing pages (`space_email_invite.html`, `space_join_approve.html`) —
+  they have no download button and are unaffected.
+- The pre-existing `t.Skip` on `TestGroupInvitePage_NoDmworkScheme` (OCTO migration
+  TODO, issue #17). Note it will collide with the existing `need_space` copy
+  "请打开 App 或 Web 首页" whenever it is unskipped — unrelated to this change.
+
+## Acceptance
+
+- [x] The download button's href never derives from `API_BASE`
+      (`TestGroupInvitePage_DownloadButtonResolvesInstallerNotAPIBase` asserts the
+      *source* of the href, not merely that the placeholder was substituted — the
+      broken code satisfied the latter, which is how it reached production).
+- [x] Both platform paths are resolved from the public updater endpoint, and those
+      routes are actually served (`TestGroupInvitePage_UpdaterRoutesAreServed`
+      issues a real request; a rename would otherwise keep every grep assertion green).
+- [x] No user-agent sniffing — in-app browsers rewrite the UA and iPadOS reports
+      itself as Macintosh, so a wrong guess hands over the wrong platform's installer.
+- [x] A platform with no version record (updater 204), a malformed address, or a
+      failed request hides only its own row. Nothing falls back to `API_BASE`.
+- [x] The address passes a scheme allowlist (http/https) before reaching `a.href`.
+- [x] Zero external resources: no CDN script, external stylesheet, `@import`,
+      `url(http…)` or remote image; icons are inline SVG
+      (`TestGroupInvitePage_NoExternalResources`).
+- [x] `modules/group` passes under the CI recipe (fresh database, `-race`,
+      `-shuffle=on`).
+
+## Known verification gap
+
+The landing page is a static asset, so the Go assertions can only grep its
+*shape*, not exercise its *behavior*. Reintroducing the bug through a local
+variable would evade them. Closing this properly means either moving the logic
+server-side or giving the repository a JS test environment; neither is in scope
+here. Behavior was verified out-of-band with a headless-browser harness against a
+stub server (platform matrix, updater 204, malformed scheme, network failure, and
+a real clipboard read-back), but that harness is not part of the repository.

--- a/assets/web/group_invite.html
+++ b/assets/web/group_invite.html
@@ -97,6 +97,17 @@
                         <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"/></svg>
                     </button>
                 </div>
+                <!-- 两个平台都没有可用安装包时的兜底入口，见 setupWebFallback。
+                     与上面两行互斥：有任一安装包可下时不显示。 -->
+                <div class="btn-row" id="row-web-fallback" style="display:none">
+                    <a class="btn btn-secondary" id="btn-web-fallback" href="#" target="_blank" rel="noopener">
+                        <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M11.99 2C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zm6.93 6h-2.95c-.32-1.25-.78-2.45-1.38-3.56 1.84.63 3.37 1.91 4.33 3.56zM12 4.04c.83 1.2 1.48 2.53 1.91 3.96h-3.82c.43-1.43 1.08-2.76 1.91-3.96zM4.26 14C4.1 13.36 4 12.69 4 12s.1-1.36.26-2h3.38c-.08.66-.14 1.32-.14 2 0 .68.06 1.34.14 2H4.26zm.82 2h2.95c.32 1.25.78 2.45 1.38 3.56-1.84-.63-3.37-1.9-4.33-3.56zm2.95-8H5.08c.96-1.66 2.49-2.93 4.33-3.56C8.81 5.55 8.35 6.75 8.03 8zM12 19.96c-.83-1.2-1.48-2.53-1.91-3.96h3.82c-.43 1.43-1.08 2.76-1.91 3.96zM14.34 14H9.66c-.09-.66-.16-1.32-.16-2 0-.68.07-1.35.16-2h4.68c.09.65.16 1.32.16 2 0 .68-.07 1.34-.16 2zm.25 5.56c.6-1.11 1.06-2.31 1.38-3.56h2.95c-.96 1.65-2.49 2.93-4.33 3.56zM16.36 14c.08-.66.14-1.32.14-2 0-.68-.06-1.34-.14-2h3.38c.16.64.26 1.31.26 2s-.1 1.36-.26 2h-3.38z"/></svg>
+                        <span>打开网页版</span>
+                    </a>
+                    <button class="btn-copy" id="btn-copy-web" type="button" title="复制网页版链接" aria-label="复制网页版链接">
+                        <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"/></svg>
+                    </button>
+                </div>
             </div>
         </div>
 
@@ -242,18 +253,33 @@ function findTokenAndSid() {
 // 浏览器，UA 被各家改写；iPadOS 13+ 干脆把自己报成 Macintosh。猜错的代价是给用户
 // 递错平台的安装包，而猜对也只省下一个按钮。顺带这样桌面端也有了入口（扫码 / 转发
 // 到手机上打开），不必再单独接一个「去官网」的兜底。
+// 版本号是「足够老」的哨兵值：updater 在 model.AppVersion == 传入版本时返回 204，
+// 所以这里必须传一个不会与真实发行版本相等的值。这两个值不是随手取的 —— Web 登录页
+// 的下载浮层在生产就一直发这两条路径，真实发行版是 1.x.y / 2.x，碰撞会先打挂那个
+// 面向全体用户的入口。沿用它们等于复用一个已被线上验证过的约定。
 var DOWNLOADS = [
     { path: "/v1/common/updater/android/1.0", row: "row-download-android", link: "btn-download-android", copy: "btn-copy-android" },
     { path: "/v1/common/updater/ios/1.0.0", row: "row-download-ios", link: "btn-download-ios", copy: "btn-copy-ios" }
 ];
+var APPCONFIG_PATH = "/v1/common/appconfig";
 
-// copyText 优先用 Clipboard API，失败/不可用时退回 execCommand。Clipboard API 要求
-// 安全上下文，而邀请链接大量在各家 IM 的内嵌浏览器里打开，能力参差；execCommand
-// 虽已废弃，但仍是这类环境里唯一稳定可用的路径。两条路都失败时由调用方提示手动复制。
+// copyText 优先用 Clipboard API，失败或不可用时都退回 execCommand。
+//
+// 兜底挂在 rejection 上而不是写成 else 分支：内嵌 webview 常常既暴露了
+// navigator.clipboard、又满足安全上下文，却被权限策略拒绝 writeText。只判「能力
+// 是否存在」会让兜底恰好在最需要它的环境里永远不执行——而 IM 内嵌浏览器正是这个
+// 页面的主战场。execCommand 虽已废弃，但仍是那类环境里唯一稳定可用的路径。
+// 两条路都失败时由调用方提示手动复制，不谎报成功。
 function copyText(text) {
     if (navigator.clipboard && window.isSecureContext) {
-        return navigator.clipboard.writeText(text);
+        return navigator.clipboard.writeText(text).catch(function () {
+            return legacyCopyText(text);
+        });
     }
+    return legacyCopyText(text);
+}
+
+function legacyCopyText(text) {
     return new Promise(function (resolve, reject) {
         var ta = document.createElement("textarea");
         ta.value = text;
@@ -276,36 +302,53 @@ function copyText(text) {
 // 裸 download_url（不像 pcupdater 会拼 APIBaseURL），可能为空 / 相对 / 畸形，而这个值
 // 最终要塞进 a.href —— 不校验就等于把 javascript: 之类的 scheme 也一起放进来。
 //
-// 先按绝对地址解析，再回退到相对解析：new URL(x, base) 会**先解析 base**，base
-// 不是绝对地址时，即使 x 本身是完整的 https 地址也照样抛 TypeError。绝对优先能让
-// 下载地址不受 BaseURL 配置形态的牵连。
+// safeAbsoluteURL 只接受绝对 http/https 地址，相对地址一律拒绝。
 //
-// 相对地址按 API_BASE 解析——注意这与 Web 登录页的 resolveSafeDownloadUrl 并不等价，
-// 那边用的是 window.location.origin。两者只在 BaseURL 带多级路径时分叉
-// （base=".../api/v2" + "files/x" → ".../api/files/x"，末段总是被替换掉）。
-// 生产库里存的是绝对地址，走不到这条分支；真要存相对地址时这里得先对齐两端。
-function safeDownloadURL(value) {
+// 曾经的实现把相对地址按 API_BASE 解析，但 Web 登录页的 resolveSafeDownloadUrl 用的
+// 是 window.location.origin —— 同一个 app_version.download_url 字段两个消费方能算出
+// 不同的地址（new URL 会替换 base 的末段：".../api/v2" + "files/x" → ".../api/files/x"），
+// 至多一处是对的。与其让两端各自猜一个 base，不如把契约钉死：安装包地址必须是绝对的。
+// 这和本页「没有入口好过一个死链」的取舍一致 —— 猜出来的地址就是死链的另一种写法。
+//
+// 副作用是协议相对地址（//host/x.apk）也会被拒，这是想要的：它绝对解析失败，
+// 只有靠相对分支才能通过，而那正是被删掉的分支。
+//
+// 若将来确实需要支持相对存储，正确做法是先和 Web 端对齐 base，再两边同时放开，
+// 而不是在这里单独恢复一个分支。
+function safeAbsoluteURL(value) {
     if (typeof value !== "string") return "";
     var trimmed = value.trim();
     if (!trimmed) return "";
-    var u = null;
-    try { u = new URL(trimmed); } catch (e) { u = null; }
-    if (!u) {
-        try { u = new URL(trimmed, API_BASE); } catch (e) { return ""; }
-    }
+    var u;
+    try { u = new URL(trimmed); } catch (e) { return ""; }
     if (u.protocol === "http:" || u.protocol === "https:") return u.toString();
     return "";
+}
+
+// safeDownloadURL 在 safeAbsoluteURL 之上，再要求路径末段带文件后缀。
+//
+// download_url 由管理台自由填写，填成一个下载引导页（无后缀）时，「下载 Android 版」
+// 会把用户送到一个网页而不是安装包 —— 按钮承诺的动作没有发生，正是本 PR 要根除的
+// 那类「说一套做一套」。无后缀一律判为「不是安装包」，让它退到 web_url 兜底，
+// 而不是伪装成一次下载。
+function safeDownloadURL(value) {
+    var url = safeAbsoluteURL(value);
+    if (!url) return "";
+    var lastSegment = new URL(url).pathname.split("/").pop();
+    // indexOf > 0：要求后缀前面有文件名，".apk" 这种纯后缀不算。
+    if (lastSegment.indexOf(".") <= 0) return "";
+    return url;
 }
 
 // setupDownloadButtons 为每个平台各解析一次安装包地址。两个请求互相独立：
 // 一个平台没记录不影响另一个显示。库里没有版本记录、地址非法、网络失败 ——
 // 该平台整行保持隐藏。没有入口好过一个死链。
 function setupDownloadButtons() {
-    DOWNLOADS.forEach(function (item) {
+    var jobs = DOWNLOADS.map(function (item) {
         var row = document.getElementById(item.row);
         var link = document.getElementById(item.link);
-        if (!row || !link) return;
-        fetch(API_BASE + item.path).then(function (r) {
+        if (!row || !link) return Promise.resolve(false);
+        return fetch(API_BASE + item.path).then(function (r) {
             // updater 在没有版本记录时返回 204：状态码是 2xx（r.ok 为真）但没有 body。
             // 下面的 r.json() 兜底也能把它吞成 null，这里显式列出来是为了把 updater
             // 的这条契约写在代码里，而不是让它藏在一个泛化的 catch 背后。
@@ -313,22 +356,57 @@ function setupDownloadButtons() {
             return r.json().catch(function () { return null; });
         }).then(function (d) {
             var url = safeDownloadURL(d && d.url);
-            if (!url) return;
+            if (!url) return false;
             link.href = url;
-            bindCopyButton(document.getElementById(item.copy), url);
+            bindCopyButton(document.getElementById(item.copy), url, "下载链接");
             row.style.display = "flex";
-        }).catch(function () { /* 网络异常：整行保持隐藏 */ });
+            return true;
+        }).catch(function () { return false; });
     });
+    // 只有当两个平台都拿不出可用安装包时才去取 web_url 兜底：否则页面上会同时
+    // 出现「下载 X 版」和「打开网页版」，把主路径稀释掉。
+    Promise.all(jobs).then(function (results) {
+        if (results.indexOf(true) === -1) setupWebFallback();
+    });
+}
+
+// setupWebFallback 在两个平台都没有可用安装包时给出「打开网页版」。
+//
+// 触发条件覆盖了所有失败形态：都没有版本记录（updater 204）、updater 5xx、网络不通、
+// 地址非法或没有安装包后缀。此前这些情况下页面是一张群卡片加一片空白，用户无从判断
+// 是「没有 App 可下」还是「页面坏了」—— 而 detail 请求是独立的，它成功时页面看起来
+// 完全正常，只是没有任何可操作项。
+//
+// 地址取自公开的 appconfig.web_url（= External.WebLoginURL，产品门户）。它是门户不是
+// 安装包，所以走 safeAbsoluteURL 而不是 safeDownloadURL —— 门户地址本就不该有后缀。
+// 取不到就仍然什么都不显示：依旧不回退到 API_BASE。
+function setupWebFallback() {
+    var row = document.getElementById("row-web-fallback");
+    var link = document.getElementById("btn-web-fallback");
+    if (!row || !link) return;
+    fetch(API_BASE + APPCONFIG_PATH).then(function (r) {
+        if (!r.ok) return null;
+        return r.json().catch(function () { return null; });
+    }).then(function (d) {
+        var url = safeAbsoluteURL(d && d.web_url);
+        if (!url) return;
+        link.href = url;
+        bindCopyButton(document.getElementById("btn-copy-web"), url, "网页版链接");
+        row.style.display = "flex";
+    }).catch(function () { /* 兜底也拿不到：保持隐藏，不猜 */ });
 }
 
 // bindCopyButton 把「复制链接」绑到已解析出的地址上。桌面端看到的是安装包，装
 // 却要在手机上装，复制link转过去是主路径；移动端内嵌浏览器拦下载时也用得上。
-// 复制的是安装包地址本身，不是当前邀请页地址——后者用户直接分享地址栏即可。
-function bindCopyButton(btn, url) {
+// 复制的是目标地址本身，不是当前邀请页地址——后者用户直接分享地址栏即可。
+//
+// label 区分「下载链接」和「网页版链接」：兜底行复制的是门户地址，提示成「下载链接
+// 已复制」会和用户刚点的按钮对不上。
+function bindCopyButton(btn, url, label) {
     if (!btn) return;
     btn.addEventListener("click", function () {
         copyText(url).then(function () {
-            toast("下载链接已复制");
+            toast((label || "链接") + "已复制");
         }, function () {
             // 两条复制路径都不可用（老 webview / 权限被拒）：不假装成功，
             // 告诉用户可以长按左边的按钮走浏览器自带的「复制链接地址」。

--- a/assets/web/group_invite.html
+++ b/assets/web/group_invite.html
@@ -30,13 +30,14 @@
         .btn[disabled], .btn.disabled { opacity: 0.5; pointer-events: none; }
         .btn-primary { background: #07c160; color: #fff; }
         .btn-secondary { background: #f0f0f0; color: #333; }
+        .btn svg { flex: 0 0 auto; }
         /* 下载行 = 下载按钮 + 复制链接。整行由 JS 在解析到合法地址后才显示。 */
         .btn-row { gap: 8px; align-items: stretch; }
-        .btn-row .btn { flex: 1; min-width: 0; }
+        .btn-row .btn { flex: 1; min-width: 0; gap: 8px; }
         .btn-copy {
-            flex: 0 0 auto; padding: 0 16px; height: 44px;
+            flex: 0 0 auto; width: 44px; height: 44px; padding: 0;
             border: none; border-radius: 22px; background: #f0f0f0; color: #666;
-            font-size: 14px; cursor: pointer; white-space: nowrap;
+            cursor: pointer; display: flex; align-items: center; justify-content: center;
         }
         .btn-copy:active { opacity: 0.7; }
         .badge {
@@ -75,13 +76,26 @@
             </div>
             <div class="btn-group">
                 <button class="btn btn-primary" id="btn-join" style="display:none">加入群聊</button>
+                <!-- 图标一律内联 SVG：落地页不引任何外部资源（无 CDN / 图标字体 /
+                     远程图片），离线、内网与被墙环境下都不会退化成空白方块。
+                     Android / Apple 两个路径与 octo-web 登录页的下载按钮同源，保持两端一致。 -->
                 <div class="btn-row" id="row-download-android" style="display:none">
-                    <a class="btn btn-secondary" id="btn-download-android" href="#" target="_blank" rel="noopener">下载 Android 版</a>
-                    <button class="btn-copy" id="btn-copy-android" type="button">复制链接</button>
+                    <a class="btn btn-secondary" id="btn-download-android" href="#" target="_blank" rel="noopener">
+                        <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M6 18c0 .55.45 1 1 1h1v3.5c0 .83.67 1.5 1.5 1.5s1.5-.67 1.5-1.5V19h2v3.5c0 .83.67 1.5 1.5 1.5s1.5-.67 1.5-1.5V19h1c.55 0 1-.45 1-1V8H6v10zM3.5 8C2.67 8 2 8.67 2 9.5v7c0 .83.67 1.5 1.5 1.5S5 17.33 5 16.5v-7C5 8.67 4.33 8 3.5 8zm17 0c-.83 0-1.5.67-1.5 1.5v7c0 .83.67 1.5 1.5 1.5s1.5-.67 1.5-1.5v-7c0-.83-.67-1.5-1.5-1.5zm-4.97-5.84 1.3-1.3c.2-.2.2-.51 0-.71-.2-.2-.51-.2-.71 0l-1.48 1.48A7.4 7.4 0 0 0 12 1c-1.1 0-2.15.23-3.12.63L7.4.15c-.2-.2-.51-.2-.71 0-.2.2-.2.51 0 .71L8 2.17A6.83 6.83 0 0 0 6 7h12c0-1.99-.97-3.75-2.47-4.84zM10 5H9V4h1v1zm5 0h-1V4h1v1z"/></svg>
+                        <span>下载 Android 版</span>
+                    </a>
+                    <button class="btn-copy" id="btn-copy-android" type="button" title="复制下载链接" aria-label="复制 Android 下载链接">
+                        <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"/></svg>
+                    </button>
                 </div>
                 <div class="btn-row" id="row-download-ios" style="display:none">
-                    <a class="btn btn-secondary" id="btn-download-ios" href="#" target="_blank" rel="noopener">下载 iOS 版</a>
-                    <button class="btn-copy" id="btn-copy-ios" type="button">复制链接</button>
+                    <a class="btn btn-secondary" id="btn-download-ios" href="#" target="_blank" rel="noopener">
+                        <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M17.05 20.28c-.98.95-2.05.8-3.08.35-1.09-.46-2.09-.48-3.24 0-1.44.62-2.2.44-3.06-.35C2.79 15.25 3.51 7.59 9.05 7.31c1.35.07 2.29.74 3.08.8 1.18-.24 2.31-.93 3.57-.84 1.51.12 2.65.72 3.4 1.8-3.12 1.87-2.38 5.98.48 7.13-.57 1.5-1.31 2.99-2.54 4.09zM12.03 7.25c-.15-2.23 1.66-4.07 3.74-4.25.29 2.58-2.34 4.5-3.74 4.25z"/></svg>
+                        <span>下载 iOS 版</span>
+                    </a>
+                    <button class="btn-copy" id="btn-copy-ios" type="button" title="复制下载链接" aria-label="复制 iOS 下载链接">
+                        <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"/></svg>
+                    </button>
                 </div>
             </div>
         </div>

--- a/assets/web/group_invite.html
+++ b/assets/web/group_invite.html
@@ -66,7 +66,7 @@
             </div>
             <div class="btn-group">
                 <button class="btn btn-primary" id="btn-join" style="display:none">加入群聊</button>
-                <a class="btn btn-secondary" id="btn-download" href="#" target="_blank" rel="noopener">下载 App</a>
+                <a class="btn btn-secondary" id="btn-download" href="#" target="_blank" rel="noopener" style="display:none">下载 App</a>
             </div>
         </div>
 
@@ -198,6 +198,61 @@ function findTokenAndSid() {
     return { token: "", sid: "" };
 }
 
+// 「下载 App」的安装包地址来自公开免登录的 updater 接口，与 Web 登录页的下载浮层
+// 同一个数据源（dmworklogin/AndroidDownloadButton.tsx / IOSDownloadButton.tsx 用的
+// 就是这两条路径）。版本号是「足够老」的哨兵值，让 updater 永远判定有新版可下。
+//
+// 历史实现把按钮 href 直接设成 API_BASE，注释写的是「回退到产品官网」，但注入的
+// External.BaseURL 在生产就是 API 前缀（.../api），点击必然落到 404 —— 语义和实现
+// 不一致。这里改为解析真实安装包地址；解析不出来就隐藏按钮，绝不回退到 API_BASE：
+// 没有入口好过一个死链。
+var ANDROID_UPDATER_PATH = "/v1/common/updater/android/1.0";
+var IOS_UPDATER_PATH = "/v1/common/updater/ios/1.0.0";
+
+function detectMobileOS() {
+    var ua = navigator.userAgent || "";
+    if (/android/i.test(ua)) return "android";
+    // iPadOS 13+ 的 UA 伪装成 Macintosh，靠 maxTouchPoints 才能区分出触屏 iPad。
+    if (/iPad|iPhone|iPod/.test(ua)) return "ios";
+    if (/Macintosh/.test(ua) && navigator.maxTouchPoints > 1) return "ios";
+    return "";
+}
+
+// safeDownloadURL 收口 updater 返回的地址：只放行 http/https。updater 直接吐库里的
+// 裸 download_url（不像 pcupdater 会拼 APIBaseURL），可能为空 / 相对 / 畸形，而这个值
+// 最终要塞进 a.href —— 不校验就等于把 javascript: 之类的 scheme 也一起放进来。
+// 相对地址按 API_BASE 解析，与 Web 端 resolveSafeDownloadUrl 保持同策略。
+function safeDownloadURL(value) {
+    if (typeof value !== "string") return "";
+    var trimmed = value.trim();
+    if (!trimmed) return "";
+    try {
+        var u = new URL(trimmed, API_BASE);
+        if (u.protocol === "http:" || u.protocol === "https:") return u.toString();
+    } catch (e) { /* 畸形地址一律按解析失败处理 */ }
+    return "";
+}
+
+// setupDownloadButton 按 UA 取当前平台的安装包地址并显示按钮。
+// 桌面端（无移动安装包可给）、updater 返回 204（库里没有该平台的版本记录，
+// 且响应无 body 不能 .json()）、地址非法、网络失败 —— 一律保持按钮隐藏。
+function setupDownloadButton() {
+    var btn = document.getElementById("btn-download");
+    if (!btn) return;
+    var os = detectMobileOS();
+    if (!os) return;
+    var path = os === "android" ? ANDROID_UPDATER_PATH : IOS_UPDATER_PATH;
+    fetch(API_BASE + path).then(function (r) {
+        if (r.status === 204 || !r.ok) return null;
+        return r.json().catch(function () { return null; });
+    }).then(function (d) {
+        var url = safeDownloadURL(d && d.url);
+        if (!url) return;
+        btn.href = url;
+        btn.style.display = "flex";
+    }).catch(function () { /* 网络异常：按钮保持隐藏 */ });
+}
+
 function renderInfo(data) {
     document.getElementById("v-name").textContent = data.group_name || "群聊";
     if (typeof data.member_count === "number") {
@@ -222,8 +277,7 @@ function renderInfo(data) {
         tip.textContent = "该群已开启邀请确认，请在 App 内由管理员审批后入群。";
         tip.style.display = "block";
     }
-    // 「下载 App」回退到产品官网（无独立配置时复用 BaseURL）
-    document.getElementById("btn-download").href = API_BASE;
+    setupDownloadButton();
 
     // Web 已登录 & 群可直接入群 → 显示「加入群聊」按钮
     // invite_required 场景仍交由 App 内审批，不在落地页直接入群

--- a/assets/web/group_invite.html
+++ b/assets/web/group_invite.html
@@ -80,7 +80,7 @@
                      远程图片），离线、内网与被墙环境下都不会退化成空白方块。
                      Android / Apple 两个路径与 octo-web 登录页的下载按钮同源，保持两端一致。 -->
                 <div class="btn-row" id="row-download-android" style="display:none">
-                    <a class="btn btn-secondary" id="btn-download-android" href="#" target="_blank" rel="noopener">
+                    <a class="btn btn-secondary" id="btn-download-android" href="#" target="_blank" rel="noopener noreferrer">
                         <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M6 18c0 .55.45 1 1 1h1v3.5c0 .83.67 1.5 1.5 1.5s1.5-.67 1.5-1.5V19h2v3.5c0 .83.67 1.5 1.5 1.5s1.5-.67 1.5-1.5V19h1c.55 0 1-.45 1-1V8H6v10zM3.5 8C2.67 8 2 8.67 2 9.5v7c0 .83.67 1.5 1.5 1.5S5 17.33 5 16.5v-7C5 8.67 4.33 8 3.5 8zm17 0c-.83 0-1.5.67-1.5 1.5v7c0 .83.67 1.5 1.5 1.5s1.5-.67 1.5-1.5v-7c0-.83-.67-1.5-1.5-1.5zm-4.97-5.84 1.3-1.3c.2-.2.2-.51 0-.71-.2-.2-.51-.2-.71 0l-1.48 1.48A7.4 7.4 0 0 0 12 1c-1.1 0-2.15.23-3.12.63L7.4.15c-.2-.2-.51-.2-.71 0-.2.2-.2.51 0 .71L8 2.17A6.83 6.83 0 0 0 6 7h12c0-1.99-.97-3.75-2.47-4.84zM10 5H9V4h1v1zm5 0h-1V4h1v1z"/></svg>
                         <span>下载 Android 版</span>
                     </a>
@@ -89,7 +89,7 @@
                     </button>
                 </div>
                 <div class="btn-row" id="row-download-ios" style="display:none">
-                    <a class="btn btn-secondary" id="btn-download-ios" href="#" target="_blank" rel="noopener">
+                    <a class="btn btn-secondary" id="btn-download-ios" href="#" target="_blank" rel="noopener noreferrer">
                         <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M17.05 20.28c-.98.95-2.05.8-3.08.35-1.09-.46-2.09-.48-3.24 0-1.44.62-2.2.44-3.06-.35C2.79 15.25 3.51 7.59 9.05 7.31c1.35.07 2.29.74 3.08.8 1.18-.24 2.31-.93 3.57-.84 1.51.12 2.65.72 3.4 1.8-3.12 1.87-2.38 5.98.48 7.13-.57 1.5-1.31 2.99-2.54 4.09zM12.03 7.25c-.15-2.23 1.66-4.07 3.74-4.25.29 2.58-2.34 4.5-3.74 4.25z"/></svg>
                         <span>下载 iOS 版</span>
                     </a>
@@ -100,7 +100,7 @@
                 <!-- 两个平台都没有可用安装包时的兜底入口，见 setupWebFallback。
                      与上面两行互斥：有任一安装包可下时不显示。 -->
                 <div class="btn-row" id="row-web-fallback" style="display:none">
-                    <a class="btn btn-secondary" id="btn-web-fallback" href="#" target="_blank" rel="noopener">
+                    <a class="btn btn-secondary" id="btn-web-fallback" href="#" target="_blank" rel="noopener noreferrer">
                         <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M11.99 2C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zm6.93 6h-2.95c-.32-1.25-.78-2.45-1.38-3.56 1.84.63 3.37 1.91 4.33 3.56zM12 4.04c.83 1.2 1.48 2.53 1.91 3.96h-3.82c.43-1.43 1.08-2.76 1.91-3.96zM4.26 14C4.1 13.36 4 12.69 4 12s.1-1.36.26-2h3.38c-.08.66-.14 1.32-.14 2 0 .68.06 1.34.14 2H4.26zm.82 2h2.95c.32 1.25.78 2.45 1.38 3.56-1.84-.63-3.37-1.9-4.33-3.56zm2.95-8H5.08c.96-1.66 2.49-2.93 4.33-3.56C8.81 5.55 8.35 6.75 8.03 8zM12 19.96c-.83-1.2-1.48-2.53-1.91-3.96h3.82c-.43 1.43-1.08 2.76-1.91 3.96zM14.34 14H9.66c-.09-.66-.16-1.32-.16-2 0-.68.07-1.35.16-2h4.68c.09.65.16 1.32.16 2 0 .68-.07 1.34-.16 2zm.25 5.56c.6-1.11 1.06-2.31 1.38-3.56h2.95c-.96 1.65-2.49 2.93-4.33 3.56zM16.36 14c.08-.66.14-1.32.14-2 0-.68-.06-1.34-.14-2h3.38c.16.64.26 1.31.26 2s-.1 1.36-.26 2h-3.38z"/></svg>
                         <span>打开网页版</span>
                     </a>
@@ -264,19 +264,35 @@ var DOWNLOADS = [
 var APPCONFIG_PATH = "/v1/common/appconfig";
 var FETCH_TIMEOUT_MS = 8000;
 
-// fetchWithTimeout 给下载相关的请求加超时。fetch 本身没有默认超时，而
-// setupWebFallback 要等 Promise.all 全部 settle 才可能触发 —— 只要有一个平台的
-// 请求被中间层吞掉不返回，兜底就永远不会出现，页面停在改动前那个空白状态。
-// 没有 AbortController 的老 webview 退回裸 fetch：拿不到超时也不该拿不到功能。
-function fetchWithTimeout(url) {
-    if (typeof AbortController === "undefined") return fetch(url);
+// 下载相关请求必须有超时：fetch 没有默认超时，而 setupWebFallback 要等 Promise.all
+// 全部 settle 才可能触发 —— 只要有一个平台的请求被中间层吞掉不返回，兜底就永远不会
+// 出现，页面停在改动前那个空白状态。没有 AbortController 的老 webview 退回裸 fetch：
+// 拿不到超时也不该拿不到功能。
+// 超时必须罩住 **body 读取**，不能只罩 fetch：fetch 的 promise 在响应头到达时就
+// resolve，body 还没读。若在那一刻清掉定时器，一个「先回 200 头、再把 body 挂住」的
+// 中间层仍然能让这个 job 永远不 settle，Promise.all 卡死、兜底永不出现 —— 正好是本
+// 函数要防的那个失效。所以 fetchJSON 把整条链（fetch + json）一起纳入同一个 signal，
+// 并且只在链终结时清定时器。
+function fetchJSONWithTimeout(url) {
+    if (typeof AbortController === "undefined") {
+        return fetch(url).then(readJSONBody);
+    }
     var controller = new AbortController();
     var timer = setTimeout(function () { controller.abort(); }, FETCH_TIMEOUT_MS);
-    var done = function () { clearTimeout(timer); };
-    return fetch(url, { signal: controller.signal }).then(
-        function (r) { done(); return r; },
-        function (e) { done(); throw e; }
-    );
+    return fetch(url, { signal: controller.signal })
+        .then(readJSONBody)
+        .then(
+            function (d) { clearTimeout(timer); return d; },
+            function (e) { clearTimeout(timer); throw e; }
+        );
+}
+
+// readJSONBody 统一处理 updater / appconfig 的响应形态：
+// 204（updater 在没有版本记录时返回，是 2xx 但无 body，直接 .json() 会抛）、
+// 非 2xx、以及 body 不是合法 JSON —— 一律收敛成 null，由调用方按「没拿到」处理。
+function readJSONBody(r) {
+    if (r.status === 204 || !r.ok) return null;
+    return r.json().catch(function () { return null; });
 }
 
 // copyText 优先用 Clipboard API，失败或不可用时都退回 execCommand。
@@ -365,13 +381,7 @@ function setupDownloadButtons() {
         var row = document.getElementById(item.row);
         var link = document.getElementById(item.link);
         if (!row || !link) return Promise.resolve(false);
-        return fetchWithTimeout(API_BASE + item.path).then(function (r) {
-            // updater 在没有版本记录时返回 204：状态码是 2xx（r.ok 为真）但没有 body。
-            // 下面的 r.json() 兜底也能把它吞成 null，这里显式列出来是为了把 updater
-            // 的这条契约写在代码里，而不是让它藏在一个泛化的 catch 背后。
-            if (r.status === 204 || !r.ok) return null;
-            return r.json().catch(function () { return null; });
-        }).then(function (d) {
+        return fetchJSONWithTimeout(API_BASE + item.path).then(function (d) {
             var url = safeAbsoluteURL(d && d.url);
             if (!url) return false;
             link.href = url;
@@ -403,10 +413,7 @@ function setupWebFallback() {
     var row = document.getElementById("row-web-fallback");
     var link = document.getElementById("btn-web-fallback");
     if (!row || !link) return;
-    fetchWithTimeout(API_BASE + APPCONFIG_PATH).then(function (r) {
-        if (!r.ok) return null;
-        return r.json().catch(function () { return null; });
-    }).then(function (d) {
+    fetchJSONWithTimeout(API_BASE + APPCONFIG_PATH).then(function (d) {
         var url = safeAbsoluteURL(d && d.web_url);
         if (!url) return;
         link.href = url;

--- a/assets/web/group_invite.html
+++ b/assets/web/group_invite.html
@@ -262,6 +262,22 @@ var DOWNLOADS = [
     { path: "/v1/common/updater/ios/1.0.0", row: "row-download-ios", link: "btn-download-ios", copy: "btn-copy-ios" }
 ];
 var APPCONFIG_PATH = "/v1/common/appconfig";
+var FETCH_TIMEOUT_MS = 8000;
+
+// fetchWithTimeout 给下载相关的请求加超时。fetch 本身没有默认超时，而
+// setupWebFallback 要等 Promise.all 全部 settle 才可能触发 —— 只要有一个平台的
+// 请求被中间层吞掉不返回，兜底就永远不会出现，页面停在改动前那个空白状态。
+// 没有 AbortController 的老 webview 退回裸 fetch：拿不到超时也不该拿不到功能。
+function fetchWithTimeout(url) {
+    if (typeof AbortController === "undefined") return fetch(url);
+    var controller = new AbortController();
+    var timer = setTimeout(function () { controller.abort(); }, FETCH_TIMEOUT_MS);
+    var done = function () { clearTimeout(timer); };
+    return fetch(url, { signal: controller.signal }).then(
+        function (r) { done(); return r; },
+        function (e) { done(); throw e; }
+    );
+}
 
 // copyText 优先用 Clipboard API，失败或不可用时都退回 execCommand。
 //
@@ -287,6 +303,7 @@ function legacyCopyText(text) {
         // 放到视口内但不可见：iOS Safari 对 display:none / 视口外的元素不给选中。
         ta.style.position = "fixed";
         ta.style.top = "0";
+        ta.style.left = "0";
         ta.style.opacity = "0";
         document.body.appendChild(ta);
         ta.select();
@@ -298,11 +315,11 @@ function legacyCopyText(text) {
     });
 }
 
-// safeDownloadURL 收口 updater 返回的地址：只放行 http/https。updater 直接吐库里的
-// 裸 download_url（不像 pcupdater 会拼 APIBaseURL），可能为空 / 相对 / 畸形，而这个值
-// 最终要塞进 a.href —— 不校验就等于把 javascript: 之类的 scheme 也一起放进来。
+// safeAbsoluteURL 收口所有要写进 a.href 的地址：只放行绝对 http/https。
+// updater 直接吐库里的裸 download_url（不像 pcupdater 会拼 APIBaseURL），可能为空 /
+// 相对 / 畸形 —— 不校验就等于把 javascript: 之类的 scheme 也一起放进来。
 //
-// safeAbsoluteURL 只接受绝对 http/https 地址，相对地址一律拒绝。
+// 相对地址一律拒绝，不做解析。
 //
 // 曾经的实现把相对地址按 API_BASE 解析，但 Web 登录页的 resolveSafeDownloadUrl 用的
 // 是 window.location.origin —— 同一个 app_version.download_url 字段两个消费方能算出
@@ -325,20 +342,20 @@ function safeAbsoluteURL(value) {
     return "";
 }
 
-// safeDownloadURL 在 safeAbsoluteURL 之上，再要求路径末段带文件后缀。
+// 安装包地址和 web_url 共用 safeAbsoluteURL，不再额外要求文件后缀。
 //
-// download_url 由管理台自由填写，填成一个下载引导页（无后缀）时，「下载 Android 版」
-// 会把用户送到一个网页而不是安装包 —— 按钮承诺的动作没有发生，正是本 PR 要根除的
-// 那类「说一套做一套」。无后缀一律判为「不是安装包」，让它退到 web_url 兜底，
-// 而不是伪装成一次下载。
-function safeDownloadURL(value) {
-    var url = safeAbsoluteURL(value);
-    if (!url) return "";
-    var lastSegment = new URL(url).pathname.split("/").pop();
-    // indexOf > 0：要求后缀前面有文件名，".apk" 这种纯后缀不算。
-    if (lastSegment.indexOf(".") <= 0) return "";
-    return url;
-}
+// 曾经加过一条「路径末段必须带后缀」的规则，想拦住把下载按钮指向落地页的情况。
+// 它做不到，而且反向伤害更大：
+//   - 判不准 —— 接受 ".../download/ios.html"（正是要拦的落地页），却拒绝
+//     App Store / TestFlight 地址和带查询参数的签名下载地址。
+//   - 对 iOS 是死局 —— 浏览器安装 iOS 应用必须走 itms-services:，而该 scheme 被
+//     白名单挡掉（正确）。于是任何真能装上 App 的 iOS 地址都是商店页，全都无后缀：
+//     不存在既通过校验又可用的取值。
+//   - 与写入侧和另一个消费方都不一致 —— addAppVersion 只要求 android 非空、不校验
+//     格式，octo-web 登录页也只校验 scheme。加了它，同一个存储值在两个页面上
+//     「能不能用」结论相反，正是本页拒绝相对地址时所反对的那种分歧。
+// 下载地址指向网页是数据质量问题，归管理台校验管；落地页从 URL 字符串判断不了。
+
 
 // setupDownloadButtons 为每个平台各解析一次安装包地址。两个请求互相独立：
 // 一个平台没记录不影响另一个显示。库里没有版本记录、地址非法、网络失败 ——
@@ -348,14 +365,14 @@ function setupDownloadButtons() {
         var row = document.getElementById(item.row);
         var link = document.getElementById(item.link);
         if (!row || !link) return Promise.resolve(false);
-        return fetch(API_BASE + item.path).then(function (r) {
+        return fetchWithTimeout(API_BASE + item.path).then(function (r) {
             // updater 在没有版本记录时返回 204：状态码是 2xx（r.ok 为真）但没有 body。
             // 下面的 r.json() 兜底也能把它吞成 null，这里显式列出来是为了把 updater
             // 的这条契约写在代码里，而不是让它藏在一个泛化的 catch 背后。
             if (r.status === 204 || !r.ok) return null;
             return r.json().catch(function () { return null; });
         }).then(function (d) {
-            var url = safeDownloadURL(d && d.url);
+            var url = safeAbsoluteURL(d && d.url);
             if (!url) return false;
             link.href = url;
             bindCopyButton(document.getElementById(item.copy), url, "下载链接");
@@ -372,19 +389,21 @@ function setupDownloadButtons() {
 
 // setupWebFallback 在两个平台都没有可用安装包时给出「打开网页版」。
 //
-// 触发条件覆盖了所有失败形态：都没有版本记录（updater 204）、updater 5xx、网络不通、
-// 地址非法或没有安装包后缀。此前这些情况下页面是一张群卡片加一片空白，用户无从判断
-// 是「没有 App 可下」还是「页面坏了」—— 而 detail 请求是独立的，它成功时页面看起来
-// 完全正常，只是没有任何可操作项。
+// 触发条件：两个平台都没有版本记录（updater 204）、updater 5xx、updater 请求失败或
+// 超时、地址非法。此前这些情况下页面是一张群卡片加一片空白，而 detail 请求是独立的、
+// 它成功时页面看起来完全正常，用户无从判断是「没有 App 可下」还是「页面坏了」。
 //
-// 地址取自公开的 appconfig.web_url（= External.WebLoginURL，产品门户）。它是门户不是
-// 安装包，所以走 safeAbsoluteURL 而不是 safeDownloadURL —— 门户地址本就不该有后缀。
-// 取不到就仍然什么都不显示：依旧不回退到 API_BASE。
+// 注意它覆盖不到整体断网：那时 detail 也会失败，走 showState("state-network-error")，
+// 而 showState 会 hide("content") —— 兜底行就在 #content 里，一并被藏掉。把三行移出
+// #content 才能覆盖那种情况（以及「链接过期且还没装 App」），那是独立的布局改动。
+//
+// 地址取自公开的 appconfig.web_url（= External.WebLoginURL，产品门户），与安装包地址
+// 走同一套 safeAbsoluteURL 校验。取不到就仍然什么都不显示：依旧不回退到 API_BASE。
 function setupWebFallback() {
     var row = document.getElementById("row-web-fallback");
     var link = document.getElementById("btn-web-fallback");
     if (!row || !link) return;
-    fetch(API_BASE + APPCONFIG_PATH).then(function (r) {
+    fetchWithTimeout(API_BASE + APPCONFIG_PATH).then(function (r) {
         if (!r.ok) return null;
         return r.json().catch(function () { return null; });
     }).then(function (d) {

--- a/assets/web/group_invite.html
+++ b/assets/web/group_invite.html
@@ -66,7 +66,8 @@
             </div>
             <div class="btn-group">
                 <button class="btn btn-primary" id="btn-join" style="display:none">加入群聊</button>
-                <a class="btn btn-secondary" id="btn-download" href="#" target="_blank" rel="noopener" style="display:none">下载 App</a>
+                <a class="btn btn-secondary" id="btn-download-android" href="#" target="_blank" rel="noopener" style="display:none">下载 Android 版</a>
+                <a class="btn btn-secondary" id="btn-download-ios" href="#" target="_blank" rel="noopener" style="display:none">下载 iOS 版</a>
             </div>
         </div>
 
@@ -206,23 +207,16 @@ function findTokenAndSid() {
 // External.BaseURL 在生产就是 API 前缀（.../api），点击必然落到 404 —— 语义和实现
 // 不一致。这里改为解析真实安装包地址；解析不出来就隐藏按钮，绝不回退到 API_BASE：
 // 没有入口好过一个死链。
-// 按平台查表，而不是 android/ios 二选一的三元表达式：将来给 detectMobileOS
-// 加第三个平台（HarmonyOS NEXT 的 UA 就不带 Android 标记）时，三元式会把它
-// 静默归到 ios 分支、给用户递一个 iOS 安装地址；查表则是查不到就退出。
-var UPDATER_PATHS = {
-    android: "/v1/common/updater/android/1.0",
-    ios: "/v1/common/updater/ios/1.0.0"
-};
-
-function detectMobileOS() {
-    var ua = navigator.userAgent || "";
-    if (/android/i.test(ua)) return "android";
-    if (/iPad|iPhone|iPod/.test(ua)) return "ios";
-    // iPadOS 13+ 的 UA 伪装成 Macintosh，只能靠 maxTouchPoints 把触屏 iPad 认出来。
-    // 这一行不是上一行的冗余，删掉就会丢掉整个 iPad 平台。
-    if (/Macintosh/.test(ua) && navigator.maxTouchPoints > 1) return "ios";
-    return "";
-}
+// 不做 UA 嗅探：两个平台各给一个按钮，各自按 updater 有没有版本记录独立显示。
+//
+// UA 分流在这个页面上尤其不可靠——邀请链接的主要打开方式是微信 / 企业 IM 的内嵌
+// 浏览器，UA 被各家改写；iPadOS 13+ 干脆把自己报成 Macintosh。猜错的代价是给用户
+// 递错平台的安装包，而猜对也只省下一个按钮。顺带这样桌面端也有了入口（扫码 / 转发
+// 到手机上打开），不必再单独接一个「去官网」的兜底。
+var DOWNLOADS = [
+    { id: "btn-download-android", path: "/v1/common/updater/android/1.0" },
+    { id: "btn-download-ios", path: "/v1/common/updater/ios/1.0.0" }
+];
 
 // safeDownloadURL 收口 updater 返回的地址：只放行 http/https。updater 直接吐库里的
 // 裸 download_url（不像 pcupdater 会拼 APIBaseURL），可能为空 / 相对 / 畸形，而这个值
@@ -249,26 +243,26 @@ function safeDownloadURL(value) {
     return "";
 }
 
-// setupDownloadButton 按 UA 取当前平台的安装包地址并显示按钮。
-// 桌面端（无移动安装包可给）、库里没有该平台的版本记录、地址非法、网络失败 ——
-// 一律保持按钮隐藏。没有入口好过一个死链。
-function setupDownloadButton() {
-    var btn = document.getElementById("btn-download");
-    if (!btn) return;
-    var path = UPDATER_PATHS[detectMobileOS()];
-    if (!path) return;
-    fetch(API_BASE + path).then(function (r) {
-        // updater 在没有版本记录时返回 204：状态码是 2xx（r.ok 为真）但没有 body。
-        // 下面的 r.json() 兜底也能把它吞成 null，这里显式列出来是为了把 updater
-        // 的这条契约写在代码里，而不是让它藏在一个泛化的 catch 背后。
-        if (r.status === 204 || !r.ok) return null;
-        return r.json().catch(function () { return null; });
-    }).then(function (d) {
-        var url = safeDownloadURL(d && d.url);
-        if (!url) return;
-        btn.href = url;
-        btn.style.display = "flex";
-    }).catch(function () { /* 网络异常：按钮保持隐藏 */ });
+// setupDownloadButtons 为每个平台各解析一次安装包地址。两个请求互相独立：
+// 一个平台没记录不影响另一个显示。库里没有版本记录、地址非法、网络失败 ——
+// 该平台的按钮保持隐藏。没有入口好过一个死链。
+function setupDownloadButtons() {
+    DOWNLOADS.forEach(function (item) {
+        var btn = document.getElementById(item.id);
+        if (!btn) return;
+        fetch(API_BASE + item.path).then(function (r) {
+            // updater 在没有版本记录时返回 204：状态码是 2xx（r.ok 为真）但没有 body。
+            // 下面的 r.json() 兜底也能把它吞成 null，这里显式列出来是为了把 updater
+            // 的这条契约写在代码里，而不是让它藏在一个泛化的 catch 背后。
+            if (r.status === 204 || !r.ok) return null;
+            return r.json().catch(function () { return null; });
+        }).then(function (d) {
+            var url = safeDownloadURL(d && d.url);
+            if (!url) return;
+            btn.href = url;
+            btn.style.display = "flex";
+        }).catch(function () { /* 网络异常：按钮保持隐藏 */ });
+    });
 }
 
 function renderInfo(data) {
@@ -453,10 +447,10 @@ function showNeedSpaceState(sid) {
     }
 }
 
-// 下载地址和邀请详情是两个互不依赖的公开 GET，并行发起。按钮本身在 #content 里，
+// 下载地址和邀请详情是互不依赖的公开 GET，并行发起。按钮本身在 #content 里，
 // 容器显示之前把它标成可见是安全的；串在 renderInfo 里只会让弱网下的下载入口
 // 白等一个 RTT 才浮出来，还会造成一次迟到的布局跳动。
-setupDownloadButton();
+setupDownloadButtons();
 
 if (!code) {
     showState("state-expired");

--- a/assets/web/group_invite.html
+++ b/assets/web/group_invite.html
@@ -30,6 +30,15 @@
         .btn[disabled], .btn.disabled { opacity: 0.5; pointer-events: none; }
         .btn-primary { background: #07c160; color: #fff; }
         .btn-secondary { background: #f0f0f0; color: #333; }
+        /* 下载行 = 下载按钮 + 复制链接。整行由 JS 在解析到合法地址后才显示。 */
+        .btn-row { gap: 8px; align-items: stretch; }
+        .btn-row .btn { flex: 1; min-width: 0; }
+        .btn-copy {
+            flex: 0 0 auto; padding: 0 16px; height: 44px;
+            border: none; border-radius: 22px; background: #f0f0f0; color: #666;
+            font-size: 14px; cursor: pointer; white-space: nowrap;
+        }
+        .btn-copy:active { opacity: 0.7; }
         .badge {
             display: inline-block; padding: 2px 10px; border-radius: 10px;
             font-size: 12px; line-height: 18px; margin-top: 8px;
@@ -66,8 +75,14 @@
             </div>
             <div class="btn-group">
                 <button class="btn btn-primary" id="btn-join" style="display:none">加入群聊</button>
-                <a class="btn btn-secondary" id="btn-download-android" href="#" target="_blank" rel="noopener" style="display:none">下载 Android 版</a>
-                <a class="btn btn-secondary" id="btn-download-ios" href="#" target="_blank" rel="noopener" style="display:none">下载 iOS 版</a>
+                <div class="btn-row" id="row-download-android" style="display:none">
+                    <a class="btn btn-secondary" id="btn-download-android" href="#" target="_blank" rel="noopener">下载 Android 版</a>
+                    <button class="btn-copy" id="btn-copy-android" type="button">复制链接</button>
+                </div>
+                <div class="btn-row" id="row-download-ios" style="display:none">
+                    <a class="btn btn-secondary" id="btn-download-ios" href="#" target="_blank" rel="noopener">下载 iOS 版</a>
+                    <button class="btn-copy" id="btn-copy-ios" type="button">复制链接</button>
+                </div>
             </div>
         </div>
 
@@ -214,9 +229,34 @@ function findTokenAndSid() {
 // 递错平台的安装包，而猜对也只省下一个按钮。顺带这样桌面端也有了入口（扫码 / 转发
 // 到手机上打开），不必再单独接一个「去官网」的兜底。
 var DOWNLOADS = [
-    { id: "btn-download-android", path: "/v1/common/updater/android/1.0" },
-    { id: "btn-download-ios", path: "/v1/common/updater/ios/1.0.0" }
+    { path: "/v1/common/updater/android/1.0", row: "row-download-android", link: "btn-download-android", copy: "btn-copy-android" },
+    { path: "/v1/common/updater/ios/1.0.0", row: "row-download-ios", link: "btn-download-ios", copy: "btn-copy-ios" }
 ];
+
+// copyText 优先用 Clipboard API，失败/不可用时退回 execCommand。Clipboard API 要求
+// 安全上下文，而邀请链接大量在各家 IM 的内嵌浏览器里打开，能力参差；execCommand
+// 虽已废弃，但仍是这类环境里唯一稳定可用的路径。两条路都失败时由调用方提示手动复制。
+function copyText(text) {
+    if (navigator.clipboard && window.isSecureContext) {
+        return navigator.clipboard.writeText(text);
+    }
+    return new Promise(function (resolve, reject) {
+        var ta = document.createElement("textarea");
+        ta.value = text;
+        ta.setAttribute("readonly", "");
+        // 放到视口内但不可见：iOS Safari 对 display:none / 视口外的元素不给选中。
+        ta.style.position = "fixed";
+        ta.style.top = "0";
+        ta.style.opacity = "0";
+        document.body.appendChild(ta);
+        ta.select();
+        ta.setSelectionRange(0, ta.value.length);
+        var ok = false;
+        try { ok = document.execCommand("copy"); } catch (e) { ok = false; }
+        document.body.removeChild(ta);
+        if (ok) { resolve(); } else { reject(new Error("copy failed")); }
+    });
+}
 
 // safeDownloadURL 收口 updater 返回的地址：只放行 http/https。updater 直接吐库里的
 // 裸 download_url（不像 pcupdater 会拼 APIBaseURL），可能为空 / 相对 / 畸形，而这个值
@@ -245,11 +285,12 @@ function safeDownloadURL(value) {
 
 // setupDownloadButtons 为每个平台各解析一次安装包地址。两个请求互相独立：
 // 一个平台没记录不影响另一个显示。库里没有版本记录、地址非法、网络失败 ——
-// 该平台的按钮保持隐藏。没有入口好过一个死链。
+// 该平台整行保持隐藏。没有入口好过一个死链。
 function setupDownloadButtons() {
     DOWNLOADS.forEach(function (item) {
-        var btn = document.getElementById(item.id);
-        if (!btn) return;
+        var row = document.getElementById(item.row);
+        var link = document.getElementById(item.link);
+        if (!row || !link) return;
         fetch(API_BASE + item.path).then(function (r) {
             // updater 在没有版本记录时返回 204：状态码是 2xx（r.ok 为真）但没有 body。
             // 下面的 r.json() 兜底也能把它吞成 null，这里显式列出来是为了把 updater
@@ -259,9 +300,26 @@ function setupDownloadButtons() {
         }).then(function (d) {
             var url = safeDownloadURL(d && d.url);
             if (!url) return;
-            btn.href = url;
-            btn.style.display = "flex";
-        }).catch(function () { /* 网络异常：按钮保持隐藏 */ });
+            link.href = url;
+            bindCopyButton(document.getElementById(item.copy), url);
+            row.style.display = "flex";
+        }).catch(function () { /* 网络异常：整行保持隐藏 */ });
+    });
+}
+
+// bindCopyButton 把「复制链接」绑到已解析出的地址上。桌面端看到的是安装包，装
+// 却要在手机上装，复制link转过去是主路径；移动端内嵌浏览器拦下载时也用得上。
+// 复制的是安装包地址本身，不是当前邀请页地址——后者用户直接分享地址栏即可。
+function bindCopyButton(btn, url) {
+    if (!btn) return;
+    btn.addEventListener("click", function () {
+        copyText(url).then(function () {
+            toast("下载链接已复制");
+        }, function () {
+            // 两条复制路径都不可用（老 webview / 权限被拒）：不假装成功，
+            // 告诉用户可以长按左边的按钮走浏览器自带的「复制链接地址」。
+            toast("复制失败，请长按左侧按钮复制链接");
+        });
     });
 }
 

--- a/assets/web/group_invite.html
+++ b/assets/web/group_invite.html
@@ -206,14 +206,20 @@ function findTokenAndSid() {
 // External.BaseURL 在生产就是 API 前缀（.../api），点击必然落到 404 —— 语义和实现
 // 不一致。这里改为解析真实安装包地址；解析不出来就隐藏按钮，绝不回退到 API_BASE：
 // 没有入口好过一个死链。
-var ANDROID_UPDATER_PATH = "/v1/common/updater/android/1.0";
-var IOS_UPDATER_PATH = "/v1/common/updater/ios/1.0.0";
+// 按平台查表，而不是 android/ios 二选一的三元表达式：将来给 detectMobileOS
+// 加第三个平台（HarmonyOS NEXT 的 UA 就不带 Android 标记）时，三元式会把它
+// 静默归到 ios 分支、给用户递一个 iOS 安装地址；查表则是查不到就退出。
+var UPDATER_PATHS = {
+    android: "/v1/common/updater/android/1.0",
+    ios: "/v1/common/updater/ios/1.0.0"
+};
 
 function detectMobileOS() {
     var ua = navigator.userAgent || "";
     if (/android/i.test(ua)) return "android";
-    // iPadOS 13+ 的 UA 伪装成 Macintosh，靠 maxTouchPoints 才能区分出触屏 iPad。
     if (/iPad|iPhone|iPod/.test(ua)) return "ios";
+    // iPadOS 13+ 的 UA 伪装成 Macintosh，只能靠 maxTouchPoints 把触屏 iPad 认出来。
+    // 这一行不是上一行的冗余，删掉就会丢掉整个 iPad 平台。
     if (/Macintosh/.test(ua) && navigator.maxTouchPoints > 1) return "ios";
     return "";
 }
@@ -221,28 +227,40 @@ function detectMobileOS() {
 // safeDownloadURL 收口 updater 返回的地址：只放行 http/https。updater 直接吐库里的
 // 裸 download_url（不像 pcupdater 会拼 APIBaseURL），可能为空 / 相对 / 畸形，而这个值
 // 最终要塞进 a.href —— 不校验就等于把 javascript: 之类的 scheme 也一起放进来。
-// 相对地址按 API_BASE 解析，与 Web 端 resolveSafeDownloadUrl 保持同策略。
+//
+// 先按绝对地址解析，再回退到相对解析：new URL(x, base) 会**先解析 base**，base
+// 不是绝对地址时，即使 x 本身是完整的 https 地址也照样抛 TypeError。绝对优先能让
+// 下载地址不受 BaseURL 配置形态的牵连。
+//
+// 相对地址按 API_BASE 解析——注意这与 Web 登录页的 resolveSafeDownloadUrl 并不等价，
+// 那边用的是 window.location.origin。两者只在 BaseURL 带多级路径时分叉
+// （base=".../api/v2" + "files/x" → ".../api/files/x"，末段总是被替换掉）。
+// 生产库里存的是绝对地址，走不到这条分支；真要存相对地址时这里得先对齐两端。
 function safeDownloadURL(value) {
     if (typeof value !== "string") return "";
     var trimmed = value.trim();
     if (!trimmed) return "";
-    try {
-        var u = new URL(trimmed, API_BASE);
-        if (u.protocol === "http:" || u.protocol === "https:") return u.toString();
-    } catch (e) { /* 畸形地址一律按解析失败处理 */ }
+    var u = null;
+    try { u = new URL(trimmed); } catch (e) { u = null; }
+    if (!u) {
+        try { u = new URL(trimmed, API_BASE); } catch (e) { return ""; }
+    }
+    if (u.protocol === "http:" || u.protocol === "https:") return u.toString();
     return "";
 }
 
 // setupDownloadButton 按 UA 取当前平台的安装包地址并显示按钮。
-// 桌面端（无移动安装包可给）、updater 返回 204（库里没有该平台的版本记录，
-// 且响应无 body 不能 .json()）、地址非法、网络失败 —— 一律保持按钮隐藏。
+// 桌面端（无移动安装包可给）、库里没有该平台的版本记录、地址非法、网络失败 ——
+// 一律保持按钮隐藏。没有入口好过一个死链。
 function setupDownloadButton() {
     var btn = document.getElementById("btn-download");
     if (!btn) return;
-    var os = detectMobileOS();
-    if (!os) return;
-    var path = os === "android" ? ANDROID_UPDATER_PATH : IOS_UPDATER_PATH;
+    var path = UPDATER_PATHS[detectMobileOS()];
+    if (!path) return;
     fetch(API_BASE + path).then(function (r) {
+        // updater 在没有版本记录时返回 204：状态码是 2xx（r.ok 为真）但没有 body。
+        // 下面的 r.json() 兜底也能把它吞成 null，这里显式列出来是为了把 updater
+        // 的这条契约写在代码里，而不是让它藏在一个泛化的 catch 背后。
         if (r.status === 204 || !r.ok) return null;
         return r.json().catch(function () { return null; });
     }).then(function (d) {
@@ -277,8 +295,6 @@ function renderInfo(data) {
         tip.textContent = "该群已开启邀请确认，请在 App 内由管理员审批后入群。";
         tip.style.display = "block";
     }
-    setupDownloadButton();
-
     // Web 已登录 & 群可直接入群 → 显示「加入群聊」按钮
     // invite_required 场景仍交由 App 内审批，不在落地页直接入群
     if (data.status === "joinable" && findTokenAndSid().token) {
@@ -436,6 +452,11 @@ function showNeedSpaceState(sid) {
         btn.addEventListener("click", function () { redirectHome(sid); });
     }
 }
+
+// 下载地址和邀请详情是两个互不依赖的公开 GET，并行发起。按钮本身在 #content 里，
+// 容器显示之前把它标成可见是安全的；串在 renderInfo 里只会让弱网下的下载入口
+// 白等一个 RTT 才浮出来，还会造成一次迟到的布局跳动。
+setupDownloadButton();
 
 if (!code) {
     showState("state-expired");

--- a/modules/group/api_invite_h5_test.go
+++ b/modules/group/api_invite_h5_test.go
@@ -561,6 +561,21 @@ func TestGroupInvitePage_UpdaterRoutesAreServed(t *testing.T) {
 	s, ctx := newTestServer(t)
 	_ = New(ctx)
 
+	// updater 在库里没有版本记录时返回 204，而 CleanAllTables 会把 app_version 清空 ——
+	// 不种数据的话两条 updater 路径在 CI 里恒为 204，下面那条「字段名必须存在」的断言
+	// 永远不会执行，看起来已经覆盖、实际是空的。版本号要与落地页发的哨兵值不同，
+	// 否则 handler 走 model.AppVersion == oldVersion 的相等分支同样返回 204。
+	for _, seed := range []struct{ os, version, url string }{
+		{"android", "9.9.9", "https://dl.example.com/dmwork-9.9.9.apk"},
+		{"ios", "9.9.9", "https://apps.apple.com/cn/app/dmwork/id999"},
+	} {
+		_, err := ctx.DB().InsertInto("app_version").
+			Columns("app_version", "os", "is_force", "update_desc", "download_url").
+			Values(seed.version, seed.os, 0, "seed for route contract test", seed.url).
+			Exec()
+		assert.NoError(t, err, "seed app_version for %s", seed.os)
+	}
+
 	// appconfig 也是落地页硬编码的 modules/common 路由，同样没有符号引用兜底，
 	// 所以和两条 updater 路径一起验。
 	for _, tc := range []struct {

--- a/modules/group/api_invite_h5_test.go
+++ b/modules/group/api_invite_h5_test.go
@@ -395,6 +395,54 @@ func TestGroupInvitePage_ContainsJoinButton(t *testing.T) {
 	assert.True(t, strings.Contains(body, "/scanjoin"))
 }
 
+// 「下载 App」按钮曾经把 href 直接设成注入的 API_BASE，而生产的 External.BaseURL
+// 就是 API 前缀（https://<host>/api），点击必然 404 —— 邀请页上唯一的下载入口是死链。
+//
+// 修法是改用公开免登录的 updater 接口拿真实安装包地址（与 Web 登录页下载浮层同源），
+// 拿不到就保持按钮隐藏。这个测试断言的是**最终 href 的来源**，而不是「占位符已被替换」——
+// 后者在旧实现下同样成立，正是它让这个 bug 一路漏到线上。
+func TestGroupInvitePage_DownloadButtonResolvesInstallerNotAPIBase(t *testing.T) {
+	s, ctx := newTestServer(t)
+	_ = New(ctx)
+
+	wd, err := os.Getwd()
+	assert.NoError(t, err)
+	if err := os.Chdir("../.."); err != nil {
+		t.Fatalf("chdir to repo root: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(wd) })
+
+	w := httptest.NewRecorder()
+	s.GetRoute().ServeHTTP(w, newInviteRequest(t, "/v1/group/invite?code=download-url-check"))
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	body := w.Body.String()
+
+	// 回归钉子：任何把按钮 href 直接绑到 API_BASE 的写法都必须挂 CI。
+	assert.NotContains(t, body, `getElementById("btn-download").href = API_BASE`,
+		"下载按钮不能回退到 API_BASE —— 生产的 BaseURL 是 API 前缀，点击会 404")
+
+	// 安装包地址必须来自公开的 updater 接口，两个平台都要覆盖。
+	assert.True(t, strings.Contains(body, "/v1/common/updater/android/1.0"),
+		"Android 安装包地址必须来自公开 updater 接口")
+	assert.True(t, strings.Contains(body, "/v1/common/updater/ios/1.0.0"),
+		"iOS 安装包地址必须来自公开 updater 接口")
+
+	// updater 在库里没有版本记录时返回 204 且无 body，直接 .json() 会抛异常。
+	assert.True(t, strings.Contains(body, "r.status === 204"),
+		"必须特判 updater 的 204（无版本记录，响应无 body）")
+
+	// href 落地前必须过 scheme 白名单：updater 吐的是库里的裸 download_url。
+	assert.True(t, strings.Contains(body, "safeDownloadURL"),
+		"updater 返回的地址必须经过 scheme 校验后才能写进 a.href")
+	assert.True(t, strings.Contains(body, `u.protocol === "http:" || u.protocol === "https:"`),
+		"只放行 http/https，挡掉 javascript: 之类的 scheme")
+
+	// 按钮默认隐藏：桌面端 / 无安装包 / 解析失败都不该露出一个点不动的入口。
+	assert.True(t, strings.Contains(body, `id="btn-download" href="#" target="_blank" rel="noopener" style="display:none"`),
+		"下载按钮必须默认隐藏，解析到合法地址后才显示")
+}
+
 // Mininglamp-OSS/octo-server#1246: 移动端两端均未注册 dmwork:// scheme，
 // H5 落地页上的「打开 App」深链按钮是死链，点击会弹错 / 被微信 block。
 // 方案 C 是最小改动——删按钮 + 删绑定 href 的 JS，所以用 grep 测试把

--- a/modules/group/api_invite_h5_test.go
+++ b/modules/group/api_invite_h5_test.go
@@ -484,6 +484,38 @@ func TestGroupInvitePage_DownloadButtonResolvesInstallerNotAPIBase(t *testing.T)
 		"必须保留 execCommand 兜底——内嵌浏览器里 Clipboard API 常不可用")
 }
 
+// 落地页必须零外部资源：不引 CDN 脚本、外链样式表、图标字体或远程图片。
+// 这个页面是用户接触产品的第一屏，且经常在内网、弱网、以及被墙的网络环境里打开——
+// 任何外部依赖失败都会让它退化成空白方块或裸样式。图标一律内联 SVG。
+func TestGroupInvitePage_NoExternalResources(t *testing.T) {
+	s, ctx := newTestServer(t)
+	_ = New(ctx)
+
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir("../.."); err != nil {
+		t.Fatalf("chdir to repo root: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(wd) })
+
+	w := httptest.NewRecorder()
+	s.GetRoute().ServeHTTP(w, newInviteRequest(t, "/v1/group/invite?code=no-external-check"))
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	body := w.Body.String()
+
+	assert.NotContains(t, body, "<script src=", "不允许外链脚本")
+	assert.NotContains(t, body, "<link ", "不允许外链样式表 / 图标字体 / preconnect")
+	assert.NotContains(t, body, "@import", "CSS 不允许 @import 外部样式")
+	assert.NotContains(t, body, "url(http", "CSS 不允许引用远程资源")
+	assert.NotContains(t, body, `<img src="http`, "不允许远程图片")
+
+	// 图标必须是内联 SVG —— 上面几条只挡住了外链，没有内联图标的话按钮会秃。
+	assert.True(t, strings.Contains(body, "<svg"), "按钮图标必须内联 SVG")
+}
+
 // 落地页把 modules/common 的 updater 路由硬编码成字符串，Go 这边没有任何符号引用能
 // 在它被改名时报错。上面的测试只 grep HTML 里有没有这个字面量——路由改名后字面量还在，
 // 全仓测试照样绿，而线上每个移动端访客的 fetch 都 404、下载按钮永远不出现。

--- a/modules/group/api_invite_h5_test.go
+++ b/modules/group/api_invite_h5_test.go
@@ -461,14 +461,27 @@ func TestGroupInvitePage_DownloadButtonResolvesInstallerNotAPIBase(t *testing.T)
 	assert.True(t, strings.Contains(body, `"https:"`) && strings.Contains(body, `"http:"`),
 		"只放行 http/https，挡掉 javascript: 之类的 scheme")
 
-	// 两个平台各有一个按钮，且都默认隐藏：无安装包 / 解析失败都不该露出一个点不动
-	// 的入口。用正则匹配整个标签，属性顺序、新增 class 之类的排版改动不该挂 CI。
-	for _, id := range []string{"btn-download-android", "btn-download-ios"} {
-		tag := regexp.MustCompile(`<a[^>]*id="` + id + `"[^>]*>`).FindString(body)
-		assert.NotEmpty(t, tag, "落地页必须有 %s 锚点", id)
-		assert.Contains(t, tag, `style="display:none"`,
-			"%s 必须默认隐藏，解析到合法地址后才显示", id)
+	// 两个平台各一行（下载按钮 + 复制链接），整行默认隐藏：无安装包 / 解析失败都不该
+	// 露出一个点不动的入口。用正则匹配整个标签，属性顺序、新增 class 之类的排版改动
+	// 不该挂 CI。
+	for _, p := range []string{"android", "ios"} {
+		row := regexp.MustCompile(`<div[^>]*id="row-download-` + p + `"[^>]*>`).FindString(body)
+		assert.NotEmpty(t, row, "落地页必须有 %s 的下载行", p)
+		assert.Contains(t, row, `style="display:none"`,
+			"%s 下载行必须默认隐藏，解析到合法地址后才显示", p)
+
+		assert.True(t, strings.Contains(body, `id="btn-download-`+p+`"`),
+			"%s 必须有下载按钮", p)
+		assert.True(t, strings.Contains(body, `id="btn-copy-`+p+`"`),
+			"%s 必须有复制链接按钮", p)
 	}
+
+	// 复制走 Clipboard API，但它要求安全上下文，而邀请链接大量在各家 IM 的内嵌
+	// 浏览器里打开。没有 execCommand 兜底时，那些环境里点复制会静默无反应。
+	assert.True(t, strings.Contains(body, "navigator.clipboard"),
+		"复制优先走 Clipboard API")
+	assert.True(t, strings.Contains(body, `execCommand("copy")`),
+		"必须保留 execCommand 兜底——内嵌浏览器里 Clipboard API 常不可用")
 }
 
 // 落地页把 modules/common 的 updater 路由硬编码成字符串，Go 这边没有任何符号引用能

--- a/modules/group/api_invite_h5_test.go
+++ b/modules/group/api_invite_h5_test.go
@@ -427,8 +427,9 @@ func TestGroupInvitePage_DownloadButtonResolvesInstallerNotAPIBase(t *testing.T)
 	assert.Equal(t, http.StatusOK, w.Code)
 	body := w.Body.String()
 
-	// 回归钉子：任何把按钮 href 直接绑到 API_BASE 的写法都必须挂 CI。
-	assert.NotContains(t, body, `getElementById("btn-download").href = API_BASE`,
+	// 回归钉子：任何把按钮 href 绑到 API_BASE 的写法都必须挂 CI。不绑具体元素 id，
+	// 这样换个 id 或先取元素再赋值也一样会被拦下。
+	assert.NotContains(t, body, "href = API_BASE",
 		"下载按钮不能回退到 API_BASE —— 生产的 BaseURL 是 API 前缀，点击会 404")
 
 	// 安装包地址必须来自公开的 updater 接口，两个平台都要覆盖。
@@ -437,10 +438,15 @@ func TestGroupInvitePage_DownloadButtonResolvesInstallerNotAPIBase(t *testing.T)
 	assert.True(t, strings.Contains(body, "/v1/common/updater/ios/1.0.0"),
 		"iOS 安装包地址必须来自公开 updater 接口")
 
+	// 不做 UA 嗅探：邀请链接主要在微信 / 企业 IM 的内嵌浏览器里打开，UA 被各家改写，
+	// 猜错就是给用户递错平台的安装包。两个平台各给一个按钮，各自独立显示。
+	assert.NotContains(t, body, "navigator.userAgent",
+		"落地页不应按 UA 分流下载入口——内嵌浏览器的 UA 不可靠")
+
 	// 最容易的静默失效方式是删掉调用点：函数定义、两条路径、scheme 校验全都还在，
 	// 上面每一条断言照样绿，而下载按钮在线上永远不显示。所以调用点必须单独钉住。
-	assert.True(t, strings.Contains(body, "setupDownloadButton()"),
-		"setupDownloadButton 必须真的被调用，只定义不调用会让按钮永远不显示")
+	assert.True(t, strings.Contains(body, "setupDownloadButtons()"),
+		"setupDownloadButtons 必须真的被调用，只定义不调用会让按钮永远不显示")
 
 	// updater 没有版本记录时返回 204（2xx 但无 body）。断言到 204 出现即可，
 	// 不绑具体写法——换成 204 === r.status 或抽成命名函数都不该挂 CI。
@@ -455,13 +461,14 @@ func TestGroupInvitePage_DownloadButtonResolvesInstallerNotAPIBase(t *testing.T)
 	assert.True(t, strings.Contains(body, `"https:"`) && strings.Contains(body, `"http:"`),
 		"只放行 http/https，挡掉 javascript: 之类的 scheme")
 
-	// 按钮默认隐藏：桌面端 / 无安装包 / 解析失败都不该露出一个点不动的入口。
-	// 用正则匹配整个标签，属性顺序、新增 class 之类的排版改动不该挂 CI。
-	downloadAnchor := regexp.MustCompile(`<a[^>]*id="btn-download"[^>]*>`)
-	tag := downloadAnchor.FindString(body)
-	assert.NotEmpty(t, tag, "落地页必须有 btn-download 锚点")
-	assert.Contains(t, tag, `style="display:none"`,
-		"下载按钮必须默认隐藏，解析到合法地址后才显示")
+	// 两个平台各有一个按钮，且都默认隐藏：无安装包 / 解析失败都不该露出一个点不动
+	// 的入口。用正则匹配整个标签，属性顺序、新增 class 之类的排版改动不该挂 CI。
+	for _, id := range []string{"btn-download-android", "btn-download-ios"} {
+		tag := regexp.MustCompile(`<a[^>]*id="` + id + `"[^>]*>`).FindString(body)
+		assert.NotEmpty(t, tag, "落地页必须有 %s 锚点", id)
+		assert.Contains(t, tag, `style="display:none"`,
+			"%s 必须默认隐藏，解析到合法地址后才显示", id)
+	}
 }
 
 // 落地页把 modules/common 的 updater 路由硬编码成字符串，Go 这边没有任何符号引用能

--- a/modules/group/api_invite_h5_test.go
+++ b/modules/group/api_invite_h5_test.go
@@ -448,9 +448,9 @@ func TestGroupInvitePage_DownloadButtonResolvesInstallerNotAPIBase(t *testing.T)
 	assert.True(t, strings.Contains(body, "setupDownloadButtons()"),
 		"setupDownloadButtons 必须真的被调用，只定义不调用会让按钮永远不显示")
 
-	// updater 没有版本记录时返回 204（2xx 但无 body）。断言到 204 出现即可，
-	// 不绑具体写法——换成 204 === r.status 或抽成命名函数都不该挂 CI。
-	assert.True(t, strings.Contains(body, "204"),
+	// updater 没有版本记录时返回 204（2xx 但无 body）。锚在 r.status === 204 上：
+	// 裸 "204" 子串今天不空转，但任何 SVG 坐标 / 色值 / padding 里出现 204 就会。
+	assert.True(t, strings.Contains(body, "r.status === 204"),
 		"必须处理 updater 的 204（无版本记录，响应无 body）")
 
 	// href 落地前必须过 scheme 白名单：updater 吐的是库里的裸 download_url。
@@ -460,6 +460,36 @@ func TestGroupInvitePage_DownloadButtonResolvesInstallerNotAPIBase(t *testing.T)
 	assert.True(t, strings.Contains(body, ".protocol"), "必须检查 scheme")
 	assert.True(t, strings.Contains(body, `"https:"`) && strings.Contains(body, `"http:"`),
 		"只放行 http/https，挡掉 javascript: 之类的 scheme")
+
+	// 安装包地址必须是绝对的。相对地址按哪个 base 解析，本页与 Web 登录页
+	// （location.origin）无法达成一致，两端算出的地址会分叉，至多一处正确 ——
+	// 所以契约是拒绝，而不是各自猜一个 base。
+	assert.NotContains(t, body, "new URL(trimmed, API_BASE)",
+		"不得把相对安装包地址按 API_BASE 解析——与 Web 端 location.origin 的口径冲突")
+
+	// 复制必须把 execCommand 兜底挂在 writeText 的 rejection 上，而不是写成
+	// else 分支：内嵌 webview 常常暴露了 clipboard 且满足安全上下文，却拒绝
+	// writeText —— 只判能力存在会让兜底恰好在最需要它的环境里永不执行。
+	assert.True(t, strings.Contains(body, "writeText(text).catch("),
+		"Clipboard API 被拒时必须继续走 execCommand 兜底，不能只判能力是否存在")
+
+	// 安装包地址必须带文件后缀。download_url 由管理台自由填写，填成一个下载引导页
+	// 时「下载 Android 版」会把用户送到网页而不是安装包 —— 按钮承诺的动作没发生。
+	assert.True(t, strings.Contains(body, "lastSegment.indexOf(\".\")"),
+		"无文件后缀的地址不是安装包，必须剔除并退到 web_url 兜底")
+
+	// 两个平台都拿不出安装包时（都 204 / updater 5xx / 网络失败 / 地址非法），
+	// 页面不能只剩一张卡片加一片空白 —— 用户无从判断是没 App 可下还是页面坏了。
+	assert.True(t, strings.Contains(body, "/v1/common/appconfig"),
+		"兜底入口地址必须取自公开的 appconfig.web_url")
+	assert.True(t, strings.Contains(body, "setupWebFallback"),
+		"必须有 web_url 兜底路径")
+	assert.True(t, strings.Contains(body, "d.web_url"),
+		"兜底必须读 appconfig 的 web_url 字段")
+	fallbackRow := regexp.MustCompile(`<div[^>]*id="row-web-fallback"[^>]*>`).FindString(body)
+	assert.NotEmpty(t, fallbackRow, "落地页必须有 web_url 兜底行")
+	assert.Contains(t, fallbackRow, `style="display:none"`,
+		"兜底行必须默认隐藏——只在两个平台都无安装包时才出现")
 
 	// 两个平台各一行（下载按钮 + 复制链接），整行默认隐藏：无安装包 / 解析失败都不该
 	// 露出一个点不动的入口。用正则匹配整个标签，属性顺序、新增 class 之类的排版改动
@@ -530,10 +560,11 @@ func TestGroupInvitePage_UpdaterRoutesAreServed(t *testing.T) {
 	} {
 		w := httptest.NewRecorder()
 		s.GetRoute().ServeHTTP(w, newInviteRequest(t, path))
-		// 库里没有版本记录时返回 204，有则 200；唯独不能是 404 —— 那意味着落地页
-		// 硬编码的路径已经和实际路由表对不上了。
-		assert.NotEqual(t, http.StatusNotFound, w.Code,
-			"落地页硬编码的 updater 路径 %s 必须能被服务端路由到", path)
+		// 库里没有版本记录时返回 204，有则 200 —— 只接受这两个。
+		// 仅排除 404 是不够的：401 / 500 同样会让落地页拿不到地址，而 401 恰好是
+		// 「有人给这条公开路由加了鉴权」的信号，那对未登录访客等同于路由消失。
+		assert.Contains(t, []int{http.StatusOK, http.StatusNoContent}, w.Code,
+			"落地页硬编码的 updater 路径 %s 必须可路由且保持公开（期望 200/204，实得 %d）", path, w.Code)
 	}
 }
 

--- a/modules/group/api_invite_h5_test.go
+++ b/modules/group/api_invite_h5_test.go
@@ -445,8 +445,12 @@ func TestGroupInvitePage_DownloadButtonResolvesInstallerNotAPIBase(t *testing.T)
 
 	// 最容易的静默失效方式是删掉调用点：函数定义、两条路径、scheme 校验全都还在，
 	// 上面每一条断言照样绿，而下载按钮在线上永远不显示。所以调用点必须单独钉住。
-	assert.True(t, strings.Contains(body, "setupDownloadButtons()"),
-		"setupDownloadButtons 必须真的被调用，只定义不调用会让按钮永远不显示")
+	//
+	// 必须锚在「行首的调用语句」上：裸子串 setupDownloadButtons() 会被函数声明
+	// `function setupDownloadButtons() {` 满足，删掉真实调用后断言照样绿 ——
+	// 那正是这条断言自称要拦的静默失效。
+	assert.Regexp(t, `(?m)^setupDownloadButtons\(\);$`, body,
+		"setupDownloadButtons 必须真的在顶层被调用，只定义不调用会让按钮永远不显示")
 
 	// updater 没有版本记录时返回 204（2xx 但无 body）。锚在 r.status === 204 上：
 	// 裸 "204" 子串今天不空转，但任何 SVG 坐标 / 色值 / padding 里出现 204 就会。
@@ -455,7 +459,7 @@ func TestGroupInvitePage_DownloadButtonResolvesInstallerNotAPIBase(t *testing.T)
 
 	// href 落地前必须过 scheme 白名单：updater 吐的是库里的裸 download_url。
 	// 只断言校验点和两个放行的 scheme 存在，不绑比较表达式的排列顺序。
-	assert.True(t, strings.Contains(body, "safeDownloadURL"),
+	assert.True(t, strings.Contains(body, "safeAbsoluteURL"),
 		"updater 返回的地址必须经过 scheme 校验后才能写进 a.href")
 	assert.True(t, strings.Contains(body, ".protocol"), "必须检查 scheme")
 	assert.True(t, strings.Contains(body, `"https:"`) && strings.Contains(body, `"http:"`),
@@ -473,17 +477,20 @@ func TestGroupInvitePage_DownloadButtonResolvesInstallerNotAPIBase(t *testing.T)
 	assert.True(t, strings.Contains(body, "writeText(text).catch("),
 		"Clipboard API 被拒时必须继续走 execCommand 兜底，不能只判能力是否存在")
 
-	// 安装包地址必须带文件后缀。download_url 由管理台自由填写，填成一个下载引导页
-	// 时「下载 Android 版」会把用户送到网页而不是安装包 —— 按钮承诺的动作没发生。
-	assert.True(t, strings.Contains(body, "lastSegment.indexOf(\".\")"),
-		"无文件后缀的地址不是安装包，必须剔除并退到 web_url 兜底")
+	// 不得再引入「路径必须带文件后缀」之类的本地规则：写入侧 addAppVersion 不校验
+	// 格式，octo-web 登录页也只校验 scheme。多加一条规则会让同一个存储值在两个页面上
+	// 「能不能用」结论相反 —— 正是本页拒绝相对地址时所反对的那种分歧。而且对 iOS 是
+	// 死局：能在浏览器里装上 App 的地址必然是商店 / TestFlight 页，全部无后缀。
+	assert.NotContains(t, body, `lastSegment.indexOf(".")`,
+		"不得对安装包地址施加文件后缀要求——与写入侧和 octo-web 消费方的契约都不一致")
 
 	// 两个平台都拿不出安装包时（都 204 / updater 5xx / 网络失败 / 地址非法），
 	// 页面不能只剩一张卡片加一片空白 —— 用户无从判断是没 App 可下还是页面坏了。
 	assert.True(t, strings.Contains(body, "/v1/common/appconfig"),
 		"兜底入口地址必须取自公开的 appconfig.web_url")
-	assert.True(t, strings.Contains(body, "setupWebFallback"),
-		"必须有 web_url 兜底路径")
+	// 同上：裸 setupWebFallback 会被函数声明和 HTML 注释满足，必须锚在调用表达式上。
+	assert.Regexp(t, `results\.indexOf\(true\) === -1\) setupWebFallback\(\);`, body,
+		"web_url 兜底必须真的在两个平台都失败时被调用")
 	assert.True(t, strings.Contains(body, "d.web_url"),
 		"兜底必须读 appconfig 的 web_url 字段")
 	fallbackRow := regexp.MustCompile(`<div[^>]*id="row-web-fallback"[^>]*>`).FindString(body)
@@ -554,17 +561,34 @@ func TestGroupInvitePage_UpdaterRoutesAreServed(t *testing.T) {
 	s, ctx := newTestServer(t)
 	_ = New(ctx)
 
-	for _, path := range []string{
-		"/v1/common/updater/android/1.0",
-		"/v1/common/updater/ios/1.0.0",
+	// appconfig 也是落地页硬编码的 modules/common 路由，同样没有符号引用兜底，
+	// 所以和两条 updater 路径一起验。
+	for _, tc := range []struct {
+		path      string
+		jsonField string // 200 响应里落地页真正读的字段；空串表示该路径不强制校验
+	}{
+		{"/v1/common/updater/android/1.0", "url"},
+		{"/v1/common/updater/ios/1.0.0", "url"},
+		{"/v1/common/appconfig", "web_url"},
 	} {
 		w := httptest.NewRecorder()
-		s.GetRoute().ServeHTTP(w, newInviteRequest(t, path))
+		s.GetRoute().ServeHTTP(w, newInviteRequest(t, tc.path))
 		// 库里没有版本记录时返回 204，有则 200 —— 只接受这两个。
 		// 仅排除 404 是不够的：401 / 500 同样会让落地页拿不到地址，而 401 恰好是
 		// 「有人给这条公开路由加了鉴权」的信号，那对未登录访客等同于路由消失。
 		assert.Contains(t, []int{http.StatusOK, http.StatusNoContent}, w.Code,
-			"落地页硬编码的 updater 路径 %s 必须可路由且保持公开（期望 200/204，实得 %d）", path, w.Code)
+			"落地页硬编码的路径 %s 必须可路由且保持公开（期望 200/204，实得 %d）", tc.path, w.Code)
+
+		// 状态码对不代表字段名对：把 JSON 里的 url 改名成 download_url，上面的断言和
+		// 所有 grep 断言照样绿，而落地页读到的 d.url 是 undefined，所有行永远不显示。
+		if w.Code == http.StatusOK && tc.jsonField != "" {
+			var payload map[string]interface{}
+			if assert.NoError(t, json.Unmarshal(w.Body.Bytes(), &payload), "%s 必须返回 JSON", tc.path) {
+				_, ok := payload[tc.jsonField]
+				assert.True(t, ok,
+					"%s 的 200 响应必须含落地页读取的 %q 字段（字段改名会让页面静默失效）", tc.path, tc.jsonField)
+			}
+		}
 	}
 }
 

--- a/modules/group/api_invite_h5_test.go
+++ b/modules/group/api_invite_h5_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -401,12 +402,20 @@ func TestGroupInvitePage_ContainsJoinButton(t *testing.T) {
 // 修法是改用公开免登录的 updater 接口拿真实安装包地址（与 Web 登录页下载浮层同源），
 // 拿不到就保持按钮隐藏。这个测试断言的是**最终 href 的来源**，而不是「占位符已被替换」——
 // 后者在旧实现下同样成立，正是它让这个 bug 一路漏到线上。
+// 这些断言只能确认落地页「长得对」，确认不了它「跑得对」——它们是对一个静态资源做
+// grep。把 bug 换个写法重新引入（先取元素再赋值）就能绕过第一条钉子。真正的行为覆盖
+// 要么把这段逻辑挪回服务端用 Go 测，要么给仓库引一套 JS 测试环境；在那之前，这里的
+// 定位是烟雾报警器，不是行为契约。所以断言尽量绑「必须存在的结构」，不绑具体排版。
 func TestGroupInvitePage_DownloadButtonResolvesInstallerNotAPIBase(t *testing.T) {
 	s, ctx := newTestServer(t)
 	_ = New(ctx)
 
 	wd, err := os.Getwd()
-	assert.NoError(t, err)
+	if err != nil {
+		// 不能只 assert：wd 为空会让 Cleanup 的 Chdir("") 静默失败，
+		// 把整个进程留在 repo 根目录，污染本包后面所有按相对路径找文件的测试。
+		t.Fatalf("getwd: %v", err)
+	}
 	if err := os.Chdir("../.."); err != nil {
 		t.Fatalf("chdir to repo root: %v", err)
 	}
@@ -428,19 +437,52 @@ func TestGroupInvitePage_DownloadButtonResolvesInstallerNotAPIBase(t *testing.T)
 	assert.True(t, strings.Contains(body, "/v1/common/updater/ios/1.0.0"),
 		"iOS 安装包地址必须来自公开 updater 接口")
 
-	// updater 在库里没有版本记录时返回 204 且无 body，直接 .json() 会抛异常。
-	assert.True(t, strings.Contains(body, "r.status === 204"),
-		"必须特判 updater 的 204（无版本记录，响应无 body）")
+	// 最容易的静默失效方式是删掉调用点：函数定义、两条路径、scheme 校验全都还在，
+	// 上面每一条断言照样绿，而下载按钮在线上永远不显示。所以调用点必须单独钉住。
+	assert.True(t, strings.Contains(body, "setupDownloadButton()"),
+		"setupDownloadButton 必须真的被调用，只定义不调用会让按钮永远不显示")
+
+	// updater 没有版本记录时返回 204（2xx 但无 body）。断言到 204 出现即可，
+	// 不绑具体写法——换成 204 === r.status 或抽成命名函数都不该挂 CI。
+	assert.True(t, strings.Contains(body, "204"),
+		"必须处理 updater 的 204（无版本记录，响应无 body）")
 
 	// href 落地前必须过 scheme 白名单：updater 吐的是库里的裸 download_url。
+	// 只断言校验点和两个放行的 scheme 存在，不绑比较表达式的排列顺序。
 	assert.True(t, strings.Contains(body, "safeDownloadURL"),
 		"updater 返回的地址必须经过 scheme 校验后才能写进 a.href")
-	assert.True(t, strings.Contains(body, `u.protocol === "http:" || u.protocol === "https:"`),
+	assert.True(t, strings.Contains(body, ".protocol"), "必须检查 scheme")
+	assert.True(t, strings.Contains(body, `"https:"`) && strings.Contains(body, `"http:"`),
 		"只放行 http/https，挡掉 javascript: 之类的 scheme")
 
 	// 按钮默认隐藏：桌面端 / 无安装包 / 解析失败都不该露出一个点不动的入口。
-	assert.True(t, strings.Contains(body, `id="btn-download" href="#" target="_blank" rel="noopener" style="display:none"`),
+	// 用正则匹配整个标签，属性顺序、新增 class 之类的排版改动不该挂 CI。
+	downloadAnchor := regexp.MustCompile(`<a[^>]*id="btn-download"[^>]*>`)
+	tag := downloadAnchor.FindString(body)
+	assert.NotEmpty(t, tag, "落地页必须有 btn-download 锚点")
+	assert.Contains(t, tag, `style="display:none"`,
 		"下载按钮必须默认隐藏，解析到合法地址后才显示")
+}
+
+// 落地页把 modules/common 的 updater 路由硬编码成字符串，Go 这边没有任何符号引用能
+// 在它被改名时报错。上面的测试只 grep HTML 里有没有这个字面量——路由改名后字面量还在，
+// 全仓测试照样绿，而线上每个移动端访客的 fetch 都 404、下载按钮永远不出现。
+// 这条测试用一次真实请求确认该路由确实由服务端提供。
+func TestGroupInvitePage_UpdaterRoutesAreServed(t *testing.T) {
+	s, ctx := newTestServer(t)
+	_ = New(ctx)
+
+	for _, path := range []string{
+		"/v1/common/updater/android/1.0",
+		"/v1/common/updater/ios/1.0.0",
+	} {
+		w := httptest.NewRecorder()
+		s.GetRoute().ServeHTTP(w, newInviteRequest(t, path))
+		// 库里没有版本记录时返回 204，有则 200；唯独不能是 404 —— 那意味着落地页
+		// 硬编码的路径已经和实际路由表对不上了。
+		assert.NotEqual(t, http.StatusNotFound, w.Code,
+			"落地页硬编码的 updater 路径 %s 必须能被服务端路由到", path)
+	}
 }
 
 // Mininglamp-OSS/octo-server#1246: 移动端两端均未注册 dmwork:// scheme，


### PR DESCRIPTION
## Summary

The group invite landing page's "download app" button was bound directly to the injected `API_BASE`. In production `External.BaseURL` is the API prefix (`https://<host>/api`), so the only download entry point on the page was a guaranteed 404 — confirmed live against the deployed host. The code comment said "fall back to the product site", but the implementation reused the API base.

The fix resolves real installer addresses from the public, unauthenticated updater endpoint — the same source the web login page's download popover already uses. No new configuration: every endpoint it touches already exists and is public.

## Related Issue

Regression introduced by `10cff2da` ("feat(group): public H5 invite landing page").

## Linked Spec

`.octospec/tasks/invite-page-download-entry/brief.md`

## Changes

- Resolve installer addresses from `GET /v1/common/updater/{android/1.0, ios/1.0.0}` instead of pointing at `API_BASE`.
- Render one row per platform rather than sniffing `navigator.userAgent`. Invite links are opened mostly from the in-app browsers of WeChat and other IM clients, which rewrite the UA, and iPadOS 13+ reports itself as a Macintosh; guessing wrong hands someone the wrong platform's installer, while guessing right only saves one button. Desktop gets both rows, to scan or forward to a phone.
- Hide a row when its platform has no version record (updater `204`), the address is malformed, or the request fails. Nothing anywhere falls back to `API_BASE` — no entry point is better than a dead link.
- **Fall back to `appconfig.web_url` when neither platform yields an installer.** That case is reachable — no version records, updater 5xx, request timeout, every address invalid — and without it the page renders a group card above an unexplained blank. Because the invite-detail request is independent and still succeeds, nothing looks broken. The fallback is mutually exclusive with the download rows so it cannot dilute the primary path, and it is validated through the same absolute-http/https check.
- Validate every address through a scheme allowlist before it reaches `a.href`. Relative values are **rejected, not resolved**: this page and the web login page would resolve them against different bases (`API_BASE` vs `location.origin`), so at most one could be right. No rule beyond the scheme check — an earlier revision required a file suffix and it was removed; see the brief's rejected-alternative section for why it was both undiscriminating and unsatisfiable for iOS.
- Add a copy-link button per row, so an address seen on a desktop can reach the phone that will install it. Prefers the Clipboard API and chains `execCommand` onto a **rejected** `writeText`, not merely onto the API being absent — embedded IM webviews commonly expose `navigator.clipboard` under HTTPS and then deny the write. When both fail the toast says so rather than reporting a copy that did not happen.
- Bound the updater and appconfig requests with `AbortController`, spanning the body read as well as the fetch. `fetch` resolves on headers, so clearing the timer there would leave a stalled body able to keep `Promise.all` pending forever and suppress the fallback.
- Add inline SVG icons. The page pulls no CDN script, external stylesheet, icon font or remote image — it is regularly opened on internal networks and behind filtered egress, where any external dependency degrades it to blank boxes.
- `rel="noopener noreferrer"` on all three outbound anchors. The page URL carries `?code=<secret>` and these anchors now navigate to third-party hosts; webviews on the legacy referrer default would otherwise put the invite code in those hosts' access logs.
- Fire the download lookups in parallel with the invite-detail request instead of chaining them.

## Testing

- [x] Unit tests added/updated
- [x] Manually verified

`modules/group` under the CI recipe (fresh database, `-race`, `-shuffle=on`, `OCTO_MASTER_KEY` set) passes; the invite-page tests were re-run after every revision.

New tests:

- `TestGroupInvitePage_DownloadButtonResolvesInstallerNotAPIBase` — asserts where the final href comes from, that `setupDownloadButtons()` is actually **called** (anchored on a line-start regex, because the bare substring is satisfied by the function declaration), that both rows default to hidden, that no UA sniffing is present, that the clipboard fallback hangs off the rejection, and that the removed suffix rule cannot creep back.
- `TestGroupInvitePage_UpdaterRoutesAreServed` — issues real requests for all three hardcoded `modules/common` paths, requires 200/204 (not merely not-404, so auth appearing in front of a public route is caught), and asserts the JSON field each one actually reads. It seeds `app_version` rows first: without them the updater answers 204 on a clean database and the field assertion never executes.
- `TestGroupInvitePage_NoExternalResources` — rejects external scripts, stylesheets, CSS `@import`, `url(http`, and remote images, and requires inline `<svg>` so the rule cannot be satisfied by deleting the icons.

Behavior was additionally verified out-of-band with a headless-browser harness against a stub server reproducing `groupInvitePage`'s substitution: both platforms present, one platform only, updater `204`, updater 5xx, network failure, App Store / TestFlight / query-string addresses accepted, `javascript:` and relative and protocol-relative addresses rejected, the `web_url` fallback firing only when both platforms fail, and a real clipboard read-back for all three copy paths. That harness is not part of this repository — see the gap below.

## COMPREHENSION

**1. What does this change actually do to the load-bearing path?**

It changes where the public invite landing page's download entry gets its URL. Previously: the injected `External.BaseURL`, which in production is an API prefix, so the link 404'd. Now: addresses returned by the public updater endpoint, gated on a scheme allowlist, with each row hidden whenever no usable address comes back, and a `web_url` entry when none does. `External.BaseURL` is still injected as `API_BASE` and still used for every API call on the page — only its misuse as a download-page address is removed. The join flow, the session-discovery logic, and all the state pages are untouched.

**2. What could break because of it (dependents + failure mode)?**

- The page names three `modules/common` routes as bare strings with no symbolic reference from Go. A rename breaks it silently — the fetch 404s, `readJSONBody` yields null, no row appears. `TestGroupInvitePage_UpdaterRoutesAreServed` is the guard; it works because `modules/group` already imports `modules/common`, so that module's `init()` is linked into the test binary and `module.Setup` registers its routes.
- A deployment whose `app_version` table has no row for a platform now shows no button for it, where before it showed a broken one. Intended, and why the copy control lives inside the same row and why the `web_url` fallback exists.
- `download_url` is admin-written but reaches `a.href`, so an unvalidated value would be a `javascript:`-scheme sink. The allowlist closes that. It is a scheme check, not an origin check — an admin can already point the column at any host.
- No deep link was added; `octo-server#1246` removed `dmwork://` because neither mobile client registers the scheme, and a grep test pins that.

**3. How do you know it works (specific test/repro/trace)?**

`modules/group` passes under the CI recipe, including the assertions above. Each guard was checked for vacuity rather than assumed: the call-site regex was confirmed to fail when the call is deleted, and the field assertion was confirmed to fail when pointed at a non-existent field name. End-to-end behavior, including every failure branch and the clipboard round-trip, was exercised in a real browser against a stub server.

**Known gap, stated plainly:** the landing page is a static asset, so the Go assertions can only check its shape, not its behavior. Reintroducing the bug through a local variable would evade them. Closing that properly means moving the logic server-side or giving this repository a JS test environment; neither is in scope here.

## Deferred follow-ups

Agreed with reviewers as non-gating: move `setupDownloadButtons()` below the invite-detail block (saves lookups on expired links and decouples the primary path from a synchronous throw), reject URL userinfo in `safeAbsoluteURL`, loosen the no-external-resource assertions to case-insensitive regexes, the `execCommand` transient-activation limit, and moving the three rows out of `#content` so they survive the expired/error state pages. The durable fix for bad `download_url` values is validation in the admin console, not more client-side heuristics.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] PR description is in English
- [x] Added tests for my changes
- [x] Updated documentation (`.octospec` task brief)
- [x] Followed commit message conventions (Conventional Commits)
