### PR TITLE
fix(bot_api): sanitize revoked messages in /v1/bot/messages/sync [WS-168]

### DIFF
--- a/modules/bot_api/sync.go
+++ b/modules/bot_api/sync.go
@@ -1,11 +1,13 @@
 package bot_api
 
 import (
+	"strconv"
 	"strings"
 
 	"github.com/Mininglamp-OSS/octo-lib/common"
 	"github.com/Mininglamp-OSS/octo-lib/config"
 	"github.com/Mininglamp-OSS/octo-lib/pkg/wkhttp"
+	"github.com/Mininglamp-OSS/octo-server/modules/message"
 	"github.com/Mininglamp-OSS/octo-server/pkg/errcode"
 	"github.com/Mininglamp-OSS/octo-server/pkg/httperr"
 	"go.uber.org/zap"
@@ -155,5 +157,91 @@ func (ba *BotAPI) syncMessages(c *wkhttp.Context) {
 		return
 	}
 
-	c.Response(resp)
+	// 撤回脱敏：bot 拉历史与人看到的状态必须一致（WS-168 / octo-server#777）。
+	// IMSyncChannelMessage 直出的是 WuKongIM 未脱敏原始 payload，撤回是
+	// message_extra.revoke=1 的软删除、原文仍在，直接下发会把撤回原文泄漏给 bot。
+	// 与 /v1/message/channel/sync 同口径：撤回消息只返回占位 payload + revoke=1/revoker。
+	out, err := ba.sanitizeRevokedSyncResp(resp)
+	if err != nil {
+		ba.Error("查询撤回状态失败", zap.Error(err))
+		httperr.ResponseErrorL(c, errcode.ErrBotAPIQueryFailed, nil, nil)
+		return
+	}
+
+	c.Response(out)
+}
+
+// botSyncMessage 是 bot 拉历史响应里的单条消息。内嵌 *config.MessageResp，使其原有
+// 字段（payload / message_id / from_uid …）逐字节按原样序列化（纯增量、向后兼容既有
+// bot adapter），并新增 revoke / revoker，让 bot 能识别「这里有过一条消息但被撤回了」
+// 而读不到原文——即辉哥定的「agent 看 = 人看」一致原则。
+type botSyncMessage struct {
+	*config.MessageResp
+	Revoke  int    `json:"revoke,omitempty"`
+	Revoker string `json:"revoker,omitempty"`
+}
+
+// botSyncMessagesResp 保持与 config.SyncChannelMessageResp 相同的顶层形状，只是把每条
+// 消息换成带 revoke 标志的 botSyncMessage。
+type botSyncMessagesResp struct {
+	StartMessageSeq uint32            `json:"start_message_seq"`
+	EndMessageSeq   uint32            `json:"end_message_seq"`
+	PullMode        config.PullMode   `json:"pull_mode"`
+	Messages        []*botSyncMessage `json:"messages"`
+}
+
+// sanitizeRevokedSyncResp 查 message_extra 找出本页里的撤回消息，对其就地剥离正文
+// （payload 替换为占位、清空 streams）并打上 revoke=1/revoker，其余消息原样透传。
+//
+// fail-closed：撤回状态查询失败时返回 error，由调用方回 500 —— 绝不能查询失败就当作
+// 「没有撤回」把原文原样下发。
+func (ba *BotAPI) sanitizeRevokedSyncResp(resp *config.SyncChannelMessageResp) (*botSyncMessagesResp, error) {
+	if len(resp.Messages) == 0 {
+		return buildBotSyncResp(resp, nil), nil
+	}
+
+	// message_extra.message_id 是 VARCHAR(20)，必须用字符串绑定才能命中索引。
+	ids := make([]string, 0, len(resp.Messages))
+	for _, m := range resp.Messages {
+		ids = append(ids, strconv.FormatInt(m.MessageID, 10))
+	}
+	var rows []struct {
+		MessageID string `db:"message_id"`
+		Revoker   string `db:"revoker"`
+	}
+	if _, err := ba.ctx.DB().
+		Select("message_id", "revoker").
+		From("message_extra").
+		Where("message_id in ? and `revoke`=1", ids).
+		Load(&rows); err != nil {
+		return nil, err
+	}
+	revokedRevoker := make(map[string]string, len(rows))
+	for _, r := range rows {
+		revokedRevoker[r.MessageID] = r.Revoker
+	}
+	return buildBotSyncResp(resp, revokedRevoker), nil
+}
+
+// buildBotSyncResp 把 IM 原始 sync 响应转换成 bot 响应：revokedRevoker 命中（key 为
+// message_id 字符串）的消息就地脱敏并打 revoke=1/revoker，其余原样透传。纯函数，不触
+// DB，便于单测覆盖脱敏/不误伤两条路径。
+func buildBotSyncResp(resp *config.SyncChannelMessageResp, revokedRevoker map[string]string) *botSyncMessagesResp {
+	out := &botSyncMessagesResp{
+		StartMessageSeq: resp.StartMessageSeq,
+		EndMessageSeq:   resp.EndMessageSeq,
+		PullMode:        resp.PullMode,
+		Messages:        make([]*botSyncMessage, 0, len(resp.Messages)),
+	}
+	for _, m := range resp.Messages {
+		wrapped := &botSyncMessage{MessageResp: m}
+		if revoker, ok := revokedRevoker[strconv.FormatInt(m.MessageID, 10)]; ok {
+			m.Payload = message.SanitizeRevokedPayloadBytes(m.Payload)
+			m.Streams = nil
+			wrapped.Revoke = 1
+			wrapped.Revoker = revoker
+		}
+		out.Messages = append(out.Messages, wrapped)
+	}
+	return out
 }

--- a/modules/bot_api/sync_revoke_integration_test.go
+++ b/modules/bot_api/sync_revoke_integration_test.go
@@ -1,0 +1,81 @@
+package bot_api
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/log"
+	"github.com/Mininglamp-OSS/octo-lib/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSanitizeRevokedSyncResp_Integration exercises the real message_extra
+// SELECT the bot history-pull path (/v1/bot/messages/sync) runs before it
+// sanitizes revoked messages. It feeds a hand-built IM sync response (WuKongIM
+// is not involved) so it needs only MySQL. Covers WS-168 acceptance:
+//
+//	(1) a revoked message → revoke=1 + placeholder body (no original text)
+//	(3) a non-revoked message in the same page → body intact (no误伤)
+//
+// The channel/sync consistency case (2) is anchored structurally in
+// modules/message TestRevokeSanitizeConsistency (both paths share revokedPayload).
+func TestSanitizeRevokedSyncResp_Integration(t *testing.T) {
+	_, ctx := newUpstreamTestServer(t)
+	defer testutil.CleanAllTables(ctx)
+
+	ba := &BotAPI{ctx: ctx, Log: log.NewTLog("bot-sync-revoke-test")}
+
+	// message 111 is revoked (revoke=1, revoker=carol); 222 is a normal message
+	// with no message_extra row at all.
+	_, err := ctx.DB().InsertBySql(
+		"INSERT INTO message_extra (message_id, channel_id, channel_type, `revoke`, revoker) VALUES (?, ?, ?, 1, ?)",
+		"111", "c1", 2, "carol",
+	).Exec()
+	require.NoError(t, err)
+
+	resp := &config.SyncChannelMessageResp{
+		StartMessageSeq: 1,
+		EndMessageSeq:   2,
+		Messages: []*config.MessageResp{
+			{MessageID: 111, FromUID: "alice", Timestamp: 1700,
+				Payload: []byte(`{"type":1,"content":"revoked secret"}`),
+				Streams: []*config.StreamItemResp{{StreamSeq: 1, Blob: []byte("blob")}}},
+			{MessageID: 222, FromUID: "bob", Timestamp: 1701,
+				Payload: []byte(`{"type":1,"content":"still visible"}`)},
+		},
+	}
+
+	out, err := ba.sanitizeRevokedSyncResp(resp)
+	require.NoError(t, err)
+	require.Len(t, out.Messages, 2)
+
+	// (1) revoked → placeholder, no original text, revoke flag + revoker present.
+	revoked := out.Messages[0]
+	assert.Equal(t, 1, revoked.Revoke)
+	assert.Equal(t, "carol", revoked.Revoker)
+	assert.Nil(t, revoked.Streams)
+	assert.NotContains(t, string(revoked.Payload), "revoked secret")
+	var pm map[string]interface{}
+	require.NoError(t, json.Unmarshal(revoked.Payload, &pm))
+	assert.EqualValues(t, 1, mustInt(pm["type"]))
+	_, hasContent := pm["content"]
+	assert.False(t, hasContent)
+
+	// (3) non-revoked → intact, not误伤.
+	kept := out.Messages[1]
+	assert.Equal(t, 0, kept.Revoke)
+	assert.Contains(t, string(kept.Payload), "still visible")
+}
+
+func mustInt(v interface{}) int64 {
+	switch t := v.(type) {
+	case json.Number:
+		i, _ := t.Int64()
+		return i
+	case float64:
+		return int64(t)
+	}
+	return -1
+}

--- a/modules/bot_api/sync_revoke_test.go
+++ b/modules/bot_api/sync_revoke_test.go
@@ -1,0 +1,98 @@
+package bot_api
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBuildBotSyncResp_RevokeSanitize covers the pure transformation the bot
+// history-pull path (/v1/bot/messages/sync) applies once message_extra has been
+// consulted. Full send→revoke→sync HTTP coverage lives in the integration test
+// (needs MySQL/Redis/WuKongIM); this locks the sanitize/no-touch decision.
+func TestBuildBotSyncResp_RevokeSanitize(t *testing.T) {
+	payloadOf := func(t *testing.T, m *botSyncMessage) map[string]interface{} {
+		t.Helper()
+		var pm map[string]interface{}
+		require.NoError(t, json.Unmarshal(m.Payload, &pm))
+		return pm
+	}
+
+	newResp := func() *config.SyncChannelMessageResp {
+		return &config.SyncChannelMessageResp{
+			StartMessageSeq: 10,
+			EndMessageSeq:   20,
+			PullMode:        config.PullModeDown,
+			Messages: []*config.MessageResp{
+				{MessageID: 111, FromUID: "alice", Timestamp: 1700,
+					Payload: []byte(`{"type":1,"content":"revoked secret"}`),
+					Streams: []*config.StreamItemResp{{StreamSeq: 1, Blob: []byte("blob")}}},
+				{MessageID: 222, FromUID: "bob", Timestamp: 1701,
+					Payload: []byte(`{"type":1,"content":"still visible"}`)},
+			},
+		}
+	}
+
+	t.Run("revoked message → placeholder body + revoke flag; non-revoked untouched", func(t *testing.T) {
+		resp := newResp()
+		out := buildBotSyncResp(resp, map[string]string{"111": "carol"})
+
+		// top-level shape preserved
+		assert.Equal(t, uint32(10), out.StartMessageSeq)
+		assert.Equal(t, uint32(20), out.EndMessageSeq)
+		require.Len(t, out.Messages, 2)
+
+		// Case 1: revoked → revoke=1/revoker, body stripped, streams cleared.
+		revoked := out.Messages[0]
+		assert.Equal(t, 1, revoked.Revoke)
+		assert.Equal(t, "carol", revoked.Revoker)
+		assert.Nil(t, revoked.Streams)
+		pm := payloadOf(t, revoked)
+		assert.Equal(t, float64(common.Text.Int()), pm["type"])
+		_, hasContent := pm["content"]
+		assert.False(t, hasContent, "revoked content must not leak")
+
+		// Case 3: non-revoked → intact, no revoke flag (不误伤).
+		kept := out.Messages[1]
+		assert.Equal(t, 0, kept.Revoke)
+		assert.Empty(t, kept.Revoker)
+		assert.Equal(t, "still visible", payloadOf(t, kept)["content"])
+	})
+
+	t.Run("empty revoked set leaves every message intact", func(t *testing.T) {
+		resp := newResp()
+		out := buildBotSyncResp(resp, nil)
+		require.Len(t, out.Messages, 2)
+		for _, m := range out.Messages {
+			assert.Equal(t, 0, m.Revoke)
+			assert.Contains(t, string(m.Payload), "content")
+		}
+	})
+}
+
+// TestBotSyncMessage_JSONShapeIsAdditive guards the wire-compat guarantee: the
+// bot sync response must keep every field the raw config.MessageResp exposed
+// (existing adapters parse `payload` as base64 bytes) and only ADD revoke/revoker.
+func TestBotSyncMessage_JSONShapeIsAdditive(t *testing.T) {
+	m := &botSyncMessage{
+		MessageResp: &config.MessageResp{MessageID: 7, FromUID: "u", Payload: []byte(`{"type":1}`)},
+		Revoke:      1,
+		Revoker:     "r",
+	}
+	b, err := json.Marshal(m)
+	require.NoError(t, err)
+	var got map[string]interface{}
+	require.NoError(t, json.Unmarshal(b, &got))
+
+	// embedded MessageResp fields promoted to the top level (unchanged names)
+	assert.Contains(t, got, "message_id")
+	assert.Contains(t, got, "from_uid")
+	assert.Contains(t, got, "payload")
+	// additive revoke signal
+	assert.Equal(t, float64(1), got["revoke"])
+	assert.Equal(t, "r", got["revoker"])
+}

--- a/modules/message/api.go
+++ b/modules/message/api.go
@@ -116,45 +116,8 @@ func placeholderPayload() map[string]interface{} {
 	}
 }
 
-// revokedPayload 返回撤回消息对外下发的最小 payload：仅保留原始 type，剥离 content
-// 及一切内容承载字段（url / name / reply / content.users …）。
-//
-// 背景（撤回原文泄漏）：Octo 撤回是 message_extra.revoke=1 的软删除，WuKongIM 里
-// 原始 payload 仍在。sync 路径此前把 revoke=1 与「完整原始 payload」一起下发，
-// 原文因此保留在客户端内存（message.content），恶意插件可从 React props 反查还原。
-// 单条直读 api_message_get.go 对 revoke==1 直接返回 404，本函数补上 sync 路径同口径的缺口。
-//
-// 保留 type 而不整条清空：撤回对所有人生效，前端仅凭 revoke=1 渲染撤回提示、不读
-// payload（撤回者名由 revoker UID 单独查，见 octo-web RevokeCell）；保留 type 只为
-// 兼容按 type 分支的老客户端渲染路径，type 本身不含消息正文。
-//
-// type 必须规范化为数字标量（scalarContentType）：payload 是不可信的调用方 JSON，
-// send 路径不约束 type 必须是数字（只剥 __obo_* / 处理 mention/space_id/richtext），
-// 若原样透传，攻击者可把正文藏进 type（字符串 / 对象 / 数组）绕过脱敏原样下发。
-// 服务端所有 type 消费方（isTextType / payloadMsgType）都严格按数字读取、非数字一律
-// 视为未知，故强制数字标量、非数字 fallback ContentError 不影响任何合法渲染（D23 安全整改）。
-func revokedPayload(original map[string]interface{}) map[string]interface{} {
-	return map[string]interface{}{
-		"type": scalarContentType(original["type"]),
-	}
-}
-
-// scalarContentType 把 payload 的 type 归一为已识别的数字 content-type：
-// float64 / int / json.Number 三种反序列化结果转 int，其余（string / map / array / 缺失）
-// 一律 fallback common.ContentError，杜绝非标量 type 承载正文逃逸。
-func scalarContentType(v interface{}) int {
-	switch t := v.(type) {
-	case float64:
-		return int(t)
-	case int:
-		return t
-	case json.Number:
-		if i, err := t.Int64(); err == nil {
-			return int(i)
-		}
-	}
-	return common.ContentError.Int()
-}
+// revokedPayload / scalarContentType 已抽到 revoke_sanitize.go（撤回脱敏的唯一实现
+// 来源），供 from() 与 bot 拉历史路径共用同一套占位定义。
 
 // isTextType 判断 payload type 是否为 common.Text（=1）。兼容 json.Number / float64 / int
 // 几种反序列化结果；string 类型的 "1" 不识别为 Text，避免误命中。
@@ -3891,19 +3854,11 @@ func (m *MsgSyncResp) from(msgResp *config.MessageResp, loginUID string, message
 
 	// 撤回消息内容脱敏：撤回对所有人生效，任何客户端都不该再拿到原文。剥离 payload
 	// 正文、加密 signal 密文与流式 blob，只保留 revoke=1 / revoker 供前端渲染撤回
-	// 提示。与单条直读 api_message_get.go 对 revoke==1 返回 404 同口径；这里补上
-	// /message/channel/sync 与 /conversation/sync（两者共用 from()）此前遗漏的缺口。
+	// 提示。与单条直读 api_message_get.go 对 revoke==1 返回 404 同口径。脱敏实现集中
+	// 在 revoke_sanitize.go（bot 拉历史路径也复用同一套占位定义）。
 	// 必须放在 Payload / SignalPayload / Streams / MessageExtra 全部赋值之后。
 	if m.Revoke == 1 {
-		m.Payload = revokedPayload(m.Payload)
-		m.SignalPayload = ""
-		m.Streams = nil
-		// message_extra.content_edit 是「编辑后的正文」，同样是原文载体：撤回后必须
-		// 一并剥离，否则编辑过的消息被撤回时仍会经 content_edit 把原文下发。
-		if m.MessageExtra != nil {
-			m.MessageExtra.ContentEdit = nil
-			m.MessageExtra.EditedAt = 0
-		}
+		sanitizeRevokedMsgSyncResp(m)
 	}
 
 }

--- a/modules/message/revoke_sanitize.go
+++ b/modules/message/revoke_sanitize.go
@@ -1,0 +1,84 @@
+package message
+
+import (
+	"encoding/json"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/Mininglamp-OSS/octo-lib/pkg/util"
+)
+
+// 撤回消息脱敏的唯一实现来源。
+//
+// Octo 撤回是 message_extra.revoke=1 的软删除，WuKongIM 里原始 payload 仍在；
+// 任何返回 message body 的拉取路径都必须在下发前把撤回消息的正文剥离，只保留占位
+// 态（type + revoke 标志），否则就绕过了发送方的撤回意图（信息治理漏洞）。历史上
+// /message/channel/sync 与单条直读各自实现过一次，bot 拉历史路径 /v1/bot/messages/sync
+// 却漏做（octo-server#777 / WS-168）。为避免每新增一个拉取接口就重漏一次，脱敏的
+// 「占位态长什么样」在此集中定义，各路径按自己的响应结构调用对应 wrapper，不再各自
+// 拼装 payload。
+
+// revokedPayload 返回撤回消息对外下发的最小 payload：仅保留原始 type，剥离 content
+// 及一切内容承载字段（url / name / reply / content.users …）。
+//
+// 保留 type 而不整条清空：撤回对所有人生效，前端仅凭 revoke=1 渲染撤回提示、不读
+// payload（撤回者名由 revoker UID 单独查，见 octo-web RevokeCell）；保留 type 只为
+// 兼容按 type 分支的老客户端渲染路径，type 本身不含消息正文。
+//
+// type 必须规范化为数字标量（scalarContentType）：payload 是不可信的调用方 JSON，
+// send 路径不约束 type 必须是数字（只剥 __obo_* / 处理 mention/space_id/richtext），
+// 若原样透传，攻击者可把正文藏进 type（字符串 / 对象 / 数组）绕过脱敏原样下发。
+// 服务端所有 type 消费方（isTextType / payloadMsgType）都严格按数字读取、非数字一律
+// 视为未知，故强制数字标量、非数字 fallback ContentError 不影响任何合法渲染（D23 安全整改）。
+func revokedPayload(original map[string]interface{}) map[string]interface{} {
+	return map[string]interface{}{
+		"type": scalarContentType(original["type"]),
+	}
+}
+
+// scalarContentType 把 payload 的 type 归一为已识别的数字 content-type：
+// float64 / int / json.Number 三种反序列化结果转 int，其余（string / map / array / 缺失）
+// 一律 fallback common.ContentError，杜绝非标量 type 承载正文逃逸。
+func scalarContentType(v interface{}) int {
+	switch t := v.(type) {
+	case float64:
+		return int(t)
+	case int:
+		return t
+	case json.Number:
+		if i, err := t.Int64(); err == nil {
+			return int(i)
+		}
+	}
+	return common.ContentError.Int()
+}
+
+// sanitizeRevokedMsgSyncResp 就地把一条撤回消息的正文从 MsgSyncResp 中剥离，只留
+// 占位 payload + revoke=1/revoker 供前端渲染撤回提示。/message/channel/sync 与
+// /conversation/sync（共用 from()）以及单条直读的响应都是 MsgSyncResp 形状，走这里。
+// 必须在 Payload / SignalPayload / Streams / MessageExtra 全部赋值之后调用。
+func sanitizeRevokedMsgSyncResp(m *MsgSyncResp) {
+	m.Payload = revokedPayload(m.Payload)
+	m.SignalPayload = ""
+	m.Streams = nil
+	// message_extra.content_edit 是「编辑后的正文」，同样是原文载体：撤回后必须
+	// 一并剥离，否则编辑过的消息被撤回时仍会经 content_edit 把原文下发。
+	if m.MessageExtra != nil {
+		m.MessageExtra.ContentEdit = nil
+		m.MessageExtra.EditedAt = 0
+	}
+}
+
+// SanitizeRevokedPayloadBytes 接收 WuKongIM 原样存储 / IMSyncChannelMessage 直出的
+// 消息 payload（JSON bytes），返回撤回占位态的 payload bytes。供 bot 拉历史路径
+// (/v1/bot/messages/sync) 这类持有原始 []byte payload、不经过 from() 的接口复用同一
+// 套占位定义，避免重复实现导致口径漂移。
+//
+// fail-closed：payload 解析失败（截断 / 非 JSON）时绝不能原样透传撤回原文，退化为
+// 空 original，revokedPayload 会 fallback 到 ContentError 占位。
+func SanitizeRevokedPayloadBytes(payload []byte) []byte {
+	var original map[string]interface{}
+	if err := util.ReadJsonByByte(payload, &original); err != nil {
+		original = nil
+	}
+	return []byte(util.ToJson(revokedPayload(original)))
+}

--- a/modules/message/revoke_sanitize.go
+++ b/modules/message/revoke_sanitize.go
@@ -75,6 +75,12 @@ func sanitizeRevokedMsgSyncResp(m *MsgSyncResp) {
 //
 // fail-closed：payload 解析失败（截断 / 非 JSON）时绝不能原样透传撤回原文，退化为
 // 空 original，revokedPayload 会 fallback 到 ContentError 占位。
+//
+// 注意：本函数只处理 payload 字节，不触碰 MessageExtra/ContentEdit。当前 bot 拉历史
+// 路径的 config.MessageResp 结构本身不含 MessageExtra，故无泄漏面。若响应结构未来
+// 引入 MessageExtra/ContentEdit（如为对齐 web 端），调用方必须自行剥离 content_edit
+// ——参见 sanitizeRevokedMsgSyncResp 对 m.MessageExtra.ContentEdit/EditedAt 的清理，
+// content_edit 是「编辑后的正文」，同样是原文载体，撤回后必须一并剥离。
 func SanitizeRevokedPayloadBytes(payload []byte) []byte {
 	var original map[string]interface{}
 	if err := util.ReadJsonByByte(payload, &original); err != nil {

--- a/modules/message/revoke_sanitize_test.go
+++ b/modules/message/revoke_sanitize_test.go
@@ -1,0 +1,82 @@
+package message
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-lib/common"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestSanitizeRevokedPayloadBytes 校验 bot 拉历史路径复用的 []byte 版占位构造器：
+// 只保留数字 type、剥离一切正文，并在 payload 不可解析时 fail-closed。
+func TestSanitizeRevokedPayloadBytes(t *testing.T) {
+	parse := func(t *testing.T, b []byte) map[string]interface{} {
+		t.Helper()
+		var m map[string]interface{}
+		assert.NoError(t, json.Unmarshal(b, &m))
+		return m
+	}
+
+	t.Run("strips content, keeps only numeric type", func(t *testing.T) {
+		in := []byte(`{"type":1,"content":"secret original text","url":"https://x/private.png"}`)
+		out := parse(t, SanitizeRevokedPayloadBytes(in))
+		assert.Equal(t, float64(common.Text.Int()), out["type"])
+		_, hasContent := out["content"]
+		_, hasURL := out["url"]
+		assert.False(t, hasContent, "content must be stripped")
+		assert.False(t, hasURL, "url must be stripped")
+		assert.Len(t, out, 1, "only type should survive")
+	})
+
+	t.Run("non-scalar type carrying a body falls back to ContentError", func(t *testing.T) {
+		// 把正文藏进 type（对象/字符串/数组）不能绕过脱敏。
+		for _, in := range [][]byte{
+			[]byte(`{"type":{"nested":"secret"}}`),
+			[]byte(`{"type":"secret as string"}`),
+			[]byte(`{"type":["secret"]}`),
+		} {
+			out := parse(t, SanitizeRevokedPayloadBytes(in))
+			assert.Equal(t, float64(common.ContentError.Int()), out["type"])
+			assert.Len(t, out, 1)
+		}
+	})
+
+	t.Run("fail-closed on unparseable / empty payload", func(t *testing.T) {
+		for _, in := range [][]byte{
+			[]byte(`not json at all`),
+			[]byte(`{"type":1,`), // truncated
+			[]byte(``),
+			nil,
+		} {
+			out := parse(t, SanitizeRevokedPayloadBytes(in))
+			// 绝不透传原文；缺失 type 归一为 ContentError。
+			assert.Equal(t, float64(common.ContentError.Int()), out["type"])
+			assert.Len(t, out, 1)
+		}
+	})
+}
+
+// TestRevokeSanitizeConsistency 保证 bot 路径（[]byte）与 from() 路径（MsgSyncResp）
+// 的撤回占位口径一致——两者都经 revokedPayload 单一来源，所以对同一原始 payload
+// 产出等价的占位 type。这是 WS-168「回归保护：channel/sync 与 bot sync 行为一致」的
+// 结构性单测锚点。
+func TestRevokeSanitizeConsistency(t *testing.T) {
+	original := map[string]interface{}{"type": common.Text.Int(), "content": "hi"}
+
+	// from() 路径
+	m := &MsgSyncResp{Payload: map[string]interface{}{"type": common.Text.Int(), "content": "hi"}, SignalPayload: "cipher"}
+	sanitizeRevokedMsgSyncResp(m)
+	assert.Equal(t, revokedPayload(original)["type"], m.Payload["type"])
+	assert.Empty(t, m.SignalPayload)
+	assert.Nil(t, m.Streams)
+
+	// bot 路径
+	raw, err := json.Marshal(original)
+	assert.NoError(t, err)
+	var botOut map[string]interface{}
+	assert.NoError(t, json.Unmarshal(SanitizeRevokedPayloadBytes(raw), &botOut))
+	assert.Equal(t, float64(common.Text.Int()), botOut["type"])
+	_, hasContent := botOut["content"]
+	assert.False(t, hasContent)
+}


### PR DESCRIPTION
## What

`POST /v1/bot/messages/sync` returned WuKongIM's raw sync response directly (`c.Response(resp)`), bypassing the revoke sanitization that `POST /v1/message/channel/sync` applies through `MsgSyncResp.from()`. Since revoke is a `message_extra.revoke=1` soft delete and the original payload remains in WuKongIM, a bot/agent pulling history read the **pre-revoke body**, bypassing the sender's revoke intent — violating the "agent sees = human sees" consistency principle.

## Fix

- Centralize the revoke placeholder definition in `modules/message/revoke_sanitize.go` (moved `revokedPayload` + `scalarContentType` out of `api.go`, added `sanitizeRevokedMsgSyncResp` and the `[]byte`-oriented `SanitizeRevokedPayloadBytes`). `from()` and the bot path now share **one** source of truth instead of duplicating the strip logic — so a future pull endpoint can't silently re-leak.
- `/v1/bot/messages/sync` now queries `message_extra` for revoked IDs in the page and returns a placeholder payload + `revoke=1`/`revoker` for those messages; non-revoked messages pass through untouched.
- Response stays **additive**: the per-message object embeds `config.MessageResp` (so `payload` stays base64 bytes and every existing field is unchanged for current adapters) and only adds `revoke`/`revoker`.
- **Fail-closed**: a failed revoke lookup returns an error (500) rather than leaking originals.

Scope is intentionally just this one endpoint — all other pull paths (`channel/sync`, single-message reads, `conversation/sync`, search) already sanitize. Webhook/bot-event-queue send↔revoke window is a separate risk surface and lands in a follow-up PR (WS-168 PR#2).

## Test

- `modules/message`: shared sanitizer — content strip, non-scalar-type normalization, fail-closed on malformed/empty; `TestRevokeSanitizeConsistency` anchors that the bot `[]byte` path and `from()` path produce equivalent placeholders (both via `revokedPayload`).
- `modules/bot_api`: pure `buildBotSyncResp` transform (revoked → placeholder + `revoke=1`; non-revoked intact; additive JSON shape) + a MySQL integration test exercising the real `message_extra` query.

Acceptance mapping (WS-168): (1) revoke → bot sync → `revoke=1` + empty/placeholder body ✅; (2) channel/sync consistency ✅ (structural, shared sanitizer); (3) non-revoked bot sync → body intact ✅.

Closes #777
