### PR TITLE
feat(auth): extend marketAdmin to the Expert Market capabilities

### DIFF
--- a/modules/user/api_manager.go
+++ b/modules/user/api_manager.go
@@ -525,7 +525,7 @@ func (m *Manager) setFixedManagerRole(c *wkhttp.Context, role string, ineligible
 		respondManagerForbidden(c)
 		return
 	}
-	if false && !isFixedManagerRole(role) {
+	if !isFixedManagerRole(role) {
 		// Programmer error, not a client one: no request shape can reach this.
 		// Fail closed and log loudly rather than writing an arbitrary role.
 		m.Error("refusing to write a role that is not a fixed manager role",

--- a/modules/user/api_manager.go
+++ b/modules/user/api_manager.go
@@ -488,15 +488,19 @@ func (m *Manager) revokeDashboardRead(c *wkhttp.Context) {
 	m.setFixedManagerRole(c, auth.ManagerRoleDashboardReader, errcode.ErrUserDashboardReaderTargetIneligible, false)
 }
 
-// grantMarketAdmin assigns the marketAdmin role, which grants the platform
-// MCP / Skill catalog admin surface (and nothing else). Assigning it to an admin
-// is a deliberate downgrade, same semantics as dashboardReader.
+// grantMarketAdmin assigns the marketAdmin role, which grants the whole platform
+// market admin surface — MCP catalog, Skill catalog and Expert Market — and no
+// console power outside it. Assigning it to an admin is a deliberate downgrade,
+// same semantics as dashboardReader. See ManagerRoleMarketAdmin for what a
+// holder can publish, and why revoking the role alone does not cut that off.
 func (m *Manager) grantMarketAdmin(c *wkhttp.Context) {
 	m.setFixedManagerRole(c, auth.ManagerRoleMarketAdmin, errcode.ErrUserManagerRoleTargetIneligible, true)
 }
 
 // revokeMarketAdmin removes only the marketAdmin role. It does not remove the
-// catalog access a SuperAdmin holds inherently.
+// market access a SuperAdmin holds inherently, and — see ManagerRoleMarketAdmin
+// — it does not end the holder's existing sessions, which is what actually cuts
+// off marketplace access.
 func (m *Manager) revokeMarketAdmin(c *wkhttp.Context) {
 	m.setFixedManagerRole(c, auth.ManagerRoleMarketAdmin, errcode.ErrUserManagerRoleTargetIneligible, false)
 }
@@ -521,7 +525,7 @@ func (m *Manager) setFixedManagerRole(c *wkhttp.Context, role string, ineligible
 		respondManagerForbidden(c)
 		return
 	}
-	if !isFixedManagerRole(role) {
+	if false && !isFixedManagerRole(role) {
 		// Programmer error, not a client one: no request shape can reach this.
 		// Fail closed and log loudly rather than writing an arbitrary role.
 		m.Error("refusing to write a role that is not a fixed manager role",

--- a/modules/user/api_manager.go
+++ b/modules/user/api_manager.go
@@ -188,8 +188,8 @@ func (m *Manager) me(c *wkhttp.Context) {
 //   - skill.write       = 系统 Skill 创建/编辑/删除/分类管理（superAdmin ∪ marketAdmin）
 //   - mcp.read          = 系统 MCP 列表/详情查看（superAdmin ∪ marketAdmin）
 //   - mcp.write         = 系统 MCP 创建/编辑/删除（superAdmin ∪ marketAdmin）
-//   - expert.read       = 专家市场 专家/专家团 列表/详情查看（requireSuperAdmin）
-//   - expert.write      = 专家市场 上传新建/编辑/删除 + 分类管理（requireSuperAdmin）
+//   - expert.read       = 专家市场 专家/专家团 列表/详情查看（superAdmin ∪ marketAdmin）
+//   - expert.write      = 专家市场 上传新建/编辑/删除 + 分类管理（superAdmin ∪ marketAdmin）
 //
 // TODO(#366 Part 2): 目前这张表按各端点当前档位手工维护；集中式 authz 策略表落地
 // 后，应改为由同一份 route→role 真源派生，彻底消除前后端漂移。
@@ -206,20 +206,19 @@ func managerCapabilities(role string) map[string]bool {
 		"users.write":        isSuper, // 重置密码 / 新增用户 / 解封 / 改密
 		"users.manage_admin": isSuper, // 管理员账号 增/查/删
 		"groups.write":       isSuper, // 解散封禁群 / 强制移除成员
-		"expert.read":        isSuper, // 专家市场 专家/专家团 列表/详情（marketplace admin surface 收窄到超管）
-		"expert.write":       isSuper, // 专家市场 创建(上传)/编辑/删除 + 分类管理（同上）
-		// superAdmin ∪ marketAdmin —— 平台 MCP / Skill 目录的运营面。marketAdmin 是
-		// 与 dashboardReader 同形状的固定角色：octo-lib 不认识它，所以它过不了任何
-		// admin/superAdmin 端点，只有这四个键为真。
+		// superAdmin ∪ marketAdmin —— 整个平台市场的运营面：MCP 目录、Skill 目录、
+		// 专家市场。marketAdmin 是与 dashboardReader 同形状的固定角色：octo-lib 不
+		// 认识它，所以它过不了任何 admin/superAdmin 端点，只有这六个键为真。
 		//
-		// 注意这四个键只驱动前端渲染；真正的放行在 octo-marketplace，且要等
-		// Mininglamp-OSS/octo-marketplace#55 上线之后——在那之前 marketplace 的
-		// /api/v1/admin/* 是一道只认 superAdmin 的门，marketAdmin 会拿到 403。
-		// 见 auth.CanAdminMarketplace。
-		"skill.read":  auth.CanAdminMarketplace(role), // 系统 Skill 列表/详情
-		"skill.write": auth.CanAdminMarketplace(role), // 系统 Skill 创建/编辑/删除/分类管理
-		"mcp.read":    auth.CanAdminMarketplace(role), // 系统 MCP 列表/详情
-		"mcp.write":   auth.CanAdminMarketplace(role), // 系统 MCP 创建/编辑/删除
+		// 这六个键只驱动前端渲染；真正的放行在 octo-marketplace 的 /api/v1/admin/*，
+		// 见 auth.CanAdminMarketplace。两侧必须同时放开——marketplace 侧仍按资源分组
+		// 挂门，所以只改这里不改那边，页面会渲染出来但每个请求 403。
+		"skill.read":   auth.CanAdminMarketplace(role), // 系统 Skill 列表/详情
+		"skill.write":  auth.CanAdminMarketplace(role), // 系统 Skill 创建/编辑/删除/分类管理
+		"mcp.read":     auth.CanAdminMarketplace(role), // 系统 MCP 列表/详情
+		"mcp.write":    auth.CanAdminMarketplace(role), // 系统 MCP 创建/编辑/删除
+		"expert.read":  auth.CanAdminMarketplace(role), // 专家市场 专家/专家团 列表/详情
+		"expert.write": auth.CanAdminMarketplace(role), // 专家市场 上传新建/编辑/删除 + 分类管理
 		// admin ∪ superAdmin；dashboardReader 仅有 dashboard.read。
 		"appversion.read": isAdmin,                            // 版本列表
 		"dashboard.read":  auth.CanReadManagerDashboard(role), // 运营看板查看

--- a/modules/user/api_manager_market_admin_test.go
+++ b/modules/user/api_manager_market_admin_test.go
@@ -75,6 +75,13 @@ func TestManagerMe_MarketAdminGetsOnlyMarketCaps(t *testing.T) {
 		assert.Equalf(t, granted[capability], enabled,
 			"marketAdmin capability %q over the wire", capability)
 	}
+	// The loop above only visits keys the response actually carries, so on its own
+	// it would pass if /v1/manager/me stopped serializing one. Assert presence
+	// separately — this is the layer where a serialization regression would show.
+	for capability := range granted {
+		assert.Containsf(t, resp.Capabilities, capability,
+			"/v1/manager/me must serialize %q", capability)
+	}
 	assert.False(t, resp.Capabilities["dashboard.read"], "marketAdmin is not a dashboard reader")
 	assert.False(t, resp.Capabilities["users.read"], "marketAdmin holds no console power outside the market")
 	assert.False(t, resp.Capabilities["system_setting"], "marketAdmin holds no console power outside the market")

--- a/modules/user/api_manager_market_admin_test.go
+++ b/modules/user/api_manager_market_admin_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
 	appauth "github.com/Mininglamp-OSS/octo-server/pkg/auth"
+	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -303,6 +304,63 @@ func TestManagerMarketAdminCannotReachAdminEndpoints(t *testing.T) {
 
 			assert.Equal(t, http.StatusBadRequest, w.Code, w.Body.String())
 			assert.Contains(t, w.Body.String(), "err.shared.auth.forbidden")
+		})
+	}
+}
+
+// TestSetFixedManagerRoleRejectsRoleOutsideClosedSet drives the write path with a
+// role outside the closed set. TestIsFixedManagerRole below pins the predicate's
+// return value; this pins that setFixedManagerRole actually *acts* on it.
+//
+// That distinction is not academic. The guard shipped disabled once (`if false &&
+// !isFixedManagerRole(role)`, restored here): build, vet, golangci-lint and the
+// entire modules/user suite stayed green, because the only test touching the guard
+// asserted the predicate in isolation and never the handler that consumes it.
+//
+// Both production callers pass constants, so no real route can reach this. The
+// synthetic route is the point — it stands in for the next caller that forwards a
+// role it did not hard-code, which is the case the guard exists to fail closed on.
+func TestSetFixedManagerRoleRejectsRoleOutsideClosedSet(t *testing.T) {
+	route, ctx, m := newManagerRouteOnly(t)
+
+	const (
+		callerToken = "closed-set-guard-caller"
+		targetUID   = "closed-set-guard-target"
+	)
+	require.NoError(t, ctx.Cache().Set(ctx.GetConfig().Cache.TokenCachePrefix+callerToken,
+		"root-uid@root@"+string(wkhttp.SuperAdmin)))
+	require.NoError(t, NewDB(ctx).Insert(&Model{
+		UID:      targetUID,
+		Username: targetUID,
+		Name:     "Closed Set Guard Target",
+		ShortNo:  targetUID,
+		Status:   StatusEnable.Int(),
+	}))
+
+	synthetic := route.Group("/v1/manager/test", m.ctx.AuthMiddleware(route))
+	synthetic.PUT("/:uid/fixed-role", func(c *wkhttp.Context) {
+		m.setFixedManagerRole(c, c.Query("role"), errcode.ErrUserManagerRoleTargetIneligible, true)
+	})
+
+	// superAdmin is a promotion and "" a silent demotion — the two the guard's own
+	// doc comment names. The other two cover a neighbouring tier and a role string
+	// that does not exist yet.
+	for _, role := range []string{string(wkhttp.SuperAdmin), string(wkhttp.Admin), "", "future-role"} {
+		t.Run("role="+role, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodPut,
+				"/v1/manager/test/"+targetUID+"/fixed-role?role="+role, nil)
+			req.Header.Set("token", callerToken)
+			route.ServeHTTP(w, req)
+
+			assert.Equal(t, http.StatusBadRequest, w.Code,
+				"forbidden is pinned to wire 400 (D14); body=%s", w.Body.String())
+			assert.Contains(t, w.Body.String(), "err.shared.auth.forbidden",
+				"must be refused for the role reason, not some other failure")
+
+			stored, err := NewDB(ctx).QueryRoleByUID(targetUID)
+			require.NoError(t, err)
+			assert.Emptyf(t, stored, "guard must not let %q reach user.role", role)
 		})
 	}
 }

--- a/modules/user/api_manager_market_admin_test.go
+++ b/modules/user/api_manager_market_admin_test.go
@@ -320,38 +320,70 @@ func TestManagerMarketAdminCannotReachAdminEndpoints(t *testing.T) {
 // Both production callers pass constants, so no real route can reach this. The
 // synthetic route is the point — it stands in for the next caller that forwards a
 // role it did not hard-code, which is the case the guard exists to fail closed on.
+//
+// The positive control is load-bearing, not decoration. The superAdmin gate at
+// setFixedManagerRole's top and the closed-set guard below it both end in
+// respondManagerForbidden, so they are indistinguishable on the wire: if the
+// caller token ever stopped resolving to superAdmin, every negative case would
+// still see 400 + err.shared.auth.forbidden and stay green while asserting
+// nothing — and the empty-role check could not tell either, because the target
+// starts with an empty role. The control proves the request actually reaches the
+// guard before any of that means anything.
 func TestSetFixedManagerRoleRejectsRoleOutsideClosedSet(t *testing.T) {
 	route, ctx, m := newManagerRouteOnly(t)
 
 	const (
-		callerToken = "closed-set-guard-caller"
-		targetUID   = "closed-set-guard-target"
+		callerToken  = "closed-set-guard-caller"
+		targetUID    = "closed-set-guard-target"
+		controlUID   = "closed-set-guard-control"
+		syntheticURL = "/v1/manager/test/%s/fixed-role?role=%s"
 	)
 	require.NoError(t, ctx.Cache().Set(ctx.GetConfig().Cache.TokenCachePrefix+callerToken,
 		"root-uid@root@"+string(wkhttp.SuperAdmin)))
-	require.NoError(t, NewDB(ctx).Insert(&Model{
-		UID:      targetUID,
-		Username: targetUID,
-		Name:     "Closed Set Guard Target",
-		ShortNo:  targetUID,
-		Status:   StatusEnable.Int(),
-	}))
+	for _, uid := range []string{targetUID, controlUID} {
+		require.NoError(t, NewDB(ctx).Insert(&Model{
+			UID:      uid,
+			Username: uid,
+			Name:     "Closed Set Guard " + uid,
+			ShortNo:  uid,
+			Status:   StatusEnable.Int(),
+		}))
+	}
 
 	synthetic := route.Group("/v1/manager/test", m.ctx.AuthMiddleware(route))
 	synthetic.PUT("/:uid/fixed-role", func(c *wkhttp.Context) {
 		m.setFixedManagerRole(c, c.Query("role"), errcode.ErrUserManagerRoleTargetIneligible, true)
 	})
 
+	doRequest := func(uid, role string) *httptest.ResponseRecorder {
+		t.Helper()
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodPut, fmt.Sprintf(syntheticURL, uid, role), nil)
+		req.Header.Set("token", callerToken)
+		route.ServeHTTP(w, req)
+		return w
+	}
+
+	// Positive control — an in-set role on the same route must get all the way
+	// through and persist. If this fails, the negative cases below prove nothing.
+	t.Run("control/in-set role reaches the write path", func(t *testing.T) {
+		w := doRequest(controlUID, appauth.ManagerRoleMarketAdmin)
+		require.Equal(t, http.StatusOK, w.Code,
+			"the harness must reach setFixedManagerRole's write path; body=%s", w.Body.String())
+
+		stored, err := NewDB(ctx).QueryRoleByUID(controlUID)
+		require.NoError(t, err)
+		require.Equal(t, appauth.ManagerRoleMarketAdmin, stored,
+			"an in-set role must actually be persisted")
+	})
+
 	// superAdmin is a promotion and "" a silent demotion — the two the guard's own
 	// doc comment names. The other two cover a neighbouring tier and a role string
-	// that does not exist yet.
+	// that does not exist yet. Each runs against a target whose role is still empty,
+	// so the guard is the only thing that can refuse them.
 	for _, role := range []string{string(wkhttp.SuperAdmin), string(wkhttp.Admin), "", "future-role"} {
 		t.Run("role="+role, func(t *testing.T) {
-			w := httptest.NewRecorder()
-			req := httptest.NewRequest(http.MethodPut,
-				"/v1/manager/test/"+targetUID+"/fixed-role?role="+role, nil)
-			req.Header.Set("token", callerToken)
-			route.ServeHTTP(w, req)
+			w := doRequest(targetUID, role)
 
 			assert.Equal(t, http.StatusBadRequest, w.Code,
 				"forbidden is pinned to wire 400 (D14); body=%s", w.Body.String())

--- a/modules/user/api_manager_market_admin_test.go
+++ b/modules/user/api_manager_market_admin_test.go
@@ -51,11 +51,11 @@ func TestManagerLoginAllowsMarketAdmin(t *testing.T) {
 	assert.Contains(t, w.Body.String(), `"role":"`+appauth.ManagerRoleMarketAdmin+`"`)
 }
 
-// TestManagerMe_MarketAdminGetsOnlyCatalogCaps is the wire-level counterpart to
+// TestManagerMe_MarketAdminGetsOnlyMarketCaps is the wire-level counterpart to
 // TestManagerCapabilities_MarketAdmin: the pure function cannot catch a
 // regression in the handler's own role gate, and the capability map is the
 // contract octo-admin renders from.
-func TestManagerMe_MarketAdminGetsOnlyCatalogCaps(t *testing.T) {
+func TestManagerMe_MarketAdminGetsOnlyMarketCaps(t *testing.T) {
 	route, ctx, _ := newManagerRouteOnly(t)
 
 	loginAsRole(t, ctx, appauth.ManagerRoleMarketAdmin)
@@ -69,13 +69,15 @@ func TestManagerMe_MarketAdminGetsOnlyCatalogCaps(t *testing.T) {
 	granted := map[string]bool{
 		"mcp.read": true, "mcp.write": true,
 		"skill.read": true, "skill.write": true,
+		"expert.read": true, "expert.write": true,
 	}
 	for capability, enabled := range resp.Capabilities {
 		assert.Equalf(t, granted[capability], enabled,
 			"marketAdmin capability %q over the wire", capability)
 	}
-	assert.False(t, resp.Capabilities["expert.read"], "expert market stays superAdmin-only")
 	assert.False(t, resp.Capabilities["dashboard.read"], "marketAdmin is not a dashboard reader")
+	assert.False(t, resp.Capabilities["users.read"], "marketAdmin holds no console power outside the market")
+	assert.False(t, resp.Capabilities["system_setting"], "marketAdmin holds no console power outside the market")
 }
 
 func TestManagerMarketAdminGrantAndRevoke(t *testing.T) {

--- a/modules/user/api_manager_me_test.go
+++ b/modules/user/api_manager_me_test.go
@@ -59,15 +59,16 @@ func TestManagerCapabilities(t *testing.T) {
 }
 
 // TestManagerCapabilities_MarketAdmin pins the whole point of the marketAdmin
-// role: exactly the four platform-catalog keys and nothing else. In particular
-// expert.* stays false — curating the Expert Market remains SuperAdmin-only,
-// and octo-marketplace gates that route group separately.
+// role: exactly the six platform-market keys and nothing else. Iterating the
+// whole map rather than spot-checking is deliberate — any capability that leaks
+// into this role fails here rather than shipping.
 func TestManagerCapabilities_MarketAdmin(t *testing.T) {
 	market := managerCapabilities(appauth.ManagerRoleMarketAdmin)
 
 	granted := map[string]bool{
 		"mcp.read": true, "mcp.write": true,
 		"skill.read": true, "skill.write": true,
+		"expert.read": true, "expert.write": true,
 	}
 	for k, v := range market {
 		if want := granted[k]; v != want {

--- a/modules/user/api_manager_me_test.go
+++ b/modules/user/api_manager_me_test.go
@@ -22,7 +22,11 @@ func TestManagerCapabilities(t *testing.T) {
 	admin := managerCapabilities(string(wkhttp.Admin))
 	reader := managerCapabilities(appauth.ManagerRoleDashboardReader)
 
-	superOnly := []string{
+	// Keys that superAdmin has and neither admin nor dashboardReader does. NOT
+	// "superAdmin-only" any more: the six market keys are also held by
+	// marketAdmin, which this test never constructs — see
+	// TestManagerCapabilities_MarketAdmin for that tier.
+	aboveAdminTier := []string{
 		"system_setting", "backup", "appversion.write", "dashboard.trigger", "space.destructive",
 		"users.write", "users.manage_admin", "groups.write", "skill.write", "skill.read", "mcp.write", "mcp.read",
 		"expert.write", "expert.read",
@@ -31,7 +35,7 @@ func TestManagerCapabilities(t *testing.T) {
 		"appversion.read", "dashboard.read", "users.read", "groups.read", "space.read", "space.write",
 	}
 
-	for _, k := range superOnly {
+	for _, k := range aboveAdminTier {
 		if !super[k] {
 			t.Errorf("superAdmin must have capability %q", k)
 		}
@@ -53,7 +57,7 @@ func TestManagerCapabilities(t *testing.T) {
 	}
 
 	// Guard against a key being silently dropped/renamed out of the contract.
-	if got, want := len(super), len(superOnly)+len(adminTier); got != want {
+	if got, want := len(super), len(aboveAdminTier)+len(adminTier); got != want {
 		t.Errorf("capability map has %d keys, want %d (update this test if the contract changed)", got, want)
 	}
 }

--- a/modules/user/api_manager_me_test.go
+++ b/modules/user/api_manager_me_test.go
@@ -40,10 +40,10 @@ func TestManagerCapabilities(t *testing.T) {
 			t.Errorf("superAdmin must have capability %q", k)
 		}
 		if admin[k] {
-			t.Errorf("admin must NOT have superAdmin-only capability %q", k)
+			t.Errorf("admin must NOT have above-admin-tier capability %q", k)
 		}
 		if reader[k] {
-			t.Errorf("dashboardReader must NOT have superAdmin-only capability %q", k)
+			t.Errorf("dashboardReader must NOT have above-admin-tier capability %q", k)
 		}
 	}
 	for _, k := range adminTier {

--- a/pkg/auth/manager_roles.go
+++ b/pkg/auth/manager_roles.go
@@ -20,9 +20,10 @@ const ManagerRoleDashboardReader = "dashboardReader"
 // per resource; each group that admits this role opts into it explicitly, and a
 // group registered without it stays superAdmin-only. Both sides must agree: a
 // capability advertised here that marketplace does not admit renders the page
-// and then 403s every call behind it.
+// and then 403s every call behind it. The marketplace half is octo-marketplace#55
+// (per-resource gating) and #56 (admitting this role on the Expert Market groups).
 //
-// Before granting this to anyone, four things are worth knowing:
+// Before granting this to anyone, five things are worth knowing:
 //
 //   - It is a publishing authority, not a read-mostly editor. A holder can
 //     create, edit and delete the public Skills, system MCPs and experts that
@@ -33,8 +34,16 @@ const ManagerRoleDashboardReader = "dashboardReader"
 //   - Do not DEPLOY this service before octo-marketplace has the matching gate
 //     live. The capabilities are computed per request from CanAdminMarketplace,
 //     so every account already holding the role picks up the advertised surface
-//     at deploy — withholding new grants does not narrow the blast radius. The
-//     affected population is fixed at release time, not at grant time.
+//     at deploy — withholding new grants does not narrow the blast radius, and
+//     the population that gains it at deploy is fixed at release time. (Later
+//     grants do of course extend it; the point is that deploy order, not grant
+//     policy, is the lever for the accounts that already hold the role.)
+//   - A GRANT DOES NOT REACH MARKETPLACE UNTIL THE HOLDER RE-AUTHENTICATES.
+//     Mirror image of the revoke trap below, same cause: /v1/manager/me reads the
+//     live role through the parser's RoleResolver, while marketplace reads the
+//     token snapshot through /v1/auth/verify. So granting this to someone with an
+//     open console session makes the menu appear immediately and every call
+//     behind it 403 until they log out and back in. Have them re-login.
 //   - REVOKING THE ROLE DOES NOT CUT OFF MARKET ACCESS. Revoke the session too.
 //     Marketplace resolves callers through /v1/auth/verify, which answers from
 //     tokenValidator.Validate — the role snapshotted into the session token at

--- a/pkg/auth/manager_roles.go
+++ b/pkg/auth/manager_roles.go
@@ -31,11 +31,17 @@ const ManagerRoleDashboardReader = "dashboardReader"
 //     settings, backups, user/group writes or space destruction — but pick people
 //     at a supply-chain bar, not at a "content editor" one.
 //   - Do not grant it before octo-marketplace has the matching gate deployed.
-//   - Revocation is not instant across the boundary: octo-marketplace caches the
-//     resolved identity per token (AUTH_CACHE_TTL, 30s default), and that cache
-//     has no invalidation entry point, so market access survives a revoke — of
-//     the role or of the session — until the entry expires. There is no faster
-//     lever short of lowering the TTL or restarting the process.
+//   - REVOKING THE ROLE DOES NOT CUT OFF MARKET ACCESS. Revoke the session too.
+//     Marketplace resolves callers through /v1/auth/verify, which answers from
+//     tokenValidator.Validate — the role snapshotted into the session token at
+//     login — not from the live user.role column. (The RoleResolver that keeps
+//     octo-server's own console fresh within RoleCacheTTL is wired into
+//     CacheTokenParser only; see main.go.) So for an existing session, clearing
+//     user.role never lands: catalog access survives for the remaining token
+//     lifetime, up to Cache.TokenExpire — 30 days by default.
+//     Revoking the session does work, bounded by marketplace's own token-keyed
+//     identity cache (AUTH_CACHE_TTL, 30s default), which has no invalidation
+//     entry point. So: role + session, and expect up to ~30s of residual access.
 //   - See the fixed-role section in modules/user/api_manager.go for the two
 //     lifecycle traps both fixed roles share (one-way downgrade, and accounts
 //     that cannot be deleted until the role is revoked).
@@ -50,8 +56,9 @@ func IsManagerConsoleRole(role string) bool {
 		role == ManagerRoleMarketAdmin
 }
 
-// CanAdminMarketplace is the server-authoritative policy for the platform market /
-// Skill catalog admin surface. It is the octo-server half of a contract whose
+// CanAdminMarketplace is the server-authoritative policy for the platform market
+// admin surface — MCP catalog, Skill catalog and Expert Market. It is the
+// octo-server half of a contract whose
 // enforcement lives in octo-marketplace (internal/middleware/admin.go): this
 // function decides what /v1/manager/me advertises, marketplace decides what the
 // /api/v1/admin/* routes actually admit. Keep the two in sync.

--- a/pkg/auth/manager_roles.go
+++ b/pkg/auth/manager_roles.go
@@ -30,7 +30,11 @@ const ManagerRoleDashboardReader = "dashboardReader"
 //     catalog taxonomy. It is genuinely narrower than superAdmin — no system
 //     settings, backups, user/group writes or space destruction — but pick people
 //     at a supply-chain bar, not at a "content editor" one.
-//   - Do not grant it before octo-marketplace has the matching gate deployed.
+//   - Do not DEPLOY this service before octo-marketplace has the matching gate
+//     live. The capabilities are computed per request from CanAdminMarketplace,
+//     so every account already holding the role picks up the advertised surface
+//     at deploy — withholding new grants does not narrow the blast radius. The
+//     affected population is fixed at release time, not at grant time.
 //   - REVOKING THE ROLE DOES NOT CUT OFF MARKET ACCESS. Revoke the session too.
 //     Marketplace resolves callers through /v1/auth/verify, which answers from
 //     tokenValidator.Validate — the role snapshotted into the session token at

--- a/pkg/auth/manager_roles.go
+++ b/pkg/auth/manager_roles.go
@@ -7,36 +7,35 @@ import "github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
 // CheckLoginRole would accidentally grant every admin endpoint.
 const ManagerRoleDashboardReader = "dashboardReader"
 
-// ManagerRoleMarketAdmin is a fixed role for staff who curate the platform's
-// MCP and Skill catalogs without holding any other administrative power.
+// ManagerRoleMarketAdmin is a fixed role for staff who run the platform market —
+// the MCP catalog, the Skill catalog and the Expert Market — without holding any
+// other administrative power.
 //
 // Same shape and same rationale as ManagerRoleDashboardReader: it is deliberately
 // NOT known to octo-lib's CheckLoginRole, so an account holding it passes zero
 // admin/superAdmin endpoint gates in octo-server. Its only effect here is the
-// mcp.*/skill.* capabilities in managerCapabilities.
+// mcp.* / skill.* / expert.* capabilities in managerCapabilities.
 //
-// Enforcement lives in octo-marketplace, and only once
-// Mininglamp-OSS/octo-marketplace#55 has shipped: before that PR a single gate
-// guards every /api/v1/admin/* group and admits superAdmin alone, so a holder of
-// this role gets 403 on the catalog surface rather than access to it. After it,
-// the catalog groups (mcps, skills, skill_categories, skill uploads) admit this
-// role and the Expert Market groups keep the superAdmin-only gate — which is why
-// expert.* is excluded from the capabilities below.
+// Enforcement lives in octo-marketplace, whose /api/v1/admin/* groups are gated
+// per resource; each group that admits this role opts into it explicitly, and a
+// group registered without it stays superAdmin-only. Both sides must agree: a
+// capability advertised here that marketplace does not admit renders the page
+// and then 403s every call behind it.
 //
 // Before granting this to anyone, four things are worth knowing:
 //
 //   - It is a publishing authority, not a read-mostly editor. A holder can
-//     create, edit and delete the public Skills and system MCPs that every user
-//     on the platform installs, and restructure the catalog taxonomy. It is
-//     genuinely narrower than superAdmin, but pick people at a supply-chain bar,
-//     not at a "content editor" one.
-//   - Do not grant it before octo-marketplace has the paired change deployed.
-//     Until then octo-admin renders the MCP / Skill pages for the holder and
-//     every call behind them 403s.
+//     create, edit and delete the public Skills, system MCPs and experts that
+//     every user on the platform installs and runs locally, and restructure the
+//     catalog taxonomy. It is genuinely narrower than superAdmin — no system
+//     settings, backups, user/group writes or space destruction — but pick people
+//     at a supply-chain bar, not at a "content editor" one.
+//   - Do not grant it before octo-marketplace has the matching gate deployed.
 //   - Revocation is not instant across the boundary: octo-marketplace caches the
-//     resolved identity per token (AUTH_CACHE_TTL, 30s default) on top of this
-//     service's own role cache, so catalog access can survive a revoke by up to
-//     the sum of the two. Revoke the session too when it must be immediate.
+//     resolved identity per token (AUTH_CACHE_TTL, 30s default), and that cache
+//     has no invalidation entry point, so market access survives a revoke — of
+//     the role or of the session — until the entry expires. There is no faster
+//     lever short of lowering the TTL or restarting the process.
 //   - See the fixed-role section in modules/user/api_manager.go for the two
 //     lifecycle traps both fixed roles share (one-way downgrade, and accounts
 //     that cannot be deleted until the role is revoked).
@@ -51,7 +50,7 @@ func IsManagerConsoleRole(role string) bool {
 		role == ManagerRoleMarketAdmin
 }
 
-// CanAdminMarketplace is the server-authoritative policy for the platform MCP /
+// CanAdminMarketplace is the server-authoritative policy for the platform market /
 // Skill catalog admin surface. It is the octo-server half of a contract whose
 // enforcement lives in octo-marketplace (internal/middleware/admin.go): this
 // function decides what /v1/manager/me advertises, marketplace decides what the

--- a/pkg/auth/manager_roles_test.go
+++ b/pkg/auth/manager_roles_test.go
@@ -18,7 +18,7 @@ func TestManagerRolePolicy(t *testing.T) {
 		{name: "admin", role: string(wkhttp.Admin), wantConsole: true, wantDashboardRead: true},
 		{name: "dashboard reader", role: ManagerRoleDashboardReader, wantConsole: true, wantDashboardRead: true},
 		// marketAdmin may enter the console, but holds neither dashboard read nor
-		// any admin-tier power — its only privilege is the platform catalog surface.
+		// any admin-tier power — its only privilege is the platform market surface.
 		{name: "market admin", role: ManagerRoleMarketAdmin, wantConsole: true, wantMarketplace: true},
 		{name: "plain user", role: "", wantConsole: false, wantDashboardRead: false},
 		{name: "unknown role", role: "unknown", wantConsole: false, wantDashboardRead: false},


### PR DESCRIPTION
## Summary

#774 gave `marketAdmin` the `mcp.*` and `skill.*` keys and left `expert.*` on SuperAdmin. That matched the original request, but it leaves the role one resource short of its purpose — an account created to run the platform market still cannot touch the Expert Market.

`expert.read` / `expert.write` now derive from `CanAdminMarketplace` like the other four keys.

The enforcement half is Mininglamp-OSS/octo-marketplace#56, **now merged**. The remaining constraint is release ordering: marketplace must be *deployed* before this service, or every existing `marketAdmin` gets a rendered Expert Market where each call 403s. Fail-closed, but a confusing state to ship.

The net production diff against `main` is two lines — the two capability-map entries. Everything else in this PR is documentation and tests.

## Related Issue

Follows #774; part of the direction tracked in #366.

## Linked Spec

None. The general capability-based RBAC design is tracked in #366 and is deliberately not implemented here — this PR is two entries in a fixed-role capability map.

## ⚠️ Correction: I disabled a security guard and shipped it in `42c6f4b`

Stating this at the top because it is the most important thing in this PR's history.

`42c6f4b` contained `if false && !isFixedManagerRole(role)` at `modules/user/api_manager.go:528`. That was **mutation-test scaffolding I injected to find out whether any test covered the guard, and then committed by mistake.** The commit message said the change was documentation corrections and never mentioned it. `adb3001` restores it.

Nothing was exploitable at any point — all four call sites pass constants and the endpoint still required a superAdmin actor. But the guard is the write side of a privilege boundary: `fixedManagerRoleTransition` persists whatever role string it is handed, so a future caller forwarding `superAdmin` would have the CAS commit a promotion, and `""` would silently demote an admin. It turned "unreachable by construction" back into "unreachable by convention" while the surrounding comments kept claiming the guard was live.

**Why nothing caught it:**

| check | why it passed |
|---|---|
| `go build` / `go vet` | Go does not warn on a constant-false condition |
| `golangci-lint` | CI profile is govet-only |
| unused-code detection | `isFixedManagerRole` stays referenced by the dead expression |
| `TestIsFixedManagerRole` | asserts the predicate in isolation, never the handler consuming it |
| full `modules/user` suite | passes identically with and without the guard |
| my own report to reviewers | I verified `git status` was clean **after** committing — which cannot distinguish "reverted" from "swept into the commit" |

Reported independently by @yujiawei, @Jerry-Xin and Octo-Q — three for three on a defect my own adversarial review missed.

## Changes

- `modules/user/api_manager.go`: `expert.read` / `expert.write` move from `isSuper` to `auth.CanAdminMarketplace(role)`, joining the other four market keys in one block. **This is the entire production change.** Closed-set guard restored to its `main` state.
- `pkg/auth/manager_roles.go`: role doc rewritten around the per-resource marketplace model; grant, revoke and deploy guidance corrected (below).

### The three lifecycle traps, all now documented

The role's two services disagree about where the role comes from, and that produces one trap in each direction:

| action | console (`/v1/manager/me`) | marketplace (`/v1/auth/verify`) |
|---|---|---|
| **grant** | immediate — live role via `RoleResolver` | **not until re-login** — token snapshot |
| **revoke** | immediate | **never**, for an existing session — up to `Cache.TokenExpire`, 30 days |
| **deploy** | every existing holder gains the surface at once | — |

- **Revoke:** an intermediate revision of this branch *removed* the "revoke the session too" instruction, claiming it was no faster than revoking the role. Wrong, and reverted. Marketplace answers from `tokenValidator.Validate` (`modules/user/api.go:4752`), which decodes the role from the token payload and never reads `user.role`. Session revocation is the lever that works, bounded by marketplace's `AuthCacheTTL` (~30s). Correct runbook: **role + session**. Two reviewers initially affirmed the incorrect version; I reverted it anyway, and it has since been independently re-derived by @yujiawei (cross-repo trace) and Octo-Q on both PRs.
- **Grant:** the mirror image, and it had no note at all until `ada2798`. Granting to someone with an open console session renders the menu immediately while every call behind it 403s until they log out and back in.
- **Deploy:** the guidance used to say "do not *grant* it before marketplace has the gate deployed". Withholding grants protects nobody — capabilities are computed per request, so existing holders gain the surface the moment this build ships. Deploy order is the lever. (Raised by @yujiawei and Octo-Q.)

No migration, no frontend change: `octo-admin` already ships both keys in `MANAGER_CAPABILITY_KEYS`, its routes and menu are gated purely on capabilities, and it contains no hardcoded system-role comparison.

## Testing

- [x] Unit tests added/updated
- [ ] Manually verified

`TestSetFixedManagerRoleRejectsRoleOutsideClosedSet` (new in `adb3001`) drives the handler rather than the predicate — the structural gap that let the guard ship disabled. **Red before green** against the disabled guard: all four negative subtests failed, with `superAdmin` genuinely persisted to `user.role`.

`ada2798` then added the positive control @yujiawei asked for, because the negative cases alone could have gone green for the wrong reason: the superAdmin gate and the closed-set guard both end in `respondManagerForbidden` and are indistinguishable on the wire. Verified by mutation — with the caller token downgraded to `admin`:

| subtest | under the mutation |
|---|---|
| **control** (in-set role must reach the write path) | **FAIL** |
| `role=superAdmin` / `admin` / `""` / `future-role` | all **PASS** |

Without the control, that mutation ships a green test that asserts nothing. Mutation reverted; file byte-compared against its pre-mutation state.

Other pins: `TestManagerCapabilities_MarketAdmin` iterates the whole map so any leaked capability fails; `TestManagerMe_MarketAdminGetsOnlyMarketCaps` asserts per-key presence plus negatives on `users.read` / `system_setting`; the #774 containment tests pass unmodified.

Full run at `ada2798` against real infrastructure (MySQL 8 + Redis + WuKongIM):

```
go test ./modules/user/ -count=1                 ok  138.412s
go test ./pkg/auth/ ./pkg/errcode/ -count=1      ok
go build ./... · go vet · make i18n-extract-check · make i18n-lint · gofmt   clean
```

## COMPREHENSION

**1. What does this change actually do to the load-bearing path?**

It flips two entries in the capability map from `isSuper` to `isSuper || role == marketAdmin`. `IsManagerConsoleRole`, `CanAdminMarketplace`, `fixedManagerRoleTransition`, the closed-set guard and every endpoint gate are identical to `main`. The capability map is display-only in this service — `managerCapabilities` has exactly one non-test caller, the `/v1/manager/me` handler — so no octo-server route is unlocked by it.

*(An earlier revision of this section claimed the closed-set guard was untouched while the diff contradicted it. That is corrected here rather than quietly deleted; see the correction above.)*

**2. What could break because of it (dependents + failure mode)?**

- **Existing holders gain the surface at deploy, not at grant**, so marketplace must be deployed first. Fail-closed 403s otherwise.
- Blast radius grows: experts and squads on top of public Skills and system MCPs — every artifact tenants install and run locally. Narrower than SuperAdmin (no system settings, backups, user/group writes, space destruction), and asserted as such.
- No change to who can grant: SuperAdmin-only, compare-and-set, mutually exclusive with `dashboardReader`, closed-set again.

**3. How do you know it works (specific test/repro/trace)?**

The capability map is asserted key-by-key at the pure-function and wire layers; the guard is asserted at the handler layer with documented red-before-green *and* a mutation-verified positive control; the full `modules/user` suite passes against real infrastructure. The enforcement half is mutation-verified in octo-marketplace#56, where @yujiawei independently reproduced both mutations rather than accepting my table.

## Open items for a human

1. **Session revocation on role change.** Both @yujiawei and Octo-Q want `revokeMarketAdmin` to revoke sessions the way `deleteAdminUser` does. Not done here, on @yujiawei's own analysis: `allowedSessionRevocationReasons` has no role-change reason and `updateUserFieldWithSessionRevocation` issues an unconditional `Where(uid=?)` where the role path needs the CAS `Where(uid=? and role=?)`. That is a new mutation, a new reason and its own tests — a PR, not a rider. Until it lands, the runbook's second step is mandatory rather than nice-to-have.
2. **Deploy ordering** — confirm marketplace's deployed build carries #56 before this service ships.
3. **Blast-radius sign-off** — confirm the current `marketAdmin` grant list is appropriate at a supply-chain bar. The role is grantable today and #56 is already merged.
4. **Coverage gap in the sibling repo** — nothing pins that `admin` and `dashboardReader` are still refused on the marketplace expert groups. #56 has merged, so that needs its own PR there.

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] PR description is in English
- [x] Added tests for my changes
- [x] Updated documentation
- [x] Followed commit message conventions (Conventional Commits)