### PR TITLE
fix(file): keep presigned-upload signed headers stable under SigV4 Trimall

### DIFF
--- a/.octospec/tasks/presigned-upload-signed-header-whitespace/brief.md
+++ b/.octospec/tasks/presigned-upload-signed-header-whitespace/brief.md
@@ -49,10 +49,17 @@ MinIO 后端从不暴露该缺陷：MinIO server 自带同一份 `signV4TrimAll`
 
 ## Load-bearing list
 
-- `BuildContentDisposition` 的输出形状——被 4 个模块 5 处调用（`file`、`robot` ×2、
-  `bot_api` ×2），同时用于预签名 PUT 与服务端 multipart `UploadFile`。
+- `BuildContentDisposition` 的输出形状——被 **3 个模块 6 处**调用：
+  `modules/file/api.go:626`（multipart `uploadFile`）与 `:945`（`getUploadCredentials`）、
+  `modules/robot/api.go:2085` 与 `:2233`、`modules/bot_api/file.go:90` 与 `:285`。
+  同时用于预签名 PUT 与服务端 multipart `UploadFile`。
 - `/v1/file/upload/credentials` 的 wire contract：`contentDisposition` 与
   `contentType` 均由客户端**逐字节回传**，任何一侧变动都会改变 PUT 成败。
+  `contentType` 的默认值改为在**折叠之后**兜底（原先在折叠之前），且带非法
+  header 字节时回退默认值而非替换为 `_`——mangle 出一个调用方没要过的 MIME
+  类型，比给个诚实的 `application/octet-stream` 更糟。副作用：纯空白
+  `contentType` 这条边路上，`Content-Type` 从「不进签名头集合」变成「进」，
+  客户端必须按契约回传（octo-web 已经如此）。
 - 三个 SigV4 后端（COS / MinIO / S3）的签名头集合。
 - 存储对象上的 `Content-Disposition` 元数据（影响裸 `downloadUrl` 的下载名）。
 - `modules/bot_api`、`modules/robot` 的调用点**不做 `sanitizeFilename`**，原始
@@ -77,6 +84,11 @@ MinIO 后端从不暴露该缺陷：MinIO server 自带同一份 `signV4TrimAll`
 
 - `TestIssue760_SignedHeaderInvariant`：`BuildContentDisposition` 的输出必须是
   `signV4TrimAll` 的**不动点**（比枚举文件名严格）。
+- `TestGetUploadCredentials_ContentTypeContract`：**驱动 handler 本身**，断言
+  `resp["contentType"]` 是 Trimall 不动点、是合法 header 值、且与交给 service 的
+  值相等。用 `.ini`（白名单内且无 MIME 映射）承载调用方原值，否则
+  `mime.TypeByExtension` 会覆盖掉它、测试沦为空转。经变异验证：摘掉
+  `normalizeUploadContentType` 该测试变红。
 - `TestIssue760_EchoedContentTypeMatchesSigned`：回显给客户端的 `contentType`
   必须与最终被签名的值**相等**，且对两套 Trimall 规则稳定。
 - `TestIssue760_Sweep*`：全部 128 个 ASCII 码位 × 4 个位置 × 长度 1–3 的连续串、

--- a/.octospec/tasks/presigned-upload-signed-header-whitespace/brief.md
+++ b/.octospec/tasks/presigned-upload-signed-header-whitespace/brief.md
@@ -1,0 +1,92 @@
+---
+type: Task
+title: "Task: presigned-upload-signed-header-whitespace"
+description: 文件名含连续半角空格时预签名 PUT 在腾讯 COS 稳定 403 SignatureDoesNotMatch。根因是 minio-go 的 signV4TrimAll 会折叠引号内空白、而 COS 按 AWS 规范保留，两侧 canonical 不同。修法是让签名头本身成为 Trimall 不动点；用户文件名不变，仍由 filename* 无损承载。同一机制在 Content-Type 上有第二个可达向量。
+tags: ["wire-contract", "bot-api", "testing", "commit"]
+timestamp: 2026-08-17T13:10:00+08:00
+# --- octospec extension fields ---
+slug: presigned-upload-signed-header-whitespace
+upstream: Mininglamp-OSS/octo-server#760
+source: self
+---
+
+# Task: presigned-upload-signed-header-whitespace
+
+> One task = one `.octospec/tasks/<slug>/` directory. This brief is the spec for
+> the work. AI may draft it from existing code; a human confirms it.
+
+## Goal
+
+让预签名 PUT 的**签名头在两套 SigV4 canonical 规则下取值相同**，从而消除
+GH#760：文件名中出现 **≥2 个连续 `U+0020`** 时，浏览器直传腾讯 COS 稳定返回
+`403 SignatureDoesNotMatch`，与文件字节、大小、格式、扩展名均无关。
+
+用户的文件名**不做任何改动**——原始名（含连续空格）仍由 RFC 5987 `filename*`
+无损承载（空格编码为 `%20`），下载文件名不变。被归一化的只有带引号的 ASCII
+兼容回退 `filename="…"`，因为只有它会把字面空白送进签名。
+
+## Background
+
+`getUploadCredentials` → `BuildContentDisposition` → `ServiceCOS.PresignedPutURL`
+→ minio-go `PresignHeader`。SigV4 对每个签名头值取 **canonical 形式**再哈希，而
+两侧的 canonical 规则不同：
+
+- minio-go v7.0.61 `pkg/signer/utils.go` 的 `signV4TrimAll` 是
+  `strings.Join(strings.Fields(v), " ")` —— 折叠**任意位置**的空白串，**包括引号内**；
+- AWS SigV4 规范明确 *"Do not trim excess white space in a header value if it
+  appears within a quoted string"*，腾讯 COS 遵守该例外，保留引号内空白。
+
+于是 `inline; filename="a  b.pdf"` 被**签成** `filename="a b.pdf"`、被**验成**
+`filename="a  b.pdf"`，canonical request 不同 → 签名不同 → 403。
+
+MinIO 后端从不暴露该缺陷：MinIO server 自带同一份 `signV4TrimAll`，两侧同样折叠。
+这解释了为什么本地/自建环境复现不出来，只有 COS（及遵守同一例外的 AWS S3）中招。
+
+历史：octo-web#348 自 2026-06-01 开放至今，4 位用户独立反馈。octo-server PR#219
+（"stop signing Content-Disposition into presigned upload PUT"）方向正确但根因描述
+错误（归因于「浏览器/代理/网关规范化不一致」），经 3 人 approve 后于 2026-06-03 被
+作者关闭且未留说明；实测证明浏览器逐字节透传，改写发生在**服务端签名侧**。
+
+## Load-bearing list
+
+- `BuildContentDisposition` 的输出形状——被 4 个模块 5 处调用（`file`、`robot` ×2、
+  `bot_api` ×2），同时用于预签名 PUT 与服务端 multipart `UploadFile`。
+- `/v1/file/upload/credentials` 的 wire contract：`contentDisposition` 与
+  `contentType` 均由客户端**逐字节回传**，任何一侧变动都会改变 PUT 成败。
+- 三个 SigV4 后端（COS / MinIO / S3）的签名头集合。
+- 存储对象上的 `Content-Disposition` 元数据（影响裸 `downloadUrl` 的下载名）。
+- `modules/bot_api`、`modules/robot` 的调用点**不做 `sanitizeFilename`**，原始
+  multipart 文件名 / query 参数直达 `BuildContentDisposition`。
+
+## Out of scope
+
+- **真实 COS 验证**。全部证据来自本地按 AWS 规范实现的替身网关，未打过线上 COS。
+- **不采用 PR#219 的方案**（预签名不签 `Content-Disposition`）。该方案会让预签名
+  路径上传的对象失去存储态 disposition，公开 bucket 直链下载会退化为 UUID 名；
+  且不覆盖服务端 multipart 路径。两方案正交，本任务选择在 header 源头修。
+- **`bot_api` / `robot` 缺失的 `sanitizeFilename`**。本修复让 header 无论是否清洗
+  都安全，但清洗缺失本身是独立隐患，未处理。
+- **扩展名尾随空格**（`report.pdf ` → 凭证接口 400「不支持的文件类型」）。既有行为，
+  与 403 无关，未改。
+- **Aliyun OSS**。其 V1 string-to-sign 逐字包含 Content-Type、不含
+  Content-Disposition，不经 `presignPutHeaders`，未纳入本次不变量。
+- **octo-web**：通用「上传失败」文案（octo-web#1396）、失败态呈现（#1393）、
+  预签名接口被调两次（`precheckUploadCredentials` 的有意设计）。
+
+## Acceptance
+
+- `TestIssue760_SignedHeaderInvariant`：`BuildContentDisposition` 的输出必须是
+  `signV4TrimAll` 的**不动点**（比枚举文件名严格）。
+- `TestIssue760_EchoedContentTypeMatchesSigned`：回显给客户端的 `contentType`
+  必须与最终被签名的值**相等**，且对两套 Trimall 规则稳定。
+- `TestIssue760_Sweep*`：全部 128 个 ASCII 码位 × 4 个位置 × 长度 1–3 的连续串、
+  25 个 Unicode 空白码位、混合空白串、引号/反斜杠注入、20000 个定种子随机名，
+  逐一满足「两套 Trimall 不动点 + 合法 header 值 + 引号平衡」，且**清洗与未清洗
+  两条入口都跑**。
+- `TestIssue760_SweepIsNotVacuous`：同一判据对**修复前**的构造必须失败。
+- `TestIssue760_CharacterMatrix` / `ConsecutiveSpacesBreakPresignedPUT`：对
+  COS 规则网关，此前 403 的每一行现在 200，且 `filename*` 仍带 `%20%20`。
+- 回归对照：`modules/{file,robot,bot_api,botfather,group}` 的失败集合与
+  `origin/main` **完全一致**（差异仅为本地无 MySQL 导致的既有失败）。
+- `go build ./...`、`go vet ./modules/...`、`golangci-lint run ./modules/file/...`、
+  `make i18n-extract-check`、`make i18n-lint` 全部通过。

--- a/modules/file/api.go
+++ b/modules/file/api.go
@@ -897,6 +897,17 @@ func (f *File) getUploadCredentials(c *wkhttp.Context) {
 	if contentType == "" {
 		contentType = "application/octet-stream"
 	}
+	// GH#760: this value is BOTH signed into the presigned PUT and echoed to
+	// the client, which is contractually required to send it back verbatim —
+	// so it has to survive SigV4 Trimall unchanged for the same reason
+	// Content-Disposition does. The caller's raw query value reaches here
+	// whenever mime.TypeByExtension cannot resolve the extension, which is
+	// the norm in production: the prod image is alpine with no
+	// /etc/mime.types, so Go falls back to its small builtin table and
+	// .docx / .xlsx / .pptx / .zip all return "". A parameter such as
+	// `; name="a  b"` would then be signed collapsed and sent uncollapsed →
+	// 403 SignatureDoesNotMatch. Normalizing here keeps signed == echoed.
+	contentType = collapseSignableWhitespace(contentType)
 
 	// When both path and filename are provided, path determines the objectKey
 	// while filename is used for Content-Disposition (friendly download name).
@@ -1124,10 +1135,31 @@ func BuildContentDisposition(filename string) string {
 // %20 and is what every modern browser prefers; only the legacy fallback is
 // normalized.
 //
+// Remaining C0 controls and DEL are replaced with '_'. Collapsing only
+// removes the whitespace ones (`\t\n\v\f\r`); bytes like 0x01 or 0x7F would
+// otherwise reach the emitted header and make it an invalid HTTP header
+// value, which Go's transport rejects outright with "invalid header field
+// value" — so the credentials response would hand the client a
+// Content-Disposition it cannot send. Most callers never hit this because
+// they pre-sanitize, but modules/bot_api and modules/robot pass the raw
+// multipart filename / query parameter straight in, so the guarantee has to
+// live here. `filename*` is unaffected: percent-encoding already renders
+// those bytes as %XX.
+//
 // A name that collapses to nothing (all-whitespace) degrades to "file" rather
 // than emitting an empty `filename=""`.
 func quotedFilenameFallback(safe string) string {
 	collapsed := collapseSignableWhitespace(safe)
+	var b strings.Builder
+	b.Grow(len(collapsed))
+	for i := 0; i < len(collapsed); i++ {
+		if c := collapsed[i]; c < 0x20 || c == 0x7F {
+			b.WriteByte('_')
+			continue
+		}
+		b.WriteByte(collapsed[i])
+	}
+	collapsed = b.String()
 	if collapsed == "" {
 		return "file"
 	}

--- a/modules/file/api.go
+++ b/modules/file/api.go
@@ -1096,7 +1096,7 @@ func BuildContentDisposition(filename string) string {
 		// ASCII 文件名：转义反斜杠和双引号以确保安全
 		safe := strings.ReplaceAll(filename, `\`, `\\`)
 		safe = strings.ReplaceAll(safe, `"`, `\"`)
-		return fmt.Sprintf("inline; filename=\"%s\"; filename*=UTF-8''%s", safe, encoded)
+		return fmt.Sprintf("inline; filename=\"%s\"; filename*=UTF-8''%s", quotedFilenameFallback(safe), encoded)
 	}
 	// 非 ASCII 文件名：filename 使用下划线替换非 ASCII 字符作为回退
 	var asciiFallback strings.Builder
@@ -1109,7 +1109,29 @@ func BuildContentDisposition(filename string) string {
 	}
 	safe := strings.ReplaceAll(asciiFallback.String(), `\`, `\\`)
 	safe = strings.ReplaceAll(safe, `"`, `\"`)
-	return fmt.Sprintf("inline; filename=\"%s\"; filename*=UTF-8''%s", safe, encoded)
+	return fmt.Sprintf("inline; filename=\"%s\"; filename*=UTF-8''%s", quotedFilenameFallback(safe), encoded)
+}
+
+// quotedFilenameFallback prepares the ASCII fallback that goes inside
+// `filename="…"`.
+//
+// Runs of whitespace are collapsed to a single space (GH#760): this header is
+// signed into presigned PUT URLs, and a whitespace run inside the quoted
+// string makes minio-go and the storage gateway derive different canonical
+// requests — see collapseSignableWhitespace for the full mechanism. The
+// user's exact filename, spaces and all, is still carried losslessly by the
+// adjacent RFC 5987 `filename*` parameter, which percent-encodes spaces as
+// %20 and is what every modern browser prefers; only the legacy fallback is
+// normalized.
+//
+// A name that collapses to nothing (all-whitespace) degrades to "file" rather
+// than emitting an empty `filename=""`.
+func quotedFilenameFallback(safe string) string {
+	collapsed := collapseSignableWhitespace(safe)
+	if collapsed == "" {
+		return "file"
+	}
+	return collapsed
 }
 
 // isASCII 检查字符串是否全部为 ASCII 字符

--- a/modules/file/api.go
+++ b/modules/file/api.go
@@ -894,20 +894,19 @@ func (f *File) getUploadCredentials(c *wkhttp.Context) {
 			contentType = inferred
 		}
 	}
-	if contentType == "" {
-		contentType = "application/octet-stream"
-	}
 	// GH#760: this value is BOTH signed into the presigned PUT and echoed to
 	// the client, which is contractually required to send it back verbatim —
-	// so it has to survive SigV4 Trimall unchanged for the same reason
-	// Content-Disposition does. The caller's raw query value reaches here
-	// whenever mime.TypeByExtension cannot resolve the extension, which is
-	// the norm in production: the prod image is alpine with no
-	// /etc/mime.types, so Go falls back to its small builtin table and
-	// .docx / .xlsx / .pptx / .zip all return "". A parameter such as
-	// `; name="a  b"` would then be signed collapsed and sent uncollapsed →
-	// 403 SignatureDoesNotMatch. Normalizing here keeps signed == echoed.
-	contentType = collapseSignableWhitespace(contentType)
+	// so it has to survive SigV4 Trimall unchanged, and be a legal header
+	// value, for the same reasons Content-Disposition does. The caller's raw
+	// query value reaches here whenever mime.TypeByExtension cannot resolve
+	// the extension, which is the norm in production: the prod image is
+	// alpine with no /etc/mime.types, so Go falls back to its small builtin
+	// table and .docx / .xlsx / .pptx / .zip all return "". A parameter such
+	// as `; name="a  b"` would then be signed collapsed and sent uncollapsed
+	// → 403 SignatureDoesNotMatch. normalizeUploadContentType also owns the
+	// empty/whitespace-only default, which is why no `== ""` check precedes
+	// it — see that function for the ordering rationale.
+	contentType = normalizeUploadContentType(contentType)
 
 	// When both path and filename are provided, path determines the objectKey
 	// while filename is used for Content-Disposition (friendly download name).
@@ -1153,7 +1152,7 @@ func quotedFilenameFallback(safe string) string {
 	var b strings.Builder
 	b.Grow(len(collapsed))
 	for i := 0; i < len(collapsed); i++ {
-		if c := collapsed[i]; c < 0x20 || c == 0x7F {
+		if isInvalidHeaderByte(collapsed[i]) {
 			b.WriteByte('_')
 			continue
 		}

--- a/modules/file/api_unit_test.go
+++ b/modules/file/api_unit_test.go
@@ -8,6 +8,7 @@ import (
 	"image"
 	"image/png"
 	"io"
+	"mime"
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
@@ -204,6 +205,7 @@ type mockService struct {
 	composeErr         error
 	lastObjectPath     string
 	lastGetObjectPath  string
+	lastContentType    string
 	lastContentDisp    string
 	lastFileSize       int64
 	presignedGetErr    error
@@ -240,6 +242,7 @@ func (m *mockService) GetFile(path string) (io.ReadCloser, string, error) {
 
 func (m *mockService) PresignedPutURL(objectPath string, contentType string, contentDisposition string, fileSize int64, expires time.Duration) (string, string, error) {
 	m.lastObjectPath = objectPath
+	m.lastContentType = contentType
 	m.lastContentDisp = contentDisposition
 	m.lastFileSize = fileSize
 	return "https://example.com/upload?" + objectPath, "https://example.com/download/" + objectPath, nil
@@ -1616,4 +1619,75 @@ func TestUploadFile_StickerAcceptsWebp(t *testing.T) {
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
 	_, has := resp["sticker_handle"]
 	require.True(t, has, "accepted webp sticker should mint a handle")
+}
+
+// TestGetUploadCredentials_ContentTypeContract drives the handler itself,
+// which is the only way to guard the GH#760 content-type half.
+//
+// Asserting `echoed == signed` through the mock cannot catch a regression:
+// the mock records whatever the handler passes it, so dropping the
+// normalization makes both sides equally dirty and the equality still holds.
+// The property that actually bites is on the emitted value — it must be a
+// SigV4 Trimall fixed point and a legal header value — so that is what is
+// asserted here, on the response body and the value handed to the service.
+//
+// The caller-supplied contentType only survives when mime.TypeByExtension
+// cannot resolve the extension, so these cases use `.ini`, which is
+// allow-listed and unmapped even in images that ship /etc/mime.types. The
+// require below fails loudly rather than silently passing if that ever
+// changes in some environment.
+func TestGetUploadCredentials_ContentTypeContract(t *testing.T) {
+	require.Empty(t, mime.TypeByExtension(".ini"),
+		"this test needs an allow-listed extension with no MIME mapping so the caller's contentType survives")
+
+	tests := []struct {
+		name        string
+		contentType string
+		want        string
+	}{
+		{"clean value passes through", "text/plain", "text/plain"},
+		{"whitespace run is collapsed", `text/plain;  charset=utf-8`, "text/plain; charset=utf-8"},
+		{"tab run is collapsed", "text/plain;\t\tcharset=utf-8", "text/plain; charset=utf-8"},
+		{"surrounding whitespace is trimmed", "  text/plain  ", "text/plain"},
+		// GH#760 review P2-2: "  " is not "" so a default applied before the
+		// collapse would never fire, and the collapsed "" would drop out of
+		// the signed header set entirely.
+		{"whitespace-only falls back to the default", "   ", "application/octet-stream"},
+		{"empty falls back to the default", "", "application/octet-stream"},
+		// GH#760 review P2-1: a control byte makes the header unsendable, so
+		// the value degrades to the default rather than being mangled.
+		{"control byte falls back to the default", "application/x\x01y", "application/octet-stream"},
+		{"DEL falls back to the default", "application/x\x7fy", "application/octet-stream"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockSvc := &mockService{}
+			f := &File{Log: log.NewTLog("FileTest"), service: mockSvc}
+
+			w := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(w)
+			c.Request, _ = http.NewRequest(http.MethodGet,
+				"/v1/file/upload/credentials?type=chat&fileSize=1024&filename=notes.ini&contentType="+
+					url.QueryEscape(tt.contentType), nil)
+
+			f.getUploadCredentials(&wkhttp.Context{Context: c})
+			require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+
+			var resp map[string]interface{}
+			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+			echoed, ok := resp["contentType"].(string)
+			require.True(t, ok, "response must carry contentType; body: %s", w.Body.String())
+
+			assert.Equal(t, tt.want, echoed)
+			assert.Equal(t, echoed, mockSvc.lastContentType,
+				"the client is told to echo %q but %q was handed to the signer", echoed, mockSvc.lastContentType)
+
+			// The two properties the 403 actually depends on.
+			assert.Equal(t, echoed, strings.Join(strings.Fields(echoed), " "),
+				"echoed contentType must be a SigV4 Trimall fixed point")
+			assert.False(t, containsInvalidHeaderByte(echoed),
+				"echoed contentType must be a legal header value, got %q", echoed)
+		})
+	}
 }

--- a/modules/file/api_unit_test.go
+++ b/modules/file/api_unit_test.go
@@ -277,6 +277,17 @@ func TestBuildContentDisposition(t *testing.T) {
 			`inline; filename="report\\2024.pdf"; filename*=UTF-8''report%5C2024.pdf`},
 		{"ascii with semicolon", "report;final.pdf",
 			`inline; filename="report;final.pdf"; filename*=UTF-8''report%3Bfinal.pdf`},
+		// GH#760: consecutive spaces are collapsed in the quoted ASCII
+		// fallback (it is a signed header value and must survive SigV4
+		// Trimall unchanged), while filename* keeps the user's name exactly.
+		{"ascii with consecutive spaces", "my  file.pdf",
+			`inline; filename="my file.pdf"; filename*=UTF-8''my%20%20file.pdf`},
+		{"unicode with consecutive spaces", "报告  文档.pdf",
+			`inline; filename="__ __.pdf"; filename*=UTF-8''` + url.PathEscape("报告  文档.pdf")},
+		{"leading and trailing spaces", "  spaced.pdf  ",
+			`inline; filename="spaced.pdf"; filename*=UTF-8''` + url.PathEscape("  spaced.pdf  ")},
+		{"all whitespace degrades to file", "   ",
+			`inline; filename="file"; filename*=UTF-8''%20%20%20`},
 	}
 
 	for _, tt := range tests {

--- a/modules/file/helpers.go
+++ b/modules/file/helpers.go
@@ -136,16 +136,25 @@ func collapseSignableWhitespace(s string) string {
 }
 
 // presignPutHeaders builds the header set signed into a presigned PUT URL.
+// Content-Length is signed so the gateway bounds the upload size;
+// Content-Type and Content-Disposition are signed so the stored object
+// carries the right metadata.
 //
-// Every value goes through collapseSignableWhitespace so the signed canonical
-// form matches whatever the storage gateway derives (see that function for
-// the failure this prevents). Content-Length is signed so the gateway bounds
-// the upload size; Content-Type and Content-Disposition are signed so the
-// stored object carries the right metadata.
+// The collapseSignableWhitespace calls here are defence in depth, NOT the
+// GH#760 fix: minio-go runs signV4TrimAll over every value it signs, so
+// passing "a  b" or "a b" produces the identical signature. What actually
+// has to be collapsed is the value handed to the client, because the client
+// echoes it verbatim and the gateway canonicalizes what arrives — that is
+// done at each value's source (BuildContentDisposition for the disposition,
+// getUploadCredentials for the content type). Normalizing again here keeps
+// this map identical to those values, so a backend that ever signs verbatim
+// cannot silently reintroduce the mismatch.
 //
 // Shared by the three SigV4 backends (COS / MinIO / S3) so the invariant
-// cannot drift between copies. Aliyun OSS V1 signs neither Content-Type nor
-// Content-Disposition and builds its options separately.
+// cannot drift between copies. Aliyun OSS builds its options separately and
+// does not come through here; note its V1 string-to-sign DOES cover
+// Content-Type (verbatim, with no Trimall step) and does NOT cover
+// Content-Disposition — see the operator matrix on getUploadCredentials.
 func presignPutHeaders(contentType, contentDisposition string, fileSize int64) http.Header {
 	headers := http.Header{}
 	headers.Set("Content-Length", strconv.FormatInt(fileSize, 10))

--- a/modules/file/helpers.go
+++ b/modules/file/helpers.go
@@ -1,6 +1,10 @@
 package file
 
-import "strings"
+import (
+	"net/http"
+	"strconv"
+	"strings"
+)
 
 // allowedMinioBuckets is the whitelist of bucket prefixes the MinIO backend
 // will auto-create and accept on upload. Keeping it in one place lets every
@@ -102,4 +106,54 @@ func violatesStickerKeyspace(fileType Type, objectPath string) bool {
 		return false
 	}
 	return strings.HasPrefix(strings.TrimPrefix(objectPath, "/"), "sticker/")
+}
+
+// collapseSignableWhitespace rewrites a string so that it survives SigV4
+// canonicalization unchanged: leading/trailing whitespace is trimmed and every
+// run of whitespace becomes a single space.
+//
+// Why this has to exist (GH#760): SigV4 hashes a *canonical* form of each
+// signed header value, and the two sides of the handshake canonicalize
+// differently.
+//
+//   - minio-go (pkg/signer/utils.go signV4TrimAll) does
+//     `strings.Join(strings.Fields(v), " ")`, collapsing whitespace runs
+//     ANYWHERE in the value — including inside a quoted string.
+//   - AWS SigV4 (and Tencent COS, which enforces it) says "Do not trim excess
+//     white space in a header value if it appears within a quoted string", so
+//     the gateway keeps the run.
+//
+// A `Content-Disposition: inline; filename="a  b.pdf"` therefore gets signed
+// as `filename="a b.pdf"` but verified as `filename="a  b.pdf"` — different
+// canonical requests, different signatures, and the browser PUT dies with
+// 403 SignatureDoesNotMatch. Emitting a value that is already collapsed makes
+// both derivations agree, whichever rule the gateway applies.
+//
+// The behaviour is deliberately identical to minio-go's signV4TrimAll: this
+// is the fixed point of that function, not a different normalization.
+func collapseSignableWhitespace(s string) string {
+	return strings.Join(strings.Fields(s), " ")
+}
+
+// presignPutHeaders builds the header set signed into a presigned PUT URL.
+//
+// Every value goes through collapseSignableWhitespace so the signed canonical
+// form matches whatever the storage gateway derives (see that function for
+// the failure this prevents). Content-Length is signed so the gateway bounds
+// the upload size; Content-Type and Content-Disposition are signed so the
+// stored object carries the right metadata.
+//
+// Shared by the three SigV4 backends (COS / MinIO / S3) so the invariant
+// cannot drift between copies. Aliyun OSS V1 signs neither Content-Type nor
+// Content-Disposition and builds its options separately.
+func presignPutHeaders(contentType, contentDisposition string, fileSize int64) http.Header {
+	headers := http.Header{}
+	headers.Set("Content-Length", strconv.FormatInt(fileSize, 10))
+	if v := collapseSignableWhitespace(contentType); v != "" {
+		headers.Set("Content-Type", v)
+	}
+	if v := collapseSignableWhitespace(contentDisposition); v != "" {
+		headers.Set("Content-Disposition", v)
+	}
+	return headers
 }

--- a/modules/file/helpers.go
+++ b/modules/file/helpers.go
@@ -135,6 +135,51 @@ func collapseSignableWhitespace(s string) string {
 	return strings.Join(strings.Fields(s), " ")
 }
 
+// defaultUploadContentType is what an upload falls back to when the caller
+// gives us nothing usable.
+const defaultUploadContentType = "application/octet-stream"
+
+// isInvalidHeaderByte reports whether c may not appear in an HTTP header value.
+// Go's transport refuses to send a request carrying one ("invalid header field
+// value"), so a header we hand a client is unusable if it contains any —
+// regardless of what the signature says about it.
+func isInvalidHeaderByte(c byte) bool { return c < 0x20 || c == 0x7F }
+
+func containsInvalidHeaderByte(s string) bool {
+	for i := 0; i < len(s); i++ {
+		if isInvalidHeaderByte(s[i]) {
+			return true
+		}
+	}
+	return false
+}
+
+// normalizeUploadContentType prepares a caller-supplied content type to be
+// both signed into a presigned PUT and echoed to the client, which must send
+// it back verbatim.
+//
+// Whitespace runs are collapsed for the GH#760 reason (see
+// collapseSignableWhitespace). Two further shapes degrade to the default
+// rather than being passed through:
+//
+//   - empty, or whitespace-only: collapsing "  " yields "", and an empty
+//     content type would silently drop out of the signed header set and be
+//     echoed as "", leaving the stored object with no declared type. Note the
+//     ordering this implies — the default has to be applied AFTER the
+//     collapse, not before, or a whitespace-only value slips past it.
+//   - carrying a byte that cannot appear in a header value: mangling those to
+//     '_' would invent a MIME type the caller never asked for, so an honest
+//     default beats a corrupted value here. (The filename fallback does
+//     substitute, because there the goal is to preserve as much of the name
+//     as possible.)
+func normalizeUploadContentType(raw string) string {
+	ct := collapseSignableWhitespace(raw)
+	if ct == "" || containsInvalidHeaderByte(ct) {
+		return defaultUploadContentType
+	}
+	return ct
+}
+
 // presignPutHeaders builds the header set signed into a presigned PUT URL.
 // Content-Length is signed so the gateway bounds the upload size;
 // Content-Type and Content-Disposition are signed so the stored object

--- a/modules/file/issue760_filename_sweep_test.go
+++ b/modules/file/issue760_filename_sweep_test.go
@@ -1,0 +1,219 @@
+package file
+
+// Exhaustive answer to "which other filenames can still break the presigned
+// PUT?" for GH#760.
+//
+// The 403 happens when the value octo-server signs is not what the storage
+// gateway derives from the value the browser sends. Both derivations are
+// Trimall over the same string, so the whole failure mode collapses to one
+// property:
+//
+//	the emitted header must be a fixed point of BOTH Trimall rules.
+//
+// If that holds, minio-go's canonical value, COS/AWS's canonical value, and
+// the bytes on the wire are the same string, and no signature mismatch is
+// possible — whichever rule the gateway implements.
+//
+// This file sweeps the filename space against that property instead of
+// enumerating suspicious characters, so a future edit that reintroduces raw
+// whitespace (or a new header parameter) fails here rather than in
+// production.
+//
+// Both entry shapes are covered, because they differ in the wild:
+//
+//   - sanitized  — modules/file/api.go runs sanitizeFilename first.
+//   - raw        — modules/bot_api/file.go and modules/robot/api.go pass the
+//     multipart filename / query parameter straight through.
+//
+// The raw shape is the adversarial one: control characters and quotes reach
+// BuildContentDisposition untouched there.
+
+import (
+	"fmt"
+	"math/rand"
+	"strings"
+	"testing"
+	"unicode"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// assertHeaderIsSignable checks every property a signed Content-Disposition
+// must have for the SigV4 handshake to be deterministic.
+func assertHeaderIsSignable(t *testing.T, label, filename string) {
+	t.Helper()
+
+	for _, cd := range []string{
+		BuildContentDisposition(filename),
+		BuildContentDisposition(sanitizeFilename(filename)),
+	} {
+		if cd == "" {
+			continue
+		}
+
+		// 1+2. Both canonicalizations must be the identity, so signer and
+		// gateway agree no matter which rule the gateway applies.
+		if got := trimAllMinIO(cd); got != cd {
+			t.Fatalf("%s: minio-go canonicalization rewrites the header\n filename=%q\n emitted =%q\n canon   =%q",
+				label, filename, cd, got)
+		}
+		if got := trimAllQuotedAware(cd); got != cd {
+			t.Fatalf("%s: COS/AWS canonicalization rewrites the header\n filename=%q\n emitted =%q\n canon   =%q",
+				label, filename, cd, got)
+		}
+
+		// 3. No bare CR/LF: those would be header injection, not merely a
+		// signature mismatch. (Property 1 already implies it — Fields splits
+		// on them — but assert it explicitly so the intent survives a
+		// refactor of the collapse helper.)
+		if strings.ContainsAny(cd, "\r\n") {
+			t.Fatalf("%s: header carries a bare CR/LF\n filename=%q\n emitted=%q", label, filename, cd)
+		}
+
+		// 4. Quotes stay balanced, so "inside a quoted string" means the same
+		// thing to us and to the gateway. Scan RFC 6266 quoted-string rules:
+		// inside quotes a backslash escapes the next octet, so `"a\\"` closes
+		// (the pair is an escaped backslash) while `"a\""` does not.
+		inQuotes := false
+		for i := 0; i < len(cd); i++ {
+			if inQuotes && cd[i] == '\\' && i+1 < len(cd) {
+				i++ // consume the escaped octet
+				continue
+			}
+			if cd[i] == '"' {
+				inQuotes = !inQuotes
+			}
+		}
+		if inQuotes {
+			t.Fatalf("%s: unbalanced quotes in header\n filename=%q\n emitted=%q", label, filename, cd)
+		}
+	}
+}
+
+// TestIssue760_SweepIsNotVacuous proves the property above actually
+// discriminates: the pre-fix construction violates it for the filename from
+// the issue. Without this, a change that made BuildContentDisposition return
+// something trivially stable (or empty) would sail through every sweep.
+func TestIssue760_SweepIsNotVacuous(t *testing.T) {
+	pre := naiveContentDisposition(sanitizeFilename("Octo  upload test.pdf"))
+	assert.NotEqual(t, pre, trimAllMinIO(pre),
+		"pre-fix header must violate the sweep property, else the sweep proves nothing")
+
+	post := BuildContentDisposition(sanitizeFilename("Octo  upload test.pdf"))
+	assert.Equal(t, post, trimAllMinIO(post))
+	assert.Contains(t, post, "%20%20", "filename* must still carry the user's original spacing")
+}
+
+// TestIssue760_SweepASCII places every ASCII code point — control characters,
+// quotes, backslashes, delimiters — at the start, middle and end of a
+// filename, singly and in runs.
+func TestIssue760_SweepASCII(t *testing.T) {
+	for c := 0; c < 128; c++ {
+		r := rune(c)
+		for _, n := range []int{1, 2, 3} {
+			run := strings.Repeat(string(r), n)
+			for _, shape := range []string{run + "name.pdf", "na" + run + "me.pdf", "name" + run + ".pdf", "name.pdf" + run} {
+				assertHeaderIsSignable(t, fmt.Sprintf("ascii U+%04X x%d", c, n), shape)
+			}
+		}
+	}
+}
+
+// TestIssue760_SweepUnicodeWhitespace covers every code point Go considers
+// whitespace — the set strings.Fields actually splits on. U+0085 and U+00A0
+// are the interesting ones: they are whitespace to unicode.IsSpace but are
+// non-ASCII, so they take the '_' fallback branch rather than surviving as
+// literal whitespace.
+func TestIssue760_SweepUnicodeWhitespace(t *testing.T) {
+	var spaces []rune
+	for _, rg := range unicode.White_Space.R16 {
+		for r := rune(rg.Lo); r <= rune(rg.Hi); r += rune(rg.Stride) {
+			spaces = append(spaces, r)
+		}
+	}
+	for _, rg := range unicode.White_Space.R32 {
+		for r := rune(rg.Lo); r <= rune(rg.Hi); r += rune(rg.Stride) {
+			spaces = append(spaces, r)
+		}
+	}
+	assert.NotEmpty(t, spaces)
+	t.Logf("sweeping %d whitespace code points", len(spaces))
+
+	for _, r := range spaces {
+		for _, n := range []int{1, 2, 3} {
+			run := strings.Repeat(string(r), n)
+			for _, shape := range []string{
+				run + "name.pdf",
+				"na" + run + "me.pdf",
+				"报告" + run + "文档.pdf",
+				"name" + run + ".pdf",
+				// Mixed runs: an ASCII space next to an exotic one is the
+				// case a naive "replace two spaces with one" fix would miss.
+				"na " + run + " me.pdf",
+			} {
+				assertHeaderIsSignable(t, fmt.Sprintf("U+%04X x%d", r, n), shape)
+			}
+		}
+	}
+}
+
+// TestIssue760_SweepAdversarial covers hand-picked shapes aimed at the header
+// grammar rather than at whitespace: quote and backslash injection, fake
+// parameters, RFC 5987 look-alikes, and names that collapse to nothing.
+func TestIssue760_SweepAdversarial(t *testing.T) {
+	names := []string{
+		``,
+		` `,
+		`   `,
+		"\t\t",
+		"\r\n",
+		"a\r\nX-Injected: 1.pdf",
+		`a"b.pdf`,
+		`a""b.pdf`,
+		`a\"b.pdf`,
+		`a\\b.pdf`,
+		`a\.pdf`,
+		`"; filename="evil.pdf`,
+		`a"; filename*=UTF-8''evil.pdf`,
+		`report.pdf"; x="  y`,
+		`inline; filename="x  y.pdf"`,
+		`filename*=UTF-8''a%20%20b.pdf`,
+		`a;b.pdf`,
+		`a,b.pdf`,
+		`../../etc/passwd`,
+		`..\..\windows\system32.dll`,
+		strings.Repeat("a b", 200) + ".pdf",
+		strings.Repeat(" ", 300) + ".pdf",
+		strings.Repeat("报告 ", 200) + ".pdf",
+		"emoji\U0001F600\U0001F600  \U0001F600.pdf",
+	}
+	for _, n := range names {
+		assertHeaderIsSignable(t, fmt.Sprintf("adversarial %q", n), n)
+	}
+}
+
+// TestIssue760_SweepRandom fuzzes over an alphabet weighted towards the
+// characters that matter — whitespace, quotes, backslashes, delimiters, CJK,
+// emoji — with a fixed seed so a failure is reproducible.
+func TestIssue760_SweepRandom(t *testing.T) {
+	alphabet := []rune{
+		' ', ' ', ' ', '\t', '\n', '\r', '\v', '\f',
+		'"', '\\', ';', '=', ',', '\'', '*', '/', '.', '-', '_',
+		'a', 'B', '7', 0x00, 0x1F, 0x7F,
+		'', ' ', ' ', ' ', ' ', ' ', ' ', '　', '​',
+		'报', '告', '\U0001F600',
+	}
+	rng := rand.New(rand.NewSource(760))
+
+	const cases = 20000
+	for i := 0; i < cases; i++ {
+		n := 1 + rng.Intn(24)
+		var b strings.Builder
+		for j := 0; j < n; j++ {
+			b.WriteRune(alphabet[rng.Intn(len(alphabet))])
+		}
+		name := b.String() + ".pdf"
+		assertHeaderIsSignable(t, fmt.Sprintf("random#%d", i), name)
+	}
+	t.Logf("swept %d random filenames with no destabilizing header", cases)
+}

--- a/modules/file/issue760_filename_sweep_test.go
+++ b/modules/file/issue760_filename_sweep_test.go
@@ -62,12 +62,19 @@ func assertHeaderIsSignable(t *testing.T, label, filename string) {
 				label, filename, cd, got)
 		}
 
-		// 3. No bare CR/LF: those would be header injection, not merely a
-		// signature mismatch. (Property 1 already implies it — Fields splits
-		// on them — but assert it explicitly so the intent survives a
-		// refactor of the collapse helper.)
-		if strings.ContainsAny(cd, "\r\n") {
-			t.Fatalf("%s: header carries a bare CR/LF\n filename=%q\n emitted=%q", label, filename, cd)
+		// 3. The value must be a legal HTTP header value, i.e. no C0 controls
+		// and no DEL. This is stricter than "no CR/LF" and it is not implied
+		// by property 1: collapsing only folds the whitespace controls, so a
+		// 0x01 would survive and Go's transport would refuse to send the
+		// request at all ("invalid header field value") — the credentials
+		// response would be handing the client a header it cannot use. Only
+		// callers that skip sanitizeFilename can get here (bot_api, robot),
+		// which is exactly why this is checked on the raw shape too.
+		for i := 0; i < len(cd); i++ {
+			if c := cd[i]; c < 0x20 || c == 0x7F {
+				t.Fatalf("%s: header carries byte 0x%02X, not a valid header value\n filename=%q\n emitted=%q",
+					label, c, filename, cd)
+			}
 		}
 
 		// 4. Quotes stay balanced, so "inside a quoted string" means the same
@@ -102,6 +109,18 @@ func TestIssue760_SweepIsNotVacuous(t *testing.T) {
 	post := BuildContentDisposition(sanitizeFilename("Octo  upload test.pdf"))
 	assert.Equal(t, post, trimAllMinIO(post))
 	assert.Contains(t, post, "%20%20", "filename* must still carry the user's original spacing")
+
+	// Same for the header-validity property: the unsanitized shape used by
+	// bot_api / robot really can carry a C0 control, so property 3 is not
+	// decoration either.
+	preCtl := naiveContentDisposition("a\x01b.pdf")
+	assert.Contains(t, preCtl, "\x01",
+		"pre-fix header must carry the raw control byte, else property 3 proves nothing")
+
+	postCtl := BuildContentDisposition("a\x01b.pdf")
+	assert.NotContains(t, postCtl, "\x01")
+	assert.Equal(t, `inline; filename="a_b.pdf"; filename*=UTF-8''a%01b.pdf`, postCtl,
+		"control byte is scrubbed from the quoted fallback but preserved, percent-encoded, in filename*")
 }
 
 // TestIssue760_SweepASCII places every ASCII code point — control characters,

--- a/modules/file/issue760_sigv4_space_repro_test.go
+++ b/modules/file/issue760_sigv4_space_repro_test.go
@@ -1,0 +1,433 @@
+package file
+
+// Local end-to-end reproduction for GH#760 —
+// "文件名含连续半角空格时预签名 PUT 稳定 403 SignatureDoesNotMatch".
+//
+// This test needs no cloud credentials and no network. It wires up the exact
+// production pieces:
+//
+//   - sanitizeFilename        (const.go, as called by getUploadCredentials)
+//   - BuildContentDisposition (api.go)
+//   - minio-go v7.0.61 PresignHeader with the same signed header set as
+//     ServiceCOS.PresignedPutURL (Content-Length / Content-Type /
+//     Content-Disposition)
+//
+// ...and points the presigned PUT at a local httptest server that verifies
+// SigV4 itself. The verifier is parameterised by the ONE thing the two
+// implementations disagree on: how a signed header value is "Trimall"-ed.
+//
+//	minio-go  : strings.Fields  → collapses whitespace runs EVERYWHERE,
+//	            including inside a quoted string.
+//	AWS / COS : collapses runs OUTSIDE quoted strings only. Per
+//	            https://docs.aws.amazon.com/general/latest/gr/sigv4-create-canonical-request.html
+//	            "Do not trim excess white space in a header value if it
+//	            appears within a quoted string."
+//
+// Content-Disposition is emitted as `inline; filename="<name>"; filename*=...`,
+// so a filename carrying two or more consecutive U+0020 puts a whitespace run
+// inside the quoted string — the one place the two rules differ.
+
+import (
+	"bytes"
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/minio/minio-go/v7"
+	"github.com/minio/minio-go/v7/pkg/credentials"
+	"github.com/minio/minio-go/v7/pkg/s3utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	repro760AccessKey = "AKIAREPRO760EXAMPLE"
+	repro760SecretKey = "wJalrXUtnFEMI-K7MDENG-bPxRfiCYEXAMPLEKEY"
+	repro760Region    = "ap-guangzhou"
+	repro760Bucket    = "octo-repro-1250000000"
+)
+
+// ---------------------------------------------------------------------------
+// The two Trimall implementations
+// ---------------------------------------------------------------------------
+
+// trimAllMinIO is a verbatim copy of minio-go v7.0.61
+// pkg/signer/utils.go signV4TrimAll — what octo-server signs with today.
+func trimAllMinIO(input string) string {
+	return strings.Join(strings.Fields(input), " ")
+}
+
+// trimAllQuotedAware collapses whitespace runs outside quoted strings and
+// leaves whitespace inside quoted strings untouched — the AWS SigV4 rule
+// that Tencent COS enforces on the verifying side.
+func trimAllQuotedAware(input string) string {
+	input = strings.Trim(input, " \t")
+	var b strings.Builder
+	inQuotes := false
+	prevSpace := false
+	for i := 0; i < len(input); i++ {
+		c := input[i]
+		if c == '\\' && inQuotes && i+1 < len(input) {
+			b.WriteByte(c)
+			b.WriteByte(input[i+1])
+			i++
+			prevSpace = false
+			continue
+		}
+		if c == '"' {
+			inQuotes = !inQuotes
+			b.WriteByte(c)
+			prevSpace = false
+			continue
+		}
+		if !inQuotes && (c == ' ' || c == '\t') {
+			if prevSpace {
+				continue
+			}
+			prevSpace = true
+			b.WriteByte(' ')
+			continue
+		}
+		prevSpace = false
+		b.WriteByte(c)
+	}
+	return b.String()
+}
+
+// ---------------------------------------------------------------------------
+// Minimal SigV4 presigned-PUT verifier, standing in for the storage gateway
+// ---------------------------------------------------------------------------
+
+type repro760Gateway struct {
+	trimAll func(string) string
+
+	lastCanonicalRequest string
+	lastStatus           int
+}
+
+func (g *repro760Gateway) canonicalRequest(r *http.Request) string {
+	q := r.URL.Query()
+	signedHeaders := strings.Split(q.Get("X-Amz-SignedHeaders"), ";")
+	sort.Strings(signedHeaders)
+
+	q.Del("X-Amz-Signature")
+	canonicalQuery := strings.ReplaceAll(q.Encode(), "+", "%20")
+
+	var headers strings.Builder
+	for _, h := range signedHeaders {
+		var value string
+		switch h {
+		case "host":
+			value = r.Host
+		case "content-length":
+			// net/http hoists Content-Length out of the header map.
+			value = strconv.FormatInt(r.ContentLength, 10)
+		default:
+			value = r.Header.Get(h)
+		}
+		headers.WriteString(h)
+		headers.WriteByte(':')
+		headers.WriteString(g.trimAll(value))
+		headers.WriteByte('\n')
+	}
+
+	return strings.Join([]string{
+		r.Method,
+		s3utils.EncodePath(r.URL.Path),
+		canonicalQuery,
+		headers.String(),
+		strings.Join(signedHeaders, ";"),
+		"UNSIGNED-PAYLOAD",
+	}, "\n")
+}
+
+func (g *repro760Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	_, _ = io.Copy(io.Discard, r.Body)
+
+	q := r.URL.Query()
+	credential := q.Get("X-Amz-Credential")
+	parts := strings.SplitN(credential, "/", 2)
+	if len(parts) != 2 {
+		g.lastStatus = http.StatusForbidden
+		http.Error(w, "InvalidCredential", http.StatusForbidden)
+		return
+	}
+	scope := parts[1]
+	scopeDate := strings.SplitN(scope, "/", 2)[0]
+
+	canonicalReq := g.canonicalRequest(r)
+	g.lastCanonicalRequest = canonicalReq
+
+	sum := sha256.Sum256([]byte(canonicalReq))
+	stringToSign := strings.Join([]string{
+		"AWS4-HMAC-SHA256",
+		q.Get("X-Amz-Date"),
+		scope,
+		hex.EncodeToString(sum[:]),
+	}, "\n")
+
+	mac := func(key, data []byte) []byte {
+		h := hmac.New(sha256.New, key)
+		h.Write(data)
+		return h.Sum(nil)
+	}
+	k := mac([]byte("AWS4"+repro760SecretKey), []byte(scopeDate))
+	k = mac(k, []byte(repro760Region))
+	k = mac(k, []byte("s3"))
+	k = mac(k, []byte("aws4_request"))
+	expected := hex.EncodeToString(mac(k, []byte(stringToSign)))
+
+	if !hmac.Equal([]byte(expected), []byte(q.Get("X-Amz-Signature"))) {
+		g.lastStatus = http.StatusForbidden
+		w.Header().Set("Content-Type", "application/xml")
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = io.WriteString(w, `<?xml version="1.0" encoding="UTF-8"?><Error><Code>SignatureDoesNotMatch</Code></Error>`)
+		return
+	}
+	g.lastStatus = http.StatusOK
+	w.WriteHeader(http.StatusOK)
+}
+
+// ---------------------------------------------------------------------------
+// Production signing path (mirrors ServiceCOS.PresignedPutURL)
+// ---------------------------------------------------------------------------
+
+func repro760Presign(t *testing.T, host string, contentType, contentDisposition string, fileSize int64) *url.URL {
+	t.Helper()
+
+	client, err := minio.New(host, &minio.Options{
+		Creds:        credentials.NewStaticV4(repro760AccessKey, repro760SecretKey, ""),
+		Secure:       false, // httptest is plain HTTP; signing math is identical
+		Region:       repro760Region,
+		BucketLookup: minio.BucketLookupPath,
+	})
+	require.NoError(t, err)
+
+	headers := http.Header{}
+	headers.Set("Content-Length", strconv.FormatInt(fileSize, 10))
+	if contentType != "" {
+		headers.Set("Content-Type", contentType)
+	}
+	if contentDisposition != "" {
+		headers.Set("Content-Disposition", contentDisposition)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	presigned, err := client.PresignHeader(ctx, http.MethodPut,
+		repro760Bucket, "chat/1755000000/repro/object.bin", 30*time.Minute, nil, headers)
+	require.NoError(t, err)
+	return presigned
+}
+
+// repro760Upload runs the full client flow for one filename: sanitize →
+// BuildContentDisposition → presign → PUT with the echoed headers.
+func repro760Upload(t *testing.T, gw *repro760Gateway, srv *httptest.Server, rawFilename string) (status int, disposition string) {
+	t.Helper()
+
+	filename := sanitizeFilename(rawFilename)
+	disposition = BuildContentDisposition(filename)
+	body := bytes.Repeat([]byte{0x41}, 4096)
+	contentType := "application/octet-stream"
+
+	presigned := repro760Presign(t, srv.Listener.Addr().String(), contentType, disposition, int64(len(body)))
+
+	req, err := http.NewRequest(http.MethodPut, presigned.String(), bytes.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", contentType)
+	req.Header.Set("Content-Disposition", disposition)
+	req.ContentLength = int64(len(body))
+
+	resp, err := srv.Client().Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	_, _ = io.Copy(io.Discard, resp.Body)
+
+	_ = gw
+	return resp.StatusCode, disposition
+}
+
+func repro760NewServer(t *testing.T, trimAll func(string) string) (*httptest.Server, *repro760Gateway) {
+	t.Helper()
+	gw := &repro760Gateway{trimAll: trimAll}
+	srv := httptest.NewServer(gw)
+	t.Cleanup(srv.Close)
+	return srv, gw
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+// wantStatusFor states the law this whole file is about: a presigned PUT is
+// accepted by a COS/AWS-style gateway if and only if the signed header value
+// is already stable under Trimall. It holds before the fix (double-space
+// filenames are unstable → 403) and after it (all filenames stable → 200),
+// so these tests never have to be rewritten alongside the fix.
+func wantStatusFor(contentDisposition string) int {
+	if trimAllMinIO(contentDisposition) == contentDisposition {
+		return http.StatusOK
+	}
+	return http.StatusForbidden
+}
+
+// TestIssue760_ConsecutiveSpacesBreakPresignedPUT is the core reproduction:
+// same bytes, same code path, filename differing only in the number of
+// consecutive U+0020, against a gateway that applies the AWS quoted-string
+// Trimall rule.
+//
+// Pre-fix this logs `double space → PUT 403` — GH#760 reproduced offline.
+// Post-fix BuildContentDisposition emits a Trimall-stable value and the same
+// case logs 200; the assertion below tracks either state.
+func TestIssue760_ConsecutiveSpacesBreakPresignedPUT(t *testing.T) {
+	srv, gw := repro760NewServer(t, trimAllQuotedAware) // COS-side behaviour
+
+	okStatus, okCD := repro760Upload(t, gw, srv, "Octo upload test.pdf")
+	t.Logf("single space  → PUT %d  CD=%q", okStatus, okCD)
+	assert.Equal(t, http.StatusOK, okStatus, "single space must upload fine")
+
+	badStatus, badCD := repro760Upload(t, gw, srv, "Octo  upload test.pdf")
+	t.Logf("double space  → PUT %d  CD=%q", badStatus, badCD)
+	assert.Equal(t, wantStatusFor(badCD), badStatus,
+		"PUT outcome must track Trimall stability of the signed header")
+
+	if badStatus == http.StatusForbidden {
+		t.Logf("GH#760 reproduced. Canonical headers the gateway computed:\n%s",
+			gw.lastCanonicalRequest)
+		t.Logf("what minio-go signed instead (whitespace run collapsed):\n%s",
+			trimAllMinIO(badCD))
+	}
+}
+
+// TestIssue760_MinIOGatewayAcceptsSameRequest shows the failure is a
+// cross-implementation disagreement, not a malformed signature: a gateway
+// that trims the minio-go way accepts the very same request. This is why the
+// bug is invisible on the MinIO backend (MinIO server ships the same
+// signV4TrimAll) and only bites on COS / AWS S3.
+func TestIssue760_MinIOGatewayAcceptsSameRequest(t *testing.T) {
+	srv, gw := repro760NewServer(t, trimAllMinIO)
+
+	status, cd := repro760Upload(t, gw, srv, "Octo  upload test.pdf")
+	t.Logf("double space vs minio-style gateway → PUT %d  CD=%q", status, cd)
+	assert.Equal(t, http.StatusOK, status,
+		"same request is accepted by a gateway using minio-go's Trimall")
+}
+
+// TestIssue760_TrimAllImplementationsDiffer isolates the disagreement itself,
+// with no HTTP involved: the two Trimall rules produce different canonical
+// values for the very header octo-server signs today.
+func TestIssue760_TrimAllImplementationsDiffer(t *testing.T) {
+	cd := BuildContentDisposition(sanitizeFilename("Octo  upload test.pdf"))
+	minioSide := trimAllMinIO(cd)
+	cosSide := trimAllQuotedAware(cd)
+
+	t.Logf("header signed : %q", cd)
+	t.Logf("minio-go canon: %q", minioSide)
+	t.Logf("COS/AWS canon : %q", cosSide)
+
+	if minioSide == cosSide {
+		t.Log("no disagreement: the emitted header is Trimall-stable (GH#760 fixed)")
+		return
+	}
+	assert.Equal(t, cd, cosSide,
+		"COS keeps whitespace inside the quoted string, i.e. it canonicalises the header verbatim")
+	assert.NotEqual(t, cd, minioSide,
+		"minio-go collapses the run inside the quoted string — the source of the signature mismatch")
+}
+
+// TestIssue760_CharacterMatrix reproduces the 25-class character matrix from
+// the issue against the COS-side rule. Every documented outcome is explained
+// by the single whitespace-run mechanism.
+func TestIssue760_CharacterMatrix(t *testing.T) {
+	srv, gw := repro760NewServer(t, trimAllQuotedAware)
+
+	// `want` records the observed pre-fix outcome for documentation. The
+	// assertion uses wantStatusFor so the table stays valid after the fix
+	// flips the 403 rows to 200.
+	cases := []struct {
+		name     string
+		filename string
+		want     int
+		why      string
+	}{
+		{"single U+0020", "Octo upload test.pdf", http.StatusOK,
+			"no whitespace run to collapse"},
+		{"two U+0020", "Octo  upload test.pdf", http.StatusForbidden,
+			"run inside filename=\"...\" collapsed by signer, kept by gateway"},
+		{"three U+0020", "Octo   upload test.pdf", http.StatusForbidden,
+			"same mechanism, any run length >= 2"},
+		{"two runs of U+0020", "Octo  upload  test.pdf", http.StatusForbidden,
+			"same mechanism"},
+		{"tab", "Octo\tupload test.pdf", http.StatusOK,
+			"sanitizeFilename maps r < 0x20 to '_' before the header is built"},
+		{"ideographic space U+3000", "Octo　upload test.pdf", http.StatusOK,
+			"non-ASCII branch: '_' in the quoted fallback, %-encoded in filename*"},
+		{"no-break space U+00A0", "Octo upload test.pdf", http.StatusOK,
+			"non-ASCII branch (note: unicode.IsSpace(U+00A0) is true, so it WOULD collapse if it survived)"},
+		{"narrow NBSP U+202F", "Octo upload test.pdf", http.StatusOK,
+			"non-ASCII branch"},
+		{"zero width space U+200B", "Octo​upload test.pdf", http.StatusOK,
+			"non-ASCII branch"},
+		{"chinese with single space", "报告 文档.pdf", http.StatusOK,
+			"non-ASCII branch, quoted fallback is all '_'"},
+		// Wider than the issue's matrix: the non-ASCII branch only replaces
+		// runes > 127 with '_', so ASCII spaces survive verbatim in the
+		// quoted fallback. A CJK filename with consecutive spaces fails too
+		// — the issue's "中文 → 200" row only held because that sample
+		// carried a single space.
+		{"chinese with double space", "报告  文档.pdf", http.StatusForbidden,
+			"non-ASCII branch keeps ASCII spaces: filename=\"__  __.pdf\" still has a run"},
+		{"emoji with single space", "photo\U0001F600 x.jpg", http.StatusOK,
+			"non-ASCII branch"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			status, cd := repro760Upload(t, gw, srv, tc.filename)
+			t.Logf("PUT %d (pre-fix: %d)  CD=%q  (%s)", status, tc.want, cd, tc.why)
+			assert.Equal(t, wantStatusFor(cd), status)
+		})
+	}
+}
+
+// TestIssue760_SignedHeaderInvariant states the property that actually has to
+// hold for SigV4 agreement, independent of any gateway: a signed header value
+// must already be Trimall-stable, i.e. collapsing its whitespace runs must be
+// a no-op.
+//
+// This is the acceptance assertion for the GH#760 fix and it FAILS on the
+// current code — BuildContentDisposition emits `filename="Octo  upload
+// test.pdf"` verbatim. It is skipped so the reproduction can land without
+// turning CI red; drop the Skip in the commit that fixes
+// BuildContentDisposition, and it becomes the permanent regression guard
+// (stricter than enumerating filenames: anything that puts a whitespace run
+// into a signed header trips it).
+func TestIssue760_SignedHeaderInvariant(t *testing.T) {
+	t.Skip("expected to fail until GH#760 is fixed; unskip together with the BuildContentDisposition fix")
+
+	filenames := []string{
+		"Octo upload test.pdf",
+		"Octo  upload test.pdf",
+		"Octo   upload  test.pdf",
+		"report.pdf",
+		"报告 文档.pdf",
+	}
+	for _, raw := range filenames {
+		t.Run(raw, func(t *testing.T) {
+			cd := BuildContentDisposition(sanitizeFilename(raw))
+			assert.Equal(t, cd, trimAllMinIO(cd),
+				"Content-Disposition must be stable under SigV4 Trimall; got %q", cd)
+		})
+	}
+}

--- a/modules/file/issue760_sigv4_space_repro_test.go
+++ b/modules/file/issue760_sigv4_space_repro_test.go
@@ -430,25 +430,39 @@ func TestIssue760_SignedHeaderInvariant(t *testing.T) {
 	}
 }
 
-// TestIssue760_SignedContentTypeInvariant covers the second signed header that
-// can carry a client-controlled whitespace run. getUploadCredentials only
-// overrides the caller's contentType when mime.TypeByExtension resolves the
-// extension; when it does not, the query value is signed as-is, so a
-// `application/pdf;  charset=x` would reproduce the same 403 through
-// Content-Type instead of Content-Disposition.
-func TestIssue760_SignedContentTypeInvariant(t *testing.T) {
+// TestIssue760_EchoedContentTypeMatchesSigned covers the second header that
+// can carry a client-controlled whitespace run.
+//
+// The property that matters is NOT "the signed value is collapsed" — minio-go
+// runs signV4TrimAll over whatever it is given, so the signature is identical
+// either way and asserting on presignPutHeaders' output proves nothing. What
+// breaks uploads is the client echoing a value the gateway canonicalizes
+// differently, so the assertion is: the value handed to the client must equal
+// the value that ends up signed, and both must be Trimall-stable.
+//
+// getUploadCredentials only overrides the caller's contentType when
+// mime.TypeByExtension resolves the extension; the prod image is alpine with
+// no /etc/mime.types, so .docx / .xlsx / .zip fall through to the raw query
+// value and this is reachable in production.
+func TestIssue760_EchoedContentTypeMatchesSigned(t *testing.T) {
 	contentTypes := []string{
 		"application/octet-stream",
+		`application/vnd.openxmlformats-officedocument.wordprocessingml.document; name="a  b.docx"`,
 		"application/pdf;  charset=utf-8",
 		"text/plain;\t\tcharset=utf-8",
 		"  application/json  ",
 	}
-	for _, ct := range contentTypes {
-		t.Run(ct, func(t *testing.T) {
-			headers := presignPutHeaders(ct, "", 4096)
-			got := headers.Get("Content-Type")
-			assert.Equal(t, got, trimAllMinIO(got),
-				"signed Content-Type must be stable under SigV4 Trimall; got %q", got)
+	for _, raw := range contentTypes {
+		t.Run(raw, func(t *testing.T) {
+			// What getUploadCredentials puts in resp["contentType"].
+			echoed := collapseSignableWhitespace(raw)
+			// What ends up in the SigV4 canonical headers for that value.
+			signed := trimAllMinIO(presignPutHeaders(echoed, "", 4096).Get("Content-Type"))
+
+			assert.Equal(t, echoed, signed,
+				"client echoes %q but the signature covers %q", echoed, signed)
+			assert.Equal(t, echoed, trimAllQuotedAware(echoed),
+				"echoed Content-Type must also be stable under the COS/AWS rule")
 		})
 	}
 }

--- a/modules/file/issue760_sigv4_space_repro_test.go
+++ b/modules/file/issue760_sigv4_space_repro_test.go
@@ -406,22 +406,20 @@ func TestIssue760_CharacterMatrix(t *testing.T) {
 // must already be Trimall-stable, i.e. collapsing its whitespace runs must be
 // a no-op.
 //
-// This is the acceptance assertion for the GH#760 fix and it FAILS on the
-// current code — BuildContentDisposition emits `filename="Octo  upload
-// test.pdf"` verbatim. It is skipped so the reproduction can land without
-// turning CI red; drop the Skip in the commit that fixes
-// BuildContentDisposition, and it becomes the permanent regression guard
-// (stricter than enumerating filenames: anything that puts a whitespace run
-// into a signed header trips it).
+// This is the acceptance assertion for the GH#760 fix, and now its permanent
+// regression guard: it is stricter than enumerating filenames, because
+// anything that puts a whitespace run into a signed header trips it.
 func TestIssue760_SignedHeaderInvariant(t *testing.T) {
-	t.Skip("expected to fail until GH#760 is fixed; unskip together with the BuildContentDisposition fix")
-
 	filenames := []string{
 		"Octo upload test.pdf",
 		"Octo  upload test.pdf",
 		"Octo   upload  test.pdf",
+		"  leading.pdf",
+		"trailing  .pdf",
 		"report.pdf",
 		"报告 文档.pdf",
+		"报告  文档.pdf",
+		"photo\U0001F600  x.jpg",
 	}
 	for _, raw := range filenames {
 		t.Run(raw, func(t *testing.T) {
@@ -432,22 +430,83 @@ func TestIssue760_SignedHeaderInvariant(t *testing.T) {
 	}
 }
 
+// TestIssue760_SignedContentTypeInvariant covers the second signed header that
+// can carry a client-controlled whitespace run. getUploadCredentials only
+// overrides the caller's contentType when mime.TypeByExtension resolves the
+// extension; when it does not, the query value is signed as-is, so a
+// `application/pdf;  charset=x` would reproduce the same 403 through
+// Content-Type instead of Content-Disposition.
+func TestIssue760_SignedContentTypeInvariant(t *testing.T) {
+	contentTypes := []string{
+		"application/octet-stream",
+		"application/pdf;  charset=utf-8",
+		"text/plain;\t\tcharset=utf-8",
+		"  application/json  ",
+	}
+	for _, ct := range contentTypes {
+		t.Run(ct, func(t *testing.T) {
+			headers := presignPutHeaders(ct, "", 4096)
+			got := headers.Get("Content-Type")
+			assert.Equal(t, got, trimAllMinIO(got),
+				"signed Content-Type must be stable under SigV4 Trimall; got %q", got)
+		})
+	}
+}
+
 // triggers760 reports whether a filename, once put through the production
 // handler path, yields a Content-Disposition that SigV4 Trimall would rewrite
-// — the exact predicate for the 403. No gateway needed.
+// — the exact predicate for the 403. No gateway needed. Post-fix this is
+// false for every input; that is what the tables below assert.
 func triggers760(rawFilename string) (bool, string) {
 	cd := BuildContentDisposition(sanitizeFilename(rawFilename))
 	return trimAllMinIO(cd) != cd, cd
 }
 
+// naiveContentDisposition reconstructs the pre-fix header exactly as
+// BuildContentDisposition emitted it before GH#760 was closed: the quoted
+// ASCII fallback keeps whatever whitespace the filename carried.
+//
+// Keeping it in the test file lets the tables below assert BOTH halves of the
+// fix — that the shipped code is now Trimall-stable, and that each "trigger"
+// row really was a defect rather than a case that never reproduced. Without
+// it, a regression that quietly stopped exercising these names would still
+// look green.
+func naiveContentDisposition(filename string) string {
+	if filename == "" {
+		return ""
+	}
+	encoded := rfc5987Encode(filename)
+	var fallback strings.Builder
+	for _, r := range filename {
+		if r > 127 {
+			fallback.WriteRune('_')
+		} else {
+			fallback.WriteRune(r)
+		}
+	}
+	safe := strings.ReplaceAll(fallback.String(), `\`, `\\`)
+	safe = strings.ReplaceAll(safe, `"`, `\"`)
+	return "inline; filename=\"" + safe + "\"; filename*=UTF-8''" + encoded
+}
+
+func triggersPreFix(rawFilename string) bool {
+	cd := naiveContentDisposition(sanitizeFilename(rawFilename))
+	return trimAllMinIO(cd) != cd
+}
+
 // TestIssue760_TriggerRule pins the trigger down to one rule: the quoted
 // ASCII fallback must carry a run of two or more literal spaces. Everything
-// else about the name — length, script, punctuation, extension — is irrelevant.
+// else about the name — length, script, punctuation, extension — is
+// irrelevant.
+//
+// `wasTrigger` is the pre-fix outcome. Every row must now be stable under
+// Trimall (no 403 possible), and every `wasTrigger` row must still be a case
+// the pre-fix construction would have broken on.
 func TestIssue760_TriggerRule(t *testing.T) {
 	cases := []struct {
-		name string
-		want bool
-		why  string
+		name       string
+		wasTrigger bool
+		why        string
 	}{
 		// --- triggers ---
 		{"Octo  upload test.pdf", true, "two U+0020"},
@@ -474,8 +533,10 @@ func TestIssue760_TriggerRule(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			got, cd := triggers760(tc.name)
-			t.Logf("trigger=%-5v cd=%q  (%s)", got, cd, tc.why)
-			assert.Equal(t, tc.want, got)
+			t.Logf("trigger=%-5v (pre-fix %-5v) cd=%q  (%s)", got, tc.wasTrigger, cd, tc.why)
+			assert.False(t, got, "shipped header must be Trimall-stable")
+			assert.Equal(t, tc.wasTrigger, triggersPreFix(tc.name),
+				"pre-fix classification of this row changed — the table no longer describes the defect")
 		})
 	}
 }
@@ -491,9 +552,9 @@ func TestIssue760_TriggerRule(t *testing.T) {
 // the trigger.
 func TestIssue760_ReportedFilenames(t *testing.T) {
 	reported := []struct {
-		source   string
-		filename string
-		want     bool
+		source     string
+		filename   string
+		wasTrigger bool
 	}{
 		{"#760 fixture 02-FAIL", "02-FAIL-Octo  upload test.pdf", true},
 		{"#760 fixture 01-PASS", "01-PASS-Octo upload test.pdf", false},
@@ -507,8 +568,10 @@ func TestIssue760_ReportedFilenames(t *testing.T) {
 	for _, r := range reported {
 		t.Run(r.source, func(t *testing.T) {
 			got, cd := triggers760(r.filename)
-			t.Logf("trigger=%-5v %q\n           cd=%q", got, r.filename, cd)
-			assert.Equal(t, r.want, got)
+			t.Logf("trigger=%-5v (pre-fix %-5v) %q\n           cd=%q",
+				got, r.wasTrigger, r.filename, cd)
+			assert.False(t, got, "shipped header must be Trimall-stable")
+			assert.Equal(t, r.wasTrigger, triggersPreFix(r.filename))
 		})
 	}
 }

--- a/modules/file/issue760_sigv4_space_repro_test.go
+++ b/modules/file/issue760_sigv4_space_repro_test.go
@@ -213,14 +213,12 @@ func repro760Presign(t *testing.T, host string, contentType, contentDisposition 
 	})
 	require.NoError(t, err)
 
-	headers := http.Header{}
-	headers.Set("Content-Length", strconv.FormatInt(fileSize, 10))
-	if contentType != "" {
-		headers.Set("Content-Type", contentType)
-	}
-	if contentDisposition != "" {
-		headers.Set("Content-Disposition", contentDisposition)
-	}
+	// Build the signed header set through the production helper rather than a
+	// hand-written copy, so this harness keeps matching ServiceCOS as the
+	// header set evolves. The independent-oracle property is not lost:
+	// naiveContentDisposition below is the pre-fix counter-example, and the
+	// sweeps assert BuildContentDisposition's output directly.
+	headers := presignPutHeaders(contentType, contentDisposition, fileSize)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
@@ -454,8 +452,10 @@ func TestIssue760_EchoedContentTypeMatchesSigned(t *testing.T) {
 	}
 	for _, raw := range contentTypes {
 		t.Run(raw, func(t *testing.T) {
-			// What getUploadCredentials puts in resp["contentType"].
-			echoed := collapseSignableWhitespace(raw)
+			// The production normalizer, not a copy of it. The handler-level
+			// guard that this is actually wired into getUploadCredentials is
+			// TestGetUploadCredentials_ContentTypeContract.
+			echoed := normalizeUploadContentType(raw)
 			// What ends up in the SigV4 canonical headers for that value.
 			signed := trimAllMinIO(presignPutHeaders(echoed, "", 4096).Get("Content-Type"))
 

--- a/modules/file/issue760_sigv4_space_repro_test.go
+++ b/modules/file/issue760_sigv4_space_repro_test.go
@@ -431,3 +431,84 @@ func TestIssue760_SignedHeaderInvariant(t *testing.T) {
 		})
 	}
 }
+
+// triggers760 reports whether a filename, once put through the production
+// handler path, yields a Content-Disposition that SigV4 Trimall would rewrite
+// — the exact predicate for the 403. No gateway needed.
+func triggers760(rawFilename string) (bool, string) {
+	cd := BuildContentDisposition(sanitizeFilename(rawFilename))
+	return trimAllMinIO(cd) != cd, cd
+}
+
+// TestIssue760_TriggerRule pins the trigger down to one rule: the quoted
+// ASCII fallback must carry a run of two or more literal spaces. Everything
+// else about the name — length, script, punctuation, extension — is irrelevant.
+func TestIssue760_TriggerRule(t *testing.T) {
+	cases := []struct {
+		name string
+		want bool
+		why  string
+	}{
+		// --- triggers ---
+		{"Octo  upload test.pdf", true, "two U+0020"},
+		{"Octo   upload test.pdf", true, "three U+0020"},
+		{"  leading.pdf", true, "run at the start of the name"},
+		{"trailing  .pdf", true, "run before the extension"},
+		{"报告  文档.pdf", true, "CJK is irrelevant; the ASCII spaces survive"},
+		{"photo\U0001F600  x.jpg", true, "emoji is irrelevant"},
+		{"a  b.pdf", true, "shortest possible trigger"},
+
+		// --- does not trigger ---
+		{"Octo upload test.pdf", false, "single space"},
+		{" leading.pdf", false, "single leading space"},
+		{"a\tb.pdf", false, "tab is replaced by '_' in sanitizeFilename"},
+		{"a\t\tb.pdf", false, "even a tab run never reaches the header"},
+		{"a　　b.pdf", false, "U+3000 replaced by '_' in the quoted fallback"},
+		{"a  b.pdf", false, "U+00A0 likewise"},
+		{"a  b.pdf", false, "U+202F likewise"},
+		{"a​​b.pdf", false, "U+200B likewise"},
+		{"报告 文档.pdf", false, "CJK with a single space"},
+		{"very-long-name-without-any-spaces-at-all-0123456789.xlsx", false, "length alone is not a trigger"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, cd := triggers760(tc.name)
+			t.Logf("trigger=%-5v cd=%q  (%s)", got, cd, tc.why)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestIssue760_ReportedFilenames runs the names actually reported across
+// octo-server#760 and octo-web#348 / #1312 through the same predicate.
+//
+// Only the #760 fixtures — the one reporter who stated space counts
+// explicitly — trigger. Every other reported name, as transcribed in the
+// issue text, does NOT reproduce. That is expected rather than
+// contradictory: rendered Markdown collapses runs of spaces, and several of
+// those names are visibly truncated, so the transcriptions cannot preserve
+// the trigger.
+func TestIssue760_ReportedFilenames(t *testing.T) {
+	reported := []struct {
+		source   string
+		filename string
+		want     bool
+	}{
+		{"#760 fixture 02-FAIL", "02-FAIL-Octo  upload test.pdf", true},
+		{"#760 fixture 01-PASS", "01-PASS-Octo upload test.pdf", false},
+		{"#348 as transcribed (xlsx)", "Lincoln 2026 Q2 Lincoln Z Launch Campaign Jun Autohome.xlsx", false},
+		{"#348 as transcribed (pdf)", "Miaozhen Onboarding.pdf", false},
+		{"#348 as transcribed (docx)", "中考体育跑鞋推荐 推荐榜单 中考体育跑鞋推荐清单，柔态碳板更适配青少年体测.docx", false},
+		{"#348 truncated in report (pptx)", "【结案报告-更新2】2.pptx", false},
+		{"#1312 truncated in report (zip)", "0807 设置中心 - 设计.zip", false},
+	}
+
+	for _, r := range reported {
+		t.Run(r.source, func(t *testing.T) {
+			got, cd := triggers760(r.filename)
+			t.Logf("trigger=%-5v %q\n           cd=%q", got, r.filename, cd)
+			assert.Equal(t, r.want, got)
+		})
+	}
+}

--- a/modules/file/service_cos.go
+++ b/modules/file/service_cos.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"net/url"
 	"path"
-	"strconv"
 	"strings"
 	"time"
 
@@ -348,14 +347,7 @@ func (sc *ServiceCOS) PresignedPutURL(objectPath string, contentType string, con
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	headers := http.Header{}
-	headers.Set("Content-Length", strconv.FormatInt(fileSize, 10))
-	if contentType != "" {
-		headers.Set("Content-Type", contentType)
-	}
-	if contentDisposition != "" {
-		headers.Set("Content-Disposition", contentDisposition)
-	}
+	headers := presignPutHeaders(contentType, contentDisposition, fileSize)
 	presigned, err := client.PresignHeader(ctx, http.MethodPut, cosConfig.Bucket, key, expires, nil, headers)
 	if err != nil {
 		return "", "", fmt.Errorf("生成预签名URL失败: %w", err)

--- a/modules/file/service_minio.go
+++ b/modules/file/service_minio.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -400,14 +399,7 @@ func (sm *ServiceMinio) PresignedPutURL(objectPath string, contentType string, c
 	// PUT of any size against the URL. Content-Type / Content-Disposition
 	// piggy-back on the same path so the per-header behaviour stays
 	// consistent with the rest of the file module.
-	headers := http.Header{}
-	headers.Set("Content-Length", strconv.FormatInt(fileSize, 10))
-	if contentType != "" {
-		headers.Set("Content-Type", contentType)
-	}
-	if contentDisposition != "" {
-		headers.Set("Content-Disposition", contentDisposition)
-	}
+	headers := presignPutHeaders(contentType, contentDisposition, fileSize)
 	presigned, err := publicClient.PresignHeader(ctx, http.MethodPut, bucketName, objectKey, expires, nil, headers)
 	if err != nil {
 		return "", "", fmt.Errorf("生成预签名URL失败: %w", err)

--- a/modules/file/service_s3.go
+++ b/modules/file/service_s3.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 	"net/url"
 	"path"
-	"strconv"
 	"strings"
 	"time"
 
@@ -301,14 +300,7 @@ func (s *ServiceS3) PresignedPutURL(objectPath string, contentType string, conte
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	headers := http.Header{}
-	headers.Set("Content-Length", strconv.FormatInt(fileSize, 10))
-	if contentType != "" {
-		headers.Set("Content-Type", contentType)
-	}
-	if contentDisposition != "" {
-		headers.Set("Content-Disposition", contentDisposition)
-	}
+	headers := presignPutHeaders(contentType, contentDisposition, fileSize)
 	presigned, err := client.PresignHeader(ctx, http.MethodPut, cfg.Bucket, key, expires, nil, headers)
 	if err != nil {
 		return "", "", fmt.Errorf("生成预签名URL失败: %w", err)

--- a/tools/repro-gh760/main.go
+++ b/tools/repro-gh760/main.go
@@ -11,8 +11,21 @@
 //	                                  applying the AWS/COS quoted-string
 //	                                  Trimall rule, one applying minio-go's.
 //
-// Not part of either repo — throwaway rig so the octo-web upload path can be
-// exercised end to end without cloud credentials.
+// Consumed by octo-web packages/dmworkdatasource/src/issue760.upload.e2e.test.ts,
+// which skips unless OCTO_REPRO_GATEWAY_API points here.
+//
+// Fidelity limits — this is an external package, so the unexported parts of
+// the handler cannot be reused. It mirrors production for the signing
+// boundary only:
+//
+//	mirrored  — BuildContentDisposition (the real exported function), the
+//	            signed header set, minio-go PresignHeader, the response shape,
+//	            and the same whitespace normalization getUploadCredentials
+//	            applies to contentType.
+//	NOT mirrored — sanitizeFilename, the extension allowlist, fileSize bounds,
+//	            auth, and the sticker keyspace guard (all unexported or
+//	            request-scoped). Feed it names that are already sanitize-clean,
+//	            and do not read a result here as a statement about validation.
 package main
 
 import (
@@ -211,6 +224,9 @@ func serveCredentials(w http.ResponseWriter, r *http.Request, gateways map[strin
 
 	// The production line under test.
 	contentDisposition := file.BuildContentDisposition(filename)
+	// Mirrors the normalization getUploadCredentials applies before it both
+	// signs contentType and echoes it to the client (GH#760).
+	contentType = strings.Join(strings.Fields(contentType), " ")
 
 	client, err := minio.New(gw.addr, &minio.Options{
 		Creds:        credentials.NewStaticV4(accessKey, secretKey, ""),

--- a/tools/repro-gh760/main.go
+++ b/tools/repro-gh760/main.go
@@ -1,0 +1,344 @@
+// Cross-repo harness for GH#760: a fake COS that octo-web can actually talk to.
+//
+// Serves two things:
+//
+//	GET  /file/upload/credentials   — the octo-server response shape, with
+//	                                  Content-Disposition built by the REAL
+//	                                  file.BuildContentDisposition and the URL
+//	                                  presigned by minio-go v7.0.61, exactly as
+//	                                  ServiceCOS.PresignedPutURL does.
+//	PUT  /<bucket>/<key>            — SigV4 verification. Two listeners: one
+//	                                  applying the AWS/COS quoted-string
+//	                                  Trimall rule, one applying minio-go's.
+//
+// Not part of either repo — throwaway rig so the octo-web upload path can be
+// exercised end to end without cloud credentials.
+package main
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"net/http"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-server/modules/file"
+	"github.com/minio/minio-go/v7"
+	"github.com/minio/minio-go/v7/pkg/credentials"
+	"github.com/minio/minio-go/v7/pkg/s3utils"
+)
+
+const (
+	accessKey = "AKIAREPRO760EXAMPLE"
+	secretKey = "wJalrXUtnFEMI-K7MDENG-bPxRfiCYEXAMPLEKEY"
+	region    = "ap-guangzhou"
+	bucket    = "octo-repro-1250000000"
+)
+
+// minio-go v7.0.61 pkg/signer/utils.go signV4TrimAll, verbatim.
+func trimAllMinIO(in string) string { return strings.Join(strings.Fields(in), " ") }
+
+// AWS SigV4 Trimall: collapse runs outside quoted strings only.
+func trimAllQuotedAware(in string) string {
+	in = strings.Trim(in, " \t")
+	var b strings.Builder
+	inQuotes, prevSpace := false, false
+	for i := 0; i < len(in); i++ {
+		c := in[i]
+		if c == '\\' && inQuotes && i+1 < len(in) {
+			b.WriteByte(c)
+			b.WriteByte(in[i+1])
+			i++
+			prevSpace = false
+			continue
+		}
+		if c == '"' {
+			inQuotes = !inQuotes
+			b.WriteByte(c)
+			prevSpace = false
+			continue
+		}
+		if !inQuotes && (c == ' ' || c == '\t') {
+			if prevSpace {
+				continue
+			}
+			prevSpace = true
+			b.WriteByte(' ')
+			continue
+		}
+		prevSpace = false
+		b.WriteByte(c)
+	}
+	return b.String()
+}
+
+type gateway struct {
+	name    string
+	addr    string
+	trimAll func(string) string
+
+	mu         sync.Mutex
+	lastCD     string
+	lastStatus int
+	lastBytes  int64
+}
+
+func (g *gateway) record(cd string, status int, n int64) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.lastCD, g.lastStatus, g.lastBytes = cd, status, n
+}
+
+func (g *gateway) snapshot() map[string]any {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return map[string]any{"observedContentDisposition": g.lastCD, "status": g.lastStatus, "bytes": g.lastBytes}
+}
+
+func (g *gateway) canonicalRequest(r *http.Request) string {
+	q := r.URL.Query()
+	signed := strings.Split(q.Get("X-Amz-SignedHeaders"), ";")
+	sort.Strings(signed)
+	q.Del("X-Amz-Signature")
+
+	var headers strings.Builder
+	for _, h := range signed {
+		var v string
+		switch h {
+		case "host":
+			v = r.Host
+		case "content-length":
+			v = strconv.FormatInt(r.ContentLength, 10)
+		default:
+			v = r.Header.Get(h)
+		}
+		headers.WriteString(h + ":" + g.trimAll(v) + "\n")
+	}
+	return strings.Join([]string{
+		r.Method,
+		s3utils.EncodePath(r.URL.Path),
+		strings.ReplaceAll(q.Encode(), "+", "%20"),
+		headers.String(),
+		strings.Join(signed, ";"),
+		"UNSIGNED-PAYLOAD",
+	}, "\n")
+}
+
+func (g *gateway) servePut(w http.ResponseWriter, r *http.Request) {
+	n, _ := io.Copy(io.Discard, r.Body)
+
+	q := r.URL.Query()
+	parts := strings.SplitN(q.Get("X-Amz-Credential"), "/", 2)
+	if len(parts) != 2 {
+		http.Error(w, "InvalidCredential", http.StatusForbidden)
+		return
+	}
+	scope := parts[1]
+
+	sum := sha256.Sum256([]byte(g.canonicalRequest(r)))
+	sts := strings.Join([]string{
+		"AWS4-HMAC-SHA256", q.Get("X-Amz-Date"), scope, hex.EncodeToString(sum[:]),
+	}, "\n")
+
+	mac := func(k, d []byte) []byte {
+		h := hmac.New(sha256.New, k)
+		h.Write(d)
+		return h.Sum(nil)
+	}
+	k := mac([]byte("AWS4"+secretKey), []byte(strings.SplitN(scope, "/", 2)[0]))
+	k = mac(k, []byte(region))
+	k = mac(k, []byte("s3"))
+	k = mac(k, []byte("aws4_request"))
+	want := hex.EncodeToString(mac(k, []byte(sts)))
+
+	cd := r.Header.Get("Content-Disposition")
+	if hmac.Equal([]byte(want), []byte(q.Get("X-Amz-Signature"))) {
+		g.record(cd, http.StatusOK, n)
+		log.Printf("[%s] PUT 200  bytes=%d  cd=%q", g.name, n, cd)
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+	g.record(cd, http.StatusForbidden, n)
+	log.Printf("[%s] PUT 403 SignatureDoesNotMatch  bytes=%d  cd=%q", g.name, n, cd)
+	w.Header().Set("Content-Type", "application/xml")
+	w.WriteHeader(http.StatusForbidden)
+	_, _ = io.WriteString(w,
+		`<?xml version="1.0" encoding="UTF-8"?><Error><Code>SignatureDoesNotMatch</Code>`+
+			`<Message>The request signature we calculated does not match the signature you provided.</Message></Error>`)
+}
+
+// serveCredentials mirrors getUploadCredentials' response shape.
+func serveCredentials(w http.ResponseWriter, r *http.Request, gateways map[string]*gateway) {
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	w.Header().Set("Access-Control-Allow-Headers", "*")
+	if r.Method == http.MethodOptions {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
+	q := r.URL.Query()
+	filename := q.Get("filename")
+	contentType := q.Get("contentType")
+	if contentType == "" {
+		contentType = "application/octet-stream"
+	}
+	fileSize, err := strconv.ParseInt(q.Get("fileSize"), 10, 64)
+	if err != nil || fileSize <= 0 {
+		http.Error(w, `{"msg":"fileSize 参数必须为正整数（字节）"}`, http.StatusBadRequest)
+		return
+	}
+	target := q.Get("gateway")
+	if target == "" {
+		target = "cos"
+	}
+	gw, ok := gateways[target]
+	if !ok {
+		http.Error(w, `{"msg":"unknown gateway"}`, http.StatusBadRequest)
+		return
+	}
+
+	// The production line under test.
+	contentDisposition := file.BuildContentDisposition(filename)
+
+	client, err := minio.New(gw.addr, &minio.Options{
+		Creds:        credentials.NewStaticV4(accessKey, secretKey, ""),
+		Secure:       false,
+		Region:       region,
+		BucketLookup: minio.BucketLookupPath,
+	})
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	key := "chat" + q.Get("path")
+	headers := http.Header{}
+	headers.Set("Content-Length", strconv.FormatInt(fileSize, 10))
+	headers.Set("Content-Type", contentType)
+	if contentDisposition != "" {
+		headers.Set("Content-Disposition", contentDisposition)
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
+	defer cancel()
+	presigned, err := client.PresignHeader(ctx, http.MethodPut, bucket, key, 30*time.Minute, nil, headers)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	resp := map[string]any{
+		"method":      "PUT",
+		"uploadUrl":   presigned.String(),
+		"downloadUrl": "http://" + gw.addr + "/" + bucket + "/" + strings.TrimPrefix(key, "/"),
+		"contentType": contentType,
+		"key":         key,
+		"expiresIn":   1800,
+		"expiredTime": time.Now().Add(30 * time.Minute).Unix(),
+		"maxFileSize": fileSize,
+	}
+	if contentDisposition != "" {
+		resp["contentDisposition"] = contentDisposition
+	}
+	log.Printf("[credentials] gateway=%s filename=%q cd=%q", target, filename, contentDisposition)
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
+func listen() (net.Listener, string) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		log.Fatal(err)
+	}
+	return ln, ln.Addr().String()
+}
+
+func main() {
+	portsOut := flag.String("ports-file", "", "write the resolved addresses here as JSON")
+	flag.Parse()
+
+	cosLn, cosAddr := listen()
+	minioLn, minioAddr := listen()
+	apiLn, apiAddr := listen()
+
+	gateways := map[string]*gateway{
+		"cos":   {name: "cos", addr: cosAddr, trimAll: trimAllQuotedAware},
+		"minio": {name: "minio", addr: minioAddr, trimAll: trimAllMinIO},
+	}
+
+	for _, gw := range gateways {
+		g := gw
+		mux := http.NewServeMux()
+		mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Access-Control-Allow-Origin", "*")
+			w.Header().Set("Access-Control-Allow-Headers", "*")
+			w.Header().Set("Access-Control-Allow-Methods", "PUT,GET,OPTIONS")
+			if r.Method == http.MethodOptions {
+				w.WriteHeader(http.StatusOK)
+				return
+			}
+			if r.Method != http.MethodPut {
+				http.Error(w, "only PUT", http.StatusMethodNotAllowed)
+				return
+			}
+			g.servePut(w, r)
+		})
+		ln := cosLn
+		if g.name == "minio" {
+			ln = minioLn
+		}
+		go func() { _ = http.Serve(ln, mux) }()
+	}
+
+	apiMux := http.NewServeMux()
+	apiMux.HandleFunc("/file/upload/credentials", func(w http.ResponseWriter, r *http.Request) {
+		serveCredentials(w, r, gateways)
+	})
+	apiMux.HandleFunc("/v1/file/upload/credentials", func(w http.ResponseWriter, r *http.Request) {
+		serveCredentials(w, r, gateways)
+	})
+	// What the client actually put on the wire, for pass-through assertions.
+	apiMux.HandleFunc("/repro/last", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+		name := r.URL.Query().Get("gateway")
+		if name == "" {
+			name = "cos"
+		}
+		gw, ok := gateways[name]
+		if !ok {
+			http.Error(w, `{"msg":"unknown gateway"}`, http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(gw.snapshot())
+	})
+	go func() { _ = http.Serve(apiLn, apiMux) }()
+
+	addrs := map[string]string{
+		"api":   "http://" + apiAddr + "/",
+		"cos":   "http://" + cosAddr,
+		"minio": "http://" + minioAddr,
+	}
+	blob, _ := json.Marshal(addrs)
+	if *portsOut != "" {
+		if err := os.WriteFile(*portsOut, blob, 0o644); err != nil {
+			log.Fatal(err)
+		}
+	}
+	fmt.Println(string(blob))
+	log.Printf("api=%s cos=%s minio=%s", addrs["api"], addrs["cos"], addrs["minio"])
+	select {}
+}


### PR DESCRIPTION
## Summary

A filename carrying two or more consecutive `U+0020` made every presigned PUT fail with `403 SignatureDoesNotMatch` on Tencent COS, regardless of file bytes, size, format or extension. This makes the signed upload headers survive SigV4 canonicalization unchanged, so both sides of the handshake derive the same value.

The user's filename is not modified. The exact name, consecutive spaces and all, is still carried losslessly by the RFC 5987 `filename*` parameter (spaces as `%20`), which is what modern browsers prefer — download names do not change. Only the legacy quoted ASCII fallback `filename="…"` is normalized, because it is the only part that puts literal whitespace into a signed value.

```
before  inline; filename="Octo  upload test.pdf"; filename*=UTF-8''Octo%20%20upload%20test.pdf
after   inline; filename="Octo upload test.pdf";  filename*=UTF-8''Octo%20%20upload%20test.pdf
                          ^ collapsed (legacy fallback)   ^ untouched, this is what the user sees
```

**Root cause.** SigV4 hashes a *canonical* form of each signed header value, and the two implementations disagree on one rule:

- minio-go v7.0.61 `signV4TrimAll` (`pkg/signer/utils.go`) is `strings.Join(strings.Fields(v), " ")` — it collapses whitespace runs **anywhere**, including inside a quoted string.
- AWS SigV4 states *"Do not trim excess white space in a header value if it appears within a quoted string"*, and Tencent COS enforces that exception.

So `filename="a  b.pdf"` is signed as `filename="a b.pdf"` and verified as `filename="a  b.pdf"` — different canonical requests, different signatures. The MinIO backend never exposed this because MinIO server ships the same `signV4TrimAll` and both sides collapse alike; only COS (and AWS S3, which follows the same exception) is affected.

The emitted values are fixed points of the *aggressive* rule (no whitespace runs, no leading/trailing whitespace), which makes them fixed points of the quoted-string-aware rule and of a hypothetical verbatim gateway too. The fix therefore does not depend on COS implementing exactly the rule modelled here.

The client is not involved: octo-web echoes `contentDisposition` byte for byte, verified against a live gateway.

## Related Issue

Fixes #760. Also the server-side cause of Mininglamp-OSS/octo-web#348.

Prior art: #219 took a different shape (stop signing `Content-Disposition` at all). It was approved by three reviewers and then closed unmerged without a stated reason. Its root-cause description — browser/proxy/gateway canonicalizing differently — is not what happens; the rewrite is on the signing side. That approach also drops stored disposition metadata for presigned uploads and does not cover the server-side multipart path, so this PR fixes the header at its source instead. The two are orthogonal.

## Linked Spec

`.octospec/tasks/presigned-upload-signed-header-whitespace/brief.md`

## Changes

**`Content-Disposition`**

- `BuildContentDisposition` collapses whitespace runs in the quoted ASCII fallback and degrades an all-whitespace name to `"file"` instead of emitting `filename=""`. `filename*` is untouched.
- The same fallback scrubs C0 controls and DEL to `_`. Collapsing only folds the whitespace controls, so a `0x01` would otherwise reach the header and Go's transport refuses to send such a request at all (`invalid header field value`) — the credentials endpoint would hand clients a header they cannot use. `modules/bot_api` and `modules/robot` pass the raw multipart filename / query parameter straight in, so this guarantee has to live at the header source.

**`Content-Type`** — same invariant, via `normalizeUploadContentType`, applied in `getUploadCredentials` where the value is resolved so the value signed and the value echoed are one string. This is reachable in production: the prod image is `alpine:3.21` with no `/etc/mime.types`, so `mime.TypeByExtension` returns `""` for `.docx` / `.xlsx` / `.pptx` / `.zip` and the caller's query value survives untouched — a parameter such as `; name="a  b"` reproduces the identical 403 through the other header.

- The `application/octet-stream` default is applied **after** the collapse, not before. `?contentType=%20%20` is not `""`, so a default that runs first never fires; the value then collapses to `""`, drops out of the signed header set, and is echoed as an empty field of a documented wire contract. Side effect worth naming: on that edge path `Content-Type` now enters the signed header set where it previously did not, so a client must echo it — which the contract already requires.
- A value carrying a byte that cannot appear in a header value degrades to the same default rather than being mangled: inventing a MIME type the caller never asked for is worse than an honest default. This is deliberately different from the filename fallback, where preserving as much of the name as possible is the point.

**Shared plumbing**

- COS / MinIO / S3 build their signed header set through one `presignPutHeaders`, so the invariant cannot drift between three copies. Its own collapse is defence in depth, not the fix — minio-go trims every value it signs, so what decides the outcome is the value handed to the client. Aliyun OSS builds its options separately and is untouched; note its V1 string-to-sign does cover `Content-Type` (verbatim, no trim step) and does not cover `Content-Disposition`.
- `isInvalidHeaderByte` is shared by both normalizers rather than open-coded twice.
- `tools/repro-gh760`: a credential-free reproduction gateway that serves the credentials response shape and verifies SigV4 under either Trimall rule.

Fixing this at the header source also covers the server-side multipart `UploadFile` path, which signs the same disposition on COS and S3.

## Testing

- [x] Unit tests added/updated
- [x] Manually verified

**Offline reproduction, then fix.** `modules/file/issue760_sigv4_space_repro_test.go` wires the real `sanitizeFilename` → `BuildContentDisposition` → minio-go `PresignHeader` to an `httptest` gateway that verifies SigV4, parameterised by the Trimall rule. Every row that returned 403 before returns 200 now, with `filename*` still carrying `%20%20`. The same request was accepted by a minio-rule gateway before and after, which is why the MinIO backend never showed the bug.

**Property, not enumeration.** `TestIssue760_SignedHeaderInvariant` asserts the emitted header is its own Trimall fixed point. `issue760_filename_sweep_test.go` sweeps that property plus header-value validity and quote balance over: all 128 ASCII code points at four positions in runs of 1–3, all 25 Unicode whitespace code points, mixed ASCII/exotic whitespace runs, quote and backslash injection, fake disposition parameters, and 20k seeded random names — each through both the sanitized and the raw entry shape. `TestIssue760_SweepIsNotVacuous` asserts the pre-fix construction fails the same property, so the sweep cannot pass silently.

**Handler-level guard for the content-type half.** `TestGetUploadCredentials_ContentTypeContract` drives `getUploadCredentials` itself and asserts on what it emits: a Trimall fixed point, a legal header value, and equal to the value handed to the service. Asserting `echoed == signed` alone would not bite — the mock records the handler's value on both sides — which is why the properties are asserted instead. Verified by mutation: neutering the normalization turns it red. The cases use `.ini`, allow-listed and unmapped even in images shipping `/etc/mime.types`, because a resolvable extension makes `mime.TypeByExtension` overwrite the caller's value and the test vacuous; a `require()` fails loudly if some environment ever maps it.

```
go test ./modules/file/                      ok (2.9s)
go build ./... , go vet ./modules/...        ok
golangci-lint run ./modules/file/...         0 issues
make i18n-extract-check , make i18n-lint     ok
```

**Regression check.** `modules/{file,robot,bot_api,botfather,group}` were run on this branch and on `origin/main`; the failing sets are identical (`diff` empty). Those failures are `testutil.NewTestServer()` failing to reach MySQL in the sandbox, not this change.

**Cross-repo.** octo-web's real `MediaMessageUploadTask` (no axios mock) was run against the harness: a double-space filename now uploads 200, and the gateway records a `Content-Disposition` byte-identical to what the credentials response returned.

**Not verified: a real Tencent COS gateway.** Every result above comes from a local stand-in implementing the AWS quoted-string rule. A smoke test against production COS with a consecutive-space filename — on the presigned path and on the server-side multipart path, which this change also reaches — is the right pre-merge gate. The fixtures attached to #760 can be used directly.

## Known follow-ups (non-blocking, raised in review)

Recorded here so they are tracked rather than lost; none of them is introduced by this diff.

- `modules/file/api.go:246` — the server-side multipart handler's `contenttype` form field is still un-normalized and reaches `PutObject` untouched, so `application/pdf; name="a  b"` reproduces the same asymmetry on that endpoint. Low reachability (no first-party client sends a parameterised content type) and pre-existing, but it is the same invariant; `normalizeUploadContentType` already exists.
- `modules/bot_api` / `modules/robot` echo `contentType` un-normalized. It cannot diverge today because both derive it from `mime.TypeByExtension` with a constant fallback, but the invariant is enforced at the source only in `modules/file`.
- `modules/bot_api` / `modules/robot` still skip `sanitizeFilename`. This change makes the emitted header safe either way; the missing sanitization is an independent hardening item.
- `.html` / `.htm` are on the upload allowlist while the disposition is `inline` and a caller-supplied `contentType` survives whenever the extension cannot be resolved. On a storage domain that serves objects directly that is a stored-content surface. Untouched here, better as its own issue.
- `sanitizeFilename` replaces `< 0x20` but not `0x7F`; this PR covers DEL for the header, but the raw byte still reaches `filename*` and the stored object metadata.

## COMPREHENSION

1. **What does this change actually do to the load-bearing path?**

   It changes the bytes of two headers that are simultaneously signed into the presigned PUT and echoed to the client, which is contractually required to send them back verbatim. `Content-Disposition`'s quoted fallback loses whitespace runs and control bytes; `contentType` loses whitespace runs, and degrades to `application/octet-stream` when it is empty, whitespace-only, or carries a byte illegal in a header value. Both become fixed points of `signV4TrimAll`, so the signed canonical value, the verified canonical value and the bytes on the wire are the same string. `filename*`, the object key, `Content-Length`, and the presigned GET path are unchanged.

2. **What could break because of it (dependents + failure mode)?**

   `BuildContentDisposition` has six call sites across three modules — `modules/file/api.go:626` (multipart `uploadFile`) and `:945` (`getUploadCredentials`), `modules/robot/api.go:2085` and `:2233`, `modules/bot_api/file.go:90` and `:285` — feeding both presigned PUT and server-side `UploadFile`. A consumer that pinned the exact legacy `filename=` string for a name with consecutive spaces or control bytes would now see a different value; no such assertion exists in the repo, and the failing-test sets match `origin/main` exactly. The visible behavioral change is confined to the legacy fallback: a client that ignores `filename*` and reads only `filename=` shows a name with single spaces. Objects stored before this PR keep their old metadata; nothing is rewritten. On the MinIO backend the emitted value changes but the outcome cannot, since both sides collapse identically. The one new signing behaviour is the whitespace-only `contentType` edge path described under Changes.

3. **How do you know it works (specific test/repro/trace)?**

   The offline gateway reproduces the exact 403 pre-fix and returns 200 post-fix on the same code path, and prints the two canonical strings that differ. The property sweep plus its not-vacuous guard show no filename can reintroduce the mismatch and that the property really discriminates; the content-type half is pinned by a handler-level test that was mutation-checked. The cross-repo run drives it from octo-web's actual upload task. The residual gap is the real COS gateway, stated above.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] PR description is in English
- [x] Added tests for my changes
- [x] Updated documentation
- [x] Followed commit message conventions (Conventional Commits)

---
_Generated by [Claude Code](https://claude.ai/code/session_01V5RikoYSpJWzjgQK6yJte3)_