### PR TITLE
feat(bot_mention): add doc_kind to mention ingress and event payload

### DIFF
--- a/modules/bot_mention/api.go
+++ b/modules/bot_mention/api.go
@@ -295,6 +295,11 @@ func mentionEventData(mention normalizedMention, enqueuedAt int64) map[string]in
 	if mention.ParentID != "" {
 		data["parent_id"] = mention.ParentID
 	}
+	// 只在非默认类型时出现:普通文档的事件载荷保持和加这个字段之前逐字节一致,
+	// 免得既有消费者的字段集断言(插件那份签进仓库的快照)无端变红。
+	if mention.DocKind != "" {
+		data["doc_kind"] = mention.DocKind
+	}
 	if mention.URL != "" {
 		data["url"] = mention.URL
 	}

--- a/modules/bot_mention/config.go
+++ b/modules/bot_mention/config.go
@@ -24,11 +24,22 @@ const (
 	internalTokenEnv           = "OCTO_DOCS_BOT_MENTION_TOKEN"
 	internalTokenHeader        = "X-Internal-Token"
 	docCommentMentionEventType = "doc_comment_mention"
+
+	// docKindHTML 标记 doc_id 是 octo-doc 的 slug(HTML 文档),而不是 docs-backend 的 docId。
+	docKindHTML = "html"
 )
 
 type mentionRequest struct {
 	IdempotencyKey string `json:"idempotency_key"`
 	DocID          string `json:"doc_id"`
+	// DocKind 说明 DocID 是哪一类文档的标识,决定消费端该走哪套 API。
+	//
+	// 为什么必须显式传而不是让消费端自己判:HTML 文档的 DocID 是 octo-doc 的 slug,
+	// 而 docs-backend 的接口按 docId 寻址 —— 拿 slug 去查必然 404。而「404」和
+	// 「文档真的不存在」无法区分,靠试错回退会把后者误判成 HTML 再失败一次。
+	//
+	// 空 = 默认 docs-backend 文档(doc/sheet/board),与加这个字段之前的行为一致。
+	DocKind        string `json:"doc_kind,omitempty"`
 	CommentID      string `json:"comment_id"`
 	ParentID       string `json:"parent_id,omitempty"`
 	FromUID        string `json:"from_uid"`
@@ -41,6 +52,7 @@ type mentionRequest struct {
 type normalizedMention struct {
 	IdempotencyKey string `json:"idempotency_key"`
 	DocID          string `json:"doc_id"`
+	DocKind        string `json:"doc_kind,omitempty"`
 	CommentID      string `json:"comment_id"`
 	ThreadID       string `json:"thread_id"`
 	ParentID       string `json:"parent_id,omitempty"`
@@ -71,6 +83,7 @@ func normalizeMentionRequest(req mentionRequest) (normalizedMention, error) {
 	normalized := normalizedMention{
 		IdempotencyKey: strings.TrimSpace(req.IdempotencyKey),
 		DocID:          strings.TrimSpace(req.DocID),
+		DocKind:        strings.ToLower(strings.TrimSpace(req.DocKind)),
 		CommentID:      strings.TrimSpace(req.CommentID),
 		ParentID:       strings.TrimSpace(req.ParentID),
 		FromUID:        strings.TrimSpace(req.FromUID),
@@ -78,6 +91,14 @@ func normalizeMentionRequest(req mentionRequest) (normalizedMention, error) {
 		Text:           req.Text,
 		URL:            strings.TrimSpace(req.URL),
 		SpaceID:        strings.TrimSpace(req.SpaceID),
+	}
+
+	// 白名单,未知值直接拒而不是当成空。
+	//
+	// 静默降级成「普通文档」的代价是消费端拿 slug 去打 docs-backend 的 docId 接口,
+	// 报出来的是一个看不出根因的 404;拒在入口,调用方拼错立刻知道。
+	if normalized.DocKind != "" && normalized.DocKind != docKindHTML {
+		return normalizedMention{}, &requestValidationError{field: "doc_kind"}
 	}
 
 	for _, field := range []struct {

--- a/modules/bot_mention/config_test.go
+++ b/modules/bot_mention/config_test.go
@@ -133,6 +133,80 @@ func TestNormalizeMentionRequest(t *testing.T) {
 	}
 }
 
+// doc_kind 决定消费端走哪套 API。HTML 文档的 doc_id 是 octo-doc 的 slug,拿它去打
+// docs-backend 的 docId 接口必然 404 —— 所以这个字段错一次,任务就静默打不中目标。
+func TestNormalizeMentionRequestDocKind(t *testing.T) {
+	base := mentionRequest{
+		IdempotencyKey: "idem-1",
+		DocID:          "doc-1",
+		CommentID:      "comment-1",
+		FromUID:        "user-1",
+		BotUID:         "bot-1",
+		Text:           "update it",
+	}
+
+	t.Run("默认为空:普通文档的行为不变", func(t *testing.T) {
+		got, err := normalizeMentionRequest(base)
+		if err != nil {
+			t.Fatalf("normalize: %v", err)
+		}
+		if got.DocKind != "" {
+			t.Fatalf("DocKind = %q, want empty", got.DocKind)
+		}
+	})
+
+	t.Run("html 大小写与空格都规范化", func(t *testing.T) {
+		for _, in := range []string{"html", " HTML ", "Html"} {
+			req := base
+			req.DocKind = in
+			got, err := normalizeMentionRequest(req)
+			if err != nil {
+				t.Fatalf("doc_kind=%q: %v", in, err)
+			}
+			if got.DocKind != docKindHTML {
+				t.Fatalf("doc_kind=%q → %q, want %q", in, got.DocKind, docKindHTML)
+			}
+		}
+	})
+
+	t.Run("未知值被拒,不静默降级成普通文档", func(t *testing.T) {
+		// ★ 这条是这个字段的要害。降级放过去的话,消费端会拿 slug 去查 docId 接口,
+		// 用户看到的是一个「文档不存在」的 404,根因(类型标错)完全看不出来。
+		for _, bad := range []string{"sheet", "htm", "html_ppt", "doc"} {
+			req := base
+			req.DocKind = bad
+			if _, err := normalizeMentionRequest(req); err == nil {
+				t.Fatalf("doc_kind=%q 应当被拒", bad)
+			} else if invalidField(err) != "doc_kind" {
+				t.Fatalf("doc_kind=%q 报的字段是 %q,want doc_kind", bad, invalidField(err))
+			}
+		}
+	})
+}
+
+// 事件载荷:doc_kind 为空时**一个字节都不该多**。
+// 既有消费者(插件)对 event_data 的字段集有精确断言,凭空多一个 key 会让它无端变红。
+func TestMentionEventDataOmitsEmptyDocKind(t *testing.T) {
+	base := normalizedMention{
+		IdempotencyKey: "idem-1",
+		DocID:          "doc-1",
+		CommentID:      "comment-1",
+		ThreadID:       "comment-1",
+		FromUID:        "user-1",
+		BotUID:         "bot-1",
+		Text:           "update it",
+	}
+
+	if _, ok := mentionEventData(base, 100)["doc_kind"]; ok {
+		t.Fatal("doc_kind 为空时不该出现在事件载荷里")
+	}
+
+	base.DocKind = docKindHTML
+	if got := mentionEventData(base, 100)["doc_kind"]; got != docKindHTML {
+		t.Fatalf("doc_kind = %v, want %q", got, docKindHTML)
+	}
+}
+
 func TestNormalizeMentionRequestRejectsInvalidFields(t *testing.T) {
 	base := mentionRequest{
 		IdempotencyKey: "idem-1",


### PR DESCRIPTION
## Summary
Add an optional `doc_kind` field to the bot-mention ingress and forward it on the
emitted event payload, so a consumer can tell an octo-doc slug apart from a
docs-backend `docId`.

**Scope reduced in response to review:** the `/v1/internal/bot-owner` endpoint has
been dropped from this PR entirely. What remains is only the `doc_kind` half, which
review explicitly accepted as-is.

## Linked Spec
`.octospec/tasks/doc-comment-bot-mention-mvp/brief.md` — event data is additive-only
(brief line 206). No new endpoint is introduced by this PR, so no brief surface
change is required.

## How verified
Isolated worktree off current `upstream/main`:

- `go build ./...` → **exit 0**
- `go vet ./modules/bot_mention/...` → **exit 0**
- `go test ./modules/bot_mention/ -skip Integration` → **ok**
- `make i18n-extract-check` → **exit 0**
- Environment note: `TestBotMentionMySQLRedisRobotQueueIntegration` fails locally
  for want of a real MySQL (`dial tcp 127.0.0.1:3306: connection refused`).
  Confirmed to be pre-existing environment noise by running the same test on a
  pristine `upstream/main` worktree, where it fails identically.
- Diff scope: `3 files changed, 100 insertions(+)`, no deletions, single commit.

## Review follow-up
Both P1 blockers applied to the `/bot-owner` endpoint, and both were correct:

1. **Duplicate endpoint.** Verified against `upstream/main`:
   `POST /v1/internal/user/resolve-bot-owner` exists at
   `modules/internal_resolve/api.go:152` and already carries the
   `bot_creator_uid == ""` ⇒ "ownerless, do not auto-grant" semantics that my
   `owner_uid == ""` was re-expressing. Two internal endpoints answering one
   question, with two tokens and two data sources, is worse than none.
2. **Wrong authority.** `modules/botidentity/resolver.go` exists on `main`
   precisely because a robot-table-only query misclassifies a published `app_bot`
   uid as "not a bot" — my `GetCreatorUID` path reintroduced that shape, and it
   also served authorization answers out of a process-lifetime `sync.Map` with no
   TTL or invalidation, so revoking a bot would not revoke derived access until
   restart.

Rather than patch around those, the endpoint is removed. The octo-doc caller
should use the existing `/v1/internal/user/resolve-bot-owner` (adding its
caller/token there), which is live-resolving and classifies both bot kinds from
one source of truth. The P2 items (missing `MaxBytesReader` /
`DisallowUnknownFields` / identifier bounds, absent per-endpoint IP limiter, and
the assertions that used `w.Code < 400` instead of pinning an exact status) all
belonged to that endpoint and are moot here.

Also noted from review and still applicable: **`/bot-mentions` uses
`DisallowUnknownFields`, so octo-server must ship before any docs-backend that
sends `doc_kind`** — otherwise the un-upgraded server answers `400` rather than
ignoring the field gracefully.

On the unresolvable `Linked Spec`: the superseded PR is unreachable because the
source fork was removed, so this change is submitted to stand on its own merits,
not on "already reviewed".

## COMPREHENSION
**What this does to the load-bearing path:** adds one optional field to the
bot-mention ingress validator and one conditional key to the outbound event
payload. No new route, no new authorization decision, no new data source.

**What it could break:** the event payload is consumed by existing subscribers
whose field-set assertions are checked into the repo. The key is emitted only when
`doc_kind` is non-empty, so for all existing traffic the payload is byte-identical
and `mentionFingerprint`'s JSON hash is unchanged — in-flight idempotency claims
survive the deploy. The one real ordering constraint is the `DisallowUnknownFields`
deploy sequencing called out above.

**What verifies it:** build, vet, module unit tests and the i18n check all green,
plus a pristine-`main` control run establishing that the single failing test is a
missing-MySQL environment artifact rather than a regression.
