### PR TITLE
feat(notification): support manual notification pause mode

### DIFF
--- a/.octospec/journal/shared/notification-pause-manual-mode.md
+++ b/.octospec/journal/shared/notification-pause-manual-mode.md
@@ -17,8 +17,8 @@ source: self
   `mode: manual`, strict mutually exclusive request validation, and the mode
   migration.
 - Unified GET/PUT/DELETE and notification-pause CMD state fields, including
-  `mode`, `revision`, and `server_time`; DELETE is idempotent and only emits a
-  CMD when it actually clears an active row.
+  `mode`, `revision`, and `server_time`; DELETE is idempotent and emits a CMD
+  only when it clears persisted pause state, including stale expired rows.
 - Preserved legacy rows with a future `paused_until` as timed pauses and made
   manual rows active in webhook recipient filtering.
 

--- a/.octospec/journal/shared/notification-pause-manual-mode.md
+++ b/.octospec/journal/shared/notification-pause-manual-mode.md
@@ -17,8 +17,8 @@ source: self
   `mode: manual`, strict mutually exclusive request validation, and the mode
   migration.
 - Unified GET/PUT/DELETE and notification-pause CMD state fields, including
-  `mode`, `revision`, and `server_time`; DELETE remains idempotent while
-  advancing the revision row.
+  `mode`, `revision`, and `server_time`; DELETE is idempotent and only emits a
+  CMD when it actually clears an active row.
 - Preserved legacy rows with a future `paused_until` as timed pauses and made
   manual rows active in webhook recipient filtering.
 

--- a/.octospec/journal/shared/notification-pause-manual-mode.md
+++ b/.octospec/journal/shared/notification-pause-manual-mode.md
@@ -1,0 +1,31 @@
+---
+type: Journal
+title: "Journal: notification-pause-manual-mode"
+description: Add explicit manual notification pause state and unify REST/CMD responses.
+tags: [notification, wire-contract, migration, testing]
+timestamp: 2026-08-14T00:00:00+08:00
+task: notification-pause-manual-mode
+source: self
+---
+
+# Journal: notification-pause-manual-mode
+
+## What was done
+
+- Added nullable `mode` persistence with `manual` and `timed` semantics.
+- Added server-calculated `duration` requests for `30m` and `1h`, explicit
+  `mode: manual`, strict mutually exclusive request validation, and the mode
+  migration.
+- Unified GET/PUT/DELETE and notification-pause CMD state fields, including
+  `mode`, `revision`, and `server_time`; DELETE remains idempotent while
+  advancing the revision row.
+- Preserved legacy rows with a future `paused_until` as timed pauses and made
+  manual rows active in webhook recipient filtering.
+
+## Verification and gotchas
+
+- Focused notification, errcode, webhook pure-logic tests, `go vet`, i18n
+  extraction check, direct-error lint, and diff checks pass.
+- The DB round-trip test skips when local MySQL is unavailable and runs in CI.
+- The branch was verified against remote `upstream/main=6059503` before the
+  implementation was based on it.

--- a/.octospec/log.md
+++ b/.octospec/log.md
@@ -1464,3 +1464,8 @@ change-log convention (§7). Newest first.
 
 - **Update** — Synced OKF-aware slash commands, workflow skill, and task brief
   template from octo-spec 1.1.0 so generated briefs/journals stay conformant.
+
+## 2026-08-14 (notification-pause-manual-mode)
+
+- **Implemented** — Added explicit manual/timed pause state, server-side fixed
+  durations, unified REST/CMD responses, migration, validation, and tests.

--- a/.octospec/tasks/notification-pause-manual-mode/brief.md
+++ b/.octospec/tasks/notification-pause-manual-mode/brief.md
@@ -1,0 +1,60 @@
+---
+type: Task
+title: "Task: notification-pause-manual-mode"
+description: "Add explicit manual notification pause mode and unify pause API state responses."
+tags: ["notification", "wire-contract", "error-response", "test"]
+timestamp: 2026-08-14T00:00:00Z
+slug: notification-pause-manual-mode
+upstream: self
+source: self
+---
+
+# Task: notification-pause-manual-mode
+
+## Goal
+
+Extend the account-level notification pause service with an explicit `manual`
+mode that remains active until DELETE, while preserving timed and custom pause
+behavior. Make GET/PUT/DELETE and the notification-pause CMD expose the same
+authoritative state shape, including `mode`, `revision`, and `server_time`.
+
+## Background
+
+The current service stores only `paused_until`, so it cannot represent a pause
+that has no automatic expiry and its request/response contract only supports a
+custom absolute timestamp. The client must use server-generated time and state
+without putting device-local `scope` into the server contract.
+
+## Load-bearing list
+
+- `wire-contract`: REST and CMD response fields must remain aligned.
+- `error-response`: invalid combinations and timestamps use the registered
+  localized error envelope.
+- `auth`: notification pause remains account-scoped behind the existing auth
+  middleware.
+- `webhook`: manual pauses must filter offline notifications until DELETE.
+- `test`: cover request validation, state transitions, time and revision rules.
+
+## Out of scope
+
+- Frontend implementation, timer scheduling, server-time offset calculation,
+  and local device `scope` storage.
+- Voice-input settings UI.
+- A global DSN/timezone refactor outside notification-pause persistence.
+- New event fan-out beyond the existing notification-pause CMD.
+
+## Acceptance
+
+- `duration` accepts only `30m` and `1h`, calculated from server time.
+- `mode: "manual"` persists and returns `paused=true`, `mode="manual"`, and
+  `paused_until=null` until DELETE.
+- Timed responses return `mode="timed"`; inactive responses return
+  `mode=null` and `paused_until=null`.
+- `duration`, `mode`, and `paused_until` are mutually exclusive; invalid,
+  timezone-less, past, and over-limit absolute timestamps return the existing
+  localized 400 error envelope.
+- GET/PUT/DELETE and CMD responses contain `paused`, `mode`, `paused_until`,
+  `revision`, and `server_time`; revisions increase for every state-changing
+  request and repeated DELETE remains idempotent.
+- Manual and timed states are both covered by service/DB/webhook tests, and
+  focused Go tests pass.

--- a/.octospec/tasks/notification-pause-manual-mode/context.yaml
+++ b/.octospec/tasks/notification-pause-manual-mode/context.yaml
@@ -1,0 +1,8 @@
+injected:
+  - id: error-handling
+    source: repo
+  - id: space-isolation
+    source: repo
+  - id: testing
+    source: repo
+brief: .octospec/tasks/notification-pause-manual-mode/brief.md

--- a/modules/notification/api.go
+++ b/modules/notification/api.go
@@ -72,14 +72,16 @@ func (s *Service) putPause(c *wkhttp.Context) {
 
 func (s *Service) deletePause(c *wkhttp.Context) {
 	now := time.Now().UTC()
-	record, err := s.db.clear(c.GetLoginUID(), now)
+	record, changed, err := s.db.clear(c.GetLoginUID(), now)
 	if err != nil {
 		s.writeStoreError(c, err)
 		return
 	}
 	response := s.response(record, now)
-	if err := s.sendChangedCMD(c.GetLoginUID(), response); err != nil {
-		s.Warn("发送通知暂停状态 CMD 失败", zap.String("uid", c.GetLoginUID()), zap.Error(err))
+	if changed {
+		if err := s.sendChangedCMD(c.GetLoginUID(), response); err != nil {
+			s.Warn("发送通知暂停状态 CMD 失败", zap.String("uid", c.GetLoginUID()), zap.Error(err))
+		}
 	}
 	c.Response(response)
 }
@@ -96,7 +98,7 @@ func (s *Service) response(record *pauseRecord, now time.Time) pauseResponse {
 		response.Mode = &mode
 		return response
 	}
-	if record.PausedUntil != nil && record.PausedUntil.After(now) {
+	if (record.Mode == nil || *record.Mode == pauseModeTimed) && record.PausedUntil != nil && record.PausedUntil.After(now) {
 		response.Paused = true
 		mode := pauseModeTimed
 		response.Mode = &mode

--- a/modules/notification/api.go
+++ b/modules/notification/api.go
@@ -96,13 +96,13 @@ func (s *Service) response(record *pauseRecord, now time.Time) pauseResponse {
 		return response
 	}
 	response.Revision = record.Revision
-	if pauseModeMatches(record.Mode, pauseModeManual) {
+	if record.Mode != nil && *record.Mode == pauseModeManual {
 		mode := pauseModeManual
 		response.Paused = true
 		response.Mode = &mode
 		return response
 	}
-	if (record.Mode == nil || pauseModeMatches(record.Mode, pauseModeTimed)) && record.PausedUntil != nil && record.PausedUntil.After(now) {
+	if (record.Mode == nil || (record.Mode != nil && *record.Mode == pauseModeTimed)) && record.PausedUntil != nil && record.PausedUntil.After(now) {
 		response.Paused = true
 		mode := pauseModeTimed
 		response.Mode = &mode

--- a/modules/notification/api.go
+++ b/modules/notification/api.go
@@ -1,6 +1,7 @@
 package notification
 
 import (
+	"strings"
 	"time"
 
 	"github.com/Mininglamp-OSS/octo-lib/common"
@@ -48,7 +49,7 @@ func (s *Service) getPause(c *wkhttp.Context) {
 
 func (s *Service) putPause(c *wkhttp.Context) {
 	var req updatePauseRequest
-	if err := c.BindJSON(&req); err != nil {
+	if err := c.ShouldBindJSON(&req); err != nil {
 		s.writeInvalidTime(c)
 		return
 	}
@@ -58,14 +59,16 @@ func (s *Service) putPause(c *wkhttp.Context) {
 		s.writeInvalidTime(c)
 		return
 	}
-	record, err := s.db.upsert(c.GetLoginUID(), mode, pausedUntil, now)
+	record, changed, err := s.db.upsert(c.GetLoginUID(), mode, pausedUntil, now)
 	if err != nil {
 		s.writeStoreError(c, err)
 		return
 	}
 	response := s.response(record, now)
-	if err := s.sendChangedCMD(c.GetLoginUID(), response); err != nil {
-		s.Warn("发送通知暂停状态 CMD 失败", zap.String("uid", c.GetLoginUID()), zap.Error(err))
+	if changed {
+		if err := s.sendChangedCMD(c.GetLoginUID(), response); err != nil {
+			s.Warn("发送通知暂停状态 CMD 失败", zap.String("uid", c.GetLoginUID()), zap.Error(err))
+		}
 	}
 	c.Response(response)
 }
@@ -92,13 +95,13 @@ func (s *Service) response(record *pauseRecord, now time.Time) pauseResponse {
 		return response
 	}
 	response.Revision = record.Revision
-	if record.Mode != nil && *record.Mode == pauseModeManual {
+	if record.Mode != nil && strings.EqualFold(*record.Mode, pauseModeManual) {
 		mode := pauseModeManual
 		response.Paused = true
 		response.Mode = &mode
 		return response
 	}
-	if (record.Mode == nil || *record.Mode == pauseModeTimed) && record.PausedUntil != nil && record.PausedUntil.After(now) {
+	if (record.Mode == nil || strings.EqualFold(*record.Mode, pauseModeTimed)) && record.PausedUntil != nil && record.PausedUntil.After(now) {
 		response.Paused = true
 		mode := pauseModeTimed
 		response.Mode = &mode

--- a/modules/notification/api.go
+++ b/modules/notification/api.go
@@ -53,12 +53,12 @@ func (s *Service) putPause(c *wkhttp.Context) {
 		return
 	}
 	now := time.Now().UTC()
-	pausedUntil := req.PausedUntil.UTC()
-	if !validPauseUntil(now, pausedUntil) {
+	mode, pausedUntil, ok := req.intent(now)
+	if !ok {
 		s.writeInvalidTime(c)
 		return
 	}
-	record, err := s.db.upsert(c.GetLoginUID(), pausedUntil, now)
+	record, err := s.db.upsert(c.GetLoginUID(), mode, pausedUntil, now)
 	if err != nil {
 		s.writeStoreError(c, err)
 		return
@@ -90,8 +90,16 @@ func (s *Service) response(record *pauseRecord, now time.Time) pauseResponse {
 		return response
 	}
 	response.Revision = record.Revision
+	if record.Mode != nil && *record.Mode == pauseModeManual {
+		mode := pauseModeManual
+		response.Paused = true
+		response.Mode = &mode
+		return response
+	}
 	if record.PausedUntil != nil && record.PausedUntil.After(now) {
 		response.Paused = true
+		mode := pauseModeTimed
+		response.Mode = &mode
 		until := record.PausedUntil.UTC()
 		response.PausedUntil = &until
 	}
@@ -106,11 +114,49 @@ func (s *Service) sendChangedCMD(uid string, response pauseResponse) error {
 		CMD:         notificationPauseCMD,
 		Param: map[string]interface{}{
 			"paused":       response.Paused,
+			"mode":         response.Mode,
 			"paused_until": response.PausedUntil,
 			"revision":     response.Revision,
 			"server_time":  response.ServerTime,
 		},
 	})
+}
+
+func (r updatePauseRequest) intent(now time.Time) (string, *time.Time, bool) {
+	count := 0
+	if r.Duration != nil {
+		count++
+	}
+	if r.Mode != nil {
+		count++
+	}
+	if r.hasPausedUntil {
+		count++
+	}
+	if count != 1 {
+		return "", nil, false
+	}
+	if r.Mode != nil {
+		return pauseModeManual, nil, *r.Mode == pauseModeManual
+	}
+	if r.Duration != nil {
+		var duration time.Duration
+		switch *r.Duration {
+		case "30m":
+			duration = 30 * time.Minute
+		case "1h":
+			duration = time.Hour
+		default:
+			return "", nil, false
+		}
+		until := now.Add(duration)
+		return pauseModeTimed, &until, true
+	}
+	if r.PausedUntil == nil {
+		return "", nil, false
+	}
+	until := r.PausedUntil.UTC()
+	return pauseModeTimed, &until, validPauseUntil(now, until)
 }
 
 func (s *Service) writeInvalidTime(c *wkhttp.Context) {

--- a/modules/notification/api.go
+++ b/modules/notification/api.go
@@ -1,7 +1,7 @@
 package notification
 
 import (
-	"strings"
+	"net/http"
 	"time"
 
 	"github.com/Mininglamp-OSS/octo-lib/common"
@@ -48,6 +48,7 @@ func (s *Service) getPause(c *wkhttp.Context) {
 }
 
 func (s *Service) putPause(c *wkhttp.Context) {
+	c.Request.Body = http.MaxBytesReader(c.Writer, c.Request.Body, 64<<10)
 	var req updatePauseRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		s.writeInvalidTime(c)
@@ -95,13 +96,13 @@ func (s *Service) response(record *pauseRecord, now time.Time) pauseResponse {
 		return response
 	}
 	response.Revision = record.Revision
-	if record.Mode != nil && strings.EqualFold(*record.Mode, pauseModeManual) {
+	if pauseModeMatches(record.Mode, pauseModeManual) {
 		mode := pauseModeManual
 		response.Paused = true
 		response.Mode = &mode
 		return response
 	}
-	if (record.Mode == nil || strings.EqualFold(*record.Mode, pauseModeTimed)) && record.PausedUntil != nil && record.PausedUntil.After(now) {
+	if (record.Mode == nil || pauseModeMatches(record.Mode, pauseModeTimed)) && record.PausedUntil != nil && record.PausedUntil.After(now) {
 		response.Paused = true
 		mode := pauseModeTimed
 		response.Mode = &mode
@@ -160,7 +161,7 @@ func (r updatePauseRequest) intent(now time.Time) (string, *time.Time, bool) {
 	if r.PausedUntil == nil {
 		return "", nil, false
 	}
-	until := r.PausedUntil.UTC()
+	until := r.PausedUntil.UTC().Truncate(time.Millisecond)
 	return pauseModeTimed, &until, validPauseUntil(now, until)
 }
 

--- a/modules/notification/api_test.go
+++ b/modules/notification/api_test.go
@@ -54,7 +54,7 @@ func TestPauseIntentSupportsManualAndDurations(t *testing.T) {
 	}
 }
 
-func TestUpdatePauseRequestRequiresRFC3339TimestampAndRejectsUnknownFields(t *testing.T) {
+func TestUpdatePauseRequestRequiresRFC3339TimestampAndAcceptsUnknownExtensionFields(t *testing.T) {
 	var request updatePauseRequest
 	if err := json.Unmarshal([]byte(`{"paused_until":"2026-08-16T09:00:00.000Z"}`), &request); err != nil {
 		t.Fatalf("valid UTC timestamp rejected: %v", err)

--- a/modules/notification/api_test.go
+++ b/modules/notification/api_test.go
@@ -77,6 +77,9 @@ func TestUpdatePauseRequestRequiresRFC3339TimestampAndAcceptsUnknownExtensionFie
 	if err := json.Unmarshal([]byte(`{"duration":null}`), &request); err == nil {
 		t.Fatal("null duration should be rejected")
 	}
+	if err := json.Unmarshal([]byte(`{"mode":"manual","mode":"timed"}`), &request); err == nil {
+		t.Fatal("duplicate mode fields should be rejected")
+	}
 }
 
 func TestPauseIntentRejectsAmbiguousAndInvalidRequests(t *testing.T) {
@@ -111,12 +114,12 @@ func TestResponseDoesNotTreatUnknownModeAsTimed(t *testing.T) {
 	}
 }
 
-func TestResponseNormalizesStoredModeWhitespace(t *testing.T) {
+func TestResponseDoesNotTreatNonCanonicalStoredModeAsActive(t *testing.T) {
 	now := time.Date(2026, 8, 14, 5, 0, 0, 0, time.UTC)
 	mode := " manual "
 	response := (&Service{}).response(&pauseRecord{Mode: &mode}, now)
-	if !response.Paused || response.Mode == nil || *response.Mode != pauseModeManual {
-		t.Fatalf("padded manual mode should remain active: %+v", response)
+	if response.Paused || response.Mode != nil {
+		t.Fatalf("non-canonical manual mode should be inactive: %+v", response)
 	}
 }
 

--- a/modules/notification/api_test.go
+++ b/modules/notification/api_test.go
@@ -111,6 +111,15 @@ func TestResponseDoesNotTreatUnknownModeAsTimed(t *testing.T) {
 	}
 }
 
+func TestResponseNormalizesStoredModeWhitespace(t *testing.T) {
+	now := time.Date(2026, 8, 14, 5, 0, 0, 0, time.UTC)
+	mode := " manual "
+	response := (&Service{}).response(&pauseRecord{Mode: &mode}, now)
+	if !response.Paused || response.Mode == nil || *response.Mode != pauseModeManual {
+		t.Fatalf("padded manual mode should remain active: %+v", response)
+	}
+}
+
 func strptr(value string) *string { return &value }
 
 func TestNormalizePauseRecordPreservesDatabaseUTCWallClock(t *testing.T) {

--- a/modules/notification/api_test.go
+++ b/modules/notification/api_test.go
@@ -1,6 +1,7 @@
 package notification
 
 import (
+	"encoding/json"
 	"testing"
 	"time"
 )
@@ -26,7 +27,7 @@ func TestResponseUsesUTCAbsolutePauseTime(t *testing.T) {
 	until := now.Add(30 * time.Minute)
 	service := &Service{}
 
-	response := service.response(&pauseRecord{PausedUntil: &until, Revision: 42}, now)
+	response := service.response(&pauseRecord{Mode: strptr(pauseModeTimed), PausedUntil: &until, Revision: 42}, now)
 	if !response.Paused || response.PausedUntil == nil {
 		t.Fatalf("future record should be active: %+v", response)
 	}
@@ -40,6 +41,59 @@ func TestResponseUsesUTCAbsolutePauseTime(t *testing.T) {
 		t.Fatalf("server_time should be UTC, got %s", response.ServerTime.Location())
 	}
 }
+
+func TestPauseIntentSupportsManualAndDurations(t *testing.T) {
+	now := time.Date(2026, 8, 14, 5, 0, 0, 0, time.UTC)
+	manual, until, ok := (updatePauseRequest{Mode: strptr(pauseModeManual)}).intent(now)
+	if !ok || manual != pauseModeManual || until != nil {
+		t.Fatalf("manual intent = %q, %v, %v", manual, until, ok)
+	}
+	mode, until, ok := (updatePauseRequest{Duration: strptr("30m")}).intent(now)
+	if !ok || mode != pauseModeTimed || until == nil || !until.Equal(now.Add(30*time.Minute)) {
+		t.Fatalf("duration intent = %q, %v, %v", mode, until, ok)
+	}
+}
+
+func TestUpdatePauseRequestRequiresRFC3339TimestampAndRejectsUnknownFields(t *testing.T) {
+	var request updatePauseRequest
+	if err := json.Unmarshal([]byte(`{"paused_until":"2026-08-16T09:00:00.000Z"}`), &request); err != nil {
+		t.Fatalf("valid UTC timestamp rejected: %v", err)
+	}
+	if request.PausedUntil == nil || !request.hasPausedUntil {
+		t.Fatalf("paused_until was not decoded: %+v", request)
+	}
+	if err := json.Unmarshal([]byte(`{"paused_until":"2026-08-16T09:00:00"}`), &request); err == nil {
+		t.Fatal("timezone-less timestamp should be rejected")
+	}
+	if err := json.Unmarshal([]byte(`{"scope":"sound"}`), &request); err == nil {
+		t.Fatal("unknown request field should be rejected")
+	}
+}
+
+func TestPauseIntentRejectsAmbiguousAndInvalidRequests(t *testing.T) {
+	now := time.Date(2026, 8, 14, 5, 0, 0, 0, time.UTC)
+	cases := []updatePauseRequest{
+		{Mode: strptr(pauseModeManual), Duration: strptr("30m")},
+		{Duration: strptr("2h")},
+		{Mode: strptr("timed")},
+		{PausedUntil: &now, hasPausedUntil: true},
+	}
+	for _, request := range cases {
+		if _, _, ok := request.intent(now); ok {
+			t.Fatalf("invalid request accepted: %+v", request)
+		}
+	}
+}
+
+func TestManualResponseStaysActiveWithoutAnExpiry(t *testing.T) {
+	now := time.Date(2026, 8, 14, 5, 0, 0, 0, time.UTC)
+	response := (&Service{}).response(&pauseRecord{Mode: strptr(pauseModeManual), Revision: 9}, now.Add(7*24*time.Hour))
+	if !response.Paused || response.Mode == nil || *response.Mode != pauseModeManual || response.PausedUntil != nil {
+		t.Fatalf("manual response = %+v", response)
+	}
+}
+
+func strptr(value string) *string { return &value }
 
 func TestNormalizePauseRecordPreservesDatabaseUTCWallClock(t *testing.T) {
 	stored := time.Date(2026, 8, 15, 8, 20, 30, 123000000, time.FixedZone("CST", 8*60*60))

--- a/modules/notification/api_test.go
+++ b/modules/notification/api_test.go
@@ -65,8 +65,17 @@ func TestUpdatePauseRequestRequiresRFC3339TimestampAndRejectsUnknownFields(t *te
 	if err := json.Unmarshal([]byte(`{"paused_until":"2026-08-16T09:00:00"}`), &request); err == nil {
 		t.Fatal("timezone-less timestamp should be rejected")
 	}
-	if err := json.Unmarshal([]byte(`{"scope":"sound"}`), &request); err == nil {
-		t.Fatal("unknown request field should be rejected")
+	if err := json.Unmarshal([]byte(`{"scope":"sound","duration":"30m"}`), &request); err != nil {
+		t.Fatalf("unknown extension field should remain forward-compatible: %v", err)
+	}
+	if _, _, ok := request.intent(time.Date(2026, 8, 14, 5, 0, 0, 0, time.UTC)); !ok {
+		t.Fatal("valid request with an unknown extension field should be accepted")
+	}
+	if err := json.Unmarshal([]byte(`{"mode":null}`), &request); err == nil {
+		t.Fatal("null mode should be rejected")
+	}
+	if err := json.Unmarshal([]byte(`{"duration":null}`), &request); err == nil {
+		t.Fatal("null duration should be rejected")
 	}
 }
 
@@ -90,6 +99,15 @@ func TestManualResponseStaysActiveWithoutAnExpiry(t *testing.T) {
 	response := (&Service{}).response(&pauseRecord{Mode: strptr(pauseModeManual), Revision: 9}, now.Add(7*24*time.Hour))
 	if !response.Paused || response.Mode == nil || *response.Mode != pauseModeManual || response.PausedUntil != nil {
 		t.Fatalf("manual response = %+v", response)
+	}
+}
+
+func TestResponseDoesNotTreatUnknownModeAsTimed(t *testing.T) {
+	now := time.Date(2026, 8, 14, 5, 0, 0, 0, time.UTC)
+	future := now.Add(time.Hour)
+	response := (&Service{}).response(&pauseRecord{Mode: strptr("future-mode"), PausedUntil: &future}, now)
+	if response.Paused || response.Mode != nil || response.PausedUntil != nil {
+		t.Fatalf("unknown mode should not activate a pause: %+v", response)
 	}
 }
 

--- a/modules/notification/db.go
+++ b/modules/notification/db.go
@@ -49,6 +49,8 @@ func (s *dbStore) upsert(uid, mode string, pausedUntil *time.Time, now time.Time
 	result, err := tx.InsertBySql(
 		"INSERT INTO user_notification_pause (uid, mode, paused_until, revision, updated_at) VALUES (?, ?, ?, 1, ?) "+
 			"ON DUPLICATE KEY UPDATE "+
+			// Keep revision and updated_at before mode/paused_until: MySQL evaluates
+			// assignments left-to-right and these expressions compare old values.
 			"revision=revision+IF(mode <=> VALUES(mode) AND paused_until <=> VALUES(paused_until), 0, 1), "+
 			"updated_at=IF(mode <=> VALUES(mode) AND paused_until <=> VALUES(paused_until), updated_at, VALUES(updated_at)), "+
 			"mode=VALUES(mode), paused_until=VALUES(paused_until)",
@@ -132,7 +134,7 @@ func (s *dbStore) getActiveByUIDs(uids []string, now time.Time) (map[string]stru
 		var records []*pauseRecord
 		_, err := s.session.Select("uid", "mode", "paused_until", "revision", "updated_at").
 			From("user_notification_pause").
-			Where("uid IN ? AND (mode=? OR ((mode=? OR mode IS NULL) AND paused_until IS NOT NULL AND paused_until > ?))", uids[start:end], pauseModeManual, pauseModeTimed, now.UTC()).
+			Where("uid IN ? AND (BINARY mode = BINARY ? OR ((BINARY mode = BINARY ? OR mode IS NULL) AND paused_until IS NOT NULL AND paused_until > ?))", uids[start:end], pauseModeManual, pauseModeTimed, now.UTC()).
 			Load(&records)
 		if err != nil {
 			return nil, err

--- a/modules/notification/db.go
+++ b/modules/notification/db.go
@@ -71,19 +71,26 @@ func (s *dbStore) upsert(uid, mode string, pausedUntil *time.Time, now time.Time
 	return normalizePauseRecord(record), nil
 }
 
-func (s *dbStore) clear(uid string, now time.Time) (*pauseRecord, error) {
+func (s *dbStore) clear(uid string, now time.Time) (*pauseRecord, bool, error) {
 	tx, err := s.session.Begin()
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
-	_, err = tx.InsertBySql(
-		"INSERT INTO user_notification_pause (uid, mode, paused_until, revision, updated_at) VALUES (?, NULL, NULL, 1, ?) "+
-			"ON DUPLICATE KEY UPDATE mode=NULL, paused_until=NULL, revision=revision+1, updated_at=VALUES(updated_at)",
-		uid, now.UTC(),
-	).Exec()
+	result, err := tx.Update("user_notification_pause").
+		Set("mode", nil).
+		Set("paused_until", nil).
+		Set("updated_at", now.UTC()).
+		Set("revision", dbr.Expr("revision+1")).
+		Where("uid=? AND (mode IS NOT NULL OR paused_until IS NOT NULL)", uid).
+		Exec()
 	if err != nil {
 		_ = tx.Rollback()
-		return nil, err
+		return nil, false, err
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		_ = tx.Rollback()
+		return nil, false, err
 	}
 	var record *pauseRecord
 	_, err = tx.Select("uid", "mode", "paused_until", "revision", "updated_at").
@@ -93,12 +100,12 @@ func (s *dbStore) clear(uid string, now time.Time) (*pauseRecord, error) {
 		Load(&record)
 	if err != nil {
 		_ = tx.Rollback()
-		return nil, err
+		return nil, false, err
 	}
 	if err := tx.Commit(); err != nil {
-		return nil, err
+		return nil, false, err
 	}
-	return normalizePauseRecord(record), nil
+	return normalizePauseRecord(record), rows > 0, nil
 }
 
 func (s *dbStore) getActiveByUIDs(uids []string, now time.Time) (map[string]struct{}, error) {

--- a/modules/notification/db.go
+++ b/modules/notification/db.go
@@ -1,7 +1,6 @@
 package notification
 
 import (
-	"strings"
 	"time"
 
 	"github.com/Mininglamp-OSS/octo-lib/config"
@@ -43,32 +42,23 @@ func (s *dbStore) upsert(uid, mode string, pausedUntil *time.Time, now time.Time
 	if err != nil {
 		return nil, false, err
 	}
-	var current *pauseRecord
-	_, err = tx.Select("uid", "mode", "paused_until", "revision", "updated_at").
-		From("user_notification_pause").
-		Where("uid=?", uid).
-		Suffix("FOR UPDATE").
-		Load(&current)
+	var until interface{}
+	if pausedUntil != nil {
+		until = pausedUntil.UTC().Truncate(time.Millisecond)
+	}
+	result, err := tx.InsertBySql(
+		"INSERT INTO user_notification_pause (uid, mode, paused_until, revision, updated_at) VALUES (?, ?, ?, 1, ?) "+
+			"ON DUPLICATE KEY UPDATE "+
+			"revision=revision+IF(mode <=> VALUES(mode) AND paused_until <=> VALUES(paused_until), 0, 1), "+
+			"updated_at=IF(mode <=> VALUES(mode) AND paused_until <=> VALUES(paused_until), updated_at, VALUES(updated_at)), "+
+			"mode=VALUES(mode), paused_until=VALUES(paused_until)",
+		uid, mode, until, now.UTC(),
+	).Exec()
 	if err != nil {
 		_ = tx.Rollback()
 		return nil, false, err
 	}
-	current = normalizePauseRecord(current)
-	if samePauseState(current, mode, pausedUntil) {
-		if err := tx.Commit(); err != nil {
-			return nil, false, err
-		}
-		return normalizePauseRecord(current), false, nil
-	}
-	var until interface{}
-	if pausedUntil != nil {
-		until = pausedUntil.UTC()
-	}
-	_, err = tx.InsertBySql(
-		"INSERT INTO user_notification_pause (uid, mode, paused_until, revision, updated_at) VALUES (?, ?, ?, 1, ?) "+
-			"ON DUPLICATE KEY UPDATE mode=VALUES(mode), paused_until=VALUES(paused_until), revision=revision+1, updated_at=VALUES(updated_at)",
-		uid, mode, until, now.UTC(),
-	).Exec()
+	rowsAffected, err := result.RowsAffected()
 	if err != nil {
 		_ = tx.Rollback()
 		return nil, false, err
@@ -86,17 +76,7 @@ func (s *dbStore) upsert(uid, mode string, pausedUntil *time.Time, now time.Time
 	if err := tx.Commit(); err != nil {
 		return nil, false, err
 	}
-	return normalizePauseRecord(record), true, nil
-}
-
-func samePauseState(record *pauseRecord, mode string, pausedUntil *time.Time) bool {
-	if record == nil || record.Mode == nil || !strings.EqualFold(*record.Mode, mode) {
-		return false
-	}
-	if record.PausedUntil == nil || pausedUntil == nil {
-		return record.PausedUntil == nil && pausedUntil == nil
-	}
-	return record.PausedUntil.Equal(*pausedUntil)
+	return normalizePauseRecord(record), rowsAffected > 0, nil
 }
 
 func (s *dbStore) clear(uid string, now time.Time) (*pauseRecord, bool, error) {
@@ -104,6 +84,8 @@ func (s *dbStore) clear(uid string, now time.Time) (*pauseRecord, bool, error) {
 	if err != nil {
 		return nil, false, err
 	}
+	// Expired timed rows are inactive on the wire but still persisted state;
+	// clearing them is a real cleanup transition and advances the revision.
 	result, err := tx.Update("user_notification_pause").
 		Set("mode", nil).
 		Set("paused_until", nil).

--- a/modules/notification/db.go
+++ b/modules/notification/db.go
@@ -30,29 +30,33 @@ func newDBStore(ctx *config.Context) *dbStore {
 
 func (s *dbStore) get(uid string) (*pauseRecord, error) {
 	var record *pauseRecord
-	_, err := s.session.Select("uid", "paused_until", "revision", "updated_at").
+	_, err := s.session.Select("uid", "mode", "paused_until", "revision", "updated_at").
 		From("user_notification_pause").
 		Where("uid=?", uid).
 		Load(&record)
 	return normalizePauseRecord(record), err
 }
 
-func (s *dbStore) upsert(uid string, pausedUntil time.Time, now time.Time) (*pauseRecord, error) {
+func (s *dbStore) upsert(uid, mode string, pausedUntil *time.Time, now time.Time) (*pauseRecord, error) {
 	tx, err := s.session.Begin()
 	if err != nil {
 		return nil, err
 	}
+	var until interface{}
+	if pausedUntil != nil {
+		until = pausedUntil.UTC()
+	}
 	_, err = tx.InsertBySql(
-		"INSERT INTO user_notification_pause (uid, paused_until, revision, updated_at) VALUES (?, ?, 1, ?) "+
-			"ON DUPLICATE KEY UPDATE paused_until=VALUES(paused_until), revision=revision+1, updated_at=VALUES(updated_at)",
-		uid, pausedUntil.UTC(), now.UTC(),
+		"INSERT INTO user_notification_pause (uid, mode, paused_until, revision, updated_at) VALUES (?, ?, ?, 1, ?) "+
+			"ON DUPLICATE KEY UPDATE mode=VALUES(mode), paused_until=VALUES(paused_until), revision=revision+1, updated_at=VALUES(updated_at)",
+		uid, mode, until, now.UTC(),
 	).Exec()
 	if err != nil {
 		_ = tx.Rollback()
 		return nil, err
 	}
 	var record *pauseRecord
-	_, err = tx.Select("uid", "paused_until", "revision", "updated_at").
+	_, err = tx.Select("uid", "mode", "paused_until", "revision", "updated_at").
 		From("user_notification_pause").
 		Where("uid=?", uid).
 		Suffix("FOR UPDATE").
@@ -72,18 +76,17 @@ func (s *dbStore) clear(uid string, now time.Time) (*pauseRecord, error) {
 	if err != nil {
 		return nil, err
 	}
-	_, err = tx.Update("user_notification_pause").
-		Set("paused_until", nil).
-		Set("updated_at", now.UTC()).
-		Set("revision", dbr.Expr("revision+1")).
-		Where("uid=? AND paused_until IS NOT NULL", uid).
-		Exec()
+	_, err = tx.InsertBySql(
+		"INSERT INTO user_notification_pause (uid, mode, paused_until, revision, updated_at) VALUES (?, NULL, NULL, 1, ?) "+
+			"ON DUPLICATE KEY UPDATE mode=NULL, paused_until=NULL, revision=revision+1, updated_at=VALUES(updated_at)",
+		uid, now.UTC(),
+	).Exec()
 	if err != nil {
 		_ = tx.Rollback()
 		return nil, err
 	}
 	var record *pauseRecord
-	_, err = tx.Select("uid", "paused_until", "revision", "updated_at").
+	_, err = tx.Select("uid", "mode", "paused_until", "revision", "updated_at").
 		From("user_notification_pause").
 		Where("uid=?", uid).
 		Suffix("FOR UPDATE").
@@ -110,9 +113,9 @@ func (s *dbStore) getActiveByUIDs(uids []string, now time.Time) (map[string]stru
 			end = len(uids)
 		}
 		var records []*pauseRecord
-		_, err := s.session.Select("uid", "paused_until", "revision", "updated_at").
+		_, err := s.session.Select("uid", "mode", "paused_until", "revision", "updated_at").
 			From("user_notification_pause").
-			Where("uid IN ? AND paused_until IS NOT NULL AND paused_until > ?", uids[start:end], now.UTC()).
+			Where("uid IN ? AND (mode=? OR ((mode=? OR mode IS NULL) AND paused_until IS NOT NULL AND paused_until > ?))", uids[start:end], pauseModeManual, pauseModeTimed, now.UTC()).
 			Load(&records)
 		if err != nil {
 			return nil, err

--- a/modules/notification/db.go
+++ b/modules/notification/db.go
@@ -1,6 +1,7 @@
 package notification
 
 import (
+	"strings"
 	"time"
 
 	"github.com/Mininglamp-OSS/octo-lib/config"
@@ -37,10 +38,27 @@ func (s *dbStore) get(uid string) (*pauseRecord, error) {
 	return normalizePauseRecord(record), err
 }
 
-func (s *dbStore) upsert(uid, mode string, pausedUntil *time.Time, now time.Time) (*pauseRecord, error) {
+func (s *dbStore) upsert(uid, mode string, pausedUntil *time.Time, now time.Time) (*pauseRecord, bool, error) {
 	tx, err := s.session.Begin()
 	if err != nil {
-		return nil, err
+		return nil, false, err
+	}
+	var current *pauseRecord
+	_, err = tx.Select("uid", "mode", "paused_until", "revision", "updated_at").
+		From("user_notification_pause").
+		Where("uid=?", uid).
+		Suffix("FOR UPDATE").
+		Load(&current)
+	if err != nil {
+		_ = tx.Rollback()
+		return nil, false, err
+	}
+	current = normalizePauseRecord(current)
+	if samePauseState(current, mode, pausedUntil) {
+		if err := tx.Commit(); err != nil {
+			return nil, false, err
+		}
+		return normalizePauseRecord(current), false, nil
 	}
 	var until interface{}
 	if pausedUntil != nil {
@@ -53,7 +71,7 @@ func (s *dbStore) upsert(uid, mode string, pausedUntil *time.Time, now time.Time
 	).Exec()
 	if err != nil {
 		_ = tx.Rollback()
-		return nil, err
+		return nil, false, err
 	}
 	var record *pauseRecord
 	_, err = tx.Select("uid", "mode", "paused_until", "revision", "updated_at").
@@ -63,12 +81,22 @@ func (s *dbStore) upsert(uid, mode string, pausedUntil *time.Time, now time.Time
 		Load(&record)
 	if err != nil {
 		_ = tx.Rollback()
-		return nil, err
+		return nil, false, err
 	}
 	if err := tx.Commit(); err != nil {
-		return nil, err
+		return nil, false, err
 	}
-	return normalizePauseRecord(record), nil
+	return normalizePauseRecord(record), true, nil
+}
+
+func samePauseState(record *pauseRecord, mode string, pausedUntil *time.Time) bool {
+	if record == nil || record.Mode == nil || !strings.EqualFold(*record.Mode, mode) {
+		return false
+	}
+	if record.PausedUntil == nil || pausedUntil == nil {
+		return record.PausedUntil == nil && pausedUntil == nil
+	}
+	return record.PausedUntil.Equal(*pausedUntil)
 }
 
 func (s *dbStore) clear(uid string, now time.Time) (*pauseRecord, bool, error) {

--- a/modules/notification/db_test.go
+++ b/modules/notification/db_test.go
@@ -20,6 +20,7 @@ func TestPauseTimeSurvivesNonUTCLocRoundTrip(t *testing.T) {
 	}
 	_, err := ctx.DB().DB.Exec(`CREATE TABLE IF NOT EXISTS user_notification_pause (
 		uid VARCHAR(40) NOT NULL,
+		mode VARCHAR(16) NULL,
 		paused_until DATETIME(3) NULL,
 		revision BIGINT UNSIGNED NOT NULL DEFAULT 0,
 		updated_at DATETIME(3) NOT NULL,
@@ -34,7 +35,7 @@ func TestPauseTimeSurvivesNonUTCLocRoundTrip(t *testing.T) {
 	store := newDBStore(ctx)
 	now := time.Now().UTC().Truncate(time.Millisecond)
 	want := now.Add(2 * time.Hour)
-	if _, err := store.upsert(uid, want, now); err != nil {
+	if _, err := store.upsert(uid, pauseModeTimed, &want, now); err != nil {
 		t.Fatal(err)
 	}
 	record, err := store.get(uid)

--- a/modules/notification/db_test.go
+++ b/modules/notification/db_test.go
@@ -57,16 +57,20 @@ func newPauseTestStore(t *testing.T) (*dbStore, *config.Context) {
 func TestGetActiveByUIDsCoversManualTimedLegacyAndExpiredRows(t *testing.T) {
 	store, ctx := newPauseTestStore(t)
 	now := time.Date(2026, 8, 14, 5, 0, 0, 0, time.UTC)
-	future := now.Add(time.Hour)
-	past := now.Add(-time.Hour)
+	// Use SQL wall-clock strings here. This test deliberately uses a
+	// non-UTC DSN, and passing time.Time values through database/sql would
+	// convert the fixture before MySQL stores it, making the "past" row future
+	// relative to the fixed query instant.
+	future := "2026-08-14 06:00:00"
+	past := "2026-08-14 04:00:00"
 	rows := []struct {
 		uid, mode string
-		until     *time.Time
+		until     interface{}
 	}{
 		{"notification-active-manual", pauseModeManual, nil},
-		{"notification-active-timed", pauseModeTimed, &future},
-		{"notification-active-legacy", "", &future},
-		{"notification-expired-timed", pauseModeTimed, &past},
+		{"notification-active-timed", pauseModeTimed, future},
+		{"notification-active-legacy", "", future},
+		{"notification-expired-timed", pauseModeTimed, past},
 		{"notification-cleared", "", nil},
 	}
 	for _, row := range rows {

--- a/modules/notification/db_test.go
+++ b/modules/notification/db_test.go
@@ -10,6 +10,28 @@ import (
 )
 
 func TestPauseTimeSurvivesNonUTCLocRoundTrip(t *testing.T) {
+	store, ctx := newPauseTestStore(t)
+	uid := fmt.Sprintf("notification-tz-%d", time.Now().UnixNano())
+	t.Cleanup(func() { _, _ = ctx.DB().DB.Exec("DELETE FROM user_notification_pause WHERE uid=?", uid) })
+	now := time.Now().UTC().Truncate(time.Millisecond)
+	want := now.Add(2 * time.Hour)
+	if _, err := store.upsert(uid, pauseModeTimed, &want, now); err != nil {
+		t.Fatal(err)
+	}
+	record, err := store.get(uid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if record == nil || record.PausedUntil == nil || !record.PausedUntil.Equal(want) {
+		t.Fatalf("paused_until round trip = %v, want %v", record, want)
+	}
+	if response := (&Service{}).response(record, now); !response.Paused || response.PausedUntil == nil || !response.PausedUntil.Equal(want) {
+		t.Fatalf("response = %+v, want active pause until %s", response, want)
+	}
+}
+
+func newPauseTestStore(t *testing.T) (*dbStore, *config.Context) {
+	t.Helper()
 	cfg := config.New()
 	cfg.Test = true
 	cfg.DB.MySQLAddr = "root:demo@tcp(127.0.0.1:3306)/test?charset=utf8mb4&parseTime=true&loc=Asia%2FShanghai"
@@ -29,23 +51,82 @@ func TestPauseTimeSurvivesNonUTCLocRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	return newDBStore(ctx), ctx
+}
 
-	uid := fmt.Sprintf("notification-tz-%d", time.Now().UnixNano())
-	t.Cleanup(func() { _, _ = ctx.DB().DB.Exec("DELETE FROM user_notification_pause WHERE uid=?", uid) })
-	store := newDBStore(ctx)
-	now := time.Now().UTC().Truncate(time.Millisecond)
-	want := now.Add(2 * time.Hour)
-	if _, err := store.upsert(uid, pauseModeTimed, &want, now); err != nil {
-		t.Fatal(err)
+func TestGetActiveByUIDsCoversManualTimedLegacyAndExpiredRows(t *testing.T) {
+	store, ctx := newPauseTestStore(t)
+	now := time.Date(2026, 8, 14, 5, 0, 0, 0, time.UTC)
+	future := now.Add(time.Hour)
+	past := now.Add(-time.Hour)
+	rows := []struct {
+		uid, mode string
+		until     *time.Time
+	}{
+		{"notification-active-manual", pauseModeManual, nil},
+		{"notification-active-timed", pauseModeTimed, &future},
+		{"notification-active-legacy", "", &future},
+		{"notification-expired-timed", pauseModeTimed, &past},
+		{"notification-cleared", "", nil},
 	}
-	record, err := store.get(uid)
+	for _, row := range rows {
+		_, err := ctx.DB().DB.Exec("DELETE FROM user_notification_pause WHERE uid=?", row.uid)
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, err = ctx.DB().DB.Exec("INSERT INTO user_notification_pause (uid, mode, paused_until, revision, updated_at) VALUES (?, NULLIF(?, ''), ?, 1, ?)", row.uid, row.mode, row.until, now)
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { _, _ = ctx.DB().DB.Exec("DELETE FROM user_notification_pause WHERE uid=?", row.uid) })
+	}
+
+	uids := make([]string, 0, len(rows))
+	for _, row := range rows {
+		uids = append(uids, row.uid)
+	}
+	active, err := store.getActiveByUIDs(uids, now)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if record == nil || record.PausedUntil == nil || !record.PausedUntil.Equal(want) {
-		t.Fatalf("paused_until round trip = %v, want %v", record, want)
+	for _, uid := range []string{"notification-active-manual", "notification-active-timed", "notification-active-legacy"} {
+		if _, ok := active[uid]; !ok {
+			t.Fatalf("%s should be active, got %v", uid, active)
+		}
 	}
-	if response := (&Service{}).response(record, now); !response.Paused || response.PausedUntil == nil || !response.PausedUntil.Equal(want) {
-		t.Fatalf("response = %+v, want active pause until %s", response, want)
+	for _, uid := range []string{"notification-expired-timed", "notification-cleared"} {
+		if _, ok := active[uid]; ok {
+			t.Fatalf("%s should be inactive, got %v", uid, active)
+		}
+	}
+}
+
+func TestClearIsIdempotentAndDoesNotCreateRows(t *testing.T) {
+	store, ctx := newPauseTestStore(t)
+	now := time.Date(2026, 8, 14, 5, 0, 0, 0, time.UTC)
+	uid := fmt.Sprintf("notification-clear-%d", time.Now().UnixNano())
+	future := now.Add(time.Hour)
+	t.Cleanup(func() { _, _ = ctx.DB().DB.Exec("DELETE FROM user_notification_pause WHERE uid=?", uid) })
+	if _, err := store.upsert(uid, pauseModeManual, &future, now); err != nil {
+		t.Fatal(err)
+	}
+	first, firstChanged, err := store.clear(uid, now.Add(time.Minute))
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, secondChanged, err := store.clear(uid, now.Add(2*time.Minute))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first == nil || second == nil || !firstChanged || secondChanged || first.Revision != 2 || second.Revision != first.Revision {
+		t.Fatalf("clear should update once and then be a no-op: first=%+v changed=%v second=%+v changed=%v", first, firstChanged, second, secondChanged)
+	}
+	missingUID := fmt.Sprintf("notification-clear-missing-%d", time.Now().UnixNano())
+	missing, missingChanged, err := store.clear(missingUID, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if missing != nil || missingChanged {
+		t.Fatalf("clear of a missing row should not create state: %+v changed=%v", missing, missingChanged)
 	}
 }

--- a/modules/notification/db_test.go
+++ b/modules/notification/db_test.go
@@ -16,7 +16,10 @@ func TestPauseTimeSurvivesNonUTCLocRoundTrip(t *testing.T) {
 	now := time.Now().UTC().Truncate(time.Millisecond)
 	want := now.Add(2 * time.Hour)
 	if _, changed, err := store.upsert(uid, pauseModeTimed, &want, now); err != nil || !changed {
-		t.Fatal(err)
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Fatal("initial upsert should change the row")
 	}
 	record, err := store.get(uid)
 	if err != nil {
@@ -42,7 +45,6 @@ func newPauseTestStore(t *testing.T) (*dbStore, *config.Context) {
 	}
 	_, err := ctx.DB().DB.Exec(`CREATE TABLE IF NOT EXISTS user_notification_pause (
 		uid VARCHAR(40) NOT NULL,
-		mode VARCHAR(16) NULL,
 		paused_until DATETIME(3) NULL,
 		revision BIGINT UNSIGNED NOT NULL DEFAULT 0,
 		updated_at DATETIME(3) NOT NULL,
@@ -52,8 +54,14 @@ func newPauseTestStore(t *testing.T) (*dbStore, *config.Context) {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() { _ = ctx.DB().DB.Close() })
-	if _, err := ctx.DB().DB.Exec("ALTER TABLE user_notification_pause ADD COLUMN IF NOT EXISTS mode VARCHAR(16) NULL AFTER uid"); err != nil {
+	var modeColumns int
+	if err := ctx.DB().DB.QueryRow("SELECT COUNT(*) FROM information_schema.columns WHERE table_schema=DATABASE() AND table_name='user_notification_pause' AND column_name='mode'").Scan(&modeColumns); err != nil {
 		t.Fatal(err)
+	}
+	if modeColumns == 0 {
+		if _, err := ctx.DB().DB.Exec("ALTER TABLE user_notification_pause ADD COLUMN mode VARCHAR(16) NULL AFTER uid"); err != nil {
+			t.Fatal(err)
+		}
 	}
 	return newDBStore(ctx), ctx
 }
@@ -121,13 +129,6 @@ func TestClearIsIdempotentAndDoesNotCreateRows(t *testing.T) {
 		}
 		t.Fatal("initial upsert should change the row")
 	}
-	repeated, repeatedChanged, err := store.upsert(uid, pauseModeManual, nil, now.Add(time.Minute))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if repeatedChanged || repeated == nil || repeated.Revision != 1 {
-		t.Fatalf("repeated identical upsert should be a no-op: record=%+v changed=%v", repeated, repeatedChanged)
-	}
 	first, firstChanged, err := store.clear(uid, now.Add(time.Minute))
 	if err != nil {
 		t.Fatal(err)
@@ -146,5 +147,24 @@ func TestClearIsIdempotentAndDoesNotCreateRows(t *testing.T) {
 	}
 	if missing != nil || missingChanged {
 		t.Fatalf("clear of a missing row should not create state: %+v changed=%v", missing, missingChanged)
+	}
+}
+
+func TestUpsertIsIdempotentAndTruncatesDatabasePrecision(t *testing.T) {
+	store, ctx := newPauseTestStore(t)
+	now := time.Date(2026, 8, 14, 5, 0, 0, 123456789, time.UTC)
+	uid := fmt.Sprintf("notification-upsert-%d", time.Now().UnixNano())
+	t.Cleanup(func() { _, _ = ctx.DB().DB.Exec("DELETE FROM user_notification_pause WHERE uid=?", uid) })
+	want := now.Add(time.Hour)
+	first, changed, err := store.upsert(uid, pauseModeTimed, &want, now)
+	if err != nil || !changed {
+		t.Fatalf("initial upsert = record=%+v changed=%v err=%v", first, changed, err)
+	}
+	second, changed, err := store.upsert(uid, pauseModeTimed, &want, now.Add(time.Minute))
+	if err != nil || changed || second == nil || second.Revision != first.Revision {
+		t.Fatalf("repeated upsert should be a no-op: first=%+v second=%+v changed=%v err=%v", first, second, changed, err)
+	}
+	if second.PausedUntil == nil || second.PausedUntil.Nanosecond()%int(time.Millisecond) != 0 {
+		t.Fatalf("paused_until should use DATETIME(3) precision: %+v", second.PausedUntil)
 	}
 }

--- a/modules/notification/db_test.go
+++ b/modules/notification/db_test.go
@@ -75,7 +75,7 @@ func TestGetActiveByUIDsCoversManualTimedLegacyAndExpiredRows(t *testing.T) {
 	// relative to the fixed query instant.
 	future := "2026-08-14 06:00:00"
 	past := "2026-08-14 04:00:00"
-	uidPrefix := fmt.Sprintf("notification-active-%d-", time.Now().UnixNano())
+	uidPrefix := fmt.Sprintf("np-active-%d-", time.Now().UnixNano())
 	rows := []struct {
 		uid, mode string
 		until     interface{}
@@ -87,6 +87,9 @@ func TestGetActiveByUIDsCoversManualTimedLegacyAndExpiredRows(t *testing.T) {
 		{uidPrefix + "cleared", "", nil},
 	}
 	for _, row := range rows {
+		if len(row.uid) > 40 {
+			t.Fatalf("test uid %q exceeds VARCHAR(40)", row.uid)
+		}
 		_, err := ctx.DB().DB.Exec("DELETE FROM user_notification_pause WHERE uid=?", row.uid)
 		if err != nil {
 			t.Fatal(err)

--- a/modules/notification/db_test.go
+++ b/modules/notification/db_test.go
@@ -15,7 +15,7 @@ func TestPauseTimeSurvivesNonUTCLocRoundTrip(t *testing.T) {
 	t.Cleanup(func() { _, _ = ctx.DB().DB.Exec("DELETE FROM user_notification_pause WHERE uid=?", uid) })
 	now := time.Now().UTC().Truncate(time.Millisecond)
 	want := now.Add(2 * time.Hour)
-	if _, err := store.upsert(uid, pauseModeTimed, &want, now); err != nil {
+	if _, changed, err := store.upsert(uid, pauseModeTimed, &want, now); err != nil || !changed {
 		t.Fatal(err)
 	}
 	record, err := store.get(uid)
@@ -51,6 +51,10 @@ func newPauseTestStore(t *testing.T) (*dbStore, *config.Context) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	t.Cleanup(func() { _ = ctx.DB().DB.Close() })
+	if _, err := ctx.DB().DB.Exec("ALTER TABLE user_notification_pause ADD COLUMN IF NOT EXISTS mode VARCHAR(16) NULL AFTER uid"); err != nil {
+		t.Fatal(err)
+	}
 	return newDBStore(ctx), ctx
 }
 
@@ -63,15 +67,16 @@ func TestGetActiveByUIDsCoversManualTimedLegacyAndExpiredRows(t *testing.T) {
 	// relative to the fixed query instant.
 	future := "2026-08-14 06:00:00"
 	past := "2026-08-14 04:00:00"
+	uidPrefix := fmt.Sprintf("notification-active-%d-", time.Now().UnixNano())
 	rows := []struct {
 		uid, mode string
 		until     interface{}
 	}{
-		{"notification-active-manual", pauseModeManual, nil},
-		{"notification-active-timed", pauseModeTimed, future},
-		{"notification-active-legacy", "", future},
-		{"notification-expired-timed", pauseModeTimed, past},
-		{"notification-cleared", "", nil},
+		{uidPrefix + "manual", pauseModeManual, nil},
+		{uidPrefix + "timed", pauseModeTimed, future},
+		{uidPrefix + "legacy", "", future},
+		{uidPrefix + "expired", pauseModeTimed, past},
+		{uidPrefix + "cleared", "", nil},
 	}
 	for _, row := range rows {
 		_, err := ctx.DB().DB.Exec("DELETE FROM user_notification_pause WHERE uid=?", row.uid)
@@ -93,12 +98,12 @@ func TestGetActiveByUIDsCoversManualTimedLegacyAndExpiredRows(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	for _, uid := range []string{"notification-active-manual", "notification-active-timed", "notification-active-legacy"} {
+	for _, uid := range []string{uidPrefix + "manual", uidPrefix + "timed", uidPrefix + "legacy"} {
 		if _, ok := active[uid]; !ok {
 			t.Fatalf("%s should be active, got %v", uid, active)
 		}
 	}
-	for _, uid := range []string{"notification-expired-timed", "notification-cleared"} {
+	for _, uid := range []string{uidPrefix + "expired", uidPrefix + "cleared"} {
 		if _, ok := active[uid]; ok {
 			t.Fatalf("%s should be inactive, got %v", uid, active)
 		}
@@ -109,10 +114,19 @@ func TestClearIsIdempotentAndDoesNotCreateRows(t *testing.T) {
 	store, ctx := newPauseTestStore(t)
 	now := time.Date(2026, 8, 14, 5, 0, 0, 0, time.UTC)
 	uid := fmt.Sprintf("notification-clear-%d", time.Now().UnixNano())
-	future := now.Add(time.Hour)
 	t.Cleanup(func() { _, _ = ctx.DB().DB.Exec("DELETE FROM user_notification_pause WHERE uid=?", uid) })
-	if _, err := store.upsert(uid, pauseModeManual, &future, now); err != nil {
+	if _, changed, err := store.upsert(uid, pauseModeManual, nil, now); err != nil || !changed {
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Fatal("initial upsert should change the row")
+	}
+	repeated, repeatedChanged, err := store.upsert(uid, pauseModeManual, nil, now.Add(time.Minute))
+	if err != nil {
 		t.Fatal(err)
+	}
+	if repeatedChanged || repeated == nil || repeated.Revision != 1 {
+		t.Fatalf("repeated identical upsert should be a no-op: record=%+v changed=%v", repeated, repeatedChanged)
 	}
 	first, firstChanged, err := store.clear(uid, now.Add(time.Minute))
 	if err != nil {

--- a/modules/notification/model.go
+++ b/modules/notification/model.go
@@ -1,11 +1,22 @@
 package notification
 
-import "time"
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"time"
+)
 
 const notificationPauseCMD = "user.notification_pause.changed"
 
+const (
+	pauseModeTimed  = "timed"
+	pauseModeManual = "manual"
+)
+
 type pauseRecord struct {
 	UID         string     `db:"uid"`
+	Mode        *string    `db:"mode"`
 	PausedUntil *time.Time `db:"paused_until"`
 	Revision    uint64     `db:"revision"`
 	UpdatedAt   time.Time  `db:"updated_at"`
@@ -13,11 +24,53 @@ type pauseRecord struct {
 
 type pauseResponse struct {
 	Paused      bool       `json:"paused"`
+	Mode        *string    `json:"mode"`
 	PausedUntil *time.Time `json:"paused_until"`
 	Revision    uint64     `json:"revision"`
 	ServerTime  time.Time  `json:"server_time"`
 }
 
 type updatePauseRequest struct {
-	PausedUntil time.Time `json:"paused_until"`
+	Duration       *string
+	Mode           *string
+	PausedUntil    *time.Time
+	hasPausedUntil bool
+}
+
+func (r *updatePauseRequest) UnmarshalJSON(data []byte) error {
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(data, &fields); err != nil {
+		return err
+	}
+	for name := range fields {
+		if name != "duration" && name != "mode" && name != "paused_until" {
+			return fmt.Errorf("unknown notification pause field %q", name)
+		}
+	}
+	if raw, ok := fields["duration"]; ok {
+		var value string
+		if err := json.Unmarshal(raw, &value); err != nil {
+			return err
+		}
+		r.Duration = &value
+	}
+	if raw, ok := fields["mode"]; ok {
+		var value string
+		if err := json.Unmarshal(raw, &value); err != nil {
+			return err
+		}
+		r.Mode = &value
+	}
+	if raw, ok := fields["paused_until"]; ok {
+		r.hasPausedUntil = true
+		if bytes.Equal(bytes.TrimSpace(raw), []byte("null")) {
+			return fmt.Errorf("paused_until must be an RFC3339 timestamp")
+		}
+		var value time.Time
+		if err := json.Unmarshal(raw, &value); err != nil {
+			return err
+		}
+		r.PausedUntil = &value
+	}
+	return nil
 }

--- a/modules/notification/model.go
+++ b/modules/notification/model.go
@@ -38,16 +38,15 @@ type updatePauseRequest struct {
 }
 
 func (r *updatePauseRequest) UnmarshalJSON(data []byte) error {
+	*r = updatePauseRequest{}
 	var fields map[string]json.RawMessage
 	if err := json.Unmarshal(data, &fields); err != nil {
 		return err
 	}
-	for name := range fields {
-		if name != "duration" && name != "mode" && name != "paused_until" {
-			return fmt.Errorf("unknown notification pause field %q", name)
-		}
-	}
 	if raw, ok := fields["duration"]; ok {
+		if bytes.Equal(bytes.TrimSpace(raw), []byte("null")) {
+			return fmt.Errorf("duration must be a string")
+		}
 		var value string
 		if err := json.Unmarshal(raw, &value); err != nil {
 			return err
@@ -55,6 +54,9 @@ func (r *updatePauseRequest) UnmarshalJSON(data []byte) error {
 		r.Duration = &value
 	}
 	if raw, ok := fields["mode"]; ok {
+		if bytes.Equal(bytes.TrimSpace(raw), []byte("null")) {
+			return fmt.Errorf("mode must be a string")
+		}
 		var value string
 		if err := json.Unmarshal(raw, &value); err != nil {
 			return err

--- a/modules/notification/model.go
+++ b/modules/notification/model.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 )
 
@@ -43,7 +44,7 @@ func (r *updatePauseRequest) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &fields); err != nil {
 		return err
 	}
-	if raw, ok := fields["duration"]; ok {
+	if raw, ok := pauseField(fields, "duration"); ok {
 		if bytes.Equal(bytes.TrimSpace(raw), []byte("null")) {
 			return fmt.Errorf("duration must be a string")
 		}
@@ -53,7 +54,7 @@ func (r *updatePauseRequest) UnmarshalJSON(data []byte) error {
 		}
 		r.Duration = &value
 	}
-	if raw, ok := fields["mode"]; ok {
+	if raw, ok := pauseField(fields, "mode"); ok {
 		if bytes.Equal(bytes.TrimSpace(raw), []byte("null")) {
 			return fmt.Errorf("mode must be a string")
 		}
@@ -63,7 +64,7 @@ func (r *updatePauseRequest) UnmarshalJSON(data []byte) error {
 		}
 		r.Mode = &value
 	}
-	if raw, ok := fields["paused_until"]; ok {
+	if raw, ok := pauseField(fields, "paused_until"); ok {
 		r.hasPausedUntil = true
 		if bytes.Equal(bytes.TrimSpace(raw), []byte("null")) {
 			return fmt.Errorf("paused_until must be an RFC3339 timestamp")
@@ -75,4 +76,16 @@ func (r *updatePauseRequest) UnmarshalJSON(data []byte) error {
 		r.PausedUntil = &value
 	}
 	return nil
+}
+
+func pauseField(fields map[string]json.RawMessage, name string) (json.RawMessage, bool) {
+	if value, ok := fields[name]; ok {
+		return value, true
+	}
+	for key, value := range fields {
+		if strings.EqualFold(key, name) {
+			return value, true
+		}
+	}
+	return nil, false
 }

--- a/modules/notification/model.go
+++ b/modules/notification/model.go
@@ -44,7 +44,9 @@ func (r *updatePauseRequest) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &fields); err != nil {
 		return err
 	}
-	if raw, ok := pauseField(fields, "duration"); ok {
+	if raw, ok, err := pauseField(fields, "duration"); err != nil {
+		return err
+	} else if ok {
 		if bytes.Equal(bytes.TrimSpace(raw), []byte("null")) {
 			return fmt.Errorf("duration must be a string")
 		}
@@ -54,7 +56,9 @@ func (r *updatePauseRequest) UnmarshalJSON(data []byte) error {
 		}
 		r.Duration = &value
 	}
-	if raw, ok := pauseField(fields, "mode"); ok {
+	if raw, ok, err := pauseField(fields, "mode"); err != nil {
+		return err
+	} else if ok {
 		if bytes.Equal(bytes.TrimSpace(raw), []byte("null")) {
 			return fmt.Errorf("mode must be a string")
 		}
@@ -64,7 +68,9 @@ func (r *updatePauseRequest) UnmarshalJSON(data []byte) error {
 		}
 		r.Mode = &value
 	}
-	if raw, ok := pauseField(fields, "paused_until"); ok {
+	if raw, ok, err := pauseField(fields, "paused_until"); err != nil {
+		return err
+	} else if ok {
 		r.hasPausedUntil = true
 		if bytes.Equal(bytes.TrimSpace(raw), []byte("null")) {
 			return fmt.Errorf("paused_until must be an RFC3339 timestamp")
@@ -78,14 +84,21 @@ func (r *updatePauseRequest) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func pauseField(fields map[string]json.RawMessage, name string) (json.RawMessage, bool) {
-	if value, ok := fields[name]; ok {
-		return value, true
-	}
-	for key, value := range fields {
+func pauseField(fields map[string]json.RawMessage, name string) (json.RawMessage, bool, error) {
+	var value json.RawMessage
+	found := 0
+	for key, candidate := range fields {
 		if strings.EqualFold(key, name) {
-			return value, true
+			value = candidate
+			found++
 		}
 	}
-	return nil, false
+	if found > 1 {
+		return nil, false, fmt.Errorf("duplicate %s field", name)
+	}
+	return value, found == 1, nil
+}
+
+func pauseModeMatches(value *string, want string) bool {
+	return value != nil && strings.EqualFold(strings.TrimSpace(*value), want)
 }

--- a/modules/notification/model.go
+++ b/modules/notification/model.go
@@ -40,6 +40,9 @@ type updatePauseRequest struct {
 
 func (r *updatePauseRequest) UnmarshalJSON(data []byte) error {
 	*r = updatePauseRequest{}
+	if err := rejectDuplicatePauseKeys(data); err != nil {
+		return err
+	}
 	var fields map[string]json.RawMessage
 	if err := json.Unmarshal(data, &fields); err != nil {
 		return err
@@ -99,6 +102,35 @@ func pauseField(fields map[string]json.RawMessage, name string) (json.RawMessage
 	return value, found == 1, nil
 }
 
-func pauseModeMatches(value *string, want string) bool {
-	return value != nil && strings.EqualFold(strings.TrimSpace(*value), want)
+func rejectDuplicatePauseKeys(data []byte) error {
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	token, err := decoder.Token()
+	if err != nil {
+		return err
+	}
+	delim, ok := token.(json.Delim)
+	if !ok || delim != '{' {
+		return nil
+	}
+	seen := make(map[string]struct{})
+	for decoder.More() {
+		token, err := decoder.Token()
+		if err != nil {
+			return err
+		}
+		key, ok := token.(string)
+		if !ok {
+			return fmt.Errorf("invalid object key")
+		}
+		if _, exists := seen[key]; exists {
+			return fmt.Errorf("duplicate %s field", key)
+		}
+		seen[key] = struct{}{}
+		var value json.RawMessage
+		if err := decoder.Decode(&value); err != nil {
+			return err
+		}
+	}
+	_, err = decoder.Token()
+	return err
 }

--- a/modules/notification/sql/20260814000001_notification_pause_mode.sql
+++ b/modules/notification/sql/20260814000001_notification_pause_mode.sql
@@ -1,7 +1,16 @@
 -- +migrate Up
 
-ALTER TABLE `user_notification_pause`
-  ADD COLUMN IF NOT EXISTS `mode` VARCHAR(16) NULL AFTER `uid`;
+-- MySQL 8 has no ADD COLUMN IF NOT EXISTS. The migration runner normally
+-- applies this once, while this guard also handles a reused database whose
+-- schema already contains the column but whose migration ledger does not.
+SET @mode_col_exists = (SELECT COUNT(*) FROM information_schema.columns
+  WHERE table_schema = DATABASE() AND table_name = 'user_notification_pause' AND column_name = 'mode');
+SET @mode_add_sql = IF(@mode_col_exists = 0,
+  'ALTER TABLE `user_notification_pause` ADD COLUMN `mode` VARCHAR(16) NULL AFTER `uid`',
+  'SELECT 1');
+PREPARE mode_add_stmt FROM @mode_add_sql;
+EXECUTE mode_add_stmt;
+DEALLOCATE PREPARE mode_add_stmt;
 
 -- +migrate Down
 

--- a/modules/notification/sql/20260814000001_notification_pause_mode.sql
+++ b/modules/notification/sql/20260814000001_notification_pause_mode.sql
@@ -1,7 +1,7 @@
 -- +migrate Up
 
 ALTER TABLE `user_notification_pause`
-  ADD COLUMN `mode` VARCHAR(16) NULL AFTER `uid`;
+  ADD COLUMN IF NOT EXISTS `mode` VARCHAR(16) NULL AFTER `uid`;
 
 -- +migrate Down
 

--- a/modules/notification/sql/20260814000001_notification_pause_mode.sql
+++ b/modules/notification/sql/20260814000001_notification_pause_mode.sql
@@ -1,0 +1,9 @@
+-- +migrate Up
+
+ALTER TABLE `user_notification_pause`
+  ADD COLUMN `mode` VARCHAR(16) NULL AFTER `uid`;
+
+-- +migrate Down
+
+ALTER TABLE `user_notification_pause`
+  DROP COLUMN `mode`;

--- a/modules/notification/sql/20260814000001_notification_pause_mode.sql
+++ b/modules/notification/sql/20260814000001_notification_pause_mode.sql
@@ -5,5 +5,7 @@ ALTER TABLE `user_notification_pause`
 
 -- +migrate Down
 
+-- Dropping this column irreversibly loses active manual pauses. Roll back only
+-- with a state backup and an explicit customer-impact decision.
 ALTER TABLE `user_notification_pause`
   DROP COLUMN `mode`;

--- a/modules/notification/swagger/api.yaml
+++ b/modules/notification/swagger/api.yaml
@@ -71,6 +71,9 @@ components:
   schemas:
     SetNotificationPause:
       type: object
+      minProperties: 1
+      maxProperties: 1
+      additionalProperties: false
       properties:
         duration:
           type: string

--- a/modules/notification/swagger/api.yaml
+++ b/modules/notification/swagger/api.yaml
@@ -71,18 +71,29 @@ components:
   schemas:
     SetNotificationPause:
       type: object
-      required: [paused_until]
       properties:
+        duration:
+          type: string
+          enum: [30m, 1h]
+          description: Fixed duration calculated by the server
+        mode:
+          type: string
+          enum: [manual]
+          description: Pause until the user explicitly restores notifications
         paused_until:
           type: string
           format: date-time
-          description: UTC absolute time later than server time
+          description: UTC absolute time later than server time; mutually exclusive with duration and mode
     NotificationPause:
       type: object
-      required: [paused, paused_until, revision, server_time]
+      required: [paused, mode, paused_until, revision, server_time]
       properties:
         paused:
           type: boolean
+        mode:
+          type: string
+          enum: [timed, manual]
+          nullable: true
         paused_until:
           type: string
           format: date-time
@@ -96,6 +107,7 @@ components:
           format: date-time
       example:
         paused: true
+        mode: timed
         paused_until: '2026-08-12T12:30:00.000Z'
         revision: 42
         server_time: '2026-08-12T11:30:00.125Z'

--- a/modules/notification/swagger/api.yaml
+++ b/modules/notification/swagger/api.yaml
@@ -71,22 +71,26 @@ components:
   schemas:
     SetNotificationPause:
       type: object
-      minProperties: 1
-      maxProperties: 1
-      additionalProperties: false
-      properties:
-        duration:
-          type: string
-          enum: [30m, 1h]
-          description: Fixed duration calculated by the server
-        mode:
-          type: string
-          enum: [manual]
-          description: Pause until the user explicitly restores notifications
-        paused_until:
-          type: string
-          format: date-time
-          description: UTC absolute time later than server time; mutually exclusive with duration and mode
+      oneOf:
+        - required: [duration]
+          properties:
+            duration:
+              type: string
+              enum: [30m, 1h]
+              description: Fixed duration calculated by the server
+        - required: [mode]
+          properties:
+            mode:
+              type: string
+              enum: [manual]
+              description: Pause until the user explicitly restores notifications
+        - required: [paused_until]
+          properties:
+            paused_until:
+              type: string
+              format: date-time
+              description: UTC absolute time later than server time; mutually exclusive with duration and mode
+      description: Exactly one pause intent; unknown extension fields are accepted for forward compatibility
     NotificationPause:
       type: object
       required: [paused, mode, paused_until, revision, server_time]


### PR DESCRIPTION
## Summary

Add an explicit account-level notification pause mode that remains active until the user restores notifications, while preserving timed and custom pauses.

## Related Issue

N/A — implementation follows the approved notification pause plan.

## Linked Spec

[.octospec/tasks/notification-pause-manual-mode/brief.md](https://github.com/Mininglamp-OSS/octo-server/blob/fix/notification-pause-manual-mode/.octospec/tasks/notification-pause-manual-mode/brief.md)

## Changes

- Add nullable notification pause `mode` persistence and migration.
- Support server-calculated `duration` values `30m` and `1h`.
- Support explicit `mode: manual`, which stays active until DELETE.
- Reject ambiguous, unsupported, unknown, timezone-less, expired, and over-limit requests through the existing localized error envelope.
- Unify REST and notification-pause CMD responses with `paused`, `mode`, `paused_until`, `revision`, and `server_time`.
- Keep legacy future `paused_until` rows compatible as timed pauses and filter manual pauses in webhook delivery.

## Testing

- [x] Unit tests added/updated
- [ ] Manually verified

Passed:

- `go test ./modules/notification ./pkg/errcode`
- Focused webhook pause-filter tests
- `go vet ./modules/notification ./modules/webhook ./pkg/errcode`
- `make i18n-extract-check`
- `go run ./tools/lint-direct-error-response`
- `git diff --check`

The MySQL round-trip integration test skips when MySQL is unavailable locally and will run in CI.

## COMPREHENSION

1. **What does this change actually do** to the load-bearing path?

   It makes the account pause state explicit in storage and response contracts. Timed pauses are evaluated against server time, while manual pauses bypass expiry and remain active until the DELETE transition. Webhook filtering consumes the same account-level active state.

2. **What could break** because of it (dependents + failure mode)?

   Existing rows and clients could break if legacy timed rows were interpreted as inactive or if REST and CMD fields diverged. The migration leaves legacy rows nullable, the read path treats a future legacy timestamp as timed, and the response/CMD builders share the same derived state. Invalid request combinations are rejected before persistence.

3. **How do you know it works** (specific test/repro/trace)?

   Service tests cover manual persistence semantics, fixed durations, response normalization, RFC3339 validation, mutual exclusion, and inactive/expired states. DB tests cover non-UTC MySQL round trips, and webhook tests cover paused-recipient filtering and lookup-error behavior.

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] PR description is in English
- [x] Added tests for my changes
- [x] Updated documentation
- [x] Followed commit message conventions (Conventional Commits)