### PR TITLE
feat(auth): add marketAdmin fixed role for the platform catalog surface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,3 +98,9 @@ octo-server-prev*
 /card-action-dlq
 /genseq-repro
 /i18nmarkers
+
+# Redis snapshots. `redis-server` writes dump.rdb into its working directory, so
+# running one from the repo root while executing the test suite drops a snapshot
+# of the test fixtures here — session tokens included. Never a source artifact.
+*.rdb
+dump.rdb

--- a/modules/user/api_manager.go
+++ b/modules/user/api_manager.go
@@ -15,6 +15,7 @@ import (
 	common2 "github.com/Mininglamp-OSS/octo-server/modules/common"
 	"github.com/Mininglamp-OSS/octo-server/pkg/auth"
 	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
+	"github.com/Mininglamp-OSS/octo-server/pkg/i18n/codes"
 	octoredis "github.com/Mininglamp-OSS/octo-server/pkg/redis"
 	spacepkg "github.com/Mininglamp-OSS/octo-server/pkg/space"
 	wkutil "github.com/Mininglamp-OSS/octo-server/pkg/util"
@@ -118,15 +119,21 @@ func (m *Manager) Route(r *wkhttp.WKHttp) {
 		auth.POST("/user/phone_shadow_backfill", backfillLimiter, m.phoneShadowBackfill)
 		auth.GET("/user/phone_shadow_backfill", backfillLimiter, m.phoneShadowBackfillStatus)
 	}
-	dashboardReader := r.Group(
+	// 固定管理角色的授予/撤销面（pre-RBAC，见 setFixedManagerRole 上方说明）。
+	// SharedUIDRateLimiter 必须挂在 AuthMiddleware 之后才读得到 uid。
+	fixedRole := r.Group(
 		"/v1/manager/user",
 		m.ctx.AuthMiddleware(r),
 		appwkhttp.SharedUIDRateLimiter(r, m.ctx),
 	)
 	{
-		dashboardReader.GET("/dashboard-read", m.listDashboardReaders)
-		dashboardReader.PUT("/:uid/dashboard-read", m.grantDashboardRead)
-		dashboardReader.DELETE("/:uid/dashboard-read", m.revokeDashboardRead)
+		fixedRole.GET("/dashboard-read", m.listDashboardReaders)
+		fixedRole.PUT("/:uid/dashboard-read", m.grantDashboardRead)
+		fixedRole.DELETE("/:uid/dashboard-read", m.revokeDashboardRead)
+
+		fixedRole.GET("/market-admin", m.listMarketAdmins)
+		fixedRole.PUT("/:uid/market-admin", m.grantMarketAdmin)
+		fixedRole.DELETE("/:uid/market-admin", m.revokeMarketAdmin)
 	}
 }
 
@@ -176,10 +183,10 @@ func (m *Manager) me(c *wkhttp.Context) {
 //   - space.read        = 空间/成员/邀请/入群申请 列表查询（requireAdmin）
 //   - space.write       = 建空间/改资料/加成员/邀请增改禁用/通过拒绝入群申请（requireAdmin，故恒 true）
 //   - space.destructive = 强制解散/封禁/强制移除/改成员角色（requireSuperAdmin）
-//   - skill.read        = 系统 Skill 列表/详情查看（requireSuperAdmin）
-//   - skill.write       = 系统 Skill 创建/编辑/删除/分类管理（requireSuperAdmin）
-//   - mcp.read          = 系统 MCP 列表/详情查看（requireSuperAdmin）
-//   - mcp.write         = 系统 MCP 创建/编辑/删除（requireSuperAdmin）
+//   - skill.read        = 系统 Skill 列表/详情查看（superAdmin ∪ marketAdmin）
+//   - skill.write       = 系统 Skill 创建/编辑/删除/分类管理（superAdmin ∪ marketAdmin）
+//   - mcp.read          = 系统 MCP 列表/详情查看（superAdmin ∪ marketAdmin）
+//   - mcp.write         = 系统 MCP 创建/编辑/删除（superAdmin ∪ marketAdmin）
 //   - expert.read       = 专家市场 专家/专家团 列表/详情查看（requireSuperAdmin）
 //   - expert.write      = 专家市场 上传新建/编辑/删除 + 分类管理（requireSuperAdmin）
 //
@@ -198,12 +205,16 @@ func managerCapabilities(role string) map[string]bool {
 		"users.write":        isSuper, // 重置密码 / 新增用户 / 解封 / 改密
 		"users.manage_admin": isSuper, // 管理员账号 增/查/删
 		"groups.write":       isSuper, // 解散封禁群 / 强制移除成员
-		"skill.read":         isSuper, // 系统 Skill 列表/详情（marketplace admin surface）
-		"skill.write":        isSuper, // 系统 Skill 创建/编辑/删除/分类管理（marketplace admin surface）
-		"mcp.read":           isSuper, // 系统 MCP 列表/详情（marketplace admin surface 只认共享 X-Admin-Token 不分 role，此处收窄到超管以缩小页面暴露面）
-		"mcp.write":          isSuper, // 系统 MCP 创建/编辑/删除（同上）
 		"expert.read":        isSuper, // 专家市场 专家/专家团 列表/详情（marketplace admin surface 收窄到超管）
 		"expert.write":       isSuper, // 专家市场 创建(上传)/编辑/删除 + 分类管理（同上）
+		// superAdmin ∪ marketAdmin —— 平台 MCP / Skill 目录的运营面。marketAdmin 是
+		// 与 dashboardReader 同形状的固定角色：octo-lib 不认识它，所以它过不了任何
+		// admin/superAdmin 端点，只有这四个键为真。真正的放行在 octo-marketplace 的
+		// /api/v1/admin/{mcps,skills,skill_categories} 上，见 auth.CanAdminMarketplace。
+		"skill.read":  auth.CanAdminMarketplace(role), // 系统 Skill 列表/详情
+		"skill.write": auth.CanAdminMarketplace(role), // 系统 Skill 创建/编辑/删除/分类管理
+		"mcp.read":    auth.CanAdminMarketplace(role), // 系统 MCP 列表/详情
+		"mcp.write":   auth.CanAdminMarketplace(role), // 系统 MCP 创建/编辑/删除
 		// admin ∪ superAdmin；dashboardReader 仅有 dashboard.read。
 		"appversion.read": isAdmin,                            // 版本列表
 		"dashboard.read":  auth.CanReadManagerDashboard(role), // 运营看板查看
@@ -441,47 +452,76 @@ func (m *Manager) resetUserPassword(c *wkhttp.Context) {
 	c.ResponseOK()
 }
 
+// ── 固定管理角色（pre-RBAC） ─────────────────────────────────────────────────
+//
+// dashboardReader 与 marketAdmin 都是「既非 admin 也非 superAdmin」的固定角色：
+// octo-lib 的 CheckLoginRole* 不认识它们，所以持有者过不了任何 admin/superAdmin
+// 端点，能力完全由 managerCapabilities 那张图（以及下游服务对该角色的承认）决定。
+//
+// 两者的授予/撤销流程逐字相同——CAS 改 user.role、失效角色热缓存、幂等、目标资格
+// 校验——因此共用下面这套按角色参数化的代码，而不是复制一份。
+//
+// 过渡性质：通用 admin RBAC 落地后（见 .octospec/tasks/admin-rbac-extraction/），
+// 这两个角色将变成角色表里的两行数据，本节连同 pkg/auth/manager_roles.go 一并删除。
+
 // grantDashboardRead assigns the temporary dashboardReader role to an existing
 // non-SuperAdmin account. The role is exclusive: assigning it to an admin is a
 // deliberate downgrade to Dashboard-only access.
 func (m *Manager) grantDashboardRead(c *wkhttp.Context) {
-	m.setDashboardReaderRole(c, true)
+	m.setFixedManagerRole(c, auth.ManagerRoleDashboardReader, errcode.ErrUserDashboardReaderTargetIneligible, true)
 }
 
 // revokeDashboardRead removes only the temporary dashboardReader role. It does
 // not remove dashboard access inherited from admin or SuperAdmin.
 func (m *Manager) revokeDashboardRead(c *wkhttp.Context) {
-	m.setDashboardReaderRole(c, false)
+	m.setFixedManagerRole(c, auth.ManagerRoleDashboardReader, errcode.ErrUserDashboardReaderTargetIneligible, false)
 }
 
-func (m *Manager) setDashboardReaderRole(c *wkhttp.Context, grant bool) {
+// grantMarketAdmin assigns the marketAdmin role, which grants the platform
+// MCP / Skill catalog admin surface (and nothing else). Assigning it to an admin
+// is a deliberate downgrade, same semantics as dashboardReader.
+func (m *Manager) grantMarketAdmin(c *wkhttp.Context) {
+	m.setFixedManagerRole(c, auth.ManagerRoleMarketAdmin, errcode.ErrUserManagerRoleTargetIneligible, true)
+}
+
+// revokeMarketAdmin removes only the marketAdmin role. It does not remove the
+// catalog access a SuperAdmin holds inherently.
+func (m *Manager) revokeMarketAdmin(c *wkhttp.Context) {
+	m.setFixedManagerRole(c, auth.ManagerRoleMarketAdmin, errcode.ErrUserManagerRoleTargetIneligible, false)
+}
+
+// setFixedManagerRole grants or revokes one fixed manager role on a target
+// account. ineligibleCode is the role-specific 4xx returned when the target is
+// not a grantable account (bot / banned / destroyed).
+func (m *Manager) setFixedManagerRole(c *wkhttp.Context, role string, ineligibleCode codes.Code, grant bool) {
 	if err := c.CheckLoginRoleIsSuperAdmin(); err != nil {
 		respondManagerForbidden(c)
 		return
 	}
 
-	target, ok := m.dashboardReaderTarget(c)
+	target, ok := m.fixedManagerRoleTarget(c, role)
 	if !ok {
 		return
 	}
-	nextRole, changed, allowed := dashboardReaderRoleTransition(target.Role, grant)
+	nextRole, changed, allowed := fixedManagerRoleTransition(target.Role, role, grant)
 	if !allowed {
 		respondManagerForbidden(c)
 		return
 	}
-	if grant && !dashboardReaderGrantEligible(target) {
-		respondUserError(c, errcode.ErrUserDashboardReaderTargetIneligible)
+	if grant && !fixedManagerRoleGrantEligible(target) {
+		respondUserError(c, ineligibleCode)
 		return
 	}
 	if !changed {
-		m.finishDashboardReaderRoleRequest(c, target.UID, grant, false)
+		m.finishFixedManagerRoleRequest(c, role, target.UID, grant, false)
 		return
 	}
 
 	updated, err := m.db.updateUserRole(target.UID, target.Role, nextRole)
 	if err != nil {
-		m.Error("update dashboard reader role failed",
+		m.Error("update fixed manager role failed",
 			zap.Error(err),
+			zap.String("role", role),
 			zap.String("actor_uid", c.GetLoginUID()),
 			zap.String("target_uid", target.UID),
 			zap.Bool("grant", grant))
@@ -491,7 +531,8 @@ func (m *Manager) setDashboardReaderRole(c *wkhttp.Context, grant bool) {
 	if !updated {
 		// The role changed after QueryByUID. Fail closed instead of overwriting a
 		// concurrent promotion (especially to SuperAdmin).
-		m.Info("dashboard reader role update lost compare-and-set",
+		m.Info("fixed manager role update lost compare-and-set",
+			zap.String("role", role),
 			zap.String("actor_uid", c.GetLoginUID()),
 			zap.String("target_uid", target.UID),
 			zap.String("expected_role", target.Role),
@@ -499,10 +540,10 @@ func (m *Manager) setDashboardReaderRole(c *wkhttp.Context, grant bool) {
 		respondUserError(c, errcode.ErrUserManagerRoleChanged)
 		return
 	}
-	m.finishDashboardReaderRoleRequest(c, target.UID, grant, true)
+	m.finishFixedManagerRoleRequest(c, role, target.UID, grant, true)
 }
 
-func (m *Manager) dashboardReaderTarget(c *wkhttp.Context) (*Model, bool) {
+func (m *Manager) fixedManagerRoleTarget(c *wkhttp.Context, role string) (*Model, bool) {
 	targetUID := strings.TrimSpace(c.Param("uid"))
 	if targetUID == "" {
 		respondUserRequestInvalid(c, "uid")
@@ -510,7 +551,8 @@ func (m *Manager) dashboardReaderTarget(c *wkhttp.Context) (*Model, bool) {
 	}
 	target, err := m.userDB.QueryByUID(targetUID)
 	if err != nil {
-		m.Error("query dashboard reader target failed", zap.Error(err), zap.String("target_uid", targetUID))
+		m.Error("query fixed manager role target failed",
+			zap.Error(err), zap.String("role", role), zap.String("target_uid", targetUID))
 		respondUserError(c, errcode.ErrUserQueryFailed)
 		return nil, false
 	}
@@ -521,15 +563,16 @@ func (m *Manager) dashboardReaderTarget(c *wkhttp.Context) (*Model, bool) {
 	return target, true
 }
 
-func dashboardReaderGrantEligible(target *Model) bool {
+func fixedManagerRoleGrantEligible(target *Model) bool {
 	return target != nil && target.Robot == 0 &&
 		target.Status == StatusEnable.Int() && target.IsDestroy == IsDestroyNo
 }
 
-func (m *Manager) finishDashboardReaderRoleRequest(c *wkhttp.Context, targetUID string, grant, changed bool) {
+func (m *Manager) finishFixedManagerRoleRequest(c *wkhttp.Context, role, targetUID string, grant, changed bool) {
 	if err := m.roleService.Invalidate(targetUID); err != nil {
-		m.Error("invalidate dashboard reader role cache failed",
+		m.Error("invalidate fixed manager role cache failed",
 			zap.Error(err),
+			zap.String("role", role),
 			zap.String("actor_uid", c.GetLoginUID()),
 			zap.String("target_uid", targetUID),
 			zap.Bool("grant", grant),
@@ -537,11 +580,12 @@ func (m *Manager) finishDashboardReaderRoleRequest(c *wkhttp.Context, targetUID 
 		respondUserError(c, errcode.ErrUserRoleCacheFailed)
 		return
 	}
-	message := "dashboard reader role already in requested state"
+	message := "fixed manager role already in requested state"
 	if changed {
-		message = "dashboard reader role changed"
+		message = "fixed manager role changed"
 	}
 	m.Info(message,
+		zap.String("role", role),
 		zap.String("actor_uid", c.GetLoginUID()),
 		zap.String("target_uid", targetUID),
 		zap.Bool("granted", grant))
@@ -549,13 +593,21 @@ func (m *Manager) finishDashboardReaderRoleRequest(c *wkhttp.Context, targetUID 
 }
 
 func (m *Manager) listDashboardReaders(c *wkhttp.Context) {
+	m.listUsersWithFixedManagerRole(c, auth.ManagerRoleDashboardReader)
+}
+
+func (m *Manager) listMarketAdmins(c *wkhttp.Context) {
+	m.listUsersWithFixedManagerRole(c, auth.ManagerRoleMarketAdmin)
+}
+
+func (m *Manager) listUsersWithFixedManagerRole(c *wkhttp.Context, role string) {
 	if err := c.CheckLoginRoleIsSuperAdmin(); err != nil {
 		respondManagerForbidden(c)
 		return
 	}
-	users, err := m.db.queryUsersWithRole(auth.ManagerRoleDashboardReader)
+	users, err := m.db.queryUsersWithRole(role)
 	if err != nil {
-		m.Error("query dashboard reader list failed", zap.Error(err))
+		m.Error("query fixed manager role list failed", zap.Error(err), zap.String("role", role))
 		respondUserError(c, errcode.ErrUserQueryFailed)
 		return
 	}
@@ -569,17 +621,21 @@ func (m *Manager) listDashboardReaders(c *wkhttp.Context) {
 	c.Response(list)
 }
 
-// dashboardReaderRoleTransition is the complete temporary-role policy. The
-// boolean results are (changed, allowed). Admin may be deliberately downgraded
-// to dashboardReader; inherited admin/SuperAdmin dashboard access cannot be
-// revoked through this fixed-role endpoint.
-func dashboardReaderRoleTransition(currentRole string, grant bool) (nextRole string, changed, allowed bool) {
+// fixedManagerRoleTransition is the complete fixed-role policy, shared by every
+// role in this section. The boolean results are (changed, allowed).
+//
+// Admin may be deliberately downgraded to a fixed role. Everything else is
+// rejected rather than silently rewritten: user.role is single-valued, so the
+// fixed roles are mutually exclusive, and swapping one for another must be an
+// explicit revoke-then-grant instead of an implicit side effect of a grant.
+// Access a SuperAdmin (or an admin) holds inherently cannot be revoked here.
+func fixedManagerRoleTransition(currentRole, role string, grant bool) (nextRole string, changed, allowed bool) {
 	if grant {
 		switch currentRole {
 		case "", string(wkhttp.Admin):
-			return auth.ManagerRoleDashboardReader, true, true
-		case auth.ManagerRoleDashboardReader:
-			return auth.ManagerRoleDashboardReader, false, true
+			return role, true, true
+		case role:
+			return role, false, true
 		default:
 			return "", false, false
 		}
@@ -588,7 +644,7 @@ func dashboardReaderRoleTransition(currentRole string, grant bool) (nextRole str
 	switch currentRole {
 	case "":
 		return "", false, true
-	case auth.ManagerRoleDashboardReader:
+	case role:
 		return "", true, true
 	default:
 		return "", false, false

--- a/modules/user/api_manager.go
+++ b/modules/user/api_manager.go
@@ -150,8 +150,9 @@ type managerMeResp struct {
 	Capabilities map[string]bool `json:"capabilities"`
 }
 
-// me 返回当前登录管理台账号的身份与能力图谱。dashboardReader 只在这里和 Dashboard
-// 读面被承认；普通管理接口仍走 octo-lib CheckLoginRole，只接受 admin∪superAdmin。
+// me 返回当前登录管理台账号的身份与能力图谱。两个固定角色都只在这里被承认——
+// dashboardReader 另加 Dashboard 读面，marketAdmin 另加 octo-marketplace 的目录面；
+// 普通管理接口仍走 octo-lib CheckLoginRole，只接受 admin∪superAdmin。
 func (m *Manager) me(c *wkhttp.Context) {
 	if !auth.IsManagerConsoleRole(c.GetLoginRole()) {
 		respondManagerForbidden(c)
@@ -209,8 +210,12 @@ func managerCapabilities(role string) map[string]bool {
 		"expert.write":       isSuper, // 专家市场 创建(上传)/编辑/删除 + 分类管理（同上）
 		// superAdmin ∪ marketAdmin —— 平台 MCP / Skill 目录的运营面。marketAdmin 是
 		// 与 dashboardReader 同形状的固定角色：octo-lib 不认识它，所以它过不了任何
-		// admin/superAdmin 端点，只有这四个键为真。真正的放行在 octo-marketplace 的
-		// /api/v1/admin/{mcps,skills,skill_categories} 上，见 auth.CanAdminMarketplace。
+		// admin/superAdmin 端点，只有这四个键为真。
+		//
+		// 注意这四个键只驱动前端渲染；真正的放行在 octo-marketplace，且要等
+		// Mininglamp-OSS/octo-marketplace#55 上线之后——在那之前 marketplace 的
+		// /api/v1/admin/* 是一道只认 superAdmin 的门，marketAdmin 会拿到 403。
+		// 见 auth.CanAdminMarketplace。
 		"skill.read":  auth.CanAdminMarketplace(role), // 系统 Skill 列表/详情
 		"skill.write": auth.CanAdminMarketplace(role), // 系统 Skill 创建/编辑/删除/分类管理
 		"mcp.read":    auth.CanAdminMarketplace(role), // 系统 MCP 列表/详情
@@ -365,8 +370,8 @@ func (m *Manager) login(c *wkhttp.Context) {
 			_ = m.userDB.updatePassword(newHash, userInfo.UID)
 		}
 	}
-	// 角色判定用上游的 IsManagerConsoleRole（放行 admin∪superAdmin∪dashboardReader，
-	// 见 575185b0），被拒同样计入登录失败日志。
+	// 角色判定用上游的 IsManagerConsoleRole（放行 admin∪superAdmin∪两个固定角色
+	// dashboardReader/marketAdmin，见 575185b0），被拒同样计入登录失败日志。
 	if !auth.IsManagerConsoleRole(userInfo.Role) {
 		m.loginLog.recordFailure(req.Username, publicIP, "manager")
 		respondUserError(c, errcode.ErrUserManagerPermissionRequired)

--- a/modules/user/api_manager.go
+++ b/modules/user/api_manager.go
@@ -466,6 +466,13 @@ func (m *Manager) resetUserPassword(c *wkhttp.Context) {
 // 两者的授予/撤销流程逐字相同——CAS 改 user.role、失效角色热缓存、幂等、目标资格
 // 校验——因此共用下面这套按角色参数化的代码，而不是复制一份。
 //
+// 两个运维陷阱，源于 user.role 是单值列（运维手册里应写明）：
+//
+//   - 授予是**单向降级**：给一个 admin 授予固定角色会覆盖掉 admin，而撤销只会回到
+//     ""，不会还原成 admin。要恢复得重新走加管理员流程。
+//   - 持有固定角色的账号**删不掉**：deleteAdminUsers 只接受 admin / superAdmin，
+//     对固定角色返回 not_admin_account，必须先撤销角色再删。
+//
 // 过渡性质：通用 admin RBAC 落地后（见 .octospec/tasks/admin-rbac-extraction/），
 // 这两个角色将变成角色表里的两行数据，本节连同 pkg/auth/manager_roles.go 一并删除。
 
@@ -495,11 +502,32 @@ func (m *Manager) revokeMarketAdmin(c *wkhttp.Context) {
 	m.setFixedManagerRole(c, auth.ManagerRoleMarketAdmin, errcode.ErrUserManagerRoleTargetIneligible, false)
 }
 
+// isFixedManagerRole reports whether role is one this section is allowed to
+// write. The set is closed on purpose: setFixedManagerRole is the write side of
+// a privilege boundary, and fixedManagerRoleTransition will persist whatever
+// role string it is handed. Without this guard a future caller passing
+// wkhttp.SuperAdmin would have the CAS commit a promotion, and passing "" would
+// silently demote an admin to a plain user — neither reachable today (both
+// callers pass a constant), both cheap to make unreachable by construction.
+func isFixedManagerRole(role string) bool {
+	return role == auth.ManagerRoleDashboardReader ||
+		role == auth.ManagerRoleMarketAdmin
+}
+
 // setFixedManagerRole grants or revokes one fixed manager role on a target
 // account. ineligibleCode is the role-specific 4xx returned when the target is
 // not a grantable account (bot / banned / destroyed).
 func (m *Manager) setFixedManagerRole(c *wkhttp.Context, role string, ineligibleCode codes.Code, grant bool) {
 	if err := c.CheckLoginRoleIsSuperAdmin(); err != nil {
+		respondManagerForbidden(c)
+		return
+	}
+	if !isFixedManagerRole(role) {
+		// Programmer error, not a client one: no request shape can reach this.
+		// Fail closed and log loudly rather than writing an arbitrary role.
+		m.Error("refusing to write a role that is not a fixed manager role",
+			zap.String("role", role),
+			zap.String("actor_uid", c.GetLoginUID()))
 		respondManagerForbidden(c)
 		return
 	}

--- a/modules/user/api_manager_dashboard_reader_test.go
+++ b/modules/user/api_manager_dashboard_reader_test.go
@@ -82,9 +82,10 @@ func TestManagerLoginAllowsDashboardReader(t *testing.T) {
 	assert.Contains(t, w.Body.String(), `"role":"`+appauth.ManagerRoleDashboardReader+`"`)
 }
 
-func TestDashboardReaderRoleTransition(t *testing.T) {
+func TestFixedManagerRoleTransition(t *testing.T) {
 	tests := []struct {
 		name        string
+		role        string
 		currentRole string
 		grant       bool
 		wantRole    string
@@ -101,11 +102,31 @@ func TestDashboardReaderRoleTransition(t *testing.T) {
 		{name: "do not revoke admin inheritance", currentRole: string(wkhttp.Admin)},
 		{name: "protect superAdmin revoke", currentRole: string(wkhttp.SuperAdmin)},
 		{name: "reject unknown revoke", currentRole: "future-role"},
+
+		// marketAdmin reuses the same policy.
+		{name: "market grant normal", role: appauth.ManagerRoleMarketAdmin, grant: true, wantRole: appauth.ManagerRoleMarketAdmin, wantChanged: true, wantAllowed: true},
+		{name: "market downgrade admin", role: appauth.ManagerRoleMarketAdmin, currentRole: string(wkhttp.Admin), grant: true, wantRole: appauth.ManagerRoleMarketAdmin, wantChanged: true, wantAllowed: true},
+		{name: "market grant idempotent", role: appauth.ManagerRoleMarketAdmin, currentRole: appauth.ManagerRoleMarketAdmin, grant: true, wantRole: appauth.ManagerRoleMarketAdmin, wantAllowed: true},
+		{name: "market protect superAdmin grant", role: appauth.ManagerRoleMarketAdmin, currentRole: string(wkhttp.SuperAdmin), grant: true},
+		{name: "market revoke", role: appauth.ManagerRoleMarketAdmin, currentRole: appauth.ManagerRoleMarketAdmin, wantChanged: true, wantAllowed: true},
+
+		// user.role is single-valued, so the fixed roles are mutually exclusive:
+		// swapping one for the other must be an explicit revoke-then-grant, never
+		// an implicit side effect of a grant (and revoking role A must not touch
+		// an account currently holding role B).
+		{name: "reject swapping reader to market", role: appauth.ManagerRoleMarketAdmin, currentRole: appauth.ManagerRoleDashboardReader, grant: true},
+		{name: "reject swapping market to reader", role: appauth.ManagerRoleDashboardReader, currentRole: appauth.ManagerRoleMarketAdmin, grant: true},
+		{name: "market revoke leaves reader alone", role: appauth.ManagerRoleMarketAdmin, currentRole: appauth.ManagerRoleDashboardReader},
+		{name: "reader revoke leaves market alone", role: appauth.ManagerRoleDashboardReader, currentRole: appauth.ManagerRoleMarketAdmin},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotRole, gotChanged, gotAllowed := dashboardReaderRoleTransition(tt.currentRole, tt.grant)
+			role := tt.role
+			if role == "" {
+				role = appauth.ManagerRoleDashboardReader
+			}
+			gotRole, gotChanged, gotAllowed := fixedManagerRoleTransition(tt.currentRole, role, tt.grant)
 			assert.Equal(t, tt.wantRole, gotRole)
 			assert.Equal(t, tt.wantChanged, gotChanged)
 			assert.Equal(t, tt.wantAllowed, gotAllowed)

--- a/modules/user/api_manager_market_admin_test.go
+++ b/modules/user/api_manager_market_admin_test.go
@@ -1,0 +1,318 @@
+package user
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	appauth "github.com/Mininglamp-OSS/octo-server/pkg/auth"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The marketAdmin routes share setFixedManagerRole with dashboardReader, whose
+// HTTP behaviour is already pinned in api_manager_dashboard_reader_test.go.
+// These tests exist because the shared path is now the write side of a
+// privilege boundary for two roles (soon three), and "covered via the other
+// role's tests" stops being true the moment someone refactors it. They pin what
+// is specific to this role: the three route registrations, the SuperAdmin gate
+// on them, the role-scoped listing, and the role-agnostic ineligible code.
+
+func TestManagerLoginAllowsMarketAdmin(t *testing.T) {
+	route, ctx, _ := newManagerRouteOnly(t)
+
+	password := "market-admin-password"
+	hashed, err := HashPassword(password)
+	require.NoError(t, err)
+	require.NoError(t, NewDB(ctx).Insert(&Model{
+		UID:      "market-admin-login",
+		Username: "market-admin-login",
+		Name:     "Market Admin",
+		ShortNo:  "market-admin-login",
+		Password: hashed,
+		Role:     appauth.ManagerRoleMarketAdmin,
+		Status:   StatusEnable.Int(),
+	}))
+
+	body, err := json.Marshal(map[string]string{
+		"username": "market-admin-login",
+		"password": password,
+	})
+	require.NoError(t, err)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/manager/login", bytes.NewReader(body))
+	route.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	assert.Contains(t, w.Body.String(), `"role":"`+appauth.ManagerRoleMarketAdmin+`"`)
+}
+
+// TestManagerMe_MarketAdminGetsOnlyCatalogCaps is the wire-level counterpart to
+// TestManagerCapabilities_MarketAdmin: the pure function cannot catch a
+// regression in the handler's own role gate, and the capability map is the
+// contract octo-admin renders from.
+func TestManagerMe_MarketAdminGetsOnlyCatalogCaps(t *testing.T) {
+	route, ctx, _ := newManagerRouteOnly(t)
+
+	loginAsRole(t, ctx, appauth.ManagerRoleMarketAdmin)
+	w := getManagerMe(route)
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	var resp meResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, appauth.ManagerRoleMarketAdmin, resp.Role)
+
+	granted := map[string]bool{
+		"mcp.read": true, "mcp.write": true,
+		"skill.read": true, "skill.write": true,
+	}
+	for capability, enabled := range resp.Capabilities {
+		assert.Equalf(t, granted[capability], enabled,
+			"marketAdmin capability %q over the wire", capability)
+	}
+	assert.False(t, resp.Capabilities["expert.read"], "expert market stays superAdmin-only")
+	assert.False(t, resp.Capabilities["dashboard.read"], "marketAdmin is not a dashboard reader")
+}
+
+func TestManagerMarketAdminGrantAndRevoke(t *testing.T) {
+	route, ctx, _ := newManagerRouteOnly(t)
+
+	const (
+		callerToken = "market-admin-grant-caller"
+		targetUID   = "market-admin-target"
+	)
+	cacheCfg := ctx.GetConfig().Cache
+	require.NoError(t, ctx.Cache().Set(cacheCfg.TokenCachePrefix+callerToken,
+		"root-uid@root@"+string(wkhttp.SuperAdmin)))
+	require.NoError(t, NewDB(ctx).Insert(&Model{
+		UID:      targetUID,
+		Username: targetUID,
+		Name:     "Market Admin Target",
+		ShortNo:  targetUID,
+		Status:   StatusEnable.Int(),
+	}))
+
+	doRoleRequest := func(method string) *httptest.ResponseRecorder {
+		t.Helper()
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest(method, "/v1/manager/user/"+targetUID+"/market-admin", nil)
+		req.Header.Set("token", callerToken)
+		route.ServeHTTP(w, req)
+		return w
+	}
+
+	granted := doRoleRequest(http.MethodPut)
+	require.Equal(t, http.StatusOK, granted.Code, granted.Body.String())
+	assert.Equal(t, "uid", granted.Header().Get("X-RateLimit-Scope"),
+		"the shared UID limiter must be mounted after AuthMiddleware on this group")
+	role, err := NewDB(ctx).QueryRoleByUID(targetUID)
+	require.NoError(t, err)
+	assert.Equal(t, appauth.ManagerRoleMarketAdmin, role)
+	cached, err := ctx.Cache().Get(RoleCacheKeyPrefix + targetUID)
+	require.NoError(t, err)
+	assert.Empty(t, cached, "grant must invalidate the target role cache")
+
+	// A stale cache entry must not survive an idempotent retry, or a partial
+	// earlier failure keeps the old role live for the TTL.
+	require.NoError(t, ctx.Cache().Set(RoleCacheKeyPrefix+targetUID, string(wkhttp.Admin)))
+	retried := doRoleRequest(http.MethodPut)
+	require.Equal(t, http.StatusOK, retried.Code, retried.Body.String())
+	cached, err = ctx.Cache().Get(RoleCacheKeyPrefix + targetUID)
+	require.NoError(t, err)
+	assert.Empty(t, cached, "idempotent grant must invalidate a stale role cache")
+
+	revoked := doRoleRequest(http.MethodDelete)
+	require.Equal(t, http.StatusOK, revoked.Code, revoked.Body.String())
+	role, err = NewDB(ctx).QueryRoleByUID(targetUID)
+	require.NoError(t, err)
+	assert.Empty(t, role)
+	cached, err = ctx.Cache().Get(RoleCacheKeyPrefix + targetUID)
+	require.NoError(t, err)
+	assert.Empty(t, cached, "revoke must invalidate the target role cache")
+}
+
+func TestManagerMarketAdminRoutesRequireSuperAdmin(t *testing.T) {
+	route, ctx, _ := newManagerRouteOnly(t)
+
+	const (
+		adminToken = "market-admin-gate-admin-caller"
+		targetUID  = "market-admin-gate-target"
+	)
+	cacheCfg := ctx.GetConfig().Cache
+	require.NoError(t, ctx.Cache().Set(cacheCfg.TokenCachePrefix+adminToken,
+		"admin-uid@admin@"+string(wkhttp.Admin)))
+	require.NoError(t, NewDB(ctx).Insert(&Model{
+		UID: targetUID, Username: targetUID, Name: "Gate Target",
+		ShortNo: targetUID, Status: StatusEnable.Int(),
+	}))
+
+	// admin is a manager-console role but not SuperAdmin: it must not be able to
+	// read or mutate who holds the role.
+	for _, tt := range []struct {
+		name   string
+		method string
+		path   string
+	}{
+		{name: "list", method: http.MethodGet, path: "/v1/manager/user/market-admin"},
+		{name: "grant", method: http.MethodPut, path: "/v1/manager/user/" + targetUID + "/market-admin"},
+		{name: "revoke", method: http.MethodDelete, path: "/v1/manager/user/" + targetUID + "/market-admin"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			req := httptest.NewRequest(tt.method, tt.path, nil)
+			req.Header.Set("token", adminToken)
+			route.ServeHTTP(w, req)
+
+			assert.Equal(t, http.StatusBadRequest, w.Code, w.Body.String())
+			assert.Contains(t, w.Body.String(), "err.shared.auth.forbidden")
+		})
+	}
+
+	role, err := NewDB(ctx).QueryRoleByUID(targetUID)
+	require.NoError(t, err)
+	assert.Empty(t, role, "a rejected grant must not mutate the target")
+}
+
+func TestManagerMarketAdminListIsRoleScoped(t *testing.T) {
+	route, ctx, _ := newManagerRouteOnly(t)
+
+	const callerToken = "market-admin-list-caller"
+	cacheCfg := ctx.GetConfig().Cache
+	require.NoError(t, ctx.Cache().Set(cacheCfg.TokenCachePrefix+callerToken,
+		"root-uid@root@"+string(wkhttp.SuperAdmin)))
+	require.NoError(t, NewDB(ctx).Insert(&Model{
+		UID: "listed-market-admin", Username: "listed-market-admin", Name: "Listed Market Admin",
+		ShortNo: "listed-market-admin", Role: appauth.ManagerRoleMarketAdmin, Status: StatusEnable.Int(),
+	}))
+	require.NoError(t, NewDB(ctx).Insert(&Model{
+		UID: "other-fixed-role", Username: "other-fixed-role", Name: "Other Fixed Role",
+		ShortNo: "other-fixed-role", Role: appauth.ManagerRoleDashboardReader, Status: StatusEnable.Int(),
+	}))
+
+	get := func(path string) []struct {
+		UID string `json:"uid"`
+	} {
+		t.Helper()
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, path, nil)
+		req.Header.Set("token", callerToken)
+		route.ServeHTTP(w, req)
+		require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+		var list []struct {
+			UID string `json:"uid"`
+		}
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &list))
+		return list
+	}
+
+	// Each listing must show only its own role — the two fixed roles are
+	// mutually exclusive and must not bleed into each other's views.
+	marketAdmins := get("/v1/manager/user/market-admin")
+	require.Len(t, marketAdmins, 1)
+	assert.Equal(t, "listed-market-admin", marketAdmins[0].UID)
+
+	readers := get("/v1/manager/user/dashboard-read")
+	require.Len(t, readers, 1)
+	assert.Equal(t, "other-fixed-role", readers[0].UID)
+}
+
+func TestManagerMarketAdminGrantRejectsIneligibleAccounts(t *testing.T) {
+	route, ctx, _ := newManagerRouteOnly(t)
+
+	const callerToken = "market-admin-ineligible-caller"
+	cacheCfg := ctx.GetConfig().Cache
+	require.NoError(t, ctx.Cache().Set(cacheCfg.TokenCachePrefix+callerToken,
+		"root-uid@root@"+string(wkhttp.SuperAdmin)))
+	tests := []struct {
+		name      string
+		status    int
+		robot     int
+		isDestroy int
+	}{
+		{name: "disabled", status: StatusDisable.Int()},
+		{name: "robot", status: StatusEnable.Int(), robot: 1},
+		{name: "destroying", status: StatusEnable.Int(), isDestroy: IsDestroyApplying},
+		{name: "destroyed", status: StatusEnable.Int(), isDestroy: IsDestroyDone},
+	}
+
+	for i, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			uid := "market-admin-ineligible-" + tt.name
+			require.NoError(t, NewDB(ctx).Insert(&Model{
+				UID: uid, Username: uid, Name: tt.name,
+				ShortNo: fmt.Sprintf("market-ineligible-%d", i), Status: tt.status,
+				Robot: tt.robot, IsDestroy: tt.isDestroy,
+			}))
+			w := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodPut, "/v1/manager/user/"+uid+"/market-admin", nil)
+			req.Header.Set("token", callerToken)
+			route.ServeHTTP(w, req)
+
+			require.Equal(t, http.StatusBadRequest, w.Code, w.Body.String())
+			// The role-agnostic code, not the dashboard-specific one.
+			assert.Contains(t, w.Body.String(), "err.server.user.manager_role_target_ineligible")
+			role, err := NewDB(ctx).QueryRoleByUID(uid)
+			require.NoError(t, err)
+			assert.Empty(t, role)
+		})
+	}
+}
+
+// TestManagerMarketAdminCannotReachAdminEndpoints is the containment claim the
+// whole design rests on: the role is unknown to octo-lib's CheckLoginRole*, so a
+// holder passes no admin gate in this service — including the endpoints that
+// manage its own role.
+func TestManagerMarketAdminCannotReachAdminEndpoints(t *testing.T) {
+	route, ctx, _ := newManagerRouteOnly(t)
+
+	const holderToken = "market-admin-holder"
+	cacheCfg := ctx.GetConfig().Cache
+	require.NoError(t, ctx.Cache().Set(cacheCfg.TokenCachePrefix+holderToken,
+		"market-uid@market@"+appauth.ManagerRoleMarketAdmin))
+
+	for _, tt := range []struct {
+		name   string
+		method string
+		path   string
+	}{
+		{name: "user list", method: http.MethodGet, path: "/v1/manager/user/list"},
+		{name: "admin list", method: http.MethodGet, path: "/v1/manager/user/admin"},
+		{name: "online devices", method: http.MethodGet, path: "/v1/manager/user/online?uid=x"},
+		{name: "own role list", method: http.MethodGet, path: "/v1/manager/user/market-admin"},
+		{name: "own role grant", method: http.MethodPut, path: "/v1/manager/user/someone/market-admin"},
+		{name: "dashboard reader list", method: http.MethodGet, path: "/v1/manager/user/dashboard-read"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			req := httptest.NewRequest(tt.method, tt.path, nil)
+			req.Header.Set("token", holderToken)
+			route.ServeHTTP(w, req)
+
+			assert.Equal(t, http.StatusBadRequest, w.Code, w.Body.String())
+			assert.Contains(t, w.Body.String(), "err.shared.auth.forbidden")
+		})
+	}
+}
+
+// TestIsFixedManagerRole pins the closed set setFixedManagerRole is willing to
+// write. superAdmin and "" are the two values that would do real damage if the
+// guard were dropped: the first is a promotion, the second a silent demotion.
+func TestIsFixedManagerRole(t *testing.T) {
+	for _, tt := range []struct {
+		role string
+		want bool
+	}{
+		{role: appauth.ManagerRoleDashboardReader, want: true},
+		{role: appauth.ManagerRoleMarketAdmin, want: true},
+		{role: string(wkhttp.SuperAdmin), want: false},
+		{role: string(wkhttp.Admin), want: false},
+		{role: "", want: false},
+		{role: "future-role", want: false},
+	} {
+		assert.Equalf(t, tt.want, isFixedManagerRole(tt.role), "isFixedManagerRole(%q)", tt.role)
+	}
+}

--- a/modules/user/api_manager_me_test.go
+++ b/modules/user/api_manager_me_test.go
@@ -58,6 +58,29 @@ func TestManagerCapabilities(t *testing.T) {
 	}
 }
 
+// TestManagerCapabilities_MarketAdmin pins the whole point of the marketAdmin
+// role: exactly the four platform-catalog keys and nothing else. In particular
+// expert.* stays false — curating the Expert Market remains SuperAdmin-only,
+// and octo-marketplace gates that route group separately.
+func TestManagerCapabilities_MarketAdmin(t *testing.T) {
+	market := managerCapabilities(appauth.ManagerRoleMarketAdmin)
+
+	granted := map[string]bool{
+		"mcp.read": true, "mcp.write": true,
+		"skill.read": true, "skill.write": true,
+	}
+	for k, v := range market {
+		if want := granted[k]; v != want {
+			t.Errorf("marketAdmin capability %q = %v, want %v", k, v, want)
+		}
+	}
+	for k := range granted {
+		if _, ok := market[k]; !ok {
+			t.Errorf("capability map is missing key %q", k)
+		}
+	}
+}
+
 func TestManagerMe_DashboardReaderGetsOnlyDashboardRead(t *testing.T) {
 	route, ctx, _ := newManagerRouteOnly(t)
 

--- a/pkg/auth/manager_roles.go
+++ b/pkg/auth/manager_roles.go
@@ -22,6 +22,24 @@ const ManagerRoleDashboardReader = "dashboardReader"
 // the catalog groups (mcps, skills, skill_categories, skill uploads) admit this
 // role and the Expert Market groups keep the superAdmin-only gate — which is why
 // expert.* is excluded from the capabilities below.
+//
+// Before granting this to anyone, four things are worth knowing:
+//
+//   - It is a publishing authority, not a read-mostly editor. A holder can
+//     create, edit and delete the public Skills and system MCPs that every user
+//     on the platform installs, and restructure the catalog taxonomy. It is
+//     genuinely narrower than superAdmin, but pick people at a supply-chain bar,
+//     not at a "content editor" one.
+//   - Do not grant it before octo-marketplace has the paired change deployed.
+//     Until then octo-admin renders the MCP / Skill pages for the holder and
+//     every call behind them 403s.
+//   - Revocation is not instant across the boundary: octo-marketplace caches the
+//     resolved identity per token (AUTH_CACHE_TTL, 30s default) on top of this
+//     service's own role cache, so catalog access can survive a revoke by up to
+//     the sum of the two. Revoke the session too when it must be immediate.
+//   - See the fixed-role section in modules/user/api_manager.go for the two
+//     lifecycle traps both fixed roles share (one-way downgrade, and accounts
+//     that cannot be deleted until the role is revoked).
 const ManagerRoleMarketAdmin = "marketAdmin"
 
 // IsManagerConsoleRole reports whether a role may establish a manager-console

--- a/pkg/auth/manager_roles.go
+++ b/pkg/auth/manager_roles.go
@@ -12,12 +12,16 @@ const ManagerRoleDashboardReader = "dashboardReader"
 //
 // Same shape and same rationale as ManagerRoleDashboardReader: it is deliberately
 // NOT known to octo-lib's CheckLoginRole, so an account holding it passes zero
-// admin/superAdmin endpoint gates in octo-server. Its only effect is the
-// mcp.*/skill.* capabilities below, which octo-marketplace honours on its
-// /api/v1/admin/{mcps,skills,skill_categories} groups.
+// admin/superAdmin endpoint gates in octo-server. Its only effect here is the
+// mcp.*/skill.* capabilities in managerCapabilities.
 //
-// Note expert.* is intentionally excluded — curating the Expert Market stays
-// SuperAdmin-only, and octo-marketplace gates that group separately.
+// Enforcement lives in octo-marketplace, and only once
+// Mininglamp-OSS/octo-marketplace#55 has shipped: before that PR a single gate
+// guards every /api/v1/admin/* group and admits superAdmin alone, so a holder of
+// this role gets 403 on the catalog surface rather than access to it. After it,
+// the catalog groups (mcps, skills, skill_categories, skill uploads) admit this
+// role and the Expert Market groups keep the superAdmin-only gate — which is why
+// expert.* is excluded from the capabilities below.
 const ManagerRoleMarketAdmin = "marketAdmin"
 
 // IsManagerConsoleRole reports whether a role may establish a manager-console

--- a/pkg/auth/manager_roles.go
+++ b/pkg/auth/manager_roles.go
@@ -7,12 +7,36 @@ import "github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
 // CheckLoginRole would accidentally grant every admin endpoint.
 const ManagerRoleDashboardReader = "dashboardReader"
 
+// ManagerRoleMarketAdmin is a fixed role for staff who curate the platform's
+// MCP and Skill catalogs without holding any other administrative power.
+//
+// Same shape and same rationale as ManagerRoleDashboardReader: it is deliberately
+// NOT known to octo-lib's CheckLoginRole, so an account holding it passes zero
+// admin/superAdmin endpoint gates in octo-server. Its only effect is the
+// mcp.*/skill.* capabilities below, which octo-marketplace honours on its
+// /api/v1/admin/{mcps,skills,skill_categories} groups.
+//
+// Note expert.* is intentionally excluded — curating the Expert Market stays
+// SuperAdmin-only, and octo-marketplace gates that group separately.
+const ManagerRoleMarketAdmin = "marketAdmin"
+
 // IsManagerConsoleRole reports whether a role may establish a manager-console
 // session and read its own /v1/manager/me capability map.
 func IsManagerConsoleRole(role string) bool {
 	return role == string(wkhttp.Admin) ||
 		role == string(wkhttp.SuperAdmin) ||
-		role == ManagerRoleDashboardReader
+		role == ManagerRoleDashboardReader ||
+		role == ManagerRoleMarketAdmin
+}
+
+// CanAdminMarketplace is the server-authoritative policy for the platform MCP /
+// Skill catalog admin surface. It is the octo-server half of a contract whose
+// enforcement lives in octo-marketplace (internal/middleware/admin.go): this
+// function decides what /v1/manager/me advertises, marketplace decides what the
+// /api/v1/admin/* routes actually admit. Keep the two in sync.
+func CanAdminMarketplace(role string) bool {
+	return role == string(wkhttp.SuperAdmin) ||
+		role == ManagerRoleMarketAdmin
 }
 
 // CanReadManagerDashboard is the server-authoritative policy for the global

--- a/pkg/auth/manager_roles_test.go
+++ b/pkg/auth/manager_roles_test.go
@@ -12,10 +12,14 @@ func TestManagerRolePolicy(t *testing.T) {
 		role              string
 		wantConsole       bool
 		wantDashboardRead bool
+		wantMarketplace   bool
 	}{
-		{name: "super admin", role: string(wkhttp.SuperAdmin), wantConsole: true, wantDashboardRead: true},
+		{name: "super admin", role: string(wkhttp.SuperAdmin), wantConsole: true, wantDashboardRead: true, wantMarketplace: true},
 		{name: "admin", role: string(wkhttp.Admin), wantConsole: true, wantDashboardRead: true},
 		{name: "dashboard reader", role: ManagerRoleDashboardReader, wantConsole: true, wantDashboardRead: true},
+		// marketAdmin may enter the console, but holds neither dashboard read nor
+		// any admin-tier power — its only privilege is the platform catalog surface.
+		{name: "market admin", role: ManagerRoleMarketAdmin, wantConsole: true, wantMarketplace: true},
 		{name: "plain user", role: "", wantConsole: false, wantDashboardRead: false},
 		{name: "unknown role", role: "unknown", wantConsole: false, wantDashboardRead: false},
 	}
@@ -27,6 +31,9 @@ func TestManagerRolePolicy(t *testing.T) {
 			}
 			if got := CanReadManagerDashboard(tt.role); got != tt.wantDashboardRead {
 				t.Fatalf("CanReadManagerDashboard(%q) = %v, want %v", tt.role, got, tt.wantDashboardRead)
+			}
+			if got := CanAdminMarketplace(tt.role); got != tt.wantMarketplace {
+				t.Fatalf("CanAdminMarketplace(%q) = %v, want %v", tt.role, got, tt.wantMarketplace)
 			}
 		})
 	}

--- a/pkg/errcode/user.go
+++ b/pkg/errcode/user.go
@@ -376,6 +376,15 @@ var (
 		HTTPStatus:     http.StatusBadRequest,
 		DefaultMessage: "This account is not eligible for analytics dashboard access.",
 	})
+	// ErrUserManagerRoleTargetIneligible is the role-agnostic counterpart used by
+	// fixed manager roles added after dashboardReader (marketAdmin, ...). The
+	// dashboard-specific code above is kept so that endpoint's message does not
+	// change for existing clients.
+	ErrUserManagerRoleTargetIneligible = register(codes.Code{
+		ID:             "err.server.user.manager_role_target_ineligible",
+		HTTPStatus:     http.StatusBadRequest,
+		DefaultMessage: "This account is not eligible for the requested management role.",
+	})
 	ErrUserManagerRoleChanged = register(codes.Code{
 		ID:             "err.server.user.manager_role_changed",
 		HTTPStatus:     http.StatusConflict,

--- a/pkg/i18n/locales/active.zh-CN.toml
+++ b/pkg/i18n/locales/active.zh-CN.toml
@@ -286,6 +286,9 @@ other = "超级管理员账号不能删除。"
 ["err.server.user.dashboard_reader_target_ineligible"]
 other = "该账号不符合运营看板只读授权条件。"
 
+["err.server.user.manager_role_target_ineligible"]
+other = "该账号不符合该管理角色的授权条件。"
+
 ["err.server.user.manager_role_changed"]
 other = "目标账号角色已变化，请刷新后重试。"
 

--- a/tools/i18nmarkers/server/active.en-US.toml
+++ b/tools/i18nmarkers/server/active.en-US.toml
@@ -1140,6 +1140,9 @@ other = "This account does not have management permission."
 ["err.server.user.manager_role_changed"]
 other = "The target account role has changed; refresh and try again."
 
+["err.server.user.manager_role_target_ineligible"]
+other = "This account is not eligible for the requested management role."
+
 ["err.server.user.new_password_same_as_old"]
 other = "The new password must be different from the current one."
 


### PR DESCRIPTION
## Summary

Curating the platform MCP / Skill catalogs required SuperAdmin, which also carries every other administrative power — system settings, backups, user and group writes, space destruction, Expert Market. There was no way to staff catalog curation without handing out the entire console.

This adds `marketAdmin`, a fixed role shaped exactly like the existing `dashboardReader`. Paired with Mininglamp-OSS/octo-marketplace#55, which is what actually admits the role on the catalog route groups. **Merge order does not matter:** until an account is granted the role here, no request carries it and every marketplace gate behaves as today.

## Related Issue

Part of the direction tracked in #366.

## Linked Spec

`.octospec/tasks/admin-rbac-extraction/brief.md` (on branch `feat/admin-rbac-extraction`) specifies the general capability-based admin RBAC. **This PR deliberately does not implement it.** It delivers the concrete need — staffing catalog curation — using the fixed-role mechanism that already exists, and the brief records what a general solution would require. Both fixed roles collapse into rows of a role table when that lands.

## Changes

- `pkg/auth/manager_roles.go`: add `ManagerRoleMarketAdmin`, admit it in `IsManagerConsoleRole`, and add `CanAdminMarketplace` as the server-authoritative policy for the catalog surface.
- `modules/user/api_manager.go`: `mcp.read/write` + `skill.read/write` now derive from `CanAdminMarketplace(role)` instead of `isSuper`. `expert.*` stays SuperAdmin-only.
- `modules/user/api_manager.go`: the dashboardReader grant/revoke flow is now parameterised by role rather than duplicated — `setFixedManagerRole`, `fixedManagerRoleTransition`, `fixedManagerRoleGrantEligible`, `finishFixedManagerRoleRequest`, `listUsersWithFixedManagerRole`.
- New routes on the existing rate-limited group: `GET /v1/manager/user/market-admin`, `PUT|DELETE /v1/manager/user/:uid/market-admin`.
- `pkg/errcode/user.go`: add role-agnostic `ErrUserManagerRoleTargetIneligible` (+ zh-CN). The dashboard-specific code is kept so that endpoint's message does not change.

No database migration, no frontend change: `octo-admin` already ships the `mcp.*` / `skill.*` capability keys, menu entries, routes, and landing path.

## Testing

- [x] Unit tests added/updated
- [ ] Manually verified

- `pkg/auth`: `TestManagerRolePolicy` extended with `CanAdminMarketplace` and a marketAdmin row — console access yes, dashboard read no.
- `modules/user`: new `TestManagerCapabilities_MarketAdmin` asserts marketAdmin holds exactly the four catalog keys and nothing else (notably `expert.*` false).
- `modules/user`: `TestDashboardReaderRoleTransition` → `TestFixedManagerRoleTransition`, now role-parameterised, with cases pinning that the two fixed roles are mutually exclusive and cannot be swapped implicitly.
- `go build ./...`, `go vet`, `make i18n-extract-check`, `make i18n-lint` all pass. `gofmt` clean on touched files.
- **Not run locally:** the `modules/user` suite needs MySQL, which was unavailable in my environment (`TestMain` → `testutil.NewTestServer` panics on connect). Those tests need to go green in CI before merge.

## COMPREHENSION

**1. What does this change actually do to the load-bearing path?**

It adds one accepted value to the manager-console login gate, and moves four capability-map entries from `isSuper` to `isSuper || role == marketAdmin`. The authorization path for every existing endpoint is untouched: octo-lib's `CheckLoginRole` / `CheckLoginRoleIsSuperAdmin` do not know the string `marketAdmin`, so an account holding it fails all 100 role checks in this service. That is the design — the role's entire effect is the capability map plus what octo-marketplace independently chooses to honour.

**2. What could break because of it (dependents + failure mode)?**

- `IsManagerConsoleRole` is widened, so it now admits console login for accounts carrying the new role. Only a SuperAdmin can assign it, and the transition table rejects granting it over `superAdmin` or over the other fixed role.
- The dashboardReader refactor is the real risk in this diff, since it touches a working authorization flow. The CAS on `user.role`, the `roleService.Invalidate` call, idempotency and eligibility semantics are preserved verbatim; the extracted functions take the role as a parameter and nothing else changed. The transition test was extended rather than rewritten to keep the original expectations pinned.
- `user.role` is single-valued, so the fixed roles are mutually exclusive. Granting `marketAdmin` to a `dashboardReader` (or the reverse) is rejected rather than silently rewritten, and revoking one role leaves an account holding the other untouched — both covered by tests.
- Cross-repo: `marketAdmin` in octo-marketplace is coupled to this constant by convention, not by import, exactly as `superAdmin` already is. If either string is renamed without the other, the catalog groups silently 403. Both constants carry comments saying so.

**3. How do you know it works (specific test/repro/trace)?**

The capability contract is asserted directly (`TestManagerCapabilities_MarketAdmin` iterates the whole map, so any key leaking to marketAdmin fails), the role policy is table-tested in `pkg/auth`, and the mutual-exclusion and downgrade rules are table-tested in `TestFixedManagerRoleTransition`. The end-to-end path — marketAdmin reaching `/api/v1/admin/skills` but getting 403 on `/api/v1/admin/experts` — is asserted on the marketplace side, where the enforcement actually lives. The `modules/user` HTTP-level tests still need a CI run with MySQL.

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] PR description is in English
- [x] Added tests for my changes
- [x] Updated documentation
- [x] Followed commit message conventions (Conventional Commits)