### PR TITLE
fix(carddispatch): re-fan-out the sync CMD on idempotent mutation repl

### DIFF
--- a/internal/carddispatch/mutation.go
+++ b/internal/carddispatch/mutation.go
@@ -176,9 +176,17 @@ type cardMutationBackend interface {
 	Sync(cardMutationWrite) error
 }
 
+// cardMutationFanoutMaxAttempts bounds the in-process CMD retry. The fanout is
+// the ONLY place a lost signal can be recovered without failing the mutation, so
+// a transient IM blip must not consume the single attempt it used to get; the
+// bound keeps a hard IM outage from holding the dispatcher worker.
+const cardMutationFanoutMaxAttempts = 3
+
 type CardMutator struct {
 	backend cardMutationBackend
 	logger  interface{ Error(string, ...zap.Field) }
+	// sleep is injectable so tests exercise the retry loop without real delay.
+	sleep func(time.Duration)
 }
 
 func NewCardMutator(ctx *config.Context) *CardMutator {
@@ -341,17 +349,31 @@ func (m *CardMutator) Mutate(ctx context.Context, request CardMutationRequest) (
 		return CardMutationResult{}, ErrCardMutationInvalid
 	}
 	hash := util.MD5(normalized)
+	write := cardMutationWrite{
+		SenderUID: request.SenderUID, MessageID: request.MessageID, MessageSeq: message.MessageSeq,
+		ChannelID: request.ChannelID, ChannelType: request.ChannelType, ContentEdit: normalized,
+		ContentHash: hash, EditedAt: int(time.Now().Unix()), CardSeq: cardSeq,
+	}
 	exists, err := m.backend.ContentHashExists(request.MessageID, hash)
 	if err != nil {
 		return CardMutationResult{}, fmt.Errorf("carddispatch: query mutation hash: %w", err)
 	}
 	if exists {
+		// Re-fan-out the CMD on replay. An identical stored frame proves the CONTENT
+		// landed, never that any client was told about it: a first attempt that
+		// committed content_edit and then lost its fanout (a crash or a lease expiry
+		// mid-finalize) is re-driven here by the at-least-once card-action
+		// dispatcher, and skipping the signal leaves the card actionable on every
+		// online client until a full conversation re-fetch. A plain Sync error does
+		// NOT reach this branch — it is swallowed in fanout and the dispatcher Acks
+		// the successful Finalize, which is why fanout retries in-process instead.
+		// Safe because the CMD carries no frame bytes — Sync sends a bare
+		// syncMessageExtra signal and the client then pulls the NEWEST extra — so a
+		// re-send is idempotent and can never surface a stale frame. The CAS write
+		// and revision append stay skipped on this path precisely because those two
+		// DO have real side effects.
+		m.fanout(write)
 		return CardMutationResult{Replay: true}, nil
-	}
-	write := cardMutationWrite{
-		SenderUID: request.SenderUID, MessageID: request.MessageID, MessageSeq: message.MessageSeq,
-		ChannelID: request.ChannelID, ChannelType: request.ChannelType, ContentEdit: normalized,
-		ContentHash: hash, EditedAt: int(time.Now().Unix()), CardSeq: cardSeq,
 	}
 	conflict, replay, err := m.backend.CASWrite(write)
 	if err != nil {
@@ -361,6 +383,12 @@ func (m *CardMutator) Mutate(ctx context.Context, request CardMutationRequest) (
 		return CardMutationResult{}, ErrCardMutationConflict
 	}
 	if replay {
+		// Same reasoning as the hash-exists branch: a concurrent writer won the CAS
+		// with byte-identical content, but ITS CMD may still be in flight or already
+		// lost. The signal is contentless and idempotent, so re-sending costs one
+		// extra client-side extra-pull and closes the window where neither writer's
+		// fanout reached the client.
+		m.fanout(write)
 		return CardMutationResult{Replay: true}, nil
 	}
 	// Revision history and CMD fanout are secondary to the authoritative
@@ -370,10 +398,50 @@ func (m *CardMutator) Mutate(ctx context.Context, request CardMutationRequest) (
 			m.logger.Error("card mutation revision append failed", zap.Error(err), zap.String("message_id", request.MessageID))
 		}
 	}
-	if err := m.backend.Sync(write); err != nil && m.logger != nil {
-		m.logger.Error("card mutation CMD sync failed", zap.Error(err), zap.String("message_id", request.MessageID))
-	}
+	m.fanout(write)
 	return CardMutationResult{Applied: true}, nil
+}
+
+// fanout sends the contentless syncMessageExtra CMD that tells online clients to
+// pull the freshest message extra, retrying a bounded number of times before
+// giving up.
+//
+// The retry exists because a swallowed Sync error is NOT re-driven by anything: a
+// successful Finalize makes the dispatcher Ack the event outright
+// (cardactiondispatch/dispatcher.go), so the replay branches above never see this
+// failure and the client keeps an actionable card until a full conversation
+// re-fetch. Retrying here is the only recovery that does not fail the mutation.
+//
+// The final failure is still logged and swallowed, keeping the CMD secondary to
+// the authoritative content_edit: the frame is already committed, and a client
+// that misses the signal still resolves the terminal card on its next
+// conversation fetch, so a broken fanout must not fail an otherwise-successful
+// mutation — nor push the card action toward the dispatcher's DLQ, where its
+// Redis idempotency claim would strand the card for the whole retention window.
+//
+// NOTE this cannot recover the case where SendCMD SUCCEEDS but the recipient is
+// offline or mid-reconnect: the CMD is NoPersist + SyncOnce (realtime-only, no
+// offline replay), so that delivery is silently dropped downstream with nothing
+// to retry here. Closing that gap needs the client to re-pull extras after a
+// socket reconnect, not a server-side change.
+func (m *CardMutator) fanout(write cardMutationWrite) {
+	sleep := m.sleep
+	if sleep == nil {
+		sleep = time.Sleep
+	}
+	var err error
+	for attempt := 0; attempt < cardMutationFanoutMaxAttempts; attempt++ {
+		if err = m.backend.Sync(write); err == nil {
+			return
+		}
+		if attempt+1 < cardMutationFanoutMaxAttempts {
+			sleep(time.Duration(attempt+1) * 20 * time.Millisecond)
+		}
+	}
+	if m.logger != nil {
+		m.logger.Error("card mutation CMD sync failed", zap.Error(err),
+			zap.String("message_id", write.MessageID), zap.Int("attempts", cardMutationFanoutMaxAttempts))
+	}
 }
 
 func (m *CardMutator) WriteCAS(request CardMutationCASRequest) (bool, error) {

--- a/internal/carddispatch/mutation_test.go
+++ b/internal/carddispatch/mutation_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/Mininglamp-OSS/octo-server/pkg/cardmsg"
 )
@@ -20,6 +21,8 @@ type fakeMutationBackend struct {
 	writeConflict bool
 	writeReplay   bool
 	writeErr      error
+	syncErr       error
+	syncFailUntil int
 	writes        []cardMutationWrite
 	revisions     []cardMutationWrite
 	syncs         []cardMutationWrite
@@ -57,7 +60,24 @@ func (b *fakeMutationBackend) AppendRevision(write cardMutationWrite) error {
 
 func (b *fakeMutationBackend) Sync(write cardMutationWrite) error {
 	b.syncs = append(b.syncs, write)
-	return nil
+	// syncFailUntil models a TRANSIENT IM blip: the first N attempts fail and the
+	// next one succeeds, so a retry loop is observably distinguishable from a
+	// single-shot fanout.
+	if b.syncFailUntil > 0 {
+		if len(b.syncs) <= b.syncFailUntil {
+			return errors.New("im blip")
+		}
+		return nil
+	}
+	return b.syncErr
+}
+
+// noSleepMutator builds a mutator whose fanout retry does not actually wait, so
+// the bounded-retry tests stay instant.
+func noSleepMutator(backend cardMutationBackend) *CardMutator {
+	mutator := newCardMutator(backend)
+	mutator.sleep = func(time.Duration) {}
+	return mutator
 }
 
 func TestCardMutatorPreservesOwnershipLifecycleCASAndReplay(t *testing.T) {
@@ -128,8 +148,17 @@ func TestCardMutatorPreservesOwnershipLifecycleCASAndReplay(t *testing.T) {
 		if err != nil || !result.Replay || result.Applied {
 			t.Fatalf("Mutate(replay) = (%+v, %v)", result, err)
 		}
-		if len(backend.writes)+len(backend.revisions)+len(backend.syncs) != 0 {
-			t.Fatal("idempotent replay must not write CAS, revision, or CMD")
+		if len(backend.writes) != 0 || len(backend.revisions) != 0 {
+			t.Fatal("idempotent replay must not repeat the side-effecting CAS write or revision append")
+		}
+		// The contentless CMD IS re-sent. An identical stored frame proves the content
+		// landed, never that a client was told: a prior attempt may have committed
+		// content_edit and lost its fanout (Sync error, crash, lease expiry), and the
+		// at-least-once card-action dispatcher replays it here. Skipping the signal
+		// leaves the card actionable on every online client until a full conversation
+		// re-fetch.
+		if len(backend.syncs) != 1 {
+			t.Fatalf("idempotent replay must re-fan-out the CMD, syncs = %d, want 1", len(backend.syncs))
 		}
 	})
 
@@ -145,8 +174,80 @@ func TestCardMutatorPreservesOwnershipLifecycleCASAndReplay(t *testing.T) {
 		if err != nil || !result.Replay || result.Applied {
 			t.Fatalf("Mutate(concurrent replay) = (%+v, %v)", result, err)
 		}
-		if len(backend.revisions)+len(backend.syncs) != 0 {
-			t.Fatal("concurrent replay must not append a duplicate revision or CMD")
+		if len(backend.revisions) != 0 {
+			t.Fatal("concurrent replay must not append a duplicate revision")
+		}
+		// Contentless, idempotent signal: the CAS winner's own CMD may still be in
+		// flight or already lost, so re-sending closes the window where neither
+		// writer's fanout reached the client.
+		if len(backend.syncs) != 1 {
+			t.Fatalf("concurrent replay must re-fan-out the CMD, syncs = %d, want 1", len(backend.syncs))
+		}
+	})
+
+	t.Run("transient fanout failure is retried until it lands", func(t *testing.T) {
+		backend := &fakeMutationBackend{
+			message:       storedCardMessage{MessageID: "1001", MessageSeq: 7, FromUID: "notification", Payload: original},
+			syncFailUntil: 1,
+		}
+		result, err := noSleepMutator(backend).Mutate(context.Background(), CardMutationRequest{
+			SenderUID: "notification", MessageID: "1001", ChannelID: "user-b", ChannelType: 1,
+			ContentEdit: string(terminal),
+		})
+		// A swallowed Sync error is re-driven by NOTHING: a successful Finalize makes
+		// the dispatcher Ack the event outright, so the replay branches above never
+		// see this failure. The in-process retry is therefore the ONLY recovery for a
+		// transient IM blip that does not fail the mutation.
+		if err != nil || !result.Applied {
+			t.Fatalf("Mutate(transient sync failure) = (%+v, %v), want applied with nil error", result, err)
+		}
+		if len(backend.syncs) != 2 {
+			t.Fatalf("transient fanout failure must be retried, syncs = %d, want 2", len(backend.syncs))
+		}
+		if len(backend.writes) != 1 {
+			t.Fatalf("fanout retry must not re-write the CAS, writes = %d, want 1", len(backend.writes))
+		}
+	})
+
+	t.Run("fanout failure keeps the committed mutation successful", func(t *testing.T) {
+		backend := &fakeMutationBackend{
+			message: storedCardMessage{MessageID: "1001", MessageSeq: 7, FromUID: "notification", Payload: original},
+			syncErr: errors.New("im unavailable"),
+		}
+		result, err := noSleepMutator(backend).Mutate(context.Background(), CardMutationRequest{
+			SenderUID: "notification", MessageID: "1001", ChannelID: "user-b", ChannelType: 1,
+			ContentEdit: string(terminal),
+		})
+		// The CMD stays SECONDARY to the authoritative content_edit: the frame is
+		// already committed and a client that misses the signal still resolves the
+		// terminal card on its next conversation fetch, so a dead IM must not fail an
+		// otherwise-successful mutation — and must not push the card action toward the
+		// dispatcher's DLQ, where its Redis idempotency claim would strand the card.
+		if err != nil || !result.Applied {
+			t.Fatalf("Mutate(sync failure) = (%+v, %v), want applied with nil error", result, err)
+		}
+		// The retry is BOUNDED: a hard IM outage must not hold the dispatcher worker.
+		if len(backend.writes) != 1 || len(backend.syncs) != cardMutationFanoutMaxAttempts {
+			t.Fatalf("writes/syncs = %d/%d, want 1/%d", len(backend.writes), len(backend.syncs), cardMutationFanoutMaxAttempts)
+		}
+	})
+
+	t.Run("stale card seq conflict must not fan out", func(t *testing.T) {
+		backend := &fakeMutationBackend{
+			message:       storedCardMessage{MessageID: "1001", MessageSeq: 7, FromUID: "notification", Payload: original},
+			writeConflict: true,
+		}
+		_, err := newCardMutator(backend).Mutate(context.Background(), CardMutationRequest{
+			SenderUID: "notification", MessageID: "1001", ChannelID: "user-b", ChannelType: 1,
+			ContentEdit: string(terminal),
+		})
+		// A conflict means a NEWER frame already won; this stale attempt committed
+		// nothing, so it announces nothing and lets the caller surface the conflict.
+		if !errors.Is(err, ErrCardMutationConflict) {
+			t.Fatalf("Mutate(conflict) error = %v, want %v", err, ErrCardMutationConflict)
+		}
+		if len(backend.syncs) != 0 {
+			t.Fatalf("conflicting stale write must not fan out, syncs = %d", len(backend.syncs))
 		}
 	})
 


### PR DESCRIPTION
## Summary
Re-lift of previously-open work from a fork that became unavailable; replayed onto the latest `upstream/main` as a single squashed commit. No functional change vs. the original branch.

## Linked Spec
Supersedes former PR #736

## How verified
- Replayed onto current `upstream/main` in an isolated worktree with `merge --squash`; zero conflicted paths (`git status` shows no U/A markers).
- Diff scope vs. `upstream/main`: 2 file(s), +182/-13 (this PR's own changes only; the source branch's three-dot count also included upstream commits already merged).
- Squashed to one commit so the PR carries only this feature's changes.

## COMPREHENSION
- **What this does to load-bearing paths:** replay-only; the change set is byte-identical to the branch that was already reviewed, rebased onto a newer base.
- **What it could break:** the newer base may have moved code this patch touches; conflict-free application plus unchanged diff scope is the evidence it did not.
- **What verified it:** conflict-free squash replay onto latest `upstream/main` + diff-scope equality against the source branch.