### PR TITLE
feat(agent-mail): provision users on first gateway access

### DIFF
--- a/.octospec/tasks/agent-mail-auto-provisioning/brief.md
+++ b/.octospec/tasks/agent-mail-auto-provisioning/brief.md
@@ -1,0 +1,70 @@
+---
+type: Task
+title: "Task: agent-mail-auto-provisioning"
+description: "Provision the authenticated OCTO user and Space in octo-mail before proxying browser mail requests."
+tags: ["agent-mail", "auth", "space", "gateway", "provisioning"]
+timestamp: 2026-08-14T00:00:00Z
+slug: agent-mail-auto-provisioning
+source: self
+upstream: "https://github.com/Mininglamp-OSS/octo-server/issues/768"
+---
+
+# Task: agent-mail-auto-provisioning
+
+## Goal
+
+Make the existing authenticated Agent Mail gateway ensure that a normal OCTO
+user has an octo-mail owner identity for the current Space before the original
+WebAPI request is proxied. The browser must not call admin APIs or provide mail
+database identifiers.
+
+## Background
+
+The gateway already derives the subject from the OCTO session, validates the
+Space, signs an exact upstream request, and strips caller credentials. octo-mail
+currently requires a pre-created `issuer + subject + space_id` binding, so a
+fresh user receives an authentication failure until an operator manually
+creates mail directory rows.
+
+## Load-bearing list
+
+- auth: the OCTO session remains the only source of the subject.
+- space: provisioning is exact to the Space accepted by SpaceMiddleware.
+- trust boundary: only the existing request-bound gateway HMAC authenticates
+  the internal provisioning call.
+- wire contract: the original `/v1/mail-gateway/webapi/v0/*` request and response
+  remain unchanged.
+
+## Out of scope
+
+- No octo-web, CLI, or plugin changes.
+- No browser-supplied subject, Space, tenant, domain, account, or address IDs.
+- No change to mail message, draft, authorization, or mailbox business APIs.
+- No removal of octo-mail admin APIs.
+
+## Acceptance
+
+- A valid authenticated UID and validated Space are provisioned before proxying.
+- The preferred mailbox localpart comes from server-owned user data, never the
+  browser request.
+- Concurrent first requests for one UID and Space collapse to one provisioning
+  operation; successful results are cached per process.
+- Provisioning failure prevents the original request from reaching octo-mail.
+- Existing proxy request/response, header stripping, size limits, and signing
+  behavior remain covered by tests.
+
+## Reuse decisions
+
+- Reuse the current `gatewayConfig`, hardened HTTP client, upstream URL base,
+  request-bound `signAssertion`, and localized gateway error envelope.
+- Reuse the authenticated UID and `SpaceMiddleware` result; no second auth or
+  Space lookup path is introduced.
+- Reuse the repository's established `singleflight` + in-process cache pattern
+  to collapse concurrent first-use work.
+- Read the preferred localpart from the existing server-owned `user` record;
+  do not create a parallel profile store or import frontend data.
+
+## Related work
+
+- `Mininglamp-OSS/octo-mail#55` provides the trusted internal provisioning
+  endpoint called by this gateway path.

--- a/.octospec/tasks/agent-mail-auto-provisioning/context.yaml
+++ b/.octospec/tasks/agent-mail-auto-provisioning/context.yaml
@@ -1,0 +1,22 @@
+brief: .octospec/tasks/agent-mail-auto-provisioning/brief.md
+injected:
+  - id: space-isolation
+    source: repo
+    reason: "Provisioning binds an authenticated UID to an exact validated Space."
+  - id: error-handling
+    source: repo
+    reason: "Provisioning failures use the existing localized gateway error envelope."
+  - id: rate-limit
+    source: repo
+    reason: "The change stays behind the existing authenticated shared UID limiter."
+  - id: testing
+    source: repo
+    reason: "The gateway trust boundary and concurrency path require regressions."
+  - id: commit-style
+    source: repo
+    reason: "Repository commit and PR convention."
+files_expected:
+  - modules/agentmailgateway/gateway.go
+  - modules/agentmailgateway/provisioning.go
+  - modules/agentmailgateway/gateway_test.go
+updated_at: 2026-08-14T00:00:00Z

--- a/modules/agentmailgateway/gateway.go
+++ b/modules/agentmailgateway/gateway.go
@@ -22,8 +22,10 @@ import (
 	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
 	spacepkg "github.com/Mininglamp-OSS/octo-server/pkg/space"
 	appwkhttp "github.com/Mininglamp-OSS/octo-server/pkg/wkhttp"
+	lru "github.com/hashicorp/golang-lru/v2"
 	"go.uber.org/zap"
 	"golang.org/x/sync/semaphore"
+	"golang.org/x/sync/singleflight"
 )
 
 const (
@@ -40,6 +42,7 @@ const (
 	maxInFlightRequestBodyBytes = maxConcurrentLargeRequests * maxRequestBytes
 	defaultLargeRequestSlotWait = 5 * time.Second
 	defaultTimeout              = 30 * time.Second
+	provisioningCacheEntries    = 4096
 )
 
 var allowedMethods = map[string]struct{}{
@@ -76,6 +79,10 @@ type Gateway struct {
 	largeRequestSlots    chan struct{}
 	largeRequestSlotWait time.Duration
 	requestBodyBudget    *semaphore.Weighted
+	provisionIdentity    func(context.Context, string, string) error
+	resolveLocalpart     func(context.Context, string) (string, error)
+	provisioned          *lru.Cache[string, struct{}]
+	provisioningFlights  singleflight.Group
 }
 
 func New(ctx *config.Context) *Gateway {
@@ -98,6 +105,13 @@ func New(ctx *config.Context) *Gateway {
 		}
 	}
 	g.client = newGatewayHTTPClient(cfg.timeout)
+	if cache, cacheErr := lru.New[string, struct{}](provisioningCacheEntries); cacheErr == nil {
+		g.provisioned = cache
+	} else {
+		g.Error("Agent Mail provisioning cache is unavailable", zap.Error(cacheErr))
+	}
+	g.provisionIdentity = g.provisionGatewayIdentity
+	g.resolveLocalpart = g.gatewayLocalpart
 	return g
 }
 
@@ -197,6 +211,11 @@ func (g *Gateway) proxy(c *wkhttp.Context) {
 	}
 	if c.Request.ContentLength > maxRequestBytes {
 		respondGatewayError(c, errcode.ErrAgentMailGatewayPayloadTooLarge)
+		return
+	}
+	if err := g.ensureProvisioned(c.Request.Context(), uid, spaceID); err != nil {
+		g.Warn("Failed to provision Agent Mail gateway identity", zap.String("uid", uid), zap.String("space_id", spaceID), zap.Error(err))
+		respondGatewayError(c, errcode.ErrAgentMailGatewayUnavailable)
 		return
 	}
 	releaseLargeRequest, err := g.acquireLargeRequestSlot(c.Request)

--- a/modules/agentmailgateway/gateway_test.go
+++ b/modules/agentmailgateway/gateway_test.go
@@ -1184,6 +1184,8 @@ func newTestGateway(t *testing.T, upstreamURL string, secret []byte, now time.Ti
 		largeRequestSlots:    make(chan struct{}, maxConcurrentLargeRequests),
 		largeRequestSlotWait: defaultLargeRequestSlotWait,
 		requestBodyBudget:    semaphore.NewWeighted(maxInFlightRequestBodyBytes),
+		provisionIdentity:    func(context.Context, string, string) error { return nil },
+		resolveLocalpart:     func(context.Context, string) (string, error) { return "test-user", nil },
 	}
 }
 

--- a/modules/agentmailgateway/provisioning.go
+++ b/modules/agentmailgateway/provisioning.go
@@ -1,0 +1,187 @@
+package agentmailgateway
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+const (
+	gatewayProvisioningPath     = "/internal/v0/gateway-identities/ensure"
+	maxProvisioningResponseSize = 8 << 10
+)
+
+type provisioningUserIdentity struct {
+	Username string `db:"username"`
+	ShortNo  string `db:"short_no"`
+}
+
+func (g *Gateway) ensureProvisioned(ctx context.Context, uid, spaceID string) error {
+	key := uid + "\x00" + spaceID
+	if g.provisioned != nil {
+		if _, ok := g.provisioned.Get(key); ok {
+			return nil
+		}
+	}
+	if g.provisionIdentity == nil {
+		return fmt.Errorf("gateway provisioning is not configured")
+	}
+	result := g.provisioningFlights.DoChan(key, func() (any, error) {
+		if g.provisioned != nil {
+			if _, ok := g.provisioned.Get(key); ok {
+				return nil, nil
+			}
+		}
+		provisionCtx, cancel := context.WithTimeout(
+			context.WithoutCancel(ctx), normalizedGatewayTimeout(g.cfg.timeout),
+		)
+		defer cancel()
+		if err := g.provisionIdentity(provisionCtx, uid, spaceID); err != nil {
+			return nil, err
+		}
+		if g.provisioned != nil {
+			g.provisioned.Add(key, struct{}{})
+		}
+		return nil, nil
+	})
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case completed := <-result:
+		return completed.Err
+	}
+}
+
+func (g *Gateway) provisionGatewayIdentity(ctx context.Context, uid, spaceID string) error {
+	if g.resolveLocalpart == nil {
+		return fmt.Errorf("gateway user identity resolver is unavailable")
+	}
+	localpart, err := g.resolveLocalpart(ctx, uid)
+	if err != nil {
+		return err
+	}
+	body, err := json.Marshal(map[string]string{"localpart": localpart})
+	if err != nil {
+		return fmt.Errorf("marshal gateway provisioning request: %w", err)
+	}
+	target, err := g.internalURL(gatewayProvisioningPath)
+	if err != nil {
+		return err
+	}
+	token, err := signAssertion(
+		g.cfg.secret, uid, spaceID, http.MethodPost, target.RequestURI(), body,
+		g.now(), g.nonceSource,
+	)
+	if err != nil {
+		return fmt.Errorf("sign gateway provisioning request: %w", err)
+	}
+	request, err := http.NewRequestWithContext(ctx, http.MethodPost, target.String(), bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("construct gateway provisioning request: %w", err)
+	}
+	request.Header.Set("Authorization", "Bearer "+token)
+	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("Accept", "application/json")
+	response, err := g.client.Do(request)
+	if err != nil {
+		return fmt.Errorf("gateway provisioning request: %w", err)
+	}
+	response.Body = newIdleTimeoutReadCloser(response.Body, normalizedGatewayTimeout(g.cfg.timeout), nil)
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		_, _ = io.Copy(io.Discard, io.LimitReader(response.Body, maxProvisioningResponseSize))
+		return fmt.Errorf("gateway provisioning returned %s", response.Status)
+	}
+	written, err := io.Copy(io.Discard, io.LimitReader(response.Body, maxProvisioningResponseSize+1))
+	if err != nil {
+		return fmt.Errorf("read gateway provisioning response: %w", err)
+	}
+	if written > maxProvisioningResponseSize {
+		return fmt.Errorf("gateway provisioning response is too large")
+	}
+	return nil
+}
+
+func (g *Gateway) gatewayLocalpart(ctx context.Context, uid string) (string, error) {
+	if g.ctx == nil || g.ctx.DB() == nil {
+		return "", fmt.Errorf("gateway user directory is unavailable")
+	}
+	var identity provisioningUserIdentity
+	if err := g.ctx.DB().Select(
+		"IFNULL(username,'') AS username", "IFNULL(short_no,'') AS short_no",
+	).From("`user`").Where(
+		"uid=? AND status=1 AND IFNULL(is_destroy,0)<>2", uid,
+	).LoadOneContext(ctx, &identity); err != nil {
+		return "", fmt.Errorf("resolve gateway user identity: %w", err)
+	}
+	return normalizeGatewayLocalpart(identity.Username, identity.ShortNo, uid), nil
+}
+
+func normalizeGatewayLocalpart(candidates ...string) string {
+	for _, candidate := range candidates {
+		if normalized := sanitizeGatewayLocalpart(candidate); normalized != "" {
+			return normalized
+		}
+	}
+	digest := sha256.Sum256([]byte(strings.Join(candidates, "\x00")))
+	return "user-" + hex.EncodeToString(digest[:6])
+}
+
+func sanitizeGatewayLocalpart(value string) string {
+	value = strings.ToLower(strings.TrimSpace(value))
+	var out strings.Builder
+	out.Grow(min(len(value), 64))
+	lastDot := false
+	var lastWritten byte
+	for i := 0; i < len(value) && out.Len() < 64; i++ {
+		ch := value[i]
+		alphaNumeric := ch >= 'a' && ch <= 'z' || ch >= '0' && ch <= '9'
+		if alphaNumeric {
+			out.WriteByte(ch)
+			lastWritten = ch
+			lastDot = false
+			continue
+		}
+		if out.Len() == 0 {
+			continue
+		}
+		switch ch {
+		case '.':
+			if !lastDot {
+				out.WriteByte(ch)
+				lastWritten = ch
+				lastDot = true
+			}
+		case '-', '_':
+			out.WriteByte(ch)
+			lastWritten = ch
+			lastDot = false
+		default:
+			if lastWritten != '-' {
+				out.WriteByte('-')
+				lastWritten = '-'
+			}
+			lastDot = false
+		}
+	}
+	return strings.TrimRight(out.String(), ".-_")
+}
+
+func (g *Gateway) internalURL(relativePath string) (*url.URL, error) {
+	if g.cfg.upstream == nil || relativePath == "" || relativePath[0] != '/' {
+		return nil, fmt.Errorf("missing gateway internal URL")
+	}
+	target := *g.cfg.upstream
+	target.Path = strings.TrimRight(g.cfg.upstream.Path, "/") + relativePath
+	target.RawPath = ""
+	target.RawQuery = ""
+	target.Fragment = ""
+	return &target, nil
+}

--- a/modules/agentmailgateway/provisioning_test.go
+++ b/modules/agentmailgateway/provisioning_test.go
@@ -1,0 +1,302 @@
+package agentmailgateway
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	lru "github.com/hashicorp/golang-lru/v2"
+)
+
+func TestProvisionGatewayIdentityUsesExistingSignedClientContract(t *testing.T) {
+	secret := []byte(strings.Repeat("g", 32))
+	fixedNow := time.Date(2026, 8, 14, 8, 0, 0, 0, time.UTC)
+	var calls atomic.Int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		if r.Method != http.MethodPost || r.URL.Path != gatewayProvisioningPath {
+			t.Errorf("provisioning request = %s %s", r.Method, r.URL.Path)
+		}
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("read provisioning body: %v", err)
+		}
+		if string(body) != `{"localpart":"guobin"}` {
+			t.Errorf("provisioning body = %s", body)
+		}
+		claims := verifyAssertionForTest(t, secret, strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer "))
+		if claims.Issuer != assertionIssuer || claims.Subject != "user-a" || claims.SpaceID != "space-a" ||
+			claims.Method != http.MethodPost || claims.RequestURI != gatewayProvisioningPath {
+			t.Errorf("provisioning claims = %#v", claims)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"created":true}`)
+	}))
+	defer upstream.Close()
+
+	gateway := newTestGateway(t, upstream.URL, secret, fixedNow)
+	cache, err := lru.New[string, struct{}](8)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gateway.provisioned = cache
+	gateway.nonceSource = bytes.NewReader(make([]byte, 32))
+	gateway.resolveLocalpart = func(_ context.Context, uid string) (string, error) {
+		if uid != "user-a" {
+			t.Fatalf("resolved uid = %q", uid)
+		}
+		return "guobin", nil
+	}
+	gateway.provisionIdentity = gateway.provisionGatewayIdentity
+
+	if err := gateway.ensureProvisioned(context.Background(), "user-a", "space-a"); err != nil {
+		t.Fatal(err)
+	}
+	if err := gateway.ensureProvisioned(context.Background(), "user-a", "space-a"); err != nil {
+		t.Fatal(err)
+	}
+	if calls.Load() != 1 {
+		t.Fatalf("provisioning calls = %d, want cached single call", calls.Load())
+	}
+}
+
+func TestProvisionGatewayIdentityBoundsStalledResponseBody(t *testing.T) {
+	gateway := newTestGateway(t, "http://octo-mail.test", []byte(strings.Repeat("g", 32)), time.Now())
+	gateway.cfg.timeout = 20 * time.Millisecond
+	stalled := newBlockingReadCloser()
+	gateway.client = &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: http.StatusOK, ContentLength: 1, Body: stalled}, nil
+	})}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- gateway.provisionGatewayIdentity(context.Background(), "user-a", "space-a")
+	}()
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("stalled provisioning response unexpectedly succeeded")
+		}
+	case <-time.After(250 * time.Millisecond):
+		_ = stalled.Close()
+		<-done
+		t.Fatal("stalled provisioning response outlived the gateway timeout")
+	}
+}
+
+func TestEnsureProvisionedCoalescesConcurrentFirstUse(t *testing.T) {
+	gateway := newTestGateway(t, "http://octo-mail.test", []byte(strings.Repeat("g", 32)), time.Now())
+	cache, err := lru.New[string, struct{}](8)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gateway.provisioned = cache
+	var calls atomic.Int32
+	started := make(chan struct{})
+	release := make(chan struct{})
+	gateway.provisionIdentity = func(context.Context, string, string) error {
+		if calls.Add(1) == 1 {
+			close(started)
+		}
+		<-release
+		return nil
+	}
+
+	const workers = 8
+	errs := make(chan error, workers)
+	var wg sync.WaitGroup
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			errs <- gateway.ensureProvisioned(context.Background(), "user-a", "space-a")
+		}()
+	}
+	<-started
+	close(release)
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	if calls.Load() != 1 {
+		t.Fatalf("concurrent provisioning calls = %d, want 1", calls.Load())
+	}
+}
+
+func TestEnsureProvisionedLeaderCancellationDoesNotPoisonFollowers(t *testing.T) {
+	gateway := newTestGateway(t, "http://octo-mail.test", []byte(strings.Repeat("g", 32)), time.Now())
+	gateway.cfg.timeout = 500 * time.Millisecond
+	cache, err := lru.New[string, struct{}](8)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gateway.provisioned = cache
+	var calls atomic.Int32
+	started := make(chan struct{})
+	release := make(chan struct{})
+	gateway.provisionIdentity = func(ctx context.Context, _, _ string) error {
+		if calls.Add(1) == 1 {
+			close(started)
+		}
+		select {
+		case <-release:
+			return nil
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+
+	leaderCtx, cancelLeader := context.WithCancel(context.Background())
+	leaderDone := make(chan error, 1)
+	go func() {
+		leaderDone <- gateway.ensureProvisioned(leaderCtx, "user-a", "space-a")
+	}()
+	<-started
+
+	followerDone := make(chan error, 1)
+	go func() {
+		followerDone <- gateway.ensureProvisioned(context.Background(), "user-a", "space-a")
+	}()
+	cancelLeader()
+	select {
+	case err := <-leaderDone:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("cancelled leader error = %v, want context.Canceled", err)
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("cancelled leader remained blocked on shared provisioning")
+	}
+
+	close(release)
+	select {
+	case err := <-followerDone:
+		if err != nil {
+			t.Fatalf("healthy follower inherited leader cancellation: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("healthy follower did not receive the shared provisioning result")
+	}
+	if calls.Load() != 1 {
+		t.Fatalf("provisioning calls = %d, want 1 shared call", calls.Load())
+	}
+}
+
+func TestEnsureProvisionedBoundsContinuouslyProgressingResponse(t *testing.T) {
+	gateway := newTestGateway(t, "http://octo-mail.test", []byte(strings.Repeat("g", 32)), time.Now())
+	gateway.cfg.timeout = 30 * time.Millisecond
+	gateway.client = &http.Client{Transport: roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body: &contextDripReadCloser{
+				ctx:      request.Context(),
+				interval: 5 * time.Millisecond,
+			},
+		}, nil
+	})}
+	gateway.provisionIdentity = gateway.provisionGatewayIdentity
+
+	startedAt := time.Now()
+	err := gateway.ensureProvisioned(context.Background(), "user-a", "space-a")
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("continuously progressing response error = %v, want context deadline", err)
+	}
+	if elapsed := time.Since(startedAt); elapsed > 250*time.Millisecond {
+		t.Fatalf("continuously progressing response outlived total timeout: %v", elapsed)
+	}
+}
+
+func TestEnsureProvisionedCacheHitRefreshesLRURecency(t *testing.T) {
+	gateway := newTestGateway(t, "http://octo-mail.test", []byte(strings.Repeat("g", 32)), time.Now())
+	cache, err := lru.New[string, struct{}](2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gateway.provisioned = cache
+	keyA := "user-a\x00space-a"
+	keyB := "user-b\x00space-a"
+	keyC := "user-c\x00space-a"
+	cache.Add(keyA, struct{}{})
+	cache.Add(keyB, struct{}{})
+
+	if err := gateway.ensureProvisioned(context.Background(), "user-a", "space-a"); err != nil {
+		t.Fatal(err)
+	}
+	cache.Add(keyC, struct{}{})
+
+	if !cache.Contains(keyA) || !cache.Contains(keyC) || cache.Contains(keyB) {
+		t.Fatalf("cache recency = A:%v B:%v C:%v, want A and C retained",
+			cache.Contains(keyA), cache.Contains(keyB), cache.Contains(keyC))
+	}
+}
+
+func TestProxyDoesNotReachBusinessUpstreamWhenProvisioningFails(t *testing.T) {
+	secret := []byte(strings.Repeat("g", 32))
+	gateway := newTestGateway(t, "http://octo-mail.test", secret, time.Now())
+	gateway.provisionIdentity = func(context.Context, string, string) error {
+		return errors.New("provisioning unavailable")
+	}
+	var upstreamCalls atomic.Int32
+	gateway.client = &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		upstreamCalls.Add(1)
+		return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader("ok"))}, nil
+	})}
+
+	recorder := httptest.NewRecorder()
+	newProxyRouter(gateway, "user-a", "space-a").ServeHTTP(
+		recorder, httptest.NewRequest(http.MethodGet, "/v1/mail-gateway/webapi/v0/mailboxes", nil),
+	)
+	if recorder.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
+	}
+	if upstreamCalls.Load() != 0 {
+		t.Fatalf("failed provisioning reached upstream %d times", upstreamCalls.Load())
+	}
+}
+
+func TestNormalizeGatewayLocalpartUsesStableServerIdentifiers(t *testing.T) {
+	for name, test := range map[string]struct {
+		candidates []string
+		want       string
+	}{
+		"username":              {[]string{" Guo.Bin ", "1001", "uid-a"}, "guo.bin"},
+		"fallback short number": {[]string{"中文", "1001", "uid-a"}, "1001"},
+		"sanitize":              {[]string{"Alice / Ops", "", "uid-a"}, "alice-ops"},
+		"collapse dots":         {[]string{"alice..ops", "", "uid-a"}, "alice.ops"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if got := normalizeGatewayLocalpart(test.candidates...); got != test.want {
+				t.Fatalf("normalized localpart = %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
+type contextDripReadCloser struct {
+	ctx      context.Context
+	interval time.Duration
+}
+
+func (r *contextDripReadCloser) Read(dst []byte) (int, error) {
+	timer := time.NewTimer(r.interval)
+	defer timer.Stop()
+	select {
+	case <-r.ctx.Done():
+		return 0, r.ctx.Err()
+	case <-timer.C:
+		dst[0] = 'x'
+		return 1, nil
+	}
+}
+
+func (*contextDripReadCloser) Close() error { return nil }


### PR DESCRIPTION
## Summary

Provision the authenticated OCTO user and current Space in octo-mail before the Agent Mail gateway proxies the user's first browser request.

## Related Issue

Fixes #768

Related octo-mail endpoint: Mininglamp-OSS/octo-mail#55

## Linked Spec

- `.octospec/tasks/agent-mail-auto-provisioning/brief.md`

## Changes

- Reuse the authenticated UID, validated Space, gateway configuration, hardened HTTP client, and request-bound HMAC assertion to call octo-mail's internal provisioning endpoint.
- Resolve the preferred mailbox localpart from the existing server-owned user record.
- Collapse concurrent first requests and cache successful provisioning per UID and Space.
- Run shared provisioning under an independent total deadline, let cancelled callers stop waiting, and refresh LRU recency on cache hits.
- Stop the original proxy request when provisioning fails while preserving existing proxy request/response and header handling.
- Add trust-boundary, cache, concurrency, localpart normalization, and failure-path tests.

## Testing

- [x] Unit tests added/updated
- [x] Manually verified

- `go test ./modules/agentmailgateway/... -count=1` — passed
- `go test -race ./modules/agentmailgateway/... -count=10` — passed
- `go vet ./modules/agentmailgateway/...` — passed
- `go build ./...` — passed
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run ./modules/agentmailgateway/... --timeout=5m` — `0 issues`
- `git diff --check` — passed
- The repository-wide local test command also requires its test MySQL listener on `127.0.0.1:3306`; the focused module suite and static gates above completed locally, and the full suite is left to CI's test services.

## COMPREHENSION

1. **What does this change actually do** to the load-bearing path?

   After session authentication and Space validation, but before forwarding the browser request, the gateway signs one internal provisioning request for the exact UID and Space. octo-mail idempotently ensures the owner identity, then the existing WebAPI proxy path continues unchanged.

2. **What could break** because of it (dependents + failure mode)?

   First access now depends on the internal provisioning endpoint. A provisioning error returns the existing localized gateway-unavailable response and does not forward the business request; successful UID/Space pairs are cached to avoid adding an upstream call to every request.

3. **How do you know it works** (specific test/repro/trace)?

   Tests verify the signed method, URI, body, subject, and Space; concurrent first requests collapse to one call; a failed provision never reaches the business upstream; and existing gateway tests continue through a no-op provisioner without changing proxy behavior.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] PR description is in English
- [x] Added tests for my changes
- [x] Updated documentation
- [x] Followed commit message conventions (Conventional Commits)

