### PR TITLE
fix(notification): preserve pause time across MySQL timezone reads

### DIFF
--- a/modules/notification/api.go
+++ b/modules/notification/api.go
@@ -63,7 +63,7 @@ func (s *Service) putPause(c *wkhttp.Context) {
 		s.writeStoreError(c, err)
 		return
 	}
-	response := s.response(record, time.Now().UTC())
+	response := s.response(record, now)
 	if err := s.sendChangedCMD(c.GetLoginUID(), response); err != nil {
 		s.Warn("发送通知暂停状态 CMD 失败", zap.String("uid", c.GetLoginUID()), zap.Error(err))
 	}
@@ -77,7 +77,7 @@ func (s *Service) deletePause(c *wkhttp.Context) {
 		s.writeStoreError(c, err)
 		return
 	}
-	response := s.response(record, time.Now().UTC())
+	response := s.response(record, now)
 	if err := s.sendChangedCMD(c.GetLoginUID(), response); err != nil {
 		s.Warn("发送通知暂停状态 CMD 失败", zap.String("uid", c.GetLoginUID()), zap.Error(err))
 	}

--- a/modules/notification/api_test.go
+++ b/modules/notification/api_test.go
@@ -41,6 +41,19 @@ func TestResponseUsesUTCAbsolutePauseTime(t *testing.T) {
 	}
 }
 
+func TestNormalizePauseRecordPreservesDatabaseUTCWallClock(t *testing.T) {
+	stored := time.Date(2026, 8, 15, 8, 20, 30, 123000000, time.FixedZone("CST", 8*60*60))
+	record := normalizePauseRecord(&pauseRecord{PausedUntil: &stored})
+
+	if record.PausedUntil == nil {
+		t.Fatal("paused_until should remain present")
+	}
+	want := time.Date(2026, 8, 15, 8, 20, 30, 123000000, time.UTC)
+	if !record.PausedUntil.Equal(want) || record.PausedUntil.Location() != time.UTC {
+		t.Fatalf("paused_until should preserve UTC wall-clock value, got %s", record.PausedUntil)
+	}
+}
+
 func TestValidPauseUntilCapsThePauseWindow(t *testing.T) {
 	now := time.Date(2026, 8, 12, 11, 30, 0, 0, time.UTC)
 	if !validPauseUntil(now, now.Add(time.Minute)) {

--- a/modules/notification/db.go
+++ b/modules/notification/db.go
@@ -11,6 +11,19 @@ type dbStore struct {
 	session *dbr.Session
 }
 
+// dbr interpolates MySQL time arguments as UTC text. Rebuild values read from
+// DATETIME using their wall-clock components so a connection configured with
+// loc=Local does not shift the persisted UTC value on read-back.
+func normalizePauseRecord(record *pauseRecord) *pauseRecord {
+	if record == nil || record.PausedUntil == nil {
+		return record
+	}
+	value := *record.PausedUntil
+	utc := time.Date(value.Year(), value.Month(), value.Day(), value.Hour(), value.Minute(), value.Second(), value.Nanosecond(), time.UTC)
+	record.PausedUntil = &utc
+	return record
+}
+
 func newDBStore(ctx *config.Context) *dbStore {
 	return &dbStore{session: ctx.DB()}
 }
@@ -21,7 +34,7 @@ func (s *dbStore) get(uid string) (*pauseRecord, error) {
 		From("user_notification_pause").
 		Where("uid=?", uid).
 		Load(&record)
-	return record, err
+	return normalizePauseRecord(record), err
 }
 
 func (s *dbStore) upsert(uid string, pausedUntil time.Time, now time.Time) (*pauseRecord, error) {
@@ -51,7 +64,7 @@ func (s *dbStore) upsert(uid string, pausedUntil time.Time, now time.Time) (*pau
 	if err := tx.Commit(); err != nil {
 		return nil, err
 	}
-	return record, nil
+	return normalizePauseRecord(record), nil
 }
 
 func (s *dbStore) clear(uid string, now time.Time) (*pauseRecord, error) {
@@ -82,7 +95,7 @@ func (s *dbStore) clear(uid string, now time.Time) (*pauseRecord, error) {
 	if err := tx.Commit(); err != nil {
 		return nil, err
 	}
-	return record, nil
+	return normalizePauseRecord(record), nil
 }
 
 func (s *dbStore) getActiveByUIDs(uids []string, now time.Time) (map[string]struct{}, error) {

--- a/modules/notification/db_test.go
+++ b/modules/notification/db_test.go
@@ -1,0 +1,50 @@
+package notification
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+)
+
+func TestPauseTimeSurvivesNonUTCLocRoundTrip(t *testing.T) {
+	cfg := config.New()
+	cfg.Test = true
+	cfg.DB.MySQLAddr = "root:demo@tcp(127.0.0.1:3306)/test?charset=utf8mb4&parseTime=true&loc=Asia%2FShanghai"
+	cfg.DB.Migration = false
+	ctx := testutil.NewTestContext(cfg)
+	if err := ctx.DB().DB.Ping(); err != nil {
+		t.Skipf("MySQL unavailable: %v", err)
+	}
+	_, err := ctx.DB().DB.Exec(`CREATE TABLE IF NOT EXISTS user_notification_pause (
+		uid VARCHAR(40) NOT NULL,
+		paused_until DATETIME(3) NULL,
+		revision BIGINT UNSIGNED NOT NULL DEFAULT 0,
+		updated_at DATETIME(3) NOT NULL,
+		PRIMARY KEY (uid)
+	) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	uid := fmt.Sprintf("notification-tz-%d", time.Now().UnixNano())
+	t.Cleanup(func() { _, _ = ctx.DB().DB.Exec("DELETE FROM user_notification_pause WHERE uid=?", uid) })
+	store := newDBStore(ctx)
+	now := time.Now().UTC().Truncate(time.Millisecond)
+	want := now.Add(2 * time.Hour)
+	if _, err := store.upsert(uid, want, now); err != nil {
+		t.Fatal(err)
+	}
+	record, err := store.get(uid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if record == nil || record.PausedUntil == nil || !record.PausedUntil.Equal(want) {
+		t.Fatalf("paused_until round trip = %v, want %v", record, want)
+	}
+	if response := (&Service{}).response(record, now); !response.Paused || response.PausedUntil == nil || !response.PausedUntil.Equal(want) {
+		t.Fatalf("response = %+v, want active pause until %s", response, want)
+	}
+}


### PR DESCRIPTION
Fix notification pause time responses when MySQL uses a local timezone. dbr writes DATETIME values as UTC text while reads may parse them in local time, shifting paused_until by 8 hours. Normalize records at the DB read boundary and use the write-time UTC snapshot for mutation responses. Tests: go test ./modules/notification ./pkg/errcode.