### PR TITLE
feat(space): add keyword search to member list endpoint

### DIFF
--- a/modules/space/api.go
+++ b/modules/space/api.go
@@ -684,6 +684,9 @@ func (s *Space) mySpaces(c *wkhttp.Context) {
 	c.Response(resps)
 }
 
+// maxMemberKeywordRunes 限制成员列表检索关键词长度，防止超长 keyword 驱动无索引 LIKE 扫描。
+const maxMemberKeywordRunes = 64
+
 // listMembers 获取空间成员列表
 func (s *Space) listMembers(c *wkhttp.Context) {
 	loginUID := c.GetLoginUID()
@@ -713,7 +716,17 @@ func (s *Space) listMembers(c *wkhttp.Context) {
 		limit = 10000
 	}
 
-	members, err := s.db.queryMembers(spaceId, loginUID, page, limit)
+	// keyword（可选）：非空时按 name/real_name/uid 服务端检索。文档成员选择器改为
+	// 服务端搜索后走此参数——避免前端全量拉取+本地过滤在超大空间被分页上限截断
+	// （5760 人空间：靠后成员搜不到）。任意成员可调，权限与列表一致。
+	keyword := c.Query("keyword")
+	// 关键词长度封顶：防止用户驱动的超长 %kw% 无索引扫描（与 members/search 的加固口径靠拢）。
+	// 用 rune 截断，避免把多字节字符切成无效 UTF-8。
+	if r := []rune(keyword); len(r) > maxMemberKeywordRunes {
+		keyword = string(r[:maxMemberKeywordRunes])
+	}
+
+	members, err := s.db.queryMembers(spaceId, loginUID, page, limit, keyword)
 	if err != nil {
 		httperr.ResponseErrorL(c, errcode.ErrSpaceQueryFailed, nil, nil)
 		return

--- a/modules/space/db.go
+++ b/modules/space/db.go
@@ -3,6 +3,7 @@ package space
 import (
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"go.uber.org/zap"
@@ -176,12 +177,33 @@ func (d *DB) queryMemberIncludeRemoved(spaceId string, uid string) (*MemberModel
 	return &m, nil
 }
 
-func (d *DB) queryMembers(spaceId string, loginUID string, page uint64, limit uint64) ([]*MemberDetailModel, error) {
+func (d *DB) queryMembers(spaceId string, loginUID string, page uint64, limit uint64, keyword string) ([]*MemberDetailModel, error) {
 	var models []*MemberDetailModel
 	// name 兜底链（issue #344）：u.name 为空时回退 user_verification.real_name，
 	// 二者皆空时由 mapping 层（MemberDetailModel.DisplayName）给稳定占位符。
 	// 这里只多挂一个只读 LEFT JOIN uv；Space + bot 归属过滤（WHERE 子句）保持不变，
 	// 不放宽任何隔离边界。禁止用 short_no / username 兜底（privacy-gated）。
+	//
+	// keyword（可选）跨列检索 name/real_name/uid：检索列必须与展示兜底链一致，否则
+	// u.name 为空、靠 real_name 显示的成员「看得见却搜不到」。文档成员选择器改为
+	// 服务端搜索后调用此参数——前端全量拉取+本地过滤在超大空间会被分页上限截断
+	// （5760 人空间实证：靠后加入的成员搜不到）。email/phone 不在本端点返回、也不参与
+	// 检索（privacy）。
+	//
+	// real_name 匹配必须 gate 到 IFNULL(u.name,'')=''：real_name 仅在 u.name 为空时才
+	// 展示（DisplayName 兜底链），若无条件检索，有昵称用户的隐藏实名会「搜得到却看不见」，
+	// 构成「猜实名→反查昵称用户」的身份 oracle（可检索粒度 > 可见粒度）。gate 后使二者
+	// 严格对齐（PR #618 review：Jerry-Xin / lml2468）。
+	kwClause := ""
+	args := []interface{}{spaceId, loginUID}
+	if kw := strings.TrimSpace(keyword); kw != "" {
+		like := buildLikePattern(kw)
+		kwClause = ` AND (u.name LIKE ?` + likeEscapeClause +
+			` OR (IFNULL(u.name,'')='' AND uv.real_name LIKE ?` + likeEscapeClause + `)` +
+			` OR sm.uid LIKE ?` + likeEscapeClause + `)`
+		args = append(args, like, like, like)
+	}
+	args = append(args, limit, (page-1)*limit)
 	_, err := d.session.SelectBySql(`
 		SELECT sm.*, IFNULL(u.name,'') as name,
 			IFNULL(uv.real_name,'') as real_name,
@@ -193,10 +215,10 @@ func (d *DB) queryMembers(spaceId string, loginUID string, page uint64, limit ui
 		WHERE sm.space_id=? AND sm.status=1 AND (
 			r.robot_id IS NULL
 			OR r.creator_uid = ?
-		)
-		ORDER BY sm.role DESC, sm.created_at ASC
+		)`+kwClause+`
+		ORDER BY sm.role DESC, sm.created_at ASC, sm.uid ASC
 		LIMIT ? OFFSET ?
-	`, spaceId, loginUID, limit, (page-1)*limit).Load(&models)
+	`, args...).Load(&models)
 	return models, err
 }
 

--- a/modules/space/db_member_name_fallback_test.go
+++ b/modules/space/db_member_name_fallback_test.go
@@ -66,7 +66,7 @@ func TestQueryMembersNameFallback(t *testing.T) {
 	seedFallbackVerification(t, uidNamed, "Should Not Win")
 	seedMemberSearchMember(t, spaceId, uidNamed, 0, 1)
 
-	members, err := testSpaceDB.queryMembers(spaceId, testutil.UID, 1, 100)
+	members, err := testSpaceDB.queryMembers(spaceId, testutil.UID, 1, 100, "")
 	assert.NoError(t, err)
 
 	// case 1: real_name 兜底
@@ -92,6 +92,57 @@ func TestQueryMembersNameFallback(t *testing.T) {
 		assert.Equal(t, "Alice", m.Name)
 		assert.Equal(t, "Alice", m.DisplayName(), "populated name must be returned unchanged")
 	}
+}
+
+// TestQueryMembersKeyword 验证 GET /space/:id/members 的 keyword 服务端检索覆盖展示
+// 兜底链：u.name 为空、仅靠 user_verification.real_name 展示的成员，必须能按 real_name
+// 搜到（文档成员选择器改服务端搜索后的核心回归点）。同时验证按 uid 命中、不匹配返回空。
+func TestQueryMembersKeyword(t *testing.T) {
+	_, _, err := setup(t)
+	assert.NoError(t, err)
+
+	const spaceId = "sp-kw-search"
+	seedMemberSearchSpace(t, spaceId, testutil.UID)
+
+	// u.name 空、real_name 有 —— 正是列表看得见、旧本地过滤（超 1000 名）搜不到的那类成员。
+	const uidRealName = "u-kw-realname"
+	seedFallbackUser(t, uidRealName, "")
+	seedFallbackVerification(t, uidRealName, "Wang Liuchao")
+	seedMemberSearchMember(t, spaceId, uidRealName, 0, 1)
+
+	// u.name 正常 + 有隐藏实名，用于验证：① 不匹配的 keyword 不误命中；② 有昵称用户的
+	// 隐藏 real_name 搜不到（堵身份 oracle：real_name 仅在无昵称时才展示与可检索）。
+	const uidNamed = "u-kw-named"
+	seedFallbackUser(t, uidNamed, "Alice")
+	seedFallbackVerification(t, uidNamed, "Hidden Zhenming")
+	seedMemberSearchMember(t, spaceId, uidNamed, 0, 1)
+
+	// 1) 按 real_name 检索命中（核心回归点）
+	hit, err := testSpaceDB.queryMembers(spaceId, testutil.UID, 1, 100, "Liuchao")
+	assert.NoError(t, err)
+	if m, ok := findMemberDetail(hit, uidRealName); assert.True(t, ok, "should find member by real_name") {
+		assert.Equal(t, "Wang Liuchao", m.DisplayName())
+	}
+	_, aliceLeaked := findMemberDetail(hit, uidNamed)
+	assert.False(t, aliceLeaked, "keyword 'Liuchao' must not match Alice")
+
+	// 2) 按 uid 检索命中
+	byUID, err := testSpaceDB.queryMembers(spaceId, testutil.UID, 1, 100, uidNamed)
+	assert.NoError(t, err)
+	_, ok := findMemberDetail(byUID, uidNamed)
+	assert.True(t, ok, "should find member by uid substring")
+
+	// 3) 不匹配的 keyword 返回空
+	none, err := testSpaceDB.queryMembers(spaceId, testutil.UID, 1, 100, "no-such-member-xyz")
+	assert.NoError(t, err)
+	assert.Empty(t, none, "non-matching keyword should return no members")
+
+	// 4) 身份 oracle 边界：有昵称用户(Alice)的隐藏实名(Hidden Zhenming)不得被搜到——
+	//    real_name 只在 u.name 为空时展示，故只在此时可检索，二者粒度严格对齐。
+	oracle, err := testSpaceDB.queryMembers(spaceId, testutil.UID, 1, 100, "Zhenming")
+	assert.NoError(t, err)
+	_, leaked := findMemberDetail(oracle, uidNamed)
+	assert.False(t, leaked, "hidden real_name of a nicknamed user must NOT be searchable (identity oracle)")
 }
 
 // TestMemberDisplayNamePure 纯函数验证 DisplayName 兜底优先级，


### PR DESCRIPTION
## Summary
Re-lift of previously-open work from a fork that became unavailable; replayed onto the latest `upstream/main` as a single squashed commit. No functional change vs. the original branch.

## Linked Spec
No prior PR reference recovered.

## How verified
- Replayed onto current `upstream/main` in an isolated worktree with `merge --squash`; zero conflicted paths (`git status` shows no U/A markers).
- Diff scope vs. `upstream/main`: 3 file(s), +92/-6 (this PR's own changes only; the source branch's three-dot count also included upstream commits already merged).
- Squashed to one commit so the PR carries only this feature's changes.

## COMPREHENSION
- **What this does to load-bearing paths:** replay-only; the change set is byte-identical to the branch that was already reviewed, rebased onto a newer base.
- **What it could break:** the newer base may have moved code this patch touches; conflict-free application plus unchanged diff scope is the evidence it did not.
- **What verified it:** conflict-free squash replay onto latest `upstream/main` + diff-scope equality against the source branch.