### PR TITLE
feat(common): expose Agent Mail appconfig gate

### DIFF
--- a/modules/common/api.go
+++ b/modules/common/api.go
@@ -399,6 +399,7 @@ func (cn *Common) appConfig(c *wkhttp.Context) {
 			DocsOn:                 cn.systemSettings.DocsEnabled(),
 			DocsSearchOn:           cn.systemSettings.DocsSearchEnabled(),
 			DriveOn:                cn.systemSettings.DriveEnabled(),
+			MailOn:                 cn.systemSettings.MailEnabled(),
 			DmloopOn:               cn.systemSettings.DmloopEnabled(),
 			DmpersonalOn:           cn.systemSettings.DmpersonalEnabled(),
 			TrackingEnabled:        cn.systemSettings.TrackingEnabled(),
@@ -452,6 +453,7 @@ func (cn *Common) appConfig(c *wkhttp.Context) {
 		DocsOn:                 cn.systemSettings.DocsEnabled(),
 		DocsSearchOn:           cn.systemSettings.DocsSearchEnabled(),
 		DriveOn:                cn.systemSettings.DriveEnabled(),
+		MailOn:                 cn.systemSettings.MailEnabled(),
 		DmloopOn:               cn.systemSettings.DmloopEnabled(),
 		DmpersonalOn:           cn.systemSettings.DmpersonalEnabled(),
 		TrackingEnabled:        cn.systemSettings.TrackingEnabled(),
@@ -852,6 +854,12 @@ type appConfigResp struct {
 	// 策略后老客户端命中 version 短路分支也必须拿到最新值，故两个分支都下发。
 	DriveOn bool `json:"drive_on"`
 
+	// MailOn 告知客户端是否展示 Agent Mail 模块入口。值来源于 system_setting
+	// mail.enabled，默认 false。该字段只表达展示策略，不替代 octo-server 网关及
+	// octo-mail 的身份、Space 和邮箱权限校验。两个 appconfig 分支均下发该字段，
+	// 避免 app_config.version 缓存阻止开关及时生效。
+	MailOn bool `json:"mail_on"`
+
 	// dmloop.enabled / dmpersonal.enabled；默认 false —— loop(回路)与「我的/运行时」入口在
 	// 后端服务就绪前先隐藏,上线后由管理台切对应 system_setting 灰度放开。两者分开:
 	// 「我的」将重设计脱离 loop、可独立放量。只表达展示策略,不承担服务端鉴权。与 app_config.version
@@ -865,7 +873,6 @@ type appConfigResp struct {
 	// 只表达采集策略，不承担服务端鉴权(collector 自身鉴权)。与 app_config.version 解耦的原因
 	// 同 DocsOn：运维切策略后老客户端命中 version 短路分支也须拿到最新值，故两分支都下发。
 	TrackingEnabled bool `json:"tracking_enabled"`
-
 
 	// MessageReaction is the deployment-wide default capability for ordinary
 	// Web/iOS/Android clients. It is intentionally identity-agnostic because

--- a/modules/common/api_manager_system_setting_test.go
+++ b/modules/common/api_manager_system_setting_test.go
@@ -130,6 +130,13 @@ func TestManagerSystemSetting_GetReturnsEffectiveValues(t *testing.T) {
 	assert.Equal(t, "", got.Value)
 	assert.Equal(t, "0", got.EffectiveValue, "yaml false → effective_value=\"0\"")
 
+	// Agent Mail display gate is part of the manager-configurable schema and
+	// stays off until explicitly enabled.
+	got = byKey["mail.enabled"]
+	assert.False(t, got.Configured)
+	assert.Equal(t, "", got.Value)
+	assert.Equal(t, "0", got.EffectiveValue)
+
 	// Unconfigured string: yaml default surfaces in effective_value.
 	got = byKey["support.email"]
 	assert.False(t, got.Configured)

--- a/modules/common/api_test.go
+++ b/modules/common/api_test.go
@@ -937,6 +937,7 @@ func TestGetAppConfig_DocsSearchOn_OnVersionShortCircuit(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Contains(t, w.Body.String(), `"docs_search_on":true`)
 }
+
 // reloads the shared snapshot. Generic sibling of setDocsEnabledSetting for the
 // dmloop / dmpersonal launch flags. Call AFTER cleanAllTablesAndReloadSettings.
 func setModuleEnabledSetting(t *testing.T, ctx *config.Context, category string, enabled bool) {
@@ -1071,7 +1072,6 @@ func TestGetAppConfig_TrackingEnabled_OnVersionShortCircuit(t *testing.T) {
 	assert.Contains(t, w.Body.String(), `"tracking_enabled":true`)
 }
 
-
 // 客户端据此隐藏网盘(drive)模块入口（独立部署的 octo-drive 上线前）。
 func TestGetAppConfig_DriveOn_DefaultFalse(t *testing.T) {
 	s, ctx := testutil.NewTestServer()
@@ -1120,6 +1120,53 @@ func TestGetAppConfig_DriveOn_OnVersionShortCircuit(t *testing.T) {
 	s.GetRoute().ServeHTTP(w, req)
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Contains(t, w.Body.String(), `"drive_on":true`)
+}
+
+// Agent Mail 展示开关默认关闭，客户端据此隐藏邮件入口。
+func TestGetAppConfig_MailOn_DefaultFalse(t *testing.T) {
+	s, ctx := testutil.NewTestServer()
+	f := New(ctx)
+	cleanAllTablesAndReloadSettings(t, ctx)
+	err := f.appConfigDB.insert(&appConfigModel{})
+	assert.NoError(t, err)
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/v1/common/appconfig", nil)
+	req.Header.Set("token", testutil.Token)
+	s.GetRoute().ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), `"mail_on":false`)
+}
+
+// system_setting mail.enabled=true 后，appconfig 下发 mail_on=true。
+func TestGetAppConfig_MailOn_True(t *testing.T) {
+	s, ctx := testutil.NewTestServer()
+	f := New(ctx)
+	cleanAllTablesAndReloadSettings(t, ctx)
+	setModuleEnabledSetting(t, ctx, "mail", true)
+	err := f.appConfigDB.insert(&appConfigModel{})
+	assert.NoError(t, err)
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/v1/common/appconfig", nil)
+	req.Header.Set("token", testutil.Token)
+	s.GetRoute().ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), `"mail_on":true`)
+}
+
+// version 短路分支也必须下发实时 mail_on，避免 app_config.version 缓存阻止开关生效。
+func TestGetAppConfig_MailOn_OnVersionShortCircuit(t *testing.T) {
+	s, ctx := testutil.NewTestServer()
+	f := New(ctx)
+	cleanAllTablesAndReloadSettings(t, ctx)
+	setModuleEnabledSetting(t, ctx, "mail", true)
+	err := f.appConfigDB.insert(&appConfigModel{})
+	assert.NoError(t, err)
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/v1/common/appconfig?version=99999999", nil)
+	req.Header.Set("token", testutil.Token)
+	s.GetRoute().ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), `"mail_on":true`)
 }
 
 // setStickerUploadLimitsSettings upserts the three sticker upload knobs

--- a/modules/common/system_setting_schema.go
+++ b/modules/common/system_setting_schema.go
@@ -273,6 +273,12 @@ var systemSettingSchema = []settingDef{
 	{Category: "docs", Key: "enabled", Type: settingTypeBool, Description: "是否向客户端展示文档(docs)模块入口（octo-docs-backend 上线前默认关闭）",
 		Effective: func(s *SystemSettings) string { return boolToCanonical(s.DocsEnabled()) }},
 
+	// Agent Mail 模块展示开关。默认关闭；部署完成 octo-mail 与网关配置后由管理台切
+	// mail.enabled 放量。仅控制客户端入口展示，不替代 Agent Mail 既有鉴权。
+	// 经 GET /v1/common/appconfig 的 mail_on 下发给客户端。
+	{Category: "mail", Key: "enabled", Type: settingTypeBool, Description: "是否向客户端展示 Agent Mail 模块入口（默认关闭）",
+		Effective: func(s *SystemSettings) string { return boolToCanonical(s.MailEnabled()) }},
+
 	// docs 全文搜索展示开关，与 docs.enabled 解耦：搜索端点由 octo-docs-backend #131
 	// 独立提供，可晚于 docs 模块本体上线。默认关闭；上线且索引灰度完成后由管理台
 	// 切 docs.search_enabled 放量。仅表达展示策略，不承担任何服务端鉴权（搜索鉴权在

--- a/modules/common/system_settings.go
+++ b/modules/common/system_settings.go
@@ -1336,6 +1336,14 @@ func (s *SystemSettings) DocsEnabled() bool {
 	return s.getBool("docs", "enabled", false)
 }
 
+// MailEnabled reports whether clients should surface the Agent Mail module.
+// This is a presentation toggle only: Agent Mail authorization and access
+// control remain enforced by octo-server and octo-mail. Default false so the
+// entry is exposed only after an operator enables system_setting mail.enabled.
+func (s *SystemSettings) MailEnabled() bool {
+	return s.getBool("mail", "enabled", false)
+}
+
 // DocsSearchEnabled reports whether clients should surface cloud-doc full-text
 // search. Decoupled from DocsEnabled: the search endpoint is provided
 // independently by octo-docs-backend and may land later than the docs module

--- a/modules/common/system_settings_test.go
+++ b/modules/common/system_settings_test.go
@@ -767,6 +767,20 @@ func TestSystemSettings_DocsEnabled_DBTrueWins(t *testing.T) {
 	assert.True(t, s.DocsEnabled(), "DB true -> docs module shown")
 }
 
+func TestSystemSettings_MailEnabled_DefaultsFalse(t *testing.T) {
+	s := newTestSystemSettings(t, nil)
+
+	assert.False(t, s.MailEnabled(), "DB empty -> Agent Mail module hidden by default")
+}
+
+func TestSystemSettings_MailEnabled_DBTrueWins(t *testing.T) {
+	s := newTestSystemSettings(t, nil)
+	require.NoError(t, s.db.upsert("mail", "enabled", "1", settingTypeBool, ""))
+	require.NoError(t, s.Reload())
+
+	assert.True(t, s.MailEnabled(), "DB true -> Agent Mail module shown")
+}
+
 func TestSystemSettings_DriveEnabled_DefaultsFalse(t *testing.T) {
 	s := newTestSystemSettings(t, nil)
 


### PR DESCRIPTION
## Summary

Expose a deployment-controlled Agent Mail presentation flag through the existing system settings and appconfig contract.

## Related Issue

Closes #780

## Linked Spec

https://github.com/Mininglamp-OSS/octo-server/issues/780

## Changes

- Add `mail.enabled` to the common system-setting schema with a default of `false`.
- Return the effective value as `mail_on` from both appconfig response paths.
- Add default, override, schema, and API serialization coverage.

## Testing

- [x] Unit tests added/updated
- [x] Manually verified
- `go test ./modules/common/... -p 1 -parallel 1 -count=1` — passed
- `go vet ./modules/common/...` — passed
- `golangci-lint run ./modules/common/...` — 0 issues

## COMPREHENSION

1. **What does this change actually do** to the load-bearing path?
   The existing system-setting reader resolves `mail.enabled`, and both appconfig response branches serialize the effective value as `mail_on`.

2. **What could break** because of it (dependents + failure mode)?
   Appconfig consumers receive one additive boolean field. Existing fields, gateway routing, and Agent Mail authorization are unchanged.

3. **How do you know it works** (specific test/repro/trace)?
   Unit tests cover the default and enabled settings, manager schema output, the normal appconfig response, and the version short-circuit response.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] PR description is in English
- [x] Added tests for my changes
- [x] Updated documentation
- [x] Followed commit message conventions (Conventional Commits)
