### PR TITLE
perf(test): stop the CI Test lane replaying the migration set per test server

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,16 @@ jobs:
       needs.changes.outputs.code == 'true'
     name: Test
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # Headroom, not comfort. Measured medians of this job's own runtime:
+    # 6.9 min (2026-05) → 9.7 (06) → 13.6 (07) → 17.5 (08), i.e. ~+3.5 min/month,
+    # with an observed 26.4 min outlier on run 31591952470. 30 min was ~2 months
+    # from becoming a hard wall.
+    #
+    # The dominant cause (test helpers replaying the whole migration set into a
+    # per-call database) is addressed in this change, so the trend should flatten;
+    # revisit this back down to 30 once a few runs land, rather than letting a
+    # generous ceiling hide the next regression.
+    timeout-minutes: 45
     # MySQL, Redis, and WuKongIM are required by integration tests
     # (modules/{user,oidc,thread,group,space,botfather,...}). The tests
     # hardcode 127.0.0.1:3306 (root/demo/test), 127.0.0.1:6379, and
@@ -171,6 +180,24 @@ jobs:
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: ${{ env.GO_VERSION }}
+          # Give THIS job its own Go cache key. setup-go derives the key from
+          # hashFiles(cache-dependency-path), which defaults to `**/go.sum` —
+          # identical across all eight jobs in this workflow. The action only
+          # SAVES on a cache miss, so whichever job finishes first wins the key
+          # forever: in practice `i18n Lint` (12s, builds two tiny tools) stores
+          # a ~10 MB stub, and every later run restores that stub and reports
+          # "Cache hit". Measured cost on run 31566358696: the Test job spent 97s
+          # cold-compiling the whole -race dependency tree and re-downloaded 166
+          # modules inside the test step.
+          #
+          # Adding this workflow file to the hash inputs yields a key no other
+          # job computes, so the Test job saves and restores its OWN cache
+          # (GOMODCACHE + a -race-populated GOCACHE, ~1 GB uncompressed).
+          # If you ever add cache-dependency-path to another job, keep the input
+          # set different from this one or the stub problem comes straight back.
+          cache-dependency-path: |
+            go.sum
+            .github/workflows/ci.yml
 
       - name: Install MySQL/Redis client tooling
         run: |
@@ -275,8 +302,29 @@ jobs:
           while read -r pkg; do
             mysql -h 127.0.0.1 -uroot -pdemo -e "DROP DATABASE IF EXISTS test; CREATE DATABASE test CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;"
             redis-cli -h 127.0.0.1 -p 6379 FLUSHALL >/dev/null
+            # Per-package deadline. 5m is the right default — a package that
+            # blows it has almost certainly deadlocked — but modules/user needed
+            # headroom: it tripped `panic: test timed out after 5m0s` on run
+            # 31591952470 with the then-current test only 20s in, i.e. the
+            # package ran out of budget rather than any single test hanging.
+            #
+            # The cause was newTokenHTTPTestServer creating a fresh database per
+            # call and replaying the whole migration set inside it (13-25s each,
+            # 14 call sites); it now shares one schema, which measured
+            # 326s -> 96s for the package locally. This override is therefore
+            # expected to be unnecessary.
+            #
+            # REMOVE IT once a few CI runs confirm the package's real duration
+            # here — keeping every package on the tight deadline is what makes a
+            # genuine hang surface fast. It is kept for now only because that
+            # -70% is a local (arm64, warm cache) measurement and this lane's
+            # DDL throughput may differ.
+            pkg_timeout=5m
+            case "$pkg" in
+              */modules/user) pkg_timeout=15m ;;
+            esac
             echo "::group::go test $pkg"
-            if ! go test -race -shuffle=on -count=1 -timeout 5m "$pkg"; then
+            if ! go test -race -shuffle=on -count=1 -timeout "$pkg_timeout" "$pkg"; then
               fail=1
             fi
             echo "::endgroup::"

--- a/.octospec/tasks/ci-test-lane-runtime/brief.md
+++ b/.octospec/tasks/ci-test-lane-runtime/brief.md
@@ -1,0 +1,94 @@
+---
+type: Task
+title: "Task: ci-test-lane-runtime"
+description: Stop the CI Test lane's runtime growth by removing per-call migration replays, and fix the ordering flake it hid
+tags: ["test", "testing", "ci"]
+timestamp: 2026-08-13T00:00:00Z
+# --- octospec extension fields ---
+slug: ci-test-lane-runtime
+upstream: n/a (no issue filed; raised from CI run 31566358696 / 31591952470)
+source: self
+---
+
+# Task: ci-test-lane-runtime
+
+## Goal
+
+Stop the CI `Test` job's runtime growth and remove its two known failure modes.
+
+Measured medians of the job across three months: 6.9 min (2026-05) → 9.7 (06) →
+13.6 (07) → 17.5 (08), i.e. ~+3.5 min/month, with a 26.4 min outlier. Two
+distinct failures rode along with it:
+
+1. `modules/user` exhausted the 5m per-package deadline (run 31591952470,
+   `FAIL 327.129s`, `panic: test timed out after 5m0s` with the then-current
+   test only 20s in — the package ran out of budget, nothing hung).
+2. `TestManagerSystemSetting_OrderingRejectsFromSidebarSide` failed
+   intermittently under `-shuffle=on` (runs 31566358696, 31571974333).
+
+## Background
+
+Instrumented in a CI-equivalent local environment (same image tags, same env,
+shared netns so `127.0.0.1:3306` resolves like it does on a runner).
+`NewTestServer` decomposes as: `module.Setup` 93.6%, `CleanAllTables` 6.1%,
+everything else ~0.
+
+Inside `module.Setup`, `executeSQL` is bimodal: p50 132ms (migrations already
+applied) but a handful of calls at 13–25s, and those few accounted for 94% of
+the total. They are the calls that genuinely replay all 194 migrations, caused by
+`newTokenHTTPTestServer` doing `CREATE DATABASE` per invocation across its 14
+call sites.
+
+Note for whoever picks this up next: the intuitive target — `CleanAllTables`
+issuing one `DELETE` per table, ~150k statements per CI run, correlating with job
+runtime at r=0.988 — is a **red herring**. That correlation is spurious (every
+cost grows with calls × scale), empty-table `DELETE` is cheap, and an
+implementation that batched it made the full suite 5% *slower*.
+
+The ordering flake is unrelated to runtime: `EnsureSystemSettings` memoises a
+package-level singleton, and `CleanAllTables` only truncates rows, so a value
+written through the admin handler by an earlier test survives into the next one's
+"current snapshot".
+
+## Load-bearing list
+
+- `modules/user` test isolation: 14 call sites previously each got a pristine
+  database. They now share one schema, so cross-test row leakage inside that file
+  is newly possible; rows are wiped per call to compensate. Redis stays isolated
+  per call via the existing per-call cache prefixes.
+- `testutil.CleanAllTables` hardcodes `table_schema = 'test'`, so it cannot be
+  used to reset any other schema (it lists `test`'s table names and deletes from
+  the connected database, erroring 1146). The new reset resolves the schema with
+  `DATABASE()` instead.
+- The CI `Test` job's per-package deadline and the job-level timeout.
+- setup-go's cache key for the `Test` job (previously shared with seven other
+  jobs, so the fastest job's ~10 MB stub won the key permanently).
+- `modules/common` admin system-setting write path reads the process-wide
+  `SystemSettings` snapshot; tests must reset it, not just the table.
+
+## Out of scope
+
+- `octo-lib` changes. A migration-parse cache in `module.FindMigrations`
+  (measured −8 to −11s on `user`/`group`/`bot_api`, 0 on small module sets) is
+  prepared separately; it requires an upstream PR plus a `go.mod` bump.
+- Package-level parallelism. It is the only order-of-magnitude lever left, but it
+  needs `NewTestServer` to accept a DSN (it hardcodes `127.0.0.1:3306/test`).
+- The other 11 build-your-own-database helpers (`modules/message` ×4,
+  `card_template_catalog` ×2, `category` ×2, `pkg/auth` ×2, `user` ×1). Same
+  pattern, but their packages total only 3.5–7.2s, so the cost is negligible.
+- `CleanAllTables` itself, in either the performance or the `DATABASE()` sense —
+  both belong upstream and the latter changes behaviour for integration-tagged
+  tests this lane does not run.
+
+## Acceptance
+
+- `go test -race -shuffle=on -count=1 ./modules/user/` passes and the package's
+  runtime drops substantially. Local CI-equivalent: 326.0s → 96.2s.
+- Full suite stays green: 112 packages, 0 failures.
+- Ordering flake is fixed and the fix is demonstrated, not asserted: with the
+  fix reverted, `-run
+  'TestManagerSystemSetting_UpdateAcceptsInRangeIntBoundaries|TestManagerSystemSetting_OrderingRejectsFromSidebarSide'`
+  reproduces the exact CI failure (`expected: 200 / actual: 400`,
+  `details.recent_days = 3650`); with the fix it passes.
+- `go test ./tools/workflow-guards/` still passes (it parses `ci.yml`).
+- `go vet ./...` clean.

--- a/modules/common/api_manager_system_setting_test.go
+++ b/modules/common/api_manager_system_setting_test.go
@@ -429,6 +429,14 @@ func TestManagerSystemSetting_UpdateAcceptsInRangeIntBoundaries(t *testing.T) {
 	t.Setenv(masterKeyEnv, "0123456789abcdef0123456789abcdef")
 	s, ctx := testutil.NewTestServer()
 	require.NoError(t, testutil.CleanAllTables(ctx))
+	// 出口清理：这个用例把 sidebar.recent_filter_thread_days 顶到上界 3650，
+	// 而写路径同时更新进程级 SystemSettings 单例 —— CleanAllTables 清不掉它。
+	// 不复位的话，后面任何校验「归档窗口 >= 最近会话子区窗口」的用例都会拿 3650
+	// 当存量而误判违规（见 thread_archive_setting_test.go 的 newSuperAdminServer）。
+	t.Cleanup(func() {
+		_ = testutil.CleanAllTables(ctx)
+		_ = EnsureSystemSettings(ctx).Reload()
+	})
 	require.NoError(t, ctx.Cache().Set(
 		ctx.GetConfig().Cache.TokenCachePrefix+testutil.Token,
 		testutil.UID+"@test@"+string(wkhttp.SuperAdmin),

--- a/modules/common/thread_archive_setting_test.go
+++ b/modules/common/thread_archive_setting_test.go
@@ -203,6 +203,15 @@ func newSuperAdminServer(t *testing.T) (*wkhttp.WKHttp, *config.Context) {
 	t.Setenv(masterKeyEnv, "0123456789abcdef0123456789abcdef")
 	s, ctx := testutil.NewTestServer()
 	require.NoError(t, testutil.CleanAllTables(ctx))
+	// 入口也要 Reload：管理 handler 读的是进程级 SystemSettings 单例
+	// （EnsureSystemSettings 把它存在包级变量里，见 system_settings.go），
+	// CleanAllTables 只清 DB 行、碰不到那份快照。前面任何用例通过 POST
+	// /v1/manager/common/system_setting 写进去的值都会留在单例里，于是本用例
+	// 建立的「合法存量」会被上一个用例的残留值判违规 —— -shuffle=on 下就是
+	// 间歇性红（TestManagerSystemSetting_OrderingRejectsFromSidebarSide 在
+	// run 31566358696 / 31571974333 各失败一次，details 里的 recent_days=3650
+	// 正是 TestManagerSystemSetting_UpdateAcceptsInRangeIntBoundaries 写的值）。
+	require.NoError(t, EnsureSystemSettings(ctx).Reload())
 	require.NoError(t, ctx.Cache().Set(
 		ctx.GetConfig().Cache.TokenCachePrefix+testutil.Token,
 		testutil.UID+"@test@"+string(wkhttp.SuperAdmin),

--- a/modules/user/token_http_ttl_test.go
+++ b/modules/user/token_http_ttl_test.go
@@ -26,6 +26,51 @@ var tokenHTTPTestDatabases struct {
 	names []string
 }
 
+// tokenHTTPSharedDatabase memoises the one isolated schema every
+// newTokenHTTPTestServer caller shares.
+var tokenHTTPSharedDatabase struct {
+	sync.Once
+	name string
+	err  error
+}
+
+// tokenHTTPTestDatabase creates — once per process — the isolated database this
+// file's HTTP tests run against, and returns its name.
+//
+// It used to be one fresh database per call, each paying a full replay of the
+// migration set inside module.Setup. Measured in a CI-equivalent local
+// environment, one replay costs 13–25s (194 migrations, most of the cost in
+// ALTER steps that rebuild tables the earlier migrations just created), and this
+// helper has 14 call sites — which accounted for the bulk of modules/user's
+// 250–400s and is the direct reason the package tripped CI's 5m per-package
+// -timeout on run 31591952470. Nothing here needs a *pristine* database, only
+// one separate from the shared `test` schema that the rest of the package
+// mutates; newTokenHTTPTestServer resets the rows on every call instead.
+func tokenHTTPTestDatabase(t *testing.T) string {
+	t.Helper()
+	tokenHTTPSharedDatabase.Do(func() {
+		name := "octo_user_token_ttl_" + util.GenerUUID()[:12]
+		bootstrapConfig := config.New()
+		bootstrapConfig.Test = true
+		bootstrapConfig.DB.MySQLAddr = "root:demo@tcp(127.0.0.1:3306)/information_schema?charset=utf8mb4&parseTime=true"
+		bootstrap := config.NewContext(bootstrapConfig)
+		defer func() { _ = bootstrap.DB().DB.Close() }()
+		if _, err := bootstrap.DB().Exec("CREATE DATABASE `" + name + "` CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci"); err != nil {
+			tokenHTTPSharedDatabase.err = err
+			return
+		}
+		// Register for TestMain's teardown before returning the name, so a
+		// failure later in this test binary still drops the schema.
+		tokenHTTPTestDatabases.Lock()
+		tokenHTTPTestDatabases.names = append(tokenHTTPTestDatabases.names, name)
+		tokenHTTPTestDatabases.Unlock()
+		tokenHTTPSharedDatabase.name = name
+	})
+	require.NoError(t, tokenHTTPSharedDatabase.err, "create isolated token TTL test database")
+	require.NotEmpty(t, tokenHTTPSharedDatabase.name, "isolated token TTL database name")
+	return tokenHTTPSharedDatabase.name
+}
+
 func TestTokenDeadlineOverHTTP(t *testing.T) {
 	server, ctx, _, _ := newTokenHTTPTestServer(t)
 	t.Run("manager login issues a finite token", func(t *testing.T) {
@@ -327,17 +372,7 @@ func testNicknameUpdatePreservesFiniteTokenDeadlineOverHTTP(t *testing.T, server
 
 func newTokenHTTPTestServer(t *testing.T) (*libserver.Server, *config.Context, *User, *Manager) {
 	t.Helper()
-	databaseName := "octo_user_token_ttl_" + util.GenerUUID()[:12]
-	bootstrapConfig := config.New()
-	bootstrapConfig.Test = true
-	bootstrapConfig.DB.MySQLAddr = "root:demo@tcp(127.0.0.1:3306)/information_schema?charset=utf8mb4&parseTime=true"
-	bootstrap := config.NewContext(bootstrapConfig)
-	_, err := bootstrap.DB().Exec("CREATE DATABASE `" + databaseName + "` CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci")
-	require.NoError(t, err, "create isolated token TTL test database")
-	require.NoError(t, bootstrap.DB().DB.Close())
-	tokenHTTPTestDatabases.Lock()
-	tokenHTTPTestDatabases.names = append(tokenHTTPTestDatabases.names, databaseName)
-	tokenHTTPTestDatabases.Unlock()
+	databaseName := tokenHTTPTestDatabase(t)
 
 	cfg := config.New()
 	cfg.Test = true
@@ -354,6 +389,11 @@ func newTokenHTTPTestServer(t *testing.T) (*libserver.Server, *config.Context, *
 	migrationServer.GetRoute().UseGin(ctx.Tracer().GinMiddle())
 	ctx.SetHttpRoute(migrationServer.GetRoute())
 	require.NoError(t, module.Setup(ctx), "set up modules in isolated token TTL database")
+
+	// The schema is shared across this helper's call sites, so drop the rows the
+	// previous test left behind now that the tables exist. Redis stays isolated
+	// per call through the cache prefixes above.
+	resetTokenHTTPDatabase(t, ctx)
 
 	// Register only the handlers exercised here from objects constructed with
 	// this test's context. This keeps handler reads and fixture writes on the
@@ -385,6 +425,29 @@ func newTokenHTTPTestServer(t *testing.T) (*libserver.Server, *config.Context, *
 		}
 	})
 	return server, ctx, userAPI, managerAPI
+}
+
+// resetTokenHTTPDatabase clears rows left by an earlier caller of
+// newTokenHTTPTestServer from the shared isolated schema.
+//
+// Deliberately not testutil.CleanAllTables: that helper hardcodes
+// table_schema = 'test', so against any other database it lists the `test`
+// schema's table names and then deletes from the connected one, failing with
+// 1146 on every name that does not exist there.
+func resetTokenHTTPDatabase(t *testing.T, ctx *config.Context) {
+	t.Helper()
+	var tables []string
+	_, err := ctx.DB().SelectBySql(
+		"SELECT table_name FROM information_schema.tables " +
+			"WHERE table_schema = DATABASE() " +
+			"AND table_type = 'BASE TABLE' " +
+			"AND table_name <> 'gorp_migrations'",
+	).Load(&tables)
+	require.NoError(t, err, "list tables in isolated token TTL database")
+	for _, table := range tables {
+		_, err := ctx.DB().UpdateBySql("DELETE FROM `" + table + "`").Exec()
+		require.NoError(t, err, "reset table %s in isolated token TTL database", table)
+	}
 }
 
 func cleanupTokenHTTPTestDatabases() error {


### PR DESCRIPTION
## Summary

The CI `Test` job has been slowing at ~+3.5 min/month (6.9 min median in 2026-05 -> 17.5 min in 2026-08) and had started failing two different ways. This addresses the dominant cause plus the order-dependent flake, and stops the Go cache for this job from being silently disabled.

Measured locally in a CI-equivalent environment (same image tags and env as this workflow, services sharing a network namespace so `127.0.0.1:3306` resolves the way it does on a runner):

| | Before | After |
|---|---|---|
| `modules/user` (`-shuffle=off`, controlled, 2 runs each) | 326.0s | **96.2s** |
| `modules/user` (`-shuffle=on`, full-suite position) | 246.6s | **94.1s** |
| Full suite | 112 packages green | 112 packages green |

## Related Issue

Closes #755

Broader analysis and the remaining work (octo-lib migration-parse cache,
package-level parallelism) are tracked in issue 753.

## Linked Spec

`.octospec/tasks/ci-test-lane-runtime/brief.md` (added in this PR)

## Changes

- `modules/user/token_http_ttl_test.go`: `newTokenHTTPTestServer` created a fresh database per call and let `module.Setup` replay all 194 migrations inside it (13-25s each, 14 call sites). It now creates one schema per process and clears its rows per call. The reset is local rather than `testutil.CleanAllTables`, which hardcodes `table_schema = test` and against another schema deletes from the connected database using `test`s table names, failing with 1146.
- `modules/common/thread_archive_setting_test.go`, `api_manager_system_setting_test.go`: reload the process-wide `SystemSettings` snapshot on setup, and give the boundary test the teardown it was missing.
- `.github/workflows/ci.yml`: give the `Test` job its own `cache-dependency-path` so it stops restoring another jobs ~10 MB stub cache; raise the job timeout to 45 min and the `modules/user` per-package deadline to 15 min, both annotated with the condition for removing them again.
- `.octospec/tasks/ci-test-lane-runtime/brief.md`: the task brief, including the red herring below so nobody repeats it.

## Testing

- [x] Unit tests added/updated
- [x] Manually verified

```
go test -race -shuffle=on -count=1 -timeout 15m ./modules/user/     ok  131.9s
go test -race -shuffle=on -count=1 -timeout 5m  ./modules/common/   ok   17.6s
go test -race -shuffle=on -count=1 ./tools/workflow-guards/         ok    1.0s   (parses ci.yml)
go vet ./...                                                       clean
```

Full suite via a local replica of this workflows `Run tests` loop (per-package `DROP`/`CREATE DATABASE` + `FLUSHALL` + `go test -race -shuffle=on -count=1`): 112 packages, 0 failures.

Flake fix demonstrated rather than asserted — with the fix reverted:

```
go test -race -count=1 -run 'TestManagerSystemSetting_UpdateAcceptsInRangeIntBoundaries|TestManagerSystemSetting_OrderingRejectsFromSidebarSide' ./modules/common/
--- FAIL: TestManagerSystemSetting_OrderingRejectsFromSidebarSide (0.14s)
        expected: 200
        actual  : 400
        {"error":{"code":"err.server.common.thread_archive_window_ordering","details":{"archive_days":"7","recent_days":"3650"}...
```

That is the same failure signature as runs 31566358696 and 31571974333. It passes with the fix.

## COMPREHENSION

**1. What does this change actually do to the load-bearing path?**

Nothing in production code — the diff is test setup plus CI config. What it does change is test isolation in one file: 14 call sites in `token_http_ttl_test.go` used to each receive a pristine database, and now share one schema whose rows are cleared per call. Redis was already isolated per call through the existing per-call `TokenCachePrefix` / `UIDTokenCachePrefix`, so only MySQL isolation changed.

The `modules/common` change fixes a real isolation bug rather than working around it: the admin write path validates against `m.systemSettings.ThreadArchiveOrdering()`, which reads the package-level singleton `EnsureSystemSettings` memoises. `CleanAllTables` truncates rows and cannot touch that snapshot, so tests must reload it explicitly. Only the entry-side reload and one missing teardown were added; no production behaviour moved.

**2. What could break because of it (dependents + failure mode)?**

- Row leakage between the 14 sharing tests. Failure mode would be a stale row from a previous test being visible; mitigated by clearing every base table on each call, and all 14 are serial (no `t.Parallel()`). This is the one genuinely new risk.
- `AUTO_INCREMENT` continuity: the reset uses `DELETE`, not `TRUNCATE`, so counters are not reset and no test that relies on generated id behaviour changes. `DELETE` was also what `CleanAllTables` did, so this half is unchanged.
- Teardown: the schema is registered with `TestMain`s cleanup list before its name is handed out, so a later failure in the binary still drops it.
- The two raised timeouts are the real reviewable risk: a generous ceiling can hide the next regression. Both carry an explicit removal condition in the comments — the `modules/user` override should be unnecessary now (96s locally) and is kept only because that figure is arm64 with a warm cache and this lanes DDL throughput may differ.
- The cache key change is additive; worst case it misses once and repopulates.

**3. How do you know it works (specific test/repro/trace)?**

`NewTestServer` was instrumented segment by segment across 152 calls: `module.Setup` 93.6%, `CleanAllTables` 6.1%, everything else ~0. Within `module.Setup`, `executeSQL` came out bimodal — p50 132ms, but nine calls at 13-25s accounting for 94% of the total — which is what identified the per-call `CREATE DATABASE` as the cost. After the change the package measures 96.2s against 326.0s on the same host, config and seed, and the full suite stays green.

For the flake, the pre-fix reproduction above matches the CI failures code, status and `details` exactly, and passes after.

One correction worth recording, also in the brief: the intuitive target here is `CleanAllTables` issuing one `DELETE` per table (~150k statements per run, correlating with job runtime at r=0.988). That correlation is spurious — every cost in this lane grows with (calls x scale) — and an implementation replacing it with a single batched probe made the full suite **5% slower** (1029s -> 1084s). This PR deliberately leaves `CleanAllTables` alone.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] PR description is in English
- [x] Added tests for my changes
- [x] Updated documentation
- [x] Followed commit message conventions (Conventional Commits)
